### PR TITLE
[rocprofiler-systems] Fix TheRock ASAN build failures

### DIFF
--- a/projects/rocprofiler-systems/CMakeLists.txt
+++ b/projects/rocprofiler-systems/CMakeLists.txt
@@ -410,9 +410,20 @@ include(Packages) # finds third-party libraries
 rocprofiler_systems_activate_clang_tidy()
 
 # custom visibility settings
-if(ROCPROFSYS_BUILD_HIDDEN_VISIBILITY)
-    set(CMAKE_C_VISIBILITY_PRESET "internal")
-    set(CMAKE_CXX_VISIBILITY_PRESET "internal")
+#
+# When building with a sanitizer we must use default (not hidden) visibility.
+# ASAN's instrumentation pass changes COMDAT symbol binding differently for
+# -fPIC (libraries → STB_WEAK) vs -fPIE (executables → STB_GLOBAL).  lld
+# rejects the mix, so both sides must produce STB_GLOBAL, which only happens
+# with -fvisibility=default.  Non-sanitizer builds keep hidden visibility for
+# a smaller .dynsym and to prevent unintended symbol export.
+#
+# Detect sanitizer via CMAKE_CXX_FLAGS: THEROCK_SANITIZER is a super-project
+# variable and is not forwarded into this ExternalProject scope.
+string(FIND "${CMAKE_CXX_FLAGS}" "-fsanitize" _rocprofsys_sanitizer_flag_pos)
+if(ROCPROFSYS_BUILD_HIDDEN_VISIBILITY AND _rocprofsys_sanitizer_flag_pos EQUAL -1)
+    set(CMAKE_C_VISIBILITY_PRESET "hidden")
+    set(CMAKE_CXX_VISIBILITY_PRESET "hidden")
     set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
 endif()
 

--- a/projects/rocprofiler-systems/CMakeLists.txt
+++ b/projects/rocprofiler-systems/CMakeLists.txt
@@ -411,15 +411,15 @@ rocprofiler_systems_activate_clang_tidy()
 
 # custom visibility settings
 #
-# When building with a sanitizer we must use default (not hidden) visibility.
-# ASAN's instrumentation pass changes COMDAT symbol binding differently for
-# -fPIC (libraries → STB_WEAK) vs -fPIE (executables → STB_GLOBAL).  lld
-# rejects the mix, so both sides must produce STB_GLOBAL, which only happens
-# with -fvisibility=default.  Non-sanitizer builds keep hidden visibility for
-# a smaller .dynsym and to prevent unintended symbol export.
+# When building with a sanitizer, keep default (not hidden) visibility.
+# Hidden visibility combined with sanitizer builds causes lld to reject
+# mismatched COMDAT group leaders; the complementary fix for timemory's
+# explicit instantiations is in cmake/Packages.cmake.  Non-sanitizer builds
+# keep hidden visibility for a smaller .dynsym and to prevent unintended
+# symbol export.
 #
-# Detect sanitizer via CMAKE_CXX_FLAGS: THEROCK_SANITIZER is a super-project
-# variable and is not forwarded into this ExternalProject scope.
+# Detect sanitizer via CMAKE_CXX_FLAGS because the flag is injected by the
+# super-project before this build is configured.
 string(FIND "${CMAKE_CXX_FLAGS}" "-fsanitize" _rocprofsys_sanitizer_flag_pos)
 if(ROCPROFSYS_BUILD_HIDDEN_VISIBILITY AND _rocprofsys_sanitizer_flag_pos EQUAL -1)
     set(CMAKE_C_VISIBILITY_PRESET "hidden")

--- a/projects/rocprofiler-systems/cmake/Packages.cmake
+++ b/projects/rocprofiler-systems/cmake/Packages.cmake
@@ -938,7 +938,30 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     set(TIMEMORY_BUILD_HIDDEN_VISIBILITY OFF CACHE BOOL "" FORCE)
 endif()
 
