### PR TITLE
[rocprofiler-systems] Improve code coverage report 

### DIFF
--- a/.github/workflows/rocprofiler-systems-code-coverage.yml
+++ b/.github/workflows/rocprofiler-systems-code-coverage.yml
@@ -100,17 +100,10 @@ jobs:
             libmpich-dev mpich &&
           apt-get autoclean
 
-    - name: Install Python Test Dependencies
+    - name: Install gcovr
       timeout-minutes: 10
       shell: bash
-      working-directory: projects/rocprofiler-systems/
-      run: |
-        pip3 install 'gcovr>=8.4'
-        env_dir=/opt/conda/envs/py3.12/
-        if [ -d "${env_dir}" ] && [ -x "${env_dir}bin/python3" ]; then
-          echo "Installing requirements into ${env_dir}"
-          "${env_dir}bin/python3" -m pip install -r requirements.txt
-        fi
+      run: pip3 install 'gcovr>=8.4'
 
     - name: Sync gcov with GCC
       shell: bash

--- a/.github/workflows/rocprofiler-systems-code-coverage.yml
+++ b/.github/workflows/rocprofiler-systems-code-coverage.yml
@@ -134,7 +134,7 @@ jobs:
         cmake --preset coverage \
           -DROCPROFSYS_PYTHON_PREFIX=/opt/conda/envs \
           -DROCPROFSYS_PYTHON_ENVS=py3.12 \
-          "-DROCPROFSYS_DISABLE_EXAMPLES=transpose;rccl;videodecode;jpegdecode;openmp" \
+          "-DROCPROFSYS_DISABLE_EXAMPLES=transpose;rccl;videodecode;jpegdecode;openmp;roctx;scratch-memory;unified-memory;transferBench;hpc;sdma_test" \
           -DROCPROFSYS_BUILD_NUMBER=${{ github.run_attempt }}
 
     - name: Build

--- a/.github/workflows/rocprofiler-systems-code-coverage.yml
+++ b/.github/workflows/rocprofiler-systems-code-coverage.yml
@@ -141,7 +141,7 @@ jobs:
       shell: bash
       working-directory: projects/rocprofiler-systems/
       env:
-        LLVM_PROFILE_FILE: "${{ github.workspace }}/projects/rocprofiler-systems/build/coverage/profraw/unit/%p-%m.profraw"
+        LLVM_PROFILE_FILE: "${{ github.workspace }}/projects/rocprofiler-systems/build/coverage/profraw/unit/%c%p-%m.profraw"
       run: |
         mkdir -p build/coverage/profraw/unit
         ./build/coverage/bin/rocprof-sys-unit-tests
@@ -165,7 +165,7 @@ jobs:
       shell: bash
       working-directory: projects/rocprofiler-systems/
       env:
-        LLVM_PROFILE_FILE: "${{ github.workspace }}/projects/rocprofiler-systems/build/coverage/profraw/e2e/%p-%m.profraw"
+        LLVM_PROFILE_FILE: "${{ github.workspace }}/projects/rocprofiler-systems/build/coverage/profraw/e2e/%c%p-%m.profraw"
       run: |
         find build/coverage/profraw -name '*.profraw' -delete
         mkdir -p build/coverage/profraw/e2e

--- a/.github/workflows/rocprofiler-systems-code-coverage.yml
+++ b/.github/workflows/rocprofiler-systems-code-coverage.yml
@@ -212,7 +212,7 @@ jobs:
         echo 'EOF' >> $GITHUB_OUTPUT
 
     - name: Write Code Coverage Comment
-      if: always() && github.event_name == 'pull_request'
+      if: github.event_name == 'pull_request'
       timeout-minutes: 5
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
       env:

--- a/.github/workflows/rocprofiler-systems-code-coverage.yml
+++ b/.github/workflows/rocprofiler-systems-code-coverage.yml
@@ -80,7 +80,6 @@ jobs:
       shell: bash
       run: |
         echo "/opt/rocm/bin" >> $GITHUB_PATH
-        echo "/opt/rocm/lib/llvm/bin" >> $GITHUB_PATH
         echo "ROCM_PATH=/opt/rocm" >> $GITHUB_ENV
         echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
 
@@ -96,7 +95,7 @@ jobs:
           apt-get remove -y --purge 'libopenmpi-dev' 'libopenmpi3' 'openmpi-bin' 'openmpi-common' &&
           apt-get autoremove -y --purge &&
           apt-get upgrade -y &&
-          apt-get install -y libomp-dev libtbb-dev rocm-llvm-dev \
+          apt-get install -y libomp-dev libtbb-dev \
             libdw-dev libdwarf-dev libelf-dev libiberty-dev \
             libmpich-dev mpich &&
           apt-get autoclean
@@ -106,11 +105,20 @@ jobs:
       shell: bash
       working-directory: projects/rocprofiler-systems/
       run: |
+        pip3 install -r requirements.txt
         env_dir=/opt/conda/envs/py3.12/
         if [ -d "${env_dir}" ] && [ -x "${env_dir}bin/python3" ]; then
           echo "Installing requirements into ${env_dir}"
           "${env_dir}bin/python3" -m pip install -r requirements.txt
         fi
+
+    - name: Sync gcov with GCC
+      shell: bash
+      run: |
+        GCC_VER=$(gcc -dumpversion | cut -d. -f1)
+        echo "GCC version: ${GCC_VER}"
+        update-alternatives \
+          --install /usr/bin/gcov gcov /usr/bin/gcov-${GCC_VER} 500
 
     - name: Configure
       timeout-minutes: 15
@@ -122,7 +130,7 @@ jobs:
         git config --global --add safe.directory ${GITHUB_WORKSPACE}
         git config --global --add safe.directory ${PWD}
         echo "CMake version: $(cmake --version | head -n 1)"
-        echo "Compiler version: $(amdclang++ --version | head -n 1)"
+        echo "Compiler version: $(gcc --version | head -n 1)"
         cmake --preset coverage \
           -DROCPROFSYS_PYTHON_PREFIX=/opt/conda/envs \
           -DROCPROFSYS_PYTHON_ENVS=py3.12 \
@@ -140,10 +148,7 @@ jobs:
       timeout-minutes: 10
       shell: bash
       working-directory: projects/rocprofiler-systems/
-      env:
-        LLVM_PROFILE_FILE: "${{ github.workspace }}/projects/rocprofiler-systems/build/coverage/profraw/unit/%c%p-%m.profraw"
       run: |
-        mkdir -p build/coverage/profraw/unit
         ./build/coverage/bin/rocprof-sys-unit-tests
 
     - name: Generate Unit Test Coverage
@@ -153,22 +158,17 @@ jobs:
       working-directory: projects/rocprofiler-systems/
       run: |
         python3 scripts/generate-coverage.py \
-          --mode llvm \
-          --profraw-dir build/coverage/profraw/unit \
-          --binary-dir  build/coverage \
-          --source-dir  . \
-          --output-dir  .codecov \
+          --build-dir build/coverage \
+          --source-dir . \
+          --output-dir .codecov \
           --label unit-tests
 
     - name: E2E Tests
       timeout-minutes: 60
       shell: bash
       working-directory: projects/rocprofiler-systems/
-      env:
-        LLVM_PROFILE_FILE: "${{ github.workspace }}/projects/rocprofiler-systems/build/coverage/profraw/e2e/%c%p-%m.profraw"
       run: |
-        find build/coverage/profraw -name '*.profraw' -delete
-        mkdir -p build/coverage/profraw/e2e
+        find build/coverage -name '*.gcda' -delete
         ctest --test-dir build/coverage \
           --output-on-failure \
           -LE "network|gpu" \
@@ -181,11 +181,9 @@ jobs:
       working-directory: projects/rocprofiler-systems/
       run: |
         python3 scripts/generate-coverage.py \
-          --mode llvm \
-          --profraw-dir build/coverage/profraw/e2e \
-          --binary-dir  build/coverage \
-          --source-dir  . \
-          --output-dir  .codecov \
+          --build-dir build/coverage \
+          --source-dir . \
+          --output-dir .codecov \
           --label e2e-tests
 
     - name: Generate Coverage Comment

--- a/.github/workflows/rocprofiler-systems-code-coverage.yml
+++ b/.github/workflows/rocprofiler-systems-code-coverage.yml
@@ -80,6 +80,7 @@ jobs:
       shell: bash
       run: |
         echo "/opt/rocm/bin" >> $GITHUB_PATH
+        echo "/opt/rocm/lib/llvm/bin" >> $GITHUB_PATH
         echo "ROCM_PATH=/opt/rocm" >> $GITHUB_ENV
         echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
 
@@ -95,7 +96,9 @@ jobs:
           apt-get remove -y --purge 'libopenmpi-dev' 'libopenmpi3' 'openmpi-bin' 'openmpi-common' &&
           apt-get autoremove -y --purge &&
           apt-get upgrade -y &&
-          apt-get install -y libomp-dev gcovr libmpich-dev mpich &&
+          apt-get install -y libomp-dev libtbb-dev rocm-llvm-dev \
+            libdw-dev libdwarf-dev libelf-dev libiberty-dev \
+            libmpich-dev mpich &&
           apt-get autoclean
 
     - name: Install Python Test Dependencies
