### PR TITLE
[rocjitsu] Avoid crash with multi-thread partitioning

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.cpp
@@ -23,6 +23,10 @@ void SoC::wire_backing(simdojo::Topology &topo) {
   if (!hbm_standalone_) {
     return;
   }
+  // The standalone HBM controller is not part of the component tree, so the
+  // automatic partitioner won't assign it a partition. Assign it to partition 0
+  // so classify_links() doesn't access partitions_ out of bounds.
+  hbm_standalone_->set_partition_id(0);
   for (auto *x : xcds_) {
     if (!x->l2_cache())
       continue;

--- a/emulation/rocjitsu/tests/config_test.cpp
+++ b/emulation/rocjitsu/tests/config_test.cpp
@@ -228,6 +228,53 @@ TEST(CheckpointTest, SaveAndRestoreMemory) {
   std::filesystem::remove(path);
 }
 
+TEST(ConfigLoaderTest, MultiThreadAutoPartitionNoIod) {
+  const char *json = R"({"max_ticks":10000,"num_threads":2,
+    "vm":{"arch":"cdna3"},
+    "topology":{
+      "root":{
+        "name":"soc","type":"soc",
+        "children":[
+          {"name":"vram","type":"gpu_memory"},
+          {"name":"xcd[0:2]","type":"xcd","children":[
+            {"name":"l2","type":"l2_cache"},
+            {"name":"cp","type":"command_processor"},
+            {"name":"se0","type":"shader_engine","children":[
+              {"name":"cu[0:2]","type":"compute_unit","config":[
+                {"key":"num_wf_slots","value":"10"},
+                {"key":"sgprs_per_wf","value":"104"},
+                {"key":"vgprs_per_wf","value":"256"},
+                {"key":"lds_size_kb","value":"64"}
+              ]}
+            ]}
+          ]}
+        ]
+      },
+      "links":[
+        {"src":"xcd0.cp.req_0","dst":"xcd0.se0.cu0.cpl","latency":1,"weight":2},
+        {"src":"xcd0.cp.req_1","dst":"xcd0.se0.cu1.cpl","latency":1,"weight":2},
+        {"src":"xcd0.se0.cu0.req","dst":"xcd0.l2.cpl_0","latency":1,"weight":10},
+        {"src":"xcd0.se0.cu1.req","dst":"xcd0.l2.cpl_1","latency":1,"weight":10},
+        {"src":"xcd1.cp.req_0","dst":"xcd1.se0.cu0.cpl","latency":1,"weight":2},
+        {"src":"xcd1.cp.req_1","dst":"xcd1.se0.cu1.cpl","latency":1,"weight":2},
+        {"src":"xcd1.se0.cu0.req","dst":"xcd1.l2.cpl_0","latency":1,"weight":10},
+        {"src":"xcd1.se0.cu1.req","dst":"xcd1.l2.cpl_1","latency":1,"weight":10}
+      ]
+    }
+  })";
+
+  auto loaded = config::load_config_from_string(json, SCHEMA_PATH);
+  auto *soc = loaded.soc();
+  EXPECT_EQ(soc->num_xcds(), 2u);
+  EXPECT_EQ(soc->num_iods(), 0u);
+
+  simdojo::SimulationEngine engine(loaded.engine_config);
+  engine.topology().set_root(loaded.take_root());
+  loaded.wire_links(engine.topology());
+  soc->wire_backing(engine.topology());
+  engine.build();
+}
+
 TEST(CApiTest, CreateAndDestroyFromString) {
   const char *json = R"({"max_ticks":10000,"num_threads":1,
     "vm":{"arch":"cdna3"},


### PR DESCRIPTION
## Motivation

Agent says: The standalone HBM controller (used in no-IOD configs) is not part of the component tree, so the automatic FM partitioner never assigns it a partition ID. When num_threads > 1, classify_links() dereferences partitions_[INVALID_PARTITION_ID] causing a segfault. Assign partition 0 to hbm_standalone_ in wire_backing() before links are created. 

James says: My goal is to use the LD_PRELOAD approach with multithreading, this fixes a segfault I observed but I don't think it actually achieves my goal.  

## Test Plan

Add a regression test that segfaults without this fix.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
