### PR TITLE
fix (CLR): Remove hardcoded /Zi in CMakeLists.txt

### DIFF
--- a/projects/clr/hipamd/CMakeLists.txt
+++ b/projects/clr/hipamd/CMakeLists.txt
@@ -33,11 +33,6 @@ option(THEROCK_FLAG_STAMP_LIBRARY_GIT_VERSIONS
   "Stamp git revisions into generated library version metadata"
   ON)
 
-if(MSVC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zi")
-  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /DEBUG:FULL")
-endif()
-
 # Set default HIPCC_BIN_DIR to ${ROCM_PATH}/bin
 set(HIPCC_BIN_DIR "${ROCM_PATH}/bin" CACHE STRING "HIPCC and HIPCONFIG binary directories")
 

--- a/projects/clr/opencl/CMakeLists.txt
+++ b/projects/clr/opencl/CMakeLists.txt
@@ -16,12 +16,6 @@ option(BUILD_ICD "Enable building OpenCL ICD Loader" OFF)
 option(EMU_ENV "Enable building for emulation environment" OFF)
 option(ENABLE_ADDRESS_SANITIZER "Option to enable ASAN build" OFF)
 
-# Add flags to generate PDB files with full symbolic information
-if(MSVC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zi")
-  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /DEBUG:FULL")
-endif()
-
 # Address sanitizer options
 if(ENABLE_ADDRESS_SANITIZER)
   message(STATUS "Building ocltst tests with Address Sanitizer options")


### PR DESCRIPTION
## Motivation
ISSUE ID: https://github.com/ROCm/TheRock/pull/4419

CLR build should not hardcode symbol generation on Windows. If any downstream release / build requires them, they should use the respective MSVC flags.

## Technical Details

Remove hardcoded /Zi and /DEBUG:FULL from amdhip and opencl.

## JIRA ID

N/A

## Test Plan

Build passes.

## Test Result

Build passes.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
