### PR TITLE
[rocDecode] Error resiliency: Add graceful VUI parameter error handling, for AVC and HEVC.

### DIFF
--- a/projects/rocdecode/CHANGELOG.md
+++ b/projects/rocdecode/CHANGELOG.md
@@ -22,6 +22,7 @@ Full documentation for rocDecode is available at [https://rocm.docs.amd.com/proj
 * Logging improvement: Unified logging format in utility classes with core library logging format.
 * Logging improvement: Moved debug logging from a compile-time switch to the runtime logger level controlled by ROCDEC_LOG_LEVEL (debug = 4).
 * Feature: support for user set output surface format.
+* Graceful handling of VUI syntax errors for AVC and HEVC.
 
 ## rocDecode 1.7.0 for ROCm 7.2.1
 

--- a/projects/rocdecode/src/parser/avc_parser.cpp
+++ b/projects/rocdecode/src/parser/avc_parser.cpp
@@ -1039,10 +1039,8 @@ ParserResult AvcVideoParser::ParseSps(uint8_t *p_stream, size_t size) {
 
     p_sps->vui_parameters_present_flag = Parser::GetBit(p_stream, offset);
     if (p_sps->vui_parameters_present_flag == 1) {
-        // Treat VUI parameter parsing failure as non-fatal error and continue parsing since VUI parameters are not necessary for decoding. The decoder can choose to apply default VUI parameters or skip applying VUI parameters when VUI parameters parsing failure.
-        if (GetVuiParameters(p_stream, offset, &p_sps->vui_seq_parameters) != PARSER_OK) {
-            ErrorLog(g_rocdec_logger, "Failed to parse VUI parameters. Default VUI parameters will be applied.");
-        }
+        // Treat VUI parameter parsing failure as non-fatal error and continue parsing since VUI parameters are not necessary for decoding.
+        GetVuiParameters(p_stream, offset, &p_sps->vui_seq_parameters);
     }
 
     p_sps->is_received = 1;  // confirm SPS with seq_parameter_set_id received (but not activated)

--- a/projects/rocdecode/src/parser/avc_parser.cpp
+++ b/projects/rocdecode/src/parser/avc_parser.cpp
@@ -1039,9 +1039,9 @@ ParserResult AvcVideoParser::ParseSps(uint8_t *p_stream, size_t size) {
 
     p_sps->vui_parameters_present_flag = Parser::GetBit(p_stream, offset);
     if (p_sps->vui_parameters_present_flag == 1) {
-        ParserResult ret;
-        if ((ret = GetVuiParameters(p_stream, offset, &p_sps->vui_seq_parameters)) != PARSER_OK) {
-            return ret;
+        // Treat VUI parameter parsing failure as non-fatal error and continue parsing since VUI parameters are not necessary for decoding. The decoder can choose to apply default VUI parameters or skip applying VUI parameters when VUI parameters parsing failure.
+        if (GetVuiParameters(p_stream, offset, &p_sps->vui_seq_parameters) != PARSER_OK) {
+            ErrorLog(g_rocdec_logger, "Failed to parse VUI parameters. Default VUI parameters will be applied.");
         }
     }
 
@@ -1640,15 +1640,24 @@ ParserResult AvcVideoParser::GetVuiParameters(uint8_t *p_stream, size_t &offset,
             p_vui_params->colour_primaries = Parser::ReadBits(p_stream, offset, 8);
             p_vui_params->transfer_characteristics = Parser::ReadBits(p_stream, offset, 8);
             p_vui_params->matrix_coefficients = Parser::ReadBits(p_stream, offset, 8);
+        } else {
+            p_vui_params->colour_primaries = 2;           // Unspecified
+            p_vui_params->transfer_characteristics = 2;   // Unspecified
+            p_vui_params->matrix_coefficients = 2;         // Unspecified
         }
+    } else {
+        p_vui_params->video_format = 5;                    // Unspecified
+        p_vui_params->colour_primaries = 2;                // Unspecified
+        p_vui_params->transfer_characteristics = 2;        // Unspecified
+        p_vui_params->matrix_coefficients = 2;             // Unspecified
     }
 
     p_vui_params->chroma_loc_info_present_flag = Parser::GetBit(p_stream, offset);
     if (p_vui_params->chroma_loc_info_present_flag == 1) {
         p_vui_params->chroma_sample_loc_type_top_field = Parser::ExpGolomb::ReadUe(p_stream, offset);
-        CHECK_ALLOWED_RANGE("chroma_sample_loc_type_top_field", p_vui_params->chroma_sample_loc_type_top_field, 0, 5);
+        CHECK_RANGE_AND_SET_DEFAULT("chroma_sample_loc_type_top_field", p_vui_params->chroma_sample_loc_type_top_field, 0, 5, 0);
         p_vui_params->chroma_sample_loc_type_bottom_field = Parser::ExpGolomb::ReadUe(p_stream, offset);
-        CHECK_ALLOWED_RANGE("chroma_sample_loc_type_bottom_field", p_vui_params->chroma_sample_loc_type_bottom_field, 0, 5);
+        CHECK_RANGE_AND_SET_DEFAULT("chroma_sample_loc_type_bottom_field", p_vui_params->chroma_sample_loc_type_bottom_field, 0, 5, 0);
     }
 
     p_vui_params->timing_info_present_flag = Parser::GetBit(p_stream, offset);
@@ -1661,7 +1670,7 @@ ParserResult AvcVideoParser::GetVuiParameters(uint8_t *p_stream, size_t &offset,
     p_vui_params->nal_hrd_parameters_present_flag = Parser::GetBit(p_stream, offset);
     if (p_vui_params->nal_hrd_parameters_present_flag == 1 ) {
         p_vui_params->nal_hrd_parameters.cpb_cnt_minus1 = Parser::ExpGolomb::ReadUe(p_stream, offset);
-        CHECK_ALLOWED_RANGE("cpb_cnt_minus1", p_vui_params->nal_hrd_parameters.cpb_cnt_minus1, 0, 31);
+        CHECK_RANGE_AND_SET_DEFAULT("cpb_cnt_minus1", p_vui_params->nal_hrd_parameters.cpb_cnt_minus1, 0, 31, 0);
         p_vui_params->nal_hrd_parameters.bit_rate_scale = Parser::ReadBits(p_stream, offset, 4);
         p_vui_params->nal_hrd_parameters.cpb_size_scale = Parser::ReadBits(p_stream, offset, 4);
         for (int SchedSelIdx = 0; SchedSelIdx <= p_vui_params->nal_hrd_parameters.cpb_cnt_minus1; SchedSelIdx ++) {
@@ -1678,6 +1687,7 @@ ParserResult AvcVideoParser::GetVuiParameters(uint8_t *p_stream, size_t &offset,
     p_vui_params->vcl_hrd_parameters_present_flag = Parser::GetBit(p_stream, offset);
     if (p_vui_params->vcl_hrd_parameters_present_flag == 1) {
         p_vui_params->vcl_hrd_parameters.cpb_cnt_minus1 = Parser::ExpGolomb::ReadUe(p_stream, offset);
+        CHECK_RANGE_AND_SET_DEFAULT("cpb_cnt_minus1", p_vui_params->vcl_hrd_parameters.cpb_cnt_minus1, 0, 31, 0);
         p_vui_params->vcl_hrd_parameters.bit_rate_scale = Parser::ReadBits(p_stream, offset, 4);
         p_vui_params->vcl_hrd_parameters.cpb_size_scale = Parser::ReadBits(p_stream, offset, 4);
         for (int SchedSelIdx = 0; SchedSelIdx <= p_vui_params->vcl_hrd_parameters.cpb_cnt_minus1; SchedSelIdx ++) {
@@ -1692,6 +1702,8 @@ ParserResult AvcVideoParser::GetVuiParameters(uint8_t *p_stream, size_t &offset,
     }
     if (p_vui_params->nal_hrd_parameters_present_flag == 1 || p_vui_params->vcl_hrd_parameters_present_flag == 1) {
         p_vui_params->low_delay_hrd_flag = Parser::GetBit(p_stream, offset);
+    } else {
+        p_vui_params->low_delay_hrd_flag = 1 - p_vui_params->fixed_frame_rate_flag;
     }
     
     p_vui_params->pic_struct_present_flag = Parser::GetBit(p_stream, offset);
@@ -1699,15 +1711,23 @@ ParserResult AvcVideoParser::GetVuiParameters(uint8_t *p_stream, size_t &offset,
     if (p_vui_params->bitstream_restriction_flag) {
         p_vui_params->motion_vectors_over_pic_boundaries_flag = Parser::GetBit(p_stream, offset);
         p_vui_params->max_bytes_per_pic_denom = Parser::ExpGolomb::ReadUe(p_stream, offset);
-        CHECK_ALLOWED_RANGE("max_bytes_per_pic_denom", p_vui_params->max_bytes_per_pic_denom, 0, 16);
+        CHECK_RANGE_AND_SET_DEFAULT("max_bytes_per_pic_denom", p_vui_params->max_bytes_per_pic_denom, 0, 16, 2);
         p_vui_params->max_bits_per_mb_denom = Parser::ExpGolomb::ReadUe(p_stream, offset);
-        CHECK_ALLOWED_RANGE("max_bits_per_mb_denom", p_vui_params->max_bits_per_mb_denom, 0, 16);
+        CHECK_RANGE_AND_SET_DEFAULT("max_bits_per_mb_denom", p_vui_params->max_bits_per_mb_denom, 0, 16, 1);
         p_vui_params->log2_max_mv_length_horizontal = Parser::ExpGolomb::ReadUe(p_stream, offset);
-        CHECK_ALLOWED_RANGE("log2_max_mv_length_horizontal", p_vui_params->log2_max_mv_length_horizontal, 0, 15);
+        CHECK_RANGE_AND_SET_DEFAULT("log2_max_mv_length_horizontal", p_vui_params->log2_max_mv_length_horizontal, 0, 15, 15);
         p_vui_params->log2_max_mv_length_vertical = Parser::ExpGolomb::ReadUe(p_stream, offset);
-        CHECK_ALLOWED_RANGE("log2_max_mv_length_vertical", p_vui_params->log2_max_mv_length_vertical, 0, 15);
+        CHECK_RANGE_AND_SET_DEFAULT("log2_max_mv_length_vertical", p_vui_params->log2_max_mv_length_vertical, 0, 15, 15);
         p_vui_params->max_num_reorder_frames = Parser::ExpGolomb::ReadUe(p_stream, offset);
         p_vui_params->max_dec_frame_buffering = Parser::ExpGolomb::ReadUe(p_stream, offset);
+    } else {
+        p_vui_params->motion_vectors_over_pic_boundaries_flag = 1;
+        p_vui_params->max_bytes_per_pic_denom = 2;
+        p_vui_params->max_bits_per_mb_denom = 1;
+        p_vui_params->log2_max_mv_length_horizontal = 15;
+        p_vui_params->log2_max_mv_length_vertical = 15;
+        p_vui_params->max_num_reorder_frames = AVC_MAX_DPB_FRAMES;
+        p_vui_params->max_dec_frame_buffering = AVC_MAX_DPB_FRAMES;
     }
     return PARSER_OK;
 }

--- a/projects/rocdecode/src/parser/hevc_parser.cpp
+++ b/projects/rocdecode/src/parser/hevc_parser.cpp
@@ -1215,14 +1215,23 @@ ParserResult HevcVideoParser::ParseVui(HevcSeqParamSet *sps_ptr, uint8_t *nalu, 
             vui->colour_primaries = Parser::ReadBits(nalu, offset, 8);
             vui->transfer_characteristics = Parser::ReadBits(nalu, offset, 8);
             vui->matrix_coeffs = Parser::ReadBits(nalu, offset, 8);
+        } else {
+            vui->colour_primaries = 2;           // Unspecified
+            vui->transfer_characteristics = 2;   // Unspecified
+            vui->matrix_coeffs = 2;              // Unspecified
         }
+    } else {
+        vui->video_format = 5;                   // Unspecified
+        vui->colour_primaries = 2;               // Unspecified
+        vui->transfer_characteristics = 2;       // Unspecified
+        vui->matrix_coeffs = 2;                  // Unspecified
     }
     vui->chroma_loc_info_present_flag = Parser::GetBit(nalu, offset);
     if (vui->chroma_loc_info_present_flag) {
         vui->chroma_sample_loc_type_top_field = Parser::ExpGolomb::ReadUe(nalu, offset);
-        CHECK_ALLOWED_RANGE("chroma_sample_loc_type_top_field", vui->chroma_sample_loc_type_top_field, 0, 5);
+        CHECK_RANGE_AND_SET_DEFAULT("chroma_sample_loc_type_top_field", vui->chroma_sample_loc_type_top_field, 0, 5, 0);
         vui->chroma_sample_loc_type_bottom_field = Parser::ExpGolomb::ReadUe(nalu, offset);
-        CHECK_ALLOWED_RANGE("chroma_sample_loc_type_bottom_field", vui->chroma_sample_loc_type_bottom_field, 0, 5);
+        CHECK_RANGE_AND_SET_DEFAULT("chroma_sample_loc_type_bottom_field", vui->chroma_sample_loc_type_bottom_field, 0, 5, 0);
     }
     vui->neutral_chroma_indication_flag = Parser::GetBit(nalu, offset);
     vui->field_seq_flag = Parser::GetBit(nalu, offset);
@@ -1233,12 +1242,20 @@ ParserResult HevcVideoParser::ParseVui(HevcSeqParamSet *sps_ptr, uint8_t *nalu, 
         vui->def_disp_win_right_offset = Parser::ExpGolomb::ReadUe(nalu, offset);
         uint32_t left_offset = sps_ptr->conf_win_left_offset + vui->def_disp_win_left_offset;
         uint32_t right_offset = sps_ptr->conf_win_right_offset + vui->def_disp_win_right_offset;
-        CHECK_ALLOWED_MAX("SubWidthC * (leftOffset + rightOffset)", sub_width_c_ * (left_offset + right_offset), sps_ptr->pic_width_in_luma_samples - 1);
+        if (sub_width_c_ * (left_offset + right_offset) > sps_ptr->pic_width_in_luma_samples - 1) {
+            ErrorLog(g_rocdec_logger, "SubWidthC * (leftOffset + rightOffset) value greater than maximum allowed value: " + ROCDEC_TOSTR(sub_width_c_ * (left_offset + right_offset)) + ", max: " + ROCDEC_TOSTR(sps_ptr->pic_width_in_luma_samples - 1) + ". Using default value: 0");
+            vui->def_disp_win_left_offset = 0;
+            vui->def_disp_win_right_offset = 0;
+        }
         vui->def_disp_win_top_offset = Parser::ExpGolomb::ReadUe(nalu, offset);
         vui->def_disp_win_bottom_offset = Parser::ExpGolomb::ReadUe(nalu, offset);
         uint32_t top_offset = sps_ptr->conf_win_top_offset + vui->def_disp_win_top_offset;
         uint32_t bottom_offset = sps_ptr->conf_win_bottom_offset + vui->def_disp_win_bottom_offset;
-        CHECK_ALLOWED_MAX("SubHeightC * (topOffset + bottomOffset)", sub_height_c_ * (top_offset + bottom_offset), sps_ptr->pic_height_in_luma_samples);
+        if (sub_height_c_ * (top_offset + bottom_offset) > sps_ptr->pic_height_in_luma_samples) {
+            ErrorLog(g_rocdec_logger, "SubHeightC * (topOffset + bottomOffset) value greater than maximum allowed value: " + ROCDEC_TOSTR(sub_height_c_ * (top_offset + bottom_offset)) + ", max: " + ROCDEC_TOSTR(sps_ptr->pic_height_in_luma_samples) + ". Using default value: 0");
+            vui->def_disp_win_top_offset = 0;
+            vui->def_disp_win_bottom_offset = 0;
+        }
     }
     vui->vui_timing_info_present_flag = Parser::GetBit(nalu, offset);
     if (vui->vui_timing_info_present_flag) {
@@ -1250,9 +1267,8 @@ ParserResult HevcVideoParser::ParseVui(HevcSeqParamSet *sps_ptr, uint8_t *nalu, 
         }
         vui->vui_hrd_parameters_present_flag = Parser::GetBit(nalu, offset);
         if (vui->vui_hrd_parameters_present_flag) {
-            ParserResult ret;
-            if ((ret = ParseHrdParameters(&vui->hrd_parameters, 1, sps_ptr->sps_max_sub_layers_minus1, nalu, size, offset)) != PARSER_OK) {
-                return ret;
+            if (ParseHrdParameters(&vui->hrd_parameters, 1, sps_ptr->sps_max_sub_layers_minus1, nalu, size, offset) != PARSER_OK) {
+                ErrorLog(g_rocdec_logger, "Failed to parse HRD parameters in VUI.");
             }
         }
     }
@@ -1262,15 +1278,21 @@ ParserResult HevcVideoParser::ParseVui(HevcSeqParamSet *sps_ptr, uint8_t *nalu, 
         vui->motion_vectors_over_pic_boundaries_flag = Parser::GetBit(nalu, offset);
         vui->restricted_ref_pic_lists_flag = Parser::GetBit(nalu, offset);
         vui->min_spatial_segmentation_idc = Parser::ExpGolomb::ReadUe(nalu, offset);
-        CHECK_ALLOWED_RANGE("min_spatial_segmentation_idc", vui->min_spatial_segmentation_idc, 0, 4095);
+        CHECK_RANGE_AND_SET_DEFAULT("min_spatial_segmentation_idc", vui->min_spatial_segmentation_idc, 0, 4095, 0);
         vui->max_bytes_per_pic_denom = Parser::ExpGolomb::ReadUe(nalu, offset);
-        CHECK_ALLOWED_RANGE("max_bytes_per_pic_denom", vui->max_bytes_per_pic_denom, 0, 16);
+        CHECK_RANGE_AND_SET_DEFAULT("max_bytes_per_pic_denom", vui->max_bytes_per_pic_denom, 0, 16, 2);
         vui->max_bits_per_min_cu_denom = Parser::ExpGolomb::ReadUe(nalu, offset);
-        CHECK_ALLOWED_RANGE("max_bits_per_min_cu_denom", vui->max_bits_per_min_cu_denom, 0, 16);
+        CHECK_RANGE_AND_SET_DEFAULT("max_bits_per_min_cu_denom", vui->max_bits_per_min_cu_denom, 0, 16, 1);
         vui->log2_max_mv_length_horizontal = Parser::ExpGolomb::ReadUe(nalu, offset);
-        CHECK_ALLOWED_RANGE("log2_max_mv_length_horizontal", vui->log2_max_mv_length_horizontal, 0, 16);
+        CHECK_RANGE_AND_SET_DEFAULT("log2_max_mv_length_horizontal", vui->log2_max_mv_length_horizontal, 0, 16, 15);
         vui->log2_max_mv_length_vertical = Parser::ExpGolomb::ReadUe(nalu, offset);
-        CHECK_ALLOWED_RANGE("log2_max_mv_length_vertical", vui->log2_max_mv_length_vertical, 0, 15);
+        CHECK_RANGE_AND_SET_DEFAULT("log2_max_mv_length_vertical", vui->log2_max_mv_length_vertical, 0, 15, 15);
+    } else {
+        vui->motion_vectors_over_pic_boundaries_flag = 1;
+        vui->max_bytes_per_pic_denom = 2;
+        vui->max_bits_per_min_cu_denom = 1;
+        vui->log2_max_mv_length_horizontal = 15;
+        vui->log2_max_mv_length_vertical = 15;
     }
     return PARSER_OK;
 }
@@ -1515,9 +1537,11 @@ ParserResult HevcVideoParser::ParseSps(uint8_t *nalu, size_t size) {
     sps_ptr->strong_intra_smoothing_enabled_flag = Parser::GetBit(nalu, offset);
     sps_ptr->vui_parameters_present_flag = Parser::GetBit(nalu, offset);
     if (sps_ptr->vui_parameters_present_flag) {
-        //vui_parameters()
-        if((ret = ParseVui(sps_ptr, nalu, size, offset)) != PARSER_OK) {
-            return ret;
+        // Treat VUI parameter parsing failure as non-fatal error and continue parsing since VUI parameters
+        // are not necessary for decoding. The decoder can choose to apply default VUI parameters or skip
+        // applying VUI parameters when VUI parameters parsing failure.
+        if (ParseVui(sps_ptr, nalu, size, offset) != PARSER_OK) {
+            ErrorLog(g_rocdec_logger, "Failed to parse VUI parameters. Default VUI parameters will be applied.");
         }
     }
     sps_ptr->sps_extension_flag = Parser::GetBit(nalu, offset);

--- a/projects/rocdecode/src/parser/hevc_parser.cpp
+++ b/projects/rocdecode/src/parser/hevc_parser.cpp
@@ -1242,8 +1242,9 @@ ParserResult HevcVideoParser::ParseVui(HevcSeqParamSet *sps_ptr, uint8_t *nalu, 
         vui->def_disp_win_right_offset = Parser::ExpGolomb::ReadUe(nalu, offset);
         uint32_t left_offset = sps_ptr->conf_win_left_offset + vui->def_disp_win_left_offset;
         uint32_t right_offset = sps_ptr->conf_win_right_offset + vui->def_disp_win_right_offset;
-        if (sub_width_c_ * (left_offset + right_offset) > sps_ptr->pic_width_in_luma_samples - 1) {
-            ErrorLog(g_rocdec_logger, "SubWidthC * (leftOffset + rightOffset) value greater than maximum allowed value: " + ROCDEC_TOSTR(sub_width_c_ * (left_offset + right_offset)) + ", max: " + ROCDEC_TOSTR(sps_ptr->pic_width_in_luma_samples - 1) + ". Using default value: 0");
+        uint64_t data = static_cast<uint64_t>(sub_width_c_) * (left_offset + right_offset);
+        if (data > sps_ptr->pic_width_in_luma_samples - 1) {
+            ErrorLog(g_rocdec_logger, "SubWidthC * (leftOffset + rightOffset) value greater than maximum allowed value: " + ROCDEC_TOSTR(data) + ", max: " + ROCDEC_TOSTR(sps_ptr->pic_width_in_luma_samples - 1) + ". Using default value: 0");
             vui->def_disp_win_left_offset = 0;
             vui->def_disp_win_right_offset = 0;
         }
@@ -1251,8 +1252,9 @@ ParserResult HevcVideoParser::ParseVui(HevcSeqParamSet *sps_ptr, uint8_t *nalu, 
         vui->def_disp_win_bottom_offset = Parser::ExpGolomb::ReadUe(nalu, offset);
         uint32_t top_offset = sps_ptr->conf_win_top_offset + vui->def_disp_win_top_offset;
         uint32_t bottom_offset = sps_ptr->conf_win_bottom_offset + vui->def_disp_win_bottom_offset;
-        if (sub_height_c_ * (top_offset + bottom_offset) > sps_ptr->pic_height_in_luma_samples) {
-            ErrorLog(g_rocdec_logger, "SubHeightC * (topOffset + bottomOffset) value greater than maximum allowed value: " + ROCDEC_TOSTR(sub_height_c_ * (top_offset + bottom_offset)) + ", max: " + ROCDEC_TOSTR(sps_ptr->pic_height_in_luma_samples) + ". Using default value: 0");
+        data = static_cast<uint64_t>(sub_height_c_) * (top_offset + bottom_offset);
+        if (data > sps_ptr->pic_height_in_luma_samples) {
+            ErrorLog(g_rocdec_logger, "SubHeightC * (topOffset + bottomOffset) value greater than maximum allowed value: " + ROCDEC_TOSTR(data) + ", max: " + ROCDEC_TOSTR(sps_ptr->pic_height_in_luma_samples) + ". Using default value: 0");
             vui->def_disp_win_top_offset = 0;
             vui->def_disp_win_bottom_offset = 0;
         }
@@ -1542,7 +1544,7 @@ ParserResult HevcVideoParser::ParseSps(uint8_t *nalu, size_t size) {
         // Treat VUI parameter parsing failure as non-fatal error and continue parsing since VUI parameters
         // are not necessary for decoding.
         if ((ret = ParseVui(sps_ptr, nalu, size, offset)) != PARSER_OK) {
-            ErrorLog(g_rocdec_logger, "Failed to parse VUI parameters. Default VUI parameters will be applied.");
+            ErrorLog(g_rocdec_logger, "Failed to parse VUI parameters.");
         }
     }
     if (ret == PARSER_OK) {

--- a/projects/rocdecode/src/parser/hevc_parser.cpp
+++ b/projects/rocdecode/src/parser/hevc_parser.cpp
@@ -814,7 +814,7 @@ void HevcVideoParser::ParseSubLayerHrdParameters(HevcSubLayerHrdParameters *sub_
     }
 }
 
-ParserResult HevcVideoParser::ParseHrdParameters(HevcHrdParameters *hrd, bool common_inf_present_flag, uint32_t max_num_sub_layers_minus1, uint8_t *nalu, size_t size,size_t &offset) {
+ParserResult HevcVideoParser::ParseHrdParameters(HevcHrdParameters *hrd, bool common_inf_present_flag, uint32_t max_num_sub_layers_minus1, uint8_t *nalu, size_t size, size_t &offset) {
     if (common_inf_present_flag) {
         hrd->nal_hrd_parameters_present_flag = Parser::GetBit(nalu, offset);
         hrd->vcl_hrd_parameters_present_flag = Parser::GetBit(nalu, offset);
@@ -1541,11 +1541,13 @@ ParserResult HevcVideoParser::ParseSps(uint8_t *nalu, size_t size) {
     if (sps_ptr->vui_parameters_present_flag) {
         // Treat VUI parameter parsing failure as non-fatal error and continue parsing since VUI parameters
         // are not necessary for decoding.
-        if (ParseVui(sps_ptr, nalu, size, offset) != PARSER_OK) {
+        if ((ret = ParseVui(sps_ptr, nalu, size, offset)) != PARSER_OK) {
             ErrorLog(g_rocdec_logger, "Failed to parse VUI parameters. Default VUI parameters will be applied.");
         }
     }
-    sps_ptr->sps_extension_flag = Parser::GetBit(nalu, offset);
+    if (ret == PARSER_OK) {
+        sps_ptr->sps_extension_flag = Parser::GetBit(nalu, offset);
+    }
     sps_ptr->is_received = 1;
 
     if (g_rocdec_logger.GetLogLevel() >= kRocDecLogDebug) {

--- a/projects/rocdecode/src/parser/hevc_parser.cpp
+++ b/projects/rocdecode/src/parser/hevc_parser.cpp
@@ -1267,8 +1267,10 @@ ParserResult HevcVideoParser::ParseVui(HevcSeqParamSet *sps_ptr, uint8_t *nalu, 
         }
         vui->vui_hrd_parameters_present_flag = Parser::GetBit(nalu, offset);
         if (vui->vui_hrd_parameters_present_flag) {
-            if (ParseHrdParameters(&vui->hrd_parameters, 1, sps_ptr->sps_max_sub_layers_minus1, nalu, size, offset) != PARSER_OK) {
+            ParserResult ret = ParseHrdParameters(&vui->hrd_parameters, 1, sps_ptr->sps_max_sub_layers_minus1, nalu, size, offset);
+            if (ret != PARSER_OK) {
                 ErrorLog(g_rocdec_logger, "Failed to parse HRD parameters in VUI.");
+                return ret;
             }
         }
     }
@@ -1538,8 +1540,7 @@ ParserResult HevcVideoParser::ParseSps(uint8_t *nalu, size_t size) {
     sps_ptr->vui_parameters_present_flag = Parser::GetBit(nalu, offset);
     if (sps_ptr->vui_parameters_present_flag) {
         // Treat VUI parameter parsing failure as non-fatal error and continue parsing since VUI parameters
-        // are not necessary for decoding. The decoder can choose to apply default VUI parameters or skip
-        // applying VUI parameters when VUI parameters parsing failure.
+        // are not necessary for decoding.
         if (ParseVui(sps_ptr, nalu, size, offset) != PARSER_OK) {
             ErrorLog(g_rocdec_logger, "Failed to parse VUI parameters. Default VUI parameters will be applied.");
         }

--- a/projects/rocdecode/src/parser/roc_video_parser.h
+++ b/projects/rocdecode/src/parser/roc_video_parser.h
@@ -87,10 +87,24 @@ typedef struct {
     } \
 }
 
+#define CHECK_RANGE_AND_SET_DEFAULT(str, val, min, max, default_val) { \
+    if (val < min || val > max) { \
+        ErrorLog(g_rocdec_logger, ROCDEC_STR(str) + " value out of range: " + ROCDEC_TOSTR(val) + ", allowed (min,max): " + ROCDEC_TOSTR(min) + "," + ROCDEC_TOSTR(max) + ". Using default value: " + ROCDEC_TOSTR(default_val)); \
+        val = default_val; \
+    } \
+}
+
 #define CHECK_ALLOWED_MAX(str, val, max) { \
     if (val > max) { \
         ErrorLog(g_rocdec_logger, ROCDEC_STR(str) +  " value greater than maximum allowed value: " + ROCDEC_TOSTR(val) + ", max: " + ROCDEC_TOSTR(max)); \
         return PARSER_OUT_OF_RANGE; \
+    } \
+}
+
+#define CHECK_MAX_AND_SET_DEFAULT(str, val, max, default_val) { \
+    if (val > max) { \
+        ErrorLog(g_rocdec_logger, ROCDEC_STR(str) + " value greater than maximum allowed value: " + ROCDEC_TOSTR(val) + ", max: " + ROCDEC_TOSTR(max) + ". Using default value: " + ROCDEC_TOSTR(default_val)); \
+        val = default_val; \
     } \
 }
 


### PR DESCRIPTION
## Motivation

This PR improves handling of VUI syntax parameter errors for AVC and HEVC stream decode.

## Technical Details
A few changes to the current VUI parameter error handling where errors are returned and result in SPS parsing failure.
 - VUI syntax parameter errors are now treated as non-fatal as they are not generally required for decoding.
 - Incorrect VUI parameters are assigned to default values according to the spec.
 - VUI parameter parsing failure will not result in SPS parsing failure.
 - Also added the missing defaults when VUI present flags are 0.

## JIRA ID

AICV-164.

## Test Plan

Decode the error streams that has VUI syntax errors.

## Test Result

rocDecode should be able to decode the error streams, instead of reporting decode errors.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
