### PR TITLE
[rocprofiler-sdk] Update perfetto submodule to v56.1 and fetch SDK at configure time

### DIFF
--- a/projects/rocprofiler-sdk/external/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/external/CMakeLists.txt
@@ -190,16 +190,35 @@ rocprofiler_checkout_git_submodule(
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
     TEST_FILE meson.build
     REPO_URL https://github.com/google/perfetto
-    REPO_BRANCH "v44.0")
+    REPO_BRANCH "v56.1")
+
+# Starting with v54.x, Perfetto no longer ships the amalgamated C++ SDK
+# (sdk/perfetto.{h,cc}) inside the source tree; it is published only as a release artifact
+# on GitHub. Fetch it via FetchContent into the build tree.
+set(ROCPROFILER_PERFETTO_SDK_VERSION
+    "v56.1"
+    CACHE STRING "Perfetto C++ SDK release version")
+set(ROCPROFILER_PERFETTO_SDK_URL_HASH
+    "SHA256=9138dad1ab39048a61d3333e0c2ebf32a7497ed45e3b7daa5f3a02c14748af38"
+    CACHE STRING "Perfetto C++ SDK release archive hash")
+
+include(FetchContent)
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
+    cmake_policy(SET CMP0135 NEW)
+endif()
+
+fetchcontent_declare(
+    perfetto-sdk
+    URL https://github.com/google/perfetto/releases/download/${ROCPROFILER_PERFETTO_SDK_VERSION}/perfetto-cpp-sdk-src.zip
+    URL_HASH ${ROCPROFILER_PERFETTO_SDK_URL_HASH})
+fetchcontent_makeavailable(perfetto-sdk)
+set(_perfetto_sdk_dir ${perfetto-sdk_SOURCE_DIR})
 
 add_library(rocprofiler-sdk-perfetto-static-library STATIC)
-target_sources(
-    rocprofiler-sdk-perfetto-static-library
-    PRIVATE ${PROJECT_SOURCE_DIR}/external/perfetto/sdk/perfetto.h
-            ${PROJECT_SOURCE_DIR}/external/perfetto/sdk/perfetto.cc)
-target_include_directories(
-    rocprofiler-sdk-perfetto-static-library SYSTEM
-    INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/external/perfetto/sdk>)
+target_sources(rocprofiler-sdk-perfetto-static-library
+               PRIVATE ${_perfetto_sdk_dir}/perfetto.h ${_perfetto_sdk_dir}/perfetto.cc)
+target_include_directories(rocprofiler-sdk-perfetto-static-library SYSTEM
+                           INTERFACE $<BUILD_INTERFACE:${_perfetto_sdk_dir}>)
 set_target_properties(
     rocprofiler-sdk-perfetto-static-library
     PROPERTIES POSITION_INDEPENDENT_CODE ON OUTPUT_NAME rocprofiler-sdk-perfetto)

--- a/projects/rocprofiler-sdk/source/lib/output/generatePerfetto.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generatePerfetto.cpp
@@ -825,7 +825,7 @@ write_perfetto(
             constexpr auto _unit = ::perfetto::CounterTrack::Unit::UNIT_SIZE_BYTES;
             auto&          _name = mem_cpy_cnt_names.emplace_back(_track_name.str());
             mem_cpy_tracks.emplace(mitr.first,
-                                   ::perfetto::CounterTrack{_name.c_str()}
+                                   ::perfetto::CounterTrack{::perfetto::StaticString{_name.c_str()}}
                                        .set_unit(_unit)
                                        .set_unit_multiplier(bytes_multiplier)
                                        .set_is_incremental(false));
@@ -996,11 +996,12 @@ write_perfetto(
 
             constexpr auto _unit = ::perfetto::CounterTrack::Unit::UNIT_SIZE_BYTES;
             auto&          _name = mem_alloc_cnt_names.emplace_back(_track_name.str());
-            mem_alloc_tracks.emplace(alloc_itr.first,
-                                     ::perfetto::CounterTrack{_name.c_str()}
-                                         .set_unit(_unit)
-                                         .set_unit_multiplier(bytes_multiplier)
-                                         .set_is_incremental(false));
+            mem_alloc_tracks.emplace(
+                alloc_itr.first,
+                ::perfetto::CounterTrack{::perfetto::StaticString{_name.c_str()}}
+                    .set_unit(_unit)
+                    .set_unit_multiplier(bytes_multiplier)
+                    .set_is_incremental(false));
         }
 
         for(auto& alloc_itr : mem_alloc_endpoints)
@@ -1080,11 +1081,12 @@ write_perfetto(
 
                 constexpr auto _unit = ::perfetto::CounterTrack::Unit::UNIT_SIZE_BYTES;
                 auto&          _name = scratch_mem_names.emplace_back(_track_name.str());
-                scratch_mem_tracks.emplace(mitr.first,
-                                           ::perfetto::CounterTrack{_name.c_str()}
-                                               .set_unit(_unit)
-                                               .set_unit_multiplier(bytes_multiplier)
-                                               .set_is_incremental(false));
+                scratch_mem_tracks.emplace(
+                    mitr.first,
+                    ::perfetto::CounterTrack{::perfetto::StaticString{_name.c_str()}}
+                        .set_unit(_unit)
+                        .set_unit_multiplier(bytes_multiplier)
+                        .set_is_incremental(false));
             }
         }
 
