### PR TITLE
[rocprofiler-compute] Link pthread for native tool gtest in ASAN builds

### DIFF
--- a/projects/rocprofiler-compute/CMakeLists.txt
+++ b/projects/rocprofiler-compute/CMakeLists.txt
@@ -57,6 +57,7 @@ set(EXECUTABLE_NAME "rocprof-compute")
 include(ExternalProject)
 include(GNUInstallDirs)
 include(utils.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/cmake/asan_build_dependencies.cmake)
 
 set(BUILD_ENABLE_LINTIAN_OVERRIDES ON CACHE BOOL "Enable/Disable Lintian Overrides")
 set(BUILD_DEBIAN_PKGING_FLAG

--- a/projects/rocprofiler-compute/cmake/asan_build_dependencies.cmake
+++ b/projects/rocprofiler-compute/cmake/asan_build_dependencies.cmake
@@ -1,0 +1,14 @@
+## Copyright (c) Advanced Micro Devices, Inc.
+## SPDX-License-Identifier:  MIT
+
+if(NOT TARGET asan_build_dependencies)
+    add_library(asan_build_dependencies INTERFACE)
+endif()
+
+if(NOT WIN32 AND (THEROCK_SANITIZER MATCHES "ASAN" OR ENABLE_ADDRESS_SANITIZER))
+    set(THREADS_PREFER_PTHREAD_FLAG ON)
+    find_package(Threads REQUIRED)
+    target_link_libraries(asan_build_dependencies INTERFACE Threads::Threads)
+    # ASAN with -shared-libsan requires explicit pthread linkage (rocm-systems#6455)
+    target_link_options(asan_build_dependencies INTERFACE -lpthread)
+endif()

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/CMakeLists.txt
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/CMakeLists.txt
@@ -15,18 +15,14 @@ add_executable(
 
 target_link_libraries(
     ${target}
-    PRIVATE rocprofiler-compute-tool gtest_main gmock gsl_assert fmt::fmt
+    PRIVATE
+        rocprofiler-compute-tool
+        gtest_main
+        gmock
+        gsl_assert
+        fmt::fmt
+        asan_build_dependencies
 )
-
-if(NOT WIN32)
-    set(THREADS_PREFER_PTHREAD_FLAG ON)
-    find_package(Threads REQUIRED)
-    target_link_libraries(${target} PRIVATE Threads::Threads)
-    # ASAN with -shared-libsan requires explicit pthread linkage (rocm-systems#6455)
-    if(THEROCK_SANITIZER MATCHES "ASAN" OR ENABLE_ADDRESS_SANITIZER)
-        target_link_options(${target} PRIVATE -lpthread)
-    endif()
-endif()
 
 set_target_properties(
     ${target}

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/CMakeLists.txt
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/CMakeLists.txt
@@ -18,6 +18,16 @@ target_link_libraries(
     PRIVATE rocprofiler-compute-tool gtest_main gmock gsl_assert fmt::fmt
 )
 
+if(NOT WIN32)
+    set(THREADS_PREFER_PTHREAD_FLAG ON)
+    find_package(Threads REQUIRED)
+    target_link_libraries(${target} PRIVATE Threads::Threads)
+    # ASAN with -shared-libsan requires explicit pthread linkage (rocm-systems#6455)
+    if(THEROCK_SANITIZER MATCHES "ASAN" OR ENABLE_ADDRESS_SANITIZER)
+        target_link_options(${target} PRIVATE -lpthread)
+    endif()
+endif()
+
 set_target_properties(
     ${target}
     PROPERTIES


### PR DESCRIPTION
## Motivation

Bugfix: `test-rocprofiler-compute-tool` fails to link under TheRock clang+lld ASAN builds (`linux-release-asan`) because GoogleTest requires POSIX TLS symbols that are not pulled in when `Threads::Threads` is empty and lld uses `--as-needed`.

Fixes ROCm/rocm-systems#6455

## Technical Details

- Link `Threads::Threads` for `test-rocprofiler-compute-tool` on non-Windows
- Add `-lpthread` when `THEROCK_SANITIZER` matches `ASAN` or `ENABLE_ADDRESS_SANITIZER` is set (same pattern as [ocltst](https://github.com/ROCm/rocm-systems/blob/develop/projects/clr/opencl/tests/ocltst/env/CMakeLists.txt))

## JIRA ID

N/A

## Test Plan

- Build with `ENABLE_TESTS=ON` and verify `test-rocprofiler-compute-tool` links
- Confirm TheRock `linux-release-asan` CI link step passes for rocprofiler-compute

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

Made with [Cursor](https://cursor.com)