### PR TITLE
[RCCL] Enable GIN Proxy Backend

### DIFF
--- a/projects/rccl/src/gin/gin_host_proxy.cc
+++ b/projects/rccl/src/gin/gin_host_proxy.cc
@@ -99,6 +99,8 @@ static ncclResult_t getDmaBufFd(void *addr, size_t length, int *fd,
                                 bool forceNonDataDirect = false) {
   if (ncclParamDmaBufEnable() == 0) return ncclInvalidUsage;
 
+  // GIN's symmetric windows are cuMem/VMM allocations registered with the NIC via ibv_reg_dmabuf_mr.
+  // the cuMem/hipMemGetHandleForAddressRange that exports the DMA-BUF FD requires this HIP version.
 #if CUDA_VERSION >= 11070 || HIP_VERSION >= 71260540
   static size_t hostPageSize = sysconf(_SC_PAGESIZE);
   size_t alignedSize = length;

--- a/projects/rccl/src/gin/gin_host_proxy.cc
+++ b/projects/rccl/src/gin/gin_host_proxy.cc
@@ -99,7 +99,7 @@ static ncclResult_t getDmaBufFd(void *addr, size_t length, int *fd,
                                 bool forceNonDataDirect = false) {
   if (ncclParamDmaBufEnable() == 0) return ncclInvalidUsage;
 
-#if CUDA_VERSION >= 11070
+#if CUDA_VERSION >= 11070 || HIP_VERSION >= 71260540
   static size_t hostPageSize = sysconf(_SC_PAGESIZE);
   size_t alignedSize = length;
   ALIGN_SIZE(alignedSize, hostPageSize);
@@ -112,8 +112,16 @@ static ncclResult_t getDmaBufFd(void *addr, size_t length, int *fd,
     if (status == CUDA_SUCCESS) return ncclSuccess;
   }
 #endif
+
+#if defined(__HIP_PLATFORM_AMD__)
+  // Direct call: hipified to hipMemGetHandleForAddressRange on HIP at build time.
+  // Same pattern as transport/net.cc and transport/coll_net.cc.
+  CUresult status = cuMemGetHandleForAddressRange((void *)fd, (CUdeviceptr)addr, alignedSize,
+                                                  CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0);
+#else
   CUresult status = pfn_cuMemGetHandleForAddressRange((void *)fd, (CUdeviceptr)addr, alignedSize,
                                                       CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0);
+#endif
   if (status == CUDA_SUCCESS) return ncclSuccess;
 #endif
 
@@ -192,9 +200,20 @@ static int proxyGinPollGfd(struct ginProxyCtx *ctx, ginProxyHostGpuCtx *hostGpuC
   // Now we have the full GFD in the local struct.
 
   // Reset the GFD in the queue. This lets the producer know that the GFD is consumed.
+  // On HIP, NT-stores avoid an RFO stall behind in-flight PCIe writes from the GPU
+  // (can cost 80-200us under multi-GPU contention).
+#if defined(__HIP_PLATFORM_AMD__)
+  for (int k = 0; k < ncclGinProxyGfdQwords; k++) {
+    __builtin_nontemporal_store((uint64_t)0, &q[idx].qword[k].raw);
+  }
+  // Drain WC buffers so the NT-zero stores are visible before the credit (ci) advance,
+  // otherwise the GPU producer could overwrite the slot before the zeros land.
+  wc_store_fence();
+#else
   for (int k = 0; k < ncclGinProxyGfdQwords; k++) {
     __atomic_store_n(&q[idx].qword[k].raw, 0, __ATOMIC_RELAXED);
   }
+#endif
 
   // set the counter_id into the state
   uint32_t stateIdx = targetRank * hostGpuCtx->queueSize + idx;
@@ -222,8 +241,13 @@ static int proxyGinPollGfd(struct ginProxyCtx *ctx, ginProxyHostGpuCtx *hostGpuC
 }
 
 static int mapGfdOpToCollNetOp(ncclGinProxyGfd_t *gfd) {
+  // Mask down to the signal-op bits only. WithInline and WithCounter are
+  // orthogonal modifiers and must be excluded -- otherwise an inline put
+  // with SignalInc (op = Put|WithInline|WithSignalInc = 0x0b) masks to
+  // 0x0a and falls through to default, silently demoting iputSignal to a
+  // plain iput so the remote signal cell never gets bumped.
   switch (gfd->qword[ncclGinProxyGfdHeader].header.op &
-          (ncclGinProxyOpComplMask & ~ncclGinProxyOpWithCounter)) {
+          (ncclGinProxyOpWithSignalInc | ncclGinProxyOpWithSignalAdd)) {
     case ncclGinProxyOpWithSignalInc:
       return NCCL_NET_SIGNAL_OP_INC;
     case ncclGinProxyOpWithSignalAdd:
@@ -243,8 +267,13 @@ static ncclResult_t proxyGinProcessGfd(ncclGin_t *ginComm, void *collComm, struc
   uint64_t srcOff;
   void *srcHandle;
   if (gfd->qword[ncclGinProxyGfdHeader].header.op & ncclGinProxyOpWithInline) {
-    uint64_t *inlineVal = &hostGpuCtx->inlines[gfd - hostGpuCtx->queues];
-    srcOff = (uint64_t)&inlineVal[0] - (uint64_t)hostGpuCtx->inlines;
+    // `gfd` is a stack-local copy filled by proxyGinPollGfd, not a pointer
+    // into hostGpuCtx->queues, so we cannot do `gfd - hostGpuCtx->queues` to
+    // recover its slot index. Recover it from `state` instead, which is a
+    // real heap pointer (`*state = &hostGpuCtx->states[stateIdx]`).
+    size_t slotIdx = state - hostGpuCtx->states;
+    uint64_t *inlineVal = &hostGpuCtx->inlines[slotIdx];
+    srcOff = slotIdx * sizeof(uint64_t);
     // reconstruct the inline value from the two qwords
     *inlineVal = gfd->qword[ncclGinProxyGfdInlineLow].inlineLow.inlineValLow;
     if (size == 8) {

--- a/projects/rccl/src/include/alloc.h
+++ b/projects/rccl/src/include/alloc.h
@@ -155,6 +155,7 @@ static inline ncclResult_t ncclCuMemHostAlloc(void** ptr, CUmemGenericAllocation
   prop.location.type = CU_MEM_LOCATION_TYPE_HOST;
   prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
   prop.requestedHandleTypes = type; // So it can be exported
+  // HIP/CLR requires host id to be 0. cpuNumaNodeId can exceed GPU count and fail.
   prop.location.id = 0;             // ignored on the Host path
 #else
   prop.location.type = CU_MEM_LOCATION_TYPE_HOST_NUMA;

--- a/projects/rccl/src/include/alloc.h
+++ b/projects/rccl/src/include/alloc.h
@@ -27,6 +27,11 @@
 #include "cudawrap.h"
 #endif
 
+#if ROCM_VERSION >= 71200
+#include <hip/hip_runtime.h>
+#include "rocmwrap.h"
+#endif
+
 // Global flag to detect process shutdown. Set by atexit handler before
 // HIP runtime static destructors run. This prevents use-after-free crashes
 // when RCCL proxy threads try to free GPU memory during process exit.
@@ -125,7 +130,7 @@ static inline ncclResult_t getSideStream(cudaStream_t *stream) {
   return ncclSuccess;
 }
 
-#if CUDART_VERSION >= 12020
+#if CUDART_VERSION >= 12020 || ROCM_VERSION >= 71200
 
 static inline ncclResult_t ncclCuMemHostAlloc(void** ptr, CUmemGenericAllocationHandle *handlep, size_t size) {
   ncclResult_t result = ncclSuccess;
@@ -145,10 +150,18 @@ static inline ncclResult_t ncclCuMemHostAlloc(void** ptr, CUmemGenericAllocation
   CUCHECK(cuDeviceGet(&currentDev, cudaDev));
   CUCHECK(cuDeviceGetAttribute(&cpuNumaNodeId, CU_DEVICE_ATTRIBUTE_HOST_NUMA_ID, currentDev));
   if (cpuNumaNodeId < 0) cpuNumaNodeId = 0;
+#if defined(__HIP_PLATFORM_AMD__)
+  // CLR rejects HostNuma; only Device or Host are accepted.
+  prop.location.type = CU_MEM_LOCATION_TYPE_HOST;
+  prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+  prop.requestedHandleTypes = type; // So it can be exported
+  prop.location.id = 0;             // ignored on the Host path
+#else
   prop.location.type = CU_MEM_LOCATION_TYPE_HOST_NUMA;
   prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
   prop.requestedHandleTypes = type; // So it can be exported
   prop.location.id = cpuNumaNodeId;
+#endif
   CUCHECK(cuMemGetAllocationGranularity(&granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM));
   ALIGN_SIZE(size, granularity);
   /* Allocate the physical memory on the device */
@@ -167,13 +180,19 @@ static inline ncclResult_t ncclCuMemHostAlloc(void** ptr, CUmemGenericAllocation
   CUCHECKGOTO(cuMemSetAccess((CUdeviceptr)*ptr, size, &accessDesc, 1), result, fail);
 
   /* Now allow RW access to the newly mapped memory from the CPU */
+#if defined(__HIP_PLATFORM_AMD__)
+  // CLR rejects HostNuma here too; mirror the Host fallback used at allocation.
+  accessDesc.location.type = CU_MEM_LOCATION_TYPE_HOST;
+  accessDesc.location.id = 0;
+#else
   accessDesc.location.type = CU_MEM_LOCATION_TYPE_HOST_NUMA;
   accessDesc.location.id = cpuNumaNodeId;
+#endif
   accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
   CUCHECKGOTO(cuMemSetAccess((CUdeviceptr)*ptr, size, &accessDesc, 1), result, fail);
 
   if (handlep) *handlep = handle;
-  INFO(NCCL_ALLOC, "CUMEM Host Alloc Size %zi pointer %p handle %llx numa %d dev %d granularity %ld", size, *ptr, handle, cpuNumaNodeId, cudaDev, granularity);
+  INFO(NCCL_ALLOC, "CUMEM Host Alloc Size %zi pointer %p handle %p numa %d dev %d granularity %ld", size, *ptr, (void*)(uintptr_t)handle, cpuNumaNodeId, cudaDev, granularity);
   return result;
 fail:
   WARN("ncclCuMemHostAlloc failed (size %zu, dev %d): cleaning up partial allocation", size, cudaDev);
@@ -195,7 +214,7 @@ static inline ncclResult_t ncclCuMemHostFree(void* ptr) {
   CUCHECK(cuMemRetainAllocationHandle(&handle, ptr));
   CUCHECK(cuMemRelease(handle));
   CUCHECK(cuMemGetAddressRange(&base, &size, (CUdeviceptr)ptr));
-  TRACE(NCCL_ALLOC, "CUMEM Host Free Size %zi pointer %p handle 0x%llx", size, ptr, handle);
+  TRACE(NCCL_ALLOC, "CUMEM Host Free Size %zi pointer %p handle %p", size, ptr, (void*)(uintptr_t)handle);
   CUCHECK(cuMemUnmap((CUdeviceptr)ptr, size));
   CUCHECK(cuMemRelease(handle));
   CUCHECK(cuMemAddressFree((CUdeviceptr)ptr, size));

--- a/projects/rccl/src/include/nccl_device/gin/proxy/gin_proxy.h
+++ b/projects/rccl/src/include/nccl_device/gin/proxy/gin_proxy.h
@@ -12,6 +12,10 @@
 #include <cstdint>
 #include <cuda_runtime.h>
 #include <cooperative_groups.h>
+#if defined(__HIP_PLATFORM_AMD__)
+// HIP analog of CUDA __stwt: dwordx4 builtins, v4u typedefs, system sync scope.
+#include "nccl_device/rccl_ptr.h"
+#endif
 #include "nccl.h"
 #include "nccl_device/utility.h"
 #include "../gin_device_host_common.h"
@@ -50,11 +54,23 @@ NCCL_DEVICE_INLINE void postGfd(Coop coop, ncclGinProxyGpuCtx_t* proxyCtx, ncclG
     while (queueSize <= idx - ci.load(cuda::memory_order_relaxed)) {
     }
     idx &= queueSize - 1;
-// 4x16 byte store with the write-through cache hint
+// 4x16 byte store
+// Cache-bypassing into the host-mapped queue: __stwt on NVIDIA,
+// system-scope dwordx4 (or NT-store fallback) on HIP - avoids a costly __threadfence_system().
 #pragma unroll
     for (uint8_t i = 0; i < 4; i++) {
 #if defined(__HIP_PLATFORM_AMD__)
-      *((uint4*)&q[idx] + i) = ((uint4*)gfd)[i];
+  #if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
+      union { v4u vec; uint4 u; } pkt;
+      pkt.u = ((uint4*)gfd)[i];
+      __builtin_amdgcn_global_store_b128((v4u_gptr)((uint4*)&q[idx] + i), pkt.vec,
+                                         RCCL_SYSTEM_SYNCSCOPE);
+  #else
+      uint64_t* p64 = reinterpret_cast<uint64_t*>((uint4*)&q[idx] + i);
+      const uint64_t* g64 = reinterpret_cast<const uint64_t*>((uint4*)gfd + i);
+      __builtin_nontemporal_store(g64[0], (u64_gptr)(p64 + 0));
+      __builtin_nontemporal_store(g64[1], (u64_gptr)(p64 + 1));
+  #endif
 #else
       __stwt((uint4*)&q[idx] + i, ((uint4*)gfd)[i]);
 #endif

--- a/projects/rccl/src/include/nccl_device/impl/gin__funcs.h
+++ b/projects/rccl/src/include/nccl_device/impl/gin__funcs.h
@@ -373,7 +373,7 @@ template<typename Coop, typename Uint>
 NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::waitSignalFollowShadow(Coop coop, ncclGinSignal_t signal, Uint leastDelta, Uint* before, Uint* delta, int bits, cuda::memory_order ord) const {
   coop.sync();
   uint64_t before64 = this->_signalShadows[signal];
-  uint64_t after64;
+  uint64_t after64 = 0;  // must be initialized: non-root threads pass it to ncclCoopBcast (undefined behavior if uninitialized)
   if (coop.thread_rank() == 0) {
     uint64_t* ptr = ncclGinCall<ncclGinApi_GetSignalPtr>(this->_makeCtx(), this->comm.ginSignalBase + signal);
     #pragma unroll 1

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -764,7 +764,6 @@ static ncclResult_t commAlloc(struct ncclComm* comm, struct ncclComm* parent, in
   comm->forcePatEnable = (parent != nullptr) ? parent->forcePatEnable : false;
 
   if (parent == NULL || !parent->shareResources) {
-    NCCLCHECK(ncclNetInit(comm));
     struct ncclSharedResources* sharedRes = NULL;
     NCCLCHECK(ncclCalloc(&sharedRes, 1));
     sharedRes->owner = comm;
@@ -776,6 +775,7 @@ static ncclResult_t commAlloc(struct ncclComm* comm, struct ncclComm* parent, in
     CUDACHECK(cudaEventCreateWithFlags(&sharedRes->scratchEvent, cudaEventDisableTiming));
     comm->sharedRes = sharedRes;
     sharedRes->refCount = 1;
+    NCCLCHECK(ncclNetInit(comm));
   } else {
     comm->sharedRes = parent->sharedRes;
     ncclAtomicRefCountIncrement(&parent->sharedRes->refCount);

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -882,24 +882,6 @@ static ncclResult_t commAlloc(struct ncclComm* comm, struct ncclComm* parent, in
   // Mark channels as non initialized.
   for (int c=0; c < MAXCHANNELS; c++) comm->channels[c].id = -1;
 
-  if (parent == NULL || !parent->shareResources) {
-    struct ncclSharedResources* sharedRes = NULL;
-    NCCLCHECK(ncclCalloc(&sharedRes, 1));
-    /* most of attributes are assigned later in initTransportsRank(). */
-    sharedRes->owner = comm;
-    sharedRes->tpNRanks = comm->nRanks;
-    NCCLCHECK(ncclCalloc(&sharedRes->tpRankToLocalRank, comm->nRanks));
-    NCCLCHECK(ncclStrongStreamConstruct(&sharedRes->deviceStream));
-    NCCLCHECK(ncclStrongStreamConstruct(&sharedRes->hostStream));
-    CUDACHECK(cudaEventCreateWithFlags(&sharedRes->launchEvent, cudaEventDisableTiming));
-    CUDACHECK(cudaEventCreateWithFlags(&sharedRes->scratchEvent, cudaEventDisableTiming));
-    comm->sharedRes = sharedRes;
-    sharedRes->refCount = 1;
-  } else {
-    comm->sharedRes = parent->sharedRes;
-    ncclAtomicRefCountIncrement(&parent->sharedRes->refCount);
-  }
-
   CUDACHECK(hipDeviceGetAttribute(&comm->WarpSize, hipDeviceAttributeWarpSize, comm->cudaDev));
   if (comm->topParentRanks == NULL) {
     NCCLCHECK(ncclCalloc(&comm->topParentRanks, comm->nRanks));

--- a/projects/rccl/src/misc/rocmwrap.cc
+++ b/projects/rccl/src/misc/rocmwrap.cc
@@ -136,10 +136,11 @@ int ncclCuMemHostEnable() {
       CUCHECK(cuDeviceGet(&currentDev, cudaDev));
       CUCHECK(cuDeviceGetAttribute(&cpuNumaNodeId, hipDeviceAttributeHostNumaId, currentDev));
       if (cpuNumaNodeId < 0) cpuNumaNodeId = 0;
-      prop.location.type = hipMemLocationTypeHostNuma;
+      // CLR rejects HostNuma; probe with Host to match alloc.h's ncclCuMemHostAlloc.
+      prop.location.type = hipMemLocationTypeHost;
       prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
       prop.requestedHandleTypes = ncclCuMemHandleType;
-      prop.location.id = cpuNumaNodeId;
+      prop.location.id = 0;  // ignored on the Host path
       CUCHECK(cuMemGetAllocationGranularity(&granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM));
       size = 1;
       ALIGN_SIZE(size, granularity);

--- a/projects/rccl/src/misc/rocmwrap.cc
+++ b/projects/rccl/src/misc/rocmwrap.cc
@@ -140,6 +140,7 @@ int ncclCuMemHostEnable() {
       prop.location.type = hipMemLocationTypeHost;
       prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
       prop.requestedHandleTypes = ncclCuMemHandleType;
+      // HIP/CLR requires host id to be 0. cpuNumaNodeId can exceed GPU count and fail.
       prop.location.id = 0;  // ignored on the Host path
       CUCHECK(cuMemGetAllocationGranularity(&granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM));
       size = 1;

--- a/projects/rccl/src/plugin/net.cc
+++ b/projects/rccl/src/plugin/net.cc
@@ -343,8 +343,10 @@ static void initPluginLibsOnceFunc() {
         netPluginLibs[pluginCounter].ncclGin = (ncclGin_t *)-1;
       else if (ncclParamGinType() == NCCL_NET_DEVICE_GIN_PROXY)
         netPluginLibs[pluginCounter].ncclGin = &ncclGinIbProxy;
+#if !defined(__HIP_PLATFORM_AMD__)
       else if (ncclParamGinType() == NCCL_NET_DEVICE_GIN_GDAKI)
         netPluginLibs[pluginCounter].ncclGin = &ncclGinIbGdaki;
+#endif
       netPluginLibs[pluginCounter].ncclNetPluginState = ncclNetPluginStateInitReady;
       netPluginLibs[pluginCounter].ncclGinPluginState = netPluginLibs[pluginCounter].ncclGin ? ncclNetPluginStateInitReady : ncclNetPluginStateLoadFailed;
       ++pluginCounter;

--- a/projects/rccl/src/plugin/net.cc
+++ b/projects/rccl/src/plugin/net.cc
@@ -338,7 +338,16 @@ static void initPluginLibsOnceFunc() {
     } else {
 #endif
       netPluginLibs[pluginCounter].ncclNet = &ncclNetIb;
-      netPluginLibs[pluginCounter++].ncclNetPluginState = ncclNetPluginStateInitReady;
+      netPluginLibs[pluginCounter].ncclGin = NULL;
+      if (ncclParamGinType() == -1)
+        netPluginLibs[pluginCounter].ncclGin = (ncclGin_t *)-1;
+      else if (ncclParamGinType() == NCCL_NET_DEVICE_GIN_PROXY)
+        netPluginLibs[pluginCounter].ncclGin = &ncclGinIbProxy;
+      else if (ncclParamGinType() == NCCL_NET_DEVICE_GIN_GDAKI)
+        netPluginLibs[pluginCounter].ncclGin = &ncclGinIbGdaki;
+      netPluginLibs[pluginCounter].ncclNetPluginState = ncclNetPluginStateInitReady;
+      netPluginLibs[pluginCounter].ncclGinPluginState = netPluginLibs[pluginCounter].ncclGin ? ncclNetPluginStateInitReady : ncclNetPluginStateLoadFailed;
+      ++pluginCounter;
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
     }
   }

--- a/projects/rccl/test/AllocTests.cpp
+++ b/projects/rccl/test/AllocTests.cpp
@@ -44,6 +44,10 @@ TEST(Alloc, ncclIbMallocDebugZeroSize)
     EXPECT_EQ(ptr, nullptr);
 }
 
+#if ROCM_VERSION < 71200
+// These tests exercise the unsupported-fallback path of ncclCuMemHostAlloc/Free
+// that returns ncclInternalError. On ROCm 7.12+ the real implementation is
+// compiled in, so the fallback no longer exists and these tests are not applicable.
 TEST(Alloc, ncclCuMemHostAlloc)
 {
     RUN_ISOLATED_TEST(
@@ -71,6 +75,7 @@ TEST(Alloc, ncclCuMemHostFree)
         }
     );
 }
+#endif // ROCM_VERSION < 71200
 
 #if ROCM_VERSION < 70000
 // This test is only valid for ROCm versions < 7.0.0

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -214,6 +214,7 @@ if(BUILD_TESTS)
       RomeTopoConsensusTests.cpp
       EnqueueCountTests.cpp
       device/TestOp128.cpp
+      device/GinDeviceTests.cpp
       common/main_fixtures.cpp
       common/EnvVars.cpp
       common/ProcessIsolatedTestRunner.cpp
@@ -298,6 +299,7 @@ if(BUILD_TESTS)
       transport/NetIbMPI/FaultInjectTests.cpp
       transport/GinMPI/GinMPITests.cpp
       transport/NetIbMPI/StressTests.cpp
+      transport/GinDeviceMPITests.cpp
       ImplicitLaunchOrderMPITests.cpp
       CommMPITests.cpp
       RegistrationMPITests.cpp

--- a/projects/rccl/test/device/GinDeviceTests.cpp
+++ b/projects/rccl/test/device/GinDeviceTests.cpp
@@ -1,0 +1,889 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Single-GPU device-leaf tests for the GIN proxy backend.
+
+#include "DeviceTestBase.hpp"
+
+// gin_proxy.h declares specializations of templates (ncclGinApi_Put, ...) and
+// references ncclGinCtx / ncclGinDescriptorSmem; their primary declarations
+// live in gin_device_common.h, which must be included first.
+#include "nccl_device/coop.h"
+#include "nccl_device/gin/gin_device_host_common.h"
+#include "nccl_device/gin/gin_device_common.h"
+#include "nccl_device/gin/proxy/gin_proxy.h"
+#include "nccl_device/gin/proxy/gin_proxy_device_host_common.h"
+
+#include <iomanip>
+
+namespace RcclUnitTesting
+{
+
+class GinDeviceTest : public DeviceTestBase {};
+
+// ---------------------------------------------------------------------------
+// ConstructProxyOp: pack (hasInline, hasSignal, signalOp, hasCounter) -> op byte
+// ---------------------------------------------------------------------------
+
+struct OpCase {
+  bool     hasInline;
+  bool     hasSignal;
+  uint32_t signalOp;   // unused when hasSignal == false
+  bool     hasCounter;
+};
+
+// Host-side reference encoding.
+static uint8_t expectedOp(const OpCase& c) {
+  uint8_t op = static_cast<uint8_t>(ncclGinProxyOpPut);
+  if (c.hasInline)  op |= static_cast<uint8_t>(ncclGinProxyOpWithInline);
+  if (c.hasCounter) op |= static_cast<uint8_t>(ncclGinProxyOpWithCounter);
+  if (c.hasSignal) {
+    if (c.signalOp == static_cast<uint32_t>(ncclGinSignalInc))
+      op |= static_cast<uint8_t>(ncclGinProxyOpWithSignalInc);
+    else
+      op |= static_cast<uint8_t>(ncclGinProxyOpWithSignalAdd);
+  }
+  return op;
+}
+
+__global__ void kernelConstructProxyOp(const OpCase* __restrict__ in,
+                                       uint8_t* __restrict__ out,
+                                       int n) {
+  int i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i >= n) return;
+  ncclGinProxyOp_t op;
+  nccl::gin::proxy::constructProxyOp(
+      op,
+      in[i].hasInline,
+      in[i].hasSignal,
+      static_cast<ncclGinSignalOp_t>(in[i].signalOp),
+      in[i].hasCounter);
+  out[i] = static_cast<uint8_t>(op);
+}
+
+TEST_F(GinDeviceTest, ConstructProxyOp) {
+  // 12 effective cases: 2 (hasInline) * 2 (hasCounter) * 3 (no-signal | Inc | Add).
+  std::vector<OpCase> cases;
+  cases.reserve(12);
+  for (bool hasInline : {false, true}) {
+    for (bool hasCounter : {false, true}) {
+      cases.push_back({hasInline, /*hasSignal=*/false,
+                       static_cast<uint32_t>(ncclGinSignalInc), hasCounter});
+      cases.push_back({hasInline, /*hasSignal=*/true,
+                       static_cast<uint32_t>(ncclGinSignalInc), hasCounter});
+      cases.push_back({hasInline, /*hasSignal=*/true,
+                       static_cast<uint32_t>(ncclGinSignalAdd), hasCounter});
+    }
+  }
+  const int N = static_cast<int>(cases.size());
+  ASSERT_EQ(N, 12);
+
+  DeviceBuffer<OpCase>  d_in(N);
+  DeviceBuffer<uint8_t> d_out(N);
+  d_in.copyFrom(cases);
+  d_out.zero();
+
+  kernelConstructProxyOp<<<gridFor(N), kDefaultBlockSize>>>(d_in.ptr, d_out.ptr, N);
+  syncAndCheck();
+
+  std::vector<uint8_t> h_out = d_out.copyTo();
+  for (int i = 0; i < N; i++) {
+    const uint8_t got = h_out[i];
+    const uint8_t exp = expectedOp(cases[i]);
+    EXPECT_EQ(got, exp)
+      << "case " << i
+      << ": hasInline="  << cases[i].hasInline
+      << ", hasSignal="  << cases[i].hasSignal
+      << ", signalOp="   << cases[i].signalOp
+      << ", hasCounter=" << cases[i].hasCounter
+      << "; got=0x"      << std::hex << static_cast<int>(got)
+      << ", expected=0x" << std::hex << static_cast<int>(exp);
+  }
+
+  // All-flags-off case must equal Put exactly (no stray bits OR'd in).
+  for (int i = 0; i < N; i++) {
+    if (!cases[i].hasInline && !cases[i].hasSignal && !cases[i].hasCounter) {
+      EXPECT_EQ(h_out[i], static_cast<uint8_t>(ncclGinProxyOpPut))
+        << "Base case (no flags) at index " << i << " is not ncclGinProxyOpPut";
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// BuildGfd_PutOnly: pack a 64-byte GFD for a non-inline put (no signal, no counter)
+// ---------------------------------------------------------------------------
+
+__global__ void kernelBuildGfdPutOnly(ncclGinProxyGfd_t* gfd,
+                                      uint64_t srcOff, uint64_t srcHandle,
+                                      uint64_t dstOff, uint64_t dstHandle,
+                                      uint64_t size) {
+  if (threadIdx.x != 0 || blockIdx.x != 0) return;
+  nccl::gin::proxy::buildGfd<uint64_t>(
+      gfd,
+      ncclGinProxyOpPut,
+      /*srcVal=*/0ULL,                                   // unused (hasInline=false)
+      /*hasInline=*/false,
+      /*srcOff=*/srcOff,
+      /*srcHandle=*/reinterpret_cast<ncclGinWindow_t>(srcHandle),
+      /*dstOff=*/dstOff,
+      /*dstHandle=*/reinterpret_cast<ncclGinWindow_t>(dstHandle),
+      /*size=*/size,
+      /*counterId=*/0,
+      /*signalId=*/0,
+      /*signalVal=*/0);
+}
+
+TEST_F(GinDeviceTest, BuildGfd_PutOnly) {
+  static_assert(sizeof(ncclGinProxyGfd_t) == 64, "GFD must be 64 bytes");
+
+  // Distinctive 48-bit values so bit-corruption in any qword is visible.
+  // Each constant is a rotation of 0x0123456789ABCDEF truncated to 48 bits,
+  // so every byte differs across the four constants.
+  constexpr uint64_t kSrcOff    = 0x0000123456789ABCULL;
+  constexpr uint64_t kSrcHandle = 0x000056789ABCDEF0ULL;
+  constexpr uint64_t kDstOff    = 0x00009ABCDEF01234ULL;
+  constexpr uint64_t kDstHandle = 0x0000DEF012345678ULL;
+  constexpr uint64_t kSize      = 4096;
+
+  DeviceBuffer<ncclGinProxyGfd_t> d_gfd(1);
+  d_gfd.zero();   // start from zeros so we know exactly what buildGfd wrote
+
+  kernelBuildGfdPutOnly<<<1, 1>>>(d_gfd.ptr, kSrcOff, kSrcHandle, kDstOff, kDstHandle, kSize);
+  syncAndCheck();
+
+  const ncclGinProxyGfd_t gfd = d_gfd.download();
+
+  // Header qword: flag, op, size.
+  EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdHeader].header.flag), 1ULL);
+  EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdHeader].header.op),
+            static_cast<uint64_t>(ncclGinProxyOpPut));
+  EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdHeader].header.size), kSize);
+
+  // Source address qwords (only valid in the hasInline=false branch).
+  EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdSrcOff].srcOff.flag), 1ULL);
+  EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdSrcOff].srcOff.srcOff), kSrcOff);
+  EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdSrcHandle].srcHandle.flag), 1ULL);
+  EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdSrcHandle].srcHandle.srcHandle),
+            kSrcHandle);
+
+  // Destination address qwords.
+  EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdDstOff].dstOff.flag), 1ULL);
+  EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdDstOff].dstOff.dstOff), kDstOff);
+  EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdDstHandle].dstHandle.flag), 1ULL);
+  EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdDstHandle].dstHandle.dstHandle),
+            kDstHandle);
+
+  // Completion qword: flag set, ids and signal-value-low zero (no signal/counter).
+  EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdCompletion].completion.flag), 1ULL);
+  EXPECT_EQ(static_cast<uint32_t>(gfd.qword[ncclGinProxyGfdCompletion].completion.counterId), 0u);
+  EXPECT_EQ(static_cast<uint32_t>(gfd.qword[ncclGinProxyGfdCompletion].completion.signalId), 0u);
+  EXPECT_EQ(static_cast<uint32_t>(gfd.qword[ncclGinProxyGfdCompletion].completion.signalValLow), 0u);
+
+  // SignalVal qword: flag set, high halves of signalVal zero (no signal).
+  EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdSignalVal].signalVal.flag), 1ULL);
+  EXPECT_EQ(static_cast<uint32_t>(gfd.qword[ncclGinProxyGfdSignalVal].signalVal.signalValLow2), 0u);
+  EXPECT_EQ(static_cast<uint32_t>(gfd.qword[ncclGinProxyGfdSignalVal].signalVal.signalValHigh), 0u);
+
+  // Reserved qword: end-of-GFD marker.
+  EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdReserved].flag.v), 1ULL);
+}
+
+// ---------------------------------------------------------------------------
+// BuildGfd_Inline: pack a 64-byte GFD for an inline put (hasInline=true).
+//   T=uint32_t -> only inlineValLow holds data; sizeof(T)>4/>6 branches stay quiet.
+//   T=uint64_t -> value splits as 32 (Low) + 16 (Low2) + 16 (High) bits.
+// ---------------------------------------------------------------------------
+
+template<typename T>
+__global__ void kernelBuildGfdInline(ncclGinProxyGfd_t* gfd, T srcVal,
+                                     uint64_t dstOff, uint64_t dstHandle) {
+  if (threadIdx.x != 0 || blockIdx.x != 0) return;
+  nccl::gin::proxy::buildGfd<T>(
+      gfd,
+      ncclGinProxyOpPut,
+      srcVal,
+      /*hasInline=*/true,
+      /*srcOff=*/0,                                        // unused (hasInline=true)
+      /*srcHandle=*/reinterpret_cast<ncclGinWindow_t>(0),  // unused (hasInline=true)
+      /*dstOff=*/dstOff,
+      /*dstHandle=*/reinterpret_cast<ncclGinWindow_t>(dstHandle),
+      /*size=*/sizeof(T),
+      /*counterId=*/0,
+      /*signalId=*/0,
+      /*signalVal=*/0);
+}
+
+TEST_F(GinDeviceTest, BuildGfd_Inline) {
+  static_assert(sizeof(ncclGinProxyGfd_t) == 64, "GFD must be 64 bytes");
+
+  constexpr uint64_t kDstOff    = 0x00009ABCDEF01234ULL;
+  constexpr uint64_t kDstHandle = 0x0000DEF012345678ULL;
+  constexpr uint32_t kValU32    = 0xA5B6C7D8u;
+  constexpr uint64_t kValU64    = 0x0123456789ABCDEFULL;
+
+  // ---- uint32_t (4-byte): only inlineValLow set; Low2 and High stay zero ----
+  {
+    DeviceBuffer<ncclGinProxyGfd_t> d_gfd(1);
+    d_gfd.zero();
+
+    kernelBuildGfdInline<uint32_t><<<1, 1>>>(d_gfd.ptr, kValU32, kDstOff, kDstHandle);
+    syncAndCheck();
+
+    const ncclGinProxyGfd_t gfd = d_gfd.download();
+
+    EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdHeader].header.flag), 1ULL) << "u32";
+    EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdHeader].header.op),
+              static_cast<uint64_t>(ncclGinProxyOpPut)) << "u32";
+    EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdHeader].header.size),
+              static_cast<uint64_t>(sizeof(uint32_t))) << "u32";
+
+    // Inline qwords (slots 1+2): Low holds the whole 32-bit value; Low2 and High must stay 0.
+    EXPECT_EQ(static_cast<uint32_t>(gfd.qword[ncclGinProxyGfdInlineLow].inlineLow.flag),    1u) << "u32";
+    EXPECT_EQ(gfd.qword[ncclGinProxyGfdInlineLow].inlineLow.inlineValLow,    kValU32) << "u32";
+    EXPECT_EQ(gfd.qword[ncclGinProxyGfdInlineLow].inlineLow.inlineValLow2,   0u) << "u32 must skip Low2 (sizeof<=4)";
+    EXPECT_EQ(static_cast<uint32_t>(gfd.qword[ncclGinProxyGfdInlineHigh].inlineHigh.flag), 1u) << "u32";
+    EXPECT_EQ(gfd.qword[ncclGinProxyGfdInlineHigh].inlineHigh.inlineValHigh, 0u) << "u32 must skip High (sizeof<=6)";
+
+    // Destination address qwords.
+    EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdDstOff].dstOff.flag),       1ULL) << "u32";
+    EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdDstOff].dstOff.dstOff),     kDstOff) << "u32";
+    EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdDstHandle].dstHandle.flag), 1ULL) << "u32";
+    EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdDstHandle].dstHandle.dstHandle),
+              kDstHandle) << "u32";
+
+    // Completion / SignalVal: no signal, no counter -> id and value fields zero.
+    EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdCompletion].completion.flag),         1ULL) << "u32";
+    EXPECT_EQ(static_cast<uint32_t>(gfd.qword[ncclGinProxyGfdCompletion].completion.counterId),    0u)   << "u32";
+    EXPECT_EQ(static_cast<uint32_t>(gfd.qword[ncclGinProxyGfdCompletion].completion.signalId),     0u)   << "u32";
+    EXPECT_EQ(static_cast<uint32_t>(gfd.qword[ncclGinProxyGfdCompletion].completion.signalValLow), 0u)   << "u32";
+    EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdSignalVal].signalVal.flag),           1ULL) << "u32";
+    EXPECT_EQ(static_cast<uint32_t>(gfd.qword[ncclGinProxyGfdSignalVal].signalVal.signalValLow2),  0u)   << "u32";
+    EXPECT_EQ(static_cast<uint32_t>(gfd.qword[ncclGinProxyGfdSignalVal].signalVal.signalValHigh),  0u)   << "u32";
+
+    EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdReserved].flag.v), 1ULL) << "u32";
+  }
+
+  // ---- uint64_t (8-byte): value splits across Low (32) + Low2 (16) + High (16) ----
+  {
+    DeviceBuffer<ncclGinProxyGfd_t> d_gfd(1);
+    d_gfd.zero();
+
+    kernelBuildGfdInline<uint64_t><<<1, 1>>>(d_gfd.ptr, kValU64, kDstOff, kDstHandle);
+    syncAndCheck();
+
+    const ncclGinProxyGfd_t gfd = d_gfd.download();
+
+    EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdHeader].header.flag), 1ULL) << "u64";
+    EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdHeader].header.op),
+              static_cast<uint64_t>(ncclGinProxyOpPut)) << "u64";
+    EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdHeader].header.size),
+              static_cast<uint64_t>(sizeof(uint64_t))) << "u64";
+
+    // Inline split: Low = bits[0:32), Low2 = bits[32:48), High = bits[48:64).
+    constexpr uint32_t expectLow  = static_cast<uint32_t>(kValU64);              // 0x89ABCDEF
+    constexpr uint16_t expectLow2 = static_cast<uint16_t>(kValU64 >> 32);        // 0x4567
+    constexpr uint16_t expectHigh = static_cast<uint16_t>(kValU64 >> 48);        // 0x0123
+    EXPECT_EQ(static_cast<uint32_t>(gfd.qword[ncclGinProxyGfdInlineLow].inlineLow.flag),    1u) << "u64";
+    EXPECT_EQ(gfd.qword[ncclGinProxyGfdInlineLow].inlineLow.inlineValLow,    expectLow)  << "u64";
+    EXPECT_EQ(gfd.qword[ncclGinProxyGfdInlineLow].inlineLow.inlineValLow2,   expectLow2) << "u64";
+    EXPECT_EQ(static_cast<uint32_t>(gfd.qword[ncclGinProxyGfdInlineHigh].inlineHigh.flag), 1u) << "u64";
+    EXPECT_EQ(gfd.qword[ncclGinProxyGfdInlineHigh].inlineHigh.inlineValHigh, expectHigh) << "u64";
+
+    // Round-trip: reassemble the 64-bit value from the three pieces.
+    const uint64_t roundtrip =
+        static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdInlineLow].inlineLow.inlineValLow) |
+        (static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdInlineLow].inlineLow.inlineValLow2) << 32) |
+        (static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdInlineHigh].inlineHigh.inlineValHigh) << 48);
+    EXPECT_EQ(roundtrip, kValU64) << "u64 inline value round-trip";
+
+    EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdDstOff].dstOff.flag),       1ULL) << "u64";
+    EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdDstOff].dstOff.dstOff),     kDstOff) << "u64";
+    EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdDstHandle].dstHandle.flag), 1ULL) << "u64";
+    EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdDstHandle].dstHandle.dstHandle),
+              kDstHandle) << "u64";
+
+    EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdCompletion].completion.flag),         1ULL) << "u64";
+    EXPECT_EQ(static_cast<uint32_t>(gfd.qword[ncclGinProxyGfdCompletion].completion.counterId),    0u)   << "u64";
+    EXPECT_EQ(static_cast<uint32_t>(gfd.qword[ncclGinProxyGfdCompletion].completion.signalId),     0u)   << "u64";
+    EXPECT_EQ(static_cast<uint32_t>(gfd.qword[ncclGinProxyGfdCompletion].completion.signalValLow), 0u)   << "u64";
+    EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdSignalVal].signalVal.flag),           1ULL) << "u64";
+    EXPECT_EQ(static_cast<uint32_t>(gfd.qword[ncclGinProxyGfdSignalVal].signalVal.signalValLow2),  0u)   << "u64";
+    EXPECT_EQ(static_cast<uint32_t>(gfd.qword[ncclGinProxyGfdSignalVal].signalVal.signalValHigh),  0u)   << "u64";
+
+    EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdReserved].flag.v), 1ULL) << "u64";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// BuildGfd_SignalAndCounter: signalId + counterId set; full 64-bit signalVal split as
+//   completion.signalValLow  = bits[ 0:16)
+//   signalVal.signalValLow2  = bits[16:32)
+//   signalVal.signalValHigh  = bits[32:64)
+// ---------------------------------------------------------------------------
+
+__global__ void kernelBuildGfdSignalAndCounter(ncclGinProxyGfd_t* gfd,
+                                               uint64_t srcOff, uint64_t srcHandle,
+                                               uint64_t dstOff, uint64_t dstHandle,
+                                               uint64_t size,
+                                               uint32_t counterId, uint32_t signalId,
+                                               uint64_t signalVal) {
+  if (threadIdx.x != 0 || blockIdx.x != 0) return;
+  nccl::gin::proxy::buildGfd<uint64_t>(
+      gfd,
+      static_cast<ncclGinProxyOp_t>(static_cast<uint32_t>(ncclGinProxyOpPut) |
+                                    static_cast<uint32_t>(ncclGinProxyOpWithSignalAdd) |
+                                    static_cast<uint32_t>(ncclGinProxyOpWithCounter)),
+      /*srcVal=*/0ULL,                                   // unused (hasInline=false)
+      /*hasInline=*/false,
+      /*srcOff=*/srcOff,
+      /*srcHandle=*/reinterpret_cast<ncclGinWindow_t>(srcHandle),
+      /*dstOff=*/dstOff,
+      /*dstHandle=*/reinterpret_cast<ncclGinWindow_t>(dstHandle),
+      /*size=*/size,
+      /*counterId=*/counterId,
+      /*signalId=*/signalId,
+      /*signalVal=*/signalVal);
+}
+
+TEST_F(GinDeviceTest, BuildGfd_SignalAndCounter) {
+  constexpr uint64_t kSrcOff     = 0x0000123456789ABCULL;
+  constexpr uint64_t kSrcHandle  = 0x000056789ABCDEF0ULL;
+  constexpr uint64_t kDstOff     = 0x00009ABCDEF01234ULL;
+  constexpr uint64_t kDstHandle  = 0x0000DEF012345678ULL;
+  constexpr uint64_t kSize       = 4096;
+  constexpr uint16_t kSignalId   = 0x1111;
+  constexpr uint16_t kCounterId  = 0x2222;
+  constexpr uint64_t kSignalVal  = 0x0123456789ABCDEFULL;
+  constexpr uint16_t kSigValLow  = static_cast<uint16_t>(kSignalVal);          // 0xCDEF
+  constexpr uint16_t kSigValLow2 = static_cast<uint16_t>(kSignalVal >> 16);    // 0x89AB
+  constexpr uint32_t kSigValHigh = static_cast<uint32_t>(kSignalVal >> 32);    // 0x01234567
+
+  DeviceBuffer<ncclGinProxyGfd_t> d_gfd(1);
+  d_gfd.zero();
+
+  kernelBuildGfdSignalAndCounter<<<1, 1>>>(d_gfd.ptr,
+                                           kSrcOff, kSrcHandle,
+                                           kDstOff, kDstHandle,
+                                           kSize,
+                                           kCounterId, kSignalId,
+                                           kSignalVal);
+  syncAndCheck();
+
+  const ncclGinProxyGfd_t gfd = d_gfd.download();
+
+  // Header: buildGfd stores the op byte unchanged (verify with the same OR we passed in).
+  const uint64_t expectedOp = static_cast<uint64_t>(ncclGinProxyOpPut) |
+                              static_cast<uint64_t>(ncclGinProxyOpWithSignalAdd) |
+                              static_cast<uint64_t>(ncclGinProxyOpWithCounter);
+  EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdHeader].header.flag), 1ULL);
+  EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdHeader].header.op),   expectedOp);
+  EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdHeader].header.size), kSize);
+
+  // Source + destination address qwords (non-inline path).
+  EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdSrcOff].srcOff.flag),       1ULL);
+  EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdSrcOff].srcOff.srcOff),     kSrcOff);
+  EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdSrcHandle].srcHandle.flag), 1ULL);
+  EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdSrcHandle].srcHandle.srcHandle),
+            kSrcHandle);
+  EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdDstOff].dstOff.flag),       1ULL);
+  EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdDstOff].dstOff.dstOff),     kDstOff);
+  EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdDstHandle].dstHandle.flag), 1ULL);
+  EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdDstHandle].dstHandle.dstHandle),
+            kDstHandle);
+
+  // Completion qword: ids and low 16 bits of signalVal.
+  EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdCompletion].completion.flag), 1ULL);
+  EXPECT_EQ(gfd.qword[ncclGinProxyGfdCompletion].completion.counterId,    kCounterId);
+  EXPECT_EQ(gfd.qword[ncclGinProxyGfdCompletion].completion.signalId,     kSignalId);
+  EXPECT_EQ(gfd.qword[ncclGinProxyGfdCompletion].completion.signalValLow, kSigValLow);
+
+  // SignalVal qword: bits[16:32) and bits[32:64) of signalVal.
+  EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdSignalVal].signalVal.flag), 1ULL);
+  EXPECT_EQ(gfd.qword[ncclGinProxyGfdSignalVal].signalVal.signalValLow2, kSigValLow2);
+  EXPECT_EQ(gfd.qword[ncclGinProxyGfdSignalVal].signalVal.signalValHigh, kSigValHigh);
+
+  // Round-trip: reassemble the 64-bit signal value from the 16+16+32 pieces.
+  const uint64_t signalValRoundtrip =
+      static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdCompletion].completion.signalValLow) |
+      (static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdSignalVal].signalVal.signalValLow2) << 16) |
+      (static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdSignalVal].signalVal.signalValHigh) << 32);
+  EXPECT_EQ(signalValRoundtrip, kSignalVal) << "signalVal 16+16+32 split round-trip";
+
+  EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdReserved].flag.v), 1ULL);
+}
+
+// ---------------------------------------------------------------------------
+// BuildGfd_SizeClasses: hasInline=true with T in {u8, u16, u32, u64}.
+//   The `sizeof(T) > 4` and `sizeof(T) > 6` branches in buildGfd must stay quiet
+//   for T <= 4 bytes (Low2 and High remain 0) and must fire for T = u64.
+// ---------------------------------------------------------------------------
+
+template<typename T>
+__global__ void kernelBuildGfdSizeClass(ncclGinProxyGfd_t* gfd, T srcVal) {
+  if (threadIdx.x != 0 || blockIdx.x != 0) return;
+  nccl::gin::proxy::buildGfd<T>(
+      gfd,
+      ncclGinProxyOpPut,
+      srcVal,
+      /*hasInline=*/true,
+      /*srcOff=*/0,                                        // unused
+      /*srcHandle=*/reinterpret_cast<ncclGinWindow_t>(0),  // unused
+      /*dstOff=*/0,
+      /*dstHandle=*/reinterpret_cast<ncclGinWindow_t>(0),
+      /*size=*/sizeof(T),
+      /*counterId=*/0,
+      /*signalId=*/0,
+      /*signalVal=*/0);
+}
+
+TEST_F(GinDeviceTest, BuildGfd_SizeClasses) {
+  // Each srcVal sets the upper bits non-zero so any spurious write to Low2/High
+  // (which must stay 0 for T <= 4 bytes) would surface as a non-zero readback.
+  // Expected Low2/High depend on sizeof(T): they must remain 0 unless the
+  // sizeof(T)>4 / sizeof(T)>6 branches fire (i.e. only for uint64_t).
+  auto run = [this](auto srcVal, const char* label) {
+    using T = decltype(srcVal);
+
+    DeviceBuffer<ncclGinProxyGfd_t> d_gfd(1);
+    d_gfd.zero();
+    kernelBuildGfdSizeClass<T><<<1, 1>>>(d_gfd.ptr, srcVal);
+    syncAndCheck();
+    const ncclGinProxyGfd_t gfd = d_gfd.download();
+
+    const uint16_t expectLow2 = (sizeof(T) > 4)
+        ? static_cast<uint16_t>(static_cast<uint64_t>(srcVal) >> 32) : uint16_t{0};
+    const uint16_t expectHigh = (sizeof(T) > 6)
+        ? static_cast<uint16_t>(static_cast<uint64_t>(srcVal) >> 48) : uint16_t{0};
+
+    EXPECT_EQ(static_cast<uint64_t>(gfd.qword[ncclGinProxyGfdHeader].header.size),
+              static_cast<uint64_t>(sizeof(T)))                                       << label;
+    EXPECT_EQ(gfd.qword[ncclGinProxyGfdInlineLow].inlineLow.inlineValLow,
+              static_cast<uint32_t>(srcVal))                                          << label;
+    EXPECT_EQ(gfd.qword[ncclGinProxyGfdInlineLow].inlineLow.inlineValLow2,
+              expectLow2)                                                             << label << " Low2";
+    EXPECT_EQ(gfd.qword[ncclGinProxyGfdInlineHigh].inlineHigh.inlineValHigh,
+              expectHigh)                                                             << label << " High";
+  };
+
+  run(uint8_t {0xA5u},                  "u8");
+  run(uint16_t{0xA5B6u},                "u16");
+  run(uint32_t{0xA5B6C7D8u},            "u32");
+  run(uint64_t{0xA5B6C7D8E9FA0B1CULL},  "u64");
+}
+
+// ---------------------------------------------------------------------------
+// PostGfd_OneSlot: a single postGfd writes the input GFD into slot 0 of peer 0's
+//   ring, advances pis[peer] from 0 -> 1, and leaves cis untouched.
+// ---------------------------------------------------------------------------
+
+__global__ void kernelPostGfdOneSlot(ncclGinProxyGpuCtx_t* ctx,
+                                     ncclGinProxyGfd_t* gfdIn,
+                                     uint32_t peer) {
+  nccl::gin::proxy::postGfd(ncclCoopCta{}, ctx, gfdIn, peer);
+}
+
+TEST_F(GinDeviceTest, PostGfd_OneSlot) {
+  static_assert(sizeof(ncclGinProxyGfd_t) == 64, "GFD must be 64 bytes");
+
+  constexpr uint32_t kNranks    = 2;
+  constexpr uint32_t kQueueSize = 4;   // power of two: postGfd uses idx & (queueSize-1)
+  constexpr uint32_t kPeer      = 0;
+
+  // Device-side ring + PI/CI arrays + input GFD + the ctx struct itself.
+  DeviceBuffer<ncclGinProxyGfd_t>     d_queues(kNranks * kQueueSize);
+  DeviceBuffer<uint32_t>              d_pis(kNranks);
+  DeviceBuffer<uint32_t>              d_cis(kNranks);
+  DeviceBuffer<ncclGinProxyGfd_t>     d_gfdIn(1);
+  DeviceBuffer<ncclGinProxyGpuCtx_t>  d_ctx(1);
+
+  d_queues.zero();
+  d_pis.zero();
+  d_cis.zero();
+
+  // Input GFD: byte ramp 0x10..0x4F (64 unique non-zero bytes). Any byte the
+  // kernel fails to write will read back as 0, distinguishable from the input.
+  ncclGinProxyGfd_t hostGfd{};
+  uint8_t* gfdBytes = reinterpret_cast<uint8_t*>(&hostGfd);
+  for (int i = 0; i < 64; i++) gfdBytes[i] = static_cast<uint8_t>(0x10 + i);
+  d_gfdIn.upload(hostGfd);
+
+  // Ctx struct: aliases the device buffers above. counters/signals unused by postGfd.
+  ncclGinProxyGpuCtx_t hostCtx{};
+  hostCtx.nranks    = static_cast<int>(kNranks);
+  hostCtx.queueSize = kQueueSize;
+  hostCtx.queues    = d_queues.ptr;
+  hostCtx.pis       = d_pis.ptr;
+  hostCtx.cis       = d_cis.ptr;
+  hostCtx.counters  = nullptr;
+  hostCtx.signals   = nullptr;
+  d_ctx.upload(hostCtx);
+
+  kernelPostGfdOneSlot<<<1, 1>>>(d_ctx.ptr, d_gfdIn.ptr, kPeer);
+  syncAndCheck();
+
+  std::vector<uint32_t>          pis    = d_pis.copyTo();
+  std::vector<uint32_t>          cis    = d_cis.copyTo();
+  std::vector<ncclGinProxyGfd_t> queues = d_queues.copyTo();
+
+  // PI for peer 0 advanced exactly once; PI for peer 1 untouched.
+  EXPECT_EQ(pis[0], 1u) << "peer 0 PI must advance 0 -> 1";
+  EXPECT_EQ(pis[1], 0u) << "peer 1 PI must be untouched";
+
+  // CIs are consumer-side; postGfd must not write them.
+  EXPECT_EQ(cis[0], 0u);
+  EXPECT_EQ(cis[1], 0u);
+
+  // Slot 0 of peer 0's ring (queues[peer * queueSize + 0] = queues[0]) must hold
+  // the input GFD byte-for-byte.
+  const uint8_t* slotBytes = reinterpret_cast<const uint8_t*>(&queues[0]);
+  for (int i = 0; i < 64; i++) {
+    EXPECT_EQ(slotBytes[i], gfdBytes[i])
+        << "slot 0 byte " << i << " mismatch";
+  }
+
+  // No other slot was written: peer 0 slots 1..3, plus all of peer 1.
+  for (size_t s = 1; s < queues.size(); s++) {
+    const uint8_t* zeroBytes = reinterpret_cast<const uint8_t*>(&queues[s]);
+    for (int i = 0; i < 64; i++) {
+      EXPECT_EQ(zeroBytes[i], 0u) << "slot " << s << " byte " << i << " was unexpectedly written";
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// PostGfd_MultiPeer: post one GFD per peer; per-peer ring base addressing
+//   (queues[pe * queueSize], pis[pe], cis[pe]) must keep peers fully isolated.
+// ---------------------------------------------------------------------------
+
+__global__ void kernelPostGfdMultiPeer(ncclGinProxyGpuCtx_t* ctx,
+                                       ncclGinProxyGfd_t* gfdsIn,
+                                       uint32_t nranks) {
+  for (uint32_t p = 0; p < nranks; p++) {
+    nccl::gin::proxy::postGfd(ncclCoopCta{}, ctx, &gfdsIn[p], p);
+  }
+}
+
+TEST_F(GinDeviceTest, PostGfd_MultiPeer) {
+  constexpr uint32_t kNranks    = 4;
+  constexpr uint32_t kQueueSize = 4;
+
+  DeviceBuffer<ncclGinProxyGfd_t>     d_queues(kNranks * kQueueSize);
+  DeviceBuffer<uint32_t>              d_pis(kNranks);
+  DeviceBuffer<uint32_t>              d_cis(kNranks);
+  DeviceBuffer<ncclGinProxyGfd_t>     d_gfdsIn(kNranks);
+  DeviceBuffer<ncclGinProxyGpuCtx_t>  d_ctx(1);
+
+  d_queues.zero();
+  d_pis.zero();
+  d_cis.zero();
+
+  // gfdsIn[p].header.size = p so each peer's slot is uniquely identifiable.
+  std::vector<ncclGinProxyGfd_t> hostGfds(kNranks);
+  std::memset(hostGfds.data(), 0, hostGfds.size() * sizeof(ncclGinProxyGfd_t));
+  for (uint32_t p = 0; p < kNranks; p++) {
+    hostGfds[p].qword[ncclGinProxyGfdHeader].header.size = p;
+  }
+  d_gfdsIn.copyFrom(hostGfds);
+
+  ncclGinProxyGpuCtx_t hostCtx{};
+  hostCtx.nranks    = static_cast<int>(kNranks);
+  hostCtx.queueSize = kQueueSize;
+  hostCtx.queues    = d_queues.ptr;
+  hostCtx.pis       = d_pis.ptr;
+  hostCtx.cis       = d_cis.ptr;
+  hostCtx.counters  = nullptr;
+  hostCtx.signals   = nullptr;
+  d_ctx.upload(hostCtx);
+
+  kernelPostGfdMultiPeer<<<1, 1>>>(d_ctx.ptr, d_gfdsIn.ptr, kNranks);
+  syncAndCheck();
+
+  std::vector<uint32_t>          pis    = d_pis.copyTo();
+  std::vector<uint32_t>          cis    = d_cis.copyTo();
+  std::vector<ncclGinProxyGfd_t> queues = d_queues.copyTo();
+
+  // Each peer's PI advanced exactly once; each peer's CI untouched.
+  for (uint32_t p = 0; p < kNranks; p++) {
+    EXPECT_EQ(pis[p], 1u) << "pis[" << p << "] must advance 0 -> 1";
+    EXPECT_EQ(cis[p], 0u) << "cis[" << p << "] must be untouched";
+  }
+
+  // Slot 0 of each peer's ring received its own GFD; other slots stay zero.
+  // No cross-peer contamination -- peer p's GFD lands at queues[p * queueSize + 0].
+  for (uint32_t p = 0; p < kNranks; p++) {
+    const auto& slot0 = queues[p * kQueueSize + 0];
+    EXPECT_EQ(static_cast<uint64_t>(slot0.qword[ncclGinProxyGfdHeader].header.size),
+              static_cast<uint64_t>(p))
+        << "peer " << p << " slot 0 header.size mismatch";
+    for (uint32_t s = 1; s < kQueueSize; s++) {
+      const auto& slotN = queues[p * kQueueSize + s];
+      EXPECT_EQ(static_cast<uint64_t>(slotN.qword[ncclGinProxyGfdHeader].header.size), 0ULL)
+          << "peer " << p << " slot " << s << " was unexpectedly written";
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// PostGfd_Wrap: pre-position pi=ci=queueSize-1 so 4 sequential posts straddle
+//   the queueSize=4 boundary on iter 1 (idx=4 -> slot 0). Tests the
+//   `idx & (queueSize-1)` wrap arithmetic at gin_proxy.h:57 deterministically.
+//
+//   Note: the credit-wait `while (queueSize <= idx - ci)` uses UNSIGNED
+//   subtraction, so a single producer can advance idx past ci by at most
+//   queueSize-1 before blocking. A more aggressive 8-post wrap test would
+//   need a concurrent consumer to bump ci, which isn't worth the complexity.
+//   Pre-positioning pi/ci near the wrap point still exercises the wrap.
+// ---------------------------------------------------------------------------
+
+__global__ void kernelPostGfdWrap(ncclGinProxyGpuCtx_t* ctx,
+                                  ncclGinProxyGfd_t* gfdsIn,
+                                  uint32_t n, uint32_t peer) {
+  for (uint32_t i = 0; i < n; i++) {
+    nccl::gin::proxy::postGfd(ncclCoopCta{}, ctx, &gfdsIn[i], peer);
+  }
+}
+
+TEST_F(GinDeviceTest, PostGfd_Wrap) {
+  constexpr uint32_t kNranks    = 1;
+  constexpr uint32_t kQueueSize = 4;
+  constexpr uint32_t kPeer      = 0;
+  constexpr uint32_t kPiPreset  = 3;       // queueSize - 1: iter 1 hits idx=4 (wrap)
+  constexpr uint32_t kCiPreset  = 3;       // = pi: idx-ci stays in [0, queueSize-1]
+  constexpr uint32_t kNumPosts  = 4;
+
+  DeviceBuffer<ncclGinProxyGfd_t>     d_queues(kNranks * kQueueSize);
+  DeviceBuffer<uint32_t>              d_pis(kNranks);
+  DeviceBuffer<uint32_t>              d_cis(kNranks);
+  DeviceBuffer<ncclGinProxyGfd_t>     d_gfdsIn(kNumPosts);
+  DeviceBuffer<ncclGinProxyGpuCtx_t>  d_ctx(1);
+
+  d_queues.zero();
+  d_pis.copyFrom(std::vector<uint32_t>{kPiPreset});
+  d_cis.copyFrom(std::vector<uint32_t>{kCiPreset});
+
+  std::vector<ncclGinProxyGfd_t> hostGfds(kNumPosts);
+  std::memset(hostGfds.data(), 0, hostGfds.size() * sizeof(ncclGinProxyGfd_t));
+  for (uint32_t i = 0; i < kNumPosts; i++) {
+    hostGfds[i].qword[ncclGinProxyGfdHeader].header.size = i;
+  }
+  d_gfdsIn.copyFrom(hostGfds);
+
+  ncclGinProxyGpuCtx_t hostCtx{};
+  hostCtx.nranks    = static_cast<int>(kNranks);
+  hostCtx.queueSize = kQueueSize;
+  hostCtx.queues    = d_queues.ptr;
+  hostCtx.pis       = d_pis.ptr;
+  hostCtx.cis       = d_cis.ptr;
+  hostCtx.counters  = nullptr;
+  hostCtx.signals   = nullptr;
+  d_ctx.upload(hostCtx);
+
+  kernelPostGfdWrap<<<1, 1>>>(d_ctx.ptr, d_gfdsIn.ptr, kNumPosts, kPeer);
+  syncAndCheck();
+
+  std::vector<uint32_t>          pis    = d_pis.copyTo();
+  std::vector<uint32_t>          cis    = d_cis.copyTo();
+  std::vector<ncclGinProxyGfd_t> queues = d_queues.copyTo();
+
+  // PI advanced by kNumPosts; CI unchanged.
+  EXPECT_EQ(pis[0], kPiPreset + kNumPosts) << "PI must advance 3 -> 7";
+  EXPECT_EQ(cis[0], kCiPreset)             << "CI must be untouched";
+
+  // Slot mapping under `idx & (queueSize-1)`:
+  //   iter 0: idx=3 -> slot 3 (gfd 0)
+  //   iter 1: idx=4 -> slot 0 (gfd 1)   <-- WRAP
+  //   iter 2: idx=5 -> slot 1 (gfd 2)
+  //   iter 3: idx=6 -> slot 2 (gfd 3)
+  EXPECT_EQ(static_cast<uint64_t>(queues[3].qword[ncclGinProxyGfdHeader].header.size), 0ULL) << "iter 0 -> slot 3";
+  EXPECT_EQ(static_cast<uint64_t>(queues[0].qword[ncclGinProxyGfdHeader].header.size), 1ULL) << "iter 1 -> slot 0 (wrap)";
+  EXPECT_EQ(static_cast<uint64_t>(queues[1].qword[ncclGinProxyGfdHeader].header.size), 2ULL) << "iter 2 -> slot 1";
+  EXPECT_EQ(static_cast<uint64_t>(queues[2].qword[ncclGinProxyGfdHeader].header.size), 3ULL) << "iter 3 -> slot 2";
+}
+
+// ---------------------------------------------------------------------------
+// PostGfd_PiCiOverflow: pre-position pi=ci=0xFFFFFFFE so 4 sequential posts
+//   straddle the uint32 wrap. Verifies that:
+//     1. `idx = pi.fetch_add(1)` correctly wraps the producer index past 2^32.
+//     2. `idx & (queueSize-1)` produces the right slot post-wrap.
+//     3. `queueSize <= idx - ci.load()` (unsigned subtraction) keeps the
+//        credit-wait dormant when both pi and ci cross the boundary together.
+// ---------------------------------------------------------------------------
+
+__global__ void kernelPostGfdOverflow(ncclGinProxyGpuCtx_t* ctx,
+                                      ncclGinProxyGfd_t* gfdsIn,
+                                      uint32_t n, uint32_t peer) {
+  for (uint32_t i = 0; i < n; i++) {
+    nccl::gin::proxy::postGfd(ncclCoopCta{}, ctx, &gfdsIn[i], peer);
+  }
+}
+
+TEST_F(GinDeviceTest, PostGfd_PiCiOverflow) {
+  constexpr uint32_t kNranks    = 2;
+  constexpr uint32_t kQueueSize = 4;
+  constexpr uint32_t kPeer      = 0;
+  constexpr uint32_t kPreset    = 0xFFFFFFFEu;   // 4 puts straddle the uint32 wrap
+  constexpr uint32_t kNumPosts  = 4;
+
+  DeviceBuffer<ncclGinProxyGfd_t>     d_queues(kNranks * kQueueSize);
+  DeviceBuffer<uint32_t>              d_pis(kNranks);
+  DeviceBuffer<uint32_t>              d_cis(kNranks);
+  DeviceBuffer<ncclGinProxyGfd_t>     d_gfdsIn(kNumPosts);
+  DeviceBuffer<ncclGinProxyGpuCtx_t>  d_ctx(1);
+
+  d_queues.zero();
+  // pis[0] = cis[0] = 0xFFFFFFFE; pis[1] = cis[1] = 0 (peer 1 acts as a sentinel).
+  d_pis.copyFrom(std::vector<uint32_t>{kPreset, 0u});
+  d_cis.copyFrom(std::vector<uint32_t>{kPreset, 0u});
+
+  std::vector<ncclGinProxyGfd_t> hostGfds(kNumPosts);
+  std::memset(hostGfds.data(), 0, hostGfds.size() * sizeof(ncclGinProxyGfd_t));
+  for (uint32_t i = 0; i < kNumPosts; i++) {
+    hostGfds[i].qword[ncclGinProxyGfdHeader].header.size = i;
+  }
+  d_gfdsIn.copyFrom(hostGfds);
+
+  ncclGinProxyGpuCtx_t hostCtx{};
+  hostCtx.nranks    = static_cast<int>(kNranks);
+  hostCtx.queueSize = kQueueSize;
+  hostCtx.queues    = d_queues.ptr;
+  hostCtx.pis       = d_pis.ptr;
+  hostCtx.cis       = d_cis.ptr;
+  hostCtx.counters  = nullptr;
+  hostCtx.signals   = nullptr;
+  d_ctx.upload(hostCtx);
+
+  kernelPostGfdOverflow<<<1, 1>>>(d_ctx.ptr, d_gfdsIn.ptr, kNumPosts, kPeer);
+  syncAndCheck();
+
+  std::vector<uint32_t>          pis    = d_pis.copyTo();
+  std::vector<uint32_t>          cis    = d_cis.copyTo();
+  std::vector<ncclGinProxyGfd_t> queues = d_queues.copyTo();
+
+  // PI started at 0xFFFFFFFE; 4 fetch_adds wrap the uint32 to (0xFFFFFFFE + 4) mod 2^32 = 2.
+  EXPECT_EQ(pis[0], static_cast<uint32_t>(kPreset + kNumPosts))
+      << "PI must wrap through 0xFFFFFFFE -> 0xFFFFFFFF -> 0 -> 1 -> 2";
+  EXPECT_EQ(pis[1], 0u)        << "peer 1 PI must be untouched";
+  EXPECT_EQ(cis[0], kPreset)   << "CI must be untouched";
+  EXPECT_EQ(cis[1], 0u)        << "peer 1 CI must be untouched";
+
+  // Slot mapping (idx is the OLD pi value returned by fetch_add):
+  //   iter 0: idx=0xFFFFFFFE -> slot 2 (gfd 0)
+  //   iter 1: idx=0xFFFFFFFF -> slot 3 (gfd 1)
+  //   iter 2: idx=0x00000000 -> slot 0 (gfd 2)
+  //   iter 3: idx=0x00000001 -> slot 1 (gfd 3)
+  EXPECT_EQ(static_cast<uint64_t>(queues[2].qword[ncclGinProxyGfdHeader].header.size), 0ULL) << "iter 0 -> slot 2";
+  EXPECT_EQ(static_cast<uint64_t>(queues[3].qword[ncclGinProxyGfdHeader].header.size), 1ULL) << "iter 1 -> slot 3";
+  EXPECT_EQ(static_cast<uint64_t>(queues[0].qword[ncclGinProxyGfdHeader].header.size), 2ULL) << "iter 2 -> slot 0 (wrap)";
+  EXPECT_EQ(static_cast<uint64_t>(queues[1].qword[ncclGinProxyGfdHeader].header.size), 3ULL) << "iter 3 -> slot 1";
+
+  // Peer 1's ring must remain entirely zero (no cross-peer contamination near the wrap).
+  for (uint32_t s = 0; s < kQueueSize; s++) {
+    EXPECT_EQ(static_cast<uint64_t>(queues[kQueueSize + s].qword[ncclGinProxyGfdHeader].header.size), 0ULL)
+        << "peer 1 slot " << s << " was unexpectedly written";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ResetSignal: ncclGinApi_ResetSignal<NCCL_NET_DEVICE_GIN_PROXY>::call writes
+//   0 to signals[signalId] via base + offset; verify only the targeted cell
+//   is touched and the rest of the pool stays intact.
+// ---------------------------------------------------------------------------
+
+__global__ void kernelResetSignal(ncclGinCtx ctx, ncclGinSignal_t signalId) {
+  if (threadIdx.x != 0 || blockIdx.x != 0) return;
+  ncclGinApi_ResetSignal<NCCL_NET_DEVICE_GIN_PROXY>::call(ctx, signalId);
+}
+
+TEST_F(GinDeviceTest, ResetSignal) {
+  constexpr uint32_t        kNumSignals = 8;
+  constexpr ncclGinSignal_t kTargetId   = 3;
+  constexpr uint64_t        kPattern    = 0xA000ULL;   // signals[i] = 0xA000 + i
+
+  DeviceBuffer<uint64_t>             d_signals(kNumSignals);
+  DeviceBuffer<ncclGinProxyGpuCtx_t> d_proxyCtx(1);
+
+  // Pre-fill with non-zero pattern so any spurious zeroing surfaces as a mismatch.
+  std::vector<uint64_t> hostSignals(kNumSignals);
+  for (uint32_t i = 0; i < kNumSignals; i++) {
+    hostSignals[i] = kPattern + i;
+  }
+  d_signals.copyFrom(hostSignals);
+
+  // ResetSignal only reads proxyCtx->signals; the rest of the struct is untouched.
+  ncclGinProxyGpuCtx_t hostProxyCtx{};
+  hostProxyCtx.signals = d_signals.ptr;
+  d_proxyCtx.upload(hostProxyCtx);
+
+  // Wrap the proxy ctx in an ncclGinCtx; the leaf only dereferences ctx.handle.
+  ncclGinCtx ctx{};
+  ctx.backend = NCCL_NET_DEVICE_GIN_PROXY;
+  ctx.handle  = d_proxyCtx.ptr;
+
+  kernelResetSignal<<<1, 1>>>(ctx, kTargetId);
+  syncAndCheck();
+
+  std::vector<uint64_t> result = d_signals.copyTo();
+
+  // Target cell zeroed; all other cells keep their pre-filled value.
+  EXPECT_EQ(result[kTargetId], 0ULL) << "target signal " << kTargetId << " must be zeroed";
+  for (uint32_t i = 0; i < kNumSignals; i++) {
+    if (i == kTargetId) continue;
+    EXPECT_EQ(result[i], kPattern + i)
+        << "signal " << i << " unexpectedly modified (expected 0x" << std::hex << (kPattern + i) << ")";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ResetCounter: ncclGinApi_ResetCounter<NCCL_NET_DEVICE_GIN_PROXY>::call writes
+//   0 to counters[counterId] via base + offset. Mirror of ResetSignal but on
+//   the separate counter pool (different base pointer, same failure shape).
+// ---------------------------------------------------------------------------
+
+__global__ void kernelResetCounter(ncclGinCtx ctx, ncclGinCounter_t counterId) {
+  if (threadIdx.x != 0 || blockIdx.x != 0) return;
+  ncclGinApi_ResetCounter<NCCL_NET_DEVICE_GIN_PROXY>::call(ctx, counterId);
+}
+
+TEST_F(GinDeviceTest, ResetCounter) {
+  constexpr uint32_t         kNumCounters = 8;
+  constexpr ncclGinCounter_t kTargetId    = 5;
+  constexpr uint64_t         kPattern     = 0xB000ULL;   // counters[i] = 0xB000 + i
+
+  DeviceBuffer<uint64_t>             d_counters(kNumCounters);
+  DeviceBuffer<ncclGinProxyGpuCtx_t> d_proxyCtx(1);
+
+  // Pre-fill with non-zero pattern so any spurious zeroing surfaces as a mismatch.
+  std::vector<uint64_t> hostCounters(kNumCounters);
+  for (uint32_t i = 0; i < kNumCounters; i++) {
+    hostCounters[i] = kPattern + i;
+  }
+  d_counters.copyFrom(hostCounters);
+
+  // ResetCounter only reads proxyCtx->counters; the rest of the struct is untouched.
+  ncclGinProxyGpuCtx_t hostProxyCtx{};
+  hostProxyCtx.counters = d_counters.ptr;
+  d_proxyCtx.upload(hostProxyCtx);
+
+  // Wrap the proxy ctx in an ncclGinCtx; the leaf only dereferences ctx.handle.
+  ncclGinCtx ctx{};
+  ctx.backend = NCCL_NET_DEVICE_GIN_PROXY;
+  ctx.handle  = d_proxyCtx.ptr;
+
+  kernelResetCounter<<<1, 1>>>(ctx, kTargetId);
+  syncAndCheck();
+
+  std::vector<uint64_t> result = d_counters.copyTo();
+
+  // Target cell zeroed; all other cells keep their pre-filled value.
+  EXPECT_EQ(result[kTargetId], 0ULL) << "target counter " << kTargetId << " must be zeroed";
+  for (uint32_t i = 0; i < kNumCounters; i++) {
+    if (i == kTargetId) continue;
+    EXPECT_EQ(result[i], kPattern + i)
+        << "counter " << i << " unexpectedly modified (expected 0x" << std::hex << (kPattern + i) << ")";
+  }
+}
+
+} // namespace RcclUnitTesting

--- a/projects/rccl/test/transport/GinDeviceMPITests.cpp
+++ b/projects/rccl/test/transport/GinDeviceMPITests.cpp
@@ -1494,7 +1494,7 @@ __global__ void alltoallHybridKernel(
   // an LSA-team barrier; multi-node crosses rails.
   ncclBarrierSession<ncclCoopCta> bar{
       ncclCoopCta(), ncclTeamTagWorld(), gin, blockIdx.x};
-  bar.sync(ncclCoopCta(), std::memory_order_relaxed, ncclGinFenceLevel::Relaxed);
+  bar.sync(ncclCoopCta(), cuda::memory_order_relaxed, ncclGinFenceLevel::Relaxed);
 
   int tid = threadIdx.x + blockIdx.x * blockDim.x;
   int nthreads = blockDim.x * gridDim.x;
@@ -1541,7 +1541,7 @@ __global__ void alltoallHybridKernel(
   // Final barrier: every rank's LSA stores into peer recvbufs are issued
   // and the local writes from peers are visible before any rank consumes
   // its recvbuf.
-  bar.sync(ncclCoopCta(), std::memory_order_release, ncclGinFenceLevel::Relaxed);
+  bar.sync(ncclCoopCta(), cuda::memory_order_release, ncclGinFenceLevel::Relaxed);
 }
 
 // Same shape and verification as Alltoall_PureReference but exercises the

--- a/projects/rccl/test/transport/GinDeviceMPITests.cpp
+++ b/projects/rccl/test/transport/GinDeviceMPITests.cpp
@@ -1,0 +1,2377 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// MPI tests for the device-side GIN proxy backend. Each test launches a real
+// gin.{put|putValue|waitSignal|...} kernel against a real proxy thread + IB,
+// and validates the wire-level result on the receiving rank.
+
+#include "MPITestBase.hpp"
+#include "ResourceGuards.hpp"
+#include "TestChecks.hpp"
+
+#include "nccl_device.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <hip/hip_runtime.h>
+#include <ios>
+#include <string>
+#include <vector>
+
+#ifdef MPI_TESTS_ENABLED
+
+using namespace RCCLTestGuards;
+
+namespace {
+
+std::string ginEnvDisabledReason() {
+  if (const char* e = std::getenv("NCCL_GIN_ENABLE"); e && std::strcmp(e, "0") == 0)
+    return "GIN explicitly disabled by environment (NCCL_GIN_ENABLE=0)";
+  return "";
+}
+
+std::string ginTypeReason() {
+  const char* ginType = std::getenv("NCCL_GIN_TYPE");
+  if (!ginType)
+    return "GIN type not set (required NCCL_GIN_TYPE=2)";
+  if (std::atoi(ginType) != 2)
+    return std::string("Invalid GIN type: ") + ginType + " (required NCCL_GIN_TYPE=2)";
+  return "";
+}
+
+std::string cuMemReason() {
+  const char* cumem = std::getenv("NCCL_CUMEM_ENABLE");
+  if (!cumem || std::strcmp(cumem, "1") != 0)
+    return "Symmetric memory required (NCCL_CUMEM_ENABLE=1)";
+  return "";
+}
+
+// Single-node runs need intranet mode -- otherwise the topology pruner
+// removes the NET node and GIN has no path to bind.
+std::string intranetReason() {
+  MPI_Comm nodeComm;
+  MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &nodeComm);
+  int nodeSize = 0, worldSize = 0;
+  MPI_Comm_size(nodeComm, &nodeSize);
+  MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
+  MPI_Comm_free(&nodeComm);
+  if (nodeSize != worldSize) return "";
+  const char* intra = std::getenv("RCCL_ENABLE_INTRANET");
+  if (!intra || std::strcmp(intra, "1") != 0)
+    return "Intranet mode required for single-node run (RCCL_ENABLE_INTRANET=1)";
+  return "";
+}
+
+// Skip if all ranks share a node -- IB would silently loopback.
+std::string crossNodeReason() {
+  MPI_Comm nodeComm;
+  MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &nodeComm);
+  int nodeSize = 0, worldSize = 0;
+  MPI_Comm_size(nodeComm, &nodeSize);
+  MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
+  MPI_Comm_free(&nodeComm);
+  if (nodeSize == worldSize)
+    return "Cross-node test requires ranks on >=2 physical nodes";
+  return "";
+}
+
+// First failing prerequisite, or "" if all met.
+std::string ginProxyTestSkipReason() {
+  for (auto check : {ginEnvDisabledReason, ginTypeReason, cuMemReason, intranetReason}) {
+    if (auto reason = check(); !reason.empty()) return reason;
+  }
+  return "";
+}
+
+}  // namespace
+
+// Producer: thread 0 of block 0 issues one put with a SignalInc; CTA flushes.
+__global__ void putBasicProducerKernel(
+    ncclWindow_t srcWin, size_t srcOff,
+    ncclWindow_t dstWin, size_t dstOff,
+    size_t bytes, ncclGinSignal_t sigIdx, int peer,
+    struct ncclDevComm devComm) {
+  ncclGin gin{devComm, /*ginContext=*/0};
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    gin.put(ncclTeamWorld(devComm), peer,
+            dstWin, dstOff,
+            srcWin, srcOff,
+            bytes,
+            ncclGin_SignalInc{sigIdx});
+  }
+  // Drain the posted GFD before the kernel exits.
+  gin.flush(ncclCoopCta());
+}
+
+// Consumer: whole CTA cooperatively waits for the signal to reach the target.
+__global__ void putBasicConsumerKernel(
+    ncclGinSignal_t sigIdx, uint64_t expectedSignalValue,
+    struct ncclDevComm devComm) {
+  ncclGin gin{devComm, /*ginContext=*/0};
+  gin.waitSignal(ncclCoopCta(), sigIdx, expectedSignalValue);
+}
+
+// Combined producer + consumer for alltoall: thread 0 puts to every non-self
+// peer (one slot each), the CTA flushes, then waits for the same number of
+// signal increments to arrive from peers.
+__global__ void alltoallKernel(
+    ncclWindow_t sendWin,
+    ncclWindow_t recvWin,
+    size_t bytesPerSlot,
+    int nRanks, int myRank,
+    size_t slotStrideBytes,
+    ncclGinSignal_t sigIdx,
+    uint64_t expectedSignalValue,
+    struct ncclDevComm devComm) {
+  ncclGin gin{devComm, /*ginContext=*/0};
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    auto team = ncclTeamWorld(devComm);
+    // Send slot p of our send buffer into peer p's recv slot for our rank.
+    for (int p = 0; p < nRanks; ++p) {
+      if (p == myRank) continue;
+      gin.put(team, p,
+              recvWin, /*dstOff=*/(size_t)myRank * slotStrideBytes,
+              sendWin, /*srcOff=*/(size_t)p     * slotStrideBytes,
+              bytesPerSlot,
+              ncclGin_SignalInc{sigIdx});
+    }
+  }
+  gin.flush(ncclCoopCta());
+  gin.waitSignal(ncclCoopCta(), sigIdx, expectedSignalValue);
+}
+
+class GinMPIDeviceTests : public MPITestBase {
+ protected:
+  // Minimal 64-byte put + waitSignal round-trip from rank 0 to rank 1.
+  // Used by the Invalid_*Pool tests to confirm comm bring-up + the GIN
+  // data path still work after the runtime clamps an oversized pool.
+  void runBasicPutSelfCheck() {
+    // Bring up the comm + stream from the fixture.
+    ASSERT_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t  comm   = getActiveCommunicator();
+    hipStream_t stream = getActiveStream();
+
+    int rank = -1, nRanks = -1;
+    ncclCommUserRank(comm, &rank);
+    ncclCommCount(comm, &nRanks);
+    ASSERT_EQ(2, nRanks);
+
+    // Tiny geometry: full-buffer transfer, signal 0, peer is rank 1.
+    constexpr size_t          kBufBytes      = 64;
+    constexpr size_t          kTransferBytes = 64;
+    constexpr ncclGinSignal_t kSigIdx        = 0;
+    constexpr int             kPeer          = 1;
+
+    // Allocate symmetric src/dst on every rank; freed on scope exit.
+    void* dSrc = nullptr;
+    void* dDst = nullptr;
+    ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dSrc, kBufBytes));
+    ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dDst, kBufBytes));
+    auto memCleanup = makeScopeGuard([&]() {
+      if (dSrc) (void)ncclMemFree(dSrc);
+      if (dDst) (void)ncclMemFree(dDst);
+    });
+
+    // Register collective symmetric windows so the device side can address
+    // peer memory through srcWin/dstWin.
+    ncclWindow_t srcWin = nullptr, dstWin = nullptr;
+    ASSERT_MPI_EQ(ncclSuccess,
+                  ncclCommWindowRegister(comm, dSrc, kBufBytes, &srcWin, NCCL_WIN_COLL_SYMMETRIC));
+    ASSERT_MPI_EQ(ncclSuccess,
+                  ncclCommWindowRegister(comm, dDst, kBufBytes, &dstWin, NCCL_WIN_COLL_SYMMETRIC));
+    auto winCleanup = makeScopeGuard([&]() {
+      if (srcWin) (void)ncclCommWindowDeregister(comm, srcWin);
+      if (dstWin) (void)ncclCommWindowDeregister(comm, dstWin);
+    });
+
+    // Bring up the GIN device comm (1 barrier slot, 1 signal cell).
+    ncclDevCommRequirements reqs{};
+    reqs.railGinBarrierCount = 1;
+    reqs.ginSignalCount      = 1;
+    ncclDevComm devComm{};
+    ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
+    auto devCommCleanup = makeScopeGuard([&]() {
+      (void)ncclDevCommDestroy(comm, &devComm);
+    });
+
+    // Stage a deterministic byte pattern in the source buffer; dst stays zero.
+    std::vector<uint8_t> hostSrc(kBufBytes, 0);
+    std::vector<uint8_t> hostDst(kBufBytes, 0);
+    for (size_t i = 0; i < kTransferBytes; i++) {
+      hostSrc[i] = static_cast<uint8_t>(0xA0 + (i & 0x3F));
+    }
+    ASSERT_MPI_EQ(hipSuccess, hipMemcpy(dSrc, hostSrc.data(), kBufBytes, hipMemcpyHostToDevice));
+    ASSERT_MPI_EQ(hipSuccess, hipMemcpy(dDst, hostDst.data(), kBufBytes, hipMemcpyHostToDevice));
+
+    // Sync so neither rank launches before the other has finished setup.
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // Rank 0 puts the payload + bumps the signal; rank 1 waits on it.
+    if (rank == 0) {
+      putBasicProducerKernel<<<1, 32, 0, stream>>>(
+          srcWin, /*srcOff=*/0,
+          dstWin, /*dstOff=*/0,
+          kTransferBytes, kSigIdx, kPeer,
+          devComm);
+    } else {
+      putBasicConsumerKernel<<<1, 32, 0, stream>>>(
+          kSigIdx, /*expectedSignalValue=*/1, devComm);
+    }
+    ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+    // Sync so rank 1's verify isn't racing rank 0's kernel completion.
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // Rank 1 reads dst back and checks every byte landed.
+    if (rank == 1) {
+      std::vector<uint8_t> hostResult(kBufBytes, 0);
+      ASSERT_EQ(hipSuccess,
+                hipMemcpy(hostResult.data(), dDst, kBufBytes, hipMemcpyDeviceToHost));
+      for (size_t i = 0; i < kTransferBytes; i++) {
+        ASSERT_EQ(hostSrc[i], hostResult[i]) << "byte " << i << " mismatched";
+      }
+    }
+  }
+};
+
+// Smallest end-to-end exercise of the device put -> proxy -> IB -> peer
+// signal chain, with non-zero src/dst/signal offsets so address-arithmetic
+// regressions surface as a verification mismatch.
+TEST_F(GinMPIDeviceTests, Put_BasicAndOffsets) {
+  if (auto reason = ginProxyTestSkipReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+
+  if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/2))
+    GTEST_SKIP() << "Requires exactly 2 ranks";
+
+  ASSERT_EQ(ncclSuccess, createTestCommunicator());
+  ncclComm_t  comm   = getActiveCommunicator();
+  hipStream_t stream = getActiveStream();
+
+  int rank = -1, nRanks = -1;
+  ncclCommUserRank(comm, &rank);
+  ncclCommCount(comm, &nRanks);
+  ASSERT_EQ(2, nRanks);
+
+  // 8 KiB symmetric buffers; 4 KiB transfer at non-zero src/dst offsets;
+  // signal at non-zero index. Forces every offset to be exercised.
+  constexpr size_t kBufBytes      = 8 * 1024;
+  constexpr size_t kTransferBytes = 4 * 1024;
+  constexpr size_t kSrcOff        = 4 * 1024;
+  constexpr size_t kDstOff        = 2 * 1024;
+  constexpr ncclGinSignal_t kSigIdx = 1;
+  constexpr int kPeer = 1;
+
+  // Allocate symmetric src/dst on every rank.
+  void* dSrc = nullptr;
+  void* dDst = nullptr;
+  ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dSrc, kBufBytes));
+  ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dDst, kBufBytes));
+  auto memCleanup = makeScopeGuard([&]() {
+    if (dSrc) (void)ncclMemFree(dSrc);
+    if (dDst) (void)ncclMemFree(dDst);
+  });
+
+  // Register collective windows over the symmetric buffers.
+  ncclWindow_t srcWin = nullptr, dstWin = nullptr;
+  ASSERT_MPI_EQ(ncclSuccess,
+                ncclCommWindowRegister(comm, dSrc, kBufBytes, &srcWin, NCCL_WIN_COLL_SYMMETRIC));
+  ASSERT_MPI_EQ(ncclSuccess,
+                ncclCommWindowRegister(comm, dDst, kBufBytes, &dstWin, NCCL_WIN_COLL_SYMMETRIC));
+  auto winCleanup = makeScopeGuard([&]() {
+    if (srcWin) (void)ncclCommWindowDeregister(comm, srcWin);
+    if (dstWin) (void)ncclCommWindowDeregister(comm, dstWin);
+  });
+
+  // Bring up GIN with 2 signals so kSigIdx=1 is a valid in-pool index.
+  ncclDevCommRequirements reqs{};
+  reqs.railGinBarrierCount = 1;
+  reqs.ginSignalCount      = 2;
+  ncclDevComm devComm{};
+  ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
+  auto devCommCleanup = makeScopeGuard([&]() {
+    (void)ncclDevCommDestroy(comm, &devComm);
+  });
+
+  // Stage source pattern in [kSrcOff, kSrcOff+kTransferBytes); rest is zero.
+  std::vector<uint8_t> hostSrc(kBufBytes, 0);
+  std::vector<uint8_t> hostDst(kBufBytes, 0);
+  for (size_t i = 0; i < kTransferBytes; i++) {
+    hostSrc[kSrcOff + i] = static_cast<uint8_t>(0x40 + (i & 0xFF));
+  }
+  ASSERT_MPI_EQ(hipSuccess, hipMemcpy(dSrc, hostSrc.data(), kBufBytes, hipMemcpyHostToDevice));
+  ASSERT_MPI_EQ(hipSuccess, hipMemcpy(dDst, hostDst.data(), kBufBytes, hipMemcpyHostToDevice));
+
+  // Sync so neither rank launches its kernel before setup is done globally.
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  // Rank 0 puts payload + bumps signal; rank 1 waits on the same signal.
+  if (rank == 0) {
+    putBasicProducerKernel<<<1, 32, 0, stream>>>(
+        srcWin, kSrcOff,
+        dstWin, kDstOff,
+        kTransferBytes, kSigIdx, kPeer,
+        devComm);
+  } else {
+    putBasicConsumerKernel<<<1, 32, 0, stream>>>(
+        kSigIdx, /*expectedSignalValue=*/1, devComm);
+  }
+  ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+  // Sync before verify; both ranks have finished their kernel.
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  // Rank 1 verifies: payload landed exactly in [kDstOff, +kTransferBytes),
+  // and bytes before/after that range are still zero.
+  if (rank == 1) {
+    std::vector<uint8_t> hostResult(kBufBytes, 0);
+    ASSERT_EQ(hipSuccess,
+              hipMemcpy(hostResult.data(), dDst, kBufBytes, hipMemcpyDeviceToHost));
+
+    for (size_t i = 0; i < kTransferBytes; i++) {
+      const uint8_t expected = static_cast<uint8_t>(0x40 + (i & 0xFF));
+      ASSERT_EQ(expected, hostResult[kDstOff + i])
+          << "byte " << i << " in [dstOff, dstOff+xfer) differs";
+    }
+    for (size_t i = 0; i < kDstOff; i++) {
+      ASSERT_EQ(0u, hostResult[i])
+          << "byte " << i << " before dstOff was unexpectedly written";
+    }
+    for (size_t i = kDstOff + kTransferBytes; i < kBufBytes; i++) {
+      ASSERT_EQ(0u, hostResult[i])
+          << "byte " << i << " after dstOff+xfer was unexpectedly written";
+    }
+  }
+}
+
+// Same wire-level put as Put_BasicAndOffsets, but requires the two ranks to
+// live on different physical nodes so IB actually traverses the fabric
+// instead of falling back to a single-node loopback path.
+TEST_F(GinMPIDeviceTests, Put_CrossNode) {
+  if (auto reason = ginProxyTestSkipReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+
+  if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/2))
+    GTEST_SKIP() << "Requires exactly 2 ranks";
+
+  // Skip on single-node runs; otherwise we'd just be retesting loopback.
+  if (auto reason = crossNodeReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+
+  ASSERT_EQ(ncclSuccess, createTestCommunicator());
+  ncclComm_t  comm   = getActiveCommunicator();
+  hipStream_t stream = getActiveStream();
+
+  int rank = -1, nRanks = -1;
+  ncclCommUserRank(comm, &rank);
+  ncclCommCount(comm, &nRanks);
+  ASSERT_EQ(2, nRanks);
+
+  // Same geometry as Put_BasicAndOffsets so the comparison is apples-to-apples.
+  constexpr size_t kBufBytes      = 8 * 1024;
+  constexpr size_t kTransferBytes = 4 * 1024;
+  constexpr size_t kSrcOff        = 4 * 1024;
+  constexpr size_t kDstOff        = 2 * 1024;
+  constexpr ncclGinSignal_t kSigIdx = 1;
+  constexpr int kPeer = 1;
+
+  // Allocate symmetric src/dst on every rank.
+  void* dSrc = nullptr;
+  void* dDst = nullptr;
+  ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dSrc, kBufBytes));
+  ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dDst, kBufBytes));
+  auto memCleanup = makeScopeGuard([&]() {
+    if (dSrc) (void)ncclMemFree(dSrc);
+    if (dDst) (void)ncclMemFree(dDst);
+  });
+
+  // Register collective windows over the symmetric buffers.
+  ncclWindow_t srcWin = nullptr, dstWin = nullptr;
+  ASSERT_MPI_EQ(ncclSuccess,
+                ncclCommWindowRegister(comm, dSrc, kBufBytes, &srcWin, NCCL_WIN_COLL_SYMMETRIC));
+  ASSERT_MPI_EQ(ncclSuccess,
+                ncclCommWindowRegister(comm, dDst, kBufBytes, &dstWin, NCCL_WIN_COLL_SYMMETRIC));
+  auto winCleanup = makeScopeGuard([&]() {
+    if (srcWin) (void)ncclCommWindowDeregister(comm, srcWin);
+    if (dstWin) (void)ncclCommWindowDeregister(comm, dstWin);
+  });
+
+  // Bring up GIN with 2 signals so kSigIdx=1 is valid.
+  ncclDevCommRequirements reqs{};
+  reqs.railGinBarrierCount = 1;
+  reqs.ginSignalCount      = 2;
+  ncclDevComm devComm{};
+  ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
+  auto devCommCleanup = makeScopeGuard([&]() {
+    (void)ncclDevCommDestroy(comm, &devComm);
+  });
+
+  // Stage source pattern in [kSrcOff, kSrcOff+kTransferBytes); rest zero.
+  std::vector<uint8_t> hostSrc(kBufBytes, 0);
+  std::vector<uint8_t> hostDst(kBufBytes, 0);
+  for (size_t i = 0; i < kTransferBytes; i++) {
+    hostSrc[kSrcOff + i] = static_cast<uint8_t>(0x40 + (i & 0xFF));
+  }
+  ASSERT_MPI_EQ(hipSuccess, hipMemcpy(dSrc, hostSrc.data(), kBufBytes, hipMemcpyHostToDevice));
+  ASSERT_MPI_EQ(hipSuccess, hipMemcpy(dDst, hostDst.data(), kBufBytes, hipMemcpyHostToDevice));
+
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  // Rank 0 puts + signals; rank 1 waits.
+  if (rank == 0) {
+    putBasicProducerKernel<<<1, 32, 0, stream>>>(
+        srcWin, kSrcOff,
+        dstWin, kDstOff,
+        kTransferBytes, kSigIdx, kPeer,
+        devComm);
+  } else {
+    putBasicConsumerKernel<<<1, 32, 0, stream>>>(
+        kSigIdx, /*expectedSignalValue=*/1, devComm);
+  }
+  ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  // Verify payload + zero-tails on rank 1.
+  if (rank == 1) {
+    std::vector<uint8_t> hostResult(kBufBytes, 0);
+    ASSERT_EQ(hipSuccess,
+              hipMemcpy(hostResult.data(), dDst, kBufBytes, hipMemcpyDeviceToHost));
+
+    for (size_t i = 0; i < kTransferBytes; i++) {
+      const uint8_t expected = static_cast<uint8_t>(0x40 + (i & 0xFF));
+      ASSERT_EQ(expected, hostResult[kDstOff + i])
+          << "byte " << i << " in [dstOff, dstOff+xfer) differs";
+    }
+    for (size_t i = 0; i < kDstOff; i++) {
+      ASSERT_EQ(0u, hostResult[i])
+          << "byte " << i << " before dstOff was unexpectedly written";
+    }
+    for (size_t i = kDstOff + kTransferBytes; i < kBufBytes; i++) {
+      ASSERT_EQ(0u, hostResult[i])
+          << "byte " << i << " after dstOff+xfer was unexpectedly written";
+    }
+  }
+}
+
+// Producer: putValue carries the 8-byte payload inside the GFD itself
+// (no source MR is dereferenced); also bumps a signal so the receiver
+// can wait synchronously.
+__global__ void putValueInlineProducerKernel(
+    ncclWindow_t dstWin, size_t dstOff,
+    uint64_t value, ncclGinSignal_t sigIdx, int peer,
+    struct ncclDevComm devComm) {
+  ncclGin gin{devComm, /*ginContext=*/0};
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    gin.putValue<uint64_t>(ncclTeamWorld(devComm), peer,
+                           dstWin, dstOff, value,
+                           ncclGin_SignalInc{sigIdx});
+  }
+  gin.flush(ncclCoopCta());
+}
+
+// Consumer: just waits for the inline-value signal.
+__global__ void putValueInlineConsumerKernel(
+    ncclGinSignal_t sigIdx, uint64_t expectedSignalValue,
+    struct ncclDevComm devComm) {
+  ncclGin gin{devComm, /*ginContext=*/0};
+  gin.waitSignal(ncclCoopCta(), sigIdx, expectedSignalValue);
+}
+
+// Sends a single 8-byte uint64_t inline (no source buffer / MR involved)
+// and verifies it lands intact at the requested offset on the peer.
+TEST_F(GinMPIDeviceTests, PutValue_Inline) {
+  if (auto reason = ginProxyTestSkipReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+
+  if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/2))
+    GTEST_SKIP() << "Requires exactly 2 ranks";
+
+  ASSERT_EQ(ncclSuccess, createTestCommunicator());
+  ncclComm_t  comm   = getActiveCommunicator();
+  hipStream_t stream = getActiveStream();
+
+  int rank = -1, nRanks = -1;
+  ncclCommUserRank(comm, &rank);
+  ncclCommCount(comm, &nRanks);
+  ASSERT_EQ(2, nRanks);
+
+  // kValue exercises all three pieces of the inline 4+2+2 byte split,
+  // so any field-reconstruction regression in the host proxy surfaces.
+  constexpr size_t   kBufBytes = 4 * 1024;
+  constexpr size_t   kDstOff   = 1 * 1024;
+  constexpr uint64_t kValue    = 0x123456789ABCDEF0ULL;
+  constexpr ncclGinSignal_t kSigIdx = 1;
+  constexpr int kPeer = 1;
+
+  // Allocate symmetric dst on every rank (no src needed: value is inline).
+  void* dDst = nullptr;
+  ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dDst, kBufBytes));
+  auto memCleanup = makeScopeGuard([&]() {
+    if (dDst) (void)ncclMemFree(dDst);
+  });
+
+  // Register dst window collectively.
+  ncclWindow_t dstWin = nullptr;
+  ASSERT_MPI_EQ(ncclSuccess,
+                ncclCommWindowRegister(comm, dDst, kBufBytes, &dstWin, NCCL_WIN_COLL_SYMMETRIC));
+  auto winCleanup = makeScopeGuard([&]() {
+    if (dstWin) (void)ncclCommWindowDeregister(comm, dstWin);
+  });
+
+  // Bring up GIN with 2 signals so kSigIdx=1 is valid.
+  ncclDevCommRequirements reqs{};
+  reqs.railGinBarrierCount = 1;
+  reqs.ginSignalCount      = 2;
+  ncclDevComm devComm{};
+  ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
+  auto devCommCleanup = makeScopeGuard([&]() {
+    (void)ncclDevCommDestroy(comm, &devComm);
+  });
+
+  // Zero dst so any spurious write outside the 8-byte landing surfaces.
+  std::vector<uint8_t> hostDst(kBufBytes, 0);
+  ASSERT_MPI_EQ(hipSuccess, hipMemcpy(dDst, hostDst.data(), kBufBytes, hipMemcpyHostToDevice));
+
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  // Rank 0 sends the inline value + signal; rank 1 waits.
+  if (rank == 0) {
+    putValueInlineProducerKernel<<<1, 32, 0, stream>>>(
+        dstWin, kDstOff, kValue, kSigIdx, kPeer, devComm);
+  } else {
+    putValueInlineConsumerKernel<<<1, 32, 0, stream>>>(
+        kSigIdx, /*expectedSignalValue=*/1, devComm);
+  }
+  ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  // Rank 1 verifies the 8 bytes at dstOff match kValue and nothing else moved.
+  if (rank == 1) {
+    std::vector<uint8_t> hostResult(kBufBytes, 0);
+    ASSERT_EQ(hipSuccess,
+              hipMemcpy(hostResult.data(), dDst, kBufBytes, hipMemcpyDeviceToHost));
+
+    uint64_t got = 0;
+    std::memcpy(&got, hostResult.data() + kDstOff, sizeof(got));
+    ASSERT_EQ(kValue, got)
+        << "inline value mismatch (4+2+2 split likely corrupted)";
+
+    for (size_t i = 0; i < kDstOff; i++) {
+      ASSERT_EQ(0u, hostResult[i])
+          << "byte " << i << " before dstOff was unexpectedly written";
+    }
+    for (size_t i = kDstOff + sizeof(uint64_t); i < kBufBytes; i++) {
+      ASSERT_EQ(0u, hostResult[i])
+          << "byte " << i << " after dstOff+8 was unexpectedly written";
+    }
+  }
+}
+
+// Producer: thread 0 issues a zero-byte gin.signal (no src/dst windows).
+// The GFD becomes a non-inline put with size=0, hasInline=false; the proxy
+// dispatches it through the signal-only iputSignal path
+// (gin_host_proxy.cc:271-273).
+__global__ void signalNoPayloadProducerKernel(
+    ncclGinSignal_t sigIdx, int peer, struct ncclDevComm devComm) {
+  ncclGin gin{devComm, /*ginContext=*/0};
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    gin.signal(ncclTeamWorld(devComm), peer, ncclGin_SignalInc{sigIdx});
+  }
+  // Drain the posted GFD before the kernel exits.
+  gin.flush(ncclCoopCta());
+}
+
+// Consumer: whole CTA cooperatively waits for the signal to reach the target.
+__global__ void signalNoPayloadConsumerKernel(
+    ncclGinSignal_t sigIdx, uint64_t expectedSignalValue,
+    struct ncclDevComm devComm) {
+  ncclGin gin{devComm, /*ginContext=*/0};
+  gin.waitSignal(ncclCoopCta(), sigIdx, expectedSignalValue);
+}
+
+// Bare-minimum signal RTT: rank 0 issues a zero-byte gin.signal that only
+// bumps rank 1's signal cell -- no data, no src/dst windows. It's the
+// latency-floor primitive the barrier is built on and exercises the proxy's
+// signal-only path. Signal index is non-zero so a regression that drops the
+// index multiplier would land at cell 0 and the consumer's waitSignal(1)
+// would never observe the bump.
+TEST_F(GinMPIDeviceTests, Signal_NoPayload) {
+  if (auto reason = ginProxyTestSkipReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+
+  if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/2))
+    GTEST_SKIP() << "Requires exactly 2 ranks";
+
+  ASSERT_EQ(ncclSuccess, createTestCommunicator());
+  ncclComm_t  comm   = getActiveCommunicator();
+  hipStream_t stream = getActiveStream();
+
+  int rank = -1, nRanks = -1;
+  ncclCommUserRank(comm, &rank);
+  ncclCommCount(comm, &nRanks);
+  ASSERT_EQ(2, nRanks);
+
+  constexpr ncclGinSignal_t kSigIdx = 1;
+  constexpr int             kPeer   = 1;  // rank 0 -> rank 1
+
+  // No buffers, no windows: gin.signal is a zero-byte put. The runtime's
+  // own signal pool is the only memory touched by the GFD; it's allocated
+  // and registered by ncclDevCommCreate based on ginSignalCount.
+  ncclDevCommRequirements reqs{};
+  reqs.railGinBarrierCount = 1;
+  reqs.ginSignalCount      = 2;
+  ncclDevComm devComm{};
+  ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
+  auto devCommCleanup = makeScopeGuard([&]() {
+    (void)ncclDevCommDestroy(comm, &devComm);
+  });
+
+  // Sync so neither rank launches its kernel before setup is done globally.
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  // Producer (rank 0) emits a single signal; consumer (rank 1) waits for
+  // signal cell kSigIdx to reach 1. The successful return of waitSignal on
+  // the consumer IS the assertion -- there is no payload to verify.
+  if (rank == 0) {
+    signalNoPayloadProducerKernel<<<1, 32, 0, stream>>>(kSigIdx, kPeer, devComm);
+  } else {
+    signalNoPayloadConsumerKernel<<<1, 32, 0, stream>>>(
+        kSigIdx, /*expectedSignalValue=*/1, devComm);
+  }
+  ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+  // Both kernels are done; rank 1's signal cell is settled.
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+// Producer-only kernel: rank 0 issues a put with no remote action and a
+// CounterInc local action, then waits on its OWN counter. The counter is
+// bumped by the local proxy thread when the IB CQE for the put lands
+// (gin_host_proxy.cc:147-152, inside proxyGinPollCompletions). That's a
+// distinct path from the remote-signal write dispatched via iputSignal
+// (gin_host_proxy.cc:271-273) which the prior put/signal tests exercise.
+__global__ void waitCounterLocalProducerKernel(
+    ncclWindow_t srcWin, size_t srcOff,
+    ncclWindow_t dstWin, size_t dstOff,
+    size_t bytes, ncclGinCounter_t cntIdx, int peer,
+    struct ncclDevComm devComm) {
+  ncclGin gin{devComm, /*ginContext=*/0};
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    gin.put(ncclTeamWorld(devComm), peer,
+            dstWin, dstOff, srcWin, srcOff, bytes,
+            ncclGin_None{},                  // no remote action (no signal)
+            ncclGin_CounterInc{cntIdx});     // local: bump cntIdx on IB CQE
+  }
+  // CTA-collective wait; only thread 0 spins on the cell. Once it returns,
+  // the proxy thread has observed the IB CQE for the put and bumped the
+  // counter.
+  gin.waitCounter(ncclCoopCta(), cntIdx, /*least=*/1);
+}
+
+// Exercises the local IB-completion -> counter-bump path. Rank 1 is a
+// passive RDMA target (no kernel) - the payload lands in its dst window
+// via the IB plugin. The successful return of waitCounter(1) on rank 0
+// (gated by hipStreamSynchronize) IS the assertion.
+TEST_F(GinMPIDeviceTests, WaitCounter_Local) {
+  if (auto reason = ginProxyTestSkipReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+
+  if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/2))
+    GTEST_SKIP() << "Requires exactly 2 ranks";
+
+  ASSERT_EQ(ncclSuccess, createTestCommunicator());
+  ncclComm_t  comm   = getActiveCommunicator();
+  hipStream_t stream = getActiveStream();
+
+  int rank = -1, nRanks = -1;
+  ncclCommUserRank(comm, &rank);
+  ncclCommCount(comm, &nRanks);
+  ASSERT_EQ(2, nRanks);
+
+  // 8 KiB symmetric buffers; 4 KiB payload at non-zero src/dst offsets so
+  // the put is a realistic data move. The counter (not the payload) is
+  // what we verify -- this test is about the LOCAL completion path.
+  constexpr size_t kBufBytes      = 8 * 1024;
+  constexpr size_t kTransferBytes = 4 * 1024;
+  constexpr size_t kSrcOff        = 4 * 1024;
+  constexpr size_t kDstOff        = 2 * 1024;
+  constexpr ncclGinCounter_t kCntIdx = 1;  // non-zero counter index
+  constexpr int kPeer = 1;
+
+  // Symmetric src + dst (every rank allocates because window registration
+  // is collective for SYMMETRIC-mode windows).
+  void* dSrc = nullptr;
+  void* dDst = nullptr;
+  ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dSrc, kBufBytes));
+  ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dDst, kBufBytes));
+  auto memCleanup = makeScopeGuard([&]() {
+    if (dSrc) (void)ncclMemFree(dSrc);
+    if (dDst) (void)ncclMemFree(dDst);
+  });
+
+  ncclWindow_t srcWin = nullptr, dstWin = nullptr;
+  ASSERT_MPI_EQ(ncclSuccess,
+                ncclCommWindowRegister(comm, dSrc, kBufBytes, &srcWin, NCCL_WIN_COLL_SYMMETRIC));
+  ASSERT_MPI_EQ(ncclSuccess,
+                ncclCommWindowRegister(comm, dDst, kBufBytes, &dstWin, NCCL_WIN_COLL_SYMMETRIC));
+  auto winCleanup = makeScopeGuard([&]() {
+    if (srcWin) (void)ncclCommWindowDeregister(comm, srcWin);
+    if (dstWin) (void)ncclCommWindowDeregister(comm, dstWin);
+  });
+
+  // ginCounterCount=2 so kCntIdx=1 is in range; no ginSignalCount needed
+  // (the put has no remote-signal action). railGinBarrierCount=1 because
+  // the runtime allocates per-CTA barrier state for any 1-CTA launch.
+  ncclDevCommRequirements reqs{};
+  reqs.railGinBarrierCount = 1;
+  reqs.ginCounterCount     = 2;
+  ncclDevComm devComm{};
+  ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
+  auto devCommCleanup = makeScopeGuard([&]() {
+    (void)ncclDevCommDestroy(comm, &devComm);
+  });
+
+  // Known fill on src so the put has real bytes to move; both ranks zero
+  // their dst as a baseline. We don't verify the destination -- this test
+  // is about the local counter, not data delivery.
+  std::vector<uint8_t> hostSrc(kBufBytes, 0xCC);
+  std::vector<uint8_t> hostDst(kBufBytes, 0);
+  ASSERT_MPI_EQ(hipSuccess, hipMemcpy(dSrc, hostSrc.data(), kBufBytes, hipMemcpyHostToDevice));
+  ASSERT_MPI_EQ(hipSuccess, hipMemcpy(dDst, hostDst.data(), kBufBytes, hipMemcpyHostToDevice));
+
+  // Sync so neither rank launches its kernel before setup is done globally.
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  // Only rank 0 launches a kernel; the local counter lives on rank 0. Rank
+  // 1 is purely the RDMA target -- the IB plugin lands the payload in its
+  // dst window passively.
+  if (rank == 0) {
+    waitCounterLocalProducerKernel<<<1, 32, 0, stream>>>(
+        srcWin, kSrcOff, dstWin, kDstOff,
+        kTransferBytes, kCntIdx, kPeer, devComm);
+  }
+  ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+  // Sync so ScopeGuards (window/comm teardown is collective) see both
+  // ranks past the kernel phase.
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+// Collective kernel: every rank runs the same code. The barrier composes
+// signal + waitSignal + an epoch counter (gin_barrier__funcs.h:42-60) -- each
+// sync sends SignalInc to every other rank and waits for the local signal
+// cell to reach a higher epoch, so consecutive syncs don't collide on the
+// same expected value. The ncclTeamTagRail{} overload routes to
+// comm.railGinBarrier and the rail team automatically.
+__global__ void barrier2RanksKernel(int iters, struct ncclDevComm devComm) {
+  ncclGin gin{devComm, /*ginContext=*/0};
+  // barrierIndex must be < railGinBarrierCount (we set =1, so 0).
+  ncclGinBarrierSession<ncclCoopCta> bar{
+      ncclCoopCta(), gin, ncclTeamTagRail{}, /*barrierIndex=*/0};
+  for (int i = 0; i < iters; i++) {
+    bar.sync(ncclCoopCta(), cuda::memory_order_relaxed, ncclGinFenceLevel::Relaxed);
+  }
+}
+
+// First test that actually USES the railGinBarrier resource (prior tests
+// only provisioned it). Kernel completion after kIters rounds proves both
+// ranks moved through the barrier in lockstep -- if the epoch math broke,
+// iter 1 would deadlock waiting for an epoch the peer never reaches.
+TEST_F(GinMPIDeviceTests, Barrier_TwoRanks) {
+  if (auto reason = ginProxyTestSkipReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+
+  if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/2))
+    GTEST_SKIP() << "Requires exactly 2 ranks";
+
+  ASSERT_EQ(ncclSuccess, createTestCommunicator());
+  ncclComm_t  comm   = getActiveCommunicator();
+  hipStream_t stream = getActiveStream();
+
+  int rank = -1, nRanks = -1;
+  ncclCommUserRank(comm, &rank);
+  ncclCommCount(comm, &nRanks);
+  ASSERT_EQ(2, nRanks);
+
+  // Large enough that a stuck-at-zero epoch would deadlock at iter 1
+  // (not silently pass on iter 0); small enough to stay fast. Each round
+  // sends 1 SignalInc per peer (1 in the 2-rank case) and waits for the
+  // corresponding signal cell to reach the new epoch.
+  constexpr int kIters = 16;
+
+  // railGinBarrierCount=1 covers our 1-CTA launch (barrierIndex=0). The
+  // barrier session uses the rail-team GIN barrier pool that the runtime
+  // allocates via ncclGinBarrierCreateRequirement; its signal cells live
+  // at (handle.signal0 + barrierIndex), separate from the user-facing
+  // ginSignalCount pool.
+  //
+  // ginForceEnable is REQUIRED. ncclDevCommCreateInternal only activates
+  // GIN (populating ginHandles[]/ginSignalBase) when nNodes>1 OR
+  // ginForceEnable OR ginSignalCount!=0 OR ginCounterCount!=0 -- the gate
+  // intentionally ignores railGinBarrierCount. Without this flag a
+  // single-node test that asks only for railGinBarrierCount gets NULL
+  // ginHandles[0], and the barrier's internal waitSignal -> getSignalPtr
+  // dispatch dereferences a NULL ncclGinProxyGpuCtx and faults at (nil)
+  // on the GPU. Other tests dodge the gate accidentally by setting
+  // ginSignalCount/ginCounterCount non-zero; this one has neither so we
+  // ask for GIN explicitly.
+  ncclDevCommRequirements reqs{};
+  reqs.railGinBarrierCount = 1;
+  reqs.ginForceEnable      = true;
+  ncclDevComm devComm{};
+  ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
+  auto devCommCleanup = makeScopeGuard([&]() {
+    (void)ncclDevCommDestroy(comm, &devComm);
+  });
+
+  // All ranks finished setup before any kernel launches.
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  // Both ranks launch the same kernel -- barrier is collective, no
+  // producer/consumer split. Each rank's iter i sends SignalInc to the
+  // other rank and waits for its own signal cell to reach epoch+1; if the
+  // barrier raced past the peer (epoch broken), iter i+1 would either spin
+  // forever or read a stale epoch. Kernel completion means all kIters
+  // rounds stayed in lockstep.
+  barrier2RanksKernel<<<1, 32, 0, stream>>>(kIters, devComm);
+  ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+  // Successful return of the kernel IS the assertion: signal + waitSignal
+  // + epoch all worked together for kIters rounds.
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+// ---------------------------------------------------------------------------
+// SignalAdd_AndShadow
+//   Walks the signal-shadow API family end-to-end. SignalAdd (variable add)
+//   takes a different proxy host path than SignalInc (+1):
+//   gin_proxy.h -> ncclGinProxyOpWithSignalAdd. The shadow-side calls
+//   (readSignal, increaseSignalShadow, waitSignalMeetShadow,
+//   waitSignalFollowShadow) are not exercised by any other test. The shadow
+//   lives in GPU memory at comm.ginSignalShadows + ... so it persists across
+//   kernel launches on the same rank; only increaseSignalShadow and
+//   resetSignal mutate it.
+//
+//   Phases (rank 0 = producer, rank 1 = consumer):
+//     P1: producer 1x put(SignalAdd+5, CounterInc); waitCounter(1).
+//         consumer waitSignal(5); readSignal -> must be 5.
+//     P2: producer 3x put(SignalAdd+7, CounterInc); waitCounter(4).
+//         consumer waitSignalFollowShadow(leastDelta=1, &b, &d) -> b=0,
+//         d=26 (signal moved 0->26 since the last shadow snapshot). Then
+//         increaseSignalShadow(+100): shadow := 126.
+//     P3: producer 1x put(SignalAdd+100); no counter; drained via flush.
+//         consumer waitSignalMeetShadow returns when signal >= 126.
+//     P4: producer readCounter -> must be 4 (4 counter-bearing puts; P3
+//         carried no counter).
+//
+//   Why waitCounter at the end of P1/P2 producer kernels: local CQ
+//   completion (counter bump) implies the remote SignalAdd write for that
+//   put has landed on the consumer's signal cell. Without it, the
+//   inter-phase MPI_Barrier would not guarantee in-flight signal writes
+//   have reached the peer, and the consumer could observe an intermediate
+//   signal value (e.g. 5 instead of 26 in P2).
+//
+//   P2 ordering quirk: waitSignalFollowShadow(leastDelta=1) returns as soon
+//   as signal > shadow. If P2's puts and the consumer's wait launched
+//   concurrently, the consumer could observe signal=5 (still just P1) and
+//   return with delta=5 -- the d==26 assertion would fail spuriously. So
+//   P2 producer runs to completion first, then an MPI_Barrier, then the P2
+//   consumer launches. P1 and P3 don't have this issue and run concurrently.
+// ---------------------------------------------------------------------------
+
+// Producer with counter. Used by P1 (nPuts=1, signalDelta=5) and P2
+// (nPuts=3, signalDelta=7). waitCounter at the end gates exit on local CQ
+// completion for all `nPuts` puts, which on the proxy backend implies the
+// remote SignalAdd writes have landed at the peer.
+__global__ void signalAddProducerWithCounterKernel(
+    ncclWindow_t srcWin, size_t srcOff,
+    ncclWindow_t dstWin, size_t dstOff,
+    size_t bytes,
+    ncclGinSignal_t sigIdx, uint64_t signalDelta,
+    ncclGinCounter_t cntIdx, uint64_t counterExpected,
+    int nPuts, int peer,
+    struct ncclDevComm devComm) {
+  ncclGin gin{devComm, /*ginContext=*/0};
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    for (int i = 0; i < nPuts; i++) {
+      gin.put(ncclTeamWorld(devComm), peer,
+              dstWin, dstOff, srcWin, srcOff, bytes,
+              ncclGin_SignalAdd{sigIdx, signalDelta},   // remote: bump peer's signal by delta
+              ncclGin_CounterInc{cntIdx});              // local: bump cntIdx on IB CQE
+    }
+  }
+  gin.waitCounter(ncclCoopCta(), cntIdx, counterExpected);
+}
+
+// Producer without counter. Used by P3: a single put carrying only
+// ncclGin_SignalAdd{sig, 100}. flush() drains posted GFDs before exit so
+// the kernel doesn't return while the SignalAdd is still in flight on the
+// proxy.
+__global__ void signalAddProducerNoCounterKernel(
+    ncclWindow_t srcWin, size_t srcOff,
+    ncclWindow_t dstWin, size_t dstOff,
+    size_t bytes,
+    ncclGinSignal_t sigIdx, uint64_t signalDelta,
+    int peer,
+    struct ncclDevComm devComm) {
+  ncclGin gin{devComm, /*ginContext=*/0};
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    gin.put(ncclTeamWorld(devComm), peer,
+            dstWin, dstOff, srcWin, srcOff, bytes,
+            ncclGin_SignalAdd{sigIdx, signalDelta});
+  }
+  gin.flush(ncclCoopCta());
+}
+
+// Producer P4: read the counter back. Must be 4 = 1 (P1) + 3 (P2); P3 had
+// no counter so it cannot have bumped it.
+__global__ void signalAddProducerReadCounterKernel(
+    ncclGinCounter_t cntIdx, uint64_t* outCounter,
+    struct ncclDevComm devComm) {
+  ncclGin gin{devComm, /*ginContext=*/0};
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    *outCounter = gin.readCounter(cntIdx);
+  }
+}
+
+// Consumer P1: waitSignal(>=5) then readSignal. After P1's single
+// SignalAdd+5 the signal cell is exactly 5, so readSignal must return 5.
+__global__ void signalAddConsumerPhase1Kernel(
+    ncclGinSignal_t sigIdx, uint64_t least,
+    uint64_t* outReadSignal,
+    struct ncclDevComm devComm) {
+  ncclGin gin{devComm, /*ginContext=*/0};
+  gin.waitSignal(ncclCoopCta(), sigIdx, least);
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    *outReadSignal = gin.readSignal(sigIdx);
+  }
+}
+
+// Consumer P2: waitSignalFollowShadow(leastDelta=1) returns once
+// signal > shadow by >= 1; P2 producer's waitCounter(4) guarantees signal
+// has reached 5+3*7=26 here, so before==0 (initial shadow) and delta==26.
+// Then increaseSignalShadow(+100) raises shadow from 26 to 126 for P3.
+__global__ void signalAddConsumerPhase2Kernel(
+    ncclGinSignal_t sigIdx,
+    uint64_t leastDelta,
+    uint64_t shadowBump,
+    uint64_t* outBefore, uint64_t* outDelta,
+    struct ncclDevComm devComm) {
+  ncclGin gin{devComm, /*ginContext=*/0};
+  uint64_t before = 0, delta = 0;
+  gin.waitSignalFollowShadow(ncclCoopCta(), sigIdx, leastDelta, &before, &delta);
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    *outBefore = before;
+    *outDelta  = delta;
+    gin.increaseSignalShadow(sigIdx, shadowBump);
+  }
+}
+
+// Consumer P3: shadow was raised to 126 in P2; this waits for the
+// producer's SignalAdd+100 to bring signal from 26 -> 126.
+__global__ void signalAddConsumerPhase3Kernel(
+    ncclGinSignal_t sigIdx, struct ncclDevComm devComm) {
+  ncclGin gin{devComm, /*ginContext=*/0};
+  gin.waitSignalMeetShadow(ncclCoopCta(), sigIdx);
+}
+
+TEST_F(GinMPIDeviceTests, SignalAdd_AndShadow) {
+  if (auto reason = ginProxyTestSkipReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+
+  if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/2))
+    GTEST_SKIP() << "Requires exactly 2 ranks";
+
+  ASSERT_EQ(ncclSuccess, createTestCommunicator());
+  ncclComm_t  comm   = getActiveCommunicator();
+  hipStream_t stream = getActiveStream();
+
+  int rank = -1, nRanks = -1;
+  ncclCommUserRank(comm, &rank);
+  ncclCommCount(comm, &nRanks);
+  ASSERT_EQ(2, nRanks);
+
+  // The put is just a vehicle for the SignalAdd + CounterInc actions; 8
+  // bytes is the smallest reasonable payload. Bytes correctness is covered
+  // by Put_BasicAndOffsets and is not asserted here.
+  constexpr size_t kBufBytes      = 64;
+  constexpr size_t kTransferBytes = 8;
+  constexpr size_t kSrcOff        = 0;
+  constexpr size_t kDstOff        = 0;
+  constexpr ncclGinSignal_t  kSigIdx = 1;  // non-zero so signal-pool indexing is exercised
+  constexpr ncclGinCounter_t kCntIdx = 1;
+  constexpr int kPeer = 1;  // rank 0 -> rank 1
+
+  // Symmetric src + dst (window registration is collective for
+  // SYMMETRIC-mode windows, so every rank allocates).
+  void* dSrc = nullptr;
+  void* dDst = nullptr;
+  ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dSrc, kBufBytes));
+  ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dDst, kBufBytes));
+  auto memCleanup = makeScopeGuard([&]() {
+    if (dSrc) (void)ncclMemFree(dSrc);
+    if (dDst) (void)ncclMemFree(dDst);
+  });
+
+  ncclWindow_t srcWin = nullptr, dstWin = nullptr;
+  ASSERT_MPI_EQ(ncclSuccess,
+                ncclCommWindowRegister(comm, dSrc, kBufBytes, &srcWin, NCCL_WIN_COLL_SYMMETRIC));
+  ASSERT_MPI_EQ(ncclSuccess,
+                ncclCommWindowRegister(comm, dDst, kBufBytes, &dstWin, NCCL_WIN_COLL_SYMMETRIC));
+  auto winCleanup = makeScopeGuard([&]() {
+    if (srcWin) (void)ncclCommWindowDeregister(comm, srcWin);
+    if (dstWin) (void)ncclCommWindowDeregister(comm, dstWin);
+  });
+
+  // sigIdx=1 and cntIdx=1 -> ginSignalCount/ginCounterCount must be >= 2.
+  ncclDevCommRequirements reqs{};
+  reqs.railGinBarrierCount = 1;
+  reqs.ginSignalCount      = 2;
+  reqs.ginCounterCount     = 2;
+  ncclDevComm devComm{};
+  ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
+  auto devCommCleanup = makeScopeGuard([&]() {
+    (void)ncclDevCommDestroy(comm, &devComm);
+  });
+
+  // Producer needs a known fill (bytes aren't asserted but the put must
+  // have something to move). Consumer's dst gets zeroed.
+  if (rank == 0) {
+    std::vector<uint8_t> hostSrc(kBufBytes, 0xA5);
+    ASSERT_EQ(hipSuccess, hipMemcpy(dSrc, hostSrc.data(), kBufBytes, hipMemcpyHostToDevice));
+  }
+  std::vector<uint8_t> hostZero(kBufBytes, 0);
+  ASSERT_MPI_EQ(hipSuccess, hipMemcpy(dDst, hostZero.data(), kBufBytes, hipMemcpyHostToDevice));
+
+  // Per-rank result buffer. Layout (uint64_t slots):
+  //   producer (rank 0): [0] readCounter (P4)
+  //   consumer (rank 1): [0] readSignal (P1), [1] before (P2), [2] delta (P2)
+  // Initialized to a sentinel so an unwritten slot is obvious in failure logs.
+  constexpr size_t kResultSlots = 4;
+  constexpr uint64_t kSentinel  = 0xFFFFFFFFFFFFFFFFull;
+  uint64_t* dResults = nullptr;
+  ASSERT_EQ(hipSuccess, hipMalloc(&dResults, kResultSlots * sizeof(uint64_t)));
+  auto resultsCleanup = makeScopeGuard([&]() { if (dResults) (void)hipFree(dResults); });
+  std::vector<uint64_t> hostInit(kResultSlots, kSentinel);
+  ASSERT_EQ(hipSuccess,
+            hipMemcpy(dResults, hostInit.data(), kResultSlots * sizeof(uint64_t),
+                      hipMemcpyHostToDevice));
+
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  // --- P1: producer 1x SignalAdd+5/CounterInc, consumer waitSignal(5) +
+  //         readSignal. Concurrent: the consumer's waitSignal blocks until
+  //         the put lands, and no later producer activity is in flight that
+  //         could push signal>5.
+  if (rank == 0) {
+    signalAddProducerWithCounterKernel<<<1, 32, 0, stream>>>(
+        srcWin, kSrcOff, dstWin, kDstOff, kTransferBytes,
+        kSigIdx, /*signalDelta=*/5,
+        kCntIdx, /*counterExpected=*/1,
+        /*nPuts=*/1, kPeer, devComm);
+  } else {
+    signalAddConsumerPhase1Kernel<<<1, 32, 0, stream>>>(
+        kSigIdx, /*least=*/5, &dResults[0], devComm);
+  }
+  ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  // --- P2: producer 3x SignalAdd+7/CounterInc, ending with waitCounter(4).
+  //         MUST complete BEFORE the consumer's waitSignalFollowShadow runs
+  //         (see banner: leastDelta=1 could otherwise observe signal=5 from
+  //         P1 and return with delta=5 instead of 26).
+  if (rank == 0) {
+    signalAddProducerWithCounterKernel<<<1, 32, 0, stream>>>(
+        srcWin, kSrcOff, dstWin, kDstOff, kTransferBytes,
+        kSigIdx, /*signalDelta=*/7,
+        kCntIdx, /*counterExpected=*/4,
+        /*nPuts=*/3, kPeer, devComm);
+    ASSERT_EQ(hipSuccess, hipStreamSynchronize(stream));
+  }
+  MPI_Barrier(MPI_COMM_WORLD);  // gate consumer P2 on producer P2 done
+
+  if (rank == 1) {
+    signalAddConsumerPhase2Kernel<<<1, 32, 0, stream>>>(
+        kSigIdx, /*leastDelta=*/1, /*shadowBump=*/100,
+        &dResults[1], &dResults[2], devComm);
+    ASSERT_EQ(hipSuccess, hipStreamSynchronize(stream));
+  }
+  MPI_Barrier(MPI_COMM_WORLD);  // shadow on rank 1 is now 26+100=126
+
+  // --- P3: producer 1x SignalAdd+100 (no counter, drained via flush);
+  //         consumer waitSignalMeetShadow returns when signal >= 126.
+  //         Concurrent: consumer is gated on the SignalAdd landing.
+  if (rank == 0) {
+    signalAddProducerNoCounterKernel<<<1, 32, 0, stream>>>(
+        srcWin, kSrcOff, dstWin, kDstOff, kTransferBytes,
+        kSigIdx, /*signalDelta=*/100,
+        kPeer, devComm);
+  } else {
+    signalAddConsumerPhase3Kernel<<<1, 32, 0, stream>>>(kSigIdx, devComm);
+  }
+  ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  // --- P4: producer reads counter back. The 4 counter-bearing puts (P1: 1,
+  //         P2: 3) were all waited for via waitCounter in their kernels;
+  //         P3 had no counter. Counter must be exactly 4.
+  if (rank == 0) {
+    signalAddProducerReadCounterKernel<<<1, 1, 0, stream>>>(
+        kCntIdx, &dResults[0], devComm);
+    ASSERT_EQ(hipSuccess, hipStreamSynchronize(stream));
+  }
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  // Pull results back per-rank and assert. These branches are
+  // rank-divergent, so use plain ASSERT_EQ (ASSERT_MPI_EQ would deadlock on
+  // its internal MPI_Allreduce).
+  std::vector<uint64_t> hostResults(kResultSlots, 0);
+  ASSERT_EQ(hipSuccess,
+            hipMemcpy(hostResults.data(), dResults, kResultSlots * sizeof(uint64_t),
+                      hipMemcpyDeviceToHost));
+  if (rank == 0) {
+    ASSERT_EQ(4ull, hostResults[0]) << "P4 readCounter must equal 4 (1 from P1 + 3 from P2)";
+  } else {
+    ASSERT_EQ(5ull,  hostResults[0]) << "P1 readSignal must equal 5";
+    ASSERT_EQ(0ull,  hostResults[1]) << "P2 waitSignalFollowShadow before must be 0";
+    ASSERT_EQ(26ull, hostResults[2]) << "P2 waitSignalFollowShadow delta must be 26";
+  }
+
+  // ScopeGuards run in reverse order on return.
+}
+
+// Producer: drives BOTH symPtr-form shims in a single kernel:
+//   1) gin.put<float>(team, peer, dstSym, srcSym, nElts, SignalInc) -- the
+//      typed-pointer put shim (gin__funcs.h:168) unpacks
+//      ncclSymPtr<T>::{window,offset} and dispatches to the window-form put
+//      with byte-size = nElts*sizeof(T).
+//   2) gin.putValue<uint32_t>(team, peer, valDstSym, value, SignalInc) --
+//      the typed-pointer putValue shim (gin__funcs.h:231) unpacks valDstSym
+//      and dispatches to the window-form putValue with the value carried
+//      inline in the GFD itself. This drives the 4-byte inline branch of
+//      buildGfd (only inlineLow.inlineValLow set, inlineValLow2/inlineValHigh
+//      stay zero because sizeof(T) is not > 4 and not > 6 -- gin_proxy.h:84-95),
+//      distinct from the uint64_t 4+2+2 split exercised by PutValue_Inline.
+// Both posts bump kSigIdx by 1 via SignalInc; the consumer waits on 2.
+__global__ void symPtrProducerKernel(
+    ncclSymPtr<float> dstSym, ncclSymPtr<float> srcSym, size_t nElts,
+    ncclSymPtr<uint32_t> valDstSym, uint32_t inlineValue,
+    ncclGinSignal_t sigIdx, int peer,
+    struct ncclDevComm devComm) {
+  ncclGin gin{devComm, /*ginContext=*/0};
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    gin.put(ncclTeamWorld(devComm), peer,
+            dstSym, srcSym, nElts,
+            ncclGin_SignalInc{sigIdx});
+    gin.putValue<uint32_t>(ncclTeamWorld(devComm), peer,
+                           valDstSym, inlineValue,
+                           ncclGin_SignalInc{sigIdx});
+  }
+  // Drain both posted GFDs before exit.
+  gin.flush(ncclCoopCta());
+}
+
+// Consumer: whole CTA waits for both signal increments from the two posts.
+__global__ void symPtrConsumerKernel(
+    ncclGinSignal_t sigIdx, uint64_t expectedSignalValue,
+    struct ncclDevComm devComm) {
+  ncclGin gin{devComm, /*ginContext=*/0};
+  gin.waitSignal(ncclCoopCta(), sigIdx, expectedSignalValue);
+}
+
+// Exercises the typed-pointer shims (ncclSymPtr<T>) for both gin.put and
+// gin.putValue. Rank 0 sends a 512-float array via symPtr put and a 4-byte
+// uint32 sentinel via symPtr putValue<uint32_t>; rank 1 verifies both
+// land at their respective offsets and nothing else moved.
+TEST_F(GinMPIDeviceTests, SymPtr_PutAndPutValue) {
+  if (auto reason = ginProxyTestSkipReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+
+  if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/2))
+    GTEST_SKIP() << "Requires exactly 2 ranks";
+
+  ASSERT_EQ(ncclSuccess, createTestCommunicator());
+  ncclComm_t  comm   = getActiveCommunicator();
+  hipStream_t stream = getActiveStream();
+
+  int rank = -1, nRanks = -1;
+  ncclCommUserRank(comm, &rank);
+  ncclCommCount(comm, &nRanks);
+  ASSERT_EQ(2, nRanks);
+
+  // Layout: src window holds a 512-float array starting at srcOff. dst
+  // window receives the float array at dstOff (deliberately != srcOff to
+  // exercise non-zero offsets), and the 4-byte uint32 inline value lands
+  // at valOff (well past the float region so a misrouted put surfaces as
+  // a verification mismatch). No src memory is needed for the inline
+  // putValue -- the 4 bytes ride inside the GFD itself.
+  constexpr size_t   kBufBytes    = 8 * 1024;
+  constexpr size_t   kNElts       = 512;
+  constexpr size_t   kSrcOff      = 1 * 1024;             // bytes
+  constexpr size_t   kDstOff      = 2 * 1024;             // bytes
+  constexpr size_t   kValOff      = 6 * 1024;             // bytes (non-overlapping)
+  constexpr uint32_t kInlineValue = 0xCAFEBABEu;
+  constexpr ncclGinSignal_t kSigIdx = 1;
+  constexpr int kPeer = 1;
+
+  static_assert(kSrcOff + kNElts * sizeof(float) <= kBufBytes, "src overflow");
+  static_assert(kDstOff + kNElts * sizeof(float) <= kBufBytes, "dst overflow");
+  static_assert(kValOff + sizeof(uint32_t)       <= kBufBytes, "val overflow");
+  static_assert(kValOff >= kDstOff + kNElts * sizeof(float),
+                "val region must not overlap dst float region");
+
+  void* dSrc = nullptr;
+  void* dDst = nullptr;
+  ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dSrc, kBufBytes));
+  ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dDst, kBufBytes));
+  auto memCleanup = makeScopeGuard([&]() {
+    if (dSrc) (void)ncclMemFree(dSrc);
+    if (dDst) (void)ncclMemFree(dDst);
+  });
+
+  ncclWindow_t srcWin = nullptr, dstWin = nullptr;
+  ASSERT_MPI_EQ(ncclSuccess,
+                ncclCommWindowRegister(comm, dSrc, kBufBytes, &srcWin, NCCL_WIN_COLL_SYMMETRIC));
+  ASSERT_MPI_EQ(ncclSuccess,
+                ncclCommWindowRegister(comm, dDst, kBufBytes, &dstWin, NCCL_WIN_COLL_SYMMETRIC));
+  auto winCleanup = makeScopeGuard([&]() {
+    if (srcWin) (void)ncclCommWindowDeregister(comm, srcWin);
+    if (dstWin) (void)ncclCommWindowDeregister(comm, dstWin);
+  });
+
+  // ginSignalCount=2 so kSigIdx=1 is in range.
+  ncclDevCommRequirements reqs{};
+  reqs.railGinBarrierCount = 1;
+  reqs.ginSignalCount      = 2;
+  ncclDevComm devComm{};
+  ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
+  auto devCommCleanup = makeScopeGuard([&]() {
+    (void)ncclDevCommDestroy(comm, &devComm);
+  });
+
+  // Rank 0 fills its src float array with a deterministic pattern. Both
+  // ranks zero their dst so any spurious write outside [dstOff, dstOff+xfer)
+  // or near kValOff surfaces as a verification mismatch.
+  std::vector<uint8_t> hostSrc(kBufBytes, 0);
+  std::vector<uint8_t> hostDst(kBufBytes, 0);
+  if (rank == 0) {
+    float* srcFloats = reinterpret_cast<float*>(hostSrc.data() + kSrcOff);
+    for (size_t i = 0; i < kNElts; i++) {
+      srcFloats[i] = static_cast<float>(i) + 0.5f;
+    }
+  }
+  ASSERT_MPI_EQ(hipSuccess, hipMemcpy(dSrc, hostSrc.data(), kBufBytes, hipMemcpyHostToDevice));
+  ASSERT_MPI_EQ(hipSuccess, hipMemcpy(dDst, hostDst.data(), kBufBytes, hipMemcpyHostToDevice));
+
+  // Sync so neither rank launches its kernel before setup is done globally.
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  // Producer issues both the float-array put and the inline uint32 putValue
+  // from a single kernel; consumer waitSignal(2) drains both. Two posts
+  // each bump kSigIdx by 1 via SignalInc, so the final value is 2.
+  if (rank == 0) {
+    ncclSymPtr<float>    srcSym(srcWin, kSrcOff);
+    ncclSymPtr<float>    dstSym(dstWin, kDstOff);
+    ncclSymPtr<uint32_t> valDstSym(dstWin, kValOff);
+    symPtrProducerKernel<<<1, 32, 0, stream>>>(
+        dstSym, srcSym, kNElts,
+        valDstSym, kInlineValue,
+        kSigIdx, kPeer, devComm);
+  } else {
+    symPtrConsumerKernel<<<1, 32, 0, stream>>>(
+        kSigIdx, /*expectedSignalValue=*/2, devComm);
+  }
+  ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  // Receiver-side verification.
+  if (rank == 1) {
+    std::vector<uint8_t> hostResult(kBufBytes, 0);
+    ASSERT_EQ(hipSuccess,
+              hipMemcpy(hostResult.data(), dDst, kBufBytes, hipMemcpyDeviceToHost));
+
+    // 1) The float array landed at dstOff and matches rank 0's source.
+    const float* gotFloats = reinterpret_cast<const float*>(hostResult.data() + kDstOff);
+    for (size_t i = 0; i < kNElts; i++) {
+      const float expected = static_cast<float>(i) + 0.5f;
+      ASSERT_EQ(expected, gotFloats[i])
+          << "float[" << i << "] mismatch at dstOff via symPtr put";
+    }
+    // 2) The 4-byte uint32 inline value landed at valOff. These bytes came
+    //    from the inline GFD slot (putValue<uint32_t>), not from any source
+    //    MR -- the symPtr shim only carried the destination offset.
+    uint32_t gotInline = 0;
+    std::memcpy(&gotInline, hostResult.data() + kValOff, sizeof(gotInline));
+    ASSERT_EQ(kInlineValue, gotInline)
+        << "inline uint32 mismatch at valOff (symPtr putValue path)";
+    // 3) Nothing was written outside the two destination regions.
+    for (size_t i = 0; i < kDstOff; i++) {
+      ASSERT_EQ(0u, hostResult[i])
+          << "byte " << i << " before float-dst region was unexpectedly written";
+    }
+    for (size_t i = kDstOff + kNElts * sizeof(float); i < kValOff; i++) {
+      ASSERT_EQ(0u, hostResult[i])
+          << "byte " << i << " between float-dst and val-dst was unexpectedly written";
+    }
+    for (size_t i = kValOff + sizeof(uint32_t); i < kBufBytes; i++) {
+      ASSERT_EQ(0u, hostResult[i])
+          << "byte " << i << " after val-dst region was unexpectedly written";
+    }
+  }
+}
+
+// Reference single-node alltoall: every rank puts its slice for every peer
+// into that peer's recvbuf via gin.put + SignalInc, then waits on its own
+// signal cell for nRanks increments. Ported one-for-one from
+// examples/06_device_api/02_gin_alltoall_pure/main.cu so a regression in
+// put + signal + barrier + flush composed under realistic load surfaces here.
+__global__ void alltoallPureKernel(
+    ncclWindow_t sendwin, size_t sendoffset,
+    ncclWindow_t recvwin, size_t recvoffset,
+    size_t count, struct ncclDevComm devComm) {
+  constexpr int ginContext = 0;
+  constexpr unsigned int signalIndex = 0;
+  ncclGin gin{devComm, ginContext};
+  // Capture current signal cell so a count-sweep that reuses the same
+  // kernel/devComm doesn't conflate increments from past iterations.
+  uint64_t signalValue = gin.readSignal(signalIndex);
+
+  // Cross-rank sync ensures every rank's sendbuf is registered before any
+  // peer reads from it via gin.put below.
+  ncclGinBarrierSession<ncclCoopCta> bar{
+      ncclCoopCta(), gin, ncclTeamWorld(devComm),
+      devComm.railGinBarrier, blockIdx.x};
+  bar.sync(ncclCoopCta(), cuda::memory_order_relaxed, ncclGinFenceLevel::Relaxed);
+
+  int tid = threadIdx.x + blockIdx.x * blockDim.x;
+  int nthreads = blockDim.x * gridDim.x;
+
+  // Each rank writes its per-peer slice into the destination's recvbuf
+  // slot (offset = my rank * size). All puts bump signalIndex by 1 on the
+  // destination, so the destination's signal cell receives nRanks
+  // increments (one per source rank including self).
+  const size_t size = count * sizeof(float);
+  for (int r = tid; r < devComm.nRanks; r += nthreads) {
+    gin.put(ncclTeamWorld(devComm), r,
+        recvwin, recvoffset + devComm.rank * size,
+        sendwin, sendoffset + r * size,
+        size, ncclGin_SignalInc{signalIndex});
+  }
+
+  gin.waitSignal(ncclCoopCta(), signalIndex, signalValue + devComm.nRanks);
+  gin.flush(ncclCoopCta());
+}
+
+// Single-node 2-8 ranks; count sweep {1, 1024, 1<<16}. Bit-for-bit verifies
+// the deterministic sendbuf[i] = rank*1000 + dst*100 + i pattern landed on
+// the right peer slot. The 1<<16 case (256 KiB / direction / peer) saturates
+// ring credit to exercise the postGfd credit-wait path.
+TEST_F(GinMPIDeviceTests, Alltoall_PureReference) {
+  if (auto reason = ginProxyTestSkipReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+
+  if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/8))
+    GTEST_SKIP() << "Requires 2-8 ranks";
+
+  ASSERT_EQ(ncclSuccess, createTestCommunicator());
+  ncclComm_t  comm   = getActiveCommunicator();
+  hipStream_t stream = getActiveStream();
+
+  int rank = -1, nRanks = -1;
+  ncclCommUserRank(comm, &rank);
+  ncclCommCount(comm, &nRanks);
+  ASSERT_GE(nRanks, 2);
+  ASSERT_LE(nRanks, 8);
+
+  // ginSignalCount=1 covers signalIndex=0; railGinBarrierCount=1 matches
+  // our single-CTA launch. Both non-zero so GIN activates without
+  // ginForceEnable.
+  ncclDevCommRequirements reqs{};
+  reqs.railGinBarrierCount = 1;
+  reqs.ginSignalCount      = 1;
+  ncclDevComm devComm{};
+  ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
+  auto devCommCleanup = makeScopeGuard([&]() {
+    (void)ncclDevCommDestroy(comm, &devComm);
+  });
+
+  // 1 (alignment/tail edges), 1024 (medium), 65536 (saturating).
+  const std::vector<size_t> counts = {1, 1024, size_t{1} << 16};
+  constexpr int kCTAs          = 1;   // == railGinBarrierCount
+  constexpr int kThreadsPerCTA = 512; // matches the production example launch
+
+  for (size_t count : counts) {
+    SCOPED_TRACE(::testing::Message() << "count=" << count);
+
+    const size_t totalElements = count * static_cast<size_t>(nRanks);
+    const size_t sizeBytes     = totalElements * sizeof(float);
+
+    void* dSend = nullptr;
+    void* dRecv = nullptr;
+    ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dSend, sizeBytes));
+    ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dRecv, sizeBytes));
+    auto memCleanup = makeScopeGuard([&]() {
+      if (dSend) (void)ncclMemFree(dSend);
+      if (dRecv) (void)ncclMemFree(dRecv);
+    });
+
+    ncclWindow_t sendWin = nullptr, recvWin = nullptr;
+    ASSERT_MPI_EQ(ncclSuccess,
+        ncclCommWindowRegister(comm, dSend, sizeBytes, &sendWin, NCCL_WIN_COLL_SYMMETRIC));
+    ASSERT_MPI_EQ(ncclSuccess,
+        ncclCommWindowRegister(comm, dRecv, sizeBytes, &recvWin, NCCL_WIN_COLL_SYMMETRIC));
+    auto winCleanup = makeScopeGuard([&]() {
+      if (sendWin) (void)ncclCommWindowDeregister(comm, sendWin);
+      if (recvWin) (void)ncclCommWindowDeregister(comm, recvWin);
+    });
+
+    // Per-source/per-dest pattern: every byte of every slice has a unique
+    // expected value, so a misrouted slice surfaces as a mismatch.
+    std::vector<float> hostSend(totalElements, 0.0f);
+    std::vector<float> hostRecv(totalElements, 0.0f);
+    for (int dst = 0; dst < nRanks; dst++) {
+      for (size_t i = 0; i < count; i++) {
+        hostSend[static_cast<size_t>(dst) * count + i] =
+            static_cast<float>(rank * 1000 + dst * 100 + static_cast<int>(i));
+      }
+    }
+    ASSERT_MPI_EQ(hipSuccess,
+        hipMemcpy(dSend, hostSend.data(), sizeBytes, hipMemcpyHostToDevice));
+    ASSERT_MPI_EQ(hipSuccess,
+        hipMemcpy(dRecv, hostRecv.data(), sizeBytes, hipMemcpyHostToDevice));
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    alltoallPureKernel<<<kCTAs, kThreadsPerCTA, 0, stream>>>(
+        sendWin, /*sendoffset=*/0,
+        recvWin, /*recvoffset=*/0,
+        count, devComm);
+    ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // recvbuf[src*count + i] on rank R should equal src*1000 + R*100 + i.
+    ASSERT_EQ(hipSuccess,
+        hipMemcpy(hostRecv.data(), dRecv, sizeBytes, hipMemcpyDeviceToHost));
+    for (int src = 0; src < nRanks; src++) {
+      for (size_t i = 0; i < count; i++) {
+        const float expected =
+            static_cast<float>(src * 1000 + rank * 100 + static_cast<int>(i));
+        const float got = hostRecv[static_cast<size_t>(src) * count + i];
+        ASSERT_EQ(expected, got)
+            << "rank=" << rank << " src=" << src << " i=" << i;
+      }
+    }
+  }
+}
+
+// Hybrid alltoall: LSA stores for intra-node peers + gin.put for cross-node
+// peers, bracketed by entry/exit barriers. Ported from
+// examples/06_device_api/03_gin_alltoall_hybrid/main.cu (HybridAlltoAllKernel).
+// On single-node nNodes==1 so world.nRanks==lsa.nRanks; numRemotePeers==0
+// and the gin.put loops are no-ops -- this run primarily exercises the
+// LSA-store path + entry/exit barrier composition. The cross-node arm is
+// covered by Alltoall_CrossNode per the plan.
+__global__ void alltoallHybridKernel(
+    ncclWindow_t sendwin, size_t sendoffset,
+    ncclWindow_t recvwin, size_t recvoffset,
+    size_t count, struct ncclDevComm devComm) {
+  constexpr int ginContext = 0;
+  constexpr unsigned int signalIndex = 0;
+  ncclGin gin{devComm, ginContext};
+  uint64_t signalValue = gin.readSignal(signalIndex);
+
+  // ncclBarrierSession (not the gin-only variant) routes through both LSA
+  // and rail-team GIN under ncclTeamTagWorld(). Single-node degenerates to
+  // an LSA-team barrier; multi-node crosses rails.
+  ncclBarrierSession<ncclCoopCta> bar{
+      ncclCoopCta(), ncclTeamTagWorld(), gin, blockIdx.x};
+  bar.sync(ncclCoopCta(), std::memory_order_relaxed, ncclGinFenceLevel::Relaxed);
+
+  int tid = threadIdx.x + blockIdx.x * blockDim.x;
+  int nthreads = blockDim.x * gridDim.x;
+
+  ncclTeam world = ncclTeamWorld(devComm);
+  ncclTeam lsa   = ncclTeamLsa(devComm);
+  const int startLsa = world.rank - lsa.rank;
+  const int lsaSize  = lsa.nRanks;
+
+  // Cross-node peers: covers everything outside this node's LSA team
+  // (no-op on single-node).
+  const size_t size = count * sizeof(float);
+  for (int r = tid; r < startLsa; r += nthreads) {
+    gin.put(world, r,
+        recvwin, recvoffset + world.rank * size,
+        sendwin, sendoffset + r * size,
+        size, ncclGin_SignalInc{signalIndex});
+  }
+  for (int r = startLsa + lsaSize + tid; r < world.nRanks; r += nthreads) {
+    gin.put(world, r,
+        recvwin, recvoffset + world.rank * size,
+        sendwin, sendoffset + r * size,
+        size, ncclGin_SignalInc{signalIndex});
+  }
+
+  // Intra-node peers: write each LSA peer's slot in their recv buffer
+  // directly. ncclGetLocalPointer resolves our own sendbuf;
+  // ncclGetLsaPointer resolves an LSA peer's recvbuf into our address space.
+  float* sendLocal = (float*)ncclGetLocalPointer(sendwin, sendoffset);
+  for (size_t offset = tid; offset < count; offset += nthreads) {
+    for (int lp = 0; lp < lsa.nRanks; lp++) {
+      int wr = startLsa + lp;
+      float* recvPtr = (float*)ncclGetLsaPointer(recvwin, recvoffset, lp);
+      recvPtr[world.rank * count + offset] = sendLocal[wr * count + offset];
+    }
+  }
+
+  // Only wait for remote peers' increments; LSA peers don't bump the
+  // signal cell. On single-node this returns immediately (delta=0).
+  int numRemotePeers = world.nRanks - lsa.nRanks;
+  gin.waitSignal(ncclCoopCta(), signalIndex, signalValue + numRemotePeers);
+  gin.flush(ncclCoopCta());
+
+  // Final barrier: every rank's LSA stores into peer recvbufs are issued
+  // and the local writes from peers are visible before any rank consumes
+  // its recvbuf.
+  bar.sync(ncclCoopCta(), std::memory_order_release, ncclGinFenceLevel::Relaxed);
+}
+
+// Same shape and verification as Alltoall_PureReference but exercises the
+// LSA-store path and the dual-pool barrier. On single-node the gin.put arm
+// is a no-op; the test still validates LSA + rail-team-GIN barrier
+// composition + readSignal/waitSignal plumbing with delta=0.
+TEST_F(GinMPIDeviceTests, AlltoallHybrid_Reference) {
+  if (auto reason = ginProxyTestSkipReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+
+  if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/8))
+    GTEST_SKIP() << "Requires 2-8 ranks";
+
+  ASSERT_EQ(ncclSuccess, createTestCommunicator());
+  ncclComm_t  comm   = getActiveCommunicator();
+  hipStream_t stream = getActiveStream();
+
+  int rank = -1, nRanks = -1;
+  ncclCommUserRank(comm, &rank);
+  ncclCommCount(comm, &nRanks);
+  ASSERT_GE(nRanks, 2);
+  ASSERT_LE(nRanks, 8);
+
+  // Both barrier pools (LSA + rail-GIN) are used by ncclBarrierSession
+  // under ncclTeamTagWorld(); both must cover our single-CTA launch
+  // (barrierIndex=0). ginSignalCount=1 covers the cross-node signal cell
+  // and triggers GIN activation.
+  ncclDevCommRequirements reqs{};
+  reqs.lsaBarrierCount     = 1;
+  reqs.railGinBarrierCount = 1;
+  reqs.ginSignalCount      = 1;
+  ncclDevComm devComm{};
+  ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
+  auto devCommCleanup = makeScopeGuard([&]() {
+    (void)ncclDevCommDestroy(comm, &devComm);
+  });
+
+  const std::vector<size_t> counts = {1, 1024, size_t{1} << 16};
+  constexpr int kCTAs          = 1;
+  constexpr int kThreadsPerCTA = 512;
+
+  for (size_t count : counts) {
+    SCOPED_TRACE(::testing::Message() << "count=" << count);
+
+    const size_t totalElements = count * static_cast<size_t>(nRanks);
+    const size_t sizeBytes     = totalElements * sizeof(float);
+
+    void* dSend = nullptr;
+    void* dRecv = nullptr;
+    ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dSend, sizeBytes));
+    ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dRecv, sizeBytes));
+    auto memCleanup = makeScopeGuard([&]() {
+      if (dSend) (void)ncclMemFree(dSend);
+      if (dRecv) (void)ncclMemFree(dRecv);
+    });
+
+    ncclWindow_t sendWin = nullptr, recvWin = nullptr;
+    ASSERT_MPI_EQ(ncclSuccess,
+        ncclCommWindowRegister(comm, dSend, sizeBytes, &sendWin, NCCL_WIN_COLL_SYMMETRIC));
+    ASSERT_MPI_EQ(ncclSuccess,
+        ncclCommWindowRegister(comm, dRecv, sizeBytes, &recvWin, NCCL_WIN_COLL_SYMMETRIC));
+    auto winCleanup = makeScopeGuard([&]() {
+      if (sendWin) (void)ncclCommWindowDeregister(comm, sendWin);
+      if (recvWin) (void)ncclCommWindowDeregister(comm, recvWin);
+    });
+
+    // Same deterministic pattern as Alltoall_PureReference.
+    std::vector<float> hostSend(totalElements, 0.0f);
+    std::vector<float> hostRecv(totalElements, 0.0f);
+    for (int dst = 0; dst < nRanks; dst++) {
+      for (size_t i = 0; i < count; i++) {
+        hostSend[static_cast<size_t>(dst) * count + i] =
+            static_cast<float>(rank * 1000 + dst * 100 + static_cast<int>(i));
+      }
+    }
+    ASSERT_MPI_EQ(hipSuccess,
+        hipMemcpy(dSend, hostSend.data(), sizeBytes, hipMemcpyHostToDevice));
+    ASSERT_MPI_EQ(hipSuccess,
+        hipMemcpy(dRecv, hostRecv.data(), sizeBytes, hipMemcpyHostToDevice));
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    alltoallHybridKernel<<<kCTAs, kThreadsPerCTA, 0, stream>>>(
+        sendWin, /*sendoffset=*/0,
+        recvWin, /*recvoffset=*/0,
+        count, devComm);
+    ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    ASSERT_EQ(hipSuccess,
+        hipMemcpy(hostRecv.data(), dRecv, sizeBytes, hipMemcpyDeviceToHost));
+    for (int src = 0; src < nRanks; src++) {
+      for (size_t i = 0; i < count; i++) {
+        const float expected =
+            static_cast<float>(src * 1000 + rank * 100 + static_cast<int>(i));
+        const float got = hostRecv[static_cast<size_t>(src) * count + i];
+        ASSERT_EQ(expected, got)
+            << "rank=" << rank << " src=" << src << " i=" << i;
+      }
+    }
+  }
+}
+
+// Producer: one block per GIN context. Block b uses ginContext=b, puts into
+// its own slot, and signals signal[b] in that context.
+__global__ void multiContextProducerKernel(
+    ncclWindow_t srcWin, ncclWindow_t dstWin,
+    size_t slotStride, size_t bytes, int peer,
+    struct ncclDevComm devComm) {
+  ncclGin gin{devComm, (int)blockIdx.x};
+  const size_t off = (size_t)blockIdx.x * slotStride;
+  if (threadIdx.x == 0) {
+    gin.put(ncclTeamWorld(devComm), peer,
+            dstWin, off,
+            srcWin, off,
+            bytes,
+            ncclGin_SignalInc{(ncclGinSignal_t)blockIdx.x});
+  }
+  gin.flush(ncclCoopCta());
+}
+
+// Consumer: block b waits on signal[b] in its own context, mirroring the
+// producer-side mapping.
+__global__ void multiContextConsumerKernel(
+    uint64_t expectedSignalValue,
+    struct ncclDevComm devComm) {
+  ncclGin gin{devComm, (int)blockIdx.x};
+  gin.waitSignal(ncclCoopCta(), (ncclGinSignal_t)blockIdx.x, expectedSignalValue);
+}
+
+// Drives all NCCL_GIN_MAX_CONTEXTS contexts in parallel, each with its own
+// slot + per-context signal. Confirms every contextId has a working
+// proxy ring + IB QP and that there's no cross-context contamination.
+TEST_F(GinMPIDeviceTests, MultiContext_AllFourRoute) {
+  if (auto reason = ginProxyTestSkipReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+
+  if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/2))
+    GTEST_SKIP() << "Requires exactly 2 ranks";
+
+  ASSERT_EQ(ncclSuccess, createTestCommunicator());
+  ncclComm_t  comm   = getActiveCommunicator();
+  hipStream_t stream = getActiveStream();
+
+  int rank = -1, nRanks = -1;
+  ncclCommUserRank(comm, &rank);
+  ncclCommCount(comm, &nRanks);
+  ASSERT_EQ(2, nRanks);
+
+  // 4 per-context slots; 1 KiB payload into each 4 KiB slot. The 3 KiB
+  // tail per slot is asserted zero to catch cross-context contamination.
+  constexpr int    kNumContexts    = NCCL_GIN_MAX_CONTEXTS;  // 4
+  constexpr size_t kSlotStride     = 4 * 1024;
+  constexpr size_t kTransferBytes  = 1 * 1024;
+  constexpr size_t kBufBytes       = kNumContexts * kSlotStride;
+  constexpr int    kPeer           = 1;
+
+  // Allocate symmetric src/dst large enough for all contexts' slots.
+  void* dSrc = nullptr;
+  void* dDst = nullptr;
+  ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dSrc, kBufBytes));
+  ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dDst, kBufBytes));
+  auto memCleanup = makeScopeGuard([&]() {
+    if (dSrc) (void)ncclMemFree(dSrc);
+    if (dDst) (void)ncclMemFree(dDst);
+  });
+
+  // Register collective windows over the symmetric buffers.
+  ncclWindow_t srcWin = nullptr, dstWin = nullptr;
+  ASSERT_MPI_EQ(ncclSuccess,
+                ncclCommWindowRegister(comm, dSrc, kBufBytes, &srcWin, NCCL_WIN_COLL_SYMMETRIC));
+  ASSERT_MPI_EQ(ncclSuccess,
+                ncclCommWindowRegister(comm, dDst, kBufBytes, &dstWin, NCCL_WIN_COLL_SYMMETRIC));
+  auto winCleanup = makeScopeGuard([&]() {
+    if (srcWin) (void)ncclCommWindowDeregister(comm, srcWin);
+    if (dstWin) (void)ncclCommWindowDeregister(comm, dstWin);
+  });
+
+  // Bring up GIN. ginContextCount on reqs is a hint; the authoritative
+  // value is env-driven and read back from devComm. Each block uses a
+  // signal id == blockIdx.x, so we need kNumContexts signal cells per ctx.
+  ncclDevCommRequirements reqs{};
+  reqs.railGinBarrierCount = 1;
+  reqs.ginContextCount     = kNumContexts;
+  reqs.ginSignalCount      = kNumContexts;
+  ncclDevComm devComm{};
+  ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
+  auto devCommCleanup = makeScopeGuard([&]() {
+    (void)ncclDevCommDestroy(comm, &devComm);
+  });
+
+  // Skip if the runtime didn't actually give us the requested number of ctxs.
+  if ((int)devComm.ginContextCount != kNumContexts) {
+    GTEST_SKIP() << "Test requires " << kNumContexts << " GIN contexts, got "
+                 << (int)devComm.ginContextCount
+                 << " (set NCCL_GIN_NCONTEXTS=" << kNumContexts << ")";
+  }
+
+  // Stage a distinct pattern (0x10 + b) per context slot so cross-context
+  // landings show up as value mismatches rather than missing writes.
+  std::vector<uint8_t> hostSrc(kBufBytes, 0);
+  std::vector<uint8_t> hostDst(kBufBytes, 0);
+  for (int b = 0; b < kNumContexts; b++) {
+    const uint8_t pattern = static_cast<uint8_t>(0x10 + b);
+    std::fill_n(hostSrc.begin() + b * kSlotStride, kTransferBytes, pattern);
+  }
+  ASSERT_MPI_EQ(hipSuccess, hipMemcpy(dSrc, hostSrc.data(), kBufBytes, hipMemcpyHostToDevice));
+  ASSERT_MPI_EQ(hipSuccess, hipMemcpy(dDst, hostDst.data(), kBufBytes, hipMemcpyHostToDevice));
+
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  // Launch kNumContexts blocks on each side; one block per context.
+  if (rank == 0) {
+    multiContextProducerKernel<<<kNumContexts, 32, 0, stream>>>(
+        srcWin, dstWin, kSlotStride, kTransferBytes, kPeer, devComm);
+  } else {
+    multiContextConsumerKernel<<<kNumContexts, 32, 0, stream>>>(
+        /*expectedSignalValue=*/1, devComm);
+  }
+  ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  // Verify every context's slot independently: payload range matches
+  // pattern, slot tail is still zero.
+  if (rank == 1) {
+    std::vector<uint8_t> hostResult(kBufBytes, 0);
+    ASSERT_EQ(hipSuccess,
+              hipMemcpy(hostResult.data(), dDst, kBufBytes, hipMemcpyDeviceToHost));
+
+    for (int b = 0; b < kNumContexts; b++) {
+      const uint8_t pattern = static_cast<uint8_t>(0x10 + b);
+      const size_t base = (size_t)b * kSlotStride;
+      for (size_t i = 0; i < kTransferBytes; i++) {
+        ASSERT_EQ(pattern, hostResult[base + i])
+            << "ctx " << b << ": byte " << i
+            << " in transferred range mismatched (expected 0x" << std::hex
+            << (int)pattern << ")";
+      }
+      for (size_t i = kTransferBytes; i < kSlotStride; i++) {
+        ASSERT_EQ(0u, hostResult[base + i])
+            << "ctx " << b << ": byte " << i
+            << " in slot tail was unexpectedly written";
+      }
+    }
+  }
+}
+
+// Exercises the non-power-of-2 context count (3), which forces the modulo
+// arm of the ncclGin ctor. Producer launches 6 blocks; pairs (0,3), (1,4),
+// (2,5) collide on contextId 0/1/2 and each pair writes a disjoint sub-slot.
+// Each producer signals signal 0 of its ctx; consumer waits for value 2.
+// Requires NCCL_GIN_NCONTEXTS=3 (skipped otherwise).
+__global__ void multiContextNpo2ProducerKernel(
+    ncclWindow_t srcWin, ncclWindow_t dstWin,
+    int numContexts, size_t slotStride, size_t subSlotBytes, int peer,
+    struct ncclDevComm devComm) {
+  ncclGin gin{devComm, (int)blockIdx.x};
+  const int    ctx       = (int)blockIdx.x % numContexts;
+  const int    subSlotIx = (int)blockIdx.x / numContexts;
+  const size_t off       = (size_t)ctx * slotStride + (size_t)subSlotIx * subSlotBytes;
+  if (threadIdx.x == 0) {
+    gin.put(ncclTeamWorld(devComm), peer,
+            dstWin, off,
+            srcWin, off,
+            subSlotBytes,
+            ncclGin_SignalInc{(ncclGinSignal_t)0});
+  }
+  gin.flush(ncclCoopCta());
+}
+
+__global__ void multiContextNpo2ConsumerKernel(
+    uint64_t expectedSignalValue,
+    struct ncclDevComm devComm) {
+  ncclGin gin{devComm, (int)blockIdx.x};
+  gin.waitSignal(ncclCoopCta(), (ncclGinSignal_t)0, expectedSignalValue);
+}
+
+TEST_F(GinMPIDeviceTests, MultiContext_NonPowerOf2) {
+  if (auto reason = ginProxyTestSkipReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+
+  if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/2))
+    GTEST_SKIP() << "Requires exactly 2 ranks";
+
+  ASSERT_EQ(ncclSuccess, createTestCommunicator());
+  ncclComm_t  comm   = getActiveCommunicator();
+  hipStream_t stream = getActiveStream();
+
+  int rank = -1, nRanks = -1;
+  ncclCommUserRank(comm, &rank);
+  ncclCommCount(comm, &nRanks);
+  ASSERT_EQ(2, nRanks);
+
+  // 3 ctx slots * 4 KiB stride; 2 sub-slots of 1 KiB per slot (one per
+  // producer block hitting that ctx); 2 KiB tail per slot asserted zero.
+  constexpr int    kNumContexts    = 3;
+  constexpr int    kBlocksPerCtx   = 2;
+  constexpr int    kProducerBlocks = kNumContexts * kBlocksPerCtx;
+  constexpr size_t kSubSlotBytes   = 1 * 1024;
+  constexpr size_t kSlotStride     = 4 * 1024;
+  constexpr size_t kBufBytes       = kNumContexts * kSlotStride;
+  constexpr int    kPeer           = 1;
+
+  // Allocate symmetric src/dst.
+  void* dSrc = nullptr;
+  void* dDst = nullptr;
+  ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dSrc, kBufBytes));
+  ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dDst, kBufBytes));
+  auto memCleanup = makeScopeGuard([&]() {
+    if (dSrc) (void)ncclMemFree(dSrc);
+    if (dDst) (void)ncclMemFree(dDst);
+  });
+
+  // Register collective windows over the symmetric buffers.
+  ncclWindow_t srcWin = nullptr, dstWin = nullptr;
+  ASSERT_MPI_EQ(ncclSuccess,
+                ncclCommWindowRegister(comm, dSrc, kBufBytes, &srcWin, NCCL_WIN_COLL_SYMMETRIC));
+  ASSERT_MPI_EQ(ncclSuccess,
+                ncclCommWindowRegister(comm, dDst, kBufBytes, &dstWin, NCCL_WIN_COLL_SYMMETRIC));
+  auto winCleanup = makeScopeGuard([&]() {
+    if (srcWin) (void)ncclCommWindowDeregister(comm, srcWin);
+    if (dstWin) (void)ncclCommWindowDeregister(comm, dstWin);
+  });
+
+  // Bring up GIN with 3 contexts, 1 signal each (signal pools are per-ctx,
+  // so signal 0 is independent across the three contexts).
+  ncclDevCommRequirements reqs{};
+  reqs.railGinBarrierCount = 1;
+  reqs.ginContextCount     = kNumContexts;
+  reqs.ginSignalCount      = 1;
+  ncclDevComm devComm{};
+  ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
+  auto devCommCleanup = makeScopeGuard([&]() {
+    (void)ncclDevCommDestroy(comm, &devComm);
+  });
+
+  // Skip unless the runtime gave us exactly 3 contexts (this test is the
+  // only thing exercising the modulo arm of the ctor).
+  if ((int)devComm.ginContextCount != kNumContexts) {
+    GTEST_SKIP() << "Test requires " << kNumContexts << " GIN contexts, got "
+                 << (int)devComm.ginContextCount
+                 << " (set NCCL_GIN_NCONTEXTS=" << kNumContexts << ")";
+  }
+
+  // Stage a distinct pattern per producer block (0x10 + b) so a stray
+  // landing surfaces as a value mismatch.
+  std::vector<uint8_t> hostSrc(kBufBytes, 0);
+  std::vector<uint8_t> hostDst(kBufBytes, 0);
+  for (int b = 0; b < kProducerBlocks; b++) {
+    const int    ctx       = b % kNumContexts;
+    const int    subSlotIx = b / kNumContexts;
+    const size_t off       = (size_t)ctx * kSlotStride + (size_t)subSlotIx * kSubSlotBytes;
+    const uint8_t pattern  = static_cast<uint8_t>(0x10 + b);
+    std::fill_n(hostSrc.begin() + off, kSubSlotBytes, pattern);
+  }
+  ASSERT_MPI_EQ(hipSuccess, hipMemcpy(dSrc, hostSrc.data(), kBufBytes, hipMemcpyHostToDevice));
+  ASSERT_MPI_EQ(hipSuccess, hipMemcpy(dDst, hostDst.data(), kBufBytes, hipMemcpyHostToDevice));
+
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  // Producer launches 6 blocks (2 per ctx); consumer launches one block
+  // per ctx and waits for value 2 on signal 0 of that ctx.
+  if (rank == 0) {
+    multiContextNpo2ProducerKernel<<<kProducerBlocks, 32, 0, stream>>>(
+        srcWin, dstWin, kNumContexts, kSlotStride, kSubSlotBytes, kPeer, devComm);
+  } else {
+    multiContextNpo2ConsumerKernel<<<kNumContexts, 32, 0, stream>>>(
+        /*expectedSignalValue=*/static_cast<uint64_t>(kBlocksPerCtx), devComm);
+  }
+  ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  // Verify both sub-slots of every ctx hold the right pattern, and the
+  // tail past the two sub-slots is still zero.
+  if (rank == 1) {
+    std::vector<uint8_t> hostResult(kBufBytes, 0);
+    ASSERT_EQ(hipSuccess,
+              hipMemcpy(hostResult.data(), dDst, kBufBytes, hipMemcpyDeviceToHost));
+
+    for (int ctx = 0; ctx < kNumContexts; ctx++) {
+      const size_t base = (size_t)ctx * kSlotStride;
+      for (int subSlotIx = 0; subSlotIx < kBlocksPerCtx; subSlotIx++) {
+        const int     b       = subSlotIx * kNumContexts + ctx;
+        const uint8_t pattern = static_cast<uint8_t>(0x10 + b);
+        const size_t  off     = base + (size_t)subSlotIx * kSubSlotBytes;
+        for (size_t i = 0; i < kSubSlotBytes; i++) {
+          ASSERT_EQ(pattern, hostResult[off + i])
+              << "ctx " << ctx << " sub-slot " << subSlotIx
+              << " (block " << b << "): byte " << i
+              << " mismatched (expected 0x" << std::hex << (int)pattern << ")";
+        }
+      }
+      const size_t tailStart = base + (size_t)kBlocksPerCtx * kSubSlotBytes;
+      for (size_t i = tailStart; i < base + kSlotStride; i++) {
+        ASSERT_EQ(0u, hostResult[i])
+            << "ctx " << ctx << ": byte " << (i - base)
+            << " in slot tail was unexpectedly written";
+      }
+    }
+  }
+}
+
+// Sweep a matrix of aligned + unaligned transfer sizes through the same
+// put kernel; reuses one comm / window pair / signal cell across iters
+// (signal monotonically bumped, consumer waits for iter+1).
+TEST_F(GinMPIDeviceTests, LargeBuffer_Sweep) {
+  if (auto reason = ginProxyTestSkipReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+
+  if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/2))
+    GTEST_SKIP() << "Requires exactly 2 ranks";
+
+  ASSERT_EQ(ncclSuccess, createTestCommunicator());
+  ncclComm_t  comm   = getActiveCommunicator();
+  hipStream_t stream = getActiveStream();
+
+  int rank = -1, nRanks = -1;
+  ncclCommUserRank(comm, &rank);
+  ncclCommCount(comm, &nRanks);
+  ASSERT_EQ(2, nRanks);
+
+  // Aligned + unaligned matrix; the +1 variants force a trailing fragment
+  // so RDMA tail-byte handling regressions surface.
+  const std::vector<size_t> kSizes = {
+      1,
+      64,
+      4 * 1024,
+      4 * 1024 + 1,
+      1 * 1024 * 1024,
+      4 * 1024 * 1024,
+      16 * 1024 * 1024,
+      16 * 1024 * 1024 + 1,
+  };
+  const size_t kMaxBytes = kSizes.back();
+  constexpr ncclGinSignal_t kSigIdx = 0;
+  constexpr int kPeer = 1;
+
+  // Allocate symmetric src/dst sized for the largest sweep entry.
+  void* dSrc = nullptr;
+  void* dDst = nullptr;
+  ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dSrc, kMaxBytes));
+  ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dDst, kMaxBytes));
+  auto memCleanup = makeScopeGuard([&]() {
+    if (dSrc) (void)ncclMemFree(dSrc);
+    if (dDst) (void)ncclMemFree(dDst);
+  });
+
+  // Register collective windows; reused across all iterations.
+  ncclWindow_t srcWin = nullptr, dstWin = nullptr;
+  ASSERT_MPI_EQ(ncclSuccess,
+                ncclCommWindowRegister(comm, dSrc, kMaxBytes, &srcWin, NCCL_WIN_COLL_SYMMETRIC));
+  ASSERT_MPI_EQ(ncclSuccess,
+                ncclCommWindowRegister(comm, dDst, kMaxBytes, &dstWin, NCCL_WIN_COLL_SYMMETRIC));
+  auto winCleanup = makeScopeGuard([&]() {
+    if (srcWin) (void)ncclCommWindowDeregister(comm, srcWin);
+    if (dstWin) (void)ncclCommWindowDeregister(comm, dstWin);
+  });
+
+  // Bring up GIN with one signal cell; we'll bump it once per iter.
+  ncclDevCommRequirements reqs{};
+  reqs.railGinBarrierCount = 1;
+  reqs.ginSignalCount      = 1;
+  ncclDevComm devComm{};
+  ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
+  auto devCommCleanup = makeScopeGuard([&]() {
+    (void)ncclDevCommDestroy(comm, &devComm);
+  });
+
+  // Stage src once: src[i] = i & 0xFF. Distinct bytes mod 256 catch
+  // byte-shift / off-by-one regressions in the RDMA path.
+  std::vector<uint8_t> hostSrc(kMaxBytes, 0);
+  for (size_t i = 0; i < kMaxBytes; i++) hostSrc[i] = static_cast<uint8_t>(i & 0xFF);
+  ASSERT_MPI_EQ(hipSuccess, hipMemcpy(dSrc, hostSrc.data(), kMaxBytes, hipMemcpyHostToDevice));
+
+  // Reusable buffers: zero pattern for clearing dst, scratch for verify.
+  const std::vector<uint8_t> hostZero(kMaxBytes, 0);
+  std::vector<uint8_t> hostResult(kMaxBytes, 0);
+
+  uint64_t signalExpected = 0;
+  for (size_t iter = 0; iter < kSizes.size(); iter++) {
+    const size_t sz = kSizes[iter];
+
+    // Clear dDst so the previous iter's larger payload doesn't leak into
+    // this iter's tail-byte assertions.
+    ASSERT_MPI_EQ(hipSuccess, hipMemcpy(dDst, hostZero.data(), kMaxBytes, hipMemcpyHostToDevice));
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // Each iter bumps signal[0] by 1; consumer waits for the cumulative count.
+    signalExpected++;
+    if (rank == 0) {
+      putBasicProducerKernel<<<1, 32, 0, stream>>>(
+          srcWin, /*srcOff=*/0,
+          dstWin, /*dstOff=*/0,
+          sz, kSigIdx, kPeer, devComm);
+    } else {
+      putBasicConsumerKernel<<<1, 32, 0, stream>>>(
+          kSigIdx, signalExpected, devComm);
+    }
+    ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // Rank 1 verifies: payload [0,sz) matches src; tail [sz,kMaxBytes) zero.
+    if (rank == 1) {
+      ASSERT_EQ(hipSuccess,
+                hipMemcpy(hostResult.data(), dDst, kMaxBytes, hipMemcpyDeviceToHost));
+
+      const int payloadCmp = std::memcmp(hostResult.data(), hostSrc.data(), sz);
+      ASSERT_EQ(0, payloadCmp)
+          << "size=" << sz << ": payload range [0," << sz
+          << ") differs from source";
+
+      if (sz < kMaxBytes) {
+        const int tailCmp =
+          std::memcmp(hostResult.data() + sz, hostZero.data(), kMaxBytes - sz);
+        ASSERT_EQ(0, tailCmp)
+            << "size=" << sz << ": bytes in [" << sz << "," << kMaxBytes
+            << ") were unexpectedly written";
+      }
+    }
+  }
+}
+
+// Negative test: with NCCL_GIN_ENABLE=0, ncclDevCommCreate on a GIN-
+// requiring config must fail with ncclInternalError -- no hang, no crash.
+TEST_F(GinMPIDeviceTests, Disable_Error) {
+  const char* e = std::getenv("NCCL_GIN_ENABLE");
+  if (!e || std::strcmp(e, "0") != 0)
+    GTEST_SKIP() << "Negative-path test; opt in by setting NCCL_GIN_ENABLE=0";
+
+  if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/2))
+    GTEST_SKIP() << "Requires exactly 2 ranks";
+
+  // Skip ginProxyTestSkipReason: bare comm bring-up does not call into GIN,
+  // so the data-path gates don't apply here.
+  ASSERT_EQ(ncclSuccess, createTestCommunicator());
+  ncclComm_t comm = getActiveCommunicator();
+
+  // ginSignalCount > 0 forces ncclDevCommCreate to bring up GIN.
+  ncclDevCommRequirements reqs{};
+  reqs.ginSignalCount = 1;
+  ncclDevComm devComm{};
+  ncclResult_t r = ncclDevCommCreate(comm, &reqs, &devComm);
+
+  ASSERT_EQ(ncclInternalError, r)
+      << "ncclDevCommCreate should fail with ncclInternalError when "
+         "NCCL_GIN_ENABLE=0; got result " << (int)r;
+}
+
+// With an oversized signal pool the runtime should silently clamp to its
+// internal max; confirm the data path still works after the clamp.
+TEST_F(GinMPIDeviceTests, Invalid_SignalPool) {
+  if (auto reason = ginProxyTestSkipReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+
+  if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/2))
+    GTEST_SKIP() << "Requires exactly 2 ranks";
+
+  // Opt in with an oversized signal pool (>= 1 GiB) to exercise the clamp.
+  const char* env = std::getenv("NCCL_GIN_SIGNAL_POOL_SIZE");
+  if (!env || std::strtoull(env, nullptr, 0) < (1ULL << 30))
+    GTEST_SKIP() << "Set NCCL_GIN_SIGNAL_POOL_SIZE>=0x40000000 to opt in";
+
+  // If clamp + data path are healthy, the basic put round-trip succeeds.
+  runBasicPutSelfCheck();
+}
+
+// Counterpart of Invalid_SignalPool for the counter pool.
+TEST_F(GinMPIDeviceTests, Invalid_CounterPool) {
+  if (auto reason = ginProxyTestSkipReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+
+  if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/2))
+    GTEST_SKIP() << "Requires exactly 2 ranks";
+
+  // Opt in with an oversized counter pool (>= 1 GiB).
+  const char* env = std::getenv("NCCL_GIN_COUNTER_POOL_SIZE");
+  if (!env || std::strtoull(env, nullptr, 0) < (1ULL << 30))
+    GTEST_SKIP() << "Set NCCL_GIN_COUNTER_POOL_SIZE>=0x40000000 to opt in";
+
+  runBasicPutSelfCheck();
+}
+
+// Run a put round-trip, then explicitly tear the comm down and check
+// cleanup returns success. Failure here indicates a leak / unjoined proxy
+// thread / undeleased MR or QP somewhere in ncclGinFinalize.
+TEST_F(GinMPIDeviceTests, Teardown_NoLeaks) {
+  if (auto reason = ginProxyTestSkipReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+
+  if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/2))
+    GTEST_SKIP() << "Requires exactly 2 ranks";
+
+  // Inner scope so window/devComm/mem guards fire before we call
+  // cleanupTestCommunicator() below (they hold refs to the comm).
+  {
+    // Setup: comm, stream, geometry.
+    ASSERT_EQ(ncclSuccess, createTestCommunicator());
+    ncclComm_t  comm   = getActiveCommunicator();
+    hipStream_t stream = getActiveStream();
+
+    constexpr size_t          kBufBytes      = 64;
+    constexpr ncclGinSignal_t kSigIdx        = 0;
+    constexpr int             kPeer          = 1;
+
+    int rank = -1, nRanks = -1;
+    ncclCommUserRank(comm, &rank);
+    ncclCommCount(comm, &nRanks);
+    ASSERT_EQ(2, nRanks);
+
+    // Allocate symmetric src/dst.
+    void* dSrc = nullptr;
+    void* dDst = nullptr;
+    ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dSrc, kBufBytes));
+    ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dDst, kBufBytes));
+    auto memCleanup = makeScopeGuard([&]() {
+      if (dSrc) (void)ncclMemFree(dSrc);
+      if (dDst) (void)ncclMemFree(dDst);
+    });
+
+    // Register collective windows.
+    ncclWindow_t srcWin = nullptr, dstWin = nullptr;
+    ASSERT_MPI_EQ(ncclSuccess,
+                  ncclCommWindowRegister(comm, dSrc, kBufBytes, &srcWin, NCCL_WIN_COLL_SYMMETRIC));
+    ASSERT_MPI_EQ(ncclSuccess,
+                  ncclCommWindowRegister(comm, dDst, kBufBytes, &dstWin, NCCL_WIN_COLL_SYMMETRIC));
+    auto winCleanup = makeScopeGuard([&]() {
+      if (srcWin) (void)ncclCommWindowDeregister(comm, srcWin);
+      if (dstWin) (void)ncclCommWindowDeregister(comm, dstWin);
+    });
+
+    // Bring up GIN (1 signal cell suffices for a single round-trip).
+    ncclDevCommRequirements reqs{};
+    reqs.railGinBarrierCount = 1;
+    reqs.ginSignalCount      = 1;
+    ncclDevComm devComm{};
+    ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
+    auto devCommCleanup = makeScopeGuard([&]() {
+      (void)ncclDevCommDestroy(comm, &devComm);
+    });
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // Run a single basic put + waitSignal round-trip.
+    if (rank == 0) {
+      putBasicProducerKernel<<<1, 32, 0, stream>>>(
+          srcWin, /*srcOff=*/0,
+          dstWin, /*dstOff=*/0,
+          kBufBytes, kSigIdx, kPeer,
+          devComm);
+    } else {
+      putBasicConsumerKernel<<<1, 32, 0, stream>>>(
+          kSigIdx, /*expectedSignalValue=*/1, devComm);
+    }
+    ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+    MPI_Barrier(MPI_COMM_WORLD);
+  }  // mem/window/devComm guards fire here while comm is still live.
+
+  // Explicit destroy: success implies ncclGinFinalize ran to completion
+  // (proxy thread joined, MR/QP released).
+  ASSERT_EQ(ncclSuccess, cleanupTestCommunicator());
+  ASSERT_EQ(nullptr, getActiveCommunicator());
+  ASSERT_EQ(nullptr, getActiveStream());
+}
+
+// Hammer create/destroy in a loop. Catches refcount, mutex, and
+// finalize-order regressions that only surface across multiple lifecycles.
+TEST_F(GinMPIDeviceTests, Init_Destroy_Stress) {
+  if (auto reason = ginProxyTestSkipReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+
+  if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/2))
+    GTEST_SKIP() << "Requires exactly 2 ranks";
+
+  constexpr int kIterations = 10;
+  for (int i = 0; i < kIterations; ++i) {
+    // Fresh comm each iter.
+    ASSERT_EQ(ncclSuccess, createTestCommunicator()) << "iter " << i;
+    ncclComm_t comm = getActiveCommunicator();
+
+    // Allocate + register a tiny window to actually trigger the GIN
+    // connect machinery (not just bare comm bring-up).
+    void* d = nullptr;
+    ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&d, 64));
+
+    ncclWindow_t win = nullptr;
+    ASSERT_MPI_EQ(ncclSuccess,
+                  ncclCommWindowRegister(comm, d, 64, &win, NCCL_WIN_COLL_SYMMETRIC));
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // Tear everything down in reverse order before the next iter.
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowDeregister(comm, win));
+    ASSERT_MPI_EQ(ncclSuccess, ncclMemFree(d));
+
+    ASSERT_EQ(ncclSuccess, cleanupTestCommunicator()) << "iter " << i;
+  }
+}
+
+// Cross-node alltoall using device-side put. Each rank sends one slot to
+// every other rank and waits for nRanks-1 signal increments per iter.
+// Sweeps tiny/medium/saturating sizes through the same comm and buffers.
+TEST_F(GinMPIDeviceTests, Alltoall_CrossNode) {
+  if (auto reason = ginProxyTestSkipReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+  // Single-node would loopback IB; require real cross-node ranks.
+  if (auto reason = crossNodeReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+  if (!validateTestPrerequisites(/*min_processes=*/2))
+    GTEST_SKIP() << "Requires >=2 ranks";
+
+  ASSERT_EQ(ncclSuccess, createTestCommunicator());
+  ncclComm_t  comm   = getActiveCommunicator();
+  hipStream_t stream = getActiveStream();
+
+  int rank = -1, nRanks = -1;
+  ncclCommUserRank(comm, &rank);
+  ncclCommCount(comm, &nRanks);
+
+  // Geometry: per-peer slot is sized for the largest sweep entry; smaller
+  // counts just use the head of each slot.
+  using T = uint32_t;
+  static constexpr size_t kCounts[]   = {1, 1u << 10, 1u << 20};
+  static constexpr size_t kMaxCount   = 1u << 20;
+  const size_t slotStrideBytes        = kMaxCount * sizeof(T);
+  const size_t bufBytes               = (size_t)nRanks * slotStrideBytes;
+  constexpr ncclGinSignal_t kSigIdx   = 0;
+
+  // Allocate symmetric send/recv buffers (one slot per peer).
+  void* dSend = nullptr;
+  void* dRecv = nullptr;
+  ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dSend, bufBytes));
+  ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dRecv, bufBytes));
+  auto memCleanup = makeScopeGuard([&]() {
+    if (dSend) (void)ncclMemFree(dSend);
+    if (dRecv) (void)ncclMemFree(dRecv);
+  });
+
+  // Register collective windows over send/recv.
+  ncclWindow_t sendWin = nullptr, recvWin = nullptr;
+  ASSERT_MPI_EQ(ncclSuccess,
+                ncclCommWindowRegister(comm, dSend, bufBytes, &sendWin, NCCL_WIN_COLL_SYMMETRIC));
+  ASSERT_MPI_EQ(ncclSuccess,
+                ncclCommWindowRegister(comm, dRecv, bufBytes, &recvWin, NCCL_WIN_COLL_SYMMETRIC));
+  auto winCleanup = makeScopeGuard([&]() {
+    if (sendWin) (void)ncclCommWindowDeregister(comm, sendWin);
+    if (recvWin) (void)ncclCommWindowDeregister(comm, recvWin);
+  });
+
+  // Bring up GIN with one signal cell (cumulative across iters).
+  ncclDevCommRequirements reqs{};
+  reqs.railGinBarrierCount = 1;
+  reqs.ginSignalCount      = 1;
+  ncclDevComm devComm{};
+  ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
+  auto devCommCleanup = makeScopeGuard([&]() {
+    (void)ncclDevCommDestroy(comm, &devComm);
+  });
+
+  // Encoding: byte[3] = sender rank, byte[2] = dest rank, byte[1:0] =
+  // element index. Lets the receiver decode both source and dest from a slot.
+  auto pack = [](int sender, int dest, size_t i) -> T {
+    return (T)((((uint32_t)sender & 0xFFu) << 24) |
+               (((uint32_t)dest   & 0xFFu) << 16) |
+               ((uint32_t)i       & 0xFFFFu));
+  };
+
+  // Stage send buffer: slot p contains values addressed to peer p.
+  std::vector<T> hostSend((size_t)nRanks * kMaxCount);
+  for (int p = 0; p < nRanks; ++p) {
+    for (size_t i = 0; i < kMaxCount; ++i) {
+      hostSend[(size_t)p * kMaxCount + i] = pack(rank, p, i);
+    }
+  }
+  ASSERT_MPI_EQ(hipSuccess,
+                hipMemcpy(dSend, hostSend.data(), bufBytes, hipMemcpyHostToDevice));
+
+  // Cumulative across iters; the signal cell is never reset between iters.
+  std::vector<T> hostRecv((size_t)nRanks * kMaxCount);
+  uint64_t expectedSignal = 0;
+
+  for (size_t count : kCounts) {
+    // Kernel skips p == myRank; fill our self slot locally so verify
+    // covers all nRanks rows uniformly.
+    ASSERT_MPI_EQ(hipSuccess,
+                  hipMemcpyAsync((uint8_t*)dRecv + (size_t)rank * slotStrideBytes,
+                                 (uint8_t*)dSend + (size_t)rank * slotStrideBytes,
+                                 count * sizeof(T),
+                                 hipMemcpyDeviceToDevice,
+                                 stream));
+
+    // We expect to receive nRanks-1 signal increments per iter.
+    expectedSignal += (uint64_t)(nRanks - 1);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // Single combined kernel: put to every peer + flush + waitSignal.
+    alltoallKernel<<<1, 32, 0, stream>>>(
+        sendWin, recvWin,
+        count * sizeof(T),
+        nRanks, rank,
+        slotStrideBytes,
+        kSigIdx, expectedSignal,
+        devComm);
+
+    ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // Verify each row of the recv buffer holds the bytes packed by sender r.
+    ASSERT_EQ(hipSuccess,
+              hipMemcpy(hostRecv.data(), dRecv, bufBytes, hipMemcpyDeviceToHost));
+    for (int r = 0; r < nRanks; ++r) {
+      for (size_t i = 0; i < count; ++i) {
+        T expected = pack(r, rank, i);
+        T actual   = hostRecv[(size_t)r * kMaxCount + i];
+        ASSERT_EQ(expected, actual)
+            << "count=" << count << " sender=" << r << " i=" << i;
+      }
+    }
+
+    // Hold all ranks here so a fast peer can't start the next iter and
+    // overwrite a slow rank's recvbuf before it has verified.
+    MPI_Barrier(MPI_COMM_WORLD);
+  }
+}
+
+#endif  // MPI_TESTS_ENABLED

