### PR TITLE
fix: resolve compiler warnings in rocm_smi, amd_smi, and tests

### DIFF
--- a/projects/amdsmi/rocm_smi/src/rocm_smi_device.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_device.cc
@@ -116,7 +116,6 @@ static const char* kDevNumaNodeFName = "numa_node";
 static const char* kDevGpuMetricsFName = "gpu_metrics";
 
 // GPU Overdrive (gpu_od) paths - used internally via Device helper methods
-static const char* kDevGpuOdPath = "gpu_od";
 static const char* kDevGpuOdFanMinPwmFName = "gpu_od/fan_ctrl/fan_minimum_pwm";
 
 static const char* kDevGpuPartitionMetricsFName = "xcp/xcp_metrics";

--- a/projects/amdsmi/src/amd_smi/amd_smi_system.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_system.cc
@@ -342,8 +342,9 @@ amdsmi_status_t AMDSmiSystem::populate_amd_gpu_devices() {
   AMDSmiSystem::cleanup();
   // init rsmi — forward the test flag so the mutex becomes non-blocking
   rsmi_driver_state_t state;
-  uint64_t rsmi_flags =
-      (init_flag_ & AMD_SMI_INIT_FLAG_RESRV_TEST1) ? RSMI_INIT_FLAG_RESRV_TEST1 : 0;
+  uint64_t rsmi_flags = (init_flag_ & AMD_SMI_INIT_FLAG_RESRV_TEST1)
+                            ? static_cast<uint64_t>(RSMI_INIT_FLAG_RESRV_TEST1)
+                            : 0ULL;
   rsmi_status_t ret = rsmi_init(rsmi_flags);
   if (ret != RSMI_STATUS_SUCCESS) {
     if (rsmi_driver_status(&state) == RSMI_STATUS_SUCCESS &&

--- a/projects/amdsmi/tests/amd_smi_test/functional/memory_read_write.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/memory_read_write.cc
@@ -234,7 +234,7 @@ void TestMemoryReadWrite::Run(void) {
                 << std::endl;
 
       // Convert to GB for display
-      const long page_size = sysconf(_SC_PAGESIZE);
+      const double page_size = static_cast<double>(sysconf(_SC_PAGESIZE));
       double gb =
           (static_cast<double>(ttm_info.current_pages) * page_size) / (1024.0 * 1024.0 * 1024.0);
       std::cout << "\t**Current TTM Size: " << gb << " GB" << std::endl;


### PR DESCRIPTION
## Motivation:
These warnings appear with -Wall -Wextra -Wconversion and pollute CI logs, masking real issues. Cleaning them up improves signal-to-noise in build output and prevents warning-count ratcheting.

## Technical details:

1. rocm_smi_device.cc: Remove unused static variable kDevGpuOdPath
   - Triggers -Wunused-variable. Confirmed zero references in the entire rocm_smi/ tree; the remaining kDevGpuOdFanMinPwmFName embeds the full subpath and does not depend on this constant.

2. amd_smi_system.cc: Add static_cast<uint64_t> + 0ULL to ternary
   - RSMI_INIT_FLAG_RESRV_TEST1 is an unscoped C enum with value 0x0800000000000000. Assigning it to uint64_t rsmi_flags without a cast triggers -Wconversion (enum-to-integer). The explicit cast matches the established pattern in amd_smi_gpu_mutex.h and rocm_smi_common.h. The 0ULL literal ensures both ternary arms have the same type.

3. memory_read_write.cc: Change page_size from const long to double
   - page_size was only used in a double-precision expression (double * long → implicit promotion triggers -Wconversion). Storing as double upfront eliminates the mixed-type arithmetic warning. Precision is not a concern: page sizes (4096, 65536) are exact in IEEE 754 double.

