### PR TITLE
ROCM-24264 - Fix out-of-order host queue rejection ignoring combined properties

### DIFF
--- a/projects/clr/opencl/amdocl/cl_command.cpp
+++ b/projects/clr/opencl/amdocl/cl_command.cpp
@@ -77,9 +77,6 @@ RUNTIME_ENTRY_RET(cl_command_queue, clCreateCommandQueueWithProperties,
     cl_queue_properties name;
     union {
       cl_queue_properties raw;
-      // FIXME_lmoriche: Check with Khronos. cl_queue_properties is an intptr,
-      // but cl_command_queue_properties is a bitfield (truncate?).
-      // cl_command_queue_properties properties;
       cl_uint size;
     } value;
   }* p = reinterpret_cast<const QueueProperty*>(queue_properties);
@@ -93,15 +90,12 @@ RUNTIME_ENTRY_RET(cl_command_queue, clCreateCommandQueueWithProperties,
     while (p->name != 0) {
       switch (p->name) {
         case CL_QUEUE_PROPERTIES:
-          // FIXME_lmoriche: See comment above.
-          // properties = p->value.properties;
           properties = static_cast<cl_command_queue_properties>(p->value.raw);
           if ((int32_t) properties < 0) {
             *not_null(errcode_ret) = CL_INVALID_VALUE;
             return (cl_command_queue)0;
           }
-          else if ((properties == CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE) &&
-            !(properties & queueProperty)) { 
+          else if (properties & ~queueProperty) {
             *not_null(errcode_ret) = CL_INVALID_QUEUE_PROPERTIES;
             return (cl_command_queue)0;
           }
@@ -121,7 +115,7 @@ RUNTIME_ENTRY_RET(cl_command_queue, clCreateCommandQueueWithProperties,
           }
           break;
         case CL_QUEUE_ON_DEVICE:
-          if((properties == CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE) &&
+          if((properties & CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE) &&
             !(properties & queueonDeviceProperty)) {
             *not_null(errcode_ret) = CL_INVALID_QUEUE_PROPERTIES;
             return (cl_command_queue)0;


### PR DESCRIPTION

## Motivation
Fix out-of-order host queue rejection ignoring combined properties
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
treat cl_command_queue_properties as a bitfield
<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
ROCM-24264
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
local test I wrote to test clCreateCommandQueueWithProperties with possible flags
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Pass
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
