### PR TITLE
[ROCM-24682] Fix For "sudo amd-smi ras --afid --cper-file file.cper" Not Showing AFIDs For Correctable Errors.

### DIFF
--- a/projects/amdsmi/src/amd_smi/amd_smi_cper.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_cper.cc
@@ -287,8 +287,8 @@ exit:
   if (!body) return -1;
 
   return aca_decode_corrected_error(
-      body->err_ctx.reg_dump, sizeof(body->err_ctx.reg_dump) / sizeof(body->err_ctx.reg_dump[0]),
-      section->flags_mask, section->revision_major, body->err_ctx.reg_ctx_type);
+      body->err_ctx.reg_dump, body->err_ctx.reg_arr_size / sizeof(uint64_t), section->flags_mask,
+      section->revision_major, body->err_ctx.reg_ctx_type);
 }
 
 static int cper_dump_cr_fatal(const struct cper_sec_crashdump* crashdump,


### PR DESCRIPTION
aca_decode_corrected_error received the count of uint32_t elements (32) but decode_afid expects the count of uint64_t elements (4 or 16). This caused decode_error_info to return NULL for all non-standard section types (corrected errors), resulting in empty AFID output.

Use reg_arr_size from the CPER context header (actual size in bytes) divided by sizeof(uint64_t) to pass the correct array length.

Motivation

When running [amd-smi ras --cper --folder <path>](vscode-file://vscode-app/c:/Users/yalmusaf/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html), the "list of afids" column was empty for all NONFATAL-CORRECTED entries while FATAL entries displayed correctly. This prevented users from identifying which AMD Field IDs were associated with corrected RAS errors.

Technical Details

The bug was in [amd_smi_cper.cc](vscode-file://vscode-app/c:/Users/yalmusaf/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html) in [cper_dump_nonstd_err](vscode-file://vscode-app/c:/Users/yalmusaf/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html). The call to aca_decode_corrected_error passed sizeof(body->err_ctx.reg_dump) / sizeof(body->err_ctx.reg_dump[0]) which evaluates to 32 (the count of uint32_t elements in the buffer). However, [decode_afid](vscode-file://vscode-app/c:/Users/yalmusaf/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html) expects the array length in uint64_t units — either 4 ([RAS_DECODE_REGISTER_ARRAY_SIZE_32_BYTES](vscode-file://vscode-app/c:/Users/yalmusaf/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) or 16 ([RAS_DECODE_REGISTER_ARRAY_SIZE_128_BYTES](vscode-file://vscode-app/c:/Users/yalmusaf/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html)). Since 32 matched neither, decode_error_info returned NULL, causing all corrected error AFIDs to be silently dropped.

The fix uses body->err_ctx.reg_arr_size / sizeof(uint64_t) — the actual register array size from the CPER context header (in bytes) converted to uint64_t element count. This is consistent with how aca_decode_fatal computes its array length.

JIRA ID
ROCM-24682

Test Plan

Ran [sudo amd-smi ras --afid --cper-file <file>](vscode-file://vscode-app/c:/Users/yalmusaf/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html) against all 10 CPER files (8 corrected, 2 fatal)
Ran [sudo amd-smi ras --cper --folder /tmp/cper](vscode-file://vscode-app/c:/Users/yalmusaf/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (human-readable table output)
Ran [sudo amd-smi ras --cper --folder /tmp/cper --json](vscode-file://vscode-app/c:/Users/yalmusaf/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (JSON output)
Verified FATAL entries still decode correctly (AFID 30)

Test Result

All corrected CPER files now return AFIDs (29 or 24 depending on error type). Fatal entries continue to return AFID 30. Both table and JSON output modes display AFIDs correctly for all severity levels.

<img width="595" height="346" alt="image" src="https://github.com/user-attachments/assets/ff5b4015-6b11-4227-8bca-6ab2e540e9ac" />

