### PR TITLE
[rocprofiler-systems] Enable `task_detach` part of openmp-fortran-host test

### DIFF
--- a/projects/rocprofiler-systems/examples/openmp/fortran/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/fortran/CMakeLists.txt
@@ -92,8 +92,6 @@ set(HOST_EXAMPLE_NAME "openmp-fortran-host")
 set(HOST_EXAMPLE_FLAGS "-fopenmp")
 
 add_executable(${HOST_EXAMPLE_NAME})
-# TODO: Once SDK issue is fixed (early_fulfill arriving after task_complete causes failure),
-# uncomment the call to run_task_detach_phase in host.f90
 target_sources(${HOST_EXAMPLE_NAME} PRIVATE host.f90)
 target_compile_options(${HOST_EXAMPLE_NAME} PRIVATE ${HOST_EXAMPLE_FLAGS})
 target_link_options(${HOST_EXAMPLE_NAME} PRIVATE ${HOST_EXAMPLE_FLAGS})

--- a/projects/rocprofiler-systems/examples/openmp/fortran/host.f90
+++ b/projects/rocprofiler-systems/examples/openmp/fortran/host.f90
@@ -3,7 +3,7 @@
 !
 ! Combined OpenMP host example that runs two distinct phases in sequence:
 !   Phase 1: round-robin parallel loop
-!   Phase 2: parallel task with detach (Currently Disabled)
+!   Phase 2: parallel task with detach
 
 
 program host_combined
@@ -12,9 +12,7 @@ program host_combined
 
     call run_ordered_phase()
     print *, "----"
-    ! DISABLED until underlying SDK issue is fixed
-    ! (ROCP fatal occurs when early_fulfill arrives after task_complete, which should not be the case)
-    ! call run_task_detach_phase()
+    call run_task_detach_phase()
 
 contains
 


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

The underlying issue involviong `early_task_fulfill` coming after a `task_complete` has been fixed via https://github.com/ROCm/rocm-systems/pull/5970

It is time to re-enable this test and put this saga behind us.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Uncomment the `call run_task_detach_phase` in `host.f90`. 
Remove comments mentioning that it was disabled.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

Final part of AIPROFSYST-454

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Local + workflows

## Test Result

<!-- Briefly summarize test outcomes. -->

Locally, all `openmp-fortran-host-.*` tests pass. Error is no longer observed.
See workflows for... well... the workflow part of the test plan...
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
