### PR TITLE
AIRUNTIME-2105 - Disable propagation of the error into the last error…

### DIFF
--- a/projects/clr/hipamd/src/hip_module.cpp
+++ b/projects/clr/hipamd/src/hip_module.cpp
@@ -78,7 +78,8 @@ hipError_t hipModuleGetFunction(hipFunction_t* hfunc, hipModule_t hmod, const ch
 
   if (hipSuccess != PlatformState::Instance().GetDynFunc(hfunc, hmod, name)) {
     LogPrintfError("Cannot find the function: %s for module: 0x%x", name, hmod);
-    HIP_RETURN(hipErrorNotFound);
+    hip::tls.last_command_error_ = hipErrorNotFound;
+    return hipErrorNotFound;
   }
 
   HIP_RETURN(hipSuccess);


### PR DESCRIPTION
… for hipModuleGetFunction.

## Motivation

Cuda parity.

## Technical Details

CUDA does not propagate error.

## JIRA ID

AIRUNTIME-2105

## Test Plan

Attached simple hip reprod.

## Test Result

Attached simple hip reprod pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
