### PR TITLE
[rocprofiler-systems] Clean up jacobi-hip example

### DIFF
--- a/projects/rocprofiler-systems/examples/hpc/jacobi-hip/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/hpc/jacobi-hip/CMakeLists.txt
@@ -27,16 +27,14 @@ if(NOT MPI_CXX_FOUND)
     return()
 endif()
 
-find_library(ROCTX64_LIBRARY NAMES roctx64 PATHS ${ROCM_PATH}/lib ${ROCM_PATH}/lib64)
-
 find_library(
-    ROCTRACER64_LIBRARY
-    NAMES roctracer64
+    ROCTX_SDK_LIBRARY
+    NAMES rocprofiler-sdk-roctx
     PATHS ${ROCM_PATH}/lib ${ROCM_PATH}/lib64
 )
 
-if(NOT ROCTX64_LIBRARY OR NOT ROCTRACER64_LIBRARY)
-    rocprofiler_systems_message(AUTHOR_WARNING "roctracer not found, this is required for jacobi-hip example")
+if(NOT ROCTX_SDK_LIBRARY)
+    rocprofiler_systems_message(AUTHOR_WARNING "rocprofiler-sdk-roctx not found, this is required for jacobi-hip example")
     return()
 endif()
 
@@ -57,10 +55,6 @@ add_executable(${HPC_EXAMPLE_NAME} ${_JACOBI_HIP_SOURCES})
 
 target_compile_options(${HPC_EXAMPLE_NAME} PRIVATE -xhip)
 target_compile_definitions(${HPC_EXAMPLE_NAME} PRIVATE __HIP_PLATFORM_HCC__)
-target_include_directories(
-    ${HPC_EXAMPLE_NAME}
-    PRIVATE ${ROCM_PATH}/roctracer/include ${ROCM_PATH}/include/roctracer
-)
 target_compile_options(
     ${HPC_EXAMPLE_NAME}
     PRIVATE -O3 -g -ggdb -fPIC -march=native -Wall -Wno-unused-result
@@ -71,10 +65,7 @@ foreach(arch IN LISTS ROCPROFSYS_GFX_TARGETS)
     target_link_options(${HPC_EXAMPLE_NAME} PRIVATE --offload-arch=${arch})
 endforeach()
 
-target_link_libraries(
-    ${HPC_EXAMPLE_NAME}
-    PRIVATE MPI::MPI_CXX ${ROCTX64_LIBRARY} ${ROCTRACER64_LIBRARY}
-)
+target_link_libraries(${HPC_EXAMPLE_NAME} PRIVATE MPI::MPI_CXX ${ROCTX_SDK_LIBRARY})
 
 if(NOT CMAKE_CXX_COMPILER_IS_HIPCC)
     rocprofiler_systems_custom_compilation(COMPILER ${HIPCC_EXECUTABLE} TARGET ${HPC_EXAMPLE_NAME})

--- a/projects/rocprofiler-systems/examples/hpc/jacobi-hip/JacobiMain.hip
+++ b/projects/rocprofiler-systems/examples/hpc/jacobi-hip/JacobiMain.hip
@@ -39,18 +39,20 @@ int main(int argc, char ** argv)
 
   MPI_Comm comm = MPI_COMM_WORLD;
 
-  grid_t grid;
-  mesh_t mesh;
+  {
+    grid_t grid;
+    mesh_t mesh;
 
-  // Extract topology and domain dimensions from the command-line arguments
-  ParseCommandLineArguments(argc, argv,
-                            comm,
-                            grid,
-                            mesh);
+    // Extract topology and domain dimensions from the command-line arguments
+    ParseCommandLineArguments(argc, argv,
+                              comm,
+                              grid,
+                              mesh);
 
-  Jacobi_t Jacobi(grid, mesh);
+    Jacobi_t Jacobi(grid, mesh);
 
-  Jacobi.Run();
+    Jacobi.Run();
+  }  // Jacobi destructor (hipHostFree) runs here, before MPI_Finalize
 
   // Finalize the MPI process
   MPI_Finalize();

--- a/projects/rocprofiler-systems/examples/hpc/jacobi-hip/JacobiSetup.hip
+++ b/projects/rocprofiler-systems/examples/hpc/jacobi-hip/JacobiSetup.hip
@@ -10,9 +10,7 @@ Jacobi_t::Jacobi_t(grid_t& grid_, mesh_t& mesh_):
   grid(grid_),
   mesh(mesh_)
 {
-  // Ensure that HIP is initialized before profiler is loaded
   SafeHipCall(hipInit(0));
-  initialize_logger();
   BEGIN_RANGE("Jacobi_t::Jacobi_t", "Top Level Init");
 
   BEGIN_RANGE("ApplyTopology", "Init");
@@ -44,7 +42,6 @@ Jacobi_t::~Jacobi_t() {
   SafeHipCall(hipHostFree(mesh.sendBuffer));
   SafeHipCall(hipHostFree(mesh.recvBuffer));
   SafeHipCall(hipFree(mesh.d_haloBuffer));
-  finalize_logger();
 }
 
 // ====================

--- a/projects/rocprofiler-systems/examples/hpc/jacobi-hip/markers.h
+++ b/projects/rocprofiler-systems/examples/hpc/jacobi-hip/markers.h
@@ -16,8 +16,7 @@
 #if defined(__HIP_PLATFORM_HCC__)
 // begin HCC
 
-#    include <roctracer/roctracer_ext.h>
-#    include <roctracer/roctx.h>
+#    include <rocprofiler-sdk-roctx/roctx.h>
 
 #    define BEGIN_RANGE(name, group)                                                     \
         do                                                                               \
@@ -68,18 +67,6 @@ public:
             const char* cstr = str.c_str();                                              \
             roctxMark(cstr);                                                             \
         } while(0)  // must terminate with semi-colon
-
-static inline void
-initialize_logger()
-{
-    roctracer_start();
-}
-
-static inline void
-finalize_logger()
-{
-    roctracer_stop();
-}
 
 #else  // __HIP_PLATFORM_NVCC__
 // Begin CUDA

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -1143,6 +1143,14 @@ configure_settings(bool _init)
         _combine_perfetto_traces->second->set(_config->get<bool>("collapse_processes"));
     }
 
