### PR TITLE
[RCCL] Enable nccl_device LSA barrier on HIP

### DIFF
--- a/projects/rccl-tests/src/all_reduce.cu
+++ b/projects/rccl-tests/src/all_reduce.cu
@@ -138,11 +138,7 @@ testResult_t AllReduceGetDevCommRequirements(int deviceImpl, ncclDevCommRequirem
 template <typename T>
 __global__ void allReduceLsaKernel(ncclWindow_t sendwin, size_t sendoffset, ncclWindow_t recvwin, size_t recvoffset, size_t count, int root, struct ncclDevComm devComm) {
   ncclLsaBarrierSession<ncclCoopCta> bar { ncclCoopCta(), devComm, ncclTeamLsa(devComm), devComm.lsaBarrier, blockIdx.x };
-#if __HIP_PLATFORM_AMD__
-  bar.sync(ncclCoopCta(), std::memory_order_relaxed);
-#else
   bar.sync(ncclCoopCta(), cuda::memory_order_relaxed);
-#endif
   const int rank = devComm.rank, nRanks = devComm.nRanks;
 
   const int globalTid = threadIdx.x + blockDim.x * (rank + blockIdx.x * nRanks);
@@ -159,11 +155,7 @@ __global__ void allReduceLsaKernel(ncclWindow_t sendwin, size_t sendoffset, nccl
       recvPtr[offset] = v;
     }
   }
-#if __HIP_PLATFORM_AMD__
-  bar.sync(ncclCoopCta(), std::memory_order_release);
-#else
   bar.sync(ncclCoopCta(), cuda::memory_order_release);
-#endif
 }
 
 /*
@@ -192,11 +184,7 @@ __global__ void allReduceLsaKernel(ncclWindow_t sendwin, size_t sendoffset, nccl
 template <typename T>
 __global__ void allReduceLsaVectorizedKernel(ncclWindow_t sendwin, size_t sendoffset, ncclWindow_t recvwin, size_t recvoffset, size_t count, int root, struct ncclDevComm devComm) {
   ncclLsaBarrierSession<ncclCoopCta> bar { ncclCoopCta(), devComm, ncclTeamLsa(devComm), devComm.lsaBarrier, blockIdx.x };
-#if __HIP_PLATFORM_AMD__
-  bar.sync(ncclCoopCta(), std::memory_order_relaxed);
-#else
   bar.sync(ncclCoopCta(), cuda::memory_order_relaxed);
-#endif
 
   // Compile time vector type and vector size mapping
   using TN = typename VectorTypeMapping<T>::Type;
@@ -319,11 +307,7 @@ __global__ void allReduceLsaVectorizedKernel(ncclWindow_t sendwin, size_t sendof
   }
 
   // Sync
-#if __HIP_PLATFORM_AMD__
-  bar.sync(ncclCoopCta(), std::memory_order_release);
-#else
   bar.sync(ncclCoopCta(), cuda::memory_order_release);
-#endif
 }
 
 /*
@@ -353,11 +337,7 @@ __global__ void allReduceLsaVectorizedKernel(ncclWindow_t sendwin, size_t sendof
 template <typename T>
 __global__ void allReduceMultimemKernel(ncclWindow_t sendwin, size_t sendoffset, ncclWindow_t recvwin, size_t recvoffset, size_t count, int root, struct ncclDevComm devComm) {
   ncclLsaBarrierSession<ncclCoopCta> bar { ncclCoopCta(), devComm, ncclTeamTagLsa(), blockIdx.x, true };
-#if __HIP_PLATFORM_AMD__
-  bar.sync(ncclCoopCta(), std::memory_order_relaxed);
-#else
   bar.sync(ncclCoopCta(), cuda::memory_order_relaxed);
-#endif
 
   const int rank = devComm.rank, nRanks = devComm.nRanks;
 
@@ -372,11 +352,7 @@ __global__ void allReduceMultimemKernel(ncclWindow_t sendwin, size_t sendoffset,
       multimemStore<T,T>(recv_ptr + offset, v);
     }
   }
-#if __HIP_PLATFORM_AMD__
-  bar.sync(ncclCoopCta(), std::memory_order_release);
-#else
   bar.sync(ncclCoopCta(), cuda::memory_order_release);
-#endif
 }
 
 /*
@@ -411,11 +387,7 @@ template <typename T>
 __global__ void allReduceMultimemVectorizedKernel(ncclWindow_t sendwin, size_t sendoffset, ncclWindow_t recvwin, size_t recvoffset, size_t count, int root, struct ncclDevComm devComm) {
   ncclLsaBarrierSession<ncclCoopCta> bar { ncclCoopCta(), devComm, ncclTeamTagLsa(), blockIdx.x, true };
 
-#if __HIP_PLATFORM_AMD__
-  bar.sync(ncclCoopCta(), std::memory_order_relaxed);
-#else
   bar.sync(ncclCoopCta(), cuda::memory_order_relaxed);
-#endif
 
   using TN = typename VectorTypeMapping<T>::Type;
   constexpr int VECTOR_FACTOR = sizeof(TN)/sizeof(T);
@@ -513,11 +485,7 @@ __global__ void allReduceMultimemVectorizedKernel(ncclWindow_t sendwin, size_t s
   }
 
   // Sync
-#if __HIP_PLATFORM_AMD__
-  bar.sync(ncclCoopCta(), std::memory_order_release);
-#else
   bar.sync(ncclCoopCta(), cuda::memory_order_release);
-#endif
 }
 #endif
 

--- a/projects/rccl-tests/src/alltoall.cu
+++ b/projects/rccl-tests/src/alltoall.cu
@@ -116,11 +116,7 @@ __device__ void AlltoAllScalarImpl(ncclWindow_t sendwin, size_t sendoffset, nccl
 template <typename T>
 __global__ void NvlAlltoAllKernel(ncclWindow_t sendwin, size_t sendoffset, ncclWindow_t recvwin, size_t recvoffset, size_t count, int root, struct ncclDevComm devComm) {
   ncclLsaBarrierSession<ncclCoopCta> bar { ncclCoopCta(), devComm, ncclTeamLsa(devComm), devComm.lsaBarrier, blockIdx.x };
-#if __HIP_PLATFORM_AMD__
-  bar.sync(ncclCoopCta(), std::memory_order_relaxed);
-#else
   bar.sync(ncclCoopCta(), cuda::memory_order_relaxed);
-#endif
 
   int rank = devComm.rank, nRanks = devComm.nRanks;
   int tid = threadIdx.x + blockDim.x * blockIdx.x;
@@ -128,22 +124,14 @@ __global__ void NvlAlltoAllKernel(ncclWindow_t sendwin, size_t sendoffset, ncclW
 
   AlltoAllScalarImpl<T>(sendwin, sendoffset, recvwin, recvoffset, count, rank, nRanks, tid, nthreads);
 
-#if __HIP_PLATFORM_AMD__
-  bar.sync(ncclCoopCta(), std::memory_order_release);
-#else
   bar.sync(ncclCoopCta(), cuda::memory_order_release);
-#endif
 }
 
 // Device implementation #2 - optimized NVL kernel using vectorization and unrolling
 template <typename T>
 __global__ void NvlAlltoAllKernelOptimized(ncclWindow_t sendwin, size_t sendoffset, ncclWindow_t recvwin, size_t recvoffset, size_t count, int root, struct ncclDevComm devComm) {
   ncclLsaBarrierSession<ncclCoopCta> bar { ncclCoopCta(), devComm, ncclTeamLsa(devComm), devComm.lsaBarrier, blockIdx.x };
-#if __HIP_PLATFORM_AMD__
-  bar.sync(ncclCoopCta(), std::memory_order_relaxed);
-#else
   bar.sync(ncclCoopCta(), cuda::memory_order_relaxed);
-#endif
 
   using TN = typename VectorTypeMapping<T>::Type;
   constexpr int VECTOR_FACTOR = sizeof(TN) / sizeof(T);
@@ -217,11 +205,7 @@ __global__ void NvlAlltoAllKernelOptimized(ncclWindow_t sendwin, size_t sendoffs
     AlltoAllScalarImpl<T>(sendwin, sendoffset, recvwin, recvoffset, count, rank, nRanks, tid, nthreads);
   }
 
-#if __HIP_PLATFORM_AMD__
-  bar.sync(ncclCoopCta(), std::memory_order_release);
-#else
   bar.sync(ncclCoopCta(), cuda::memory_order_release);
-#endif
 }
 
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2,28,7)
@@ -233,11 +217,7 @@ __global__ void GinAlltoAllKernel(ncclWindow_t sendwin, size_t sendoffset, ncclW
   uint64_t signalValue = gin.readSignal(signalIndex);
 
   ncclBarrierSession<ncclCoopCta> bar { ncclCoopCta(), ncclTeamTagWorld(), gin, blockIdx.x };
-#if __HIP_PLATFORM_AMD__
-  bar.sync(ncclCoopCta(), std::memory_order_relaxed, ncclGinFenceLevel::Relaxed);
-#else
   bar.sync(ncclCoopCta(), cuda::memory_order_relaxed, ncclGinFenceLevel::Relaxed);
-#endif
 
   int tid = threadIdx.x + blockIdx.x * blockDim.x;
   int nthreads = blockDim.x * gridDim.x;
@@ -254,11 +234,7 @@ __global__ void GinAlltoAllKernel(ncclWindow_t sendwin, size_t sendoffset, ncclW
   gin.waitSignal(ncclCoopCta(), signalIndex, signalValue + devComm.nRanks);
   gin.flush(ncclCoopCta());
 
-#if __HIP_PLATFORM_AMD__
-  bar.sync(ncclCoopCta(), std::memory_order_release, ncclGinFenceLevel::Relaxed);
-#else
   bar.sync(ncclCoopCta(), cuda::memory_order_release, ncclGinFenceLevel::Relaxed);
-#endif
 }
 
 template <typename T>
@@ -269,11 +245,7 @@ __global__ void HybridAlltoAllKernel(ncclWindow_t sendwin, size_t sendoffset, nc
   uint64_t signalValue = gin.readSignal(signalIndex);
 
   ncclBarrierSession<ncclCoopCta> bar { ncclCoopCta(), ncclTeamTagWorld(), gin, blockIdx.x };
-#if __HIP_PLATFORM_AMD__
-  bar.sync(ncclCoopCta(), std::memory_order_relaxed, ncclGinFenceLevel::Relaxed);
-#else
   bar.sync(ncclCoopCta(), cuda::memory_order_relaxed, ncclGinFenceLevel::Relaxed);
-#endif
 
   int tid = threadIdx.x + blockIdx.x*blockDim.x;
   int nthreads = blockDim.x * gridDim.x;
@@ -312,11 +284,7 @@ __global__ void HybridAlltoAllKernel(ncclWindow_t sendwin, size_t sendoffset, nc
   gin.waitSignal(ncclCoopCta(), signalIndex, signalValue + numRemotePeers);
   gin.flush(ncclCoopCta());
 
-#if __HIP_PLATFORM_AMD__
-  bar.sync(ncclCoopCta(), std::memory_order_release, ncclGinFenceLevel::Relaxed);
-#else
   bar.sync(ncclCoopCta(), cuda::memory_order_release, ncclGinFenceLevel::Relaxed);
-#endif
 }
 #endif
 #endif

--- a/projects/rccl/src/include/nccl_device/barrier.h
+++ b/projects/rccl/src/include/nccl_device/barrier.h
@@ -6,11 +6,12 @@
 
 #ifndef _NCCL_DEVICE_BARRIER_H_
 #define _NCCL_DEVICE_BARRIER_H_
+#include "hip_compat.h"
 #include "impl/core__types.h"
 #include "impl/lsa_barrier__types.h"
 #include "impl/gin_barrier__types.h"
 
-#if NCCL_DEVICE_COMPILE
+#if __CUDACC__
 template<typename Coop>
 struct ncclBarrierSession_internal;
 
@@ -40,11 +41,7 @@ struct ncclBarrierSession: ncclBarrierSession_internal<Coop> {
   NCCL_DEVICE_INLINE ncclLsaBarrierSession<Coop>& lsaBarrier();
   NCCL_DEVICE_INLINE ncclGinBarrierSession<Coop>& ginBarrier();
 
-#if __HIP_PLATFORM_AMD__
-  NCCL_DEVICE_INLINE void sync(Coop, std::memory_order, ncclGinFenceLevel);
-#else
   NCCL_DEVICE_INLINE void sync(Coop, cuda::memory_order, ncclGinFenceLevel);
-#endif
 };
 #endif
 

--- a/projects/rccl/src/include/nccl_device/barrier.h
+++ b/projects/rccl/src/include/nccl_device/barrier.h
@@ -10,7 +10,7 @@
 #include "impl/lsa_barrier__types.h"
 #include "impl/gin_barrier__types.h"
 
-#if __CUDACC__
+#if NCCL_DEVICE_COMPILE
 template<typename Coop>
 struct ncclBarrierSession_internal;
 
@@ -40,7 +40,11 @@ struct ncclBarrierSession: ncclBarrierSession_internal<Coop> {
   NCCL_DEVICE_INLINE ncclLsaBarrierSession<Coop>& lsaBarrier();
   NCCL_DEVICE_INLINE ncclGinBarrierSession<Coop>& ginBarrier();
 
+#if __HIP_PLATFORM_AMD__
+  NCCL_DEVICE_INLINE void sync(Coop, std::memory_order, ncclGinFenceLevel);
+#else
   NCCL_DEVICE_INLINE void sync(Coop, cuda::memory_order, ncclGinFenceLevel);
+#endif
 };
 #endif
 

--- a/projects/rccl/src/include/nccl_device/gin/gin_device_host_common.h
+++ b/projects/rccl/src/include/nccl_device/gin/gin_device_host_common.h
@@ -9,7 +9,7 @@
 
 #include <cuda.h>
 #include "../net_device.h"
-#include "../core.h"  // for ncclGin{Signal|Counter}_t
+#include "../core_tmp.h"  // for ncclGin{Signal|Counter}_t
 
 #define NCCL_GIN_MAX_CONTEXTS 4
 

--- a/projects/rccl/src/include/nccl_device/gin/proxy/gin_proxy.h
+++ b/projects/rccl/src/include/nccl_device/gin/proxy/gin_proxy.h
@@ -53,7 +53,11 @@ NCCL_DEVICE_INLINE void postGfd(Coop coop, ncclGinProxyGpuCtx_t* proxyCtx, ncclG
 // 4x16 byte store with the write-through cache hint
 #pragma unroll
     for (uint8_t i = 0; i < 4; i++) {
+#if defined(__HIP_PLATFORM_AMD__)
+      *((uint4*)&q[idx] + i) = ((uint4*)gfd)[i];
+#else
       __stwt((uint4*)&q[idx] + i, ((uint4*)gfd)[i]);
+#endif
     }
   }
 }

--- a/projects/rccl/src/include/nccl_device/impl/barrier__funcs.h
+++ b/projects/rccl/src/include/nccl_device/impl/barrier__funcs.h
@@ -6,6 +6,7 @@
 
 #ifndef _NCCL_DEVICE_BARRIER__FUNCS_H_
 #define _NCCL_DEVICE_BARRIER__FUNCS_H_
+#include "../hip_compat.h"
 #include "barrier__types.h"
 #include "lsa_barrier__funcs.h"
 #include "gin_barrier__funcs.h"
@@ -39,7 +40,7 @@ NCCL_DEVICE_INLINE ncclBarrierSession<Coop>::ncclBarrierSession(
 }
 #endif
 
-#if NCCL_DEVICE_COMPILE
+#if __CUDACC__
 template<typename Coop>
 NCCL_DEVICE_INLINE ncclBarrierSession<Coop>::ncclBarrierSession(
     Coop coop, ncclTeamTagLsa, ncclDevComm const& comm, uint32_t index, bool multimem
@@ -65,7 +66,7 @@ NCCL_DEVICE_INLINE ncclBarrierSession<Coop>::ncclBarrierSession(
 }
 #endif
 
-#if NCCL_DEVICE_COMPILE
+#if __CUDACC__
 template<typename Coop>
 NCCL_DEVICE_INLINE ncclLsaBarrierSession<Coop>& ncclBarrierSession<Coop>::lsaBarrier() {
   return this->innerLsaBar.thing;
@@ -81,20 +82,12 @@ NCCL_DEVICE_INLINE ncclGinBarrierSession<Coop>& ncclBarrierSession<Coop>::ginBar
 
 #if __CUDACC__
 template<typename Coop>
-#if __HIP_PLATFORM_AMD__
-NCCL_DEVICE_INLINE void ncclBarrierSession<Coop>::sync(Coop, std::memory_order ord, ncclGinFenceLevel fence) {
-#else
 NCCL_DEVICE_INLINE void ncclBarrierSession<Coop>::sync(Coop, cuda::memory_order ord, ncclGinFenceLevel fence) {
-#endif
   if (this->innerLsaBar.present) {
     this->innerLsaBar.thing.sync(this->coop, this->outerGinBar.present ? nccl::utility::releaseOrderOf(ord) : ord);
   }
   if (this->outerGinBar.present) {
-#if __HIP_PLATFORM_AMD__
-    auto ginOrd = nccl::utility::toCudaOrder(this->innerLsaBar.present ? nccl::utility::acquireOrderOf(ord) : ord);
-#else
     auto ginOrd = this->innerLsaBar.present ? nccl::utility::acquireOrderOf(ord) : ord;
-#endif
     this->outerGinBar.thing.sync(this->coop, ginOrd, fence);
   }
 }

--- a/projects/rccl/src/include/nccl_device/impl/barrier__funcs.h
+++ b/projects/rccl/src/include/nccl_device/impl/barrier__funcs.h
@@ -39,7 +39,7 @@ NCCL_DEVICE_INLINE ncclBarrierSession<Coop>::ncclBarrierSession(
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_DEVICE_COMPILE
 template<typename Coop>
 NCCL_DEVICE_INLINE ncclBarrierSession<Coop>::ncclBarrierSession(
     Coop coop, ncclTeamTagLsa, ncclDevComm const& comm, uint32_t index, bool multimem
@@ -65,7 +65,7 @@ NCCL_DEVICE_INLINE ncclBarrierSession<Coop>::ncclBarrierSession(
 }
 #endif
 
-#if __CUDACC__
+#if NCCL_DEVICE_COMPILE
 template<typename Coop>
 NCCL_DEVICE_INLINE ncclLsaBarrierSession<Coop>& ncclBarrierSession<Coop>::lsaBarrier() {
   return this->innerLsaBar.thing;
@@ -81,12 +81,21 @@ NCCL_DEVICE_INLINE ncclGinBarrierSession<Coop>& ncclBarrierSession<Coop>::ginBar
 
 #if __CUDACC__
 template<typename Coop>
+#if __HIP_PLATFORM_AMD__
+NCCL_DEVICE_INLINE void ncclBarrierSession<Coop>::sync(Coop, std::memory_order ord, ncclGinFenceLevel fence) {
+#else
 NCCL_DEVICE_INLINE void ncclBarrierSession<Coop>::sync(Coop, cuda::memory_order ord, ncclGinFenceLevel fence) {
+#endif
   if (this->innerLsaBar.present) {
     this->innerLsaBar.thing.sync(this->coop, this->outerGinBar.present ? nccl::utility::releaseOrderOf(ord) : ord);
   }
   if (this->outerGinBar.present) {
-    this->outerGinBar.thing.sync(this->coop, this->innerLsaBar.present ? nccl::utility::acquireOrderOf(ord) : ord, fence);
+#if __HIP_PLATFORM_AMD__
+    auto ginOrd = nccl::utility::toCudaOrder(this->innerLsaBar.present ? nccl::utility::acquireOrderOf(ord) : ord);
+#else
+    auto ginOrd = this->innerLsaBar.present ? nccl::utility::acquireOrderOf(ord) : ord;
+#endif
+    this->outerGinBar.thing.sync(this->coop, ginOrd, fence);
   }
 }
 #endif

--- a/projects/rccl/src/include/nccl_device/impl/lsa_barrier__funcs.h
+++ b/projects/rccl/src/include/nccl_device/impl/lsa_barrier__funcs.h
@@ -8,8 +8,7 @@
 #define _NCCL_DEVICE_MEM_BARRIER__FUNCS_H_
 #include "lsa_barrier__types.h"
 #include "comm__types.h"
-
-#define __CUDACC__ 0
+#include <atomic>
 
 #if __CUDACC__
 template<typename Coop>
@@ -60,6 +59,30 @@ NCCL_DEVICE_INLINE ncclLsaBarrierSession<Coop>::~ncclLsaBarrierSession() {
 #endif
 
 #if __CUDACC__
+#if __HIP_PLATFORM_AMD__
+template<typename Coop>
+NCCL_DEVICE_INLINE void ncclLsaBarrierSession<Coop>::arrive(Coop, std::memory_order order) {
+  this->coop.sync();
+  if (this->multimem) {
+    if (this->coop.thread_rank() == 0) {
+      uint32_t* inbox = this->mcInbox(/*multimem=*/true);
+      if (nccl::utility::releaseOrderOf(order) != std::memory_order_relaxed) {
+        (void)__atomic_fetch_add(inbox, 1u, __ATOMIC_RELEASE);
+      } else {
+        (void)__atomic_fetch_add(inbox, 1u, __ATOMIC_RELAXED);
+      }
+    }
+  } else {
+    #pragma unroll 1
+    for (int i = this->coop.thread_rank(); i < this->team.nRanks - 1; i += this->coop.size()) {
+      int peer = i + (this->team.rank <= i ? 1 : 0);
+      uint32_t* inbox = this->ucInbox(peer, this->team.rank);
+      int ao = nccl::utility::toAtomicBuiltinOrder(nccl::utility::acquireOrderOf(order));
+      __atomic_store_n(inbox, this->epoch + 1, ao);
+    }
+  }
+}
+#else
 template<typename Coop>
 NCCL_DEVICE_INLINE void ncclLsaBarrierSession<Coop>::arrive(Coop, cuda::memory_order order) {
   this->coop.sync();
@@ -84,8 +107,40 @@ NCCL_DEVICE_INLINE void ncclLsaBarrierSession<Coop>::arrive(Coop, cuda::memory_o
   }
 }
 #endif
