### PR TITLE
[CLR] Fix __mulhi shift-count-overflow on Windows

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_device_functions.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_device_functions.h
@@ -274,7 +274,7 @@ __device__ static inline long long __mul64hi(long long int x, long long int y) {
   return x1 * y1 + z2 + (z1 >> 32);
 }
 
-__device__ static inline int __mulhi(int x, int y) { return (int)(((long)x * (long)y) >> 32); }
+__device__ static inline int __mulhi(int x, int y) { return (int)(((__hip_int64_t)x * (__hip_int64_t)y) >> 32); }
 
 __device__ static inline int __rhadd(int x, int y) {
   return ((__hip_int64_t)x + (__hip_int64_t)y + 1) >> 1;


### PR DESCRIPTION
## Motivation

Fix `__mulhi` on Windows where `long` is 32 bits (LLP64 data model), causing `shift count >= width of type` error with `-Wshift-count-overflow`. Resolves #6281.

## Technical Details

Replace implementation-defined `long` cast with fixed-width `__hip_int64_t` in `__mulhi()` to guarantee 64-bit multiplication before the `>> 32` shift.

File changed: `projects/clr/hipamd/include/hip/amd_detail/amd_device_functions.h` line 277.

## JIRA ID

N/A

## Test Plan

Compiled a standalone reproducer with `clang-cl -Werror -Wshift-count-overflow` on Windows 11:
- Original `(long)` cast: triggers `error: shift count >= width of type`
- Fixed `(__hip_int64_t)` cast: compiles cleanly (exit code 0)

## Test Result

Fix eliminates the shift-count-overflow error on Windows. No functional change on Linux where `long` is already 64 bits.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.