### PR TITLE
Fix COLLTRACE triggering hostcall buffer on kernels with COLLTRACE=false

### DIFF
--- a/projects/rccl/src/device/common.h
+++ b/projects/rccl/src/device/common.h
@@ -674,7 +674,9 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
   }
 #endif
   if (tid == 0) __insert_timestamp(__LINE__);
-  if (COLLTRACE && tid%WARP_SIZE == 0) traceKernelLaunch(ncclCollTraceKernelLaunchType, 0);
+  if constexpr (COLLTRACE) {
+    if (tid%WARP_SIZE == 0) traceKernelLaunch(ncclCollTraceKernelLaunchType, 0);
+  }
 
   while (ncclShmem.aborted == 0) {
     if (tid == 0) __insert_timestamp(__LINE__);
@@ -717,10 +719,14 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
     profiler(STOP);
     loadWorkBatchToShmem(tid%WARP_SIZE, tn, args, batchIx);
     __syncthreads();
-    if (COLLTRACE && tid%WARP_SIZE == 0) traceKernelLaunch(ncclCollTraceCollLaunchType, batchIx);
+    if constexpr (COLLTRACE) {
+      if (tid%WARP_SIZE == 0) traceKernelLaunch(ncclCollTraceCollLaunchType, batchIx);
+    }
   }
   profiler(FINI);
-  if (COLLTRACE && tid%WARP_SIZE == 0) traceKernelEnd(ncclCollTraceKernelEndType);
+  if constexpr (COLLTRACE) {
+    if (tid%WARP_SIZE == 0) traceKernelEnd(ncclCollTraceKernelEndType);
+  }
 
 #ifdef ENABLE_PROFILING
   if (ncclShmem.comm.devProf->seq < PROFILE_NUM_LAUNCHES) {


### PR DESCRIPTION
## Motivation
Replace runtime `if (COLLTRACE && ...)` checks with `if constexpr (COLLTRACE)` to eliminate tracing code at compile-time for kernels instantiated with COLLTRACE=false template parameter.

When ENABLE_COLLTRACE is defined, the preprocessor includes tracing code for ALL kernels in the translation unit, including those instantiated with COLLTRACE=false. The compiler's metadata generation phase sees potential wall_clock64() calls before dead-code elimination, causing it to conservatively add hidden_hostcall_buffer to all kernels. This requires PCIe atomics and causes kernel launch failures on systems without atomics.

Related issues:
- ROCm/ROCm#6074
- ROCm/ROCm#6148

## Technical Details
Using `if constexpr` ensures the tracing code is completely eliminated during template instantiation for COLLTRACE=false kernels, before the compiler generates kernel metadata. This prevents unnecessary hostcall buffer requirements.

- ncclDevKernel_Generic_* kernels (COLLTRACE=false) will no longer require hidden_hostcall_buffer
- ncclDevKernelDebug_Generic_* kernels (COLLTRACE=true) will still have hostcall buffer (correct behavior)
- Fixes kernel launch failures on systems without PCIe atomics

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
