### PR TITLE
[kpack] Extend --gpu-targets filter to fat binary code object extraction

### DIFF
--- a/shared/kpack/python/rocm_kpack/artifact_splitter.py
+++ b/shared/kpack/python/rocm_kpack/artifact_splitter.py
@@ -72,7 +72,7 @@ class FileClassificationVisitor:
             toolchain: Toolchain instance for binary operations
             database_handlers: List of database handler instances
             verbose: Enable verbose output
-            gpu_targets: If set, only classify database files for these GPU targets
+            gpu_targets: If set, only produce per-arch artifacts for these GPU targets
         """
         self.toolchain = toolchain
         self.database_handlers = database_handlers or []
@@ -357,6 +357,17 @@ class ArtifactSplitter:
                     # Extract architecture from target name (e.g., "hip-amdgcn-amd-amdhsa-gfx1100")
                     arch = extract_architecture_from_target(target_name)
                     if arch:
+                        if self.gpu_targets is not None:
+                            bare_arch = strip_target_features(arch)
+                            if bare_arch not in self.gpu_targets:
+                                code_object_index[arch] += 1
+                                if self.verbose:
+                                    print(
+                                        f"    Skipping kernel for {arch} "
+                                        f"(not in gpu_targets)"
+                                    )
+                                continue
+
                         kernel_path = unbundled.dest_dir / file_name
                         # Read kernel data while the file still exists
                         kernel_data = kernel_path.read_bytes()

--- a/shared/kpack/python/rocm_kpack/artifact_splitter.py
+++ b/shared/kpack/python/rocm_kpack/artifact_splitter.py
@@ -363,8 +363,8 @@ class ArtifactSplitter:
                                 code_object_index[arch] += 1
                                 if self.verbose:
                                     print(
-                                        f"    Skipping kernel for {arch} "
-                                        f"(not in gpu_targets)"
+                                        f"    Skipping kernel for {arch}: "
+                                        f"{file_name} (not in gpu_targets)"
                                     )
                                 continue
 

--- a/shared/kpack/tests/test_artifact_splitter_integration.py
+++ b/shared/kpack/tests/test_artifact_splitter_integration.py
@@ -1005,8 +1005,7 @@ class TestArtifactSplitterIntegration:
         When a fat binary contains code objects for multiple architectures
         (e.g., gfx906 and gfx1100), only the architectures in gpu_targets
         should produce kpack artifacts. Without this filter, a cross-arch
-        build can produce spurious per-arch artifacts that overwrite correct
-        ones when uploaded to the same S3 prefix.
+        build can produce spurious per-arch kpack artifacts.
         """
         # Set up a fake prefix with a placeholder binary
         prefix = "math-libs/BLAS/rocSOLVER/stage"

--- a/shared/kpack/tests/test_artifact_splitter_integration.py
+++ b/shared/kpack/tests/test_artifact_splitter_integration.py
@@ -1075,6 +1075,12 @@ class TestArtifactSplitterIntegration:
         assert "gfx1100" in result_filtered, (
             "gfx1100 should be in filtered results (in gpu_targets)"
         )
+        assert len(result_filtered["gfx1100"]) == 1, (
+            "gfx1100 kernel should be preserved intact"
+        )
+        assert result_filtered["gfx1100"][0].kernel_data == b"\x00" * 100, (
+            "gfx1100 kernel data should be unchanged by filtering"
+        )
         assert "gfx906" not in result_filtered, (
             "gfx906 should not be in filtered results (not in gpu_targets)"
         )

--- a/shared/kpack/tests/test_artifact_splitter_integration.py
+++ b/shared/kpack/tests/test_artifact_splitter_integration.py
@@ -997,3 +997,92 @@ class TestArtifactSplitterIntegration:
         assert not (output_dir / "miopen_lib_gfx90a").exists(), (
             "gfx90a per-arch directory should not exist when filtered out"
         )
