### PR TITLE
kfdtest fails to build against latest staging compiler

### DIFF
--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/Assemble.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/Assemble.cpp
@@ -349,7 +349,11 @@ int Assembler::RunAssemble(const char* const AssemblySource) {
 
     // Set up the MCContext for creating symbols and MCExpr's
 #if LLVM_VERSION_MAJOR > 12
+#if LLVM_MAIN_REVISION >= 577912 // commit # when createMCAsmParser API changed
+    MCContext Ctx(TheTriple, *MAI, *MRI, *STI, &SrcMgr, &MCOptions);
+#else
     MCContext Ctx(TheTriple, MAI.get(), MRI.get(), STI.get(), &SrcMgr, &MCOptions);
+#endif
 #else
     MCObjectFileInfo MOFI;
     MCContext Ctx(MAI.get(), MRI.get(), &MOFI, &SrcMgr, &MCOptions);
@@ -391,8 +395,13 @@ int Assembler::RunAssemble(const char* const AssemblySource) {
             createMCAsmParser(SrcMgr, Ctx, *Streamer, *MAI));
 
     // Set parser to target parser and run
+#if LLVM_MAIN_REVISION >= 577912 // commit # when createMCAsmParser API changed
+    std::unique_ptr<MCTargetAsmParser> TAP(
+            TheTarget->createMCAsmParser(*STI, *Parser, *MCII));
+#else
     std::unique_ptr<MCTargetAsmParser> TAP(
             TheTarget->createMCAsmParser(*STI, *Parser, *MCII, MCOptions));
+#endif
     if (!TAP) {
         outs() << "ASM Error: no assembly parsing support for target " << MCPU << "\n";
         return -1;


### PR DESCRIPTION
This version of compiler is 'LLVM 23.0.0git' and it failes because the code uses pre–LLVM-23 llvm::MCContext and
llvm::Target::createMCAsmParser signatures. The specific error is for "Assemble.cpp MC API mismatch".

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
