### PR TITLE
ROCM-25102 - libhsakmt: include non-local memory in APU local-pool size

### DIFF
--- a/projects/hip-tests/catch/config/configs/unit/memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/memory.yaml
@@ -1505,6 +1505,9 @@ memory:
     # Rock_Window_Failures_on_gfx1151
     disabled: [amd_windows]
     tags: [alloc]
+  Unit_hipMalloc_Positive_APU_LargeAllocSpill:
+    <<: *level_2
+    tags: [alloc]
   Unit_hipMalloc_Allocate110PercentOfDeviceMemory: *level_2
   Unit_hipMalloc_AllocateAvailableVRAMAndPossibleRAM: *level_2
   Unit_hipMalloc_AllocateMoreThanTotalRAM: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/virtualMemoryManagement.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/virtualMemoryManagement.yaml
@@ -180,6 +180,7 @@ virtualMemoryManagement:
     # Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
     disabled: [amd_wsl]
   Unit_hipMemGetAllocationPropertiesFromHandle_Capture: *level_2
+  Unit_hipMemMap_Positive_APU_LargeAllocSpill: *level_2
   Unit_hipMemMap_SameMemoryReuse:
     <<: *level_2
     # (amd_windows) SWDEV-444041: These tests fail randomly in gfx1030 MGU