@@ -109,14 +112,6 @@ jobs:
           "${env_dir}bin/python3" -m pip install -r requirements.txt
         fi
 
-    - name: Sync gcov with GCC
-      shell: bash
-      run: |
-        GCC_VER=$(gcc -dumpversion | cut -d. -f1)
-        echo "GCC version: ${GCC_VER}"
-        update-alternatives \
-          --install /usr/bin/gcov gcov /usr/bin/gcov-${GCC_VER} 500
-
     - name: Configure
       timeout-minutes: 15
       shell: bash
@@ -127,7 +122,7 @@ jobs:
         git config --global --add safe.directory ${GITHUB_WORKSPACE}
         git config --global --add safe.directory ${PWD}
         echo "CMake version: $(cmake --version | head -n 1)"
-        echo "Compiler version: $(gcc --version | head -n 1)"
+        echo "Compiler version: $(amdclang++ --version | head -n 1)"
         cmake --preset coverage \
           -DROCPROFSYS_PYTHON_PREFIX=/opt/conda/envs \
           -DROCPROFSYS_PYTHON_ENVS=py3.12 \
@@ -145,7 +140,10 @@ jobs:
       timeout-minutes: 10
       shell: bash
       working-directory: projects/rocprofiler-systems/
+      env:
+        LLVM_PROFILE_FILE: "${{ github.workspace }}/projects/rocprofiler-systems/build/coverage/profraw/unit/%p-%m.profraw"
       run: |
+        mkdir -p build/coverage/profraw/unit
         ./build/coverage/bin/rocprof-sys-unit-tests
 
     - name: Generate Unit Test Coverage
@@ -155,17 +153,22 @@ jobs:
       working-directory: projects/rocprofiler-systems/
       run: |
         python3 scripts/generate-coverage.py \
-          --build-dir build/coverage \
-          --source-dir . \
-          --output-dir .codecov \
+          --mode llvm \
+          --profraw-dir build/coverage/profraw/unit \
+          --binary-dir  build/coverage \
+          --source-dir  . \
+          --output-dir  .codecov \
           --label unit-tests
 
     - name: E2E Tests
       timeout-minutes: 60
       shell: bash
       working-directory: projects/rocprofiler-systems/
+      env:
+        LLVM_PROFILE_FILE: "${{ github.workspace }}/projects/rocprofiler-systems/build/coverage/profraw/e2e/%p-%m.profraw"
       run: |
-        find build/coverage -name '*.gcda' -delete
+        find build/coverage/profraw -name '*.profraw' -delete
+        mkdir -p build/coverage/profraw/e2e
         ctest --test-dir build/coverage \
           --output-on-failure \
           -LE "network|gpu" \
@@ -178,9 +181,11 @@ jobs:
       working-directory: projects/rocprofiler-systems/
       run: |
         python3 scripts/generate-coverage.py \
-          --build-dir build/coverage \
-          --source-dir . \
-          --output-dir .codecov \
+          --mode llvm \
+          --profraw-dir build/coverage/profraw/e2e \
+          --binary-dir  build/coverage \
+          --source-dir  . \
+          --output-dir  .codecov \
           --label e2e-tests
 
     - name: Generate Coverage Comment

--- a/.github/workflows/rocprofiler-systems-code-coverage.yml
+++ b/.github/workflows/rocprofiler-systems-code-coverage.yml
@@ -105,7 +105,7 @@ jobs:
       shell: bash
       working-directory: projects/rocprofiler-systems/
       run: |
-        pip3 install -r requirements.txt
+        pip3 install 'gcovr>=8.4'
         env_dir=/opt/conda/envs/py3.12/
         if [ -d "${env_dir}" ] && [ -x "${env_dir}bin/python3" ]; then
           echo "Installing requirements into ${env_dir}"

--- a/.github/workflows/rocprofiler-systems-code-coverage.yml
+++ b/.github/workflows/rocprofiler-systems-code-coverage.yml
@@ -103,12 +103,11 @@ jobs:
       shell: bash
       working-directory: projects/rocprofiler-systems/
       run: |
-        for env_dir in /opt/conda/envs/py3.{8,9,10,11,12,13}/; do
-          if [ -d "${env_dir}" ] && [ -x "${env_dir}bin/python3" ]; then
-            echo "Installing requirements into ${env_dir}"
-            "${env_dir}bin/python3" -m pip install -r requirements.txt
-          fi
-        done
+        env_dir=/opt/conda/envs/py3.12/
+        if [ -d "${env_dir}" ] && [ -x "${env_dir}bin/python3" ]; then
+          echo "Installing requirements into ${env_dir}"
+          "${env_dir}bin/python3" -m pip install -r requirements.txt
+        fi
 
     - name: Sync gcov with GCC
       shell: bash
@@ -134,7 +133,7 @@ jobs:
           -DROCPROFSYS_BUILD_CI=ON \
           -DROCPROFSYS_USE_MPI=ON \
           -DROCPROFSYS_PYTHON_PREFIX=/opt/conda/envs \
-          "-DROCPROFSYS_PYTHON_ENVS=py3.8;py3.9;py3.10;py3.11;py3.12;py3.13" \
+          -DROCPROFSYS_PYTHON_ENVS=py3.12 \
           -DROCPROFSYS_MAX_THREADS=64 \
           "-DROCPROFSYS_DISABLE_EXAMPLES=transpose;rccl;videodecode;jpegdecode;openmp" \
           -DROCPROFSYS_BUILD_NUMBER=${{ github.run_attempt }} \

--- a/.github/workflows/rocprofiler-systems-code-coverage.yml
+++ b/.github/workflows/rocprofiler-systems-code-coverage.yml
@@ -129,15 +129,10 @@ jobs:
         echo "CMake version: $(cmake --version | head -n 1)"
         echo "Compiler version: $(gcc --version | head -n 1)"
         cmake --preset coverage \
-          -DCMAKE_INSTALL_PREFIX=/opt/rocprofiler-systems-dev \
-          -DROCPROFSYS_BUILD_CI=ON \
-          -DROCPROFSYS_USE_MPI=ON \
           -DROCPROFSYS_PYTHON_PREFIX=/opt/conda/envs \
           -DROCPROFSYS_PYTHON_ENVS=py3.12 \
-          -DROCPROFSYS_MAX_THREADS=64 \
           "-DROCPROFSYS_DISABLE_EXAMPLES=transpose;rccl;videodecode;jpegdecode;openmp" \
-          -DROCPROFSYS_BUILD_NUMBER=${{ github.run_attempt }} \
-          -DUSE_CLANG_OMP=OFF
+          -DROCPROFSYS_BUILD_NUMBER=${{ github.run_attempt }}
 
     - name: Build
       timeout-minutes: 60

--- a/projects/rocprofiler-systems/CMakeLists.txt
+++ b/projects/rocprofiler-systems/CMakeLists.txt
@@ -441,7 +441,7 @@ if(ROCPROFSYS_BUILD_CODECOV)
         message(
             FATAL_ERROR
             "gcovr not found in the active Python environment (${Python3_EXECUTABLE}). "
-            "Install with: pip install -r requirements.txt"
+            "Install with: pip install 'gcovr>=8.4'"
         )
     endif()
     string(REGEX MATCH "([0-9]+)\\.([0-9]+)" _gcovr_version "${_gcovr_version_output}")
@@ -451,10 +451,9 @@ if(ROCPROFSYS_BUILD_CODECOV)
         message(
             FATAL_ERROR
             "gcovr >= 8.4 is required for ROCPROFSYS_BUILD_CODECOV "
-            "(found ${_gcovr_version}). Install with: pip install -r requirements.txt"
+            "(found ${_gcovr_version}). Install with: pip install 'gcovr>=8.4'"
         )
     endif()
-    set(GCOVR_EXECUTABLE ${Python3_EXECUTABLE} -m gcovr)
     message(STATUS "Found gcovr: ${Python3_EXECUTABLE} -m gcovr (${_gcovr_version})")
 
     rocprofiler_systems_save_variables(CODECOV_FLAGS VARIABLES CMAKE_C_FLAGS

--- a/projects/rocprofiler-systems/CMakeLists.txt
+++ b/projects/rocprofiler-systems/CMakeLists.txt
@@ -440,17 +440,25 @@ if(ROCPROFSYS_BUILD_CODECOV)
         )
     endforeach()
 
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        set(_CODECOV_FLAGS
+            "-Og -g3 -fno-omit-frame-pointer -fprofile-instr-generate -fcoverage-mapping"
+        )
+        set(_CODECOV_LINK_FLAGS "-fprofile-instr-generate")
+    else()
+        set(_CODECOV_FLAGS
+            "-Og -g3 -fno-omit-frame-pointer -fprofile-abs-path -fprofile-arcs -ftest-coverage"
+        )
+        set(_CODECOV_LINK_FLAGS "--coverage")
+    endif()
+
     foreach(_BUILD_TYPE DEBUG MINSIZEREL RELWITHDEBINFO RELEASE)
