### PR TITLE
clr: Execution ctx fix CU alignment based on arch type

### DIFF
--- a/projects/clr/hipamd/src/hip_executionctx.cpp
+++ b/projects/clr/hipamd/src/hip_executionctx.cpp
@@ -25,14 +25,14 @@ ExecutionCtx::ExecutionCtx(int deviceId, DevResourceDesc* desc, uint32_t flags)
       ctxId_(nextCtxId_.fetch_add(1)) {}
 
 hipError_t ExecutionCtx::Create() {
-  hipDeviceProp_t prop{};
-  hipError_t status = ihipGetDeviceProperties(&prop, deviceId_);
-  if (status != hipSuccess) return status;
-
-  uint32_t totalCUs = static_cast<uint32_t>(prop.multiProcessorCount);
-  uint32_t maskWords = (totalCUs + 31) / 32;
-
+  uint32_t totalCUs = getTotalCuCount(deviceId_);
+  if (totalCUs == 0) return hipErrorInvalidConfiguration;
+  uint32_t alignment = getSmAlignment(deviceId_);
+  uint32_t totalWGPs = (alignment > 1) ? (totalCUs / alignment) : totalCUs;
+  uint32_t maskWords = (totalWGPs + 31) / 32;
   cuMask_.resize(maskWords, 0);
+  LogPrintfInfo("[ExecCtx] Create: deviceId=%d totalCUs=%u alignment=%u totalWGPs=%u maskWords=%u",
+                deviceId_, totalCUs, alignment, totalWGPs, maskWords);
   for (const auto& res : resourceDesc_->resources) {
     if (res.type == hipDevResourceTypeSm) {
       cuCount_ += res.sm.smCount;
@@ -42,11 +42,15 @@ hipError_t ExecutionCtx::Create() {
         const auto* meta = lookupResourceMeta(deviceId_, resId);
         if (meta != nullptr) startCU = meta->startCU;
       }
-      auto partial = buildCuMask(startCU, res.sm.smCount, totalCUs);
+      LogPrintfInfo("[ExecCtx] Create: resId=%u smCount=%u startCU=%u cuCount_=%u",
+                    resId, res.sm.smCount, startCU, cuCount_);
+      auto partial = buildCuMask(startCU, res.sm.smCount, totalCUs, alignment);
       for (uint32_t w = 0; w < maskWords && w < partial.size(); w++)
         cuMask_[w] |= partial[w];
     }
   }
+  LogPrintfInfo("[ExecCtx] Create done: ctxId=%llu cuCount_=%u mask[0]=0x%08x",
+                ctxId_, cuCount_, maskWords > 0 ? cuMask_[0] : 0u);
   return hipSuccess;
 }
 
