### PR TITLE
[hipFile] Add a CI stage to build & test on ROCm 7.13

### DIFF
--- a/.github/workflows/hipfile-ci-toplevel.yml
+++ b/.github/workflows/hipfile-ci-toplevel.yml
@@ -37,6 +37,9 @@ jobs:
           - ubuntu
         rocm_versions:
           - 7.2.2
+        include:
+          - supported_platforms: ubuntu
+            rocm_versions: 7.13.0
     uses: ./.github/workflows/hipfile-ci.yml
     with:
       platform: ${{ matrix.supported_platforms }}

--- a/.github/workflows/hipfile-ci.yml
+++ b/.github/workflows/hipfile-ci.yml
@@ -122,7 +122,11 @@ jobs:
       rocm_version: ${{ inputs.rocm_version }}
 
   build_and_test_NVIDIA:
-    if: ${{ !cancelled() && needs.build_AIS_CI_image.outputs.ci_image_build_satisfied == 'true' }}
+    if: >-
+      ${{ !cancelled()
+        && needs.build_AIS_CI_image.outputs.ci_image_build_satisfied == 'true'
+        && !startsWith(inputs.rocm_version, '7.13.')
+      }}
     needs: [AIS_CI_Pre-check, build_AIS_CI_image]
     uses: ./.github/workflows/hipfile-build-nvidia.yml
     with:

--- a/projects/hipfile/CMakeLists.txt
+++ b/projects/hipfile/CMakeLists.txt
@@ -121,8 +121,16 @@ endif()
 if(DEFINED ENV{ROCM_PATH})
     set(ROCM_INITIAL_PATH "$ENV{ROCM_PATH}")
 elseif(DEFINED ROCM_VERSION)
-    # Infer default based on ROCM_VERSION
-    set(ROCM_INITIAL_PATH "/opt/rocm-${ROCM_VERSION}")
+    # ROCm 7.11+ installs to /opt/rocm/core-MAJOR.MINOR (new repo.amd.com layout);
+    # earlier releases install to /opt/rocm-MAJOR.MINOR.PATCH.
+    string(REGEX MATCH "^([0-9]+)\\.([0-9]+)" _rocm_mm "${ROCM_VERSION}")
+    set(_rocm_major "${CMAKE_MATCH_1}")
+    set(_rocm_minor "${CMAKE_MATCH_2}")
+    if(_rocm_major GREATER 7 OR (_rocm_major EQUAL 7 AND _rocm_minor GREATER_EQUAL 11))
+        set(ROCM_INITIAL_PATH "/opt/rocm/core-${_rocm_major}.${_rocm_minor}")
+    else()
+        set(ROCM_INITIAL_PATH "/opt/rocm-${ROCM_VERSION}")
+    endif()
 else()
     # Default install location symlink
     set(ROCM_INITIAL_PATH "/opt/rocm")

--- a/projects/hipfile/CMakeLists.txt
+++ b/projects/hipfile/CMakeLists.txt
@@ -124,6 +124,11 @@ elseif(DEFINED ROCM_VERSION)
     # ROCm 7.11+ installs to /opt/rocm/core-MAJOR.MINOR (new repo.amd.com layout);
     # earlier releases install to /opt/rocm-MAJOR.MINOR.PATCH.
     string(REGEX MATCH "^([0-9]+)\\.([0-9]+)" _rocm_mm "${ROCM_VERSION}")
+    if(NOT _rocm_mm)
+        message(FATAL_ERROR
+            "ROCM_VERSION='${ROCM_VERSION}' does not match the expected "
+            "MAJOR.MINOR[.PATCH] form (e.g., 7.13.0).")
+    endif()
     set(_rocm_major "${CMAKE_MATCH_1}")
     set(_rocm_minor "${CMAKE_MATCH_2}")
     if(_rocm_major GREATER 7 OR (_rocm_major EQUAL 7 AND _rocm_minor GREATER_EQUAL 11))