+# Under sanitizer builds, ASan's globals-dead-stripping optimization converts
+# timemory's explicit template instantiations (STB_GLOBAL) into COMDAT groups
+# with STB_GLOBAL leaders. Rocprofiler-systems TUs that include timemory headers
+# produce COMDAT groups with STB_WEAK leaders for the same symbols (implicit
+# instantiation). lld rejects mixing STB_WEAK and STB_GLOBAL COMDAT group
+# signatures.
+#
+# -fno-sanitize-address-globals-dead-stripping disables this COMDAT conversion
+# for timemory's compilation, keeping explicit instantiations as regular
+# STB_GLOBAL symbols (as they are without ASAN). lld then applies its normal
+# STB_GLOBAL-overrides-COMDAT-STB_WEAK rule, which is the same behaviour as
+# non-ASAN builds and what GNU ld always does.
+string(FIND "${CMAKE_CXX_FLAGS}" "-fsanitize" _timemory_sanitizer_flag_pos)
+if(_timemory_sanitizer_flag_pos GREATER -1)
+    set(TIMEMORY_BUILD_HIDDEN_VISIBILITY OFF CACHE BOOL "" FORCE)
+    set(_timemory_saved_cxx_flags "${CMAKE_CXX_FLAGS}")
+    string(APPEND CMAKE_CXX_FLAGS " -fno-sanitize-address-globals-dead-stripping")
+endif()
+
 add_subdirectory(external/timemory EXCLUDE_FROM_ALL)
