### PR TITLE
[RCCL] Harden ncclDevrFinalize cleanup (AICOMRCCL-835)

### DIFF
--- a/projects/rccl/src/dev_runtime.cc
+++ b/projects/rccl/src/dev_runtime.cc
@@ -137,19 +137,28 @@ ncclResult_t ncclDevrFinalize(struct ncclComm* comm) {
       CUDACHECKIGNORE(cudaStreamDestroy(stream));
     }
   }
-  // Drain leaked windows so every per-peer slice is unmapped before VA free.
-  // Without this, on HIP cuMemAddressFree over a still-mapped range returns
-  // hipErrorInvalidValue, which then cascades into ibv_dealloc_pd EBUSY at teardown.
+  // Drain memories whose owning windows were never explicitly destroyed
+  // (e.g. resource windows created by ncclDevCommCreate when the caller
+  // skips the matching ncclDevCommDestroy). Without this, every per-rank
+  // cuMemMap slice inside lsaFlatBase is still live when cuMemAddressFree
+  // is called below, and HIP returns hipErrorInvalidValue (AICOMRCCL-835).
+  if (devr->memHead != nullptr) {
+    int leftover = 0;
+    for (struct ncclDevrMemory* m = devr->memHead; m != nullptr; m = m->next) leftover++;
+    INFO(NCCL_INIT, "ncclDevrFinalize: draining %d leftover device-API memory record(s)", leftover);
+  }
   while (devr->memHead != nullptr) {
     struct ncclDevrMemory* m = devr->memHead;
     m->refCount = 1; // force drop on the next call
     symMemoryDropRef(comm, m);
   }
   if (devr->lsaFlatBase != nullptr) {
+    // The drain above unmapped every per-rank slice via symMemoryDropRef,
+    // so this is now expected to succeed. Surface failures instead of
+    // masking with CUCHECKIGNORE — a regression in the drain path should
+    // not be silently swallowed (AICOMRCCL-835).
     CUdeviceptr flatAddr = reinterpret_cast<CUdeviceptr>(devr->lsaFlatBase);
-  // Returns error: invalid argument. Already unmapped by symMemoryDropRef
-  // CUCHECKIGNORE(cuMemUnmap(flatAddr, devr->lsaSize*devr->bigSize));
-    CUCHECKIGNORE(cuMemAddressFree(flatAddr, devr->lsaSize*devr->bigSize));
+    CUCHECK(cuMemAddressFree(flatAddr, devr->lsaSize*devr->bigSize));
   }
   ncclShadowPoolDestruct(&devr->shadows);
   ncclSpaceDestruct(&devr->bigSpace);


### PR DESCRIPTION
## Summary

Follow-up to the `symMemoryDropRef` drain that landed via the NCCL 2.28.9-1 sync (`46931872a0`). Three small changes in `src/dev_runtime.cc`:

1. **`CUCHECKIGNORE` → `CUCHECK` on `cuMemAddressFree`.** With the drain in place this call is expected to succeed; the mask was originally added to paper over the very failure mode the drain was introduced to fix. Keeping it silently swallows any future regression in the drain path.
2. **Replace the misleading comment.** The previous `// Already unmapped by symMemoryDropRef` next to a commented-out `cuMemUnmap` was a fossil from the original misdiagnosis. The new comment explains why the call is now safe and references the ticket.
3. **Add `INFO(NCCL_INIT, ...)` when the drain actually runs**, so leaked device-API state is observable in logs.

No behavior change when `devr->memHead` is empty (the common case — comms whose Device-API resource windows were properly destroyed).

## Context

AICOMRCCL-835 was a `hipMemAddressFree` failure at process exit when a Device-API consumer (e.g. `rccl-tests -D 1`) created a resource window via `ncclDevCommCreate` without a matching `ncclDevCommDestroy`. The leftover `ncclDevrMemory` on `devr->memHead` kept per-rank `cuMemMap` slices alive inside the LSA flat VA reservation, so `cuMemAddressFree` returned `hipErrorInvalidValue` (logged as `dev_runtime.cc:131 HIP failure 'unknown error'`).

The drain in `46931872a0` is the correct functional fix. This PR makes the surrounding code honest about what the drain does and surfaces regressions instead of hiding them.

A companion rccl-tests PR will pair every `ncclDevCommCreate` with `ncclDevCommDestroy`, so the drain becomes a defensive backstop rather than a load-bearing fixup for misuse.

## Test plan

- [x] Builds clean (`./install.sh -l -j $(nproc)`) inside the same ROCm container that originally reproduced the bug.
- [x] `NCCL_DEBUG=INFO NCCL_WIN_ENABLE=1 NCCL_CUMEM_ENABLE=1 mpirun --allow-run-as-root -np 2 ./all_reduce_perf -b 1K -e 1K -R 2 -D 1` on 2× MI300X reaches `Destroy COMPLETE` on both ranks with no `HIP failure 'unknown error'` log line. The new INFO line `ncclDevrFinalize: draining N leftover device-API memory record(s)` is emitted (and will disappear once the companion rccl-tests fix lands).
- [x] Same command with `-D 0` (no Device API) — drain log not emitted, no behavior change.