--- a/projects/hipfile/cmake/AISInstall.cmake
+++ b/projects/hipfile/cmake/AISInstall.cmake
@@ -65,9 +65,23 @@ endif()
 # where these dependencies are added.
 # For now, just add both runtime & dev deps.
 
-# AMD Runtime Dependencies
+# AMD ROCm Runtime + Dev Dependencies
 if(CMAKE_HIP_PLATFORM STREQUAL "amd")
-    rocm_package_add_dependencies(DEPENDS hip-runtime-amd) # Need minimum version
+    string(REGEX MATCH "^([0-9]+)\\.([0-9]+)" _rocm_mm "${ROCM_VERSION}")
+    set(_rocm_major "${CMAKE_MATCH_1}")
+    set(_rocm_minor "${CMAKE_MATCH_2}")
+    if(_rocm_major GREATER 7 OR (_rocm_major EQUAL 7 AND _rocm_minor GREATER_EQUAL 11))
+        # 7.11+ ships runtime + dev as a single amdrocm-runtime-dev<MAJOR>.<MINOR>
+        # meta-package on repo.amd.com; rocm-core, hip-runtime-amd, and hip-dev
+        # do not exist there, so suppress rocm-cmake's auto-added rocm-core dep.
+        set(ROCM_DEP_ROCMCORE OFF CACHE BOOL "" FORCE)
+        rocm_package_add_deb_dependencies(DEPENDS "amdrocm-runtime-dev${_rocm_major}.${_rocm_minor}")
+    else()
+        rocm_package_add_dependencies(DEPENDS hip-runtime-amd) # Need minimum version
+        rocm_package_add_deb_dependencies(DEPENDS hip-dev) # Need minimum version
+        rocm_package_add_rpm_dependencies(DEPENDS hip-devel)
+    endif()
+
     # Suppressing libmount RELEASE dependency for now for the following:
     # 1) We currently default to DEV builds.
     # 2) libmount naming convention is not consistent across distros.
@@ -76,13 +90,6 @@ if(CMAKE_HIP_PLATFORM STREQUAL "amd")
     #    rocky    (RPM): libmount
     #    Ubuntu   (DEB): libmount1
     #rocm_package_add_dependencies(DEPENDS libmount)
-endif()
-
-# AMD Development Dependencies
-if(CMAKE_HIP_PLATFORM STREQUAL "amd")
-    rocm_package_add_deb_dependencies(DEPENDS hip-dev) # Need minimum version
-    rocm_package_add_rpm_dependencies(DEPENDS hip-devel)
-
     rocm_package_add_deb_dependencies(DEPENDS libmount-dev)
     rocm_package_add_rpm_dependencies(DEPENDS libmount-devel)
 endif()

--- a/projects/hipfile/cmake/AISInstall.cmake
+++ b/projects/hipfile/cmake/AISInstall.cmake
@@ -68,6 +68,11 @@ endif()
 # AMD ROCm Runtime + Dev Dependencies
 if(CMAKE_HIP_PLATFORM STREQUAL "amd")
     string(REGEX MATCH "^([0-9]+)\\.([0-9]+)" _rocm_mm "${ROCM_VERSION}")
+    if(NOT _rocm_mm)
+        message(FATAL_ERROR
+            "ROCM_VERSION='${ROCM_VERSION}' does not match the expected "
+            "MAJOR.MINOR[.PATCH] form (e.g., 7.13.0).")
+    endif()
     set(_rocm_major "${CMAKE_MATCH_1}")
     set(_rocm_minor "${CMAKE_MATCH_2}")
     if(_rocm_major GREATER 7 OR (_rocm_major EQUAL 7 AND _rocm_minor GREATER_EQUAL 11))

--- a/projects/hipfile/python/CMakeLists.txt
+++ b/projects/hipfile/python/CMakeLists.txt
@@ -8,11 +8,27 @@ find_program(CYTHON_EXECUTABLE cython REQUIRED)
 
 # ---- hipFile library & headers --------------------------------------------
 
