### PR TITLE
[CLR]: Fix hipMallocPitch align pitch when image support is disabled.

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -1529,6 +1529,9 @@ bool Device::populateOCLDeviceConstants() {
     info_.bufferFromImageSupport_ = false;
 
     info_.imageSupport_ = (info_.maxReadWriteImageArgs_ > 0) ? true : false;
+  } else {
+    // hipMallocPitch/hipMalloc3D align pitch by this value regardless of image support
+    info_.imagePitchAlignment_ = 256;
   }
 
   // Enable SVM Capabilities of Hsa device. Ensure

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -1424,6 +1424,9 @@ bool Device::populateOCLDeviceConstants() {
     return false;
   }
 
+  // hipMallocPitch/hipMalloc3D align pitch by this value regardless of image support
+  info_.imagePitchAlignment_ = 256;
+
   assert(HSA_EXTENSION_IMAGES < 8);
   const bool image_is_supported = ((hsa_extensions[0] & (1 << HSA_EXTENSION_IMAGES)) != 0);
   if (image_is_supported) {
@@ -1522,16 +1525,11 @@ bool Device::populateOCLDeviceConstants() {
     }
     info_.imageMaxBufferSize_ = (amd::IS_HIP) ? image_max_dim[0] : (1 << 27);
 
-    info_.imagePitchAlignment_ = 256;
-
     info_.imageBaseAddressAlignment_ = 256;
 
     info_.bufferFromImageSupport_ = false;
 
     info_.imageSupport_ = (info_.maxReadWriteImageArgs_ > 0) ? true : false;
-  } else {
-    // hipMallocPitch/hipMalloc3D align pitch by this value regardless of image support
-    info_.imagePitchAlignment_ = 256;
   }
 
   // Enable SVM Capabilities of Hsa device. Ensure


### PR DESCRIPTION
## Motivation

With image support disabled, hip-tests about pitch memory should pass.

## Technical Details

ihipMallocPitch uses imagePitchAlignment_ as a generic device pitch for all pitched allocations — including non-image hipMallocPitch / hipMalloc3D buffers. If image support is off, every pitched device buffer allocation gets size=0.

## JIRA ID

AIRUNTIME-2176

## Test Plan

Run hip-tests with HIP/ROCr built with -DIMAGE_SUPPORT=OFF.

## Test Result

Before fix, Unit_hipMalloc3D_Basic & Unit_hipMemcpy2D_Positive_Basic failed; After fix, these two tests passed.

## Submission Checklist

- [X ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