+    auto _merge_perfetto_files = _config->find("ROCPROFSYS_MERGE_PERFETTO_FILES");
+    if(!_merge_perfetto_files->second->get_environ_updated() &&
+       !_merge_perfetto_files->second->get_config_updated())
+    {
+        _merge_perfetto_files->second->set(
+            static_cast<tim::tsettings<bool>&>(*_combine_perfetto_traces->second).get());
+    }
+
     handle_deprecated_setting("ROCPROFSYS_AMD_SMI_DEVICES", "ROCPROFSYS_SAMPLING_GPUS");
     handle_deprecated_setting("ROCPROFSYS_USE_THREAD_SAMPLING",
                               "ROCPROFSYS_USE_PROCESS_SAMPLING");

--- a/projects/rocprofiler-systems/tests/pytest/test_hpc.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_hpc.py
@@ -168,11 +168,9 @@ class TestJacobi(RocprofsysTest):
             depths=[1, 1],
         )
 
-    @pytest.mark.rocm
     @pytest.mark.hip
     @pytest.mark.mpi
     @pytest.mark.multi_gpu(2)
-    @pytest.mark.timeout(600)
     @pytest.mark.rocpd("hpc_hip_environment")
     @pytest.mark.parametrize("mode", ["sys_run"])
     def test_hip(self, mode, hpc_hip_environment):
@@ -187,6 +185,7 @@ class TestJacobi(RocprofsysTest):
             launcher="mpi",
             num_procs=2,
         )
+        self.assert_regex(result)
         # Taken from the program's defines.hpp
         JACOBI_MAX_LOOPS = 1000
 

--- a/projects/rocprofiler-systems/tests/pytest/test_hpc.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_hpc.py
@@ -171,11 +171,12 @@ class TestJacobi(RocprofsysTest):
     @pytest.mark.rocm
     @pytest.mark.hip
     @pytest.mark.mpi
+    @pytest.mark.multi_gpu(2)
+    @pytest.mark.timeout(600)
     @pytest.mark.rocpd("hpc_hip_environment")
     @pytest.mark.parametrize("mode", ["sys_run"])
     def test_hip(self, mode, hpc_hip_environment):
         env = hpc_hip_environment.copy()
-        env["ROCPROFSYS_TRACE_LEGACY"] = "ON"
         env["ROCPROFSYS_PERFETTO_COMBINE_TRACES"] = "ON"
 
         result = self.run_test(
@@ -186,18 +187,10 @@ class TestJacobi(RocprofsysTest):
             launcher="mpi",
             num_procs=2,
         )
-        # hipHostFree is one of the last calls and should be present if the program worked correctly
-        self.assert_regex(
-            result,
-            pass_regex=[r"0>>>.*_hipHostFree"],
-        )
-
         # Taken from the program's defines.hpp
         JACOBI_MAX_LOOPS = 1000
 
         # With -g 2 1, 2 MPI ranks exist. The merged perfetto trace has 2x the per-rank count
