### PR TITLE
refactor(rocprof-sys-causal): centralize runtime state

### DIFF
--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-causal/impl.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-causal/impl.cpp
@@ -7,6 +7,7 @@
 #include "common/env_vars.hpp"
 #include "common/environment.hpp"
 #include "common/path.hpp"
+#include "core/argparse.hpp"
 #include "core/mproc.hpp"
 #include "core/utility.hpp"
 
@@ -49,11 +50,24 @@ using ::tim::log::stream;
 
 namespace
 {
-int  verbose       = 0;
-auto updated_envs  = std::unordered_set<std::string_view>{};
-auto original_envs = std::unordered_set<std::string>{};
-auto child_pids    = std::unordered_set<pid_t>{};
-auto launcher      = std::string{};
+struct causal_runtime_context
+{
+    int                                verbose_level = 0;
+    std::string                        launcher      = {};
+    rocprofsys::argparse::env_snapshot env           = {};
+};
+
+causal_runtime_context&
+runtime_context()
+{
+    // Temporary aggregation point while causal's free-function API is untangled.
+    // Signal-handler globals stay separate because POSIX callbacks need global
+    // reachability.
+    static auto ctx = causal_runtime_context{};
+    return ctx;
+}
+
+auto child_pids = std::unordered_set<pid_t>{};
 
 inline signal_handler&
 get_signal_handler(int _sig)
@@ -94,8 +108,9 @@ int
 get_verbose()
 {
     const auto* _log_level = std::getenv(env::LOG_LEVEL.data());
-    if(_log_level != nullptr) verbose = env::log_level_to_verbose(_log_level);
-    return verbose;
+    auto&       ctx        = runtime_context();
+    if(_log_level != nullptr) ctx.verbose_level = env::log_level_to_verbose(_log_level);
+    return ctx.verbose_level;
 }
 
 void
@@ -129,10 +144,10 @@ diagnose_status(pid_t _pid, int _status)
     return ::rocprofsys::mproc::diagnose_status(_pid, _status, get_verbose());
 }
 
-const std::unordered_set<std::string_view>&
+const std::unordered_set<std::string>&
 get_updated_envs()
 {
-    return updated_envs;
+    return runtime_context().env.updated;
 }
 
 std::vector<std::string>
@@ -141,9 +156,10 @@ get_initial_environment()
     auto _env = std::vector<std::string>{};
     if(environ != nullptr)
     {
+        auto& ctx = runtime_context();
         for(int idx = 0; environ[idx] != nullptr; ++idx)
         {
-            original_envs.emplace(environ[idx]);
+            ctx.env.initial.emplace(environ[idx]);
             _env.emplace_back(environ[idx]);
         }
     }
@@ -170,18 +186,20 @@ get_initial_environment()
 }
 
 void
