### PR TITLE
fix 2N performance regression in nccl sync v2_29

### DIFF
--- a/projects/rccl/src/graph/paths.cc
+++ b/projects/rccl/src/graph/paths.cc
@@ -1156,7 +1156,7 @@ ncclResult_t ncclTopoComputeP2pChannels(struct ncclComm* comm) {
   if (comm->nNodes > 1 && comm->config.nChannelsPerNetPeer == NCCL_CONFIG_UNDEF_INT) {
     // In the case of >1 NVLD (and the user didn't set nChannelsPerNetPeer), the network is the bottleneck.
     // Reduce the number of channels per host to avoid going above p2pnChannels to fit all the peers within a single round.
-    while (comm->p2pnChannelsPerPeer * divUp(comm->nRanks, NCCL_MAX_DEV_WORK_P2P_PER_BATCH) > comm->p2pnChannels && comm->p2pnChannelsPerPeer > 1) comm->p2pnChannelsPerPeer /= 2;
+    while (comm->p2pnChannelsPerPeer * divUp(comm->nRanks, NCCL_MAX_DEV_WORK_P2P_PER_BATCH) >= comm->p2pnChannels && comm->p2pnChannelsPerPeer > 1) comm->p2pnChannelsPerPeer /= 2;
   } else {
     comm->p2pnChannelsPerPeer = std::min(comm->p2pnChannelsPerPeer, comm->p2pnChannels);
   }


### PR DESCRIPTION
The v2.29 sync changed P2P channel-per-peer calculation from a fixed value (2) to bandwidth-based: divUp(netBw, 14), which yields 4 on mi350x 48 GB/s PCI paths. A reduction loop in ncclTopoComputeP2pChannels() is meant to halve p2pnChannelsPerPeer when total demand exceeds p2pnChannels, but it used strict >. At 2N (16 ranks), 4 * divUp(16, 2) = 32 exactly equals p2pnChannels=32, so the loop never fires — leaving 4 channels/peer instead of 2. The fix changes > to >= on line 1159 of src/graph/paths.cc, causing the boundary case to reduce properly. This restores alltoall, alltoallv, and scatter to baseline performance at 2N while being a no-op at 4N+ where the product already exceeds 32.

## Motivation

fix perf regression

## Technical Details
The v2.29 sync changed P2P channel-per-peer calculation from a fixed value (2) to bandwidth-based: divUp(netBw, 14), which yields 4 on mi350x 48 GB/s PCI paths. A reduction loop in ncclTopoComputeP2pChannels() is meant to halve p2pnChannelsPerPeer when total demand exceeds p2pnChannels, but it used strict >. At 2N (16 ranks), 4 * divUp(16, 2) = 32 exactly equals p2pnChannels=32, so the loop never fires — leaving 4 channels/peer instead of 2. The fix changes > to >= on line 1159 of src/graph/paths.cc, causing the boundary case to reduce properly. This restores alltoall, alltoallv, and scatter to baseline performance at 2N while being a no-op at 4N+ where the product already exceeds 32.


## JIRA ID

Resolves AICOMRCCL-1102

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.