### PR TITLE
[ROCM-1552] Prevent improper python test runs and improve help

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -10,7 +10,7 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 - **Improved Python test runner behavior**.
   - Added `-l`/`--list` flag to list all available tests and exit without running them.
-  - Added shadow detection: if `amdsmi` loads from a path other than `AMDSMI_PATH`, tests exit early with a clear error message and remediation steps.
+  - Added shadow detection: if `amdsmi` loads from a path other than the resolved expected path (`AMDSMI_PATH`, `ROCM_HOME`, `ROCM_PATH`, or `/opt/rocm` default), tests exit early with a clear error message and remediation steps.
   - Non-root invocations now exit with code 1 immediately with a clear message instead of failing mid-test.
 
 ## amd_smi_lib for ROCm 7.13.0

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -4,6 +4,15 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 ***All information listed below is for reference and subject to change.***
 
+## amd_smi_lib for ROCm 7.14.0
+
+### Added
+
+- **Improved Python test runner behavior**.
+  - Added `-l`/`--list` flag to list all available tests and exit without running them.
+  - Added shadow detection: if `amdsmi` loads from a path other than `AMDSMI_PATH`, tests exit early with a clear error message and remediation steps.
+  - Non-root invocations now exit with code 1 immediately with a clear message instead of failing mid-test.
+
 ## amd_smi_lib for ROCm 7.13.0
 
 ### Changed

--- a/projects/amdsmi/tests/python_unittest/README.md
+++ b/projects/amdsmi/tests/python_unittest/README.md
@@ -38,14 +38,15 @@ The Unittest Run calls the tests directly. The cache provider will always be use
 
 options:
   -  -h, --help           show this help message and exit
+  -  -l, --list           List all available tests and exit
   -  -v, --verbose        Verbose output
   -  -q, --quiet          Quiet output
   -  -b, --buffer         Buffer stdout and stderr during tests
   -  -k "testname"        Only run tests which match the given substring
 
 ### Unittest: not verbose
-Runs all tests. Silence print statements to stdout. Lists tests results.
-This is also the best way to list all tests available.
+Runs all tests. Silences print statements to stdout. Lists test results.
+To list all available test names without running them, use `-l` instead.
 
 ```/opt/rocm/share/amd_smi/tests/python_unittest/unit_tests.py -b```
 ```/opt/rocm/share/amd_smi/tests/python_unittest/integration_test.py -b```

