### PR TITLE
rocjitsu: Expand DBT support for fp16 CDNA4 -> CDNA3

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/CMakeLists.txt
@@ -12,6 +12,7 @@ rj_add_object_library(rocjitsu_code
     dbt/hazard_tracker.cpp
     dbt/kernel_descriptor_translator.cpp
     dbt/lane_permutation.cpp
+    dbt/semantic/cdna4_to_cdna3.cpp
     dbt/semantic/cdna4_to_rdna_common.cpp
     dbt/semantic/cdna4_to_rdna3.cpp
     dbt/semantic/cdna4_to_rdna4.cpp

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/CMakeLists.txt
@@ -11,6 +11,7 @@ rj_add_object_library(rocjitsu_code
     dbt/hazard_tracker.cpp
     dbt/kernel_descriptor_translator.cpp
     dbt/lane_permutation.cpp
+    dbt/semantic/cdna4_to_cdna3.cpp
     dbt/semantic/cdna4_to_rdna_common.cpp
     dbt/semantic/cdna4_to_rdna3.cpp
     dbt/semantic/cdna4_to_rdna4.cpp

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_elf.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_elf.h
@@ -4,6 +4,8 @@
 #ifndef ROCJITSU_CODE_AMDGPU_ELF_H_
 #define ROCJITSU_CODE_AMDGPU_ELF_H_
 
+#include "rocjitsu/code/rj_code.h"
+
 #include <cstdint>
 
 namespace rocjitsu {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.cpp
@@ -416,6 +416,11 @@ void visit_kernel_descriptors(std::span<const uint8_t> image, uint64_t text_offs
   return (registers + granularity - 1) / granularity - 1;
 }
 
+[[nodiscard]] uint32_t align_up(uint32_t value, uint32_t alignment) {
+  alignment = std::max(alignment, 1u);
+  return ((value + alignment - 1) / alignment) * alignment;
+}
+
 [[nodiscard]] uint16_t accum_vgpr_base(const KD &desc, rj_code_arch_t guest_arch) {
   if (!uses_gfx90a_accum_offset(guest_arch) || !arch_has_accvgpr(guest_arch))
     return 0;
@@ -550,6 +555,7 @@ translate_one_descriptor(rj_code_arch_t guest_arch, rj_code_arch_t host_arch,
   // The descriptor translator records the first unified VGPR index that must be
   // reserved for those remapped accumulator registers.
   result.accvgpr_base = accum_vgpr_base(src, guest_arch);
+  result.target_accvgpr_base = result.accvgpr_base;
 
   // Descriptor ABI fixes that require instructions, not bitfield changes, are
   // emitted as prologue words. CodeObjectPatcher decides where to place them and
@@ -572,13 +578,39 @@ translate_one_descriptor(rj_code_arch_t guest_arch, rj_code_arch_t host_arch,
       granulated_count_to_registers(guest_vgpr_granulated, guest_vgpr_granularity);
 
   // Start from the guest's required VGPR allocation. Then grow it for semantic
-  // lowering requirements: AccVGPR unification needs enough unified VGPRs to
-  // cover the remapped accumulator window, and instruction lowering may request
-  // additional scratch temporaries through options.minimum_vgprs.
+  // lowering requirements:
+  //
+  // - CDNA-to-RDNA unifies AccVGPRs into the ordinary VGPR namespace, so the
+  //   target needs enough VGPRs to cover the remapped accumulator window.
+  //
+  // - CDNA-to-CDNA keeps a real AccVGPR bank. On GFX90A/GFX942/GFX950 the
+  //   ACCUM_OFFSET descriptor field selects where that bank starts in the
+  //   unified register file. If a semantic lowering needs new ordinary VGPRs
+  //   at or above the original offset, merely increasing VGPRS is not enough:
+  //   those temporary VGPRs would alias a0, a1, ... at runtime. Move the
+  //   accumulator base up and preserve the original accumulator-window size.
+  //
+  // - instruction lowering may request additional scratch temporaries through
+  //   options.minimum_vgprs.
   uint32_t required_vgprs = result.guest_vgpr_count;
   if (arch_has_accvgpr(guest_arch) && !arch_has_accvgpr(host_arch) && result.accvgpr_base != 0)
     required_vgprs = std::max(required_vgprs, result.accvgpr_base + result.guest_vgpr_count);
   required_vgprs = std::max(required_vgprs, options.minimum_vgprs);
+  if (arch_has_accvgpr(guest_arch) && arch_has_accvgpr(host_arch) &&
+      uses_gfx90a_accum_offset(host_arch) && result.accvgpr_base != 0) {
+    const uint32_t source_accvgpr_count = result.guest_vgpr_count > result.accvgpr_base
+                                              ? result.guest_vgpr_count - result.accvgpr_base
+                                              : 0;
+    if (source_accvgpr_count != 0 && options.minimum_vgprs > result.accvgpr_base) {
+      result.target_accvgpr_base = align_up(options.minimum_vgprs, 4);
+      required_vgprs = std::max(required_vgprs, result.target_accvgpr_base + source_accvgpr_count);
+      if (result.target_accvgpr_base > 256) {
+        result.warnings.push_back("required AccVGPR offset exceeds GFX90A descriptor field range; "
+                                  "AccVGPR base virtualization is not implemented");
+        result.supported = false;
+      }
+    }
+  }
   result.host_vgpr_count = required_vgprs;
   result.target_vgpr_count = required_vgprs;
   if (arch_max_vgprs(host_arch) != 0 && required_vgprs > arch_max_vgprs(host_arch)) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.h
@@ -35,6 +35,7 @@ struct KdTranslation {
 
   uint32_t target_vgpr_count = 0;
   uint32_t target_vgpr_granulated = 0;
+  uint32_t target_accvgpr_base = 0;
   uint32_t accvgpr_base = 0;
   uint32_t vgpr_spill_to_lds_count = 0;
   uint32_t vgpr_spill_to_scratch_count = 0;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/cdna4_to_cdna3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/cdna4_to_cdna3.cpp
@@ -1,0 +1,730 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file semantic/cdna4_to_cdna3.cpp
+/// @brief CDNA4-to-CDNA3 handwritten semantic expansion rules.
+
+#include "rocjitsu/code/dbt/semantic/rules.h"
+
+#include "rocjitsu/analysis/liveness.h"
+#include "rocjitsu/code/patch/instruction_builder.h"
+#include "rocjitsu/isa/arch/amdgpu/cdna3/machine_insts.h"
+#include "rocjitsu/isa/arch/amdgpu/cdna4/machine_insts.h"
+#include "rocjitsu/isa/arch/amdgpu/cdna4/vop3.h"
+#include "rocjitsu/isa/instruction.h"
+
+#include <algorithm>
+#include <array>
+#include <bit>
+#include <cstring>
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace rocjitsu {
+namespace {
+
+// CDNA3 instruction builders used by the narrow semantic rules below. These
+// helpers intentionally only cover the encodings the lowering emits; keeping
+// them local avoids adding a broad assembler abstraction for a handful of
+// code-cave sequences.
+
+[[nodiscard]] std::pair<uint32_t, uint32_t>
+build_cdna3_vop3(uint16_t op, uint8_t vdst, uint16_t src0, uint16_t src1 = 0, uint16_t src2 = 0) {
+  cdna3::Vop3MachineInst dst{};
+  dst.encoding = 0x34;
+  dst.op = op;
+  dst.vdst = vdst;
+  dst.src0 = src0 & 0x1FF;
+  dst.src1 = src1 & 0x1FF;
+  dst.src2 = src2 & 0x1FF;
+
+  uint32_t words[2]{};
+  std::memcpy(words, &dst, sizeof(dst));
+  return {words[0], words[1]};
+}
+
+/// @brief Build a CDNA3 VOP3P-MFMA instruction word pair.
+/// @details The wide-K lowering materializes A/B operands in ordinary VGPRs, so
+/// the emitted narrow MFMA clears the source ACC selector while preserving the
+/// destination AccVGPR selector from the CDNA4 instruction.
+[[nodiscard]] std::pair<uint32_t, uint32_t>
+build_cdna3_vop3p_mfma(uint8_t op, const cdna4::Vop3pMfmaMachineInst &src, uint8_t vdst,
+                       uint8_t acc_cd, uint16_t src0, uint16_t src1, uint16_t src2) {
+  cdna3::Vop3pMfmaMachineInst dst{};
+  dst.encoding = 0x1A7;
+  dst.op = op;
+  dst.vdst = vdst;
+  dst.cbsz = src.cbsz;
+  dst.abid = src.abid;
+  dst.acc_cd = acc_cd;
+  dst.src0 = src0 & 0x1FF;
+  dst.src1 = src1 & 0x1FF;
+  dst.src2 = src2 & 0x1FF;
+  dst.acc = 0;
+  dst.blgp = src.blgp;
+
+  uint32_t words[2]{};
+  std::memcpy(words, &dst, sizeof(dst));
+  return {words[0], words[1]};
+}
+
+[[nodiscard]] std::pair<uint32_t, uint32_t> build_cdna3_ds(uint8_t op, uint8_t vdst, uint8_t addr,
+                                                           uint8_t data0 = 0, uint8_t data1 = 0,
+                                                           uint8_t offset0 = 0,
+                                                           uint8_t offset1 = 0) {
+  cdna3::DsMachineInst dst{};
+  dst.encoding = 0x36;
+  dst.op = op;
+  dst.offset0 = offset0;
+  dst.offset1 = offset1;
+  dst.addr = addr;
+  dst.data0 = data0;
+  dst.data1 = data1;
+  dst.vdst = vdst;
+
+  uint32_t words[2]{};
+  std::memcpy(words, &dst, sizeof(dst));
+  return {words[0], words[1]};
+}
+
+[[nodiscard]] constexpr std::pair<uint32_t, uint32_t> build_s_mov_b32_lit(uint8_t sdst,
+                                                                          uint32_t literal) {
+  return {pack_sop1(0, sdst, 0xFF), literal};
+}
+
+constexpr uint8_t kExecLo = 126;
+constexpr uint16_t kInlineConst0 = 128;
+constexpr uint16_t kInlineConstNeg1 = 193;
+
+// BinaryTranslator currently reserves 128 VGPRs for all semantic lowerings.
+// Scratch allocation must remain inside that descriptor headroom until the DBT
+// pipeline grows per-lowering resource reporting.
+constexpr uint16_t kSemanticScratchVgprLimit = 128;
+
+// CDNA3 VOP3 opcodes used by the bitop3, wide-K, and DS transpose expansions.
+constexpr uint16_t kCdna3OpMovB32 = 321;
+constexpr uint16_t kCdna3OpLshrrevB32 = 272;
+constexpr uint16_t kCdna3OpLshlrevB32 = 274;
+constexpr uint16_t kCdna3OpAndB32 = 275;
+constexpr uint16_t kCdna3OpOrB32 = 276;
+constexpr uint16_t kCdna3OpXorB32 = 277;
+constexpr uint16_t kCdna3OpAddU32 = 308;
+constexpr uint16_t kCdna3OpPermB32 = 493;
+constexpr uint16_t kCdna3OpMbcntLoU32B32 = 652;
+constexpr uint16_t kCdna3OpMbcntHiU32B32 = 653;
+
+// CDNA3 VOP3P-MFMA opcodes used by CDNA4 wide-K MFMA expansion.
+constexpr uint8_t kCdna3OpMfmaF32_32x32x8F16 = 76;
+constexpr uint8_t kCdna3OpMfmaF32_16x16x16F16 = 77;
+
+// CDNA3 DS opcodes used to synthesize CDNA4 transposed LDS reads.
+constexpr uint8_t kCdna3DsOpBpermuteB32 = 63;
+constexpr uint8_t kCdna3DsOpReadB64 = 118;
+
+constexpr uint8_t kCdna3SoppOpWaitcnt = 12;
+constexpr uint16_t kCdnaWaitcntLgkmcnt0 = 0xC07F;
+
+void emit_cdna3_vop3(std::vector<uint32_t> &words, uint16_t op, uint8_t vdst, uint16_t src0,
+                     uint16_t src1 = 0, uint16_t src2 = 0) {
+  auto [w0, w1] = build_cdna3_vop3(op, vdst, src0, src1, src2);
+  words.push_back(w0);
+  words.push_back(w1);
+}
+
+void emit_cdna3_ds(std::vector<uint32_t> &words, uint8_t op, uint8_t vdst, uint8_t addr,
+                   uint8_t data0 = 0, uint8_t data1 = 0, uint8_t offset0 = 0, uint8_t offset1 = 0) {
+  auto [w0, w1] = build_cdna3_ds(op, vdst, addr, data0, data1, offset0, offset1);
+  words.push_back(w0);
+  words.push_back(w1);
+}
+
+void emit_cdna3_lgkm_wait(std::vector<uint32_t> &words) {
+  // GFX9/CDNA s_waitcnt encodes "lgkmcnt(0)" as lgkm=0 while leaving VM/EXP at
+  // their no-wait maxima. The DS read/bpermute sequences below require the
+  // loaded/permuted data before issuing dependent VALU instructions.
+  words.push_back(pack_sopp(kCdna3SoppOpWaitcnt, kCdnaWaitcntLgkmcnt0));
+}
+
+[[nodiscard]] constexpr uint16_t vgpr_src(uint8_t reg) { return static_cast<uint16_t>(256 + reg); }
+
+void emit_s_mov_b32_lit(std::vector<uint32_t> &words, uint8_t sdst, uint32_t literal) {
+  auto [w0, w1] = build_s_mov_b32_lit(sdst, literal);
+  words.push_back(w0);
+  words.push_back(w1);
+}
+
+[[maybe_unused]] void emit_cdna3_exec_mask(std::vector<uint32_t> &words, uint64_t mask) {
+  emit_s_mov_b32_lit(words, kExecLo, static_cast<uint32_t>(mask));
+  emit_s_mov_b32_lit(words, kExecLo + 1, static_cast<uint32_t>(mask >> 32));
+}
+
+void emit_cdna3_mfma(std::vector<uint32_t> &words, uint8_t op,
+                     const cdna4::Vop3pMfmaMachineInst &src, uint16_t src0, uint16_t src1,
+                     uint16_t src2) {
+  auto [w0, w1] = build_cdna3_vop3p_mfma(op, src, static_cast<uint8_t>(src.vdst),
+                                         static_cast<uint8_t>(src.acc_cd), src0, src1, src2);
+  words.push_back(w0);
+  words.push_back(w1);
+}
+
+void emit_cdna3_mfma_to_vgpr(std::vector<uint32_t> &words, uint8_t op,
+                             const cdna4::Vop3pMfmaMachineInst &src, uint8_t vdst, uint16_t src0,
+                             uint16_t src1, uint16_t src2) {
+  auto [w0, w1] = build_cdna3_vop3p_mfma(op, src, vdst, 0, src0, src1, src2);
+  words.push_back(w0);
+  words.push_back(w1);
+}
+
+/// @brief Find a dead contiguous VGPR run that stays below a semantic scratch limit.
+/// @details This wraps LivenessAnalysis::find_free_run() for semantic lowerings
+/// that must allocate temporary VGPRs inside the descriptor headroom reserved by
+/// the DBT pipeline. The returned base is at or after @p search_start and the
+/// half-open run [base, base + @p count) is guaranteed not to cross @p limit.
+/// @returns The first matching VGPR base, or std::nullopt if no suitable run is
+/// available before @p limit.
+[[nodiscard]] std::optional<uint16_t>
+find_free_vgpr_run_below(const LivenessAnalysis &liveness, const Instruction &inst, uint16_t count,
+                         uint16_t search_start, uint16_t limit) {
+  auto candidate = liveness.find_free_run(&inst, count, search_start);
+  if (!candidate || *candidate + count > limit)
+    return std::nullopt;
+  return candidate;
+}
+
+// -----------------------------------------------------------------------------
+// V_BITOP3 expansions.
+// -----------------------------------------------------------------------------
+
+/// @brief Convert the 3-input truth table into algebraic-normal-form coefficients.
+/// @details Truth-table bit index is {S0[i], S1[i], S2[i]}: bit 2 is S0, bit 1
+/// is S1, and bit 0 is S2. ANF lets CDNA3 synthesize the LUT from AND/XOR.
+[[nodiscard]] std::array<uint8_t, 8> bitop3_anf_coefficients(uint8_t truth_table) {
+  std::array<uint8_t, 8> coeff{};
+  for (uint8_t mask = 0; mask < coeff.size(); ++mask)
+    coeff[mask] = static_cast<uint8_t>((truth_table >> mask) & 0x1);
+
+  for (uint8_t variable_mask : {uint8_t{4}, uint8_t{2}, uint8_t{1}}) {
+    for (uint8_t mask = 0; mask < coeff.size(); ++mask) {
+      if ((mask & variable_mask) != 0)
+        coeff[mask] ^= coeff[mask ^ variable_mask];
+    }
+  }
+  return coeff;
+}
+
+[[nodiscard]] bool vdst_aliases_any_vgpr_source(uint8_t vdst, const std::array<uint16_t, 3> &src) {
+  const uint16_t encoded_vdst = static_cast<uint16_t>(256 + vdst);
+  return src[0] == encoded_vdst || src[1] == encoded_vdst || src[2] == encoded_vdst;
+}
+
+[[nodiscard]] bool bitop3_needs_product_term(const std::array<uint8_t, 8> &coeff) {
+  for (uint8_t mask = 1; mask < coeff.size(); ++mask) {
+    if (coeff[mask] != 0 && std::popcount(mask) >= 2)
+      return true;
+  }
+  return false;
+}
+
+template <typename Bitop3Inst>
+std::vector<uint32_t> lower_cdna4_bitop3_to_cdna3(const Bitop3Inst &inst,
+                                                  const LivenessAnalysis &liveness, bool is_b16) {
+  // V_BITOP3 is a three-input bitwise LUT. CDNA4 encodes the eight LUT bits in
+  // VOP3 modifier fields; CDNA3 has no equivalent instruction, so the lowering
+  // emits the LUT as algebraic normal form over GF(2):
+  //
+  //   ttbl_index = (S0_bit << 2) | (S1_bit << 1) | S2_bit
+  //   coeff[] = mobius_transform(ttbl[])
+  //   result = coeff[0]
+  //          ^ coeff[1] & S2
+  //          ^ coeff[2] & S1
+  //          ^ coeff[3] & S1 & S2
+  //          ^ coeff[4] & S0
+  //          ^ coeff[5] & S0 & S2
+  //          ^ coeff[6] & S0 & S1
+  //          ^ coeff[7] & S0 & S1 & S2
+  //
+  // Multiplication in that expression is bitwise AND, addition is XOR, and a
+  // constant one term is materialized as -1 so every lane bit sees true. The B16
+  // form computes the same 32-bit LUT, then clears the high half with a
+  // left/right shift pair.
+  const uint8_t vdst = static_cast<uint8_t>(inst.vdst.encoding_value());
+  const std::array<uint16_t, 3> src = {static_cast<uint16_t>(inst.src0.encoding_value()),
+                                       static_cast<uint16_t>(inst.src1.encoding_value()),
+                                       static_cast<uint16_t>(inst.src2.encoding_value())};
+
+  if (is_b16 && inst.inst_.op_sel != 0)
+    // NYI: OP_SEL selects B16 source/destination halves. Source-half selection
+    // can be lowered by shifting selected high halves down before the LUT, but
+    // OP_SEL[3] is read-modify-write: it writes the high half of vdst while
+    // preserving the old low half. The generated operand metadata currently
+    // treats vdst only as a destination, so liveness may allocate vdst as
+    // scratch and clobber the implicit source value. Until that implicit vdst
+    // read is modeled, only lower the canonical OP_SEL=0 form instead of
+    // silently producing wrong code.
+    return {};
+  // V_BITOP3 overloads VOP3 modifier fields as TTBL bits instead of ordinary
+  // arithmetic modifiers: {OMOD[1:0], ABS[2:0], NEG[2:0]}.
+  const uint8_t truth_table = static_cast<uint8_t>(
+      ((inst.inst_.omod & 0x3) << 6) | ((inst.inst_.abs & 0x7) << 3) | (inst.inst_.neg & 0x7));
+  const auto coeff = bitop3_anf_coefficients(truth_table);
+
+  const bool needs_acc_temp = vdst_aliases_any_vgpr_source(vdst, src);
+  const bool needs_term_temp = bitop3_needs_product_term(coeff);
+
+  // Scratch policy:
+  //   - No product terms and no vdst/source alias: use vdst as the accumulator.
+  //   - vdst/source alias only: use one scratch accumulator, then copy to vdst.
+  //   - Any product term: use two scratch VGPRs, one accumulator and one AND
+  //     term. This keeps the generated sequence simple and prevents the AND temp
+  //     from aliasing the accumulator. Liveness may choose vdst as scratch when
+  //     vdst is dead before the original instruction; that is fine because the
+  //     final result still lands in vdst.
+  const uint16_t scratch_count =
+      needs_term_temp ? 2 : static_cast<uint16_t>(needs_acc_temp ? 1 : 0);
+
+  uint8_t acc = vdst;
+  uint8_t term = 0;
+  if (scratch_count != 0) {
+    auto scratch =
+        find_free_vgpr_run_below(liveness, inst, scratch_count, 0, kSemanticScratchVgprLimit);
+    if (!scratch)
+      return {};
+
+    acc = static_cast<uint8_t>(*scratch);
+    if (needs_term_temp)
+      term = static_cast<uint8_t>(*scratch + 1);
+  }
+
+  std::vector<uint32_t> words;
+
+  auto src_for_variable = [&](uint8_t variable_mask) -> uint16_t {
+    switch (variable_mask) {
+    case 4:
+      return src[0];
+    case 2:
+      return src[1];
+    default:
+      return src[2];
+    }
+  };
+
+  auto emit_mov = [&](uint8_t dst, uint16_t src0) {
+    emit_cdna3_vop3(words, kCdna3OpMovB32, dst, src0);
+  };
+  auto emit_and = [&](uint8_t dst, uint16_t src0, uint16_t src1) {
+    emit_cdna3_vop3(words, kCdna3OpAndB32, dst, src0, src1);
+  };
+  auto emit_xor = [&](uint8_t dst, uint16_t src0, uint16_t src1) {
+    emit_cdna3_vop3(words, kCdna3OpXorB32, dst, src0, src1);
+  };
+
+  bool acc_initialized = false;
+  if (coeff[0] != 0) {
+    emit_mov(acc, kInlineConstNeg1);
+    acc_initialized = true;
+  }
+
+  for (uint8_t mask = 1; mask < coeff.size(); ++mask) {
+    if (coeff[mask] == 0)
+      continue;
+
+    std::array<uint16_t, 3> variables{};
+    uint8_t variable_count = 0;
+    for (uint8_t variable_mask : {uint8_t{4}, uint8_t{2}, uint8_t{1}}) {
+      if ((mask & variable_mask) != 0)
+        variables[variable_count++] = src_for_variable(variable_mask);
+    }
+
+    uint16_t term_src = variables[0];
+    if (variable_count >= 2) {
+      emit_and(term, variables[0], variables[1]);
+      if (variable_count == 3)
+        emit_and(term, vgpr_src(term), variables[2]);
+      term_src = vgpr_src(term);
+    }
+
+    if (!acc_initialized) {
+      emit_mov(acc, term_src);
+      acc_initialized = true;
+    } else {
+      emit_xor(acc, vgpr_src(acc), term_src);
+    }
+  }
+
+  if (!acc_initialized)
+    emit_mov(acc, kInlineConst0);
+
+  if (is_b16) {
+    // The B16 form writes a zero-extended low half. Shift left then logical
+    // shift right to clear bits 31:16 without needing a separate 0xffff mask,
+    // which CDNA3 cannot encode as an inline VALU operand.
+    const uint16_t shift16 = scalar_positive_inline_u32(16);
+    emit_cdna3_vop3(words, kCdna3OpLshlrevB32, acc, shift16, vgpr_src(acc));
+    emit_cdna3_vop3(words, kCdna3OpLshrrevB32, acc, shift16, vgpr_src(acc));
+  }
+
+  if (acc != vdst)
+    emit_mov(vdst, vgpr_src(acc));
+
+  return words;
+}
+
+// -----------------------------------------------------------------------------
+// Wide-K MFMA expansions.
+// -----------------------------------------------------------------------------
+
+enum class WideKMfmaShape {
+  F32_16x16x32_F16,
+  F32_32x32x16_F16,
+};
+
+struct WideKMfmaLowering {
+  WideKMfmaShape shape;
+  uint8_t narrow_op;
+  uint8_t dst_regs;
+  uint8_t wide_src_regs;
+  uint8_t narrow_src_regs;
+};
+
+[[nodiscard]] constexpr WideKMfmaLowering lowering_for_shape(WideKMfmaShape shape) {
+  switch (shape) {
+  case WideKMfmaShape::F32_16x16x32_F16:
+    return {shape, kCdna3OpMfmaF32_16x16x16F16, 4, 4, 2};
+  case WideKMfmaShape::F32_32x32x16_F16:
+    return {shape, kCdna3OpMfmaF32_32x32x8F16, 16, 4, 2};
+  }
+  return {shape, 0, 0, 0, 0};
+}
+
+[[nodiscard]] bool ranges_overlap(uint16_t lhs_base, uint16_t lhs_count, uint16_t rhs_base,
+                                  uint16_t rhs_count) {
+  return lhs_base < rhs_base + rhs_count && rhs_base < lhs_base + lhs_count;
+}
+
+[[nodiscard]] bool wide_mfma_needs_partial_accum_scratch(const cdna4::Vop3pMfmaMachineInst &mfma,
+                                                         const WideKMfmaLowering &lowering) {
+  // acc_cd=1 writes the AccVGPR bank. Because this lowering currently rejects
+  // ACC-selected A/B sources, the original A/B operands are ordinary VGPRs and
+  // cannot be clobbered by an AccVGPR partial accumulator.
+  if (mfma.acc_cd != 0)
+    return false;
+
+  const uint16_t dst_base = static_cast<uint16_t>(mfma.vdst);
+  const uint16_t src0_base = static_cast<uint16_t>(mfma.src0 - 256);
+  const uint16_t src1_base = static_cast<uint16_t>(mfma.src1 - 256);
+  return ranges_overlap(dst_base, lowering.dst_regs, src0_base, lowering.wide_src_regs) ||
+         ranges_overlap(dst_base, lowering.dst_regs, src1_base, lowering.wide_src_regs);
+}
+
+std::vector<uint32_t> lower_wide_k_mfma_f16_cdna4_to_cdna3(const Instruction &inst,
+                                                           const LivenessAnalysis &liveness,
+                                                           WideKMfmaShape shape) {
+  const auto *raw = inst.raw_encoding();
+  if (!raw || static_cast<size_t>(inst.size()) < sizeof(cdna4::Vop3pMfmaMachineInst))
+    return {};
+
+  cdna4::Vop3pMfmaMachineInst mfma{};
+  std::memcpy(&mfma, raw, sizeof(mfma));
+  const WideKMfmaLowering lowering = lowering_for_shape(shape);
+  if (lowering.narrow_op == 0)
+    return {};
+
+  // CDNA4's wide-K F16 forms double the K dimension by doubling each contiguous
+  // A/B VGPR source window. CDNA3 has the same output layout for the narrower-K
+  // forms, so the lowering emits two narrow MFMAs over the low and high halves
+  // of the source windows:
+  //
+  //   partial = mfma_narrow(A[0:1], B[0:1], C)
+  //   D       = mfma_narrow(A[2:3], B[2:3], partial)
+  //
+  // When D is an AccVGPR destination, `partial` is the final destination and the
+  // second instruction reads it back through src2. CDNA3 resolves src2 encodings
+  // 256-511 to the AccVGPR bank when acc_cd=1. When D is an ordinary VGPR
+  // destination that overlaps either full A/B source window, the first MFMA must
+  // instead write a dead VGPR run; otherwise it could clobber source registers
+  // that the second MFMA has not read yet.
+  //
+  // NYI: non-default cbsz/abid/blgp/acc modifiers need validation against the
+  // two-instruction expansion before this can preserve them safely.
+  if (mfma.cbsz != 0 || mfma.abid != 0 || mfma.blgp != 0 || mfma.acc != 0)
+    return {};
+  // SRC0/SRC1 are OPR_SRC_VGPR_OR_ACCVGPR operands. The ISA defines the CDNA4
+  // wide forms as 128-bit source windows and the CDNA3 narrow forms as 64-bit
+  // source windows; the operand value is the base of that contiguous window, and
+  // 64-bit-or-wider VGPR/AccVGPR operands are even-aligned by the ISA. Since this
+  // rule rejects ACC-selected A/B sources above and assumes the original CDNA4
+  // instruction is well-formed, the split can use src and src + narrow_src_regs
+  // directly without a packing step.
+  // The original accumulator is only consumed by the first narrow MFMA; the
+  // second consumes the partial accumulator produced by the first. Forward src2
+  // unchanged and rely on the original CDNA4 instruction being well-formed.
+  // VDST has the same operand size in the CDNA4 wide form and the emitted CDNA3
+  // narrow form. Forward the original destination base and acc_cd; destination
+  // window validity is part of the source instruction's ISA contract.
+
+  const bool needs_scratch = wide_mfma_needs_partial_accum_scratch(mfma, lowering);
+  uint8_t partial_vdst = static_cast<uint8_t>(mfma.vdst);
+  uint16_t partial_src2 = static_cast<uint16_t>(256 + mfma.vdst);
+  if (needs_scratch) {
+    std::optional<uint16_t> scratch =
+        find_free_vgpr_run_below(liveness, inst, lowering.dst_regs, 0, kSemanticScratchVgprLimit);
+    // NYI: if no dead VGPR run exists, the general solution is to spill a live
+    // VGPR range and use it for the partial accumulator. That waits on spill
+    // manager integration, so reject for now rather than clobbering live inputs.
+    if (!scratch)
+      return {};
+    partial_vdst = static_cast<uint8_t>(*scratch);
+    partial_src2 = static_cast<uint16_t>(256 + partial_vdst);
+  }
+
+  std::vector<uint32_t> words;
+  if (needs_scratch) {
+    emit_cdna3_mfma_to_vgpr(words, lowering.narrow_op, mfma, partial_vdst,
+                            static_cast<uint16_t>(mfma.src0), static_cast<uint16_t>(mfma.src1),
+                            static_cast<uint16_t>(mfma.src2));
+  } else {
+    emit_cdna3_mfma(words, lowering.narrow_op, mfma, static_cast<uint16_t>(mfma.src0),
+                    static_cast<uint16_t>(mfma.src1), static_cast<uint16_t>(mfma.src2));
+  }
+  emit_cdna3_mfma(words, lowering.narrow_op, mfma,
+                  static_cast<uint16_t>(mfma.src0 + lowering.narrow_src_regs),
+                  static_cast<uint16_t>(mfma.src1 + lowering.narrow_src_regs), partial_src2);
+  return words;
+}
+
+// -----------------------------------------------------------------------------
+// DS transpose expansions.
+// -----------------------------------------------------------------------------
+
+void emit_cdna3_b16_transpose_halfword(std::vector<uint32_t> &words, uint8_t halfword_dst,
+                                       uint8_t gather_tmp, uint8_t lane_byte_addr, uint8_t raw_lo,
+                                       uint8_t raw_hi, uint8_t halfword_selector) {
+  emit_cdna3_ds(words, kCdna3DsOpBpermuteB32, halfword_dst, lane_byte_addr, raw_lo);
+  emit_cdna3_ds(words, kCdna3DsOpBpermuteB32, gather_tmp, lane_byte_addr, raw_hi);
+  emit_cdna3_lgkm_wait(words);
+  emit_cdna3_vop3(words, kCdna3OpPermB32, halfword_dst, vgpr_src(gather_tmp),
+                  vgpr_src(halfword_dst), vgpr_src(halfword_selector));
+}
+
+void emit_cdna3_pack_low_b16_pair(std::vector<uint32_t> &words, uint8_t dst, uint8_t halfword_lo,
+                                  uint8_t halfword_hi, uint8_t shifted_hi_tmp, uint8_t mask_tmp) {
+  // Pack the low 16 bits of two VGPR values into a raw 32-bit payload. This is
+  // not an FP16 conversion; `v_pack_b32_f16` can canonicalize/change FP
+  // payloads, so build the packed destination with integer operations:
+  //
+  //   dst = (halfword_hi[15:0] << 16) | halfword_lo[15:0]
+  //
+  // CDNA3 cannot inline 0xffff as a VALU source, so synthesize the mask from
+  // -1 >> 16. The helper may clobber halfword_lo, shifted_hi_tmp, and mask_tmp.
+  emit_cdna3_vop3(words, kCdna3OpMovB32, mask_tmp, kInlineConstNeg1);
+  emit_cdna3_vop3(words, kCdna3OpLshrrevB32, mask_tmp, scalar_positive_inline_u32(16),
+                  vgpr_src(mask_tmp));
+  emit_cdna3_vop3(words, kCdna3OpAndB32, halfword_lo, vgpr_src(mask_tmp), vgpr_src(halfword_lo));
+  emit_cdna3_vop3(words, kCdna3OpAndB32, shifted_hi_tmp, vgpr_src(mask_tmp), vgpr_src(halfword_hi));
+  emit_cdna3_vop3(words, kCdna3OpLshlrevB32, shifted_hi_tmp, scalar_positive_inline_u32(16),
+                  vgpr_src(shifted_hi_tmp));
+  emit_cdna3_vop3(words, kCdna3OpOrB32, dst, vgpr_src(halfword_lo), vgpr_src(shifted_hi_tmp));
+}
+
+std::vector<uint32_t> lower_ds_read_b64_tr_b16_cdna4_to_cdna3(const Instruction &inst,
+                                                              const LivenessAnalysis &liveness) {
+  const auto *raw = inst.raw_encoding();
+  if (!raw || static_cast<size_t>(inst.size()) < sizeof(cdna4::DsMachineInst))
+    return {};
+
+  cdna4::DsMachineInst src{};
+  std::memcpy(&src, raw, sizeof(src));
+  if (src.gds != 0)
+    // CDNA4 DS encodings can select GDS, but CDNA3 reserves GDS=1 for this
+    // instruction. Do not translate that variant into an illegal CDNA3 encoding.
+    return {};
+  if (src.acc != 0)
+    // DS ACC redirects VDST into the AccVGPR file. This lowering rebuilds the
+    // result with ordinary VALU writes, so AccVGPR destinations need a separate
+    // implementation before they can be translated safely.
+    return {};
+
+  const uint8_t vdst = static_cast<uint8_t>(src.vdst);
+  const uint8_t addr = static_cast<uint8_t>(src.addr);
+  // VDST is a 64-bit destination, so it names a contiguous two-register pair.
+  // Pair validity is part of the source instruction's ISA contract.
+
+  constexpr uint16_t kScratchCount = 8;
+  uint16_t scratch_start =
+      std::max<uint16_t>(static_cast<uint16_t>(vdst + 2), static_cast<uint16_t>(addr + 1));
+  if ((scratch_start & 1) != 0)
+    ++scratch_start;
+
+  std::optional<uint16_t> scratch;
+  // The pack helper wants several even/odd register relationships to stay
+  // simple, so search only for an even-aligned run. If liveness first reports
+  // an odd free run, advance past it and keep looking instead of accepting a
+  // scratch layout that would make the emitted DS transpose sequence harder to
+  // reason about.
+  for (uint16_t search = scratch_start; search + kScratchCount <= kSemanticScratchVgprLimit;) {
+    auto candidate =
+        find_free_vgpr_run_below(liveness, inst, kScratchCount, search, kSemanticScratchVgprLimit);
+    if (!candidate)
+      break;
+    if ((*candidate & 1) == 0) {
+      scratch = candidate;
+      break;
+    }
+    search = static_cast<uint16_t>(*candidate + 1);
+    if ((search & 1) != 0)
+      ++search;
+  }
+  if (!scratch)
+    return {};
+
+  const uint8_t raw_lo = static_cast<uint8_t>(*scratch + 0);
+  const uint8_t raw_hi = static_cast<uint8_t>(*scratch + 1);
+  const uint8_t lane_base = static_cast<uint8_t>(*scratch + 2);
+  const uint8_t halfword_selector = static_cast<uint8_t>(*scratch + 3);
+  const uint8_t tmp = static_cast<uint8_t>(*scratch + 4);
+  const uint8_t halfword_lo = static_cast<uint8_t>(*scratch + 5);
+  const uint8_t halfword_hi = static_cast<uint8_t>(*scratch + 6);
+  const uint8_t gather_tmp = static_cast<uint8_t>(*scratch + 7);
+
+  std::vector<uint32_t> words;
+
+  // CDNA4 ds_read_b64_tr_b16 loads four transposed halfwords per lane from the
+  // LDS read footprint. CDNA3 only has the non-transposed ds_read_b64, so the
+  // expansion reconstructs the transposed result through the DS crossbar:
+  //
+  //   raw_lo:raw_hi = ds_read_b64(addr, offset0, offset1)
+  //   lane          = mbcnt(exec)
+  //   selector      = ((lane & 3) * 2) | (((lane & 3) * 2 + 1) << 8)
+  //   lane_base     = ((lane & 0x30) << 2) | (lane & 0x0c)
+  //   h0            = halfword_at(lane_base +  0, selector, raw_lo, raw_hi)
+  //   h1            = halfword_at(lane_base + 16, selector, raw_lo, raw_hi)
+  //   h2            = halfword_at(lane_base + 32, selector, raw_lo, raw_hi)
+  //   h3            = halfword_at(lane_base + 48, selector, raw_lo, raw_hi)
+  //   vdst          = pack_u16_pair(h0, h1)
+  //   vdst+1        = pack_u16_pair(h2, h3)
+  //
+  // halfword_at() is emitted as two ds_bpermute_b32 operations followed by
+  // v_perm_b32 so the selector can choose the required halfword from either
+  // 32-bit half of the original b64 read. pack_u16_pair() is deliberately
+  // integer mask/shift/or instead of v_pack_b32_f16 because this DS op moves
+  // raw 16-bit payloads, not FP16 values.
+  emit_cdna3_ds(words, kCdna3DsOpReadB64, raw_lo, addr, 0, 0, src.offset0, src.offset1);
+  emit_cdna3_lgkm_wait(words);
+
+  emit_cdna3_vop3(words, kCdna3OpMbcntLoU32B32, tmp, kInlineConstNeg1, kInlineConst0);
+  emit_cdna3_vop3(words, kCdna3OpMbcntHiU32B32, tmp, kInlineConstNeg1, vgpr_src(tmp));
+
+  // Build the ds_bpermute byte addresses that recover each halfword in the
+  // transposed 4x16-lane pattern, then pack pairs of halfwords back into the
+  // two 32-bit destination registers produced by ds_read_b64_tr_b16.
+  emit_cdna3_vop3(words, kCdna3OpAndB32, halfword_selector, scalar_positive_inline_u32(3),
+                  vgpr_src(tmp));
+  emit_cdna3_vop3(words, kCdna3OpLshlrevB32, halfword_selector, scalar_positive_inline_u32(1),
+                  vgpr_src(halfword_selector));
+
+  emit_cdna3_vop3(words, kCdna3OpAndB32, lane_base, scalar_positive_inline_u32(0x30),
+                  vgpr_src(tmp));
+  emit_cdna3_vop3(words, kCdna3OpLshlrevB32, lane_base, scalar_positive_inline_u32(2),
+                  vgpr_src(lane_base));
+  emit_cdna3_vop3(words, kCdna3OpAndB32, tmp, scalar_positive_inline_u32(0x0c), vgpr_src(tmp));
+  emit_cdna3_vop3(words, kCdna3OpOrB32, lane_base, vgpr_src(lane_base), vgpr_src(tmp));
+
+  emit_cdna3_vop3(words, kCdna3OpAddU32, tmp, scalar_positive_inline_u32(1),
+                  vgpr_src(halfword_selector));
+  emit_cdna3_vop3(words, kCdna3OpLshlrevB32, tmp, scalar_positive_inline_u32(8), vgpr_src(tmp));
+  emit_cdna3_vop3(words, kCdna3OpOrB32, halfword_selector, vgpr_src(halfword_selector),
+                  vgpr_src(tmp));
+
+  emit_cdna3_b16_transpose_halfword(words, halfword_lo, gather_tmp, lane_base, raw_lo, raw_hi,
+                                    halfword_selector);
+  emit_cdna3_vop3(words, kCdna3OpAddU32, tmp, scalar_positive_inline_u32(16), vgpr_src(lane_base));
+  emit_cdna3_b16_transpose_halfword(words, halfword_hi, gather_tmp, tmp, raw_lo, raw_hi,
+                                    halfword_selector);
+  emit_cdna3_pack_low_b16_pair(words, vdst, halfword_lo, halfword_hi, tmp, gather_tmp);
+
+  emit_cdna3_vop3(words, kCdna3OpAddU32, tmp, scalar_positive_inline_u32(32), vgpr_src(lane_base));
+  emit_cdna3_b16_transpose_halfword(words, halfword_lo, gather_tmp, tmp, raw_lo, raw_hi,
+                                    halfword_selector);
+  emit_cdna3_vop3(words, kCdna3OpAddU32, tmp, scalar_positive_inline_u32(48), vgpr_src(lane_base));
+  emit_cdna3_b16_transpose_halfword(words, halfword_hi, gather_tmp, tmp, raw_lo, raw_hi,
+                                    halfword_selector);
+  emit_cdna3_pack_low_b16_pair(words, static_cast<uint8_t>(vdst + 1), halfword_lo, halfword_hi, tmp,
+                               gather_tmp);
+
+  return words;
+}
+
+std::vector<uint32_t> expand_v_bitop3_b16_cdna4_to_cdna3(const Instruction &inst, uint32_t,
+                                                         uint64_t, const LivenessAnalysis &liveness,
+                                                         const LaneLayout *, const LaneLayout *) {
+  // The rule table only routes V_BITOP3_B16 here, so use the generated
+  // instruction type directly instead of re-decoding ordinary operands.
+  return lower_cdna4_bitop3_to_cdna3(static_cast<const cdna4::VBitop3B16Vop3 &>(inst), liveness,
+                                     true);
+}
+
+std::vector<uint32_t> expand_v_bitop3_b32_cdna4_to_cdna3(const Instruction &inst, uint32_t,
+                                                         uint64_t, const LivenessAnalysis &liveness,
+                                                         const LaneLayout *, const LaneLayout *) {
+  // The rule table only routes V_BITOP3_B32 here, so use the generated
+  // instruction type directly instead of re-decoding ordinary operands.
+  return lower_cdna4_bitop3_to_cdna3(static_cast<const cdna4::VBitop3B32Vop3 &>(inst), liveness,
+                                     false);
+}
+
+std::vector<uint32_t> expand_ds_read_b64_tr_b16_cdna4_to_cdna3(const Instruction &inst, uint32_t,
+                                                               uint64_t,
+                                                               const LivenessAnalysis &liveness,
+                                                               const LaneLayout *,
+                                                               const LaneLayout *) {
+  return lower_ds_read_b64_tr_b16_cdna4_to_cdna3(inst, liveness);
+}
+
+std::vector<uint32_t> expand_mfma_f32_16x16x32_f16_cdna4_to_cdna3(const Instruction &inst, uint32_t,
+                                                                  uint64_t,
+                                                                  const LivenessAnalysis &liveness,
+                                                                  const LaneLayout *,
+                                                                  const LaneLayout *) {
+  return lower_wide_k_mfma_f16_cdna4_to_cdna3(inst, liveness, WideKMfmaShape::F32_16x16x32_F16);
+}
+
+std::vector<uint32_t> expand_mfma_f32_32x32x16_f16_cdna4_to_cdna3(const Instruction &inst, uint32_t,
+                                                                  uint64_t,
+                                                                  const LivenessAnalysis &liveness,
+                                                                  const LaneLayout *,
+                                                                  const LaneLayout *) {
+  return lower_wide_k_mfma_f16_cdna4_to_cdna3(inst, liveness, WideKMfmaShape::F32_32x32x16_F16);
+}
+
+constexpr uint16_t kEncVop3 = 0x1A4;
+constexpr uint16_t kEncVop3pMfma = 0x1A7;
+constexpr uint16_t kEncDsReadB64TrB16 = 0x1B3;
+
+constexpr uint16_t kCdna4Op_v_mfma_f32_16x16x32_f16 = 84;
+constexpr uint16_t kCdna4Op_v_mfma_f32_32x32x16_f16 = 85;
+constexpr uint16_t kCdna4Op_v_bitop3_b16 = 563;
+constexpr uint16_t kCdna4Op_v_bitop3_b32 = 564;
+constexpr uint16_t kCdna4Op_ds_read_b64_tr_b16 = 227;
+
+// Table MUST be sorted by (src_encoding_id, src_opcode) for binary search.
+const TranslationRule kExpandRules_cdna4_to_cdna3[] = {
+    {kEncVop3, kCdna4Op_v_bitop3_b16, RuleAction::Expand, 0, 0, nullptr,
+     expand_v_bitop3_b16_cdna4_to_cdna3, nullptr, nullptr},
+    {kEncVop3, kCdna4Op_v_bitop3_b32, RuleAction::Expand, 0, 0, nullptr,
+     expand_v_bitop3_b32_cdna4_to_cdna3, nullptr, nullptr},
+    {kEncVop3pMfma, kCdna4Op_v_mfma_f32_16x16x32_f16, RuleAction::Expand, 0, 0, nullptr,
+     expand_mfma_f32_16x16x32_f16_cdna4_to_cdna3, nullptr, nullptr},
+    {kEncVop3pMfma, kCdna4Op_v_mfma_f32_32x32x16_f16, RuleAction::Expand, 0, 0, nullptr,
+     expand_mfma_f32_32x32x16_f16_cdna4_to_cdna3, nullptr, nullptr},
+    {kEncDsReadB64TrB16, kCdna4Op_ds_read_b64_tr_b16, RuleAction::Expand, 0, 0, nullptr,
+     expand_ds_read_b64_tr_b16_cdna4_to_cdna3, nullptr, nullptr},
+};
+
+} // namespace
+
+std::span<const TranslationRule> semantic_expand_rules_cdna4_to_cdna3() {
+  return std::span<const TranslationRule>(kExpandRules_cdna4_to_cdna3);
+}
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/cdna4_to_cdna3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/cdna4_to_cdna3.cpp
@@ -195,6 +195,7 @@ struct Bitop3Operands {
   uint8_t vdst = 0;
   uint16_t src[3]{};
   uint8_t truth_table = 0;
+  uint8_t op_sel = 0;
 };
 
 /// @brief Extract the overloaded V_BITOP3 truth table from a CDNA4 VOP3 pair.
@@ -214,6 +215,7 @@ struct Bitop3Operands {
   operands.src[0] = static_cast<uint16_t>(src.src0);
   operands.src[1] = static_cast<uint16_t>(src.src1);
   operands.src[2] = static_cast<uint16_t>(src.src2);
+  operands.op_sel = static_cast<uint8_t>(src.op_sel);
   operands.truth_table =
       static_cast<uint8_t>(((src.omod & 0x3) << 6) | ((src.abs & 0x7) << 3) | (src.neg & 0x7));
   return operands;
@@ -276,6 +278,11 @@ std::vector<uint32_t> lower_cdna4_bitop3_to_cdna3(const Instruction &inst,
   if (!decoded)
     return {};
   const Bitop3Operands &op = *decoded;
+  if (is_b16 && op.op_sel != 0)
+    // OP_SEL selects B16 source/destination halves. The current expansion only
+    // models the canonical low-half form, so reject other encodings rather than
+    // silently translating them as OP_SEL=0.
+    return {};
   const auto coeff = bitop3_anf_coefficients(op.truth_table);
 
   const bool needs_acc_temp = vdst_aliases_any_vgpr_source(op.vdst, op.src);
@@ -538,6 +545,11 @@ std::vector<uint32_t> lower_ds_read_b64_tr_b16_cdna4_to_cdna3(const Instruction 
   cdna4::DsMachineInst src{};
   std::memcpy(&src, raw, sizeof(src));
   if (src.gds != 0)
+    return {};
+  if (src.acc != 0)
+    // DS ACC redirects VDST into the AccVGPR file. This lowering rebuilds the
+    // result with ordinary VALU writes, so AccVGPR destinations need a separate
+    // implementation before they can be translated safely.
     return {};
 
   const uint8_t vdst = static_cast<uint8_t>(src.vdst);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/cdna4_to_cdna3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/cdna4_to_cdna3.cpp
@@ -10,6 +10,7 @@
 #include "rocjitsu/code/patch/instruction_builder.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna3/machine_insts.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna4/machine_insts.h"
+#include "rocjitsu/isa/arch/amdgpu/cdna4/vop3.h"
 #include "rocjitsu/isa/instruction.h"
 
 #include <algorithm>
@@ -175,51 +176,25 @@ void emit_cdna3_mfma_to_vgpr(std::vector<uint32_t> &words, uint8_t op,
   words.push_back(w1);
 }
 
+/// @brief Find a dead contiguous VGPR run that stays below a semantic scratch limit.
+/// @details This wraps LivenessAnalysis::find_free_run() for semantic lowerings
+/// that must allocate temporary VGPRs inside the descriptor headroom reserved by
+/// the DBT pipeline. The returned base is at or after @p search_start and the
+/// half-open run [base, base + @p count) is guaranteed not to cross @p limit.
+/// @returns The first matching VGPR base, or std::nullopt if no suitable run is
+/// available before @p limit.
 [[nodiscard]] std::optional<uint16_t>
 find_free_vgpr_run_below(const LivenessAnalysis &liveness, const Instruction &inst, uint16_t count,
                          uint16_t search_start, uint16_t limit) {
-  for (uint16_t search = search_start; search + count <= limit;) {
-    auto candidate = liveness.find_free_run(&inst, count, search);
-    if (!candidate || *candidate + count > limit)
-      return std::nullopt;
-    return candidate;
-  }
-  return std::nullopt;
+  auto candidate = liveness.find_free_run(&inst, count, search_start);
+  if (!candidate || *candidate + count > limit)
+    return std::nullopt;
+  return candidate;
 }
 
 // -----------------------------------------------------------------------------
 // V_BITOP3 expansions.
 // -----------------------------------------------------------------------------
-
-struct Bitop3Operands {
-  uint8_t vdst = 0;
-  uint16_t src[3]{};
-  uint8_t truth_table = 0;
-  uint8_t op_sel = 0;
-};
-
-/// @brief Extract the overloaded V_BITOP3 truth table from a CDNA4 VOP3 pair.
-/// @details TTBL is encoded in normal VOP3 modifier fields:
-/// {OMOD[1:0], ABS[2:0], NEG[2:0]}. For V_BITOP3 those fields are data bits,
-/// not arithmetic modifiers.
-[[nodiscard]] std::optional<Bitop3Operands> decode_cdna4_bitop3(const Instruction &inst) {
-  const auto *raw = inst.raw_encoding();
-  if (!raw || static_cast<size_t>(inst.size()) < sizeof(cdna4::Vop3MachineInst))
-    return std::nullopt;
-
-  cdna4::Vop3MachineInst src{};
-  std::memcpy(&src, raw, sizeof(src));
-
-  Bitop3Operands operands;
-  operands.vdst = static_cast<uint8_t>(src.vdst);
-  operands.src[0] = static_cast<uint16_t>(src.src0);
-  operands.src[1] = static_cast<uint16_t>(src.src1);
-  operands.src[2] = static_cast<uint16_t>(src.src2);
-  operands.op_sel = static_cast<uint8_t>(src.op_sel);
-  operands.truth_table =
-      static_cast<uint8_t>(((src.omod & 0x3) << 6) | ((src.abs & 0x7) << 3) | (src.neg & 0x7));
-  return operands;
-}
 
 /// @brief Convert the 3-input truth table into algebraic-normal-form coefficients.
 /// @details Truth-table bit index is {S0[i], S1[i], S2[i]}: bit 2 is S0, bit 1
@@ -238,7 +213,8 @@ struct Bitop3Operands {
   return coeff;
 }
 
-[[nodiscard]] bool vdst_aliases_any_vgpr_source(uint8_t vdst, const uint16_t src[3]) {
+[[nodiscard]] bool vdst_aliases_any_vgpr_source(uint8_t vdst,
+                                                const std::array<uint16_t, 3> &src) {
   const uint16_t encoded_vdst = static_cast<uint16_t>(256 + vdst);
   return src[0] == encoded_vdst || src[1] == encoded_vdst || src[2] == encoded_vdst;
 }
@@ -251,7 +227,8 @@ struct Bitop3Operands {
   return false;
 }
 
-std::vector<uint32_t> lower_cdna4_bitop3_to_cdna3(const Instruction &inst,
+template <typename Bitop3Inst>
+std::vector<uint32_t> lower_cdna4_bitop3_to_cdna3(const Bitop3Inst &inst,
                                                   const LivenessAnalysis &liveness, bool is_b16) {
   // V_BITOP3 is a three-input bitwise LUT. CDNA4 encodes the eight LUT bits in
   // VOP3 modifier fields; CDNA3 has no equivalent instruction, so the lowering
@@ -269,43 +246,56 @@ std::vector<uint32_t> lower_cdna4_bitop3_to_cdna3(const Instruction &inst,
   //          ^ coeff[7] & S0 & S1 & S2
   //
   // Multiplication in that expression is bitwise AND, addition is XOR, and a
-  // constant one term is materialized as -1 so every lane bit sees true. If the
-  // destination aliases an input VGPR, the accumulator is placed in scratch and
-  // copied back at the end. Product terms with two or three inputs use one more
-  // scratch VGPR as the running AND. The B16 form computes the same 32-bit LUT
-  // then clears the high half with a left/right shift pair.
-  auto decoded = decode_cdna4_bitop3(inst);
-  if (!decoded)
-    return {};
-  const Bitop3Operands &op = *decoded;
-  if (is_b16 && op.op_sel != 0)
-    // OP_SEL selects B16 source/destination halves. The current expansion only
-    // models the canonical low-half form, so reject other encodings rather than
-    // silently translating them as OP_SEL=0.
-    return {};
-  const auto coeff = bitop3_anf_coefficients(op.truth_table);
+  // constant one term is materialized as -1 so every lane bit sees true. The B16
+  // form computes the same 32-bit LUT, then clears the high half with a
+  // left/right shift pair.
+  const uint8_t vdst = static_cast<uint8_t>(inst.vdst.encoding_value());
+  const std::array<uint16_t, 3> src = {static_cast<uint16_t>(inst.src0.encoding_value()),
+                                       static_cast<uint16_t>(inst.src1.encoding_value()),
+                                       static_cast<uint16_t>(inst.src2.encoding_value())};
 
-  const bool needs_acc_temp = vdst_aliases_any_vgpr_source(op.vdst, op.src);
+  if (is_b16 && inst.inst_.op_sel != 0)
+    // NYI: OP_SEL selects B16 source/destination halves. Source-half selection
+    // can be lowered by shifting selected high halves down before the LUT, but
+    // OP_SEL[3] is read-modify-write: it writes the high half of vdst while
+    // preserving the old low half. The generated operand metadata currently
+    // treats vdst only as a destination, so liveness may allocate vdst as
+    // scratch and clobber the implicit source value. Until that implicit vdst
+    // read is modeled, only lower the canonical OP_SEL=0 form instead of
+    // silently producing wrong code.
+    return {};
+  // V_BITOP3 overloads VOP3 modifier fields as TTBL bits instead of ordinary
+  // arithmetic modifiers: {OMOD[1:0], ABS[2:0], NEG[2:0]}.
+  const uint8_t truth_table = static_cast<uint8_t>(((inst.inst_.omod & 0x3) << 6) |
+                                                   ((inst.inst_.abs & 0x7) << 3) |
+                                                   (inst.inst_.neg & 0x7));
+  const auto coeff = bitop3_anf_coefficients(truth_table);
+
+  const bool needs_acc_temp = vdst_aliases_any_vgpr_source(vdst, src);
   const bool needs_term_temp = bitop3_needs_product_term(coeff);
-  const uint16_t scratch_count =
-      static_cast<uint16_t>((needs_acc_temp ? 1 : 0) + (needs_term_temp ? 1 : 0));
 
-  uint8_t acc = op.vdst;
+  // Scratch policy:
+  //   - No product terms and no vdst/source alias: use vdst as the accumulator.
+  //   - vdst/source alias only: use one scratch accumulator, then copy to vdst.
+  //   - Any product term: use two scratch VGPRs, one accumulator and one AND
+  //     term. This keeps the generated sequence simple and prevents the AND temp
+  //     from aliasing the accumulator. Liveness may choose vdst as scratch when
+  //     vdst is dead before the original instruction; that is fine because the
+  //     final result still lands in vdst.
+  const uint16_t scratch_count =
+      needs_term_temp ? 2 : static_cast<uint16_t>(needs_acc_temp ? 1 : 0);
+
+  uint8_t acc = vdst;
   uint8_t term = 0;
   if (scratch_count != 0) {
-    auto scratch = find_free_vgpr_run_below(liveness, inst, scratch_count, op.vdst + 1,
+    auto scratch = find_free_vgpr_run_below(liveness, inst, scratch_count, 0,
                                             kSemanticScratchVgprLimit);
-    if (!scratch)
-      scratch =
-          find_free_vgpr_run_below(liveness, inst, scratch_count, 0, kSemanticScratchVgprLimit);
     if (!scratch)
       return {};
 
-    uint16_t next = *scratch;
-    if (needs_acc_temp)
-      acc = static_cast<uint8_t>(next++);
+    acc = static_cast<uint8_t>(*scratch);
     if (needs_term_temp)
-      term = static_cast<uint8_t>(next++);
+      term = static_cast<uint8_t>(*scratch + 1);
   }
 
   std::vector<uint32_t> words;
@@ -313,11 +303,11 @@ std::vector<uint32_t> lower_cdna4_bitop3_to_cdna3(const Instruction &inst,
   auto src_for_variable = [&](uint8_t variable_mask) -> uint16_t {
     switch (variable_mask) {
     case 4:
-      return op.src[0];
+      return src[0];
     case 2:
-      return op.src[1];
+      return src[1];
     default:
-      return op.src[2];
+      return src[2];
     }
   };
 
@@ -368,13 +358,16 @@ std::vector<uint32_t> lower_cdna4_bitop3_to_cdna3(const Instruction &inst,
     emit_mov(acc, kInlineConst0);
 
   if (is_b16) {
+    // The B16 form writes a zero-extended low half. Shift left then logical
+    // shift right to clear bits 31:16 without needing a separate 0xffff mask,
+    // which CDNA3 cannot encode as an inline VALU operand.
     const uint16_t shift16 = scalar_positive_inline_u32(16);
     emit_cdna3_vop3(words, kCdna3OpLshlrevB32, acc, shift16, vgpr_src(acc));
     emit_cdna3_vop3(words, kCdna3OpLshrrevB32, acc, shift16, vgpr_src(acc));
   }
 
-  if (acc != op.vdst)
-    emit_mov(op.vdst, vgpr_src(acc));
+  if (acc != vdst)
+    emit_mov(vdst, vgpr_src(acc));
 
   return words;
 }
@@ -406,14 +399,6 @@ struct WideKMfmaLowering {
   return {shape, 0, 0, 0, 0};
 }
 
-[[nodiscard]] bool is_arch_vgpr_run(uint16_t src, uint8_t regs) {
-  return src >= 256 && src + regs <= 512;
-}
-
-[[nodiscard]] bool is_even_aligned_arch_vgpr_run(uint16_t src, uint8_t regs) {
-  return is_arch_vgpr_run(src, regs) && ((src - 256) % 2 == 0);
-}
-
 [[nodiscard]] bool ranges_overlap(uint16_t lhs_base, uint16_t lhs_count, uint16_t rhs_base,
                                   uint16_t rhs_count) {
   return lhs_base < rhs_base + rhs_count && rhs_base < lhs_base + lhs_count;
@@ -421,9 +406,9 @@ struct WideKMfmaLowering {
 
 [[nodiscard]] bool wide_mfma_needs_partial_accum_scratch(const cdna4::Vop3pMfmaMachineInst &mfma,
                                                          const WideKMfmaLowering &lowering) {
-  // acc_cd=1 writes the AccVGPR bank, while the accepted A/B operands below are
-  // ordinary VGPR operands encoded as 256-511. That bank separation means the
-  // first partial MFMA cannot clobber the A/B registers needed by the second.
+  // acc_cd=1 writes the AccVGPR bank. Because this lowering currently rejects
+  // ACC-selected A/B sources, the original A/B operands are ordinary VGPRs and
+  // cannot be clobbered by an AccVGPR partial accumulator.
   if (mfma.acc_cd != 0)
     return false;
 
@@ -457,23 +442,28 @@ std::vector<uint32_t> lower_wide_k_mfma_f16_cdna4_to_cdna3(const Instruction &in
   //
   // When D is an AccVGPR destination, `partial` is the final destination and the
   // second instruction reads it back through src2. CDNA3 resolves src2 encodings
-  // 256-511 to the AccVGPR bank when acc_cd=1, which keeps the emitted encoding
-  // identical to the Triton pattern this rule was introduced for. When D is an
-  // ordinary VGPR destination that overlaps either full A/B source window, the
-  // first MFMA must instead write a dead VGPR run; otherwise it could clobber
-  // source registers that the second MFMA has not read yet.
+  // 256-511 to the AccVGPR bank when acc_cd=1. When D is an ordinary VGPR
+  // destination that overlaps either full A/B source window, the first MFMA must
+  // instead write a dead VGPR run; otherwise it could clobber source registers
+  // that the second MFMA has not read yet.
+  //
+  // NYI: non-default cbsz/abid/blgp/acc modifiers need validation against the
+  // two-instruction expansion before this can preserve them safely.
   if (mfma.cbsz != 0 || mfma.abid != 0 || mfma.blgp != 0 || mfma.acc != 0)
     return {};
-  const uint16_t src2 = static_cast<uint16_t>(mfma.src2);
-  const bool src2_is_acc_window =
-      src2 >= 256 && static_cast<uint16_t>(src2 + lowering.dst_regs) <= 512;
-  if (src2 != kInlineConst0 && !src2_is_acc_window)
-    return {};
-  if (!is_even_aligned_arch_vgpr_run(static_cast<uint16_t>(mfma.src0), lowering.wide_src_regs) ||
-      !is_even_aligned_arch_vgpr_run(static_cast<uint16_t>(mfma.src1), lowering.wide_src_regs))
-    return {};
-  if (static_cast<uint16_t>(mfma.vdst) + lowering.dst_regs > 256)
-    return {};
+  // SRC0/SRC1 are OPR_SRC_VGPR_OR_ACCVGPR operands. The ISA defines the CDNA4
+  // wide forms as 128-bit source windows and the CDNA3 narrow forms as 64-bit
+  // source windows; the operand value is the base of that contiguous window, and
+  // 64-bit-or-wider VGPR/AccVGPR operands are even-aligned by the ISA. Since this
+  // rule rejects ACC-selected A/B sources above and assumes the original CDNA4
+  // instruction is well-formed, the split can use src and src + narrow_src_regs
+  // directly without a packing step.
+  // The original accumulator is only consumed by the first narrow MFMA; the
+  // second consumes the partial accumulator produced by the first. Forward src2
+  // unchanged and rely on the original CDNA4 instruction being well-formed.
+  // VDST has the same operand size in the CDNA4 wide form and the emitted CDNA3
+  // narrow form. Forward the original destination base and acc_cd; destination
+  // window validity is part of the source instruction's ISA contract.
 
   const bool needs_scratch = wide_mfma_needs_partial_accum_scratch(mfma, lowering);
   uint8_t partial_vdst = static_cast<uint8_t>(mfma.vdst);
@@ -481,6 +471,9 @@ std::vector<uint32_t> lower_wide_k_mfma_f16_cdna4_to_cdna3(const Instruction &in
   if (needs_scratch) {
     std::optional<uint16_t> scratch =
         find_free_vgpr_run_below(liveness, inst, lowering.dst_regs, 0, kSemanticScratchVgprLimit);
+    // NYI: if no dead VGPR run exists, the general solution is to spill a live
+    // VGPR range and use it for the partial accumulator. That waits on spill
+    // manager integration, so reject for now rather than clobbering live inputs.
     if (!scratch)
       return {};
     partial_vdst = static_cast<uint8_t>(*scratch);
@@ -545,6 +538,8 @@ std::vector<uint32_t> lower_ds_read_b64_tr_b16_cdna4_to_cdna3(const Instruction 
   cdna4::DsMachineInst src{};
   std::memcpy(&src, raw, sizeof(src));
   if (src.gds != 0)
+    // CDNA4 DS encodings can select GDS, but CDNA3 reserves GDS=1 for this
+    // instruction. Do not translate that variant into an illegal CDNA3 encoding.
     return {};
   if (src.acc != 0)
     // DS ACC redirects VDST into the AccVGPR file. This lowering rebuilds the
@@ -554,8 +549,8 @@ std::vector<uint32_t> lower_ds_read_b64_tr_b16_cdna4_to_cdna3(const Instruction 
 
   const uint8_t vdst = static_cast<uint8_t>(src.vdst);
   const uint8_t addr = static_cast<uint8_t>(src.addr);
-  if (src.vdst > 254)
-    return {};
+  // VDST is a 64-bit destination, so it names a contiguous two-register pair.
+  // Pair validity is part of the source instruction's ISA contract.
 
   constexpr uint16_t kScratchCount = 8;
   uint16_t scratch_start =
@@ -564,6 +559,11 @@ std::vector<uint32_t> lower_ds_read_b64_tr_b16_cdna4_to_cdna3(const Instruction 
     ++scratch_start;
 
   std::optional<uint16_t> scratch;
+  // The pack helper wants several even/odd register relationships to stay
+  // simple, so search only for an even-aligned run. If liveness first reports
+  // an odd free run, advance past it and keep looking instead of accepting a
+  // scratch layout that would make the emitted DS transpose sequence harder to
+  // reason about.
   for (uint16_t search = scratch_start; search + kScratchCount <= kSemanticScratchVgprLimit;) {
     auto candidate =
         find_free_vgpr_run_below(liveness, inst, kScratchCount, search, kSemanticScratchVgprLimit);
@@ -660,13 +660,19 @@ std::vector<uint32_t> lower_ds_read_b64_tr_b16_cdna4_to_cdna3(const Instruction 
 std::vector<uint32_t> expand_v_bitop3_b16_cdna4_to_cdna3(const Instruction &inst, uint32_t,
                                                          uint64_t, const LivenessAnalysis &liveness,
                                                          const LaneLayout *, const LaneLayout *) {
-  return lower_cdna4_bitop3_to_cdna3(inst, liveness, true);
+  // The rule table only routes V_BITOP3_B16 here, so use the generated
+  // instruction type directly instead of re-decoding ordinary operands.
+  return lower_cdna4_bitop3_to_cdna3(static_cast<const cdna4::VBitop3B16Vop3 &>(inst), liveness,
+                                     true);
 }
 
 std::vector<uint32_t> expand_v_bitop3_b32_cdna4_to_cdna3(const Instruction &inst, uint32_t,
                                                          uint64_t, const LivenessAnalysis &liveness,
                                                          const LaneLayout *, const LaneLayout *) {
-  return lower_cdna4_bitop3_to_cdna3(inst, liveness, false);
+  // The rule table only routes V_BITOP3_B32 here, so use the generated
+  // instruction type directly instead of re-decoding ordinary operands.
+  return lower_cdna4_bitop3_to_cdna3(static_cast<const cdna4::VBitop3B32Vop3 &>(inst), liveness,
+                                     false);
 }
 
 std::vector<uint32_t> expand_ds_read_b64_tr_b16_cdna4_to_cdna3(const Instruction &inst, uint32_t,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/cdna4_to_cdna3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/cdna4_to_cdna3.cpp
@@ -1,0 +1,714 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file semantic/cdna4_to_cdna3.cpp
+/// @brief CDNA4-to-CDNA3 handwritten semantic expansion rules.
+
+#include "rocjitsu/code/dbt/semantic/rules.h"
+
+#include "rocjitsu/analysis/liveness.h"
+#include "rocjitsu/code/patch/instruction_builder.h"
+#include "rocjitsu/isa/arch/amdgpu/cdna3/machine_insts.h"
+#include "rocjitsu/isa/arch/amdgpu/cdna4/machine_insts.h"
+#include "rocjitsu/isa/instruction.h"
+
+#include <algorithm>
+#include <array>
+#include <bit>
+#include <cstring>
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace rocjitsu {
+namespace {
+
+// CDNA3 instruction builders used by the narrow semantic rules below. These
+// helpers intentionally only cover the encodings the lowering emits; keeping
+// them local avoids adding a broad assembler abstraction for a handful of
+// code-cave sequences.
+
+[[nodiscard]] std::pair<uint32_t, uint32_t>
+build_cdna3_vop3(uint16_t op, uint8_t vdst, uint16_t src0, uint16_t src1 = 0, uint16_t src2 = 0) {
+  cdna3::Vop3MachineInst dst{};
+  dst.encoding = 0x34;
+  dst.op = op;
+  dst.vdst = vdst;
+  dst.src0 = src0 & 0x1FF;
+  dst.src1 = src1 & 0x1FF;
+  dst.src2 = src2 & 0x1FF;
+
+  uint32_t words[2]{};
+  std::memcpy(words, &dst, sizeof(dst));
+  return {words[0], words[1]};
+}
+
+/// @brief Build a CDNA3 VOP3P-MFMA instruction word pair.
+/// @details The wide-K lowering materializes A/B operands in ordinary VGPRs, so
+/// the emitted narrow MFMA clears the source ACC selector while preserving the
+/// destination AccVGPR selector from the CDNA4 instruction.
+[[nodiscard]] std::pair<uint32_t, uint32_t>
+build_cdna3_vop3p_mfma(uint8_t op, const cdna4::Vop3pMfmaMachineInst &src, uint8_t vdst,
+                       uint8_t acc_cd, uint16_t src0, uint16_t src1, uint16_t src2) {
+  cdna3::Vop3pMfmaMachineInst dst{};
+  dst.encoding = 0x1A7;
+  dst.op = op;
+  dst.vdst = vdst;
+  dst.cbsz = src.cbsz;
+  dst.abid = src.abid;
+  dst.acc_cd = acc_cd;
+  dst.src0 = src0 & 0x1FF;
+  dst.src1 = src1 & 0x1FF;
+  dst.src2 = src2 & 0x1FF;
+  dst.acc = 0;
+  dst.blgp = src.blgp;
+
+  uint32_t words[2]{};
+  std::memcpy(words, &dst, sizeof(dst));
+  return {words[0], words[1]};
+}
+
+[[nodiscard]] std::pair<uint32_t, uint32_t> build_cdna3_ds(uint8_t op, uint8_t vdst, uint8_t addr,
+                                                           uint8_t data0 = 0, uint8_t data1 = 0,
+                                                           uint8_t offset0 = 0,
+                                                           uint8_t offset1 = 0) {
+  cdna3::DsMachineInst dst{};
+  dst.encoding = 0x36;
+  dst.op = op;
+  dst.offset0 = offset0;
+  dst.offset1 = offset1;
+  dst.addr = addr;
+  dst.data0 = data0;
+  dst.data1 = data1;
+  dst.vdst = vdst;
+
+  uint32_t words[2]{};
+  std::memcpy(words, &dst, sizeof(dst));
+  return {words[0], words[1]};
+}
+
+[[nodiscard]] constexpr std::pair<uint32_t, uint32_t> build_s_mov_b32_lit(uint8_t sdst,
+                                                                          uint32_t literal) {
+  return {pack_sop1(0, sdst, 0xFF), literal};
+}
+
+constexpr uint8_t kExecLo = 126;
+constexpr uint16_t kInlineConst0 = 128;
+constexpr uint16_t kInlineConstNeg1 = 193;
+
+// BinaryTranslator currently reserves 128 VGPRs for all semantic lowerings.
+// Scratch allocation must remain inside that descriptor headroom until the DBT
+// pipeline grows per-lowering resource reporting.
+constexpr uint16_t kSemanticScratchVgprLimit = 128;
+
+// CDNA3 VOP3 opcodes used by the bitop3, wide-K, and DS transpose expansions.
+constexpr uint16_t kCdna3OpMovB32 = 321;
+constexpr uint16_t kCdna3OpLshrrevB32 = 272;
+constexpr uint16_t kCdna3OpLshlrevB32 = 274;
+constexpr uint16_t kCdna3OpAndB32 = 275;
+constexpr uint16_t kCdna3OpOrB32 = 276;
+constexpr uint16_t kCdna3OpXorB32 = 277;
+constexpr uint16_t kCdna3OpAddU32 = 308;
+constexpr uint16_t kCdna3OpPermB32 = 493;
+constexpr uint16_t kCdna3OpMbcntLoU32B32 = 652;
+constexpr uint16_t kCdna3OpMbcntHiU32B32 = 653;
+
+// CDNA3 VOP3P-MFMA opcodes used by CDNA4 wide-K MFMA expansion.
+constexpr uint8_t kCdna3OpMfmaF32_32x32x8F16 = 76;
+constexpr uint8_t kCdna3OpMfmaF32_16x16x16F16 = 77;
+
+// CDNA3 DS opcodes used to synthesize CDNA4 transposed LDS reads.
+constexpr uint8_t kCdna3DsOpBpermuteB32 = 63;
+constexpr uint8_t kCdna3DsOpReadB64 = 118;
+
+constexpr uint8_t kCdna3SoppOpWaitcnt = 12;
+constexpr uint16_t kCdnaWaitcntLgkmcnt0 = 0xC07F;
+
+void emit_cdna3_vop3(std::vector<uint32_t> &words, uint16_t op, uint8_t vdst, uint16_t src0,
+                     uint16_t src1 = 0, uint16_t src2 = 0) {
+  auto [w0, w1] = build_cdna3_vop3(op, vdst, src0, src1, src2);
+  words.push_back(w0);
+  words.push_back(w1);
+}
+
+void emit_cdna3_ds(std::vector<uint32_t> &words, uint8_t op, uint8_t vdst, uint8_t addr,
+                   uint8_t data0 = 0, uint8_t data1 = 0, uint8_t offset0 = 0, uint8_t offset1 = 0) {
+  auto [w0, w1] = build_cdna3_ds(op, vdst, addr, data0, data1, offset0, offset1);
+  words.push_back(w0);
+  words.push_back(w1);
+}
+
+void emit_cdna3_lgkm_wait(std::vector<uint32_t> &words) {
+  // GFX9/CDNA s_waitcnt encodes "lgkmcnt(0)" as lgkm=0 while leaving VM/EXP at
+  // their no-wait maxima. The DS read/bpermute sequences below require the
+  // loaded/permuted data before issuing dependent VALU instructions.
+  words.push_back(pack_sopp(kCdna3SoppOpWaitcnt, kCdnaWaitcntLgkmcnt0));
+}
+
+[[nodiscard]] constexpr uint16_t vgpr_src(uint8_t reg) { return static_cast<uint16_t>(256 + reg); }
+
+void emit_s_mov_b32_lit(std::vector<uint32_t> &words, uint8_t sdst, uint32_t literal) {
+  auto [w0, w1] = build_s_mov_b32_lit(sdst, literal);
+  words.push_back(w0);
+  words.push_back(w1);
+}
+
+[[maybe_unused]] void emit_cdna3_exec_mask(std::vector<uint32_t> &words, uint64_t mask) {
+  emit_s_mov_b32_lit(words, kExecLo, static_cast<uint32_t>(mask));
+  emit_s_mov_b32_lit(words, kExecLo + 1, static_cast<uint32_t>(mask >> 32));
+}
+
+void emit_cdna3_mfma(std::vector<uint32_t> &words, uint8_t op,
+                     const cdna4::Vop3pMfmaMachineInst &src, uint16_t src0, uint16_t src1,
+                     uint16_t src2) {
+  auto [w0, w1] = build_cdna3_vop3p_mfma(op, src, static_cast<uint8_t>(src.vdst),
+                                         static_cast<uint8_t>(src.acc_cd), src0, src1, src2);
+  words.push_back(w0);
+  words.push_back(w1);
+}
+
+void emit_cdna3_mfma_to_vgpr(std::vector<uint32_t> &words, uint8_t op,
+                             const cdna4::Vop3pMfmaMachineInst &src, uint8_t vdst, uint16_t src0,
+                             uint16_t src1, uint16_t src2) {
+  auto [w0, w1] = build_cdna3_vop3p_mfma(op, src, vdst, 0, src0, src1, src2);
+  words.push_back(w0);
+  words.push_back(w1);
+}
+
+[[nodiscard]] std::optional<uint16_t>
+find_free_vgpr_run_below(const LivenessAnalysis &liveness, const Instruction &inst, uint16_t count,
+                         uint16_t search_start, uint16_t limit) {
+  for (uint16_t search = search_start; search + count <= limit;) {
+    auto candidate = liveness.find_free_run(&inst, count, search);
+    if (!candidate || *candidate + count > limit)
+      return std::nullopt;
+    return candidate;
+  }
+  return std::nullopt;
+}
+
+// -----------------------------------------------------------------------------
+// V_BITOP3 expansions.
+// -----------------------------------------------------------------------------
+
+struct Bitop3Operands {
+  uint8_t vdst = 0;
+  uint16_t src[3]{};
+  uint8_t truth_table = 0;
+};
+
+/// @brief Extract the overloaded V_BITOP3 truth table from a CDNA4 VOP3 pair.
+/// @details TTBL is encoded in normal VOP3 modifier fields:
+/// {OMOD[1:0], ABS[2:0], NEG[2:0]}. For V_BITOP3 those fields are data bits,
+/// not arithmetic modifiers.
+[[nodiscard]] std::optional<Bitop3Operands> decode_cdna4_bitop3(const Instruction &inst) {
+  const auto *raw = inst.raw_encoding();
+  if (!raw || static_cast<size_t>(inst.size()) < sizeof(cdna4::Vop3MachineInst))
+    return std::nullopt;
+
+  cdna4::Vop3MachineInst src{};
+  std::memcpy(&src, raw, sizeof(src));
+
+  Bitop3Operands operands;
+  operands.vdst = static_cast<uint8_t>(src.vdst);
+  operands.src[0] = static_cast<uint16_t>(src.src0);
+  operands.src[1] = static_cast<uint16_t>(src.src1);
+  operands.src[2] = static_cast<uint16_t>(src.src2);
+  operands.truth_table =
+      static_cast<uint8_t>(((src.omod & 0x3) << 6) | ((src.abs & 0x7) << 3) | (src.neg & 0x7));
+  return operands;
+}
+
+/// @brief Convert the 3-input truth table into algebraic-normal-form coefficients.
+/// @details Truth-table bit index is {S0[i], S1[i], S2[i]}: bit 2 is S0, bit 1
+/// is S1, and bit 0 is S2. ANF lets CDNA3 synthesize the LUT from AND/XOR.
+[[nodiscard]] std::array<uint8_t, 8> bitop3_anf_coefficients(uint8_t truth_table) {
+  std::array<uint8_t, 8> coeff{};
+  for (uint8_t mask = 0; mask < coeff.size(); ++mask)
+    coeff[mask] = static_cast<uint8_t>((truth_table >> mask) & 0x1);
+
+  for (uint8_t variable_mask : {uint8_t{4}, uint8_t{2}, uint8_t{1}}) {
+    for (uint8_t mask = 0; mask < coeff.size(); ++mask) {
+      if ((mask & variable_mask) != 0)
+        coeff[mask] ^= coeff[mask ^ variable_mask];
+    }
+  }
+  return coeff;
+}
+
+[[nodiscard]] bool vdst_aliases_any_vgpr_source(uint8_t vdst, const uint16_t src[3]) {
+  const uint16_t encoded_vdst = static_cast<uint16_t>(256 + vdst);
+  return src[0] == encoded_vdst || src[1] == encoded_vdst || src[2] == encoded_vdst;
+}
+
+[[nodiscard]] bool bitop3_needs_product_term(const std::array<uint8_t, 8> &coeff) {
+  for (uint8_t mask = 1; mask < coeff.size(); ++mask) {
+    if (coeff[mask] != 0 && std::popcount(mask) >= 2)
+      return true;
+  }
+  return false;
+}
+
+std::vector<uint32_t> lower_cdna4_bitop3_to_cdna3(const Instruction &inst,
+                                                  const LivenessAnalysis &liveness, bool is_b16) {
+  // V_BITOP3 is a three-input bitwise LUT. CDNA4 encodes the eight LUT bits in
+  // VOP3 modifier fields; CDNA3 has no equivalent instruction, so the lowering
+  // emits the LUT as algebraic normal form over GF(2):
+  //
+  //   ttbl_index = (S0_bit << 2) | (S1_bit << 1) | S2_bit
+  //   coeff[] = mobius_transform(ttbl[])
+  //   result = coeff[0]
+  //          ^ coeff[1] & S2
+  //          ^ coeff[2] & S1
+  //          ^ coeff[3] & S1 & S2
+  //          ^ coeff[4] & S0
+  //          ^ coeff[5] & S0 & S2
+  //          ^ coeff[6] & S0 & S1
+  //          ^ coeff[7] & S0 & S1 & S2
+  //
+  // Multiplication in that expression is bitwise AND, addition is XOR, and a
+  // constant one term is materialized as -1 so every lane bit sees true. If the
+  // destination aliases an input VGPR, the accumulator is placed in scratch and
+  // copied back at the end. Product terms with two or three inputs use one more
+  // scratch VGPR as the running AND. The B16 form computes the same 32-bit LUT
+  // then clears the high half with a left/right shift pair.
+  auto decoded = decode_cdna4_bitop3(inst);
+  if (!decoded)
+    return {};
+  const Bitop3Operands &op = *decoded;
+  const auto coeff = bitop3_anf_coefficients(op.truth_table);
+
+  const bool needs_acc_temp = vdst_aliases_any_vgpr_source(op.vdst, op.src);
+  const bool needs_term_temp = bitop3_needs_product_term(coeff);
+  const uint16_t scratch_count =
+      static_cast<uint16_t>((needs_acc_temp ? 1 : 0) + (needs_term_temp ? 1 : 0));
+
+  uint8_t acc = op.vdst;
+  uint8_t term = 0;
+  if (scratch_count != 0) {
+    auto scratch = find_free_vgpr_run_below(liveness, inst, scratch_count, op.vdst + 1,
+                                            kSemanticScratchVgprLimit);
+    if (!scratch)
+      scratch =
+          find_free_vgpr_run_below(liveness, inst, scratch_count, 0, kSemanticScratchVgprLimit);
+    if (!scratch)
+      return {};
+
+    uint16_t next = *scratch;
+    if (needs_acc_temp)
+      acc = static_cast<uint8_t>(next++);
+    if (needs_term_temp)
+      term = static_cast<uint8_t>(next++);
+  }
+
+  std::vector<uint32_t> words;
+
+  auto src_for_variable = [&](uint8_t variable_mask) -> uint16_t {
+    switch (variable_mask) {
+    case 4:
+      return op.src[0];
+    case 2:
+      return op.src[1];
+    default:
+      return op.src[2];
+    }
+  };
+
+  auto emit_mov = [&](uint8_t dst, uint16_t src0) {
+    emit_cdna3_vop3(words, kCdna3OpMovB32, dst, src0);
+  };
+  auto emit_and = [&](uint8_t dst, uint16_t src0, uint16_t src1) {
+    emit_cdna3_vop3(words, kCdna3OpAndB32, dst, src0, src1);
+  };
+  auto emit_xor = [&](uint8_t dst, uint16_t src0, uint16_t src1) {
+    emit_cdna3_vop3(words, kCdna3OpXorB32, dst, src0, src1);
+  };
+
+  bool acc_initialized = false;
+  if (coeff[0] != 0) {
+    emit_mov(acc, kInlineConstNeg1);
+    acc_initialized = true;
+  }
+
+  for (uint8_t mask = 1; mask < coeff.size(); ++mask) {
+    if (coeff[mask] == 0)
+      continue;
+
+    std::array<uint16_t, 3> variables{};
+    uint8_t variable_count = 0;
+    for (uint8_t variable_mask : {uint8_t{4}, uint8_t{2}, uint8_t{1}}) {
+      if ((mask & variable_mask) != 0)
+        variables[variable_count++] = src_for_variable(variable_mask);
+    }
+
+    uint16_t term_src = variables[0];
+    if (variable_count >= 2) {
+      emit_and(term, variables[0], variables[1]);
+      if (variable_count == 3)
+        emit_and(term, vgpr_src(term), variables[2]);
+      term_src = vgpr_src(term);
+    }
+
+    if (!acc_initialized) {
+      emit_mov(acc, term_src);
+      acc_initialized = true;
+    } else {
+      emit_xor(acc, vgpr_src(acc), term_src);
+    }
+  }
+
+  if (!acc_initialized)
+    emit_mov(acc, kInlineConst0);
+
+  if (is_b16) {
+    const uint16_t shift16 = scalar_positive_inline_u32(16);
+    emit_cdna3_vop3(words, kCdna3OpLshlrevB32, acc, shift16, vgpr_src(acc));
+    emit_cdna3_vop3(words, kCdna3OpLshrrevB32, acc, shift16, vgpr_src(acc));
+  }
+
+  if (acc != op.vdst)
+    emit_mov(op.vdst, vgpr_src(acc));
+
+  return words;
+}
+
+// -----------------------------------------------------------------------------
+// Wide-K MFMA expansions.
+// -----------------------------------------------------------------------------
+
+enum class WideKMfmaShape {
+  F32_16x16x32_F16,
+  F32_32x32x16_F16,
+};
+
+struct WideKMfmaLowering {
+  WideKMfmaShape shape;
+  uint8_t narrow_op;
+  uint8_t dst_regs;
+  uint8_t wide_src_regs;
+  uint8_t narrow_src_regs;
+};
+
+[[nodiscard]] constexpr WideKMfmaLowering lowering_for_shape(WideKMfmaShape shape) {
+  switch (shape) {
+  case WideKMfmaShape::F32_16x16x32_F16:
+    return {shape, kCdna3OpMfmaF32_16x16x16F16, 4, 4, 2};
+  case WideKMfmaShape::F32_32x32x16_F16:
+    return {shape, kCdna3OpMfmaF32_32x32x8F16, 16, 4, 2};
+  }
+  return {shape, 0, 0, 0, 0};
+}
+
+[[nodiscard]] bool is_arch_vgpr_run(uint16_t src, uint8_t regs) {
+  return src >= 256 && src + regs <= 512;
+}
+
+[[nodiscard]] bool is_even_aligned_arch_vgpr_run(uint16_t src, uint8_t regs) {
+  return is_arch_vgpr_run(src, regs) && ((src - 256) % 2 == 0);
+}
+
+[[nodiscard]] bool ranges_overlap(uint16_t lhs_base, uint16_t lhs_count, uint16_t rhs_base,
+                                  uint16_t rhs_count) {
+  return lhs_base < rhs_base + rhs_count && rhs_base < lhs_base + lhs_count;
+}
+
+[[nodiscard]] bool wide_mfma_needs_partial_accum_scratch(const cdna4::Vop3pMfmaMachineInst &mfma,
+                                                         const WideKMfmaLowering &lowering) {
+  // acc_cd=1 writes the AccVGPR bank, while the accepted A/B operands below are
+  // ordinary VGPR operands encoded as 256-511. That bank separation means the
+  // first partial MFMA cannot clobber the A/B registers needed by the second.
+  if (mfma.acc_cd != 0)
+    return false;
+
+  const uint16_t dst_base = static_cast<uint16_t>(mfma.vdst);
+  const uint16_t src0_base = static_cast<uint16_t>(mfma.src0 - 256);
+  const uint16_t src1_base = static_cast<uint16_t>(mfma.src1 - 256);
+  return ranges_overlap(dst_base, lowering.dst_regs, src0_base, lowering.wide_src_regs) ||
+         ranges_overlap(dst_base, lowering.dst_regs, src1_base, lowering.wide_src_regs);
+}
+
+std::vector<uint32_t> lower_wide_k_mfma_f16_cdna4_to_cdna3(const Instruction &inst,
+                                                           const LivenessAnalysis &liveness,
+                                                           WideKMfmaShape shape) {
+  const auto *raw = inst.raw_encoding();
+  if (!raw || static_cast<size_t>(inst.size()) < sizeof(cdna4::Vop3pMfmaMachineInst))
+    return {};
+
+  cdna4::Vop3pMfmaMachineInst mfma{};
+  std::memcpy(&mfma, raw, sizeof(mfma));
+  const WideKMfmaLowering lowering = lowering_for_shape(shape);
+  if (lowering.narrow_op == 0)
+    return {};
+
+  // CDNA4's wide-K F16 forms double the K dimension by doubling each contiguous
+  // A/B VGPR source window. CDNA3 has the same output layout for the narrower-K
+  // forms, so the lowering emits two narrow MFMAs over the low and high halves
+  // of the source windows:
+  //
+  //   partial = mfma_narrow(A[0:1], B[0:1], C)
+  //   D       = mfma_narrow(A[2:3], B[2:3], partial)
+  //
+  // When D is an AccVGPR destination, `partial` is the final destination and the
+  // second instruction reads it back through src2. CDNA3 resolves src2 encodings
+  // 256-511 to the AccVGPR bank when acc_cd=1, which keeps the emitted encoding
+  // identical to the Triton pattern this rule was introduced for. When D is an
+  // ordinary VGPR destination that overlaps either full A/B source window, the
+  // first MFMA must instead write a dead VGPR run; otherwise it could clobber
+  // source registers that the second MFMA has not read yet.
+  if (mfma.cbsz != 0 || mfma.abid != 0 || mfma.blgp != 0 || mfma.acc != 0)
+    return {};
+  const uint16_t src2 = static_cast<uint16_t>(mfma.src2);
+  const bool src2_is_acc_window =
+      src2 >= 256 && static_cast<uint16_t>(src2 + lowering.dst_regs) <= 512;
+  if (src2 != kInlineConst0 && !src2_is_acc_window)
+    return {};
+  if (!is_even_aligned_arch_vgpr_run(static_cast<uint16_t>(mfma.src0), lowering.wide_src_regs) ||
+      !is_even_aligned_arch_vgpr_run(static_cast<uint16_t>(mfma.src1), lowering.wide_src_regs))
+    return {};
+  if (static_cast<uint16_t>(mfma.vdst) + lowering.dst_regs > 256)
+    return {};
+
+  const bool needs_scratch = wide_mfma_needs_partial_accum_scratch(mfma, lowering);
+  uint8_t partial_vdst = static_cast<uint8_t>(mfma.vdst);
+  uint16_t partial_src2 = static_cast<uint16_t>(256 + mfma.vdst);
+  if (needs_scratch) {
+    std::optional<uint16_t> scratch =
+        find_free_vgpr_run_below(liveness, inst, lowering.dst_regs, 0, kSemanticScratchVgprLimit);
+    if (!scratch)
+      return {};
+    partial_vdst = static_cast<uint8_t>(*scratch);
+    partial_src2 = static_cast<uint16_t>(256 + partial_vdst);
+  }
+
+  std::vector<uint32_t> words;
+  if (needs_scratch) {
+    emit_cdna3_mfma_to_vgpr(words, lowering.narrow_op, mfma, partial_vdst,
+                            static_cast<uint16_t>(mfma.src0), static_cast<uint16_t>(mfma.src1),
+                            static_cast<uint16_t>(mfma.src2));
+  } else {
+    emit_cdna3_mfma(words, lowering.narrow_op, mfma, static_cast<uint16_t>(mfma.src0),
+                    static_cast<uint16_t>(mfma.src1), static_cast<uint16_t>(mfma.src2));
+  }
+  emit_cdna3_mfma(words, lowering.narrow_op, mfma,
+                  static_cast<uint16_t>(mfma.src0 + lowering.narrow_src_regs),
+                  static_cast<uint16_t>(mfma.src1 + lowering.narrow_src_regs), partial_src2);
+  return words;
+}
+
+// -----------------------------------------------------------------------------
+// DS transpose expansions.
+// -----------------------------------------------------------------------------
+
+void emit_cdna3_b16_transpose_halfword(std::vector<uint32_t> &words, uint8_t halfword_dst,
+                                       uint8_t gather_tmp, uint8_t lane_byte_addr, uint8_t raw_lo,
+                                       uint8_t raw_hi, uint8_t halfword_selector) {
+  emit_cdna3_ds(words, kCdna3DsOpBpermuteB32, halfword_dst, lane_byte_addr, raw_lo);
+  emit_cdna3_ds(words, kCdna3DsOpBpermuteB32, gather_tmp, lane_byte_addr, raw_hi);
+  emit_cdna3_lgkm_wait(words);
+  emit_cdna3_vop3(words, kCdna3OpPermB32, halfword_dst, vgpr_src(gather_tmp),
+                  vgpr_src(halfword_dst), vgpr_src(halfword_selector));
+}
+
+void emit_cdna3_pack_low_b16_pair(std::vector<uint32_t> &words, uint8_t dst, uint8_t halfword_lo,
+                                  uint8_t halfword_hi, uint8_t shifted_hi_tmp, uint8_t mask_tmp) {
+  // Pack the low 16 bits of two VGPR values into a raw 32-bit payload. This is
+  // not an FP16 conversion; `v_pack_b32_f16` can canonicalize/change FP
+  // payloads, so build the packed destination with integer operations:
+  //
+  //   dst = (halfword_hi[15:0] << 16) | halfword_lo[15:0]
+  //
+  // CDNA3 cannot inline 0xffff as a VALU source, so synthesize the mask from
+  // -1 >> 16. The helper may clobber halfword_lo, shifted_hi_tmp, and mask_tmp.
+  emit_cdna3_vop3(words, kCdna3OpMovB32, mask_tmp, kInlineConstNeg1);
+  emit_cdna3_vop3(words, kCdna3OpLshrrevB32, mask_tmp, scalar_positive_inline_u32(16),
+                  vgpr_src(mask_tmp));
+  emit_cdna3_vop3(words, kCdna3OpAndB32, halfword_lo, vgpr_src(mask_tmp), vgpr_src(halfword_lo));
+  emit_cdna3_vop3(words, kCdna3OpAndB32, shifted_hi_tmp, vgpr_src(mask_tmp), vgpr_src(halfword_hi));
+  emit_cdna3_vop3(words, kCdna3OpLshlrevB32, shifted_hi_tmp, scalar_positive_inline_u32(16),
+                  vgpr_src(shifted_hi_tmp));
+  emit_cdna3_vop3(words, kCdna3OpOrB32, dst, vgpr_src(halfword_lo), vgpr_src(shifted_hi_tmp));
+}
+
+std::vector<uint32_t> lower_ds_read_b64_tr_b16_cdna4_to_cdna3(const Instruction &inst,
+                                                              const LivenessAnalysis &liveness) {
+  const auto *raw = inst.raw_encoding();
+  if (!raw || static_cast<size_t>(inst.size()) < sizeof(cdna4::DsMachineInst))
+    return {};
+
+  cdna4::DsMachineInst src{};
+  std::memcpy(&src, raw, sizeof(src));
+  if (src.gds != 0)
+    return {};
+
+  const uint8_t vdst = static_cast<uint8_t>(src.vdst);
+  const uint8_t addr = static_cast<uint8_t>(src.addr);
+  if (src.vdst > 254)
+    return {};
+
+  constexpr uint16_t kScratchCount = 8;
+  uint16_t scratch_start =
+      std::max<uint16_t>(static_cast<uint16_t>(vdst + 2), static_cast<uint16_t>(addr + 1));
+  if ((scratch_start & 1) != 0)
+    ++scratch_start;
+
+  std::optional<uint16_t> scratch;
+  for (uint16_t search = scratch_start; search + kScratchCount <= kSemanticScratchVgprLimit;) {
+    auto candidate =
+        find_free_vgpr_run_below(liveness, inst, kScratchCount, search, kSemanticScratchVgprLimit);
+    if (!candidate)
+      break;
+    if ((*candidate & 1) == 0) {
+      scratch = candidate;
+      break;
+    }
+    search = static_cast<uint16_t>(*candidate + 1);
+    if ((search & 1) != 0)
+      ++search;
+  }
+  if (!scratch)
+    return {};
+
+  const uint8_t raw_lo = static_cast<uint8_t>(*scratch + 0);
+  const uint8_t raw_hi = static_cast<uint8_t>(*scratch + 1);
+  const uint8_t lane_base = static_cast<uint8_t>(*scratch + 2);
+  const uint8_t halfword_selector = static_cast<uint8_t>(*scratch + 3);
+  const uint8_t tmp = static_cast<uint8_t>(*scratch + 4);
+  const uint8_t halfword_lo = static_cast<uint8_t>(*scratch + 5);
+  const uint8_t halfword_hi = static_cast<uint8_t>(*scratch + 6);
+  const uint8_t gather_tmp = static_cast<uint8_t>(*scratch + 7);
+
+  std::vector<uint32_t> words;
+
+  // CDNA4 ds_read_b64_tr_b16 loads four transposed halfwords per lane from the
+  // LDS read footprint. CDNA3 only has the non-transposed ds_read_b64, so the
+  // expansion reconstructs the transposed result through the DS crossbar:
+  //
+  //   raw_lo:raw_hi = ds_read_b64(addr, offset0, offset1)
+  //   lane          = mbcnt(exec)
+  //   selector      = ((lane & 3) * 2) | (((lane & 3) * 2 + 1) << 8)
+  //   lane_base     = ((lane & 0x30) << 2) | (lane & 0x0c)
+  //   h0            = halfword_at(lane_base +  0, selector, raw_lo, raw_hi)
+  //   h1            = halfword_at(lane_base + 16, selector, raw_lo, raw_hi)
+  //   h2            = halfword_at(lane_base + 32, selector, raw_lo, raw_hi)
+  //   h3            = halfword_at(lane_base + 48, selector, raw_lo, raw_hi)
+  //   vdst          = pack_u16_pair(h0, h1)
+  //   vdst+1        = pack_u16_pair(h2, h3)
+  //
+  // halfword_at() is emitted as two ds_bpermute_b32 operations followed by
+  // v_perm_b32 so the selector can choose the required halfword from either
+  // 32-bit half of the original b64 read. pack_u16_pair() is deliberately
+  // integer mask/shift/or instead of v_pack_b32_f16 because this DS op moves
+  // raw 16-bit payloads, not FP16 values.
+  emit_cdna3_ds(words, kCdna3DsOpReadB64, raw_lo, addr, 0, 0, src.offset0, src.offset1);
+  emit_cdna3_lgkm_wait(words);
+
+  emit_cdna3_vop3(words, kCdna3OpMbcntLoU32B32, tmp, kInlineConstNeg1, kInlineConst0);
+  emit_cdna3_vop3(words, kCdna3OpMbcntHiU32B32, tmp, kInlineConstNeg1, vgpr_src(tmp));
+
+  // Build the ds_bpermute byte addresses that recover each halfword in the
+  // transposed 4x16-lane pattern, then pack pairs of halfwords back into the
+  // two 32-bit destination registers produced by ds_read_b64_tr_b16.
+  emit_cdna3_vop3(words, kCdna3OpAndB32, halfword_selector, scalar_positive_inline_u32(3),
+                  vgpr_src(tmp));
+  emit_cdna3_vop3(words, kCdna3OpLshlrevB32, halfword_selector, scalar_positive_inline_u32(1),
+                  vgpr_src(halfword_selector));
+
+  emit_cdna3_vop3(words, kCdna3OpAndB32, lane_base, scalar_positive_inline_u32(0x30),
+                  vgpr_src(tmp));
+  emit_cdna3_vop3(words, kCdna3OpLshlrevB32, lane_base, scalar_positive_inline_u32(2),
+                  vgpr_src(lane_base));
+  emit_cdna3_vop3(words, kCdna3OpAndB32, tmp, scalar_positive_inline_u32(0x0c), vgpr_src(tmp));
+  emit_cdna3_vop3(words, kCdna3OpOrB32, lane_base, vgpr_src(lane_base), vgpr_src(tmp));
+
+  emit_cdna3_vop3(words, kCdna3OpAddU32, tmp, scalar_positive_inline_u32(1),
+                  vgpr_src(halfword_selector));
+  emit_cdna3_vop3(words, kCdna3OpLshlrevB32, tmp, scalar_positive_inline_u32(8), vgpr_src(tmp));
+  emit_cdna3_vop3(words, kCdna3OpOrB32, halfword_selector, vgpr_src(halfword_selector),
+                  vgpr_src(tmp));
+
+  emit_cdna3_b16_transpose_halfword(words, halfword_lo, gather_tmp, lane_base, raw_lo, raw_hi,
+                                    halfword_selector);
+  emit_cdna3_vop3(words, kCdna3OpAddU32, tmp, scalar_positive_inline_u32(16), vgpr_src(lane_base));
+  emit_cdna3_b16_transpose_halfword(words, halfword_hi, gather_tmp, tmp, raw_lo, raw_hi,
+                                    halfword_selector);
+  emit_cdna3_pack_low_b16_pair(words, vdst, halfword_lo, halfword_hi, tmp, gather_tmp);
+
+  emit_cdna3_vop3(words, kCdna3OpAddU32, tmp, scalar_positive_inline_u32(32), vgpr_src(lane_base));
+  emit_cdna3_b16_transpose_halfword(words, halfword_lo, gather_tmp, tmp, raw_lo, raw_hi,
+                                    halfword_selector);
+  emit_cdna3_vop3(words, kCdna3OpAddU32, tmp, scalar_positive_inline_u32(48), vgpr_src(lane_base));
+  emit_cdna3_b16_transpose_halfword(words, halfword_hi, gather_tmp, tmp, raw_lo, raw_hi,
+                                    halfword_selector);
+  emit_cdna3_pack_low_b16_pair(words, static_cast<uint8_t>(vdst + 1), halfword_lo, halfword_hi, tmp,
+                               gather_tmp);
+
+  return words;
+}
+
+std::vector<uint32_t> expand_v_bitop3_b16_cdna4_to_cdna3(const Instruction &inst, uint32_t,
+                                                         uint64_t, const LivenessAnalysis &liveness,
+                                                         const LaneLayout *, const LaneLayout *) {
+  return lower_cdna4_bitop3_to_cdna3(inst, liveness, true);
+}
+
+std::vector<uint32_t> expand_v_bitop3_b32_cdna4_to_cdna3(const Instruction &inst, uint32_t,
+                                                         uint64_t, const LivenessAnalysis &liveness,
+                                                         const LaneLayout *, const LaneLayout *) {
+  return lower_cdna4_bitop3_to_cdna3(inst, liveness, false);
+}
+
+std::vector<uint32_t> expand_ds_read_b64_tr_b16_cdna4_to_cdna3(const Instruction &inst, uint32_t,
+                                                               uint64_t,
+                                                               const LivenessAnalysis &liveness,
+                                                               const LaneLayout *,
+                                                               const LaneLayout *) {
+  return lower_ds_read_b64_tr_b16_cdna4_to_cdna3(inst, liveness);
+}
+
+std::vector<uint32_t> expand_mfma_f32_16x16x32_f16_cdna4_to_cdna3(const Instruction &inst, uint32_t,
+                                                                  uint64_t,
+                                                                  const LivenessAnalysis &liveness,
+                                                                  const LaneLayout *,
+                                                                  const LaneLayout *) {
+  return lower_wide_k_mfma_f16_cdna4_to_cdna3(inst, liveness, WideKMfmaShape::F32_16x16x32_F16);
+}
+
+std::vector<uint32_t> expand_mfma_f32_32x32x16_f16_cdna4_to_cdna3(const Instruction &inst, uint32_t,
+                                                                  uint64_t,
+                                                                  const LivenessAnalysis &liveness,
+                                                                  const LaneLayout *,
+                                                                  const LaneLayout *) {
+  return lower_wide_k_mfma_f16_cdna4_to_cdna3(inst, liveness, WideKMfmaShape::F32_32x32x16_F16);
+}
+
+constexpr uint16_t kEncVop3 = 0x1A4;
+constexpr uint16_t kEncVop3pMfma = 0x1A7;
+constexpr uint16_t kEncDsReadB64TrB16 = 0x1B3;
+
+constexpr uint16_t kCdna4Op_v_mfma_f32_16x16x32_f16 = 84;
+constexpr uint16_t kCdna4Op_v_mfma_f32_32x32x16_f16 = 85;
+constexpr uint16_t kCdna4Op_v_bitop3_b16 = 563;
+constexpr uint16_t kCdna4Op_v_bitop3_b32 = 564;
+constexpr uint16_t kCdna4Op_ds_read_b64_tr_b16 = 227;
+
+// Table MUST be sorted by (src_encoding_id, src_opcode) for binary search.
+const TranslationRule kExpandRules_cdna4_to_cdna3[] = {
+    {kEncVop3, kCdna4Op_v_bitop3_b16, RuleAction::Expand, 0, 0, nullptr,
+     expand_v_bitop3_b16_cdna4_to_cdna3, nullptr, nullptr},
+    {kEncVop3, kCdna4Op_v_bitop3_b32, RuleAction::Expand, 0, 0, nullptr,
+     expand_v_bitop3_b32_cdna4_to_cdna3, nullptr, nullptr},
+    {kEncVop3pMfma, kCdna4Op_v_mfma_f32_16x16x32_f16, RuleAction::Expand, 0, 0, nullptr,
+     expand_mfma_f32_16x16x32_f16_cdna4_to_cdna3, nullptr, nullptr},
+    {kEncVop3pMfma, kCdna4Op_v_mfma_f32_32x32x16_f16, RuleAction::Expand, 0, 0, nullptr,
+     expand_mfma_f32_32x32x16_f16_cdna4_to_cdna3, nullptr, nullptr},
+    {kEncDsReadB64TrB16, kCdna4Op_ds_read_b64_tr_b16, RuleAction::Expand, 0, 0, nullptr,
+     expand_ds_read_b64_tr_b16_cdna4_to_cdna3, nullptr, nullptr},
+};
+
+} // namespace
+
+std::span<const TranslationRule> semantic_expand_rules_cdna4_to_cdna3() {
+  return std::span<const TranslationRule>(kExpandRules_cdna4_to_cdna3);
+}
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/rules.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/rules.h
@@ -15,6 +15,9 @@ namespace rocjitsu {
 /// @brief CDNA4 source rules for the RDNA4 target.
 [[nodiscard]] std::span<const TranslationRule> semantic_expand_rules_cdna4_to_rdna4();
 
+/// @brief CDNA4 source rules for the CDNA3 target.
+[[nodiscard]] std::span<const TranslationRule> semantic_expand_rules_cdna4_to_cdna3();
+
 /// @brief CDNA4 source rules for the RDNA3 target.
 [[nodiscard]] std::span<const TranslationRule> semantic_expand_rules_cdna4_to_rdna3();
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic_translator.cpp
@@ -22,6 +22,8 @@ namespace {
                                                                          rj_code_arch_t host) {
   if (guest == ROCJITSU_CODE_ARCH_CDNA4 && host == ROCJITSU_CODE_ARCH_RDNA4)
     return semantic_expand_rules_cdna4_to_rdna4();
+  if (guest == ROCJITSU_CODE_ARCH_CDNA4 && host == ROCJITSU_CODE_ARCH_CDNA3)
+    return semantic_expand_rules_cdna4_to_cdna3();
   if (guest == ROCJITSU_CODE_ARCH_CDNA4 && host == ROCJITSU_CODE_ARCH_RDNA3)
     return semantic_expand_rules_cdna4_to_rdna3();
   return {};

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
@@ -190,6 +190,11 @@ void insert_file_bytes(std::vector<uint8_t> &image, Elf64_Ehdr &ehdr,
   return target_supports_wave32(arch);
 }
 
+[[nodiscard]] bool target_uses_gfx90a_accum_offset(rj_code_arch_t arch) {
+  return arch == ROCJITSU_CODE_ARCH_CDNA2 || arch == ROCJITSU_CODE_ARCH_CDNA3 ||
+         arch == ROCJITSU_CODE_ARCH_CDNA4;
+}
+
 [[nodiscard]] bool target_clears_rsrc1_mode_bits(rj_code_arch_t arch) {
   // DX10_CLAMP and IEEE_MODE are deprecated on GFX12. Preserve them for GFX10
   // and GFX11 targets where they still affect floating-point behavior.
@@ -487,6 +492,13 @@ bool CodeObjectPatcher::apply_kernel_descriptor_translation(const KdTranslation 
       AMDHSA_BITS_SET(desc->compute_pgm_rsrc3, kd::COMPUTE_PGM_RSRC3_GFX10_PLUS_INST_PREF_SIZE,
                       inst_pref);
     }
+  } else if (target_uses_gfx90a_accum_offset(target_arch) && translation.target_accvgpr_base != 0) {
+    // On GFX90A/GFX942/GFX950, AccVGPRs are placed by ACCUM_OFFSET rather than
+    // by the ordinary VGPR count. KernelDescriptorTranslator decides whether the
+    // base must move up to make room for semantic-lowering scratch; the patcher
+    // only materializes that already-translated target base.
+    AMDHSA_BITS_SET(desc->compute_pgm_rsrc3, kd::COMPUTE_PGM_RSRC3_GFX90A_ACCUM_OFFSET,
+                    (translation.target_accvgpr_base / 4 - 1));
   }
 
   desc->private_segment_fixed_size = translation.target_private_size;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
@@ -494,8 +494,9 @@ bool CodeObjectPatcher::apply_kernel_descriptor_translation(const KdTranslation 
     }
   } else if (target_uses_gfx90a_accum_offset(target_arch) && translation.target_accvgpr_base != 0) {
     // On GFX90A/GFX942/GFX950, AccVGPRs are placed by ACCUM_OFFSET rather than
-    // by the ordinary VGPR count. Descriptor translation may move this base up
-    // when semantic lowering needs extra ordinary VGPR scratch below it.
+    // by the ordinary VGPR count. KernelDescriptorTranslator decides whether the
+    // base must move up to make room for semantic-lowering scratch; the patcher
+    // only materializes that already-translated target base.
     AMDHSA_BITS_SET(desc->compute_pgm_rsrc3, kd::COMPUTE_PGM_RSRC3_GFX90A_ACCUM_OFFSET,
                     (translation.target_accvgpr_base / 4 - 1));
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
@@ -78,8 +78,7 @@ void write_elf_tables(std::vector<uint8_t> &image, const Elf64_Ehdr &ehdr,
 void insert_file_bytes(std::vector<uint8_t> &image, Elf64_Ehdr &ehdr,
                        std::vector<Elf64_Shdr> &shdrs, std::vector<Elf64_Phdr> &phdrs,
                        uint64_t file_offset, std::span<const uint8_t> bytes,
-                       std::optional<size_t> grown_section_index,
-                       bool grow_load_at_segment_end) {
+                       std::optional<size_t> grown_section_index, bool grow_load_at_segment_end) {
   assert(file_offset <= image.size() && "ELF insertion offset out of bounds");
   if (bytes.empty())
     return;
@@ -189,6 +188,11 @@ void insert_file_bytes(std::vector<uint8_t> &image, Elf64_Ehdr &ehdr,
 
 [[nodiscard]] bool target_uses_gfx10_plus_mode_bits(rj_code_arch_t arch) {
   return target_supports_wave32(arch);
+}
+
+[[nodiscard]] bool target_uses_gfx90a_accum_offset(rj_code_arch_t arch) {
+  return arch == ROCJITSU_CODE_ARCH_CDNA2 || arch == ROCJITSU_CODE_ARCH_CDNA3 ||
+         arch == ROCJITSU_CODE_ARCH_CDNA4;
 }
 
 [[nodiscard]] bool target_clears_rsrc1_mode_bits(rj_code_arch_t arch) {
@@ -488,6 +492,12 @@ bool CodeObjectPatcher::apply_kernel_descriptor_translation(const KdTranslation 
       AMDHSA_BITS_SET(desc->compute_pgm_rsrc3, kd::COMPUTE_PGM_RSRC3_GFX10_PLUS_INST_PREF_SIZE,
                       inst_pref);
     }
+  } else if (target_uses_gfx90a_accum_offset(target_arch) && translation.target_accvgpr_base != 0) {
+    // On GFX90A/GFX942/GFX950, AccVGPRs are placed by ACCUM_OFFSET rather than
+    // by the ordinary VGPR count. Descriptor translation may move this base up
+    // when semantic lowering needs extra ordinary VGPR scratch below it.
+    AMDHSA_BITS_SET(desc->compute_pgm_rsrc3, kd::COMPUTE_PGM_RSRC3_GFX90A_ACCUM_OFFSET,
+                    (translation.target_accvgpr_base / 4 - 1));
   }
 
   desc->private_segment_fixed_size = translation.target_private_size;
@@ -635,8 +645,7 @@ bool CodeObjectPatcher::append_cave_section(std::string_view section_name) {
       [[maybe_unused]] const uint64_t old_addr = shdrs[i].sh_addr;
       shdrs[i].sh_addr += padded_file_delta;
       assert((shdrs[i].sh_addralign <= 1 ||
-              shdrs[i].sh_addr % shdrs[i].sh_addralign ==
-                  old_addr % shdrs[i].sh_addralign) &&
+              shdrs[i].sh_addr % shdrs[i].sh_addralign == old_addr % shdrs[i].sh_addralign) &&
              "shifted allocated section lost its address alignment residue");
     }
   }

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -222,6 +222,7 @@ if(HSA_RUNTIME64)
             PATH_SUFFIXES bin
         )
         set(HAS_DBT_VECTOR_ADD_GPU FALSE)
+        set(HAS_CDNA3_GPU FALSE)
         set(HAS_RDNA4_GPU FALSE)
         if(ROCM_AGENT_ENUM)
             execute_process(
@@ -236,6 +237,9 @@ if(HSA_RUNTIME64)
                 AND _agents MATCHES "gfx94[012]|gfx1100|gfx120[01]"
             )
                 set(HAS_DBT_VECTOR_ADD_GPU TRUE)
+            endif()
+            if(_agent_rc EQUAL 0 AND _agents MATCHES "gfx94[012]")
+                set(HAS_CDNA3_GPU TRUE)
             endif()
             if(_agent_rc EQUAL 0 AND _agents MATCHES "gfx120[01]")
                 set(HAS_RDNA4_GPU TRUE)
@@ -311,6 +315,70 @@ if(HSA_RUNTIME64)
                 STATUS
                 "HSA translate MFMA test built but NOT registered with CTest "
                 "(no RDNA4 GPU)"
+            )
+        endif()
+
+        add_executable(
+            cdna4_to_cdna3_dispatch_test
+            dbt/cdna4_to_cdna3_dispatch_test.cpp
+        )
+        target_include_directories(
+            cdna4_to_cdna3_dispatch_test
+            PRIVATE
+                ${CMAKE_SOURCE_DIR}/lib/rocjitsu/include
+                ${CMAKE_SOURCE_DIR}/lib/rocjitsu/src
+                ${CMAKE_SOURCE_DIR}/lib/util/include
+                ${RJ_HSA_INCLUDE_DIR}
+        )
+        target_link_libraries(
+            cdna4_to_cdna3_dispatch_test
+            PRIVATE
+                ${RJ_OBJECT_LIBS}
+                ${HSA_RUNTIME64}
+                GTest::gtest
+                GTest::gtest_main
+        )
+        target_link_options(
+            cdna4_to_cdna3_dispatch_test
+            PRIVATE -Wl,-rpath,${RJ_HSA_LIBRARY_DIR}
+        )
+        target_compile_definitions(
+            cdna4_to_cdna3_dispatch_test
+            PRIVATE HAS_HOST_AMDGPU=1 KERNEL_DIR="${KERNEL_OUTPUT_DIR}"
+        )
+        add_dependencies(cdna4_to_cdna3_dispatch_test device_kernels)
+        rj_configure_target(cdna4_to_cdna3_dispatch_test TEST)
+
+        if(HAS_CDNA3_GPU)
+            add_test(
+                NAME "Cdna4ToCdna3DispatchTest.DynamicCopyLoopDispatchAndRun"
+                COMMAND
+                    cdna4_to_cdna3_dispatch_test
+                    --gtest_filter=Cdna4ToCdna3DispatchTest.DynamicCopyLoopDispatchAndRun
+                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            )
+            add_test(
+                NAME
+                    "Cdna4ToCdna3DispatchTest.TritonDynamicMatmulDispatchAndRun"
+                COMMAND
+                    cdna4_to_cdna3_dispatch_test
+                    --gtest_filter=Cdna4ToCdna3DispatchTest.TritonDynamicMatmulDispatchAndRun
+                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            )
+            set_tests_properties(
+                "Cdna4ToCdna3DispatchTest.DynamicCopyLoopDispatchAndRun"
+                "Cdna4ToCdna3DispatchTest.TritonDynamicMatmulDispatchAndRun"
+                PROPERTIES TIMEOUT 120
+            )
+            message(
+                STATUS
+                "CDNA4->CDNA3 dispatch tests enabled (CDNA3 GPU detected)"
+            )
+        else()
+            message(
+                STATUS
+                "CDNA4->CDNA3 dispatch tests built but NOT registered with CTest "
+                "(no CDNA3 GPU)"
             )
         endif()
     endif()

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -170,6 +170,7 @@ if(HSA_RUNTIME64)
             HINTS ENV ROCM_PATH ${RJ_HSA_ROCM_ROOT} /opt/rocm
             PATH_SUFFIXES bin)
         set(HAS_DBT_VECTOR_ADD_GPU FALSE)
+        set(HAS_CDNA3_GPU FALSE)
         set(HAS_RDNA4_GPU FALSE)
         if(ROCM_AGENT_ENUM)
             execute_process(COMMAND ${ROCM_AGENT_ENUM}
@@ -177,6 +178,9 @@ if(HSA_RUNTIME64)
                 ERROR_QUIET RESULT_VARIABLE _agent_rc)
             if(_agent_rc EQUAL 0 AND _agents MATCHES "gfx94[012]|gfx1100|gfx120[01]")
                 set(HAS_DBT_VECTOR_ADD_GPU TRUE)
+            endif()
+            if(_agent_rc EQUAL 0 AND _agents MATCHES "gfx94[012]")
+                set(HAS_CDNA3_GPU TRUE)
             endif()
             if(_agent_rc EQUAL 0 AND _agents MATCHES "gfx120[01]")
                 set(HAS_RDNA4_GPU TRUE)
@@ -220,6 +224,40 @@ if(HSA_RUNTIME64)
         else()
             message(STATUS "HSA translate MFMA test built but NOT registered with CTest "
                            "(no RDNA4 GPU)")
+        endif()
+
+        add_executable(cdna4_to_cdna3_dispatch_test dbt/cdna4_to_cdna3_dispatch_test.cpp)
+        target_include_directories(cdna4_to_cdna3_dispatch_test PRIVATE
+            ${CMAKE_SOURCE_DIR}/lib/rocjitsu/include
+            ${CMAKE_SOURCE_DIR}/lib/rocjitsu/src
+            ${CMAKE_SOURCE_DIR}/lib/util/include
+            ${RJ_HSA_INCLUDE_DIR})
+        target_link_libraries(cdna4_to_cdna3_dispatch_test PRIVATE
+            ${RJ_OBJECT_LIBS} ${HSA_RUNTIME64} GTest::gtest GTest::gtest_main)
+        target_link_options(cdna4_to_cdna3_dispatch_test PRIVATE -Wl,-rpath,${RJ_HSA_LIBRARY_DIR})
+        target_compile_definitions(cdna4_to_cdna3_dispatch_test PRIVATE
+            HAS_HOST_AMDGPU=1
+            KERNEL_DIR="${KERNEL_OUTPUT_DIR}")
+        add_dependencies(cdna4_to_cdna3_dispatch_test device_kernels)
+        rj_configure_target(cdna4_to_cdna3_dispatch_test TEST)
+
+        if(HAS_CDNA3_GPU)
+            add_test(NAME "Cdna4ToCdna3DispatchTest.DynamicCopyLoopDispatchAndRun"
+                COMMAND cdna4_to_cdna3_dispatch_test
+                    --gtest_filter=Cdna4ToCdna3DispatchTest.DynamicCopyLoopDispatchAndRun
+                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+            add_test(NAME "Cdna4ToCdna3DispatchTest.TritonDynamicMatmulDispatchAndRun"
+                COMMAND cdna4_to_cdna3_dispatch_test
+                    --gtest_filter=Cdna4ToCdna3DispatchTest.TritonDynamicMatmulDispatchAndRun
+                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+            set_tests_properties(
+                "Cdna4ToCdna3DispatchTest.DynamicCopyLoopDispatchAndRun"
+                "Cdna4ToCdna3DispatchTest.TritonDynamicMatmulDispatchAndRun"
+                PROPERTIES TIMEOUT 120)
+            message(STATUS "CDNA4->CDNA3 dispatch tests enabled (CDNA3 GPU detected)")
+        else()
+            message(STATUS "CDNA4->CDNA3 dispatch tests built but NOT registered with CTest "
+                           "(no CDNA3 GPU)")
         endif()
     endif()
 else()

--- a/emulation/rocjitsu/tests/dbt/cdna4_to_cdna3_dispatch_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/cdna4_to_cdna3_dispatch_test.cpp
@@ -1,0 +1,597 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file cdna4_to_cdna3_dispatch_test.cpp
+/// @brief End-to-end dispatch tests for CDNA4-to-CDNA3 DBT.
+
+#include "rocjitsu/base/rj_compiler.h"
+RJ_DIAGNOSTIC_PUSH
+RJ_DIAGNOSTIC_IGNORE_PEDANTIC
+#include <hsa/hsa.h>
+#include <hsa/hsa_ext_amd.h>
+RJ_DIAGNOSTIC_POP
+
+#include "rocjitsu/code/amdgpu_elf.h"
+#include "rocjitsu/code/dbt/binary_translator.h"
+#include "rocjitsu/code/executable.h"
+#include "rocjitsu/code/rj_code.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#ifdef HAS_HOST_AMDGPU
+using namespace rocjitsu;
+
+namespace {
+
+std::string kernel_path(const char *name) { return std::string(KERNEL_DIR) + "/" + name + ".o"; }
+std::string kernel_hsaco_path(const char *name) {
+  return std::string(KERNEL_DIR) + "/" + name + ".hsaco";
+}
+
+hsa_agent_t find_cpu_agent() {
+  hsa_agent_t cpu{};
+  hsa_iterate_agents(
+      [](hsa_agent_t agent, void *data) -> hsa_status_t {
+        hsa_device_type_t type;
+        hsa_agent_get_info(agent, HSA_AGENT_INFO_DEVICE, &type);
+        if (type == HSA_DEVICE_TYPE_CPU) {
+          *static_cast<hsa_agent_t *>(data) = agent;
+          return HSA_STATUS_INFO_BREAK;
+        }
+        return HSA_STATUS_SUCCESS;
+      },
+      &cpu);
+  return cpu;
+}
+
+hsa_amd_memory_pool_t find_pool(hsa_agent_t agent, hsa_amd_segment_t segment,
+                                bool host_accessible = false) {
+  struct Ctx {
+    hsa_amd_segment_t seg;
+    bool host_acc;
+    hsa_amd_memory_pool_t pool;
+  } ctx{segment, host_accessible, {}};
+
+  hsa_amd_agent_iterate_memory_pools(
+      agent,
+      [](hsa_amd_memory_pool_t pool, void *data) -> hsa_status_t {
+        auto *c = static_cast<Ctx *>(data);
+        hsa_amd_segment_t seg;
+        hsa_amd_memory_pool_get_info(pool, HSA_AMD_MEMORY_POOL_INFO_SEGMENT, &seg);
+        if (seg != c->seg)
+          return HSA_STATUS_SUCCESS;
+        if (c->host_acc) {
+          bool acc = false;
+          hsa_amd_memory_pool_get_info(pool, HSA_AMD_MEMORY_POOL_INFO_ACCESSIBLE_BY_ALL, &acc);
+          if (!acc)
+            return HSA_STATUS_SUCCESS;
+        }
+        c->pool = pool;
+        return HSA_STATUS_INFO_BREAK;
+      },
+      &ctx);
+  return ctx.pool;
+}
+
+struct Cdna3Target {
+  hsa_agent_t agent{};
+  uint32_t mach = 0;
+  std::string isa_name;
+  std::vector<std::string> seen_gpu_isas;
+};
+
+uint32_t cdna3_mach_for_isa_name(const char *name) {
+  if (std::strstr(name, "gfx940"))
+    return EF_AMDGPU_MACH_AMDGCN_GFX940;
+  if (std::strstr(name, "gfx941"))
+    return EF_AMDGPU_MACH_AMDGCN_GFX941;
+  if (std::strstr(name, "gfx942"))
+    return EF_AMDGPU_MACH_AMDGCN_GFX942;
+  return 0;
+}
+
+Cdna3Target find_cdna3_target() {
+  Cdna3Target target;
+  hsa_iterate_agents(
+      [](hsa_agent_t agent, void *data) -> hsa_status_t {
+        auto *t = static_cast<Cdna3Target *>(data);
+        hsa_device_type_t type;
+        hsa_agent_get_info(agent, HSA_AGENT_INFO_DEVICE, &type);
+        if (type != HSA_DEVICE_TYPE_GPU)
+          return HSA_STATUS_SUCCESS;
+
+        hsa_isa_t isa{};
+        char isa_name[128]{};
+        hsa_agent_get_info(agent, HSA_AGENT_INFO_ISA, &isa);
+        hsa_isa_get_info_alt(isa, HSA_ISA_INFO_NAME, isa_name);
+        t->seen_gpu_isas.emplace_back(isa_name);
+
+        const uint32_t mach = cdna3_mach_for_isa_name(isa_name);
+        if (mach == 0)
+          return HSA_STATUS_SUCCESS;
+
+        t->agent = agent;
+        t->mach = mach;
+        t->isa_name = isa_name;
+        return HSA_STATUS_INFO_BREAK;
+      },
+      &target);
+  return target;
+}
+
+std::string join_seen_isas(const std::vector<std::string> &isas) {
+  if (isas.empty())
+    return "<none>";
+  std::string out = isas.front();
+  for (size_t i = 1; i < isas.size(); ++i)
+    out += ", " + isas[i];
+  return out;
+}
+
+struct HsaShutdownGuard {
+  ~HsaShutdownGuard() { hsa_shut_down(); }
+};
+
+void run_dynamic_copy_loop(const std::vector<uint8_t> &elf_bytes, const Cdna3Target &target) {
+  hsa_agent_t cpu = find_cpu_agent();
+  ASSERT_NE(cpu.handle, 0u) << "No CPU agent found";
+
+  hsa_code_object_reader_t reader{};
+  auto st = hsa_code_object_reader_create_from_memory(elf_bytes.data(), elf_bytes.size(), &reader);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+
+  hsa_executable_t executable{};
+  st = hsa_executable_create_alt(HSA_PROFILE_FULL, HSA_DEFAULT_FLOAT_ROUNDING_MODE_DEFAULT, nullptr,
+                                 &executable);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+  st = hsa_executable_load_agent_code_object(executable, target.agent, reader, nullptr, nullptr);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+  st = hsa_executable_freeze(executable, nullptr);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+
+  hsa_executable_symbol_t symbol{};
+  st =
+      hsa_executable_get_symbol_by_name(executable, "dynamic_copy_loop.kd", &target.agent, &symbol);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+
+  uint64_t kernel_object = 0;
+  hsa_executable_symbol_get_info(symbol, HSA_EXECUTABLE_SYMBOL_INFO_KERNEL_OBJECT, &kernel_object);
+  ASSERT_NE(kernel_object, 0u);
+
+  constexpr uint32_t kMaxN = 8193;
+  constexpr uint32_t kWorkgroupSize = 64;
+  constexpr uint32_t kDispatchWorkItems = 256;
+  constexpr size_t kMaxBytes = kMaxN * sizeof(uint32_t);
+  constexpr uint32_t kSentinel = 0xDEADBEEFu;
+
+  auto gpu_pool = find_pool(target.agent, HSA_AMD_SEGMENT_GLOBAL);
+  ASSERT_NE(gpu_pool.handle, 0u);
+  uint32_t *src_dev = nullptr;
+  uint32_t *dst_dev = nullptr;
+  ASSERT_EQ(
+      hsa_amd_memory_pool_allocate(gpu_pool, kMaxBytes, 0, reinterpret_cast<void **>(&src_dev)),
+      HSA_STATUS_SUCCESS);
+  ASSERT_EQ(
+      hsa_amd_memory_pool_allocate(gpu_pool, kMaxBytes, 0, reinterpret_cast<void **>(&dst_dev)),
+      HSA_STATUS_SUCCESS);
+
+  hsa_agent_t both[] = {cpu, target.agent};
+  ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, src_dev), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, dst_dev), HSA_STATUS_SUCCESS);
+
+  auto kernarg_pool = find_pool(cpu, HSA_AMD_SEGMENT_GLOBAL, true);
+  ASSERT_NE(kernarg_pool.handle, 0u);
+  void *kernarg = nullptr;
+  ASSERT_EQ(hsa_amd_memory_pool_allocate(kernarg_pool, 256, 0, &kernarg), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, kernarg), HSA_STATUS_SUCCESS);
+  std::memset(kernarg, 0, 256);
+
+  struct __attribute__((packed)) KernArgs {
+    const uint32_t *src;
+    uint32_t *dst;
+    uint32_t n;
+    uint32_t workgroup_size;
+    uint32_t stride;
+  };
+  auto *args = static_cast<KernArgs *>(kernarg);
+  args->src = src_dev;
+  args->dst = dst_dev;
+  // The kernel is launched through raw HSA rather than the HIP runtime, so pass
+  // the packet workgroup size explicitly instead of relying on blockDim.x.
+  args->workgroup_size = kWorkgroupSize;
+  args->stride = kDispatchWorkItems;
+
+  hsa_queue_t *queue = nullptr;
+  uint32_t queue_size = 0;
+  hsa_agent_get_info(target.agent, HSA_AGENT_INFO_QUEUE_MAX_SIZE, &queue_size);
+  st = hsa_queue_create(target.agent, queue_size, HSA_QUEUE_TYPE_SINGLE, nullptr, nullptr,
+                        UINT32_MAX, UINT32_MAX, &queue);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+
+  hsa_signal_t signal{};
+  ASSERT_EQ(hsa_signal_create(1, 0, nullptr, &signal), HSA_STATUS_SUCCESS);
+
+  const std::array<uint32_t, 12> shapes = {0, 1, 17, 63, 64, 65, 255, 256, 257, 1024, 4097, kMaxN};
+  std::vector<uint32_t> src_host(kMaxN);
+  std::vector<uint32_t> dst_init(kMaxN, kSentinel);
+  std::vector<uint32_t> dst_host(kMaxN);
+
+  for (size_t iter = 0; iter < shapes.size(); ++iter) {
+    const uint32_t n = shapes[iter];
+    SCOPED_TRACE(::testing::Message()
+                 << "shape N=" << n << " iter=" << iter << " host=" << target.isa_name);
+
+    for (uint32_t i = 0; i < kMaxN; ++i)
+      src_host[i] = 0x12340000u ^ (static_cast<uint32_t>(iter) << 12) ^ i;
+    std::fill(dst_init.begin(), dst_init.end(), kSentinel);
+
+    ASSERT_EQ(hsa_memory_copy(src_dev, src_host.data(), kMaxBytes), HSA_STATUS_SUCCESS);
+    ASSERT_EQ(hsa_memory_copy(dst_dev, dst_init.data(), kMaxBytes), HSA_STATUS_SUCCESS);
+
+    args->n = n;
+    hsa_signal_store_relaxed(signal, 1);
+
+    const uint64_t write_idx = hsa_queue_add_write_index_relaxed(queue, 1);
+    auto *aql = static_cast<hsa_kernel_dispatch_packet_t *>(queue->base_address) +
+                (write_idx & (queue->size - 1));
+    std::memset(aql, 0, sizeof(*aql));
+    aql->setup = 1;
+    aql->workgroup_size_x = kWorkgroupSize;
+    aql->workgroup_size_y = 1;
+    aql->workgroup_size_z = 1;
+    aql->grid_size_x = kDispatchWorkItems;
+    aql->grid_size_y = 1;
+    aql->grid_size_z = 1;
+    aql->kernel_object = kernel_object;
+    aql->kernarg_address = kernarg;
+    aql->completion_signal = signal;
+
+    uint16_t header = HSA_PACKET_TYPE_KERNEL_DISPATCH << HSA_PACKET_HEADER_TYPE;
+    header |= 1 << HSA_PACKET_HEADER_BARRIER;
+    header |= HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_ACQUIRE_FENCE_SCOPE;
+    header |= HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_RELEASE_FENCE_SCOPE;
+    __atomic_store_n(reinterpret_cast<uint16_t *>(aql), header, __ATOMIC_RELEASE);
+    hsa_signal_store_relaxed(queue->doorbell_signal, write_idx);
+
+    const hsa_signal_value_t val = hsa_signal_wait_scacquire(
+        signal, HSA_SIGNAL_CONDITION_LT, 1, 5'000'000'000ULL, HSA_WAIT_STATE_BLOCKED);
+    ASSERT_EQ(val, 0) << "Kernel dispatch timed out or failed";
+
+    ASSERT_EQ(hsa_memory_copy(dst_host.data(), dst_dev, kMaxBytes), HSA_STATUS_SUCCESS);
+
+    uint32_t mismatches = 0;
+    for (uint32_t i = 0; i < kMaxN; ++i) {
+      const uint32_t expected = (i < n) ? src_host[i] : kSentinel;
+      if (dst_host[i] != expected) {
+        if (mismatches < 8) {
+          ADD_FAILURE() << "mismatch at i=" << i << ": got=0x" << std::hex << dst_host[i]
+                        << " expected=0x" << expected << std::dec;
+        }
+        ++mismatches;
+      }
+    }
+    EXPECT_EQ(mismatches, 0u) << mismatches << " mismatches for N=" << n;
+  }
+
+  hsa_signal_destroy(signal);
+  hsa_queue_destroy(queue);
+  hsa_amd_memory_pool_free(kernarg);
+  hsa_amd_memory_pool_free(src_dev);
+  hsa_amd_memory_pool_free(dst_dev);
+  hsa_executable_destroy(executable);
+  hsa_code_object_reader_destroy(reader);
+}
+
+struct TritonMatmulCase {
+  uint32_t m;
+  uint32_t n;
+  uint32_t k;
+};
+
+void translate_dynamic_triton_matmul(uint32_t mach, std::vector<uint8_t> &elf_bytes) {
+  Executable exec(kernel_hsaco_path("triton_cdna4_matmul_dynamic_32x32x64"));
+  ASSERT_TRUE(exec.is_valid());
+  ASSERT_GT(exec.num_code_objects(ROCJITSU_CODE_TARGET_GFX950), 0u);
+  const auto *co = exec.code_object(ROCJITSU_CODE_TARGET_GFX950, 0);
+  ASSERT_NE(co, nullptr);
+
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_CDNA3, mach);
+  auto translated = translator.translate(*co);
+  ASSERT_FALSE(translated.elf_bytes.empty());
+  ASSERT_TRUE(translated.warnings.empty())
+      << "Translation warning: " << translated.warnings.front();
+  elf_bytes = std::move(translated.elf_bytes);
+}
+
+void run_triton_matmul(const std::vector<uint8_t> &elf_bytes, const Cdna3Target &target,
+                       const TritonMatmulCase &test_case) {
+  hsa_agent_t cpu = find_cpu_agent();
+  ASSERT_NE(cpu.handle, 0u) << "No CPU agent found";
+
+  hsa_code_object_reader_t reader{};
+  auto st = hsa_code_object_reader_create_from_memory(elf_bytes.data(), elf_bytes.size(), &reader);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+
+  hsa_executable_t executable{};
+  st = hsa_executable_create_alt(HSA_PROFILE_FULL, HSA_DEFAULT_FLOAT_ROUNDING_MODE_DEFAULT, nullptr,
+                                 &executable);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+  st = hsa_executable_load_agent_code_object(executable, target.agent, reader, nullptr, nullptr);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+  st = hsa_executable_freeze(executable, nullptr);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+
+  hsa_executable_symbol_t symbol{};
+  st = hsa_executable_get_symbol_by_name(executable, "triton_cdna4_matmul_kernel.kd", &target.agent,
+                                         &symbol);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+
+  uint64_t kernel_object = 0;
+  hsa_executable_symbol_get_info(symbol, HSA_EXECUTABLE_SYMBOL_INFO_KERNEL_OBJECT, &kernel_object);
+  ASSERT_NE(kernel_object, 0u);
+
+  const uint32_t kM = test_case.m;
+  const uint32_t kN = test_case.n;
+  const uint32_t kK = test_case.k;
+  constexpr uint32_t kBlockM = 32;
+  constexpr uint32_t kBlockN = 32;
+  constexpr uint32_t kWorkgroupSize = 256;
+  constexpr uint32_t kSharedBytes = 8192;
+  const uint32_t kGroupsM = (kM + kBlockM - 1) / kBlockM;
+  const uint32_t kGroupsN = (kN + kBlockN - 1) / kBlockN;
+  constexpr float kSentinel = -12345.0f;
+  const size_t kAElements = static_cast<size_t>(kM) * kK;
+  const size_t kBElements = static_cast<size_t>(kK) * kN;
+  const size_t kCElements = static_cast<size_t>(kM) * kN;
+  const size_t kABytes = kAElements * sizeof(uint16_t);
+  const size_t kBBytes = kBElements * sizeof(uint16_t);
+  const size_t kCBytes = kCElements * sizeof(float);
+
+  auto half_bits = [](uint32_t value) -> uint16_t {
+    static constexpr uint16_t kHalfOneToEight[] = {0x3C00, 0x4000, 0x4200, 0x4400,
+                                                   0x4500, 0x4600, 0x4700, 0x4800};
+    return kHalfOneToEight[value - 1];
+  };
+
+  auto gpu_pool = find_pool(target.agent, HSA_AMD_SEGMENT_GLOBAL);
+  ASSERT_NE(gpu_pool.handle, 0u);
+  uint16_t *a_dev = nullptr;
+  uint16_t *b_dev = nullptr;
+  float *c_dev = nullptr;
+  ASSERT_EQ(hsa_amd_memory_pool_allocate(gpu_pool, kABytes, 0, reinterpret_cast<void **>(&a_dev)),
+            HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_memory_pool_allocate(gpu_pool, kBBytes, 0, reinterpret_cast<void **>(&b_dev)),
+            HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_memory_pool_allocate(gpu_pool, kCBytes, 0, reinterpret_cast<void **>(&c_dev)),
+            HSA_STATUS_SUCCESS);
+
+  hsa_agent_t both[] = {cpu, target.agent};
+  ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, a_dev), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, b_dev), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, c_dev), HSA_STATUS_SUCCESS);
+
+  auto kernarg_pool = find_pool(cpu, HSA_AMD_SEGMENT_GLOBAL, true);
+  ASSERT_NE(kernarg_pool.handle, 0u);
+  void *kernarg = nullptr;
+  ASSERT_EQ(hsa_amd_memory_pool_allocate(kernarg_pool, 256, 0, &kernarg), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, kernarg), HSA_STATUS_SUCCESS);
+  std::memset(kernarg, 0, 256);
+
+  struct __attribute__((packed)) DynamicKernArgs {
+    const uint16_t *a;
+    const uint16_t *b;
+    float *c;
+    uint32_t m;
+    uint32_t n;
+    uint32_t k;
+    uint32_t padding;
+    const void *unused0;
+    const void *unused1;
+  };
+  static_assert(sizeof(DynamicKernArgs) == 56, "Dynamic Triton matmul kernarg layout changed");
+
+  auto *args = static_cast<DynamicKernArgs *>(kernarg);
+  args->a = a_dev;
+  args->b = b_dev;
+  args->c = c_dev;
+  args->m = kM;
+  args->n = kN;
+  args->k = kK;
+
+  std::vector<uint16_t> a_host(kAElements);
+  std::vector<uint16_t> b_host(kBElements);
+  std::vector<float> c_init(kCElements, kSentinel);
+  std::vector<float> c_host(kCElements);
+  std::vector<float> expected(kCElements, 0.0f);
+  for (uint32_t m = 0; m < kM; ++m) {
+    for (uint32_t k = 0; k < kK; ++k)
+      a_host[static_cast<size_t>(m) * kK + k] = half_bits(1 + ((m + k) & 0x3));
+  }
+  for (uint32_t k = 0; k < kK; ++k) {
+    for (uint32_t n = 0; n < kN; ++n)
+      b_host[static_cast<size_t>(k) * kN + n] = half_bits(1 + ((2 * k + n) & 0x3));
+  }
+  for (uint32_t m = 0; m < kM; ++m) {
+    for (uint32_t n = 0; n < kN; ++n) {
+      float sum = 0.0f;
+      for (uint32_t k = 0; k < kK; ++k) {
+        const float a = static_cast<float>(1 + ((m + k) & 0x3));
+        const float b = static_cast<float>(1 + ((2 * k + n) & 0x3));
+        sum += a * b;
+      }
+      expected[static_cast<size_t>(m) * kN + n] = sum;
+    }
+  }
+  ASSERT_EQ(hsa_memory_copy(a_dev, a_host.data(), kABytes), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_memory_copy(b_dev, b_host.data(), kBBytes), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_memory_copy(c_dev, c_init.data(), kCBytes), HSA_STATUS_SUCCESS);
+
+  hsa_queue_t *queue = nullptr;
+  uint32_t queue_size = 0;
+  hsa_agent_get_info(target.agent, HSA_AGENT_INFO_QUEUE_MAX_SIZE, &queue_size);
+  st = hsa_queue_create(target.agent, queue_size, HSA_QUEUE_TYPE_SINGLE, nullptr, nullptr,
+                        UINT32_MAX, UINT32_MAX, &queue);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+
+  hsa_signal_t signal{};
+  ASSERT_EQ(hsa_signal_create(1, 0, nullptr, &signal), HSA_STATUS_SUCCESS);
+  hsa_signal_store_relaxed(signal, 1);
+
+  const uint64_t write_idx = hsa_queue_add_write_index_relaxed(queue, 1);
+  auto *aql = static_cast<hsa_kernel_dispatch_packet_t *>(queue->base_address) +
+              (write_idx & (queue->size - 1));
+  std::memset(aql, 0, sizeof(*aql));
+  aql->setup = 2;
+  aql->workgroup_size_x = kWorkgroupSize;
+  aql->workgroup_size_y = 1;
+  aql->workgroup_size_z = 1;
+  aql->grid_size_x = kGroupsM * kWorkgroupSize;
+  aql->grid_size_y = kGroupsN;
+  aql->grid_size_z = 1;
+  aql->group_segment_size = kSharedBytes;
+  aql->kernel_object = kernel_object;
+  aql->kernarg_address = kernarg;
+  aql->completion_signal = signal;
+
+  uint16_t header = HSA_PACKET_TYPE_KERNEL_DISPATCH << HSA_PACKET_HEADER_TYPE;
+  header |= 1 << HSA_PACKET_HEADER_BARRIER;
+  header |= HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_ACQUIRE_FENCE_SCOPE;
+  header |= HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_RELEASE_FENCE_SCOPE;
+  __atomic_store_n(reinterpret_cast<uint16_t *>(aql), header, __ATOMIC_RELEASE);
+  hsa_signal_store_relaxed(queue->doorbell_signal, write_idx);
+
+  const hsa_signal_value_t val = hsa_signal_wait_scacquire(
+      signal, HSA_SIGNAL_CONDITION_LT, 1, 5'000'000'000ULL, HSA_WAIT_STATE_BLOCKED);
+  ASSERT_EQ(val, 0) << "Kernel dispatch timed out or failed";
+
+  ASSERT_EQ(hsa_memory_copy(c_host.data(), c_dev, kCBytes), HSA_STATUS_SUCCESS);
+
+  uint32_t mismatches = 0;
+  std::vector<uint32_t> row_mismatches(kM, 0);
+  for (size_t i = 0; i < kCElements; ++i) {
+    if (c_host[i] != expected[i]) {
+      ++row_mismatches[i / kN];
+      if (mismatches < 8)
+        ADD_FAILURE() << "mismatch at i=" << i << " (m=" << (i / kN) << ", n=" << (i % kN)
+                      << "): got=" << c_host[i] << " expected=" << expected[i]
+                      << " diff=" << (expected[i] - c_host[i]);
+      ++mismatches;
+    }
+  }
+  if (mismatches != 0) {
+    std::string rows;
+    for (uint32_t m = 0; m < std::min<uint32_t>(kM, 64); ++m) {
+      if (row_mismatches[m] == 0)
+        continue;
+      if (!rows.empty())
+        rows += ", ";
+      rows += std::to_string(m) + ":" + std::to_string(row_mismatches[m]);
+    }
+    ADD_FAILURE() << "row mismatch counts (first 64 rows): " << rows;
+  }
+  EXPECT_EQ(mismatches, 0u) << mismatches << " matmul output mismatches";
+
+  hsa_signal_destroy(signal);
+  hsa_queue_destroy(queue);
+  hsa_amd_memory_pool_free(kernarg);
+  hsa_amd_memory_pool_free(a_dev);
+  hsa_amd_memory_pool_free(b_dev);
+  hsa_amd_memory_pool_free(c_dev);
+  hsa_executable_destroy(executable);
+  hsa_code_object_reader_destroy(reader);
+}
+
+} // namespace
+
+TEST(Cdna4ToCdna3DispatchTest, DynamicCopyLoopTranslates) {
+  Executable exec(kernel_path("dynamic_copy_loop"));
+  ASSERT_TRUE(exec.is_valid());
+  ASSERT_GT(exec.num_code_objects(ROCJITSU_CODE_TARGET_GFX950), 0u);
+  const auto *co = exec.code_object(ROCJITSU_CODE_TARGET_GFX950, 0);
+  ASSERT_NE(co, nullptr);
+
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_CDNA3,
+                              EF_AMDGPU_MACH_AMDGCN_GFX942);
+  auto translated = translator.translate(*co);
+  ASSERT_FALSE(translated.elf_bytes.empty());
+  ASSERT_TRUE(translated.warnings.empty())
+      << "Translation warning: " << translated.warnings.front();
+}
+
+TEST(Cdna4ToCdna3DispatchTest, TritonDynamicMatmulTranslates) {
+  std::vector<uint8_t> translated;
+  ASSERT_NO_FATAL_FAILURE(
+      translate_dynamic_triton_matmul(EF_AMDGPU_MACH_AMDGCN_GFX942, translated));
+}
+
+TEST(Cdna4ToCdna3DispatchTest, DynamicCopyLoopDispatchAndRun) {
+  const hsa_status_t init_status = hsa_init();
+  if (init_status != HSA_STATUS_SUCCESS)
+    GTEST_SKIP() << "hsa_init failed with status " << init_status
+                 << "; CDNA4->CDNA3 dispatch verification requires an HSA-capable host";
+  const HsaShutdownGuard shutdown;
+
+  Cdna3Target target = find_cdna3_target();
+  if (target.agent.handle == 0)
+    GTEST_SKIP() << "Test requires a CDNA3 GPU agent (gfx940/gfx941/gfx942); found: "
+                 << join_seen_isas(target.seen_gpu_isas);
+
+  Executable exec(kernel_path("dynamic_copy_loop"));
+  ASSERT_TRUE(exec.is_valid());
+  ASSERT_GT(exec.num_code_objects(ROCJITSU_CODE_TARGET_GFX950), 0u);
+  const auto *co = exec.code_object(ROCJITSU_CODE_TARGET_GFX950, 0);
+  ASSERT_NE(co, nullptr);
+
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_CDNA3, target.mach);
+  auto translated = translator.translate(*co);
+  ASSERT_FALSE(translated.elf_bytes.empty());
+  ASSERT_TRUE(translated.warnings.empty())
+      << "Translation warning: " << translated.warnings.front();
+
+  ASSERT_NO_FATAL_FAILURE(run_dynamic_copy_loop(translated.elf_bytes, target));
+}
+
+TEST(Cdna4ToCdna3DispatchTest, TritonDynamicMatmulDispatchAndRun) {
+  const std::array<TritonMatmulCase, 11> cases = {{
+      {32, 32, 64},
+      {32, 32, 65},
+      {32, 32, 66},
+      {32, 32, 128},
+      {32, 32, 130},
+      {32, 32, 192},
+      {32, 32, 512},
+      {512, 512, 512},
+      {31, 31, 64},
+      {32, 32, 63},
+      {257, 129, 130},
+  }};
+
+  const hsa_status_t init_status = hsa_init();
+  if (init_status != HSA_STATUS_SUCCESS)
+    GTEST_SKIP() << "hsa_init failed with status " << init_status
+                 << "; CDNA4->CDNA3 dispatch verification requires an HSA-capable host";
+  const HsaShutdownGuard shutdown;
+
+  Cdna3Target target = find_cdna3_target();
+  if (target.agent.handle == 0)
+    GTEST_SKIP() << "Test requires a CDNA3 GPU agent (gfx940/gfx941/gfx942); found: "
+                 << join_seen_isas(target.seen_gpu_isas);
+
+  std::vector<uint8_t> translated;
+  ASSERT_NO_FATAL_FAILURE(translate_dynamic_triton_matmul(target.mach, translated));
+
+  for (const TritonMatmulCase &test_case : cases) {
+    SCOPED_TRACE(::testing::Message()
+                 << "M=" << test_case.m << " N=" << test_case.n << " K=" << test_case.k);
+    ASSERT_NO_FATAL_FAILURE(run_triton_matmul(translated, target, test_case));
+  }
+}
+
+#endif // HAS_HOST_AMDGPU

--- a/emulation/rocjitsu/tests/dbt/cdna4_to_cdna3_dispatch_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/cdna4_to_cdna3_dispatch_test.cpp
@@ -197,11 +197,15 @@ void run_dynamic_copy_loop(const std::vector<uint8_t> &elf_bytes, const Cdna3Tar
     const uint32_t *src;
     uint32_t *dst;
     uint32_t n;
+    uint32_t workgroup_size;
     uint32_t stride;
   };
   auto *args = static_cast<KernArgs *>(kernarg);
   args->src = src_dev;
   args->dst = dst_dev;
+  // The kernel is launched through raw HSA rather than the HIP runtime, so pass
+  // the packet workgroup size explicitly instead of relying on blockDim.x.
+  args->workgroup_size = kWorkgroupSize;
   args->stride = kDispatchWorkItems;
 
   hsa_queue_t *queue = nullptr;

--- a/emulation/rocjitsu/tests/dbt/cdna4_to_cdna3_dispatch_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/cdna4_to_cdna3_dispatch_test.cpp
@@ -1,0 +1,593 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file cdna4_to_cdna3_dispatch_test.cpp
+/// @brief End-to-end dispatch tests for CDNA4-to-CDNA3 DBT.
+
+#include "rocjitsu/base/rj_compiler.h"
+RJ_DIAGNOSTIC_PUSH
+RJ_DIAGNOSTIC_IGNORE_PEDANTIC
+#include <hsa/hsa.h>
+#include <hsa/hsa_ext_amd.h>
+RJ_DIAGNOSTIC_POP
+
+#include "rocjitsu/code/amdgpu_elf.h"
+#include "rocjitsu/code/dbt/binary_translator.h"
+#include "rocjitsu/code/executable.h"
+#include "rocjitsu/code/rj_code.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#ifdef HAS_HOST_AMDGPU
+using namespace rocjitsu;
+
+namespace {
+
+std::string kernel_path(const char *name) { return std::string(KERNEL_DIR) + "/" + name + ".o"; }
+std::string kernel_hsaco_path(const char *name) {
+  return std::string(KERNEL_DIR) + "/" + name + ".hsaco";
+}
+
+hsa_agent_t find_cpu_agent() {
+  hsa_agent_t cpu{};
+  hsa_iterate_agents(
+      [](hsa_agent_t agent, void *data) -> hsa_status_t {
+        hsa_device_type_t type;
+        hsa_agent_get_info(agent, HSA_AGENT_INFO_DEVICE, &type);
+        if (type == HSA_DEVICE_TYPE_CPU) {
+          *static_cast<hsa_agent_t *>(data) = agent;
+          return HSA_STATUS_INFO_BREAK;
+        }
+        return HSA_STATUS_SUCCESS;
+      },
+      &cpu);
+  return cpu;
+}
+
+hsa_amd_memory_pool_t find_pool(hsa_agent_t agent, hsa_amd_segment_t segment,
+                                bool host_accessible = false) {
+  struct Ctx {
+    hsa_amd_segment_t seg;
+    bool host_acc;
+    hsa_amd_memory_pool_t pool;
+  } ctx{segment, host_accessible, {}};
+
+  hsa_amd_agent_iterate_memory_pools(
+      agent,
+      [](hsa_amd_memory_pool_t pool, void *data) -> hsa_status_t {
+        auto *c = static_cast<Ctx *>(data);
+        hsa_amd_segment_t seg;
+        hsa_amd_memory_pool_get_info(pool, HSA_AMD_MEMORY_POOL_INFO_SEGMENT, &seg);
+        if (seg != c->seg)
+          return HSA_STATUS_SUCCESS;
+        if (c->host_acc) {
+          bool acc = false;
+          hsa_amd_memory_pool_get_info(pool, HSA_AMD_MEMORY_POOL_INFO_ACCESSIBLE_BY_ALL, &acc);
+          if (!acc)
+            return HSA_STATUS_SUCCESS;
+        }
+        c->pool = pool;
+        return HSA_STATUS_INFO_BREAK;
+      },
+      &ctx);
+  return ctx.pool;
+}
+
+struct Cdna3Target {
+  hsa_agent_t agent{};
+  uint32_t mach = 0;
+  std::string isa_name;
+  std::vector<std::string> seen_gpu_isas;
+};
+
+uint32_t cdna3_mach_for_isa_name(const char *name) {
+  if (std::strstr(name, "gfx940"))
+    return EF_AMDGPU_MACH_AMDGCN_GFX940;
+  if (std::strstr(name, "gfx941"))
+    return EF_AMDGPU_MACH_AMDGCN_GFX941;
+  if (std::strstr(name, "gfx942"))
+    return EF_AMDGPU_MACH_AMDGCN_GFX942;
+  return 0;
+}
+
+Cdna3Target find_cdna3_target() {
+  Cdna3Target target;
+  hsa_iterate_agents(
+      [](hsa_agent_t agent, void *data) -> hsa_status_t {
+        auto *t = static_cast<Cdna3Target *>(data);
+        hsa_device_type_t type;
+        hsa_agent_get_info(agent, HSA_AGENT_INFO_DEVICE, &type);
+        if (type != HSA_DEVICE_TYPE_GPU)
+          return HSA_STATUS_SUCCESS;
+
+        hsa_isa_t isa{};
+        char isa_name[128]{};
+        hsa_agent_get_info(agent, HSA_AGENT_INFO_ISA, &isa);
+        hsa_isa_get_info_alt(isa, HSA_ISA_INFO_NAME, isa_name);
+        t->seen_gpu_isas.emplace_back(isa_name);
+
+        const uint32_t mach = cdna3_mach_for_isa_name(isa_name);
+        if (mach == 0)
+          return HSA_STATUS_SUCCESS;
+
+        t->agent = agent;
+        t->mach = mach;
+        t->isa_name = isa_name;
+        return HSA_STATUS_INFO_BREAK;
+      },
+      &target);
+  return target;
+}
+
+std::string join_seen_isas(const std::vector<std::string> &isas) {
+  if (isas.empty())
+    return "<none>";
+  std::string out = isas.front();
+  for (size_t i = 1; i < isas.size(); ++i)
+    out += ", " + isas[i];
+  return out;
+}
+
+struct HsaShutdownGuard {
+  ~HsaShutdownGuard() { hsa_shut_down(); }
+};
+
+void run_dynamic_copy_loop(const std::vector<uint8_t> &elf_bytes, const Cdna3Target &target) {
+  hsa_agent_t cpu = find_cpu_agent();
+  ASSERT_NE(cpu.handle, 0u) << "No CPU agent found";
+
+  hsa_code_object_reader_t reader{};
+  auto st = hsa_code_object_reader_create_from_memory(elf_bytes.data(), elf_bytes.size(), &reader);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+
+  hsa_executable_t executable{};
+  st = hsa_executable_create_alt(HSA_PROFILE_FULL, HSA_DEFAULT_FLOAT_ROUNDING_MODE_DEFAULT, nullptr,
+                                 &executable);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+  st = hsa_executable_load_agent_code_object(executable, target.agent, reader, nullptr, nullptr);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+  st = hsa_executable_freeze(executable, nullptr);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+
+  hsa_executable_symbol_t symbol{};
+  st =
+      hsa_executable_get_symbol_by_name(executable, "dynamic_copy_loop.kd", &target.agent, &symbol);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+
+  uint64_t kernel_object = 0;
+  hsa_executable_symbol_get_info(symbol, HSA_EXECUTABLE_SYMBOL_INFO_KERNEL_OBJECT, &kernel_object);
+  ASSERT_NE(kernel_object, 0u);
+
+  constexpr uint32_t kMaxN = 8193;
+  constexpr uint32_t kWorkgroupSize = 64;
+  constexpr uint32_t kDispatchWorkItems = 256;
+  constexpr size_t kMaxBytes = kMaxN * sizeof(uint32_t);
+  constexpr uint32_t kSentinel = 0xDEADBEEFu;
+
+  auto gpu_pool = find_pool(target.agent, HSA_AMD_SEGMENT_GLOBAL);
+  ASSERT_NE(gpu_pool.handle, 0u);
+  uint32_t *src_dev = nullptr;
+  uint32_t *dst_dev = nullptr;
+  ASSERT_EQ(
+      hsa_amd_memory_pool_allocate(gpu_pool, kMaxBytes, 0, reinterpret_cast<void **>(&src_dev)),
+      HSA_STATUS_SUCCESS);
+  ASSERT_EQ(
+      hsa_amd_memory_pool_allocate(gpu_pool, kMaxBytes, 0, reinterpret_cast<void **>(&dst_dev)),
+      HSA_STATUS_SUCCESS);
+
+  hsa_agent_t both[] = {cpu, target.agent};
+  ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, src_dev), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, dst_dev), HSA_STATUS_SUCCESS);
+
+  auto kernarg_pool = find_pool(cpu, HSA_AMD_SEGMENT_GLOBAL, true);
+  ASSERT_NE(kernarg_pool.handle, 0u);
+  void *kernarg = nullptr;
+  ASSERT_EQ(hsa_amd_memory_pool_allocate(kernarg_pool, 256, 0, &kernarg), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, kernarg), HSA_STATUS_SUCCESS);
+  std::memset(kernarg, 0, 256);
+
+  struct __attribute__((packed)) KernArgs {
+    const uint32_t *src;
+    uint32_t *dst;
+    uint32_t n;
+    uint32_t stride;
+  };
+  auto *args = static_cast<KernArgs *>(kernarg);
+  args->src = src_dev;
+  args->dst = dst_dev;
+  args->stride = kDispatchWorkItems;
+
+  hsa_queue_t *queue = nullptr;
+  uint32_t queue_size = 0;
+  hsa_agent_get_info(target.agent, HSA_AGENT_INFO_QUEUE_MAX_SIZE, &queue_size);
+  st = hsa_queue_create(target.agent, queue_size, HSA_QUEUE_TYPE_SINGLE, nullptr, nullptr,
+                        UINT32_MAX, UINT32_MAX, &queue);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+
+  hsa_signal_t signal{};
+  ASSERT_EQ(hsa_signal_create(1, 0, nullptr, &signal), HSA_STATUS_SUCCESS);
+
+  const std::array<uint32_t, 12> shapes = {0, 1, 17, 63, 64, 65, 255, 256, 257, 1024, 4097, kMaxN};
+  std::vector<uint32_t> src_host(kMaxN);
+  std::vector<uint32_t> dst_init(kMaxN, kSentinel);
+  std::vector<uint32_t> dst_host(kMaxN);
+
+  for (size_t iter = 0; iter < shapes.size(); ++iter) {
+    const uint32_t n = shapes[iter];
+    SCOPED_TRACE(::testing::Message()
+                 << "shape N=" << n << " iter=" << iter << " host=" << target.isa_name);
+
+    for (uint32_t i = 0; i < kMaxN; ++i)
+      src_host[i] = 0x12340000u ^ (static_cast<uint32_t>(iter) << 12) ^ i;
+    std::fill(dst_init.begin(), dst_init.end(), kSentinel);
+
+    ASSERT_EQ(hsa_memory_copy(src_dev, src_host.data(), kMaxBytes), HSA_STATUS_SUCCESS);
+    ASSERT_EQ(hsa_memory_copy(dst_dev, dst_init.data(), kMaxBytes), HSA_STATUS_SUCCESS);
+
+    args->n = n;
+    hsa_signal_store_relaxed(signal, 1);
+
+    const uint64_t write_idx = hsa_queue_add_write_index_relaxed(queue, 1);
+    auto *aql = static_cast<hsa_kernel_dispatch_packet_t *>(queue->base_address) +
+                (write_idx & (queue->size - 1));
+    std::memset(aql, 0, sizeof(*aql));
+    aql->setup = 1;
+    aql->workgroup_size_x = kWorkgroupSize;
+    aql->workgroup_size_y = 1;
+    aql->workgroup_size_z = 1;
+    aql->grid_size_x = kDispatchWorkItems;
+    aql->grid_size_y = 1;
+    aql->grid_size_z = 1;
+    aql->kernel_object = kernel_object;
+    aql->kernarg_address = kernarg;
+    aql->completion_signal = signal;
+
+    uint16_t header = HSA_PACKET_TYPE_KERNEL_DISPATCH << HSA_PACKET_HEADER_TYPE;
+    header |= 1 << HSA_PACKET_HEADER_BARRIER;
+    header |= HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_ACQUIRE_FENCE_SCOPE;
+    header |= HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_RELEASE_FENCE_SCOPE;
+    __atomic_store_n(reinterpret_cast<uint16_t *>(aql), header, __ATOMIC_RELEASE);
+    hsa_signal_store_relaxed(queue->doorbell_signal, write_idx);
+
+    const hsa_signal_value_t val = hsa_signal_wait_scacquire(
+        signal, HSA_SIGNAL_CONDITION_LT, 1, 5'000'000'000ULL, HSA_WAIT_STATE_BLOCKED);
+    ASSERT_EQ(val, 0) << "Kernel dispatch timed out or failed";
+
+    ASSERT_EQ(hsa_memory_copy(dst_host.data(), dst_dev, kMaxBytes), HSA_STATUS_SUCCESS);
+
+    uint32_t mismatches = 0;
+    for (uint32_t i = 0; i < kMaxN; ++i) {
+      const uint32_t expected = (i < n) ? src_host[i] : kSentinel;
+      if (dst_host[i] != expected) {
+        if (mismatches < 8) {
+          ADD_FAILURE() << "mismatch at i=" << i << ": got=0x" << std::hex << dst_host[i]
+                        << " expected=0x" << expected << std::dec;
+        }
+        ++mismatches;
+      }
+    }
+    EXPECT_EQ(mismatches, 0u) << mismatches << " mismatches for N=" << n;
+  }
+
+  hsa_signal_destroy(signal);
+  hsa_queue_destroy(queue);
+  hsa_amd_memory_pool_free(kernarg);
+  hsa_amd_memory_pool_free(src_dev);
+  hsa_amd_memory_pool_free(dst_dev);
+  hsa_executable_destroy(executable);
+  hsa_code_object_reader_destroy(reader);
+}
+
+struct TritonMatmulCase {
+  uint32_t m;
+  uint32_t n;
+  uint32_t k;
+};
+
+void translate_dynamic_triton_matmul(uint32_t mach, std::vector<uint8_t> &elf_bytes) {
+  Executable exec(kernel_hsaco_path("triton_cdna4_matmul_dynamic_32x32x64"));
+  ASSERT_TRUE(exec.is_valid());
+  ASSERT_GT(exec.num_code_objects(ROCJITSU_CODE_TARGET_GFX950), 0u);
+  const auto *co = exec.code_object(ROCJITSU_CODE_TARGET_GFX950, 0);
+  ASSERT_NE(co, nullptr);
+
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_CDNA3, mach);
+  auto translated = translator.translate(*co);
+  ASSERT_FALSE(translated.elf_bytes.empty());
+  ASSERT_TRUE(translated.warnings.empty())
+      << "Translation warning: " << translated.warnings.front();
+  elf_bytes = std::move(translated.elf_bytes);
+}
+
+void run_triton_matmul(const std::vector<uint8_t> &elf_bytes, const Cdna3Target &target,
+                       const TritonMatmulCase &test_case) {
+  hsa_agent_t cpu = find_cpu_agent();
+  ASSERT_NE(cpu.handle, 0u) << "No CPU agent found";
+
+  hsa_code_object_reader_t reader{};
+  auto st = hsa_code_object_reader_create_from_memory(elf_bytes.data(), elf_bytes.size(), &reader);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+
+  hsa_executable_t executable{};
+  st = hsa_executable_create_alt(HSA_PROFILE_FULL, HSA_DEFAULT_FLOAT_ROUNDING_MODE_DEFAULT, nullptr,
+                                 &executable);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+  st = hsa_executable_load_agent_code_object(executable, target.agent, reader, nullptr, nullptr);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+  st = hsa_executable_freeze(executable, nullptr);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+
+  hsa_executable_symbol_t symbol{};
+  st = hsa_executable_get_symbol_by_name(executable, "triton_cdna4_matmul_kernel.kd", &target.agent,
+                                         &symbol);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+
+  uint64_t kernel_object = 0;
+  hsa_executable_symbol_get_info(symbol, HSA_EXECUTABLE_SYMBOL_INFO_KERNEL_OBJECT, &kernel_object);
+  ASSERT_NE(kernel_object, 0u);
+
+  const uint32_t kM = test_case.m;
+  const uint32_t kN = test_case.n;
+  const uint32_t kK = test_case.k;
+  constexpr uint32_t kBlockM = 32;
+  constexpr uint32_t kBlockN = 32;
+  constexpr uint32_t kWorkgroupSize = 256;
+  constexpr uint32_t kSharedBytes = 8192;
+  const uint32_t kGroupsM = (kM + kBlockM - 1) / kBlockM;
+  const uint32_t kGroupsN = (kN + kBlockN - 1) / kBlockN;
+  constexpr float kSentinel = -12345.0f;
+  const size_t kAElements = static_cast<size_t>(kM) * kK;
+  const size_t kBElements = static_cast<size_t>(kK) * kN;
+  const size_t kCElements = static_cast<size_t>(kM) * kN;
+  const size_t kABytes = kAElements * sizeof(uint16_t);
+  const size_t kBBytes = kBElements * sizeof(uint16_t);
+  const size_t kCBytes = kCElements * sizeof(float);
+
+  auto half_bits = [](uint32_t value) -> uint16_t {
+    static constexpr uint16_t kHalfOneToEight[] = {0x3C00, 0x4000, 0x4200, 0x4400,
+                                                   0x4500, 0x4600, 0x4700, 0x4800};
+    return kHalfOneToEight[value - 1];
+  };
+
+  auto gpu_pool = find_pool(target.agent, HSA_AMD_SEGMENT_GLOBAL);
+  ASSERT_NE(gpu_pool.handle, 0u);
+  uint16_t *a_dev = nullptr;
+  uint16_t *b_dev = nullptr;
+  float *c_dev = nullptr;
+  ASSERT_EQ(hsa_amd_memory_pool_allocate(gpu_pool, kABytes, 0, reinterpret_cast<void **>(&a_dev)),
+            HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_memory_pool_allocate(gpu_pool, kBBytes, 0, reinterpret_cast<void **>(&b_dev)),
+            HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_memory_pool_allocate(gpu_pool, kCBytes, 0, reinterpret_cast<void **>(&c_dev)),
+            HSA_STATUS_SUCCESS);
+
+  hsa_agent_t both[] = {cpu, target.agent};
+  ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, a_dev), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, b_dev), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, c_dev), HSA_STATUS_SUCCESS);
+
+  auto kernarg_pool = find_pool(cpu, HSA_AMD_SEGMENT_GLOBAL, true);
+  ASSERT_NE(kernarg_pool.handle, 0u);
+  void *kernarg = nullptr;
+  ASSERT_EQ(hsa_amd_memory_pool_allocate(kernarg_pool, 256, 0, &kernarg), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, kernarg), HSA_STATUS_SUCCESS);
+  std::memset(kernarg, 0, 256);
+
+  struct __attribute__((packed)) DynamicKernArgs {
+    const uint16_t *a;
+    const uint16_t *b;
+    float *c;
+    uint32_t m;
+    uint32_t n;
+    uint32_t k;
+    uint32_t padding;
+    const void *unused0;
+    const void *unused1;
+  };
+  static_assert(sizeof(DynamicKernArgs) == 56, "Dynamic Triton matmul kernarg layout changed");
+
+  auto *args = static_cast<DynamicKernArgs *>(kernarg);
+  args->a = a_dev;
+  args->b = b_dev;
+  args->c = c_dev;
+  args->m = kM;
+  args->n = kN;
+  args->k = kK;
+
+  std::vector<uint16_t> a_host(kAElements);
+  std::vector<uint16_t> b_host(kBElements);
+  std::vector<float> c_init(kCElements, kSentinel);
+  std::vector<float> c_host(kCElements);
+  std::vector<float> expected(kCElements, 0.0f);
+  for (uint32_t m = 0; m < kM; ++m) {
+    for (uint32_t k = 0; k < kK; ++k)
+      a_host[static_cast<size_t>(m) * kK + k] = half_bits(1 + ((m + k) & 0x3));
+  }
+  for (uint32_t k = 0; k < kK; ++k) {
+    for (uint32_t n = 0; n < kN; ++n)
+      b_host[static_cast<size_t>(k) * kN + n] = half_bits(1 + ((2 * k + n) & 0x3));
+  }
+  for (uint32_t m = 0; m < kM; ++m) {
+    for (uint32_t n = 0; n < kN; ++n) {
+      float sum = 0.0f;
+      for (uint32_t k = 0; k < kK; ++k) {
+        const float a = static_cast<float>(1 + ((m + k) & 0x3));
+        const float b = static_cast<float>(1 + ((2 * k + n) & 0x3));
+        sum += a * b;
+      }
+      expected[static_cast<size_t>(m) * kN + n] = sum;
+    }
+  }
+  ASSERT_EQ(hsa_memory_copy(a_dev, a_host.data(), kABytes), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_memory_copy(b_dev, b_host.data(), kBBytes), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_memory_copy(c_dev, c_init.data(), kCBytes), HSA_STATUS_SUCCESS);
+
+  hsa_queue_t *queue = nullptr;
+  uint32_t queue_size = 0;
+  hsa_agent_get_info(target.agent, HSA_AGENT_INFO_QUEUE_MAX_SIZE, &queue_size);
+  st = hsa_queue_create(target.agent, queue_size, HSA_QUEUE_TYPE_SINGLE, nullptr, nullptr,
+                        UINT32_MAX, UINT32_MAX, &queue);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+
+  hsa_signal_t signal{};
+  ASSERT_EQ(hsa_signal_create(1, 0, nullptr, &signal), HSA_STATUS_SUCCESS);
+  hsa_signal_store_relaxed(signal, 1);
+
+  const uint64_t write_idx = hsa_queue_add_write_index_relaxed(queue, 1);
+  auto *aql = static_cast<hsa_kernel_dispatch_packet_t *>(queue->base_address) +
+              (write_idx & (queue->size - 1));
+  std::memset(aql, 0, sizeof(*aql));
+  aql->setup = 2;
+  aql->workgroup_size_x = kWorkgroupSize;
+  aql->workgroup_size_y = 1;
+  aql->workgroup_size_z = 1;
+  aql->grid_size_x = kGroupsM * kWorkgroupSize;
+  aql->grid_size_y = kGroupsN;
+  aql->grid_size_z = 1;
+  aql->group_segment_size = kSharedBytes;
+  aql->kernel_object = kernel_object;
+  aql->kernarg_address = kernarg;
+  aql->completion_signal = signal;
+
+  uint16_t header = HSA_PACKET_TYPE_KERNEL_DISPATCH << HSA_PACKET_HEADER_TYPE;
+  header |= 1 << HSA_PACKET_HEADER_BARRIER;
+  header |= HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_ACQUIRE_FENCE_SCOPE;
+  header |= HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_RELEASE_FENCE_SCOPE;
+  __atomic_store_n(reinterpret_cast<uint16_t *>(aql), header, __ATOMIC_RELEASE);
+  hsa_signal_store_relaxed(queue->doorbell_signal, write_idx);
+
+  const hsa_signal_value_t val = hsa_signal_wait_scacquire(
+      signal, HSA_SIGNAL_CONDITION_LT, 1, 5'000'000'000ULL, HSA_WAIT_STATE_BLOCKED);
+  ASSERT_EQ(val, 0) << "Kernel dispatch timed out or failed";
+
+  ASSERT_EQ(hsa_memory_copy(c_host.data(), c_dev, kCBytes), HSA_STATUS_SUCCESS);
+
+  uint32_t mismatches = 0;
+  std::vector<uint32_t> row_mismatches(kM, 0);
+  for (size_t i = 0; i < kCElements; ++i) {
+    if (c_host[i] != expected[i]) {
+      ++row_mismatches[i / kN];
+      if (mismatches < 8)
+        ADD_FAILURE() << "mismatch at i=" << i << " (m=" << (i / kN) << ", n=" << (i % kN)
+                      << "): got=" << c_host[i] << " expected=" << expected[i]
+                      << " diff=" << (expected[i] - c_host[i]);
+      ++mismatches;
+    }
+  }
+  if (mismatches != 0) {
+    std::string rows;
+    for (uint32_t m = 0; m < std::min<uint32_t>(kM, 64); ++m) {
+      if (row_mismatches[m] == 0)
+        continue;
+      if (!rows.empty())
+        rows += ", ";
+      rows += std::to_string(m) + ":" + std::to_string(row_mismatches[m]);
+    }
+    ADD_FAILURE() << "row mismatch counts (first 64 rows): " << rows;
+  }
+  EXPECT_EQ(mismatches, 0u) << mismatches << " matmul output mismatches";
+
+  hsa_signal_destroy(signal);
+  hsa_queue_destroy(queue);
+  hsa_amd_memory_pool_free(kernarg);
+  hsa_amd_memory_pool_free(a_dev);
+  hsa_amd_memory_pool_free(b_dev);
+  hsa_amd_memory_pool_free(c_dev);
+  hsa_executable_destroy(executable);
+  hsa_code_object_reader_destroy(reader);
+}
+
+} // namespace
+
+TEST(Cdna4ToCdna3DispatchTest, DynamicCopyLoopTranslates) {
+  Executable exec(kernel_path("dynamic_copy_loop"));
+  ASSERT_TRUE(exec.is_valid());
+  ASSERT_GT(exec.num_code_objects(ROCJITSU_CODE_TARGET_GFX950), 0u);
+  const auto *co = exec.code_object(ROCJITSU_CODE_TARGET_GFX950, 0);
+  ASSERT_NE(co, nullptr);
+
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_CDNA3,
+                              EF_AMDGPU_MACH_AMDGCN_GFX942);
+  auto translated = translator.translate(*co);
+  ASSERT_FALSE(translated.elf_bytes.empty());
+  ASSERT_TRUE(translated.warnings.empty())
+      << "Translation warning: " << translated.warnings.front();
+}
+
+TEST(Cdna4ToCdna3DispatchTest, TritonDynamicMatmulTranslates) {
+  std::vector<uint8_t> translated;
+  ASSERT_NO_FATAL_FAILURE(
+      translate_dynamic_triton_matmul(EF_AMDGPU_MACH_AMDGCN_GFX942, translated));
+}
+
+TEST(Cdna4ToCdna3DispatchTest, DynamicCopyLoopDispatchAndRun) {
+  const hsa_status_t init_status = hsa_init();
+  if (init_status != HSA_STATUS_SUCCESS)
+    GTEST_SKIP() << "hsa_init failed with status " << init_status
+                 << "; CDNA4->CDNA3 dispatch verification requires an HSA-capable host";
+  const HsaShutdownGuard shutdown;
+
+  Cdna3Target target = find_cdna3_target();
+  if (target.agent.handle == 0)
+    GTEST_SKIP() << "Test requires a CDNA3 GPU agent (gfx940/gfx941/gfx942); found: "
+                 << join_seen_isas(target.seen_gpu_isas);
+
+  Executable exec(kernel_path("dynamic_copy_loop"));
+  ASSERT_TRUE(exec.is_valid());
+  ASSERT_GT(exec.num_code_objects(ROCJITSU_CODE_TARGET_GFX950), 0u);
+  const auto *co = exec.code_object(ROCJITSU_CODE_TARGET_GFX950, 0);
+  ASSERT_NE(co, nullptr);
+
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_CDNA3, target.mach);
+  auto translated = translator.translate(*co);
+  ASSERT_FALSE(translated.elf_bytes.empty());
+  ASSERT_TRUE(translated.warnings.empty())
+      << "Translation warning: " << translated.warnings.front();
+
+  ASSERT_NO_FATAL_FAILURE(run_dynamic_copy_loop(translated.elf_bytes, target));
+}
+
+TEST(Cdna4ToCdna3DispatchTest, TritonDynamicMatmulDispatchAndRun) {
+  const std::array<TritonMatmulCase, 11> cases = {{
+      {32, 32, 64},
+      {32, 32, 65},
+      {32, 32, 66},
+      {32, 32, 128},
+      {32, 32, 130},
+      {32, 32, 192},
+      {32, 32, 512},
+      {512, 512, 512},
+      {31, 31, 64},
+      {32, 32, 63},
+      {257, 129, 130},
+  }};
+
+  const hsa_status_t init_status = hsa_init();
+  if (init_status != HSA_STATUS_SUCCESS)
+    GTEST_SKIP() << "hsa_init failed with status " << init_status
+                 << "; CDNA4->CDNA3 dispatch verification requires an HSA-capable host";
+  const HsaShutdownGuard shutdown;
+
+  Cdna3Target target = find_cdna3_target();
+  if (target.agent.handle == 0)
+    GTEST_SKIP() << "Test requires a CDNA3 GPU agent (gfx940/gfx941/gfx942); found: "
+                 << join_seen_isas(target.seen_gpu_isas);
+
+  std::vector<uint8_t> translated;
+  ASSERT_NO_FATAL_FAILURE(translate_dynamic_triton_matmul(target.mach, translated));
+
+  for (const TritonMatmulCase &test_case : cases) {
+    SCOPED_TRACE(::testing::Message()
+                 << "M=" << test_case.m << " N=" << test_case.n << " K=" << test_case.k);
+    ASSERT_NO_FATAL_FAILURE(run_triton_matmul(translated, target, test_case));
+  }
+}
+
+#endif // HAS_HOST_AMDGPU

--- a/emulation/rocjitsu/tests/dbt/device_kernels_translate_tests.cpp
+++ b/emulation/rocjitsu/tests/dbt/device_kernels_translate_tests.cpp
@@ -87,10 +87,10 @@ mutable_kernel_descriptor(MutableKernelDescriptorImage &fixture) {
 
 std::vector<rocjitsu::KdTranslation>
 translate_mutable_descriptor(const MutableKernelDescriptorImage &fixture, rj_code_arch_t guest_arch,
-                             rj_code_arch_t host_arch) {
+                             rj_code_arch_t host_arch,
+                             const rocjitsu::KernelDescriptorTranslationOptions &options = {}) {
   rocjitsu::KernelDescriptorTranslator translator(guest_arch, host_arch);
-  return translator.translate_image(fixture.image, fixture.text_offset, fixture.text_size,
-                                    rocjitsu::KernelDescriptorTranslationOptions{});
+  return translator.translate_image(fixture.image, fixture.text_offset, fixture.text_size, options);
 }
 
 } // namespace
@@ -354,6 +354,44 @@ TEST(KernelDescriptorTranslator, CdnaAccVgprExpansionGrowsUnifiedVgprAllocationF
     EXPECT_EQ(translated->target_vgpr_count, 128u);
     EXPECT_EQ(translated->target_vgpr_granulated, 31u);
   }
+}
+
+TEST(KernelDescriptorTranslator, CdnaToCdnaMovesAccVgprBaseAboveSemanticScratch) {
+  using namespace rocr::llvm::amdhsa;
+
+  auto fixture = mutable_vector_add_descriptor(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_TRUE(fixture.valid);
+
+  auto *kd = mutable_kernel_descriptor(fixture);
+  kd->compute_pgm_rsrc1 = 0;
+  kd->compute_pgm_rsrc3 = 0;
+  AMDHSA_BITS_SET(kd->compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT, 13);
+  AMDHSA_BITS_SET(kd->compute_pgm_rsrc3, COMPUTE_PGM_RSRC3_GFX90A_ACCUM_OFFSET, 23);
+
+  rocjitsu::KernelDescriptorTranslationOptions options;
+  options.minimum_vgprs = 128;
+  const auto translations = translate_mutable_descriptor(fixture, ROCJITSU_CODE_ARCH_CDNA4,
+                                                         ROCJITSU_CODE_ARCH_CDNA3, options);
+  const auto translated =
+      std::find_if(translations.begin(), translations.end(), [&fixture](const auto &translation) {
+        return translation.descriptor_file_offset == fixture.kd_file_off;
+      });
+  ASSERT_NE(translated, translations.end());
+  EXPECT_EQ(translated->accvgpr_base, 96u);
+  EXPECT_EQ(translated->target_accvgpr_base, 128u);
+  EXPECT_EQ(translated->target_vgpr_count, 144u);
+  EXPECT_EQ(translated->target_vgpr_granulated, 17u);
+
+  rocjitsu::AmdGpuCodeObject mutated(fixture.image.data(), fixture.image.size());
+  ASSERT_TRUE(mutated.is_valid());
+  rocjitsu::CodeObjectPatcher patcher(mutated);
+  ASSERT_TRUE(patcher.apply_kernel_descriptor_translation(*translated, ROCJITSU_CODE_ARCH_CDNA3));
+
+  const auto patched_image = patcher.emit();
+  const auto *patched_kd =
+      reinterpret_cast<const kernel_descriptor_t *>(patched_image.data() + fixture.kd_file_off);
+  EXPECT_EQ(AMDHSA_BITS_GET(patched_kd->compute_pgm_rsrc3, COMPUTE_PGM_RSRC3_GFX90A_ACCUM_OFFSET),
+            31u);
 }
 
 TEST(KernelDescriptorTranslator, RdnaWave64UsesAmdhsaDescriptorVgprEncoding) {

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -52,8 +52,13 @@
 #include "rocjitsu/code/dbt/generated/legalization_rdna4_to_cdna4.h"
 #include "rocjitsu/code/dbt/generated/legalization_types.h"
 #include "rocjitsu/code/dbt/kernel_descriptor_translator.h"
+#include "rocjitsu/code/dbt/semantic/rules.h"
 #include "rocjitsu/code/patch/code_object_patcher.h"
 #include "rocjitsu/code/patch/instruction_builder.h"
+#include "rocjitsu/isa/arch/amdgpu/cdna3/machine_insts.h"
+#include "rocjitsu/isa/arch/amdgpu/cdna4/machine_insts.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
 
 #include "rocjitsu/base/rj_compiler.h"
 RJ_DIAGNOSTIC_PUSH
@@ -1302,6 +1307,313 @@ TEST(WaitcntTranslator, EncodeVmcnt0EmitsLoadcntAndStorecnt) {
   EXPECT_TRUE(has_storecnt_dscnt);
 }
 
+constexpr uint16_t kAnyExpectedField = 0xffff;
+
+enum class ExpectedCdna3Kind {
+  Vop3,
+  Vop3pMfma,
+  Ds,
+  Sopp,
+};
+
+struct ExpectedCdna3Inst {
+  ExpectedCdna3Kind kind = ExpectedCdna3Kind::Vop3;
+  uint16_t op = 0;
+  uint16_t vdst = kAnyExpectedField;
+  uint16_t acc_cd = kAnyExpectedField;
+  uint16_t src0 = kAnyExpectedField;
+  uint16_t src1 = kAnyExpectedField;
+  uint16_t src2 = kAnyExpectedField;
+};
+
+struct Cdna4ToCdna3SemanticRuleCase {
+  const char *name = "";
+  uint16_t encoding_id = 0;
+  uint16_t opcode = 0;
+  std::array<uint32_t, 2> words{};
+  std::vector<ExpectedCdna3Inst> expected{};
+};
+
+ExpectedCdna3Inst expect_vop3(uint16_t op) {
+  ExpectedCdna3Inst inst{};
+  inst.kind = ExpectedCdna3Kind::Vop3;
+  inst.op = op;
+  return inst;
+}
+
+ExpectedCdna3Inst expect_mfma(uint16_t op, uint16_t vdst, uint16_t acc_cd, uint16_t src0,
+                              uint16_t src1, uint16_t src2) {
+  ExpectedCdna3Inst inst{};
+  inst.kind = ExpectedCdna3Kind::Vop3pMfma;
+  inst.op = op;
+  inst.vdst = vdst;
+  inst.acc_cd = acc_cd;
+  inst.src0 = src0;
+  inst.src1 = src1;
+  inst.src2 = src2;
+  return inst;
+}
+
+ExpectedCdna3Inst expect_ds(uint16_t op) {
+  ExpectedCdna3Inst inst{};
+  inst.kind = ExpectedCdna3Kind::Ds;
+  inst.op = op;
+  return inst;
+}
+
+ExpectedCdna3Inst expect_sopp(uint16_t op) {
+  ExpectedCdna3Inst inst{};
+  inst.kind = ExpectedCdna3Kind::Sopp;
+  inst.op = op;
+  return inst;
+}
+
+std::vector<ExpectedCdna3Inst> expected_cdna3_bitop3_sequence(bool b16) {
+  // Truth table 0xde lowers to S2 ^ S1 ^ (S1 & S2) ^ S0 ^ (S0 & S1).
+  std::vector<ExpectedCdna3Inst> expected = {
+      expect_vop3(321), // v_mov_b32
+      expect_vop3(277), // v_xor_b32
+      expect_vop3(275), // v_and_b32
+      expect_vop3(277), // v_xor_b32
+      expect_vop3(277), // v_xor_b32
+      expect_vop3(275), // v_and_b32
+      expect_vop3(277), // v_xor_b32
+  };
+  if (b16) {
+    expected.push_back(expect_vop3(274)); // v_lshlrev_b32
+    expected.push_back(expect_vop3(272)); // v_lshrrev_b32
+  }
+  expected.push_back(expect_vop3(321)); // v_mov_b32 copy scratch accumulator to vdst.
+  expected.push_back(expect_sopp(2));   // s_branch back to original fallthrough.
+  return expected;
+}
+
+std::vector<ExpectedCdna3Inst> expected_cdna3_mfma_sequence(uint16_t narrow_op,
+                                                            uint16_t src2 = 128) {
+  return {
+      expect_mfma(narrow_op, 0, 1, 256, 260, src2),
+      expect_mfma(narrow_op, 0, 1, 258, 262, 256),
+      expect_sopp(2),
+  };
+}
+
+std::vector<ExpectedCdna3Inst> expected_cdna3_raw_b16_pack_sequence() {
+  return {
+      expect_vop3(321), // v_mov_b32 -1
+      expect_vop3(272), // v_lshrrev_b32 16, mask
+      expect_vop3(275), // v_and_b32 low half
+      expect_vop3(275), // v_and_b32 high half
+      expect_vop3(274), // v_lshlrev_b32 16, high half
+      expect_vop3(276), // v_or_b32
+  };
+}
+
+std::vector<ExpectedCdna3Inst> expected_cdna3_ds_read_b64_tr_b16_sequence() {
+  std::vector<ExpectedCdna3Inst> expected = {
+      expect_ds(118),   // ds_read_b64
+      expect_sopp(12),  // s_waitcnt lgkmcnt(0)
+      expect_vop3(652), // v_mbcnt_lo_u32_b32
+      expect_vop3(653), // v_mbcnt_hi_u32_b32
+      expect_vop3(275), // v_and_b32
+      expect_vop3(274), // v_lshlrev_b32
+      expect_vop3(275), // v_and_b32
+      expect_vop3(274), // v_lshlrev_b32
+      expect_vop3(275), // v_and_b32
+      expect_vop3(276), // v_or_b32
+      expect_vop3(308), // v_add_u32
+      expect_vop3(274), // v_lshlrev_b32
+      expect_vop3(276), // v_or_b32
+      expect_ds(63),    // ds_bpermute_b32
+      expect_ds(63),    // ds_bpermute_b32
+      expect_sopp(12),  // s_waitcnt lgkmcnt(0)
+      expect_vop3(493), // v_perm_b32
+      expect_vop3(308), // v_add_u32
+      expect_ds(63),    expect_ds(63), expect_sopp(12), expect_vop3(493),
+  };
+
+  auto first_pack = expected_cdna3_raw_b16_pack_sequence();
+  expected.insert(expected.end(), first_pack.begin(), first_pack.end());
+  expected.insert(expected.end(), {
+                                      expect_vop3(308),
+                                      expect_ds(63),
+                                      expect_ds(63),
+                                      expect_sopp(12),
+                                      expect_vop3(493),
+                                      expect_vop3(308),
+                                      expect_ds(63),
+                                      expect_ds(63),
+                                      expect_sopp(12),
+                                      expect_vop3(493),
+                                  });
+  auto second_pack = expected_cdna3_raw_b16_pack_sequence();
+  expected.insert(expected.end(), second_pack.begin(), second_pack.end());
+  expected.push_back(expect_sopp(2));
+  return expected;
+}
+
+template <typename MachineInst>
+std::array<uint32_t, 2> encode_two_word_inst(const MachineInst &inst) {
+  std::array<uint32_t, 2> words{};
+  std::memcpy(words.data(), &inst, sizeof(inst));
+  return words;
+}
+
+std::array<uint32_t, 2> make_cdna4_bitop3_words(uint16_t opcode, uint8_t vdst) {
+  rocjitsu::cdna4::Vop3MachineInst inst{};
+  inst.encoding = 0x34;
+  inst.op = opcode;
+  inst.vdst = vdst;
+  inst.src0 = static_cast<uint16_t>(256 + vdst + 1);
+  inst.src1 = static_cast<uint16_t>(256 + vdst + 2);
+  inst.src2 = static_cast<uint16_t>(256 + vdst + 3);
+
+  // Use a non-trivial LUT so the generic expansion emits real AND/XOR work and
+  // cannot accidentally pass by lowering to a simple move.
+  constexpr uint8_t kTruthTable = 0xde;
+  inst.omod = kTruthTable >> 6;
+  inst.abs = (kTruthTable >> 3) & 0x7;
+  inst.neg = kTruthTable & 0x7;
+  return encode_two_word_inst(inst);
+}
+
+std::array<uint32_t, 2> make_cdna4_mfma_words(uint8_t opcode, uint8_t vdst, uint16_t src0,
+                                              uint16_t src1, uint16_t src2 = 128) {
+  rocjitsu::cdna4::Vop3pMfmaMachineInst inst{};
+  inst.encoding = 0x1A7;
+  inst.op = opcode;
+  inst.vdst = vdst;
+  inst.acc_cd = 1;
+  inst.src0 = src0;
+  inst.src1 = src1;
+  inst.src2 = src2;
+  return encode_two_word_inst(inst);
+}
+
+std::array<uint32_t, 2> make_cdna4_ds_read_b64_tr_b16_words() {
+  rocjitsu::cdna4::DsMachineInst inst{};
+  inst.encoding = 0x36;
+  inst.op = 227;
+  inst.addr = 2;
+  inst.vdst = 0;
+  return encode_two_word_inst(inst);
+}
+
+std::vector<Cdna4ToCdna3SemanticRuleCase> cdna4_to_cdna3_semantic_rule_cases() {
+  return {
+      {"VBitop3B16", 0x1A4, 563, make_cdna4_bitop3_words(563, 8),
+       expected_cdna3_bitop3_sequence(true)},
+      {"VBitop3B32", 0x1A4, 564, make_cdna4_bitop3_words(564, 16),
+       expected_cdna3_bitop3_sequence(false)},
+      {"MfmaF32_16x16x32F16", 0x1A7, 84, make_cdna4_mfma_words(84, 0, 256, 260),
+       expected_cdna3_mfma_sequence(77)},
+      {"MfmaF32_32x32x16F16", 0x1A7, 85, make_cdna4_mfma_words(85, 0, 256, 260),
+       expected_cdna3_mfma_sequence(76)},
+      {"MfmaF32_16x16x32F16AccumVgpr", 0x1A7, 84, make_cdna4_mfma_words(84, 0, 256, 260, 272),
+       expected_cdna3_mfma_sequence(77, 272)},
+      {"MfmaF32_32x32x16F16AccumVgpr", 0x1A7, 85, make_cdna4_mfma_words(85, 0, 256, 260, 272),
+       expected_cdna3_mfma_sequence(76, 272)},
+      {"DsReadB64TrB16", 0x1B3, 227, make_cdna4_ds_read_b64_tr_b16_words(),
+       expected_cdna3_ds_read_b64_tr_b16_sequence()},
+  };
+}
+
+bool has_cdna4_to_cdna3_semantic_rule(uint16_t encoding_id, uint16_t opcode) {
+  for (const auto &rule : rocjitsu::semantic_expand_rules_cdna4_to_cdna3()) {
+    if (rule.src_encoding_id == encoding_id && rule.src_opcode == opcode)
+      return true;
+  }
+  return false;
+}
+
+bool has_cdna4_to_cdna3_semantic_rule_case(uint16_t encoding_id, uint16_t opcode) {
+  for (const auto &test_case : cdna4_to_cdna3_semantic_rule_cases()) {
+    if (test_case.encoding_id == encoding_id && test_case.opcode == opcode)
+      return true;
+  }
+  return false;
+}
+
+void expect_field_matches(uint16_t expected, uint16_t actual, std::string_view field_name) {
+  if (expected != kAnyExpectedField)
+    EXPECT_EQ(actual, expected) << field_name;
+}
+
+void expect_cdna3_instruction_matches(const rocjitsu::Instruction &inst,
+                                      const ExpectedCdna3Inst &expected) {
+  const uint32_t *raw = inst.raw_encoding();
+  ASSERT_NE(raw, nullptr);
+
+  switch (expected.kind) {
+  case ExpectedCdna3Kind::Vop3: {
+    rocjitsu::cdna3::Vop3MachineInst actual{};
+    std::memcpy(&actual, raw, sizeof(actual));
+    EXPECT_EQ(actual.encoding, 0x34u);
+    EXPECT_EQ(actual.op, expected.op);
+    expect_field_matches(expected.vdst, static_cast<uint16_t>(actual.vdst), "vdst");
+    expect_field_matches(expected.src0, static_cast<uint16_t>(actual.src0), "src0");
+    expect_field_matches(expected.src1, static_cast<uint16_t>(actual.src1), "src1");
+    expect_field_matches(expected.src2, static_cast<uint16_t>(actual.src2), "src2");
+    break;
+  }
+  case ExpectedCdna3Kind::Vop3pMfma: {
+    rocjitsu::cdna3::Vop3pMfmaMachineInst actual{};
+    std::memcpy(&actual, raw, sizeof(actual));
+    EXPECT_EQ(actual.encoding, 0x1A7u);
+    EXPECT_EQ(actual.op, expected.op);
+    expect_field_matches(expected.vdst, static_cast<uint16_t>(actual.vdst), "vdst");
+    expect_field_matches(expected.acc_cd, static_cast<uint16_t>(actual.acc_cd), "acc_cd");
+    expect_field_matches(expected.src0, static_cast<uint16_t>(actual.src0), "src0");
+    expect_field_matches(expected.src1, static_cast<uint16_t>(actual.src1), "src1");
+    expect_field_matches(expected.src2, static_cast<uint16_t>(actual.src2), "src2");
+    break;
+  }
+  case ExpectedCdna3Kind::Ds: {
+    rocjitsu::cdna3::DsMachineInst actual{};
+    std::memcpy(&actual, raw, sizeof(actual));
+    EXPECT_EQ(actual.encoding, 0x36u);
+    EXPECT_EQ(actual.op, expected.op);
+    expect_field_matches(expected.vdst, static_cast<uint16_t>(actual.vdst), "vdst");
+    break;
+  }
+  case ExpectedCdna3Kind::Sopp: {
+    rocjitsu::cdna3::SoppMachineInst actual{};
+    std::memcpy(&actual, raw, sizeof(actual));
+    EXPECT_EQ(actual.encoding, 0x17Fu);
+    EXPECT_EQ(actual.op, expected.op);
+    break;
+  }
+  }
+}
+
+void expect_cdna3_code_cave_matches(const rocjitsu::Section &translations,
+                                    const std::vector<ExpectedCdna3Inst> &expected) {
+  ASSERT_EQ(translations.size() % sizeof(uint32_t), 0u);
+  ASSERT_GT(translations.size(), 0u);
+
+  auto decoder = rocjitsu::Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_NE(decoder, nullptr);
+
+  const auto *words = reinterpret_cast<const uint32_t *>(translations.data());
+  const size_t word_count = translations.size() / sizeof(uint32_t);
+  std::vector<std::unique_ptr<rocjitsu::Instruction>> actual;
+  for (size_t pc = 0; pc < word_count;) {
+    SCOPED_TRACE(pc);
+    auto inst = std::unique_ptr<rocjitsu::Instruction>(decoder->decode(&words[pc]));
+    ASSERT_NE(inst, nullptr);
+    ASSERT_GT(inst->size(), 0u);
+    ASSERT_EQ(inst->size() % sizeof(uint32_t), 0u);
+    ASSERT_LE(pc + inst->size() / sizeof(uint32_t), word_count);
+    pc += inst->size() / sizeof(uint32_t);
+    actual.push_back(std::move(inst));
+  }
+
+  ASSERT_EQ(actual.size(), expected.size());
+  for (size_t i = 0; i < expected.size(); ++i) {
+    SCOPED_TRACE(i);
+    expect_cdna3_instruction_matches(*actual[i], expected[i]);
+  }
+}
+
 // --- Synthetic BinaryTranslator integration tests ---
 TEST(BinaryTranslatorE2E, TranslatesMultiKernelCodeObject) {
   using KD = rocr::llvm::amdhsa::kernel_descriptor_t;
@@ -1367,6 +1679,59 @@ TEST(BinaryTranslatorE2E, TranslatesMultiKernelCodeObject) {
   EXPECT_EQ(translated_entries, (std::vector<uint64_t>{0, sizeof(uint32_t)}));
   EXPECT_EQ(translated_descriptor_offsets, original_descriptor_offsets);
 }
+
+TEST(BinaryTranslatorE2E, Cdna4ToCdna3SemanticExpandRulesHaveTranslationFixtures) {
+  const auto test_cases = cdna4_to_cdna3_semantic_rule_cases();
+  const auto rules = rocjitsu::semantic_expand_rules_cdna4_to_cdna3();
+
+  for (const auto &rule : rules) {
+    EXPECT_TRUE(has_cdna4_to_cdna3_semantic_rule_case(rule.src_encoding_id, rule.src_opcode))
+        << "missing fixture for CDNA4->CDNA3 semantic rule encoding=0x" << std::hex
+        << rule.src_encoding_id << " opcode=" << rule.src_opcode << std::dec;
+  }
+  for (const auto &test_case : test_cases) {
+    EXPECT_TRUE(has_cdna4_to_cdna3_semantic_rule(test_case.encoding_id, test_case.opcode))
+        << "test fixture has no CDNA4->CDNA3 semantic rule: " << test_case.name;
+  }
+}
+
+class Cdna4ToCdna3SemanticRuleTranslationTest
+    : public ::testing::TestWithParam<Cdna4ToCdna3SemanticRuleCase> {};
+
+TEST_P(Cdna4ToCdna3SemanticRuleTranslationTest, TranslatesSingleInstruction) {
+  const auto &test_case = GetParam();
+  SCOPED_TRACE(test_case.name);
+
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text();
+  rocjitsu::AmdGpuCodeObject source_layout(image.data(), image.size());
+  ASSERT_TRUE(source_layout.is_valid());
+  ASSERT_FALSE(source_layout.text_sections().empty());
+
+  const auto *source_text = source_layout.text_sections()[0];
+  ASSERT_EQ(source_text->size(), test_case.words.size() * sizeof(uint32_t));
+  std::memcpy(image.data() + source_text->sectionOffset(), test_case.words.data(),
+              test_case.words.size() * sizeof(uint32_t));
+
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_CDNA3);
+  auto result = translator.translate(source);
+  ASSERT_FALSE(result.elf_bytes.empty());
+  ASSERT_TRUE(result.warnings.empty()) << result.warnings.front();
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_TRUE(translated.is_valid());
+  const rocjitsu::Section *translations = rocjitsu::find_section(translated, ".rj_translations");
+  ASSERT_NE(translations, nullptr);
+  expect_cdna3_code_cave_matches(*translations, test_case.expected);
+}
+
+INSTANTIATE_TEST_SUITE_P(ImplementedRules, Cdna4ToCdna3SemanticRuleTranslationTest,
+                         ::testing::ValuesIn(cdna4_to_cdna3_semantic_rule_cases()),
+                         [](const ::testing::TestParamInfo<Cdna4ToCdna3SemanticRuleCase> &info) {
+                           return std::string(info.param.name);
+                         });
 
 TEST(KernelDescriptorTranslator, IgnoresNonAllocExecutableSectionsForEntryRange) {
   using KD = rocr::llvm::amdhsa::kernel_descriptor_t;

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -1383,13 +1383,15 @@ std::vector<ExpectedCdna3Inst> expected_cdna3_bitop3_sequence(bool b16) {
     expected.push_back(expect_vop3(274)); // v_lshlrev_b32
     expected.push_back(expect_vop3(272)); // v_lshrrev_b32
   }
+  expected.push_back(expect_vop3(321)); // v_mov_b32 copy scratch accumulator to vdst.
   expected.push_back(expect_sopp(2)); // s_branch back to original fallthrough.
   return expected;
 }
 
-std::vector<ExpectedCdna3Inst> expected_cdna3_mfma_sequence(uint16_t narrow_op) {
+std::vector<ExpectedCdna3Inst> expected_cdna3_mfma_sequence(uint16_t narrow_op,
+                                                            uint16_t src2 = 128) {
   return {
-      expect_mfma(narrow_op, 0, 1, 256, 260, 128),
+      expect_mfma(narrow_op, 0, 1, 256, 260, src2),
       expect_mfma(narrow_op, 0, 1, 258, 262, 256),
       expect_sopp(2),
   };
@@ -1478,7 +1480,7 @@ std::array<uint32_t, 2> make_cdna4_bitop3_words(uint16_t opcode, uint8_t vdst) {
 }
 
 std::array<uint32_t, 2> make_cdna4_mfma_words(uint8_t opcode, uint8_t vdst, uint16_t src0,
-                                              uint16_t src1) {
+                                              uint16_t src1, uint16_t src2 = 128) {
   rocjitsu::cdna4::Vop3pMfmaMachineInst inst{};
   inst.encoding = 0x1A7;
   inst.op = opcode;
@@ -1486,7 +1488,7 @@ std::array<uint32_t, 2> make_cdna4_mfma_words(uint8_t opcode, uint8_t vdst, uint
   inst.acc_cd = 1;
   inst.src0 = src0;
   inst.src1 = src1;
-  inst.src2 = 128; // Inline zero accumulator.
+  inst.src2 = src2;
   return encode_two_word_inst(inst);
 }
 
@@ -1509,6 +1511,10 @@ std::vector<Cdna4ToCdna3SemanticRuleCase> cdna4_to_cdna3_semantic_rule_cases() {
        expected_cdna3_mfma_sequence(77)},
       {"MfmaF32_32x32x16F16", 0x1A7, 85, make_cdna4_mfma_words(85, 0, 256, 260),
        expected_cdna3_mfma_sequence(76)},
+      {"MfmaF32_16x16x32F16AccumVgpr", 0x1A7, 84,
+       make_cdna4_mfma_words(84, 0, 256, 260, 272), expected_cdna3_mfma_sequence(77, 272)},
+      {"MfmaF32_32x32x16F16AccumVgpr", 0x1A7, 85,
+       make_cdna4_mfma_words(85, 0, 256, 260, 272), expected_cdna3_mfma_sequence(76, 272)},
       {"DsReadB64TrB16", 0x1B3, 227, make_cdna4_ds_read_b64_tr_b16_words(),
        expected_cdna3_ds_read_b64_tr_b16_sequence()},
   };
@@ -1681,7 +1687,6 @@ TEST(BinaryTranslatorE2E, Cdna4ToCdna3SemanticExpandRulesHaveTranslationFixtures
   const auto test_cases = cdna4_to_cdna3_semantic_rule_cases();
   const auto rules = rocjitsu::semantic_expand_rules_cdna4_to_cdna3();
 
-  ASSERT_EQ(test_cases.size(), rules.size());
   for (const auto &rule : rules) {
     EXPECT_TRUE(has_cdna4_to_cdna3_semantic_rule_case(rule.src_encoding_id, rule.src_opcode))
         << "missing fixture for CDNA4->CDNA3 semantic rule encoding=0x" << std::hex

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -52,8 +52,13 @@
 #include "rocjitsu/code/dbt/generated/legalization_rdna4_to_cdna4.h"
 #include "rocjitsu/code/dbt/generated/legalization_types.h"
 #include "rocjitsu/code/dbt/kernel_descriptor_translator.h"
+#include "rocjitsu/code/dbt/semantic/rules.h"
 #include "rocjitsu/code/patch/code_object_patcher.h"
 #include "rocjitsu/code/patch/instruction_builder.h"
+#include "rocjitsu/isa/arch/amdgpu/cdna3/machine_insts.h"
+#include "rocjitsu/isa/arch/amdgpu/cdna4/machine_insts.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
 
 #include "rocjitsu/base/rj_compiler.h"
 RJ_DIAGNOSTIC_PUSH
@@ -1302,6 +1307,310 @@ TEST(WaitcntTranslator, EncodeVmcnt0EmitsLoadcntAndStorecnt) {
   EXPECT_TRUE(has_storecnt_dscnt);
 }
 
+constexpr uint16_t kAnyExpectedField = 0xffff;
+
+enum class ExpectedCdna3Kind {
+  Vop3,
+  Vop3pMfma,
+  Ds,
+  Sopp,
+};
+
+struct ExpectedCdna3Inst {
+  ExpectedCdna3Kind kind = ExpectedCdna3Kind::Vop3;
+  uint16_t op = 0;
+  uint16_t vdst = kAnyExpectedField;
+  uint16_t acc_cd = kAnyExpectedField;
+  uint16_t src0 = kAnyExpectedField;
+  uint16_t src1 = kAnyExpectedField;
+  uint16_t src2 = kAnyExpectedField;
+};
+
+struct Cdna4ToCdna3SemanticRuleCase {
+  const char *name = "";
+  uint16_t encoding_id = 0;
+  uint16_t opcode = 0;
+  std::array<uint32_t, 2> words{};
+  std::vector<ExpectedCdna3Inst> expected{};
+};
+
+ExpectedCdna3Inst expect_vop3(uint16_t op) {
+  ExpectedCdna3Inst inst{};
+  inst.kind = ExpectedCdna3Kind::Vop3;
+  inst.op = op;
+  return inst;
+}
+
+ExpectedCdna3Inst expect_mfma(uint16_t op, uint16_t vdst, uint16_t acc_cd, uint16_t src0,
+                              uint16_t src1, uint16_t src2) {
+  ExpectedCdna3Inst inst{};
+  inst.kind = ExpectedCdna3Kind::Vop3pMfma;
+  inst.op = op;
+  inst.vdst = vdst;
+  inst.acc_cd = acc_cd;
+  inst.src0 = src0;
+  inst.src1 = src1;
+  inst.src2 = src2;
+  return inst;
+}
+
+ExpectedCdna3Inst expect_ds(uint16_t op) {
+  ExpectedCdna3Inst inst{};
+  inst.kind = ExpectedCdna3Kind::Ds;
+  inst.op = op;
+  return inst;
+}
+
+ExpectedCdna3Inst expect_sopp(uint16_t op) {
+  ExpectedCdna3Inst inst{};
+  inst.kind = ExpectedCdna3Kind::Sopp;
+  inst.op = op;
+  return inst;
+}
+
+std::vector<ExpectedCdna3Inst> expected_cdna3_bitop3_sequence(bool b16) {
+  // Truth table 0xde lowers to S2 ^ S1 ^ (S1 & S2) ^ S0 ^ (S0 & S1).
+  std::vector<ExpectedCdna3Inst> expected = {
+      expect_vop3(321), // v_mov_b32
+      expect_vop3(277), // v_xor_b32
+      expect_vop3(275), // v_and_b32
+      expect_vop3(277), // v_xor_b32
+      expect_vop3(277), // v_xor_b32
+      expect_vop3(275), // v_and_b32
+      expect_vop3(277), // v_xor_b32
+  };
+  if (b16) {
+    expected.push_back(expect_vop3(274)); // v_lshlrev_b32
+    expected.push_back(expect_vop3(272)); // v_lshrrev_b32
+  }
+  expected.push_back(expect_sopp(2)); // s_branch back to original fallthrough.
+  return expected;
+}
+
+std::vector<ExpectedCdna3Inst> expected_cdna3_mfma_sequence(uint16_t narrow_op) {
+  return {
+      expect_mfma(narrow_op, 0, 1, 256, 260, 128),
+      expect_mfma(narrow_op, 0, 1, 258, 262, 256),
+      expect_sopp(2),
+  };
+}
+
+std::vector<ExpectedCdna3Inst> expected_cdna3_raw_b16_pack_sequence() {
+  return {
+      expect_vop3(321), // v_mov_b32 -1
+      expect_vop3(272), // v_lshrrev_b32 16, mask
+      expect_vop3(275), // v_and_b32 low half
+      expect_vop3(275), // v_and_b32 high half
+      expect_vop3(274), // v_lshlrev_b32 16, high half
+      expect_vop3(276), // v_or_b32
+  };
+}
+
+std::vector<ExpectedCdna3Inst> expected_cdna3_ds_read_b64_tr_b16_sequence() {
+  std::vector<ExpectedCdna3Inst> expected = {
+      expect_ds(118),   // ds_read_b64
+      expect_sopp(12),  // s_waitcnt lgkmcnt(0)
+      expect_vop3(652), // v_mbcnt_lo_u32_b32
+      expect_vop3(653), // v_mbcnt_hi_u32_b32
+      expect_vop3(275), // v_and_b32
+      expect_vop3(274), // v_lshlrev_b32
+      expect_vop3(275), // v_and_b32
+      expect_vop3(274), // v_lshlrev_b32
+      expect_vop3(275), // v_and_b32
+      expect_vop3(276), // v_or_b32
+      expect_vop3(308), // v_add_u32
+      expect_vop3(274), // v_lshlrev_b32
+      expect_vop3(276), // v_or_b32
+      expect_ds(63),    // ds_bpermute_b32
+      expect_ds(63),    // ds_bpermute_b32
+      expect_sopp(12),  // s_waitcnt lgkmcnt(0)
+      expect_vop3(493), // v_perm_b32
+      expect_vop3(308), // v_add_u32
+      expect_ds(63),
+      expect_ds(63),
+      expect_sopp(12),
+      expect_vop3(493),
+  };
+
+  auto first_pack = expected_cdna3_raw_b16_pack_sequence();
+  expected.insert(expected.end(), first_pack.begin(), first_pack.end());
+  expected.insert(expected.end(), {
+                                    expect_vop3(308),
+                                    expect_ds(63),
+                                    expect_ds(63),
+                                    expect_sopp(12),
+                                    expect_vop3(493),
+                                    expect_vop3(308),
+                                    expect_ds(63),
+                                    expect_ds(63),
+                                    expect_sopp(12),
+                                    expect_vop3(493),
+                                });
+  auto second_pack = expected_cdna3_raw_b16_pack_sequence();
+  expected.insert(expected.end(), second_pack.begin(), second_pack.end());
+  expected.push_back(expect_sopp(2));
+  return expected;
+}
+
+template <typename MachineInst>
+std::array<uint32_t, 2> encode_two_word_inst(const MachineInst &inst) {
+  std::array<uint32_t, 2> words{};
+  std::memcpy(words.data(), &inst, sizeof(inst));
+  return words;
+}
+
+std::array<uint32_t, 2> make_cdna4_bitop3_words(uint16_t opcode, uint8_t vdst) {
+  rocjitsu::cdna4::Vop3MachineInst inst{};
+  inst.encoding = 0x34;
+  inst.op = opcode;
+  inst.vdst = vdst;
+  inst.src0 = static_cast<uint16_t>(256 + vdst + 1);
+  inst.src1 = static_cast<uint16_t>(256 + vdst + 2);
+  inst.src2 = static_cast<uint16_t>(256 + vdst + 3);
+
+  // Use a non-trivial LUT so the generic expansion emits real AND/XOR work and
+  // cannot accidentally pass by lowering to a simple move.
+  constexpr uint8_t kTruthTable = 0xde;
+  inst.omod = kTruthTable >> 6;
+  inst.abs = (kTruthTable >> 3) & 0x7;
+  inst.neg = kTruthTable & 0x7;
+  return encode_two_word_inst(inst);
+}
+
+std::array<uint32_t, 2> make_cdna4_mfma_words(uint8_t opcode, uint8_t vdst, uint16_t src0,
+                                              uint16_t src1) {
+  rocjitsu::cdna4::Vop3pMfmaMachineInst inst{};
+  inst.encoding = 0x1A7;
+  inst.op = opcode;
+  inst.vdst = vdst;
+  inst.acc_cd = 1;
+  inst.src0 = src0;
+  inst.src1 = src1;
+  inst.src2 = 128; // Inline zero accumulator.
+  return encode_two_word_inst(inst);
+}
+
+std::array<uint32_t, 2> make_cdna4_ds_read_b64_tr_b16_words() {
+  rocjitsu::cdna4::DsMachineInst inst{};
+  inst.encoding = 0x36;
+  inst.op = 227;
+  inst.addr = 2;
+  inst.vdst = 0;
+  return encode_two_word_inst(inst);
+}
+
+std::vector<Cdna4ToCdna3SemanticRuleCase> cdna4_to_cdna3_semantic_rule_cases() {
+  return {
+      {"VBitop3B16", 0x1A4, 563, make_cdna4_bitop3_words(563, 8),
+       expected_cdna3_bitop3_sequence(true)},
+      {"VBitop3B32", 0x1A4, 564, make_cdna4_bitop3_words(564, 16),
+       expected_cdna3_bitop3_sequence(false)},
+      {"MfmaF32_16x16x32F16", 0x1A7, 84, make_cdna4_mfma_words(84, 0, 256, 260),
+       expected_cdna3_mfma_sequence(77)},
+      {"MfmaF32_32x32x16F16", 0x1A7, 85, make_cdna4_mfma_words(85, 0, 256, 260),
+       expected_cdna3_mfma_sequence(76)},
+      {"DsReadB64TrB16", 0x1B3, 227, make_cdna4_ds_read_b64_tr_b16_words(),
+       expected_cdna3_ds_read_b64_tr_b16_sequence()},
+  };
+}
+
+bool has_cdna4_to_cdna3_semantic_rule(uint16_t encoding_id, uint16_t opcode) {
+  for (const auto &rule : rocjitsu::semantic_expand_rules_cdna4_to_cdna3()) {
+    if (rule.src_encoding_id == encoding_id && rule.src_opcode == opcode)
+      return true;
+  }
+  return false;
+}
+
+bool has_cdna4_to_cdna3_semantic_rule_case(uint16_t encoding_id, uint16_t opcode) {
+  for (const auto &test_case : cdna4_to_cdna3_semantic_rule_cases()) {
+    if (test_case.encoding_id == encoding_id && test_case.opcode == opcode)
+      return true;
+  }
+  return false;
+}
+
+void expect_field_matches(uint16_t expected, uint16_t actual, std::string_view field_name) {
+  if (expected != kAnyExpectedField)
+    EXPECT_EQ(actual, expected) << field_name;
+}
+
+void expect_cdna3_instruction_matches(const rocjitsu::Instruction &inst,
+                                      const ExpectedCdna3Inst &expected) {
+  const uint32_t *raw = inst.raw_encoding();
+  ASSERT_NE(raw, nullptr);
+
+  switch (expected.kind) {
+  case ExpectedCdna3Kind::Vop3: {
+    rocjitsu::cdna3::Vop3MachineInst actual{};
+    std::memcpy(&actual, raw, sizeof(actual));
+    EXPECT_EQ(actual.encoding, 0x34u);
+    EXPECT_EQ(actual.op, expected.op);
+    expect_field_matches(expected.vdst, static_cast<uint16_t>(actual.vdst), "vdst");
+    expect_field_matches(expected.src0, static_cast<uint16_t>(actual.src0), "src0");
+    expect_field_matches(expected.src1, static_cast<uint16_t>(actual.src1), "src1");
+    expect_field_matches(expected.src2, static_cast<uint16_t>(actual.src2), "src2");
+    break;
+  }
+  case ExpectedCdna3Kind::Vop3pMfma: {
+    rocjitsu::cdna3::Vop3pMfmaMachineInst actual{};
+    std::memcpy(&actual, raw, sizeof(actual));
+    EXPECT_EQ(actual.encoding, 0x1A7u);
+    EXPECT_EQ(actual.op, expected.op);
+    expect_field_matches(expected.vdst, static_cast<uint16_t>(actual.vdst), "vdst");
+    expect_field_matches(expected.acc_cd, static_cast<uint16_t>(actual.acc_cd), "acc_cd");
+    expect_field_matches(expected.src0, static_cast<uint16_t>(actual.src0), "src0");
+    expect_field_matches(expected.src1, static_cast<uint16_t>(actual.src1), "src1");
+    expect_field_matches(expected.src2, static_cast<uint16_t>(actual.src2), "src2");
+    break;
+  }
+  case ExpectedCdna3Kind::Ds: {
+    rocjitsu::cdna3::DsMachineInst actual{};
+    std::memcpy(&actual, raw, sizeof(actual));
+    EXPECT_EQ(actual.encoding, 0x36u);
+    EXPECT_EQ(actual.op, expected.op);
+    expect_field_matches(expected.vdst, static_cast<uint16_t>(actual.vdst), "vdst");
+    break;
+  }
+  case ExpectedCdna3Kind::Sopp: {
+    rocjitsu::cdna3::SoppMachineInst actual{};
+    std::memcpy(&actual, raw, sizeof(actual));
+    EXPECT_EQ(actual.encoding, 0x17Fu);
+    EXPECT_EQ(actual.op, expected.op);
+    break;
+  }
+  }
+}
+
+void expect_cdna3_code_cave_matches(const rocjitsu::Section &translations,
+                                    const std::vector<ExpectedCdna3Inst> &expected) {
+  ASSERT_EQ(translations.size() % sizeof(uint32_t), 0u);
+  ASSERT_GT(translations.size(), 0u);
+
+  auto decoder = rocjitsu::Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_NE(decoder, nullptr);
+
+  const auto *words = reinterpret_cast<const uint32_t *>(translations.data());
+  const size_t word_count = translations.size() / sizeof(uint32_t);
+  std::vector<std::unique_ptr<rocjitsu::Instruction>> actual;
+  for (size_t pc = 0; pc < word_count;) {
+    SCOPED_TRACE(pc);
+    auto inst = std::unique_ptr<rocjitsu::Instruction>(decoder->decode(&words[pc]));
+    ASSERT_NE(inst, nullptr);
+    ASSERT_GT(inst->size(), 0u);
+    ASSERT_EQ(inst->size() % sizeof(uint32_t), 0u);
+    ASSERT_LE(pc + inst->size() / sizeof(uint32_t), word_count);
+    pc += inst->size() / sizeof(uint32_t);
+    actual.push_back(std::move(inst));
+  }
+
+  ASSERT_EQ(actual.size(), expected.size());
+  for (size_t i = 0; i < expected.size(); ++i) {
+    SCOPED_TRACE(i);
+    expect_cdna3_instruction_matches(*actual[i], expected[i]);
+  }
+}
+
 // --- Synthetic BinaryTranslator integration tests ---
 TEST(BinaryTranslatorE2E, TranslatesMultiKernelCodeObject) {
   using KD = rocr::llvm::amdhsa::kernel_descriptor_t;
@@ -1367,6 +1676,60 @@ TEST(BinaryTranslatorE2E, TranslatesMultiKernelCodeObject) {
   EXPECT_EQ(translated_entries, (std::vector<uint64_t>{0, sizeof(uint32_t)}));
   EXPECT_EQ(translated_descriptor_offsets, original_descriptor_offsets);
 }
+
+TEST(BinaryTranslatorE2E, Cdna4ToCdna3SemanticExpandRulesHaveTranslationFixtures) {
+  const auto test_cases = cdna4_to_cdna3_semantic_rule_cases();
+  const auto rules = rocjitsu::semantic_expand_rules_cdna4_to_cdna3();
+
+  ASSERT_EQ(test_cases.size(), rules.size());
+  for (const auto &rule : rules) {
+    EXPECT_TRUE(has_cdna4_to_cdna3_semantic_rule_case(rule.src_encoding_id, rule.src_opcode))
+        << "missing fixture for CDNA4->CDNA3 semantic rule encoding=0x" << std::hex
+        << rule.src_encoding_id << " opcode=" << rule.src_opcode << std::dec;
+  }
+  for (const auto &test_case : test_cases) {
+    EXPECT_TRUE(has_cdna4_to_cdna3_semantic_rule(test_case.encoding_id, test_case.opcode))
+        << "test fixture has no CDNA4->CDNA3 semantic rule: " << test_case.name;
+  }
+}
+
+class Cdna4ToCdna3SemanticRuleTranslationTest
+    : public ::testing::TestWithParam<Cdna4ToCdna3SemanticRuleCase> {};
+
+TEST_P(Cdna4ToCdna3SemanticRuleTranslationTest, TranslatesSingleInstruction) {
+  const auto &test_case = GetParam();
+  SCOPED_TRACE(test_case.name);
+
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text();
+  rocjitsu::AmdGpuCodeObject source_layout(image.data(), image.size());
+  ASSERT_TRUE(source_layout.is_valid());
+  ASSERT_FALSE(source_layout.text_sections().empty());
+
+  const auto *source_text = source_layout.text_sections()[0];
+  ASSERT_EQ(source_text->size(), test_case.words.size() * sizeof(uint32_t));
+  std::memcpy(image.data() + source_text->sectionOffset(), test_case.words.data(),
+              test_case.words.size() * sizeof(uint32_t));
+
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_CDNA3);
+  auto result = translator.translate(source);
+  ASSERT_FALSE(result.elf_bytes.empty());
+  ASSERT_TRUE(result.warnings.empty()) << result.warnings.front();
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_TRUE(translated.is_valid());
+  const rocjitsu::Section *translations = rocjitsu::find_section(translated, ".rj_translations");
+  ASSERT_NE(translations, nullptr);
+  expect_cdna3_code_cave_matches(*translations, test_case.expected);
+}
+
+INSTANTIATE_TEST_SUITE_P(ImplementedRules, Cdna4ToCdna3SemanticRuleTranslationTest,
+                         ::testing::ValuesIn(cdna4_to_cdna3_semantic_rule_cases()),
+                         [](const ::testing::TestParamInfo<Cdna4ToCdna3SemanticRuleCase> &info) {
+                           return std::string(info.param.name);
+                         });
 
 TEST(KernelDescriptorTranslator, IgnoresNonAllocExecutableSectionsForEntryRange) {
   using KD = rocr::llvm::amdhsa::kernel_descriptor_t;

--- a/emulation/rocjitsu/tests/kernels/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/kernels/CMakeLists.txt
@@ -49,6 +49,35 @@ rj_add_device_kernel(matmul_mfma gfx950)
 rj_add_device_kernel(matmul_mfma_16x16 gfx950)
 rj_add_device_kernel(matmul_tiled gfx950)
 rj_add_device_kernel(vector_add gfx950)
+rj_add_device_kernel(dynamic_copy_loop gfx950)
+
+# Triton-generated CDNA4 matmul fixture. The checked-in assembly records the
+# original Triton-generated kernel, so normal test builds only need the ROCm
+# assembler/linker and do not depend on a Python/Triton install.
+function(rj_add_triton_cdna4_asm_fixture name)
+    set(asm_obj ${KERNEL_OUTPUT_DIR}/${name}.asm.o)
+    set(hsaco ${KERNEL_OUTPUT_DIR}/${name}.hsaco)
+    add_custom_command(
+        OUTPUT ${asm_obj}
+        COMMAND
+            ${AMDCLANG} -x assembler -target amdgcn-amd-amdhsa -mcpu=gfx950
+            --rocm-path=${ROCM_PATH} -c -o ${asm_obj}
+            ${CMAKE_CURRENT_SOURCE_DIR}/${name}.s
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${name}.s
+        COMMENT "Assembling Triton CDNA4 fixture: ${name} (gfx950)"
+    )
+    add_custom_command(
+        OUTPUT ${hsaco}
+        COMMAND
+            ${AMDCLANG} -target amdgcn-amd-amdhsa -mcpu=gfx950
+            --rocm-path=${ROCM_PATH} -nostdlib -shared -o ${hsaco} ${asm_obj}
+        DEPENDS ${asm_obj}
+        COMMENT "Linking Triton CDNA4 fixture: ${name} (gfx950)"
+    )
+    add_custom_target(kernel_${name} DEPENDS ${hsaco})
+endfunction()
+
+rj_add_triton_cdna4_asm_fixture(triton_cdna4_matmul_dynamic_32x32x64)
 
 # Umbrella target for all device kernels.
 add_custom_target(
@@ -59,6 +88,8 @@ add_custom_target(
         kernel_matmul_mfma_16x16
         kernel_matmul_tiled
         kernel_vector_add
+        kernel_dynamic_copy_loop
+        kernel_triton_cdna4_matmul_dynamic_32x32x64
 )
 
 # Export variables to the parent scope so the test executable can use them.

--- a/emulation/rocjitsu/tests/kernels/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/kernels/CMakeLists.txt
@@ -55,6 +55,7 @@ function(rj_add_triton_cdna4_asm_fixture name)
         COMMAND ${AMDCLANG} -x assembler
                 -target amdgcn-amd-amdhsa
                 -mcpu=gfx950
+                --rocm-path=${ROCM_PATH}
                 -c
                 -o ${asm_obj}
                 ${CMAKE_CURRENT_SOURCE_DIR}/${name}.s
@@ -66,6 +67,7 @@ function(rj_add_triton_cdna4_asm_fixture name)
         COMMAND ${AMDCLANG}
                 -target amdgcn-amd-amdhsa
                 -mcpu=gfx950
+                --rocm-path=${ROCM_PATH}
                 -nostdlib
                 -shared
                 -o ${hsaco}

--- a/emulation/rocjitsu/tests/kernels/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/kernels/CMakeLists.txt
@@ -42,6 +42,41 @@ rj_add_device_kernel(matmul_mfma gfx950)
 rj_add_device_kernel(matmul_mfma_16x16 gfx950)
 rj_add_device_kernel(matmul_tiled gfx950)
 rj_add_device_kernel(vector_add gfx950)
+rj_add_device_kernel(dynamic_copy_loop gfx950)
+
+# Triton-generated CDNA4 matmul fixture. The checked-in assembly records the
+# original Triton-generated kernel, so normal test builds only need the ROCm
+# assembler/linker and do not depend on a Python/Triton install.
+function(rj_add_triton_cdna4_asm_fixture name)
+    set(asm_obj ${KERNEL_OUTPUT_DIR}/${name}.asm.o)
+    set(hsaco ${KERNEL_OUTPUT_DIR}/${name}.hsaco)
+    add_custom_command(
+        OUTPUT ${asm_obj}
+        COMMAND ${AMDCLANG} -x assembler
+                -target amdgcn-amd-amdhsa
+                -mcpu=gfx950
+                -c
+                -o ${asm_obj}
+                ${CMAKE_CURRENT_SOURCE_DIR}/${name}.s
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${name}.s
+        COMMENT "Assembling Triton CDNA4 fixture: ${name} (gfx950)"
+    )
+    add_custom_command(
+        OUTPUT ${hsaco}
+        COMMAND ${AMDCLANG}
+                -target amdgcn-amd-amdhsa
+                -mcpu=gfx950
+                -nostdlib
+                -shared
+                -o ${hsaco}
+                ${asm_obj}
+        DEPENDS ${asm_obj}
+        COMMENT "Linking Triton CDNA4 fixture: ${name} (gfx950)"
+    )
+    add_custom_target(kernel_${name} DEPENDS ${hsaco})
+endfunction()
+
+rj_add_triton_cdna4_asm_fixture(triton_cdna4_matmul_dynamic_32x32x64)
 
 # Umbrella target for all device kernels.
 add_custom_target(device_kernels DEPENDS
@@ -50,6 +85,8 @@ add_custom_target(device_kernels DEPENDS
     kernel_matmul_mfma_16x16
     kernel_matmul_tiled
     kernel_vector_add
+    kernel_dynamic_copy_loop
+    kernel_triton_cdna4_matmul_dynamic_32x32x64
 )
 
 # Export variables to the parent scope so the test executable can use them.

--- a/emulation/rocjitsu/tests/kernels/dynamic_copy_loop.hip
+++ b/emulation/rocjitsu/tests/kernels/dynamic_copy_loop.hip
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <hip/hip_runtime.h>
+
+/// Runtime-sized copy kernel used by CDNA4->CDNA3 DBT dispatch tests.
+///
+/// The grid is intentionally allowed to be smaller than N. Each lane walks an
+/// explicit-stride loop, so the host test can dispatch the same kernel object
+/// for many dynamic sizes without recompiling or changing the workgroup shape.
+///
+/// The stride is passed as a normal kernarg instead of reading gridDim.x. These
+/// tests dispatch the code object through raw HSA, not the HIP runtime, and raw
+/// HSA launchers do not provide every HIP implicit runtime field.
+extern "C" __global__
+void dynamic_copy_loop(const unsigned *__restrict__ src, unsigned *__restrict__ dst, unsigned n,
+                       unsigned workgroup_size, unsigned stride) {
+  // The raw HSA dispatch path does not reliably materialize HIP's blockDim.x
+  // implicit field, so the host passes the packet workgroup size explicitly.
+  const unsigned first = blockIdx.x * workgroup_size + threadIdx.x;
+
+  for (unsigned i = first; i < n; i += stride)
+    dst[i] = src[i];
+}

--- a/emulation/rocjitsu/tests/kernels/dynamic_copy_loop.hip
+++ b/emulation/rocjitsu/tests/kernels/dynamic_copy_loop.hip
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <hip/hip_runtime.h>
+
+/// Runtime-sized copy kernel used by CDNA4->CDNA3 DBT dispatch tests.
+///
+/// The grid is intentionally allowed to be smaller than N. Each lane walks an
+/// explicit-stride loop, so the host test can dispatch the same kernel object
+/// for many dynamic sizes without recompiling or changing the workgroup shape.
+///
+/// The stride is passed as a normal kernarg instead of reading gridDim.x. These
+/// tests dispatch the code object through raw HSA, not the HIP runtime, and raw
+/// HSA launchers do not provide every HIP implicit runtime field.
+extern "C" __global__ void dynamic_copy_loop(const unsigned *__restrict__ src,
+                                             unsigned *__restrict__ dst, unsigned n,
+                                             unsigned stride) {
+  constexpr unsigned kBlockSize = 64;
+  const unsigned first = blockIdx.x * kBlockSize + threadIdx.x;
+
+  for (unsigned i = first; i < n; i += stride)
+    dst[i] = src[i];
+}

--- a/emulation/rocjitsu/tests/kernels/dynamic_copy_loop.hip
+++ b/emulation/rocjitsu/tests/kernels/dynamic_copy_loop.hip
@@ -12,11 +12,12 @@
 /// The stride is passed as a normal kernarg instead of reading gridDim.x. These
 /// tests dispatch the code object through raw HSA, not the HIP runtime, and raw
 /// HSA launchers do not provide every HIP implicit runtime field.
-extern "C" __global__ void dynamic_copy_loop(const unsigned *__restrict__ src,
-                                             unsigned *__restrict__ dst, unsigned n,
-                                             unsigned stride) {
-  constexpr unsigned kBlockSize = 64;
-  const unsigned first = blockIdx.x * kBlockSize + threadIdx.x;
+extern "C" __global__
+void dynamic_copy_loop(const unsigned *__restrict__ src, unsigned *__restrict__ dst, unsigned n,
+                       unsigned workgroup_size, unsigned stride) {
+  // The raw HSA dispatch path does not reliably materialize HIP's blockDim.x
+  // implicit field, so the host passes the packet workgroup size explicitly.
+  const unsigned first = blockIdx.x * workgroup_size + threadIdx.x;
 
   for (unsigned i = first; i < n; i += stride)
     dst[i] = src[i];

--- a/emulation/rocjitsu/tests/kernels/triton_cdna4_matmul_dynamic_32x32x64.s
+++ b/emulation/rocjitsu/tests/kernels/triton_cdna4_matmul_dynamic_32x32x64.s
@@ -1,0 +1,1827 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// Generated with Triton 3.6.0 for gfx950/CDNA4 from this source:
+//
+//   import triton
+//   from triton import language as tl
+//
+//   @triton.jit
+//   def triton_cdna4_matmul_kernel(a, b, c, M, N, K,
+//                                  BLOCK_M: tl.constexpr,
+//                                  BLOCK_N: tl.constexpr,
+//                                  BLOCK_K: tl.constexpr):
+//       pid_m = tl.program_id(0)
+//       pid_n = tl.program_id(1)
+//       offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+//       offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+//       offs_k = tl.arange(0, BLOCK_K)
+//       acc = tl.zeros((BLOCK_M, BLOCK_N), tl.float32)
+//       for k0 in tl.range(0, K, BLOCK_K):
+//           k_idxs = k0 + offs_k
+//           a_tile = tl.load(a + offs_m[:, None] * K + k_idxs[None, :],
+//                            mask=(offs_m[:, None] < M) & (k_idxs[None, :] < K),
+//                            other=0.0)
+//           b_tile = tl.load(b + k_idxs[:, None] * N + offs_n[None, :],
+//                            mask=(k_idxs[:, None] < K) & (offs_n[None, :] < N),
+//                            other=0.0)
+//           acc += tl.dot(a_tile, b_tile, out_dtype=tl.float32)
+//       tl.store(c + offs_m[:, None] * N + offs_n[None, :], acc,
+//                mask=(offs_m[:, None] < M) & (offs_n[None, :] < N))
+//
+//   triton.compile(ASTSource(...,
+//                            signature={"a": '*fp16', "b": '*fp16', "c": '*fp32', "M": 'i32', "N": 'i32', "K": 'i32'},
+//                            constexprs={"BLOCK_M": 32, "BLOCK_N": 32, "BLOCK_K": 64}),
+//                  target=GPUTarget("hip", "gfx950", 64),
+//                  options={"num_warps": 4})
+
+	.amdgcn_target "amdgcn-amd-amdhsa--gfx950"
+	.amdhsa_code_object_version 5
+	.text
+	.globl	triton_cdna4_matmul_kernel      ; -- Begin function triton_cdna4_matmul_kernel
+	.p2align	8
+	.type	triton_cdna4_matmul_kernel,@function
+triton_cdna4_matmul_kernel:             ; @triton_cdna4_matmul_kernel
+.Lfunc_begin0:
+	.cfi_sections .debug_frame
+	.cfi_startproc
+; %bb.140:
+	.file	1 "tests/kernels" "triton_cdna4_matmul_source"
+	.loc	1 6 0 prologue_end              ; triton_cdna4_matmul_source:6:0
+	s_load_dwordx2 s[2:3], s[0:1], 0x0
+	s_load_dwordx8 s[4:11], s[0:1], 0x8
+	s_load_dwordx4 s[12:15], s[0:1], 0x28
+	s_waitcnt lgkmcnt(0)
+	s_branch .LBB0_0
+	.loc	1 0 0 is_stmt 0                 ; :0:0
+.Ltmp0:
+	.p2align	8
+; %bb.141:
+.LBB0_0:
+.Ltmp1:
+	.loc	1 12 21 is_stmt 1               ; triton_cdna4_matmul_source:12:21
+	s_lshl_b32 s11, s16, 5
+	.loc	1 12 44 is_stmt 0               ; triton_cdna4_matmul_source:12:44
+	v_lshrrev_b32_e32 v1, 6, v0
+	.loc	1 12 31                         ; triton_cdna4_matmul_source:12:31
+	v_or_b32_e32 v1, s11, v1
+	.loc	1 14 26 is_stmt 1               ; triton_cdna4_matmul_source:14:26
+	v_and_b32_e32 v53, 63, v0
+	.loc	1 18 47                         ; triton_cdna4_matmul_source:18:47
+	v_mul_lo_u32 v4, s10, v1
+	.loc	1 19 49                         ; triton_cdna4_matmul_source:19:49
+	v_cmp_gt_i32_e64 s[0:1], s8, v1
+	.loc	1 18 29                         ; triton_cdna4_matmul_source:18:29
+	v_ashrrev_i32_e32 v5, 31, v4
+	.loc	1 19 73                         ; triton_cdna4_matmul_source:19:73
+	v_cmp_gt_i32_e32 vcc, s10, v53
+	.loc	1 18 29                         ; triton_cdna4_matmul_source:18:29
+	v_lshl_add_u64 v[18:19], v[4:5], 1, s[2:3]
+	.loc	1 19 55                         ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[14:15], s[0:1], vcc
+	.loc	1 18 51                         ; triton_cdna4_matmul_source:18:51
+	v_mov_b32_e32 v42, 0
+	v_lshlrev_b32_e32 v2, 1, v53
+	v_mov_b32_e32 v43, 0
+	.loc	1 18 25 is_stmt 0               ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[12:13], s[14:15]
+	s_cbranch_execz .LBB0_2
+; %bb.1:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	v_mov_b32_e32 v3, 0
+	v_lshl_add_u64 v[6:7], v[18:19], 0, v[2:3]
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	global_load_ushort v43, v[6:7], off
+.LBB0_2:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[12:13]
+	.loc	1 18 47                         ; triton_cdna4_matmul_source:18:47
+	s_lshl_b32 s16, s10, 2
+	v_add_u32_e32 v6, s16, v4
+	.loc	1 12 31 is_stmt 1               ; triton_cdna4_matmul_source:12:31
+	v_or_b32_e32 v3, 4, v1
+	.loc	1 18 29                         ; triton_cdna4_matmul_source:18:29
+	v_ashrrev_i32_e32 v7, 31, v6
+	.loc	1 19 49                         ; triton_cdna4_matmul_source:19:49
+	v_cmp_gt_i32_e64 s[24:25], s8, v3
+	.loc	1 18 29                         ; triton_cdna4_matmul_source:18:29
+	v_lshl_add_u64 v[20:21], v[6:7], 1, s[2:3]
+	.loc	1 18 51 is_stmt 0               ; triton_cdna4_matmul_source:18:51
+	v_mov_b32_e32 v3, v42
+	.loc	1 19 55 is_stmt 1               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[14:15], s[24:25], vcc
+	.loc	1 18 51                         ; triton_cdna4_matmul_source:18:51
+	v_lshl_add_u64 v[4:5], v[20:21], 0, v[2:3]
+	.loc	1 18 25 is_stmt 0               ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[12:13], s[14:15]
+	s_cbranch_execz .LBB0_4
+; %bb.3:
+	global_load_ushort v42, v[4:5], off
+.LBB0_4:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[12:13]
+	.loc	1 18 47                         ; triton_cdna4_matmul_source:18:47
+	v_add_u32_e32 v10, s16, v6
+	.loc	1 12 31 is_stmt 1               ; triton_cdna4_matmul_source:12:31
+	v_or_b32_e32 v3, 8, v1
+	.loc	1 18 29                         ; triton_cdna4_matmul_source:18:29
+	v_ashrrev_i32_e32 v11, 31, v10
+	.loc	1 19 49                         ; triton_cdna4_matmul_source:19:49
+	v_cmp_gt_i32_e64 s[20:21], s8, v3
+	.loc	1 18 29                         ; triton_cdna4_matmul_source:18:29
+	v_lshl_add_u64 v[22:23], v[10:11], 1, s[2:3]
+	.loc	1 18 51 is_stmt 0               ; triton_cdna4_matmul_source:18:51
+	v_mov_b32_e32 v3, 0
+	.loc	1 19 55 is_stmt 1               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[14:15], s[20:21], vcc
+	.loc	1 18 51                         ; triton_cdna4_matmul_source:18:51
+	v_lshl_add_u64 v[6:7], v[22:23], 0, v[2:3]
+	v_mov_b32_e32 v44, v3
+	.loc	1 18 25 is_stmt 0               ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[12:13], s[14:15]
+	s_cbranch_execz .LBB0_6
+; %bb.5:
+	global_load_ushort v44, v[6:7], off
+.LBB0_6:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[12:13]
+	.loc	1 12 31 is_stmt 1               ; triton_cdna4_matmul_source:12:31
+	v_or_b32_e32 v8, 12, v1
+	.loc	1 19 49                         ; triton_cdna4_matmul_source:19:49
+	v_cmp_gt_i32_e64 s[26:27], s8, v8
+	.loc	1 18 47                         ; triton_cdna4_matmul_source:18:47
+	v_mul_lo_u32 v8, s10, v8
+	.loc	1 18 29 is_stmt 0               ; triton_cdna4_matmul_source:18:29
+	v_ashrrev_i32_e32 v9, 31, v8
+	v_lshl_add_u64 v[24:25], v[8:9], 1, s[2:3]
+	.loc	1 19 55 is_stmt 1               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[14:15], s[26:27], vcc
+	.loc	1 18 51                         ; triton_cdna4_matmul_source:18:51
+	v_lshl_add_u64 v[8:9], v[24:25], 0, v[2:3]
+	.loc	1 18 25 is_stmt 0               ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[12:13], s[14:15]
+	s_cbranch_execz .LBB0_8
+; %bb.7:
+	global_load_ushort v3, v[8:9], off
+.LBB0_8:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[12:13]
+	.loc	1 18 47                         ; triton_cdna4_matmul_source:18:47
+	v_lshl_add_u32 v12, s10, 3, v10
+	.loc	1 12 31 is_stmt 1               ; triton_cdna4_matmul_source:12:31
+	v_or_b32_e32 v11, 16, v1
+	.loc	1 18 29                         ; triton_cdna4_matmul_source:18:29
+	v_ashrrev_i32_e32 v13, 31, v12
+	.loc	1 19 49                         ; triton_cdna4_matmul_source:19:49
+	v_cmp_gt_i32_e64 s[28:29], s8, v11
+	.loc	1 18 29                         ; triton_cdna4_matmul_source:18:29
+	v_lshl_add_u64 v[26:27], v[12:13], 1, s[2:3]
+	.loc	1 18 51 is_stmt 0               ; triton_cdna4_matmul_source:18:51
+	v_mov_b32_e32 v37, 0
+	v_mov_b32_e32 v36, v2
+	.loc	1 19 55 is_stmt 1               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[14:15], s[28:29], vcc
+	.loc	1 18 51                         ; triton_cdna4_matmul_source:18:51
+	v_lshl_add_u64 v[10:11], v[26:27], 0, v[36:37]
+	v_mov_b32_e32 v45, v37
+	.loc	1 18 25 is_stmt 0               ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[12:13], s[14:15]
+	s_cbranch_execz .LBB0_10
+; %bb.9:
+	global_load_ushort v45, v[10:11], off
+.LBB0_10:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[12:13]
+	.loc	1 18 47                         ; triton_cdna4_matmul_source:18:47
+	v_add_u32_e32 v14, s16, v12
+	.loc	1 12 31 is_stmt 1               ; triton_cdna4_matmul_source:12:31
+	v_or_b32_e32 v13, 20, v1
+	.loc	1 18 29                         ; triton_cdna4_matmul_source:18:29
+	v_ashrrev_i32_e32 v15, 31, v14
+	.loc	1 19 49                         ; triton_cdna4_matmul_source:19:49
+	v_cmp_gt_i32_e64 s[12:13], s8, v13
+	.loc	1 18 29                         ; triton_cdna4_matmul_source:18:29
+	v_lshl_add_u64 v[28:29], v[14:15], 1, s[2:3]
+	.loc	1 19 55                         ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[18:19], s[12:13], vcc
+	.loc	1 18 51                         ; triton_cdna4_matmul_source:18:51
+	v_lshl_add_u64 v[12:13], v[28:29], 0, v[36:37]
+	.loc	1 18 25 is_stmt 0               ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[14:15], s[18:19]
+	s_cbranch_execz .LBB0_12
+; %bb.11:
+	global_load_ushort v37, v[12:13], off
+.LBB0_12:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[14:15]
+	.loc	1 12 31 is_stmt 1               ; triton_cdna4_matmul_source:12:31
+	v_or_b32_e32 v15, 24, v1
+	.loc	1 18 47                         ; triton_cdna4_matmul_source:18:47
+	v_add_u32_e32 v14, s16, v14
+	.loc	1 19 49                         ; triton_cdna4_matmul_source:19:49
+	v_cmp_gt_i32_e64 s[14:15], s8, v15
+	.loc	1 18 29                         ; triton_cdna4_matmul_source:18:29
+	v_ashrrev_i32_e32 v15, 31, v14
+	v_lshl_add_u64 v[30:31], v[14:15], 1, s[2:3]
+	.loc	1 18 51 is_stmt 0               ; triton_cdna4_matmul_source:18:51
+	v_mov_b32_e32 v39, 0
+	v_mov_b32_e32 v38, v2
+	.loc	1 19 55 is_stmt 1               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[22:23], s[14:15], vcc
+	.loc	1 18 51                         ; triton_cdna4_matmul_source:18:51
+	v_lshl_add_u64 v[14:15], v[30:31], 0, v[38:39]
+	v_mov_b32_e32 v36, v39
+	.loc	1 18 25 is_stmt 0               ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[18:19], s[22:23]
+	s_cbranch_execz .LBB0_14
+; %bb.13:
+	global_load_ushort v36, v[14:15], off
+.LBB0_14:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[18:19]
+	.loc	1 12 31 is_stmt 1               ; triton_cdna4_matmul_source:12:31
+	v_or_b32_e32 v1, 28, v1
+	.loc	1 18 47                         ; triton_cdna4_matmul_source:18:47
+	v_mul_lo_u32 v16, s10, v1
+	.loc	1 18 29 is_stmt 0               ; triton_cdna4_matmul_source:18:29
+	v_ashrrev_i32_e32 v17, 31, v16
+	.loc	1 19 49 is_stmt 1               ; triton_cdna4_matmul_source:19:49
+	v_cmp_gt_i32_e64 s[30:31], s8, v1
+	.loc	1 18 29                         ; triton_cdna4_matmul_source:18:29
+	v_lshl_add_u64 v[32:33], v[16:17], 1, s[2:3]
+	.loc	1 19 55                         ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[18:19], s[30:31], vcc
+	.loc	1 18 51                         ; triton_cdna4_matmul_source:18:51
+	v_lshl_add_u64 v[34:35], v[32:33], 0, v[38:39]
+	.loc	1 18 25 is_stmt 0               ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[2:3], s[18:19]
+	s_cbranch_execz .LBB0_16
+; %bb.15:
+	global_load_ushort v39, v[34:35], off
+.LBB0_16:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 12 44 is_stmt 1               ; triton_cdna4_matmul_source:12:44
+	v_and_b32_e32 v1, 31, v0
+	.loc	1 13 21                         ; triton_cdna4_matmul_source:13:21
+	s_lshl_b32 s33, s17, 5
+	.loc	1 13 31 is_stmt 0               ; triton_cdna4_matmul_source:13:31
+	v_or_b32_e32 v16, s33, v1
+	.loc	1 14 26 is_stmt 1               ; triton_cdna4_matmul_source:14:26
+	v_lshrrev_b32_e32 v47, 5, v0
+	.loc	1 22 73                         ; triton_cdna4_matmul_source:22:73
+	v_cmp_gt_i32_e64 s[18:19], s9, v16
+	.loc	1 22 49 is_stmt 0               ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v47
+	.loc	1 22 55                         ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[16:17], s[18:19], vcc
+	.loc	1 21 51 is_stmt 1               ; triton_cdna4_matmul_source:21:51
+	v_ashrrev_i32_e32 v17, 31, v16
+	v_mov_b32_e32 v38, 0
+	v_mov_b32_e32 v48, 0
+	.loc	1 21 25 is_stmt 0               ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[2:3], s[16:17]
+	s_cbranch_execz .LBB0_18
+; %bb.17:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	v_mul_lo_u32 v40, s9, v47
+	v_ashrrev_i32_e32 v41, 31, v40
+	v_lshl_add_u64 v[40:41], v[40:41], 1, s[4:5]
+	v_lshl_add_u64 v[40:41], v[16:17], 1, v[40:41]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v48, v[40:41], off
+.LBB0_18:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 14 26 is_stmt 1               ; triton_cdna4_matmul_source:14:26
+	v_or_b32_e32 v40, 8, v47
+	.loc	1 16 29                         ; triton_cdna4_matmul_source:16:29
+	s_cmp_gt_i32 s10, 0
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v40
+	.loc	1 16 29                         ; triton_cdna4_matmul_source:16:29
+	s_cselect_b64 s[2:3], -1, 0
+	.loc	1 22 55                         ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[16:17], s[18:19], vcc
+	.loc	1 21 47                         ; triton_cdna4_matmul_source:21:47
+	v_mul_lo_u32 v40, s9, v40
+	.loc	1 16 29                         ; triton_cdna4_matmul_source:16:29
+	s_and_b64 s[22:23], s[2:3], s[16:17]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[16:17], s[22:23]
+	s_cbranch_execz .LBB0_20
+; %bb.19:
+	.loc	1 21 29 is_stmt 0               ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v41, 31, v40
+	v_lshl_add_u64 v[50:51], v[40:41], 1, s[4:5]
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[50:51], v[16:17], 1, v[50:51]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v38, v[50:51], off
+.LBB0_20:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[16:17]
+	.loc	1 14 26 is_stmt 1               ; triton_cdna4_matmul_source:14:26
+	v_or_b32_e32 v41, 16, v47
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v41
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[16:17], s[18:19], vcc
+	.loc	1 21 47 is_stmt 1               ; triton_cdna4_matmul_source:21:47
+	s_lshl_b32 s34, s9, 3
+	v_add_u32_e32 v40, s34, v40
+	.loc	1 16 29                         ; triton_cdna4_matmul_source:16:29
+	s_and_b64 s[22:23], s[2:3], s[16:17]
+	v_mov_b32_e32 v54, 0
+	v_mov_b32_e32 v55, 0
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[16:17], s[22:23]
+	s_cbranch_execz .LBB0_22
+; %bb.21:
+	.loc	1 21 29 is_stmt 0               ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v41, 31, v40
+	v_lshl_add_u64 v[50:51], v[40:41], 1, s[4:5]
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[50:51], v[16:17], 1, v[50:51]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v55, v[50:51], off
+.LBB0_22:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[16:17]
+	.loc	1 14 26 is_stmt 1               ; triton_cdna4_matmul_source:14:26
+	v_or_b32_e32 v58, 24, v47
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v58
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[16:17], s[18:19], vcc
+	.loc	1 16 29 is_stmt 1               ; triton_cdna4_matmul_source:16:29
+	s_and_b64 s[22:23], s[2:3], s[16:17]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[16:17], s[22:23]
+	s_cbranch_execz .LBB0_24
+; %bb.23:
+	.loc	1 21 47 is_stmt 0               ; triton_cdna4_matmul_source:21:47
+	v_mul_lo_u32 v50, s9, v58
+	.loc	1 21 29                         ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v51, 31, v50
+	v_lshl_add_u64 v[50:51], v[50:51], 1, s[4:5]
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[50:51], v[16:17], 1, v[50:51]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v54, v[50:51], off
+.LBB0_24:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[16:17]
+	.loc	1 14 26 is_stmt 1               ; triton_cdna4_matmul_source:14:26
+	v_or_b32_e32 v41, 32, v47
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v41
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[16:17], s[18:19], vcc
+	.loc	1 21 47 is_stmt 1               ; triton_cdna4_matmul_source:21:47
+	s_lshl_b32 s35, s9, 4
+	v_add_u32_e32 v40, s35, v40
+	.loc	1 16 29                         ; triton_cdna4_matmul_source:16:29
+	s_and_b64 s[22:23], s[2:3], s[16:17]
+	v_mov_b32_e32 v56, 0
+	v_mov_b32_e32 v57, 0
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[16:17], s[22:23]
+	s_cbranch_execz .LBB0_26
+; %bb.25:
+	.loc	1 21 29 is_stmt 0               ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v41, 31, v40
+	v_lshl_add_u64 v[50:51], v[40:41], 1, s[4:5]
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[50:51], v[16:17], 1, v[50:51]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v57, v[50:51], off
+.LBB0_26:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[16:17]
+	.loc	1 14 26 is_stmt 1               ; triton_cdna4_matmul_source:14:26
+	v_or_b32_e32 v41, 40, v47
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v41
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[16:17], s[18:19], vcc
+	.loc	1 21 47 is_stmt 1               ; triton_cdna4_matmul_source:21:47
+	v_add_u32_e32 v40, s34, v40
+	.loc	1 16 29                         ; triton_cdna4_matmul_source:16:29
+	s_and_b64 s[22:23], s[2:3], s[16:17]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[16:17], s[22:23]
+	s_cbranch_execz .LBB0_28
+; %bb.27:
+	.loc	1 21 29 is_stmt 0               ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v41, 31, v40
+	v_lshl_add_u64 v[50:51], v[40:41], 1, s[4:5]
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[50:51], v[16:17], 1, v[50:51]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v56, v[50:51], off
+.LBB0_28:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[16:17]
+	.loc	1 14 26 is_stmt 1               ; triton_cdna4_matmul_source:14:26
+	v_or_b32_e32 v41, 48, v47
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v41
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[16:17], s[18:19], vcc
+	.loc	1 16 29 is_stmt 1               ; triton_cdna4_matmul_source:16:29
+	s_and_b64 s[22:23], s[2:3], s[16:17]
+	v_mov_b32_e32 v41, 0
+	v_mov_b32_e32 v61, 0
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[16:17], s[22:23]
+	s_cbranch_execz .LBB0_30
+; %bb.29:
+	.loc	1 21 47 is_stmt 0               ; triton_cdna4_matmul_source:21:47
+	v_add_u32_e32 v50, s34, v40
+	.loc	1 21 29                         ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v51, 31, v50
+	v_lshl_add_u64 v[50:51], v[50:51], 1, s[4:5]
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[50:51], v[16:17], 1, v[50:51]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v61, v[50:51], off
+.LBB0_30:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[16:17]
+	.loc	1 14 26 is_stmt 1               ; triton_cdna4_matmul_source:14:26
+	v_or_b32_e32 v59, 56, v47
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v59
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[16:17], s[18:19], vcc
+	.loc	1 16 29 is_stmt 1               ; triton_cdna4_matmul_source:16:29
+	s_and_b64 s[16:17], s[2:3], s[16:17]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[2:3], s[16:17]
+	s_cbranch_execz .LBB0_32
+; %bb.31:
+	.loc	1 21 47 is_stmt 0               ; triton_cdna4_matmul_source:21:47
+	v_mul_lo_u32 v40, s9, v59
+	.loc	1 21 29                         ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v41, 31, v40
+	v_lshl_add_u64 v[40:41], v[40:41], 1, s[4:5]
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[40:41], v[16:17], 1, v[40:41]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v41, v[40:41], off
+.LBB0_32:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 18 25 is_stmt 1               ; triton_cdna4_matmul_source:18:25
+	v_lshlrev_b32_e32 v60, 1, v0
+	v_and_b32_e32 v40, 0xfe, v60
+	v_bfe_i32 v49, v0, 7, 1
+	s_movk_i32 s2, 0x110
+	v_bitop3_b32 v40, v49, v40, s2 bitop3:0x6c
+	v_add_u32_e32 v49, 0, v40
+	s_waitcnt vmcnt(0)
+	ds_write_b16 v49, v43
+	ds_write_b16 v49, v45 offset:2048
+	v_xor_b32_e32 v43, 32, v40
+	v_add_u32_e32 v50, 0, v43
+	ds_write_b16 v50, v42 offset:512
+	ds_write_b16 v50, v37 offset:2560
+	v_xor_b32_e32 v37, 64, v40
+	v_add_u32_e32 v51, 0, v37
+	ds_write_b16 v51, v44 offset:1024
+	ds_write_b16 v51, v36 offset:3072
+	v_xor_b32_e32 v36, 0x60, v40
+	.loc	1 12 44                         ; triton_cdna4_matmul_source:12:44
+	v_and_b32_e32 v46, 32, v0
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	v_add_u32_e32 v52, 0, v36
+	.loc	1 16 29                         ; triton_cdna4_matmul_source:16:29
+	s_sub_i32 s16, s10, 64
+	.loc	1 12 44                         ; triton_cdna4_matmul_source:12:44
+	v_cmp_eq_u32_e64 s[22:23], 0, v46
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	ds_write_b16 v52, v3 offset:1536
+	ds_write_b16 v52, v39 offset:3584
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	ds_write_b16 v49, v48 offset:4096
+	ds_write_b16 v49, v55 offset:5120
+	ds_write_b16 v49, v57 offset:6144
+	ds_write_b16 v49, v61 offset:7168
+	ds_write_b16 v50, v38 offset:4608
+	ds_write_b16 v50, v54 offset:5632
+	ds_write_b16 v50, v56 offset:6656
+	ds_write_b16 v50, v41 offset:7680
+	.loc	1 16 29                         ; triton_cdna4_matmul_source:16:29
+	s_cmp_gt_i32 s16, 0
+	v_lshlrev_b32_e32 v61, 4, v0
+	v_lshlrev_b32_e32 v48, 3, v0
+	s_cbranch_scc1 .LBB0_34
+; %bb.33:                               ; %.._crit_edge_crit_edge
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	v_lshlrev_b32_e32 v3, 3, v0
+	v_mov_b32_e32 v37, 0x220
+	v_and_b32_e32 v36, 24, v3
+	v_cndmask_b32_e64 v37, v37, 0, s[22:23]
+	s_movk_i32 s3, 0xc0
+	v_and_or_b32 v38, v61, s3, v36
+	v_bitop3_b32 v37, v37, v60, 32 bitop3:0x78
+	v_or_b32_e32 v36, v38, v37
+	v_bitop3_b32 v37, v38, s2, v37 bitop3:0x36
+	s_mov_b64 s[2:3], 0
+	s_branch .LBB0_35
+.LBB0_34:
+	.loc	1 0 25 is_stmt 0                ; triton_cdna4_matmul_source:0:25
+	s_mov_b64 s[2:3], -1
+                                        ; implicit-def: $vgpr3
+                                        ; implicit-def: $vgpr36
+                                        ; implicit-def: $vgpr37
+.LBB0_35:                               ; %Flow126
+	v_mov_b32_e32 v62, 0
+	v_accvgpr_write_b32 a0, 0
+	v_accvgpr_write_b32 a1, 0
+	v_accvgpr_write_b32 a2, 0
+	v_accvgpr_write_b32 a3, 0
+	v_accvgpr_write_b32 a4, 0
+	v_accvgpr_write_b32 a5, 0
+	v_accvgpr_write_b32 a6, 0
+	v_accvgpr_write_b32 a7, 0
+	v_accvgpr_write_b32 a8, 0
+	v_accvgpr_write_b32 a9, 0
+	v_accvgpr_write_b32 a10, 0
+	v_accvgpr_write_b32 a11, 0
+	v_accvgpr_write_b32 a12, 0
+	v_accvgpr_write_b32 a13, 0
+	v_accvgpr_write_b32 a14, 0
+	s_andn2_b64 vcc, exec, s[2:3]
+	v_accvgpr_write_b32 a15, 0
+	s_cbranch_vccnz .LBB0_105
+; %bb.36:                               ; %.lr.ph
+	.loc	1 17 22 is_stmt 1               ; triton_cdna4_matmul_source:17:22
+	v_or_b32_e32 v3, 64, v53
+	.loc	1 19 73                         ; triton_cdna4_matmul_source:19:73
+	v_cmp_gt_i32_e32 vcc, s10, v3
+	.loc	1 19 55 is_stmt 0               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[36:37], s[0:1], vcc
+	v_mov_b32_e32 v63, 0
+	.loc	1 18 25 is_stmt 1               ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[2:3], s[36:37]
+	s_cbranch_execz .LBB0_38
+; %bb.37:
+	.loc	1 0 25 is_stmt 0                ; triton_cdna4_matmul_source:0:25
+	v_mov_b32_e32 v3, 0
+	v_lshl_add_u64 v[2:3], v[18:19], 0, v[2:3]
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	global_load_ushort v63, v[2:3], off offset:128
+.LBB0_38:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 55 is_stmt 1               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[36:37], s[24:25], vcc
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[2:3], s[36:37]
+	s_cbranch_execz .LBB0_40
+; %bb.39:
+	global_load_ushort v62, v[4:5], off offset:128
+.LBB0_40:
+	.loc	1 0 25 is_stmt 0                ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 55 is_stmt 1               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[36:37], s[20:21], vcc
+	v_mov_b32_e32 v64, 0
+	v_mov_b32_e32 v65, 0
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[2:3], s[36:37]
+	s_cbranch_execz .LBB0_42
+; %bb.41:
+	global_load_ushort v65, v[6:7], off offset:128
+.LBB0_42:
+	.loc	1 0 25 is_stmt 0                ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 55 is_stmt 1               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[36:37], s[26:27], vcc
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[2:3], s[36:37]
+	s_cbranch_execz .LBB0_44
+; %bb.43:
+	global_load_ushort v64, v[8:9], off offset:128
+.LBB0_44:
+	.loc	1 0 25 is_stmt 0                ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 55 is_stmt 1               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[36:37], s[28:29], vcc
+	v_mov_b32_e32 v66, 0
+	v_mov_b32_e32 v67, 0
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[2:3], s[36:37]
+	s_cbranch_execz .LBB0_46
+; %bb.45:
+	global_load_ushort v67, v[10:11], off offset:128
+.LBB0_46:
+	.loc	1 0 25 is_stmt 0                ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 55 is_stmt 1               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[36:37], s[12:13], vcc
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[2:3], s[36:37]
+	s_cbranch_execz .LBB0_48
+; %bb.47:
+	global_load_ushort v66, v[12:13], off offset:128
+.LBB0_48:
+	.loc	1 0 25 is_stmt 0                ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 55 is_stmt 1               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[36:37], s[14:15], vcc
+	v_mov_b32_e32 v68, 0
+	v_mov_b32_e32 v69, 0
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[2:3], s[36:37]
+	s_cbranch_execz .LBB0_50
+; %bb.49:
+	global_load_ushort v69, v[14:15], off offset:128
+.LBB0_50:
+	.loc	1 0 25 is_stmt 0                ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 55 is_stmt 1               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[36:37], s[30:31], vcc
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[2:3], s[36:37]
+	s_cbranch_execz .LBB0_52
+; %bb.51:
+	global_load_ushort v68, v[34:35], off offset:128
+.LBB0_52:
+	.loc	1 0 25 is_stmt 0                ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	s_movk_i32 s2, 0x70
+	v_lshrrev_b32_e32 v4, 1, v46
+	v_lshlrev_b32_e32 v2, 7, v1
+	v_and_b32_e32 v3, 0x70, v48
+	v_bitop3_b32 v5, v48, v4, s2 bitop3:0x6c
+	v_bitop3_b32 v3, v3, v2, v4 bitop3:0xde
+	v_bitop3_b32 v6, v5, 64, v2 bitop3:0x36
+	s_movk_i32 s2, 0x60
+	v_bitop3_b32 v4, v5, 32, v2 bitop3:0x36
+	v_bitop3_b32 v2, v5, s2, v2 bitop3:0x36
+	.loc	1 17 22 is_stmt 1               ; triton_cdna4_matmul_source:17:22
+	v_or_b32_e32 v37, 0x48, v47
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	v_add_u32_e32 v54, 0, v3
+	v_add_u32_e32 v56, 0, v6
+	.loc	1 16 29                         ; triton_cdna4_matmul_source:16:29
+	v_lshl_add_u64 v[34:35], v[16:17], 1, s[4:5]
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	v_add_u32_e32 v55, 0, v4
+	ds_read_b128 v[14:17], v54
+	ds_read_b128 v[10:13], v55
+	v_add_u32_e32 v57, 0, v2
+	ds_read_b128 v[6:9], v56
+	ds_read_b128 v[2:5], v57
+	.loc	1 21 47                         ; triton_cdna4_matmul_source:21:47
+	v_mul_lo_u32 v44, v37, s9
+	v_add_u32_e32 v42, s34, v44
+	.loc	1 17 22                         ; triton_cdna4_matmul_source:17:22
+	v_or_b32_e32 v36, 64, v47
+	.loc	1 21 47                         ; triton_cdna4_matmul_source:21:47
+	v_add_u32_e32 v40, s35, v42
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v36
+	.loc	1 21 47                         ; triton_cdna4_matmul_source:21:47
+	v_add_u32_e32 v38, s34, v40
+	.loc	1 22 55                         ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[4:5], s[18:19], vcc
+	.loc	1 21 47                         ; triton_cdna4_matmul_source:21:47
+	v_add_u32_e32 v36, s34, v38
+	v_mov_b32_e32 v45, 0
+	v_mov_b32_e32 v70, 0
+	.loc	1 21 25 is_stmt 0               ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_54
+; %bb.53:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_mul_i32 s4, s9, 0xffffffd0
+	v_add_u32_e32 v70, s4, v36
+	v_ashrrev_i32_e32 v71, 31, v70
+	v_lshl_add_u64 v[70:71], v[70:71], 1, v[34:35]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v70, v[70:71], off
+.LBB0_54:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 22 49 is_stmt 1               ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v37
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[4:5], s[18:19], vcc
+	.loc	1 21 25 is_stmt 1               ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_56
+; %bb.55:
+	.loc	1 21 29 is_stmt 0               ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v45, 31, v44
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[44:45], v[44:45], 1, v[34:35]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v45, v[44:45], off
+.LBB0_56:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 17 22 is_stmt 1               ; triton_cdna4_matmul_source:17:22
+	v_or_b32_e32 v37, 0x50, v47
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v37
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[4:5], s[18:19], vcc
+	v_mov_b32_e32 v44, 0
+	v_mov_b32_e32 v43, 0
+	.loc	1 21 25 is_stmt 1               ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_58
+; %bb.57:
+	.loc	1 21 29 is_stmt 0               ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v43, 31, v42
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[42:43], v[42:43], 1, v[34:35]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v43, v[42:43], off
+.LBB0_58:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 17 22 is_stmt 1               ; triton_cdna4_matmul_source:17:22
+	v_or_b32_e32 v37, 0x58, v47
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v37
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[4:5], s[18:19], vcc
+	.loc	1 21 25 is_stmt 1               ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_60
+; %bb.59:
+	.loc	1 21 47 is_stmt 0               ; triton_cdna4_matmul_source:21:47
+	v_mul_lo_u32 v72, v37, s9
+	.loc	1 21 29                         ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v73, 31, v72
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[72:73], v[72:73], 1, v[34:35]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v44, v[72:73], off
+.LBB0_60:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 17 22 is_stmt 1               ; triton_cdna4_matmul_source:17:22
+	v_or_b32_e32 v37, 0x60, v47
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v37
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[4:5], s[18:19], vcc
+	v_mov_b32_e32 v42, 0
+	v_mov_b32_e32 v41, 0
+	.loc	1 21 25 is_stmt 1               ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_62
+; %bb.61:
+	.loc	1 21 29 is_stmt 0               ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v41, 31, v40
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[40:41], v[40:41], 1, v[34:35]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v41, v[40:41], off
+.LBB0_62:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 17 22 is_stmt 1               ; triton_cdna4_matmul_source:17:22
+	v_or_b32_e32 v37, 0x68, v47
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v37
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[4:5], s[18:19], vcc
+	.loc	1 21 25 is_stmt 1               ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_64
+; %bb.63:
+	.loc	1 21 29 is_stmt 0               ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v39, 31, v38
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[38:39], v[38:39], 1, v[34:35]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v42, v[38:39], off
+.LBB0_64:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 17 22 is_stmt 1               ; triton_cdna4_matmul_source:17:22
+	v_or_b32_e32 v37, 0x70, v47
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v37
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[4:5], s[18:19], vcc
+	v_mov_b32_e32 v71, 0
+	v_mov_b32_e32 v72, 0
+	.loc	1 21 25 is_stmt 1               ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_66
+; %bb.65:
+	.loc	1 21 29 is_stmt 0               ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v37, 31, v36
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[36:37], v[36:37], 1, v[34:35]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v72, v[36:37], off
+.LBB0_66:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 17 22 is_stmt 1               ; triton_cdna4_matmul_source:17:22
+	v_or_b32_e32 v36, 0x78, v47
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v36
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[4:5], s[18:19], vcc
+	.loc	1 21 25 is_stmt 1               ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_68
+; %bb.67:
+	.loc	1 21 47 is_stmt 0               ; triton_cdna4_matmul_source:21:47
+	v_mul_lo_u32 v36, v36, s9
+	.loc	1 21 29                         ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v37, 31, v36
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[36:37], v[36:37], 1, v[34:35]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v71, v[36:37], off
+.LBB0_68:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	v_mov_b32_e32 v37, 0x220
+	v_and_b32_e32 v36, 24, v48
+	v_cndmask_b32_e64 v38, v37, 0, s[22:23]
+	s_movk_i32 s2, 0xc0
+	v_and_or_b32 v37, v61, s2, v36
+	v_bitop3_b32 v38, v38, v60, 32 bitop3:0x78
+	v_bitop3_b32 v40, v37, 16, v38 bitop3:0x36
+	v_or_b32_e32 v36, v37, v38
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	v_add_u32_e32 v40, 0, v40
+	v_add_u32_e32 v39, 0, v36
+	ds_read_b64_tr_b16 v[76:77], v40 offset:4352
+	ds_read_b64_tr_b16 v[74:75], v39 offset:4096
+	ds_read_b64_tr_b16 v[78:79], v39 offset:5120
+	ds_read_b64_tr_b16 v[82:83], v39 offset:6144
+	ds_read_b64_tr_b16 v[86:87], v39 offset:7168
+	ds_read_b64_tr_b16 v[80:81], v40 offset:5376
+	ds_read_b64_tr_b16 v[84:85], v40 offset:6400
+	ds_read_b64_tr_b16 v[88:89], v40 offset:7424
+	.loc	1 24 30 is_stmt 1               ; triton_cdna4_matmul_source:24:30
+	s_waitcnt lgkmcnt(6)
+	v_mfma_f32_32x32x16_f16 a[0:15], v[74:77], v[14:17], 0
+	s_movk_i32 s4, 0x110
+	s_mov_b32 s5, 0
+	.loc	1 16 29                         ; triton_cdna4_matmul_source:16:29
+	s_cmpk_lt_u32 s16, 0x41
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	s_waitcnt vmcnt(0)
+	ds_write_b16 v49, v63
+	ds_write_b16 v49, v67 offset:2048
+	ds_write_b16 v50, v62 offset:512
+	ds_write_b16 v50, v66 offset:2560
+	ds_write_b16 v51, v65 offset:1024
+	ds_write_b16 v51, v69 offset:3072
+	ds_write_b16 v52, v64 offset:1536
+	ds_write_b16 v52, v68 offset:3584
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	ds_write_b16 v49, v70 offset:4096
+	.loc	1 24 30                         ; triton_cdna4_matmul_source:24:30
+	v_mfma_f32_32x32x16_f16 a[0:15], v[78:81], v[10:13], a[0:15]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	ds_write_b16 v49, v43 offset:5120
+	ds_write_b16 v49, v41 offset:6144
+	ds_write_b16 v49, v72 offset:7168
+	ds_write_b16 v50, v45 offset:4608
+	ds_write_b16 v50, v44 offset:5632
+	ds_write_b16 v50, v42 offset:6656
+	ds_write_b16 v50, v71 offset:7680
+	.loc	1 24 30                         ; triton_cdna4_matmul_source:24:30
+	v_mfma_f32_32x32x16_f16 a[0:15], v[82:85], v[6:9], a[0:15]
+	v_mfma_f32_32x32x16_f16 a[0:15], v[86:89], v[2:5], a[0:15]
+	.loc	1 16 29                         ; triton_cdna4_matmul_source:16:29
+	s_cbranch_scc1 .LBB0_104
+; %bb.69:                               ; %.peel.next
+	v_or_b32_e32 v2, 0xb0, v47
+	v_mul_lo_u32 v43, s9, v2
+	v_or_b32_e32 v2, 0xa8, v47
+	v_mul_lo_u32 v44, s9, v2
+	v_or_b32_e32 v2, 0xa0, v47
+	v_mul_lo_u32 v45, s9, v2
+	v_or_b32_e32 v2, 0x90, v47
+	v_mul_lo_u32 v60, s9, v2
+	v_or_b32_e32 v2, 0x88, v47
+	v_or_b32_e32 v41, 0x80, v59
+	v_or_b32_e32 v58, 0x80, v58
+	v_mul_lo_u32 v61, s9, v2
+	v_or_b32_e32 v2, 0x80, v47
+	v_mul_lo_u32 v42, s9, v41
+	s_lshl_b32 s17, s9, 6
+	v_mul_lo_u32 v59, s9, v58
+	v_mul_lo_u32 v62, s9, v2
+	v_or_b32_e32 v53, 0x80, v53
+	s_mov_b32 s22, 0
+.LBB0_70:                               ; =>This Inner Loop Header: Depth=1
+	.loc	1 17 22                         ; triton_cdna4_matmul_source:17:22
+	v_add_u32_e32 v2, s22, v53
+	.loc	1 19 73                         ; triton_cdna4_matmul_source:19:73
+	v_cmp_gt_i32_e32 vcc, s10, v2
+	.loc	1 19 55 is_stmt 0               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[34:35], s[0:1], vcc
+	.loc	1 18 51 is_stmt 1               ; triton_cdna4_matmul_source:18:51
+	v_ashrrev_i32_e32 v3, 31, v2
+	v_mov_b32_e32 v64, 0
+	v_mov_b32_e32 v65, 0
+	.loc	1 18 25 is_stmt 0               ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[2:3], s[34:35]
+	s_cbranch_execz .LBB0_72
+; %bb.71:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	v_lshl_add_u64 v[4:5], v[2:3], 1, v[18:19]
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	global_load_ushort v65, v[4:5], off
+.LBB0_72:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 55 is_stmt 1               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[34:35], s[24:25], vcc
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[2:3], s[34:35]
+	s_cbranch_execz .LBB0_74
+; %bb.73:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 18 51 is_stmt 0               ; triton_cdna4_matmul_source:18:51
+	v_lshl_add_u64 v[4:5], v[2:3], 1, v[20:21]
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	global_load_ushort v64, v[4:5], off
+.LBB0_74:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 55 is_stmt 1               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[34:35], s[20:21], vcc
+	v_mov_b32_e32 v66, 0
+	v_mov_b32_e32 v67, 0
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[2:3], s[34:35]
+	s_cbranch_execz .LBB0_76
+; %bb.75:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 18 51 is_stmt 0               ; triton_cdna4_matmul_source:18:51
+	v_lshl_add_u64 v[4:5], v[2:3], 1, v[22:23]
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	global_load_ushort v67, v[4:5], off
+.LBB0_76:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 55 is_stmt 1               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[34:35], s[26:27], vcc
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[2:3], s[34:35]
+	s_cbranch_execz .LBB0_78
+; %bb.77:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 18 51 is_stmt 0               ; triton_cdna4_matmul_source:18:51
+	v_lshl_add_u64 v[4:5], v[2:3], 1, v[24:25]
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	global_load_ushort v66, v[4:5], off
+.LBB0_78:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 55 is_stmt 1               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[34:35], s[28:29], vcc
+	v_mov_b32_e32 v68, 0
+	v_mov_b32_e32 v69, 0
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[2:3], s[34:35]
+	s_cbranch_execz .LBB0_80
+; %bb.79:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 18 51 is_stmt 0               ; triton_cdna4_matmul_source:18:51
+	v_lshl_add_u64 v[4:5], v[2:3], 1, v[26:27]
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	global_load_ushort v69, v[4:5], off
+.LBB0_80:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 55 is_stmt 1               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[34:35], s[12:13], vcc
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[2:3], s[34:35]
+	s_cbranch_execz .LBB0_82
+; %bb.81:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 18 51 is_stmt 0               ; triton_cdna4_matmul_source:18:51
+	v_lshl_add_u64 v[4:5], v[2:3], 1, v[28:29]
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	global_load_ushort v68, v[4:5], off
+.LBB0_82:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 55 is_stmt 1               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[34:35], s[14:15], vcc
+	v_mov_b32_e32 v70, 0
+	v_mov_b32_e32 v71, 0
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[2:3], s[34:35]
+	s_cbranch_execz .LBB0_84
+; %bb.83:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 18 51 is_stmt 0               ; triton_cdna4_matmul_source:18:51
+	v_lshl_add_u64 v[4:5], v[2:3], 1, v[30:31]
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	global_load_ushort v71, v[4:5], off
+.LBB0_84:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 55 is_stmt 1               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[34:35], s[30:31], vcc
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[2:3], s[34:35]
+	s_cbranch_execz .LBB0_86
+; %bb.85:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 18 51 is_stmt 0               ; triton_cdna4_matmul_source:18:51
+	v_lshl_add_u64 v[2:3], v[2:3], 1, v[32:33]
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	global_load_ushort v70, v[2:3], off
+.LBB0_86:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	ds_read_b128 v[14:17], v54
+	ds_read_b128 v[10:13], v55
+	ds_read_b128 v[6:9], v56
+	ds_read_b128 v[2:5], v57
+	.loc	1 17 22 is_stmt 1               ; triton_cdna4_matmul_source:17:22
+	v_add_u32_e32 v63, s22, v47
+	v_add_u32_e32 v72, 0x80, v63
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v72
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[34:35], s[18:19], vcc
+	v_mov_b32_e32 v72, 0
+	v_mov_b32_e32 v73, 0
+	.loc	1 21 25 is_stmt 1               ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[2:3], s[34:35]
+	s_cbranch_execz .LBB0_88
+; %bb.87:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 0 25 is_stmt 0                ; triton_cdna4_matmul_source:0:25
+	v_add_u32_e32 v74, s5, v62
+	v_ashrrev_i32_e32 v75, 31, v74
+	v_lshl_add_u64 v[74:75], v[74:75], 1, v[34:35]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v73, v[74:75], off
+.LBB0_88:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 17 22 is_stmt 1               ; triton_cdna4_matmul_source:17:22
+	v_add_u32_e32 v74, 0x88, v63
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v74
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[34:35], s[18:19], vcc
+	.loc	1 21 25 is_stmt 1               ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[2:3], s[34:35]
+	s_cbranch_execz .LBB0_90
+; %bb.89:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 21 47 is_stmt 0               ; triton_cdna4_matmul_source:21:47
+	v_add_u32_e32 v74, s5, v61
+	.loc	1 21 29                         ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v75, 31, v74
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[74:75], v[74:75], 1, v[34:35]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v72, v[74:75], off
+.LBB0_90:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 17 22 is_stmt 1               ; triton_cdna4_matmul_source:17:22
+	v_add_u32_e32 v74, 0x90, v63
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v74
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[34:35], s[18:19], vcc
+	v_mov_b32_e32 v74, 0
+	v_mov_b32_e32 v75, 0
+	.loc	1 21 25 is_stmt 1               ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[2:3], s[34:35]
+	s_cbranch_execz .LBB0_92
+; %bb.91:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 21 47 is_stmt 0               ; triton_cdna4_matmul_source:21:47
+	v_add_u32_e32 v76, s5, v60
+	.loc	1 21 29                         ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v77, 31, v76
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[76:77], v[76:77], 1, v[34:35]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v75, v[76:77], off
+.LBB0_92:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 17 22 is_stmt 1               ; triton_cdna4_matmul_source:17:22
+	v_add_u32_e32 v76, s22, v58
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v76
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[34:35], s[18:19], vcc
+	.loc	1 21 25 is_stmt 1               ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[2:3], s[34:35]
+	s_cbranch_execz .LBB0_94
+; %bb.93:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 21 47 is_stmt 0               ; triton_cdna4_matmul_source:21:47
+	v_add_u32_e32 v76, s5, v59
+	.loc	1 21 29                         ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v77, 31, v76
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[76:77], v[76:77], 1, v[34:35]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v74, v[76:77], off
+.LBB0_94:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 17 22 is_stmt 1               ; triton_cdna4_matmul_source:17:22
+	v_add_u32_e32 v76, 0xa0, v63
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v76
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[34:35], s[18:19], vcc
+	v_mov_b32_e32 v76, 0
+	v_mov_b32_e32 v77, 0
+	.loc	1 21 25 is_stmt 1               ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[2:3], s[34:35]
+	s_cbranch_execz .LBB0_96
+; %bb.95:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 21 47 is_stmt 0               ; triton_cdna4_matmul_source:21:47
+	v_add_u32_e32 v78, s5, v45
+	.loc	1 21 29                         ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v79, 31, v78
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[78:79], v[78:79], 1, v[34:35]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v77, v[78:79], off
+.LBB0_96:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 17 22 is_stmt 1               ; triton_cdna4_matmul_source:17:22
+	v_add_u32_e32 v78, 0xa8, v63
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v78
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[34:35], s[18:19], vcc
+	.loc	1 21 25 is_stmt 1               ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[2:3], s[34:35]
+	s_cbranch_execz .LBB0_98
+; %bb.97:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 21 47 is_stmt 0               ; triton_cdna4_matmul_source:21:47
+	v_add_u32_e32 v78, s5, v44
+	.loc	1 21 29                         ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v79, 31, v78
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[78:79], v[78:79], 1, v[34:35]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v76, v[78:79], off
+.LBB0_98:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 17 22 is_stmt 1               ; triton_cdna4_matmul_source:17:22
+	v_add_u32_e32 v63, 0xb0, v63
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v63
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[34:35], s[18:19], vcc
+	v_mov_b32_e32 v63, 0
+	v_mov_b32_e32 v78, 0
+	.loc	1 21 25 is_stmt 1               ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[2:3], s[34:35]
+	s_cbranch_execz .LBB0_100
+; %bb.99:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 21 47 is_stmt 0               ; triton_cdna4_matmul_source:21:47
+	v_add_u32_e32 v78, s5, v43
+	.loc	1 21 29                         ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v79, 31, v78
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[78:79], v[78:79], 1, v[34:35]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v78, v[78:79], off
+.LBB0_100:                              ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 73 is_stmt 1               ; triton_cdna4_matmul_source:19:73
+	v_add_u32_e32 v79, s22, v41
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v79
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[34:35], s[18:19], vcc
+	.loc	1 21 25 is_stmt 1               ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[2:3], s[34:35]
+	s_cbranch_execz .LBB0_102
+; %bb.101:                              ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 21 29 is_stmt 0               ; triton_cdna4_matmul_source:21:29
+	v_add_u32_e32 v80, s5, v42
+	v_ashrrev_i32_e32 v81, 31, v80
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[80:81], v[80:81], 1, v[34:35]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v63, v[80:81], off
+.LBB0_102:                              ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	ds_read_b64_tr_b16 v[82:83], v40 offset:4352
+	ds_read_b64_tr_b16 v[80:81], v39 offset:4096
+	ds_read_b64_tr_b16 v[84:85], v39 offset:5120
+	ds_read_b64_tr_b16 v[88:89], v39 offset:6144
+	ds_read_b64_tr_b16 v[92:93], v39 offset:7168
+	ds_read_b64_tr_b16 v[86:87], v40 offset:5376
+	ds_read_b64_tr_b16 v[90:91], v40 offset:6400
+	ds_read_b64_tr_b16 v[94:95], v40 offset:7424
+	.loc	1 24 30 is_stmt 1               ; triton_cdna4_matmul_source:24:30
+	s_waitcnt lgkmcnt(6)
+	v_mfma_f32_32x32x16_f16 a[0:15], v[80:83], v[14:17], a[0:15]
+	.loc	1 16 29                         ; triton_cdna4_matmul_source:16:29
+	s_add_i32 s2, s22, 64
+	s_add_i32 s3, s22, 0x80
+	s_add_i32 s5, s5, s17
+	s_cmp_lt_i32 s3, s16
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	s_waitcnt vmcnt(0)
+	ds_write_b16 v49, v65
+	ds_write_b16 v49, v69 offset:2048
+	ds_write_b16 v50, v64 offset:512
+	ds_write_b16 v50, v68 offset:2560
+	ds_write_b16 v51, v67 offset:1024
+	.loc	1 24 30                         ; triton_cdna4_matmul_source:24:30
+	v_mfma_f32_32x32x16_f16 a[0:15], v[84:87], v[10:13], a[0:15]
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	ds_write_b16 v51, v71 offset:3072
+	ds_write_b16 v52, v66 offset:1536
+	ds_write_b16 v52, v70 offset:3584
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	ds_write_b16 v49, v73 offset:4096
+	ds_write_b16 v49, v75 offset:5120
+	ds_write_b16 v49, v77 offset:6144
+	ds_write_b16 v49, v78 offset:7168
+	ds_write_b16 v50, v72 offset:4608
+	ds_write_b16 v50, v74 offset:5632
+	ds_write_b16 v50, v76 offset:6656
+	ds_write_b16 v50, v63 offset:7680
+	.loc	1 24 30                         ; triton_cdna4_matmul_source:24:30
+	v_mfma_f32_32x32x16_f16 a[0:15], v[88:91], v[6:9], a[0:15]
+	v_mfma_f32_32x32x16_f16 a[0:15], v[92:95], v[2:5], a[0:15]
+	.loc	1 16 29                         ; triton_cdna4_matmul_source:16:29
+	s_cbranch_scc0 .LBB0_104
+; %bb.103:                              ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 0 29 is_stmt 0                ; triton_cdna4_matmul_source:0:29
+	s_mov_b32 s22, s2
+	.loc	1 16 29                         ; triton_cdna4_matmul_source:16:29
+	s_branch .LBB0_70
+.LBB0_104:                              ; %Flow125
+	.loc	1 0 29                          ; triton_cdna4_matmul_source:0:29
+	v_bitop3_b32 v37, v37, s4, v38 bitop3:0x36
+	v_mov_b32_e32 v3, v48
+.LBB0_105:                              ; %._crit_edge
+	.loc	1 21 25 is_stmt 1               ; triton_cdna4_matmul_source:21:25
+	v_add_u32_e32 v2, 0, v36
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	ds_read_b64_tr_b16 v[32:33], v2 offset:4096
+	ds_read_b64_tr_b16 v[28:29], v2 offset:5120
+	ds_read_b64_tr_b16 v[24:25], v2 offset:6144
+	ds_read_b64_tr_b16 v[20:21], v2 offset:7168
+	v_add_u32_e32 v2, 0, v37
+	ds_read_b64_tr_b16 v[34:35], v2 offset:4096
+	ds_read_b64_tr_b16 v[30:31], v2 offset:5120
+	ds_read_b64_tr_b16 v[26:27], v2 offset:6144
+	ds_read_b64_tr_b16 v[22:23], v2 offset:7168
+	.loc	1 16 29                         ; triton_cdna4_matmul_source:16:29
+	s_add_i32 s10, s10, 63
+	s_cmp_lt_i32 s10, 64
+	.loc	1 24 30                         ; triton_cdna4_matmul_source:24:30
+	s_cbranch_scc1 .LBB0_107
+; %bb.106:
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	v_lshlrev_b32_e32 v2, 7, v1
+	v_and_b32_e32 v36, 0x70, v3
+	v_lshrrev_b32_e32 v40, 1, v46
+	v_bitop3_b32 v41, v36, v2, v40 bitop3:0xde
+	v_add_u32_e32 v36, 0, v41
+	ds_read_b128 v[36:39], v36
+	v_accvgpr_read_b32 v4, a0
+	v_accvgpr_read_b32 v5, a1
+	v_accvgpr_read_b32 v6, a2
+	v_accvgpr_read_b32 v7, a3
+	v_accvgpr_read_b32 v8, a4
+	v_accvgpr_read_b32 v9, a5
+	v_accvgpr_read_b32 v10, a6
+	v_accvgpr_read_b32 v11, a7
+	v_accvgpr_read_b32 v12, a8
+	v_accvgpr_read_b32 v13, a9
+	v_accvgpr_read_b32 v14, a10
+	v_accvgpr_read_b32 v15, a11
+	v_accvgpr_read_b32 v16, a12
+	v_accvgpr_read_b32 v17, a13
+	v_accvgpr_read_b32 v18, a14
+	v_accvgpr_read_b32 v19, a15
+	.loc	1 24 30                         ; triton_cdna4_matmul_source:24:30
+	v_accvgpr_write_b32 a0, v4
+	v_accvgpr_write_b32 a1, v5
+	v_accvgpr_write_b32 a2, v6
+	v_accvgpr_write_b32 a3, v7
+	v_accvgpr_write_b32 a4, v8
+	v_accvgpr_write_b32 a5, v9
+	v_accvgpr_write_b32 a6, v10
+	v_accvgpr_write_b32 a7, v11
+	v_accvgpr_write_b32 a8, v12
+	v_accvgpr_write_b32 a9, v13
+	v_accvgpr_write_b32 a10, v14
+	v_accvgpr_write_b32 a11, v15
+	v_accvgpr_write_b32 a12, v16
+	v_accvgpr_write_b32 a13, v17
+	v_accvgpr_write_b32 a14, v18
+	v_accvgpr_write_b32 a15, v19
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	v_xad_u32 v4, v41, 32, 0
+	ds_read_b128 v[4:7], v4
+	.loc	1 24 30                         ; triton_cdna4_matmul_source:24:30
+	s_waitcnt lgkmcnt(1)
+	v_mfma_f32_32x32x16_f16 a[0:15], v[32:35], v[36:39], a[0:15]
+	s_movk_i32 s0, 0x70
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	v_bitop3_b32 v3, v3, v40, s0 bitop3:0x6c
+	s_movk_i32 s0, 0x60
+	v_bitop3_b32 v2, v3, s0, v2 bitop3:0x36
+	v_add_u32_e32 v2, 0, v2
+	.loc	1 24 30                         ; triton_cdna4_matmul_source:24:30
+	s_waitcnt lgkmcnt(0)
+	v_mfma_f32_32x32x16_f16 a[0:15], v[28:31], v[4:7], a[0:15]
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	v_xad_u32 v4, v41, 64, 0
+	ds_read_b128 v[4:7], v4
+	.loc	1 24 30                         ; triton_cdna4_matmul_source:24:30
+	s_waitcnt lgkmcnt(0)
+	v_mfma_f32_32x32x16_f16 a[0:15], v[24:27], v[4:7], a[0:15]
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	ds_read_b128 v[2:5], v2
+	.loc	1 24 30                         ; triton_cdna4_matmul_source:24:30
+	s_waitcnt lgkmcnt(0)
+	v_mfma_f32_32x32x16_f16 a[0:15], v[20:23], v[2:5], a[0:15]
+.LBB0_107:                              ; %._crit_edge._crit_edge
+	.loc	1 12 44                         ; triton_cdna4_matmul_source:12:44
+	v_lshrrev_b32_e32 v2, 3, v46
+	.loc	1 12 31 is_stmt 0               ; triton_cdna4_matmul_source:12:31
+	v_or_b32_e32 v1, s11, v1
+	.loc	1 13 31 is_stmt 1               ; triton_cdna4_matmul_source:13:31
+	v_or_b32_e32 v2, s33, v2
+	.loc	1 25 35                         ; triton_cdna4_matmul_source:25:35
+	v_mul_lo_u32 v4, s9, v1
+	.loc	1 26 37                         ; triton_cdna4_matmul_source:26:37
+	v_cmp_gt_i32_e32 vcc, s8, v1
+	.loc	1 26 61 is_stmt 0               ; triton_cdna4_matmul_source:26:61
+	v_cmp_gt_i32_e64 s[0:1], s9, v2
+	.loc	1 25 17 is_stmt 1               ; triton_cdna4_matmul_source:25:17
+	v_ashrrev_i32_e32 v5, 31, v4
+	.loc	1 25 56 is_stmt 0               ; triton_cdna4_matmul_source:25:56
+	v_and_b32_e32 v0, 0xc0, v0
+	.loc	1 26 43 is_stmt 1               ; triton_cdna4_matmul_source:26:43
+	s_and_b64 s[2:3], vcc, s[0:1]
+	.loc	1 25 17                         ; triton_cdna4_matmul_source:25:17
+	v_lshl_add_u64 v[4:5], v[4:5], 2, s[6:7]
+	.loc	1 25 39 is_stmt 0               ; triton_cdna4_matmul_source:25:39
+	v_ashrrev_i32_e32 v3, 31, v2
+	.loc	1 25 56                         ; triton_cdna4_matmul_source:25:56
+	v_cmp_eq_u32_e64 s[0:1], 0, v0
+	.loc	1 25 39                         ; triton_cdna4_matmul_source:25:39
+	v_lshl_add_u64 v[4:5], v[2:3], 2, v[4:5]
+	.loc	1 25 56                         ; triton_cdna4_matmul_source:25:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_109
+; %bb.108:
+	global_store_dword v[4:5], a0, off
+.LBB0_109:
+	.loc	1 0 56                          ; triton_cdna4_matmul_source:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 13 31 is_stmt 1               ; triton_cdna4_matmul_source:13:31
+	v_or_b32_e32 v0, 1, v2
+	.loc	1 26 61                         ; triton_cdna4_matmul_source:26:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v0
+	.loc	1 26 43 is_stmt 0               ; triton_cdna4_matmul_source:26:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 25 56 is_stmt 1               ; triton_cdna4_matmul_source:25:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_111
+; %bb.110:
+	global_store_dword v[4:5], a1, off offset:4
+.LBB0_111:
+	.loc	1 0 56 is_stmt 0                ; triton_cdna4_matmul_source:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 13 31 is_stmt 1               ; triton_cdna4_matmul_source:13:31
+	v_or_b32_e32 v0, 2, v2
+	.loc	1 26 61                         ; triton_cdna4_matmul_source:26:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v0
+	.loc	1 26 43 is_stmt 0               ; triton_cdna4_matmul_source:26:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 25 56 is_stmt 1               ; triton_cdna4_matmul_source:25:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_113
+; %bb.112:
+	global_store_dword v[4:5], a2, off offset:8
+.LBB0_113:
+	.loc	1 0 56 is_stmt 0                ; triton_cdna4_matmul_source:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 13 31 is_stmt 1               ; triton_cdna4_matmul_source:13:31
+	v_or_b32_e32 v0, 3, v2
+	.loc	1 26 61                         ; triton_cdna4_matmul_source:26:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v0
+	.loc	1 26 43 is_stmt 0               ; triton_cdna4_matmul_source:26:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 25 56 is_stmt 1               ; triton_cdna4_matmul_source:25:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_115
+; %bb.114:
+	global_store_dword v[4:5], a3, off offset:12
+.LBB0_115:
+	.loc	1 0 56 is_stmt 0                ; triton_cdna4_matmul_source:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 13 31 is_stmt 1               ; triton_cdna4_matmul_source:13:31
+	v_or_b32_e32 v0, 8, v2
+	.loc	1 26 61                         ; triton_cdna4_matmul_source:26:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v0
+	.loc	1 26 43 is_stmt 0               ; triton_cdna4_matmul_source:26:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 25 56 is_stmt 1               ; triton_cdna4_matmul_source:25:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_117
+; %bb.116:
+	global_store_dword v[4:5], a4, off offset:32
+.LBB0_117:
+	.loc	1 0 56 is_stmt 0                ; triton_cdna4_matmul_source:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 13 31 is_stmt 1               ; triton_cdna4_matmul_source:13:31
+	v_or_b32_e32 v0, 9, v2
+	.loc	1 26 61                         ; triton_cdna4_matmul_source:26:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v0
+	.loc	1 26 43 is_stmt 0               ; triton_cdna4_matmul_source:26:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 25 56 is_stmt 1               ; triton_cdna4_matmul_source:25:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_119
+; %bb.118:
+	global_store_dword v[4:5], a5, off offset:36
+.LBB0_119:
+	.loc	1 0 56 is_stmt 0                ; triton_cdna4_matmul_source:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 13 31 is_stmt 1               ; triton_cdna4_matmul_source:13:31
+	v_or_b32_e32 v0, 10, v2
+	.loc	1 26 61                         ; triton_cdna4_matmul_source:26:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v0
+	.loc	1 26 43 is_stmt 0               ; triton_cdna4_matmul_source:26:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 25 56 is_stmt 1               ; triton_cdna4_matmul_source:25:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_121
+; %bb.120:
+	global_store_dword v[4:5], a6, off offset:40
+.LBB0_121:
+	.loc	1 0 56 is_stmt 0                ; triton_cdna4_matmul_source:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 13 31 is_stmt 1               ; triton_cdna4_matmul_source:13:31
+	v_or_b32_e32 v0, 11, v2
+	.loc	1 26 61                         ; triton_cdna4_matmul_source:26:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v0
+	.loc	1 26 43 is_stmt 0               ; triton_cdna4_matmul_source:26:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 25 56 is_stmt 1               ; triton_cdna4_matmul_source:25:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_123
+; %bb.122:
+	global_store_dword v[4:5], a7, off offset:44
+.LBB0_123:
+	.loc	1 0 56 is_stmt 0                ; triton_cdna4_matmul_source:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 13 31 is_stmt 1               ; triton_cdna4_matmul_source:13:31
+	v_or_b32_e32 v0, 16, v2
+	.loc	1 26 61                         ; triton_cdna4_matmul_source:26:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v0
+	.loc	1 26 43 is_stmt 0               ; triton_cdna4_matmul_source:26:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 25 56 is_stmt 1               ; triton_cdna4_matmul_source:25:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_125
+; %bb.124:
+	global_store_dword v[4:5], a8, off offset:64
+.LBB0_125:
+	.loc	1 0 56 is_stmt 0                ; triton_cdna4_matmul_source:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 13 31 is_stmt 1               ; triton_cdna4_matmul_source:13:31
+	v_or_b32_e32 v0, 17, v2
+	.loc	1 26 61                         ; triton_cdna4_matmul_source:26:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v0
+	.loc	1 26 43 is_stmt 0               ; triton_cdna4_matmul_source:26:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 25 56 is_stmt 1               ; triton_cdna4_matmul_source:25:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_127
+; %bb.126:
+	global_store_dword v[4:5], a9, off offset:68
+.LBB0_127:
+	.loc	1 0 56 is_stmt 0                ; triton_cdna4_matmul_source:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 13 31 is_stmt 1               ; triton_cdna4_matmul_source:13:31
+	v_or_b32_e32 v0, 18, v2
+	.loc	1 26 61                         ; triton_cdna4_matmul_source:26:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v0
+	.loc	1 26 43 is_stmt 0               ; triton_cdna4_matmul_source:26:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 25 56 is_stmt 1               ; triton_cdna4_matmul_source:25:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_129
+; %bb.128:
+	global_store_dword v[4:5], a10, off offset:72
+.LBB0_129:
+	.loc	1 0 56 is_stmt 0                ; triton_cdna4_matmul_source:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 13 31 is_stmt 1               ; triton_cdna4_matmul_source:13:31
+	v_or_b32_e32 v0, 19, v2
+	.loc	1 26 61                         ; triton_cdna4_matmul_source:26:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v0
+	.loc	1 26 43 is_stmt 0               ; triton_cdna4_matmul_source:26:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 25 56 is_stmt 1               ; triton_cdna4_matmul_source:25:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_131
+; %bb.130:
+	global_store_dword v[4:5], a11, off offset:76
+.LBB0_131:
+	.loc	1 0 56 is_stmt 0                ; triton_cdna4_matmul_source:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 13 31 is_stmt 1               ; triton_cdna4_matmul_source:13:31
+	v_or_b32_e32 v0, 24, v2
+	.loc	1 26 61                         ; triton_cdna4_matmul_source:26:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v0
+	.loc	1 26 43 is_stmt 0               ; triton_cdna4_matmul_source:26:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 25 56 is_stmt 1               ; triton_cdna4_matmul_source:25:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_133
+; %bb.132:
+	global_store_dword v[4:5], a12, off offset:96
+.LBB0_133:
+	.loc	1 0 56 is_stmt 0                ; triton_cdna4_matmul_source:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 13 31 is_stmt 1               ; triton_cdna4_matmul_source:13:31
+	v_or_b32_e32 v0, 25, v2
+	.loc	1 26 61                         ; triton_cdna4_matmul_source:26:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v0
+	.loc	1 26 43 is_stmt 0               ; triton_cdna4_matmul_source:26:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 25 56 is_stmt 1               ; triton_cdna4_matmul_source:25:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_135
+; %bb.134:
+	global_store_dword v[4:5], a13, off offset:100
+.LBB0_135:
+	.loc	1 0 56 is_stmt 0                ; triton_cdna4_matmul_source:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 13 31 is_stmt 1               ; triton_cdna4_matmul_source:13:31
+	v_or_b32_e32 v0, 26, v2
+	.loc	1 26 61                         ; triton_cdna4_matmul_source:26:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v0
+	.loc	1 26 43 is_stmt 0               ; triton_cdna4_matmul_source:26:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 25 56 is_stmt 1               ; triton_cdna4_matmul_source:25:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_137
+; %bb.136:
+	global_store_dword v[4:5], a14, off offset:104
+.LBB0_137:
+	.loc	1 0 56 is_stmt 0                ; triton_cdna4_matmul_source:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 13 31 is_stmt 1               ; triton_cdna4_matmul_source:13:31
+	v_or_b32_e32 v0, 27, v2
+	.loc	1 26 61                         ; triton_cdna4_matmul_source:26:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v0
+	.loc	1 26 43 is_stmt 0               ; triton_cdna4_matmul_source:26:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 25 56 is_stmt 1               ; triton_cdna4_matmul_source:25:56
+	s_and_b64 s[0:1], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[0:1]
+	s_cbranch_execz .LBB0_139
+; %bb.138:
+	global_store_dword v[4:5], a15, off offset:108
+.LBB0_139:
+	.loc	1 25 4 is_stmt 0                ; triton_cdna4_matmul_source:25:4
+	s_endpgm
+.Ltmp2:
+	.section	.rodata,"a",@progbits
+	.p2align	6, 0x0
+	.amdhsa_kernel triton_cdna4_matmul_kernel
+		.amdhsa_group_segment_fixed_size 0
+		.amdhsa_private_segment_fixed_size 0
+		.amdhsa_kernarg_size 56
+		.amdhsa_user_sgpr_count 16
+		.amdhsa_user_sgpr_dispatch_ptr 0
+		.amdhsa_user_sgpr_queue_ptr 0
+		.amdhsa_user_sgpr_kernarg_segment_ptr 1
+		.amdhsa_user_sgpr_dispatch_id 0
+		.amdhsa_user_sgpr_kernarg_preload_length 14
+		.amdhsa_user_sgpr_kernarg_preload_offset 0
+		.amdhsa_user_sgpr_private_segment_size 0
+		.amdhsa_uses_dynamic_stack 0
+		.amdhsa_enable_private_segment 0
+		.amdhsa_system_sgpr_workgroup_id_x 1
+		.amdhsa_system_sgpr_workgroup_id_y 1
+		.amdhsa_system_sgpr_workgroup_id_z 0
+		.amdhsa_system_sgpr_workgroup_info 0
+		.amdhsa_system_vgpr_workitem_id 0
+		.amdhsa_next_free_vgpr 112
+		.amdhsa_next_free_sgpr 38
+		.amdhsa_accum_offset 96
+		.amdhsa_reserve_vcc 1
+		.amdhsa_reserve_xnack_mask 1
+		.amdhsa_float_round_mode_32 0
+		.amdhsa_float_round_mode_16_64 0
+		.amdhsa_float_denorm_mode_32 3
+		.amdhsa_float_denorm_mode_16_64 3
+		.amdhsa_dx10_clamp 1
+		.amdhsa_ieee_mode 1
+		.amdhsa_fp16_overflow 0
+		.amdhsa_tg_split 0
+		.amdhsa_exception_fp_ieee_invalid_op 0
+		.amdhsa_exception_fp_denorm_src 0
+		.amdhsa_exception_fp_ieee_div_zero 0
+		.amdhsa_exception_fp_ieee_overflow 0
+		.amdhsa_exception_fp_ieee_underflow 0
+		.amdhsa_exception_fp_ieee_inexact 0
+		.amdhsa_exception_int_div_zero 0
+	.end_amdhsa_kernel
+	.text
+.Lfunc_end0:
+	.size	triton_cdna4_matmul_kernel, .Lfunc_end0-triton_cdna4_matmul_kernel
+	.cfi_endproc
+                                        ; -- End function
+	.set triton_cdna4_matmul_kernel.num_vgpr, 96
+	.set triton_cdna4_matmul_kernel.num_agpr, 16
+	.set triton_cdna4_matmul_kernel.numbered_sgpr, 38
+	.set triton_cdna4_matmul_kernel.num_named_barrier, 0
+	.set triton_cdna4_matmul_kernel.private_seg_size, 0
+	.set triton_cdna4_matmul_kernel.uses_vcc, 1
+	.set triton_cdna4_matmul_kernel.uses_flat_scratch, 0
+	.set triton_cdna4_matmul_kernel.has_dyn_sized_stack, 0
+	.set triton_cdna4_matmul_kernel.has_recursion, 0
+	.set triton_cdna4_matmul_kernel.has_indirect_call, 0
+	.section	.AMDGPU.csdata,"",@progbits
+; Kernel info:
+; codeLenInByte = 5384
+; TotalNumSgprs: 44
+; NumVgprs: 96
+; NumAgprs: 16
+; TotalNumVgprs: 112
+; ScratchSize: 0
+; MemoryBound: 0
+; FloatMode: 240
+; IeeeMode: 1
+; LDSByteSize: 0 bytes/workgroup (compile time only)
+; SGPRBlocks: 5
+; VGPRBlocks: 13
+; NumSGPRsForWavesPerEU: 44
+; NumVGPRsForWavesPerEU: 112
+; AccumOffset: 96
+; Occupancy: 4
+; WaveLimiterHint : 0
+; COMPUTE_PGM_RSRC2:SCRATCH_EN: 0
+; COMPUTE_PGM_RSRC2:USER_SGPR: 16
+; COMPUTE_PGM_RSRC2:TRAP_HANDLER: 0
+; COMPUTE_PGM_RSRC2:TGID_X_EN: 1
+; COMPUTE_PGM_RSRC2:TGID_Y_EN: 1
+; COMPUTE_PGM_RSRC2:TGID_Z_EN: 0
+; COMPUTE_PGM_RSRC2:TIDIG_COMP_CNT: 0
+; COMPUTE_PGM_RSRC3_GFX90A:ACCUM_OFFSET: 23
+; COMPUTE_PGM_RSRC3_GFX90A:TG_SPLIT: 0
+	.text
+	.p2alignl 6, 3212836864
+	.fill 256, 4, 3212836864
+	.section	.AMDGPU.gpr_maximums,"",@progbits
+	.set amdgpu.max_num_vgpr, 0
+	.set amdgpu.max_num_agpr, 0
+	.set amdgpu.max_num_sgpr, 0
+	.text
+	.section	.debug_abbrev,"",@progbits
+	.byte	1                               ; Abbreviation Code
+	.byte	17                              ; DW_TAG_compile_unit
+	.byte	0                               ; DW_CHILDREN_no
+	.byte	37                              ; DW_AT_producer
+	.byte	14                              ; DW_FORM_strp
+	.byte	19                              ; DW_AT_language
+	.byte	5                               ; DW_FORM_data2
+	.byte	3                               ; DW_AT_name
+	.byte	14                              ; DW_FORM_strp
+	.byte	16                              ; DW_AT_stmt_list
+	.byte	23                              ; DW_FORM_sec_offset
+	.byte	27                              ; DW_AT_comp_dir
+	.byte	14                              ; DW_FORM_strp
+	.byte	17                              ; DW_AT_low_pc
+	.byte	1                               ; DW_FORM_addr
+	.byte	18                              ; DW_AT_high_pc
+	.byte	6                               ; DW_FORM_data4
+	.byte	0                               ; EOM(1)
+	.byte	0                               ; EOM(2)
+	.byte	0                               ; EOM(3)
+	.section	.debug_info,"",@progbits
+.Lcu_begin0:
+	.long	.Ldebug_info_end0-.Ldebug_info_start0 ; Length of Unit
+.Ldebug_info_start0:
+	.short	4                               ; DWARF version number
+	.long	.debug_abbrev                   ; Offset Into Abbrev. Section
+	.byte	8                               ; Address Size (in bytes)
+	.byte	1                               ; Abbrev [1] 0xb:0x1f DW_TAG_compile_unit
+	.long	.Linfo_string0                  ; DW_AT_producer
+	.short	2                               ; DW_AT_language
+	.long	.Linfo_string1                  ; DW_AT_name
+	.long	.Lline_table_start0             ; DW_AT_stmt_list
+	.long	.Linfo_string2                  ; DW_AT_comp_dir
+	.quad	.Lfunc_begin0                   ; DW_AT_low_pc
+	.long	.Lfunc_end0-.Lfunc_begin0       ; DW_AT_high_pc
+.Ldebug_info_end0:
+	.section	.debug_str,"MS",@progbits,1
+.Linfo_string0:
+	.asciz	"triton"                        ; string offset=0
+.Linfo_string1:
+	.asciz	"triton_cdna4_matmul_source"    ; string offset=7
+.Linfo_string2:
+	.asciz	"tests/kernels"                 ; string offset=34
+	.section	".note.GNU-stack","",@progbits
+	.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .agpr_count:     16
+    .args:
+      - .address_space:  global
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .address_space:  global
+        .offset:         8
+        .size:           8
+        .value_kind:     global_buffer
+      - .address_space:  global
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .offset:         24
+        .size:           4
+        .value_kind:     by_value
+      - .offset:         28
+        .size:           4
+        .value_kind:     by_value
+      - .offset:         32
+        .size:           4
+        .value_kind:     by_value
+      - .address_space:  global
+        .offset:         40
+        .size:           8
+        .value_kind:     global_buffer
+      - .address_space:  global
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+    .group_segment_fixed_size: 0
+    .kernarg_segment_align: 8
+    .kernarg_segment_size: 56
+    .max_flat_workgroup_size: 256
+    .name:           triton_cdna4_matmul_kernel
+    .private_segment_fixed_size: 0
+    .sgpr_count:     44
+    .sgpr_spill_count: 0
+    .symbol:         triton_cdna4_matmul_kernel.kd
+    .uniform_work_group_size: 1
+    .uses_dynamic_stack: false
+    .vgpr_count:     112
+    .vgpr_spill_count: 0
+    .wavefront_size: 64
+amdhsa.target:   amdgcn-amd-amdhsa--gfx950
+amdhsa.version:
+  - 1
+  - 2
+...
+
+	.end_amdgpu_metadata
+	.section	.debug_line,"",@progbits
+.Lline_table_start0:


### PR DESCRIPTION
This patch expands DBT support for fp16 workloads for CDNA4 -> CDNA3 conversions. The base test use to drive this is a triton kernel compiled for cdna4 which uses bitop, ds read transpose and wide k mfma instructions.