### PR TITLE
[rocprofiler-systems] refactor(env_vars): use env_vars:: constants in place of ROCPROFSYS_* literals

### DIFF
--- a/projects/rocprofiler-systems/source/bin/common/common_utils.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/common_utils.cpp
@@ -184,8 +184,7 @@ translate_arguments(int argc, char** argv, preset_registry& registry,
 std::string
 get_output_directory(const char* env_var = nullptr)
 {
-    const char* output_path =
-        std::getenv(env_var ? env_var : env_vars::OUTPUT_PATH.data());
+    const char* output_path = std::getenv(env_var ? env_var : env_vars::OUTPUT_PATH);
     if(output_path && std::strlen(output_path) > 0) return std::string(output_path);
 
     return "rocprof-sys-output";
@@ -308,8 +307,8 @@ void
 validate_configuration()
 {
     // Check for conflicting ENABLE/DISABLE categories (causes std::abort() at runtime)
-    const char* enable_cats  = std::getenv(env_vars::ENABLE_CATEGORIES.data());
-    const char* disable_cats = std::getenv(env_vars::DISABLE_CATEGORIES.data());
+    const char* enable_cats  = std::getenv(env_vars::ENABLE_CATEGORIES);
+    const char* disable_cats = std::getenv(env_vars::DISABLE_CATEGORIES);
     if(enable_cats && std::strlen(enable_cats) > 0 && disable_cats &&
        std::strlen(disable_cats) > 0)
     {
@@ -321,7 +320,7 @@ validate_configuration()
     }
 
     // Check ROCPROFSYS_TMPDIR writability
-    const char* tmpdir     = std::getenv(env_vars::TMPDIR.data());
+    const char* tmpdir     = std::getenv(env_vars::TMPDIR);
     auto        tmpdir_str = std::string{ tmpdir ? tmpdir : "/tmp" };
     if(!check_directory_writable(tmpdir_str))
     {

--- a/projects/rocprofiler-systems/source/bin/common/json_config.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/json_config.cpp
@@ -399,7 +399,7 @@ resolve_schema_config(const nlohmann::json& config)
         }
         if(hw.contains("papi_multiplexing"))
             resolve_enabled(result, hw["papi_multiplexing"], "enabled",
-                            env_vars::PAPI_MULTIPLEXING);
+                            env_vars::PAPI_MULTIPLEXING_ENABLED);
     }
 
     // --- Advanced section ---
@@ -417,7 +417,7 @@ resolve_schema_config(const nlohmann::json& config)
         resolve_value(result, adv, "trace_duration_sec", env_vars::TRACE_DURATION);
         resolve_value(result, adv, "verbose", env_vars::VERBOSE);
         if(adv.contains("debug"))
-            resolve_enabled(result, adv["debug"], "enabled", env_vars::DEBUG);
+            resolve_enabled(result, adv["debug"], "enabled", env_vars::DEBUG_MODE);
         resolve_value(result, adv, "timemory_components", env_vars::TIMEMORY_COMPONENTS);
         resolve_value(result, adv, "network_interface", env_vars::NETWORK_INTERFACE);
         resolve_value(result, adv, "trace_periods", env_vars::TRACE_PERIODS);
@@ -857,8 +857,8 @@ export_hardware_counters(nlohmann::json&                           config,
         hw["enabled"]                    = true;
         hw["gpu_perf_counters"]["value"] = *v;
     }
-    export_enabled(config, env_map, env_vars::PAPI_MULTIPLEXING, "hardware_counters",
-                   "papi_multiplexing");
+    export_enabled(config, env_map, env_vars::PAPI_MULTIPLEXING_ENABLED,
+                   "hardware_counters", "papi_multiplexing");
 }
 }  // namespace
 
@@ -912,7 +912,7 @@ env_vars_to_json_schema(const std::map<std::string, std::string>& env_map)
 
     // --- Advanced ---
     export_int_value(config, env_map, env_vars::VERBOSE, "advanced", "verbose");
-    export_enabled(config, env_map, env_vars::DEBUG, "advanced", "debug");
+    export_enabled(config, env_map, env_vars::DEBUG_MODE, "advanced", "debug");
     export_int_value(config, env_map, env_vars::MAX_DEPTH, "advanced", "max_depth");
     export_double_value(config, env_map, env_vars::TRACE_DELAY, "advanced",
                         "trace_delay_sec");

--- a/projects/rocprofiler-systems/source/bin/common/json_config.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/json_config.cpp
@@ -398,7 +398,7 @@ resolve_schema_config(const nlohmann::json& config)
         }
         if(hw.contains("papi_multiplexing"))
             resolve_enabled(result, hw["papi_multiplexing"], "enabled",
-                            env_vars::PAPI_MULTIPLEXING);
+                            env_vars::PAPI_MULTIPLEXING_ENABLED);
     }
 
     // --- Advanced section ---
@@ -416,7 +416,7 @@ resolve_schema_config(const nlohmann::json& config)
         resolve_value(result, adv, "trace_duration_sec", env_vars::TRACE_DURATION);
         resolve_value(result, adv, "verbose", env_vars::VERBOSE);
         if(adv.contains("debug"))
-            resolve_enabled(result, adv["debug"], "enabled", env_vars::DEBUG);
+            resolve_enabled(result, adv["debug"], "enabled", env_vars::DEBUG_MODE);
         resolve_value(result, adv, "timemory_components", env_vars::TIMEMORY_COMPONENTS);
         resolve_value(result, adv, "network_interface", env_vars::NETWORK_INTERFACE);
         resolve_value(result, adv, "trace_periods", env_vars::TRACE_PERIODS);
@@ -851,8 +851,8 @@ export_hardware_counters(nlohmann::json&                           config,
         hw["enabled"]              = true;
         hw["papi_events"]["value"] = *v;
     }
-    export_enabled(config, env_map, env_vars::PAPI_MULTIPLEXING, "hardware_counters",
-                   "papi_multiplexing");
+    export_enabled(config, env_map, env_vars::PAPI_MULTIPLEXING_ENABLED,
+                   "hardware_counters", "papi_multiplexing");
 }
 }  // namespace
 
@@ -906,7 +906,7 @@ env_vars_to_json_schema(const std::map<std::string, std::string>& env_map)
 
     // --- Advanced ---
     export_int_value(config, env_map, env_vars::VERBOSE, "advanced", "verbose");
-    export_enabled(config, env_map, env_vars::DEBUG, "advanced", "debug");
+    export_enabled(config, env_map, env_vars::DEBUG_MODE, "advanced", "debug");
     export_int_value(config, env_map, env_vars::MAX_DEPTH, "advanced", "max_depth");
     export_double_value(config, env_map, env_vars::TRACE_DELAY, "advanced",
                         "trace_delay_sec");

--- a/projects/rocprofiler-systems/source/bin/common/preset_registry.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/preset_registry.cpp
@@ -22,7 +22,7 @@ namespace
 std::string
 find_preset_directory()
 {
-    const auto* preset_dir_env = std::getenv(env_vars::PRESET_DIR.data());
+    const auto* preset_dir_env = std::getenv(env_vars::PRESET_DIR);
     if(preset_dir_env && std::strlen(preset_dir_env) > 0)
     {
         auto dir = std::string{ preset_dir_env };

--- a/projects/rocprofiler-systems/source/bin/common/tests/test_json_config.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/tests/test_json_config.cpp
@@ -10,6 +10,7 @@
 #include <string>
 
 using namespace rocprofsys::json_config;
+namespace env_vars = rocprofsys::env_vars;
 
 class json_config_test : public ::testing::Test
 {};
@@ -26,9 +27,9 @@ TEST_F(json_config_test, resolves_tracing_section)
 
     auto result = resolve_config(j);
 
-    EXPECT_EQ(result.at("ROCPROFSYS_TRACE"), "true");
-    EXPECT_EQ(result.at("ROCPROFSYS_PERFETTO_BUFFER_SIZE_KB"), "2048");
-    EXPECT_EQ(result.at("ROCPROFSYS_PERFETTO_FILL_POLICY"), "ring_buffer");
+    EXPECT_EQ(result.at(env_vars::TRACE.data()), "true");
+    EXPECT_EQ(result.at(env_vars::PERFETTO_BUFFER_SIZE_KB.data()), "2048");
+    EXPECT_EQ(result.at(env_vars::PERFETTO_FILL_POLICY.data()), "ring_buffer");
 }
 
 TEST_F(json_config_test, resolves_profiling_section)
@@ -42,8 +43,8 @@ TEST_F(json_config_test, resolves_profiling_section)
 
     auto result = resolve_config(j);
 
-    EXPECT_EQ(result.at("ROCPROFSYS_PROFILE"), "true");
-    EXPECT_EQ(result.at("ROCPROFSYS_FLAT_PROFILE"), "true");
+    EXPECT_EQ(result.at(env_vars::PROFILE.data()), "true");
+    EXPECT_EQ(result.at(env_vars::FLAT_PROFILE.data()), "true");
 }
 
 TEST_F(json_config_test, resolves_sampling_section)
@@ -60,11 +61,11 @@ TEST_F(json_config_test, resolves_sampling_section)
 
     auto result = resolve_config(j);
 
-    EXPECT_EQ(result.at("ROCPROFSYS_USE_SAMPLING"), "true");
-    EXPECT_EQ(result.at("ROCPROFSYS_SAMPLING_TIMER"), "realtime");
-    EXPECT_EQ(result.at("ROCPROFSYS_SAMPLING_FREQ"), "200");
-    EXPECT_EQ(result.at("ROCPROFSYS_SAMPLING_CPUS"), "0-3");
-    EXPECT_EQ(result.at("ROCPROFSYS_SAMPLING_DELAY"), std::to_string(1.5));
+    EXPECT_EQ(result.at(env_vars::USE_SAMPLING.data()), "true");
+    EXPECT_EQ(result.at(env_vars::SAMPLING_TIMER.data()), "realtime");
+    EXPECT_EQ(result.at(env_vars::SAMPLING_FREQ.data()), "200");
+    EXPECT_EQ(result.at(env_vars::SAMPLING_CPUS.data()), "0-3");
+    EXPECT_EQ(result.at(env_vars::SAMPLING_DELAY.data()), std::to_string(1.5));
 }
 
 // Test new schema format - domains.gpu section
@@ -86,14 +87,14 @@ TEST_F(json_config_test, resolves_gpu_domain)
 
     auto result = resolve_config(j);
 
-    EXPECT_EQ(result.at("ROCPROFSYS_USE_AMD_SMI"), "true");
-    EXPECT_EQ(result.at("ROCPROFSYS_USE_PROCESS_SAMPLING"), "true");
+    EXPECT_EQ(result.at(env_vars::USE_AMD_SMI.data()), "true");
+    EXPECT_EQ(result.at(env_vars::USE_PROCESS_SAMPLING.data()), "true");
     // Order might vary, but should contain temp and power
-    auto metrics = result.at("ROCPROFSYS_AMD_SMI_METRICS");
+    auto metrics = result.at(env_vars::AMD_SMI_METRICS.data());
     EXPECT_NE(metrics.find("temp"), std::string::npos);
     EXPECT_NE(metrics.find("power"), std::string::npos);
     EXPECT_EQ(metrics.find("busy"), std::string::npos);  // busy is disabled
-    EXPECT_EQ(result.at("ROCPROFSYS_AMD_SMI_FREQ"), "10");
+    EXPECT_EQ(result.at(env_vars::AMD_SMI_FREQ.data()), "10");
 }
 
 // Test new schema format - domains.rocm section
@@ -113,7 +114,7 @@ TEST_F(json_config_test, resolves_rocm_domain)
 
     auto result = resolve_config(j);
 
-    auto domains = result.at("ROCPROFSYS_ROCM_DOMAINS");
+    auto domains = result.at(env_vars::ROCM_DOMAINS.data());
     EXPECT_NE(domains.find("hip_runtime_api"), std::string::npos);
     EXPECT_NE(domains.find("kernel_dispatch"), std::string::npos);
     EXPECT_EQ(domains.find("memory_copy"), std::string::npos);
@@ -136,9 +137,9 @@ TEST_F(json_config_test, resolves_parallel_domain)
 
     auto result = resolve_config(j);
 
-    EXPECT_EQ(result.at("ROCPROFSYS_USE_MPIP"), "true");
-    EXPECT_EQ(result.at("ROCPROFSYS_USE_OMPT"), "true");
-    EXPECT_EQ(result.count("ROCPROFSYS_USE_KOKKOSP"), 0u);
+    EXPECT_EQ(result.at(env_vars::USE_MPIP.data()), "true");
+    EXPECT_EQ(result.at(env_vars::USE_OMPT.data()), "true");
+    EXPECT_EQ(result.count(env_vars::USE_KOKKOSP.data()), 0u);
 }
 
 // Test new schema format - output section
@@ -154,10 +155,10 @@ TEST_F(json_config_test, resolves_output_section)
 
     auto result = resolve_config(j);
 
-    EXPECT_EQ(result.at("ROCPROFSYS_OUTPUT_PATH"), "/tmp/my-traces");
+    EXPECT_EQ(result.at(env_vars::OUTPUT_PATH.data()), "/tmp/my-traces");
     // time_output and file_output are resolved when the enabled field is present
-    EXPECT_EQ(result.count("ROCPROFSYS_TIME_OUTPUT"), 1u);
-    EXPECT_EQ(result.count("ROCPROFSYS_FILE_OUTPUT"), 1u);
+    EXPECT_EQ(result.count(env_vars::TIME_OUTPUT.data()), 1u);
+    EXPECT_EQ(result.count(env_vars::FILE_OUTPUT.data()), 1u);
 }
 
 // Test new schema format - hardware_counters section
@@ -173,8 +174,8 @@ TEST_F(json_config_test, rasolves_hw_counters_section)
 
     auto result = resolve_config(j);
 
-    EXPECT_EQ(result.at("ROCPROFSYS_ROCM_EVENTS"), "VALUUtilization,Occupancy");
-    EXPECT_EQ(result.at("ROCPROFSYS_PAPI_EVENTS"), "PAPI_TOT_CYC,PAPI_TOT_INS");
+    EXPECT_EQ(result.at(env_vars::ROCM_EVENTS.data()), "VALUUtilization,Occupancy");
+    EXPECT_EQ(result.at(env_vars::PAPI_EVENTS.data()), "PAPI_TOT_CYC,PAPI_TOT_INS");
 }
 
 // Test new schema format - causal section
@@ -191,10 +192,10 @@ TEST_F(json_config_test, resolves_causal_section)
 
     auto result = resolve_config(j);
 
-    EXPECT_EQ(result.at("ROCPROFSYS_USE_CAUSAL"), "true");
-    EXPECT_EQ(result.at("ROCPROFSYS_CAUSAL_MODE"), "function");
-    EXPECT_EQ(result.at("ROCPROFSYS_CAUSAL_BACKEND"), "perf");
-    EXPECT_EQ(result.at("ROCPROFSYS_CAUSAL_BINARY_SCOPE"), "%MAIN%");
+    EXPECT_EQ(result.at(env_vars::USE_CAUSAL.data()), "true");
+    EXPECT_EQ(result.at(env_vars::CAUSAL_MODE.data()), "function");
+    EXPECT_EQ(result.at(env_vars::CAUSAL_BACKEND.data()), "perf");
+    EXPECT_EQ(result.at(env_vars::CAUSAL_BINARY_SCOPE.data()), "%MAIN%");
 }
 
 // Test new schema format - advanced section
@@ -211,11 +212,11 @@ TEST_F(json_config_test, resolves_advanced_configuration_section)
 
     auto result = resolve_config(j);
 
-    EXPECT_EQ(result.at("ROCPROFSYS_MAX_DEPTH"), "100");
-    EXPECT_EQ(result.at("ROCPROFSYS_VERBOSE"), "2");
-    EXPECT_EQ(result.at("ROCPROFSYS_DEBUG"), "true");
+    EXPECT_EQ(result.at(env_vars::MAX_DEPTH.data()), "100");
+    EXPECT_EQ(result.at(env_vars::VERBOSE.data()), "2");
+    EXPECT_EQ(result.at(env_vars::DEBUG_MODE.data()), "true");
     // collapse_threads is resolved when the enabled field is present
-    EXPECT_EQ(result.count("ROCPROFSYS_COLLAPSE_THREADS"), 1u);
+    EXPECT_EQ(result.count(env_vars::COLLAPSE_THREADS.data()), 1u);
 }
 
 // Test combined sections
@@ -233,11 +234,11 @@ TEST_F(json_config_test, combines_multiple_sections)
 
     auto result = resolve_config(j);
 
-    EXPECT_EQ(result.at("ROCPROFSYS_TRACE"), "true");
-    EXPECT_EQ(result.at("ROCPROFSYS_PROFILE"), "true");
-    EXPECT_EQ(result.at("ROCPROFSYS_USE_SAMPLING"), "true");
-    EXPECT_EQ(result.at("ROCPROFSYS_SAMPLING_FREQ"), "50");
-    EXPECT_EQ(result.at("ROCPROFSYS_USE_AMD_SMI"), "true");
+    EXPECT_EQ(result.at(env_vars::TRACE.data()), "true");
+    EXPECT_EQ(result.at(env_vars::PROFILE.data()), "true");
+    EXPECT_EQ(result.at(env_vars::USE_SAMPLING.data()), "true");
+    EXPECT_EQ(result.at(env_vars::SAMPLING_FREQ.data()), "50");
+    EXPECT_EQ(result.at(env_vars::USE_AMD_SMI.data()), "true");
 }
 
 // Test empty JSON returns empty map
@@ -295,7 +296,7 @@ TEST_F(json_config_test, resolves_rocpd_output)
 
     auto result = resolve_config(j);
 
-    EXPECT_EQ(result.at("ROCPROFSYS_USE_ROCPD"), "true");
+    EXPECT_EQ(result.at(env_vars::USE_ROCPD.data()), "true");
 }
 
 // Test advanced.network_interface resolution
@@ -309,7 +310,7 @@ TEST_F(json_config_test, resolves_network_interface)
 
     auto result = resolve_config(j);
 
-    EXPECT_EQ(result.at("ROCPROFSYS_NETWORK_INTERFACE"), "eth0");
+    EXPECT_EQ(result.at(env_vars::NETWORK_INTERFACE.data()), "eth0");
 }
 
 // Test advanced.trace_periods resolution
@@ -323,7 +324,7 @@ TEST_F(json_config_test, resolves_trace_periods)
 
     auto result = resolve_config(j);
 
-    EXPECT_EQ(result.at("ROCPROFSYS_TRACE_PERIODS"), "0:10,20:30");
+    EXPECT_EQ(result.at(env_vars::TRACE_PERIODS.data()), "0:10,20:30");
 }
 
 // Test hardware_counters.papi_multiplexing resolution
@@ -338,7 +339,7 @@ TEST_F(json_config_test, resolves_papi_multiplexing)
 
     auto result = resolve_config(j);
 
-    EXPECT_EQ(result.at("ROCPROFSYS_PAPI_MULTIPLEXING"), "true");
+    EXPECT_EQ(result.at(env_vars::PAPI_MULTIPLEXING_ENABLED.data()), "true");
 }
 
 // Test domains.rocm.enabled top-level flag
@@ -354,7 +355,7 @@ TEST_F(json_config_test, resolves_rocm_enabled_flag)
 
     auto result = resolve_config(j);
 
-    EXPECT_EQ(result.at("ROCPROFSYS_TRACE"), "true");
+    EXPECT_EQ(result.at(env_vars::TRACE.data()), "true");
 }
 
 // Test env_vars_to_json_schema with non-numeric env var values

--- a/projects/rocprofiler-systems/source/bin/common/tests/test_json_config.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/tests/test_json_config.cpp
@@ -27,9 +27,9 @@ TEST_F(json_config_test, resolves_tracing_section)
 
     auto result = resolve_config(j);
 
-    EXPECT_EQ(result.at(env_vars::TRACE.data()), "true");
-    EXPECT_EQ(result.at(env_vars::PERFETTO_BUFFER_SIZE_KB.data()), "2048");
-    EXPECT_EQ(result.at(env_vars::PERFETTO_FILL_POLICY.data()), "ring_buffer");
+    EXPECT_EQ(result.at(env_vars::TRACE), "true");
+    EXPECT_EQ(result.at(env_vars::PERFETTO_BUFFER_SIZE_KB), "2048");
+    EXPECT_EQ(result.at(env_vars::PERFETTO_FILL_POLICY), "ring_buffer");
 }
 
 TEST_F(json_config_test, resolves_profiling_section)
@@ -43,8 +43,8 @@ TEST_F(json_config_test, resolves_profiling_section)
 
     auto result = resolve_config(j);
 
-    EXPECT_EQ(result.at(env_vars::PROFILE.data()), "true");
-    EXPECT_EQ(result.at(env_vars::FLAT_PROFILE.data()), "true");
+    EXPECT_EQ(result.at(env_vars::PROFILE), "true");
+    EXPECT_EQ(result.at(env_vars::FLAT_PROFILE), "true");
 }
 
 TEST_F(json_config_test, resolves_sampling_section)
@@ -61,11 +61,11 @@ TEST_F(json_config_test, resolves_sampling_section)
 
     auto result = resolve_config(j);
 
-    EXPECT_EQ(result.at(env_vars::USE_SAMPLING.data()), "true");
-    EXPECT_EQ(result.at(env_vars::SAMPLING_TIMER.data()), "realtime");
-    EXPECT_EQ(result.at(env_vars::SAMPLING_FREQ.data()), "200");
-    EXPECT_EQ(result.at(env_vars::SAMPLING_CPUS.data()), "0-3");
-    EXPECT_EQ(result.at(env_vars::SAMPLING_DELAY.data()), std::to_string(1.5));
+    EXPECT_EQ(result.at(env_vars::USE_SAMPLING), "true");
+    EXPECT_EQ(result.at(env_vars::SAMPLING_TIMER), "realtime");
+    EXPECT_EQ(result.at(env_vars::SAMPLING_FREQ), "200");
+    EXPECT_EQ(result.at(env_vars::SAMPLING_CPUS), "0-3");
+    EXPECT_EQ(result.at(env_vars::SAMPLING_DELAY), std::to_string(1.5));
 }
 
 // Test new schema format - domains.gpu section
@@ -87,14 +87,14 @@ TEST_F(json_config_test, resolves_gpu_domain)
 
     auto result = resolve_config(j);
 
-    EXPECT_EQ(result.at(env_vars::USE_AMD_SMI.data()), "true");
-    EXPECT_EQ(result.at(env_vars::USE_PROCESS_SAMPLING.data()), "true");
+    EXPECT_EQ(result.at(env_vars::USE_AMD_SMI), "true");
+    EXPECT_EQ(result.at(env_vars::USE_PROCESS_SAMPLING), "true");
     // Order might vary, but should contain temp and power
-    auto metrics = result.at(env_vars::AMD_SMI_METRICS.data());
+    auto metrics = result.at(env_vars::AMD_SMI_METRICS);
     EXPECT_NE(metrics.find("temp"), std::string::npos);
     EXPECT_NE(metrics.find("power"), std::string::npos);
     EXPECT_EQ(metrics.find("busy"), std::string::npos);  // busy is disabled
-    EXPECT_EQ(result.at(env_vars::AMD_SMI_FREQ.data()), "10");
+    EXPECT_EQ(result.at(env_vars::AMD_SMI_FREQ), "10");
 }
 
 // Test new schema format - domains.rocm section
@@ -114,7 +114,7 @@ TEST_F(json_config_test, resolves_rocm_domain)
 
     auto result = resolve_config(j);
 
-    auto domains = result.at(env_vars::ROCM_DOMAINS.data());
+    auto domains = result.at(env_vars::ROCM_DOMAINS);
     EXPECT_NE(domains.find("hip_runtime_api"), std::string::npos);
     EXPECT_NE(domains.find("kernel_dispatch"), std::string::npos);
     EXPECT_EQ(domains.find("memory_copy"), std::string::npos);
@@ -137,9 +137,9 @@ TEST_F(json_config_test, resolves_parallel_domain)
 
     auto result = resolve_config(j);
 
-    EXPECT_EQ(result.at(env_vars::USE_MPIP.data()), "true");
-    EXPECT_EQ(result.at(env_vars::USE_OMPT.data()), "true");
-    EXPECT_EQ(result.count(env_vars::USE_KOKKOSP.data()), 0u);
+    EXPECT_EQ(result.at(env_vars::USE_MPIP), "true");
+    EXPECT_EQ(result.at(env_vars::USE_OMPT), "true");
+    EXPECT_EQ(result.count(env_vars::USE_KOKKOSP), 0u);
 }
 
 // Test new schema format - output section
@@ -155,10 +155,10 @@ TEST_F(json_config_test, resolves_output_section)
 
     auto result = resolve_config(j);
 
-    EXPECT_EQ(result.at(env_vars::OUTPUT_PATH.data()), "/tmp/my-traces");
+    EXPECT_EQ(result.at(env_vars::OUTPUT_PATH), "/tmp/my-traces");
     // time_output and file_output are resolved when the enabled field is present
-    EXPECT_EQ(result.count(env_vars::TIME_OUTPUT.data()), 1u);
-    EXPECT_EQ(result.count(env_vars::FILE_OUTPUT.data()), 1u);
+    EXPECT_EQ(result.count(env_vars::TIME_OUTPUT), 1u);
+    EXPECT_EQ(result.count(env_vars::FILE_OUTPUT), 1u);
 }
 
 // Test new schema format - hardware_counters section
@@ -174,8 +174,8 @@ TEST_F(json_config_test, rasolves_hw_counters_section)
 
     auto result = resolve_config(j);
 
-    EXPECT_EQ(result.at(env_vars::ROCM_EVENTS.data()), "VALUUtilization,Occupancy");
-    EXPECT_EQ(result.at(env_vars::PAPI_EVENTS.data()), "PAPI_TOT_CYC,PAPI_TOT_INS");
+    EXPECT_EQ(result.at(env_vars::ROCM_EVENTS), "VALUUtilization,Occupancy");
+    EXPECT_EQ(result.at(env_vars::PAPI_EVENTS), "PAPI_TOT_CYC,PAPI_TOT_INS");
 }
 
 // Test new schema format - causal section
@@ -192,10 +192,10 @@ TEST_F(json_config_test, resolves_causal_section)
 
     auto result = resolve_config(j);
 
-    EXPECT_EQ(result.at(env_vars::USE_CAUSAL.data()), "true");
-    EXPECT_EQ(result.at(env_vars::CAUSAL_MODE.data()), "function");
-    EXPECT_EQ(result.at(env_vars::CAUSAL_BACKEND.data()), "perf");
-    EXPECT_EQ(result.at(env_vars::CAUSAL_BINARY_SCOPE.data()), "%MAIN%");
+    EXPECT_EQ(result.at(env_vars::USE_CAUSAL), "true");
+    EXPECT_EQ(result.at(env_vars::CAUSAL_MODE), "function");
+    EXPECT_EQ(result.at(env_vars::CAUSAL_BACKEND), "perf");
+    EXPECT_EQ(result.at(env_vars::CAUSAL_BINARY_SCOPE), "%MAIN%");
 }
 
 // Test new schema format - advanced section
@@ -212,11 +212,11 @@ TEST_F(json_config_test, resolves_advanced_configuration_section)
 
     auto result = resolve_config(j);
 
-    EXPECT_EQ(result.at(env_vars::MAX_DEPTH.data()), "100");
-    EXPECT_EQ(result.at(env_vars::VERBOSE.data()), "2");
-    EXPECT_EQ(result.at(env_vars::DEBUG_MODE.data()), "true");
+    EXPECT_EQ(result.at(env_vars::MAX_DEPTH), "100");
+    EXPECT_EQ(result.at(env_vars::VERBOSE), "2");
+    EXPECT_EQ(result.at(env_vars::DEBUG_MODE), "true");
     // collapse_threads is resolved when the enabled field is present
-    EXPECT_EQ(result.count(env_vars::COLLAPSE_THREADS.data()), 1u);
+    EXPECT_EQ(result.count(env_vars::COLLAPSE_THREADS), 1u);
 }
 
 // Test combined sections
@@ -234,11 +234,11 @@ TEST_F(json_config_test, combines_multiple_sections)
 
     auto result = resolve_config(j);
 
-    EXPECT_EQ(result.at(env_vars::TRACE.data()), "true");
-    EXPECT_EQ(result.at(env_vars::PROFILE.data()), "true");
-    EXPECT_EQ(result.at(env_vars::USE_SAMPLING.data()), "true");
-    EXPECT_EQ(result.at(env_vars::SAMPLING_FREQ.data()), "50");
-    EXPECT_EQ(result.at(env_vars::USE_AMD_SMI.data()), "true");
+    EXPECT_EQ(result.at(env_vars::TRACE), "true");
+    EXPECT_EQ(result.at(env_vars::PROFILE), "true");
+    EXPECT_EQ(result.at(env_vars::USE_SAMPLING), "true");
+    EXPECT_EQ(result.at(env_vars::SAMPLING_FREQ), "50");
+    EXPECT_EQ(result.at(env_vars::USE_AMD_SMI), "true");
 }
 
 // Test empty JSON returns empty map
@@ -296,7 +296,7 @@ TEST_F(json_config_test, resolves_rocpd_output)
 
     auto result = resolve_config(j);
 
-    EXPECT_EQ(result.at(env_vars::USE_ROCPD.data()), "true");
+    EXPECT_EQ(result.at(env_vars::USE_ROCPD), "true");
 }
 
 // Test advanced.network_interface resolution
@@ -310,7 +310,7 @@ TEST_F(json_config_test, resolves_network_interface)
 
     auto result = resolve_config(j);
 
-    EXPECT_EQ(result.at(env_vars::NETWORK_INTERFACE.data()), "eth0");
+    EXPECT_EQ(result.at(env_vars::NETWORK_INTERFACE), "eth0");
 }
 
 // Test advanced.trace_periods resolution
@@ -324,7 +324,7 @@ TEST_F(json_config_test, resolves_trace_periods)
 
     auto result = resolve_config(j);
 
-    EXPECT_EQ(result.at(env_vars::TRACE_PERIODS.data()), "0:10,20:30");
+    EXPECT_EQ(result.at(env_vars::TRACE_PERIODS), "0:10,20:30");
 }
 
 // Test hardware_counters.papi_multiplexing resolution
@@ -339,7 +339,7 @@ TEST_F(json_config_test, resolves_papi_multiplexing)
 
     auto result = resolve_config(j);
 
-    EXPECT_EQ(result.at(env_vars::PAPI_MULTIPLEXING_ENABLED.data()), "true");
+    EXPECT_EQ(result.at(env_vars::PAPI_MULTIPLEXING_ENABLED), "true");
 }
 
 // Test domains.rocm.enabled top-level flag
@@ -355,7 +355,7 @@ TEST_F(json_config_test, resolves_rocm_enabled_flag)
 
     auto result = resolve_config(j);
 
-    EXPECT_EQ(result.at(env_vars::TRACE.data()), "true");
+    EXPECT_EQ(result.at(env_vars::TRACE), "true");
 }
 
 // Test env_vars_to_json_schema with non-numeric env var values
@@ -400,13 +400,13 @@ TEST_F(json_config_test, handling_round_trip_for_new_values_in_json_schema)
 // Test env_vars constants match expected string values
 TEST_F(json_config_test, validate_env_var_constants)
 {
-    EXPECT_EQ(rocprofsys::env_vars::TRACE, "ROCPROFSYS_TRACE");
-    EXPECT_EQ(rocprofsys::env_vars::PROFILE, "ROCPROFSYS_PROFILE");
-    EXPECT_EQ(rocprofsys::env_vars::USE_SAMPLING, "ROCPROFSYS_USE_SAMPLING");
-    EXPECT_EQ(rocprofsys::env_vars::USE_AMD_SMI, "ROCPROFSYS_USE_AMD_SMI");
-    EXPECT_EQ(rocprofsys::env_vars::ROCM_DOMAINS, "ROCPROFSYS_ROCM_DOMAINS");
-    EXPECT_EQ(rocprofsys::env_vars::USE_MPIP, "ROCPROFSYS_USE_MPIP");
-    EXPECT_EQ(rocprofsys::env_vars::OUTPUT_PATH, "ROCPROFSYS_OUTPUT_PATH");
-    EXPECT_EQ(rocprofsys::env_vars::USE_CAUSAL, "ROCPROFSYS_USE_CAUSAL");
-    EXPECT_EQ(rocprofsys::env_vars::VERBOSE, "ROCPROFSYS_VERBOSE");
+    EXPECT_STREQ(rocprofsys::env_vars::TRACE, "ROCPROFSYS_TRACE");
+    EXPECT_STREQ(rocprofsys::env_vars::PROFILE, "ROCPROFSYS_PROFILE");
+    EXPECT_STREQ(rocprofsys::env_vars::USE_SAMPLING, "ROCPROFSYS_USE_SAMPLING");
+    EXPECT_STREQ(rocprofsys::env_vars::USE_AMD_SMI, "ROCPROFSYS_USE_AMD_SMI");
+    EXPECT_STREQ(rocprofsys::env_vars::ROCM_DOMAINS, "ROCPROFSYS_ROCM_DOMAINS");
+    EXPECT_STREQ(rocprofsys::env_vars::USE_MPIP, "ROCPROFSYS_USE_MPIP");
+    EXPECT_STREQ(rocprofsys::env_vars::OUTPUT_PATH, "ROCPROFSYS_OUTPUT_PATH");
+    EXPECT_STREQ(rocprofsys::env_vars::USE_CAUSAL, "ROCPROFSYS_USE_CAUSAL");
+    EXPECT_STREQ(rocprofsys::env_vars::VERBOSE, "ROCPROFSYS_VERBOSE");
 }

--- a/projects/rocprofiler-systems/source/bin/common/tests/test_preset_registry.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/tests/test_preset_registry.cpp
@@ -159,11 +159,11 @@ TEST_F(preset_registry_test, explain_finds_by_name)
     temp_dir dir;
     dir.write_file("balanced.json", balanced_json);
 
-    ::setenv(env_vars::PRESET_DIR.data(), dir.path().c_str(), 1);
+    ::setenv(env_vars::PRESET_DIR, dir.path().c_str(), 1);
     preset_registry    registry;
     std::ostringstream oss;
     bool               found = registry.explain("balanced", "run", oss);
-    ::unsetenv(env_vars::PRESET_DIR.data());
+    ::unsetenv(env_vars::PRESET_DIR);
 
     EXPECT_TRUE(found);
     EXPECT_NE(oss.str().find("balanced"), std::string::npos);
@@ -173,11 +173,11 @@ TEST_F(preset_registry_test, explain_returns_false_for_unknown_preset)
 {
     temp_dir dir;
 
-    ::setenv(env_vars::PRESET_DIR.data(), dir.path().c_str(), 1);
+    ::setenv(env_vars::PRESET_DIR, dir.path().c_str(), 1);
     preset_registry    registry;
     std::ostringstream oss;
     bool               found = registry.explain("nonexistent-preset", "run", oss);
-    ::unsetenv(env_vars::PRESET_DIR.data());
+    ::unsetenv(env_vars::PRESET_DIR);
 
     EXPECT_FALSE(found);
 }
@@ -187,11 +187,11 @@ TEST_F(preset_registry_test, load_all_from_directory)
     temp_dir dir;
     dir.write_file("balanced.json", balanced_json);
 
-    ::setenv(env_vars::PRESET_DIR.data(), dir.path().c_str(), 1);
+    ::setenv(env_vars::PRESET_DIR, dir.path().c_str(), 1);
     preset_registry    registry;
     std::ostringstream oss;
     registry.list("run", oss);
-    ::unsetenv(env_vars::PRESET_DIR.data());
+    ::unsetenv(env_vars::PRESET_DIR);
 
     auto output = oss.str();
     EXPECT_NE(output.find("balanced"), std::string::npos);
@@ -250,11 +250,11 @@ TEST_F(preset_registry_test, list_output_content)
     temp_dir dir;
     dir.write_file("balanced.json", balanced_json);
 
-    ::setenv(env_vars::PRESET_DIR.data(), dir.path().c_str(), 1);
+    ::setenv(env_vars::PRESET_DIR, dir.path().c_str(), 1);
     preset_registry    registry;
     std::ostringstream oss;
     registry.list("run", oss);
-    ::unsetenv(env_vars::PRESET_DIR.data());
+    ::unsetenv(env_vars::PRESET_DIR);
 
     auto output = oss.str();
     EXPECT_NE(output.find("Available Presets:"), std::string::npos);
@@ -267,11 +267,11 @@ TEST_F(preset_registry_test, explain_output_content)
     temp_dir dir;
     dir.write_file("balanced.json", balanced_json);
 
-    ::setenv(env_vars::PRESET_DIR.data(), dir.path().c_str(), 1);
+    ::setenv(env_vars::PRESET_DIR, dir.path().c_str(), 1);
     preset_registry    registry;
     std::ostringstream oss;
     bool               result = registry.explain("balanced", "run", oss);
-    ::unsetenv(env_vars::PRESET_DIR.data());
+    ::unsetenv(env_vars::PRESET_DIR);
 
     EXPECT_TRUE(result);
     auto output = oss.str();
@@ -292,10 +292,10 @@ TEST_F(preset_registry_test, describe_generates_output_tree)
     temp_dir dir;
     dir.write_file("balanced.json", balanced_json);
 
-    ::setenv(env_vars::PRESET_DIR.data(), dir.path().c_str(), 1);
+    ::setenv(env_vars::PRESET_DIR, dir.path().c_str(), 1);
     preset_registry registry;
     auto            desc = registry.describe("balanced");
-    ::unsetenv(env_vars::PRESET_DIR.data());
+    ::unsetenv(env_vars::PRESET_DIR);
 
     EXPECT_NE(desc.find("Tracing:"), std::string::npos);
     EXPECT_NE(desc.find("Profiling:"), std::string::npos);

--- a/projects/rocprofiler-systems/source/bin/common/tests/test_preset_registry.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/tests/test_preset_registry.cpp
@@ -3,6 +3,8 @@
 
 #include "common/preset_registry.hpp"
 
+#include "common/env_vars.hpp"
+
 #include <gtest/gtest.h>
 
 #include <cstdlib>
@@ -11,6 +13,7 @@
 #include <string>
 
 using rocprofsys::preset_registry;
+namespace env_vars = rocprofsys::env_vars;
 
 namespace
 {
@@ -104,10 +107,10 @@ TEST_F(preset_registry_test, get_settings_loads_metadata_and_settings)
     auto            settings = registry.get_settings(filepath);
 
     ASSERT_TRUE(settings.has_value());
-    EXPECT_EQ(settings->at("ROCPROFSYS_TRACE"), "true");
-    EXPECT_EQ(settings->at("ROCPROFSYS_PROFILE"), "true");
-    EXPECT_EQ(settings->at("ROCPROFSYS_USE_SAMPLING"), "true");
-    EXPECT_EQ(settings->at("ROCPROFSYS_SAMPLING_FREQ"), "50");
+    EXPECT_EQ(settings->at(std::string{ env_vars::TRACE }), "true");
+    EXPECT_EQ(settings->at(std::string{ env_vars::PROFILE }), "true");
+    EXPECT_EQ(settings->at(std::string{ env_vars::USE_SAMPLING }), "true");
+    EXPECT_EQ(settings->at(std::string{ env_vars::SAMPLING_FREQ }), "50");
 
     // Verify metadata via explain
     std::ostringstream oss;
@@ -127,9 +130,9 @@ TEST_F(preset_registry_test, get_settings_resolves_gpu_domain)
     auto            settings = registry.get_settings(filepath);
 
     ASSERT_TRUE(settings.has_value());
-    EXPECT_EQ(settings->at("ROCPROFSYS_USE_AMD_SMI"), "true");
-    EXPECT_EQ(settings->at("ROCPROFSYS_USE_PROCESS_SAMPLING"), "true");
-    auto metrics = settings->at("ROCPROFSYS_AMD_SMI_METRICS");
+    EXPECT_EQ(settings->at(std::string{ env_vars::USE_AMD_SMI }), "true");
+    EXPECT_EQ(settings->at(std::string{ env_vars::USE_PROCESS_SAMPLING }), "true");
+    auto metrics = settings->at(std::string{ env_vars::AMD_SMI_METRICS });
     EXPECT_NE(metrics.find("temp"), std::string::npos);
     EXPECT_NE(metrics.find("power"), std::string::npos);
 }
@@ -156,11 +159,11 @@ TEST_F(preset_registry_test, explain_finds_by_name)
     temp_dir dir;
     dir.write_file("balanced.json", balanced_json);
 
-    ::setenv("ROCPROFSYS_PRESET_DIR", dir.path().c_str(), 1);
+    ::setenv(env_vars::PRESET_DIR.data(), dir.path().c_str(), 1);
     preset_registry    registry;
     std::ostringstream oss;
     bool               found = registry.explain("balanced", "run", oss);
-    ::unsetenv("ROCPROFSYS_PRESET_DIR");
+    ::unsetenv(env_vars::PRESET_DIR.data());
 
     EXPECT_TRUE(found);
     EXPECT_NE(oss.str().find("balanced"), std::string::npos);
@@ -170,11 +173,11 @@ TEST_F(preset_registry_test, explain_returns_false_for_unknown_preset)
 {
     temp_dir dir;
 
-    ::setenv("ROCPROFSYS_PRESET_DIR", dir.path().c_str(), 1);
+    ::setenv(env_vars::PRESET_DIR.data(), dir.path().c_str(), 1);
     preset_registry    registry;
     std::ostringstream oss;
     bool               found = registry.explain("nonexistent-preset", "run", oss);
-    ::unsetenv("ROCPROFSYS_PRESET_DIR");
+    ::unsetenv(env_vars::PRESET_DIR.data());
 
     EXPECT_FALSE(found);
 }
@@ -184,11 +187,11 @@ TEST_F(preset_registry_test, load_all_from_directory)
     temp_dir dir;
     dir.write_file("balanced.json", balanced_json);
 
-    ::setenv("ROCPROFSYS_PRESET_DIR", dir.path().c_str(), 1);
+    ::setenv(env_vars::PRESET_DIR.data(), dir.path().c_str(), 1);
     preset_registry    registry;
     std::ostringstream oss;
     registry.list("run", oss);
-    ::unsetenv("ROCPROFSYS_PRESET_DIR");
+    ::unsetenv(env_vars::PRESET_DIR.data());
 
     auto output = oss.str();
     EXPECT_NE(output.find("balanced"), std::string::npos);
@@ -239,7 +242,7 @@ TEST_F(preset_registry_test, get_settings_handles_empty_metadata)
     auto            settings = registry.get_settings(filepath);
 
     ASSERT_TRUE(settings.has_value());
-    EXPECT_EQ(settings->at("ROCPROFSYS_TRACE"), "true");
+    EXPECT_EQ(settings->at(std::string{ env_vars::TRACE }), "true");
 }
 
 TEST_F(preset_registry_test, list_output_content)
@@ -247,11 +250,11 @@ TEST_F(preset_registry_test, list_output_content)
     temp_dir dir;
     dir.write_file("balanced.json", balanced_json);
 
-    ::setenv("ROCPROFSYS_PRESET_DIR", dir.path().c_str(), 1);
+    ::setenv(env_vars::PRESET_DIR.data(), dir.path().c_str(), 1);
     preset_registry    registry;
     std::ostringstream oss;
     registry.list("run", oss);
-    ::unsetenv("ROCPROFSYS_PRESET_DIR");
+    ::unsetenv(env_vars::PRESET_DIR.data());
 
     auto output = oss.str();
     EXPECT_NE(output.find("Available Presets:"), std::string::npos);
@@ -264,16 +267,16 @@ TEST_F(preset_registry_test, explain_output_content)
     temp_dir dir;
     dir.write_file("balanced.json", balanced_json);
 
-    ::setenv("ROCPROFSYS_PRESET_DIR", dir.path().c_str(), 1);
+    ::setenv(env_vars::PRESET_DIR.data(), dir.path().c_str(), 1);
     preset_registry    registry;
     std::ostringstream oss;
     bool               result = registry.explain("balanced", "run", oss);
-    ::unsetenv("ROCPROFSYS_PRESET_DIR");
+    ::unsetenv(env_vars::PRESET_DIR.data());
 
     EXPECT_TRUE(result);
     auto output = oss.str();
     EXPECT_NE(output.find("Preset: balanced"), std::string::npos);
-    EXPECT_NE(output.find("ROCPROFSYS_TRACE"), std::string::npos);
+    EXPECT_NE(output.find(std::string{ env_vars::TRACE }), std::string::npos);
 }
 
 TEST_F(preset_registry_test, explain_return_false_for_missing_preset)
@@ -289,10 +292,10 @@ TEST_F(preset_registry_test, describe_generates_output_tree)
     temp_dir dir;
     dir.write_file("balanced.json", balanced_json);
 
-    ::setenv("ROCPROFSYS_PRESET_DIR", dir.path().c_str(), 1);
+    ::setenv(env_vars::PRESET_DIR.data(), dir.path().c_str(), 1);
     preset_registry registry;
     auto            desc = registry.describe("balanced");
-    ::unsetenv("ROCPROFSYS_PRESET_DIR");
+    ::unsetenv(env_vars::PRESET_DIR.data());
 
     EXPECT_NE(desc.find("Tracing:"), std::string::npos);
     EXPECT_NE(desc.find("Profiling:"), std::string::npos);

--- a/projects/rocprofiler-systems/source/bin/common/tool_runner.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/tool_runner.cpp
@@ -308,7 +308,7 @@ tool_runner::print_usage() const
 void
 tool_runner::update_verbose_from_env()
 {
-    const auto* log_level = std::getenv(env::LOG_LEVEL.data());
+    const auto* log_level = std::getenv(env::LOG_LEVEL);
     if(log_level != nullptr) data.out.verbose = env::log_level_to_verbose(log_level);
 }
 

--- a/projects/rocprofiler-systems/source/bin/common/tool_runner.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/tool_runner.cpp
@@ -39,7 +39,7 @@
 namespace argparse  = ::tim::argparse;
 namespace signals   = ::tim::signals;
 namespace path      = rocprofsys::common::path;
-namespace env       = rocprofsys::env_vars;
+namespace env_vars  = rocprofsys::env_vars;
 namespace utils     = rocprofsys::common_utils;
 using settings      = ::rocprofsys::settings;
 using parser_data_t = rocprofsys::argparse::parser_data;
@@ -308,8 +308,8 @@ tool_runner::print_usage() const
 void
 tool_runner::update_verbose_from_env()
 {
-    const auto* log_level = std::getenv(env::LOG_LEVEL);
-    if(log_level != nullptr) data.out.verbose = env::log_level_to_verbose(log_level);
+    const auto* log_level = std::getenv(env_vars::LOG_LEVEL);
+    if(log_level != nullptr) data.out.verbose = env_vars::log_level_to_verbose(log_level);
 }
 
 void
@@ -327,7 +327,7 @@ tool_runner::get_initial_environment()
     }
 
     auto libexec_path = path::realpath(path::get_internal_script_path());
-    if(!libexec_path.empty()) data.env.set(env::SCRIPT_PATH, libexec_path);
+    if(!libexec_path.empty()) data.env.set(env_vars::SCRIPT_PATH, libexec_path);
 
     update_verbose_from_env();
     if(auto llvm_dir = rocprofsys::common::discover_llvm_libdir_for_ompt();
@@ -345,10 +345,10 @@ tool_runner::get_initial_environment()
 
     if(config.force_sampling)
     {
-        auto mode = getenv_string(env::MODE, "sampling");
+        auto mode = getenv_string(env_vars::MODE, "sampling");
         // Bool value flows through update_env's to_env_string(bool) overload,
         // becoming "true"/"false" in the env string.
-        data.env.set(env::USE_SAMPLING, (mode != "causal"));
+        data.env.set(env_vars::USE_SAMPLING, (mode != "causal"));
     }
 }
 
@@ -466,7 +466,7 @@ tool_runner::apply_post_parse(parser_t& parser)
     if(config.disable_cputime_on_realtime_only)
     {
         if(parser.exists("sample-realtime") && !parser.exists("sample-cputime"))
-            data.env.set(env::SAMPLING_CPUTIME, false);
+            data.env.set(env_vars::SAMPLING_CPUTIME, false);
     }
 
     if(parser.exists("profile") && parser.exists("flat-profile"))

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-attach/rocprof-sys-attach.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-attach/rocprof-sys-attach.cpp
@@ -54,10 +54,12 @@ print_usage(const char* prog_name)
 void
 setup_tool_library_env()
 {
-    const auto* attach_tool_library_env_name     = "ROCPROF_ATTACH_TOOL_LIBRARY";
-    const auto* rocp_tool_libraries_env_name     = "ROCP_TOOL_LIBRARIES";
-    const auto* output_use_current_time_env_name = "ROCPROFSYS_OUTPUT_USE_CURRENT_TIME";
-    const auto* reattach_add_session_id_env_name = "ROCPROFSYS_REATTACH_ADD_SESSION_ID";
+    const auto* attach_tool_library_env_name = "ROCPROF_ATTACH_TOOL_LIBRARY";
+    const auto* rocp_tool_libraries_env_name = "ROCP_TOOL_LIBRARIES";
+    const auto* output_use_current_time_env_name =
+        rocprofsys::env_vars::OUTPUT_USE_CURRENT_TIME.data();
+    const auto* reattach_add_session_id_env_name =
+        rocprofsys::env_vars::REATTACH_ADD_SESSION_ID.data();
 
     // enable the use of the current time for the output path
     setenv(output_use_current_time_env_name, "true", 1);
@@ -86,7 +88,7 @@ setup_tool_library_env()
 void
 setup_output_env(const std::string& output_path)
 {
-    const auto* existing_output_path = getenv("ROCPROFSYS_OUTPUT_PATH");
+    const auto* existing_output_path = getenv(rocprofsys::env_vars::OUTPUT_PATH.data());
     if(output_path.empty() && existing_output_path != nullptr)
     {
         LOG_INFO("Output path: {}", existing_output_path);
@@ -97,7 +99,7 @@ setup_output_env(const std::string& output_path)
     const auto        output =
         output_path.empty() ? fmt::format("{}/rocprof-sys-output", pwd) : output_path;
 
-    setenv("ROCPROFSYS_OUTPUT_PATH", output.c_str(), 1);
+    setenv(rocprofsys::env_vars::OUTPUT_PATH.data(), output.c_str(), 1);
     LOG_INFO("Output path: {}", output);
 }
 
@@ -114,8 +116,10 @@ setup_output_format_env(const std::vector<std::string>& formats)
 
     if(has_format("perfetto") || has_format("rocpd"))
     {
-        setenv("ROCPROFSYS_TRACE", has_format("perfetto") ? "true" : "false", 1);
-        setenv("ROCPROFSYS_USE_ROCPD", has_format("rocpd") ? "true" : "false", 1);
+        setenv(rocprofsys::env_vars::TRACE.data(),
+               has_format("perfetto") ? "true" : "false", 1);
+        setenv(rocprofsys::env_vars::USE_ROCPD.data(),
+               has_format("rocpd") ? "true" : "false", 1);
     }
 
     LOG_INFO("Output format: {}", fmt::join(formats, " "));

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-attach/rocprof-sys-attach.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-attach/rocprof-sys-attach.cpp
@@ -57,9 +57,9 @@ setup_tool_library_env()
     const auto* attach_tool_library_env_name = "ROCPROF_ATTACH_TOOL_LIBRARY";
     const auto* rocp_tool_libraries_env_name = "ROCP_TOOL_LIBRARIES";
     const auto* output_use_current_time_env_name =
-        rocprofsys::env_vars::OUTPUT_USE_CURRENT_TIME.data();
+        rocprofsys::env_vars::OUTPUT_USE_CURRENT_TIME;
     const auto* reattach_add_session_id_env_name =
-        rocprofsys::env_vars::REATTACH_ADD_SESSION_ID.data();
+        rocprofsys::env_vars::REATTACH_ADD_SESSION_ID;
 
     // enable the use of the current time for the output path
     setenv(output_use_current_time_env_name, "true", 1);
@@ -88,7 +88,7 @@ setup_tool_library_env()
 void
 setup_output_env(const std::string& output_path)
 {
-    const auto* existing_output_path = getenv(rocprofsys::env_vars::OUTPUT_PATH.data());
+    const auto* existing_output_path = getenv(rocprofsys::env_vars::OUTPUT_PATH);
     if(output_path.empty() && existing_output_path != nullptr)
     {
         LOG_INFO("Output path: {}", existing_output_path);
@@ -99,7 +99,7 @@ setup_output_env(const std::string& output_path)
     const auto        output =
         output_path.empty() ? fmt::format("{}/rocprof-sys-output", pwd) : output_path;
 
-    setenv(rocprofsys::env_vars::OUTPUT_PATH.data(), output.c_str(), 1);
+    setenv(rocprofsys::env_vars::OUTPUT_PATH, output.c_str(), 1);
     LOG_INFO("Output path: {}", output);
 }
 
@@ -116,10 +116,9 @@ setup_output_format_env(const std::vector<std::string>& formats)
 
     if(has_format("perfetto") || has_format("rocpd"))
     {
-        setenv(rocprofsys::env_vars::TRACE.data(),
-               has_format("perfetto") ? "true" : "false", 1);
-        setenv(rocprofsys::env_vars::USE_ROCPD.data(),
-               has_format("rocpd") ? "true" : "false", 1);
+        setenv(rocprofsys::env_vars::TRACE, has_format("perfetto") ? "true" : "false", 1);
+        setenv(rocprofsys::env_vars::USE_ROCPD, has_format("rocpd") ? "true" : "false",
+               1);
     }
 
     LOG_INFO("Output format: {}", fmt::join(formats, " "));

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.cpp
@@ -3,6 +3,7 @@
 
 #include "common.hpp"
 #include "common/env_vars.hpp"
+#include "common/environment.hpp"
 #include <cstdint>
 
 #include <timemory/mpl/apply.hpp>
@@ -27,9 +28,10 @@ str_vec_t         category_regex_keys = {};
 str_set_t         category_view       = {};
 std::stringstream lerr{};
 
-bool debug_msg = tim::get_env<bool>(rocprofsys::env_vars::DEBUG_AVAIL, settings::debug());
+bool debug_msg =
+    rocprofsys::get_env(rocprofsys::env_vars::DEBUG_AVAIL, settings::debug());
 std::int32_t verbose_level =
-    tim::get_env<std::int32_t>(rocprofsys::env_vars::VERBOSE_AVAIL, settings::verbose());
+    rocprofsys::get_env(rocprofsys::env_vars::VERBOSE_AVAIL, settings::verbose());
 
 // explicit setting names to exclude
 std::set<std::string> settings_exclude = {

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "common.hpp"
+#include "common/env_vars.hpp"
 #include <cstdint>
 
 #include <timemory/mpl/apply.hpp>
@@ -26,14 +27,15 @@ str_vec_t         category_regex_keys = {};
 str_set_t         category_view       = {};
 std::stringstream lerr{};
 
-bool         debug_msg = tim::get_env<bool>("ROCPROFSYS_DEBUG_AVAIL", settings::debug());
-std::int32_t verbose_level =
-    tim::get_env<std::int32_t>("ROCPROFSYS_VERBOSE_AVAIL", settings::verbose());
+bool debug_msg =
+    tim::get_env<bool>(rocprofsys::env_vars::DEBUG_AVAIL.data(), settings::debug());
+std::int32_t verbose_level = tim::get_env<std::int32_t>(
+    rocprofsys::env_vars::VERBOSE_AVAIL.data(), settings::verbose());
 
 // explicit setting names to exclude
 std::set<std::string> settings_exclude = {
-    "ROCPROFSYS_ENVIRONMENT",
-    "ROCPROFSYS_COMMAND_LINE",
+    std::string{ rocprofsys::env_vars::ENVIRONMENT },
+    std::string{ rocprofsys::env_vars::COMMAND_LINE },
     "cereal_class_version",
     "settings",
 };

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.cpp
@@ -27,10 +27,9 @@ str_vec_t         category_regex_keys = {};
 str_set_t         category_view       = {};
 std::stringstream lerr{};
 
-bool debug_msg =
-    tim::get_env<bool>(rocprofsys::env_vars::DEBUG_AVAIL.data(), settings::debug());
-std::int32_t verbose_level = tim::get_env<std::int32_t>(
-    rocprofsys::env_vars::VERBOSE_AVAIL.data(), settings::verbose());
+bool debug_msg = tim::get_env<bool>(rocprofsys::env_vars::DEBUG_AVAIL, settings::debug());
+std::int32_t verbose_level =
+    tim::get_env<std::int32_t>(rocprofsys::env_vars::VERBOSE_AVAIL, settings::verbose());
 
 // explicit setting names to exclude
 std::set<std::string> settings_exclude = {

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/generate_config.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/generate_config.cpp
@@ -6,6 +6,7 @@
 #include "defines.hpp"
 #include "info_type.hpp"
 
+#include "common/env_vars.hpp"
 #include "common/json_config.hpp"
 
 #include <nlohmann/json.hpp>
@@ -352,13 +353,15 @@ generate_config(std::string _config_file, const std::set<std::string>& _config_f
                 auto _romni = _rhs->get_categories().count("rocprofsys") > 0;
                 if(_lomni && !_romni) return true;
                 if(_romni && !_lomni) return false;
+                namespace env_vars = rocprofsys::env_vars;
                 for(const auto* itr :
-                    { "ROCPROFSYS_CONFIG", "ROCPROFSYS_MODE", "ROCPROFSYS_TRACE",
-                      "ROCPROFSYS_TRACE_LEGACY", "ROCPROFSYS_PROFILE",
-                      "ROCPROFSYS_USE_SAMPLING", "ROCPROFSYS_USE_PROCESS_SAMPLING",
-                      "ROCPROFSYS_USE_AMD_SMI", "ROCPROFSYS_USE_AINIC",
-                      "ROCPROFSYS_USE_KOKKOSP", "ROCPROFSYS_USE_OMPT", "ROCPROFSYS_USE",
-                      "ROCPROFSYS_OUTPUT" })
+                    { env_vars::CONFIG.data(), env_vars::MODE.data(),
+                      env_vars::TRACE.data(), env_vars::TRACE_LEGACY.data(),
+                      env_vars::PROFILE.data(), env_vars::USE_SAMPLING.data(),
+                      env_vars::USE_PROCESS_SAMPLING.data(), env_vars::USE_AMD_SMI.data(),
+                      env_vars::USE_AINIC.data(), env_vars::USE_KOKKOSP.data(),
+                      env_vars::USE_OMPT.data(), "ROCPROFSYS_USE",
+                      env_vars::OUTPUT.data() })
                 {
                     if(_lhs->get_env_name().find(itr) == 0 &&
                        _rhs->get_env_name().find(itr) != 0)
@@ -367,8 +370,8 @@ generate_config(std::string _config_file, const std::set<std::string>& _config_f
                        _lhs->get_env_name().find(itr) != 0)
                         return false;
                 }
-                for(const auto* itr :
-                    { "ROCPROFSYS_SUPPRESS_PARSING", "ROCPROFSYS_SUPPRESS_CONFIG" })
+                for(const auto* itr : { env_vars::SUPPRESS_PARSING.data(),
+                                        env_vars::SUPPRESS_CONFIG.data() })
                 {
                     if(_lhs->get_env_name().find(itr) == 0 &&
                        _rhs->get_env_name().find(itr) != 0)
@@ -489,6 +492,6 @@ update_choices(const std::shared_ptr<settings>& _settings)
     if(_settings->get_verbose() >= 2 || _settings->get_debug())
         printf("[rocprof-sys-avail] # of component choices: %zu\n",
                _component_choices.size());
-    _settings->find("ROCPROFSYS_TIMEMORY_COMPONENTS")
+    _settings->find(std::string{ rocprofsys::env_vars::TIMEMORY_COMPONENTS })
         ->second->set_choices(_component_choices);
 }

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/generate_config.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/generate_config.cpp
@@ -355,13 +355,11 @@ generate_config(std::string _config_file, const std::set<std::string>& _config_f
                 if(_romni && !_lomni) return false;
                 namespace env_vars = rocprofsys::env_vars;
                 for(const auto* itr :
-                    { env_vars::CONFIG.data(), env_vars::MODE.data(),
-                      env_vars::TRACE.data(), env_vars::TRACE_LEGACY.data(),
-                      env_vars::PROFILE.data(), env_vars::USE_SAMPLING.data(),
-                      env_vars::USE_PROCESS_SAMPLING.data(), env_vars::USE_AMD_SMI.data(),
-                      env_vars::USE_AINIC.data(), env_vars::USE_KOKKOSP.data(),
-                      env_vars::USE_OMPT.data(), "ROCPROFSYS_USE",
-                      env_vars::OUTPUT.data() })
+                    { env_vars::CONFIG, env_vars::MODE, env_vars::TRACE,
+                      env_vars::TRACE_LEGACY, env_vars::PROFILE, env_vars::USE_SAMPLING,
+                      env_vars::USE_PROCESS_SAMPLING, env_vars::USE_AMD_SMI,
+                      env_vars::USE_AINIC, env_vars::USE_KOKKOSP, env_vars::USE_OMPT,
+                      "ROCPROFSYS_USE", env_vars::OUTPUT })
                 {
                     if(_lhs->get_env_name().find(itr) == 0 &&
                        _rhs->get_env_name().find(itr) != 0)
@@ -370,8 +368,8 @@ generate_config(std::string _config_file, const std::set<std::string>& _config_f
                        _lhs->get_env_name().find(itr) != 0)
                         return false;
                 }
-                for(const auto* itr : { env_vars::SUPPRESS_PARSING.data(),
-                                        env_vars::SUPPRESS_CONFIG.data() })
+                for(const auto* itr :
+                    { env_vars::SUPPRESS_PARSING, env_vars::SUPPRESS_CONFIG })
                 {
                     if(_lhs->get_env_name().find(itr) == 0 &&
                        _rhs->get_env_name().find(itr) != 0)

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/generate_config.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/generate_config.cpp
@@ -6,6 +6,7 @@
 #include "defines.hpp"
 #include "info_type.hpp"
 
+#include "common/env_vars.hpp"
 #include "common/json_config.hpp"
 
 #include <nlohmann/json.hpp>
@@ -352,13 +353,15 @@ generate_config(std::string _config_file, const std::set<std::string>& _config_f
                 auto _romni = _rhs->get_categories().count("rocprofsys") > 0;
                 if(_lomni && !_romni) return true;
                 if(_romni && !_lomni) return false;
+                namespace env_vars = rocprofsys::env_vars;
                 for(const auto* itr :
-                    { "ROCPROFSYS_CONFIG", "ROCPROFSYS_MODE", "ROCPROFSYS_TRACE",
-                      "ROCPROFSYS_TRACE_LEGACY", "ROCPROFSYS_PROFILE",
-                      "ROCPROFSYS_USE_SAMPLING", "ROCPROFSYS_USE_PROCESS_SAMPLING",
-                      "ROCPROFSYS_USE_AMD_SMI", "ROCPROFSYS_USE_AINIC",
-                      "ROCPROFSYS_USE_KOKKOSP", "ROCPROFSYS_USE_OMPT", "ROCPROFSYS_USE",
-                      "ROCPROFSYS_OUTPUT" })
+                    { env_vars::CONFIG.data(), env_vars::MODE.data(),
+                      env_vars::TRACE.data(), env_vars::TRACE_LEGACY.data(),
+                      env_vars::PROFILE.data(), env_vars::USE_SAMPLING.data(),
+                      env_vars::USE_PROCESS_SAMPLING.data(), env_vars::USE_AMD_SMI.data(),
+                      env_vars::USE_AINIC.data(), env_vars::USE_KOKKOSP.data(),
+                      env_vars::USE_OMPT.data(), "ROCPROFSYS_USE",
+                      env_vars::OUTPUT.data() })
                 {
                     if(_lhs->get_env_name().find(itr) == 0 &&
                        _rhs->get_env_name().find(itr) != 0)
@@ -367,8 +370,8 @@ generate_config(std::string _config_file, const std::set<std::string>& _config_f
                        _lhs->get_env_name().find(itr) != 0)
                         return false;
                 }
-                for(const auto* itr :
-                    { "ROCPROFSYS_SUPPRESS_PARSING", "ROCPROFSYS_SUPPRESS_CONFIG" })
+                for(const auto* itr : { env_vars::SUPPRESS_PARSING.data(),
+                                        env_vars::SUPPRESS_CONFIG.data() })
                 {
                     if(_lhs->get_env_name().find(itr) == 0 &&
                        _rhs->get_env_name().find(itr) != 0)
@@ -483,6 +486,6 @@ update_choices(const std::shared_ptr<settings>& _settings)
     if(_settings->get_verbose() >= 2 || _settings->get_debug())
         printf("[rocprof-sys-avail] # of component choices: %zu\n",
                _component_choices.size());
-    _settings->find("ROCPROFSYS_TIMEMORY_COMPONENTS")
+    _settings->find(std::string{ rocprofsys::env_vars::TIMEMORY_COMPONENTS })
         ->second->set_choices(_component_choices);
 }

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-causal/impl.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-causal/impl.cpp
@@ -93,7 +93,7 @@ forward_signal(int sig)
 int
 get_verbose()
 {
-    const auto* _log_level = std::getenv(env::LOG_LEVEL.data());
+    const auto* _log_level = std::getenv(env::LOG_LEVEL);
     if(_log_level != nullptr) verbose = env::log_level_to_verbose(_log_level);
     return verbose;
 }
@@ -154,8 +154,7 @@ get_initial_environment()
     update_env(_env, env::TRACE, false);
     update_env(_env, env::PROFILE, false);
     update_env(_env, env::USE_PROCESS_SAMPLING, false);
-    update_env(_env, env::THREAD_POOL_SIZE,
-               get_env<int>(env::THREAD_POOL_SIZE.data(), 0));
+    update_env(_env, env::THREAD_POOL_SIZE, get_env<int>(env::THREAD_POOL_SIZE, 0));
     update_env(_env, env::LAUNCHER, "rocprof-sys-causal");
 
     // Ensure libomptarget.so can be found by the target (OpenMP/HIP apps)

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-causal/impl.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-causal/impl.cpp
@@ -148,15 +148,15 @@ get_initial_environment()
         }
     }
 
-    update_env(_env, "ROCPROFSYS_MODE", "causal");
-    update_env(_env, "ROCPROFSYS_USE_CAUSAL", true);
-    update_env(_env, "ROCPROFSYS_USE_SAMPLING", false);
-    update_env(_env, "ROCPROFSYS_TRACE", false);
-    update_env(_env, "ROCPROFSYS_PROFILE", false);
-    update_env(_env, "ROCPROFSYS_USE_PROCESS_SAMPLING", false);
-    update_env(_env, "ROCPROFSYS_THREAD_POOL_SIZE",
-               get_env<int>("ROCPROFSYS_THREAD_POOL_SIZE", 0));
-    update_env(_env, "ROCPROFSYS_LAUNCHER", "rocprof-sys-causal");
+    update_env(_env, env::MODE, "causal");
+    update_env(_env, env::USE_CAUSAL, true);
+    update_env(_env, env::USE_SAMPLING, false);
+    update_env(_env, env::TRACE, false);
+    update_env(_env, env::PROFILE, false);
+    update_env(_env, env::USE_PROCESS_SAMPLING, false);
+    update_env(_env, env::THREAD_POOL_SIZE,
+               get_env<int>(env::THREAD_POOL_SIZE.data(), 0));
+    update_env(_env, env::LAUNCHER, "rocprof-sys-causal");
 
     // Ensure libomptarget.so can be found by the target (OpenMP/HIP apps)
     if(auto llvm_dir = rocprofsys::common::discover_llvm_libdir_for_ompt();
@@ -208,8 +208,8 @@ prepare_environment_for_run(std::vector<std::string>& _env)
             join(":", LIBPTHREAD_SO,
                  path::realpath(path::get_internal_libpath("librocprof-sys-dl.so"))),
             true);
-        update_env(_env, "ROCPROFSYS_SCRIPT_DIR", path::get_internal_script_path());
-        update_env(_env, "ROCPROFSYS_ROOT", path::get_rocprofsys_root());
+        update_env(_env, env::SCRIPT_DIR, path::get_internal_script_path());
+        update_env(_env, env::ROOT, path::get_rocprofsys_root());
     }
 }
 
@@ -322,7 +322,7 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
         .dtype("string")
         .choices({ "trace", "debug", "info", "warn", "error", "critical", "off" })
         .action([&](parser_t& p) {
-            update_env(_env, "ROCPROFSYS_LOG_LEVEL", p.get<std::string>("log-level"));
+            update_env(_env, env::LOG_LEVEL, p.get<std::string>("log-level"));
         });
 
     parser.add_argument({ "--monochrome" }, "Disable colorized output")
@@ -332,14 +332,14 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
             auto _monochrome = p.get<bool>("monochrome");
             monochrome()     = _monochrome;
             p.set_use_color(!_monochrome);
-            update_env(_env, "ROCPROFSYS_MONOCHROME", (_monochrome) ? "1" : "0");
+            update_env(_env, env::MONOCHROME, (_monochrome) ? "1" : "0");
             update_env(_env, "MONOCHROME", (_monochrome) ? "1" : "0");
         });
     parser.add_argument({ "--debug" }, "[DEPRECATED Use --log-level=debug] Debug output")
         .max_count(1)
         .action([&](parser_t& p) {
-            update_env(_env, "ROCPROFSYS_DEBUG", p.get<bool>("debug"));
-            update_env(_env, "ROCPROFSYS_LOG_LEVEL", "debug");
+            update_env(_env, env::DEBUG_MODE, p.get<bool>("debug"));
+            update_env(_env, env::LOG_LEVEL, "debug");
         });
     parser
         .add_argument({ "-v", "--verbose" },
@@ -348,13 +348,13 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
         .action([&](parser_t& p) {
             auto _v = p.get<int>("verbose");
             verbose = _v;
-            update_env(_env, "ROCPROFSYS_VERBOSE", _v);
+            update_env(_env, env::VERBOSE, _v);
 
             constexpr std::array<const char*, 5> log_levels = { "off", "info", "debug",
                                                                 "debug", "trace" };
 
             auto index = std::clamp(_v + 1, 0, static_cast<int>(log_levels.size() - 1));
-            update_env(_env, "ROCPROFSYS_LOG_LEVEL", log_levels[index]);
+            update_env(_env, env::LOG_LEVEL, log_levels[index]);
         });
 
     std::string _config_file      = {};
@@ -424,7 +424,7 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
         .choices({ "function", "line" })
         .choice_alias("function", { "func" })
         .action([&](parser_t& p) {
-            update_env(_env, "ROCPROFSYS_CAUSAL_MODE", p.get<std::string>("mode"));
+            update_env(_env, env::CAUSAL_MODE, p.get<std::string>("mode"));
         });
 
     parser.add_argument({ "-b", "--backend" }, "Causal profiling sampling backend.")
@@ -432,7 +432,7 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
         .dtype("string")
         .choices({ "auto", "perf", "timer" })
         .action([&](parser_t& p) {
-            update_env(_env, "ROCPROFSYS_CAUSAL_BACKEND", p.get<std::string>("backend"));
+            update_env(_env, env::CAUSAL_BACKEND, p.get<std::string>("backend"));
         });
 
     parser
@@ -441,7 +441,7 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
         .min_count(1)
         .dtype("filename")
         .action([&](parser_t& p) {
-            update_env(_env, "ROCPROFSYS_CAUSAL_FILE", p.get<std::string>("output-name"));
+            update_env(_env, env::CAUSAL_FILE, p.get<std::string>("output-name"));
         });
 
     bool _reset = false;
@@ -459,7 +459,7 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
         .max_count(1)
         .dtype("bool")
         .action([&](parser_t& p) {
-            update_env(_env, "ROCPROFSYS_CAUSAL_END_TO_END", p.get<bool>("end-to-end"));
+            update_env(_env, env::CAUSAL_END_TO_END, p.get<bool>("end-to-end"));
         });
 
     parser
@@ -469,7 +469,7 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
         .count(1)
         .dtype("seconds")
         .action([&](parser_t& p) {
-            update_env(_env, "ROCPROFSYS_CAUSAL_DELAY", p.get<double>("wait"));
+            update_env(_env, env::CAUSAL_DELAY, p.get<double>("wait"));
         });
 
     parser
@@ -482,7 +482,7 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
         .count(1)
         .dtype("seconds")
         .action([&](parser_t& p) {
-            update_env(_env, "ROCPROFSYS_CAUSAL_DURATION", p.get<double>("duration"));
+            update_env(_env, env::CAUSAL_DURATION, p.get<double>("duration"));
         });
 
     std::int64_t _niterations       = 1;
@@ -682,29 +682,29 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
 
     if(_add_defaults)
     {
-        add_default_env(_env, "ROCPROFSYS_TIME_OUTPUT", false);
-        add_default_env(_env, "ROCPROFSYS_USE_PID", false);
-        add_default_env(_env, "ROCPROFSYS_USE_KOKKOSP", true);
+        add_default_env(_env, env::TIME_OUTPUT, false);
+        add_default_env(_env, env::USE_PID, false);
+        add_default_env(_env, env::USE_KOKKOSP, true);
 
 #if defined(ROCPROFSYS_USE_OMPT) && ROCPROFSYS_USE_OMPT > 0
-        add_default_env(_env, "ROCPROFSYS_USE_OMPT", true);
+        add_default_env(_env, env::USE_OMPT, true);
 #endif
 
 #if(defined(ROCPROFSYS_USE_MPI) && ROCPROFSYS_USE_MPI > 0) ||                            \
     (defined(ROCPROFSYS_USE_MPI_HEADERS) && ROCPROFSYS_USE_MPI_HEADERS > 0)
-        add_default_env(_env, "ROCPROFSYS_USE_MPIP", true);
+        add_default_env(_env, env::USE_MPIP, true);
 #endif
     }
 
-    _fill("ROCPROFSYS_CAUSAL_BINARY_EXCLUDE", _binary_excludes, _generate_configs);
-    _fill("ROCPROFSYS_CAUSAL_SOURCE_EXCLUDE", _source_excludes, _generate_configs);
-    _fill("ROCPROFSYS_CAUSAL_FUNCTION_EXCLUDE", _function_excludes, _generate_configs);
+    _fill(env::CAUSAL_BINARY_EXCLUDE, _binary_excludes, _generate_configs);
+    _fill(env::CAUSAL_SOURCE_EXCLUDE, _source_excludes, _generate_configs);
+    _fill(env::CAUSAL_FUNCTION_EXCLUDE, _function_excludes, _generate_configs);
 
-    _fill("ROCPROFSYS_CAUSAL_BINARY_SCOPE", _binary_scopes, _generate_configs);
-    _fill("ROCPROFSYS_CAUSAL_SOURCE_SCOPE", _source_scopes, _generate_configs);
-    _fill("ROCPROFSYS_CAUSAL_FUNCTION_SCOPE", _function_scopes, _generate_configs);
+    _fill(env::CAUSAL_BINARY_SCOPE, _binary_scopes, _generate_configs);
+    _fill(env::CAUSAL_SOURCE_SCOPE, _source_scopes, _generate_configs);
+    _fill(env::CAUSAL_FUNCTION_SCOPE, _function_scopes, _generate_configs);
 
-    _fill("ROCPROFSYS_CAUSAL_FIXED_SPEEDUP", _virtual_speedups, false);
+    _fill(env::CAUSAL_FIXED_SPEEDUP, _virtual_speedups, false);
 
     // make sure at least one env exists
     if(_causal_envs_tmp.empty()) _causal_envs_tmp.emplace_back();
@@ -721,7 +721,7 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
     if(_generate_configs)
     {
         auto _is_omni_cfg = [](std::string_view itr) {
-            return (itr.find("ROCPROFSYS") == 0 && itr.find("ROCPROFSYS_MODE") != 0 &&
+            return (itr.find("ROCPROFSYS") == 0 && itr.find(env::MODE) != 0 &&
                     itr.find("ROCPROFSYS_DEBUG_") != 0 && itr.find('=') < itr.length());
             // rocprof-sys has miscellaneous env options starting with ROCPROFSYS_DEBUG_
             // that are not official options
@@ -747,7 +747,7 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
         auto _omni_env = std::vector<std::pair<std::string, std::string>>{};
         // make sure that ROCPROFSYS_CONFIG_FILE is the first entry
         {
-            auto citr = _omni_env_m.find("ROCPROFSYS_CONFIG_FILE");
+            auto citr = _omni_env_m.find(std::string{ env::CONFIG_FILE });
             if(citr != _omni_env_m.end())
             {
                 _omni_env.emplace_back(citr->first, citr->second);
@@ -791,16 +791,14 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
             auto _cfg_name = (_config_file.empty())
                                  ? fname.str()
                                  : join(array_config{ ":" }, _config_file, fname.str());
-            auto _cfg =
-                std::map<std::string_view, std::string>{ { "ROCPROFSYS_CONFIG_FILE",
-                                                           _cfg_name } };
+            auto _cfg      = std::map<std::string_view, std::string>{ { env::CONFIG_FILE,
+                                                                        _cfg_name } };
             _causal_envs.emplace_back(_cfg);
         }
     }
 
     if(_reset)
-        _causal_envs.front().emplace(std::string_view{ "ROCPROFSYS_CAUSAL_FILE_RESET" },
-                                     std::string{ "true" });
+        _causal_envs.front().emplace(env::CAUSAL_FILE_RESET, std::string{ "true" });
 
     return _outv;
 }

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-causal/impl.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-causal/impl.cpp
@@ -41,9 +41,9 @@ namespace argparse = ::tim::argparse;
 namespace path     = rocprofsys::common::path;
 namespace env      = rocprofsys::env_vars;
 using namespace ::timemory::join;
+using rocprofsys::get_env;
 using rocprofsys::common::update_mode;
 using ::rocprofsys::utility::parse_numeric_range;
-using ::tim::get_env;
 using ::tim::log::monochrome;
 using ::tim::log::stream;
 

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-causal/impl.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-causal/impl.cpp
@@ -148,15 +148,15 @@ get_initial_environment()
         }
     }
 
-    update_env(_env, "ROCPROFSYS_MODE", "causal");
-    update_env(_env, "ROCPROFSYS_USE_CAUSAL", true);
-    update_env(_env, "ROCPROFSYS_USE_SAMPLING", false);
-    update_env(_env, "ROCPROFSYS_TRACE", false);
-    update_env(_env, "ROCPROFSYS_PROFILE", false);
-    update_env(_env, "ROCPROFSYS_USE_PROCESS_SAMPLING", false);
-    update_env(_env, "ROCPROFSYS_THREAD_POOL_SIZE",
-               get_env<int>("ROCPROFSYS_THREAD_POOL_SIZE", 0));
-    update_env(_env, "ROCPROFSYS_LAUNCHER", "rocprof-sys-causal");
+    update_env(_env, env::MODE, "causal");
+    update_env(_env, env::USE_CAUSAL, true);
+    update_env(_env, env::USE_SAMPLING, false);
+    update_env(_env, env::TRACE, false);
+    update_env(_env, env::PROFILE, false);
+    update_env(_env, env::USE_PROCESS_SAMPLING, false);
+    update_env(_env, env::THREAD_POOL_SIZE,
+               get_env<int>(env::THREAD_POOL_SIZE.data(), 0));
+    update_env(_env, env::LAUNCHER, "rocprof-sys-causal");
 
     // Ensure libomptarget.so can be found by the target (OpenMP/HIP apps)
     if(auto llvm_dir =
@@ -209,8 +209,8 @@ prepare_environment_for_run(std::vector<std::string>& _env)
             join(":", LIBPTHREAD_SO,
                  path::realpath(path::get_internal_libpath("librocprof-sys-dl.so"))),
             true);
-        update_env(_env, "ROCPROFSYS_SCRIPT_DIR", path::get_internal_script_path());
-        update_env(_env, "ROCPROFSYS_ROOT", path::get_rocprofsys_root());
+        update_env(_env, env::SCRIPT_DIR, path::get_internal_script_path());
+        update_env(_env, env::ROOT, path::get_rocprofsys_root());
     }
 }
 
@@ -323,7 +323,7 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
         .dtype("string")
         .choices({ "trace", "debug", "info", "warn", "error", "critical", "off" })
         .action([&](parser_t& p) {
-            update_env(_env, "ROCPROFSYS_LOG_LEVEL", p.get<std::string>("log-level"));
+            update_env(_env, env::LOG_LEVEL, p.get<std::string>("log-level"));
         });
 
     parser.add_argument({ "--monochrome" }, "Disable colorized output")
@@ -333,14 +333,14 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
             auto _monochrome = p.get<bool>("monochrome");
             monochrome()     = _monochrome;
             p.set_use_color(!_monochrome);
-            update_env(_env, "ROCPROFSYS_MONOCHROME", (_monochrome) ? "1" : "0");
+            update_env(_env, env::MONOCHROME, (_monochrome) ? "1" : "0");
             update_env(_env, "MONOCHROME", (_monochrome) ? "1" : "0");
         });
     parser.add_argument({ "--debug" }, "[DEPRECATED Use --log-level=debug] Debug output")
         .max_count(1)
         .action([&](parser_t& p) {
-            update_env(_env, "ROCPROFSYS_DEBUG", p.get<bool>("debug"));
-            update_env(_env, "ROCPROFSYS_LOG_LEVEL", "debug");
+            update_env(_env, env::DEBUG_MODE, p.get<bool>("debug"));
+            update_env(_env, env::LOG_LEVEL, "debug");
         });
     parser
         .add_argument({ "-v", "--verbose" },
@@ -349,13 +349,13 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
         .action([&](parser_t& p) {
             auto _v = p.get<int>("verbose");
             verbose = _v;
-            update_env(_env, "ROCPROFSYS_VERBOSE", _v);
+            update_env(_env, env::VERBOSE, _v);
 
             constexpr std::array<const char*, 5> log_levels = { "off", "info", "debug",
                                                                 "debug", "trace" };
 
             auto index = std::clamp(_v + 1, 0, static_cast<int>(log_levels.size() - 1));
-            update_env(_env, "ROCPROFSYS_LOG_LEVEL", log_levels[index]);
+            update_env(_env, env::LOG_LEVEL, log_levels[index]);
         });
 
     std::string _config_file      = {};
@@ -425,7 +425,7 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
         .choices({ "function", "line" })
         .choice_alias("function", { "func" })
         .action([&](parser_t& p) {
-            update_env(_env, "ROCPROFSYS_CAUSAL_MODE", p.get<std::string>("mode"));
+            update_env(_env, env::CAUSAL_MODE, p.get<std::string>("mode"));
         });
 
     parser.add_argument({ "-b", "--backend" }, "Causal profiling sampling backend.")
@@ -433,7 +433,7 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
         .dtype("string")
         .choices({ "auto", "perf", "timer" })
         .action([&](parser_t& p) {
-            update_env(_env, "ROCPROFSYS_CAUSAL_BACKEND", p.get<std::string>("backend"));
+            update_env(_env, env::CAUSAL_BACKEND, p.get<std::string>("backend"));
         });
 
     parser
@@ -442,7 +442,7 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
         .min_count(1)
         .dtype("filename")
         .action([&](parser_t& p) {
-            update_env(_env, "ROCPROFSYS_CAUSAL_FILE", p.get<std::string>("output-name"));
+            update_env(_env, env::CAUSAL_FILE, p.get<std::string>("output-name"));
         });
 
     bool _reset = false;
@@ -460,7 +460,7 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
         .max_count(1)
         .dtype("bool")
         .action([&](parser_t& p) {
-            update_env(_env, "ROCPROFSYS_CAUSAL_END_TO_END", p.get<bool>("end-to-end"));
+            update_env(_env, env::CAUSAL_END_TO_END, p.get<bool>("end-to-end"));
         });
 
     parser
@@ -470,7 +470,7 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
         .count(1)
         .dtype("seconds")
         .action([&](parser_t& p) {
-            update_env(_env, "ROCPROFSYS_CAUSAL_DELAY", p.get<double>("wait"));
+            update_env(_env, env::CAUSAL_DELAY, p.get<double>("wait"));
         });
 
     parser
@@ -483,7 +483,7 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
         .count(1)
         .dtype("seconds")
         .action([&](parser_t& p) {
-            update_env(_env, "ROCPROFSYS_CAUSAL_DURATION", p.get<double>("duration"));
+            update_env(_env, env::CAUSAL_DURATION, p.get<double>("duration"));
         });
 
     std::int64_t _niterations       = 1;
@@ -683,29 +683,29 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
 
     if(_add_defaults)
     {
-        add_default_env(_env, "ROCPROFSYS_TIME_OUTPUT", false);
-        add_default_env(_env, "ROCPROFSYS_USE_PID", false);
-        add_default_env(_env, "ROCPROFSYS_USE_KOKKOSP", true);
+        add_default_env(_env, env::TIME_OUTPUT, false);
+        add_default_env(_env, env::USE_PID, false);
+        add_default_env(_env, env::USE_KOKKOSP, true);
 
 #if defined(ROCPROFSYS_USE_OMPT) && ROCPROFSYS_USE_OMPT > 0
-        add_default_env(_env, "ROCPROFSYS_USE_OMPT", true);
+        add_default_env(_env, env::USE_OMPT, true);
 #endif
 
 #if(defined(ROCPROFSYS_USE_MPI) && ROCPROFSYS_USE_MPI > 0) ||                            \
     (defined(ROCPROFSYS_USE_MPI_HEADERS) && ROCPROFSYS_USE_MPI_HEADERS > 0)
-        add_default_env(_env, "ROCPROFSYS_USE_MPIP", true);
+        add_default_env(_env, env::USE_MPIP, true);
 #endif
     }
 
-    _fill("ROCPROFSYS_CAUSAL_BINARY_EXCLUDE", _binary_excludes, _generate_configs);
-    _fill("ROCPROFSYS_CAUSAL_SOURCE_EXCLUDE", _source_excludes, _generate_configs);
-    _fill("ROCPROFSYS_CAUSAL_FUNCTION_EXCLUDE", _function_excludes, _generate_configs);
+    _fill(env::CAUSAL_BINARY_EXCLUDE, _binary_excludes, _generate_configs);
+    _fill(env::CAUSAL_SOURCE_EXCLUDE, _source_excludes, _generate_configs);
+    _fill(env::CAUSAL_FUNCTION_EXCLUDE, _function_excludes, _generate_configs);
 
-    _fill("ROCPROFSYS_CAUSAL_BINARY_SCOPE", _binary_scopes, _generate_configs);
-    _fill("ROCPROFSYS_CAUSAL_SOURCE_SCOPE", _source_scopes, _generate_configs);
-    _fill("ROCPROFSYS_CAUSAL_FUNCTION_SCOPE", _function_scopes, _generate_configs);
+    _fill(env::CAUSAL_BINARY_SCOPE, _binary_scopes, _generate_configs);
+    _fill(env::CAUSAL_SOURCE_SCOPE, _source_scopes, _generate_configs);
+    _fill(env::CAUSAL_FUNCTION_SCOPE, _function_scopes, _generate_configs);
 
-    _fill("ROCPROFSYS_CAUSAL_FIXED_SPEEDUP", _virtual_speedups, false);
+    _fill(env::CAUSAL_FIXED_SPEEDUP, _virtual_speedups, false);
 
     // make sure at least one env exists
     if(_causal_envs_tmp.empty()) _causal_envs_tmp.emplace_back();
@@ -722,7 +722,7 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
     if(_generate_configs)
     {
         auto _is_omni_cfg = [](std::string_view itr) {
-            return (itr.find("ROCPROFSYS") == 0 && itr.find("ROCPROFSYS_MODE") != 0 &&
+            return (itr.find("ROCPROFSYS") == 0 && itr.find(env::MODE) != 0 &&
                     itr.find("ROCPROFSYS_DEBUG_") != 0 && itr.find('=') < itr.length());
             // rocprof-sys has miscellaneous env options starting with ROCPROFSYS_DEBUG_
             // that are not official options
@@ -748,7 +748,7 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
         auto _omni_env = std::vector<std::pair<std::string, std::string>>{};
         // make sure that ROCPROFSYS_CONFIG_FILE is the first entry
         {
-            auto citr = _omni_env_m.find("ROCPROFSYS_CONFIG_FILE");
+            auto citr = _omni_env_m.find(std::string{ env::CONFIG_FILE });
             if(citr != _omni_env_m.end())
             {
                 _omni_env.emplace_back(citr->first, citr->second);
@@ -792,16 +792,14 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
             auto _cfg_name = (_config_file.empty())
                                  ? fname.str()
                                  : join(array_config{ ":" }, _config_file, fname.str());
-            auto _cfg =
-                std::map<std::string_view, std::string>{ { "ROCPROFSYS_CONFIG_FILE",
-                                                           _cfg_name } };
+            auto _cfg      = std::map<std::string_view, std::string>{ { env::CONFIG_FILE,
+                                                                        _cfg_name } };
             _causal_envs.emplace_back(_cfg);
         }
     }
 
     if(_reset)
-        _causal_envs.front().emplace(std::string_view{ "ROCPROFSYS_CAUSAL_FILE_RESET" },
-                                     std::string{ "true" });
+        _causal_envs.front().emplace(env::CAUSAL_FILE_RESET, std::string{ "true" });
 
     return _outv;
 }

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-causal/impl.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-causal/impl.cpp
@@ -39,7 +39,7 @@ namespace filepath = ::tim::filepath;
 namespace console  = ::tim::utility::console;
 namespace argparse = ::tim::argparse;
 namespace path     = rocprofsys::common::path;
-namespace env      = rocprofsys::env_vars;
+namespace env_vars = rocprofsys::env_vars;
 using namespace ::timemory::join;
 using rocprofsys::get_env;
 using rocprofsys::common::update_mode;
@@ -93,8 +93,8 @@ forward_signal(int sig)
 int
 get_verbose()
 {
-    const auto* _log_level = std::getenv(env::LOG_LEVEL);
-    if(_log_level != nullptr) verbose = env::log_level_to_verbose(_log_level);
+    const auto* _log_level = std::getenv(env_vars::LOG_LEVEL);
+    if(_log_level != nullptr) verbose = env_vars::log_level_to_verbose(_log_level);
     return verbose;
 }
 
@@ -148,14 +148,15 @@ get_initial_environment()
         }
     }
 
-    update_env(_env, env::MODE, "causal");
-    update_env(_env, env::USE_CAUSAL, true);
-    update_env(_env, env::USE_SAMPLING, false);
-    update_env(_env, env::TRACE, false);
-    update_env(_env, env::PROFILE, false);
-    update_env(_env, env::USE_PROCESS_SAMPLING, false);
-    update_env(_env, env::THREAD_POOL_SIZE, get_env<int>(env::THREAD_POOL_SIZE, 0));
-    update_env(_env, env::LAUNCHER, "rocprof-sys-causal");
+    update_env(_env, env_vars::MODE, "causal");
+    update_env(_env, env_vars::USE_CAUSAL, true);
+    update_env(_env, env_vars::USE_SAMPLING, false);
+    update_env(_env, env_vars::TRACE, false);
+    update_env(_env, env_vars::PROFILE, false);
+    update_env(_env, env_vars::USE_PROCESS_SAMPLING, false);
+    update_env(_env, env_vars::THREAD_POOL_SIZE,
+               get_env<int>(env_vars::THREAD_POOL_SIZE, 0));
+    update_env(_env, env_vars::LAUNCHER, "rocprof-sys-causal");
 
     // Ensure libomptarget.so can be found by the target (OpenMP/HIP apps)
     if(auto llvm_dir = rocprofsys::common::discover_llvm_libdir_for_ompt();
@@ -207,8 +208,8 @@ prepare_environment_for_run(std::vector<std::string>& _env)
             join(":", LIBPTHREAD_SO,
                  path::realpath(path::get_internal_libpath("librocprof-sys-dl.so"))),
             true);
-        update_env(_env, env::SCRIPT_DIR, path::get_internal_script_path());
-        update_env(_env, env::ROOT, path::get_rocprofsys_root());
+        update_env(_env, env_vars::SCRIPT_DIR, path::get_internal_script_path());
+        update_env(_env, env_vars::ROOT, path::get_rocprofsys_root());
     }
 }
 
@@ -321,7 +322,7 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
         .dtype("string")
         .choices({ "trace", "debug", "info", "warn", "error", "critical", "off" })
         .action([&](parser_t& p) {
-            update_env(_env, env::LOG_LEVEL, p.get<std::string>("log-level"));
+            update_env(_env, env_vars::LOG_LEVEL, p.get<std::string>("log-level"));
         });
 
     parser.add_argument({ "--monochrome" }, "Disable colorized output")
@@ -331,14 +332,14 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
             auto _monochrome = p.get<bool>("monochrome");
             monochrome()     = _monochrome;
             p.set_use_color(!_monochrome);
-            update_env(_env, env::MONOCHROME, (_monochrome) ? "1" : "0");
+            update_env(_env, env_vars::MONOCHROME, (_monochrome) ? "1" : "0");
             update_env(_env, "MONOCHROME", (_monochrome) ? "1" : "0");
         });
     parser.add_argument({ "--debug" }, "[DEPRECATED Use --log-level=debug] Debug output")
         .max_count(1)
         .action([&](parser_t& p) {
-            update_env(_env, env::DEBUG_MODE, p.get<bool>("debug"));
-            update_env(_env, env::LOG_LEVEL, "debug");
+            update_env(_env, env_vars::DEBUG_MODE, p.get<bool>("debug"));
+            update_env(_env, env_vars::LOG_LEVEL, "debug");
         });
     parser
         .add_argument({ "-v", "--verbose" },
@@ -347,13 +348,13 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
         .action([&](parser_t& p) {
             auto _v = p.get<int>("verbose");
             verbose = _v;
-            update_env(_env, env::VERBOSE, _v);
+            update_env(_env, env_vars::VERBOSE, _v);
 
             constexpr std::array<const char*, 5> log_levels = { "off", "info", "debug",
                                                                 "debug", "trace" };
 
             auto index = std::clamp(_v + 1, 0, static_cast<int>(log_levels.size() - 1));
-            update_env(_env, env::LOG_LEVEL, log_levels[index]);
+            update_env(_env, env_vars::LOG_LEVEL, log_levels[index]);
         });
 
     std::string _config_file      = {};
@@ -423,7 +424,7 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
         .choices({ "function", "line" })
         .choice_alias("function", { "func" })
         .action([&](parser_t& p) {
-            update_env(_env, env::CAUSAL_MODE, p.get<std::string>("mode"));
+            update_env(_env, env_vars::CAUSAL_MODE, p.get<std::string>("mode"));
         });
 
     parser.add_argument({ "-b", "--backend" }, "Causal profiling sampling backend.")
@@ -431,7 +432,7 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
         .dtype("string")
         .choices({ "auto", "perf", "timer" })
         .action([&](parser_t& p) {
-            update_env(_env, env::CAUSAL_BACKEND, p.get<std::string>("backend"));
+            update_env(_env, env_vars::CAUSAL_BACKEND, p.get<std::string>("backend"));
         });
 
     parser
@@ -440,7 +441,7 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
         .min_count(1)
         .dtype("filename")
         .action([&](parser_t& p) {
-            update_env(_env, env::CAUSAL_FILE, p.get<std::string>("output-name"));
+            update_env(_env, env_vars::CAUSAL_FILE, p.get<std::string>("output-name"));
         });
 
     bool _reset = false;
@@ -458,7 +459,7 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
         .max_count(1)
         .dtype("bool")
         .action([&](parser_t& p) {
-            update_env(_env, env::CAUSAL_END_TO_END, p.get<bool>("end-to-end"));
+            update_env(_env, env_vars::CAUSAL_END_TO_END, p.get<bool>("end-to-end"));
         });
 
     parser
@@ -468,7 +469,7 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
         .count(1)
         .dtype("seconds")
         .action([&](parser_t& p) {
-            update_env(_env, env::CAUSAL_DELAY, p.get<double>("wait"));
+            update_env(_env, env_vars::CAUSAL_DELAY, p.get<double>("wait"));
         });
 
     parser
@@ -481,7 +482,7 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
         .count(1)
         .dtype("seconds")
         .action([&](parser_t& p) {
-            update_env(_env, env::CAUSAL_DURATION, p.get<double>("duration"));
+            update_env(_env, env_vars::CAUSAL_DURATION, p.get<double>("duration"));
         });
 
     std::int64_t _niterations       = 1;
@@ -681,29 +682,29 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
 
     if(_add_defaults)
     {
-        add_default_env(_env, env::TIME_OUTPUT, false);
-        add_default_env(_env, env::USE_PID, false);
-        add_default_env(_env, env::USE_KOKKOSP, true);
+        add_default_env(_env, env_vars::TIME_OUTPUT, false);
+        add_default_env(_env, env_vars::USE_PID, false);
+        add_default_env(_env, env_vars::USE_KOKKOSP, true);
 
 #if defined(ROCPROFSYS_USE_OMPT) && ROCPROFSYS_USE_OMPT > 0
-        add_default_env(_env, env::USE_OMPT, true);
+        add_default_env(_env, env_vars::USE_OMPT, true);
 #endif
 
 #if(defined(ROCPROFSYS_USE_MPI) && ROCPROFSYS_USE_MPI > 0) ||                            \
     (defined(ROCPROFSYS_USE_MPI_HEADERS) && ROCPROFSYS_USE_MPI_HEADERS > 0)
-        add_default_env(_env, env::USE_MPIP, true);
+        add_default_env(_env, env_vars::USE_MPIP, true);
 #endif
     }
 
-    _fill(env::CAUSAL_BINARY_EXCLUDE, _binary_excludes, _generate_configs);
-    _fill(env::CAUSAL_SOURCE_EXCLUDE, _source_excludes, _generate_configs);
-    _fill(env::CAUSAL_FUNCTION_EXCLUDE, _function_excludes, _generate_configs);
+    _fill(env_vars::CAUSAL_BINARY_EXCLUDE, _binary_excludes, _generate_configs);
+    _fill(env_vars::CAUSAL_SOURCE_EXCLUDE, _source_excludes, _generate_configs);
+    _fill(env_vars::CAUSAL_FUNCTION_EXCLUDE, _function_excludes, _generate_configs);
 
-    _fill(env::CAUSAL_BINARY_SCOPE, _binary_scopes, _generate_configs);
-    _fill(env::CAUSAL_SOURCE_SCOPE, _source_scopes, _generate_configs);
-    _fill(env::CAUSAL_FUNCTION_SCOPE, _function_scopes, _generate_configs);
+    _fill(env_vars::CAUSAL_BINARY_SCOPE, _binary_scopes, _generate_configs);
+    _fill(env_vars::CAUSAL_SOURCE_SCOPE, _source_scopes, _generate_configs);
+    _fill(env_vars::CAUSAL_FUNCTION_SCOPE, _function_scopes, _generate_configs);
 
-    _fill(env::CAUSAL_FIXED_SPEEDUP, _virtual_speedups, false);
+    _fill(env_vars::CAUSAL_FIXED_SPEEDUP, _virtual_speedups, false);
 
     // make sure at least one env exists
     if(_causal_envs_tmp.empty()) _causal_envs_tmp.emplace_back();
@@ -720,7 +721,7 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
     if(_generate_configs)
     {
         auto _is_omni_cfg = [](std::string_view itr) {
-            return (itr.find("ROCPROFSYS") == 0 && itr.find(env::MODE) != 0 &&
+            return (itr.find("ROCPROFSYS") == 0 && itr.find(env_vars::MODE) != 0 &&
                     itr.find("ROCPROFSYS_DEBUG_") != 0 && itr.find('=') < itr.length());
             // rocprof-sys has miscellaneous env options starting with ROCPROFSYS_DEBUG_
             // that are not official options
@@ -746,7 +747,7 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
         auto _omni_env = std::vector<std::pair<std::string, std::string>>{};
         // make sure that ROCPROFSYS_CONFIG_FILE is the first entry
         {
-            auto citr = _omni_env_m.find(std::string{ env::CONFIG_FILE });
+            auto citr = _omni_env_m.find(std::string{ env_vars::CONFIG_FILE });
             if(citr != _omni_env_m.end())
             {
                 _omni_env.emplace_back(citr->first, citr->second);
@@ -790,14 +791,14 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
             auto _cfg_name = (_config_file.empty())
                                  ? fname.str()
                                  : join(array_config{ ":" }, _config_file, fname.str());
-            auto _cfg      = std::map<std::string_view, std::string>{ { env::CONFIG_FILE,
-                                                                        _cfg_name } };
+            auto _cfg = std::map<std::string_view, std::string>{ { env_vars::CONFIG_FILE,
+                                                                   _cfg_name } };
             _causal_envs.emplace_back(_cfg);
         }
     }
 
     if(_reset)
-        _causal_envs.front().emplace(env::CAUSAL_FILE_RESET, std::string{ "true" });
+        _causal_envs.front().emplace(env_vars::CAUSAL_FILE_RESET, std::string{ "true" });
 
     return _outv;
 }

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-exe/rocprof-sys.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-exe/rocprof-sys.cpp
@@ -99,7 +99,7 @@ main(int argc, char** argv)
         _completed.set_value();
     };
 
-    for(const auto* itr : { "CI", rocprofsys::env_vars::CI.data() })
+    for(const auto* itr : { "CI", rocprofsys::env_vars::CI })
     {
         if(_get_env(itr)) _env_failure(itr);
     }

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-exe/rocprof-sys.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-exe/rocprof-sys.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
+#include "common/env_vars.hpp"
+
 #include <algorithm>
 #include <cmath>
 #include <cstdlib>
@@ -97,7 +99,7 @@ main(int argc, char** argv)
         _completed.set_value();
     };
 
-    for(const auto* itr : { "CI", "ROCPROFSYS_CI" })
+    for(const auto* itr : { "CI", rocprofsys::env_vars::CI.data() })
     {
         if(_get_env(itr)) _env_failure(itr);
     }

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/internal_libs.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/internal_libs.cpp
@@ -9,6 +9,7 @@
 #include "binary/symbol.hpp"
 #include "common/defines.h"
 #include "common/env_vars.hpp"
+#include "common/environment.hpp"
 #include "core/demangler.hpp"
 #include "core/utility.hpp"
 #include "fwd.hpp"
@@ -32,8 +33,8 @@
 namespace
 {
 namespace filepath = ::tim::filepath;
+using rocprofsys::get_env;
 using ::tim::delimit;
-using ::tim::get_env;
 using ::timemory::join::join;
 using strview_init_t   = std::initializer_list<std::string_view>;
 using strview_set_t    = std::set<std::string_view>;
@@ -178,7 +179,7 @@ get_library_search_paths_impl()
     };
 
     // search paths from environment variables
-    for(const auto& itr : delimit(get_env("LD_LIBRARY_PATH", std::string{}, false), ":"))
+    for(const auto& itr : delimit(get_env("LD_LIBRARY_PATH", std::string{}), ":"))
         _emplace_if_exists(itr);
 
     for(const auto& itr : { get_env<std::string>(rocprofsys::env_vars::ROCM_PATH, ""),

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/internal_libs.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/internal_libs.cpp
@@ -8,6 +8,7 @@
 #include "binary/scope_filter.hpp"
 #include "binary/symbol.hpp"
 #include "common/defines.h"
+#include "common/env_vars.hpp"
 #include "core/demangler.hpp"
 #include "core/utility.hpp"
 #include "fwd.hpp"
@@ -180,9 +181,10 @@ get_library_search_paths_impl()
     for(const auto& itr : delimit(get_env("LD_LIBRARY_PATH", std::string{}, false), ":"))
         _emplace_if_exists(itr);
 
-    for(const auto& itr : { get_env<std::string>("ROCPROFSYS_ROCM_PATH", ""),
-                            get_env<std::string>("ROCM_PATH", ""),
-                            std::string{ ROCPROFSYS_DEFAULT_ROCM_PATH } })
+    for(const auto& itr :
+        { get_env<std::string>(rocprofsys::env_vars::ROCM_PATH.data(), ""),
+          get_env<std::string>("ROCM_PATH", ""),
+          std::string{ ROCPROFSYS_DEFAULT_ROCM_PATH } })
     {
         if(!itr.empty())
         {

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/internal_libs.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/internal_libs.cpp
@@ -181,10 +181,9 @@ get_library_search_paths_impl()
     for(const auto& itr : delimit(get_env("LD_LIBRARY_PATH", std::string{}, false), ":"))
         _emplace_if_exists(itr);
 
-    for(const auto& itr :
-        { get_env<std::string>(rocprofsys::env_vars::ROCM_PATH.data(), ""),
-          get_env<std::string>("ROCM_PATH", ""),
-          std::string{ ROCPROFSYS_DEFAULT_ROCM_PATH } })
+    for(const auto& itr : { get_env<std::string>(rocprofsys::env_vars::ROCM_PATH, ""),
+                            get_env<std::string>("ROCM_PATH", ""),
+                            std::string{ ROCPROFSYS_DEFAULT_ROCM_PATH } })
     {
         if(!itr.empty())
         {

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/internal_libs.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/internal_libs.cpp
@@ -8,6 +8,7 @@
 #include "binary/scope_filter.hpp"
 #include "binary/symbol.hpp"
 #include "common/defines.h"
+#include "common/env_vars.hpp"
 #include "core/demangler.hpp"
 #include "core/utility.hpp"
 #include "fwd.hpp"
@@ -181,9 +182,10 @@ get_library_search_paths_impl()
     for(const auto& itr : delimit(get_env("LD_LIBRARY_PATH", std::string{}, false), ":"))
         _emplace_if_exists(itr);
 
-    for(const auto& itr : { get_env<std::string>("ROCPROFSYS_ROCM_PATH", ""),
-                            get_env<std::string>("ROCM_PATH", ""),
-                            std::string{ ROCPROFSYS_DEFAULT_ROCM_PATH } })
+    for(const auto& itr :
+        { get_env<std::string>(rocprofsys::env_vars::ROCM_PATH.data(), ""),
+          get_env<std::string>("ROCM_PATH", ""),
+          std::string{ ROCPROFSYS_DEFAULT_ROCM_PATH } })
     {
         if(!itr.empty())
         {

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
@@ -4,6 +4,7 @@
 #include "rocprof-sys-instrument.hpp"
 #include "common/defines.h"
 #include "common/env_vars.hpp"
+#include "common/environment.hpp"
 #include "common/join.hpp"
 #include "common/path.hpp"
 #include "core/demangler.hpp"
@@ -61,8 +62,8 @@ auto
 get_default_min_instructions()
 {
     // default to 1024
-    return tim::get_env<size_t>(rocprofsys::env_vars::DEFAULT_MIN_INSTRUCTIONS, (1 << 10),
-                                false);
+    return rocprofsys::get_env<size_t>(rocprofsys::env_vars::DEFAULT_MIN_INSTRUCTIONS,
+                                       (1 << 10));
 }
 auto
 get_default_min_address_range()
@@ -94,10 +95,10 @@ bool   instr_print                  = false;
 bool   simulate                     = false;
 bool   include_uninstr              = false;
 bool   include_internal_linked_libs = false;
-int    verbose_level = tim::get_env<int>(rocprofsys::env_vars::VERBOSE_INSTRUMENT, 0);
-int    num_log_entries =
-    tim::get_env<int>(rocprofsys::env_vars::LOG_COUNT,
-                      tim::get_env<bool>(rocprofsys::env_vars::CI, false) ? 20 : 50);
+int verbose_level = rocprofsys::get_env<int>(rocprofsys::env_vars::VERBOSE_INSTRUMENT, 0);
+int num_log_entries = rocprofsys::get_env<int>(
+    rocprofsys::env_vars::LOG_COUNT,
+    rocprofsys::get_env<bool>(rocprofsys::env_vars::CI, false) ? 20 : 50);
 string_t main_fname     = "main";
 string_t argv0          = {};
 string_t cmdv0          = {};
@@ -178,13 +179,13 @@ bool                                            dump_info_enabled    = false;
 std::string                                     modfunc_dump_dir     = {};
 auto regex_opts = std::regex_constants::egrep | std::regex_constants::optimize;
 
-strvec_t lib_search_paths =
-    tim::delimit(rocprofsys::join(':', path::get_internal_libdir(),
-                                  tim::get_env<std::string>("DYNINSTAPI_RT_LIB"),
-                                  tim::get_env<std::string>("DYNINST_REWRITER_PATHS"),
-                                  tim::get_env<std::string>("LD_LIBRARY_PATH")),
-                 ":");
-strvec_t bin_search_paths = tim::delimit(tim::get_env<std::string>("PATH"), ":");
+strvec_t lib_search_paths = tim::delimit(
+    rocprofsys::join(':', path::get_internal_libdir(),
+                     rocprofsys::get_env<std::string>("DYNINSTAPI_RT_LIB"),
+                     rocprofsys::get_env<std::string>("DYNINST_REWRITER_PATHS"),
+                     rocprofsys::get_env<std::string>("LD_LIBRARY_PATH")),
+    ":");
+strvec_t bin_search_paths = tim::delimit(rocprofsys::get_env<std::string>("PATH"), ":");
 
 auto _dyn_api_rt_paths = tim::delimit(
     rocprofsys::join(":", path::get_internal_libdir(),
@@ -289,9 +290,9 @@ main(int argc, char** argv)
 {
     argv0 = argv[0];
 
-    auto _omni_root = tim::get_env<std::string>(
+    auto _omni_root = rocprofsys::get_env<std::string>(
         "rocprofiler_systems_ROOT",
-        tim::get_env<std::string>(rocprofsys::env_vars::ROOT, ""));
+        rocprofsys::get_env<std::string>(rocprofsys::env_vars::ROOT, ""));
     if(!_omni_root.empty() && exists(_omni_root))
     {
         bin_search_paths.emplace_back(JOIN('/', _omni_root, "bin"));
@@ -1280,30 +1281,30 @@ main(int argc, char** argv)
         };
 
         add_regex(func_include,
-                  tim::get_env<string_t>(rocprofsys::env_vars::REGEX_INCLUDE, ""));
+                  rocprofsys::get_env<string_t>(rocprofsys::env_vars::REGEX_INCLUDE, ""));
         add_regex(func_exclude,
-                  tim::get_env<string_t>(rocprofsys::env_vars::REGEX_EXCLUDE, ""));
-        add_regex(func_restrict,
-                  tim::get_env<string_t>(rocprofsys::env_vars::REGEX_RESTRICT, ""));
-        add_regex(caller_include,
-                  tim::get_env<string_t>(rocprofsys::env_vars::REGEX_CALLER_INCLUDE));
-        add_regex(
-            func_internal_include,
-            tim::get_env<string_t>(rocprofsys::env_vars::REGEX_INTERNAL_INCLUDE, ""));
+                  rocprofsys::get_env<string_t>(rocprofsys::env_vars::REGEX_EXCLUDE, ""));
+        add_regex(func_restrict, rocprofsys::get_env<string_t>(
+                                     rocprofsys::env_vars::REGEX_RESTRICT, ""));
+        add_regex(caller_include, rocprofsys::get_env<string_t>(
+                                      rocprofsys::env_vars::REGEX_CALLER_INCLUDE));
+        add_regex(func_internal_include,
+                  rocprofsys::get_env<string_t>(
+                      rocprofsys::env_vars::REGEX_INTERNAL_INCLUDE, ""));
 
-        add_regex(file_include,
-                  tim::get_env<string_t>(rocprofsys::env_vars::REGEX_MODULE_INCLUDE, ""));
-        add_regex(file_exclude,
-                  tim::get_env<string_t>(rocprofsys::env_vars::REGEX_MODULE_EXCLUDE, ""));
-        add_regex(file_restrict, tim::get_env<string_t>(
+        add_regex(file_include, rocprofsys::get_env<string_t>(
+                                    rocprofsys::env_vars::REGEX_MODULE_INCLUDE, ""));
+        add_regex(file_exclude, rocprofsys::get_env<string_t>(
+                                    rocprofsys::env_vars::REGEX_MODULE_EXCLUDE, ""));
+        add_regex(file_restrict, rocprofsys::get_env<string_t>(
                                      rocprofsys::env_vars::REGEX_MODULE_RESTRICT, ""));
         add_regex(file_internal_include,
-                  tim::get_env<string_t>(
+                  rocprofsys::get_env<string_t>(
                       rocprofsys::env_vars::REGEX_MODULE_INTERNAL_INCLUDE, ""));
 
-        add_regex(
-            instruction_exclude,
-            tim::get_env<string_t>(rocprofsys::env_vars::REGEX_INSTRUCTION_EXCLUDE, ""));
+        add_regex(instruction_exclude,
+                  rocprofsys::get_env<string_t>(
+                      rocprofsys::env_vars::REGEX_INSTRUCTION_EXCLUDE, ""));
 
         //  Helper function for parsing the regex options
         auto _parse_regex_option = [&parser, &add_regex](const string_t& _option,
@@ -2056,7 +2057,7 @@ main(int argc, char** argv)
         }
         auto _var = itr.substr(0, _pos);
         auto _val = itr.substr(_pos + 1);
-        tim::set_env(_var, _val);
+        rocprofsys::set_env(_var.c_str(), _val, 0);
         auto _expr = rocprofsys_call_expr(_var, _val);
         env_variables.emplace_back(_expr.get(env_func));
     }
@@ -2929,7 +2930,7 @@ find_dyn_api_rt()
 #endif
 
     auto _dyn_api_rt_env =
-        tim::get_env<std::string>("DYNINSTAPI_RT_LIB", _dyn_api_rt_base + ".so");
+        rocprofsys::get_env<std::string>("DYNINSTAPI_RT_LIB", _dyn_api_rt_base + ".so");
     auto _dyn_api_rt_abs = get_absolute_lib_filepath(_dyn_api_rt_env);
 
     if(!exists(_dyn_api_rt_abs))
@@ -2938,14 +2939,15 @@ find_dyn_api_rt()
     if(exists(_dyn_api_rt_abs))
     {
         namespace join = ::timemory::join;
-        tim::set_env<string_t>("DYNINSTAPI_RT_LIB", _dyn_api_rt_abs, 1);
-        tim::set_env<string_t>("DYNINST_REWRITER_PATHS",
-                               join::join(join::array_config{ ":", "", "" },
-                                          dirname(_dyn_api_rt_abs), lib_search_paths),
-                               1);
+        rocprofsys::set_env<string_t>("DYNINSTAPI_RT_LIB", _dyn_api_rt_abs, 1);
+        rocprofsys::set_env<string_t>("DYNINST_REWRITER_PATHS",
+                                      join::join(join::array_config{ ":", "", "" },
+                                                 dirname(_dyn_api_rt_abs),
+                                                 lib_search_paths),
+                                      1);
     }
 
-    auto _v = tim::get_env<string_t>("DYNINSTAPI_RT_LIB", "");
+    auto _v = rocprofsys::get_env<string_t>("DYNINSTAPI_RT_LIB", "");
     verbprintf(0, "DYNINST_API_RT: %s\n", (_v.empty()) ? "<unknown>" : _v.c_str());
 }
 }  // namespace

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
@@ -3,6 +3,7 @@
 
 #include "rocprof-sys-instrument.hpp"
 #include "common/defines.h"
+#include "common/env_vars.hpp"
 #include "common/join.hpp"
 #include "common/path.hpp"
 #include "core/demangler.hpp"
@@ -60,7 +61,8 @@ auto
 get_default_min_instructions()
 {
     // default to 1024
-    return tim::get_env<size_t>("ROCPROFSYS_DEFAULT_MIN_INSTRUCTIONS", (1 << 10), false);
+    return tim::get_env<size_t>(rocprofsys::env_vars::DEFAULT_MIN_INSTRUCTIONS.data(),
+                                (1 << 10), false);
 }
 auto
 get_default_min_address_range()
@@ -92,9 +94,10 @@ bool   instr_print                  = false;
 bool   simulate                     = false;
 bool   include_uninstr              = false;
 bool   include_internal_linked_libs = false;
-int    verbose_level   = tim::get_env<int>("ROCPROFSYS_VERBOSE_INSTRUMENT", 0);
-int    num_log_entries = tim::get_env<int>(
-    "ROCPROFSYS_LOG_COUNT", tim::get_env<bool>("ROCPROFSYS_CI", false) ? 20 : 50);
+int verbose_level = tim::get_env<int>(rocprofsys::env_vars::VERBOSE_INSTRUMENT.data(), 0);
+int num_log_entries = tim::get_env<int>(
+    rocprofsys::env_vars::LOG_COUNT.data(),
+    tim::get_env<bool>(rocprofsys::env_vars::CI.data(), false) ? 20 : 50);
 string_t main_fname     = "main";
 string_t argv0          = {};
 string_t cmdv0          = {};
@@ -287,7 +290,8 @@ main(int argc, char** argv)
     argv0 = argv[0];
 
     auto _omni_root = tim::get_env<std::string>(
-        "rocprofiler_systems_ROOT", tim::get_env<std::string>("ROCPROFSYS_ROOT", ""));
+        "rocprofiler_systems_ROOT",
+        tim::get_env<std::string>(rocprofsys::env_vars::ROOT.data(), ""));
     if(!_omni_root.empty() && exists(_omni_root))
     {
         bin_search_paths.emplace_back(JOIN('/', _omni_root, "bin"));
@@ -1275,25 +1279,34 @@ main(int argc, char** argv)
                 regex_array.emplace_back(std::regex(regex_expr, regex_opts));
         };
 
-        add_regex(func_include, tim::get_env<string_t>("ROCPROFSYS_REGEX_INCLUDE", ""));
-        add_regex(func_exclude, tim::get_env<string_t>("ROCPROFSYS_REGEX_EXCLUDE", ""));
-        add_regex(func_restrict, tim::get_env<string_t>("ROCPROFSYS_REGEX_RESTRICT", ""));
-        add_regex(caller_include,
-                  tim::get_env<string_t>("ROCPROFSYS_REGEX_CALLER_INCLUDE"));
+        add_regex(func_include,
+                  tim::get_env<string_t>(rocprofsys::env_vars::REGEX_INCLUDE.data(), ""));
+        add_regex(func_exclude,
+                  tim::get_env<string_t>(rocprofsys::env_vars::REGEX_EXCLUDE.data(), ""));
+        add_regex(func_restrict, tim::get_env<string_t>(
+                                     rocprofsys::env_vars::REGEX_RESTRICT.data(), ""));
+        add_regex(caller_include, tim::get_env<string_t>(
+                                      rocprofsys::env_vars::REGEX_CALLER_INCLUDE.data()));
         add_regex(func_internal_include,
-                  tim::get_env<string_t>("ROCPROFSYS_REGEX_INTERNAL_INCLUDE", ""));
+                  tim::get_env<string_t>(
+                      rocprofsys::env_vars::REGEX_INTERNAL_INCLUDE.data(), ""));
 
         add_regex(file_include,
-                  tim::get_env<string_t>("ROCPROFSYS_REGEX_MODULE_INCLUDE", ""));
+                  tim::get_env<string_t>(
+                      rocprofsys::env_vars::REGEX_MODULE_INCLUDE.data(), ""));
         add_regex(file_exclude,
-                  tim::get_env<string_t>("ROCPROFSYS_REGEX_MODULE_EXCLUDE", ""));
+                  tim::get_env<string_t>(
+                      rocprofsys::env_vars::REGEX_MODULE_EXCLUDE.data(), ""));
         add_regex(file_restrict,
-                  tim::get_env<string_t>("ROCPROFSYS_REGEX_MODULE_RESTRICT", ""));
+                  tim::get_env<string_t>(
+                      rocprofsys::env_vars::REGEX_MODULE_RESTRICT.data(), ""));
         add_regex(file_internal_include,
-                  tim::get_env<string_t>("ROCPROFSYS_REGEX_MODULE_INTERNAL_INCLUDE", ""));
+                  tim::get_env<string_t>(
+                      rocprofsys::env_vars::REGEX_MODULE_INTERNAL_INCLUDE.data(), ""));
 
         add_regex(instruction_exclude,
-                  tim::get_env<string_t>("ROCPROFSYS_REGEX_INSTRUCTION_EXCLUDE", ""));
+                  tim::get_env<string_t>(
+                      rocprofsys::env_vars::REGEX_INSTRUCTION_EXCLUDE.data(), ""));
 
         //  Helper function for parsing the regex options
         auto _parse_regex_option = [&parser, &add_regex](const string_t& _option,
@@ -1418,12 +1431,12 @@ main(int argc, char** argv)
     env_vars.reserve(env_vars.size() + env_config_variables.size());
     for(auto&& itr : env_config_variables)
         env_vars.emplace_back(itr);
-    env_vars.emplace_back(TIMEMORY_JOIN('=', "ROCPROFSYS_MODE", instr_mode));
+    env_vars.emplace_back(TIMEMORY_JOIN('=', rocprofsys::env_vars::MODE, instr_mode));
     env_vars.emplace_back(
-        TIMEMORY_JOIN('=', "ROCPROFSYS_INSTRUMENT_MODE", instr_mode_v_int));
-    env_vars.emplace_back(TIMEMORY_JOIN('=', "ROCPROFSYS_MPI_INIT", "OFF"));
-    env_vars.emplace_back(TIMEMORY_JOIN('=', "ROCPROFSYS_MPI_FINALIZE", "OFF"));
-    env_vars.emplace_back(TIMEMORY_JOIN('=', "ROCPROFSYS_USE_CODE_COVERAGE",
+        TIMEMORY_JOIN('=', rocprofsys::env_vars::INSTRUMENT_MODE, instr_mode_v_int));
+    env_vars.emplace_back(TIMEMORY_JOIN('=', rocprofsys::env_vars::MPI_INIT, "OFF"));
+    env_vars.emplace_back(TIMEMORY_JOIN('=', rocprofsys::env_vars::MPI_FINALIZE, "OFF"));
+    env_vars.emplace_back(TIMEMORY_JOIN('=', rocprofsys::env_vars::USE_CODE_COVERAGE,
                                         (coverage_mode != CODECOV_NONE) ? "ON" : "OFF"));
     addr_space = rocprofsys_get_address_space(bpatch, _cmdc, _cmdv, env_vars,
                                               binary_rewrite, _pid, mutname);
@@ -2026,14 +2039,15 @@ main(int argc, char** argv)
     if(!binary_rewrite && !is_attached) env_vars.clear();
 
     env_vars.emplace_back(
-        TIMEMORY_JOIN('=', "ROCPROFSYS_INIT_ENABLED",
+        TIMEMORY_JOIN('=', rocprofsys::env_vars::INIT_ENABLED,
                       (user_start_func && user_stop_func) ? "OFF" : "ON"));
-    env_vars.emplace_back(TIMEMORY_JOIN('=', "ROCPROFSYS_USE_MPIP",
+    env_vars.emplace_back(TIMEMORY_JOIN('=', rocprofsys::env_vars::USE_MPIP,
                                         (binary_rewrite && use_mpi) ? "ON" : "OFF"));
-    if(use_mpi) env_vars.emplace_back(TIMEMORY_JOIN('=', "ROCPROFSYS_USE_PID", "ON"));
+    if(use_mpi)
+        env_vars.emplace_back(TIMEMORY_JOIN('=', rocprofsys::env_vars::USE_PID, "ON"));
 
-    env_vars.emplace_back(
-        TIMEMORY_JOIN('=', "ROCPROFSYS_SCRIPT_PATH", _omni_internal_libexec_path));
+    env_vars.emplace_back(TIMEMORY_JOIN('=', rocprofsys::env_vars::SCRIPT_PATH,
+                                        _omni_internal_libexec_path));
 
     for(auto& itr : env_vars)
     {

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
@@ -61,8 +61,8 @@ auto
 get_default_min_instructions()
 {
     // default to 1024
-    return tim::get_env<size_t>(rocprofsys::env_vars::DEFAULT_MIN_INSTRUCTIONS.data(),
-                                (1 << 10), false);
+    return tim::get_env<size_t>(rocprofsys::env_vars::DEFAULT_MIN_INSTRUCTIONS, (1 << 10),
+                                false);
 }
 auto
 get_default_min_address_range()
@@ -94,10 +94,10 @@ bool   instr_print                  = false;
 bool   simulate                     = false;
 bool   include_uninstr              = false;
 bool   include_internal_linked_libs = false;
-int verbose_level = tim::get_env<int>(rocprofsys::env_vars::VERBOSE_INSTRUMENT.data(), 0);
-int num_log_entries = tim::get_env<int>(
-    rocprofsys::env_vars::LOG_COUNT.data(),
-    tim::get_env<bool>(rocprofsys::env_vars::CI.data(), false) ? 20 : 50);
+int    verbose_level = tim::get_env<int>(rocprofsys::env_vars::VERBOSE_INSTRUMENT, 0);
+int    num_log_entries =
+    tim::get_env<int>(rocprofsys::env_vars::LOG_COUNT,
+                      tim::get_env<bool>(rocprofsys::env_vars::CI, false) ? 20 : 50);
 string_t main_fname     = "main";
 string_t argv0          = {};
 string_t cmdv0          = {};
@@ -291,7 +291,7 @@ main(int argc, char** argv)
 
     auto _omni_root = tim::get_env<std::string>(
         "rocprofiler_systems_ROOT",
-        tim::get_env<std::string>(rocprofsys::env_vars::ROOT.data(), ""));
+        tim::get_env<std::string>(rocprofsys::env_vars::ROOT, ""));
     if(!_omni_root.empty() && exists(_omni_root))
     {
         bin_search_paths.emplace_back(JOIN('/', _omni_root, "bin"));
@@ -1280,33 +1280,30 @@ main(int argc, char** argv)
         };
 
         add_regex(func_include,
-                  tim::get_env<string_t>(rocprofsys::env_vars::REGEX_INCLUDE.data(), ""));
+                  tim::get_env<string_t>(rocprofsys::env_vars::REGEX_INCLUDE, ""));
         add_regex(func_exclude,
-                  tim::get_env<string_t>(rocprofsys::env_vars::REGEX_EXCLUDE.data(), ""));
-        add_regex(func_restrict, tim::get_env<string_t>(
-                                     rocprofsys::env_vars::REGEX_RESTRICT.data(), ""));
-        add_regex(caller_include, tim::get_env<string_t>(
-                                      rocprofsys::env_vars::REGEX_CALLER_INCLUDE.data()));
-        add_regex(func_internal_include,
-                  tim::get_env<string_t>(
-                      rocprofsys::env_vars::REGEX_INTERNAL_INCLUDE.data(), ""));
+                  tim::get_env<string_t>(rocprofsys::env_vars::REGEX_EXCLUDE, ""));
+        add_regex(func_restrict,
+                  tim::get_env<string_t>(rocprofsys::env_vars::REGEX_RESTRICT, ""));
+        add_regex(caller_include,
+                  tim::get_env<string_t>(rocprofsys::env_vars::REGEX_CALLER_INCLUDE));
+        add_regex(
+            func_internal_include,
+            tim::get_env<string_t>(rocprofsys::env_vars::REGEX_INTERNAL_INCLUDE, ""));
 
         add_regex(file_include,
-                  tim::get_env<string_t>(
-                      rocprofsys::env_vars::REGEX_MODULE_INCLUDE.data(), ""));
+                  tim::get_env<string_t>(rocprofsys::env_vars::REGEX_MODULE_INCLUDE, ""));
         add_regex(file_exclude,
-                  tim::get_env<string_t>(
-                      rocprofsys::env_vars::REGEX_MODULE_EXCLUDE.data(), ""));
-        add_regex(file_restrict,
-                  tim::get_env<string_t>(
-                      rocprofsys::env_vars::REGEX_MODULE_RESTRICT.data(), ""));
+                  tim::get_env<string_t>(rocprofsys::env_vars::REGEX_MODULE_EXCLUDE, ""));
+        add_regex(file_restrict, tim::get_env<string_t>(
+                                     rocprofsys::env_vars::REGEX_MODULE_RESTRICT, ""));
         add_regex(file_internal_include,
                   tim::get_env<string_t>(
-                      rocprofsys::env_vars::REGEX_MODULE_INTERNAL_INCLUDE.data(), ""));
+                      rocprofsys::env_vars::REGEX_MODULE_INTERNAL_INCLUDE, ""));
 
-        add_regex(instruction_exclude,
-                  tim::get_env<string_t>(
-                      rocprofsys::env_vars::REGEX_INSTRUCTION_EXCLUDE.data(), ""));
+        add_regex(
+            instruction_exclude,
+            tim::get_env<string_t>(rocprofsys::env_vars::REGEX_INSTRUCTION_EXCLUDE, ""));
 
         //  Helper function for parsing the regex options
         auto _parse_regex_option = [&parser, &add_regex](const string_t& _option,

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
@@ -3,6 +3,7 @@
 
 #include "rocprof-sys-instrument.hpp"
 #include "common/defines.h"
+#include "common/env_vars.hpp"
 #include "common/join.hpp"
 #include "common/path.hpp"
 #include "core/demangler.hpp"
@@ -61,7 +62,8 @@ auto
 get_default_min_instructions()
 {
     // default to 1024
-    return tim::get_env<size_t>("ROCPROFSYS_DEFAULT_MIN_INSTRUCTIONS", (1 << 10), false);
+    return tim::get_env<size_t>(rocprofsys::env_vars::DEFAULT_MIN_INSTRUCTIONS.data(),
+                                (1 << 10), false);
 }
 auto
 get_default_min_address_range()
@@ -93,9 +95,10 @@ bool   instr_print                  = false;
 bool   simulate                     = false;
 bool   include_uninstr              = false;
 bool   include_internal_linked_libs = false;
-int    verbose_level   = tim::get_env<int>("ROCPROFSYS_VERBOSE_INSTRUMENT", 0);
-int    num_log_entries = tim::get_env<int>(
-    "ROCPROFSYS_LOG_COUNT", tim::get_env<bool>("ROCPROFSYS_CI", false) ? 20 : 50);
+int verbose_level = tim::get_env<int>(rocprofsys::env_vars::VERBOSE_INSTRUMENT.data(), 0);
+int num_log_entries = tim::get_env<int>(
+    rocprofsys::env_vars::LOG_COUNT.data(),
+    tim::get_env<bool>(rocprofsys::env_vars::CI.data(), false) ? 20 : 50);
 string_t main_fname     = "main";
 string_t argv0          = {};
 string_t cmdv0          = {};
@@ -288,7 +291,8 @@ main(int argc, char** argv)
     argv0 = argv[0];
 
     auto _omni_root = tim::get_env<std::string>(
-        "rocprofiler_systems_ROOT", tim::get_env<std::string>("ROCPROFSYS_ROOT", ""));
+        "rocprofiler_systems_ROOT",
+        tim::get_env<std::string>(rocprofsys::env_vars::ROOT.data(), ""));
     if(!_omni_root.empty() && exists(_omni_root))
     {
         bin_search_paths.emplace_back(JOIN('/', _omni_root, "bin"));
@@ -1276,25 +1280,34 @@ main(int argc, char** argv)
                 regex_array.emplace_back(std::regex(regex_expr, regex_opts));
         };
 
-        add_regex(func_include, tim::get_env<string_t>("ROCPROFSYS_REGEX_INCLUDE", ""));
-        add_regex(func_exclude, tim::get_env<string_t>("ROCPROFSYS_REGEX_EXCLUDE", ""));
-        add_regex(func_restrict, tim::get_env<string_t>("ROCPROFSYS_REGEX_RESTRICT", ""));
-        add_regex(caller_include,
-                  tim::get_env<string_t>("ROCPROFSYS_REGEX_CALLER_INCLUDE"));
+        add_regex(func_include,
+                  tim::get_env<string_t>(rocprofsys::env_vars::REGEX_INCLUDE.data(), ""));
+        add_regex(func_exclude,
+                  tim::get_env<string_t>(rocprofsys::env_vars::REGEX_EXCLUDE.data(), ""));
+        add_regex(func_restrict, tim::get_env<string_t>(
+                                     rocprofsys::env_vars::REGEX_RESTRICT.data(), ""));
+        add_regex(caller_include, tim::get_env<string_t>(
+                                      rocprofsys::env_vars::REGEX_CALLER_INCLUDE.data()));
         add_regex(func_internal_include,
-                  tim::get_env<string_t>("ROCPROFSYS_REGEX_INTERNAL_INCLUDE", ""));
+                  tim::get_env<string_t>(
+                      rocprofsys::env_vars::REGEX_INTERNAL_INCLUDE.data(), ""));
 
         add_regex(file_include,
-                  tim::get_env<string_t>("ROCPROFSYS_REGEX_MODULE_INCLUDE", ""));
+                  tim::get_env<string_t>(
+                      rocprofsys::env_vars::REGEX_MODULE_INCLUDE.data(), ""));
         add_regex(file_exclude,
-                  tim::get_env<string_t>("ROCPROFSYS_REGEX_MODULE_EXCLUDE", ""));
+                  tim::get_env<string_t>(
+                      rocprofsys::env_vars::REGEX_MODULE_EXCLUDE.data(), ""));
         add_regex(file_restrict,
-                  tim::get_env<string_t>("ROCPROFSYS_REGEX_MODULE_RESTRICT", ""));
+                  tim::get_env<string_t>(
+                      rocprofsys::env_vars::REGEX_MODULE_RESTRICT.data(), ""));
         add_regex(file_internal_include,
-                  tim::get_env<string_t>("ROCPROFSYS_REGEX_MODULE_INTERNAL_INCLUDE", ""));
+                  tim::get_env<string_t>(
+                      rocprofsys::env_vars::REGEX_MODULE_INTERNAL_INCLUDE.data(), ""));
 
         add_regex(instruction_exclude,
-                  tim::get_env<string_t>("ROCPROFSYS_REGEX_INSTRUCTION_EXCLUDE", ""));
+                  tim::get_env<string_t>(
+                      rocprofsys::env_vars::REGEX_INSTRUCTION_EXCLUDE.data(), ""));
 
         //  Helper function for parsing the regex options
         auto _parse_regex_option = [&parser, &add_regex](const string_t& _option,
@@ -1419,12 +1432,12 @@ main(int argc, char** argv)
     env_vars.reserve(env_vars.size() + env_config_variables.size());
     for(auto&& itr : env_config_variables)
         env_vars.emplace_back(itr);
-    env_vars.emplace_back(TIMEMORY_JOIN('=', "ROCPROFSYS_MODE", instr_mode));
+    env_vars.emplace_back(TIMEMORY_JOIN('=', rocprofsys::env_vars::MODE, instr_mode));
     env_vars.emplace_back(
-        TIMEMORY_JOIN('=', "ROCPROFSYS_INSTRUMENT_MODE", instr_mode_v_int));
-    env_vars.emplace_back(TIMEMORY_JOIN('=', "ROCPROFSYS_MPI_INIT", "OFF"));
-    env_vars.emplace_back(TIMEMORY_JOIN('=', "ROCPROFSYS_MPI_FINALIZE", "OFF"));
-    env_vars.emplace_back(TIMEMORY_JOIN('=', "ROCPROFSYS_USE_CODE_COVERAGE",
+        TIMEMORY_JOIN('=', rocprofsys::env_vars::INSTRUMENT_MODE, instr_mode_v_int));
+    env_vars.emplace_back(TIMEMORY_JOIN('=', rocprofsys::env_vars::MPI_INIT, "OFF"));
+    env_vars.emplace_back(TIMEMORY_JOIN('=', rocprofsys::env_vars::MPI_FINALIZE, "OFF"));
+    env_vars.emplace_back(TIMEMORY_JOIN('=', rocprofsys::env_vars::USE_CODE_COVERAGE,
                                         (coverage_mode != CODECOV_NONE) ? "ON" : "OFF"));
     addr_space = rocprofsys_get_address_space(bpatch, _cmdc, _cmdv, env_vars,
                                               binary_rewrite, _pid, mutname);
@@ -2017,14 +2030,15 @@ main(int argc, char** argv)
     if(!binary_rewrite && !is_attached) env_vars.clear();
 
     env_vars.emplace_back(
-        TIMEMORY_JOIN('=', "ROCPROFSYS_INIT_ENABLED",
+        TIMEMORY_JOIN('=', rocprofsys::env_vars::INIT_ENABLED,
                       (user_start_func && user_stop_func) ? "OFF" : "ON"));
-    env_vars.emplace_back(TIMEMORY_JOIN('=', "ROCPROFSYS_USE_MPIP",
+    env_vars.emplace_back(TIMEMORY_JOIN('=', rocprofsys::env_vars::USE_MPIP,
                                         (binary_rewrite && use_mpi) ? "ON" : "OFF"));
-    if(use_mpi) env_vars.emplace_back(TIMEMORY_JOIN('=', "ROCPROFSYS_USE_PID", "ON"));
+    if(use_mpi)
+        env_vars.emplace_back(TIMEMORY_JOIN('=', rocprofsys::env_vars::USE_PID, "ON"));
 
-    env_vars.emplace_back(
-        TIMEMORY_JOIN('=', "ROCPROFSYS_SCRIPT_PATH", _omni_internal_libexec_path));
+    env_vars.emplace_back(TIMEMORY_JOIN('=', rocprofsys::env_vars::SCRIPT_PATH,
+                                        _omni_internal_libexec_path));
 
     for(auto& itr : env_vars)
     {

--- a/projects/rocprofiler-systems/source/lib/common/env_vars.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/env_vars.hpp
@@ -19,58 +19,93 @@ constexpr std::string_view CONFIG_FILE        = "ROCPROFSYS_CONFIG_FILE";
 constexpr std::string_view PRESET_DIR         = "ROCPROFSYS_PRESET_DIR";
 constexpr std::string_view MONOCHROME         = "ROCPROFSYS_MONOCHROME";
 constexpr std::string_view LOG_LEVEL          = "ROCPROFSYS_LOG_LEVEL";
+constexpr std::string_view LOG_FILE           = "ROCPROFSYS_LOG_FILE";
+constexpr std::string_view LOG_COUNT          = "ROCPROFSYS_LOG_COUNT";
 constexpr std::string_view TMPDIR             = "ROCPROFSYS_TMPDIR";
 constexpr std::string_view ENABLE_CATEGORIES  = "ROCPROFSYS_ENABLE_CATEGORIES";
 constexpr std::string_view DISABLE_CATEGORIES = "ROCPROFSYS_DISABLE_CATEGORIES";
+constexpr std::string_view ENABLED            = "ROCPROFSYS_ENABLED";
+constexpr std::string_view INIT_ENABLED       = "ROCPROFSYS_INIT_ENABLED";
+constexpr std::string_view INIT_TOOLING       = "ROCPROFSYS_INIT_TOOLING";
+constexpr std::string_view STRICT_CONFIG      = "ROCPROFSYS_STRICT_CONFIG";
+constexpr std::string_view SUPPRESS_CONFIG    = "ROCPROFSYS_SUPPRESS_CONFIG";
+constexpr std::string_view SUPPRESS_PARSING   = "ROCPROFSYS_SUPPRESS_PARSING";
+constexpr std::string_view PRINT_ENV          = "ROCPROFSYS_PRINT_ENV";
 
 // --- Tracing ---
 constexpr std::string_view TRACE                   = "ROCPROFSYS_TRACE";
+constexpr std::string_view USE_TRACE               = "ROCPROFSYS_USE_TRACE";
 constexpr std::string_view TRACE_LEGACY            = "ROCPROFSYS_TRACE_LEGACY";
 constexpr std::string_view PERFETTO_FILE           = "ROCPROFSYS_PERFETTO_FILE";
 constexpr std::string_view PERFETTO_BUFFER_SIZE_KB = "ROCPROFSYS_PERFETTO_BUFFER_SIZE_KB";
 constexpr std::string_view PERFETTO_FILL_POLICY    = "ROCPROFSYS_PERFETTO_FILL_POLICY";
 constexpr std::string_view PERFETTO_BACKEND        = "ROCPROFSYS_PERFETTO_BACKEND";
+constexpr std::string_view PERFETTO_BACKEND_SYSTEM = "ROCPROFSYS_PERFETTO_BACKEND_SYSTEM";
 constexpr std::string_view PERFETTO_FLUSH_PERIOD = "ROCPROFSYS_PERFETTO_FLUSH_PERIOD_MS";
-constexpr std::string_view SELECTED_REGIONS      = "ROCPROFSYS_SELECTED_REGIONS";
-constexpr std::string_view TRACE_THREAD_LOCKS    = "ROCPROFSYS_TRACE_THREAD_LOCKS";
-constexpr std::string_view TRACE_THREAD_RW_LOCKS = "ROCPROFSYS_TRACE_THREAD_RW_LOCKS";
+constexpr std::string_view PERFETTO_ANNOTATIONS  = "ROCPROFSYS_PERFETTO_ANNOTATIONS";
+constexpr std::string_view PERFETTO_COMBINE_TRACES = "ROCPROFSYS_PERFETTO_COMBINE_TRACES";
+constexpr std::string_view PERFETTO_SHMEM_SIZE_HINT_KB =
+    "ROCPROFSYS_PERFETTO_SHMEM_SIZE_HINT_KB";
+constexpr std::string_view MERGE_PERFETTO_FILES    = "ROCPROFSYS_MERGE_PERFETTO_FILES";
+constexpr std::string_view SELECTED_REGIONS        = "ROCPROFSYS_SELECTED_REGIONS";
+constexpr std::string_view TRACE_THREAD_LOCKS      = "ROCPROFSYS_TRACE_THREAD_LOCKS";
+constexpr std::string_view TRACE_THREAD_RW_LOCKS   = "ROCPROFSYS_TRACE_THREAD_RW_LOCKS";
 constexpr std::string_view TRACE_THREAD_SPIN_LOCKS = "ROCPROFSYS_TRACE_THREAD_SPIN_LOCKS";
+constexpr std::string_view TRACE_THREAD_BARRIERS   = "ROCPROFSYS_TRACE_THREAD_BARRIERS";
+constexpr std::string_view TRACE_THREAD_JOIN       = "ROCPROFSYS_TRACE_THREAD_JOIN";
 
 // --- Profiling ---
-constexpr std::string_view PROFILE      = "ROCPROFSYS_PROFILE";
-constexpr std::string_view FLAT_PROFILE = "ROCPROFSYS_FLAT_PROFILE";
+constexpr std::string_view PROFILE          = "ROCPROFSYS_PROFILE";
+constexpr std::string_view FLAT_PROFILE     = "ROCPROFSYS_FLAT_PROFILE";
+constexpr std::string_view TIMELINE_PROFILE = "ROCPROFSYS_TIMELINE_PROFILE";
 
 // --- Sampling ---
-constexpr std::string_view USE_SAMPLING      = "ROCPROFSYS_USE_SAMPLING";
-constexpr std::string_view SAMPLING_TIMER    = "ROCPROFSYS_SAMPLING_TIMER";
-constexpr std::string_view SAMPLING_FREQ     = "ROCPROFSYS_SAMPLING_FREQ";
-constexpr std::string_view SAMPLING_DELAY    = "ROCPROFSYS_SAMPLING_DELAY";
-constexpr std::string_view SAMPLING_DURATION = "ROCPROFSYS_SAMPLING_DURATION";
-constexpr std::string_view SAMPLING_CPUS     = "ROCPROFSYS_SAMPLING_CPUS";
-constexpr std::string_view SAMPLING_GPUS     = "ROCPROFSYS_SAMPLING_GPUS";
-constexpr std::string_view SAMPLING_AINICS   = "ROCPROFSYS_SAMPLING_AINICS";
-constexpr std::string_view SAMPLING_TIDS     = "ROCPROFSYS_SAMPLING_TIDS";
+constexpr std::string_view USE_SAMPLING        = "ROCPROFSYS_USE_SAMPLING";
+constexpr std::string_view USE_THREAD_SAMPLING = "ROCPROFSYS_USE_THREAD_SAMPLING";
+constexpr std::string_view SAMPLING_TIMER      = "ROCPROFSYS_SAMPLING_TIMER";
+constexpr std::string_view SAMPLING_FREQ       = "ROCPROFSYS_SAMPLING_FREQ";
+constexpr std::string_view SAMPLING_DELAY      = "ROCPROFSYS_SAMPLING_DELAY";
+constexpr std::string_view SAMPLING_DURATION   = "ROCPROFSYS_SAMPLING_DURATION";
+constexpr std::string_view SAMPLING_CPUS       = "ROCPROFSYS_SAMPLING_CPUS";
+constexpr std::string_view SAMPLING_GPUS       = "ROCPROFSYS_SAMPLING_GPUS";
+constexpr std::string_view SAMPLING_AINICS     = "ROCPROFSYS_SAMPLING_AINICS";
+constexpr std::string_view SAMPLING_TIDS       = "ROCPROFSYS_SAMPLING_TIDS";
 constexpr std::string_view SAMPLING_INCLUDE_INLINES =
     "ROCPROFSYS_SAMPLING_INCLUDE_INLINES";
 constexpr std::string_view SAMPLING_OVERFLOW_EVENT = "ROCPROFSYS_SAMPLING_OVERFLOW_EVENT";
+constexpr std::string_view SAMPLING_ALLOCATOR_SIZE = "ROCPROFSYS_SAMPLING_ALLOCATOR_SIZE";
+constexpr std::string_view SAMPLING_KEEP_DYNINST_SUFFIX =
+    "ROCPROFSYS_SAMPLING_KEEP_DYNINST_SUFFIX";
+constexpr std::string_view SAMPLING_KEEP_INTERNAL = "ROCPROFSYS_SAMPLING_KEEP_INTERNAL";
 
 // --- Sampling: cputime timer ---
-constexpr std::string_view SAMPLING_CPUTIME       = "ROCPROFSYS_SAMPLING_CPUTIME";
-constexpr std::string_view SAMPLING_CPUTIME_FREQ  = "ROCPROFSYS_SAMPLING_CPUTIME_FREQ";
-constexpr std::string_view SAMPLING_CPUTIME_DELAY = "ROCPROFSYS_SAMPLING_CPUTIME_DELAY";
-constexpr std::string_view SAMPLING_CPUTIME_TIDS  = "ROCPROFSYS_SAMPLING_CPUTIME_TIDS";
+constexpr std::string_view SAMPLING_CPUTIME        = "ROCPROFSYS_SAMPLING_CPUTIME";
+constexpr std::string_view SAMPLING_CPUTIME_FREQ   = "ROCPROFSYS_SAMPLING_CPUTIME_FREQ";
+constexpr std::string_view SAMPLING_CPUTIME_DELAY  = "ROCPROFSYS_SAMPLING_CPUTIME_DELAY";
+constexpr std::string_view SAMPLING_CPUTIME_TIDS   = "ROCPROFSYS_SAMPLING_CPUTIME_TIDS";
+constexpr std::string_view SAMPLING_CPUTIME_SIGNAL = "ROCPROFSYS_SAMPLING_CPUTIME_SIGNAL";
 
 // --- Sampling: realtime timer ---
 constexpr std::string_view SAMPLING_REALTIME       = "ROCPROFSYS_SAMPLING_REALTIME";
 constexpr std::string_view SAMPLING_REALTIME_FREQ  = "ROCPROFSYS_SAMPLING_REALTIME_FREQ";
 constexpr std::string_view SAMPLING_REALTIME_DELAY = "ROCPROFSYS_SAMPLING_REALTIME_DELAY";
 constexpr std::string_view SAMPLING_REALTIME_TIDS  = "ROCPROFSYS_SAMPLING_REALTIME_TIDS";
+constexpr std::string_view SAMPLING_REALTIME_SIGNAL =
+    "ROCPROFSYS_SAMPLING_REALTIME_SIGNAL";
+
+// --- Sampling: overflow (PAPI event-based) ---
+constexpr std::string_view SAMPLING_OVERFLOW      = "ROCPROFSYS_SAMPLING_OVERFLOW";
+constexpr std::string_view SAMPLING_OVERFLOW_FREQ = "ROCPROFSYS_SAMPLING_OVERFLOW_FREQ";
+constexpr std::string_view SAMPLING_OVERFLOW_TIDS = "ROCPROFSYS_SAMPLING_OVERFLOW_TIDS";
+constexpr std::string_view SAMPLING_OVERFLOW_SIGNAL =
+    "ROCPROFSYS_SAMPLING_OVERFLOW_SIGNAL";
 
 // --- Domains: GPU (AMD SMI) ---
 constexpr std::string_view USE_AMD_SMI          = "ROCPROFSYS_USE_AMD_SMI";
 constexpr std::string_view USE_PROCESS_SAMPLING = "ROCPROFSYS_USE_PROCESS_SAMPLING";
 constexpr std::string_view AMD_SMI_METRICS      = "ROCPROFSYS_AMD_SMI_METRICS";
 constexpr std::string_view AMD_SMI_FREQ         = "ROCPROFSYS_AMD_SMI_FREQ";
+constexpr std::string_view AMD_SMI_DEVICES      = "ROCPROFSYS_AMD_SMI_DEVICES";
 
 // --- Domains: ROCm ---
 constexpr std::string_view ROCM_DOMAINS        = "ROCPROFSYS_ROCM_DOMAINS";
@@ -83,6 +118,7 @@ constexpr std::string_view CPU_FREQ_ENABLED = "ROCPROFSYS_CPU_FREQ_ENABLED";
 constexpr std::string_view CPU_METRICS      = "ROCPROFSYS_CPU_METRICS";
 
 // --- Domains: Parallel runtimes ---
+constexpr std::string_view USE_MPI     = "ROCPROFSYS_USE_MPI";
 constexpr std::string_view USE_MPIP    = "ROCPROFSYS_USE_MPIP";
 constexpr std::string_view USE_OMPT    = "ROCPROFSYS_USE_OMPT";
 constexpr std::string_view USE_KOKKOSP = "ROCPROFSYS_USE_KOKKOSP";
@@ -91,21 +127,46 @@ constexpr std::string_view USE_AINIC   = "ROCPROFSYS_USE_AINIC";
 constexpr std::string_view USE_SHMEM   = "ROCPROFSYS_USE_SHMEM";
 constexpr std::string_view USE_UCX     = "ROCPROFSYS_USE_UCX";
 
+// --- Domains: Shmem ---
+constexpr std::string_view SHMEM_PERMIT_LIST = "ROCPROFSYS_SHMEM_PERMIT_LIST";
+constexpr std::string_view SHMEM_REJECT_LIST = "ROCPROFSYS_SHMEM_REJECT_LIST";
+
 // --- Output ---
-constexpr std::string_view OUTPUT_PATH   = "ROCPROFSYS_OUTPUT_PATH";
-constexpr std::string_view OUTPUT_PREFIX = "ROCPROFSYS_OUTPUT_PREFIX";
-constexpr std::string_view USE_PID       = "ROCPROFSYS_USE_PID";
-constexpr std::string_view TIME_OUTPUT   = "ROCPROFSYS_TIME_OUTPUT";
-constexpr std::string_view FILE_OUTPUT   = "ROCPROFSYS_FILE_OUTPUT";
-constexpr std::string_view TEXT_OUTPUT   = "ROCPROFSYS_TEXT_OUTPUT";
-constexpr std::string_view JSON_OUTPUT   = "ROCPROFSYS_JSON_OUTPUT";
-constexpr std::string_view COUT_OUTPUT   = "ROCPROFSYS_COUT_OUTPUT";
-constexpr std::string_view DIFF_OUTPUT   = "ROCPROFSYS_DIFF_OUTPUT";
-constexpr std::string_view INPUT_PATH    = "ROCPROFSYS_INPUT_PATH";
-constexpr std::string_view INPUT_PREFIX  = "ROCPROFSYS_INPUT_PREFIX";
-constexpr std::string_view USE_ROCPD     = "ROCPROFSYS_USE_ROCPD";
+constexpr std::string_view OUTPUT_PATH             = "ROCPROFSYS_OUTPUT_PATH";
+constexpr std::string_view OUTPUT_PREFIX           = "ROCPROFSYS_OUTPUT_PREFIX";
+constexpr std::string_view OUTPUT                  = "ROCPROFSYS_OUTPUT";
+constexpr std::string_view OUTPUT_FILE             = "ROCPROFSYS_OUTPUT_FILE";
+constexpr std::string_view OUTPUT_USE_CURRENT_TIME = "ROCPROFSYS_OUTPUT_USE_CURRENT_TIME";
+constexpr std::string_view USE_PID                 = "ROCPROFSYS_USE_PID";
+constexpr std::string_view TIME_OUTPUT             = "ROCPROFSYS_TIME_OUTPUT";
+constexpr std::string_view FILE_OUTPUT             = "ROCPROFSYS_FILE_OUTPUT";
+constexpr std::string_view TEXT_OUTPUT             = "ROCPROFSYS_TEXT_OUTPUT";
+constexpr std::string_view JSON_OUTPUT             = "ROCPROFSYS_JSON_OUTPUT";
+constexpr std::string_view COUT_OUTPUT             = "ROCPROFSYS_COUT_OUTPUT";
+constexpr std::string_view DIFF_OUTPUT             = "ROCPROFSYS_DIFF_OUTPUT";
+constexpr std::string_view TREE_OUTPUT             = "ROCPROFSYS_TREE_OUTPUT";
+constexpr std::string_view INPUT_PATH              = "ROCPROFSYS_INPUT_PATH";
+constexpr std::string_view INPUT_PREFIX            = "ROCPROFSYS_INPUT_PREFIX";
+constexpr std::string_view INPUT_EXTENSIONS        = "ROCPROFSYS_INPUT_EXTENSIONS";
+constexpr std::string_view USE_ROCPD               = "ROCPROFSYS_USE_ROCPD";
+constexpr std::string_view USE_TEMPORARY_FILES     = "ROCPROFSYS_USE_TEMPORARY_FILES";
 constexpr std::string_view USE_UNIFIED_MEMORY_PROFILING =
     "ROCPROFSYS_USE_UNIFIED_MEMORY_PROFILING";
+constexpr std::string_view TIME_FORMAT = "ROCPROFSYS_TIME_FORMAT";
+
+// --- Output: number formatting ---
+constexpr std::string_view PRECISION         = "ROCPROFSYS_PRECISION";
+constexpr std::string_view SCIENTIFIC        = "ROCPROFSYS_SCIENTIFIC";
+constexpr std::string_view WIDTH             = "ROCPROFSYS_WIDTH";
+constexpr std::string_view MAX_WIDTH         = "ROCPROFSYS_MAX_WIDTH";
+constexpr std::string_view TIMING_PRECISION  = "ROCPROFSYS_TIMING_PRECISION";
+constexpr std::string_view TIMING_SCIENTIFIC = "ROCPROFSYS_TIMING_SCIENTIFIC";
+constexpr std::string_view TIMING_UNITS      = "ROCPROFSYS_TIMING_UNITS";
+constexpr std::string_view TIMING_WIDTH      = "ROCPROFSYS_TIMING_WIDTH";
+constexpr std::string_view MEMORY_PRECISION  = "ROCPROFSYS_MEMORY_PRECISION";
+constexpr std::string_view MEMORY_SCIENTIFIC = "ROCPROFSYS_MEMORY_SCIENTIFIC";
+constexpr std::string_view MEMORY_UNITS      = "ROCPROFSYS_MEMORY_UNITS";
+constexpr std::string_view MEMORY_WIDTH      = "ROCPROFSYS_MEMORY_WIDTH";
 
 // --- MPI output filtering ---
 constexpr std::string_view RANK_FILTER_ID     = "ROCPROFSYS_RANK_FILTER_ID";
@@ -130,17 +191,110 @@ constexpr std::string_view CAUSAL_BINARY_SCOPE     = "ROCPROFSYS_CAUSAL_BINARY_S
 constexpr std::string_view CAUSAL_BINARY_EXCLUDE   = "ROCPROFSYS_CAUSAL_BINARY_EXCLUDE";
 constexpr std::string_view CAUSAL_FUNCTION_SCOPE   = "ROCPROFSYS_CAUSAL_FUNCTION_SCOPE";
 constexpr std::string_view CAUSAL_FUNCTION_EXCLUDE = "ROCPROFSYS_CAUSAL_FUNCTION_EXCLUDE";
-constexpr std::string_view CAUSAL_SOURCE_SCOPE     = "ROCPROFSYS_CAUSAL_SOURCE_SCOPE";
-constexpr std::string_view CAUSAL_SOURCE_EXCLUDE   = "ROCPROFSYS_CAUSAL_SOURCE_EXCLUDE";
-constexpr std::string_view CAUSAL_END_TO_END       = "ROCPROFSYS_CAUSAL_END_TO_END";
-constexpr std::string_view CAUSAL_DELAY            = "ROCPROFSYS_CAUSAL_DELAY";
-constexpr std::string_view CAUSAL_DURATION         = "ROCPROFSYS_CAUSAL_DURATION";
-constexpr std::string_view CAUSAL_RANDOM_SEED      = "ROCPROFSYS_CAUSAL_RANDOM_SEED";
+constexpr std::string_view CAUSAL_FUNCTION_EXCLUDE_DEFAULTS =
+    "ROCPROFSYS_CAUSAL_FUNCTION_EXCLUDE_DEFAULTS";
+constexpr std::string_view CAUSAL_SOURCE_SCOPE   = "ROCPROFSYS_CAUSAL_SOURCE_SCOPE";
+constexpr std::string_view CAUSAL_SOURCE_EXCLUDE = "ROCPROFSYS_CAUSAL_SOURCE_EXCLUDE";
+constexpr std::string_view CAUSAL_END_TO_END     = "ROCPROFSYS_CAUSAL_END_TO_END";
+constexpr std::string_view CAUSAL_DELAY          = "ROCPROFSYS_CAUSAL_DELAY";
+constexpr std::string_view CAUSAL_DURATION       = "ROCPROFSYS_CAUSAL_DURATION";
+constexpr std::string_view CAUSAL_RANDOM_SEED    = "ROCPROFSYS_CAUSAL_RANDOM_SEED";
+constexpr std::string_view CAUSAL_FIXED_SPEEDUP  = "ROCPROFSYS_CAUSAL_FIXED_SPEEDUP";
+constexpr std::string_view CAUSAL_SPEEDUP_DIVISIONS =
+    "ROCPROFSYS_CAUSAL_SPEEDUP_DIVISIONS";
+constexpr std::string_view CAUSAL_SCALE_EXPERIMENT_TIME_BY_SPEEDUP =
+    "ROCPROFSYS_CAUSAL_SCALE_EXPERIMENT_TIME_BY_SPEEDUP";
+constexpr std::string_view CAUSAL_FILE       = "ROCPROFSYS_CAUSAL_FILE";
+constexpr std::string_view CAUSAL_FILE_RESET = "ROCPROFSYS_CAUSAL_FILE_RESET";
 
 // --- Hardware counters ---
-constexpr std::string_view ROCM_EVENTS       = "ROCPROFSYS_ROCM_EVENTS";
-constexpr std::string_view PAPI_EVENTS       = "ROCPROFSYS_PAPI_EVENTS";
-constexpr std::string_view PAPI_MULTIPLEXING = "ROCPROFSYS_PAPI_MULTIPLEXING";
+// Note: PAPI_MULTIPLEXING and PAPI_QUIET would collide with integer macros defined in
+// PAPI's C header (papi.h). The identifiers carry a trailing suffix to avoid
+// preprocessor substitution; the env-var strings retain the original names.
+constexpr std::string_view ROCM_EVENTS               = "ROCPROFSYS_ROCM_EVENTS";
+constexpr std::string_view PAPI_EVENTS               = "ROCPROFSYS_PAPI_EVENTS";
+constexpr std::string_view PAPI_MULTIPLEXING_ENABLED = "ROCPROFSYS_PAPI_MULTIPLEXING";
+constexpr std::string_view PAPI_FAIL_ON_ERROR        = "ROCPROFSYS_PAPI_FAIL_ON_ERROR";
+constexpr std::string_view PAPI_OVERFLOW             = "ROCPROFSYS_PAPI_OVERFLOW";
+constexpr std::string_view PAPI_QUIET_MODE           = "ROCPROFSYS_PAPI_QUIET";
+constexpr std::string_view PAPI_THREADING            = "ROCPROFSYS_PAPI_THREADING";
+constexpr std::string_view USE_CODE_COVERAGE         = "ROCPROFSYS_USE_CODE_COVERAGE";
+
+// --- MPI ---
+constexpr std::string_view MPI_INIT             = "ROCPROFSYS_MPI_INIT";
+constexpr std::string_view MPI_FINALIZE         = "ROCPROFSYS_MPI_FINALIZE";
+constexpr std::string_view MPI_FAIL_ON_ERROR    = "ROCPROFSYS_MPI_FAIL_ON_ERROR";
+constexpr std::string_view MPI_QUIET            = "ROCPROFSYS_MPI_QUIET";
+constexpr std::string_view MPI_THREAD           = "ROCPROFSYS_MPI_THREAD";
+constexpr std::string_view MPI_THREAD_TYPE      = "ROCPROFSYS_MPI_THREAD_TYPE";
+constexpr std::string_view MPI_MAX_COMM_UPDATES = "ROCPROFSYS_MPI_MAX_COMM_UPDATES";
+
+// --- Kokkos profiling ---
+constexpr std::string_view KOKKOSP_PREFIX          = "ROCPROFSYS_KOKKOSP_PREFIX";
+constexpr std::string_view KOKKOSP_KERNEL_LOGGER   = "ROCPROFSYS_KOKKOSP_KERNEL_LOGGER";
+constexpr std::string_view KOKKOSP_NAME_LENGTH_MAX = "ROCPROFSYS_KOKKOSP_NAME_LENGTH_MAX";
+constexpr std::string_view KOKKOSP_DEEP_COPY       = "ROCPROFSYS_KOKKOSP_DEEP_COPY";
+
+// --- DL (dynamic loader / preload) ---
+constexpr std::string_view DL_VERBOSE = "ROCPROFSYS_DL_VERBOSE";
+constexpr std::string_view DL_DEBUG   = "ROCPROFSYS_DL_DEBUG";
+constexpr std::string_view DL_LIBRARY = "ROCPROFSYS_DL_LIBRARY";
+
+// --- Regex include/exclude filters ---
+constexpr std::string_view REGEX_INCLUDE          = "ROCPROFSYS_REGEX_INCLUDE";
+constexpr std::string_view REGEX_EXCLUDE          = "ROCPROFSYS_REGEX_EXCLUDE";
+constexpr std::string_view REGEX_RESTRICT         = "ROCPROFSYS_REGEX_RESTRICT";
+constexpr std::string_view REGEX_CALLER_INCLUDE   = "ROCPROFSYS_REGEX_CALLER_INCLUDE";
+constexpr std::string_view REGEX_INTERNAL_INCLUDE = "ROCPROFSYS_REGEX_INTERNAL_INCLUDE";
+constexpr std::string_view REGEX_INSTRUCTION_EXCLUDE =
+    "ROCPROFSYS_REGEX_INSTRUCTION_EXCLUDE";
+constexpr std::string_view REGEX_MODULE_INCLUDE  = "ROCPROFSYS_REGEX_MODULE_INCLUDE";
+constexpr std::string_view REGEX_MODULE_EXCLUDE  = "ROCPROFSYS_REGEX_MODULE_EXCLUDE";
+constexpr std::string_view REGEX_MODULE_RESTRICT = "ROCPROFSYS_REGEX_MODULE_RESTRICT";
+constexpr std::string_view REGEX_MODULE_INTERNAL_INCLUDE =
+    "ROCPROFSYS_REGEX_MODULE_INTERNAL_INCLUDE";
+
+// --- CI / continuous integration ---
+constexpr std::string_view CI                     = "ROCPROFSYS_CI";
+constexpr std::string_view CI_SKIP_PUSH_POP_CHECK = "ROCPROFSYS_CI_SKIP_PUSH_POP_CHECK";
+constexpr std::string_view CI_TIMEOUT             = "ROCPROFSYS_CI_TIMEOUT";
+constexpr std::string_view CI_TIMEOUT_COUNT       = "ROCPROFSYS_CI_TIMEOUT_COUNT";
+constexpr std::string_view CI_TIMEOUT_OVERRIDE    = "ROCPROFSYS_CI_TIMEOUT_OVERRIDE";
+
+// --- Process / threading / behavior ---
+constexpr std::string_view NUM_THREADS             = "ROCPROFSYS_NUM_THREADS";
+constexpr std::string_view NUM_THREADS_HINT        = "ROCPROFSYS_NUM_THREADS_HINT";
+constexpr std::string_view THREAD_POOL_SIZE        = "ROCPROFSYS_THREAD_POOL_SIZE";
+constexpr std::string_view RECYCLE_TIDS            = "ROCPROFSYS_RECYCLE_TIDS";
+constexpr std::string_view KILL_DELAY              = "ROCPROFSYS_KILL_DELAY";
+constexpr std::string_view COLLAPSE_PROCESSES      = "ROCPROFSYS_COLLAPSE_PROCESSES";
+constexpr std::string_view NODE_COUNT              = "ROCPROFSYS_NODE_COUNT";
+constexpr std::string_view ROOT_PROCESS            = "ROCPROFSYS_ROOT_PROCESS";
+constexpr std::string_view RANK_FILTER_ID          = "ROCPROFSYS_RANK_FILTER_ID";
+constexpr std::string_view RANK_FILTER_OUTPUT      = "ROCPROFSYS_RANK_FILTER_OUTPUT";
+constexpr std::string_view REATTACH_ADD_SESSION_ID = "ROCPROFSYS_REATTACH_ADD_SESSION_ID";
+
+// --- Instrumentation ---
+constexpr std::string_view INSTRUMENT_MODE = "ROCPROFSYS_INSTRUMENT_MODE";
+constexpr std::string_view IGNORE_DYNINST_TRAMPOLINE =
+    "ROCPROFSYS_IGNORE_DYNINST_TRAMPOLINE";
+constexpr std::string_view DEFAULT_MIN_INSTRUCTIONS =
+    "ROCPROFSYS_DEFAULT_MIN_INSTRUCTIONS";
+
+// --- Runtime / launcher (set by instrumenter / read by the loaded library) ---
+constexpr std::string_view PATH                   = "ROCPROFSYS_PATH";
+constexpr std::string_view PRELOAD                = "ROCPROFSYS_PRELOAD";
+constexpr std::string_view LIBRARY                = "ROCPROFSYS_LIBRARY";
+constexpr std::string_view USER_LIBRARY           = "ROCPROFSYS_USER_LIBRARY";
+constexpr std::string_view COMMAND_LINE           = "ROCPROFSYS_COMMAND_LINE";
+constexpr std::string_view LAUNCHER               = "ROCPROFSYS_LAUNCHER";
+constexpr std::string_view SCRIPT_DIR             = "ROCPROFSYS_SCRIPT_DIR";
+constexpr std::string_view ROCM_PATH              = "ROCPROFSYS_ROCM_PATH";
+constexpr std::string_view CONFIG                 = "ROCPROFSYS_CONFIG";
+constexpr std::string_view ENVIRONMENT            = "ROCPROFSYS_ENVIRONMENT";
+constexpr std::string_view SETTINGS_DESC          = "ROCPROFSYS_SETTINGS_DESC";
+constexpr std::string_view SETTINGS_DESC_MARKDOWN = "ROCPROFSYS_SETTINGS_DESC_MARKDOWN";
+constexpr std::string_view CRAYPAT                = "ROCPROFSYS_CRAYPAT";
 
 // --- Advanced ---
 constexpr std::string_view CPU_AFFINITY          = "ROCPROFSYS_CPU_AFFINITY";
@@ -151,11 +305,34 @@ constexpr std::string_view TRACE_DURATION        = "ROCPROFSYS_TRACE_DURATION";
 constexpr std::string_view TRACE_PERIODS         = "ROCPROFSYS_TRACE_PERIODS";
 constexpr std::string_view TRACE_PERIOD_CLOCK_ID = "ROCPROFSYS_TRACE_PERIOD_CLOCK_ID";
 constexpr std::string_view VERBOSE               = "ROCPROFSYS_VERBOSE";
-constexpr std::string_view DEBUG                 = "ROCPROFSYS_DEBUG";
+constexpr std::string_view VERBOSE_AVAIL         = "ROCPROFSYS_VERBOSE_AVAIL";
+constexpr std::string_view VERBOSE_INSTRUMENT    = "ROCPROFSYS_VERBOSE_INSTRUMENT";
+// Note: identifier is DEBUG_MODE to avoid collision with `#define DEBUG 1` injected by
+// the project's generated common/defines.h on CI builds (ROCPROFSYS_CI > 0). The
+// env-var string itself remains "ROCPROFSYS_DEBUG".
+constexpr std::string_view DEBUG_MODE = "ROCPROFSYS_DEBUG";
 // well above the highest verbose threshold (3) so debug mode enables all verbose output
-constexpr int              DEBUG_VERBOSE_BOOST = 8;
-constexpr std::string_view TIMEMORY_COMPONENTS = "ROCPROFSYS_TIMEMORY_COMPONENTS";
-constexpr std::string_view NETWORK_INTERFACE   = "ROCPROFSYS_NETWORK_INTERFACE";
+constexpr int              DEBUG_VERBOSE_BOOST   = 8;
+constexpr std::string_view DEBUG_INIT            = "ROCPROFSYS_DEBUG_INIT";
+constexpr std::string_view DEBUG_FINALIZE        = "ROCPROFSYS_DEBUG_FINALIZE";
+constexpr std::string_view DEBUG_AVAIL           = "ROCPROFSYS_DEBUG_AVAIL";
+constexpr std::string_view DEBUG_MARK            = "ROCPROFSYS_DEBUG_MARK";
+constexpr std::string_view DEBUG_PIDS            = "ROCPROFSYS_DEBUG_PIDS";
+constexpr std::string_view DEBUG_TIDS            = "ROCPROFSYS_DEBUG_TIDS";
+constexpr std::string_view DEBUG_PUSH            = "ROCPROFSYS_DEBUG_PUSH";
+constexpr std::string_view DEBUG_POP             = "ROCPROFSYS_DEBUG_POP";
+constexpr std::string_view DEBUG_SAMPLING        = "ROCPROFSYS_DEBUG_SAMPLING";
+constexpr std::string_view DEBUG_USER_REGIONS    = "ROCPROFSYS_DEBUG_USER_REGIONS";
+constexpr std::string_view ENABLE_SIGNAL_HANDLER = "ROCPROFSYS_ENABLE_SIGNAL_HANDLER";
+constexpr std::string_view TIMEMORY_COMPONENTS   = "ROCPROFSYS_TIMEMORY_COMPONENTS";
+constexpr std::string_view NETWORK_INTERFACE     = "ROCPROFSYS_NETWORK_INTERFACE";
+
+// --- Deprecated aliases ---
+// Names retained only for legacy/migration paths — the codebase emits deprecation
+// warnings when these are encountered. Do not introduce new references; prefer the
+// replacement (TRACE for USE_PERFETTO, PROFILE for USE_TIMEMORY).
+constexpr std::string_view USE_PERFETTO = "ROCPROFSYS_USE_PERFETTO";
+constexpr std::string_view USE_TIMEMORY = "ROCPROFSYS_USE_TIMEMORY";
 
 [[nodiscard]] inline int
 log_level_to_verbose(std::string_view level) noexcept

--- a/projects/rocprofiler-systems/source/lib/common/env_vars.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/env_vars.hpp
@@ -12,327 +12,337 @@ namespace env_vars
 {
 
 // --- General ---
-constexpr std::string_view ROOT               = "ROCPROFSYS_ROOT";
-constexpr std::string_view MODE               = "ROCPROFSYS_MODE";
-constexpr std::string_view SCRIPT_PATH        = "ROCPROFSYS_SCRIPT_PATH";
-constexpr std::string_view CONFIG_FILE        = "ROCPROFSYS_CONFIG_FILE";
-constexpr std::string_view PRESET_DIR         = "ROCPROFSYS_PRESET_DIR";
-constexpr std::string_view MONOCHROME         = "ROCPROFSYS_MONOCHROME";
-constexpr std::string_view LOG_LEVEL          = "ROCPROFSYS_LOG_LEVEL";
-constexpr std::string_view LOG_FILE           = "ROCPROFSYS_LOG_FILE";
-constexpr std::string_view LOG_COUNT          = "ROCPROFSYS_LOG_COUNT";
-constexpr std::string_view TMPDIR             = "ROCPROFSYS_TMPDIR";
-constexpr std::string_view ENABLE_CATEGORIES  = "ROCPROFSYS_ENABLE_CATEGORIES";
-constexpr std::string_view DISABLE_CATEGORIES = "ROCPROFSYS_DISABLE_CATEGORIES";
-constexpr std::string_view ENABLED            = "ROCPROFSYS_ENABLED";
-constexpr std::string_view INIT_ENABLED       = "ROCPROFSYS_INIT_ENABLED";
-constexpr std::string_view INIT_TOOLING       = "ROCPROFSYS_INIT_TOOLING";
-constexpr std::string_view STRICT_CONFIG      = "ROCPROFSYS_STRICT_CONFIG";
-constexpr std::string_view SUPPRESS_CONFIG    = "ROCPROFSYS_SUPPRESS_CONFIG";
-constexpr std::string_view SUPPRESS_PARSING   = "ROCPROFSYS_SUPPRESS_PARSING";
-constexpr std::string_view PRINT_ENV          = "ROCPROFSYS_PRINT_ENV";
+inline constexpr const char* ROOT               = "ROCPROFSYS_ROOT";
+inline constexpr const char* MODE               = "ROCPROFSYS_MODE";
+inline constexpr const char* SCRIPT_PATH        = "ROCPROFSYS_SCRIPT_PATH";
+inline constexpr const char* CONFIG_FILE        = "ROCPROFSYS_CONFIG_FILE";
+inline constexpr const char* PRESET_DIR         = "ROCPROFSYS_PRESET_DIR";
+inline constexpr const char* MONOCHROME         = "ROCPROFSYS_MONOCHROME";
+inline constexpr const char* LOG_LEVEL          = "ROCPROFSYS_LOG_LEVEL";
+inline constexpr const char* LOG_FILE           = "ROCPROFSYS_LOG_FILE";
+inline constexpr const char* LOG_COUNT          = "ROCPROFSYS_LOG_COUNT";
+inline constexpr const char* TMPDIR             = "ROCPROFSYS_TMPDIR";
+inline constexpr const char* ENABLE_CATEGORIES  = "ROCPROFSYS_ENABLE_CATEGORIES";
+inline constexpr const char* DISABLE_CATEGORIES = "ROCPROFSYS_DISABLE_CATEGORIES";
+inline constexpr const char* ENABLED            = "ROCPROFSYS_ENABLED";
+inline constexpr const char* INIT_ENABLED       = "ROCPROFSYS_INIT_ENABLED";
+inline constexpr const char* INIT_TOOLING       = "ROCPROFSYS_INIT_TOOLING";
+inline constexpr const char* STRICT_CONFIG      = "ROCPROFSYS_STRICT_CONFIG";
+inline constexpr const char* SUPPRESS_CONFIG    = "ROCPROFSYS_SUPPRESS_CONFIG";
+inline constexpr const char* SUPPRESS_PARSING   = "ROCPROFSYS_SUPPRESS_PARSING";
+inline constexpr const char* PRINT_ENV          = "ROCPROFSYS_PRINT_ENV";
 
 // --- Tracing ---
-constexpr std::string_view TRACE                   = "ROCPROFSYS_TRACE";
-constexpr std::string_view USE_TRACE               = "ROCPROFSYS_USE_TRACE";
-constexpr std::string_view TRACE_LEGACY            = "ROCPROFSYS_TRACE_LEGACY";
-constexpr std::string_view PERFETTO_FILE           = "ROCPROFSYS_PERFETTO_FILE";
-constexpr std::string_view PERFETTO_BUFFER_SIZE_KB = "ROCPROFSYS_PERFETTO_BUFFER_SIZE_KB";
-constexpr std::string_view PERFETTO_FILL_POLICY    = "ROCPROFSYS_PERFETTO_FILL_POLICY";
-constexpr std::string_view PERFETTO_BACKEND        = "ROCPROFSYS_PERFETTO_BACKEND";
-constexpr std::string_view PERFETTO_BACKEND_SYSTEM = "ROCPROFSYS_PERFETTO_BACKEND_SYSTEM";
-constexpr std::string_view PERFETTO_FLUSH_PERIOD = "ROCPROFSYS_PERFETTO_FLUSH_PERIOD_MS";
-constexpr std::string_view PERFETTO_ANNOTATIONS  = "ROCPROFSYS_PERFETTO_ANNOTATIONS";
-constexpr std::string_view PERFETTO_COMBINE_TRACES = "ROCPROFSYS_PERFETTO_COMBINE_TRACES";
-constexpr std::string_view PERFETTO_SHMEM_SIZE_HINT_KB =
+inline constexpr const char* TRACE         = "ROCPROFSYS_TRACE";
+inline constexpr const char* USE_TRACE     = "ROCPROFSYS_USE_TRACE";
+inline constexpr const char* TRACE_LEGACY  = "ROCPROFSYS_TRACE_LEGACY";
+inline constexpr const char* PERFETTO_FILE = "ROCPROFSYS_PERFETTO_FILE";
+inline constexpr const char* PERFETTO_BUFFER_SIZE_KB =
+    "ROCPROFSYS_PERFETTO_BUFFER_SIZE_KB";
+inline constexpr const char* PERFETTO_FILL_POLICY = "ROCPROFSYS_PERFETTO_FILL_POLICY";
+inline constexpr const char* PERFETTO_BACKEND     = "ROCPROFSYS_PERFETTO_BACKEND";
+inline constexpr const char* PERFETTO_BACKEND_SYSTEM =
+    "ROCPROFSYS_PERFETTO_BACKEND_SYSTEM";
+inline constexpr const char* PERFETTO_FLUSH_PERIOD =
+    "ROCPROFSYS_PERFETTO_FLUSH_PERIOD_MS";
+inline constexpr const char* PERFETTO_ANNOTATIONS = "ROCPROFSYS_PERFETTO_ANNOTATIONS";
+inline constexpr const char* PERFETTO_COMBINE_TRACES =
+    "ROCPROFSYS_PERFETTO_COMBINE_TRACES";
+inline constexpr const char* PERFETTO_SHMEM_SIZE_HINT_KB =
     "ROCPROFSYS_PERFETTO_SHMEM_SIZE_HINT_KB";
-constexpr std::string_view MERGE_PERFETTO_FILES    = "ROCPROFSYS_MERGE_PERFETTO_FILES";
-constexpr std::string_view SELECTED_REGIONS        = "ROCPROFSYS_SELECTED_REGIONS";
-constexpr std::string_view TRACE_THREAD_LOCKS      = "ROCPROFSYS_TRACE_THREAD_LOCKS";
-constexpr std::string_view TRACE_THREAD_RW_LOCKS   = "ROCPROFSYS_TRACE_THREAD_RW_LOCKS";
-constexpr std::string_view TRACE_THREAD_SPIN_LOCKS = "ROCPROFSYS_TRACE_THREAD_SPIN_LOCKS";
-constexpr std::string_view TRACE_THREAD_BARRIERS   = "ROCPROFSYS_TRACE_THREAD_BARRIERS";
-constexpr std::string_view TRACE_THREAD_JOIN       = "ROCPROFSYS_TRACE_THREAD_JOIN";
+inline constexpr const char* MERGE_PERFETTO_FILES  = "ROCPROFSYS_MERGE_PERFETTO_FILES";
+inline constexpr const char* SELECTED_REGIONS      = "ROCPROFSYS_SELECTED_REGIONS";
+inline constexpr const char* TRACE_THREAD_LOCKS    = "ROCPROFSYS_TRACE_THREAD_LOCKS";
+inline constexpr const char* TRACE_THREAD_RW_LOCKS = "ROCPROFSYS_TRACE_THREAD_RW_LOCKS";
+inline constexpr const char* TRACE_THREAD_SPIN_LOCKS =
+    "ROCPROFSYS_TRACE_THREAD_SPIN_LOCKS";
+inline constexpr const char* TRACE_THREAD_BARRIERS = "ROCPROFSYS_TRACE_THREAD_BARRIERS";
+inline constexpr const char* TRACE_THREAD_JOIN     = "ROCPROFSYS_TRACE_THREAD_JOIN";
 
 // --- Profiling ---
-constexpr std::string_view PROFILE          = "ROCPROFSYS_PROFILE";
-constexpr std::string_view FLAT_PROFILE     = "ROCPROFSYS_FLAT_PROFILE";
-constexpr std::string_view TIMELINE_PROFILE = "ROCPROFSYS_TIMELINE_PROFILE";
+inline constexpr const char* PROFILE          = "ROCPROFSYS_PROFILE";
+inline constexpr const char* FLAT_PROFILE     = "ROCPROFSYS_FLAT_PROFILE";
+inline constexpr const char* TIMELINE_PROFILE = "ROCPROFSYS_TIMELINE_PROFILE";
 
 // --- Sampling ---
-constexpr std::string_view USE_SAMPLING        = "ROCPROFSYS_USE_SAMPLING";
-constexpr std::string_view USE_THREAD_SAMPLING = "ROCPROFSYS_USE_THREAD_SAMPLING";
-constexpr std::string_view SAMPLING_TIMER      = "ROCPROFSYS_SAMPLING_TIMER";
-constexpr std::string_view SAMPLING_FREQ       = "ROCPROFSYS_SAMPLING_FREQ";
-constexpr std::string_view SAMPLING_DELAY      = "ROCPROFSYS_SAMPLING_DELAY";
-constexpr std::string_view SAMPLING_DURATION   = "ROCPROFSYS_SAMPLING_DURATION";
-constexpr std::string_view SAMPLING_CPUS       = "ROCPROFSYS_SAMPLING_CPUS";
-constexpr std::string_view SAMPLING_GPUS       = "ROCPROFSYS_SAMPLING_GPUS";
-constexpr std::string_view SAMPLING_AINICS     = "ROCPROFSYS_SAMPLING_AINICS";
-constexpr std::string_view SAMPLING_TIDS       = "ROCPROFSYS_SAMPLING_TIDS";
-constexpr std::string_view SAMPLING_INCLUDE_INLINES =
+inline constexpr const char* USE_SAMPLING        = "ROCPROFSYS_USE_SAMPLING";
+inline constexpr const char* USE_THREAD_SAMPLING = "ROCPROFSYS_USE_THREAD_SAMPLING";
+inline constexpr const char* SAMPLING_TIMER      = "ROCPROFSYS_SAMPLING_TIMER";
+inline constexpr const char* SAMPLING_FREQ       = "ROCPROFSYS_SAMPLING_FREQ";
+inline constexpr const char* SAMPLING_DELAY      = "ROCPROFSYS_SAMPLING_DELAY";
+inline constexpr const char* SAMPLING_DURATION   = "ROCPROFSYS_SAMPLING_DURATION";
+inline constexpr const char* SAMPLING_CPUS       = "ROCPROFSYS_SAMPLING_CPUS";
+inline constexpr const char* SAMPLING_GPUS       = "ROCPROFSYS_SAMPLING_GPUS";
+inline constexpr const char* SAMPLING_AINICS     = "ROCPROFSYS_SAMPLING_AINICS";
+inline constexpr const char* SAMPLING_TIDS       = "ROCPROFSYS_SAMPLING_TIDS";
+inline constexpr const char* SAMPLING_INCLUDE_INLINES =
     "ROCPROFSYS_SAMPLING_INCLUDE_INLINES";
-constexpr std::string_view SAMPLING_OVERFLOW_EVENT = "ROCPROFSYS_SAMPLING_OVERFLOW_EVENT";
-constexpr std::string_view SAMPLING_ALLOCATOR_SIZE = "ROCPROFSYS_SAMPLING_ALLOCATOR_SIZE";
-constexpr std::string_view SAMPLING_KEEP_DYNINST_SUFFIX =
+inline constexpr const char* SAMPLING_OVERFLOW_EVENT =
+    "ROCPROFSYS_SAMPLING_OVERFLOW_EVENT";
+inline constexpr const char* SAMPLING_ALLOCATOR_SIZE =
+    "ROCPROFSYS_SAMPLING_ALLOCATOR_SIZE";
+inline constexpr const char* SAMPLING_KEEP_DYNINST_SUFFIX =
     "ROCPROFSYS_SAMPLING_KEEP_DYNINST_SUFFIX";
-constexpr std::string_view SAMPLING_KEEP_INTERNAL = "ROCPROFSYS_SAMPLING_KEEP_INTERNAL";
+inline constexpr const char* SAMPLING_KEEP_INTERNAL = "ROCPROFSYS_SAMPLING_KEEP_INTERNAL";
 
 // --- Sampling: cputime timer ---
-constexpr std::string_view SAMPLING_CPUTIME        = "ROCPROFSYS_SAMPLING_CPUTIME";
-constexpr std::string_view SAMPLING_CPUTIME_FREQ   = "ROCPROFSYS_SAMPLING_CPUTIME_FREQ";
-constexpr std::string_view SAMPLING_CPUTIME_DELAY  = "ROCPROFSYS_SAMPLING_CPUTIME_DELAY";
-constexpr std::string_view SAMPLING_CPUTIME_TIDS   = "ROCPROFSYS_SAMPLING_CPUTIME_TIDS";
-constexpr std::string_view SAMPLING_CPUTIME_SIGNAL = "ROCPROFSYS_SAMPLING_CPUTIME_SIGNAL";
+inline constexpr const char* SAMPLING_CPUTIME       = "ROCPROFSYS_SAMPLING_CPUTIME";
+inline constexpr const char* SAMPLING_CPUTIME_FREQ  = "ROCPROFSYS_SAMPLING_CPUTIME_FREQ";
+inline constexpr const char* SAMPLING_CPUTIME_DELAY = "ROCPROFSYS_SAMPLING_CPUTIME_DELAY";
+inline constexpr const char* SAMPLING_CPUTIME_TIDS  = "ROCPROFSYS_SAMPLING_CPUTIME_TIDS";
+inline constexpr const char* SAMPLING_CPUTIME_SIGNAL =
+    "ROCPROFSYS_SAMPLING_CPUTIME_SIGNAL";
 
 // --- Sampling: realtime timer ---
-constexpr std::string_view SAMPLING_REALTIME       = "ROCPROFSYS_SAMPLING_REALTIME";
-constexpr std::string_view SAMPLING_REALTIME_FREQ  = "ROCPROFSYS_SAMPLING_REALTIME_FREQ";
-constexpr std::string_view SAMPLING_REALTIME_DELAY = "ROCPROFSYS_SAMPLING_REALTIME_DELAY";
-constexpr std::string_view SAMPLING_REALTIME_TIDS  = "ROCPROFSYS_SAMPLING_REALTIME_TIDS";
-constexpr std::string_view SAMPLING_REALTIME_SIGNAL =
+inline constexpr const char* SAMPLING_REALTIME      = "ROCPROFSYS_SAMPLING_REALTIME";
+inline constexpr const char* SAMPLING_REALTIME_FREQ = "ROCPROFSYS_SAMPLING_REALTIME_FREQ";
+inline constexpr const char* SAMPLING_REALTIME_DELAY =
+    "ROCPROFSYS_SAMPLING_REALTIME_DELAY";
+inline constexpr const char* SAMPLING_REALTIME_TIDS = "ROCPROFSYS_SAMPLING_REALTIME_TIDS";
+inline constexpr const char* SAMPLING_REALTIME_SIGNAL =
     "ROCPROFSYS_SAMPLING_REALTIME_SIGNAL";
 
 // --- Sampling: overflow (PAPI event-based) ---
-constexpr std::string_view SAMPLING_OVERFLOW      = "ROCPROFSYS_SAMPLING_OVERFLOW";
-constexpr std::string_view SAMPLING_OVERFLOW_FREQ = "ROCPROFSYS_SAMPLING_OVERFLOW_FREQ";
-constexpr std::string_view SAMPLING_OVERFLOW_TIDS = "ROCPROFSYS_SAMPLING_OVERFLOW_TIDS";
-constexpr std::string_view SAMPLING_OVERFLOW_SIGNAL =
+inline constexpr const char* SAMPLING_OVERFLOW      = "ROCPROFSYS_SAMPLING_OVERFLOW";
+inline constexpr const char* SAMPLING_OVERFLOW_FREQ = "ROCPROFSYS_SAMPLING_OVERFLOW_FREQ";
+inline constexpr const char* SAMPLING_OVERFLOW_TIDS = "ROCPROFSYS_SAMPLING_OVERFLOW_TIDS";
+inline constexpr const char* SAMPLING_OVERFLOW_SIGNAL =
     "ROCPROFSYS_SAMPLING_OVERFLOW_SIGNAL";
 
 // --- Domains: GPU (AMD SMI) ---
-constexpr std::string_view USE_AMD_SMI          = "ROCPROFSYS_USE_AMD_SMI";
-constexpr std::string_view USE_PROCESS_SAMPLING = "ROCPROFSYS_USE_PROCESS_SAMPLING";
-constexpr std::string_view AMD_SMI_METRICS      = "ROCPROFSYS_AMD_SMI_METRICS";
-constexpr std::string_view AMD_SMI_FREQ         = "ROCPROFSYS_AMD_SMI_FREQ";
-constexpr std::string_view AMD_SMI_DEVICES      = "ROCPROFSYS_AMD_SMI_DEVICES";
+inline constexpr const char* USE_AMD_SMI          = "ROCPROFSYS_USE_AMD_SMI";
+inline constexpr const char* USE_PROCESS_SAMPLING = "ROCPROFSYS_USE_PROCESS_SAMPLING";
+inline constexpr const char* AMD_SMI_METRICS      = "ROCPROFSYS_AMD_SMI_METRICS";
+inline constexpr const char* AMD_SMI_FREQ         = "ROCPROFSYS_AMD_SMI_FREQ";
+inline constexpr const char* AMD_SMI_DEVICES      = "ROCPROFSYS_AMD_SMI_DEVICES";
 
 // --- Domains: ROCm ---
-constexpr std::string_view ROCM_DOMAINS        = "ROCPROFSYS_ROCM_DOMAINS";
-constexpr std::string_view ROCM_GROUP_BY_QUEUE = "ROCPROFSYS_ROCM_GROUP_BY_QUEUE";
-constexpr std::string_view GPU_PERF_COUNTERS   = "ROCPROFSYS_GPU_PERF_COUNTERS";
+inline constexpr const char* ROCM_DOMAINS        = "ROCPROFSYS_ROCM_DOMAINS";
+inline constexpr const char* ROCM_GROUP_BY_QUEUE = "ROCPROFSYS_ROCM_GROUP_BY_QUEUE";
+inline constexpr const char* GPU_PERF_COUNTERS   = "ROCPROFSYS_GPU_PERF_COUNTERS";
 
 // --- Domains: CPU ---
-constexpr std::string_view CPU_FREQ         = "ROCPROFSYS_CPU_FREQ";
-constexpr std::string_view CPU_FREQ_ENABLED = "ROCPROFSYS_CPU_FREQ_ENABLED";
-constexpr std::string_view CPU_METRICS      = "ROCPROFSYS_CPU_METRICS";
+inline constexpr const char* CPU_FREQ         = "ROCPROFSYS_CPU_FREQ";
+inline constexpr const char* CPU_FREQ_ENABLED = "ROCPROFSYS_CPU_FREQ_ENABLED";
+inline constexpr const char* CPU_METRICS      = "ROCPROFSYS_CPU_METRICS";
 
 // --- Domains: Parallel runtimes ---
-constexpr std::string_view USE_MPI     = "ROCPROFSYS_USE_MPI";
-constexpr std::string_view USE_MPIP    = "ROCPROFSYS_USE_MPIP";
-constexpr std::string_view USE_OMPT    = "ROCPROFSYS_USE_OMPT";
-constexpr std::string_view USE_KOKKOSP = "ROCPROFSYS_USE_KOKKOSP";
-constexpr std::string_view USE_RCCLP   = "ROCPROFSYS_USE_RCCLP";
-constexpr std::string_view USE_AINIC   = "ROCPROFSYS_USE_AINIC";
-constexpr std::string_view USE_SHMEM   = "ROCPROFSYS_USE_SHMEM";
-constexpr std::string_view USE_UCX     = "ROCPROFSYS_USE_UCX";
+inline constexpr const char* USE_MPI     = "ROCPROFSYS_USE_MPI";
+inline constexpr const char* USE_MPIP    = "ROCPROFSYS_USE_MPIP";
+inline constexpr const char* USE_OMPT    = "ROCPROFSYS_USE_OMPT";
+inline constexpr const char* USE_KOKKOSP = "ROCPROFSYS_USE_KOKKOSP";
+inline constexpr const char* USE_RCCLP   = "ROCPROFSYS_USE_RCCLP";
+inline constexpr const char* USE_AINIC   = "ROCPROFSYS_USE_AINIC";
+inline constexpr const char* USE_SHMEM   = "ROCPROFSYS_USE_SHMEM";
+inline constexpr const char* USE_UCX     = "ROCPROFSYS_USE_UCX";
 
 // --- Domains: Shmem ---
-constexpr std::string_view SHMEM_PERMIT_LIST = "ROCPROFSYS_SHMEM_PERMIT_LIST";
-constexpr std::string_view SHMEM_REJECT_LIST = "ROCPROFSYS_SHMEM_REJECT_LIST";
+inline constexpr const char* SHMEM_PERMIT_LIST = "ROCPROFSYS_SHMEM_PERMIT_LIST";
+inline constexpr const char* SHMEM_REJECT_LIST = "ROCPROFSYS_SHMEM_REJECT_LIST";
 
 // --- Output ---
-constexpr std::string_view OUTPUT_PATH             = "ROCPROFSYS_OUTPUT_PATH";
-constexpr std::string_view OUTPUT_PREFIX           = "ROCPROFSYS_OUTPUT_PREFIX";
-constexpr std::string_view OUTPUT                  = "ROCPROFSYS_OUTPUT";
-constexpr std::string_view OUTPUT_FILE             = "ROCPROFSYS_OUTPUT_FILE";
-constexpr std::string_view OUTPUT_USE_CURRENT_TIME = "ROCPROFSYS_OUTPUT_USE_CURRENT_TIME";
-constexpr std::string_view USE_PID                 = "ROCPROFSYS_USE_PID";
-constexpr std::string_view TIME_OUTPUT             = "ROCPROFSYS_TIME_OUTPUT";
-constexpr std::string_view FILE_OUTPUT             = "ROCPROFSYS_FILE_OUTPUT";
-constexpr std::string_view TEXT_OUTPUT             = "ROCPROFSYS_TEXT_OUTPUT";
-constexpr std::string_view JSON_OUTPUT             = "ROCPROFSYS_JSON_OUTPUT";
-constexpr std::string_view COUT_OUTPUT             = "ROCPROFSYS_COUT_OUTPUT";
-constexpr std::string_view DIFF_OUTPUT             = "ROCPROFSYS_DIFF_OUTPUT";
-constexpr std::string_view TREE_OUTPUT             = "ROCPROFSYS_TREE_OUTPUT";
-constexpr std::string_view INPUT_PATH              = "ROCPROFSYS_INPUT_PATH";
-constexpr std::string_view INPUT_PREFIX            = "ROCPROFSYS_INPUT_PREFIX";
-constexpr std::string_view INPUT_EXTENSIONS        = "ROCPROFSYS_INPUT_EXTENSIONS";
-constexpr std::string_view USE_ROCPD               = "ROCPROFSYS_USE_ROCPD";
-constexpr std::string_view USE_TEMPORARY_FILES     = "ROCPROFSYS_USE_TEMPORARY_FILES";
-constexpr std::string_view USE_UNIFIED_MEMORY_PROFILING =
+inline constexpr const char* OUTPUT_PATH   = "ROCPROFSYS_OUTPUT_PATH";
+inline constexpr const char* OUTPUT_PREFIX = "ROCPROFSYS_OUTPUT_PREFIX";
+inline constexpr const char* OUTPUT        = "ROCPROFSYS_OUTPUT";
+inline constexpr const char* OUTPUT_FILE   = "ROCPROFSYS_OUTPUT_FILE";
+inline constexpr const char* OUTPUT_USE_CURRENT_TIME =
+    "ROCPROFSYS_OUTPUT_USE_CURRENT_TIME";
+inline constexpr const char* USE_PID             = "ROCPROFSYS_USE_PID";
+inline constexpr const char* TIME_OUTPUT         = "ROCPROFSYS_TIME_OUTPUT";
+inline constexpr const char* FILE_OUTPUT         = "ROCPROFSYS_FILE_OUTPUT";
+inline constexpr const char* TEXT_OUTPUT         = "ROCPROFSYS_TEXT_OUTPUT";
+inline constexpr const char* JSON_OUTPUT         = "ROCPROFSYS_JSON_OUTPUT";
+inline constexpr const char* COUT_OUTPUT         = "ROCPROFSYS_COUT_OUTPUT";
+inline constexpr const char* DIFF_OUTPUT         = "ROCPROFSYS_DIFF_OUTPUT";
+inline constexpr const char* TREE_OUTPUT         = "ROCPROFSYS_TREE_OUTPUT";
+inline constexpr const char* INPUT_PATH          = "ROCPROFSYS_INPUT_PATH";
+inline constexpr const char* INPUT_PREFIX        = "ROCPROFSYS_INPUT_PREFIX";
+inline constexpr const char* INPUT_EXTENSIONS    = "ROCPROFSYS_INPUT_EXTENSIONS";
+inline constexpr const char* USE_ROCPD           = "ROCPROFSYS_USE_ROCPD";
+inline constexpr const char* USE_TEMPORARY_FILES = "ROCPROFSYS_USE_TEMPORARY_FILES";
+inline constexpr const char* USE_UNIFIED_MEMORY_PROFILING =
     "ROCPROFSYS_USE_UNIFIED_MEMORY_PROFILING";
-constexpr std::string_view TIME_FORMAT = "ROCPROFSYS_TIME_FORMAT";
+inline constexpr const char* TIME_FORMAT = "ROCPROFSYS_TIME_FORMAT";
 
 // --- Output: number formatting ---
-constexpr std::string_view PRECISION         = "ROCPROFSYS_PRECISION";
-constexpr std::string_view SCIENTIFIC        = "ROCPROFSYS_SCIENTIFIC";
-constexpr std::string_view WIDTH             = "ROCPROFSYS_WIDTH";
-constexpr std::string_view MAX_WIDTH         = "ROCPROFSYS_MAX_WIDTH";
-constexpr std::string_view TIMING_PRECISION  = "ROCPROFSYS_TIMING_PRECISION";
-constexpr std::string_view TIMING_SCIENTIFIC = "ROCPROFSYS_TIMING_SCIENTIFIC";
-constexpr std::string_view TIMING_UNITS      = "ROCPROFSYS_TIMING_UNITS";
-constexpr std::string_view TIMING_WIDTH      = "ROCPROFSYS_TIMING_WIDTH";
-constexpr std::string_view MEMORY_PRECISION  = "ROCPROFSYS_MEMORY_PRECISION";
-constexpr std::string_view MEMORY_SCIENTIFIC = "ROCPROFSYS_MEMORY_SCIENTIFIC";
-constexpr std::string_view MEMORY_UNITS      = "ROCPROFSYS_MEMORY_UNITS";
-constexpr std::string_view MEMORY_WIDTH      = "ROCPROFSYS_MEMORY_WIDTH";
+inline constexpr const char* PRECISION         = "ROCPROFSYS_PRECISION";
+inline constexpr const char* SCIENTIFIC        = "ROCPROFSYS_SCIENTIFIC";
+inline constexpr const char* WIDTH             = "ROCPROFSYS_WIDTH";
+inline constexpr const char* MAX_WIDTH         = "ROCPROFSYS_MAX_WIDTH";
+inline constexpr const char* TIMING_PRECISION  = "ROCPROFSYS_TIMING_PRECISION";
+inline constexpr const char* TIMING_SCIENTIFIC = "ROCPROFSYS_TIMING_SCIENTIFIC";
+inline constexpr const char* TIMING_UNITS      = "ROCPROFSYS_TIMING_UNITS";
+inline constexpr const char* TIMING_WIDTH      = "ROCPROFSYS_TIMING_WIDTH";
+inline constexpr const char* MEMORY_PRECISION  = "ROCPROFSYS_MEMORY_PRECISION";
+inline constexpr const char* MEMORY_SCIENTIFIC = "ROCPROFSYS_MEMORY_SCIENTIFIC";
+inline constexpr const char* MEMORY_UNITS      = "ROCPROFSYS_MEMORY_UNITS";
+inline constexpr const char* MEMORY_WIDTH      = "ROCPROFSYS_MEMORY_WIDTH";
 
 // --- MPI output filtering ---
-constexpr std::string_view RANK_FILTER_ID     = "ROCPROFSYS_RANK_FILTER_ID";
-constexpr std::string_view RANK_FILTER_OUTPUT = "ROCPROFSYS_RANK_FILTER_OUTPUT";
-constexpr std::string_view RANK_FILTER_LOGS   = "ROCPROFSYS_RANK_FILTER_LOGS";
+inline constexpr const char* RANK_FILTER_ID     = "ROCPROFSYS_RANK_FILTER_ID";
+inline constexpr const char* RANK_FILTER_OUTPUT = "ROCPROFSYS_RANK_FILTER_OUTPUT";
+inline constexpr const char* RANK_FILTER_LOGS   = "ROCPROFSYS_RANK_FILTER_LOGS";
 
 // --- Process sampling ---
-constexpr std::string_view PROCESS_SAMPLING_FREQ  = "ROCPROFSYS_PROCESS_SAMPLING_FREQ";
-constexpr std::string_view PROCESS_SAMPLING_DELAY = "ROCPROFSYS_PROCESS_SAMPLING_DELAY";
-constexpr std::string_view PROCESS_SAMPLING_DURATION =
+inline constexpr const char* PROCESS_SAMPLING_FREQ  = "ROCPROFSYS_PROCESS_SAMPLING_FREQ";
+inline constexpr const char* PROCESS_SAMPLING_DELAY = "ROCPROFSYS_PROCESS_SAMPLING_DELAY";
+inline constexpr const char* PROCESS_SAMPLING_DURATION =
     "ROCPROFSYS_PROCESS_SAMPLING_DURATION";
-constexpr std::string_view SAMPLING_PROCESS_DURATION =
+inline constexpr const char* SAMPLING_PROCESS_DURATION =
     "ROCPROFSYS_SAMPLING_PROCESS_DURATION";
 
 // --- Causal profiling ---
-constexpr std::string_view USE_CAUSAL              = "ROCPROFSYS_USE_CAUSAL";
-constexpr std::string_view CAUSAL_MODE             = "ROCPROFSYS_CAUSAL_MODE";
-constexpr std::string_view CAUSAL_BACKEND          = "ROCPROFSYS_CAUSAL_BACKEND";
-constexpr std::string_view CAUSAL_VERBOSE          = "ROCPROFSYS_CAUSAL_VERBOSE";
-constexpr std::string_view CAUSAL_DEBUG            = "ROCPROFSYS_CAUSAL_DEBUG";
-constexpr std::string_view CAUSAL_BINARY_SCOPE     = "ROCPROFSYS_CAUSAL_BINARY_SCOPE";
-constexpr std::string_view CAUSAL_BINARY_EXCLUDE   = "ROCPROFSYS_CAUSAL_BINARY_EXCLUDE";
-constexpr std::string_view CAUSAL_FUNCTION_SCOPE   = "ROCPROFSYS_CAUSAL_FUNCTION_SCOPE";
-constexpr std::string_view CAUSAL_FUNCTION_EXCLUDE = "ROCPROFSYS_CAUSAL_FUNCTION_EXCLUDE";
-constexpr std::string_view CAUSAL_FUNCTION_EXCLUDE_DEFAULTS =
+inline constexpr const char* USE_CAUSAL            = "ROCPROFSYS_USE_CAUSAL";
+inline constexpr const char* CAUSAL_MODE           = "ROCPROFSYS_CAUSAL_MODE";
+inline constexpr const char* CAUSAL_BACKEND        = "ROCPROFSYS_CAUSAL_BACKEND";
+inline constexpr const char* CAUSAL_VERBOSE        = "ROCPROFSYS_CAUSAL_VERBOSE";
+inline constexpr const char* CAUSAL_DEBUG          = "ROCPROFSYS_CAUSAL_DEBUG";
+inline constexpr const char* CAUSAL_BINARY_SCOPE   = "ROCPROFSYS_CAUSAL_BINARY_SCOPE";
+inline constexpr const char* CAUSAL_BINARY_EXCLUDE = "ROCPROFSYS_CAUSAL_BINARY_EXCLUDE";
+inline constexpr const char* CAUSAL_FUNCTION_SCOPE = "ROCPROFSYS_CAUSAL_FUNCTION_SCOPE";
+inline constexpr const char* CAUSAL_FUNCTION_EXCLUDE =
+    "ROCPROFSYS_CAUSAL_FUNCTION_EXCLUDE";
+inline constexpr const char* CAUSAL_FUNCTION_EXCLUDE_DEFAULTS =
     "ROCPROFSYS_CAUSAL_FUNCTION_EXCLUDE_DEFAULTS";
-constexpr std::string_view CAUSAL_SOURCE_SCOPE   = "ROCPROFSYS_CAUSAL_SOURCE_SCOPE";
-constexpr std::string_view CAUSAL_SOURCE_EXCLUDE = "ROCPROFSYS_CAUSAL_SOURCE_EXCLUDE";
-constexpr std::string_view CAUSAL_END_TO_END     = "ROCPROFSYS_CAUSAL_END_TO_END";
-constexpr std::string_view CAUSAL_DELAY          = "ROCPROFSYS_CAUSAL_DELAY";
-constexpr std::string_view CAUSAL_DURATION       = "ROCPROFSYS_CAUSAL_DURATION";
-constexpr std::string_view CAUSAL_RANDOM_SEED    = "ROCPROFSYS_CAUSAL_RANDOM_SEED";
-constexpr std::string_view CAUSAL_FIXED_SPEEDUP  = "ROCPROFSYS_CAUSAL_FIXED_SPEEDUP";
-constexpr std::string_view CAUSAL_SPEEDUP_DIVISIONS =
+inline constexpr const char* CAUSAL_SOURCE_SCOPE   = "ROCPROFSYS_CAUSAL_SOURCE_SCOPE";
+inline constexpr const char* CAUSAL_SOURCE_EXCLUDE = "ROCPROFSYS_CAUSAL_SOURCE_EXCLUDE";
+inline constexpr const char* CAUSAL_END_TO_END     = "ROCPROFSYS_CAUSAL_END_TO_END";
+inline constexpr const char* CAUSAL_DELAY          = "ROCPROFSYS_CAUSAL_DELAY";
+inline constexpr const char* CAUSAL_DURATION       = "ROCPROFSYS_CAUSAL_DURATION";
+inline constexpr const char* CAUSAL_RANDOM_SEED    = "ROCPROFSYS_CAUSAL_RANDOM_SEED";
+inline constexpr const char* CAUSAL_FIXED_SPEEDUP  = "ROCPROFSYS_CAUSAL_FIXED_SPEEDUP";
+inline constexpr const char* CAUSAL_SPEEDUP_DIVISIONS =
     "ROCPROFSYS_CAUSAL_SPEEDUP_DIVISIONS";
-constexpr std::string_view CAUSAL_SCALE_EXPERIMENT_TIME_BY_SPEEDUP =
+inline constexpr const char* CAUSAL_SCALE_EXPERIMENT_TIME_BY_SPEEDUP =
     "ROCPROFSYS_CAUSAL_SCALE_EXPERIMENT_TIME_BY_SPEEDUP";
-constexpr std::string_view CAUSAL_FILE       = "ROCPROFSYS_CAUSAL_FILE";
-constexpr std::string_view CAUSAL_FILE_RESET = "ROCPROFSYS_CAUSAL_FILE_RESET";
+inline constexpr const char* CAUSAL_FILE       = "ROCPROFSYS_CAUSAL_FILE";
+inline constexpr const char* CAUSAL_FILE_RESET = "ROCPROFSYS_CAUSAL_FILE_RESET";
 
 // --- Hardware counters ---
 // Note: PAPI_MULTIPLEXING and PAPI_QUIET would collide with integer macros defined in
 // PAPI's C header (papi.h). The identifiers carry a trailing suffix to avoid
 // preprocessor substitution; the env-var strings retain the original names.
-constexpr std::string_view ROCM_EVENTS               = "ROCPROFSYS_ROCM_EVENTS";
-constexpr std::string_view PAPI_EVENTS               = "ROCPROFSYS_PAPI_EVENTS";
-constexpr std::string_view PAPI_MULTIPLEXING_ENABLED = "ROCPROFSYS_PAPI_MULTIPLEXING";
-constexpr std::string_view PAPI_FAIL_ON_ERROR        = "ROCPROFSYS_PAPI_FAIL_ON_ERROR";
-constexpr std::string_view PAPI_OVERFLOW             = "ROCPROFSYS_PAPI_OVERFLOW";
-constexpr std::string_view PAPI_QUIET_MODE           = "ROCPROFSYS_PAPI_QUIET";
-constexpr std::string_view PAPI_THREADING            = "ROCPROFSYS_PAPI_THREADING";
-constexpr std::string_view USE_CODE_COVERAGE         = "ROCPROFSYS_USE_CODE_COVERAGE";
+inline constexpr const char* ROCM_EVENTS               = "ROCPROFSYS_ROCM_EVENTS";
+inline constexpr const char* PAPI_EVENTS               = "ROCPROFSYS_PAPI_EVENTS";
+inline constexpr const char* PAPI_MULTIPLEXING_ENABLED = "ROCPROFSYS_PAPI_MULTIPLEXING";
+inline constexpr const char* PAPI_FAIL_ON_ERROR        = "ROCPROFSYS_PAPI_FAIL_ON_ERROR";
+inline constexpr const char* PAPI_OVERFLOW             = "ROCPROFSYS_PAPI_OVERFLOW";
+inline constexpr const char* PAPI_QUIET_MODE           = "ROCPROFSYS_PAPI_QUIET";
+inline constexpr const char* PAPI_THREADING            = "ROCPROFSYS_PAPI_THREADING";
+inline constexpr const char* USE_CODE_COVERAGE         = "ROCPROFSYS_USE_CODE_COVERAGE";
 
 // --- MPI ---
-constexpr std::string_view MPI_INIT             = "ROCPROFSYS_MPI_INIT";
-constexpr std::string_view MPI_FINALIZE         = "ROCPROFSYS_MPI_FINALIZE";
-constexpr std::string_view MPI_FAIL_ON_ERROR    = "ROCPROFSYS_MPI_FAIL_ON_ERROR";
-constexpr std::string_view MPI_QUIET            = "ROCPROFSYS_MPI_QUIET";
-constexpr std::string_view MPI_THREAD           = "ROCPROFSYS_MPI_THREAD";
-constexpr std::string_view MPI_THREAD_TYPE      = "ROCPROFSYS_MPI_THREAD_TYPE";
-constexpr std::string_view MPI_MAX_COMM_UPDATES = "ROCPROFSYS_MPI_MAX_COMM_UPDATES";
+inline constexpr const char* MPI_INIT             = "ROCPROFSYS_MPI_INIT";
+inline constexpr const char* MPI_FINALIZE         = "ROCPROFSYS_MPI_FINALIZE";
+inline constexpr const char* MPI_FAIL_ON_ERROR    = "ROCPROFSYS_MPI_FAIL_ON_ERROR";
+inline constexpr const char* MPI_QUIET            = "ROCPROFSYS_MPI_QUIET";
+inline constexpr const char* MPI_THREAD           = "ROCPROFSYS_MPI_THREAD";
+inline constexpr const char* MPI_THREAD_TYPE      = "ROCPROFSYS_MPI_THREAD_TYPE";
+inline constexpr const char* MPI_MAX_COMM_UPDATES = "ROCPROFSYS_MPI_MAX_COMM_UPDATES";
 
 // --- Kokkos profiling ---
-constexpr std::string_view KOKKOSP_PREFIX          = "ROCPROFSYS_KOKKOSP_PREFIX";
-constexpr std::string_view KOKKOSP_KERNEL_LOGGER   = "ROCPROFSYS_KOKKOSP_KERNEL_LOGGER";
-constexpr std::string_view KOKKOSP_NAME_LENGTH_MAX = "ROCPROFSYS_KOKKOSP_NAME_LENGTH_MAX";
-constexpr std::string_view KOKKOSP_DEEP_COPY       = "ROCPROFSYS_KOKKOSP_DEEP_COPY";
+inline constexpr const char* KOKKOSP_PREFIX        = "ROCPROFSYS_KOKKOSP_PREFIX";
+inline constexpr const char* KOKKOSP_KERNEL_LOGGER = "ROCPROFSYS_KOKKOSP_KERNEL_LOGGER";
+inline constexpr const char* KOKKOSP_NAME_LENGTH_MAX =
+    "ROCPROFSYS_KOKKOSP_NAME_LENGTH_MAX";
+inline constexpr const char* KOKKOSP_DEEP_COPY = "ROCPROFSYS_KOKKOSP_DEEP_COPY";
 
 // --- DL (dynamic loader / preload) ---
-constexpr std::string_view DL_VERBOSE = "ROCPROFSYS_DL_VERBOSE";
-constexpr std::string_view DL_DEBUG   = "ROCPROFSYS_DL_DEBUG";
-constexpr std::string_view DL_LIBRARY = "ROCPROFSYS_DL_LIBRARY";
+inline constexpr const char* DL_VERBOSE = "ROCPROFSYS_DL_VERBOSE";
+inline constexpr const char* DL_DEBUG   = "ROCPROFSYS_DL_DEBUG";
+inline constexpr const char* DL_LIBRARY = "ROCPROFSYS_DL_LIBRARY";
 
 // --- Regex include/exclude filters ---
-constexpr std::string_view REGEX_INCLUDE          = "ROCPROFSYS_REGEX_INCLUDE";
-constexpr std::string_view REGEX_EXCLUDE          = "ROCPROFSYS_REGEX_EXCLUDE";
-constexpr std::string_view REGEX_RESTRICT         = "ROCPROFSYS_REGEX_RESTRICT";
-constexpr std::string_view REGEX_CALLER_INCLUDE   = "ROCPROFSYS_REGEX_CALLER_INCLUDE";
-constexpr std::string_view REGEX_INTERNAL_INCLUDE = "ROCPROFSYS_REGEX_INTERNAL_INCLUDE";
-constexpr std::string_view REGEX_INSTRUCTION_EXCLUDE =
+inline constexpr const char* REGEX_INCLUDE          = "ROCPROFSYS_REGEX_INCLUDE";
+inline constexpr const char* REGEX_EXCLUDE          = "ROCPROFSYS_REGEX_EXCLUDE";
+inline constexpr const char* REGEX_RESTRICT         = "ROCPROFSYS_REGEX_RESTRICT";
+inline constexpr const char* REGEX_CALLER_INCLUDE   = "ROCPROFSYS_REGEX_CALLER_INCLUDE";
+inline constexpr const char* REGEX_INTERNAL_INCLUDE = "ROCPROFSYS_REGEX_INTERNAL_INCLUDE";
+inline constexpr const char* REGEX_INSTRUCTION_EXCLUDE =
     "ROCPROFSYS_REGEX_INSTRUCTION_EXCLUDE";
-constexpr std::string_view REGEX_MODULE_INCLUDE  = "ROCPROFSYS_REGEX_MODULE_INCLUDE";
-constexpr std::string_view REGEX_MODULE_EXCLUDE  = "ROCPROFSYS_REGEX_MODULE_EXCLUDE";
-constexpr std::string_view REGEX_MODULE_RESTRICT = "ROCPROFSYS_REGEX_MODULE_RESTRICT";
-constexpr std::string_view REGEX_MODULE_INTERNAL_INCLUDE =
+inline constexpr const char* REGEX_MODULE_INCLUDE  = "ROCPROFSYS_REGEX_MODULE_INCLUDE";
+inline constexpr const char* REGEX_MODULE_EXCLUDE  = "ROCPROFSYS_REGEX_MODULE_EXCLUDE";
+inline constexpr const char* REGEX_MODULE_RESTRICT = "ROCPROFSYS_REGEX_MODULE_RESTRICT";
+inline constexpr const char* REGEX_MODULE_INTERNAL_INCLUDE =
     "ROCPROFSYS_REGEX_MODULE_INTERNAL_INCLUDE";
 
 // --- CI / continuous integration ---
-constexpr std::string_view CI                     = "ROCPROFSYS_CI";
-constexpr std::string_view CI_SKIP_PUSH_POP_CHECK = "ROCPROFSYS_CI_SKIP_PUSH_POP_CHECK";
-constexpr std::string_view CI_TIMEOUT             = "ROCPROFSYS_CI_TIMEOUT";
-constexpr std::string_view CI_TIMEOUT_COUNT       = "ROCPROFSYS_CI_TIMEOUT_COUNT";
-constexpr std::string_view CI_TIMEOUT_OVERRIDE    = "ROCPROFSYS_CI_TIMEOUT_OVERRIDE";
+inline constexpr const char* CI                  = "ROCPROFSYS_CI";
+inline constexpr const char* CI_TIMEOUT          = "ROCPROFSYS_CI_TIMEOUT";
+inline constexpr const char* CI_TIMEOUT_COUNT    = "ROCPROFSYS_CI_TIMEOUT_COUNT";
+inline constexpr const char* CI_TIMEOUT_OVERRIDE = "ROCPROFSYS_CI_TIMEOUT_OVERRIDE";
 
 // --- Process / threading / behavior ---
-constexpr std::string_view NUM_THREADS             = "ROCPROFSYS_NUM_THREADS";
-constexpr std::string_view NUM_THREADS_HINT        = "ROCPROFSYS_NUM_THREADS_HINT";
-constexpr std::string_view THREAD_POOL_SIZE        = "ROCPROFSYS_THREAD_POOL_SIZE";
-constexpr std::string_view RECYCLE_TIDS            = "ROCPROFSYS_RECYCLE_TIDS";
-constexpr std::string_view KILL_DELAY              = "ROCPROFSYS_KILL_DELAY";
-constexpr std::string_view COLLAPSE_PROCESSES      = "ROCPROFSYS_COLLAPSE_PROCESSES";
-constexpr std::string_view NODE_COUNT              = "ROCPROFSYS_NODE_COUNT";
-constexpr std::string_view ROOT_PROCESS            = "ROCPROFSYS_ROOT_PROCESS";
-constexpr std::string_view RANK_FILTER_ID          = "ROCPROFSYS_RANK_FILTER_ID";
-constexpr std::string_view RANK_FILTER_OUTPUT      = "ROCPROFSYS_RANK_FILTER_OUTPUT";
-constexpr std::string_view REATTACH_ADD_SESSION_ID = "ROCPROFSYS_REATTACH_ADD_SESSION_ID";
+inline constexpr const char* NUM_THREADS        = "ROCPROFSYS_NUM_THREADS";
+inline constexpr const char* NUM_THREADS_HINT   = "ROCPROFSYS_NUM_THREADS_HINT";
+inline constexpr const char* THREAD_POOL_SIZE   = "ROCPROFSYS_THREAD_POOL_SIZE";
+inline constexpr const char* RECYCLE_TIDS       = "ROCPROFSYS_RECYCLE_TIDS";
+inline constexpr const char* KILL_DELAY         = "ROCPROFSYS_KILL_DELAY";
+inline constexpr const char* COLLAPSE_PROCESSES = "ROCPROFSYS_COLLAPSE_PROCESSES";
+inline constexpr const char* NODE_COUNT         = "ROCPROFSYS_NODE_COUNT";
+inline constexpr const char* ROOT_PROCESS       = "ROCPROFSYS_ROOT_PROCESS";
+inline constexpr const char* REATTACH_ADD_SESSION_ID =
+    "ROCPROFSYS_REATTACH_ADD_SESSION_ID";
 
 // --- Instrumentation ---
-constexpr std::string_view INSTRUMENT_MODE = "ROCPROFSYS_INSTRUMENT_MODE";
-constexpr std::string_view IGNORE_DYNINST_TRAMPOLINE =
+inline constexpr const char* INSTRUMENT_MODE = "ROCPROFSYS_INSTRUMENT_MODE";
+inline constexpr const char* IGNORE_DYNINST_TRAMPOLINE =
     "ROCPROFSYS_IGNORE_DYNINST_TRAMPOLINE";
-constexpr std::string_view DEFAULT_MIN_INSTRUCTIONS =
+inline constexpr const char* DEFAULT_MIN_INSTRUCTIONS =
     "ROCPROFSYS_DEFAULT_MIN_INSTRUCTIONS";
 
 // --- Runtime / launcher (set by instrumenter / read by the loaded library) ---
-constexpr std::string_view PATH                   = "ROCPROFSYS_PATH";
-constexpr std::string_view PRELOAD                = "ROCPROFSYS_PRELOAD";
-constexpr std::string_view LIBRARY                = "ROCPROFSYS_LIBRARY";
-constexpr std::string_view USER_LIBRARY           = "ROCPROFSYS_USER_LIBRARY";
-constexpr std::string_view COMMAND_LINE           = "ROCPROFSYS_COMMAND_LINE";
-constexpr std::string_view LAUNCHER               = "ROCPROFSYS_LAUNCHER";
-constexpr std::string_view SCRIPT_DIR             = "ROCPROFSYS_SCRIPT_DIR";
-constexpr std::string_view ROCM_PATH              = "ROCPROFSYS_ROCM_PATH";
-constexpr std::string_view CONFIG                 = "ROCPROFSYS_CONFIG";
-constexpr std::string_view ENVIRONMENT            = "ROCPROFSYS_ENVIRONMENT";
-constexpr std::string_view SETTINGS_DESC          = "ROCPROFSYS_SETTINGS_DESC";
-constexpr std::string_view SETTINGS_DESC_MARKDOWN = "ROCPROFSYS_SETTINGS_DESC_MARKDOWN";
-constexpr std::string_view CRAYPAT                = "ROCPROFSYS_CRAYPAT";
+inline constexpr const char* PATH                   = "ROCPROFSYS_PATH";
+inline constexpr const char* PRELOAD                = "ROCPROFSYS_PRELOAD";
+inline constexpr const char* LIBRARY                = "ROCPROFSYS_LIBRARY";
+inline constexpr const char* USER_LIBRARY           = "ROCPROFSYS_USER_LIBRARY";
+inline constexpr const char* COMMAND_LINE           = "ROCPROFSYS_COMMAND_LINE";
+inline constexpr const char* LAUNCHER               = "ROCPROFSYS_LAUNCHER";
+inline constexpr const char* SCRIPT_DIR             = "ROCPROFSYS_SCRIPT_DIR";
+inline constexpr const char* ROCM_PATH              = "ROCPROFSYS_ROCM_PATH";
+inline constexpr const char* CONFIG                 = "ROCPROFSYS_CONFIG";
+inline constexpr const char* ENVIRONMENT            = "ROCPROFSYS_ENVIRONMENT";
+inline constexpr const char* SETTINGS_DESC          = "ROCPROFSYS_SETTINGS_DESC";
+inline constexpr const char* SETTINGS_DESC_MARKDOWN = "ROCPROFSYS_SETTINGS_DESC_MARKDOWN";
+inline constexpr const char* CRAYPAT                = "ROCPROFSYS_CRAYPAT";
 
 // --- Advanced ---
-constexpr std::string_view CPU_AFFINITY          = "ROCPROFSYS_CPU_AFFINITY";
-constexpr std::string_view COLLAPSE_THREADS      = "ROCPROFSYS_COLLAPSE_THREADS";
-constexpr std::string_view MAX_DEPTH             = "ROCPROFSYS_MAX_DEPTH";
-constexpr std::string_view TRACE_DELAY           = "ROCPROFSYS_TRACE_DELAY";
-constexpr std::string_view TRACE_DURATION        = "ROCPROFSYS_TRACE_DURATION";
-constexpr std::string_view TRACE_PERIODS         = "ROCPROFSYS_TRACE_PERIODS";
-constexpr std::string_view TRACE_PERIOD_CLOCK_ID = "ROCPROFSYS_TRACE_PERIOD_CLOCK_ID";
-constexpr std::string_view VERBOSE               = "ROCPROFSYS_VERBOSE";
-constexpr std::string_view VERBOSE_AVAIL         = "ROCPROFSYS_VERBOSE_AVAIL";
-constexpr std::string_view VERBOSE_INSTRUMENT    = "ROCPROFSYS_VERBOSE_INSTRUMENT";
+inline constexpr const char* CPU_AFFINITY          = "ROCPROFSYS_CPU_AFFINITY";
+inline constexpr const char* COLLAPSE_THREADS      = "ROCPROFSYS_COLLAPSE_THREADS";
+inline constexpr const char* MAX_DEPTH             = "ROCPROFSYS_MAX_DEPTH";
+inline constexpr const char* TRACE_DELAY           = "ROCPROFSYS_TRACE_DELAY";
+inline constexpr const char* TRACE_DURATION        = "ROCPROFSYS_TRACE_DURATION";
+inline constexpr const char* TRACE_PERIODS         = "ROCPROFSYS_TRACE_PERIODS";
+inline constexpr const char* TRACE_PERIOD_CLOCK_ID = "ROCPROFSYS_TRACE_PERIOD_CLOCK_ID";
+inline constexpr const char* VERBOSE               = "ROCPROFSYS_VERBOSE";
+inline constexpr const char* VERBOSE_AVAIL         = "ROCPROFSYS_VERBOSE_AVAIL";
+inline constexpr const char* VERBOSE_INSTRUMENT    = "ROCPROFSYS_VERBOSE_INSTRUMENT";
 // Note: identifier is DEBUG_MODE to avoid collision with `#define DEBUG 1` injected by
 // the project's generated common/defines.h on CI builds (ROCPROFSYS_CI > 0). The
 // env-var string itself remains "ROCPROFSYS_DEBUG".
-constexpr std::string_view DEBUG_MODE = "ROCPROFSYS_DEBUG";
+inline constexpr const char* DEBUG_MODE = "ROCPROFSYS_DEBUG";
 // well above the highest verbose threshold (3) so debug mode enables all verbose output
-constexpr int              DEBUG_VERBOSE_BOOST   = 8;
-constexpr std::string_view DEBUG_INIT            = "ROCPROFSYS_DEBUG_INIT";
-constexpr std::string_view DEBUG_FINALIZE        = "ROCPROFSYS_DEBUG_FINALIZE";
-constexpr std::string_view DEBUG_AVAIL           = "ROCPROFSYS_DEBUG_AVAIL";
-constexpr std::string_view DEBUG_MARK            = "ROCPROFSYS_DEBUG_MARK";
-constexpr std::string_view DEBUG_PIDS            = "ROCPROFSYS_DEBUG_PIDS";
-constexpr std::string_view DEBUG_TIDS            = "ROCPROFSYS_DEBUG_TIDS";
-constexpr std::string_view DEBUG_PUSH            = "ROCPROFSYS_DEBUG_PUSH";
-constexpr std::string_view DEBUG_POP             = "ROCPROFSYS_DEBUG_POP";
-constexpr std::string_view DEBUG_SAMPLING        = "ROCPROFSYS_DEBUG_SAMPLING";
-constexpr std::string_view DEBUG_USER_REGIONS    = "ROCPROFSYS_DEBUG_USER_REGIONS";
-constexpr std::string_view ENABLE_SIGNAL_HANDLER = "ROCPROFSYS_ENABLE_SIGNAL_HANDLER";
-constexpr std::string_view TIMEMORY_COMPONENTS   = "ROCPROFSYS_TIMEMORY_COMPONENTS";
-constexpr std::string_view NETWORK_INTERFACE     = "ROCPROFSYS_NETWORK_INTERFACE";
+constexpr int                DEBUG_VERBOSE_BOOST   = 8;
+inline constexpr const char* DEBUG_INIT            = "ROCPROFSYS_DEBUG_INIT";
+inline constexpr const char* DEBUG_FINALIZE        = "ROCPROFSYS_DEBUG_FINALIZE";
+inline constexpr const char* DEBUG_AVAIL           = "ROCPROFSYS_DEBUG_AVAIL";
+inline constexpr const char* DEBUG_MARK            = "ROCPROFSYS_DEBUG_MARK";
+inline constexpr const char* DEBUG_PIDS            = "ROCPROFSYS_DEBUG_PIDS";
+inline constexpr const char* DEBUG_TIDS            = "ROCPROFSYS_DEBUG_TIDS";
+inline constexpr const char* DEBUG_PUSH            = "ROCPROFSYS_DEBUG_PUSH";
+inline constexpr const char* DEBUG_POP             = "ROCPROFSYS_DEBUG_POP";
+inline constexpr const char* DEBUG_SAMPLING        = "ROCPROFSYS_DEBUG_SAMPLING";
+inline constexpr const char* DEBUG_USER_REGIONS    = "ROCPROFSYS_DEBUG_USER_REGIONS";
+inline constexpr const char* ENABLE_SIGNAL_HANDLER = "ROCPROFSYS_ENABLE_SIGNAL_HANDLER";
+inline constexpr const char* TIMEMORY_COMPONENTS   = "ROCPROFSYS_TIMEMORY_COMPONENTS";
+inline constexpr const char* NETWORK_INTERFACE     = "ROCPROFSYS_NETWORK_INTERFACE";
 
 // --- Deprecated aliases ---
 // Names retained only for legacy/migration paths — the codebase emits deprecation
 // warnings when these are encountered. Do not introduce new references; prefer the
 // replacement (TRACE for USE_PERFETTO, PROFILE for USE_TIMEMORY).
-constexpr std::string_view USE_PERFETTO = "ROCPROFSYS_USE_PERFETTO";
-constexpr std::string_view USE_TIMEMORY = "ROCPROFSYS_USE_TIMEMORY";
+inline constexpr const char* USE_PERFETTO = "ROCPROFSYS_USE_PERFETTO";
+inline constexpr const char* USE_TIMEMORY = "ROCPROFSYS_USE_TIMEMORY";
 
 [[nodiscard]] inline int
 log_level_to_verbose(std::string_view level) noexcept

--- a/projects/rocprofiler-systems/source/lib/common/env_vars.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/env_vars.hpp
@@ -19,58 +19,93 @@ constexpr std::string_view CONFIG_FILE        = "ROCPROFSYS_CONFIG_FILE";
 constexpr std::string_view PRESET_DIR         = "ROCPROFSYS_PRESET_DIR";
 constexpr std::string_view MONOCHROME         = "ROCPROFSYS_MONOCHROME";
 constexpr std::string_view LOG_LEVEL          = "ROCPROFSYS_LOG_LEVEL";
+constexpr std::string_view LOG_FILE           = "ROCPROFSYS_LOG_FILE";
+constexpr std::string_view LOG_COUNT          = "ROCPROFSYS_LOG_COUNT";
 constexpr std::string_view TMPDIR             = "ROCPROFSYS_TMPDIR";
 constexpr std::string_view ENABLE_CATEGORIES  = "ROCPROFSYS_ENABLE_CATEGORIES";
 constexpr std::string_view DISABLE_CATEGORIES = "ROCPROFSYS_DISABLE_CATEGORIES";
+constexpr std::string_view ENABLED            = "ROCPROFSYS_ENABLED";
+constexpr std::string_view INIT_ENABLED       = "ROCPROFSYS_INIT_ENABLED";
+constexpr std::string_view INIT_TOOLING       = "ROCPROFSYS_INIT_TOOLING";
+constexpr std::string_view STRICT_CONFIG      = "ROCPROFSYS_STRICT_CONFIG";
+constexpr std::string_view SUPPRESS_CONFIG    = "ROCPROFSYS_SUPPRESS_CONFIG";
+constexpr std::string_view SUPPRESS_PARSING   = "ROCPROFSYS_SUPPRESS_PARSING";
+constexpr std::string_view PRINT_ENV          = "ROCPROFSYS_PRINT_ENV";
 
 // --- Tracing ---
 constexpr std::string_view TRACE                   = "ROCPROFSYS_TRACE";
+constexpr std::string_view USE_TRACE               = "ROCPROFSYS_USE_TRACE";
 constexpr std::string_view TRACE_LEGACY            = "ROCPROFSYS_TRACE_LEGACY";
 constexpr std::string_view PERFETTO_FILE           = "ROCPROFSYS_PERFETTO_FILE";
 constexpr std::string_view PERFETTO_BUFFER_SIZE_KB = "ROCPROFSYS_PERFETTO_BUFFER_SIZE_KB";
 constexpr std::string_view PERFETTO_FILL_POLICY    = "ROCPROFSYS_PERFETTO_FILL_POLICY";
 constexpr std::string_view PERFETTO_BACKEND        = "ROCPROFSYS_PERFETTO_BACKEND";
+constexpr std::string_view PERFETTO_BACKEND_SYSTEM = "ROCPROFSYS_PERFETTO_BACKEND_SYSTEM";
 constexpr std::string_view PERFETTO_FLUSH_PERIOD = "ROCPROFSYS_PERFETTO_FLUSH_PERIOD_MS";
-constexpr std::string_view SELECTED_REGIONS      = "ROCPROFSYS_SELECTED_REGIONS";
-constexpr std::string_view TRACE_THREAD_LOCKS    = "ROCPROFSYS_TRACE_THREAD_LOCKS";
-constexpr std::string_view TRACE_THREAD_RW_LOCKS = "ROCPROFSYS_TRACE_THREAD_RW_LOCKS";
+constexpr std::string_view PERFETTO_ANNOTATIONS  = "ROCPROFSYS_PERFETTO_ANNOTATIONS";
+constexpr std::string_view PERFETTO_COMBINE_TRACES = "ROCPROFSYS_PERFETTO_COMBINE_TRACES";
+constexpr std::string_view PERFETTO_SHMEM_SIZE_HINT_KB =
+    "ROCPROFSYS_PERFETTO_SHMEM_SIZE_HINT_KB";
+constexpr std::string_view MERGE_PERFETTO_FILES    = "ROCPROFSYS_MERGE_PERFETTO_FILES";
+constexpr std::string_view SELECTED_REGIONS        = "ROCPROFSYS_SELECTED_REGIONS";
+constexpr std::string_view TRACE_THREAD_LOCKS      = "ROCPROFSYS_TRACE_THREAD_LOCKS";
+constexpr std::string_view TRACE_THREAD_RW_LOCKS   = "ROCPROFSYS_TRACE_THREAD_RW_LOCKS";
 constexpr std::string_view TRACE_THREAD_SPIN_LOCKS = "ROCPROFSYS_TRACE_THREAD_SPIN_LOCKS";
+constexpr std::string_view TRACE_THREAD_BARRIERS   = "ROCPROFSYS_TRACE_THREAD_BARRIERS";
+constexpr std::string_view TRACE_THREAD_JOIN       = "ROCPROFSYS_TRACE_THREAD_JOIN";
 
 // --- Profiling ---
-constexpr std::string_view PROFILE      = "ROCPROFSYS_PROFILE";
-constexpr std::string_view FLAT_PROFILE = "ROCPROFSYS_FLAT_PROFILE";
+constexpr std::string_view PROFILE          = "ROCPROFSYS_PROFILE";
+constexpr std::string_view FLAT_PROFILE     = "ROCPROFSYS_FLAT_PROFILE";
+constexpr std::string_view TIMELINE_PROFILE = "ROCPROFSYS_TIMELINE_PROFILE";
 
 // --- Sampling ---
-constexpr std::string_view USE_SAMPLING      = "ROCPROFSYS_USE_SAMPLING";
-constexpr std::string_view SAMPLING_TIMER    = "ROCPROFSYS_SAMPLING_TIMER";
-constexpr std::string_view SAMPLING_FREQ     = "ROCPROFSYS_SAMPLING_FREQ";
-constexpr std::string_view SAMPLING_DELAY    = "ROCPROFSYS_SAMPLING_DELAY";
-constexpr std::string_view SAMPLING_DURATION = "ROCPROFSYS_SAMPLING_DURATION";
-constexpr std::string_view SAMPLING_CPUS     = "ROCPROFSYS_SAMPLING_CPUS";
-constexpr std::string_view SAMPLING_GPUS     = "ROCPROFSYS_SAMPLING_GPUS";
-constexpr std::string_view SAMPLING_AINICS   = "ROCPROFSYS_SAMPLING_AINICS";
-constexpr std::string_view SAMPLING_TIDS     = "ROCPROFSYS_SAMPLING_TIDS";
+constexpr std::string_view USE_SAMPLING        = "ROCPROFSYS_USE_SAMPLING";
+constexpr std::string_view USE_THREAD_SAMPLING = "ROCPROFSYS_USE_THREAD_SAMPLING";
+constexpr std::string_view SAMPLING_TIMER      = "ROCPROFSYS_SAMPLING_TIMER";
+constexpr std::string_view SAMPLING_FREQ       = "ROCPROFSYS_SAMPLING_FREQ";
+constexpr std::string_view SAMPLING_DELAY      = "ROCPROFSYS_SAMPLING_DELAY";
+constexpr std::string_view SAMPLING_DURATION   = "ROCPROFSYS_SAMPLING_DURATION";
+constexpr std::string_view SAMPLING_CPUS       = "ROCPROFSYS_SAMPLING_CPUS";
+constexpr std::string_view SAMPLING_GPUS       = "ROCPROFSYS_SAMPLING_GPUS";
+constexpr std::string_view SAMPLING_AINICS     = "ROCPROFSYS_SAMPLING_AINICS";
+constexpr std::string_view SAMPLING_TIDS       = "ROCPROFSYS_SAMPLING_TIDS";
 constexpr std::string_view SAMPLING_INCLUDE_INLINES =
     "ROCPROFSYS_SAMPLING_INCLUDE_INLINES";
 constexpr std::string_view SAMPLING_OVERFLOW_EVENT = "ROCPROFSYS_SAMPLING_OVERFLOW_EVENT";
+constexpr std::string_view SAMPLING_ALLOCATOR_SIZE = "ROCPROFSYS_SAMPLING_ALLOCATOR_SIZE";
+constexpr std::string_view SAMPLING_KEEP_DYNINST_SUFFIX =
+    "ROCPROFSYS_SAMPLING_KEEP_DYNINST_SUFFIX";
+constexpr std::string_view SAMPLING_KEEP_INTERNAL = "ROCPROFSYS_SAMPLING_KEEP_INTERNAL";
 
 // --- Sampling: cputime timer ---
-constexpr std::string_view SAMPLING_CPUTIME       = "ROCPROFSYS_SAMPLING_CPUTIME";
-constexpr std::string_view SAMPLING_CPUTIME_FREQ  = "ROCPROFSYS_SAMPLING_CPUTIME_FREQ";
-constexpr std::string_view SAMPLING_CPUTIME_DELAY = "ROCPROFSYS_SAMPLING_CPUTIME_DELAY";
-constexpr std::string_view SAMPLING_CPUTIME_TIDS  = "ROCPROFSYS_SAMPLING_CPUTIME_TIDS";
+constexpr std::string_view SAMPLING_CPUTIME        = "ROCPROFSYS_SAMPLING_CPUTIME";
+constexpr std::string_view SAMPLING_CPUTIME_FREQ   = "ROCPROFSYS_SAMPLING_CPUTIME_FREQ";
+constexpr std::string_view SAMPLING_CPUTIME_DELAY  = "ROCPROFSYS_SAMPLING_CPUTIME_DELAY";
+constexpr std::string_view SAMPLING_CPUTIME_TIDS   = "ROCPROFSYS_SAMPLING_CPUTIME_TIDS";
+constexpr std::string_view SAMPLING_CPUTIME_SIGNAL = "ROCPROFSYS_SAMPLING_CPUTIME_SIGNAL";
 
 // --- Sampling: realtime timer ---
 constexpr std::string_view SAMPLING_REALTIME       = "ROCPROFSYS_SAMPLING_REALTIME";
 constexpr std::string_view SAMPLING_REALTIME_FREQ  = "ROCPROFSYS_SAMPLING_REALTIME_FREQ";
 constexpr std::string_view SAMPLING_REALTIME_DELAY = "ROCPROFSYS_SAMPLING_REALTIME_DELAY";
 constexpr std::string_view SAMPLING_REALTIME_TIDS  = "ROCPROFSYS_SAMPLING_REALTIME_TIDS";
+constexpr std::string_view SAMPLING_REALTIME_SIGNAL =
+    "ROCPROFSYS_SAMPLING_REALTIME_SIGNAL";
+
+// --- Sampling: overflow (PAPI event-based) ---
+constexpr std::string_view SAMPLING_OVERFLOW      = "ROCPROFSYS_SAMPLING_OVERFLOW";
+constexpr std::string_view SAMPLING_OVERFLOW_FREQ = "ROCPROFSYS_SAMPLING_OVERFLOW_FREQ";
+constexpr std::string_view SAMPLING_OVERFLOW_TIDS = "ROCPROFSYS_SAMPLING_OVERFLOW_TIDS";
+constexpr std::string_view SAMPLING_OVERFLOW_SIGNAL =
+    "ROCPROFSYS_SAMPLING_OVERFLOW_SIGNAL";
 
 // --- Domains: GPU (AMD SMI) ---
 constexpr std::string_view USE_AMD_SMI          = "ROCPROFSYS_USE_AMD_SMI";
 constexpr std::string_view USE_PROCESS_SAMPLING = "ROCPROFSYS_USE_PROCESS_SAMPLING";
 constexpr std::string_view AMD_SMI_METRICS      = "ROCPROFSYS_AMD_SMI_METRICS";
 constexpr std::string_view AMD_SMI_FREQ         = "ROCPROFSYS_AMD_SMI_FREQ";
+constexpr std::string_view AMD_SMI_DEVICES      = "ROCPROFSYS_AMD_SMI_DEVICES";
 
 // --- Domains: ROCm ---
 constexpr std::string_view ROCM_DOMAINS        = "ROCPROFSYS_ROCM_DOMAINS";
@@ -82,6 +117,7 @@ constexpr std::string_view CPU_FREQ_ENABLED = "ROCPROFSYS_CPU_FREQ_ENABLED";
 constexpr std::string_view CPU_METRICS      = "ROCPROFSYS_CPU_METRICS";
 
 // --- Domains: Parallel runtimes ---
+constexpr std::string_view USE_MPI     = "ROCPROFSYS_USE_MPI";
 constexpr std::string_view USE_MPIP    = "ROCPROFSYS_USE_MPIP";
 constexpr std::string_view USE_OMPT    = "ROCPROFSYS_USE_OMPT";
 constexpr std::string_view USE_KOKKOSP = "ROCPROFSYS_USE_KOKKOSP";
@@ -90,21 +126,46 @@ constexpr std::string_view USE_AINIC   = "ROCPROFSYS_USE_AINIC";
 constexpr std::string_view USE_SHMEM   = "ROCPROFSYS_USE_SHMEM";
 constexpr std::string_view USE_UCX     = "ROCPROFSYS_USE_UCX";
 
+// --- Domains: Shmem ---
+constexpr std::string_view SHMEM_PERMIT_LIST = "ROCPROFSYS_SHMEM_PERMIT_LIST";
+constexpr std::string_view SHMEM_REJECT_LIST = "ROCPROFSYS_SHMEM_REJECT_LIST";
+
 // --- Output ---
-constexpr std::string_view OUTPUT_PATH   = "ROCPROFSYS_OUTPUT_PATH";
-constexpr std::string_view OUTPUT_PREFIX = "ROCPROFSYS_OUTPUT_PREFIX";
-constexpr std::string_view USE_PID       = "ROCPROFSYS_USE_PID";
-constexpr std::string_view TIME_OUTPUT   = "ROCPROFSYS_TIME_OUTPUT";
-constexpr std::string_view FILE_OUTPUT   = "ROCPROFSYS_FILE_OUTPUT";
-constexpr std::string_view TEXT_OUTPUT   = "ROCPROFSYS_TEXT_OUTPUT";
-constexpr std::string_view JSON_OUTPUT   = "ROCPROFSYS_JSON_OUTPUT";
-constexpr std::string_view COUT_OUTPUT   = "ROCPROFSYS_COUT_OUTPUT";
-constexpr std::string_view DIFF_OUTPUT   = "ROCPROFSYS_DIFF_OUTPUT";
-constexpr std::string_view INPUT_PATH    = "ROCPROFSYS_INPUT_PATH";
-constexpr std::string_view INPUT_PREFIX  = "ROCPROFSYS_INPUT_PREFIX";
-constexpr std::string_view USE_ROCPD     = "ROCPROFSYS_USE_ROCPD";
+constexpr std::string_view OUTPUT_PATH             = "ROCPROFSYS_OUTPUT_PATH";
+constexpr std::string_view OUTPUT_PREFIX           = "ROCPROFSYS_OUTPUT_PREFIX";
+constexpr std::string_view OUTPUT                  = "ROCPROFSYS_OUTPUT";
+constexpr std::string_view OUTPUT_FILE             = "ROCPROFSYS_OUTPUT_FILE";
+constexpr std::string_view OUTPUT_USE_CURRENT_TIME = "ROCPROFSYS_OUTPUT_USE_CURRENT_TIME";
+constexpr std::string_view USE_PID                 = "ROCPROFSYS_USE_PID";
+constexpr std::string_view TIME_OUTPUT             = "ROCPROFSYS_TIME_OUTPUT";
+constexpr std::string_view FILE_OUTPUT             = "ROCPROFSYS_FILE_OUTPUT";
+constexpr std::string_view TEXT_OUTPUT             = "ROCPROFSYS_TEXT_OUTPUT";
+constexpr std::string_view JSON_OUTPUT             = "ROCPROFSYS_JSON_OUTPUT";
+constexpr std::string_view COUT_OUTPUT             = "ROCPROFSYS_COUT_OUTPUT";
+constexpr std::string_view DIFF_OUTPUT             = "ROCPROFSYS_DIFF_OUTPUT";
+constexpr std::string_view TREE_OUTPUT             = "ROCPROFSYS_TREE_OUTPUT";
+constexpr std::string_view INPUT_PATH              = "ROCPROFSYS_INPUT_PATH";
+constexpr std::string_view INPUT_PREFIX            = "ROCPROFSYS_INPUT_PREFIX";
+constexpr std::string_view INPUT_EXTENSIONS        = "ROCPROFSYS_INPUT_EXTENSIONS";
+constexpr std::string_view USE_ROCPD               = "ROCPROFSYS_USE_ROCPD";
+constexpr std::string_view USE_TEMPORARY_FILES     = "ROCPROFSYS_USE_TEMPORARY_FILES";
 constexpr std::string_view USE_UNIFIED_MEMORY_PROFILING =
     "ROCPROFSYS_USE_UNIFIED_MEMORY_PROFILING";
+constexpr std::string_view TIME_FORMAT = "ROCPROFSYS_TIME_FORMAT";
+
+// --- Output: number formatting ---
+constexpr std::string_view PRECISION         = "ROCPROFSYS_PRECISION";
+constexpr std::string_view SCIENTIFIC        = "ROCPROFSYS_SCIENTIFIC";
+constexpr std::string_view WIDTH             = "ROCPROFSYS_WIDTH";
+constexpr std::string_view MAX_WIDTH         = "ROCPROFSYS_MAX_WIDTH";
+constexpr std::string_view TIMING_PRECISION  = "ROCPROFSYS_TIMING_PRECISION";
+constexpr std::string_view TIMING_SCIENTIFIC = "ROCPROFSYS_TIMING_SCIENTIFIC";
+constexpr std::string_view TIMING_UNITS      = "ROCPROFSYS_TIMING_UNITS";
+constexpr std::string_view TIMING_WIDTH      = "ROCPROFSYS_TIMING_WIDTH";
+constexpr std::string_view MEMORY_PRECISION  = "ROCPROFSYS_MEMORY_PRECISION";
+constexpr std::string_view MEMORY_SCIENTIFIC = "ROCPROFSYS_MEMORY_SCIENTIFIC";
+constexpr std::string_view MEMORY_UNITS      = "ROCPROFSYS_MEMORY_UNITS";
+constexpr std::string_view MEMORY_WIDTH      = "ROCPROFSYS_MEMORY_WIDTH";
 
 // --- Process sampling ---
 constexpr std::string_view PROCESS_SAMPLING_FREQ  = "ROCPROFSYS_PROCESS_SAMPLING_FREQ";
@@ -124,17 +185,110 @@ constexpr std::string_view CAUSAL_BINARY_SCOPE     = "ROCPROFSYS_CAUSAL_BINARY_S
 constexpr std::string_view CAUSAL_BINARY_EXCLUDE   = "ROCPROFSYS_CAUSAL_BINARY_EXCLUDE";
 constexpr std::string_view CAUSAL_FUNCTION_SCOPE   = "ROCPROFSYS_CAUSAL_FUNCTION_SCOPE";
 constexpr std::string_view CAUSAL_FUNCTION_EXCLUDE = "ROCPROFSYS_CAUSAL_FUNCTION_EXCLUDE";
-constexpr std::string_view CAUSAL_SOURCE_SCOPE     = "ROCPROFSYS_CAUSAL_SOURCE_SCOPE";
-constexpr std::string_view CAUSAL_SOURCE_EXCLUDE   = "ROCPROFSYS_CAUSAL_SOURCE_EXCLUDE";
-constexpr std::string_view CAUSAL_END_TO_END       = "ROCPROFSYS_CAUSAL_END_TO_END";
-constexpr std::string_view CAUSAL_DELAY            = "ROCPROFSYS_CAUSAL_DELAY";
-constexpr std::string_view CAUSAL_DURATION         = "ROCPROFSYS_CAUSAL_DURATION";
-constexpr std::string_view CAUSAL_RANDOM_SEED      = "ROCPROFSYS_CAUSAL_RANDOM_SEED";
+constexpr std::string_view CAUSAL_FUNCTION_EXCLUDE_DEFAULTS =
+    "ROCPROFSYS_CAUSAL_FUNCTION_EXCLUDE_DEFAULTS";
+constexpr std::string_view CAUSAL_SOURCE_SCOPE   = "ROCPROFSYS_CAUSAL_SOURCE_SCOPE";
+constexpr std::string_view CAUSAL_SOURCE_EXCLUDE = "ROCPROFSYS_CAUSAL_SOURCE_EXCLUDE";
+constexpr std::string_view CAUSAL_END_TO_END     = "ROCPROFSYS_CAUSAL_END_TO_END";
+constexpr std::string_view CAUSAL_DELAY          = "ROCPROFSYS_CAUSAL_DELAY";
+constexpr std::string_view CAUSAL_DURATION       = "ROCPROFSYS_CAUSAL_DURATION";
+constexpr std::string_view CAUSAL_RANDOM_SEED    = "ROCPROFSYS_CAUSAL_RANDOM_SEED";
+constexpr std::string_view CAUSAL_FIXED_SPEEDUP  = "ROCPROFSYS_CAUSAL_FIXED_SPEEDUP";
+constexpr std::string_view CAUSAL_SPEEDUP_DIVISIONS =
+    "ROCPROFSYS_CAUSAL_SPEEDUP_DIVISIONS";
+constexpr std::string_view CAUSAL_SCALE_EXPERIMENT_TIME_BY_SPEEDUP =
+    "ROCPROFSYS_CAUSAL_SCALE_EXPERIMENT_TIME_BY_SPEEDUP";
+constexpr std::string_view CAUSAL_FILE       = "ROCPROFSYS_CAUSAL_FILE";
+constexpr std::string_view CAUSAL_FILE_RESET = "ROCPROFSYS_CAUSAL_FILE_RESET";
 
 // --- Hardware counters ---
-constexpr std::string_view ROCM_EVENTS       = "ROCPROFSYS_ROCM_EVENTS";
-constexpr std::string_view PAPI_EVENTS       = "ROCPROFSYS_PAPI_EVENTS";
-constexpr std::string_view PAPI_MULTIPLEXING = "ROCPROFSYS_PAPI_MULTIPLEXING";
+// Note: PAPI_MULTIPLEXING and PAPI_QUIET would collide with integer macros defined in
+// PAPI's C header (papi.h). The identifiers carry a trailing suffix to avoid
+// preprocessor substitution; the env-var strings retain the original names.
+constexpr std::string_view ROCM_EVENTS               = "ROCPROFSYS_ROCM_EVENTS";
+constexpr std::string_view PAPI_EVENTS               = "ROCPROFSYS_PAPI_EVENTS";
+constexpr std::string_view PAPI_MULTIPLEXING_ENABLED = "ROCPROFSYS_PAPI_MULTIPLEXING";
+constexpr std::string_view PAPI_FAIL_ON_ERROR        = "ROCPROFSYS_PAPI_FAIL_ON_ERROR";
+constexpr std::string_view PAPI_OVERFLOW             = "ROCPROFSYS_PAPI_OVERFLOW";
+constexpr std::string_view PAPI_QUIET_MODE           = "ROCPROFSYS_PAPI_QUIET";
+constexpr std::string_view PAPI_THREADING            = "ROCPROFSYS_PAPI_THREADING";
+constexpr std::string_view USE_CODE_COVERAGE         = "ROCPROFSYS_USE_CODE_COVERAGE";
+
+// --- MPI ---
+constexpr std::string_view MPI_INIT             = "ROCPROFSYS_MPI_INIT";
+constexpr std::string_view MPI_FINALIZE         = "ROCPROFSYS_MPI_FINALIZE";
+constexpr std::string_view MPI_FAIL_ON_ERROR    = "ROCPROFSYS_MPI_FAIL_ON_ERROR";
+constexpr std::string_view MPI_QUIET            = "ROCPROFSYS_MPI_QUIET";
+constexpr std::string_view MPI_THREAD           = "ROCPROFSYS_MPI_THREAD";
+constexpr std::string_view MPI_THREAD_TYPE      = "ROCPROFSYS_MPI_THREAD_TYPE";
+constexpr std::string_view MPI_MAX_COMM_UPDATES = "ROCPROFSYS_MPI_MAX_COMM_UPDATES";
+
+// --- Kokkos profiling ---
+constexpr std::string_view KOKKOSP_PREFIX          = "ROCPROFSYS_KOKKOSP_PREFIX";
+constexpr std::string_view KOKKOSP_KERNEL_LOGGER   = "ROCPROFSYS_KOKKOSP_KERNEL_LOGGER";
+constexpr std::string_view KOKKOSP_NAME_LENGTH_MAX = "ROCPROFSYS_KOKKOSP_NAME_LENGTH_MAX";
+constexpr std::string_view KOKKOSP_DEEP_COPY       = "ROCPROFSYS_KOKKOSP_DEEP_COPY";
+
+// --- DL (dynamic loader / preload) ---
+constexpr std::string_view DL_VERBOSE = "ROCPROFSYS_DL_VERBOSE";
+constexpr std::string_view DL_DEBUG   = "ROCPROFSYS_DL_DEBUG";
+constexpr std::string_view DL_LIBRARY = "ROCPROFSYS_DL_LIBRARY";
+
+// --- Regex include/exclude filters ---
+constexpr std::string_view REGEX_INCLUDE          = "ROCPROFSYS_REGEX_INCLUDE";
+constexpr std::string_view REGEX_EXCLUDE          = "ROCPROFSYS_REGEX_EXCLUDE";
+constexpr std::string_view REGEX_RESTRICT         = "ROCPROFSYS_REGEX_RESTRICT";
+constexpr std::string_view REGEX_CALLER_INCLUDE   = "ROCPROFSYS_REGEX_CALLER_INCLUDE";
+constexpr std::string_view REGEX_INTERNAL_INCLUDE = "ROCPROFSYS_REGEX_INTERNAL_INCLUDE";
+constexpr std::string_view REGEX_INSTRUCTION_EXCLUDE =
+    "ROCPROFSYS_REGEX_INSTRUCTION_EXCLUDE";
+constexpr std::string_view REGEX_MODULE_INCLUDE  = "ROCPROFSYS_REGEX_MODULE_INCLUDE";
+constexpr std::string_view REGEX_MODULE_EXCLUDE  = "ROCPROFSYS_REGEX_MODULE_EXCLUDE";
+constexpr std::string_view REGEX_MODULE_RESTRICT = "ROCPROFSYS_REGEX_MODULE_RESTRICT";
+constexpr std::string_view REGEX_MODULE_INTERNAL_INCLUDE =
+    "ROCPROFSYS_REGEX_MODULE_INTERNAL_INCLUDE";
+
+// --- CI / continuous integration ---
+constexpr std::string_view CI                     = "ROCPROFSYS_CI";
+constexpr std::string_view CI_SKIP_PUSH_POP_CHECK = "ROCPROFSYS_CI_SKIP_PUSH_POP_CHECK";
+constexpr std::string_view CI_TIMEOUT             = "ROCPROFSYS_CI_TIMEOUT";
+constexpr std::string_view CI_TIMEOUT_COUNT       = "ROCPROFSYS_CI_TIMEOUT_COUNT";
+constexpr std::string_view CI_TIMEOUT_OVERRIDE    = "ROCPROFSYS_CI_TIMEOUT_OVERRIDE";
+
+// --- Process / threading / behavior ---
+constexpr std::string_view NUM_THREADS             = "ROCPROFSYS_NUM_THREADS";
+constexpr std::string_view NUM_THREADS_HINT        = "ROCPROFSYS_NUM_THREADS_HINT";
+constexpr std::string_view THREAD_POOL_SIZE        = "ROCPROFSYS_THREAD_POOL_SIZE";
+constexpr std::string_view RECYCLE_TIDS            = "ROCPROFSYS_RECYCLE_TIDS";
+constexpr std::string_view KILL_DELAY              = "ROCPROFSYS_KILL_DELAY";
+constexpr std::string_view COLLAPSE_PROCESSES      = "ROCPROFSYS_COLLAPSE_PROCESSES";
+constexpr std::string_view NODE_COUNT              = "ROCPROFSYS_NODE_COUNT";
+constexpr std::string_view ROOT_PROCESS            = "ROCPROFSYS_ROOT_PROCESS";
+constexpr std::string_view RANK_FILTER_ID          = "ROCPROFSYS_RANK_FILTER_ID";
+constexpr std::string_view RANK_FILTER_OUTPUT      = "ROCPROFSYS_RANK_FILTER_OUTPUT";
+constexpr std::string_view REATTACH_ADD_SESSION_ID = "ROCPROFSYS_REATTACH_ADD_SESSION_ID";
+
+// --- Instrumentation ---
+constexpr std::string_view INSTRUMENT_MODE = "ROCPROFSYS_INSTRUMENT_MODE";
+constexpr std::string_view IGNORE_DYNINST_TRAMPOLINE =
+    "ROCPROFSYS_IGNORE_DYNINST_TRAMPOLINE";
+constexpr std::string_view DEFAULT_MIN_INSTRUCTIONS =
+    "ROCPROFSYS_DEFAULT_MIN_INSTRUCTIONS";
+
+// --- Runtime / launcher (set by instrumenter / read by the loaded library) ---
+constexpr std::string_view PATH                   = "ROCPROFSYS_PATH";
+constexpr std::string_view PRELOAD                = "ROCPROFSYS_PRELOAD";
+constexpr std::string_view LIBRARY                = "ROCPROFSYS_LIBRARY";
+constexpr std::string_view USER_LIBRARY           = "ROCPROFSYS_USER_LIBRARY";
+constexpr std::string_view COMMAND_LINE           = "ROCPROFSYS_COMMAND_LINE";
+constexpr std::string_view LAUNCHER               = "ROCPROFSYS_LAUNCHER";
+constexpr std::string_view SCRIPT_DIR             = "ROCPROFSYS_SCRIPT_DIR";
+constexpr std::string_view ROCM_PATH              = "ROCPROFSYS_ROCM_PATH";
+constexpr std::string_view CONFIG                 = "ROCPROFSYS_CONFIG";
+constexpr std::string_view ENVIRONMENT            = "ROCPROFSYS_ENVIRONMENT";
+constexpr std::string_view SETTINGS_DESC          = "ROCPROFSYS_SETTINGS_DESC";
+constexpr std::string_view SETTINGS_DESC_MARKDOWN = "ROCPROFSYS_SETTINGS_DESC_MARKDOWN";
+constexpr std::string_view CRAYPAT                = "ROCPROFSYS_CRAYPAT";
 
 // --- Advanced ---
 constexpr std::string_view CPU_AFFINITY          = "ROCPROFSYS_CPU_AFFINITY";
@@ -145,11 +299,34 @@ constexpr std::string_view TRACE_DURATION        = "ROCPROFSYS_TRACE_DURATION";
 constexpr std::string_view TRACE_PERIODS         = "ROCPROFSYS_TRACE_PERIODS";
 constexpr std::string_view TRACE_PERIOD_CLOCK_ID = "ROCPROFSYS_TRACE_PERIOD_CLOCK_ID";
 constexpr std::string_view VERBOSE               = "ROCPROFSYS_VERBOSE";
-constexpr std::string_view DEBUG                 = "ROCPROFSYS_DEBUG";
+constexpr std::string_view VERBOSE_AVAIL         = "ROCPROFSYS_VERBOSE_AVAIL";
+constexpr std::string_view VERBOSE_INSTRUMENT    = "ROCPROFSYS_VERBOSE_INSTRUMENT";
+// Note: identifier is DEBUG_MODE to avoid collision with `#define DEBUG 1` injected by
+// the project's generated common/defines.h on CI builds (ROCPROFSYS_CI > 0). The
+// env-var string itself remains "ROCPROFSYS_DEBUG".
+constexpr std::string_view DEBUG_MODE = "ROCPROFSYS_DEBUG";
 // well above the highest verbose threshold (3) so debug mode enables all verbose output
-constexpr int              DEBUG_VERBOSE_BOOST = 8;
-constexpr std::string_view TIMEMORY_COMPONENTS = "ROCPROFSYS_TIMEMORY_COMPONENTS";
-constexpr std::string_view NETWORK_INTERFACE   = "ROCPROFSYS_NETWORK_INTERFACE";
+constexpr int              DEBUG_VERBOSE_BOOST   = 8;
+constexpr std::string_view DEBUG_INIT            = "ROCPROFSYS_DEBUG_INIT";
+constexpr std::string_view DEBUG_FINALIZE        = "ROCPROFSYS_DEBUG_FINALIZE";
+constexpr std::string_view DEBUG_AVAIL           = "ROCPROFSYS_DEBUG_AVAIL";
+constexpr std::string_view DEBUG_MARK            = "ROCPROFSYS_DEBUG_MARK";
+constexpr std::string_view DEBUG_PIDS            = "ROCPROFSYS_DEBUG_PIDS";
+constexpr std::string_view DEBUG_TIDS            = "ROCPROFSYS_DEBUG_TIDS";
+constexpr std::string_view DEBUG_PUSH            = "ROCPROFSYS_DEBUG_PUSH";
+constexpr std::string_view DEBUG_POP             = "ROCPROFSYS_DEBUG_POP";
+constexpr std::string_view DEBUG_SAMPLING        = "ROCPROFSYS_DEBUG_SAMPLING";
+constexpr std::string_view DEBUG_USER_REGIONS    = "ROCPROFSYS_DEBUG_USER_REGIONS";
+constexpr std::string_view ENABLE_SIGNAL_HANDLER = "ROCPROFSYS_ENABLE_SIGNAL_HANDLER";
+constexpr std::string_view TIMEMORY_COMPONENTS   = "ROCPROFSYS_TIMEMORY_COMPONENTS";
+constexpr std::string_view NETWORK_INTERFACE     = "ROCPROFSYS_NETWORK_INTERFACE";
+
+// --- Deprecated aliases ---
+// Names retained only for legacy/migration paths — the codebase emits deprecation
+// warnings when these are encountered. Do not introduce new references; prefer the
+// replacement (TRACE for USE_PERFETTO, PROFILE for USE_TIMEMORY).
+constexpr std::string_view USE_PERFETTO = "ROCPROFSYS_USE_PERFETTO";
+constexpr std::string_view USE_TIMEMORY = "ROCPROFSYS_USE_TIMEMORY";
 
 [[nodiscard]] inline int
 log_level_to_verbose(std::string_view level) noexcept

--- a/projects/rocprofiler-systems/source/lib/common/environment.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/environment.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "common/defines.h"
+#include "common/env_vars.hpp"
 #include "common/join.hpp"
 #include "logger/debug.hpp"
 
@@ -800,8 +801,8 @@ consolidate_env_entries(std::vector<std::string>& envp)
     /// - ROCPROFSYS_SAMPLING_OVERFLOW_EVENT: uses perf::EVENT_NAME syntax
     /// - ROCPROFSYS_ROCM_EVENTS: uses EVENT_NAME:device=N syntax
     auto get_delimiter = [](std::string_view key) -> char {
-        if(key == "ROCPROFSYS_PAPI_EVENTS" ||
-           key == "ROCPROFSYS_SAMPLING_OVERFLOW_EVENT" || key == "ROCPROFSYS_ROCM_EVENTS")
+        if(key == env_vars::PAPI_EVENTS || key == env_vars::SAMPLING_OVERFLOW_EVENT ||
+           key == env_vars::ROCM_EVENTS)
             return ',';
         return ':';
     };

--- a/projects/rocprofiler-systems/source/lib/common/environment.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/environment.hpp
@@ -247,16 +247,6 @@ public:
         }
     }
 
-    /// @brief std::string_view / std::string overload of @ref get_env: materialises
-    ///        a null-terminated copy of @p env_id once, then dispatches to the
-    ///        const char* overload.
-    template <typename Tp>
-    static auto get_env(std::string_view env_id, Tp&& value_default)
-    {
-        const std::string name{ env_id };
-        return get_env(name.c_str(), std::forward<Tp>(value_default));
-    }
-
     /// @brief Read environment variable @p env_id as @p Tp, using a
     ///        value-initialised @c Tp{} as the fallback.
     /// @tparam Tp Target type (defaults to std::string).
@@ -264,14 +254,6 @@ public:
     /// @return The parsed value, or @c Tp{} when the variable is unset.
     template <typename Tp = std::string>
     static auto get_env(const char* env_id)
-    {
-        return get_env(env_id, Tp{});
-    }
-
-    /// @brief std::string_view / std::string overload of the single-argument
-    ///        @ref get_env.
-    template <typename Tp = std::string>
-    static auto get_env(std::string_view env_id)
     {
         return get_env(env_id, Tp{});
     }
@@ -289,14 +271,6 @@ public:
         std::stringstream ss_val;
         ss_val << value;
         EnvType::setenv(env_var, ss_val.str().c_str(), override);
-    }
-
-    /// @brief std::string_view / std::string overload of @ref set_env.
-    template <typename Tp>
-    static void set_env(std::string_view env_var, const Tp& value, int override)
-    {
-        const std::string name{ env_var };
-        set_env(name.c_str(), value, override);
     }
 
     /// @brief Read environment variable @p env_id constrained to a set of allowed
@@ -322,15 +296,6 @@ public:
             return value_default;
         }
         return value;
-    }
-
-    /// @brief std::string_view / std::string overload of @ref get_env_choice.
-    template <typename Tp>
-    static auto get_env_choice(std::string_view env_id, Tp value_default,
-                               std::set<Tp> choices)
-    {
-        const std::string name{ env_id };
-        return get_env_choice(name.c_str(), std::move(value_default), std::move(choices));
     }
 };
 
@@ -370,14 +335,6 @@ get_env(const char* env_id, Tp&& value_default)
     return environment<>::get_env(env_id, std::forward<Tp>(value_default));
 }
 
-/// @brief std::string_view / std::string overload of @ref get_env.
-template <typename Tp>
-inline auto
-get_env(std::string_view env_id, Tp&& value_default)
-{
-    return environment<>::get_env(env_id, std::forward<Tp>(value_default));
-}
-
 /// @brief Read environment variable @p env_id as @p Tp, falling back to @c Tp{}.
 /// @tparam Tp Target type (defaults to std::string).
 /// @param env_id Null-terminated variable name.
@@ -385,15 +342,6 @@ get_env(std::string_view env_id, Tp&& value_default)
 template <typename Tp = std::string>
 inline auto
 get_env(const char* env_id)
-{
-    return environment<>::get_env<Tp>(env_id);
-}
-
-/// @brief std::string_view / std::string overload of the single-argument
-///        @ref get_env.
-template <typename Tp = std::string>
-inline auto
-get_env(std::string_view env_id)
 {
     return environment<>::get_env<Tp>(env_id);
 }
@@ -410,14 +358,6 @@ set_env(const char* env_var, const Tp& value, int override)
     environment<>::set_env(env_var, value, override);
 }
 
-/// @brief std::string_view / std::string overload of @ref set_env.
-template <typename Tp>
-inline void
-set_env(std::string_view env_var, const Tp& value, int override)
-{
-    environment<>::set_env(env_var, value, override);
-}
-
 /// @brief Read environment variable @p env_id constrained to @p value_choices,
 ///        returning @p value_default when unset or not allowed. Allocation-free
 ///        overload for null-terminated names.
@@ -428,15 +368,6 @@ set_env(std::string_view env_var, const Tp& value, int override)
 template <typename Tp>
 inline auto
 get_env_choice(const char* env_id, Tp value_default, std::set<Tp> value_choices)
-{
-    return environment<>::get_env_choice(env_id, std::move(value_default),
-                                         std::move(value_choices));
-}
-
-/// @brief std::string_view / std::string overload of @ref get_env_choice.
-template <typename Tp>
-inline auto
-get_env_choice(std::string_view env_id, Tp value_default, std::set<Tp> value_choices)
 {
     return environment<>::get_env_choice(env_id, std::move(value_default),
                                          std::move(value_choices));

--- a/projects/rocprofiler-systems/source/lib/common/environment.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/environment.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "common/defines.h"
+#include "common/env_vars.hpp"
 #include <cstdint>
 
 #include "common/join.hpp"
@@ -478,8 +479,8 @@ consolidate_env_entries(std::vector<std::string>& envp)
     /// - ROCPROFSYS_SAMPLING_OVERFLOW_EVENT: uses perf::EVENT_NAME syntax
     /// - ROCPROFSYS_ROCM_EVENTS: uses EVENT_NAME:device=N syntax
     auto get_delimiter = [](std::string_view key) -> char {
-        if(key == "ROCPROFSYS_PAPI_EVENTS" ||
-           key == "ROCPROFSYS_SAMPLING_OVERFLOW_EVENT" || key == "ROCPROFSYS_ROCM_EVENTS")
+        if(key == env_vars::PAPI_EVENTS || key == env_vars::SAMPLING_OVERFLOW_EVENT ||
+           key == env_vars::ROCM_EVENTS)
             return ',';
         return ':';
     };

--- a/projects/rocprofiler-systems/source/lib/common/path.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/path.hpp
@@ -5,6 +5,7 @@
 
 #include "common/defines.h"
 #include "common/delimit.hpp"
+#include "common/env_vars.hpp"
 #include "common/environment.hpp"
 #include "common/join.hpp"
 
@@ -175,9 +176,8 @@ template <typename RetT>
 RetT
 get_default_lib_search_paths()
 {
-    auto _paths =
-        join(":", get_env("ROCPROFSYS_PATH", ""), get_env("LD_LIBRARY_PATH", ""),
-             get_env("LIBRARY_PATH", ""), get_env("PWD", ""), ".");
+    auto _paths = join(":", get_env(env_vars::PATH, ""), get_env("LD_LIBRARY_PATH", ""),
+                       get_env("LIBRARY_PATH", ""), get_env("PWD", ""), ".");
     if constexpr(std::is_same<RetT, std::string>::value)
         return _paths;
     else

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_environment.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_environment.cpp
@@ -9,6 +9,7 @@
 #include <unordered_map>
 
 using namespace rocprofsys::common;
+namespace env_vars = rocprofsys::env_vars;
 
 // ── fake_env ─────────────────────────────────────────────────────────────────
 // In-memory environment backend for unit tests.
@@ -108,62 +109,65 @@ TEST_F(DuplicatedEnvironmentEntriesTest, HandlesEmptyValues)
 TEST_F(DuplicatedEnvironmentEntriesTest, PapiEventsUsesCommaDelimiter)
 {
     std::vector<std::string> env_vars = {
-        "ROCPROFSYS_PAPI_EVENTS=perf::INSTRUCTIONS",
-        "ROCPROFSYS_PAPI_EVENTS=perf::CACHE_MISSES",
+        std::string{ env_vars::PAPI_EVENTS } + "=perf::INSTRUCTIONS",
+        std::string{ env_vars::PAPI_EVENTS } + "=perf::CACHE_MISSES",
     };
     consolidate_env_entries(env_vars);
     ASSERT_EQ(env_vars.size(), 1);
-    EXPECT_EQ(env_vars[0],
-              "ROCPROFSYS_PAPI_EVENTS=perf::INSTRUCTIONS,perf::CACHE_MISSES");
+    EXPECT_EQ(env_vars[0], std::string{ env_vars::PAPI_EVENTS } +
+                               "=perf::INSTRUCTIONS,perf::CACHE_MISSES");
 }
 
 TEST_F(DuplicatedEnvironmentEntriesTest, PapiEventsPreservesColonInValue)
 {
     std::vector<std::string> env_vars = {
-        "ROCPROFSYS_PAPI_EVENTS=perf::PERF_COUNT_SW_CPU_CLOCK",
+        std::string{ env_vars::PAPI_EVENTS } + "=perf::PERF_COUNT_SW_CPU_CLOCK",
     };
     consolidate_env_entries(env_vars);
     ASSERT_EQ(env_vars.size(), 1);
-    EXPECT_EQ(env_vars[0], "ROCPROFSYS_PAPI_EVENTS=perf::PERF_COUNT_SW_CPU_CLOCK");
+    EXPECT_EQ(env_vars[0],
+              std::string{ env_vars::PAPI_EVENTS } + "=perf::PERF_COUNT_SW_CPU_CLOCK");
 }
 
 TEST_F(DuplicatedEnvironmentEntriesTest, PapiEventsDeduplicates)
 {
     std::vector<std::string> env_vars = {
-        "ROCPROFSYS_PAPI_EVENTS=perf::INSTRUCTIONS",
-        "ROCPROFSYS_PAPI_EVENTS=perf::CACHE_MISSES",
-        "ROCPROFSYS_PAPI_EVENTS=perf::INSTRUCTIONS",
+        std::string{ env_vars::PAPI_EVENTS } + "=perf::INSTRUCTIONS",
+        std::string{ env_vars::PAPI_EVENTS } + "=perf::CACHE_MISSES",
+        std::string{ env_vars::PAPI_EVENTS } + "=perf::INSTRUCTIONS",
     };
     consolidate_env_entries(env_vars);
     ASSERT_EQ(env_vars.size(), 1);
-    EXPECT_EQ(env_vars[0],
-              "ROCPROFSYS_PAPI_EVENTS=perf::INSTRUCTIONS,perf::CACHE_MISSES");
+    EXPECT_EQ(env_vars[0], std::string{ env_vars::PAPI_EVENTS } +
+                               "=perf::INSTRUCTIONS,perf::CACHE_MISSES");
 }
 
 TEST_F(DuplicatedEnvironmentEntriesTest, SamplingOverflowEventUsesCommaDelimiter)
 {
     std::vector<std::string> env_vars = {
-        "ROCPROFSYS_SAMPLING_OVERFLOW_EVENT=perf::INSTRUCTIONS",
-        "ROCPROFSYS_SAMPLING_OVERFLOW_EVENT=perf::CYCLES",
+        std::string{ env_vars::SAMPLING_OVERFLOW_EVENT } + "=perf::INSTRUCTIONS",
+        std::string{ env_vars::SAMPLING_OVERFLOW_EVENT } + "=perf::CYCLES",
     };
     consolidate_env_entries(env_vars);
     ASSERT_EQ(env_vars.size(), 1);
-    EXPECT_EQ(env_vars[0],
-              "ROCPROFSYS_SAMPLING_OVERFLOW_EVENT=perf::INSTRUCTIONS,perf::CYCLES");
+    EXPECT_EQ(env_vars[0], std::string{ env_vars::SAMPLING_OVERFLOW_EVENT } +
+                               "=perf::INSTRUCTIONS,perf::CYCLES");
 }
 
 TEST_F(DuplicatedEnvironmentEntriesTest, MixedDelimiterVariables)
 {
     std::vector<std::string> env_vars = {
-        "PATH=/usr/bin",        "ROCPROFSYS_PAPI_EVENTS=perf::INSTRUCTIONS",
-        "PATH=/usr/local/bin",  "ROCPROFSYS_PAPI_EVENTS=perf::CACHE_MISSES",
+        "PATH=/usr/bin",
+        std::string{ env_vars::PAPI_EVENTS } + "=perf::INSTRUCTIONS",
+        "PATH=/usr/local/bin",
+        std::string{ env_vars::PAPI_EVENTS } + "=perf::CACHE_MISSES",
         "LD_LIBRARY_PATH=/lib",
     };
     consolidate_env_entries(env_vars);
     ASSERT_EQ(env_vars.size(), 3);
     EXPECT_EQ(env_vars[0], "PATH=/usr/bin:/usr/local/bin");
-    EXPECT_EQ(env_vars[1],
-              "ROCPROFSYS_PAPI_EVENTS=perf::INSTRUCTIONS,perf::CACHE_MISSES");
+    EXPECT_EQ(env_vars[1], std::string{ env_vars::PAPI_EVENTS } +
+                               "=perf::INSTRUCTIONS,perf::CACHE_MISSES");
     EXPECT_EQ(env_vars[2], "LD_LIBRARY_PATH=/lib");
 }
 
@@ -184,38 +188,37 @@ TEST_F(DuplicatedEnvironmentEntriesTest, PreservesKeyOrder)
 TEST_F(DuplicatedEnvironmentEntriesTest, PapiEventsWithCommaInValue)
 {
     std::vector<std::string> env_vars = {
-        "ROCPROFSYS_PAPI_EVENTS=perf::INSTRUCTIONS,perf::CYCLES",
-        "ROCPROFSYS_PAPI_EVENTS=perf::CACHE_MISSES",
+        std::string{ env_vars::PAPI_EVENTS } + "=perf::INSTRUCTIONS,perf::CYCLES",
+        std::string{ env_vars::PAPI_EVENTS } + "=perf::CACHE_MISSES",
     };
     consolidate_env_entries(env_vars);
     ASSERT_EQ(env_vars.size(), 1);
-    EXPECT_EQ(
-        env_vars[0],
-        "ROCPROFSYS_PAPI_EVENTS=perf::INSTRUCTIONS,perf::CYCLES,perf::CACHE_MISSES");
+    EXPECT_EQ(env_vars[0], std::string{ env_vars::PAPI_EVENTS } +
+                               "=perf::INSTRUCTIONS,perf::CYCLES,perf::CACHE_MISSES");
 }
 
 TEST_F(DuplicatedEnvironmentEntriesTest, RocmEventsUsesCommaDelimiter)
 {
     std::vector<std::string> env_vars = {
-        "ROCPROFSYS_ROCM_EVENTS=SQ_WAVES:device=0",
-        "ROCPROFSYS_ROCM_EVENTS=TA_TA_BUSY:device=1",
+        std::string{ env_vars::ROCM_EVENTS } + "=SQ_WAVES:device=0",
+        std::string{ env_vars::ROCM_EVENTS } + "=TA_TA_BUSY:device=1",
     };
     consolidate_env_entries(env_vars);
     ASSERT_EQ(env_vars.size(), 1);
-    EXPECT_EQ(env_vars[0],
-              "ROCPROFSYS_ROCM_EVENTS=SQ_WAVES:device=0,TA_TA_BUSY:device=1");
+    EXPECT_EQ(env_vars[0], std::string{ env_vars::ROCM_EVENTS } +
+                               "=SQ_WAVES:device=0,TA_TA_BUSY:device=1");
 }
 
 TEST_F(DuplicatedEnvironmentEntriesTest, RocmEventsPreservesDeviceSyntax)
 {
     std::vector<std::string> env_vars = {
-        "ROCPROFSYS_ROCM_EVENTS=GRBM_COUNT,SQ_WAVES,SQ_INSTS_VALU,TA_TA_BUSY:device=0",
+        std::string{ env_vars::ROCM_EVENTS } +
+            "=GRBM_COUNT,SQ_WAVES,SQ_INSTS_VALU,TA_TA_BUSY:device=0",
     };
     consolidate_env_entries(env_vars);
     ASSERT_EQ(env_vars.size(), 1);
-    EXPECT_EQ(
-        env_vars[0],
-        "ROCPROFSYS_ROCM_EVENTS=GRBM_COUNT,SQ_WAVES,SQ_INSTS_VALU,TA_TA_BUSY:device=0");
+    EXPECT_EQ(env_vars[0], std::string{ env_vars::ROCM_EVENTS } +
+                               "=GRBM_COUNT,SQ_WAVES,SQ_INSTS_VALU,TA_TA_BUSY:device=0");
 }
 
 class AddTorchLibraryPathTest : public ::testing::Test

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_environment.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_environment.cpp
@@ -303,7 +303,7 @@ TEST(FreeFunctionEnvTest, GetEnvOneArgReturnsEmptyForUnsetVar)
 TEST(FreeFunctionEnvTest, SetEnvAndGetViaFreeFunction)
 {
     const char* name = "ROCPROFSYS_FREE_FUNC_SETENV_TEST_99887766";
-    set_env(std::string{ name }, std::string{ "free_val" }, 1);
+    set_env(name, std::string{ "free_val" }, 1);
     EXPECT_EQ(get_env(name, std::string{}), "free_val");
     ::unsetenv(name);
 }
@@ -335,21 +335,6 @@ TEST_F(FakeEnvGetEnvTest, StringReturnsValueWhenSet)
 {
     fake_env::setenv("FOO", "bar", 1);
     EXPECT_EQ(fake_environment::get_env("FOO", std::string{ "default" }), "bar");
-}
-
-TEST_F(FakeEnvGetEnvTest, StringViewEnvIdResolvesViaShim)
-{
-    // A non-null-terminated string_view name must still resolve correctly.
-    fake_env::setenv("FOO", "bar", 1);
-    const std::string_view name = std::string_view{ "FOOBAR" }.substr(0, 3);
-    EXPECT_EQ(fake_environment::get_env(name, std::string{ "default" }), "bar");
-}
-
-TEST_F(FakeEnvGetEnvTest, StdStringEnvIdResolvesViaShim)
-{
-    fake_env::setenv("FOO", "7", 1);
-    const std::string name{ "FOO" };
-    EXPECT_EQ(fake_environment::get_env(name, 42), 7);
 }
 
 TEST_F(FakeEnvGetEnvTest, IntReturnsDefaultWhenUnset)
@@ -437,14 +422,6 @@ TEST_F(FakeEnvSetEnvTest, OverrideOneOverwrites)
     fake_env::setenv("FOO", "original", 1);
     fake_environment::set_env("FOO", std::string{ "new" }, 1);
     EXPECT_EQ(fake_environment::get_env("FOO", std::string{}), "new");
-}
-
-TEST_F(FakeEnvSetEnvTest, StringViewEnvVarResolvesViaShim)
-{
-    // A non-null-terminated string_view name must be materialised before setenv.
-    const std::string_view name = std::string_view{ "FOOBAR" }.substr(0, 3);
-    fake_environment::set_env(name, std::string{ "baz" }, 1);
-    EXPECT_EQ(fake_environment::get_env("FOO", std::string{}), "baz");
 }
 
 class FakeEnvGetEnvChoiceTest : public ::testing::Test

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_environment.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_environment.cpp
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 
 using namespace rocprofsys::common;
+namespace env_vars = rocprofsys::env_vars;
 
 class IsPythonInterpreterTest : public ::testing::Test
 {};
@@ -79,62 +80,65 @@ TEST_F(DuplicatedEnvironmentEntriesTest, HandlesEmptyValues)
 TEST_F(DuplicatedEnvironmentEntriesTest, PapiEventsUsesCommaDelimiter)
 {
     std::vector<std::string> env_vars = {
-        "ROCPROFSYS_PAPI_EVENTS=perf::INSTRUCTIONS",
-        "ROCPROFSYS_PAPI_EVENTS=perf::CACHE_MISSES",
+        std::string{ env_vars::PAPI_EVENTS } + "=perf::INSTRUCTIONS",
+        std::string{ env_vars::PAPI_EVENTS } + "=perf::CACHE_MISSES",
     };
     consolidate_env_entries(env_vars);
     ASSERT_EQ(env_vars.size(), 1);
-    EXPECT_EQ(env_vars[0],
-              "ROCPROFSYS_PAPI_EVENTS=perf::INSTRUCTIONS,perf::CACHE_MISSES");
+    EXPECT_EQ(env_vars[0], std::string{ env_vars::PAPI_EVENTS } +
+                               "=perf::INSTRUCTIONS,perf::CACHE_MISSES");
 }
 
 TEST_F(DuplicatedEnvironmentEntriesTest, PapiEventsPreservesColonInValue)
 {
     std::vector<std::string> env_vars = {
-        "ROCPROFSYS_PAPI_EVENTS=perf::PERF_COUNT_SW_CPU_CLOCK",
+        std::string{ env_vars::PAPI_EVENTS } + "=perf::PERF_COUNT_SW_CPU_CLOCK",
     };
     consolidate_env_entries(env_vars);
     ASSERT_EQ(env_vars.size(), 1);
-    EXPECT_EQ(env_vars[0], "ROCPROFSYS_PAPI_EVENTS=perf::PERF_COUNT_SW_CPU_CLOCK");
+    EXPECT_EQ(env_vars[0],
+              std::string{ env_vars::PAPI_EVENTS } + "=perf::PERF_COUNT_SW_CPU_CLOCK");
 }
 
 TEST_F(DuplicatedEnvironmentEntriesTest, PapiEventsDeduplicates)
 {
     std::vector<std::string> env_vars = {
-        "ROCPROFSYS_PAPI_EVENTS=perf::INSTRUCTIONS",
-        "ROCPROFSYS_PAPI_EVENTS=perf::CACHE_MISSES",
-        "ROCPROFSYS_PAPI_EVENTS=perf::INSTRUCTIONS",
+        std::string{ env_vars::PAPI_EVENTS } + "=perf::INSTRUCTIONS",
+        std::string{ env_vars::PAPI_EVENTS } + "=perf::CACHE_MISSES",
+        std::string{ env_vars::PAPI_EVENTS } + "=perf::INSTRUCTIONS",
     };
     consolidate_env_entries(env_vars);
     ASSERT_EQ(env_vars.size(), 1);
-    EXPECT_EQ(env_vars[0],
-              "ROCPROFSYS_PAPI_EVENTS=perf::INSTRUCTIONS,perf::CACHE_MISSES");
+    EXPECT_EQ(env_vars[0], std::string{ env_vars::PAPI_EVENTS } +
+                               "=perf::INSTRUCTIONS,perf::CACHE_MISSES");
 }
 
 TEST_F(DuplicatedEnvironmentEntriesTest, SamplingOverflowEventUsesCommaDelimiter)
 {
     std::vector<std::string> env_vars = {
-        "ROCPROFSYS_SAMPLING_OVERFLOW_EVENT=perf::INSTRUCTIONS",
-        "ROCPROFSYS_SAMPLING_OVERFLOW_EVENT=perf::CYCLES",
+        std::string{ env_vars::SAMPLING_OVERFLOW_EVENT } + "=perf::INSTRUCTIONS",
+        std::string{ env_vars::SAMPLING_OVERFLOW_EVENT } + "=perf::CYCLES",
     };
     consolidate_env_entries(env_vars);
     ASSERT_EQ(env_vars.size(), 1);
-    EXPECT_EQ(env_vars[0],
-              "ROCPROFSYS_SAMPLING_OVERFLOW_EVENT=perf::INSTRUCTIONS,perf::CYCLES");
+    EXPECT_EQ(env_vars[0], std::string{ env_vars::SAMPLING_OVERFLOW_EVENT } +
+                               "=perf::INSTRUCTIONS,perf::CYCLES");
 }
 
 TEST_F(DuplicatedEnvironmentEntriesTest, MixedDelimiterVariables)
 {
     std::vector<std::string> env_vars = {
-        "PATH=/usr/bin",        "ROCPROFSYS_PAPI_EVENTS=perf::INSTRUCTIONS",
-        "PATH=/usr/local/bin",  "ROCPROFSYS_PAPI_EVENTS=perf::CACHE_MISSES",
+        "PATH=/usr/bin",
+        std::string{ env_vars::PAPI_EVENTS } + "=perf::INSTRUCTIONS",
+        "PATH=/usr/local/bin",
+        std::string{ env_vars::PAPI_EVENTS } + "=perf::CACHE_MISSES",
         "LD_LIBRARY_PATH=/lib",
     };
     consolidate_env_entries(env_vars);
     ASSERT_EQ(env_vars.size(), 3);
     EXPECT_EQ(env_vars[0], "PATH=/usr/bin:/usr/local/bin");
-    EXPECT_EQ(env_vars[1],
-              "ROCPROFSYS_PAPI_EVENTS=perf::INSTRUCTIONS,perf::CACHE_MISSES");
+    EXPECT_EQ(env_vars[1], std::string{ env_vars::PAPI_EVENTS } +
+                               "=perf::INSTRUCTIONS,perf::CACHE_MISSES");
     EXPECT_EQ(env_vars[2], "LD_LIBRARY_PATH=/lib");
 }
 
@@ -155,38 +159,37 @@ TEST_F(DuplicatedEnvironmentEntriesTest, PreservesKeyOrder)
 TEST_F(DuplicatedEnvironmentEntriesTest, PapiEventsWithCommaInValue)
 {
     std::vector<std::string> env_vars = {
-        "ROCPROFSYS_PAPI_EVENTS=perf::INSTRUCTIONS,perf::CYCLES",
-        "ROCPROFSYS_PAPI_EVENTS=perf::CACHE_MISSES",
+        std::string{ env_vars::PAPI_EVENTS } + "=perf::INSTRUCTIONS,perf::CYCLES",
+        std::string{ env_vars::PAPI_EVENTS } + "=perf::CACHE_MISSES",
     };
     consolidate_env_entries(env_vars);
     ASSERT_EQ(env_vars.size(), 1);
-    EXPECT_EQ(
-        env_vars[0],
-        "ROCPROFSYS_PAPI_EVENTS=perf::INSTRUCTIONS,perf::CYCLES,perf::CACHE_MISSES");
+    EXPECT_EQ(env_vars[0], std::string{ env_vars::PAPI_EVENTS } +
+                               "=perf::INSTRUCTIONS,perf::CYCLES,perf::CACHE_MISSES");
 }
 
 TEST_F(DuplicatedEnvironmentEntriesTest, RocmEventsUsesCommaDelimiter)
 {
     std::vector<std::string> env_vars = {
-        "ROCPROFSYS_ROCM_EVENTS=SQ_WAVES:device=0",
-        "ROCPROFSYS_ROCM_EVENTS=TA_TA_BUSY:device=1",
+        std::string{ env_vars::ROCM_EVENTS } + "=SQ_WAVES:device=0",
+        std::string{ env_vars::ROCM_EVENTS } + "=TA_TA_BUSY:device=1",
     };
     consolidate_env_entries(env_vars);
     ASSERT_EQ(env_vars.size(), 1);
-    EXPECT_EQ(env_vars[0],
-              "ROCPROFSYS_ROCM_EVENTS=SQ_WAVES:device=0,TA_TA_BUSY:device=1");
+    EXPECT_EQ(env_vars[0], std::string{ env_vars::ROCM_EVENTS } +
+                               "=SQ_WAVES:device=0,TA_TA_BUSY:device=1");
 }
 
 TEST_F(DuplicatedEnvironmentEntriesTest, RocmEventsPreservesDeviceSyntax)
 {
     std::vector<std::string> env_vars = {
-        "ROCPROFSYS_ROCM_EVENTS=GRBM_COUNT,SQ_WAVES,SQ_INSTS_VALU,TA_TA_BUSY:device=0",
+        std::string{ env_vars::ROCM_EVENTS } +
+            "=GRBM_COUNT,SQ_WAVES,SQ_INSTS_VALU,TA_TA_BUSY:device=0",
     };
     consolidate_env_entries(env_vars);
     ASSERT_EQ(env_vars.size(), 1);
-    EXPECT_EQ(
-        env_vars[0],
-        "ROCPROFSYS_ROCM_EVENTS=GRBM_COUNT,SQ_WAVES,SQ_INSTS_VALU,TA_TA_BUSY:device=0");
+    EXPECT_EQ(env_vars[0], std::string{ env_vars::ROCM_EVENTS } +
+                               "=GRBM_COUNT,SQ_WAVES,SQ_INSTS_VALU,TA_TA_BUSY:device=0");
 }
 
 class AddTorchLibraryPathTest : public ::testing::Test

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_remove_env.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_remove_env.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 using namespace rocprofsys::common;
+namespace env_vars = rocprofsys::env_vars;
 
 namespace
 {
@@ -158,15 +159,18 @@ TEST_F(RemoveEnvTest, RealWorld_LD_PRELOAD)
 
 TEST_F(RemoveEnvTest, RealWorld_RestoreROCPROFSYS_Variable)
 {
-    m_original_envs.insert("ROCPROFSYS_TRACE=false");
+    m_original_envs.insert(std::string{ env_vars::TRACE } + "=false");
 
-    m_env_vars = { "ROCPROFSYS_TRACE=true", "ROCPROFSYS_PROFILE=true" };
+    m_env_vars = { std::string{ env_vars::TRACE } + "=true",
+                   std::string{ env_vars::PROFILE } + "=true" };
 
-    remove_env(m_env_vars, "ROCPROFSYS_TRACE", m_original_envs);
+    remove_env(m_env_vars, env_vars::TRACE, m_original_envs);
 
     ASSERT_EQ(m_env_vars.size(), 2);
-    EXPECT_EQ(find_env_var(m_env_vars, "ROCPROFSYS_TRACE"), "ROCPROFSYS_TRACE=false");
-    EXPECT_EQ(find_env_var(m_env_vars, "ROCPROFSYS_PROFILE"), "ROCPROFSYS_PROFILE=true");
+    EXPECT_EQ(find_env_var(m_env_vars, env_vars::TRACE),
+              std::string{ env_vars::TRACE } + "=false");
+    EXPECT_EQ(find_env_var(m_env_vars, env_vars::PROFILE),
+              std::string{ env_vars::PROFILE } + "=true");
 }
 
 TEST_F(RemoveEnvTest, EmptyVariableName)

--- a/projects/rocprofiler-systems/source/lib/common/tests/test_update_env.cpp
+++ b/projects/rocprofiler-systems/source/lib/common/tests/test_update_env.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 using namespace rocprofsys::common;
+namespace env_vars = rocprofsys::env_vars;
 
 static std::string
 find_env_var(const std::vector<std::string>& env, std::string_view var_name)
@@ -66,15 +67,15 @@ TEST_F(UpdateEnvTest, ReplaceMode_RemovesDuplicateEntries)
     // Same key present twice (e.g. one from shell env, one from config file).
     // REPLACE must leave exactly one entry; otherwise consolidate_env_entries
     // later joins the parts and turns REPLACE into APPEND.
-    m_env_vars.emplace_back("ROCPROFSYS_TRACE=true");
+    m_env_vars.emplace_back(std::string{ env_vars::TRACE } + "=true");
     m_env_vars.emplace_back("OTHER_VAR=keep");
-    m_env_vars.emplace_back("ROCPROFSYS_TRACE=true");
+    m_env_vars.emplace_back(std::string{ env_vars::TRACE } + "=true");
 
-    update_env(m_env_vars, "ROCPROFSYS_TRACE", false, update_mode::REPLACE, ":",
+    update_env(m_env_vars, env_vars::TRACE, false, update_mode::REPLACE, ":",
                m_updated_envs, m_original_envs);
 
     ASSERT_EQ(m_env_vars.size(), 2);
-    EXPECT_EQ(m_env_vars[0], "ROCPROFSYS_TRACE=false");
+    EXPECT_EQ(m_env_vars[0], std::string{ env_vars::TRACE } + "=false");
     EXPECT_EQ(m_env_vars[1], "OTHER_VAR=keep");
 }
 
@@ -231,33 +232,35 @@ TEST_F(UpdateEnvTest, RealWorld_LD_PRELOAD_Prepend)
 
 TEST_F(UpdateEnvTest, RealWorld_ROCPROFSYS_Environment_Variables)
 {
-    update_env(m_env_vars, "ROCPROFSYS_TRACE", true, update_mode::REPLACE, ":",
+    update_env(m_env_vars, env_vars::TRACE, true, update_mode::REPLACE, ":",
                m_updated_envs, m_original_envs);
-    update_env(m_env_vars, "ROCPROFSYS_PROFILE", false, update_mode::REPLACE, ":",
+    update_env(m_env_vars, env_vars::PROFILE, false, update_mode::REPLACE, ":",
                m_updated_envs, m_original_envs);
-    update_env(m_env_vars, "ROCPROFSYS_USE_SAMPLING", true, update_mode::REPLACE, ":",
+    update_env(m_env_vars, env_vars::USE_SAMPLING, true, update_mode::REPLACE, ":",
                m_updated_envs, m_original_envs);
 
     ASSERT_EQ(m_env_vars.size(), 3);
-    EXPECT_EQ(find_env_var(m_env_vars, "ROCPROFSYS_TRACE"), "ROCPROFSYS_TRACE=true");
-    EXPECT_EQ(find_env_var(m_env_vars, "ROCPROFSYS_PROFILE"), "ROCPROFSYS_PROFILE=false");
-    EXPECT_EQ(find_env_var(m_env_vars, "ROCPROFSYS_USE_SAMPLING"),
-              "ROCPROFSYS_USE_SAMPLING=true");
+    EXPECT_EQ(find_env_var(m_env_vars, env_vars::TRACE),
+              std::string{ env_vars::TRACE } + "=true");
+    EXPECT_EQ(find_env_var(m_env_vars, env_vars::PROFILE),
+              std::string{ env_vars::PROFILE } + "=false");
+    EXPECT_EQ(find_env_var(m_env_vars, env_vars::USE_SAMPLING),
+              std::string{ env_vars::USE_SAMPLING } + "=true");
 }
 
 TEST_F(UpdateEnvTest, RealWorld_Timing_DoubleValues)
 {
-    update_env(m_env_vars, "ROCPROFSYS_TRACE_DELAY", 1.5, update_mode::REPLACE, ":",
+    update_env(m_env_vars, env_vars::TRACE_DELAY, 1.5, update_mode::REPLACE, ":",
                m_updated_envs, m_original_envs);
-    update_env(m_env_vars, "ROCPROFSYS_SAMPLING_FREQ", 100.0, update_mode::REPLACE, ":",
+    update_env(m_env_vars, env_vars::SAMPLING_FREQ, 100.0, update_mode::REPLACE, ":",
                m_updated_envs, m_original_envs);
 
     ASSERT_EQ(m_env_vars.size(), 2);
-    std::string delay_var = find_env_var(m_env_vars, "ROCPROFSYS_TRACE_DELAY");
-    std::string freq_var  = find_env_var(m_env_vars, "ROCPROFSYS_SAMPLING_FREQ");
+    std::string delay_var = find_env_var(m_env_vars, env_vars::TRACE_DELAY);
+    std::string freq_var  = find_env_var(m_env_vars, env_vars::SAMPLING_FREQ);
 
-    EXPECT_TRUE(delay_var.find("ROCPROFSYS_TRACE_DELAY=") == 0);
-    EXPECT_TRUE(freq_var.find("ROCPROFSYS_SAMPLING_FREQ=") == 0);
+    EXPECT_TRUE(delay_var.find(std::string{ env_vars::TRACE_DELAY } + "=") == 0);
+    EXPECT_TRUE(freq_var.find(std::string{ env_vars::SAMPLING_FREQ } + "=") == 0);
 }
 
 TEST_F(UpdateEnvTest, StringTypes_StdString)

--- a/projects/rocprofiler-systems/source/lib/core/amd_smi.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/amd_smi.cpp
@@ -105,7 +105,7 @@ config_settings(const std::shared_ptr<settings>& _config)
 #endif
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, env_vars::AMD_SMI_METRICS.data(),
+        std::string, env_vars::AMD_SMI_METRICS,
         "amd-smi metrics to collect: " + default_metrics + jpeg_activity_support +
             vcn_activity_support + xgmi_support + pcie_support + sdma_support + ". " +
             "An empty value implies 'all' and 'none' suppresses all.",

--- a/projects/rocprofiler-systems/source/lib/core/amd_smi.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/amd_smi.cpp
@@ -4,7 +4,9 @@
 #include "backends/amd_smi/ainic_feature.hpp"
 #include "backends/amd_smi/sdma_feature.hpp"
 
+#include "common/env_vars.hpp"
 #include "core/amd_smi.hpp"
+#include "core/common.hpp"
 #include "core/config.hpp"
 #include "core/gpu.hpp"
 #include "timemory.hpp"
@@ -103,7 +105,7 @@ config_settings(const std::shared_ptr<settings>& _config)
 #endif
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_AMD_SMI_METRICS",
+        std::string, env_vars::AMD_SMI_METRICS.data(),
         "amd-smi metrics to collect: " + default_metrics + jpeg_activity_support +
             vcn_activity_support + xgmi_support + pcie_support + sdma_support + ". " +
             "An empty value implies 'all' and 'none' suppresses all.",

--- a/projects/rocprofiler-systems/source/lib/core/amd_smi.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/amd_smi.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "core/amd_smi.hpp"
+#include "common/env_vars.hpp"
 #include "core/common.hpp"
 #include "core/config.hpp"
 #include "core/gpu.hpp"
@@ -101,7 +102,7 @@ config_settings(const std::shared_ptr<settings>& _config)
 #endif
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_AMD_SMI_METRICS",
+        std::string, env_vars::AMD_SMI_METRICS.data(),
         "amd-smi metrics to collect: " + default_metrics + jpeg_activity_support +
             vcn_activity_support + xgmi_support + pcie_support + sdma_support + ". " +
             "An empty value implies 'all' and 'none' suppresses all.",

--- a/projects/rocprofiler-systems/source/lib/core/argparse.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse.cpp
@@ -114,10 +114,10 @@ init_parser(parser_data& _data)
         path::realpath(path::get_internal_libpath("librocprof-sys.so").c_str());
 
     auto _libexecpath = path::realpath(path::get_internal_script_path());
-    update_env(_data, "ROCPROFSYS_SCRIPT_PATH", _libexecpath, update_mode::REPLACE);
+    update_env(_data, env_vars::SCRIPT_PATH, _libexecpath, update_mode::REPLACE);
 
     auto _rootpath = path::realpath(path::get_rocprofsys_root());
-    update_env(_data, "ROCPROFSYS_ROOT", _rootpath, update_mode::REPLACE);
+    update_env(_data, env_vars::ROOT, _rootpath, update_mode::REPLACE);
 
     return _data;
 }
@@ -215,8 +215,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .dtype("string")
             .choices({ "trace", "debug", "info", "warn", "error", "critical", "off" })
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_LOG_LEVEL",
-                           p.get<std::string>("log-level"));
+                update_env(_data, env_vars::LOG_LEVEL, p.get<std::string>("log-level"));
             });
 
         _data.reg.processed_environs.emplace("log_level");
@@ -231,7 +230,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
                 auto _monochrome     = p.get<bool>("monochrome");
                 _data.out.monochrome = _monochrome;
                 p.set_use_color(!_monochrome);
-                update_env(_data, "ROCPROFSYS_MONOCHROME", (_monochrome) ? "1" : "0");
+                update_env(_data, env_vars::MONOCHROME, (_monochrome) ? "1" : "0");
                 update_env(_data, "MONOCHROME", (_monochrome) ? "1" : "0");
             });
 
@@ -244,8 +243,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .add_argument({ "--debug" },
                           "[DEPRECATED Use --log-level=debug] Debug output")
             .max_count(1)
-            .action(
-                [&](parser_t&) { update_env(_data, "ROCPROFSYS_LOG_LEVEL", "debug"); });
+            .action([&](parser_t&) { update_env(_data, env_vars::LOG_LEVEL, "debug"); });
 
         _data.reg.processed_environs.emplace("debug");
     }
@@ -260,7 +258,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .action([&](parser_t& p) {
                 auto _v           = p.get<int>("verbose");
                 _data.out.verbose = _v;
-                update_env(_data, "ROCPROFSYS_VERBOSE", _v);
+                update_env(_data, env_vars::VERBOSE, _v);
 
                 constexpr std::array<const char*, 5> log_levels = { "off", "info",
                                                                     "debug", "debug",
@@ -268,7 +266,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
 
                 auto index =
                     std::clamp(_v + 1, 0, static_cast<int>(log_levels.size() - 1));
-                update_env(_data, "ROCPROFSYS_LOG_LEVEL", log_levels[index]);
+                update_env(_data, env_vars::LOG_LEVEL, log_levels[index]);
             });
 
         _data.reg.processed_environs.emplace("verbose");
@@ -286,7 +284,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .min_count(1)
             .dtype("filepath")
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_CONFIG_FILE",
+                update_env(_data, env_vars::CONFIG_FILE,
                            fmt::format("{}", fmt::join(p.get<strvec_t>("config"), ":")));
             });
 
@@ -306,8 +304,8 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .dtype("path [prefix]")
             .action([&](parser_t& p) {
                 auto _v = p.get<strvec_t>("output");
-                update_env(_data, "ROCPROFSYS_OUTPUT_PATH", _v.at(0));
-                if(_v.size() > 1) update_env(_data, "ROCPROFSYS_OUTPUT_PREFIX", _v.at(1));
+                update_env(_data, env_vars::OUTPUT_PATH, _v.at(0));
+                if(_v.size() > 1) update_env(_data, env_vars::OUTPUT_PREFIX, _v.at(1));
             });
 
         _data.reg.processed_environs.emplace("output");
@@ -323,7 +321,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
                           "--output-format.")
             .max_count(1)
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_TRACE", p.get<bool>("trace"));
+                update_env(_data, env_vars::TRACE, p.get<bool>("trace"));
             });
 
         _parser
@@ -332,7 +330,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
                           "generation (higher overhead)")
             .max_count(1)
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_TRACE_LEGACY", p.get<bool>("trace-legacy"));
+                update_env(_data, env_vars::TRACE_LEGACY, p.get<bool>("trace-legacy"));
             });
 
         _data.reg.processed_environs.emplace("trace");
@@ -349,7 +347,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .max_count(1)
             .conflicts({ "flat-profile" })
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_PROFILE", p.get<bool>("profile"));
+                update_env(_data, env_vars::PROFILE, p.get<bool>("profile"));
             });
 
         _data.reg.processed_environs.emplace("profile");
@@ -363,8 +361,8 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .max_count(1)
             .conflicts({ "profile" })
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_PROFILE", p.get<bool>("flat-profile"));
-                update_env(_data, "ROCPROFSYS_FLAT_PROFILE", p.get<bool>("flat-profile"));
+                update_env(_data, env_vars::PROFILE, p.get<bool>("flat-profile"));
+                update_env(_data, env_vars::FLAT_PROFILE, p.get<bool>("flat-profile"));
             });
 
         _data.reg.processed_environs.emplace("flat_profile");
@@ -380,13 +378,13 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .dtype("timer-type")
             .choices({ "cputime", "realtime" })
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_USE_SAMPLING", true);
+                update_env(_data, env_vars::USE_SAMPLING, true);
                 auto _modes = p.get<strset_t>("sample");
                 if(!_modes.empty())
                 {
-                    update_env(_data, "ROCPROFSYS_SAMPLING_CPUTIME",
+                    update_env(_data, env_vars::SAMPLING_CPUTIME,
                                _modes.count("cputime") > 0, update_mode::WEAK);
-                    update_env(_data, "ROCPROFSYS_SAMPLING_REALTIME",
+                    update_env(_data, env_vars::SAMPLING_REALTIME,
                                _modes.count("realtime") > 0, update_mode::WEAK);
                 }
             });
@@ -404,9 +402,9 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .action([&](parser_t& p) {
                 auto _h = p.get<bool>("host");
                 auto _d = p.get<bool>("device");
-                update_env(_data, "ROCPROFSYS_USE_PROCESS_SAMPLING", _h || _d);
-                update_env(_data, "ROCPROFSYS_CPU_FREQ_ENABLED", _h);
-                if(_h) update_env(_data, "ROCPROFSYS_USE_AMD_SMI", _d);
+                update_env(_data, env_vars::USE_PROCESS_SAMPLING, _h || _d);
+                update_env(_data, env_vars::CPU_FREQ_ENABLED, _h);
+                if(_h) update_env(_data, env_vars::USE_AMD_SMI, _d);
             });
 
         _data.reg.processed_environs.emplace("host");
@@ -424,9 +422,9 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .action([&](parser_t& p) {
                 auto _h = p.get<bool>("host");
                 auto _d = p.get<bool>("device");
-                update_env(_data, "ROCPROFSYS_USE_PROCESS_SAMPLING", _h || _d);
-                update_env(_data, "ROCPROFSYS_USE_AMD_SMI", _d);
-                if(_d) update_env(_data, "ROCPROFSYS_CPU_FREQ_ENABLED", _h);
+                update_env(_data, env_vars::USE_PROCESS_SAMPLING, _h || _d);
+                update_env(_data, env_vars::USE_AMD_SMI, _d);
+                if(_d) update_env(_data, env_vars::CPU_FREQ_ENABLED, _h);
             });
 
         _data.reg.processed_environs.emplace("device");
@@ -443,11 +441,11 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .count(1)
             .dtype("seconds")
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_TRACE_DELAY", p.get<double>("wait"),
+                update_env(_data, env_vars::TRACE_DELAY, p.get<double>("wait"),
                            update_mode::WEAK);
-                update_env(_data, "ROCPROFSYS_SAMPLING_DELAY", p.get<double>("wait"),
+                update_env(_data, env_vars::SAMPLING_DELAY, p.get<double>("wait"),
                            update_mode::WEAK);
-                update_env(_data, "ROCPROFSYS_CAUSAL_DELAY", p.get<double>("wait"),
+                update_env(_data, env_vars::CAUSAL_DELAY, p.get<double>("wait"),
                            update_mode::WEAK);
             });
 
@@ -464,11 +462,11 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .count(1)
             .dtype("seconds")
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_TRACE_DURATION", p.get<double>("duration"),
+                update_env(_data, env_vars::TRACE_DURATION, p.get<double>("duration"),
                            update_mode::WEAK);
-                update_env(_data, "ROCPROFSYS_SAMPLING_DURATION",
-                           p.get<double>("duration"), update_mode::WEAK);
-                update_env(_data, "ROCPROFSYS_CAUSAL_DURATION", p.get<double>("duration"),
+                update_env(_data, env_vars::SAMPLING_DURATION, p.get<double>("duration"),
+                           update_mode::WEAK);
+                update_env(_data, env_vars::CAUSAL_DURATION, p.get<double>("duration"),
                            update_mode::WEAK);
             });
 
@@ -485,7 +483,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .min_count(1)
             .dtype("period-spec(s)")
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_TRACE_PERIODS",
+                update_env(_data, env_vars::TRACE_PERIODS,
                            fmt::format("{}", fmt::join(p.get<strvec_t>("periods"), " ")),
                            update_mode::WEAK);
             });
@@ -503,7 +501,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .dtype("string")
             .required({ "rank-filter-output|rank-filter-logs" })
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_RANK_FILTER_ID",
+                update_env(_data, env_vars::RANK_FILTER_ID,
                            p.get<std::string>("rank-filter-id"));
             });
 
@@ -521,7 +519,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .dtype("int and/or range")
             .action([&](parser_t& p) {
                 update_env(
-                    _data, "ROCPROFSYS_RANK_FILTER_OUTPUT",
+                    _data, env_vars::RANK_FILTER_OUTPUT,
                     fmt::format("{}",
                                 fmt::join(p.get<strvec_t>("rank-filter-output"), ",")));
             });
@@ -568,7 +566,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
         _backend_choices.erase("amd-smi");
         _backend_choices.erase("rocm");
 
-        update_env(_data, "ROCPROFSYS_USE_AMD_SMI", false);
+        update_env(_data, env_vars::USE_AMD_SMI, false);
     }
 
     _parser.start_group("BACKEND OPTIONS",
@@ -587,14 +585,14 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
                 auto _update = [&](const auto& _opt, bool _cond) {
                     if(_cond || _v.count("all") > 0) update_env(_data, _opt, true);
                 };
-                _update("ROCPROFSYS_USE_KOKKOSP", _v.count("kokkosp") > 0);
-                _update("ROCPROFSYS_USE_MPIP", _v.count("mpip") > 0);
-                _update("ROCPROFSYS_USE_OMPT", _v.count("ompt") > 0);
-                _update("ROCPROFSYS_USE_RCCLP", _v.count("rcclp") > 0);
-                _update("ROCPROFSYS_USE_AMD_SMI", _v.count("amd-smi") > 0);
-                _update("ROCPROFSYS_TRACE_THREAD_LOCKS", _v.count("mutex-locks") > 0);
-                _update("ROCPROFSYS_TRACE_THREAD_RW_LOCKS", _v.count("rw-locks") > 0);
-                _update("ROCPROFSYS_TRACE_THREAD_SPIN_LOCKS", _v.count("spin-locks") > 0);
+                _update(env_vars::USE_KOKKOSP, _v.count("kokkosp") > 0);
+                _update(env_vars::USE_MPIP, _v.count("mpip") > 0);
+                _update(env_vars::USE_OMPT, _v.count("ompt") > 0);
+                _update(env_vars::USE_RCCLP, _v.count("rcclp") > 0);
+                _update(env_vars::USE_AMD_SMI, _v.count("amd-smi") > 0);
+                _update(env_vars::TRACE_THREAD_LOCKS, _v.count("mutex-locks") > 0);
+                _update(env_vars::TRACE_THREAD_RW_LOCKS, _v.count("rw-locks") > 0);
+                _update(env_vars::TRACE_THREAD_SPIN_LOCKS, _v.count("spin-locks") > 0);
 
                 if(_v.count("all") > 0 || _v.count("kokkosp") > 0)
                     update_env(_data, "KOKKOS_TOOLS_LIBS", _data.env.omni_libpath,
@@ -616,14 +614,14 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
                 auto _update = [&](const auto& _opt, bool _cond) {
                     if(_cond || _v.count("all") > 0) update_env(_data, _opt, false);
                 };
-                _update("ROCPROFSYS_USE_KOKKOSP", _v.count("kokkosp") > 0);
-                _update("ROCPROFSYS_USE_MPIP", _v.count("mpip") > 0);
-                _update("ROCPROFSYS_USE_OMPT", _v.count("ompt") > 0);
-                _update("ROCPROFSYS_USE_RCCLP", _v.count("rcclp") > 0);
-                _update("ROCPROFSYS_USE_AMD_SMI", _v.count("amd-smi") > 0);
-                _update("ROCPROFSYS_TRACE_THREAD_LOCKS", _v.count("mutex-locks") > 0);
-                _update("ROCPROFSYS_TRACE_THREAD_RW_LOCKS", _v.count("rw-locks") > 0);
-                _update("ROCPROFSYS_TRACE_THREAD_SPIN_LOCKS", _v.count("spin-locks") > 0);
+                _update(env_vars::USE_KOKKOSP, _v.count("kokkosp") > 0);
+                _update(env_vars::USE_MPIP, _v.count("mpip") > 0);
+                _update(env_vars::USE_OMPT, _v.count("ompt") > 0);
+                _update(env_vars::USE_RCCLP, _v.count("rcclp") > 0);
+                _update(env_vars::USE_AMD_SMI, _v.count("amd-smi") > 0);
+                _update(env_vars::TRACE_THREAD_LOCKS, _v.count("mutex-locks") > 0);
+                _update(env_vars::TRACE_THREAD_RW_LOCKS, _v.count("rw-locks") > 0);
+                _update(env_vars::TRACE_THREAD_SPIN_LOCKS, _v.count("spin-locks") > 0);
 
                 if(_v.count("all") > 0 || _v.count("kokkosp") > 0)
                     remove_env(_data.env.current, "KOKKOS_TOOLS_LIBS", _data.env.initial);
@@ -671,7 +669,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .count(1)
             .dtype("filepath")
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_PERFETTO_FILE",
+                update_env(_data, env_vars::PERFETTO_FILE,
                            p.get<std::string>("trace-file"));
             });
 
@@ -687,7 +685,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .count(1)
             .dtype("KB")
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_PERFETTO_BUFFER_SIZE_KB",
+                update_env(_data, env_vars::PERFETTO_BUFFER_SIZE_KB,
                            p.get<std::int64_t>("trace-buffer-size"));
             });
 
@@ -702,7 +700,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .dtype("policy")
             .choices({ "discard", "ring_buffer" })
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_PERFETTO_FILL_POLICY",
+                update_env(_data, env_vars::PERFETTO_FILL_POLICY,
                            p.get<std::string>("trace-fill-policy"));
             });
 
@@ -722,7 +720,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .count(1)
             .dtype("seconds")
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_TRACE_DELAY", p.get<double>("trace-wait"));
+                update_env(_data, env_vars::TRACE_DELAY, p.get<double>("trace-wait"));
             });
 
         _data.reg.processed_environs.emplace("trace_delay");
@@ -739,7 +737,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .count(1)
             .dtype("seconds")
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_TRACE_DURATION",
+                update_env(_data, env_vars::TRACE_DURATION,
                            p.get<double>("trace-duration"));
             });
 
@@ -759,7 +757,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .dtype("period-spec(s)")
             .action([&](parser_t& p) {
                 update_env(
-                    _data, "ROCPROFSYS_TRACE_PERIODS",
+                    _data, env_vars::TRACE_PERIODS,
                     fmt::format("{}", fmt::join(p.get<strvec_t>("trace-periods"), ",")));
             });
 
@@ -777,7 +775,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .count(1)
             .dtype("string")
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_SELECTED_REGIONS",
+                update_env(_data, env_vars::SELECTED_REGIONS,
                            p.get<std::string>("selected-regions"));
             });
 
@@ -802,7 +800,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .count(1)
             .dtype("clock-id")
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_TRACE_PERIOD_CLOCK_ID",
+                update_env(_data, env_vars::TRACE_PERIOD_CLOCK_ID,
                            p.get<double>("trace-clock-id"));
             })
             .choices(_clock_id_choices.first)
@@ -861,12 +859,12 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .choices({ "text", "json", "console" })
             .action([&](parser_t& p) {
                 auto _v = p.get<strset_t>("profile-format");
-                update_env(_data, "ROCPROFSYS_PROFILE", true);
+                update_env(_data, env_vars::PROFILE, true);
                 if(!_v.empty())
                 {
-                    update_env(_data, "ROCPROFSYS_TEXT_OUTPUT", _v.count("text") != 0);
-                    update_env(_data, "ROCPROFSYS_JSON_OUTPUT", _v.count("json") != 0);
-                    update_env(_data, "ROCPROFSYS_COUT_OUTPUT", _v.count("console") != 0);
+                    update_env(_data, env_vars::TEXT_OUTPUT, _v.count("text") != 0);
+                    update_env(_data, env_vars::JSON_OUTPUT, _v.count("json") != 0);
+                    update_env(_data, env_vars::COUT_OUTPUT, _v.count("console") != 0);
                 }
             });
 
@@ -889,9 +887,9 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .dtype("path [prefix]")
             .action([&](parser_t& p) {
                 auto _v = p.get<strvec_t>("profile-diff");
-                update_env(_data, "ROCPROFSYS_DIFF_OUTPUT", true);
-                update_env(_data, "ROCPROFSYS_INPUT_PATH", _v.at(0));
-                if(_v.size() > 1) update_env(_data, "ROCPROFSYS_INPUT_PREFIX", _v.at(1));
+                update_env(_data, env_vars::DIFF_OUTPUT, true);
+                update_env(_data, env_vars::INPUT_PATH, _v.at(0));
+                if(_v.size() > 1) update_env(_data, env_vars::INPUT_PREFIX, _v.at(1));
             });
 
         _data.reg.processed_environs.emplace("profile_diff");
@@ -914,7 +912,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .count(1)
             .dtype("floating-point")
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_PROCESS_SAMPLING_FREQ",
+                update_env(_data, env_vars::PROCESS_SAMPLING_FREQ,
                            p.get<double>("process-freq"));
             });
 
@@ -931,7 +929,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .count(1)
             .dtype("seconds")
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_PROCESS_SAMPLING_DELAY",
+                update_env(_data, env_vars::PROCESS_SAMPLING_DELAY,
                            p.get<double>("process-wait"));
             });
 
@@ -948,7 +946,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .count(1)
             .dtype("seconds")
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_SAMPLING_PROCESS_DURATION",
+                update_env(_data, env_vars::SAMPLING_PROCESS_DURATION,
                            p.get<double>("process-duration"));
             });
 
@@ -964,7 +962,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
                 "CPU IDs for frequency sampling. Supports integers and/or ranges")
             .dtype("int and/or range")
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_SAMPLING_CPUS",
+                update_env(_data, env_vars::SAMPLING_CPUS,
                            fmt::format("{}", fmt::join(p.get<strvec_t>("cpus"), ",")));
             });
 
@@ -979,7 +977,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
                           "GPU IDs for SMI queries. Supports integers and/or ranges")
             .dtype("int and/or range")
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_SAMPLING_GPUS",
+                update_env(_data, env_vars::SAMPLING_GPUS,
                            fmt::format("{}", fmt::join(p.get<strvec_t>("gpus"), ",")));
             });
 
@@ -994,7 +992,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
                           "AI NIC IDs for SMI queries. Supports comma-separated list")
             .dtype("list of strings")
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_SAMPLING_AINICS",
+                update_env(_data, env_vars::SAMPLING_AINICS,
                            fmt::format("{}", fmt::join(p.get<strvec_t>("ai-nics"), ",")));
             });
 
@@ -1014,7 +1012,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .count(1)
             .dtype("floating-point")
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_SAMPLING_FREQ",
+                update_env(_data, env_vars::SAMPLING_FREQ,
                            p.get<double>("sampling-freq"));
             });
 
@@ -1033,7 +1031,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .dtype("int and/or range")
             .action([&](parser_t& p) {
                 update_env(
-                    _data, "ROCPROFSYS_SAMPLING_TIDS",
+                    _data, env_vars::SAMPLING_TIDS,
                     fmt::format(
                         "{}", fmt::join(p.get<std::vector<std::int64_t>>("tids"), ", ")));
             });
@@ -1055,7 +1053,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .count(1)
             .dtype("seconds")
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_SAMPLING_DELAY",
+                update_env(_data, env_vars::SAMPLING_DELAY,
                            p.get<double>("sampling-wait"));
             });
 
@@ -1074,7 +1072,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .count(1)
             .dtype("seconds")
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_SAMPLING_DURATION",
+                update_env(_data, env_vars::SAMPLING_DURATION,
                            p.get<double>("sampling-duration"));
             });
 
@@ -1092,20 +1090,20 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .dtype("[freq] [delay] [tids...]")
             .action([&](parser_t& p) {
                 auto _v = p.get<std::deque<std::string>>("sample-cputime");
-                update_env(_data, "ROCPROFSYS_SAMPLING_CPUTIME", true);
+                update_env(_data, env_vars::SAMPLING_CPUTIME, true);
                 if(!_v.empty())
                 {
-                    update_env(_data, "ROCPROFSYS_SAMPLING_CPUTIME_FREQ", _v.front());
+                    update_env(_data, env_vars::SAMPLING_CPUTIME_FREQ, _v.front());
                     _v.pop_front();
                 }
                 if(!_v.empty())
                 {
-                    update_env(_data, "ROCPROFSYS_SAMPLING_CPUTIME_DELAY", _v.front());
+                    update_env(_data, env_vars::SAMPLING_CPUTIME_DELAY, _v.front());
                     _v.pop_front();
                 }
                 if(!_v.empty())
                 {
-                    update_env(_data, "ROCPROFSYS_SAMPLING_CPUTIME_TIDS",
+                    update_env(_data, env_vars::SAMPLING_CPUTIME_TIDS,
                                fmt::format("{}", fmt::join(_v, ",")));
                 }
             });
@@ -1120,20 +1118,20 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .dtype("[freq] [delay] [tids...]")
             .action([&](parser_t& p) {
                 auto _v = p.get<std::deque<std::string>>("sample-realtime");
-                update_env(_data, "ROCPROFSYS_SAMPLING_REALTIME", true);
+                update_env(_data, env_vars::SAMPLING_REALTIME, true);
                 if(!_v.empty())
                 {
-                    update_env(_data, "ROCPROFSYS_SAMPLING_REALTIME_FREQ", _v.front());
+                    update_env(_data, env_vars::SAMPLING_REALTIME_FREQ, _v.front());
                     _v.pop_front();
                 }
                 if(!_v.empty())
                 {
-                    update_env(_data, "ROCPROFSYS_SAMPLING_REALTIME_DELAY", _v.front());
+                    update_env(_data, env_vars::SAMPLING_REALTIME_DELAY, _v.front());
                     _v.pop_front();
                 }
                 if(!_v.empty())
                 {
-                    update_env(_data, "ROCPROFSYS_SAMPLING_REALTIME_TIDS",
+                    update_env(_data, env_vars::SAMPLING_REALTIME_TIDS,
                                fmt::format("{}", fmt::join(_v, ",")));
                 }
             });
@@ -1148,7 +1146,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .dtype("[event] [freq] [tids...]")
             .action([&](parser_t& p) {
                 auto _v = p.get<std::deque<std::string>>("sample-overflow");
-                update_env(_data, "ROCPROFSYS_SAMPLING_OVERFLOW", true);
+                update_env(_data, env_vars::SAMPLING_OVERFLOW, true);
 
                 if(!_v.empty())
                 {
@@ -1158,17 +1156,17 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
                             "'--sample-overflow {} ...' conflicts with "
                             "'--sampling-overflow-event {}' option",
                             _v.front(), p.get<std::string>("sampling-overflow-event")));
-                    update_env(_data, "ROCPROFSYS_SAMPLING_OVERFLOW_EVENT", _v.front());
+                    update_env(_data, env_vars::SAMPLING_OVERFLOW_EVENT, _v.front());
                     _v.pop_front();
                 }
                 if(!_v.empty())
                 {
-                    update_env(_data, "ROCPROFSYS_SAMPLING_OVERFLOW_FREQ", _v.front());
+                    update_env(_data, env_vars::SAMPLING_OVERFLOW_FREQ, _v.front());
                     _v.pop_front();
                 }
                 if(!_v.empty())
                 {
-                    update_env(_data, "ROCPROFSYS_SAMPLING_OVERFLOW_TIDS",
+                    update_env(_data, env_vars::SAMPLING_OVERFLOW_TIDS,
                                fmt::format("{}", fmt::join(_v, ",")));
                 }
             });
@@ -1195,7 +1193,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .action([&](parser_t& p) {
                 auto _events =
                     fmt::format("{}", fmt::join(p.get<strvec_t>("cpu-events"), ","));
-                update_env(_data, "ROCPROFSYS_PAPI_EVENTS", _events);
+                update_env(_data, env_vars::PAPI_EVENTS, _events);
             });
 
         _data.reg.processed_environs.emplace("cpu_events");
@@ -1213,7 +1211,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .action([&](parser_t& p) {
                 auto _events =
                     fmt::format("{}", fmt::join(p.get<strvec_t>("gpu-events"), ","));
-                update_env(_data, "ROCPROFSYS_ROCM_EVENTS", _events);
+                update_env(_data, env_vars::ROCM_EVENTS, _events);
             });
 
         _data.reg.processed_environs.emplace("gpu_events");
@@ -1235,7 +1233,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
                           "Include inline info in output when available")
             .max_count(1)
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_SAMPLING_INCLUDE_INLINES",
+                update_env(_data, env_vars::SAMPLING_INCLUDE_INLINES,
                            p.get<bool>("inlines"));
             });
 

--- a/projects/rocprofiler-systems/source/lib/core/argparse.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse.cpp
@@ -538,7 +538,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .dtype("int and/or range")
             .action([&](parser_t& p) {
                 update_env(
-                    _data, "ROCPROFSYS_RANK_FILTER_LOGS",
+                    _data, env_vars::RANK_FILTER_LOGS,
                     fmt::format("{}",
                                 fmt::join(p.get<strvec_t>("rank-filter-logs"), ",")));
             });

--- a/projects/rocprofiler-systems/source/lib/core/argparse.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse.cpp
@@ -114,10 +114,10 @@ init_parser(parser_data& _data)
         path::realpath(path::get_internal_libpath("librocprof-sys.so").c_str());
 
     auto _libexecpath = path::realpath(path::get_internal_script_path());
-    update_env(_data, "ROCPROFSYS_SCRIPT_PATH", _libexecpath, update_mode::REPLACE);
+    update_env(_data, env_vars::SCRIPT_PATH, _libexecpath, update_mode::REPLACE);
 
     auto _rootpath = path::realpath(path::get_rocprofsys_root());
-    update_env(_data, "ROCPROFSYS_ROOT", _rootpath, update_mode::REPLACE);
+    update_env(_data, env_vars::ROOT, _rootpath, update_mode::REPLACE);
 
     return _data;
 }
@@ -204,8 +204,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .dtype("string")
             .choices({ "trace", "debug", "info", "warn", "error", "critical", "off" })
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_LOG_LEVEL",
-                           p.get<std::string>("log-level"));
+                update_env(_data, env_vars::LOG_LEVEL, p.get<std::string>("log-level"));
             });
 
         _data.reg.processed_environs.emplace("log_level");
@@ -220,7 +219,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
                 auto _monochrome     = p.get<bool>("monochrome");
                 _data.out.monochrome = _monochrome;
                 p.set_use_color(!_monochrome);
-                update_env(_data, "ROCPROFSYS_MONOCHROME", (_monochrome) ? "1" : "0");
+                update_env(_data, env_vars::MONOCHROME, (_monochrome) ? "1" : "0");
                 update_env(_data, "MONOCHROME", (_monochrome) ? "1" : "0");
             });
 
@@ -233,8 +232,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .add_argument({ "--debug" },
                           "[DEPRECATED Use --log-level=debug] Debug output")
             .max_count(1)
-            .action(
-                [&](parser_t&) { update_env(_data, "ROCPROFSYS_LOG_LEVEL", "debug"); });
+            .action([&](parser_t&) { update_env(_data, env_vars::LOG_LEVEL, "debug"); });
 
         _data.reg.processed_environs.emplace("debug");
     }
@@ -249,7 +247,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .action([&](parser_t& p) {
                 auto _v           = p.get<int>("verbose");
                 _data.out.verbose = _v;
-                update_env(_data, "ROCPROFSYS_VERBOSE", _v);
+                update_env(_data, env_vars::VERBOSE, _v);
 
                 constexpr std::array<const char*, 5> log_levels = { "off", "info",
                                                                     "debug", "debug",
@@ -257,7 +255,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
 
                 auto index =
                     std::clamp(_v + 1, 0, static_cast<int>(log_levels.size() - 1));
-                update_env(_data, "ROCPROFSYS_LOG_LEVEL", log_levels[index]);
+                update_env(_data, env_vars::LOG_LEVEL, log_levels[index]);
             });
 
         _data.reg.processed_environs.emplace("verbose");
@@ -275,7 +273,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .min_count(1)
             .dtype("filepath")
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_CONFIG_FILE",
+                update_env(_data, env_vars::CONFIG_FILE,
                            fmt::format("{}", fmt::join(p.get<strvec_t>("config"), ":")));
             });
 
@@ -295,8 +293,8 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .dtype("path [prefix]")
             .action([&](parser_t& p) {
                 auto _v = p.get<strvec_t>("output");
-                update_env(_data, "ROCPROFSYS_OUTPUT_PATH", _v.at(0));
-                if(_v.size() > 1) update_env(_data, "ROCPROFSYS_OUTPUT_PREFIX", _v.at(1));
+                update_env(_data, env_vars::OUTPUT_PATH, _v.at(0));
+                if(_v.size() > 1) update_env(_data, env_vars::OUTPUT_PREFIX, _v.at(1));
             });
 
         _data.reg.processed_environs.emplace("output");
@@ -311,7 +309,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
                           "Generate a detailed trace (perfetto output)")
             .max_count(1)
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_TRACE", p.get<bool>("trace"));
+                update_env(_data, env_vars::TRACE, p.get<bool>("trace"));
             });
 
         _parser
@@ -320,7 +318,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
                           "generation (higher overhead)")
             .max_count(1)
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_TRACE_LEGACY", p.get<bool>("trace-legacy"));
+                update_env(_data, env_vars::TRACE_LEGACY, p.get<bool>("trace-legacy"));
             });
 
         _data.reg.processed_environs.emplace("trace");
@@ -336,7 +334,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .max_count(1)
             .conflicts({ "flat-profile" })
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_PROFILE", p.get<bool>("profile"));
+                update_env(_data, env_vars::PROFILE, p.get<bool>("profile"));
             });
 
         _data.reg.processed_environs.emplace("profile");
@@ -350,8 +348,8 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .max_count(1)
             .conflicts({ "profile" })
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_PROFILE", p.get<bool>("flat-profile"));
-                update_env(_data, "ROCPROFSYS_FLAT_PROFILE", p.get<bool>("flat-profile"));
+                update_env(_data, env_vars::PROFILE, p.get<bool>("flat-profile"));
+                update_env(_data, env_vars::FLAT_PROFILE, p.get<bool>("flat-profile"));
             });
 
         _data.reg.processed_environs.emplace("flat_profile");
@@ -367,13 +365,13 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .dtype("timer-type")
             .choices({ "cputime", "realtime" })
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_USE_SAMPLING", true);
+                update_env(_data, env_vars::USE_SAMPLING, true);
                 auto _modes = p.get<strset_t>("sample");
                 if(!_modes.empty())
                 {
-                    update_env(_data, "ROCPROFSYS_SAMPLING_CPUTIME",
+                    update_env(_data, env_vars::SAMPLING_CPUTIME,
                                _modes.count("cputime") > 0, update_mode::WEAK);
-                    update_env(_data, "ROCPROFSYS_SAMPLING_REALTIME",
+                    update_env(_data, env_vars::SAMPLING_REALTIME,
                                _modes.count("realtime") > 0, update_mode::WEAK);
                 }
             });
@@ -391,9 +389,9 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .action([&](parser_t& p) {
                 auto _h = p.get<bool>("host");
                 auto _d = p.get<bool>("device");
-                update_env(_data, "ROCPROFSYS_USE_PROCESS_SAMPLING", _h || _d);
-                update_env(_data, "ROCPROFSYS_CPU_FREQ_ENABLED", _h);
-                if(_h) update_env(_data, "ROCPROFSYS_USE_AMD_SMI", _d);
+                update_env(_data, env_vars::USE_PROCESS_SAMPLING, _h || _d);
+                update_env(_data, env_vars::CPU_FREQ_ENABLED, _h);
+                if(_h) update_env(_data, env_vars::USE_AMD_SMI, _d);
             });
 
         _data.reg.processed_environs.emplace("host");
@@ -411,9 +409,9 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .action([&](parser_t& p) {
                 auto _h = p.get<bool>("host");
                 auto _d = p.get<bool>("device");
-                update_env(_data, "ROCPROFSYS_USE_PROCESS_SAMPLING", _h || _d);
-                update_env(_data, "ROCPROFSYS_USE_AMD_SMI", _d);
-                if(_d) update_env(_data, "ROCPROFSYS_CPU_FREQ_ENABLED", _h);
+                update_env(_data, env_vars::USE_PROCESS_SAMPLING, _h || _d);
+                update_env(_data, env_vars::USE_AMD_SMI, _d);
+                if(_d) update_env(_data, env_vars::CPU_FREQ_ENABLED, _h);
             });
 
         _data.reg.processed_environs.emplace("device");
@@ -430,11 +428,11 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .count(1)
             .dtype("seconds")
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_TRACE_DELAY", p.get<double>("wait"),
+                update_env(_data, env_vars::TRACE_DELAY, p.get<double>("wait"),
                            update_mode::WEAK);
-                update_env(_data, "ROCPROFSYS_SAMPLING_DELAY", p.get<double>("wait"),
+                update_env(_data, env_vars::SAMPLING_DELAY, p.get<double>("wait"),
                            update_mode::WEAK);
-                update_env(_data, "ROCPROFSYS_CAUSAL_DELAY", p.get<double>("wait"),
+                update_env(_data, env_vars::CAUSAL_DELAY, p.get<double>("wait"),
                            update_mode::WEAK);
             });
 
@@ -451,11 +449,11 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .count(1)
             .dtype("seconds")
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_TRACE_DURATION", p.get<double>("duration"),
+                update_env(_data, env_vars::TRACE_DURATION, p.get<double>("duration"),
                            update_mode::WEAK);
-                update_env(_data, "ROCPROFSYS_SAMPLING_DURATION",
-                           p.get<double>("duration"), update_mode::WEAK);
-                update_env(_data, "ROCPROFSYS_CAUSAL_DURATION", p.get<double>("duration"),
+                update_env(_data, env_vars::SAMPLING_DURATION, p.get<double>("duration"),
+                           update_mode::WEAK);
+                update_env(_data, env_vars::CAUSAL_DURATION, p.get<double>("duration"),
                            update_mode::WEAK);
             });
 
@@ -472,7 +470,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .min_count(1)
             .dtype("period-spec(s)")
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_TRACE_PERIODS",
+                update_env(_data, env_vars::TRACE_PERIODS,
                            fmt::format("{}", fmt::join(p.get<strvec_t>("periods"), " ")),
                            update_mode::WEAK);
             });
@@ -491,7 +489,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .count(1)
             .dtype("string")
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_SELECTED_REGIONS",
+                update_env(_data, env_vars::SELECTED_REGIONS,
                            p.get<std::string>("selected-regions"));
             });
 
@@ -508,7 +506,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .dtype("string")
             .required({ "rank-filter-output" })
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_RANK_FILTER_ID",
+                update_env(_data, env_vars::RANK_FILTER_ID,
                            p.get<std::string>("rank-filter-id"));
             });
 
@@ -526,7 +524,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .dtype("int and/or range")
             .action([&](parser_t& p) {
                 update_env(
-                    _data, "ROCPROFSYS_RANK_FILTER_OUTPUT",
+                    _data, env_vars::RANK_FILTER_OUTPUT,
                     fmt::format("{}",
                                 fmt::join(p.get<strvec_t>("rank-filter-output"), ",")));
             });
@@ -554,7 +552,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
         _backend_choices.erase("amd-smi");
         _backend_choices.erase("rocm");
 
-        update_env(_data, "ROCPROFSYS_USE_AMD_SMI", false);
+        update_env(_data, env_vars::USE_AMD_SMI, false);
     }
 
     _parser.start_group("BACKEND OPTIONS",
@@ -573,14 +571,14 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
                 auto _update = [&](const auto& _opt, bool _cond) {
                     if(_cond || _v.count("all") > 0) update_env(_data, _opt, true);
                 };
-                _update("ROCPROFSYS_USE_KOKKOSP", _v.count("kokkosp") > 0);
-                _update("ROCPROFSYS_USE_MPIP", _v.count("mpip") > 0);
-                _update("ROCPROFSYS_USE_OMPT", _v.count("ompt") > 0);
-                _update("ROCPROFSYS_USE_RCCLP", _v.count("rcclp") > 0);
-                _update("ROCPROFSYS_USE_AMD_SMI", _v.count("amd-smi") > 0);
-                _update("ROCPROFSYS_TRACE_THREAD_LOCKS", _v.count("mutex-locks") > 0);
-                _update("ROCPROFSYS_TRACE_THREAD_RW_LOCKS", _v.count("rw-locks") > 0);
-                _update("ROCPROFSYS_TRACE_THREAD_SPIN_LOCKS", _v.count("spin-locks") > 0);
+                _update(env_vars::USE_KOKKOSP, _v.count("kokkosp") > 0);
+                _update(env_vars::USE_MPIP, _v.count("mpip") > 0);
+                _update(env_vars::USE_OMPT, _v.count("ompt") > 0);
+                _update(env_vars::USE_RCCLP, _v.count("rcclp") > 0);
+                _update(env_vars::USE_AMD_SMI, _v.count("amd-smi") > 0);
+                _update(env_vars::TRACE_THREAD_LOCKS, _v.count("mutex-locks") > 0);
+                _update(env_vars::TRACE_THREAD_RW_LOCKS, _v.count("rw-locks") > 0);
+                _update(env_vars::TRACE_THREAD_SPIN_LOCKS, _v.count("spin-locks") > 0);
 
                 if(_v.count("all") > 0 || _v.count("kokkosp") > 0)
                     update_env(_data, "KOKKOS_TOOLS_LIBS", _data.env.omni_libpath,
@@ -602,14 +600,14 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
                 auto _update = [&](const auto& _opt, bool _cond) {
                     if(_cond || _v.count("all") > 0) update_env(_data, _opt, false);
                 };
-                _update("ROCPROFSYS_USE_KOKKOSP", _v.count("kokkosp") > 0);
-                _update("ROCPROFSYS_USE_MPIP", _v.count("mpip") > 0);
-                _update("ROCPROFSYS_USE_OMPT", _v.count("ompt") > 0);
-                _update("ROCPROFSYS_USE_RCCLP", _v.count("rcclp") > 0);
-                _update("ROCPROFSYS_USE_AMD_SMI", _v.count("amd-smi") > 0);
-                _update("ROCPROFSYS_TRACE_THREAD_LOCKS", _v.count("mutex-locks") > 0);
-                _update("ROCPROFSYS_TRACE_THREAD_RW_LOCKS", _v.count("rw-locks") > 0);
-                _update("ROCPROFSYS_TRACE_THREAD_SPIN_LOCKS", _v.count("spin-locks") > 0);
+                _update(env_vars::USE_KOKKOSP, _v.count("kokkosp") > 0);
+                _update(env_vars::USE_MPIP, _v.count("mpip") > 0);
+                _update(env_vars::USE_OMPT, _v.count("ompt") > 0);
+                _update(env_vars::USE_RCCLP, _v.count("rcclp") > 0);
+                _update(env_vars::USE_AMD_SMI, _v.count("amd-smi") > 0);
+                _update(env_vars::TRACE_THREAD_LOCKS, _v.count("mutex-locks") > 0);
+                _update(env_vars::TRACE_THREAD_RW_LOCKS, _v.count("rw-locks") > 0);
+                _update(env_vars::TRACE_THREAD_SPIN_LOCKS, _v.count("spin-locks") > 0);
 
                 if(_v.count("all") > 0 || _v.count("kokkosp") > 0)
                     remove_env(_data.env.current, "KOKKOS_TOOLS_LIBS", _data.env.initial);
@@ -657,7 +655,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .count(1)
             .dtype("filepath")
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_PERFETTO_FILE",
+                update_env(_data, env_vars::PERFETTO_FILE,
                            p.get<std::string>("trace-file"));
             });
 
@@ -673,7 +671,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .count(1)
             .dtype("KB")
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_PERFETTO_BUFFER_SIZE_KB",
+                update_env(_data, env_vars::PERFETTO_BUFFER_SIZE_KB,
                            p.get<std::int64_t>("trace-buffer-size"));
             });
 
@@ -688,7 +686,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .dtype("policy")
             .choices({ "discard", "ring_buffer" })
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_PERFETTO_FILL_POLICY",
+                update_env(_data, env_vars::PERFETTO_FILL_POLICY,
                            p.get<std::string>("trace-fill-policy"));
             });
 
@@ -708,7 +706,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .count(1)
             .dtype("seconds")
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_TRACE_DELAY", p.get<double>("trace-wait"));
+                update_env(_data, env_vars::TRACE_DELAY, p.get<double>("trace-wait"));
             });
 
         _data.reg.processed_environs.emplace("trace_delay");
@@ -725,7 +723,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .count(1)
             .dtype("seconds")
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_TRACE_DURATION",
+                update_env(_data, env_vars::TRACE_DURATION,
                            p.get<double>("trace-duration"));
             });
 
@@ -745,7 +743,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .dtype("period-spec(s)")
             .action([&](parser_t& p) {
                 update_env(
-                    _data, "ROCPROFSYS_TRACE_PERIODS",
+                    _data, env_vars::TRACE_PERIODS,
                     fmt::format("{}", fmt::join(p.get<strvec_t>("trace-periods"), ",")));
             });
 
@@ -770,7 +768,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .count(1)
             .dtype("clock-id")
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_TRACE_PERIOD_CLOCK_ID",
+                update_env(_data, env_vars::TRACE_PERIOD_CLOCK_ID,
                            p.get<double>("trace-clock-id"));
             })
             .choices(_clock_id_choices.first)
@@ -794,12 +792,12 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .choices({ "text", "json", "console" })
             .action([&](parser_t& p) {
                 auto _v = p.get<strset_t>("profile-format");
-                update_env(_data, "ROCPROFSYS_PROFILE", true);
+                update_env(_data, env_vars::PROFILE, true);
                 if(!_v.empty())
                 {
-                    update_env(_data, "ROCPROFSYS_TEXT_OUTPUT", _v.count("text") != 0);
-                    update_env(_data, "ROCPROFSYS_JSON_OUTPUT", _v.count("json") != 0);
-                    update_env(_data, "ROCPROFSYS_COUT_OUTPUT", _v.count("console") != 0);
+                    update_env(_data, env_vars::TEXT_OUTPUT, _v.count("text") != 0);
+                    update_env(_data, env_vars::JSON_OUTPUT, _v.count("json") != 0);
+                    update_env(_data, env_vars::COUT_OUTPUT, _v.count("console") != 0);
                 }
             });
 
@@ -822,9 +820,9 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .dtype("path [prefix]")
             .action([&](parser_t& p) {
                 auto _v = p.get<strvec_t>("profile-diff");
-                update_env(_data, "ROCPROFSYS_DIFF_OUTPUT", true);
-                update_env(_data, "ROCPROFSYS_INPUT_PATH", _v.at(0));
-                if(_v.size() > 1) update_env(_data, "ROCPROFSYS_INPUT_PREFIX", _v.at(1));
+                update_env(_data, env_vars::DIFF_OUTPUT, true);
+                update_env(_data, env_vars::INPUT_PATH, _v.at(0));
+                if(_v.size() > 1) update_env(_data, env_vars::INPUT_PREFIX, _v.at(1));
             });
 
         _data.reg.processed_environs.emplace("profile_diff");
@@ -847,7 +845,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .count(1)
             .dtype("floating-point")
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_PROCESS_SAMPLING_FREQ",
+                update_env(_data, env_vars::PROCESS_SAMPLING_FREQ,
                            p.get<double>("process-freq"));
             });
 
@@ -864,7 +862,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .count(1)
             .dtype("seconds")
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_PROCESS_SAMPLING_DELAY",
+                update_env(_data, env_vars::PROCESS_SAMPLING_DELAY,
                            p.get<double>("process-wait"));
             });
 
@@ -881,7 +879,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .count(1)
             .dtype("seconds")
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_SAMPLING_PROCESS_DURATION",
+                update_env(_data, env_vars::SAMPLING_PROCESS_DURATION,
                            p.get<double>("process-duration"));
             });
 
@@ -898,7 +896,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .dtype("int and/or range")
             .required({ "host" })
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_SAMPLING_CPUS",
+                update_env(_data, env_vars::SAMPLING_CPUS,
                            fmt::format("{}", fmt::join(p.get<strvec_t>("cpus"), ",")));
             });
 
@@ -914,7 +912,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .dtype("int and/or range")
             .required({ "device" })
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_SAMPLING_GPUS",
+                update_env(_data, env_vars::SAMPLING_GPUS,
                            fmt::format("{}", fmt::join(p.get<strvec_t>("gpus"), ",")));
             });
 
@@ -930,7 +928,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .dtype("list of strings")
             .required({ "device" })
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_SAMPLING_AINICS",
+                update_env(_data, env_vars::SAMPLING_AINICS,
                            fmt::format("{}", fmt::join(p.get<strvec_t>("ai-nics"), ",")));
             });
 
@@ -950,7 +948,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .count(1)
             .dtype("floating-point")
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_SAMPLING_FREQ",
+                update_env(_data, env_vars::SAMPLING_FREQ,
                            p.get<double>("sampling-freq"));
             });
 
@@ -969,7 +967,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .dtype("int and/or range")
             .action([&](parser_t& p) {
                 update_env(
-                    _data, "ROCPROFSYS_SAMPLING_TIDS",
+                    _data, env_vars::SAMPLING_TIDS,
                     fmt::format(
                         "{}", fmt::join(p.get<std::vector<std::int64_t>>("tids"), ", ")));
             });
@@ -991,7 +989,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .count(1)
             .dtype("seconds")
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_SAMPLING_DELAY",
+                update_env(_data, env_vars::SAMPLING_DELAY,
                            p.get<double>("sampling-wait"));
             });
 
@@ -1010,7 +1008,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .count(1)
             .dtype("seconds")
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_SAMPLING_DURATION",
+                update_env(_data, env_vars::SAMPLING_DURATION,
                            p.get<double>("sampling-duration"));
             });
 
@@ -1028,20 +1026,20 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .dtype("[freq] [delay] [tids...]")
             .action([&](parser_t& p) {
                 auto _v = p.get<std::deque<std::string>>("sample-cputime");
-                update_env(_data, "ROCPROFSYS_SAMPLING_CPUTIME", true);
+                update_env(_data, env_vars::SAMPLING_CPUTIME, true);
                 if(!_v.empty())
                 {
-                    update_env(_data, "ROCPROFSYS_SAMPLING_CPUTIME_FREQ", _v.front());
+                    update_env(_data, env_vars::SAMPLING_CPUTIME_FREQ, _v.front());
                     _v.pop_front();
                 }
                 if(!_v.empty())
                 {
-                    update_env(_data, "ROCPROFSYS_SAMPLING_CPUTIME_DELAY", _v.front());
+                    update_env(_data, env_vars::SAMPLING_CPUTIME_DELAY, _v.front());
                     _v.pop_front();
                 }
                 if(!_v.empty())
                 {
-                    update_env(_data, "ROCPROFSYS_SAMPLING_CPUTIME_TIDS",
+                    update_env(_data, env_vars::SAMPLING_CPUTIME_TIDS,
                                fmt::format("{}", fmt::join(_v, ",")));
                 }
             });
@@ -1056,20 +1054,20 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .dtype("[freq] [delay] [tids...]")
             .action([&](parser_t& p) {
                 auto _v = p.get<std::deque<std::string>>("sample-realtime");
-                update_env(_data, "ROCPROFSYS_SAMPLING_REALTIME", true);
+                update_env(_data, env_vars::SAMPLING_REALTIME, true);
                 if(!_v.empty())
                 {
-                    update_env(_data, "ROCPROFSYS_SAMPLING_REALTIME_FREQ", _v.front());
+                    update_env(_data, env_vars::SAMPLING_REALTIME_FREQ, _v.front());
                     _v.pop_front();
                 }
                 if(!_v.empty())
                 {
-                    update_env(_data, "ROCPROFSYS_SAMPLING_REALTIME_DELAY", _v.front());
+                    update_env(_data, env_vars::SAMPLING_REALTIME_DELAY, _v.front());
                     _v.pop_front();
                 }
                 if(!_v.empty())
                 {
-                    update_env(_data, "ROCPROFSYS_SAMPLING_REALTIME_TIDS",
+                    update_env(_data, env_vars::SAMPLING_REALTIME_TIDS,
                                fmt::format("{}", fmt::join(_v, ",")));
                 }
             });
@@ -1084,7 +1082,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .dtype("[event] [freq] [tids...]")
             .action([&](parser_t& p) {
                 auto _v = p.get<std::deque<std::string>>("sample-overflow");
-                update_env(_data, "ROCPROFSYS_SAMPLING_OVERFLOW", true);
+                update_env(_data, env_vars::SAMPLING_OVERFLOW, true);
 
                 if(!_v.empty())
                 {
@@ -1094,17 +1092,17 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
                             "'--sample-overflow {} ...' conflicts with "
                             "'--sampling-overflow-event {}' option",
                             _v.front(), p.get<std::string>("sampling-overflow-event")));
-                    update_env(_data, "ROCPROFSYS_SAMPLING_OVERFLOW_EVENT", _v.front());
+                    update_env(_data, env_vars::SAMPLING_OVERFLOW_EVENT, _v.front());
                     _v.pop_front();
                 }
                 if(!_v.empty())
                 {
-                    update_env(_data, "ROCPROFSYS_SAMPLING_OVERFLOW_FREQ", _v.front());
+                    update_env(_data, env_vars::SAMPLING_OVERFLOW_FREQ, _v.front());
                     _v.pop_front();
                 }
                 if(!_v.empty())
                 {
-                    update_env(_data, "ROCPROFSYS_SAMPLING_OVERFLOW_TIDS",
+                    update_env(_data, env_vars::SAMPLING_OVERFLOW_TIDS,
                                fmt::format("{}", fmt::join(_v, ",")));
                 }
             });
@@ -1131,7 +1129,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .action([&](parser_t& p) {
                 auto _events =
                     fmt::format("{}", fmt::join(p.get<strvec_t>("cpu-events"), ","));
-                update_env(_data, "ROCPROFSYS_PAPI_EVENTS", _events);
+                update_env(_data, env_vars::PAPI_EVENTS, _events);
             });
 
         _data.reg.processed_environs.emplace("cpu_events");
@@ -1149,7 +1147,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .action([&](parser_t& p) {
                 auto _events =
                     fmt::format("{}", fmt::join(p.get<strvec_t>("gpu-events"), ","));
-                update_env(_data, "ROCPROFSYS_ROCM_EVENTS", _events);
+                update_env(_data, env_vars::ROCM_EVENTS, _events);
             });
 
         _data.reg.processed_environs.emplace("gpu_events");
@@ -1171,7 +1169,7 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
                           "Include inline info in output when available")
             .max_count(1)
             .action([&](parser_t& p) {
-                update_env(_data, "ROCPROFSYS_SAMPLING_INCLUDE_INLINES",
+                update_env(_data, env_vars::SAMPLING_INCLUDE_INLINES,
                            p.get<bool>("inlines"));
             });
 

--- a/projects/rocprofiler-systems/source/lib/core/argparse.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse.cpp
@@ -831,12 +831,12 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
                 { "trace", "profile", "flat-profile", "profile-format", "use-rocpd" })
             .action([&](parser_t& p) {
                 const auto _sel = resolve_output_format(p.get<strset_t>("output-format"));
-                update_env(_data, "ROCPROFSYS_TRACE", _sel.perfetto);
-                update_env(_data, "ROCPROFSYS_USE_ROCPD", _sel.rocpd);
-                update_env(_data, "ROCPROFSYS_PROFILE", _sel.profile());
-                update_env(_data, "ROCPROFSYS_JSON_OUTPUT", _sel.json);
-                update_env(_data, "ROCPROFSYS_TEXT_OUTPUT", _sel.text);
-                update_env(_data, "ROCPROFSYS_COUT_OUTPUT", false);
+                update_env(_data, env_vars::TRACE, _sel.perfetto);
+                update_env(_data, env_vars::USE_ROCPD, _sel.rocpd);
+                update_env(_data, env_vars::PROFILE, _sel.profile());
+                update_env(_data, env_vars::JSON_OUTPUT, _sel.json);
+                update_env(_data, env_vars::TEXT_OUTPUT, _sel.text);
+                update_env(_data, env_vars::COUT_OUTPUT, false);
             });
 
         _data.reg.processed_environs.emplace("output_format");

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -4,6 +4,7 @@
 #include "config.hpp"
 #include "amd_smi.hpp"
 #include "common/defines.h"
+#include "common/env_vars.hpp"
 #include "common/environment.hpp"
 #include "common/static_object.hpp"
 #include "constraint.hpp"
@@ -65,8 +66,8 @@ using settings = tim::settings;
 
 namespace
 {
-int  verbose_value  = rocprofsys::get_env<int>("ROCPROFSYS_VERBOSE", 0);
-bool debug_value    = rocprofsys::get_env<bool>("ROCPROFSYS_DEBUG", false);
+int  verbose_value  = rocprofsys::get_env<int>(env_vars::VERBOSE, 0);
+bool debug_value    = rocprofsys::get_env<bool>(env_vars::DEBUG_MODE, false);
 auto configure_once = std::once_flag{};
 
 TIMEMORY_NOINLINE bool&
@@ -118,49 +119,54 @@ get_available_categories()
 
 using utility::parse_numeric_range;
 
-#define ROCPROFSYS_CONFIG_SETTING(TYPE, ENV_NAME, DESCRIPTION, INITIAL_VALUE, ...)       \
-    [&]() {                                                                              \
-        auto _ret = _config->insert<TYPE, TYPE>(                                         \
-            ENV_NAME, get_setting_name(ENV_NAME), DESCRIPTION, TYPE{ INITIAL_VALUE },    \
-            std::set<std::string>{ "custom", "rocprofsys", "librocprof-sys",             \
-                                   __VA_ARGS__ });                                       \
-        if(!_ret.second)                                                                 \
-        {                                                                                \
-            LOG_WARNING("Duplicate setting: {} / {}", get_setting_name(ENV_NAME),        \
-                        ENV_NAME);                                                       \
-        }                                                                                \
-        return _config->find(ENV_NAME)->second;                                          \
+// Accepts either a `const char*` literal or `std::string_view` (e.g. env_vars::FOO)
+// for ENV_NAME — std::string{} can be constructed from either.
+#define ROCPROFSYS_CONFIG_SETTING(TYPE, ENV_NAME, DESCRIPTION, INITIAL_VALUE, ...)           \
+    [&]() {                                                                                  \
+        auto _env_name = std::string{ ENV_NAME };                                            \
+        auto _ret      = _config->insert<TYPE, TYPE>(                                        \
+            _env_name, get_setting_name(_env_name), DESCRIPTION, TYPE{ INITIAL_VALUE }, \
+            std::set<std::string>{ "custom", "rocprofsys", "librocprof-sys",            \
+                                        __VA_ARGS__ });                                      \
+        if(!_ret.second)                                                                     \
+        {                                                                                    \
+            LOG_WARNING("Duplicate setting: {} / {}", get_setting_name(_env_name),           \
+                        _env_name);                                                          \
+        }                                                                                    \
+        return _config->find(_env_name)->second;                                             \
     }()
 
 // below does not include "librocprof-sys"
-#define ROCPROFSYS_CONFIG_EXT_SETTING(TYPE, ENV_NAME, DESCRIPTION, INITIAL_VALUE, ...)   \
-    [&]() {                                                                              \
-        auto _ret = _config->insert<TYPE, TYPE>(                                         \
-            ENV_NAME, get_setting_name(ENV_NAME), DESCRIPTION, TYPE{ INITIAL_VALUE },    \
-            std::set<std::string>{ "custom", "rocprofsys", __VA_ARGS__ });               \
-        if(!_ret.second)                                                                 \
-        {                                                                                \
-            LOG_WARNING("Duplicate setting: {} / {}", get_setting_name(ENV_NAME),        \
-                        ENV_NAME);                                                       \
-        }                                                                                \
-        return _config->find(ENV_NAME)->second;                                          \
+#define ROCPROFSYS_CONFIG_EXT_SETTING(TYPE, ENV_NAME, DESCRIPTION, INITIAL_VALUE, ...)       \
+    [&]() {                                                                                  \
+        auto _env_name = std::string{ ENV_NAME };                                            \
+        auto _ret      = _config->insert<TYPE, TYPE>(                                        \
+            _env_name, get_setting_name(_env_name), DESCRIPTION, TYPE{ INITIAL_VALUE }, \
+            std::set<std::string>{ "custom", "rocprofsys", __VA_ARGS__ });              \
+        if(!_ret.second)                                                                     \
+        {                                                                                    \
+            LOG_WARNING("Duplicate setting: {} / {}", get_setting_name(_env_name),           \
+                        _env_name);                                                          \
+        }                                                                                    \
+        return _config->find(_env_name)->second;                                             \
     }()
 
 // setting + command line option
-#define ROCPROFSYS_CONFIG_CL_SETTING(TYPE, ENV_NAME, DESCRIPTION, INITIAL_VALUE,         \
-                                     CMD_LINE, ...)                                      \
-    [&]() {                                                                              \
-        auto _ret = _config->insert<TYPE, TYPE>(                                         \
-            ENV_NAME, get_setting_name(ENV_NAME), DESCRIPTION, TYPE{ INITIAL_VALUE },    \
-            std::set<std::string>{ "custom", "rocprofsys", "librocprof-sys",             \
-                                   __VA_ARGS__ },                                        \
-            std::vector<std::string>{ CMD_LINE });                                       \
-        if(!_ret.second)                                                                 \
-        {                                                                                \
-            LOG_WARNING("Duplicate setting: {} / {}", get_setting_name(ENV_NAME),        \
-                        ENV_NAME);                                                       \
-        }                                                                                \
-        return _config->find(ENV_NAME)->second;                                          \
+#define ROCPROFSYS_CONFIG_CL_SETTING(TYPE, ENV_NAME, DESCRIPTION, INITIAL_VALUE,             \
+                                     CMD_LINE, ...)                                          \
+    [&]() {                                                                                  \
+        auto _env_name = std::string{ ENV_NAME };                                            \
+        auto _ret      = _config->insert<TYPE, TYPE>(                                        \
+            _env_name, get_setting_name(_env_name), DESCRIPTION, TYPE{ INITIAL_VALUE }, \
+            std::set<std::string>{ "custom", "rocprofsys", "librocprof-sys",            \
+                                        __VA_ARGS__ },                                       \
+            std::vector<std::string>{ CMD_LINE });                                      \
+        if(!_ret.second)                                                                     \
+        {                                                                                    \
+            LOG_WARNING("Duplicate setting: {} / {}", get_setting_name(_env_name),           \
+                        _env_name);                                                          \
+        }                                                                                    \
+        return _config->find(_env_name)->second;                                             \
     }()
 }  // namespace
 
@@ -254,44 +260,43 @@ configure_settings(bool _init)
     auto _config = *get_config_impl();
 
     // if using timemory, default to perfetto being off
-    auto _default_perfetto_v = !rocprofsys::get_env<bool>("ROCPROFSYS_PROFILE", false);
+    auto _default_perfetto_v = !rocprofsys::get_env<bool>(env_vars::PROFILE, false);
 
-    auto _system_backend =
-        rocprofsys::get_env("ROCPROFSYS_PERFETTO_BACKEND_SYSTEM", false);
+    auto _system_backend = rocprofsys::get_env(env_vars::PERFETTO_BACKEND_SYSTEM, false);
 
-    ROCPROFSYS_CONFIG_SETTING(std::string, "ROCPROFSYS_LOG_LEVEL",
+    ROCPROFSYS_CONFIG_SETTING(std::string, env_vars::LOG_LEVEL,
                               "Rocprofiler-systems log level", "info", "debugging",
                               "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(std::string, "ROCPROFSYS_LOG_FILE",
+    ROCPROFSYS_CONFIG_SETTING(std::string, env_vars::LOG_FILE,
                               "Filename for the Rocprofiler-systems log file. Leave "
                               "empty to not write to a file.",
                               "rocprof-sys-log.txt", "debugging", "advanced");
 
-    auto _rocprofsys_debug = _config->get<bool>("ROCPROFSYS_DEBUG");
+    auto _rocprofsys_debug = _config->get<bool>(std::string{ env_vars::DEBUG_MODE });
     if(_rocprofsys_debug) rocprofsys::set_env("TIMEMORY_DEBUG_SETTINGS", "1", 0);
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_MODE",
+        std::string, env_vars::MODE,
         "Data collection mode. Used to set default values for ROCPROFSYS_USE_* options. "
         "Typically set by rocprof-sys binary instrumenter.",
         std::string{ "trace" }, "backend", "advanced", "mode")
         ->set_choices({ "trace", "sampling", "causal", "coverage" });
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_CI",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::CI,
                               "Enable some runtime validation checks (typically enabled "
                               "for continuous integration)",
                               false, "debugging", "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_MONOCHROME", "Disable colorized logging",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::MONOCHROME, "Disable colorized logging",
                               false, "debugging", "advanced");
 
-    ROCPROFSYS_CONFIG_EXT_SETTING(int, "ROCPROFSYS_DL_VERBOSE",
+    ROCPROFSYS_CONFIG_EXT_SETTING(int, env_vars::DL_VERBOSE,
                                   "Verbosity within the rocprof-sys-dl library", 0,
                                   "debugging", "librocprof-sys-dl", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        size_t, "ROCPROFSYS_NUM_THREADS_HINT",
+        size_t, env_vars::NUM_THREADS_HINT,
         "This is hint for how many threads are expected to be created in the "
         "application. Setting this value allows rocprof-sys to preallocate resources "
         "during initialization and warn about any potential issues. For example, when "
@@ -302,14 +307,14 @@ configure_settings(bool _init)
         "threads that get sampled, rocprof-sys can start all the background threads "
         "during "
         "initialization",
-        get_env<size_t>("ROCPROFSYS_NUM_THREADS", 1), "threading", "performance",
+        get_env<size_t>(env_vars::NUM_THREADS.data(), 1), "threading", "performance",
         "sampling", "parallelism", "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_TRACE",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::TRACE,
                               "Enable perfetto backend for tracing", _default_perfetto_v,
                               "backend", "perfetto");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_TRACE_LEGACY",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::TRACE_LEGACY,
                               "[DEPRECATED] The new default option is to use data from "
                               "cached buffer. When set to true system will use "
                               "legacy direct mode for perfetto tracing instead of "
@@ -317,120 +322,119 @@ configure_settings(bool _init)
                               "cached mode with minimal runtime overhead.",
                               false, "backend", "perfetto");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_USE_PERFETTO",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::USE_PERFETTO,
                               "[DEPRECATED] Renamed to ROCPROFSYS_TRACE", false,
                               "backend", "perfetto", "deprecated");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_PROFILE", "Enable timemory backend",
-                              !_config->get<bool>("ROCPROFSYS_TRACE"), "backend",
-                              "timemory");
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::PROFILE, "Enable timemory backend",
+                              !_config->get<bool>(std::string{ env_vars::TRACE }),
+                              "backend", "timemory");
 
-    ROCPROFSYS_CONFIG_SETTING(
-        bool, "ROCPROFSYS_USE_TIMEMORY", "[DEPRECATED] Renamed to ROCPROFSYS_PROFILE",
-        !_config->get<bool>("ROCPROFSYS_TRACE"), "backend", "timemory", "deprecated");
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::USE_TIMEMORY,
+                              "[DEPRECATED] Renamed to ROCPROFSYS_PROFILE",
+                              !_config->get<bool>(std::string{ env_vars::TRACE }),
+                              "backend", "timemory", "deprecated");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_USE_CAUSAL",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::USE_CAUSAL,
                               "Enable causal profiling analysis", false, "backend",
                               "causal", "analysis");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_USE_ROCPD", "Enable rocpd backend", false,
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::USE_ROCPD, "Enable rocpd backend", false,
                               "backend", "rocpd");
 
     ROCPROFSYS_CONFIG_SETTING(
-        bool, "ROCPROFSYS_USE_UNIFIED_MEMORY_PROFILING",
+        bool, env_vars::USE_UNIFIED_MEMORY_PROFILING,
         "Enable unified memory profiling reports from KFD page fault and migration "
         "events (requires HSA_XNACK=1 on a supported GPU; required KFD tracing is "
         "enabled automatically)",
         false, "backend", "unified_memory", "kfd");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_USE_AMD_SMI",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::USE_AMD_SMI,
                               "Enable sampling GPU power, temp, utilization, "
                               "vcn_activity, jpeg_activity and memory usage",
                               true, "backend", "amd_smi", "rocm", "process_sampling");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_USE_SAMPLING",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::USE_SAMPLING,
                               "Enable statistical sampling of call-stack", false,
                               "backend", "sampling");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_USE_THREAD_SAMPLING",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::USE_THREAD_SAMPLING,
                               "[DEPRECATED] Renamed to ROCPROFSYS_USE_PROCESS_SAMPLING",
                               true, "backend", "sampling", "process_sampling",
                               "deprecated", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        bool, "ROCPROFSYS_USE_PROCESS_SAMPLING",
+        bool, env_vars::USE_PROCESS_SAMPLING,
         "Enable a background thread which samples process-level and system metrics "
         "such as the CPU/GPU freq, power, memory usage, etc.",
         true, "backend", "sampling", "process_sampling");
 
     ROCPROFSYS_CONFIG_SETTING(
-        bool, "ROCPROFSYS_USE_PID",
+        bool, env_vars::USE_PID,
         "Enable tagging filenames with process identifier (either MPI rank or pid)", true,
         "io", "filename");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_USE_KOKKOSP",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::USE_KOKKOSP,
                               "Enable support for Kokkos Tools", false, "kokkos",
                               "backend");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_USE_MPIP",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::USE_MPIP,
                               "Enable support for MPI functions", true, "mpi", "backend",
                               "parallelism");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_USE_UCX",
-                              "Enable support for UCX functions", false, "ucx", "backend",
-                              "parallelism");
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::USE_UCX, "Enable support for UCX functions",
+                              false, "ucx", "backend", "parallelism");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_USE_SHMEM",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::USE_SHMEM,
                               "Enable support for OpenSHMEM functions", false, "shmem",
                               "backend", "parallelism");
 
     ROCPROFSYS_CONFIG_SETTING(
-        bool, "ROCPROFSYS_USE_RCCLP",
+        bool, env_vars::USE_RCCLP,
         "Enable support for ROCm Communication Collectives Library (RCCL) Performance",
         false, "rocm", "rccl", "backend");
 
     ROCPROFSYS_CONFIG_CL_SETTING(
-        bool, "ROCPROFSYS_KOKKOSP_KERNEL_LOGGER", "Enables kernel logging", false,
+        bool, env_vars::KOKKOSP_KERNEL_LOGGER, "Enables kernel logging", false,
         "--rocprofsys-kokkos-kernel-logger", "kokkos", "debugging", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::int64_t, "ROCPROFSYS_KOKKOSP_NAME_LENGTH_MAX",
+        std::int64_t, env_vars::KOKKOSP_NAME_LENGTH_MAX,
         "Set this to a value > 0 to help avoid unnamed Kokkos Tools "
         "callbacks. Generally, unnamed callbacks are the demangled "
         "name of the function, which is very long",
         0, "kokkos", "debugging", "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(std::string, "ROCPROFSYS_KOKKOSP_PREFIX",
+    ROCPROFSYS_CONFIG_SETTING(std::string, env_vars::KOKKOSP_PREFIX,
                               "Set to [kokkos] to maintain old naming convention", "",
                               "kokkos", "debugging", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        bool, "ROCPROFSYS_KOKKOSP_DEEP_COPY",
+        bool, env_vars::KOKKOSP_DEEP_COPY,
         "Enable tracking deep copies (warning: may corrupt flamegraph in perfetto)",
         false, "kokkos", "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_USE_OMPT",
-                              "Enable support for OpenMP-Tools", false, "openmp", "ompt",
-                              "backend");
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::USE_OMPT, "Enable support for OpenMP-Tools",
+                              false, "openmp", "ompt", "backend");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_USE_CODE_COVERAGE",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::USE_CODE_COVERAGE,
                               "Enable support for code coverage", false, "coverage",
                               "backend", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        double, "ROCPROFSYS_TRACE_DELAY",
+        double, env_vars::TRACE_DELAY,
         "Time in seconds to wait before enabling trace/profile data collection. If "
         "multiple delays + durations are needed, see ROCPROFSYS_TRACE_PERIODS.",
         0.0, "trace", "profile", "perfetto", "timemory");
 
     ROCPROFSYS_CONFIG_SETTING(
-        double, "ROCPROFSYS_TRACE_DURATION",
+        double, env_vars::TRACE_DURATION,
         "If > 0.0, time (in seconds) to collect trace/profile data. If multiple delays + "
         "durations are needed, see ROCPROFSYS_TRACE_PERIODS.",
         0.0, "trace", "profile", "perfetto", "timemory");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_SELECTED_REGIONS",
+        std::string, env_vars::SELECTED_REGIONS,
         "Comma-separated list of roctx region names. When set, only "
         "activity inside roctx regions matching one of these names "
         "(matched against roctxRangeStartA message). Uses process-wide "
@@ -444,14 +448,14 @@ configure_settings(bool _init)
             fmt::format("({}|{}|{})", itr.name, itr.value, itr.raw_name));
     }
 
-    ROCPROFSYS_CONFIG_SETTING(std::string, "ROCPROFSYS_TRACE_PERIODS",
+    ROCPROFSYS_CONFIG_SETTING(std::string, env_vars::TRACE_PERIODS,
                               "Similar to specify trace delay and/or duration except in "
                               "the form <DELAY>:<DURATION>, <DELAY>:<DURATION>:<REPEAT>, "
                               "and/or <DELAY>:<DURATION>:<REPEAT>:<CLOCK_ID>",
                               std::string{}, "trace", "profile", "perfetto", "timemory");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_TRACE_PERIOD_CLOCK_ID",
+        std::string, env_vars::TRACE_PERIOD_CLOCK_ID,
         "Set the default clock ID for ROCPROFSYS_TRACE_DELAY, ROCPROFSYS_TRACE_DURATION, "
         "and/or ROCPROFSYS_TRACE_PERIODS. E.g. \"realtime\" == the delay/duration is "
         "governed by the elapsed realtime, \"cputime\" == the delay/duration is governed "
@@ -462,71 +466,71 @@ configure_settings(bool _init)
         ->set_choices(_clock_choices);
 
     ROCPROFSYS_CONFIG_SETTING(
-        double, "ROCPROFSYS_SAMPLING_FREQ",
+        double, env_vars::SAMPLING_FREQ,
         "Number of software interrupts per second when ROCPROFSYS_USE_SAMPLING=ON", 300.0,
         "sampling", "process_sampling");
 
-    ROCPROFSYS_CONFIG_SETTING(double, "ROCPROFSYS_SAMPLING_CPUTIME_FREQ",
+    ROCPROFSYS_CONFIG_SETTING(double, env_vars::SAMPLING_CPUTIME_FREQ,
                               "Number of software interrupts per second of CPU-time. "
                               "Defaults to ROCPROFSYS_SAMPLING_FREQ when <= 0.0",
                               -1.0, "sampling", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        double, "ROCPROFSYS_SAMPLING_REALTIME_FREQ",
+        double, env_vars::SAMPLING_REALTIME_FREQ,
         "Number of software interrupts per second of real (wall) time. "
         "Defaults to ROCPROFSYS_SAMPLING_FREQ when <= 0.0",
         -1.0, "sampling", "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(double, "ROCPROFSYS_SAMPLING_OVERFLOW_FREQ",
+    ROCPROFSYS_CONFIG_SETTING(double, env_vars::SAMPLING_OVERFLOW_FREQ,
                               "Number of events in between each sample. "
                               "Defaults to ROCPROFSYS_SAMPLING_FREQ when <= 0.0",
                               -1.0, "sampling", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        double, "ROCPROFSYS_SAMPLING_DELAY",
+        double, env_vars::SAMPLING_DELAY,
         "Time (in seconds) to wait before the first sampling signal is delivered, "
         "increasing this value can fix deadlocks during init",
         0.5, "sampling", "process_sampling");
 
-    ROCPROFSYS_CONFIG_SETTING(double, "ROCPROFSYS_SAMPLING_CPUTIME_DELAY",
+    ROCPROFSYS_CONFIG_SETTING(double, env_vars::SAMPLING_CPUTIME_DELAY,
                               "Time (in seconds) to wait before the first CPU-time "
                               "sampling signal is delivered. "
                               "Defaults to ROCPROFSYS_SAMPLING_DELAY when <= 0.0",
                               -1.0, "sampling", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        double, "ROCPROFSYS_SAMPLING_REALTIME_DELAY",
+        double, env_vars::SAMPLING_REALTIME_DELAY,
         "Time (in seconds) to wait before the first real (wall) time sampling signal is "
         "delivered. Defaults to ROCPROFSYS_SAMPLING_DELAY when <= 0.0",
         -1.0, "sampling", "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(double, "ROCPROFSYS_SAMPLING_DURATION",
+    ROCPROFSYS_CONFIG_SETTING(double, env_vars::SAMPLING_DURATION,
                               "If > 0.0, time (in seconds) to sample before stopping",
                               0.0, "sampling", "process_sampling");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_CPU_FREQ_ENABLED",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::CPU_FREQ_ENABLED,
                               "Enable tracking for CPU frequency, memory usage, virtual "
                               "memory usage, peak memory, context switches, page faults, "
                               "user time, and kernel time",
                               false, "process_sampling");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_USE_AINIC",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::USE_AINIC,
                               "Enable tracking for AI NIC metrics", false,
                               "process_sampling");
 
     ROCPROFSYS_CONFIG_SETTING(
-        double, "ROCPROFSYS_PROCESS_SAMPLING_FREQ",
+        double, env_vars::PROCESS_SAMPLING_FREQ,
         "Number of measurements per second when ROCPROFSYS_USE_PROCESS_SAMPLING=ON. If "
         "set to zero, uses ROCPROFSYS_SAMPLING_FREQ value",
         0.0, "process_sampling");
 
-    ROCPROFSYS_CONFIG_SETTING(double, "ROCPROFSYS_PROCESS_SAMPLING_DURATION",
+    ROCPROFSYS_CONFIG_SETTING(double, env_vars::PROCESS_SAMPLING_DURATION,
                               "If > 0.0, time (in seconds) to sample before stopping. If "
                               "less than zero, uses ROCPROFSYS_SAMPLING_DURATION",
                               -1.0, "sampling", "process_sampling");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_SAMPLING_CPUS",
+        std::string, env_vars::SAMPLING_CPUS,
         "CPU socket (physical package) IDs for CPU PMC sampling. Values should be "
         "separated by commas and can be explicit or ranges, e.g. 0,1. Selects which "
         "CPU sockets to monitor; all cores on a selected socket are always sampled. "
@@ -534,14 +538,14 @@ configure_settings(bool _init)
         std::string{ "none" }, "process_sampling");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_CPU_METRICS",
+        std::string, env_vars::CPU_METRICS,
         "CPU metrics to collect. Comma-separated tokens: frequency, load, memory "
         "(page_rss+virt_mem+peak_rss), ctx_switches, page_faults, cpu_time "
         "(user_time+kernel_time). Fine-grained: page_rss, virt_mem, peak_rss, "
         "user_time, kernel_time. Special: all, none",
         std::string{ "all" }, "process_sampling");
 
-    ROCPROFSYS_CONFIG_SETTING(std::string, "ROCPROFSYS_SAMPLING_AINICS",
+    ROCPROFSYS_CONFIG_SETTING(std::string, env_vars::SAMPLING_AINICS,
                               "AI NICs to query when ROCPROFSYS_USE_AMD_SMI=ON. NIC "
                               "names should be separated by "
                               "commas, e.g. eno8303,enp7s0.",
@@ -549,14 +553,14 @@ configure_settings(bool _init)
                               "process_sampling");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_SAMPLING_GPUS",
+        std::string, env_vars::SAMPLING_GPUS,
         "Devices to query when ROCPROFSYS_USE_AMD_SMI=ON. Values should be separated by "
         "commas and can be explicit or ranges, e.g. 0,1,5-8. An empty value implies "
         "'all' and 'none' suppresses all GPU sampling",
         std::string{ "all" }, "amd_smi", "rocm", "process_sampling");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_SAMPLING_TIDS",
+        std::string, env_vars::SAMPLING_TIDS,
         "Limit call-stack sampling to specific thread IDs, starting at zero for the main "
         "thread. Be aware that some libraries, such as ROCm may create additional "
         "threads which increment the TID count. However, no threads started by "
@@ -566,76 +570,76 @@ configure_settings(bool _init)
         std::string{}, "sampling", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_SAMPLING_CPUTIME_TIDS",
+        std::string, env_vars::SAMPLING_CPUTIME_TIDS,
         "Same as ROCPROFSYS_SAMPLING_TIDS but applies specifically to samplers whose "
         "timers are based on the CPU-time. This is useful when you want to restrict "
         "samples to particular threads.",
         std::string{}, "sampling", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_SAMPLING_REALTIME_TIDS",
+        std::string, env_vars::SAMPLING_REALTIME_TIDS,
         "Same as ROCPROFSYS_SAMPLING_TIDS but applies specifically to samplers whose "
         "timers are based on the real (wall) time. This is useful when you want to "
         "restrict samples to particular threads.",
         std::string{}, "sampling", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_SAMPLING_OVERFLOW_TIDS",
+        std::string, env_vars::SAMPLING_OVERFLOW_TIDS,
         "Same as ROCPROFSYS_SAMPLING_TIDS but applies specifically to samplers whose "
         "samples are based on the overflow of a particular event. This is useful when "
         "you want to restrict samples to particular threads.",
         std::string{}, "sampling", "advanced");
 
     auto _backend = rocprofsys::get_env_choice<std::string>(
-        "ROCPROFSYS_PERFETTO_BACKEND",
+        env_vars::PERFETTO_BACKEND,
         (_system_backend) ? "system"  // if ROCPROFSYS_PERFETTO_BACKEND_SYSTEM is true,
                                       // default to system.
                           : "inprocess",  // Otherwise, default to inprocess
         { "inprocess", "system", "all" });
 
-    ROCPROFSYS_CONFIG_SETTING(std::string, "ROCPROFSYS_PERFETTO_BACKEND",
+    ROCPROFSYS_CONFIG_SETTING(std::string, env_vars::PERFETTO_BACKEND,
                               "Specify the perfetto backend to activate. Options are: "
                               "'inprocess', 'system', or 'all'",
                               _backend, "perfetto")
         ->set_choices({ "inprocess", "system", "all" });
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_TRACE_THREAD_LOCKS",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::TRACE_THREAD_LOCKS,
                               "Enable tracing calls to pthread_mutex_lock, "
                               "pthread_mutex_unlock, pthread_mutex_trylock",
                               false, "backend", "parallelism", "gotcha", "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_TRACE_THREAD_RW_LOCKS",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::TRACE_THREAD_RW_LOCKS,
                               "Enable tracing calls to pthread_rwlock_* functions. May "
                               "cause deadlocks with ROCm-enabled OpenMPI.",
                               false, "backend", "parallelism", "gotcha", "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_TRACE_THREAD_SPIN_LOCKS",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::TRACE_THREAD_SPIN_LOCKS,
                               "Enable tracing calls to pthread_spin_* functions. May "
                               "cause deadlocks with MPI distributions.",
                               false, "backend", "parallelism", "gotcha", "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_TRACE_THREAD_BARRIERS",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::TRACE_THREAD_BARRIERS,
                               "Enable tracing calls to pthread_barrier functions.", true,
                               "backend", "parallelism", "gotcha", "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_TRACE_THREAD_JOIN",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::TRACE_THREAD_JOIN,
                               "Enable tracing calls to pthread_join functions.", true,
                               "backend", "parallelism", "gotcha", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        bool, "ROCPROFSYS_SAMPLING_KEEP_INTERNAL",
+        bool, env_vars::SAMPLING_KEEP_INTERNAL,
         "Configure whether the statistical samples should include call-stack entries "
         "from internal routines in rocprof-sys. E.g. when ON, the call-stack will show "
         "functions like rocprofsys_push_trace. If disabled, rocprof-sys will attempt to "
         "filter out internal routines from the sampling call-stacks",
         true, "sampling", "data", "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_SAMPLING_INCLUDE_INLINES",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::SAMPLING_INCLUDE_INLINES,
                               "Create entries for inlined functions when available",
                               false, "sampling", "data", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        size_t, "ROCPROFSYS_SAMPLING_ALLOCATOR_SIZE",
+        size_t, env_vars::SAMPLING_ALLOCATOR_SIZE,
         "The number of sampled threads handled by an allocator running in a background "
         "thread. Each thread that is sampled communicates with an allocator running in a "
         "background thread which handles storing/caching the data when it's buffer is "
@@ -646,45 +650,45 @@ configure_settings(bool _init)
         "thread started by the application.",
         8, "sampling", "debugging", "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_SAMPLING_OVERFLOW",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::SAMPLING_OVERFLOW,
                               "Enable sampling via an overflow of a HW counter. This "
                               "requires Linux perf (/proc/sys/kernel/perf_event_paranoid "
                               "created by OS) with a value of 2 or less in that file",
                               false, "sampling", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        bool, "ROCPROFSYS_SAMPLING_REALTIME",
+        bool, env_vars::SAMPLING_REALTIME,
         "Enable sampling frequency via a wall-clock timer. This may result in typically "
         "idle child threads consuming an unnecessary large amount of CPU time.",
         false, "sampling", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        bool, "ROCPROFSYS_SAMPLING_CPUTIME",
+        bool, env_vars::SAMPLING_CPUTIME,
         "Enable sampling frequency via a timer that measures both CPU time used by the "
         "current process, and CPU time expended on behalf of the process by the system. "
         "This is recommended.",
         false, "sampling", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        int, "ROCPROFSYS_SAMPLING_CPUTIME_SIGNAL",
+        int, env_vars::SAMPLING_CPUTIME_SIGNAL,
         "Modify this value only if the target process is also using "
         "the same signal (SIGPROF)",
         SIGPROF, "sampling", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        int, "ROCPROFSYS_SAMPLING_REALTIME_SIGNAL",
+        int, env_vars::SAMPLING_REALTIME_SIGNAL,
         "Modify this value only if the target process is also using "
         "the same signal (SIGRTMIN)",
         SIGRTMIN, "sampling", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        int, "ROCPROFSYS_SAMPLING_OVERFLOW_SIGNAL",
+        int, env_vars::SAMPLING_OVERFLOW_SIGNAL,
         "Modify this value only if the target process is also using "
         "the same signal (SIGRTMIN + 1)",
         SIGRTMIN + 1, "sampling", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_SAMPLING_OVERFLOW_EVENT",
+        std::string, env_vars::SAMPLING_OVERFLOW_EVENT,
         "Metric for overflow sampling. Defaults to perf::PERF_COUNT_HW_CACHE_REFERENCES. "
         "For full list of events see: rocprof-sys-avail -H -c CPU -r overflow",
         std::string{ "perf::PERF_COUNT_HW_CACHE_REFERENCES" }, "sampling",
@@ -693,31 +697,31 @@ configure_settings(bool _init)
     rocprofiler_sdk::config_settings(_config);
     amd_smi::config_settings(_config);
 
-    ROCPROFSYS_CONFIG_SETTING(size_t, "ROCPROFSYS_PERFETTO_SHMEM_SIZE_HINT_KB",
+    ROCPROFSYS_CONFIG_SETTING(size_t, env_vars::PERFETTO_SHMEM_SIZE_HINT_KB,
                               "Hint for shared-memory buffer size in perfetto (in KB)",
                               size_t{ 4096 }, "perfetto", "data", "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(size_t, "ROCPROFSYS_PERFETTO_BUFFER_SIZE_KB",
+    ROCPROFSYS_CONFIG_SETTING(size_t, env_vars::PERFETTO_BUFFER_SIZE_KB,
                               "Size of perfetto buffer (in KB)", size_t{ 1024000 },
                               "perfetto", "data");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_PERFETTO_COMBINE_TRACES",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::PERFETTO_COMBINE_TRACES,
                               "Combine Perfetto traces. If not explicitly set, it will "
                               "default to the value of ROCPROFSYS_COLLAPSE_PROCESSES",
                               false, "perfetto", "data", "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(std::uint32_t, "ROCPROFSYS_PERFETTO_FLUSH_PERIOD_MS",
+    ROCPROFSYS_CONFIG_SETTING(std::uint32_t, env_vars::PERFETTO_FLUSH_PERIOD,
                               "Set Perfetto flush period (in ms)", std::uint32_t{ 10000 },
                               "perfetto", "data");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_PERFETTO_FILL_POLICY",
+        std::string, env_vars::PERFETTO_FILL_POLICY,
         "Behavior when perfetto buffer is full. 'discard' will ignore new entries, "
         "'ring_buffer' will overwrite old entries",
         "discard", "perfetto", "data")
         ->set_choices({ "fill", "discard" });
 
-    ROCPROFSYS_CONFIG_SETTING(std::string, "ROCPROFSYS_ENABLE_CATEGORIES",
+    ROCPROFSYS_CONFIG_SETTING(std::string, env_vars::ENABLE_CATEGORIES,
                               "Enable collecting profiling and trace data for these "
                               "categories and disable all other categories",
                               "", "trace", "profile", "perfetto", "timemory", "data",
@@ -725,13 +729,13 @@ configure_settings(bool _init)
         ->set_choices(get_available_categories<std::vector<std::string>>());
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_DISABLE_CATEGORIES",
+        std::string, env_vars::DISABLE_CATEGORIES,
         "Disable collecting profiling and trace data for these categories", "", "trace",
         "profile", "perfetto", "timemory", "data", "category", "advanced")
         ->set_choices(get_available_categories<std::vector<std::string>>());
 
     ROCPROFSYS_CONFIG_SETTING(
-        bool, "ROCPROFSYS_PERFETTO_ANNOTATIONS",
+        bool, env_vars::PERFETTO_ANNOTATIONS,
         "Include debug annotations in perfetto trace. When enabled, "
         "this feature will encode information such as the values of "
         "the function arguments (when available). Disabling this "
@@ -739,43 +743,43 @@ configure_settings(bool _init)
         true, "perfetto", "data", "debugging", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::uint64_t, "ROCPROFSYS_THREAD_POOL_SIZE",
+        std::uint64_t, env_vars::THREAD_POOL_SIZE,
         "Max number of threads for processing background tasks",
         std::max<std::uint64_t>(
             std::min<std::uint64_t>(4, std::thread::hardware_concurrency() / 2), 1),
         "parallelism", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_TIMEMORY_COMPONENTS",
+        std::string, env_vars::TIMEMORY_COMPONENTS,
         "List of components to collect via timemory (see `rocprof-sys-avail -C`)",
         "wall_clock", "timemory", "component");
 
-    ROCPROFSYS_CONFIG_SETTING(std::string, "ROCPROFSYS_OUTPUT_FILE",
+    ROCPROFSYS_CONFIG_SETTING(std::string, env_vars::OUTPUT_FILE,
                               "[DEPRECATED] See ROCPROFSYS_PERFETTO_FILE", std::string{},
                               "perfetto", "io", "filename", "deprecated", "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(std::string, "ROCPROFSYS_PERFETTO_FILE",
-                              "Perfetto filename", std::string{ "perfetto-trace.proto" },
-                              "perfetto", "io", "filename", "advanced");
+    ROCPROFSYS_CONFIG_SETTING(std::string, env_vars::PERFETTO_FILE, "Perfetto filename",
+                              std::string{ "perfetto-trace.proto" }, "perfetto", "io",
+                              "filename", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        bool, "ROCPROFSYS_USE_TEMPORARY_FILES",
+        bool, env_vars::USE_TEMPORARY_FILES,
         "Write data to temporary files to minimize the memory usage "
         "of rocprof-sys, e.g. call-stack samples will be periodically "
         "written to a file and re-loaded during finalization",
         true, "io", "data", "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_MERGE_PERFETTO_FILES",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::MERGE_PERFETTO_FILES,
                               "Merge Perfetto traces. If not explicitly set, it will "
                               "default to the value of ROCPROFSYS_COLLAPSE_PROCESSES",
                               false, "perfetto", "data", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_TMPDIR", "Base directory for temporary files",
+        std::string, env_vars::TMPDIR, "Base directory for temporary files",
         get_env<std::string>("TMPDIR", "/tmp"), "io", "data", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_CAUSAL_BACKEND",
+        std::string, env_vars::CAUSAL_BACKEND,
         "Backend for call-stack sampling. See "
         "https://rocm.docs.amd.com/projects/rocprofiler-systems/en/latest/how-to/"
         "performing-causal-profiling.html#backends for more "
@@ -785,7 +789,7 @@ configure_settings(bool _init)
         ->set_choices({ "auto", "perf", "timer" });
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_CAUSAL_MODE",
+        std::string, env_vars::CAUSAL_MODE,
         "Perform causal experiments at the function-scope or line-scope. Ideally, use "
         "function first to locate function with highest impact and then switch to line "
         "mode + ROCPROFSYS_CAUSAL_FUNCTION_SCOPE set to the function being targeted.",
@@ -793,12 +797,12 @@ configure_settings(bool _init)
         ->set_choices({ "func", "line", "function" });
 
     ROCPROFSYS_CONFIG_SETTING(
-        double, "ROCPROFSYS_CAUSAL_DELAY",
+        double, env_vars::CAUSAL_DELAY,
         "Length of time to wait (in seconds) before starting the first causal experiment",
         0.0, "causal", "analysis");
 
     ROCPROFSYS_CONFIG_SETTING(
-        double, "ROCPROFSYS_CAUSAL_DURATION",
+        double, env_vars::CAUSAL_DURATION,
         "Length of time to perform causal experimentation (in seconds) after the first "
         "experiment has started. After this amount of time has elapsed, no more causal "
         "experiments will be performed and the application will continue without any "
@@ -807,85 +811,85 @@ configure_settings(bool _init)
         0.0, "causal", "analysis");
 
     ROCPROFSYS_CONFIG_SETTING(
-        bool, "ROCPROFSYS_CAUSAL_END_TO_END",
+        bool, env_vars::CAUSAL_END_TO_END,
         "Perform causal experiment over the length of the entire application", false,
         "causal", "analysis", "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(std::string, "ROCPROFSYS_CAUSAL_FILE",
+    ROCPROFSYS_CONFIG_SETTING(std::string, env_vars::CAUSAL_FILE,
                               "Name of causal output filename (w/o extension)",
                               std::string{ "experiments" }, "causal", "analysis",
                               "advanced", "io");
 
     ROCPROFSYS_CONFIG_SETTING(
-        bool, "ROCPROFSYS_CAUSAL_FILE_RESET",
+        bool, env_vars::CAUSAL_FILE_RESET,
         "Overwrite any existing causal output file instead of appending to it", false,
         "causal", "analysis", "advanced", "io");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::uint64_t, "ROCPROFSYS_CAUSAL_RANDOM_SEED",
+        std::uint64_t, env_vars::CAUSAL_RANDOM_SEED,
         "Seed for random number generator which selects speedups and experiments -- "
         "please note that the lines selected for experimentation are not reproducible "
         "but the speedup selection is. If set to zero, std::random_device{}() will be "
         "used.",
         0, "causal", "analysis");
 
-    ROCPROFSYS_CONFIG_SETTING(std::string, "ROCPROFSYS_CAUSAL_FIXED_SPEEDUP",
+    ROCPROFSYS_CONFIG_SETTING(std::string, env_vars::CAUSAL_FIXED_SPEEDUP,
                               "List of virtual speedups between 0 and 100 (inclusive) to "
                               "sample from for causal profiling",
                               std::string{}, "causal", "analysis", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_CAUSAL_BINARY_SCOPE",
+        std::string, env_vars::CAUSAL_BINARY_SCOPE,
         "Limits causal experiments to the binaries matching the provided list of regular "
         "expressions (separated by tab, semi-colon, and/or quotes (single or double))",
         std::string{ "%MAIN%" }, "causal", "analysis");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_CAUSAL_SOURCE_SCOPE",
+        std::string, env_vars::CAUSAL_SOURCE_SCOPE,
         "Limits causal experiments to the source files or source file + lineno pair "
         "(i.e. <file> or <file>:<line>) matching the provided list of regular "
         "expressions (separated by tab, semi-colon, and/or quotes (single or double))",
         std::string{}, "causal", "analysis");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_CAUSAL_FUNCTION_SCOPE",
+        std::string, env_vars::CAUSAL_FUNCTION_SCOPE,
         "List of <function> regex entries for causal profiling (separated by tab, "
         "semi-colon, and/or quotes (single or double))",
         std::string{}, "causal", "analysis");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_CAUSAL_BINARY_EXCLUDE",
+        std::string, env_vars::CAUSAL_BINARY_EXCLUDE,
         "Excludes binaries matching the list of provided regexes from causal experiments "
         "(separated by tab, semi-colon, and/or quotes (single or double))",
         std::string{}, "causal", "analysis");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_CAUSAL_SOURCE_EXCLUDE",
+        std::string, env_vars::CAUSAL_SOURCE_EXCLUDE,
         "Excludes source files or source file + lineno pair (i.e. <file> or "
         "<file>:<line>) matching the list of provided regexes from causal experiments "
         "(separated by tab, semi-colon, and/or quotes (single or double))",
         std::string{}, "causal", "analysis");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_CAUSAL_FUNCTION_EXCLUDE",
+        std::string, env_vars::CAUSAL_FUNCTION_EXCLUDE,
         "Excludes functions matching the list of provided regexes from causal "
         "experiments (separated by tab, semi-colon, and/or quotes (single or double))",
         std::string{}, "causal", "analysis");
 
     ROCPROFSYS_CONFIG_SETTING(
-        bool, "ROCPROFSYS_CAUSAL_FUNCTION_EXCLUDE_DEFAULTS",
+        bool, env_vars::CAUSAL_FUNCTION_EXCLUDE_DEFAULTS,
         "This controls adding a series of function exclude regexes to avoid "
         "experimenting on STL implementation functions, etc. which are, "
         "generally, not helpful. Details: excludes demangled function names "
         "starting with '_' or containing '::_M'.",
         true, "causal", "analysis", "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(int, "ROCPROFSYS_KILL_DELAY",
+    ROCPROFSYS_CONFIG_SETTING(int, env_vars::KILL_DELAY,
                               "Delay (in seconds) before terminating the process "
                               "after a kill signal is received.",
                               0, "process", "advanced");
 
-    auto kill_delay_config = _config->find("ROCPROFSYS_KILL_DELAY")->second;
+    auto kill_delay_config = _config->find(std::string{ env_vars::KILL_DELAY })->second;
     auto kill_delay_value  = kill_delay_config->get<int>().second;
     if(kill_delay_value < 0)
     {
@@ -893,7 +897,7 @@ configure_settings(bool _init)
     }
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_GPU_PERF_COUNTERS",
+        std::string, env_vars::GPU_PERF_COUNTERS,
         "GPU hardware counters to collect via device counting service (PMC polled "
         "sampling). Comma-separated list of counter names (e.g. "
         "SQ_WAVES,SQ_BUSY_CYCLES). "
@@ -903,12 +907,12 @@ configure_settings(bool _init)
         "", "rocm", "hardware_counters", "pmc", "process_sampling");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_RANK_FILTER_ID",
+        std::string, env_vars::RANK_FILTER_ID,
         "Name of environment variable to read rank from for MPI output filtering",
         std::string{}, "data", "io", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_RANK_FILTER_OUTPUT",
+        std::string, env_vars::RANK_FILTER_OUTPUT,
         "Ranks for which file output is generated. Values should be separated by commas "
         "and can be explicit or ranges, e.g. 0,1,5-8. An empty value enables output "
         "for all ranks",
@@ -949,16 +953,17 @@ configure_settings(bool _init)
         }
     };
 
-    _add_rocprofsys_category(_config->find("ROCPROFSYS_CONFIG_FILE"));
-    _add_rocprofsys_category(_config->find("ROCPROFSYS_DEBUG"));
-    _add_rocprofsys_category(_config->find("ROCPROFSYS_VERBOSE"));
-    _add_rocprofsys_category(_config->find("ROCPROFSYS_LOG_LEVEL"));
-    _add_rocprofsys_category(_config->find("ROCPROFSYS_TIME_OUTPUT"));
-    _add_rocprofsys_category(_config->find("ROCPROFSYS_OUTPUT_PREFIX"));
-    _add_rocprofsys_category(_config->find("ROCPROFSYS_OUTPUT_PATH"));
+    _add_rocprofsys_category(_config->find(std::string{ env_vars::CONFIG_FILE }));
+    _add_rocprofsys_category(_config->find(std::string{ env_vars::DEBUG_MODE }));
+    _add_rocprofsys_category(_config->find(std::string{ env_vars::VERBOSE }));
+    _add_rocprofsys_category(_config->find(std::string{ env_vars::LOG_LEVEL }));
+    _add_rocprofsys_category(_config->find(std::string{ env_vars::TIME_OUTPUT }));
+    _add_rocprofsys_category(_config->find(std::string{ env_vars::OUTPUT_PREFIX }));
+    _add_rocprofsys_category(_config->find(std::string{ env_vars::OUTPUT_PATH }));
 
-    auto _add_advanced_category = [&_config](const std::string& _name) {
-        auto itr = _config->find(_name);
+    auto _add_advanced_category = [&_config](std::string_view _name_view) {
+        auto _name = std::string{ _name_view };
+        auto itr   = _config->find(_name);
         if(itr != _config->end())
         {
             auto _categories = itr->second->get_categories();
@@ -967,7 +972,7 @@ configure_settings(bool _init)
         }
         else
         {
-            if(_config->get<bool>("ROCPROFSYS_CI"))
+            if(_config->get<bool>(std::string{ env_vars::CI }))
             {
                 throw std::runtime_error(
                     fmt::format("Error! Setting '{}' not found!", _name));
@@ -975,46 +980,46 @@ configure_settings(bool _init)
         }
     };
 
-    _add_advanced_category("ROCPROFSYS_CPU_AFFINITY");
-    _add_advanced_category("ROCPROFSYS_COUT_OUTPUT");
-    _add_advanced_category("ROCPROFSYS_FILE_OUTPUT");
-    _add_advanced_category("ROCPROFSYS_JSON_OUTPUT");
-    _add_advanced_category("ROCPROFSYS_TREE_OUTPUT");
-    _add_advanced_category("ROCPROFSYS_TEXT_OUTPUT");
-    _add_advanced_category("ROCPROFSYS_DIFF_OUTPUT");
-    _add_advanced_category("ROCPROFSYS_DEBUG");
-    _add_advanced_category("ROCPROFSYS_LOG_LEVEL");
-    _add_advanced_category("ROCPROFSYS_ENABLE_SIGNAL_HANDLER");
-    _add_advanced_category("ROCPROFSYS_FLAT_PROFILE");
-    _add_advanced_category("ROCPROFSYS_INPUT_EXTENSIONS");
-    _add_advanced_category("ROCPROFSYS_INPUT_PATH");
-    _add_advanced_category("ROCPROFSYS_INPUT_PREFIX");
-    _add_advanced_category("ROCPROFSYS_MAX_DEPTH");
-    _add_advanced_category("ROCPROFSYS_MAX_WIDTH");
-    _add_advanced_category("ROCPROFSYS_MEMORY_PRECISION");
-    _add_advanced_category("ROCPROFSYS_MEMORY_SCIENTIFIC");
-    _add_advanced_category("ROCPROFSYS_MEMORY_UNITS");
-    _add_advanced_category("ROCPROFSYS_MEMORY_WIDTH");
-    _add_advanced_category("ROCPROFSYS_NETWORK_INTERFACE");
-    _add_advanced_category("ROCPROFSYS_NODE_COUNT");
-    _add_advanced_category("ROCPROFSYS_PAPI_FAIL_ON_ERROR");
-    _add_advanced_category("ROCPROFSYS_PAPI_OVERFLOW");
-    _add_advanced_category("ROCPROFSYS_PAPI_MULTIPLEXING");
-    _add_advanced_category("ROCPROFSYS_PAPI_QUIET");
-    _add_advanced_category("ROCPROFSYS_PAPI_THREADING");
-    _add_advanced_category("ROCPROFSYS_PRECISION");
-    _add_advanced_category("ROCPROFSYS_SCIENTIFIC");
-    _add_advanced_category("ROCPROFSYS_STRICT_CONFIG");
-    _add_advanced_category("ROCPROFSYS_TIMELINE_PROFILE");
-    _add_advanced_category("ROCPROFSYS_SCIENTIFIC");
-    _add_advanced_category("ROCPROFSYS_TIME_FORMAT");
-    _add_advanced_category("ROCPROFSYS_TIMING_PRECISION");
-    _add_advanced_category("ROCPROFSYS_TIMING_SCIENTIFIC");
-    _add_advanced_category("ROCPROFSYS_TIMING_UNITS");
-    _add_advanced_category("ROCPROFSYS_TIMING_WIDTH");
-    _add_advanced_category("ROCPROFSYS_WIDTH");
-    _add_advanced_category("ROCPROFSYS_COLLAPSE_THREADS");
-    _add_advanced_category("ROCPROFSYS_COLLAPSE_PROCESSES");
+    _add_advanced_category(env_vars::CPU_AFFINITY);
+    _add_advanced_category(env_vars::COUT_OUTPUT);
+    _add_advanced_category(env_vars::FILE_OUTPUT);
+    _add_advanced_category(env_vars::JSON_OUTPUT);
+    _add_advanced_category(env_vars::TREE_OUTPUT);
+    _add_advanced_category(env_vars::TEXT_OUTPUT);
+    _add_advanced_category(env_vars::DIFF_OUTPUT);
+    _add_advanced_category(env_vars::DEBUG_MODE);
+    _add_advanced_category(env_vars::LOG_LEVEL);
+    _add_advanced_category(env_vars::ENABLE_SIGNAL_HANDLER);
+    _add_advanced_category(env_vars::FLAT_PROFILE);
+    _add_advanced_category(env_vars::INPUT_EXTENSIONS);
+    _add_advanced_category(env_vars::INPUT_PATH);
+    _add_advanced_category(env_vars::INPUT_PREFIX);
+    _add_advanced_category(env_vars::MAX_DEPTH);
+    _add_advanced_category(env_vars::MAX_WIDTH);
+    _add_advanced_category(env_vars::MEMORY_PRECISION);
+    _add_advanced_category(env_vars::MEMORY_SCIENTIFIC);
+    _add_advanced_category(env_vars::MEMORY_UNITS);
+    _add_advanced_category(env_vars::MEMORY_WIDTH);
+    _add_advanced_category(env_vars::NETWORK_INTERFACE);
+    _add_advanced_category(env_vars::NODE_COUNT);
+    _add_advanced_category(env_vars::PAPI_FAIL_ON_ERROR);
+    _add_advanced_category(env_vars::PAPI_OVERFLOW);
+    _add_advanced_category(env_vars::PAPI_MULTIPLEXING_ENABLED);
+    _add_advanced_category(env_vars::PAPI_QUIET_MODE);
+    _add_advanced_category(env_vars::PAPI_THREADING);
+    _add_advanced_category(env_vars::PRECISION);
+    _add_advanced_category(env_vars::SCIENTIFIC);
+    _add_advanced_category(env_vars::STRICT_CONFIG);
+    _add_advanced_category(env_vars::TIMELINE_PROFILE);
+    _add_advanced_category(env_vars::SCIENTIFIC);
+    _add_advanced_category(env_vars::TIME_FORMAT);
+    _add_advanced_category(env_vars::TIMING_PRECISION);
+    _add_advanced_category(env_vars::TIMING_SCIENTIFIC);
+    _add_advanced_category(env_vars::TIMING_UNITS);
+    _add_advanced_category(env_vars::TIMING_WIDTH);
+    _add_advanced_category(env_vars::WIDTH);
+    _add_advanced_category(env_vars::COLLAPSE_THREADS);
+    _add_advanced_category(env_vars::COLLAPSE_PROCESSES);
 
     // Setting is registered above with "ROCPROFSYS_CONFIG_SETTING"; safe to read them
     // here.
@@ -1057,7 +1062,7 @@ configure_settings(bool _init)
     }
     else
     {
-        auto _papi_events = _config->find("ROCPROFSYS_PAPI_EVENTS");
+        auto _papi_events = _config->find(std::string{ env_vars::PAPI_EVENTS });
         _add_rocprofsys_category(_papi_events);
         // Only enumerate PAPI events if the user has specified them
         if(_papi_events->second->get_config_updated() ||
@@ -1073,13 +1078,13 @@ configure_settings(bool _init)
         }
     }
 #else
-    _config->find("ROCPROFSYS_PAPI_EVENTS")->second->set_hidden(true);
+    _config->find(std::string{ env_vars::PAPI_EVENTS })->second->set_hidden(true);
     _config->get_papi_quiet() = true;
 #endif
 
     // always initialize timemory because gotcha wrappers are always used
     auto _cmd     = tim::read_command_line(process::get_id());
-    auto _cmd_env = rocprofsys::get_env<std::string>("ROCPROFSYS_COMMAND_LINE", "");
+    auto _cmd_env = rocprofsys::get_env<std::string>(env_vars::COMMAND_LINE, "");
     if(!_cmd_env.empty()) _cmd = tim::delimit(_cmd_env, " ");
     auto _exe          = (_cmd.empty()) ? "exe" : _cmd.front();
     get_exe_realpath() = filepath::realpath(_exe, nullptr, false);
@@ -1101,7 +1106,7 @@ configure_settings(bool _init)
     bool _main_proc = (_proc.size() < 2 || *_proc.begin() == _pid);
 
     for(auto&& filename :
-        tim::delimit(_config->get<std::string>("ROCPROFSYS_CONFIG_FILE"), ";:"))
+        tim::delimit(_config->get<std::string>(std::string{ env_vars::CONFIG_FILE }), ";:"))
     {
         if(_config->get_suppress_config()) continue;
 
@@ -1122,7 +1127,7 @@ configure_settings(bool _init)
 
         LOG_DEBUG("Reading config file {}", filename);
         if(_config->read(filename) && _main_proc &&
-           ((_config->get<bool>("ROCPROFSYS_CI") && settings::verbose() >= 0) ||
+           ((_config->get<bool>(std::string{ env_vars::CI }) && settings::verbose() >= 0) ||
             settings::verbose() >= 1 || settings::debug()))
         {
             std::ifstream     _in{ expanded_filename };
@@ -1142,10 +1147,13 @@ configure_settings(bool _init)
 
     settings::suppress_config() = true;
 
-    if(auto opt = get_setting_value<int>("ROCPROFSYS_VERBOSE"); opt) verbose_value = *opt;
-    if(auto opt = get_setting_value<bool>("ROCPROFSYS_DEBUG"); opt) debug_value = *opt;
+    if(auto opt = get_setting_value<int>(std::string{ env_vars::VERBOSE }); opt)
+        verbose_value = *opt;
+    if(auto opt = get_setting_value<bool>(std::string{ env_vars::DEBUG_MODE }); opt)
+        debug_value = *opt;
 
-    if(get_env("ROCPROFSYS_MONOCHROME", _config->get<bool>("ROCPROFSYS_MONOCHROME")))
+    if(get_env(env_vars::MONOCHROME.data(),
+               _config->get<bool>(std::string{ env_vars::MONOCHROME })))
         tim::log::monochrome() = true;
 
     if(_init)
@@ -1156,20 +1164,22 @@ configure_settings(bool _init)
     }
 
 #if !defined(ROCPROFSYS_USE_MPI) && !defined(ROCPROFSYS_USE_MPI_HEADERS)
-    set_setting_value("ROCPROFSYS_USE_MPIP", false);
+    set_setting_value(std::string{ env_vars::USE_MPIP }, false);
 #endif
 
     _config->get_global_components() =
-        _config->get<std::string>("ROCPROFSYS_TIMEMORY_COMPONENTS");
+        _config->get<std::string>(std::string{ env_vars::TIMEMORY_COMPONENTS });
 
-    auto _combine_perfetto_traces = _config->find("ROCPROFSYS_PERFETTO_COMBINE_TRACES");
+    auto _combine_perfetto_traces =
+        _config->find(std::string{ env_vars::PERFETTO_COMBINE_TRACES });
     if(!_combine_perfetto_traces->second->get_environ_updated() &&
        _combine_perfetto_traces->second->get_config_updated())
     {
         _combine_perfetto_traces->second->set(_config->get<bool>("collapse_processes"));
     }
 
-    auto _merge_perfetto_files = _config->find("ROCPROFSYS_MERGE_PERFETTO_FILES");
+    auto _merge_perfetto_files =
+        _config->find(std::string{ env_vars::MERGE_PERFETTO_FILES });
     if(!_merge_perfetto_files->second->get_environ_updated() &&
        !_merge_perfetto_files->second->get_config_updated())
     {
@@ -1177,28 +1187,35 @@ configure_settings(bool _init)
             static_cast<tim::tsettings<bool>&>(*_combine_perfetto_traces->second).get());
     }
 
-    handle_deprecated_setting("ROCPROFSYS_AMD_SMI_DEVICES", "ROCPROFSYS_SAMPLING_GPUS");
-    handle_deprecated_setting("ROCPROFSYS_USE_THREAD_SAMPLING",
-                              "ROCPROFSYS_USE_PROCESS_SAMPLING");
-    handle_deprecated_setting("ROCPROFSYS_OUTPUT_FILE", "ROCPROFSYS_PERFETTO_FILE");
-    handle_deprecated_setting("ROCPROFSYS_USE_PERFETTO", "ROCPROFSYS_TRACE");
-    handle_deprecated_setting("ROCPROFSYS_USE_TIMEMORY", "ROCPROFSYS_PROFILE");
-    handle_deprecated_setting("ROCPROFSYS_DEBUG", "ROCPROFSYS_LOG_LEVEL");
-    handle_deprecated_setting("ROCPROFSYS_VERBOSE", "ROCPROFSYS_LOG_LEVEL");
-    handle_deprecated_setting("ROCPROFSYS_TRACE_LEGACY", "ROCPROFSYS_TRACE");
+    handle_deprecated_setting(std::string{ env_vars::AMD_SMI_DEVICES },
+                              std::string{ env_vars::SAMPLING_GPUS });
+    handle_deprecated_setting(std::string{ env_vars::USE_THREAD_SAMPLING },
+                              std::string{ env_vars::USE_PROCESS_SAMPLING });
+    handle_deprecated_setting(std::string{ env_vars::OUTPUT_FILE },
+                              std::string{ env_vars::PERFETTO_FILE });
+    handle_deprecated_setting(std::string{ env_vars::USE_PERFETTO },
+                              std::string{ env_vars::TRACE });
+    handle_deprecated_setting(std::string{ env_vars::USE_TIMEMORY },
+                              std::string{ env_vars::PROFILE });
+    handle_deprecated_setting(std::string{ env_vars::DEBUG_MODE },
+                              std::string{ env_vars::LOG_LEVEL });
+    handle_deprecated_setting(std::string{ env_vars::VERBOSE },
+                              std::string{ env_vars::LOG_LEVEL });
+    handle_deprecated_setting(std::string{ env_vars::TRACE_LEGACY },
+                              std::string{ env_vars::TRACE });
 
     scope::get_fields()[scope::flat::value]     = _config->get_flat_profile();
     scope::get_fields()[scope::timeline::value] = _config->get_timeline_profile();
 
     settings::suppress_parsing()  = true;
-    settings::use_output_suffix() = _config->get<bool>("ROCPROFSYS_USE_PID");
+    settings::use_output_suffix() = _config->get<bool>(std::string{ env_vars::USE_PID });
     if(settings::use_output_suffix())
         settings::default_process_suffix() = process::get_id();
 #if !defined(ROCPROFSYS_USE_MPI) && defined(ROCPROFSYS_USE_MPI_HEADERS)
     if(tim::dmp::is_initialized()) settings::default_process_suffix() = tim::dmp::rank();
 #endif
 
-    auto _dl_verbose = _config->find("ROCPROFSYS_DL_VERBOSE");
+    auto _dl_verbose = _config->find(std::string{ env_vars::DL_VERBOSE });
     if(_dl_verbose->second->get_config_updated())
         rocprofsys::set_env(std::string{ _dl_verbose->first },
                             _dl_verbose->second->as_string(), 0);
@@ -1217,8 +1234,10 @@ configure_settings(bool _init)
 
     LOG_DEBUG("Configuration complete");
 
-    if(auto opt = get_setting_value<int>("ROCPROFSYS_VERBOSE"); opt) verbose_value = *opt;
-    if(auto opt = get_setting_value<bool>("ROCPROFSYS_DEBUG"); opt) debug_value = *opt;
+    if(auto opt = get_setting_value<int>(std::string{ env_vars::VERBOSE }); opt)
+        verbose_value = *opt;
+    if(auto opt = get_setting_value<bool>(std::string{ env_vars::DEBUG_MODE }); opt)
+        debug_value = *opt;
 
     _settings_are_configured() = true;
 }
@@ -1226,7 +1245,8 @@ configure_settings(bool _init)
 void
 configure_mode_settings(const std::shared_ptr<settings>& _config)
 {
-    auto _set = [](const std::string& _name, bool _v) {
+    auto _set = [](std::string_view _name_view, bool _v) {
+        auto _name = std::string{ _name_view };
         if(!set_setting_value(_name, _v))
         {
             LOG_DEBUG("[configure_mode_settings] No configuration setting named '{}'...",
@@ -1243,43 +1263,43 @@ configure_mode_settings(const std::shared_ptr<settings>& _config)
         }
     };
 
-    auto _use_causal = get_setting_value<bool>("ROCPROFSYS_USE_CAUSAL");
-    if(_use_causal && *_use_causal) set_env("ROCPROFSYS_MODE", "causal", 1);
+    auto _use_causal = get_setting_value<bool>(std::string{ env_vars::USE_CAUSAL });
+    if(_use_causal && *_use_causal) set_env(std::string{ env_vars::MODE }, "causal", 1);
 
     if(get_mode() == Mode::Coverage)
     {
-        set_default_setting_value("ROCPROFSYS_USE_CODE_COVERAGE", true);
-        _set("ROCPROFSYS_TRACE", false);
-        _set("ROCPROFSYS_PROFILE", false);
-        _set("ROCPROFSYS_USE_CAUSAL", false);
-        _set("ROCPROFSYS_USE_AMD_SMI", false);
-        _set("ROCPROFSYS_USE_KOKKOSP", false);
-        _set("ROCPROFSYS_USE_RCCLP", false);
-        _set("ROCPROFSYS_USE_OMPT", false);
-        _set("ROCPROFSYS_USE_SAMPLING", false);
-        _set("ROCPROFSYS_USE_PROCESS_SAMPLING", false);
+        set_default_setting_value(std::string{ env_vars::USE_CODE_COVERAGE }, true);
+        _set(env_vars::TRACE, false);
+        _set(env_vars::PROFILE, false);
+        _set(env_vars::USE_CAUSAL, false);
+        _set(env_vars::USE_AMD_SMI, false);
+        _set(env_vars::USE_KOKKOSP, false);
+        _set(env_vars::USE_RCCLP, false);
+        _set(env_vars::USE_OMPT, false);
+        _set(env_vars::USE_SAMPLING, false);
+        _set(env_vars::USE_PROCESS_SAMPLING, false);
     }
     else if(get_mode() == Mode::Causal)
     {
-        _set("ROCPROFSYS_USE_CAUSAL", true);
-        _set("ROCPROFSYS_TRACE", false);
-        _set("ROCPROFSYS_PROFILE", false);
-        _set("ROCPROFSYS_USE_SAMPLING", false);
-        _set("ROCPROFSYS_USE_PROCESS_SAMPLING", false);
+        _set(env_vars::USE_CAUSAL, true);
+        _set(env_vars::TRACE, false);
+        _set(env_vars::PROFILE, false);
+        _set(env_vars::USE_SAMPLING, false);
+        _set(env_vars::USE_PROCESS_SAMPLING, false);
     }
     else if(get_mode() == Mode::Sampling)
     {
-        set_default_setting_value("ROCPROFSYS_USE_SAMPLING", true);
-        set_default_setting_value("ROCPROFSYS_USE_PROCESS_SAMPLING", true);
+        set_default_setting_value(std::string{ env_vars::USE_SAMPLING }, true);
+        set_default_setting_value(std::string{ env_vars::USE_PROCESS_SAMPLING }, true);
     }
 
     if(gpu::device_count() == 0)
     {
         LOG_WARNING("No ROCm devices were found: disabling amd_smi...");
-        _set("ROCPROFSYS_USE_AMD_SMI", false);
+        _set(env_vars::USE_AMD_SMI, false);
     }
 
-    if(_config->get<bool>("ROCPROFSYS_USE_KOKKOSP"))
+    if(_config->get<bool>(std::string{ env_vars::USE_KOKKOSP }))
     {
         auto _current_kokkosp_lib = rocprofsys::get_env<std::string>("KOKKOS_TOOLS_LIBS");
         if(_current_kokkosp_lib.find("librocprof-sys-dl.so") == std::string::npos &&
@@ -1300,24 +1320,24 @@ configure_mode_settings(const std::shared_ptr<settings>& _config)
 
     // recycle all subsequent thread ids
     threading::recycle_ids() = rocprofsys::get_env<bool>(
-        "ROCPROFSYS_RECYCLE_TIDS", !_config->get<bool>("ROCPROFSYS_USE_SAMPLING"));
+        env_vars::RECYCLE_TIDS, !_config->get<bool>(std::string{ env_vars::USE_SAMPLING }));
 
     if(!_config->get_enabled())
     {
-        _set("ROCPROFSYS_TRACE", false);
-        _set("ROCPROFSYS_PROFILE", false);
-        _set("ROCPROFSYS_USE_CAUSAL", false);
-        _set("ROCPROFSYS_USE_AMD_SMI", false);
-        _set("ROCPROFSYS_USE_KOKKOSP", false);
-        _set("ROCPROFSYS_USE_RCCLP", false);
-        _set("ROCPROFSYS_USE_OMPT", false);
-        _set("ROCPROFSYS_USE_SAMPLING", false);
-        _set("ROCPROFSYS_USE_PROCESS_SAMPLING", false);
-        _set("ROCPROFSYS_USE_CODE_COVERAGE", false);
-        _set("ROCPROFSYS_CPU_FREQ_ENABLED", false);
-        _set("ROCPROFSYS_USE_AINIC", false);
-        set_setting_value("ROCPROFSYS_TIMEMORY_COMPONENTS", std::string{});
-        set_setting_value("ROCPROFSYS_PAPI_EVENTS", std::string{});
+        _set(env_vars::TRACE, false);
+        _set(env_vars::PROFILE, false);
+        _set(env_vars::USE_CAUSAL, false);
+        _set(env_vars::USE_AMD_SMI, false);
+        _set(env_vars::USE_KOKKOSP, false);
+        _set(env_vars::USE_RCCLP, false);
+        _set(env_vars::USE_OMPT, false);
+        _set(env_vars::USE_SAMPLING, false);
+        _set(env_vars::USE_PROCESS_SAMPLING, false);
+        _set(env_vars::USE_CODE_COVERAGE, false);
+        _set(env_vars::CPU_FREQ_ENABLED, false);
+        _set(env_vars::USE_AINIC, false);
+        set_setting_value(std::string{ env_vars::TIMEMORY_COMPONENTS }, std::string{});
+        set_setting_value(std::string{ env_vars::PAPI_EVENTS }, std::string{});
     }
 }
 
@@ -1378,12 +1398,12 @@ void
 configure_signal_handler(const std::shared_ptr<settings>& _config)
 {
     auto _ignore_dyninst_trampoline =
-        rocprofsys::get_env("ROCPROFSYS_IGNORE_DYNINST_TRAMPOLINE", false);
+        rocprofsys::get_env(env_vars::IGNORE_DYNINST_TRAMPOLINE, false);
     // this is how dyninst looks up the env variable
     static auto _dyninst_trampoline_signal =
         getenv("DYNINST_SIGNAL_TRAMPOLINE_SIGILL") ? SIGILL : SIGTRAP;
 
-    static auto root_pid = get_env<pid_t>("ROCPROFSYS_ROOT_PROCESS", process::get_id());
+    static auto root_pid = get_env<pid_t>(env_vars::ROOT_PROCESS, process::get_id());
     if(_config->get_enable_signal_handler())
     {
         tim::signals::disable_signal_detection();
@@ -1417,21 +1437,21 @@ configure_signal_handler(const std::shared_ptr<settings>& _config)
 bool
 get_use_sampling_overflow()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_SAMPLING_OVERFLOW");
+    static auto _v = get_config()->find(std::string{ env_vars::SAMPLING_OVERFLOW });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 bool
 get_use_sampling_realtime()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_SAMPLING_REALTIME");
+    static auto _v = get_config()->find(std::string{ env_vars::SAMPLING_REALTIME });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 bool
 get_use_sampling_cputime()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_SAMPLING_CPUTIME");
+    static auto _v = get_config()->find(std::string{ env_vars::SAMPLING_CPUTIME });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
@@ -1451,7 +1471,7 @@ get_sampling_signals(std::int64_t)
         {
             LOG_WARNING("Sampling enabled by cputime/realtime/overflow is not "
                         "specified. Defaulting to cputime...");
-            set_setting_value("ROCPROFSYS_SAMPLING_CPUTIME", true);
+            set_setting_value(std::string{ env_vars::SAMPLING_CPUTIME }, true);
         }
 
         if(get_use_sampling_cputime()) _v.emplace(get_sampling_cputime_signal());
@@ -1465,8 +1485,9 @@ get_sampling_signals(std::int64_t)
 void
 configure_disabled_settings(const std::shared_ptr<settings>& _config)
 {
-    auto _handle_use_option = [_config](const std::string& _opt,
+    auto _handle_use_option = [_config](std::string_view   _opt_view,
                                         const std::string& _category) {
+        auto _opt = std::string{ _opt_view };
         if(!_config->get<bool>(_opt))
         {
             auto _disabled = _config->disable_category(_category);
@@ -1481,27 +1502,28 @@ configure_disabled_settings(const std::shared_ptr<settings>& _config)
         return true;
     };
 
-    _handle_use_option("ROCPROFSYS_USE_SAMPLING", "sampling");
-    _handle_use_option("ROCPROFSYS_USE_PROCESS_SAMPLING", "process_sampling");
-    _handle_use_option("ROCPROFSYS_USE_CAUSAL", "causal");
-    _handle_use_option("ROCPROFSYS_USE_KOKKOSP", "kokkos");
-    _handle_use_option("ROCPROFSYS_TRACE", "perfetto");
-    _handle_use_option("ROCPROFSYS_PROFILE", "timemory");
-    _handle_use_option("ROCPROFSYS_USE_OMPT", "ompt");
-    _handle_use_option("ROCPROFSYS_USE_RCCLP", "rcclp");
-    _handle_use_option("ROCPROFSYS_USE_AMD_SMI", "amd_smi");
+    _handle_use_option(env_vars::USE_SAMPLING, "sampling");
+    _handle_use_option(env_vars::USE_PROCESS_SAMPLING, "process_sampling");
+    _handle_use_option(env_vars::USE_CAUSAL, "causal");
+    _handle_use_option(env_vars::USE_KOKKOSP, "kokkos");
+    _handle_use_option(env_vars::TRACE, "perfetto");
+    _handle_use_option(env_vars::PROFILE, "timemory");
+    _handle_use_option(env_vars::USE_OMPT, "ompt");
+    _handle_use_option(env_vars::USE_RCCLP, "rcclp");
+    _handle_use_option(env_vars::USE_AMD_SMI, "amd_smi");
 
 #if defined(ROCPROFSYS_USE_OMPT) || ROCPROFSYS_USE_OMPT == 0
-    _config->find("ROCPROFSYS_USE_OMPT")->second->set_hidden(true);
+    _config->find(std::string{ env_vars::USE_OMPT })->second->set_hidden(true);
     for(const auto& itr : _config->disable_category("ompt"))
         _config->find(itr)->second->set_hidden(true);
 #endif
 
 #if !defined(ROCPROFSYS_USE_MPI) || ROCPROFSYS_USE_MPI == 0
-    _config->disable("ROCPROFSYS_PERFETTO_COMBINE_TRACES");
-    _config->disable("ROCPROFSYS_COLLAPSE_PROCESSES");
-    _config->find("ROCPROFSYS_PERFETTO_COMBINE_TRACES")->second->set_hidden(true);
-    _config->find("ROCPROFSYS_COLLAPSE_PROCESSES")->second->set_hidden(true);
+    _config->disable(env_vars::PERFETTO_COMBINE_TRACES);
+    _config->disable(env_vars::COLLAPSE_PROCESSES);
+    _config->find(std::string{ env_vars::PERFETTO_COMBINE_TRACES })
+        ->second->set_hidden(true);
+    _config->find(std::string{ env_vars::COLLAPSE_PROCESSES })->second->set_hidden(true);
 #endif
 
     _config->disable_category("throttle");
@@ -1543,7 +1565,7 @@ configure_disabled_settings(const std::shared_ptr<settings>& _config)
     auto _hidden_exact = std::set<std::string>{};
 
 #if !defined(TIMEMORY_USE_CRAYPAT)
-    _hidden_exact.emplace("ROCPROFSYS_CRAYPAT");
+    _hidden_exact.emplace(env_vars::CRAYPAT);
 #endif
 
     for(const auto& itr : *_config)
@@ -1671,8 +1693,8 @@ print_settings(
     std::stringstream _os{};
 
     bool _print_desc =
-        get_debug() || rocprofsys::get_env("ROCPROFSYS_SETTINGS_DESC", false);
-    bool _md = rocprofsys::get_env<bool>("ROCPROFSYS_SETTINGS_DESC_MARKDOWN", false);
+        get_debug() || rocprofsys::get_env(env_vars::SETTINGS_DESC, false);
+    bool _md = rocprofsys::get_env<bool>(env_vars::SETTINGS_DESC_MARKDOWN, false);
 
     constexpr size_t nfields = 3;
     using str_array_t        = std::array<std::string, nfields>;
@@ -1700,11 +1722,11 @@ print_settings(
     std::sort(_data.begin(), _data.end(), [](const auto& lhs, const auto& rhs) {
         auto _npos = std::string::npos;
         // ROCPROFSYS_CONFIG_FILE always first
-        if(lhs.at(0) == "ROCPROFSYS_MODE") return true;
-        if(rhs.at(0) == "ROCPROFSYS_MODE") return false;
+        if(lhs.at(0) == env_vars::MODE) return true;
+        if(rhs.at(0) == env_vars::MODE) return false;
         // ROCPROFSYS_CONFIG_FILE always second
-        if(lhs.at(0).find("ROCPROFSYS_CONFIG") != _npos) return true;
-        if(rhs.at(0).find("ROCPROFSYS_CONFIG") != _npos) return false;
+        if(lhs.at(0).find(env_vars::CONFIG) != _npos) return true;
+        if(rhs.at(0).find(env_vars::CONFIG) != _npos) return false;
         // ROCPROFSYS_USE_* prioritized
         auto _lhs_use = lhs.at(0).find("ROCPROFSYS_USE_");
         auto _rhs_use = rhs.at(0).find("ROCPROFSYS_USE_");
@@ -1832,7 +1854,7 @@ get_exe_realpath()
 std::string
 get_config_file()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_CONFIG_FILE");
+    static auto _v = get_config()->find(std::string{ env_vars::CONFIG_FILE });
     return static_cast<tim::tsettings<std::string>&>(*_v->second).get();
 }
 
@@ -1842,7 +1864,7 @@ get_mode()
     if(!settings_are_configured())
     {
         auto _mode = rocprofsys::get_env_choice<std::string>(
-            "ROCPROFSYS_MODE", "trace", { "trace", "sampling", "causal", "coverage" });
+            env_vars::MODE, "trace", { "trace", "sampling", "causal", "coverage" });
         if(_mode == "sampling")
             return Mode::Sampling;
         else if(_mode == "causal")
@@ -1856,7 +1878,7 @@ get_mode()
                                                     { "causal", Mode::Causal },
                                                     { "sampling", Mode::Sampling },
                                                     { "coverage", Mode::Coverage } };
-    static auto _v = get_config()->find("ROCPROFSYS_MODE");
+    static auto _v = get_config()->find(std::string{ env_vars::MODE });
     try
     {
         return _m.at(static_cast<tim::tsettings<std::string>&>(*_v->second).get());
@@ -1892,19 +1914,19 @@ get_debug_env()
 {
     return (settings_are_configured())
                ? get_debug()
-               : rocprofsys::get_env<bool>("ROCPROFSYS_DEBUG", false);
+               : rocprofsys::get_env<bool>(env_vars::DEBUG_MODE, false);
 }
 
 bool
 get_debug_init()
 {
-    return rocprofsys::get_env<bool>("ROCPROFSYS_DEBUG_INIT", get_debug_env());
+    return rocprofsys::get_env<bool>(env_vars::DEBUG_INIT, get_debug_env());
 }
 
 bool
 get_debug_finalize()
 {
-    return rocprofsys::get_env<bool>("ROCPROFSYS_DEBUG_FINALIZE", false);
+    return rocprofsys::get_env<bool>(env_vars::DEBUG_FINALIZE, false);
 }
 
 bool
@@ -1918,7 +1940,7 @@ bool
 get_debug_sampling()
 {
     static bool _v = rocprofsys::get_env<bool>(
-        "ROCPROFSYS_DEBUG_SAMPLING",
+        env_vars::DEBUG_SAMPLING,
         (settings_are_configured() ? get_debug() : get_debug_env()));
     return _v;
 }
@@ -1928,7 +1950,7 @@ get_verbose_env()
 {
     return (settings_are_configured())
                ? get_verbose()
-               : rocprofsys::get_env<int>("ROCPROFSYS_VERBOSE", 0);
+               : rocprofsys::get_env<int>(env_vars::VERBOSE, 0);
 }
 
 int
@@ -1941,8 +1963,8 @@ get_verbose()
 bool&
 get_use_perfetto()
 {
-    static auto _trace_setting  = get_config()->at("ROCPROFSYS_TRACE");
-    static auto _legacy_setting = get_config()->at("ROCPROFSYS_TRACE_LEGACY");
+    static auto _trace_setting  = get_config()->at(env_vars::TRACE);
+    static auto _legacy_setting = get_config()->at(env_vars::TRACE_LEGACY);
     auto&       _trace  = static_cast<tim::tsettings<bool>&>(*_trace_setting).get();
     auto&       _legacy = static_cast<tim::tsettings<bool>&>(*_legacy_setting).get();
     static bool _v      = _trace && _legacy;
@@ -1952,21 +1974,21 @@ get_use_perfetto()
 bool&
 get_use_timemory()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_PROFILE");
+    static auto _v = get_config()->find(std::string{ env_vars::PROFILE });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 bool&
 get_use_causal()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_USE_CAUSAL");
+    static auto _v = get_config()->find(std::string{ env_vars::USE_CAUSAL });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 bool
 get_use_amd_smi()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_USE_AMD_SMI");
+    static auto _v = get_config()->find(std::string{ env_vars::USE_AMD_SMI });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
@@ -1974,7 +1996,7 @@ bool&
 get_use_sampling()
 {
 #if defined(TIMEMORY_USE_LIBUNWIND)
-    static auto _v = get_config()->find("ROCPROFSYS_USE_SAMPLING");
+    static auto _v = get_config()->find(std::string{ env_vars::USE_SAMPLING });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 #else
     throw std::runtime_error(
@@ -1988,63 +2010,63 @@ get_use_sampling()
 bool&
 get_use_process_sampling()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_USE_PROCESS_SAMPLING");
+    static auto _v = get_config()->find(std::string{ env_vars::USE_PROCESS_SAMPLING });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 bool&
 get_cpu_freq_enabled()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_CPU_FREQ_ENABLED");
+    static auto _v = get_config()->find(std::string{ env_vars::CPU_FREQ_ENABLED });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 std::string
 get_sampling_ainics()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_SAMPLING_AINICS");
+    static auto _v = get_config()->find(std::string{ env_vars::SAMPLING_AINICS });
     return static_cast<tim::tsettings<std::string>&>(*_v->second).get();
 }
 
 bool&
 get_use_pid()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_USE_PID");
+    static auto _v = get_config()->find(std::string{ env_vars::USE_PID });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 bool&
 get_use_mpip()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_USE_MPIP");
+    static auto _v = get_config()->find(std::string{ env_vars::USE_MPIP });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 bool&
 get_use_ucx()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_USE_UCX");
+    static auto _v = get_config()->find(std::string{ env_vars::USE_UCX });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 bool&
 get_use_shmem()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_USE_SHMEM");
+    static auto _v = get_config()->find(std::string{ env_vars::USE_SHMEM });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 bool
 get_use_kokkosp()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_USE_KOKKOSP");
+    static auto _v = get_config()->find(std::string{ env_vars::USE_KOKKOSP });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 bool
 get_use_kokkosp_kernel_logger()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_KOKKOSP_KERNEL_LOGGER");
+    static auto _v = get_config()->find(std::string{ env_vars::KOKKOSP_KERNEL_LOGGER });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
@@ -2052,7 +2074,7 @@ get_use_kokkosp_kernel_logger()
 bool
 get_use_vaapi_tracing()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_ROCM_DOMAINS");
+    static auto _v = get_config()->find(std::string{ env_vars::ROCM_DOMAINS });
     if(_v == get_config()->end())
     {
         return false;  // Setting not found
@@ -2068,7 +2090,7 @@ get_use_vaapi_tracing()
 bool
 get_use_ompt()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_USE_OMPT");
+    static auto _v = get_config()->find(std::string{ env_vars::USE_OMPT });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
@@ -2077,91 +2099,94 @@ get_group_by_queue()
 {
     // When the `hip_stream` domain is unavailable, the setting is not registered
     // and there is no stream concept to attach to, so fall back to queue grouping.
-    return config::get_setting_value<bool>("ROCPROFSYS_ROCM_GROUP_BY_QUEUE")
+    return config::get_setting_value<bool>(std::string{ env_vars::ROCM_GROUP_BY_QUEUE })
         .value_or(true);
 }
 
 bool
 get_use_code_coverage()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_USE_CODE_COVERAGE");
+    static auto _v = get_config()->find(std::string{ env_vars::USE_CODE_COVERAGE });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 bool
 get_use_rcclp()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_USE_RCCLP");
+    static auto _v = get_config()->find(std::string{ env_vars::USE_RCCLP });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 size_t
 get_num_threads_hint()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_NUM_THREADS_HINT");
+    static auto _v = get_config()->find(std::string{ env_vars::NUM_THREADS_HINT });
     return static_cast<tim::tsettings<size_t>&>(*_v->second).get();
 }
 
 bool
 get_sampling_keep_internal()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_SAMPLING_KEEP_INTERNAL");
+    static auto _v = get_config()->find(std::string{ env_vars::SAMPLING_KEEP_INTERNAL });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 int
 get_sampling_overflow_signal()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_SAMPLING_OVERFLOW_SIGNAL");
+    static auto _v =
+        get_config()->find(std::string{ env_vars::SAMPLING_OVERFLOW_SIGNAL });
     return static_cast<tim::tsettings<int>&>(*_v->second).get();
 }
 
 int
 get_sampling_realtime_signal()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_SAMPLING_REALTIME_SIGNAL");
+    static auto _v =
+        get_config()->find(std::string{ env_vars::SAMPLING_REALTIME_SIGNAL });
     return static_cast<tim::tsettings<int>&>(*_v->second).get();
 }
 
 int
 get_sampling_cputime_signal()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_SAMPLING_CPUTIME_SIGNAL");
+    static auto _v = get_config()->find(std::string{ env_vars::SAMPLING_CPUTIME_SIGNAL });
     return static_cast<tim::tsettings<int>&>(*_v->second).get();
 }
 
 size_t
 get_perfetto_shmem_size_hint()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_PERFETTO_SHMEM_SIZE_HINT_KB");
+    static auto _v =
+        get_config()->find(std::string{ env_vars::PERFETTO_SHMEM_SIZE_HINT_KB });
     return static_cast<tim::tsettings<size_t>&>(*_v->second).get();
 }
 
 size_t
 get_perfetto_buffer_size()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_PERFETTO_BUFFER_SIZE_KB");
+    static auto _v = get_config()->find(std::string{ env_vars::PERFETTO_BUFFER_SIZE_KB });
     return static_cast<tim::tsettings<size_t>&>(*_v->second).get();
 }
 
 std::uint32_t
 get_perfetto_flush_period()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_PERFETTO_FLUSH_PERIOD_MS");
+    static auto _v = get_config()->find(std::string{ env_vars::PERFETTO_FLUSH_PERIOD });
     return static_cast<tim::tsettings<std::uint32_t>&>(*_v->second).get();
 }
 
 bool
 get_perfetto_combined_traces()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_PERFETTO_COMBINE_TRACES");
+    static auto _v = get_config()->find(std::string{ env_vars::PERFETTO_COMBINE_TRACES });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 std::string
 get_perfetto_fill_policy()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_PERFETTO_FILL_POLICY");
+    static auto _v = get_config()->find(std::string{ env_vars::PERFETTO_FILL_POLICY });
     return static_cast<tim::tsettings<std::string>&>(*_v->second).get();
 }
 
@@ -2185,8 +2210,10 @@ get_category_config()
             return _ret;
         };
 
-        auto _enabled  = _parse(get_config()->find("ROCPROFSYS_ENABLE_CATEGORIES"));
-        auto _disabled = _parse(get_config()->find("ROCPROFSYS_DISABLE_CATEGORIES"));
+        auto _enabled =
+            _parse(get_config()->find(std::string{ env_vars::ENABLE_CATEGORIES }));
+        auto _disabled =
+            _parse(get_config()->find(std::string{ env_vars::DISABLE_CATEGORIES }));
 
         if(_enabled.empty() && _disabled.empty())
         {
@@ -2243,7 +2270,7 @@ get_disabled_categories()
 bool
 get_perfetto_annotations()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_PERFETTO_ANNOTATIONS");
+    static auto _v = get_config()->find(std::string{ env_vars::PERFETTO_ANNOTATIONS });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
@@ -2251,7 +2278,7 @@ std::uint64_t
 get_thread_pool_size()
 {
     static std::uint64_t _v =
-        get_config()->get<std::uint64_t>("ROCPROFSYS_THREAD_POOL_SIZE");
+        get_config()->get<std::uint64_t>(std::string{ env_vars::THREAD_POOL_SIZE });
     return _v;
 }
 
@@ -2259,16 +2286,16 @@ std::string&
 get_perfetto_backend()
 {
     // select inprocess, system, or both (i.e. all)
-    static auto _v = get_config()->find("ROCPROFSYS_PERFETTO_BACKEND");
+    static auto _v = get_config()->find(std::string{ env_vars::PERFETTO_BACKEND });
     return static_cast<tim::tsettings<std::string>&>(*_v->second).get();
 }
 
 std::string
 get_perfetto_output_filename()
 {
-    const auto*  pwd                   = getenv("PWD");
-    static auto  setting               = get_config()->find("ROCPROFSYS_PERFETTO_FILE");
-    static auto* attach_add_session_id = getenv("ROCPROFSYS_REATTACH_ADD_SESSION_ID");
+    const auto*  pwd     = getenv("PWD");
+    static auto  setting = get_config()->find(std::string{ env_vars::PERFETTO_FILE });
+    static auto* attach_add_session_id = getenv(env_vars::REATTACH_ADD_SESSION_ID.data());
 
     if(setting == get_config()->end())
     {
@@ -2319,14 +2346,14 @@ get_perfetto_output_filename()
 double
 get_sampling_freq()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_SAMPLING_FREQ");
+    static auto _v = get_config()->find(std::string{ env_vars::SAMPLING_FREQ });
     return static_cast<tim::tsettings<double>&>(*_v->second).get();
 }
 
 double
 get_sampling_cputime_freq()
 {
-    static auto _v   = get_config()->find("ROCPROFSYS_SAMPLING_CPUTIME_FREQ");
+    static auto _v   = get_config()->find(std::string{ env_vars::SAMPLING_CPUTIME_FREQ });
     auto&       _val = static_cast<tim::tsettings<double>&>(*_v->second).get();
     if(_val <= 0.0) _val = get_sampling_freq();
     return _val;
@@ -2335,7 +2362,7 @@ get_sampling_cputime_freq()
 double
 get_sampling_realtime_freq()
 {
-    static auto _v   = get_config()->find("ROCPROFSYS_SAMPLING_REALTIME_FREQ");
+    static auto _v = get_config()->find(std::string{ env_vars::SAMPLING_REALTIME_FREQ });
     auto&       _val = static_cast<tim::tsettings<double>&>(*_v->second).get();
     if(_val <= 0.0) _val = get_sampling_freq();
     return _val;
@@ -2344,7 +2371,7 @@ get_sampling_realtime_freq()
 double
 get_sampling_overflow_freq()
 {
-    static auto _v   = get_config()->find("ROCPROFSYS_SAMPLING_OVERFLOW_FREQ");
+    static auto _v = get_config()->find(std::string{ env_vars::SAMPLING_OVERFLOW_FREQ });
     auto&       _val = static_cast<tim::tsettings<double>&>(*_v->second).get();
     if(_val <= 0.0) _val = get_sampling_freq();
     return _val;
@@ -2353,14 +2380,14 @@ get_sampling_overflow_freq()
 double
 get_sampling_delay()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_SAMPLING_DELAY");
+    static auto _v = get_config()->find(std::string{ env_vars::SAMPLING_DELAY });
     return static_cast<tim::tsettings<double>&>(*_v->second).get();
 }
 
 double
 get_sampling_cputime_delay()
 {
-    static auto _v   = get_config()->find("ROCPROFSYS_SAMPLING_CPUTIME_DELAY");
+    static auto _v = get_config()->find(std::string{ env_vars::SAMPLING_CPUTIME_DELAY });
     auto&       _val = static_cast<tim::tsettings<double>&>(*_v->second).get();
     if(_val <= 0.0) _val = get_sampling_delay();
     return _val;
@@ -2369,7 +2396,7 @@ get_sampling_cputime_delay()
 double
 get_sampling_realtime_delay()
 {
-    static auto _v   = get_config()->find("ROCPROFSYS_SAMPLING_REALTIME_DELAY");
+    static auto _v = get_config()->find(std::string{ env_vars::SAMPLING_REALTIME_DELAY });
     auto&       _val = static_cast<tim::tsettings<double>&>(*_v->second).get();
     if(_val <= 0.0) _val = get_sampling_delay();
     return _val;
@@ -2378,21 +2405,21 @@ get_sampling_realtime_delay()
 double
 get_sampling_duration()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_SAMPLING_DURATION");
+    static auto _v = get_config()->find(std::string{ env_vars::SAMPLING_DURATION });
     return static_cast<tim::tsettings<double>&>(*_v->second).get();
 }
 
 std::string
 get_sampling_cpus()
 {
-    auto _v = get_config()->find("ROCPROFSYS_SAMPLING_CPUS");
+    auto _v = get_config()->find(std::string{ env_vars::SAMPLING_CPUS });
     return static_cast<tim::tsettings<std::string>&>(*_v->second).get();
 }
 
 std::string
 get_cpu_metrics()
 {
-    auto _v = get_config()->find("ROCPROFSYS_CPU_METRICS");
+    auto _v = get_config()->find(std::string{ env_vars::CPU_METRICS });
     if(_v == get_config()->end()) return "all";
     return static_cast<tim::tsettings<std::string>&>(*_v->second).get();
 }
@@ -2400,7 +2427,7 @@ get_cpu_metrics()
 std::set<std::int64_t>
 get_sampling_tids()
 {
-    auto _v = get_config()->find("ROCPROFSYS_SAMPLING_TIDS");
+    auto _v = get_config()->find(std::string{ env_vars::SAMPLING_TIDS });
     return parse_numeric_range<>(
         static_cast<tim::tsettings<std::string>&>(*_v->second).get(), "thread IDs", 1L);
 }
@@ -2408,7 +2435,7 @@ get_sampling_tids()
 std::set<std::int64_t>
 get_sampling_cputime_tids()
 {
-    auto _v = get_config()->find("ROCPROFSYS_SAMPLING_CPUTIME_TIDS");
+    auto _v = get_config()->find(std::string{ env_vars::SAMPLING_CPUTIME_TIDS });
     return parse_numeric_range<>(
         static_cast<tim::tsettings<std::string>&>(*_v->second).get(), "thread IDs", 1L);
 }
@@ -2416,7 +2443,7 @@ get_sampling_cputime_tids()
 std::set<std::int64_t>
 get_sampling_realtime_tids()
 {
-    auto _v = get_config()->find("ROCPROFSYS_SAMPLING_REALTIME_TIDS");
+    auto _v = get_config()->find(std::string{ env_vars::SAMPLING_REALTIME_TIDS });
     return parse_numeric_range<>(
         static_cast<tim::tsettings<std::string>&>(*_v->second).get(), "thread IDs", 1L);
 }
@@ -2424,7 +2451,7 @@ get_sampling_realtime_tids()
 std::set<std::int64_t>
 get_sampling_overflow_tids()
 {
-    auto _v = get_config()->find("ROCPROFSYS_SAMPLING_OVERFLOW_TIDS");
+    auto _v = get_config()->find(std::string{ env_vars::SAMPLING_OVERFLOW_TIDS });
     return parse_numeric_range<>(
         static_cast<tim::tsettings<std::string>&>(*_v->second).get(), "thread IDs", 1L);
 }
@@ -2432,21 +2459,22 @@ get_sampling_overflow_tids()
 bool
 get_sampling_include_inlines()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_SAMPLING_INCLUDE_INLINES");
+    static auto _v =
+        get_config()->find(std::string{ env_vars::SAMPLING_INCLUDE_INLINES });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 size_t
 get_sampling_allocator_size()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_SAMPLING_ALLOCATOR_SIZE");
+    static auto _v = get_config()->find(std::string{ env_vars::SAMPLING_ALLOCATOR_SIZE });
     return std::max<size_t>(static_cast<tim::tsettings<size_t>&>(*_v->second).get(), 1);
 }
 
 double
 get_process_sampling_freq()
 {
-    static auto _v   = get_config()->find("ROCPROFSYS_PROCESS_SAMPLING_FREQ");
+    static auto _v   = get_config()->find(std::string{ env_vars::PROCESS_SAMPLING_FREQ });
     const auto  _val = static_cast<tim::tsettings<double>&>(*_v->second).get();
 
     constexpr auto effective_zero = 1.0e-9;
@@ -2461,14 +2489,15 @@ get_process_sampling_freq()
 double
 get_process_sampling_duration()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_PROCESS_SAMPLING_DURATION");
+    static auto _v =
+        get_config()->find(std::string{ env_vars::PROCESS_SAMPLING_DURATION });
     return static_cast<tim::tsettings<double>&>(*_v->second).get();
 }
 
 std::string
 get_sampling_gpus()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_SAMPLING_GPUS");
+    static auto _v = get_config()->find(std::string{ env_vars::SAMPLING_GPUS });
     return static_cast<tim::tsettings<std::string>&>(*_v->second).get();
 }
 
@@ -2482,42 +2511,42 @@ get_gpu_perf_counters()
 bool
 get_trace_thread_locks()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_TRACE_THREAD_LOCKS");
+    static auto _v = get_config()->find(std::string{ env_vars::TRACE_THREAD_LOCKS });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 bool
 get_trace_thread_rwlocks()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_TRACE_THREAD_RW_LOCKS");
+    static auto _v = get_config()->find(std::string{ env_vars::TRACE_THREAD_RW_LOCKS });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 bool
 get_trace_thread_spin_locks()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_TRACE_THREAD_SPIN_LOCKS");
+    static auto _v = get_config()->find(std::string{ env_vars::TRACE_THREAD_SPIN_LOCKS });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 bool
 get_trace_thread_barriers()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_TRACE_THREAD_BARRIERS");
+    static auto _v = get_config()->find(std::string{ env_vars::TRACE_THREAD_BARRIERS });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 bool
 get_trace_thread_join()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_TRACE_THREAD_JOIN");
+    static auto _v = get_config()->find(std::string{ env_vars::TRACE_THREAD_JOIN });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 std::string
 get_trace_region()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_SELECTED_REGIONS");
+    static auto _v = get_config()->find(std::string{ env_vars::SELECTED_REGIONS });
     return static_cast<tim::tsettings<std::string>&>(*_v->second).get();
 }
 
@@ -2526,8 +2555,7 @@ get_debug_tid()
 {
     static auto _vlist =
         parse_numeric_range<std::int64_t, std::unordered_set<std::int64_t>>(
-            rocprofsys::get_env<std::string>("ROCPROFSYS_DEBUG_TIDS", ""), "debug tids",
-            1L);
+            rocprofsys::get_env<std::string>(env_vars::DEBUG_TIDS, ""), "debug tids", 1L);
     static thread_local bool _v =
         _vlist.empty() || _vlist.count(tim::threading::get_id()) > 0;
     return _v;
@@ -2538,8 +2566,7 @@ get_debug_pid()
 {
     static auto _vlist =
         parse_numeric_range<std::int64_t, std::unordered_set<std::int64_t>>(
-            rocprofsys::get_env<std::string>("ROCPROFSYS_DEBUG_PIDS", ""), "debug pids",
-            1L);
+            rocprofsys::get_env<std::string>(env_vars::DEBUG_PIDS, ""), "debug pids", 1L);
     static bool _v = _vlist.empty() || _vlist.count(tim::process::get_id()) > 0 ||
                      _vlist.count(dmp::rank()) > 0;
     return _v;
@@ -2548,21 +2575,21 @@ get_debug_pid()
 bool
 get_use_tmp_files()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_USE_TEMPORARY_FILES");
+    static auto _v = get_config()->find(std::string{ env_vars::USE_TEMPORARY_FILES });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 bool
 get_merge_perfetto_files()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_MERGE_PERFETTO_FILES");
+    static auto _v = get_config()->find(std::string{ env_vars::MERGE_PERFETTO_FILES });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 std::string
 get_tmpdir()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_TMPDIR");
+    static auto _v = get_config()->find(std::string{ env_vars::TMPDIR });
     return static_cast<tim::tsettings<std::string>&>(*_v->second).get();
 }
 
@@ -2639,7 +2666,7 @@ get_output_absolute_path(std::string_view basename, std::string_view extension,
 std::string
 get_perfetto_output_filename_with_suffix(std::string_view suffix)
 {
-    static auto _v   = get_config()->find("ROCPROFSYS_PERFETTO_FILE");
+    static auto _v   = get_config()->find(std::string{ env_vars::PERFETTO_FILE });
     auto        _val = static_cast<tim::tsettings<std::string>&>(*_v->second).get();
 
     LOG_DEBUG("Initial ROCPROFSYS_PERFETTO_FILE='{}', suffix='{}'", _val, suffix);
@@ -2718,22 +2745,22 @@ get_ump_absolute_path()
 bool&
 get_use_rocpd()
 {
-    static auto _v = get_config()->at("ROCPROFSYS_USE_ROCPD");
+    static auto _v = get_config()->at(env_vars::USE_ROCPD);
     return static_cast<tim::tsettings<bool>&>(*_v).get();
 }
 
 bool&
 get_use_unified_memory_profiling()
 {
-    static auto _v = get_config()->at("ROCPROFSYS_USE_UNIFIED_MEMORY_PROFILING");
+    static auto _v = get_config()->at(env_vars::USE_UNIFIED_MEMORY_PROFILING);
     return static_cast<tim::tsettings<bool>&>(*_v).get();
 }
 
 bool&
 get_caching_perfetto()
 {
-    static auto _trace_setting  = get_config()->at("ROCPROFSYS_TRACE");
-    static auto _legacy_setting = get_config()->at("ROCPROFSYS_TRACE_LEGACY");
+    static auto _trace_setting  = get_config()->at(env_vars::TRACE);
+    static auto _legacy_setting = get_config()->at(env_vars::TRACE_LEGACY);
     auto&       _trace  = static_cast<tim::tsettings<bool>&>(*_trace_setting).get();
     auto&       _legacy = static_cast<tim::tsettings<bool>&>(*_legacy_setting).get();
     static bool _v      = _trace && !_legacy;
@@ -2743,7 +2770,7 @@ get_caching_perfetto()
 int
 get_kill_delay()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_KILL_DELAY");
+    static auto _v = get_config()->find(std::string{ env_vars::KILL_DELAY });
     return static_cast<tim::tsettings<int>&>(*_v->second).get();
 }
 
@@ -2752,14 +2779,14 @@ namespace
 std::string
 get_rank_filter_id()
 {
-    static auto _v = get_config()->at("ROCPROFSYS_RANK_FILTER_ID");
+    static auto _v = get_config()->at(env_vars::RANK_FILTER_ID);
     return static_cast<tim::tsettings<std::string>&>(*_v).get();
 }
 
 std::string
 get_rank_filter_output()
 {
-    static auto _v = get_config()->at("ROCPROFSYS_RANK_FILTER_OUTPUT");
+    static auto _v = get_config()->at(env_vars::RANK_FILTER_OUTPUT);
     return static_cast<tim::tsettings<std::string>&>(*_v).get();
 }
 
@@ -3147,7 +3174,7 @@ get_causal_backend()
         { "timer", CausalBackend::Timer },
     };
 
-    auto _v = get_config()->find("ROCPROFSYS_CAUSAL_BACKEND");
+    auto _v = get_config()->find(std::string{ env_vars::CAUSAL_BACKEND });
     try
     {
         return _m.at(static_cast<tim::tsettings<std::string>&>(*_v->second).get());
@@ -3167,7 +3194,7 @@ get_causal_mode()
     if(!settings_are_configured())
     {
         auto _mode = rocprofsys::get_env_choice<std::string>(
-            "ROCPROFSYS_CAUSAL_MODE", "function", { "line", "function" });
+            env_vars::CAUSAL_MODE, "function", { "line", "function" });
         if(_mode == "line") return CausalMode::Line;
         return CausalMode::Function;
     }
@@ -3177,7 +3204,7 @@ get_causal_mode()
             { "func", CausalMode::Function },
             { "function", CausalMode::Function }
         };
-        auto _v = get_config()->find("ROCPROFSYS_CAUSAL_MODE");
+        auto _v = get_config()->find(std::string{ env_vars::CAUSAL_MODE });
         try
         {
             return _m.at(static_cast<tim::tsettings<std::string>&>(*_v->second).get());
@@ -3196,14 +3223,14 @@ get_causal_mode()
 bool
 get_causal_end_to_end()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_CAUSAL_END_TO_END");
+    static auto _v = get_config()->find(std::string{ env_vars::CAUSAL_END_TO_END });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 std::vector<std::int64_t>
 get_causal_fixed_speedup()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_CAUSAL_FIXED_SPEEDUP");
+    static auto _v = get_config()->find(std::string{ env_vars::CAUSAL_FIXED_SPEEDUP });
     return parse_numeric_range<std::int64_t, std::vector<std::int64_t>>(
         static_cast<tim::tsettings<std::string>&>(*_v->second).get(),
         "causal fixed speedup", 5L);
@@ -3212,7 +3239,7 @@ get_causal_fixed_speedup()
 std::string
 get_causal_output_filename()
 {
-    static auto _v     = get_config()->find("ROCPROFSYS_CAUSAL_FILE");
+    static auto _v     = get_config()->find(std::string{ env_vars::CAUSAL_FILE });
     auto        _fname = static_cast<tim::tsettings<std::string>&>(*_v->second).get();
     for(auto&& itr : std::initializer_list<std::string>{ ".txt", ".json", ".xml" })
     {
@@ -3255,7 +3282,7 @@ std::vector<std::string>
 get_causal_binary_scope()
 {
     auto&&      _config = get_config();
-    static auto _v      = _config->find("ROCPROFSYS_CAUSAL_BINARY_SCOPE");
+    static auto _v      = _config->find(std::string{ env_vars::CAUSAL_BINARY_SCOPE });
     return format_causal_scopes(
         tim::delimit(static_cast<tim::tsettings<std::string>&>(*_v->second).get(),
                      "\t\"';"),
@@ -3265,7 +3292,7 @@ get_causal_binary_scope()
 std::vector<std::string>
 get_causal_source_scope()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_CAUSAL_SOURCE_SCOPE");
+    static auto _v = get_config()->find(std::string{ env_vars::CAUSAL_SOURCE_SCOPE });
     return tim::delimit(static_cast<tim::tsettings<std::string>&>(*_v->second).get(),
                         "\t\"';");
 }
@@ -3273,7 +3300,7 @@ get_causal_source_scope()
 std::vector<std::string>
 get_causal_function_scope()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_CAUSAL_FUNCTION_SCOPE");
+    static auto _v = get_config()->find(std::string{ env_vars::CAUSAL_FUNCTION_SCOPE });
     return tim::delimit(static_cast<tim::tsettings<std::string>&>(*_v->second).get(),
                         "\t\"';");
 }
@@ -3282,7 +3309,7 @@ std::vector<std::string>
 get_causal_binary_exclude()
 {
     auto&&      _config = get_config();
-    static auto _v      = _config->find("ROCPROFSYS_CAUSAL_BINARY_EXCLUDE");
+    static auto _v      = _config->find(std::string{ env_vars::CAUSAL_BINARY_EXCLUDE });
     return format_causal_scopes(
         tim::delimit(static_cast<tim::tsettings<std::string>&>(*_v->second).get(),
                      "\t\"';"),
@@ -3292,7 +3319,7 @@ get_causal_binary_exclude()
 std::vector<std::string>
 get_causal_source_exclude()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_CAUSAL_SOURCE_EXCLUDE");
+    static auto _v = get_config()->find(std::string{ env_vars::CAUSAL_SOURCE_EXCLUDE });
     return tim::delimit(static_cast<tim::tsettings<std::string>&>(*_v->second).get(),
                         "\t\"';");
 }
@@ -3300,7 +3327,7 @@ get_causal_source_exclude()
 std::vector<std::string>
 get_causal_function_exclude()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_CAUSAL_FUNCTION_EXCLUDE");
+    static auto _v = get_config()->find(std::string{ env_vars::CAUSAL_FUNCTION_EXCLUDE });
     return tim::delimit(static_cast<tim::tsettings<std::string>&>(*_v->second).get(),
                         "\t\"';");
 }

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -1218,7 +1218,7 @@ configure_settings(bool _init)
 
     auto _dl_verbose = _config->find(std::string{ env_vars::DL_VERBOSE });
     if(_dl_verbose->second->get_config_updated())
-        rocprofsys::set_env(std::string{ _dl_verbose->first },
+        rocprofsys::set_env(std::string{ _dl_verbose->first }.c_str(),
                             _dl_verbose->second->as_string(), 0);
 
     if(_config->get_papi_events().empty())
@@ -1265,7 +1265,7 @@ configure_mode_settings(const std::shared_ptr<settings>& _config)
     };
 
     auto _use_causal = get_setting_value<bool>(std::string{ env_vars::USE_CAUSAL });
-    if(_use_causal && *_use_causal) set_env(std::string{ env_vars::MODE }, "causal", 1);
+    if(_use_causal && *_use_causal) set_env(env_vars::MODE, "causal", 1);
 
     if(get_mode() == Mode::Coverage)
     {
@@ -2813,7 +2813,7 @@ get_first_mpi_env_uint(const std::vector<std::string>& env_var_options,
 {
     for(const auto& env_var : env_var_options)
     {
-        const std::string value_str = get_env(env_var, std::string{});
+        const std::string value_str = get_env(env_var.c_str(), std::string{});
 
         if(value_str.empty()) continue;
 

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -307,8 +307,8 @@ configure_settings(bool _init)
         "threads that get sampled, rocprof-sys can start all the background threads "
         "during "
         "initialization",
-        get_env<size_t>(env_vars::NUM_THREADS.data(), 1), "threading", "performance",
-        "sampling", "parallelism", "advanced");
+        get_env<size_t>(env_vars::NUM_THREADS, 1), "threading", "performance", "sampling",
+        "parallelism", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(bool, env_vars::TRACE,
                               "Enable perfetto backend for tracing", _default_perfetto_v,
@@ -919,7 +919,7 @@ configure_settings(bool _init)
         std::string{}, "data", "io", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_RANK_FILTER_LOGS",
+        std::string, env_vars::RANK_FILTER_LOGS,
         "Ranks for which console output is generated. Values should be separated by "
         "commas and can be explicit or ranges, e.g. 0,1,5-8. An empty value enables "
         "output for all ranks",
@@ -1026,9 +1026,9 @@ configure_settings(bool _init)
     if(!output_filtering::is_log_output_enabled_for_current_mpi_rank())
     {
         logger_t::instance().set_level(spdlog::level::err);
-        setenv("ROCPROFSYS_LOG_LEVEL", "error", 1);
-        setenv("ROCPROFSYS_DL_VERBOSE", "-1", 1);
-        setenv("ROCPROFSYS_VERBOSE", "-1", 1);
+        setenv(env_vars::LOG_LEVEL, "error", 1);
+        setenv(env_vars::DL_VERBOSE, "-1", 1);
+        setenv(env_vars::VERBOSE, "-1", 1);
     }
 
 #if defined(TIMEMORY_USE_PAPI)
@@ -1105,8 +1105,8 @@ configure_settings(bool _init)
     auto _proc      = mproc::get_concurrent_processes(_ppid);
     bool _main_proc = (_proc.size() < 2 || *_proc.begin() == _pid);
 
-    for(auto&& filename :
-        tim::delimit(_config->get<std::string>(std::string{ env_vars::CONFIG_FILE }), ";:"))
+    for(auto&& filename : tim::delimit(
+            _config->get<std::string>(std::string{ env_vars::CONFIG_FILE }), ";:"))
     {
         if(_config->get_suppress_config()) continue;
 
@@ -1127,7 +1127,8 @@ configure_settings(bool _init)
 
         LOG_DEBUG("Reading config file {}", filename);
         if(_config->read(filename) && _main_proc &&
-           ((_config->get<bool>(std::string{ env_vars::CI }) && settings::verbose() >= 0) ||
+           ((_config->get<bool>(std::string{ env_vars::CI }) &&
+             settings::verbose() >= 0) ||
             settings::verbose() >= 1 || settings::debug()))
         {
             std::ifstream     _in{ expanded_filename };
@@ -1152,7 +1153,7 @@ configure_settings(bool _init)
     if(auto opt = get_setting_value<bool>(std::string{ env_vars::DEBUG_MODE }); opt)
         debug_value = *opt;
 
-    if(get_env(env_vars::MONOCHROME.data(),
+    if(get_env(env_vars::MONOCHROME,
                _config->get<bool>(std::string{ env_vars::MONOCHROME })))
         tim::log::monochrome() = true;
 
@@ -1320,7 +1321,8 @@ configure_mode_settings(const std::shared_ptr<settings>& _config)
 
     // recycle all subsequent thread ids
     threading::recycle_ids() = rocprofsys::get_env<bool>(
-        env_vars::RECYCLE_TIDS, !_config->get<bool>(std::string{ env_vars::USE_SAMPLING }));
+        env_vars::RECYCLE_TIDS,
+        !_config->get<bool>(std::string{ env_vars::USE_SAMPLING }));
 
     if(!_config->get_enabled())
     {
@@ -1692,9 +1694,8 @@ print_settings(
 
     std::stringstream _os{};
 
-    bool _print_desc =
-        get_debug() || rocprofsys::get_env(env_vars::SETTINGS_DESC, false);
-    bool _md = rocprofsys::get_env<bool>(env_vars::SETTINGS_DESC_MARKDOWN, false);
+    bool _print_desc = get_debug() || rocprofsys::get_env(env_vars::SETTINGS_DESC, false);
+    bool _md         = rocprofsys::get_env<bool>(env_vars::SETTINGS_DESC_MARKDOWN, false);
 
     constexpr size_t nfields = 3;
     using str_array_t        = std::array<std::string, nfields>;
@@ -1948,9 +1949,8 @@ get_debug_sampling()
 int
 get_verbose_env()
 {
-    return (settings_are_configured())
-               ? get_verbose()
-               : rocprofsys::get_env<int>(env_vars::VERBOSE, 0);
+    return (settings_are_configured()) ? get_verbose()
+                                       : rocprofsys::get_env<int>(env_vars::VERBOSE, 0);
 }
 
 int
@@ -2295,7 +2295,7 @@ get_perfetto_output_filename()
 {
     const auto*  pwd     = getenv("PWD");
     static auto  setting = get_config()->find(std::string{ env_vars::PERFETTO_FILE });
-    static auto* attach_add_session_id = getenv(env_vars::REATTACH_ADD_SESSION_ID.data());
+    static auto* attach_add_session_id = getenv(env_vars::REATTACH_ADD_SESSION_ID);
 
     if(setting == get_config()->end())
     {
@@ -2504,7 +2504,7 @@ get_sampling_gpus()
 std::string
 get_gpu_perf_counters()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_GPU_PERF_COUNTERS");
+    static auto _v = get_config()->find(std::string{ env_vars::GPU_PERF_COUNTERS });
     return static_cast<tim::tsettings<std::string>&>(*_v->second).get();
 }
 
@@ -2793,7 +2793,7 @@ get_rank_filter_output()
 std::string
 get_rank_filter_logs()
 {
-    static auto _v = get_config()->at("ROCPROFSYS_RANK_FILTER_LOGS");
+    static auto _v = get_config()->at(std::string{ env_vars::RANK_FILTER_LOGS });
     return static_cast<tim::tsettings<std::string>&>(*_v).get();
 }
 

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -4,6 +4,7 @@
 #include "config.hpp"
 #include "amd_smi.hpp"
 #include "common/defines.h"
+#include "common/env_vars.hpp"
 #include "common/static_object.hpp"
 #include "constraint.hpp"
 #include "gpu.hpp"
@@ -65,8 +66,8 @@ using settings = tim::settings;
 
 namespace
 {
-int  verbose_value  = tim::get_env<int>("ROCPROFSYS_VERBOSE", 0, false);
-bool debug_value    = tim::get_env<bool>("ROCPROFSYS_DEBUG", false, false);
+int  verbose_value  = tim::get_env<int>(env_vars::VERBOSE.data(), 0, false);
+bool debug_value    = tim::get_env<bool>(env_vars::DEBUG_MODE.data(), false, false);
 auto configure_once = std::once_flag{};
 
 TIMEMORY_NOINLINE bool&
@@ -118,49 +119,54 @@ get_available_categories()
 
 using utility::parse_numeric_range;
 
-#define ROCPROFSYS_CONFIG_SETTING(TYPE, ENV_NAME, DESCRIPTION, INITIAL_VALUE, ...)       \
-    [&]() {                                                                              \
-        auto _ret = _config->insert<TYPE, TYPE>(                                         \
-            ENV_NAME, get_setting_name(ENV_NAME), DESCRIPTION, TYPE{ INITIAL_VALUE },    \
-            std::set<std::string>{ "custom", "rocprofsys", "librocprof-sys",             \
-                                   __VA_ARGS__ });                                       \
-        if(!_ret.second)                                                                 \
-        {                                                                                \
-            LOG_WARNING("Duplicate setting: {} / {}", get_setting_name(ENV_NAME),        \
-                        ENV_NAME);                                                       \
-        }                                                                                \
-        return _config->find(ENV_NAME)->second;                                          \
+// Accepts either a `const char*` literal or `std::string_view` (e.g. env_vars::FOO)
+// for ENV_NAME — std::string{} can be constructed from either.
+#define ROCPROFSYS_CONFIG_SETTING(TYPE, ENV_NAME, DESCRIPTION, INITIAL_VALUE, ...)           \
+    [&]() {                                                                                  \
+        auto _env_name = std::string{ ENV_NAME };                                            \
+        auto _ret      = _config->insert<TYPE, TYPE>(                                        \
+            _env_name, get_setting_name(_env_name), DESCRIPTION, TYPE{ INITIAL_VALUE }, \
+            std::set<std::string>{ "custom", "rocprofsys", "librocprof-sys",            \
+                                        __VA_ARGS__ });                                      \
+        if(!_ret.second)                                                                     \
+        {                                                                                    \
+            LOG_WARNING("Duplicate setting: {} / {}", get_setting_name(_env_name),           \
+                        _env_name);                                                          \
+        }                                                                                    \
+        return _config->find(_env_name)->second;                                             \
     }()
 
 // below does not include "librocprof-sys"
-#define ROCPROFSYS_CONFIG_EXT_SETTING(TYPE, ENV_NAME, DESCRIPTION, INITIAL_VALUE, ...)   \
-    [&]() {                                                                              \
-        auto _ret = _config->insert<TYPE, TYPE>(                                         \
-            ENV_NAME, get_setting_name(ENV_NAME), DESCRIPTION, TYPE{ INITIAL_VALUE },    \
-            std::set<std::string>{ "custom", "rocprofsys", __VA_ARGS__ });               \
-        if(!_ret.second)                                                                 \
-        {                                                                                \
-            LOG_WARNING("Duplicate setting: {} / {}", get_setting_name(ENV_NAME),        \
-                        ENV_NAME);                                                       \
-        }                                                                                \
-        return _config->find(ENV_NAME)->second;                                          \
+#define ROCPROFSYS_CONFIG_EXT_SETTING(TYPE, ENV_NAME, DESCRIPTION, INITIAL_VALUE, ...)       \
+    [&]() {                                                                                  \
+        auto _env_name = std::string{ ENV_NAME };                                            \
+        auto _ret      = _config->insert<TYPE, TYPE>(                                        \
+            _env_name, get_setting_name(_env_name), DESCRIPTION, TYPE{ INITIAL_VALUE }, \
+            std::set<std::string>{ "custom", "rocprofsys", __VA_ARGS__ });              \
+        if(!_ret.second)                                                                     \
+        {                                                                                    \
+            LOG_WARNING("Duplicate setting: {} / {}", get_setting_name(_env_name),           \
+                        _env_name);                                                          \
+        }                                                                                    \
+        return _config->find(_env_name)->second;                                             \
     }()
 
 // setting + command line option
-#define ROCPROFSYS_CONFIG_CL_SETTING(TYPE, ENV_NAME, DESCRIPTION, INITIAL_VALUE,         \
-                                     CMD_LINE, ...)                                      \
-    [&]() {                                                                              \
-        auto _ret = _config->insert<TYPE, TYPE>(                                         \
-            ENV_NAME, get_setting_name(ENV_NAME), DESCRIPTION, TYPE{ INITIAL_VALUE },    \
-            std::set<std::string>{ "custom", "rocprofsys", "librocprof-sys",             \
-                                   __VA_ARGS__ },                                        \
-            std::vector<std::string>{ CMD_LINE });                                       \
-        if(!_ret.second)                                                                 \
-        {                                                                                \
-            LOG_WARNING("Duplicate setting: {} / {}", get_setting_name(ENV_NAME),        \
-                        ENV_NAME);                                                       \
-        }                                                                                \
-        return _config->find(ENV_NAME)->second;                                          \
+#define ROCPROFSYS_CONFIG_CL_SETTING(TYPE, ENV_NAME, DESCRIPTION, INITIAL_VALUE,             \
+                                     CMD_LINE, ...)                                          \
+    [&]() {                                                                                  \
+        auto _env_name = std::string{ ENV_NAME };                                            \
+        auto _ret      = _config->insert<TYPE, TYPE>(                                        \
+            _env_name, get_setting_name(_env_name), DESCRIPTION, TYPE{ INITIAL_VALUE }, \
+            std::set<std::string>{ "custom", "rocprofsys", "librocprof-sys",            \
+                                        __VA_ARGS__ },                                       \
+            std::vector<std::string>{ CMD_LINE });                                      \
+        if(!_ret.second)                                                                     \
+        {                                                                                    \
+            LOG_WARNING("Duplicate setting: {} / {}", get_setting_name(_env_name),           \
+                        _env_name);                                                          \
+        }                                                                                    \
+        return _config->find(_env_name)->second;                                             \
     }()
 }  // namespace
 
@@ -236,50 +242,51 @@ configure_settings(bool _init)
     auto _config = *get_config_impl();
 
     // if using timemory, default to perfetto being off
-    auto _default_perfetto_v = !tim::get_env<bool>("ROCPROFSYS_PROFILE", false, false);
+    auto _default_perfetto_v =
+        !tim::get_env<bool>(env_vars::PROFILE.data(), false, false);
 
     auto _system_backend =
-        tim::get_env("ROCPROFSYS_PERFETTO_BACKEND_SYSTEM", false, false);
+        tim::get_env(env_vars::PERFETTO_BACKEND_SYSTEM.data(), false, false);
 
-    ROCPROFSYS_CONFIG_SETTING(std::string, "ROCPROFSYS_LOG_LEVEL",
+    ROCPROFSYS_CONFIG_SETTING(std::string, env_vars::LOG_LEVEL,
                               "Rocprofiler-systems log level", "info", "debugging",
                               "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(std::string, "ROCPROFSYS_LOG_FILE",
+    ROCPROFSYS_CONFIG_SETTING(std::string, env_vars::LOG_FILE,
                               "Filename for the Rocprofiler-systems log file. Leave "
                               "empty to not write to a file.",
                               "rocprof-sys-log.txt", "debugging", "advanced");
 
-    auto _rocprofsys_debug = _config->get<bool>("ROCPROFSYS_DEBUG");
+    auto _rocprofsys_debug = _config->get<bool>(std::string{ env_vars::DEBUG_MODE });
     if(_rocprofsys_debug) tim::set_env("TIMEMORY_DEBUG_SETTINGS", "1", 0);
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_MODE",
+        std::string, env_vars::MODE,
         "Data collection mode. Used to set default values for ROCPROFSYS_USE_* options. "
         "Typically set by rocprof-sys binary instrumenter.",
         std::string{ "trace" }, "backend", "advanced", "mode")
         ->set_choices({ "trace", "sampling", "causal", "coverage" });
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_CI",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::CI,
                               "Enable some runtime validation checks (typically enabled "
                               "for continuous integration)",
                               false, "debugging", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        bool, "ROCPROFSYS_CI_SKIP_PUSH_POP_CHECK",
+        bool, env_vars::CI_SKIP_PUSH_POP_CHECK,
         "Skip CI validation check for push/pop trace count mismatch "
         "(used only for tests with known imbalances)",
         false, "debugging", "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_MONOCHROME", "Disable colorized logging",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::MONOCHROME, "Disable colorized logging",
                               false, "debugging", "advanced");
 
-    ROCPROFSYS_CONFIG_EXT_SETTING(int, "ROCPROFSYS_DL_VERBOSE",
+    ROCPROFSYS_CONFIG_EXT_SETTING(int, env_vars::DL_VERBOSE,
                                   "Verbosity within the rocprof-sys-dl library", 0,
                                   "debugging", "librocprof-sys-dl", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        size_t, "ROCPROFSYS_NUM_THREADS_HINT",
+        size_t, env_vars::NUM_THREADS_HINT,
         "This is hint for how many threads are expected to be created in the "
         "application. Setting this value allows rocprof-sys to preallocate resources "
         "during initialization and warn about any potential issues. For example, when "
@@ -290,14 +297,14 @@ configure_settings(bool _init)
         "threads that get sampled, rocprof-sys can start all the background threads "
         "during "
         "initialization",
-        get_env<size_t>("ROCPROFSYS_NUM_THREADS", 1), "threading", "performance",
+        get_env<size_t>(env_vars::NUM_THREADS.data(), 1), "threading", "performance",
         "sampling", "parallelism", "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_TRACE",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::TRACE,
                               "Enable perfetto backend for tracing", _default_perfetto_v,
                               "backend", "perfetto");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_TRACE_LEGACY",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::TRACE_LEGACY,
                               "[DEPRECATED] The new default option is to use data from "
                               "cached buffer. When set to true system will use "
                               "legacy direct mode for perfetto tracing instead of "
@@ -305,120 +312,119 @@ configure_settings(bool _init)
                               "cached mode with minimal runtime overhead.",
                               false, "backend", "perfetto");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_USE_PERFETTO",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::USE_PERFETTO,
                               "[DEPRECATED] Renamed to ROCPROFSYS_TRACE", false,
                               "backend", "perfetto", "deprecated");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_PROFILE", "Enable timemory backend",
-                              !_config->get<bool>("ROCPROFSYS_TRACE"), "backend",
-                              "timemory");
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::PROFILE, "Enable timemory backend",
+                              !_config->get<bool>(std::string{ env_vars::TRACE }),
+                              "backend", "timemory");
 
-    ROCPROFSYS_CONFIG_SETTING(
-        bool, "ROCPROFSYS_USE_TIMEMORY", "[DEPRECATED] Renamed to ROCPROFSYS_PROFILE",
-        !_config->get<bool>("ROCPROFSYS_TRACE"), "backend", "timemory", "deprecated");
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::USE_TIMEMORY,
+                              "[DEPRECATED] Renamed to ROCPROFSYS_PROFILE",
+                              !_config->get<bool>(std::string{ env_vars::TRACE }),
+                              "backend", "timemory", "deprecated");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_USE_CAUSAL",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::USE_CAUSAL,
                               "Enable causal profiling analysis", false, "backend",
                               "causal", "analysis");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_USE_ROCPD", "Enable rocpd backend", false,
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::USE_ROCPD, "Enable rocpd backend", false,
                               "backend", "rocpd");
 
     ROCPROFSYS_CONFIG_SETTING(
-        bool, "ROCPROFSYS_USE_UNIFIED_MEMORY_PROFILING",
+        bool, env_vars::USE_UNIFIED_MEMORY_PROFILING,
         "Enable unified memory profiling reports from KFD page fault and migration "
         "events (requires HSA_XNACK=1 on a supported GPU; required KFD tracing is "
         "enabled automatically)",
         false, "backend", "unified_memory", "kfd");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_USE_AMD_SMI",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::USE_AMD_SMI,
                               "Enable sampling GPU power, temp, utilization, "
                               "vcn_activity, jpeg_activity and memory usage",
                               true, "backend", "amd_smi", "rocm", "process_sampling");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_USE_SAMPLING",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::USE_SAMPLING,
                               "Enable statistical sampling of call-stack", false,
                               "backend", "sampling");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_USE_THREAD_SAMPLING",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::USE_THREAD_SAMPLING,
                               "[DEPRECATED] Renamed to ROCPROFSYS_USE_PROCESS_SAMPLING",
                               true, "backend", "sampling", "process_sampling",
                               "deprecated", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        bool, "ROCPROFSYS_USE_PROCESS_SAMPLING",
+        bool, env_vars::USE_PROCESS_SAMPLING,
         "Enable a background thread which samples process-level and system metrics "
         "such as the CPU/GPU freq, power, memory usage, etc.",
         true, "backend", "sampling", "process_sampling");
 
     ROCPROFSYS_CONFIG_SETTING(
-        bool, "ROCPROFSYS_USE_PID",
+        bool, env_vars::USE_PID,
         "Enable tagging filenames with process identifier (either MPI rank or pid)", true,
         "io", "filename");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_USE_KOKKOSP",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::USE_KOKKOSP,
                               "Enable support for Kokkos Tools", false, "kokkos",
                               "backend");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_USE_MPIP",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::USE_MPIP,
                               "Enable support for MPI functions", true, "mpi", "backend",
                               "parallelism");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_USE_UCX",
-                              "Enable support for UCX functions", false, "ucx", "backend",
-                              "parallelism");
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::USE_UCX, "Enable support for UCX functions",
+                              false, "ucx", "backend", "parallelism");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_USE_SHMEM",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::USE_SHMEM,
                               "Enable support for OpenSHMEM functions", false, "shmem",
                               "backend", "parallelism");
 
     ROCPROFSYS_CONFIG_SETTING(
-        bool, "ROCPROFSYS_USE_RCCLP",
+        bool, env_vars::USE_RCCLP,
         "Enable support for ROCm Communication Collectives Library (RCCL) Performance",
         false, "rocm", "rccl", "backend");
 
     ROCPROFSYS_CONFIG_CL_SETTING(
-        bool, "ROCPROFSYS_KOKKOSP_KERNEL_LOGGER", "Enables kernel logging", false,
+        bool, env_vars::KOKKOSP_KERNEL_LOGGER, "Enables kernel logging", false,
         "--rocprofsys-kokkos-kernel-logger", "kokkos", "debugging", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::int64_t, "ROCPROFSYS_KOKKOSP_NAME_LENGTH_MAX",
+        std::int64_t, env_vars::KOKKOSP_NAME_LENGTH_MAX,
         "Set this to a value > 0 to help avoid unnamed Kokkos Tools "
         "callbacks. Generally, unnamed callbacks are the demangled "
         "name of the function, which is very long",
         0, "kokkos", "debugging", "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(std::string, "ROCPROFSYS_KOKKOSP_PREFIX",
+    ROCPROFSYS_CONFIG_SETTING(std::string, env_vars::KOKKOSP_PREFIX,
                               "Set to [kokkos] to maintain old naming convention", "",
                               "kokkos", "debugging", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        bool, "ROCPROFSYS_KOKKOSP_DEEP_COPY",
+        bool, env_vars::KOKKOSP_DEEP_COPY,
         "Enable tracking deep copies (warning: may corrupt flamegraph in perfetto)",
         false, "kokkos", "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_USE_OMPT",
-                              "Enable support for OpenMP-Tools", false, "openmp", "ompt",
-                              "backend");
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::USE_OMPT, "Enable support for OpenMP-Tools",
+                              false, "openmp", "ompt", "backend");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_USE_CODE_COVERAGE",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::USE_CODE_COVERAGE,
                               "Enable support for code coverage", false, "coverage",
                               "backend", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        double, "ROCPROFSYS_TRACE_DELAY",
+        double, env_vars::TRACE_DELAY,
         "Time in seconds to wait before enabling trace/profile data collection. If "
         "multiple delays + durations are needed, see ROCPROFSYS_TRACE_PERIODS.",
         0.0, "trace", "profile", "perfetto", "timemory");
 
     ROCPROFSYS_CONFIG_SETTING(
-        double, "ROCPROFSYS_TRACE_DURATION",
+        double, env_vars::TRACE_DURATION,
         "If > 0.0, time (in seconds) to collect trace/profile data. If multiple delays + "
         "durations are needed, see ROCPROFSYS_TRACE_PERIODS.",
         0.0, "trace", "profile", "perfetto", "timemory");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_SELECTED_REGIONS",
+        std::string, env_vars::SELECTED_REGIONS,
         "Comma-separated list of roctx region names. When set, only "
         "activity inside roctx regions matching one of these names "
         "(matched against roctxRangeStartA message). Uses process-wide "
@@ -432,14 +438,14 @@ configure_settings(bool _init)
             fmt::format("({}|{}|{})", itr.name, itr.value, itr.raw_name));
     }
 
-    ROCPROFSYS_CONFIG_SETTING(std::string, "ROCPROFSYS_TRACE_PERIODS",
+    ROCPROFSYS_CONFIG_SETTING(std::string, env_vars::TRACE_PERIODS,
                               "Similar to specify trace delay and/or duration except in "
                               "the form <DELAY>:<DURATION>, <DELAY>:<DURATION>:<REPEAT>, "
                               "and/or <DELAY>:<DURATION>:<REPEAT>:<CLOCK_ID>",
                               std::string{}, "trace", "profile", "perfetto", "timemory");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_TRACE_PERIOD_CLOCK_ID",
+        std::string, env_vars::TRACE_PERIOD_CLOCK_ID,
         "Set the default clock ID for ROCPROFSYS_TRACE_DELAY, ROCPROFSYS_TRACE_DURATION, "
         "and/or ROCPROFSYS_TRACE_PERIODS. E.g. \"realtime\" == the delay/duration is "
         "governed by the elapsed realtime, \"cputime\" == the delay/duration is governed "
@@ -450,71 +456,71 @@ configure_settings(bool _init)
         ->set_choices(_clock_choices);
 
     ROCPROFSYS_CONFIG_SETTING(
-        double, "ROCPROFSYS_SAMPLING_FREQ",
+        double, env_vars::SAMPLING_FREQ,
         "Number of software interrupts per second when ROCPROFSYS_USE_SAMPLING=ON", 300.0,
         "sampling", "process_sampling");
 
-    ROCPROFSYS_CONFIG_SETTING(double, "ROCPROFSYS_SAMPLING_CPUTIME_FREQ",
+    ROCPROFSYS_CONFIG_SETTING(double, env_vars::SAMPLING_CPUTIME_FREQ,
                               "Number of software interrupts per second of CPU-time. "
                               "Defaults to ROCPROFSYS_SAMPLING_FREQ when <= 0.0",
                               -1.0, "sampling", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        double, "ROCPROFSYS_SAMPLING_REALTIME_FREQ",
+        double, env_vars::SAMPLING_REALTIME_FREQ,
         "Number of software interrupts per second of real (wall) time. "
         "Defaults to ROCPROFSYS_SAMPLING_FREQ when <= 0.0",
         -1.0, "sampling", "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(double, "ROCPROFSYS_SAMPLING_OVERFLOW_FREQ",
+    ROCPROFSYS_CONFIG_SETTING(double, env_vars::SAMPLING_OVERFLOW_FREQ,
                               "Number of events in between each sample. "
                               "Defaults to ROCPROFSYS_SAMPLING_FREQ when <= 0.0",
                               -1.0, "sampling", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        double, "ROCPROFSYS_SAMPLING_DELAY",
+        double, env_vars::SAMPLING_DELAY,
         "Time (in seconds) to wait before the first sampling signal is delivered, "
         "increasing this value can fix deadlocks during init",
         0.5, "sampling", "process_sampling");
 
-    ROCPROFSYS_CONFIG_SETTING(double, "ROCPROFSYS_SAMPLING_CPUTIME_DELAY",
+    ROCPROFSYS_CONFIG_SETTING(double, env_vars::SAMPLING_CPUTIME_DELAY,
                               "Time (in seconds) to wait before the first CPU-time "
                               "sampling signal is delivered. "
                               "Defaults to ROCPROFSYS_SAMPLING_DELAY when <= 0.0",
                               -1.0, "sampling", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        double, "ROCPROFSYS_SAMPLING_REALTIME_DELAY",
+        double, env_vars::SAMPLING_REALTIME_DELAY,
         "Time (in seconds) to wait before the first real (wall) time sampling signal is "
         "delivered. Defaults to ROCPROFSYS_SAMPLING_DELAY when <= 0.0",
         -1.0, "sampling", "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(double, "ROCPROFSYS_SAMPLING_DURATION",
+    ROCPROFSYS_CONFIG_SETTING(double, env_vars::SAMPLING_DURATION,
                               "If > 0.0, time (in seconds) to sample before stopping",
                               0.0, "sampling", "process_sampling");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_CPU_FREQ_ENABLED",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::CPU_FREQ_ENABLED,
                               "Enable tracking for CPU frequency, memory usage, virtual "
                               "memory usage, peak memory, context switches, page faults, "
                               "user time, and kernel time",
                               false, "process_sampling");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_USE_AINIC",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::USE_AINIC,
                               "Enable tracking for AI NIC metrics", false,
                               "process_sampling");
 
     ROCPROFSYS_CONFIG_SETTING(
-        double, "ROCPROFSYS_PROCESS_SAMPLING_FREQ",
+        double, env_vars::PROCESS_SAMPLING_FREQ,
         "Number of measurements per second when ROCPROFSYS_USE_PROCESS_SAMPLING=ON. If "
         "set to zero, uses ROCPROFSYS_SAMPLING_FREQ value",
         0.0, "process_sampling");
 
-    ROCPROFSYS_CONFIG_SETTING(double, "ROCPROFSYS_PROCESS_SAMPLING_DURATION",
+    ROCPROFSYS_CONFIG_SETTING(double, env_vars::PROCESS_SAMPLING_DURATION,
                               "If > 0.0, time (in seconds) to sample before stopping. If "
                               "less than zero, uses ROCPROFSYS_SAMPLING_DURATION",
                               -1.0, "sampling", "process_sampling");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_SAMPLING_CPUS",
+        std::string, env_vars::SAMPLING_CPUS,
         "CPU socket (physical package) IDs for CPU PMC sampling. Values should be "
         "separated by commas and can be explicit or ranges, e.g. 0,1. Selects which "
         "CPU sockets to monitor; all cores on a selected socket are always sampled. "
@@ -522,14 +528,14 @@ configure_settings(bool _init)
         std::string{ "none" }, "process_sampling");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_CPU_METRICS",
+        std::string, env_vars::CPU_METRICS,
         "CPU metrics to collect. Comma-separated tokens: frequency, load, memory "
         "(page_rss+virt_mem+peak_rss), ctx_switches, page_faults, cpu_time "
         "(user_time+kernel_time). Fine-grained: page_rss, virt_mem, peak_rss, "
         "user_time, kernel_time. Special: all, none",
         std::string{ "all" }, "process_sampling");
 
-    ROCPROFSYS_CONFIG_SETTING(std::string, "ROCPROFSYS_SAMPLING_AINICS",
+    ROCPROFSYS_CONFIG_SETTING(std::string, env_vars::SAMPLING_AINICS,
                               "AI NICs to query when ROCPROFSYS_USE_AMD_SMI=ON. NIC "
                               "names should be separated by "
                               "commas, e.g. eno8303,enp7s0.",
@@ -537,14 +543,14 @@ configure_settings(bool _init)
                               "process_sampling");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_SAMPLING_GPUS",
+        std::string, env_vars::SAMPLING_GPUS,
         "Devices to query when ROCPROFSYS_USE_AMD_SMI=ON. Values should be separated by "
         "commas and can be explicit or ranges, e.g. 0,1,5-8. An empty value implies "
         "'all' and 'none' suppresses all GPU sampling",
         std::string{ "all" }, "amd_smi", "rocm", "process_sampling");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_SAMPLING_TIDS",
+        std::string, env_vars::SAMPLING_TIDS,
         "Limit call-stack sampling to specific thread IDs, starting at zero for the main "
         "thread. Be aware that some libraries, such as ROCm may create additional "
         "threads which increment the TID count. However, no threads started by "
@@ -554,76 +560,76 @@ configure_settings(bool _init)
         std::string{}, "sampling", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_SAMPLING_CPUTIME_TIDS",
+        std::string, env_vars::SAMPLING_CPUTIME_TIDS,
         "Same as ROCPROFSYS_SAMPLING_TIDS but applies specifically to samplers whose "
         "timers are based on the CPU-time. This is useful when you want to restrict "
         "samples to particular threads.",
         std::string{}, "sampling", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_SAMPLING_REALTIME_TIDS",
+        std::string, env_vars::SAMPLING_REALTIME_TIDS,
         "Same as ROCPROFSYS_SAMPLING_TIDS but applies specifically to samplers whose "
         "timers are based on the real (wall) time. This is useful when you want to "
         "restrict samples to particular threads.",
         std::string{}, "sampling", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_SAMPLING_OVERFLOW_TIDS",
+        std::string, env_vars::SAMPLING_OVERFLOW_TIDS,
         "Same as ROCPROFSYS_SAMPLING_TIDS but applies specifically to samplers whose "
         "samples are based on the overflow of a particular event. This is useful when "
         "you want to restrict samples to particular threads.",
         std::string{}, "sampling", "advanced");
 
     auto _backend = tim::get_env_choice<std::string>(
-        "ROCPROFSYS_PERFETTO_BACKEND",
+        env_vars::PERFETTO_BACKEND.data(),
         (_system_backend) ? "system"  // if ROCPROFSYS_PERFETTO_BACKEND_SYSTEM is true,
                                       // default to system.
                           : "inprocess",  // Otherwise, default to inprocess
         { "inprocess", "system", "all" }, false);
 
-    ROCPROFSYS_CONFIG_SETTING(std::string, "ROCPROFSYS_PERFETTO_BACKEND",
+    ROCPROFSYS_CONFIG_SETTING(std::string, env_vars::PERFETTO_BACKEND,
                               "Specify the perfetto backend to activate. Options are: "
                               "'inprocess', 'system', or 'all'",
                               _backend, "perfetto")
         ->set_choices({ "inprocess", "system", "all" });
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_TRACE_THREAD_LOCKS",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::TRACE_THREAD_LOCKS,
                               "Enable tracing calls to pthread_mutex_lock, "
                               "pthread_mutex_unlock, pthread_mutex_trylock",
                               false, "backend", "parallelism", "gotcha", "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_TRACE_THREAD_RW_LOCKS",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::TRACE_THREAD_RW_LOCKS,
                               "Enable tracing calls to pthread_rwlock_* functions. May "
                               "cause deadlocks with ROCm-enabled OpenMPI.",
                               false, "backend", "parallelism", "gotcha", "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_TRACE_THREAD_SPIN_LOCKS",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::TRACE_THREAD_SPIN_LOCKS,
                               "Enable tracing calls to pthread_spin_* functions. May "
                               "cause deadlocks with MPI distributions.",
                               false, "backend", "parallelism", "gotcha", "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_TRACE_THREAD_BARRIERS",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::TRACE_THREAD_BARRIERS,
                               "Enable tracing calls to pthread_barrier functions.", true,
                               "backend", "parallelism", "gotcha", "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_TRACE_THREAD_JOIN",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::TRACE_THREAD_JOIN,
                               "Enable tracing calls to pthread_join functions.", true,
                               "backend", "parallelism", "gotcha", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        bool, "ROCPROFSYS_SAMPLING_KEEP_INTERNAL",
+        bool, env_vars::SAMPLING_KEEP_INTERNAL,
         "Configure whether the statistical samples should include call-stack entries "
         "from internal routines in rocprof-sys. E.g. when ON, the call-stack will show "
         "functions like rocprofsys_push_trace. If disabled, rocprof-sys will attempt to "
         "filter out internal routines from the sampling call-stacks",
         true, "sampling", "data", "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_SAMPLING_INCLUDE_INLINES",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::SAMPLING_INCLUDE_INLINES,
                               "Create entries for inlined functions when available",
                               false, "sampling", "data", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        size_t, "ROCPROFSYS_SAMPLING_ALLOCATOR_SIZE",
+        size_t, env_vars::SAMPLING_ALLOCATOR_SIZE,
         "The number of sampled threads handled by an allocator running in a background "
         "thread. Each thread that is sampled communicates with an allocator running in a "
         "background thread which handles storing/caching the data when it's buffer is "
@@ -634,45 +640,45 @@ configure_settings(bool _init)
         "thread started by the application.",
         8, "sampling", "debugging", "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_SAMPLING_OVERFLOW",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::SAMPLING_OVERFLOW,
                               "Enable sampling via an overflow of a HW counter. This "
                               "requires Linux perf (/proc/sys/kernel/perf_event_paranoid "
                               "created by OS) with a value of 2 or less in that file",
                               false, "sampling", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        bool, "ROCPROFSYS_SAMPLING_REALTIME",
+        bool, env_vars::SAMPLING_REALTIME,
         "Enable sampling frequency via a wall-clock timer. This may result in typically "
         "idle child threads consuming an unnecessary large amount of CPU time.",
         false, "sampling", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        bool, "ROCPROFSYS_SAMPLING_CPUTIME",
+        bool, env_vars::SAMPLING_CPUTIME,
         "Enable sampling frequency via a timer that measures both CPU time used by the "
         "current process, and CPU time expended on behalf of the process by the system. "
         "This is recommended.",
         false, "sampling", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        int, "ROCPROFSYS_SAMPLING_CPUTIME_SIGNAL",
+        int, env_vars::SAMPLING_CPUTIME_SIGNAL,
         "Modify this value only if the target process is also using "
         "the same signal (SIGPROF)",
         SIGPROF, "sampling", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        int, "ROCPROFSYS_SAMPLING_REALTIME_SIGNAL",
+        int, env_vars::SAMPLING_REALTIME_SIGNAL,
         "Modify this value only if the target process is also using "
         "the same signal (SIGRTMIN)",
         SIGRTMIN, "sampling", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        int, "ROCPROFSYS_SAMPLING_OVERFLOW_SIGNAL",
+        int, env_vars::SAMPLING_OVERFLOW_SIGNAL,
         "Modify this value only if the target process is also using "
         "the same signal (SIGRTMIN + 1)",
         SIGRTMIN + 1, "sampling", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_SAMPLING_OVERFLOW_EVENT",
+        std::string, env_vars::SAMPLING_OVERFLOW_EVENT,
         "Metric for overflow sampling. Defaults to perf::PERF_COUNT_HW_CACHE_REFERENCES. "
         "For full list of events see: rocprof-sys-avail -H -c CPU -r overflow",
         std::string{ "perf::PERF_COUNT_HW_CACHE_REFERENCES" }, "sampling",
@@ -681,31 +687,31 @@ configure_settings(bool _init)
     rocprofiler_sdk::config_settings(_config);
     amd_smi::config_settings(_config);
 
-    ROCPROFSYS_CONFIG_SETTING(size_t, "ROCPROFSYS_PERFETTO_SHMEM_SIZE_HINT_KB",
+    ROCPROFSYS_CONFIG_SETTING(size_t, env_vars::PERFETTO_SHMEM_SIZE_HINT_KB,
                               "Hint for shared-memory buffer size in perfetto (in KB)",
                               size_t{ 4096 }, "perfetto", "data", "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(size_t, "ROCPROFSYS_PERFETTO_BUFFER_SIZE_KB",
+    ROCPROFSYS_CONFIG_SETTING(size_t, env_vars::PERFETTO_BUFFER_SIZE_KB,
                               "Size of perfetto buffer (in KB)", size_t{ 1024000 },
                               "perfetto", "data");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_PERFETTO_COMBINE_TRACES",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::PERFETTO_COMBINE_TRACES,
                               "Combine Perfetto traces. If not explicitly set, it will "
                               "default to the value of ROCPROFSYS_COLLAPSE_PROCESSES",
                               false, "perfetto", "data", "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(std::uint32_t, "ROCPROFSYS_PERFETTO_FLUSH_PERIOD_MS",
+    ROCPROFSYS_CONFIG_SETTING(std::uint32_t, env_vars::PERFETTO_FLUSH_PERIOD,
                               "Set Perfetto flush period (in ms)", std::uint32_t{ 10000 },
                               "perfetto", "data");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_PERFETTO_FILL_POLICY",
+        std::string, env_vars::PERFETTO_FILL_POLICY,
         "Behavior when perfetto buffer is full. 'discard' will ignore new entries, "
         "'ring_buffer' will overwrite old entries",
         "discard", "perfetto", "data")
         ->set_choices({ "fill", "discard" });
 
-    ROCPROFSYS_CONFIG_SETTING(std::string, "ROCPROFSYS_ENABLE_CATEGORIES",
+    ROCPROFSYS_CONFIG_SETTING(std::string, env_vars::ENABLE_CATEGORIES,
                               "Enable collecting profiling and trace data for these "
                               "categories and disable all other categories",
                               "", "trace", "profile", "perfetto", "timemory", "data",
@@ -713,13 +719,13 @@ configure_settings(bool _init)
         ->set_choices(get_available_categories<std::vector<std::string>>());
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_DISABLE_CATEGORIES",
+        std::string, env_vars::DISABLE_CATEGORIES,
         "Disable collecting profiling and trace data for these categories", "", "trace",
         "profile", "perfetto", "timemory", "data", "category", "advanced")
         ->set_choices(get_available_categories<std::vector<std::string>>());
 
     ROCPROFSYS_CONFIG_SETTING(
-        bool, "ROCPROFSYS_PERFETTO_ANNOTATIONS",
+        bool, env_vars::PERFETTO_ANNOTATIONS,
         "Include debug annotations in perfetto trace. When enabled, "
         "this feature will encode information such as the values of "
         "the function arguments (when available). Disabling this "
@@ -727,43 +733,43 @@ configure_settings(bool _init)
         true, "perfetto", "data", "debugging", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::uint64_t, "ROCPROFSYS_THREAD_POOL_SIZE",
+        std::uint64_t, env_vars::THREAD_POOL_SIZE,
         "Max number of threads for processing background tasks",
         std::max<std::uint64_t>(
             std::min<std::uint64_t>(4, std::thread::hardware_concurrency() / 2), 1),
         "parallelism", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_TIMEMORY_COMPONENTS",
+        std::string, env_vars::TIMEMORY_COMPONENTS,
         "List of components to collect via timemory (see `rocprof-sys-avail -C`)",
         "wall_clock", "timemory", "component");
 
-    ROCPROFSYS_CONFIG_SETTING(std::string, "ROCPROFSYS_OUTPUT_FILE",
+    ROCPROFSYS_CONFIG_SETTING(std::string, env_vars::OUTPUT_FILE,
                               "[DEPRECATED] See ROCPROFSYS_PERFETTO_FILE", std::string{},
                               "perfetto", "io", "filename", "deprecated", "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(std::string, "ROCPROFSYS_PERFETTO_FILE",
-                              "Perfetto filename", std::string{ "perfetto-trace.proto" },
-                              "perfetto", "io", "filename", "advanced");
+    ROCPROFSYS_CONFIG_SETTING(std::string, env_vars::PERFETTO_FILE, "Perfetto filename",
+                              std::string{ "perfetto-trace.proto" }, "perfetto", "io",
+                              "filename", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        bool, "ROCPROFSYS_USE_TEMPORARY_FILES",
+        bool, env_vars::USE_TEMPORARY_FILES,
         "Write data to temporary files to minimize the memory usage "
         "of rocprof-sys, e.g. call-stack samples will be periodically "
         "written to a file and re-loaded during finalization",
         true, "io", "data", "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_MERGE_PERFETTO_FILES",
+    ROCPROFSYS_CONFIG_SETTING(bool, env_vars::MERGE_PERFETTO_FILES,
                               "Merge Perfetto traces. If not explicitly set, it will "
                               "default to the value of ROCPROFSYS_COLLAPSE_PROCESSES",
                               false, "perfetto", "data", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_TMPDIR", "Base directory for temporary files",
+        std::string, env_vars::TMPDIR, "Base directory for temporary files",
         get_env<std::string>("TMPDIR", "/tmp"), "io", "data", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_CAUSAL_BACKEND",
+        std::string, env_vars::CAUSAL_BACKEND,
         "Backend for call-stack sampling. See "
         "https://rocm.docs.amd.com/projects/rocprofiler-systems/en/latest/how-to/"
         "performing-causal-profiling.html#backends for more "
@@ -773,7 +779,7 @@ configure_settings(bool _init)
         ->set_choices({ "auto", "perf", "timer" });
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_CAUSAL_MODE",
+        std::string, env_vars::CAUSAL_MODE,
         "Perform causal experiments at the function-scope or line-scope. Ideally, use "
         "function first to locate function with highest impact and then switch to line "
         "mode + ROCPROFSYS_CAUSAL_FUNCTION_SCOPE set to the function being targeted.",
@@ -781,12 +787,12 @@ configure_settings(bool _init)
         ->set_choices({ "func", "line", "function" });
 
     ROCPROFSYS_CONFIG_SETTING(
-        double, "ROCPROFSYS_CAUSAL_DELAY",
+        double, env_vars::CAUSAL_DELAY,
         "Length of time to wait (in seconds) before starting the first causal experiment",
         0.0, "causal", "analysis");
 
     ROCPROFSYS_CONFIG_SETTING(
-        double, "ROCPROFSYS_CAUSAL_DURATION",
+        double, env_vars::CAUSAL_DURATION,
         "Length of time to perform causal experimentation (in seconds) after the first "
         "experiment has started. After this amount of time has elapsed, no more causal "
         "experiments will be performed and the application will continue without any "
@@ -795,85 +801,85 @@ configure_settings(bool _init)
         0.0, "causal", "analysis");
 
     ROCPROFSYS_CONFIG_SETTING(
-        bool, "ROCPROFSYS_CAUSAL_END_TO_END",
+        bool, env_vars::CAUSAL_END_TO_END,
         "Perform causal experiment over the length of the entire application", false,
         "causal", "analysis", "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(std::string, "ROCPROFSYS_CAUSAL_FILE",
+    ROCPROFSYS_CONFIG_SETTING(std::string, env_vars::CAUSAL_FILE,
                               "Name of causal output filename (w/o extension)",
                               std::string{ "experiments" }, "causal", "analysis",
                               "advanced", "io");
 
     ROCPROFSYS_CONFIG_SETTING(
-        bool, "ROCPROFSYS_CAUSAL_FILE_RESET",
+        bool, env_vars::CAUSAL_FILE_RESET,
         "Overwrite any existing causal output file instead of appending to it", false,
         "causal", "analysis", "advanced", "io");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::uint64_t, "ROCPROFSYS_CAUSAL_RANDOM_SEED",
+        std::uint64_t, env_vars::CAUSAL_RANDOM_SEED,
         "Seed for random number generator which selects speedups and experiments -- "
         "please note that the lines selected for experimentation are not reproducible "
         "but the speedup selection is. If set to zero, std::random_device{}() will be "
         "used.",
         0, "causal", "analysis");
 
-    ROCPROFSYS_CONFIG_SETTING(std::string, "ROCPROFSYS_CAUSAL_FIXED_SPEEDUP",
+    ROCPROFSYS_CONFIG_SETTING(std::string, env_vars::CAUSAL_FIXED_SPEEDUP,
                               "List of virtual speedups between 0 and 100 (inclusive) to "
                               "sample from for causal profiling",
                               std::string{}, "causal", "analysis", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_CAUSAL_BINARY_SCOPE",
+        std::string, env_vars::CAUSAL_BINARY_SCOPE,
         "Limits causal experiments to the binaries matching the provided list of regular "
         "expressions (separated by tab, semi-colon, and/or quotes (single or double))",
         std::string{ "%MAIN%" }, "causal", "analysis");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_CAUSAL_SOURCE_SCOPE",
+        std::string, env_vars::CAUSAL_SOURCE_SCOPE,
         "Limits causal experiments to the source files or source file + lineno pair "
         "(i.e. <file> or <file>:<line>) matching the provided list of regular "
         "expressions (separated by tab, semi-colon, and/or quotes (single or double))",
         std::string{}, "causal", "analysis");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_CAUSAL_FUNCTION_SCOPE",
+        std::string, env_vars::CAUSAL_FUNCTION_SCOPE,
         "List of <function> regex entries for causal profiling (separated by tab, "
         "semi-colon, and/or quotes (single or double))",
         std::string{}, "causal", "analysis");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_CAUSAL_BINARY_EXCLUDE",
+        std::string, env_vars::CAUSAL_BINARY_EXCLUDE,
         "Excludes binaries matching the list of provided regexes from causal experiments "
         "(separated by tab, semi-colon, and/or quotes (single or double))",
         std::string{}, "causal", "analysis");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_CAUSAL_SOURCE_EXCLUDE",
+        std::string, env_vars::CAUSAL_SOURCE_EXCLUDE,
         "Excludes source files or source file + lineno pair (i.e. <file> or "
         "<file>:<line>) matching the list of provided regexes from causal experiments "
         "(separated by tab, semi-colon, and/or quotes (single or double))",
         std::string{}, "causal", "analysis");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_CAUSAL_FUNCTION_EXCLUDE",
+        std::string, env_vars::CAUSAL_FUNCTION_EXCLUDE,
         "Excludes functions matching the list of provided regexes from causal "
         "experiments (separated by tab, semi-colon, and/or quotes (single or double))",
         std::string{}, "causal", "analysis");
 
     ROCPROFSYS_CONFIG_SETTING(
-        bool, "ROCPROFSYS_CAUSAL_FUNCTION_EXCLUDE_DEFAULTS",
+        bool, env_vars::CAUSAL_FUNCTION_EXCLUDE_DEFAULTS,
         "This controls adding a series of function exclude regexes to avoid "
         "experimenting on STL implementation functions, etc. which are, "
         "generally, not helpful. Details: excludes demangled function names "
         "starting with '_' or containing '::_M'.",
         true, "causal", "analysis", "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(int, "ROCPROFSYS_KILL_DELAY",
+    ROCPROFSYS_CONFIG_SETTING(int, env_vars::KILL_DELAY,
                               "Delay (in seconds) before terminating the process "
                               "after a kill signal is received.",
                               0, "process", "advanced");
 
-    auto kill_delay_config = _config->find("ROCPROFSYS_KILL_DELAY")->second;
+    auto kill_delay_config = _config->find(std::string{ env_vars::KILL_DELAY })->second;
     auto kill_delay_value  = kill_delay_config->get<int>().second;
     if(kill_delay_value < 0)
     {
@@ -881,12 +887,12 @@ configure_settings(bool _init)
     }
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_RANK_FILTER_ID",
+        std::string, env_vars::RANK_FILTER_ID,
         "Name of environment variable to read rank from for MPI output filtering",
         std::string{}, "data", "io", "advanced");
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_RANK_FILTER_OUTPUT",
+        std::string, env_vars::RANK_FILTER_OUTPUT,
         "Ranks for which file output is generated. Values should be separated by commas "
         "and can be explicit or ranges, e.g. 0,1,5-8. An empty value enables output "
         "for all ranks",
@@ -920,16 +926,17 @@ configure_settings(bool _init)
         }
     };
 
-    _add_rocprofsys_category(_config->find("ROCPROFSYS_CONFIG_FILE"));
-    _add_rocprofsys_category(_config->find("ROCPROFSYS_DEBUG"));
-    _add_rocprofsys_category(_config->find("ROCPROFSYS_VERBOSE"));
-    _add_rocprofsys_category(_config->find("ROCPROFSYS_LOG_LEVEL"));
-    _add_rocprofsys_category(_config->find("ROCPROFSYS_TIME_OUTPUT"));
-    _add_rocprofsys_category(_config->find("ROCPROFSYS_OUTPUT_PREFIX"));
-    _add_rocprofsys_category(_config->find("ROCPROFSYS_OUTPUT_PATH"));
+    _add_rocprofsys_category(_config->find(std::string{ env_vars::CONFIG_FILE }));
+    _add_rocprofsys_category(_config->find(std::string{ env_vars::DEBUG_MODE }));
+    _add_rocprofsys_category(_config->find(std::string{ env_vars::VERBOSE }));
+    _add_rocprofsys_category(_config->find(std::string{ env_vars::LOG_LEVEL }));
+    _add_rocprofsys_category(_config->find(std::string{ env_vars::TIME_OUTPUT }));
+    _add_rocprofsys_category(_config->find(std::string{ env_vars::OUTPUT_PREFIX }));
+    _add_rocprofsys_category(_config->find(std::string{ env_vars::OUTPUT_PATH }));
 
-    auto _add_advanced_category = [&_config](const std::string& _name) {
-        auto itr = _config->find(_name);
+    auto _add_advanced_category = [&_config](std::string_view _name_view) {
+        auto _name = std::string{ _name_view };
+        auto itr   = _config->find(_name);
         if(itr != _config->end())
         {
             auto _categories = itr->second->get_categories();
@@ -938,7 +945,7 @@ configure_settings(bool _init)
         }
         else
         {
-            if(_config->get<bool>("ROCPROFSYS_CI"))
+            if(_config->get<bool>(std::string{ env_vars::CI }))
             {
                 throw std::runtime_error(
                     fmt::format("Error! Setting '{}' not found!", _name));
@@ -946,46 +953,46 @@ configure_settings(bool _init)
         }
     };
 
-    _add_advanced_category("ROCPROFSYS_CPU_AFFINITY");
-    _add_advanced_category("ROCPROFSYS_COUT_OUTPUT");
-    _add_advanced_category("ROCPROFSYS_FILE_OUTPUT");
-    _add_advanced_category("ROCPROFSYS_JSON_OUTPUT");
-    _add_advanced_category("ROCPROFSYS_TREE_OUTPUT");
-    _add_advanced_category("ROCPROFSYS_TEXT_OUTPUT");
-    _add_advanced_category("ROCPROFSYS_DIFF_OUTPUT");
-    _add_advanced_category("ROCPROFSYS_DEBUG");
-    _add_advanced_category("ROCPROFSYS_LOG_LEVEL");
-    _add_advanced_category("ROCPROFSYS_ENABLE_SIGNAL_HANDLER");
-    _add_advanced_category("ROCPROFSYS_FLAT_PROFILE");
-    _add_advanced_category("ROCPROFSYS_INPUT_EXTENSIONS");
-    _add_advanced_category("ROCPROFSYS_INPUT_PATH");
-    _add_advanced_category("ROCPROFSYS_INPUT_PREFIX");
-    _add_advanced_category("ROCPROFSYS_MAX_DEPTH");
-    _add_advanced_category("ROCPROFSYS_MAX_WIDTH");
-    _add_advanced_category("ROCPROFSYS_MEMORY_PRECISION");
-    _add_advanced_category("ROCPROFSYS_MEMORY_SCIENTIFIC");
-    _add_advanced_category("ROCPROFSYS_MEMORY_UNITS");
-    _add_advanced_category("ROCPROFSYS_MEMORY_WIDTH");
-    _add_advanced_category("ROCPROFSYS_NETWORK_INTERFACE");
-    _add_advanced_category("ROCPROFSYS_NODE_COUNT");
-    _add_advanced_category("ROCPROFSYS_PAPI_FAIL_ON_ERROR");
-    _add_advanced_category("ROCPROFSYS_PAPI_OVERFLOW");
-    _add_advanced_category("ROCPROFSYS_PAPI_MULTIPLEXING");
-    _add_advanced_category("ROCPROFSYS_PAPI_QUIET");
-    _add_advanced_category("ROCPROFSYS_PAPI_THREADING");
-    _add_advanced_category("ROCPROFSYS_PRECISION");
-    _add_advanced_category("ROCPROFSYS_SCIENTIFIC");
-    _add_advanced_category("ROCPROFSYS_STRICT_CONFIG");
-    _add_advanced_category("ROCPROFSYS_TIMELINE_PROFILE");
-    _add_advanced_category("ROCPROFSYS_SCIENTIFIC");
-    _add_advanced_category("ROCPROFSYS_TIME_FORMAT");
-    _add_advanced_category("ROCPROFSYS_TIMING_PRECISION");
-    _add_advanced_category("ROCPROFSYS_TIMING_SCIENTIFIC");
-    _add_advanced_category("ROCPROFSYS_TIMING_UNITS");
-    _add_advanced_category("ROCPROFSYS_TIMING_WIDTH");
-    _add_advanced_category("ROCPROFSYS_WIDTH");
-    _add_advanced_category("ROCPROFSYS_COLLAPSE_THREADS");
-    _add_advanced_category("ROCPROFSYS_COLLAPSE_PROCESSES");
+    _add_advanced_category(env_vars::CPU_AFFINITY);
+    _add_advanced_category(env_vars::COUT_OUTPUT);
+    _add_advanced_category(env_vars::FILE_OUTPUT);
+    _add_advanced_category(env_vars::JSON_OUTPUT);
+    _add_advanced_category(env_vars::TREE_OUTPUT);
+    _add_advanced_category(env_vars::TEXT_OUTPUT);
+    _add_advanced_category(env_vars::DIFF_OUTPUT);
+    _add_advanced_category(env_vars::DEBUG_MODE);
+    _add_advanced_category(env_vars::LOG_LEVEL);
+    _add_advanced_category(env_vars::ENABLE_SIGNAL_HANDLER);
+    _add_advanced_category(env_vars::FLAT_PROFILE);
+    _add_advanced_category(env_vars::INPUT_EXTENSIONS);
+    _add_advanced_category(env_vars::INPUT_PATH);
+    _add_advanced_category(env_vars::INPUT_PREFIX);
+    _add_advanced_category(env_vars::MAX_DEPTH);
+    _add_advanced_category(env_vars::MAX_WIDTH);
+    _add_advanced_category(env_vars::MEMORY_PRECISION);
+    _add_advanced_category(env_vars::MEMORY_SCIENTIFIC);
+    _add_advanced_category(env_vars::MEMORY_UNITS);
+    _add_advanced_category(env_vars::MEMORY_WIDTH);
+    _add_advanced_category(env_vars::NETWORK_INTERFACE);
+    _add_advanced_category(env_vars::NODE_COUNT);
+    _add_advanced_category(env_vars::PAPI_FAIL_ON_ERROR);
+    _add_advanced_category(env_vars::PAPI_OVERFLOW);
+    _add_advanced_category(env_vars::PAPI_MULTIPLEXING_ENABLED);
+    _add_advanced_category(env_vars::PAPI_QUIET_MODE);
+    _add_advanced_category(env_vars::PAPI_THREADING);
+    _add_advanced_category(env_vars::PRECISION);
+    _add_advanced_category(env_vars::SCIENTIFIC);
+    _add_advanced_category(env_vars::STRICT_CONFIG);
+    _add_advanced_category(env_vars::TIMELINE_PROFILE);
+    _add_advanced_category(env_vars::SCIENTIFIC);
+    _add_advanced_category(env_vars::TIME_FORMAT);
+    _add_advanced_category(env_vars::TIMING_PRECISION);
+    _add_advanced_category(env_vars::TIMING_SCIENTIFIC);
+    _add_advanced_category(env_vars::TIMING_UNITS);
+    _add_advanced_category(env_vars::TIMING_WIDTH);
+    _add_advanced_category(env_vars::WIDTH);
+    _add_advanced_category(env_vars::COLLAPSE_THREADS);
+    _add_advanced_category(env_vars::COLLAPSE_PROCESSES);
 
 #if defined(TIMEMORY_USE_PAPI)
     int _paranoid = 2;
@@ -1018,7 +1025,7 @@ configure_settings(bool _init)
     }
     else
     {
-        auto _papi_events = _config->find("ROCPROFSYS_PAPI_EVENTS");
+        auto _papi_events = _config->find(std::string{ env_vars::PAPI_EVENTS });
         _add_rocprofsys_category(_papi_events);
         // Only enumerate PAPI events if the user has specified them
         if(_papi_events->second->get_config_updated() ||
@@ -1034,13 +1041,13 @@ configure_settings(bool _init)
         }
     }
 #else
-    _config->find("ROCPROFSYS_PAPI_EVENTS")->second->set_hidden(true);
+    _config->find(std::string{ env_vars::PAPI_EVENTS })->second->set_hidden(true);
     _config->get_papi_quiet() = true;
 #endif
 
     // always initialize timemory because gotcha wrappers are always used
     auto _cmd     = tim::read_command_line(process::get_id());
-    auto _cmd_env = tim::get_env<std::string>("ROCPROFSYS_COMMAND_LINE", "");
+    auto _cmd_env = tim::get_env<std::string>(env_vars::COMMAND_LINE.data(), "");
     if(!_cmd_env.empty()) _cmd = tim::delimit(_cmd_env, " ");
     auto _exe          = (_cmd.empty()) ? "exe" : _cmd.front();
     get_exe_realpath() = filepath::realpath(_exe, nullptr, false);
@@ -1061,14 +1068,15 @@ configure_settings(bool _init)
     auto _proc      = mproc::get_concurrent_processes(_ppid);
     bool _main_proc = (_proc.size() < 2 || *_proc.begin() == _pid);
 
-    for(auto&& itr :
-        tim::delimit(_config->get<std::string>("ROCPROFSYS_CONFIG_FILE"), ";:"))
+    for(auto&& itr : tim::delimit(
+            _config->get<std::string>(std::string{ env_vars::CONFIG_FILE }), ";:"))
     {
         if(_config->get_suppress_config()) continue;
 
         LOG_DEBUG("Reading config file {}", itr);
         if(_config->read(itr) && _main_proc &&
-           ((_config->get<bool>("ROCPROFSYS_CI") && settings::verbose() >= 0) ||
+           ((_config->get<bool>(std::string{ env_vars::CI }) &&
+             settings::verbose() >= 0) ||
             settings::verbose() >= 1 || settings::debug()))
         {
             auto              fitr = settings::format(itr, _config->get_tag());
@@ -1089,10 +1097,13 @@ configure_settings(bool _init)
 
     settings::suppress_config() = true;
 
-    if(auto opt = get_setting_value<int>("ROCPROFSYS_VERBOSE"); opt) verbose_value = *opt;
-    if(auto opt = get_setting_value<bool>("ROCPROFSYS_DEBUG"); opt) debug_value = *opt;
+    if(auto opt = get_setting_value<int>(std::string{ env_vars::VERBOSE }); opt)
+        verbose_value = *opt;
+    if(auto opt = get_setting_value<bool>(std::string{ env_vars::DEBUG_MODE }); opt)
+        debug_value = *opt;
 
-    if(get_env("ROCPROFSYS_MONOCHROME", _config->get<bool>("ROCPROFSYS_MONOCHROME")))
+    if(get_env(env_vars::MONOCHROME.data(),
+               _config->get<bool>(std::string{ env_vars::MONOCHROME })))
         tim::log::monochrome() = true;
 
     if(_init)
@@ -1103,41 +1114,49 @@ configure_settings(bool _init)
     }
 
 #if !defined(ROCPROFSYS_USE_MPI) && !defined(ROCPROFSYS_USE_MPI_HEADERS)
-    set_setting_value("ROCPROFSYS_USE_MPIP", false);
+    set_setting_value(std::string{ env_vars::USE_MPIP }, false);
 #endif
 
     _config->get_global_components() =
-        _config->get<std::string>("ROCPROFSYS_TIMEMORY_COMPONENTS");
+        _config->get<std::string>(std::string{ env_vars::TIMEMORY_COMPONENTS });
 
-    auto _combine_perfetto_traces = _config->find("ROCPROFSYS_PERFETTO_COMBINE_TRACES");
+    auto _combine_perfetto_traces =
+        _config->find(std::string{ env_vars::PERFETTO_COMBINE_TRACES });
     if(!_combine_perfetto_traces->second->get_environ_updated() &&
        _combine_perfetto_traces->second->get_config_updated())
     {
         _combine_perfetto_traces->second->set(_config->get<bool>("collapse_processes"));
     }
 
-    handle_deprecated_setting("ROCPROFSYS_AMD_SMI_DEVICES", "ROCPROFSYS_SAMPLING_GPUS");
-    handle_deprecated_setting("ROCPROFSYS_USE_THREAD_SAMPLING",
-                              "ROCPROFSYS_USE_PROCESS_SAMPLING");
-    handle_deprecated_setting("ROCPROFSYS_OUTPUT_FILE", "ROCPROFSYS_PERFETTO_FILE");
-    handle_deprecated_setting("ROCPROFSYS_USE_PERFETTO", "ROCPROFSYS_TRACE");
-    handle_deprecated_setting("ROCPROFSYS_USE_TIMEMORY", "ROCPROFSYS_PROFILE");
-    handle_deprecated_setting("ROCPROFSYS_DEBUG", "ROCPROFSYS_LOG_LEVEL");
-    handle_deprecated_setting("ROCPROFSYS_VERBOSE", "ROCPROFSYS_LOG_LEVEL");
-    handle_deprecated_setting("ROCPROFSYS_TRACE_LEGACY", "ROCPROFSYS_TRACE");
+    handle_deprecated_setting(std::string{ env_vars::AMD_SMI_DEVICES },
+                              std::string{ env_vars::SAMPLING_GPUS });
+    handle_deprecated_setting(std::string{ env_vars::USE_THREAD_SAMPLING },
+                              std::string{ env_vars::USE_PROCESS_SAMPLING });
+    handle_deprecated_setting(std::string{ env_vars::OUTPUT_FILE },
+                              std::string{ env_vars::PERFETTO_FILE });
+    handle_deprecated_setting(std::string{ env_vars::USE_PERFETTO },
+                              std::string{ env_vars::TRACE });
+    handle_deprecated_setting(std::string{ env_vars::USE_TIMEMORY },
+                              std::string{ env_vars::PROFILE });
+    handle_deprecated_setting(std::string{ env_vars::DEBUG_MODE },
+                              std::string{ env_vars::LOG_LEVEL });
+    handle_deprecated_setting(std::string{ env_vars::VERBOSE },
+                              std::string{ env_vars::LOG_LEVEL });
+    handle_deprecated_setting(std::string{ env_vars::TRACE_LEGACY },
+                              std::string{ env_vars::TRACE });
 
     scope::get_fields()[scope::flat::value]     = _config->get_flat_profile();
     scope::get_fields()[scope::timeline::value] = _config->get_timeline_profile();
 
     settings::suppress_parsing()  = true;
-    settings::use_output_suffix() = _config->get<bool>("ROCPROFSYS_USE_PID");
+    settings::use_output_suffix() = _config->get<bool>(std::string{ env_vars::USE_PID });
     if(settings::use_output_suffix())
         settings::default_process_suffix() = process::get_id();
 #if !defined(ROCPROFSYS_USE_MPI) && defined(ROCPROFSYS_USE_MPI_HEADERS)
     if(tim::dmp::is_initialized()) settings::default_process_suffix() = tim::dmp::rank();
 #endif
 
-    auto _dl_verbose = _config->find("ROCPROFSYS_DL_VERBOSE");
+    auto _dl_verbose = _config->find(std::string{ env_vars::DL_VERBOSE });
     if(_dl_verbose->second->get_config_updated())
         tim::set_env(std::string{ _dl_verbose->first }, _dl_verbose->second->as_string(),
                      0);
@@ -1156,8 +1175,10 @@ configure_settings(bool _init)
 
     LOG_DEBUG("Configuration complete");
 
-    if(auto opt = get_setting_value<int>("ROCPROFSYS_VERBOSE"); opt) verbose_value = *opt;
-    if(auto opt = get_setting_value<bool>("ROCPROFSYS_DEBUG"); opt) debug_value = *opt;
+    if(auto opt = get_setting_value<int>(std::string{ env_vars::VERBOSE }); opt)
+        verbose_value = *opt;
+    if(auto opt = get_setting_value<bool>(std::string{ env_vars::DEBUG_MODE }); opt)
+        debug_value = *opt;
 
     _settings_are_configured() = true;
 }
@@ -1165,7 +1186,8 @@ configure_settings(bool _init)
 void
 configure_mode_settings(const std::shared_ptr<settings>& _config)
 {
-    auto _set = [](const std::string& _name, bool _v) {
+    auto _set = [](std::string_view _name_view, bool _v) {
+        auto _name = std::string{ _name_view };
         if(!set_setting_value(_name, _v))
         {
             LOG_DEBUG("[configure_mode_settings] No configuration setting named '{}'...",
@@ -1182,43 +1204,43 @@ configure_mode_settings(const std::shared_ptr<settings>& _config)
         }
     };
 
-    auto _use_causal = get_setting_value<bool>("ROCPROFSYS_USE_CAUSAL");
-    if(_use_causal && *_use_causal) set_env("ROCPROFSYS_MODE", "causal", 1);
+    auto _use_causal = get_setting_value<bool>(std::string{ env_vars::USE_CAUSAL });
+    if(_use_causal && *_use_causal) set_env(std::string{ env_vars::MODE }, "causal", 1);
 
     if(get_mode() == Mode::Coverage)
     {
-        set_default_setting_value("ROCPROFSYS_USE_CODE_COVERAGE", true);
-        _set("ROCPROFSYS_TRACE", false);
-        _set("ROCPROFSYS_PROFILE", false);
-        _set("ROCPROFSYS_USE_CAUSAL", false);
-        _set("ROCPROFSYS_USE_AMD_SMI", false);
-        _set("ROCPROFSYS_USE_KOKKOSP", false);
-        _set("ROCPROFSYS_USE_RCCLP", false);
-        _set("ROCPROFSYS_USE_OMPT", false);
-        _set("ROCPROFSYS_USE_SAMPLING", false);
-        _set("ROCPROFSYS_USE_PROCESS_SAMPLING", false);
+        set_default_setting_value(std::string{ env_vars::USE_CODE_COVERAGE }, true);
+        _set(env_vars::TRACE, false);
+        _set(env_vars::PROFILE, false);
+        _set(env_vars::USE_CAUSAL, false);
+        _set(env_vars::USE_AMD_SMI, false);
+        _set(env_vars::USE_KOKKOSP, false);
+        _set(env_vars::USE_RCCLP, false);
+        _set(env_vars::USE_OMPT, false);
+        _set(env_vars::USE_SAMPLING, false);
+        _set(env_vars::USE_PROCESS_SAMPLING, false);
     }
     else if(get_mode() == Mode::Causal)
     {
-        _set("ROCPROFSYS_USE_CAUSAL", true);
-        _set("ROCPROFSYS_TRACE", false);
-        _set("ROCPROFSYS_PROFILE", false);
-        _set("ROCPROFSYS_USE_SAMPLING", false);
-        _set("ROCPROFSYS_USE_PROCESS_SAMPLING", false);
+        _set(env_vars::USE_CAUSAL, true);
+        _set(env_vars::TRACE, false);
+        _set(env_vars::PROFILE, false);
+        _set(env_vars::USE_SAMPLING, false);
+        _set(env_vars::USE_PROCESS_SAMPLING, false);
     }
     else if(get_mode() == Mode::Sampling)
     {
-        set_default_setting_value("ROCPROFSYS_USE_SAMPLING", true);
-        set_default_setting_value("ROCPROFSYS_USE_PROCESS_SAMPLING", true);
+        set_default_setting_value(std::string{ env_vars::USE_SAMPLING }, true);
+        set_default_setting_value(std::string{ env_vars::USE_PROCESS_SAMPLING }, true);
     }
 
     if(gpu::device_count() == 0)
     {
         LOG_WARNING("No ROCm devices were found: disabling amd_smi...");
-        _set("ROCPROFSYS_USE_AMD_SMI", false);
+        _set(env_vars::USE_AMD_SMI, false);
     }
 
-    if(_config->get<bool>("ROCPROFSYS_USE_KOKKOSP"))
+    if(_config->get<bool>(std::string{ env_vars::USE_KOKKOSP }))
     {
         auto _current_kokkosp_lib = tim::get_env<std::string>("KOKKOS_TOOLS_LIBS");
         if(_current_kokkosp_lib.find("librocprof-sys-dl.so") == std::string::npos &&
@@ -1238,25 +1260,26 @@ configure_mode_settings(const std::shared_ptr<settings>& _config)
     }
 
     // recycle all subsequent thread ids
-    threading::recycle_ids() = tim::get_env<bool>(
-        "ROCPROFSYS_RECYCLE_TIDS", !_config->get<bool>("ROCPROFSYS_USE_SAMPLING"));
+    threading::recycle_ids() =
+        tim::get_env<bool>(env_vars::RECYCLE_TIDS.data(),
+                           !_config->get<bool>(std::string{ env_vars::USE_SAMPLING }));
 
     if(!_config->get_enabled())
     {
-        _set("ROCPROFSYS_USE_TRACE", false);
-        _set("ROCPROFSYS_PROFILE", false);
-        _set("ROCPROFSYS_USE_CAUSAL", false);
-        _set("ROCPROFSYS_USE_AMD_SMI", false);
-        _set("ROCPROFSYS_USE_KOKKOSP", false);
-        _set("ROCPROFSYS_USE_RCCLP", false);
-        _set("ROCPROFSYS_USE_OMPT", false);
-        _set("ROCPROFSYS_USE_SAMPLING", false);
-        _set("ROCPROFSYS_USE_PROCESS_SAMPLING", false);
-        _set("ROCPROFSYS_USE_CODE_COVERAGE", false);
-        _set("ROCPROFSYS_CPU_FREQ_ENABLED", false);
-        _set("ROCPROFSYS_USE_AINIC", false);
-        set_setting_value("ROCPROFSYS_TIMEMORY_COMPONENTS", std::string{});
-        set_setting_value("ROCPROFSYS_PAPI_EVENTS", std::string{});
+        _set(env_vars::USE_TRACE, false);
+        _set(env_vars::PROFILE, false);
+        _set(env_vars::USE_CAUSAL, false);
+        _set(env_vars::USE_AMD_SMI, false);
+        _set(env_vars::USE_KOKKOSP, false);
+        _set(env_vars::USE_RCCLP, false);
+        _set(env_vars::USE_OMPT, false);
+        _set(env_vars::USE_SAMPLING, false);
+        _set(env_vars::USE_PROCESS_SAMPLING, false);
+        _set(env_vars::USE_CODE_COVERAGE, false);
+        _set(env_vars::CPU_FREQ_ENABLED, false);
+        _set(env_vars::USE_AINIC, false);
+        set_setting_value(std::string{ env_vars::TIMEMORY_COMPONENTS }, std::string{});
+        set_setting_value(std::string{ env_vars::PAPI_EVENTS }, std::string{});
     }
 }
 
@@ -1317,13 +1340,13 @@ void
 configure_signal_handler(const std::shared_ptr<settings>& _config)
 {
     auto _ignore_dyninst_trampoline =
-        tim::get_env("ROCPROFSYS_IGNORE_DYNINST_TRAMPOLINE", false);
+        tim::get_env(env_vars::IGNORE_DYNINST_TRAMPOLINE.data(), false);
     // this is how dyninst looks up the env variable
     static auto _dyninst_trampoline_signal =
         getenv("DYNINST_SIGNAL_TRAMPOLINE_SIGILL") ? SIGILL : SIGTRAP;
 
     static auto root_pid =
-        get_env<pid_t>("ROCPROFSYS_ROOT_PROCESS", process::get_id(), false);
+        get_env<pid_t>(env_vars::ROOT_PROCESS.data(), process::get_id(), false);
     if(_config->get_enable_signal_handler())
     {
         tim::signals::disable_signal_detection();
@@ -1357,21 +1380,21 @@ configure_signal_handler(const std::shared_ptr<settings>& _config)
 bool
 get_use_sampling_overflow()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_SAMPLING_OVERFLOW");
+    static auto _v = get_config()->find(std::string{ env_vars::SAMPLING_OVERFLOW });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 bool
 get_use_sampling_realtime()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_SAMPLING_REALTIME");
+    static auto _v = get_config()->find(std::string{ env_vars::SAMPLING_REALTIME });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 bool
 get_use_sampling_cputime()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_SAMPLING_CPUTIME");
+    static auto _v = get_config()->find(std::string{ env_vars::SAMPLING_CPUTIME });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
@@ -1391,7 +1414,7 @@ get_sampling_signals(std::int64_t)
         {
             LOG_WARNING("Sampling enabled by cputime/realtime/overflow is not "
                         "specified. Defaulting to cputime...");
-            set_setting_value("ROCPROFSYS_SAMPLING_CPUTIME", true);
+            set_setting_value(std::string{ env_vars::SAMPLING_CPUTIME }, true);
         }
 
         if(get_use_sampling_cputime()) _v.emplace(get_sampling_cputime_signal());
@@ -1405,8 +1428,9 @@ get_sampling_signals(std::int64_t)
 void
 configure_disabled_settings(const std::shared_ptr<settings>& _config)
 {
-    auto _handle_use_option = [_config](const std::string& _opt,
+    auto _handle_use_option = [_config](std::string_view   _opt_view,
                                         const std::string& _category) {
+        auto _opt = std::string{ _opt_view };
         if(!_config->get<bool>(_opt))
         {
             auto _disabled = _config->disable_category(_category);
@@ -1421,27 +1445,28 @@ configure_disabled_settings(const std::shared_ptr<settings>& _config)
         return true;
     };
 
-    _handle_use_option("ROCPROFSYS_USE_SAMPLING", "sampling");
-    _handle_use_option("ROCPROFSYS_USE_PROCESS_SAMPLING", "process_sampling");
-    _handle_use_option("ROCPROFSYS_USE_CAUSAL", "causal");
-    _handle_use_option("ROCPROFSYS_USE_KOKKOSP", "kokkos");
-    _handle_use_option("ROCPROFSYS_USE_TRACE", "perfetto");
-    _handle_use_option("ROCPROFSYS_PROFILE", "timemory");
-    _handle_use_option("ROCPROFSYS_USE_OMPT", "ompt");
-    _handle_use_option("ROCPROFSYS_USE_RCCLP", "rcclp");
-    _handle_use_option("ROCPROFSYS_USE_AMD_SMI", "amd_smi");
+    _handle_use_option(env_vars::USE_SAMPLING, "sampling");
+    _handle_use_option(env_vars::USE_PROCESS_SAMPLING, "process_sampling");
+    _handle_use_option(env_vars::USE_CAUSAL, "causal");
+    _handle_use_option(env_vars::USE_KOKKOSP, "kokkos");
+    _handle_use_option(env_vars::USE_TRACE, "perfetto");
+    _handle_use_option(env_vars::PROFILE, "timemory");
+    _handle_use_option(env_vars::USE_OMPT, "ompt");
+    _handle_use_option(env_vars::USE_RCCLP, "rcclp");
+    _handle_use_option(env_vars::USE_AMD_SMI, "amd_smi");
 
 #if defined(ROCPROFSYS_USE_OMPT) || ROCPROFSYS_USE_OMPT == 0
-    _config->find("ROCPROFSYS_USE_OMPT")->second->set_hidden(true);
+    _config->find(std::string{ env_vars::USE_OMPT })->second->set_hidden(true);
     for(const auto& itr : _config->disable_category("ompt"))
         _config->find(itr)->second->set_hidden(true);
 #endif
 
 #if !defined(ROCPROFSYS_USE_MPI) || ROCPROFSYS_USE_MPI == 0
-    _config->disable("ROCPROFSYS_PERFETTO_COMBINE_TRACES");
-    _config->disable("ROCPROFSYS_COLLAPSE_PROCESSES");
-    _config->find("ROCPROFSYS_PERFETTO_COMBINE_TRACES")->second->set_hidden(true);
-    _config->find("ROCPROFSYS_COLLAPSE_PROCESSES")->second->set_hidden(true);
+    _config->disable(env_vars::PERFETTO_COMBINE_TRACES);
+    _config->disable(env_vars::COLLAPSE_PROCESSES);
+    _config->find(std::string{ env_vars::PERFETTO_COMBINE_TRACES })
+        ->second->set_hidden(true);
+    _config->find(std::string{ env_vars::COLLAPSE_PROCESSES })->second->set_hidden(true);
 #endif
 
     _config->disable_category("throttle");
@@ -1483,7 +1508,7 @@ configure_disabled_settings(const std::shared_ptr<settings>& _config)
     auto _hidden_exact = std::set<std::string>{};
 
 #if !defined(TIMEMORY_USE_CRAYPAT)
-    _hidden_exact.emplace("ROCPROFSYS_CRAYPAT");
+    _hidden_exact.emplace(env_vars::CRAYPAT);
 #endif
 
     for(const auto& itr : *_config)
@@ -1608,8 +1633,8 @@ print_settings(
 
     std::stringstream _os{};
 
-    bool _print_desc = get_debug() || tim::get_env("ROCPROFSYS_SETTINGS_DESC", false);
-    bool _md         = tim::get_env<bool>("ROCPROFSYS_SETTINGS_DESC_MARKDOWN", false);
+    bool _print_desc = get_debug() || tim::get_env(env_vars::SETTINGS_DESC.data(), false);
+    bool _md         = tim::get_env<bool>(env_vars::SETTINGS_DESC_MARKDOWN.data(), false);
 
     constexpr size_t nfields = 3;
     using str_array_t        = std::array<std::string, nfields>;
@@ -1637,11 +1662,11 @@ print_settings(
     std::sort(_data.begin(), _data.end(), [](const auto& lhs, const auto& rhs) {
         auto _npos = std::string::npos;
         // ROCPROFSYS_CONFIG_FILE always first
-        if(lhs.at(0) == "ROCPROFSYS_MODE") return true;
-        if(rhs.at(0) == "ROCPROFSYS_MODE") return false;
+        if(lhs.at(0) == env_vars::MODE) return true;
+        if(rhs.at(0) == env_vars::MODE) return false;
         // ROCPROFSYS_CONFIG_FILE always second
-        if(lhs.at(0).find("ROCPROFSYS_CONFIG") != _npos) return true;
-        if(rhs.at(0).find("ROCPROFSYS_CONFIG") != _npos) return false;
+        if(lhs.at(0).find(env_vars::CONFIG) != _npos) return true;
+        if(rhs.at(0).find(env_vars::CONFIG) != _npos) return false;
         // ROCPROFSYS_USE_* prioritized
         auto _lhs_use = lhs.at(0).find("ROCPROFSYS_USE_");
         auto _rhs_use = rhs.at(0).find("ROCPROFSYS_USE_");
@@ -1769,7 +1794,7 @@ get_exe_realpath()
 std::string
 get_config_file()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_CONFIG_FILE");
+    static auto _v = get_config()->find(std::string{ env_vars::CONFIG_FILE });
     return static_cast<tim::tsettings<std::string>&>(*_v->second).get();
 }
 
@@ -1779,7 +1804,8 @@ get_mode()
     if(!settings_are_configured())
     {
         auto _mode = tim::get_env_choice<std::string>(
-            "ROCPROFSYS_MODE", "trace", { "trace", "sampling", "causal", "coverage" });
+            env_vars::MODE.data(), "trace",
+            { "trace", "sampling", "causal", "coverage" });
         if(_mode == "sampling")
             return Mode::Sampling;
         else if(_mode == "causal")
@@ -1793,7 +1819,7 @@ get_mode()
                                                     { "causal", Mode::Causal },
                                                     { "sampling", Mode::Sampling },
                                                     { "coverage", Mode::Coverage } };
-    static auto _v = get_config()->find("ROCPROFSYS_MODE");
+    static auto _v = get_config()->find(std::string{ env_vars::MODE });
     try
     {
         return _m.at(static_cast<tim::tsettings<std::string>&>(*_v->second).get());
@@ -1829,19 +1855,19 @@ get_debug_env()
 {
     return (settings_are_configured())
                ? get_debug()
-               : tim::get_env<bool>("ROCPROFSYS_DEBUG", false, false);
+               : tim::get_env<bool>(env_vars::DEBUG_MODE.data(), false, false);
 }
 
 bool
 get_debug_init()
 {
-    return tim::get_env<bool>("ROCPROFSYS_DEBUG_INIT", get_debug_env());
+    return tim::get_env<bool>(env_vars::DEBUG_INIT.data(), get_debug_env());
 }
 
 bool
 get_debug_finalize()
 {
-    return tim::get_env<bool>("ROCPROFSYS_DEBUG_FINALIZE", false);
+    return tim::get_env<bool>(env_vars::DEBUG_FINALIZE.data(), false);
 }
 
 bool
@@ -1855,7 +1881,7 @@ bool
 get_debug_sampling()
 {
     static bool _v =
-        tim::get_env<bool>("ROCPROFSYS_DEBUG_SAMPLING",
+        tim::get_env<bool>(env_vars::DEBUG_SAMPLING.data(),
                            (settings_are_configured() ? get_debug() : get_debug_env()));
     return _v;
 }
@@ -1865,7 +1891,7 @@ get_verbose_env()
 {
     return (settings_are_configured())
                ? get_verbose()
-               : tim::get_env<int>("ROCPROFSYS_VERBOSE", 0, false);
+               : tim::get_env<int>(env_vars::VERBOSE.data(), 0, false);
 }
 
 int
@@ -1878,8 +1904,8 @@ get_verbose()
 bool&
 get_use_perfetto()
 {
-    static auto _trace_setting  = get_config()->at("ROCPROFSYS_TRACE");
-    static auto _legacy_setting = get_config()->at("ROCPROFSYS_TRACE_LEGACY");
+    static auto _trace_setting  = get_config()->at(env_vars::TRACE);
+    static auto _legacy_setting = get_config()->at(env_vars::TRACE_LEGACY);
     auto&       _trace  = static_cast<tim::tsettings<bool>&>(*_trace_setting).get();
     auto&       _legacy = static_cast<tim::tsettings<bool>&>(*_legacy_setting).get();
     static bool _v      = _trace && _legacy;
@@ -1889,21 +1915,21 @@ get_use_perfetto()
 bool&
 get_use_timemory()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_PROFILE");
+    static auto _v = get_config()->find(std::string{ env_vars::PROFILE });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 bool&
 get_use_causal()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_USE_CAUSAL");
+    static auto _v = get_config()->find(std::string{ env_vars::USE_CAUSAL });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 bool
 get_use_amd_smi()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_USE_AMD_SMI");
+    static auto _v = get_config()->find(std::string{ env_vars::USE_AMD_SMI });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
@@ -1911,7 +1937,7 @@ bool&
 get_use_sampling()
 {
 #if defined(TIMEMORY_USE_LIBUNWIND)
-    static auto _v = get_config()->find("ROCPROFSYS_USE_SAMPLING");
+    static auto _v = get_config()->find(std::string{ env_vars::USE_SAMPLING });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 #else
     throw std::runtime_error(
@@ -1925,63 +1951,63 @@ get_use_sampling()
 bool&
 get_use_process_sampling()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_USE_PROCESS_SAMPLING");
+    static auto _v = get_config()->find(std::string{ env_vars::USE_PROCESS_SAMPLING });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 bool&
 get_cpu_freq_enabled()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_CPU_FREQ_ENABLED");
+    static auto _v = get_config()->find(std::string{ env_vars::CPU_FREQ_ENABLED });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 std::string
 get_sampling_ainics()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_SAMPLING_AINICS");
+    static auto _v = get_config()->find(std::string{ env_vars::SAMPLING_AINICS });
     return static_cast<tim::tsettings<std::string>&>(*_v->second).get();
 }
 
 bool&
 get_use_pid()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_USE_PID");
+    static auto _v = get_config()->find(std::string{ env_vars::USE_PID });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 bool&
 get_use_mpip()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_USE_MPIP");
+    static auto _v = get_config()->find(std::string{ env_vars::USE_MPIP });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 bool&
 get_use_ucx()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_USE_UCX");
+    static auto _v = get_config()->find(std::string{ env_vars::USE_UCX });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 bool&
 get_use_shmem()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_USE_SHMEM");
+    static auto _v = get_config()->find(std::string{ env_vars::USE_SHMEM });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 bool
 get_use_kokkosp()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_USE_KOKKOSP");
+    static auto _v = get_config()->find(std::string{ env_vars::USE_KOKKOSP });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 bool
 get_use_kokkosp_kernel_logger()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_KOKKOSP_KERNEL_LOGGER");
+    static auto _v = get_config()->find(std::string{ env_vars::KOKKOSP_KERNEL_LOGGER });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
@@ -1989,7 +2015,7 @@ get_use_kokkosp_kernel_logger()
 bool
 get_use_vaapi_tracing()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_ROCM_DOMAINS");
+    static auto _v = get_config()->find(std::string{ env_vars::ROCM_DOMAINS });
     if(_v == get_config()->end())
     {
         return false;  // Setting not found
@@ -2005,7 +2031,7 @@ get_use_vaapi_tracing()
 bool
 get_use_ompt()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_USE_OMPT");
+    static auto _v = get_config()->find(std::string{ env_vars::USE_OMPT });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
@@ -2014,91 +2040,94 @@ get_group_by_queue()
 {
     // When the `hip_stream` domain is unavailable, the setting is not registered
     // and there is no stream concept to attach to, so fall back to queue grouping.
-    return config::get_setting_value<bool>("ROCPROFSYS_ROCM_GROUP_BY_QUEUE")
+    return config::get_setting_value<bool>(std::string{ env_vars::ROCM_GROUP_BY_QUEUE })
         .value_or(true);
 }
 
 bool
 get_use_code_coverage()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_USE_CODE_COVERAGE");
+    static auto _v = get_config()->find(std::string{ env_vars::USE_CODE_COVERAGE });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 bool
 get_use_rcclp()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_USE_RCCLP");
+    static auto _v = get_config()->find(std::string{ env_vars::USE_RCCLP });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 size_t
 get_num_threads_hint()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_NUM_THREADS_HINT");
+    static auto _v = get_config()->find(std::string{ env_vars::NUM_THREADS_HINT });
     return static_cast<tim::tsettings<size_t>&>(*_v->second).get();
 }
 
 bool
 get_sampling_keep_internal()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_SAMPLING_KEEP_INTERNAL");
+    static auto _v = get_config()->find(std::string{ env_vars::SAMPLING_KEEP_INTERNAL });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 int
 get_sampling_overflow_signal()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_SAMPLING_OVERFLOW_SIGNAL");
+    static auto _v =
+        get_config()->find(std::string{ env_vars::SAMPLING_OVERFLOW_SIGNAL });
     return static_cast<tim::tsettings<int>&>(*_v->second).get();
 }
 
 int
 get_sampling_realtime_signal()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_SAMPLING_REALTIME_SIGNAL");
+    static auto _v =
+        get_config()->find(std::string{ env_vars::SAMPLING_REALTIME_SIGNAL });
     return static_cast<tim::tsettings<int>&>(*_v->second).get();
 }
 
 int
 get_sampling_cputime_signal()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_SAMPLING_CPUTIME_SIGNAL");
+    static auto _v = get_config()->find(std::string{ env_vars::SAMPLING_CPUTIME_SIGNAL });
     return static_cast<tim::tsettings<int>&>(*_v->second).get();
 }
 
 size_t
 get_perfetto_shmem_size_hint()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_PERFETTO_SHMEM_SIZE_HINT_KB");
+    static auto _v =
+        get_config()->find(std::string{ env_vars::PERFETTO_SHMEM_SIZE_HINT_KB });
     return static_cast<tim::tsettings<size_t>&>(*_v->second).get();
 }
 
 size_t
 get_perfetto_buffer_size()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_PERFETTO_BUFFER_SIZE_KB");
+    static auto _v = get_config()->find(std::string{ env_vars::PERFETTO_BUFFER_SIZE_KB });
     return static_cast<tim::tsettings<size_t>&>(*_v->second).get();
 }
 
 std::uint32_t
 get_perfetto_flush_period()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_PERFETTO_FLUSH_PERIOD_MS");
+    static auto _v = get_config()->find(std::string{ env_vars::PERFETTO_FLUSH_PERIOD });
     return static_cast<tim::tsettings<std::uint32_t>&>(*_v->second).get();
 }
 
 bool
 get_perfetto_combined_traces()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_PERFETTO_COMBINE_TRACES");
+    static auto _v = get_config()->find(std::string{ env_vars::PERFETTO_COMBINE_TRACES });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 std::string
 get_perfetto_fill_policy()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_PERFETTO_FILL_POLICY");
+    static auto _v = get_config()->find(std::string{ env_vars::PERFETTO_FILL_POLICY });
     return static_cast<tim::tsettings<std::string>&>(*_v->second).get();
 }
 
@@ -2122,8 +2151,10 @@ get_category_config()
             return _ret;
         };
 
-        auto _enabled  = _parse(get_config()->find("ROCPROFSYS_ENABLE_CATEGORIES"));
-        auto _disabled = _parse(get_config()->find("ROCPROFSYS_DISABLE_CATEGORIES"));
+        auto _enabled =
+            _parse(get_config()->find(std::string{ env_vars::ENABLE_CATEGORIES }));
+        auto _disabled =
+            _parse(get_config()->find(std::string{ env_vars::DISABLE_CATEGORIES }));
 
         if(_enabled.empty() && _disabled.empty())
         {
@@ -2180,7 +2211,7 @@ get_disabled_categories()
 bool
 get_perfetto_annotations()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_PERFETTO_ANNOTATIONS");
+    static auto _v = get_config()->find(std::string{ env_vars::PERFETTO_ANNOTATIONS });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
@@ -2188,7 +2219,7 @@ std::uint64_t
 get_thread_pool_size()
 {
     static std::uint64_t _v =
-        get_config()->get<std::uint64_t>("ROCPROFSYS_THREAD_POOL_SIZE");
+        get_config()->get<std::uint64_t>(std::string{ env_vars::THREAD_POOL_SIZE });
     return _v;
 }
 
@@ -2196,16 +2227,16 @@ std::string&
 get_perfetto_backend()
 {
     // select inprocess, system, or both (i.e. all)
-    static auto _v = get_config()->find("ROCPROFSYS_PERFETTO_BACKEND");
+    static auto _v = get_config()->find(std::string{ env_vars::PERFETTO_BACKEND });
     return static_cast<tim::tsettings<std::string>&>(*_v->second).get();
 }
 
 std::string
 get_perfetto_output_filename()
 {
-    const auto*  pwd                   = getenv("PWD");
-    static auto  setting               = get_config()->find("ROCPROFSYS_PERFETTO_FILE");
-    static auto* attach_add_session_id = getenv("ROCPROFSYS_REATTACH_ADD_SESSION_ID");
+    const auto*  pwd     = getenv("PWD");
+    static auto  setting = get_config()->find(std::string{ env_vars::PERFETTO_FILE });
+    static auto* attach_add_session_id = getenv(env_vars::REATTACH_ADD_SESSION_ID.data());
 
     if(setting == get_config()->end())
     {
@@ -2256,14 +2287,14 @@ get_perfetto_output_filename()
 double
 get_sampling_freq()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_SAMPLING_FREQ");
+    static auto _v = get_config()->find(std::string{ env_vars::SAMPLING_FREQ });
     return static_cast<tim::tsettings<double>&>(*_v->second).get();
 }
 
 double
 get_sampling_cputime_freq()
 {
-    static auto _v   = get_config()->find("ROCPROFSYS_SAMPLING_CPUTIME_FREQ");
+    static auto _v   = get_config()->find(std::string{ env_vars::SAMPLING_CPUTIME_FREQ });
     auto&       _val = static_cast<tim::tsettings<double>&>(*_v->second).get();
     if(_val <= 0.0) _val = get_sampling_freq();
     return _val;
@@ -2272,7 +2303,7 @@ get_sampling_cputime_freq()
 double
 get_sampling_realtime_freq()
 {
-    static auto _v   = get_config()->find("ROCPROFSYS_SAMPLING_REALTIME_FREQ");
+    static auto _v = get_config()->find(std::string{ env_vars::SAMPLING_REALTIME_FREQ });
     auto&       _val = static_cast<tim::tsettings<double>&>(*_v->second).get();
     if(_val <= 0.0) _val = get_sampling_freq();
     return _val;
@@ -2281,7 +2312,7 @@ get_sampling_realtime_freq()
 double
 get_sampling_overflow_freq()
 {
-    static auto _v   = get_config()->find("ROCPROFSYS_SAMPLING_OVERFLOW_FREQ");
+    static auto _v = get_config()->find(std::string{ env_vars::SAMPLING_OVERFLOW_FREQ });
     auto&       _val = static_cast<tim::tsettings<double>&>(*_v->second).get();
     if(_val <= 0.0) _val = get_sampling_freq();
     return _val;
@@ -2290,14 +2321,14 @@ get_sampling_overflow_freq()
 double
 get_sampling_delay()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_SAMPLING_DELAY");
+    static auto _v = get_config()->find(std::string{ env_vars::SAMPLING_DELAY });
     return static_cast<tim::tsettings<double>&>(*_v->second).get();
 }
 
 double
 get_sampling_cputime_delay()
 {
-    static auto _v   = get_config()->find("ROCPROFSYS_SAMPLING_CPUTIME_DELAY");
+    static auto _v = get_config()->find(std::string{ env_vars::SAMPLING_CPUTIME_DELAY });
     auto&       _val = static_cast<tim::tsettings<double>&>(*_v->second).get();
     if(_val <= 0.0) _val = get_sampling_delay();
     return _val;
@@ -2306,7 +2337,7 @@ get_sampling_cputime_delay()
 double
 get_sampling_realtime_delay()
 {
-    static auto _v   = get_config()->find("ROCPROFSYS_SAMPLING_REALTIME_DELAY");
+    static auto _v = get_config()->find(std::string{ env_vars::SAMPLING_REALTIME_DELAY });
     auto&       _val = static_cast<tim::tsettings<double>&>(*_v->second).get();
     if(_val <= 0.0) _val = get_sampling_delay();
     return _val;
@@ -2315,21 +2346,21 @@ get_sampling_realtime_delay()
 double
 get_sampling_duration()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_SAMPLING_DURATION");
+    static auto _v = get_config()->find(std::string{ env_vars::SAMPLING_DURATION });
     return static_cast<tim::tsettings<double>&>(*_v->second).get();
 }
 
 std::string
 get_sampling_cpus()
 {
-    auto _v = get_config()->find("ROCPROFSYS_SAMPLING_CPUS");
+    auto _v = get_config()->find(std::string{ env_vars::SAMPLING_CPUS });
     return static_cast<tim::tsettings<std::string>&>(*_v->second).get();
 }
 
 std::string
 get_cpu_metrics()
 {
-    auto _v = get_config()->find("ROCPROFSYS_CPU_METRICS");
+    auto _v = get_config()->find(std::string{ env_vars::CPU_METRICS });
     if(_v == get_config()->end()) return "all";
     return static_cast<tim::tsettings<std::string>&>(*_v->second).get();
 }
@@ -2337,7 +2368,7 @@ get_cpu_metrics()
 std::set<std::int64_t>
 get_sampling_tids()
 {
-    auto _v = get_config()->find("ROCPROFSYS_SAMPLING_TIDS");
+    auto _v = get_config()->find(std::string{ env_vars::SAMPLING_TIDS });
     return parse_numeric_range<>(
         static_cast<tim::tsettings<std::string>&>(*_v->second).get(), "thread IDs", 1L);
 }
@@ -2345,7 +2376,7 @@ get_sampling_tids()
 std::set<std::int64_t>
 get_sampling_cputime_tids()
 {
-    auto _v = get_config()->find("ROCPROFSYS_SAMPLING_CPUTIME_TIDS");
+    auto _v = get_config()->find(std::string{ env_vars::SAMPLING_CPUTIME_TIDS });
     return parse_numeric_range<>(
         static_cast<tim::tsettings<std::string>&>(*_v->second).get(), "thread IDs", 1L);
 }
@@ -2353,7 +2384,7 @@ get_sampling_cputime_tids()
 std::set<std::int64_t>
 get_sampling_realtime_tids()
 {
-    auto _v = get_config()->find("ROCPROFSYS_SAMPLING_REALTIME_TIDS");
+    auto _v = get_config()->find(std::string{ env_vars::SAMPLING_REALTIME_TIDS });
     return parse_numeric_range<>(
         static_cast<tim::tsettings<std::string>&>(*_v->second).get(), "thread IDs", 1L);
 }
@@ -2361,7 +2392,7 @@ get_sampling_realtime_tids()
 std::set<std::int64_t>
 get_sampling_overflow_tids()
 {
-    auto _v = get_config()->find("ROCPROFSYS_SAMPLING_OVERFLOW_TIDS");
+    auto _v = get_config()->find(std::string{ env_vars::SAMPLING_OVERFLOW_TIDS });
     return parse_numeric_range<>(
         static_cast<tim::tsettings<std::string>&>(*_v->second).get(), "thread IDs", 1L);
 }
@@ -2369,21 +2400,22 @@ get_sampling_overflow_tids()
 bool
 get_sampling_include_inlines()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_SAMPLING_INCLUDE_INLINES");
+    static auto _v =
+        get_config()->find(std::string{ env_vars::SAMPLING_INCLUDE_INLINES });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 size_t
 get_sampling_allocator_size()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_SAMPLING_ALLOCATOR_SIZE");
+    static auto _v = get_config()->find(std::string{ env_vars::SAMPLING_ALLOCATOR_SIZE });
     return std::max<size_t>(static_cast<tim::tsettings<size_t>&>(*_v->second).get(), 1);
 }
 
 double
 get_process_sampling_freq()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_PROCESS_SAMPLING_FREQ");
+    static auto _v = get_config()->find(std::string{ env_vars::PROCESS_SAMPLING_FREQ });
     auto        _val =
         std::min<double>(static_cast<tim::tsettings<double>&>(*_v->second).get(), 1000.0);
     if(_val < 1.0e-9) return std::min<double>(get_sampling_freq(), 100.0);
@@ -2393,56 +2425,57 @@ get_process_sampling_freq()
 double
 get_process_sampling_duration()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_PROCESS_SAMPLING_DURATION");
+    static auto _v =
+        get_config()->find(std::string{ env_vars::PROCESS_SAMPLING_DURATION });
     return static_cast<tim::tsettings<double>&>(*_v->second).get();
 }
 
 std::string
 get_sampling_gpus()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_SAMPLING_GPUS");
+    static auto _v = get_config()->find(std::string{ env_vars::SAMPLING_GPUS });
     return static_cast<tim::tsettings<std::string>&>(*_v->second).get();
 }
 
 bool
 get_trace_thread_locks()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_TRACE_THREAD_LOCKS");
+    static auto _v = get_config()->find(std::string{ env_vars::TRACE_THREAD_LOCKS });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 bool
 get_trace_thread_rwlocks()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_TRACE_THREAD_RW_LOCKS");
+    static auto _v = get_config()->find(std::string{ env_vars::TRACE_THREAD_RW_LOCKS });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 bool
 get_trace_thread_spin_locks()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_TRACE_THREAD_SPIN_LOCKS");
+    static auto _v = get_config()->find(std::string{ env_vars::TRACE_THREAD_SPIN_LOCKS });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 bool
 get_trace_thread_barriers()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_TRACE_THREAD_BARRIERS");
+    static auto _v = get_config()->find(std::string{ env_vars::TRACE_THREAD_BARRIERS });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 bool
 get_trace_thread_join()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_TRACE_THREAD_JOIN");
+    static auto _v = get_config()->find(std::string{ env_vars::TRACE_THREAD_JOIN });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 std::string
 get_trace_region()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_SELECTED_REGIONS");
+    static auto _v = get_config()->find(std::string{ env_vars::SELECTED_REGIONS });
     return static_cast<tim::tsettings<std::string>&>(*_v->second).get();
 }
 
@@ -2451,7 +2484,7 @@ get_debug_tid()
 {
     static auto _vlist =
         parse_numeric_range<std::int64_t, std::unordered_set<std::int64_t>>(
-            tim::get_env<std::string>("ROCPROFSYS_DEBUG_TIDS", ""), "debug tids", 1L);
+            tim::get_env<std::string>(env_vars::DEBUG_TIDS.data(), ""), "debug tids", 1L);
     static thread_local bool _v =
         _vlist.empty() || _vlist.count(tim::threading::get_id()) > 0;
     return _v;
@@ -2462,7 +2495,7 @@ get_debug_pid()
 {
     static auto _vlist =
         parse_numeric_range<std::int64_t, std::unordered_set<std::int64_t>>(
-            tim::get_env<std::string>("ROCPROFSYS_DEBUG_PIDS", ""), "debug pids", 1L);
+            tim::get_env<std::string>(env_vars::DEBUG_PIDS.data(), ""), "debug pids", 1L);
     static bool _v = _vlist.empty() || _vlist.count(tim::process::get_id()) > 0 ||
                      _vlist.count(dmp::rank()) > 0;
     return _v;
@@ -2471,21 +2504,21 @@ get_debug_pid()
 bool
 get_use_tmp_files()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_USE_TEMPORARY_FILES");
+    static auto _v = get_config()->find(std::string{ env_vars::USE_TEMPORARY_FILES });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 bool
 get_merge_perfetto_files()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_MERGE_PERFETTO_FILES");
+    static auto _v = get_config()->find(std::string{ env_vars::MERGE_PERFETTO_FILES });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 std::string
 get_tmpdir()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_TMPDIR");
+    static auto _v = get_config()->find(std::string{ env_vars::TMPDIR });
     return static_cast<tim::tsettings<std::string>&>(*_v->second).get();
 }
 
@@ -2562,7 +2595,7 @@ get_output_absolute_path(std::string_view basename, std::string_view extension,
 std::string
 get_perfetto_output_filename_with_suffix(std::string_view suffix)
 {
-    static auto _v   = get_config()->find("ROCPROFSYS_PERFETTO_FILE");
+    static auto _v   = get_config()->find(std::string{ env_vars::PERFETTO_FILE });
     auto        _val = static_cast<tim::tsettings<std::string>&>(*_v->second).get();
 
     LOG_DEBUG("Initial ROCPROFSYS_PERFETTO_FILE='{}', suffix='{}'", _val, suffix);
@@ -2641,22 +2674,22 @@ get_ump_absolute_path()
 bool&
 get_use_rocpd()
 {
-    static auto _v = get_config()->at("ROCPROFSYS_USE_ROCPD");
+    static auto _v = get_config()->at(env_vars::USE_ROCPD);
     return static_cast<tim::tsettings<bool>&>(*_v).get();
 }
 
 bool&
 get_use_unified_memory_profiling()
 {
-    static auto _v = get_config()->at("ROCPROFSYS_USE_UNIFIED_MEMORY_PROFILING");
+    static auto _v = get_config()->at(env_vars::USE_UNIFIED_MEMORY_PROFILING);
     return static_cast<tim::tsettings<bool>&>(*_v).get();
 }
 
 bool&
 get_caching_perfetto()
 {
-    static auto _trace_setting  = get_config()->at("ROCPROFSYS_TRACE");
-    static auto _legacy_setting = get_config()->at("ROCPROFSYS_TRACE_LEGACY");
+    static auto _trace_setting  = get_config()->at(env_vars::TRACE);
+    static auto _legacy_setting = get_config()->at(env_vars::TRACE_LEGACY);
     auto&       _trace  = static_cast<tim::tsettings<bool>&>(*_trace_setting).get();
     auto&       _legacy = static_cast<tim::tsettings<bool>&>(*_legacy_setting).get();
     static bool _v      = _trace && !_legacy;
@@ -2666,7 +2699,7 @@ get_caching_perfetto()
 int
 get_kill_delay()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_KILL_DELAY");
+    static auto _v = get_config()->find(std::string{ env_vars::KILL_DELAY });
     return static_cast<tim::tsettings<int>&>(*_v->second).get();
 }
 
@@ -2675,14 +2708,14 @@ namespace
 std::string
 get_rank_filter_id()
 {
-    static auto _v = get_config()->at("ROCPROFSYS_RANK_FILTER_ID");
+    static auto _v = get_config()->at(env_vars::RANK_FILTER_ID);
     return static_cast<tim::tsettings<std::string>&>(*_v).get();
 }
 
 std::string
 get_rank_filter_output()
 {
-    static auto _v = get_config()->at("ROCPROFSYS_RANK_FILTER_OUTPUT");
+    static auto _v = get_config()->at(env_vars::RANK_FILTER_OUTPUT);
     return static_cast<tim::tsettings<std::string>&>(*_v).get();
 }
 
@@ -2980,7 +3013,7 @@ get_causal_backend()
         { "timer", CausalBackend::Timer },
     };
 
-    auto _v = get_config()->find("ROCPROFSYS_CAUSAL_BACKEND");
+    auto _v = get_config()->find(std::string{ env_vars::CAUSAL_BACKEND });
     try
     {
         return _m.at(static_cast<tim::tsettings<std::string>&>(*_v->second).get());
@@ -2999,7 +3032,7 @@ get_causal_mode()
 {
     if(!settings_are_configured())
     {
-        auto _mode = tim::get_env_choice<std::string>("ROCPROFSYS_CAUSAL_MODE",
+        auto _mode = tim::get_env_choice<std::string>(env_vars::CAUSAL_MODE.data(),
                                                       "function", { "line", "function" });
         if(_mode == "line") return CausalMode::Line;
         return CausalMode::Function;
@@ -3010,7 +3043,7 @@ get_causal_mode()
             { "func", CausalMode::Function },
             { "function", CausalMode::Function }
         };
-        auto _v = get_config()->find("ROCPROFSYS_CAUSAL_MODE");
+        auto _v = get_config()->find(std::string{ env_vars::CAUSAL_MODE });
         try
         {
             return _m.at(static_cast<tim::tsettings<std::string>&>(*_v->second).get());
@@ -3029,14 +3062,14 @@ get_causal_mode()
 bool
 get_causal_end_to_end()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_CAUSAL_END_TO_END");
+    static auto _v = get_config()->find(std::string{ env_vars::CAUSAL_END_TO_END });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 
 std::vector<std::int64_t>
 get_causal_fixed_speedup()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_CAUSAL_FIXED_SPEEDUP");
+    static auto _v = get_config()->find(std::string{ env_vars::CAUSAL_FIXED_SPEEDUP });
     return parse_numeric_range<std::int64_t, std::vector<std::int64_t>>(
         static_cast<tim::tsettings<std::string>&>(*_v->second).get(),
         "causal fixed speedup", 5L);
@@ -3045,7 +3078,7 @@ get_causal_fixed_speedup()
 std::string
 get_causal_output_filename()
 {
-    static auto _v     = get_config()->find("ROCPROFSYS_CAUSAL_FILE");
+    static auto _v     = get_config()->find(std::string{ env_vars::CAUSAL_FILE });
     auto        _fname = static_cast<tim::tsettings<std::string>&>(*_v->second).get();
     for(auto&& itr : std::initializer_list<std::string>{ ".txt", ".json", ".xml" })
     {
@@ -3088,7 +3121,7 @@ std::vector<std::string>
 get_causal_binary_scope()
 {
     auto&&      _config = get_config();
-    static auto _v      = _config->find("ROCPROFSYS_CAUSAL_BINARY_SCOPE");
+    static auto _v      = _config->find(std::string{ env_vars::CAUSAL_BINARY_SCOPE });
     return format_causal_scopes(
         tim::delimit(static_cast<tim::tsettings<std::string>&>(*_v->second).get(),
                      "\t\"';"),
@@ -3098,7 +3131,7 @@ get_causal_binary_scope()
 std::vector<std::string>
 get_causal_source_scope()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_CAUSAL_SOURCE_SCOPE");
+    static auto _v = get_config()->find(std::string{ env_vars::CAUSAL_SOURCE_SCOPE });
     return tim::delimit(static_cast<tim::tsettings<std::string>&>(*_v->second).get(),
                         "\t\"';");
 }
@@ -3106,7 +3139,7 @@ get_causal_source_scope()
 std::vector<std::string>
 get_causal_function_scope()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_CAUSAL_FUNCTION_SCOPE");
+    static auto _v = get_config()->find(std::string{ env_vars::CAUSAL_FUNCTION_SCOPE });
     return tim::delimit(static_cast<tim::tsettings<std::string>&>(*_v->second).get(),
                         "\t\"';");
 }
@@ -3115,7 +3148,7 @@ std::vector<std::string>
 get_causal_binary_exclude()
 {
     auto&&      _config = get_config();
-    static auto _v      = _config->find("ROCPROFSYS_CAUSAL_BINARY_EXCLUDE");
+    static auto _v      = _config->find(std::string{ env_vars::CAUSAL_BINARY_EXCLUDE });
     return format_causal_scopes(
         tim::delimit(static_cast<tim::tsettings<std::string>&>(*_v->second).get(),
                      "\t\"';"),
@@ -3125,7 +3158,7 @@ get_causal_binary_exclude()
 std::vector<std::string>
 get_causal_source_exclude()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_CAUSAL_SOURCE_EXCLUDE");
+    static auto _v = get_config()->find(std::string{ env_vars::CAUSAL_SOURCE_EXCLUDE });
     return tim::delimit(static_cast<tim::tsettings<std::string>&>(*_v->second).get(),
                         "\t\"';");
 }
@@ -3133,7 +3166,7 @@ get_causal_source_exclude()
 std::vector<std::string>
 get_causal_function_exclude()
 {
-    static auto _v = get_config()->find("ROCPROFSYS_CAUSAL_FUNCTION_EXCLUDE");
+    static auto _v = get_config()->find(std::string{ env_vars::CAUSAL_FUNCTION_EXCLUDE });
     return tim::delimit(static_cast<tim::tsettings<std::string>&>(*_v->second).get(),
                         "\t\"';");
 }

--- a/projects/rocprofiler-systems/source/lib/core/constraint.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/constraint.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "constraint.hpp"
+#include "common/env_vars.hpp"
 #include "common/units.hpp"
 #include "config.hpp"
 #include "state.hpp"
@@ -220,10 +221,13 @@ spec::spec(const std::string& _clock_id, double _delay, double _dur, std::uint64
 {}
 
 spec::spec(const std::string& _line)
-: spec{ config::get_setting_value<std::string>("ROCPROFSYS_TRACE_PERIOD_CLOCK_ID")
-            .value_or("CLOCK_REALTIME"),
-        config::get_setting_value<double>("ROCPROFSYS_TRACE_DELAY").value_or(0.0),
-        config::get_setting_value<double>("ROCPROFSYS_TRACE_DURATION").value_or(0.0) }
+: spec{
+    config::get_setting_value<std::string>(std::string{ env_vars::TRACE_PERIOD_CLOCK_ID })
+        .value_or("CLOCK_REALTIME"),
+    config::get_setting_value<double>(std::string{ env_vars::TRACE_DELAY }).value_or(0.0),
+    config::get_setting_value<double>(std::string{ env_vars::TRACE_DURATION })
+        .value_or(0.0)
+}
 {
     auto _delim = tim::delimit(_line, ":");
     if(!_delim.empty()) delay = utility::convert<double>(_delim.at(0));
@@ -290,12 +294,15 @@ get_trace_specs()
 
     {
         auto _delay_v =
-            config::get_setting_value<double>("ROCPROFSYS_TRACE_DELAY").value_or(0.0);
+            config::get_setting_value<double>(std::string{ env_vars::TRACE_DELAY })
+                .value_or(0.0);
         auto _duration_v =
-            config::get_setting_value<double>("ROCPROFSYS_TRACE_DURATION").value_or(0.0);
-        auto _clock_v = find_clock_identifier(
-            config::get_setting_value<std::string>("ROCPROFSYS_TRACE_PERIOD_CLOCK_ID")
-                .value_or("CLOCK_REALTIME"));
+            config::get_setting_value<double>(std::string{ env_vars::TRACE_DURATION })
+                .value_or(0.0);
+        auto _clock_v =
+            find_clock_identifier(config::get_setting_value<std::string>(
+                                      std::string{ env_vars::TRACE_PERIOD_CLOCK_ID })
+                                      .value_or("CLOCK_REALTIME"));
 
         if(_delay_v > 0.0 || _duration_v > 0.0)
         {
@@ -305,7 +312,7 @@ get_trace_specs()
 
     {
         auto _periods_v =
-            config::get_setting_value<std::string>("ROCPROFSYS_TRACE_PERIODS")
+            config::get_setting_value<std::string>(std::string{ env_vars::TRACE_PERIODS })
                 .value_or("");
         if(!_periods_v.empty())
         {

--- a/projects/rocprofiler-systems/source/lib/core/constraint.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/constraint.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "constraint.hpp"
+#include "common/env_vars.hpp"
 #include "config.hpp"
 #include "state.hpp"
 #include "utility.hpp"
@@ -222,10 +223,13 @@ spec::spec(const std::string& _clock_id, double _delay, double _dur, std::uint64
 {}
 
 spec::spec(const std::string& _line)
-: spec{ config::get_setting_value<std::string>("ROCPROFSYS_TRACE_PERIOD_CLOCK_ID")
-            .value_or("CLOCK_REALTIME"),
-        config::get_setting_value<double>("ROCPROFSYS_TRACE_DELAY").value_or(0.0),
-        config::get_setting_value<double>("ROCPROFSYS_TRACE_DURATION").value_or(0.0) }
+: spec{
+    config::get_setting_value<std::string>(std::string{ env_vars::TRACE_PERIOD_CLOCK_ID })
+        .value_or("CLOCK_REALTIME"),
+    config::get_setting_value<double>(std::string{ env_vars::TRACE_DELAY }).value_or(0.0),
+    config::get_setting_value<double>(std::string{ env_vars::TRACE_DURATION })
+        .value_or(0.0)
+}
 {
     auto _delim = tim::delimit(_line, ":");
     if(!_delim.empty()) delay = utility::convert<double>(_delim.at(0));
@@ -292,12 +296,15 @@ get_trace_specs()
 
     {
         auto _delay_v =
-            config::get_setting_value<double>("ROCPROFSYS_TRACE_DELAY").value_or(0.0);
+            config::get_setting_value<double>(std::string{ env_vars::TRACE_DELAY })
+                .value_or(0.0);
         auto _duration_v =
-            config::get_setting_value<double>("ROCPROFSYS_TRACE_DURATION").value_or(0.0);
-        auto _clock_v = find_clock_identifier(
-            config::get_setting_value<std::string>("ROCPROFSYS_TRACE_PERIOD_CLOCK_ID")
-                .value_or("CLOCK_REALTIME"));
+            config::get_setting_value<double>(std::string{ env_vars::TRACE_DURATION })
+                .value_or(0.0);
+        auto _clock_v =
+            find_clock_identifier(config::get_setting_value<std::string>(
+                                      std::string{ env_vars::TRACE_PERIOD_CLOCK_ID })
+                                      .value_or("CLOCK_REALTIME"));
 
         if(_delay_v > 0.0 || _duration_v > 0.0)
         {
@@ -307,7 +314,7 @@ get_trace_specs()
 
     {
         auto _periods_v =
-            config::get_setting_value<std::string>("ROCPROFSYS_TRACE_PERIODS")
+            config::get_setting_value<std::string>(std::string{ env_vars::TRACE_PERIODS })
                 .value_or("");
         if(!_periods_v.empty())
         {

--- a/projects/rocprofiler-systems/source/lib/core/dynamic_library.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/dynamic_library.cpp
@@ -35,7 +35,7 @@ find_library_path(const std::string& _name, const std::vector<std::string>& _env
     auto _paths = std::vector<std::string>{};
     for(const std::string& itr : _env_vars)
     {
-        auto _env_val = get_env(itr, std::string{});
+        auto _env_val = get_env(itr.c_str(), std::string{});
         for(auto vitr : tim::delimit(_env_val, ":"))
             if(!vitr.empty()) _paths.emplace_back(vitr);
     }
@@ -70,7 +70,7 @@ dynamic_library::dynamic_library(std::string _env, std::string _fname, int _flag
 
     if(_query_env)
     {
-        auto _env_val = common::get_env(envname, std::string{});
+        auto _env_val = common::get_env(envname.c_str(), std::string{});
         // if the environment variable is set to an absolute path that exists,
         // override with value
         if(!_env_val.empty())

--- a/projects/rocprofiler-systems/source/lib/core/mpi.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/mpi.hpp
@@ -13,6 +13,7 @@
 #include "common/environment.hpp"
 #include <timemory/utility/types.hpp>
 
+#include "common/env_vars.hpp"
 #include "logger/debug.hpp"
 
 #include <cstdint>
@@ -194,7 +195,7 @@ inline void         set_size(std::int32_t, comm_t = comm_world_v);
 inline bool&
 use_mpi_thread()
 {
-    static bool _instance = rocprofsys::get_env("ROCPROFSYS_MPI_THREAD", true);
+    static bool _instance = rocprofsys::get_env(env_vars::MPI_THREAD, true);
     return _instance;
 }
 
@@ -204,7 +205,7 @@ inline std::string&
 use_mpi_thread_type()
 {
     static std::string _instance =
-        rocprofsys::get_env<std::string>("ROCPROFSYS_MPI_THREAD_TYPE", "");
+        rocprofsys::get_env<std::string>(env_vars::MPI_THREAD_TYPE, "");
     return _instance;
 }
 
@@ -213,7 +214,7 @@ use_mpi_thread_type()
 inline bool&
 fail_on_error()
 {
-    static bool _instance = rocprofsys::get_env("ROCPROFSYS_MPI_FAIL_ON_ERROR", false);
+    static bool _instance = rocprofsys::get_env(env_vars::MPI_FAIL_ON_ERROR, false);
     return _instance;
 }
 
@@ -222,7 +223,7 @@ fail_on_error()
 inline bool&
 quiet()
 {
-    static bool _instance = rocprofsys::get_env("ROCPROFSYS_MPI_QUIET", false);
+    static bool _instance = rocprofsys::get_env(env_vars::MPI_QUIET, false);
     return _instance;
 }
 

--- a/projects/rocprofiler-systems/source/lib/core/mpi.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/mpi.hpp
@@ -13,6 +13,7 @@
 #include <timemory/environment/declaration.hpp>
 #include <timemory/utility/types.hpp>
 
+#include "common/env_vars.hpp"
 #include "logger/debug.hpp"
 
 #include <cstdint>
@@ -194,7 +195,7 @@ inline void         set_size(std::int32_t, comm_t = comm_world_v);
 inline bool&
 use_mpi_thread()
 {
-    static bool _instance = tim::get_env("ROCPROFSYS_MPI_THREAD", true);
+    static bool _instance = tim::get_env(env_vars::MPI_THREAD.data(), true);
     return _instance;
 }
 
@@ -204,7 +205,7 @@ inline std::string&
 use_mpi_thread_type()
 {
     static std::string _instance =
-        tim::get_env<std::string>("ROCPROFSYS_MPI_THREAD_TYPE", "");
+        tim::get_env<std::string>(env_vars::MPI_THREAD_TYPE.data(), "");
     return _instance;
 }
 
@@ -213,7 +214,7 @@ use_mpi_thread_type()
 inline bool&
 fail_on_error()
 {
-    static bool _instance = tim::get_env("ROCPROFSYS_MPI_FAIL_ON_ERROR", false);
+    static bool _instance = tim::get_env(env_vars::MPI_FAIL_ON_ERROR.data(), false);
     return _instance;
 }
 
@@ -222,7 +223,7 @@ fail_on_error()
 inline bool&
 quiet()
 {
-    static bool _instance = tim::get_env("ROCPROFSYS_MPI_QUIET", false);
+    static bool _instance = tim::get_env(env_vars::MPI_QUIET.data(), false);
     return _instance;
 }
 

--- a/projects/rocprofiler-systems/source/lib/core/perfetto.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/perfetto.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "perfetto.hpp"
+#include "common/env_vars.hpp"
 #include "common/units.hpp"
 #include "config.hpp"
 #include "library/runtime.hpp"
@@ -278,7 +279,7 @@ post_process(tim::manager* _timemory_manager, bool& _perfetto_output_error,
     {
         auto _output_folder = filepath::dirname(_filename);
         auto _script_path   = std::string{ "rocprof-sys-merge-output.sh" };
-        auto _script_dir    = get_env("ROCPROFSYS_SCRIPT_PATH", std::string{});
+        auto _script_dir    = get_env(env_vars::SCRIPT_PATH, std::string{});
 
         if(!_script_dir.empty())
         {

--- a/projects/rocprofiler-systems/source/lib/core/perfetto.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/perfetto.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "perfetto.hpp"
+#include "common/env_vars.hpp"
 #include "config.hpp"
 #include "library/runtime.hpp"
 #include "output_file_registry.hpp"
@@ -270,7 +271,7 @@ post_process(tim::manager* _timemory_manager, bool& _perfetto_output_error,
     {
         auto _output_folder = filepath::dirname(_filename);
         auto _script_path   = std::string{ "rocprof-sys-merge-output.sh" };
-        auto _script_dir    = get_env("ROCPROFSYS_SCRIPT_PATH", std::string{}, false);
+        auto _script_dir    = get_env(env_vars::SCRIPT_PATH.data(), std::string{}, false);
 
         if(!_script_dir.empty())
         {

--- a/projects/rocprofiler-systems/source/lib/core/rocprofiler-sdk.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/rocprofiler-sdk.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "core/rocprofiler-sdk.hpp"
+#include "common/env_vars.hpp"
 #include "core/config.hpp"
 #include "timemory.hpp"
 #include <regex>
@@ -52,18 +53,21 @@ get_setting_name(std::string _v)
     return _v;
 }
 
-#define ROCPROFSYS_CONFIG_SETTING(TYPE, ENV_NAME, DESCRIPTION, INITIAL_VALUE, ...)       \
-    [&]() {                                                                              \
-        auto _ret = _config->insert<TYPE, TYPE>(                                         \
-            ENV_NAME, get_setting_name(ENV_NAME), DESCRIPTION, TYPE{ INITIAL_VALUE },    \
-            std::set<std::string>{ "custom", "rocprofsys", "librocprof-sys",             \
-                                   __VA_ARGS__ });                                       \
-        if(!_ret.second)                                                                 \
-        {                                                                                \
-            LOG_WARNING("Duplicate setting: {} / {}", get_setting_name(ENV_NAME),        \
-                        ENV_NAME);                                                       \
-        }                                                                                \
-        return _config->find(ENV_NAME)->second;                                          \
+// Accepts either a `const char*` literal or `std::string_view` (e.g. env_vars::FOO)
+// for ENV_NAME — std::string{} can be constructed from either.
+#define ROCPROFSYS_CONFIG_SETTING(TYPE, ENV_NAME, DESCRIPTION, INITIAL_VALUE, ...)           \
+    [&]() {                                                                                  \
+        auto _env_name = std::string{ ENV_NAME };                                            \
+        auto _ret      = _config->insert<TYPE, TYPE>(                                        \
+            _env_name, get_setting_name(_env_name), DESCRIPTION, TYPE{ INITIAL_VALUE }, \
+            std::set<std::string>{ "custom", "rocprofsys", "librocprof-sys",            \
+                                        __VA_ARGS__ });                                      \
+        if(!_ret.second)                                                                     \
+        {                                                                                    \
+            LOG_WARNING("Duplicate setting: {} / {}", get_setting_name(_env_name),           \
+                        _env_name);                                                          \
+        }                                                                                    \
+        return _config->find(_env_name)->second;                                             \
     }()
 
 template <typename Tp>
@@ -335,12 +339,12 @@ config_settings(const std::shared_ptr<settings>& _config)
     _domain_defaults.append(",page_migration");
 #endif
 
-    ROCPROFSYS_CONFIG_SETTING(std::string, "ROCPROFSYS_ROCM_DOMAINS", _domain_description,
+    ROCPROFSYS_CONFIG_SETTING(std::string, env_vars::ROCM_DOMAINS, _domain_description,
                               _domain_defaults, "rocm", "rocprofiler-sdk")
         ->set_choices(_domain_choices);
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_ROCM_EVENTS",
+        std::string, env_vars::ROCM_EVENTS,
         "ROCm hardware counters. Use ':device=N' syntax to specify collection on device "
         "number N, e.g. ':device=0'. If no device specification is provided, the event "
         "is collected on every available device",
@@ -367,7 +371,7 @@ config_settings(const std::shared_ptr<settings>& _config)
     if(_has_hip_stream)
     {
         ROCPROFSYS_CONFIG_SETTING(
-            bool, "ROCPROFSYS_ROCM_GROUP_BY_QUEUE",
+            bool, env_vars::ROCM_GROUP_BY_QUEUE,
             "By default, Perfetto trace will show the HIP streams to which kernel "
             "and memory copy operations submitted. With the "
             "`ROCPROFSYS_ROCM_GROUP_BY_QUEUE` option, the trace will display HSA queues "
@@ -413,11 +417,11 @@ get_callback_domains()
     }
 #endif
 
-    auto _data = std::unordered_set<rocprofiler_callback_tracing_kind_t>{};
-    auto _domains =
-        tim::delimit(config::get_setting_value<std::string>("ROCPROFSYS_ROCM_DOMAINS")
-                         .value_or(std::string{}),
-                     " ,;:\t\n");
+    auto _data    = std::unordered_set<rocprofiler_callback_tracing_kind_t>{};
+    auto _domains = tim::delimit(
+        config::get_setting_value<std::string>(std::string{ env_vars::ROCM_DOMAINS })
+            .value_or(std::string{}),
+        " ,;:\t\n");
 
     if(config::get_use_rcclp() && _version.formatted >= 600)
     {
@@ -435,7 +439,7 @@ get_callback_domains()
 
     // Check that the domains are valid
     const auto valid_choices =
-        settings::instance()->at("ROCPROFSYS_ROCM_DOMAINS")->get_choices();
+        settings::instance()->at(std::string{ env_vars::ROCM_DOMAINS })->get_choices();
 
     auto invalid_domain = [&valid_choices](const auto& domainv) {
         return !std::any_of(valid_choices.begin(), valid_choices.end(),
@@ -510,13 +514,13 @@ get_buffered_domains()
 #endif
     };
 
-    auto _data = std::unordered_set<rocprofiler_buffer_tracing_kind_t>{};
-    auto _domains =
-        tim::delimit(config::get_setting_value<std::string>("ROCPROFSYS_ROCM_DOMAINS")
-                         .value_or(std::string{}),
-                     " ,;:\t\n");
+    auto _data    = std::unordered_set<rocprofiler_buffer_tracing_kind_t>{};
+    auto _domains = tim::delimit(
+        config::get_setting_value<std::string>(std::string{ env_vars::ROCM_DOMAINS })
+            .value_or(std::string{}),
+        " ,;:\t\n");
     const auto valid_choices =
-        settings::instance()->at("ROCPROFSYS_ROCM_DOMAINS")->get_choices();
+        settings::instance()->at(std::string{ env_vars::ROCM_DOMAINS })->get_choices();
 
     auto invalid_domain = [&valid_choices](const auto& domainv) {
         return !std::any_of(valid_choices.begin(), valid_choices.end(),
@@ -654,7 +658,8 @@ std::vector<std::string>
 get_rocm_events()
 {
     return tim::delimit(
-        get_setting_value<std::string>("ROCPROFSYS_ROCM_EVENTS").value_or(std::string{}),
+        get_setting_value<std::string>(std::string{ env_vars::ROCM_EVENTS })
+            .value_or(std::string{}),
         " ,;\t\n");
 }
 

--- a/projects/rocprofiler-systems/source/lib/core/rocprofiler-sdk.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/rocprofiler-sdk.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "core/rocprofiler-sdk.hpp"
+#include "common/env_vars.hpp"
 #include "core/config.hpp"
 #include "timemory.hpp"
 #include <regex>
@@ -53,18 +54,21 @@ get_setting_name(std::string _v)
     return _v;
 }
 
-#define ROCPROFSYS_CONFIG_SETTING(TYPE, ENV_NAME, DESCRIPTION, INITIAL_VALUE, ...)       \
-    [&]() {                                                                              \
-        auto _ret = _config->insert<TYPE, TYPE>(                                         \
-            ENV_NAME, get_setting_name(ENV_NAME), DESCRIPTION, TYPE{ INITIAL_VALUE },    \
-            std::set<std::string>{ "custom", "rocprofsys", "librocprof-sys",             \
-                                   __VA_ARGS__ });                                       \
-        if(!_ret.second)                                                                 \
-        {                                                                                \
-            LOG_WARNING("Duplicate setting: {} / {}", get_setting_name(ENV_NAME),        \
-                        ENV_NAME);                                                       \
-        }                                                                                \
-        return _config->find(ENV_NAME)->second;                                          \
+// Accepts either a `const char*` literal or `std::string_view` (e.g. env_vars::FOO)
+// for ENV_NAME — std::string{} can be constructed from either.
+#define ROCPROFSYS_CONFIG_SETTING(TYPE, ENV_NAME, DESCRIPTION, INITIAL_VALUE, ...)           \
+    [&]() {                                                                                  \
+        auto _env_name = std::string{ ENV_NAME };                                            \
+        auto _ret      = _config->insert<TYPE, TYPE>(                                        \
+            _env_name, get_setting_name(_env_name), DESCRIPTION, TYPE{ INITIAL_VALUE }, \
+            std::set<std::string>{ "custom", "rocprofsys", "librocprof-sys",            \
+                                        __VA_ARGS__ });                                      \
+        if(!_ret.second)                                                                     \
+        {                                                                                    \
+            LOG_WARNING("Duplicate setting: {} / {}", get_setting_name(_env_name),           \
+                        _env_name);                                                          \
+        }                                                                                    \
+        return _config->find(_env_name)->second;                                             \
     }()
 
 template <typename Tp>
@@ -336,12 +340,12 @@ config_settings(const std::shared_ptr<settings>& _config)
     _domain_defaults.append(",page_migration");
 #endif
 
-    ROCPROFSYS_CONFIG_SETTING(std::string, "ROCPROFSYS_ROCM_DOMAINS", _domain_description,
+    ROCPROFSYS_CONFIG_SETTING(std::string, env_vars::ROCM_DOMAINS, _domain_description,
                               _domain_defaults, "rocm", "rocprofiler-sdk")
         ->set_choices(_domain_choices);
 
     ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_ROCM_EVENTS",
+        std::string, env_vars::ROCM_EVENTS,
         "ROCm hardware counters. Use ':device=N' syntax to specify collection on device "
         "number N, e.g. ':device=0'. If no device specification is provided, the event "
         "is collected on every available device",
@@ -368,7 +372,7 @@ config_settings(const std::shared_ptr<settings>& _config)
     if(_has_hip_stream)
     {
         ROCPROFSYS_CONFIG_SETTING(
-            bool, "ROCPROFSYS_ROCM_GROUP_BY_QUEUE",
+            bool, env_vars::ROCM_GROUP_BY_QUEUE,
             "By default, Perfetto trace will show the HIP streams to which kernel "
             "and memory copy operations submitted. With the "
             "`ROCPROFSYS_ROCM_GROUP_BY_QUEUE` option, the trace will display HSA queues "
@@ -414,11 +418,11 @@ get_callback_domains()
     }
 #endif
 
-    auto _data = std::unordered_set<rocprofiler_callback_tracing_kind_t>{};
-    auto _domains =
-        tim::delimit(config::get_setting_value<std::string>("ROCPROFSYS_ROCM_DOMAINS")
-                         .value_or(std::string{}),
-                     " ,;:\t\n");
+    auto _data    = std::unordered_set<rocprofiler_callback_tracing_kind_t>{};
+    auto _domains = tim::delimit(
+        config::get_setting_value<std::string>(std::string{ env_vars::ROCM_DOMAINS })
+            .value_or(std::string{}),
+        " ,;:\t\n");
 
     if(config::get_use_rcclp() && _version.formatted >= 600)
     {
@@ -436,7 +440,7 @@ get_callback_domains()
 
     // Check that the domains are valid
     const auto valid_choices =
-        settings::instance()->at("ROCPROFSYS_ROCM_DOMAINS")->get_choices();
+        settings::instance()->at(std::string{ env_vars::ROCM_DOMAINS })->get_choices();
 
     auto invalid_domain = [&valid_choices](const auto& domainv) {
         return !std::any_of(valid_choices.begin(), valid_choices.end(),
@@ -511,13 +515,13 @@ get_buffered_domains()
 #endif
     };
 
-    auto _data = std::unordered_set<rocprofiler_buffer_tracing_kind_t>{};
-    auto _domains =
-        tim::delimit(config::get_setting_value<std::string>("ROCPROFSYS_ROCM_DOMAINS")
-                         .value_or(std::string{}),
-                     " ,;:\t\n");
+    auto _data    = std::unordered_set<rocprofiler_buffer_tracing_kind_t>{};
+    auto _domains = tim::delimit(
+        config::get_setting_value<std::string>(std::string{ env_vars::ROCM_DOMAINS })
+            .value_or(std::string{}),
+        " ,;:\t\n");
     const auto valid_choices =
-        settings::instance()->at("ROCPROFSYS_ROCM_DOMAINS")->get_choices();
+        settings::instance()->at(std::string{ env_vars::ROCM_DOMAINS })->get_choices();
 
     auto invalid_domain = [&valid_choices](const auto& domainv) {
         return !std::any_of(valid_choices.begin(), valid_choices.end(),
@@ -655,7 +659,8 @@ std::vector<std::string>
 get_rocm_events()
 {
     return tim::delimit(
-        get_setting_value<std::string>("ROCPROFSYS_ROCM_EVENTS").value_or(std::string{}),
+        get_setting_value<std::string>(std::string{ env_vars::ROCM_EVENTS })
+            .value_or(std::string{}),
         " ,;\t\n");
 }
 

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/discovery.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/discovery.cpp
@@ -3,6 +3,7 @@
 
 #include "core/trace_cache/discovery.hpp"
 
+#include "common/env_vars.hpp"
 #include "core/config.hpp"
 #include "core/timemory.hpp"
 #include "core/trace_cache/cacheable.hpp"
@@ -143,7 +144,7 @@ merge_perfetto_files()
     auto _filename      = config::get_perfetto_output_filename();
     auto _output_folder = tim::filepath::dirname(_filename);
     auto _script_path   = std::string{ "rocprof-sys-merge-output.sh" };
-    auto _script_dir    = get_env("ROCPROFSYS_SCRIPT_PATH", std::string{});
+    auto _script_dir    = get_env(env_vars::SCRIPT_PATH, std::string{});
 
     if(!_script_dir.empty())
         _script_path = fmt::format("{}/{}", _script_dir, _script_path);

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/discovery.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/discovery.cpp
@@ -3,6 +3,7 @@
 
 #include "core/trace_cache/discovery.hpp"
 
+#include "common/env_vars.hpp"
 #include "core/config.hpp"
 #include "core/timemory.hpp"
 #include "core/trace_cache/cacheable.hpp"
@@ -143,7 +144,7 @@ merge_perfetto_files()
     auto _filename      = config::get_perfetto_output_filename();
     auto _output_folder = tim::filepath::dirname(_filename);
     auto _script_path   = std::string{ "rocprof-sys-merge-output.sh" };
-    auto _script_dir    = get_env("ROCPROFSYS_SCRIPT_PATH", std::string{}, false);
+    auto _script_dir    = get_env(env_vars::SCRIPT_PATH.data(), std::string{}, false);
 
     if(!_script_dir.empty())
         _script_path = fmt::format("{}/{}", _script_dir, _script_path);

--- a/projects/rocprofiler-systems/source/lib/logger/logger.hpp
+++ b/projects/rocprofiler-systems/source/lib/logger/logger.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "common/env_vars.hpp"
+
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>
@@ -63,10 +65,10 @@ parse_boolean_env(const char* env)
 struct logger_settings_t
 {
     logger_settings_t()
-    : m_log_level(log_level_from_env(std::getenv("ROCPROFSYS_LOG_LEVEL")))
-    , m_log_file(std::getenv("ROCPROFSYS_LOG_FILE"))
+    : m_log_level(log_level_from_env(std::getenv(env_vars::LOG_LEVEL.data())))
+    , m_log_file(std::getenv(env_vars::LOG_FILE.data()))
     {
-        const char* rocprofsys_monochrome_env = std::getenv("ROCPROFSYS_MONOCHROME");
+        const char* rocprofsys_monochrome_env = std::getenv(env_vars::MONOCHROME.data());
         const char* monochrome_env            = std::getenv("MONOCHROME");
         if(rocprofsys_monochrome_env || monochrome_env)
         {

--- a/projects/rocprofiler-systems/source/lib/logger/logger.hpp
+++ b/projects/rocprofiler-systems/source/lib/logger/logger.hpp
@@ -65,10 +65,10 @@ parse_boolean_env(const char* env)
 struct logger_settings_t
 {
     logger_settings_t()
-    : m_log_level(log_level_from_env(std::getenv(env_vars::LOG_LEVEL.data())))
-    , m_log_file(std::getenv(env_vars::LOG_FILE.data()))
+    : m_log_level(log_level_from_env(std::getenv(env_vars::LOG_LEVEL)))
+    , m_log_file(std::getenv(env_vars::LOG_FILE))
     {
-        const char* rocprofsys_monochrome_env = std::getenv(env_vars::MONOCHROME.data());
+        const char* rocprofsys_monochrome_env = std::getenv(env_vars::MONOCHROME);
         const char* monochrome_env            = std::getenv("MONOCHROME");
         if(rocprofsys_monochrome_env || monochrome_env)
         {

--- a/projects/rocprofiler-systems/source/lib/logger/logger.hpp
+++ b/projects/rocprofiler-systems/source/lib/logger/logger.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "common/env_vars.hpp"
+
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>
@@ -83,10 +85,10 @@ parse_boolean_env(const char* env)
 struct logger_settings_t
 {
     logger_settings_t()
-    : m_log_level(log_level_from_env(std::getenv("ROCPROFSYS_LOG_LEVEL")))
-    , m_log_file(std::getenv("ROCPROFSYS_LOG_FILE"))
+    : m_log_level(log_level_from_env(std::getenv(env_vars::LOG_LEVEL.data())))
+    , m_log_file(std::getenv(env_vars::LOG_FILE.data()))
     {
-        const char* rocprofsys_monochrome_env = std::getenv("ROCPROFSYS_MONOCHROME");
+        const char* rocprofsys_monochrome_env = std::getenv(env_vars::MONOCHROME.data());
         const char* monochrome_env            = std::getenv("MONOCHROME");
         if(rocprofsys_monochrome_env || monochrome_env)
         {

--- a/projects/rocprofiler-systems/source/lib/logger/tests/test_logger.cpp
+++ b/projects/rocprofiler-systems/source/lib/logger/tests/test_logger.cpp
@@ -282,8 +282,8 @@ TEST_F(logger_test, fork_resets_logger_in_child)
 
 TEST_F(logger_test, logger_settings_default_values)
 {
-    unsetenv(rocprofsys::env_vars::LOG_LEVEL.data());
-    unsetenv(rocprofsys::env_vars::LOG_FILE.data());
+    unsetenv(rocprofsys::env_vars::LOG_LEVEL);
+    unsetenv(rocprofsys::env_vars::LOG_FILE);
 
     rocprofsys::logger_settings_t settings;
 
@@ -293,21 +293,21 @@ TEST_F(logger_test, logger_settings_default_values)
 
 TEST_F(logger_test, logger_settings_with_env_vars)
 {
-    setenv(rocprofsys::env_vars::LOG_LEVEL.data(), "debug", 1);
-    setenv(rocprofsys::env_vars::LOG_FILE.data(), "/tmp/test.log", 1);
+    setenv(rocprofsys::env_vars::LOG_LEVEL, "debug", 1);
+    setenv(rocprofsys::env_vars::LOG_FILE, "/tmp/test.log", 1);
 
     rocprofsys::logger_settings_t settings;
 
     EXPECT_EQ(settings.get_log_level(), spdlog::level::debug);
     EXPECT_EQ(settings.get_log_file(), "/tmp/test.log");
 
-    unsetenv(rocprofsys::env_vars::LOG_LEVEL.data());
-    unsetenv(rocprofsys::env_vars::LOG_FILE.data());
+    unsetenv(rocprofsys::env_vars::LOG_LEVEL);
+    unsetenv(rocprofsys::env_vars::LOG_FILE);
 }
 
 TEST_F(logger_test, logger_settings_monochrome)
 {
-    setenv(rocprofsys::env_vars::MONOCHROME.data(), "1", 1);
+    setenv(rocprofsys::env_vars::MONOCHROME, "1", 1);
 
     rocprofsys::logger_settings_t settings;
     const auto*                   pattern = settings.get_log_pattern();
@@ -315,7 +315,7 @@ TEST_F(logger_test, logger_settings_monochrome)
     EXPECT_TRUE(std::string(pattern).find("%^") == std::string::npos);
     EXPECT_TRUE(std::string(pattern).find("%$") == std::string::npos);
 
-    unsetenv(rocprofsys::env_vars::MONOCHROME.data());
+    unsetenv(rocprofsys::env_vars::MONOCHROME);
 }
 
 TEST_F(logger_test, fork_child_creates_log_file_with_child_pid)
@@ -327,7 +327,7 @@ TEST_F(logger_test, fork_child_creates_log_file_with_child_pid)
     pid_t child_pid = fork();
     if(child_pid == 0)
     {
-        setenv(rocprofsys::env_vars::LOG_FILE.data(), test_log_file.c_str(), 1);
+        setenv(rocprofsys::env_vars::LOG_FILE, test_log_file.c_str(), 1);
 
         pid_t current_pid = getpid();
 
@@ -488,7 +488,7 @@ TEST_F(logger_test, parent_continues_logging_after_fork)
     std::string log_base = "/tmp/test_parent_post_fork";
     std::string log_file = log_base + ".log";
 
-    setenv(rocprofsys::env_vars::LOG_FILE.data(), log_file.c_str(), 1);
+    setenv(rocprofsys::env_vars::LOG_FILE, log_file.c_str(), 1);
 
     // Force a fresh logger with the file sink
     // (the singleton was already created without a file sink,
@@ -529,7 +529,7 @@ TEST_F(logger_test, parent_continues_logging_after_fork)
     auto& parent_logger = rocprofsys::logger_t::instance();
     EXPECT_NO_THROW(parent_logger.info("Parent logging after child completed"));
 
-    unsetenv(rocprofsys::env_vars::LOG_FILE.data());
+    unsetenv(rocprofsys::env_vars::LOG_FILE);
 }
 
 TEST_F(logger_test, fork_child_gets_new_logger_instance)

--- a/projects/rocprofiler-systems/source/lib/logger/tests/test_logger.cpp
+++ b/projects/rocprofiler-systems/source/lib/logger/tests/test_logger.cpp
@@ -3,6 +3,8 @@
 
 #include "logger/logger.hpp"
 
+#include "common/env_vars.hpp"
+
 #include <gtest/gtest.h>
 
 #include <sys/wait.h>
@@ -280,8 +282,8 @@ TEST_F(logger_test, fork_resets_logger_in_child)
 
 TEST_F(logger_test, logger_settings_default_values)
 {
-    unsetenv("ROCPROFSYS_LOG_LEVEL");
-    unsetenv("ROCPROFSYS_LOG_FILE");
+    unsetenv(rocprofsys::env_vars::LOG_LEVEL.data());
+    unsetenv(rocprofsys::env_vars::LOG_FILE.data());
 
     rocprofsys::logger_settings_t settings;
 
@@ -291,21 +293,21 @@ TEST_F(logger_test, logger_settings_default_values)
 
 TEST_F(logger_test, logger_settings_with_env_vars)
 {
-    setenv("ROCPROFSYS_LOG_LEVEL", "debug", 1);
-    setenv("ROCPROFSYS_LOG_FILE", "/tmp/test.log", 1);
+    setenv(rocprofsys::env_vars::LOG_LEVEL.data(), "debug", 1);
+    setenv(rocprofsys::env_vars::LOG_FILE.data(), "/tmp/test.log", 1);
 
     rocprofsys::logger_settings_t settings;
 
     EXPECT_EQ(settings.get_log_level(), spdlog::level::debug);
     EXPECT_EQ(settings.get_log_file(), "/tmp/test.log");
 
-    unsetenv("ROCPROFSYS_LOG_LEVEL");
-    unsetenv("ROCPROFSYS_LOG_FILE");
+    unsetenv(rocprofsys::env_vars::LOG_LEVEL.data());
+    unsetenv(rocprofsys::env_vars::LOG_FILE.data());
 }
 
 TEST_F(logger_test, logger_settings_monochrome)
 {
-    setenv("ROCPROFSYS_MONOCHROME", "1", 1);
+    setenv(rocprofsys::env_vars::MONOCHROME.data(), "1", 1);
 
     rocprofsys::logger_settings_t settings;
     const auto*                   pattern = settings.get_log_pattern();
@@ -313,7 +315,7 @@ TEST_F(logger_test, logger_settings_monochrome)
     EXPECT_TRUE(std::string(pattern).find("%^") == std::string::npos);
     EXPECT_TRUE(std::string(pattern).find("%$") == std::string::npos);
 
-    unsetenv("ROCPROFSYS_MONOCHROME");
+    unsetenv(rocprofsys::env_vars::MONOCHROME.data());
 }
 
 TEST_F(logger_test, fork_child_creates_log_file_with_child_pid)
@@ -325,7 +327,7 @@ TEST_F(logger_test, fork_child_creates_log_file_with_child_pid)
     pid_t child_pid = fork();
     if(child_pid == 0)
     {
-        setenv("ROCPROFSYS_LOG_FILE", test_log_file.c_str(), 1);
+        setenv(rocprofsys::env_vars::LOG_FILE.data(), test_log_file.c_str(), 1);
 
         pid_t current_pid = getpid();
 
@@ -486,7 +488,7 @@ TEST_F(logger_test, parent_continues_logging_after_fork)
     std::string log_base = "/tmp/test_parent_post_fork";
     std::string log_file = log_base + ".log";
 
-    setenv("ROCPROFSYS_LOG_FILE", log_file.c_str(), 1);
+    setenv(rocprofsys::env_vars::LOG_FILE.data(), log_file.c_str(), 1);
 
     // Force a fresh logger with the file sink
     // (the singleton was already created without a file sink,
@@ -527,7 +529,7 @@ TEST_F(logger_test, parent_continues_logging_after_fork)
     auto& parent_logger = rocprofsys::logger_t::instance();
     EXPECT_NO_THROW(parent_logger.info("Parent logging after child completed"));
 
-    unsetenv("ROCPROFSYS_LOG_FILE");
+    unsetenv(rocprofsys::env_vars::LOG_FILE.data());
 }
 
 TEST_F(logger_test, fork_child_gets_new_logger_instance)

--- a/projects/rocprofiler-systems/source/lib/logger/tests/test_logger.cpp
+++ b/projects/rocprofiler-systems/source/lib/logger/tests/test_logger.cpp
@@ -3,6 +3,8 @@
 
 #include "logger/logger.hpp"
 
+#include "common/env_vars.hpp"
+
 #include <gtest/gtest.h>
 
 #include <sys/wait.h>
@@ -274,8 +276,8 @@ TEST_F(logger_test, fork_resets_logger_in_child)
 
 TEST_F(logger_test, logger_settings_default_values)
 {
-    unsetenv("ROCPROFSYS_LOG_LEVEL");
-    unsetenv("ROCPROFSYS_LOG_FILE");
+    unsetenv(rocprofsys::env_vars::LOG_LEVEL.data());
+    unsetenv(rocprofsys::env_vars::LOG_FILE.data());
 
     rocprofsys::logger_settings_t settings;
 
@@ -285,21 +287,21 @@ TEST_F(logger_test, logger_settings_default_values)
 
 TEST_F(logger_test, logger_settings_with_env_vars)
 {
-    setenv("ROCPROFSYS_LOG_LEVEL", "debug", 1);
-    setenv("ROCPROFSYS_LOG_FILE", "/tmp/test.log", 1);
+    setenv(rocprofsys::env_vars::LOG_LEVEL.data(), "debug", 1);
+    setenv(rocprofsys::env_vars::LOG_FILE.data(), "/tmp/test.log", 1);
 
     rocprofsys::logger_settings_t settings;
 
     EXPECT_EQ(settings.get_log_level(), spdlog::level::debug);
     EXPECT_EQ(settings.get_log_file(), "/tmp/test.log");
 
-    unsetenv("ROCPROFSYS_LOG_LEVEL");
-    unsetenv("ROCPROFSYS_LOG_FILE");
+    unsetenv(rocprofsys::env_vars::LOG_LEVEL.data());
+    unsetenv(rocprofsys::env_vars::LOG_FILE.data());
 }
 
 TEST_F(logger_test, logger_settings_monochrome)
 {
-    setenv("ROCPROFSYS_MONOCHROME", "1", 1);
+    setenv(rocprofsys::env_vars::MONOCHROME.data(), "1", 1);
 
     rocprofsys::logger_settings_t settings;
     const auto*                   pattern = settings.get_log_pattern();
@@ -307,7 +309,7 @@ TEST_F(logger_test, logger_settings_monochrome)
     EXPECT_TRUE(std::string(pattern).find("%^") == std::string::npos);
     EXPECT_TRUE(std::string(pattern).find("%$") == std::string::npos);
 
-    unsetenv("ROCPROFSYS_MONOCHROME");
+    unsetenv(rocprofsys::env_vars::MONOCHROME.data());
 }
 
 TEST_F(logger_test, fork_child_creates_log_file_with_child_pid)
@@ -319,7 +321,7 @@ TEST_F(logger_test, fork_child_creates_log_file_with_child_pid)
     pid_t child_pid = fork();
     if(child_pid == 0)
     {
-        setenv("ROCPROFSYS_LOG_FILE", test_log_file.c_str(), 1);
+        setenv(rocprofsys::env_vars::LOG_FILE.data(), test_log_file.c_str(), 1);
 
         pid_t current_pid = getpid();
 
@@ -480,7 +482,7 @@ TEST_F(logger_test, parent_continues_logging_after_fork)
     std::string log_base = "/tmp/test_parent_post_fork";
     std::string log_file = log_base + ".log";
 
-    setenv("ROCPROFSYS_LOG_FILE", log_file.c_str(), 1);
+    setenv(rocprofsys::env_vars::LOG_FILE.data(), log_file.c_str(), 1);
 
     // Force a fresh logger with the file sink
     // (the singleton was already created without a file sink,
@@ -521,7 +523,7 @@ TEST_F(logger_test, parent_continues_logging_after_fork)
     auto& parent_logger = rocprofsys::logger_t::instance();
     EXPECT_NO_THROW(parent_logger.info("Parent logging after child completed"));
 
-    unsetenv("ROCPROFSYS_LOG_FILE");
+    unsetenv(rocprofsys::env_vars::LOG_FILE.data());
 }
 
 TEST_F(logger_test, fork_child_gets_new_logger_instance)

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys-dl/dl.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys-dl/dl.cpp
@@ -83,16 +83,16 @@ namespace
 inline int
 get_rocprofsys_env()
 {
-    auto&& _debug = get_env("ROCPROFSYS_DEBUG", false);
-    return get_env("ROCPROFSYS_VERBOSE", (_debug) ? 100 : 0);
+    auto&& _debug = get_env(env_vars::DEBUG_MODE, false);
+    return get_env(env_vars::VERBOSE, (_debug) ? 100 : 0);
 }
 
 inline int
 get_rocprofsys_dl_env()
 {
-    return get_env("ROCPROFSYS_DL_DEBUG", false)
+    return get_env(env_vars::DL_DEBUG, false)
                ? 100
-               : get_env("ROCPROFSYS_DL_VERBOSE", get_rocprofsys_env());
+               : get_env(env_vars::DL_VERBOSE, get_rocprofsys_env());
 }
 
 inline bool&
@@ -109,7 +109,7 @@ inline bool
 get_rocprofsys_preload()
 {
     static bool _v = []() {
-        auto&& _preload      = get_env("ROCPROFSYS_PRELOAD", true);
+        auto&& _preload      = get_env(env_vars::PRELOAD, true);
         auto&& _preload_libs = get_env("LD_PRELOAD", std::string{});
         return (_preload &&
                 _preload_libs.find("librocprof-sys-dl.so") != std::string::npos);
@@ -132,8 +132,8 @@ inline pid_t
 get_rocprofsys_root_pid()
 {
     auto _pid = getpid();
-    setenv("ROCPROFSYS_ROOT_PROCESS", std::to_string(_pid).c_str(), 0);
-    return get_env("ROCPROFSYS_ROOT_PROCESS", _pid);
+    setenv(env_vars::ROOT_PROCESS.data(), std::to_string(_pid).c_str(), 0);
+    return get_env(env_vars::ROOT_PROCESS, _pid);
 }
 
 void
@@ -474,9 +474,9 @@ get_indirect()
 {
     rocprofsys_preinit_library();
 
-    static auto  _libomni = get_env("ROCPROFSYS_LIBRARY", "librocprof-sys.so");
-    static auto  _libuser = get_env("ROCPROFSYS_USER_LIBRARY", "librocprof-sys-user.so");
-    static auto  _libdlib = get_env("ROCPROFSYS_DL_LIBRARY", "librocprof-sys-dl.so");
+    static auto  _libomni = get_env(env_vars::LIBRARY, "librocprof-sys.so");
+    static auto  _libuser = get_env(env_vars::USER_LIBRARY, "librocprof-sys-user.so");
+    static auto  _libdlib = get_env(env_vars::DL_LIBRARY, "librocprof-sys-dl.so");
     static auto* _v       = new indirect{ _libomni, _libuser, _libdlib };
     return *_v;
 }
@@ -512,7 +512,7 @@ get_user_api_active()
 auto&
 get_enabled()
 {
-    static auto* _v = new std::atomic<bool>{ get_env("ROCPROFSYS_INIT_ENABLED", true) };
+    static auto* _v = new std::atomic<bool>{ get_env(env_vars::INIT_ENABLED, true) };
     return *_v;
 }
 
@@ -540,7 +540,7 @@ get_thread_status()
 InstrumentMode&
 get_instrumented()
 {
-    static auto _v = get_env("ROCPROFSYS_INSTRUMENT_MODE", InstrumentMode::None);
+    static auto _v = get_env(env_vars::INSTRUMENT_MODE, InstrumentMode::None);
     return _v;
 }
 
@@ -587,7 +587,8 @@ extern "C"
 {
     void rocprofsys_preinit_library(void)
     {
-        if(rocprofsys::common::get_env("ROCPROFSYS_MONOCHROME", tim::log::monochrome()))
+        if(rocprofsys::common::get_env(rocprofsys::env_vars::MONOCHROME,
+                                       tim::log::monochrome()))
             tim::log::monochrome() = true;
     }
 
@@ -1183,7 +1184,7 @@ get_link_map(const char* _name, std::vector<int>&& _open_modes)
 const char*
 get_default_mode()
 {
-    if(get_env("ROCPROFSYS_USE_CAUSAL", false)) return "causal";
+    if(get_env(env_vars::USE_CAUSAL, false)) return "causal";
 
     auto _link_map = get_link_map(nullptr);
     for(const auto& itr : _link_map)
@@ -1206,10 +1207,10 @@ rocprofsys_preinit()
         case InstrumentMode::ProcessCreate:
         case InstrumentMode::ProcessAttach:
         {
-            auto _use_mpip = get_env("ROCPROFSYS_USE_MPIP", false);
-            auto _use_mpi  = get_env("ROCPROFSYS_USE_MPI", _use_mpip);
-            auto _causal   = get_env("ROCPROFSYS_USE_CAUSAL", false);
-            auto _mode     = get_env("ROCPROFSYS_MODE", get_default_mode());
+            auto _use_mpip = get_env(env_vars::USE_MPIP, false);
+            auto _use_mpi  = get_env(env_vars::USE_MPI, _use_mpip);
+            auto _causal   = get_env(env_vars::USE_CAUSAL, false);
+            auto _mode     = get_env(env_vars::MODE, get_default_mode());
 
             if(_use_mpi && !(_causal && _mode == "causal"))
             {
@@ -1264,11 +1265,11 @@ bool
 rocprofsys_preload()
 {
     auto _preload = get_rocprofsys_is_preloaded() && get_rocprofsys_preload() &&
-                    get_env("ROCPROFSYS_ENABLED", true);
+                    get_env(env_vars::ENABLED, true);
 
     auto _link_map = get_link_map(nullptr);
     auto _instr_mode =
-        get_env("ROCPROFSYS_INSTRUMENT_MODE", dl::InstrumentMode::BinaryRewrite);
+        get_env(env_vars::INSTRUMENT_MODE, dl::InstrumentMode::BinaryRewrite);
     for(const auto& itr : _link_map)
     {
         if(itr.find("librocprof-sys-rt.so") != std::string::npos ||
@@ -1552,7 +1553,7 @@ extern "C"
             }
         }
 
-        auto _mode = get_env("ROCPROFSYS_MODE", get_default_mode());
+        auto _mode = get_env(rocprofsys::env_vars::MODE, get_default_mode());
         rocprofsys_init(_mode.c_str(),
                         dl::get_instrumented() == dl::InstrumentMode::BinaryRewrite,
                         argv[0]);

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys-dl/dl.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys-dl/dl.cpp
@@ -132,7 +132,7 @@ inline pid_t
 get_rocprofsys_root_pid()
 {
     auto _pid = getpid();
-    setenv(env_vars::ROOT_PROCESS.data(), std::to_string(_pid).c_str(), 0);
+    setenv(env_vars::ROOT_PROCESS, std::to_string(_pid).c_str(), 0);
     return get_env(env_vars::ROOT_PROCESS, _pid);
 }
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys-dl/dl.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys-dl/dl.cpp
@@ -83,16 +83,16 @@ namespace
 inline int
 get_rocprofsys_env()
 {
-    auto&& _debug = get_env("ROCPROFSYS_DEBUG", false);
-    return get_env("ROCPROFSYS_VERBOSE", (_debug) ? 100 : 0);
+    auto&& _debug = get_env(env_vars::DEBUG_MODE, false);
+    return get_env(env_vars::VERBOSE, (_debug) ? 100 : 0);
 }
 
 inline int
 get_rocprofsys_dl_env()
 {
-    return get_env("ROCPROFSYS_DL_DEBUG", false)
+    return get_env(env_vars::DL_DEBUG, false)
                ? 100
-               : get_env("ROCPROFSYS_DL_VERBOSE", get_rocprofsys_env());
+               : get_env(env_vars::DL_VERBOSE, get_rocprofsys_env());
 }
 
 inline bool&
@@ -109,7 +109,7 @@ inline bool
 get_rocprofsys_preload()
 {
     static bool _v = []() {
-        auto&& _preload      = get_env("ROCPROFSYS_PRELOAD", true);
+        auto&& _preload      = get_env(env_vars::PRELOAD, true);
         auto&& _preload_libs = get_env("LD_PRELOAD", std::string{});
         return (_preload &&
                 _preload_libs.find("librocprof-sys-dl.so") != std::string::npos);
@@ -132,8 +132,8 @@ inline pid_t
 get_rocprofsys_root_pid()
 {
     auto _pid = getpid();
-    setenv("ROCPROFSYS_ROOT_PROCESS", std::to_string(_pid).c_str(), 0);
-    return get_env("ROCPROFSYS_ROOT_PROCESS", _pid);
+    setenv(env_vars::ROOT_PROCESS.data(), std::to_string(_pid).c_str(), 0);
+    return get_env(env_vars::ROOT_PROCESS, _pid);
 }
 
 void
@@ -471,9 +471,9 @@ get_indirect()
 {
     rocprofsys_preinit_library();
 
-    static auto  _libomni = get_env("ROCPROFSYS_LIBRARY", "librocprof-sys.so");
-    static auto  _libuser = get_env("ROCPROFSYS_USER_LIBRARY", "librocprof-sys-user.so");
-    static auto  _libdlib = get_env("ROCPROFSYS_DL_LIBRARY", "librocprof-sys-dl.so");
+    static auto  _libomni = get_env(env_vars::LIBRARY, "librocprof-sys.so");
+    static auto  _libuser = get_env(env_vars::USER_LIBRARY, "librocprof-sys-user.so");
+    static auto  _libdlib = get_env(env_vars::DL_LIBRARY, "librocprof-sys-dl.so");
     static auto* _v       = new indirect{ _libomni, _libuser, _libdlib };
     return *_v;
 }
@@ -509,7 +509,7 @@ get_user_api_active()
 auto&
 get_enabled()
 {
-    static auto* _v = new std::atomic<bool>{ get_env("ROCPROFSYS_INIT_ENABLED", true) };
+    static auto* _v = new std::atomic<bool>{ get_env(env_vars::INIT_ENABLED, true) };
     return *_v;
 }
 
@@ -537,7 +537,7 @@ get_thread_status()
 InstrumentMode&
 get_instrumented()
 {
-    static auto _v = get_env("ROCPROFSYS_INSTRUMENT_MODE", InstrumentMode::None);
+    static auto _v = get_env(env_vars::INSTRUMENT_MODE, InstrumentMode::None);
     return _v;
 }
 
@@ -584,7 +584,8 @@ extern "C"
 {
     void rocprofsys_preinit_library(void)
     {
-        if(rocprofsys::common::get_env("ROCPROFSYS_MONOCHROME", tim::log::monochrome()))
+        if(rocprofsys::common::get_env(rocprofsys::env_vars::MONOCHROME,
+                                       tim::log::monochrome()))
             tim::log::monochrome() = true;
     }
 
@@ -1159,7 +1160,7 @@ get_link_map(const char* _name, std::vector<int>&& _open_modes)
 const char*
 get_default_mode()
 {
-    if(get_env("ROCPROFSYS_USE_CAUSAL", false)) return "causal";
+    if(get_env(env_vars::USE_CAUSAL, false)) return "causal";
 
     auto _link_map = get_link_map(nullptr);
     for(const auto& itr : _link_map)
@@ -1182,10 +1183,10 @@ rocprofsys_preinit()
         case InstrumentMode::ProcessCreate:
         case InstrumentMode::ProcessAttach:
         {
-            auto _use_mpip = get_env("ROCPROFSYS_USE_MPIP", false);
-            auto _use_mpi  = get_env("ROCPROFSYS_USE_MPI", _use_mpip);
-            auto _causal   = get_env("ROCPROFSYS_USE_CAUSAL", false);
-            auto _mode     = get_env("ROCPROFSYS_MODE", get_default_mode());
+            auto _use_mpip = get_env(env_vars::USE_MPIP, false);
+            auto _use_mpi  = get_env(env_vars::USE_MPI, _use_mpip);
+            auto _causal   = get_env(env_vars::USE_CAUSAL, false);
+            auto _mode     = get_env(env_vars::MODE, get_default_mode());
 
             if(_use_mpi && !(_causal && _mode == "causal"))
             {
@@ -1240,11 +1241,11 @@ bool
 rocprofsys_preload()
 {
     auto _preload = get_rocprofsys_is_preloaded() && get_rocprofsys_preload() &&
-                    get_env("ROCPROFSYS_ENABLED", true);
+                    get_env(env_vars::ENABLED, true);
 
     auto _link_map = get_link_map(nullptr);
     auto _instr_mode =
-        get_env("ROCPROFSYS_INSTRUMENT_MODE", dl::InstrumentMode::BinaryRewrite);
+        get_env(env_vars::INSTRUMENT_MODE, dl::InstrumentMode::BinaryRewrite);
     for(const auto& itr : _link_map)
     {
         if(itr.find("librocprof-sys-rt.so") != std::string::npos ||
@@ -1528,7 +1529,7 @@ extern "C"
             }
         }
 
-        auto _mode = get_env("ROCPROFSYS_MODE", get_default_mode());
+        auto _mode = get_env(rocprofsys::env_vars::MODE, get_default_mode());
         rocprofsys_init(_mode.c_str(),
                         dl::get_instrumented() == dl::InstrumentMode::BinaryRewrite,
                         argv[0]);

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
@@ -1219,9 +1219,8 @@ rocprofsys_finalize_hidden(void)
                tim::cereal::make_nvp("memory_maps", _maps));
         });
 
-        static auto* attach_add_session_id =
-            getenv(env_vars::REATTACH_ADD_SESSION_ID.data());
-        static auto session_id = 0;
+        static auto* attach_add_session_id = getenv(env_vars::REATTACH_ADD_SESSION_ID);
+        static auto  session_id            = 0;
 
         if(attach_add_session_id)
             settings::default_process_suffix() = fmt::format("%pid%-{}", session_id++);

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
@@ -8,6 +8,7 @@
 //
 #include "api.hpp"
 #include "common/defines.h"
+#include "common/env_vars.hpp"
 #include "common/setup.hpp"
 #include "common/static_object.hpp"
 #include "core/agent.hpp"
@@ -213,7 +214,7 @@ ensure_finalization(bool _static_init = false)
         }
     }
 
-    if(common::get_env("ROCPROFSYS_MONOCHROME", false)) tim::log::monochrome() = true;
+    if(common::get_env(env_vars::MONOCHROME, false)) tim::log::monochrome() = true;
 
     timeout::setup();
 
@@ -233,7 +234,7 @@ ensure_finalization(bool _static_init = false)
         auto _verbose =
             get_verbose_env() + ((get_debug_env() || get_debug_init()) ? 16 : 0);
         auto _search_paths = fmt::format(
-            "{}:{}:{}:{}:{}", rocprofsys::get_env<std::string>("ROCPROFSYS_PATH", ""),
+            "{}:{}:{}:{}:{}", rocprofsys::get_env<std::string>(env_vars::PATH, ""),
             rocprofsys::get_env<std::string>("PWD"), ".",
             rocprofsys::get_env<std::string>("LD_LIBRARY_PATH", ""),
             rocprofsys::get_env<std::string>("LIBRARY_PATH", ""),
@@ -456,7 +457,7 @@ rocprofsys_set_mpi_hidden(bool use, bool attached)
 
     if(use && !attached && get_state() == State::PreInit)
     {
-        rocprofsys::set_env("ROCPROFSYS_USE_PID", "ON", 1);
+        rocprofsys::set_env(env_vars::USE_PID, "ON", 1);
     }
     else if(!use)
     {
@@ -559,9 +560,10 @@ rocprofsys_init_library_hidden()
     }
 
     auto _debug_value = get_debug();
-    if(_debug_init) config::set_setting_value("ROCPROFSYS_DEBUG", true);
+    if(_debug_init) config::set_setting_value(std::string{ env_vars::DEBUG_MODE }, true);
     scope::destructor _debug_dtor{ [_debug_value, _debug_init]() {
-        if(_debug_init) config::set_setting_value("ROCPROFSYS_DEBUG", _debug_value);
+        if(_debug_init)
+            config::set_setting_value(std::string{ env_vars::DEBUG_MODE }, _debug_value);
     } };
 }
 
@@ -570,9 +572,9 @@ rocprofsys_init_library_hidden()
 extern "C" bool
 rocprofsys_init_tooling_hidden(void)
 {
-    if(get_env("ROCPROFSYS_MONOCHROME", false)) tim::log::monochrome() = true;
+    if(get_env(env_vars::MONOCHROME, false)) tim::log::monochrome() = true;
 
-    if(!rocprofsys::get_env("ROCPROFSYS_INIT_TOOLING", true))
+    if(!rocprofsys::get_env(env_vars::INIT_TOOLING, true))
     {
         rocprofsys_init_library_hidden();
         return false;
@@ -865,7 +867,7 @@ rocprofsys_init_hidden(const char* _mode, bool _is_binary_rewrite, const char* _
                   (_is_binary_rewrite) ? "y" : "n", _argv0);
     }
 
-    rocprofsys::set_env("ROCPROFSYS_MODE", _mode, 0);
+    rocprofsys::set_env(env_vars::MODE, _mode, 0);
     config::is_binary_rewrite() = _is_binary_rewrite;
 
     if(_set_mpi_called)
@@ -879,7 +881,7 @@ rocprofsys_init_hidden(const char* _mode, bool _is_binary_rewrite, const char* _
 extern "C" void
 rocprofsys_reset_preload_hidden(void)
 {
-    rocprofsys::set_env("ROCPROFSYS_PRELOAD", "0", 1);
+    rocprofsys::set_env(env_vars::PRELOAD, "0", 1);
     auto&& _preload_libs = common::get_env("LD_PRELOAD", std::string{});
     if(_preload_libs.find("librocprof-sys") != std::string::npos)
     {
@@ -982,9 +984,10 @@ rocprofsys_finalize_hidden(void)
 
     auto _debug_init  = get_debug_finalize();
     auto _debug_value = get_debug();
-    if(_debug_init) config::set_setting_value("ROCPROFSYS_DEBUG", true);
+    if(_debug_init) config::set_setting_value(std::string{ env_vars::DEBUG_MODE }, true);
     scope::destructor _debug_dtor{ [_debug_value, _debug_init]() {
-        if(_debug_init) config::set_setting_value("ROCPROFSYS_DEBUG", _debug_value);
+        if(_debug_init)
+            config::set_setting_value(std::string{ env_vars::DEBUG_MODE }, _debug_value);
     } };
 
     auto& _thread_bundle = thread_data<thread_bundle_t>::instance();
@@ -995,7 +998,7 @@ rocprofsys_finalize_hidden(void)
         if(dmp::rank() == 0)
         {
             config::print_settings(
-                rocprofsys::get_env<bool>("ROCPROFSYS_PRINT_ENV", get_debug()));
+                rocprofsys::get_env<bool>(env_vars::PRINT_ENV, get_debug()));
         }
     }
 
@@ -1216,8 +1219,9 @@ rocprofsys_finalize_hidden(void)
                tim::cereal::make_nvp("memory_maps", _maps));
         });
 
-        static auto* attach_add_session_id = getenv("ROCPROFSYS_REATTACH_ADD_SESSION_ID");
-        static auto  session_id            = 0;
+        static auto* attach_add_session_id =
+            getenv(env_vars::REATTACH_ADD_SESSION_ID.data());
+        static auto session_id = 0;
 
         if(attach_add_session_id)
             settings::default_process_suffix() = fmt::format("%pid%-{}", session_id++);
@@ -1245,9 +1249,9 @@ rocprofsys_finalize_hidden(void)
 
         if(config::get_use_timemory())
         {
-            auto _components =
-                config::get_setting_value<std::string>("ROCPROFSYS_TIMEMORY_COMPONENTS")
-                    .value_or("wall_clock");
+            auto _components = config::get_setting_value<std::string>(
+                                   std::string{ env_vars::TIMEMORY_COMPONENTS })
+                                   .value_or("wall_clock");
 
             for(auto&& _comp_name : tim::delimit(_components, ",; "))
             {

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
@@ -8,6 +8,7 @@
 //
 #include "api.hpp"
 #include "common/defines.h"
+#include "common/env_vars.hpp"
 #include "common/setup.hpp"
 #include "common/static_object.hpp"
 #include "core/agent.hpp"
@@ -214,7 +215,7 @@ ensure_finalization(bool _static_init = false)
         }
     }
 
-    if(common::get_env("ROCPROFSYS_MONOCHROME", false)) tim::log::monochrome() = true;
+    if(common::get_env(env_vars::MONOCHROME, false)) tim::log::monochrome() = true;
 
     timeout::setup();
 
@@ -233,12 +234,12 @@ ensure_finalization(bool _static_init = false)
     {
         auto _verbose =
             get_verbose_env() + ((get_debug_env() || get_debug_init()) ? 16 : 0);
-        auto _search_paths = fmt::format("{}:{}:{}:{}:{}",
-                                         tim::get_env<std::string>("ROCPROFSYS_PATH", ""),
-                                         tim::get_env<std::string>("PWD"), ".",
-                                         tim::get_env<std::string>("LD_LIBRARY_PATH", ""),
-                                         tim::get_env<std::string>("LIBRARY_PATH", ""),
-                                         tim::get_env<std::string>("PATH", ""));
+        auto _search_paths = fmt::format(
+            "{}:{}:{}:{}:{}", tim::get_env<std::string>(env_vars::PATH.data(), ""),
+            tim::get_env<std::string>("PWD"), ".",
+            tim::get_env<std::string>("LD_LIBRARY_PATH", ""),
+            tim::get_env<std::string>("LIBRARY_PATH", ""),
+            tim::get_env<std::string>("PATH", ""));
         common::setup_environ(_verbose, _search_paths);
     }
 
@@ -457,7 +458,7 @@ rocprofsys_set_mpi_hidden(bool use, bool attached)
 
     if(use && !attached && get_state() == State::PreInit)
     {
-        tim::set_env("ROCPROFSYS_USE_PID", "ON", 1);
+        tim::set_env(env_vars::USE_PID.data(), "ON", 1);
     }
     else if(!use)
     {
@@ -548,9 +549,10 @@ rocprofsys_init_library_hidden()
     configure_settings();
 
     auto _debug_value = get_debug();
-    if(_debug_init) config::set_setting_value("ROCPROFSYS_DEBUG", true);
+    if(_debug_init) config::set_setting_value(std::string{ env_vars::DEBUG_MODE }, true);
     scope::destructor _debug_dtor{ [_debug_value, _debug_init]() {
-        if(_debug_init) config::set_setting_value("ROCPROFSYS_DEBUG", _debug_value);
+        if(_debug_init)
+            config::set_setting_value(std::string{ env_vars::DEBUG_MODE }, _debug_value);
     } };
 }
 
@@ -559,9 +561,9 @@ rocprofsys_init_library_hidden()
 extern "C" bool
 rocprofsys_init_tooling_hidden(void)
 {
-    if(get_env("ROCPROFSYS_MONOCHROME", false, false)) tim::log::monochrome() = true;
+    if(get_env(env_vars::MONOCHROME.data(), false, false)) tim::log::monochrome() = true;
 
-    if(!tim::get_env("ROCPROFSYS_INIT_TOOLING", true))
+    if(!tim::get_env(env_vars::INIT_TOOLING.data(), true))
     {
         rocprofsys_init_library_hidden();
         return false;
@@ -854,7 +856,7 @@ rocprofsys_init_hidden(const char* _mode, bool _is_binary_rewrite, const char* _
                   (_is_binary_rewrite) ? "y" : "n", _argv0);
     }
 
-    tim::set_env("ROCPROFSYS_MODE", _mode, 0);
+    tim::set_env(env_vars::MODE.data(), _mode, 0);
     config::is_binary_rewrite() = _is_binary_rewrite;
 
     if(_set_mpi_called)
@@ -868,7 +870,7 @@ rocprofsys_init_hidden(const char* _mode, bool _is_binary_rewrite, const char* _
 extern "C" void
 rocprofsys_reset_preload_hidden(void)
 {
-    tim::set_env("ROCPROFSYS_PRELOAD", "0", 1);
+    tim::set_env(env_vars::PRELOAD.data(), "0", 1);
     auto&& _preload_libs = common::get_env("LD_PRELOAD", std::string{});
     if(_preload_libs.find("librocprof-sys") != std::string::npos)
     {
@@ -971,9 +973,10 @@ rocprofsys_finalize_hidden(void)
 
     auto _debug_init  = get_debug_finalize();
     auto _debug_value = get_debug();
-    if(_debug_init) config::set_setting_value("ROCPROFSYS_DEBUG", true);
+    if(_debug_init) config::set_setting_value(std::string{ env_vars::DEBUG_MODE }, true);
     scope::destructor _debug_dtor{ [_debug_value, _debug_init]() {
-        if(_debug_init) config::set_setting_value("ROCPROFSYS_DEBUG", _debug_value);
+        if(_debug_init)
+            config::set_setting_value(std::string{ env_vars::DEBUG_MODE }, _debug_value);
     } };
 
     auto& _thread_bundle = thread_data<thread_bundle_t>::instance();
@@ -984,7 +987,7 @@ rocprofsys_finalize_hidden(void)
         if(dmp::rank() == 0)
         {
             config::print_settings(
-                tim::get_env<bool>("ROCPROFSYS_PRINT_ENV", get_debug()));
+                tim::get_env<bool>(env_vars::PRINT_ENV.data(), get_debug()));
         }
     }
 
@@ -1204,8 +1207,9 @@ rocprofsys_finalize_hidden(void)
                tim::cereal::make_nvp("memory_maps", _maps));
         });
 
-        static auto* attach_add_session_id = getenv("ROCPROFSYS_REATTACH_ADD_SESSION_ID");
-        static auto  session_id            = 0;
+        static auto* attach_add_session_id =
+            getenv(env_vars::REATTACH_ADD_SESSION_ID.data());
+        static auto session_id = 0;
 
         if(attach_add_session_id)
             settings::default_process_suffix() = fmt::format("%pid%-{}", session_id++);
@@ -1233,9 +1237,9 @@ rocprofsys_finalize_hidden(void)
 
         if(config::get_use_timemory())
         {
-            auto _components =
-                config::get_setting_value<std::string>("ROCPROFSYS_TIMEMORY_COMPONENTS")
-                    .value_or("wall_clock");
+            auto _components = config::get_setting_value<std::string>(
+                                   std::string{ env_vars::TIMEMORY_COMPONENTS })
+                                   .value_or("wall_clock");
 
             for(auto&& _comp_name : tim::delimit(_components, ",; "))
             {
@@ -1264,7 +1268,7 @@ rocprofsys_finalize_hidden(void)
     }
 
     if(_push_count > _pop_count &&
-       !get_env<bool>("ROCPROFSYS_CI_SKIP_PUSH_POP_CHECK", false, false))
+       !get_env<bool>(env_vars::CI_SKIP_PUSH_POP_CHECK.data(), false, false))
     {
         throw std::runtime_error(fmt::format(
             "rocprofsys_push_trace was called more times than "

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/data.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/data.cpp
@@ -7,6 +7,7 @@
 #include "binary/binary_info.hpp"
 #include "binary/link_map.hpp"
 #include "binary/scope_filter.hpp"
+#include "common/env_vars.hpp"
 #include "common/units.hpp"
 #include "core/binary/fwd.hpp"
 #include "core/config.hpp"
@@ -58,13 +59,14 @@ namespace
 using random_engine_t    = std::mt19937_64;
 using progress_bundles_t = component_bundle_cache<component::progress_point>;
 
-auto speedup_seeds     = std::vector<size_t>{};
-auto speedup_divisions = get_env<std::uint16_t>("ROCPROFSYS_CAUSAL_SPEEDUP_DIVISIONS", 5);
-auto speedup_dist      = []() {
+auto speedup_seeds = std::vector<size_t>{};
+auto speedup_divisions =
+    get_env<std::uint16_t>(env_vars::CAUSAL_SPEEDUP_DIVISIONS.data(), 5);
+auto speedup_dist = []() {
     size_t                     _n = std::max<size_t>(1, 100 / speedup_divisions);
     std::vector<std::uint16_t> _v(_n, std::uint16_t{ 0 });
     std::generate(_v.begin(), _v.end(),
-                       [_value = 0]() mutable { return (_value += speedup_divisions); });
+                  [_value = 0]() mutable { return (_value += speedup_divisions); });
     // approximately 25% of bins should be zero speedup
     size_t _nzero = std::ceil(_v.size() / 4.0);
     _v.resize(_v.size() + _nzero, 0);
@@ -92,9 +94,9 @@ auto&
 get_engine()
 {
     static auto _seed = []() -> hash_value_t {
-        auto _seed_v =
-            config::get_setting_value<std::uint64_t>("ROCPROFSYS_CAUSAL_RANDOM_SEED")
-                .value_or(0);
+        auto _seed_v = config::get_setting_value<std::uint64_t>(
+                           std::string{ env_vars::CAUSAL_RANDOM_SEED })
+                           .value_or(0);
         if(_seed_v == 0) _seed_v = std::random_device{}();
         return _seed_v;
     }();
@@ -134,7 +136,8 @@ get_filters(const std::set<binary::scope_filter::filter_scope>& _scopes = {
                                   "( main\\(|^main$|^main\\.cold$)" });
 
     bool _use_default_excludes =
-        config::get_setting_value<bool>("ROCPROFSYS_CAUSAL_FUNCTION_EXCLUDE_DEFAULTS")
+        config::get_setting_value<bool>(
+            std::string{ env_vars::CAUSAL_FUNCTION_EXCLUDE_DEFAULTS })
             .value_or(true);
 
     if(_use_default_excludes && _scopes.count(sf::FUNCTION_FILTER) > 0)
@@ -481,9 +484,11 @@ perform_experiment_impl(std::shared_ptr<std::promise<void>> _started)  // NOLINT
     std::this_thread::sleep_for(std::chrono::milliseconds{ 10 });
 
     double _delay_sec =
-        config::get_setting_value<double>("ROCPROFSYS_CAUSAL_DELAY").value_or(0.0);
+        config::get_setting_value<double>(std::string{ env_vars::CAUSAL_DELAY })
+            .value_or(0.0);
     double _duration_sec =
-        config::get_setting_value<double>("ROCPROFSYS_CAUSAL_DURATION").value_or(0.0);
+        config::get_setting_value<double>(std::string{ env_vars::CAUSAL_DURATION })
+            .value_or(0.0);
     auto _duration_nsec = duration_nsec_t{ _duration_sec * units::sec };
 
     if(_delay_sec > 0.0)
@@ -617,7 +622,7 @@ perform_experiment_impl(std::shared_ptr<std::promise<void>> _started)  // NOLINT
                 // if launched via rocprof-sys-causal, allow end-to-end runs that do not
                 // start experiments
                 auto _omni_causal_launcher =
-                    get_env<std::string>("ROCPROFSYS_LAUNCHER", "") ==
+                    get_env<std::string>(env_vars::LAUNCHER, "") ==
                     "rocprof-sys-causal";
 
                 if(!(get_causal_end_to_end() && _omni_causal_launcher))

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/data.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/data.cpp
@@ -59,14 +59,13 @@ namespace
 using random_engine_t    = std::mt19937_64;
 using progress_bundles_t = component_bundle_cache<component::progress_point>;
 
-auto speedup_seeds = std::vector<size_t>{};
-auto speedup_divisions =
-    get_env<std::uint16_t>(env_vars::CAUSAL_SPEEDUP_DIVISIONS.data(), 5);
-auto speedup_dist = []() {
+auto speedup_seeds     = std::vector<size_t>{};
+auto speedup_divisions = get_env<std::uint16_t>(env_vars::CAUSAL_SPEEDUP_DIVISIONS, 5);
+auto speedup_dist      = []() {
     size_t                     _n = std::max<size_t>(1, 100 / speedup_divisions);
     std::vector<std::uint16_t> _v(_n, std::uint16_t{ 0 });
     std::generate(_v.begin(), _v.end(),
-                  [_value = 0]() mutable { return (_value += speedup_divisions); });
+                       [_value = 0]() mutable { return (_value += speedup_divisions); });
     // approximately 25% of bins should be zero speedup
     size_t _nzero = std::ceil(_v.size() / 4.0);
     _v.resize(_v.size() + _nzero, 0);
@@ -622,8 +621,7 @@ perform_experiment_impl(std::shared_ptr<std::promise<void>> _started)  // NOLINT
                 // if launched via rocprof-sys-causal, allow end-to-end runs that do not
                 // start experiments
                 auto _omni_causal_launcher =
-                    get_env<std::string>(env_vars::LAUNCHER, "") ==
-                    "rocprof-sys-causal";
+                    get_env<std::string>(env_vars::LAUNCHER, "") == "rocprof-sys-causal";
 
                 if(!(get_causal_end_to_end() && _omni_causal_launcher))
                 {

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/data.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/data.cpp
@@ -7,6 +7,7 @@
 #include "binary/binary_info.hpp"
 #include "binary/link_map.hpp"
 #include "binary/scope_filter.hpp"
+#include "common/env_vars.hpp"
 #include "core/binary/fwd.hpp"
 #include "core/config.hpp"
 #include "core/containers/c_array.hpp"
@@ -58,13 +59,14 @@ namespace
 using random_engine_t    = std::mt19937_64;
 using progress_bundles_t = component_bundle_cache<component::progress_point>;
 
-auto speedup_seeds     = std::vector<size_t>{};
-auto speedup_divisions = get_env<std::uint16_t>("ROCPROFSYS_CAUSAL_SPEEDUP_DIVISIONS", 5);
-auto speedup_dist      = []() {
+auto speedup_seeds = std::vector<size_t>{};
+auto speedup_divisions =
+    get_env<std::uint16_t>(env_vars::CAUSAL_SPEEDUP_DIVISIONS.data(), 5);
+auto speedup_dist = []() {
     size_t                     _n = std::max<size_t>(1, 100 / speedup_divisions);
     std::vector<std::uint16_t> _v(_n, std::uint16_t{ 0 });
     std::generate(_v.begin(), _v.end(),
-                       [_value = 0]() mutable { return (_value += speedup_divisions); });
+                  [_value = 0]() mutable { return (_value += speedup_divisions); });
     // approximately 25% of bins should be zero speedup
     size_t _nzero = std::ceil(_v.size() / 4.0);
     _v.resize(_v.size() + _nzero, 0);
@@ -92,9 +94,9 @@ auto&
 get_engine()
 {
     static auto _seed = []() -> hash_value_t {
-        auto _seed_v =
-            config::get_setting_value<std::uint64_t>("ROCPROFSYS_CAUSAL_RANDOM_SEED")
-                .value_or(0);
+        auto _seed_v = config::get_setting_value<std::uint64_t>(
+                           std::string{ env_vars::CAUSAL_RANDOM_SEED })
+                           .value_or(0);
         if(_seed_v == 0) _seed_v = std::random_device{}();
         return _seed_v;
     }();
@@ -134,7 +136,8 @@ get_filters(const std::set<binary::scope_filter::filter_scope>& _scopes = {
                                   "( main\\(|^main$|^main\\.cold$)" });
 
     bool _use_default_excludes =
-        config::get_setting_value<bool>("ROCPROFSYS_CAUSAL_FUNCTION_EXCLUDE_DEFAULTS")
+        config::get_setting_value<bool>(
+            std::string{ env_vars::CAUSAL_FUNCTION_EXCLUDE_DEFAULTS })
             .value_or(true);
 
     if(_use_default_excludes && _scopes.count(sf::FUNCTION_FILTER) > 0)
@@ -481,9 +484,11 @@ perform_experiment_impl(std::shared_ptr<std::promise<void>> _started)  // NOLINT
     std::this_thread::sleep_for(std::chrono::milliseconds{ 10 });
 
     double _delay_sec =
-        config::get_setting_value<double>("ROCPROFSYS_CAUSAL_DELAY").value_or(0.0);
+        config::get_setting_value<double>(std::string{ env_vars::CAUSAL_DELAY })
+            .value_or(0.0);
     double _duration_sec =
-        config::get_setting_value<double>("ROCPROFSYS_CAUSAL_DURATION").value_or(0.0);
+        config::get_setting_value<double>(std::string{ env_vars::CAUSAL_DURATION })
+            .value_or(0.0);
     auto _duration_nsec = duration_nsec_t{ _duration_sec * units::sec };
 
     if(_delay_sec > 0.0)
@@ -617,7 +622,7 @@ perform_experiment_impl(std::shared_ptr<std::promise<void>> _started)  // NOLINT
                 // if launched via rocprof-sys-causal, allow end-to-end runs that do not
                 // start experiments
                 auto _omni_causal_launcher =
-                    get_env<std::string>("ROCPROFSYS_LAUNCHER", "", false) ==
+                    get_env<std::string>(env_vars::LAUNCHER.data(), "", false) ==
                     "rocprof-sys-causal";
 
                 if(!(get_causal_end_to_end() && _omni_causal_launcher))

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/experiment.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/experiment.cpp
@@ -55,7 +55,7 @@ auto         experiment_history        = std::vector<experiment>{};
 std::int64_t global_scaling            = 1;
 std::int64_t global_scaling_increments = 0;
 bool         use_exp_speedup_scaling =
-    get_env<bool>(env_vars::CAUSAL_SCALE_EXPERIMENT_TIME_BY_SPEEDUP.data(), false);
+    get_env<bool>(env_vars::CAUSAL_SCALE_EXPERIMENT_TIME_BY_SPEEDUP, false);
 }  // namespace
 
 experiment::sample::sample(const base_type& _b, std::uint64_t _c)

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/experiment.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/experiment.cpp
@@ -6,6 +6,7 @@
 #include "binary/dwarf_entry.hpp"
 #include "binary/symbol.hpp"
 #include "common/defines.h"
+#include "common/env_vars.hpp"
 #include "common/units.hpp"
 #include "core/config.hpp"
 #include "core/demangler.hpp"
@@ -54,7 +55,7 @@ auto         experiment_history        = std::vector<experiment>{};
 std::int64_t global_scaling            = 1;
 std::int64_t global_scaling_increments = 0;
 bool         use_exp_speedup_scaling =
-    get_env<bool>("ROCPROFSYS_CAUSAL_SCALE_EXPERIMENT_TIME_BY_SPEEDUP", false);
+    get_env<bool>(env_vars::CAUSAL_SCALE_EXPERIMENT_TIME_BY_SPEEDUP.data(), false);
 }  // namespace
 
 experiment::sample::sample(const base_type& _b, std::uint64_t _c)
@@ -517,7 +518,8 @@ experiment::save_experiments(std::string _fname_base, const filename_config_t& _
     }
 
     bool _causal_output_reset =
-        config::get_setting_value<bool>("ROCPROFSYS_CAUSAL_FILE_RESET").value_or(false);
+        config::get_setting_value<bool>(std::string{ env_vars::CAUSAL_FILE_RESET })
+            .value_or(false);
 
     {
         auto _saved_experiments = (_causal_output_reset)

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/experiment.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/experiment.cpp
@@ -6,6 +6,7 @@
 #include "binary/dwarf_entry.hpp"
 #include "binary/symbol.hpp"
 #include "common/defines.h"
+#include "common/env_vars.hpp"
 #include "core/config.hpp"
 #include "core/demangler.hpp"
 #include "core/state.hpp"
@@ -54,7 +55,7 @@ auto         experiment_history        = std::vector<experiment>{};
 std::int64_t global_scaling            = 1;
 std::int64_t global_scaling_increments = 0;
 bool         use_exp_speedup_scaling =
-    get_env<bool>("ROCPROFSYS_CAUSAL_SCALE_EXPERIMENT_TIME_BY_SPEEDUP", false);
+    get_env<bool>(env_vars::CAUSAL_SCALE_EXPERIMENT_TIME_BY_SPEEDUP.data(), false);
 }  // namespace
 
 experiment::sample::sample(const base_type& _b, std::uint64_t _c)
@@ -517,7 +518,8 @@ experiment::save_experiments(std::string _fname_base, const filename_config_t& _
     }
 
     bool _causal_output_reset =
-        config::get_setting_value<bool>("ROCPROFSYS_CAUSAL_FILE_RESET").value_or(false);
+        config::get_setting_value<bool>(std::string{ env_vars::CAUSAL_FILE_RESET })
+            .value_or(false);
 
     {
         auto _saved_experiments = (_causal_output_reset)

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/sampling.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/sampling.cpp
@@ -3,6 +3,7 @@
 
 #include "library/causal/sampling.hpp"
 #include "binary/analysis.hpp"
+#include "common/env_vars.hpp"
 #include "core/common.hpp"
 #include "core/concepts.hpp"
 #include "core/config.hpp"
@@ -322,7 +323,7 @@ configure(bool _setup, std::int64_t _tid)
             auto _perf_error = _activate_perf_backend();
             if(!_perf_error)
             {
-                config::set_setting_value("ROCPROFSYS_CAUSAL_BACKEND",
+                config::set_setting_value(std::string{ env_vars::CAUSAL_BACKEND },
                                           std::string{ "perf" });
             }
             else
@@ -336,7 +337,7 @@ configure(bool _setup, std::int64_t _tid)
                     std::exit(1);
                 }
 
-                config::set_setting_value("ROCPROFSYS_CAUSAL_BACKEND",
+                config::set_setting_value(std::string{ env_vars::CAUSAL_BACKEND },
                                           std::string{ "timer" });
             }
         }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/sampling.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/sampling.cpp
@@ -3,6 +3,7 @@
 
 #include "library/causal/sampling.hpp"
 #include "binary/analysis.hpp"
+#include "common/env_vars.hpp"
 #include "core/common.hpp"
 #include "core/concepts.hpp"
 #include "core/config.hpp"
@@ -323,7 +324,7 @@ configure(bool _setup, std::int64_t _tid)
             auto _perf_error = _activate_perf_backend();
             if(!_perf_error)
             {
-                config::set_setting_value("ROCPROFSYS_CAUSAL_BACKEND",
+                config::set_setting_value(std::string{ env_vars::CAUSAL_BACKEND },
                                           std::string{ "perf" });
             }
             else
@@ -337,7 +338,7 @@ configure(bool _setup, std::int64_t _tid)
                     std::exit(1);
                 }
 
-                config::set_setting_value("ROCPROFSYS_CAUSAL_BACKEND",
+                config::set_setting_value(std::string{ env_vars::CAUSAL_BACKEND },
                                           std::string{ "timer" });
             }
         }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/backtrace.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/backtrace.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
+#include "common/env_vars.hpp"
 #include "core/common.hpp"
 #include "core/components/fwd.hpp"
 #include "core/config.hpp"
@@ -111,7 +112,7 @@ backtrace::filter_and_patch(const std::vector<entry_type>& _data)
     };
 
     static bool _keep_suffix = rocprofsys::get_env<bool>(
-        "ROCPROFSYS_SAMPLING_KEEP_DYNINST_SUFFIX", get_debug_sampling());
+        env_vars::SAMPLING_KEEP_DYNINST_SUFFIX, get_debug_sampling());
 
     // in the dyninst binary rewrite runtime, instrumented functions are appended with
     // "_dyninst", i.e. "main" will show up as "main_dyninst" in the backtrace.

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/backtrace.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/backtrace.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
+#include "common/env_vars.hpp"
 #include "core/common.hpp"
 #include "core/components/fwd.hpp"
 #include "core/config.hpp"
@@ -113,7 +114,7 @@ backtrace::filter_and_patch(const std::vector<entry_type>& _data)
     };
 
     static bool _keep_suffix = tim::get_env<bool>(
-        "ROCPROFSYS_SAMPLING_KEEP_DYNINST_SUFFIX", get_debug_sampling());
+        env_vars::SAMPLING_KEEP_DYNINST_SUFFIX.data(), get_debug_sampling());
 
     // in the dyninst binary rewrite runtime, instrumented functions are appended with
     // "_dyninst", i.e. "main" will show up as "main_dyninst" in the backtrace.

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/fork_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/fork_gotcha.cpp
@@ -3,6 +3,7 @@
 
 #include "api.hpp"
 
+#include "common/env_vars.hpp"
 #include "core/config.hpp"
 #include "core/perfetto.hpp"
 #include "core/perfetto_fwd.hpp"
@@ -54,8 +55,8 @@ prefork_setup()
     if(get_state() < State::Active && !config::settings_are_configured())
         rocprofsys_init_library_hidden();
 
-    rocprofsys::set_env("ROCPROFSYS_PRELOAD", "0", 1);
-    rocprofsys::set_env("ROCPROFSYS_ROOT_PROCESS", process::get_id(), 0);
+    rocprofsys::set_env(env_vars::PRELOAD, "0", 1);
+    rocprofsys::set_env(env_vars::ROOT_PROCESS, process::get_id(), 0);
     rocprofsys_reset_preload_hidden();
     LOG_INFO("fork() called on PID {} (rank: {}), TID {}", process::get_id(), dmp::rank(),
              threading::get_id());

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/fork_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/fork_gotcha.cpp
@@ -3,6 +3,7 @@
 
 #include "api.hpp"
 
+#include "common/env_vars.hpp"
 #include "core/config.hpp"
 #include "core/perfetto.hpp"
 #include "core/perfetto_fwd.hpp"
@@ -54,8 +55,8 @@ prefork_setup()
     if(get_state() < State::Active && !config::settings_are_configured())
         rocprofsys_init_library_hidden();
 
-    tim::set_env("ROCPROFSYS_PRELOAD", "0", 1);
-    tim::set_env("ROCPROFSYS_ROOT_PROCESS", process::get_id(), 0);
+    tim::set_env(env_vars::PRELOAD.data(), "0", 1);
+    tim::set_env(env_vars::ROOT_PROCESS.data(), process::get_id(), 0);
     rocprofsys_reset_preload_hidden();
     LOG_INFO("fork() called on PID {} (rank: {}), TID {}", process::get_id(), dmp::rank(),
              threading::get_id());

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpi_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpi_gotcha.cpp
@@ -3,6 +3,7 @@
 
 #include "library/components/mpi_gotcha.hpp"
 #include "api.hpp"
+#include "common/env_vars.hpp"
 #include "core/components/fwd.hpp"
 #include "core/config.hpp"
 #include "core/mpi.hpp"
@@ -396,7 +397,7 @@ mpi_gotcha::audit(const gotcha_data_t& _data, audit::outgoing, int _retval)
             {
                 static thread_local int _num_updates = 0;
                 static int              _disable_after =
-                    rocprofsys::get_env<int>("ROCPROFSYS_MPI_MAX_COMM_UPDATES", 4);
+                    rocprofsys::get_env<int>(env_vars::MPI_MAX_COMM_UPDATES, 4);
                 if(_num_updates++ < _disable_after) update();
             }
         }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpi_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpi_gotcha.cpp
@@ -3,6 +3,7 @@
 
 #include "library/components/mpi_gotcha.hpp"
 #include "api.hpp"
+#include "common/env_vars.hpp"
 #include "core/components/fwd.hpp"
 #include "core/config.hpp"
 #include "core/mpi.hpp"
@@ -396,7 +397,7 @@ mpi_gotcha::audit(const gotcha_data_t& _data, audit::outgoing, int _retval)
             {
                 static thread_local int _num_updates = 0;
                 static int              _disable_after =
-                    tim::get_env<int>("ROCPROFSYS_MPI_MAX_COMM_UPDATES", 4);
+                    tim::get_env<int>(env_vars::MPI_MAX_COMM_UPDATES.data(), 4);
                 if(_num_updates++ < _disable_after) update();
             }
         }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/shmem_gotcha.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/shmem_gotcha.hpp
@@ -7,6 +7,7 @@
 #include <timemory/utility/types.hpp>
 
 #include "common/delimit.hpp"
+#include "common/env_vars.hpp"
 #include "common/environment.hpp"
 
 #include <cstddef>
@@ -471,7 +472,7 @@ shmem_gotcha<SHMEMPolicy>::configure()
     shmem_gotcha_t::get_reject_list() = []() {
         std::set<std::string> tokens;
         auto                  reject_list =
-            rocprofsys::common::get_env<std::string>("ROCPROFSYS_SHMEM_REJECT_LIST", "");
+            rocprofsys::common::get_env<std::string>(env_vars::SHMEM_REJECT_LIST, "");
         for(const auto& itr : rocprofsys::common::delimit(reject_list))
             tokens.insert(itr);
         return shmem_categories::expand_tokens_to_apis(tokens);
@@ -483,7 +484,7 @@ shmem_gotcha<SHMEMPolicy>::configure()
     // Set to "all" to permit every bound API; or list categories/APIs to trace.
     shmem_gotcha_t::get_permit_list() = []() {
         auto permit_list =
-            rocprofsys::common::get_env<std::string>("ROCPROFSYS_SHMEM_PERMIT_LIST", "");
+            rocprofsys::common::get_env<std::string>(env_vars::SHMEM_PERMIT_LIST, "");
         std::set<std::string> tokens;
         for(const auto& itr : rocprofsys::common::delimit(permit_list))
             tokens.insert(itr);

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/tests/test_shmem_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/tests/test_shmem_gotcha.cpp
@@ -182,8 +182,8 @@ protected:
 
     void TearDown() override
     {
-        unsetenv(rocprofsys::env_vars::SHMEM_REJECT_LIST.data());
-        unsetenv(rocprofsys::env_vars::SHMEM_PERMIT_LIST.data());
+        unsetenv(rocprofsys::env_vars::SHMEM_REJECT_LIST);
+        unsetenv(rocprofsys::env_vars::SHMEM_PERMIT_LIST);
         test_globals::g_shmem_gotcha_gmock.reset();
         test_globals::g_comm_data_gmock.reset();
         test_globals::g_category_region_gmock.reset();
@@ -199,8 +199,8 @@ TEST_F(shmem_gotcha_test, test_static_labels)
 
 TEST_F(shmem_gotcha_test, test_component_lifecycle)
 {
-    setenv(rocprofsys::env_vars::SHMEM_REJECT_LIST.data(), "", 1);
-    setenv(rocprofsys::env_vars::SHMEM_PERMIT_LIST.data(), "all", 1);
+    setenv(rocprofsys::env_vars::SHMEM_REJECT_LIST, "", 1);
+    setenv(rocprofsys::env_vars::SHMEM_PERMIT_LIST, "all", 1);
     std::function<void()> initializer;
 
     EXPECT_CALL(*test_globals::g_shmem_gotcha_gmock, get_is_running())
@@ -414,8 +414,8 @@ TEST_F(shmem_gotcha_test, test_expand_tokens_to_apis)
 
 TEST_F(shmem_gotcha_test, test_configure_function_names)
 {
-    unsetenv(rocprofsys::env_vars::SHMEM_REJECT_LIST.data());
-    setenv(rocprofsys::env_vars::SHMEM_PERMIT_LIST.data(), "all", 1);
+    unsetenv(rocprofsys::env_vars::SHMEM_REJECT_LIST);
+    setenv(rocprofsys::env_vars::SHMEM_PERMIT_LIST, "all", 1);
     std::function<void()>    initializer;
     std::vector<std::string> configured_names;
 
@@ -465,9 +465,8 @@ TEST_F(shmem_gotcha_test, test_get_reject_list_assignable_and_invokable)
 
 TEST_F(shmem_gotcha_test, test_reject_list_excludes_from_configure)
 {
-    setenv(rocprofsys::env_vars::SHMEM_REJECT_LIST.data(), "shmem_init,shmem_finalize",
-           1);
-    setenv(rocprofsys::env_vars::SHMEM_PERMIT_LIST.data(), "all", 1);
+    setenv(rocprofsys::env_vars::SHMEM_REJECT_LIST, "shmem_init,shmem_finalize", 1);
+    setenv(rocprofsys::env_vars::SHMEM_PERMIT_LIST, "all", 1);
 
     std::function<void()>    initializer;
     std::vector<std::string> configured_names;
@@ -498,14 +497,14 @@ TEST_F(shmem_gotcha_test, test_reject_list_excludes_from_configure)
         std::find(configured_names.begin(), configured_names.end(), "shmem_finalize"));
     EXPECT_EQ(configured_names.size(), static_cast<size_t>(NUMBER_OF_FUNCTIONS - 2));
 
-    unsetenv(rocprofsys::env_vars::SHMEM_REJECT_LIST.data());
-    unsetenv(rocprofsys::env_vars::SHMEM_PERMIT_LIST.data());
+    unsetenv(rocprofsys::env_vars::SHMEM_REJECT_LIST);
+    unsetenv(rocprofsys::env_vars::SHMEM_PERMIT_LIST);
 }
 
 TEST_F(shmem_gotcha_test, test_permit_list_restricts_configure)
 {
-    setenv(rocprofsys::env_vars::SHMEM_REJECT_LIST.data(), "", 1);
-    setenv(rocprofsys::env_vars::SHMEM_PERMIT_LIST.data(), "shmem_put32,shmem_get32", 1);
+    setenv(rocprofsys::env_vars::SHMEM_REJECT_LIST, "", 1);
+    setenv(rocprofsys::env_vars::SHMEM_PERMIT_LIST, "shmem_put32,shmem_get32", 1);
 
     std::function<void()>    initializer;
     std::vector<std::string> configured_names;
@@ -535,8 +534,8 @@ TEST_F(shmem_gotcha_test, test_permit_list_restricts_configure)
     EXPECT_NE(configured_names.end(),
               std::find(configured_names.begin(), configured_names.end(), "shmem_get32"));
 
-    unsetenv(rocprofsys::env_vars::SHMEM_REJECT_LIST.data());
-    unsetenv(rocprofsys::env_vars::SHMEM_PERMIT_LIST.data());
+    unsetenv(rocprofsys::env_vars::SHMEM_REJECT_LIST);
+    unsetenv(rocprofsys::env_vars::SHMEM_PERMIT_LIST);
 }
 
 TEST_F(shmem_gotcha_test, test_get_permit_list_assignable_and_invokable)

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/tests/test_shmem_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/tests/test_shmem_gotcha.cpp
@@ -3,6 +3,8 @@
 
 #include "rocprof-sys/library/components/shmem_gotcha.hpp"
 
+#include "common/env_vars.hpp"
+
 #include <algorithm>
 #include <cstdlib>
 #include <functional>
@@ -180,8 +182,8 @@ protected:
 
     void TearDown() override
     {
-        unsetenv("ROCPROFSYS_SHMEM_REJECT_LIST");
-        unsetenv("ROCPROFSYS_SHMEM_PERMIT_LIST");
+        unsetenv(rocprofsys::env_vars::SHMEM_REJECT_LIST.data());
+        unsetenv(rocprofsys::env_vars::SHMEM_PERMIT_LIST.data());
         test_globals::g_shmem_gotcha_gmock.reset();
         test_globals::g_comm_data_gmock.reset();
         test_globals::g_category_region_gmock.reset();
@@ -197,8 +199,8 @@ TEST_F(shmem_gotcha_test, test_static_labels)
 
 TEST_F(shmem_gotcha_test, test_component_lifecycle)
 {
-    setenv("ROCPROFSYS_SHMEM_REJECT_LIST", "", 1);
-    setenv("ROCPROFSYS_SHMEM_PERMIT_LIST", "all", 1);
+    setenv(rocprofsys::env_vars::SHMEM_REJECT_LIST.data(), "", 1);
+    setenv(rocprofsys::env_vars::SHMEM_PERMIT_LIST.data(), "all", 1);
     std::function<void()> initializer;
 
     EXPECT_CALL(*test_globals::g_shmem_gotcha_gmock, get_is_running())
@@ -412,8 +414,8 @@ TEST_F(shmem_gotcha_test, test_expand_tokens_to_apis)
 
 TEST_F(shmem_gotcha_test, test_configure_function_names)
 {
-    unsetenv("ROCPROFSYS_SHMEM_REJECT_LIST");
-    setenv("ROCPROFSYS_SHMEM_PERMIT_LIST", "all", 1);
+    unsetenv(rocprofsys::env_vars::SHMEM_REJECT_LIST.data());
+    setenv(rocprofsys::env_vars::SHMEM_PERMIT_LIST.data(), "all", 1);
     std::function<void()>    initializer;
     std::vector<std::string> configured_names;
 
@@ -463,8 +465,9 @@ TEST_F(shmem_gotcha_test, test_get_reject_list_assignable_and_invokable)
 
 TEST_F(shmem_gotcha_test, test_reject_list_excludes_from_configure)
 {
-    setenv("ROCPROFSYS_SHMEM_REJECT_LIST", "shmem_init,shmem_finalize", 1);
-    setenv("ROCPROFSYS_SHMEM_PERMIT_LIST", "all", 1);
+    setenv(rocprofsys::env_vars::SHMEM_REJECT_LIST.data(), "shmem_init,shmem_finalize",
+           1);
+    setenv(rocprofsys::env_vars::SHMEM_PERMIT_LIST.data(), "all", 1);
 
     std::function<void()>    initializer;
     std::vector<std::string> configured_names;
@@ -495,14 +498,14 @@ TEST_F(shmem_gotcha_test, test_reject_list_excludes_from_configure)
         std::find(configured_names.begin(), configured_names.end(), "shmem_finalize"));
     EXPECT_EQ(configured_names.size(), static_cast<size_t>(NUMBER_OF_FUNCTIONS - 2));
 
-    unsetenv("ROCPROFSYS_SHMEM_REJECT_LIST");
-    unsetenv("ROCPROFSYS_SHMEM_PERMIT_LIST");
+    unsetenv(rocprofsys::env_vars::SHMEM_REJECT_LIST.data());
+    unsetenv(rocprofsys::env_vars::SHMEM_PERMIT_LIST.data());
 }
 
 TEST_F(shmem_gotcha_test, test_permit_list_restricts_configure)
 {
-    setenv("ROCPROFSYS_SHMEM_REJECT_LIST", "", 1);
-    setenv("ROCPROFSYS_SHMEM_PERMIT_LIST", "shmem_put32,shmem_get32", 1);
+    setenv(rocprofsys::env_vars::SHMEM_REJECT_LIST.data(), "", 1);
+    setenv(rocprofsys::env_vars::SHMEM_PERMIT_LIST.data(), "shmem_put32,shmem_get32", 1);
 
     std::function<void()>    initializer;
     std::vector<std::string> configured_names;
@@ -532,8 +535,8 @@ TEST_F(shmem_gotcha_test, test_permit_list_restricts_configure)
     EXPECT_NE(configured_names.end(),
               std::find(configured_names.begin(), configured_names.end(), "shmem_get32"));
 
-    unsetenv("ROCPROFSYS_SHMEM_REJECT_LIST");
-    unsetenv("ROCPROFSYS_SHMEM_PERMIT_LIST");
+    unsetenv(rocprofsys::env_vars::SHMEM_REJECT_LIST.data());
+    unsetenv(rocprofsys::env_vars::SHMEM_PERMIT_LIST.data());
 }
 
 TEST_F(shmem_gotcha_test, test_get_permit_list_assignable_and_invokable)

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/coverage.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/coverage.cpp
@@ -3,6 +3,7 @@
 
 #include "library/coverage.hpp"
 #include "api.hpp"
+#include "common/env_vars.hpp"
 #include "core/config.hpp"
 #include "library/coverage/impl.hpp"
 #include "library/thread_data.hpp"
@@ -204,8 +205,8 @@ post_process()
         return _b.value_or(true);
     };
 
-    auto _text_output = _get_setting("ROCPROFSYS_TEXT_OUTPUT");
-    auto _json_output = _get_setting("ROCPROFSYS_JSON_OUTPUT");
+    auto _text_output = _get_setting(std::string{ env_vars::TEXT_OUTPUT });
+    auto _json_output = _get_setting(std::string{ env_vars::JSON_OUTPUT });
 
     if(_text_output)
     {

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/kokkosp.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/kokkosp.cpp
@@ -8,6 +8,7 @@
 
 #include "api.hpp"
 #include "common/defines.h"
+#include "common/env_vars.hpp"
 #include "core/agent_manager.hpp"
 #include "core/components/fwd.hpp"
 #include "core/config.hpp"
@@ -251,7 +252,7 @@ extern "C"
                 _command_line.append(" ").append(argv[i]);
             }
             if(_command_line.length() > 1) _command_line = _command_line.substr(1);
-            rocprofsys::set_env("ROCPROFSYS_COMMAND_LINE", _command_line, 0);
+            rocprofsys::set_env(rocprofsys::env_vars::COMMAND_LINE, _command_line, 0);
         }
     }
 
@@ -317,7 +318,8 @@ extern "C"
             }
 
             LOG_DEBUG("Initializing rocprof-sys (standalone)... ");
-            auto _mode = rocprofsys::get_env<std::string>("ROCPROFSYS_MODE", "trace");
+            auto _mode =
+                rocprofsys::get_env<std::string>(rocprofsys::env_vars::MODE, "trace");
             auto _arg0 = (_initialize_arguments.empty()) ? std::string{ "unknown" }
                                                          : _initialize_arguments.at(0);
 
@@ -337,16 +339,17 @@ extern "C"
 
         LOG_DEBUG("Done");
 
-        _name_len_limit = rocprofsys::config::get_setting_value<std::int64_t>(
-                              "ROCPROFSYS_KOKKOSP_NAME_LENGTH_MAX")
-                              .value_or(_name_len_limit);
+        _name_len_limit =
+            rocprofsys::config::get_setting_value<std::int64_t>(
+                std::string{ rocprofsys::env_vars::KOKKOSP_NAME_LENGTH_MAX })
+                .value_or(_name_len_limit);
         _kp_prefix = rocprofsys::config::get_setting_value<std::string>(
-                         "ROCPROFSYS_KOKKOSP_PREFIX")
+                         std::string{ rocprofsys::env_vars::KOKKOSP_PREFIX })
                          .value_or(_kp_prefix);
 
-        _kp_deep_copy =
-            rocprofsys::config::get_setting_value<bool>("ROCPROFSYS_KOKKOSP_DEEP_COPY")
-                .value_or(_kp_deep_copy);
+        _kp_deep_copy = rocprofsys::config::get_setting_value<bool>(
+                            std::string{ rocprofsys::env_vars::KOKKOSP_DEEP_COPY })
+                            .value_or(_kp_deep_copy);
     }
 
     void kokkosp_finalize_library()

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/kokkosp.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/kokkosp.cpp
@@ -8,6 +8,7 @@
 
 #include "api.hpp"
 #include "common/defines.h"
+#include "common/env_vars.hpp"
 #include "core/agent_manager.hpp"
 #include "core/components/fwd.hpp"
 #include "core/config.hpp"
@@ -251,7 +252,7 @@ extern "C"
                 _command_line.append(" ").append(argv[i]);
             }
             if(_command_line.length() > 1) _command_line = _command_line.substr(1);
-            tim::set_env("ROCPROFSYS_COMMAND_LINE", _command_line, 0);
+            tim::set_env(rocprofsys::env_vars::COMMAND_LINE.data(), _command_line, 0);
         }
     }
 
@@ -316,7 +317,8 @@ extern "C"
             }
 
             LOG_DEBUG("Initializing rocprof-sys (standalone)... ");
-            auto _mode = tim::get_env<std::string>("ROCPROFSYS_MODE", "trace");
+            auto _mode =
+                tim::get_env<std::string>(rocprofsys::env_vars::MODE.data(), "trace");
             auto _arg0 = (_initialize_arguments.empty()) ? std::string{ "unknown" }
                                                          : _initialize_arguments.at(0);
 
@@ -336,16 +338,17 @@ extern "C"
 
         LOG_DEBUG("Done");
 
-        _name_len_limit = rocprofsys::config::get_setting_value<std::int64_t>(
-                              "ROCPROFSYS_KOKKOSP_NAME_LENGTH_MAX")
-                              .value_or(_name_len_limit);
+        _name_len_limit =
+            rocprofsys::config::get_setting_value<std::int64_t>(
+                std::string{ rocprofsys::env_vars::KOKKOSP_NAME_LENGTH_MAX })
+                .value_or(_name_len_limit);
         _kp_prefix = rocprofsys::config::get_setting_value<std::string>(
-                         "ROCPROFSYS_KOKKOSP_PREFIX")
+                         std::string{ rocprofsys::env_vars::KOKKOSP_PREFIX })
                          .value_or(_kp_prefix);
 
-        _kp_deep_copy =
-            rocprofsys::config::get_setting_value<bool>("ROCPROFSYS_KOKKOSP_DEEP_COPY")
-                .value_or(_kp_deep_copy);
+        _kp_deep_copy = rocprofsys::config::get_setting_value<bool>(
+                            std::string{ rocprofsys::env_vars::KOKKOSP_DEEP_COPY })
+                            .value_or(_kp_deep_copy);
     }
 
     void kokkosp_finalize_library()

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/common/settings.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/common/settings.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "common/env_vars.hpp"
 #include "core/config.hpp"
 #include "library/pmc/collectors/cpu/types.hpp"
 #include "library/pmc/collectors/gpu/types.hpp"
@@ -88,7 +89,8 @@ struct settings_policy
     static gpu::enabled_metrics get_enabled_metrics() noexcept
     {
         static auto _enabled_metrics = []() {
-            auto setting   = get_setting_value<std::string>("ROCPROFSYS_AMD_SMI_METRICS");
+            auto setting =
+                get_setting_value<std::string>(std::string{ env_vars::AMD_SMI_METRICS });
             auto value_str = setting.has_value() ? setting.value() : "all";
             auto result    = parse_enabled_metrics(value_str);
             return result;
@@ -106,7 +108,8 @@ struct settings_policy
      */
     static nic::nic_device_filter get_nic_device_filter() noexcept
     {
-        auto filter = get_setting_value<std::string>("ROCPROFSYS_SAMPLING_AINICS");
+        auto filter =
+            get_setting_value<std::string>(std::string{ env_vars::SAMPLING_AINICS });
         if(!filter.has_value())
         {
             // NIC sampling disabled by default
@@ -158,7 +161,8 @@ struct settings_policy
     static cpu::enabled_metrics get_cpu_enabled_metrics()
     {
         static auto _result = []() {
-            auto       setting = get_setting_value<std::string>("ROCPROFSYS_CPU_METRICS");
+            auto setting =
+                get_setting_value<std::string>(std::string{ env_vars::CPU_METRICS });
             const auto value_str = setting.has_value() ? setting.value() : "all";
             return parse_cpu_enabled_metrics(value_str);
         }();

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/common/settings.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/common/settings.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "common/env_vars.hpp"
 #include "core/config.hpp"
 #include "library/pmc/collectors/cpu/types.hpp"
 #include "library/pmc/collectors/gpu/types.hpp"
@@ -81,7 +82,8 @@ struct settings_policy
     static gpu::enabled_metrics get_enabled_metrics() noexcept
     {
         static auto _enabled_metrics = []() {
-            auto setting   = get_setting_value<std::string>("ROCPROFSYS_AMD_SMI_METRICS");
+            auto setting =
+                get_setting_value<std::string>(std::string{ env_vars::AMD_SMI_METRICS });
             auto value_str = setting.has_value() ? setting.value() : "all";
             auto result    = parse_enabled_metrics(value_str);
             return result;
@@ -99,7 +101,8 @@ struct settings_policy
      */
     static nic::nic_device_filter get_nic_device_filter() noexcept
     {
-        auto filter = get_setting_value<std::string>("ROCPROFSYS_SAMPLING_AINICS");
+        auto filter =
+            get_setting_value<std::string>(std::string{ env_vars::SAMPLING_AINICS });
         if(!filter.has_value())
         {
             // NIC sampling disabled by default
@@ -151,7 +154,8 @@ struct settings_policy
     static cpu::enabled_metrics get_cpu_enabled_metrics()
     {
         static auto _result = []() {
-            auto       setting = get_setting_value<std::string>("ROCPROFSYS_CPU_METRICS");
+            auto setting =
+                get_setting_value<std::string>(std::string{ env_vars::CPU_METRICS });
             const auto value_str = setting.has_value() ? setting.value() : "all";
             return parse_cpu_enabled_metrics(value_str);
         }();

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -4,6 +4,7 @@
 #include "core/rocprofiler-sdk.hpp"
 #include "api.hpp"
 #include "binary/analysis.hpp"
+#include "common/env_vars.hpp"
 #include "common/synchronized.hpp"
 #include "core/common.hpp"
 #include "core/common_types.hpp"
@@ -95,10 +96,10 @@ get_roctx_client()
 {
     if(!g_roctx_client)
     {
-        const auto _domains =
-            tim::delimit(config::get_setting_value<std::string>("ROCPROFSYS_ROCM_DOMAINS")
-                             .value_or(std::string{}),
-                         " ,;:\t\n");
+        const auto _domains = tim::delimit(
+            config::get_setting_value<std::string>(std::string{ env_vars::ROCM_DOMAINS })
+                .value_or(std::string{}),
+            " ,;:\t\n");
         const auto has_marker_domain =
             (std::find(_domains.begin(), _domains.end(), "marker_api") !=
                  _domains.end() ||
@@ -2416,7 +2417,7 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* user_data)
     // Only initialize once per session
     if(tool_init_done.exchange(true)) return 0;
 
-    auto domains = settings::instance()->at("ROCPROFSYS_ROCM_DOMAINS");
+    auto domains = settings::instance()->at(std::string{ env_vars::ROCM_DOMAINS });
 
     std::stringstream _domains_ss;
     for(const auto& itr : domains->get_choices())
@@ -3072,7 +3073,7 @@ extern "C"
             _first = false;
         }
 
-        if(!rocprofsys::get_env("ROCPROFSYS_INIT_TOOLING", true)) return nullptr;
+        if(!rocprofsys::get_env(rocprofsys::env_vars::INIT_TOOLING, true)) return nullptr;
         if(!tim::settings::enabled()) return nullptr;
 
         if(!sdk_tool_configure(version, runtime_version, id)) return nullptr;

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -4,6 +4,7 @@
 #include "core/rocprofiler-sdk.hpp"
 #include "api.hpp"
 #include "binary/analysis.hpp"
+#include "common/env_vars.hpp"
 #include "common/synchronized.hpp"
 #include "core/common.hpp"
 #include "core/common_types.hpp"
@@ -95,10 +96,10 @@ get_roctx_client()
 {
     if(!g_roctx_client)
     {
-        const auto _domains =
-            tim::delimit(config::get_setting_value<std::string>("ROCPROFSYS_ROCM_DOMAINS")
-                             .value_or(std::string{}),
-                         " ,;:\t\n");
+        const auto _domains = tim::delimit(
+            config::get_setting_value<std::string>(std::string{ env_vars::ROCM_DOMAINS })
+                .value_or(std::string{}),
+            " ,;:\t\n");
         const auto has_marker_domain =
             (std::find(_domains.begin(), _domains.end(), "marker_api") !=
                  _domains.end() ||
@@ -2416,7 +2417,7 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* user_data)
     // Only initialize once per session
     if(tool_init_done.exchange(true)) return 0;
 
-    auto domains = settings::instance()->at("ROCPROFSYS_ROCM_DOMAINS");
+    auto domains = settings::instance()->at(std::string{ env_vars::ROCM_DOMAINS });
 
     std::stringstream _domains_ss;
     for(const auto& itr : domains->get_choices())
@@ -3064,7 +3065,7 @@ extern "C"
             _first = false;
         }
 
-        if(!tim::get_env("ROCPROFSYS_INIT_TOOLING", true)) return nullptr;
+        if(!tim::get_env(rocprofsys::env_vars::INIT_TOOLING.data(), true)) return nullptr;
         if(!tim::settings::enabled()) return nullptr;
 
         if(!sdk_tool_configure(version, runtime_version, id)) return nullptr;

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/runtime.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/runtime.cpp
@@ -4,6 +4,7 @@
 #include "library/runtime.hpp"
 #include "api.hpp"
 #include "common/defines.h"
+#include "common/env_vars.hpp"
 #include "core/config.hpp"
 #include "core/utility.hpp"
 #include "library/thread_data.hpp"
@@ -37,7 +38,7 @@ namespace rocprofsys
 {
 namespace
 {
-auto root_process_id = get_env<pid_t>("ROCPROFSYS_ROOT_PROCESS", process::get_id());
+auto root_process_id = get_env<pid_t>(env_vars::ROOT_PROCESS, process::get_id());
 
 auto&
 get_sampling_on_child_threads_history(std::int64_t _idx = utility::get_thread_index())

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/runtime.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/runtime.cpp
@@ -4,6 +4,7 @@
 #include "library/runtime.hpp"
 #include "api.hpp"
 #include "common/defines.h"
+#include "common/env_vars.hpp"
 #include "core/config.hpp"
 #include "core/utility.hpp"
 #include "library/thread_data.hpp"
@@ -39,7 +40,7 @@ namespace rocprofsys
 namespace
 {
 auto root_process_id =
-    get_env<pid_t>("ROCPROFSYS_ROOT_PROCESS", process::get_id(), false);
+    get_env<pid_t>(env_vars::ROOT_PROCESS.data(), process::get_id(), false);
 
 auto&
 get_sampling_on_child_threads_history(std::int64_t _idx = utility::get_thread_index())

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/sampling.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/sampling.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "library/sampling.hpp"
+#include "common/env_vars.hpp"
 #include "common/units.hpp"
 #include "core/common.hpp"
 #include "core/components/fwd.hpp"
@@ -322,7 +323,8 @@ cache_sampling_data(std::int64_t                               _tid,
     }
 
     auto _overflow_event =
-        get_setting_value<std::string>("ROCPROFSYS_SAMPLING_OVERFLOW_EVENT").value_or("");
+        get_setting_value<std::string>(std::string{ env_vars::SAMPLING_OVERFLOW_EVENT })
+            .value_or("");
 
     if(!_overflow_event.empty())
     {
@@ -844,10 +846,10 @@ configure(bool _setup, std::int64_t _tid)
             struct perf_event_attr _pe;
             memset(&_pe, 0, sizeof(_pe));
 
-            auto _freq = get_sampling_overflow_freq();
-            auto _overflow_event =
-                get_setting_value<std::string>("ROCPROFSYS_SAMPLING_OVERFLOW_EVENT")
-                    .value_or("perf::PERF_COUNT_HW_CACHE_REFERENCES");
+            auto _freq           = get_sampling_overflow_freq();
+            auto _overflow_event = get_setting_value<std::string>(
+                                       std::string{ env_vars::SAMPLING_OVERFLOW_EVENT })
+                                       .value_or("perf::PERF_COUNT_HW_CACHE_REFERENCES");
 
             perf::config_overflow_sampling(_pe, _overflow_event, _freq);
 
@@ -932,7 +934,8 @@ configure(bool _setup, std::int64_t _tid)
             {
                 auto _freq = get_sampling_overflow_freq();
                 auto _overflow_event =
-                    get_setting_value<std::string>("ROCPROFSYS_SAMPLING_OVERFLOW_EVENT")
+                    get_setting_value<std::string>(
+                        std::string{ env_vars::SAMPLING_OVERFLOW_EVENT })
                         .value_or("perf::PERF_COUNT_HW_CACHE_REFERENCES");
                 LOG_INFO("[SIG{}] Sampler for thread {} will be triggered every {:.1f} "
                          "{} events...",
@@ -1430,7 +1433,8 @@ post_process_perfetto(std::int64_t                               _tid,
     if(!_thread_info) return;
 
     auto _overflow_event =
-        get_setting_value<std::string>("ROCPROFSYS_SAMPLING_OVERFLOW_EVENT").value_or("");
+        get_setting_value<std::string>(std::string{ env_vars::SAMPLING_OVERFLOW_EVENT })
+            .value_or("");
 
     if(!_overflow_event.empty() && !_overflow_data.empty())
     {

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/sampling.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/sampling.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "library/sampling.hpp"
+#include "common/env_vars.hpp"
 #include "core/common.hpp"
 #include "core/components/fwd.hpp"
 #include "core/config.hpp"
@@ -323,7 +324,8 @@ cache_sampling_data(std::int64_t                               _tid,
     }
 
     auto _overflow_event =
-        get_setting_value<std::string>("ROCPROFSYS_SAMPLING_OVERFLOW_EVENT").value_or("");
+        get_setting_value<std::string>(std::string{ env_vars::SAMPLING_OVERFLOW_EVENT })
+            .value_or("");
 
     if(!_overflow_event.empty())
     {
@@ -832,10 +834,10 @@ configure(bool _setup, std::int64_t _tid)
             struct perf_event_attr _pe;
             memset(&_pe, 0, sizeof(_pe));
 
-            auto _freq = get_sampling_overflow_freq();
-            auto _overflow_event =
-                get_setting_value<std::string>("ROCPROFSYS_SAMPLING_OVERFLOW_EVENT")
-                    .value_or("perf::PERF_COUNT_HW_CACHE_REFERENCES");
+            auto _freq           = get_sampling_overflow_freq();
+            auto _overflow_event = get_setting_value<std::string>(
+                                       std::string{ env_vars::SAMPLING_OVERFLOW_EVENT })
+                                       .value_or("perf::PERF_COUNT_HW_CACHE_REFERENCES");
 
             perf::config_overflow_sampling(_pe, _overflow_event, _freq);
 
@@ -920,7 +922,8 @@ configure(bool _setup, std::int64_t _tid)
             {
                 auto _freq = get_sampling_overflow_freq();
                 auto _overflow_event =
-                    get_setting_value<std::string>("ROCPROFSYS_SAMPLING_OVERFLOW_EVENT")
+                    get_setting_value<std::string>(
+                        std::string{ env_vars::SAMPLING_OVERFLOW_EVENT })
                         .value_or("perf::PERF_COUNT_HW_CACHE_REFERENCES");
                 LOG_INFO("[SIG{}] Sampler for thread {} will be triggered every {:.1f} "
                          "{} events...",
@@ -1418,7 +1421,8 @@ post_process_perfetto(std::int64_t                               _tid,
     if(!_thread_info) return;
 
     auto _overflow_event =
-        get_setting_value<std::string>("ROCPROFSYS_SAMPLING_OVERFLOW_EVENT").value_or("");
+        get_setting_value<std::string>(std::string{ env_vars::SAMPLING_OVERFLOW_EVENT })
+            .value_or("");
 
     if(!_overflow_event.empty() && !_overflow_data.empty())
     {

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/tracing.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/tracing.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "library/tracing.hpp"
+#include "common/env_vars.hpp"
 #include "core/concepts.hpp"
 #include "core/config.hpp"
 #include "core/state.hpp"
@@ -39,11 +40,11 @@ get_timemory_hash_aliases(std::int64_t _tid)
 }
 }  // namespace
 
-bool debug_push = rocprofsys::get_env("ROCPROFSYS_DEBUG_PUSH", false) || get_debug_env();
-bool debug_pop  = rocprofsys::get_env("ROCPROFSYS_DEBUG_POP", false) || get_debug_env();
-bool debug_mark = rocprofsys::get_env("ROCPROFSYS_DEBUG_MARK", false) || get_debug_env();
+bool debug_push = rocprofsys::get_env(env_vars::DEBUG_PUSH, false) || get_debug_env();
+bool debug_pop  = rocprofsys::get_env(env_vars::DEBUG_POP, false) || get_debug_env();
+bool debug_mark = rocprofsys::get_env(env_vars::DEBUG_MARK, false) || get_debug_env();
 bool debug_user =
-    rocprofsys::get_env("ROCPROFSYS_DEBUG_USER_REGIONS", false) || get_debug_env();
+    rocprofsys::get_env(env_vars::DEBUG_USER_REGIONS, false) || get_debug_env();
 
 std::unordered_map<hash_value_t, std::string>&
 get_perfetto_track_uuids()

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/tracing.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/tracing.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "library/tracing.hpp"
+#include "common/env_vars.hpp"
 #include "core/concepts.hpp"
 #include "core/config.hpp"
 #include "core/state.hpp"
@@ -39,10 +40,11 @@ get_timemory_hash_aliases(std::int64_t _tid)
 }
 }  // namespace
 
-bool debug_push = tim::get_env("ROCPROFSYS_DEBUG_PUSH", false) || get_debug_env();
-bool debug_pop  = tim::get_env("ROCPROFSYS_DEBUG_POP", false) || get_debug_env();
-bool debug_mark = tim::get_env("ROCPROFSYS_DEBUG_MARK", false) || get_debug_env();
-bool debug_user = tim::get_env("ROCPROFSYS_DEBUG_USER_REGIONS", false) || get_debug_env();
+bool debug_push = tim::get_env(env_vars::DEBUG_PUSH.data(), false) || get_debug_env();
+bool debug_pop  = tim::get_env(env_vars::DEBUG_POP.data(), false) || get_debug_env();
+bool debug_mark = tim::get_env(env_vars::DEBUG_MARK.data(), false) || get_debug_env();
+bool debug_user =
+    tim::get_env(env_vars::DEBUG_USER_REGIONS.data(), false) || get_debug_env();
 
 std::unordered_map<hash_value_t, std::string>&
 get_perfetto_track_uuids()

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/timeout.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/timeout.cpp
@@ -81,8 +81,7 @@ ensure_ci_timeout_backtrace(double             _ci_timeout_seconds,
 
     std::uint64_t _ci_timeout_nitr    = 0;
     std::int64_t  _ci_timeout_nanosec = (_ci_timeout_seconds - _factor) * units::sec;
-    auto          _ci_timeout_total_count =
-        get_env<std::uint64_t>(env_vars::CI_TIMEOUT_COUNT, 1);
+    auto _ci_timeout_total_count = get_env<std::uint64_t>(env_vars::CI_TIMEOUT_COUNT, 1);
     const auto root_pid = get_env<pid_t>(env_vars::ROOT_PROCESS, process::get_id());
 
     while(get_state() < State::Finalized && _ci_timeout_nitr < _ci_timeout_total_count)

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/timeout.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/timeout.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
+#include "common/env_vars.hpp"
 #include "common/units.hpp"
 #include "core/categories.hpp"
 #include "core/config.hpp"
@@ -81,8 +82,8 @@ ensure_ci_timeout_backtrace(double             _ci_timeout_seconds,
     std::uint64_t _ci_timeout_nitr    = 0;
     std::int64_t  _ci_timeout_nanosec = (_ci_timeout_seconds - _factor) * units::sec;
     auto          _ci_timeout_total_count =
-        get_env<std::uint64_t>("ROCPROFSYS_CI_TIMEOUT_COUNT", 1);
-    const auto root_pid = get_env<pid_t>("ROCPROFSYS_ROOT_PROCESS", process::get_id());
+        get_env<std::uint64_t>(env_vars::CI_TIMEOUT_COUNT, 1);
+    const auto root_pid = get_env<pid_t>(env_vars::ROOT_PROCESS, process::get_id());
 
     while(get_state() < State::Finalized && _ci_timeout_nitr < _ci_timeout_total_count)
     {
@@ -170,14 +171,14 @@ setup()
     // set, start a thread that will print out the backtrace for each thread
     // before the timeout is hit (i.e. killed by CTest) so we can potentially
     // diagnose where the code is stuck
-    auto _ci = get_env("ROCPROFSYS_CI", false);
+    auto _ci = get_env(env_vars::CI, false);
     if(_ci)
     {
         // set by CTest
-        auto _ci_timeout_default = get_env("ROCPROFSYS_CI_TIMEOUT", -1.0);
+        auto _ci_timeout_default = get_env(env_vars::CI_TIMEOUT, -1.0);
         // allow override by user
         auto _ci_timeout_seconds =
-            get_env("ROCPROFSYS_CI_TIMEOUT_OVERRIDE", _ci_timeout_default);
+            get_env(env_vars::CI_TIMEOUT_OVERRIDE, _ci_timeout_default);
 
         if(_ci_timeout_seconds > 0.0)
         {

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/timeout.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/timeout.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
+#include "common/env_vars.hpp"
 #include "core/categories.hpp"
 #include "core/config.hpp"
 #include "core/locking.hpp"
@@ -80,9 +81,9 @@ ensure_ci_timeout_backtrace(double             _ci_timeout_seconds,
     std::uint64_t _ci_timeout_nitr    = 0;
     std::int64_t  _ci_timeout_nanosec = (_ci_timeout_seconds - _factor) * units::sec;
     auto          _ci_timeout_total_count =
-        get_env<std::uint64_t>("ROCPROFSYS_CI_TIMEOUT_COUNT", 1, false);
+        get_env<std::uint64_t>(env_vars::CI_TIMEOUT_COUNT.data(), 1, false);
     const auto root_pid =
-        get_env<pid_t>("ROCPROFSYS_ROOT_PROCESS", process::get_id(), false);
+        get_env<pid_t>(env_vars::ROOT_PROCESS.data(), process::get_id(), false);
 
     while(get_state() < State::Finalized && _ci_timeout_nitr < _ci_timeout_total_count)
     {
@@ -170,14 +171,14 @@ setup()
     // set, start a thread that will print out the backtrace for each thread
     // before the timeout is hit (i.e. killed by CTest) so we can potentially
     // diagnose where the code is stuck
-    auto _ci = get_env("ROCPROFSYS_CI", false, false);
+    auto _ci = get_env(env_vars::CI.data(), false, false);
     if(_ci)
     {
         // set by CTest
-        auto _ci_timeout_default = get_env("ROCPROFSYS_CI_TIMEOUT", -1.0, false);
+        auto _ci_timeout_default = get_env(env_vars::CI_TIMEOUT.data(), -1.0, false);
         // allow override by user
         auto _ci_timeout_seconds =
-            get_env("ROCPROFSYS_CI_TIMEOUT_OVERRIDE", _ci_timeout_default, false);
+            get_env(env_vars::CI_TIMEOUT_OVERRIDE.data(), _ci_timeout_default, false);
 
         if(_ci_timeout_seconds > 0.0)
         {

--- a/projects/rocprofiler-systems/source/python/libpyrocprofsys.cpp
+++ b/projects/rocprofiler-systems/source/python/libpyrocprofsys.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "libpyrocprofsys.hpp"
+#include "common/env_vars.hpp"
 #include "dl/dl.hpp"
 #include "library/coverage.hpp"
 #include "library/coverage/impl.hpp"
@@ -140,7 +141,7 @@ PYBIND11_MODULE(libpyrocprofsys, omni)
             if(!_cmd_line.empty())
             {
                 _cmd_line = _cmd_line.substr(_cmd_line.find_first_not_of(' '));
-                rocprofsys::set_env("ROCPROFSYS_COMMAND_LINE", _cmd_line, 0);
+                rocprofsys::set_env(rocprofsys::env_vars::COMMAND_LINE, _cmd_line, 0);
             }
             rocprofsys_init("trace", false, _cmd.c_str());
         },
@@ -160,11 +161,11 @@ PYBIND11_MODULE(libpyrocprofsys, omni)
     pycoverage::generate(omni);
     pyuser::generate(omni);
 
-    auto _python_path = rocprofsys::get_env("ROCPROFSYS_PATH", std::string{});
+    auto _python_path = rocprofsys::get_env(rocprofsys::env_vars::PATH, std::string{});
     auto _libpath     = std::string{ "librocprof-sys-dl.so" };
     if(!_python_path.empty()) _libpath = TIMEMORY_JOIN("/", _python_path, _libpath);
     // permit env override if default path fails/is wrong
-    _libpath = rocprofsys::get_env("ROCPROFSYS_DL_LIBRARY", _libpath);
+    _libpath = rocprofsys::get_env(rocprofsys::env_vars::DL_LIBRARY, _libpath);
     // this is necessary when building with -static-libstdc++
     // without it, loading librocprof-sys.so within librocprof-sys-dl.so segfaults
     if(!dlopen(_libpath.c_str(), RTLD_NOW | RTLD_GLOBAL))

--- a/projects/rocprofiler-systems/source/python/libpyrocprofsys.cpp
+++ b/projects/rocprofiler-systems/source/python/libpyrocprofsys.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "libpyrocprofsys.hpp"
+#include "common/env_vars.hpp"
 #include "dl/dl.hpp"
 #include "library/coverage.hpp"
 #include "library/coverage/impl.hpp"
@@ -135,7 +136,7 @@ PYBIND11_MODULE(libpyrocprofsys, omni)
             if(!_cmd_line.empty())
             {
                 _cmd_line = _cmd_line.substr(_cmd_line.find_first_not_of(' '));
-                tim::set_env("ROCPROFSYS_COMMAND_LINE", _cmd_line, 0);
+                tim::set_env(rocprofsys::env_vars::COMMAND_LINE.data(), _cmd_line, 0);
             }
             rocprofsys_init("trace", false, _cmd.c_str());
         },
@@ -155,11 +156,12 @@ PYBIND11_MODULE(libpyrocprofsys, omni)
     pycoverage::generate(omni);
     pyuser::generate(omni);
 
-    auto _python_path = tim::get_env("ROCPROFSYS_PATH", std::string{}, false);
-    auto _libpath     = std::string{ "librocprof-sys-dl.so" };
+    auto _python_path =
+        tim::get_env(rocprofsys::env_vars::PATH.data(), std::string{}, false);
+    auto _libpath = std::string{ "librocprof-sys-dl.so" };
     if(!_python_path.empty()) _libpath = TIMEMORY_JOIN("/", _python_path, _libpath);
     // permit env override if default path fails/is wrong
-    _libpath = tim::get_env("ROCPROFSYS_DL_LIBRARY", _libpath);
+    _libpath = tim::get_env(rocprofsys::env_vars::DL_LIBRARY.data(), _libpath);
     // this is necessary when building with -static-libstdc++
     // without it, loading librocprof-sys.so within librocprof-sys-dl.so segfaults
     if(!dlopen(_libpath.c_str(), RTLD_NOW | RTLD_GLOBAL))


### PR DESCRIPTION
## Motivation

- The source/lib/common/env_vars.hpp header was introduced to give every rocprofiler-systems environment variable a single canonical, compile-time name, but the codebase still referenced 264 distinct "ROCPROFSYS_*" string literals across ~46 files (936 total occurrences). Only ~110 of those names were defined in the header — the rest lived as raw literals at every call site. That meant most env-var names existed in two places, a typo or rename touched dozens of unrelated files, and there was no single authoritative list of the env vars we ship.

This PR makes env_vars.hpp the single source of truth for runtime env-var names. Renaming a variable becomes a one-line edit; new env vars must be declared in one place before they can be used.

## Technical Details

### Header expansion (source/lib/common/env_vars.hpp)

- Added ~140 missing constexpr std::string_view constants for env vars previously referenced only as literals, organized into existing or new category sections:

- New sections: CI / testing, MPI, Kokkos profiling, DL (dynamic loader), Regex include/exclude filters, Process / threading / behavior, Instrumentation, Runtime / launcher, Deprecated aliases.
- Extended existing sections: Tracing, Sampling (+ new "Sampling: overflow" sub-section), Causal profiling, Output (+ new "Output: number formatting" sub-section), Hardware counters, Domains (Shmem, GPU), Advanced (debugging knobs).
- Deprecated aliases (USE_PERFETTO, USE_TIMEMORY) declared with an inline comment explaining they exist only for legacy migration paths and should not be referenced by new code.

### Collision rename

PAPI_MULTIPLEXING and PAPI_QUIET collide with integer macros defined in PAPI's C header (papi.h). Renamed the C++ identifiers to PAPI_MULTIPLEXING_ENABLED and PAPI_QUIET_MODE with an in-header comment. The env-var strings are unchanged (ROCPROFSYS_PAPI_MULTIPLEXING, ROCPROFSYS_PAPI_QUIET) — only the C++ symbol name diverges. All callers updated.

## JIRA ID

N/A

## Test Plan

- Unit-test ctest target: ctest -R '^unit-tests$' --output-on-failure. This binary exercises every migrated test file (test_environment, test_update_env, test_remove_env, test_logger, test_json_config, test_preset_registry, test_print_output, test_shmem_gotcha).
- Pre-commit hooks (clang-format, trailing whitespace, EOF fixer, copyright detector, fixed-width type consistency) run as part of git commit.
- Final audit grep grep -rn '"ROCPROFSYS_' source/ to confirm only the documented-as-intentional literals remain.

## Test Result

- Full build: green (204/204 targets).
- unit-tests: 3/3 passed (rocprofiler-systems-pytest-config, us-test-cleanup).
- Pre-commit: all hooks passed (clang-format applied formattinefore the final commit).
- Audit grep: only the intentionally-preserved literals remainally NOT migrated" list above.

Because this is a pure rename refactor — env-var strings are b runtime control flow changed — behavior is preserved by
construction.

## Submission Checklist

- [ x] Look over the contributing guidelines at https://github.com/BUTING.md#pull-requests.