### PR TITLE
cmake 4.0 + does not support get_filename_component REAL_PATH

### DIFF
--- a/projects/hip-tests/catch/cmake/relative_paths.py
+++ b/projects/hip-tests/catch/cmake/relative_paths.py
@@ -22,9 +22,9 @@ modified_msg = """
 # File has been updated by hip-tests/catch folder for portability
 """
 ctest_current_str = """
-get_filename_component(FULL_FILE_PATH ${CMAKE_CURRENT_LIST_FILE} REALPATH)
+file(REAL_PATH ${CMAKE_CURRENT_LIST_FILE} FULL_FILE_PATH)
 get_filename_component(CTEST_CURRENT_DIR ${FULL_FILE_PATH} DIRECTORY)
-get_filename_component(EXE_PATH ${CTEST_CURRENT_DIR}/.. REALPATH)
+file(REAL_PATH ${CTEST_CURRENT_DIR}/.. EXE_PATH)
 """
 if os.name == "posix":
     library_path_str = """
@@ -64,7 +64,7 @@ def make_test_files_portable(filenames):
             modified_content = file_content.replace(old_text, "")
             if inc_cmake_pattern in filename:
                 # 2 get folder path relative to the current *_include.cmake
-                if r"get_filename_component(FULL_FILE_PATH" not in modified_content:
+                if r"file(REAL_PATH" not in modified_content:
                     modified_content = ctest_current_str + modified_content
                 # 3 CTEST_FILE to have parameterized relative file
                 test_cmake_pattern = r"\[==\[(\w+-[a-f0-9]+_tests.cmake)\]==\]"


### PR DESCRIPTION
## Motivation
causes paths to be not populated correctly causing hip-tests ctest failure for systems with cmake 4.0+

example - 
registry-sc-harbor.amd.com/framework/therock-main:1374_gfx94X_7.13.0a20260514_ubuntu24.04_py3.12_pytorch_release-2.11_96bfee1  

Error -
CMake Error at script/RTC-b12d07c_include.cmake:19 (include):
  include could not find requested file:
    /script/CatchAddTests.cmake


## Technical Details
cmake 4.0+ deprecated the use of get_filename_component REAL_PATH so need to use something thats more compatiable across cmake versions

## JIRA ID
NA

## Test Plan
hip-tests build and execute correctly across different cmake versions

## Test Result
hip-tests build and execute correctly across different cmake versions

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