+# ROCm install hints: prefer $ROCM_PATH from env; fall back to a glob of
+# /opt/rocm/core-* (7.11+ layout) plus legacy /opt/rocm.
+if(DEFINED ENV{ROCM_PATH})
+    set(_ROCM_ROOTS "$ENV{ROCM_PATH}")
+else()
+    file(GLOB _ROCM_ROOTS "/opt/rocm/core-*")
+    list(APPEND _ROCM_ROOTS "/opt/rocm")
+endif()
+
+set(_ROCM_INCLUDE_HINTS)
+set(_ROCM_LIB_HINTS)
+foreach(_r IN LISTS _ROCM_ROOTS)
+    list(APPEND _ROCM_INCLUDE_HINTS "${_r}/include")
+    list(APPEND _ROCM_LIB_HINTS "${_r}/lib")
+endforeach()
+
 # hipfile.h location (prefer sibling include/ from source, fall back to installed)
 find_path(HIPFILE_INCLUDE_DIR hipfile.h
     HINTS
         "${CMAKE_CURRENT_SOURCE_DIR}/../include"
-        "/opt/rocm/include"
+        ${_ROCM_INCLUDE_HINTS}
     PATH "Path to directory containing hipfile.h"
 )
 if(NOT HIPFILE_INCLUDE_DIR)
