### PR TITLE
Simplify cache config to carveout mapping

### DIFF
--- a/projects/clr/hipamd/src/hip_device_runtime.cpp
+++ b/projects/clr/hipamd/src/hip_device_runtime.cpp
@@ -603,7 +603,8 @@ hipError_t hipDeviceSetCacheConfig(hipFuncCache_t cacheConfig) {
 
   // No way to set cache config yet.
 
-  hip::getCurrentDevice()->devices()[0]->UpdateGroupMemCarveout(cacheConfig);
+  hip::getCurrentDevice()->devices()[0]->UpdateGroupMemCarveout(
+      amd::funcCacheToCarveoutPercent(static_cast<uint32_t>(cacheConfig)));
   HIP_RETURN(hipSuccess);
 }
 

--- a/projects/clr/hipamd/src/hip_module.cpp
+++ b/projects/clr/hipamd/src/hip_module.cpp
@@ -270,7 +270,7 @@ hipError_t hipFuncSetCacheConfig(const void* func, hipFuncCache_t cacheConfig) {
     HIP_RETURN(status);
   }
   d_kernel->workGroupInfo()->groupMemCarveout_ =
-      d_kernel->device().GetGroupMemCarveout(static_cast<amd::FuncCache>(cacheConfig));
+      amd::funcCacheToCarveoutPercent(static_cast<uint32_t>(cacheConfig));
 
   HIP_RETURN(hipSuccess);
 }

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -28,6 +28,7 @@
 #endif
 #endif
 
+#include <array>
 #include <cassert>
 #include <cstdint>
 #include <cstdio>
@@ -109,12 +110,20 @@ enum MemRangeAttribute : uint32_t {
   CoherencyMode = 100,       ///< Current coherency mode for the specified range
 };
 
-enum FuncCache : uint32_t  {
-  kPreferNone = 0,   ///< Default function cache configuration, no preference
-  kPreferLDS = 1,    ///< Prefer larger shared memory and smaller L1 cache
-  kPreferCache = 2,  ///< Prefer larger L1 cache and smaller shared memory
-  kPreferEqual = 3   ///< Prefer equal size L1 cache and shared memory
-};
+//! Maps hipFuncCache_t to group memory carveout percentage.
+//! PreferL1 maps to 1% (not 0%) because 0 means "no preference" in the
+//! AQL packet's group_mem_carveout field; 1% is the minimum value that
+//! signals a preference for cache over LDS.
+inline constexpr std::array<uint8_t, 4> kFuncCacheToGroupMemCarveoutPercent = {0, 100, 1, 50};
+static_assert(kFuncCacheToGroupMemCarveoutPercent.size() == 4,
+              "Must cover all hipFuncCache_t values");
+
+//! Convert hipFuncCache_t to carveout percentage, returning 0 for out-of-range values.
+inline uint8_t funcCacheToCarveoutPercent(uint32_t cacheConfig) {
+  return cacheConfig < kFuncCacheToGroupMemCarveoutPercent.size()
+      ? kFuncCacheToGroupMemCarveoutPercent[cacheConfig]
+      : 0;
+}
 
 constexpr int CpuDeviceId = static_cast<int>(-1);
 constexpr int InvalidDeviceId = static_cast<int>(-2);
