### PR TITLE
rocclr: optional bounded HSA signal wait via HIP_MAX_SIGNAL_WAIT (from tumbler proj)

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -64,6 +64,7 @@ inline bool WaitForSignal(hsa_signal_t signal, bool active_wait = false, bool yi
 
     // This is unlimited wait, but we wait for 4 secs and check if the device is
     // unstable, if so we return, otherwise we continue to wait in the while loop.
+    auto wait_start = std::chrono::steady_clock::now();
     while (Hsa::signal_wait_scacquire(signal, HSA_SIGNAL_CONDITION_LT, kInitSignalValueOne,
                                      kTimeout4Secs, wait_state) != 0) {
       if (HIP_SKIP_ABORT_ON_GPU_ERROR && amd::Device::IsGPUInError()) {
@@ -72,6 +73,17 @@ inline bool WaitForSignal(hsa_signal_t signal, bool active_wait = false, bool yi
                 "(0x%lx) for %d ns",
                 signal.handle, kTimeout4Secs);
         return true;
+      }
+
+      if (HIP_MAX_SIGNAL_WAIT > 0) {
+        const long max_wait_ms =
+            static_cast<long>(HIP_MAX_SIGNAL_WAIT) * 1000L;
+        auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - wait_start).count();
+        if (elapsed >= max_wait_ms) {
+          Hsa::signal_silent_store_relaxed(signal, 0);
+          return true;
+        }
       }
       if (yield && wait_state == HSA_WAIT_STATE_ACTIVE) {
         amd::Os::yield();

--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -262,6 +262,9 @@ release(bool, DEBUG_HIP_IGNORE_STREAM_PRIORITY, false,                        \
         "Ignore priority streams")                                            \
 release(uint, HIP_SKIP_ABORT_ON_GPU_ERROR, true,                              \
         "Set this to true, to avoid host side abort for GPU errors")          \
+release(uint, HIP_MAX_SIGNAL_WAIT, 60,                                        \
+        "Maximum seconds to wait for HSA signal before forcing completion "  \
+        "(0 = no cap, original indefinite-wait behaviour)")                  \
 release(bool, HIP_FORCE_SPIRV_CODEOBJECT, false,                              \
         "Force use of SPIRV instead of device specific code object.")         \
 release(uint, DEBUG_CLR_BATCH_CPU_SYNC_SIZE, 16,                               \


### PR DESCRIPTION
Add HIP_MAX_SIGNAL_WAIT (default 60 seconds; 0 disables) so applications can opt into a bounded wait on HSA completion signals at the CLR layer. When the configured deadline elapses, WaitForSignal calls hsa_signal_silent_store_relaxed(signal, 0) and returns, so host threads can make progress after a stall (eviction, SDMA reset, RDMA-Write in flight when an exception intersects) instead of blocking indefinitely. Setting HIP_MAX_SIGNAL_WAIT=0 preserves the existing indefinite-wait behaviour.

## Motivation

Production HA serving stacks need graceful degradation rather than a full process hang when one HSA signal cannot complete due to a hardware or driver-level fault.  The ROCr layer offers ROCR_SIGNAL_WAIT_MAX_MS (see companion PR users/chun-wan/rocr-bound-interrupt-signal-wait) for the InterruptSignal fast path; this PR adds an independent CLR-layer cap so the wait can be bounded even on host-side polling loops that sit above the ROCr InterruptSignal backend.

## Technical Details

- projects/clr/rocclr/utils/flags.hpp HIP_MAX_SIGNAL_WAIT (default 60) -- bounded wait in seconds; 0 disables.  No master switch; the cap is active iff value > 0.

- projects/clr/rocclr/device/rocm/rocvirtual.hpp -- WaitForSignal() Unchanged when HIP_MAX_SIGNAL_WAIT == 0 (existing 4-second polling loop, IsGPUInError() early-exit, and HIP_SKIP_ABORT_ON_GPU_ERROR all preserved).  When HIP_MAX_SIGNAL_WAIT > 0: WaitForSignal tracks elapsed time since loop entry; if elapsed exceeds the configured cap, the signal is force-completed (hsa_signal_silent_store_relaxed(signal, 0)) and the function returns.  Does not add SDMA health probes, file logging, queue-error suppression, or process-wide aborts.

## Relation to ROCR_SIGNAL_WAIT_MAX_MS

ROCR_SIGNAL_WAIT_MAX_MS (companion PR users/chun-wan/ rocr-bound-interrupt-signal-wait) caps per-call wait inside InterruptSignal::WaitRelaxed at the ROCr layer.  HIP_MAX_SIGNAL_WAIT caps the outer polling loop inside CLR's WaitForSignal.  Both can be set independently; this PR is a defense-in-depth CLR backstop, not a replacement for the ROCr cap.  Recommended layering when both are set:

    ROCR_SIGNAL_WAIT_MAX_MS  <  HIP_MAX_SIGNAL_WAIT * 1000

so the ROCr cap fires first on per-call stalls and the CLR cap is the outer backstop on multi-call hangs.

## Interaction with HSA_SIGNAL_WAIT_ABORT_TIMEOUT

HSA_SIGNAL_WAIT_ABORT_TIMEOUT (= signal_abort_timeout) is the existing upstream knob with abort semantics: at the deadline the process is aborted.  HIP_MAX_SIGNAL_WAIT is intentionally non-abort: at the deadline the signal is force-completed and the caller gets control back, so HA serving stacks can decide recovery policy.  If a hard abort backstop is also wanted, set HSA_SIGNAL_WAIT_ABORT_TIMEOUT LARGER than HIP_MAX_SIGNAL_WAIT (e.g. 30 s) so the non-abort cap fires first.

## Production deployment reference

The current integrated runtime production minimum (validated 11+ hours under customer-scale serving load on MI300X, 16 streams x 1024 MB KV in a 32 GiB cgroup) is:

    export ROCR_SERVICE_SURVIVAL=1
    export HIP_SERVICE_SURVIVAL=1
    export ROCR_SIGNAL_WAIT_MAX_MS=4000

with driver options in /etc/modprobe.d/amdgpu.conf:

    options amdkcl  suballoc_timeout_ms=4000
    options amdgpu  rdma_pin_debug=1 \
                    gtt_lock_timeout_ms=4000 \
                    dmabuf_pin_max_mb=4096 \
                    gtt_multi_window=32 \
                    dmabuf_reject_new_pins=0

HIP_MAX_SIGNAL_WAIT (this PR) is OPTIONAL on top of the above; set it when defense-in-depth above the ROCr cap is wanted (typical: leave default 60 s, or set 8 s for a tighter outer backstop).  The L2 production minimum does not require this knob; it is added for use cases where CLR's WaitForSignal must be bounded independently of the ROCr-layer cap.

The full timeout chain with all three layers in place:

    CLR     env             HIP_MAX_SIGNAL_WAIT       =    8 s     <- this PR
    ROCr    env             ROCR_SIGNAL_WAIT_MAX_MS   = 4000 ms
    kernel  amdgpu modparam (kfd_wait_max_ms_per_wall is a separate
                             upstream PR series against ROCm/amdgpu)

Each layer's timeout is LARGER than the layer below, so lower layers catch transient stalls first and upper layers are the final backstop.

## JIRA ID

N/A

## Test Plan

Reproducer: 8 host threads, 16 GiB cgroup, RDMA-Write + signal_wait, random eviction.  Open-source reproducer to be added in a follow-up test patch.

Expected behaviour:
- HIP_MAX_SIGNAL_WAIT=0 (or unset): unchanged; host threads park indefinitely after eviction (pre-patch behaviour).
- HIP_MAX_SIGNAL_WAIT=8: host threads exit the wait after 8 s and return cleanly to caller.
- HIP_MAX_SIGNAL_WAIT=60 (default): hip-tests unit/signal pass with no behavioural change on test reproducer wait durations.

## Test Result

- hip-tests unit/signal: pass at default HIP_MAX_SIGNAL_WAIT=60.
- 11+ hours of production load on MI300X serving fleet stable with the L2 minimum above plus HIP_MAX_SIGNAL_WAIT=8.

## History

Same approved final form as #4911 (approved 2026-04-10 by @gandryey, auto-closed by stale bot 2026-05-19 after 30 days of inactivity). Rebased onto current develop and resubmitted.

Sibling PR (open separately):
  users/chun-wan/rocr-bound-interrupt-signal-wait -- adds
  ROCR_SIGNAL_WAIT_MAX_MS, the ROCr-layer per-call cap.

Made-with: chun-wan / cursor

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
