### PR TITLE
Unregistered host memory should be reported appropriately by hipPointerGetAttribute API

### DIFF
--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -3939,13 +3939,8 @@ hipError_t ihipPointerGetAttributes(void* data, hipPointer_attribute attribute,
     case HIP_POINTER_ATTRIBUTE_MEMORY_TYPE: {
       if (memObj) {  // checks for host type or device type
         *reinterpret_cast<uint32_t*>(data) = getMemoryType(memObj);
-      } else {  // checks for array type
-        // ptr must be a host allocation using malloc since memObj is null and is
-        // not found in hipArraySet.
-        if (hip::hipArraySet.find(static_cast<hipArray*>(ptr)) == hip::hipArraySet.end()) {
-          *reinterpret_cast<uint32_t*>(data) = 0;
-          return hipErrorInvalidValue;
-        }
+      } else if (hip::hipArraySet.find(static_cast<hipArray*>(ptr)) != hip::hipArraySet.end()) {
+        // checks for array type
         cl_mem dstMemObj = reinterpret_cast<cl_mem>((static_cast<hipArray*>(ptr))->data);
         if (!is_valid(dstMemObj)) {
           *reinterpret_cast<uint32_t*>(data) = 0;
@@ -3958,6 +3953,9 @@ hipError_t ihipPointerGetAttributes(void* data, hipPointer_attribute attribute,
           *reinterpret_cast<uint32_t*>(data) = 0;
           return hipErrorInvalidValue;
         }
+      } else {
+        // Unregistered host memory (allocated on stack, heap etc.)
+        *reinterpret_cast<uint32_t*>(data) = hipMemoryTypeUnregistered;
       }
       break;
     }

--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -3939,20 +3939,34 @@ hipError_t ihipPointerGetAttributes(void* data, hipPointer_attribute attribute,
     case HIP_POINTER_ATTRIBUTE_MEMORY_TYPE: {
       if (memObj) {  // checks for host type or device type
         *reinterpret_cast<uint32_t*>(data) = getMemoryType(memObj);
-      } else if (hip::hipArraySet.find(static_cast<hipArray*>(ptr)) != hip::hipArraySet.end()) {
+        break;
+      }
+      hipArray* arr = static_cast<hipArray*>(ptr);
+      cl_mem arrayData = nullptr;
+      bool isHipArray = false;
+      {
+        amd::ScopedLock lock(hipArraySetLock);
+        if (hip::hipArraySet.find(arr) != hip::hipArraySet.end()) {
+          isHipArray = true;
+          arrayData = reinterpret_cast<cl_mem>(arr->data);
+        }
+      }
+      if (isHipArray) {
         // checks for array type
-        cl_mem dstMemObj = reinterpret_cast<cl_mem>((static_cast<hipArray*>(ptr))->data);
-        if (!is_valid(dstMemObj)) {
+        if (!is_valid(arrayData)) {
           *reinterpret_cast<uint32_t*>(data) = 0;
           return hipErrorInvalidValue;
         }
-        amd::Image* dstImage = as_amd(dstMemObj)->asImage();
+        amd::Image* dstImage = as_amd(arrayData)->asImage();
         if (dstImage) {
           *reinterpret_cast<uint32_t*>(data) = hipMemoryTypeArray;
         } else {
           *reinterpret_cast<uint32_t*>(data) = 0;
           return hipErrorInvalidValue;
         }
+      } else if (ptr != nullptr &&
+                 PlatformState::Instance().StatCO().FindDeferredManagedVar(ptr) != nullptr) {
+        *reinterpret_cast<uint32_t*>(data) = hipMemoryTypeManaged;
       } else {
         // Unregistered host memory (allocated on stack, heap etc.)
         *reinterpret_cast<uint32_t*>(data) = hipMemoryTypeUnregistered;

--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -3855,13 +3855,8 @@ hipError_t ihipPointerGetAttributes(void* data, hipPointer_attribute attribute,
     case HIP_POINTER_ATTRIBUTE_MEMORY_TYPE: {
       if (memObj) {  // checks for host type or device type
         *reinterpret_cast<uint32_t*>(data) = getMemoryType(memObj);
-      } else {  // checks for array type
-        // ptr must be a host allocation using malloc since memObj is null and is
-        // not found in hipArraySet.
-        if (hip::hipArraySet.find(static_cast<hipArray*>(ptr)) == hip::hipArraySet.end()) {
-          *reinterpret_cast<uint32_t*>(data) = 0;
-          return hipErrorInvalidValue;
-        }
+      } else if (hip::hipArraySet.find(static_cast<hipArray*>(ptr)) != hip::hipArraySet.end()) {
+        // checks for array type
         cl_mem dstMemObj = reinterpret_cast<cl_mem>((static_cast<hipArray*>(ptr))->data);
         if (!is_valid(dstMemObj)) {
           *reinterpret_cast<uint32_t*>(data) = 0;
@@ -3874,6 +3869,9 @@ hipError_t ihipPointerGetAttributes(void* data, hipPointer_attribute attribute,
           *reinterpret_cast<uint32_t*>(data) = 0;
           return hipErrorInvalidValue;
         }
+      } else {
+        // Unregistered host memory (allocated on stack, heap etc.)
+        *reinterpret_cast<uint32_t*>(data) = hipMemoryTypeUnregistered;
       }
       break;
     }

--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -3855,20 +3855,34 @@ hipError_t ihipPointerGetAttributes(void* data, hipPointer_attribute attribute,
     case HIP_POINTER_ATTRIBUTE_MEMORY_TYPE: {
       if (memObj) {  // checks for host type or device type
         *reinterpret_cast<uint32_t*>(data) = getMemoryType(memObj);
-      } else if (hip::hipArraySet.find(static_cast<hipArray*>(ptr)) != hip::hipArraySet.end()) {
+        break;
+      }
+      hipArray* arr = static_cast<hipArray*>(ptr);
+      cl_mem arrayData = nullptr;
+      bool isHipArray = false;
+      {
+        amd::ScopedLock lock(hipArraySetLock);
+        if (hip::hipArraySet.find(arr) != hip::hipArraySet.end()) {
+          isHipArray = true;
+          arrayData = reinterpret_cast<cl_mem>(arr->data);
+        }
+      }
+      if (isHipArray) {
         // checks for array type
-        cl_mem dstMemObj = reinterpret_cast<cl_mem>((static_cast<hipArray*>(ptr))->data);
-        if (!is_valid(dstMemObj)) {
+        if (!is_valid(arrayData)) {
           *reinterpret_cast<uint32_t*>(data) = 0;
           return hipErrorInvalidValue;
         }
-        amd::Image* dstImage = as_amd(dstMemObj)->asImage();
+        amd::Image* dstImage = as_amd(arrayData)->asImage();
         if (dstImage) {
           *reinterpret_cast<uint32_t*>(data) = hipMemoryTypeArray;
         } else {
           *reinterpret_cast<uint32_t*>(data) = 0;
           return hipErrorInvalidValue;
         }
+      } else if (ptr != nullptr &&
+                 PlatformState::Instance().StatCO().FindDeferredManagedVar(ptr) != nullptr) {
+        *reinterpret_cast<uint32_t*>(data) = hipMemoryTypeManaged;
       } else {
         // Unregistered host memory (allocated on stack, heap etc.)
         *reinterpret_cast<uint32_t*>(data) = hipMemoryTypeUnregistered;

--- a/projects/hip-tests/catch/config/configs/unit/memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/memory.yaml
@@ -1723,6 +1723,9 @@ memory:
   Unit_hipPointerGetAttribute_MemoryTypes:
     <<: *level_2
     tags: [query, image]
+  Unit_hipPointerGetAttribute_DeferredManagedVar:
+    <<: *level_2
+    tags: [query]
   Unit_hipPointerGetAttribute_KernelUpdation:
     <<: *level_2
     tags: [query]

--- a/projects/hip-tests/catch/config/configs/unit/memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/memory.yaml
@@ -1720,6 +1720,9 @@ memory:
   Unit_hipPointerGetAttribute_MemoryTypes:
     <<: *level_2
     tags: [query, image]
+  Unit_hipPointerGetAttribute_DeferredManagedVar:
+    <<: *level_2
+    tags: [query]
   Unit_hipPointerGetAttribute_KernelUpdation:
     <<: *level_2
     tags: [query]

--- a/projects/hip-tests/catch/unit/memory/hipPointerGetAttribute.cc
+++ b/projects/hip-tests/catch/unit/memory/hipPointerGetAttribute.cc
@@ -54,6 +54,8 @@ static __global__ void var_update(int* data) {
   }
 }
 
+__managed__ int m_deferred_managed_var = 0;
+
 /* Allocate memory using different Allocation APIs and check whether
    correct memory type and device oridinal are returned */
 HIP_TEST_CASE(Unit_hipPointerGetAttribute_MemoryTypes) {
@@ -98,6 +100,30 @@ HIP_TEST_CASE(Unit_hipPointerGetAttribute_MemoryTypes) {
     HIP_CHECK(hipFreeArray(arr));
   }
 #endif
+  SECTION("Unregistered Stack Pointer") {
+    int stack_var = 0;
+    HIP_CHECK(hipPointerGetAttribute(&datatype, HIP_POINTER_ATTRIBUTE_MEMORY_TYPE,
+                                     reinterpret_cast<hipDeviceptr_t>(&stack_var)));
+    REQUIRE(datatype == hipMemoryTypeUnregistered);
+  }
+  SECTION("Unregistered Heap Pointer") {
+    int* heap_ptr = static_cast<int*>(malloc(sizeof(int)));
+    REQUIRE(heap_ptr != nullptr);
+    HIP_CHECK(hipPointerGetAttribute(&datatype, HIP_POINTER_ATTRIBUTE_MEMORY_TYPE,
+                                     reinterpret_cast<hipDeviceptr_t>(heap_ptr)));
+    REQUIRE(datatype == hipMemoryTypeUnregistered);
+    free(heap_ptr);
+  }
+}
+
+// A deferred managed variable must be classified as hipMemoryTypeManaged
+// by hipPointerGetAttribute (HIP_POINTER_ATTRIBUTE_MEMORY_TYPE)
+HIP_TEST_CASE(Unit_hipPointerGetAttribute_DeferredManagedVar) {
+  CHECK_MANAGED_MEMORY_SUPPORT
+  unsigned int datatype = 0;
+  HIP_CHECK(hipPointerGetAttribute(&datatype, HIP_POINTER_ATTRIBUTE_MEMORY_TYPE,
+                                   reinterpret_cast<hipDeviceptr_t>(&m_deferred_managed_var)));
+  REQUIRE(datatype == hipMemoryTypeManaged);
 }
 
 /*


### PR DESCRIPTION
## Motivation

hipPointerGetAttribute API returns hipErrorInvalidValue when an unregistered host pointer (allocated using stack or heap) is passed to it.

## Technical Details

The API now checks if the memory type of the pointer is one of the host, device or array allocation types and if not, it returns the type as hipMemoryTypeUnregistered and status as hipSuccess.

## JIRA ID

AIRUNTIME-2218

## Test Plan

Verified with the given reproducer.

## Test Result

PASS

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