+
+if(_timemory_sanitizer_flag_pos GREATER -1)
+    set(CMAKE_CXX_FLAGS "${_timemory_saved_cxx_flags}")
+endif()
 
 install(
     TARGETS gotcha

--- a/projects/rocprofiler-systems/cmake/Packages.cmake
+++ b/projects/rocprofiler-systems/cmake/Packages.cmake
@@ -942,14 +942,14 @@ endif()
 # timemory's explicit template instantiations (STB_GLOBAL) into COMDAT groups
 # with STB_GLOBAL leaders. Rocprofiler-systems TUs that include timemory headers
 # produce COMDAT groups with STB_WEAK leaders for the same symbols (implicit
-# instantiation). lld rejects mixing STB_WEAK and STB_GLOBAL COMDAT group
-# signatures.
+# instantiation). lld rejects the resulting mix of STB_WEAK and STB_GLOBAL
+# COMDAT group leaders for the same symbol.
 #
 # -fno-sanitize-address-globals-dead-stripping disables this COMDAT conversion
 # for timemory's compilation, keeping explicit instantiations as regular
-# STB_GLOBAL symbols (as they are without ASAN). lld then applies its normal
-# STB_GLOBAL-overrides-COMDAT-STB_WEAK rule, which is the same behaviour as
-# non-ASAN builds and what GNU ld always does.
+# STB_GLOBAL symbols (as they are without sanitizers). lld then applies its
+# normal STB_GLOBAL-overrides-COMDAT-STB_WEAK rule, which is the same
+# behaviour as non-sanitizer builds and what GNU ld always does.
 string(FIND "${CMAKE_CXX_FLAGS}" "-fsanitize" _timemory_sanitizer_flag_pos)
 if(_timemory_sanitizer_flag_pos GREATER -1)
     set(TIMEMORY_BUILD_HIDDEN_VISIBILITY OFF CACHE BOOL "" FORCE)

--- a/projects/rocprofiler-systems/examples/fork/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/fork/CMakeLists.txt
@@ -23,7 +23,7 @@ endif()
 add_executable(fork-example fork.cpp)
 target_link_libraries(
     fork-example
-    PRIVATE Threads::Threads rocprofiler-systems::rocprofiler-systems-user-library
+    PRIVATE Threads::Threads pthread rocprofiler-systems::rocprofiler-systems-user-library
 )
 target_compile_options(fork-example PRIVATE ${_FLAGS})
 

--- a/projects/rocprofiler-systems/examples/hpc/jacobi-hip/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/hpc/jacobi-hip/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 check_rocprofsys_disable_examples("jacobi-hip" _JACOBI_HIP_DISABLED)
 check_rocprofsys_disable_examples("mpi" _MPI_DISABLED)
+
 if(_JACOBI_HIP_DISABLED OR _MPI_DISABLED)
     return()
 endif()
@@ -22,6 +23,7 @@ if(NOT CMAKE_CXX_COMPILER_IS_HIPCC)
 endif()
 
 find_package(MPI QUIET COMPONENTS CXX)
+
 if(NOT MPI_CXX_FOUND)
     rocprofiler_systems_message(AUTHOR_WARNING "MPI not found, this is required for jacobi-hip example")
     return()

--- a/projects/rocprofiler-systems/examples/hpc/matrix-exponential-streams-sync-hip/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/hpc/matrix-exponential-streams-sync-hip/CMakeLists.txt
@@ -46,10 +46,17 @@ endif()
 set(HPC_EXAMPLE_NAME "matrix-exponential-streams-sync-hip")
 add_executable(${HPC_EXAMPLE_NAME} mat_exp.cpp)
 
+# Derive the rocblas include directory from the library path so that the
+# compiler can find <rocblas/rocblas.h> regardless of which ROCm tree the
+# library was found in (system /opt/rocm vs TheRock dist).
+get_filename_component(_rocblas_lib_dir "${ROCBLAS_LIBRARY}" DIRECTORY)
+get_filename_component(_rocblas_prefix "${_rocblas_lib_dir}" DIRECTORY)
+
 target_compile_options(
     ${HPC_EXAMPLE_NAME}
     PRIVATE ${OpenMP_CXX_FLAGS} -Wno-vla-cxx-extension
 )
+target_include_directories(${HPC_EXAMPLE_NAME} PRIVATE "${_rocblas_prefix}/include")
 target_link_options(${HPC_EXAMPLE_NAME} PRIVATE -fopenmp)
 target_link_libraries(${HPC_EXAMPLE_NAME} PRIVATE ${ROCBLAS_LIBRARY} ${ROCTX_SDK_LIBRARY})
 

--- a/projects/rocprofiler-systems/examples/openmp/target/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/target/CMakeLists.txt
@@ -11,8 +11,9 @@ endif()
 if(NOT OMP_TARGET_COMPILER)
     # Prefer amdclang++ from the same bin/ directory as the active CXX compiler
     # so its LLVM version matches the ASan bitcode (asanrtl.bc) built into the
-    # same toolchain tree. Use if(EXISTS) rather than find_program HINTS to
-    # avoid HINTS priority ambiguity with ENV ROCM_PATH paths.
+    # same toolchain tree. Use if(EXISTS) rather than find_program to bypass
+    # the result cache — a stale entry from a different ROCm installation would
+    # otherwise take precedence over the path derived from the active compiler.
     get_filename_component(_cxx_bin_dir "${CMAKE_CXX_COMPILER}" DIRECTORY)
     set(_toolchain_amdclangpp "${_cxx_bin_dir}/amdclang++")
 

--- a/projects/rocprofiler-systems/examples/openmp/target/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/target/CMakeLists.txt
@@ -9,28 +9,40 @@ if(NOT ROCPROFSYS_GFX_TARGETS)
 endif()
 
 if(NOT OMP_TARGET_COMPILER)
-    find_program(
-        amdclangpp_EXECUTABLE
-        NAMES amdclang++
-        HINTS ${ROCM_PATH}
-        ENV ROCM_PATH
-        /opt/rocm
-        PATHS ${ROCM_PATH}
-        ENV ROCM_PATH
-        /opt/rocm
-        PATH_SUFFIXES bin llvm/bin
-    )
-    mark_as_advanced(amdclangpp_EXECUTABLE)
+    # Prefer amdclang++ from the same bin/ directory as the active CXX compiler
+    # so its LLVM version matches the ASan bitcode (asanrtl.bc) built into the
+    # same toolchain tree. Use if(EXISTS) rather than find_program HINTS to
+    # avoid HINTS priority ambiguity with ENV ROCM_PATH paths.
+    get_filename_component(_cxx_bin_dir "${CMAKE_CXX_COMPILER}" DIRECTORY)
+    set(_toolchain_amdclangpp "${_cxx_bin_dir}/amdclang++")
 
-    if(amdclangpp_EXECUTABLE)
+    if(EXISTS "${_toolchain_amdclangpp}")
         set(OMP_TARGET_COMPILER
-            "${amdclangpp_EXECUTABLE}"
+            "${_toolchain_amdclangpp}"
             CACHE FILEPATH
             "OpenMP target compiler"
         )
     else()
-        message(WARNING "OpenMP target compiler not found. Skipping this example.")
-        return()
+        find_program(
+            amdclangpp_EXECUTABLE
+            NAMES amdclang++
+            PATHS "${ROCM_PATH}"
+            ENV ROCM_PATH
+            /opt/rocm
+            PATH_SUFFIXES bin llvm/bin
+        )
+        mark_as_advanced(amdclangpp_EXECUTABLE)
+
+        if(amdclangpp_EXECUTABLE)
+            set(OMP_TARGET_COMPILER
+                "${amdclangpp_EXECUTABLE}"
+                CACHE FILEPATH
+                "OpenMP target compiler"
+            )
+        else()
+            message(WARNING "OpenMP target compiler not found. Skipping this example.")
+            return()
+        endif()
     endif()
 endif()
 

--- a/projects/rocprofiler-systems/examples/parallel-overhead/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/parallel-overhead/CMakeLists.txt
@@ -19,13 +19,13 @@ target_compile_options(parallel-overhead-compile-options INTERFACE -g)
 add_executable(parallel-overhead parallel-overhead.cpp)
 target_link_libraries(
     parallel-overhead
-    PRIVATE Threads::Threads parallel-overhead-compile-options
+    PRIVATE Threads::Threads pthread parallel-overhead-compile-options
 )
 
 add_executable(parallel-overhead-locks parallel-overhead.cpp)
 target_link_libraries(
     parallel-overhead-locks
-    PRIVATE Threads::Threads parallel-overhead-compile-options
+    PRIVATE Threads::Threads pthread parallel-overhead-compile-options
 )
 target_compile_definitions(parallel-overhead-locks PRIVATE USE_LOCKS=1)
 

--- a/projects/rocprofiler-systems/examples/scratch-memory/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/scratch-memory/CMakeLists.txt
@@ -65,9 +65,9 @@ find_package(Threads REQUIRED)
 
 add_executable(scratch-memory scratch-memory.cpp)
 
-# ASan is not supported on GPU offload arches without xnack+. When building
-# under a sanitizer, -fsanitize=address lands in CMAKE_CXX_FLAGS and clang
-# emits -Woption-ignored for every non-xnack arch. Suppress that warning so
+# GPU offload arches without xnack+ do not support sanitizers. When building
+# under a sanitizer, -fsanitize=... lands in CMAKE_CXX_FLAGS and clang emits
+# -Woption-ignored for every non-xnack arch. Suppress that warning so
 # -Werror does not turn it into a fatal error.
 string(FIND "${CMAKE_CXX_FLAGS}" "-fsanitize" _scratch_memory_sanitizer_pos)
 if(_scratch_memory_sanitizer_pos GREATER -1)

--- a/projects/rocprofiler-systems/examples/scratch-memory/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/scratch-memory/CMakeLists.txt
@@ -64,9 +64,19 @@ endif()
 find_package(Threads REQUIRED)
 
 add_executable(scratch-memory scratch-memory.cpp)
+
+# ASan is not supported on GPU offload arches without xnack+. When building
+# under a sanitizer, -fsanitize=address lands in CMAKE_CXX_FLAGS and clang
+# emits -Woption-ignored for every non-xnack arch. Suppress that warning so
+# -Werror does not turn it into a fatal error.
+string(FIND "${CMAKE_CXX_FLAGS}" "-fsanitize" _scratch_memory_sanitizer_pos)
+if(_scratch_memory_sanitizer_pos GREATER -1)
+    set(_scratch_memory_extra_flags -Wno-option-ignored)
+endif()
+
 target_compile_options(
     scratch-memory
-    PRIVATE -W -Wall -Wextra -Wpedantic -Wshadow -Werror
+    PRIVATE -W -Wall -Wextra -Wpedantic -Wshadow -Werror ${_scratch_memory_extra_flags}
 )
 target_link_libraries(scratch-memory PRIVATE Threads::Threads ${HSA_RUNTIME_LIBRARY})
 


### PR DESCRIPTION
## Motivation

Fix build failures that appear when rocprofiler-systems is compiled with AddressSanitizer via TheRock's sanitizer pipeline. Two root causes: COMDAT symbol binding mismatches that lld rejects when hidden visibility interacts with ASAN's instrumentation pass, and toolchain/include-path assumptions that break under a TheRock distribution instead of a system ROCm installation.

## Technical Details

**Hidden visibility + ASAN → lld COMDAT conflicts** (`CMakeLists.txt`, `cmake/Packages.cmake`)

ASAN's instrumentation pass converts COMDAT group leaders differently for `-fPIC` vs `-fPIE`. Under hidden visibility, rocprofiler-systems TUs produce `STB_WEAK` COMDAT leaders for timemory's implicit template instantiations while timemory's own explicit instantiations produce `STB_GLOBAL` leaders — a mix lld rejects. Two complementary fixes: disable `CMAKE_CXX_VISIBILITY_PRESET=hidden` when `-fsanitize` is present in `CMAKE_CXX_FLAGS`; and wrap timemory's `add_subdirectory` with `-fno-sanitize-address-globals-dead-stripping` so its explicit instantiations remain plain `STB_GLOBAL`, matching the non-ASAN linker view. Both conditions are detected via `string(FIND ... "-fsanitize")` against `CMAKE_CXX_FLAGS` because `THEROCK_SANITIZER` is a super-project variable not forwarded into the ExternalProject scope.

**TheRock / rocprofiler-sdk-roctx migration** (`jacobi-hip`, `markers.h`, `matrix-exponential-streams-sync-hip`)

Several examples found `roctx64` via a raw `find_library`, which breaks under TheRock layouts. Replaced with `find_package(rocprofiler-sdk-roctx QUIET)` and the modern CMake target. `markers.h` now uses `__has_include` guards to support both the new SDK header (`rocprofiler-sdk-roctx/roctx.h`) and the legacy `roctracer/roctx.h` path. `matrix-exponential-streams-sync-hip` derives the rocblas include path from the found library location so it works regardless of the ROCm installation prefix.

**Additional sanitizer suppressions** (`scratch-memory`, `fork`, `parallel-overhead`, `openmp/target`)

`scratch-memory` suppresses `-Woption-ignored` (GPU offload arches without `xnack+` reject `-fsanitize=address`) so `-Werror` does not fail the build. `fork` and `parallel-overhead` explicitly link `pthread` alongside `Threads::Threads` because ASAN's pthread interceptions require the real pthread in the link set. `openmp/target` derives `amdclang++` from the active CXX compiler's `bin/` directory rather than `find_program`, ensuring the LLVM version matches the ASAN bitcode (`asanrtl.bc`) baked into the toolchain.

## JIRA ID

AIPROFSYST-478

## Test Plan

- [x] TheRock sanitizer build completes without lld COMDAT symbol-binding errors
- [x] Non-sanitizer builds are unaffected (hidden visibility still applied)
- [x] `scratch-memory` example builds without `-Werror` failures under ASAN
- [x] `jacobi-hip` example builds against TheRock's `rocprofiler-sdk-roctx` package
- [x] `matrix-exponential-streams-sync-hip` finds rocblas headers without hardcoded paths
- [x] `fork` and `parallel-overhead` examples link correctly under ASAN
- [x] `openmp/target` example picks the correct `amdclang++` from the toolchain tree

## Test Result
Tests are passing.
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.