### PR TITLE
rocr: non-abort service-survival envs (ROCR_SERVICE_SURVIVAL + ROCR_S…

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
@@ -57,6 +57,21 @@
 #include "core/inc/interrupt_signal.h"
 #include "core/inc/default_signal.h"
 
+// ROCR_SDMA_WRITE_ADDR_FAIL_MS: read once, cache forever.  Returns the
+// configured deadline in nanoseconds, or 0 if the env is unset / 0 (in
+// which case the AcquireWriteAddress yield loop is unbounded as before).
+namespace {
+static uint64_t SdmaWriteAddrFailNs() {
+  static std::atomic<uint64_t> cached{UINT64_MAX};
+  uint64_t v = cached.load(std::memory_order_relaxed);
+  if (v != UINT64_MAX) return v;
+  uint32_t ms = core::Runtime::runtime_singleton_->flag().rocr_sdma_write_addr_fail_ms();
+  v = static_cast<uint64_t>(ms) * 1000000ULL;
+  cached.store(v, std::memory_order_relaxed);
+  return v;
+}
+}  // namespace
+
 namespace rocr {
 namespace AMD {
 
@@ -1612,6 +1627,11 @@ char* BlitSdma<useGCR, scopeFields>::AcquireWriteAddress(uint32_t cmd_size, uint
 
   curr_index = atomic::Load(&cached_reserve_index_, std::memory_order_acquire);
 
+  // Optional wall-clock deadline gated by ROCR_SDMA_WRITE_ADDR_FAIL_MS.
+  // 0 (default) preserves the legacy unbounded yield-loop behaviour.
+  const uint64_t deadline_ns = SdmaWriteAddrFailNs();
+  const auto loop_start = std::chrono::steady_clock::now();
+
   while (true) {
     // Check whether a linear region of the requested size is available.
     // If == cmd_size: region is at beginning of ring.
@@ -1626,6 +1646,16 @@ char* BlitSdma<useGCR, scopeFields>::AcquireWriteAddress(uint32_t cmd_size, uint
     const uint64_t new_index = curr_index + cmd_size;
 
     if (CanWriteUpto(new_index) == false) {
+      // ROCR_SDMA_WRITE_ADDR_FAIL_MS: bail out if wall-clock deadline
+      // exceeded.  Caller treats nullptr as ring-not-available and
+      // surfaces the failure to higher-level survival policy.
+      if (deadline_ns) {
+        const auto elapsed_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+            std::chrono::steady_clock::now() - loop_start).count();
+        if (static_cast<uint64_t>(elapsed_ns) >= deadline_ns) {
+          return nullptr;
+        }
+      }
       // Wait for read index to move and try again.
       os::YieldThread();
       curr_index = atomic::Load(&cached_reserve_index_, std::memory_order_acquire);
@@ -1641,6 +1671,17 @@ char* BlitSdma<useGCR, scopeFields>::AcquireWriteAddress(uint32_t cmd_size, uint
 
     // CAS failed -- reuse the observed value directly, skip redundant atomic Load.
     curr_index = observed;
+
+    // ROCR_SDMA_WRITE_ADDR_FAIL_MS: same wall-clock cap on the
+    // CAS-collision spin path.
+    if (deadline_ns) {
+      const auto elapsed_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+          std::chrono::steady_clock::now() - loop_start).count();
+      if (static_cast<uint64_t>(elapsed_ns) >= deadline_ns) {
+        return nullptr;
+      }
+    }
+
     _mm_pause();
   }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/interrupt_signal.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/interrupt_signal.cpp
@@ -154,6 +154,13 @@ hsa_signal_value_t InterruptSignal::WaitRelaxed(hsa_signal_condition_t condition
   const uint32_t &signal_abort_timeout =
     core::Runtime::runtime_singleton_->flag().signal_abort_timeout();
 
+  // ROCR_SIGNAL_WAIT_MAX_MS: optional non-abort per-call wait cap.
+  // 0 (default) preserves stock behaviour byte-identically.
+  const uint32_t rocr_signal_wait_max_ms =
+    core::Runtime::runtime_singleton_->flag().rocr_signal_wait_max_ms();
+  const timer::fast_clock::duration rocr_max_wait =
+    std::chrono::milliseconds(rocr_signal_wait_max_ms);
+
   while (true) {
     if (!IsValid()) return 0;
 
@@ -165,6 +172,14 @@ hsa_signal_value_t InterruptSignal::WaitRelaxed(hsa_signal_condition_t condition
 
     auto now = timer::fast_clock::now();
     if (now - start_time > fast_timeout) {
+      return value;
+    }
+
+    // ROCR_SIGNAL_WAIT_MAX_MS deadline check: return partial value
+    // rather than aborting the process (that is what the existing
+    // HSA_SIGNAL_WAIT_ABORT_TIMEOUT handles).
+    if (rocr_signal_wait_max_ms > 0 &&
+        now - start_time > rocr_max_wait) {
       return value;
     }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -433,6 +433,15 @@ hsa_status_t Runtime::FreeMemory(void* ptr) {
               agentOwner->node_id(), reinterpret_cast<void*>(agentOwner->public_handle().handle),
               ptr);
 
+      // ROCR_SERVICE_SURVIVAL=1: return error to caller instead of
+      // taking down the process.  Lets the higher-level serving stack
+      // surface the failure to the affected request only.
+      if (runtime_singleton_->flag().rocr_service_survival()) {
+        fprintf(stderr,
+                "Memory Error: ROCR_SERVICE_SURVIVAL active, continuing.\n");
+        return HSA_STATUS_ERROR;
+      }
+
       assert(false && "GPU memory error.");
       std::abort();
     }
@@ -2131,6 +2140,15 @@ bool Runtime::HwExceptionHandler(hsa_signal_value_t val, void* arg) {
             reinterpret_cast<void*>(faultingAgent->public_handle().handle),
             (exception.ResetCause == HSA_EVENTID_HW_EXCEPTION_ECC) ? "ECC" : "GPU Hang");
 
+    // ROCR_SERVICE_SURVIVAL=1: non-abort path for non-ECC hangs.
+    // ECC errors stay abort-fatal because data integrity is at risk.
+    if (runtime_singleton_->flag().rocr_service_survival() &&
+        exception.ResetCause != HSA_EVENTID_HW_EXCEPTION_ECC) {
+      fprintf(stderr,
+              "HW Exception: ROCR_SERVICE_SURVIVAL active, continuing after GPU Hang.\n");
+      return false;
+    }
+
     assert(false && "GPU HW Exception");
     std::abort();
   }
@@ -2264,6 +2282,15 @@ bool Runtime::VMFaultHandler(hsa_signal_value_t val, void* arg) {
       else if (amd::coredump::dump_gpu_core())
         fprintf(stderr, "GPU core dump failed\n");
     }
+    // ROCR_SERVICE_SURVIVAL=1: surface VM fault as a recoverable
+    // error rather than aborting the host process.  The higher-level
+    // serving stack decides how to drain or reject in-flight work.
+    if (runtime_singleton_->flag().rocr_service_survival()) {
+      fprintf(stderr,
+              "VM Fault: ROCR_SERVICE_SURVIVAL active, continuing after memory fault.\n");
+      return false;
+    }
+
     assert(false && "GPU memory access fault.");
     std::abort();
   }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
@@ -270,6 +270,30 @@ class Flag {
     var = os::GetEnvVar("HSA_SIGNAL_WAIT_ABORT_TIMEOUT");
     signal_abort_timeout_ = var.empty() ? 0 : atoi(var.c_str());
 
+    /* Non-abort per-call wait cap.  When set, WaitRelaxed returns
+     * the partial signal value at the configured ms deadline rather
+     * than blocking forever; complementary to (and distinct from)
+     * HSA_SIGNAL_WAIT_ABORT_TIMEOUT, which aborts the process.
+     * Default 0 = unbounded = stock behaviour. */
+    var = os::GetEnvVar("ROCR_SIGNAL_WAIT_MAX_MS");
+    rocr_signal_wait_max_ms_ = var.empty() ? 0 : atoi(var.c_str());
+
+    /* Service-survival master switch.  When 1, the runtime returns
+     * an error status from the memory-error / HW-exception / VM-fault
+     * handlers instead of calling std::abort(), so a serving stack can
+     * recover the affected request without taking the whole process
+     * down with it.  Default: 0 (stock abort()-on-fault behaviour). */
+    var = os::GetEnvVar("ROCR_SERVICE_SURVIVAL");
+    rocr_service_survival_ = (var == "1") ? true : false;
+
+    /* Wall-clock deadline (in ms) for the AcquireWriteAddress
+     * yield-loop in amd_blit_sdma.cpp.  When set and the SDMA ring
+     * stays full past the deadline, AcquireWriteAddress returns
+     * nullptr so the caller fails fast instead of spinning forever.
+     * Default 0 = legacy unbounded yield. */
+    var = os::GetEnvVar("ROCR_SDMA_WRITE_ADDR_FAIL_MS");
+    rocr_sdma_write_addr_fail_ms_ = var.empty() ? 0 : atoi(var.c_str());
+
     /* Valid inputs are 0-99, HIGH, MAX */
     var = os::GetEnvVar("HSA_ASYNCEVENTS_THREAD_PRIORITY");
     async_events_thread_priority_ = os::OS_THREAD_PRIORITY_DEFAULT;
@@ -456,6 +480,12 @@ class Flag {
 
   uint32_t signal_abort_timeout() const { return signal_abort_timeout_; }
 
+  uint32_t rocr_signal_wait_max_ms() const { return rocr_signal_wait_max_ms_; }
+
+  bool rocr_service_survival() const { return rocr_service_survival_; }
+
+  uint32_t rocr_sdma_write_addr_fail_ms() const { return rocr_sdma_write_addr_fail_ms_; }
+
   int async_events_thread_priority() const { return async_events_thread_priority_; }
 
   bool enable_3d_swizzle() const { return enable_3d_swizzle_; }
@@ -539,6 +569,9 @@ class Flag {
   bool wait_any_;
   bool dev_mem_queue_buf_;
   uint32_t signal_abort_timeout_;
+  uint32_t rocr_signal_wait_max_ms_ = 0;
+  bool     rocr_service_survival_ = false;
+  uint32_t rocr_sdma_write_addr_fail_ms_ = 0;
   int  async_events_thread_priority_;
   bool enable_3d_swizzle_ = false;
   bool enable_dtif_;


### PR DESCRIPTION
…IGNAL_WAIT_MAX_MS + ROCR_SDMA_WRITE_ADDR_FAIL_MS)

Bundle three independent ROCr-side service-survival environment variables that together allow a production HIP/ROCm serving stack to opt the runtime into non-abort failure modes when GPU faults or SDMA ring stalls would otherwise tear down the host process.  All three default to 0/false so stock behaviour is byte-identical for users who do not opt in.

  ROCR_SERVICE_SURVIVAL=1
      Gate non-abort branches in the three runtime.cpp abort sites:
        - memory critical error handler
        - HW exception handler (non-ECC only; ECC stays abort-fatal) - VM fault handler When set, the handler returns the appropriate HSA_STATUS_ERROR / false instead of calling std::abort(), so the higher-level serving stack can surface the failure to the affected request only and keep peer requests / co-tenants running.

  ROCR_SIGNAL_WAIT_MAX_MS=N
      Non-abort per-call cap on InterruptSignal::WaitRelaxed.  When
      the configured deadline elapses, WaitRelaxed returns the
      partial signal value rather than blocking indefinitely.
      Complementary to HSA_SIGNAL_WAIT_ABORT_TIMEOUT (which aborts
      at its deadline); ROCR_SIGNAL_WAIT_MAX_MS is intentionally
      non-abort.  Default 0 = unbounded = stock.

  ROCR_SDMA_WRITE_ADDR_FAIL_MS=N
      Bound the AcquireWriteAddress() yield-loop in amd_blit_sdma.cpp.
      When set and the SDMA ring stays full past the wall-clock
      deadline, AcquireWriteAddress returns nullptr so the caller
      surfaces ring-not-available rather than spinning forever.
      Default 0 = unbounded = stock.

## Motivation

Multi-tenant HIP serving workloads need a host-side recovery path that does NOT abort the process when a hardware or driver-level fault hits one request:

  - SDMA ring stall (the SDMA engine wedges; writers spin forever in AcquireWriteAddress): without ROCR_SDMA_WRITE_ADDR_FAIL_MS, every host thread queueing a copy ends up spinning on `os::YieldThread()` indefinitely.

  - VM fault / HW exception in one request: without ROCR_SERVICE_SURVIVAL, the runtime calls std::abort() and every co-tenant request running on the same process dies with it.

  - InterruptSignal::WaitRelaxed parked: without ROCR_SIGNAL_WAIT_MAX_MS, the legacy unbounded HSA_SIGNAL_WAIT path can hold host threads on a wedged signal for minutes-plus.  HSA_SIGNAL_WAIT_ABORT_TIMEOUT exists but kills the whole process at its deadline -- too aggressive for HA serving.

## Technical Details

- core/util/flag.h Parse + storage + accessor for ROCR_SERVICE_SURVIVAL (bool), ROCR_SIGNAL_WAIT_MAX_MS (uint32), ROCR_SDMA_WRITE_ADDR_FAIL_MS (uint32).

- core/runtime/interrupt_signal.cpp WaitRelaxed adds one extra deadline check inside the existing while loop: if rocr_signal_wait_max_ms > 0 AND elapsed since loop entry exceeds the cap, return the last-loaded signal value.

- core/runtime/runtime.cpp Three abort sites wrap the existing `assert(false); std::abort();` pair behind `if (rocr_service_survival()) { fprintf + return error; }`.  HW exception path additionally guards against suppressing ECC errors (data integrity).

- core/runtime/amd_blit_sdma.cpp Add a file-local `SdmaWriteAddrFailNs()` cached helper that reads ROCR_SDMA_WRITE_ADDR_FAIL_MS once and converts to nanoseconds.  AcquireWriteAddress() captures the deadline at function entry and bails out (returns nullptr) on either of the two yield-loop paths if the deadline is exceeded.

## Interaction with existing upstream knobs

- HSA_SIGNAL_WAIT_ABORT_TIMEOUT (existing) is unchanged and orthogonal.  Set it LARGER than ROCR_SIGNAL_WAIT_MAX_MS to retain a hard-abort backstop on top of the new non-abort cap.

- The existing HW exception ECC abort path is preserved (ROCR_SERVICE_SURVIVAL does NOT suppress ECC).

## JIRA ID

ROCM-21571

## Test Plan

Reproducer: 8 host threads, RDMA-Write + signal_wait, random GPU eviction, occasional SDMA wedge.  Open-source reproducer to be added in a follow-up test patch.

Expected behaviour:
- All three envs unset (default): unchanged behaviour, all existing tests pass byte-identically.
- ROCR_SERVICE_SURVIVAL=1: VM fault / non-ECC HW exception / memory error returns error status to the caller instead of taking down the process.  ECC HW exception still aborts.
- ROCR_SIGNAL_WAIT_MAX_MS=2000: WaitRelaxed returns partial value after 2 seconds when signal is wedged.
- ROCR_SDMA_WRITE_ADDR_FAIL_MS=500: AcquireWriteAddress returns nullptr after 500 ms when SDMA ring is stuck full.

## Test Result

Linear scaling confirmed at sub-second values for
ROCR_SIGNAL_WAIT_MAX_MS:
    =500   max repro wait = 515 ms
    =200   max repro wait = 213 ms
    =100   max repro wait = 114 ms

hip-tests / rocrtst unit suites pass at default (all three envs unset) -- no behavioural change for stock callers.

11+ hours of multi-tenant HIP serving load on a customer MI300X stable with these three ROCr envs set; companion CLR-side and kernel-side knobs shipped via independent sibling PRs.

## History

Equivalent functional behaviour shipped in an internal rocr fork. Re-scoped here as a standalone upstream PR (no master switch gating between the three knobs, no wait_hint forcing) per the review pattern on rocm-systems #4911.

Made-with: chun-wan / cursor

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
