### PR TITLE
[CI] [Documentation] Add docs PR preview pipeline from rocm-libraries

### DIFF
--- a/.github/docs-config.json
+++ b/.github/docs-config.json
@@ -1,84 +1,84 @@
 {
-    "projects": [
+  "projects": [
     {
-        "folder":  "amdsmi",
-        "rtd_slug": "advanced-micro-devices-amdsmi",
-        "rtd_alias": "amdsmi"
+      "folder": "amdsmi",
+      "rtd_slug": "advanced-micro-devices-amdsmi",
+      "rtd_alias": "amdsmi"
     },
     {
-        "folder":  "aqlprofile",
-        "rtd_slug": "advanced-micro-devices-aqlprofile",
-        "rtd_alias": "aqlprofile"
+      "folder": "aqlprofile",
+      "rtd_slug": "advanced-micro-devices-aqlprofile",
+      "rtd_alias": "aqlprofile"
     },
     {
-        "folder":  "cuid",
-        "rtd_slug": "advanced-micro-devices-cuid",
-        "rtd_alias": "cuid"
+      "folder": "cuid",
+      "rtd_slug": "advanced-micro-devices-cuid",
+      "rtd_alias": "cuid"
     },
     {
-        "folder":  "hip",
-        "rtd_slug": "advanced-micro-devices-hip",
-        "rtd_alias": "HIP"
+      "folder": "hip",
+      "rtd_slug": "advanced-micro-devices-hip",
+      "rtd_alias": "HIP"
     },
     {
-        "folder":  "rccl",
-        "rtd_slug": "advanced-micro-devices-rccl",
-        "rtd_alias": "rccl"
+      "folder": "rccl",
+      "rtd_slug": "advanced-micro-devices-rccl",
+      "rtd_alias": "rccl"
     },
     {
-        "folder":  "rdc",
-        "rtd_slug": "advanced-micro-devices-rdc",
-        "rtd_alias": "rdc"
+      "folder": "rdc",
+      "rtd_slug": "advanced-micro-devices-rdc",
+      "rtd_alias": "rdc"
     },
     {
-        "folder":  "rocdecode",
-        "rtd_slug": "advanced-micro-devices-rocdecode",
-        "rtd_alias": "rocDecode"
+      "folder": "rocdecode",
+      "rtd_slug": "advanced-micro-devices-rocdecode",
+      "rtd_alias": "rocDecode"
     },
     {
-        "folder":  "rocjpeg",
-        "rtd_slug": "advanced-micro-devices-rocjpeg",
-        "rtd_alias": "rocJPEG"
+      "folder": "rocjpeg",
+      "rtd_slug": "advanced-micro-devices-rocjpeg",
+      "rtd_alias": "rocJPEG"
     },
     {
-        "folder":  "rocm-smi-lib",
-        "rtd_slug": "advanced-micro-devices-rocm-smi-lib",
-        "rtd_alias": "rocm_smi_lib"
+      "folder": "rocm-smi-lib",
+      "rtd_slug": "advanced-micro-devices-rocm-smi-lib",
+      "rtd_alias": "rocm_smi_lib"
     },
     {
-        "folder":  "rocminfo",
-        "rtd_slug": "advanced-micro-devices-rocminfo",
-        "rtd_alias": "rocminfo"
+      "folder": "rocminfo",
+      "rtd_slug": "advanced-micro-devices-rocminfo",
+      "rtd_alias": "rocminfo"
     },
     {
-        "folder":  "rocprofiler-compute",
-        "rtd_slug": "advanced-micro-devices-rocprofiler-compute",
-        "rtd_alias": "rocprofiler-compute"
+      "folder": "rocprofiler-compute",
+      "rtd_slug": "advanced-micro-devices-rocprofiler-compute",
+      "rtd_alias": "rocprofiler-compute"
     },
     {
-        "folder":  "rocprofiler-sdk",
-        "rtd_slug": "advanced-micro-devices-rocprofiler-sdk",
-        "rtd_alias": "rocprofiler-sdk"
+      "folder": "rocprofiler-sdk",
+      "rtd_slug": "advanced-micro-devices-rocprofiler-sdk",
+      "rtd_alias": "rocprofiler-sdk"
     },
     {
-        "folder":  "rocprofiler-systems",
-        "rtd_slug": "advanced-micro-devices-rocprofiler-systems",
-        "rtd_alias": "rocprofiler-systems"
+      "folder": "rocprofiler-systems",
+      "rtd_slug": "advanced-micro-devices-rocprofiler-systems",
+      "rtd_alias": "rocprofiler-systems"
     },
     {
-        "folder":  "rocr-debug-agent",
-        "rtd_slug": "advanced-micro-devices-rocr-debug-agent",
-        "rtd_alias": "rocr_debug_agent"
+      "folder": "rocr-debug-agent",
+      "rtd_slug": "advanced-micro-devices-rocr-debug-agent",
+      "rtd_alias": "rocr_debug_agent"
     },
     {
-        "folder":  "rocr-runtime",
-        "rtd_slug": "advanced-micro-devices-rocr-runtime",
-        "rtd_alias": "ROCR-Runtime"
+      "folder": "rocr-runtime",
+      "rtd_slug": "advanced-micro-devices-rocr-runtime",
+      "rtd_alias": "ROCR-Runtime"
     },
     {
-        "folder":  "rocshmem",
-        "rtd_slug": "advanced-micro-devices-rocshmem",
-        "rtd_alias": "rocSHMEM"
+      "folder": "rocshmem",
+      "rtd_slug": "advanced-micro-devices-rocshmem",
+      "rtd_alias": "rocSHMEM"
     }
-    ]
+  ]
 }

