### PR TITLE
[rccl/net_ib] resiliency fixes for AINIC

### DIFF
--- a/projects/rccl/src/transport/net_ib_cast/common_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/common_cast.h
@@ -420,6 +420,8 @@ struct ncclIbQp {
   // to.
   int remDevIdx;
   int8_t ctsQpSlot;
+  int channelId;
+  bool isDataQp;
 };
 
 // We need to support NCCL_NET_MAX_REQUESTS for each concurrent receive

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -418,6 +418,29 @@ static ncclResult_t ncclIbCreateQpIonic(struct ncclIbQpCreateAttr* createQpAttrs
   return ncclSuccess;
 }
 
+// Build base QP creation attributes from comm context. Callers MUST set
+// channelId and isDataQp from the saved ncclIbQp fields — these control
+// AINIC driver behavior (UDMA load balancing and sq_sig_all feature flags)
+// and differ between sender QPs (isDataQp=true) and receiver QPs (isDataQp=false).
+void IbCastBuildDataQpCreateAttr(struct ncclIbNetCommBase* base, int devIndex, struct ncclIbQpCreateAttr* out) {
+  memset(out, 0, sizeof(*out));
+  out->type = IBV_QPT_RC;
+  out->qpContext = (void*)&base->stats;
+  struct ncclIbNetCommDevBase* devBase = IbCastGetNetCommDevBase(base, devIndex);
+  out->cq = devBase->cq;
+  out->pd = devBase->pd;
+  out->ibDevN = devBase->ibDevN;
+  if (base->isSend) {
+    out->maxRecvWorkRequest = 0;
+    out->maxSendWorkRequest = 2 * NET_IB_MAX_REQUESTS;
+  } else {
+    out->maxRecvWorkRequest = NET_IB_MAX_REQUESTS;
+    // Receiver needs send WRs for CTS messages. With resiliency, every CTS is
+    // signaled so NET_IB_MAX_REQUESTS suffices; without, need 2x.
+    out->maxSendWorkRequest = NET_IB_MAX_REQUESTS * (base->resiliency ? 1 : 2);
+  }
+}
+
 ncclResult_t IbCastQpCreate(struct ncclIbQp* qp, struct ncclIbQpCreateAttr* createQpAttrs) {
   if (createQpAttrs->oooRq) {
      NCCLCHECK(ncclIbCreateQpMlx5(createQpAttrs, qp));
@@ -602,6 +625,7 @@ static ncclResult_t IbCastSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbCon
     }
 
     NCCLCHECK(IbCastQpCreate(localQp, &qpCreateAttrs));
+
     INFO(NCCL_NET, "NET/IB: %s: QP created: port=%d dev=%d devName=%s ndevs=%d nmdevs=%d qp_num=%u pkey=%u pd=%p oooRq=%d",
         __func__,
         ibDev->portNum,
@@ -614,6 +638,8 @@ static ncclResult_t IbCastSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbCon
         commDev->base.pd,
         qpCreateAttrs.oooRq);
     localQp->devIndex = devIndex;
+    localQp->channelId = channelId;
+    localQp->isDataQp = qpCreateAttrs.isDataQp;
 
     // Populate the metadata that will be delivered to the remote peer
     localQpInfo->qpn      = localQp->qp->qp_num;
@@ -1099,6 +1125,9 @@ static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
       }
     }
     NCCLCHECK(IbCastQpCreate(localQp, &qpCreateAttrs));
