### PR TITLE
rocr: Add limited debug print

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -673,7 +673,7 @@ void GpuAgent::InitDerivedCuid() {
   }
 
 #else
-  debug_print("Secondary CUID not available: AMDCUID support not enabled.\n");
+  debug_print_n(1, "Secondary CUID not available: AMDCUID support not enabled.\n");
 #endif
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/utils.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/utils.h
@@ -129,7 +129,7 @@ static __forceinline unsigned long long int strtoull(const char* str,
 #if defined(__linux__)
 #define debug_warning_n(exp, limit)                                                                \
   do {                                                                                             \
-    static std::atomic<int> count(0);                                                              \
+    static std::atomic<unsigned int> count(0);                                                              \
     if (!(exp) && (limit == 0 || count < limit)) {                                                 \
       fprintf(stderr, "Warning: " STRING(exp) " in %s, " __FILE__ ":" STRING(__LINE__) "\n",       \
               __PRETTY_FUNCTION__);                                                                \
@@ -160,6 +160,21 @@ static __forceinline unsigned long long int strtoull(const char* str,
   do {                                                                                             \
     fprintf(stderr, fmt, ##__VA_ARGS__);                                                           \
   } while (false)
+#endif
+
+#ifdef NDEBUG
+#define debug_print_n(fmt, ...)                                                                      \
+  do {                                                                                             \
+  } while (false)
+#else
+#define debug_print_n(limit, fmt, ...)                                                             \
+  do {                                                                                             \
+    static std::atomic<unsigned int> count(0);                                                              \
+    if (limit == 0 || count < limit) {                                                             \
+      fprintf(stderr, fmt, ##__VA_ARGS__);                                                         \
+    count++;                                                                                       \
+  }                                                                                                \
+} while (false)
 #endif
 
 #ifdef NDEBUG


### PR DESCRIPTION
Add support for debug_print_n. Limit number of debug prints when AMDCUID library is missing.

## Motivation

Reduce number of debug prints for some types of logging