### PR TITLE
[rocprofiler-compute] Fix kernel names regression in roofline plots and logs

### DIFF
--- a/projects/rocprofiler-compute/src/roofline/roofline_main.py
+++ b/projects/rocprofiler-compute/src/roofline/roofline_main.py
@@ -1204,7 +1204,7 @@ class Roofline:
                     plt.plot(
                         [self.__ai_data[key][0][i]],
                         [self.__ai_data[key][1][i]],
-                        label=f"AI_{cache_level}_{kernel_names[i]}",
+                        label=f"AI_{cache_level}_{kernel_names[i][:40]}",
                         color=color_scheme[cache_level],
                         marker=kernel_markers[i % len(kernel_markers)],
                     )

--- a/projects/rocprofiler-compute/src/utils/roofline_calc.py
+++ b/projects/rocprofiler-compute/src/utils/roofline_calc.py
@@ -432,11 +432,17 @@ def calc_ai_analyze(
                 plot_points.ai_l1[0].append(ai_l1)
                 plot_points.ai_l1[1].append(performance)
 
-            plot_points.kernelNames.append(f"K{kernel_id}")
-            console_debug("roofline", f"Added kernel {kernel_id} to plot points")
+            plot_points.kernelNames.append(f"{kernel_name}")
+            console_debug(
+                "roofline",
+                f"Added kernel {kernel_id}: {kernel_name[:50]}\
+                          to plot points",
+            )
         else:
             console_debug(
-                "roofline", f"Skipping kernel {kernel_id} - no performance data"
+                "roofline",
+                f"Skipping kernel {kernel_id}: {kernel_name[:50]} \
+                    - no performance data",
             )
 
         # store metrics for display

--- a/projects/rocprofiler-compute/src/utils/roofline_calc.py
+++ b/projects/rocprofiler-compute/src/utils/roofline_calc.py
@@ -432,17 +432,16 @@ def calc_ai_analyze(
                 plot_points.ai_l1[0].append(ai_l1)
                 plot_points.ai_l1[1].append(performance)
 
-            plot_points.kernelNames.append(f"{kernel_name}")
+            plot_points.kernelNames.append(kernel_name)
             console_debug(
                 "roofline",
-                f"Added kernel {kernel_id}: {kernel_name[:50]}\
-                          to plot points",
+                f"Added kernel {kernel_id}: {kernel_name[:50]} to plot points",
             )
         else:
             console_debug(
                 "roofline",
-                f"Skipping kernel {kernel_id}: {kernel_name[:50]} \
-                    - no performance data",
+                f"Skipping kernel {kernel_id}: {kernel_name[:50]}"
+                f" - no performance data",
             )
 
         # store metrics for display

--- a/projects/rocprofiler-compute/tests/test_roofline_calc_ai_analyze.py
+++ b/projects/rocprofiler-compute/tests/test_roofline_calc_ai_analyze.py
@@ -84,7 +84,7 @@ def test_calc_ai_analyze_replaces_inf_with_zero(monkeypatch):
         },
     )
 
-    assert result["kernelNames"] == ["K0"]
+    assert result["kernelNames"] == ["test_kernel"]
     assert result["ai_hbm"][0] == [0], "np.inf should be replaced with 0"
     assert result["ai_hbm"][1] == [100.0]
     assert result["ai_l2"][0] == [0], "-np.inf should be replaced with 0"
@@ -105,7 +105,7 @@ def test_calc_ai_analyze_replaces_none_with_zero(monkeypatch):
         },
     )
 
-    assert result["kernelNames"] == ["K0"]
+    assert result["kernelNames"] == ["test_kernel"]
     assert result["ai_hbm"][0] == [0], "None should be replaced with 0"
     assert result["ai_l2"][0] == [0], "None should be replaced with 0"
     assert result["ai_l1"][0] == [0], "None should be replaced with 0"
@@ -123,7 +123,7 @@ def test_calc_ai_analyze_valid_values_pass_through(monkeypatch):
         },
     )
 
-    assert result["kernelNames"] == ["K0"]
+    assert result["kernelNames"] == ["test_kernel"]
     assert result["ai_hbm"][0] == [2.5]
     assert result["ai_hbm"][1] == [100.0]
     assert result["ai_l2"][0] == [3.0]
@@ -144,7 +144,7 @@ def test_calc_ai_analyze_na_and_empty_replaced(monkeypatch):
         },
     )
 
-    assert result["kernelNames"] == ["K0"]
+    assert result["kernelNames"] == ["test_kernel"]
     assert result["ai_hbm"][0] == [0], "'N/A' should be replaced with 0"
     assert result["ai_l2"][0] == [0], "'' should be replaced with 0"
     assert result["ai_l1"][0] == [0], "'N/A' should be replaced with 0"


### PR DESCRIPTION
## Motivation

Kernel names were reported missing in the roofline plots. This commit re-populates the kernel names into the roofline db schema's kernel_names key, and into the plots in CLI, html output, and debug logging.

## Technical Details

Kernel ID was populated into the schema rather than the kernel names, so we were not able to see names to IDs.

Populates the actual names of the kernels into kernel_name of the db instead of kernel's ID
Added name to the debug console logs
Split kernel name at :40 for CLI plot output to ensure generic fit into terminal console, since we don't know the size.


## JIRA ID

ROCM-24909

## Test Plan

Manual testing to ensure human readability of the plots and logs.

See below for original vs modified kernel names section of the html plots:
<img width="978" height="1113" alt="Screenshot 2026-05-20 172911" src="https://github.com/user-attachments/assets/1bdb6e3d-5ccf-4d53-b495-e04060d71ae2" />
<img width="1030" height="1127" alt="Screenshot 2026-05-20 172533" src="https://github.com/user-attachments/assets/3437955e-ef1f-448c-b7f5-9aeca71d69bd" />

See below for CLI terminal output after commit:
<img width="1087" height="528" alt="Screenshot 2026-05-20 174248" src="https://github.com/user-attachments/assets/36842e5a-51e7-45da-a21e-cc3dc5c53dd3" />

Also verified handling of long wraparound names in the html output:
<img width="1070" height="900" alt="Screenshot 2026-05-20 175123" src="https://github.com/user-attachments/assets/d2ae262c-927a-4d2c-bad8-eca3444f7428" />

Also verified works with kernel filtering in analyze mode.

## Test Result

See above. Changes all involve visual checks to ensure UX is fine.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