+    localQp->channelId = channelId;
+    localQp->isDataQp = qpCreateAttrs.isDataQp;
+
     INFO(NCCL_NET, "NET/IB: %s: QP created: port=%d dev=%d devName=%s ndevs=%d nmdevs=%d qp_num=%u pkey=%u pd=%p oooRq=%d",
         __func__,
         ibDev->portNum,
@@ -1186,6 +1215,9 @@ static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
       qpCreateAttrs.ibDevN = rCommDev->base.ibDevN;
 
       NCCLCHECK(IbCastQpCreate(&rCommDev->gpuFlush.qp, &qpCreateAttrs));
+      rCommDev->gpuFlush.qp.channelId = channelId;
+      rCommDev->gpuFlush.qp.isDataQp = qpCreateAttrs.isDataQp;
+
       INFO(NCCL_NET, "NET/IB: %s: Flush QP created: port=%d dev=%d devName=%s ndevs=%d nmdevs=%d qp_num=%u pkey=%u pd=%p",
           __func__,
           ibDev->portNum,

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -435,10 +435,8 @@ void IbCastBuildDataQpCreateAttr(struct ncclIbNetCommBase* base, int devIndex, s
     out->maxRecvWorkRequest = 0;
     out->maxSendWorkRequest = 2 * NET_IB_MAX_REQUESTS;
   } else {
-    out->maxRecvWorkRequest = NET_IB_MAX_REQUESTS;
-    // Receiver needs send WRs for CTS messages. With resiliency, every CTS is
-    // signaled so NET_IB_MAX_REQUESTS suffices; without, need 2x.
-    out->maxSendWorkRequest = NET_IB_MAX_REQUESTS * (base->resiliency ? 1 : 2);
+    IbCastResiliencyDataRqSizeGet(base->resiliency, devIndex, &out->maxRecvWorkRequest);
+    out->maxSendWorkRequest = NET_IB_MAX_REQUESTS;
   }
 }
 

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -430,6 +430,7 @@ void IbCastBuildDataQpCreateAttr(struct ncclIbNetCommBase* base, int devIndex, s
   out->cq = devBase->cq;
   out->pd = devBase->pd;
   out->ibDevN = devBase->ibDevN;
+  out->useIonic = IbCastAinicRoce;
   if (base->isSend) {
     out->maxRecvWorkRequest = 0;
     out->maxSendWorkRequest = 2 * NET_IB_MAX_REQUESTS;
@@ -446,7 +447,7 @@ ncclResult_t IbCastQpCreate(struct ncclIbQp* qp, struct ncclIbQpCreateAttr* crea
      NCCLCHECK(ncclIbCreateQpMlx5(createQpAttrs, qp));
      return ncclSuccess;
   }
-  if (IbCastAinicRoce && createQpAttrs->type != IBV_QPT_UD) {
+  if (createQpAttrs->useIonic && createQpAttrs->type != IBV_QPT_UD) {
     NCCLCHECK(ncclIbCreateQpIonic(createQpAttrs, qp));
     return ncclSuccess;
   }
@@ -610,6 +611,7 @@ static ncclResult_t IbCastSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbCon
     qpCreateAttrs.isDataQp = true;
     qpCreateAttrs.channelId = channelId;
     qpCreateAttrs.ibDevN = commDev->base.ibDevN;
+    qpCreateAttrs.useIonic = IbCastAinicRoce;
 
     if (ibDev->ibProvider == IB_PROVIDER_MLX5 && ncclParamIbCastOooRq()) {
       if (ibDev->ar == 0) {
@@ -1101,6 +1103,7 @@ static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
     qpCreateAttrs.isDataQp = false;
     qpCreateAttrs.channelId = channelId;
     qpCreateAttrs.ibDevN = rCommDev->base.ibDevN;
+    qpCreateAttrs.useIonic = IbCastAinicRoce;
 
     if (rComm->base.resiliency) {
       IbCastResiliencyDataRqSizeGet(rComm->base.resiliency, devIndex, &qpCreateAttrs.maxRecvWorkRequest);
@@ -1213,6 +1216,7 @@ static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
       qpCreateAttrs.isDataQp = true;
       qpCreateAttrs.channelId = channelId;
       qpCreateAttrs.ibDevN = rCommDev->base.ibDevN;
+      qpCreateAttrs.useIonic = IbCastAinicRoce;
 
       NCCLCHECK(IbCastQpCreate(&rCommDev->gpuFlush.qp, &qpCreateAttrs));
       rCommDev->gpuFlush.qp.channelId = channelId;

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -423,7 +423,7 @@ ncclResult_t IbCastQpCreate(struct ncclIbQp* qp, struct ncclIbQpCreateAttr* crea
      NCCLCHECK(ncclIbCreateQpMlx5(createQpAttrs, qp));
      return ncclSuccess;
   }
-  if (IbCastAinicRoce) {
+  if (IbCastAinicRoce && createQpAttrs->type != IBV_QPT_UD) {
     NCCLCHECK(ncclIbCreateQpIonic(createQpAttrs, qp));
     return ncclSuccess;
   }

--- a/projects/rccl/src/transport/net_ib_cast/connect_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/connect_cast.h
@@ -52,6 +52,7 @@ struct ncclIbQpCreateAttr {
   int8_t ctsQpSlot;
   int channelId;
   int ibDevN;
+  bool useIonic;
 };
 
 // Per-QP connection metatdata

--- a/projects/rccl/src/transport/net_ib_cast/connect_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/connect_cast.h
@@ -103,6 +103,7 @@ struct ncclIbConnectionMetadata {
 };
 
 ncclResult_t IbCastQpCreate(struct ncclIbQp* qp, struct ncclIbQpCreateAttr* createQpAttrs);
+void IbCastBuildDataQpCreateAttr(struct ncclIbNetCommBase* base, int devIndex, struct ncclIbQpCreateAttr* out);
 ncclResult_t IbCastQpInit(struct ncclIbQp* qp);
 ncclResult_t IbCastQpRtr(struct ncclIbQp* qp);
 ncclResult_t IbCastQpRts(struct ncclIbQp* qp);

--- a/projects/rccl/src/transport/net_ib_cast/net_ib_cast_inspect.h
+++ b/projects/rccl/src/transport/net_ib_cast/net_ib_cast_inspect.h
@@ -9,6 +9,7 @@
 
 #include <stdint.h>
 #include "net_ib_limits.h"
+#include "plugin/nccl_net.h"  /* NCCL_NET_MAX_DEVS_PER_NIC */
 
 #ifdef __cplusplus
 #include "nccl.h"  /* ncclResult_t */
@@ -61,8 +62,8 @@ struct ncclIbCastResiliencyState {
   int  outstandingRequests;
   int  outstandingRecovery;
   int  ndevs;
-  int  devState[4];
-  int  recoveryCount[4];
+  int  devState[NCCL_NET_MAX_DEVS_PER_NIC];
+  int  recoveryCount[NCCL_NET_MAX_DEVS_PER_NIC];
 };
 
 /* Fills out with the current resiliency state of the communicator.

--- a/projects/rccl/src/transport/net_ib_cast/net_ib_cast_inspect.h
+++ b/projects/rccl/src/transport/net_ib_cast/net_ib_cast_inspect.h
@@ -62,6 +62,7 @@ struct ncclIbCastResiliencyState {
   int  outstandingRecovery;
   int  ndevs;
   int  devState[4];
+  int  recoveryCount[4];
 };
 
 /* Fills out with the current resiliency state of the communicator.

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency.cc
@@ -578,6 +578,7 @@ ncclResult_t IbCastResiliencyDevInit(struct ncclIbResiliency* resCtx, uint devIn
   assert(devIndex < resCtx->ndevs);
   struct ncclIbResiliencyDev* resDev = &resCtx->devs[devIndex];
   resDev->state.store(ncclIbResiliencyDevStateOk, std::memory_order_release);
+  resDev->recoveryCount = 0;
   void* cqContext = (void*)&resCtx->baseComm->stats;
   int cqSize = -1;
   if (resCtx->baseComm->isSend) {
@@ -999,7 +1000,8 @@ ncclResult_t IbCastResiliencyProgress(struct ncclIbResiliency* resCtx) {
       TRACE(NCCL_NET, "NET/IB: %s: Checking dev state for device %d: state=%d (comm=%p).", __func__, devIndex, devState, resCtx->baseComm);
       if (devState == ncclIbResiliencyDevStateRecovered) {
         resCtx->outstandingRecovery--;
-        INFO(NCCL_NET, "NET/IB: %s: Device %d has been recovered for resiliency context (%s comm=%p, outstandingRecovery=%d)", __func__, devIndex, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm, resCtx->outstandingRecovery);
+        resCtx->devs[devIndex].recoveryCount++;
+        INFO(NCCL_NET, "NET/IB: %s: Device %d has been recovered for resiliency context (%s comm=%p, outstandingRecovery=%d, recoveryCount=%d)", __func__, devIndex, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm, resCtx->outstandingRecovery, resCtx->devs[devIndex].recoveryCount);
         IbCastResiliencyActiveQpsRestore(resCtx, devIndex);
         resCtx->devs[devIndex].state.store(ncclIbResiliencyDevStateOk, std::memory_order_release);
       }

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_cast.h
@@ -42,8 +42,11 @@ struct ncclIbResiliencyDev {
   // CQ to get CQEs for recovery protocol messages.
   struct ibv_cq* portRecoveryCq;
   // GRH buffer and MR for UD recovery QP receives (UD prepends 40-byte GRH).
-  uint8_t portRecoveryGrhBuf[40];
+  // Extended to 128 bytes to hold GRH (40) + QPN payload for AINIC recovery.
+  uint8_t portRecoveryGrhBuf[128];
   struct ibv_mr* portRecoveryGrhMr;
+  // MR for QPN send buffer, registered against this device's PD.
+  struct ibv_mr* portRecoveryQpnMr;
 };
 
 struct ncclIbResiliency {
@@ -86,6 +89,13 @@ struct ncclIbResiliency {
 
   // Counter for selective retransmits (IbCastResiliencyRepostRequest calls).
   int repostCount;
+
+  // QPN exchange send buffer for AINIC destroy+recreate recovery.
+  // Used to send local QPN data as ACK payload. MR is per-device (in ncclIbResiliencyDev).
+  // Shared across devices — safe because the recovery thread processes contexts
+  // serially (one device at a time). If concurrent device recovery is ever added,
+  // this buffer must be moved to per-device or per-recovery-context.
+  uint8_t portRecoveryQpnBuf[128];
 };
 
 enum ncclIbResiliencyRequestSendState {

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_cast.h
@@ -42,9 +42,14 @@ struct ncclIbResiliencyDev {
   // CQ to get CQEs for recovery protocol messages.
   struct ibv_cq* portRecoveryCq;
   // GRH buffer and MR for UD recovery QP receives (UD prepends 40-byte GRH).
-  // Extended to 128 bytes to hold GRH (40) + QPN payload for AINIC recovery.
-  uint8_t portRecoveryGrhBuf[128];
+  // Sized to hold GRH + max QPN payload for AINIC destroy+recreate recovery.
+  // RecoveryQpnEntry is 8 bytes; worst case is NCCL_IB_MAX_QPS entries.
+  uint8_t portRecoveryGrhBuf[40 + NCCL_IB_MAX_QPS * 8];
   struct ibv_mr* portRecoveryGrhMr;
+  // Number of times this device completed recovery (Recovered → Ok).
+  // Monotonically increasing; used by tests to verify recovery without
+  // depending on devState timing.
+  int recoveryCount;
   // MR for QPN send buffer, registered against this device's PD.
   struct ibv_mr* portRecoveryQpnMr;
 };
@@ -95,7 +100,7 @@ struct ncclIbResiliency {
   // Shared across devices — safe because the recovery thread processes contexts
   // serially (one device at a time). If concurrent device recovery is ever added,
   // this buffer must be moved to per-device or per-recovery-context.
-  uint8_t portRecoveryQpnBuf[128];
+  uint8_t portRecoveryQpnBuf[NCCL_IB_MAX_QPS * 8];
 };
 
 enum ncclIbResiliencyRequestSendState {

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_cast.h
@@ -11,6 +11,13 @@
 #include "common_cast.h"
 #include "connect_cast.h"
 
+#define NCCL_IB_UD_GRH_SIZE 40
+
+struct RecoveryQpnEntry {
+  uint32_t qpIndex;
+  uint32_t newQpn;
+};
+
 enum ncclIbResiliencyDevState {
   // The device is operating normally.
   ncclIbResiliencyDevStateOk = 0,
@@ -41,10 +48,9 @@ struct ncclIbResiliencyDev {
   struct ibv_mr* probingResultMr;
   // CQ to get CQEs for recovery protocol messages.
   struct ibv_cq* portRecoveryCq;
-  // GRH buffer and MR for UD recovery QP receives (UD prepends 40-byte GRH).
+  // GRH buffer and MR for UD recovery QP receives (UD prepends GRH).
   // Sized to hold GRH + max QPN payload for AINIC destroy+recreate recovery.
-  // RecoveryQpnEntry is 8 bytes; worst case is NCCL_IB_MAX_QPS entries.
-  uint8_t portRecoveryGrhBuf[40 + NCCL_IB_MAX_QPS * 8];
+  uint8_t portRecoveryGrhBuf[NCCL_IB_UD_GRH_SIZE + NCCL_IB_MAX_QPS * sizeof(struct RecoveryQpnEntry)];
   struct ibv_mr* portRecoveryGrhMr;
   // Number of times this device completed recovery (Recovered → Ok).
   // Monotonically increasing; used by tests to verify recovery without
@@ -100,7 +106,7 @@ struct ncclIbResiliency {
   // Shared across devices — safe because the recovery thread processes contexts
   // serially (one device at a time). If concurrent device recovery is ever added,
   // this buffer must be moved to per-device or per-recovery-context.
-  uint8_t portRecoveryQpnBuf[NCCL_IB_MAX_QPS * 8];
+  uint8_t portRecoveryQpnBuf[NCCL_IB_MAX_QPS * sizeof(struct RecoveryQpnEntry)];
 };
 
 enum ncclIbResiliencyRequestSendState {

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery.cc
@@ -215,7 +215,7 @@ static inline ncclResult_t IbCastPortRecoveryQpsToError(ncclIbPortRecoveryContex
 inline static ncclResult_t IbCastPortRecoveryPostRecvWorkRequest(struct ibv_qp* qp, struct ncclIbResiliencyDev* resDev) {
   struct ibv_sge sge;
   sge.addr = (uintptr_t)resDev->portRecoveryGrhBuf;
-  sge.length = sizeof(resDev->portRecoveryGrhBuf); // 128 bytes: GRH (40) + QPN payload (up to 88)
+  sge.length = sizeof(resDev->portRecoveryGrhBuf);
   sge.lkey = resDev->portRecoveryGrhMr->lkey;
   struct ibv_recv_wr wr;
   memset(&wr, 0, sizeof(wr));

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery.cc
@@ -30,8 +30,24 @@ extern int64_t ncclParamIbCastPkey();
 // no more than two batches of "alive" messsages should be pending in the CQ at
 // any time.
 #define NCCL_IB_RESILIENCY_PORT_RECOVERY_CQ_SIZE (NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX*2)
+#define NCCL_IB_RESILIENCY_PORT_RECOVERY_ACK_MSG_ID (0x1234)
 
 #define NCCL_IB_RECOVERY_QKEY 0x1234ABCD
+
+// UD receives prepend a 40-byte Global Routing Header (GRH).
+#define NCCL_IB_UD_GRH_SIZE 40
+
+// Entry for exchanging new QPNs during AINIC destroy+recreate recovery.
+struct RecoveryQpnEntry {
+  uint32_t qpIndex;
+  uint32_t newQpn;
+};
+
+// Max QPN entries that fit in the UD receive buffer after GRH.
+// portRecoveryGrhBuf is 128 bytes; UD prepends 40-byte GRH; remaining 88 bytes
+// fits 11 RecoveryQpnEntry (8 bytes each). Send buffer is 128 bytes (16 entries)
+// but the receiver is the bottleneck.
+#define NCCL_IB_MAX_RECOVERY_QPN_ENTRIES ((128 - NCCL_IB_UD_GRH_SIZE) / (int)sizeof(struct RecoveryQpnEntry))
 
 static ncclResult_t IbCastPortRecoveryQpInitUd(struct ncclIbQp* qp, int pkeyIndex, int portNum) {
   struct ibv_qp_attr attr;
@@ -177,6 +193,12 @@ struct ncclIbPortRecoveryContext {
       uint32_t receivedBits;
     } recv;
   };
+
+  // AINIC destroy+recreate: local and remote QPN exchange buffers.
+  struct RecoveryQpnEntry localQpns[NCCL_IB_MAX_QPS];
+  int nLocalQpns;
+  struct RecoveryQpnEntry remoteQpns[NCCL_IB_MAX_QPS];
+  int nRemoteQpns;
 };
 
 // Shared inbox for new recovery contexts - protected by IbCastPortRecoveryMutex.
@@ -203,7 +225,7 @@ static inline ncclResult_t IbCastPortRecoveryQpsToError(ncclIbPortRecoveryContex
 inline static ncclResult_t IbCastPortRecoveryPostRecvWorkRequest(struct ibv_qp* qp, struct ncclIbResiliencyDev* resDev) {
   struct ibv_sge sge;
   sge.addr = (uintptr_t)resDev->portRecoveryGrhBuf;
-  sge.length = sizeof(resDev->portRecoveryGrhBuf);
+  sge.length = sizeof(resDev->portRecoveryGrhBuf); // 128 bytes: GRH (40) + QPN payload (up to 88)
   sge.lkey = resDev->portRecoveryGrhMr->lkey;
   struct ibv_recv_wr wr;
   memset(&wr, 0, sizeof(wr));
@@ -269,6 +291,8 @@ static inline ncclResult_t IbCastPortRecoveryContextInit(struct ncclIbResiliency
   recoveryCtx->ackReceived = false;
   recoveryCtx->ackPosted = false;
   recoveryCtx->ackCompleted = false;
+  recoveryCtx->nLocalQpns = 0;
+  recoveryCtx->nRemoteQpns = 0;
 
   for (int i = 0; i < resCtx->ndevs; i++) {
     if (i != failedDevIndex) continue;
@@ -328,6 +352,8 @@ ncclResult_t IbCastPortRecoveryDevInit(struct ncclIbResiliency* resCtx, int devI
   NCCLCHECK(wrap_ibv_create_cq(&resDev->portRecoveryCq, ibDev->context, NCCL_IB_RESILIENCY_PORT_RECOVERY_CQ_SIZE, cqContext, NULL, 0));
   memset(resDev->portRecoveryGrhBuf, 0, sizeof(resDev->portRecoveryGrhBuf));
   NCCLCHECK(wrap_ibv_reg_mr(&resDev->portRecoveryGrhMr, ibDev->pd, resDev->portRecoveryGrhBuf, sizeof(resDev->portRecoveryGrhBuf), IBV_ACCESS_LOCAL_WRITE));
+  // Register QPN send buffer against this device's PD so ACK sends use a matching lkey.
+  NCCLCHECK(wrap_ibv_reg_mr(&resDev->portRecoveryQpnMr, ibDev->pd, resCtx->portRecoveryQpnBuf, sizeof(resCtx->portRecoveryQpnBuf), IBV_ACCESS_LOCAL_WRITE));
   INFO(NCCL_NET, "NET/IB: %s: Created port recovery CQ and GRH MR for resiliency context (%s comm=%p) on device %d", __func__, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm, devIndex);
   return ncclSuccess;
 }
@@ -340,6 +366,10 @@ ncclResult_t IbCastPortRecoveryDevDestroy(struct ncclIbResiliency* resCtx, int d
   }
   if (resDev->portRecoveryCq) {
     NCCLCHECK(wrap_ibv_destroy_cq(resDev->portRecoveryCq));
+  }
+  if (resDev->portRecoveryQpnMr) {
+    wrap_ibv_dereg_mr(resDev->portRecoveryQpnMr);
+    resDev->portRecoveryQpnMr = nullptr;
   }
   INFO(NCCL_NET, "NET/IB: %s: Destroyed port recovery CQ and GRH MR on device %d for resiliency context (comm=%p)", __func__, devIndex, resCtx->baseComm);
   return ncclSuccess;
@@ -585,7 +615,228 @@ static inline ncclResult_t IbCastPortRecoveryQpsRestore(ncclIbPortRecoveryContex
   return ncclSuccess;
 }
 
-#define NCCL_IB_RESILIENCY_PORT_RECOVERY_ACK_MSG_ID (0x1234)
+// AINIC workaround: Destroy old QPs and create new ones (Phase A).
+// ibv_modify_qp(RESET) does not work on AINIC, so we must destroy and
+// recreate the QP to get a fresh one. This produces a new QPN which must
+// be exchanged with the remote side before RTR/RTS (Phase B).
+static inline ncclResult_t IbCastPortRecoveryQpsDestroyAndCreate(ncclIbPortRecoveryContext* recoveryContext) {
+  uint nqps = recoveryContext->resCtx->baseComm->nqps;
+  recoveryContext->nLocalQpns = 0;
+
+  for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
+    ncclIbQp* localQp = &recoveryContext->resCtx->baseComm->qps[qpIndex];
+    if (localQp->devIndex != recoveryContext->devIndex) {
+      continue;
+    }
+
+    uint32_t oldQpn = localQp->qp->qp_num;
+    INFO(NCCL_NET, "NET/IB: %s: Destroying QP %d on device %d (comm=%p, old_qp_num=%u)",
+         __func__, qpIndex, recoveryContext->devIndex,
+         recoveryContext->resCtx->baseComm, oldQpn);
+
+    NCCLCHECK(wrap_ibv_destroy_qp(localQp->qp));
+    localQp->qp = NULL;
+
+    struct ncclIbQpCreateAttr createAttr;
+    IbCastBuildDataQpCreateAttr(recoveryContext->resCtx->baseComm, recoveryContext->devIndex, &createAttr);
+    createAttr.channelId = localQp->channelId;
+    createAttr.isDataQp = localQp->isDataQp;
+    // isCtsEnabled and ctsQpSlot are left at 0 (from memset in IbCastBuildDataQpCreateAttr).
+    // CTS offload is disabled when resiliency features are enabled (init.cc).
+    NCCLCHECK(IbCastQpCreate(localQp, &createAttr));
+
+    INFO(NCCL_NET, "NET/IB: %s: Recreated QP %d on device %d (comm=%p, old_qp_num=%u, new_qp_num=%u)",
+         __func__, qpIndex, recoveryContext->devIndex,
+         recoveryContext->resCtx->baseComm, oldQpn, localQp->qp->qp_num);
+
+    // Transition to INIT
+    NCCLCHECK(IbCastQpInit(localQp));
+
+    // Record the new QPN for exchange with remote
+    int idx = recoveryContext->nLocalQpns;
+    recoveryContext->localQpns[idx].qpIndex = qpIndex;
+    recoveryContext->localQpns[idx].newQpn = localQp->qp->qp_num;
+    recoveryContext->nLocalQpns++;
+  }
+
+  // Also destroy+recreate flush QP on receiver side (it connects to itself)
+  if (!recoveryContext->resCtx->baseComm->isSend) {
+    ncclIbRecvComm* recvComm = (ncclIbRecvComm*)recoveryContext->resCtx->baseComm;
+    if (recvComm->flushEnabled) {
+      for (int i = 0; i < recvComm->base.vProps.ndevs; i++) {
+        if (i != recoveryContext->devIndex) continue;
+        struct ncclIbRecvCommDev* rCommDev = &recvComm->devs[i];
+        ncclIbQp* flushQp = &rCommDev->gpuFlush.qp;
+        INFO(NCCL_NET, "NET/IB: %s: Destroying Flush QP on device %d (comm=%p, old_qp_num=%u)",
+             __func__, i, recoveryContext->resCtx->baseComm, flushQp->qp->qp_num);
+        NCCLCHECK(wrap_ibv_destroy_qp(flushQp->qp));
+        flushQp->qp = NULL;
+        struct ncclIbQpCreateAttr flushCreateAttr;
+        IbCastBuildDataQpCreateAttr(recoveryContext->resCtx->baseComm, recoveryContext->devIndex, &flushCreateAttr);
+        flushCreateAttr.maxRecvWorkRequest = 0;
+        flushCreateAttr.maxSendWorkRequest = NET_IB_MAX_REQUESTS;
+        flushCreateAttr.channelId = flushQp->channelId;
+        flushCreateAttr.isDataQp = flushQp->isDataQp;
+        NCCLCHECK(IbCastQpCreate(flushQp, &flushCreateAttr));
+        INFO(NCCL_NET, "NET/IB: %s: Recreated Flush QP on device %d (comm=%p, new_qp_num=%u)",
+             __func__, i, recoveryContext->resCtx->baseComm, flushQp->qp->qp_num);
+        NCCLCHECK(IbCastQpInit(flushQp));
+      }
+    }
+  }
+
+  INFO(NCCL_NET, "NET/IB: %s: Phase A complete: %d QPs destroyed+recreated on device %d (comm=%p)",
+       __func__, recoveryContext->nLocalQpns, recoveryContext->devIndex,
+       recoveryContext->resCtx->baseComm);
+  return ncclSuccess;
+}
+
+// AINIC workaround: Transition recreated QPs to RTR+RTS (Phase B).
+// Uses remote QPNs received via ACK payload to set remoteQpNum before RTR.
+static inline ncclResult_t IbCastPortRecoveryQpsToRts(ncclIbPortRecoveryContext* recoveryContext) {
+  uint nqps = recoveryContext->resCtx->baseComm->nqps;
+
+  for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
+    ncclIbQp* localQp = &recoveryContext->resCtx->baseComm->qps[qpIndex];
+    if (localQp->devIndex != recoveryContext->devIndex) {
+      continue;
+    }
+
+    // Find the matching remote QPN for this QP
+    uint32_t remoteQpn = 0;
+    bool found = false;
+    for (int r = 0; r < recoveryContext->nRemoteQpns; r++) {
+      if (recoveryContext->remoteQpns[r].qpIndex == qpIndex) {
+        remoteQpn = recoveryContext->remoteQpns[r].newQpn;
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      WARN("NET/IB: %s: No remote QPN found for QP index %d on device %d (comm=%p)",
+           __func__, qpIndex, recoveryContext->devIndex,
+           recoveryContext->resCtx->baseComm);
+      return ncclInternalError;
+    }
+
+    // Update the remote QPN and transition to RTR+RTS
+    localQp->rtrAttr.remoteQpNum = remoteQpn;
+    INFO(NCCL_NET, "NET/IB: %s: QP %d RTR with remoteQpn=%u (comm=%p, qp_num=%u)",
+         __func__, qpIndex, remoteQpn, recoveryContext->resCtx->baseComm,
+         localQp->qp->qp_num);
+
+    if (localQp->eceSupported) {
+      NCCLCHECK(wrap_ibv_set_ece(localQp->qp, &localQp->ece, &localQp->eceSupported));
+    }
+    NCCLCHECK(IbCastQpRtr(localQp));
+    NCCLCHECK(IbCastQpRts(localQp));
+
+    INFO(NCCL_NET, "NET/IB: %s: Restored QP %d on device %d (comm=%p, qp_num=%u)",
+         __func__, qpIndex, recoveryContext->devIndex,
+         recoveryContext->resCtx->baseComm, localQp->qp->qp_num);
+
+    // Pre-post receive work requests on receiver QPs
+    if (!recoveryContext->resCtx->baseComm->isSend) {
+      struct ncclIbRecvComm* recvComm = (struct ncclIbRecvComm*)recoveryContext->resCtx->baseComm;
+      NCCLCHECK(IbCastPostReceiveWorkRequestsOnQp(recvComm, localQp));
+    }
+  }
+
+  // Restore Flush QP on receiver (self-loopback — remote QPN is own new QPN)
+  if (!recoveryContext->resCtx->baseComm->isSend) {
+    ncclIbRecvComm* recvComm = (ncclIbRecvComm*)recoveryContext->resCtx->baseComm;
+    if (recvComm->flushEnabled) {
+      for (int i = 0; i < recvComm->base.vProps.ndevs; i++) {
+        if (i != recoveryContext->devIndex) continue;
+        struct ncclIbRecvCommDev* rCommDev = &recvComm->devs[i];
+        ncclIbQp* flushQp = &rCommDev->gpuFlush.qp;
+        // Self-loopback: remote QPN = own new QPN
+        flushQp->rtrAttr.remoteQpNum = flushQp->qp->qp_num;
+        NCCLCHECK(IbCastQpRtr(flushQp));
+        NCCLCHECK(IbCastQpRts(flushQp));
+        INFO(NCCL_NET, "NET/IB: %s: Restored Flush QP on device %d (comm=%p, qp_num=%u)",
+             __func__, i, recoveryContext->resCtx->baseComm, flushQp->qp->qp_num);
+      }
+    }
+  }
+
+  return ncclSuccess;
+}
+
+// Post an ACK message with QPN payload for AINIC destroy+recreate recovery.
+static inline ncclResult_t IbCastPortRecoveryPostAckWithQpns(ncclIbPortRecoveryContext* recoveryContext, bool* success) {
+  int devIdx = recoveryContext->devIndex;
+  struct ncclIbResiliency* resCtx = recoveryContext->resCtx;
+
+  // Populate the QPN send buffer with local QPN entries.
+  // Payload must fit in both the send buffer and the remote recv buffer (after GRH).
+  if (recoveryContext->nLocalQpns > NCCL_IB_MAX_RECOVERY_QPN_ENTRIES) {
+    WARN("NET/IB: %s: Too many QPN entries (%d) for recovery ACK payload (max %d)",
+         __func__, recoveryContext->nLocalQpns, NCCL_IB_MAX_RECOVERY_QPN_ENTRIES);
+    return ncclInternalError;
+  }
+  int payloadSize = recoveryContext->nLocalQpns * sizeof(struct RecoveryQpnEntry);
+  memcpy(resCtx->portRecoveryQpnBuf, recoveryContext->localQpns, payloadSize);
+
+  struct ibv_sge qpnSge;
+  qpnSge.addr = (uintptr_t)resCtx->portRecoveryQpnBuf;
+  qpnSge.length = payloadSize;
+  qpnSge.lkey = resCtx->devs[devIdx].portRecoveryQpnMr->lkey;
+
+  struct ibv_send_wr wr;
+  memset(&wr, 0, sizeof(wr));
+  wr.wr_id = recoveryContext->aliveMsgNextId;
+  wr.opcode = IBV_WR_SEND_WITH_IMM;
+  wr.imm_data = NCCL_IB_RESILIENCY_PORT_RECOVERY_ACK_MSG_ID;
+  wr.send_flags = IBV_SEND_SIGNALED;
+  wr.sg_list = &qpnSge;
+  wr.num_sge = 1;
+  wr.wr.ud.ah = resCtx->portRecoveryAh[devIdx];
+  wr.wr.ud.remote_qpn = resCtx->portRecoveryRemoteQpn[devIdx];
+  wr.wr.ud.remote_qkey = NCCL_IB_RECOVERY_QKEY;
+
+  INFO(NCCL_NET, "NET/IB: %s: %s posting ACK with %d QPN entries for device %d (comm=%p)",
+       __func__, resCtx->baseComm->isSend ? "Sender" : "Receiver",
+       recoveryContext->nLocalQpns, devIdx, resCtx->baseComm);
+
+  struct ibv_send_wr* bad_wr = NULL;
+  struct ncclIbQp* recoveryQp = &resCtx->portRecoveryQps[devIdx];
+  if (wrap_ibv_post_send(recoveryQp->qp, &wr, &bad_wr) != ncclSuccess) {
+    INFO(NCCL_NET, "NET/IB: %s: Failed to post ACK with QPNs on device %d (comm=%p, qp_num=%u)",
+         __func__, devIdx, resCtx->baseComm, recoveryQp->qp->qp_num);
+    *success = false;
+    return ncclSuccess;
+  }
+  recoveryContext->ackPosted = true;
+  *success = true;
+  return ncclSuccess;
+}
+
+// Extract QPNs from a received ACK message buffer (after GRH offset in UD recv).
+static inline void IbCastPortRecoveryExtractQpns(ncclIbPortRecoveryContext* recoveryContext, struct ibv_wc* wc) {
+  struct ncclIbResiliencyDev* resDev = &recoveryContext->resCtx->devs[recoveryContext->devIndex];
+  // UD receives prepend GRH; QPN payload starts at offset NCCL_IB_UD_GRH_SIZE
+  int totalLen = wc->byte_len;
+  int payloadLen = totalLen - NCCL_IB_UD_GRH_SIZE;
+  if (payloadLen <= 0) {
+    // No QPN payload (shouldn't happen on AINIC path, but be safe)
+    recoveryContext->nRemoteQpns = 0;
+    return;
+  }
+  int nEntries = payloadLen / sizeof(struct RecoveryQpnEntry);
+  if (nEntries > NCCL_IB_MAX_QPS) nEntries = NCCL_IB_MAX_QPS;
+
+  uint8_t* payload = resDev->portRecoveryGrhBuf + NCCL_IB_UD_GRH_SIZE;
+  memcpy(recoveryContext->remoteQpns, payload, nEntries * sizeof(struct RecoveryQpnEntry));
+  recoveryContext->nRemoteQpns = nEntries;
+
+  for (int i = 0; i < nEntries; i++) {
+    INFO(NCCL_NET, "NET/IB: %s: Extracted remote QPN: qpIndex=%u newQpn=%u (comm=%p)",
+         __func__, recoveryContext->remoteQpns[i].qpIndex,
+         recoveryContext->remoteQpns[i].newQpn,
+         recoveryContext->resCtx->baseComm);
+  }
+}
 
 static inline ncclResult_t IbCastPortRecoveryHandleCompletionReceiver(struct ncclIbPortRecoveryContext* recoveryContext, struct ibv_wc completion, bool* success) {
   ncclResult_t res = ncclSuccess;
@@ -639,6 +890,10 @@ static inline ncclResult_t IbCastPortRecoveryHandleCompletionReceiver(struct ncc
     assert(completion.opcode == IBV_WC_RECV);
     assert(completion.imm_data == NCCL_IB_RESILIENCY_PORT_RECOVERY_ACK_MSG_ID);
     INFO(NCCL_NET, "NET/IB: %s: Receiver received final ACK message for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+    // On AINIC, extract sender's new QPNs from the final ACK payload
+    if (IbCastAinicRoce) {
+      IbCastPortRecoveryExtractQpns(recoveryContext, &completion);
+    }
     recoveryContext->ackReceived = true;
   }
   *success = true;
@@ -664,6 +919,10 @@ static inline ncclResult_t IbCastPortRecoveryHandleCompletionSender(struct ncclI
       assert(completion.opcode == IBV_WC_RECV);
       assert(completion.imm_data == NCCL_IB_RESILIENCY_PORT_RECOVERY_ACK_MSG_ID);
       INFO(NCCL_NET, "NET/IB: %s: Sender received an ACK message from the receiver for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+      // On AINIC, extract receiver's new QPNs from the ACK payload
+      if (IbCastAinicRoce) {
+        IbCastPortRecoveryExtractQpns(recoveryContext, &completion);
+      }
       recoveryContext->ackReceived = true;
       *success = true;
       return ncclSuccess;
@@ -854,13 +1113,20 @@ static inline ncclResult_t IbCastPortRecoveryProgressAliveMessagesReceiver(ncclI
         return ncclSuccess;
       }
       INFO(NCCL_NET, "NET/IB: %s: Receiver received enough in-order alive messages for device %d (comm=%p). Restoring QPs and posting ACK message.", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
-      NCCLCHECK(IbCastPortRecoveryQpsRestore(recoveryContext, &success));
-      if (!success) {
-        INFO(NCCL_NET, "NET/IB: %s: Receiver failed to restore QPs on device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
-        *outResult = ncclIbPortRecoveryStateProgressResultFailed;
-        return ncclSuccess;
+      if (IbCastAinicRoce) {
+        // AINIC workaround: destroy+recreate QPs (Phase A), send ACK with QPNs
+        NCCLCHECK(IbCastPortRecoveryQpsDestroyAndCreate(recoveryContext));
+        NCCLCHECK(IbCastPortRecoveryPostAckWithQpns(recoveryContext, &success));
+      } else {
+        // bnxt_re: standard RESET path, send zero-byte ACK
+        NCCLCHECK(IbCastPortRecoveryQpsRestore(recoveryContext, &success));
+        if (!success) {
+          INFO(NCCL_NET, "NET/IB: %s: Receiver failed to restore QPs on device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+          *outResult = ncclIbPortRecoveryStateProgressResultFailed;
+          return ncclSuccess;
+        }
+        NCCLCHECK(IbCastPortRecoveryPostAck(recoveryContext, &success));
       }
-      NCCLCHECK(IbCastPortRecoveryPostAck(recoveryContext, &success));
       if (!success) {
         INFO(NCCL_NET, "NET/IB: %s: Failed to post ACK message for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
         *outResult = ncclIbPortRecoveryStateProgressResultFailed;
@@ -902,9 +1168,15 @@ static inline ncclResult_t IbCastPortRecoveryProgressAliveMessagesReceiver(ncclI
           *outResult = ncclIbPortRecoveryStateProgressResultFailed;
           return ncclSuccess;
         }
-        // Go back to alive messages state
+        // Go back to alive messages state. On AINIC, the QPs created in Phase A
+        // (currently in INIT state) will be destroyed+recreated again when the
+        // receiver re-enters Phase A on the next attempt. The sender also retries
+        // from alive messages state, so both sides restart the full handshake
+        // with fresh QPNs — no stale QPN mismatch.
         recoveryContext->ackPosted = false;
         recoveryContext->ackCompleted = false;
+        recoveryContext->nLocalQpns = 0;
+        recoveryContext->nRemoteQpns = 0;
         recoveryContext->timeLastMsg = now;
         *outResult = ncclIbPortRecoveryStateProgressResultGoToPrevState;
         INFO(NCCL_NET, "NET/IB: %s: Receiver posting (%d) recv WRs on device %d (comm=%p)", __func__, NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
@@ -982,13 +1254,22 @@ static inline ncclResult_t IbCastPortRecoveryProgressAckSender(ncclIbPortRecover
   }
 
   if (recoveryContext->ackPosted == false) {
-    NCCLCHECK(IbCastPortRecoveryQpsRestore(recoveryContext, &success));
-    if (!success) {
-      INFO(NCCL_NET, "NET/IB: %s: Sender failed to restore QPs on device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
-      *outResult = ncclIbPortRecoveryStateProgressResultFailed;
-      return ncclSuccess;
+    if (IbCastAinicRoce) {
+      // AINIC workaround: Phase A (destroy+create) + Phase B (RTR+RTS with
+      // receiver's QPNs), then send final ACK with our new QPNs
+      NCCLCHECK(IbCastPortRecoveryQpsDestroyAndCreate(recoveryContext));
+      NCCLCHECK(IbCastPortRecoveryQpsToRts(recoveryContext));
+      NCCLCHECK(IbCastPortRecoveryPostAckWithQpns(recoveryContext, &success));
+    } else {
+      // bnxt_re: standard RESET path, send zero-byte final ACK
+      NCCLCHECK(IbCastPortRecoveryQpsRestore(recoveryContext, &success));
+      if (!success) {
+        INFO(NCCL_NET, "NET/IB: %s: Sender failed to restore QPs on device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+        *outResult = ncclIbPortRecoveryStateProgressResultFailed;
+        return ncclSuccess;
+      }
+      NCCLCHECK(IbCastPortRecoveryPostAck(recoveryContext, &success));
     }
-    NCCLCHECK(IbCastPortRecoveryPostAck(recoveryContext, &success));
     if (!success) {
       INFO(NCCL_NET, "NET/IB: %s: Failed to post ack for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
       *outResult = ncclIbPortRecoveryStateProgressResultFailed;
@@ -1032,10 +1313,13 @@ static inline ncclResult_t IbCastPortRecoveryProgressAckReceiver(ncclIbPortRecov
         return ncclSuccess;
       }
       *outResult = ncclIbPortRecoveryStateProgressResultGoToPrevState;
-      // Reset internal state
+      // Reset internal state. On AINIC, QPs from Phase A will be destroyed+
+      // recreated again on the next attempt with fresh QPNs.
       recoveryContext->ackPosted = false;
       recoveryContext->ackCompleted = false;
       recoveryContext->recv.receivedBits = 0;
+      recoveryContext->nLocalQpns = 0;
+      recoveryContext->nRemoteQpns = 0;
       NCCLCHECK(IbCastPortRecoveryDrainCqAndPostReceiveWRs(recoveryContext, &success));
       if (!success) {
         INFO(NCCL_NET, "NET/IB: %s: Failed to drain CQ and post recv WRs for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
@@ -1046,6 +1330,11 @@ static inline ncclResult_t IbCastPortRecoveryProgressAckReceiver(ncclIbPortRecov
       *outResult = ncclIbPortRecoveryStateProgressResultInProgress;
     }
   } else {
+    // Final ACK received. On AINIC, complete Phase B (RTR+RTS with sender's QPNs).
+    // On bnxt_re, QPs were already restored before the ACK was posted.
+    if (IbCastAinicRoce && recoveryContext->nRemoteQpns > 0) {
+      NCCLCHECK(IbCastPortRecoveryQpsToRts(recoveryContext));
+    }
     *outResult = ncclIbPortRecoveryStateProgressResultGoToNextState;
   }
   return ncclSuccess;

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery.cc
@@ -34,15 +34,6 @@ extern int64_t ncclParamIbCastPkey();
 
 #define NCCL_IB_RECOVERY_QKEY 0x1234ABCD
 
-// UD receives prepend a 40-byte Global Routing Header (GRH).
-#define NCCL_IB_UD_GRH_SIZE 40
-
-// Entry for exchanging new QPNs during AINIC destroy+recreate recovery.
-struct RecoveryQpnEntry {
-  uint32_t qpIndex;
-  uint32_t newQpn;
-};
-
 // Max QPN entries for recovery exchange. Both send and recv buffers are
 // sized to NCCL_IB_MAX_QPS entries, accommodating the worst case where
 // all QPs belong to the failed device.

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery.cc
@@ -43,11 +43,10 @@ struct RecoveryQpnEntry {
   uint32_t newQpn;
 };
 
-// Max QPN entries that fit in the UD receive buffer after GRH.
-// portRecoveryGrhBuf is 128 bytes; UD prepends 40-byte GRH; remaining 88 bytes
-// fits 11 RecoveryQpnEntry (8 bytes each). Send buffer is 128 bytes (16 entries)
-// but the receiver is the bottleneck.
-#define NCCL_IB_MAX_RECOVERY_QPN_ENTRIES ((128 - NCCL_IB_UD_GRH_SIZE) / (int)sizeof(struct RecoveryQpnEntry))
+// Max QPN entries for recovery exchange. Both send and recv buffers are
+// sized to NCCL_IB_MAX_QPS entries, accommodating the worst case where
+// all QPs belong to the failed device.
+#define NCCL_IB_MAX_RECOVERY_QPN_ENTRIES NCCL_IB_MAX_QPS
 
 static ncclResult_t IbCastPortRecoveryQpInitUd(struct ncclIbQp* qp, int pkeyIndex, int portNum) {
   struct ibv_qp_attr attr;

--- a/projects/rccl/src/transport/net_ib_cast/scheduler.cc
+++ b/projects/rccl/src/transport/net_ib_cast/scheduler.cc
@@ -521,8 +521,10 @@ extern "C" ncclResult_t ncclIbCastGetResiliencyState(void* sendComm, struct nccl
   out->outstandingRequests = res->outstandingRequests;
   out->outstandingRecovery = res->outstandingRecovery;
   out->ndevs              = res->ndevs;
-  for (int i = 0; i < res->ndevs && i < 4; i++)
+  for (int i = 0; i < res->ndevs && i < 4; i++) {
     out->devState[i] = (int)res->devs[i].state.load(std::memory_order_acquire);
+    out->recoveryCount[i] = res->devs[i].recoveryCount;
+  }
 
   return ncclSuccess;
 }

--- a/projects/rccl/src/transport/net_ib_cast/scheduler.cc
+++ b/projects/rccl/src/transport/net_ib_cast/scheduler.cc
@@ -521,7 +521,7 @@ extern "C" ncclResult_t ncclIbCastGetResiliencyState(void* sendComm, struct nccl
   out->outstandingRequests = res->outstandingRequests;
   out->outstandingRecovery = res->outstandingRecovery;
   out->ndevs              = res->ndevs;
-  for (int i = 0; i < res->ndevs && i < 4; i++) {
+  for (int i = 0; i < res->ndevs && i < NCCL_IB_MAX_DEVS_PER_NIC; i++) {
     out->devState[i] = (int)res->devs[i].state.load(std::memory_order_acquire);
     out->recoveryCount[i] = res->devs[i].recoveryCount;
   }

--- a/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
@@ -2097,10 +2097,10 @@ TEST_F(NetIbMPITest, RecoveryPendingWhileLinkDown) {
 // Test: RecoveryDeviceOneFailure
 //
 // Same as RecoverySuccessRestoresTraffic but faults device 1 (QP index 1)
-// instead of device 0. QP-to-device mapping is interleaved (QP 0=dev 0,
-// QP 1=dev 1, QP 2=dev 0...), so this catches index-arithmetic bugs in
-// IbCastPortRecoveryQpsToError, IbCastPortRecoveryQpsRestore, and
-// IbCastPortRecoveryContextInit that would only surface with device 1.
+// instead of device 0. Sends 20 post-recovery messages. QP-to-device
+// mapping is interleaved (QP 0=dev 0, QP 1=dev 1, QP 2=dev 0...), so
+// this catches index-arithmetic bugs in IbCastPortRecoveryQpsToError,
+// IbCastPortRecoveryQpsRestore, and IbCastPortRecoveryContextInit.
 // =============================================================================
 TEST_F(NetIbMPITest, RecoveryDeviceOneFailure) {
     ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
@@ -2134,7 +2134,8 @@ TEST_F(NetIbMPITest, RecoveryDeviceOneFailure) {
     SetupCastConnection(/*dev=*/mergedDev, &listenComm, &sendComm, &recvComm);
 
     constexpr size_t kMsgSize = 8192;
-    const size_t     kBufSize = kMsgSize * 2;
+    constexpr int    kPostRecoveryMsgs = 20;
+    const size_t     kBufSize = kMsgSize * (kPostRecoveryMsgs + 1);
     std::vector<char> sendBuf(kBufSize), recvBuf(kBufSize);
     for (size_t i = 0; i < kBufSize; i++) sendBuf[i] = static_cast<char>((i * 47 + 31) & 0xFF);
     memset(recvBuf.data(), 0, kBufSize);
@@ -2250,89 +2251,63 @@ TEST_F(NetIbMPITest, RecoveryDeviceOneFailure) {
     }
     MPI_Barrier(MPI_COMM_WORLD);
 
-    // ── Phase 3: post-recovery send ──────────────────────────────────────
-    bool phase3RecvDone = false;
-    void* recvReq3 = nullptr;
-
+    // ── Phase 3: send 20 messages to verify sustained traffic on restored QPs ──
     if (rank == 0) {
-        void*  bufs[1]    = {regBuf + kMsgSize};
-        size_t sizes[1]   = {kMsgSize};
-        int    tags[1]    = {1602};
-        void*  handles[1] = {mhandle};
-        ASSERT_EQ(PostRecv(recvComm, 1, bufs, sizes, tags, handles, &recvReq3), ncclSuccess);
-    }
-    MPI_Barrier(MPI_COMM_WORLD);
-
-    struct PostRecoveryResult {
-        int sendRet;
-        int fatalCount;
-    };
-    static constexpr int kDev1Phase3MpiTag = 9902;
-    PostRecoveryResult pr = {};
-
-    if (rank == 1) {
-        void* sendReq = nullptr;
-        ncclResult_t sendRet = ncclSuccess;
-        for (int attempt = 0; attempt < kMaxRetryAttempts; attempt++) {
-            sendRet = PostSend(sendComm, regBuf + kMsgSize, kMsgSize, 1602, mhandle, &sendReq);
-            if (sendRet != ncclSuccess || sendReq != nullptr) break;
-            usleep(kPollIntervalUs);
-        }
-
-        if (sendRet == ncclSuccess && sendReq != nullptr) {
-            for (int poll = 0; poll < 500; poll++) {
-                int done = 0, sz = 0;
-                ncclResult_t testRet = TestRequest(sendReq, &done, &sz);
-                if (testRet != ncclSuccess) { sendRet = testRet; break; }
-                if (done) break;
-                usleep(kPollIntervalUs);
-            }
-        }
-
-        int fatalCount = 0;
-        ncclIbCastFaultGetFatalCount(sendComm, &fatalCount);
-
-        pr.sendRet   = static_cast<int>(sendRet);
-        pr.fatalCount = fatalCount;
-
-        MPI_Send(&pr, sizeof(pr), MPI_BYTE, 0, kDev1Phase3MpiTag, MPI_COMM_WORLD);
-    }
-
-    if (rank == 0) {
-        for (int poll = 0; poll < 500; poll++) {
-            int done = 0, sz = 0;
-            if (TestRequest(recvReq3, &done, &sz) != ncclSuccess) break;
-            if (done) { phase3RecvDone = true; break; }
-            usleep(kPollIntervalUs);
-        }
-
-        MPI_Recv(&pr, sizeof(pr), MPI_BYTE, 1, kDev1Phase3MpiTag, MPI_COMM_WORLD,
-                 MPI_STATUS_IGNORE);
-
         EXPECT_TRUE(devState1AfterRecovery == kDevStateOk || devState1AfterRecovery == kDevStateRecovered)
             << "Recovery did not restore device 1 within timeout; "
             << "devState[1]=" << devState1AfterRecovery
             << " (expected Ok=0 or Recovered=4)";
+    }
 
-        EXPECT_EQ(pr.sendRet, static_cast<int>(ncclSuccess))
-            << "Post-recovery send failed (sendRet=" << pr.sendRet << ")";
-        EXPECT_EQ(pr.fatalCount, 0)
-            << "Fatal error during post-recovery traffic";
-
-        if (pr.sendRet == static_cast<int>(ncclSuccess)) {
-            EXPECT_TRUE(phase3RecvDone)
-                << "Post-recovery send succeeded but receiver did not get data";
+    if (devState1AfterRecovery != kDevStateOk && devState1AfterRecovery != kDevStateRecovered) {
+        if (rank == 0) {
+            ADD_FAILURE() << "Recovery did not succeed — skipping post-recovery traffic";
         }
-        if (phase3RecvDone) {
-            size_t offset = kMsgSize;
-            EXPECT_EQ(memcmp(recvBuf.data() + offset, sendBuf.data() + offset, kMsgSize), 0)
-                << "Data corruption in post-recovery message on device 1";
+        TeardownConnection(recvComm, listenComm, sendComm, mhandle);
+        return;
+    }
+
+    constexpr int kBaseTag = 1610;
+    for (int m = 0; m < kPostRecoveryMsgs; m++) {
+        char* msgSendBuf = sendBuf.data() + (m + 1) * kMsgSize;
+        char* msgRecvBuf = recvBuf.data() + (m + 1) * kMsgSize;
+        void* req = nullptr;
+
+        if (rank == 0) {
+            void*  bufs[1]    = {msgRecvBuf};
+            size_t sizes[1]   = {kMsgSize};
+            int    tags[1]    = {kBaseTag + m};
+            void*  handles[1] = {mhandle};
+            ASSERT_EQ(PostRecv(recvComm, 1, bufs, sizes, tags, handles, &req), ncclSuccess);
+            int sz = 0;
+            ASSERT_EQ(WaitForCompletion(req, &sz, 10000), ncclSuccess)
+                << "Post-recovery message " << m << " recv failed";
+        } else {
+            PostSendWithRetry(sendComm, msgSendBuf, kMsgSize, kBaseTag + m, mhandle, &req);
+            int sz = 0;
+            ASSERT_EQ(WaitForCompletion(req, &sz, 10000), ncclSuccess)
+                << "Post-recovery message " << m << " send failed";
         }
     }
 
+    int fatalCount = 0;
+    if (rank == 1) {
+        ncclIbCastFaultGetFatalCount(sendComm, &fatalCount);
+    }
+    MPI_Bcast(&fatalCount, 1, MPI_INT, /*root=*/1, MPI_COMM_WORLD);
+
     MPI_Barrier(MPI_COMM_WORLD);
-    if (rank == 0 && !phase3RecvDone)
-        DrainRecvRequest(recvReq3);
+
+    if (rank == 0) {
+        for (int m = 0; m < kPostRecoveryMsgs; m++) {
+            size_t offset = (m + 1) * kMsgSize;
+            EXPECT_EQ(memcmp(recvBuf.data() + offset, sendBuf.data() + offset, kMsgSize), 0)
+                << "Data corruption in post-recovery message " << m << " on device 1";
+        }
+        EXPECT_EQ(fatalCount, 0)
+            << "Fatal error during sustained post-recovery traffic on device 1";
+    }
+
     TeardownConnection(recvComm, listenComm, sendComm, mhandle);
 }
 

--- a/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
@@ -1838,15 +1838,17 @@ TEST_F(NetIbMPITest, RecoverySuccessRestoresTraffic) {
     }
     MPI_Barrier(MPI_COMM_WORLD);
 
-    // ── Phase 2: wait for recovery to complete (recoveryCount increments) ──
+    // ── Phase 2: wait for recovery to restore devState[0] ──
+    // Poll devState (set directly by recovery thread) rather than recoveryCount
+    // (which requires IbCastResiliencyProgress to be called from an active request).
     if (rank == 1) {
         struct ncclIbCastResiliencyState resState = {};
         for (int poll = 0; poll < kRecoveryPollIters; poll++) {
             ncclIbCastGetResiliencyState(sendComm, &resState);
-            if (resState.recoveryCount[0] >= 1) break;
+            if (resState.devState[0] == kDevStateOk || resState.devState[0] == kDevStateRecovered) break;
             usleep(10000);  // 10 ms
         }
-        rp.recoveryCount0 = resState.recoveryCount[0];
+        rp.recoveryCount0 = resState.devState[0];
         MPI_Send(&rp, sizeof(rp), MPI_BYTE, 0, kPostRecoveryMpiTag, MPI_COMM_WORLD);
     } else {
         MPI_Recv(&rp, sizeof(rp), MPI_BYTE, 1, kPostRecoveryMpiTag, MPI_COMM_WORLD,
@@ -1856,9 +1858,9 @@ TEST_F(NetIbMPITest, RecoverySuccessRestoresTraffic) {
 
     // ── Phase 3: send 20 messages to verify sustained traffic on restored QPs ──
     if (rank == 0) {
-        EXPECT_GE(rp.recoveryCount0, 1)
-            << "Recovery did not complete for device 0 within timeout; "
-            << "recoveryCount[0]=" << rp.recoveryCount0;
+        EXPECT_TRUE(rp.recoveryCount0 == kDevStateOk || rp.recoveryCount0 == kDevStateRecovered)
+            << "Recovery did not restore device 0 within timeout; "
+            << "devState[0]=" << rp.recoveryCount0;
     }
 
     if (rp.recoveryCount0 < 1) {
@@ -2227,10 +2229,10 @@ TEST_F(NetIbMPITest, RecoveryDeviceOneFailure) {
         struct ncclIbCastResiliencyState resState = {};
         for (int poll = 0; poll < kRecoveryPollIters; poll++) {
             ncclIbCastGetResiliencyState(sendComm, &resState);
-            if (resState.recoveryCount[1] >= 1) break;
+            if (resState.devState[1] == kDevStateOk || resState.devState[1] == kDevStateRecovered) break;
             usleep(10000);
         }
-        devState1AfterRecovery = resState.recoveryCount[1];
+        devState1AfterRecovery = resState.devState[1];
         MPI_Send(&devState1AfterRecovery, 1, MPI_INT, 0, kDev1PostRecoveryMpiTag, MPI_COMM_WORLD);
     } else {
         MPI_Recv(&devState1AfterRecovery, 1, MPI_INT, 1, kDev1PostRecoveryMpiTag, MPI_COMM_WORLD,
@@ -2297,9 +2299,9 @@ TEST_F(NetIbMPITest, RecoveryDeviceOneFailure) {
         MPI_Recv(&pr, sizeof(pr), MPI_BYTE, 1, kDev1Phase3MpiTag, MPI_COMM_WORLD,
                  MPI_STATUS_IGNORE);
 
-        EXPECT_GE(devState1AfterRecovery, 1)
-            << "Recovery did not complete for device 1 within timeout; "
-            << "recoveryCount[1]=" << devState1AfterRecovery;
+        EXPECT_TRUE(devState1AfterRecovery == kDevStateOk || devState1AfterRecovery == kDevStateRecovered)
+            << "Recovery did not restore device 1 within timeout; "
+            << "devState[1]=" << devState1AfterRecovery;
 
         EXPECT_EQ(pr.sendRet, static_cast<int>(ncclSuccess))
             << "Post-recovery send failed (sendRet=" << pr.sendRet << ")";

--- a/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
@@ -1755,7 +1755,7 @@ TEST_F(NetIbMPITest, RecoverySuccessRestoresTraffic) {
         int devState0AfterFailover;
     };
     struct RecoveryPhaseResult {
-        int devState0AfterRecovery;
+        int recoveryCount0;
     };
 
     FailoverPhaseResult fp = {};
@@ -1835,25 +1835,18 @@ TEST_F(NetIbMPITest, RecoverySuccessRestoresTraffic) {
             << "Phase 1: send should complete via surviving device after failover";
         EXPECT_EQ(fp.fatalCount, 0)
             << "Phase 1: no fatal error expected";
-        EXPECT_NE(fp.devState0AfterFailover, 0)
-            << "Phase 1: device 0 should not be Ok after failover";
     }
     MPI_Barrier(MPI_COMM_WORLD);
 
-    // ── Phase 2: wait for recovery to restore devState[0] to Ok ─────────
-    // Recovery runs in a background thread with its own CQ and QPs — neither
-    // rank's main thread needs to poll during the handshake.
-    // ncclIbResiliencyDevStateOk = 0, ncclIbResiliencyDevStateRecovered = 4
-    // Recovery thread sets Recovered(4); main progress path promotes to Ok(0)
-    // during IbCastTest. Accept either as success.
+    // ── Phase 2: wait for recovery to complete (recoveryCount increments) ──
     if (rank == 1) {
         struct ncclIbCastResiliencyState resState = {};
         for (int poll = 0; poll < kRecoveryPollIters; poll++) {
             ncclIbCastGetResiliencyState(sendComm, &resState);
-            if (resState.devState[0] == kDevStateOk || resState.devState[0] == kDevStateRecovered) break;
+            if (resState.recoveryCount[0] >= 1) break;
             usleep(10000);  // 10 ms
         }
-        rp.devState0AfterRecovery = resState.devState[0];
+        rp.recoveryCount0 = resState.recoveryCount[0];
         MPI_Send(&rp, sizeof(rp), MPI_BYTE, 0, kPostRecoveryMpiTag, MPI_COMM_WORLD);
     } else {
         MPI_Recv(&rp, sizeof(rp), MPI_BYTE, 1, kPostRecoveryMpiTag, MPI_COMM_WORLD,
@@ -1862,16 +1855,13 @@ TEST_F(NetIbMPITest, RecoverySuccessRestoresTraffic) {
     MPI_Barrier(MPI_COMM_WORLD);
 
     // ── Phase 3: send 20 messages to verify sustained traffic on restored QPs ──
-    // Recovery assertion first
     if (rank == 0) {
-        EXPECT_TRUE(rp.devState0AfterRecovery == kDevStateOk || rp.devState0AfterRecovery == kDevStateRecovered)
-            << "Recovery did not restore device 0 within timeout; "
-            << "devState[0]=" << rp.devState0AfterRecovery
-            << " (expected Ok=0 or Recovered=4)";
+        EXPECT_GE(rp.recoveryCount0, 1)
+            << "Recovery did not complete for device 0 within timeout; "
+            << "recoveryCount[0]=" << rp.recoveryCount0;
     }
 
-    // Skip sustained traffic if recovery failed
-    if (rp.devState0AfterRecovery != kDevStateOk && rp.devState0AfterRecovery != kDevStateRecovered) {
+    if (rp.recoveryCount0 < 1) {
         if (rank == 0) {
             ADD_FAILURE() << "Recovery did not succeed — skipping post-recovery traffic";
         }
@@ -2229,8 +2219,6 @@ TEST_F(NetIbMPITest, RecoveryDeviceOneFailure) {
             << "Phase 1: send should complete via device 0 after device 1 failover";
         EXPECT_EQ(fp.fatalCount, 0)
             << "Phase 1: no fatal error expected";
-        EXPECT_NE(fp.devState1AfterFailover, 0)
-            << "Phase 1: device 1 should not be Ok after failover";
     }
     MPI_Barrier(MPI_COMM_WORLD);
 
@@ -2239,10 +2227,10 @@ TEST_F(NetIbMPITest, RecoveryDeviceOneFailure) {
         struct ncclIbCastResiliencyState resState = {};
         for (int poll = 0; poll < kRecoveryPollIters; poll++) {
             ncclIbCastGetResiliencyState(sendComm, &resState);
-            if (resState.devState[1] == kDevStateOk || resState.devState[1] == kDevStateRecovered) break;
+            if (resState.recoveryCount[1] >= 1) break;
             usleep(10000);
         }
-        devState1AfterRecovery = resState.devState[1];
+        devState1AfterRecovery = resState.recoveryCount[1];
         MPI_Send(&devState1AfterRecovery, 1, MPI_INT, 0, kDev1PostRecoveryMpiTag, MPI_COMM_WORLD);
     } else {
         MPI_Recv(&devState1AfterRecovery, 1, MPI_INT, 1, kDev1PostRecoveryMpiTag, MPI_COMM_WORLD,
@@ -2309,10 +2297,9 @@ TEST_F(NetIbMPITest, RecoveryDeviceOneFailure) {
         MPI_Recv(&pr, sizeof(pr), MPI_BYTE, 1, kDev1Phase3MpiTag, MPI_COMM_WORLD,
                  MPI_STATUS_IGNORE);
 
-        EXPECT_TRUE(devState1AfterRecovery == kDevStateOk || devState1AfterRecovery == kDevStateRecovered)
-            << "Recovery did not restore device 1 within timeout; "
-            << "devState[1]=" << devState1AfterRecovery
-            << " (expected Ok=0 or Recovered=4)";
+        EXPECT_GE(devState1AfterRecovery, 1)
+            << "Recovery did not complete for device 1 within timeout; "
+            << "recoveryCount[1]=" << devState1AfterRecovery;
 
         EXPECT_EQ(pr.sendRet, static_cast<int>(ncclSuccess))
             << "Post-recovery send failed (sendRet=" << pr.sendRet << ")";

--- a/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
@@ -2097,10 +2097,10 @@ TEST_F(NetIbMPITest, RecoveryPendingWhileLinkDown) {
 // Test: RecoveryDeviceOneFailure
 //
 // Same as RecoverySuccessRestoresTraffic but faults device 1 (QP index 1)
-// instead of device 0. Sends 20 post-recovery messages. QP-to-device
-// mapping is interleaved (QP 0=dev 0, QP 1=dev 1, QP 2=dev 0...), so
-// this catches index-arithmetic bugs in IbCastPortRecoveryQpsToError,
-// IbCastPortRecoveryQpsRestore, and IbCastPortRecoveryContextInit.
+// instead of device 0. QP-to-device mapping is interleaved (QP 0=dev 0,
+// QP 1=dev 1, QP 2=dev 0...), so this catches index-arithmetic bugs in
+// IbCastPortRecoveryQpsToError, IbCastPortRecoveryQpsRestore, and
+// IbCastPortRecoveryContextInit that would only surface with device 1.
 // =============================================================================
 TEST_F(NetIbMPITest, RecoveryDeviceOneFailure) {
     ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
@@ -2134,8 +2134,7 @@ TEST_F(NetIbMPITest, RecoveryDeviceOneFailure) {
     SetupCastConnection(/*dev=*/mergedDev, &listenComm, &sendComm, &recvComm);
 
     constexpr size_t kMsgSize = 8192;
-    constexpr int    kPostRecoveryMsgs = 20;
-    const size_t     kBufSize = kMsgSize * (kPostRecoveryMsgs + 1);
+    const size_t     kBufSize = kMsgSize * 2;
     std::vector<char> sendBuf(kBufSize), recvBuf(kBufSize);
     for (size_t i = 0; i < kBufSize; i++) sendBuf[i] = static_cast<char>((i * 47 + 31) & 0xFF);
     memset(recvBuf.data(), 0, kBufSize);
@@ -2251,63 +2250,89 @@ TEST_F(NetIbMPITest, RecoveryDeviceOneFailure) {
     }
     MPI_Barrier(MPI_COMM_WORLD);
 
-    // ── Phase 3: send 20 messages to verify sustained traffic on restored QPs ──
+    // ── Phase 3: post-recovery send ──────────────────────────────────────
+    bool phase3RecvDone = false;
+    void* recvReq3 = nullptr;
+
     if (rank == 0) {
+        void*  bufs[1]    = {regBuf + kMsgSize};
+        size_t sizes[1]   = {kMsgSize};
+        int    tags[1]    = {1602};
+        void*  handles[1] = {mhandle};
+        ASSERT_EQ(PostRecv(recvComm, 1, bufs, sizes, tags, handles, &recvReq3), ncclSuccess);
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    struct PostRecoveryResult {
+        int sendRet;
+        int fatalCount;
+    };
+    static constexpr int kDev1Phase3MpiTag = 9902;
+    PostRecoveryResult pr = {};
+
+    if (rank == 1) {
+        void* sendReq = nullptr;
+        ncclResult_t sendRet = ncclSuccess;
+        for (int attempt = 0; attempt < kMaxRetryAttempts; attempt++) {
+            sendRet = PostSend(sendComm, regBuf + kMsgSize, kMsgSize, 1602, mhandle, &sendReq);
+            if (sendRet != ncclSuccess || sendReq != nullptr) break;
+            usleep(kPollIntervalUs);
+        }
+
+        if (sendRet == ncclSuccess && sendReq != nullptr) {
+            for (int poll = 0; poll < 500; poll++) {
+                int done = 0, sz = 0;
+                ncclResult_t testRet = TestRequest(sendReq, &done, &sz);
+                if (testRet != ncclSuccess) { sendRet = testRet; break; }
+                if (done) break;
+                usleep(kPollIntervalUs);
+            }
+        }
+
+        int fatalCount = 0;
+        ncclIbCastFaultGetFatalCount(sendComm, &fatalCount);
+
+        pr.sendRet   = static_cast<int>(sendRet);
+        pr.fatalCount = fatalCount;
+
+        MPI_Send(&pr, sizeof(pr), MPI_BYTE, 0, kDev1Phase3MpiTag, MPI_COMM_WORLD);
+    }
+
+    if (rank == 0) {
+        for (int poll = 0; poll < 500; poll++) {
+            int done = 0, sz = 0;
+            if (TestRequest(recvReq3, &done, &sz) != ncclSuccess) break;
+            if (done) { phase3RecvDone = true; break; }
+            usleep(kPollIntervalUs);
+        }
+
+        MPI_Recv(&pr, sizeof(pr), MPI_BYTE, 1, kDev1Phase3MpiTag, MPI_COMM_WORLD,
+                 MPI_STATUS_IGNORE);
+
         EXPECT_TRUE(devState1AfterRecovery == kDevStateOk || devState1AfterRecovery == kDevStateRecovered)
             << "Recovery did not restore device 1 within timeout; "
             << "devState[1]=" << devState1AfterRecovery
             << " (expected Ok=0 or Recovered=4)";
-    }
 
-    if (devState1AfterRecovery != kDevStateOk && devState1AfterRecovery != kDevStateRecovered) {
-        if (rank == 0) {
-            ADD_FAILURE() << "Recovery did not succeed — skipping post-recovery traffic";
+        EXPECT_EQ(pr.sendRet, static_cast<int>(ncclSuccess))
+            << "Post-recovery send failed (sendRet=" << pr.sendRet << ")";
+        EXPECT_EQ(pr.fatalCount, 0)
+            << "Fatal error during post-recovery traffic";
+
+        if (pr.sendRet == static_cast<int>(ncclSuccess)) {
+            EXPECT_TRUE(phase3RecvDone)
+                << "Post-recovery send succeeded but receiver did not get data";
         }
-        TeardownConnection(recvComm, listenComm, sendComm, mhandle);
-        return;
-    }
-
-    constexpr int kBaseTag = 1610;
-    for (int m = 0; m < kPostRecoveryMsgs; m++) {
-        char* msgSendBuf = sendBuf.data() + (m + 1) * kMsgSize;
-        char* msgRecvBuf = recvBuf.data() + (m + 1) * kMsgSize;
-        void* req = nullptr;
-
-        if (rank == 0) {
-            void*  bufs[1]    = {msgRecvBuf};
-            size_t sizes[1]   = {kMsgSize};
-            int    tags[1]    = {kBaseTag + m};
-            void*  handles[1] = {mhandle};
-            ASSERT_EQ(PostRecv(recvComm, 1, bufs, sizes, tags, handles, &req), ncclSuccess);
-            int sz = 0;
-            ASSERT_EQ(WaitForCompletion(req, &sz, 10000), ncclSuccess)
-                << "Post-recovery message " << m << " recv failed";
-        } else {
-            PostSendWithRetry(sendComm, msgSendBuf, kMsgSize, kBaseTag + m, mhandle, &req);
-            int sz = 0;
-            ASSERT_EQ(WaitForCompletion(req, &sz, 10000), ncclSuccess)
-                << "Post-recovery message " << m << " send failed";
+        if (phase3RecvDone) {
+            size_t offset = kMsgSize;
+            EXPECT_EQ(memcmp(recvBuf.data() + offset, sendBuf.data() + offset, kMsgSize), 0)
+                << "Data corruption in post-recovery message on device 1";
         }
     }
-
-    int fatalCount = 0;
-    if (rank == 1) {
-        ncclIbCastFaultGetFatalCount(sendComm, &fatalCount);
-    }
-    MPI_Bcast(&fatalCount, 1, MPI_INT, /*root=*/1, MPI_COMM_WORLD);
 
     MPI_Barrier(MPI_COMM_WORLD);
-
-    if (rank == 0) {
-        for (int m = 0; m < kPostRecoveryMsgs; m++) {
-            size_t offset = (m + 1) * kMsgSize;
-            EXPECT_EQ(memcmp(recvBuf.data() + offset, sendBuf.data() + offset, kMsgSize), 0)
-                << "Data corruption in post-recovery message " << m << " on device 1";
-        }
-        EXPECT_EQ(fatalCount, 0)
-            << "Fatal error during sustained post-recovery traffic on device 1";
-    }
-
+    if (rank == 0 && !phase3RecvDone)
+        DrainRecvRequest(recvReq3);
     TeardownConnection(recvComm, listenComm, sendComm, mhandle);
 }
 

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -971,6 +971,93 @@
       ]
     },
 
+    "resiliency_failover": {
+      "extends": "cast_base",
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_IB_RESILIENCY_PORT_FAILOVER": "1",
+        "NCCL_IB_MERGE_NICS": "1",
+        "NCCL_IB_QPS_PER_CONNECTION": "4",
+        "NCCL_IB_SPLIT_DATA_ON_QPS": "1"
+      },
+      "tests": [
+        {
+          "name": "Resiliency_FailoverErrorCodeWhitelist",
+          "description": "Validate non-fatal error code classification (WR_FLUSH_ERR, RETRY_EXC_ERR)",
+          "test_filter": "NetIbMPITest.FailoverErrorCodeWhitelist"
+        },
+        {
+          "name": "Resiliency_FailoverCqeErrorRecovered",
+          "description": "Core failover: inject CQE error on one device, traffic continues on surviving device",
+          "test_filter": "NetIbMPITest.FailoverCqeErrorRecovered"
+        },
+        {
+          "name": "Resiliency_FailoverSingleDeviceTopology",
+          "description": "Single-device topology (ndevs=1): error is fatal, no failover possible",
+          "test_filter": "NetIbMPITest.FailoverSingleDeviceTopology"
+        },
+        {
+          "name": "Resiliency_FailoverAllDevicesFailed",
+          "description": "All devices driven to ERR: connection becomes fatal",
+          "test_filter": "NetIbMPITest.FailoverAllDevicesFailed"
+        },
+        {
+          "name": "Resiliency_FailoverLargeMessageDataIntegrity",
+          "description": "Large message data integrity preserved after failover to surviving device",
+          "test_filter": "NetIbMPITest.FailoverLargeMessageDataIntegrity"
+        },
+        {
+          "name": "Resiliency_FailoverDeviceOneFailure",
+          "description": "Device 1 failure: device 0 continues sending, data integrity verified",
+          "test_filter": "NetIbMPITest.FailoverDeviceOneFailure"
+        },
+        {
+          "name": "Resiliency_FailoverMultiRequestInFlight",
+          "description": "Multiple in-flight requests during failover: all complete with correct data",
+          "test_filter": "NetIbMPITest.FailoverMultiRequestInFlight"
+        }
+      ]
+    },
+
+    "resiliency_recovery": {
+      "extends": "cast_base",
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_IB_RESILIENCY_PORT_FAILOVER": "1",
+        "NCCL_IB_RESILIENCY_PORT_RECOVERY": "1",
+        "NCCL_IB_MERGE_NICS": "1",
+        "NCCL_IB_QPS_PER_CONNECTION": "4",
+        "NCCL_IB_SPLIT_DATA_ON_QPS": "1"
+      },
+      "tests": [
+        {
+          "name": "Resiliency_RecoveryThreadStartedOnlyWithParam",
+          "description": "Recovery thread enabled only when PORT_RECOVERY=1 is set",
+          "test_filter": "NetIbMPITest.RecoveryThreadStartedOnlyWithParam"
+        },
+        {
+          "name": "Resiliency_RecoverySuccessRestoresTraffic",
+          "description": "Core recovery: inject error, QP destroy+recreate, traffic restored on recovered device",
+          "test_filter": "NetIbMPITest.RecoverySuccessRestoresTraffic"
+        },
+        {
+          "name": "Resiliency_RecoveryPendingWhileLinkDown",
+          "description": "Recovery stays in pending state while link remains down",
+          "test_filter": "NetIbMPITest.RecoveryPendingWhileLinkDown"
+        },
+        {
+          "name": "Resiliency_RecoveryDeviceOneFailure",
+          "description": "Device 1 recovery with per-device recovery counter verification",
+          "test_filter": "NetIbMPITest.RecoveryDeviceOneFailure"
+        },
+        {
+          "name": "Resiliency_RecoveryUdTimeoutExhaustsAttempts",
+          "description": "UD recovery timeout exhausts max attempts, device stays failed",
+          "test_filter": "NetIbMPITest.RecoveryUdTimeoutExhaustsAttempts"
+        }
+      ]
+    },
+
     "graph_capture_multi_node": {
       "extends": "default",
       "is_gtest": true,
@@ -1720,6 +1807,18 @@
       "name": "NET IB - Fault Injection (CAST path, QPS=4, splitData=1)",
       "description": "Per-QP fault injection on CAST multi-QP path: error propagation, RTT rebalancing, data integrity under delay",
       "config": "fault_inject_cast",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Resiliency Port Failover",
+      "description": "Port failover tests: error classification, CQE recovery, multi-device failover, data integrity under failure",
+      "config": "resiliency_failover",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Resiliency Port Recovery",
+      "description": "Port recovery tests: QP destroy+recreate, UD-based QPN exchange, recovery timeout exhaustion",
+      "config": "resiliency_recovery",
       "enabled": true
     },
     {


### PR DESCRIPTION
## Motivation

Port recovery feature doesn’t work on AINIC hardware. There are two blocking problems:

AINIC doesn’t support UC QPs. Recovery protocol should be implemented over UD QPs.

AINIC has a bug with QP recovery after an error. As a workaround, we should destroy broken QPs, recreate them from scratch and exchange QP numbers to continue data transfers.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

This PRs introduces new QP recovery mechanism that destroys and re-creates QPs and exchange QP information as part of recovery protocol. This is a temporal workaround to mitigate current AINIC fw limitations.

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

AICOMNET-238

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

- Resiliency unit testing on Thor2 and AINIC
- rccl-tests with manual link disruption

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

- Resiliency unit testing on Thor2 and AINIC **passes**.
- rccl-tests with manual link disruption is **in progress**.
<!-- Briefly summarize test outcomes. -->

```
Note: Google Test filter = *Failover*
  [==========] Running 7 tests from 1 test suite.
  [----------] 7 tests from NetIbMPITest
  [ RUN      ] NetIbMPITest.FailoverErrorCodeWhitelist
  [       OK ] NetIbMPITest.FailoverErrorCodeWhitelist (443 ms)
  [ RUN      ] NetIbMPITest.FailoverCqeErrorRecovered
  [       OK ] NetIbMPITest.FailoverCqeErrorRecovered (535 ms)
  [ RUN      ] NetIbMPITest.FailoverSingleDeviceTopology
  [       OK ] NetIbMPITest.FailoverSingleDeviceTopology (7269 ms)
  [ RUN      ] NetIbMPITest.FailoverAllDevicesFailed
  [       OK ] NetIbMPITest.FailoverAllDevicesFailed (8705 ms)
  [ RUN      ] NetIbMPITest.FailoverLargeMessageDataIntegrity
  [       OK ] NetIbMPITest.FailoverLargeMessageDataIntegrity (459 ms)
  [ RUN      ] NetIbMPITest.FailoverDeviceOneFailure
  [       OK ] NetIbMPITest.FailoverDeviceOneFailure (366 ms)
  [ RUN      ] NetIbMPITest.FailoverMultiRequestInFlight
  [       OK ] NetIbMPITest.FailoverMultiRequestInFlight (382 ms)
  [----------] 7 tests from NetIbMPITest (18163 ms total)
  [==========] 7 tests from 1 test suite ran. (18409 ms total)
  [  PASSED  ] 7 tests.

  Note: Google Test filter = *Recovery*
  [==========] Running 5 tests from 1 test suite.
  [----------] 5 tests from NetIbMPITest
  [ RUN      ] NetIbMPITest.RecoveryThreadStartedOnlyWithParam
  [       OK ] NetIbMPITest.RecoveryThreadStartedOnlyWithParam (401 ms)
  [ RUN      ] NetIbMPITest.RecoverySuccessRestoresTraffic
  [       OK ] NetIbMPITest.RecoverySuccessRestoresTraffic (914 ms)
  [ RUN      ] NetIbMPITest.RecoveryPendingWhileLinkDown
  [       OK ] NetIbMPITest.RecoveryPendingWhileLinkDown (467 ms)
  [ RUN      ] NetIbMPITest.RecoveryDeviceOneFailure
  [       OK ] NetIbMPITest.RecoveryDeviceOneFailure (20731 ms)
  [ RUN      ] NetIbMPITest.RecoveryUdTimeoutExhaustsAttempts
  [       OK ] NetIbMPITest.RecoveryUdTimeoutExhaustsAttempts (25718 ms)
  [----------] 5 tests from NetIbMPITest (48233 ms total)
  [==========] 5 tests from 1 test suite ran. (48495 ms total)
  [  PASSED  ] 5 tests.
```
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
