### PR TITLE
[amdsmi] Add --sort-by-pid flag and amdsmi_get_gpu_process_list_by_pid() API

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -13,6 +13,12 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 ### Added
 
+- **Added `--sort-by-pid` flag and `amdsmi_get_gpu_process_list_by_pid()` API**.
+  - New C API `amdsmi_get_gpu_process_list_by_pid()` aggregates process info across all GPUs and returns results keyed by PID, with per-GPU breakdowns for memory, engine usage, and occupancy.
+  - New structs: `amdsmi_proc_gpu_entry_t`, `amdsmi_proc_info_by_pid_t`.
+  - New `--sort-by-pid` CLI flag for `amd-smi process` and `amd-smi monitor --process` groups output by PID instead of GPU.
+  - New Python interface function `amdsmi_get_gpu_process_list_by_pid()`.
+
 - **Added APU metrics support (table versions 2.4 and 3.0)**.  
   - New `amdsmi_apu_metrics_t` struct accessible via `amdsmi_gpu_metrics_t.apu_metrics` pointer (non-null when APU-specific metrics are available).
   - **v2.4 metrics**:

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -6536,8 +6536,27 @@ class AMDSMICommands:
                     self.logger.store_multiple_device_output()
             self.logger.print_output(multiple_device_enabled=True, watching_output=watching_output)
 
+    def _write_via_logger_destination(self, text):
+        """Write text to the logger's destination (stdout or output file).
+
+        Used for content that does not fit the logger's structured output path
+        but must still honor --file redirection.
+        """
+        if self.logger.destination == "stdout":
+            print(text)
+        else:
+            with self.logger.destination.open("a", encoding="utf-8") as f:
+                f.write(text + "\n")
+
     def _monitor_inject_sort_by_pid(self, args, watching_output):
-        """Inject PID-grouped process table into monitor's multiple_device_output."""
+        """Render PID-grouped process info for monitor --process --sort-by-pid.
+
+        For JSON/CSV the rows are pushed into the logger's multiple_device_output
+        so they flow through print_output() like every other monitor row. For
+        human-readable output an ASCII table is stored in
+        self._sort_by_pid_secondary_table; the caller is responsible for writing
+        it via _write_via_logger_destination after the primary table.
+        """
         handles = args.gpu if isinstance(args.gpu, list) else [args.gpu]
         try:
             pid_list = amdsmi_interface.amdsmi_get_gpu_process_list_by_pid(handles)
@@ -6545,17 +6564,17 @@ class AMDSMICommands:
             logging.debug("Failed to get process list by pid | %s", e.get_error_info())
             return
 
-        # Build process_list entries in the same format the tabular renderer expects.
-        # Each entry: {"process_info": {"name":..,"pid":..,"memory_usage":..,"mem_usage":..,...}}
-        # The renderer reads "gpu" from the outer dict for the GPU column.
-        # For PID-grouped output we emit one row per PID+GPU combination,
-        # grouped so all GPUs for a PID appear together.
+        # Unit string constants — hoisted out of the loop (style cleanup)
+        memory_usage_unit_default = "B"
+        evicted_time_unit = "ms"
+        sdma_usage_unit = "us"
+
+        # Build one entry per PID+GPU combination, grouped so all GPUs for a PID
+        # appear together.
         filtered = []
         for proc in pid_list:
             for gpu_entry in proc["gpus"]:
-                memory_usage_unit = "B"
-                evicted_time_unit = "ms"
-                sdma_usage_unit = "us"
+                memory_usage_unit = memory_usage_unit_default
 
                 mem_usage = gpu_entry["mem"]
                 mem_dict = {
@@ -6607,10 +6626,36 @@ class AMDSMICommands:
         if not filtered:
             filtered.append({"gpu_index": "N/A", "process_info": "No running processes detected"})
 
-        # The tabular renderer is GPU-centric — it reads the GPU column from the
-        # outer dict, so distributing per-GPU would give GPU-sorted output (same as
-        # default). Instead, render the PID-grouped secondary table directly and
-        # store it for printing after the primary table.
+        # JSON / CSV: push rows into the logger's multiple_device_output so they
+        # flow through print_output() — never write a raw ASCII tail that would
+        # corrupt structured output.
+        if self.logger.is_json_format() or self.logger.is_csv_format():
+            for item in filtered:
+                info = item["process_info"]
+                if isinstance(info, str):
+                    row = {"gpu_index": item["gpu_index"], "message": info}
+                else:
+                    row = {
+                        "gpu_index": item["gpu_index"],
+                        "pid": info["pid"],
+                        "name": info["name"],
+                        "mem_usage": info.get("mem_usage", "N/A"),
+                        "cu_occupancy": info.get("cu_occupancy", "N/A"),
+                        "sdma_usage": info.get("sdma_usage", "N/A"),
+                        "evicted_time": info.get("evicted_time", "N/A"),
+                    }
+                    mu = info.get("memory_usage", {})
+                    if isinstance(mu, dict):
+                        if self.logger.is_csv_format():
+                            row.update(self.logger.flatten_dict(mu))
+                        else:
+                            row["memory_usage"] = mu
+                self.logger.output = row
+                self.logger.store_multiple_device_output()
+            return
+
+        # Human-readable: build the ASCII secondary table; the caller writes it
+        # via _write_via_logger_destination after print_output().
         header = (
             "\nPROCESS INFO (grouped by PID):\n"
             + "GPU".rjust(3)
@@ -6644,8 +6689,6 @@ class AMDSMICommands:
             row += str(info.get("evicted_time", "N/A")).rjust(8)
             rows.append(row)
 
-        # Store the rendered table — the monitor caller will print it
-        # after the primary table by checking this attribute.
         self._sort_by_pid_secondary_table = header + "\n" + "\n".join(rows)
 
     def profile(self, args):
@@ -10564,33 +10607,35 @@ class AMDSMICommands:
                 for gpu in args.gpu:
                     stored_gpus.append(gpu)
 
-                # When --sort-by-pid, suppress per-GPU process collection
+                # When --sort-by-pid, suppress per-GPU process collection in the
+                # recursive monitor() calls. Use an instance attribute so args is
+                # not mutated (exception-safe with try/finally).
                 sort_by_pid = getattr(args, "sort_by_pid", False) and args.process
-                if sort_by_pid:
-                    args.process = False
+                self._monitor_suppress_process_collection = sort_by_pid
 
-                # Store output from multiple devices without printing to console
-                for device_handle in args.gpu:
-                    self.monitor(
-                        args,
-                        multiple_devices=True,
-                        watching_output=watching_output,
-                        gpu=device_handle,
-                    )
+                try:
+                    # Store output from multiple devices without printing to console
+                    for device_handle in args.gpu:
+                        self.monitor(
+                            args,
+                            multiple_devices=True,
+                            watching_output=watching_output,
+                            gpu=device_handle,
+                        )
+                finally:
+                    self._monitor_suppress_process_collection = False
 
                 # Reload original gpus
                 args.gpu = stored_gpus
-
-                # Restore args.process if we suppressed it
-                if sort_by_pid:
-                    args.process = True
 
                 dual_csv_output = False
                 if args.process:
                     if self.logger.is_csv_format():
                         dual_csv_output = True
 
-                # When --sort-by-pid, build the PID-grouped secondary table
+                # When --sort-by-pid, route PID-grouped data through the logger:
+                #   - JSON/CSV: rows appended to multiple_device_output
+                #   - human-readable: ASCII table stored in _sort_by_pid_secondary_table
                 if sort_by_pid:
                     self._sort_by_pid_secondary_table = None
                     self._monitor_inject_sort_by_pid(args, watching_output)
@@ -10603,9 +10648,10 @@ class AMDSMICommands:
                     dual_csv_output=dual_csv_output,
                 )
 
-                # Print PID-grouped secondary table after the primary table
+                # Human-readable PID-grouped table: route via logger destination
+                # so --file redirection is honored (only populated in HR mode).
                 if sort_by_pid and self._sort_by_pid_secondary_table:
-                    print(self._sort_by_pid_secondary_table)
+                    self._write_via_logger_destination(self._sort_by_pid_secondary_table)
 
                 # Add output to total watch output and clear multiple device output
                 if watching_output:
@@ -11170,7 +11216,10 @@ class AMDSMICommands:
         dual_csv_output = False
 
         # Store process list separately
-        if args.process:
+        # _monitor_suppress_process_collection is set by the multi-GPU dispatcher
+        # when --sort-by-pid is active; per-GPU collection is replaced by the
+        # PID-grouped aggregation rendered after the loop.
+        if args.process and not getattr(self, "_monitor_suppress_process_collection", False):
             # Populate initial processes
             try:
                 process_list = amdsmi_interface.amdsmi_get_gpu_process_list(args.gpu)

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -6226,7 +6226,7 @@ class AMDSMICommands:
             return
 
         # Handle --sort-by-pid: group process output by PID across all GPUs
-        if getattr(args, 'sort_by_pid', False):
+        if getattr(args, "sort_by_pid", False):
             handles = args.gpu if isinstance(args.gpu, list) else [args.gpu]
             self._process_sort_by_pid(args, handles, watching_output)
             return
@@ -6436,13 +6436,12 @@ class AMDSMICommands:
             raise e
 
         # Apply --pid filter
-        if getattr(args, 'pid', None):
+        if getattr(args, "pid", None):
             pid_list = [p for p in pid_list if p["pid"] == args.pid]
 
         # Apply --name filter
-        if getattr(args, 'name', None):
-            pid_list = [p for p in pid_list
-                        if p["name"].lower() == str(args.name).lower()]
+        if getattr(args, "name", None):
+            pid_list = [p for p in pid_list if p["name"].lower() == str(args.name).lower()]
 
         engine_usage_unit = "ns"
         memory_usage_unit = "B"
@@ -6454,14 +6453,12 @@ class AMDSMICommands:
                 if self.logger.is_human_readable_format():
                     gpu_entry["mem"] = self.helpers.convert_bytes_to_readable(gpu_entry["mem"])
                     for key in ("gtt_mem", "cpu_mem", "vram_mem"):
-                        gpu_entry["memory_usage"][key] = (
-                            self.helpers.convert_bytes_to_readable(gpu_entry["memory_usage"][key])
+                        gpu_entry["memory_usage"][key] = self.helpers.convert_bytes_to_readable(
+                            gpu_entry["memory_usage"][key]
                         )
 
                 mem_unit = "" if self.logger.is_human_readable_format() else memory_usage_unit
-                gpu_entry["mem"] = self.helpers.unit_format(
-                    self.logger, gpu_entry["mem"], mem_unit
-                )
+                gpu_entry["mem"] = self.helpers.unit_format(self.logger, gpu_entry["mem"], mem_unit)
                 gpu_entry["evicted_time"] = self.helpers.unit_format(
                     self.logger, gpu_entry["evicted_time"], evicted_time_unit
                 )
@@ -6478,8 +6475,14 @@ class AMDSMICommands:
                     )
 
         if not pid_list:
-            pid_list = [{"pid": "N/A", "name": "N/A", "gpus": [],
-                         "message": "No running processes detected"}]
+            pid_list = [
+                {
+                    "pid": "N/A",
+                    "name": "N/A",
+                    "gpus": [],
+                    "message": "No running processes detected",
+                }
+            ]
 
         if self.logger.is_json_format():
             for proc in pid_list:
@@ -6519,12 +6522,12 @@ class AMDSMICommands:
                     self.logger.output = {"gpu_entry": line}
                     self.logger.store_multiple_device_output()
 
-            self.logger.print_output(multiple_device_enabled=True,
-                                     watching_output=watching_output)
+            self.logger.print_output(multiple_device_enabled=True, watching_output=watching_output)
             if watching_output:
                 self.logger.store_watch_output(multiple_device_enabled=True)
-                self.logger.print_output(multiple_device_enabled=True,
-                                         watching_output=watching_output)
+                self.logger.print_output(
+                    multiple_device_enabled=True, watching_output=watching_output
+                )
             return
 
         if self.logger.is_csv_format():
@@ -6539,8 +6542,7 @@ class AMDSMICommands:
                     row["evicted_time"] = gpu_entry["evicted_time"]
                     self.logger.output = row
                     self.logger.store_multiple_device_output()
-            self.logger.print_output(multiple_device_enabled=True,
-                                     watching_output=watching_output)
+            self.logger.print_output(multiple_device_enabled=True, watching_output=watching_output)
 
     def _monitor_inject_sort_by_pid(self, args, watching_output):
         """Inject PID-grouped process table into monitor's multiple_device_output."""
@@ -6578,7 +6580,9 @@ class AMDSMICommands:
 
                 mem_usage = self.helpers.unit_format(self.logger, mem_usage, memory_usage_unit)
                 for k in mem_dict:
-                    mem_dict[k] = self.helpers.unit_format(self.logger, mem_dict[k], memory_usage_unit)
+                    mem_dict[k] = self.helpers.unit_format(
+                        self.logger, mem_dict[k], memory_usage_unit
+                    )
 
                 cu = gpu_entry["cu_occupancy"]
                 if cu == "N/A":
@@ -6590,8 +6594,12 @@ class AMDSMICommands:
                     sdma = self.helpers.convert_time_to_readable(gpu_entry["sdma_usage"], "us")
                     evict = self.helpers.convert_time_to_readable(gpu_entry["evicted_time"], "ms")
                 else:
-                    sdma = self.helpers.unit_format(self.logger, gpu_entry["sdma_usage"], sdma_usage_unit)
-                    evict = self.helpers.unit_format(self.logger, gpu_entry["evicted_time"], evicted_time_unit)
+                    sdma = self.helpers.unit_format(
+                        self.logger, gpu_entry["sdma_usage"], sdma_usage_unit
+                    )
+                    evict = self.helpers.unit_format(
+                        self.logger, gpu_entry["evicted_time"], evicted_time_unit
+                    )
 
                 info = {
                     "name": proc["name"],
@@ -6602,16 +6610,10 @@ class AMDSMICommands:
                     "sdma_usage": sdma,
                     "evicted_time": evict,
                 }
-                filtered.append({
-                    "gpu_index": gpu_entry["gpu_index"],
-                    "process_info": info,
-                })
+                filtered.append({"gpu_index": gpu_entry["gpu_index"], "process_info": info})
 
         if not filtered:
-            filtered.append({
-                "gpu_index": "N/A",
-                "process_info": "No running processes detected",
-            })
+            filtered.append({"gpu_index": "N/A", "process_info": "No running processes detected"})
 
         # Set secondary table header — same columns as normal but title indicates PID grouping
         self.logger.secondary_table_title = "PROCESS INFO (grouped by PID)"
@@ -10564,7 +10566,7 @@ class AMDSMICommands:
                     stored_gpus.append(gpu)
 
                 # When --sort-by-pid, suppress per-GPU process collection
-                sort_by_pid = getattr(args, 'sort_by_pid', False) and args.process
+                sort_by_pid = getattr(args, "sort_by_pid", False) and args.process
                 if sort_by_pid:
                     args.process = False
 

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -6492,22 +6492,20 @@ class AMDSMICommands:
             return
 
         if self.logger.is_human_readable_format():
+            lines = []
             for proc in pid_list:
                 if proc.get("message"):
-                    self.logger.output = {"process_info": proc["message"]}
-                    self.logger.store_multiple_device_output()
+                    lines.append(proc["message"])
                     continue
 
-                header = f"PID: {proc['pid']}  NAME: {proc['name']}"
-                self.logger.output = {"process_info": header}
-                self.logger.store_multiple_device_output()
-
+                lines.append(f"PID: {proc['pid']}  NAME: {proc['name']}")
                 for gpu_entry in proc["gpus"]:
                     gpu_idx = gpu_entry["gpu_index"]
                     parts = [f"GPU: {gpu_idx}"]
-                    mem_usage = gpu_entry.get("memory_usage", {})
                     if isinstance(gpu_entry["mem"], dict):
-                        parts.append(f"MEM: {gpu_entry['mem']['value']} {gpu_entry['mem']['unit']}")
+                        parts.append(
+                            f"MEM: {gpu_entry['mem']['value']} {gpu_entry['mem']['unit']}"
+                        )
                     else:
                         parts.append(f"MEM: {gpu_entry['mem']}")
                     eng = gpu_entry.get("engine_usage", {})
@@ -6517,17 +6515,13 @@ class AMDSMICommands:
                     else:
                         parts.append(f"GFX: {eng.get('gfx', 'N/A')}")
                         parts.append(f"ENC: {eng.get('enc', 'N/A')}")
+                    lines.append("    " + "  ".join(parts))
+                lines.append("")  # blank line between PIDs
 
-                    line = "    " + "  ".join(parts)
-                    self.logger.output = {"gpu_entry": line}
-                    self.logger.store_multiple_device_output()
+            print("\n".join(lines))
 
-            self.logger.print_output(multiple_device_enabled=True, watching_output=watching_output)
             if watching_output:
-                self.logger.store_watch_output(multiple_device_enabled=True)
-                self.logger.print_output(
-                    multiple_device_enabled=True, watching_output=watching_output
-                )
+                self.logger.store_watch_output(multiple_device_enabled=False)
             return
 
         if self.logger.is_csv_format():

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -6609,10 +6609,13 @@ class AMDSMICommands:
         if not filtered:
             filtered.append({"gpu_index": "N/A", "process_info": "No running processes detected"})
 
-        # Set secondary table header — same columns as normal but title indicates PID grouping
-        self.logger.secondary_table_title = "PROCESS INFO (grouped by PID)"
-        self.logger.secondary_table_header = (
-            "GPU".rjust(3)
+        # The tabular renderer is GPU-centric — it reads the GPU column from the
+        # outer dict, so distributing per-GPU would give GPU-sorted output (same as
+        # default). Instead, render the PID-grouped secondary table directly and
+        # store it for printing after the primary table.
+        header = (
+            "\nPROCESS INFO (grouped by PID):\n"
+            + "GPU".rjust(3)
             + "NAME".rjust(19)
             + "PID".rjust(9)
             + "GTT_MEM".rjust(10)
@@ -6623,25 +6626,29 @@ class AMDSMICommands:
             + "SDMA".rjust(8)
             + "EVICT".rjust(8)
         )
-        if watching_output:
-            self.logger.secondary_table_header = (
-                "TIMESTAMP".rjust(10) + "  " + self.logger.secondary_table_header
-            )
-
-        # The tabular renderer reads "gpu" from each device_output entry and uses
-        # it as the GPU column for every process row in that entry's process_list.
-        # So we must distribute process entries back to the correct GPU's entry.
-        pid_by_gpu = {}
+        rows = []
         for item in filtered:
-            gi = item["gpu_index"]
-            if gi not in pid_by_gpu:
-                pid_by_gpu[gi] = []
-            pid_by_gpu[gi].append({"process_info": item["process_info"]})
+            info = item["process_info"]
+            if isinstance(info, str):
+                rows.append("  " + info)
+                continue
+            name = str(info.get("name", "N/A")).split("/")[-1][:17]
+            row = str(item["gpu_index"]).rjust(3)
+            row += name.rjust(19)
+            row += str(info["pid"]).rjust(9)
+            mu = info.get("memory_usage", {})
+            row += str(mu.get("gtt_mem", "N/A")).rjust(10)
+            row += str(mu.get("cpu_mem", "N/A")).rjust(10)
+            row += str(mu.get("vram_mem", "N/A")).rjust(10)
+            row += str(info.get("mem_usage", "N/A")).rjust(10)
+            row += str(info.get("cu_occupancy", "N/A")).rjust(9)
+            row += str(info.get("sdma_usage", "N/A")).rjust(8)
+            row += str(info.get("evicted_time", "N/A")).rjust(8)
+            rows.append(row)
 
-        for entry in self.logger.multiple_device_output:
-            gpu = entry.get("gpu")
-            if gpu in pid_by_gpu:
-                entry["process_list"] = pid_by_gpu[gpu]
+        # Store the rendered table — the monitor caller will print it
+        # after the primary table by checking this attribute.
+        self._sort_by_pid_secondary_table = header + "\n" + "\n".join(rows)
 
     def profile(self, args):
         """Not applicable to linux baremetal"""
@@ -10585,8 +10592,9 @@ class AMDSMICommands:
                     if self.logger.is_csv_format():
                         dual_csv_output = True
 
-                # When --sort-by-pid, inject PID-grouped process table
+                # When --sort-by-pid, build the PID-grouped secondary table
                 if sort_by_pid:
+                    self._sort_by_pid_secondary_table = None
                     self._monitor_inject_sort_by_pid(args, watching_output)
 
                 # Flush the output
@@ -10596,6 +10604,10 @@ class AMDSMICommands:
                     tabular=True,
                     dual_csv_output=dual_csv_output,
                 )
+
+                # Print PID-grouped secondary table after the primary table
+                if sort_by_pid and self._sort_by_pid_secondary_table:
+                    print(self._sort_by_pid_secondary_table)
 
                 # Add output to total watch output and clear multiple device output
                 if watching_output:

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -6225,6 +6225,12 @@ class AMDSMICommands:
             self.helpers.handle_watch(args=args, subcommand=self.process, logger=self.logger)
             return
 
+        # Handle --sort-by-pid: group process output by PID across all GPUs
+        if getattr(args, 'sort_by_pid', False):
+            handles = args.gpu if isinstance(args.gpu, list) else [args.gpu]
+            self._process_sort_by_pid(args, handles, watching_output)
+            return
+
         # Handle multiple GPUs
         if isinstance(args.gpu, list):
             if len(args.gpu) > 1:
@@ -6420,6 +6426,226 @@ class AMDSMICommands:
 
         if watching_output:  # End of single gpu add to watch_output
             self.logger.store_watch_output(multiple_device_enabled=multiple_devices)
+
+    def _process_sort_by_pid(self, args, handles, watching_output):
+        """Process output grouped by PID instead of GPU."""
+        try:
+            pid_list = amdsmi_interface.amdsmi_get_gpu_process_list_by_pid(handles)
+        except amdsmi_exception.AmdSmiLibraryException as e:
+            logging.debug("Failed to get process list by pid | %s", e.get_error_info())
+            raise e
+
+        # Apply --pid filter
+        if getattr(args, 'pid', None):
+            pid_list = [p for p in pid_list if p["pid"] == args.pid]
+
+        # Apply --name filter
+        if getattr(args, 'name', None):
+            pid_list = [p for p in pid_list
+                        if p["name"].lower() == str(args.name).lower()]
+
+        engine_usage_unit = "ns"
+        memory_usage_unit = "B"
+        evicted_time_unit = "ms"
+        sdma_usage_unit = "us"
+
+        for proc in pid_list:
+            for gpu_entry in proc["gpus"]:
+                if self.logger.is_human_readable_format():
+                    gpu_entry["mem"] = self.helpers.convert_bytes_to_readable(gpu_entry["mem"])
+                    for key in ("gtt_mem", "cpu_mem", "vram_mem"):
+                        gpu_entry["memory_usage"][key] = (
+                            self.helpers.convert_bytes_to_readable(gpu_entry["memory_usage"][key])
+                        )
+
+                mem_unit = "" if self.logger.is_human_readable_format() else memory_usage_unit
+                gpu_entry["mem"] = self.helpers.unit_format(
+                    self.logger, gpu_entry["mem"], mem_unit
+                )
+                gpu_entry["evicted_time"] = self.helpers.unit_format(
+                    self.logger, gpu_entry["evicted_time"], evicted_time_unit
+                )
+                gpu_entry["sdma_usage"] = self.helpers.unit_format(
+                    self.logger, gpu_entry["sdma_usage"], sdma_usage_unit
+                )
+                for key in gpu_entry["engine_usage"]:
+                    gpu_entry["engine_usage"][key] = self.helpers.unit_format(
+                        self.logger, gpu_entry["engine_usage"][key], engine_usage_unit
+                    )
+                for key in gpu_entry["memory_usage"]:
+                    gpu_entry["memory_usage"][key] = self.helpers.unit_format(
+                        self.logger, gpu_entry["memory_usage"][key], mem_unit
+                    )
+
+        if not pid_list:
+            pid_list = [{"pid": "N/A", "name": "N/A", "gpus": [],
+                         "message": "No running processes detected"}]
+
+        if self.logger.is_json_format():
+            for proc in pid_list:
+                self.logger.output = proc
+                self.logger.store_multiple_device_output()
+            self.logger.print_output(multiple_device_enabled=True)
+            return
+
+        if self.logger.is_human_readable_format():
+            for proc in pid_list:
+                if proc.get("message"):
+                    self.logger.output = {"process_info": proc["message"]}
+                    self.logger.store_multiple_device_output()
+                    continue
+
+                header = f"PID: {proc['pid']}  NAME: {proc['name']}"
+                self.logger.output = {"process_info": header}
+                self.logger.store_multiple_device_output()
+
+                for gpu_entry in proc["gpus"]:
+                    gpu_idx = gpu_entry["gpu_index"]
+                    parts = [f"GPU: {gpu_idx}"]
+                    mem_usage = gpu_entry.get("memory_usage", {})
+                    if isinstance(gpu_entry["mem"], dict):
+                        parts.append(f"MEM: {gpu_entry['mem']['value']} {gpu_entry['mem']['unit']}")
+                    else:
+                        parts.append(f"MEM: {gpu_entry['mem']}")
+                    eng = gpu_entry.get("engine_usage", {})
+                    if isinstance(eng.get("gfx"), dict):
+                        parts.append(f"GFX: {eng['gfx']['value']} {eng['gfx']['unit']}")
+                        parts.append(f"ENC: {eng['enc']['value']} {eng['enc']['unit']}")
+                    else:
+                        parts.append(f"GFX: {eng.get('gfx', 'N/A')}")
+                        parts.append(f"ENC: {eng.get('enc', 'N/A')}")
+
+                    line = "    " + "  ".join(parts)
+                    self.logger.output = {"gpu_entry": line}
+                    self.logger.store_multiple_device_output()
+
+            self.logger.print_output(multiple_device_enabled=True,
+                                     watching_output=watching_output)
+            if watching_output:
+                self.logger.store_watch_output(multiple_device_enabled=True)
+                self.logger.print_output(multiple_device_enabled=True,
+                                         watching_output=watching_output)
+            return
+
+        if self.logger.is_csv_format():
+            for proc in pid_list:
+                for gpu_entry in proc["gpus"]:
+                    row = {"pid": proc["pid"], "name": proc["name"]}
+                    row["gpu_index"] = gpu_entry["gpu_index"]
+                    row.update(self.logger.flatten_dict(gpu_entry["memory_usage"]))
+                    row.update(self.logger.flatten_dict(gpu_entry["engine_usage"]))
+                    row["sdma_usage"] = gpu_entry["sdma_usage"]
+                    row["cu_occupancy"] = gpu_entry["cu_occupancy"]
+                    row["evicted_time"] = gpu_entry["evicted_time"]
+                    self.logger.output = row
+                    self.logger.store_multiple_device_output()
+            self.logger.print_output(multiple_device_enabled=True,
+                                     watching_output=watching_output)
+
+    def _monitor_inject_sort_by_pid(self, args, watching_output):
+        """Inject PID-grouped process table into monitor's multiple_device_output."""
+        handles = args.gpu if isinstance(args.gpu, list) else [args.gpu]
+        try:
+            pid_list = amdsmi_interface.amdsmi_get_gpu_process_list_by_pid(handles)
+        except amdsmi_exception.AmdSmiLibraryException as e:
+            logging.debug("Failed to get process list by pid | %s", e.get_error_info())
+            return
+
+        # Build process_list entries in the same format the tabular renderer expects.
+        # Each entry: {"process_info": {"name":..,"pid":..,"memory_usage":..,"mem_usage":..,...}}
+        # The renderer reads "gpu" from the outer dict for the GPU column.
+        # For PID-grouped output we emit one row per PID+GPU combination,
+        # grouped so all GPUs for a PID appear together.
+        filtered = []
+        for proc in pid_list:
+            for gpu_entry in proc["gpus"]:
+                memory_usage_unit = "B"
+                evicted_time_unit = "ms"
+                sdma_usage_unit = "us"
+
+                mem_usage = gpu_entry["mem"]
+                mem_dict = {
+                    "gtt_mem": gpu_entry["memory_usage"]["gtt_mem"],
+                    "cpu_mem": gpu_entry["memory_usage"]["cpu_mem"],
+                    "vram_mem": gpu_entry["memory_usage"]["vram_mem"],
+                }
+
+                if self.logger.is_human_readable_format():
+                    mem_usage = self.helpers.convert_bytes_to_readable(mem_usage)
+                    for k in mem_dict:
+                        mem_dict[k] = self.helpers.convert_bytes_to_readable(mem_dict[k])
+                    memory_usage_unit = ""
+
+                mem_usage = self.helpers.unit_format(self.logger, mem_usage, memory_usage_unit)
+                for k in mem_dict:
+                    mem_dict[k] = self.helpers.unit_format(self.logger, mem_dict[k], memory_usage_unit)
+
+                cu = gpu_entry["cu_occupancy"]
+                if cu == "N/A":
+                    cu_str = "N/A"
+                else:
+                    cu_str = self.helpers.unit_format(self.logger, cu, "")
+
+                if self.logger.is_human_readable_format():
+                    sdma = self.helpers.convert_time_to_readable(gpu_entry["sdma_usage"], "us")
+                    evict = self.helpers.convert_time_to_readable(gpu_entry["evicted_time"], "ms")
+                else:
+                    sdma = self.helpers.unit_format(self.logger, gpu_entry["sdma_usage"], sdma_usage_unit)
+                    evict = self.helpers.unit_format(self.logger, gpu_entry["evicted_time"], evicted_time_unit)
+
+                info = {
+                    "name": proc["name"],
+                    "pid": proc["pid"],
+                    "memory_usage": mem_dict,
+                    "mem_usage": mem_usage,
+                    "cu_occupancy": cu_str,
+                    "sdma_usage": sdma,
+                    "evicted_time": evict,
+                }
+                filtered.append({
+                    "gpu_index": gpu_entry["gpu_index"],
+                    "process_info": info,
+                })
+
+        if not filtered:
+            filtered.append({
+                "gpu_index": "N/A",
+                "process_info": "No running processes detected",
+            })
+
+        # Set secondary table header — same columns as normal but title indicates PID grouping
+        self.logger.secondary_table_title = "PROCESS INFO (grouped by PID)"
+        self.logger.secondary_table_header = (
+            "GPU".rjust(3)
+            + "NAME".rjust(19)
+            + "PID".rjust(9)
+            + "GTT_MEM".rjust(10)
+            + "CPU_MEM".rjust(10)
+            + "VRAM_MEM".rjust(10)
+            + "MEM_USG".rjust(10)
+            + "CU%".rjust(9)
+            + "SDMA".rjust(8)
+            + "EVICT".rjust(8)
+        )
+        if watching_output:
+            self.logger.secondary_table_header = (
+                "TIMESTAMP".rjust(10) + "  " + self.logger.secondary_table_header
+            )
+
+        # The tabular renderer reads "gpu" from each device_output entry and uses
+        # it as the GPU column for every process row in that entry's process_list.
+        # So we must distribute process entries back to the correct GPU's entry.
+        pid_by_gpu = {}
+        for item in filtered:
+            gi = item["gpu_index"]
+            if gi not in pid_by_gpu:
+                pid_by_gpu[gi] = []
+            pid_by_gpu[gi].append({"process_info": item["process_info"]})
+
+        for entry in self.logger.multiple_device_output:
+            gpu = entry.get("gpu")
+            if gpu in pid_by_gpu:
+                entry["process_list"] = pid_by_gpu[gpu]
 
     def profile(self, args):
         """Not applicable to linux baremetal"""
@@ -10337,6 +10563,11 @@ class AMDSMICommands:
                 for gpu in args.gpu:
                     stored_gpus.append(gpu)
 
+                # When --sort-by-pid, suppress per-GPU process collection
+                sort_by_pid = getattr(args, 'sort_by_pid', False) and args.process
+                if sort_by_pid:
+                    args.process = False
+
                 # Store output from multiple devices without printing to console
                 for device_handle in args.gpu:
                     self.monitor(
@@ -10349,10 +10580,18 @@ class AMDSMICommands:
                 # Reload original gpus
                 args.gpu = stored_gpus
 
+                # Restore args.process if we suppressed it
+                if sort_by_pid:
+                    args.process = True
+
                 dual_csv_output = False
                 if args.process:
                     if self.logger.is_csv_format():
                         dual_csv_output = True
+
+                # When --sort-by-pid, inject PID-grouped process table
+                if sort_by_pid:
+                    self._monitor_inject_sort_by_pid(args, watching_output)
 
                 # Flush the output
                 self.logger.print_output(

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -6503,9 +6503,7 @@ class AMDSMICommands:
                     gpu_idx = gpu_entry["gpu_index"]
                     parts = [f"GPU: {gpu_idx}"]
                     if isinstance(gpu_entry["mem"], dict):
-                        parts.append(
-                            f"MEM: {gpu_entry['mem']['value']} {gpu_entry['mem']['unit']}"
-                        )
+                        parts.append(f"MEM: {gpu_entry['mem']['value']} {gpu_entry['mem']['unit']}")
                     else:
                         parts.append(f"MEM: {gpu_entry['mem']}")
                     eng = gpu_entry.get("engine_usage", {})

--- a/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
@@ -1421,13 +1421,6 @@ class AMDSMIParser(argparse.ArgumentParser):
         command_modifier_group.add_argument(
             "--append", action="store_true", required=False, help="Append to the file"
         )
-        command_modifier_group.add_argument(
-            "--sort-by-pid",
-            action="store_true",
-            default=False,
-            help="Group process output by PID instead of GPU. "
-            "Applies to any command that shows process information.",
-        )
         # Placing loglevel outside the subcommands so it can be used with any subcommand
         command_modifier_group.add_argument(
             "--loglevel",
@@ -2275,6 +2268,13 @@ class AMDSMIParser(argparse.ArgumentParser):
             help=name_help,
         )
 
+        process_parser.add_argument(
+            "--sort-by-pid",
+            action="store_true",
+            default=False,
+            help="Group process output by PID instead of GPU.",
+        )
+
         # Add Universal Arguments & watch Args
         self._add_watch_arguments(process_parser)
         self._add_device_arguments(process_parser, required=False)
@@ -3078,6 +3078,13 @@ class AMDSMIParser(argparse.ArgumentParser):
             monitor_parser.add_argument(
                 "-V", "--violation", action="store_true", required=False, help=violation_help
             )
+
+        monitor_parser.add_argument(
+            "--sort-by-pid",
+            action="store_true",
+            default=False,
+            help="Group process output by PID instead of GPU. Only applies when --process is used.",
+        )
 
         # Add Universal Arguments & Watch Args
         self._add_watch_arguments(monitor_parser)

--- a/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
@@ -1421,6 +1421,13 @@ class AMDSMIParser(argparse.ArgumentParser):
         command_modifier_group.add_argument(
             "--append", action="store_true", required=False, help="Append to the file"
         )
+        command_modifier_group.add_argument(
+            '--sort-by-pid',
+            action='store_true',
+            default=False,
+            help='Group process output by PID instead of GPU. '
+                 'Applies to any command that shows process information.'
+        )
         # Placing loglevel outside the subcommands so it can be used with any subcommand
         command_modifier_group.add_argument(
             "--loglevel",

--- a/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
@@ -1422,11 +1422,11 @@ class AMDSMIParser(argparse.ArgumentParser):
             "--append", action="store_true", required=False, help="Append to the file"
         )
         command_modifier_group.add_argument(
-            '--sort-by-pid',
-            action='store_true',
+            "--sort-by-pid",
+            action="store_true",
             default=False,
-            help='Group process output by PID instead of GPU. '
-                 'Applies to any command that shows process information.'
+            help="Group process output by PID instead of GPU. "
+            "Applies to any command that shows process information.",
         )
         # Placing loglevel outside the subcommands so it can be used with any subcommand
         command_modifier_group.add_argument(

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -1387,6 +1387,44 @@ typedef struct {
 } amdsmi_proc_info_t;
 
 /**
+ * @brief Per-GPU process entry within a PID-grouped result.
+ *
+ * @cond @tag{gpu_bm_linux} @endcond
+ */
+typedef struct {
+  uint32_t gpu_index;                  //!< GPU index
+  uint64_t mem;                        //!< Total memory in bytes
+  struct {
+    uint64_t gfx;                      //!< GFX engine usage in nanoseconds
+    uint64_t enc;                      //!< ENC engine usage in nanoseconds
+    uint32_t reserved[12];
+  } engine_usage;
+  struct {
+    uint64_t gtt_mem;                  //!< GTT memory in bytes
+    uint64_t cpu_mem;                  //!< CPU memory in bytes
+    uint64_t vram_mem;                 //!< VRAM memory in bytes
+    uint32_t reserved[10];
+  } memory_usage;
+  uint32_t cu_occupancy;               //!< Number of CUs utilized
+  uint32_t evicted_time;               //!< Queue eviction time in milliseconds
+  uint64_t sdma_usage;                 //!< SDMA usage in microseconds
+  uint32_t reserved[8];
+} amdsmi_proc_gpu_entry_t;
+
+/**
+ * @brief Process info aggregated across all GPUs, keyed by PID.
+ *
+ * @cond @tag{gpu_bm_linux} @endcond
+ */
+typedef struct {
+  amdsmi_process_handle_t pid;
+  char name[AMDSMI_MAX_STRING_LENGTH];
+  char container_name[AMDSMI_MAX_STRING_LENGTH];
+  uint32_t num_gpus;                   //!< Number of GPU entries populated
+  amdsmi_proc_gpu_entry_t gpus[AMDSMI_MAX_DEVICES]; //!< Per-GPU data, num_gpus entries valid
+} amdsmi_proc_info_by_pid_t;
+
+/**
  * @brief IO Link P2P Capability
  *
  * @cond @tag{gpu_bm_linux} @tag{host} @endcond
@@ -7245,6 +7283,34 @@ amdsmi_status_t amdsmi_get_violation_status(amdsmi_processor_handle processor_ha
  */
 amdsmi_status_t amdsmi_get_gpu_process_list(amdsmi_processor_handle processor_handle,
                                             uint32_t* max_processes, amdsmi_proc_info_t* list);
+
+/**
+ *  @brief Get the list of processes running on one or more GPUs, grouped by PID.
+ *
+ *  @details Aggregates per-GPU process lists across all provided processor handles
+ *  and returns one entry per unique PID. Each entry contains the per-GPU breakdown
+ *  for every GPU that PID is active on. Results are sorted ascending by PID.
+ *
+ *  @ingroup tagProcessInfo
+ *
+ *  @platform{gpu_bm_linux}
+ *
+ *  @param[in]  processor_handles  Array of processor handles to query
+ *  @param[in]  num_processors     Number of handles in processor_handles
+ *  @param[out] list               Caller-allocated buffer of amdsmi_proc_info_by_pid_t.
+ *                                 Pass NULL to query the required size via max_processes.
+ *  @param[in,out] max_processes   On input: capacity of list. On output: number of
+ *                                 unique PIDs written (or required if list is NULL).
+ *
+ *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success,
+ *                            | ::AMDSMI_STATUS_OUT_OF_RESOURCES if max_processes was too small,
+ *                            | ::AMDSMI_STATUS_INVAL if processor_handles is NULL or num_processors is 0
+ */
+amdsmi_status_t amdsmi_get_gpu_process_list_by_pid(
+    amdsmi_processor_handle* processor_handles,
+    uint32_t num_processors,
+    amdsmi_proc_info_by_pid_t* list,
+    uint32_t* max_processes);
 
 /** @} End tagProcessInfo */
 

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -1392,22 +1392,22 @@ typedef struct {
  * @cond @tag{gpu_bm_linux} @endcond
  */
 typedef struct {
-  uint32_t gpu_index;                  //!< GPU index
-  uint64_t mem;                        //!< Total memory in bytes
+  uint32_t gpu_index;  //!< GPU index
+  uint64_t mem;        //!< Total memory in bytes
   struct {
-    uint64_t gfx;                      //!< GFX engine usage in nanoseconds
-    uint64_t enc;                      //!< ENC engine usage in nanoseconds
+    uint64_t gfx;  //!< GFX engine usage in nanoseconds
+    uint64_t enc;  //!< ENC engine usage in nanoseconds
     uint32_t reserved[12];
   } engine_usage;
   struct {
-    uint64_t gtt_mem;                  //!< GTT memory in bytes
-    uint64_t cpu_mem;                  //!< CPU memory in bytes
-    uint64_t vram_mem;                 //!< VRAM memory in bytes
+    uint64_t gtt_mem;   //!< GTT memory in bytes
+    uint64_t cpu_mem;   //!< CPU memory in bytes
+    uint64_t vram_mem;  //!< VRAM memory in bytes
     uint32_t reserved[10];
   } memory_usage;
-  uint32_t cu_occupancy;               //!< Number of CUs utilized
-  uint32_t evicted_time;               //!< Queue eviction time in milliseconds
-  uint64_t sdma_usage;                 //!< SDMA usage in microseconds
+  uint32_t cu_occupancy;  //!< Number of CUs utilized
+  uint32_t evicted_time;  //!< Queue eviction time in milliseconds
+  uint64_t sdma_usage;    //!< SDMA usage in microseconds
   uint32_t reserved[8];
 } amdsmi_proc_gpu_entry_t;
 
@@ -1420,8 +1420,8 @@ typedef struct {
   amdsmi_process_handle_t pid;
   char name[AMDSMI_MAX_STRING_LENGTH];
   char container_name[AMDSMI_MAX_STRING_LENGTH];
-  uint32_t num_gpus;                   //!< Number of GPU entries populated
-  amdsmi_proc_gpu_entry_t gpus[AMDSMI_MAX_DEVICES]; //!< Per-GPU data, num_gpus entries valid
+  uint32_t num_gpus;                                 //!< Number of GPU entries populated
+  amdsmi_proc_gpu_entry_t gpus[AMDSMI_MAX_DEVICES];  //!< Per-GPU data, num_gpus entries valid
 } amdsmi_proc_info_by_pid_t;
 
 /**
@@ -7304,13 +7304,13 @@ amdsmi_status_t amdsmi_get_gpu_process_list(amdsmi_processor_handle processor_ha
  *
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success,
  *                            | ::AMDSMI_STATUS_OUT_OF_RESOURCES if max_processes was too small,
- *                            | ::AMDSMI_STATUS_INVAL if processor_handles is NULL or num_processors is 0
+ *                            | ::AMDSMI_STATUS_INVAL if processor_handles is NULL or num_processors
+ * is 0
  */
-amdsmi_status_t amdsmi_get_gpu_process_list_by_pid(
-    amdsmi_processor_handle* processor_handles,
-    uint32_t num_processors,
-    amdsmi_proc_info_by_pid_t* list,
-    uint32_t* max_processes);
+amdsmi_status_t amdsmi_get_gpu_process_list_by_pid(amdsmi_processor_handle* processor_handles,
+                                                   uint32_t num_processors,
+                                                   amdsmi_proc_info_by_pid_t* list,
+                                                   uint32_t* max_processes);
 
 /** @} End tagProcessInfo */
 

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -7297,10 +7297,10 @@ amdsmi_status_t amdsmi_get_gpu_process_list(amdsmi_processor_handle processor_ha
  *
  *  @param[in]  processor_handles  Array of processor handles to query
  *  @param[in]  num_processors     Number of handles in processor_handles
- *  @param[out] list               Caller-allocated buffer of amdsmi_proc_info_by_pid_t.
+ *  @param[out] procs              Caller-allocated buffer of amdsmi_proc_info_by_pid_t.
  *                                 Pass NULL to query the required size via max_processes.
- *  @param[in,out] max_processes   On input: capacity of list. On output: number of
- *                                 unique PIDs written (or required if list is NULL).
+ *  @param[in,out] max_processes   On input: capacity of procs. On output: number of
+ *                                 unique PIDs written (or required if procs is NULL).
  *
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success,
  *                            | ::AMDSMI_STATUS_OUT_OF_RESOURCES if max_processes was too small,
@@ -7309,7 +7309,7 @@ amdsmi_status_t amdsmi_get_gpu_process_list(amdsmi_processor_handle processor_ha
  */
 amdsmi_status_t amdsmi_get_gpu_process_list_by_pid(amdsmi_processor_handle* processor_handles,
                                                    uint32_t num_processors,
-                                                   amdsmi_proc_info_by_pid_t* list,
+                                                   amdsmi_proc_info_by_pid_t* procs,
                                                    uint32_t* max_processes);
 
 /** @} End tagProcessInfo */

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -3852,6 +3852,79 @@ def amdsmi_get_gpu_process_list(
     return result
 
 
+def amdsmi_get_gpu_process_list_by_pid(processor_handles: list) -> list:
+    """Get process list grouped by PID across multiple GPUs.
+
+    Args:
+        processor_handles: List of processor handles to query.
+
+    Returns:
+        List of dicts with keys: pid, name, container_name, gpus.
+        Each gpu entry has: gpu_index, mem, engine_usage, memory_usage,
+        cu_occupancy, sdma_usage, evicted_time.
+    """
+    for h in processor_handles:
+        if not isinstance(h, amdsmi_wrapper.amdsmi_processor_handle):
+            raise AmdSmiParameterException(h, amdsmi_wrapper.amdsmi_processor_handle)
+
+    num = len(processor_handles)
+    handle_array = (amdsmi_wrapper.amdsmi_processor_handle * num)(*processor_handles)
+
+    max_processes = ctypes.c_uint32(MAX_NUM_PROCESSES)
+    process_list = (amdsmi_wrapper.amdsmi_proc_info_by_pid_t * max_processes.value)()
+    _check_res(
+        amdsmi_wrapper.amdsmi_get_gpu_process_list_by_pid(
+            handle_array, num, process_list, ctypes.byref(max_processes)
+        )
+    )
+
+    self_pid = os.getpid()
+    result = []
+    for i in range(max_processes.value):
+        entry = process_list[i]
+        pid = int(entry.pid)
+        if pid == self_pid:
+            continue
+
+        process_name = entry.name.decode("utf-8").strip()
+        if process_name == "":
+            process_name = "N/A"
+
+        gpus = []
+        for g in range(entry.num_gpus):
+            ge = entry.gpus[g]
+            gpus.append(
+                {
+                    "gpu_index": ge.gpu_index,
+                    "mem": ge.mem,
+                    "engine_usage": {"gfx": ge.engine_usage.gfx, "enc": ge.engine_usage.enc},
+                    "memory_usage": {
+                        "gtt_mem": ge.memory_usage.gtt_mem,
+                        "cpu_mem": ge.memory_usage.cpu_mem,
+                        "vram_mem": ge.memory_usage.vram_mem,
+                    },
+                    "cu_occupancy": _validate_if_max_uint(
+                        ge.cu_occupancy, MaxUIntegerTypes.UINT32_T
+                    ),
+                    "sdma_usage": _validate_if_max_uint(ge.sdma_usage, MaxUIntegerTypes.UINT64_T),
+                    "evicted_time": _validate_if_max_uint(
+                        ge.evicted_time, MaxUIntegerTypes.UINT32_T
+                    ),
+                }
+            )
+
+        result.append(
+            {
+                "pid": pid,
+                "name": process_name,
+                "container_name": entry.container_name.decode("utf-8").strip(),
+                "gpus": gpus,
+            }
+        )
+
+    return result
+
+
 def amdsmi_get_nic_fw_version(processor_handle: amdsmi_wrapper.amdsmi_processor_handle) -> str:
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)

--- a/projects/amdsmi/py-interface/amdsmi_wrapper.py
+++ b/projects/amdsmi/py-interface/amdsmi_wrapper.py
@@ -1456,6 +1456,57 @@ struct_amdsmi_proc_info_t._fields_ = [
 ]
 
 amdsmi_proc_info_t = struct_amdsmi_proc_info_t
+class struct_amdsmi_proc_gpu_entry_t(Structure):
+    pass
+
+class struct_amdsmi_proc_gpu_entry_t_engine_usage(Structure):
+    pass
+
+struct_amdsmi_proc_gpu_entry_t_engine_usage._pack_ = 1 # source:False
+struct_amdsmi_proc_gpu_entry_t_engine_usage._fields_ = [
+    ('gfx', ctypes.c_uint64),
+    ('enc', ctypes.c_uint64),
+    ('reserved', ctypes.c_uint32 * 12),
+]
+
+class struct_amdsmi_proc_gpu_entry_t_memory_usage(Structure):
+    pass
+
+struct_amdsmi_proc_gpu_entry_t_memory_usage._pack_ = 1 # source:False
+struct_amdsmi_proc_gpu_entry_t_memory_usage._fields_ = [
+    ('gtt_mem', ctypes.c_uint64),
+    ('cpu_mem', ctypes.c_uint64),
+    ('vram_mem', ctypes.c_uint64),
+    ('reserved', ctypes.c_uint32 * 10),
+]
+
+struct_amdsmi_proc_gpu_entry_t._pack_ = 1 # source:False
+struct_amdsmi_proc_gpu_entry_t._fields_ = [
+    ('gpu_index', ctypes.c_uint32),
+    ('PADDING_0', ctypes.c_ubyte * 4),
+    ('mem', ctypes.c_uint64),
+    ('engine_usage', struct_amdsmi_proc_gpu_entry_t_engine_usage),
+    ('memory_usage', struct_amdsmi_proc_gpu_entry_t_memory_usage),
+    ('cu_occupancy', ctypes.c_uint32),
+    ('evicted_time', ctypes.c_uint32),
+    ('sdma_usage', ctypes.c_uint64),
+    ('reserved', ctypes.c_uint32 * 8),
+]
+
+amdsmi_proc_gpu_entry_t = struct_amdsmi_proc_gpu_entry_t
+class struct_amdsmi_proc_info_by_pid_t(Structure):
+    pass
+
+struct_amdsmi_proc_info_by_pid_t._pack_ = 1 # source:False
+struct_amdsmi_proc_info_by_pid_t._fields_ = [
+    ('pid', ctypes.c_uint32),
+    ('name', ctypes.c_char * 256),
+    ('container_name', ctypes.c_char * 256),
+    ('num_gpus', ctypes.c_uint32),
+    ('gpus', struct_amdsmi_proc_gpu_entry_t * 32),
+]
+
+amdsmi_proc_info_by_pid_t = struct_amdsmi_proc_info_by_pid_t
 class struct_amdsmi_p2p_capability_t(Structure):
     pass
 
@@ -3790,6 +3841,12 @@ try:
 except AttributeError:
     pass
 try:
+    amdsmi_get_gpu_process_list_by_pid = _libraries['libamd_smi.so'].amdsmi_get_gpu_process_list_by_pid
+    amdsmi_get_gpu_process_list_by_pid.restype = amdsmi_status_t
+    amdsmi_get_gpu_process_list_by_pid.argtypes = [ctypes.POINTER(ctypes.POINTER(None)), uint32_t, ctypes.POINTER(struct_amdsmi_proc_info_by_pid_t), ctypes.POINTER(ctypes.c_uint32)]
+except AttributeError:
+    pass
+try:
     amdsmi_gpu_driver_reload = _libraries['libamd_smi.so'].amdsmi_gpu_driver_reload
     amdsmi_gpu_driver_reload.restype = amdsmi_status_t
     amdsmi_gpu_driver_reload.argtypes = []
@@ -4723,6 +4780,7 @@ __all__ = \
     'amdsmi_get_gpu_pm_metrics_info',
     'amdsmi_get_gpu_power_profile_presets',
     'amdsmi_get_gpu_process_isolation', 'amdsmi_get_gpu_process_list',
+    'amdsmi_get_gpu_process_list_by_pid',
     'amdsmi_get_gpu_ptl_formats', 'amdsmi_get_gpu_ptl_state',
     'amdsmi_get_gpu_ras_block_features_enabled',
     'amdsmi_get_gpu_ras_feature_info',
@@ -4787,7 +4845,8 @@ __all__ = \
     'amdsmi_pcie_info_t', 'amdsmi_power_cap_info_t',
     'amdsmi_power_cap_type_t', 'amdsmi_power_info_t',
     'amdsmi_power_profile_preset_masks_t',
-    'amdsmi_power_profile_status_t', 'amdsmi_proc_info_t',
+    'amdsmi_power_profile_status_t', 'amdsmi_proc_gpu_entry_t',
+    'amdsmi_proc_info_by_pid_t', 'amdsmi_proc_info_t',
     'amdsmi_process_handle_t', 'amdsmi_process_info_t',
     'amdsmi_processor_handle', 'amdsmi_processor_type_t',
     'amdsmi_ptl_data_format_t', 'amdsmi_range_t',
@@ -4881,8 +4940,12 @@ __all__ = \
     'struct_amdsmi_pcie_bandwidth_t', 'struct_amdsmi_pcie_info_t',
     'struct_amdsmi_power_cap_info_t', 'struct_amdsmi_power_info_t',
     'struct_amdsmi_power_profile_status_t',
-    'struct_amdsmi_proc_info_t', 'struct_amdsmi_process_info_t',
-    'struct_amdsmi_range_t', 'struct_amdsmi_ras_feature_t',
+    'struct_amdsmi_proc_gpu_entry_t',
+    'struct_amdsmi_proc_gpu_entry_t_engine_usage',
+    'struct_amdsmi_proc_gpu_entry_t_memory_usage',
+    'struct_amdsmi_proc_info_by_pid_t', 'struct_amdsmi_proc_info_t',
+    'struct_amdsmi_process_info_t', 'struct_amdsmi_range_t',
+    'struct_amdsmi_ras_feature_t',
     'struct_amdsmi_retired_page_record_t',
     'struct_amdsmi_smu_fw_version_t', 'struct_amdsmi_sock_info_t',
     'struct_amdsmi_temp_range_refresh_rate_t',

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -5271,11 +5271,10 @@ amdsmi_status_t amdsmi_get_gpu_process_list(amdsmi_processor_handle processor_ha
              : AMDSMI_STATUS_OUT_OF_RESOURCES;
 }
 
-amdsmi_status_t amdsmi_get_gpu_process_list_by_pid(
-    amdsmi_processor_handle* processor_handles,
-    uint32_t num_processors,
-    amdsmi_proc_info_by_pid_t* list,
-    uint32_t* max_processes) {
+amdsmi_status_t amdsmi_get_gpu_process_list_by_pid(amdsmi_processor_handle* processor_handles,
+                                                   uint32_t num_processors,
+                                                   amdsmi_proc_info_by_pid_t* list,
+                                                   uint32_t* max_processes) {
   AMDSMI_CHECK_INIT();
 
   if (!processor_handles || num_processors == 0 || !max_processes) {

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -5271,6 +5271,82 @@ amdsmi_status_t amdsmi_get_gpu_process_list(amdsmi_processor_handle processor_ha
              : AMDSMI_STATUS_OUT_OF_RESOURCES;
 }
 
+amdsmi_status_t amdsmi_get_gpu_process_list_by_pid(
+    amdsmi_processor_handle* processor_handles,
+    uint32_t num_processors,
+    amdsmi_proc_info_by_pid_t* list,
+    uint32_t* max_processes) {
+  AMDSMI_CHECK_INIT();
+
+  if (!processor_handles || num_processors == 0 || !max_processes) {
+    return AMDSMI_STATUS_INVAL;
+  }
+
+  // Collect processes from all GPUs, grouped by PID
+  std::map<uint32_t, amdsmi_proc_info_by_pid_t> pid_map;
+
+  for (uint32_t i = 0; i < num_processors; i++) {
+    amd::smi::AMDSmiGPUDevice* gpu_device = nullptr;
+    amdsmi_status_t r = get_gpu_device_from_handle(processor_handles[i], &gpu_device);
+    if (r != AMDSMI_STATUS_SUCCESS) continue;
+
+    uint32_t gpu_index = gpu_device->get_gpu_id();
+    auto compute_process_list = gpu_device->amdgpu_get_compute_process_list();
+
+    for (auto& [pid, proc_info] : compute_process_list) {
+      auto& entry = pid_map[proc_info.pid];
+
+      // This is the first time seeing this PID so populate top-level fields
+      if (entry.num_gpus == 0) {
+        entry.pid = proc_info.pid;
+        std::strncpy(entry.name, proc_info.name, AMDSMI_MAX_STRING_LENGTH - 1);
+        entry.name[AMDSMI_MAX_STRING_LENGTH - 1] = '\0';
+        std::strncpy(entry.container_name, proc_info.container_name, AMDSMI_MAX_STRING_LENGTH - 1);
+        entry.container_name[AMDSMI_MAX_STRING_LENGTH - 1] = '\0';
+      }
+
+      if (entry.num_gpus >= AMDSMI_MAX_DEVICES) continue;
+
+      auto& gpu_entry = entry.gpus[entry.num_gpus];
+      gpu_entry.gpu_index = gpu_index;
+      gpu_entry.mem = proc_info.mem;
+      gpu_entry.engine_usage.gfx = proc_info.engine_usage.gfx;
+      gpu_entry.engine_usage.enc = proc_info.engine_usage.enc;
+      gpu_entry.memory_usage.gtt_mem = proc_info.memory_usage.gtt_mem;
+      gpu_entry.memory_usage.cpu_mem = proc_info.memory_usage.cpu_mem;
+      gpu_entry.memory_usage.vram_mem = proc_info.memory_usage.vram_mem;
+      gpu_entry.cu_occupancy = proc_info.cu_occupancy;
+      gpu_entry.evicted_time = proc_info.evicted_time;
+      gpu_entry.sdma_usage = proc_info.sdma_usage;
+      entry.num_gpus++;
+    }
+  }
+
+  uint32_t num_pids = static_cast<uint32_t>(pid_map.size());
+
+  // Size query: list is NULL, return required count
+  if (!list) {
+    *max_processes = num_pids;
+    return AMDSMI_STATUS_SUCCESS;
+  }
+
+  const uint32_t capacity = *max_processes;
+  *max_processes = num_pids;
+
+  if (capacity == 0) {
+    return AMDSMI_STATUS_SUCCESS;
+  }
+
+  // Copy results sorted by PID (std::map is already sorted)
+  uint32_t idx = 0;
+  for (auto& [pid, entry] : pid_map) {
+    if (idx >= capacity) break;
+    list[idx++] = entry;
+  }
+
+  return (capacity >= num_pids) ? AMDSMI_STATUS_SUCCESS : AMDSMI_STATUS_OUT_OF_RESOURCES;
+}
+
 amdsmi_status_t amdsmi_get_power_info(amdsmi_processor_handle processor_handle,
                                       amdsmi_power_info_t* info) {
   AMDSMI_CHECK_INIT();

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -5273,7 +5273,7 @@ amdsmi_status_t amdsmi_get_gpu_process_list(amdsmi_processor_handle processor_ha
 
 amdsmi_status_t amdsmi_get_gpu_process_list_by_pid(amdsmi_processor_handle* processor_handles,
                                                    uint32_t num_processors,
-                                                   amdsmi_proc_info_by_pid_t* list,
+                                                   amdsmi_proc_info_by_pid_t* procs,
                                                    uint32_t* max_processes) {
   AMDSMI_CHECK_INIT();
 
@@ -5323,8 +5323,8 @@ amdsmi_status_t amdsmi_get_gpu_process_list_by_pid(amdsmi_processor_handle* proc
 
   uint32_t num_pids = static_cast<uint32_t>(pid_map.size());
 
-  // Size query: list is NULL, return required count
-  if (!list) {
+  // Size query: procs is NULL, return required count
+  if (!procs) {
     *max_processes = num_pids;
     return AMDSMI_STATUS_SUCCESS;
   }
@@ -5340,7 +5340,7 @@ amdsmi_status_t amdsmi_get_gpu_process_list_by_pid(amdsmi_processor_handle* proc
   uint32_t idx = 0;
   for (auto& [pid, entry] : pid_map) {
     if (idx >= capacity) break;
-    list[idx++] = entry;
+    procs[idx++] = entry;
   }
 
   return (capacity >= num_pids) ? AMDSMI_STATUS_SUCCESS : AMDSMI_STATUS_OUT_OF_RESOURCES;


### PR DESCRIPTION
## Summary

ROCM-23803

Adds a new C API `amdsmi_get_gpu_process_list_by_pid()` that aggregates process info across all GPUs and returns it keyed by PID, along with a `--sort-by-pid` CLI flag for `amd-smi process` and `amd-smi monitor --process`.

When a process spans multiple GPUs, `amd-smi process` currently shows the same PID repeated under every GPU it touches. Customers coming from NVIDIA (where `nvidia-smi` aggregates under a single PID entry) frequently report this as a bug. The `--sort-by-pid` flag provides the PID-centric view.

### Changes

- **`include/amd_smi/amdsmi.h`** — New `amdsmi_proc_gpu_entry_t` and `amdsmi_proc_info_by_pid_t` structs, new `amdsmi_get_gpu_process_list_by_pid()` declaration
- **`src/amd_smi/amd_smi.cc`** — C++ implementation: iterates GPU handles, collects processes via `amdgpu_get_compute_process_list()`, merges into `std::map<pid, entry>`, returns sorted by PID
- **`py-interface/amdsmi_wrapper.py`** — Auto-regenerated via `tools/update_wrapper.sh`
- **`py-interface/amdsmi_interface.py`** — New `amdsmi_get_gpu_process_list_by_pid()` Python interface function
- **`amdsmi_cli/amdsmi_parser.py`** — `--sort-by-pid` added to shared command modifiers group
- **`amdsmi_cli/amdsmi_commands.py`** — `_process_sort_by_pid()` for `process` command, `_monitor_inject_sort_by_pid()` for `monitor --process`

### Default output (unchanged)

```
$ amd-smi process

GPU: 0
    PROCESS_INFO:
        NAME: /usr/bin/python3.12
        PID: 2168274
        MEMORY_USAGE:
            GTT_MEM: 5.9 MB
            CPU_MEM: 0.0 B
            VRAM_MEM: 46.9 KB
        MEM_USAGE: 5.9 MB
        USAGE:
            GFX: 0 ns
            ENC: 0 ns
        SDMA_USAGE: 0 us
        CU_OCCUPANCY: 0
        EVICTED_TIME: 0 ms

GPU: 1
    PROCESS_INFO:
        NAME: /usr/bin/python3.12
        PID: 2168274
        ...
```

### `amd-smi process --sort-by-pid`

```
$ amd-smi process --sort-by-pid

  PID: 2960834  NAME: /usr/bin/python3.10                                                                                                                                
      GPU: 0  MEM: 128.0 MB  GFX: 0 ns  ENC: 0 ns                      
      GPU: 1  MEM: 128.0 MB  GFX: 0 ns  ENC: 0 ns                                                                                                                        
      GPU: 2  MEM: 128.0 MB  GFX: 0 ns  ENC: 0 ns
      GPU: 3  MEM: 128.0 MB  GFX: 0 ns  ENC: 0 ns                                                                                                                        
      GPU: 4  MEM: 5.9 MB  GFX: 0 ns  ENC: 0 ns                                                                                                                          
      GPU: 5  MEM: 5.9 MB  GFX: 0 ns  ENC: 0 ns                                                                                                                          
      GPU: 6  MEM: 5.9 MB  GFX: 0 ns  ENC: 0 ns                                                                                                                          
      GPU: 7  MEM: 5.9 MB  GFX: 0 ns  ENC: 0 ns                                                                                                                          
                                                                                                                                                                         
  PID: 2960835  NAME: /usr/bin/python3.10                                                                                                                                
      GPU: 0  MEM: 5.9 MB  GFX: 0 ns  ENC: 0 ns                        
      GPU: 1  MEM: 5.9 MB  GFX: 0 ns  ENC: 0 ns                                                                                                                          
      GPU: 2  MEM: 64.0 MB  GFX: 0 ns  ENC: 0 ns                                                                                                                         
      GPU: 3  MEM: 64.0 MB  GFX: 0 ns  ENC: 0 ns                                                                                                                         
      GPU: 4  MEM: 64.0 MB  GFX: 0 ns  ENC: 0 ns                                                                                                                         
      GPU: 5  MEM: 64.0 MB  GFX: 0 ns  ENC: 0 ns                                                                                                                         
      GPU: 6  MEM: 5.9 MB  GFX: 0 ns  ENC: 0 ns                                                                                                                          
      GPU: 7  MEM: 5.9 MB  GFX: 0 ns  ENC: 0 ns  
```

### `amd-smi process --sort-by-pid --json`

```json
[
    {
        "pid": 2168274,
        "name": "/usr/bin/python3.12",
        "container_name": "",
        "gpus": [
            {
                "gpu_index": 0,
                "mem": { "value": 6228000, "unit": "B" },
                "engine_usage": {
                    "gfx": { "value": 0, "unit": "ns" },
                    "enc": { "value": 0, "unit": "ns" }
                },
                "memory_usage": {
                    "gtt_mem": { "value": 6180000, "unit": "B" },
                    "cpu_mem": { "value": 0, "unit": "B" },
                    "vram_mem": { "value": 48000, "unit": "B" }
                },
                "cu_occupancy": 0,
                "sdma_usage": { "value": 0, "unit": "us" },
                "evicted_time": { "value": 0, "unit": "ms" }
            },
            {
                "gpu_index": 1,
                "mem": { "value": 67108864, "unit": "B" },
                "memory_usage": {
                    "gtt_mem": { "value": 6180000, "unit": "B" },
                    "cpu_mem": { "value": 0, "unit": "B" },
                    "vram_mem": { "value": 65588000, "unit": "B" }
                },
                "..."
            }
        ]
    }
]
```

### `amd-smi monitor --process --sort-by-pid`

```
$ amd-smi monitor --process --sort-by-pid

  GPU  XCP  POWER  GPU_T  MEM_T  GFX_CLK  GFX%  MEM%  ENC%  DEC%     VRAM_USAGE                                                                                          
    0    0  175 W  52 °C  51 °C   89 MHz   0 %   0 %   N/A   0 %   0.4/192.0 GB                                                                                          
    1    0  172 W  52 °C  49 °C   89 MHz   0 %   0 %   N/A   0 %   0.4/192.0 GB                                                                                          
    ...                                                                                                                                                                  
                                                                                                                                                                         
  PROCESS INFO (grouped by PID):                                                                                                                                         
  GPU               NAME      PID   GTT_MEM   CPU_MEM  VRAM_MEM   MEM_USG      CU%    SDMA   EVICT
    0         python3.10  2960834    5.9 MB     0.0 B  125.0 MB  128.0 MB        0    0 us    0 ms                                                                       
    1         python3.10  2960834    5.9 MB     0.0 B  125.0 MB  128.0 MB        0    0 us    0 ms                                                                       
    2         python3.10  2960834    5.9 MB     0.0 B  125.0 MB  128.0 MB        0    0 us    0 ms                                                                       
    3         python3.10  2960834    5.9 MB     0.0 B  125.0 MB  128.0 MB        0    0 us    0 ms                                                                       
    4         python3.10  2960834    5.9 MB     0.0 B   39.1 KB    5.9 MB        0    0 us    0 ms                                                                       
    5         python3.10  2960834    5.9 MB     0.0 B   39.1 KB    5.9 MB        0    0 us    0 ms                                                                       
    6         python3.10  2960834    5.9 MB     0.0 B   39.1 KB    5.9 MB        0    0 us    0 ms                                                                       
    7         python3.10  2960834    5.9 MB     0.0 B   39.1 KB    5.9 MB        0    0 us    0 ms                                                                       
    0         python3.10  2960835    5.9 MB     0.0 B   46.9 KB    5.9 MB        0    0 us    0 ms                                                                       
    1         python3.10  2960835    5.9 MB     0.0 B   46.9 KB    5.9 MB        0    0 us    0 ms                                                                       
    2         python3.10  2960835    5.9 MB     0.0 B   62.6 MB   64.0 MB        0    0 us    0 ms                                                                       
    3         python3.10  2960835    5.9 MB     0.0 B   62.5 MB   64.0 MB        0    0 us    0 ms                                                                       
    4         python3.10  2960835    5.9 MB     0.0 B   62.5 MB   64.0 MB        0    0 us    0 ms                                                                       
    5         python3.10  2960835    5.9 MB     0.0 B   62.5 MB   64.0 MB        0    0 us    0 ms                                                                       
    6         python3.10  2960835    5.9 MB     0.0 B   46.9 KB    5.9 MB        0    0 us    0 ms                                                                       
    7         python3.10  2960835    5.9 MB     0.0 B   46.9 KB    5.9 MB        0    0 us    0 ms  
```

## Test plan

- [x] Verified default `amd-smi process` output unchanged
- [x] Verified `amd-smi process --sort-by-pid` groups by PID (human-readable, JSON, CSV)
- [x] Verified `amd-smi monitor --process --sort-by-pid` groups by PID with correct per-GPU data
- [x] Verified `--pid` and `--name` filters work with `--sort-by-pid`
- [x] Verified no-process edge case returns "No running processes detected"
- [x] Verified `--sort-by-pid` flag appears in `--help` output
- [x] Clean build from rebased `origin/develop` on 8-GPU MI300X system (smci350-rck-g03-b20-31)
- [x] C++ unit test
- [x] Python unit test