### PR TITLE
[rocprof-sys] allow --gpus/--cpus/--ai-nics without --device/--host

### DIFF
--- a/projects/rocprofiler-systems/source/lib/core/argparse.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse.cpp
@@ -915,7 +915,6 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
                 { "--cpus" },
                 "CPU IDs for frequency sampling. Supports integers and/or ranges")
             .dtype("int and/or range")
-            .required({ "host" })
             .action([&](parser_t& p) {
                 update_env(_data, "ROCPROFSYS_SAMPLING_CPUS",
                            fmt::format("{}", fmt::join(p.get<strvec_t>("cpus"), ",")));
@@ -931,7 +930,6 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .add_argument({ "--gpus" },
                           "GPU IDs for SMI queries. Supports integers and/or ranges")
             .dtype("int and/or range")
-            .required({ "device" })
             .action([&](parser_t& p) {
                 update_env(_data, "ROCPROFSYS_SAMPLING_GPUS",
                            fmt::format("{}", fmt::join(p.get<strvec_t>("gpus"), ",")));
@@ -947,7 +945,6 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
             .add_argument({ "--ai-nics" },
                           "AI NIC IDs for SMI queries. Supports comma-separated list")
             .dtype("list of strings")
-            .required({ "device" })
             .action([&](parser_t& p) {
                 update_env(_data, "ROCPROFSYS_SAMPLING_AINICS",
                            fmt::format("{}", fmt::join(p.get<strvec_t>("ai-nics"), ",")));

--- a/projects/rocprofiler-systems/tests/pytest/test_presets.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_presets.py
@@ -264,6 +264,116 @@ class TestRunDomainFlags(RocprofsysTest):
 
 
 # ============================================================================
+# Sampling target flags (--gpus / --cpus / --ai-nics) stand alone:
+# they must not require --device / --host on the command line, so presets
+# that already enable the matching backend (e.g. trace-hpc, trace-gpu set
+# ROCPROFSYS_USE_AMD_SMI=true) can compose with them.
+# ============================================================================
+
+
+@pytest.mark.timeout(60)
+@pytest.mark.class_name("run-sampling-target-flags")
+class TestRunSamplingTargetFlags(RocprofsysTest):
+    @pytest.mark.sys_run
+    def test_gpus_without_device(self):
+        result = self.run_test(
+            "baseline",
+            target="rocprof-sys-run",
+            run_args=["--gpus=0", "-v", "2", "--", "ls"],
+            fail_on_not_found=True,
+        )
+        self.assert_regex(result, pass_regex=["ROCPROFSYS_SAMPLING_GPUS=0"])
+
+    @pytest.mark.sys_run
+    def test_cpus_without_host(self):
+        result = self.run_test(
+            "baseline",
+            target="rocprof-sys-run",
+            run_args=["--cpus=0-3", "-v", "2", "--", "ls"],
+            fail_on_not_found=True,
+        )
+        self.assert_regex(result, pass_regex=["ROCPROFSYS_SAMPLING_CPUS=0-3"])
+
+    @pytest.mark.sys_run
+    def test_ai_nics_without_device(self):
+        result = self.run_test(
+            "baseline",
+            target="rocprof-sys-run",
+            run_args=["--ai-nics=nic0", "-v", "2", "--", "ls"],
+            fail_on_not_found=True,
+        )
+        self.assert_regex(result, pass_regex=["ROCPROFSYS_SAMPLING_AINICS=nic0"])
+
+    @pytest.mark.sys_run
+    @pytest.mark.parametrize("preset", ["trace-hpc", "trace-gpu"])
+    def test_preset_plus_gpus(self, preset):
+        result = self.run_test(
+            "baseline",
+            target="rocprof-sys-run",
+            run_args=[f"--preset={preset}", "--gpus=0", "-v", "2", "--", "ls"],
+            fail_on_not_found=True,
+        )
+        self.assert_regex(
+            result,
+            pass_regex=[
+                "ROCPROFSYS_SAMPLING_GPUS=0",
+                "ROCPROFSYS_USE_AMD_SMI=true",
+            ],
+        )
+
+
+@pytest.mark.timeout(60)
+@pytest.mark.class_name("sample-sampling-target-flags")
+class TestSampleSamplingTargetFlags(RocprofsysTest):
+    @pytest.mark.sampling
+    def test_gpus_without_device(self):
+        result = self.run_test(
+            "baseline",
+            target="rocprof-sys-sample",
+            run_args=["--gpus=0", "-v", "2", "--", "ls"],
+            fail_on_not_found=True,
+        )
+        self.assert_regex(result, pass_regex=["ROCPROFSYS_SAMPLING_GPUS=0"])
+
+    @pytest.mark.sampling
+    def test_cpus_without_host(self):
+        result = self.run_test(
+            "baseline",
+            target="rocprof-sys-sample",
+            run_args=["--cpus=0-3", "-v", "2", "--", "ls"],
+            fail_on_not_found=True,
+        )
+        self.assert_regex(result, pass_regex=["ROCPROFSYS_SAMPLING_CPUS=0-3"])
+
+    @pytest.mark.sampling
+    def test_ai_nics_without_device(self):
+        result = self.run_test(
+            "baseline",
+            target="rocprof-sys-sample",
+            run_args=["--ai-nics=nic0", "-v", "2", "--", "ls"],
+            fail_on_not_found=True,
+        )
+        self.assert_regex(result, pass_regex=["ROCPROFSYS_SAMPLING_AINICS=nic0"])
+
+    @pytest.mark.sampling
+    @pytest.mark.parametrize("preset", ["trace-hpc", "trace-gpu"])
+    def test_preset_plus_gpus(self, preset):
+        result = self.run_test(
+            "baseline",
+            target="rocprof-sys-sample",
+            run_args=[f"--preset={preset}", "--gpus=0", "-v", "2", "--", "ls"],
+            fail_on_not_found=True,
+        )
+        self.assert_regex(
+            result,
+            pass_regex=[
+                "ROCPROFSYS_SAMPLING_GPUS=0",
+                "ROCPROFSYS_USE_AMD_SMI=true",
+            ],
+        )
+
+
+# ============================================================================
 # Export Config Tests
 # ============================================================================
 

--- a/projects/rocprofiler-systems/tests/pytest/test_presets.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_presets.py
@@ -111,9 +111,9 @@ class TestRunPresets(RocprofsysTest):
 
 
 @pytest.mark.timeout(60)
+@pytest.mark.sampling
 @pytest.mark.class_name("sample-domain-flags")
 class TestSampleDomainFlags(RocprofsysTest):
-    @pytest.mark.sampling
     def test_gpu(self):
         result = self.run_test(
             "baseline",
@@ -123,7 +123,6 @@ class TestSampleDomainFlags(RocprofsysTest):
         )
         self.assert_regex(result, pass_regex=["ROCPROFSYS_USE_AMD_SMI=true"])
 
-    @pytest.mark.sampling
     def test_gpu_metrics(self):
         result = self.run_test(
             "baseline",
@@ -133,7 +132,6 @@ class TestSampleDomainFlags(RocprofsysTest):
         )
         self.assert_regex(result, pass_regex=["ROCPROFSYS_AMD_SMI_METRICS=temp,power"])
 
-    @pytest.mark.sampling
     def test_rocm(self):
         result = self.run_test(
             "baseline",
@@ -146,7 +144,6 @@ class TestSampleDomainFlags(RocprofsysTest):
             pass_regex=["ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,kernel_dispatch"],
         )
 
-    @pytest.mark.sampling
     def test_cpu(self):
         result = self.run_test(
             "baseline",
@@ -156,7 +153,6 @@ class TestSampleDomainFlags(RocprofsysTest):
         )
         self.assert_regex(result, pass_regex=["ROCPROFSYS_SAMPLING_FREQ=50"])
 
-    @pytest.mark.sampling
     def test_parallel(self):
         result = self.run_test(
             "baseline",
@@ -166,7 +162,6 @@ class TestSampleDomainFlags(RocprofsysTest):
         )
         self.assert_regex(result, pass_regex=["ROCPROFSYS_USE_MPIP=true"])
 
-    @pytest.mark.sampling
     def test_preset_plus_domain(self):
         result = self.run_test(
             "baseline",
@@ -190,9 +185,9 @@ class TestSampleDomainFlags(RocprofsysTest):
 
 
 @pytest.mark.timeout(60)
+@pytest.mark.sys_run
 @pytest.mark.class_name("run-domain-flags")
 class TestRunDomainFlags(RocprofsysTest):
-    @pytest.mark.sys_run
     def test_gpu(self):
         result = self.run_test(
             "baseline",
@@ -202,7 +197,6 @@ class TestRunDomainFlags(RocprofsysTest):
         )
         self.assert_regex(result, pass_regex=["ROCPROFSYS_USE_AMD_SMI=true"])
 
-    @pytest.mark.sys_run
     def test_gpu_metrics(self):
         result = self.run_test(
             "baseline",
@@ -212,7 +206,6 @@ class TestRunDomainFlags(RocprofsysTest):
         )
         self.assert_regex(result, pass_regex=["ROCPROFSYS_AMD_SMI_METRICS=temp,power"])
 
-    @pytest.mark.sys_run
     def test_rocm(self):
         result = self.run_test(
             "baseline",
@@ -225,7 +218,6 @@ class TestRunDomainFlags(RocprofsysTest):
             pass_regex=["ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,kernel_dispatch"],
         )
 
-    @pytest.mark.sys_run
     def test_cpu(self):
         result = self.run_test(
             "baseline",
@@ -235,7 +227,6 @@ class TestRunDomainFlags(RocprofsysTest):
         )
         self.assert_regex(result, pass_regex=["ROCPROFSYS_SAMPLING_FREQ=50"])
 
-    @pytest.mark.sys_run
     def test_parallel(self):
         result = self.run_test(
             "baseline",
@@ -245,7 +236,6 @@ class TestRunDomainFlags(RocprofsysTest):
         )
         self.assert_regex(result, pass_regex=["ROCPROFSYS_USE_MPIP=true"])
 
-    @pytest.mark.sys_run
     def test_preset_plus_domain(self):
         result = self.run_test(
             "baseline",
@@ -272,9 +262,9 @@ class TestRunDomainFlags(RocprofsysTest):
 
 
 @pytest.mark.timeout(60)
+@pytest.mark.sys_run
 @pytest.mark.class_name("run-sampling-target-flags")
 class TestRunSamplingTargetFlags(RocprofsysTest):
-    @pytest.mark.sys_run
     def test_gpus_without_device(self):
         result = self.run_test(
             "baseline",
@@ -284,7 +274,6 @@ class TestRunSamplingTargetFlags(RocprofsysTest):
         )
         self.assert_regex(result, pass_regex=["ROCPROFSYS_SAMPLING_GPUS=0"])
 
-    @pytest.mark.sys_run
     def test_cpus_without_host(self):
         result = self.run_test(
             "baseline",
@@ -294,7 +283,6 @@ class TestRunSamplingTargetFlags(RocprofsysTest):
         )
         self.assert_regex(result, pass_regex=["ROCPROFSYS_SAMPLING_CPUS=0-3"])
 
-    @pytest.mark.sys_run
     def test_ai_nics_without_device(self):
         result = self.run_test(
             "baseline",
@@ -304,7 +292,6 @@ class TestRunSamplingTargetFlags(RocprofsysTest):
         )
         self.assert_regex(result, pass_regex=["ROCPROFSYS_SAMPLING_AINICS=nic0"])
 
-    @pytest.mark.sys_run
     @pytest.mark.parametrize("preset", ["trace-hpc", "trace-gpu"])
     def test_preset_plus_gpus(self, preset):
         result = self.run_test(
@@ -323,9 +310,9 @@ class TestRunSamplingTargetFlags(RocprofsysTest):
 
 
 @pytest.mark.timeout(60)
+@pytest.mark.sampling
 @pytest.mark.class_name("sample-sampling-target-flags")
 class TestSampleSamplingTargetFlags(RocprofsysTest):
-    @pytest.mark.sampling
     def test_gpus_without_device(self):
         result = self.run_test(
             "baseline",
@@ -335,7 +322,6 @@ class TestSampleSamplingTargetFlags(RocprofsysTest):
         )
         self.assert_regex(result, pass_regex=["ROCPROFSYS_SAMPLING_GPUS=0"])
 
-    @pytest.mark.sampling
     def test_cpus_without_host(self):
         result = self.run_test(
             "baseline",
@@ -345,7 +331,6 @@ class TestSampleSamplingTargetFlags(RocprofsysTest):
         )
         self.assert_regex(result, pass_regex=["ROCPROFSYS_SAMPLING_CPUS=0-3"])
 
-    @pytest.mark.sampling
     def test_ai_nics_without_device(self):
         result = self.run_test(
             "baseline",
@@ -355,7 +340,6 @@ class TestSampleSamplingTargetFlags(RocprofsysTest):
         )
         self.assert_regex(result, pass_regex=["ROCPROFSYS_SAMPLING_AINICS=nic0"])
 
-    @pytest.mark.sampling
     @pytest.mark.parametrize("preset", ["trace-hpc", "trace-gpu"])
     def test_preset_plus_gpus(self, preset):
         result = self.run_test(


### PR DESCRIPTION
## Motivation

`rocprof-sys-run --preset=trace-hpc --gpus=0 -- ./app` (and the same shape with `--preset=trace-gpu`) was rejected by the parser even though `--preset=trace-hpc` already sets `ROCPROFSYS_USE_AMD_SMI=true` via `domains.gpu.enabled` in the preset JSON. The user had to add a redundant `--device` token to satisfy the parser, defeating the point of the preset/domain-flag composition model. The same issue applied to `--cpus` (which required `--host`) and `--ai-nics` (which required `--device`).

## Technical Details

The bug lived in `source/lib/core/argparse.cpp` where three flags carried timemory-argparse's parser-level dependency constraint:

- `--cpus` had `.required({ "host" })`
- `--gpus` had `.required({ "device" })`
- `--ai-nics` had `.required({ "device" })`

These constraints fire *at parser dispatch time*, before any `.action()` callback runs. Presets that set the matching env var via
`json_config::resolve_schema_config` (forward mapping for `domains.gpu.enabled` → `ROCPROFSYS_USE_AMD_SMI=true`) could never satisfy them, because they don't add a literal `-D`/`-H` token to the command line. The constraint was a stale assumption from before the preset/domain-flag system existed.

The fix drops all three `.required({...})` calls. Each flag's `.action()` body already only writes its own `*_GPUS` / `*_CPUS` / `*_AINICS` env var; it does not enable any backend on its own. Orphan use (e.g. `--gpus=0` with no preset and no `-D`) becomes a silent no-op - the env var is set but ignored at runtime when AMD SMI is disabled, matching the project's existing behavior for orphan
env vars.

No other code paths needed adjustment: the runtime already gates on `USE_AMD_SMI`/`USE_PROCESS_SAMPLING` before consuming `SAMPLING_GPUS` (see the dual-write pattern in `argparse.cpp` for the `-D/--device` No other code paths needed adjustment: the runtime already gates on `USE_AMD_SMI`/`USE_PROCESS_SAMPLING` before consuming `SAMPLING_GPUS`
(see the dual-write pattern in `argparse.cpp` for the `-D/--device` action, which the preset path emulates).

## JIRA ID

ROCM-24817

## Test Plan

- Added 10 new regression cases in `tests/pytest/test_presets.py`, split across two new test classes (`TestRunSamplingTargetFlags`, `TestSampleSamplingTargetFlags`) so both `rocprof-sys-run` and `rocprof-sys-sample` are covered. Each class asserts:

- `--gpus=0 -v 2 -- ls` succeeds and `ROCPROFSYS_SAMPLING_GPUS=0` reaches the inferior env (orphan case, no preset, no `--device`)
- `--cpus=0-3 -v 2 -- ls` succeeds and `ROCPROFSYS_SAMPLING_CPUS=0-3` reaches the env (orphan, no `--host`)
- `--ai-nics=nic0 -v 2 -- ls` succeeds and `ROCPROFSYS_SAMPLING_AINICS=nic0` reaches the env (orphan)
- `--preset={trace-hpc,trace-gpu} --gpus=0 -v 2 -- ls` succeeds and both `ROCPROFSYS_SAMPLING_GPUS=0` AND `ROCPROFSYS_USE_AMD_SMI=true` reach the env (the user's reported scenario, parameterized over the two affected presets)

- Full preset-labeled suite was re-run to confirm no collateral regression.

## Test Result

- New regression tests (10 of 10): **PASS**
- Full `ctest -L presets` suite (56 of 56): **PASS** in ~20 s
- Manual sanity:
  `rocprof-sys-run --preset=trace-hpc --gpus=0 -v 2 -- ls` now exec's the inferior with `ROCPROFSYS_SAMPLING_GPUS=0` and   `ROCPROFSYS_USE_AMD_SMI=true` both present in the env dump

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/C