### PR TITLE
[rocprofiler-compute] auto-redact env var secrets in logger outputs

### DIFF
--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -37,6 +37,8 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 ### Resolved issues
 
+* `console_log`, `console_debug`, `console_warning`, `console_error`, and `trace_logger` now auto-redact environment-variable-shaped tokens (`KEY=value` / `'KEY': 'value'`) unless the key is on the allowlist in `utils/env_allowlist.yaml`. Previously, the profiler's debug log dumped the entire process environment, which could leak third-party API keys or other secrets.
+
 * Fixed `inf` display for metrics with zero-denominator counters (e.g., L2-Fabric Write Latency when no write requests are issued). The metric evaluation path now catches `inf` scalar results and returns `"N/A"`, consistent with existing `NaN` handling.
 
 * Kernels with missing counter data after iteration multiplexing imputation are now excluded from metrics calculations. A warning at analysis time lists the affected kernels. Their execution times remain visible in Top Stats.

--- a/projects/rocprofiler-compute/CMakeLists.txt
+++ b/projects/rocprofiler-compute/CMakeLists.txt
@@ -513,6 +513,14 @@ add_test(
         ${WORKING_DIR_OPTION}
 )
 
+add_test(
+    NAME test_logger
+    COMMAND
+        ${PYTHON_TEST_COMMAND} -m pytest ${STANDALONEBINARY_TEST_OPTION}
+        --junitxml=tests/test_logger.xml ${COV_OPTION} tests/test_logger.py
+        ${WORKING_DIR_OPTION}
+)
+
 # Memory chart CLI renderers (gfx9 plotille + gfx11 Rich) — no GPU required
 add_test(
     NAME test_mem_chart
@@ -710,6 +718,7 @@ if(${ENABLE_COVERAGE})
         test_num_xcds_spec_class
         test_num_xcds_cli_output
         test_utils
+        test_logger
         test_mem_chart
         test_roofline_calc_ai_analyze
         test_data_imputation

--- a/projects/rocprofiler-compute/src/utils/env_allowlist.yaml
+++ b/projects/rocprofiler-compute/src/utils/env_allowlist.yaml
@@ -1,0 +1,16 @@
+env_allowlist:
+  exact:
+    - LD_PRELOAD
+    - LD_LIBRARY_PATH
+    - ROCM_PATH
+    - ROCM_VER
+    - ROCPROF
+  prefixes:
+    - HSA_
+    - HIP_
+    - ROCR_
+    - ROCM_
+    - ROCPROFILER_
+    - ROCPROF_
+    - ROCPROFCOMPUTE_
+    - AMDGPU_

--- a/projects/rocprofiler-compute/src/utils/logger.py
+++ b/projects/rocprofiler-compute/src/utils/logger.py
@@ -3,9 +3,12 @@
 
 import logging
 import os
+import re
 import sys
 from pathlib import Path
-from typing import Any, Callable, Optional, TypeVar
+from typing import Any, Callable, Optional, TextIO, TypeVar
+
+import config
 
 R = TypeVar("R")
 
@@ -25,6 +28,21 @@ COLORS = {
 
 # Constants
 TRACE_LEVEL = logging.DEBUG - 5
+ENV_ALLOWLIST_PATH = config.rocprof_compute_home / "utils" / "env_allowlist.yaml"
+ENV_PAIR_RE = re.compile(
+    r"""
+    (?P<qkey>['"]?)
+    (?P<key>[A-Z][A-Z0-9_]{1,})
+    (?P=qkey)
+    (?P<sep>\s*[:=]\s*)
+    (?:
+        (?P<qval>['"])(?P<val>.*?)(?P=qval)
+      | (?P<uval>[^\s,'"{}\[\]]+)
+    )
+    """,
+    re.VERBOSE,
+)
+REDACTED_VALUE = "<redacted>"
 
 LOG_LEVEL_MAPPING = {
     "DEBUG": logging.DEBUG,
@@ -36,6 +54,74 @@ LOG_LEVEL_MAPPING = {
     "ERROR": logging.ERROR,
     "error": logging.ERROR,
 }
+
+_env_allowlist_cache: Optional[tuple[frozenset[str], tuple[str, ...]]] = None
+
+
+def _safe_load_yaml(allowlist_file: TextIO) -> dict[str, Any]:
+    """Load YAML with vendored PyYAML when available."""
+    try:
+        from vendored import yaml
+    except ImportError:
+        import yaml
+
+    return yaml.safe_load(allowlist_file)
+
+
+def _read_env_allowlist() -> tuple[frozenset[str], tuple[str, ...]]:
+    """Read the logger env var allowlist from YAML."""
+    try:
+        with open(ENV_ALLOWLIST_PATH, encoding="utf-8") as allowlist_file:
+            allowlist_yaml = _safe_load_yaml(allowlist_file) or {}
+    except (ImportError, OSError):
+        allowlist_yaml = {}
+
+    env_allowlist = allowlist_yaml.get("env_allowlist", {}) or {}
+    exact_names = frozenset(env_allowlist.get("exact", []) or [])
+    prefixes = tuple(env_allowlist.get("prefixes", []) or [])
+    return (exact_names, prefixes)
+
+
+def _load_env_allowlist() -> tuple[frozenset[str], tuple[str, ...]]:
+    """Load and cache the logger env var allowlist."""
+    global _env_allowlist_cache
+    if _env_allowlist_cache is None:
+        _env_allowlist_cache = _read_env_allowlist()
+    return _env_allowlist_cache
+
+
+def _is_env_var_allowlisted(key: str) -> bool:
+    """Return True when an env var name should be logged verbatim."""
+    exact_names, prefixes = _load_env_allowlist()
+    return key in exact_names or any(key.startswith(prefix) for prefix in prefixes)
+
+
+def _redact_env_var_match(match: re.Match[str]) -> str:
+    """Redact one env-var regex match when its key is not allowlisted."""
+    if _is_env_var_allowlisted(match.group("key")):
+        return match.group(0)
+
+    value_quote = match.group("qval")
+    key_quote = match.group("qkey")
+    key_and_separator = (
+        f"{key_quote}{match.group('key')}{key_quote}{match.group('sep')}"
+    )
+    if value_quote:
+        return f"{key_and_separator}{value_quote}{REDACTED_VALUE}{value_quote}"
+    return f"{key_and_separator}{REDACTED_VALUE}"
+
+
+def _redact_env_vars(message: str) -> str:
+    """Redact env-var-shaped tokens whose key is not on the allowlist."""
+    return ENV_PAIR_RE.sub(_redact_env_var_match, message)
+
+
+def _format_log_message(message: str, args: tuple[Any, ...]) -> str:
+    """Apply logging-style interpolation before redaction."""
+    if not args:
+        return message
+    record = logging.LogRecord("", 0, "", 0, message, args, None)
+    return record.getMessage()
 
 
 def demarcate(function: Callable[..., R]) -> Callable[..., R]:
@@ -50,9 +136,9 @@ def demarcate(function: Callable[..., R]) -> Callable[..., R]:
 
 def console_error(*argv: Any, exit: bool = True) -> None:
     if len(argv) > 1:
-        logging.error(f"[{argv[0]}] {argv[1]}")
+        logging.error(_redact_env_vars(f"[{argv[0]}] {argv[1]}"))
     elif len(argv) == 1:
-        logging.error(f"{argv[0]}")
+        logging.error(_redact_env_vars(f"{argv[0]}"))
     else:
         logging.error("Empty error message")
     if exit:
@@ -65,33 +151,37 @@ def console_log(*argv: Any, indent_level: int = 0) -> None:
         indent = " " * (3 * indent_level) + "|-> "  # spaces per indent level
 
     if len(argv) > 1:
-        logging.info(indent + f"[{argv[0]}] {argv[1]}")
+        logging.info(_redact_env_vars(indent + f"[{argv[0]}] {argv[1]}"))
     elif len(argv) == 1:
-        logging.info(indent + f"{argv[0]}")
+        logging.info(_redact_env_vars(indent + f"{argv[0]}"))
     else:
         logging.info(indent + "Empty log message")
 
 
 def console_debug(*argv: Any) -> None:
     if len(argv) > 1:
-        logging.debug(f"[{argv[0]}] {argv[1]}")
+        logging.debug(_redact_env_vars(f"[{argv[0]}] {argv[1]}"))
     elif len(argv) == 1:
-        logging.debug(f"{argv[0]}")
+        logging.debug(_redact_env_vars(f"{argv[0]}"))
     else:
         logging.debug("Empty debug message")
 
 
 def console_warning(*argv: Any) -> None:
     if len(argv) > 1:
-        logging.warning(f"[{argv[0]}] {argv[1]}")
+        logging.warning(_redact_env_vars(f"[{argv[0]}] {argv[1]}"))
     elif len(argv) == 1:
-        logging.warning(f"{argv[0]}")
+        logging.warning(_redact_env_vars(f"{argv[0]}"))
     else:
         logging.warning("Empty warning message")
 
 
 def trace_logger(message: str, *args: Any, **kwargs: Any) -> None:
-    logging.log(TRACE_LEVEL, message, *args, **kwargs)
+    logging.log(
+        TRACE_LEVEL,
+        _redact_env_vars(_format_log_message(message, args)),
+        **kwargs,
+    )
 
 
 # Define the formatter

--- a/projects/rocprofiler-compute/tests/test_logger.py
+++ b/projects/rocprofiler-compute/tests/test_logger.py
@@ -1,0 +1,99 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
+"""Tests for environment variable redaction in logger wrappers."""
+
+import logging
+from typing import Callable
+
+import pytest
+
+from utils.logger import (
+    REDACTED_VALUE,
+    TRACE_LEVEL,
+    _redact_env_vars,
+    console_debug,
+    console_error,
+    console_log,
+    console_warning,
+    trace_logger,
+)
+
+
+def test_redact_env_vars_keeps_allowlisted():
+    message = (
+        "HSA_TOOLS_LIB='libfoo.so' "
+        "HIP_VISIBLE_DEVICES=0 "
+        "ROCPROFILER_METRICS_PATH='/tmp/x'"
+    )
+
+    assert _redact_env_vars(message) == message
+
+
+def test_redact_env_vars_redacts_secrets():
+    message = (
+        "{'ANTHROPIC_API_KEY': 'sk-abc', "
+        "'PATH': '/usr/bin', "
+        "'HSA_TOOLS_LIB': 'libfoo.so'}"
+    )
+
+    redacted_message = _redact_env_vars(message)
+
+    assert REDACTED_VALUE in redacted_message
+    assert "sk-abc" not in redacted_message
+    assert "/usr/bin" not in redacted_message
+    assert "'ANTHROPIC_API_KEY': '<redacted>'" in redacted_message
+    assert "'PATH': '<redacted>'" in redacted_message
+    assert "'HSA_TOOLS_LIB': 'libfoo.so'" in redacted_message
+
+
+def test_redact_handles_unquoted_values():
+    message = "setting HOME=/root and HSA_TOOLS_LIB=libfoo.so"
+
+    redacted_message = _redact_env_vars(message)
+
+    assert "HOME=<redacted>" in redacted_message
+    assert "/root" not in redacted_message
+    assert "HSA_TOOLS_LIB=libfoo.so" in redacted_message
+
+
+@pytest.mark.parametrize(
+    "logger_wrapper,level",
+    [
+        (console_log, logging.INFO),
+        (console_debug, logging.DEBUG),
+        (console_warning, logging.WARNING),
+        (lambda message: console_error(message, exit=False), logging.ERROR),
+    ],
+)
+def test_each_wrapper_redacts_via_caplog(
+    caplog,
+    logger_wrapper: Callable[[str], None],
+    level: int,
+):
+    caplog.set_level(level)
+    message = (
+        "{'SECRET_TOKEN': 'abc', 'HSA_TOOLS_LIB': 'libfoo.so', 'PATH': '/usr/bin'}"
+    )
+
+    logger_wrapper(message)
+
+    assert REDACTED_VALUE in caplog.text
+    assert "abc" not in caplog.text
+    assert "/usr/bin" not in caplog.text
+    assert "libfoo.so" in caplog.text
+
+
+def test_trace_logger_redacts_and_interpolates(caplog):
+    caplog.set_level(TRACE_LEVEL)
+
+    trace_logger(
+        "HSA_TOOLS_LIB=%s SECRET_TOKEN=%s",
+        "libfoo.so",
+        "abc",
+    )
+
+    assert REDACTED_VALUE in caplog.text
+    assert "SECRET_TOKEN=<redacted>" in caplog.text
+    assert "abc" not in caplog.text
+    assert "HSA_TOOLS_LIB=libfoo.so" in caplog.text


### PR DESCRIPTION
## Motivation

The profiler's console and trace logging helpers can receive full environment dumps or interpolated environment-variable tokens while users collect debug logs for triage. Before this change, tokens shaped like KEY=value or 'KEY': 'value' were emitted verbatim, which meant unrelated third-party secrets such as API keys could be written into logs attached to issues or shared with maintainers. This PR closes that disclosure path while preserving ROCm and profiler environment values that are useful for debugging. Redacting by default gives users safer debug output without removing the allowlisted runtime context needed to diagnose profiler behavior.

## Technical Details

This update adds a small redaction layer to the existing logger wrappers and keeps the allowlist data outside the Python implementation so ROCm-specific environment names remain easy to audit and extend. The redactor recognizes common KEY=value and mapping-style environment token forms, preserves explicitly allowlisted ROCm/HIP/HSA variables, and replaces all other matched values with <redacted> before the message reaches the Python logger.

- Add env-var token matching and `_redact_env_vars` in `src/utils/logger.py`, with a cached YAML-backed allowlist loaded from `src/utils/env_allowlist.yaml`.
- Apply redaction to `console_log`, `console_debug`, `console_warning`, `console_error`, and `trace_logger`, including logging-style `%s` interpolation before redaction in `trace_logger`.
- Add `tests/test_logger.py` coverage for allowlisted values, quoted and unquoted secret values, all console wrapper entry points, and trace logging interpolation behavior.
- Register the new `test_logger` ctest in `CMakeLists.txt` and include it in the coverage test list.
- Record the behavior change in `CHANGELOG.md` under the ROCm Compute Profiler 3.7.0 resolved issues section.

## JIRA ID

N/A

## Test Plan

Validation focuses on the new security-sensitive logger behavior and on ensuring the new pytest module is wired into the existing test entry points. The local pytest run exercises the exact redaction surfaces changed by this PR, while CI will provide broader confirmation through the repository test and lint matrix.

- [x] Run `pytest tests/test_logger.py` locally to validate allowlist preservation, dict-style secret redaction, unquoted value redaction, all four console wrappers, and `trace_logger` interpolation followed by redaction.
- [x] Confirm the new test module is registered as the `test_logger` ctest and added to the coverage suite in `CMakeLists.txt`.
- [ ] Let GitHub CI validate the broader ROCm Systems matrix after the draft PR is opened.

## Test Result

All tests in tests/test_logger.py passed locally via pytest, covering allowlist preservation, dict-style secret redaction, unquoted-value redaction, all four console wrappers, and trace_logger %s interpolation followed by redaction. CI on ROCm/rocm-systems will provide independent confirmation across platforms.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.