### PR TITLE
Add orphan MPI/RCCL process cleanup before artifact reinstall in multi-node RCCL workflow

### DIFF
--- a/.github/workflows/therock-rccl-test-packages-multi-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-multi-node.yml
@@ -75,6 +75,22 @@ jobs:
               ;;
           esac
 
+      - name: Cleanup orphan RCCL/MPI processes
+        if: always()
+        run: |
+          echo "Cleaning up orphan processes..."
+
+          pkill -9 -f gather_perf || true
+          pkill -9 -f all_reduce_perf || true
+          pkill -9 -f prterun || true
+          pkill -9 -f mpirun || true
+          pkill -9 -f "_perf" || true
+
+          sleep 10
+
+          echo "Processes still holding artifact directory:"
+          fuser -vm "${OUTPUT_ARTIFACTS_DIR}" || true
+
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'
         with:

--- a/.github/workflows/therock-rccl-test-packages-multi-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-multi-node.yml
@@ -79,8 +79,6 @@ jobs:
         if: always()
         run: |
           echo "Cleaning up orphan processes..."
-
-          pkill -9 -f gather_perf || true
           pkill -9 -f prterun || true
           pkill -9 -f mpirun || true
           pkill -9 -f "_perf" || true

--- a/.github/workflows/therock-rccl-test-packages-multi-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-multi-node.yml
@@ -81,7 +81,6 @@ jobs:
           echo "Cleaning up orphan processes..."
 
           pkill -9 -f gather_perf || true
-          pkill -9 -f all_reduce_perf || true
           pkill -9 -f prterun || true
           pkill -9 -f mpirun || true
           pkill -9 -f "_perf" || true

--- a/projects/rccl/.github/workflows/therock-ci-linux.yml
+++ b/projects/rccl/.github/workflows/therock-ci-linux.yml
@@ -91,6 +91,7 @@ jobs:
       - name: Report
         #if: ${{ !cancelled() }}
         run: |
+          echo "Test"
           echo "Full SDK du:"
           echo "------------"
           du -h -d 1 build/dist/rocm

--- a/projects/rccl/.github/workflows/therock-ci-linux.yml
+++ b/projects/rccl/.github/workflows/therock-ci-linux.yml
@@ -91,7 +91,6 @@ jobs:
       - name: Report
         #if: ${{ !cancelled() }}
         run: |
-          echo "Test"
           echo "Full SDK du:"
           echo "------------"
           du -h -d 1 build/dist/rocm


### PR DESCRIPTION
## PR Description

This change adds a cleanup step before `setup_test_environment` in the multi-node RCCL workflow to terminate orphaned MPI/RCCL processes from previous runs.

Recently, we have observed intermittent failures while reinstalling artifacts into the shared install directory:

```
OSError: [Errno 16] Device or resource busy
```

The issue appears to occur when RCCL collective tests time out and leave orphaned MPI runtime processes alive, which continue holding files under the shared artifact directory.

Since the workflow currently reuses the same artifact install directory across runs:

```
/home/arravikum/dist_new/dist/rocm
```

the next workflow run can fail while attempting to remove and recreate the directory before copying new artifacts.

This PR introduces a cleanup step that:

* kills orphaned MPI runtime processes (`mpirun`, `prterun`)
* kills lingering RCCL performance binaries (`*_perf`)
* explicitly cleans up currently observed stuck `gather_perf` processes
* logs remaining processes still holding the artifact directory using `fuser`

This should improve workflow stability by ensuring stale RCCL/MPI processes do not block artifact cleanup between runs.
