### PR TITLE
[rocjitsu] Remove duplicate PT_LOAD definition

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_elf.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_elf.h
@@ -111,8 +111,6 @@ inline constexpr uint64_t SHF_WRITE = 1u << 0;
 inline constexpr uint64_t SHF_ALLOC = 1u << 1;
 inline constexpr uint64_t SHF_EXECINSTR = 1u << 2;
 
-inline constexpr uint32_t PT_LOAD = 1;
-
 /// @brief AMDGPU vendor specific notes for Code Object V3.
 inline constexpr uint32_t NT_AMDGPU_METADATA = 32;
 


### PR DESCRIPTION
## Summary
- Remove duplicate `PT_LOAD` definition in `amdgpu_elf.h` (defined at both line 114 and line 120)
- Introduced in #6228, breaks TheRock CI build with `-Werror`

## Test plan
- [ ] TheRock CI passes (currently failing on develop due to this)


<img width="383" height="225" alt="{BD8CA019-73FF-4FEB-83F2-01CD8648136E}" src="https://github.com/user-attachments/assets/89f4f899-f885-45e8-a12c-e471ebac465e" />
