### PR TITLE
[rocprofiler-compute] replace glob.glob with pathlib (PTH)

### DIFF
--- a/projects/rocprofiler-compute/src/utils/utils_common.py
+++ b/projects/rocprofiler-compute/src/utils/utils_common.py
@@ -930,12 +930,11 @@ def get_arch_panel_id_to_alias(arch: str) -> dict[str, str]:
     """Return panel_id_str -> alias from the *_config_template.yaml whose
     filename prefix matches arch. Empty/None aliases stay as "".
     Returns {} when no template matches the arch."""
-    template_glob = (
-        f"{config.rocprof_compute_home}"
-        "/rocprof_compute_soc/analysis_configs/*_config_template.yaml"
+    analysis_dir = (
+        Path(config.rocprof_compute_home) / "rocprof_compute_soc" / "analysis_configs"
     )
-    for path in sorted(glob.glob(template_glob)):
-        m = re.match(r".*(gfx\d+)_config_template\.yaml$", path)
+    for path in sorted(analysis_dir.glob("*_config_template.yaml")):
+        m = re.match(r"(gfx\d+)_config_template\.yaml$", path.name)
         if m and arch.startswith(m.group(1)):
             panel_yaml = load_yaml(path) or {}
             panels = panel_yaml.get("panels") or []

--- a/projects/rocprofiler-compute/src/utils/utils_common.py
+++ b/projects/rocprofiler-compute/src/utils/utils_common.py
@@ -126,6 +126,8 @@ def resolve_rocm_library_path(library_path: Optional[str]) -> Optional[str]:
         return str(path)
 
     # Use iterdir to avoid glob metacharacter issues in library_path.
+    if not path.parent.is_dir():
+        return None
     matches = [
         str(p) for p in path.parent.iterdir() if p.name.startswith(path.name + ".")
     ]

--- a/projects/rocprofiler-compute/src/utils/utils_common.py
+++ b/projects/rocprofiler-compute/src/utils/utils_common.py
@@ -128,9 +128,8 @@ def resolve_rocm_library_path(library_path: Optional[str]) -> Optional[str]:
     # Use iterdir to avoid glob metacharacter issues in library_path.
     if not path.parent.is_dir():
         return None
-    matches = [
-        str(p) for p in path.parent.iterdir() if p.name.startswith(path.name + ".")
-    ]
+    prefix = f"{path.name}."
+    matches = [str(p) for p in path.parent.iterdir() if p.name.startswith(prefix)]
 
     # First pass: filter to numeric versions and collect version tuples
     version_tuples: list[tuple[list[int], str]] = []
@@ -923,7 +922,7 @@ def convert_metric_id_to_panel_info(
     return (file_id, panel_id, metric_id_int)
 
 
-def load_yaml(filepath: str) -> dict[str, Any]:
+def load_yaml(filepath: Union[str, os.PathLike]) -> dict[str, Any]:
     """Load YAML file and return as dictionary."""
     with open(filepath, encoding="utf-8") as f:
         return yaml.safe_load(f)

--- a/projects/rocprofiler-compute/src/utils/utils_common.py
+++ b/projects/rocprofiler-compute/src/utils/utils_common.py
@@ -5,7 +5,6 @@ import argparse
 import csv
 import ctypes
 import errno
-import glob
 import io
 import os
 import pty
@@ -126,8 +125,10 @@ def resolve_rocm_library_path(library_path: Optional[str]) -> Optional[str]:
         console_debug(f"Resolved library (exact match): {path}")
         return str(path)
 
-    # Escape the input path so any glob metacharacters are treated literally.
-    matches = glob.glob(f"{glob.escape(library_path)}.*")
+    # Use iterdir to avoid glob metacharacter issues in library_path.
+    matches = [
+        str(p) for p in path.parent.iterdir() if p.name.startswith(path.name + ".")
+    ]
 
     # First pass: filter to numeric versions and collect version tuples
     version_tuples: list[tuple[list[int], str]] = []

--- a/projects/rocprofiler-compute/src/utils/utils_profile.py
+++ b/projects/rocprofiler-compute/src/utils/utils_profile.py
@@ -1,7 +1,6 @@
 # Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier:  MIT
 
-import glob
 import importlib
 import os
 import pkgutil
@@ -210,8 +209,8 @@ def run_prof(
             get_rocprof_cmd() == "rocprofiler-sdk"
             and options["ROCPROF_COUNTER_COLLECTION"] == "0"
         ):
-            for db_name in glob.glob(workload_dir + "/out/pmc_1/*/*.db"):
-                pid = Path(db_name).stem.split("_")[0]
+            for db_name in (Path(workload_dir) / "out/pmc_1").glob("*/*.db"):
+                pid = db_name.stem.split("_")[0]
                 counter_csv = (
                     Path(workload_dir)
                     / "out"
@@ -227,12 +226,12 @@ def run_prof(
                 counter_rows, _ = csv_ops.read_csv_as_dicts(str(counter_csv))
                 rocpd_data.update_rocpd_pmc_events(
                     counter_rows,
-                    db_name,
+                    str(db_name),
                 )
                 console_debug(f"Updated rocpd db {db_name} with native tool counters.")
         # Write results_fbase.csv
         rocpd_data.convert_dbs_to_csv(
-            glob.glob(workload_dir + "/out/pmc_1/*/*.db"),
+            [str(p) for p in (Path(workload_dir) / "out/pmc_1").glob("*/*.db")],
             workload_dir + f"/out/pmc_1/{fbase}_counter_collection.csv",
             workload_dir + f"/out/pmc_1/{fbase}_marker_api_trace.csv",
         )
@@ -297,8 +296,8 @@ def run_prof(
                 "--retain-rocpd-output is deprecated and will be removed in "
                 "a future release. .db files will be retained automatically."
             )
-            for db_path in glob.glob(workload_dir + "/out/pmc_1/*/*.db"):
-                pid = Path(db_path).stem.split("_")[0]
+            for db_path in (Path(workload_dir) / "out/pmc_1").glob("*/*.db"):
+                pid = db_path.stem.split("_")[0]
                 shutil.copyfile(
                     db_path,
                     workload_dir + f"/{fbase}_{pid}.db",
@@ -713,10 +712,10 @@ def convert_native_counter_collection_csv(workload_dir: str) -> None:
     trace to write counter collection csv in rocprofiler-sdk format
     for further processing to pmc_perf.csv file
     """
-    for native_filename in glob.glob(
-        f"{workload_dir}/out/pmc_1/*_native_counter_collection.csv"
+    for native_path in (Path(workload_dir) / "out/pmc_1").glob(
+        "*_native_counter_collection.csv"
     ):
-        counter_data, _ = csv_ops.read_csv_as_dicts(native_filename)
+        counter_data, _ = csv_ops.read_csv_as_dicts(str(native_path))
         # Group by on dispatch_id and counter_id and sum the counter_value,
         # Other rows in group have the same value, so take the first one
         groupby_cols = ["dispatch_id", "counter_name"]
@@ -732,10 +731,10 @@ def convert_native_counter_collection_csv(workload_dir: str) -> None:
         agg_dict["counter_value"] = "sum"
         counter_data = csv_ops.groupby_aggregate(counter_data, groupby_cols, agg_dict)
 
-        pid = Path(native_filename).stem.split("_")[0]
-        kernel_data_filename = glob.glob(
-            f"{workload_dir}/out/pmc_1/*/{pid}_kernel_trace.csv"
-        )[0]
+        pid = native_path.stem.split("_")[0]
+        kernel_data_filename = str(
+            next((Path(workload_dir) / "out/pmc_1").glob(f"*/{pid}_kernel_trace.csv"))
+        )
         kernel_data, _ = csv_ops.read_csv_as_dicts(kernel_data_filename)
 
         # Merge counter_data with kernel_data on dispatch_id
@@ -802,10 +801,11 @@ def process_rocprofv3_output(workload_dir: str, using_native_tool: bool) -> list
                 f"Stacktrace:\n{traceback.format_exc()}"
             )
 
-    counter_info_csvs = glob.glob(
-        f"{workload_dir}/out/pmc_1/*/*_counter_collection.csv"
-    )
-    existing_counter_files_csv = [f for f in counter_info_csvs if Path(f).is_file()]
+    existing_counter_files_csv = [
+        str(p)
+        for p in (Path(workload_dir) / "out/pmc_1").glob("*/*_counter_collection.csv")
+        if p.is_file()
+    ]
 
     if existing_counter_files_csv:
         for counter_file in existing_counter_files_csv:
@@ -835,7 +835,9 @@ def process_rocprofv3_output(workload_dir: str, using_native_tool: bool) -> list
                 )
                 return []
 
-        results_files_csv = glob.glob(f"{workload_dir}/out/pmc_1/*/*_converted.csv")
+        results_files_csv = [
+            str(p) for p in (Path(workload_dir) / "out/pmc_1").glob("*/*_converted.csv")
+        ]
     else:
         return []
 
@@ -872,26 +874,22 @@ def save_torch_trace_inputs(
         console_log("Marker API Trace: ", str(dst_marker))
     elif output_format == "csv":
         # Multiple pairs possible (one per PID/process)
-        counter_files = glob.glob(str(src_dir / "*/*_counter_collection.csv"))
-        marker_files = glob.glob(str(src_dir / "*/*_marker_api_trace.csv"))
+        counter_files = list(src_dir.glob("*/*_counter_collection.csv"))
+        marker_files = list(src_dir.glob("*/*_marker_api_trace.csv"))
         (Path(workload_dir) / f"{fbase}").mkdir(parents=True, exist_ok=True)
         # Expecting the files to be present
         # Letting shutil.copyfile raise error if files not found
         # Path: workload_dir/fbase/torch_trace_<src_basename> (discovered by
         # process_torch_trace_output via glob **/torch_trace*_marker_api_trace.csv)
         for src_counter in counter_files:
-            dst_counter = str(
-                Path(workload_dir)
-                / f"{fbase}"
-                / ("torch_trace_" + Path(src_counter).name)
+            dst_counter = (
+                Path(workload_dir) / f"{fbase}" / ("torch_trace_" + src_counter.name)
             )
             shutil.copyfile(src_counter, dst_counter)
             console_log("torch trace", f"Copied Counter Collection: {dst_counter}")
         for src_marker in marker_files:
-            dst_marker = str(
-                Path(workload_dir)
-                / f"{fbase}"
-                / ("torch_trace_" + Path(src_marker).name)
+            dst_marker = (
+                Path(workload_dir) / f"{fbase}" / ("torch_trace_" + src_marker.name)
             )
             shutil.copyfile(src_marker, dst_marker)
             console_log("torch trace", f"Copied Marker API Trace: {dst_marker}")
@@ -905,10 +903,11 @@ def save_torch_trace_inputs(
 @demarcate
 def process_kokkos_trace_output(workload_dir: str, fbase: str) -> None:
     # marker api trace csv files are generated for each process
-    marker_api_trace_csvs = glob.glob(
-        f"{workload_dir}/out/pmc_1/*/*_marker_api_trace.csv"
-    )
-    existing_marker_files_csv = [f for f in marker_api_trace_csvs if Path(f).is_file()]
+    existing_marker_files_csv = [
+        str(p)
+        for p in (Path(workload_dir) / "out/pmc_1").glob("*/*_marker_api_trace.csv")
+        if p.is_file()
+    ]
 
     # concate and output marker api trace info
     combined_results = csv_ops.concat_csv_files(existing_marker_files_csv)

--- a/projects/rocprofiler-compute/tests/generate_test_analyze_workloads.py
+++ b/projects/rocprofiler-compute/tests/generate_test_analyze_workloads.py
@@ -2,8 +2,7 @@
 # SPDX-License-Identifier:  MIT
 
 import argparse
-import glob
-import os
+from pathlib import Path
 
 if __name__ == "__main__":
     my_parser = argparse.ArgumentParser(description="create test_analyze_workloads.py")
@@ -13,13 +12,12 @@ if __name__ == "__main__":
     )
 
     args = my_parser.parse_args()
-    workloads_path = args.path
-    workloads = glob.glob(workloads_path + "/*")
+    workloads_path = Path(args.path)
 
     with open("test_analyze_workloads.py", "a") as f:
-        for workload in workloads:
-            workload_name = workload[workload.rfind("/") + 1 :]
-            archs = os.listdir(workload)
+        for workload in sorted(workloads_path.iterdir()):
+            workload_name = workload.name
+            archs = [p.name for p in workload.iterdir()]
             for arch in archs:
                 test = (
                     "\n\ndef test_analyze_"
@@ -35,7 +33,7 @@ if __name__ == "__main__":
                         "'rocprof-compute', "
                         "'analyze', "
                         "'--path', "
-                        "'" + workload + "/" + arch + "']"
+                        "'" + str(workload / arch) + "']"
                         "):\n\t\t\trocprof_compute.main()"
                     )
                     + "\n\tassert e.value.code == 0"

--- a/projects/rocprofiler-compute/tests/test_utils.py
+++ b/projects/rocprofiler-compute/tests/test_utils.py
@@ -972,7 +972,8 @@ def test_run_prof_success_v3(tmp_path, monkeypatch):
     monkeypatch.setattr("utils.utils_profile.console_debug", lambda *a, **k: None)
     monkeypatch.setattr("utils.utils_profile.console_log", lambda *a, **k: None)
     monkeypatch.setattr(
-        "glob.glob", lambda pattern: [workload_dir + "/out/pmc_1/results_0.csv"]
+        "utils.utils_profile.process_rocprofv3_output",
+        lambda *a, **k: [workload_dir + "/out/pmc_1/results_0.csv"],
     )
 
     utils_profile.run_prof(str(fname), ["--arg"], workload_dir, logging.INFO, "csv")
@@ -1314,7 +1315,6 @@ def test_run_prof_no_results_files(tmp_path, monkeypatch):
         "utils.utils_profile.capture_subprocess_output",
         lambda *a, **k: (True, "success"),
     )
-    monkeypatch.setattr("glob.glob", lambda pattern: [])  # No files found
     monkeypatch.setattr("utils.utils_profile.console_debug", lambda *a, **k: None)
     monkeypatch.setattr("utils.utils_profile.console_log", lambda *a, **k: None)
 
@@ -1432,9 +1432,6 @@ def test_run_prof_tcc_flattening_mi300(tmp_path, monkeypatch):
         lambda *a, **k: (True, "success"),
     )
     monkeypatch.setattr("utils.mi_gpu_spec.mi_gpu_specs.get_num_xcds", lambda *a: 2)
-    monkeypatch.setattr(
-        "glob.glob", lambda pattern: [workload_dir + "/results_test.csv"]
-    )
     monkeypatch.setattr("utils.utils_profile.console_debug", lambda *a, **k: None)
     monkeypatch.setattr("utils.utils_profile.console_log", lambda *a, **k: None)
 
@@ -1757,15 +1754,6 @@ def test_process_rocprofv3_output_csv_format_with_counter_files(tmp_path, monkey
 
     counter_file.write_text("counter,data\ntest,value")
     agent_file.write_text("agent,data\ntest,value")
-
-    def mock_glob(pattern):
-        if "_counter_collection.csv" in pattern:
-            return [str(counter_file)]
-        elif "_converted.csv" in pattern:
-            return [str(converted_file)]
-        return []
-
-    monkeypatch.setattr("glob.glob", mock_glob)
 
     def mock_v3_counter_csv_to_v2_csv(counter_path, agent_path, output_path):
         Path(output_path).write_text("converted,data\ntest,value")

--- a/projects/rocprofiler-compute/tests/test_utils.py
+++ b/projects/rocprofiler-compute/tests/test_utils.py
@@ -952,17 +952,24 @@ def test_run_prof_success_v3(tmp_path, monkeypatch):
     fname = tmp_path / "pmc_perf_test.yaml"
     fname.write_text("jobs:\n  - pmc:\n    - SQ_WAVES\n")
     workload_dir = str(tmp_path / "workload")
-    os.makedirs(workload_dir + "/out/pmc_1", exist_ok=True)
+    pmc_1_subdir = Path(workload_dir) / "out" / "pmc_1" / "0"
+    pmc_1_subdir.mkdir(parents=True, exist_ok=True)
 
-    csv_content = (
-        "Agent_Type,Node_Id,Wave_Front_Size,Correlation_Id,Dispatch_Id,Agent_Id,Queue_Id,Process_Id,Thread_Id,"
+    # counter_collection.csv and agent_info.csv are required by
+    # process_rocprofv3_output; the converted.csv is produced by
+    # v3_counter_csv_to_v2_csv which we stub to keep the test self-contained.
+    counter_file = pmc_1_subdir / "run_counter_collection.csv"
+    agent_info_file = pmc_1_subdir / "run_agent_info.csv"
+    converted_file = pmc_1_subdir / "run_converted.csv"
+
+    counter_file.write_text(
+        "Correlation_Id,Dispatch_Id,Agent_Id,Queue_Id,Process_Id,Thread_Id,"
         "Grid_Size,Kernel_Id,Kernel_Name,Workgroup_Size,LDS_Block_Size,"
         "Scratch_Size,VGPR_Count,Accum_VGPR_Count,SGPR_Count,Start_Timestamp,"
         "End_Timestamp,Counter_Name,Counter_Value\n"
-        "GPU,0,0,0,0,0,0,0,0,0,0,test_kernel,0,0,0,0,0,0,0,1,SQ_WAVES,100"
+        "0,0,0,0,0,0,0,0,test_kernel,0,0,0,0,0,0,0,1,SQ_WAVES,100\n"
     )
-    with open(workload_dir + "/out/pmc_1/results_0.csv", "w") as f:
-        f.write(csv_content)
+    agent_info_file.write_text("Agent_Type,Node_Id,Wave_Front_Size\nGPU,0,64\n")
 
     monkeypatch.setattr("utils.utils_common._rocprof_cmd", "rocprofv3")
     monkeypatch.setattr(
@@ -971,9 +978,13 @@ def test_run_prof_success_v3(tmp_path, monkeypatch):
     )
     monkeypatch.setattr("utils.utils_profile.console_debug", lambda *a, **k: None)
     monkeypatch.setattr("utils.utils_profile.console_log", lambda *a, **k: None)
+    # Stub the conversion so the test doesn't depend on csv_ops pivot logic,
+    # but process_rocprofv3_output itself runs and exercises Path.glob.
     monkeypatch.setattr(
-        "utils.utils_profile.process_rocprofv3_output",
-        lambda *a, **k: [workload_dir + "/out/pmc_1/results_0.csv"],
+        "utils.utils_profile.v3_counter_csv_to_v2_csv",
+        lambda *a, **k: converted_file.write_text(
+            "GPU_ID,Kernel_Name,SQ_WAVES\n0,test_kernel,100\n"
+        ),
     )
 
     utils_profile.run_prof(str(fname), ["--arg"], workload_dir, logging.INFO, "csv")

--- a/projects/rocprofiler-compute/tools/run-ci.py
+++ b/projects/rocprofiler-compute/tools/run-ci.py
@@ -3,13 +3,13 @@
 # SPDX-License-Identifier:  MIT
 
 import argparse
-import glob
 import multiprocessing
 import os
 import re
 import shutil
 import socket
 import sys
+from pathlib import Path
 
 
 def which(cmd, require):
@@ -297,19 +297,16 @@ if __name__ == "__main__":
         )
     finally:
         if "-VV" not in ctest_args:
-            for file in glob.glob(
-                os.path.join(args.binary_dir, "Testing/**"), recursive=True
-            ):
-                if not os.path.isfile(file):
+            for file in Path(args.binary_dir, "Testing").rglob("*"):
+                if not file.is_file():
                     continue
                 print(f"\n\n\n###### Reading {file}... ######\n\n\n")
-                with open(file, "r") as inpf:
-                    fdata = inpf.read()
-                    if "LastTest" not in file and "Coverage" not in file:
-                        print(fdata)
-                    oname = os.path.basename(file)
-                    if oname.endswith(".log"):
-                        oname += ".log"
-                    with open(os.path.join(args.binary_dir, oname), "w") as outf:
-                        print(f"\n\n###### Writing {oname}... ######\n\n")
-                        outf.write(fdata)
+                fdata = file.read_text()
+                if "LastTest" not in str(file) and "Coverage" not in str(file):
+                    print(fdata)
+                oname = file.name
+                if oname.endswith(".log"):
+                    oname += ".log"
+                out_path = Path(args.binary_dir) / oname
+                print(f"\n\n###### Writing {oname}... ######\n\n")
+                out_path.write_text(fdata)


### PR DESCRIPTION
## Motivation

Replace `glob.glob` with pathlib (PTH) per project ruff rules.

## Technical Details

- `utils_common.py`: `get_arch_panel_id_to_alias` uses `Path.glob()` and matches on `path.name`, removing the leading `.*` from the regex
- `utils_profile.py`: remove `import glob`; convert all 8 `glob.glob` call sites to `Path.glob()` with correct `str()` wrapping for `list[str]` APIs
- `generate_test_analyze_workloads.py`: replace glob+os with pathlib
- `run-ci.py`: replace `glob.glob(..., recursive=True)` with `Path.rglob()`
- `test_utils.py`: update `glob.glob` monkeypatches that targeted `utils_profile` to patch `Path.glob` or `process_rocprofv3_output` directly

## JIRA ID

N/A

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
