### PR TITLE
Re-enable gfx950 RCCL multi-node CI and disable unstable gfx94X multinode tests

### DIFF
--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -120,7 +120,8 @@ jobs:
 
   therock-test-linux-multi-node:
     name: "Test multi-node"
-    if: ${{ inputs.amdgpu_families == 'gfx94X-dcgpu' || inputs.amdgpu_families == 'gfx950-dcgpu' }}
+    # TODO: Re-enable gfx94X-dcgpu multi-node tests once the cluster is stable again.
+    if: ${{ inputs.amdgpu_families == 'gfx950-dcgpu' }}
     permissions:
       contents: read
       id-token: write
@@ -129,7 +130,7 @@ jobs:
     with:
       amdgpu_families: ${{ inputs.amdgpu_families }}
       artifact_group: ${{ inputs.artifact_group }}
-      test_runs_on: ${{ inputs.amdgpu_families == 'gfx950-dcgpu' && 'ruby-linux-slurm-scale-runner' || 'linux-vultr-mi325-scale-runner' }}
+      test_runs_on: ruby-linux-slurm-scale-runner
       artifact_run_id: ${{ github.run_id }}
 
   therock-test-linux-single-node:

--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -120,7 +120,7 @@ jobs:
 
   therock-test-linux-multi-node:
     name: "Test multi-node"
-    if: ${{ inputs.amdgpu_families == 'gfx94X-dcgpu' }}
+    if: ${{ inputs.amdgpu_families == 'gfx94X-dcgpu' || inputs.amdgpu_families == 'gfx950-dcgpu' }}
     permissions:
       contents: read
       id-token: write
@@ -129,7 +129,7 @@ jobs:
     with:
       amdgpu_families: ${{ inputs.amdgpu_families }}
       artifact_group: ${{ inputs.artifact_group }}
-      test_runs_on: linux-vultr-mi325-scale-runner # Disabling gfx950 runner till lab move completes
+      test_runs_on: ${{ inputs.amdgpu_families == 'gfx950-dcgpu' && 'ruby-linux-slurm-scale-runner' || 'linux-vultr-mi325-scale-runner' }}
       artifact_run_id: ${{ github.run_id }}
 
   therock-test-linux-single-node:

--- a/.github/workflows/therock-rccl-test-packages-multi-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-multi-node.yml
@@ -75,6 +75,9 @@ jobs:
               ;;
           esac
 
+      # Only needed for gfx94X, which runs CVS tests directly from this workflow
+      # and can leave orphan MPI/RCCL processes after failures or cancellations.
+      # gfx950 uses the Slurm-backed ci-entrypoint.sh flow, so Slurm handles cleanup.
       - name: Cleanup orphan RCCL/MPI processes
         if: ${{ inputs.amdgpu_families == 'gfx94X-dcgpu' }}
         run: |

--- a/.github/workflows/therock-rccl-test-packages-multi-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-multi-node.yml
@@ -76,7 +76,7 @@ jobs:
           esac
 
       - name: Cleanup orphan RCCL/MPI processes
-        if: always()
+        if: ${{ inputs.amdgpu_families == 'gfx94X-dcgpu' }}
         run: |
           echo "Cleaning up orphan processes..."
           pkill -9 -f prterun || true

--- a/projects/rccl/.github/workflows/therock-ci-linux.yml
+++ b/projects/rccl/.github/workflows/therock-ci-linux.yml
@@ -91,6 +91,7 @@ jobs:
       - name: Report
         #if: ${{ !cancelled() }}
         run: |
+          echo "Test"
           echo "Full SDK du:"
           echo "------------"
           du -h -d 1 build/dist/rocm

--- a/projects/rccl/.github/workflows/therock-ci-linux.yml
+++ b/projects/rccl/.github/workflows/therock-ci-linux.yml
@@ -91,7 +91,6 @@ jobs:
       - name: Report
         #if: ${{ !cancelled() }}
         run: |
-          echo "Test"
           echo "Full SDK du:"
           echo "------------"
           du -h -d 1 build/dist/rocm


### PR DESCRIPTION
## Summary

Re-enables multi-node RCCL CI coverage for `gfx950-dcgpu` while temporarily disabling `gfx94X-dcgpu` multi-node testing.

`gfx94X-dcgpu` multi-node tests are currently unstable due to cluster issues, so this change limits the reusable multi-node RCCL workflow to `gfx950-dcgpu` until the cluster is stable again.

## Changes

- Enables the multi-node RCCL test job for `gfx950-dcgpu`.
- Temporarily disables `gfx94X-dcgpu` multi-node RCCL tests.
- Routes `gfx950-dcgpu` multi-node tests to the restored Slurm-backed runner:
  - `ruby-linux-slurm-scale-runner`
- Keeps the existing build → artifact upload → test dependency flow.
- Keeps `gfx950-dcgpu` excluded from the single-node test path, so it only runs through the intended multi-node workflow.

## Motivation

`gfx950-dcgpu` CI coverage was previously disabled while runner/lab availability was being restored. The runner is now available again, so this brings back automated `gfx950-dcgpu` multi-node RCCL validation.

At the same time, `gfx94X-dcgpu` multi-node testing is temporarily disabled because the cluster is not currently stable enough for reliable CI runs.

## Testing

- Verified the reusable multi-node workflow already contains the `gfx950-dcgpu` setup and execution path.
- Verified the restored runner service is running under the correct user.
- Verified artifact install and Slurm submission issues caused by previous root-owned files were cleaned up.
- Confirmed `gfx950-dcgpu` is still excluded from the single-node test job.

Passing Test run: https://github.com/ROCm/rocm-systems/actions/runs/26540482055/job/78319631051