### PR TITLE
Windows: fix `-Wshift-count-overflow` warning

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_device_functions.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_device_functions.h
@@ -274,7 +274,9 @@ __device__ static inline long long __mul64hi(long long int x, long long int y) {
   return x1 * y1 + z2 + (z1 >> 32);
 }
 
-__device__ static inline int __mulhi(int x, int y) { return (int)(((long)x * (long)y) >> 32); }
+__device__ static inline int __mulhi(int x, int y) {
+  return (int)(((long long)x * (long long)y) >> 32);
+}
 
 __device__ static inline int __rhadd(int x, int y) {
   return ((__hip_int64_t)x + (__hip_int64_t)y + 1) >> 1;


### PR DESCRIPTION
## Motivation

Building flash attn 2 (ck backend) meets this warning and it spams in every single one of the thousands of kernels:

```
DEBUG [368/1837] hipcc.exe ...
DEBUG In file included from H:\ROCm\flash-attention\build\fmha_bwd_d256_bf16_group_b16x64x256x16x256x16x32x256x256_r1x4x1_r4x1x1_r1x4x1_w16x16x16_w16x16x16_o-1_maxq0_pd1dv1_nbias_ndbias_nmask_ndropout_deterministic_ntrload_gfx12.cu:5:
DEBUG In file included from H:\ROCm\flash-attention\csrc\composable_kernel\example\ck_tile\01_fmha\fmha_bwd.hpp:6:
DEBUG In file included from H:\ROCm\flash-attention\csrc\composable_kernel\include\ck_tile/core.hpp:5:
DEBUG In file included from H:\ROCm\flash-attention\csrc\composable_kernel\include\ck_tile/core/algorithm/cluster_descriptor.hpp:6:
DEBUG In file included from H:\ROCm\flash-attention\csrc\composable_kernel\include\ck_tile/core/config.hpp:46:
DEBUG In file included from H:\ROCm\.venv\Lib\site-packages\_rocm_sdk_devel\include\hip/hip_runtime.h:41:
DEBUG In file included from H:\ROCm\.venv\Lib\site-packages\_rocm_sdk_devel\include\hip/amd_detail/amd_hip_runtime.h:89:
DEBUG In file included from H:\ROCm\.venv\Lib\site-packages\_rocm_sdk_devel\include\hip/amd_detail/amd_hip_atomic.h:10:
DEBUG H:\ROCm\.venv\Lib\site-packages\_rocm_sdk_devel\include\hip/amd_detail\amd_device_functions.h:277:87: warning: shift count >= width of type [-Wshift-count-overflow]
DEBUG   277 | __device__ static inline int __mulhi(int x, int y) { return (int)(((long)x * (long)y) >> 32); }
DEBUG       |                                                                                       ^  ~~
DEBUG 1 warning generated when compiling for gfx1201.
DEBUG In file included from H:\ROCm\flash-attention\build\fmha_bwd_d256_bf16_group_b16x64x256x16x256x16x32x256x256_r1x4x1_r4x1x1_r1x4x1_w16x16x16_w16x16x16_o-1_maxq0_pd1dv1_nbias_ndbias_nmask_ndropout_deterministic_ntrload_gfx12.cu:5:
DEBUG In file included from H:\ROCm\flash-attention\csrc\composable_kernel\example\ck_tile\01_fmha\fmha_bwd.hpp:6:
DEBUG In file included from H:\ROCm\flash-attention\csrc\composable_kernel\include\ck_tile/core.hpp:5:
DEBUG In file included from H:\ROCm\flash-attention\csrc\composable_kernel\include\ck_tile/core/algorithm/cluster_descriptor.hpp:6:
DEBUG In file included from H:\ROCm\flash-attention\csrc\composable_kernel\include\ck_tile/core/config.hpp:46:
DEBUG In file included from H:\ROCm\.venv\Lib\site-packages\_rocm_sdk_devel\include\hip/hip_runtime.h:41:
DEBUG In file included from H:\ROCm\.venv\Lib\site-packages\_rocm_sdk_devel\include\hip/amd_detail/amd_hip_runtime.h:89:
DEBUG In file included from H:\ROCm\.venv\Lib\site-packages\_rocm_sdk_devel\include\hip/amd_detail/amd_hip_atomic.h:10:
DEBUG H:\ROCm\.venv\Lib\site-packages\_rocm_sdk_devel\include\hip/amd_detail\amd_device_functions.h:277:87: warning: shift count >= width of type [-Wshift-count-overflow]
DEBUG   277 | __device__ static inline int __mulhi(int x, int y) { return (int)(((long)x * (long)y) >> 32); }
DEBUG       |                                                                                       ^  ~~
DEBUG 1 warning generated when compiling for host.
```

## Technical Details

On Linux both `long` and `long long` are 64 bits but on Windows `long` is 32 bits. Change `__mulhi` to use `long long` as `__uhadd` do:
https://github.com/ROCm/rocm-systems/blob/4215845406149e8d877acbf2dcf7ce4c4e67c85a/projects/clr/hipamd/include/hip/amd_detail/amd_device_functions.h#L286-L290

## Test Plan

Run FA2 build.

## Test Result

No this warning anymore.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
