### PR TITLE
test_runner: add missing net_ib_branch_coverage config

### DIFF
--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -1001,6 +1001,18 @@
       ]
     },
 
+    "net_ib_branch_coverage": {
+      "extends": "net_ib_base",
+      "timeout": 60,
+      "tests": [
+        { "name": "NetIB_Branch_InvalidRecvCount",  "description": "irecv n>8 returns ncclInternalError (net_ib.cc early-return branch)",               "test_filter": "NetIbMPITest.InvalidRecvCount" },
+        { "name": "NetIB_Branch_MrCacheRefCount",   "description": "Double-register same buffer: refs reach 2, first dereg keeps MR, second frees it",  "test_filter": "NetIbMPITest.MrCacheRefCount" },
+        { "name": "NetIB_Branch_SendSizeClamping",  "description": "isend with size > maxRecvs*maxSize is clamped to maxSize, data integrity verified",  "test_filter": "NetIbMPITest.SendSizeClamping" },
+        { "name": "NetIB_Branch_NullCommClose",     "description": "closeSend/closeRecv/closeListen on NULL comm returns ncclSuccess without crash",     "test_filter": "NetIbMPITest.NullCommClose" },
+        { "name": "NetIB_Branch_SetNetAttrNoOp",    "description": "ncclNetPlugin_v9.setAttr returns ncclSuccess for all known attribute types",         "test_filter": "NetIbMPITest.SetNetAttrNoOp" }
+      ]
+    },
+
     "net_ib_stress": {
       "extends": "net_ib_base",
       "timeout": 600,


### PR DESCRIPTION
## Motivation

```
Traceback (most recent call last):
  File "/projects/math-ci/slurm-batch-submitter-1/workspace/_batch-codecoverage_rccl_PR-6321/run2/rccl/projects/rccl/tools/scripts/test_runner/test_runner.py", line 76, in main
    test_suites = config_processor.parse_test_suites()
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/projects/math-ci/slurm-batch-submitter-1/workspace/_batch-codecoverage_rccl_PR-6321/run2/rccl/projects/rccl/tools/scripts/test_runner/lib/test_config.py", line 292, in parse_test_suites
    combined_config = self.combine_configs(config_name)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/projects/math-ci/slurm-batch-submitter-1/workspace/_batch-codecoverage_rccl_PR-6321/run2/rccl/projects/rccl/tools/scripts/test_runner/lib/test_config.py", line 142, in combine_configs
    raise ValueError(
ValueError: Configuration 'net_ib_branch_coverage' not found in test_configurations. Available: default, shm_comprehensive, p2p_comprehensive, net_transport_eth_multinode, net_ib_base, net_ib_initialization, net_ib_properties, net_ib_connection, net_ib_memory, net_ib_transfer, net_ib_multirecv, net_ib_cts_stress, unit_tests_fixtures, unit_tests_fixtures_debug, unit_tests_standard, debug_tests, alt_rsmi_tests, implicit_launch_order, comm_mpi_tests, ubr_multi_node, ubr_concurrent_reg_hang, cast_base, cast_wrr_split, cast_wrr_no_split, cast_single_qp, cast_four_qp, cast_max_qp, cast_stress, fault_inject_cast, graph_capture_multi_node, net_ib_stress, net_ib_stress_4rank, net_ib_stress_multi_qp_split, net_ib_stress_multi_qp_nosplit, net_ib_stress_multi_qp_fanin, net_ib_stress_ar, net_ib_stress_inline
```

## Technical Details

test_runner: add missing net_ib_branch_coverage config to the mellanox config

## JIRA ID

AICOMRCCL-1069

## Test Plan

Run the tests with the updated config.

## Test Result

No failure

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
