### PR TITLE
Replace is_running_container check with generic handler binary check for coredumps

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/lnx/amd_core_dump.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/lnx/amd_core_dump.cpp
@@ -83,23 +83,6 @@ namespace {
 /* Implementation details */
 namespace impl {
 
-// Optional: Detect if running in a container
-namespace {
-[[nodiscard]] bool is_running_in_container() {
-  std::ifstream cgroup("/proc/1/cgroup");
-  if (!cgroup.is_open()) return false;
-
-  std::string line;
-  while (std::getline(cgroup, line)) {
-    if (line.find("docker") != std::string::npos ||
-        line.find("lxc") != std::string::npos ||
-        line.find("kubepods") != std::string::npos) {
-      return true;
-    }
-  }
-  return false;
-}
-} // anonymous namespace
 
 // Read kernel core pattern from /proc/sys/kernel/core_pattern
 static std::string read_kernel_core_pattern() {
@@ -747,17 +730,6 @@ hsa_status_t write_to_pipe_handler(const std::string& pattern,
                                           const SegmentsInfo& segments,
                                           size_t size_limit,
                                           bool show_progress) {
-  // Check if we're in a container
-  if (is_running_in_container() && custom_core_dump().empty()) {
-    fprintf(stderr,
-      "GPU coredump: System pipe patterns not supported in containers.\n"
-      "Falling back to file-based dump. Use custom pattern (HSA_COREDUMP_FILE)"
-      " to override.\n");
-    // Fall back to file-based dump
-    std::string filename = PREFIX_FILE_NAME + "." + std::to_string(getpid()) + ".gpu";
-    return build_core_dump(filename, segments, size_limit, show_progress);
-  }
-
   // Extract program and arguments (remove leading '|')
   std::string command = pattern.substr(1);
   std::string substituted = substitute_core_pattern(command);
@@ -768,15 +740,13 @@ hsa_status_t write_to_pipe_handler(const std::string& pattern,
     return HSA_STATUS_ERROR;
   }
 
-  // Verify the handler binary exists before forking, otherwise, the child
-  // would exit immediately and the parent would receive SIGPIPE.
-  // Only check absolute paths; bare names (e.g. "sh") rely on execvp's PATH
-  // lookup and are handled by the waitpid error path after fork.
   if (args[0][0] == '/' && access(args[0].c_str(), X_OK) != 0) {
     fprintf(stderr,
-            "GPU coredump: pipe handler '%s' not found or not executable, "
-            "skipping core dump\n", args[0].c_str());
-    return HSA_STATUS_ERROR;
+      "GPU coredump: Pipe handler '%s' not found or not executable.\n"
+      "Falling back to file-based dump. Set HSA_COREDUMP_PATTERN to override.\n",
+      args[0].c_str());
+    std::string filename = PREFIX_FILE_NAME + "." + std::to_string(getpid()) + ".gpu";
+    return build_core_dump(filename, segments, size_limit, show_progress);
   }
 
   // Create pipe for communication

--- a/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/lnx/amd_core_dump.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/lnx/amd_core_dump.cpp
@@ -83,23 +83,6 @@ namespace {
 /* Implementation details */
 namespace impl {
 
-// Optional: Detect if running in a container
-namespace {
-[[nodiscard]] bool is_running_in_container() {
-  std::ifstream cgroup("/proc/1/cgroup");
-  if (!cgroup.is_open()) return false;
-
-  std::string line;
-  while (std::getline(cgroup, line)) {
-    if (line.find("docker") != std::string::npos ||
-        line.find("lxc") != std::string::npos ||
-        line.find("kubepods") != std::string::npos) {
-      return true;
-    }
-  }
-  return false;
-}
-} // anonymous namespace
 
 // Read kernel core pattern from /proc/sys/kernel/core_pattern
 static std::string read_kernel_core_pattern() {
@@ -747,17 +730,6 @@ hsa_status_t write_to_pipe_handler(const std::string& pattern,
                                           const SegmentsInfo& segments,
                                           size_t size_limit,
                                           bool show_progress) {
-  // Check if we're in a container
-  if (is_running_in_container() && custom_core_dump().empty()) {
-    fprintf(stderr,
-      "GPU coredump: System pipe patterns not supported in containers.\n"
-      "Falling back to file-based dump. Use custom pattern (HSA_COREDUMP_FILE)"
-      " to override.\n");
-    // Fall back to file-based dump
-    std::string filename = PREFIX_FILE_NAME + "." + std::to_string(getpid()) + ".gpu";
-    return build_core_dump(filename, segments, size_limit, show_progress);
-  }
-
   // Extract program and arguments (remove leading '|')
   std::string command = pattern.substr(1);
   std::string substituted = substitute_core_pattern(command);
@@ -767,6 +739,16 @@ hsa_status_t write_to_pipe_handler(const std::string& pattern,
     fprintf(stderr, "GPU coredump: Invalid pipe pattern\n");
     return HSA_STATUS_ERROR;
   }
+
+  if (access(args[0].c_str(), X_OK) != 0) {
+    fprintf(stderr,
+      "GPU coredump: Pipe handler '%s' not found or not executable.\n"
+      "Falling back to file-based dump. Set HSA_COREDUMP_PATTERN to override.\n",
+      args[0].c_str());
+    std::string filename = PREFIX_FILE_NAME + "." + std::to_string(getpid()) + ".gpu";
+    return build_core_dump(filename, segments, size_limit, show_progress);
+  }
+
   // Create pipe for communication
   int pipefd[2];
   if (pipe(pipefd) == -1) {


### PR DESCRIPTION
## Motivation

Resolves https://github.com/ROCm/rocm-systems/issues/6206

## Technical Details

`is_running_in_container()` checks /proc/1/cgroup for docker, lxc, or kubepods strings. This detection is broken on cgroup v2 systems (CentOS Stream 9, Ubuntu 22.04+, Fedora 31+) where /proc/1/cgroup contains only 0::/.

Replace existing check with a more generic check `access(args[0].c_str(), X_OK)` to see if handler binary is available which can cover more failure cases (containers, minimal installs, chroots.etc) 

## Test Plan

  - Built a test program that reproduces the write_to_pipe_handler() logic from amd_core_dump.cpp and ran in rocm/dev-ubuntu-22.04 container. Test both pre and post fix.

## Test Result

Prior to Fix: 
```
GPU coredump: execvp failed: No such file or directory
GPU coredump: handler exited with error (status: 1)                                                                                                                                                                                                    
```
Post Fix:
```
GPU coredump: Pipe handler '/usr/share/apport/apport' not found or not executable.                                                                                                                                                                     
Falling back to file-based dump. Set HSA_COREDUMP_PATTERN to override.                                                                                                                                                                                 
GPU core dump created: gpucore.1.gpu 
```
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