-        set(CMAKE_C_FLAGS_${_BUILD_TYPE}
-            "-Og -g3 -fno-omit-frame-pointer -fprofile-abs-path -fprofile-arcs -ftest-coverage"
-        )
-        set(CMAKE_CXX_FLAGS_${_BUILD_TYPE}
-            "-Og -g3 -fno-omit-frame-pointer -fprofile-abs-path -fprofile-arcs -ftest-coverage"
-        )
+        set(CMAKE_C_FLAGS_${_BUILD_TYPE} "${_CODECOV_FLAGS}")
+        set(CMAKE_CXX_FLAGS_${_BUILD_TYPE} "${_CODECOV_FLAGS}")
     endforeach()
 
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${_CODECOV_LINK_FLAGS}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${_CODECOV_LINK_FLAGS}")
 endif()
 
 add_subdirectory(source)

--- a/projects/rocprofiler-systems/CMakeLists.txt
+++ b/projects/rocprofiler-systems/CMakeLists.txt
@@ -430,6 +430,33 @@ endif()
 set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME core)
 
 if(ROCPROFSYS_BUILD_CODECOV)
+    find_package(Python3 REQUIRED COMPONENTS Interpreter)
+    execute_process(
+        COMMAND ${Python3_EXECUTABLE} -m gcovr --version
+        OUTPUT_VARIABLE _gcovr_version_output
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        RESULT_VARIABLE _gcovr_result
+    )
+    if(NOT _gcovr_result EQUAL 0)
+        message(
+            FATAL_ERROR
+            "gcovr not found in the active Python environment (${Python3_EXECUTABLE}). "
+            "Install with: pip install -r requirements.txt"
+        )
+    endif()
+    string(REGEX MATCH "([0-9]+)\\.([0-9]+)" _gcovr_version "${_gcovr_version_output}")
+    set(_gcovr_major ${CMAKE_MATCH_1})
+    set(_gcovr_minor ${CMAKE_MATCH_2})
+    if(_gcovr_major LESS 8 OR (_gcovr_major EQUAL 8 AND _gcovr_minor LESS 4))
+        message(
+            FATAL_ERROR
+            "gcovr >= 8.4 is required for ROCPROFSYS_BUILD_CODECOV "
+            "(found ${_gcovr_version}). Install with: pip install -r requirements.txt"
+        )
+    endif()
+    set(GCOVR_EXECUTABLE ${Python3_EXECUTABLE} -m gcovr)
+    message(STATUS "Found gcovr: ${Python3_EXECUTABLE} -m gcovr (${_gcovr_version})")
+
     rocprofiler_systems_save_variables(CODECOV_FLAGS VARIABLES CMAKE_C_FLAGS
         CMAKE_CXX_FLAGS
     )
@@ -440,25 +467,17 @@ if(ROCPROFSYS_BUILD_CODECOV)
         )
     endforeach()
 
-    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-        set(_CODECOV_FLAGS
-            "-Og -g3 -fno-omit-frame-pointer -fprofile-instr-generate -fcoverage-mapping"
-        )
-        set(_CODECOV_LINK_FLAGS "-fprofile-instr-generate")
-    else()
-        set(_CODECOV_FLAGS
+    foreach(_BUILD_TYPE DEBUG MINSIZEREL RELWITHDEBINFO RELEASE)
+        set(CMAKE_C_FLAGS_${_BUILD_TYPE}
             "-Og -g3 -fno-omit-frame-pointer -fprofile-abs-path -fprofile-arcs -ftest-coverage"
         )
-        set(_CODECOV_LINK_FLAGS "--coverage")
-    endif()
-
-    foreach(_BUILD_TYPE DEBUG MINSIZEREL RELWITHDEBINFO RELEASE)
-        set(CMAKE_C_FLAGS_${_BUILD_TYPE} "${_CODECOV_FLAGS}")
-        set(CMAKE_CXX_FLAGS_${_BUILD_TYPE} "${_CODECOV_FLAGS}")
+        set(CMAKE_CXX_FLAGS_${_BUILD_TYPE}
+            "-Og -g3 -fno-omit-frame-pointer -fprofile-abs-path -fprofile-arcs -ftest-coverage"
+        )
     endforeach()
 
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${_CODECOV_LINK_FLAGS}")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${_CODECOV_LINK_FLAGS}")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
 endif()
 
 add_subdirectory(source)

--- a/projects/rocprofiler-systems/CMakePresets.json
+++ b/projects/rocprofiler-systems/CMakePresets.json
@@ -83,7 +83,6 @@
                 "ROCPROFSYS_MAX_THREADS": "64",
                 "ROCPROFSYS_STRIP_LIBRARIES": "OFF",
                 "ROCPROFSYS_USE_MPI": "ON",
-                "ROCPROFSYS_USE_PYTESTS": "ON",
                 "USE_CLANG_OMP": "OFF"
             },
             "description": "Build with GCC code coverage instrumentation",

--- a/projects/rocprofiler-systems/CMakePresets.json
+++ b/projects/rocprofiler-systems/CMakePresets.json
@@ -72,11 +72,16 @@
             "binaryDir": "${sourceDir}/build/coverage",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_INSTALL_PREFIX": "/opt/rocprofiler-systems-dev",
+                "ROCPROFSYS_BUILD_CI": "ON",
                 "ROCPROFSYS_BUILD_CODECOV": "ON",
                 "ROCPROFSYS_BUILD_GTEST": "ON",
                 "ROCPROFSYS_BUILD_HIDDEN_VISIBILITY": "OFF",
                 "ROCPROFSYS_BUILD_TESTING": "ON",
-                "ROCPROFSYS_STRIP_LIBRARIES": "OFF"
+                "ROCPROFSYS_MAX_THREADS": "64",
+                "ROCPROFSYS_STRIP_LIBRARIES": "OFF",
+                "ROCPROFSYS_USE_MPI": "ON",
+                "USE_CLANG_OMP": "OFF"
             },
             "description": "Build with GCC code coverage instrumentation",
             "displayName": "Code coverage build",

--- a/projects/rocprofiler-systems/CMakePresets.json
+++ b/projects/rocprofiler-systems/CMakePresets.json
@@ -71,9 +71,8 @@
             "binaryDir": "${sourceDir}/build/coverage",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug",
-                "CMAKE_CXX_COMPILER": "amdclang++",
-                "CMAKE_C_COMPILER": "amdclang",
                 "CMAKE_INSTALL_PREFIX": "/opt/rocprofiler-systems-dev",
+                "ROCPROFSYS_BUILD_CI": "ON",
                 "ROCPROFSYS_BUILD_CODECOV": "ON",
                 "ROCPROFSYS_BUILD_ELFUTILS": "OFF",
                 "ROCPROFSYS_BUILD_GTEST": "ON",
@@ -84,6 +83,7 @@
                 "ROCPROFSYS_MAX_THREADS": "64",
                 "ROCPROFSYS_STRIP_LIBRARIES": "OFF",
                 "ROCPROFSYS_USE_MPI": "ON",
+                "ROCPROFSYS_USE_PYTESTS": "ON",
                 "USE_CLANG_OMP": "OFF"
             },
             "description": "Build with GCC code coverage instrumentation",

--- a/projects/rocprofiler-systems/CMakePresets.json
+++ b/projects/rocprofiler-systems/CMakePresets.json
@@ -25,7 +25,6 @@
             "binaryDir": "${sourceDir}/build/ci",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release",
-                "ROCPROFSYS_BUILD_CI": "ON",
                 "ROCPROFSYS_BUILD_GTEST": "ON",
                 "ROCPROFSYS_BUILD_TESTING": "ON",
                 "ROCPROFSYS_MAX_THREADS": "64"
@@ -72,11 +71,15 @@
             "binaryDir": "${sourceDir}/build/coverage",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_CXX_COMPILER": "amdclang++",
+                "CMAKE_C_COMPILER": "amdclang",
                 "CMAKE_INSTALL_PREFIX": "/opt/rocprofiler-systems-dev",
-                "ROCPROFSYS_BUILD_CI": "ON",
                 "ROCPROFSYS_BUILD_CODECOV": "ON",
+                "ROCPROFSYS_BUILD_ELFUTILS": "OFF",
                 "ROCPROFSYS_BUILD_GTEST": "ON",
                 "ROCPROFSYS_BUILD_HIDDEN_VISIBILITY": "OFF",
+                "ROCPROFSYS_BUILD_LIBIBERTY": "OFF",
+                "ROCPROFSYS_BUILD_TBB": "OFF",
                 "ROCPROFSYS_BUILD_TESTING": "ON",
                 "ROCPROFSYS_MAX_THREADS": "64",
                 "ROCPROFSYS_STRIP_LIBRARIES": "OFF",

--- a/projects/rocprofiler-systems/requirements.txt
+++ b/projects/rocprofiler-systems/requirements.txt
@@ -14,6 +14,7 @@ pytest>=7.4.0
 pytest-subtests>=0.10.0
 
 # Optional
+gcovr>=8.4
 pytest-cov>=4.0.0
 perfetto>=0.7.0
 typing-extensions>=4.0.0

--- a/projects/rocprofiler-systems/requirements.txt
+++ b/projects/rocprofiler-systems/requirements.txt
@@ -14,7 +14,6 @@ pytest>=7.4.0
 pytest-subtests>=0.10.0
 
 # Optional
-gcovr>=8.4
 pytest-cov>=4.0.0
 perfetto>=0.7.0
 typing-extensions>=4.0.0