--- a/projects/hip-tests/catch/unit/memory/hipMalloc.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMalloc.cc
@@ -166,10 +166,10 @@ HIP_TEST_CASE(Unit_hipMalloc_Allocate90PercentOfDeviceMemory) {
  * Test Description
  * ------------------------
  * - APU-only. Allocates a single device buffer expected to exceed the
- *   dedicated-VRAM carveout, then exercises it end-to-end (memset, copy
- *   back, verify head and tail). Validates that hipMalloc honours the
- *   spill path for large allocations on unified memory and that the
- *   resulting buffer is usable by an AQL kernel submit.
+ *   dedicated-VRAM carveout, then exercises it with memory operations
+ *   (memset, copy back, verify head and tail). Validates that hipMalloc
+ *   honours the spill path for large allocations on unified memory and
+ *   that the resulting buffer remains accessible for those operations.
  * Test source
  * ------------------------
  * - unit/memory/hipMalloc.cc

--- a/projects/hip-tests/catch/unit/memory/hipMalloc.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMalloc.cc
@@ -162,6 +162,55 @@ HIP_TEST_CASE(Unit_hipMalloc_Allocate90PercentOfDeviceMemory) {
   HIP_CHECK(hipFree(devMem));
 }
 
+/**
+ * Test Description
+ * ------------------------
+ * - APU-only. Allocates a single device buffer expected to exceed the
+ *   dedicated-VRAM carveout, then exercises it end-to-end (memset, copy
+ *   back, verify head and tail). Validates that hipMalloc honours the
+ *   spill path for large allocations on unified memory and that the
+ *   resulting buffer is usable by an AQL kernel submit.
+ * Test source
+ * ------------------------
+ * - unit/memory/hipMalloc.cc
+ */
+HIP_TEST_CASE(Unit_hipMalloc_Positive_APU_LargeAllocSpill) {
+  hipDeviceProp_t prop{};
+  HIP_CHECK(hipGetDeviceProperties(&prop, 0));
+  if (!prop.integrated) {
+    HIP_SKIP_TEST("dGPU --- APU spill regression test does not apply");
+    return;
+  }
+  // Assumes the dedicated-VRAM carveout is smaller than 5 GiB.
+  constexpr size_t size = static_cast<size_t>(5) << 30;
+  constexpr size_t headroom = static_cast<size_t>(1) << 30;
+  if (prop.totalGlobalMem < size + headroom) {
+    HIP_SKIP_TEST("APU totalGlobalMem too small for this allocation plus headroom");
+    return;
+  }
+
+  char* devMem = nullptr;
+  HIP_CHECK(hipMalloc(&devMem, size));
+  REQUIRE(devMem != nullptr);
+
+  constexpr int fill = 0xCD;
+  HIP_CHECK(hipMemset(devMem, fill, size));
+
+  // Sample-verify head and tail; full read-back is bandwidth-bound at GiB
+  // scale but touching both ends catches page-table or aperture mismatches.
+  constexpr size_t sample = static_cast<size_t>(64) * 1024;
+  std::vector<char> head(sample), tail(sample);
+  HIP_CHECK(hipMemcpy(head.data(), devMem, sample, hipMemcpyDeviceToHost));
+  HIP_CHECK(hipMemcpy(tail.data(), devMem + (size - sample), sample,
+                      hipMemcpyDeviceToHost));
+  for (size_t i = 0; i < sample; ++i) {
+    REQUIRE(head[i] == static_cast<char>(fill));
+    REQUIRE(tail[i] == static_cast<char>(fill));
+  }
+
+  HIP_CHECK(hipFree(devMem));
+}
+
 // Commenting this due to defect SWDEV-501675
 #if 0
 /**

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemMap.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemMap.cc
@@ -744,7 +744,7 @@ HIP_TEST_CASE(Unit_hipMemMap_Positive_APU_LargeAllocSpill) {
   size_t granularity = 0;
   HIP_CHECK(hipMemGetAllocationGranularity(&granularity, &aprop,
                                            hipMemAllocationGranularityMinimum));
-  if (granularity == 0) granularity = static_cast<size_t>(2) * 1024 * 1024;
+  REQUIRE(granularity > 0);
   const size_t size = ((requested + granularity - 1) / granularity) * granularity;
 
   void* va = nullptr;

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemMap.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemMap.cc
@@ -702,6 +702,86 @@ HIP_TEST_CASE(Unit_hipMemMap_Capture) {
 }
 
 /**
+ * Test Description
+ * ------------------------
+ * - APU-only. Reserves a VA, creates a physical handle expected to exceed
+ *   the dedicated-VRAM carveout, maps it, grants access, and exercises the
+ *   buffer end-to-end (memset, copy back, verify head and tail). Mirrors
+ *   Unit_hipMalloc_Positive_APU_LargeAllocSpill but through the VMEM API
+ *   path that hipGraphAddMemAllocNode ultimately uses, so it guards the
+ *   same spill behaviour for graph-based allocations.
+ * Test source
+ * ------------------------
+ * - unit/virtualMemoryManagement/hipMemMap.cc
+ */
+HIP_TEST_CASE(Unit_hipMemMap_Positive_APU_LargeAllocSpill) {
+  hipDeviceProp_t prop{};
+  HIP_CHECK(hipGetDeviceProperties(&prop, 0));
+  if (!prop.integrated) {
+    HIP_SKIP_TEST("dGPU --- APU spill regression test does not apply");
+    return;
+  }
+  int vmm_supported = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&vmm_supported,
+                                  hipDeviceAttributeVirtualMemoryManagementSupported, 0));
+  if (!vmm_supported) {
+    HIP_SKIP_TEST("Device does not support virtual memory management");
+    return;
+  }
+  // Assumes the dedicated-VRAM carveout is smaller than 5 GiB.
+  constexpr size_t requested = static_cast<size_t>(5) << 30;
+  constexpr size_t headroom = static_cast<size_t>(1) << 30;
+  if (prop.totalGlobalMem < requested + headroom) {
+    HIP_SKIP_TEST("APU totalGlobalMem too small for this allocation plus headroom");
+    return;
+  }
+
+  hipMemAllocationProp aprop{};
+  aprop.type = hipMemAllocationTypePinned;
+  aprop.location.type = hipMemLocationTypeDevice;
+  aprop.location.id = 0;
+
+  size_t granularity = 0;
+  HIP_CHECK(hipMemGetAllocationGranularity(&granularity, &aprop,
+                                           hipMemAllocationGranularityMinimum));
+  if (granularity == 0) granularity = static_cast<size_t>(2) * 1024 * 1024;
+  const size_t size = ((requested + granularity - 1) / granularity) * granularity;
+
+  void* va = nullptr;
+  HIP_CHECK(hipMemAddressReserve(&va, size, 0, nullptr, 0));
+  REQUIRE(va != nullptr);
+
+  hipMemGenericAllocationHandle_t handle = nullptr;
+  HIP_CHECK(hipMemCreate(&handle, size, &aprop, 0));
+  REQUIRE(handle != nullptr);
+
+  HIP_CHECK(hipMemMap(va, size, 0, handle, 0));
+
+  hipMemAccessDesc access{};
+  access.location.type = hipMemLocationTypeDevice;
+  access.location.id = 0;
+  access.flags = hipMemAccessFlagsProtReadWrite;
+  HIP_CHECK(hipMemSetAccess(va, size, &access, 1));
+
+  constexpr int fill = 0xCD;
+  HIP_CHECK(hipMemset(va, fill, size));
+
+  constexpr size_t sample = static_cast<size_t>(64) * 1024;
+  std::vector<char> head(sample), tail(sample);
+  HIP_CHECK(hipMemcpy(head.data(), va, sample, hipMemcpyDeviceToHost));
+  HIP_CHECK(hipMemcpy(tail.data(), static_cast<char*>(va) + (size - sample), sample,
+                      hipMemcpyDeviceToHost));
+  for (size_t i = 0; i < sample; ++i) {
+    REQUIRE(head[i] == static_cast<char>(fill));
+    REQUIRE(tail[i] == static_cast<char>(fill));
+  }
+
+  HIP_CHECK(hipMemUnmap(va, size));
+  HIP_CHECK(hipMemRelease(handle));
+  HIP_CHECK(hipMemAddressFree(va, size));
+}
+
+/**
  * End doxygen group VirtualMemoryManagementTest.
  * @}
  */

