### PR TITLE
[rocprofiler-systems] Hide vendored binutils symbols to avoid collision with system libbfd

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/CMakeLists.txt
@@ -107,6 +107,11 @@ target_link_libraries(
         rocprofiler-systems::rocprofiler-systems-binary
 )
 
+target_link_options(
+    rocprofiler-systems-shared-library
+    PRIVATE "LINKER:--exclude-libs=ALL"
+)
+
 set_target_properties(
     rocprofiler-systems-shared-library
     PROPERTIES


### PR DESCRIPTION
## Motivation

Users running rocprof-sys-run against ROCm 7.2.0 workloads that pull in UCX (CONQUEST, any OpenMPI-based HPC app) see a SIGSEGV during pre-main DSO initialization, before any application code runs. The crash address looks like a binutils bug at first glance: with binutils 2.42 it fires in `_bfd_x86_elf_get_synthetic_symtab` at offset 0x75953; bumping to binutils 2.46 changes the address to `_bfd_elf_link_hide_symbol+0xc` but the process still dies. The real cause is not binutils.

## Technical Details

`librocprof-sys.so` statically links the vendored binutils libraries. By default, every global symbol pulled in from those static archives gets promoted to the dynamic symbol table of the resulting shared object, so we end up exporting around 3700 `bfd_*` / `_bfd_*` / `elf_*` names as if they were part of our public API. When an HPC process later loads UCX, UCX's `DT_NEEDED` brings in the system `libbfd-2.38-system.so`. Now both DSOs export the same names, and the ELF "first definition in global scope wins" rule means libbfd-2.38's internal relocations get bound to OUR vendored 2.46 implementations. The two libraries disagree on struct field offsets (`bfd_link_info`, `elf_link_hash_entry` both grew fields between 2.38 and 2.46), so libbfd-2.38 calls into 2.46 helpers passing the wrong layout, the helper reads at the wrong offset, and the process segfaults.

The fix adds `-Wl,--exclude-libs=ALL` to the `rocprofiler-systems-shared-library` target. That tells the linker to keep symbols from static archives `local` in the produced `.so` instead of promoting them to `.dynsym`. They still exist in `.text` and are reachable via direct PC-relative calls from within `librocprof-sys.so`, so our internal callers of the vendored binutils continue to work. But they vanish from the dynamic symbol table, so the loader cannot pick them up for global lookups, and libbfd-2.38 binds to its own implementations as it should. No runtime cost. No source change to the vendored binutils.

This is a link-time discipline fix, not a workaround. The public ABI of librocprof-sys is `rocprofsys_*`, `ROCPROFSYS_*`, `rocprofiler_configure`, `kokkosp_*`. Everything else is implementation detail and should not have been exported.

## JIRA

ROCM-21218

## Test Plan

Validated on DiRAC PPaC MI300A (aac6), nodes ppac-pl1-s25-40 and ppac-pl1-s24-16, ROCm 7.2.0, CONQUEST f-AMD-GPU branch. Four-axis validation: negative control (revert patch, crash returns identically); cross-node (second host runs clean); LD_DEBUG=bindings (libbfd-2.38 binds 18+ `bfd_*` symbols to itself, zero bindings reach into librocprof-sys); ctest regression suite.

## Test Result

Before patch: exit 139 with `_bfd_elf_link_hide_symbol+0xc` backtrace on s25-40. After patch: exit 0, full Perfetto trace produced, all four sentinels (`_bfd_x86_elf_get_synthetic_symtab`, `_bfd_elf_link_hide_symbol`, `Caught signal 11`, `Segmentation fault`) at zero. Reverting the `.so` reproduces the crash, confirming causality. `bfd_*` symbol count in dynamic exports went from 355 to 0; `rocprofsys_*` / `ROCPROFSYS_*` / `kokkosp_*` / `rocprofiler_configure` count unchanged at 46. ctest: 185 passed, 167 skipped (hardware absent), 3 failed (`causal-e2e` statistical timing flakes, unrelated to BFD/unwind/load).

## Checklist

- [x] Tests pass locally
- [x] Validated against the ROCM-21218 reproducer
- [x] No changes to public API
- [x] No source-level changes outside CMake