--- a/.github/docs-config.json
+++ b/.github/docs-config.json
@@ -1,0 +1,84 @@
+{
+    "projects": [
+    {
+        "folder":  "amdsmi",
+        "rtd_slug": "advanced-micro-devices-amdsmi",
+        "rtd_alias": "amdsmi"
+    },
+    {
+        "folder":  "aqlprofile",
+        "rtd_slug": "advanced-micro-devices-aqlprofile",
+        "rtd_alias": "aqlprofile"
+    },
+    {
+        "folder":  "cuid",
+        "rtd_slug": "advanced-micro-devices-cuid",
+        "rtd_alias": "cuid"
+    },
+    {
+        "folder":  "hip",
+        "rtd_slug": "advanced-micro-devices-hip",
+        "rtd_alias": "HIP"
+    },
+    {
+        "folder":  "rccl",
+        "rtd_slug": "advanced-micro-devices-rccl",
+        "rtd_alias": "rccl"
+    },
+    {
+        "folder":  "rdc",
+        "rtd_slug": "advanced-micro-devices-rdc",
+        "rtd_alias": "rdc"
+    },
+    {
+        "folder":  "rocdecode",
+        "rtd_slug": "advanced-micro-devices-rocdecode",
+        "rtd_alias": "rocDecode"
+    },
+    {
+        "folder":  "rocjpeg",
+        "rtd_slug": "advanced-micro-devices-rocjpeg",
+        "rtd_alias": "rocJPEG"
+    },
+    {
+        "folder":  "rocm-smi-lib",
+        "rtd_slug": "advanced-micro-devices-rocm-smi-lib",
+        "rtd_alias": "rocm_smi_lib"
+    },
+    {
+        "folder":  "rocminfo",
+        "rtd_slug": "advanced-micro-devices-rocminfo",
+        "rtd_alias": "rocminfo"
+    },
+    {
+        "folder":  "rocprofiler-compute",
+        "rtd_slug": "advanced-micro-devices-rocprofiler-compute",
+        "rtd_alias": "rocprofiler-compute"
+    },
+    {
+        "folder":  "rocprofiler-sdk",
+        "rtd_slug": "advanced-micro-devices-rocprofiler-sdk",
+        "rtd_alias": "rocprofiler-sdk"
+    },
+    {
+        "folder":  "rocprofiler-systems",
+        "rtd_slug": "advanced-micro-devices-rocprofiler-systems",
+        "rtd_alias": "rocprofiler-systems"
+    },
+    {
+        "folder":  "rocr-debug-agent",
+        "rtd_slug": "advanced-micro-devices-rocr-debug-agent",
+        "rtd_alias": "rocr_debug_agent"
+    },
+    {
+        "folder":  "rocr-runtime",
+        "rtd_slug": "advanced-micro-devices-rocr-runtime",
+        "rtd_alias": "ROCR-Runtime"
+    },
+    {
+        "folder":  "rocshmem",
+        "rtd_slug": "advanced-micro-devices-rocshmem",
+        "rtd_alias": "rocSHMEM"
+    }
+    ]
+}

