### PR TITLE
[rocshmem4py] Add Python binding coverage for teams APIs

### DIFF
--- a/projects/rocshmem/python/README.md
+++ b/projects/rocshmem/python/README.md
@@ -149,7 +149,11 @@ handles come from `rocshmem_team_split_strided`.
 | `rocshmem_team_split_strided(parent, start, stride, size, config=None, mask=0)` | Split a parent team into a strided sub-team; returns `(status, team_handle)`. Non-members receive `ROCSHMEM_TEAM_INVALID` (`-1`), not `0` |
 | `rocshmem_team_destroy(team)` | Destroy a team (no-op for `ROCSHMEM_TEAM_WORLD` / `ROCSHMEM_TEAM_INVALID`) |
 | `rocshmem_team_translate_pe(src_team, src_pe, dest_team)` | Map a PE index between teams; returns `-1` if unmappable |
-| `rocshmem_team_world()` | Return the runtime `ROCSHMEM_TEAM_WORLD` handle (prefer the `ROCSHMEM_TEAM_WORLD` sentinel `0` in application code) |
+
+Pass `ROCSHMEM_TEAM_WORLD` (`0`) for world-scope team operations. The C
+binding's `resolve_team_handle()` translates this sentinel to the runtime
+handle; use the constant rather than a raw runtime pointer so
+`rocshmem_team_destroy` and the tracked split/destroy wrappers stay safe.
 
 `finalize_with_torch()` and `finalize_with_mpi()` automatically destroy any
 teams created via the tracked `rocshmem_team_split_strided` wrapper before

--- a/projects/rocshmem/python/README.md
+++ b/projects/rocshmem/python/README.md
@@ -8,18 +8,23 @@
 ## Features
 
 - **Core rocSHMEM API**: Memory management, data transfer, atomics, synchronization
+- **Teams**: Team split/destroy/translate with tracked lifecycle and WORLD/INVALID sentinels
+- **Team-scoped collectives**: Stream-ordered all-to-all and broadcast
 - **Framework-agnostic allocation**: `rocshmem_create_buffer` / `rocshmem_get_peer_buffer` work without any ML framework
+- **Heap-base introspection**: `rocshmem_get_heap_bases` for device-side pointer translation
 - **`__cuda_array_interface__`**: Zero-copy interop between `SymmetricBuffer` and PyTorch tensors
-- **PyTorch interop submodule**: `rocshmem4py.interop.torch` for tensor allocation and tensor-aware RMA (`put`, `get`, `barrier_all`)
+- **PyTorch interop submodule**: `rocshmem4py.interop.torch` for tensor allocation, RMA, and collectives
 - **PyTorch coordination**: `init_with_torch()` / `finalize_with_torch()` for torch.distributed-based init
-- **MPI Integration**: `init_with_mpi()` for existing MPI applications
+- **MPI Integration**: `init_with_mpi()` / `finalize_with_mpi()` for existing MPI applications
 
 ## API Coverage
 
 `rocshmem4py` currently exposes a focused host-side subset of rocSHMEM APIs:
-initialization/finalization, PE/team queries, memory allocation, put/get
-(blocking/non-blocking/stream variants), selected atomics, and key constants.
-It does not yet expose every rocSHMEM host API.
+initialization/finalization, PE/team queries, team management, memory
+allocation, put/get (blocking/non-blocking/stream variants), team-scoped
+collectives, the full host atomic-operation matrix, and key constants.
+Context APIs (`rocshmem_ctx_*`) are not yet exposed. It does not yet expose
+every rocSHMEM host API.
 
 Host-facing symbols are exported directly from the compiled extension module
 (`_rocshmem4py`) to avoid drift between Python imports and C++ bindings.
@@ -103,7 +108,7 @@ buf = rocshmem4py.SymmetricBuffer(1024)
 rocshmem4py.rocshmem_barrier_all()
 
 buf.free()