@@ -736,13 +745,6 @@ class Settings {
   void enableExtension(uint name) { extensions_ |= static_cast<uint64_t>(1) << name; }
 
   size_t stagedXferSize_ = 0;     //!< Staged buffer size
-  typedef struct CarveoutPref {
-    uint8_t totalSharedBanks;
-    uint8_t preferLDSBanks;
-    uint8_t preferCacheLDSBanks;
-    uint8_t preferEqualLDSBanks;
-  } CarveoutPref;
-  CarveoutPref groupMemPref_;
 
  private:
   //! Disable copy constructor
@@ -2286,34 +2288,6 @@ class Device : public RuntimeObject {
   //! Sets the group memory carveout percentage hint for the device
   void UpdateGroupMemCarveout(uint8_t percent) { group_mem_carveout_hint_ = percent; }
 
-  uint8_t GetGroupMemCarveout(amd::FuncCache cacheConfig) const {
-    uint8_t totalSharedBanks = 0;
-    uint8_t LDSBanks = 0;
-    if (settings().groupMemCarveout_) {
-      totalSharedBanks = settings_->groupMemPref_.totalSharedBanks;
-      switch (cacheConfig) {
-        case kPreferLDS:
-          LDSBanks = settings_->groupMemPref_.preferLDSBanks;
-          break;
-        case kPreferCache:
-          LDSBanks = settings_->groupMemPref_.preferCacheLDSBanks;
-          break;
-        case kPreferEqual:
-          LDSBanks = settings_->groupMemPref_.preferEqualLDSBanks;
-          break;
-        case kPreferNone:
-        default:
-          break;
-      }
-    }
-    return (totalSharedBanks != 0) ? (static_cast<double>(LDSBanks) / totalSharedBanks) * 100 : 0;
-  }
-
-  //! Sets group memory carveout percentage hint for the device for respective cacheConfig
-  void UpdateGroupMemCarveout(amd::FuncCache cacheConfig) {
-    group_mem_carveout_hint_ = GetGroupMemCarveout(cacheConfig);
-  }
-
 #if defined(__clang__)
 #if __has_feature(address_sanitizer)
   virtual device::UriLocator* createUriLocator() const = 0;
@@ -2376,7 +2350,7 @@ class Device : public RuntimeObject {
   uint64_t initial_heap_size_{HIP_INITIAL_DM_SIZE};     //!< Initial device heap size
   amd::Monitor activeQueuesLock_{};                     //!< Guards access to the activeQueues set
   std::unordered_map<amd::CommandQueue*, bool> activeQueues;  //!< The set of active queues
-  uint8_t group_mem_carveout_hint_; //!< LDS carveout
+  uint8_t group_mem_carveout_hint_{0}; //!< LDS carveout percentage (0 = no preference)
  private:
   const Isa* isa_;  //!< Device isa
   bool IsTypeMatching(cl_device_type type, bool offlineDevices);

--- a/projects/clr/rocclr/device/rocm/rocsettings.cpp
+++ b/projects/clr/rocclr/device/rocm/rocsettings.cpp
@@ -184,10 +184,6 @@ bool Settings::create(bool fullProfile, const amd::Isa& isa, bool enableXNACK, b
   if (gfxipMajor == 12 && gfxipMinor >= 5) {
     ext_dispatch_packet_ = true;
     groupMemCarveout_ = true;
-    groupMemPref_.totalSharedBanks = 7;
-    groupMemPref_.preferLDSBanks = 5;
-    groupMemPref_.preferCacheLDSBanks = 2;
-    groupMemPref_.preferEqualLDSBanks = 3;
   }
 
   // Override current device settings

--- a/projects/hip-tests/catch/config/configs/unit/device.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/device.yaml
@@ -50,6 +50,9 @@ device:
   Unit_hipDeviceSetCacheConfig_Positive_Basic:
     <<: *level_2
     tags: [config]
+  Unit_hipDeviceSetCacheConfig_Positive_Carveout:
+    <<: *level_2
+    tags: [config]
   Unit_hipDeviceGetCacheConfig_Positive_Default:
     <<: *level_2
     tags: [config]

--- a/projects/hip-tests/catch/config/configs/unit/executionControl.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/executionControl.yaml
@@ -91,7 +91,7 @@ executionControl:
     # Note: intermittent Seg fault failure
     disabled: [amd_windows, amd_wsl]
     tags: [attributes, kernel]
-  Unit_hipFuncSetCacheConfig_Negative_Not_Supported:
+  Unit_hipFuncSetCacheConfig_Positive_VerifyCarveoutMapping:
     <<: *level_2
     tags: [attributes, kernel]
   Unit_hipFuncSetSharedMemConfig_Positive_Basic:

--- a/projects/hip-tests/catch/unit/device/hipDeviceSetGetCacheConfig.cc
+++ b/projects/hip-tests/catch/unit/device/hipDeviceSetGetCacheConfig.cc
@@ -42,6 +42,31 @@ HIP_TEST_CASE(Unit_hipDeviceSetCacheConfig_Positive_Basic) {
 }
 
 /**
+ * Test Description
+ * ------------------------
+ *  - Verifies that hipDeviceSetCacheConfig with each cache config hint
+ *    succeeds on carveout-capable devices and that a subsequent kernel
+ *    launch (without per-function carveout) uses the device-level default
+ *    without error.
+ * Test source
+ * ------------------------
+ *  - unit/device/hipDeviceSetGetCacheConfig.cc
+ */
+__global__ void empty_kernel() {}
+
+HIP_TEST_CASE(Unit_hipDeviceSetCacheConfig_Positive_Carveout) {
+  const auto cache_config =
+      GENERATE(from_range(std::begin(kCacheConfigs), std::end(kCacheConfigs)));
+
+  HIP_CHECK(hipDeviceSetCacheConfig(cache_config));
+
+  // Launch a kernel without per-function carveout to exercise the
+  // device-level carveout fallback path in the dispatch packet.
+  empty_kernel<<<1, 1>>>();
+  HIP_CHECK(hipDeviceSynchronize());
+}
+
+/**
  * End doxygen group hipDeviceSetCacheConfig.
  * @}
  */

--- a/projects/hip-tests/catch/unit/executionControl/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/executionControl/CMakeLists.txt
@@ -5,6 +5,7 @@
 set(TEST_SRC
     execution_control_common.cc
     hipFuncGetAttributesBasic.cc
+    hipFuncSetCacheConfig.cc
     hipLaunchKernel.cc
     hipLaunchCooperativeKernel.cc
 )
@@ -18,9 +19,7 @@ if(HIP_PLATFORM MATCHES "amd")
     hipLaunchCooperativeKernelMultiDevice.cc
     )
 else()
-  # These functions are currently unimplemented on AMD
   set(TEST_SRC ${TEST_SRC}
-        hipFuncSetCacheConfig.cc
         hipFuncSetSharedMemConfig.cc
         hipFuncSetAttribute.cc
     )

--- a/projects/hip-tests/catch/unit/executionControl/hipFuncSetCacheConfig.cc
+++ b/projects/hip-tests/catch/unit/executionControl/hipFuncSetCacheConfig.cc
@@ -73,23 +73,39 @@ HIP_TEST_CASE(Unit_hipFuncSetCacheConfig_Negative_Parameters) {
 /**
  * Test Description
  * ------------------------
- *  - Sets cache config that is not supported.
- *    - Expected output: return `hipErrorNotSupported`
+ *  - Verifies that hipFuncSetCacheConfig maps cache config hints to the
+ *    expected preferredShmemCarveout percentages:
+ *    -# hipFuncCachePreferShared  -> 100%
+ *    -# hipFuncCachePreferL1      -> 1%
+ *    -# hipFuncCachePreferEqual   -> 50%
+ *    -# hipFuncCachePreferNone    -> 0% (no preference)
  * Test source
  * ------------------------
  *  - unit/executionControl/hipFuncSetCacheConfig.cc
- * Test requirements
- * ------------------------
- *  - Platform specific (AMD)
- *  - HIP_VERSION >= 5.2
  */
-HIP_TEST_CASE(Unit_hipFuncSetCacheConfig_Negative_Not_Supported) {
+HIP_TEST_CASE(Unit_hipFuncSetCacheConfig_Positive_VerifyCarveoutMapping) {
 #if HT_NVIDIA
   HIP_SKIP_TEST(HipTest::SkipReason::kApiUnsupportedOnNvidia);
 #endif
 
-  HIP_CHECK_ERROR(hipFuncSetCacheConfig(reinterpret_cast<void*>(kernel), hipFuncCachePreferNone),
-                  hipErrorNotSupported);
+  struct {
+    hipFuncCache_t config;
+    int expectedCarveout;
+  } testCases[] = {
+      {hipFuncCachePreferNone, 0},
+      {hipFuncCachePreferShared, 100},
+      {hipFuncCachePreferL1, 1},
+      {hipFuncCachePreferEqual, 50},
+  };
+
+  for (const auto& tc : testCases) {
+    HIP_CHECK(hipFuncSetCacheConfig(reinterpret_cast<void*>(kernel), tc.config));
+
+    hipFuncAttributes attributes;
+    HIP_CHECK(hipFuncGetAttributes(&attributes, reinterpret_cast<void*>(kernel)));
+
+    REQUIRE(attributes.preferredShmemCarveout == tc.expectedCarveout);
+  }
 }
 
 /**


### PR DESCRIPTION
## Motivation
Replace the bank-ratio heuristic (CarveoutPref struct, FuncCache enum, GetGroupMemCarveout switch) with a direct lookup table that maps hipFuncCache_t to carveout percentages:

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

  Changes:                                                                                                                                                                                                         
  - Remove CarveoutPref struct, FuncCache enum, and bank-based conversion                                                                                        
  - Add constexpr lookup table with bounds-checked helper function                                                                                                                                                                                                                                                                                   
  - Add Unit_hipFuncSetCacheConfig_Positive_VerifyCarveoutMapping test                                                                                                                                             
  - Add Unit_hipDeviceSetCacheConfig_Positive_Carveout test                                                                                                                                                        
  
<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
AIRUNTIME-14
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
  - Add Unit_hipFuncSetCacheConfig_Positive_VerifyCarveoutMapping test                                                                                                                                             
  - Add Unit_hipDeviceSetCacheConfig_Positive_Carveout test                                                                                                                                                        
  
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
  The new tests exercise the mapping and also test that the carveout setting is functional through DeviceSetCache API
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