--- a/.github/workflows/docs-pr-preview-cleanup.yml
+++ b/.github/workflows/docs-pr-preview-cleanup.yml
@@ -1,0 +1,82 @@
+# Clean up documentation preview versions from Read the Docs
+# ---------------------------------------------------------
+# This workflow triggers when a PR is closed (merged or abandoned).
+# It checks if a docs preview was created by parsing PR comments posted
+# by the bot, then deactivates the corresponding version on Read the Docs.
+
+name: Docs Preview Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout docs-config only
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: |
+            .github/docs-config.json
+          sparse-checkout-cone-mode: false
+
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b # v2.1.1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Get project slug from preview comment
+        id: rtd
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          # Extract project identifier from the bot's comment.
+          # The JSON output for a valid commit will have "assistant-librarian[bot]"
+          # for key `user.login` and contain "rocm.docs.amd.com/projects/" for key `body`
+          # and we need to parse "rocm.docs.amd.com/projects/project_slug/xyz..." to "project_slug"
+
+          comment=$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
+            --jq '[.[] | select(.user.login == "assistant-librarian[bot]" and (.body | contains("rocm.docs.amd.com/projects/")))] | last | .body')
+
+          if [ -z "$comment" ] || [ "$comment" = "null" ]; then
+            echo "No preview comment found, skipping cleanup."
+            exit 0
+          fi
+
+          # Extract the string immediately following "projects/" (up to the next "/") from $comment
+          project_alias=$(echo "$comment" | grep --only-matching --perl-regexp 'projects/\K[^/]+')
+
+          # Load the map and look up the rtd_slug by rtd_alias
+          project_slug=$(jq -r --arg alias "$project_alias" \
+            '.projects[] | select(.rtd_alias == $alias) | .rtd_slug' \
+            .github/docs-config.json)
+
+          echo "project_slug=$project_slug" >> $GITHUB_OUTPUT
+
+      - name: Deactivate RTD preview version
+        if: steps.rtd.outputs.project_slug
+        env:
+          RTD_TOKEN: ${{ secrets.RTD_TOKEN }}
+        run: |
+          branch_name="${{ github.head_ref }}"
+          # Generate slug like 'user-me-my_test_branch' from 'user/me/my_test_branch'
+          version_slug="${branch_name//\//-}"
+
+          response=$(curl \
+            --connect-timeout 180 \
+            --silent \
+            --output /dev/null \
+            --write-out "%{http_code}" \
+            --request PATCH \
+            --header "Authorization: Token $RTD_TOKEN" \
+            --header "Content-Type: application/json" \
+            --data '{"active": false}' \
+            "https://app.readthedocs.com/api/v3/projects/${{ steps.rtd.outputs.project_slug }}/versions/${version_slug}/")
+          echo "RTD PATCH responded with HTTP $response"

--- a/.github/workflows/docs-pr-preview.yml
+++ b/.github/workflows/docs-pr-preview.yml
@@ -71,7 +71,6 @@ jobs:
             --repo "${{ github.repository }}" \
             --pr "${{ github.event.issue.number }}" \
             --config ".github/repos-config.json" \
-            --require-auto-push
 
       - name: Extract first project
         id: extract

