### PR TITLE
[rocprofiler-systems]: stop forcing CMAKE_BUILD_TYPE=Release in dl/user shims

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys-dl/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys-dl/CMakeLists.txt
@@ -7,7 +7,6 @@
 #
 # ------------------------------------------------------------------------------#
 
-set(CMAKE_BUILD_TYPE "Release")
 set(CMAKE_SKIP_RPATH OFF)
 set(CMAKE_BUILD_RPATH_USE_ORIGIN ON)
 set(CMAKE_CXX_VISIBILITY_PRESET "internal")

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys-user/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys-user/CMakeLists.txt
@@ -7,7 +7,6 @@
 #
 # ------------------------------------------------------------------------------#
 
-set(CMAKE_BUILD_TYPE "Release")
 set(CMAKE_SKIP_RPATH OFF)
 set(BUILD_RPATH_USE_ORIGIN ON)
 set(CMAKE_CXX_VISIBILITY_PRESET "hidden")


### PR DESCRIPTION
## Motivation

`rocprof-sys-dl` and `rocprof-sys-user` CMakeLists hard-coded `set(CMAKE_BUILD_TYPE "Release")` at directory scope, shadowing the project-wide build type and breaking Debug builds.

## Technical Details

- Drop line 10 (`set(CMAKE_BUILD_TYPE "Release")`) from both shim CMakeLists.
- Override predates spdlog adoption; lean-shim intent still covered by `VISIBILITY_PRESET internal/hidden`, `rocprofiler_systems_strip_target`, and `-g3` already present.
- Removes spdlog `libspdlogd` vs `libspdlog` debug-postfix linker error and lets sanitizer/coverage flags reach the shim TUs.

## Jira

AIPROFSYST-393

## Test Plan

- `cmake -DCMAKE_BUILD_TYPE=Release ... && ninja`
- `cmake -DCMAKE_BUILD_TYPE=Debug ... && ninja`
- `ctest -E "long|gpu|hip|rocm"`

## Test Result

- Release: 894/894 PASS.
- Debug: 887/887 PASS (was the failing case).
- Debug dl-shim 923 KB vs Release 166 KB confirms Debug flags now applied.
- ctest 315 passed / 18 skipped / 32 failed; all 32 are pre-existing env failures (RCCL/HIP/dyninst/openmp), none touch shim-lib targets.

## Checklist

- [x] Builds Release + Debug
- [x] Unit tests (non-GPU subset)
- [ ] GPU tests not run (env limit)