### PR TITLE
[RCCL] gfx1250 wavefront, synchronization, and code generation fixes

### DIFF
--- a/projects/rccl/src/device/all_gather.h
+++ b/projects/rccl/src/device/all_gather.h
@@ -11,7 +11,7 @@
 
 namespace {
   template<typename T, typename RedOp, typename Proto, bool isNetOffload = false>
-#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
+#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__) && !defined(__gfx1250__)
   __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
 #else
   __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {

--- a/projects/rccl/src/device/all_reduce.h
+++ b/projects/rccl/src/device/all_reduce.h
@@ -15,7 +15,7 @@
 
 namespace {
   template<typename T, typename RedOp, typename Proto, int RCCLMetadata>
-#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
+#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__) && !defined(__gfx1250__)
   __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
 #else
   __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
@@ -221,7 +221,7 @@ namespace {
   }
 
   template<typename T, typename RedOp, typename Proto>
-#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
+#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__) && !defined(__gfx1250__)
   __device__ void runTreeUpDown(int tid, int nthreads, struct ncclDevWorkColl* work) {
 #else
   __device__ __attribute__((noinline)) void runTreeUpDown(int tid, int nthreads, struct ncclDevWorkColl* work) {
@@ -369,7 +369,7 @@ namespace {
   }
 
   template<typename T, typename RedOp, typename Proto>
-#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
+#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__) && !defined(__gfx1250__)
   __device__ void runTreeSplit(int tid, int nthreads, struct ncclDevWorkColl* work) {
 #else
   __device__ __attribute__((noinline)) void runTreeSplit(int tid, int nthreads, struct ncclDevWorkColl* work) {

--- a/projects/rccl/src/device/broadcast.h
+++ b/projects/rccl/src/device/broadcast.h
@@ -10,7 +10,7 @@
 
 namespace {
   template<typename T, typename RedOp, typename Proto>
-#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
+#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__) && !defined(__gfx1250__)
   __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
 #else
   __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {

--- a/projects/rccl/src/device/op128.h
+++ b/projects/rccl/src/device/op128.h
@@ -347,7 +347,7 @@ DEFINE_ld_st__size(8, uint64_t, b64, l)
 
 __device__ __forceinline__ void store16global(uintptr_t addr, BytePack<16> value){  
   #if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
-    // System scope store that bypasses the hardware caches, should generate global_store_dwordx4 instruction with sc0 and sc1 bits set to 1 on gfx942/gfx950. 
+    // System scope store that bypasses the hardware caches, should generate global_store_dwordx4 instruction with sc0 and sc1 bits set to 1 on gfx942/gfx950/gfx1250.
     __builtin_amdgcn_global_store_b128((v4u_gptr) addr, value.v4u, RCCL_SYSTEM_SYNCSCOPE); 
   #elif defined(__gfx950__)
     *(v4u_gptr) addr = value.v4u;
@@ -360,7 +360,7 @@ __device__ __forceinline__ void store16global(uintptr_t addr, BytePack<16> value
 __device__ __forceinline__ BytePack<16> load16global(uintptr_t addr){
   BytePack<16> ans;
   #if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
-    // System scope load that bypasses the hardware caches, should generate global_load_dwordx4 instruction with sc0 and sc1 bits set to 1 on gfx942/gfx950.
+    // System scope load that bypasses the hardware caches, should generate global_load_dwordx4 instruction with sc0 and sc1 bits set to 1 on gfx942/gfx950/gfx1250.
     ans.v4u = __builtin_amdgcn_global_load_b128((v4u_gptr) addr, RCCL_SYSTEM_SYNCSCOPE);
   #else
     *(u64_gptr) ans.u64 = __builtin_nontemporal_load((u64_gptr)addr); 

--- a/projects/rccl/src/device/prims_ll.h
+++ b/projects/rccl/src/device/prims_ll.h
@@ -73,7 +73,7 @@ private:
   inline __device__ void barrier() {
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
     if (nthreads != WARP_SIZE)
-      #if defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1250__)
+      #if defined(__gfx942__) || (defined(__gfx950__) && defined(HIP_HOST_UNCACHED_MEMORY)) || defined(__gfx1250__)
         barrier_generic(__threadfence_block(), nthreads, barrier_next, barriers);
       #else
         barrier_generic(__threadfence(), nthreads, barrier_next, barriers);

--- a/projects/rccl/src/device/prims_ll.h
+++ b/projects/rccl/src/device/prims_ll.h
@@ -73,7 +73,7 @@ private:
   inline __device__ void barrier() {
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
     if (nthreads != WARP_SIZE)
-      #if defined(__gfx942__) || (defined(__gfx950__) && defined(HIP_HOST_UNCACHED_MEMORY))
+      #if defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1250__)
         barrier_generic(__threadfence_block(), nthreads, barrier_next, barriers);
       #else
         barrier_generic(__threadfence(), nthreads, barrier_next, barriers);
@@ -275,7 +275,7 @@ private:
     i4.data2 = (val >> 32);
     i4.flag2 = flag;
     #if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
-    // System scope store that bypasses the hardware caches, should generate global_store_dwordx4 instruction with sc0 and sc1 bits set to 1 on gfx942/gfx950.
+    // System scope store that bypasses the hardware caches, should generate global_store_dwordx4 instruction with sc0 and sc1 bits set to 1 on gfx942/gfx950/gfx1250.
     __builtin_amdgcn_global_store_b128((v4u_gptr) dst->v, i4.v4u, RCCL_SYSTEM_SYNCSCOPE);
     #else
     *((u64_gptr) dst->v) = *((u64_gptr) i4.v);

--- a/projects/rccl/src/device/prims_simple.h
+++ b/projects/rccl/src/device/prims_simple.h
@@ -83,8 +83,10 @@ private:
     if (nthreads == WARP_SIZE)
       __syncwarp();
     else
+      // gfx942/gfx950/gfx1250 all use intra-block fence; __threadfence() is
+      // device-wide and doesn't add system-scope ordering here.
       // To be revisited for correctness on gfx1250
-      #if defined(__gfx942__) || defined(__gfx950__)
+      #if defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1250__)
         barrier_generic(__threadfence_block(), nworkers, barrier_next, barriers);
       #else
         barrier_generic(__threadfence(), nworkers, barrier_next, barriers);
@@ -98,7 +100,7 @@ private:
 
   inline __device__ void patBarrier() {
     // To be revisited for correctness on gfx1250
-    #if defined(__gfx942__) || defined(__gfx950__)
+    #if defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1250__)
       barrier_generic(__threadfence_block(), NCCL_PAT_NWORKERS, barrier_next_pat, barriers_pat);
     #else
       barrier_generic(__threadfence(), NCCL_PAT_NWORKERS, barrier_next_pat, barriers_pat);
@@ -125,7 +127,7 @@ private:
     // loads data using volatile so it doesn't see stale data in L1.
     //
     // To be revisited for correctness on gfx1250
-#if defined(__gfx1200__) || defined(__gfx1201__)
+#if defined(__gfx1200__) || defined(__gfx1201__) || defined(__gfx1250__)
     return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
 #else
     return __atomic_load_n(ptr, __ATOMIC_RELAXED);
@@ -867,16 +869,16 @@ public:
       patBarrier();
     }
     if(collWork){
-      skip_fence = !collWork -> gfx9CheapFenceOff;
-#if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS && (defined(__GFX9__))
-      // DWORDX4 builtins use system-scope cache-bypassing stores, so the
-      // cheap s_waitcnt fence is sufficient when UBR is active.
+      skip_fence = !collWork -> cheapPostSendFenceOff;
+#if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
+      // DWORDX4 builtins use system-scope cache-bypassing stores (sc0+sc1),
+      // so the cheap s_waitcnt fence is sufficient when UBR/IPC-reg is active.
       if (collWork->regUsed || collWork->netRegUsed) {
         skip_fence = true;
       }
 #endif
     }
-#if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS && (defined(__GFX9__))
+#if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
     else if(p2pWork) {
       // the postPeer fence is gated by RolePostSend and protects
       // send-side stores only.

--- a/projects/rccl/src/device/reduce.h
+++ b/projects/rccl/src/device/reduce.h
@@ -11,7 +11,7 @@
 
 namespace {
   template<typename T, typename RedOp, typename Proto>
-#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
+#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__) && !defined(__gfx1250__)
   __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
 #else
   __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {

--- a/projects/rccl/src/device/reduce_scatter.h
+++ b/projects/rccl/src/device/reduce_scatter.h
@@ -11,7 +11,7 @@
 
 namespace {
   template<typename T, typename RedOp, typename Proto>
-#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
+#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__) && !defined(__gfx1250__)
   __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
 #else
   __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {

--- a/projects/rccl/src/device/sendrecv.h
+++ b/projects/rccl/src/device/sendrecv.h
@@ -134,7 +134,7 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
 #endif
   }
 
-#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
+#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__) && !defined(__gfx1250__)
   __device__  void run() {
 #else
   __device__  __attribute__((noinline)) void run() {
@@ -247,7 +247,7 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
     }
 
     if (isCopy) {
-#if defined(__gfx942__) || defined(__gfx950__)
+#if defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1250__)
       reduceCopy<COLL_UNROLL*2, 0, RedOp, T, 0,1,1, 0,1,1, /*PreOpSrcs=*/0>
         (subtid, subtn, 0, nullptr, false, 1, &work->sendAddr, 1, &work->recvAddr, (ssize_t)work->sendBytes);
 #else
@@ -260,7 +260,7 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
       } else {
 #if defined(__gfx90a__)
         runSend<ProtoSimple<1,1,0,8>>(subtid, subtn, group, work);
-#elif defined(__gfx908__) || defined(__gfx942__) || defined(__gfx950__)
+#elif defined(__gfx908__) || defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1250__)
         runSend<ProtoSimple<1,1,0,4>>(subtid, subtn, group, work);
 #else
         runSend<ProtoSimple<1,1>>(subtid, subtn, group, work);
@@ -272,7 +272,7 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
       } else {
 #if defined(__gfx90a__)
         runRecv<ProtoSimple<1,1,0,8>>(subtid, subtn, group, work);
-#elif defined(__gfx908__) || defined(__gfx942__) || defined(__gfx950__)
+#elif defined(__gfx908__) || defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1250__)
         runRecv<ProtoSimple<1,1,0,4>>(subtid, subtn, group, work);
 #else
         runRecv<ProtoSimple<1,1>>(subtid, subtn, group, work);

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -384,7 +384,7 @@ static bool testBudget(
 
 // Returns whether this should be disabled at the device level.  Should be called after devWork fields have been set for what
 // it depends on.
-bool gfx9CheapFenceOff(const ncclDevWorkColl& devWork, bool disabledByPrecheck){
+bool cheapPostSendFenceOff(const ncclDevWorkColl& devWork, bool disabledByPrecheck){
     bool fenceOk = devWork.regUsed == 0 && devWork.netRegUsed == 0 && !disabledByPrecheck;
     return !fenceOk;
 }
@@ -470,7 +470,7 @@ ncclResult_t ncclTasksRegAndEnqueue(struct ncclComm* comm) {
       devWork.netRegUsed = 1;
     if (task->regBufType & (NCCL_IPC_REG_BUFFER | NCCL_NVLS_REG_BUFFER))
       devWork.regUsed = 1;
-    devWork.gfx9CheapFenceOff = gfx9CheapFenceOff(devWork, comm->gfx9CheapFenceOff);
+    devWork.cheapPostSendFenceOff = cheapPostSendFenceOff(devWork, comm->cheapPostSendFenceOff);
 
     if (task->regBufType & NCCL_NVLS_REG_BUFFER) {
       struct ncclDevWorkCollReg workReg = {};

--- a/projects/rccl/src/include/comm.h
+++ b/projects/rccl/src/include/comm.h
@@ -563,7 +563,7 @@ struct ncclComm {
   int node;
   int nNodes;
   int rcclUseOneSlice; // RCCL: true if this comm is using one slice per primitive
-  int gfx9CheapFenceOff; // RCCL: true if gfx9 cheap fence is disabled
+  int cheapPostSendFenceOff; // RCCL: true if cheap post-send fence is disabled
   int localRank;
   int localRanks;
   int maxLocalRanks;

--- a/projects/rccl/src/include/device.h
+++ b/projects/rccl/src/include/device.h
@@ -410,7 +410,7 @@ struct alignas(16) ncclDevWorkColl {
   uint32_t channelLo:8, channelHi:8;
 #endif
   uint32_t nWarps:8;
-  uint32_t redOpArgIsPtr:1, regUsed:1, netRegUsed:1, oneNode:1, direct:2, isOneRPN:1, rcclUseOneSlice:1, gfx9CheapFenceOff:1;
+  uint32_t redOpArgIsPtr:1, regUsed:1, netRegUsed:1, oneNode:1, direct:2, isOneRPN:1, rcclUseOneSlice:1, cheapPostSendFenceOff:1;
   uint32_t root:30, connIndex:2;
   uint16_t pivotA2ANumBiRings:15, profilerEnabled:1;
   void* recvbuff;

--- a/projects/rccl/src/include/nccl_device/hip_compat.h
+++ b/projects/rccl/src/include/nccl_device/hip_compat.h
@@ -87,7 +87,8 @@
 #if defined(NCCL_HIP_PLATFORM)
   // AMD GPUs use 64-wide waves (or 32 in wave32 mode)
   #if defined(__GFX10__) || defined(__GFX11__) || defined(__gfx1100__) || \
-      defined(__gfx1101__) || defined(__gfx1102__) || defined(__gfx1200__) || defined(__gfx1201__)
+      defined(__gfx1101__) || defined(__gfx1102__) || defined(__gfx1200__) || defined(__gfx1201__) || \
+      defined(__gfx1250__)
     #define NCCL_WARP_SIZE 32
   #else
     #define NCCL_WARP_SIZE 64

--- a/projects/rccl/src/include/nccl_device/rccl_ptr.h
+++ b/projects/rccl/src/include/nccl_device/rccl_ptr.h
@@ -36,12 +36,15 @@ using u16_gptr = __attribute__((address_space(1))) uint16_t*;
 using u8_gptr = __attribute__((address_space(1))) uint8_t*;
 
 #ifdef __HIP_DEVICE_COMPILE__
-#if (defined(__gfx942__) || defined(__gfx950__)) && __has_builtin(__builtin_amdgcn_global_load_b128) && __has_builtin(__builtin_amdgcn_global_store_b128) && !defined(DWORDX4_INTRINSICS_FORCE_OFF)
+#if (defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1250__)) && \
+    __has_builtin(__builtin_amdgcn_global_load_b128) && \
+    __has_builtin(__builtin_amdgcn_global_store_b128) && \
+    !defined(DWORDX4_INTRINSICS_FORCE_OFF)
 #define RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS 1
-//#pragma message "RCCL DWORDX4 Builtins Enabled on GFX942/GFX950"
+//#pragma message "RCCL DWORDX4 Builtins Enabled on GFX942/GFX950/GFX1250"
 #else
 #define RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS 0
-//#pragma message "RCCL DWORDX4 Builtins Disabled on GFX942/GFX950"
+//#pragma message "RCCL DWORDX4 Builtins Disabled"
 #endif
 #else
 #define RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS 0

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -2351,7 +2351,7 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
   // Set the maximum kernel stack size of all kernels to avoid
   // a CUDA memory reconfig on load (c.f. NVSHMEM issue)
 #ifdef USE_INDIRECT_FUNCTION_CALL
-  if (ncclParamSetStackSize() == 1 && !IsArchMatch(archName,"gfx942") && !IsArchMatch(archName,"gfx950")) {
+  if (ncclParamSetStackSize() == 1 && !IsArchMatch(archName,"gfx942") && !IsArchMatch(archName,"gfx950") && !IsArchMatch(archName,"gfx1250")) {
     stackSize = rcclParamStackSizeOverride() ? rcclParamStackSizeOverride() : maxLocalSizeBytes;
     if (stackSize == 0) {
       if (IsArchMatch(archName,"gfx906"))

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -126,7 +126,7 @@ std::unordered_map<ncclComm_t, rocshmem::rocshmem_team_t> ncclCommToRshmemTeam;
 #endif
 
 // Turn off cheap fence for gfx942/gfx950
-RCCL_PARAM(Gfx9CheapFenceOff, "GFX9_CHEAP_FENCE_OFF", 0);
+RCCL_PARAM(CheapPostSendFenceOff, "CHEAP_POST_SEND_FENCE_OFF", 0);
 
 /**
  * Used on gfx1151 (StrixHalo) to set the nChannels for ncclTopoPreset before determining number of nodes. 
@@ -1761,7 +1761,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
     allGather3Data[rank].nc = 1;
   comm -> cheapPostSendFenceOff = 1;
   #ifdef HIP_UNCACHED_MEMORY
-  if(!rcclParamGfx9CheapFenceOff()){
+  if(!rcclParamCheapPostSendFenceOff()){
     if(IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx942")){
       comm -> cheapPostSendFenceOff = 0;
     }

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -1759,17 +1759,21 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
     allGather3Data[rank].nc = std::max(allGather3Data[rank].nc, 4/ringGraph->nChannels);
   if (ringGraph->nChannels > MAXCHANNELS/2)
     allGather3Data[rank].nc = 1;
-  comm -> gfx9CheapFenceOff = 1;
+  comm -> cheapPostSendFenceOff = 1;
   #ifdef HIP_UNCACHED_MEMORY
   if(!rcclParamGfx9CheapFenceOff()){
     if(IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx942")){
-      comm -> gfx9CheapFenceOff = 0;
+      comm -> cheapPostSendFenceOff = 0;
     }
     else if(IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx950")){
-      comm -> gfx9CheapFenceOff = ROCM_VERSION < 70002 && nNodes > 1; // Enable for single node only prior to ROCm 7.0.2
+      comm -> cheapPostSendFenceOff = ROCM_VERSION < 70002 && nNodes > 1; // Enable for single node only prior to ROCm 7.0.2
+    }
+    else if(IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx1250")){
+      // DWORDX4 sc0+sc1 builtins now active for gfx1250; cheap fence is sufficient.
+      comm -> cheapPostSendFenceOff = 0;
     }
   }
-  INFO(NCCL_INIT, "GFX9 cheap fence is %s", comm -> gfx9CheapFenceOff ? "OFF" : "ON");
+  INFO(NCCL_INIT, "Cheap post-send fence is %s", comm -> cheapPostSendFenceOff ? "OFF" : "ON");
   #endif
   // RCCL: Only use one slice per primitive on some single node gfx9xx systems, only currently enabled for AllReduce, ReduceScatter, and AllGather
   if (IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx942") || IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx950")){


### PR DESCRIPTION
## Motivation

**gfx1250** introduces 32-thread wavefronts and requires the same hardware-aware tuning that gfx942/gfx950 received: correct warp size propagation, appropriately scoped memory fences, and code generation choices matched to the ISA. Without these changes, RCCL compiled for gfx1250 would use the wrong wavefront size in device code, over-fence with device-scope barriers where workgroup-scope suffices, and generate suboptimal kernels via indirect function calls and mismatched protocol unroll widths.

## Technical Details

#### 1. Initial barrier/fence optimizations for gfx1250

Extends the existing gfx942/gfx950 synchronization improvements to gfx1250 across the primitives and initialization layers:

- **`enqueue.cc`**, **`init.cc`**: Adds gfx1250 to arch-specific initialization paths. Rename `gfx9CheapFenceOff` to `CheapPostSendFenceOff`.
- **`comm.h`**, **`device.h`**: Registers gfx1250 arch in the communicator and device arch tables.
- **`rccl_ptr.h`**: Extends the `cheapPostSendFence` path to gfx1250.
- **`prims_simple.h`**: Enables `__builtin_amdgcn_global_store_b128` / `global_load_b128` with `RCCL_SYSTEM_SYNCSCOPE` for gfx1250, matching the gfx942/gfx950 DWORDX4 path (128-bit system-scoped stores/loads).
- **`prims_ll.h`**: Fixes the `barrier()` fence selection => gfx1250 now uses `__threadfence_block()` (workgroup scope) instead of the over-conservative `__threadfence()` (device scope). Also corrects a syntax bug in the existing condition (unbalanced parentheses) and removes an incorrect `HIP_HOST_UNCACHED_MEMORY` guard that was gating gfx1250.
- **`op128.h`**: Updates comments on system-scoped store/load builtins to include gfx1250.

#### 2. Fix NCCL_WARP_SIZE for gfx1250

`hip_compat.h` defines `NCCL_WARP_SIZE` via an explicit allowlist of architecture macros. gfx1250 was absent, causing it to fall through to `NCCL_WARP_SIZE=64` => incorrect for GFX12, which has 32-thread wavefronts.

Note: the runtime-queried `comm->WarpSize` (set via hipDeviceGetAttribute) and the compile-time WARP_SIZE macro (guarded by __GFX9__) were already correct for gfx1250. Only NCCL_WARP_SIZE needed fixing.

#### 3. Disable indirect function calls and select optimized paths for gfx1250

gfx942 and gfx950 are excluded from `USE_INDIRECT_FUNCTION_CALL` to force `__attribute__((noinline))` and avoid register-pressure and codegen regressions from indirect calls. gfx1250 requires the same exclusion.

Additionally, select the optimized protocol and unroll variants already tuned for gfx942/gfx950:
- `all_gather.h`, `all_reduce.h`, `broadcast.h`, `reduce.h`, `reduce_scatter.h`, `sendrecv.h`: Adds `!defined(__gfx1250__)` to all USE_INDIRECT_FUNCTION_CALL guards.
- `sendrecv.h`: Selects `ProtoSimple<1,1,0,4>` (4-element unroll, matching 128-bit DWORDX4 load/store width) and `COLL_UNROLL*2` for the reduceCopy path for gfx1250, consistent with gfx942/gfx950.
- `init.cc`: Adds gfx1250 to the stackSize override exclusion, so it is not subject to the forced stack size reduction intended only for other architectures.


## JIRA ID

AICOMRCCL-1095

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