--- a/projects/rccl/test/transport/GinDeviceMPITests.cpp
+++ b/projects/rccl/test/transport/GinDeviceMPITests.cpp
@@ -764,6 +764,169 @@ TEST_F(GinMPIDeviceTests, WaitCounter_Local) {
   MPI_Barrier(MPI_COMM_WORLD);
 }
 
+// Producer kernel: rank 0 issues a single put carrying BOTH a remote
+// SignalInc action and a local CounterInc action, then waits on its OWN
+// counter. The remote SignalInc bumps the peer's signal cell when the IB
+// write lands at the target (gin_host_proxy.cc:271-273); the local
+// CounterInc bumps rank 0's counter when the IB CQE for the put is
+// observed by the local proxy (gin_host_proxy.cc:147-152). One put,
+// two completion sites.
+__global__ void waitCounterAndSignalProducerKernel(
+    ncclWindow_t srcWin, size_t srcOff,
+    ncclWindow_t dstWin, size_t dstOff,
+    size_t bytes,
+    ncclGinSignal_t sigIdx, ncclGinCounter_t cntIdx, int peer,
+    struct ncclDevComm devComm) {
+  ncclGin gin{devComm, /*ginContext=*/0};
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    gin.put(ncclTeamWorld(devComm), peer,
+            dstWin, dstOff, srcWin, srcOff, bytes,
+            ncclGin_SignalInc{sigIdx},        // remote: bump peer's signal cell
+            ncclGin_CounterInc{cntIdx});      // local: bump cntIdx on IB CQE
+  }
+  // CTA-collective wait gating kernel exit on local CQ completion. On the
+  // proxy backend, the local CQE strictly follows the remote SignalInc
+  // landing, so once this returns the consumer's waitSignal is unblocked
+  // (or already past).
+  gin.waitCounter(ncclCoopCta(), cntIdx, /*least=*/1);
+}
+
+// Consumer kernel: rank 1 waits on its signal cell to reach 1. No put is
+// issued from this side -- the IB plugin lands rank 0's payload + signal
+// passively.
+__global__ void waitCounterAndSignalConsumerKernel(
+    ncclGinSignal_t sigIdx, uint64_t expectedSignalValue,
+    struct ncclDevComm devComm) {
+  ncclGin gin{devComm, /*ginContext=*/0};
+  gin.waitSignal(ncclCoopCta(), sigIdx, expectedSignalValue);
+}
+
+// Exercises both completion sites of a single gin.put with combined
+// (SignalInc, CounterInc) actions:
+//   - Remote signal notification: rank 1's waitSignal returns when the
+//     IB write of the SignalInc lands on its signal cell.
+//   - Local IB-CQE -> counter bump: rank 0's waitCounter returns when the
+//     local proxy thread has observed the CQE for the put.
+// Together with the post-sync host-side payload check on rank 1, this
+// proves the same put delivered (a) bytes, (b) remote signal, and
+// (c) local counter -- all driven by one gin.put.
+TEST_F(GinMPIDeviceTests, WaitCounterAndSignal) {
+  if (auto reason = ginProxyTestSkipReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+
+  if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/2))
+    GTEST_SKIP() << "Requires exactly 2 ranks";
+
+  ASSERT_EQ(ncclSuccess, createTestCommunicator());
+  ncclComm_t  comm   = getActiveCommunicator();
+  hipStream_t stream = getActiveStream();
+
+  int rank = -1, nRanks = -1;
+  ncclCommUserRank(comm, &rank);
+  ncclCommCount(comm, &nRanks);
+  ASSERT_EQ(2, nRanks);
+
+  // 8 KiB symmetric buffers; 4 KiB payload at non-zero src/dst offsets so
+  // the put is a realistic data move. Both signal and counter indices are
+  // non-zero so a regression that drops the index multiplier would land
+  // at cell 0 and the waits would never observe the bump.
+  constexpr size_t kBufBytes      = 8 * 1024;
+  constexpr size_t kTransferBytes = 4 * 1024;
+  constexpr size_t kSrcOff        = 4 * 1024;
+  constexpr size_t kDstOff        = 2 * 1024;
+  constexpr ncclGinSignal_t  kSigIdx = 1;
+  constexpr ncclGinCounter_t kCntIdx = 1;
+  constexpr int kPeer = 1;
+
+  // Symmetric src + dst on every rank (window registration is collective
+  // for SYMMETRIC-mode windows).
+  void* dSrc = nullptr;
+  void* dDst = nullptr;
+  ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dSrc, kBufBytes));
+  ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dDst, kBufBytes));
+  auto memCleanup = makeScopeGuard([&]() {
+    if (dSrc) (void)ncclMemFree(dSrc);
+    if (dDst) (void)ncclMemFree(dDst);
+  });
+
+  ncclWindow_t srcWin = nullptr, dstWin = nullptr;
+  ASSERT_MPI_EQ(ncclSuccess,
+                ncclCommWindowRegister(comm, dSrc, kBufBytes, &srcWin, NCCL_WIN_COLL_SYMMETRIC));
+  ASSERT_MPI_EQ(ncclSuccess,
+                ncclCommWindowRegister(comm, dDst, kBufBytes, &dstWin, NCCL_WIN_COLL_SYMMETRIC));
+  auto winCleanup = makeScopeGuard([&]() {
+    if (srcWin) (void)ncclCommWindowDeregister(comm, srcWin);
+    if (dstWin) (void)ncclCommWindowDeregister(comm, dstWin);
+  });
+
+  // ginSignalCount=2 and ginCounterCount=2 so kSigIdx=1 and kCntIdx=1 are
+  // both in range. railGinBarrierCount=1 covers the 1-CTA launch.
+  ncclDevCommRequirements reqs{};
+  reqs.railGinBarrierCount = 1;
+  reqs.ginSignalCount      = 2;
+  reqs.ginCounterCount     = 2;
+  ncclDevComm devComm{};
+  ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
+  auto devCommCleanup = makeScopeGuard([&]() {
+    (void)ncclDevCommDestroy(comm, &devComm);
+  });
+
+  // Deterministic byte pattern in src so the post-sync data check on
+  // rank 1 catches wrong-bytes / wrong-offset regressions. Both ranks
+  // zero their dst as a baseline.
+  std::vector<uint8_t> hostSrc(kBufBytes, 0);
+  std::vector<uint8_t> hostDst(kBufBytes, 0);
+  for (size_t i = 0; i < kTransferBytes; i++) {
+    hostSrc[kSrcOff + i] = static_cast<uint8_t>(0x40 + (i & 0xFF));
+  }
+  ASSERT_MPI_EQ(hipSuccess, hipMemcpy(dSrc, hostSrc.data(), kBufBytes, hipMemcpyHostToDevice));
+  ASSERT_MPI_EQ(hipSuccess, hipMemcpy(dDst, hostDst.data(), kBufBytes, hipMemcpyHostToDevice));
+
+  // Sync so neither rank launches before setup is done globally.
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  // Rank 0 puts + bumps remote signal + bumps local counter; rank 1 waits
+  // for the signal. Each side's gin wait IS its assertion (counter on
+  // rank 0, signal on rank 1); the host-side memcmp on rank 1 below
+  // verifies the payload.
+  if (rank == 0) {
+    waitCounterAndSignalProducerKernel<<<1, 32, 0, stream>>>(
+        srcWin, kSrcOff, dstWin, kDstOff,
+        kTransferBytes, kSigIdx, kCntIdx, kPeer, devComm);
+  } else {
+    waitCounterAndSignalConsumerKernel<<<1, 32, 0, stream>>>(
+        kSigIdx, /*expectedSignalValue=*/1, devComm);
+  }
+  ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+  // Sync so rank 1's verify isn't racing rank 0's kernel completion.
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  // Rank 1 verifies the payload landed at [kDstOff, kDstOff+kTransferBytes)
+  // and nothing outside that range was touched.
+  if (rank == 1) {
+    std::vector<uint8_t> hostResult(kBufBytes, 0);
+    ASSERT_EQ(hipSuccess,
+              hipMemcpy(hostResult.data(), dDst, kBufBytes, hipMemcpyDeviceToHost));
+    for (size_t i = 0; i < kDstOff; i++) {
+      ASSERT_EQ(0u, hostResult[i])
+          << "byte " << i << " before dstOff was unexpectedly written";
+    }
+    for (size_t i = 0; i < kTransferBytes; i++) {
+      ASSERT_EQ(hostSrc[kSrcOff + i], hostResult[kDstOff + i])
+          << "payload byte " << i << " mismatched";
+    }
+    for (size_t i = kDstOff + kTransferBytes; i < kBufBytes; i++) {
+      ASSERT_EQ(0u, hostResult[i])
+          << "byte " << i << " after dstOff+kTransferBytes was unexpectedly written";
+    }
+  }
+
+  // Final sync so collective teardown (ScopeGuards) see both ranks past
+  // the verification phase.
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
 // Collective kernel: every rank runs the same code. The barrier composes
 // signal + waitSignal + an epoch counter (gin_barrier__funcs.h:42-60) -- each
 // sync sends SignalInc to every other rank and waits for the local signal

