### PR TITLE
[rocprofiler-compute] Fix gfx1151 roofline AI metrics

### DIFF
--- a/projects/rocprofiler-compute/docs/data/analyze/analysis_data_dump_schema.mmd
+++ b/projects/rocprofiler-compute/docs/data/analyze/analysis_data_dump_schema.mmd
@@ -1,0 +1,104 @@
+%% Source for analysis_data_dump_schema.png. Re-export the PNG via draw.io.
+%% Tables and relationships mirror src/utils/analysis_orm.py.
+
+erDiagram
+    compute_workload {
+        int workload_id PK
+        string name
+        string sub_name
+        json sys_info_extdata
+        json roofline_bench_extdata
+        json profiling_config_extdata
+    }
+
+    compute_metric_definition {
+        int metric_uuid PK
+        int workload_id FK
+        string name
+        string metric_id
+        text description
+        string table_name
+        string sub_table_name
+        string unit
+    }
+
+    compute_kernel {
+        int kernel_uuid PK
+        int workload_id FK
+        string kernel_name
+    }
+
+    compute_dispatch {
+        int dispatch_uuid PK
+        int kernel_uuid FK
+        int dispatch_id
+        int gpu_id
+        int start_timestamp
+        int end_timestamp
+    }
+
+    compute_pcsampling {
+        int pc_sampling_uuid PK
+        int kernel_uuid FK
+        string source
+        string instruction
+        int count
+        int offset
+        int count_issue
+        int count_stall
+        json stall_reason
+    }
+
+    compute_kernel_roofline_data {
+        int roofline_uuid PK
+        int kernel_uuid FK
+        float total_flops
+        float l1_cache_data
+        float l2_cache_data
+        float hbm_cache_data
+    }
+
+    compute_kernel_metric_value {
+        int value_uuid PK
+        int metric_uuid FK
+        int kernel_uuid FK
+        string value_name
+        float value
+    }
+
+    compute_workload_metric_value {
+        int value_uuid PK
+        int metric_uuid FK
+        int workload_id FK
+        string value_name
+        float value
+    }
+
+    compute_workload_roofline_data {
+        int roofline_uuid PK
+        int workload_id FK
+        float total_flops
+        float l1_cache_data
+        float l2_cache_data
+        float hbm_cache_data
+    }
+
+    compute_metadata {
+        int id PK
+        string compute_version
+        string git_version
+        string schema_version
+    }
+
+    compute_workload ||--o{ compute_kernel : workload_id
+    compute_workload ||--o{ compute_metric_definition : workload_id
+    compute_workload ||--o{ compute_workload_metric_value : workload_id
+    compute_workload ||--o{ compute_workload_roofline_data : workload_id
+
+    compute_kernel ||--o{ compute_dispatch : kernel_uuid
+    compute_kernel ||--o{ compute_pcsampling : kernel_uuid
+    compute_kernel ||--o{ compute_kernel_roofline_data : kernel_uuid
+    compute_kernel ||--o{ compute_kernel_metric_value : kernel_uuid
+
+    compute_metric_definition ||--o{ compute_kernel_metric_value : metric_uuid
+    compute_metric_definition ||--o{ compute_workload_metric_value : metric_uuid

--- a/projects/rocprofiler-compute/docs/data/metrics/gfx1151_metrics.yaml
+++ b/projects/rocprofiler-compute/docs/data/metrics/gfx1151_metrics.yaml
@@ -32,7 +32,7 @@ System Speed-of-Light:
   GL0 Cache Hit Rate (TCP Cache):
     rst: 'Percentage of GL0 vector cache (TCP Cache) requests that hit in cache. The TCP cache is the first-level cache for vector memory operations. High hit rates reduce traffic to the GL1 cache and improve memory access latency.'
     unit: Percent
-  GL0 Cache BW:
+  GL0 Cache BW (TCP Cache):
     rst: 'Bandwidth of requests to the GL0 vector cache (TCP Cache). This represents the rate at which the shader cores are requesting data from the cache hierarchy. High bandwidth indicates memory-intensive workloads.'
     unit: Bytes/s
   GL1 Cache Hit Rate:

--- a/projects/rocprofiler-compute/docs/data/metrics/gfx1151_metrics.yaml
+++ b/projects/rocprofiler-compute/docs/data/metrics/gfx1151_metrics.yaml
@@ -15,7 +15,7 @@ System Speed-of-Light:
     rst: 'Percentage of GL2 cache requests that are serviced from cache without accessing system memory. Higher hit rates reduce memory bandwidth pressure and improve performance. Low hit rates may indicate poor data locality or working sets that exceed cache capacity.'
     unit: Percent
   GL2-Fabric Read BW:
-    rst: 'Read bandwidth between the GL2 cache and the memory fabric/system memory. High bandwidth utilization indicates memory-intensive read patterns. This metric helps identify when memory bandwidth is a performance bottleneck.'
+    rst: 'Read bandwidth between the GL2 cache and the memory fabric/system memory. High bandwidth utilization indicates memory-intensive read patterns. This metric helps identify when memory bandwidth is a performance bottleneck. Requires $max_mclk populated in sysinfo (max MEM clock from amd-smi).'
     unit: Bytes/s
   GL2-Fabric Write BW:
     rst: 'Write bandwidth between the GL2 cache and the memory fabric/system memory. High values indicate write-intensive workloads. Combined with read bandwidth, this shows total memory traffic leaving the GPU caches.'
@@ -32,7 +32,7 @@ System Speed-of-Light:
   GL0 Cache Hit Rate (TCP Cache):
     rst: 'Percentage of GL0 vector cache (TCP Cache) requests that hit in cache. The TCP cache is the first-level cache for vector memory operations. High hit rates reduce traffic to the GL1 cache and improve memory access latency.'
     unit: Percent
-  GL0 Cache BW (TCP Cache):
+  GL0 Cache BW:
     rst: 'Bandwidth of requests to the GL0 vector cache (TCP Cache). This represents the rate at which the shader cores are requesting data from the cache hierarchy. High bandwidth indicates memory-intensive workloads.'
     unit: Bytes/s
   GL1 Cache Hit Rate:
@@ -182,14 +182,11 @@ Roofline Performance Rates:
     rst: 'Achieved bandwidth for Local Data Share memory operations. LDS provides high-bandwidth, low-latency shared memory within a workgroup. Compare against peak to identify if LDS bandwidth is limiting performance.'
     unit: Bytes/s
 Roofline Plot Points:
-  AI GL2:
-    rst: 'Arithmetic Intensity relative to the GL2 cache. This metric shows compute density relative to GL2 cache traffic. Higher values indicate better cache reuse at GL1, while lower values suggest significant GL1 miss rates.'
+  AI L2:
+    rst: 'Arithmetic Intensity relative to the L2 cache. This metric shows compute density relative to L2 cache traffic. Higher values indicate better data reuse upstream of L2, while lower values suggest heavy traffic into L2.'
     unit: FLOPs/Byte
-  AI GL1:
-    rst: 'Arithmetic Intensity relative to the GL1 cache. This metric shows compute density relative to GL1 cache traffic. Kernels with high AI GL1 but low AI GL0 benefit from GL0 cache locality.'
-    unit: FLOPs/Byte
-  AI GL0:
-    rst: 'Arithmetic Intensity relative to the GL0 cache (TCP Cache). Higher values indicate more compute operations per byte of data loaded, suggesting compute-bound behavior. Lower values suggest memory-bound behavior limited by GL0 bandwidth.'
+  AI L1:
+    rst: 'Arithmetic Intensity relative to the L1 cache (TCP). Higher values indicate more compute operations per byte of data loaded, suggesting compute-bound behavior. Lower values suggest memory-bound behavior limited by L1 bandwidth.'
     unit: FLOPs/Byte
   Performance (GFLOPs):
     rst: 'Achieved compute throughput measured in billions of floating-point operations per second. This value, combined with arithmetic intensity, determines the kernel''s position on the roofline chart for performance analysis.'

--- a/projects/rocprofiler-compute/docs/data/metrics/gfx1151_metrics.yaml
+++ b/projects/rocprofiler-compute/docs/data/metrics/gfx1151_metrics.yaml
@@ -15,7 +15,7 @@ System Speed-of-Light:
     rst: 'Percentage of GL2 cache requests that are serviced from cache without accessing system memory. Higher hit rates reduce memory bandwidth pressure and improve performance. Low hit rates may indicate poor data locality or working sets that exceed cache capacity.'
     unit: Percent
   GL2-Fabric Read BW:
-    rst: 'Read bandwidth between the GL2 cache and the memory fabric/system memory. High bandwidth utilization indicates memory-intensive read patterns. This metric helps identify when memory bandwidth is a performance bottleneck. Requires $max_mclk populated in sysinfo (max MEM clock from amd-smi).'
+    rst: 'Read bandwidth between the GL2 cache and the memory fabric/system memory. High bandwidth utilization indicates memory-intensive read patterns. This metric helps identify when memory bandwidth is a performance bottleneck.'
     unit: Bytes/s
   GL2-Fabric Write BW:
     rst: 'Write bandwidth between the GL2 cache and the memory fabric/system memory. High values indicate write-intensive workloads. Combined with read bandwidth, this shows total memory traffic leaving the GPU caches.'

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
@@ -146,19 +146,20 @@ class db_analysis(OmniAnalyze_Base):
             for roofline_data in self._roofline_data_per_kernel.get(
                 workload_path, pd.DataFrame()
             ).itertuples():
-                if roofline_data.kernel_name not in kernel_objs:
+                kernel_name = getattr(roofline_data, "kernel_name", None)
+                if kernel_name not in kernel_objs:
                     console_warning(
-                        f"Kernel {roofline_data.kernel_name} from roofline data "
+                        f"Kernel {kernel_name} from roofline data "
                         "not found in dispatch data. Skipping roofline entry."
                     )
                     continue
                 Database.get_session().add(
                     orm.KernelRooflineData(
-                        total_flops=roofline_data.total_flops,
-                        l1_cache_data=roofline_data.l1_cache_data,
-                        l2_cache_data=roofline_data.l2_cache_data,
-                        hbm_cache_data=roofline_data.hbm_cache_data,
-                        kernel=kernel_objs[roofline_data.kernel_name],
+                        total_flops=getattr(roofline_data, "total_flops", None),
+                        l1_cache_data=getattr(roofline_data, "l1_cache_data", None),
+                        l2_cache_data=getattr(roofline_data, "l2_cache_data", None),
+                        hbm_cache_data=getattr(roofline_data, "hbm_cache_data", None),
+                        kernel=kernel_objs[kernel_name],
                     )
                 )
 

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0400_roofline.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx1151/0400_roofline.yaml
@@ -57,14 +57,11 @@ Panel Config:
         value: Value
         unit: Unit
       metric:
-        AI GL2:
+        AI L2:
           # Note: GL1-GL2 reads can be 32B, 64B, or 128B. Writes can be 32B or 64B.
           value: ( SUM($wave_size * SQ_INSTS_VALU_sum) / SUM((GL1C_GL2_REQ_READ_32B_sum*32 + GL1C_GL2_REQ_READ_64B_sum*64 + GL1C_GL2_REQ_READ_128B_sum*128) + (GL1C_GL2_REQ_WRITE_32B_sum*32 + GL1C_GL2_REQ_WRITE_64B_sum*64)) )
           unit: FLOPs/Byte
-        AI GL1:
-          value: ( SUM($wave_size * SQ_INSTS_VALU_sum) / SUM((TCP_GL1_REQ_READ_sum * 64) + (TCP_GL1_REQ_WRITE_sum * 64)) )
-          unit: FLOPs/Byte
-        AI GL0:
+        AI L1:
           value: ( SUM($wave_size * SQ_INSTS_VALU_sum) / SUM(TCP_REQ_sum * 64) )
           unit: FLOPs/Byte
         Performance (GFLOPs):
@@ -97,18 +94,14 @@ Panel Config:
       Achieved bandwidth for Local Data Share memory operations. LDS provides
       high-bandwidth, low-latency shared memory within a workgroup. Compare against
       peak to identify if LDS bandwidth is limiting performance.
-    AI GL2: >-
-      Arithmetic Intensity relative to the GL2 cache. This metric shows compute
-      density relative to GL2 cache traffic. Higher values indicate better cache reuse
-      at GL1, while lower values suggest significant GL1 miss rates.
-    AI GL1: >-
-      Arithmetic Intensity relative to the GL1 cache. This metric shows compute
-      density relative to GL1 cache traffic. Kernels with high AI GL1 but low AI GL0
-      benefit from GL0 cache locality.
-    AI GL0: >-
-      Arithmetic Intensity relative to the GL0 cache (TCP Cache). Higher values indicate
+    AI L2: >-
+      Arithmetic Intensity relative to the L2 cache. This metric shows compute
+      density relative to L2 cache traffic. Higher values indicate better data
+      reuse upstream of L2, while lower values suggest heavy traffic into L2.
+    AI L1: >-
+      Arithmetic Intensity relative to the L1 cache (TCP). Higher values indicate
       more compute operations per byte of data loaded, suggesting compute-bound
-      behavior. Lower values suggest memory-bound behavior limited by GL0 bandwidth.
+      behavior. Lower values suggest memory-bound behavior limited by L1 bandwidth.
     Performance (GFLOPs): >-
       Achieved compute throughput measured in billions of floating-point operations
       per second. This value, combined with arithmetic intensity, determines the

--- a/projects/rocprofiler-compute/src/utils/.config_hashes.json
+++ b/projects/rocprofiler-compute/src/utils/.config_hashes.json
@@ -7,7 +7,7 @@
         "0100_system_info.yaml": "5bee16deca4a0b880af47a002fa7bab9",
         "0200_system_speed_of_light.yaml": "8023e47032c4cb6b1060062135b18e64",
         "0300_memory_chart.yaml": "3ea467a5cdd48bd7a20ec0c94304e7a9",
-        "0400_roofline.yaml": "17b62eb17edee43abd833576a7c142a4",
+        "0400_roofline.yaml": "9c3405ed493fcdc23c084cdd9db18baf",
         "0500_command_processor_cpc.yaml": "9de95259d153357dde907a7a410aa1a3",
         "0600_workgroup_manager_spi.yaml": "e0fb474a8a5e97cf26467578f7b5c316",
         "0700_workgroup_processor.yaml": "2e4b9dcea407fdebba15c08b9b4f312c",

--- a/projects/rocprofiler-compute/src/utils/analysis_orm.py
+++ b/projects/rocprofiler-compute/src/utils/analysis_orm.py
@@ -1,6 +1,16 @@
 # Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier:  MIT
 
+"""SQLAlchemy ORM models and SQLite backend for the analysis database.
+
+The schema is documented visually in:
+    docs/data/analyze/analysis_data_dump_schema.png
+generated from its Mermaid source:
+    docs/data/analyze/analysis_data_dump_schema.mmd
+When changing the schema, ask an AI agent to update the .mmd file to match,
+then re-export the .png via draw.io.
+"""
+
 import csv
 import sqlite3
 from contextlib import closing

--- a/projects/rocprofiler-compute/src/utils/analysis_orm.py
+++ b/projects/rocprofiler-compute/src/utils/analysis_orm.py
@@ -7,7 +7,7 @@ The schema is documented visually in:
     docs/data/analyze/analysis_data_dump_schema.png
 generated from its Mermaid source:
     docs/data/analyze/analysis_data_dump_schema.mmd
-When changing the schema, ask an AI agent to update the .mmd file to match,
+When changing the schema, update the .mmd file to match,
 then re-export the .png via draw.io.
 """
 

--- a/projects/rocprofiler-compute/tools/per_arch_metric_definitions/gfx1151_metrics_description.yaml
+++ b/projects/rocprofiler-compute/tools/per_arch_metric_definitions/gfx1151_metrics_description.yaml
@@ -20,8 +20,8 @@ System Speed-of-Light:
     rst: Percentage of GL2 cache requests that are serviced from cache without accessing system memory. Higher hit rates reduce memory bandwidth pressure and improve performance. Low hit rates may indicate poor data locality or working sets that exceed cache capacity.
     unit: Percent
   GL2-Fabric Read BW:
-    plain: Read bandwidth between the GL2 cache and the memory fabric/system memory. High bandwidth utilization indicates memory-intensive read patterns. This metric helps identify when memory bandwidth is a performance bottleneck.
-    rst: Read bandwidth between the GL2 cache and the memory fabric/system memory. High bandwidth utilization indicates memory-intensive read patterns. This metric helps identify when memory bandwidth is a performance bottleneck.
+    plain: Read bandwidth between the GL2 cache and the memory fabric/system memory. High bandwidth utilization indicates memory-intensive read patterns. This metric helps identify when memory bandwidth is a performance bottleneck. Requires $max_mclk populated in sysinfo (max MEM clock from amd-smi).
+    rst: Read bandwidth between the GL2 cache and the memory fabric/system memory. High bandwidth utilization indicates memory-intensive read patterns. This metric helps identify when memory bandwidth is a performance bottleneck. Requires $max_mclk populated in sysinfo (max MEM clock from amd-smi).
     unit: Bytes/s
   GL2-Fabric Write BW:
     plain: Write bandwidth between the GL2 cache and the memory fabric/system memory. High values indicate write-intensive workloads. Combined with read bandwidth, this shows total memory traffic leaving the GPU caches.
@@ -240,17 +240,13 @@ Roofline Performance Rates:
     rst: Achieved bandwidth for Local Data Share memory operations. LDS provides high-bandwidth, low-latency shared memory within a workgroup. Compare against peak to identify if LDS bandwidth is limiting performance.
     unit: Bytes/s
 Roofline Plot Points:
-  AI GL2:
-    plain: Arithmetic Intensity relative to the GL2 cache. This metric shows compute density relative to GL2 cache traffic. Higher values indicate better cache reuse at GL1, while lower values suggest significant GL1 miss rates.
-    rst: Arithmetic Intensity relative to the GL2 cache. This metric shows compute density relative to GL2 cache traffic. Higher values indicate better cache reuse at GL1, while lower values suggest significant GL1 miss rates.
+  AI L2:
+    plain: Arithmetic Intensity relative to the L2 cache. This metric shows compute density relative to L2 cache traffic. Higher values indicate better data reuse upstream of L2, while lower values suggest heavy traffic into L2.
+    rst: Arithmetic Intensity relative to the L2 cache. This metric shows compute density relative to L2 cache traffic. Higher values indicate better data reuse upstream of L2, while lower values suggest heavy traffic into L2.
     unit: FLOPs/Byte
-  AI GL1:
-    plain: Arithmetic Intensity relative to the GL1 cache. This metric shows compute density relative to GL1 cache traffic. Kernels with high AI GL1 but low AI GL0 benefit from GL0 cache locality.
-    rst: Arithmetic Intensity relative to the GL1 cache. This metric shows compute density relative to GL1 cache traffic. Kernels with high AI GL1 but low AI GL0 benefit from GL0 cache locality.
-    unit: FLOPs/Byte
-  AI GL0:
-    plain: Arithmetic Intensity relative to the GL0 cache (TCP Cache). Higher values indicate more compute operations per byte of data loaded, suggesting compute-bound behavior. Lower values suggest memory-bound behavior limited by GL0 bandwidth.
-    rst: Arithmetic Intensity relative to the GL0 cache (TCP Cache). Higher values indicate more compute operations per byte of data loaded, suggesting compute-bound behavior. Lower values suggest memory-bound behavior limited by GL0 bandwidth.
+  AI L1:
+    plain: Arithmetic Intensity relative to the L1 cache (TCP). Higher values indicate more compute operations per byte of data loaded, suggesting compute-bound behavior. Lower values suggest memory-bound behavior limited by L1 bandwidth.
+    rst: Arithmetic Intensity relative to the L1 cache (TCP). Higher values indicate more compute operations per byte of data loaded, suggesting compute-bound behavior. Lower values suggest memory-bound behavior limited by L1 bandwidth.
     unit: FLOPs/Byte
   Performance (GFLOPs):
     plain: Achieved compute throughput measured in billions of floating-point operations per second. This value, combined with arithmetic intensity, determines the kernel's position on the roofline chart for performance analysis.

--- a/projects/rocprofiler-compute/tools/per_arch_metric_definitions/gfx1151_metrics_description.yaml
+++ b/projects/rocprofiler-compute/tools/per_arch_metric_definitions/gfx1151_metrics_description.yaml
@@ -20,8 +20,8 @@ System Speed-of-Light:
     rst: Percentage of GL2 cache requests that are serviced from cache without accessing system memory. Higher hit rates reduce memory bandwidth pressure and improve performance. Low hit rates may indicate poor data locality or working sets that exceed cache capacity.
     unit: Percent
   GL2-Fabric Read BW:
-    plain: Read bandwidth between the GL2 cache and the memory fabric/system memory. High bandwidth utilization indicates memory-intensive read patterns. This metric helps identify when memory bandwidth is a performance bottleneck. Requires $max_mclk populated in sysinfo (max MEM clock from amd-smi).
-    rst: Read bandwidth between the GL2 cache and the memory fabric/system memory. High bandwidth utilization indicates memory-intensive read patterns. This metric helps identify when memory bandwidth is a performance bottleneck. Requires $max_mclk populated in sysinfo (max MEM clock from amd-smi).
+    plain: Read bandwidth between the GL2 cache and the memory fabric/system memory. High bandwidth utilization indicates memory-intensive read patterns. This metric helps identify when memory bandwidth is a performance bottleneck.
+    rst: Read bandwidth between the GL2 cache and the memory fabric/system memory. High bandwidth utilization indicates memory-intensive read patterns. This metric helps identify when memory bandwidth is a performance bottleneck.
     unit: Bytes/s
   GL2-Fabric Write BW:
     plain: Write bandwidth between the GL2 cache and the memory fabric/system memory. High values indicate write-intensive workloads. Combined with read bandwidth, this shows total memory traffic leaving the GPU caches.


### PR DESCRIPTION
## Motivation

Align gfx1151 roofline AI metrics with existing ORM columns instead of
extending the schema. Supersedes #6287.

## Technical Details

- Drop AI GL1 (GL1 is a buffer, not a cache); rename AI GL0/GL2 to AI L1/L2
  in gfx1151 0400_roofline.yaml; re-sync per-arch + docs yaml + hashes
- Bugfix: kernel-level roofline writer uses getattr(..., None) so a missing
  AI metric produces NULL instead of AttributeError
- Add mermaid source for analysis_data_dump_schema.png + docstring pointer

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

- master_config_workflow_script.py --validate-only / --hash-only
- pytest tests/test_autogen_config.py tests/test_analysis_db.py tests/test_roofline_calc_ai_analyze.py

## Test Result

Passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.