### PR TITLE
Add hipLaunchAttributeExtDynDataPrefetch to rocprofiler-sdk enum

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hip/details/format.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hip/details/format.hpp
@@ -563,6 +563,7 @@ struct formatter<hipLaunchAttributeID> : rocprofiler::hip::details::base_formatt
             ROCP_SDK_HIP_FORMAT_CASE_STMT(hipLaunchAttribute, Ignore);
             ROCP_SDK_HIP_FORMAT_CASE_STMT(hipLaunchAttribute, ClusterDimension);
             ROCP_SDK_HIP_FORMAT_CASE_STMT(hipLaunchAttribute, ClusterSchedulingPolicyPreference);
+            ROCP_SDK_HIP_FORMAT_CASE_STMT(hipLaunchAttribute, ExtDynDataPrefetch);
 #    endif
             ROCP_SDK_HIP_FORMAT_DFLT_CASE(hipLaunchAttributeID);
         }


### PR DESCRIPTION
## Motivation
We currently have an issue with rocprofiler-sdk build in develop: see https://github.com/ROCm/rocm-systems/actions/runs/26147013601/job/76904829305?pr=5984 and https://github.com/ROCm/rocm-systems/actions/runs/26139986894/job/76883321039?pr=6289. This was caused by a change in https://github.com/ROCm/rocm-systems/commit/7d22db251ae642dcd14edab52923e3524b074c28, which added the enum member without including it in rocprofiler-sdk format.hpp
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Adds the corresponding hipLaunch option to format.hpp.
<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
NA
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
Compile and test on rocprofiler-sdk should pass
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Waiting for PSDB
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
