### PR TITLE
Apply expected-failure handling to TheRock test components

### DIFF
--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -24,8 +24,12 @@ permissions:
 
 jobs:
   test_component:
-    name: 'Test ${{ fromJSON(inputs.component).job_name }} (shard ${{ matrix.shard }} of ${{ fromJSON(inputs.component).total_shards }})'
+    name: >-
+      Test ${{ fromJSON(inputs.component).job_name }}
+      (shard ${{ matrix.shard }} of ${{ fromJSON(inputs.component).total_shards }})
+      ${{ fromJSON(inputs.component).expect_failure == true && '(xfail)' || '' }}
     runs-on: ${{ inputs.test_runs_on }}
+    continue-on-error: ${{ fromJSON(inputs.component).expect_failure == true }}
     container:
       # If the component has specified an alternate image, honor that option.
       # Otherwise use the default image.


### PR DESCRIPTION
## Summary

- Applies `expect_failure` from TheRock-generated test component configuration.
- Marks expected-failure jobs with `(xfail)` in the rocm-systems test job name.
- Uses `continue-on-error` for expected-failure components so informational failures do not fail the reusable test workflow.

## Motivation

TheRock already emits expected-failure metadata for Windows HIP ROCR test jobs, and TheRock’s reusable test workflow already applies that field in the job name and `continue-on-error` handling:

https://github.com/ROCm/TheRock/blob/main/.github/workflows/test_component.yml#L42-L50

rocm-systems consumes that generated component matrix, but its local reusable test workflow was not applying the `expect_failure` field.

This lets Windows HIP ROCR test failures remain visible without turning the rocm-systems TheRock CI summary red when those are the only failing test components.