@@ -25,7 +41,7 @@ endif()
 find_library(HIPFILE_LIBRARY hipfile
     HINTS
         "${CMAKE_CURRENT_SOURCE_DIR}/../build/src/amd_detail"
-        "/opt/rocm/lib"
+        ${_ROCM_LIB_HINTS}
 )
 if(NOT HIPFILE_LIBRARY)
     message(FATAL_ERROR
@@ -36,8 +52,7 @@ endif()
 # HIP runtime headers (needed because hipfile.h includes hip/hip_runtime_api.h)
 find_path(HIP_INCLUDE_DIR hip/hip_runtime_api.h
     HINTS
-        "/opt/rocm/include"
-        "/opt/rocm/hip/include"
+        ${_ROCM_INCLUDE_HINTS}
 )
 if(NOT HIP_INCLUDE_DIR)
     message(FATAL_ERROR

--- a/projects/hipfile/util/docker/DOCKERFILE.ais_ci_ubuntu
+++ b/projects/hipfile/util/docker/DOCKERFILE.ais_ci_ubuntu
@@ -20,26 +20,60 @@ RUN apt update && \
         curl \
         gpg
 
+# Cache MAJOR/MINOR and a 'use new repo' flag for use by later RUN steps.
+# Threshold: ROCm 7.11+ ships from repo.amd.com to /opt/rocm/core-<MAJOR>.<MINOR>;
+# earlier releases ship from repo.radeon.com to /opt/rocm (legacy symlink).
+RUN ROCM_MAJOR=$(echo "${ROCM_VERSION}" | cut -d. -f1); \
+    ROCM_MINOR=$(echo "${ROCM_VERSION}" | cut -d. -f2); \
+    if [ "${ROCM_MAJOR}" -gt 7 ] || { [ "${ROCM_MAJOR}" -eq 7 ] && [ "${ROCM_MINOR}" -ge 11 ]; }; then \
+        ROCM_USE_NEW_REPO=1; \
+        ROCM_INSTALL_PATH="/opt/rocm/core-${ROCM_MAJOR}.${ROCM_MINOR}"; \
+    else \
+        ROCM_USE_NEW_REPO=0; \
+        ROCM_INSTALL_PATH="/opt/rocm"; \
+    fi; \
+    printf 'ROCM_MAJOR=%s\nROCM_MINOR=%s\nROCM_USE_NEW_REPO=%s\nROCM_INSTALL_PATH=%s\n' \
+        "${ROCM_MAJOR}" "${ROCM_MINOR}" "${ROCM_USE_NEW_REPO}" "${ROCM_INSTALL_PATH}" \
+        > /etc/rocm-build.env
+
 # Retrieve ROCm GPG key
-RUN curl https://repo.radeon.com/rocm/rocm.gpg.key | \
-    gpg --dearmor >> /etc/apt/keyrings/rocm.gpg
+RUN . /etc/rocm-build.env && \
+    if [ "${ROCM_USE_NEW_REPO}" = "1" ]; then \
+        curl https://repo.amd.com/rocm/packages/gpg/rocm.gpg | \
+            gpg --dearmor >> /etc/apt/keyrings/amdrocm.gpg; \
+    else \
+        curl https://repo.radeon.com/rocm/rocm.gpg.key | \
+            gpg --dearmor >> /etc/apt/keyrings/rocm.gpg; \
+    fi
 
 # Manually setup ROCm Package Repos
-# ROCM_PKG_REPO_VERSION normalizes the ROCm version used in the package repo URL.
+# ROCM_PKG_REPO_VERSION normalizes the legacy ROCm version used in the package repo URL.
 # If the PATCH component is 0, the PATCH of the version is dropped. Otherwise no
 # modification is made.
-RUN ROCM_PKG_REPO_VERSION="$(echo ${ROCM_PKG_REPO_OVERRIDE:-$ROCM_VERSION} | sed -E 's|([^.]+\.[^.]+)\.0$|\1|')"; \
-    cat <<EOF > /etc/apt/sources.list.d/rocm.list
-deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/${ROCM_PKG_REPO_VERSION} ${UBUNTU_CODENAME} main
-EOF
+RUN . /etc/rocm-build.env && \
+    if [ "${ROCM_USE_NEW_REPO}" = "1" ]; then \
+        echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/amdrocm.gpg] https://repo.amd.com/rocm/packages/ubuntu${UBUNTU_MAJOR_VERSION}${UBUNTU_MINOR_VERSION} stable main" \
+            > /etc/apt/sources.list.d/amdrocm.list; \
+    else \
+        ROCM_PKG_REPO_VERSION="$(echo ${ROCM_PKG_REPO_OVERRIDE:-$ROCM_VERSION} | sed -E 's|([^.]+\.[^.]+)\.0$|\1|')"; \
+        echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/${ROCM_PKG_REPO_VERSION} ${UBUNTU_CODENAME} main" \
+            > /etc/apt/sources.list.d/rocm.list; \
+    fi
 
-RUN cat <<EOF > /etc/apt/preferences.d/rocm-pin-600
+# Apt pinning is required for the legacy repo only; 7.11+ does not need it.
+# Outer EOT is a Dockerfile-level heredoc delimiter, kept distinct from the inner shell EOF.
+RUN <<"EOT"
+. /etc/rocm-build.env
+if [ "${ROCM_USE_NEW_REPO}" = "0" ]; then
+    cat <<EOF > /etc/apt/preferences.d/rocm-pin-600
 Package: *
 Pin: release o=repo.radeon.com
 Pin-Priority: 600
 EOF
+fi
+EOT
 
-# Development Dependencies
+# Common development dependencies
 RUN apt update && \
     apt install -y \
         clang \
@@ -47,23 +81,46 @@ RUN apt update && \
         doxygen \
         gdb \
         git \
-        hip-dev \
         libboost-program-options-dev \
         libmount-dev \
         llvm-dev \
         python3.12-dev \
-        python3.12-venv \
-        rocm-llvm-dev
+        python3.12-venv
+
+# ROCm dev packages
+RUN . /etc/rocm-build.env && \
+    if [ "${ROCM_USE_NEW_REPO}" = "1" ]; then \
+        apt install -y \
+            amdrocm-runtime-dev${ROCM_MAJOR}.${ROCM_MINOR}; \
+    else \
+        apt install -y \
+            hip-dev \
+            rocm-llvm-dev; \
+    fi
 
 # Configure system linker for ROCm
-RUN cat <<EOF > /etc/ld.so.conf.d/rocm.conf
-/opt/rocm/lib
-/opt/rocm/lib64
-EOF
-RUN ldconfig
+RUN . /etc/rocm-build.env && \
+    { echo "${ROCM_INSTALL_PATH}/lib"; \
+      echo "${ROCM_INSTALL_PATH}/lib64"; } \
+        > /etc/ld.so.conf.d/rocm.conf && \
+    ldconfig
 
-# Add ROCm bin directory to the path
-ENV PATH=/opt/rocm/bin:${PATH}
+# Write a /etc/profile.d script exporting ROCM_PATH and PATH for the install layout.
+RUN . /etc/rocm-build.env && \
+    printf 'export ROCM_PATH=%s\nexport PATH=%s/bin:$PATH\n' \
+        "${ROCM_INSTALL_PATH}" "${ROCM_INSTALL_PATH}" \
+        > /etc/profile.d/rocm.sh && \
+    chmod +x /etc/profile.d/rocm.sh
+
+# /etc/profile already iterates /etc/profile.d/*.sh for login shells. The
+# iterator script below applies the same behavior to interactive non-login
+# bash (via /etc/bash.bashrc) and non-interactive bash (via BASH_ENV).
+RUN printf '%s\n' \
+        'for _f in /etc/profile.d/*.sh; do [ -r "$_f" ] && . "$_f"; done' \
+        'unset _f' \
+        > /etc/bash_env.sh && \
+    echo '. /etc/bash_env.sh' >> /etc/bash.bashrc
+ENV BASH_ENV="/etc/bash_env.sh"
 
 # Environment Build Arg for ROCm
 ENV ROCM_VERSION="${ROCM_VERSION}"


### PR DESCRIPTION
## Motivation

Expand hipFile CI coverage to ROCm 7.13 so regressions against the new ROCm release line are caught alongside the existing 7.2.x matrix. ROCm 7.13 introduces a new package distribution (repo.amd.com instead of repo.radeon.com) and a new install layout (/opt/rocm/core-7.13 instead of /opt/rocm-7.2.2), so adding it required teaching the Ubuntu CI image and CMake configuration about both flows in parallel.

## Technical Details

Three targeted changes, all scoped to keep the legacy 7.2.x path unchanged:

* .github/workflows/hipfile-ci-toplevel.yml
  * added a matrix include: entry to append a single ubuntu × 7.13.0 job rather than expanding the cross-product (Rocky/SUSE on the new repo.amd.com host are out of scope).
* .github/workflows/hipfile-ci.yml
  * skip build_and_test_NVIDIA on ROCm prerelease versions. Left as a rudimentary check for now.
* projects/hipfile/util/docker/DOCKERFILE.ais_ci_ubuntu
  * a one-time RUN computes a ROCM_USE_NEW_REPO flag from ROCM_VERSION and writes it to /etc/rocm-build.env
  * subsequent steps branch on if the target ROCm version is legacy or a preview release
  * ROCm Preview Releases do not require apt pinning.
  * A /etc/profile.d/rocm.sh exports the install-aware ROCM_PATH and prepends ${ROCM_PATH}/bin to PATH; a small /etc/bash_env.sh iterator (sourced via BASH_ENV and appended to /etc/bash.bashrc) mirrors what /etc/profile does for login shells, so any file dropped into /etc/profile.d/ is picked up across login, interactive non-login, and non-interactive bash invocations alike.
* projects/hipfile/cmake/AISInstall.cmake
  *  Added a branch for packaging hipFile for ROCm 7.13. This package has different dependencies declared.
* projects/hipfile/CMakeLists.txt
  * when inferring ROCM_INITIAL_PATH from ROCM_VERSION, added a major.minor parse with a 7.11+ branch that selects /opt/rocm/core-MAJOR.MINOR; legacy versions still resolve to /opt/rocm-MAJOR.MINOR.PATCH. The existing CMAKE_PREFIX_PATH block already includes ${ROCM_PATH}/llvm, ${ROCM_PATH}, ${ROCM_PATH}/hip, so no further changes were needed for find_package(hsa-runtime64) / find_package(hip) to pick up the new prefix.
* projects/hipfile/python/CMakeLists.txt
  *  the Python bindings can now search for ROCm prerelease versions

## JIRA ID

AIHIPFILE-193

## Test Plan

Does the existing CI legs and new CI leg pass?

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
