### PR TITLE
[rocprofiler-sdk] add check to keep loads of nameless kernels from producing a warning

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
@@ -282,9 +282,8 @@ iterate_args_callback(rocprofiler_buffer_tracing_kind_t /*kind*/,
     auto* _data = static_cast<function_args_t*>(data);
     if(arg_type && arg_name && arg_value_str)
     {
-        const char* arg_val = *arg_value_str != '\0' ? arg_value_str : "<unknown>";
         _data->emplace_back(
-            argument_info{arg_number, common::cxx_demangle(arg_type), arg_name, arg_val});
+            argument_info{arg_number, common::cxx_demangle(arg_type), arg_name, arg_value_str});
     }
     return 0;
 }
@@ -1839,15 +1838,16 @@ write_rocpd(
                 {
                     auto demangled_type = common::cxx_demangle(arg_info.arg_type);
 
-                    get_insert_statement(db,
-                                         "rocpd_arg{{uuid}}",
-                                         {
-                                             insert_value("event_id", evt_id),
-                                             insert_value("position", arg_info.arg_number),
-                                             insert_value("type", demangled_type),
-                                             insert_value("name", arg_info.arg_name),
-                                             insert_value("value", arg_info.arg_value),
-                                         });
+                    get_insert_statement(
+                        db,
+                        "rocpd_arg{{uuid}}",
+                        {
+                            insert_value("event_id", evt_id),
+                            insert_value("position", arg_info.arg_number),
+                            insert_value("type", demangled_type),
+                            insert_value("name", arg_info.arg_name),
+                            insert_value("value", arg_info.arg_value, allow_empty_string{}),
+                        });
                 }
 
                 if(itr.start_timestamp != itr.end_timestamp)

--- a/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
@@ -280,9 +280,11 @@ iterate_args_callback(rocprofiler_buffer_tracing_kind_t /*kind*/,
     ROCP_FATAL_IF(data == nullptr) << "nullptr to data for iterate_args_callback";
 
     auto* _data = static_cast<function_args_t*>(data);
-    if(arg_type && arg_name && arg_value_str && *arg_value_str != '\0')
+    if(arg_type && arg_name && arg_value_str) {
+        const char* arg_val = *arg_value_str != '\0' ? arg_value_str : "<unknown>";
         _data->emplace_back(
-            argument_info{arg_number, common::cxx_demangle(arg_type), arg_name, arg_value_str});
+            argument_info{arg_number, common::cxx_demangle(arg_type), arg_name, arg_val});
+    }
     return 0;
 }
 

--- a/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
@@ -280,7 +280,8 @@ iterate_args_callback(rocprofiler_buffer_tracing_kind_t /*kind*/,
     ROCP_FATAL_IF(data == nullptr) << "nullptr to data for iterate_args_callback";
 
     auto* _data = static_cast<function_args_t*>(data);
-    if(arg_type && arg_name && arg_value_str) {
+    if(arg_type && arg_name && arg_value_str)
+    {
         const char* arg_val = *arg_value_str != '\0' ? arg_value_str : "<unknown>";
         _data->emplace_back(
             argument_info{arg_number, common::cxx_demangle(arg_type), arg_name, arg_val});

--- a/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
@@ -280,7 +280,7 @@ iterate_args_callback(rocprofiler_buffer_tracing_kind_t /*kind*/,
     ROCP_FATAL_IF(data == nullptr) << "nullptr to data for iterate_args_callback";
 
     auto* _data = static_cast<function_args_t*>(data);
-    if(arg_type && arg_name && arg_value_str)
+    if(arg_type && arg_name && arg_value_str && *arg_value_str != '\0')
         _data->emplace_back(
             argument_info{arg_number, common::cxx_demangle(arg_type), arg_name, arg_value_str});
     return 0;


### PR DESCRIPTION
## Motivation
This PR addresses AIPROFSDK-829, which is about nightly builds crashing when profiling a particular HIP application.

## Technical Details
A HIP application may load a kernel via hipModuleGetFunction without providing a kernel name. Currently, this causes rocprof to generate a warning when recording the event due to the value field being empty. In CI builds, warning logs are overridden to be fatal, thus causing the nightlies to crash.

This commit extends the check in iterate_args_callback to omit recording the argument if the value string is empty.

## JIRA ID
Addresses AIPROFSDK-829.

## Test Plan
Ran unit test suite and reran target application with CI defines set and unset.

## Test Result
All unit tests run and pass. [testOutput.txt](https://github.com/user-attachments/files/28071933/testOutput.txt)
Target application in ticket now runs without crashing, regardless of CI flag status.

## Submission Checklist
- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
