### PR TITLE
[rocshmem] Change default ROCSHMEM_DEBUG_LEVEL from WARN to ERROR

### DIFF
--- a/projects/rocshmem/docs/env_variables.rst
+++ b/projects/rocshmem/docs/env_variables.rst
@@ -21,11 +21,11 @@ control the behavior of rocSHMEM.
 
     * - | ``ROCSHMEM_DEBUG_LEVEL``
         | Debug output level
-      - ``WARN``
+      - ``ERROR``
       - | Levels (from least to most verbose):
         | ``NONE``: Suppress all output.
-        | ``ERROR``: Print error messages only.
-        | ``WARN``: Print warnings and errors (default).
+        | ``ERROR``: Print error messages only (default).
+        | ``WARN``: Print warnings and errors.
         | ``ENV``: Print modified environment variables at startup.
         | ``VERSION``: Print build/version information at startup.
         | ``INFO``: Print informational messages and above.

--- a/projects/rocshmem/src/envvar.cpp
+++ b/projects/rocshmem/src/envvar.cpp
@@ -48,7 +48,7 @@ namespace envvar {
       "Append modifiers: :noversion, :noenv, :noinfo, :nowarn, :notrace to suppress categories; "
       ":env[:all|:full] to enable/control env variable output; "
       ":color (default) or :nocolor for ANSI colors (e.g. trace:noversion:nocolor, env:full)",
-      types::debug_level::WARN);
+      types::debug_level::ERROR);
   }  // close _base temporarily to define log_flags after debug_level
 
   // Build log_flags from the parsed debug_level and any :modifiers.


### PR DESCRIPTION
## Motivation
2/2 fix for https://github.com/ROCm/TheRock/issues/5459.

Prevents LOG_WARN messages from printing to stderr on library load. Users can still opt in to warnings with ROCSHMEM_DEBUG_LEVEL=WARN.

## Technical Details

Change default ROCSHMEM_DEBUG_LEVEL from WARN to ERROR

## Test Plan

- Simulate change by simply setting environment variable `ROCSHMEM_DEBUG_LEVEL` to ERROR
- Confirm below warning is no longer outputted with simple `import torch`
```
W-001h rocSHMEM Could not open libibverbs. Disabled.    IBVWrapper@src/gda/ibv_wrapper.cpp:51
```

## Test Result

Warning is no longer printed due to elevated debug level

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