@@ -94,12 +98,21 @@ void ExecutionCtx::fillRemainder(hipDevResource* remainder, uint32_t remainingCU
 }
 
 std::vector<uint32_t> ExecutionCtx::buildCuMask(uint32_t startCU, uint32_t count,
-                                             uint32_t totalCUs) {
-  uint32_t maskWords = (totalCUs + 31) / 32;
+                                             uint32_t totalCUs, uint32_t alignment) {
+  // Each mask bit represents one WGP (alignment CUs). Convert CU units to WGP units.
+  uint32_t totalWGPs = (alignment > 1) ? (totalCUs / alignment) : totalCUs;
+  uint32_t maskWords = (totalWGPs + 31) / 32;
   std::vector<uint32_t> mask(maskWords, 0);
-  for (uint32_t i = startCU; i < startCU + count && i < totalCUs; i++) {
+  uint32_t startWGP = startCU / alignment;
+  uint32_t wgpCount = count / alignment;
+  for (uint32_t i = startWGP; i < startWGP + wgpCount && i < totalWGPs; i++) {
     mask[i / 32] |= (1u << (i % 32));
   }
+  LogPrintfInfo("[ExecCtx] buildCuMask: startCU=%u count=%u totalCUs=%u alignment=%u "
+                "-> startWGP=%u wgpCount=%u totalWGPs=%u maskWords=%u mask[0]=0x%08x",
+                startCU, count, totalCUs, alignment,
+                startWGP, wgpCount, totalWGPs, maskWords,
+                maskWords > 0 ? mask[0] : 0u);
   return mask;
 }
 
@@ -107,10 +120,23 @@ uint32_t ExecutionCtx::getSmAlignment(int deviceId) {
   return g_devices[deviceId]->devices()[0]->settings().enableWgpMode_ ? 2 : 1;
 }
 
+uint32_t ExecutionCtx::getTotalCuCount(int deviceId) {
+  hipDeviceProp_t prop{};
+  hipError_t status = ihipGetDeviceProperties(&prop, deviceId);
+  if (status != hipSuccess) {
+    LogPrintfError("Can't read device props for device id : %d", deviceId);
+    return 0;
+  }
+  uint32_t alignment = getSmAlignment(deviceId);
+  return static_cast<uint32_t>(prop.multiProcessorCount) * alignment;
+}
+
 void ExecutionCtx::tagResource(hipDevResource* res, uint32_t resourceId, int deviceId) {
   std::memcpy(&res->_internal_padding[0], &resourceId, sizeof(uint32_t));
   int32_t devId = static_cast<int32_t>(deviceId);
   std::memcpy(&res->_internal_padding[4], &devId, sizeof(int32_t));
+  LogPrintfInfo("[ExecCtx] tagResource: resourceId=%u deviceId=%d smCount=%u alignment=%u",
+                resourceId, deviceId, res->sm.smCount, res->sm.smCoscheduledAlignment);
 }
 
 uint32_t ExecutionCtx::readResourceId(const hipDevResource* res) {
@@ -127,6 +153,8 @@ int ExecutionCtx::readDeviceId(const hipDevResource* res) {
 
 void ExecutionCtx::registerResourceMeta(int deviceId, uint32_t resourceId,
                                     uint32_t familyId, uint32_t startCU) {
+  LogPrintfInfo("[ExecCtx] registerResourceMeta: deviceId=%d resourceId=%u familyId=%u startCU=%u",
+                deviceId, resourceId, familyId, startCU);
   g_devices[deviceId]->registerResource(resourceId, familyId, startCU);
 }
 
@@ -196,7 +224,6 @@ hipError_t ExecutionCtx::recordEvent(hipEvent_t event) {
     snapshot[0]->release();
     return err;
   }
-  
   std::scoped_lock lock(e->lock());
 
   amd::Command::EventWaitList waitList;
@@ -220,7 +247,6 @@ hipError_t ExecutionCtx::recordEvent(hipEvent_t event) {
     cmd->enqueue();
     waitList.push_back(&cmd->event());
   }
-  
   // Create a single Marker to wait on all events in waitlist
   // Cache Flush not required for this fan-in marker
   amd::Command* fanIn = new amd::Marker(*snapshot[0], kMarkerDisableFlush, waitList);
@@ -256,7 +282,6 @@ hipError_t ExecutionCtx::waitEvent(hipEvent_t event) {
 hipError_t ExecutionCtx::deviceGetDevResource(int device, hipDevResource* resource,
                                            hipDevResourceType type) {
   if (resource == nullptr) return hipErrorInvalidValue;
-  
   if (type != hipDevResourceTypeSm) {
     return hipErrorInvalidResourceType;
   }
@@ -266,11 +291,8 @@ hipError_t ExecutionCtx::deviceGetDevResource(int device, hipDevResource* resour
 
   std::memset(resource, 0, sizeof(hipDevResource));
   resource->type = type;
-
-  hipDeviceProp_t prop{};
-  HIP_RETURN_ONFAIL(ihipGetDeviceProperties(&prop, device));
+  uint32_t cuCount = getTotalCuCount(device);
   uint32_t alignment = getSmAlignment(device);
-  uint32_t cuCount = static_cast<uint32_t>(prop.multiProcessorCount) * alignment;
 
   resource->sm.smCount = cuCount;
   resource->sm.minSmPartitionSize = alignment;
@@ -299,6 +321,8 @@ hipError_t ExecutionCtx::devSmResourceSplitByCount(
   if (alignedMin == 0) alignedMin = alignment;
 
   uint32_t possibleGroups = totalCUs / alignedMin;
+  LogPrintfInfo("[ExecCtx] SplitByCount: totalCUs=%u alignment=%u minCount=%u alignedMin=%u possibleGroups=%u",
+                totalCUs, alignment, minCount, alignedMin, possibleGroups);
 
   if (result == nullptr) {
     *nbGroups = possibleGroups;
@@ -315,6 +339,8 @@ hipError_t ExecutionCtx::devSmResourceSplitByCount(
 
   uint32_t actualGroups = std::min(*nbGroups, possibleGroups);
   *nbGroups = actualGroups;
+  LogPrintfInfo("[ExecCtx] SplitByCount: inputDevId=%d inputStartCU=%u familyId=%u actualGroups=%u",
+                inputDevId, inputStartCU, familyId, actualGroups);
 
   uint32_t assignedCUs = 0;
   for (uint32_t i = 0; i < actualGroups; i++) {
@@ -326,6 +352,8 @@ hipError_t ExecutionCtx::devSmResourceSplitByCount(
   }
 
   fillRemainder(remainder, totalCUs - assignedCUs, alignment);
+  LogPrintfInfo("[ExecCtx] SplitByCount done: assignedCUs=%u remainderCUs=%u",
+                assignedCUs, totalCUs - assignedCUs);
   if (remainder != nullptr && remainder->type != hipDevResourceTypeInvalid) {
     uint32_t remId = nextResourceId_.fetch_add(1);
     tagResource(remainder, remId, inputDevId);
@@ -345,6 +373,8 @@ hipError_t ExecutionCtx::devSmResourceSplit(
 
   uint32_t totalCUs = input->sm.smCount;
   uint32_t defaultAlignment = input->sm.smCoscheduledAlignment;
+  LogPrintfInfo("[ExecCtx] Split: totalCUs=%u defaultAlignment=%u nbGroups=%u",
+                totalCUs, defaultAlignment, nbGroups);
 
   for (uint32_t i = 0; i < nbGroups; i++) {
     if (groupParams[i].coscheduledSmCount == 0)
@@ -377,11 +407,13 @@ hipError_t ExecutionCtx::devSmResourceSplit(
 
   int inputDevId = readDeviceId(input);
   if (inputDevId < 0) return hipErrorInvalidDevice;
-  
   uint32_t inputStartCU = 0;
   const ResourceMeta* inputMeta = lookupResourceMeta(inputDevId, readResourceId(input));
   if (inputMeta != nullptr) inputStartCU = inputMeta->startCU;
   uint32_t familyId = nextFamilyId_.fetch_add(1);
+
+  LogPrintfInfo("[ExecCtx] Split: inputDevId=%d inputStartCU=%u familyId=%u assignedCUs=%u",
+                inputDevId, inputStartCU, familyId, assignedCUs);
 
   if (result != nullptr) {
     uint32_t cuOffset = 0;
@@ -395,6 +427,8 @@ hipError_t ExecutionCtx::devSmResourceSplit(
           !(groupParams[i].flags & hipDevSmResourceGroupBackfill))
         return hipErrorInvalidResourceConfiguration;
 
+      LogPrintfInfo("[ExecCtx] Split group[%u]: smCount=%u cosched=%u cuOffset=%u flags=0x%x",
+                    i, count, cosched, cuOffset, groupParams[i].flags);
       fillSmResult(&result[i], count, cosched, groupParams[i].flags);
       uint32_t resId = nextResourceId_.fetch_add(1);
       tagResource(&result[i], resId, inputDevId);
@@ -404,6 +438,8 @@ hipError_t ExecutionCtx::devSmResourceSplit(
   }
 
   fillRemainder(remainder, totalCUs - assignedCUs, defaultAlignment);
+  LogPrintfInfo("[ExecCtx] Split done: assignedCUs=%u remainderCUs=%u",
+                assignedCUs, totalCUs - assignedCUs);
   if (remainder != nullptr && remainder->type != hipDevResourceTypeInvalid) {
     uint32_t remId = nextResourceId_.fetch_add(1);
     tagResource(remainder, remId, inputDevId);
@@ -547,7 +583,7 @@ hipError_t hipGreenCtxCreate(hipExecutionCtx_t* phCtx, hipDevResourceDesc_t desc
   if (resourceDesc->deviceId < 0) {
     HIP_RETURN(hipErrorInvalidDevice);
   }
-  
+
   if (resourceDesc->deviceId != device) {
     HIP_RETURN(hipErrorInvalidDevice);
   }

--- a/projects/clr/hipamd/src/hip_executionctx.cpp
+++ b/projects/clr/hipamd/src/hip_executionctx.cpp
@@ -290,12 +290,10 @@ hipError_t ExecutionCtx::devSmResourceSplitByCount(
 
   if (nbGroups == nullptr || input == nullptr) return hipErrorInvalidValue;
   if (input->type != hipDevResourceTypeSm) return hipErrorInvalidResourceType;
+  if (flags & hipDevSmResourceSplitIgnoreSmCoscheduling) return hipErrorNotSupported;
 
   uint32_t totalCUs = input->sm.smCount;
   uint32_t alignment = input->sm.smCoscheduledAlignment;
-
-  if (flags & hipDevSmResourceSplitIgnoreSmCoscheduling)
-    alignment = 1;
 
   uint32_t alignedMin = ((minCount + alignment - 1) / alignment) * alignment;
   if (alignedMin == 0) alignedMin = alignment;

--- a/projects/clr/hipamd/src/hip_executionctx.cpp
+++ b/projects/clr/hipamd/src/hip_executionctx.cpp
@@ -103,6 +103,10 @@ std::vector<uint32_t> ExecutionCtx::buildCuMask(uint32_t startCU, uint32_t count
   return mask;
 }
 
+uint32_t ExecutionCtx::getSmAlignment(int deviceId) {
+  return g_devices[deviceId]->devices()[0]->settings().enableWgpMode_ ? 2 : 1;
+}
+
 void ExecutionCtx::tagResource(hipDevResource* res, uint32_t resourceId, int deviceId) {
   std::memcpy(&res->_internal_padding[0], &resourceId, sizeof(uint32_t));
   int32_t devId = static_cast<int32_t>(deviceId);
@@ -264,13 +268,13 @@ hipError_t ExecutionCtx::deviceGetDevResource(int device, hipDevResource* resour
   resource->type = type;
 
   hipDeviceProp_t prop{};
-  constexpr uint32_t kAlignment = 2;
   HIP_RETURN_ONFAIL(ihipGetDeviceProperties(&prop, device));
   uint32_t cuCount = static_cast<uint32_t>(prop.multiProcessorCount);
+  uint32_t alignment = getSmAlignment(device);
 
   resource->sm.smCount = cuCount;
-  resource->sm.minSmPartitionSize = kAlignment;
-  resource->sm.smCoscheduledAlignment =  kAlignment;
+  resource->sm.minSmPartitionSize = alignment;
+  resource->sm.smCoscheduledAlignment = alignment;
   resource->sm.flags = 0;
 
   resource->nextResource = nullptr;
@@ -351,7 +355,7 @@ hipError_t ExecutionCtx::devSmResourceSplit(
       groupParams[i].preferredCoscheduledSmCount = groupParams[i].coscheduledSmCount;
 
     if (groupParams[i].smCount != 0) {
-      if (groupParams[i].smCount < 2 || groupParams[i].smCount > totalCUs)
+      if (groupParams[i].smCount < defaultAlignment || groupParams[i].smCount > totalCUs)
         return hipErrorInvalidResourceConfiguration;
     }
   }
@@ -724,8 +728,9 @@ hipError_t hipStreamGetDevResource(hipStream_t hStream, hipDevResource* resource
         for (auto word : cuMask) cnt += amd::countBitsSet32(word);
         resource->sm.smCount = cnt;
       }
-      resource->sm.smCoscheduledAlignment = 2;
-      resource->sm.minSmPartitionSize = 2;
+      uint32_t alignment = ExecutionCtx::getSmAlignment(stream->DeviceId());
+      resource->sm.smCoscheduledAlignment = alignment;
+      resource->sm.minSmPartitionSize = alignment;
       resource->sm.flags = 0;
       resource->nextResource = nullptr;
       break;

--- a/projects/clr/hipamd/src/hip_executionctx.cpp
+++ b/projects/clr/hipamd/src/hip_executionctx.cpp
@@ -269,8 +269,8 @@ hipError_t ExecutionCtx::deviceGetDevResource(int device, hipDevResource* resour
 
   hipDeviceProp_t prop{};
   HIP_RETURN_ONFAIL(ihipGetDeviceProperties(&prop, device));
-  uint32_t cuCount = static_cast<uint32_t>(prop.multiProcessorCount);
   uint32_t alignment = getSmAlignment(device);
+  uint32_t cuCount = static_cast<uint32_t>(prop.multiProcessorCount) * alignment;
 
   resource->sm.smCount = cuCount;
   resource->sm.minSmPartitionSize = alignment;
@@ -727,6 +727,7 @@ hipError_t hipStreamGetDevResource(hipStream_t hStream, hipDevResource* resource
         resource->sm.smCount = cnt;
       }
       uint32_t alignment = ExecutionCtx::getSmAlignment(stream->DeviceId());
+      resource->sm.smCount *= alignment;
       resource->sm.smCoscheduledAlignment = alignment;
       resource->sm.minSmPartitionSize = alignment;
       resource->sm.flags = 0;

--- a/projects/clr/hipamd/src/hip_executionctx.hpp
+++ b/projects/clr/hipamd/src/hip_executionctx.hpp
@@ -37,7 +37,7 @@ public:
   int deviceId() const { return deviceId_; }
   /// Underlying hip::Device pointer.
   hip::Device* device() const { return g_devices[deviceId_]; }
-  /// Bitmask of compute units assigned to this context (one bit per CU).
+  /// Bitmask of compute units assigned to this context (one bit per WGP in WGP mode, one bit per CU otherwise).
   const std::vector<uint32_t>& cuMask() const { return cuMask_; }
   /// Number of compute units available in this context.
   uint32_t cuCount() const { return cuCount_; }
@@ -62,6 +62,9 @@ public:
 
   /// Return SM co-scheduling alignment for the given device (2 in WGP mode, 1 otherwise).
   static uint32_t getSmAlignment(int deviceId);
+
+  /// Return total CU count for device
+  static uint32_t getTotalCuCount(int deviceId);
 
   /// Query the full device resource for a device (all CUs).
   static hipError_t deviceGetDevResource(int device, hipDevResource* resource,
@@ -93,7 +96,7 @@ private:
   uint32_t flags_;                            ///< Context creation flags
   uint32_t cuCount_;                          ///< Number of CUs assigned to this context
   uint64_t ctxId_;                            ///< Unique context identifier
-  std::vector<uint32_t> cuMask_;              ///< Bitmask of assigned CUs
+  std::vector<uint32_t> cuMask_;              ///< Bitmask of assigned WGPs (one bit per WGP)
   DevResourceDesc* resourceDesc_;             ///< Owning pointer to the resource descriptor
 
   std::recursive_mutex lock_;                 ///< Context-level lock
@@ -122,9 +125,10 @@ private:
   /// Populate a remainder resource with leftover CUs, or mark it invalid if none remain.
   static void fillRemainder(hipDevResource* remainder, uint32_t remainingCUs,
                             uint32_t alignment);
-  /// Build a CU bitmask covering a range of CUs from startCU to startCU + count.
+  /// Build a WGP bitmask covering CUs [startCU, startCU+count). Each bit represents
+  /// one WGP (alignment CUs). startCU and count are in CU units.
   static std::vector<uint32_t> buildCuMask(uint32_t startCU, uint32_t count,
-                                           uint32_t totalCUs);
+                                           uint32_t totalCUs, uint32_t alignment = 1);
 };
 
 } // namespace hip

--- a/projects/clr/hipamd/src/hip_executionctx.hpp
+++ b/projects/clr/hipamd/src/hip_executionctx.hpp
@@ -60,6 +60,9 @@ public:
   /// Copy the matching device resource from the resource descriptor into the output.
   hipError_t getDevResource(hipDevResource* resource, hipDevResourceType type);
 
+  /// Return SM co-scheduling alignment for the given device (2 in WGP mode, 1 otherwise).
+  static uint32_t getSmAlignment(int deviceId);
+
   /// Query the full device resource for a device (all CUs).
   static hipError_t deviceGetDevResource(int device, hipDevResource* resource,
                                          hipDevResourceType type);

--- a/projects/clr/hipamd/src/hip_internal.hpp
+++ b/projects/clr/hipamd/src/hip_internal.hpp
@@ -565,7 +565,6 @@ namespace hip {
     }
 
     // --- Execution context management ---
-    
     ExecutionCtx* getPrimaryExecCtx() const { return primaryExecCtx_; }
     void setPrimaryExecCtx(ExecutionCtx* ctx) { primaryExecCtx_ = ctx; }
     std::recursive_mutex& getLock() { return lock_; }

--- a/projects/hip-tests/catch/config/configs/unit/executionctx.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/executionctx.yaml
@@ -44,5 +44,3 @@ executionctx:
     <<: *level_2
   Unit_hipExecutionCtxSmAlignment_GreenCtxPreservesAlignment:
     <<: *level_2
-  Unit_hipExecutionCtxSmAlignment_IgnoreCoschedulingFlag:
-    <<: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/executionctx.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/executionctx.yaml
@@ -36,3 +36,13 @@ executionctx:
   Unit_hipExecutionCtxResourceSplit_Disjoint_Sets:
     <<: *level_2
     disabled: [nvidia_linux]
+  Unit_hipExecutionCtxSmAlignment_DeviceGetDevResource:
+    <<: *level_2
+  Unit_hipExecutionCtxSmAlignment_StreamGetDevResource:
+    <<: *level_2
+  Unit_hipExecutionCtxSmAlignment_PropagatesThroughSplit:
+    <<: *level_2
+  Unit_hipExecutionCtxSmAlignment_GreenCtxPreservesAlignment:
+    <<: *level_2
+  Unit_hipExecutionCtxSmAlignment_IgnoreCoschedulingFlag:
+    <<: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/executionctx.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/executionctx.yaml
@@ -44,3 +44,25 @@ executionctx:
     <<: *level_2
   Unit_hipExecutionCtxSmAlignment_GreenCtxPreservesAlignment:
     <<: *level_2
+  Unit_hipDeviceGetExecutionCtx_Sanity:
+    <<: *level_2
+  Unit_hipDeviceGetExecutionCtx_Consistent:
+    <<: *level_2
+  Unit_hipDeviceGetExecutionCtx_MultiDevice:
+    <<: *level_2
+  Unit_hipDeviceGetExecutionCtx_GetDevice_RoundTrip:
+    <<: *level_2
+  Unit_hipDeviceGetExecutionCtx_GetId:
+    <<: *level_2
+  Unit_hipDeviceGetExecutionCtx_Negative:
+    <<: *level_2
+  Unit_hipDeviceGetExecutionCtx_KernelLaunch_Functional:
+    <<: *level_2
+  Unit_hipDeviceGetExecutionCtx_PrimaryCtx_Persistence:
+    <<: *level_2
+  Unit_hipStreamGetDevResource_GreenCtxStream_Functional:
+    <<: *level_2
+  Unit_hipStreamGetDevResource_RegularStream_Functional:
+    <<: *level_2
+  Unit_hipStreamGetDevResource_Negative:
+    <<: *level_2

--- a/projects/hip-tests/catch/include/hip_test_common.hh
+++ b/projects/hip-tests/catch/include/hip_test_common.hh
@@ -517,6 +517,8 @@ inline bool isKernelArgPrefetchSupported() {
  * Use these instead of duplicating slightly different wording for the same condition.
  */
 namespace SkipReason {
+inline constexpr char const kSmCountTooSmall[] =
+    "sm count is too small for this test.";
 inline constexpr char const kPeerAccessUnavailable[] =
     "peer access is not available between devices.";
 inline constexpr char const kFewerThanTwoGpus[] =

--- a/projects/hip-tests/catch/unit/executionContext/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/executionContext/CMakeLists.txt
@@ -4,6 +4,8 @@ set(TEST_SRC
   hipExecutionCtxRecordEvent.cc
   hipExecutionCtxResourceSplit.cc
   hipExecutionCtxSmAlignment.cc
+  hipDeviceGetExecutionCtx.cc
+  hipStreamGetDevResource.cc
 )
 
 hip_add_exe_to_target(

--- a/projects/hip-tests/catch/unit/executionContext/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/executionContext/CMakeLists.txt
@@ -3,6 +3,7 @@ set(TEST_SRC
   hipExecutionCtxStreamCreate.cc
   hipExecutionCtxRecordEvent.cc
   hipExecutionCtxResourceSplit.cc
+  hipExecutionCtxSmAlignment.cc
 )
 
 hip_add_exe_to_target(

--- a/projects/hip-tests/catch/unit/executionContext/hipDeviceGetExecutionCtx.cc
+++ b/projects/hip-tests/catch/unit/executionContext/hipDeviceGetExecutionCtx.cc
@@ -1,0 +1,391 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * @addtogroup hipDeviceGetExecutionCtx hipDeviceGetExecutionCtx
+ * @{
+ * @ingroup ExecutionContextTest
+ * `hipDeviceGetExecutionCtx`, `hipExecutionCtxGetDevice`, and
+ * `hipExecutionCtxGetId` APIs
+ */
+
+#include <hip_test_common.hh>
+#include <hip_test_kernels.hh>
+#include "hip_executionctx_common.hh"
+
+#include <cstdlib>
+#include <vector>
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Retrieves the primary execution context for device 0 via
+ *    hipDeviceGetExecutionCtx and verifies the returned context is non-null.
+ */
+HIP_TEST_CASE(Unit_hipDeviceGetExecutionCtx_Sanity) {
+  HIP_CHECK(hipSetDevice(0));
+
+  hipExecutionCtx_t ctx = nullptr;
+  HIP_CHECK(hipDeviceGetExecutionCtx(&ctx, 0));
+  REQUIRE(ctx != nullptr);
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Calls hipDeviceGetExecutionCtx twice for the same device and verifies
+ *    that the same primary context is returned both times.
+ */
+HIP_TEST_CASE(Unit_hipDeviceGetExecutionCtx_Consistent) {
+  HIP_CHECK(hipSetDevice(0));
+
+  hipExecutionCtx_t ctx1 = nullptr;
+  hipExecutionCtx_t ctx2 = nullptr;
+  HIP_CHECK(hipDeviceGetExecutionCtx(&ctx1, 0));
+  HIP_CHECK(hipDeviceGetExecutionCtx(&ctx2, 0));
+  REQUIRE(ctx1 == ctx2);
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Retrieves the primary execution context for each available device and
+ *    verifies each is non-null and that contexts for different devices differ.
+ */
+HIP_TEST_CASE(Unit_hipDeviceGetExecutionCtx_MultiDevice) {
+  int deviceCount = 0;
+  HIP_CHECK(hipGetDeviceCount(&deviceCount));
+
+  std::vector<hipExecutionCtx_t> contexts(deviceCount, nullptr);
+  for (int dev = 0; dev < deviceCount; dev++) {
+    HIP_CHECK(hipDeviceGetExecutionCtx(&contexts[dev], dev));
+    REQUIRE(contexts[dev] != nullptr);
+  }
+
+  for (int i = 0; i < deviceCount; i++) {
+    for (int j = i + 1; j < deviceCount; j++) {
+      REQUIRE(contexts[i] != contexts[j]);
+    }
+  }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Retrieves the primary execution context for each device, then calls
+ *    hipExecutionCtxGetDevice to verify the returned device ID matches.
+ */
+HIP_TEST_CASE(Unit_hipDeviceGetExecutionCtx_GetDevice_RoundTrip) {
+  int deviceCount = 0;
+  HIP_CHECK(hipGetDeviceCount(&deviceCount));
+
+  for (int dev = 0; dev < deviceCount; dev++) {
+    hipExecutionCtx_t ctx = nullptr;
+    HIP_CHECK(hipDeviceGetExecutionCtx(&ctx, dev));
+    REQUIRE(ctx != nullptr);
+
+    int returnedDev = -1;
+    HIP_CHECK(hipExecutionCtxGetDevice(&returnedDev, ctx));
+    REQUIRE(returnedDev == dev);
+  }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Retrieves the primary execution context and calls hipExecutionCtxGetId
+ *    to verify a non-zero context ID is returned.  Also verifies that different
+ *    devices produce different context IDs.
+ */
+HIP_TEST_CASE(Unit_hipDeviceGetExecutionCtx_GetId) {
+  int deviceCount = 0;
+  HIP_CHECK(hipGetDeviceCount(&deviceCount));
+
+  std::vector<unsigned long long> ids(deviceCount, 0);
+  for (int dev = 0; dev < deviceCount; dev++) {
+    hipExecutionCtx_t ctx = nullptr;
+    HIP_CHECK(hipDeviceGetExecutionCtx(&ctx, dev));
+
+    HIP_CHECK(hipExecutionCtxGetId(ctx, &ids[dev]));
+    REQUIRE(ids[dev] != 0);
+  }
+
+  for (int i = 0; i < deviceCount; i++) {
+    for (int j = i + 1; j < deviceCount; j++) {
+      REQUIRE(ids[i] != ids[j]);
+    }
+  }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Validates error codes from hipDeviceGetExecutionCtx, hipExecutionCtxGetDevice,
+ *    and hipExecutionCtxGetId for invalid parameters.
+ */
+HIP_TEST_CASE(Unit_hipDeviceGetExecutionCtx_Negative) {
+  int deviceCount = 0;
+  HIP_CHECK(hipGetDeviceCount(&deviceCount));
+
+  // NULL ctx pointer
+  REQUIRE(hipDeviceGetExecutionCtx(nullptr, 0) == hipErrorInvalidValue);
+
+  // Invalid device (negative)
+  hipExecutionCtx_t ctx = nullptr;
+  REQUIRE(hipDeviceGetExecutionCtx(&ctx, -1) == hipErrorInvalidDevice);
+
+  // Invalid device (out of range)
+  REQUIRE(hipDeviceGetExecutionCtx(&ctx, deviceCount) == hipErrorInvalidDevice);
+
+  // hipExecutionCtxGetDevice: NULL device pointer
+  HIP_CHECK(hipDeviceGetExecutionCtx(&ctx, 0));
+  REQUIRE(hipExecutionCtxGetDevice(nullptr, ctx) == hipErrorInvalidValue);
+
+  // hipExecutionCtxGetDevice: NULL ctx
+  int dev = -1;
+  REQUIRE(hipExecutionCtxGetDevice(&dev, nullptr) == hipErrorInvalidValue);
+
+  // hipExecutionCtxGetId: NULL ctx
+  unsigned long long id = 0;
+  REQUIRE(hipExecutionCtxGetId(nullptr, &id) == hipErrorInvalidValue);
+
+  // hipExecutionCtxGetId: NULL id pointer
+  REQUIRE(hipExecutionCtxGetId(ctx, nullptr) == hipErrorInvalidValue);
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Retrieves the primary execution context and creates a green context from
+ *    a split SM resource.  Creates a stream from each context, launches a
+ *    vectorADD kernel on both streams concurrently, synchronizes, and verifies
+ *    that both produce identical correct results.  The primary context must NOT
+ *    be destroyed; only the green context is cleaned up.
+ */
+HIP_TEST_CASE(Unit_hipDeviceGetExecutionCtx_KernelLaunch_Functional) {
+  HIP_CHECK(hipSetDevice(0));
+
+  // Get the primary execution context
+  hipExecutionCtx_t primaryCtx = nullptr;
+  HIP_CHECK(hipDeviceGetExecutionCtx(&primaryCtx, 0));
+  REQUIRE(primaryCtx != nullptr);
+
+  // Create a stream from the primary context
+  hipStream_t primaryStream = nullptr;
+  HIP_CHECK(hipExecutionCtxStreamCreate(&primaryStream, primaryCtx, hipStreamNonBlocking, 0));
+  REQUIRE(primaryStream != nullptr);
+
+  // Create a green context from a split SM resource
+  hipDevice_t device;
+  HIP_CHECK(hipDeviceGet(&device, 0));
+
+  hipDevResource input{};
+  HIP_CHECK(hipDeviceGetDevResource(device, &input, hipDevResourceTypeSm));
+
+  unsigned int alignment = input.sm.smCoscheduledAlignment;
+  unsigned int groupSize = (input.sm.smCount / 2 / alignment) * alignment;
+  REQUIRE(groupSize >= alignment);
+
+  hipDevSmResourceGroupParams params[1] = {};
+  params[0].smCount = groupSize;
+
+  hipDevResource splitResult[1] = {};
+  hipDevResource remainder{};
+  HIP_CHECK(hipDevSmResourceSplit(splitResult, 1, &input, &remainder, 0, params));
+
+  hipDevResourceDesc_t desc{};
+  HIP_CHECK(hipDevResourceGenerateDesc(&desc, splitResult, 1));
+
+  hipExecutionCtx_t greenCtx = nullptr;
+  HIP_CHECK(hipGreenCtxCreate(&greenCtx, desc, 0, 0));
+  REQUIRE(greenCtx != nullptr);
+
+  // Create a stream from the green context
+  hipStream_t greenStream = nullptr;
+  HIP_CHECK(hipExecutionCtxStreamCreate(&greenStream, greenCtx, hipStreamNonBlocking, 0));
+  REQUIRE(greenStream != nullptr);
+
+  // Verify both contexts return valid device IDs
+  int primaryDev = -1, greenDev = -1;
+  HIP_CHECK(hipExecutionCtxGetDevice(&primaryDev, primaryCtx));
+  HIP_CHECK(hipExecutionCtxGetDevice(&greenDev, greenCtx));
+  REQUIRE(primaryDev == 0);
+  REQUIRE(greenDev == 0);
+
+  // Verify contexts have different IDs
+  unsigned long long primaryId = 0, greenId = 0;
+  HIP_CHECK(hipExecutionCtxGetId(primaryCtx, &primaryId));
+  HIP_CHECK(hipExecutionCtxGetId(greenCtx, &greenId));
+  REQUIRE(primaryId != greenId);
+
+  // Prepare data for vectorADD on both streams
+  constexpr size_t kN = 1024;
+  const size_t kBytes = kN * sizeof(int);
+
+  int* h_a = reinterpret_cast<int*>(malloc(kBytes));
+  int* h_b = reinterpret_cast<int*>(malloc(kBytes));
+  int* h_c_primary = reinterpret_cast<int*>(malloc(kBytes));
+  int* h_c_green = reinterpret_cast<int*>(malloc(kBytes));
+  REQUIRE(h_a != nullptr);
+  REQUIRE(h_b != nullptr);
+  REQUIRE(h_c_primary != nullptr);
+  REQUIRE(h_c_green != nullptr);
+
+  for (size_t i = 0; i < kN; i++) {
+    h_a[i] = static_cast<int>(i);
+    h_b[i] = static_cast<int>(i * 2);
+  }
+
+  // Allocate device memory for both streams (separate output buffers)
+  int *d_a = nullptr, *d_b = nullptr;
+  int *d_c_primary = nullptr, *d_c_green = nullptr;
+  HIP_CHECK(hipMalloc(&d_a, kBytes));
+  HIP_CHECK(hipMalloc(&d_b, kBytes));
+  HIP_CHECK(hipMalloc(&d_c_primary, kBytes));
+  HIP_CHECK(hipMalloc(&d_c_green, kBytes));
+
+  // Launch on primary stream
+  HIP_CHECK(hipMemcpyAsync(d_a, h_a, kBytes, hipMemcpyHostToDevice, primaryStream));
+  HIP_CHECK(hipMemcpyAsync(d_b, h_b, kBytes, hipMemcpyHostToDevice, primaryStream));
+
+  constexpr int kThreads = 256;
+  const int blocks = static_cast<int>((kN + kThreads - 1) / kThreads);
+  HipTest::vectorADD<<<blocks, kThreads, 0, primaryStream>>>(d_a, d_b, d_c_primary, kN);
+  HIP_CHECK(hipGetLastError());
+
+  // Launch on green stream (reuse same input buffers after primary stream sync)
+  HIP_CHECK(hipStreamSynchronize(primaryStream));
+  HIP_CHECK(hipMemcpyAsync(d_a, h_a, kBytes, hipMemcpyHostToDevice, greenStream));
+  HIP_CHECK(hipMemcpyAsync(d_b, h_b, kBytes, hipMemcpyHostToDevice, greenStream));
+  HipTest::vectorADD<<<blocks, kThreads, 0, greenStream>>>(d_a, d_b, d_c_green, kN);
+  HIP_CHECK(hipGetLastError());
+
+  // Copy results back
+  HIP_CHECK(hipMemcpyAsync(h_c_primary, d_c_primary, kBytes, hipMemcpyDeviceToHost, primaryStream));
+  HIP_CHECK(hipMemcpyAsync(h_c_green, d_c_green, kBytes, hipMemcpyDeviceToHost, greenStream));
+  HIP_CHECK(hipStreamSynchronize(primaryStream));
+  HIP_CHECK(hipStreamSynchronize(greenStream));
+
+  // Verify both produce correct and identical results
+  for (size_t i = 0; i < kN; i++) {
+    REQUIRE(h_c_primary[i] == h_a[i] + h_b[i]);
+    REQUIRE(h_c_green[i] == h_a[i] + h_b[i]);
+    REQUIRE(h_c_primary[i] == h_c_green[i]);
+  }
+
+  // Cleanup
+  HIP_CHECK(hipFree(d_a));
+  HIP_CHECK(hipFree(d_b));
+  HIP_CHECK(hipFree(d_c_primary));
+  HIP_CHECK(hipFree(d_c_green));
+  free(h_a);
+  free(h_b);
+  free(h_c_primary);
+  free(h_c_green);
+
+  HIP_CHECK(hipStreamDestroy(greenStream));
+  HIP_CHECK(hipStreamDestroy(primaryStream));
+  HIP_CHECK(hipExecutionCtxDestroy(greenCtx));
+  // Primary context must NOT be destroyed
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Simulates two independent application modules that each obtain the primary
+ *    execution context, create their own stream, and launch work.  Module A
+ *    produces partial results, Module B (getting the same context later) launches
+ *    dependent work using event synchronization.  Verifies that:
+ *    1. Both modules get the same primary context handle.
+ *    2. Streams from separate acquisitions of the primary context work correctly.
+ *    3. Event-based synchronization across streams from the same context works.
+ *    4. The primary context remains valid throughout, demonstrating its
+ *       application-lifetime persistence.
+ *    5. Attempting to destroy the primary context returns hipErrorInvalidValue.
+ */
+HIP_TEST_CASE(Unit_hipDeviceGetExecutionCtx_PrimaryCtx_Persistence) {
+  HIP_CHECK(hipSetDevice(0));
+
+  // --- Module A: get primary context, create stream, launch work ---
+  hipExecutionCtx_t ctxA = nullptr;
+  HIP_CHECK(hipDeviceGetExecutionCtx(&ctxA, 0));
+  REQUIRE(ctxA != nullptr);
+
+  hipStream_t streamA = nullptr;
+  HIP_CHECK(hipExecutionCtxStreamCreate(&streamA, ctxA, hipStreamNonBlocking, 0));
+  REQUIRE(streamA != nullptr);
+
+  constexpr size_t kN = 1024;
+  const size_t kBytes = kN * sizeof(int);
+
+  int* h_a = reinterpret_cast<int*>(malloc(kBytes));
+  int* h_b = reinterpret_cast<int*>(malloc(kBytes));
+  int* h_c = reinterpret_cast<int*>(malloc(kBytes));
+  REQUIRE(h_a != nullptr);
+  REQUIRE(h_b != nullptr);
+  REQUIRE(h_c != nullptr);
+
+  for (size_t i = 0; i < kN; i++) {
+    h_a[i] = static_cast<int>(i);
+    h_b[i] = static_cast<int>(i * 2);
+  }
+
+  int *d_a = nullptr, *d_b = nullptr, *d_c = nullptr;
+  HIP_CHECK(hipMalloc(&d_a, kBytes));
+  HIP_CHECK(hipMalloc(&d_b, kBytes));
+  HIP_CHECK(hipMalloc(&d_c, kBytes));
+
+  HIP_CHECK(hipMemcpyAsync(d_a, h_a, kBytes, hipMemcpyHostToDevice, streamA));
+  HIP_CHECK(hipMemcpyAsync(d_b, h_b, kBytes, hipMemcpyHostToDevice, streamA));
+
+  constexpr int kThreads = 256;
+  const int blocks = static_cast<int>((kN + kThreads - 1) / kThreads);
+  HipTest::vectorADD<<<blocks, kThreads, 0, streamA>>>(d_a, d_b, d_c, kN);
+  HIP_CHECK(hipGetLastError());
+
+  hipEvent_t event = nullptr;
+  HIP_CHECK(hipEventCreate(&event));
+  HIP_CHECK(hipEventRecord(event, streamA));
+
+  // --- Module B: independently get the same primary context ---
+  hipExecutionCtx_t ctxB = nullptr;
+  HIP_CHECK(hipDeviceGetExecutionCtx(&ctxB, 0));
+  REQUIRE(ctxB == ctxA);
+
+  hipStream_t streamB = nullptr;
+  HIP_CHECK(hipExecutionCtxStreamCreate(&streamB, ctxB, hipStreamNonBlocking, 0));
+  REQUIRE(streamB != nullptr);
+
+  // Wait for Module A's work to complete before reading its output
+  HIP_CHECK(hipStreamWaitEvent(streamB, event, 0));
+
+  // Module B reads the result produced by Module A
+  HIP_CHECK(hipMemcpyAsync(h_c, d_c, kBytes, hipMemcpyDeviceToHost, streamB));
+  HIP_CHECK(hipStreamSynchronize(streamB));
+
+  for (size_t i = 0; i < kN; i++) {
+    REQUIRE(h_c[i] == h_a[i] + h_b[i]);
+  }
+
+  // Verify primary context cannot be destroyed
+  REQUIRE(hipExecutionCtxDestroy(ctxA) == hipErrorInvalidValue);
+
+  // Cleanup
+  HIP_CHECK(hipEventDestroy(event));
+  HIP_CHECK(hipFree(d_a));
+  HIP_CHECK(hipFree(d_b));
+  HIP_CHECK(hipFree(d_c));
+  free(h_a);
+  free(h_b);
+  free(h_c);
+  HIP_CHECK(hipStreamDestroy(streamB));
+  HIP_CHECK(hipStreamDestroy(streamA));
+}
+
+/**
+ * End doxygen group hipDeviceGetExecutionCtx.
+ * @}
+ */

--- a/projects/hip-tests/catch/unit/executionContext/hipExecutionCtxResourceSplit.cc
+++ b/projects/hip-tests/catch/unit/executionContext/hipExecutionCtxResourceSplit.cc
@@ -131,10 +131,12 @@ HIP_TEST_CASE(Unit_hipExecutionCtxResourceSplit_Negative) {
           == hipErrorInvalidResourceType);
 
   // smCount < minSmPartitionSize (must be >= minSmPartitionSize)
-  hipDevSmResourceGroupParams tooSmall[1] = {};
-  tooSmall[0].smCount = input.sm.minSmPartitionSize - 1;
-  REQUIRE(hipDevSmResourceSplit(result, 1, &input, nullptr, 0, tooSmall)
-          == hipErrorInvalidResourceConfiguration);
+  if (input.sm.minSmPartitionSize > 1) {
+    hipDevSmResourceGroupParams tooSmall[1] = {};
+    tooSmall[0].smCount = input.sm.minSmPartitionSize - 1;
+    REQUIRE(hipDevSmResourceSplit(result, 1, &input, nullptr, 0, tooSmall)
+            == hipErrorInvalidResourceConfiguration);
+  }
 
   // smCount exceeds total SMs
   hipDevSmResourceGroupParams tooLarge[1] = {};

--- a/projects/hip-tests/catch/unit/executionContext/hipExecutionCtxResourceSplit.cc
+++ b/projects/hip-tests/catch/unit/executionContext/hipExecutionCtxResourceSplit.cc
@@ -362,7 +362,8 @@ HIP_TEST_CASE(Unit_hipExecutionCtxResourceSplit_Disjoint_Sets) {
     REQUIRE(result[i].sm.smCount == groupSize);
   }
 
-  unsigned int maskWords = (totalSMs + 31) / 32;
+  unsigned int totalWGPs = (alignment > 1) ? totalSMs / alignment : totalSMs;
+  unsigned int maskWords = (totalWGPs + 31) / 32;
   std::vector<std::vector<uint32_t>> masks(3);
   hipExecutionCtx_t ctx[3] = {};
   hipStream_t stream[3] = {};

--- a/projects/hip-tests/catch/unit/executionContext/hipExecutionCtxResourceSplit.cc
+++ b/projects/hip-tests/catch/unit/executionContext/hipExecutionCtxResourceSplit.cc
@@ -15,13 +15,15 @@
 #include <hip_test_kernels.hh>
 #include "hip_executionctx_common.hh"
 
+#include <algorithm>
 #include <vector>
 
 /**
  * Test Description
  * ------------------------
- *  - Splits device SM resources into 2 explicit groups via hipDevSmResourceSplit
- *    and verifies the output resource counts match the request.
+ *  - Splits device SM resources into a single group containing half the total
+ *    SMs (aligned to smCoscheduledAlignment) via hipDevSmResourceSplit.
+ *    Verifies the result SM count and that the remainder captures the rest.
  */
 HIP_TEST_CASE(Unit_hipExecutionCtxResourceSplit_Sanity) {
   HIP_CHECK(hipSetDevice(0));
@@ -34,26 +36,20 @@ HIP_TEST_CASE(Unit_hipExecutionCtxResourceSplit_Sanity) {
   unsigned int totalSMs = input.sm.smCount;
   unsigned int alignment = input.sm.smCoscheduledAlignment;
   unsigned int halfSMs = (totalSMs / 2 / alignment) * alignment;
-  REQUIRE(halfSMs >= 2);
+  REQUIRE(halfSMs >= alignment);
 
-  hipDevSmResourceGroupParams params[2] = {};
+  hipDevSmResourceGroupParams params[1] = {};
   params[0].smCount = halfSMs;
-  params[1].smCount = halfSMs;
 
-  hipDevResource result[2] = {};
+  hipDevResource result[1] = {};
   hipDevResource remainder{};
-  HIP_CHECK(hipDevSmResourceSplit(result, 2, &input, &remainder, 0, params));
+  HIP_CHECK(hipDevSmResourceSplit(result, 1, &input, &remainder, 0, params));
 
   REQUIRE(result[0].type == hipDevResourceTypeSm);
   REQUIRE(result[0].sm.smCount == halfSMs);
-  REQUIRE(result[1].type == hipDevResourceTypeSm);
-  REQUIRE(result[1].sm.smCount == halfSMs);
 
-  unsigned int remainderSMs = 0;
-  if (remainder.type == hipDevResourceTypeSm) {
-    remainderSMs = remainder.sm.smCount;
-  }
-  REQUIRE(result[0].sm.smCount + result[1].sm.smCount + remainderSMs == totalSMs);
+  REQUIRE(remainder.type == hipDevResourceTypeSm);
+  REQUIRE(remainder.sm.smCount == totalSMs - halfSMs);
 }
 
 /**
@@ -157,10 +153,12 @@ HIP_TEST_CASE(Unit_hipExecutionCtxResourceSplit_Negative) {
 /**
  * Test Description
  * ------------------------
- *  - Splits SM resources into 2 explicit groups via hipDevSmResourceSplit using
- *    a 60/40 split.  Any SMs left over due to alignment are captured in the
- *    remainder.  Creates a execution context and stream from each partition, runs a
- *    vectorADD kernel, and verifies correctness.
+ *  - Uses hipDevSmResourceSplitByCount discovery to find the supported number
+ *    of groups.  If at least 3 groups are possible, performs an asymmetric
+ *    hipDevSmResourceSplit (1x and 2x alignment); otherwise falls back to a
+ *    symmetric split (alignment + alignment).  Creates a execution context and
+ *    stream from each partition, runs a vectorADD kernel, and verifies
+ *    correctness.
  */
 HIP_TEST_CASE(Unit_hipExecutionCtxResourceSplit_Functional) {
   HIP_CHECK(hipSetDevice(0));
@@ -172,10 +170,13 @@ HIP_TEST_CASE(Unit_hipExecutionCtxResourceSplit_Functional) {
 
   unsigned int totalSMs = input.sm.smCount;
   unsigned int alignment = input.sm.smCoscheduledAlignment;
-  unsigned int groupA = (static_cast<unsigned int>(totalSMs * 0.6) / alignment) * alignment;
-  unsigned int groupB = (static_cast<unsigned int>(totalSMs * 0.4) / alignment) * alignment;
-  REQUIRE(groupA >= alignment);
-  REQUIRE(groupB >= alignment);
+
+  unsigned int nbGroups = 0;
+  HIP_CHECK(hipDevSmResourceSplitByCount(nullptr, &nbGroups, &input, nullptr, 0, alignment));
+  REQUIRE(nbGroups >= 2);
+
+  unsigned int groupA = alignment;
+  unsigned int groupB = (nbGroups >= 3) ? alignment * 2 : alignment;
 
   hipDevSmResourceGroupParams params[2] = {};
   params[0].smCount = groupA;
@@ -185,7 +186,9 @@ HIP_TEST_CASE(Unit_hipExecutionCtxResourceSplit_Functional) {
   hipDevResource remainder{};
   HIP_CHECK(hipDevSmResourceSplit(result, 2, &input, &remainder, 0, params));
 
+  REQUIRE(result[0].type == hipDevResourceTypeSm);
   REQUIRE(result[0].sm.smCount == groupA);
+  REQUIRE(result[1].type == hipDevResourceTypeSm);
   REQUIRE(result[1].sm.smCount == groupB);
 
   unsigned int remainderSMs = 0;
@@ -267,6 +270,7 @@ HIP_TEST_CASE(Unit_hipExecutionCtxResourceSplit_By_Count_Functional) {
   if (remainder.type == hipDevResourceTypeSm) {
     remainderSMs = remainder.sm.smCount;
   }
+
   REQUIRE(assignedSMs + remainderSMs == totalSMs);
 
   RunVectorAddOnResource(&result[0], 0);
@@ -276,10 +280,12 @@ HIP_TEST_CASE(Unit_hipExecutionCtxResourceSplit_By_Count_Functional) {
 /**
  * Test Description
  * ------------------------
- *  - Splits SM resources into 2 groups via hipDevSmResourceSplit where the first
- *    group gets 65% of CUs and the second group uses the backfill flag to absorb
- *    all remaining CUs.  Verifies that the remainder has 0 CUs and runs a
- *    vectorADD kernel on each partition.
+ *  - Uses hipDevSmResourceSplitByCount discovery to find the supported number
+ *    of groups, then splits SM resources into 2 groups via hipDevSmResourceSplit
+ *    where the first group gets ~65% of SMs (capped to the discoverable range)
+ *    and the second group uses the backfill flag to absorb all remaining SMs.
+ *    Verifies that the remainder is invalid and runs a vectorADD kernel on each
+ *    partition.
  */
 HIP_TEST_CASE(Unit_hipExecutionCtxResourceSplit_Backfill_Functional) {
   HIP_CHECK(hipSetDevice(0));
@@ -291,7 +297,14 @@ HIP_TEST_CASE(Unit_hipExecutionCtxResourceSplit_Backfill_Functional) {
 
   unsigned int totalSMs = input.sm.smCount;
   unsigned int alignment = input.sm.smCoscheduledAlignment;
+
+  unsigned int nbGroups = 0;
+  HIP_CHECK(hipDevSmResourceSplitByCount(nullptr, &nbGroups, &input, nullptr, 0, alignment));
+  REQUIRE(nbGroups >= 2);
+
+  unsigned int maxExplicit = (nbGroups - 1) * alignment;
   unsigned int group0 = (static_cast<unsigned int>(totalSMs * 0.65) / alignment) * alignment;
+  group0 = std::min(group0, maxExplicit);
   REQUIRE(group0 >= alignment);
 
   hipDevSmResourceGroupParams params[2] = {};

--- a/projects/hip-tests/catch/unit/executionContext/hipExecutionCtxResourceSplit.cc
+++ b/projects/hip-tests/catch/unit/executionContext/hipExecutionCtxResourceSplit.cc
@@ -253,8 +253,7 @@ HIP_TEST_CASE(Unit_hipExecutionCtxResourceSplit_By_Count_Functional) {
 
   unsigned int totalSMs = input.sm.smCount;
   unsigned int alignment = input.sm.smCoscheduledAlignment;
-  unsigned int minCount = (static_cast<unsigned int>(totalSMs * 0.4) / alignment) * alignment;
-  REQUIRE(minCount >= alignment);
+  unsigned int minCount = min(alignment, (static_cast<unsigned int>(totalSMs * 0.4) / alignment) * alignment);
 
   unsigned int nbGroups = 0;
   HIP_CHECK(hipDevSmResourceSplitByCount(nullptr, &nbGroups, &input, nullptr, 0, minCount));
@@ -346,8 +345,9 @@ HIP_TEST_CASE(Unit_hipExecutionCtxResourceSplit_Disjoint_Sets) {
   unsigned int totalSMs = input.sm.smCount;
   unsigned int alignment = input.sm.smCoscheduledAlignment;
   unsigned int groupSize = (totalSMs / 3 / alignment) * alignment;
-  REQUIRE(groupSize >= alignment);
-
+  if (groupSize < alignment) {
+    HIP_SKIP_TEST(HipTest::SkipReason::kSmCountTooSmall);
+  }
   hipDevSmResourceGroupParams params[3] = {};
   params[0].smCount = groupSize;
   params[1].smCount = groupSize;

--- a/projects/hip-tests/catch/unit/executionContext/hipExecutionCtxSmAlignment.cc
+++ b/projects/hip-tests/catch/unit/executionContext/hipExecutionCtxSmAlignment.cc
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * @addtogroup hipExecutionCtxSmAlignment hipExecutionCtxSmAlignment
+ * @{
+ * @ingroup ExecutionContextTest
+ * Validates that SM co-scheduling alignment returned by device resource APIs
+ * is consistent with the device's WGP/CU mode (arch-dependent).
+ */
+
+#include <hip_test_common.hh>
+#include "hip_executionctx_common.hh"
+
+#include <algorithm>
+#include <vector>
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Verifies that hipDeviceGetDevResource returns a valid smCoscheduledAlignment
+ *    (1 or 2), that minSmPartitionSize matches it, and that smCount equals
+ *    multiProcessorCount.
+ */
+HIP_TEST_CASE(Unit_hipExecutionCtxSmAlignment_DeviceGetDevResource) {
+  int deviceCount = 0;
+  HIP_CHECK(hipGetDeviceCount(&deviceCount));
+
+  for (int dev = 0; dev < deviceCount; dev++) {
+    HIP_CHECK(hipSetDevice(dev));
+
+    hipDeviceProp_t prop{};
+    HIP_CHECK(hipGetDeviceProperties(&prop, dev));
+
+    hipDevice_t device;
+    HIP_CHECK(hipDeviceGet(&device, dev));
+
+    hipDevResource resource{};
+    HIP_CHECK(hipDeviceGetDevResource(device, &resource, hipDevResourceTypeSm));
+
+    unsigned int alignment = resource.sm.smCoscheduledAlignment;
+
+    INFO("Device " << dev << " (" << prop.gcnArchName << "): "
+         << "smCoscheduledAlignment=" << alignment
+         << " minSmPartitionSize=" << resource.sm.minSmPartitionSize);
+
+    REQUIRE((alignment >= 1));
+    REQUIRE(resource.sm.minSmPartitionSize == alignment);
+    REQUIRE(resource.sm.smCount == static_cast<unsigned int>(prop.multiProcessorCount));
+  }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Verifies that hipStreamGetDevResource returns alignment values matching
+ *    hipDeviceGetDevResource for the same device, for both the NULL stream
+ *    and a user-created stream.
+ */
+HIP_TEST_CASE(Unit_hipExecutionCtxSmAlignment_StreamGetDevResource) {
+  HIP_CHECK(hipSetDevice(0));
+
+  hipDevice_t device;
+  HIP_CHECK(hipDeviceGet(&device, 0));
+
+  hipDevResource devResource{};
+  HIP_CHECK(hipDeviceGetDevResource(device, &devResource, hipDevResourceTypeSm));
+
+  // NULL stream
+  hipDevResource nullStreamRes{};
+  HIP_CHECK(hipStreamGetDevResource(nullptr, &nullStreamRes, hipDevResourceTypeSm));
+  REQUIRE(nullStreamRes.sm.smCoscheduledAlignment == devResource.sm.smCoscheduledAlignment);
+  REQUIRE(nullStreamRes.sm.minSmPartitionSize == devResource.sm.minSmPartitionSize);
+
+  // User-created stream
+  hipStream_t stream = nullptr;
+  HIP_CHECK(hipStreamCreate(&stream));
+
+  hipDevResource streamRes{};
+  HIP_CHECK(hipStreamGetDevResource(stream, &streamRes, hipDevResourceTypeSm));
+  REQUIRE(streamRes.sm.smCoscheduledAlignment == devResource.sm.smCoscheduledAlignment);
+  REQUIRE(streamRes.sm.minSmPartitionSize == devResource.sm.minSmPartitionSize);
+
+  HIP_CHECK(hipStreamDestroy(stream));
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Verifies that alignment propagates correctly through resource splitting.
+ *    After hipDevSmResourceSplitByCount, each result partition and the remainder
+ *    must carry the same alignment as the input resource.
+ */
+HIP_TEST_CASE(Unit_hipExecutionCtxSmAlignment_PropagatesThroughSplit) {
+  HIP_CHECK(hipSetDevice(0));
+
+  hipDevice_t device;
+  HIP_CHECK(hipDeviceGet(&device, 0));
+
+  hipDevResource input{};
+  HIP_CHECK(hipDeviceGetDevResource(device, &input, hipDevResourceTypeSm));
+
+  unsigned int alignment = input.sm.smCoscheduledAlignment;
+  unsigned int minCount = alignment;
+
+  unsigned int nbGroups = 0;
+  HIP_CHECK(hipDevSmResourceSplitByCount(nullptr, &nbGroups, &input, nullptr, 0, minCount));
+  REQUIRE(nbGroups > 0);
+
+  unsigned int requestedGroups = std::min(nbGroups, 2u);
+  std::vector<hipDevResource> result(requestedGroups);
+  hipDevResource remainder{};
+  HIP_CHECK(hipDevSmResourceSplitByCount(result.data(), &requestedGroups, &input,
+                                         &remainder, 0, minCount));
+
+  for (unsigned int i = 0; i < requestedGroups; i++) {
+    REQUIRE(result[i].sm.smCoscheduledAlignment == alignment);
+    REQUIRE(result[i].sm.minSmPartitionSize == alignment);
+  }
+
+  if (remainder.type == hipDevResourceTypeSm) {
+    REQUIRE(remainder.sm.smCoscheduledAlignment >= 1);
+    REQUIRE(remainder.sm.minSmPartitionSize >= 1);
+  }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Verifies that hipExecutionCtxGetDevResource on a green context created
+ *    from a split resource preserves the alignment from the original resource.
+ */
+HIP_TEST_CASE(Unit_hipExecutionCtxSmAlignment_GreenCtxPreservesAlignment) {
+  HIP_CHECK(hipSetDevice(0));
+
+  hipDevice_t device;
+  HIP_CHECK(hipDeviceGet(&device, 0));
+
+  hipDevResource input{};
+  HIP_CHECK(hipDeviceGetDevResource(device, &input, hipDevResourceTypeSm));
+
+  unsigned int alignment = input.sm.smCoscheduledAlignment;
+  unsigned int groupSize = (input.sm.smCount / 2 / alignment) * alignment;
+  REQUIRE(groupSize >= alignment);
+
+  hipDevSmResourceGroupParams params[1] = {};
+  params[0].smCount = groupSize;
+
+  hipDevResource splitResult[1] = {};
+  hipDevResource remainder{};
+  HIP_CHECK(hipDevSmResourceSplit(splitResult, 1, &input, &remainder, 0, params));
+
+  hipDevResourceDesc_t desc{};
+  HIP_CHECK(hipDevResourceGenerateDesc(&desc, splitResult, 1));
+
+  hipExecutionCtx_t ctx = nullptr;
+  HIP_CHECK(hipGreenCtxCreate(&ctx, desc, 0, 0));
+  REQUIRE(ctx != nullptr);
+
+  hipDevResource ctxResource{};
+  HIP_CHECK(hipExecutionCtxGetDevResource(ctx, &ctxResource, hipDevResourceTypeSm));
+
+  REQUIRE(ctxResource.sm.smCoscheduledAlignment == alignment);
+  REQUIRE(ctxResource.sm.minSmPartitionSize >= 1);
+  REQUIRE(ctxResource.sm.minSmPartitionSize <= alignment);
+  REQUIRE(ctxResource.sm.smCount == groupSize);
+
+  HIP_CHECK(hipExecutionCtxDestroy(ctx));
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - When hipDevSmResourceSplitByCount is called with minCount=1 and the
+ *    hipDevSmResourceSplitIgnoreSmCoscheduling flag, alignment should be
+ *    treated as Architectural Minimum regardless of device arch,
+ *    producing groups of minimum SM.
+ */
+HIP_TEST_CASE(Unit_hipExecutionCtxSmAlignment_IgnoreCoschedulingFlag) {
+  HIP_CHECK(hipSetDevice(0));
+
+  hipDevice_t device;
+  HIP_CHECK(hipDeviceGet(&device, 0));
+
+  hipDevResource input{};
+  HIP_CHECK(hipDeviceGetDevResource(device, &input, hipDevResourceTypeSm));
+
+  unsigned int nbGroups = 0;
+  HIP_CHECK(hipDevSmResourceSplitByCount(nullptr, &nbGroups, &input, nullptr,
+                                         hipDevSmResourceSplitIgnoreSmCoscheduling, 1));
+  REQUIRE(nbGroups >= input.sm.smCount / input.sm.smCoscheduledAlignment);
+
+  unsigned int requestedGroups = std::min(nbGroups, 3u);
+  std::vector<hipDevResource> result(requestedGroups);
+  hipDevResource remainder{};
+  HIP_CHECK(hipDevSmResourceSplitByCount(result.data(), &requestedGroups, &input,
+                                         &remainder, hipDevSmResourceSplitIgnoreSmCoscheduling, 1));
+
+  for (unsigned int i = 0; i < requestedGroups; i++) {
+    REQUIRE(result[i].sm.smCount >= 1);
+    REQUIRE(result[i].sm.smCount <= input.sm.smCoscheduledAlignment);
+  }
+}
+
+/**
+ * End doxygen group hipExecutionCtxSmAlignment.
+ * @}
+ */

--- a/projects/hip-tests/catch/unit/executionContext/hipExecutionCtxSmAlignment.cc
+++ b/projects/hip-tests/catch/unit/executionContext/hipExecutionCtxSmAlignment.cc
@@ -46,8 +46,11 @@ HIP_TEST_CASE(Unit_hipExecutionCtxSmAlignment_DeviceGetDevResource) {
     INFO("Device " << dev << " (" << prop.gcnArchName << "): "
          << "smCoscheduledAlignment=" << alignment
          << " minSmPartitionSize=" << resource.sm.minSmPartitionSize);
-
+#if HT_AMD
+    REQUIRE((alignment == 1 || alignment == 2));
+#else
     REQUIRE((alignment >= 1));
+#endif
     REQUIRE(resource.sm.minSmPartitionSize == alignment);
     REQUIRE(resource.sm.smCount == static_cast<unsigned int>(prop.multiProcessorCount));
   }
@@ -91,8 +94,11 @@ HIP_TEST_CASE(Unit_hipExecutionCtxSmAlignment_StreamGetDevResource) {
  * Test Description
  * ------------------------
  *  - Verifies that alignment propagates correctly through resource splitting.
- *    After hipDevSmResourceSplitByCount, each result partition and the remainder
- *    must carry the same alignment as the input resource.
+ *    After hipDevSmResourceSplitByCount, each result partition must carry the
+ *    same alignment as the input resource. Remainder resource, if present,
+ *    must have minimum architectural alignment. On AMD this is same as WGP alignment,
+ *    but CUDA devices set remainder alignment to minimum architectural alignment which
+ *    may be less than the input alignment.
  */
 HIP_TEST_CASE(Unit_hipExecutionCtxSmAlignment_PropagatesThroughSplit) {
   HIP_CHECK(hipSetDevice(0));
@@ -122,8 +128,13 @@ HIP_TEST_CASE(Unit_hipExecutionCtxSmAlignment_PropagatesThroughSplit) {
   }
 
   if (remainder.type == hipDevResourceTypeSm) {
+#if HT_AMD
+    REQUIRE(remainder.sm.smCoscheduledAlignment == alignment);
+    REQUIRE(remainder.sm.minSmPartitionSize == alignment);
+#else 
     REQUIRE(remainder.sm.smCoscheduledAlignment >= 1);
     REQUIRE(remainder.sm.minSmPartitionSize >= 1);
+#endif
   }
 }
 
@@ -169,40 +180,6 @@ HIP_TEST_CASE(Unit_hipExecutionCtxSmAlignment_GreenCtxPreservesAlignment) {
   REQUIRE(ctxResource.sm.smCount == groupSize);
 
   HIP_CHECK(hipExecutionCtxDestroy(ctx));
-}
-
-/**
- * Test Description
- * ------------------------
- *  - When hipDevSmResourceSplitByCount is called with minCount=1 and the
- *    hipDevSmResourceSplitIgnoreSmCoscheduling flag, alignment should be
- *    treated as Architectural Minimum regardless of device arch,
- *    producing groups of minimum SM.
- */
-HIP_TEST_CASE(Unit_hipExecutionCtxSmAlignment_IgnoreCoschedulingFlag) {
-  HIP_CHECK(hipSetDevice(0));
-
-  hipDevice_t device;
-  HIP_CHECK(hipDeviceGet(&device, 0));
-
-  hipDevResource input{};
-  HIP_CHECK(hipDeviceGetDevResource(device, &input, hipDevResourceTypeSm));
-
-  unsigned int nbGroups = 0;
-  HIP_CHECK(hipDevSmResourceSplitByCount(nullptr, &nbGroups, &input, nullptr,
-                                         hipDevSmResourceSplitIgnoreSmCoscheduling, 1));
-  REQUIRE(nbGroups >= input.sm.smCount / input.sm.smCoscheduledAlignment);
-
-  unsigned int requestedGroups = std::min(nbGroups, 3u);
-  std::vector<hipDevResource> result(requestedGroups);
-  hipDevResource remainder{};
-  HIP_CHECK(hipDevSmResourceSplitByCount(result.data(), &requestedGroups, &input,
-                                         &remainder, hipDevSmResourceSplitIgnoreSmCoscheduling, 1));
-
-  for (unsigned int i = 0; i < requestedGroups; i++) {
-    REQUIRE(result[i].sm.smCount >= 1);
-    REQUIRE(result[i].sm.smCount <= input.sm.smCoscheduledAlignment);
-  }
 }
 
 /**

--- a/projects/hip-tests/catch/unit/executionContext/hipExecutionCtxSmAlignment.cc
+++ b/projects/hip-tests/catch/unit/executionContext/hipExecutionCtxSmAlignment.cc
@@ -52,7 +52,7 @@ HIP_TEST_CASE(Unit_hipExecutionCtxSmAlignment_DeviceGetDevResource) {
     REQUIRE((alignment >= 1));
 #endif
     REQUIRE(resource.sm.minSmPartitionSize == alignment);
-    REQUIRE(resource.sm.smCount == static_cast<unsigned int>(prop.multiProcessorCount));
+    REQUIRE(resource.sm.smCount == static_cast<unsigned int>(prop.multiProcessorCount) * alignment);
   }
 }
 

--- a/projects/hip-tests/catch/unit/executionContext/hipStreamGetDevResource.cc
+++ b/projects/hip-tests/catch/unit/executionContext/hipStreamGetDevResource.cc
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * @addtogroup hipStreamGetDevResource hipStreamGetDevResource
+ * @{
+ * @ingroup ExecutionContextTest
+ * `hipStreamGetDevResource` API - functional and negative tests
+ */
+
+#include <hip_test_common.hh>
+#include "hip_executionctx_common.hh"
+
+#include <vector>
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Creates a green context from a split SM resource, creates a stream from
+ *    it, then calls hipStreamGetDevResource on that stream.  Verifies the
+ *    returned SM count matches the partition size used to create the green
+ *    context.
+ */
+HIP_TEST_CASE(Unit_hipStreamGetDevResource_GreenCtxStream_Functional) {
+  HIP_CHECK(hipSetDevice(0));
+
+  hipDevice_t device;
+  HIP_CHECK(hipDeviceGet(&device, 0));
+
+  hipDevResource input{};
+  HIP_CHECK(hipDeviceGetDevResource(device, &input, hipDevResourceTypeSm));
+
+  unsigned int alignment = input.sm.smCoscheduledAlignment;
+  unsigned int groupSize = (input.sm.smCount / 2 / alignment) * alignment;
+  REQUIRE(groupSize >= alignment);
+
+  hipDevSmResourceGroupParams params[1] = {};
+  params[0].smCount = groupSize;
+
+  hipDevResource splitResult[1] = {};
+  hipDevResource remainder{};
+  HIP_CHECK(hipDevSmResourceSplit(splitResult, 1, &input, &remainder, 0, params));
+  REQUIRE(splitResult[0].sm.smCount == groupSize);
+
+  hipDevResourceDesc_t desc{};
+  HIP_CHECK(hipDevResourceGenerateDesc(&desc, splitResult, 1));
+
+  hipExecutionCtx_t ctx = nullptr;
+  HIP_CHECK(hipGreenCtxCreate(&ctx, desc, 0, 0));
+  REQUIRE(ctx != nullptr);
+
+  hipStream_t stream = nullptr;
+  HIP_CHECK(hipExecutionCtxStreamCreate(&stream, ctx, hipStreamNonBlocking, 0));
+  REQUIRE(stream != nullptr);
+
+  // Query the stream's SM resource
+  hipDevResource streamRes{};
+  HIP_CHECK(hipStreamGetDevResource(stream, &streamRes, hipDevResourceTypeSm));
+
+  REQUIRE(streamRes.type == hipDevResourceTypeSm);
+  REQUIRE(streamRes.sm.smCount == groupSize);
+  REQUIRE(streamRes.sm.smCoscheduledAlignment >= 1);
+
+  HIP_CHECK(hipStreamDestroy(stream));
+  HIP_CHECK(hipExecutionCtxDestroy(ctx));
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Creates a regular HIP stream (not from a green context), calls
+ *    hipStreamGetDevResource to get its SM resource, and verifies the resource
+ *    matches hipDeviceGetDevResource for the same device.  Then partitions the
+ *    derived resource via hipDevSmResourceSplit, creates a green context and
+ *    stream from the partition, launches a vectorADD kernel, and verifies output.
+ */
+HIP_TEST_CASE(Unit_hipStreamGetDevResource_RegularStream_Functional) {
+  HIP_CHECK(hipSetDevice(0));
+
+  hipDevice_t device;
+  HIP_CHECK(hipDeviceGet(&device, 0));
+
+  // Get device resource for comparison
+  hipDevResource devResource{};
+  HIP_CHECK(hipDeviceGetDevResource(device, &devResource, hipDevResourceTypeSm));
+
+  // Create a regular stream and get its resource
+  hipStream_t regularStream = nullptr;
+  HIP_CHECK(hipStreamCreate(&regularStream));
+
+  hipDevResource streamRes{};
+  HIP_CHECK(hipStreamGetDevResource(regularStream, &streamRes, hipDevResourceTypeSm));
+
+  REQUIRE(streamRes.type == hipDevResourceTypeSm);
+  REQUIRE(streamRes.sm.smCount == devResource.sm.smCount);
+  REQUIRE(streamRes.sm.smCoscheduledAlignment == devResource.sm.smCoscheduledAlignment);
+  REQUIRE(streamRes.sm.minSmPartitionSize == devResource.sm.minSmPartitionSize);
+
+  HIP_CHECK(hipStreamDestroy(regularStream));
+
+  // Partition the stream-derived resource
+  unsigned int alignment = streamRes.sm.smCoscheduledAlignment;
+  unsigned int groupSize = (streamRes.sm.smCount / 2 / alignment) * alignment;
+  REQUIRE(groupSize >= alignment);
+
+  hipDevSmResourceGroupParams params[1] = {};
+  params[0].smCount = groupSize;
+
+  hipDevResource splitResult[1] = {};
+  hipDevResource remainder{};
+  HIP_CHECK(hipDevSmResourceSplit(splitResult, 1, &streamRes, &remainder, 0, params));
+  REQUIRE(splitResult[0].sm.smCount == groupSize);
+
+  // Create green context from the partitioned resource and launch kernel
+  RunVectorAddOnResource(&splitResult[0], 0);
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Validates error codes from hipStreamGetDevResource for invalid parameters:
+ *    NULL resource pointer, unsupported resource types (workqueue, workqueue
+ *    config), and invalid resource type.
+ */
+HIP_TEST_CASE(Unit_hipStreamGetDevResource_Negative) {
+  HIP_CHECK(hipSetDevice(0));
+
+  hipStream_t stream = nullptr;
+  HIP_CHECK(hipStreamCreate(&stream));
+
+  // NULL resource pointer
+  REQUIRE(hipStreamGetDevResource(stream, nullptr, hipDevResourceTypeSm)
+          == hipErrorInvalidValue);
+
+  // Unsupported resource types
+  hipDevResource resource{};
+  REQUIRE(hipStreamGetDevResource(stream, &resource, hipDevResourceTypeWorkqueue)
+          == hipErrorInvalidResourceType);
+  REQUIRE(hipStreamGetDevResource(stream, &resource, hipDevResourceTypeWorkqueueConfig)
+          == hipErrorInvalidResourceType);
+
+  // Invalid resource type
+  REQUIRE(hipStreamGetDevResource(stream, &resource, hipDevResourceTypeInvalid)
+          == hipErrorInvalidResourceType);
+
+  HIP_CHECK(hipStreamDestroy(stream));
+}
+
+/**
+ * End doxygen group hipStreamGetDevResource.
+ * @}
+ */


### PR DESCRIPTION
## Motivation

## CU Alignment ##
1. CU alignment should be based on WGP mode.
2. for gfx10 and above WGP mode is enables which sets alignment to 2 which means minimum 2 CUs have to be co-scheduled.
3. Added tests to make sure Alignment is set correctly and propagates after split
4. Remove IgnoreSmCoSchedulingAlignment flag since it sets alignment to 1 even when WGP mode is enabled which won't work.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

https://amd-hub.atlassian.net/browse/AIRUNTIME-2039

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