--- a/projects/amdsmi/tests/python_unittest/cli_unit_test.py
+++ b/projects/amdsmi/tests/python_unittest/cli_unit_test.py
@@ -1402,23 +1402,39 @@ class TestAmdSmiCli(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    verbose = 1
+    verbose = common.VERBOSITY_NORMAL
     if "-q" in sys.argv or "--quiet" in sys.argv:
-        verbose = 0
+        verbose = common.VERBOSITY_QUIET
     elif "-v" in sys.argv or "--verbose" in sys.argv:
-        verbose = 2
+        verbose = common.VERBOSITY_VERBOSE
 
-    if verbose:
-        print("AMD SMI CLI Tests")
+    if "-h" in sys.argv or "--help" in sys.argv:
+        common.print_unittest_help()
+        common.print_amdsmi_path_help()
+        sys.exit(0)
 
-    # Detect if ran without sudo or root privileges
+    if "-l" in sys.argv or "--list" in sys.argv:
+        common.print_tests(__name__)
+        sys.exit(0)
+
     if os.geteuid() != 0:
         print(
-            "Warning: Some tests may require elevated privileges (sudo/root) to run completely.\n"
+            "Warning: Some tests may require elevated privileges (sudo/root) to run completely.\n",
+            file=sys.stderr,
         )
-        print("Please relaunch with elevated privileges.\n")
+        print("Please relaunch with elevated privileges.\n", file=sys.stderr)
         sys.exit(1)
 
-    runner = unittest.TextTestRunner(verbosity=verbose)
+    # Only show the dot-character legend when not in verbose mode; in verbose
+    # mode each test prints its own result line so the dot legend is irrelevant.
+    if verbose < common.VERBOSITY_VERBOSE:
+        common.print_legend()
+
+    if verbose > common.VERBOSITY_QUIET:
+        print("AMD SMI CLI Tests")
+
+    runner = unittest.TextTestRunner(
+        stream=sys.stderr, verbosity=common.make_runner_verbosity(verbose)
+    )
     unittest.main(testRunner=runner)
     sys.exit(0)

--- a/projects/amdsmi/tests/python_unittest/cli_unit_test.py
+++ b/projects/amdsmi/tests/python_unittest/cli_unit_test.py
@@ -30,12 +30,15 @@ import unittest
 import common
 import runcmd
 
-amdsmi_path = os.environ.get("AMDSMI_PATH", "/opt/rocm/share/amd_smi")
+amdsmi_path = os.environ.get("AMDSMI_PATH") or os.path.join(
+    os.environ.get("ROCM_HOME") or os.environ.get("ROCM_PATH") or "/opt/rocm", "share/amd_smi"
+)
 if not os.path.exists(amdsmi_path):
     raise FileNotFoundError(
-        f'AMDSMI_PATH "{amdsmi_path}" does not exist. Please set the correct path in your environment.'
+        f'amdsmi path "{amdsmi_path}" does not exist. '
+        "Set ROCM_HOME, ROCM_PATH, or AMDSMI_PATH to the correct install location."
     )
-sys.path.append(amdsmi_path)
+sys.path.insert(0, amdsmi_path)
 try:
     import amdsmi
 except ImportError:

--- a/projects/amdsmi/tests/python_unittest/cli_unit_test.py
+++ b/projects/amdsmi/tests/python_unittest/cli_unit_test.py
@@ -30,24 +30,13 @@ import unittest
 import common
 import runcmd
 
-amdsmi_path = os.environ.get("AMDSMI_PATH") or os.path.join(
-    os.environ.get("ROCM_HOME") or os.environ.get("ROCM_PATH") or "/opt/rocm", "share/amd_smi"
-)
-if not os.path.exists(amdsmi_path):
-    raise FileNotFoundError(
-        f'amdsmi path "{amdsmi_path}" does not exist. '
-        "Set ROCM_HOME, ROCM_PATH, or AMDSMI_PATH to the correct install location."
-    )
-sys.path.insert(0, amdsmi_path)
-try:
-    import amdsmi
-except ImportError:
-    raise ImportError(f'Could not import the "amdsmi" module from "{amdsmi_path}"')
+# common.py owns path resolution, sys.path setup, and amdsmi loading — borrow the reference.
+from common import amdsmi
 
 # Module-level default; __main__ overwrites this with the actual parsed value.
 # It must exist at module scope so setUpClass/setUp can reference it before
 # __main__ runs (e.g. when loaded by an external test runner).
-verbose = 1
+verbose = common.VERBOSITY_NORMAL
 
 
 class TestAmdSmiCli(unittest.TestCase):

--- a/projects/amdsmi/tests/python_unittest/common.py
+++ b/projects/amdsmi/tests/python_unittest/common.py
@@ -27,6 +27,63 @@ import sys
 
 import unittest
 
+
+def print_amdsmi_path_help(script=None, loaded_from=None, expected_path=None, file=sys.stdout):
+    """Print amdsmi path help and remediation steps.
+
+    Without error context (script/loaded_from/expected_path), prints the env-var
+    table followed by the remediation list; used for -h output.
+    With error context, prints an ERROR header and appends a 'Refer to -h' footer;
+    used when the wrong amdsmi package was loaded at import time.
+    """
+    _script = script or os.path.basename(sys.argv[0]) or "<script>"
+    if loaded_from is not None and expected_path is not None:
+        print(
+            f"ERROR: amdsmi loaded from '{loaded_from}' instead of AMDSMI_PATH='{expected_path}'.",
+            file=file,
+        )
+    else:
+        print("\nAdditional options:", file=file)
+        print("  -l, --list           List all available tests and exit", file=file)
+        print(file=file)
+        print("Environment variables:", file=file)
+        print(
+            "  AMDSMI_PATH   Path to amd_smi share dir (overrides ROCM_HOME/ROCM_PATH)", file=file
+        )
+        print("  ROCM_HOME     ROCm install root, used when AMDSMI_PATH is unset", file=file)
+        print("  ROCM_PATH     Fallback ROCm install root (default: /opt/rocm)", file=file)
+        print(file=file)
+    print(
+        "A system-installed amdsmi package is shadowing the test target.\n"
+        "Fix with one of:\n"
+        "\t 1. Run the tests from the installed amd-smi-lib-tests package location (RECOMMENDED):\n"
+        f"\t\t `sudo $ROCM_PATH/share/amd_smi/tests/python_unittest/{_script} -v`\n"
+        f"\t\t e.g. `sudo /opt/rocm/share/amd_smi/tests/python_unittest/{_script} -v`\n\n"
+        "\t 2. Set AMDSMI_PATH to point at the correct build:\n"
+        "\t\t `export AMDSMI_PATH=$ROCM_PATH/share/amd_smi`\n\n"
+        "\t 3. Reinstall the correct amd-smi-lib package (removes the stale Python package too):\n"
+        "\t\t `sudo apt remove amd-smi-lib && sudo apt install amd-smi-lib`\n"
+        "\t\t or, if amdsmi was installed directly via pip:\n"
+        "\t\t `sudo pip uninstall amdsmi`",
+        file=file,
+    )
+    if loaded_from is not None:
+        print(f"\nRefer to `{_script} -h` for more details.", file=file)
+    else:
+        _full = "sudo " + (sys.argv[0] or _script)
+        _cmds = [
+            (_full + " -l", "list all available tests"),
+            (_full + " -v", "run all tests, verbose with print statements (RECOMMENDED)"),
+            (_full + ' -k "test_name" -v', "run only tests matching substring"),
+            (_full + " -q", "run all tests, quiet with no print statements"),
+        ]
+        _w = max(len(cmd) for cmd, _ in _cmds) + 2
+        print(file=file)
+        print("Examples:", file=file)
+        for cmd, desc in _cmds:
+            print(f"  {cmd:<{_w}} - {desc}", file=file)
+
+
 _rocm_root = os.environ.get("AMDSMI_PATH") or os.path.join(
     os.environ.get("ROCM_HOME") or os.environ.get("ROCM_PATH") or "/opt/rocm", "share/amd_smi"
 )
@@ -52,19 +109,8 @@ except ImportError as e:
 _amdsmi_file = getattr(amdsmi, "__file__", "")
 if not os.path.abspath(_amdsmi_file).startswith(os.path.abspath(amdsmi_path)):
     _script = os.path.basename(sys.argv[0]) or "unit_tests.py"
-    print(
-        f"ERROR: amdsmi loaded from '{_amdsmi_file}' instead of AMDSMI_PATH='{amdsmi_path}'.\n"
-        "A system-installed amdsmi package is shadowing the test target.\n"
-        "Fix with one of:\n"
-        "\t 1. Run the tests from the installed amd-lib-tests package location (recommended):\n"
-        f"\t\t `sudo $ROCM_PATH/share/amd_smi/tests/python_unittest/{_script} -v`\n"
-        f"\t\t e.g. `sudo /opt/rocm/share/amd_smi/tests/python_unittest/{_script} -v`\n\n"
-        "\t 2. Set AMDSMI_PATH to point at the correct build:\n"
-        "\t\t `export AMDSMI_PATH=$ROCM_PATH/share/amd_smi`\n\n"
-        "\t 3. Remove the stale system package:\n"
-        "\t\t `sudo pip uninstall amdsmi`\n\n"
-        f"Refer to `{_script} -h` for more details.",
-        file=sys.stderr,
+    print_amdsmi_path_help(
+        script=_script, loaded_from=_amdsmi_file, expected_path=amdsmi_path, file=sys.stderr
     )
     sys.exit(1)
 
@@ -77,10 +123,10 @@ VERBOSITY_NORMAL = 1  # default (dot-per-test)
 VERBOSITY_VERBOSE = 2  # -v / --verbose (per-test result lines)
 
 
-def print_test_ids(suite):
+def _print_test_ids(suite):
     for test in suite:
         if isinstance(test, unittest.TestSuite):
-            print_test_ids(test)
+            _print_test_ids(test)
         else:
             test = str(test).split()[0]
             print(f"\t{test}", file=sys.stderr)
@@ -88,20 +134,54 @@ def print_test_ids(suite):
 
 
 def print_tests(module_name):
+    """Print all test IDs in the given module to stderr and return.
+
+    Loads every test discovered by unittest.TestLoader from the named module
+    (pass __name__ from the script's __main__ block) and prints each ID,
+    one per line, indented by a tab.  Output goes to stderr so it can be
+    captured independently of normal stdout test output.
+    """
     loader = unittest.TestLoader()
     suite = loader.loadTestsFromModule(sys.modules[module_name])
-    print("=" * 70, file=sys.stderr)
     print("Available tests:", file=sys.stderr)
-    print_test_ids(suite)
+    _print_test_ids(suite)
     return
 
 
 def print_legend():
-    # Provide Legend for test results, otherwise it is not clear what the output means
+    """Print the dot-character legend for unittest output to stderr.
+
+    Call this before running tests in non-verbose mode so users know what
+    the single-character result indicators (., s, F, E) mean.
+    """
     print("=" * 70, file=sys.stderr)
     print("Legend: . = pass, s = skipped, F = fail, E = error", file=sys.stderr)
     print("=" * 70, file=sys.stderr)
     return
+
+
+def print_unittest_help():
+    """Print unittest's -h output with its built-in Examples epilog stripped.
+
+    unittest (via argparse) appends its own Examples block; we capture stdout,
+    remove everything from the last 'Examples:' onward, and reprint — leaving
+    our print_amdsmi_path_help() as the sole Examples section at the bottom.
+    """
+    import contextlib
+    import io
+
+    buf = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(buf):
+            unittest.main()
+    except SystemExit:
+        pass
+    output = buf.getvalue()
+    examples_idx = output.rfind("\nExamples:")
+    if examples_idx != -1:
+        output = output[:examples_idx]
+    sys.stdout.write(output)
+    sys.stdout.flush()
 
 
 def make_runner_verbosity(verbose):

--- a/projects/amdsmi/tests/python_unittest/common.py
+++ b/projects/amdsmi/tests/python_unittest/common.py
@@ -64,8 +64,9 @@ def print_amdsmi_path_help(file=sys.stdout):
     print("If amd-smi loads from the wrong path, fix with one of:", file=file)
     _print_path_remediation(_script, file)
     _full = "sudo " + (sys.argv[0] or _script)
+    _base = sys.argv[0] or _script
     _cmds = [
-        (_full + " -l", "list all available tests"),
+        (_base + " -l", "list all available tests"),
         (_full + " -v", "run all tests, verbose with print statements (RECOMMENDED)"),
         (_full + ' -k "test_name" -v', "run only tests matching substring"),
         (_full + " -q", "run all tests, quiet with no print statements"),

--- a/projects/amdsmi/tests/python_unittest/common.py
+++ b/projects/amdsmi/tests/python_unittest/common.py
@@ -84,7 +84,7 @@ def print_shadow_error(script, loaded_from, expected_path, file=sys.stderr):
     diagnosis, the shared remediation steps, and a pointer to -h for more details.
     """
     print(
-        f"ERROR: amdsmi loaded from '{loaded_from}' instead of AMDSMI_PATH='{expected_path}'.",
+        f"ERROR: amdsmi loaded from '{loaded_from}' instead of expected path '{expected_path}'.",
         file=file,
     )
     print("A system-installed amdsmi package is shadowing the test target.", file=file)
@@ -185,7 +185,7 @@ def print_unittest_help():
     buf = io.StringIO()
     try:
         with contextlib.redirect_stdout(buf):
-            unittest.main(argv=["", "--help"])
+            unittest.main(argv=[sys.argv[0] or "unit_tests.py", "--help"])
     except SystemExit:
         pass
     output = buf.getvalue()

--- a/projects/amdsmi/tests/python_unittest/common.py
+++ b/projects/amdsmi/tests/python_unittest/common.py
@@ -19,7 +19,9 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+import contextlib
 import inspect
+import io
 import json
 import os
 import pathlib
@@ -28,66 +30,72 @@ import sys
 import unittest
 
 
-def print_amdsmi_path_help(script=None, loaded_from=None, expected_path=None, file=sys.stdout):
-    """Print amdsmi path help and remediation steps.
+def _print_path_remediation(script, file):
+    """Print the shared 'fix with one of:' remediation block.
 
-    Without error context (script/loaded_from/expected_path), prints the env-var
-    table followed by the remediation list; used for -h output.
-    With error context, prints an ERROR header and appends a 'Refer to -h' footer;
-    used when the wrong amdsmi package was loaded at import time.
+    Used by both print_amdsmi_path_help() (-h context) and print_shadow_error()
+    (import-error context) to avoid duplicating the step list.
     """
-    _script = script or os.path.basename(sys.argv[0]) or "<script>"
-    if loaded_from is not None and expected_path is not None:
-        print(
-            f"ERROR: amdsmi loaded from '{loaded_from}' instead of AMDSMI_PATH='{expected_path}'.",
-            file=file,
-        )
-    else:
-        print("\nAdditional options:", file=file)
-        print("  -l, --list           List all available tests and exit", file=file)
-        print(file=file)
-        print("Environment variables:", file=file)
-        print(
-            "  AMDSMI_PATH   Path to amd_smi share dir (overrides ROCM_HOME/ROCM_PATH)", file=file
-        )
-        print("  ROCM_HOME     ROCm install root, used when AMDSMI_PATH is unset", file=file)
-        print("  ROCM_PATH     Fallback ROCm install root (default: /opt/rocm)", file=file)
-        print(file=file)
     print(
-        "A system-installed amdsmi package is shadowing the test target.\n"
-        "Fix with one of:\n"
         "\t 1. Run the tests from the installed amd-smi-lib-tests package location (RECOMMENDED):\n"
-        f"\t\t `sudo $ROCM_PATH/share/amd_smi/tests/python_unittest/{_script} -v`\n"
-        f"\t\t e.g. `sudo /opt/rocm/share/amd_smi/tests/python_unittest/{_script} -v`\n\n"
+        f"\t\t `sudo $ROCM_PATH/share/amd_smi/tests/python_unittest/{script} -v`\n"
+        f"\t\t e.g. `sudo /opt/rocm/share/amd_smi/tests/python_unittest/{script} -v`\n\n"
         "\t 2. Set AMDSMI_PATH to point at the correct build:\n"
         "\t\t `export AMDSMI_PATH=$ROCM_PATH/share/amd_smi`\n\n"
         "\t 3. Reinstall the correct amd-smi-lib package (removes the stale Python package too):\n"
         "\t\t `sudo apt remove amd-smi-lib && sudo apt install amd-smi-lib`\n"
-        "\t\t or, if amdsmi was installed directly via pip:\n"
+        "\t\t or, if amd-smi was installed directly via pip:\n"
         "\t\t `sudo pip uninstall amdsmi`",
         file=file,
     )
-    if loaded_from is not None:
-        print(f"\nRefer to `{_script} -h` for more details.", file=file)
-    else:
-        _full = "sudo " + (sys.argv[0] or _script)
-        _cmds = [
-            (_full + " -l", "list all available tests"),
-            (_full + " -v", "run all tests, verbose with print statements (RECOMMENDED)"),
-            (_full + ' -k "test_name" -v', "run only tests matching substring"),
-            (_full + " -q", "run all tests, quiet with no print statements"),
-        ]
-        _w = max(len(cmd) for cmd, _ in _cmds) + 2
-        print(file=file)
-        print("Examples:", file=file)
-        for cmd, desc in _cmds:
-            print(f"  {cmd:<{_w}} - {desc}", file=file)
 
 
-_rocm_root = os.environ.get("AMDSMI_PATH") or os.path.join(
+def print_amdsmi_path_help(file=sys.stdout):
+    """Print env-var documentation, path remediation guidance, and usage examples for -h output."""
+    _script = os.path.basename(sys.argv[0]) or "<script>"
+    print("\nAdditional options:", file=file)
+    print("  -l, --list           List all available tests and exit", file=file)
+    print(file=file)
+    print("Environment variables:", file=file)
+    print("  AMDSMI_PATH   Path to amd_smi share dir (overrides ROCM_HOME/ROCM_PATH)", file=file)
+    print("  ROCM_HOME     ROCm install root, used when AMDSMI_PATH is unset", file=file)
+    print("  ROCM_PATH     Fallback ROCm install root (default: /opt/rocm)", file=file)
+    print(file=file)
+    print("If amd-smi loads from the wrong path, fix with one of:", file=file)
+    _print_path_remediation(_script, file)
+    _full = "sudo " + (sys.argv[0] or _script)
+    _cmds = [
+        (_full + " -l", "list all available tests"),
+        (_full + " -v", "run all tests, verbose with print statements (RECOMMENDED)"),
+        (_full + ' -k "test_name" -v', "run only tests matching substring"),
+        (_full + " -q", "run all tests, quiet with no print statements"),
+    ]
+    _w = max(len(cmd) for cmd, _ in _cmds) + 2
+    print(file=file)
+    print("Examples:", file=file)
+    for cmd, desc in _cmds:
+        print(f"  {cmd:<{_w}} - {desc}", file=file)
+
+
+def print_shadow_error(script, loaded_from, expected_path, file=sys.stderr):
+    """Print an actionable error when amdsmi was loaded from the wrong path.
+
+    Prints an ERROR header identifying the unexpected source, the shadowing
+    diagnosis, the shared remediation steps, and a pointer to -h for more details.
+    """
+    print(
+        f"ERROR: amdsmi loaded from '{loaded_from}' instead of AMDSMI_PATH='{expected_path}'.",
+        file=file,
+    )
+    print("A system-installed amdsmi package is shadowing the test target.", file=file)
+    print("Fix with one of:", file=file)
+    _print_path_remediation(script, file)
+    print(f"\nRefer to `{script} -h` for more details.", file=file)
+
+
+amdsmi_path = os.environ.get("AMDSMI_PATH") or os.path.join(
     os.environ.get("ROCM_HOME") or os.environ.get("ROCM_PATH") or "/opt/rocm", "share/amd_smi"
 )
-amdsmi_path = _rocm_root
 if not os.path.exists(amdsmi_path):
     raise FileNotFoundError(
         f'amdsmi path "{amdsmi_path}" does not exist. '
@@ -104,15 +112,22 @@ except ImportError as e:
 # dist-packages is already on sys.path at interpreter startup; insert(0,...) above
 # prevents this, but error explicitly in case amdsmi was already cached in sys.modules.
 #
-# Example of how to proc this error output (for test purposes):
+# Example of how to trigger this error output (for test purposes):
 # sudo AMDSMI_PATH=/tmp /opt/rocm/share/amd_smi/tests/python_unittest/cli_unit_test.py -v
-_amdsmi_file = getattr(amdsmi, "__file__", "")
-if not os.path.abspath(_amdsmi_file).startswith(os.path.abspath(amdsmi_path)):
+_amdsmi_file = getattr(amdsmi, "__file__", None) or ""
+if not os.path.realpath(_amdsmi_file).startswith(os.path.realpath(amdsmi_path) + os.sep):
     _script = os.path.basename(sys.argv[0]) or "unit_tests.py"
-    print_amdsmi_path_help(
-        script=_script, loaded_from=_amdsmi_file, expected_path=amdsmi_path, file=sys.stderr
+    print_shadow_error(_script, _amdsmi_file, amdsmi_path)
+    # For direct test-script invocations use sys.exit so no Python traceback
+    # clutters the remediation output.  For anything else (pytest, IDE runners,
+    # ad-hoc imports) raise so the caller gets a clear error with location.
+    _known_scripts = ("unit_tests.py", "integration_test.py", "cli_unit_test.py")
+    _main_file = getattr(sys.modules.get("__main__"), "__file__", "") or ""
+    if os.path.basename(_main_file) in _known_scripts:
+        sys.exit(1)
+    raise RuntimeError(
+        f"amdsmi loaded from wrong path: '{_amdsmi_file}' (expected under '{amdsmi_path}')"
     )
-    sys.exit(1)
 
 #################################################
 # Module level functions, not part of the class #
@@ -167,13 +182,10 @@ def print_unittest_help():
     remove everything from the last 'Examples:' onward, and reprint — leaving
     our print_amdsmi_path_help() as the sole Examples section at the bottom.
     """
-    import contextlib
-    import io
-
     buf = io.StringIO()
     try:
         with contextlib.redirect_stdout(buf):
-            unittest.main()
+            unittest.main(argv=["", "--help"])
     except SystemExit:
         pass
     output = buf.getvalue()

--- a/projects/amdsmi/tests/python_unittest/common.py
+++ b/projects/amdsmi/tests/python_unittest/common.py
@@ -27,16 +27,46 @@ import sys
 
 import unittest
 
-amdsmi_path = os.environ.get("AMDSMI_PATH", "/opt/rocm/share/amd_smi")
+_rocm_root = os.environ.get("AMDSMI_PATH") or os.path.join(
+    os.environ.get("ROCM_HOME") or os.environ.get("ROCM_PATH") or "/opt/rocm", "share/amd_smi"
+)
+amdsmi_path = _rocm_root
 if not os.path.exists(amdsmi_path):
     raise FileNotFoundError(
-        f'AMDSMI_PATH "{amdsmi_path}" does not exist. Please set the correct path in your environment.'
+        f'amdsmi path "{amdsmi_path}" does not exist. '
+        "Set ROCM_HOME, ROCM_PATH, or AMDSMI_PATH to the correct install location."
     )
-sys.path.append(amdsmi_path)
+sys.path.insert(0, amdsmi_path)
 try:
     import amdsmi
 except ImportError as e:
     raise ImportError(f'Could not import the "amdsmi" module from "{amdsmi_path}"') from e
+
+# Verify the imported amdsmi package came from amdsmi_path, not a system-installed
+# package in dist-packages. A stale system install wins over sys.path.append() because
+# dist-packages is already on sys.path at interpreter startup; insert(0,...) above
+# prevents this, but error explicitly in case amdsmi was already cached in sys.modules.
+#
+# Example of how to proc this error output (for test purposes):
+# sudo AMDSMI_PATH=/tmp /opt/rocm/share/amd_smi/tests/python_unittest/cli_unit_test.py -v
+_amdsmi_file = getattr(amdsmi, "__file__", "")
+if not os.path.abspath(_amdsmi_file).startswith(os.path.abspath(amdsmi_path)):
+    _script = os.path.basename(sys.argv[0]) or "unit_tests.py"
+    print(
+        f"ERROR: amdsmi loaded from '{_amdsmi_file}' instead of AMDSMI_PATH='{amdsmi_path}'.\n"
+        "A system-installed amdsmi package is shadowing the test target.\n"
+        "Fix with one of:\n"
+        "\t 1. Run the tests from the installed amd-lib-tests package location (recommended):\n"
+        f"\t\t `sudo $ROCM_PATH/share/amd_smi/tests/python_unittest/{_script} -v`\n"
+        f"\t\t e.g. `sudo /opt/rocm/share/amd_smi/tests/python_unittest/{_script} -v`\n\n"
+        "\t 2. Set AMDSMI_PATH to point at the correct build:\n"
+        "\t\t `export AMDSMI_PATH=$ROCM_PATH/share/amd_smi`\n\n"
+        "\t 3. Remove the stale system package:\n"
+        "\t\t `sudo pip uninstall amdsmi`\n\n"
+        f"Refer to `{_script} -h` for more details.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
 
 #################################################
 # Module level functions, not part of the class #

--- a/projects/amdsmi/tests/python_unittest/integration_test.py
+++ b/projects/amdsmi/tests/python_unittest/integration_test.py
@@ -1552,15 +1552,15 @@ if __name__ == "__main__":
     elif any(a in ("-v", "-vv", "--verbose") for a in sys.argv):
         verbose = common.VERBOSITY_VERBOSE
 
-    # If no -k or --keyword argument is given, print all available tests.
-    # Do this before the -h check so the test list appears above unittest's help output.
-    if not ("-k" in sys.argv or "--keyword" in sys.argv):
-        if verbose > common.VERBOSITY_QUIET:
-            common.print_tests(__name__)
-
     # Skip legend/title/"Running" preamble when the user just wants help text.
     if "-h" in sys.argv or "--help" in sys.argv:
-        unittest.main()
+        common.print_unittest_help()
+        common.print_amdsmi_path_help()
+        sys.exit(0)
+
+    if "-l" in sys.argv or "--list" in sys.argv:
+        common.print_tests(__name__)
+        sys.exit(0)
 
     # Only show the dot-character legend when not in verbose mode; in verbose
     # mode each test prints its own result line so the dot legend is irrelevant.

--- a/projects/amdsmi/tests/python_unittest/integration_test.py
+++ b/projects/amdsmi/tests/python_unittest/integration_test.py
@@ -42,19 +42,8 @@ import common
 verbose = common.VERBOSITY_NORMAL
 
 
-amdsmi_path = os.environ.get("AMDSMI_PATH") or os.path.join(
-    os.environ.get("ROCM_HOME") or os.environ.get("ROCM_PATH") or "/opt/rocm", "share/amd_smi"
-)
-if not os.path.exists(amdsmi_path):
-    raise FileNotFoundError(
-        f'amdsmi path "{amdsmi_path}" does not exist. '
-        "Set ROCM_HOME, ROCM_PATH, or AMDSMI_PATH to the correct install location."
-    )
-sys.path.insert(0, amdsmi_path)
-try:
-    import amdsmi
-except ImportError as exc:
-    raise ImportError(f"Could not import {amdsmi_path}") from exc
+# common.py owns path resolution, sys.path setup, and amdsmi loading — borrow the reference.
+from common import amdsmi
 
 
 class TestAmdSmiInit(unittest.TestCase):
@@ -1562,15 +1551,6 @@ if __name__ == "__main__":
         common.print_tests(__name__)
         sys.exit(0)
 
-    # Only show the dot-character legend when not in verbose mode; in verbose
-    # mode each test prints its own result line so the dot legend is irrelevant.
-    if verbose < common.VERBOSITY_VERBOSE:
-        common.print_legend()
-
-    if verbose > common.VERBOSITY_QUIET:
-        print(f"AMD SMI Integration Tests\n")
-        print("Running tests...\n")
-
     # Detect if ran without sudo or root privileges
     if os.geteuid() != 0:
         print(
@@ -1579,6 +1559,15 @@ if __name__ == "__main__":
         )
         print("Please relaunch with elevated privileges.\n", file=sys.stderr)
         sys.exit(1)
+
+    # Only show the dot-character legend when not in verbose mode; in verbose
+    # mode each test prints its own result line so the dot legend is irrelevant.
+    if verbose < common.VERBOSITY_VERBOSE:
+        common.print_legend()
+
+    if verbose > common.VERBOSITY_QUIET:
+        print(f"AMD SMI Integration Tests\n")
+        print("Running tests...\n")
 
     # WARNING: Future developers! Please read. :)
     # Avoid per-test ASIC skipping because:
@@ -1615,7 +1604,9 @@ if __name__ == "__main__":
     #       self.assertEqual(e.get_error_code(), amdsmi.AmdSmiStatus.AMDSMI_STATUS_NOT_SUPPORTED)
     # ---------------------------------------------------------------------------
 
-    runner = unittest.TextTestRunner(verbosity=common.make_runner_verbosity(verbose))
+    runner = unittest.TextTestRunner(
+        stream=sys.stderr, verbosity=common.make_runner_verbosity(verbose)
+    )
 
     common.expand_glob_k_arg(globals())
     unittest.main(testRunner=runner)

--- a/projects/amdsmi/tests/python_unittest/integration_test.py
+++ b/projects/amdsmi/tests/python_unittest/integration_test.py
@@ -42,12 +42,15 @@ import common
 verbose = common.VERBOSITY_NORMAL
 
 
-amdsmi_path = os.environ.get("AMDSMI_PATH", "/opt/rocm/share/amd_smi")
+amdsmi_path = os.environ.get("AMDSMI_PATH") or os.path.join(
+    os.environ.get("ROCM_HOME") or os.environ.get("ROCM_PATH") or "/opt/rocm", "share/amd_smi"
+)
 if not os.path.exists(amdsmi_path):
     raise FileNotFoundError(
-        f'AMDSMI_PATH "{amdsmi_path}" does not exist. Please set the correct path in your environment.'
+        f'amdsmi path "{amdsmi_path}" does not exist. '
+        "Set ROCM_HOME, ROCM_PATH, or AMDSMI_PATH to the correct install location."
     )
-sys.path.append(amdsmi_path)
+sys.path.insert(0, amdsmi_path)
 try:
     import amdsmi
 except ImportError as exc:

--- a/projects/amdsmi/tests/python_unittest/unit_tests.py
+++ b/projects/amdsmi/tests/python_unittest/unit_tests.py
@@ -1749,15 +1749,6 @@ class TestAmdSmiPython(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    # Detect if ran without sudo or root privileges
-    if os.geteuid() != 0:
-        print(
-            "Warning: Some tests may require elevated privileges (sudo/root) to run completely.\n",
-            file=sys.stderr,
-        )
-        print("Please relaunch with elevated privileges.\n", file=sys.stderr)
-        sys.exit(1)
-
     verbose = common.VERBOSITY_NORMAL
     # Parse verbosity from command line (updates the module-level default).
     # -v/-vv/--verbose all select VERBOSITY_VERBOSE; -q/--quiet selects QUIET.
@@ -1766,15 +1757,24 @@ if __name__ == "__main__":
     elif any(a in ("-v", "-vv", "--verbose") for a in sys.argv):
         verbose = common.VERBOSITY_VERBOSE
 
-    # If no -k or --keyword argument is given, print all available tests.
-    # Do this before the -h check so the test list appears above unittest's help output.
-    if not ("-k" in sys.argv or "--keyword" in sys.argv):
-        if verbose > common.VERBOSITY_QUIET:
-            common.print_tests(__name__)
-
     # Skip legend/title/"Running" preamble when the user just wants help text.
     if "-h" in sys.argv or "--help" in sys.argv:
-        unittest.main()
+        common.print_unittest_help()
+        common.print_amdsmi_path_help()
+        sys.exit(0)
+
+    if "-l" in sys.argv or "--list" in sys.argv:
+        common.print_tests(__name__)
+        sys.exit(0)
+
+    # Detect if ran without sudo or root privileges
+    if os.geteuid() != 0:
+        print(
+            "Warning: Some tests may require elevated privileges (sudo/root) to run completely.\n",
+            file=sys.stderr,
+        )
+        print("Please relaunch with elevated privileges.\n", file=sys.stderr)
+        sys.exit(1)
 
     # Only show the dot-character legend when not in verbose mode; in verbose
     # mode each test prints its own result line so the dot legend is irrelevant.

--- a/projects/amdsmi/tests/python_unittest/unit_tests.py
+++ b/projects/amdsmi/tests/python_unittest/unit_tests.py
@@ -43,19 +43,8 @@ import unittest
 
 import common
 
-amdsmi_path = os.environ.get("AMDSMI_PATH") or os.path.join(
-    os.environ.get("ROCM_HOME") or os.environ.get("ROCM_PATH") or "/opt/rocm", "share/amd_smi"
-)
-if not os.path.exists(amdsmi_path):
-    raise FileNotFoundError(
-        f'amdsmi path "{amdsmi_path}" does not exist. '
-        "Set ROCM_HOME, ROCM_PATH, or AMDSMI_PATH to the correct install location."
-    )
-sys.path.insert(0, amdsmi_path)
-try:
-    import amdsmi
-except ImportError as exc:
-    raise ImportError(f"Could not import {amdsmi_path}") from exc
+# common.py owns path resolution, sys.path setup, and amdsmi loading — borrow the reference.
+from common import amdsmi
 
 
 verbose = common.VERBOSITY_NORMAL

--- a/projects/amdsmi/tests/python_unittest/unit_tests.py
+++ b/projects/amdsmi/tests/python_unittest/unit_tests.py
@@ -43,12 +43,15 @@ import unittest
 
 import common
 
-amdsmi_path = os.environ.get("AMDSMI_PATH", "/opt/rocm/share/amd_smi")
+amdsmi_path = os.environ.get("AMDSMI_PATH") or os.path.join(
+    os.environ.get("ROCM_HOME") or os.environ.get("ROCM_PATH") or "/opt/rocm", "share/amd_smi"
+)
 if not os.path.exists(amdsmi_path):
     raise FileNotFoundError(
-        f'AMDSMI_PATH "{amdsmi_path}" does not exist. Please set the correct path in your environment.'
+        f'amdsmi path "{amdsmi_path}" does not exist. '
+        "Set ROCM_HOME, ROCM_PATH, or AMDSMI_PATH to the correct install location."
     )
-sys.path.append(amdsmi_path)
+sys.path.insert(0, amdsmi_path)
 try:
     import amdsmi
 except ImportError as exc:


### PR DESCRIPTION
## Motivation

Running the AMD SMI Python tests from a non-standard location or with a stale system-installed `amdsmi` package produced silent, hard-to-diagnose failures. Users also had no easy way to list available tests or understand how to set up the test environment from `--help`.

## Technical Details

- Replaced hardcoded `AMDSMI_PATH=/opt/rocm/share/amd_smi` fallback with a resolution chain: `AMDSMI_PATH` → `ROCM_HOME` → `ROCM_PATH` → `/opt/rocm`, consistent across all three test scripts.
- Changed `sys.path.append()` to `sys.path.insert(0, ...)` so the target `amdsmi` package wins over any system-installed copy; added a post-import check that errors with clear remediation if a stale package still loads.
- Added `-l` / `--list` flag to all scripts to enumerate available tests and exit.
- Improved `-h` / `--help` output: trims unittest's default Examples section and appends env var documentation and usage examples via `common.print_amdsmi_path_help()`.
- Moved the `geteuid` privilege check after `-h` and `-l` so those flags work without `sudo`.

## JIRA ID

ROCM-1552

## Test Plan

- Ran each script with `-h`, `-l`, `-v`, and `-q`.
- Triggered the stale-package error by setting `AMDSMI_PATH` to an incorrect path and confirmed the error message and remediation steps printed correctly.

## Test Result

All flags work as expected. The stale-package error correctly identifies the loaded path and exits with actionable output.

### Examples:
#### Incorrect Test Run
<img width="607" height="185" alt="image" src="https://github.com/user-attachments/assets/092e62d6-7096-43da-a5ca-460863d4809f" />


#### Updated Help
<img width="761" height="403" alt="image" src="https://github.com/user-attachments/assets/830e5316-4fd7-4eb8-ad73-a87a8ac0db63" />


#### Updated Test List
<img width="646" height="1212" alt="image" src="https://github.com/user-attachments/assets/3655c025-e699-442c-8c41-ba38ab99acf6" />

