### PR TITLE
[RCCL] Auto-detect rocSHMEM GDA backend and self-heal worktree

### DIFF
--- a/projects/rccl/cmake/ROCSHMEM.cmake
+++ b/projects/rccl/cmake/ROCSHMEM.cmake
@@ -54,7 +54,21 @@ function(add_rocshmem_targets)
 
     set(_rccl_root           "${CMAKE_SOURCE_DIR}")
     set(ROCSHMEM_INSTALL_DIR "${_rccl_root}/ext/rocshmem")
+
+    # Pick the rocSHMEM build_configs script based on the RDMA NIC vendor.
+    # install.sh auto-detects this from /sys/class/infiniband/*/device/vendor
+    # and forwards it via -DROCSHMEM_GDA_CONFIG. Default to gda_mlx5 if the
+    # caller invoked CMake directly without setting it.
+    if(NOT ROCSHMEM_GDA_CONFIG)
+        set(ROCSHMEM_GDA_CONFIG "gda_mlx5")
+    endif()
+    set(_valid_gda_configs "gda_mlx5" "gda_bnxt" "gda_ionic")
+    if(NOT ROCSHMEM_GDA_CONFIG IN_LIST _valid_gda_configs)
+        message(FATAL_ERROR "ROCSHMEM_GDA_CONFIG='${ROCSHMEM_GDA_CONFIG}' is not one of: ${_valid_gda_configs}")
+    endif()
+
     message(STATUS "rocSHMEM: building from ${ROCSHMEM_SOURCE_DIR}")
+    message(STATUS "rocSHMEM: GDA backend config = ${ROCSHMEM_GDA_CONFIG}")
 
     ExternalProject_Add(rocshmem_ext
         SOURCE_DIR          "${ROCSHMEM_SOURCE_DIR}"
@@ -71,7 +85,7 @@ function(add_rocshmem_targets)
         CONFIGURE_COMMAND   ""
         BUILD_COMMAND
             ${CMAKE_COMMAND} -E make_directory build
-            && ${CMAKE_COMMAND} -E chdir build bash -lc "../scripts/build_configs/gda_bnxt -DUSE_EXTERNAL_MPI=OFF -DUSE_IPC=ON -DBUILD_EXAMPLES=OFF "
+            && ${CMAKE_COMMAND} -E chdir build bash -lc "../scripts/build_configs/${ROCSHMEM_GDA_CONFIG} -DUSE_EXTERNAL_MPI=OFF -DUSE_IPC=ON -DBUILD_EXAMPLES=OFF "
             && ${CMAKE_COMMAND} -E chdir build ${CMAKE_COMMAND}
                 -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                 -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>

--- a/projects/rccl/install.sh
+++ b/projects/rccl/install.sh
@@ -110,6 +110,8 @@ function display_help()
     echo "                               Advanced: Specify algo, protocol, redop, and type per collective."
     echo "                                 ONLY_FUNCS=\"AllReduce RING SIMPLE Sum f32|SendRecv\""
     echo "    ROCSHMEM_INSTALL_DIR       Path to a pre-built rocSHMEM installation (skips building from source)"
+    echo "    ROCSHMEM_GDA_CONFIG        rocSHMEM build_configs script to use (auto-detected from RDMA NIC vendor"
+    echo "                               if unset). Examples: gda_mlx5, gda_bnxt, gda_ionic"
 }
 
 # #################################################
@@ -210,6 +212,62 @@ check_exit_code( )
     fi
 }
 
