### PR TITLE
[rocprofiler-compute] derive --list-blocks parser offsets from header

### DIFF
--- a/projects/rocprofiler-compute/tests/test_utils.py
+++ b/projects/rocprofiler-compute/tests/test_utils.py
@@ -4413,15 +4413,19 @@ def test_list_blocks_all_archs(binary_handler_analyze_rocprof_compute, capsys, a
     assert "BLOCK NAME" in output
 
     # Fixed-width parse: empty aliases break whitespace splitting.
+    # Derive column offsets from the header so this parser tracks the producer.
     lines = output.splitlines()
     header_idx = next(i for i, line in enumerate(lines) if line.startswith("INDEX"))
+    header = lines[header_idx]
+    alias_col = header.index("BLOCK ALIAS")
+    name_col = header.index("BLOCK NAME")
     block_entries: dict[str, tuple[str, str]] = {}
     for line in lines[header_idx + 1 :]:
-        block_id = line[0:8].strip()
+        block_id = line[:alias_col].strip()
         if not block_id:
             continue
-        alias = line[9:25].strip()
-        name = line[26:].strip()
+        alias = line[alias_col:name_col].strip()
+        name = line[name_col:].strip()
         block_entries[block_id] = (alias, name)
 
     expected_panels = arch_panels_from_disk(arch)


### PR DESCRIPTION
## Motivation

`test_list_blocks_all_archs()` previously used hardcoded slice offsets that mirrored widths in `rocprof_compute_base.py`. If those widths change the test would silently misparse instead of failing loudly.

clean up to #5832 

## Technical Details

Derive offsets from the header line instead:
``` python
  alias_col = header.index("BLOCK ALIAS")
  name_col  = header.index("BLOCK NAME")
```

## JIRA ID

N/A

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
