### PR TITLE
[AICOMNET-225][RCCL][in debug, not for merge] Fix Bootstrap Split Bidirectional Deadlock at 256 Ranks 

### DIFF
--- a/projects/rccl/src/bootstrap.cc
+++ b/projects/rccl/src/bootstrap.cc
@@ -22,6 +22,7 @@
 #define BOOTSTRAP_TAG_CONNECT             (0x1 << 31)
 #define BOOTSTRAP_TAG_ALLGATHER           (0x1 << 30)
 #define BOOTSTRAP_TAG_COMMSPLIT           (0x1 << 29)
+#define BOOTSTRAP_TAG_COMMSPLIT_REV       (BOOTSTRAP_TAG_COMMSPLIT | 0x1)
 #define BOOTSTRAP_TAG_INTRANODE_ALLGATHER (0x1 << 28)
 // Tag used to exchange reverse-ring listen handles during bidirectional NET
 // bootstrap setup (fallback path when no piggybacked handle is available).
@@ -1239,7 +1240,7 @@ ncclResult_t bootstrapSplit(uint64_t magic, struct ncclComm* comm, struct ncclCo
   struct ncclSocket* proxySocket = NULL;
   struct bootstrapState* state;
   union ncclSocketAddress peerSocketAddress;
-  bool useBidirBootstrap = bootstrapNetEnabledEffective(nranks) && bootstrapBidirEnabled(nranks, 1);
+  bool useBidirBootstrap = bootstrapBidirEnabled(nranks, 1);
   char prevRevHandle[NCCL_NET_HANDLE_MAXSIZE];
   memset(prevRevHandle, 0, NCCL_NET_HANDLE_MAXSIZE);
 
@@ -1285,9 +1286,9 @@ ncclResult_t bootstrapSplit(uint64_t magic, struct ncclComm* comm, struct ncclCo
   // For bidirectional bootstrap, do a second exchange in the opposite direction to get
   // prev's revHandle. Use a distinct tag to avoid message matching issues at scale.
   if (useBidirBootstrap) {
-    NCCLCHECKGOTO(bootstrapSend(parent->bootstrap, next, BOOTSTRAP_TAG_COMMSPLIT + 1, &info, sizeof(struct ringConnectInfo)), ret, fail);
-    NCCLCHECKGOTO(bootstrapRecv(parent->bootstrap, prev, BOOTSTRAP_TAG_COMMSPLIT + 1, &prevPeer, sizeof(struct ringConnectInfo)), ret, fail);
-    memcpy(prevRevHandle, prevPeer.revHandle, NCCL_NET_HANDLE_MAXSIZE);
+    NCCLCHECKGOTO(bootstrapSend(parent->bootstrap, next, BOOTSTRAP_TAG_COMMSPLIT_REV, &info, sizeof(struct ringConnectInfo)), ret, fail);
+    NCCLCHECKGOTO(bootstrapRecv(parent->bootstrap, prev, BOOTSTRAP_TAG_COMMSPLIT_REV, &prevPeer, sizeof(struct ringConnectInfo)), ret, fail);
+    memcpy(prevRevHandle, prevPeer.revHandle, NCCL_NET_HANDLE_MAXSIZE); // only revHandle is consumed from prevPeer
   }
 
   if (bootstrapNetEnabledEffective(nranks)) {

--- a/projects/rccl/src/bootstrap.cc
+++ b/projects/rccl/src/bootstrap.cc
@@ -1235,8 +1235,13 @@ ncclResult_t bootstrapSplit(uint64_t magic, struct ncclComm* comm, struct ncclCo
   int prev, next;
   struct ringConnectInfo info = {};
   struct ringConnectInfo nextPeer = {};
+  struct ringConnectInfo prevPeer = {};
   struct ncclSocket* proxySocket = NULL;
   struct bootstrapState* state;
+  union ncclSocketAddress peerSocketAddress;
+  bool useBidirBootstrap = bootstrapNetEnabledEffective(nranks) && bootstrapBidirEnabled(nranks, 1);
+  char prevRevHandle[NCCL_NET_HANDLE_MAXSIZE];
+  memset(prevRevHandle, 0, NCCL_NET_HANDLE_MAXSIZE);
 
   NCCLCHECKGOTO(ncclCalloc(&state, 1), ret, fail);
   state->rank = rank;
@@ -1255,12 +1260,18 @@ ncclResult_t bootstrapSplit(uint64_t magic, struct ncclComm* comm, struct ncclCo
     NCCLCHECKGOTO(netGetDevice(rank, comm, &STATE_LISTEN(state, net.dev)), ret, fail);
     NCCLCHECKGOTO(state->net->listen(comm->netContext, STATE_LISTEN(state, net.dev), STATE_LISTEN(state, net.handle), &STATE_LISTEN(state, net.comm)), ret, fail);
     memcpy(info.fwd.handle, STATE_LISTEN(state, net.handle), NCCL_NET_HANDLE_MAXSIZE);
+    // For bidirectional bootstrap, create the reverse listener now and include its handle
+    // in the exchange. This avoids the blocking netSendRecv fallback that deadlocks at scale.
+    if (useBidirBootstrap) {
+      NCCLCHECKGOTO(state->net->listen(comm->netContext, STATE_LISTEN(state, net.dev),
+                                       STATE_LISTEN(state, net.revHandle), &STATE_LISTEN(state, net.revComm)), ret, fail);
+      memcpy(info.revHandle, STATE_LISTEN(state, net.revHandle), NCCL_NET_HANDLE_MAXSIZE);
+    }
   } else {
     // create socket for ring neighbor to contact me
     NCCLCHECK(createListenSocket(comm, comm->magic, &STATE_LISTEN(state, socket.fwd), &info.fwd.addr, ncclSocketTypeBootstrap));
   }
   // create a socket for others to reach out (P2P)
-  union ncclSocketAddress peerSocketAddress;
   NCCLCHECK(createListenSocket(comm, comm->magic, &STATE_LISTEN(state, peerSocket), &peerSocketAddress, ncclSocketTypeBootstrap));
 
   if (ncclParamRasEnable() == 1) {
@@ -1271,6 +1282,14 @@ ncclResult_t bootstrapSplit(uint64_t magic, struct ncclComm* comm, struct ncclCo
   // Get addr from next rank using the parent's connections
   NCCLCHECKGOTO(bootstrapSend(parent->bootstrap, prev, BOOTSTRAP_TAG_COMMSPLIT, &info, sizeof(struct ringConnectInfo)), ret, fail);
   NCCLCHECKGOTO(bootstrapRecv(parent->bootstrap, next, BOOTSTRAP_TAG_COMMSPLIT, &nextPeer, sizeof(struct ringConnectInfo)), ret, fail);
+  // For bidirectional bootstrap, do a second exchange in the opposite direction to get
+  // prev's revHandle. Use a distinct tag to avoid message matching issues at scale.
+  if (useBidirBootstrap) {
+    NCCLCHECKGOTO(bootstrapSend(parent->bootstrap, next, BOOTSTRAP_TAG_COMMSPLIT + 1, &info, sizeof(struct ringConnectInfo)), ret, fail);
+    NCCLCHECKGOTO(bootstrapRecv(parent->bootstrap, prev, BOOTSTRAP_TAG_COMMSPLIT + 1, &prevPeer, sizeof(struct ringConnectInfo)), ret, fail);
+    memcpy(prevRevHandle, prevPeer.revHandle, NCCL_NET_HANDLE_MAXSIZE);
+  }
+
   if (bootstrapNetEnabledEffective(nranks)) {
     NCCLCHECKGOTO(netRingConnect(comm->netContext, state->net, &state->listen, nextPeer.fwd.handle,
                                  &STATE_RING(state, net.sendComm), &STATE_RING(state, net.sendDevHandle),
@@ -1281,10 +1300,9 @@ ncclResult_t bootstrapSplit(uint64_t magic, struct ncclComm* comm, struct ncclCo
   }
 
   // Mirror the bidirectional ring setup done in bootstrapInit so that split communicators
-  // can also benefit from the N/2-step AllGather. bootstrapSplit doesn't go through the
-  // root rendezvous, so no piggybacked revHandle is available — pass NULL to use the
-  // legacy in-place handle exchange.
-  NCCLCHECKGOTO(bootstrapBidirRingSetup(comm, state, NULL), ret, fail);
+  // can also benefit from the N/2-step AllGather. Pass the piggybacked prevRevHandle if available,
+  // otherwise NULL falls back to the legacy (potentially blocking) in-place handle exchange.
+  NCCLCHECKGOTO(bootstrapBidirRingSetup(comm, state, useBidirBootstrap ? prevRevHandle : NULL), ret, fail);
 
   NCCLCHECKGOTO(ncclCalloc(&state->peerP2pAddresses, nranks), ret, fail);
   memcpy(state->peerP2pAddresses + rank, &peerSocketAddress, sizeof(union ncclSocketAddress));


### PR DESCRIPTION
## Motivation

Resolve blocking netSendRecv collective fallback that deadlocks at scale. Create a reverse listener and add a second neighbor exchange so prev's revHandle can be piggybacked through the parent bootstrap, enabling the async bidirectional ring setup path.

## Technical Details

When running at 256 ranks, the RevokeMPITest.RepeatedRevokeShrinkCycles_ResourceCleanup would consistently run for a really long time (over 20 minutes) and appear to hang. This is consistently the case at 256 ranks+ but always runs fine up to 128 ranks. 

Based on the backtrace, it seems that ~10 ranks on the last few nodes were stuck in hipStreamSynchronize while others waited at an MPI barrier. This issue occurs at 128+ ranks but not below, which corresponds to the BOOTSTRAP_BIDIR_THRESHOLD. Disabling bidirectional net bootstrap with NCCL_BOOTSTRAP_BIDIR_NET=0 fixes the hang at 256 ranks. 

In bootstrapSplit, when creating a child communicator from a revoked parent, the bidirectional ring setup requires each rank to know its previous neighbor's reverse handle (prevRevHandle). Unlike bootstrapInit which gets this handle piggybacked through a central root rendezvous, bootstrapSplit was passing NULL to bootstrapBidirRingSetup. This forced a fallback to a blocking netSendRecv collective to exchange handles in-place. At scale (256 ranks), this blocking collective can deadlock because all ranks must participate simultaneously, but the forward ring connections aren't fully synchronized at that point.

This fix modifies bootstrapSplit to perform a bidirectional neighbor exchange via the parent bootstrap - sending connection info to both prev and next neighbors, and receiving from both. This gives us prevPeer.revHandle directly, which is then passed to bootstrapBidirRingSetup. With the piggybacked handle available, the bidirectional ring setup uses the async connect/accept path instead of the blocking fallback, avoiding the deadlock at scale.

## JIRA ID

AICOMNET-225

## Test Plan

Evaluate Revoke tests on up to 256 ranks: 

## Test Result

### Test Results Summary (2–32 Nodes)

| Config  | Ranks | RevokeMPITest (Pass) | RevokeNonBlockingMPITest (Pass) | Total (Pass) |
|---------|-------|----------------------|----------------------------------|--------------|
| 2-node  | 16    | 15/15                | 3/3                              | 18/18        |
| 4-node  | 32    | 15/15                | 3/3                              | 18/18        |
| 8-node  | 64    | 15/15                | 3/3                              | 18/18        |
| 16-node | 128   | 15/15                | 3/3                              | 18/18        |
| 32-node | 256   | 15/15                | 3/3                              | 18/18        |

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
