### PR TITLE
[rocprofiler-systems] Bump dyninst submodule and add RHEL 10 workflows

### DIFF
--- a/.github/workflows/rocprofiler-systems-redhat.yml
+++ b/.github/workflows/rocprofiler-systems-redhat.yml
@@ -60,9 +60,16 @@ jobs:
       fail-fast: false
       matrix:
         compiler: ['g++']
-        os-release: [ '8.10', '9' ]
+        os-release: [ '8.10', '9', '10']
         rocm-version: [ '6.3', '6.4', '7.0', '7.1', '7.2' ]
         build-type: ['Release']
+        exclude:
+          - os-release: '10'
+            rocm-version: '6.3'
+          - os-release: '10'
+            rocm-version: '6.4'
+          - os-release: '10'
+            rocm-version: '7.0'
 
     steps:
     - uses: actions/checkout@v6
@@ -92,6 +99,14 @@ jobs:
             chmod +x /opt/trace_processor/bin/trace_processor_shell
             # Set env var so validate_perfetto_trace() uses the downloaded binary
             echo "ROCPROFSYS_TRACE_PROC_SHELL=/opt/trace_processor/bin/trace_processor_shell" >> $GITHUB_ENV
+          fi
+          if [ $OS_VERSION_MAJOR -eq 10 ]; then
+            # RHEL 10 ships OpenMPI 5.x, whose PRRTE launcher consumes the '--'
+            # option-terminator that rocprof-sys-run requires. Install MPICH
+            # and put it ahead of OpenMPI on PATH so the test capability probe
+            # picks mpich's mpiexec instead.
+            dnf install -y --enablerepo=crb mpich mpich-devel
+            echo "/usr/lib64/mpich/bin" >> $GITHUB_PATH
           fi
 
     - name: Configure, Build, and Test

--- a/.github/workflows/rocprofiler-systems-redhat.yml
+++ b/.github/workflows/rocprofiler-systems-redhat.yml
@@ -60,7 +60,7 @@ jobs:
       fail-fast: false
       matrix:
         compiler: ['g++']
-        os-release: [ '8.10', '9', '10']
+        os-release: [ '8.10', '9', '10' ]
         rocm-version: [ '6.3', '6.4', '7.0', '7.1', '7.2' ]
         build-type: ['Release']
         exclude:
@@ -101,10 +101,7 @@ jobs:
             echo "ROCPROFSYS_TRACE_PROC_SHELL=/opt/trace_processor/bin/trace_processor_shell" >> $GITHUB_ENV
           fi
           if [ $OS_VERSION_MAJOR -eq 10 ]; then
-            # RHEL 10 ships OpenMPI 5.x, whose PRRTE launcher consumes the '--'
-            # option-terminator that rocprof-sys-run requires. Install MPICH
-            # and put it ahead of OpenMPI on PATH so the test capability probe
-            # picks mpich's mpiexec instead.
+            # TODO: Move package install to the docker.
             dnf install -y --enablerepo=crb mpich mpich-devel
             echo "/usr/lib64/mpich/bin" >> $GITHUB_PATH
           fi


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

This PR bumps the dyninst submodule from 42c0744dcac3337ac3382b61d87a8a9eab6216e8 to 8d6f2bf3043f4307dc59d2b3e66514aac9a44160

This includes 4 PRs:
 - https://github.com/ROCm/dyninst/pull/18
 - https://github.com/ROCm/dyninst/pull/19
 - https://github.com/ROCm/dyninst/pull/21
 - https://github.com/ROCm/dyninst/pull/20

Of these four, only the PR that adds support for ELF's RELR relocation (https://github.com/ROCm/dyninst/pull/19) requires changes here for testing purposes.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

 - Update dyninst submodule
 - Add RHEL 10 workflow. This will test the RELR relocation change as `coreutils` is distributed in such a way that it uses RELR. 

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

AIPROFSYST-438 (https://github.com/ROCm/dyninst/pull/19)
AIPROFSYST-179 (https://github.com/ROCm/dyninst/pull/20)

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Only the RELR PR (https://github.com/ROCm/dyninst/pull/19) needs to have an associated test. That test will be the RHEL 10 workflow itself as `coreutils` was compiled with RELR enabled. An independent test in our suite is not required.


https://github.com/ROCm/dyninst/pull/20 has been tested independently using the `matmul` example (https://github.com/ROCm/rocm-examples/blob/amd-staging/Tools/rocprof-systems/main.hip) compiled in such a way that there are two adjacent `LOAD` segments, with the `.text` section starting at the same address of the second adjacent `LOAD` segment.
Adding an independent test for this in `rocprofiler-systems` is not a trivial task and is not required. Trying to hard code a simple one that does not use the linker forces a static `rocprofsys` library to be needed, which is not built by default. Ones that require the linker are more complex and risk the `LOAD` segments no longer being adjacent. **Plus, this is a change within dyninst that has been merged within their repo, so no test on our side should be required**.

## Test Result

<!-- Briefly summarize test outcomes. -->

Passing RHEL 10 workflows:
 - https://github.com/ROCm/rocm-systems/actions/runs/26448716553/job/77864812855?pr=6419
 - https://github.com/ROCm/rocm-systems/actions/runs/26448716553/job/77864812858?pr=6419

`matmul` `binary rewrite` now passes. Also the suite of `rocprof-systems` CTests associated with https://github.com/ROCm/rocm-examples pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