--- a/.github/workflows/docs-pr-preview.yml
+++ b/.github/workflows/docs-pr-preview.yml
@@ -1,0 +1,212 @@
+# Create a documentation preview in the pull request
+# --------------------------------------------------
+# This GitHub Actions workflow triggers by commenting '/docs-preview' on a PR.
+# It creates a new Read the Docs version for the PR branch and triggers a build.
+#
+# Key Steps:
+# 1. Use the script (.github/scripts/pr_detect_changed_subtrees.py) to detect changed project
+# 2. Get the PR branch name and derive the RTD version slug
+# 3. Activate the branch as a new version on Read the Docs (key difference from update-docs.yml)
+# 4. Trigger a build for that version
+# 5. Comment the preview URL back on the PR
+#
+# Note: if multiple projects are changed in one PR, only the first detected project is previewed.
+
+name: Docs Preview
+
+on:
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    # Only run when '/docs-preview' is commented on a PR by a member or owner
+    if: >-
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '/docs-preview') &&
+      (github.event.comment.author_association == 'MEMBER' ||
+      github.event.comment.author_association == 'OWNER')
+    steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b # v2.1.1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Checkout config files only
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          sparse-checkout: .github
+          sparse-checkout-cone-mode: true
+          token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Set up Python
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        with:
+          python-version: '3.10'
+
+      - name: Install python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pydantic requests
+
+      - name: Set up Git user
+        run: |
+          git config user.name "assistant-librarian[bot]"
+          git config user.email "assistant-librarian[bot]@users.noreply.github.com"
+
+      - name: Detect changed subtrees from PR
+        id: detect
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          python .github/scripts/pr_detect_changed_subtrees.py \
+            --repo "${{ github.repository }}" \
+            --pr "${{ github.event.issue.number }}" \
+            --config ".github/repos-config.json" \
+            --require-auto-push
+
+      - name: Extract first project
+        id: extract
+        run: |
+          # pr_detect_changed_subtrees.py returns a string of project names
+          # separated by "\n", i.e. "projects/rocprim\nprojects/hipblaslt\nshared/tensile"
+          # head -n1: extracts the first project, i.e. "projects/rocprim"
+          # cut -d'/' -f2:  cuts the "projects/" prefix, leaving "rocprim" for project_name
+          project=$(echo "${{ steps.detect.outputs.subtrees }}" | head -n1)
+          echo "project=$project" >> $GITHUB_OUTPUT
+          echo "project_name=$(echo "$project" | cut -d'/' -f2)" >> $GITHUB_OUTPUT
+
+      - name: Get PR branch
+        if: steps.extract.outputs.project
+        id: pr
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          PR_DATA=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number }})
+          echo "branch=$(echo $PR_DATA | jq -r .head.ref)" >> $GITHUB_OUTPUT
+
+      - name: Derive RTD slugs and verify project exists
+        if: steps.extract.outputs.project
+        id: rtd
+        env:
+          RTD_TOKEN: ${{ secrets.RTD_TOKEN }}
+        run: |
+          branch_name="${{ steps.pr.outputs.branch }}"
+          # Generate slug like 'user-me-my_test_branch' from 'user/me/my_test_branch'
+          version_slug="${branch_name//\//-}"
+          project_slug="advanced-micro-devices-${{ steps.extract.outputs.project_name }}"
+
+          echo "version_slug=$version_slug" >> $GITHUB_OUTPUT
+          echo "project_slug=$project_slug" >> $GITHUB_OUTPUT
+
+          # The API call returns upto 300 projects information from RTD
+          # jq extracts the project slug from the list
+          project_list=$(curl \
+            --connect-timeout 180 \
+            --header "Authorization: Token $RTD_TOKEN" \
+            "https://app.readthedocs.com/api/v3/projects/?expand=advanced-micro-devices&limit=300" \
+            | jq -r '.results[].slug')
+
+          if echo "$project_list" | grep -Fxq "$project_slug"; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+
+            # Fetch documentation URL
+            doc_url=$(curl \
+              --connect-timeout 180 \
+              --silent \
+              --header "Authorization: Token $RTD_TOKEN" \
+              "https://app.readthedocs.com/api/v3/projects/$project_slug/" \
+              | jq --raw-output '.urls.documentation')
+
+            # Strip trailing version segment (e.g. "latest/") to get the base url
+            doc_base=$(echo "$doc_url" | sed 's|/[^/]\+/\?$||')
+            echo "doc_base=$doc_base" >> $GITHUB_OUTPUT
+          else
+            echo "${{ steps.extract.outputs.project_name }} does not exist on Read the Docs, skipping."
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Sync RTD versions to discover PR branch
+        # Without a GitHub webhook configured on the repo, RTD is unaware of new branches.
+        # Triggering a sync forces RTD to re-scan the repository and register the PR branch
+        # as a version before we attempt to activate it in the next step.
+        if: steps.rtd.outputs.exists == 'true'
+        env:
+          RTD_TOKEN: ${{ secrets.RTD_TOKEN }}
+        run: |
+          curl \
+            --connect-timeout 180 \
+            --fail \
+            --request POST \
+            --header "Authorization: Token $RTD_TOKEN" \
+            "https://app.readthedocs.com/api/v3/projects/${{ steps.rtd.outputs.project_slug }}/sync-versions/"
+
+      - name: Wait for RTD to register PR branch version
+        if: steps.rtd.outputs.exists == 'true'
+        env:
+          RTD_TOKEN: ${{ secrets.RTD_TOKEN }}
+        run: |
+          declare version_url="https://app.readthedocs.com/api/v3/projects/${{ steps.rtd.outputs.project_slug }}/versions/${{ steps.rtd.outputs.version_slug }}/"
+
+          declare -i MAXIMUM_NUMBER_OF_POLLS=20
+          declare -i SLEEP_BETWEEN_POLLS_SECONDS=15
+
+          echo "Polling for version to appear: $version_url"
+          for i in $(seq 1 ${MAXIMUM_NUMBER_OF_POLLS}); do
+            status=$(curl --silent --output /dev/null --write-out "%{http_code}" \
+              --header "Authorization: Token $RTD_TOKEN" \
+              "$version_url")
+            if [ "$status" = "200" ]; then
+              echo "Version found after $i attempt(s)."
+              exit 0
+            fi
+            echo "Attempt $i: version not yet registered (HTTP $status), waiting 15s..."
+            sleep ${SLEEP_BETWEEN_POLLS_SECONDS}
+          done
+          echo "Timed out waiting for RTD to register version."
+          exit 1
+
+      - name: Activate PR branch as a new RTD version
+        if: steps.rtd.outputs.exists == 'true'
+        env:
+          RTD_TOKEN: ${{ secrets.RTD_TOKEN }}
+        run: |
+          curl \
+            --connect-timeout 180 \
+            --fail \
+            --request PATCH \
+            --header "Authorization: Token $RTD_TOKEN" \
+            --header "Content-Type: application/json" \
+            --data '{"active": true, "hidden": true, "privacy_level": "private"}' \
+            "https://app.readthedocs.com/api/v3/projects/${{ steps.rtd.outputs.project_slug }}/versions/${{ steps.rtd.outputs.version_slug }}/"
+
+      - name: Trigger RTD build for PR branch
+        if: steps.rtd.outputs.exists == 'true'
+        env:
+          RTD_TOKEN: ${{ secrets.RTD_TOKEN }}
+        run: |
+          curl \
+            --fail \
+            --silent \
+            --request POST \
+            --header "Authorization: Token $RTD_TOKEN" \
+            "https://app.readthedocs.com/api/v3/projects/${{ steps.rtd.outputs.project_slug }}/versions/${{ steps.rtd.outputs.version_slug }}/builds/"
+
+      - name: Comment RTD preview URL on PR
+        if: steps.rtd.outputs.exists == 'true'
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          preview_url="${{ steps.rtd.outputs.doc_base }}/${{ steps.rtd.outputs.version_slug }}/"
+          gh pr comment ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --body "Docs preview for **${{ steps.extract.outputs.project_name }}** is building on Read the Docs: $preview_url \
+            (Note: If a pull request includes multiple projects, only the preview for the first project will be built.)"


### PR DESCRIPTION
**This PR adds merged pipelines from rocm-libraries. https://github.com/ROCm/rocm-libraries/pull/1413**

## Motivation

To provide Tech Writers a preview of their docs development, accelerate the review process.

## Technical Details

Key Steps:
`docs-pr-preview.yml` (triggered via commenting '/docs-preview')
1. Use the script (.github/scripts/pr_detect_changed_subtrees.py) to detect changed project
2. Trigger preview build on RTD based on the detected project
3. Comment the preview URL back to the PR

`docs-pr-preview-cleanup.yml` (triggered when PR is closed)
1. Scan through PR comment section
2. If bot's preview comment is detected, deactivate the preview from RTD

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Tested on rocm-libraries

## Test Result

Preview behaves as expected

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