--- a/projects/rocprofiler-systems/scripts/generate-coverage.py
+++ b/projects/rocprofiler-systems/scripts/generate-coverage.py
@@ -3,22 +3,21 @@
 # Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-"""Generate code coverage reports.
+"""Generate code coverage reports using gcovr.
 
-Supports two modes:
-  gcov  -- uses gcovr (GCC --coverage builds)
-  llvm  -- uses llvm-profdata + llvm-cov (Clang -fprofile-instr-generate builds)
+Runs gcovr on a build directory instrumented with --coverage flags,
+producing XML (Cobertura), HTML, and Markdown reports.
 
-Usage (gcov mode):
-    python3 scripts/generate-coverage.py --mode gcov \
-        --build-dir build/coverage --source-dir .
+Usage:
+    python3 scripts/generate-coverage.py --build-dir build/coverage --source-dir .
 
-Usage (llvm mode):
-    python3 scripts/generate-coverage.py --mode llvm \
-        --profraw-dir build/coverage/profraw/unit \
-        --binary-dir  build/coverage \
-        --source-dir  . \
-        --label unit-tests
+    # Compare against a baseline:
+    python3 scripts/generate-coverage.py --build-dir build/coverage --source-dir . \
+        --baseline .codecov/baseline.json
+
+    # Custom output directory:
+    python3 scripts/generate-coverage.py --build-dir build/coverage --source-dir . \
+        --output-dir .codecov --label all
 """
 
 from __future__ import annotations
@@ -32,7 +31,7 @@ import sys
 from pathlib import Path
 from typing import Optional
 
