### PR TITLE
rocrtst: Fix invalid usage of hsa_amd_memory_async_copy

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/performance/memory_async_copy.cc
+++ b/projects/rocr-runtime/rocrtst/suites/performance/memory_async_copy.cc
@@ -378,7 +378,7 @@ void MemoryAsyncCopy::RunBenchmarkWithVerification(Transaction *t) {
     return;
   }
 
-  err = hsa_amd_memory_async_copy(ptr_src, *cpy_ag, host_ptr_src, *cpy_ag,
+  err = hsa_amd_memory_async_copy(ptr_src, src_agent, host_ptr_src, cpu_agent_,
                                                             size, 0, NULL, s);
   ASSERT_EQ(HSA_STATUS_SUCCESS, err);
 
@@ -421,7 +421,7 @@ void MemoryAsyncCopy::RunBenchmarkWithVerification(Transaction *t) {
       int index = copy_timer.CreateTimer();
 
       copy_timer.StartTimer(index);
-      err = hsa_amd_memory_async_copy(ptr_dst, *cpy_ag, ptr_src, *cpy_ag, 
+      err = hsa_amd_memory_async_copy(ptr_dst, dst_agent, ptr_src, src_agent,
                                                 Granularities[i].Size, 0, NULL, t->signal);
       ASSERT_EQ(HSA_STATUS_SUCCESS, err);
 

--- a/projects/rocr-runtime/rocrtst/suites/performance/memory_async_copy_on_engine.cc
+++ b/projects/rocr-runtime/rocrtst/suites/performance/memory_async_copy_on_engine.cc
@@ -152,7 +152,7 @@ void MemoryAsyncCopyOnEngine::RunBenchmarkWithVerification(Transaction *t) {
     return;
   }
 
-  err = hsa_amd_memory_async_copy(ptr_src, *cpy_ag, host_ptr_src, *cpy_ag,
+  err = hsa_amd_memory_async_copy(ptr_src, src_agent, host_ptr_src, cpu_agent_,
                                                             size, 0, NULL, s);
   ASSERT_EQ(HSA_STATUS_SUCCESS, err);
 


### PR DESCRIPTION
## Motivation

It was discovered that both `rocrtstPerf.Memory_Async_Copy` and `rocrtstPerf.Memory_Async_Copy_On_Engine` are failing due to memory corruption.

## Technical Details

Upon investigation it was determined that the cause is the incorrect usage of `hsa_amd_memory_async_copy` which was provided with the CPU agent for both GPU and CPU accesses which is invalid. This results in a success result but with a corrupted destination buffer.

This issue had gone undetected until recently due to another bug that was corrected (6ad0a3804290cae49f9b214c3042b71663aab5de) which prevented verification failure from causing the test to yield a fail

## JIRA ID

FEAT-78533

## Test Plan

`rocrtst64 --gtest_filter="rocrtstPerf.Memory_Async_Copy:rocrtstPerf.Memory_Async_Copy_On_Engine"`

## Test Result

```
Note: Google Test filter = rocrtstPerf.Memory_Async_Copy:rocrtstPerf.Memory_Async_Copy_On_Engine
[==========] Running 2 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 2 tests from rocrtstPerf
[ RUN      ] rocrtstPerf.Memory_Async_Copy

  ** Details stripped due to avoid disclosure **
  
#### TEST RESULTS ####
=========================== PATH: From Pool 0 To Pool 4 (Host-To-Device) ===========================
Verification: Pass

  ** Details stripped due to avoid disclosure **

=========================== PATH: From Pool 4 To Pool 0 (Device-To-Host) ===========================
Verification: Pass

  ** Details stripped due to avoid disclosure **

#### TEST CLEAN UP ####
[       OK ] rocrtstPerf.Memory_Async_Copy (... ms)
[ RUN      ] rocrtstPerf.Memory_Async_Copy_On_Engine

  ** Details stripped due to avoid disclosure **

#### TEST RESULTS ####
=========================== PATH: From Pool 0 To Pool 4 (Host-To-Device) ===========================
Verification: Pass

  ** Details stripped due to avoid disclosure **

=========================== PATH: From Pool 4 To Pool 0 (Device-To-Host) ===========================
Verification: Pass

  ** Details stripped due to avoid disclosure **
  
	#### TEST CLEAN UP ####
[       OK ] rocrtstPerf.Memory_Async_Copy_On_Engine (.. ms)
[----------] 2 tests from rocrtstPerf (.. ms total)

[----------] Global test environment tear-down
[==========] 2 tests from
```

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