--- a/projects/rccl/tools/scripts/test_runner/configs/ci-precheckin.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/ci-precheckin.json
@@ -173,7 +173,8 @@
         {"name": "BitOps", "description": "Bit operation utility tests (macros and typed fixtures)", "test_filter": "ALIGN_*:DIVUP:ROUNDUP:u32fp*:*Hash:BitOpsTemplate*"},
         {"name": "CommTests", "description": "Communicator helper tests", "test_filter": "CommTests.*"},
         {"name": "EnqueueCountTests", "description": "Enqueue send/recv count helpers", "test_filter": "EnqueueCountTests.*"},
-        {"name": "MiscTests.Sorter", "description": "Task coll sorter unit test", "test_filter": "MiscTests.Sorter"}
+        {"name": "MiscTests.Sorter", "description": "Task coll sorter unit test", "test_filter": "MiscTests.Sorter"},
+        {"name": "GinDeviceTest", "description": "GIN proxy backend device-leaf tests", "test_filter": "GinDeviceTest.*"}
       ]
     }
   },


### PR DESCRIPTION
## Motivation

Enable the GIN Proxy backend on AMD GPUs

## Technical Details

GIN IB Proxy backend - Lets device kernels initiate network operations directly. In this backend, the GPU writes work descriptors into a ring buffer and a CPU proxy drains it and submits each through RCCL's IB net plugin, which issues the corresponding RDMA op.

Supports Pure GIN (D=3, all hops via GIN) and Hybrid (D=4, LSA intra-node + GIN inter-node) exercised by the new alltoall tests.

## JIRA ID

AICOMRCCL-949

## Test Plan

- Validate rccl unit tests on CI
- Add new tests to exercise the GIN device APIs end-to-end - AICOMRCCL-950
- Functional validation of the GIN device collectives on MI300 and MI350:
  - **Pure GIN** path (D=3, all data movement via GIN).
  - **Hybrid** path (D=4, GIN + LSA team barrier across rails).

## Test Result

- Added `GinDeviceTests.cpp` covering device-side GIN primitives
- Added`GinDeviceMPITests.cpp` covering the multi-process / multi-node MPI surface across multiple processes and nodes

- Validated on MI300 and MI350 - AICOMRCCL-799

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
