### PR TITLE
Add hipMemcpyBatchAsync unit and performance tests

### DIFF
--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -734,7 +734,7 @@ hipError_t ihipMemcpy(void* dst, const void* src, size_t sizeBytes, hipMemcpyKin
   amd::Memory* srcDeviceMemory = nullptr;
   amd::Memory* dstDeviceMemory = nullptr;
   getMemoryObjectPairs(src, dst, srcDeviceMemory, dstDeviceMemory, sOffset, dOffset);
-  
+
   // Handle kind vs memobject miss matches
   if (kind == hipMemcpyDeviceToHost && srcDeviceMemory == nullptr) {
     return hipErrorInvalidValue;
@@ -3015,33 +3015,74 @@ hipError_t ihipMemcpyBatch(void** dsts, void** srcs, size_t* sizes, size_t count
 
   // Handle buffer-to-buffer copies as a batch
   if (!bufferCopyIndices.empty()) {
-    std::vector<amd::BatchCopyOp> copyOps;
-    copyOps.reserve(bufferCopyIndices.size());
+    std::vector<std::vector<amd::BatchCopyOp>> copy_ops_by_device(g_devices.size());
 
     for (size_t idx : bufferCopyIndices) {
-      if (srcMemories[idx] == nullptr || dstMemories[idx] == nullptr) {
-        return hipErrorInvalidValue;
+      const int device_id = dstMemories[idx]->getUserData().deviceId;
+      amd::CopyMetadata metadata =
+          buildCopyMetadataFromAttrs(attrs, attrsIdxs, numAttrs, idx, isAsync);
+      copy_ops_by_device[device_id].emplace_back(srcMemories[idx], dstMemories[idx],
+                                                 srcOffsets[idx], dstOffsets[idx], sizes[idx],
+                                                 metadata);
+    }
+
+    amd::Command::EventWaitList marker_wait_list;
+    amd::Command* stream_wait_cmd = stream.getLastQueuedCommand(true);
+    for (size_t device_id = 0; device_id < copy_ops_by_device.size(); ++device_id) {
+      auto& copy_ops = copy_ops_by_device[device_id];
+      if (copy_ops.empty()) {
+        continue;
       }
 
-      amd::CopyMetadata metadata = buildCopyMetadataFromAttrs(attrs, attrsIdxs, numAttrs, idx, isAsync);
-      copyOps.emplace_back(srcMemories[idx], dstMemories[idx], srcOffsets[idx], dstOffsets[idx], sizes[idx],
-                           metadata);
+      hip::Stream* queue_stream = static_cast<int>(device_id) == stream.DeviceId()
+                                      ? &stream
+                                      : hip::getNullStream(*g_devices[device_id]->asContext());
+      amd::Command::EventWaitList wait_list;
+      if (queue_stream != &stream && stream_wait_cmd != nullptr) {
+        wait_list.push_back(stream_wait_cmd);
+      }
+
+      amd::BatchCopyMemoryCommand* batch_cmd = new amd::BatchCopyMemoryCommand(
+          *queue_stream, ROCCLR_COMMAND_BATCH_COPY_BUFFER, wait_list, std::move(copy_ops));
+
+      if (batch_cmd == nullptr) {
+        if (stream_wait_cmd != nullptr) {
+          stream_wait_cmd->release();
+        }
+        for (auto* cmd : marker_wait_list) {
+          cmd->release();
+        }
+        return hipErrorOutOfMemory;
+      }
+
+      batch_cmd->enqueue();
+      if (!isAsync) {
+        batch_cmd->queue()->finishCommand(batch_cmd);
+      } else if (queue_stream != &stream) {
+        batch_cmd->retain();
+        marker_wait_list.push_back(batch_cmd);
+      }
+      batch_cmd->release();
     }
 
-    // Create and enqueue batch copy command
-    amd::Command::EventWaitList waitList;
-    amd::BatchCopyMemoryCommand* batchCmd = new amd::BatchCopyMemoryCommand(
-        stream, ROCCLR_COMMAND_BATCH_COPY_BUFFER, waitList, std::move(copyOps));
-
-    if (batchCmd == nullptr) {
-      return hipErrorOutOfMemory;
+    if (stream_wait_cmd != nullptr) {
+      stream_wait_cmd->release();
     }
 
-    batchCmd->enqueue();
-    if (!isAsync) {
-      batchCmd->queue()->finishCommand(batchCmd);
+    if (!marker_wait_list.empty()) {
+      amd::Command* dependent_marker = new amd::Marker(stream, true, marker_wait_list);
+      if (dependent_marker == nullptr) {
+        for (auto* cmd : marker_wait_list) {
+          cmd->release();
+        }
+        return hipErrorOutOfMemory;
+      }
+      dependent_marker->enqueue();
+      dependent_marker->release();
+      for (auto* cmd : marker_wait_list) {
+        cmd->release();
+      }
     }
-    batchCmd->release();
   }
 
   // Handle write buffer (host to device) copies.

--- a/projects/hip-tests/.clang-format
+++ b/projects/hip-tests/.clang-format
@@ -3,7 +3,7 @@ BasedOnStyle: Google
 AlignEscapedNewlinesLeft: false
 AlignOperands: Align
 ColumnLimit: 100
-BreakTemplateDeclarations: No
+AlwaysBreakTemplateDeclarations: No
 DerivePointerAlignment: false
 IndentFunctionDeclarationAfterType: false
 MaxEmptyLinesToKeep: 2

--- a/projects/hip-tests/catch/config/configs/performance.yaml
+++ b/projects/hip-tests/catch/config/configs/performance.yaml
@@ -37,8 +37,12 @@ performance:
   Performance_hipMemcpyHtoA:
     <<: *level_2
     tags: [image]
-  Performance_hipMemcpyBatchAsync_D2D_OptimizedPath_Aligned: *level_2
-  Performance_hipMemcpyBatchAsync_D2D_OptimizedPath_4ByteOffset: *level_2
+  Performance_hipMemcpyBatchAsync_D2D: *level_2
+  Performance_hipMemcpyBatchAsync_P2P: *level_2
+  Performance_hipMemcpyBatchAsync_H2D_Pageable: *level_2
+  Performance_hipMemcpyBatchAsync_H2D_Pinned: *level_2
+  Performance_hipMemcpyBatchAsync_D2H_Pageable: *level_2
+  Performance_hipMemcpyBatchAsync_D2H_Pinned: *level_2
   Performance_hipMemcpyDtoD_PeerAccessEnabled: *level_2
   Performance_hipMemcpyDtoD_PeerAccessDisabled: *level_2
   Performance_hipMemcpyDtoDAsync_PeerAccessEnabled: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/memory.yaml
@@ -733,12 +733,33 @@ memory:
     <<: *level_2
     tags: [transfer]
   Unit_hipMemcpyBatchAsync_D2D_Functional: *level_2
-  Unit_hipMemcpyBatchAsync_H2D_Functional: *level_2
-  Unit_hipMemcpyBatchAsync_D2H_Functional: *level_2
-  Unit_hipMemcpyBatchAsync_H2H_Functional: *level_2
-  Unit_hipMemcpyBatchAsync_NegativeTsts:
+  Unit_hipMemcpyBatchAsync_Negative:
     <<: *level_2
     tags: [transfer]
+  Unit_hipMemcpyBatchAsync_Attrs_Negative:
+    <<: *level_2
+    tags: [transfer]
+  Unit_hipMemcpyBatchAsync_Attrs_Functional:
+    <<: *level_2
+    tags: [transfer]
+  Unit_hipMemcpyBatchAsync_H2D_Functional: *level_2
+  Unit_hipMemcpyBatchAsync_H2D_Pageable_DuringApiCall_SourceAccess:
+    <<: *level_2
+    tags: [transfer]
+  Unit_hipMemcpyBatchAsync_H2D_Pageable_Stream_SourceAccess:
+    <<: *level_2
+    tags: [transfer, stream]
+  Unit_hipMemcpyBatchAsync_D2H_Functional: *level_2
+  Unit_hipMemcpyBatchAsync_H2H_Functional: *level_2
+  Unit_hipMemcpyBatchAsync_Mixed_Functional:
+    <<: *level_2
+    tags: [transfer]
+  Unit_hipMemcpyBatchAsync_Stream:
+    <<: *level_2
+    tags: [transfer, stream]
+  Unit_hipMemcpyBatchAsync_P2P_Functional:
+    <<: *level_2
+    tags: [transfer, multigpu]
   Unit_hipMemsetD2D8_BasicFunctional:
     <<: *level_2
     tags: [memset]

--- a/projects/hip-tests/catch/include/performance_common.hh
+++ b/projects/hip-tests/catch/include/performance_common.hh
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <functional>
 #include <iomanip>
 #include <memory>
 #include <numeric>
@@ -135,7 +136,14 @@ template <typename Derived> class Benchmark {
   using ModifierSignature = std::function<float(float)>;
   void RegisterModifier(const ModifierSignature& modifier) { modifier_ = modifier; }
 
+  using StatsSuffixSignature = std::function<std::string(float)>;
+  void RegisterStatsSuffix(const StatsSuffixSignature& stats_suffix) {
+    stats_suffix_ = stats_suffix;
+  }
+
   void RegisterBandwidth(size_t bytes) { bandwidth_bytes_ = bytes; }
+
+  void SetDisplayOutput(bool display_output) { display_output_ = display_output; }
 
   template <typename... Args> std::tuple<float, float, float, float> Run(Args&&... args) {
     AddSectionName(std::to_string(iterations_));
@@ -205,6 +213,7 @@ template <typename Derived> class Benchmark {
   size_t bandwidth_bytes_ = 0;
 
   ModifierSignature modifier_;
+  StatsSuffixSignature stats_suffix_;
 
   void Print(const std::string& out = "") {
     if (!display_output_) return;
@@ -225,6 +234,9 @@ template <typename Derived> class Benchmark {
                         " ms, Slowest: " + std::to_string(worst) + " ms";
     if (bandwidth_bytes_ != 0) {
       stats += ", Bandwidth: " + FormatGigabytesPerSecond(bandwidth_bytes_, mean) + " GB/s";
+    }
+    if (stats_suffix_) {
+      stats += stats_suffix_(mean);
     }
     Print(stats + "\n");
   }

--- a/projects/hip-tests/catch/performance/api/memcpy/hipMemcpyBatchAsync.cc
+++ b/projects/hip-tests/catch/performance/api/memcpy/hipMemcpyBatchAsync.cc
@@ -6,9 +6,11 @@
 
 #include "memcpy_performance_common.hh"
 
-#include <array>
-#include <cstdint>
+#include <cstring>
+#include <iomanip>
+#include <sstream>
 #include <string>
+#include <tuple>
 #include <vector>
 
 /**
@@ -17,12 +19,14 @@
  * @ingroup PerformanceTestMemory
  */
 
-#if HT_AMD
-
 namespace {
 
-constexpr size_t kBatchCount = 8;
 constexpr unsigned char kPattern = 0x5a;
+
+enum class PointerPattern {
+  BasePointers,
+  BroadcastSource,
+};
 
 std::string GetSizeSectionName(size_t size) {
   if (size < 1_MB) {
@@ -31,129 +35,206 @@ std::string GetSizeSectionName(size_t size) {
   return std::to_string(size / 1_MB) + " MB";
 }
 
-size_t AlignUp(size_t value, size_t alignment) {
-  return ((value + alignment - 1) / alignment) * alignment;
+std::string GetPointerPatternSectionName(PointerPattern pointer_pattern) {
+  switch (pointer_pattern) {
+    case PointerPattern::BasePointers:
+      return "base pointers";
+    case PointerPattern::BroadcastSource:
+      return "broadcast source";
+  }
+  return "unknown pointer pattern";
 }
 
-class MemcpyBatchAsyncDtoDBenchmark
-    : public Benchmark<MemcpyBatchAsyncDtoDBenchmark> {
-public:
-  void operator()(void **dsts, void **srcs, size_t *sizes, size_t count,
-                  const hipStream_t &stream) {
-    constexpr size_t kNumAttrs = 0;
-    size_t attrs_idxs[1] = {0};
-    size_t fail_idx = 0;
-
+class MemcpyBatchAsync : public Benchmark<MemcpyBatchAsync> {
+ public:
+  void operator()(void** dsts, void** srcs, size_t* sizes, size_t count, hipStream_t stream) {
     TIMED_SECTION_STREAM(kTimerTypeCpu, stream) {
-      HIP_CHECK(hipMemcpyBatchAsync(dsts, srcs, sizes, count, nullptr,
-                                    attrs_idxs, kNumAttrs, &fail_idx, stream));
+      HIP_CHECK(
+          hipMemcpyBatchAsync(dsts, srcs, sizes, count, nullptr, nullptr, 0, nullptr, stream));
     }
   }
 };
 
-void ValidateCopy(void *dst, size_t size) {
-  std::array<unsigned char, 16> prefix = {};
-  unsigned char suffix = 0;
-
-  HIP_CHECK(
-      hipMemcpy(prefix.data(), dst, prefix.size(), hipMemcpyDeviceToHost));
-  HIP_CHECK(hipMemcpy(&suffix, static_cast<unsigned char *>(dst) + size - 1,
-                      sizeof(suffix), hipMemcpyDeviceToHost));
-
-  for (const auto value : prefix) {
-    REQUIRE(value == kPattern);
+class MemcpySequentialAsync : public Benchmark<MemcpySequentialAsync> {
+ public:
+  void operator()(void** dsts, void** srcs, size_t* sizes, size_t count, hipMemcpyKind kind,
+                  hipStream_t stream) {
+    TIMED_SECTION_STREAM(kTimerTypeCpu, stream) {
+      for (size_t i = 0; i < count; ++i) {
+        HIP_CHECK(hipMemcpyAsync(dsts[i], srcs[i], sizes[i], kind, stream));
+      }
+    }
   }
-  REQUIRE(suffix == kPattern);
+};
+
+template <typename BenchmarkType>
+void AddCommonSectionNames(BenchmarkType& benchmark, size_t copy_size, size_t batch_copy_count,
+                           PointerPattern pointer_pattern) {
+  benchmark.AddSectionName(GetPointerPatternSectionName(pointer_pattern));
+  benchmark.AddSectionName(GetSizeSectionName(copy_size));
+  benchmark.AddSectionName(std::to_string(batch_copy_count) + " copies");
+  benchmark.RegisterBandwidth(copy_size * batch_copy_count);
 }
 
-void RunBenchmark(size_t copy_size, size_t offset) {
-  MemcpyBatchAsyncDtoDBenchmark benchmark;
-  benchmark.AddSectionName(GetSizeSectionName(copy_size));
-  benchmark.AddSectionName(offset == 0 ? "aligned" : "4-byte offset");
-  benchmark.AddSectionName(std::to_string(kBatchCount) + " copies");
-  benchmark.RegisterBandwidth(copy_size * kBatchCount);
+std::string FormatSpeedupRatio(float batch_mean, float sequential_mean) {
+  std::ostringstream ratio;
+  ratio << std::fixed << std::setprecision(2) << sequential_mean / batch_mean;
+  return ratio.str();
+}
 
-  constexpr size_t kAllocationAlignment = 256;
-  const size_t stride = AlignUp(copy_size + offset, kAllocationAlignment);
-  const size_t allocation_size = stride * kBatchCount;
+void RunComparison(void** dsts, void** srcs, size_t* sizes, size_t count, size_t copy_size,
+                   size_t batch_copy_count, PointerPattern pointer_pattern, hipMemcpyKind kind) {
+  const StreamGuard stream_guard{Streams::created};
+  const hipStream_t stream = stream_guard.stream();
 
-  void *src_allocation = nullptr;
-  void *dst_allocation = nullptr;
-  HIP_CHECK(hipMalloc(&src_allocation, allocation_size));
-  HIP_CHECK(hipMalloc(&dst_allocation, allocation_size));
-  HIP_CHECK(hipMemset(src_allocation, kPattern, allocation_size));
-  HIP_CHECK(hipMemset(dst_allocation, 0, allocation_size));
+  MemcpySequentialAsync sequential_benchmark;
+  sequential_benchmark.SetDisplayOutput(false);
+  const auto sequential_stats = sequential_benchmark.Run(dsts, srcs, sizes, count, kind, stream);
+  const float sequential_mean = std::get<0>(sequential_stats);
 
-  std::vector<void *> srcs(kBatchCount);
-  std::vector<void *> dsts(kBatchCount);
-  std::vector<size_t> sizes(kBatchCount, copy_size);
-  for (size_t i = 0; i < kBatchCount; ++i) {
-    srcs[i] =
-        static_cast<unsigned char *>(src_allocation) + (i * stride) + offset;
-    dsts[i] =
-        static_cast<unsigned char *>(dst_allocation) + (i * stride) + offset;
+  MemcpyBatchAsync batch_benchmark;
+  AddCommonSectionNames(batch_benchmark, copy_size, batch_copy_count, pointer_pattern);
+  batch_benchmark.RegisterStatsSuffix([sequential_mean](float batch_mean) {
+    return " Ratio " + FormatSpeedupRatio(batch_mean, sequential_mean) + "x";
+  });
+  batch_benchmark.Run(dsts, srcs, sizes, count, stream);
+}
+
+void RunDeviceToDeviceBenchmark(size_t copy_size, size_t batch_copy_count,
+                                PointerPattern pointer_pattern) {
+  const size_t allocation_size = copy_size * batch_copy_count;
+
+  LinearAllocGuard<unsigned char> src_allocation(LinearAllocs::hipMalloc, allocation_size);
+  LinearAllocGuard<unsigned char> dst_allocation(LinearAllocs::hipMalloc, allocation_size);
+  HIP_CHECK(hipMemset(src_allocation.ptr(), kPattern, allocation_size));
+
+  std::vector<void*> srcs(batch_copy_count);
+  std::vector<void*> dsts(batch_copy_count);
+  std::vector<size_t> sizes(batch_copy_count, copy_size);
+  for (size_t i = 0; i < batch_copy_count; ++i) {
+    srcs[i] = pointer_pattern == PointerPattern::BroadcastSource
+                  ? src_allocation.ptr()
+                  : src_allocation.ptr() + (i * copy_size);
+    dsts[i] = dst_allocation.ptr() + (i * copy_size);
   }
 
-  const StreamGuard stream_guard(Streams::created);
-  benchmark.Run(dsts.data(), srcs.data(), sizes.data(), sizes.size(),
-                stream_guard.stream());
+  RunComparison(dsts.data(), srcs.data(), sizes.data(), sizes.size(), copy_size, batch_copy_count,
+                pointer_pattern, hipMemcpyDeviceToDevice);
+}
 
-  for (size_t i = 0; i < kBatchCount; ++i) {
-    ValidateCopy(dsts[i], copy_size);
+void RunPeerToPeerBenchmark(size_t copy_size, size_t batch_copy_count,
+                            PointerPattern pointer_pattern) {
+  const size_t allocation_size = copy_size * batch_copy_count;
+  HIP_CHECK(hipSetDevice(0));
+  auto [src_device, dst_device] = GetDeviceIds(true);
+
+  HIP_CHECK(hipSetDevice(src_device));
+  LinearAllocGuard<unsigned char> src_allocation(LinearAllocs::hipMalloc, allocation_size);
+  HIP_CHECK(hipMemset(src_allocation.ptr(), kPattern, allocation_size));
+
+  HIP_CHECK(hipSetDevice(dst_device));
+  LinearAllocGuard<unsigned char> dst_allocation(LinearAllocs::hipMalloc, allocation_size);
+
+  std::vector<void*> srcs(batch_copy_count);
+  std::vector<void*> dsts(batch_copy_count);
+  std::vector<size_t> sizes(batch_copy_count, copy_size);
+  for (size_t i = 0; i < batch_copy_count; ++i) {
+    srcs[i] = pointer_pattern == PointerPattern::BroadcastSource
+                  ? src_allocation.ptr()
+                  : src_allocation.ptr() + (i * copy_size);
+    dsts[i] = dst_allocation.ptr() + (i * copy_size);
   }
 
-  HIP_CHECK(hipFree(src_allocation));
-  HIP_CHECK(hipFree(dst_allocation));
+  HIP_CHECK(hipSetDevice(src_device));
+  RunComparison(dsts.data(), srcs.data(), sizes.data(), sizes.size(), copy_size, batch_copy_count,
+                pointer_pattern, hipMemcpyDeviceToDevice);
+}
+
+void RunHostDeviceBenchmark(size_t copy_size, size_t batch_copy_count,
+                            LinearAllocs src_allocation_type, LinearAllocs dst_allocation_type,
+                            PointerPattern pointer_pattern) {
+  const size_t allocation_size = copy_size * batch_copy_count;
+
+  LinearAllocGuard<unsigned char> src_allocation(src_allocation_type, allocation_size);
+  LinearAllocGuard<unsigned char> dst_allocation(dst_allocation_type, allocation_size);
+  if (src_allocation_type == LinearAllocs::hipMalloc) {
+    HIP_CHECK(hipMemset(src_allocation.ptr(), kPattern, allocation_size));
+  } else {
+    std::memset(src_allocation.host_ptr(), kPattern, allocation_size);
+  }
+
+  std::vector<void*> srcs(batch_copy_count);
+  std::vector<void*> dsts(batch_copy_count);
+  std::vector<size_t> sizes(batch_copy_count, copy_size);
+  for (size_t i = 0; i < batch_copy_count; ++i) {
+    srcs[i] = pointer_pattern == PointerPattern::BroadcastSource
+                  ? src_allocation.ptr()
+                  : src_allocation.ptr() + (i * copy_size);
+    dsts[i] = dst_allocation.ptr() + (i * copy_size);
+  }
+
+  const hipMemcpyKind kind = src_allocation_type == LinearAllocs::hipMalloc ? hipMemcpyDeviceToHost
+                                                                            : hipMemcpyHostToDevice;
+  RunComparison(dsts.data(), srcs.data(), sizes.data(), sizes.size(), copy_size, batch_copy_count,
+                pointer_pattern, kind);
 }
 
 } // namespace
 
-/**
- * Test Description
- * ------------------------
- *  - Executes `hipMemcpyBatchAsync` with kBatchCount same-device D2D copies:
- *    -# Copy sizes: 4 KB, 64 KB, 128 KB, 256 KB, 1 MB, 4 MB,
- *       16 MB, 64 MB, 128 MB, 256 MB, 1024 MB
- *    -# Source and destination allocation type: hipMalloc on the current device
- *    -# Source and destination pointers are 256-byte aligned
- * Test source
- * ------------------------
- * - performance/api/memcpy/hipMemcpyBatchAsync.cc
- * Test requirements
- * ------------------------
- *  - AMD
- *  - HIP_VERSION >= 7.1
- */
-HIP_TEST_CASE(Performance_hipMemcpyBatchAsync_D2D_OptimizedPath_Aligned) {
-  const auto copy_size = GENERATE(4_KB, 64_KB, 128_KB, 256_KB, 1_MB, 4_MB,
-                                  16_MB, 64_MB, 128_MB, 256_MB, 1024_MB);
-  RunBenchmark(copy_size, 0);
+HIP_TEST_CASE(Performance_hipMemcpyBatchAsync_D2D) {
+  const PointerPattern pointer_pattern =
+      GENERATE(PointerPattern::BasePointers, PointerPattern::BroadcastSource);
+  const auto [copy_size, batch_copy_count] = GENERATE(table<size_t, size_t>(
+      {{4_KB, 4096}, {16_KB, 1024}, {64_KB, 256}, {256_KB, 64}, {1024_KB, 16}}));
+  RunDeviceToDeviceBenchmark(copy_size, batch_copy_count, pointer_pattern);
 }
 
-/**
- * Test Description
- * ------------------------
- *  - Executes `hipMemcpyBatchAsync` with kBatchCount same-device D2D copies:
- *    -# Copy sizes: 4 KB, 64 KB, 128 KB, 256 KB, 1 MB, 4 MB,
- *       16 MB, 64 MB, 128 MB, 256 MB, 1024 MB
- *    -# Source and destination allocation type: hipMalloc on the current device
- *    -# Source and destination pointers are offset by 4 bytes from a
- *       256-byte-aligned stride
- * Test source
- * ------------------------
- * - performance/api/memcpy/hipMemcpyBatchAsync.cc
- * Test requirements
- * ------------------------
- *  - AMD
- *  - HIP_VERSION >= 7.1
- */
-HIP_TEST_CASE(Performance_hipMemcpyBatchAsync_D2D_OptimizedPath_4ByteOffset) {
-  const auto copy_size = GENERATE(4_KB, 64_KB, 128_KB, 256_KB, 1_MB, 4_MB,
-                                  16_MB, 64_MB, 128_MB, 256_MB, 1024_MB);
-  RunBenchmark(copy_size, sizeof(uint32_t));
+HIP_TEST_CASE(Performance_hipMemcpyBatchAsync_P2P) {
+  if (HipTest::getDeviceCount() < 2) {
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+  }
+  const PointerPattern pointer_pattern =
+      GENERATE(PointerPattern::BasePointers, PointerPattern::BroadcastSource);
+  const auto [copy_size, batch_copy_count] = GENERATE(table<size_t, size_t>(
+      {{4_KB, 4096}, {16_KB, 1024}, {64_KB, 256}, {256_KB, 64}, {1024_KB, 16}}));
+  RunPeerToPeerBenchmark(copy_size, batch_copy_count, pointer_pattern);
 }
 
-#endif
+HIP_TEST_CASE(Performance_hipMemcpyBatchAsync_H2D_Pageable) {
+  const PointerPattern pointer_pattern =
+      GENERATE(PointerPattern::BasePointers, PointerPattern::BroadcastSource);
+  const auto [copy_size, batch_copy_count] = GENERATE(table<size_t, size_t>(
+      {{4_KB, 4096}, {16_KB, 1024}, {64_KB, 256}, {256_KB, 64}, {1024_KB, 16}}));
+  RunHostDeviceBenchmark(copy_size, batch_copy_count, LinearAllocs::malloc, LinearAllocs::hipMalloc,
+                         pointer_pattern);
+}
+
+HIP_TEST_CASE(Performance_hipMemcpyBatchAsync_H2D_Pinned) {
+  const PointerPattern pointer_pattern =
+      GENERATE(PointerPattern::BasePointers, PointerPattern::BroadcastSource);
+  const auto [copy_size, batch_copy_count] = GENERATE(table<size_t, size_t>(
+      {{4_KB, 4096}, {16_KB, 1024}, {64_KB, 256}, {256_KB, 64}, {1024_KB, 16}}));
+  RunHostDeviceBenchmark(copy_size, batch_copy_count, LinearAllocs::hipHostMalloc,
+                         LinearAllocs::hipMalloc, pointer_pattern);
+}
+
+HIP_TEST_CASE(Performance_hipMemcpyBatchAsync_D2H_Pageable) {
+  const PointerPattern pointer_pattern =
+      GENERATE(PointerPattern::BasePointers, PointerPattern::BroadcastSource);
+  const auto [copy_size, batch_copy_count] = GENERATE(table<size_t, size_t>(
+      {{4_KB, 4096}, {16_KB, 1024}, {64_KB, 256}, {256_KB, 64}, {1024_KB, 16}}));
+  RunHostDeviceBenchmark(copy_size, batch_copy_count, LinearAllocs::hipMalloc, LinearAllocs::malloc,
+                         pointer_pattern);
+}
+
+HIP_TEST_CASE(Performance_hipMemcpyBatchAsync_D2H_Pinned) {
+  const PointerPattern pointer_pattern =
+      GENERATE(PointerPattern::BasePointers, PointerPattern::BroadcastSource);
+  const auto [copy_size, batch_copy_count] = GENERATE(table<size_t, size_t>(
+      {{4_KB, 4096}, {16_KB, 1024}, {64_KB, 256}, {256_KB, 64}, {1024_KB, 16}}));
+  RunHostDeviceBenchmark(copy_size, batch_copy_count, LinearAllocs::hipMalloc,
+                         LinearAllocs::hipHostMalloc, pointer_pattern);
+}
 
 /**
  * End doxygen group memcpy.

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
@@ -704,16 +704,29 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_H2H_Functional) {
 HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_Mixed_Functional) {
   constexpr size_t copy_size = kMediumCopySize;
   const size_t copy_elements = CopyElements(copy_size);
+
+  if (HipTest::getDeviceCount() < 3) {
+    HIP_SKIP_TEST("Test requires at least three GPUs.");
+  }
+
+  HIP_CHECK(hipSetDevice(0));
   StreamGuard stream_guard(Streams::created);
 
   LinearAllocGuard<int> h2d_src(LinearAllocs::malloc, copy_size);
   LinearAllocGuard<int> h2d_dst(LinearAllocs::hipMalloc, copy_size);
+
+  HIP_CHECK(hipSetDevice(1));
   LinearAllocGuard<int> d2d_src(LinearAllocs::hipMalloc, copy_size);
   LinearAllocGuard<int> d2d_dst(LinearAllocs::hipMalloc, copy_size);
+
+  HIP_CHECK(hipSetDevice(2));
   LinearAllocGuard<int> d2h_src(LinearAllocs::hipMalloc, copy_size);
+
   LinearAllocGuard<int> d2h_dst(LinearAllocs::malloc, copy_size);
   LinearAllocGuard<int> h2h_src(LinearAllocs::malloc, copy_size);
   LinearAllocGuard<int> h2h_dst(LinearAllocs::malloc, copy_size);
+
+  HIP_CHECK(hipSetDevice(0));
   std::array<void*, 4> src_ptrs{h2d_src.ptr(), d2d_src.ptr(), d2h_src.ptr(), h2h_src.ptr()};
   std::array<void*, 4> dst_ptrs{h2d_dst.ptr(), d2d_dst.ptr(), d2h_dst.ptr(), h2h_dst.ptr()};
   std::array<size_t, 4> sizes{copy_size, copy_size, copy_size, copy_size};

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
@@ -610,7 +610,6 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_H2D_Pageable_Stream_SourceAccess) {
   hipMemcpyAttributes attr{hipMemcpySrcAccessOrderStream, {}, {}, hipMemcpyFlagDefault};
 
   FillDeviceBuffers(MakeBatchPtrs(producer), copy_size, kStreamProducedValue);
-  FillHostBuffers(src, copy_size, kInitialValue);
 
   for (size_t i = 0; i < copy_count; ++i) {
     HIP_CHECK(hipMemcpyAsync(src_ptrs[i], producer[i].ptr(), copy_size, hipMemcpyDeviceToHost,

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
@@ -4,26 +4,184 @@
  * SPDX-License-Identifier: MIT
  */
 
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <utility>
+#include <vector>
+
 #include <hip_test_common.hh>
 #include <hip_test_defgroups.hh>
+#include <resource_guards.hh>
+#include <utils.hh>
+
 /**
  * @addtogroup hipMemcpyBatchAsync hipMemcpyBatchAsync
  * @{
  * @ingroup MemoryTest
  * `hipError_t hipMemcpyBatchAsync(void** dsts, void** srcs, size_t* sizes,
- size_t count, hipMemcpyAttributes* attrs, size_t* attrsIdxs, size_t numAttrs,
-                               size_t* failIdx, hipStream_t stream __dparm(0))`
- -
- * Perform Batch of 1D copies.
+ * size_t count, hipMemcpyAttributes* attrs, size_t* attrsIdxs, size_t numAttrs,
+ * size_t* failIdx, hipStream_t stream __dparm(0))`
+ *
+ * Perform a batch of 1D copies.
  */
+
+namespace {
+
+constexpr size_t kOneKiB = 1024;
+constexpr size_t kSmallCopySize = 4 * kOneKiB;
+constexpr size_t kMediumCopySize = 32 * kOneKiB;
+constexpr size_t kLargeCopySize = 512 * kOneKiB;
+constexpr int kPatternValue = 0x42;
+
+struct BatchConfig {
+  size_t copy_count;
+  size_t copy_size;
+};
+
+enum class PointerPattern {
+  BasePointers,
+  OffsetPointers,
+  UnalignedPointers,
+  BroadcastSource,
+};
+
+size_t CopyElements(size_t copy_size) {
+  REQUIRE(copy_size % sizeof(int) == 0);
+  return copy_size / sizeof(int);
+}
+
+std::vector<std::pair<int, int>> GetPeerAccessibleDevicePairs() {
+  if (HipTest::getDeviceCount() < 2) {
+    HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+  }
+
+  const int device_count = HipTest::getDeviceCount();
+  std::vector<std::pair<int, int>> peer_pairs;
+  for (int src_device = 0; src_device < device_count; ++src_device) {
+    for (int dst_device = 0; dst_device < device_count; ++dst_device) {
+      if (src_device == dst_device) {
+        continue;
+      }
+      int can_access_peer = 0;
+      HIP_CHECK(hipDeviceCanAccessPeer(&can_access_peer, src_device, dst_device));
+      if (can_access_peer != 0) {
+        peer_pairs.emplace_back(src_device, dst_device);
+      }
+    }
+  }
+
+  if (peer_pairs.empty()) {
+    HIP_SKIP_TEST(HipTest::SkipReason::kPeerAccessUnavailable);
+  }
+  return peer_pairs;
+}
+
+void EnablePeerAccess(const std::vector<std::pair<int, int>>& peer_pairs) {
+  for (const auto& [src_device, dst_device] : peer_pairs) {
+    HIP_CHECK(hipSetDevice(src_device));
+    hipError_t peer_status = hipDeviceEnablePeerAccess(dst_device, 0);
+    if (peer_status != hipSuccess && peer_status != hipErrorPeerAccessAlreadyEnabled) {
+      HIP_CHECK(peer_status);
+    }
+  }
+}
+
+void DisablePeerAccess(const std::vector<std::pair<int, int>>& peer_pairs) {
+  for (const auto& [src_device, dst_device] : peer_pairs) {
+    HIP_CHECK(hipSetDevice(src_device));
+    HIP_CHECK(hipDeviceDisablePeerAccess(dst_device));
+  }
+}
+
+std::vector<LinearAllocGuard<int>> AllocateBatchBuffers(LinearAllocs allocation_type,
+                                                        const BatchConfig& config,
+                                                        size_t extra_bytes = 0) {
+  std::vector<LinearAllocGuard<int>> allocations;
+
+  for (size_t i = 0; i < config.copy_count; ++i) {
+    allocations.emplace_back(allocation_type, config.copy_size + extra_bytes);
+  }
+
+  return allocations;
+}
+
+std::vector<void*> MakeBatchPtrs(std::vector<LinearAllocGuard<int>>& allocations,
+                                 size_t offset_bytes = 0) {
+  std::vector<void*> ptrs;
+
+  for (LinearAllocGuard<int>& allocation : allocations) {
+    ptrs.push_back(static_cast<void*>(reinterpret_cast<char*>(allocation.ptr()) + offset_bytes));
+  }
+
+  return ptrs;
+}
+
+void FillDeviceBuffers(const std::vector<void*>& ptrs, size_t copy_size, int value) {
+  const size_t copy_elements = CopyElements(copy_size);
+  std::vector<int> source(copy_elements);
+
+  for (size_t i = 0; i < ptrs.size(); ++i) {
+    std::fill(source.begin(), source.end(), value + static_cast<int>(i));
+    HIP_CHECK(hipMemcpy(ptrs[i], source.data(), copy_size, hipMemcpyHostToDevice));
+  }
+}
+
+void FillHostBuffers(std::vector<LinearAllocGuard<int>>& buffers, size_t copy_size,
+                     int value = kPatternValue) {
+  const size_t copy_elements = CopyElements(copy_size);
+
+  for (size_t i = 0; i < buffers.size(); ++i) {
+    std::fill_n(buffers[i].host_ptr(), copy_elements, value + static_cast<int>(i));
+  }
+}
+
+void VerifyArrayFromBothEnds(const int* values, size_t copy_elements, int expected,
+                             size_t copy_index) {
+  for (size_t offset = 0; offset < (copy_elements + 1) / 2; ++offset) {
+    const size_t front_index = offset;
+    const size_t back_index = copy_elements - 1 - offset;
+
+    INFO("Array failure at copy index " << copy_index << ", element " << front_index);
+    REQUIRE(values[front_index] == expected);
+
+    if (front_index == back_index) {
+      continue;
+    }
+
+    INFO("Array failure at copy index " << copy_index << ", element " << back_index);
+    REQUIRE(values[back_index] == expected);
+  }
+}
+
+void VerifyDeviceBuffers(const std::vector<void*>& ptrs, size_t copy_size,
+                         int expected = kPatternValue, bool add_index = true) {
+  const size_t copy_elements = CopyElements(copy_size);
+  std::vector<int> result(copy_elements);
+
+  for (size_t i = 0; i < ptrs.size(); ++i) {
+    HIP_CHECK(hipMemcpy(result.data(), ptrs[i], copy_size, hipMemcpyDeviceToHost));
+    const int value = expected + (add_index ? static_cast<int>(i) : 0);
+    VerifyArrayFromBothEnds(result.data(), copy_elements, value, i);
+  }
+}
+
+void VerifyHostBuffers(std::vector<LinearAllocGuard<int>>& buffers, size_t copy_size,
+                       int expected = kPatternValue) {
+  const size_t copy_elements = CopyElements(copy_size);
+
+  for (size_t i = 0; i < buffers.size(); ++i) {
+    VerifyArrayFromBothEnds(buffers[i].host_ptr(), copy_elements, expected + static_cast<int>(i),
+                            i);
+  }
+}
+
+}  // namespace
+
 /**
  * Test Description
  * ------------------------
- * - Test case to verify the 1D batch memory copy.
- * 1. Create Array of device pointers(Src, Dst).
- * 2. Set the MemcpyBatch params. As of now no support for memcpy Attributes.
- * 3. Perform batch memcpy operation from deviceptr to deviceptr.
- * 4. Validate data on host.
+ * - Verifies API-level negative validation for hipMemcpyBatchAsync.
  * Test source
  * ------------------------
  * - catch/unit/memory/hipMemcpyBatchAsync.cc
@@ -31,71 +189,119 @@
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-#if HT_AMD
-HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpyBatchAsync_D2D_Functional, char, int,
-                   float) {
-  const size_t count = 2;
-  size_t numAttrs = 0;
-  const size_t arrSize = 4096;
-  const size_t size = 4096 * sizeof(TestType);
-  hipStream_t stream;
-  HIP_CHECK(hipStreamCreate(&stream));
-  constexpr auto kfloatval1 = 2.25f;
-  constexpr auto kfloatval2 = 0.25f;
-  const TestType val1 = std::is_floating_point_v<TestType> ? kfloatval1
-                        : std::is_integral_v<TestType>     ? 10
-                                                           : 'a';
-  const TestType val2 = std::is_floating_point_v<TestType> ? kfloatval2
-                        : std::is_integral_v<TestType>     ? 4
-                                                           : 'b';
+HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_Negative) {
+  constexpr size_t kCount = 3;
 
-  // Allocate buffers for pointer-ptr copy
-  void *srcPtr[count], *dstPtr[count];
-  std::vector<std::vector<TestType>> hostPtr1(
-      count, std::vector<TestType>(arrSize, val1));
-  std::vector<std::vector<TestType>> hostPtr2(
-      count, std::vector<TestType>(arrSize, val2));
-  size_t sizes[2];
-  size_t attrsIdxs[1];
-  for (int i = 0; i < count; i++) {
-    HIP_CHECK(hipMalloc(&srcPtr[i], size));
-    HIP_CHECK(hipMalloc(&dstPtr[i], size));
-    HIP_CHECK(
-        hipMemcpy(srcPtr[i], hostPtr2[i].data(), size, hipMemcpyHostToDevice));
-    sizes[i] = size;
-  }
-  attrsIdxs[0] = 0;
-  size_t failIdx;
+  StreamGuard stream_guard(Streams::created);
+  std::array<LinearAllocGuard<int>, kCount> src_allocs;
+  std::array<LinearAllocGuard<int>, kCount> dst_allocs;
+  std::array<void*, kCount> src_ptrs{};
+  std::array<void*, kCount> dst_ptrs{};
+  std::array<size_t, kCount> sizes{};
 
-  HIP_CHECK(hipMemcpyBatchAsync(dstPtr, srcPtr, sizes, count, nullptr,
-                                attrsIdxs, numAttrs, &failIdx, stream));
-  HIP_CHECK(hipStreamSynchronize(stream));
-  // validation
-  for (int i = 0; i < count; i++) {
-    HIP_CHECK(
-        hipMemcpy(hostPtr1[i].data(), dstPtr[i], size, hipMemcpyDeviceToHost));
-    for (int j = 0; j < arrSize; j++) {
-      INFO("Array FAILURE at Index: " << i << " " << j
-                                      << "\nval : " << hostPtr1[i][j]);
-      REQUIRE(hostPtr1[i][j] == val2);
-    }
+  for (size_t i = 0; i < kCount; ++i) {
+    src_allocs[i] = LinearAllocGuard<int>(LinearAllocs::hipMalloc, kSmallCopySize);
+    dst_allocs[i] = LinearAllocGuard<int>(LinearAllocs::hipMalloc, kSmallCopySize);
+    src_ptrs[i] = src_allocs[i].ptr();
+    dst_ptrs[i] = dst_allocs[i].ptr();
+    sizes[i] = kSmallCopySize;
   }
-  // Clean up
-  for (int i = 0; i < count; i++) {
-    HIP_CHECK(hipFree(srcPtr[i]));
-    HIP_CHECK(hipFree(dstPtr[i]));
+
+  size_t attrs_idxs[1] = {0};
+
+  SECTION("Null destination array") {
+    HIP_CHECK_ERROR(hipMemcpyBatchAsync(nullptr, src_ptrs.data(), sizes.data(), kCount, nullptr,
+                                        attrs_idxs, 0, nullptr, stream_guard.stream()),
+                    hipErrorInvalidValue);
   }
-  HIP_CHECK(hipStreamDestroy(stream));
+
+  SECTION("Null source array") {
+    HIP_CHECK_ERROR(hipMemcpyBatchAsync(dst_ptrs.data(), nullptr, sizes.data(), kCount, nullptr,
+                                        attrs_idxs, 0, nullptr, stream_guard.stream()),
+                    hipErrorInvalidValue);
+  }
+
+  SECTION("Null sizes array") {
+    HIP_CHECK_ERROR(hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), nullptr, kCount, nullptr,
+                                        attrs_idxs, 0, nullptr, stream_guard.stream()),
+                    hipErrorInvalidValue);
+  }
+
+  SECTION("Zero count") {
+    HIP_CHECK_ERROR(hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(), 0, nullptr,
+                                        attrs_idxs, 0, nullptr, stream_guard.stream()),
+                    hipErrorInvalidValue);
+  }
+
+  SECTION("Null destination element") {
+    dst_ptrs[1] = nullptr;
+    HIP_CHECK_ERROR(hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(), kCount,
+                                        nullptr, attrs_idxs, 0, nullptr, stream_guard.stream()),
+                    hipErrorInvalidValue);
+  }
+
+  SECTION("Null source element") {
+    src_ptrs[1] = nullptr;
+    HIP_CHECK_ERROR(hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(), kCount,
+                                        nullptr, attrs_idxs, 0, nullptr, stream_guard.stream()),
+                    hipErrorInvalidValue);
+  }
+
+  SECTION("Zero size first copy") {
+    sizes[0] = 0;
+    size_t fail_idx = 0;
+    HIP_CHECK_ERROR(hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(), kCount,
+                                        nullptr, attrs_idxs, 0, &fail_idx, stream_guard.stream()),
+                    hipErrorInvalidValue);
+    REQUIRE(fail_idx == 0);
+  }
+
+  SECTION("Zero size middle copy") {
+    sizes[1] = 0;
+    size_t fail_idx = 0;
+    HIP_CHECK_ERROR(hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(), kCount,
+                                        nullptr, attrs_idxs, 0, &fail_idx, stream_guard.stream()),
+                    hipErrorInvalidValue);
+    REQUIRE(fail_idx == 1);
+  }
+
+  SECTION("Zero size last copy") {
+    sizes[2] = 0;
+    size_t fail_idx = 0;
+    HIP_CHECK_ERROR(hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(), kCount,
+                                        nullptr, attrs_idxs, 0, &fail_idx, stream_guard.stream()),
+                    hipErrorInvalidValue);
+    REQUIRE(fail_idx == 2);
+  }
+
+  SECTION("Null fail index on zero size") {
+    sizes[1] = 0;
+    HIP_CHECK_ERROR(hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(), kCount,
+                                        nullptr, attrs_idxs, 0, nullptr, stream_guard.stream()),
+                    hipErrorInvalidValue);
+  }
+
+  SECTION("Source range exceeds allocation") {
+    src_ptrs[1] = static_cast<void*>(src_allocs[1].ptr() + 1);
+    sizes[1] = kSmallCopySize;
+    HIP_CHECK_ERROR(hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(), kCount,
+                                        nullptr, attrs_idxs, 0, nullptr, stream_guard.stream()),
+                    hipErrorInvalidValue);
+  }
+
+  SECTION("Destination range exceeds allocation") {
+    dst_ptrs[1] = static_cast<void*>(dst_allocs[1].ptr() + 1);
+    sizes[1] = kSmallCopySize;
+    HIP_CHECK_ERROR(hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(), kCount,
+                                        nullptr, attrs_idxs, 0, nullptr, stream_guard.stream()),
+                    hipErrorInvalidValue);
+  }
 }
 
 /**
  * Test Description
  * ------------------------
- * - Test case to verify the 1D batch memory copy.
- * 1. Create Array of device pointers(Src, Dst).
- * 2. Set the MemcpyBatch params. As of now no support for memcpy Attributes.
- * 3. Perform batch memcpy operation From Host to Device.
- * 4. Validate data on host.
+ * - Verifies attribute array validation for hipMemcpyBatchAsync.
  * Test source
  * ------------------------
  * - catch/unit/memory/hipMemcpyBatchAsync.cc
@@ -103,273 +309,567 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpyBatchAsync_D2D_Functional, char, int,
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpyBatchAsync_H2D_Functional, char, int,
-                   float) {
-  const size_t count = 2;
-  size_t numAttrs = 0;
-  const size_t arrSize = 4096;
-  const size_t size = 4096 * sizeof(TestType);
-  hipStream_t stream;
-  HIP_CHECK(hipStreamCreate(&stream));
+HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_Attrs_Negative) {
+  constexpr size_t kCount = 2;
+  BatchConfig config{kCount, kSmallCopySize};
+  StreamGuard stream_guard(Streams::created);
+  std::vector<LinearAllocGuard<int>> src = AllocateBatchBuffers(LinearAllocs::hipMalloc, config);
+  std::vector<LinearAllocGuard<int>> dst = AllocateBatchBuffers(LinearAllocs::hipMalloc, config);
+  std::vector<void*> src_ptrs = MakeBatchPtrs(src);
+  std::vector<void*> dst_ptrs = MakeBatchPtrs(dst);
+  std::vector<size_t> sizes(config.copy_count, config.copy_size);
+  std::array<hipMemcpyAttributes, 3> attrs{
+      hipMemcpyAttributes{hipMemcpySrcAccessOrderStream, {}, {}, hipMemcpyFlagDefault},
+      hipMemcpyAttributes{hipMemcpySrcAccessOrderStream, {}, {}, hipMemcpyFlagDefault},
+      hipMemcpyAttributes{hipMemcpySrcAccessOrderStream, {}, {}, hipMemcpyFlagDefault},
+  };
+  std::array<size_t, 3> attrs_idxs{0, 1, 2};
 
-  // Allocate buffers for pointer-ptr copy
-  void *hostSrcPtr[count], *dstPtr[count];
-  constexpr auto kfloatval1 = 2.25f;
-  constexpr auto kfloatval2 = 0.25f;
-  const TestType val1 = std::is_floating_point_v<TestType> ? kfloatval1
-                        : std::is_integral_v<TestType>     ? 10
-                                                           : 'a';
-  const TestType val2 = std::is_floating_point_v<TestType> ? kfloatval2
-                        : std::is_integral_v<TestType>     ? 4
-                                                           : 'b';
-  std::vector<std::vector<TestType>> hostPtr(
-      count, std::vector<TestType>(arrSize, val2));
-  std::array<TestType, arrSize> arr;
-  arr.fill(val1);
-  size_t sizes[2];
-  size_t attrsIdxs[1];
-  for (int i = 0; i < count; i++) {
-    hostSrcPtr[i] = arr.data();
-    HIP_CHECK(hipMalloc(&dstPtr[i], size));
-    sizes[i] = size;
-  }
-  attrsIdxs[0] = 0;
-  size_t failIdx;
-
-  HIP_CHECK(hipMemcpyBatchAsync(dstPtr, hostSrcPtr, sizes, count, nullptr,
-                                attrsIdxs, numAttrs, &failIdx, stream));
-  HIP_CHECK(hipStreamSynchronize(stream));
-  // validation
-  for (int i = 0; i < count; i++) {
-    HIP_CHECK(
-        hipMemcpy(hostPtr[i].data(), dstPtr[i], size, hipMemcpyDeviceToHost));
-    for (int j = 0; j < arrSize; j++) {
-      INFO("Array FAILURE at Index: " << i << " " << j
-                                      << "\nval : " << hostPtr[i][j]);
-      REQUIRE(hostPtr[i][j] == val1);
-    }
-  }
-  // Clean up
-  for (int i = 0; i < count; i++) {
-    HIP_CHECK(hipFree(dstPtr[i]));
-  }
-  HIP_CHECK(hipStreamDestroy(stream));
-}
-
-/**
- * Test Description
- * ------------------------
- * - Test case to verify the 1D batch memory copy.
- * 1. Create Array of device pointers(Src, Dst).
- * 2. Set the MemcpyBatch params. As of now no support for memcpy Attributes.
- * 3. Perform batch memcpy operation From Device to Host.
- * 4. Validate data on host.
- * Test source
- * ------------------------
- * - catch/unit/memory/hipMemcpyBatchAsync.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 7.1
- */
-HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpyBatchAsync_D2H_Functional, char, int,
-                   float) {
-  const size_t count = 2;
-  size_t numAttrs = 0;
-  const size_t arrSize = 4096;
-  const size_t size = 4096 * sizeof(TestType);
-  hipStream_t stream;
-  HIP_CHECK(hipStreamCreate(&stream));
-
-  constexpr auto kfloatval1 = 2.25f;
-  constexpr auto kfloatval2 = 0.25f;
-  const TestType val1 = std::is_floating_point_v<TestType> ? kfloatval1
-                        : std::is_integral_v<TestType>     ? 10
-                                                           : 'a';
-  const TestType val2 = std::is_floating_point_v<TestType> ? kfloatval2
-                        : std::is_integral_v<TestType>     ? 4
-                                                           : 'b';
-  // Allocate buffers for pointer-ptr copy
-  TestType *hostDstPtr[count];
-  void *deviceSrcPtr[count];
-  std::vector<std::vector<TestType>> hostPtr(
-      count, std::vector<TestType>(arrSize, val1));
-  std::array<TestType, arrSize> arr;
-  arr.fill(val2);
-  size_t sizes[2];
-  size_t attrsIdxs[1];
-  for (int i = 0; i < count; i++) {
-    hostDstPtr[i] = arr.data();
-    HIP_CHECK(hipMalloc(&deviceSrcPtr[i], size));
-    HIP_CHECK(hipMemcpy(deviceSrcPtr[i], hostPtr[i].data(), size,
-                        hipMemcpyHostToDevice));
-    sizes[i] = size;
-  }
-  attrsIdxs[0] = 0;
-  size_t failIdx;
-
-  HIP_CHECK(hipMemcpyBatchAsync(reinterpret_cast<void **>(hostDstPtr),
-                                deviceSrcPtr, sizes, count, nullptr, attrsIdxs,
-                                numAttrs, &failIdx, stream));
-  HIP_CHECK(hipStreamSynchronize(stream));
-  // validation
-  for (int i = 0; i < count; i++) {
-    for (int j = 0; j < arrSize; j++) {
-      INFO("Array FAILURE at Index: " << i << " " << j
-                                      << "\nval : " << hostDstPtr[i][j]);
-      REQUIRE(hostDstPtr[i][j] == val1);
-    }
-  }
-  // Clean up
-  for (int i = 0; i < count; i++) {
-    HIP_CHECK(hipFree(deviceSrcPtr[i]));
-  }
-  HIP_CHECK(hipStreamDestroy(stream));
-}
-
-/**
- * Test Description
- * ------------------------
- * - Test case to verify the 1D batch memory copy.
- * 1. Create Array of device pointers(Src, Dst).
- * 2. Set the MemcpyBatch params. As of now no support for memcpy Attributes.
- * 3. Perform batch memcpy operation From Host to Host.
- * 4. Validate data on host.
- * Test source
- * ------------------------
- * - catch/unit/memory/hipMemcpyBatchAsync.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 7.1
- */
-HIP_TEMPLATE_TEST_CASE(Unit_hipMemcpyBatchAsync_H2H_Functional, char, int,
-                   float) {
-  const size_t count = 2;
-  size_t numAttrs = 0;
-  const size_t arrSize = 4096;
-  hipStream_t stream;
-  HIP_CHECK(hipStreamCreate(&stream));
-
-  constexpr auto kfloatval1 = 2.25;
-  const TestType val1 = std::is_floating_point_v<TestType> ? kfloatval1
-                        : std::is_integral_v<TestType>     ? 10
-                                                           : 'a';
-  constexpr auto kfloatval2 = 0.25f;
-  const TestType val2 = std::is_floating_point_v<TestType> ? kfloatval2
-                        : std::is_integral_v<TestType>     ? 4
-                                                           : 'b';
-
-  // Allocate buffers for pointer-ptr copy
-  TestType *hostDstPtr[count], *hostSrcPtr[count];
-  std::array<TestType, arrSize> arr1, arr2;
-  arr1.fill(val1);
-  arr2.fill(val2);
-  size_t sizes[2];
-  size_t attrsIdxs[1];
-  for (int i = 0; i < count; i++) {
-    hostDstPtr[i] = arr1.data();
-    hostSrcPtr[i] = arr2.data();
-    sizes[i] = arrSize * sizeof(TestType);
-  }
-  attrsIdxs[0] = 0;
-  size_t failIdx;
-
-  HIP_CHECK(hipMemcpyBatchAsync(reinterpret_cast<void **>(hostDstPtr),
-                                reinterpret_cast<void **>(hostSrcPtr), sizes,
-                                count, nullptr, attrsIdxs, numAttrs, &failIdx,
-                                stream));
-  HIP_CHECK(hipStreamSynchronize(stream));
-  // validation
-  for (int i = 0; i < count; i++) {
-    for (int j = 0; j < arrSize; j++) {
-      INFO("Array FAILURE at Index: " << i << " " << j
-                                      << "\nval : " << hostDstPtr[i][j]);
-      REQUIRE(hostDstPtr[i][j] == val2);
-    }
-  }
-  // Clean up
-  HIP_CHECK(hipStreamDestroy(stream));
-}
-#endif
-/**
- * Test Description
- * ------------------------
- * - Test case to verify the negative cases of hipMemcpyBatchAsync.
- * 1. Dst Array as nullptr.
- * 2. Src Array as nullptr.
- * 3. Operations Count as 0.
- * 4. Num of attributes as 0.
- * 5. Sizes Array as nullptr.
- * 6. Attr Array as nullptr.
- * 7. AttrsIdxs Array as nullptr.
- * Test source
- * ------------------------
- * - catch/unit/memory/hipMemcpyBatchAsync.cc
- * Test requirements
- * ------------------------
- *  - HIP_VERSION >= 7.1
- */
-HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_NegativeTsts) {
-  const size_t count = 2;
-  size_t numAttrs = 0;
-  size_t sizes[2];
-  size_t attrsIdxs[1];
-  const size_t size = 4096 * sizeof(char);
-  hipStream_t stream = NULL;
-  HIP_CHECK(hipStreamCreate(&stream));
-  void *srcPtr[count], *dstPtr[count];
-  for (int i = 0; i < count; i++) {
-    HIP_CHECK(hipMalloc(&srcPtr[i], size));
-    HIP_CHECK(hipMalloc(&dstPtr[i], size));
-    sizes[i] = size;
-  }
-
-  attrsIdxs[0] = 0;
-  size_t failIdx;
-  SECTION("Dst Array as nullptr") {
-    HIP_CHECK_ERROR(hipMemcpyBatchAsync(nullptr, srcPtr, sizes, count, nullptr,
-                                        attrsIdxs, numAttrs, &failIdx, stream),
-                    hipErrorInvalidValue);
-  }
-  SECTION("Src Array as nullptr") {
-    HIP_CHECK_ERROR(hipMemcpyBatchAsync(dstPtr, nullptr, sizes, count, nullptr,
-                                        attrsIdxs, numAttrs, &failIdx, stream),
-                    hipErrorInvalidValue);
-  }
-  SECTION("Count as zero") {
-    HIP_CHECK_ERROR(hipMemcpyBatchAsync(dstPtr, srcPtr, sizes, 0, nullptr,
-                                        attrsIdxs, numAttrs, &failIdx, stream),
-                    hipErrorInvalidValue);
-  }
-  SECTION("sizes Array as nullptr") {
-    HIP_CHECK_ERROR(hipMemcpyBatchAsync(dstPtr, srcPtr, nullptr, count, nullptr,
-                                        attrsIdxs, numAttrs, &failIdx, stream),
-                    hipErrorInvalidValue);
-  }
-#if 0 // Enable these tests when support for memcpy attributes is enabled.
-  SECTION("Number of Attributes as zero") {
+  SECTION("Null attrs with nonzero numAttrs") {
     HIP_CHECK_ERROR(
-        hipMemcpyBatchAsync(dstPtr, srcPtr, sizes, count, attr, attrsIdxs, 0, &failIdx, stream),
+        hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(), kCount, nullptr,
+                            attrs_idxs.data(), 1, nullptr, stream_guard.stream()),
         hipErrorInvalidValue);
   }
-  SECTION("Attr Array as nullptr") {
-    HIP_CHECK_ERROR(hipMemcpyBatchAsync(dstPtr, srcPtr, sizes, count, nullptr, attrsIdxs, numAttrs,
-                                        &failIdx, stream),
+
+  SECTION("Null attrsIdxs with nonzero numAttrs") {
+    HIP_CHECK_ERROR(hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(), kCount,
+                                        attrs.data(), nullptr, 1, nullptr, stream_guard.stream()),
                     hipErrorInvalidValue);
   }
 
-  SECTION("attrsIdxs Array as nullptr") {
-    HIP_CHECK_ERROR(hipMemcpyBatchAsync(dstPtr, srcPtr, sizes, count, attr, nullptr, numAttrs,
-                                        &failIdx, stream),
-                    hipErrorInvalidValue);
+  SECTION("First attrsIdxs entry is not zero") {
+    attrs_idxs[0] = 1;
+    HIP_CHECK_ERROR(
+        hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(), kCount, attrs.data(),
+                            attrs_idxs.data(), 1, nullptr, stream_guard.stream()),
+        hipErrorInvalidValue);
   }
-#endif
-  // Clean up
-  for (int i = 0; i < count; i++) {
-    HIP_CHECK(hipFree(srcPtr[i]));
-    HIP_CHECK(hipFree(dstPtr[i]));
+
+  SECTION("numAttrs exceeds count") {
+    HIP_CHECK_ERROR(
+        hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(), kCount, attrs.data(),
+                            attrs_idxs.data(), kCount + 1, nullptr, stream_guard.stream()),
+        hipErrorInvalidValue);
   }
-  HIP_CHECK(hipStreamDestroy(stream));
+
+  SECTION("attrsIdxs is not monotonic") {
+    attrs_idxs[1] = 0;
+    HIP_CHECK_ERROR(
+        hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(), kCount, attrs.data(),
+                            attrs_idxs.data(), 2, nullptr, stream_guard.stream()),
+        hipErrorInvalidValue);
+  }
+
+  SECTION("attrsIdxs entry is out of range") {
+    attrs_idxs[1] = kCount;
+    HIP_CHECK_ERROR(
+        hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(), kCount, attrs.data(),
+                            attrs_idxs.data(), 2, nullptr, stream_guard.stream()),
+        hipErrorInvalidValue);
+  }
+
+  SECTION("Invalid source access order") {
+    attrs[0].srcAccessOrder = hipMemcpySrcAccessOrderInvalid;
+    HIP_CHECK_ERROR(
+        hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(), kCount, attrs.data(),
+                            attrs_idxs.data(), 1, nullptr, stream_guard.stream()),
+        hipErrorInvalidValue);
+  }
 }
+
+/**
+ * Test Description
+ * ------------------------
+ * - Verifies segmented host-source access attributes and swap attributes for
+ * hipMemcpyBatchAsync.
+ * Test source
+ * ------------------------
+ * - catch/unit/memory/hipMemcpyBatchAsync.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 7.1
+ */
+HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_Attrs_Functional) {
+  constexpr size_t kCopiesPerAttr = 3;
+  StreamGuard stream_guard(Streams::created);
+
+  SECTION("Regular attributes") {
+    std::array<hipMemcpyAttributes, 6> host_attrs{
+        hipMemcpyAttributes{hipMemcpySrcAccessOrderStream, {}, {}, hipMemcpyFlagDefault},
+        hipMemcpyAttributes{hipMemcpySrcAccessOrderStream, {}, {}, hipMemcpyFlagExtPreferCE},
+        hipMemcpyAttributes{hipMemcpySrcAccessOrderDuringApiCall, {}, {}, hipMemcpyFlagDefault},
+        hipMemcpyAttributes{hipMemcpySrcAccessOrderDuringApiCall, {}, {}, hipMemcpyFlagExtPreferCE},
+        hipMemcpyAttributes{hipMemcpySrcAccessOrderAny, {}, {}, hipMemcpyFlagDefault},
+        hipMemcpyAttributes{hipMemcpySrcAccessOrderAny, {}, {}, hipMemcpyFlagExtPreferCE},
+    };
+    BatchConfig host_config{host_attrs.size() * kCopiesPerAttr, kSmallCopySize};
+    std::vector<LinearAllocGuard<int>> host_src =
+        AllocateBatchBuffers(LinearAllocs::hipHostMalloc, host_config);
+    std::vector<LinearAllocGuard<int>> dst =
+        AllocateBatchBuffers(LinearAllocs::hipMalloc, host_config);
+    std::vector<void*> host_src_ptrs = MakeBatchPtrs(host_src);
+    std::vector<void*> dst_ptrs = MakeBatchPtrs(dst);
+    std::vector<size_t> sizes(host_src_ptrs.size(), kSmallCopySize);
+    std::vector<size_t> attrs_idxs;
+
+    for (size_t attr_idx = 0; attr_idx < host_attrs.size(); ++attr_idx) {
+      attrs_idxs.push_back(attr_idx * kCopiesPerAttr);
+    }
+
+    FillHostBuffers(host_src, kSmallCopySize);
+
+    HIP_CHECK(hipMemcpyBatchAsync(dst_ptrs.data(), host_src_ptrs.data(), sizes.data(), sizes.size(),
+                                  host_attrs.data(), attrs_idxs.data(), attrs_idxs.size(), nullptr,
+                                  stream_guard.stream()));
+    HIP_CHECK(hipStreamSynchronize(stream_guard.stream()));
+    VerifyDeviceBuffers(dst_ptrs, kSmallCopySize);
+  }
+
+  SECTION("Swap attribute") {
+    BatchConfig d2d_config{kCopiesPerAttr, kSmallCopySize};
+    std::vector<LinearAllocGuard<int>> d2d_src =
+        AllocateBatchBuffers(LinearAllocs::hipMalloc, d2d_config);
+    std::vector<LinearAllocGuard<int>> d2d_dst =
+        AllocateBatchBuffers(LinearAllocs::hipMalloc, d2d_config);
+    std::vector<void*> d2d_src_ptrs = MakeBatchPtrs(d2d_src);
+    std::vector<void*> d2d_dst_ptrs = MakeBatchPtrs(d2d_dst);
+    std::vector<size_t> sizes(d2d_src_ptrs.size(), kSmallCopySize);
+    hipMemcpyAttributes attr{hipMemcpySrcAccessOrderStream, {}, {}, hipMemcpyFlagExtOpSwap};
+    size_t attrs_idxs[1] = {0};
+    constexpr int kSwapSrcValue = 23;
+    constexpr int kSwapDstValue = 47;
+    FillDeviceBuffers(d2d_src_ptrs, kSmallCopySize, kSwapSrcValue);
+    FillDeviceBuffers(d2d_dst_ptrs, kSmallCopySize, kSwapDstValue);
+
+    hipError_t status = hipMemcpyBatchAsync(d2d_dst_ptrs.data(), d2d_src_ptrs.data(), sizes.data(),
+                                            d2d_src_ptrs.size(), &attr, attrs_idxs, 1, nullptr,
+                                            stream_guard.stream());
+    if (status == hipErrorNotSupported) {
+      SUCCEED("hipMemcpyFlagExtOpSwap is not supported on this device");
+    } else {
+      HIP_CHECK(status);
+      HIP_CHECK(hipStreamSynchronize(stream_guard.stream()));
+      VerifyDeviceBuffers(d2d_src_ptrs, kSmallCopySize, kSwapDstValue);
+      VerifyDeviceBuffers(d2d_dst_ptrs, kSmallCopySize, kSwapSrcValue);
+    }
+  }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ * - Verifies D2D batch copies across generated copy sizes, counts, pointer
+ * patterns, and copy flags.
+ * Test source
+ * ------------------------
+ * - catch/unit/memory/hipMemcpyBatchAsync.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 7.1
+ */
+HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_D2D_Functional) {
+  const size_t copy_count = GENERATE(1, 8);
+  const size_t copy_size = GENERATE(kSmallCopySize, kMediumCopySize, kLargeCopySize);
+  const PointerPattern pointer_pattern =
+      GENERATE(PointerPattern::BasePointers, PointerPattern::OffsetPointers,
+               PointerPattern::UnalignedPointers, PointerPattern::BroadcastSource);
+  const hipMemcpyFlags flag = GENERATE(hipMemcpyFlagDefault, hipMemcpyFlagExtPreferCE);
+  const size_t offset_bytes = pointer_pattern == PointerPattern::OffsetPointers      ? sizeof(int)
+                              : pointer_pattern == PointerPattern::UnalignedPointers ? 1
+                                                                                     : 0;
+
+  BatchConfig config{copy_count, copy_size};
+  StreamGuard stream_guard(Streams::created);
+  std::vector<LinearAllocGuard<int>> src =
+      AllocateBatchBuffers(LinearAllocs::hipMalloc, config, offset_bytes);
+  std::vector<LinearAllocGuard<int>> dst =
+      AllocateBatchBuffers(LinearAllocs::hipMalloc, config, offset_bytes);
+  std::vector<void*> src_ptrs = MakeBatchPtrs(src, offset_bytes);
+  std::vector<void*> dst_ptrs = MakeBatchPtrs(dst, offset_bytes);
+  std::vector<size_t> sizes(config.copy_count, config.copy_size);
+  size_t attrs_idxs[1] = {0};
+  hipMemcpyAttributes attr{hipMemcpySrcAccessOrderStream, {}, {}, flag};
+
+  if (pointer_pattern == PointerPattern::BroadcastSource) {
+    FillDeviceBuffers(src_ptrs, copy_size, kPatternValue);
+    void* broadcast_src = src_ptrs.front();
+    std::fill(src_ptrs.begin(), src_ptrs.end(), broadcast_src);
+  } else {
+    FillDeviceBuffers(src_ptrs, copy_size, kPatternValue);
+  }
+
+  HIP_CHECK(hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(), copy_count, &attr,
+                                attrs_idxs, 1, nullptr, stream_guard.stream()));
+  HIP_CHECK(hipStreamSynchronize(stream_guard.stream()));
+
+  if (pointer_pattern == PointerPattern::BroadcastSource) {
+    VerifyDeviceBuffers(dst_ptrs, copy_size, kPatternValue, false);
+  } else {
+    VerifyDeviceBuffers(dst_ptrs, copy_size);
+  }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ * - Verifies H2D batch copies across generated host source allocation types,
+ * copy counts, and copy sizes.
+ * Test source
+ * ------------------------
+ * - catch/unit/memory/hipMemcpyBatchAsync.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 7.1
+ */
+HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_H2D_Functional) {
+  const LinearAllocs host_alloc_type = GENERATE(LinearAllocs::malloc, LinearAllocs::hipHostMalloc);
+  const size_t copy_count = GENERATE(1, 8);
+  const size_t copy_size = GENERATE(kSmallCopySize, kMediumCopySize, kLargeCopySize);
+
+  BatchConfig config{copy_count, copy_size};
+  StreamGuard stream_guard(Streams::created);
+  std::vector<LinearAllocGuard<int>> src = AllocateBatchBuffers(host_alloc_type, config);
+  std::vector<LinearAllocGuard<int>> dst = AllocateBatchBuffers(LinearAllocs::hipMalloc, config);
+  std::vector<void*> src_ptrs = MakeBatchPtrs(src);
+  std::vector<void*> dst_ptrs = MakeBatchPtrs(dst);
+  std::vector<size_t> sizes(config.copy_count, config.copy_size);
+
+  FillHostBuffers(src, copy_size);
+
+  HIP_CHECK(hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(), copy_count, nullptr,
+                                nullptr, 0, nullptr, stream_guard.stream()));
+  HIP_CHECK(hipStreamSynchronize(stream_guard.stream()));
+
+  VerifyDeviceBuffers(dst_ptrs, copy_size);
+}
+
+/**
+ * Test Description
+ * ------------------------
+ * - Verifies that pageable H2D source access is complete before
+ * hipMemcpyBatchAsync returns when srcAccessOrder is DuringApiCall.
+ * Test source
+ * ------------------------
+ * - catch/unit/memory/hipMemcpyBatchAsync.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 7.1
+ */
+HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_H2D_Pageable_DuringApiCall_SourceAccess) {
+  constexpr size_t copy_count = 8;
+  constexpr size_t copy_size = kLargeCopySize;
+  constexpr int kOriginalValue = 17;
+  constexpr int kAlteredValue = 23;
+  BatchConfig config{copy_count, copy_size};
+  StreamGuard stream_guard(Streams::created);
+  std::vector<LinearAllocGuard<int>> src = AllocateBatchBuffers(LinearAllocs::malloc, config);
+  std::vector<LinearAllocGuard<int>> dst = AllocateBatchBuffers(LinearAllocs::hipMalloc, config);
+  std::vector<void*> src_ptrs = MakeBatchPtrs(src);
+  std::vector<void*> dst_ptrs = MakeBatchPtrs(dst);
+  std::vector<size_t> sizes(config.copy_count, config.copy_size);
+  size_t attrs_idxs[1] = {0};
+  hipMemcpyAttributes attr{hipMemcpySrcAccessOrderDuringApiCall, {}, {}, hipMemcpyFlagDefault};
+
+  FillHostBuffers(src, copy_size, kOriginalValue);
+
+  HIP_CHECK(hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(), copy_count, &attr,
+                                attrs_idxs, 1, nullptr, stream_guard.stream()));
+  FillHostBuffers(src, copy_size, kAlteredValue);
+  HIP_CHECK(hipStreamSynchronize(stream_guard.stream()));
+  VerifyHostBuffers(src, copy_size, kAlteredValue);
+}
+
+/**
+ * Test Description
+ * ------------------------
+ * - Verifies that pageable H2D source access observes previous same-stream
+ * writes to the source when srcAccessOrder is Stream.
+ * Test source
+ * ------------------------
+ * - catch/unit/memory/hipMemcpyBatchAsync.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 7.1
+ */
+HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_H2D_Pageable_Stream_SourceAccess) {
+  constexpr size_t copy_count = 1;
+  size_t copy_size = GENERATE(kSmallCopySize, kLargeCopySize);
+  constexpr int kInitialValue = 31;
+  constexpr int kStreamProducedValue = 47;
+  BatchConfig config{copy_count, copy_size};
+  StreamGuard stream_guard(Streams::created);
+  std::vector<LinearAllocGuard<int>> producer =
+      AllocateBatchBuffers(LinearAllocs::hipMalloc, config);
+  std::vector<LinearAllocGuard<int>> src = AllocateBatchBuffers(LinearAllocs::malloc, config);
+  std::vector<LinearAllocGuard<int>> dst = AllocateBatchBuffers(LinearAllocs::hipMalloc, config);
+  std::vector<void*> src_ptrs = MakeBatchPtrs(src);
+  std::vector<void*> dst_ptrs = MakeBatchPtrs(dst);
+  std::vector<size_t> sizes(config.copy_count, config.copy_size);
+  size_t attrs_idxs[1] = {0};
+  hipMemcpyAttributes attr{hipMemcpySrcAccessOrderStream, {}, {}, hipMemcpyFlagDefault};
+
+  FillDeviceBuffers(MakeBatchPtrs(producer), copy_size, kStreamProducedValue);
+  FillHostBuffers(src, copy_size, kInitialValue);
+
+  for (size_t i = 0; i < copy_count; ++i) {
+    HIP_CHECK(hipMemcpyAsync(src_ptrs[i], producer[i].ptr(), copy_size, hipMemcpyDeviceToHost,
+                             stream_guard.stream()));
+  }
+  HIP_CHECK(hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(), copy_count, &attr,
+                                attrs_idxs, 1, nullptr, stream_guard.stream()));
+  HIP_CHECK(hipStreamSynchronize(stream_guard.stream()));
+
+  VerifyDeviceBuffers(dst_ptrs, copy_size, kStreamProducedValue);
+}
+
+/**
+ * Test Description
+ * ------------------------
+ * - Verifies D2H batch copies across generated host destination allocation
+ * types, copy counts, and copy sizes.
+ * Test source
+ * ------------------------
+ * - catch/unit/memory/hipMemcpyBatchAsync.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 7.1
+ */
+HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_D2H_Functional) {
+  const LinearAllocs host_alloc_type = GENERATE(LinearAllocs::malloc, LinearAllocs::hipHostMalloc);
+  const size_t copy_count = GENERATE(1, 8);
+  const size_t copy_size = GENERATE(kSmallCopySize, kMediumCopySize, kLargeCopySize);
+
+  BatchConfig config{copy_count, copy_size};
+  StreamGuard stream_guard(Streams::created);
+  std::vector<LinearAllocGuard<int>> src = AllocateBatchBuffers(LinearAllocs::hipMalloc, config);
+  std::vector<LinearAllocGuard<int>> dst = AllocateBatchBuffers(host_alloc_type, config);
+  std::vector<void*> src_ptrs = MakeBatchPtrs(src);
+  std::vector<void*> dst_ptrs = MakeBatchPtrs(dst);
+  std::vector<size_t> sizes(config.copy_count, config.copy_size);
+
+  FillDeviceBuffers(src_ptrs, copy_size, kPatternValue);
+
+  HIP_CHECK(hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(), copy_count, nullptr,
+                                nullptr, 0, nullptr, stream_guard.stream()));
+  HIP_CHECK(hipStreamSynchronize(stream_guard.stream()));
+
+  VerifyHostBuffers(dst, copy_size);
+}
+
+/**
+ * Test Description
+ * ------------------------
+ * - Verifies H2H batch copies across generated host allocation types, copy
+ * counts, and copy sizes.
+ * Test source
+ * ------------------------
+ * - catch/unit/memory/hipMemcpyBatchAsync.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 7.1
+ */
+HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_H2H_Functional) {
+  const LinearAllocs host_alloc_type = GENERATE(LinearAllocs::malloc, LinearAllocs::hipHostMalloc);
+  const size_t copy_count = GENERATE(1, 8);
+  const size_t copy_size = kSmallCopySize;
+
+  BatchConfig config{copy_count, copy_size};
+  StreamGuard stream_guard(Streams::created);
+  std::vector<LinearAllocGuard<int>> src = AllocateBatchBuffers(host_alloc_type, config);
+  std::vector<LinearAllocGuard<int>> dst = AllocateBatchBuffers(host_alloc_type, config);
+  std::vector<void*> src_ptrs = MakeBatchPtrs(src);
+  std::vector<void*> dst_ptrs = MakeBatchPtrs(dst);
+  std::vector<size_t> sizes(config.copy_count, config.copy_size);
+
+  FillHostBuffers(src, copy_size);
+
+  HIP_CHECK(hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(), copy_count, nullptr,
+                                nullptr, 0, nullptr, stream_guard.stream()));
+  HIP_CHECK(hipStreamSynchronize(stream_guard.stream()));
+
+  VerifyHostBuffers(dst, copy_size);
+}
+
+/**
+ * Test Description
+ * ------------------------
+ * - Verifies one batch containing H2D, D2D, D2H, and H2H copies.
+ * Test source
+ * ------------------------
+ * - catch/unit/memory/hipMemcpyBatchAsync.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 7.1
+ */
+HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_Mixed_Functional) {
+  constexpr size_t copy_size = kMediumCopySize;
+  const size_t copy_elements = CopyElements(copy_size);
+  StreamGuard stream_guard(Streams::created);
+
+  LinearAllocGuard<int> h2d_src(LinearAllocs::malloc, copy_size);
+  LinearAllocGuard<int> h2d_dst(LinearAllocs::hipMalloc, copy_size);
+  LinearAllocGuard<int> d2d_src(LinearAllocs::hipMalloc, copy_size);
+  LinearAllocGuard<int> d2d_dst(LinearAllocs::hipMalloc, copy_size);
+  LinearAllocGuard<int> d2h_src(LinearAllocs::hipMalloc, copy_size);
+  LinearAllocGuard<int> d2h_dst(LinearAllocs::malloc, copy_size);
+  LinearAllocGuard<int> h2h_src(LinearAllocs::malloc, copy_size);
+  LinearAllocGuard<int> h2h_dst(LinearAllocs::malloc, copy_size);
+  std::array<void*, 4> src_ptrs{h2d_src.ptr(), d2d_src.ptr(), d2h_src.ptr(), h2h_src.ptr()};
+  std::array<void*, 4> dst_ptrs{h2d_dst.ptr(), d2d_dst.ptr(), d2h_dst.ptr(), h2h_dst.ptr()};
+  std::array<size_t, 4> sizes{copy_size, copy_size, copy_size, copy_size};
+
+  std::fill_n(h2d_src.host_ptr(), copy_elements, kPatternValue);
+  std::fill_n(h2h_src.host_ptr(), copy_elements, kPatternValue + 3);
+  std::vector<int> source(copy_elements);
+  std::fill(source.begin(), source.end(), kPatternValue + 1);
+  HIP_CHECK(hipMemcpy(d2d_src.ptr(), source.data(), copy_size, hipMemcpyHostToDevice));
+  std::fill(source.begin(), source.end(), kPatternValue + 2);
+  HIP_CHECK(hipMemcpy(d2h_src.ptr(), source.data(), copy_size, hipMemcpyHostToDevice));
+
+  HIP_CHECK(hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(), sizes.size(),
+                                nullptr, nullptr, 0, nullptr, stream_guard.stream()));
+  HIP_CHECK(hipStreamSynchronize(stream_guard.stream()));
+
+  std::vector<int> result(copy_elements);
+  HIP_CHECK(hipMemcpy(result.data(), h2d_dst.ptr(), copy_size, hipMemcpyDeviceToHost));
+  VerifyArrayFromBothEnds(result.data(), copy_elements, kPatternValue, 0);
+  HIP_CHECK(hipMemcpy(result.data(), d2d_dst.ptr(), copy_size, hipMemcpyDeviceToHost));
+  VerifyArrayFromBothEnds(result.data(), copy_elements, kPatternValue + 1, 1);
+  VerifyArrayFromBothEnds(d2h_dst.host_ptr(), copy_elements, kPatternValue + 2, 2);
+  VerifyArrayFromBothEnds(h2h_dst.host_ptr(), copy_elements, kPatternValue + 3, 3);
+}
+
+/**
+ * Test Description
+ * ------------------------
+ * - Verifies default stream behavior, same-stream ordering, and event
+ * dependency ordering for hipMemcpyBatchAsync.
+ * Test source
+ * ------------------------
+ * - catch/unit/memory/hipMemcpyBatchAsync.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 7.1
+ */
+HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_Stream) {
+  constexpr size_t kCount = 2;
+  constexpr size_t kCopyElements = kSmallCopySize / sizeof(int);
+  BatchConfig config{kCount, kSmallCopySize};
+  std::vector<size_t> sizes(config.copy_count, config.copy_size);
+
+  SECTION("Default stream") {
+    std::vector<LinearAllocGuard<int>> src = AllocateBatchBuffers(LinearAllocs::hipMalloc, config);
+    std::vector<LinearAllocGuard<int>> dst = AllocateBatchBuffers(LinearAllocs::hipMalloc, config);
+    std::vector<void*> src_ptrs = MakeBatchPtrs(src);
+    std::vector<void*> dst_ptrs = MakeBatchPtrs(dst);
+    FillDeviceBuffers(src_ptrs, kSmallCopySize, kPatternValue);
+
+    HIP_CHECK(hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(), kCount, nullptr,
+                                  nullptr, 0, nullptr, nullptr));
+    HIP_CHECK(hipStreamSynchronize(nullptr));
+
+    VerifyDeviceBuffers(dst_ptrs, kSmallCopySize);
+  }
+
+  SECTION("Ordering after prior kernel on same stream") {
+    StreamGuard stream_guard(Streams::created);
+    std::vector<LinearAllocGuard<int>> src = AllocateBatchBuffers(LinearAllocs::hipMalloc, config);
+    std::vector<LinearAllocGuard<int>> dst = AllocateBatchBuffers(LinearAllocs::hipMalloc, config);
+    std::vector<void*> src_ptrs = MakeBatchPtrs(src);
+    std::vector<void*> dst_ptrs = MakeBatchPtrs(dst);
+
+    static_cast<void>(hipGetLastError());
+    for (size_t i = 0; i < kCount; ++i) {
+      VectorSet<<<1, 256, 0, stream_guard.stream()>>>(
+          static_cast<int*>(src_ptrs[i]), kPatternValue + static_cast<int>(i), kCopyElements);
+    }
+    HIP_CHECK(hipGetLastError());
+    HIP_CHECK(hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(), kCount, nullptr,
+                                  nullptr, 0, nullptr, stream_guard.stream()));
+    HIP_CHECK(hipStreamSynchronize(stream_guard.stream()));
+
+    VerifyDeviceBuffers(dst_ptrs, kSmallCopySize);
+  }
+
+  SECTION("Ordering via event dependency") {
+    StreamGuard producer_stream(Streams::created);
+    StreamGuard copy_stream(Streams::created);
+    EventsGuard events(1);
+    std::vector<LinearAllocGuard<int>> src = AllocateBatchBuffers(LinearAllocs::hipMalloc, config);
+    std::vector<LinearAllocGuard<int>> dst = AllocateBatchBuffers(LinearAllocs::hipMalloc, config);
+    std::vector<void*> src_ptrs = MakeBatchPtrs(src);
+    std::vector<void*> dst_ptrs = MakeBatchPtrs(dst);
+
+    static_cast<void>(hipGetLastError());
+    for (size_t i = 0; i < kCount; ++i) {
+      VectorSet<<<1, 256, 0, producer_stream.stream()>>>(
+          static_cast<int*>(src_ptrs[i]), kPatternValue + static_cast<int>(i), kCopyElements);
+    }
+    HIP_CHECK(hipGetLastError());
+    HIP_CHECK(hipEventRecord(events[0], producer_stream.stream()));
+    HIP_CHECK(hipStreamWaitEvent(copy_stream.stream(), events[0], 0));
+    HIP_CHECK(hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(), kCount, nullptr,
+                                  nullptr, 0, nullptr, copy_stream.stream()));
+    HIP_CHECK(hipStreamSynchronize(copy_stream.stream()));
+
+    VerifyDeviceBuffers(dst_ptrs, kSmallCopySize);
+  }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ * - Verifies peer-to-peer batches across peer-accessible device pairs.
+ * Test source
+ * ------------------------
+ * - catch/unit/memory/hipMemcpyBatchAsync.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 7.1
+ */
+HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_P2P_Functional) {
+  const std::vector<std::pair<int, int>> peer_pairs = GetPeerAccessibleDevicePairs();
+  const int stream_device = peer_pairs.front().first;
+  const hipMemcpyFlags flag = GENERATE(hipMemcpyFlagDefault, hipMemcpyFlagExtPreferCE);
+
+  constexpr size_t copy_size = kSmallCopySize;
+  constexpr size_t batch_count = 2;
+  const size_t total_copy_count = peer_pairs.size() * batch_count;
+  std::vector<LinearAllocGuard<int>> src_allocations;
+  std::vector<LinearAllocGuard<int>> dst_allocations;
+  std::vector<void*> src_ptrs;
+  std::vector<void*> dst_ptrs;
+  std::vector<size_t> sizes(total_copy_count, copy_size);
+  hipMemcpyAttributes attr{hipMemcpySrcAccessOrderStream, {}, {}, flag};
+  size_t attrs_idxs[1] = {0};
+
+  EnablePeerAccess(peer_pairs);
+  for (const auto& [src_device, dst_device] : peer_pairs) {
+    for (size_t i = 0; i < batch_count; ++i) {
+      HIP_CHECK(hipSetDevice(src_device));
+      src_allocations.emplace_back(LinearAllocs::hipMalloc, copy_size);
+      src_ptrs.push_back(src_allocations.back().ptr());
+
+      HIP_CHECK(hipSetDevice(dst_device));
+      dst_allocations.emplace_back(LinearAllocs::hipMalloc, copy_size);
+      dst_ptrs.push_back(dst_allocations.back().ptr());
+    }
+  }
+
+  HIP_CHECK(hipSetDevice(stream_device));
+  StreamGuard stream_guard(Streams::created);
+  FillDeviceBuffers(src_ptrs, copy_size, kPatternValue);
+  HIP_CHECK(hipSetDevice(stream_device));
+  HIP_CHECK(hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(), sizes.size(), &attr,
+                                attrs_idxs, 1, nullptr, stream_guard.stream()));
+  HIP_CHECK(hipStreamSynchronize(stream_guard.stream()));
+
+  VerifyDeviceBuffers(dst_ptrs, copy_size);
+  DisablePeerAccess(peer_pairs);
+  HIP_CHECK(hipSetDevice(stream_device));
+}
+
 /**
  * End doxygen group MemoryTest.
  * @}


### PR DESCRIPTION
## Motivation

The hipMemcpyBatchAsync API is missing unit and performance tests.

## Technical Details

Added unit and performance tests for hipMemcpyBatchAsync .

## JIRA ID

AIRUNTIME-2248

## Test Plan

Run tests on different platforms.

## Test Result

All tests are passing.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
