### PR TITLE
[hipFile/CI] Add ROCm 7.13 leg to update CI image

### DIFF
--- a/.github/workflows/hipfile-image-update.yml
+++ b/.github/workflows/hipfile-image-update.yml
@@ -50,6 +50,9 @@ jobs:
           - ubuntu
         rocm_versions:
           - 7.2.2
+        include:
+          - supported_platforms: ubuntu
+            rocm_versions: 7.13.0
     steps:
       - name: Fetching code repository...
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Motivation

Fixes a forgotten addition to the hipFile Update CI image workflow. The CI image with ROCm 7.13 is not pushed into the registry which causes job failures as there is no image to pull.

## JIRA ID

AIHIPFILE-193
AIHIPFILE-196

## Test Plan

Manually run a dispatch trigger.
Expect CI failure as this PR does not change the Dockerfiles, so it will try to fetch the latest image.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