-rocshmem4py.rocshmem_finalize()
+rocshmem4py.finalize_with_mpi()
 ```
 
 ## API Reference
@@ -115,7 +120,9 @@ rocshmem4py.rocshmem_finalize()
 | `init_with_torch(group=None)` | Init rocSHMEM via torch.distributed (recommended) |
 | `finalize_with_torch()` | Synchronized teardown of rocSHMEM + torch.distributed |
 | `init_with_mpi(comm)` | Init rocSHMEM via mpi4py |
+| `finalize_with_mpi()` | Synchronized teardown for `init_with_mpi()` sessions |
 | `init_rocshmem_by_uniqueid(group)` | Low-level init with a torch process group |
+| `set_hip_device_from_env()` | Pin HIP device from `LOCAL_RANK` before raw init |
 | `rocshmem_init()` | Raw rocSHMEM init (rarely needed directly) |
 | `rocshmem_finalize()` | Raw rocSHMEM finalize |
 | `rocshmem_init_attr(rank, nranks, uid)` | Init with unique ID |
@@ -130,6 +137,24 @@ rocshmem4py.rocshmem_finalize()
 | `rocshmem_team_my_pe(team)` | PE number within a team |
 | `rocshmem_team_n_pes(team)` | Number of PEs in a team |
 
+### Teams
+
+Team handles are passed as Python `int` values (raw `intptr_t` from the C
+library). Use the sentinel constants below for the special teams; all other
+handles come from `rocshmem_team_split_strided`.
+
+| Function / type | Description |
+|---|---|
+| `TeamConfig()` | Configuration record for `rocshmem_team_split_strided` (`num_contexts`) |
+| `rocshmem_team_split_strided(parent, start, stride, size, config=None, mask=0)` | Split a parent team into a strided sub-team; returns `(status, team_handle)`. Non-members receive `ROCSHMEM_TEAM_INVALID` (`-1`), not `0` |
+| `rocshmem_team_destroy(team)` | Destroy a team (no-op for `ROCSHMEM_TEAM_WORLD` / `ROCSHMEM_TEAM_INVALID`) |
+| `rocshmem_team_translate_pe(src_team, src_pe, dest_team)` | Map a PE index between teams; returns `-1` if unmappable |
+| `rocshmem_team_world()` | Return the runtime `ROCSHMEM_TEAM_WORLD` handle (prefer the `ROCSHMEM_TEAM_WORLD` sentinel `0` in application code) |
+
+`finalize_with_torch()` and `finalize_with_mpi()` automatically destroy any
+teams created via the tracked `rocshmem_team_split_strided` wrapper before
+calling `rocshmem_finalize()`.
+
 ### Memory Management
 
 #### Framework-agnostic (`rocshmem4py`)
@@ -142,6 +167,7 @@ rocshmem4py.rocshmem_finalize()
 | `SymmetricBuffer(size)` | RAII wrapper; exposes `__cuda_array_interface__` for zero-copy torch interop |
 | `rocshmem_create_buffer(nbytes)` | Collective allocation returning a `SymmetricBuffer` |
 | `rocshmem_get_peer_buffer(buf, peer)` | Non-owning `SymmetricBuffer` view of a peer's buffer (IPC only) |
+| `rocshmem_get_heap_bases(ptr)` | Per-PE base addresses for a symmetric allocation (for device-side pointer translation) |
 
 #### PyTorch interop (`rocshmem4py.interop.torch`)
 
@@ -153,6 +179,22 @@ rocshmem4py.rocshmem_finalize()
 | `put(dst, src, peer, stream=None)` | Stream-ordered put (all backends) |
 | `get(dst, src, peer, stream=None)` | Stream-ordered get (all backends) |
 | `barrier_all(stream=None)` | Stream-ordered collective barrier |
+| `get_heap_bases(tensor)` | `(n_pes,)` int64 GPU tensor of per-PE heap bases for a symmetric tensor |
+| `alltoall(team, dst, src, stream=None)` | Stream-ordered all-to-all over a team |
+| `broadcast(team, dst, src, pe_root, stream=None)` | Stream-ordered broadcast over a team |
+
+### Collectives
+
+#### Host (`rocshmem4py`)
+
+| Function | Description |
+|---|---|
+| `rocshmem_alltoallmem_on_stream(team, dest, source, bytes_per_pe, stream)` | Stream-ordered all-to-all; `bytes_per_pe` is bytes sent to each PE in the team |
+| `rocshmem_broadcastmem_on_stream(team, dest, source, nbytes, pe_root, stream)` | Stream-ordered broadcast; `nbytes` is total bytes; `pe_root` is in the team's PE space |
+| `rocshmem_sync_all()` | Lighter-weight sync (local-store visibility) |
+| `rocshmem_sync_all_on_stream(stream)` | Stream-ordered `sync_all` |
+
+Pass `ROCSHMEM_TEAM_WORLD` (`0`) as the team handle for world-scope collectives.
 
 ### Data Transfer
 
@@ -175,14 +217,27 @@ rocshmem4py.rocshmem_finalize()
 | `rocshmem_barrier_all_on_stream(stream)` | Stream-ordered barrier |
 | `rocshmem_fence()` | Ordering fence |
 | `rocshmem_quiet()` | Wait for all outstanding operations |
+| `hip_device_synchronize()` | Synchronize the current HIP device |
 
 ### Atomic Operations
+
+Host atomic operations are auto-exported from the compiled extension by naming
+convention (`rocshmem_{type}_atomic_{op}`). The matrix covers integer, unsigned,
+and floating types with fetch/set/swap/CAS, fetch-add/add, fetch-inc/inc, and
+bitwise ops where the rocSHMEM header provides them.
+
+Examples:
 
 | Function | Description |
 |---|---|
 | `rocshmem_int_atomic_fetch_add(dest, value, pe)` | Atomic int fetch-and-add |
 | `rocshmem_long_atomic_fetch_add(dest, value, pe)` | Atomic long fetch-and-add |
 | `rocshmem_int_atomic_compare_swap(dest, cond, value, pe)` | Atomic int CAS |
+| `rocshmem_uint64_atomic_or(dest, value, pe)` | Atomic uint64 OR |
+
+> **Note:** Host AMO bindings are present in all builds, but behavioral
+> correctness on the IPC no-MPI backend depends on runtime support that is
+> still being extended.
 
 ### Constants
 

--- a/projects/rocshmem/python/rocshmem4py/__init__.py
+++ b/projects/rocshmem/python/rocshmem4py/__init__.py
@@ -51,7 +51,6 @@ try:
         rocshmem_putmem_signal_on_stream,
         rocshmem_signal_wait_until_on_stream,
         TeamConfig,
-        rocshmem_team_world,
         rocshmem_sync_all,
         rocshmem_sync_all_on_stream,
         # TODO: rocshmem_ctx_{create,destroy,fence,quiet} to be added later

--- a/projects/rocshmem/python/rocshmem4py/__init__.py
+++ b/projects/rocshmem/python/rocshmem4py/__init__.py
@@ -25,6 +25,7 @@ __author__ = "Advanced Micro Devices, Inc."
 try:
     # Keep this import list aligned with src/rocshmem4py.cc host bindings.
     from _rocshmem4py import (
+        hip_device_synchronize,
         rocshmem_init,
         rocshmem_finalize,
         rocshmem_hipmodule_init,
@@ -49,9 +50,24 @@ try:
         rocshmem_getmem_on_stream,
         rocshmem_putmem_signal_on_stream,
         rocshmem_signal_wait_until_on_stream,
-        rocshmem_int_atomic_fetch_add,
-        rocshmem_long_atomic_fetch_add,
-        rocshmem_int_atomic_compare_swap,
+        TeamConfig,
+        rocshmem_team_world,
+        rocshmem_sync_all,
+        rocshmem_sync_all_on_stream,
+        # TODO: rocshmem_ctx_{create,destroy,fence,quiet} to be added later
+        # due to IPC no-MPI HostInterface aborting on non-MPI WindowInfo
+        # rocshmem_ctx_create,
+        # rocshmem_ctx_destroy,
+        # rocshmem_ctx_fence,
+        # rocshmem_ctx_quiet,
+        rocshmem_alltoallmem_on_stream,
+        rocshmem_broadcastmem_on_stream,
+        rocshmem_query_thread,
+        rocshmem_global_exit,
+        rocshmem_dump_stats,
+        rocshmem_reset_stats,
+        rocshmem_get_device_ctx,
+        # Constants
         ROCSHMEM_SUCCESS,
         ROCSHMEM_SIGNAL_SET,
         ROCSHMEM_SIGNAL_ADD,
@@ -69,14 +85,125 @@ except ImportError as e:
         "the rocSHMEM library path."
     ) from e
 
-ROCSHMEM_TEAM_INVALID = -1
+
+# Distinct Python sentinels for the two special team handles.  Both are
+# translated by the C binding's resolve_team_handle():
+#   ROCSHMEM_TEAM_WORLD   ==  0  -> host::ROCSHMEM_TEAM_WORLD (runtime ptr)
+#   ROCSHMEM_TEAM_INVALID == -1  -> rocshmem_team_t(nullptr) (rocSHMEM ABI)
 ROCSHMEM_TEAM_WORLD = 0
+ROCSHMEM_TEAM_INVALID = -1
+_SPECIAL_TEAM_HANDLES = {ROCSHMEM_TEAM_INVALID, ROCSHMEM_TEAM_WORLD}
+
+
+# ---------------------------------------------------------------------------
+# Team APIs (registry + tracked split/destroy)
+# ---------------------------------------------------------------------------
+
+# Live-team registry: every successful split_strided adds the new handle
+# here so finalize_with_torch can drain leaks before rocshmem_finalize.
+_live_teams: set = set()
+
+
+def _team_split_strided_tracked(parent, start, stride, size,
+                                config=None, mask=0):
+    """Tracked variant of rocshmem_team_split_strided.
+
+    Records every successfully created team handle in ``_live_teams`` so
+    finalize_with_torch can destroy any leaked teams before
+    rocshmem_finalize.  Returns ``(status, team_handle)`` matching the
+    raw pybind signature.  Callers that intentionally bypass this wrapper
+    via ``_rocshmem4py.rocshmem_team_split_strided`` own the returned team
+    handle and must destroy it themselves.
+
+    Translates the rocSHMEM ABI INVALID return (C ``nullptr`` ==
+    Python ``0``) to the Python sentinel ``ROCSHMEM_TEAM_INVALID``
+    (``-1``) so callers can distinguish a non-member return from
+    ``ROCSHMEM_TEAM_WORLD``.  Without this translation, a non-member of
+    a child split and a successful WORLD-equivalent call would both
+    look like ``0`` to Python.
+    """
+    from _rocshmem4py import rocshmem_team_split_strided as _raw
+    status, team = _raw(parent, start, stride, size, config, mask)
+    if team == 0:
+        return status, ROCSHMEM_TEAM_INVALID
+    if status == ROCSHMEM_SUCCESS and team not in _SPECIAL_TEAM_HANDLES:
+        _live_teams.add(team)
+    return status, team
+
+
+def _team_destroy_tracked(team):
+    """Tracked variant of rocshmem_team_destroy.
+
+    Removes the handle from the live-team registry on destroy.  Calling
+    on an unknown handle is a no-op (matches rocshmem_team_destroy
+    behavior for ROCSHMEM_TEAM_{INVALID,WORLD,SHARED}).
+    """
+    if team in _SPECIAL_TEAM_HANDLES:
+        return
+    from _rocshmem4py import rocshmem_team_destroy as _raw
+    _raw(team)
+    _live_teams.discard(team)
+
+
+# Public names always go through the tracked variants.  Direct callers of
+# _rocshmem4py.rocshmem_team_split_strided bypass the registry by design
+# (e.g. tests that intentionally exercise the raw API); those callers own
+# any returned team handle and must destroy it themselves.
+rocshmem_team_split_strided = _team_split_strided_tracked
+rocshmem_team_destroy = _team_destroy_tracked
+
+from _rocshmem4py import rocshmem_team_translate_pe  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Full host AMO matrix (re-export by symbol-name discovery)
+# ---------------------------------------------------------------------------
+#
+# The pybind layer generates host AMO bindings via macros.  Hand-listing
+# them in the import block is fragile — instead, walk the extension module
+# and re-export every name matching the AMO naming convention.  These are
+# runtime-backed host APIs; IPC no-MPI support for host AMOs needs to be 
+# added to the rocSHMEM runtime.
+
+_AMO_TYPE_PREFIXES = (
+    "int_", "long_", "longlong_",
+    "uint32_", "uint64_", "size_", "ptrdiff_",
+    "float_", "double_",
+)
+
+
+def _is_amo_name(name: str) -> bool:
+    if not name.startswith("rocshmem_"):
+        return False
+    if "_atomic_" not in name:
+        return False
+    suffix = name[len("rocshmem_"):]
+    return any(suffix.startswith(p) for p in _AMO_TYPE_PREFIXES)
+
+
+def _import_amo_symbols() -> list:
+    import _rocshmem4py as _ext
+    names = []
+    for name in dir(_ext):
+        if _is_amo_name(name):
+            globals()[name] = getattr(_ext, name)
+            names.append(name)
+    return names
+
+
+_AMO_NAMES = tuple(sorted(_import_amo_symbols()))
+
+
+# ---------------------------------------------------------------------------
+# Public surface
+# ---------------------------------------------------------------------------
 
 _HOST_API_BINDINGS = tuple(
     sorted(
         name
         for name in globals()
-        if name.startswith("rocshmem_") or name.startswith("ROCSHMEM_")
+        if (name.startswith("rocshmem_") or name.startswith("ROCSHMEM_"))
+        and not name.startswith("_")
     )
 )
 
@@ -85,6 +212,7 @@ __all__ = [
     *_HOST_API_BINDINGS,
     'ROCSHMEM_TEAM_INVALID',
     'ROCSHMEM_TEAM_WORLD',
+    'TeamConfig',
     # Core framework-agnostic symmetric memory
     'SymmetricBuffer',
     'rocshmem_create_buffer',
@@ -93,12 +221,19 @@ __all__ = [
     'init_rocshmem_by_uniqueid',
     'init_with_mpi',
     'init_with_torch',
+    'finalize_with_mpi',
     'finalize_with_torch',
+    'set_hip_device_from_env',
 ]
 
 
-def _set_hip_device_from_env():
-    """Set HIP device based on LOCAL_RANK or OMPI_COMM_WORLD_LOCAL_RANK."""
+def set_hip_device_from_env():
+    """Pin the HIP device from LOCAL_RANK / OMPI_COMM_WORLD_LOCAL_RANK.
+
+    Call before ``rocshmem_init()`` on the raw (non-torch, non-mpi4py) path so
+    each PE owns a distinct GPU.  ``init_with_torch()`` and ``init_with_mpi()``
+    already do this internally.
+    """
     local_rank = os.environ.get("LOCAL_RANK") or os.environ.get("OMPI_COMM_WORLD_LOCAL_RANK")
     if local_rank is not None:
         try:
@@ -108,11 +243,13 @@ def _set_hip_device_from_env():
             pass
 
 
+_set_hip_device_from_env = set_hip_device_from_env
+
+
 class SymmetricBuffer:
     """RAII wrapper around ``rocshmem_malloc`` that exposes the
     ``__cuda_array_interface__`` protocol for zero-copy interop with
-    PyTorch (``torch.as_tensor``) and any other framework that
-    implements that protocol.
+    consumers that implement that protocol.
 
     Framework-agnostic: works without any ML framework installed.
     """
@@ -123,6 +260,9 @@ class SymmetricBuffer:
             self.ptr = ptr
             self.nbytes = size
         else:
+            # rocshmem_malloc spawns kernels on every PE that can race with
+            # concurrent GPU module setup unless the device is quiesced first.
+            hip_device_synchronize()
             self.ptr = rocshmem_malloc(size)
             self.nbytes = size
         self.size = size
@@ -211,8 +351,8 @@ def rocshmem_create_buffer(nbytes: int) -> SymmetricBuffer:
     """Collectively allocate ``nbytes`` of symmetric memory.
 
     Returns a :class:`SymmetricBuffer` that exposes
-    ``__cuda_array_interface__`` for zero-copy integration with PyTorch
-    (``torch.as_tensor``), and any other ``__cuda_array_interface__`` consumer.
+    ``__cuda_array_interface__`` for zero-copy integration with consumers
+    that understand the protocol.
 
     **This is a collective operation** — all PEs must call this function
     with the same ``nbytes`` argument, matching the SHMEM symmetric heap
@@ -221,6 +361,26 @@ def rocshmem_create_buffer(nbytes: int) -> SymmetricBuffer:
     For the PyTorch convenience wrapper see :mod:`rocshmem4py.interop.torch`.
     """
     return SymmetricBuffer(nbytes)
+
+
+# ---------------------------------------------------------------------------
+# Heap-base introspection helpers for device-side pointer translation
+# ---------------------------------------------------------------------------
+
+def rocshmem_get_heap_bases(ptr: int) -> list:
+    """Return the per-PE base pointer for a symmetric allocation.
+
+    For PE ``i``, returns ``rocshmem_ptr(ptr, i)`` — the address of the
+    same allocation in PE ``i``'s symmetric heap as visible from the
+    local PE.  Entries are 0 when ``rocshmem_ptr`` returns NULL (e.g. on
+    the RO backend, where direct remote dereference is unavailable).
+
+    This helper constructs the ``heap_bases`` array used by device kernels
+    that translate a local symmetric pointer to a peer's pointer via
+    ``heap_bases[peer] + (local_ptr - heap_bases[my_pe])``.
+    """
+    n = rocshmem_n_pes()
+    return [rocshmem_ptr(ptr, pe) for pe in range(n)]
 
 
 def rocshmem_get_peer_buffer(buf: SymmetricBuffer, peer: int) -> SymmetricBuffer:
@@ -255,6 +415,23 @@ def rocshmem_get_peer_buffer(buf: SymmetricBuffer, peer: int) -> SymmetricBuffer
 # Initialization helpers
 # ---------------------------------------------------------------------------
 
+
+def _drain_live_teams() -> None:
+    """Destroy any teams left in the registry before rocshmem_finalize.
+
+    Team destruction is collective: every PE must call ``rocshmem_team_destroy``
+    on the same teams in the same order, or rocshmem_finalize will segfault.
+    Iterating the sorted set guarantees identical order across PEs.
+    """
+    if not _live_teams:
+        return
+    from _rocshmem4py import rocshmem_team_destroy as _raw_destroy
+
+    for team in sorted(_live_teams):
+        _raw_destroy(team)
+    _live_teams.clear()
+
+
 def init_rocshmem_by_uniqueid(group: 'torch.distributed.ProcessGroup'):
     """Broadcast unique ID from rank 0 and call ``rocshmem_init_attr``."""
     import torch
@@ -274,7 +451,13 @@ def init_rocshmem_by_uniqueid(group: 'torch.distributed.ProcessGroup'):
 
 
 def init_with_mpi(mpi_comm: Optional[Any] = None):
-    """Initialize rocSHMEM using mpi4py for coordination."""
+    """Initialize rocSHMEM using mpi4py to broadcast the unique ID.
+
+    The caller must launch with ``mpirun`` (or another MPI launcher) so that
+    ``MPI.COMM_WORLD`` actually spans all PEs.  Under ``torchrun`` (or any
+    non-MPI launcher) ``MPI.COMM_WORLD`` is a singleton per process and this
+    function raises -- use ``init_with_torch()`` in that case.
+    """
     try:
         from mpi4py import MPI
     except ImportError:
@@ -287,6 +470,21 @@ def init_with_mpi(mpi_comm: Optional[Any] = None):
 
     rank = mpi_comm.Get_rank()
     size = mpi_comm.Get_size()
+
+    # Sanity check: if a process launcher set WORLD_SIZE/OMPI_COMM_WORLD_SIZE
+    # but MPI.COMM_WORLD doesn't match, we are not running under MPI and the
+    # init below would silently create N independent size-1 worlds.
+    launcher_size_str = (
+        os.environ.get("WORLD_SIZE") or os.environ.get("OMPI_COMM_WORLD_SIZE")
+    )
+    if launcher_size_str is not None and int(launcher_size_str) != size:
+        raise RuntimeError(
+            f"MPI.COMM_WORLD has size {size} but the launcher reports "
+            f"WORLD_SIZE={launcher_size_str}. This usually means the job was "
+            "launched with torchrun (or another non-MPI launcher) where "
+            "MPI.COMM_WORLD is a singleton per process. Use init_with_torch() "
+            "for torchrun, or launch with mpirun for init_with_mpi()."
+        )
 
     unique_id = rocshmem_get_uniqueid() if rank == 0 else None
     unique_id = mpi_comm.bcast(unique_id, root=0)
@@ -374,11 +572,34 @@ def _populate_torch_env_from_mpi():
 _rocshmem_initialized = False
 
 
+def finalize_with_mpi():
+    """Synchronized teardown for sessions initialized via ``init_with_mpi()``.
+
+    Drains any teams the caller forgot to destroy (collective op, sorted for
+    deterministic order across PEs), quiesces the device, then barriers and
+    finalizes rocSHMEM.  MPI itself is not finalized here -- the launcher /
+    application owns ``MPI_Finalize``.
+    """
+    global _rocshmem_initialized
+    if not _rocshmem_initialized:
+        return
+
+    hip_device_synchronize()
+    _drain_live_teams()
+    rocshmem_barrier_all()
+    rocshmem_finalize()
+    _rocshmem_initialized = False
+
+
 def finalize_with_torch():
-    """Synchronized teardown: sync -> barrier_all -> dist.barrier -> finalize.
-    The barriers ensure all ranks have completed their work before any
-    rank enters ``rocshmem_finalize()``, preventing the segfault that
-    occurs when one rank tears down while another is still communicating.
+    """Synchronized teardown for sessions initialized via ``init_with_torch()``.
+
+    Order is critical:
+      1. ``torch.cuda.synchronize()`` so no rank enters finalize with pending GPU work
+      2. drain leaked teams (collective; deterministic order via sorted set)
+      3. ``rocshmem_barrier_all`` + ``dist.barrier`` -- both world barriers, paired
+         so neither library tears down while the other is still communicating
+      4. ``rocshmem_finalize`` then ``destroy_process_group``
     """
     global _rocshmem_initialized
     if not _rocshmem_initialized:
@@ -391,6 +612,7 @@ def finalize_with_torch():
         return
 
     torch.cuda.synchronize()
+    _drain_live_teams()
     rocshmem_barrier_all()
     if dist.is_initialized():
         dist.barrier()

--- a/projects/rocshmem/python/rocshmem4py/interop/torch.py
+++ b/projects/rocshmem/python/rocshmem4py/interop/torch.py
@@ -227,3 +227,117 @@ def barrier_all(stream=None) -> None:
         Defaults to ``torch.cuda.current_stream()``.
     """
     rocshmem4py.rocshmem_barrier_all_on_stream(_stream_handle(stream))
+
+
+# ---------------------------------------------------------------------------
+# Heap-base helper for device kernels
+# ---------------------------------------------------------------------------
+
+def get_heap_bases(tensor: 'torch.Tensor') -> 'torch.Tensor':
+    """Return an int64 CUDA tensor of per-PE base addresses for a symmetric tensor.
+
+    The returned tensor has shape ``(n_pes,)``, dtype ``torch.int64``, on
+    the current CUDA device.  Device kernels can use this array to translate
+    a local symmetric pointer to a peer's pointer via
+    ``heap_bases[peer] + (local_ptr - heap_bases[my_pe])``.
+
+    Entries are 0 for PEs whose memory is not directly accessible from
+    the local PE (e.g. on the RO backend).  Device kernels using this
+    array must check for the zero entry or use the rocSHMEM device-side
+    bitcode wrappers (``rocshmem_putmem_wrapper`` etc.) instead of
+    arithmetic translation when targeting RO.
+
+    Parameters
+    ----------
+    tensor:
+        A symmetric tensor allocated by :func:`create_tensor` (must have
+        ``__symm_tensor__`` set).
+    """
+    try:
+        import torch
+    except ImportError:
+        raise ImportError("PyTorch is required for rocshmem4py.interop.torch.")
+
+    if not getattr(tensor, "__symm_tensor__", False):
+        raise ValueError(
+            "tensor is not a symmetric tensor (missing __symm_tensor__ "
+            "attribute). Use create_tensor() to allocate it."
+        )
+
+    bases = rocshmem4py.rocshmem_get_heap_bases(tensor.data_ptr())
+    return torch.tensor(bases, dtype=torch.int64, device="cuda")
+
+
+# ---------------------------------------------------------------------------
+# Tensor-aware team-scoped collectives
+# ---------------------------------------------------------------------------
+
+def alltoall(team: int, dst: 'torch.Tensor', src: 'torch.Tensor',
+             stream=None) -> None:
+    """Stream-ordered all-to-all over a team.
+
+    Each PE in *team* sends ``src.nbytes / team_size`` bytes to every
+    other PE; the layout is concatenation of per-PE chunks in PE-order.
+
+    Parameters
+    ----------
+    team:
+        rocshmem team handle (intptr_t).  Use ``ROCSHMEM_TEAM_WORLD``
+        for the world team.
+    dst:
+        Destination tensor on the local PE (symmetric); must hold
+        ``team_size`` chunks.
+    src:
+        Source tensor on the local PE (symmetric); must match
+        ``dst.nbytes``.
+    stream:
+        Defaults to ``torch.cuda.current_stream()``.
+    """
+    if dst.nbytes != src.nbytes:
+        raise ValueError(
+            f"dst.nbytes ({dst.nbytes}) must match src.nbytes ({src.nbytes})"
+        )
+    team_size = rocshmem4py.rocshmem_team_n_pes(team)
+    if team_size <= 0:
+        raise ValueError(f"team has invalid size: {team_size}")
+    if src.nbytes % team_size != 0:
+        raise ValueError(
+            f"src.nbytes ({src.nbytes}) must be divisible by team size "
+            f"({team_size})"
+        )
+    rocshmem4py.rocshmem_alltoallmem_on_stream(
+        team, dst.data_ptr(), src.data_ptr(), src.nbytes // team_size,
+        _stream_handle(stream),
+    )
+
+
+def broadcast(team: int, dst: 'torch.Tensor', src: 'torch.Tensor',
+              pe_root: int, stream=None) -> None:
+    """Stream-ordered broadcast over a team.
+
+    On the root PE the contents of *src* are copied to *dst* on every
+    other PE in *team*.  ``pe_root`` is in the team's PE space, not the
+    world PE space.
+
+    Parameters
+    ----------
+    team:
+        rocshmem team handle (intptr_t).
+    dst:
+        Destination tensor on the local PE (symmetric).
+    src:
+        Source tensor on the local PE (symmetric); only its contents on
+        the root PE matter.
+    pe_root:
+        Root PE index in *team*'s PE space.
+    stream:
+        Defaults to ``torch.cuda.current_stream()``.
+    """
+    if dst.nbytes != src.nbytes:
+        raise ValueError(
+            f"dst.nbytes ({dst.nbytes}) must match src.nbytes ({src.nbytes})"
+        )
+    rocshmem4py.rocshmem_broadcastmem_on_stream(
+        team, dst.data_ptr(), src.data_ptr(), src.nbytes, pe_root,
+        _stream_handle(stream),
+    )

--- a/projects/rocshmem/python/src/rocshmem4py.cc
+++ b/projects/rocshmem/python/src/rocshmem4py.cc
@@ -15,6 +15,19 @@
 namespace py = pybind11;
 using namespace rocshmem;
 
+namespace {
+rocshmem_team_t resolve_team_handle(intptr_t team) {
+  // Python sentinels are translated to rocSHMEM ABI handles:
+  //   0   -> host::ROCSHMEM_TEAM_WORLD (runtime pointer set at init)
+  //  -1   -> ROCSHMEM_TEAM_INVALID    (rocSHMEM ABI nullptr)
+  // Anything else is a raw rocshmem_team_t (intptr_t-cast pointer)
+  // returned by a previous successful split and passed back through.
+  if (team == 0)  return ROCSHMEM_TEAM_WORLD;
+  if (team == -1) return ROCSHMEM_TEAM_INVALID;
+  return reinterpret_cast<rocshmem_team_t>(team);
+}
+}  // namespace
+
 #define CHECK_ROCSHMEM(expr)                                                   \
   do {                                                                         \
     int status = expr;                                                         \
@@ -45,13 +58,22 @@ PYBIND11_MODULE(_rocshmem4py, m) {
   m.def("rocshmem_my_pe", []() -> int { return rocshmem_my_pe(); });
   m.def("rocshmem_n_pes", []() -> int { return rocshmem_n_pes(); });
 
+  m.def("hip_device_synchronize", []() {
+    hipError_t err = hipDeviceSynchronize();
+    if (err != hipSuccess) {
+      std::ostringstream err_msg;
+      err_msg << "hipDeviceSynchronize failed: " << hipGetErrorString(err);
+      throw std::runtime_error(err_msg.str());
+    }
+  }, "Synchronize the current HIP device.");
+
   // Team queries
   m.def("rocshmem_team_my_pe", [](intptr_t team) -> int {
-    return rocshmem_team_my_pe((rocshmem_team_t)team);
+    return rocshmem_team_my_pe(resolve_team_handle(team));
   }, "Get PE number within a team", py::arg("team"));
 
   m.def("rocshmem_team_n_pes", [](intptr_t team) -> int {
-    return rocshmem_team_n_pes((rocshmem_team_t)team);
+    return rocshmem_team_n_pes(resolve_team_handle(team));
   }, "Get number of PEs in a team", py::arg("team"));
 
   // Memory management
@@ -143,16 +165,287 @@ PYBIND11_MODULE(_rocshmem4py, m) {
     }, "Stream-ordered wait on signal",
     py::arg("sig_addr"), py::arg("cmp"), py::arg("cmp_value"), py::arg("stream"));
 
-  // Atomics
-  m.def("rocshmem_int_atomic_fetch_add", [](intptr_t dest, int value, int pe) -> int {
-    return rocshmem_int_atomic_fetch_add((int *)dest, value, pe);
-  });
-  m.def("rocshmem_long_atomic_fetch_add", [](intptr_t dest, long value, int pe) -> long {
-    return rocshmem_long_atomic_fetch_add((long *)dest, value, pe);
-  });
-  m.def("rocshmem_int_atomic_compare_swap", [](intptr_t dest, int cond, int value, int pe) -> int {
-    return rocshmem_int_atomic_compare_swap((int *)dest, cond, value, pe);
-  });
+  // -------------------------------------------------------------------------
+  // Team APIs
+  // -------------------------------------------------------------------------
+
+  py::class_<rocshmem_team_config_t>(m, "TeamConfig",
+      "Configuration record for rocshmem_team_split_strided.")
+    .def(py::init<>())
+    .def_readwrite("num_contexts", &rocshmem_team_config_t::num_contexts);
+
+  m.def("rocshmem_team_split_strided",
+    [](intptr_t parent, int start, int stride, int size,
+       py::object config_obj, long mask) -> py::tuple {
+      rocshmem_team_t new_team = ROCSHMEM_TEAM_INVALID;
+      rocshmem_team_config_t cfg{};
+      const rocshmem_team_config_t* cfg_ptr = nullptr;
+      if (!config_obj.is_none()) {
+        cfg = config_obj.cast<rocshmem_team_config_t>();
+        cfg_ptr = &cfg;
+      }
+      int status = rocshmem_team_split_strided(
+          resolve_team_handle(parent), start, stride, size, cfg_ptr, mask,
+          &new_team);
+      return py::make_tuple(status, (intptr_t)new_team);
+    },
+    "Split parent team into a strided sub-team. Returns (status, new_team_handle).",
+    py::arg("parent"), py::arg("start"), py::arg("stride"), py::arg("size"),
+    py::arg("config") = py::none(), py::arg("mask") = 0L);
+
+  m.def("rocshmem_team_destroy", [](intptr_t team) {
+    // Both Python sentinels (WORLD=0, INVALID=-1) are no-ops, matching
+    // rocshmem_team_destroy()'s documented behavior for WORLD / INVALID
+    // / SHARED.  Stale callers that pass 0 thinking it means INVALID
+    // still get the expected no-op (silent compatibility).
+    if (team == 0 || team == -1) return;
+    rocshmem_team_destroy(reinterpret_cast<rocshmem_team_t>(team));
+  }, "Destroy a team. Silently ignored for INVALID/WORLD/SHARED.",
+     py::arg("team"));
+
+  m.def("rocshmem_team_translate_pe",
+    [](intptr_t src, int pe, intptr_t dst) -> int {
+      return rocshmem_team_translate_pe(
+          resolve_team_handle(src), pe, resolve_team_handle(dst));
+    },
+    "Translate a PE index from src_team to dst_team. Returns -1 if unmappable.",
+    py::arg("src_team"), py::arg("src_pe"), py::arg("dest_team"));
+
+  m.def("rocshmem_team_world", []() -> intptr_t {
+    return reinterpret_cast<intptr_t>(ROCSHMEM_TEAM_WORLD);
+  }, "Return the runtime ROCSHMEM_TEAM_WORLD handle.");
+
+  // -------------------------------------------------------------------------
+  // sync_all (host-side ordering)
+  // -------------------------------------------------------------------------
+  //
+  // TODO: ctx-scoped APIs (rocshmem_ctx_create / _destroy / _fence / _quiet)
+  
+  m.def("rocshmem_sync_all", []() { rocshmem_sync_all(); },
+    "Lighter-weight partner to barrier_all (local-store visibility).");
+
+  m.def("rocshmem_sync_all_on_stream", [](intptr_t stream) {
+    rocshmem_sync_all_on_stream((hipStream_t)stream);
+  }, "Stream-ordered sync_all.", py::arg("stream"));
+
+  // -------------------------------------------------------------------------
+  // Full host AMO matrix
+  // -------------------------------------------------------------------------
+  //
+  // Generated via macro expansion from rocshmem_AMO.hpp.  Coverage matrix:
+  //
+  //   types: int, long, longlong, uint32_t, uint64_t, size_t, ptrdiff_t,
+  //          float, double
+  //   ops:   fetch, set, compare_swap, swap,
+  //          fetch_add, fetch_inc, fetch_and, fetch_or, fetch_xor,
+  //          add, inc, and, or, xor
+  //
+  // Bitwise + inc skipped on float/double (rocSHMEM does not provide them).
+  // longlong has only set/inc/add per header; other ops omitted.
+  //
+
+#define AMO_FETCH_T(T, Tname)                                                  \
+  m.def("rocshmem_" #Tname "_atomic_fetch",                                    \
+    [](intptr_t dest, int pe) -> T {                                           \
+      return rocshmem_##Tname##_atomic_fetch((T *)dest, pe);                   \
+    }, py::arg("dest"), py::arg("pe"))
+
+#define AMO_SET_T(T, Tname)                                                    \
+  m.def("rocshmem_" #Tname "_atomic_set",                                      \
+    [](intptr_t dest, T value, int pe) {                                       \
+      rocshmem_##Tname##_atomic_set((T *)dest, value, pe);                     \
+    }, py::arg("dest"), py::arg("value"), py::arg("pe"))
+
+#define AMO_CAS_T(T, Tname)                                                    \
+  m.def("rocshmem_" #Tname "_atomic_compare_swap",                             \
+    [](intptr_t dest, T cond, T value, int pe) -> T {                          \
+      return rocshmem_##Tname##_atomic_compare_swap(                           \
+          (T *)dest, cond, value, pe);                                         \
+    }, py::arg("dest"), py::arg("cond"), py::arg("value"), py::arg("pe"))
+
+#define AMO_SWAP_T(T, Tname)                                                   \
+  m.def("rocshmem_" #Tname "_atomic_swap",                                     \
+    [](intptr_t dest, T value, int pe) -> T {                                  \
+      return rocshmem_##Tname##_atomic_swap((T *)dest, value, pe);             \
+    }, py::arg("dest"), py::arg("value"), py::arg("pe"))
+
+#define AMO_FETCH_ADD_T(T, Tname)                                              \
+  m.def("rocshmem_" #Tname "_atomic_fetch_add",                                \
+    [](intptr_t dest, T value, int pe) -> T {                                  \
+      return rocshmem_##Tname##_atomic_fetch_add((T *)dest, value, pe);        \
+    }, py::arg("dest"), py::arg("value"), py::arg("pe"))
+
+#define AMO_FETCH_INC_T(T, Tname)                                              \
+  m.def("rocshmem_" #Tname "_atomic_fetch_inc",                                \
+    [](intptr_t dest, int pe) -> T {                                           \
+      return rocshmem_##Tname##_atomic_fetch_inc((T *)dest, pe);               \
+    }, py::arg("dest"), py::arg("pe"))
+
+#define AMO_ADD_T(T, Tname)                                                    \
+  m.def("rocshmem_" #Tname "_atomic_add",                                      \
+    [](intptr_t dest, T value, int pe) {                                       \
+      rocshmem_##Tname##_atomic_add((T *)dest, value, pe);                     \
+    }, py::arg("dest"), py::arg("value"), py::arg("pe"))
+
+#define AMO_INC_T(T, Tname)                                                    \
+  m.def("rocshmem_" #Tname "_atomic_inc",                                      \
+    [](intptr_t dest, int pe) {                                                \
+      rocshmem_##Tname##_atomic_inc((T *)dest, pe);                            \
+    }, py::arg("dest"), py::arg("pe"))
+
+#define AMO_FETCH_BITWISE_T(T, Tname, Op)                                      \
+  m.def("rocshmem_" #Tname "_atomic_fetch_" #Op,                               \
+    [](intptr_t dest, T value, int pe) -> T {                                  \
+      return rocshmem_##Tname##_atomic_fetch_##Op((T *)dest, value, pe);       \
+    }, py::arg("dest"), py::arg("value"), py::arg("pe"))
+
+#define AMO_BITWISE_T(T, Tname, Op)                                            \
+  m.def("rocshmem_" #Tname "_atomic_" #Op,                                     \
+    [](intptr_t dest, T value, int pe) {                                       \
+      rocshmem_##Tname##_atomic_##Op((T *)dest, value, pe);                    \
+    }, py::arg("dest"), py::arg("value"), py::arg("pe"))
+
+  // ------ fetch / set / cas / swap (full type set) ------
+  // Note: numeric types only. CAS is missing on float/double per header.
+  AMO_FETCH_T(int, int);
+  AMO_FETCH_T(long, long);
+  AMO_FETCH_T(uint32_t, uint32);
+  AMO_FETCH_T(uint64_t, uint64);
+  AMO_FETCH_T(size_t, size);
+  AMO_FETCH_T(ptrdiff_t, ptrdiff);
+  AMO_FETCH_T(float, float);
+  AMO_FETCH_T(double, double);
+
+  AMO_SET_T(int, int);
+  AMO_SET_T(long, long);
+  AMO_SET_T(long long, longlong);
+  AMO_SET_T(uint32_t, uint32);
+  AMO_SET_T(uint64_t, uint64);
+  AMO_SET_T(size_t, size);
+  AMO_SET_T(ptrdiff_t, ptrdiff);
+  AMO_SET_T(float, float);
+  AMO_SET_T(double, double);
+
+  AMO_CAS_T(int, int);
+  AMO_CAS_T(long, long);
+  AMO_CAS_T(uint32_t, uint32);
+  AMO_CAS_T(uint64_t, uint64);
+  AMO_CAS_T(size_t, size);
+  AMO_CAS_T(ptrdiff_t, ptrdiff);
+
+  AMO_SWAP_T(int, int);
+  AMO_SWAP_T(long, long);
+  AMO_SWAP_T(uint32_t, uint32);
+  AMO_SWAP_T(uint64_t, uint64);
+  AMO_SWAP_T(size_t, size);
+  AMO_SWAP_T(ptrdiff_t, ptrdiff);
+  AMO_SWAP_T(float, float);
+  AMO_SWAP_T(double, double);
+
+  // ------ fetch_add / add (numeric types) ------
+  AMO_FETCH_ADD_T(int, int);
+  AMO_FETCH_ADD_T(long, long);
+  AMO_FETCH_ADD_T(uint32_t, uint32);
+  AMO_FETCH_ADD_T(uint64_t, uint64);
+  AMO_FETCH_ADD_T(size_t, size);
+  AMO_FETCH_ADD_T(ptrdiff_t, ptrdiff);
+
+  AMO_ADD_T(int, int);
+  AMO_ADD_T(long, long);
+  AMO_ADD_T(long long, longlong);
+  AMO_ADD_T(uint32_t, uint32);
+  AMO_ADD_T(uint64_t, uint64);
+  AMO_ADD_T(size_t, size);
+  AMO_ADD_T(ptrdiff_t, ptrdiff);
+
+  // ------ fetch_inc / inc (integer types) ------
+  AMO_FETCH_INC_T(int, int);
+  AMO_FETCH_INC_T(long, long);
+  AMO_FETCH_INC_T(uint32_t, uint32);
+  AMO_FETCH_INC_T(uint64_t, uint64);
+  AMO_FETCH_INC_T(size_t, size);
+  AMO_FETCH_INC_T(ptrdiff_t, ptrdiff);
+
+  AMO_INC_T(int, int);
+  AMO_INC_T(long, long);
+  AMO_INC_T(long long, longlong);
+  AMO_INC_T(uint32_t, uint32);
+  AMO_INC_T(uint64_t, uint64);
+  AMO_INC_T(size_t, size);
+  AMO_INC_T(ptrdiff_t, ptrdiff);
+
+  // ------ fetch_and / and / fetch_or / or / fetch_xor / xor (uint32/uint64) ------
+  AMO_FETCH_BITWISE_T(uint32_t, uint32, and);
+  AMO_FETCH_BITWISE_T(uint64_t, uint64, and);
+  AMO_BITWISE_T(uint32_t, uint32, and);
+  AMO_BITWISE_T(uint64_t, uint64, and);
+
+  AMO_FETCH_BITWISE_T(uint32_t, uint32, or);
+  AMO_FETCH_BITWISE_T(uint64_t, uint64, or);
+  AMO_BITWISE_T(uint32_t, uint32, or);
+  AMO_BITWISE_T(uint64_t, uint64, or);
+
+  AMO_FETCH_BITWISE_T(uint32_t, uint32, xor);
+  AMO_FETCH_BITWISE_T(uint64_t, uint64, xor);
+  AMO_BITWISE_T(uint32_t, uint32, xor);
+  AMO_BITWISE_T(uint64_t, uint64, xor);
+
+#undef AMO_FETCH_T
+#undef AMO_SET_T
+#undef AMO_CAS_T
+#undef AMO_SWAP_T
+#undef AMO_FETCH_ADD_T
+#undef AMO_FETCH_INC_T
+#undef AMO_ADD_T
+#undef AMO_INC_T
+#undef AMO_FETCH_BITWISE_T
+#undef AMO_BITWISE_T
+
+  // -------------------------------------------------------------------------
+  // Team-scoped collectives + small host primitives
+  // -------------------------------------------------------------------------
+
+  m.def("rocshmem_alltoallmem_on_stream",
+    [](intptr_t team, intptr_t dest, intptr_t source, size_t nelems,
+       intptr_t stream) {
+      rocshmem_alltoallmem_on_stream(
+          resolve_team_handle(team), (void *)dest, (const void *)source,
+          nelems, (hipStream_t)stream);
+    },
+    "Stream-ordered all-to-all over a team.",
+    py::arg("team"), py::arg("dest"), py::arg("source"), py::arg("nelems"),
+    py::arg("stream"));
+
+  m.def("rocshmem_broadcastmem_on_stream",
+    [](intptr_t team, intptr_t dest, intptr_t source, size_t nelems,
+       int pe_root, intptr_t stream) {
+      rocshmem_broadcastmem_on_stream(
+          resolve_team_handle(team), (void *)dest, (const void *)source,
+          nelems, pe_root, (hipStream_t)stream);
+    },
+    "Stream-ordered broadcast over a team. pe_root is in the team's PE space.",
+    py::arg("team"), py::arg("dest"), py::arg("source"), py::arg("nelems"),
+    py::arg("pe_root"), py::arg("stream"));
+
+  m.def("rocshmem_query_thread", []() -> int {
+    int provided = 0;
+    rocshmem_query_thread(&provided);
+    return provided;
+  }, "Return the threading mode provided by rocshmem_init_thread.");
+
+  m.def("rocshmem_global_exit", [](int status) {
+    rocshmem_global_exit(status);
+  }, "Emergency abort hook (collective).", py::arg("status"));
+
+  m.def("rocshmem_dump_stats", []() { rocshmem_dump_stats(); },
+    "Dump runtime telemetry to stdout.");
+
+  m.def("rocshmem_reset_stats", []() { rocshmem_reset_stats(); },
+    "Reset runtime telemetry counters.");
+
+  m.def("rocshmem_get_device_ctx", []() -> intptr_t {
+    return (intptr_t)rocshmem_get_device_ctx();
+  }, "Return the default device context as an intptr_t.");
 
   // Constants
   m.attr("ROCSHMEM_SUCCESS") = py::int_(0);

--- a/projects/rocshmem/python/src/rocshmem4py.cc
+++ b/projects/rocshmem/python/src/rocshmem4py.cc
@@ -406,25 +406,27 @@ PYBIND11_MODULE(_rocshmem4py, m) {
   // -------------------------------------------------------------------------
 
   m.def("rocshmem_alltoallmem_on_stream",
-    [](intptr_t team, intptr_t dest, intptr_t source, size_t nelems,
+    [](intptr_t team, intptr_t dest, intptr_t source, size_t bytes_per_pe,
        intptr_t stream) {
       rocshmem_alltoallmem_on_stream(
           resolve_team_handle(team), (void *)dest, (const void *)source,
-          nelems, (hipStream_t)stream);
+          bytes_per_pe, (hipStream_t)stream);
     },
-    "Stream-ordered all-to-all over a team.",
-    py::arg("team"), py::arg("dest"), py::arg("source"), py::arg("nelems"),
-    py::arg("stream"));
+    "Stream-ordered all-to-all over a team. bytes_per_pe is the number of "
+    "bytes transferred to each PE in the team.",
+    py::arg("team"), py::arg("dest"), py::arg("source"),
+    py::arg("bytes_per_pe"), py::arg("stream"));
 
   m.def("rocshmem_broadcastmem_on_stream",
-    [](intptr_t team, intptr_t dest, intptr_t source, size_t nelems,
+    [](intptr_t team, intptr_t dest, intptr_t source, size_t nbytes,
        int pe_root, intptr_t stream) {
       rocshmem_broadcastmem_on_stream(
           resolve_team_handle(team), (void *)dest, (const void *)source,
-          nelems, pe_root, (hipStream_t)stream);
+          nbytes, pe_root, (hipStream_t)stream);
     },
-    "Stream-ordered broadcast over a team. pe_root is in the team's PE space.",
-    py::arg("team"), py::arg("dest"), py::arg("source"), py::arg("nelems"),
+    "Stream-ordered broadcast over a team. nbytes is the number of bytes "
+    "broadcast. pe_root is in the team's PE space.",
+    py::arg("team"), py::arg("dest"), py::arg("source"), py::arg("nbytes"),
     py::arg("pe_root"), py::arg("stream"));
 
   m.def("rocshmem_query_thread", []() -> int {

--- a/projects/rocshmem/python/src/rocshmem4py.cc
+++ b/projects/rocshmem/python/src/rocshmem4py.cc
@@ -211,10 +211,6 @@ PYBIND11_MODULE(_rocshmem4py, m) {
     "Translate a PE index from src_team to dst_team. Returns -1 if unmappable.",
     py::arg("src_team"), py::arg("src_pe"), py::arg("dest_team"));
 
-  m.def("rocshmem_team_world", []() -> intptr_t {
-    return reinterpret_cast<intptr_t>(ROCSHMEM_TEAM_WORLD);
-  }, "Return the runtime ROCSHMEM_TEAM_WORLD handle.");
-
   // -------------------------------------------------------------------------
   // sync_all (host-side ordering)
   // -------------------------------------------------------------------------

--- a/projects/rocshmem/python/tests/conftest.py
+++ b/projects/rocshmem/python/tests/conftest.py
@@ -5,42 +5,36 @@ Shared helpers exported to all test modules:
   - ``requires_torch``   : skip marker for tests that need PyTorch.
   - ``requires_multi_pe``: skip marker for tests that need at least 2 PEs.
 
-Init priority
-  1. torch   → ``init_with_torch()``  (torch.distributed rendezvous)
-  2. mpi4py  → ``init_with_mpi()``    (Python MPI wrapper)
-  3. neither → ``rocshmem_init()``    (rocSHMEM calls MPI_Init internally)
+Init selection (first match wins):
+  1. torch installed (unless explicitly opted out under mpirun) -> ``init_with_torch()``
+  2. mpirun + mpi4py available                                  -> ``init_with_mpi()``
+  3. mpirun without mpi4py                                      -> ``rocshmem_init()``
+
+Set ``ROCSHMEM_USE_TORCH_INIT=0`` under mpirun to force the mpi4py path
+(useful for exercising the MPI bootstrap when torch is also installed).
+Outside mpirun the env var is ignored, since ``init_with_mpi()`` requires
+``MPI.COMM_WORLD`` to span all PEs and raises otherwise.
 """
 
 import os
-import ctypes
 import pytest
 
 
-def _torch_available() -> bool:
+def _try_import(name: str) -> bool:
     try:
-        import torch  # noqa: F401
+        __import__(name)
         return True
     except ImportError:
         return False
 
 
-def _mpi4py_available() -> bool:
-    try:
-        from mpi4py import MPI  # noqa: F401
-        return True
-    except ImportError:
-        return False
-
-
-def _use_torch_init() -> bool:
-    """Use torch init if torch is available AND not explicitly disabled.
-
-    ROCSHMEM_USE_TORCH_INIT=0 forces the mpi4py/raw path regardless of
-    torch presence.  When torch is absent the function always returns False.
-    """
-    if not _torch_available():
-        return False
-    return os.environ.get("ROCSHMEM_USE_TORCH_INIT", "1") == "1"
+_HAS_TORCH = _try_import("torch")
+_HAS_MPI4PY = _try_import("mpi4py")
+_UNDER_MPIRUN = "OMPI_COMM_WORLD_SIZE" in os.environ
+_USE_TORCH = _HAS_TORCH and (
+    os.environ.get("ROCSHMEM_USE_TORCH_INIT", "1") == "1" or not _UNDER_MPIRUN
+)
+_USE_MPI = not _USE_TORCH and _UNDER_MPIRUN and _HAS_MPI4PY
 
 
 def _world_size() -> int:
@@ -51,17 +45,14 @@ def _world_size() -> int:
     )
 
 
-requires_torch = pytest.mark.skipif(
-    not _torch_available(), reason="torch not installed"
-)
-
+requires_torch = pytest.mark.skipif(not _HAS_TORCH, reason="torch not installed")
 requires_multi_pe = pytest.mark.skipif(
     _world_size() < 2, reason="Requires at least 2 PEs"
 )
 
 
 # Tracks whether the session-scoped fixture successfully initialized rocSHMEM.
-# pytest_sessionfinish must not call into the library if init never ran —
+# pytest_sessionfinish must not call into the library if init never ran --
 # an unguarded barrier_all / finalize on an uninitialized context segfaults
 # and masks the real collection error in CI logs.
 _rocshmem_initialized = False
@@ -72,27 +63,17 @@ def rocshmem_session():
     import rocshmem4py
 
     global _rocshmem_initialized
-    if _use_torch_init():
+    if _USE_TORCH:
         rocshmem4py.init_with_torch()
-    elif _mpi4py_available():
+    elif _USE_MPI:
         rocshmem4py.init_with_mpi()
     else:
-        # Neither torch nor mpi4py available (e.g. bare CI image).
-        # rocshmem_init() calls MPI_Init internally — works under mpirun
-        # with no Python MPI wrapper required.
-        local_rank = (
-            os.environ.get("LOCAL_RANK")
-            or os.environ.get("OMPI_COMM_WORLD_LOCAL_RANK")
-        )
-        if local_rank is not None:
-            try:
-                hip = ctypes.CDLL("libamdhip64.so")
-                hip.hipSetDevice(int(local_rank))
-            except OSError:
-                pass
+        # Bare CI image or mpirun without mpi4py.  Pin the HIP device from
+        # LOCAL_RANK before rocshmem_init() so each PE owns a distinct GPU --
+        # the torch / mpi4py helpers already do this internally.
+        rocshmem4py.set_hip_device_from_env()
         rocshmem4py.rocshmem_init()
     _rocshmem_initialized = True
-
     yield
 
 
@@ -102,15 +83,13 @@ def pytest_sessionfinish(session, exitstatus):
 
     import rocshmem4py
 
-    if _use_torch_init():
+    if _USE_TORCH:
         rocshmem4py.finalize_with_torch()
+    elif _USE_MPI:
+        rocshmem4py.finalize_with_mpi()
     else:
         # Sync device before the collective barrier so no rank enters
         # finalize while another is still executing GPU work.
-        try:
-            hip = ctypes.CDLL("libamdhip64.so")
-            hip.hipDeviceSynchronize()
-        except OSError:
-            pass
+        rocshmem4py.hip_device_synchronize()
         rocshmem4py.rocshmem_barrier_all()
         rocshmem4py.rocshmem_finalize()

--- a/projects/rocshmem/python/tests/test_atomics.py
+++ b/projects/rocshmem/python/tests/test_atomics.py
@@ -1,0 +1,172 @@
+"""Full host AMO matrix tests.
+
+Binding coverage: 69 host AMO symbols are generated in ``rocshmem4py.cc`` and
+re-exported via ``_import_amo_symbols()``. ``test_amo_matrix_completeness``
+checks the same 69 (type, op) pairs — there is no drift vs the C++ macro block.
+
+rocSHMEM also declares ``longlong`` fetch/cas/swap/etc. in the header, but these
+bindings intentionally expose only ``longlong`` set/add/inc (see comment in
+``rocshmem4py.cc``).
+
+Runtime limitation: these are host AMO bindings.  IPC no-MPI runtime support
+for host AMOs is not implemented yet, so behavioral AMO tests are opt-in via
+``ROCSHMEM4PY_RUN_HOST_AMO_IPC=1`` until the runtime grows that support.
+"""
+
+import os
+
+import pytest
+
+import rocshmem4py
+from rocshmem4py import (
+    rocshmem_my_pe,
+    rocshmem_n_pes,
+    rocshmem_barrier_all,
+)
+from conftest import requires_torch, requires_multi_pe
+
+try:
+    import torch
+except ImportError:
+    torch = None  # type: ignore[assignment]
+
+
+requires_host_amo_runtime = pytest.mark.skipif(
+    os.environ.get("ROCSHMEM4PY_RUN_HOST_AMO_IPC") != "1",
+    reason=(
+        "IPC no-MPI host AMOs are not supported in rocSHMEM runtime yet; "
+        "set ROCSHMEM4PY_RUN_HOST_AMO_IPC=1 only when validating a runtime fix"
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Coverage matrix — every (type, op) we expect the pybind layer to expose.
+# ---------------------------------------------------------------------------
+
+INTEGER_TYPES = ["int", "long", "uint32", "uint64", "size", "ptrdiff"]
+FLOAT_TYPES = ["float", "double"]
+ALL_NUMERIC_TYPES = INTEGER_TYPES + FLOAT_TYPES
+
+_EXPECTED_OPS = {
+    "fetch": ALL_NUMERIC_TYPES,
+    "set": ALL_NUMERIC_TYPES + ["longlong"],
+    "swap": ALL_NUMERIC_TYPES,
+    "compare_swap": INTEGER_TYPES,  # CAS not provided on float/double.
+    "fetch_add": INTEGER_TYPES,
+    "fetch_inc": INTEGER_TYPES,
+    "add": INTEGER_TYPES + ["longlong"],
+    "inc": INTEGER_TYPES + ["longlong"],
+    "fetch_and": ["uint32", "uint64"],
+    "fetch_or": ["uint32", "uint64"],
+    "fetch_xor": ["uint32", "uint64"],
+    "and": ["uint32", "uint64"],
+    "or": ["uint32", "uint64"],
+    "xor": ["uint32", "uint64"],
+}
+
+
+def test_amo_matrix_completeness():
+    """Every (type, op) in the expected matrix is bound in rocshmem4py."""
+    missing = []
+    for op, types in _EXPECTED_OPS.items():
+        for t in types:
+            name = f"rocshmem_{t}_atomic_{op}"
+            if not hasattr(rocshmem4py, name):
+                missing.append(name)
+    assert not missing, f"Missing AMO bindings: {missing}"
+
+    from rocshmem4py import _AMO_NAMES
+
+    expected_count = sum(len(types) for types in _EXPECTED_OPS.values())
+    assert expected_count == len(_AMO_NAMES), (
+        f"test matrix ({expected_count}) vs imported AMOs ({len(_AMO_NAMES)})"
+    )
+    # longlong: only set/add/inc per rocshMEM header subset in rocshmem4py.cc.
+    longlong_ops = {
+        n.removeprefix("rocshmem_longlong_atomic_")
+        for n in _AMO_NAMES
+        if "longlong" in n
+    }
+    assert longlong_ops == {"set", "add", "inc"}
+
+
+@requires_torch
+@requires_multi_pe
+@requires_host_amo_runtime
+def test_int_atomic_fetch_add_against_peer0():
+    """Every PE atomically adds 1 to peer 0's counter; peer 0 sees n_pes."""
+    n = rocshmem_n_pes()
+    me = rocshmem_my_pe()
+
+    # Symmetric int counter.
+    nbytes = 4
+    buf = rocshmem4py.SymmetricBuffer(nbytes)
+    try:
+        t = torch.as_tensor(buf, device="cuda").view(torch.int32).view([1])
+        t.zero_()
+        rocshmem_barrier_all()
+        torch.cuda.synchronize()
+
+        rocshmem4py.rocshmem_int_atomic_fetch_add(buf.ptr, 1, 0)
+        rocshmem_barrier_all()
+        torch.cuda.synchronize()
+
+        if me == 0:
+            assert int(t.item()) == n
+    finally:
+        buf.free()
+
+
+@requires_torch
+@requires_multi_pe
+@requires_host_amo_runtime
+def test_int_atomic_compare_swap_lock_pattern():
+    """Use CAS to acquire a lock from peer 0; only one PE wins."""
+    me = rocshmem_my_pe()
+    nbytes = 4
+    buf = rocshmem4py.SymmetricBuffer(nbytes)
+    try:
+        t = torch.as_tensor(buf, device="cuda").view(torch.int32).view([1])
+        t.zero_()
+        rocshmem_barrier_all()
+        torch.cuda.synchronize()
+
+        # Each PE attempts CAS(0 -> me+1) on peer 0's counter.
+        rocshmem4py.rocshmem_int_atomic_compare_swap(buf.ptr, 0, me + 1, 0)
+        rocshmem_barrier_all()
+        torch.cuda.synchronize()
+
+        if me == 0:
+            assert 1 <= int(t.item()) <= rocshmem_n_pes()
+    finally:
+        buf.free()
+
+
+@requires_torch
+@requires_multi_pe
+@requires_host_amo_runtime
+def test_uint64_atomic_or_against_peer0():
+    """Every PE ORs (1 << me) into peer 0's mask; peer 0 sees full bitmask."""
+    n = rocshmem_n_pes()
+    me = rocshmem_my_pe()
+
+    nbytes = 8
+    buf = rocshmem4py.SymmetricBuffer(nbytes)
+    try:
+        # uint64 = int64 view here; we set/check via ints.
+        t = torch.as_tensor(buf, device="cuda").view(torch.int64).view([1])
+        t.zero_()
+        rocshmem_barrier_all()
+        torch.cuda.synchronize()
+
+        rocshmem4py.rocshmem_uint64_atomic_or(buf.ptr, 1 << me, 0)
+        rocshmem_barrier_all()
+        torch.cuda.synchronize()
+
+        if me == 0:
+            # Use unsigned interpretation: shift mask is fine as int up to 63 PEs.
+            expected = (1 << n) - 1 if n < 64 else -1
+            assert int(t.item()) == expected
+    finally:
+        buf.free()

--- a/projects/rocshmem/python/tests/test_basic.py
+++ b/projects/rocshmem/python/tests/test_basic.py
@@ -19,6 +19,7 @@ def test_import_and_constants():
     assert rocshmem4py.ROCSHMEM_SUCCESS == 0
     assert rocshmem4py.ROCSHMEM_TEAM_WORLD == 0
     assert rocshmem4py.ROCSHMEM_TEAM_INVALID == -1
+    assert rocshmem4py.ROCSHMEM_TEAM_WORLD != rocshmem4py.ROCSHMEM_TEAM_INVALID
 
     assert rocshmem4py.ROCSHMEM_SIGNAL_SET == 0
     assert rocshmem4py.ROCSHMEM_SIGNAL_ADD == 1

--- a/projects/rocshmem/python/tests/test_ctx.py
+++ b/projects/rocshmem/python/tests/test_ctx.py
@@ -1,0 +1,28 @@
+
+import rocshmem4py
+from rocshmem4py import (
+    rocshmem_get_device_ctx,
+    rocshmem_query_thread,
+    rocshmem_sync_all,
+    rocshmem_sync_all_on_stream,
+)
+from conftest import requires_torch
+
+
+def test_sync_all_single_pe():
+    """sync_all is callable on a single PE (degenerate but legal)."""
+    rocshmem_sync_all()
+
+
+@requires_torch
+def test_sync_all_on_stream():
+    import torch
+
+    stream = torch.cuda.current_stream()
+    rocshmem_sync_all_on_stream(stream.cuda_stream)
+    torch.cuda.synchronize()
+
+
+def test_context_introspection_bindings():
+    assert isinstance(rocshmem_query_thread(), int)
+    assert isinstance(rocshmem_get_device_ctx(), int)

--- a/projects/rocshmem/python/tests/test_heap_bases.py
+++ b/projects/rocshmem/python/tests/test_heap_bases.py
@@ -1,0 +1,70 @@
+"""Heap-base introspection tests.
+
+Validates rocshmem4py.rocshmem_get_heap_bases (raw pointer list) and
+rocshmem4py.interop.torch.get_heap_bases (int64 CUDA tensor).
+"""
+
+import pytest
+
+import rocshmem4py
+from rocshmem4py import (
+    rocshmem_my_pe,
+    rocshmem_n_pes,
+    rocshmem_get_heap_bases,
+)
+from conftest import requires_torch
+
+
+def test_get_heap_bases_returns_n_pes_entries():
+    """Bare-Python helper returns one entry per PE."""
+    nbytes = 1024
+    buf = rocshmem4py.SymmetricBuffer(nbytes)
+    try:
+        bases = rocshmem_get_heap_bases(buf.ptr)
+        assert isinstance(bases, list)
+        assert len(bases) == rocshmem_n_pes()
+    finally:
+        buf.free()
+
+
+def test_local_pe_entry_is_self_pointer():
+    """bases[my_pe] == the local allocation's pointer."""
+    nbytes = 1024
+    buf = rocshmem4py.SymmetricBuffer(nbytes)
+    try:
+        bases = rocshmem_get_heap_bases(buf.ptr)
+        me = rocshmem_my_pe()
+        assert bases[me] == buf.ptr
+    finally:
+        buf.free()
+
+
+@requires_torch
+def test_get_heap_bases_torch_helper_shape_and_dtype():
+    """Torch helper returns (n_pes,) int64 CUDA tensor."""
+    import torch
+    from rocshmem4py.interop.torch import create_tensor, get_heap_bases
+
+    n = rocshmem_n_pes()
+    t = create_tensor((1024,), torch.uint8)
+    try:
+        bases = get_heap_bases(t)
+        assert bases.shape == (n,)
+        assert bases.dtype == torch.int64
+        assert bases.is_cuda
+        # Local entry matches the local data pointer.
+        assert int(bases[rocshmem_my_pe()].item()) == t.data_ptr()
+    finally:
+        from rocshmem4py.interop.torch import free_tensor
+        free_tensor(t)
+
+
+@requires_torch
+def test_get_heap_bases_rejects_non_symmetric_tensor():
+    """Helper raises on a non-symmetric tensor."""
+    import torch
+    from rocshmem4py.interop.torch import get_heap_bases
+
+    t = torch.zeros(10, device="cuda")
+    with pytest.raises(ValueError, match="not a symmetric tensor"):
+        get_heap_bases(t)

--- a/projects/rocshmem/python/tests/test_jit_race.py
+++ b/projects/rocshmem/python/tests/test_jit_race.py
@@ -1,0 +1,28 @@
+"""SymmetricBuffer allocation synchronization tests."""
+
+import rocshmem4py
+
+
+def test_symmetric_buffer_synchronizes_before_malloc(monkeypatch):
+    events = []
+
+    def fake_sync():
+        events.append("sync")
+
+    def fake_malloc(size):
+        events.append(("malloc", size))
+        return 0x1000
+
+    def fake_free(ptr):
+        events.append(("free", ptr))
+
+    monkeypatch.setattr(rocshmem4py, "hip_device_synchronize", fake_sync)
+    monkeypatch.setattr(rocshmem4py, "rocshmem_malloc", fake_malloc)
+    monkeypatch.setattr(rocshmem4py, "rocshmem_free", fake_free)
+
+    buf = rocshmem4py.SymmetricBuffer(4096)
+    buf._hip = None
+    try:
+        assert events[:2] == ["sync", ("malloc", 4096)]
+    finally:
+        buf.free()

--- a/projects/rocshmem/python/tests/test_team_collectives.py
+++ b/projects/rocshmem/python/tests/test_team_collectives.py
@@ -1,0 +1,74 @@
+"""Team-scoped collective binding tests."""
+
+from conftest import requires_multi_pe, requires_torch
+
+import rocshmem4py
+from rocshmem4py.interop import torch as rshmem_torch
+
+pytestmark = [requires_torch, requires_multi_pe]
+
+
+def test_world_alltoall_torch_wrapper():
+    import torch
+
+    me = rocshmem4py.rocshmem_my_pe()
+    n = rocshmem4py.rocshmem_n_pes()
+    chunk = 4
+
+    src = rshmem_torch.create_tensor((n, chunk), torch.int32)
+    dst = rshmem_torch.create_tensor((n, chunk), torch.int32)
+    try:
+        for peer in range(n):
+            src[peer].fill_(me * 100 + peer)
+        dst.fill_(-1)
+        torch.cuda.synchronize()
+        rshmem_torch.barrier_all()
+
+        rshmem_torch.alltoall(rocshmem4py.ROCSHMEM_TEAM_WORLD, dst, src)
+        rshmem_torch.barrier_all()
+        torch.cuda.synchronize()
+
+        expected = torch.empty_like(dst)
+        for peer in range(n):
+            expected[peer].fill_(peer * 100 + me)
+        torch.testing.assert_close(dst, expected)
+    finally:
+        rshmem_torch.free_tensor(src)
+        rshmem_torch.free_tensor(dst)
+
+
+def test_world_broadcast_torch_wrapper():
+    import torch
+
+    me = rocshmem4py.rocshmem_my_pe()
+    root = 0
+
+    src = rshmem_torch.create_tensor((16,), torch.int32)
+    dst = rshmem_torch.create_tensor((16,), torch.int32)
+    try:
+        src.fill_(me)
+        dst.fill_(-1)
+        if me == root:
+            dst.copy_(src)
+        torch.cuda.synchronize()
+        rshmem_torch.barrier_all()
+
+        rshmem_torch.broadcast(rocshmem4py.ROCSHMEM_TEAM_WORLD, dst, src, root)
+        rshmem_torch.barrier_all()
+        torch.cuda.synchronize()
+
+        torch.testing.assert_close(dst, torch.full_like(dst, root))
+    finally:
+        rshmem_torch.free_tensor(src)
+        rshmem_torch.free_tensor(dst)
+
+
+def test_team_collective_symbols_are_exported():
+    for name in (
+        "rocshmem_alltoallmem_on_stream",
+        "rocshmem_broadcastmem_on_stream",
+        "rocshmem_global_exit",
+        "rocshmem_dump_stats",
+        "rocshmem_reset_stats",
+    ):
+        assert hasattr(rocshmem4py, name)

--- a/projects/rocshmem/python/tests/test_teams.py
+++ b/projects/rocshmem/python/tests/test_teams.py
@@ -1,0 +1,286 @@
+"""
+Multi-PE tests; require at least 2 PEs.
+"""
+
+import pytest
+
+import rocshmem4py
+from rocshmem4py import (
+    ROCSHMEM_SUCCESS,
+    ROCSHMEM_TEAM_INVALID,
+    ROCSHMEM_TEAM_WORLD,
+    TeamConfig,
+    rocshmem_my_pe,
+    rocshmem_n_pes,
+    rocshmem_team_my_pe,
+    rocshmem_team_n_pes,
+    rocshmem_team_split_strided,
+    rocshmem_team_destroy,
+    rocshmem_team_translate_pe,
+    rocshmem_barrier_all,
+)
+from conftest import requires_multi_pe
+
+
+def test_team_config_struct():
+    """TeamConfig is constructible and num_contexts is read/write."""
+    cfg = TeamConfig()
+    cfg.num_contexts = 4
+    assert cfg.num_contexts == 4
+
+
+@requires_multi_pe
+def test_split_strided_world():
+    """split_strided(WORLD, 0, 1, n_pes) -> handle equivalent to WORLD."""
+    n = rocshmem_n_pes()
+    cfg = TeamConfig()
+    cfg.num_contexts = 1
+    status, team = rocshmem_team_split_strided(
+        ROCSHMEM_TEAM_WORLD, 0, 1, n, cfg, 0,
+    )
+    assert status == ROCSHMEM_SUCCESS
+    assert team != ROCSHMEM_TEAM_INVALID
+
+    assert rocshmem_team_n_pes(team) == n
+    assert rocshmem_team_my_pe(team) == rocshmem_my_pe()
+
+    rocshmem_barrier_all()
+    rocshmem_team_destroy(team)
+    rocshmem_barrier_all()
+
+
+@requires_multi_pe
+def test_split_strided_even_subteam():
+    """split_strided over even PEs only; odd PEs see team_my_pe == -1."""
+    n = rocshmem_n_pes()
+    if n < 4:
+        pytest.skip("requires >= 4 PEs so the even subteam has multiple members")
+
+    cfg = TeamConfig()
+    cfg.num_contexts = 1
+    even_size = (n + 1) // 2  # ceil(n/2)
+    status, team = rocshmem_team_split_strided(
+        ROCSHMEM_TEAM_WORLD, 0, 2, even_size, cfg, 0,
+    )
+    assert status == ROCSHMEM_SUCCESS
+
+    me = rocshmem_my_pe()
+    if me % 2 == 0:
+        assert team != ROCSHMEM_TEAM_INVALID
+        assert rocshmem_team_my_pe(team) == me // 2
+        assert rocshmem_team_n_pes(team) == even_size
+    else:
+        # Odd PEs are non-members of the even-subteam; the binding's
+        # tracked split helper translates the C nullptr to the Python
+        # ROCSHMEM_TEAM_INVALID sentinel.  Asserting `==` (not just
+        # `!= some_real_team`) is the regression guard that the
+        # WORLD/INVALID sentinel collapse stays fixed.
+        assert team == ROCSHMEM_TEAM_INVALID
+
+    rocshmem_barrier_all()
+    rocshmem_team_destroy(team)  # no-op for INVALID per spec
+    rocshmem_barrier_all()
+
+
+@requires_multi_pe
+def test_split_strided_subset_parent_then_split():
+    """Port of upstream teamctxsubsetparentinfra (PR ROCm/rocm-systems#5960).
+
+    Two-level split exercising the non-WORLD-parent path that PR #5960
+    enabled in the IPC backend's create_new_team via groupAllGather over
+    the new team's world ranks (instead of an all-PEs allGather).
+
+    Step 1: parity-based subset parent.
+      - even PEs build team {0,2,4,...}
+      - odd  PEs build team {1,3,5,...}
+      With odd n_pes the even subset is one PE larger than the odd subset.
+
+    Step 2: split that subset parent (which is NOT WORLD) into two halves.
+      Lower half PEs of the subset parent get team {0..mid-1}; upper half
+      PEs get team {mid..subset_n-1}.
+
+    Designed for 4 and 5 PEs to mirror the upstream functional-tests
+    driver lines `ExecTest "teamctxsubsetparentinfra" 4 1 1` and `5 1 1`.
+    """
+    n = rocshmem_n_pes()
+    if n < 4:
+        pytest.skip("requires >= 4 PEs to form non-trivial subset parents")
+
+    me = rocshmem_my_pe()
+    cfg = TeamConfig()
+    cfg.num_contexts = 1
+
+    # ---------- Step 1: subset parent via parity split ----------
+    parity = me % 2
+    start_pe = parity  # 0 for even, 1 for odd
+    subset_size = n // 2
+    if (n % 2) != 0 and parity == 0:
+        subset_size += 1  # even subset absorbs the leftover when n is odd
+
+    status, subset_parent = rocshmem_team_split_strided(
+        ROCSHMEM_TEAM_WORLD, start_pe, 2, subset_size, cfg, 0,
+    )
+    assert status == ROCSHMEM_SUCCESS
+    assert subset_parent != ROCSHMEM_TEAM_INVALID, (
+        f"PE {me}: subset parent (parity={parity}, size={subset_size}) "
+        "must be valid; every PE is a member of exactly one parity subset"
+    )
+    assert rocshmem_team_n_pes(subset_parent) == subset_size
+    assert rocshmem_team_my_pe(subset_parent) == me // 2
+
+    # ---------- Step 2: split the subset parent (non-WORLD) into halves ----------
+    subset_n = rocshmem_team_n_pes(subset_parent)
+    subset_me = rocshmem_team_my_pe(subset_parent)
+    mid = subset_n // 2
+
+    if subset_me < mid:
+        child_start = 0
+        child_size = mid
+        expected_child_pe = subset_me
+    else:
+        child_start = mid
+        child_size = subset_n - mid
+        expected_child_pe = subset_me - mid
+
+    status, child = rocshmem_team_split_strided(
+        subset_parent, child_start, 1, child_size, cfg, 0,
+    )
+    assert status == ROCSHMEM_SUCCESS
+    assert child != ROCSHMEM_TEAM_INVALID, (
+        f"PE {me}: child team (subset_parent parity={parity}, "
+        f"start={child_start}, size={child_size}) must be valid; every PE in "
+        "the subset parent participates in exactly one half"
+    )
+    assert rocshmem_team_n_pes(child) == child_size
+    assert rocshmem_team_my_pe(child) == expected_child_pe
+
+    # ---------- Cleanup: destroy in reverse creation order ----------
+    rocshmem_barrier_all()
+    rocshmem_team_destroy(child)
+    rocshmem_team_destroy(subset_parent)
+    rocshmem_barrier_all()
+
+
+@requires_multi_pe
+def test_split_strided_recursive_split_world():
+    """Recursive split of WORLD: WORLD -> halves -> split one half.
+
+    Complementary to the parity-based test above: this exercises the
+    non-WORLD-parent path with a contiguous (stride=1) child, and also
+    confirms ROCSHMEM_TEAM_INVALID for non-members of the second-level
+    split is observed correctly across PEs.
+    """
+    n = rocshmem_n_pes()
+    if n < 4:
+        pytest.skip("requires >= 4 PEs so each half can be split again")
+
+    me = rocshmem_my_pe()
+    cfg = TeamConfig()
+    cfg.num_contexts = 1
+
+    # First-level split: lower half {0..mid-1}, upper half {mid..n-1}.
+    mid = n // 2
+    if me < mid:
+        half_start, half_size = 0, mid
+        my_half_pe = me
+    else:
+        half_start, half_size = mid, n - mid
+        my_half_pe = me - mid
+
+    status, half = rocshmem_team_split_strided(
+        ROCSHMEM_TEAM_WORLD, half_start, 1, half_size, cfg, 0,
+    )
+    assert status == ROCSHMEM_SUCCESS
+    assert half != ROCSHMEM_TEAM_INVALID
+    assert rocshmem_team_n_pes(half) == half_size
+    assert rocshmem_team_my_pe(half) == my_half_pe
+
+    # Second-level split: split each half into a single-PE team containing
+    # only its first PE.  Non-members (everyone except the half's PE 0)
+    # must observe ROCSHMEM_TEAM_INVALID per OpenSHMEM spec.
+    status, leader = rocshmem_team_split_strided(half, 0, 1, 1, cfg, 0)
+    assert status == ROCSHMEM_SUCCESS
+
+    if my_half_pe == 0:
+        assert leader != ROCSHMEM_TEAM_INVALID
+        assert rocshmem_team_n_pes(leader) == 1
+        assert rocshmem_team_my_pe(leader) == 0
+    else:
+        # Every non-leader gets the Python ROCSHMEM_TEAM_INVALID sentinel.
+        # Asserting `==` makes this a positive check for the sentinel
+        # split (vs the previous WORLD==INVALID==0 collapse where this
+        # would tautologically pass against any non-WORLD return).
+        assert leader == ROCSHMEM_TEAM_INVALID
+
+    rocshmem_barrier_all()
+    rocshmem_team_destroy(leader)
+    rocshmem_team_destroy(half)
+    rocshmem_barrier_all()
+
+
+def test_team_invalid_sentinel_distinct_from_world():
+    """Regression guard: the two special team handles are distinct.
+
+    Previously both ``ROCSHMEM_TEAM_WORLD`` and ``ROCSHMEM_TEAM_INVALID``
+    were Python ``0``, which made non-member returns from
+    ``rocshmem_team_split_strided`` indistinguishable from WORLD.  This
+    test prevents that collapse from being re-introduced.
+    """
+    assert ROCSHMEM_TEAM_WORLD == 0
+    assert ROCSHMEM_TEAM_INVALID == -1
+    assert ROCSHMEM_TEAM_WORLD != ROCSHMEM_TEAM_INVALID
+    # Both sentinels must be no-op safe to pass to destroy.
+    rocshmem_team_destroy(ROCSHMEM_TEAM_WORLD)
+    rocshmem_team_destroy(ROCSHMEM_TEAM_INVALID)
+
+
+@requires_multi_pe
+def test_team_translate_pe_round_trip():
+    """team_translate_pe(child, child_pe, WORLD) returns the world rank."""
+    n = rocshmem_n_pes()
+    cfg = TeamConfig()
+    cfg.num_contexts = 1
+    status, team = rocshmem_team_split_strided(
+        ROCSHMEM_TEAM_WORLD, 0, 1, n, cfg, 0,
+    )
+    assert status == ROCSHMEM_SUCCESS
+
+    # In a contiguous-strided child the translation is identity.
+    for child_pe in range(n):
+        world_pe = rocshmem_team_translate_pe(team, child_pe, ROCSHMEM_TEAM_WORLD)
+        assert world_pe == child_pe
+
+    rocshmem_barrier_all()
+    rocshmem_team_destroy(team)
+    rocshmem_barrier_all()
+
+
+@requires_multi_pe
+def test_team_destroy_idempotent_on_special_handles():
+    """Destroying ROCSHMEM_TEAM_{INVALID,WORLD} is a documented no-op."""
+    rocshmem_team_destroy(ROCSHMEM_TEAM_INVALID)
+    rocshmem_team_destroy(ROCSHMEM_TEAM_WORLD)
+    # Just survives without segfault.
+
+
+@requires_multi_pe
+def test_live_teams_registry_drain():
+    """Tracked split adds to _live_teams; tracked destroy removes it."""
+    from rocshmem4py import _live_teams
+
+    n = rocshmem_n_pes()
+    cfg = TeamConfig()
+    cfg.num_contexts = 1
+    initial = set(_live_teams)
+
+    status, t1 = rocshmem_team_split_strided(
+        ROCSHMEM_TEAM_WORLD, 0, 1, n, cfg, 0,
+    )
+    assert status == ROCSHMEM_SUCCESS
+    assert t1 in _live_teams
+    assert t1 not in initial
+
+    rocshmem_barrier_all()
+    rocshmem_team_destroy(t1)
+    rocshmem_barrier_all()
+    assert t1 not in _live_teams

--- a/projects/rocshmem/scripts/python_tests/driver.sh
+++ b/projects/rocshmem/scripts/python_tests/driver.sh
@@ -35,7 +35,7 @@
 #                                  (runs on torch-less hosts)
 #                    - basic:      single-PE tensor API tests  (require torch)
 #                    - collective: multi-PE tensor API tests   (require torch)
-#                    - all:        raw + basic + collective
+#                    - all:        pytest discovery over tests/ (auto-picks new files)
 #   log_dir        : Directory for test output logs
 #   hostfile       : (optional) MPI hostfile for multi-node
 #
@@ -106,7 +106,7 @@ ExecPythonTest() {
         ${TIMEOUT:+--timeout "$TIMEOUT"}
         ${HOSTFILE:+--hostfile "$HOSTFILE"}
         --map-by numa
-        # DEBUG (drop before merge): -s disables pytest capture so prints/tracebacks
+        # DEBUG: -s disables pytest capture so prints/tracebacks
         # reach the console before prterun kills peers; --tb=long for full frames.
         pytest $TEST_FILES -v -s --tb=long -rA --color=no
       )
@@ -138,7 +138,9 @@ TestRaw() {
 }
 
 TestAll() {
-  ExecPythonTest "all" 2 "$PYTHON_SRC_DIR/tests/test_smoke.py $PYTHON_SRC_DIR/tests/test_basic.py $PYTHON_SRC_DIR/tests/test_collective.py"
+  # Use pytest discovery instead of a hardcoded file list so newly added
+  # test_*.py files are automatically included in CI.
+  ExecPythonTest "all" 2 "$PYTHON_SRC_DIR/tests"
 }
 
 # --- Main ---

--- a/projects/rocshmem/tests/CMakeLists.txt
+++ b/projects/rocshmem/tests/CMakeLists.txt
@@ -37,11 +37,14 @@ IF (BUILD_PYTHON_TESTS)
     rocm_install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/rocshmem_python_driver.sh
                  COMPONENT tests DESTINATION ${CMAKE_INSTALL_DATADIR}/rocshmem)
 
+    # Install all Python test files so adding new tests does not require
+    # touching this CMake list.
+    file(GLOB ROCSHMEM_PYTHON_TEST_FILES CONFIGURE_DEPENDS
+        ${CMAKE_SOURCE_DIR}/python/tests/*.py)
+    list(SORT ROCSHMEM_PYTHON_TEST_FILES)
+
     rocm_install(FILES
-        ${CMAKE_SOURCE_DIR}/python/tests/test_smoke.py
-        ${CMAKE_SOURCE_DIR}/python/tests/test_basic.py
-        ${CMAKE_SOURCE_DIR}/python/tests/test_collective.py
-        ${CMAKE_SOURCE_DIR}/python/tests/conftest.py
+        ${ROCSHMEM_PYTHON_TEST_FILES}
         COMPONENT tests
         DESTINATION ${CMAKE_INSTALL_DATADIR}/rocshmem/python_tests)
 


### PR DESCRIPTION
## Motivation

Extends rocshmem4py with python bindings and test coverage for the OpenSHMEM teams and host AMO API surfaces (with some limitations, see AIROCSHMEM-419 for details) . 

## Technical Details
Teams API bindings: rocshmem_team_split_strided, rocshmem_team_destroy, rocshmem_team_translate_pe, rocshmem_team_world

Host AMO bindings: full (type, op) matrix generated by the macro block in rocshmem4py.cc, only limited subset is tested due to missing non-MPI IPC support for key atomics APIs.

Host AMO runtime not exercised by default. rocSHMEM's host AMO path via IPC no-MPI bootstrapping is not yet supported.
TODO: 
1. ROCSHMEM_INIT_WITH_MPI_COMM bootstrap + behavioral host-AMO tests for MPI and non-MPI runtime
2. User-facing rocshmem_ctx_create / rocshmem_ctx_destroy bindings.

## JIRA ID
AIROCSHMEM-420

## Test Plan

Python tests are added for coverage

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
