### PR TITLE
[AICOMRCCL-1097] [RCCL] Fail fast at configure when GPU_TARGETS resol…

### DIFF
--- a/projects/rccl/CMakeLists.txt
+++ b/projects/rccl/CMakeLists.txt
@@ -175,6 +175,20 @@ else()
 endif()
 
 set(GPU_TARGETS "${SUPPORTED_GPUS}")
+
+# Fail fast if we ended up with no GPU targets at all
+if(NOT GPU_TARGETS OR "${GPU_TARGETS}" STREQUAL "NOTFOUND")
+  message(FATAL_ERROR
+    "GPU_TARGETS is empty (resolved to '${GPU_TARGETS}').\n"
+    "This usually means ./install.sh -l was used on a host with no visible "
+    "AMD GPU (no /dev/kfd, no /dev/dri), so local-arch detection found "
+    "nothing to target.\n"
+    "\n"
+    "If you wish to build here anyway, re-run with an explicit GPU "
+    "architecture, e.g.:\n"
+    "    ./install.sh --amdgpu_targets gfx1201\n")
+endif()
+
 message(STATUS "Compiling for ${GPU_TARGETS}")
 
 ## NOTE: Reload rocm-cmake in order to update GPU_TARGETS


### PR DESCRIPTION
…ves to empty

When ./install.sh -l is used on a host with no visible AMD GPU (e.g. a container without /dev/kfd or /dev/dri, or a older dev laptop), rocm_local_targets() comes up empty and GPU_TARGETS ends up as NOTFOUND. Configure was happily continuing in that state and the failure surfaced much later in the device-linker pipeline as opaque errors (empty --offload-arch, missing -I flags, 'argcheck.h not found', clang-offload-bundler with no targets, etc.) -- with no breadcrumb back to the actual cause.

Add a FATAL_ERROR right after GPU_TARGETS is finalised, with an actionable fix: re-run with --amdgpu_targets <arch> explicitly.

