### PR TITLE
rocrtst: Skip IPC test under ASAN as it does not support fork()

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/functional/ipc.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/ipc.cc
@@ -189,6 +189,14 @@ static void ClearShared(Shared *s) {
 void IPCTest::SetUp(void) {
   if (!checkPlatformFiltering()) return;
 
+#ifdef ROCRTST_ASAN
+  // IPC test uses fork() which is unsupported under ASAN as ASAN's shadow
+  // memory state becomes inconsistent after fork, causing failure on free
+  std::cout << "Skipping IPC test under ASAN (fork unsupported)." << std::endl;
+  test_skipped_ = true;
+  return;
+#endif
+
   hsa_status_t err;
 
   // Allow user to trigger a failure


### PR DESCRIPTION
Make `test_skipped_` true as AddressSanitizer does not support fork().

JIRA ID: [ROCM-25258](https://amd-hub.atlassian.net/browse/ROCM-25258)

[ROCM-25258]: https://amd-hub.atlassian.net/browse/ROCM-25258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