--- a/projects/rocr-runtime/libhsakmt/src/dxg/topology.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/topology.cpp
@@ -842,6 +842,11 @@ HSAKMT_STATUS topology_sysfs_get_mem_props(uint32_t node_id, uint32_t mem_id,
 
   props.HeapType = HSA_HEAPTYPE_FRAME_BUFFER_PRIVATE;
   props.SizeInBytes = device->LocalHeapSize();
+  // On APU, allocations can spill from local to non-local via the GART fallback,
+  // so the effective per-allocation cap is local + non-local.
+  if (!device->IsDgpu()) {
+    props.SizeInBytes += device->NonLocalHeapSize();
+  }
   props.Width = device->MemoryBusWidth();
   props.MemoryClockMax = device->MaxMemoryClockMhz();
 


### PR DESCRIPTION
## Motivation

MemoryRegion::AllocateImpl rejects any local-pool allocation larger than max_single_alloc_size_, which HSA derives from the pool size reported by libhsakmt. On APU, libhsakmt reports only the dedicated-VRAM carveout, so any hipMalloc/hipMemCreate above that is rejected with hipErrorOutOfMemory even though the GPU can reach the full unified    
memory via spill. This change makes the reported size reflect the actual addressable memory on APU.

## Technical Details

In topology_sysfs_get_mem_props, when populating HSA_HEAPTYPE_FRAME_BUFFER_PRIVATE, on APU add device->NonLocalHeapSize() to the existing device->LocalHeapSize() before assigning to props.SizeInBytes. Gated by !device->IsDgpu(). Relies on NonLocalHeapSize() being populated by wkmi jungx098/non-local-heap-size (already used by commit 2cd6e693b9 in the same branch). dGPU path is unchanged.

Following PRs should be merged being dependencies..
https://github.com/AMD-ROCm-Internal/wkmi/pull/10 
https://github.com/AMD-ROCm-Internal/wkmi/pull/11 
https://github.com/ROCm/rocm-systems/pull/6350 

## JIRA ID

ROCM-25102

## Test Plan

Covered by the same hip-tests

## Test Result

 - Build with -DWKMI_SRC_DIR=... against the wkmi branch carrying the non_local_heap_size population.
  - Strix Halo, GPU_ENABLE_PAL=0: run the two new hip-tests at 4–10 GiB; allocation should succeed and the end-to-end      
  memset+memcpy should pass.
  - Verify hipMemGetInfo still reports a coherent total on APU.
  - dGPU regression: pool size for FRAME_BUFFER_PRIVATE unchanged (still LocalHeapSize()), no behaviour delta expected. 

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
