### PR TITLE
[rocprofiler-compute] Remove gfx950 bandwidth requests metrics

### DIFF
--- a/projects/rocprofiler-compute/docs/data/metrics/gfx950_metrics.yaml
+++ b/projects/rocprofiler-compute/docs/data/metrics/gfx950_metrics.yaml
@@ -985,12 +985,6 @@ L2 - Fabric interface detailed metrics:
   Read (Uncached):
     rst: The total number of L2 requests to Infinity Fabric to read :ref:`uncached data <memory-type>` from any memory location, per :ref:`normalization unit <normalization-units>`. 64B requests for uncached data are counted as two 32B uncached data requests. See :ref:`l2-request-flow` for more detail.
     unit: Req per Normalization Unit
-  HBM Read:
-    rst: The total number of L2 requests to Infinity Fabric to read 32B or 64B of data from the accelerator's local HBM, per :ref:`normalization unit <normalization-units>`. See :ref:`l2-request-flow` for more detail.
-    unit: Req per Normalization Unit
-  Remote Read:
-    rst: The total number of L2 requests to Infinity Fabric to read 32B or 64B of data from any source other than the accelerator's local HBM, per :ref:`normalization unit <normalization-units>`. See :ref:`l2-request-flow` for more detail.
-    unit: Req per Normalization Unit
   Read Bandwidth - PCIe:
     rst: Total number of bytes due to L2 read requests due to PCIe traffic, divided by total duration.
     unit: Gbps
@@ -1008,12 +1002,6 @@ L2 - Fabric interface detailed metrics:
     unit: Req per Normalization Unit
   Write and Atomic (64B):
     rst: The total number of L2 requests to Infinity Fabric to write or atomically update 64B of data in any memory location, per :ref:`normalization unit <normalization-units>`. See :ref:`l2-request-flow` for more detail.
-    unit: Req per Normalization Unit
-  HBM Write and Atomic:
-    rst: The total number of L2 requests to Infinity Fabric to write or atomically update 32B or 64B of data in the accelerator's local HBM, per :ref:`normalization unit <normalization-units>`. See :ref:`l2-request-flow` for more detail. plain
-    unit: Req per Normalization Unit
-  Remote Write and Atomic:
-    rst: The total number of L2 requests to Infinity Fabric to write or atomically update 32B or 64B of data in any memory location other than the accelerator's local HBM, per :ref:`normalization unit <normalization-units>`. See :ref:`l2-request-flow` for more detail.
     unit: Req per Normalization Unit
   Write Bandwidth - PCIe:
     rst: Total number of bytes due to L2 write requests due to PCIe traffic, divided by total duration.
@@ -1033,9 +1021,21 @@ L2 - Fabric interface detailed metrics:
   Atomic Bandwidth - HBM:
     rst: Total number of bytes due to L2 atomic requests due to HBM traffic, divided by total duration.
     unit: Gbps
-  Atomic - HBM:
-    rst: The total number of L2 atomic requests (either 32-byte or 64-byte) destined for the accelerator's local high-bandwidth memory (HBM), per normalization unit. These are read-modify-write operations that update memory atomically.
-    unit: Req per Normalization Unit
   Atomic:
     rst: The total number of L2 requests to Infinity Fabric to atomically update 32B or 64B of data in any memory location, per :ref:`normalization unit <normalization-units>`. See :ref:`l2-request-flow` for more detail. Note that on current CDNA accelerators, such as the :ref:`MI2XX <mixxx-note>`, requests are only considered *atomic* by Infinity Fabric if they are targeted at non-write-cacheable memory, such as :ref:`fine-grained memory <memory-type>` allocations or :ref:`uncached memory <memory-type>` allocations on the MI2XX.
+    unit: Req per Normalization Unit
+  HBM Read:
+    rst: The total number of L2 requests to Infinity Fabric to read 32B or 64B of data from the accelerator's local HBM, per :ref:`normalization unit <normalization-units>`. See :ref:`l2-request-flow` for more detail.
+    unit: Req per Normalization Unit
+  Remote Read:
+    rst: The total number of L2 requests to Infinity Fabric to read 32B or 64B of data from any source other than the accelerator's local HBM, per :ref:`normalization unit <normalization-units>`. See :ref:`l2-request-flow` for more detail.
+    unit: Req per Normalization Unit
+  HBM Write and Atomic:
+    rst: The total number of L2 requests to Infinity Fabric to write or atomically update 32B or 64B of data in the accelerator's local HBM, per :ref:`normalization unit <normalization-units>`. See :ref:`l2-request-flow` for more detail. plain
+    unit: Req per Normalization Unit
+  Remote Write and Atomic:
+    rst: The total number of L2 requests to Infinity Fabric to write or atomically update 32B or 64B of data in any memory location other than the accelerator's local HBM, per :ref:`normalization unit <normalization-units>`. See :ref:`l2-request-flow` for more detail.
+    unit: Req per Normalization Unit
+  Atomic - HBM:
+    rst: The total number of L2 atomic requests (either 32-byte or 64-byte) destined for the accelerator's local high-bandwidth memory (HBM), per normalization unit. These are read-modify-write operations that update memory atomically.
     unit: Req per Normalization Unit

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx908/config_delta/gfx950_diff.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx908/config_delta/gfx950_diff.yaml
@@ -952,11 +952,6 @@ Addition:
         min: MIN(TCC_EA0_WRREQ_WRITE_DRAM_32B_sum * 32/ (End_Timestamp - Start_Timestamp))
         max: MAX(TCC_EA0_WRREQ_WRITE_DRAM_32B_sum * 32/ (End_Timestamp - Start_Timestamp))
         unit: Gbps
