### PR TITLE
[rocprofiler-compute] Fix test_metric_validation test case

### DIFF
--- a/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
+++ b/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
@@ -599,8 +599,9 @@ Dispatch filtering
 
 Dispatch filtering selects which iterations of each kernel to profile.
 Indices are 1-based, so the first dispatch of a kernel is ``1``. Each
-value is a positive integer or a ``start:end`` range with
-``start <= end`` (for example, ``1`` or ``3:5``).
+value is a positive integer or a range with ``start <= end``, written as
+either ``start:end`` or ``start-end`` (for example, ``1``, ``3:5``, or
+``3-5``).
 
 The following example profiles the first dispatch of each kernel in the
 application.

--- a/projects/rocprofiler-compute/src/argparser.py
+++ b/projects/rocprofiler-compute/src/argparser.py
@@ -339,8 +339,9 @@ Examples:
         required=False,
         help=(
             "\t\t\tWhich dispatch iterations of each kernel to filter \n"
-            "\t\t\t(1-based; positive integer or 'start:end' range, \n"
-            "\t\t\te.g. 1 3:5 captures 1st, 3rd, 4th and 5th iterations)."
+            "\t\t\t(1-based; positive integer or 'start:end'/'start-end' \n"
+            "\t\t\trange, e.g. 1 3:5 captures 1st, 3rd, 4th and 5th \n"
+            "\t\t\titerations)."
         ),
     )
     profile_group.add_argument(

--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
@@ -184,16 +184,16 @@ class RocProfCompute_Base:
                     "options."
                 )
 
-        # Each --dispatch token must be a positive integer or a 'start:end'
-        # range with start <= end (1-based indexing).
+        # Each --dispatch token must be a positive integer or a range
+        # ('start:end' or 'start-end') with start <= end (1-based indexing).
         if args.dispatch:
             for token in args.dispatch:
-                m = re.fullmatch(r"([1-9]\d*)(?::([1-9]\d*))?", token)
+                m = re.fullmatch(r"([1-9]\d*)(?:[-:]([1-9]\d*))?", token)
                 if not m or (m.group(2) and int(m.group(2)) < int(m.group(1))):
                     console_error(
                         f"Invalid --dispatch value '{token}'. Expected a "
-                        "positive integer or 'start:end' range with "
-                        "start <= end (e.g. 1, 3:5)."
+                        "positive integer or 'start:end'/'start-end' "
+                        "range with start <= end (e.g. 1, 3:5, 3-5)."
                     )
 
         # verify correct formatting for application binary

--- a/projects/rocprofiler-compute/tests/test_metric_validation.py
+++ b/projects/rocprofiler-compute/tests/test_metric_validation.py
@@ -77,7 +77,7 @@ VALIDATE_METRICS = {
         ],
         # Ignore warmup dispatch
         # Collect roofline block
-        "profile_options": ["-d", "2-1001", "-b", "4"],
+        "profile_options": ["-d", "2:1001", "-b", "4"],
         "roof": True,
     }
 }


### PR DESCRIPTION
## Motivation

Test case failure on gfx950 runner (see https://github.com/ROCm/rocm-systems/actions/runs/26106696477/job/76772648105) caused by test_metric_validation.py test case.

## Technical Details

Test has arg "-d 2-1001" for dispatch argument, but recent commit 940f519 (https://github.com/ROCm/rocm-systems/commit/940f5190ff09f15d7e6a6030c8919cef505c722a) looks for different input style.

Modified "-d 2-1001" to "-d 2:1001"

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Manual ctest on MI300 system running `ctest --output-on-failure -R test_metric_validation`

## Test Result

Able to repro the initial issue on latest 7.14 branch.
With above fix for dispatch arg style, test case passes.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
