### PR TITLE
move warpLevelComm to ncclDevKernelArgs

### DIFF
--- a/projects/rccl/src/include/device.h
+++ b/projects/rccl/src/include/device.h
@@ -590,7 +590,6 @@ struct ncclKernelComm {
   int isAllNvlink;
   int p2pnChannelsPerPeer;
   int p2pChannelShiftSize; // [RCCL] Modifies how parts are mapped to p2p channels
-  int warpLevelComm;
   int* collNetDenseToUserRank;
 
   // Flag to ask NCCL kernels to abort
@@ -631,11 +630,13 @@ struct channelMasks {
 
 struct alignas(16) ncclDevKernelArgs {
   struct ncclKernelComm* comm;
+#ifdef ENABLE_WARP_SPEED
+  int warpLevelComm;
+#endif
   struct channelMasks channelMask;
   enum ncclDevWorkStorageType workStorageType;
   uint32_t workMask;
   void* workBuf;
-  int warpLevelComm;
   // A channel's first batch is at `blockIdx.x`. Use `nextJump` to follow rest of list.
   // struct ncclDevWorkBatch batches[];
 };

--- a/projects/rccl/src/include/device.h
+++ b/projects/rccl/src/include/device.h
@@ -651,7 +651,6 @@ struct ncclKernelComm {
   int isAllNvlink;
   int p2pnChannelsPerPeer;
   int p2pChannelShiftSize; // [RCCL] Modifies how parts are mapped to p2p channels
-  int warpLevelComm;
   int* collNetDenseToUserRank;
 
   // Flag to ask NCCL kernels to abort
@@ -707,11 +706,13 @@ struct channelMasks {
 
 struct alignas(16) ncclDevKernelArgs {
   struct ncclKernelComm* comm;
+#ifdef ENABLE_WARP_SPEED
+  int warpLevelComm;
+#endif
   struct channelMasks channelMask;
   enum ncclDevWorkStorageType workStorageType;
   uint32_t workMask;
   void* workBuf;
-  int warpLevelComm;
   // A channel's first batch is at `blockIdx.x`. Use `nextJump` to follow rest of list.
   // struct ncclDevWorkBatch batches[];
 };

--- a/projects/rccl/src/include/rccl_common.h
+++ b/projects/rccl/src/include/rccl_common.h
@@ -141,6 +141,8 @@ RCCL_PARAM_DECLARE(DdaEnable);
 int getFirmwareVersion();
 bool rcclIsArchSupportedForFunc(struct ncclTaskColl* info, char const* archName);
 #ifdef ENABLE_WARP_SPEED
+RCCL_PARAM_DECLARE(WarpSpeedARThreshold);
+RCCL_PARAM_DECLARE(WarpSpeedAutoMode);
 void rcclSetWarpSpeedCUs(struct ncclComm* comm, int algo, int threadsPerBlock, int& rcclWarpSpeedChannels);
 bool rcclWarpSpeedSupported(struct ncclComm* comm, struct ncclKernelPlan* plan);
 ncclResult_t rcclSetWarpSpeedAuto(struct ncclComm* comm, struct ncclTaskColl* info, size_t nBytes);

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -311,6 +311,7 @@ if(BUILD_TESTS)
       transport/GinMPI/GinMPITests.cpp
       transport/NetIbMPI/StressTests.cpp
       transport/GinDeviceMPITests.cpp
+      WarpSpeedMPITests.cpp
       ImplicitLaunchOrderMPITests.cpp
       CommMPITests.cpp
       RegistrationMPITests.cpp

--- a/projects/rccl/test/WarpSpeedMPITests.cpp
+++ b/projects/rccl/test/WarpSpeedMPITests.cpp
@@ -1,0 +1,269 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+/*
+    This test evaluates the capability of the WarpSpeed feature to correctly
+    handle back-to-back enqueues of different message sizes, both below and
+    above the threshold, without synchronization.
+    One test runs with WarpSpeed disabled to provide context on whether any
+    failures are directly related to to WarpSpeed.
+*/
+
+#include "DeviceBufferHelpers.hpp"
+#include "MPITestBase.hpp"
+#include "ResourceGuards.hpp"
+#include "TestChecks.hpp"
+#include "comm.h"
+#include "rccl_common.h"
+
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+
+#ifdef ENABLE_WARP_SPEED
+
+using namespace MPITestConstants;
+using namespace RCCLTestGuards;
+using namespace RCCLTestHelpers;
+
+namespace WarpSpeedConstants
+{
+    constexpr int64_t kSmallBufferThresholdDivisor    = 64;
+    constexpr int64_t kLargeBufferThresholdMultiplier = 2;
+
+    inline size_t smallBufferElementCount(int64_t threshold_bytes)
+    {
+        const int64_t bytes = threshold_bytes / kSmallBufferThresholdDivisor;
+        return static_cast<size_t>(bytes / static_cast<int64_t>(sizeof(hip_bfloat16)));
+    }
+
+    inline size_t largeBufferElementCount(int64_t threshold_bytes)
+    {
+        const int64_t bytes = threshold_bytes * kLargeBufferThresholdMultiplier;
+        return static_cast<size_t>(bytes / static_cast<int64_t>(sizeof(hip_bfloat16)));
+    }
+
+    constexpr int kSmallOpsBefore = 10;
+    constexpr int kSmallOpsAfter  = 10;
+
+    constexpr int kTrainIterations = 30;
+}
+
+using namespace WarpSpeedConstants;
+
+static void setWarpSpeedAutoEnv(const char* value)
+{
+    ASSERT_EQ(setenv("RCCL_WARP_SPEED_AUTO", value, 1), 0)
+        << "Failed to set RCCL_WARP_SPEED_AUTO";
+    TEST_INFO("RCCL_WARP_SPEED_AUTO=%s", value);
+}
+
+class WarpSpeedMPITest : public MPITestBase
+{
+protected:
+    hipStream_t stream_{};
+    void*       d_small_{};
+    void*       d_large_{};
+    int64_t     ar_threshold_bytes_{};
+    size_t      small_count_{};
+    size_t      large_count_{};
+
+    void skipUnlessWarpSpeedAutoDisabled()
+    {
+        if(rcclParamWarpSpeedAutoMode() != 0)
+        {
+            GTEST_SKIP() << "RCCL_WARP_SPEED_AUTO is not 0 (WarpSpeed auto still enabled)";
+        }
+    }
+
+    void skipUnlessWarpSpeedAutoEnabled()
+    {
+        if(rcclParamWarpSpeedAutoMode() == 0)
+        {
+            GTEST_SKIP() << "RCCL_WARP_SPEED_AUTO is not 1 (WarpSpeed auto not enabled)";
+        }
+        struct ncclComm* comm = reinterpret_cast<struct ncclComm*>(getActiveCommunicator());
+        if(!rcclCanUseWarpSpeedAuto(comm, comm->nNodes))
+        {
+            GTEST_SKIP() << "RCCL_WARP_SPEED_AUTO=1 but auto mode unavailable (gfx950, "
+                            "single-node required)";
+        }
+    }
+
+    void initBufferCounts()
+    {
+        ar_threshold_bytes_ = rcclParamWarpSpeedARThreshold();
+        ASSERT_GE(ar_threshold_bytes_,
+                  kSmallBufferThresholdDivisor * static_cast<int64_t>(sizeof(hip_bfloat16)))
+            << "RCCL_WARP_SPEED_AR_THRESHOLD too small for small buffer (threshold/64)";
+        small_count_ = smallBufferElementCount(ar_threshold_bytes_);
+        large_count_ = largeBufferElementCount(ar_threshold_bytes_);
+        TEST_INFO("RCCL_WARP_SPEED_AR_THRESHOLD=%ld bytes, small=%zu elems (%ld bytes), "
+                  "large=%zu elems (%ld bytes)",
+                  static_cast<long>(ar_threshold_bytes_),
+                  small_count_,
+                  static_cast<long>(small_count_ * sizeof(hip_bfloat16)),
+                  large_count_,
+                  static_cast<long>(large_count_ * sizeof(hip_bfloat16)));
+    }
+
+    void TearDown() override
+    {
+        if(d_small_) { hipFree(d_small_); d_small_ = nullptr; }
+        if(d_large_) { hipFree(d_large_); d_large_ = nullptr; }
+        if(stream_)
+        {
+            hipStreamSynchronize(stream_);
+            hipStreamDestroy(stream_);
+            stream_ = {};
+        }
+        MPITestBase::TearDown();
+    }
+
+    ncclResult_t allocateBuffers()
+    {
+        HIPCHECK(hipMalloc(&d_small_, small_count_ * sizeof(hip_bfloat16)));
+        HIPCHECK(hipMalloc(&d_large_, large_count_ * sizeof(hip_bfloat16)));
+        return ncclSuccess;
+    }
+
+    /** Expected value after numInPlaceSumOps consecutive in-place AllReduce sums. */
+    static double expectedInPlaceAllReduceSum(int nranks, int numInPlaceSumOps)
+    {
+        const double base = static_cast<double>(nranks) * (nranks - 1) / 2.0;
+        if(numInPlaceSumOps <= 1)
+            return base;
+        return base * std::pow(static_cast<double>(nranks), numInPlaceSumOps - 1);
+    }
+
+    ncclResult_t prepareIteration()
+    {
+        const int rank = MPIEnvironment::world_rank;
+        const auto pattern = [rank](size_t) {
+            return hip_bfloat16(static_cast<float>(rank));
+        };
+        HIPCHECK(initializeBufferWithPattern<hip_bfloat16>(d_small_, small_count_, pattern));
+        HIPCHECK(initializeBufferWithPattern<hip_bfloat16>(d_large_, large_count_, pattern));
+        return ncclSuccess;
+    }
+
+    bool verifyBuffers(double expected_small,
+                      double expected_large) const
+    {
+        const auto expect_small = [expected_small](size_t) {
+            return hip_bfloat16(static_cast<float>(expected_small));
+        };
+        const auto expect_large = [expected_large](size_t) {
+            return hip_bfloat16(static_cast<float>(expected_large));
+        };
+        const bool small_ok = verifyBufferData<hip_bfloat16>(
+            d_small_, small_count_, expect_small);
+        const bool large_ok = verifyBufferData<hip_bfloat16>(
+            d_large_, large_count_, expect_large);
+        return small_ok && large_ok;
+    }
+
+    void runValidatedTrainingLoop()
+    {
+        const int    nranks         = MPIEnvironment::world_size;
+        const int    small_ops      = kSmallOpsBefore + kSmallOpsAfter;
+        const double expected_small = expectedInPlaceAllReduceSum(nranks, small_ops);
+        const double expected_large = expectedInPlaceAllReduceSum(nranks, 1);
+
+        int correct_count = 0;
+        int wrong_count   = 0;
+
+        for(int iter = 0; iter < kTrainIterations; iter++)
+        {
+            ASSERT_MPI_EQ(ncclSuccess, prepareIteration());
+            ASSERT_MPI_EQ(ncclSuccess, submitIteration());
+
+            if(verifyBuffers(expected_small, expected_large))
+                correct_count++;
+            else
+                wrong_count++;
+        }
+
+        TEST_INFO("Expected small: %.6g (%d ops), large: %.6g (1 op), Correct: %d/%d, Wrong: %d",
+                  expected_small,
+                  small_ops,
+                  expected_large,
+                  correct_count,
+                  kTrainIterations,
+                  wrong_count);
+
+        EXPECT_EQ(correct_count, kTrainIterations)
+            << "AllReduce result mismatch on small and/or large buffer (possible silent "
+               "corruption)";
+    }
+
+    ncclResult_t submitIteration()
+    {
+        ncclComm_t comm = getActiveCommunicator();
+
+        for(int i = 0; i < kSmallOpsBefore; i++)
+            RCCL_TEST_CHECK(ncclAllReduce(d_small_, d_small_, small_count_,
+                                          ncclBfloat16, ncclSum, comm, stream_));
+
+        RCCL_TEST_CHECK(ncclAllReduce(d_large_, d_large_, large_count_,
+                                      ncclBfloat16, ncclSum, comm, stream_));
+
+        for(int i = 0; i < kSmallOpsAfter; i++)
+            RCCL_TEST_CHECK(ncclAllReduce(d_small_, d_small_, small_count_,
+                                          ncclBfloat16, ncclSum, comm, stream_));
+
+        HIPCHECK(hipStreamSynchronize(stream_));
+        return ncclSuccess;
+    }
+};
+
+// Sanity test: WarpSpeed disabled
+TEST_F(WarpSpeedMPITest, Disabled)
+{
+    int  min_processes = 8;
+    int  max_processes = 8;
+    int  min_nodes     = 1;
+    int  max_nodes     = 1;
+    ASSERT_TRUE(validateTestPrerequisites(min_processes, max_processes, kNoPowerOfTwoRequired, min_nodes, max_nodes))
+        << "Requires exactly 8 ranks on a single node";
+
+    setWarpSpeedAutoEnv("0");
+    ASSERT_EQ(ncclSuccess, createTestCommunicator());
+    skipUnlessWarpSpeedAutoDisabled();
+    HIP_TEST_CHECK_GTEST_FAIL(hipStreamCreate(&stream_));
+    initBufferCounts();
+    ASSERT_MPI_EQ(ncclSuccess, allocateBuffers());
+
+    runValidatedTrainingLoop();
+
+    TEST_INFO("Sanity passed: %d iterations, no hang", kTrainIterations);
+}
+
+TEST_F(WarpSpeedMPITest, MixedThresholdRace)
+{
+    int  min_processes = 8;
+    int  max_processes = 8;
+    int  min_nodes     = 1;
+    int  max_nodes     = 1;
+    ASSERT_TRUE(validateTestPrerequisites(min_processes, max_processes, kNoPowerOfTwoRequired, min_nodes, max_nodes))
+        << "Requires exactly 8 ranks on a single node";
+
+    setWarpSpeedAutoEnv("1");
+    ASSERT_EQ(ncclSuccess, createTestCommunicator());
+    skipUnlessWarpSpeedAutoEnabled();
+    HIP_TEST_CHECK_GTEST_FAIL(hipStreamCreate(&stream_));
+    initBufferCounts();
+    ASSERT_MPI_EQ(ncclSuccess, allocateBuffers());
+
+    TEST_INFO("%d non-WS + 1 WS + %d non-WS AllReduce per iter, no intermediate sync",
+              kSmallOpsBefore, kSmallOpsAfter);
+
+    runValidatedTrainingLoop();
+
+    TEST_INFO("All %d iterations passed", kTrainIterations);
+}
+
+#endif // ENABLE_WARP_SPEED

--- a/projects/rccl/test/WarpSpeedMPITests.cpp
+++ b/projects/rccl/test/WarpSpeedMPITests.cpp
@@ -8,8 +8,8 @@
     This test evaluates the capability of the WarpSpeed feature to correctly
     handle back-to-back enqueues of different message sizes, both below and
     above the threshold, without synchronization.
-    One test runs with WarpSpeed disabled to provide context on whether any
-    failures are directly related to to WarpSpeed.
+    This test is requires warpSpeed enablement and will skip if RCCL_WARP_SPEED_AUTO=0 
+    or if architecture doesn't support warpSpeed.
 */
 
 #include "DeviceBufferHelpers.hpp"
@@ -54,13 +54,6 @@ namespace WarpSpeedConstants
 
 using namespace WarpSpeedConstants;
 
-static void setWarpSpeedAutoEnv(const char* value)
-{
-    ASSERT_EQ(setenv("RCCL_WARP_SPEED_AUTO", value, 1), 0)
-        << "Failed to set RCCL_WARP_SPEED_AUTO";
-    TEST_INFO("RCCL_WARP_SPEED_AUTO=%s", value);
-}
-
 class WarpSpeedMPITest : public MPITestBase
 {
 protected:
@@ -70,14 +63,6 @@ protected:
     int64_t     ar_threshold_bytes_{};
     size_t      small_count_{};
     size_t      large_count_{};
-
-    void skipUnlessWarpSpeedAutoDisabled()
-    {
-        if(rcclParamWarpSpeedAutoMode() != 0)
-        {
-            GTEST_SKIP() << "RCCL_WARP_SPEED_AUTO is not 0 (WarpSpeed auto still enabled)";
-        }
-    }
 
     void skipUnlessWarpSpeedAutoEnabled()
     {
@@ -220,28 +205,6 @@ protected:
     }
 };
 
-// Sanity test: WarpSpeed disabled
-TEST_F(WarpSpeedMPITest, Disabled)
-{
-    int  min_processes = 8;
-    int  max_processes = 8;
-    int  min_nodes     = 1;
-    int  max_nodes     = 1;
-    ASSERT_TRUE(validateTestPrerequisites(min_processes, max_processes, kNoPowerOfTwoRequired, min_nodes, max_nodes))
-        << "Requires exactly 8 ranks on a single node";
-
-    setWarpSpeedAutoEnv("0");
-    ASSERT_EQ(ncclSuccess, createTestCommunicator());
-    skipUnlessWarpSpeedAutoDisabled();
-    HIP_TEST_CHECK_GTEST_FAIL(hipStreamCreate(&stream_));
-    initBufferCounts();
-    ASSERT_MPI_EQ(ncclSuccess, allocateBuffers());
-
-    runValidatedTrainingLoop();
-
-    TEST_INFO("Sanity passed: %d iterations, no hang", kTrainIterations);
-}
-
 TEST_F(WarpSpeedMPITest, MixedThresholdRace)
 {
     int  min_processes = 8;
@@ -251,7 +214,6 @@ TEST_F(WarpSpeedMPITest, MixedThresholdRace)
     ASSERT_TRUE(validateTestPrerequisites(min_processes, max_processes, kNoPowerOfTwoRequired, min_nodes, max_nodes))
         << "Requires exactly 8 ranks on a single node";
 
-    setWarpSpeedAutoEnv("1");
     ASSERT_EQ(ncclSuccess, createTestCommunicator());
     skipUnlessWarpSpeedAutoEnabled();
     HIP_TEST_CHECK_GTEST_FAIL(hipStreamCreate(&stream_));

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_single_node.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_single_node.json
@@ -1,0 +1,70 @@
+{
+  "system_configurations": {
+    "name": "RCCL-Tests-MI355X-Single-Node",
+    "description": "MI355X (gfx950) single-node RCCL test configuration — WarpSpeed MPI tests"
+  },
+  "paths": {
+    "workdir": "${WORKDIR:-$PWD}",
+    "rocm_path": "${ROCM_PATH:-/opt/rocm}",
+    "mpi_path": "${MPI_PATH:-/opt/ompi}"
+  },
+  "env_variables": {
+    "HSA_NO_SCRATCH_RECLAIM": "1",
+    "NCCL_DEBUG": "INFO"
+  },
+  "build_configuration": {
+    "install_flags": ["--debug", "-t", "-l", "--enable-mpi-tests", "--no_clean"],
+    "cmake_options": "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DENABLE_WARP_SPEED=ON",
+    "parallel_jobs": 64
+  },
+  "test_configurations": {
+    "default": {
+      "env_variables": {
+        "NCCL_LAUNCH_MODE": "GROUP"
+      },
+      "rerun_env_variables": {
+        "NCCL_DEBUG": "INFO"
+      }
+    },
+    "warp_speed_mpi": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 8,
+      "num_nodes": 1,
+      "num_gpus": 8,
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_DEBUG": "INFO"
+      },
+      "tests": [
+        {
+          "name": "WarpSpeed_MixedThresholdRace_AutoEnabled",
+          "description": "WarpSpeed back-to-back AllReduce enqueue race with RCCL_WARP_SPEED_AUTO=1 (8 ranks, single node)",
+          "test_filter": "WarpSpeedMPITest.*",
+          "timeout": 180,
+          "env_variables": {
+            "RCCL_WARP_SPEED_AUTO": "1"
+          }
+        },
+        {
+          "name": "WarpSpeed_MixedThresholdRace_AutoDisabled",
+          "description": "Same test with RCCL_WARP_SPEED_AUTO=0 — expects GTEST_SKIP (WarpSpeed auto disabled)",
+          "test_filter": "WarpSpeedMPITest.*",
+          "timeout": 180,
+          "env_variables": {
+            "RCCL_WARP_SPEED_AUTO": "0"
+          }
+        }
+      ]
+    }
+  },
+  "test_suites": [
+    {
+      "name": "WarpSpeed MPI Tests - Single Node 8 Ranks",
+      "description": "WarpSpeed MPI tests with auto mode enabled and disabled (RCCL_WARP_SPEED_AUTO=1/0)",
+      "config": "warp_speed_mpi",
+      "enabled": true
+    }
+  ]
+}


### PR DESCRIPTION
## Motivation

On RCCL build based on commit `fa36124`, a hang was observed with 1N workload when warpSpeed was enabled.

## Technical Details

The hang was caused by warpSpeed enablement flag that was stored in communicator instead of kernelArgs. 
This caused corruption as subsequent calls to allReduce would override the common flag in the communicator based on message size being above or below the warpSpeed message size threshold of 64MB.
Original fix on top of commit `fa36124` involved moving the `warpLevelComm` flag to `ncclDevKernelArgs`.
This was also partially done by a commit `5b3d826` which is more recent than `fa36124` and had added a flag to  `ncclDevKernelArgs` but had not removed it from the communicator.

## JIRA ID

AICOMRCCL-1034

## Test Plan

`fa36124` based fix was tested with  PyTorch reproducer.
After rebasing to current rccl-develop, the fix was tested on PyTorch reproducer.
Add new unit-test to rccl unit tests and tested on a branch where the warpLevelComm was moved back to the communicator.

## Test Result

`fa36124` based fix run on PyTorch reproducer without triggering a hang.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
