### PR TITLE
hipfile: Enable hipFILE rocprofiler-register integration

### DIFF
--- a/projects/hipfile/CMakeLists.txt
+++ b/projects/hipfile/CMakeLists.txt
@@ -248,6 +248,12 @@ else()
     message(NOTICE "find_package did NOT find hip")
 endif()
 
+if(HIPFILE_ROCPROFILER_REGISTER)
+    find_package(rocprofiler-register QUIET
+        HINTS $ENV{rocprofiler_register_ROOT} $ENV{ROCPROFILER_REGISTER_ROOT} ${CMAKE_INSTALL_PREFIX}
+        PATHS ${ROCM_PATH})
+endif()
+
 # Find the cuFile library and headers on NVIDIA
 if(AIS_BUILD_NVIDIA_DETAIL)
     find_package(CUDAToolkit REQUIRED)

--- a/projects/hipfile/cmake/AISProfiling.cmake
+++ b/projects/hipfile/cmake/AISProfiling.cmake
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: MIT
 
-option(AIS_ENABLE_PROFILING "Turn API profiling on" OFF)
+option(HIPFILE_ROCPROFILER_REGISTER "Enable rocprofiler-register support" ON)

--- a/projects/hipfile/src/amd_detail/CMakeLists.txt
+++ b/projects/hipfile/src/amd_detail/CMakeLists.txt
@@ -30,7 +30,7 @@ set(HIPFILE_SOURCES
     sys.cpp
 )
 
-if (AIS_ENABLE_PROFILING)
+if (HIPFILE_ROCPROFILER_REGISTER AND rocprofiler-register_FOUND)
     set(HIPFILE_SOURCES
         api_trace/api-dispatch-interface.cpp
         api_trace/api-trace.cpp
@@ -47,3 +47,15 @@ ais_add_libraries(
     LIBINCL  ${HIPFILE_INCLUDE_PATH}
     SYSINCLS ${HIPFILE_AMD_SOURCE_PATH}
 )
+
+if (HIPFILE_ROCPROFILER_REGISTER AND rocprofiler-register_FOUND)
+    target_link_libraries(hipfile PRIVATE rocprofiler-register::rocprofiler-register)
+    target_compile_definitions(
+        hipfile
+        PRIVATE
+            HIPFILE_ROCPROFILER_REGISTER=1
+            HIPFILE_ROCP_REG_VERSION_MAJOR=${PROJECT_VERSION_MAJOR}
+            HIPFILE_ROCP_REG_VERSION_MINOR=${PROJECT_VERSION_MINOR}
+            HIPFILE_ROCP_REG_VERSION_PATCH=${PROJECT_VERSION_PATCH}
+    )
+endif()

--- a/projects/hipfile/src/amd_detail/api_trace/api-trace.cpp
+++ b/projects/hipfile/src/amd_detail/api_trace/api-trace.cpp
@@ -5,6 +5,8 @@
 
 #include "hipfile-api-trace.h"
 
+#include <cstddef>
+
 #if defined(HIPFILE_ROCPROFILER_REGISTER) && HIPFILE_ROCPROFILER_REGISTER > 0
 #include <rocprofiler-register/rocprofiler-register.h>
 

--- a/projects/hipfile/src/amd_detail/hipfile-private.h
+++ b/projects/hipfile/src/amd_detail/hipfile-private.h
@@ -16,6 +16,14 @@ enum class IoType;
 struct Backend;
 }
 
+#if defined(HIPFILE_ROCPROFILER_REGISTER) && HIPFILE_ROCPROFILER_REGISTER > 0
+namespace hipFile {
+#endif
+
 ssize_t hipFileIo(hipFile::IoType type, hipFileHandle_t fh, const void *buffer_base, size_t size,
                   hoff_t file_offset, hoff_t buffer_offset,
                   const std::vector<std::shared_ptr<hipFile::Backend>> &backends);
+
+#if defined(HIPFILE_ROCPROFILER_REGISTER) && HIPFILE_ROCPROFILER_REGISTER > 0
+}
+#endif

--- a/projects/hipfile/src/amd_detail/hipfile.cpp
+++ b/projects/hipfile/src/amd_detail/hipfile.cpp
@@ -29,6 +29,10 @@
 using namespace hipFile;
 using namespace std;
 
+#if defined(HIPFILE_ROCPROFILER_REGISTER) && HIPFILE_ROCPROFILER_REGISTER > 0
+namespace hipFile {
+#endif
+
 /// Catch C++ exceptions from the hipFile code and convert
 /// them into error values that can be returned from public
 /// C API calls.
@@ -606,3 +610,7 @@ try {
 catch (...) {
     return handle_exception();
 }
+
+#if defined(HIPFILE_ROCPROFILER_REGISTER) && HIPFILE_ROCPROFILER_REGISTER > 0
+} // namespace hipFile
+#endif

--- a/projects/hipfile/src/common/hipfile-common.cpp
+++ b/projects/hipfile/src/common/hipfile-common.cpp
@@ -7,6 +7,10 @@
 
 #include <hip/hip_runtime_api.h>
 
+#if defined(HIPFILE_ROCPROFILER_REGISTER) && HIPFILE_ROCPROFILER_REGISTER > 0
+namespace hipFile {
+#endif
+
 const char *
 hipFileGetOpErrorString(hipFileOpError_t status)
 {
@@ -111,3 +115,7 @@ try {
 catch (...) {
     return {hipFileInternalError, hipSuccess};
 }
+
+#if defined(HIPFILE_ROCPROFILER_REGISTER) && HIPFILE_ROCPROFILER_REGISTER > 0
+} // namespace hipFile
+#endif


### PR DESCRIPTION


## Motivation

- hipfile tracing support 

## Technical Details

- Wire HIPFILE_ROCPROFILER_REGISTER through CMake so profiling builds find and link rocprofiler-register, compile the API dispatch shim, and define the table registration version macros. Namespace the real hipFILE implementations behind the dispatch shim to preserve the public C ABI while allowing rocprofiler-register to intercept calls.
- 
## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