+# Pick the rocSHMEM build_configs script (gda_mlx5 / gda_bnxt / gda_ionic)
+# based on the RDMA NIC vendor IDs exposed under /sys/class/infiniband/.
+# Honors $ROCSHMEM_GDA_CONFIG as an explicit override.
+#
+# Sets the global $rocshmem_gda_config on success; exits on ambiguity or
+# failure. Detection is purely sysfs-based — no extra tools required.
+detect_rocshmem_gda_config()
+{
+    # 1. Explicit override always wins.
+    if [[ -n "${ROCSHMEM_GDA_CONFIG}" ]]; then
+        rocshmem_gda_config="${ROCSHMEM_GDA_CONFIG}"
+        echo "  rocSHMEM GDA config (override): ${rocshmem_gda_config}"
+        return 0
+    fi
+
+    local ib_root="/sys/class/infiniband"
+    if [[ ! -d "$ib_root" ]] || [[ -z "$(ls -A "$ib_root" 2>/dev/null)" ]]; then
+        echo "ERROR: No RDMA devices found under ${ib_root}."
+        echo "       Load the RDMA stack or set ROCSHMEM_GDA_CONFIG=<gda_mlx5|gda_bnxt|gda_ionic>."
+        exit 1
+    fi
+
+    # PCI vendor IDs of RDMA NICs we know how to build rocSHMEM for.
+    local -A vendor_to_config=(
+        [0x15b3]="gda_mlx5"   # Mellanox / NVIDIA Networking ConnectX
+        [0x14e4]="gda_bnxt"   # Broadcom NetXtreme-E (bnxt_re)
+        [0x1dd8]="gda_ionic"  # Pensando / AMD Ionic
+    )
+
+    local -A seen=()
+    local dev vendor cfg
+    for dev in "$ib_root"/*/device/vendor; do
+        [[ -r "$dev" ]] || continue
+        vendor=$(cat "$dev" 2>/dev/null)
+        cfg="${vendor_to_config[$vendor]:-}"
+        if [[ -n "$cfg" ]]; then
+            seen[$cfg]=1
+        fi
+    done
+
+    if [[ ${#seen[@]} -eq 0 ]]; then
+        echo "ERROR: RDMA devices present but none have a known vendor (15b3/14e4/1dd8)."
+        echo "       Vendor IDs seen: $(cat ${ib_root}/*/device/vendor 2>/dev/null | sort -u | tr '\n' ' ')"
+        echo "       Set ROCSHMEM_GDA_CONFIG=<config> manually."
+        exit 1
+    elif [[ ${#seen[@]} -gt 1 ]]; then
+        echo "ERROR: Multiple RDMA NIC vendors detected (${!seen[*]})."
+        echo "       rocSHMEM must be built for a single backend."
+        echo "       Set ROCSHMEM_GDA_CONFIG=<config> to disambiguate."
+        exit 1
+    fi
+
+    rocshmem_gda_config="${!seen[*]}"
+    echo "  rocSHMEM GDA config (auto-detected): ${rocshmem_gda_config}"
+}
+
 # Set up a git worktree of the rocm-systems mono-repo so that
 # projects/rocshmem is checked out at a pinned commit hash while the
 # main working tree (which contains rccl at HEAD) stays untouched.
@@ -234,12 +292,29 @@ setup_rocshmem_worktree()
         local current_hash
         current_hash=$(git -C "$worktree_dir" rev-parse HEAD 2>/dev/null)
         if [[ "${current_hash}" == "${pinned_hash}"* ]] || [[ "${pinned_hash}" == "${current_hash}"* ]]; then
-            echo "  Worktree already at the correct hash — reusing."
-            rocshmem_source_dir="${worktree_dir}/projects/rocshmem"
-            return 0
+            # HEAD matches, but the working tree can still be incomplete
+            # (e.g. an earlier sparse `git checkout` was interrupted, or files
+            # were nuked). Sanity-check a directory that MUST exist when the
+            # sparse cone is fully populated; repair in place if not.
+            local sentinel_dir="${worktree_dir}/projects/rocshmem/src/gda"
+            if [[ ! -d "$sentinel_dir" ]]; then
+                echo "  Worktree HEAD matches but working tree is incomplete — repairing..."
+                git -C "$worktree_dir" sparse-checkout reapply 2>/dev/null
+                git -C "$worktree_dir" read-tree -mu HEAD
+                if [[ ! -d "$sentinel_dir" ]]; then
+                    echo "  Repair failed; rebuilding worktree from scratch..."
+                    git -C "$mono_root" worktree remove "$worktree_dir" --force 2>/dev/null || rm -rf "$worktree_dir"
+                fi
+            fi
+            if [[ -d "$worktree_dir" ]]; then
+                echo "  Worktree already at the correct hash — reusing."
+                rocshmem_source_dir="${worktree_dir}/projects/rocshmem"
+                return 0
+            fi
+        else
+            echo "  Removing stale worktree..."
+            git -C "$mono_root" worktree remove "$worktree_dir" --force 2>/dev/null || rm -rf "$worktree_dir"
         fi
-        echo "  Removing stale worktree..."
-        git -C "$mono_root" worktree remove "$worktree_dir" --force 2>/dev/null || rm -rf "$worktree_dir"
     fi
 
     git -C "$mono_root" worktree add --no-checkout "$worktree_dir" "$pinned_hash"
@@ -279,7 +354,9 @@ fi
 # rocSHMEM worktree setup (must run before cd-ing into the build directory)
 # #################################################
 rocshmem_source_dir=""
+rocshmem_gda_config=""
 if [[ "${build_rocshmem_support}" == true ]] && [[ -z "${ROCSHMEM_INSTALL_DIR}" ]]; then
+    detect_rocshmem_gda_config
     setup_rocshmem_worktree
 fi
 
@@ -433,6 +510,9 @@ if [[ "${build_rocshmem_support}" == true ]]; then
         cmake_common_options="${cmake_common_options} -DROCSHMEM_INSTALL_DIR=${ROCSHMEM_INSTALL_DIR}"
     elif [[ -n "${rocshmem_source_dir}" ]]; then
         cmake_common_options="${cmake_common_options} -DROCSHMEM_SOURCE_DIR=${rocshmem_source_dir}"
+        if [[ -n "${rocshmem_gda_config}" ]]; then
+            cmake_common_options="${cmake_common_options} -DROCSHMEM_GDA_CONFIG=${rocshmem_gda_config}"
+        fi
     fi
 else
     cmake_common_options="${cmake_common_options} -DENABLE_ROCSHMEM=OFF"


### PR DESCRIPTION
install.sh's --rocshmem path previously hard-coded gda_mlx5 in ROCSHMEM.cmake, so building on a Broadcom (bnxt_re) or Pensando (ionic) host required editing CMake. It also blindly reused .rocshmem-worktree whenever HEAD matched the pinned hash, which silently broke the build if the sparse-checkout was left half- populated (e.g. an interrupted `git checkout`): the next configure failed with `add_subdirectory given source "gda" which is not an existing directory` and friends.

## Motivation

Enable mellanox and Ionic support for rccl+rocshmem GDA feature.

## Technical Details

Allows auto-detection of NIC vendor so that we can use the proper config script for building rocshmem

## JIRA ID

Resolves AICOMRCCL-1080

## Test Plan

Manually test build on cluster with thor 2 and mellanox

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
