### PR TITLE
[AICOMRCCL-1097] [RCCL] Avoid restamping nccl_device headers on every…

### DIFF
--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -450,8 +450,8 @@ list(APPEND NCCL_DEVICE_HIP_FILES ${HIP_COMPAT_DST})
 add_custom_command(
   OUTPUT ${NCCL_DEVICE_HEADER}
   COMMAND ${CMAKE_COMMAND} -E make_directory "${PROJECT_BINARY_DIR}/include"
-  COMMAND ${CMAKE_COMMAND} -E copy "${HIPIFY_DIR}/src/include/nccl_device.h" "${PROJECT_BINARY_DIR}/include/"
-  COMMAND ${CMAKE_COMMAND} -E copy_directory "${HIPIFY_DIR}/src/include/nccl_device" "${PROJECT_BINARY_DIR}/include/nccl_device"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different "${HIPIFY_DIR}/src/include/nccl_device.h" "${PROJECT_BINARY_DIR}/include/"
+  COMMAND ${CMAKE_COMMAND} -E copy_directory_if_different "${HIPIFY_DIR}/src/include/nccl_device" "${PROJECT_BINARY_DIR}/include/nccl_device"
   DEPENDS ${NCCL_DEVICE_HIP_FILES}
   VERBATIM
 )


### PR DESCRIPTION
… build

The copy_nccl_device_headers custom command used `cmake -E copy` and `cmake -E copy_directory`, both of which unconditionally rewrite destination mtimes. Every librccl .o that #includes <nccl_device/...> (most of them) then looked out-of-date on the next build, forcing a full librccl rebuild every incremental cycle.

Switch to the _if_different variants (available since CMake 3.26; project already requires newer). No behaviour change when headers actually change; headers are only re-copied when content differs.

Measured on rccl-UnitTestsMicro, -j $(nproc), Release:
  - no-op rebuild:                    33.06s -> 0.44s  (75x)
  - touch test/micro/p2p-test.cc only:  33.27s -> 5.58s  (6x)