-EXCLUDE_PATTERNS = [
+GCOVR_EXCLUDE_PATTERNS = [
     r"/usr/.*",
     r"/opt/.*",
     r".*external/.*",
@@ -40,11 +39,6 @@ EXCLUDE_PATTERNS = [
     r".*tests/.*",
     r".*/googletest/.*",
 ]
-
-
-# ---------------------------------------------------------------------------
-# shared utilities
-# ---------------------------------------------------------------------------
 
 
 def find_tool(name: str, required: bool = True) -> Optional[str]:
@@ -55,38 +49,108 @@ def find_tool(name: str, required: bool = True) -> Optional[str]:
     return path
 
 
-def compute_file_coverage(files_raw: list[dict]) -> list[dict]:
+def run_gcovr(
+    *,
+    gcov_cmd: str,
+    source_dir: Path,
+    build_dir: Path,
+    output_dir: Path,
+    label: str,
+) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    json_path = output_dir / f"{label}.json"
+    xml_path = output_dir / f"{label}.xml"
+    html_path = output_dir / f"{label}.html"
+
+    gcovr_cmd = [sys.executable, "-m", "gcovr"]
+    cmd = [
+        *gcovr_cmd,
+        "--root",
+        str(source_dir),
+        "--gcov-executable",
+        gcov_cmd,
+        "--exclude-unreachable-branches",
+        "--exclude-throw-branches",
+        "--gcov-ignore-parse-errors",
+        "--merge-lines",
+        "-s",
+        "-p",
+        "--json",
+        str(json_path),
+        "--xml",
+        str(xml_path),
+        "--html-details",
+        str(html_path),
+    ]
+
+    for pattern in GCOVR_EXCLUDE_PATTERNS:
+        cmd.extend(["--exclude", pattern])
+
+    cmd.append(str(build_dir))
+
+    print(f"Running: {' '.join(cmd)}")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+
+    if result.stdout:
+        print(result.stdout)
+    if result.returncode != 0:
+        print(f"gcovr stderr:\n{result.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+    return json_path
+
+
+def load_coverage_json(path: Path) -> dict:
+    with open(path) as f:
+        return json.load(f)
+
+
+def compute_file_coverage(data: dict) -> list[dict]:
     files = []
-    for f in files_raw:
-        filename = f.get("filename", "")
-        covered = f.get("covered_lines", 0)
-        total = f.get("total_lines", 0)
-        if not filename or total == 0:
+    for file_data in data.get("files", []):
+        filename = file_data.get("filename", "") or file_data.get("file", "")
+        if not filename:
             continue
+        lines = file_data.get("lines", [])
+        if not lines:
+            continue
+
+        covered = sum(1 for l in lines if l.get("count", 0) > 0)
+        total = len(lines)
+        pct = (covered / total * 100) if total > 0 else 0.0
+
         files.append(
             {
                 "filename": filename,
                 "covered_lines": covered,
                 "total_lines": total,
-                "coverage_pct": (covered / total * 100) if total > 0 else 0.0,
+                "coverage_pct": pct,
             }
         )
+
     return sorted(files, key=lambda f: f["coverage_pct"])
 
 
 def compute_totals(file_coverages: list[dict]) -> dict:
     total_covered = sum(f["covered_lines"] for f in file_coverages)
     total_lines = sum(f["total_lines"] for f in file_coverages)
+    pct = (total_covered / total_lines * 100) if total_lines > 0 else 0.0
     return {
         "covered_lines": total_covered,
         "total_lines": total_lines,
-        "coverage_pct": (total_covered / total_lines * 100) if total_lines > 0 else 0.0,
+        "coverage_pct": pct,
         "file_count": len(file_coverages),
     }
 
 
 def coverage_bar(pct: float) -> str:
-    icon = "🟢" if pct >= 80 else ("🟡" if pct >= 50 else "🔴")
+    if pct >= 80:
+        icon = "🟢"
+    elif pct >= 50:
+        icon = "🟡"
+    else:
+        icon = "🔴"
     return f"{icon} **{pct:.1f}%**"
 
 
@@ -116,31 +180,32 @@ def generate_markdown(
     )
     lines.append("")
 
-    groups = [
-        ("🔴 0-20%", [f for f in file_coverages if f["coverage_pct"] < 20]),
-        ("🟠 20-50%", [f for f in file_coverages if 20 <= f["coverage_pct"] < 50]),
-        ("🟡 50-80%", [f for f in file_coverages if 50 <= f["coverage_pct"] < 80]),
-        ("🟢 80-100%", [f for f in file_coverages if f["coverage_pct"] >= 80]),
-    ]
-    for group_label, group_files in groups:
-        if not group_files:
-            continue
-        lines.append("<details>")
-        lines.append(f"<summary>{group_label} ({len(group_files)} files)</summary>")
-        lines.append("")
-        lines.append("| Coverage | Lines | File |")
-        lines.append("|----------|-------|------|")
-        for f in group_files:
-            rel = os.path.relpath(f["filename"], source_dir)
-            pct = f["coverage_pct"]
-            lines.append(
-                f"| {pct:5.1f}% | "
-                f"{f['covered_lines']}/{f['total_lines']} | "
-                f"`{rel}` |"
-            )
-        lines.append("")
-        lines.append("</details>")
-        lines.append("")
+    if file_coverages:
+        groups = [
+            ("🔴 0-20%", [f for f in file_coverages if f["coverage_pct"] < 20]),
+            ("🟠 20-50%", [f for f in file_coverages if 20 <= f["coverage_pct"] < 50]),
+            ("🟡 50-80%", [f for f in file_coverages if 50 <= f["coverage_pct"] < 80]),
+            ("🟢 80-100%", [f for f in file_coverages if f["coverage_pct"] >= 80]),
+        ]
+        for group_label, group_files in groups:
+            if not group_files:
+                continue
+            lines.append(f"<details>")
+            lines.append(f"<summary>{group_label} ({len(group_files)} files)</summary>")
+            lines.append("")
+            lines.append("| Coverage | Lines | File |")
+            lines.append("|----------|-------|------|")
+            for f in group_files:
+                rel = os.path.relpath(f["filename"], source_dir)
+                pct = f["coverage_pct"]
+                lines.append(
+                    f"| {pct:5.1f}% | "
+                    f"{f['covered_lines']}/{f['total_lines']} | "
+                    f"`{rel}` |"
+                )
+            lines.append("")
+            lines.append("</details>")
+            lines.append("")
 
     buckets = {"0-20%": 0, "20-50%": 0, "50-80%": 0, "80-100%": 0}
     for f in file_coverages:
@@ -165,28 +230,96 @@ def generate_markdown(
     return "\n".join(lines)
 
 
-def write_reports(
-    *,
-    label: str,
-    file_coverages: list[dict],
-    totals: dict,
-    baseline_totals: Optional[dict],
-    source_dir: Path,
-    output_dir: Path,
-) -> None:
+def main():
+    parser = argparse.ArgumentParser(description="Generate code coverage reports")
+    parser.add_argument(
+        "--build-dir",
+        required=True,
+        type=Path,
+        help="Build directory with .gcda/.gcno files",
+    )
+    parser.add_argument(
+        "--source-dir",
+        required=True,
+        type=Path,
+        help="Source directory root",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Output directory for reports (default: <source-dir>/.codecov)",
+    )
+    parser.add_argument(
+        "--label",
+        type=str,
+        default="all",
+        help="Coverage report label",
+    )
+    parser.add_argument(
+        "--baseline",
+        type=Path,
+        default=None,
+        help="Baseline coverage JSON for delta comparison",
+    )
+    parser.add_argument(
+        "--gcov",
+        type=str,
+        default=None,
+        help="Path to gcov executable",
+    )
+
+    args = parser.parse_args()
+
+    source_dir = args.source_dir.resolve()
+    build_dir = args.build_dir.resolve()
+    output_dir = (args.output_dir or source_dir / ".codecov").resolve()
+    gcov_cmd = args.gcov or find_tool("gcov")
+
+    gitignore_path = output_dir / ".gitignore"
+    if not gitignore_path.exists():
+        output_dir.mkdir(parents=True, exist_ok=True)
+        gitignore_path.write_text("/*\n")
+
+    print(f"Source dir:  {source_dir}")
+    print(f"Build dir:   {build_dir}")
+    print(f"Output dir:  {output_dir}")
+    print(f"Label:       {args.label}")
+    print(f"gcov:        {gcov_cmd}")
+    print()
+
+    json_path = run_gcovr(
+        gcov_cmd=gcov_cmd,
+        source_dir=source_dir,
+        build_dir=build_dir,
+        output_dir=output_dir,
+        label=args.label,
+    )
+
+    data = load_coverage_json(json_path)
+    file_coverages = compute_file_coverage(data)
+    totals = compute_totals(file_coverages)
+
+    baseline_totals = None
+    if args.baseline and args.baseline.exists():
+        baseline_data = load_coverage_json(args.baseline)
+        baseline_files = compute_file_coverage(baseline_data)
+        baseline_totals = compute_totals(baseline_files)
+
     md = generate_markdown(
-        label=label,
+        label=args.label,
         file_coverages=file_coverages,
         totals=totals,
         baseline_totals=baseline_totals,
         source_dir=source_dir,
     )
-    md_path = output_dir / f"{label}.md"
+
+    md_path = output_dir / f"{args.label}.md"
     md_path.write_text(md)
     print(f"Wrote markdown report: {md_path}")
 
     summary = {
-        "label": label,
+        "label": args.label,
         "coverage_pct": round(totals["coverage_pct"], 2),
         "covered_lines": totals["covered_lines"],
         "total_lines": totals["total_lines"],
@@ -198,7 +331,7 @@ def write_reports(
             totals["coverage_pct"] - baseline_totals["coverage_pct"], 2
         )
 
-    summary_path = output_dir / f"{label}-summary.json"
+    summary_path = output_dir / f"{args.label}-summary.json"
     summary_path.write_text(json.dumps(summary, indent=2))
     print(f"Wrote summary JSON:    {summary_path}")
 
@@ -206,307 +339,6 @@ def write_reports(
     if baseline_totals:
         delta = totals["coverage_pct"] - baseline_totals["coverage_pct"]
         print(f"Delta:    {'+' if delta >= 0 else ''}{delta:.2f}%")
-
-
-# ---------------------------------------------------------------------------
-# gcov mode
-# ---------------------------------------------------------------------------
-
-GCOVR_EXCLUDE_PATTERNS = EXCLUDE_PATTERNS
-
-
-def run_gcov_mode(args: argparse.Namespace) -> None:
-    gcovr_cmd = args.gcovr or find_tool("gcovr")
-    gcov_cmd = args.gcov or find_tool("gcov")
-
-    source_dir = args.source_dir.resolve()
-    build_dir = args.build_dir.resolve()
-    output_dir = (args.output_dir or source_dir / ".codecov").resolve()
-    output_dir.mkdir(parents=True, exist_ok=True)
-
-    json_path = output_dir / f"{args.label}.json"
-    xml_path = output_dir / f"{args.label}.xml"
-    html_path = output_dir / f"{args.label}.html"
-
-    cmd = [
-        gcovr_cmd,
-        "--root",
-        str(source_dir),
-        "--gcov-executable",
-        gcov_cmd,
-        "--exclude-unreachable-branches",
-        "--exclude-throw-branches",
-        "--gcov-ignore-parse-errors",
-        "-s",
-        "-p",
-        "--json",
-        str(json_path),
-        "--xml",
-        str(xml_path),
-        "--html-details",
-        str(html_path),
-    ]
-    for pattern in GCOVR_EXCLUDE_PATTERNS:
-        cmd.extend(["--exclude", pattern])
-    cmd.append(str(build_dir))
-
-    print(f"Running: {' '.join(cmd)}")
-    result = subprocess.run(cmd, capture_output=True, text=True)
-    if result.stdout:
-        print(result.stdout)
-    if result.returncode != 0:
-        print(f"gcovr stderr:\n{result.stderr}", file=sys.stderr)
-        sys.exit(1)
-
-    with open(json_path) as f:
-        data = json.load(f)
-
-    raw = []
-    for file_data in data.get("files", []):
-        filename = file_data.get("filename", "") or file_data.get("file", "")
-        lines = file_data.get("lines", [])
-        if not filename or not lines:
-            continue
-        covered = sum(1 for ln in lines if ln.get("count", 0) > 0)
-        total = len(lines)
-        raw.append({"filename": filename, "covered_lines": covered, "total_lines": total})
-
-    file_coverages = compute_file_coverage(raw)
-    totals = compute_totals(file_coverages)
-
-    baseline_totals = None
-    if args.baseline and args.baseline.exists():
-        with open(args.baseline) as f:
-            bd = json.load(f)
-        br = []
-        for fd in bd.get("files", []):
-            fname = fd.get("filename", "") or fd.get("file", "")
-            lns = fd.get("lines", [])
-            if fname and lns:
-                cov = sum(1 for ln in lns if ln.get("count", 0) > 0)
-                br.append(
-                    {"filename": fname, "covered_lines": cov, "total_lines": len(lns)}
-                )
-        baseline_totals = compute_totals(compute_file_coverage(br))
-
-    write_reports(
-        label=args.label,
-        file_coverages=file_coverages,
-        totals=totals,
-        baseline_totals=baseline_totals,
-        source_dir=source_dir,
-        output_dir=output_dir,
-    )
-
-
-# ---------------------------------------------------------------------------
-# llvm mode
-# ---------------------------------------------------------------------------
-
-
-def _find_elf_binaries(binary_dir: Path) -> list[Path]:
-    binaries = []
-    for path in binary_dir.rglob("*"):
-        if not path.is_file() or path.is_symlink():
-            continue
-        try:
-            with open(path, "rb") as f:
-                if f.read(4) == b"\x7fELF":
-                    binaries.append(path)
-        except (IOError, PermissionError):
-            pass
-    return binaries
-
-
-def run_llvm_mode(args: argparse.Namespace) -> None:
-    llvm_profdata = args.llvm_profdata or find_tool("llvm-profdata")
-    llvm_cov = args.llvm_cov or find_tool("llvm-cov")
-
-    source_dir = args.source_dir.resolve()
-    profraw_dir = args.profraw_dir.resolve()
-    binary_dir = args.binary_dir.resolve()
-    output_dir = (args.output_dir or source_dir / ".codecov").resolve()
-    output_dir.mkdir(parents=True, exist_ok=True)
-
-    profraw_files = list(profraw_dir.rglob("*.profraw"))
-    if not profraw_files:
-        print(f"ERROR: no .profraw files found in {profraw_dir}", file=sys.stderr)
-        sys.exit(1)
-    print(f"Found {len(profraw_files)} .profraw file(s)")
-
-    profdata_path = output_dir / f"{args.label}.profdata"
-    merge_cmd = [
-        llvm_profdata,
-        "merge",
-        "--sparse",
-        *[str(p) for p in profraw_files],
-        "-o",
-        str(profdata_path),
-    ]
-    print(f"Running: {' '.join(merge_cmd)}")
-    result = subprocess.run(merge_cmd, capture_output=True, text=True)
-    if result.returncode != 0:
-        print(f"llvm-profdata stderr:\n{result.stderr}", file=sys.stderr)
-        sys.exit(1)
-
-    binaries = _find_elf_binaries(binary_dir)
-    if not binaries:
-        print(f"ERROR: no ELF binaries found in {binary_dir}", file=sys.stderr)
-        sys.exit(1)
-    print(f"Found {len(binaries)} ELF binary/libraries for coverage mapping")
-
-    object_flags: list[str] = []
-    for b in binaries:
-        object_flags.extend(["-object", str(b)])
-
-    export_cmd = [
-        llvm_cov,
-        "export",
-        f"-instr-profile={profdata_path}",
-        "--format=text",
-        *object_flags,
-    ]
-    for pattern in EXCLUDE_PATTERNS:
-        export_cmd.extend([f"--ignore-filename-regex={pattern}"])
-
-    print(
-        f"Running: llvm-cov export -instr-profile=... --format=text [{len(binaries)} objects] ..."
-    )
-    result = subprocess.run(export_cmd, capture_output=True, text=True)
-    if result.returncode != 0:
-        print(f"llvm-cov stderr:\n{result.stderr}", file=sys.stderr)
-        sys.exit(1)
-
-    data = json.loads(result.stdout)
-
-    raw = []
-    for record in data.get("data", []):
-        for file_data in record.get("files", []):
-            filename = file_data.get("filename", "")
-            summary = file_data.get("summary", {})
-            lines = summary.get("lines", {})
-            total = lines.get("count", 0)
-            covered = lines.get("covered", 0)
-            if filename and total > 0:
-                raw.append(
-                    {
-                        "filename": filename,
-                        "covered_lines": covered,
-                        "total_lines": total,
-                    }
-                )
-
-    file_coverages = compute_file_coverage(raw)
-    totals = compute_totals(file_coverages)
-
-    baseline_totals = None
-    if args.baseline and args.baseline.exists():
-        with open(args.baseline) as f:
-            bd = json.load(f)
-        br = []
-        for record in bd.get("data", []):
-            for fd in record.get("files", []):
-                fname = fd.get("filename", "")
-                lns = fd.get("summary", {}).get("lines", {})
-                total = lns.get("count", 0)
-                if fname and total > 0:
-                    br.append(
-                        {
-                            "filename": fname,
-                            "covered_lines": lns.get("covered", 0),
-                            "total_lines": total,
-                        }
-                    )
-        baseline_totals = compute_totals(compute_file_coverage(br))
-
-    write_reports(
-        label=args.label,
-        file_coverages=file_coverages,
-        totals=totals,
-        baseline_totals=baseline_totals,
-        source_dir=source_dir,
-        output_dir=output_dir,
-    )
-
-
-# ---------------------------------------------------------------------------
-# CLI
-# ---------------------------------------------------------------------------
-
-
-def main() -> None:
-    parser = argparse.ArgumentParser(description="Generate code coverage reports")
-    parser.add_argument(
-        "--mode",
-        choices=["gcov", "llvm"],
-        default="gcov",
-        help="Coverage toolchain (default: gcov)",
-    )
-    parser.add_argument(
-        "--source-dir", required=True, type=Path, help="Source directory root"
-    )
-    parser.add_argument(
-        "--output-dir", type=Path, default=None, help="Output directory for reports"
-    )
-    parser.add_argument("--label", type=str, default="all", help="Coverage report label")
-    parser.add_argument(
-        "--baseline",
-        type=Path,
-        default=None,
-        help="Baseline coverage JSON for delta comparison",
-    )
-
-    # gcov-mode args
-    parser.add_argument(
-        "--build-dir", type=Path, help="[gcov] Build directory with .gcda/.gcno files"
-    )
-    parser.add_argument("--gcovr", type=str, default=None, help="[gcov] Path to gcovr")
-    parser.add_argument("--gcov", type=str, default=None, help="[gcov] Path to gcov")
-
-    # llvm-mode args
-    parser.add_argument(
-        "--profraw-dir", type=Path, help="[llvm] Directory containing .profraw files"
-    )
-    parser.add_argument(
-        "--binary-dir",
-        type=Path,
-        help="[llvm] Directory to search for instrumented ELF binaries",
-    )
-    parser.add_argument(
-        "--llvm-profdata", type=str, default=None, help="[llvm] Path to llvm-profdata"
-    )
-    parser.add_argument(
-        "--llvm-cov", type=str, default=None, help="[llvm] Path to llvm-cov"
-    )
-
-    args = parser.parse_args()
-
-    source_dir = args.source_dir.resolve()
-    output_dir = (args.output_dir or source_dir / ".codecov").resolve()
-    output_dir.mkdir(parents=True, exist_ok=True)
-
-    gitignore = output_dir / ".gitignore"
-    if not gitignore.exists():
-        gitignore.write_text("/*\n")
-
-    print(f"Source dir:  {source_dir}")
-    print(f"Output dir:  {output_dir}")
-    print(f"Label:       {args.label}")
-    print(f"Mode:        {args.mode}")
-    print()
-
-    args.output_dir = output_dir
-
-    if args.mode == "gcov":
-        if not args.build_dir:
-            parser.error("--build-dir is required for gcov mode")
-        run_gcov_mode(args)
-    else:
-        if not args.profraw_dir:
-            parser.error("--profraw-dir is required for llvm mode")
-        if not args.binary_dir:
-            parser.error("--binary-dir is required for llvm mode")
-        run_llvm_mode(args)
 
 
 if __name__ == "__main__":

--- a/projects/rocprofiler-systems/scripts/generate-coverage.py
+++ b/projects/rocprofiler-systems/scripts/generate-coverage.py
@@ -74,6 +74,7 @@ def run_gcovr(
         "--exclude-throw-branches",
         "--gcov-ignore-parse-errors",
         "--merge-lines",
+        "--merge-mode-functions=merge-use-line-max",
         "-s",
         "-p",
         "--json",

--- a/projects/rocprofiler-systems/scripts/generate-coverage.py
+++ b/projects/rocprofiler-systems/scripts/generate-coverage.py
@@ -3,21 +3,22 @@
 # Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-"""Generate code coverage reports using gcovr.
+"""Generate code coverage reports.
 
-Runs gcovr on a build directory instrumented with --coverage flags,
-producing XML (Cobertura), HTML, and Markdown reports.
+Supports two modes:
+  gcov  -- uses gcovr (GCC --coverage builds)
+  llvm  -- uses llvm-profdata + llvm-cov (Clang -fprofile-instr-generate builds)
 
-Usage:
-    python3 scripts/generate-coverage.py --build-dir build/coverage --source-dir .
+Usage (gcov mode):
+    python3 scripts/generate-coverage.py --mode gcov \
+        --build-dir build/coverage --source-dir .
 
-    # Compare against a baseline:
-    python3 scripts/generate-coverage.py --build-dir build/coverage --source-dir . \
-        --baseline .codecov/baseline.json
-
-    # Custom output directory:
-    python3 scripts/generate-coverage.py --build-dir build/coverage --source-dir . \
-        --output-dir .codecov --label all
+Usage (llvm mode):
+    python3 scripts/generate-coverage.py --mode llvm \
+        --profraw-dir build/coverage/profraw/unit \
+        --binary-dir  build/coverage \
+        --source-dir  . \
+        --label unit-tests
 """
 
 from __future__ import annotations
@@ -31,7 +32,7 @@ import sys
 from pathlib import Path
 from typing import Optional
 
-GCOVR_EXCLUDE_PATTERNS = [
+EXCLUDE_PATTERNS = [
     r"/usr/.*",
     r"/opt/.*",
     r".*external/.*",
@@ -39,6 +40,11 @@ GCOVR_EXCLUDE_PATTERNS = [
     r".*tests/.*",
     r".*/googletest/.*",
 ]
+
+
+# ---------------------------------------------------------------------------
+# shared utilities
+# ---------------------------------------------------------------------------
 
 
 def find_tool(name: str, required: bool = True) -> Optional[str]:
@@ -49,107 +55,38 @@ def find_tool(name: str, required: bool = True) -> Optional[str]:
     return path
 
 
-def run_gcovr(
-    *,
-    gcovr_cmd: str,
-    gcov_cmd: str,
-    source_dir: Path,
-    build_dir: Path,
-    output_dir: Path,
-    label: str,
-) -> Path:
-    output_dir.mkdir(parents=True, exist_ok=True)
-
-    json_path = output_dir / f"{label}.json"
-    xml_path = output_dir / f"{label}.xml"
-    html_path = output_dir / f"{label}.html"
-
-    cmd = [
-        gcovr_cmd,
-        "--root",
-        str(source_dir),
-        "--gcov-executable",
-        gcov_cmd,
-        "--exclude-unreachable-branches",
-        "--exclude-throw-branches",
-        "--gcov-ignore-parse-errors",
-        "-s",
-        "-p",
-        "--json",
-        str(json_path),
-        "--xml",
-        str(xml_path),
-        "--html-details",
-        str(html_path),
-    ]
-
-    for pattern in GCOVR_EXCLUDE_PATTERNS:
-        cmd.extend(["--exclude", pattern])
-
-    cmd.append(str(build_dir))
-
-    print(f"Running: {' '.join(cmd)}")
-    result = subprocess.run(cmd, capture_output=True, text=True)
-
-    if result.stdout:
-        print(result.stdout)
-    if result.returncode != 0:
-        print(f"gcovr stderr:\n{result.stderr}", file=sys.stderr)
-        sys.exit(1)
-
-    return json_path
-
-
-def load_coverage_json(path: Path) -> dict:
-    with open(path) as f:
-        return json.load(f)
-
-
-def compute_file_coverage(data: dict) -> list[dict]:
+def compute_file_coverage(files_raw: list[dict]) -> list[dict]:
     files = []
-    for file_data in data.get("files", []):
-        filename = file_data.get("filename", "") or file_data.get("file", "")
-        if not filename:
+    for f in files_raw:
+        filename = f.get("filename", "")
+        covered = f.get("covered_lines", 0)
+        total = f.get("total_lines", 0)
+        if not filename or total == 0:
             continue
-        lines = file_data.get("lines", [])
-        if not lines:
-            continue
-
-        covered = sum(1 for l in lines if l.get("count", 0) > 0)
-        total = len(lines)
-        pct = (covered / total * 100) if total > 0 else 0.0
-
         files.append(
             {
                 "filename": filename,
                 "covered_lines": covered,
                 "total_lines": total,
-                "coverage_pct": pct,
+                "coverage_pct": (covered / total * 100) if total > 0 else 0.0,
             }
         )
-
     return sorted(files, key=lambda f: f["coverage_pct"])
 
 
 def compute_totals(file_coverages: list[dict]) -> dict:
     total_covered = sum(f["covered_lines"] for f in file_coverages)
     total_lines = sum(f["total_lines"] for f in file_coverages)
-    pct = (total_covered / total_lines * 100) if total_lines > 0 else 0.0
     return {
         "covered_lines": total_covered,
         "total_lines": total_lines,
-        "coverage_pct": pct,
+        "coverage_pct": (total_covered / total_lines * 100) if total_lines > 0 else 0.0,
         "file_count": len(file_coverages),
     }
 
 
 def coverage_bar(pct: float) -> str:
-    if pct >= 80:
-        icon = "🟢"
-    elif pct >= 50:
-        icon = "🟡"
-    else:
-        icon = "🔴"
+    icon = "🟢" if pct >= 80 else ("🟡" if pct >= 50 else "🔴")
     return f"{icon} **{pct:.1f}%**"
 
 
@@ -179,32 +116,31 @@ def generate_markdown(
     )
     lines.append("")
 
-    if file_coverages:
-        groups = [
-            ("🔴 0-20%", [f for f in file_coverages if f["coverage_pct"] < 20]),
-            ("🟠 20-50%", [f for f in file_coverages if 20 <= f["coverage_pct"] < 50]),
-            ("🟡 50-80%", [f for f in file_coverages if 50 <= f["coverage_pct"] < 80]),
-            ("🟢 80-100%", [f for f in file_coverages if f["coverage_pct"] >= 80]),
-        ]
-        for group_label, group_files in groups:
-            if not group_files:
-                continue
-            lines.append(f"<details>")
-            lines.append(f"<summary>{group_label} ({len(group_files)} files)</summary>")
-            lines.append("")
-            lines.append("| Coverage | Lines | File |")
-            lines.append("|----------|-------|------|")
-            for f in group_files:
-                rel = os.path.relpath(f["filename"], source_dir)
-                pct = f["coverage_pct"]
-                lines.append(
-                    f"| {pct:5.1f}% | "
-                    f"{f['covered_lines']}/{f['total_lines']} | "
-                    f"`{rel}` |"
-                )
-            lines.append("")
-            lines.append("</details>")
-            lines.append("")
+    groups = [
+        ("🔴 0-20%", [f for f in file_coverages if f["coverage_pct"] < 20]),
+        ("🟠 20-50%", [f for f in file_coverages if 20 <= f["coverage_pct"] < 50]),
+        ("🟡 50-80%", [f for f in file_coverages if 50 <= f["coverage_pct"] < 80]),
+        ("🟢 80-100%", [f for f in file_coverages if f["coverage_pct"] >= 80]),
+    ]
+    for group_label, group_files in groups:
+        if not group_files:
+            continue
+        lines.append("<details>")
+        lines.append(f"<summary>{group_label} ({len(group_files)} files)</summary>")
+        lines.append("")
+        lines.append("| Coverage | Lines | File |")
+        lines.append("|----------|-------|------|")
+        for f in group_files:
+            rel = os.path.relpath(f["filename"], source_dir)
+            pct = f["coverage_pct"]
+            lines.append(
+                f"| {pct:5.1f}% | "
+                f"{f['covered_lines']}/{f['total_lines']} | "
+                f"`{rel}` |"
+            )
+        lines.append("")
+        lines.append("</details>")
+        lines.append("")
 
     buckets = {"0-20%": 0, "20-50%": 0, "50-80%": 0, "80-100%": 0}
     for f in file_coverages:
@@ -229,106 +165,28 @@ def generate_markdown(
     return "\n".join(lines)
 
 
-def main():
-    parser = argparse.ArgumentParser(description="Generate code coverage reports")
-    parser.add_argument(
-        "--build-dir",
-        required=True,
-        type=Path,
-        help="Build directory with .gcda/.gcno files",
-    )
-    parser.add_argument(
-        "--source-dir",
-        required=True,
-        type=Path,
-        help="Source directory root",
-    )
-    parser.add_argument(
-        "--output-dir",
-        type=Path,
-        default=None,
-        help="Output directory for reports (default: <source-dir>/.codecov)",
-    )
-    parser.add_argument(
-        "--label",
-        type=str,
-        default="all",
-        help="Coverage report label",
-    )
-    parser.add_argument(
-        "--baseline",
-        type=Path,
-        default=None,
-        help="Baseline coverage JSON for delta comparison",
-    )
-    parser.add_argument(
-        "--gcovr",
-        type=str,
-        default=None,
-        help="Path to gcovr executable",
-    )
-    parser.add_argument(
-        "--gcov",
-        type=str,
-        default=None,
-        help="Path to gcov executable",
-    )
-
-    args = parser.parse_args()
-
-    source_dir = args.source_dir.resolve()
-    build_dir = args.build_dir.resolve()
-    output_dir = (args.output_dir or source_dir / ".codecov").resolve()
-
-    gcovr_cmd = args.gcovr or find_tool("gcovr")
-    gcov_cmd = args.gcov or find_tool("gcov")
-
-    gitignore_path = output_dir / ".gitignore"
-    if not gitignore_path.exists():
-        output_dir.mkdir(parents=True, exist_ok=True)
-        gitignore_path.write_text("/*\n")
-
-    print(f"Source dir:  {source_dir}")
-    print(f"Build dir:   {build_dir}")
-    print(f"Output dir:  {output_dir}")
-    print(f"Label:       {args.label}")
-    print(f"gcovr:       {gcovr_cmd}")
-    print(f"gcov:        {gcov_cmd}")
-    print()
-
-    json_path = run_gcovr(
-        gcovr_cmd=gcovr_cmd,
-        gcov_cmd=gcov_cmd,
-        source_dir=source_dir,
-        build_dir=build_dir,
-        output_dir=output_dir,
-        label=args.label,
-    )
-
-    data = load_coverage_json(json_path)
-    file_coverages = compute_file_coverage(data)
-    totals = compute_totals(file_coverages)
-
-    baseline_totals = None
-    if args.baseline and args.baseline.exists():
-        baseline_data = load_coverage_json(args.baseline)
-        baseline_files = compute_file_coverage(baseline_data)
-        baseline_totals = compute_totals(baseline_files)
-
+def write_reports(
+    *,
+    label: str,
+    file_coverages: list[dict],
+    totals: dict,
+    baseline_totals: Optional[dict],
+    source_dir: Path,
+    output_dir: Path,
+) -> None:
     md = generate_markdown(
-        label=args.label,
+        label=label,
         file_coverages=file_coverages,
         totals=totals,
         baseline_totals=baseline_totals,
         source_dir=source_dir,
     )
-
-    md_path = output_dir / f"{args.label}.md"
+    md_path = output_dir / f"{label}.md"
     md_path.write_text(md)
     print(f"Wrote markdown report: {md_path}")
 
     summary = {
-        "label": args.label,
+        "label": label,
         "coverage_pct": round(totals["coverage_pct"], 2),
         "covered_lines": totals["covered_lines"],
         "total_lines": totals["total_lines"],
@@ -340,7 +198,7 @@ def main():
             totals["coverage_pct"] - baseline_totals["coverage_pct"], 2
         )
 
-    summary_path = output_dir / f"{args.label}-summary.json"
+    summary_path = output_dir / f"{label}-summary.json"
     summary_path.write_text(json.dumps(summary, indent=2))
     print(f"Wrote summary JSON:    {summary_path}")
 
@@ -348,6 +206,307 @@ def main():
     if baseline_totals:
         delta = totals["coverage_pct"] - baseline_totals["coverage_pct"]
         print(f"Delta:    {'+' if delta >= 0 else ''}{delta:.2f}%")
+
+
+# ---------------------------------------------------------------------------
+# gcov mode
+# ---------------------------------------------------------------------------
+
+GCOVR_EXCLUDE_PATTERNS = EXCLUDE_PATTERNS
+
+
+def run_gcov_mode(args: argparse.Namespace) -> None:
+    gcovr_cmd = args.gcovr or find_tool("gcovr")
+    gcov_cmd = args.gcov or find_tool("gcov")
+
+    source_dir = args.source_dir.resolve()
+    build_dir = args.build_dir.resolve()
+    output_dir = (args.output_dir or source_dir / ".codecov").resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    json_path = output_dir / f"{args.label}.json"
+    xml_path = output_dir / f"{args.label}.xml"
+    html_path = output_dir / f"{args.label}.html"
+
+    cmd = [
+        gcovr_cmd,
+        "--root",
+        str(source_dir),
+        "--gcov-executable",
+        gcov_cmd,
+        "--exclude-unreachable-branches",
+        "--exclude-throw-branches",
+        "--gcov-ignore-parse-errors",
+        "-s",
+        "-p",
+        "--json",
+        str(json_path),
+        "--xml",
+        str(xml_path),
+        "--html-details",
+        str(html_path),
+    ]
+    for pattern in GCOVR_EXCLUDE_PATTERNS:
+        cmd.extend(["--exclude", pattern])
+    cmd.append(str(build_dir))
+
+    print(f"Running: {' '.join(cmd)}")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.stdout:
+        print(result.stdout)
+    if result.returncode != 0:
+        print(f"gcovr stderr:\n{result.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+    with open(json_path) as f:
+        data = json.load(f)
+
+    raw = []
+    for file_data in data.get("files", []):
+        filename = file_data.get("filename", "") or file_data.get("file", "")
+        lines = file_data.get("lines", [])
+        if not filename or not lines:
+            continue
+        covered = sum(1 for ln in lines if ln.get("count", 0) > 0)
+        total = len(lines)
+        raw.append({"filename": filename, "covered_lines": covered, "total_lines": total})
+
+    file_coverages = compute_file_coverage(raw)
+    totals = compute_totals(file_coverages)
+
+    baseline_totals = None
+    if args.baseline and args.baseline.exists():
+        with open(args.baseline) as f:
+            bd = json.load(f)
+        br = []
+        for fd in bd.get("files", []):
+            fname = fd.get("filename", "") or fd.get("file", "")
+            lns = fd.get("lines", [])
+            if fname and lns:
+                cov = sum(1 for ln in lns if ln.get("count", 0) > 0)
+                br.append(
+                    {"filename": fname, "covered_lines": cov, "total_lines": len(lns)}
+                )
+        baseline_totals = compute_totals(compute_file_coverage(br))
+
+    write_reports(
+        label=args.label,
+        file_coverages=file_coverages,
+        totals=totals,
+        baseline_totals=baseline_totals,
+        source_dir=source_dir,
+        output_dir=output_dir,
+    )
+
+
+# ---------------------------------------------------------------------------
+# llvm mode
+# ---------------------------------------------------------------------------
+
+
+def _find_elf_binaries(binary_dir: Path) -> list[Path]:
+    binaries = []
+    for path in binary_dir.rglob("*"):
+        if not path.is_file() or path.is_symlink():
+            continue
+        try:
+            with open(path, "rb") as f:
+                if f.read(4) == b"\x7fELF":
+                    binaries.append(path)
+        except (IOError, PermissionError):
+            pass
+    return binaries
+
+
+def run_llvm_mode(args: argparse.Namespace) -> None:
+    llvm_profdata = args.llvm_profdata or find_tool("llvm-profdata")
+    llvm_cov = args.llvm_cov or find_tool("llvm-cov")
+
+    source_dir = args.source_dir.resolve()
+    profraw_dir = args.profraw_dir.resolve()
+    binary_dir = args.binary_dir.resolve()
+    output_dir = (args.output_dir or source_dir / ".codecov").resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    profraw_files = list(profraw_dir.rglob("*.profraw"))
+    if not profraw_files:
+        print(f"ERROR: no .profraw files found in {profraw_dir}", file=sys.stderr)
+        sys.exit(1)
+    print(f"Found {len(profraw_files)} .profraw file(s)")
+
+    profdata_path = output_dir / f"{args.label}.profdata"
+    merge_cmd = [
+        llvm_profdata,
+        "merge",
+        "--sparse",
+        *[str(p) for p in profraw_files],
+        "-o",
+        str(profdata_path),
+    ]
+    print(f"Running: {' '.join(merge_cmd)}")
+    result = subprocess.run(merge_cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"llvm-profdata stderr:\n{result.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+    binaries = _find_elf_binaries(binary_dir)
+    if not binaries:
+        print(f"ERROR: no ELF binaries found in {binary_dir}", file=sys.stderr)
+        sys.exit(1)
+    print(f"Found {len(binaries)} ELF binary/libraries for coverage mapping")
+
+    object_flags: list[str] = []
+    for b in binaries:
+        object_flags.extend(["-object", str(b)])
+
+    export_cmd = [
+        llvm_cov,
+        "export",
+        f"-instr-profile={profdata_path}",
+        "--format=text",
+        *object_flags,
+    ]
+    for pattern in EXCLUDE_PATTERNS:
+        export_cmd.extend([f"--ignore-filename-regex={pattern}"])
+
+    print(
+        f"Running: llvm-cov export -instr-profile=... --format=text [{len(binaries)} objects] ..."
+    )
+    result = subprocess.run(export_cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"llvm-cov stderr:\n{result.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+    data = json.loads(result.stdout)
+
+    raw = []
+    for record in data.get("data", []):
+        for file_data in record.get("files", []):
+            filename = file_data.get("filename", "")
+            summary = file_data.get("summary", {})
+            lines = summary.get("lines", {})
+            total = lines.get("count", 0)
+            covered = lines.get("covered", 0)
+            if filename and total > 0:
+                raw.append(
+                    {
+                        "filename": filename,
+                        "covered_lines": covered,
+                        "total_lines": total,
+                    }
+                )
+
+    file_coverages = compute_file_coverage(raw)
+    totals = compute_totals(file_coverages)
+
+    baseline_totals = None
+    if args.baseline and args.baseline.exists():
+        with open(args.baseline) as f:
+            bd = json.load(f)
+        br = []
+        for record in bd.get("data", []):
+            for fd in record.get("files", []):
+                fname = fd.get("filename", "")
+                lns = fd.get("summary", {}).get("lines", {})
+                total = lns.get("count", 0)
+                if fname and total > 0:
+                    br.append(
+                        {
+                            "filename": fname,
+                            "covered_lines": lns.get("covered", 0),
+                            "total_lines": total,
+                        }
+                    )
+        baseline_totals = compute_totals(compute_file_coverage(br))
+
+    write_reports(
+        label=args.label,
+        file_coverages=file_coverages,
+        totals=totals,
+        baseline_totals=baseline_totals,
+        source_dir=source_dir,
+        output_dir=output_dir,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate code coverage reports")
+    parser.add_argument(
+        "--mode",
+        choices=["gcov", "llvm"],
+        default="gcov",
+        help="Coverage toolchain (default: gcov)",
+    )
+    parser.add_argument(
+        "--source-dir", required=True, type=Path, help="Source directory root"
+    )
+    parser.add_argument(
+        "--output-dir", type=Path, default=None, help="Output directory for reports"
+    )
+    parser.add_argument("--label", type=str, default="all", help="Coverage report label")
+    parser.add_argument(
+        "--baseline",
+        type=Path,
+        default=None,
+        help="Baseline coverage JSON for delta comparison",
+    )
+
+    # gcov-mode args
+    parser.add_argument(
+        "--build-dir", type=Path, help="[gcov] Build directory with .gcda/.gcno files"
+    )
+    parser.add_argument("--gcovr", type=str, default=None, help="[gcov] Path to gcovr")
+    parser.add_argument("--gcov", type=str, default=None, help="[gcov] Path to gcov")
+
+    # llvm-mode args
+    parser.add_argument(
+        "--profraw-dir", type=Path, help="[llvm] Directory containing .profraw files"
+    )
+    parser.add_argument(
+        "--binary-dir",
+        type=Path,
+        help="[llvm] Directory to search for instrumented ELF binaries",
+    )
+    parser.add_argument(
+        "--llvm-profdata", type=str, default=None, help="[llvm] Path to llvm-profdata"
+    )
+    parser.add_argument(
+        "--llvm-cov", type=str, default=None, help="[llvm] Path to llvm-cov"
+    )
+
+    args = parser.parse_args()
+
+    source_dir = args.source_dir.resolve()
+    output_dir = (args.output_dir or source_dir / ".codecov").resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    gitignore = output_dir / ".gitignore"
+    if not gitignore.exists():
+        gitignore.write_text("/*\n")
+
+    print(f"Source dir:  {source_dir}")
+    print(f"Output dir:  {output_dir}")
+    print(f"Label:       {args.label}")
+    print(f"Mode:        {args.mode}")
+    print()
+
+    args.output_dir = output_dir
+
+    if args.mode == "gcov":
+        if not args.build_dir:
+            parser.error("--build-dir is required for gcov mode")
+        run_gcov_mode(args)
+    else:
+        if not args.profraw_dir:
+            parser.error("--profraw-dir is required for llvm mode")
+        if not args.binary_dir:
+            parser.error("--binary-dir is required for llvm mode")
+        run_llvm_mode(args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

The rocprofiler-systems code coverage job was inconsistent between local and CI runs, could post spurious 0% comments when a step failed, and duplicated build configuration between the workflow and the CMake preset. This PR makes coverage reproducible, fails fast on a missing/old gcovr, and trims the job to fit time/space limits.

## Technical Details

- Generate coverage via `python -m gcovr` (`sys.executable`) and add `--merge-lines` / `--merge-mode-functions=merge-use-line-max` so local and CI results match; drop the unused `--gcovr` argument.
- Check at configure time (`ROCPROFSYS_BUILD_CODECOV`) that gcovr is importable and `>= 8.4`, failing with a clear `pip install 'gcovr>=8.4'` message otherwise.
- Move coverage-specific cache variables from the workflow into the `coverage` preset in `CMakePresets.json`; remove `ROCPROFSYS_BUILD_CI` from the shared `ci` preset.
- Install required system libs, use a single `py3.12` Python env, and expand `ROCPROFSYS_DISABLE_EXAMPLES` to reduce build time/disk.
- Only post the coverage comment on `pull_request` (no `always()`), avoiding empty 0% reports.

## JIRA ID

## Test Plan

- [x] rocprofiler-systems Code Coverage workflow completes successfully.
- [x] Coverage comment is posted with non-zero unit-test and e2e-test coverage.
- [x] Local `cmake --preset coverage` numbers align with CI.
- [x] Configure fails clearly when gcovr is absent or `< 8.4`.

## Test Result

The Code Coverage workflow run on this branch completed successfully (2026-06-01).

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.