-prepare_command_for_run(char* _exe, std::vector<char*>& _argv)
+prepare_command_for_run(const char* _exe, std::vector<std::string>& _argv)
 {
-    if(!launcher.empty())
+    auto& ctx = runtime_context();
+    if(!ctx.launcher.empty())
     {
         bool _injected = false;
-        auto _new_argv = std::vector<char*>{};
-        for(auto* itr : _argv)
+        auto _new_argv = std::vector<std::string>{};
+        _new_argv.reserve(_argv.size() + 2);
+        for(const auto& itr : _argv)
         {
-            if(!_injected && std::regex_search(itr, std::regex{ launcher }))
+            if(!_injected && std::regex_search(itr, std::regex{ ctx.launcher }))
             {
                 _new_argv.emplace_back(_exe);
-                _new_argv.emplace_back(strdup("--"));
+                _new_argv.emplace_back("--");
                 _injected = true;
             }
             _new_argv.emplace_back(itr);
@@ -190,7 +208,7 @@ prepare_command_for_run(char* _exe, std::vector<char*>& _argv)
         if(!_injected)
         {
             throw std::runtime_error(
-                join("", "rocprof-sys-causal was unable to match \"", launcher,
+                join("", "rocprof-sys-causal was unable to match \"", ctx.launcher,
                      "\" to any arguments on the command line: \"",
                      join(array_config{ " ", "", "" }, _argv), "\""));
         }
@@ -202,7 +220,7 @@ prepare_command_for_run(char* _exe, std::vector<char*>& _argv)
 void
 prepare_environment_for_run(std::vector<std::string>& _env)
 {
-    if(launcher.empty())
+    if(runtime_context().launcher.empty())
     {
         update_env(
             _env, "LD_PRELOAD",
@@ -219,9 +237,10 @@ void
 update_env(std::vector<std::string>& _environ, std::string_view _env_var, Tp&& _env_val,
            bool _append, std::string_view _join_delim)
 {
-    auto _mode = _append ? update_mode::APPEND : update_mode::REPLACE;
+    auto  _mode = _append ? update_mode::APPEND : update_mode::REPLACE;
+    auto& ctx   = runtime_context();
     rocprofsys::common::update_env(_environ, _env_var, std::forward<Tp>(_env_val), _mode,
-                                   _join_delim, updated_envs, original_envs);
+                                   _join_delim, ctx.env.updated, ctx.env.initial);
 }
 
 template <typename Tp>
@@ -237,12 +256,13 @@ add_default_env(std::vector<std::string>& _environ, std::string_view _env_var,
 
     if(exists) return;
 
+    auto& ctx = runtime_context();
     rocprofsys::common::update_env(_environ, _env_var, std::forward<Tp>(_env_val),
-                                   update_mode::REPLACE, ":", updated_envs,
-                                   original_envs);
+                                   update_mode::REPLACE, ":", ctx.env.updated,
+                                   ctx.env.initial);
 }
 
-std::vector<char*>
+std::vector<std::string>
 parse_args(int argc, char** argv, std::vector<std::string>& _env,
            std::vector<std::map<std::string_view, std::string>>& _causal_envs)
 {
@@ -347,8 +367,8 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
                       "[DEPRECATED Use --log-level=trace] Verbose output")
         .count(1)
         .action([&](parser_t& p) {
-            auto _v = p.get<int>("verbose");
-            verbose = _v;
+            auto _v                         = p.get<int>("verbose");
+            runtime_context().verbose_level = _v;
             update_env(_env, "ROCPROFSYS_VERBOSE", _v);
 
             constexpr std::array<const char*, 5> log_levels = { "off", "info", "debug",
@@ -384,7 +404,9 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
             "proper target")
         .count(1)
         .dtype("executable")
-        .action([&](parser_t& p) { launcher = p.get<std::string>("launcher"); });
+        .action([&](parser_t& p) {
+            runtime_context().launcher = p.get<std::string>("launcher");
+        });
     parser
         .add_argument({ "-g", "--generate-configs" },
                       "Generate config files instead of passing environment variables "
@@ -629,7 +651,7 @@ parse_args(int argc, char** argv, std::vector<std::string>& _env,
     parser.end_group();
 
     auto _inpv = std::vector<char*>{};
-    auto _outv = std::vector<char*>{};
+    auto _outv = std::vector<std::string>{};
     bool _hash = false;
     for(int i = 0; i < argc; ++i)
     {

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-causal/rocprof-sys-causal.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-causal/rocprof-sys-causal.cpp
@@ -16,19 +16,6 @@
 
 namespace utils = rocprofsys::common_utils;
 
-namespace
-{
-std::vector<std::string>
-to_string_vec(const std::vector<char*>& argv)
-{
-    std::vector<std::string> out;
-    out.reserve(argv.size());
-    for(const auto* arg : argv)
-        if(arg != nullptr) out.emplace_back(arg);
-    return out;
-}
-}  // namespace
-
 int
 main(int argc, char** argv)
 {
@@ -44,7 +31,7 @@ main(int argc, char** argv)
             _has_double_hyphen = true;
     }
 
-    std::vector<char*> _argv = {};
+    std::vector<std::string> _argv = {};
     if(_has_double_hyphen)
     {
         _argv = parse_args(argc, argv, _base_env, _causal_env);
@@ -84,10 +71,10 @@ main(int argc, char** argv)
             auto _verbose = get_verbose();
             if(_verbose >= 0)
                 utils::print_environment(_env, get_updated_envs(), _verbose >= 1, "0: ");
-            if(_verbose >= 1) utils::print_command(to_string_vec(_argv), "0: ");
-            _argv.emplace_back(nullptr);
+            if(_verbose >= 1) utils::print_command(_argv, "0: ");
+            auto argv_ptrs = utils::to_c_argv(_argv);
             auto envp_ptrs = utils::to_c_argv(_env);
-            return execvpe(_argv.front(), _argv.data(), envp_ptrs.data());
+            return execvpe(argv_ptrs.front(), argv_ptrs.data(), envp_ptrs.data());
         }
 
         forward_signals({ SIGINT, SIGTERM, SIGQUIT });
@@ -119,11 +106,10 @@ main(int argc, char** argv)
                 if(_verbose >= 0)
                     utils::print_environment(_env, get_updated_envs(), _verbose >= 1,
                                              _prefix.str());
-                if(_verbose >= 1)
-                    utils::print_command(to_string_vec(_argv), _prefix.str());
-                _argv.emplace_back(nullptr);
+                if(_verbose >= 1) utils::print_command(_argv, _prefix.str());
+                auto argv_ptrs = utils::to_c_argv(_argv);
                 auto envp_ptrs = utils::to_c_argv(_env);
-                return execvpe(_argv.front(), _argv.data(), envp_ptrs.data());
+                return execvpe(argv_ptrs.front(), argv_ptrs.data(), envp_ptrs.data());
             }
             else
             {

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-causal/rocprof-sys-causal.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-causal/rocprof-sys-causal.hpp
@@ -22,19 +22,19 @@ update_env(std::vector<std::string>& _environ, std::string_view _env_var, Tp&& _
 int
 get_verbose();
 
-const std::unordered_set<std::string_view>&
+const std::unordered_set<std::string>&
 get_updated_envs();
 
 std::vector<std::string>
 get_initial_environment();
 
 void
-prepare_command_for_run(char*, std::vector<char*>&);
+prepare_command_for_run(const char*, std::vector<std::string>&);
 
 void
 prepare_environment_for_run(std::vector<std::string>&);
 
-std::vector<char*>
+std::vector<std::string>
 parse_args(int argc, char** argv, std::vector<std::string>&,
            std::vector<std::map<std::string_view, std::string>>&);
 


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Clean up `rocprof-sys-causal` runtime state before extracting shared runner utilities. This reduces file-scope mutable state and removes manual command argv ownership without changing causal behavior.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Added `causal_runtime_context` using `rocprofsys::argparse::env_snapshot`.
- Moved causal env/parser state into the context:
    - verbose level
    - launcher
    - initial env snapshot
    - updated env keys
- Kept signal-handler globals separate for POSIX signal callback access.
- Changed causal command argv ownership from `std::vector<char*>` to `std::vector<std::string>`.
- Convert to C argv only at `execvpe()` via `common_utils::to_c_argv()`.
- Removed command-path `strdup("--")`.
- Preserved existing launcher regex matching.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
AIPROFSYST-482

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Built the affected causal target and required causal test assets/examples:
cmake --build build/debug --target rocprofiler-systems-causal -j 8
cmake --build build/debug --target copy-test-files -j 8
cmake --build build/debug --target rocprofsys-causal-examples -j 8

 Ran the causal regression subset covering baseline, lulesh, config-generation, and e2e paths:

ROCPROFSYS_TEST_EXECUTABLE=$(pwd)/build/pytest-venv/bin/pytest \
ctest --test-dir build/debug --output-on-failure -R \
    "rocprofiler-systems-pytest-config|causal-baseline|causal-config-both|causal-e2e-cpu"

## Test Result

<!-- Briefly summarize test outcomes. -->
100% tests passed, 0 tests failed out of 10

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