-    - Atomic - HBM:
-        avg: SUM(TCC_EA0_WRREQ_ATOMIC_DRAM_sum) / SUM($denom)
-        min: MIN((TCC_EA0_WRREQ_ATOMIC_DRAM_sum / $denom))
-        max: MAX((TCC_EA0_WRREQ_ATOMIC_DRAM_sum / $denom))
-        unit: (Req + $normUnit)
     - Atomic Bandwidth - PCIe:
         avg: SUM(TCC_EA0_WRREQ_ATOMIC_IO_32B_sum * 32) / SUM(End_Timestamp - Start_Timestamp)
         min: MIN(TCC_EA0_WRREQ_ATOMIC_IO_32B_sum * 32/ (End_Timestamp - Start_Timestamp))
@@ -990,7 +985,6 @@ Addition:
     Atomic Bandwidth - PCIe: Total number of bytes due to L2 atomic requests due to PCIe traffic, divided by total duration.
     "Atomic Bandwidth - Infinity Fabric™": Total number of bytes due to L2 atomic requests due to Infinity Fabric traffic, divided by total duration.
     Atomic Bandwidth - HBM: Total number of bytes due to L2 atomic requests due to HBM traffic, divided by total duration.
-    Atomic - HBM: The total number of L2 atomic requests (either 32-byte or 64-byte) destined for the accelerator's local high-bandwidth memory (HBM), per normalization unit. These are read-modify-write operations that update memory atomically.
     Read Stall: >-
       The ratio of the total number of cycles the L2-Fabric interface was
       stalled on a read request to any destination (local HBM, remote PCIe\xAE
@@ -1003,6 +997,23 @@ Addition:
     Write - PCIe Stall: The number of cycles the L2-Fabric interface was stalled on write or atomic requests to remote PCIe connected accelerators or CPUs as a percent of the total active L2 cycles.
     Write - Infinity Fabric Stall: The number of cycles the L2-Fabric interface was stalled on write or atomic requests to remote Infinity Fabric connected accelerators or CPUs as a percent of the total active L2 cycles.
     Write - HBM Stall: The number of cycles the L2-Fabric interface was stalled on write or atomic requests to accelerator's local HBM as a percent of the total active L2 cycles.
+Deletion:
+- Panel Config:
+    id: 1700
+  metric_table:
+    id: 1706
+    metrics:
+    - HBM Read:
+    - Remote Read:
+    - HBM Write and Atomic:
+    - Remote Write and Atomic:
+- Panel Config:
+    id: 1700
+  metric_descriptions:
+    HBM Read:
+    Remote Read:
+    HBM Write and Atomic:
+    Remote Write and Atomic:
 Modification:
 - Panel Config:
     id: 200
@@ -1215,10 +1226,6 @@ Modification:
         avg: SUM(TCC_EA0_RDREQ_64B_sum) / SUM($denom)
         min: MIN((TCC_EA0_RDREQ_64B_sum / $denom))
         max: MAX((TCC_EA0_RDREQ_64B_sum / $denom))
-    - HBM Write and Atomic:
-        avg: SUM(TCC_EA0_WRREQ_WRITE_DRAM_sum) / SUM($denom)
-        min: MIN((TCC_EA0_WRREQ_WRITE_DRAM_sum / $denom))
-        max: MAX((TCC_EA0_WRREQ_WRITE_DRAM_sum / $denom))
 - Panel Config:
     id: 1800
   metric_table:

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx90a/config_delta/gfx950_diff.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx90a/config_delta/gfx950_diff.yaml
@@ -638,11 +638,6 @@ Addition:
         min: MIN(TCC_EA0_WRREQ_WRITE_DRAM_32B_sum * 32/ (End_Timestamp - Start_Timestamp))
         max: MAX(TCC_EA0_WRREQ_WRITE_DRAM_32B_sum * 32/ (End_Timestamp - Start_Timestamp))
         unit: Gbps
-    - Atomic - HBM:
-        avg: SUM(TCC_EA0_WRREQ_ATOMIC_DRAM_sum) / SUM($denom)
-        min: MIN((TCC_EA0_WRREQ_ATOMIC_DRAM_sum / $denom))
-        max: MAX((TCC_EA0_WRREQ_ATOMIC_DRAM_sum / $denom))
-        unit: (Req + $normUnit)
     - Atomic Bandwidth - PCIe:
         avg: SUM(TCC_EA0_WRREQ_ATOMIC_IO_32B_sum * 32) / SUM(End_Timestamp - Start_Timestamp)
         min: MIN(TCC_EA0_WRREQ_ATOMIC_IO_32B_sum * 32/ (End_Timestamp - Start_Timestamp))
@@ -676,7 +671,6 @@ Addition:
     Atomic Bandwidth - PCIe: Total number of bytes due to L2 atomic requests due to PCIe traffic, divided by total duration.
     "Atomic Bandwidth - Infinity Fabric™": Total number of bytes due to L2 atomic requests due to Infinity Fabric traffic, divided by total duration.
     Atomic Bandwidth - HBM: Total number of bytes due to L2 atomic requests due to HBM traffic, divided by total duration.
-    Atomic - HBM: The total number of L2 atomic requests (either 32-byte or 64-byte) destined for the accelerator's local high-bandwidth memory (HBM), per normalization unit. These are read-modify-write operations that update memory atomically.
     Read Stall: >-
       The ratio of the total number of cycles the L2-Fabric interface was
       stalled on a read request to any destination (local HBM, remote PCIe\xAE
@@ -689,6 +683,23 @@ Addition:
     Write - PCIe Stall: The number of cycles the L2-Fabric interface was stalled on write or atomic requests to remote PCIe connected accelerators or CPUs as a percent of the total active L2 cycles.
     Write - Infinity Fabric Stall: The number of cycles the L2-Fabric interface was stalled on write or atomic requests to remote Infinity Fabric connected accelerators or CPUs as a percent of the total active L2 cycles.
     Write - HBM Stall: The number of cycles the L2-Fabric interface was stalled on write or atomic requests to accelerator's local HBM as a percent of the total active L2 cycles.
+Deletion:
+- Panel Config:
+    id: 1700
+  metric_table:
+    id: 1706
+    metrics:
+    - HBM Read:
+    - Remote Read:
+    - HBM Write and Atomic:
+    - Remote Write and Atomic:
+- Panel Config:
+    id: 1700
+  metric_descriptions:
+    HBM Read:
+    Remote Read:
+    HBM Write and Atomic:
+    Remote Write and Atomic:
 Modification:
 - Panel Config:
     id: 200
@@ -977,14 +988,6 @@ Modification:
         avg: SUM(TCC_EA0_RD_UNCACHED_32B_sum) / SUM($denom)
         min: MIN((TCC_EA0_RD_UNCACHED_32B_sum / $denom))
         max: MAX((TCC_EA0_RD_UNCACHED_32B_sum / $denom))
-    - HBM Read:
-        avg: SUM(TCC_EA0_RDREQ_DRAM_sum) / SUM($denom)
-        min: MIN((TCC_EA0_RDREQ_DRAM_sum / $denom))
-        max: MAX((TCC_EA0_RDREQ_DRAM_sum / $denom))
-    - Remote Read:
-        avg: SUM(NOISE_CLAMP(TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_DRAM_sum, TCC_EA0_RDREQ_sum)) / SUM($denom)
-        min: MIN((NOISE_CLAMP((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_DRAM_sum), TCC_EA0_RDREQ_sum) / $denom))
-        max: MAX((NOISE_CLAMP((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_DRAM_sum), TCC_EA0_RDREQ_sum) / $denom))
     - Write and Atomic (32B):
         avg: AVG(NOISE_CLAMP(((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum) / $denom), TCC_EA0_WRREQ_sum))
         min: MIN(NOISE_CLAMP(((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_64B_sum) / $denom), TCC_EA0_WRREQ_sum))
@@ -997,14 +1000,6 @@ Modification:
         avg: SUM(TCC_EA0_WRREQ_64B_sum) / SUM($denom)
         min: MIN((TCC_EA0_WRREQ_64B_sum / $denom))
         max: MAX((TCC_EA0_WRREQ_64B_sum / $denom))
-    - HBM Write and Atomic:
-        avg: SUM(TCC_EA0_WRREQ_WRITE_DRAM_sum) / SUM($denom)
-        min: MIN((TCC_EA0_WRREQ_WRITE_DRAM_sum / $denom))
-        max: MAX((TCC_EA0_WRREQ_WRITE_DRAM_sum / $denom))
-    - Remote Write and Atomic:
-        avg: SUM(NOISE_CLAMP(TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_DRAM_sum, TCC_EA0_WRREQ_sum)) / SUM($denom)
-        min: MIN((NOISE_CLAMP((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_DRAM_sum), TCC_EA0_WRREQ_sum) / $denom))
-        max: MAX((NOISE_CLAMP((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_DRAM_sum), TCC_EA0_WRREQ_sum) / $denom))
     - Atomic:
         avg: SUM(TCC_EA0_ATOMIC_sum) / SUM($denom)
         min: MIN((TCC_EA0_ATOMIC_sum / $denom))

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx940/config_delta/gfx950_diff.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx940/config_delta/gfx950_diff.yaml
@@ -643,11 +643,6 @@ Addition:
         min: MIN(TCC_EA0_WRREQ_WRITE_DRAM_32B_sum * 32/ (End_Timestamp - Start_Timestamp))
         max: MAX(TCC_EA0_WRREQ_WRITE_DRAM_32B_sum * 32/ (End_Timestamp - Start_Timestamp))
         unit: Gbps
-    - Atomic - HBM:
-        avg: SUM(TCC_EA0_WRREQ_ATOMIC_DRAM_sum) / SUM($denom)
-        min: MIN((TCC_EA0_WRREQ_ATOMIC_DRAM_sum / $denom))
-        max: MAX((TCC_EA0_WRREQ_ATOMIC_DRAM_sum / $denom))
-        unit: (Req + $normUnit)
     - Atomic Bandwidth - PCIe:
         avg: SUM(TCC_EA0_WRREQ_ATOMIC_IO_32B_sum * 32) / SUM(End_Timestamp - Start_Timestamp)
         min: MIN(TCC_EA0_WRREQ_ATOMIC_IO_32B_sum * 32/ (End_Timestamp - Start_Timestamp))
@@ -681,7 +676,6 @@ Addition:
     Atomic Bandwidth - PCIe: Total number of bytes due to L2 atomic requests due to PCIe traffic, divided by total duration.
     "Atomic Bandwidth - Infinity Fabric™": Total number of bytes due to L2 atomic requests due to Infinity Fabric traffic, divided by total duration.
     Atomic Bandwidth - HBM: Total number of bytes due to L2 atomic requests due to HBM traffic, divided by total duration.
-    Atomic - HBM: The total number of L2 atomic requests (either 32-byte or 64-byte) destined for the accelerator's local high-bandwidth memory (HBM), per normalization unit. These are read-modify-write operations that update memory atomically.
     Read Stall: >-
       The ratio of the total number of cycles the L2-Fabric interface was
       stalled on a read request to any destination (local HBM, remote PCIe\xAE
@@ -694,6 +688,23 @@ Addition:
     Write - PCIe Stall: The number of cycles the L2-Fabric interface was stalled on write or atomic requests to remote PCIe connected accelerators or CPUs as a percent of the total active L2 cycles.
     Write - Infinity Fabric Stall: The number of cycles the L2-Fabric interface was stalled on write or atomic requests to remote Infinity Fabric connected accelerators or CPUs as a percent of the total active L2 cycles.
     Write - HBM Stall: The number of cycles the L2-Fabric interface was stalled on write or atomic requests to accelerator's local HBM as a percent of the total active L2 cycles.
+Deletion:
+- Panel Config:
+    id: 1700
+  metric_table:
+    id: 1706
+    metrics:
+    - HBM Read:
+    - Remote Read:
+    - HBM Write and Atomic:
+    - Remote Write and Atomic:
+- Panel Config:
+    id: 1700
+  metric_descriptions:
+    HBM Read:
+    Remote Read:
+    HBM Write and Atomic:
+    Remote Write and Atomic:
 Modification:
 - Panel Config:
     id: 200
@@ -853,10 +864,6 @@ Modification:
         avg: SUM(TCC_EA0_RDREQ_64B_sum) / SUM($denom)
         min: MIN((TCC_EA0_RDREQ_64B_sum / $denom))
         max: MAX((TCC_EA0_RDREQ_64B_sum / $denom))
-    - HBM Write and Atomic:
-        avg: SUM(TCC_EA0_WRREQ_WRITE_DRAM_sum) / SUM($denom)
-        min: MIN((TCC_EA0_WRREQ_WRITE_DRAM_sum / $denom))
-        max: MAX((TCC_EA0_WRREQ_WRITE_DRAM_sum / $denom))
 - Panel Config:
     id: 1800
   metric_table:

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx941/config_delta/gfx950_diff.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx941/config_delta/gfx950_diff.yaml
@@ -643,11 +643,6 @@ Addition:
         min: MIN(TCC_EA0_WRREQ_WRITE_DRAM_32B_sum * 32/ (End_Timestamp - Start_Timestamp))
         max: MAX(TCC_EA0_WRREQ_WRITE_DRAM_32B_sum * 32/ (End_Timestamp - Start_Timestamp))
         unit: Gbps
-    - Atomic - HBM:
-        avg: SUM(TCC_EA0_WRREQ_ATOMIC_DRAM_sum) / SUM($denom)
-        min: MIN((TCC_EA0_WRREQ_ATOMIC_DRAM_sum / $denom))
-        max: MAX((TCC_EA0_WRREQ_ATOMIC_DRAM_sum / $denom))
-        unit: (Req + $normUnit)
     - Atomic Bandwidth - PCIe:
         avg: SUM(TCC_EA0_WRREQ_ATOMIC_IO_32B_sum * 32) / SUM(End_Timestamp - Start_Timestamp)
         min: MIN(TCC_EA0_WRREQ_ATOMIC_IO_32B_sum * 32/ (End_Timestamp - Start_Timestamp))
@@ -681,7 +676,6 @@ Addition:
     Atomic Bandwidth - PCIe: Total number of bytes due to L2 atomic requests due to PCIe traffic, divided by total duration.
     "Atomic Bandwidth - Infinity Fabric™": Total number of bytes due to L2 atomic requests due to Infinity Fabric traffic, divided by total duration.
     Atomic Bandwidth - HBM: Total number of bytes due to L2 atomic requests due to HBM traffic, divided by total duration.
-    Atomic - HBM: The total number of L2 atomic requests (either 32-byte or 64-byte) destined for the accelerator's local high-bandwidth memory (HBM), per normalization unit. These are read-modify-write operations that update memory atomically.
     Read Stall: >-
       The ratio of the total number of cycles the L2-Fabric interface was
       stalled on a read request to any destination (local HBM, remote PCIe\xAE
@@ -694,6 +688,23 @@ Addition:
     Write - PCIe Stall: The number of cycles the L2-Fabric interface was stalled on write or atomic requests to remote PCIe connected accelerators or CPUs as a percent of the total active L2 cycles.
     Write - Infinity Fabric Stall: The number of cycles the L2-Fabric interface was stalled on write or atomic requests to remote Infinity Fabric connected accelerators or CPUs as a percent of the total active L2 cycles.
     Write - HBM Stall: The number of cycles the L2-Fabric interface was stalled on write or atomic requests to accelerator's local HBM as a percent of the total active L2 cycles.
+Deletion:
+- Panel Config:
+    id: 1700
+  metric_table:
+    id: 1706
+    metrics:
+    - HBM Read:
+    - Remote Read:
+    - HBM Write and Atomic:
+    - Remote Write and Atomic:
+- Panel Config:
+    id: 1700
+  metric_descriptions:
+    HBM Read:
+    Remote Read:
+    HBM Write and Atomic:
+    Remote Write and Atomic:
 Modification:
 - Panel Config:
     id: 200
@@ -854,10 +865,6 @@ Modification:
         avg: SUM(TCC_EA0_RDREQ_64B_sum) / SUM($denom)
         min: MIN((TCC_EA0_RDREQ_64B_sum / $denom))
         max: MAX((TCC_EA0_RDREQ_64B_sum / $denom))
-    - HBM Write and Atomic:
-        avg: SUM(TCC_EA0_WRREQ_WRITE_DRAM_sum) / SUM($denom)
-        min: MIN((TCC_EA0_WRREQ_WRITE_DRAM_sum / $denom))
-        max: MAX((TCC_EA0_WRREQ_WRITE_DRAM_sum / $denom))
 - Panel Config:
     id: 1800
   metric_table:

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx942/config_delta/gfx950_diff.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx942/config_delta/gfx950_diff.yaml
@@ -632,11 +632,6 @@ Addition:
         min: MIN(TCC_EA0_WRREQ_WRITE_DRAM_32B_sum * 32/ (End_Timestamp - Start_Timestamp))
         max: MAX(TCC_EA0_WRREQ_WRITE_DRAM_32B_sum * 32/ (End_Timestamp - Start_Timestamp))
         unit: Gbps
-    - Atomic - HBM:
-        avg: SUM(TCC_EA0_WRREQ_ATOMIC_DRAM_sum) / SUM($denom)
-        min: MIN((TCC_EA0_WRREQ_ATOMIC_DRAM_sum / $denom))
-        max: MAX((TCC_EA0_WRREQ_ATOMIC_DRAM_sum / $denom))
-        unit: (Req + $normUnit)
     - Atomic Bandwidth - PCIe:
         avg: SUM(TCC_EA0_WRREQ_ATOMIC_IO_32B_sum * 32) / SUM(End_Timestamp - Start_Timestamp)
         min: MIN(TCC_EA0_WRREQ_ATOMIC_IO_32B_sum * 32/ (End_Timestamp - Start_Timestamp))
@@ -669,7 +664,6 @@ Addition:
     Atomic Bandwidth - PCIe: Total number of bytes due to L2 atomic requests due to PCIe traffic, divided by total duration.
     "Atomic Bandwidth - Infinity Fabric™": Total number of bytes due to L2 atomic requests due to Infinity Fabric traffic, divided by total duration.
     Atomic Bandwidth - HBM: Total number of bytes due to L2 atomic requests due to HBM traffic, divided by total duration.
-    Atomic - HBM: The total number of L2 atomic requests (either 32-byte or 64-byte) destined for the accelerator's local high-bandwidth memory (HBM), per normalization unit. These are read-modify-write operations that update memory atomically.
     Read Stall: >-
       The ratio of the total number of cycles the L2-Fabric interface was
       stalled on a read request to any destination (local HBM, remote PCIe\xAE
@@ -693,6 +687,22 @@ Deletion:
     "Sequencer → TA Address Stall":
     "Sequencer → TA Command Stall":
     "Sequencer → TA Data Stall":
+- Panel Config:
+    id: 1700
+  metric_table:
+    id: 1706
+    metrics:
+    - HBM Read:
+    - Remote Read:
+    - HBM Write and Atomic:
+    - Remote Write and Atomic:
+- Panel Config:
+    id: 1700
+  metric_descriptions:
+    HBM Read:
+    Remote Read:
+    HBM Write and Atomic:
+    Remote Write and Atomic:
 Modification:
 - Panel Config:
     id: 200
@@ -857,10 +867,6 @@ Modification:
         avg: SUM(TCC_EA0_RDREQ_128B_sum) / SUM($denom)
         min: MIN((TCC_EA0_RDREQ_128B_sum / $denom))
         max: MAX((TCC_EA0_RDREQ_128B_sum / $denom))
-    - HBM Write and Atomic:
-        avg: SUM(TCC_EA0_WRREQ_WRITE_DRAM_sum) / SUM($denom)
-        min: MIN((TCC_EA0_WRREQ_WRITE_DRAM_sum / $denom))
-        max: MAX((TCC_EA0_WRREQ_WRITE_DRAM_sum / $denom))
 - Panel Config:
     id: 1800
   metric_table:

--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx950/1700_l2_cache.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx950/1700_l2_cache.yaml
@@ -362,16 +362,6 @@ Panel Config:
           min: MIN((TCC_EA0_RD_UNCACHED_32B_sum / $denom))
           max: MAX((TCC_EA0_RD_UNCACHED_32B_sum / $denom))
           unit: (Req + $normUnit)
-        HBM Read:
-          avg: SUM(TCC_EA0_RDREQ_DRAM_sum) / SUM($denom)
-          min: MIN((TCC_EA0_RDREQ_DRAM_sum / $denom))
-          max: MAX((TCC_EA0_RDREQ_DRAM_sum / $denom))
-          unit: (Req + $normUnit)
-        Remote Read:
-          avg: SUM(NOISE_CLAMP(TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_DRAM_sum, TCC_EA0_RDREQ_sum)) / SUM($denom)
-          min: MIN((NOISE_CLAMP((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_DRAM_sum), TCC_EA0_RDREQ_sum) / $denom))
-          max: MAX((NOISE_CLAMP((TCC_EA0_RDREQ_sum - TCC_EA0_RDREQ_DRAM_sum), TCC_EA0_RDREQ_sum) / $denom))
-          unit: (Req + $normUnit)
         Read Bandwidth - PCIe:
           avg: SUM(TCC_EA0_RDREQ_IO_32B_sum * 32) / SUM(End_Timestamp - Start_Timestamp)
           min: MIN(TCC_EA0_RDREQ_IO_32B_sum * 32/ (End_Timestamp - Start_Timestamp))
@@ -402,16 +392,6 @@ Panel Config:
           min: MIN((TCC_EA0_WRREQ_64B_sum / $denom))
           max: MAX((TCC_EA0_WRREQ_64B_sum / $denom))
           unit: (Req + $normUnit)
-        HBM Write and Atomic:
-          avg: SUM(TCC_EA0_WRREQ_WRITE_DRAM_sum) / SUM($denom)
-          min: MIN((TCC_EA0_WRREQ_WRITE_DRAM_sum / $denom))
-          max: MAX((TCC_EA0_WRREQ_WRITE_DRAM_sum / $denom))
-          unit: (Req + $normUnit)
-        Remote Write and Atomic:
-          avg: SUM(NOISE_CLAMP(TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_DRAM_sum, TCC_EA0_WRREQ_sum)) / SUM($denom)
-          min: MIN((NOISE_CLAMP((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_DRAM_sum), TCC_EA0_WRREQ_sum) / $denom))
-          max: MAX((NOISE_CLAMP((TCC_EA0_WRREQ_sum - TCC_EA0_WRREQ_DRAM_sum), TCC_EA0_WRREQ_sum) / $denom))
-          unit: (Req + $normUnit)
         Write Bandwidth - PCIe:
           avg: SUM(TCC_EA0_WRREQ_WRITE_IO_32B_sum * 32) / SUM(End_Timestamp - Start_Timestamp)
           min: MIN(TCC_EA0_WRREQ_WRITE_IO_32B_sum * 32/ (End_Timestamp - Start_Timestamp))
@@ -431,11 +411,6 @@ Panel Config:
           avg: SUM(TCC_EA0_ATOMIC_sum) / SUM($denom)
           min: MIN((TCC_EA0_ATOMIC_sum / $denom))
           max: MAX((TCC_EA0_ATOMIC_sum / $denom))
-          unit: (Req + $normUnit)
-        Atomic - HBM:
-          avg: SUM(TCC_EA0_WRREQ_ATOMIC_DRAM_sum) / SUM($denom)
-          min: MIN((TCC_EA0_WRREQ_ATOMIC_DRAM_sum / $denom))
-          max: MAX((TCC_EA0_WRREQ_ATOMIC_DRAM_sum / $denom))
           unit: (Req + $normUnit)
         Atomic Bandwidth - PCIe:
           avg: SUM(TCC_EA0_WRREQ_ATOMIC_IO_32B_sum * 32) / SUM(End_Timestamp - Start_Timestamp)
@@ -603,11 +578,6 @@ Panel Config:
     Read (Uncached): The total number of L2 requests to Infinity Fabric to read uncached
       data from any memory location, per normalization unit. 64B requests for uncached
       data are counted as two 32B uncached data requests.
-    HBM Read: The total number of L2 requests to Infinity Fabric to read 32B or 64B
-      of data from the accelerator's local HBM, per normalization unit.
-    Remote Read: The total number of L2 requests to Infinity Fabric to read 32B or
-      64B of data from any source other than the accelerator's local HBM, per normalization
-      unit.
     Read Bandwidth - PCIe: Total number of bytes due to L2 read requests due to PCIe
       traffic, divided by total duration.
     "Read Bandwidth - Infinity Fabric\u2122": Total number of bytes due to L2 read
@@ -623,12 +593,6 @@ Panel Config:
     Write and Atomic (64B): The total number of L2 requests to Infinity Fabric to
       write or atomically update 64B of data in any memory location, per normalization
       unit.
-    HBM Write and Atomic: The total number of L2 requests to Infinity Fabric to write
-      or atomically update 32B or 64B of data in the accelerator's local HBM, per
-      normalization unit.
-    Remote Write and Atomic: The total number of L2 requests to Infinity Fabric to
-      write or atomically update 32B or 64B of data in any memory location other than
-      the accelerator's local HBM, per normalization unit.
     Write Bandwidth - PCIe: Total number of bytes due to L2 write requests due to
       PCIe traffic, divided by total duration.
     "Write Bandwidth - Infinity Fabric\u2122": Total number of bytes due to L2 write
@@ -641,9 +605,6 @@ Panel Config:
       requests due to Infinity Fabric traffic, divided by total duration.
     Atomic Bandwidth - HBM: Total number of bytes due to L2 atomic requests due to
       HBM traffic, divided by total duration.
-    Atomic - HBM: The total number of L2 atomic requests (either 32-byte or 64-byte)
-      destined for the accelerator's local high-bandwidth memory (HBM), per normalization
-      unit. These are read-modify-write operations that update memory atomically.
     Atomic: The total number of L2 requests to Infinity Fabric to atomically update
       32B or 64B of data in any memory location, per normalization unit. See Request
       flow for more detail. Note that on current CDNA accelerators, such as the MI2XX,

--- a/projects/rocprofiler-compute/src/utils/.config_hashes.json
+++ b/projects/rocprofiler-compute/src/utils/.config_hashes.json
@@ -19,7 +19,7 @@
       }
     },
     "gfx908": {
-      "delta_hash": "8b027c53f003dd0ee213076fe99b74fa",
+      "delta_hash": "717eaf8b9a69c4188d4d8e987ab77150",
       "files": {
         "0000_top_stats.yaml": "2819d96f5b1c3704f2ac50868a246a7f",
         "0100_system_info.yaml": "cefae2b10db8cf4b0d3a971cff5e82c8",
@@ -42,7 +42,7 @@
       }
     },
     "gfx90a": {
-      "delta_hash": "4edabbe9c22dcae6e986b2d2a8b8759c",
+      "delta_hash": "492b38d6dc43d49a5d670aad7cbd4ac4",
       "files": {
         "0000_top_stats.yaml": "2819d96f5b1c3704f2ac50868a246a7f",
         "0100_system_info.yaml": "cefae2b10db8cf4b0d3a971cff5e82c8",
@@ -65,7 +65,7 @@
       }
     },
     "gfx940": {
-      "delta_hash": "6797e71567bdea7697dbc1d737f4b988",
+      "delta_hash": "02930479942fc671e662f9bfc38c6d5f",
       "files": {
         "0000_top_stats.yaml": "2819d96f5b1c3704f2ac50868a246a7f",
         "0100_system_info.yaml": "cefae2b10db8cf4b0d3a971cff5e82c8",
@@ -88,7 +88,7 @@
       }
     },
     "gfx941": {
-      "delta_hash": "1d9c4c8765658a7095c631ff7cdb5727",
+      "delta_hash": "1b7a2bf07a9fde6f08fd0db3dcf85294",
       "files": {
         "0000_top_stats.yaml": "2819d96f5b1c3704f2ac50868a246a7f",
         "0100_system_info.yaml": "cefae2b10db8cf4b0d3a971cff5e82c8",
@@ -111,7 +111,7 @@
       }
     },
     "gfx942": {
-      "delta_hash": "3ffe80b9da144d9585090014053ddf4d",
+      "delta_hash": "0dfe03a35d4dd7e87881799737fa9d4c",
       "files": {
         "0000_top_stats.yaml": "2819d96f5b1c3704f2ac50868a246a7f",
         "0100_system_info.yaml": "cefae2b10db8cf4b0d3a971cff5e82c8",
@@ -151,7 +151,7 @@
         "1400_scalar_l1_data_cache.yaml": "9358238e7adc61c0da89323626eb01c6",
         "1500_address_processing_unit_and_data_return_path_ta_td.yaml": "7d6d8cfd60256877f20d78e037c5ddad",
         "1600_vector_l1_data_cache.yaml": "fb29fd502f3937daeec4dfd4a2434ead",
-        "1700_l2_cache.yaml": "4a798cde1e58f0b0d337197d36eec1fb",
+        "1700_l2_cache.yaml": "36e6e8c68673b7ab0dc32337ffa30a4d",
         "1800_l2_cache_per_channel.yaml": "0d2447fc336fc797a4bb38ef95688afb",
         "2100_pc_sampling.yaml": "8049866f25214544f1e53a9e2f08399b",
         "3000_mem_bw.yaml": "bdc167a85a3bffd439fb4d651b3c2df8"

--- a/projects/rocprofiler-compute/tools/per_arch_metric_definitions/gfx950_metrics_description.yaml
+++ b/projects/rocprofiler-compute/tools/per_arch_metric_definitions/gfx950_metrics_description.yaml
@@ -1307,14 +1307,6 @@ L2 - Fabric interface detailed metrics:
     plain: The total number of L2 requests to Infinity Fabric to read uncached data from any memory location, per normalization unit. 64B requests for uncached data are counted as two 32B uncached data requests.
     rst: The total number of L2 requests to Infinity Fabric to read :ref:`uncached data <memory-type>` from any memory location, per :ref:`normalization unit <normalization-units>`. 64B requests for uncached data are counted as two 32B uncached data requests. See :ref:`l2-request-flow` for more detail.
     unit: Req per Normalization Unit
-  HBM Read:
-    plain: The total number of L2 requests to Infinity Fabric to read 32B or 64B of data from the accelerator's local HBM, per normalization unit.
-    rst: The total number of L2 requests to Infinity Fabric to read 32B or 64B of data from the accelerator's local HBM, per :ref:`normalization unit <normalization-units>`. See :ref:`l2-request-flow` for more detail.
-    unit: Req per Normalization Unit
-  Remote Read:
-    plain: The total number of L2 requests to Infinity Fabric to read 32B or 64B of data from any source other than the accelerator's local HBM, per normalization unit.
-    rst: The total number of L2 requests to Infinity Fabric to read 32B or 64B of data from any source other than the accelerator's local HBM, per :ref:`normalization unit <normalization-units>`. See :ref:`l2-request-flow` for more detail.
-    unit: Req per Normalization Unit
   Read Bandwidth - PCIe:
     plain: Total number of bytes due to L2 read requests due to PCIe traffic, divided by total duration.
     rst: Total number of bytes due to L2 read requests due to PCIe traffic, divided by total duration.
@@ -1338,14 +1330,6 @@ L2 - Fabric interface detailed metrics:
   Write and Atomic (64B):
     plain: The total number of L2 requests to Infinity Fabric to write or atomically update 64B of data in any memory location, per normalization unit.
     rst: The total number of L2 requests to Infinity Fabric to write or atomically update 64B of data in any memory location, per :ref:`normalization unit <normalization-units>`. See :ref:`l2-request-flow` for more detail.
-    unit: Req per Normalization Unit
-  HBM Write and Atomic:
-    plain: The total number of L2 requests to Infinity Fabric to write or atomically update 32B or 64B of data in the accelerator's local HBM, per normalization unit.
-    rst: The total number of L2 requests to Infinity Fabric to write or atomically update 32B or 64B of data in the accelerator's local HBM, per :ref:`normalization unit <normalization-units>`. See :ref:`l2-request-flow` for more detail. plain
-    unit: Req per Normalization Unit
-  Remote Write and Atomic:
-    plain: The total number of L2 requests to Infinity Fabric to write or atomically update 32B or 64B of data in any memory location other than the accelerator's local HBM, per normalization unit.
-    rst: The total number of L2 requests to Infinity Fabric to write or atomically update 32B or 64B of data in any memory location other than the accelerator's local HBM, per :ref:`normalization unit <normalization-units>`. See :ref:`l2-request-flow` for more detail.
     unit: Req per Normalization Unit
   Write Bandwidth - PCIe:
     plain: Total number of bytes due to L2 write requests due to PCIe traffic, divided by total duration.
@@ -1371,11 +1355,27 @@ L2 - Fabric interface detailed metrics:
     plain: Total number of bytes due to L2 atomic requests due to HBM traffic, divided by total duration.
     rst: Total number of bytes due to L2 atomic requests due to HBM traffic, divided by total duration.
     unit: Gbps
-  Atomic - HBM:
-    plain: The total number of L2 atomic requests (either 32-byte or 64-byte) destined for the accelerator's local high-bandwidth memory (HBM), per normalization unit. These are read-modify-write operations that update memory atomically.
-    rst: The total number of L2 atomic requests (either 32-byte or 64-byte) destined for the accelerator's local high-bandwidth memory (HBM), per normalization unit. These are read-modify-write operations that update memory atomically.
-    unit: Req per Normalization Unit
   Atomic:
     plain: The total number of L2 requests to Infinity Fabric to atomically update 32B or 64B of data in any memory location, per normalization unit. See Request flow for more detail. Note that on current CDNA accelerators, such as the MI2XX, requests are only considered atomic by Infinity Fabric if they are targeted at non-write-cacheable memory, such as fine-grained memory allocations or uncached memory allocations on the MI2XX.
     rst: The total number of L2 requests to Infinity Fabric to atomically update 32B or 64B of data in any memory location, per :ref:`normalization unit <normalization-units>`. See :ref:`l2-request-flow` for more detail. Note that on current CDNA accelerators, such as the :ref:`MI2XX <mixxx-note>`, requests are only considered *atomic* by Infinity Fabric if they are targeted at non-write-cacheable memory, such as :ref:`fine-grained memory <memory-type>` allocations or :ref:`uncached memory <memory-type>` allocations on the MI2XX.
+    unit: Req per Normalization Unit
+  HBM Read:
+    plain: The total number of L2 requests to Infinity Fabric to read 32B or 64B of data from the accelerator's local HBM, per normalization unit.
+    rst: The total number of L2 requests to Infinity Fabric to read 32B or 64B of data from the accelerator's local HBM, per :ref:`normalization unit <normalization-units>`. See :ref:`l2-request-flow` for more detail.
+    unit: Req per Normalization Unit
+  Remote Read:
+    plain: The total number of L2 requests to Infinity Fabric to read 32B or 64B of data from any source other than the accelerator's local HBM, per normalization unit.
+    rst: The total number of L2 requests to Infinity Fabric to read 32B or 64B of data from any source other than the accelerator's local HBM, per :ref:`normalization unit <normalization-units>`. See :ref:`l2-request-flow` for more detail.
+    unit: Req per Normalization Unit
+  HBM Write and Atomic:
+    plain: The total number of L2 requests to Infinity Fabric to write or atomically update 32B or 64B of data in the accelerator's local HBM, per normalization unit.
+    rst: The total number of L2 requests to Infinity Fabric to write or atomically update 32B or 64B of data in the accelerator's local HBM, per :ref:`normalization unit <normalization-units>`. See :ref:`l2-request-flow` for more detail. plain
+    unit: Req per Normalization Unit
+  Remote Write and Atomic:
+    plain: The total number of L2 requests to Infinity Fabric to write or atomically update 32B or 64B of data in any memory location other than the accelerator's local HBM, per normalization unit.
+    rst: The total number of L2 requests to Infinity Fabric to write or atomically update 32B or 64B of data in any memory location other than the accelerator's local HBM, per :ref:`normalization unit <normalization-units>`. See :ref:`l2-request-flow` for more detail.
+    unit: Req per Normalization Unit
+  Atomic - HBM:
+    plain: The total number of L2 atomic requests (either 32-byte or 64-byte) destined for the accelerator's local high-bandwidth memory (HBM), per normalization unit. These are read-modify-write operations that update memory atomically.
+    rst: The total number of L2 atomic requests (either 32-byte or 64-byte) destined for the accelerator's local high-bandwidth memory (HBM), per normalization unit. These are read-modify-write operations that update memory atomically.
     unit: Req per Normalization Unit

--- a/projects/rocprofiler-compute/tools/per_arch_metric_definitions/gfx950_metrics_description.yaml
+++ b/projects/rocprofiler-compute/tools/per_arch_metric_definitions/gfx950_metrics_description.yaml
@@ -1359,23 +1359,3 @@ L2 - Fabric interface detailed metrics:
     plain: The total number of L2 requests to Infinity Fabric to atomically update 32B or 64B of data in any memory location, per normalization unit. See Request flow for more detail. Note that on current CDNA accelerators, such as the MI2XX, requests are only considered atomic by Infinity Fabric if they are targeted at non-write-cacheable memory, such as fine-grained memory allocations or uncached memory allocations on the MI2XX.
     rst: The total number of L2 requests to Infinity Fabric to atomically update 32B or 64B of data in any memory location, per :ref:`normalization unit <normalization-units>`. See :ref:`l2-request-flow` for more detail. Note that on current CDNA accelerators, such as the :ref:`MI2XX <mixxx-note>`, requests are only considered *atomic* by Infinity Fabric if they are targeted at non-write-cacheable memory, such as :ref:`fine-grained memory <memory-type>` allocations or :ref:`uncached memory <memory-type>` allocations on the MI2XX.
     unit: Req per Normalization Unit
-  HBM Read:
-    plain: The total number of L2 requests to Infinity Fabric to read 32B or 64B of data from the accelerator's local HBM, per normalization unit.
-    rst: The total number of L2 requests to Infinity Fabric to read 32B or 64B of data from the accelerator's local HBM, per :ref:`normalization unit <normalization-units>`. See :ref:`l2-request-flow` for more detail.
-    unit: Req per Normalization Unit
-  Remote Read:
-    plain: The total number of L2 requests to Infinity Fabric to read 32B or 64B of data from any source other than the accelerator's local HBM, per normalization unit.
-    rst: The total number of L2 requests to Infinity Fabric to read 32B or 64B of data from any source other than the accelerator's local HBM, per :ref:`normalization unit <normalization-units>`. See :ref:`l2-request-flow` for more detail.
-    unit: Req per Normalization Unit
-  HBM Write and Atomic:
-    plain: The total number of L2 requests to Infinity Fabric to write or atomically update 32B or 64B of data in the accelerator's local HBM, per normalization unit.
-    rst: The total number of L2 requests to Infinity Fabric to write or atomically update 32B or 64B of data in the accelerator's local HBM, per :ref:`normalization unit <normalization-units>`. See :ref:`l2-request-flow` for more detail. plain
-    unit: Req per Normalization Unit
-  Remote Write and Atomic:
-    plain: The total number of L2 requests to Infinity Fabric to write or atomically update 32B or 64B of data in any memory location other than the accelerator's local HBM, per normalization unit.
-    rst: The total number of L2 requests to Infinity Fabric to write or atomically update 32B or 64B of data in any memory location other than the accelerator's local HBM, per :ref:`normalization unit <normalization-units>`. See :ref:`l2-request-flow` for more detail.
-    unit: Req per Normalization Unit
-  Atomic - HBM:
-    plain: The total number of L2 atomic requests (either 32-byte or 64-byte) destined for the accelerator's local high-bandwidth memory (HBM), per normalization unit. These are read-modify-write operations that update memory atomically.
-    rst: The total number of L2 atomic requests (either 32-byte or 64-byte) destined for the accelerator's local high-bandwidth memory (HBM), per normalization unit. These are read-modify-write operations that update memory atomically.
-    unit: Req per Normalization Unit


### PR DESCRIPTION
## Motivation

Remove misleading gfx950 L2-Fabric request-count metrics now that gfx950 has bandwidth counters for HBM/PCIe/xGMI traffic.

## Technical Details

Removed the following metrics from gfx950 table `17.6` (`L2 - Fabric interface detailed metrics`):

- `HBM Read`
- `Remote Read`
- `HBM Write and Atomic`
- `Remote Write and Atomic`
- `Atomic - HBM`

Kept the gfx950 bandwidth alternatives in the same table, including `Read Bandwidth - HBM`, `Write Bandwidth - HBM`, and `Atomic Bandwidth - HBM`. I regenerated the gfx9 deltas, gfx950 metric docs, and config hashes and other CDNA arches are unchanged.

## JIRA ID

ROCM-21224

## Test Plan

Ran config validation, hash validation, targeted unit tests, and `--list-metrics` checks for gfx950 and gfx942

## Test Result

- `master_config_workflow_script.py --validate-only` passed
- `master_config_workflow_script.py --hash-only` passed
- `pytest tests/test_autogen_config.py tests/test_mem_chart.py tests/test_metric_utils.py -q` `109 passed`
- Verified gfx950 no longer lists the removed `17.6` metrics and gfx942 still lists its request metrics

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.