### PR TITLE
[RCCL] remove broken bf16 guard from NetIbMPITestBase.hpp

### DIFF
--- a/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
@@ -8,18 +8,6 @@
 #define RCCL_TEST_NET_IB_MPI_TEST_BASE_HPP_
 
 #include <gtest/gtest.h>
-// Pre-seed the bf16 guard macros and pull in the new hip_bf16.h before
-// hip_runtime.h transitively includes the old hip_bfloat16.h. Otherwise
-// device.h's #error guard fires during the device-pass compile (the test
-// include path exposes the hipified librccl device.h via
-// ${PROJECT_BINARY_DIR}/hipify/src/include).
-#if defined(ROCM_VERSION) && ROCM_VERSION >= 60000
-  #if !defined(_HIP_INCLUDE_HIP_AMD_DETAIL_HIP_BFLOAT16_H_) && !defined(_HIP_BFLOAT16_H_)
-    #define _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_BFLOAT16_H_
-    #define _HIP_BFLOAT16_H_
-    #include <hip/hip_bf16.h>
-  #endif
-#endif
 #include <hip/hip_runtime.h>
 #include "MPITestBase.hpp"
 #include "NetIbCastInspect.hpp"


### PR DESCRIPTION
## Problem
`NetIbMPITestBase.hpp` contained a guard block that pre-defined `_HIP_BFLOAT16_H_` as a workaround for a prior include-order issue. This is exactly the macro `device.h` checks on ROCm 6.x to fire its sanity `#error`, so every translation unit that included `NetIbMPITestBase.hpp` broke the `rccl-UnitTestsMPI` CI build.

## Fix
Remove the guard block. The underlying root cause (unconditional `#include <hip/hip_bfloat16.h>` in `CollCommon.h`) was already fixed in ae23fb0e7f, making this workaround both unnecessary and harmful.

## Reproduce
Build with `-DENABLE_MPI_TESTS=ON` on the unfixed code to see `device.h:error: RCCL is not using the correct hip_bf16.h file` from any file that includes `NetIbMPITestBase.hpp`.

## JIRA ID

AICOMRCCL-1070