### PR TITLE
[CLR] Return correct granularity on PAL

### DIFF
--- a/projects/clr/rocclr/device/pal/paldevice.cpp
+++ b/projects/clr/rocclr/device/pal/paldevice.cpp
@@ -618,7 +618,7 @@ void NullDevice::fillDeviceInfo(const Pal::DeviceProperties& palProp,
   info_.virtualMemAllocGranularityMinimum_ =
       static_cast<size_t>(palProp.gpuMemoryProperties.virtualMemAllocGranularity);
   info_.virtualMemAllocGranularityRecommended_ =
-      static_cast<size_t>(palProp.gpuMemoryProperties.virtualMemAllocGranularity);
+      static_cast<size_t>(palProp.gpuMemoryProperties.largePageSizeInBytes);
   info_.vgprAllocGranularity_ = palProp.gfxipProperties.shaderCore.vgprAllocGranularity;
   info_.vgprsPerSimd_ = palProp.gfxipProperties.shaderCore.vgprsPerSimd;
   info_.availableVGPRs_ = palProp.gfxipProperties.shaderCore.numAvailableVgprs;


### PR DESCRIPTION
## Motivation

PAL returns the minimum granularity as the recommended value, this doesn't reflect how we actually want our sizes to be allocated.

## Technical Details

Return largePageSizeInBytes instead of virtualMemAllocGranularity

## JIRA ID

AIRUNTIME-2065

## Test Plan

No new testing needed

## Test Result

Recommended Allocation Granularity: 262144 bytes
Minimum Allocation Granularity: 65536 bytes

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
