### PR TITLE
[rocjitsu] Add marketing name interposer, update default device_id

### DIFF
--- a/emulation/rocjitsu/configs/amdgpu_cdna4.json
+++ b/emulation/rocjitsu/configs/amdgpu_cdna4.json
@@ -9,7 +9,7 @@
         "gpu_id": 38144,
         "gfx_target_version": 90500,
         "vendor_id": 4098,
-        "device_id": 5892,
+        "device_id": 30112,
         "family_id": 160,
         "unique_id": 5929628898254127105,
         "marketing_name": "AMD Instinct MI350X",

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -875,6 +875,17 @@ int amdgpu_device_get_fd(void * /*device_handle*/) {
   return fd >= 0 ? fd : InterposerContext::ctx.driver_fd();
 }
 
+// Interpose libdrm_amdgpu's amdgpu_get_marketing_name. ROCR calls this to
+// get the GPU's marketing name. We return the name from the simulation config
+// so that the simulated GPU is reported correctly regardless of what physical
+// GPU (if any) is present on the host.
+const char *amdgpu_get_marketing_name(void * /*device_handle*/) {
+  auto *drv = SimulatedDriver::lookup(SimulatedDriver::kfd_fd());
+  if (drv)
+    return drv->topology().gpu_info().marketing_name;
+  return "";
+}
+
 // -- fopen / freopen interposition (sysfs redirect) --
 
 FILE *fopen(const char *path, const char *mode) {

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -156,6 +156,11 @@ if(ROCMINFO_EXECUTABLE)
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
     add_test(
+        NAME "RocminfoTest.ReportsMarketingName"
+        COMMAND rocminfo_test --gtest_filter=RocminfoTest.ReportsMarketingName
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    )
+    add_test(
         NAME "RocminfoTest.ReportsWavefrontSize"
         COMMAND rocminfo_test --gtest_filter=RocminfoTest.ReportsWavefrontSize
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}

--- a/emulation/rocjitsu/tests/rocminfo_test.cpp
+++ b/emulation/rocjitsu/tests/rocminfo_test.cpp
@@ -77,6 +77,13 @@ TEST(RocminfoTest, ReportsGfx950) {
       << rocminfo_output().output;
 }
 
+TEST(RocminfoTest, ReportsMarketingName) {
+  ASSERT_EQ(rocminfo_output().exit_code, 0) << rocminfo_output().output;
+  EXPECT_NE(rocminfo_output().output.find("MI350"), std::string::npos)
+      << "rocminfo did not report MI350 marketing name.\nOutput:\n"
+      << rocminfo_output().output;
+}
+
 TEST(RocminfoTest, ReportsWavefrontSize) {
   ASSERT_EQ(rocminfo_output().exit_code, 0) << rocminfo_output().output;
   EXPECT_NE(rocminfo_output().output.find("Wavefront Size:"), std::string::npos)


### PR DESCRIPTION
Part of the race detection work on the race-detection-11 branch: https://github.com/newling/rocm-systems/tree/race-detection-11

Two small fixes needed for running workloads under the KMD interposer:

- Add amdgpu_get_marketing_name() interposer. ROCR calls this via libdrm_amdgpu to query the GPU's marketing name. Without it, the call reaches the real libdrm which has no device matching our simulated device_id, and returns null. A rocminfo test is added to verify the name appears in the output.

- Update the default device_id in amdgpu_cdna4.json from 5892 to 30112 to match MI350X.