+
+    def test_gpu_targets_filters_fat_binary_kernels(self, toolchain, tmp_path):
+        """
+        Test that gpu_targets filters code objects extracted from fat binaries.
+
+        When a fat binary contains code objects for multiple architectures
+        (e.g., gfx906 and gfx1100), only the architectures in gpu_targets
+        should produce kpack artifacts. Without this filter, a cross-arch
+        build can produce spurious per-arch artifacts that overwrite correct
+        ones when uploaded to the same S3 prefix.
+        """
+        # Set up a fake prefix with a placeholder binary
+        prefix = "math-libs/BLAS/rocSOLVER/stage"
+        prefix_path = tmp_path / prefix
+        lib_dir = prefix_path / "lib"
+        lib_dir.mkdir(parents=True)
+
+        fat_binary = lib_dir / "librocsolver.so.0"
+        fat_binary.write_text("placeholder")
+
+        # Create mock unbundled code objects for two architectures
+        mock_dest_dir = tmp_path / "unbundled"
+        mock_dest_dir.mkdir()
+        mock_targets = [
+            ("hipv4-amdgcn-amd-amdhsa--gfx906", "gfx906.hsaco"),
+            ("hipv4-amdgcn-amd-amdhsa--gfx1100", "gfx1100.hsaco"),
+        ]
+        for _, fname in mock_targets:
+            (mock_dest_dir / fname).write_bytes(b"\x00" * 100)
+
+        mock_unbundled = type(
+            "MockUnbundled",
+            (),
+            {
+                "target_list": mock_targets,
+                "dest_dir": mock_dest_dir,
+                "__enter__": lambda s: s,
+                "__exit__": lambda s, *a: None,
+            },
+        )()
+
+        with patch(
+            "rocm_kpack.artifact_splitter.BundledBinary"
+        ) as MockBinary:
+            MockBinary.return_value.unbundle.return_value = mock_unbundled
+
+            # With gpu_targets=["gfx1100"], only gfx1100 kernels should appear
+            splitter = ArtifactSplitter(
+                artifact_prefix="blas_lib",
+                toolchain=toolchain,
+                database_handlers=[],
+                verbose=True,
+                gpu_targets=["gfx1100"],
+            )
+            result_filtered = splitter.process_fat_binaries(
+                [fat_binary], prefix, prefix_path
+            )
+
+            # Recreate mock files consumed by the first call
+            for _, fname in mock_targets:
+                (mock_dest_dir / fname).write_bytes(b"\x00" * 100)
+
+            # Without gpu_targets, both architectures should appear
+            splitter_all = ArtifactSplitter(
+                artifact_prefix="blas_lib",
+                toolchain=toolchain,
+                database_handlers=[],
+                verbose=True,
+                gpu_targets=None,
+            )
+            result_unfiltered = splitter_all.process_fat_binaries(
+                [fat_binary], prefix, prefix_path
+            )
+
+        # Filtered: only targeted architecture should be present
+        assert "gfx1100" in result_filtered, (
+            "gfx1100 should be in filtered results (in gpu_targets)"
+        )
+        assert "gfx906" not in result_filtered, (
+            "gfx906 should not be in filtered results (not in gpu_targets)"
+        )
+
+        # Unfiltered: all architectures should be present
+        assert "gfx1100" in result_unfiltered, (
+            "gfx1100 should be in unfiltered results"
+        )
+        assert "gfx906" in result_unfiltered, (
+            "gfx906 should be in unfiltered results"
+        )


### PR DESCRIPTION
## Motivation

Fixes: https://github.com/ROCm/TheRock/issues/5274

`torch.linalg.cholesky()` fails with `hipErrorInvalidImage` on gfx906
when using multi-arch ROCm packages. Per-family packages work 
correctly.

Root cause: in the multi-arch CI pipeline, the `--gpu-targets` flag
(added in #4916) only filters database files (Tensile `.co`/`.dat`)
during artifact splitting, not fat binary code object extraction into
kpack archives. This allows cross-arch builds to produce spurious per-arch
kpack artifacts. For example, the `gfx110X-all` build produces a
`blas_lib_gfx906` artifact containing only 3 stray hipSPARSELt kernels.
When uploaded to S3, it overwrites the correct artifact from the gfx906
build (which contained 646 kernels from rocBLAS, rocsolver, and
rocSPARSE).

Evidence from CI run
https://github.com/ROCm/TheRock/actions/runs/26148631112:
- gfx906 build uploads `blas_lib_gfx906.tar.zst` at 10:40:34 (correct, 646 kernels)
- gfx110X-all build uploads `blas_lib_gfx906.tar.zst` at 10:46:10 (overwrites with 3 kernels)

## Technical Details

The `--gpu-targets` filter was applied in `FileClassificationVisitor.visit_file()`
for database files but not in `ArtifactSplitter.process_fat_binaries()` for
code objects extracted from `.hip_fatbin` sections. This PR adds the same
`gpu_targets` check to `process_fat_binaries()`, skipping code objects whose
architecture (after stripping target features) is not in the target set.

The `code_object_index` counter is still incremented for skipped entries to
keep index numbering consistent with the HIPK `co_index` embedded in the
binary wrapper.

## Test Plan

Verified locally with a gfx906 (Radeon VII):

1. Ran the artifact splitter on a per-family rocsolver binary (containing
   247 gfx906 code objects) with `--gpu-targets gfx906`:
   - Produced `blas_lib_gfx906.kpack` with 247 kernels (24 MB)

2. Ran the same binary with `--gpu-targets gfx1100`:
   - All 247 gfx906 kernels skipped ("not in gpu_targets")
   - No `blas_lib_gfx906` artifact produced

3. Existing `gpu_targets` unit tests pass (15 passed, 4 pre-existing
   failures unrelated to this change):
   `pytest shared/kpack/tests/test_artifact_splitter_integration.py -k gpu_targets`

## Test Result

- `test_gpu_targets_filters_database_files`: PASSED
- `test_no_gpu_targets_creates_all_arches`: PASSED
- `test_gpu_targets_strips_feature_flags`: PASSED
- Manual splitter run with `--gpu-targets gfx906`: correct kpack produced
- Manual splitter run with `--gpu-targets gfx1100`: no spurious gfx906 artifact

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