@@ -1186,7 +1188,8 @@ write_perfetto(
                         auto track_name = track_name_ss.str();
 
                         counter_tracks[info.agent_id].emplace(
-                            track_name, ::perfetto::CounterTrack(track_name.c_str()));
+                            track_name,
+                            ::perfetto::CounterTrack(::perfetto::StaticString{track_name.c_str()}));
                         auto& endpoints = counters_endpoints[info.agent_id][counter_id];
                         for(auto& counter_itr : endpoints)
                         {

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/source/perfetto.cpp
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/source/perfetto.cpp
@@ -807,7 +807,7 @@ write_perfetto(
         // memory copy counter track
         auto mem_cpy_endpoints = std::map<uint64_t, std::map<rocprofiler_timestamp_t, uint64_t>>{};
         auto mem_cpy_extremes  = std::pair<uint64_t, uint64_t>{std::numeric_limits<uint64_t>::max(),
-                                                              std::numeric_limits<uint64_t>::min()};
+                                                               std::numeric_limits<uint64_t>::min()};
         auto constexpr timestamp_buffer = 1000;
         for(auto ditr : memory_copy_gen)
         {
@@ -863,11 +863,12 @@ write_perfetto(
 
             constexpr auto _unit = ::perfetto::CounterTrack::Unit::UNIT_SIZE_BYTES;
             auto&          _name = mem_cpy_cnt_names.emplace_back(_track_name.str());
-            mem_cpy_tracks.emplace(abs_index,
-                                   ::perfetto::CounterTrack{_name.c_str(), this_pid_track}
-                                       .set_unit(_unit)
-                                       .set_unit_multiplier(bytes_multiplier)
-                                       .set_is_incremental(false));
+            mem_cpy_tracks.emplace(
+                abs_index,
+                ::perfetto::CounterTrack{::perfetto::StaticString{_name.c_str()}, this_pid_track}
+                    .set_unit(_unit)
+                    .set_unit_multiplier(bytes_multiplier)
+                    .set_is_incremental(false));
         }
 
         for(auto& mitr : mem_cpy_endpoints)
@@ -1060,11 +1061,12 @@ write_perfetto(
 
             constexpr auto _unit = ::perfetto::CounterTrack::Unit::UNIT_SIZE_BYTES;
             auto&          _name = mem_alloc_cnt_names.emplace_back(_track_name.str());
-            mem_alloc_tracks.emplace(abs_index,
-                                     ::perfetto::CounterTrack{_name.c_str(), this_pid_track}
-                                         .set_unit(_unit)
-                                         .set_unit_multiplier(bytes_multiplier)
-                                         .set_is_incremental(false));
+            mem_alloc_tracks.emplace(
+                abs_index,
+                ::perfetto::CounterTrack{::perfetto::StaticString{_name.c_str()}, this_pid_track}
+                    .set_unit(_unit)
+                    .set_unit_multiplier(bytes_multiplier)
+                    .set_is_incremental(false));
         }
 
         for(auto& alloc_itr : mem_alloc_endpoints)
@@ -1139,11 +1141,13 @@ write_perfetto(
 
                 constexpr auto _unit = ::perfetto::CounterTrack::Unit::UNIT_SIZE_BYTES;
                 auto&          _name = scratch_mem_names.emplace_back(_track_name.str());
-                scratch_mem_tracks.emplace(abs_index,
-                                           ::perfetto::CounterTrack{_name.c_str(), this_pid_track}
-                                               .set_unit(_unit)
-                                               .set_unit_multiplier(bytes_multiplier)
-                                               .set_is_incremental(false));
+                scratch_mem_tracks.emplace(
+                    abs_index,
+                    ::perfetto::CounterTrack{::perfetto::StaticString{_name.c_str()},
+                                             this_pid_track}
+                        .set_unit(_unit)
+                        .set_unit_multiplier(bytes_multiplier)
+                        .set_is_incremental(false));
             }
         }
 
@@ -1237,7 +1241,9 @@ write_perfetto(
                     auto track_name = track_name_ss.str();
 
                     counter_tracks[record.agent_abs_index].emplace(
-                        track_name, ::perfetto::CounterTrack{track_name.c_str(), this_pid_track});
+                        track_name,
+                        ::perfetto::CounterTrack{::perfetto::StaticString{track_name.c_str()},
+                                                 this_pid_track});
                     auto& endpoints = counters_endpoints[record.agent_id][counter_id];
                     for(auto& counter_itr : endpoints)
                     {


### PR DESCRIPTION
## Motivation

Bump external/perfetto to the upstream v56.1 tag.

## Technical Details

Starting in v54.x, Perfetto no longer ships the amalgamated C++ SDK
(sdk/perfetto.{h,cc}) inside the source tree; it is published only as a
release artifact on GitHub (see sdk/MOVED_TO_GITHUB_RELEASES_ARTIFACTS.md).
external/CMakeLists.txt now declares the SDK as a FetchContent dependency
pinned to the matching release ZIP with a SHA256 URL_HASH, so configure
populates it into the build tree (_deps/perfetto-sdk-src/) on first use
and reuses the populated copy on subsequent configures. The static
library target sources/include dirs are repointed at that location;
nothing else changes about how the SDK is built or linked.

### Adapt CounterTrack calls to Perfetto v56 API

Perfetto v56 dropped the implicit `CounterTrack(const char*)` constructor
overload. Wrap each call site in `::perfetto::StaticString{name.c_str()}`
to preserve the pre-v56 wire format (`static_name` proto field, pointer
caching enabled) and the lifetime assumption the surrounding code already
relied on. No behavior change in the emitted .pftrace.

## Test Plan

rocprofiler-sdk-tool builds and `rocprofv3 --kernel-trace --hip-trace --memory-copy-trace --output-format pftrace` produces trace for an example `vector_add` workload that matches the previous trace output

## Test Result

See above

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

Related to #6411