-        MERGED_LAPLACIAN_KERNEL_COUNT = JACOBI_MAX_LOOPS * 2
-
         self.assert_perfetto(
             result,
             subtest_name="Laplacian Kernel Count Validation",
@@ -205,8 +198,17 @@ class TestJacobi(RocprofsysTest):
             categories=["rocm_hip_stream"],
             print_output=True,
             pass_regex=[
-                rf"LocalLaplacianKernel.*\|\s+{MERGED_LAPLACIAN_KERNEL_COUNT}\s+\|"
+                rf"LocalLaplacianKernel.*\|\s+{JACOBI_MAX_LOOPS * 2}\s+\|"
             ],
+        )
+
+        # hipHostFree is one of the last calls — tracked via rocprofiler-sdk in Perfetto
+        self.assert_perfetto(
+            result,
+            subtest_name="hipHostFree Validation",
+            perfetto_file="merged.proto",
+            categories=["rocm_hip_api"],
+            pass_regex=[r"hipHostFree\s*\|\s*[1-9]"],
         )
 
 

--- a/projects/rocprofiler-systems/tests/pytest/test_hpc.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_hpc.py
@@ -168,6 +168,7 @@ class TestJacobi(RocprofsysTest):
             depths=[1, 1],
         )
 
+    @pytest.mark.rocm
     @pytest.mark.hip
     @pytest.mark.mpi
     @pytest.mark.rocpd("hpc_hip_environment")

--- a/projects/rocprofiler-systems/tests/pytest/test_hpc.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_hpc.py
@@ -197,9 +197,7 @@ class TestJacobi(RocprofsysTest):
             perfetto_file="merged.proto",
             categories=["rocm_hip_stream"],
             print_output=True,
-            pass_regex=[
-                rf"LocalLaplacianKernel.*\|\s+{JACOBI_MAX_LOOPS * 2}\s+\|"
-            ],
+            pass_regex=[rf"LocalLaplacianKernel.*\|\s+{JACOBI_MAX_LOOPS * 2}\s+\|"],
         )
 
         # hipHostFree is one of the last calls — tracked via rocprofiler-sdk in Perfetto


### PR DESCRIPTION
## Motivation

The `jacobi-hip` HPC example used `roctx64` + `roctracer64` (the legacy roctracer library pair) for range markers and start/stop lifecycle calls. `roctracer` has been superseded by `rocprofiler-sdk`, which exposes the same roctx push/pop/mark API through `rocprofiler-sdk-roctx` and manages profiling lifecycle externally via the tool — making explicit `roctracer_start()`/`roctracer_stop()` calls unnecessary.

## Technical Details

**`examples/hpc/jacobi-hip/markers.h`**
- Replaced `#include <roctracer/roctracer_ext.h>` and `#include <roctracer/roctx.h>` with `#include <rocprofiler-sdk-roctx/roctx.h>`.
- Removed the no-op `initialize_logger()` / `finalize_logger()` functions from the HCC block; the SDK does not require explicit profiler start/stop from the application side.

**`examples/hpc/jacobi-hip/JacobiSetup.hip`**
- Removed the `initialize_logger()` call from `Jacobi_t::Jacobi_t()` and its associated comment.
- Removed the `finalize_logger()` call from `Jacobi_t::~Jacobi_t()`.

**`examples/hpc/jacobi-hip/CMakeLists.txt`**
- Replaced `find_library(ROCTX64_LIBRARY ...)` + `find_library(ROCTRACER64_LIBRARY ...)` with a single `find_library(ROCTX_SDK_LIBRARY NAMES rocprofiler-sdk-roctx ...)`.
- Removed `target_include_directories` for the roctracer header paths (`${ROCM_PATH}/roctracer/include`, `${ROCM_PATH}/include/roctracer`); the SDK headers are under the standard ROCm include tree.
- Updated `target_link_libraries` to link only `${ROCTX_SDK_LIBRARY}` instead of the two legacy libraries.

## JIRA ID

AIPROFSYST-345

## Test Plan

- [x] CMake configuration completes without error with `rocprofiler-sdk-roctx` present.
- [x] `jacobi-hip` builds cleanly against `rocprofiler-sdk-roctx`.
- [x] Verify `BEGIN_RANGE` / `END_RANGE` / `SCOPED_RANGE` / `MARKER` macros emit correctly at runtime when profiled with `rocprof-sys-run`.

## Test Result

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.