### PR TITLE
[rocprofiler-systems] wire ccache via CMAKE_<LANG>_COMPILER_LAUNCHER

### DIFF
--- a/projects/rocprofiler-systems/CMakeLists.txt
+++ b/projects/rocprofiler-systems/CMakeLists.txt
@@ -239,6 +239,9 @@ rocprofiler_systems_add_option(CMAKE_INSTALL_RPATH_USE_LINK_PATH
 set(CMAKE_INSTALL_MESSAGE "LAZY" CACHE STRING "Installation message")
 mark_as_advanced(CMAKE_INSTALL_MESSAGE)
 
+rocprofiler_systems_add_option(ROCPROFSYS_USE_CCACHE
+    "Auto-wire ccache as the compiler launcher when present" ON
+)
 rocprofiler_systems_add_option(ROCPROFSYS_USE_CLANG_TIDY "Enable clang-tidy" OFF)
 rocprofiler_systems_add_option(ROCPROFSYS_USE_BFD
     "Enable BFD support (map call-stack samples to LOC)" ON

--- a/projects/rocprofiler-systems/cmake/BuildSettings.cmake
+++ b/projects/rocprofiler-systems/cmake/BuildSettings.cmake
@@ -15,6 +15,29 @@ include(Compilers)
 include(FindPackageHandleStandardArgs)
 include(MacroUtilities)
 
+# Auto-wire ccache when present so warm rebuilds hit cache.
+# Skip if user has already set a compiler launcher (don't clobber distcc, sccache, etc.).
+if(ROCPROFSYS_USE_CCACHE)
+    find_program(ROCPROFSYS_CCACHE_PROGRAM ccache)
+    if(ROCPROFSYS_CCACHE_PROGRAM)
+        message(STATUS "Using ccache: ${ROCPROFSYS_CCACHE_PROGRAM}")
+        if(NOT DEFINED CMAKE_C_COMPILER_LAUNCHER)
+            set(CMAKE_C_COMPILER_LAUNCHER
+                "${ROCPROFSYS_CCACHE_PROGRAM}"
+                CACHE STRING
+                "C compiler launcher"
+            )
+        endif()
+        if(NOT DEFINED CMAKE_CXX_COMPILER_LAUNCHER)
+            set(CMAKE_CXX_COMPILER_LAUNCHER
+                "${ROCPROFSYS_CCACHE_PROGRAM}"
+                CACHE STRING
+                "C++ compiler launcher"
+            )
+        endif()
+    endif()
+endif()
+
 rocprofiler_systems_add_option(
     ROCPROFSYS_BUILD_DEVELOPER "Extra build flags for development like -Werror"
     ${ROCPROFSYS_BUILD_CI}


### PR DESCRIPTION
## Motivation

ccache was installed in dev environments but never wired into the rocprof-sys build because CMake never set CMAKE_<LANG>_COMPILER_LAUNCHER. Cold rebuilds compiled every TU from scratch. This PR is the CMake half of the split: auto-detect ccache and inject the launcher when the user has not already configured one. Expected steady-state speedup is 5-10x on warm-cache full rebuilds.

## Technical Details

projects/rocprofiler-systems/cmake/BuildSettings.cmake adds 14 LOC: find_program(CCACHE_PROGRAM ccache) followed by guarded set() of CMAKE_C_COMPILER_LAUNCHER and CMAKE_CXX_COMPILER_LAUNCHER. The guards check NOT DEFINED so any user-supplied launcher (distcc, sccache, custom wrapper) is preserved. When ccache is absent the block is a no-op.

## JIRA

None.

## Test Plan

Configure with the Ninja generator on a host that has ccache installed. Confirm CMAKE_C_COMPILER_LAUNCHER and CMAKE_CXX_COMPILER_LAUNCHER in CMakeCache.txt resolve to the ccache binary. Confirm compile_commands.json prefixes compile lines with ccache. Run `ccache -z`, build cold, delete object files, build warm, confirm direct cache hits.

## Test Result

ccache 4.9.1 at /usr/bin/ccache. Configure (Ninja, Release, full external deps) emitted CMAKE_CXX_COMPILER_LAUNCHER:STRING=/usr/bin/ccache and CMAKE_C_COMPILER_LAUNCHER:STRING=/usr/bin/ccache. Cold build of timemory-common-static after `ccache -z` reported 16/16 cacheable calls all misses. After deleting object files, zeroing stats, and rebuilding, ccache reported 6/6 cacheable calls all direct hits.

## Checklist

- [x] Launcher only set when not already defined by the user.
- [x] No-op when ccache is absent.
- [x] Verified launcher in CMakeCache.txt and compile_commands.json.
- [x] Verified cache populates on cold build and hits on warm rebuild.
- [x] Pre-commit hooks pass.
