### PR TITLE
ROCM-1028 Enable hipExtHostRegisterCoarseGrained

### DIFF
--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -1397,6 +1397,10 @@ hipError_t ihipHostRegister(void* hostPtr, size_t sizeBytes, unsigned int flags)
       memFlags |= ROCCLR_MEM_IO_MEMORY;
     }
 
+    if (flags & hipExtHostRegisterCoarseGrained) {
+      memFlags &= ~CL_MEM_SVM_ATOMICS;
+    }
+
     amd::Memory* mem =
         new (*hip::host_context) amd::Buffer(*hip::host_context, memFlags, sizeBytes);
 

--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -1398,6 +1398,10 @@ hipError_t ihipHostRegister(void* hostPtr, size_t sizeBytes, unsigned int flags)
       memFlags |= ROCCLR_MEM_IO_MEMORY;
     }
 
+    if (flags & hipExtHostRegisterCoarseGrained) {
+      memFlags &= ~CL_MEM_SVM_ATOMICS;
+    }
+
     amd::Memory* mem =
         new (*hip::host_context) amd::Buffer(*hip::host_context, memFlags, sizeBytes);
 

--- a/projects/hip-tests/catch/config/configs/unit/memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/memory.yaml
@@ -400,6 +400,9 @@ memory:
   Unit_hipHostRegister_DuplicateAndDisjoint:
     <<: *level_2
     tags: [alloc]
+  Unit_hipHostRegister_with_hipExtHostRegisterCoarseGrained:
+    <<: *level_2
+    tags: [alloc]
   Unit_hipHostRegister_Capture:
     <<: *level_2
     tags: [alloc]

--- a/projects/hip-tests/catch/unit/memory/hipHostRegister.cc
+++ b/projects/hip-tests/catch/unit/memory/hipHostRegister.cc
@@ -37,6 +37,21 @@ template <typename T> __global__ void Inc(T* Ad) {
   Ad[i]++;
 }
 
+#if HT_AMD
+__global__ void AtomicFAddKernelKernel(float* data, size_t n) {
+  size_t i = blockDim.x * blockIdx.x + threadIdx.x;
+  if (i < n) {
+#if __has_builtin(__builtin_amdgcn_global_atomic_fadd_f32)
+    __builtin_amdgcn_global_atomic_fadd_f32(data, 1.0f);  // Only work on coarse grained buffer
+#else
+    if (i == 0) {
+      *data = -1.0;
+    }
+#endif
+  }
+}
+#endif
+
 template <typename T>
 void doMemCopy(size_t numElements, int offset, T* A, T* Bh, T* Bd, bool internalRegister) {
   constexpr auto memsetval = 13.0f;
@@ -677,7 +692,7 @@ HIP_TEST_CASE(Unit_hipHostRegister_Flags) {
       FlagType{hipHostRegisterReadOnly, true}, FlagType{hipHostRegisterPortable | hipHostRegisterMapped, true},
       FlagType{hipHostRegisterPortable | hipHostRegisterMapped | hipHostRegisterReadOnly, true},
 #if (HT_AMD == 1) && (HT_LINUX == 1)
-      FlagType{hipHostRegisterIoMemory, true},
+      FlagType{hipHostRegisterIoMemory, true}, FlagType{hipExtHostRegisterCoarseGrained, true},
       FlagType{hipExtHostRegisterUncached, true},
       FlagType{hipHostRegisterPortable | hipHostRegisterMapped | hipExtHostRegisterUncached, true},
 #endif
@@ -698,6 +713,7 @@ HIP_TEST_CASE(Unit_hipHostRegister_Flags) {
   }
   free(hostPtr);
 }
+
 /**
  * Test Description
  * ------------------------
@@ -831,6 +847,48 @@ HIP_TEST_CASE(Unit_hipHostRegister_Capture) {
   if (capture_error == hipSuccess) {
     HIP_CHECK(hipHostUnregister(buffer.get()));
   }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *    - This testcase verifies hipExtHostRegisterCoarseGrained flags of hipHostRegister.
+ *    - In this case L2 cache is enabled on device, atomic is valid on device only,
+ *    - and perf will be better.
+ * Test source
+ * ------------------------
+ *    - catch\unit\memory\hipHostRegister.cc
+ * Test requirements
+ * ------------------------
+ *    - HIP_VERSION >= 5.2
+ */
+HIP_TEST_CASE(Unit_hipHostRegister_with_hipExtHostRegisterCoarseGrained) {
+#if HT_AMD
+  const size_t count = 65536;
+  const size_t threadsPerBlock = 64;
+  size_t sizeBytes = sizeof(float);
+  float* hostPtr = reinterpret_cast<float*>(malloc(sizeBytes));
+  float* devicePtr = nullptr;
+  *hostPtr = 0;
+  HIP_CHECK(hipHostRegister(hostPtr, sizeBytes, hipExtHostRegisterCoarseGrained));
+  HIP_CHECK(hipHostGetDevicePointer(reinterpret_cast<void**>(&devicePtr), hostPtr, 0));
+  AtomicFAddKernelKernel<<<(count + threadsPerBlock - 1) / threadsPerBlock, threadsPerBlock>>>(
+      devicePtr, count);
+  HIP_CHECK(hipDeviceSynchronize());
+  HIP_CHECK(hipHostUnregister(hostPtr));
+  std::cout << "hostPtr=" << hostPtr << ", devicePtr=" << devicePtr << std::endl;
+  if (*hostPtr == static_cast<float>(count)) {
+    std::cout << "__builtin_amdgcn_global_atomic_fadd_f32 works well!" << std::endl;
+    REQUIRE(true);
+  } else if (*hostPtr == -1.0f) {
+    std::cout << "__builtin_amdgcn_global_atomic_fadd_f32 not supported!" << std::endl;
+    REQUIRE(true);
+  } else {
+    std::cout << count << " -> " << *hostPtr << std::endl;
+    REQUIRE(false);
+  }
+  free(hostPtr);
+#endif
 }
 
 /**


### PR DESCRIPTION
For Rocr backend, enable hipExtHostRegisterCoarseGrained in hipHostRegister() so that the host buffer will be locked onto coarse_grain_pool of cpu agent in Rocr.
If coarse_grain_pool is not avaible, the buffer will be locked onto fine_grain_pool of cpu agent, thus
hipExtHostRegisterCoarseGrained will fall back to default flag.

## Motivation

support coarse grain access on pinned host memory

## Technical Details

Remove atomic flag internally when hipExtHostRegisterCoarseGrained is set in hipHostRegister().

## JIRA ID

ROCM-1028

## Test Plan

all pass 

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
