### PR TITLE
fix UT regression in v2_29 sync

### DIFF
--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -797,7 +797,7 @@ static ncclResult_t scheduleCollTasksToPlan(
 
     int kind = 2*task->isCollnet + task->isNvls;
     if (kind != kindPrev) {
-      trafficPerChannel = divUp(trafficBytes[kind] / nChannels[kind], 16) * 16;
+      trafficPerChannel = std::max<size_t>(MinTrafficPerChannel, divUp(trafficBytes[kind] / nChannels[kind], 16) * 16);
       kindPrev = kind;
       channelId = 0;
       currentTraffic = 0;

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -3036,7 +3036,7 @@ static ncclResult_t parseCommConfig(ncclComm_t comm, ncclConfig_t *config) {
   NCCL_CONFIG_DEFAULT(internalConfigPtr, nChannelsPerNetPeer, NCCL_CONFIG_UNDEF_INT,
                       NCCL_CONFIG_UNDEF_INT, "nChannelsPerNetPeer", "%d");
   NCCL_CONFIG_DEFAULT(internalConfigPtr, nvlinkCentricSched, NCCL_CONFIG_UNDEF_INT, 0, "nvlinkCentricSched", "%d");
-  NCCL_CONFIG_DEFAULT(internalConfigPtr, graphUsageMode, NCCL_CONFIG_UNDEF_INT, 2, "graphUsageMode", "%d");
+  NCCL_CONFIG_DEFAULT(internalConfigPtr, graphUsageMode, NCCL_CONFIG_UNDEF_INT, 0, "graphUsageMode", "%d");
   NCCL_CONFIG_DEFAULT(internalConfigPtr, numRmaCtx, NCCL_CONFIG_UNDEF_INT, 1, "numRmaCtx", "%d");
 
   /* assign config to communicator */


### PR DESCRIPTION
1. Root cause: The NCCL v2.29 sync changed graphUsageMode default from 0 (disabled) to 2 (enabled), activating CUDA-centric event synchronization between graph-captured and non-captured streams that causes deadlocks on ROCm/HIP at 8 ranks.

2. Fix 1 (src/init.cc:3039): Restored graphUsageMode default to 0, matching the original RCCL behavior where graph mixing support is off by default (users can still enable via NCCL_GRAPH_MIXING_SUPPORT=1).
3. Fix 2 (src/enqueue.cc:800): Restored the MinTrafficPerChannel floor in the trafficPerChannel scheduling formula, which the sync had removed, preventing under-sized work distribution for small collective payloads.

## Motivation

Fix UT regression due to graphUsageMode default change


## JIRA ID

Resolves AICOMRCCL-1121

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.