### PR TITLE
clr: Fix stream capture invalidation and cleanup

### DIFF
--- a/projects/clr/hipamd/src/hip_event.cpp
+++ b/projects/clr/hipamd/src/hip_event.cpp
@@ -497,22 +497,29 @@ static hipError_t checkEventCaptureRestrictions(hipEvent_t event) {
     return hipSuccess;
   }
 
-  // Block in GLOBAL mode if any global captures are ongoing
+  // Block in GLOBAL mode if any global captures are actively ongoing
+  bool capture_invalidated = false;
   if (hip::tls.stream_capture_mode_ == hipStreamCaptureModeGlobal) {
     amd::ScopedLock lock(g_captureStreamsLock);
-    if (!g_captureStreams.empty()) {
-      for (auto stream : g_captureStreams) {
+    for (auto stream : g_captureStreams) {
+      if (stream->GetCaptureStatus() == hipStreamCaptureStatusActive) {
         stream->SetCaptureStatus(hipStreamCaptureStatusInvalidated);
+        capture_invalidated = true;
       }
+    }
+    if (capture_invalidated) {
       return hipErrorStreamCaptureUnsupported;
     }
   }
 
-  // Block if calling thread itself is capturing (both GLOBAL and THREAD_LOCAL)
-  if (!hip::tls.capture_streams_.empty()) {
-    for (auto stream : hip::tls.capture_streams_) {
+  // Block if calling thread itself is actively capturing (both GLOBAL and THREAD_LOCAL)
+  for (auto stream : hip::tls.capture_streams_) {
+    if (stream->GetCaptureStatus() == hipStreamCaptureStatusActive) {
       stream->SetCaptureStatus(hipStreamCaptureStatusInvalidated);
+      capture_invalidated = true;
     }
+  }
+  if (capture_invalidated) {
     return hipErrorStreamCaptureUnsupported;
   }
 

--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -1210,18 +1210,25 @@ hipError_t hipStreamEndCapture_common(hipStream_t stream, hip::Graph** pGraph) {
   }
   if (s->GetCaptureMode() == hipStreamCaptureModeGlobal) {
     amd::ScopedLock lock(g_captureStreamsLock);
-    g_captureStreams.erase(std::find(g_captureStreams.begin(), g_captureStreams.end(), s));
+    auto git = std::find(g_captureStreams.begin(), g_captureStreams.end(), s);
+    if (git != g_captureStreams.end()) {
+      g_captureStreams.erase(git);
+    }
   }
   {
     amd::ScopedLock lock(g_streamSetLock);
-    g_allCapturingStreams.erase(
-        std::find(g_allCapturingStreams.begin(), g_allCapturingStreams.end(), s));
+    auto ait = g_allCapturingStreams.find(s);
+    if (ait != g_allCapturingStreams.end()) {
+      g_allCapturingStreams.erase(ait);
+    }
   }
   // If capture was invalidated, due to a violation of the rules of stream capture
   if (s->GetCaptureStatus() == hipStreamCaptureStatusInvalidated) {
     *pGraph = nullptr;
     // When capture is invalidated, graph should be deleted, otherwise it leaks
     s->ReleaseCaptureGraph();
+    // Clean up forked streams' state to avoid dangling pointers and stale capture status
+    s->EndCapture();
 
     return hipErrorStreamCaptureInvalidated;
   }
@@ -1260,6 +1267,8 @@ hipError_t hipStreamEndCapture_common(hipStream_t stream, hip::Graph** pGraph) {
     if (leafNodes.size() > 1 && foundInRemovedDep == false) {
       // Release created graph as it can't be retrieved anymore
       s->ReleaseCaptureGraph();
+      // Clean up forked streams' state to avoid dangling pointers and stale capture status
+      s->EndCapture();
       return hipErrorStreamCaptureUnjoined;
     }
   } else {

--- a/projects/clr/hipamd/src/hip_internal.hpp
+++ b/projects/clr/hipamd/src/hip_internal.hpp
@@ -212,30 +212,45 @@ const char* ihipGetErrorName(hipError_t hip_error);
 // During stream capture some actions, such as a call to hipMalloc, may be unsafe and prohibited
 // during capture. It is allowed only in relaxed mode.
 #define CHECK_STREAM_CAPTURE_SUPPORTED()                                                           \
-  if (hip::tls.stream_capture_mode_ == hipStreamCaptureModeThreadLocal ||                          \
-      hip::tls.stream_capture_mode_ == hipStreamCaptureModeGlobal) {                               \
-    if (!hip::tls.capture_streams_.empty()) {                                                      \
+  {                                                                                                \
+    bool _capture_invalidated = false;                                                             \
+    if (hip::tls.stream_capture_mode_ == hipStreamCaptureModeThreadLocal ||                        \
+        hip::tls.stream_capture_mode_ == hipStreamCaptureModeGlobal) {                             \
       for (auto stream : hip::tls.capture_streams_) {                                              \
-        stream->SetCaptureStatus(hipStreamCaptureStatusInvalidated);                               \
+        if (stream->GetCaptureStatus() == hipStreamCaptureStatusActive) {                          \
+          stream->SetCaptureStatus(hipStreamCaptureStatusInvalidated);                             \
+          _capture_invalidated = true;                                                             \
+        }                                                                                          \
       }                                                                                            \
+    }                                                                                              \
+    if (hip::tls.stream_capture_mode_ == hipStreamCaptureModeGlobal) {                             \
+      amd::ScopedLock _csl(g_captureStreamsLock);                                                  \
+      for (auto stream : g_captureStreams) {                                                       \
+        if (stream->GetCaptureStatus() == hipStreamCaptureStatusActive) {                          \
+          stream->SetCaptureStatus(hipStreamCaptureStatusInvalidated);                             \
+          _capture_invalidated = true;                                                             \
+        }                                                                                          \
+      }                                                                                            \
+    }                                                                                              \
+    if (_capture_invalidated) {                                                                    \
       HIP_RETURN(hipErrorStreamCaptureUnsupported);                                                \
     }                                                                                              \
-  }                                                                                                \
-  if (hip::tls.stream_capture_mode_ == hipStreamCaptureModeGlobal &&                               \
-      !g_captureStreams.empty()) {                                                                 \
-    for (auto stream : g_captureStreams) {                                                         \
-      stream->SetCaptureStatus(hipStreamCaptureStatusInvalidated);                                 \
-    }                                                                                              \
-    HIP_RETURN(hipErrorStreamCaptureUnsupported);                                                  \
   }
 
-// Helper: invalidate all capturing streams and return an error code.
+// Helper: invalidate all actively capturing streams and return an error code.
 #define INVALIDATE_ALL_CAPTURING_AND_RETURN(err)                                                   \
-  if (!g_allCapturingStreams.empty()) {                                                            \
+  {                                                                                                \
+    bool _capture_invalidated = false;                                                             \
+    amd::ScopedLock _ssl(g_streamSetLock);                                                         \
     for (auto stream : g_allCapturingStreams) {                                                    \
-      stream->SetCaptureStatus(hipStreamCaptureStatusInvalidated);                                 \
+      if (stream->GetCaptureStatus() == hipStreamCaptureStatusActive) {                            \
+        stream->SetCaptureStatus(hipStreamCaptureStatusInvalidated);                               \
+        _capture_invalidated = true;                                                               \
+      }                                                                                            \
     }                                                                                              \
-    return err;                                                                                    \
+    if (_capture_invalidated) {                                                                    \
+      return err;                                                                                  \
+    }                                                                                              \
   }
 
 // Device sync is not supported during capture.

--- a/projects/clr/hipamd/src/hip_stream.cpp
+++ b/projects/clr/hipamd/src/hip_stream.cpp
@@ -157,24 +157,28 @@ bool Stream::StreamCaptureOngoing(hipStream_t hStream) {
   if (hip::tls.stream_capture_mode_ == hipStreamCaptureModeRelaxed) {
     return false;
   }
-  // Global mode — invalidate all capturing streams in any thread.
+  // Global mode — invalidate all actively capturing streams in any thread.
+  bool capture_invalidated = false;
   if (hip::tls.stream_capture_mode_ == hipStreamCaptureModeGlobal) {
     amd::ScopedLock lock(g_captureStreamsLock);
-    if (!g_captureStreams.empty()) {
-      for (auto stream : hip::g_captureStreams) {
+    for (auto stream : hip::g_captureStreams) {
+      if (stream->GetCaptureStatus() == hipStreamCaptureStatusActive) {
         stream->SetCaptureStatus(hipStreamCaptureStatusInvalidated);
+        capture_invalidated = true;
       }
+    }
+    if (capture_invalidated) {
       return true;
     }
   }
-  // ThreadLocal mode — invalidate all capturing streams in current thread.
-  if (!hip::tls.capture_streams_.empty()) {
-    for (auto stream : hip::tls.capture_streams_) {
+  // ThreadLocal mode — invalidate all actively capturing streams in current thread.
+  for (auto stream : hip::tls.capture_streams_) {
+    if (stream->GetCaptureStatus() == hipStreamCaptureStatusActive) {
       stream->SetCaptureStatus(hipStreamCaptureStatusInvalidated);
+      capture_invalidated = true;
     }
-    return true;
   }
-  return false;
+  return capture_invalidated;
 }
 
 // ================================================================================================


### PR DESCRIPTION
Only invalidate streams with Active capture status in restriction checks, preventing stale entries from causing perpetual API failures.

Guard erase calls in hipStreamEndCapture_common to avoid undefined behavior when the stream is not in the tracking list. Call EndCapture() on invalidated and unjoined error paths to clean up forked streams' state and prevent dangling pCaptureGraph_ pointers.

Add proper locking around shared container iteration in capture restriction macros and helper functions.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