+#endif
 
 #if __CUDACC__
+#if __HIP_PLATFORM_AMD__
+template<typename Coop>
+NCCL_DEVICE_INLINE void ncclLsaBarrierSession<Coop>::wait(Coop, std::memory_order order) {
+  if (this->multimem) {
+    if (this->coop.thread_rank() == 0) {
+      uint32_t* inbox = this->mcInbox(/*multimem=*/false);
+      int ao = nccl::utility::toAtomicBuiltinOrder(nccl::utility::acquireOrderOf(order));
+      #pragma unroll 1
+      while (true) {
+        uint32_t got = __atomic_load_n(inbox, ao);
+        if (got - (this->epoch + this->team.nRanks) <= uint32_t(-1)>>1) break;
+      }
+    }
+    this->epoch += this->team.nRanks;
+  } else {
+    #pragma unroll 1
+    for (int i = this->coop.thread_rank(); i < this->team.nRanks-1; i += this->coop.size()) {
+      int peer = i + (this->team.rank <= i ? 1 : 0);
+      uint32_t* inbox = this->ucInbox(this->team.rank, peer);
+      int ao = nccl::utility::toAtomicBuiltinOrder(nccl::utility::acquireOrderOf(order));
+      #pragma unroll 1
+      while (true) {
+        uint32_t got = __atomic_load_n(inbox, ao);
+        if (got - (this->epoch + 1) <= uint32_t(-1)>>1) break;
+      }
+    }
+    this->epoch += 1;
+  }
+  this->coop.sync();
+}
+#else
 template<typename Coop>
 NCCL_DEVICE_INLINE void ncclLsaBarrierSession<Coop>::wait(Coop, cuda::memory_order order) {
   if (this->multimem) {
@@ -116,10 +171,15 @@ NCCL_DEVICE_INLINE void ncclLsaBarrierSession<Coop>::wait(Coop, cuda::memory_ord
   this->coop.sync();
 }
 #endif
+#endif
 
 #if __CUDACC__
 template<typename Coop>
+#if __HIP_PLATFORM_AMD__
+NCCL_DEVICE_INLINE void ncclLsaBarrierSession<Coop>::sync(Coop coop, std::memory_order order) {
+#else
 NCCL_DEVICE_INLINE void ncclLsaBarrierSession<Coop>::sync(Coop coop, cuda::memory_order order) {
+#endif
   this->arrive(coop, order);
   this->wait(coop, order);
 }

--- a/projects/rccl/src/include/nccl_device/impl/lsa_barrier__funcs.h
+++ b/projects/rccl/src/include/nccl_device/impl/lsa_barrier__funcs.h
@@ -6,6 +6,7 @@
 
 #ifndef _NCCL_DEVICE_MEM_BARRIER__FUNCS_H_
 #define _NCCL_DEVICE_MEM_BARRIER__FUNCS_H_
+#include "../hip_compat.h"
 #include "lsa_barrier__types.h"
 #include "comm__types.h"
 #include <atomic>
@@ -59,41 +60,17 @@ NCCL_DEVICE_INLINE ncclLsaBarrierSession<Coop>::~ncclLsaBarrierSession() {
 #endif
 
 #if __CUDACC__
-#if __HIP_PLATFORM_AMD__
-template<typename Coop>
-NCCL_DEVICE_INLINE void ncclLsaBarrierSession<Coop>::arrive(Coop, std::memory_order order) {
-  this->coop.sync();
-  if (this->multimem) {
-    if (this->coop.thread_rank() == 0) {
-      uint32_t* inbox = this->mcInbox(/*multimem=*/true);
-      if (nccl::utility::releaseOrderOf(order) != std::memory_order_relaxed) {
-        (void)__atomic_fetch_add(inbox, 1u, __ATOMIC_RELEASE);
-      } else {
-        (void)__atomic_fetch_add(inbox, 1u, __ATOMIC_RELAXED);
-      }
-    }
-  } else {
-    #pragma unroll 1
-    for (int i = this->coop.thread_rank(); i < this->team.nRanks - 1; i += this->coop.size()) {
-      int peer = i + (this->team.rank <= i ? 1 : 0);
-      uint32_t* inbox = this->ucInbox(peer, this->team.rank);
-      int ao = nccl::utility::toAtomicBuiltinOrder(nccl::utility::acquireOrderOf(order));
-      __atomic_store_n(inbox, this->epoch + 1, ao);
-    }
-  }
-}
-#else
 template<typename Coop>
 NCCL_DEVICE_INLINE void ncclLsaBarrierSession<Coop>::arrive(Coop, cuda::memory_order order) {
   this->coop.sync();
   if (this->multimem) {
-  #if __CUDA_ARCH__ >= 900
+  #if NCCL_ARCH_HAS_MULTIMEM
     if (this->coop.thread_rank() == 0) {
       uint32_t* inbox = this->mcInbox(/*multimem=*/true);
       if (nccl::utility::releaseOrderOf(order) != cuda::memory_order_relaxed) {
-        asm volatile("multimem.red.release.sys.add.u32 [%0],1;" :: "l"(inbox));
+        nccl_multimem_red_release_add_u32(inbox);
       } else {
-        asm volatile("multimem.red.relaxed.sys.add.u32 [%0],1;" :: "l"(inbox));
+        nccl_multimem_red_relaxed_add_u32(inbox);
       }
     }
   #endif
@@ -107,44 +84,12 @@ NCCL_DEVICE_INLINE void ncclLsaBarrierSession<Coop>::arrive(Coop, cuda::memory_o
   }
 }
 #endif
-#endif
 
 #if __CUDACC__
-#if __HIP_PLATFORM_AMD__
-template<typename Coop>
-NCCL_DEVICE_INLINE void ncclLsaBarrierSession<Coop>::wait(Coop, std::memory_order order) {
-  if (this->multimem) {
-    if (this->coop.thread_rank() == 0) {
-      uint32_t* inbox = this->mcInbox(/*multimem=*/false);
-      int ao = nccl::utility::toAtomicBuiltinOrder(nccl::utility::acquireOrderOf(order));
-      #pragma unroll 1
-      while (true) {
-        uint32_t got = __atomic_load_n(inbox, ao);
-        if (got - (this->epoch + this->team.nRanks) <= uint32_t(-1)>>1) break;
-      }
-    }
-    this->epoch += this->team.nRanks;
-  } else {
-    #pragma unroll 1
-    for (int i = this->coop.thread_rank(); i < this->team.nRanks-1; i += this->coop.size()) {
-      int peer = i + (this->team.rank <= i ? 1 : 0);
-      uint32_t* inbox = this->ucInbox(this->team.rank, peer);
-      int ao = nccl::utility::toAtomicBuiltinOrder(nccl::utility::acquireOrderOf(order));
-      #pragma unroll 1
-      while (true) {
-        uint32_t got = __atomic_load_n(inbox, ao);
-        if (got - (this->epoch + 1) <= uint32_t(-1)>>1) break;
-      }
-    }
-    this->epoch += 1;
-  }
-  this->coop.sync();
-}
-#else
 template<typename Coop>
 NCCL_DEVICE_INLINE void ncclLsaBarrierSession<Coop>::wait(Coop, cuda::memory_order order) {
   if (this->multimem) {
-  #if __CUDA_ARCH__ >= 900
+  #if NCCL_ARCH_HAS_MULTIMEM
     if (this->coop.thread_rank() == 0) {
       cuda::atomic_ref<uint32_t> inbox(*this->mcInbox(/*multimem=*/false));
       #pragma unroll 1
@@ -171,15 +116,10 @@ NCCL_DEVICE_INLINE void ncclLsaBarrierSession<Coop>::wait(Coop, cuda::memory_ord
   this->coop.sync();
 }
 #endif
-#endif
 
 #if __CUDACC__
 template<typename Coop>
-#if __HIP_PLATFORM_AMD__
-NCCL_DEVICE_INLINE void ncclLsaBarrierSession<Coop>::sync(Coop coop, std::memory_order order) {
-#else
 NCCL_DEVICE_INLINE void ncclLsaBarrierSession<Coop>::sync(Coop coop, cuda::memory_order order) {
-#endif
   this->arrive(coop, order);
   this->wait(coop, order);
 }

--- a/projects/rccl/src/include/nccl_device/impl/lsa_barrier__types.h
+++ b/projects/rccl/src/include/nccl_device/impl/lsa_barrier__types.h
@@ -9,8 +9,6 @@
 #include "../lsa_barrier.h"
 #include "core__types.h"
 
-#define __CUDACC__ 0
-
 struct ncclLsaBarrierHandle {
   ncclDevResourceHandle_t bufHandle;
   int nBarriers;

--- a/projects/rccl/src/include/nccl_device/lsa_barrier.h
+++ b/projects/rccl/src/include/nccl_device/lsa_barrier.h
@@ -9,9 +9,6 @@
 #include "impl/core__types.h"
 #include "core_tmp.h"
 
-#undef __CUDACC__
-#define __CUDACC__ 0
-
 struct ncclLsaBarrierHandle;
 
 NCCL_EXTERN_C __host__ ncclResult_t ncclLsaBarrierCreateRequirement(ncclTeam_t, int nBarriers, ncclLsaBarrierHandle_t* outHandle, ncclDevResourceRequirements_t* outReq);
@@ -30,9 +27,15 @@ struct ncclLsaBarrierSession: ncclLsaBarrierSession_internal<Coop> {
 
   ncclLsaBarrierSession(ncclLsaBarrierSession const&) = delete; // Sessions are not copyable
 
+#if __HIP_PLATFORM_AMD__
+  NCCL_DEVICE_INLINE void arrive(Coop, std::memory_order);
+  NCCL_DEVICE_INLINE void wait(Coop, std::memory_order);
+  NCCL_DEVICE_INLINE void sync(Coop, std::memory_order);
+#else
   NCCL_DEVICE_INLINE void arrive(Coop, cuda::memory_order);
   NCCL_DEVICE_INLINE void wait(Coop, cuda::memory_order);
   NCCL_DEVICE_INLINE void sync(Coop, cuda::memory_order);
+#endif
 };
 #endif
 

--- a/projects/rccl/src/include/nccl_device/lsa_barrier.h
+++ b/projects/rccl/src/include/nccl_device/lsa_barrier.h
@@ -6,6 +6,7 @@
 
 #ifndef _NCCL_DEVICE_MEM_BARRIER_H_
 #define _NCCL_DEVICE_MEM_BARRIER_H_
+#include "hip_compat.h"
 #include "impl/core__types.h"
 #include "core_tmp.h"
 
@@ -27,15 +28,9 @@ struct ncclLsaBarrierSession: ncclLsaBarrierSession_internal<Coop> {
 
   ncclLsaBarrierSession(ncclLsaBarrierSession const&) = delete; // Sessions are not copyable
 
-#if __HIP_PLATFORM_AMD__
-  NCCL_DEVICE_INLINE void arrive(Coop, std::memory_order);
-  NCCL_DEVICE_INLINE void wait(Coop, std::memory_order);
-  NCCL_DEVICE_INLINE void sync(Coop, std::memory_order);
-#else
   NCCL_DEVICE_INLINE void arrive(Coop, cuda::memory_order);
   NCCL_DEVICE_INLINE void wait(Coop, cuda::memory_order);
   NCCL_DEVICE_INLINE void sync(Coop, cuda::memory_order);
-#endif
 };
 #endif
 

--- a/projects/rccl/src/include/sym_kernels.h
+++ b/projects/rccl/src/include/sym_kernels.h
@@ -13,13 +13,9 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 // ncclSymk[Foo]: Kernels built on the device API
-#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-#define NCCL_MEM_ORDER_RELAXED std::memory_order_relaxed
-#define NCCL_MEM_ORDER_RELEASE std::memory_order_release
-#else
+// cuda::memory_order is provided on HIP by hip_compat.h, pulled in transitively via nccl_device.h above.
 #define NCCL_MEM_ORDER_RELAXED cuda::memory_order_relaxed
 #define NCCL_MEM_ORDER_RELEASE cuda::memory_order_release
-#endif
 
 #define NCCL_SYM_KERNEL_CELL_SIZE 1024 // no less than 16 bytes minimal cell size
 


### PR DESCRIPTION
## Motivation

After the NCCL 2.28.9 sync, several headers under `nccl_device/` came in without working HIP paths, both the LSA barrier session and the GIN proxy header lost their HIP support

As a result, any RCCL TU (GIN, and rccl-tests with `ENABLE_DEVICE_API=1`) that includes `nccl_device.h` currently fails to build or link.

## Technical Details

RCCL
- `hip_compat.h` already exposes `cuda::memory_order` and `cuda::atomic_ref` on HIP, so the upstream barrier code can stay platform-neutral. 

- The `arrive` / `wait` / `sync` implementations in `impl/lsa_barrier__funcs.h` and the `ncclBarrierSession::sync` implementation in `impl/barrier__funcs.h` are enabled on HIP through that polyfill, same `cuda::memory_order` signature on both platforms

RCCL-TESTS
- `all_reduce.cu` and `alltoall.cu` previously had `#if __HIP_PLATFORM_AMD__ ... std::memory_order ... #else ... cuda::memory_order ... #endif` ladders around the LSA barrier session calls. With the unified API, the platform branches are removed and both files use `cuda::memory_order` directly.

- The `cuda::memory_order_*` enumerators resolve on HIP because each TU already `#include "nccl_device.h"`, which transitively pulls in `hip_compat.h`

## JIRA ID

AICOMRCCL-1063

## Test Plan

- Monitor CI
- Validate rccl and rccl-tests (ENABLE_DEVICE_API=1/0) release / debug builds on different ROCm versions
- Validate `all_reduce_perf` and `alltoall_perf` with `NCCL_CUMEM_ENABLE=1` and `-R 2` 

## Test Result

- Validated rccl and rccl-tests (ENABLE_DEVICE_API=1/0) build on ROCm 6.4.1, 7.0.2, 7.2.0, and 7.13.0
- Validated `./install.sh -l --generate-sym-kernels`
- Validated `all_reduce_perf` and `alltoall_perf` with `NCCL_CUMEM_ENABLE=1` and `-R 2` 
- Validated `topo_expl` build 

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
