### PR TITLE
rocjitsu: Add rj_dbt_translate tool for debugging

### DIFF
--- a/emulation/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/CMakeLists.txt
@@ -193,6 +193,9 @@ target_link_libraries(rocjitsu_shared PRIVATE
 target_include_directories(rocjitsu_shared PRIVATE ${GENERATED_DIR})
 add_dependencies(rocjitsu_shared flatbuffers_schemas)
 
+# Developer and test workflow tools.
+add_subdirectory(tools)
+
 # Tests and scaling tools.
 if(BUILD_TESTING)
   add_subdirectory(tests)

--- a/emulation/rocjitsu/docs/rj_dbt_translate.md
+++ b/emulation/rocjitsu/docs/rj_dbt_translate.md
@@ -1,0 +1,110 @@
+# rj_dbt_translate
+
+`rj_dbt_translate` inspects or translates an AMDGPU code object with the DBT
+pipeline. It accepts either a standalone AMDGPU code object or a host object
+containing bundled AMDGPU code objects.
+
+This tool is mostly meant as a debugging tool for DBT developers and agents.
+Start with `--output-mode diff` when investigating translation behavior; it
+shows what changed without requiring you to compare full disassemblies by hand.
+
+## Usage
+
+```text
+rj_dbt_translate INPUT --input-target TARGET --output-target TARGET [options]
+```
+
+Required arguments:
+
+- `INPUT`: input file path. For host objects, the tool extracts an embedded
+  AMDGPU code object for the selected input target.
+- `--input-target TARGET`: input LLVM machine name, such as `gfx950`.
+- `--output-target TARGET`: output LLVM machine name, such as `gfx1200`.
+
+Options:
+
+- `--code-object-index N`: code-object index for executable inputs. Defaults to
+  `0`.
+- `--output-mode MODE`: output format. `disasm` prints translated
+  disassembly, `code-object` writes the translated code-object bytes, and
+  `diff` prints a compact source-to-target translation report. Defaults to
+  `disasm`.
+- `--list-code-objects`: list extractable code objects and exit.
+- `--help`: print command-line help.
+
+Supported target names are `gfx908`, `gfx90a`, `gfx940`, `gfx941`, `gfx942`,
+`gfx950`, `gfx1010`, `gfx1030`, `gfx1100`, `gfx1150`, `gfx1200`, and
+`gfx1201`.
+
+## Output
+
+All selected output is written to stdout. Use shell redirection when a file is
+needed:
+
+```sh
+rj_dbt_translate vector_add.o --input-target gfx950 --output-target gfx1200 \
+  --output-mode code-object > vector_add.gfx1200.co
+```
+
+Diagnostics and validation errors are written to stderr. Translation warnings
+are treated as failures.
+
+## Diff Mode
+
+`diff` mode is the primary debugging mode. It prints a compact translation
+report with enough context to answer the usual DBT questions:
+
+- Did the instruction change, lower, expand, or get copied unchanged?
+- Which source words produced the change?
+- Which target words did the translator emit?
+- Did expanded code stay in `.text`, or move into `.rj_translations`?
+- Did source or translated decode validation fail?
+
+Run it with:
+
+```sh
+rj_dbt_translate vector_add.o --input-target gfx950 --output-target gfx1200 \
+  --output-mode diff
+```
+
+The report starts with source and translated code-object summaries, then lists
+the shown instruction translations. Identity translations are omitted unless
+their words changed or they were emitted through the code cave, so the report
+stays focused on places worth inspecting.
+
+Each shown translation uses this order:
+
+```text
+source_words: bf8cc07f
+source: s_waitcnt vmcnt(63) expcnt(7) lgkmcnt(0)
+target_words: bfc900f0 bfc70000
+target: s_wait_storecnt_dscnt 240
+target: s_wait_kmcnt 0
+```
+
+Read `source_words` and `target_words` as the exact machine words, not as a
+re-encoding of the printed assembly. This is useful when checking literal
+operands, opcode substitution, wait-counter lowering, and instruction-size
+changes. Multiple `target:` lines mean one source instruction lowered to a
+target instruction sequence.
+
+## Examples
+
+Print translated disassembly:
+
+```sh
+rj_dbt_translate vector_add.o --input-target gfx950 --output-target gfx1200
+```
+
+Print a compact translation diff:
+
+```sh
+rj_dbt_translate vector_add.o --input-target gfx950 --output-target gfx1200 \
+  --output-mode diff
+```
+
+List bundled code objects in an executable input:
+
+```sh
+rj_dbt_translate vector_add.o --list-code-objects
+```

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -28,6 +28,7 @@
 #include <memory>
 #include <span>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 namespace rocjitsu {
@@ -100,6 +101,20 @@ LegalizationLookupFn select_legalization(rj_code_arch_t guest, rj_code_arch_t ho
 
   offset_dwords = static_cast<int16_t>(delta_dwords);
   return true;
+}
+
+[[nodiscard]] std::vector<uint32_t> raw_words_for_inst(const Instruction &inst) {
+  const uint32_t *raw = inst.raw_encoding();
+  if (!raw)
+    return {};
+  return {raw, raw + inst.size() / sizeof(uint32_t)};
+}
+
+[[nodiscard]] bool words_changed(std::span<const uint32_t> before,
+                                 std::span<const uint32_t> after) {
+  if (before.size() != after.size())
+    return true;
+  return !std::ranges::equal(before, after);
 }
 
 [[nodiscard]] std::vector<uint64_t> kernel_entry_offsets(std::span<const KdTranslation> kernels) {
@@ -193,6 +208,10 @@ BinaryTranslator::BinaryTranslator(rj_code_arch_t guest_arch, rj_code_arch_t hos
       encoding_translate_(select_encoding_translator(guest_arch, host_arch)),
       legalization_lookup_(select_legalization(guest_arch, host_arch)),
       semantic_translator_(std::make_unique<SemanticTranslator>(guest_arch, host_arch)) {}
+
+void BinaryTranslator::set_trace_callback(TranslationTraceCallback callback) {
+  trace_callback_ = std::move(callback);
+}
 
 TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   TranslatedCodeObject result;
@@ -297,6 +316,18 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
         const uint32_t *raw = inst.raw_encoding();
         if (!raw) {
           std::memcpy(translated_text.data() + offset, text.data() + offset, inst_size);
+          if (trace_callback_) {
+            trace_callback_({.source_offset = offset,
+                             .source_size = inst_size,
+                             .source_words = {},
+                             .legalization = nullptr,
+                             .copied_original = true,
+                             .semantic_lowering = false,
+                             .changed = false,
+                             .emitted_in_cave = false,
+                             .target_offset = offset,
+                             .target_words = {}});
+          }
           offset += inst_size;
           continue;
         }
@@ -313,9 +344,25 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
         {
           auto expansion = semantic_translator_->try_lower_expand(inst, offset, liveness);
           if (!expansion.empty()) {
+            const bool emitted_in_cave = expansion.size() * sizeof(uint32_t) > inst_size;
+            const uint64_t target_offset =
+                emitted_in_cave ? patcher.cave_start() + patcher.cave_body_size() : offset;
             SemanticReplacement repl{offset, offset + inst_size, std::move(expansion)};
             if (!apply_semantic(repl, translated_text, patcher))
               return leave_unchanged();
+            if (trace_callback_) {
+              const auto source_words = raw_words_for_inst(inst);
+              trace_callback_({.source_offset = offset,
+                               .source_size = inst_size,
+                               .source_words = source_words,
+                               .legalization = leg,
+                               .copied_original = false,
+                               .semantic_lowering = true,
+                               .changed = true,
+                               .emitted_in_cave = emitted_in_cave,
+                               .target_offset = target_offset,
+                               .target_words = repl.target_words});
+            }
             offset += inst_size;
             continue;
           }
@@ -325,13 +372,31 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
           result.warnings.push_back("EXPAND not yet implemented for " +
                                     std::string(inst.mnemonic()));
           const uint32_t nop = build_s_nop(0, host_arch_);
+          std::vector<uint32_t> target_words;
+          if (trace_callback_)
+            target_words.reserve(inst_size / sizeof(uint32_t));
           for (uint32_t i = 0; i < inst_size; i += 4)
             std::memcpy(translated_text.data() + offset + i, &nop, 4);
+          if (trace_callback_) {
+            for (uint32_t i = 0; i < inst_size; i += sizeof(uint32_t))
+              target_words.push_back(nop);
+            const auto source_words = raw_words_for_inst(inst);
+            trace_callback_({.source_offset = offset,
+                             .source_size = inst_size,
+                             .source_words = source_words,
+                             .legalization = leg,
+                             .copied_original = false,
+                             .semantic_lowering = false,
+                             .changed = words_changed(source_words, target_words),
+                             .emitted_in_cave = false,
+                             .target_offset = offset,
+                             .target_words = target_words});
+          }
           offset += inst_size;
           continue;
         }
 
-        if (!handle_encoding(inst, offset, translated_text, dst_opcode, patcher, text))
+        if (!handle_encoding(inst, offset, translated_text, dst_opcode, patcher, text, leg))
           return leave_unchanged();
         offset += inst_size;
       }
@@ -418,11 +483,32 @@ bool BinaryTranslator::apply_semantic(const SemanticReplacement &repl, std::vect
 bool BinaryTranslator::handle_encoding(const Instruction &inst, uint64_t offset,
                                        std::vector<uint8_t> &text, uint16_t dst_opcode,
                                        CodeObjectPatcher &patcher,
-                                       std::span<const uint8_t> orig_text) {
+                                       std::span<const uint8_t> orig_text,
+                                       const InstructionLegalization *leg) {
   const uint32_t *raw = inst.raw_encoding();
   assert(raw && "handle_encoding called without raw encoding");
+  const bool tracing = static_cast<bool>(trace_callback_);
+  const auto source_words = tracing ? raw_words_for_inst(inst) : std::vector<uint32_t>{};
+
+  auto emit_trace = [&](bool copied_original, bool changed, bool emitted_in_cave,
+                        uint64_t target_offset, std::span<const uint32_t> target_words) {
+    if (!trace_callback_)
+      return;
+    trace_callback_({.source_offset = offset,
+                     .source_size = static_cast<uint32_t>(inst.size()),
+                     .source_words = source_words,
+                     .legalization = leg,
+                     .copied_original = copied_original,
+                     .semantic_lowering = false,
+                     .changed = changed,
+                     .emitted_in_cave = emitted_in_cave,
+                     .target_offset = target_offset,
+                     .target_words = target_words});
+  };
+
   if (!encoding_translate_) {
     std::memcpy(text.data() + offset, raw, inst.size());
+    emit_trace(true, false, false, offset, source_words);
     return true;
   }
 
@@ -434,6 +520,7 @@ bool BinaryTranslator::handle_encoding(const Instruction &inst, uint64_t offset,
 
   if (tr.word_count == 0) {
     std::memcpy(text.data() + offset, raw, inst.size());
+    emit_trace(true, false, false, offset, source_words);
     return true;
   }
 
@@ -453,6 +540,12 @@ bool BinaryTranslator::handle_encoding(const Instruction &inst, uint64_t offset,
   }
 
   const uint32_t target_size = tr.word_count * 4u;
+  const auto target_words = std::span<const uint32_t>(tr.words, tr.word_count);
+  const bool emitted_in_cave = target_size > orig_bytes;
+  const uint64_t target_offset =
+      emitted_in_cave ? patcher.cave_start() + patcher.cave_body_size() : offset;
+  const bool changed = tracing && words_changed(source_words, target_words);
+
   if (target_size <= orig_bytes) {
     std::memcpy(text.data() + offset, tr.words, target_size);
   } else {
@@ -460,6 +553,7 @@ bool BinaryTranslator::handle_encoding(const Instruction &inst, uint64_t offset,
     if (!apply_semantic(repl, text, patcher))
       return false;
   }
+  emit_trace(false, changed, emitted_in_cave, target_offset, target_words);
   return true;
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <span>
 #include <string>
@@ -67,6 +68,29 @@ using EncodingTranslateFn = TranslationResult (*)(uint32_t encoding_id, uint32_t
 using LegalizationLookupFn = const InstructionLegalization *(*)(uint16_t encoding_id,
                                                                 uint16_t opcode);
 
+/// @brief One source instruction trace event emitted by BinaryTranslator.
+///
+/// @details Offsets are .text-relative. When emitted_in_cave is true,
+/// target_offset points into the logical .text continuation that later becomes
+/// `.rj_translations`; subtracting the original .text size gives the offset in
+/// that cave section. source_words and target_words are only valid for the
+/// duration of the callback; callers that need to retain them must copy the
+/// spans.
+struct TranslationTraceEvent {
+  uint64_t source_offset = 0;
+  uint32_t source_size = 0;
+  std::span<const uint32_t> source_words;
+  const InstructionLegalization *legalization = nullptr;
+  bool copied_original = false;
+  bool semantic_lowering = false;
+  bool changed = false;
+  bool emitted_in_cave = false;
+  uint64_t target_offset = 0;
+  std::span<const uint32_t> target_words;
+};
+
+using TranslationTraceCallback = std::function<void(const TranslationTraceEvent &)>;
+
 /// @brief Result of translating a code object.
 struct TranslatedCodeObject {
   std::vector<uint8_t> elf_bytes;    ///< Translated ELF for the host ISA.
@@ -95,6 +119,9 @@ public:
   ///                      0 = auto-detect from host_arch (default GFX1200 for RDNA4).
   BinaryTranslator(rj_code_arch_t guest_arch, rj_code_arch_t host_arch, uint32_t target_mach = 0);
   ~BinaryTranslator();
+
+  /// @brief Install an optional callback for per-instruction debugging.
+  void set_trace_callback(TranslationTraceCallback callback);
 
   /// @brief Translate a decoded code object.
   /// @param obj  The guest code object to translate.
@@ -134,12 +161,13 @@ private:
   ///          the code cave.
   [[nodiscard]] bool handle_encoding(const Instruction &inst, uint64_t offset,
                                      std::vector<uint8_t> &text, uint16_t dst_opcode,
-                                     CodeObjectPatcher &patcher,
-                                     std::span<const uint8_t> orig_text);
+                                     CodeObjectPatcher &patcher, std::span<const uint8_t> orig_text,
+                                     const InstructionLegalization *leg);
 
   rj_code_arch_t guest_arch_;                               ///< Source ISA.
   rj_code_arch_t host_arch_;                                ///< Target ISA.
   uint32_t target_mach_;                                    ///< ELF MACH flag for target stepping.
+  TranslationTraceCallback trace_callback_;                  ///< Optional debug trace callback.
   EncodingTranslateFn encoding_translate_;                  ///< Per-pair encoding translator.
   LegalizationLookupFn legalization_lookup_;                ///< Per-pair legalization table.
   std::unique_ptr<SemanticTranslator> semantic_translator_; ///< Per-pair semantic rule engine.

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -58,6 +58,19 @@ rj_configure_target(rocjitsu_tests TEST)
 include(GoogleTest)
 gtest_discover_tests(rocjitsu_tests)
 
+add_executable(rj_dbt_translate_smoke_test
+    tools/rj_dbt_translate_smoke_test.cpp
+)
+target_include_directories(rj_dbt_translate_smoke_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/lib/rocjitsu/include
+    ${CMAKE_SOURCE_DIR}/lib/rocjitsu/src
+)
+rj_configure_target(rj_dbt_translate_smoke_test TEST)
+add_dependencies(rj_dbt_translate_smoke_test rj_dbt_translate)
+add_test(NAME "RjDbtTranslate.Smoke"
+    COMMAND rj_dbt_translate_smoke_test $<TARGET_FILE:rj_dbt_translate>
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
 # --- Scaling test (standalone executable) ---
 
 add_executable(scaling_test scaling_test.cpp)

--- a/emulation/rocjitsu/tests/tools/rj_dbt_translate_smoke_test.cpp
+++ b/emulation/rocjitsu/tests/tools/rj_dbt_translate_smoke_test.cpp
@@ -1,0 +1,268 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file rj_dbt_translate_smoke_test.cpp
+/// @brief End-to-end smoke test for the rj_dbt_translate command-line tool.
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/code/amdgpu_elf.h"
+
+#include <array>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <sys/wait.h>
+#include <unistd.h>
+
+namespace {
+
+uint32_t add_elf_name(std::vector<uint8_t> &names, std::string_view name) {
+  const uint32_t offset = static_cast<uint32_t>(names.size());
+  names.insert(names.end(), name.begin(), name.end());
+  names.push_back('\0');
+  return offset;
+}
+
+uint64_t align_up(uint64_t value, uint64_t alignment) {
+  const uint64_t remainder = value % alignment;
+  return remainder == 0 ? value : value + alignment - remainder;
+}
+
+std::vector<uint8_t> make_smoke_code_object() {
+  using namespace rocjitsu;
+
+  constexpr uint64_t text_offset = 0x100;
+  constexpr uint64_t text_vaddr = 0x1100;
+  constexpr uint64_t text_size = 8;
+  constexpr uint64_t load_align = 0x1000;
+  constexpr uint64_t kernel_descriptor_size = 64;
+
+  std::vector<uint8_t> shstrtab{'\0'};
+  const uint32_t text_name = add_elf_name(shstrtab, ".text");
+  const uint32_t rodata_name = add_elf_name(shstrtab, ".rodata");
+  const uint32_t symtab_name = add_elf_name(shstrtab, ".symtab");
+  const uint32_t strtab_name = add_elf_name(shstrtab, ".strtab");
+  const uint32_t shstrtab_name = add_elf_name(shstrtab, ".shstrtab");
+
+  std::vector<uint8_t> strtab{'\0'};
+  const uint32_t kd_symbol_name = add_elf_name(strtab, "smoke.kd");
+
+  const uint64_t rodata_offset = text_offset + text_size;
+  const uint64_t rodata_vaddr = text_vaddr + text_size + load_align;
+  const uint64_t strtab_offset = rodata_offset + kernel_descriptor_size;
+  const uint64_t symtab_offset = align_up(strtab_offset + strtab.size(), 8);
+  constexpr size_t sym_count = 2;
+  const uint64_t shstrtab_offset = symtab_offset + sym_count * sizeof(Elf64_Sym);
+  const uint64_t shoff = align_up(shstrtab_offset + shstrtab.size(), 8);
+  constexpr uint16_t section_count = 6;
+  constexpr uint16_t phdr_count = 2;
+
+  std::vector<uint8_t> image(shoff + section_count * sizeof(Elf64_Shdr), 0);
+
+  Elf64_Ehdr ehdr{};
+  std::memcpy(ehdr.e_ident, EI_MAGIC, EI_MAGIC_SIZE);
+  ehdr.e_ident[EI_CLASS] = ELFCLASS64;
+  ehdr.e_ident[EI_DATA] = 1;
+  ehdr.e_ident[EI_VERSION] = 1;
+  ehdr.e_ident[EI_OSABI] = ELFOSABI_AMDGPU_HSA;
+  ehdr.e_ident[EI_ABIVERSION] = ELFABIVERSION_AMDGPU_HSA_V5;
+  ehdr.e_type = ET_DYN;
+  ehdr.e_machine = EM_AMDGPU;
+  ehdr.e_version = 1;
+  ehdr.e_phoff = sizeof(Elf64_Ehdr);
+  ehdr.e_shoff = shoff;
+  ehdr.e_flags = EF_AMDGPU_MACH_AMDGCN_GFX950;
+  ehdr.e_ehsize = sizeof(Elf64_Ehdr);
+  ehdr.e_phentsize = sizeof(Elf64_Phdr);
+  ehdr.e_phnum = phdr_count;
+  ehdr.e_shentsize = sizeof(Elf64_Shdr);
+  ehdr.e_shnum = section_count;
+  ehdr.e_shstrndx = 5;
+  std::memcpy(image.data(), &ehdr, sizeof(ehdr));
+
+  std::array<Elf64_Phdr, phdr_count> phdrs{};
+  phdrs[0].p_type = PT_LOAD;
+  phdrs[0].p_flags = 0x5; // PF_R | PF_X
+  phdrs[0].p_offset = text_offset;
+  phdrs[0].p_vaddr = text_vaddr;
+  phdrs[0].p_paddr = text_vaddr;
+  phdrs[0].p_filesz = text_size;
+  phdrs[0].p_memsz = text_size;
+  phdrs[0].p_align = load_align;
+
+  phdrs[1].p_type = PT_LOAD;
+  phdrs[1].p_flags = 0x4; // PF_R
+  phdrs[1].p_offset = rodata_offset;
+  phdrs[1].p_vaddr = rodata_vaddr;
+  phdrs[1].p_paddr = rodata_vaddr;
+  phdrs[1].p_filesz = kernel_descriptor_size;
+  phdrs[1].p_memsz = kernel_descriptor_size;
+  phdrs[1].p_align = load_align;
+  std::memcpy(image.data() + ehdr.e_phoff, phdrs.data(), phdrs.size() * sizeof(Elf64_Phdr));
+
+  // Use a CDNA4 waitcnt that lowers to split RDNA4 wait instructions so the
+  // diff report is guaranteed to contain a shown source/target pair.
+  const std::array<uint32_t, 2> text_words = {0xbf8cc07fu, 0xbf810000u};
+  std::memcpy(image.data() + text_offset, text_words.data(), text_size);
+
+  // The DBT pipeline translates kernel entry offsets through AMDHSA kernel
+  // descriptors. For this smoke fixture only the entry offset must be valid;
+  // the remaining descriptor fields can stay zero.
+  constexpr size_t kernel_code_entry_byte_offset_offset = 16;
+  std::array<uint8_t, kernel_descriptor_size> kernel_descriptor{};
+  const int64_t entry_offset =
+      static_cast<int64_t>(text_vaddr) - static_cast<int64_t>(rodata_vaddr);
+  std::memcpy(kernel_descriptor.data() + kernel_code_entry_byte_offset_offset, &entry_offset,
+              sizeof(entry_offset));
+  std::memcpy(image.data() + rodata_offset, kernel_descriptor.data(), kernel_descriptor.size());
+  std::memcpy(image.data() + strtab_offset, strtab.data(), strtab.size());
+
+  std::array<Elf64_Sym, sym_count> syms{};
+  syms[1].st_name = kd_symbol_name;
+  syms[1].st_info = elf_symbol_info(kElfSymbolBindGlobal, kElfSymbolTypeObject);
+  syms[1].st_shndx = 2;
+  syms[1].st_value = rodata_vaddr;
+  syms[1].st_size = kernel_descriptor.size();
+  std::memcpy(image.data() + symtab_offset, syms.data(), syms.size() * sizeof(Elf64_Sym));
+
+  std::memcpy(image.data() + shstrtab_offset, shstrtab.data(), shstrtab.size());
+
+  std::array<Elf64_Shdr, section_count> shdrs{};
+  shdrs[1].sh_name = text_name;
+  shdrs[1].sh_type = SHT_PROGBITS;
+  shdrs[1].sh_flags = SHF_ALLOC | SHF_EXECINSTR;
+  shdrs[1].sh_addr = text_vaddr;
+  shdrs[1].sh_offset = text_offset;
+  shdrs[1].sh_size = text_size;
+  shdrs[1].sh_addralign = sizeof(uint32_t);
+
+  shdrs[2].sh_name = rodata_name;
+  shdrs[2].sh_type = SHT_PROGBITS;
+  shdrs[2].sh_flags = SHF_ALLOC;
+  shdrs[2].sh_addr = rodata_vaddr;
+  shdrs[2].sh_offset = rodata_offset;
+  shdrs[2].sh_size = kernel_descriptor_size;
+  shdrs[2].sh_addralign = 64;
+
+  shdrs[3].sh_name = symtab_name;
+  shdrs[3].sh_type = SHT_SYMTAB;
+  shdrs[3].sh_offset = symtab_offset;
+  shdrs[3].sh_size = syms.size() * sizeof(Elf64_Sym);
+  shdrs[3].sh_link = 4;
+  shdrs[3].sh_info = 1;
+  shdrs[3].sh_addralign = 8;
+  shdrs[3].sh_entsize = sizeof(Elf64_Sym);
+
+  shdrs[4].sh_name = strtab_name;
+  shdrs[4].sh_type = SHT_STRTAB;
+  shdrs[4].sh_offset = strtab_offset;
+  shdrs[4].sh_size = strtab.size();
+  shdrs[4].sh_addralign = 1;
+
+  shdrs[5].sh_name = shstrtab_name;
+  shdrs[5].sh_type = SHT_STRTAB;
+  shdrs[5].sh_offset = shstrtab_offset;
+  shdrs[5].sh_size = shstrtab.size();
+  shdrs[5].sh_addralign = 1;
+
+  std::memcpy(image.data() + shoff, shdrs.data(), shdrs.size() * sizeof(Elf64_Shdr));
+  return image;
+}
+
+std::string shell_quote(std::string_view text) {
+  std::string quoted = "'";
+  for (const char ch : text) {
+    if (ch == '\'')
+      quoted += "'\\''";
+    else
+      quoted += ch;
+  }
+  quoted += "'";
+  return quoted;
+}
+
+std::string read_text_file(const std::filesystem::path &path) {
+  std::ifstream in(path, std::ios::binary);
+  return {std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>()};
+}
+
+bool contains(std::string_view haystack, std::string_view needle) {
+  return haystack.find(needle) != std::string_view::npos;
+}
+
+bool command_succeeded(int status) {
+  return status != -1 && WIFEXITED(status) && WEXITSTATUS(status) == 0;
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+  if (argc != 2) {
+    std::cerr << "usage: rj_dbt_translate_smoke_test <rj_dbt_translate>\n";
+    return 2;
+  }
+
+  const std::filesystem::path temp_dir =
+      std::filesystem::temp_directory_path() /
+      ("rj_dbt_translate_smoke_" + std::to_string(static_cast<long long>(getpid())));
+  std::filesystem::create_directories(temp_dir);
+
+  const auto input = temp_dir / "smoke_gfx950.co";
+  const auto output = temp_dir / "stdout.txt";
+  const auto error = temp_dir / "stderr.txt";
+
+  {
+    const auto image = make_smoke_code_object();
+    std::ofstream out(input, std::ios::binary);
+    out.write(reinterpret_cast<const char *>(image.data()),
+              static_cast<std::streamsize>(image.size()));
+  }
+
+  const std::string command =
+      shell_quote(argv[1]) + " " + shell_quote(input.string()) +
+      " --input-target gfx950 --output-target gfx1200 --output-mode diff > " +
+      shell_quote(output.string()) + " 2> " + shell_quote(error.string());
+
+  const int status = std::system(command.c_str());
+  const std::string stdout_text = read_text_file(output);
+  const std::string stderr_text = read_text_file(error);
+
+  std::filesystem::remove_all(temp_dir);
+
+  if (!command_succeeded(status)) {
+    std::cerr << "rj_dbt_translate failed\nstderr:\n" << stderr_text << "\nstdout:\n"
+              << stdout_text;
+    return 1;
+  }
+
+  if (!stderr_text.empty()) {
+    std::cerr << "expected empty stderr, got:\n" << stderr_text;
+    return 1;
+  }
+
+  const std::array<std::string_view, 5> expected = {
+      "rj_dbt_translate: ok",
+      "source_words: bf8cc07f",
+      "source: s_waitcnt",
+      "target_words:",
+      "target: s_wait",
+  };
+  for (const std::string_view needle : expected) {
+    if (!contains(stdout_text, needle)) {
+      std::cerr << "missing expected output fragment: " << needle << "\noutput:\n"
+                << stdout_text;
+      return 1;
+    }
+  }
+
+  return 0;
+}

--- a/emulation/rocjitsu/tools/CMakeLists.txt
+++ b/emulation/rocjitsu/tools/CMakeLists.txt
@@ -1,0 +1,42 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+include(rj_configure_target)
+
+set(RJ_TOOL_OBJECT_LIBS
+    rocjitsu_analysis
+    rocjitsu_code
+    rocjitsu_isa
+    rocjitsu_isa_cdna1
+    rocjitsu_isa_cdna2
+    rocjitsu_isa_cdna3
+    rocjitsu_isa_cdna4
+    rocjitsu_isa_rdna1
+    rocjitsu_isa_rdna2
+    rocjitsu_isa_rdna3
+    rocjitsu_isa_rdna3_5
+    rocjitsu_isa_rdna4
+    # The DBT tool only needs generated AMDGPU decoders/disassemblers, but
+    # those object files currently also contain instruction execute methods.
+    # Until generated ISA decode/disassembly is split from VM execution, the
+    # linker needs the AMDGPU VM support referenced by those execute methods.
+    simdojo
+    rocjitsu_vm_amdgpu
+)
+
+add_library(rocjitsu_tooling STATIC
+    dbt_translate.cpp
+)
+target_include_directories(rocjitsu_tooling PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(rocjitsu_tooling PUBLIC ${CMAKE_SOURCE_DIR})
+target_link_libraries(rocjitsu_tooling PUBLIC
+    ${RJ_TOOL_OBJECT_LIBS}
+    util
+    flatbuffers
+    Threads::Threads
+)
+rj_configure_target(rocjitsu_tooling TOOL)
+
+add_executable(rj_dbt_translate dbt_translate_main.cpp)
+target_link_libraries(rj_dbt_translate PRIVATE rocjitsu_tooling)
+rj_configure_target(rj_dbt_translate TOOL)

--- a/emulation/rocjitsu/tools/dbt_translate.cpp
+++ b/emulation/rocjitsu/tools/dbt_translate.cpp
@@ -1,0 +1,386 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "tools/dbt_translate.h"
+
+#include "rocjitsu/code/amdgpu_code_object.h"
+#include "rocjitsu/code/amdgpu_elf.h"
+#include "rocjitsu/code/dbt/binary_translator.h"
+#include "rocjitsu/code/executable.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+
+#include <exception>
+#include <iomanip>
+#include <memory>
+#include <span>
+#include <sstream>
+#include <utility>
+
+namespace rocjitsu::tools {
+
+namespace {
+
+constexpr int kInputError = 2;
+constexpr int kTranslationError = 3;
+constexpr int kValidationError = 5;
+
+void add_error(ToolResult<TranslateOutput> &result, int exit_code, std::string message) {
+  result.errors.push_back({exit_code, std::move(message)});
+}
+
+struct CodeObjectInspection {
+  CodeObjectReport report;
+  std::string disassembly;
+};
+
+void record_decode_failure(CodeSectionReport &section_report, size_t byte_offset,
+                           std::string message) {
+  ++section_report.decode_failure_count;
+  if (!section_report.has_first_decode_failure) {
+    section_report.has_first_decode_failure = true;
+    section_report.first_decode_failure_offset = byte_offset;
+    section_report.first_decode_failure_message = std::move(message);
+  }
+}
+
+[[nodiscard]] CodeObjectInspection inspect_code_object(const AmdGpuCodeObject &obj,
+                                                       rj_code_arch_t arch,
+                                                       const std::string &label,
+                                                       bool include_disassembly) {
+  CodeObjectInspection inspection;
+  inspection.report.available = true;
+
+  std::ostringstream os;
+  if (include_disassembly)
+    os << "--- " << label << " ---\n";
+
+  auto decoder = Decoder::create(arch);
+  inspection.report.decoder_available = decoder != nullptr;
+  if (!decoder) {
+    if (include_disassembly)
+      os << "decoder unavailable\n";
+    for (const auto *section : obj.code_sections()) {
+      CodeSectionReport section_report;
+      section_report.name = section->name();
+      section_report.size_bytes = section->size();
+      inspection.report.sections.push_back(std::move(section_report));
+    }
+    inspection.disassembly = os.str();
+    return inspection;
+  }
+
+  for (const auto *section : obj.code_sections()) {
+    CodeSectionReport section_report;
+    section_report.name = section->name();
+    section_report.size_bytes = section->size();
+
+    if (include_disassembly)
+      os << "section " << section->name() << " size=" << section->size() << "\n";
+
+    const auto *words = reinterpret_cast<const uint32_t *>(section->data());
+    const size_t word_count = section->size() / sizeof(uint32_t);
+    size_t pc = 0;
+
+    while (pc < word_count) {
+      try {
+        std::unique_ptr<Instruction> inst(decoder->decode(&words[pc]));
+        if (!inst) {
+          record_decode_failure(section_report, pc * sizeof(uint32_t),
+                                "decode returned null");
+          if (include_disassembly) {
+            os << "  0x" << std::hex << std::setw(4) << std::setfill('0') << pc * 4
+               << ": <decode returned null>\n"
+               << std::dec << std::setfill(' ');
+          }
+          ++pc;
+          continue;
+        }
+
+        const uint32_t inst_words = inst->size() / sizeof(uint32_t);
+        ++section_report.instruction_count;
+        if (include_disassembly) {
+          os << "  0x" << std::hex << std::setw(4) << std::setfill('0') << pc * 4 << ": "
+             << std::dec << std::setfill(' ') << inst->disassemble() << " [";
+          for (uint32_t i = 0; i < inst_words && pc + i < word_count; ++i) {
+            if (i != 0)
+              os << ' ';
+            os << std::hex << std::setw(8) << std::setfill('0') << words[pc + i];
+          }
+          os << std::dec << std::setfill(' ') << "]\n";
+        }
+        pc += inst_words == 0 ? 1 : inst_words;
+      } catch (const std::exception &e) {
+        record_decode_failure(section_report, pc * sizeof(uint32_t), e.what());
+        if (include_disassembly) {
+          os << "  0x" << std::hex << std::setw(4) << std::setfill('0') << pc * 4
+             << ": <decode error: " << e.what() << ">\n"
+             << std::dec << std::setfill(' ');
+        }
+        ++pc;
+      }
+    }
+
+    inspection.report.sections.push_back(std::move(section_report));
+  }
+
+  inspection.disassembly = os.str();
+  return inspection;
+}
+
+[[nodiscard]] std::string format_offset(size_t offset) {
+  std::ostringstream os;
+  os << "0x" << std::hex << offset;
+  return os.str();
+}
+
+[[nodiscard]] bool validate_host_decode(const CodeObjectReport &report, std::string &error) {
+  if (!report.available) {
+    error = "translated output was not inspected";
+    return false;
+  }
+  if (!report.decoder_available) {
+    error = "host decoder unavailable";
+    return false;
+  }
+
+  size_t inst_count = 0;
+  size_t failures = 0;
+  const CodeSectionReport *first_failed_section = nullptr;
+  for (const auto &section : report.sections) {
+    inst_count += section.instruction_count;
+    failures += section.decode_failure_count;
+    if (first_failed_section == nullptr && section.has_first_decode_failure)
+      first_failed_section = &section;
+  }
+
+  if (inst_count == 0) {
+    error = "translated output contains no decodable host instructions";
+    return false;
+  }
+  if (failures != 0) {
+    error = std::to_string(failures) + " translated instructions failed host decode";
+    if (first_failed_section != nullptr) {
+      error += " (first failure in " + first_failed_section->name + " at " +
+               format_offset(first_failed_section->first_decode_failure_offset) + ": " +
+               first_failed_section->first_decode_failure_message + ")";
+    }
+    return false;
+  }
+
+  return true;
+}
+
+[[nodiscard]] std::string disassemble_source_instruction(const AmdGpuCodeObject &obj,
+                                                         uint64_t offset,
+                                                         rj_code_arch_t arch) {
+  auto decoder = Decoder::create(arch);
+  if (!decoder)
+    return "<decoder unavailable>";
+
+  const auto &text_sections = obj.text_sections();
+  if (text_sections.empty())
+    return "<source section unavailable>";
+
+  // BinaryTranslator trace offsets are relative to the original .text section.
+  // Use text_sections() instead of code_sections() so the DBT cave never shifts
+  // source locations when a translated object is inspected again.
+  const auto *text = text_sections.front();
+  if (offset % sizeof(uint32_t) != 0)
+    return "<source offset unaligned>";
+  if (offset + sizeof(uint32_t) > text->size())
+    return "<source offset out of range>";
+
+  const auto *words = reinterpret_cast<const uint32_t *>(text->data());
+  try {
+    std::unique_ptr<Instruction> inst(decoder->decode(&words[offset / sizeof(uint32_t)]));
+    if (!inst)
+      return "<decode returned null>";
+    return inst->disassemble();
+  } catch (const std::exception &e) {
+    return std::string("<decode error: ") + e.what() + ">";
+  }
+}
+
+[[nodiscard]] std::vector<std::string> disassemble_words(std::span<const uint32_t> words,
+                                                         rj_code_arch_t arch) {
+  std::vector<std::string> lines;
+  auto decoder = Decoder::create(arch);
+  if (!decoder) {
+    lines.push_back("<decoder unavailable>");
+    return lines;
+  }
+
+  size_t pc = 0;
+  while (pc < words.size()) {
+    try {
+      std::unique_ptr<Instruction> inst(decoder->decode(&words[pc]));
+      if (!inst) {
+        lines.push_back("<decode returned null>");
+        ++pc;
+        continue;
+      }
+
+      lines.push_back(inst->disassemble());
+      const uint32_t inst_words = inst->size() / sizeof(uint32_t);
+      pc += inst_words == 0 ? 1 : inst_words;
+    } catch (const std::exception &e) {
+      lines.push_back(std::string("<decode error: ") + e.what() + ">");
+      ++pc;
+    }
+  }
+
+  return lines;
+}
+
+[[nodiscard]] InstructionTranslationReport
+build_instruction_report(const TranslationTraceEvent &trace, const AmdGpuCodeObject &source,
+                         rj_code_arch_t guest_arch, rj_code_arch_t host_arch) {
+  InstructionTranslationReport report;
+  report.source_offset = trace.source_offset;
+  report.source_size = trace.source_size;
+  report.source_words.assign(trace.source_words.begin(), trace.source_words.end());
+  report.source_instruction =
+      disassemble_source_instruction(source, trace.source_offset, guest_arch);
+  report.has_legalization = trace.legalization != nullptr;
+  report.action = trace.legalization ? trace.legalization->action : Action::Identity;
+  report.copied_original = trace.copied_original;
+  report.semantic_lowering = trace.semantic_lowering;
+  report.changed = trace.changed;
+  report.emitted_in_cave = trace.emitted_in_cave;
+  report.target_offset = trace.target_offset;
+  report.target_words.assign(trace.target_words.begin(), trace.target_words.end());
+  report.target_instructions = disassemble_words(report.target_words, host_arch);
+  return report;
+}
+
+struct SelectedInput {
+  std::unique_ptr<Executable> executable;
+  std::unique_ptr<AmdGpuCodeObject> direct_code_object;
+  const AmdGpuCodeObject *code_object = nullptr;
+};
+
+[[nodiscard]] SelectedInput select_input(const TranslateOptions &options, std::string &error) {
+  SelectedInput selected;
+
+  selected.executable = std::make_unique<Executable>(options.input_path);
+  if (selected.executable->is_valid()) {
+    if (options.input_target == ROCJITSU_CODE_TARGET_INVALID) {
+      error = "input target is not selectable from executable inputs: " + options.input_path;
+      selected.executable.reset();
+      return selected;
+    }
+
+    selected.code_object =
+        selected.executable->code_object(options.input_target, options.code_object_index);
+    if (selected.code_object != nullptr)
+      return selected;
+
+    error = "failed to select requested code object from executable: " + options.input_path;
+    selected.executable.reset();
+    return selected;
+  }
+
+  // Try executable inputs first, then standalone AMDGPU code-object ELFs. This
+  // keeps the CLI convenient for both HIP objects and already-extracted DBT
+  // outputs without exposing a mode flag.
+  selected.executable.reset();
+  selected.direct_code_object = std::make_unique<AmdGpuCodeObject>(options.input_path);
+  if (!selected.direct_code_object->is_valid()) {
+    error = "failed to parse input as an AMDGPU code object: " + options.input_path;
+    selected.direct_code_object.reset();
+    return selected;
+  }
+
+  selected.code_object = selected.direct_code_object.get();
+  return selected;
+}
+
+} // namespace
+
+ToolResult<TranslateOutput> translate_code_object(const TranslateOptions &options) {
+  ToolResult<TranslateOutput> output;
+  output.value.host_arch = options.host_arch;
+  output.value.target_mach =
+      options.target_mach ? options.target_mach : elf_mach_for_arch(options.host_arch);
+
+  if (options.input_path.empty()) {
+    add_error(output, kInputError, "input path is required");
+    return output;
+  }
+
+  std::string error;
+  SelectedInput input = select_input(options, error);
+  if (input.code_object == nullptr) {
+    add_error(output, kInputError, error.empty() ? "failed to load input" : error);
+    return output;
+  }
+
+  const bool need_report = options.collect_diagnostics;
+  const bool need_source_disassembly = options.disassembly == DisassemblyMode::Source ||
+                                       options.disassembly == DisassemblyMode::Both;
+  const bool need_translated_disassembly = options.disassembly == DisassemblyMode::Translated ||
+                                           options.disassembly == DisassemblyMode::Both;
+
+  if (need_report || need_source_disassembly) {
+    auto source_inspection =
+        inspect_code_object(*input.code_object, options.guest_arch, "source",
+                            need_source_disassembly);
+    output.value.source_report = std::move(source_inspection.report);
+    output.value.disassembly += source_inspection.disassembly;
+  }
+
+  try {
+    BinaryTranslator translator(options.guest_arch, options.host_arch, options.target_mach);
+    if (need_report) {
+      output.value.instruction_translations.clear();
+      translator.set_trace_callback([&](const TranslationTraceEvent &trace) {
+        output.value.instruction_translations.push_back(
+            build_instruction_report(trace, *input.code_object, options.guest_arch,
+                                     options.host_arch));
+      });
+    }
+    auto translated = translator.translate(*input.code_object);
+    output.value.elf_bytes = std::move(translated.elf_bytes);
+    output.value.host_arch = translated.host_arch;
+    output.value.target_mach =
+        options.target_mach ? options.target_mach : elf_mach_for_arch(output.value.host_arch);
+    output.warnings = std::move(translated.warnings);
+  } catch (const std::exception &e) {
+    add_error(output, kTranslationError, std::string("translation threw exception: ") + e.what());
+    return output;
+  }
+
+  if (output.value.elf_bytes.empty()) {
+    add_error(output, kTranslationError, "translation produced an empty ELF image");
+    return output;
+  }
+
+  AmdGpuCodeObject translated_obj(output.value.elf_bytes.data(), output.value.elf_bytes.size());
+  if (!translated_obj.is_valid()) {
+    add_error(output, kTranslationError, "translation produced an invalid AMDGPU code object");
+    return output;
+  }
+
+  {
+    auto translated_inspection =
+        inspect_code_object(translated_obj, options.host_arch, "translated",
+                            need_translated_disassembly);
+    output.value.translated_report = std::move(translated_inspection.report);
+    output.value.disassembly += translated_inspection.disassembly;
+  }
+
+  if (!validate_host_decode(output.value.translated_report, error)) {
+    add_error(output, kValidationError, error);
+    return output;
+  }
+
+  if (!output.warnings.empty()) {
+    add_error(output, kValidationError, "translation produced warnings");
+    return output;
+  }
+
+  return output;
+}
+
+} // namespace rocjitsu::tools

--- a/emulation/rocjitsu/tools/dbt_translate.h
+++ b/emulation/rocjitsu/tools/dbt_translate.h
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file dbt_translate.h
+/// @brief Internal entry point for the rj_dbt_translate CLI and tests.
+
+#ifndef ROCJITSU_TOOLS_DBT_TRANSLATE_H_
+#define ROCJITSU_TOOLS_DBT_TRANSLATE_H_
+
+#include "rocjitsu/code/dbt/generated/legalization_types.h"
+#include "rocjitsu/code/rj_code.h"
+#include "tools/tool_result.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace rocjitsu::tools {
+
+enum class DisassemblyMode {
+  None,
+  Source,
+  Translated,
+  Both,
+};
+
+struct CodeSectionReport {
+  std::string name;
+  size_t size_bytes = 0;
+  size_t instruction_count = 0;
+  size_t decode_failure_count = 0;
+
+  // Store the first failing offset so the text report points developers at a
+  // concrete location without retaining every failed decode in memory.
+  bool has_first_decode_failure = false;
+  size_t first_decode_failure_offset = 0;
+  std::string first_decode_failure_message;
+};
+
+struct CodeObjectReport {
+  bool available = false;
+  bool decoder_available = false;
+  std::vector<CodeSectionReport> sections;
+};
+
+struct InstructionTranslationReport {
+  uint64_t source_offset = 0;
+  uint32_t source_size = 0;
+  std::vector<uint32_t> source_words;
+  std::string source_instruction;
+  bool has_legalization = false;
+  Action action = Action::Identity;
+  bool copied_original = false;
+  bool semantic_lowering = false;
+  bool changed = false;
+  bool emitted_in_cave = false;
+  uint64_t target_offset = 0;
+  std::vector<uint32_t> target_words;
+  std::vector<std::string> target_instructions;
+};
+
+struct TranslateOptions {
+  std::string input_path;
+
+  rj_code_target_id_t input_target = ROCJITSU_CODE_TARGET_GFX950;
+  uint32_t code_object_index = 0;
+
+  rj_code_arch_t guest_arch = ROCJITSU_CODE_ARCH_CDNA4;
+  rj_code_arch_t host_arch = ROCJITSU_CODE_ARCH_RDNA4;
+  uint32_t target_mach = 0;
+
+  bool collect_diagnostics = false;
+  DisassemblyMode disassembly = DisassemblyMode::None;
+};
+
+struct TranslateOutput {
+  std::vector<uint8_t> elf_bytes;
+  rj_code_arch_t host_arch = ROCJITSU_CODE_ARCH_INVALID;
+  uint32_t target_mach = 0;
+  CodeObjectReport source_report;
+  CodeObjectReport translated_report;
+  std::vector<InstructionTranslationReport> instruction_translations;
+  std::string disassembly;
+};
+
+/// @brief Translate one AMDGPU code object using the DBT pipeline.
+///
+/// This is an internal repo-facing API. It is deliberately small and mirrors the
+/// CLI behavior so tests can avoid process management when they need direct
+/// access to translated bytes or structured diagnostics.
+[[nodiscard]] ToolResult<TranslateOutput> translate_code_object(const TranslateOptions &options);
+
+} // namespace rocjitsu::tools
+
+#endif // ROCJITSU_TOOLS_DBT_TRANSLATE_H_

--- a/emulation/rocjitsu/tools/dbt_translate_main.cpp
+++ b/emulation/rocjitsu/tools/dbt_translate_main.cpp
@@ -1,0 +1,506 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "tools/dbt_translate.h"
+
+#include "rocjitsu/code/amdgpu_code_object.h"
+#include "rocjitsu/code/amdgpu_elf.h"
+#include "rocjitsu/code/executable.h"
+
+#include <charconv>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <string_view>
+
+using namespace rocjitsu;
+using namespace rocjitsu::tools;
+
+namespace {
+
+constexpr int kUsageError = 1;
+constexpr int kOutputError = 4;
+
+enum class OutputMode {
+  Disasm,
+  CodeObject,
+  Diff,
+};
+
+struct TargetInfo {
+  std::string_view name;
+  rj_code_arch_t arch;
+  uint32_t mach;
+  rj_code_target_id_t code_object_target;
+};
+
+struct CliOptions {
+  TranslateOptions translate;
+  std::string input_target_name;
+  std::string output_target_name;
+  OutputMode output_mode = OutputMode::Disasm;
+  bool list_code_objects = false;
+  bool show_help = false;
+  bool saw_input = false;
+  bool saw_input_target = false;
+  bool saw_output_target = false;
+};
+
+void print_help() {
+  std::cout
+      << "Usage: rj_dbt_translate INPUT --input-target TARGET --output-target TARGET "
+         "[options]\n\n"
+      << "Options:\n"
+      << "  --input-target TARGET           Input LLVM machine, e.g. gfx950\n"
+      << "  --output-target TARGET          Output LLVM machine, e.g. gfx1200\n"
+      << "  --code-object-index N           Code-object index for executable input (default: 0)\n"
+      << "  --output-mode MODE              disasm, code-object, or diff (default: disasm)\n"
+      << "  --list-code-objects             List extractable code objects and exit\n"
+      << "  --help                          Show this help\n\n"
+      << "Supported target names: gfx908, gfx90a, gfx940, gfx941, gfx942, gfx950, "
+         "gfx1010, gfx1030, gfx1100, gfx1150, gfx1200, gfx1201.\n";
+}
+
+[[nodiscard]] bool parse_u32(std::string_view text, uint32_t &value) {
+  int base = 10;
+  if (text.size() > 2 && text[0] == '0' && (text[1] == 'x' || text[1] == 'X')) {
+    text.remove_prefix(2);
+    base = 16;
+  }
+  auto *begin = text.data();
+  auto *end = text.data() + text.size();
+  auto [ptr, ec] = std::from_chars(begin, end, value, base);
+  return ec == std::errc{} && ptr == end;
+}
+
+[[nodiscard]] std::optional<TargetInfo> parse_target_info(std::string_view value) {
+  if (value == "gfx908")
+    return TargetInfo{value, ROCJITSU_CODE_ARCH_CDNA1, EF_AMDGPU_MACH_AMDGCN_GFX908,
+                      ROCJITSU_CODE_TARGET_INVALID};
+  if (value == "gfx90a")
+    return TargetInfo{value, ROCJITSU_CODE_ARCH_CDNA2, EF_AMDGPU_MACH_AMDGCN_GFX90A,
+                      ROCJITSU_CODE_TARGET_INVALID};
+  if (value == "gfx940")
+    return TargetInfo{value, ROCJITSU_CODE_ARCH_CDNA3, EF_AMDGPU_MACH_AMDGCN_GFX940,
+                      ROCJITSU_CODE_TARGET_INVALID};
+  if (value == "gfx941")
+    return TargetInfo{value, ROCJITSU_CODE_ARCH_CDNA3, EF_AMDGPU_MACH_AMDGCN_GFX941,
+                      ROCJITSU_CODE_TARGET_INVALID};
+  if (value == "gfx942")
+    return TargetInfo{value, ROCJITSU_CODE_ARCH_CDNA3, EF_AMDGPU_MACH_AMDGCN_GFX942,
+                      ROCJITSU_CODE_TARGET_GFX942};
+  if (value == "gfx950")
+    return TargetInfo{value, ROCJITSU_CODE_ARCH_CDNA4, EF_AMDGPU_MACH_AMDGCN_GFX950,
+                      ROCJITSU_CODE_TARGET_GFX950};
+  if (value == "gfx1010")
+    return TargetInfo{value, ROCJITSU_CODE_ARCH_RDNA1, EF_AMDGPU_MACH_AMDGCN_GFX1010,
+                      ROCJITSU_CODE_TARGET_INVALID};
+  if (value == "gfx1030")
+    return TargetInfo{value, ROCJITSU_CODE_ARCH_RDNA2, EF_AMDGPU_MACH_AMDGCN_GFX1030,
+                      ROCJITSU_CODE_TARGET_INVALID};
+  if (value == "gfx1100")
+    return TargetInfo{value, ROCJITSU_CODE_ARCH_RDNA3, EF_AMDGPU_MACH_AMDGCN_GFX1100,
+                      ROCJITSU_CODE_TARGET_INVALID};
+  if (value == "gfx1150")
+    return TargetInfo{value, ROCJITSU_CODE_ARCH_RDNA3_5, EF_AMDGPU_MACH_AMDGCN_GFX1150,
+                      ROCJITSU_CODE_TARGET_INVALID};
+  if (value == "gfx1200")
+    return TargetInfo{value, ROCJITSU_CODE_ARCH_RDNA4, EF_AMDGPU_MACH_AMDGCN_GFX1200,
+                      ROCJITSU_CODE_TARGET_INVALID};
+  if (value == "gfx1201")
+    return TargetInfo{value, ROCJITSU_CODE_ARCH_RDNA4, EF_AMDGPU_MACH_AMDGCN_GFX1201,
+                      ROCJITSU_CODE_TARGET_INVALID};
+  return std::nullopt;
+}
+
+[[nodiscard]] std::optional<OutputMode> parse_output_mode(std::string_view value) {
+  if (value == "disasm")
+    return OutputMode::Disasm;
+  if (value == "code-object")
+    return OutputMode::CodeObject;
+  if (value == "diff")
+    return OutputMode::Diff;
+  return std::nullopt;
+}
+
+[[nodiscard]] bool require_value(int argc, char **argv, int &index, std::string_view flag,
+                                 std::string_view &value) {
+  if (index + 1 >= argc) {
+    std::cerr << "missing value for " << flag << "\n";
+    return false;
+  }
+  ++index;
+  value = argv[index];
+  return true;
+}
+
+[[nodiscard]] bool parse_args(int argc, char **argv, CliOptions &options) {
+  for (int i = 1; i < argc; ++i) {
+    std::string_view arg = argv[i];
+    std::string_view value;
+
+    if (arg == "--help" || arg == "-h") {
+      options.show_help = true;
+      return true;
+    }
+    if (arg == "--list-code-objects") {
+      options.list_code_objects = true;
+      continue;
+    }
+
+    if (arg == "--input-target") {
+      if (!require_value(argc, argv, i, arg, value))
+        return false;
+      auto target = parse_target_info(value);
+      if (!target) {
+        std::cerr << "invalid input target: " << value << "\n";
+        return false;
+      }
+      options.translate.guest_arch = target->arch;
+      options.translate.input_target = target->code_object_target;
+      options.input_target_name = std::string(target->name);
+      options.saw_input_target = true;
+    } else if (arg == "--output-target") {
+      if (!require_value(argc, argv, i, arg, value))
+        return false;
+      auto target = parse_target_info(value);
+      if (!target) {
+        std::cerr << "invalid output target: " << value << "\n";
+        return false;
+      }
+      options.translate.host_arch = target->arch;
+      options.translate.target_mach = target->mach;
+      options.output_target_name = std::string(target->name);
+      options.saw_output_target = true;
+    } else if (arg == "--code-object-index") {
+      if (!require_value(argc, argv, i, arg, value))
+        return false;
+      if (!parse_u32(value, options.translate.code_object_index)) {
+        std::cerr << "invalid code-object index: " << value << "\n";
+        return false;
+      }
+    } else if (arg == "--output-mode") {
+      if (!require_value(argc, argv, i, arg, value))
+        return false;
+      auto mode = parse_output_mode(value);
+      if (!mode) {
+        std::cerr << "invalid output mode: " << value << "\n";
+        return false;
+      }
+      options.output_mode = *mode;
+    } else {
+      if (!arg.empty() && arg.front() != '-') {
+        if (options.saw_input) {
+          std::cerr << "unexpected positional argument: " << arg << "\n";
+          return false;
+        }
+        options.translate.input_path = std::string(arg);
+        options.saw_input = true;
+        continue;
+      }
+      std::cerr << "unknown option: " << arg << "\n";
+      return false;
+    }
+  }
+
+  return true;
+}
+
+struct ReportTotals {
+  size_t size_bytes = 0;
+  size_t instruction_count = 0;
+  size_t decode_failure_count = 0;
+};
+
+[[nodiscard]] ReportTotals report_totals(const CodeObjectReport &report) {
+  ReportTotals totals;
+  for (const auto &section : report.sections) {
+    totals.size_bytes += section.size_bytes;
+    totals.instruction_count += section.instruction_count;
+    totals.decode_failure_count += section.decode_failure_count;
+  }
+  return totals;
+}
+
+[[nodiscard]] size_t text_section_size(const CodeObjectReport &report) {
+  for (const auto &section : report.sections) {
+    if (section.name == ".text")
+      return section.size_bytes;
+  }
+  return 0;
+}
+
+[[nodiscard]] std::string hex_offset(uint64_t value) {
+  std::ostringstream os;
+  os << "0x" << std::hex << std::setw(4) << std::setfill('0') << value;
+  return os.str();
+}
+
+[[nodiscard]] std::string words_text(const std::vector<uint32_t> &words) {
+  std::ostringstream os;
+  for (size_t i = 0; i < words.size(); ++i) {
+    if (i != 0)
+      os << ' ';
+    os << std::hex << std::setw(8) << std::setfill('0') << words[i];
+  }
+  return os.str();
+}
+
+[[nodiscard]] const char *legalization_action_name(Action action) {
+  switch (action) {
+  case Action::Identity:
+    return "identity";
+  case Action::Substitute:
+    return "substitute";
+  case Action::Lower:
+    return "lower";
+  case Action::Expand:
+    return "expand";
+  case Action::Illegal:
+    return "illegal";
+  }
+  return "unknown";
+}
+
+[[nodiscard]] std::string
+translation_action_text(const InstructionTranslationReport &translation) {
+  if (translation.copied_original)
+    return "copy_original";
+  if (!translation.has_legalization)
+    return "encode";
+
+  std::string text = legalization_action_name(translation.action);
+  if (translation.semantic_lowering)
+    text += " semantic";
+  return text;
+}
+
+[[nodiscard]] bool should_show_translation(const InstructionTranslationReport &translation) {
+  if (translation.copied_original ||
+      (translation.has_legalization && translation.action == Action::Identity))
+    return translation.changed || translation.emitted_in_cave;
+  return true;
+}
+
+[[nodiscard]] size_t count_action(const std::vector<InstructionTranslationReport> &translations,
+                                  Action action) {
+  size_t count = 0;
+  for (const auto &translation : translations) {
+    if (!translation.copied_original && translation.has_legalization &&
+        translation.action == action)
+      ++count;
+  }
+  return count;
+}
+
+[[nodiscard]] size_t
+count_runtime_encode(const std::vector<InstructionTranslationReport> &translations) {
+  size_t count = 0;
+  for (const auto &translation : translations) {
+    if (!translation.copied_original && !translation.has_legalization)
+      ++count;
+  }
+  return count;
+}
+
+[[nodiscard]] size_t count_copied_original(
+    const std::vector<InstructionTranslationReport> &translations) {
+  size_t count = 0;
+  for (const auto &translation : translations) {
+    if (translation.copied_original)
+      ++count;
+  }
+  return count;
+}
+
+[[nodiscard]] size_t count_semantic_lowerings(
+    const std::vector<InstructionTranslationReport> &translations) {
+  size_t count = 0;
+  for (const auto &translation : translations) {
+    if (translation.semantic_lowering)
+      ++count;
+  }
+  return count;
+}
+
+[[nodiscard]] std::string target_location(const InstructionTranslationReport &translation,
+                                          size_t text_size) {
+  if (translation.emitted_in_cave && translation.target_offset >= text_size)
+    return ".rj_translations+" + hex_offset(translation.target_offset - text_size);
+  return ".text+" + hex_offset(translation.target_offset);
+}
+
+void print_code_object_report(std::ostream &os, std::string_view label,
+                              const CodeObjectReport &report) {
+  os << "\n" << label << ":\n";
+  if (!report.available) {
+    os << "  unavailable\n";
+    return;
+  }
+
+  const ReportTotals totals = report_totals(report);
+  os << "  decoder: " << (report.decoder_available ? "available" : "unavailable") << "\n";
+  os << "  sections: " << report.sections.size() << " bytes=" << totals.size_bytes
+     << " instructions=" << totals.instruction_count
+     << " decode_failures=" << totals.decode_failure_count << "\n";
+
+  for (const auto &section : report.sections) {
+    os << "  section " << section.name << " bytes=" << section.size_bytes
+       << " instructions=" << section.instruction_count
+       << " decode_failures=" << section.decode_failure_count;
+    if (section.has_first_decode_failure) {
+      os << " first_failure=0x" << std::hex << section.first_decode_failure_offset << std::dec
+         << " reason=" << section.first_decode_failure_message;
+    }
+    os << "\n";
+  }
+}
+
+void print_instruction_translation_report(std::ostream &os, const TranslateOutput &output) {
+  const auto &translations = output.instruction_translations;
+  size_t shown = 0;
+  size_t changed = 0;
+  for (const auto &translation : translations) {
+    if (translation.changed)
+      ++changed;
+    if (should_show_translation(translation))
+      ++shown;
+  }
+
+  os << "\ninstruction_translations:\n";
+  os << "  total=" << translations.size() << " changed=" << changed << " shown=" << shown
+     << "\n";
+  os << "  actions:"
+     << " copy_original=" << count_copied_original(translations)
+     << " encode=" << count_runtime_encode(translations)
+     << " identity=" << count_action(translations, Action::Identity)
+     << " substitute=" << count_action(translations, Action::Substitute)
+     << " lower=" << count_action(translations, Action::Lower)
+     << " expand=" << count_action(translations, Action::Expand)
+     << " illegal=" << count_action(translations, Action::Illegal)
+     << " semantic=" << count_semantic_lowerings(translations) << "\n";
+
+  const size_t text_size = text_section_size(output.source_report);
+  for (const auto &translation : translations) {
+    if (!should_show_translation(translation))
+      continue;
+
+    os << "  " << hex_offset(translation.source_offset) << " "
+       << translation_action_text(translation) << " .text+"
+       << hex_offset(translation.source_offset) << " -> "
+       << target_location(translation, text_size) << "\n";
+    if (!translation.source_words.empty())
+      os << "    source_words: " << words_text(translation.source_words) << "\n";
+    os << "    source: " << translation.source_instruction << "\n";
+    if (!translation.target_words.empty())
+      os << "    target_words: " << words_text(translation.target_words) << "\n";
+    for (const auto &target_instruction : translation.target_instructions)
+      os << "    target: " << target_instruction << "\n";
+  }
+}
+
+void print_text_report(std::ostream &os, const CliOptions &options,
+                       const ToolResult<TranslateOutput> &result) {
+  const TranslateOutput &output = result.value;
+
+  os << "rj_dbt_translate: " << (result.ok() ? "ok" : "failed") << "\n";
+  os << "input: " << options.translate.input_path << "\n";
+  os << "input_target: " << options.input_target_name << "\n";
+  os << "output_target: " << options.output_target_name << "\n";
+  os << "output_elf_bytes: " << output.elf_bytes.size() << "\n";
+
+  print_code_object_report(os, "source", output.source_report);
+  print_code_object_report(os, "translated", output.translated_report);
+  print_instruction_translation_report(os, output);
+
+  os << "\nwarnings: " << result.warnings.size() << "\n";
+  os << "errors: " << result.errors.size() << "\n";
+}
+
+int list_code_objects(const CliOptions &options) {
+  if (options.translate.input_path.empty()) {
+    std::cerr << "input path is required with --list-code-objects\n";
+    return kUsageError;
+  }
+
+  Executable executable(options.translate.input_path);
+  if (executable.is_valid()) {
+    std::cout << "gfx942: " << executable.num_code_objects(ROCJITSU_CODE_TARGET_GFX942) << "\n";
+    std::cout << "gfx950: " << executable.num_code_objects(ROCJITSU_CODE_TARGET_GFX950) << "\n";
+    return 0;
+  }
+
+  AmdGpuCodeObject code_object(options.translate.input_path);
+  if (!code_object.is_valid()) {
+    std::cerr << "failed to parse input as executable or AMDGPU code object\n";
+    return 2;
+  }
+
+  std::cout << "standalone-code-object: target-id=" << static_cast<int>(code_object.target_id())
+            << "\n";
+  return 0;
+}
+
+[[nodiscard]] bool emit_output(const CliOptions &options, const TranslateOutput &output) {
+  if (options.output_mode == OutputMode::CodeObject) {
+    std::cout.write(reinterpret_cast<const char *>(output.elf_bytes.data()),
+                    static_cast<std::streamsize>(output.elf_bytes.size()));
+    return static_cast<bool>(std::cout);
+  }
+
+  std::cout << output.disassembly;
+  return static_cast<bool>(std::cout);
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+  CliOptions options;
+  if (!parse_args(argc, argv, options)) {
+    print_help();
+    return kUsageError;
+  }
+
+  if (options.show_help) {
+    print_help();
+    return 0;
+  }
+
+  if (options.list_code_objects)
+    return list_code_objects(options);
+
+  if (!options.saw_input || !options.saw_input_target || !options.saw_output_target) {
+    std::cerr << "input path, --input-target, and --output-target are required\n";
+    print_help();
+    return kUsageError;
+  }
+
+  options.translate.collect_diagnostics = options.output_mode == OutputMode::Diff;
+  options.translate.disassembly =
+      options.output_mode == OutputMode::Disasm ? DisassemblyMode::Translated
+                                                : DisassemblyMode::None;
+
+  auto result = translate_code_object(options.translate);
+
+  for (const auto &warning : result.warnings)
+    std::cerr << "warning: " << warning << "\n";
+
+  if (options.output_mode == OutputMode::Diff)
+    print_text_report(std::cout, options, result);
+
+  if (!result.ok()) {
+    for (const auto &error : result.errors)
+      std::cerr << "error: " << error.message << "\n";
+    return result.errors.front().exit_code;
+  }
+
+  if (options.output_mode != OutputMode::Diff && !emit_output(options, result.value)) {
+    std::cerr << "error: failed to write output\n";
+    return kOutputError;
+  }
+
+  return 0;
+}

--- a/emulation/rocjitsu/tools/tool_result.h
+++ b/emulation/rocjitsu/tools/tool_result.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file tool_result.h
+/// @brief Small result type shared by internal rocjitsu tool entry points.
+
+#ifndef ROCJITSU_TOOLS_TOOL_RESULT_H_
+#define ROCJITSU_TOOLS_TOOL_RESULT_H_
+
+#include <string>
+#include <vector>
+
+namespace rocjitsu::tools {
+
+/// @brief Structured error returned by a tool entry point.
+///
+/// The exit code is intentionally stored with the error so CLI wrappers can
+/// return the same code that in-process tests would assert on. This keeps tests
+/// from scraping stderr just to decide what failed.
+struct ToolError {
+  int exit_code = 1;
+  std::string message;
+};
+
+/// @brief Value-or-errors result for tool functions.
+template <typename T> struct ToolResult {
+  T value;
+  std::vector<ToolError> errors;
+  std::vector<std::string> warnings;
+
+  [[nodiscard]] bool ok() const { return errors.empty(); }
+};
+
+} // namespace rocjitsu::tools
+
+#endif // ROCJITSU_TOOLS_TOOL_RESULT_H_


### PR DESCRIPTION
Adds a new tool rj_dbt_translate for debugging DBT translations. The tool allows converting a code object from one target to another target using DBT. The main debugging feature is the diff trace. The diff mode traces how each instruction is converted. Example:

```
  0x0040 expand semantic .text+0x0040 -> .rj_translations+0x0018
    source_words: d2080004 04010004
    source: v_lshl_add_u64 v[4:5], s[4:5], 0, v[0:1]
    target_words: d7006a04 00020004 bf88fffd d5206a05 01aa0205
    target: v_add_co_u32 v4, vcc_lo, s4, v0
    target: s_wait_alu 65533
    target: v_add_co_ci_u32 v5, vcc_lo, s5, v1, vcc_lo
  0x0048 expand semantic .text+0x0048 -> .rj_translations+0x0030
    source_words: d2080002 04010006
    source: v_lshl_add_u64 v[2:3], s[6:7], 0, v[0:1]
    target_words: d7006a02 00020006 bf88fffd d5206a03 01aa0207
    target: v_add_co_u32 v2, vcc_lo, s6, v0
    target: s_wait_alu 65533
    target: v_add_co_ci_u32 v3, vcc_lo, s7, v1, vcc_lo
```