### PR TITLE
[rocjpeg] add log levels to the doc

### DIFF
--- a/projects/rocjpeg/docs/index.rst
+++ b/projects/rocjpeg/docs/index.rst
@@ -34,6 +34,7 @@ rocJPEG is delivered as part of `TheRock <https://github.com/ROCm/TheRock>`_. Th
   .. grid-item-card:: Reference
 
     * :doc:`rocJPEG environment variables <./reference/rocJPEG-env-vars>`
+    * :doc:`rocJPEG logging levels <./reference/rocJPEG-logging-controls>`
     * :doc:`rocJPEG subsampling and hardware capabilities <./reference/rocjpeg-formats-and-architectures>`
     * :doc:`rocJPEG API library <../doxygen/html/files>`
     * :doc:`rocJPEG Functions <../doxygen/html/globals>`

--- a/projects/rocjpeg/docs/reference/rocJPEG-env-vars.rst
+++ b/projects/rocjpeg/docs/reference/rocJPEG-env-vars.rst
@@ -21,7 +21,7 @@ The following environment variables affect the rocJPEG runtime.
         | Hardware color-space conversion is off by default regardless of the number of cores. 
         | Not used for ``CSS_440`` (4:4:0) chroma subsampling even when enabled.
    * - ``ROCJPEG_LOG_LEVEL``
-     - | Sets the maximum severity of log messages. Level defines the maximum severity of log messages to output.
+     - | Sets the maximum severity of log messages. Each level defines the maximum severity of log messages to output.
        | ``0``: Output critical messages only (default) 
        | ``1``: Output critical and error messages
        | ``2``: Output critical, error, and warning messages

--- a/projects/rocjpeg/docs/reference/rocJPEG-env-vars.rst
+++ b/projects/rocjpeg/docs/reference/rocJPEG-env-vars.rst
@@ -21,7 +21,7 @@ The following environment variables affect the rocJPEG runtime.
         | Hardware color-space conversion is off by default regardless of the number of cores. 
         | Not used for ``CSS_440`` (4:4:0) chroma subsampling even when enabled.
    * - ``ROCJPEG_LOG_LEVEL``
-     - | Sets the maximum severity of log messages during decoding. The log level defines the maximum severity of log messages to output.
+     - | Sets the maximum severity of log messages. Level defines the maximum severity of log messages to output.
        | ``0``: Output critical messages only (default) 
        | ``1``: Output critical and error messages
        | ``2``: Output critical, error, and warning messages

--- a/projects/rocjpeg/docs/reference/rocJPEG-env-vars.rst
+++ b/projects/rocjpeg/docs/reference/rocJPEG-env-vars.rst
@@ -13,13 +13,21 @@ The following environment variables affect the rocJPEG runtime.
    :widths: 28 72
 
    * - Environment variable
-     - Values
+     - Values 
+   * - ``HIP_VISIBLE_DEVICES``
+     - | Comma-separated list of GPU indices. Parsed when ``ROCR_VISIBLE_DEVICES`` isn't set.
    * - ``ROCJPEG_ENABLE_VCN_HW_CSC``
      -  | ``1``: Enables hardware color-space conversion when there are eight or more JPEG cores and RGB or RGB planar output is in use.
         | Hardware color-space conversion is off by default regardless of the number of cores. 
         | Not used for ``CSS_440`` (4:4:0) chroma subsampling even when enabled.
+   * - ``ROCJPEG_LOG_LEVEL``
+     - | Sets the maximum severity of log messages during decoding. The log level defines the maximum severity of log messages to output.
+       | ``0``: Output critical messages only (default) 
+       | ``1``: Output critical and error messages
+       | ``2``: Output critical, error, and warning messages
+       | ``3``: Output critical, error, warning, and info messages
+       | ``4``: Output critical, error, warning, info, and debug messages 
    * - ``ROCR_VISIBLE_DEVICES``
      - | Takes a comma-separated list of GPU indices. 
        | When set, the VAAPI decoder path parses this list before it falls back to ``HIP_VISIBLE_DEVICES``. 
-   * - ``HIP_VISIBLE_DEVICES``
-     - | Comma-separated list of GPU indices. Parsed when ``ROCR_VISIBLE_DEVICES`` isn't set.
+

--- a/projects/rocjpeg/docs/reference/rocJPEG-logging-controls.rst
+++ b/projects/rocjpeg/docs/reference/rocJPEG-logging-controls.rst
@@ -20,4 +20,4 @@ The log level defines the maximum severity of log messages to output. For exampl
 
 .. code:: shell
 
-    ROCJPEG_LOG_LEVEL = 2
+    ROCJPEG_LOG_LEVEL=2

--- a/projects/rocjpeg/docs/reference/rocJPEG-logging-controls.rst
+++ b/projects/rocjpeg/docs/reference/rocJPEG-logging-controls.rst
@@ -1,0 +1,23 @@
+.. meta::
+  :description: rocJPEG logging controls
+  :keywords: rocJPEG, core APIs, logging, AMD, ROCm
+
+********************************************************************
+rocJPEG logging control
+********************************************************************
+
+rocJPEG can be configured to output different levels of log messages using the ``ROCJPEG_LOG_LEVEL`` environment variable.
+
+The logging levels are:
+
+| 0: Critical (Default level; output critical messages only)
+| 1: Error (Output critical and error messages)
+| 2: Warning (Output critical, error, and warning messages)
+| 3: Info (Output critical, error, warning, and info messages)
+| 4: Debug (Output critical, error, warning, info, and debug messages)
+
+The log level defines the maximum severity of log messages to output. For example, to output warning and error messages as well as critical messages, set ``ROCJPEG_LOG_LEVEL`` to 2:
+
+.. code:: shell
+
+    ROCJPEG_LOG_LEVEL = 2

--- a/projects/rocjpeg/docs/sphinx/_toc.yml.in
+++ b/projects/rocjpeg/docs/sphinx/_toc.yml.in
@@ -34,6 +34,8 @@ subtrees:
   entries:
   - file: reference/rocJPEG-env-vars.rst
     title: Environment variables
+  - file: reference/rocJPEG-logging-controls.rst
+    title: Logging levels 
   - file: reference/rocjpeg-formats-and-architectures.rst
     title: Subsampling and hardware capabilities
   - file: doxygen/html/files


### PR DESCRIPTION
## Motivation

In #6082, log levels were added to rocJPEG. This adds documentation about the log levels in a dedicated topic and in the env var topic.