### PR TITLE
[rocjitsu] use CMAKE_CURRENT_SOURCE/BINARY_DIR to fix other cmake projects that import rocjitsu

### DIFF
--- a/emulation/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/CMakeLists.txt
@@ -170,12 +170,12 @@ set(FLATBUFFERS_BUILD_FLATLIB ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest flatbuffers)
 
 # Compile FlatBuffers schemas into C++ headers.
-set(GENERATED_DIR ${CMAKE_BINARY_DIR}/generated)
+set(GENERATED_DIR ${CMAKE_CURRENT_BINARY_DIR}/generated)
 file(MAKE_DIRECTORY ${GENERATED_DIR})
 
 set(SCHEMA_FILES
-    ${CMAKE_SOURCE_DIR}/schemas/simulation_config.fbs
-    ${CMAKE_SOURCE_DIR}/schemas/checkpoint.fbs
+    ${CMAKE_CURRENT_SOURCE_DIR}/schemas/simulation_config.fbs
+    ${CMAKE_CURRENT_SOURCE_DIR}/schemas/checkpoint.fbs
 )
 
 set(GENERATED_HEADERS)
@@ -185,7 +185,7 @@ foreach(schema ${SCHEMA_FILES})
     add_custom_command(
         OUTPUT ${output_header}
         COMMAND
-            $<TARGET_FILE:flatc> --cpp -I ${CMAKE_SOURCE_DIR}/schemas -o
+            $<TARGET_FILE:flatc> --cpp -I ${CMAKE_CURRENT_SOURCE_DIR}/schemas -o
             ${GENERATED_DIR} ${schema}
         DEPENDS flatc ${schema}
         COMMENT "Compiling FlatBuffers schema: ${schema_name}.fbs"


### PR DESCRIPTION
## Motivation

I'm using FetchContent_Declare to add rocjitsu dependency to my cmake project which results in this error:

```-- Build files have been written to: /__w/pyisa/pyisa/build/pyisa
. .venv/bin/activate && cmake --build build/pyisa --parallel 2
ninja: error: '/__w/pyisa/pyisa/schemas/simulation_config.fbs', needed by 'generated/simulation_config_generated.h', missing and no known rule to make it
make: *** [Makefile:19: build] Error 1
```

## Technical Details

How I integrate my fix:
```
if(WITH_ROCJITSU)
    message(STATUS "rocjitsu integration: ENABLED")
    set(BUILD_TESTING OFF CACHE BOOL "" FORCE)

    include(FetchContent)
    FetchContent_Declare(
        rocjitsu
        GIT_REPOSITORY https://github.com/fwahlster-amd/rocm-systems.git
        # GIT_TAG        a6059e6352fb0267414d3cfe978822441a9c14bc
        GIT_TAG        cmake-fixes
        SOURCE_SUBDIR  emulation/rocjitsu
        GIT_SHALLOW    TRUE
        GIT_PROGRESS   TRUE
    )
    FetchContent_MakeAvailable(rocjitsu)
endif()
```
## Test Plan

Build rocjitsu standalone and as `target_link_libraries(${PROJECT_NAME} PRIVATE rocjitsu_shared)` from my project.

## Test Result

Both build correctly.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
