### PR TITLE
rocjitsu: SIMD fast-path enablement

### DIFF
--- a/emulation/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/CMakeLists.txt
@@ -223,6 +223,7 @@ target_link_libraries(
         rocjitsu_plugin_logging
         rocjitsu_vm_risc_v
         rocjitsu_config
+        util
         flatbuffers
         Threads::Threads
 )

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -260,7 +260,9 @@ class CodeGenerator:
         os.makedirs(out_dir, exist_ok=True)
         guard = f'ROCJITSU_ISA_ARCH_AMDGPU_{arch.upper()}_VOPD_H_'
 
-        header = textwrap.dedent('''
+        header = (
+            textwrap.dedent(
+                '''
             // Copyright (c) 2026 Advanced Micro Devices, Inc.
             // SPDX-License-Identifier: MIT
             //
@@ -337,9 +339,16 @@ class CodeGenerator:
             } // namespace rocjitsu
 
             #endif // @GUARD@
-            ''').lstrip().replace('@ARCH@', arch).replace('@GUARD@', guard)
+            '''
+            )
+            .lstrip()
+            .replace('@ARCH@', arch)
+            .replace('@GUARD@', guard)
+        )
 
-        impl = textwrap.dedent('''
+        impl = (
+            textwrap.dedent(
+                '''
             // Copyright (c) 2026 Advanced Micro Devices, Inc.
             // SPDX-License-Identifier: MIT
             //
@@ -745,7 +754,11 @@ class CodeGenerator:
 
             } // namespace @ARCH@
             } // namespace rocjitsu
-            ''').lstrip().replace('@ARCH@', arch)
+            '''
+            )
+            .lstrip()
+            .replace('@ARCH@', arch)
+        )
 
         with open(os.path.join(out_dir, 'vopd.h'), 'w') as f:
             f.write(header)
@@ -1319,7 +1332,8 @@ class CodeGenerator:
     def _emit_gfx1250_matrix_fmt_helpers() -> str:
         """Emit C++ helpers for gfx1250 VOP3P packed and matrix quirks."""
         return (
-            textwrap.dedent('''\
+            textwrap.dedent(
+                '''\
             namespace {
             struct PkF32Words {
               uint32_t lo;
@@ -1338,7 +1352,8 @@ class CodeGenerator:
               const uint64_t raw = operand.read_lane64(wf, lane);
               return {static_cast<uint32_t>(raw), static_cast<uint32_t>(raw >> 32)};
             }
-            ''')
+            '''
+            )
             + (
                 'const char *gfx1250_matrix_fmt_name(uint32_t fmt) {\n'
                 '  switch (fmt) {\n'
@@ -1553,7 +1568,8 @@ class CodeGenerator:
 
     @staticmethod
     def _emit_gfx1250_scaled_wmma_vop3px2_class() -> str:
-        return textwrap.dedent('''\
+        return textwrap.dedent(
+            '''\
             class VWmmaScaleF3216x16x128F8f6f4Vop3px2 : public Vop3p {
             public:
               VWmmaScaleF3216x16x128F8f6f4Vop3px2(const MachineInst *inst);
@@ -1569,11 +1585,13 @@ class CodeGenerator:
               OpEncoding scale_inst_;
               std::array<uint32_t, 4> raw_words_{};
             };
-            ''')
+            '''
+        )
 
     @staticmethod
     def _emit_gfx1250_scaled_wmma_vop3px2_impls() -> str:
-        return textwrap.dedent('''\
+        return textwrap.dedent(
+            '''\
             VWmmaScaleF3216x16x128F8f6f4Vop3px2::VWmmaScaleF3216x16x128F8f6f4Vop3px2(const MachineInst *inst)
                 : Vop3p("v_wmma_scale_f32_16x16x128_f8f6f4", reinterpret_cast<const OpEncoding *>(inst + 2),
                         make_exec_fn<VWmmaScaleF3216x16x128F8f6f4Vop3px2>()),
@@ -1683,11 +1701,13 @@ class CodeGenerator:
               if (!dispatched)
                 throw util::UnimplementedInst(mnemonic());
             }
-            ''')
+            '''
+        )
 
     @staticmethod
     def _emit_gfx1250_scaled_wmma_vop3px2_decoder_helpers() -> str:
-        return textwrap.dedent('''\
+        return textwrap.dedent(
+            '''\
             namespace {
 
             bool isWmmaScaleF32F8f6f4Vop3px2(const MachineInst *opcode) {
@@ -1700,7 +1720,8 @@ class CodeGenerator:
             }
 
             } // namespace
-            ''')
+            '''
+        )
 
     def _gen_execute_body(
         self, inst: Instruction, sem: InstructionSemantics, enc_name: str = ''
@@ -1783,7 +1804,6 @@ class CodeGenerator:
                 'scalar_cvt_pkrtz_f16_f32',
                 'scalar_saveexec',
                 'scalar_bfe',
-                'vector_cmp_class',
                 'vector_swap',
                 'vector_mov',
                 'vector_binop',
@@ -1816,29 +1836,28 @@ class CodeGenerator:
                     if 'omod' in inst_fields:
                         ef.add('omod')
                     sema_block = enrich_block(sema_block, enc_field_names=frozenset(ef))
-                omap_dtype = dtype
-                omap_kwargs = {}
-                name_lower = inst.name.lower()
-                # AMD naming: V_CVT_DST_SRC — last suffix is source type
-                if name_lower.endswith('_f64'):
-                    omap_kwargs['src_width'] = 64
-                elif 'cvt_f64_' in name_lower:
-                    omap_kwargs['dst_width'] = 64
-                if 'frexp_exp_i32_f64' in name_lower:
-                    omap_kwargs['src_width'] = 64
-                elif 'frexp_mant_f64' in name_lower:
-                    omap_kwargs['src_width'] = 64
-                    omap_kwargs['dst_width'] = 64
-                if cls == 'scalar_bitcmp':
-                    omap_kwargs['src_widths'] = {1: 32}
-                omap_kwargs['src_reg_classes'] = {
+                # Preserve 6470's scalar_saveexec -> b64 dtype fix. Per-operand
+                # bit widths (op_widths) subsume the old src_width/dst_width name
+                # heuristics: mixed-width instructions (e.g. the f64<->32-bit
+                # conversions, frexp_*_f64) bind each operand to its own declared
+                # lane width via op.size instead of a single instruction-level
+                # dtype width.
+                omap_dtype = 'b64' if cls == 'scalar_saveexec' else dtype
+                op_widths = {op.name: op.size for op in inst.operands}
+                src_reg_classes = {
                     i: _semantic_reg_class(opnd) for i, opnd in enumerate(src_operands)
                 }
-                omap_kwargs['dst_reg_classes'] = {
+                dst_reg_classes = {
                     i: _semantic_reg_class(opnd) for i, opnd in enumerate(dst_operands)
                 }
                 omap = OperandMap.from_operand_names(
-                    src_ops, dst_ops, sema_block.pragma, omap_dtype, **omap_kwargs
+                    src_ops,
+                    dst_ops,
+                    sema_block.pragma,
+                    omap_dtype,
+                    op_widths,
+                    src_reg_classes,
+                    dst_reg_classes,
                 )
                 lctx = LoweringContext(exec_model=sema_block.pragma, operand_map=omap)
                 if (
@@ -4883,12 +4902,35 @@ class CodeGenerator:
                         can_share = self._can_share_execute(
                             inst.mnemonic, inst, enc.enc_name
                         )
+                        # Ops with an arch-portable SIMD fast-path probe must
+                        # route through the shared execute template even when
+                        # _can_share_execute is False for this ISA: the probe
+                        # lives only in the shared kernel (simd_probe_line is
+                        # emitted in _write_shared_execute_templates), and
+                        # delegating keeps the DPP/SDWA cleanup + postamble
+                        # running around the call (an inlined body with the
+                        # probe's early `return` would skip them). Without this,
+                        # the dst-accumulate v_fmac_f64 / v_fmac_f32 / v_mac_*
+                        # family inlines its scalar loop on CDNA4 and the probe
+                        # is dead code. Only *arch-portable* probes qualify: the
+                        # inline-literal FMA forms (v_fmaak/fmamk/madak/madmk)
+                        # read the literal through an ISA-divergent member, so a
+                        # single shared body can't serve every ISA — those are
+                        # left to the genuine shared plan.
+                        from amdisa.codegen.execute.simd_codegen import (
+                            simd_probe_arch_portable as _simd_probe_arch_portable,
+                        )
+
+                        _enc_key_for_probe = enc.enc_name.lower().replace('enc_', '')
+                        _portable_probe = _simd_probe_arch_portable(
+                            f'{inst.mnemonic}_{_enc_key_for_probe}'
+                        )
                         if body_throws:
                             exec_impl = cgen.Line(
                                 f'void {inst.fmt_name}::execute_impl'
                                 f'(amdgpu::Wavefront &wf) {{ (void)wf; throw util::UnimplementedInst(mnemonic()); }}'
                             )
-                        elif can_share:
+                        elif can_share or _portable_probe:
                             enc_key = enc.enc_name.lower().replace('enc_', '')
                             tmpl_name = f'{inst.mnemonic}_{enc_key}'
                             exec_impl = cgen.Line(
@@ -4899,13 +4941,38 @@ class CodeGenerator:
                                 f'{_dpp_cleanup}'
                                 f'{_sdwa_postamble}}}'
                             )
+                            # Store the shared template body. First writer wins:
+                            # for a can_share op that is its plan owner; for a
+                            # force-shared portable probe op (no plan owner on any
+                            # ISA) the body is arch-independent, so whichever ISA
+                            # writes first is correct. That arch-independence is an
+                            # invariant, not a hope: verify it. If a later ISA
+                            # produces a DIFFERENT body for the same
+                            # (mnemonic, enc) key, the "shared" body is silently
+                            # arch-dependent and emitting just the first writer's
+                            # version would miscompile the other arch. Assert
+                            # instead of discarding.
                             body_key = (inst.mnemonic, enc.enc_name)
-                            self._shared_execute_bodies[body_key] = (
-                                inst,
-                                sem,
-                                body,
-                                enc.enc_name,
-                            )
+                            existing = self._shared_execute_bodies.get(body_key)
+                            if existing is None:
+                                self._shared_execute_bodies[body_key] = (
+                                    inst,
+                                    sem,
+                                    body,
+                                    enc.enc_name,
+                                )
+                            elif existing[2] != body:
+                                _exist_inst, _, _exist_body, _ = existing
+                                raise AssertionError(
+                                    'shared execute body collision: '
+                                    f'mnemonic={inst.mnemonic!r} '
+                                    f'enc={enc.enc_name!r} produced two '
+                                    'different bodies for the same shared-template '
+                                    'key (the body is not arch-independent, so '
+                                    'first-writer-wins would miscompile one arch).'
+                                    f'\n--- first writer body ---\n{_exist_body}'
+                                    f'\n--- this writer body ---\n{body}'
+                                )
                         else:
                             exec_impl = cgen.Line(
                                 f'void {inst.fmt_name}::execute_impl'
@@ -5109,11 +5176,23 @@ class CodeGenerator:
                 # Include the unified shared execute template header when
                 # any instruction in this encoding delegates to a template.
                 if self.shared_plan is not None:
-                    has_shared = any(
-                        self._can_share_execute(i.mnemonic, i, enc.enc_name)
-                        for i in all_insts
-                        if self.semantics and i.name in self.semantics.instructions
+                    from amdisa.codegen.execute.simd_codegen import (
+                        simd_probe_arch_portable as _simd_probe_arch_portable,
                     )
+
+                    enc_key = enc.enc_name.lower().replace('enc_', '')
+
+                    def _delegates_to_shared(i: Instruction) -> bool:
+                        if (
+                            not self.semantics
+                            or i.name not in self.semantics.instructions
+                        ):
+                            return False
+                        return self._can_share_execute(
+                            i.mnemonic, i, enc.enc_name
+                        ) or _simd_probe_arch_portable(f'{i.mnemonic}_{enc_key}')
+
+                    has_shared = any(_delegates_to_shared(i) for i in all_insts)
                     if has_shared:
                         cpp_includes.append(
                             (
@@ -5999,7 +6078,8 @@ class CodeGenerator:
 
         simd_methods = ''
         if uses_packed_16bit_sources:
-            simd_methods = textwrap.dedent('''\
+            simd_methods = textwrap.dedent(
+                '''\
                 bool Operand::simd_capable() const {
                   if (delegate())
                     return delegate()->simd_capable();
@@ -6022,7 +6102,8 @@ class CodeGenerator:
                   AmdgpuIsaOperand<Isa>::read_lane_chunk(wf, lane_base, count, out);
                 }
 
-                ''')
+                '''
+            )
 
         resolve_code = cgen.Line(
             'namespace {\n'

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -260,9 +260,7 @@ class CodeGenerator:
         os.makedirs(out_dir, exist_ok=True)
         guard = f'ROCJITSU_ISA_ARCH_AMDGPU_{arch.upper()}_VOPD_H_'
 
-        header = (
-            textwrap.dedent(
-                '''
+        header = textwrap.dedent('''
             // Copyright (c) 2026 Advanced Micro Devices, Inc.
             // SPDX-License-Identifier: MIT
             //
@@ -339,16 +337,9 @@ class CodeGenerator:
             } // namespace rocjitsu
 
             #endif // @GUARD@
-            '''
-            )
-            .lstrip()
-            .replace('@ARCH@', arch)
-            .replace('@GUARD@', guard)
-        )
+            ''').lstrip().replace('@ARCH@', arch).replace('@GUARD@', guard)
 
-        impl = (
-            textwrap.dedent(
-                '''
+        impl = textwrap.dedent('''
             // Copyright (c) 2026 Advanced Micro Devices, Inc.
             // SPDX-License-Identifier: MIT
             //
@@ -754,11 +745,7 @@ class CodeGenerator:
 
             } // namespace @ARCH@
             } // namespace rocjitsu
-            '''
-            )
-            .lstrip()
-            .replace('@ARCH@', arch)
-        )
+            ''').lstrip().replace('@ARCH@', arch)
 
         with open(os.path.join(out_dir, 'vopd.h'), 'w') as f:
             f.write(header)
@@ -1332,8 +1319,7 @@ class CodeGenerator:
     def _emit_gfx1250_matrix_fmt_helpers() -> str:
         """Emit C++ helpers for gfx1250 VOP3P packed and matrix quirks."""
         return (
-            textwrap.dedent(
-                '''\
+            textwrap.dedent('''\
             namespace {
             struct PkF32Words {
               uint32_t lo;
@@ -1352,8 +1338,7 @@ class CodeGenerator:
               const uint64_t raw = operand.read_lane64(wf, lane);
               return {static_cast<uint32_t>(raw), static_cast<uint32_t>(raw >> 32)};
             }
-            '''
-            )
+            ''')
             + (
                 'const char *gfx1250_matrix_fmt_name(uint32_t fmt) {\n'
                 '  switch (fmt) {\n'
@@ -1568,8 +1553,7 @@ class CodeGenerator:
 
     @staticmethod
     def _emit_gfx1250_scaled_wmma_vop3px2_class() -> str:
-        return textwrap.dedent(
-            '''\
+        return textwrap.dedent('''\
             class VWmmaScaleF3216x16x128F8f6f4Vop3px2 : public Vop3p {
             public:
               VWmmaScaleF3216x16x128F8f6f4Vop3px2(const MachineInst *inst);
@@ -1585,13 +1569,11 @@ class CodeGenerator:
               OpEncoding scale_inst_;
               std::array<uint32_t, 4> raw_words_{};
             };
-            '''
-        )
+            ''')
 
     @staticmethod
     def _emit_gfx1250_scaled_wmma_vop3px2_impls() -> str:
-        return textwrap.dedent(
-            '''\
+        return textwrap.dedent('''\
             VWmmaScaleF3216x16x128F8f6f4Vop3px2::VWmmaScaleF3216x16x128F8f6f4Vop3px2(const MachineInst *inst)
                 : Vop3p("v_wmma_scale_f32_16x16x128_f8f6f4", reinterpret_cast<const OpEncoding *>(inst + 2),
                         make_exec_fn<VWmmaScaleF3216x16x128F8f6f4Vop3px2>()),
@@ -1701,13 +1683,11 @@ class CodeGenerator:
               if (!dispatched)
                 throw util::UnimplementedInst(mnemonic());
             }
-            '''
-        )
+            ''')
 
     @staticmethod
     def _emit_gfx1250_scaled_wmma_vop3px2_decoder_helpers() -> str:
-        return textwrap.dedent(
-            '''\
+        return textwrap.dedent('''\
             namespace {
 
             bool isWmmaScaleF32F8f6f4Vop3px2(const MachineInst *opcode) {
@@ -1720,8 +1700,7 @@ class CodeGenerator:
             }
 
             } // namespace
-            '''
-        )
+            ''')
 
     def _gen_execute_body(
         self, inst: Instruction, sem: InstructionSemantics, enc_name: str = ''
@@ -6078,8 +6057,7 @@ class CodeGenerator:
 
         simd_methods = ''
         if uses_packed_16bit_sources:
-            simd_methods = textwrap.dedent(
-                '''\
+            simd_methods = textwrap.dedent('''\
                 bool Operand::simd_capable() const {
                   if (delegate())
                     return delegate()->simd_capable();
@@ -6102,8 +6080,7 @@ class CodeGenerator:
                   AmdgpuIsaOperand<Isa>::read_lane_chunk(wf, lane_base, count, out);
                 }
 
-                '''
-            )
+                ''')
 
         resolve_code = cgen.Line(
             'namespace {\n'

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/__init__.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/__init__.py
@@ -125,10 +125,16 @@ def _register_handlers() -> None:
     # Vector ALU — vector_unary, vector_binop, vector_ternary now handled
     # by SemaAST pipeline (_SEMA_CLASSES).
 
-    # Vector compare — vector_cmp, vector_cmp_class, vector_add_co now
-    # handled by SemaAST pipeline (_SEMA_CLASSES).
+    # Vector compare — vector_cmp, vector_add_co handled by SemaAST pipeline
+    # (_SEMA_CLASSES). vector_cmp_class is NOT: the SemaAST lowering mangles the
+    # operand (a bit_cast<float>(static_cast<uint32_t>(...)) value round-trip)
+    # and always classifies in f32, so the dedicated per-type generator here
+    # (correct f16/f32/f64 qnan masks, full 64-bit f64 read) owns it instead.
     DISPATCH['vector_cmpx'] = lambda c: gen_vector_cmpx(
         c.src_ops, c.op, c.dtype, c.cmpx_writes_vcc, c.is_vop3, c.dst_ops, c.has_abs
+    )
+    DISPATCH['vector_cmp_class'] = lambda c: gen_vector_cmp_class(
+        c.dst_ops, c.src_ops, c.dtype, False, False, c.is_vop3, c.has_abs
     )
     DISPATCH['vector_cmpx_class'] = lambda c: gen_vector_cmp_class(
         c.dst_ops, c.src_ops, c.dtype, True, c.cmpx_writes_vcc, c.is_vop3, c.has_abs

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/packed.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/packed.py
@@ -167,7 +167,10 @@ def gen_pk_binop(
         u_op_map = {
             'add': ('a_lo + b_lo', 'a_hi + b_hi'),
             'sub': ('a_lo - b_lo', 'a_hi - b_hi'),
-            'mul': ('a_lo * b_lo', 'a_hi * b_hi'),
+            'mul': (
+                'static_cast<uint32_t>(a_lo) * b_lo',
+                'static_cast<uint32_t>(a_hi) * b_hi',
+            ),
             'max': ('a_lo > b_lo ? a_lo : b_lo', 'a_hi > b_hi ? a_hi : b_hi'),
             'min': ('a_lo < b_lo ? a_lo : b_lo', 'a_hi < b_hi ? a_hi : b_hi'),
             'shl': (
@@ -335,8 +338,12 @@ def gen_pk_ternary(
                 '    uint16_t rhi = static_cast<uint16_t>(std::max(std::max(a_hi, b_hi), c_hi));'
             )
         else:
-            L.append('    uint16_t rlo = static_cast<uint16_t>(a_lo * b_lo + c_lo);')
-            L.append('    uint16_t rhi = static_cast<uint16_t>(a_hi * b_hi + c_hi);')
+            L.append(
+                '    uint16_t rlo = static_cast<uint16_t>(static_cast<uint32_t>(a_lo) * b_lo + c_lo);'
+            )
+            L.append(
+                '    uint16_t rhi = static_cast<uint16_t>(static_cast<uint32_t>(a_hi) * b_hi + c_hi);'
+            )
         L.append(
             f'    {d}.write_lane(wf, lane, static_cast<uint32_t>(rlo) | (static_cast<uint32_t>(rhi) << 16));'
         )
@@ -366,8 +373,12 @@ def gen_pk_ternary(
             L.append('    uint16_t rlo = std::max(std::max(a_lo, b_lo), c_lo);')
             L.append('    uint16_t rhi = std::max(std::max(a_hi, b_hi), c_hi);')
         else:
-            L.append('    uint16_t rlo = static_cast<uint16_t>(a_lo * b_lo + c_lo);')
-            L.append('    uint16_t rhi = static_cast<uint16_t>(a_hi * b_hi + c_hi);')
+            L.append(
+                '    uint16_t rlo = static_cast<uint16_t>(static_cast<uint32_t>(a_lo) * b_lo + c_lo);'
+            )
+            L.append(
+                '    uint16_t rhi = static_cast<uint16_t>(static_cast<uint32_t>(a_hi) * b_hi + c_hi);'
+            )
         L.append(
             f'    {d}.write_lane(wf, lane, static_cast<uint32_t>(rlo) | (static_cast<uint32_t>(rhi) << 16));'
         )

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/sema_lower.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/sema_lower.py
@@ -59,29 +59,45 @@ class OperandMap:
         dst_ops: list[str],
         exec_model: ExecModel,
         dtype: str | None = None,
-        src_width: int | None = None,
-        dst_width: int | None = None,
-        src_widths: dict[int, int] | None = None,
-        dst_widths: dict[int, int] | None = None,
+        op_widths: dict[str, int] | None = None,
         src_reg_classes: dict[int, RegClass] | None = None,
         dst_reg_classes: dict[int, RegClass] | None = None,
+        src_widths: dict[int, int] | None = None,
+        dst_widths: dict[int, int] | None = None,
     ) -> OperandMap:
         is_64 = dtype in ('b64', 'i64', 'u64', 'f64')
         is_scalar = exec_model == ExecModel.SCALAR
         reg = RegClass.SGPR if is_scalar else RegClass.VGPR
-        default_width = 64 if is_64 else 32
-        sw = src_width if src_width is not None else default_width
-        dw = dst_width if dst_width is not None else default_width
-        src_widths = src_widths or {}
-        dst_widths = dst_widths or {}
+        width = 64 if is_64 else 32
+
+        def _bw(name: str, explicit_width: int | None = None) -> int:
+            # Prefer the operand's own declared bit size so mixed-width
+            # instructions (e.g. the f64<->32-bit conversions, where one side is
+            # 64-bit and the other 32-bit) get the correct per-operand lane
+            # width instead of a single instruction-level dtype width. Only the
+            # 64-bit case matters for read_lane64/write_lane64 selection; every
+            # narrower size (8/16/32) reads/writes through the 32-bit path.
+            if explicit_width is not None:
+                return 64 if explicit_width == 64 else 32
+            size = op_widths.get(name) if op_widths else None
+            if size is None:
+                return width
+            return 64 if size == 64 else 32
+
         src_reg_classes = src_reg_classes or {}
         dst_reg_classes = dst_reg_classes or {}
+        src_widths = src_widths or {}
+        dst_widths = dst_widths or {}
         src_b = {
-            i: OperandBinding(name, src_reg_classes.get(i, reg), src_widths.get(i, sw))
+            i: OperandBinding(
+                name, src_reg_classes.get(i, reg), _bw(name, src_widths.get(i))
+            )
             for i, name in enumerate(src_ops)
         }
         dst_b = {
-            i: OperandBinding(name, dst_reg_classes.get(i, reg), dst_widths.get(i, dw))
+            i: OperandBinding(
+                name, dst_reg_classes.get(i, reg), _bw(name, dst_widths.get(i))
+            )
             for i, name in enumerate(dst_ops)
         }
         return OperandMap(src_bindings=src_b, dst_bindings=dst_b)
@@ -881,6 +897,23 @@ def _rhs_is_float_expr(node: SemaNode) -> int:
     Checks if the RHS expression evaluates to a float in C++, meaning the
     dst write needs bit_cast<uint32_t> to store it as a register value.
     """
+    # VOP3 result modifiers (apply_omod/apply_clamp) always emit a float/double
+    # lambda regardless of the declared dst type, so a write to a non-float
+    # register (e.g. v_mov_b32 with omod/clamp) still needs the bit_cast back —
+    # without it the float is truncated float->int at the integer write_lane.
+    # apply_src_mod only produces a float lambda when it actually applies abs/neg
+    # to a float source; otherwise it passes its operand through unchanged.
+    if node.kind == SemaNodeKind.CALL:
+        if node.call_name in ('apply_omod', 'apply_clamp'):
+            return 64 if (node.ty and node.ty.size == 64) else 32
+        if node.call_name == 'apply_src_mod':
+            src = node.children[1] if len(node.children) > 1 else None
+            has_neg = len(node.children) > 3 and node.children[3].lit_value == '1'
+            has_abs = len(node.children) > 4 and node.children[4].lit_value == '1'
+            src_is_int = src is not None and src.ty and src.ty.base in ('I', 'U')
+            if (has_neg or has_abs) and not src_is_int:
+                return 64 if (node.ty and node.ty.size == 64) else 32
+            return _rhs_is_float_expr(src) if src is not None else 0
     if node.ty and node.ty.base in ('F', 'BF') and node.ty.size in (32, 64):
         if node.kind in (
             SemaNodeKind.ADD,

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/simd_codegen.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/simd_codegen.py
@@ -7,8 +7,10 @@ Emits an `<experimental/simd>`-based fast path on top of the generated
 scalar per-lane bodies. The scalar body is preserved verbatim as a
 fallback; the SIMD probe is a single line at the start of the kernel:
 
-    if (try_execute_binary_vop2_simd<T>(inst, wf, op_functor))
-      return;
+    ROCJITSU_TRY_SIMD_VOP2_BINARY(T, op_functor);
+
+That macro (defined in ``simd_glue.h``) expands to a call to
+``try_execute_binary_vop2_simd<T>`` plus an early ``return`` on success.
 
 `try_execute_binary_vop2_simd` in ``simd_glue.h`` is a constrained
 template (``requires(util::has_stdx_simd)``) plus an unconstrained
@@ -34,21 +36,2542 @@ from __future__ import annotations
 # The functor is invoked as `bin_op(simd<T>, simd<T>) -> simd<T>` inside
 # try_execute_binary_vop2_simd. Use std::*<> for stateless ops.
 SIMD_VOP2_BINARY: dict[str, tuple[str, str]] = {
+    # --- float32 (IEEE-754 single-rounded, bit-identical to scalar body) ---
     "v_add_f32_vop2": ("float32_t", "std::plus<>{}"),
+    'v_sub_f32_vop2': ('float32_t', 'std::minus<>{}'),
+    'v_subrev_f32_vop2': ('float32_t', '[](auto a, auto b) { return b - a; }'),
+    'v_mul_f32_vop2': ('float32_t', 'std::multiplies<>{}'),
+    # Legacy / DX9 zero-multiply: (a==0 || b==0) ? 0 : a*b. The ==0 matches both
+    # ±0 (as the scalar `a == 0.0f` does). Routed via the VOP3 binary fp glue for
+    # the _vop3 twin (which applies abs/neg/omod/clamp around this functor).
+    'v_mul_legacy_f32_vop2': (
+        'float32_t',
+        '[](auto a, auto b) {'
+        ' auto r = a * b;'
+        ' util::stdx::where(a == 0.0f || b == 0.0f, r) = util::native<float32_t>(0.0f);'
+        ' return r; }',
+    ),
+    'v_mul_dx9_zero_f32_vop2': (
+        'float32_t',
+        '[](auto a, auto b) {'
+        ' auto r = a * b;'
+        ' util::stdx::where(a == 0.0f || b == 0.0f, r) = util::native<float32_t>(0.0f);'
+        ' return r; }',
+    ),
+    # --- uint32 (wrap-around / bitwise, bit-identical to scalar body) ---
     "v_add_u32_vop2": ("uint32_t", "std::plus<>{}"),
+    'v_sub_u32_vop2': ('uint32_t', 'std::minus<>{}'),
+    'v_subrev_u32_vop2': ('uint32_t', '[](auto a, auto b) { return b - a; }'),
+    # RDNA "no-carry" int add/sub — bit-identical to add_u32/sub_u32/subrev_u32
+    # (no VCC interaction), just renamed.
+    'v_add_nc_u32_vop2': ('uint32_t', 'std::plus<>{}'),
+    'v_sub_nc_u32_vop2': ('uint32_t', 'std::minus<>{}'),
+    'v_subrev_nc_u32_vop2': ('uint32_t', '[](auto a, auto b) { return b - a; }'),
+    'v_and_b32_vop2': ('uint32_t', 'std::bit_and<>{}'),
+    'v_or_b32_vop2': ('uint32_t', 'std::bit_or<>{}'),
+    'v_xor_b32_vop2': ('uint32_t', 'std::bit_xor<>{}'),
+    'v_xnor_b32_vop2': ('uint32_t', '[](auto a, auto b) { return ~(a ^ b); }'),
+    # rev: shift value is vsrc1 (b), shift count is src0 (a), masked to 5 bits.
+    'v_lshlrev_b32_vop2': ('uint32_t', '[](auto a, auto b) { return b << (a & 31u); }'),
+    'v_lshrrev_b32_vop2': ('uint32_t', '[](auto a, auto b) { return b >> (a & 31u); }'),
+    'v_mul_u32_u24_vop2': (
+        'uint32_t',
+        '[](auto a, auto b) { return (a & 0x00FFFFFFu) * (b & 0x00FFFFFFu); }',
+    ),
+    # Signed 24-bit multiply, low 32 bits. Sign-extend the low 24 bits to int32
+    # (matching the scalar (int32_t)(x<<8)>>8); the int32 product's low 32 bits
+    # are exact, so no widening is needed.
+    'v_mul_i32_i24_vop2': (
+        'uint32_t',
+        '[](auto a, auto b) {'
+        ' auto sa = (util::stdx::static_simd_cast<util::native<int32_t>>(a) << 8) >> 8;'
+        ' auto sb = (util::stdx::static_simd_cast<util::native<int32_t>>(b) << 8) >> 8;'
+        ' return util::stdx::static_simd_cast<util::native<uint32_t>>(sa * sb); }',
+    ),
+    # High 32 bits of the 24-bit multiply (48-bit product). The 32x32->high32
+    # step uses util::mul_hi_{u,i}32_simd, a 16x16 partial-product decomposition
+    # in pure native<uint32_t> arithmetic. It deliberately avoids
+    # fixed_size_simd<{u,i}64, N>: clang + libstdc++ miscompile the 64-bit-lane
+    # multiply/shift of an over-native-width fixed_size_simd, so the int64
+    # widening diverges from the scalar uint64/int64 intermediates at every SIMD
+    # width. The decomposition is bit-identical to the scalar reference.
+    'v_mul_hi_u32_u24_vop2': (
+        'uint32_t',
+        '[](auto a, auto b) {'
+        ' return util::mul_hi_u32_simd(a & 0x00FFFFFFu, b & 0x00FFFFFFu); }',
+    ),
+    'v_mul_hi_i32_i24_vop2': (
+        'uint32_t',
+        '[](auto a, auto b) {'
+        ' auto sa = (util::stdx::static_simd_cast<util::native<int32_t>>(a) << 8) >> 8;'
+        ' auto sb = (util::stdx::static_simd_cast<util::native<int32_t>>(b) << 8) >> 8;'
+        ' return util::mul_hi_i32_simd('
+        ' util::stdx::static_simd_cast<util::native<uint32_t>>(sa),'
+        ' util::stdx::static_simd_cast<util::native<uint32_t>>(sb)); }',
+    ),
+    'v_max_u32_vop2': (
+        'uint32_t',
+        '[](auto a, auto b) { return util::stdx::max(a, b); }',
+    ),
+    'v_min_u32_vop2': (
+        'uint32_t',
+        '[](auto a, auto b) { return util::stdx::min(a, b); }',
+    ),
+    # --- int32 (signed: arithmetic shift / signed min-max) ---
+    'v_ashrrev_i32_vop2': ('int32_t', '[](auto a, auto b) { return b >> (a & 31); }'),
+    'v_max_i32_vop2': (
+        'int32_t',
+        '[](auto a, auto b) { return util::stdx::max(a, b); }',
+    ),
+    'v_min_i32_vop2': (
+        'int32_t',
+        '[](auto a, auto b) { return util::stdx::min(a, b); }',
+    ),
+    # --- 16-bit integer (low 16 bits, result zero-extended to 32). Lane type
+    # stays uint32_t; the functor masks/sign-extends the low 16 bits and writes
+    # back the zero-extended 16-bit result, matching write_lane semantics. ---
+    'v_add_u16_vop2': ('uint32_t', '[](auto a, auto b) { return (a + b) & 0xFFFFu; }'),
+    'v_sub_u16_vop2': ('uint32_t', '[](auto a, auto b) { return (a - b) & 0xFFFFu; }'),
+    'v_subrev_u16_vop2': (
+        'uint32_t',
+        '[](auto a, auto b) { return (b - a) & 0xFFFFu; }',
+    ),
+    'v_mul_lo_u16_vop2': (
+        'uint32_t',
+        '[](auto a, auto b) { return ((a & 0xFFFFu) * (b & 0xFFFFu)) & 0xFFFFu; }',
+    ),
+    # rev: shift value is vsrc1 (b), count is src0 (a) masked to 4 bits.
+    'v_lshlrev_b16_vop2': (
+        'uint32_t',
+        '[](auto a, auto b) { return (b << (a & 15u)) & 0xFFFFu; }',
+    ),
+    'v_lshrrev_b16_vop2': (
+        'uint32_t',
+        '[](auto a, auto b) { return (b & 0xFFFFu) >> (a & 15u); }',
+    ),
+    # ashr: sign-extend the low 16 bits to int32, arithmetic-shift by count & 15
+    # (the scalar masks the i16 count to 4 bits), then take the low 16 bits.
+    'v_ashrrev_i16_vop2': (
+        'uint32_t',
+        '[](auto a, auto b) {'
+        ' auto sb = (util::stdx::static_simd_cast<util::native<int32_t>>(b) << 16) >> 16;'
+        ' auto sa = (util::stdx::static_simd_cast<util::native<int32_t>>(a) << 16) >> 16;'
+        ' return util::stdx::static_simd_cast<util::native<uint32_t>>(sb >> (sa & 15)) & 0xFFFFu; }',
+    ),
+    'v_max_i16_vop2': (
+        'uint32_t',
+        '[](auto a, auto b) {'
+        ' auto sa = (util::stdx::static_simd_cast<util::native<int32_t>>(a) << 16) >> 16;'
+        ' auto sb = (util::stdx::static_simd_cast<util::native<int32_t>>(b) << 16) >> 16;'
+        ' return util::stdx::static_simd_cast<util::native<uint32_t>>(util::stdx::max(sa, sb))'
+        ' & 0xFFFFu; }',
+    ),
+    'v_min_i16_vop2': (
+        'uint32_t',
+        '[](auto a, auto b) {'
+        ' auto sa = (util::stdx::static_simd_cast<util::native<int32_t>>(a) << 16) >> 16;'
+        ' auto sb = (util::stdx::static_simd_cast<util::native<int32_t>>(b) << 16) >> 16;'
+        ' return util::stdx::static_simd_cast<util::native<uint32_t>>(util::stdx::min(sa, sb))'
+        ' & 0xFFFFu; }',
+    ),
+    'v_max_u16_vop2': (
+        'uint32_t',
+        '[](auto a, auto b) { return util::stdx::max(a & 0xFFFFu, b & 0xFFFFu); }',
+    ),
+    'v_min_u16_vop2': (
+        'uint32_t',
+        '[](auto a, auto b) { return util::stdx::min(a & 0xFFFFu, b & 0xFFFFu); }',
+    ),
+    # --- float min/max. util::stdx::fmax/fmin match the scalar std::fmax/fmin
+    # used by the generated bodies for all finite/Inf inputs. Two accepted
+    # divergences (per project direction): (1) NaN inputs may differ in NaN
+    # payload; (2) a signed-zero tie returns the opposite-signed zero — scalar
+    # std::fmax/fmin returns the first operand, the packed vmaxps/vminps the
+    # second, so e.g. fmax(-0,+0) is -0 (scalar) vs +0 (SIMD). Both are
+    # numerically equal results; the guard tests skip NaN-input and zero-tie
+    # lanes (UtilSimd.Fmax/Fmin_VectorMatchesScalar_BitExact). All other inputs
+    # are bit-exact. (The earlier "not reproducible" note conflated these two
+    # accepted corners with a hard blocker.) ---
+    'v_max_f32_vop2': (
+        'float32_t',
+        '[](auto a, auto b) { return util::stdx::fmax(a, b); }',
+    ),
+    'v_min_f32_vop2': (
+        'float32_t',
+        '[](auto a, auto b) { return util::stdx::fmin(a, b); }',
+    ),
+    'v_max_f16_vop2': (
+        'uint32_t',
+        '[](auto a, auto b) {'
+        ' return util::f32_to_f16_simd('
+        'util::stdx::fmax(util::f16_to_f32_simd(a), util::f16_to_f32_simd(b))); }',
+    ),
+    'v_min_f16_vop2': (
+        'uint32_t',
+        '[](auto a, auto b) {'
+        ' return util::f32_to_f16_simd('
+        'util::stdx::fmin(util::f16_to_f32_simd(a), util::f16_to_f32_simd(b))); }',
+    ),
+    # --- f16 binary (low 16 bits f16, result zero-extended). Same f32
+    # intermediate as the scalar bodies (single final round) ⇒ bit-identical. ---
+    'v_add_f16_vop2': (
+        'uint32_t',
+        '[](auto a, auto b) {'
+        ' return util::f32_to_f16_simd(util::f16_to_f32_simd(a) + util::f16_to_f32_simd(b)); }',
+    ),
+    'v_sub_f16_vop2': (
+        'uint32_t',
+        '[](auto a, auto b) {'
+        ' return util::f32_to_f16_simd(util::f16_to_f32_simd(a) - util::f16_to_f32_simd(b)); }',
+    ),
+    'v_subrev_f16_vop2': (
+        'uint32_t',
+        '[](auto a, auto b) {'
+        ' return util::f32_to_f16_simd(util::f16_to_f32_simd(b) - util::f16_to_f32_simd(a)); }',
+    ),
+    'v_mul_f16_vop2': (
+        'uint32_t',
+        '[](auto a, auto b) {'
+        ' return util::f32_to_f16_simd(util::f16_to_f32_simd(a) * util::f16_to_f32_simd(b)); }',
+    ),
+    # v_ldexp_f16: dst = f16(ldexp(f16->f32(src0), (int16)vsrc1)). src0 is an f16
+    # multiplicand, vsrc1 a signed-16-bit exponent (widened to a fixed_size int
+    # lane). std::ldexp is a power-of-2 scale with a single correctly-rounded
+    # result; util::stdx::ldexp matches it bit-for-bit (verified full-range incl
+    # NaN/Inf/denormal), and the f16<->f32 conversions are bit-exact, so the
+    # composition matches the scalar body. No NaN-operand ambiguity (unlike fma).
+    'v_ldexp_f16_vop2': (
+        'uint32_t',
+        '[](auto a, auto b) {'
+        ' auto x = util::f16_to_f32_simd(a);'
+        ' auto n = util::stdx::static_simd_cast<'
+        'util::stdx::fixed_size_simd<int, util::native<float>::size()>>('
+        '(util::stdx::static_simd_cast<util::native<int32_t>>(b) << 16) >> 16);'
+        ' return util::f32_to_f16_simd(util::stdx::ldexp(x, n)); }',
+    ),
 }
+
+# template_name -> (cpp_in_type, cpp_out_type, cpp_unary_op_functor)
+#
+# Same keying as SIMD_VOP2_BINARY. The functor is invoked as
+#   un_op(simd<Tin>) -> simd<Tout>
+# inside try_execute_unary_vop1_simd. Tin and Tout are both 32-bit lane
+# types and may differ (e.g. int32->float32 for v_cvt_f32_i32). Eligible
+# kernels are those whose host SIMD result is bit-identical to the scalar
+# generated body: elementwise bit ops, exact int<->float casts, and the
+# correctly-rounded IEEE operations (div, sqrt, and — verified per toolchain
+# via the parity test — exp2/log2). NaN/clamp-bearing conversions and the
+# inexact transcendentals (sin/cos) are excluded.
+# VOP1 base mnemonics whose VOP3 form applies float abs/neg/omod/clamp modifiers
+# over an f32 source and result (so the VOP3 twin routes through the f32 unary
+# modifier glue rather than reusing the plain VOP1 path). v_mov_b32's VOP3 body
+# treats src0 as f32 and applies the same modifiers, so it belongs here too.
+# v_accvgpr_mov_b32 (acc<->acc move) has the identical f32-modifier VOP3 body.
+_VOP3_UNARY_FP_F32 = {
+    'v_mov_b32',
+    'v_accvgpr_mov_b32',
+    'v_floor_f32',
+    'v_ceil_f32',
+    'v_trunc_f32',
+    'v_rndne_f32',
+    'v_fract_f32',
+    'v_rcp_f32',
+    'v_rcp_iflag_f32',
+    'v_rsq_f32',
+    'v_sqrt_f32',
+    'v_exp_f32',
+    'v_log_f32',
+    'v_frexp_mant_f32',
+}
+
+# VOP1 base mnemonics whose VOP3 twin stays scalar: the f16 rounding/transcendental
+# forms carry modifiers applied around an f16<->f32 round trip (not yet handled).
+# v_mov_b16 is here for the same reason — its VOP3 body reads src0 as a u16 value,
+# widens it to f32, applies omod/clamp, then narrows back to u16 (a 16-bit->f32->16-bit
+# modifier round trip). The plain `a & 0xFFFFu` VOP1 functor it would otherwise reuse
+# ignores those modifiers, so with clamp/omod set the SIMD path diverged from scalar
+# (clamp=1: scalar 0x1 vs simd 0xffff). Leaving the VOP3 twin scalar keeps it correct;
+# the modifier-free VOP1 form still takes the fast path.
+_VOP3_UNARY_SKIP = {
+    'v_floor_f16',
+    'v_ceil_f16',
+    'v_trunc_f16',
+    'v_rndne_f16',
+    'v_fract_f16',
+    'v_rcp_f16',
+    'v_rsq_f16',
+    'v_sqrt_f16',
+    'v_exp_f16',
+    'v_log_f16',
+    'v_mov_b16',
+    'v_frexp_exp_i32_f32',
+    'v_frexp_exp_i32_f64',
+    'v_frexp_mant_f16',
+    'v_frexp_exp_i16_f16',
+}
+
+SIMD_VOP1_UNARY: dict[str, tuple[str, str, str]] = {
+    # --- bitwise / move (uint32, bit-identical) ---
+    'v_mov_b32_vop1': ('uint32_t', 'uint32_t', '[](auto a) { return a; }'),
+    'v_accvgpr_mov_b32_vop1': ('uint32_t', 'uint32_t', '[](auto a) { return a; }'),
+    'v_not_b32_vop1': ('uint32_t', 'uint32_t', '[](auto a) { return ~a; }'),
+    # RDNA3+ 16-bit move / not / int16<->int32 conversions (low-16, zero-extend
+    # to the 32-bit VGPR). The _vop3 twins auto-route through the same VOP1 path,
+    # except v_mov_b16 whose VOP3 form applies float omod/clamp (see
+    # _VOP3_UNARY_SKIP above).
+    'v_mov_b16_vop1': ('uint32_t', 'uint32_t', '[](auto a) { return a & 0xFFFFu; }'),
+    'v_not_b16_vop1': ('uint32_t', 'uint32_t', '[](auto a) { return (~a) & 0xFFFFu; }'),
+    'v_cvt_i32_i16_vop1': (
+        'uint32_t',
+        'uint32_t',
+        '[](auto a) {'
+        ' auto x = util::stdx::static_simd_cast<util::native<int32_t>>(a & 0xFFFFu);'
+        ' return util::stdx::static_simd_cast<util::native<uint32_t>>((x << 16) >> 16); }',
+    ),
+    'v_cvt_u32_u16_vop1': (
+        'uint32_t',
+        'uint32_t',
+        '[](auto a) { return a & 0xFFFFu; }',
+    ),
+    # RDNA f32->i32 round-toward-floor / round-to-nearest-even conversions
+    # (cdna4 spells these v_cvt_flr_i32_f32 / v_cvt_rpi_i32_f32). floor via
+    # stdx::floor; nearest via ceil(s - 0.5) (round-half-to-even on the .5 path).
+    # Out-of-range saturates to INT32_MIN/MAX and NaN -> 0, matching the scalar.
+    'v_cvt_floor_i32_f32_vop1': (
+        'float32_t',
+        'int32_t',
+        '[](auto s) {'
+        ' auto r = util::stdx::floor(s);'
+        ' util::native<int32_t> out = util::stdx::static_simd_cast<util::native<int32_t>>(r);'
+        ' util::stdx::where(simd_mask_as<int32_t>(r >= 2147483648.0f), out) = 2147483647;'
+        ' util::stdx::where(simd_mask_as<int32_t>(r < -2147483648.0f), out) = (-2147483647 - 1);'
+        ' util::stdx::where(simd_mask_as<int32_t>(util::stdx::isnan(r)), out) = 0;'
+        ' return out; }',
+    ),
+    'v_cvt_nearest_i32_f32_vop1': (
+        'float32_t',
+        'int32_t',
+        '[](auto s) {'
+        ' auto r = util::stdx::ceil(s - util::native<float32_t>(0.5f));'
+        ' util::native<int32_t> out = util::stdx::static_simd_cast<util::native<int32_t>>(r);'
+        ' util::stdx::where(simd_mask_as<int32_t>(r >= 2147483648.0f), out) = 2147483647;'
+        ' util::stdx::where(simd_mask_as<int32_t>(r < -2147483648.0f), out) = (-2147483647 - 1);'
+        ' util::stdx::where(simd_mask_as<int32_t>(util::stdx::isnan(r)), out) = 0;'
+        ' return out; }',
+    ),
+    # --- bit-scan (SWAR, no stdx primitive) -----------------------------------
+    # All return uint32_t and special-case the zero input to 0xFFFFFFFF, matching
+    # the scalar bodies (std::countl_zero / countr_zero / popcount). The VOP3
+    # twins share these (modifier-free integer bodies, auto-routed below). f16<->
+    # f32 round-trip not involved -> not in _VOP3_UNARY_SKIP.
+    #
+    # ffbh_u32 / clz_i32_u32: count leading zeros; 0 -> 0xFFFFFFFF.
+    'v_ffbh_u32_vop1': (
+        'uint32_t',
+        'uint32_t',
+        '[](auto a) {'
+        ' auto c = util::clz_u32_simd(a);'
+        ' util::stdx::where(a == 0u, c) = 0xFFFFFFFFu;'
+        ' return c; }',
+    ),
+    'v_clz_i32_u32_vop1': (
+        'uint32_t',
+        'uint32_t',
+        '[](auto a) {'
+        ' auto c = util::clz_u32_simd(a);'
+        ' util::stdx::where(a == 0u, c) = 0xFFFFFFFFu;'
+        ' return c; }',
+    ),
+    # ffbl_b32 / ctz_i32_b32: count trailing zeros; 0 -> 0xFFFFFFFF.
+    'v_ffbl_b32_vop1': (
+        'uint32_t',
+        'uint32_t',
+        '[](auto a) {'
+        ' auto c = util::ctz_u32_simd(a);'
+        ' util::stdx::where(a == 0u, c) = 0xFFFFFFFFu;'
+        ' return c; }',
+    ),
+    'v_ctz_i32_b32_vop1': (
+        'uint32_t',
+        'uint32_t',
+        '[](auto a) {'
+        ' auto c = util::ctz_u32_simd(a);'
+        ' util::stdx::where(a == 0u, c) = 0xFFFFFFFFu;'
+        ' return c; }',
+    ),
+    # ffbh_i32 / cls_i32: count leading sign bits = clz of (s < 0 ? ~s : s);
+    # 0 (== all-zero or all-one source) -> 0xFFFFFFFF.
+    'v_ffbh_i32_vop1': (
+        'uint32_t',
+        'uint32_t',
+        '[](auto a) {'
+        ' util::native<uint32_t> u = a;'
+        ' util::stdx::where((a & 0x80000000u) != 0u, u) = ~a;'
+        ' auto c = util::clz_u32_simd(u);'
+        ' util::stdx::where(u == 0u, c) = 0xFFFFFFFFu;'
+        ' return c; }',
+    ),
+    'v_cls_i32_vop1': (
+        'uint32_t',
+        'uint32_t',
+        '[](auto a) {'
+        ' util::native<uint32_t> u = a;'
+        ' util::stdx::where((a & 0x80000000u) != 0u, u) = ~a;'
+        ' auto c = util::clz_u32_simd(u);'
+        ' util::stdx::where(u == 0u, c) = 0xFFFFFFFFu;'
+        ' return c; }',
+    ),
+    # v_bfrev_b32: reverse the 32 bits of src0. The scalar body loops bit-by-bit;
+    # this is the branchless swap-by-strides equivalent (1/2/4/8/16-bit groups),
+    # bit-identical for every input. Pure uint32 bitwise ops.
+    'v_bfrev_b32_vop1': (
+        'uint32_t',
+        'uint32_t',
+        '[](auto a) {'
+        ' auto x = a;'
+        ' x = ((x & 0x55555555u) << 1) | ((x >> 1) & 0x55555555u);'
+        ' x = ((x & 0x33333333u) << 2) | ((x >> 2) & 0x33333333u);'
+        ' x = ((x & 0x0F0F0F0Fu) << 4) | ((x >> 4) & 0x0F0F0F0Fu);'
+        ' x = ((x & 0x00FF00FFu) << 8) | ((x >> 8) & 0x00FF00FFu);'
+        ' return (x << 16) | (x >> 16); }',
+    ),
+    # --- frexp (f32 split into mantissa / exponent) ----------------------------
+    # frexp_mant returns the significand m with |m| in [0.5,1) (±0/Inf/NaN pass
+    # through); read as float so the VOP3 twin reuses the f32 unary FP glue for
+    # abs/neg/omod/clamp (added to _VOP3_UNARY_FP_F32 below). frexp_exp returns
+    # the raw int32 exponent bits; its VOP3 twin applies float omod/clamp to
+    # float(exp) and bit-casts (a different output encoding than the VOP1 int),
+    # so the VOP3 form stays scalar (_VOP3_UNARY_SKIP).
+    'v_frexp_mant_f32_vop1': (
+        'float32_t',
+        'float32_t',
+        '[](auto a) { return util::frexp_mant_f32_simd(std::bit_cast<util::native<uint32_t>>(a)); }',
+    ),
+    'v_frexp_exp_i32_f32_vop1': (
+        'uint32_t',
+        'uint32_t',
+        '[](auto a) { return util::frexp_exp_f32_simd(a); }',
+    ),
+    # frexp f16: the scalar widens src to f32, runs std::frexp, then narrows the
+    # mantissa (or float(exp)) back to f16 via f32_to_f16. Compose the bit-exact
+    # f16<->f32 ports with the f32 frexp helpers; the f16<->f32 round trips and
+    # frexp are each bit-identical, so the composition matches. The VOP3 twins
+    # carry omod/clamp around that round trip (not reproduced) -> _VOP3_UNARY_SKIP.
+    'v_frexp_mant_f16_vop1': (
+        'uint32_t',
+        'uint32_t',
+        '[](auto a) {'
+        ' return util::f32_to_f16_simd(util::frexp_mant_f32_simd('
+        'std::bit_cast<util::native<uint32_t>>(util::f16_to_f32_simd(a)))); }',
+    ),
+    'v_frexp_exp_i16_f16_vop1': (
+        'uint32_t',
+        'uint32_t',
+        # The scalar narrows `static_cast<uint32_t>(exp)` to f16 -- the int->float
+        # conversion is UNSIGNED, so a negative exponent (0xFFFF_FFxx) becomes a
+        # ~4.29e9 float and f32_to_f16 saturates it to +Inf (0x7C00). Mirror that
+        # with an unsigned static_simd_cast (no signed intermediate).
+        '[](auto a) {'
+        ' auto e = util::frexp_exp_f32_simd('
+        'std::bit_cast<util::native<uint32_t>>(util::f16_to_f32_simd(a)));'
+        ' return util::f32_to_f16_simd(util::stdx::static_simd_cast<util::native<float>>(e)); }',
+    ),
+    # --- f8 -> f32 (E4M3 / E5M2 8-bit float expand) ----------------------------
+    # Scalar reads the low byte of src0 and expands via util::fp8_e4m3_to_f32 /
+    # bf8_e5m2_to_f32 (no op_sel / byte-select in the body), so the unary functor
+    # mirrors them bit-for-bit through the vector ports (denormal, ±0, max-normal /
+    # Inf, NaN all handled). The VOP3 twins are modifier-free -> auto-route here.
+    'v_cvt_f32_fp8_vop1': (
+        'uint32_t',
+        'float32_t',
+        '[](auto a) { return util::fp8_e4m3_to_f32_simd(a); }',
+    ),
+    'v_cvt_f32_bf8_vop1': (
+        'uint32_t',
+        'float32_t',
+        '[](auto a) { return util::bf8_e5m2_to_f32_simd(a); }',
+    ),
+    # --- ubyte -> f32 (extract byte N, exact int->float) -----------------------
+    # dst = float(byte_N(src0)); byte value is 0..255 so the int->float cast is
+    # exact and bit-identical to the scalar static_cast<float>.
+    'v_cvt_f32_ubyte0_vop1': (
+        'uint32_t',
+        'float32_t',
+        '[](auto a) { return util::stdx::static_simd_cast<util::native<float32_t>>(a & 0xFFu); }',
+    ),
+    'v_cvt_f32_ubyte1_vop1': (
+        'uint32_t',
+        'float32_t',
+        '[](auto a) {'
+        ' return util::stdx::static_simd_cast<util::native<float32_t>>((a >> 8) & 0xFFu); }',
+    ),
+    'v_cvt_f32_ubyte2_vop1': (
+        'uint32_t',
+        'float32_t',
+        '[](auto a) {'
+        ' return util::stdx::static_simd_cast<util::native<float32_t>>((a >> 16) & 0xFFu); }',
+    ),
+    'v_cvt_f32_ubyte3_vop1': (
+        'uint32_t',
+        'float32_t',
+        '[](auto a) {'
+        ' return util::stdx::static_simd_cast<util::native<float32_t>>((a >> 24) & 0xFFu); }',
+    ),
+    # --- int<->float casts (single-rounded, bit-identical) ---
+    'v_cvt_f32_i32_vop1': (
+        'int32_t',
+        'float32_t',
+        '[](auto a) { return util::stdx::static_simd_cast<util::native<float32_t>>(a); }',
+    ),
+    'v_cvt_f32_u32_vop1': (
+        'uint32_t',
+        'float32_t',
+        '[](auto a) { return util::stdx::static_simd_cast<util::native<float32_t>>(a); }',
+    ),
+    # --- float rounding (bit-identical to std::* on host) ---
+    'v_floor_f32_vop1': (
+        'float32_t',
+        'float32_t',
+        '[](auto a) { return util::floor_simd(a); }',
+    ),
+    'v_ceil_f32_vop1': (
+        'float32_t',
+        'float32_t',
+        '[](auto a) { return util::ceil_simd(a); }',
+    ),
+    'v_trunc_f32_vop1': (
+        'float32_t',
+        'float32_t',
+        '[](auto a) { return util::trunc_simd(a); }',
+    ),
+    'v_rndne_f32_vop1': (
+        'float32_t',
+        'float32_t',
+        '[](auto a) { return util::rndne_simd(a); }',
+    ),
+    'v_fract_f32_vop1': (
+        'float32_t',
+        'float32_t',
+        '[](auto a) { return a - util::floor_simd(a); }',
+    ),
+    # --- transcendental div / sqrt. These mirror amdgpu::transcendental::*_f32
+    # exactly via util::*_f32_simd (FTZ input/output flush + canonical-qNaN and
+    # NaN-input-preservation blends), so the SIMD result is bit-identical to the
+    # forced-scalar body on every input incl NaN/Inf/denormal. ---
+    'v_rcp_f32_vop1': (
+        'float32_t',
+        'float32_t',
+        '[](auto a) { return util::rcp_f32_simd(a); }',
+    ),
+    'v_rcp_iflag_f32_vop1': (
+        'float32_t',
+        'float32_t',
+        '[](auto a) { return util::rcp_f32_simd(a); }',
+    ),
+    'v_rsq_f32_vop1': (
+        'float32_t',
+        'float32_t',
+        '[](auto a) { return util::rsq_f32_simd(a); }',
+    ),
+    'v_sqrt_f32_vop1': (
+        'float32_t',
+        'float32_t',
+        '[](auto a) { return util::sqrt_f32_simd(a); }',
+    ),
+    # --- transcendental exp2/log2. util::{exp,log}_f32_simd wrap stdx::exp2/log2
+    # with the same FTZ flush / special-case guards as the scalar transcendental
+    # reference; the underlying vector libm is bit-exact to scalar std::* on the
+    # supported toolchains (libstdc++ 13 / AVX-512), guarded by
+    # UtilSimd.Exp2/Log2_*_BitExact. v_sin/v_cos excluded: vector libm ~1 ULP off. ---
+    'v_exp_f32_vop1': (
+        'float32_t',
+        'float32_t',
+        '[](auto a) { return util::exp_f32_simd(a); }',
+    ),
+    'v_log_f32_vop1': (
+        'float32_t',
+        'float32_t',
+        '[](auto a) { return util::log_f32_simd(a); }',
+    ),
+    # --- float -> int conversions with NaN->0 and saturating clamp. The float
+    # comparison masks are re-typed to the int lane via simd_mask_as<> before
+    # the where-blend. Masks are mutually exclusive so application order is
+    # irrelevant. Matches the scalar bodies' truncate-toward-zero cast. ---
+    'v_cvt_i32_f32_vop1': (
+        'float32_t',
+        'int32_t',
+        '[](auto s) {'
+        ' util::native<int32_t> out = util::stdx::static_simd_cast<util::native<int32_t>>(s);'
+        ' util::stdx::where(simd_mask_as<int32_t>(s >= 2147483648.0f), out) = 2147483647;'
+        ' util::stdx::where(simd_mask_as<int32_t>(s < -2147483648.0f), out) = (-2147483647 - 1);'
+        ' util::stdx::where(simd_mask_as<int32_t>(util::stdx::isnan(s)), out) = 0;'
+        ' return out; }',
+    ),
+    'v_cvt_u32_f32_vop1': (
+        'float32_t',
+        'uint32_t',
+        '[](auto s) {'
+        ' util::native<uint32_t> out = util::stdx::static_simd_cast<util::native<uint32_t>>(s);'
+        ' util::stdx::where(simd_mask_as<uint32_t>(s >= 4294967296.0f), out) = 4294967295u;'
+        ' util::stdx::where(simd_mask_as<uint32_t>(util::stdx::isnan(s) || s < 0.0f), out) = 0u;'
+        ' return out; }',
+    ),
+    'v_cvt_flr_i32_f32_vop1': (
+        'float32_t',
+        'int32_t',
+        '[](auto s) {'
+        ' auto r = util::stdx::floor(s);'
+        ' util::native<int32_t> out = util::stdx::static_simd_cast<util::native<int32_t>>(r);'
+        ' util::stdx::where(simd_mask_as<int32_t>(r >= 2147483648.0f), out) = 2147483647;'
+        ' util::stdx::where(simd_mask_as<int32_t>(r < -2147483648.0f), out) = (-2147483647 - 1);'
+        ' util::stdx::where(simd_mask_as<int32_t>(util::stdx::isnan(r)), out) = 0;'
+        ' return out; }',
+    ),
+    'v_cvt_rpi_i32_f32_vop1': (
+        'float32_t',
+        'int32_t',
+        '[](auto s) {'
+        ' auto r = util::stdx::ceil(s - util::native<float32_t>(0.5f));'
+        ' util::native<int32_t> out = util::stdx::static_simd_cast<util::native<int32_t>>(r);'
+        ' util::stdx::where(simd_mask_as<int32_t>(r >= 2147483648.0f), out) = 2147483647;'
+        ' util::stdx::where(simd_mask_as<int32_t>(r < -2147483648.0f), out) = (-2147483647 - 1);'
+        ' util::stdx::where(simd_mask_as<int32_t>(util::stdx::isnan(r)), out) = 0;'
+        ' return out; }',
+    ),
+    # --- f16 (half) ops. Scalar bodies route through an f32 intermediate with a
+    # single final round, so the SIMD path (f16_to_f32_simd -> f32 op ->
+    # f32_to_f16_simd) is bit-identical. The conversions are bit-exact (see
+    # UtilSimd.F16ToF32/F32ToF16 guards). f16 result occupies the low 16 bits of
+    # the dst, high zeroed (Tout=uint32_t), matching write_lane zero-extension. ---
+    'v_floor_f16_vop1': (
+        'uint32_t',
+        'uint32_t',
+        '[](auto a) { return util::f32_to_f16_simd(util::floor_simd(util::f16_to_f32_simd(a))); }',
+    ),
+    'v_ceil_f16_vop1': (
+        'uint32_t',
+        'uint32_t',
+        '[](auto a) { return util::f32_to_f16_simd(util::ceil_simd(util::f16_to_f32_simd(a))); }',
+    ),
+    'v_trunc_f16_vop1': (
+        'uint32_t',
+        'uint32_t',
+        '[](auto a) { return util::f32_to_f16_simd(util::trunc_simd(util::f16_to_f32_simd(a))); }',
+    ),
+    'v_rndne_f16_vop1': (
+        'uint32_t',
+        'uint32_t',
+        '[](auto a) {'
+        ' return util::f32_to_f16_simd(util::rndne_simd(util::f16_to_f32_simd(a))); }',
+    ),
+    'v_fract_f16_vop1': (
+        'uint32_t',
+        'uint32_t',
+        '[](auto a) {'
+        ' auto f = util::f16_to_f32_simd(a);'
+        ' return util::f32_to_f16_simd(f - util::floor_simd(f)); }',
+    ),
+    # f16 transcendentals mirror the scalar f32_to_f16(<op>_f32(f16_to_f32(x)))
+    # by applying the f32-domain util::*_f32_simd helper (FTZ flush + canonical
+    # qNaN / NaN-input guards) on the f16->f32 intermediate.
+    'v_rcp_f16_vop1': (
+        'uint32_t',
+        'uint32_t',
+        '[](auto a) {'
+        ' return util::f32_to_f16_simd(util::rcp_f32_simd(util::f16_to_f32_simd(a))); }',
+    ),
+    'v_rsq_f16_vop1': (
+        'uint32_t',
+        'uint32_t',
+        '[](auto a) {'
+        ' return util::f32_to_f16_simd(util::rsq_f32_simd(util::f16_to_f32_simd(a))); }',
+    ),
+    'v_sqrt_f16_vop1': (
+        'uint32_t',
+        'uint32_t',
+        '[](auto a) {'
+        ' return util::f32_to_f16_simd(util::sqrt_f32_simd(util::f16_to_f32_simd(a))); }',
+    ),
+    # exp/log_f16 inherit the exp2/log2 toolchain guard (UtilSimd.Exp2/Log2_*).
+    'v_exp_f16_vop1': (
+        'uint32_t',
+        'uint32_t',
+        '[](auto a) {'
+        ' return util::f32_to_f16_simd(util::exp_f32_simd(util::f16_to_f32_simd(a))); }',
+    ),
+    'v_log_f16_vop1': (
+        'uint32_t',
+        'uint32_t',
+        '[](auto a) {'
+        ' return util::f32_to_f16_simd(util::log_f32_simd(util::f16_to_f32_simd(a))); }',
+    ),
+    # --- f16 <-> f32 / int16 conversions ---
+    'v_cvt_f32_f16_vop1': (
+        'uint32_t',
+        'float32_t',
+        '[](auto a) { return util::f16_to_f32_simd(a); }',
+    ),
+    'v_cvt_f16_f32_vop1': (
+        'float32_t',
+        'uint32_t',
+        '[](auto a) { return util::f32_to_f16_simd(a); }',
+    ),
+    'v_cvt_f16_i16_vop1': (
+        'int32_t',
+        'uint32_t',
+        '[](auto a) {'
+        ' auto i = (a << 16) >> 16;'  # sign-extend low 16 bits
+        ' return util::f32_to_f16_simd(util::stdx::static_simd_cast<util::native<float32_t>>(i)); }',
+    ),
+    'v_cvt_f16_u16_vop1': (
+        'uint32_t',
+        'uint32_t',
+        '[](auto a) {'
+        ' auto u = a & 0xFFFFu;'
+        ' return util::f32_to_f16_simd(util::stdx::static_simd_cast<util::native<float32_t>>(u)); }',
+    ),
+    'v_cvt_i16_f16_vop1': (
+        'uint32_t',
+        'uint32_t',
+        '[](auto a) {'
+        ' auto s = util::f16_to_f32_simd(a);'
+        ' util::native<int32_t> o = util::stdx::static_simd_cast<util::native<int32_t>>(s);'
+        ' util::stdx::where(simd_mask_as<int32_t>(s >= 32768.0f), o) = 32767;'
+        ' util::stdx::where(simd_mask_as<int32_t>(s < -32768.0f), o) = -32768;'
+        ' util::stdx::where(simd_mask_as<int32_t>(util::stdx::isnan(s)), o) = 0;'
+        ' return util::stdx::static_simd_cast<util::native<uint32_t>>(o) & 0xFFFFu; }',
+    ),
+    'v_cvt_u16_f16_vop1': (
+        'uint32_t',
+        'uint32_t',
+        '[](auto a) {'
+        ' auto s = util::f16_to_f32_simd(a);'
+        ' util::native<uint32_t> o = util::stdx::static_simd_cast<util::native<uint32_t>>(s);'
+        ' util::stdx::where(simd_mask_as<uint32_t>(s >= 65536.0f), o) = 65535u;'
+        ' util::stdx::where(simd_mask_as<uint32_t>(util::stdx::isnan(s) || s < 0.0f), o) = 0u;'
+        ' return o & 0xFFFFu; }',
+    ),
+}
+
+
+# template_name -> cpp_carry_op_functor
+#
+# Same keying as SIMD_VOP2_BINARY. The functor is invoked as
+#   carry_op(simd<uint32_t> src0, simd<uint32_t> vsrc1, simd<uint32_t> cin)
+#     -> SimdCarry<simd<uint32_t>, mask>
+# inside try_execute_binary_vop2_carry_simd (lane type fixed to uint32_t).
+# `cin` is the incoming VCC bit (0/1 per lane); the add_co/sub_co/subrev_co
+# forms have no carry-in and ignore it (unnamed third parameter). Each functor
+# returns the 32-bit result and a per-lane carry/borrow mask via make_simd_carry;
+# the glue masked-stores the result and merges the carry into VCC for active
+# lanes only. Bit-identical to the scalar bodies:
+#   add_co:     w = (u64)a + (u64)b;          carry  = w > 0xFFFFFFFF
+#   sub_co:     dst = a - b;                  borrow = a < b
+#   subrev_co:  dst = b - a;                  borrow = b < a   (operands swapped)
+#   addc:       w = (u64)a + (u64)b + cin;    carry  = w > 0xFFFFFFFF
+#   subb:       dst = a - b - cin;            borrow = a < b + cin
+#   subbrev:    dst = b - a - cin;            borrow = b < a + cin (operands swapped)
+# The unsigned-wraparound carry/borrow identities (e.g. add carry = (a+b) < a;
+# subtract-with-borrow chain) reproduce the scalar u64-domain results exactly.
+SIMD_VOP2_CARRY: dict[str, str] = {
+    'v_add_co_u32_vop2': (
+        '[](auto a, auto b, auto) {'
+        ' auto s = a + b;'
+        ' return make_simd_carry(s, s < a); }'
+    ),
+    'v_sub_co_u32_vop2': (
+        '[](auto a, auto b, auto) { return make_simd_carry(a - b, a < b); }'
+    ),
+    'v_subrev_co_u32_vop2': (
+        '[](auto a, auto b, auto) { return make_simd_carry(b - a, b < a); }'
+    ),
+    'v_addc_co_u32_vop2': (
+        '[](auto a, auto b, auto cin) {'
+        ' auto t1 = a + b; auto c1 = t1 < a;'
+        ' auto t2 = t1 + cin; auto c2 = t2 < t1;'
+        ' return make_simd_carry(t2, c1 | c2); }'
+    ),
+    'v_subb_co_u32_vop2': (
+        '[](auto a, auto b, auto cin) {'
+        ' auto t1 = a - b; auto bw1 = a < b;'
+        ' auto t2 = t1 - cin; auto bw2 = t1 < cin;'
+        ' return make_simd_carry(t2, bw1 | bw2); }'
+    ),
+    'v_subbrev_co_u32_vop2': (
+        '[](auto a, auto b, auto cin) {'
+        ' auto t1 = b - a; auto bw1 = b < a;'
+        ' auto t2 = t1 - cin; auto bw2 = t1 < cin;'
+        ' return make_simd_carry(t2, bw1 | bw2); }'
+    ),
+    # NOTE: the RDNA VOP2 carry-in aliases (v_add_co_ci / sub_co_ci /
+    # subrev_co_ci _vop2) are intentionally NOT wired here. On RDNA their decoded
+    # form shares routing with the VOP3 add_co_ci path, and a VOP2-carry probe
+    # (carry-in from VCC) diverges from the VOP3 src2 carry-in the kernels feed;
+    # the _vop3 forms in SIMD_VOP3_CARRY_CIN cover these ops correctly.
+}
+
+
+# template_name -> (cpp_type, k_literal_expr, cpp_fma_op_functor)
+#
+# Same keying as SIMD_VOP2_BINARY. The VOP2 FMA/MAC/MAD family has three operand
+# shapes, all built on the single-rounded fused multiply-add (the scalar bodies
+# use std::fma). The functor is invoked as
+#   fma_op(simd<T> src0, simd<T> vsrc1, simd<T> vdst, simd<T> k) -> simd<T>
+# inside try_execute_ternary_vop2_simd; `k` is the broadcast inline literal
+# (`k_literal_expr`, an inst.-qualified expression, or "0u" when there is none).
+# Shapes:
+#   dst-accumulate (fmac/mac):     fma(s0, s1, dvst)        -- ignores k
+#   literal addend (fmaak/madak):  fma(s0, s1, k)           -- ignores dvst
+#   literal mult  (fmamk/madmk):   fma(s0, k, s1)           -- ignores dvst
+# f16 forms (lane type uint32_t) convert each operand via f16_to_f32_simd and
+# round the result with f32_to_f16_simd (single final round, matching scalar).
+# util::stdx::fma is bit-identical to std::fma for all finite/Inf inputs
+# (UtilSimd.Fma_VectorMatchesScalar_BitExact, NaN inputs excluded); the f16<->f32
+# conversions are already bit-exact, so the f16 forms match by composition. When
+# an input is NaN the packed and scalar FMA may pick a different NaN operand to
+# propagate (toolchain-dependent payload); that NaN-payload divergence is
+# accepted (the result is a NaN either way). Note the two
+# distinct literal members: fmaak/fmamk use inst.simm32_, while madak/madmk use
+# inst.simm32.encoding_value_ (matching the scalar bodies). v_fmac_f64 is
+# excluded (64-bit / 2-VGPR lanes — a separate width).
+_FMA_ACC_F32 = '[](auto a, auto b, auto d, auto) { return util::stdx::fma(a, b, d); }'
+_FMA_ADDK_F32 = '[](auto a, auto b, auto, auto k) { return util::stdx::fma(a, b, k); }'
+_FMA_MULK_F32 = '[](auto a, auto b, auto, auto k) { return util::stdx::fma(a, k, b); }'
+_FMA_ACC_F16 = (
+    '[](auto a, auto b, auto d, auto) {'
+    ' return util::f32_to_f16_simd(util::stdx::fma('
+    'util::f16_to_f32_simd(a), util::f16_to_f32_simd(b), util::f16_to_f32_simd(d))); }'
+)
+_FMA_ADDK_F16 = (
+    '[](auto a, auto b, auto, auto k) {'
+    ' return util::f32_to_f16_simd(util::stdx::fma('
+    'util::f16_to_f32_simd(a), util::f16_to_f32_simd(b), util::f16_to_f32_simd(k))); }'
+)
+_FMA_MULK_F16 = (
+    '[](auto a, auto b, auto, auto k) {'
+    ' return util::f32_to_f16_simd(util::stdx::fma('
+    'util::f16_to_f32_simd(a), util::f16_to_f32_simd(k), util::f16_to_f32_simd(b))); }'
+)
+SIMD_VOP2_TERNARY: dict[str, tuple[str, str, str]] = {
+    # --- f32 dst-accumulate ---
+    'v_fmac_f32_vop2': ('float32_t', '0u', _FMA_ACC_F32),
+    'v_fmac_dx9_zero_f32_vop2': ('float32_t', '0u', _FMA_ACC_F32),
+    'v_mac_f32_vop2': ('float32_t', '0u', _FMA_ACC_F32),
+    # --- f32 inline literal ---
+    'v_fmaak_f32_vop2': ('float32_t', 'inst.simm32_', _FMA_ADDK_F32),
+    'v_madak_f32_vop2': ('float32_t', 'inst.simm32.encoding_value_', _FMA_ADDK_F32),
+    'v_fmamk_f32_vop2': ('float32_t', 'inst.simm32_', _FMA_MULK_F32),
+    'v_madmk_f32_vop2': ('float32_t', 'inst.simm32.encoding_value_', _FMA_MULK_F32),
+    # --- f16 dst-accumulate ---
+    'v_fmac_f16_vop2': ('uint32_t', '0u', _FMA_ACC_F16),
+    'v_mac_f16_vop2': ('uint32_t', '0u', _FMA_ACC_F16),
+    # --- f16 inline literal ---
+    'v_madak_f16_vop2': ('uint32_t', 'inst.simm32.encoding_value_', _FMA_ADDK_F16),
+    'v_fmamk_f16_vop2': ('uint32_t', 'inst.simm32_', _FMA_MULK_F16),
+    'v_madmk_f16_vop2': ('uint32_t', 'inst.simm32.encoding_value_', _FMA_MULK_F16),
+    # v_fmaak_f16 (RDNA only): dst = fma(s0, s1, K), K = f16(simm32_). Same f16
+    # FMA functor as v_madak_f16, differing only in the literal field (simm32_ vs
+    # simm32.encoding_value_); the SIMD path is identical to the tested madak_f16.
+    'v_fmaak_f16_vop2': ('uint32_t', 'inst.simm32_', _FMA_ADDK_F16),
+}
+
+
+# template_name -> cpp_fma_op_functor (dst-accumulate, over native<double>).
+#
+# 64-bit-lane VOP2 FMA. The only f64 VOP2 op reachable on CDNA4 is v_fmac_f64
+# (dst = fma(src0, vsrc1, dst), all f64). The functor is invoked as
+#   fma_op(simd<double> src0, simd<double> vsrc1, simd<double> vdst) -> simd<double>
+# inside try_execute_ternary_vop2_f64_simd (lane type fixed to double, read/written
+# through the split lo/hi 32-bit VGPR-pair path). util::stdx::fma over native<double>
+# is bit-identical to the scalar std::fma for all finite/Inf inputs; NaN-input lanes
+# may differ in propagated NaN payload (accepted). Guarded by
+# UtilSimd.FmaF64_VectorMatchesScalar_BitExact.
+SIMD_VOP2_FMA_F64: dict[str, str] = {
+    'v_fmac_f64_vop2': '[](auto a, auto b, auto d) { return util::stdx::fma(a, b, d); }',
+}
+
+
+# --- 64-bit-lane VOP1 unary (f64 math + v_mov_b64) -------------------------
+#
+# Maps template_name -> (lane_cpp_type, unary functor). Read/written as
+# native<T> through the split lo/hi VGPR-pair path (read_simd64/write_simd64).
+# The math ops use T = double and mirror the scalar body verbatim: the scalar
+# rcp/rsq write `1.0f / x` (the float 1.0f converts exactly to 1.0 and the
+# division is done in double), so the SIMD form uses native<double>(1.0). All
+# map to correctly-rounded IEEE ops (vroundpd / vsqrtpd / vdivpd), bit-identical
+# to std::* for finite/Inf inputs; NaN-input payload divergence is accepted (see
+# the glue note + UtilSimd.*F64*_BitExact guards). v_mov_b64 is a pure 64-bit
+# copy (T = uint64_t).
+SIMD_VOP1_UNARY_F64: dict[str, tuple[str, str]] = {
+    'v_ceil_f64_vop1': ('double', '[](auto a) { return util::ceil_simd(a); }'),
+    'v_floor_f64_vop1': ('double', '[](auto a) { return util::floor_simd(a); }'),
+    'v_trunc_f64_vop1': ('double', '[](auto a) { return util::trunc_simd(a); }'),
+    'v_rndne_f64_vop1': ('double', '[](auto a) { return util::rndne_simd(a); }'),
+    'v_fract_f64_vop1': ('double', '[](auto a) { return a - util::floor_simd(a); }'),
+    'v_rcp_f64_vop1': (
+        'double',
+        '[](auto a) { return util::native<double>(1.0) / a; }',
+    ),
+    'v_rsq_f64_vop1': (
+        'double',
+        '[](auto a) { return util::native<double>(1.0) / util::stdx::sqrt(a); }',
+    ),
+    'v_sqrt_f64_vop1': ('double', '[](auto a) { return util::stdx::sqrt(a); }'),
+    'v_mov_b64_vop1': ('uint64_t', '[](auto a) { return a; }'),
+    # frexp mantissa: significand in [0.5,1) via bitfield rebias + denormal
+    # renorm (see util::frexp_mant_f64_simd). VOP3 twin in SIMD_VOP3_UNARY_FP64.
+    'v_frexp_mant_f64_vop1': (
+        'double',
+        '[](auto a) { return util::frexp_mant_f64_simd(a); }',
+    ),
+}
+
+
+# --- mixed-width f64 <-> 32-bit conversions -------------------------------
+#
+# These VOP1 cvt ops bridge an 8-wide (native_width64) f64 chunk and the same
+# number of 32-bit lanes, so they use dedicated glue rather than the equal-width
+# unary path. The 32-bit side is a util::narrow32<T> (fixed_size_simd<T,8>); a
+# direct static_simd_cast bridges it to/from native<double> with no bit_cast.
+#
+# f64 source -> 32-bit dst. template_name -> (out_lane_cpp_type, functor); the
+# functor is invoked as cvt_op(native<double>) -> narrow32<Tout> inside
+# try_execute_cvt_f64_to_b32_simd. cvt_f32_f64 is a single correctly-rounded
+# narrowing cast (vcvtpd2ps); the int forms do NaN->0 and the saturating clamp in
+# the double domain (all where-masks native<double>, so no cross-width mask cast)
+# then one truncating cast to the 8-wide int — bit-identical to the scalar body
+# for finite/Inf inputs. A NaN *result* of cvt_f32_f64 may differ in payload
+# (accepted; the A/B test skips it). INT32_MAX/MIN and UINT32_MAX are all exactly
+# representable in double, so the clamp constants cast back to the exact integers.
+SIMD_CVT_F64_TO_B32: dict[str, tuple[str, str]] = {
+    'v_cvt_f32_f64_vop1': (
+        'float32_t',
+        '[](auto s) { return util::stdx::static_simd_cast<util::narrow32<float32_t>>(s); }',
+    ),
+    'v_cvt_i32_f64_vop1': (
+        'int32_t',
+        '[](auto s) {'
+        ' auto r = s;'
+        ' util::stdx::where(util::stdx::isnan(s), r) = 0.0;'
+        ' util::stdx::where(s >= 2147483648.0, r) = 2147483647.0;'
+        ' util::stdx::where(s < -2147483648.0, r) = -2147483648.0;'
+        ' return util::stdx::static_simd_cast<util::narrow32<int32_t>>(r); }',
+    ),
+    'v_cvt_u32_f64_vop1': (
+        'uint32_t',
+        '[](auto s) {'
+        ' auto r = s;'
+        ' util::stdx::where(util::stdx::isnan(s) || s < 0.0, r) = 0.0;'
+        ' util::stdx::where(s >= 4294967296.0, r) = 4294967295.0;'
+        ' return util::stdx::static_simd_cast<util::narrow32<uint32_t>>(r); }',
+    ),
+    # frexp exponent (f64 -> int32). util::frexp_exp_f64_simd returns the int32 in
+    # the low 32 bits of each 64-bit lane; the narrowing cast keeps them. The VOP3
+    # twin applies float omod/clamp to float(exp) + bit-casts (a different output
+    # encoding), so it stays scalar (_VOP3_UNARY_SKIP gates the cvt auto-route).
+    'v_frexp_exp_i32_f64_vop1': (
+        'int32_t',
+        '[](auto s) {'
+        ' return util::stdx::static_simd_cast<util::narrow32<int32_t>>('
+        'util::frexp_exp_f64_simd(s)); }',
+    ),
+}
+
+# 32-bit source -> f64 dst. template_name -> (in_lane_cpp_type, functor); the
+# functor is invoked as cvt_op(narrow32<Tin>) -> native<double> inside
+# try_execute_cvt_b32_to_f64_simd. Each is an exact widening static_simd_cast
+# (vcvtps2pd for f32; int->double for i32/u32), bit-identical to the scalar body
+# (static_cast<double>) for every input.
+SIMD_CVT_B32_TO_F64: dict[str, tuple[str, str]] = {
+    'v_cvt_f64_f32_vop1': (
+        'float32_t',
+        '[](auto in) { return util::stdx::static_simd_cast<util::native<double>>(in); }',
+    ),
+    'v_cvt_f64_i32_vop1': (
+        'int32_t',
+        '[](auto in) { return util::stdx::static_simd_cast<util::native<double>>(in); }',
+    ),
+    'v_cvt_f64_u32_vop1': (
+        'uint32_t',
+        '[](auto in) { return util::stdx::static_simd_cast<util::native<double>>(in); }',
+    ),
+}
+
+
+# template_name set for v_cndmask_b32 (VCC-driven per-lane select). No functor:
+# the op is fixed (dst = (VCC bit) ? vsrc1 : src0), a pure 32-bit bit select, so
+# the SIMD result is bit-identical to the scalar body for every input.
+SIMD_VOP2_CNDMASK: set[str] = {
+    'v_cndmask_b32_vop2',
+}
+
+# VOP3 form of v_cndmask_b32: same per-lane select, but the 64-bit selector is
+# read from the SGPR-pair `src2` instead of VCC. Also fixed-op / functorless.
+SIMD_VOP3_CNDMASK: set[str] = {
+    'v_cndmask_b32_vop3',
+}
+
+# 16-bit variant — RDNA3+. Low-16 of each source selected per lane, high-16
+# zero (matches scalar `uint32_t(uint16_t(...))` write pattern).
+SIMD_VOP3_CNDMASK_B16: set[str] = {
+    'v_cndmask_b16_vop3',
+}
+
+# VOP3 div_fmas: fma(src0, src1, src2) followed by a VCC-bit-gated
+# ldexp(result, 32) (f32) or ldexp(result, 64) (f64). Fixed-op / functorless.
+SIMD_VOP3_DIV_FMAS_FP32: set[str] = {
+    'v_div_fmas_f32_vop3',
+}
+SIMD_VOP3_DIV_FMAS_FP64: set[str] = {
+    'v_div_fmas_f64_vop3',
+}
+
+# VOP3P fma_mix / mad_mix family. The six ops share one body (`a*b + c` plus
+# optional clamp to [0,1]); only the destination shape differs:
+#  - F32     -> v_fma_mix_f32_vop3p (RDNA3+), v_mad_mix_f32_vop3p (CDNA1-4)
+#  - F16_LO  -> v_fma_mixlo_f16_vop3p, v_mad_mixlo_f16_vop3p
+#  - F16_HI  -> v_fma_mixhi_f16_vop3p, v_mad_mixhi_f16_vop3p
+# Per-source op_sel_hi gates the f16<->f32 widening shape; op_sel picks the f16
+# half. neg flips the sign bit. No abs, no omod. Functorless / fixed-op.
+SIMD_VOP3P_FMA_MIX_F32: set[str] = {
+    'v_fma_mix_f32_vop3p',
+    'v_mad_mix_f32_vop3p',
+}
+SIMD_VOP3P_FMA_MIX_F16_LO: set[str] = {
+    'v_fma_mixlo_f16_vop3p',
+    'v_mad_mixlo_f16_vop3p',
+}
+SIMD_VOP3P_FMA_MIX_F16_HI: set[str] = {
+    'v_fma_mixhi_f16_vop3p',
+    'v_mad_mixhi_f16_vop3p',
+}
+
+# VOP3P packed-16 integer binary family. Each 32-bit lane holds {low16,
+# high16}. The glue gates op_sel == 0 && op_sel_hi == 3 (default packing)
+# and bails to scalar otherwise; the functor receives the two u32 simd
+# vectors as packed pairs and returns the same shape with the per-half op
+# applied. Scalar bodies for these ops do NOT apply neg/neg_hi/clamp on
+# integer operands, so the SIMD path also passes through. mul_lo / shift
+# functors mask each half to 16 bits before packing to drop any product
+# overflow / shift-into-bit-16 leakage between halves.
+SIMD_VOP3P_PK_BINARY_INT: dict[str, str] = {
+    'v_pk_add_u16_vop3p': (
+        '[](auto a, auto b) {'
+        ' auto lo = (a + b) & 0xFFFFu;'
+        ' auto hi = ((a >> 16) + (b >> 16)) & 0xFFFFu;'
+        ' return lo | (hi << 16); }'
+    ),
+    # add_i16 is bit-identical to add_u16 (mod-2^16 wrap matches).
+    'v_pk_add_i16_vop3p': (
+        '[](auto a, auto b) {'
+        ' auto lo = (a + b) & 0xFFFFu;'
+        ' auto hi = ((a >> 16) + (b >> 16)) & 0xFFFFu;'
+        ' return lo | (hi << 16); }'
+    ),
+    'v_pk_sub_u16_vop3p': (
+        '[](auto a, auto b) {'
+        ' auto lo = (a - b) & 0xFFFFu;'
+        ' auto hi = ((a >> 16) - (b >> 16)) & 0xFFFFu;'
+        ' return lo | (hi << 16); }'
+    ),
+    'v_pk_sub_i16_vop3p': (
+        '[](auto a, auto b) {'
+        ' auto lo = (a - b) & 0xFFFFu;'
+        ' auto hi = ((a >> 16) - (b >> 16)) & 0xFFFFu;'
+        ' return lo | (hi << 16); }'
+    ),
+    'v_pk_mul_lo_u16_vop3p': (
+        '[](auto a, auto b) {'
+        ' auto lo = ((a & 0xFFFFu) * (b & 0xFFFFu)) & 0xFFFFu;'
+        ' auto hi = ((a >> 16) * (b >> 16)) & 0xFFFFu;'
+        ' return lo | (hi << 16); }'
+    ),
+    # Reverse-shift forms: src1 holds the value, src0 holds the count.
+    # Shift count masked to low 4 bits per scalar (`& 15u`).
+    'v_pk_lshlrev_b16_vop3p': (
+        '[](auto a, auto b) {'
+        ' auto lo = ((b & 0xFFFFu) << (a & 15u)) & 0xFFFFu;'
+        ' auto hi = (((b >> 16) & 0xFFFFu) << ((a >> 16) & 15u)) & 0xFFFFu;'
+        ' return lo | (hi << 16); }'
+    ),
+    'v_pk_lshrrev_b16_vop3p': (
+        '[](auto a, auto b) {'
+        ' auto lo = ((b & 0xFFFFu) >> (a & 15u)) & 0xFFFFu;'
+        ' auto hi = ((b >> 16) >> ((a >> 16) & 15u)) & 0xFFFFu;'
+        ' return lo | (hi << 16); }'
+    ),
+    # Arithmetic right shift on i16: sign-extend each half to int32 via
+    # (x << 16) >> 16, shift, mask back to 16.
+    'v_pk_ashrrev_i16_vop3p': (
+        '[](auto a, auto b) {'
+        ' using I = util::native<int32_t>;'
+        ' auto bv_lo = (util::stdx::static_simd_cast<I>(b & 0xFFFFu) << 16) >> 16;'
+        ' auto bv_hi = (util::stdx::static_simd_cast<I>(b >> 16) << 16) >> 16;'
+        ' auto sh_lo = util::stdx::static_simd_cast<I>(a & 15u);'
+        ' auto sh_hi = util::stdx::static_simd_cast<I>((a >> 16) & 15u);'
+        ' auto rlo = util::stdx::static_simd_cast<util::native<uint32_t>>(bv_lo >> sh_lo) & 0xFFFFu;'
+        ' auto rhi = util::stdx::static_simd_cast<util::native<uint32_t>>(bv_hi >> sh_hi) & 0xFFFFu;'
+        ' return rlo | (rhi << 16); }'
+    ),
+    'v_pk_min_u16_vop3p': (
+        '[](auto a, auto b) {'
+        ' auto lo = util::stdx::min(a & 0xFFFFu, b & 0xFFFFu);'
+        ' auto hi = util::stdx::min(a >> 16, b >> 16);'
+        ' return (lo & 0xFFFFu) | ((hi & 0xFFFFu) << 16); }'
+    ),
+    'v_pk_max_u16_vop3p': (
+        '[](auto a, auto b) {'
+        ' auto lo = util::stdx::max(a & 0xFFFFu, b & 0xFFFFu);'
+        ' auto hi = util::stdx::max(a >> 16, b >> 16);'
+        ' return (lo & 0xFFFFu) | ((hi & 0xFFFFu) << 16); }'
+    ),
+    'v_pk_min_i16_vop3p': (
+        '[](auto a, auto b) {'
+        ' using I = util::native<int32_t>;'
+        ' auto a_lo = (util::stdx::static_simd_cast<I>(a & 0xFFFFu) << 16) >> 16;'
+        ' auto a_hi = (util::stdx::static_simd_cast<I>(a >> 16) << 16) >> 16;'
+        ' auto b_lo = (util::stdx::static_simd_cast<I>(b & 0xFFFFu) << 16) >> 16;'
+        ' auto b_hi = (util::stdx::static_simd_cast<I>(b >> 16) << 16) >> 16;'
+        ' auto rlo = util::stdx::static_simd_cast<util::native<uint32_t>>(util::stdx::min(a_lo, b_lo)) & 0xFFFFu;'
+        ' auto rhi = util::stdx::static_simd_cast<util::native<uint32_t>>(util::stdx::min(a_hi, b_hi)) & 0xFFFFu;'
+        ' return rlo | (rhi << 16); }'
+    ),
+    'v_pk_max_i16_vop3p': (
+        '[](auto a, auto b) {'
+        ' using I = util::native<int32_t>;'
+        ' auto a_lo = (util::stdx::static_simd_cast<I>(a & 0xFFFFu) << 16) >> 16;'
+        ' auto a_hi = (util::stdx::static_simd_cast<I>(a >> 16) << 16) >> 16;'
+        ' auto b_lo = (util::stdx::static_simd_cast<I>(b & 0xFFFFu) << 16) >> 16;'
+        ' auto b_hi = (util::stdx::static_simd_cast<I>(b >> 16) << 16) >> 16;'
+        ' auto rlo = util::stdx::static_simd_cast<util::native<uint32_t>>(util::stdx::max(a_lo, b_lo)) & 0xFFFFu;'
+        ' auto rhi = util::stdx::static_simd_cast<util::native<uint32_t>>(util::stdx::max(a_hi, b_hi)) & 0xFFFFu;'
+        ' return rlo | (rhi << 16); }'
+    ),
+}
+
+# VOP3P packed-16 integer ternary (pk_mad_i16 / pk_mad_u16). Same default
+# packing gate as the binary table (op_sel/op_sel_hi/op_sel_hi_2). Scalar
+# truncates to 16 bits via uint16_t cast, so the SIMD path masks each half
+# to 16 bits before pack.
+SIMD_VOP3P_PK_TERNARY_INT: dict[str, str] = {
+    'v_pk_mad_i16_vop3p': (
+        '[](auto a, auto b, auto c) {'
+        ' using I = util::native<int32_t>;'
+        ' auto a_lo = (util::stdx::static_simd_cast<I>(a & 0xFFFFu) << 16) >> 16;'
+        ' auto a_hi = (util::stdx::static_simd_cast<I>(a >> 16) << 16) >> 16;'
+        ' auto b_lo = (util::stdx::static_simd_cast<I>(b & 0xFFFFu) << 16) >> 16;'
+        ' auto b_hi = (util::stdx::static_simd_cast<I>(b >> 16) << 16) >> 16;'
+        ' auto c_lo = (util::stdx::static_simd_cast<I>(c & 0xFFFFu) << 16) >> 16;'
+        ' auto c_hi = (util::stdx::static_simd_cast<I>(c >> 16) << 16) >> 16;'
+        ' auto rlo = util::stdx::static_simd_cast<util::native<uint32_t>>(a_lo * b_lo + c_lo) & 0xFFFFu;'
+        ' auto rhi = util::stdx::static_simd_cast<util::native<uint32_t>>(a_hi * b_hi + c_hi) & 0xFFFFu;'
+        ' return rlo | (rhi << 16); }'
+    ),
+    'v_pk_mad_u16_vop3p': (
+        '[](auto a, auto b, auto c) {'
+        ' auto a_lo = a & 0xFFFFu;'
+        ' auto a_hi = a >> 16;'
+        ' auto b_lo = b & 0xFFFFu;'
+        ' auto b_hi = b >> 16;'
+        ' auto c_lo = c & 0xFFFFu;'
+        ' auto c_hi = c >> 16;'
+        ' auto rlo = (a_lo * b_lo + c_lo) & 0xFFFFu;'
+        ' auto rhi = (a_hi * b_hi + c_hi) & 0xFFFFu;'
+        ' return rlo | (rhi << 16); }'
+    ),
+}
+
+# VOP3P packed-16 f16 binary family. Each 32-bit lane holds 2 f16 values.
+# Glue widens halves to f32, applies neg/neg_hi (sign-bit toggle), runs the
+# per-half functor in f32, narrows back to f16, packs. No clamp on any
+# pk_*_f16 scalar body (verified line 15109, 15519). NaN-input lanes can
+# diverge in payload (same as the existing f16 ternary slice).
+SIMD_VOP3P_PK_BINARY_FP16: dict[str, str] = {
+    'v_pk_add_f16_vop3p': '[](auto a, auto b) { return a + b; }',
+    'v_pk_mul_f16_vop3p': '[](auto a, auto b) { return a * b; }',
+    'v_pk_max_f16_vop3p': '[](auto a, auto b) { return util::stdx::fmax(a, b); }',
+    'v_pk_min_f16_vop3p': '[](auto a, auto b) { return util::stdx::fmin(a, b); }',
+}
+
+# pk_fma_f16 — 3-source FMA per half. NaN-input payload divergence accepted.
+SIMD_VOP3P_PK_TERNARY_FP16: dict[str, str] = {
+    'v_pk_fma_f16_vop3p': '[](auto a, auto b, auto c) { return util::stdx::fma(a, b, c); }',
+}
+
+# v_pk_mov_b32 — default-packing-only fast path. Each src is a 64-bit pair
+# (consecutive VGPRs), result is (src0_lo, src1_hi). Functorless / fixed-op.
+SIMD_VOP3P_MOV_B32: set[str] = {
+    'v_pk_mov_b32_vop3p',
+}
+
+# VOP3P integer dot products. dst is a single 32-bit lane (not packed) and
+# src2 is the accumulator; the dot reduction happens within each lane so the
+# fast path vectorizes across lanes. Parameterised by (ElemBits, Signed):
+# the 8/4-bit forms ignore op_sel in the scalar body, the 16-bit forms gate
+# on default packing inside the glue. Signed forms lower-clamp to 0 when
+# inst.clamp is set; the unsigned scalar bodies have no clamp branch.
+SIMD_VOP3P_DOT_INT: dict[str, str] = {
+    'v_dot4_i32_i8_vop3p': '8, true',
+    'v_dot4_u32_u8_vop3p': '8, false',
+    'v_dot8_i32_i4_vop3p': '4, true',
+    'v_dot8_u32_u4_vop3p': '4, false',
+    'v_dot2_i32_i16_vop3p': '16, true',
+    'v_dot2_u32_u16_vop3p': '16, false',
+}
+
+# v_dot2_f32_f16 — two f16 products + an f32 accumulator into one f32 lane.
+# op_sel half-select (gated default), neg/neg_hi sign flips, optional clamp
+# to [0,1]. Functorless / fixed-op.
+SIMD_VOP3P_DOT_F16: set[str] = {
+    'v_dot2_f32_f16_vop3p',
+}
+
+
+# --- VOPC compare -> VCC ---------------------------------------------------
+#
+# 198 VOPC opcodes on CDNA4 are the single biggest breadth. Each writes one bit
+# into VCC per active EXEC lane (inactive bits preserved); CDNA4 has no v_cmpx
+# (EXEC-writing) form, so one glue shape (try_execute_vopc_simd) covers them all.
+# The table maps template_name -> (lane_cpp_type, cmp_functor); the functor is
+# invoked as cmp_op(native<T> src0, native<T> vsrc1) -> simd_mask and must mirror
+# the scalar body's comparison expression *verbatim* (esp. the ordered vs
+# unordered NaN behaviour, e.g. v_cmp_nlt = !(a < b), true on NaN). It is built
+# programmatically below from per-suffix operand conversions and per-relation
+# expressions.
+#
+# Lane width buckets: the 32-bit (f32/i32/u32) and 16-bit (f16/i16/u16) suffixes
+# all read as 32-bit lanes — the 16-bit ones narrow/convert inside the functor —
+# so they share the existing read_simd<T> path. The 64-bit suffixes (f64/i64/u64)
+# need the 64-bit-lane infra and are wired separately. v_cmp_class_* (a bitfield
+# class test, not a relational compare) is left scalar.
+
+# suffix -> (lane_cpp_type, operand-conversion template using {x})
+_VOPC_SUFFIX: dict[str, tuple[str, str]] = {
+    'f32': ('float32_t', '{x}'),
+    'f16': ('uint32_t', 'util::f16_to_f32_simd({x})'),
+    'i32': ('int32_t', '{x}'),
+    'u32': ('uint32_t', '{x}'),
+    # 16-bit integers read as uint32 lanes; sign-extend / mask the low 16 bits to
+    # match the scalar static_cast<int16_t>/<uint16_t>.
+    'i16': (
+        'uint32_t',
+        '((util::stdx::static_simd_cast<util::native<int32_t>>({x}) << 16) >> 16)',
+    ),
+    'u16': ('uint32_t', '({x} & 0xFFFFu)'),
+    # 64-bit lanes: read directly as the native 64-bit lane type (read_simd64),
+    # so the conversion is the identity. Routed through the VOPC64 glue.
+    'f64': ('double', '{x}'),
+    'i64': ('int64_t', '{x}'),
+    'u64': ('uint64_t', '{x}'),
+}
+
+# relation -> mask expression over converted operands {a}, {b}. These mirror the
+# generated scalar comparison expressions exactly (incl. float ordered/unordered
+# NaN semantics): the n* forms are the logical negation of the base relation, so
+# they are true on NaN; o/u test orderedness directly.
+_VOPC_REL: dict[str, str] = {
+    'eq': '{a} == {b}',
+    'lt': '{a} < {b}',
+    'le': '{a} <= {b}',
+    'gt': '{a} > {b}',
+    'ge': '{a} >= {b}',
+    'ne': '{a} != {b}',  # integer not-equal
+    # float less-or-greater: ordered, FALSE on NaN. Scalar body is (a<b)||(a>b),
+    # NOT a!=b (which is TRUE on NaN). nlg is its logical negation.
+    'lg': '({a} < {b}) || ({a} > {b})',
+    'neq': '{a} != {b}',  # float not-equal
+    'nge': '!({a} >= {b})',
+    'ngt': '!({a} > {b})',
+    'nle': '!({a} <= {b})',
+    'nlg': '!(({a} < {b}) || ({a} > {b}))',
+    'nlt': '!({a} < {b})',
+    'o': '!util::stdx::isnan({a}) && !util::stdx::isnan({b})',
+    'u': 'util::stdx::isnan({a}) || util::stdx::isnan({b})',
+}
+
+# Constant relations carry no comparison: f is always-false, t/tru always-true.
+# The mask type is taken from the converted-operand compare so it matches lane
+# width regardless of suffix.
+_VOPC_CONST: dict[str, str] = {'f': 'false', 't': 'true', 'tru': 'true'}
+
+_VOPC_FLOAT_RELS = [
+    'eq',
+    'ge',
+    'gt',
+    'le',
+    'lg',
+    'lt',
+    'neq',
+    'nge',
+    'ngt',
+    'nle',
+    'nlg',
+    'nlt',
+    'o',
+    'u',
+    'f',
+    'tru',
+]
+_VOPC_INT_RELS = ['eq', 'ge', 'gt', 'le', 'lt', 'ne', 'f', 't']
+
+
+def _vopc_functor(conv: str, rel: str) -> str:
+    ca = conv.format(x='a')
+    cb = conv.format(x='b')
+    if rel in _VOPC_CONST:
+        body = f'decltype({ca} == {cb})({_VOPC_CONST[rel]})'
+    else:
+        body = _VOPC_REL[rel].format(a=ca, b=cb)
+    return f'[](auto a, auto b) {{ return {body}; }}'
+
+
+def _build_simd_vopc() -> dict[str, tuple[str, str]]:
+    table: dict[str, tuple[str, str]] = {}
+    # 16-/32-bit lane suffixes only; f64/i64/u64 (64-bit lane) wired separately.
+    for suf in ('f16', 'f32'):
+        lane_t, conv = _VOPC_SUFFIX[suf]
+        for rel in _VOPC_FLOAT_RELS:
+            table[f'v_cmp_{rel}_{suf}_vopc'] = (lane_t, _vopc_functor(conv, rel))
+    for suf in ('i16', 'u16', 'i32', 'u32'):
+        lane_t, conv = _VOPC_SUFFIX[suf]
+        for rel in _VOPC_INT_RELS:
+            table[f'v_cmp_{rel}_{suf}_vopc'] = (lane_t, _vopc_functor(conv, rel))
+    return table
+
+
+def _build_simd_vopc64() -> dict[str, tuple[str, str]]:
+    """64-bit-lane VOPC compares (f64/i64/u64), routed through the VOPC64 glue."""
+    table: dict[str, tuple[str, str]] = {}
+    lane_t, conv = _VOPC_SUFFIX['f64']
+    for rel in _VOPC_FLOAT_RELS:
+        table[f'v_cmp_{rel}_f64_vopc'] = (lane_t, _vopc_functor(conv, rel))
+    for suf in ('i64', 'u64'):
+        lane_t, conv = _VOPC_SUFFIX[suf]
+        for rel in _VOPC_INT_RELS:
+            table[f'v_cmp_{rel}_{suf}_vopc'] = (lane_t, _vopc_functor(conv, rel))
+    return table
+
+
+SIMD_VOPC: dict[str, tuple[str, str]] = _build_simd_vopc()
+SIMD_VOPC64: dict[str, tuple[str, str]] = _build_simd_vopc64()
+
+
+# --- VOPC v_cmp_class -> VCC ----------------------------------------------
+#
+# v_cmp_class tests src0's IEEE-754 float class against a 10-bit class mask in
+# vsrc1 and writes one VCC bit per active lane. It is NOT a relational compare
+# (no src0-vs-vsrc1 ordering), so it needs a class-decode functor rather than the
+# relational builder above — but the VCC merge / lane packing is identical, so the
+# f16/f32 forms reuse try_execute_vopc_simd (lane type uint32_t, raw bits). src0 is
+# read as raw bits and vsrc1 as the mask; the functor partitions the value into
+# exactly one of the 10 mutually exclusive classes (one bit set in `cls`) and
+# returns `(cls & mask) != 0`, which equals the scalar body's OR of mask-gated
+# class predicates. The classification is done purely from the exponent / mantissa
+# / sign bits (matching the scalar std::isnan/isinf/isnormal/signbit outcomes,
+# which for finite/Inf reduce to the same bit tests), so it is bit-exact for every
+# input including NaN payloads. f64 (a 64-bit value vs a 32-bit mask) needs a
+# mixed-width glue and is wired separately.
+#
+# Class-bit layout (low 10 bits of the mask): 0x001 sNaN, 0x002 qNaN, 0x004 -Inf,
+# 0x008 -normal, 0x010 -denormal, 0x020 -0, 0x040 +0, 0x080 +denormal,
+# 0x100 +normal, 0x200 +Inf. The qNaN bit is the mantissa MSB
+# (f32 0x00400000, f16 0x0200).
+_CMP_CLASS_F32 = (
+    '[](auto a, auto b) {'
+    ' using U = util::native<uint32_t>;'
+    ' U exp = (a >> 23) & 0xFFu;'
+    ' U mant = a & 0x7FFFFFu;'
+    ' auto sgn = ((a >> 31) & 1u) != 0u;'
+    ' auto qnan = ((a >> 22) & 1u) != 0u;'
+    ' auto is_nan = (exp == 0xFFu) && (mant != 0u);'
+    ' auto is_inf = (exp == 0xFFu) && (mant == 0u);'
+    ' auto is_zero = (exp == 0u) && (mant == 0u);'
+    ' auto is_den = (exp == 0u) && (mant != 0u);'
+    ' auto is_norm = (exp >= 1u) && (exp <= 0xFEu);'
+    ' U cls(0u);'
+    ' util::stdx::where(is_nan && !qnan, cls) = 0x001u;'
+    ' util::stdx::where(is_nan && qnan, cls) = 0x002u;'
+    ' util::stdx::where(is_inf && sgn, cls) = 0x004u;'
+    ' util::stdx::where(is_norm && sgn, cls) = 0x008u;'
+    ' util::stdx::where(is_den && sgn, cls) = 0x010u;'
+    ' util::stdx::where(is_zero && sgn, cls) = 0x020u;'
+    ' util::stdx::where(is_zero && !sgn, cls) = 0x040u;'
+    ' util::stdx::where(is_den && !sgn, cls) = 0x080u;'
+    ' util::stdx::where(is_norm && !sgn, cls) = 0x100u;'
+    ' util::stdx::where(is_inf && !sgn, cls) = 0x200u;'
+    ' return (cls & b) != 0u; }'
+)
+_CMP_CLASS_F16 = (
+    '[](auto a, auto b) {'
+    ' using U = util::native<uint32_t>;'
+    ' U h = a & 0xFFFFu;'
+    ' U exp = (h >> 10) & 0x1Fu;'
+    ' U mant = h & 0x3FFu;'
+    ' auto sgn = ((h >> 15) & 1u) != 0u;'
+    ' auto qnan = ((h >> 9) & 1u) != 0u;'
+    ' auto is_nan = (exp == 0x1Fu) && (mant != 0u);'
+    ' auto is_inf = (exp == 0x1Fu) && (mant == 0u);'
+    ' auto is_zero = (exp == 0u) && (mant == 0u);'
+    ' auto is_den = (exp == 0u) && (mant != 0u);'
+    ' auto is_norm = (exp >= 1u) && (exp <= 30u);'
+    ' U cls(0u);'
+    ' util::stdx::where(is_nan && !qnan, cls) = 0x001u;'
+    ' util::stdx::where(is_nan && qnan, cls) = 0x002u;'
+    ' util::stdx::where(is_inf && sgn, cls) = 0x004u;'
+    ' util::stdx::where(is_norm && sgn, cls) = 0x008u;'
+    ' util::stdx::where(is_den && sgn, cls) = 0x010u;'
+    ' util::stdx::where(is_zero && sgn, cls) = 0x020u;'
+    ' util::stdx::where(is_zero && !sgn, cls) = 0x040u;'
+    ' util::stdx::where(is_den && !sgn, cls) = 0x080u;'
+    ' util::stdx::where(is_norm && !sgn, cls) = 0x100u;'
+    ' util::stdx::where(is_inf && !sgn, cls) = 0x200u;'
+    ' return (cls & b) != 0u; }'
+)
+SIMD_VOPC_CLASS: dict[str, tuple[str, str]] = {
+    'v_cmp_class_f16_vopc': ('uint32_t', _CMP_CLASS_F16),
+    'v_cmp_class_f32_vopc': ('uint32_t', _CMP_CLASS_F32),
+}
+
+
+# v_cmp_class_f64: a 64-bit f64 value (src0) tested against a 32-bit class mask
+# (vsrc1), so it needs the mixed-width class glue (try_execute_vopc_class_f64_simd)
+# rather than the equal-width VOPC path. The functor receives src0 as
+# native<uint64_t> raw bits and vsrc1 as a native_width64-wide narrow32<uint32_t>
+# mask; it classifies the f64 from its raw bits (qNaN bit = mantissa MSB
+# 0x0008000000000000), partitions into one of the 10 mutually exclusive classes,
+# casts the small class code down to the 32-bit mask width, and returns
+# (cls & mask) != 0. Pure bit decode, bit-exact with the scalar body. The
+# class-bit layout matches the f16/f32 forms above.
+_CMP_CLASS_F64 = (
+    '[](auto s, auto m) {'
+    ' using U = util::native<uint64_t>;'
+    ' U exp = (s >> 52) & 0x7FFu;'
+    ' U mant = s & 0xFFFFFFFFFFFFFull;'
+    ' auto sgn = ((s >> 63) & 1u) != 0u;'
+    ' auto qnan = ((s >> 51) & 1u) != 0u;'
+    ' auto is_nan = (exp == 0x7FFu) && (mant != 0u);'
+    ' auto is_inf = (exp == 0x7FFu) && (mant == 0u);'
+    ' auto is_zero = (exp == 0u) && (mant == 0u);'
+    ' auto is_den = (exp == 0u) && (mant != 0u);'
+    ' auto is_norm = (exp >= 1u) && (exp <= 0x7FEu);'
+    ' U cls(0u);'
+    ' util::stdx::where(is_nan && !qnan, cls) = 0x001u;'
+    ' util::stdx::where(is_nan && qnan, cls) = 0x002u;'
+    ' util::stdx::where(is_inf && sgn, cls) = 0x004u;'
+    ' util::stdx::where(is_norm && sgn, cls) = 0x008u;'
+    ' util::stdx::where(is_den && sgn, cls) = 0x010u;'
+    ' util::stdx::where(is_zero && sgn, cls) = 0x020u;'
+    ' util::stdx::where(is_zero && !sgn, cls) = 0x040u;'
+    ' util::stdx::where(is_den && !sgn, cls) = 0x080u;'
+    ' util::stdx::where(is_norm && !sgn, cls) = 0x100u;'
+    ' util::stdx::where(is_inf && !sgn, cls) = 0x200u;'
+    ' auto cls32 = util::stdx::static_simd_cast<util::narrow32<uint32_t>>(cls);'
+    ' return (cls32 & m) != 0u; }'
+)
+SIMD_VOPC_CLASS_F64: dict[str, str] = {
+    'v_cmp_class_f64_vopc': _CMP_CLASS_F64,
+}
+
+
+# VOP3 forms of v_cmp_class. Same classification as the VOPC forms (the functors
+# are reused verbatim), but the VOP3 glue additionally applies the abs/neg source
+# modifiers to src0's raw bits before classifying, reads the class mask from src1,
+# and merges the result into the SGPR-pair dst (inst.vdst.read/write_scalar64)
+# rather than VCC. The per-op sign-bit mask (abs clears it, neg flips it) is passed
+# to the glue: 0x8000 (f16) / 0x80000000 (f32) share a uint32 lane, 0x8000…0 (f64)
+# is 64-bit. f16/f32 go through the 32-bit-value glue; f64 through the 64-bit one.
+SIMD_VOP3_CLASS: dict[str, tuple[str, str]] = {
+    'v_cmp_class_f16_vop3': ('0x8000u', _CMP_CLASS_F16),
+    'v_cmp_class_f32_vop3': ('0x80000000u', _CMP_CLASS_F32),
+}
+SIMD_VOP3_CLASS_F64: dict[str, str] = {
+    'v_cmp_class_f64_vop3': _CMP_CLASS_F64,
+}
+
+
+# --- VOP3 forms of the relational VOPC compares ----------------------------
+#
+# The VOP3 form of v_cmp_<rel>_<suffix> differs from the VOPC form in three
+# ways: (1) it reads src0/src1 (not src0/vsrc1), (2) abs/neg per-source
+# modifiers apply to floating-point operands, and (3) the per-lane compare
+# result merges into an arbitrary SGPR-pair dst via
+# inst.vdst.read/write_scalar64 instead of the fixed VCC. The lane-pack /
+# inactive-bit-preservation merge is identical to the VOPC path; this is what
+# the VOP3 VOPC glue templates implement.
+#
+# Integer/bitwise VOPC bodies apply no modifiers, so their functors are the
+# same as the VOPC ones (built by _vopc_functor); they go through
+# try_execute_vopc_vop3_int_simd (32-bit lane) or
+# try_execute_vopc64_vop3_int_simd (64-bit lane).
+#
+# Floating-point VOPC bodies in VOP3 form apply abs (std::fabs) then neg per
+# source on the already-widened/converted operand; the float-bucket tables
+# below build new functors that take the post-modifier value (no in-functor
+# widen), and the corresponding glue applies the modifier outside before
+# calling.
+#
+# VOP3 fp adds two extra rels vs VOPC: 't' alongside 'tru' (both constant
+# always-true), so the table keys span the union of the two.
+_VOP3_FLOAT_RELS = _VOPC_FLOAT_RELS + ['t']
+
+
+def _build_simd_vopc_vop3_int_32() -> dict[str, tuple[str, str]]:
+    """VOP3 form of the 32-bit-lane integer VOPC relations (i16/u16/i32/u32).
+
+    Keyed by ``_vop3``; the functor matches the VOPC one (no modifiers).
+    """
+    table: dict[str, tuple[str, str]] = {}
+    for suf in ('i16', 'u16', 'i32', 'u32'):
+        lane_t, conv = _VOPC_SUFFIX[suf]
+        for rel in _VOPC_INT_RELS:
+            table[f'v_cmp_{rel}_{suf}_vop3'] = (lane_t, _vopc_functor(conv, rel))
+    return table
+
+
+def _build_simd_vopc_vop3_int_64() -> dict[str, tuple[str, str]]:
+    """VOP3 form of the 64-bit-lane integer VOPC relations (i64/u64). Same
+    keying / functor as the VOPC64 path; no modifiers."""
+    table: dict[str, tuple[str, str]] = {}
+    for suf in ('i64', 'u64'):
+        lane_t, conv = _VOPC_SUFFIX[suf]
+        for rel in _VOPC_INT_RELS:
+            table[f'v_cmp_{rel}_{suf}_vop3'] = (lane_t, _vopc_functor(conv, rel))
+    return table
+
+
+SIMD_VOPC_VOP3_INT_32: dict[str, tuple[str, str]] = _build_simd_vopc_vop3_int_32()
+SIMD_VOPC_VOP3_INT_64: dict[str, tuple[str, str]] = _build_simd_vopc_vop3_int_64()
+
+
+def _build_simd_vopc_vop3_f32() -> dict[str, str]:
+    """VOP3 form of the f32 VOPC relations (16 from VOPC + 't' constant).
+
+    Keyed by ``_vop3``; the functor is the same shape as the VOPC f32 one
+    (identity operand conversion), and operates on already-modifier-applied
+    `native<float>` arguments — the VOP3 fp32 glue applies abs/neg outside the
+    functor.
+    """
+    table: dict[str, str] = {}
+    _, conv = _VOPC_SUFFIX['f32']
+    for rel in _VOP3_FLOAT_RELS:
+        table[f'v_cmp_{rel}_f32_vop3'] = _vopc_functor(conv, rel)
+    return table
+
+
+SIMD_VOPC_VOP3_F32: dict[str, str] = _build_simd_vopc_vop3_f32()
+
+
+def _build_simd_vopc_vop3_f16() -> dict[str, str]:
+    """VOP3 form of the f16 VOPC relations (17 — same set as f32).
+
+    The f16 VOP3 glue widens raw lanes via util::f16_to_f32_simd and applies
+    abs/neg on the f32 outside the functor; the functor itself takes
+    already-widened `native<float>` arguments, so it is the same functor as
+    the f32 path (identity operand conversion).
+    """
+    table: dict[str, str] = {}
+    _, conv = _VOPC_SUFFIX['f32']
+    for rel in _VOP3_FLOAT_RELS:
+        table[f'v_cmp_{rel}_f16_vop3'] = _vopc_functor(conv, rel)
+    return table
+
+
+SIMD_VOPC_VOP3_F16: dict[str, str] = _build_simd_vopc_vop3_f16()
+
+
+def _build_simd_vopc_vop3_f64() -> dict[str, str]:
+    """VOP3 form of the f64 VOPC relations (17 — same set as f32/f16).
+
+    Lane type `double`; the glue applies abs/neg outside the functor on the
+    f64 value, so the functor itself takes already-modified `native<double>`
+    arguments and reuses the VOPC64 f64 builder (identity operand conversion).
+    """
+    table: dict[str, str] = {}
+    _, conv = _VOPC_SUFFIX['f64']
+    for rel in _VOP3_FLOAT_RELS:
+        table[f'v_cmp_{rel}_f64_vop3'] = _vopc_functor(conv, rel)
+    return table
+
+
+SIMD_VOPC_VOP3_F64: dict[str, str] = _build_simd_vopc_vop3_f64()
+
+
+# --- VOP3 integer/bitwise ternary (3-source) -------------------------------
+#
+# A handful of integer 3-source VOP3 ops are plain element-wise functions of
+# (src0, src1, src2) with no modifiers and no widening: routed through
+# try_execute_ternary_vop3_simd<T>. Functor sig: `(native<T> a, native<T> b,
+# native<T> c) -> native<T>`. Excluded from this table: the float ternary
+# family (fma/mad/mad_mix — needs modifier glue), med3/min3/max3 (NaN /
+# signed-integer-vs-fmin semantics — see project_pr6470_review_findings), the
+# bfe ops (branchy mask), the byte-permute ops (perm/alignbyte/lerp/sad/msad —
+# byte-wise / table-driven), and 64-bit-lane ternary (would need a 64-bit
+# ternary glue).
+# --- Extra plain integer/bitwise binary VOP3 ops ---------------------------
+#
+# VOP3-only integer/bitwise binary ops that have no VOP2 twin (so the existing
+# _vop3 -> _vop2 fallback doesn't pick them up). All read src0/src1 and apply
+# no modifiers; routed through try_execute_binary_vop3_simd<T>.
+#
+# 16-bit forms compute a 32-bit add/sub and mask the low 16 bits, matching the
+# scalar body's `uint32_t(uint16_t(int16_t(low16(a)+low16(b))))` (or the u16
+# variant) — both reduce to `(a + b) & 0xFFFFu` / `(a - b) & 0xFFFFu` because
+# unsigned 32-bit wrap-around at the low 16 bits is identical to signed/unsigned
+# 16-bit wrap. 32-bit forms use the wrap-around add/sub on uint32 lanes;
+# signed-vs-unsigned wraps the same way.
+SIMD_VOP3_BINARY_INT_EXTRA: dict[str, tuple[str, str]] = {
+    # Pack two clamped 32-bit ints into the hi/lo 16-bit halves of the dst.
+    # v_cvt_pk_i16_i32: signed-clamp each source to [-32768, 32767]; u16_u32:
+    # unsigned-saturate each to 0xFFFF. Pure element-wise, no modifiers.
+    'v_cvt_pk_i16_i32_vop3': (
+        'uint32_t',
+        '[](auto a, auto b) {'
+        ' using I = util::native<int32_t>;'
+        ' using U = util::native<uint32_t>;'
+        ' I lo = util::stdx::static_simd_cast<I>(a);'
+        ' util::stdx::where(lo < I(-32768), lo) = I(-32768);'
+        ' util::stdx::where(lo > I(32767), lo) = I(32767);'
+        ' I hi = util::stdx::static_simd_cast<I>(b);'
+        ' util::stdx::where(hi < I(-32768), hi) = I(-32768);'
+        ' util::stdx::where(hi > I(32767), hi) = I(32767);'
+        ' return ((util::stdx::static_simd_cast<U>(hi) & 0xFFFFu) << 16) |'
+        ' (util::stdx::static_simd_cast<U>(lo) & 0xFFFFu); }',
+    ),
+    'v_cvt_pk_u16_u32_vop3': (
+        'uint32_t',
+        '[](auto a, auto b) {'
+        ' auto lo = a; util::stdx::where(a > 0xFFFFu, lo) = 0xFFFFu;'
+        ' auto hi = b; util::stdx::where(b > 0xFFFFu, hi) = 0xFFFFu;'
+        ' return (hi << 16) | lo; }',
+    ),
+    'v_add_i32_vop3': ('uint32_t', '[](auto a, auto b) { return a + b; }'),
+    'v_sub_i32_vop3': ('uint32_t', '[](auto a, auto b) { return a - b; }'),
+    'v_add_nc_i32_vop3': ('uint32_t', '[](auto a, auto b) { return a + b; }'),
+    'v_add_nc_u32_vop3': ('uint32_t', '[](auto a, auto b) { return a + b; }'),
+    'v_sub_nc_i32_vop3': ('uint32_t', '[](auto a, auto b) { return a - b; }'),
+    'v_sub_nc_u32_vop3': ('uint32_t', '[](auto a, auto b) { return a - b; }'),
+    'v_subrev_nc_u32_vop3': ('uint32_t', '[](auto a, auto b) { return b - a; }'),
+    'v_add_i16_vop3': ('uint32_t', '[](auto a, auto b) { return (a + b) & 0xFFFFu; }'),
+    'v_sub_i16_vop3': ('uint32_t', '[](auto a, auto b) { return (a - b) & 0xFFFFu; }'),
+    'v_add_nc_i16_vop3': (
+        'uint32_t',
+        '[](auto a, auto b) { return (a + b) & 0xFFFFu; }',
+    ),
+    'v_add_nc_u16_vop3': (
+        'uint32_t',
+        '[](auto a, auto b) { return (a + b) & 0xFFFFu; }',
+    ),
+    'v_sub_nc_i16_vop3': (
+        'uint32_t',
+        '[](auto a, auto b) { return (a - b) & 0xFFFFu; }',
+    ),
+    'v_sub_nc_u16_vop3': (
+        'uint32_t',
+        '[](auto a, auto b) { return (a - b) & 0xFFFFu; }',
+    ),
+    # 32-bit integer multiply: low 32 bits of the product is just `a * b`
+    # (uint32 wrap is identical signed/unsigned for the low half).
+    'v_mul_lo_u32_vop3': ('uint32_t', '[](auto a, auto b) { return a * b; }'),
+    # High 32 bits of the 32x32 -> 64 multiply via util::mul_hi_{u,i}32_simd
+    # (16x16 partial-product decomposition in pure native<uint32_t>). Avoids
+    # fixed_size_simd<{u,i}64, N>, which clang + libstdc++ miscompile at every
+    # SIMD width (over-native-width 64-bit-lane multiply/shift). Bit-identical to
+    # the scalar uint64/int64 `(a * b) >> 32`.
+    'v_mul_hi_u32_vop3': (
+        'uint32_t',
+        '[](auto a, auto b) { return util::mul_hi_u32_simd(a, b); }',
+    ),
+    'v_mul_hi_i32_vop3': (
+        'uint32_t',
+        '[](auto a, auto b) { return util::mul_hi_i32_simd(a, b); }',
+    ),
+    # v_bfm_b32: ((1 << (a & 31)) - 1) << (b & 31). Two shift counts both
+    # masked to low 5 bits — same vpsllvd-vs-shl rationale as v_lshl_add_u32.
+    'v_bfm_b32_vop3': (
+        'uint32_t',
+        '[](auto a, auto b) { return ((util::native<uint32_t>(1u) << (a & 31u)) - 1u) << (b & 31u); }',
+    ),
+    # v_pack_b32_f16: pack two f16 halves into a b32. low16(src0) into the low
+    # half, low16(src1) into the high half. The scalar body applies no abs/neg
+    # despite the f16 typing (it pre-masks the operands to 16 bits before the
+    # shift), and clamp/omod are likewise unused. Pure integer bit-pack.
+    'v_pack_b32_f16_vop3': (
+        'uint32_t',
+        '[](auto a, auto b) { return (a & 0xFFFFu) | ((b & 0xFFFFu) << 16); }',
+    ),
+    # 16-bit-lane bitwise binary VOP3 ops (RDNA3+; CDNA4 does not decode).
+    # The scalar body computes `uint16_t(uint16_t(a) OP uint16_t(b))` and
+    # writes the result as a zero-extended uint32; SIMD reproduces with a
+    # 32-bit `& 0xFFFFu` mask on the result. No modifiers (integer ops).
+    'v_and_b16_vop3': ('uint32_t', '[](auto a, auto b) { return (a & b) & 0xFFFFu; }'),
+    'v_or_b16_vop3': ('uint32_t', '[](auto a, auto b) { return (a | b) & 0xFFFFu; }'),
+    'v_xor_b16_vop3': ('uint32_t', '[](auto a, auto b) { return (a ^ b) & 0xFFFFu; }'),
+}
+
+# VOP3 unary integer ops without a VOP1 twin. Reuse the VOP1 unary glue
+# (operand shape is identical: src0 in, vdst out, 32-bit lanes) — only the
+# probe routing key differs. RDNA3+; CDNA4 does not decode.
+SIMD_VOP3_UNARY_INT_EXTRA: dict[str, tuple[str, str, str]] = {
+    # v_not_b16: `uint16_t(~src0)`, zero-extended. Same shape as v_not_b32 but
+    # masked to 16 bits.
+    'v_not_b16_vop3': (
+        'uint32_t',
+        'uint32_t',
+        '[](auto a) { return (~a) & 0xFFFFu; }',
+    ),
+    # v_bcnt_u32_b32: VOP3-only (no VOP1 twin). The scalar body is a plain
+    # std::popcount(src0) -> vdst (src1 is read but unused by this codebase's
+    # body), so the unary src0->vdst glue is bit-exact.
+    'v_bcnt_u32_b32_vop3': (
+        'uint32_t',
+        'uint32_t',
+        '[](auto a) { return util::popcount_u32_simd(a); }',
+    ),
+}
+
+
+# --- VOP3 f64 binary + unary -----------------------------------------------
+#
+# VOP3 f64 ops carry per-source abs/neg and result omod/clamp modifiers, all
+# applied in the f64 domain (apply_vop3_src_mod_f64 / apply_vop3_dst_mod_f64).
+# The VOPC table key convention is preserved: dict[name] -> functor string.
+#
+# For v_max_f64 / v_min_f64, stdx::fmax / stdx::fmin match scalar std::fmax /
+# std::fmin for all finite/Inf inputs except (a) NaN payload and (b) signed-zero
+# tie (matching the f32 finding) — accepted divergences, with the A/B test
+# skipping NaN-input and zero-tie lanes (same convention as v_max_f32 / v_min_f32
+# in SIMD_VOP2_BINARY).
+SIMD_VOP3_BINARY_FP64: dict[str, str] = {
+    'v_add_f64_vop3': '[](auto a, auto b) { return a + b; }',
+    'v_mul_f64_vop3': '[](auto a, auto b) { return a * b; }',
+    'v_max_f64_vop3': '[](auto a, auto b) { return util::stdx::fmax(a, b); }',
+    'v_min_f64_vop3': '[](auto a, auto b) { return util::stdx::fmin(a, b); }',
+}
+
+# Plain f64 unary: scalar bodies are std::ceil / std::floor / std::trunc /
+# std::nearbyint applied to the (modifier-applied) double, then omod/clamp on
+# the result. util::{ceil,floor,trunc,rndne}_simd wrap the stdx native<double>
+# rounding primitives and repair the two edge cases libstdc++ gets wrong at
+# narrow widths (sign-of-zero on a zero-magnitude result, NaN-payload
+# preservation), so they are bit-identical to the scalar libm calls for every
+# finite / Inf / NaN / signed-zero input.
+SIMD_VOP3_UNARY_FP64: dict[str, str] = {
+    'v_ceil_f64_vop3': '[](auto a) { return util::ceil_simd(a); }',
+    'v_floor_f64_vop3': '[](auto a) { return util::floor_simd(a); }',
+    'v_trunc_f64_vop3': '[](auto a) { return util::trunc_simd(a); }',
+    'v_rndne_f64_vop3': '[](auto a) { return util::rndne_simd(a); }',
+    # sqrt_f64 is correctly-rounded IEEE (scalar uses transcendental::sqrt_f64
+    # which is `std::sqrt` after NaN/negative guards); stdx::sqrt matches.
+    'v_sqrt_f64_vop3': (
+        '[](auto a) {'
+        ' auto r = util::stdx::sqrt(a);'
+        ' util::stdx::where(util::stdx::isnan(a), r) = a;'
+        ' util::stdx::where(a < 0.0, r) = std::numeric_limits<double>::quiet_NaN();'
+        ' return r; }'
+    ),
+    # v_fract_f64: scalar = v - std::floor(v); util::floor_simd matches
+    # std::floor bit-exact incl. sign-of-zero (NaN-floor(NaN) = NaN; NaN result
+    # skipped by the test like any other NaN-result lane).
+    'v_fract_f64_vop3': '[](auto a) { return a - util::floor_simd(a); }',
+    # frexp mantissa: same functor as the VOP1 form; the f64 unary FP glue applies
+    # abs/neg on the source and omod/clamp on the mantissa, matching the scalar.
+    'v_frexp_mant_f64_vop3': '[](auto a) { return util::frexp_mant_f64_simd(a); }',
+    # v_rcp_f64 / v_rsq_f64: scalar uses transcendental::*_f64 with explicit
+    # NaN passthrough, ±0 -> copysign(Inf, x), ±Inf -> copysign(0, x); negative
+    # rsq inputs -> qNaN. Plain 1.0 / x and 1.0 / sqrt match the IEEE result
+    # for all non-NaN inputs; NaN-result lanes are skipped by the A/B test.
+    'v_rcp_f64_vop3': '[](auto a) { return util::native<double>(1.0) / a; }',
+    'v_rsq_f64_vop3': '[](auto a) { return util::native<double>(1.0) / util::stdx::sqrt(a); }',
+    # v_mov_b64 with VOP3 modifiers: scalar bit_casts to double, applies
+    # abs/neg/omod/clamp, bit_casts back. The f64 unary glue operates entirely
+    # in native<double> domain, so an identity functor + the same modifier
+    # helpers reproduce the scalar bit pattern exactly.
+    'v_mov_b64_vop3': '[](auto a) { return a; }',
+}
+
+
+# VOP3 f16 unary: widen f16->f32, apply abs/neg, op, omod/clamp, narrow back.
+# Rounding ops (ceil/floor/trunc/rndne) have no FTZ. sqrt is also no-FTZ
+# (transcendental::sqrt_f32 keeps denormals). The four transcendentals
+# (rcp/rsq/exp/log) reuse util::*_f32_simd which already wraps the scalar
+# transcendental::flush_denorm_f32 carve-outs (FTZ input + matching ±0/Inf
+# blends + NaN-passthrough), so the f16 scalar
+# f32_to_f16(transcendental::op_f32(f16_to_f32(...))) maps directly.
+SIMD_VOP3_UNARY_FP16: dict[str, str] = {
+    'v_ceil_f16_vop3': '[](auto a) { return util::ceil_simd(a); }',
+    'v_floor_f16_vop3': '[](auto a) { return util::floor_simd(a); }',
+    'v_trunc_f16_vop3': '[](auto a) { return util::trunc_simd(a); }',
+    'v_rndne_f16_vop3': '[](auto a) { return util::rndne_simd(a); }',
+    'v_sqrt_f16_vop3': (
+        '[](auto a) {'
+        ' auto r = util::stdx::sqrt(a);'
+        ' util::stdx::where(util::stdx::isnan(a), r) = a;'
+        ' util::stdx::where(a < 0.0f, r) = std::numeric_limits<float>::quiet_NaN();'
+        ' return r; }'
+    ),
+    'v_rcp_f16_vop3': '[](auto a) { return util::rcp_f32_simd(a); }',
+    'v_rsq_f16_vop3': '[](auto a) { return util::rsq_f32_simd(a); }',
+    'v_exp_f16_vop3': '[](auto a) { return util::exp_f32_simd(a); }',
+    'v_log_f16_vop3': '[](auto a) { return util::log_f32_simd(a); }',
+    # v_fract_f16: x - floor(x) in the widened f32 domain (the glue widens/narrows
+    # and applies abs/neg/omod/clamp), mirroring the covered v_fract_f16_vop1.
+    'v_fract_f16_vop3': '[](auto a) { return a - util::floor_simd(a); }',
+}
+
+
+# --- VOP3 floating-point ternary (FMA / MAD family) ------------------------
+#
+# v_fma_*: util::stdx::fma (fused multiply-add, single-rounded). v_fmac/v_mac:
+# same body (the scalar generator emits std::fma for both because of dst-
+# accumulate semantics — src2 == vdst). v_mad: non-fused `a * b + c`. NaN-input
+# divergence between stdx::fma and std::fma (gcc-13 packed FMA picks a
+# different NaN operand to quiet) is accepted, same as the existing VOP2
+# ternary FMA slice — the A/B test skips NaN-input lanes.
+SIMD_VOP3_TERNARY_FP32: dict[str, str] = {
+    'v_fma_f32_vop3': '[](auto a, auto b, auto c) { return util::stdx::fma(a, b, c); }',
+    'v_mad_f32_vop3': '[](auto a, auto b, auto c) { return a * b + c; }',
+    'v_mad_legacy_f32_vop3': '[](auto a, auto b, auto c) { return a * b + c; }',
+    # min3/max3/med3 (f32): the scalar body composes std::fmax/std::fmin
+    # (max3 = fmax(fmax(a,b),c); min3 = fmin(fmin(a,b),c);
+    # med3 = fmax(fmin(fmax(a,b),c), fmin(a,b))). stdx::fmax/fmin match scalar
+    # for all finite/Inf inputs except NaN-payload and signed-zero tie (same
+    # accepted carve-out as v_max_f32 / v_min_f32; the A/B test skips NaN-input
+    # lanes and uses no ±0 inputs). omod/clamp applied by the glue.
+    # v_fma_dx9_zero_f32: the scalar body is a plain fused multiply-add (the
+    # DX9 zero-multiply special-case is not applied to the FMA form).
+    'v_fma_dx9_zero_f32_vop3': '[](auto a, auto b, auto c) { return util::stdx::fma(a, b, c); }',
+    'v_max3_f32_vop3': '[](auto a, auto b, auto c) { return util::stdx::fmax(util::stdx::fmax(a, b), c); }',
+    'v_min3_f32_vop3': '[](auto a, auto b, auto c) { return util::stdx::fmin(util::stdx::fmin(a, b), c); }',
+    'v_med3_f32_vop3': '[](auto a, auto b, auto c) { return util::stdx::fmax(util::stdx::fmin(util::stdx::fmax(a, b), c), util::stdx::fmin(a, b)); }',
+    # minmax = max(min(a,b),c); maxmin = min(max(a,b),c). (RDNA3+.)
+    'v_minmax_f32_vop3': '[](auto a, auto b, auto c) { return util::stdx::fmax(util::stdx::fmin(a, b), c); }',
+    'v_maxmin_f32_vop3': '[](auto a, auto b, auto c) { return util::stdx::fmin(util::stdx::fmax(a, b), c); }',
+    # v_div_fixup_f32: per-AMD-spec `else if` cascade selecting the result
+    # among NaN/Inf/zero copysign cases. Lives as a helper in simd_glue.h
+    # (div_fixup_f32_simd) — bit-exact match to the scalar body's predicate
+    # tree applied lowest-priority-first so higher-priority `where` blends
+    # overwrite. Omod/clamp DO apply (scalar applies them at end).
+    'v_div_fixup_f32_vop3': (
+        '[](auto p, auto b, auto c) { return ::rocjitsu::amdgpu::div_fixup_f32_simd(p, b, c); }'
+    ),
+    # v_div_fixup_f16 / _legacy_f16: despite the _f16 name, the generated CDNA4
+    # scalar body reads/writes the operands as raw f32 (std::bit_cast<float>, not
+    # f16_to_f32) — bit-identical to the f32 div_fixup body — so it routes through
+    # the same f32 ternary glue + div_fixup_f32_simd cascade.
+    'v_div_fixup_f16_vop3': (
+        '[](auto p, auto b, auto c) { return ::rocjitsu::amdgpu::div_fixup_f32_simd(p, b, c); }'
+    ),
+    'v_div_fixup_legacy_f16_vop3': (
+        '[](auto p, auto b, auto c) { return ::rocjitsu::amdgpu::div_fixup_f32_simd(p, b, c); }'
+    ),
+}
+
+# f16 ternary — widen each src to f32, op in f32, narrow back. Same NaN
+# carve-out as the f32 path.
+SIMD_VOP3_TERNARY_FP16: dict[str, str] = {
+    'v_fma_f16_vop3': '[](auto a, auto b, auto c) { return util::stdx::fma(a, b, c); }',
+    'v_mad_f16_vop3': '[](auto a, auto b, auto c) { return a * b + c; }',
+    'v_mad_legacy_f16_vop3': '[](auto a, auto b, auto c) { return a * b + c; }',
+    'v_fma_legacy_f16_vop3': '[](auto a, auto b, auto c) { return util::stdx::fma(a, b, c); }',
+    # min3/max3/med3 (f16): widened to f32 by the glue; same fmax/fmin
+    # composition as the f32 forms (see SIMD_VOP3_TERNARY_FP32).
+    'v_max3_f16_vop3': '[](auto a, auto b, auto c) { return util::stdx::fmax(util::stdx::fmax(a, b), c); }',
+    'v_min3_f16_vop3': '[](auto a, auto b, auto c) { return util::stdx::fmin(util::stdx::fmin(a, b), c); }',
+    'v_med3_f16_vop3': '[](auto a, auto b, auto c) { return util::stdx::fmax(util::stdx::fmin(util::stdx::fmax(a, b), c), util::stdx::fmin(a, b)); }',
+    'v_minmax_f16_vop3': '[](auto a, auto b, auto c) { return util::stdx::fmax(util::stdx::fmin(a, b), c); }',
+    'v_maxmin_f16_vop3': '[](auto a, auto b, auto c) { return util::stdx::fmin(util::stdx::fmax(a, b), c); }',
+}
+
+# f64 ternary FMA.
+SIMD_VOP3_TERNARY_FP64: dict[str, str] = {
+    'v_fma_f64_vop3': '[](auto a, auto b, auto c) { return util::stdx::fma(a, b, c); }',
+    # v_div_fixup_f64: 64-bit-lane div_fixup cascade (same shape as f32, see
+    # SIMD_VOP3_TERNARY_FP32 above).
+    'v_div_fixup_f64_vop3': (
+        '[](auto p, auto b, auto c) { return ::rocjitsu::amdgpu::div_fixup_f64_simd(p, b, c); }'
+    ),
+}
+
+# --- VOP3 dst-accumulate FMA / MAC (vdst is the accumulator) ----------------
+#
+# v_fmac / v_mac per-isa classes only initialize src0+src1+vdst; the third FMA
+# operand IS vdst (no src2 Operand). The accumulate-form glue reads inst.vdst
+# as the third operand and applies abs/neg only to src0/src1 (per scalar body).
+# NaN payload divergence accepted, same as the non-accumulate ternary slice.
+SIMD_VOP3_FMAC_FP32: dict[str, str] = {
+    'v_fmac_f32_vop3': '[](auto a, auto b, auto c) { return util::stdx::fma(a, b, c); }',
+    'v_mac_f32_vop3': '[](auto a, auto b, auto c) { return util::stdx::fma(a, b, c); }',
+    'v_fmac_dx9_zero_f32_vop3': '[](auto a, auto b, auto c) { return util::stdx::fma(a, b, c); }',
+}
+SIMD_VOP3_FMAC_FP16: dict[str, str] = {
+    'v_fmac_f16_vop3': '[](auto a, auto b, auto c) { return util::stdx::fma(a, b, c); }',
+    'v_mac_f16_vop3': '[](auto a, auto b, auto c) { return util::stdx::fma(a, b, c); }',
+}
+SIMD_VOP3_FMAC_FP64: dict[str, str] = {
+    'v_fmac_f64_vop3': '[](auto a, auto b, auto c) { return util::stdx::fma(a, b, c); }',
+}
+
+# --- VOP3 ldexp (mixed-width: fp src0 + int32 src1 exp) --------------------
+#
+# stdx::ldexp on native<float|double> with same-size int simd is bit-exact to
+# std::ldexp for every input including NaN (proven in the v_ldexp_f16 VOP2
+# slice).
+SIMD_VOP3_LDEXP_FP32: dict[str, str] = {
+    # stdx::ldexp wants the integer arg as fixed_size_simd<int, size> matching
+    # the float abi, not the native<int32_t> the operand reader returns.
+    'v_ldexp_f32_vop3': (
+        '[](auto a, auto e) {'
+        ' return util::stdx::ldexp(a, util::stdx::static_simd_cast<'
+        'util::stdx::fixed_size_simd<int, util::native<float>::size()>>(e)); }'
+    ),
+}
+SIMD_VOP3_LDEXP_FP64: dict[str, str] = {
+    # narrow32<int32_t> is already an 8-wide fixed_size_simd; just re-cast to
+    # the int-typed equivalent so stdx::ldexp accepts the matching abi.
+    'v_ldexp_f64_vop3': (
+        '[](auto a, auto e) {'
+        ' return util::stdx::ldexp(a, util::stdx::static_simd_cast<'
+        'util::stdx::fixed_size_simd<int, util::native_width64>>(e)); }'
+    ),
+}
+
+
+SIMD_VOP3_TERNARY_INT: dict[str, tuple[str, str]] = {
+    # Sum-of-absolute-differences (byte / 16-bit / 32-bit) + accumulate src2.
+    # Pure integer byte SWAR (see util::sad_bytes_u32_simd etc); no modifiers.
+    'v_sad_u8_vop3': (
+        'uint32_t',
+        '[](auto a, auto b, auto c) { return c + util::sad_bytes_u32_simd(a, b); }',
+    ),
+    'v_sad_hi_u8_vop3': (
+        'uint32_t',
+        '[](auto a, auto b, auto c) { return (util::sad_bytes_u32_simd(a, b) << 16) + c; }',
+    ),
+    'v_sad_u16_vop3': (
+        'uint32_t',
+        '[](auto a, auto b, auto c) {'
+        ' using U = util::native<uint32_t>;'
+        ' U al = a & 0xFFFFu, ah = (a >> 16) & 0xFFFFu;'
+        ' U bl = b & 0xFFFFu, bh = (b >> 16) & 0xFFFFu;'
+        ' U dl = al - bl; util::stdx::where(bl > al, dl) = bl - al;'
+        ' U dh = ah - bh; util::stdx::where(bh > ah, dh) = bh - ah;'
+        ' return c + dl + dh; }',
+    ),
+    'v_sad_u32_vop3': (
+        'uint32_t',
+        '[](auto a, auto b, auto c) {'
+        ' auto d = a - b; util::stdx::where(b > a, d) = b - a; return c + d; }',
+    ),
+    'v_msad_u8_vop3': (
+        'uint32_t',
+        '[](auto a, auto b, auto c) { return c + util::msad_bytes_u32_simd(a, b); }',
+    ),
+    'v_lerp_u8_vop3': (
+        'uint32_t',
+        '[](auto a, auto b, auto c) { return util::lerp_u8_simd(a, b, c); }',
+    ),
+    'v_add3_u32_vop3': (
+        'uint32_t',
+        '[](auto a, auto b, auto c) { return a + b + c; }',
+    ),
+    'v_or3_b32_vop3': (
+        'uint32_t',
+        '[](auto a, auto b, auto c) { return a | b | c; }',
+    ),
+    'v_xor3_b32_vop3': (
+        'uint32_t',
+        '[](auto a, auto b, auto c) { return a ^ b ^ c; }',
+    ),
+    'v_xad_u32_vop3': (
+        'uint32_t',
+        '[](auto a, auto b, auto c) { return (a ^ b) + c; }',
+    ),
+    'v_and_or_b32_vop3': (
+        'uint32_t',
+        '[](auto a, auto b, auto c) { return (a & b) | c; }',
+    ),
+    'v_lshl_or_b32_vop3': (
+        'uint32_t',
+        '[](auto a, auto b, auto c) { return (a << (b & 31u)) | c; }',
+    ),
+    # v_mad_i32_i24: low-24 sign-extended a, b -> int32 multiply (low 32 of the
+    # 48-bit product, identical signed/unsigned for the low half) + int32(c).
+    'v_mad_i32_i24_vop3': (
+        'uint32_t',
+        '[](auto a, auto b, auto c) {'
+        ' auto sa = (util::stdx::static_simd_cast<util::native<int32_t>>(a) << 8) >> 8;'
+        ' auto sb = (util::stdx::static_simd_cast<util::native<int32_t>>(b) << 8) >> 8;'
+        ' return util::stdx::static_simd_cast<util::native<uint32_t>>('
+        'sa * sb + util::stdx::static_simd_cast<util::native<int32_t>>(c)); }',
+    ),
+    # v_mad_u32_u24: low-24 mask a, b, multiply, add c.
+    'v_mad_u32_u24_vop3': (
+        'uint32_t',
+        '[](auto a, auto b, auto c) { return (a & 0x00FFFFFFu) * (b & 0x00FFFFFFu) + c; }',
+    ),
+    # v_alignbit_b32: low 32 of ((u64(a) << 32) | b) >> (c & 31). Per-lane
+    # variable shift on a 64-bit-lane fixed_size_simd<u64> — proven on the
+    # widening mul_hi pattern; shift count is masked to [0, 31] so vpsrlvq
+    # and scalar shr agree on the result.
+    'v_alignbit_b32_vop3': (
+        'uint32_t',
+        '[](auto a, auto b, auto c) {'
+        ' using U64 = util::stdx::fixed_size_simd<uint64_t, util::native<uint32_t>::size()>;'
+        ' auto va = util::stdx::static_simd_cast<U64>(a);'
+        ' auto vb = util::stdx::static_simd_cast<U64>(b);'
+        ' auto val = (va << 32) | vb;'
+        ' auto sh = util::stdx::static_simd_cast<U64>(c & 31u);'
+        ' return util::stdx::static_simd_cast<util::native<uint32_t>>(val >> sh); }',
+    ),
+    # v_alignbyte_b32: same widen but shift count is (c & 3) * 8 = {0,8,16,24}.
+    'v_alignbyte_b32_vop3': (
+        'uint32_t',
+        '[](auto a, auto b, auto c) {'
+        ' using U64 = util::stdx::fixed_size_simd<uint64_t, util::native<uint32_t>::size()>;'
+        ' auto va = util::stdx::static_simd_cast<U64>(a);'
+        ' auto vb = util::stdx::static_simd_cast<U64>(b);'
+        ' auto val = (va << 32) | vb;'
+        ' auto sh = util::stdx::static_simd_cast<U64>((c & 3u) * 8u);'
+        ' return util::stdx::static_simd_cast<util::native<uint32_t>>(val >> sh); }',
+    ),
+    # The shift count is masked to the low 5 bits to match the scalar body's
+    # x86 `shl` semantics (which mask cl to 5 bits) — stdx's `<<` on native<u32>
+    # lowers to vpsllvd, which zeros out lanes where the count is >= 32 rather
+    # than masking, so SIMD without the explicit `& 31u` diverges from scalar
+    # whenever src1 (or src2 below) is >= 32 (verified empirically on the test
+    # value 0x80000000). The scalar body's `<<` is C++ UB at those counts; the
+    # masked SIMD form reproduces the x86 scalar result for every value of the
+    # shift operand on this host.
+    'v_lshl_add_u32_vop3': (
+        'uint32_t',
+        '[](auto a, auto b, auto c) { return (a << (b & 31u)) + c; }',
+    ),
+    'v_add_lshl_u32_vop3': (
+        'uint32_t',
+        '[](auto a, auto b, auto c) { return (a + b) << (c & 31u); }',
+    ),
+    'v_bfi_b32_vop3': (
+        'uint32_t',
+        '[](auto a, auto b, auto c) { return (a & b) | (~a & c); }',
+    ),
+    # Byte permute: each output byte selected from the 8 bytes of {src0:src1} by
+    # a selector byte of src2 (see util::perm_b32_simd). Pure byte gather.
+    'v_perm_b32_vop3': (
+        'uint32_t',
+        '[](auto a, auto b, auto c) { return util::perm_b32_simd(a, b, c); }',
+    ),
+    # min3/max3/med3 (integer). The scalar body uses std::max/std::min for the
+    # 16/32-bit forms (and the minmax/maxmin scalar bodies use std::fmax/fmin on
+    # *integers* — order-preserving and exactly representable, so the integer
+    # min/max here matches for every input; this is the correct SIMD form, NOT
+    # the std::fmin-on-int pattern flagged in project_pr6470_review_findings).
+    # 32-bit: signed lane type for i32 (signed compare), unsigned for u32.
+    # max3 = max(max(a,b),c); min3 = min(min(a,b),c);
+    # med3 = max(min(max(a,b),c), min(a,b)).
+    'v_max3_i32_vop3': (
+        'int32_t',
+        '[](auto a, auto b, auto c) { return util::stdx::max(util::stdx::max(a, b), c); }',
+    ),
+    'v_min3_i32_vop3': (
+        'int32_t',
+        '[](auto a, auto b, auto c) { return util::stdx::min(util::stdx::min(a, b), c); }',
+    ),
+    'v_med3_i32_vop3': (
+        'int32_t',
+        '[](auto a, auto b, auto c) {'
+        ' return util::stdx::max(util::stdx::min(util::stdx::max(a, b), c),'
+        ' util::stdx::min(a, b)); }',
+    ),
+    'v_max3_u32_vop3': (
+        'uint32_t',
+        '[](auto a, auto b, auto c) { return util::stdx::max(util::stdx::max(a, b), c); }',
+    ),
+    'v_min3_u32_vop3': (
+        'uint32_t',
+        '[](auto a, auto b, auto c) { return util::stdx::min(util::stdx::min(a, b), c); }',
+    ),
+    'v_med3_u32_vop3': (
+        'uint32_t',
+        '[](auto a, auto b, auto c) {'
+        ' return util::stdx::max(util::stdx::min(util::stdx::max(a, b), c),'
+        ' util::stdx::min(a, b)); }',
+    ),
+    # NOTE: integer v_minmax/v_maxmin i32/u32 are intentionally NOT wired. Unlike
+    # min3/max3 (whose scalar uses std::max/std::min), the minmax/maxmin scalar
+    # bodies use std::fmax/std::fmin on *ints* and write the double result back
+    # through a double->uint32 conversion that saturates negatives to 0xFFFFFFFF
+    # (x86 cvttsd2si overflow). That scalar is UB and the integer SIMD min/max
+    # cannot match it — left scalar-authoritative (see project_pr6470 findings).
+    # 16-bit: the scalar body sign-/zero-extends the low 16 bits, takes the
+    # min/max, then truncates to uint16 and zero-extends to uint32. SIMD lane is
+    # the raw uint32; i16 sign-extends via (cast<int32> << 16) >> 16 (same
+    # pattern as v_mad_i32_i24's 24-bit extend), u16 masks & 0xFFFF; the result
+    # is masked back to the low 16 bits.
+    'v_max3_i16_vop3': (
+        'uint32_t',
+        '[](auto a, auto b, auto c) {'
+        ' using I = util::native<int32_t>;'
+        ' auto sa = (util::stdx::static_simd_cast<I>(a) << 16) >> 16;'
+        ' auto sb = (util::stdx::static_simd_cast<I>(b) << 16) >> 16;'
+        ' auto sc = (util::stdx::static_simd_cast<I>(c) << 16) >> 16;'
+        ' return util::stdx::static_simd_cast<util::native<uint32_t>>('
+        'util::stdx::max(util::stdx::max(sa, sb), sc)) & 0xFFFFu; }',
+    ),
+    'v_min3_i16_vop3': (
+        'uint32_t',
+        '[](auto a, auto b, auto c) {'
+        ' using I = util::native<int32_t>;'
+        ' auto sa = (util::stdx::static_simd_cast<I>(a) << 16) >> 16;'
+        ' auto sb = (util::stdx::static_simd_cast<I>(b) << 16) >> 16;'
+        ' auto sc = (util::stdx::static_simd_cast<I>(c) << 16) >> 16;'
+        ' return util::stdx::static_simd_cast<util::native<uint32_t>>('
+        'util::stdx::min(util::stdx::min(sa, sb), sc)) & 0xFFFFu; }',
+    ),
+    'v_med3_i16_vop3': (
+        'uint32_t',
+        '[](auto a, auto b, auto c) {'
+        ' using I = util::native<int32_t>;'
+        ' auto sa = (util::stdx::static_simd_cast<I>(a) << 16) >> 16;'
+        ' auto sb = (util::stdx::static_simd_cast<I>(b) << 16) >> 16;'
+        ' auto sc = (util::stdx::static_simd_cast<I>(c) << 16) >> 16;'
+        ' return util::stdx::static_simd_cast<util::native<uint32_t>>('
+        'util::stdx::max(util::stdx::min(util::stdx::max(sa, sb), sc),'
+        ' util::stdx::min(sa, sb))) & 0xFFFFu; }',
+    ),
+    'v_max3_u16_vop3': (
+        'uint32_t',
+        '[](auto a, auto b, auto c) {'
+        ' auto sa = a & 0xFFFFu; auto sb = b & 0xFFFFu; auto sc = c & 0xFFFFu;'
+        ' return util::stdx::max(util::stdx::max(sa, sb), sc) & 0xFFFFu; }',
+    ),
+    'v_min3_u16_vop3': (
+        'uint32_t',
+        '[](auto a, auto b, auto c) {'
+        ' auto sa = a & 0xFFFFu; auto sb = b & 0xFFFFu; auto sc = c & 0xFFFFu;'
+        ' return util::stdx::min(util::stdx::min(sa, sb), sc) & 0xFFFFu; }',
+    ),
+    'v_med3_u16_vop3': (
+        'uint32_t',
+        '[](auto a, auto b, auto c) {'
+        ' auto sa = a & 0xFFFFu; auto sb = b & 0xFFFFu; auto sc = c & 0xFFFFu;'
+        ' return util::stdx::max(util::stdx::min(util::stdx::max(sa, sb), sc),'
+        ' util::stdx::min(sa, sb)) & 0xFFFFu; }',
+    ),
+    # v_mad_i32_i16: sign-extend the low 16 bits of src0/src1 to int32, multiply
+    # (the int16 product fits in int32), add the full int32 src2, store as uint32
+    # — matches the scalar `(int16)a * (int16)b + (int32)c`.
+    'v_mad_i32_i16_vop3': (
+        'uint32_t',
+        '[](auto a, auto b, auto c) {'
+        ' using I = util::native<int32_t>;'
+        ' auto sa = (util::stdx::static_simd_cast<I>(a) << 16) >> 16;'
+        ' auto sb = (util::stdx::static_simd_cast<I>(b) << 16) >> 16;'
+        ' auto sc = util::stdx::static_simd_cast<I>(c);'
+        ' return util::stdx::static_simd_cast<util::native<uint32_t>>(sa * sb + sc); }',
+    ),
+    # v_mad_u32_u16: zero-extend low 16 of src0/src1, multiply, add full uint32 c.
+    'v_mad_u32_u16_vop3': (
+        'uint32_t',
+        '[](auto a, auto b, auto c) { return (a & 0xFFFFu) * (b & 0xFFFFu) + c; }',
+    ),
+    # v_mad_i16 / v_mad_u16 (and the _legacy twins): 16-bit multiply-add, result
+    # truncated to the low 16 bits and zero-extended. The low 16 bits of the
+    # product+add are independent of operand sign, so masking the operands and
+    # the result to 16 bits reproduces the int16 and uint16 scalar bodies alike.
+    'v_mad_i16_vop3': (
+        'uint32_t',
+        '[](auto a, auto b, auto c) { return ((a & 0xFFFFu) * (b & 0xFFFFu) + (c & 0xFFFFu)) & 0xFFFFu; }',
+    ),
+    'v_mad_u16_vop3': (
+        'uint32_t',
+        '[](auto a, auto b, auto c) { return ((a & 0xFFFFu) * (b & 0xFFFFu) + (c & 0xFFFFu)) & 0xFFFFu; }',
+    ),
+    'v_mad_legacy_i16_vop3': (
+        'uint32_t',
+        '[](auto a, auto b, auto c) { return ((a & 0xFFFFu) * (b & 0xFFFFu) + (c & 0xFFFFu)) & 0xFFFFu; }',
+    ),
+    'v_mad_legacy_u16_vop3': (
+        'uint32_t',
+        '[](auto a, auto b, auto c) { return ((a & 0xFFFFu) * (b & 0xFFFFu) + (c & 0xFFFFu)) & 0xFFFFu; }',
+    ),
+    # v_bfe_u32: bitfield extract. off = src1 & 31, w = src2 & 31, result =
+    # (src >> off) & ((1<<w)-1). The scalar `if (w==0) return 0` is redundant —
+    # ((1u<<w)-1) is already 0 for w==0 — and `w>=32` is dead since w is masked
+    # to 31, so the SIMD form is branchless. Variable logical shift (vpsrlvd /
+    # vpsllvd) matches scalar for every count in [0,31].
+    'v_bfe_u32_vop3': (
+        'uint32_t',
+        '[](auto a, auto b, auto c) {'
+        ' auto off = b & 31u; auto w = c & 31u;'
+        ' auto mask = (util::native<uint32_t>(1u) << w) - 1u;'
+        ' return (a >> off) & mask; }',
+    ),
+    # v_bfe_i32: signed bitfield extract. Same off/width masking; the field is
+    # extracted with an arithmetic shift (vpsravd, so off+w>32 sign-fill matches
+    # the scalar int32 `src >> off`) then sign-extended from bit w-1 via the
+    # branchless `(x ^ s) - s` trick (s = 1<<(w-1) = (mask+1)>>1, which is 0 for
+    # w==0 so the result is 0, matching the scalar early return).
+    'v_bfe_i32_vop3': (
+        'uint32_t',
+        '[](auto a, auto b, auto c) {'
+        ' using I = util::native<int32_t>;'
+        ' auto off = b & 31u; auto w = c & 31u;'
+        ' auto mask = (util::native<uint32_t>(1u) << w) - 1u;'
+        ' auto ext = util::stdx::static_simd_cast<util::native<uint32_t>>('
+        'util::stdx::static_simd_cast<I>(a) >> util::stdx::static_simd_cast<I>(off)) & mask;'
+        ' auto signbit = (mask + 1u) >> 1;'
+        ' return (ext ^ signbit) - signbit; }',
+    ),
+}
+
+
+# --- VOP3 64-bit reverse shifts --------------------------------------------
+#
+# v_lshlrev_b64 / v_lshrrev_b64 / v_ashrrev_i64: shift the 64-bit src1 by the
+# 32-bit src0 (masked to [0,63]). Routed through try_execute_shift64_vop3_simd,
+# whose functor receives (native<uint64_t> value, native<uint64_t> shift) with
+# the count already widened+masked. Logical shifts are plain `<< / >>` on the
+# uint64 lane; the signed (arithmetic) form casts through int64.
+SIMD_SHIFT64_VOP3: dict[str, str] = {
+    'v_lshlrev_b64_vop3': '[](auto v, auto sh) { return v << sh; }',
+    'v_lshrrev_b64_vop3': '[](auto v, auto sh) { return v >> sh; }',
+    'v_ashrrev_i64_vop3': (
+        '[](auto v, auto sh) {'
+        ' return util::stdx::static_simd_cast<util::native<uint64_t>>('
+        'util::stdx::static_simd_cast<util::native<int64_t>>(v) >>'
+        ' util::stdx::static_simd_cast<util::native<int64_t>>(sh)); }'
+    ),
+}
+
+# v_lshl_add_u64: (src0 << (src1 & 63)) + src2 — 64-bit value/addend, 32-bit
+# shift. Fixed op, dedicated glue (operand widths differ from the rev-shifts).
+SIMD_LSHL_ADD_U64: set[str] = {'v_lshl_add_u64_vop3'}
+
+# --- VOP3 wide 32x32->64 multiply-add (v_mad_u64_u32 / v_mad_i64_i32) -------
+#
+# 32-bit src0/src1 multiplicands widened to 64 (zero-/sign-extend), 64-bit
+# low-half product, plus the 64-bit src2 addend. Routed through
+# try_execute_mad_wide64_vop3_simd; the functor receives the two narrow operands
+# and the 64-bit addend.
+SIMD_MAD_WIDE64: dict[str, str] = {
+    'v_mad_u64_u32_vop3': (
+        '[](auto a, auto b, auto c) {'
+        ' return util::stdx::static_simd_cast<util::native<uint64_t>>(a)'
+        ' * util::stdx::static_simd_cast<util::native<uint64_t>>(b) + c; }'
+    ),
+    'v_mad_i64_i32_vop3': (
+        '[](auto a, auto b, auto c) {'
+        ' auto wa = util::stdx::static_simd_cast<util::native<uint64_t>>('
+        'util::stdx::static_simd_cast<util::native<int64_t>>('
+        'util::stdx::static_simd_cast<util::narrow32<int32_t>>(a)));'
+        ' auto wb = util::stdx::static_simd_cast<util::native<uint64_t>>('
+        'util::stdx::static_simd_cast<util::native<int64_t>>('
+        'util::stdx::static_simd_cast<util::narrow32<int32_t>>(b)));'
+        ' return wa * wb + c; }'
+    ),
+}
+
+# --- VOP3 carry binary (carry-out -> SGPR sdst, carry-in <- SGPR src2) ------
+#
+# Same SimdCarry functors as the VOP2 carry family, keyed by _vop3, split by
+# whether the form has a carry-in (and thus a src2 member): the carry-OUT forms
+# (add_co/sub_co/subrev_co) have no src2 and route through the _co glue; the
+# carry-IN forms (addc/subb/subbrev) read src2 and route through the _cin glue.
+_VOP3_CARRY_CIN_NAMES = {'v_addc_co_u32', 'v_subb_co_u32', 'v_subbrev_co_u32'}
+SIMD_VOP3_CARRY_CO: dict[str, str] = {
+    name.replace('_vop2', '_vop3'): functor
+    for name, functor in SIMD_VOP2_CARRY.items()
+    if name.replace('_vop2', '') not in _VOP3_CARRY_CIN_NAMES
+}
+SIMD_VOP3_CARRY_CIN: dict[str, str] = {
+    name.replace('_vop2', '_vop3'): functor
+    for name, functor in SIMD_VOP2_CARRY.items()
+    if name.replace('_vop2', '') in _VOP3_CARRY_CIN_NAMES
+}
+# RDNA-only carry-in aliases (add_co_ci / sub_co_ci / subrev_co_ci): same
+# per-lane add/sub-with-carry functor as the CDNA addc / subb / subbrev forms;
+# the decoder binds src2/sdst to VCC, but the body is uniform.
+SIMD_VOP3_CARRY_CIN.update(
+    {
+        'v_add_co_ci_u32_vop3': SIMD_VOP2_CARRY['v_addc_co_u32_vop2'],
+        'v_sub_co_ci_u32_vop3': SIMD_VOP2_CARRY['v_subb_co_u32_vop2'],
+        'v_subrev_co_ci_u32_vop3': SIMD_VOP2_CARRY['v_subbrev_co_u32_vop2'],
+    }
+)
 
 
 def simd_probe_line(template_name: str) -> str | None:
     """Return the SIMD fast-path probe block for a kernel, or None."""
-    spec = SIMD_VOP2_BINARY.get(template_name)
-    if spec is None:
-        return None
-    cpp_t, cpp_op = spec
-    return (
-        f"  if (try_execute_binary_vop2_simd<{cpp_t}>(inst, wf, {cpp_op}))\n"
-        f"    return;"
-    )
+    if template_name in SIMD_VOP2_CNDMASK:
+        return '  ROCJITSU_TRY_SIMD_VOP2_CNDMASK();'
+    if template_name in SIMD_VOP3_CNDMASK:
+        return '  ROCJITSU_TRY_SIMD_VOP3_CNDMASK();'
+    if template_name in SIMD_VOP3_CNDMASK_B16:
+        return '  ROCJITSU_TRY_SIMD_VOP3_CNDMASK_B16();'
+    spec2 = SIMD_VOP2_BINARY.get(template_name)
+    if spec2 is not None:
+        cpp_t, cpp_op = spec2
+        return f'  ROCJITSU_TRY_SIMD_VOP2_BINARY({cpp_t}, {cpp_op});'
+    spec1 = SIMD_VOP1_UNARY.get(template_name)
+    if spec1 is not None:
+        cpp_tin, cpp_tout, cpp_op = spec1
+        return f'  ROCJITSU_TRY_SIMD_VOP1_UNARY({cpp_tin}, {cpp_tout}, {cpp_op});'
+    specc = SIMD_VOP2_CARRY.get(template_name)
+    if specc is not None:
+        return f'  ROCJITSU_TRY_SIMD_VOP2_CARRY({specc});'
+    spect = SIMD_VOP2_TERNARY.get(template_name)
+    if spect is not None:
+        cpp_t, k_expr, cpp_op = spect
+        return f'  ROCJITSU_TRY_SIMD_VOP2_TERNARY({cpp_t}, {k_expr}, {cpp_op});'
+    specf64 = SIMD_VOP2_FMA_F64.get(template_name)
+    if specf64 is not None:
+        return f'  ROCJITSU_TRY_SIMD_VOP2_FMA_F64({specf64});'
+    spec1f64 = SIMD_VOP1_UNARY_F64.get(template_name)
+    if spec1f64 is not None:
+        lane_t, cpp_op = spec1f64
+        return f'  ROCJITSU_TRY_SIMD_VOP1_UNARY_F64({lane_t}, {cpp_op});'
+    speccvtout = SIMD_CVT_F64_TO_B32.get(template_name)
+    if speccvtout is not None:
+        out_t, cpp_op = speccvtout
+        return f'  ROCJITSU_TRY_SIMD_CVT_F64_TO_B32({out_t}, {cpp_op});'
+    speccvtin = SIMD_CVT_B32_TO_F64.get(template_name)
+    if speccvtin is not None:
+        in_t, cpp_op = speccvtin
+        return f'  ROCJITSU_TRY_SIMD_CVT_B32_TO_F64({in_t}, {cpp_op});'
+    specvopc = SIMD_VOPC.get(template_name)
+    if specvopc is not None:
+        lane_t, cpp_op = specvopc
+        return f'  ROCJITSU_TRY_SIMD_VOPC({lane_t}, {cpp_op});'
+    specclass = SIMD_VOPC_CLASS.get(template_name)
+    if specclass is not None:
+        lane_t, cpp_op = specclass
+        return f'  ROCJITSU_TRY_SIMD_VOPC({lane_t}, {cpp_op});'
+    specclass64 = SIMD_VOPC_CLASS_F64.get(template_name)
+    if specclass64 is not None:
+        return f'  ROCJITSU_TRY_SIMD_VOPC_CLASS_F64({specclass64});'
+    spec3class = SIMD_VOP3_CLASS.get(template_name)
+    if spec3class is not None:
+        sm, cpp_op = spec3class
+        return f'  ROCJITSU_TRY_SIMD_VOP3_CLASS_B32({sm}, {cpp_op});'
+    spec3class64 = SIMD_VOP3_CLASS_F64.get(template_name)
+    if spec3class64 is not None:
+        return f'  ROCJITSU_TRY_SIMD_VOP3_CLASS_F64(0x8000000000000000ull, {spec3class64});'
+    specvopc64 = SIMD_VOPC64.get(template_name)
+    if specvopc64 is not None:
+        lane_t, cpp_op = specvopc64
+        return f'  ROCJITSU_TRY_SIMD_VOPC64({lane_t}, {cpp_op});'
+    # VOP3 form of the integer/bitwise VOPC compares (i16/u16/i32/u32 and
+    # i64/u64). Same functor as the VOPC table (no modifiers), but the merge
+    # writes the SGPR-pair dst instead of VCC.
+    specvopcv3i32 = SIMD_VOPC_VOP3_INT_32.get(template_name)
+    if specvopcv3i32 is not None:
+        lane_t, cpp_op = specvopcv3i32
+        return f'  ROCJITSU_TRY_SIMD_VOPC_VOP3_INT({lane_t}, {cpp_op});'
+    specvopcv3i64 = SIMD_VOPC_VOP3_INT_64.get(template_name)
+    if specvopcv3i64 is not None:
+        lane_t, cpp_op = specvopcv3i64
+        return f'  ROCJITSU_TRY_SIMD_VOPC64_VOP3_INT({lane_t}, {cpp_op});'
+    # VOP3 form of the f32 VOPC relational compares (17 ops: 16 relations +
+    # 't' constant). Per-source abs/neg modifiers applied outside the functor
+    # via the fp32 VOPC glue; SGPR-pair dst merge identical to the integer path.
+    specvopcv3f32 = SIMD_VOPC_VOP3_F32.get(template_name)
+    if specvopcv3f32 is not None:
+        return f'  ROCJITSU_TRY_SIMD_VOPC_VOP3_FP32({specvopcv3f32});'
+    # VOP3 form of the f16 VOPC relational compares (17 ops). The glue widens
+    # raw lanes to f32 then applies abs/neg in f32 domain — matching the scalar
+    # body's f16_to_f32 -> std::fabs/-x order. Same functor as the f32 path.
+    specvopcv3f16 = SIMD_VOPC_VOP3_F16.get(template_name)
+    if specvopcv3f16 is not None:
+        return f'  ROCJITSU_TRY_SIMD_VOPC_VOP3_FP16({specvopcv3f16});'
+    # VOP3 form of the f64 VOPC relational compares (17 ops). 64-bit-lane,
+    # per-source abs/neg modifiers applied in the f64 domain outside the functor.
+    specvopcv3f64 = SIMD_VOPC_VOP3_F64.get(template_name)
+    if specvopcv3f64 is not None:
+        return f'  ROCJITSU_TRY_SIMD_VOPC64_VOP3_FP64({specvopcv3f64});'
+    # VOP3 integer/bitwise ternary ops (add3/or3/xor3/lshl_add/add_lshl/bfi).
+    # Plain element-wise functor of (src0, src1, src2); no modifiers.
+    spec3tern = SIMD_VOP3_TERNARY_INT.get(template_name)
+    if spec3tern is not None:
+        cpp_t, cpp_op = spec3tern
+        return f'  ROCJITSU_TRY_SIMD_VOP3_TERNARY_INT({cpp_t}, {cpp_op});'
+    # 64-bit reverse shifts (src0 = 32-bit count, src1 = 64-bit value).
+    specshift64 = SIMD_SHIFT64_VOP3.get(template_name)
+    if specshift64 is not None:
+        return f'  ROCJITSU_TRY_SIMD_SHIFT64_VOP3({specshift64});'
+    if template_name in SIMD_LSHL_ADD_U64:
+        return '  ROCJITSU_TRY_SIMD_LSHL_ADD_U64();'
+    specmad64 = SIMD_MAD_WIDE64.get(template_name)
+    if specmad64 is not None:
+        return f'  ROCJITSU_TRY_SIMD_MAD_WIDE64_VOP3({specmad64});'
+    specv3co = SIMD_VOP3_CARRY_CO.get(template_name)
+    if specv3co is not None:
+        return f'  ROCJITSU_TRY_SIMD_VOP3_CO({specv3co});'
+    specv3cin = SIMD_VOP3_CARRY_CIN.get(template_name)
+    if specv3cin is not None:
+        return f'  ROCJITSU_TRY_SIMD_VOP3_CIN({specv3cin});'
+    # VOP3 fp ternary (FMA / MAD family). Per-source abs/neg + omod/clamp in
+    # the f32 / f16 / f64 domain. NaN-input lanes skipped by test (gcc-13
+    # packed FMA quiets a different NaN operand vs scalar std::fma).
+    spec3tf32 = SIMD_VOP3_TERNARY_FP32.get(template_name)
+    if spec3tf32 is not None:
+        return f'  ROCJITSU_TRY_SIMD_VOP3_TERNARY_FP32({spec3tf32});'
+    spec3tf16 = SIMD_VOP3_TERNARY_FP16.get(template_name)
+    if spec3tf16 is not None:
+        return f'  ROCJITSU_TRY_SIMD_VOP3_TERNARY_FP16({spec3tf16});'
+    spec3tf64 = SIMD_VOP3_TERNARY_FP64.get(template_name)
+    if spec3tf64 is not None:
+        return f'  ROCJITSU_TRY_SIMD_VOP3_TERNARY_FP64({spec3tf64});'
+    if template_name in SIMD_VOP3_DIV_FMAS_FP32:
+        return '  ROCJITSU_TRY_SIMD_DIV_FMAS_VOP3_FP32();'
+    if template_name in SIMD_VOP3_DIV_FMAS_FP64:
+        return '  ROCJITSU_TRY_SIMD_DIV_FMAS_VOP3_FP64();'
+    # VOP3P packed-16 integer binary family (pk_add/sub/mul_lo/min/max for
+    # i16/u16 + pk_lshlrev/lshrrev/ashrrev for b16/i16). Gated on default
+    # op_sel = 0 / op_sel_hi = 3 inside the glue.
+    specpk = SIMD_VOP3P_PK_BINARY_INT.get(template_name)
+    if specpk is not None:
+        return f'  ROCJITSU_TRY_SIMD_VOP3P_PK_BINARY_INT({specpk});'
+    specpkt = SIMD_VOP3P_PK_TERNARY_INT.get(template_name)
+    if specpkt is not None:
+        return f'  ROCJITSU_TRY_SIMD_VOP3P_PK_TERNARY_INT({specpkt});'
+    specpkf16 = SIMD_VOP3P_PK_BINARY_FP16.get(template_name)
+    if specpkf16 is not None:
+        return f'  ROCJITSU_TRY_SIMD_VOP3P_PK_BINARY_FP16({specpkf16});'
+    specpkf16t = SIMD_VOP3P_PK_TERNARY_FP16.get(template_name)
+    if specpkf16t is not None:
+        return f'  ROCJITSU_TRY_SIMD_VOP3P_PK_TERNARY_FP16({specpkf16t});'
+    if template_name in SIMD_VOP3P_MOV_B32:
+        return '  ROCJITSU_TRY_SIMD_VOP3P_MOV_B32();'
+    # VOP3P integer dot products (dot4 i8/u8, dot8 i4/u4, dot2 i16/u16).
+    specdot = SIMD_VOP3P_DOT_INT.get(template_name)
+    if specdot is not None:
+        return f'  ROCJITSU_TRY_SIMD_VOP3P_DOT_INT({specdot});'
+    if template_name in SIMD_VOP3P_DOT_F16:
+        return '  ROCJITSU_TRY_SIMD_VOP3P_DOT_F16();'
+    # VOP3P fma_mix / mad_mix (six ops, three destination shapes). Same body
+    # for all; the routing picks the matching glue specialization.
+    if template_name in SIMD_VOP3P_FMA_MIX_F32:
+        return '  ROCJITSU_TRY_SIMD_VOP3P_FMA_MIX_F32();'
+    if template_name in SIMD_VOP3P_FMA_MIX_F16_LO:
+        return '  ROCJITSU_TRY_SIMD_VOP3P_FMA_MIX_F16_LO();'
+    if template_name in SIMD_VOP3P_FMA_MIX_F16_HI:
+        return '  ROCJITSU_TRY_SIMD_VOP3P_FMA_MIX_F16_HI();'
+    # VOP3 dst-accumulate FMA/MAC (vdst is the third operand). Per-isa class
+    # has no src2; the accumulate glue reads vdst instead.
+    specfmacf32 = SIMD_VOP3_FMAC_FP32.get(template_name)
+    if specfmacf32 is not None:
+        return f'  ROCJITSU_TRY_SIMD_FMAC_VOP3_FP32({specfmacf32});'
+    specfmacf16 = SIMD_VOP3_FMAC_FP16.get(template_name)
+    if specfmacf16 is not None:
+        return f'  ROCJITSU_TRY_SIMD_FMAC_VOP3_FP16({specfmacf16});'
+    specfmacf64 = SIMD_VOP3_FMAC_FP64.get(template_name)
+    if specfmacf64 is not None:
+        return f'  ROCJITSU_TRY_SIMD_FMAC_VOP3_FP64({specfmacf64});'
+    # VOP3 ldexp: mixed-width fp src0 + int32 src1 exp.
+    specldexpf32 = SIMD_VOP3_LDEXP_FP32.get(template_name)
+    if specldexpf32 is not None:
+        return f'  ROCJITSU_TRY_SIMD_LDEXP_VOP3_FP32({specldexpf32});'
+    specldexpf64 = SIMD_VOP3_LDEXP_FP64.get(template_name)
+    if specldexpf64 is not None:
+        return f'  ROCJITSU_TRY_SIMD_LDEXP_VOP3_FP64({specldexpf64});'
+    # VOP3 unary integer ops with no VOP1 twin (e.g. v_not_b16). Reuse the
+    # VOP1 unary glue — operand shape (src0, vdst, 32-bit lanes) matches.
+    spec3unai = SIMD_VOP3_UNARY_INT_EXTRA.get(template_name)
+    if spec3unai is not None:
+        cpp_tin, cpp_tout, cpp_op = spec3unai
+        return f'  ROCJITSU_TRY_SIMD_VOP1_UNARY({cpp_tin}, {cpp_tout}, {cpp_op});'
+    # Extra plain integer binary VOP3 ops without a VOP2 twin (add_i32/i16,
+    # sub_*, nc_* variants). Routed through the int VOP3 binary glue.
+    spec3binx = SIMD_VOP3_BINARY_INT_EXTRA.get(template_name)
+    if spec3binx is not None:
+        cpp_t, cpp_op = spec3binx
+        return f'  ROCJITSU_TRY_SIMD_VOP3_BINARY_INT({cpp_t}, {cpp_op});'
+    # VOP3 f64 binary (add/mul/max/min). Per-source abs/neg + result omod/clamp
+    # in the f64 domain.
+    spec3binf64 = SIMD_VOP3_BINARY_FP64.get(template_name)
+    if spec3binf64 is not None:
+        return f'  ROCJITSU_TRY_SIMD_VOP3_BINARY_FP64({spec3binf64});'
+    # VOP3 f64 unary (ceil/floor/trunc/rndne/sqrt). Same modifier policy.
+    spec3unaf64 = SIMD_VOP3_UNARY_FP64.get(template_name)
+    if spec3unaf64 is not None:
+        return f'  ROCJITSU_TRY_SIMD_VOP3_UNARY_FP64({spec3unaf64});'
+    # VOP3 f16 unary (widen-then-modify-then-narrow). FTZ-free ops only:
+    # ceil/floor/trunc/rndne/sqrt. Transcendentals deferred.
+    spec3unaf16 = SIMD_VOP3_UNARY_FP16.get(template_name)
+    if spec3unaf16 is not None:
+        return f'  ROCJITSU_TRY_SIMD_VOP3_UNARY_FP16({spec3unaf16});'
+    # VOP3-encoded twins of the SIMD VOP2 binary ops. Same operator/lane type;
+    # the VOP3 form reads src0/src1 and carries abs/neg/omod/clamp modifiers.
+    # f32 ops apply the modifiers in-vector (bit-exact); integer/bitwise ops
+    # apply none (their scalar bodies ignore them), so the plain op suffices.
+    if template_name.endswith('_vop3'):
+        base = template_name[: -len('_vop3')]
+        spec2v3 = SIMD_VOP2_BINARY.get(base + '_vop2')
+        if spec2v3 is not None:
+            cpp_t, cpp_op = spec2v3
+            if cpp_t == 'float32_t':
+                return f'  ROCJITSU_TRY_SIMD_VOP3_BINARY_FP({cpp_t}, {cpp_op});'
+            return f'  ROCJITSU_TRY_SIMD_VOP3_BINARY_INT({cpp_t}, {cpp_op});'
+        # VOP3-encoded twins of the SIMD VOP1 unary ops. The plain int/cvt forms
+        # apply no modifiers and read the same src0/vdst operands as VOP1, so they
+        # reuse the VOP1 unary path verbatim. The f32 forms (and the float-domain
+        # v_mov_b32) carry abs/neg/omod/clamp and route through the f32 unary glue.
+        # The f16 forms also carry modifiers, but applying them around the f16<->f32
+        # round trip is not yet handled, so they are left scalar (_VOP3_UNARY_SKIP).
+        spec1v3 = SIMD_VOP1_UNARY.get(base + '_vop1')
+        if spec1v3 is not None:
+            cpp_tin, cpp_tout, cpp_op = spec1v3
+            if base in _VOP3_UNARY_SKIP:
+                return None
+            if base in _VOP3_UNARY_FP_F32:
+                return f'  ROCJITSU_TRY_SIMD_VOP3_UNARY_FP(float32_t, float32_t, {cpp_op});'
+            return f'  ROCJITSU_TRY_SIMD_VOP1_UNARY({cpp_tin}, {cpp_tout}, {cpp_op});'
+        # VOP3 twins of the mixed-width f64<->b32 cvt ops. Their generated VOP3
+        # bodies drop the abs/neg/omod/clamp modifier reads (verified per-op),
+        # so routing through the existing cvt glue is bit-exact. (A symmetric
+        # SIMD_VOP1_UNARY_F64 fallback was considered but explicitly NOT added:
+        # the f64-unary VOP3 forms apply modifiers via apply_vop3_*_mod_f64 —
+        # routed through SIMD_VOP3_UNARY_FP64 above instead — and the rcp/rsq
+        # forms use transcendental::*_f64 with NaN/±0/±Inf carve-outs not
+        # present in the plain VOP1 functors.)
+        speccvtoutv3 = SIMD_CVT_F64_TO_B32.get(base + '_vop1')
+        if speccvtoutv3 is not None:
+            # Unlike the plain cvt ops, v_frexp_exp_i32_f64's VOP3 body keeps the
+            # modifiers (float omod/clamp on float(exp) + bit_cast) — a different
+            # output encoding than the VOP1 int. Keep that twin scalar.
+            if base in _VOP3_UNARY_SKIP:
+                return None
+            out_t, cpp_op = speccvtoutv3
+            return f'  ROCJITSU_TRY_SIMD_CVT_F64_TO_B32({out_t}, {cpp_op});'
+        speccvtinv3 = SIMD_CVT_B32_TO_F64.get(base + '_vop1')
+        if speccvtinv3 is not None:
+            in_t, cpp_op = speccvtinv3
+            return f'  ROCJITSU_TRY_SIMD_CVT_B32_TO_F64({in_t}, {cpp_op});'
+    return None
+
+
+def simd_probe_arch_portable(template_name: str) -> bool:
+    """Whether a SIMD-probe kernel can be force-routed through the shared
+    execute template on an ISA that is not in its cross-ISA shared group.
+
+    Most SIMD fast-path kernels have an arch-independent body (arithmetic /
+    compare on `inst.src0` / `inst.vsrc1` / `inst.vdst`), so an ISA whose
+    operand/field signature kept it out of the shared plan can still safely
+    delegate to the one shared template — the body is identical. The exception
+    is the inline-literal FMA family (v_fmaak/fmamk/madak/madmk): those read the
+    32-bit literal through an ISA-divergent member (`simm32_` on some ISAs vs a
+    `simm32` Operand with `.encoding_value_` on others), so a single shared body
+    cannot satisfy every ISA. Those are identified by a non-``"0u"`` literal
+    expression in SIMD_VOP2_TERNARY and are left to the genuine shared plan;
+    the dst-accumulate forms (literal ``"0u"``: v_fmac/v_mac, and v_fmac_f64)
+    are portable.
+    """
+    if simd_probe_line(template_name) is None:
+        return False
+    spect = SIMD_VOP2_TERNARY.get(template_name)
+    if spect is not None and spect[1] != '0u':
+        return False
+    return True
 
 
 def simd_extra_includes() -> list[str]:

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/vector_alu.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/vector_alu.py
@@ -959,7 +959,9 @@ def gen_vector_ternary(
             f'    int32_t b = static_cast<int32_t>({s1}.read_lane(wf, lane) << 8) >> 8;'
         )
         L.append(f'    int32_t c = static_cast<int32_t>({s2}.read_lane(wf, lane));')
-        L.append(f'    {d}.write_lane(wf, lane, static_cast<uint32_t>(a * b + c));')
+        L.append(
+            f'    {d}.write_lane(wf, lane, static_cast<uint32_t>(static_cast<int64_t>(a) * b + c));'
+        )
     elif dtype in ('u24',):
         L.append(f'    uint32_t a = {s0}.read_lane(wf, lane) & 0x00FFFFFFu;')
         L.append(f'    uint32_t b = {s1}.read_lane(wf, lane) & 0x00FFFFFFu;')

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/vector_cmp.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/vector_cmp.py
@@ -66,43 +66,45 @@ def gen_vector_cmp_class(
         L.append('    if ((mask & 0x100) && std::isnormal(s0) && s0 > 0) match = true;')
         L.append('    if ((mask & 0x200) && std::isinf(s0) && s0 > 0) match = true;')
     elif dtype == 'f16':
-        # Read raw f16 bits first for sNaN/qNaN detection (bit 9 is the
-        # quiet NaN bit in IEEE 754 binary16), then convert to f32 for
-        # the remaining class checks. The f16→f32 conversion may turn
-        # sNaN into qNaN, so we cannot rely on the converted value.
+        # Classify directly from the raw f16 bit fields. Converting to f32
+        # first is lossy for this purpose: an f16 denormal widens to an f32
+        # *normal*, so std::isnormal would misclassify every f16 denormal as
+        # normal. The exponent/mantissa/sign decode below distinguishes all ten
+        # classes on the true f16 value (bit 9 of the mantissa is the quiet-NaN
+        # bit in IEEE 754 binary16).
         L.append(
             f'    uint16_t s0_raw = static_cast<uint16_t>({src[0]}.read_lane(wf, lane));'
         )
-        L.append(f'    float s0 = util::f16_to_f32(s0_raw);')
         if is_vop3:
-            L.extend(vop3_src_mod('s0', 0, has_abs))
+            # VOP3 abs/neg apply to the f16 value: abs clears the sign bit, neg
+            # flips it (abs before neg, matching neg(abs(x))).
+            if has_abs:
+                L.append('    if (inst_.abs & (1u << 0)) s0_raw &= 0x7FFFu;')
+            L.append('    if (inst_.neg & (1u << 0)) s0_raw ^= 0x8000u;')
         L.append(f'    uint32_t mask = {src[1]}.read_lane(wf, lane);')
         L.append('    bool match = false;')
+        L.append('    uint16_t f16_exp = (s0_raw >> 10) & 0x1F;')
+        L.append('    uint16_t f16_mant = s0_raw & 0x3FF;')
+        L.append('    bool f16_sign = (s0_raw & 0x8000) != 0;')
+        L.append('    bool is_nan = (f16_exp == 0x1F) && (f16_mant != 0);')
+        L.append('    bool is_inf = (f16_exp == 0x1F) && (f16_mant == 0);')
+        L.append('    bool is_zero = (f16_exp == 0) && (f16_mant == 0);')
+        L.append('    bool is_denorm = (f16_exp == 0) && (f16_mant != 0);')
+        L.append('    bool is_normal = (f16_exp >= 1) && (f16_exp <= 30);')
         L.append(
-            '    bool is_f16_nan = ((s0_raw & 0x7C00) == 0x7C00) && ((s0_raw & 0x03FF) != 0);'
+            '    if ((mask & 0x001) && is_nan && (s0_raw & 0x0200) == 0) match = true;'
         )
         L.append(
-            '    if ((mask & 0x001) && is_f16_nan && (s0_raw & 0x0200) == 0) match = true;'
+            '    if ((mask & 0x002) && is_nan && (s0_raw & 0x0200) != 0) match = true;'
         )
-        L.append(
-            '    if ((mask & 0x002) && is_f16_nan && (s0_raw & 0x0200) != 0) match = true;'
-        )
-        L.append('    if ((mask & 0x004) && std::isinf(s0) && s0 < 0) match = true;')
-        L.append('    if ((mask & 0x008) && std::isnormal(s0) && s0 < 0) match = true;')
-        L.append(
-            '    if ((mask & 0x010) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) && s0 != 0.0f && std::signbit(s0)) match = true;'
-        )
-        L.append(
-            '    if ((mask & 0x020) && s0 == 0.0f && std::signbit(s0)) match = true;'
-        )
-        L.append(
-            '    if ((mask & 0x040) && s0 == 0.0f && !std::signbit(s0)) match = true;'
-        )
-        L.append(
-            '    if ((mask & 0x080) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) && s0 != 0.0f && !std::signbit(s0)) match = true;'
-        )
-        L.append('    if ((mask & 0x100) && std::isnormal(s0) && s0 > 0) match = true;')
-        L.append('    if ((mask & 0x200) && std::isinf(s0) && s0 > 0) match = true;')
+        L.append('    if ((mask & 0x004) && is_inf && f16_sign) match = true;')
+        L.append('    if ((mask & 0x008) && is_normal && f16_sign) match = true;')
+        L.append('    if ((mask & 0x010) && is_denorm && f16_sign) match = true;')
+        L.append('    if ((mask & 0x020) && is_zero && f16_sign) match = true;')
+        L.append('    if ((mask & 0x040) && is_zero && !f16_sign) match = true;')
+        L.append('    if ((mask & 0x080) && is_denorm && !f16_sign) match = true;')
+        L.append('    if ((mask & 0x100) && is_normal && !f16_sign) match = true;')
+        L.append('    if ((mask & 0x200) && is_inf && !f16_sign) match = true;')
     else:
         L.append(f'    float s0 = std::bit_cast<float>({src[0]}.read_lane(wf, lane));')
         if is_vop3:

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/vector_special.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/vector_special.py
@@ -202,8 +202,8 @@ def gen_vector_div_fixup(
             L.extend(vop3_src_mod('b', 1, has_abs))
             L.extend(vop3_src_mod('c', 2, has_abs))
         L.append('    double result;')
-        L.append('    if (std::isnan(b)) result = b;')
-        L.append('    else if (std::isnan(c)) result = c;')
+        L.append('    if (std::isnan(c)) result = c;')
+        L.append('    else if (std::isnan(b)) result = b;')
         L.append(
             '    else if (c == 0.0 && b == 0.0) result = std::numeric_limits<double>::quiet_NaN();'
         )
@@ -247,8 +247,8 @@ def gen_vector_div_fixup(
             L.extend(vop3_src_mod('b', 1, has_abs))
             L.extend(vop3_src_mod('c', 2, has_abs))
         L.append('    float result;')
-        L.append('    if (std::isnan(b)) result = b;')
-        L.append('    else if (std::isnan(c)) result = c;')
+        L.append('    if (std::isnan(c)) result = c;')
+        L.append('    else if (std::isnan(b)) result = b;')
         L.append(
             '    else if (c == 0.0f && b == 0.0f) result = std::numeric_limits<float>::quiet_NaN();'
         )

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna1/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna1/vop3.cpp
@@ -3961,35 +3961,39 @@ void VCmpxClassF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     uint16_t s0_raw = static_cast<uint16_t>(src0.read_lane(wf, lane));
-    float s0 = util::f16_to_f32(s0_raw);
     if (inst_.abs & (1u << 0))
-      s0 = std::fabs(s0);
+      s0_raw &= 0x7FFFu;
     if (inst_.neg & (1u << 0))
-      s0 = -s0;
+      s0_raw ^= 0x8000u;
     uint32_t mask = src1.read_lane(wf, lane);
     bool match = false;
-    bool is_f16_nan = ((s0_raw & 0x7C00) == 0x7C00) && ((s0_raw & 0x03FF) != 0);
-    if ((mask & 0x001) && is_f16_nan && (s0_raw & 0x0200) == 0)
+    uint16_t f16_exp = (s0_raw >> 10) & 0x1F;
+    uint16_t f16_mant = s0_raw & 0x3FF;
+    bool f16_sign = (s0_raw & 0x8000) != 0;
+    bool is_nan = (f16_exp == 0x1F) && (f16_mant != 0);
+    bool is_inf = (f16_exp == 0x1F) && (f16_mant == 0);
+    bool is_zero = (f16_exp == 0) && (f16_mant == 0);
+    bool is_denorm = (f16_exp == 0) && (f16_mant != 0);
+    bool is_normal = (f16_exp >= 1) && (f16_exp <= 30);
+    if ((mask & 0x001) && is_nan && (s0_raw & 0x0200) == 0)
       match = true;
-    if ((mask & 0x002) && is_f16_nan && (s0_raw & 0x0200) != 0)
+    if ((mask & 0x002) && is_nan && (s0_raw & 0x0200) != 0)
       match = true;
-    if ((mask & 0x004) && std::isinf(s0) && s0 < 0)
+    if ((mask & 0x004) && is_inf && f16_sign)
       match = true;
-    if ((mask & 0x008) && std::isnormal(s0) && s0 < 0)
+    if ((mask & 0x008) && is_normal && f16_sign)
       match = true;
-    if ((mask & 0x010) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) && s0 != 0.0f &&
-        std::signbit(s0))
+    if ((mask & 0x010) && is_denorm && f16_sign)
       match = true;
-    if ((mask & 0x020) && s0 == 0.0f && std::signbit(s0))
+    if ((mask & 0x020) && is_zero && f16_sign)
       match = true;
-    if ((mask & 0x040) && s0 == 0.0f && !std::signbit(s0))
+    if ((mask & 0x040) && is_zero && !f16_sign)
       match = true;
-    if ((mask & 0x080) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) && s0 != 0.0f &&
-        !std::signbit(s0))
+    if ((mask & 0x080) && is_denorm && !f16_sign)
       match = true;
-    if ((mask & 0x100) && std::isnormal(s0) && s0 > 0)
+    if ((mask & 0x100) && is_normal && !f16_sign)
       match = true;
-    if ((mask & 0x200) && std::isinf(s0) && s0 > 0)
+    if ((mask & 0x200) && is_inf && !f16_sign)
       match = true;
     if (match)
       result |= (1ULL << lane);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna1/vopc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna1/vopc.cpp
@@ -780,31 +780,35 @@ void VCmpxClassF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     uint16_t s0_raw = static_cast<uint16_t>(src0.read_lane(wf, lane));
-    float s0 = util::f16_to_f32(s0_raw);
     uint32_t mask = vsrc1.read_lane(wf, lane);
     bool match = false;
-    bool is_f16_nan = ((s0_raw & 0x7C00) == 0x7C00) && ((s0_raw & 0x03FF) != 0);
-    if ((mask & 0x001) && is_f16_nan && (s0_raw & 0x0200) == 0)
+    uint16_t f16_exp = (s0_raw >> 10) & 0x1F;
+    uint16_t f16_mant = s0_raw & 0x3FF;
+    bool f16_sign = (s0_raw & 0x8000) != 0;
+    bool is_nan = (f16_exp == 0x1F) && (f16_mant != 0);
+    bool is_inf = (f16_exp == 0x1F) && (f16_mant == 0);
+    bool is_zero = (f16_exp == 0) && (f16_mant == 0);
+    bool is_denorm = (f16_exp == 0) && (f16_mant != 0);
+    bool is_normal = (f16_exp >= 1) && (f16_exp <= 30);
+    if ((mask & 0x001) && is_nan && (s0_raw & 0x0200) == 0)
       match = true;
-    if ((mask & 0x002) && is_f16_nan && (s0_raw & 0x0200) != 0)
+    if ((mask & 0x002) && is_nan && (s0_raw & 0x0200) != 0)
       match = true;
-    if ((mask & 0x004) && std::isinf(s0) && s0 < 0)
+    if ((mask & 0x004) && is_inf && f16_sign)
       match = true;
-    if ((mask & 0x008) && std::isnormal(s0) && s0 < 0)
+    if ((mask & 0x008) && is_normal && f16_sign)
       match = true;
-    if ((mask & 0x010) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) && s0 != 0.0f &&
-        std::signbit(s0))
+    if ((mask & 0x010) && is_denorm && f16_sign)
       match = true;
-    if ((mask & 0x020) && s0 == 0.0f && std::signbit(s0))
+    if ((mask & 0x020) && is_zero && f16_sign)
       match = true;
-    if ((mask & 0x040) && s0 == 0.0f && !std::signbit(s0))
+    if ((mask & 0x040) && is_zero && !f16_sign)
       match = true;
-    if ((mask & 0x080) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) && s0 != 0.0f &&
-        !std::signbit(s0))
+    if ((mask & 0x080) && is_denorm && !f16_sign)
       match = true;
-    if ((mask & 0x100) && std::isnormal(s0) && s0 > 0)
+    if ((mask & 0x100) && is_normal && !f16_sign)
       match = true;
-    if ((mask & 0x200) && std::isinf(s0) && s0 > 0)
+    if ((mask & 0x200) && is_inf && !f16_sign)
       match = true;
     if (match)
       result |= (1ULL << lane);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna2/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna2/vop3.cpp
@@ -3864,35 +3864,39 @@ void VCmpxClassF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     uint16_t s0_raw = static_cast<uint16_t>(src0.read_lane(wf, lane));
-    float s0 = util::f16_to_f32(s0_raw);
     if (inst_.abs & (1u << 0))
-      s0 = std::fabs(s0);
+      s0_raw &= 0x7FFFu;
     if (inst_.neg & (1u << 0))
-      s0 = -s0;
+      s0_raw ^= 0x8000u;
     uint32_t mask = src1.read_lane(wf, lane);
     bool match = false;
-    bool is_f16_nan = ((s0_raw & 0x7C00) == 0x7C00) && ((s0_raw & 0x03FF) != 0);
-    if ((mask & 0x001) && is_f16_nan && (s0_raw & 0x0200) == 0)
+    uint16_t f16_exp = (s0_raw >> 10) & 0x1F;
+    uint16_t f16_mant = s0_raw & 0x3FF;
+    bool f16_sign = (s0_raw & 0x8000) != 0;
+    bool is_nan = (f16_exp == 0x1F) && (f16_mant != 0);
+    bool is_inf = (f16_exp == 0x1F) && (f16_mant == 0);
+    bool is_zero = (f16_exp == 0) && (f16_mant == 0);
+    bool is_denorm = (f16_exp == 0) && (f16_mant != 0);
+    bool is_normal = (f16_exp >= 1) && (f16_exp <= 30);
+    if ((mask & 0x001) && is_nan && (s0_raw & 0x0200) == 0)
       match = true;
-    if ((mask & 0x002) && is_f16_nan && (s0_raw & 0x0200) != 0)
+    if ((mask & 0x002) && is_nan && (s0_raw & 0x0200) != 0)
       match = true;
-    if ((mask & 0x004) && std::isinf(s0) && s0 < 0)
+    if ((mask & 0x004) && is_inf && f16_sign)
       match = true;
-    if ((mask & 0x008) && std::isnormal(s0) && s0 < 0)
+    if ((mask & 0x008) && is_normal && f16_sign)
       match = true;
-    if ((mask & 0x010) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) && s0 != 0.0f &&
-        std::signbit(s0))
+    if ((mask & 0x010) && is_denorm && f16_sign)
       match = true;
-    if ((mask & 0x020) && s0 == 0.0f && std::signbit(s0))
+    if ((mask & 0x020) && is_zero && f16_sign)
       match = true;
-    if ((mask & 0x040) && s0 == 0.0f && !std::signbit(s0))
+    if ((mask & 0x040) && is_zero && !f16_sign)
       match = true;
-    if ((mask & 0x080) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) && s0 != 0.0f &&
-        !std::signbit(s0))
+    if ((mask & 0x080) && is_denorm && !f16_sign)
       match = true;
-    if ((mask & 0x100) && std::isnormal(s0) && s0 > 0)
+    if ((mask & 0x100) && is_normal && !f16_sign)
       match = true;
-    if ((mask & 0x200) && std::isinf(s0) && s0 > 0)
+    if ((mask & 0x200) && is_inf && !f16_sign)
       match = true;
     if (match)
       result |= (1ULL << lane);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna2/vopc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna2/vopc.cpp
@@ -780,31 +780,35 @@ void VCmpxClassF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     uint16_t s0_raw = static_cast<uint16_t>(src0.read_lane(wf, lane));
-    float s0 = util::f16_to_f32(s0_raw);
     uint32_t mask = vsrc1.read_lane(wf, lane);
     bool match = false;
-    bool is_f16_nan = ((s0_raw & 0x7C00) == 0x7C00) && ((s0_raw & 0x03FF) != 0);
-    if ((mask & 0x001) && is_f16_nan && (s0_raw & 0x0200) == 0)
+    uint16_t f16_exp = (s0_raw >> 10) & 0x1F;
+    uint16_t f16_mant = s0_raw & 0x3FF;
+    bool f16_sign = (s0_raw & 0x8000) != 0;
+    bool is_nan = (f16_exp == 0x1F) && (f16_mant != 0);
+    bool is_inf = (f16_exp == 0x1F) && (f16_mant == 0);
+    bool is_zero = (f16_exp == 0) && (f16_mant == 0);
+    bool is_denorm = (f16_exp == 0) && (f16_mant != 0);
+    bool is_normal = (f16_exp >= 1) && (f16_exp <= 30);
+    if ((mask & 0x001) && is_nan && (s0_raw & 0x0200) == 0)
       match = true;
-    if ((mask & 0x002) && is_f16_nan && (s0_raw & 0x0200) != 0)
+    if ((mask & 0x002) && is_nan && (s0_raw & 0x0200) != 0)
       match = true;
-    if ((mask & 0x004) && std::isinf(s0) && s0 < 0)
+    if ((mask & 0x004) && is_inf && f16_sign)
       match = true;
-    if ((mask & 0x008) && std::isnormal(s0) && s0 < 0)
+    if ((mask & 0x008) && is_normal && f16_sign)
       match = true;
-    if ((mask & 0x010) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) && s0 != 0.0f &&
-        std::signbit(s0))
+    if ((mask & 0x010) && is_denorm && f16_sign)
       match = true;
-    if ((mask & 0x020) && s0 == 0.0f && std::signbit(s0))
+    if ((mask & 0x020) && is_zero && f16_sign)
       match = true;
-    if ((mask & 0x040) && s0 == 0.0f && !std::signbit(s0))
+    if ((mask & 0x040) && is_zero && !f16_sign)
       match = true;
-    if ((mask & 0x080) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) && s0 != 0.0f &&
-        !std::signbit(s0))
+    if ((mask & 0x080) && is_denorm && !f16_sign)
       match = true;
-    if ((mask & 0x100) && std::isnormal(s0) && s0 > 0)
+    if ((mask & 0x100) && is_normal && !f16_sign)
       match = true;
-    if ((mask & 0x200) && std::isinf(s0) && s0 > 0)
+    if ((mask & 0x200) && is_inf && !f16_sign)
       match = true;
     if (match)
       result |= (1ULL << lane);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/vop3.cpp
@@ -3997,35 +3997,39 @@ void VCmpxClassF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     uint16_t s0_raw = static_cast<uint16_t>(src0.read_lane(wf, lane));
-    float s0 = util::f16_to_f32(s0_raw);
     if (inst_.abs & (1u << 0))
-      s0 = std::fabs(s0);
+      s0_raw &= 0x7FFFu;
     if (inst_.neg & (1u << 0))
-      s0 = -s0;
+      s0_raw ^= 0x8000u;
     uint32_t mask = src1.read_lane(wf, lane);
     bool match = false;
-    bool is_f16_nan = ((s0_raw & 0x7C00) == 0x7C00) && ((s0_raw & 0x03FF) != 0);
-    if ((mask & 0x001) && is_f16_nan && (s0_raw & 0x0200) == 0)
+    uint16_t f16_exp = (s0_raw >> 10) & 0x1F;
+    uint16_t f16_mant = s0_raw & 0x3FF;
+    bool f16_sign = (s0_raw & 0x8000) != 0;
+    bool is_nan = (f16_exp == 0x1F) && (f16_mant != 0);
+    bool is_inf = (f16_exp == 0x1F) && (f16_mant == 0);
+    bool is_zero = (f16_exp == 0) && (f16_mant == 0);
+    bool is_denorm = (f16_exp == 0) && (f16_mant != 0);
+    bool is_normal = (f16_exp >= 1) && (f16_exp <= 30);
+    if ((mask & 0x001) && is_nan && (s0_raw & 0x0200) == 0)
       match = true;
-    if ((mask & 0x002) && is_f16_nan && (s0_raw & 0x0200) != 0)
+    if ((mask & 0x002) && is_nan && (s0_raw & 0x0200) != 0)
       match = true;
-    if ((mask & 0x004) && std::isinf(s0) && s0 < 0)
+    if ((mask & 0x004) && is_inf && f16_sign)
       match = true;
-    if ((mask & 0x008) && std::isnormal(s0) && s0 < 0)
+    if ((mask & 0x008) && is_normal && f16_sign)
       match = true;
-    if ((mask & 0x010) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) && s0 != 0.0f &&
-        std::signbit(s0))
+    if ((mask & 0x010) && is_denorm && f16_sign)
       match = true;
-    if ((mask & 0x020) && s0 == 0.0f && std::signbit(s0))
+    if ((mask & 0x020) && is_zero && f16_sign)
       match = true;
-    if ((mask & 0x040) && s0 == 0.0f && !std::signbit(s0))
+    if ((mask & 0x040) && is_zero && !f16_sign)
       match = true;
-    if ((mask & 0x080) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) && s0 != 0.0f &&
-        !std::signbit(s0))
+    if ((mask & 0x080) && is_denorm && !f16_sign)
       match = true;
-    if ((mask & 0x100) && std::isnormal(s0) && s0 > 0)
+    if ((mask & 0x100) && is_normal && !f16_sign)
       match = true;
-    if ((mask & 0x200) && std::isinf(s0) && s0 > 0)
+    if ((mask & 0x200) && is_inf && !f16_sign)
       match = true;
     if (match)
       result |= (1ULL << lane);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/vopc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/vopc.cpp
@@ -780,31 +780,35 @@ void VCmpxClassF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     uint16_t s0_raw = static_cast<uint16_t>(src0.read_lane(wf, lane));
-    float s0 = util::f16_to_f32(s0_raw);
     uint32_t mask = vsrc1.read_lane(wf, lane);
     bool match = false;
-    bool is_f16_nan = ((s0_raw & 0x7C00) == 0x7C00) && ((s0_raw & 0x03FF) != 0);
-    if ((mask & 0x001) && is_f16_nan && (s0_raw & 0x0200) == 0)
+    uint16_t f16_exp = (s0_raw >> 10) & 0x1F;
+    uint16_t f16_mant = s0_raw & 0x3FF;
+    bool f16_sign = (s0_raw & 0x8000) != 0;
+    bool is_nan = (f16_exp == 0x1F) && (f16_mant != 0);
+    bool is_inf = (f16_exp == 0x1F) && (f16_mant == 0);
+    bool is_zero = (f16_exp == 0) && (f16_mant == 0);
+    bool is_denorm = (f16_exp == 0) && (f16_mant != 0);
+    bool is_normal = (f16_exp >= 1) && (f16_exp <= 30);
+    if ((mask & 0x001) && is_nan && (s0_raw & 0x0200) == 0)
       match = true;
-    if ((mask & 0x002) && is_f16_nan && (s0_raw & 0x0200) != 0)
+    if ((mask & 0x002) && is_nan && (s0_raw & 0x0200) != 0)
       match = true;
-    if ((mask & 0x004) && std::isinf(s0) && s0 < 0)
+    if ((mask & 0x004) && is_inf && f16_sign)
       match = true;
-    if ((mask & 0x008) && std::isnormal(s0) && s0 < 0)
+    if ((mask & 0x008) && is_normal && f16_sign)
       match = true;
-    if ((mask & 0x010) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) && s0 != 0.0f &&
-        std::signbit(s0))
+    if ((mask & 0x010) && is_denorm && f16_sign)
       match = true;
-    if ((mask & 0x020) && s0 == 0.0f && std::signbit(s0))
+    if ((mask & 0x020) && is_zero && f16_sign)
       match = true;
-    if ((mask & 0x040) && s0 == 0.0f && !std::signbit(s0))
+    if ((mask & 0x040) && is_zero && !f16_sign)
       match = true;
-    if ((mask & 0x080) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) && s0 != 0.0f &&
-        !std::signbit(s0))
+    if ((mask & 0x080) && is_denorm && !f16_sign)
       match = true;
-    if ((mask & 0x100) && std::isnormal(s0) && s0 > 0)
+    if ((mask & 0x100) && is_normal && !f16_sign)
       match = true;
-    if ((mask & 0x200) && std::isinf(s0) && s0 > 0)
+    if ((mask & 0x200) && is_inf && !f16_sign)
       match = true;
     if (match)
       result |= (1ULL << lane);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop2.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop2.cpp
@@ -4948,16 +4948,7 @@ void VMacF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     src0.set_delegate(dpp_src0_.get());
   if (dpp_src1_)
     vsrc1.set_delegate(dpp_src1_.get());
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    vdst.write_lane(wf, lane,
-                    util::f32_to_f16(std::fma(
-                        util::f16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane))),
-                        util::f16_to_f32(static_cast<uint16_t>(vsrc1.read_lane(wf, lane))),
-                        util::f16_to_f32(static_cast<uint16_t>(vdst.read_lane(wf, lane))))));
-  }
+  amdgpu::execute_v_mac_f16_vop2(*this, wf);
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3.cpp
@@ -5617,35 +5617,39 @@ void VCmpxClassF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     uint16_t s0_raw = static_cast<uint16_t>(src0.read_lane(wf, lane));
-    float s0 = util::f16_to_f32(s0_raw);
     if (inst_.abs & (1u << 0))
-      s0 = std::fabs(s0);
+      s0_raw &= 0x7FFFu;
     if (inst_.neg & (1u << 0))
-      s0 = -s0;
+      s0_raw ^= 0x8000u;
     uint32_t mask = src1.read_lane(wf, lane);
     bool match = false;
-    bool is_f16_nan = ((s0_raw & 0x7C00) == 0x7C00) && ((s0_raw & 0x03FF) != 0);
-    if ((mask & 0x001) && is_f16_nan && (s0_raw & 0x0200) == 0)
+    uint16_t f16_exp = (s0_raw >> 10) & 0x1F;
+    uint16_t f16_mant = s0_raw & 0x3FF;
+    bool f16_sign = (s0_raw & 0x8000) != 0;
+    bool is_nan = (f16_exp == 0x1F) && (f16_mant != 0);
+    bool is_inf = (f16_exp == 0x1F) && (f16_mant == 0);
+    bool is_zero = (f16_exp == 0) && (f16_mant == 0);
+    bool is_denorm = (f16_exp == 0) && (f16_mant != 0);
+    bool is_normal = (f16_exp >= 1) && (f16_exp <= 30);
+    if ((mask & 0x001) && is_nan && (s0_raw & 0x0200) == 0)
       match = true;
-    if ((mask & 0x002) && is_f16_nan && (s0_raw & 0x0200) != 0)
+    if ((mask & 0x002) && is_nan && (s0_raw & 0x0200) != 0)
       match = true;
-    if ((mask & 0x004) && std::isinf(s0) && s0 < 0)
+    if ((mask & 0x004) && is_inf && f16_sign)
       match = true;
-    if ((mask & 0x008) && std::isnormal(s0) && s0 < 0)
+    if ((mask & 0x008) && is_normal && f16_sign)
       match = true;
-    if ((mask & 0x010) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) && s0 != 0.0f &&
-        std::signbit(s0))
+    if ((mask & 0x010) && is_denorm && f16_sign)
       match = true;
-    if ((mask & 0x020) && s0 == 0.0f && std::signbit(s0))
+    if ((mask & 0x020) && is_zero && f16_sign)
       match = true;
-    if ((mask & 0x040) && s0 == 0.0f && !std::signbit(s0))
+    if ((mask & 0x040) && is_zero && !f16_sign)
       match = true;
-    if ((mask & 0x080) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) && s0 != 0.0f &&
-        !std::signbit(s0))
+    if ((mask & 0x080) && is_denorm && !f16_sign)
       match = true;
-    if ((mask & 0x100) && std::isnormal(s0) && s0 > 0)
+    if ((mask & 0x100) && is_normal && !f16_sign)
       match = true;
-    if ((mask & 0x200) && std::isinf(s0) && s0 > 0)
+    if ((mask & 0x200) && is_inf && !f16_sign)
       match = true;
     if (match)
       result |= (1ULL << lane);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3.cpp
@@ -2307,7 +2307,8 @@ void VMadI32I24Vop3::execute_impl(amdgpu::Wavefront &wf) {
     vdst.write_lane(wf, lane, [&]() {
       auto a = static_cast<int32_t>(src0.read_lane(wf, lane) << 8) >> 8;
       auto b = static_cast<int32_t>(src1.read_lane(wf, lane) << 8) >> 8;
-      return static_cast<uint32_t>(a * b + static_cast<int32_t>(src2.read_lane(wf, lane)));
+      return static_cast<uint32_t>(static_cast<int64_t>(a) * b +
+                                   static_cast<int32_t>(src2.read_lane(wf, lane)));
     }());
   }
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3p.cpp
@@ -995,12 +995,10 @@ VAccvgprReadVop3p::VAccvgprReadVop3p(const MachineInst *inst)
 }
 
 void VAccvgprReadVop3p::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    vdst.write_lane(wf, lane, src0.read_lane(wf, lane));
-  }
+  uint32_t n = wf.wf_size();
+  alignas(64) uint32_t buf[64];
+  src0.read_lane_chunk(wf, 0, n, buf);
+  vdst.write_lane_chunk(wf, 0, n, buf, wf.exec());
 }
 
 VAccvgprWriteVop3p::VAccvgprWriteVop3p(const MachineInst *inst)
@@ -1015,12 +1013,10 @@ VAccvgprWriteVop3p::VAccvgprWriteVop3p(const MachineInst *inst)
 }
 
 void VAccvgprWriteVop3p::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    vdst.write_lane(wf, lane, src0.read_lane(wf, lane));
-  }
+  uint32_t n = wf.wf_size();
+  alignas(64) uint32_t buf[64];
+  src0.read_lane_chunk(wf, 0, n, buf);
+  vdst.write_lane_chunk(wf, 0, n, buf, wf.exec());
 }
 
 VMfmaF3216x16x128F8f6f4Vop3pMfma::VMfmaF3216x16x128F8f6f4Vop3pMfma(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3p.cpp
@@ -54,8 +54,8 @@ void VPkMadI16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
     int16_t a_hi = static_cast<int16_t>(sel0_hi ? (raw0 >> 16) : raw0);
     int16_t b_hi = static_cast<int16_t>(sel1_hi ? (raw1 >> 16) : raw1);
     int16_t c_hi = static_cast<int16_t>(sel2_hi ? (raw2 >> 16) : raw2);
-    uint16_t rlo = static_cast<uint16_t>(a_lo * b_lo + c_lo);
-    uint16_t rhi = static_cast<uint16_t>(a_hi * b_hi + c_hi);
+    uint16_t rlo = static_cast<uint16_t>(static_cast<uint32_t>(a_lo) * b_lo + c_lo);
+    uint16_t rhi = static_cast<uint16_t>(static_cast<uint32_t>(a_hi) * b_hi + c_hi);
     vdst.write_lane(wf, lane, static_cast<uint32_t>(rlo) | (static_cast<uint32_t>(rhi) << 16));
   }
 }
@@ -88,8 +88,8 @@ void VPkMulLoU16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
     uint16_t b_lo = static_cast<uint16_t>(sel1_lo ? (raw1 >> 16) : raw1);
     uint16_t a_hi = static_cast<uint16_t>(sel0_hi ? (raw0 >> 16) : raw0);
     uint16_t b_hi = static_cast<uint16_t>(sel1_hi ? (raw1 >> 16) : raw1);
-    uint16_t rlo = static_cast<uint16_t>(a_lo * b_lo);
-    uint16_t rhi = static_cast<uint16_t>(a_hi * b_hi);
+    uint16_t rlo = static_cast<uint16_t>(static_cast<uint32_t>(a_lo) * b_lo);
+    uint16_t rhi = static_cast<uint16_t>(static_cast<uint32_t>(a_hi) * b_hi);
     vdst.write_lane(wf, lane, static_cast<uint32_t>(rlo) | (static_cast<uint32_t>(rhi) << 16));
   }
 }
@@ -282,8 +282,8 @@ void VPkMadU16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
     uint16_t a_hi = static_cast<uint16_t>(sel0_hi ? (raw0 >> 16) : raw0);
     uint16_t b_hi = static_cast<uint16_t>(sel1_hi ? (raw1 >> 16) : raw1);
     uint16_t c_hi = static_cast<uint16_t>(sel2_hi ? (raw2 >> 16) : raw2);
-    uint16_t rlo = static_cast<uint16_t>(a_lo * b_lo + c_lo);
-    uint16_t rhi = static_cast<uint16_t>(a_hi * b_hi + c_hi);
+    uint16_t rlo = static_cast<uint16_t>(static_cast<uint32_t>(a_lo) * b_lo + c_lo);
+    uint16_t rhi = static_cast<uint16_t>(static_cast<uint32_t>(a_hi) * b_hi + c_hi);
     vdst.write_lane(wf, lane, static_cast<uint32_t>(rlo) | (static_cast<uint32_t>(rhi) << 16));
   }
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vopc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vopc.cpp
@@ -780,31 +780,35 @@ void VCmpxClassF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     uint16_t s0_raw = static_cast<uint16_t>(src0.read_lane(wf, lane));
-    float s0 = util::f16_to_f32(s0_raw);
     uint32_t mask = vsrc1.read_lane(wf, lane);
     bool match = false;
-    bool is_f16_nan = ((s0_raw & 0x7C00) == 0x7C00) && ((s0_raw & 0x03FF) != 0);
-    if ((mask & 0x001) && is_f16_nan && (s0_raw & 0x0200) == 0)
+    uint16_t f16_exp = (s0_raw >> 10) & 0x1F;
+    uint16_t f16_mant = s0_raw & 0x3FF;
+    bool f16_sign = (s0_raw & 0x8000) != 0;
+    bool is_nan = (f16_exp == 0x1F) && (f16_mant != 0);
+    bool is_inf = (f16_exp == 0x1F) && (f16_mant == 0);
+    bool is_zero = (f16_exp == 0) && (f16_mant == 0);
+    bool is_denorm = (f16_exp == 0) && (f16_mant != 0);
+    bool is_normal = (f16_exp >= 1) && (f16_exp <= 30);
+    if ((mask & 0x001) && is_nan && (s0_raw & 0x0200) == 0)
       match = true;
-    if ((mask & 0x002) && is_f16_nan && (s0_raw & 0x0200) != 0)
+    if ((mask & 0x002) && is_nan && (s0_raw & 0x0200) != 0)
       match = true;
-    if ((mask & 0x004) && std::isinf(s0) && s0 < 0)
+    if ((mask & 0x004) && is_inf && f16_sign)
       match = true;
-    if ((mask & 0x008) && std::isnormal(s0) && s0 < 0)
+    if ((mask & 0x008) && is_normal && f16_sign)
       match = true;
-    if ((mask & 0x010) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) && s0 != 0.0f &&
-        std::signbit(s0))
+    if ((mask & 0x010) && is_denorm && f16_sign)
       match = true;
-    if ((mask & 0x020) && s0 == 0.0f && std::signbit(s0))
+    if ((mask & 0x020) && is_zero && f16_sign)
       match = true;
-    if ((mask & 0x040) && s0 == 0.0f && !std::signbit(s0))
+    if ((mask & 0x040) && is_zero && !f16_sign)
       match = true;
-    if ((mask & 0x080) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) && s0 != 0.0f &&
-        !std::signbit(s0))
+    if ((mask & 0x080) && is_denorm && !f16_sign)
       match = true;
-    if ((mask & 0x100) && std::isnormal(s0) && s0 > 0)
+    if ((mask & 0x100) && is_normal && !f16_sign)
       match = true;
-    if ((mask & 0x200) && std::isinf(s0) && s0 > 0)
+    if ((mask & 0x200) && is_inf && !f16_sign)
       match = true;
     if (match)
       result |= (1ULL << lane);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna1/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna1/vop3.cpp
@@ -8785,35 +8785,39 @@ void VCmpxClassF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     uint16_t s0_raw = static_cast<uint16_t>(src0.read_lane(wf, lane));
-    float s0 = util::f16_to_f32(s0_raw);
     if (inst_.abs & (1u << 0))
-      s0 = std::fabs(s0);
+      s0_raw &= 0x7FFFu;
     if (inst_.neg & (1u << 0))
-      s0 = -s0;
+      s0_raw ^= 0x8000u;
     uint32_t mask = src1.read_lane(wf, lane);
     bool match = false;
-    bool is_f16_nan = ((s0_raw & 0x7C00) == 0x7C00) && ((s0_raw & 0x03FF) != 0);
-    if ((mask & 0x001) && is_f16_nan && (s0_raw & 0x0200) == 0)
+    uint16_t f16_exp = (s0_raw >> 10) & 0x1F;
+    uint16_t f16_mant = s0_raw & 0x3FF;
+    bool f16_sign = (s0_raw & 0x8000) != 0;
+    bool is_nan = (f16_exp == 0x1F) && (f16_mant != 0);
+    bool is_inf = (f16_exp == 0x1F) && (f16_mant == 0);
+    bool is_zero = (f16_exp == 0) && (f16_mant == 0);
+    bool is_denorm = (f16_exp == 0) && (f16_mant != 0);
+    bool is_normal = (f16_exp >= 1) && (f16_exp <= 30);
+    if ((mask & 0x001) && is_nan && (s0_raw & 0x0200) == 0)
       match = true;
-    if ((mask & 0x002) && is_f16_nan && (s0_raw & 0x0200) != 0)
+    if ((mask & 0x002) && is_nan && (s0_raw & 0x0200) != 0)
       match = true;
-    if ((mask & 0x004) && std::isinf(s0) && s0 < 0)
+    if ((mask & 0x004) && is_inf && f16_sign)
       match = true;
-    if ((mask & 0x008) && std::isnormal(s0) && s0 < 0)
+    if ((mask & 0x008) && is_normal && f16_sign)
       match = true;
-    if ((mask & 0x010) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) && s0 != 0.0f &&
-        std::signbit(s0))
+    if ((mask & 0x010) && is_denorm && f16_sign)
       match = true;
-    if ((mask & 0x020) && s0 == 0.0f && std::signbit(s0))
+    if ((mask & 0x020) && is_zero && f16_sign)
       match = true;
-    if ((mask & 0x040) && s0 == 0.0f && !std::signbit(s0))
+    if ((mask & 0x040) && is_zero && !f16_sign)
       match = true;
-    if ((mask & 0x080) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) && s0 != 0.0f &&
-        !std::signbit(s0))
+    if ((mask & 0x080) && is_denorm && !f16_sign)
       match = true;
-    if ((mask & 0x100) && std::isnormal(s0) && s0 > 0)
+    if ((mask & 0x100) && is_normal && !f16_sign)
       match = true;
-    if ((mask & 0x200) && std::isinf(s0) && s0 > 0)
+    if ((mask & 0x200) && is_inf && !f16_sign)
       match = true;
     if (match)
       result |= (1ULL << lane);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna1/vopc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna1/vopc.cpp
@@ -11715,31 +11715,35 @@ void VCmpxClassF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     uint16_t s0_raw = static_cast<uint16_t>(src0.read_lane(wf, lane));
-    float s0 = util::f16_to_f32(s0_raw);
     uint32_t mask = vsrc1.read_lane(wf, lane);
     bool match = false;
-    bool is_f16_nan = ((s0_raw & 0x7C00) == 0x7C00) && ((s0_raw & 0x03FF) != 0);
-    if ((mask & 0x001) && is_f16_nan && (s0_raw & 0x0200) == 0)
+    uint16_t f16_exp = (s0_raw >> 10) & 0x1F;
+    uint16_t f16_mant = s0_raw & 0x3FF;
+    bool f16_sign = (s0_raw & 0x8000) != 0;
+    bool is_nan = (f16_exp == 0x1F) && (f16_mant != 0);
+    bool is_inf = (f16_exp == 0x1F) && (f16_mant == 0);
+    bool is_zero = (f16_exp == 0) && (f16_mant == 0);
+    bool is_denorm = (f16_exp == 0) && (f16_mant != 0);
+    bool is_normal = (f16_exp >= 1) && (f16_exp <= 30);
+    if ((mask & 0x001) && is_nan && (s0_raw & 0x0200) == 0)
       match = true;
-    if ((mask & 0x002) && is_f16_nan && (s0_raw & 0x0200) != 0)
+    if ((mask & 0x002) && is_nan && (s0_raw & 0x0200) != 0)
       match = true;
-    if ((mask & 0x004) && std::isinf(s0) && s0 < 0)
+    if ((mask & 0x004) && is_inf && f16_sign)
       match = true;
-    if ((mask & 0x008) && std::isnormal(s0) && s0 < 0)
+    if ((mask & 0x008) && is_normal && f16_sign)
       match = true;
-    if ((mask & 0x010) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) && s0 != 0.0f &&
-        std::signbit(s0))
+    if ((mask & 0x010) && is_denorm && f16_sign)
       match = true;
-    if ((mask & 0x020) && s0 == 0.0f && std::signbit(s0))
+    if ((mask & 0x020) && is_zero && f16_sign)
       match = true;
-    if ((mask & 0x040) && s0 == 0.0f && !std::signbit(s0))
+    if ((mask & 0x040) && is_zero && !f16_sign)
       match = true;
-    if ((mask & 0x080) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) && s0 != 0.0f &&
-        !std::signbit(s0))
+    if ((mask & 0x080) && is_denorm && !f16_sign)
       match = true;
-    if ((mask & 0x100) && std::isnormal(s0) && s0 > 0)
+    if ((mask & 0x100) && is_normal && !f16_sign)
       match = true;
-    if ((mask & 0x200) && std::isinf(s0) && s0 > 0)
+    if ((mask & 0x200) && is_inf && !f16_sign)
       match = true;
     if (match)
       result |= (1ULL << lane);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna2/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna2/vop3.cpp
@@ -8639,35 +8639,39 @@ void VCmpxClassF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     uint16_t s0_raw = static_cast<uint16_t>(src0.read_lane(wf, lane));
-    float s0 = util::f16_to_f32(s0_raw);
     if (inst_.abs & (1u << 0))
-      s0 = std::fabs(s0);
+      s0_raw &= 0x7FFFu;
     if (inst_.neg & (1u << 0))
-      s0 = -s0;
+      s0_raw ^= 0x8000u;
     uint32_t mask = src1.read_lane(wf, lane);
     bool match = false;
-    bool is_f16_nan = ((s0_raw & 0x7C00) == 0x7C00) && ((s0_raw & 0x03FF) != 0);
-    if ((mask & 0x001) && is_f16_nan && (s0_raw & 0x0200) == 0)
+    uint16_t f16_exp = (s0_raw >> 10) & 0x1F;
+    uint16_t f16_mant = s0_raw & 0x3FF;
+    bool f16_sign = (s0_raw & 0x8000) != 0;
+    bool is_nan = (f16_exp == 0x1F) && (f16_mant != 0);
+    bool is_inf = (f16_exp == 0x1F) && (f16_mant == 0);
+    bool is_zero = (f16_exp == 0) && (f16_mant == 0);
+    bool is_denorm = (f16_exp == 0) && (f16_mant != 0);
+    bool is_normal = (f16_exp >= 1) && (f16_exp <= 30);
+    if ((mask & 0x001) && is_nan && (s0_raw & 0x0200) == 0)
       match = true;
-    if ((mask & 0x002) && is_f16_nan && (s0_raw & 0x0200) != 0)
+    if ((mask & 0x002) && is_nan && (s0_raw & 0x0200) != 0)
       match = true;
-    if ((mask & 0x004) && std::isinf(s0) && s0 < 0)
+    if ((mask & 0x004) && is_inf && f16_sign)
       match = true;
-    if ((mask & 0x008) && std::isnormal(s0) && s0 < 0)
+    if ((mask & 0x008) && is_normal && f16_sign)
       match = true;
-    if ((mask & 0x010) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) && s0 != 0.0f &&
-        std::signbit(s0))
+    if ((mask & 0x010) && is_denorm && f16_sign)
       match = true;
-    if ((mask & 0x020) && s0 == 0.0f && std::signbit(s0))
+    if ((mask & 0x020) && is_zero && f16_sign)
       match = true;
-    if ((mask & 0x040) && s0 == 0.0f && !std::signbit(s0))
+    if ((mask & 0x040) && is_zero && !f16_sign)
       match = true;
-    if ((mask & 0x080) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) && s0 != 0.0f &&
-        !std::signbit(s0))
+    if ((mask & 0x080) && is_denorm && !f16_sign)
       match = true;
-    if ((mask & 0x100) && std::isnormal(s0) && s0 > 0)
+    if ((mask & 0x100) && is_normal && !f16_sign)
       match = true;
-    if ((mask & 0x200) && std::isinf(s0) && s0 > 0)
+    if ((mask & 0x200) && is_inf && !f16_sign)
       match = true;
     if (match)
       result |= (1ULL << lane);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna2/vopc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna2/vopc.cpp
@@ -11715,31 +11715,35 @@ void VCmpxClassF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     uint16_t s0_raw = static_cast<uint16_t>(src0.read_lane(wf, lane));
-    float s0 = util::f16_to_f32(s0_raw);
     uint32_t mask = vsrc1.read_lane(wf, lane);
     bool match = false;
-    bool is_f16_nan = ((s0_raw & 0x7C00) == 0x7C00) && ((s0_raw & 0x03FF) != 0);
-    if ((mask & 0x001) && is_f16_nan && (s0_raw & 0x0200) == 0)
+    uint16_t f16_exp = (s0_raw >> 10) & 0x1F;
+    uint16_t f16_mant = s0_raw & 0x3FF;
+    bool f16_sign = (s0_raw & 0x8000) != 0;
+    bool is_nan = (f16_exp == 0x1F) && (f16_mant != 0);
+    bool is_inf = (f16_exp == 0x1F) && (f16_mant == 0);
+    bool is_zero = (f16_exp == 0) && (f16_mant == 0);
+    bool is_denorm = (f16_exp == 0) && (f16_mant != 0);
+    bool is_normal = (f16_exp >= 1) && (f16_exp <= 30);
+    if ((mask & 0x001) && is_nan && (s0_raw & 0x0200) == 0)
       match = true;
-    if ((mask & 0x002) && is_f16_nan && (s0_raw & 0x0200) != 0)
+    if ((mask & 0x002) && is_nan && (s0_raw & 0x0200) != 0)
       match = true;
-    if ((mask & 0x004) && std::isinf(s0) && s0 < 0)
+    if ((mask & 0x004) && is_inf && f16_sign)
       match = true;
-    if ((mask & 0x008) && std::isnormal(s0) && s0 < 0)
+    if ((mask & 0x008) && is_normal && f16_sign)
       match = true;
-    if ((mask & 0x010) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) && s0 != 0.0f &&
-        std::signbit(s0))
+    if ((mask & 0x010) && is_denorm && f16_sign)
       match = true;
-    if ((mask & 0x020) && s0 == 0.0f && std::signbit(s0))
+    if ((mask & 0x020) && is_zero && f16_sign)
       match = true;
-    if ((mask & 0x040) && s0 == 0.0f && !std::signbit(s0))
+    if ((mask & 0x040) && is_zero && !f16_sign)
       match = true;
-    if ((mask & 0x080) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) && s0 != 0.0f &&
-        !std::signbit(s0))
+    if ((mask & 0x080) && is_denorm && !f16_sign)
       match = true;
-    if ((mask & 0x100) && std::isnormal(s0) && s0 > 0)
+    if ((mask & 0x100) && is_normal && !f16_sign)
       match = true;
-    if ((mask & 0x200) && std::isinf(s0) && s0 > 0)
+    if ((mask & 0x200) && is_inf && !f16_sign)
       match = true;
     if (match)
       result |= (1ULL << lane);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/vop3.cpp
@@ -11710,35 +11710,39 @@ void VCmpxClassF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     uint16_t s0_raw = static_cast<uint16_t>(src0.read_lane(wf, lane));
-    float s0 = util::f16_to_f32(s0_raw);
     if (inst_.abs & (1u << 0))
-      s0 = std::fabs(s0);
+      s0_raw &= 0x7FFFu;
     if (inst_.neg & (1u << 0))
-      s0 = -s0;
+      s0_raw ^= 0x8000u;
     uint32_t mask = src1.read_lane(wf, lane);
     bool match = false;
-    bool is_f16_nan = ((s0_raw & 0x7C00) == 0x7C00) && ((s0_raw & 0x03FF) != 0);
-    if ((mask & 0x001) && is_f16_nan && (s0_raw & 0x0200) == 0)
+    uint16_t f16_exp = (s0_raw >> 10) & 0x1F;
+    uint16_t f16_mant = s0_raw & 0x3FF;
+    bool f16_sign = (s0_raw & 0x8000) != 0;
+    bool is_nan = (f16_exp == 0x1F) && (f16_mant != 0);
+    bool is_inf = (f16_exp == 0x1F) && (f16_mant == 0);
+    bool is_zero = (f16_exp == 0) && (f16_mant == 0);
+    bool is_denorm = (f16_exp == 0) && (f16_mant != 0);
+    bool is_normal = (f16_exp >= 1) && (f16_exp <= 30);
+    if ((mask & 0x001) && is_nan && (s0_raw & 0x0200) == 0)
       match = true;
-    if ((mask & 0x002) && is_f16_nan && (s0_raw & 0x0200) != 0)
+    if ((mask & 0x002) && is_nan && (s0_raw & 0x0200) != 0)
       match = true;
-    if ((mask & 0x004) && std::isinf(s0) && s0 < 0)
+    if ((mask & 0x004) && is_inf && f16_sign)
       match = true;
-    if ((mask & 0x008) && std::isnormal(s0) && s0 < 0)
+    if ((mask & 0x008) && is_normal && f16_sign)
       match = true;
-    if ((mask & 0x010) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) && s0 != 0.0f &&
-        std::signbit(s0))
+    if ((mask & 0x010) && is_denorm && f16_sign)
       match = true;
-    if ((mask & 0x020) && s0 == 0.0f && std::signbit(s0))
+    if ((mask & 0x020) && is_zero && f16_sign)
       match = true;
-    if ((mask & 0x040) && s0 == 0.0f && !std::signbit(s0))
+    if ((mask & 0x040) && is_zero && !f16_sign)
       match = true;
-    if ((mask & 0x080) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) && s0 != 0.0f &&
-        !std::signbit(s0))
+    if ((mask & 0x080) && is_denorm && !f16_sign)
       match = true;
-    if ((mask & 0x100) && std::isnormal(s0) && s0 > 0)
+    if ((mask & 0x100) && is_normal && !f16_sign)
       match = true;
-    if ((mask & 0x200) && std::isinf(s0) && s0 > 0)
+    if ((mask & 0x200) && is_inf && !f16_sign)
       match = true;
     if (match)
       result |= (1ULL << lane);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/vopc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/vopc.cpp
@@ -19874,31 +19874,35 @@ void VCmpxClassF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     uint16_t s0_raw = static_cast<uint16_t>(src0.read_lane(wf, lane));
-    float s0 = util::f16_to_f32(s0_raw);
     uint32_t mask = vsrc1.read_lane(wf, lane);
     bool match = false;
-    bool is_f16_nan = ((s0_raw & 0x7C00) == 0x7C00) && ((s0_raw & 0x03FF) != 0);
-    if ((mask & 0x001) && is_f16_nan && (s0_raw & 0x0200) == 0)
+    uint16_t f16_exp = (s0_raw >> 10) & 0x1F;
+    uint16_t f16_mant = s0_raw & 0x3FF;
+    bool f16_sign = (s0_raw & 0x8000) != 0;
+    bool is_nan = (f16_exp == 0x1F) && (f16_mant != 0);
+    bool is_inf = (f16_exp == 0x1F) && (f16_mant == 0);
+    bool is_zero = (f16_exp == 0) && (f16_mant == 0);
+    bool is_denorm = (f16_exp == 0) && (f16_mant != 0);
+    bool is_normal = (f16_exp >= 1) && (f16_exp <= 30);
+    if ((mask & 0x001) && is_nan && (s0_raw & 0x0200) == 0)
       match = true;
-    if ((mask & 0x002) && is_f16_nan && (s0_raw & 0x0200) != 0)
+    if ((mask & 0x002) && is_nan && (s0_raw & 0x0200) != 0)
       match = true;
-    if ((mask & 0x004) && std::isinf(s0) && s0 < 0)
+    if ((mask & 0x004) && is_inf && f16_sign)
       match = true;
-    if ((mask & 0x008) && std::isnormal(s0) && s0 < 0)
+    if ((mask & 0x008) && is_normal && f16_sign)
       match = true;
-    if ((mask & 0x010) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) && s0 != 0.0f &&
-        std::signbit(s0))
+    if ((mask & 0x010) && is_denorm && f16_sign)
       match = true;
-    if ((mask & 0x020) && s0 == 0.0f && std::signbit(s0))
+    if ((mask & 0x020) && is_zero && f16_sign)
       match = true;
-    if ((mask & 0x040) && s0 == 0.0f && !std::signbit(s0))
+    if ((mask & 0x040) && is_zero && !f16_sign)
       match = true;
-    if ((mask & 0x080) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) && s0 != 0.0f &&
-        !std::signbit(s0))
+    if ((mask & 0x080) && is_denorm && !f16_sign)
       match = true;
-    if ((mask & 0x100) && std::isnormal(s0) && s0 > 0)
+    if ((mask & 0x100) && is_normal && !f16_sign)
       match = true;
-    if ((mask & 0x200) && std::isinf(s0) && s0 > 0)
+    if ((mask & 0x200) && is_inf && !f16_sign)
       match = true;
     if (match)
       result |= (1ULL << lane);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/vop3.cpp
@@ -11710,35 +11710,39 @@ void VCmpxClassF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     uint16_t s0_raw = static_cast<uint16_t>(src0.read_lane(wf, lane));
-    float s0 = util::f16_to_f32(s0_raw);
     if (inst_.abs & (1u << 0))
-      s0 = std::fabs(s0);
+      s0_raw &= 0x7FFFu;
     if (inst_.neg & (1u << 0))
-      s0 = -s0;
+      s0_raw ^= 0x8000u;
     uint32_t mask = src1.read_lane(wf, lane);
     bool match = false;
-    bool is_f16_nan = ((s0_raw & 0x7C00) == 0x7C00) && ((s0_raw & 0x03FF) != 0);
-    if ((mask & 0x001) && is_f16_nan && (s0_raw & 0x0200) == 0)
+    uint16_t f16_exp = (s0_raw >> 10) & 0x1F;
+    uint16_t f16_mant = s0_raw & 0x3FF;
+    bool f16_sign = (s0_raw & 0x8000) != 0;
+    bool is_nan = (f16_exp == 0x1F) && (f16_mant != 0);
+    bool is_inf = (f16_exp == 0x1F) && (f16_mant == 0);
+    bool is_zero = (f16_exp == 0) && (f16_mant == 0);
+    bool is_denorm = (f16_exp == 0) && (f16_mant != 0);
+    bool is_normal = (f16_exp >= 1) && (f16_exp <= 30);
+    if ((mask & 0x001) && is_nan && (s0_raw & 0x0200) == 0)
       match = true;
-    if ((mask & 0x002) && is_f16_nan && (s0_raw & 0x0200) != 0)
+    if ((mask & 0x002) && is_nan && (s0_raw & 0x0200) != 0)
       match = true;
-    if ((mask & 0x004) && std::isinf(s0) && s0 < 0)
+    if ((mask & 0x004) && is_inf && f16_sign)
       match = true;
-    if ((mask & 0x008) && std::isnormal(s0) && s0 < 0)
+    if ((mask & 0x008) && is_normal && f16_sign)
       match = true;
-    if ((mask & 0x010) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) && s0 != 0.0f &&
-        std::signbit(s0))
+    if ((mask & 0x010) && is_denorm && f16_sign)
       match = true;
-    if ((mask & 0x020) && s0 == 0.0f && std::signbit(s0))
+    if ((mask & 0x020) && is_zero && f16_sign)
       match = true;
-    if ((mask & 0x040) && s0 == 0.0f && !std::signbit(s0))
+    if ((mask & 0x040) && is_zero && !f16_sign)
       match = true;
-    if ((mask & 0x080) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) && s0 != 0.0f &&
-        !std::signbit(s0))
+    if ((mask & 0x080) && is_denorm && !f16_sign)
       match = true;
-    if ((mask & 0x100) && std::isnormal(s0) && s0 > 0)
+    if ((mask & 0x100) && is_normal && !f16_sign)
       match = true;
-    if ((mask & 0x200) && std::isinf(s0) && s0 > 0)
+    if ((mask & 0x200) && is_inf && !f16_sign)
       match = true;
     if (match)
       result |= (1ULL << lane);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/vopc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/vopc.cpp
@@ -19874,31 +19874,35 @@ void VCmpxClassF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     uint16_t s0_raw = static_cast<uint16_t>(src0.read_lane(wf, lane));
-    float s0 = util::f16_to_f32(s0_raw);
     uint32_t mask = vsrc1.read_lane(wf, lane);
     bool match = false;
-    bool is_f16_nan = ((s0_raw & 0x7C00) == 0x7C00) && ((s0_raw & 0x03FF) != 0);
-    if ((mask & 0x001) && is_f16_nan && (s0_raw & 0x0200) == 0)
+    uint16_t f16_exp = (s0_raw >> 10) & 0x1F;
+    uint16_t f16_mant = s0_raw & 0x3FF;
+    bool f16_sign = (s0_raw & 0x8000) != 0;
+    bool is_nan = (f16_exp == 0x1F) && (f16_mant != 0);
+    bool is_inf = (f16_exp == 0x1F) && (f16_mant == 0);
+    bool is_zero = (f16_exp == 0) && (f16_mant == 0);
+    bool is_denorm = (f16_exp == 0) && (f16_mant != 0);
+    bool is_normal = (f16_exp >= 1) && (f16_exp <= 30);
+    if ((mask & 0x001) && is_nan && (s0_raw & 0x0200) == 0)
       match = true;
-    if ((mask & 0x002) && is_f16_nan && (s0_raw & 0x0200) != 0)
+    if ((mask & 0x002) && is_nan && (s0_raw & 0x0200) != 0)
       match = true;
-    if ((mask & 0x004) && std::isinf(s0) && s0 < 0)
+    if ((mask & 0x004) && is_inf && f16_sign)
       match = true;
-    if ((mask & 0x008) && std::isnormal(s0) && s0 < 0)
+    if ((mask & 0x008) && is_normal && f16_sign)
       match = true;
-    if ((mask & 0x010) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) && s0 != 0.0f &&
-        std::signbit(s0))
+    if ((mask & 0x010) && is_denorm && f16_sign)
       match = true;
-    if ((mask & 0x020) && s0 == 0.0f && std::signbit(s0))
+    if ((mask & 0x020) && is_zero && f16_sign)
       match = true;
-    if ((mask & 0x040) && s0 == 0.0f && !std::signbit(s0))
+    if ((mask & 0x040) && is_zero && !f16_sign)
       match = true;
-    if ((mask & 0x080) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) && s0 != 0.0f &&
-        !std::signbit(s0))
+    if ((mask & 0x080) && is_denorm && !f16_sign)
       match = true;
-    if ((mask & 0x100) && std::isnormal(s0) && s0 > 0)
+    if ((mask & 0x100) && is_normal && !f16_sign)
       match = true;
-    if ((mask & 0x200) && std::isinf(s0) && s0 > 0)
+    if ((mask & 0x200) && is_inf && !f16_sign)
       match = true;
     if (match)
       result |= (1ULL << lane);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/vopc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/vopc.cpp
@@ -16948,31 +16948,35 @@ void VCmpxClassF16Vopc::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     uint16_t s0_raw = static_cast<uint16_t>(src0.read_lane(wf, lane));
-    float s0 = util::f16_to_f32(s0_raw);
     uint32_t mask = vsrc1.read_lane(wf, lane);
     bool match = false;
-    bool is_f16_nan = ((s0_raw & 0x7C00) == 0x7C00) && ((s0_raw & 0x03FF) != 0);
-    if ((mask & 0x001) && is_f16_nan && (s0_raw & 0x0200) == 0)
+    uint16_t f16_exp = (s0_raw >> 10) & 0x1F;
+    uint16_t f16_mant = s0_raw & 0x3FF;
+    bool f16_sign = (s0_raw & 0x8000) != 0;
+    bool is_nan = (f16_exp == 0x1F) && (f16_mant != 0);
+    bool is_inf = (f16_exp == 0x1F) && (f16_mant == 0);
+    bool is_zero = (f16_exp == 0) && (f16_mant == 0);
+    bool is_denorm = (f16_exp == 0) && (f16_mant != 0);
+    bool is_normal = (f16_exp >= 1) && (f16_exp <= 30);
+    if ((mask & 0x001) && is_nan && (s0_raw & 0x0200) == 0)
       match = true;
-    if ((mask & 0x002) && is_f16_nan && (s0_raw & 0x0200) != 0)
+    if ((mask & 0x002) && is_nan && (s0_raw & 0x0200) != 0)
       match = true;
-    if ((mask & 0x004) && std::isinf(s0) && s0 < 0)
+    if ((mask & 0x004) && is_inf && f16_sign)
       match = true;
-    if ((mask & 0x008) && std::isnormal(s0) && s0 < 0)
+    if ((mask & 0x008) && is_normal && f16_sign)
       match = true;
-    if ((mask & 0x010) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) && s0 != 0.0f &&
-        std::signbit(s0))
+    if ((mask & 0x010) && is_denorm && f16_sign)
       match = true;
-    if ((mask & 0x020) && s0 == 0.0f && std::signbit(s0))
+    if ((mask & 0x020) && is_zero && f16_sign)
       match = true;
-    if ((mask & 0x040) && s0 == 0.0f && !std::signbit(s0))
+    if ((mask & 0x040) && is_zero && !f16_sign)
       match = true;
-    if ((mask & 0x080) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) && s0 != 0.0f &&
-        !std::signbit(s0))
+    if ((mask & 0x080) && is_denorm && !f16_sign)
       match = true;
-    if ((mask & 0x100) && std::isnormal(s0) && s0 > 0)
+    if ((mask & 0x100) && is_normal && !f16_sign)
       match = true;
-    if ((mask & 0x200) && std::isinf(s0) && s0 > 0)
+    if ((mask & 0x200) && is_inf && !f16_sign)
       match = true;
     if (match)
       result |= (1ULL << lane);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
@@ -9451,10 +9451,10 @@ inline void execute_v_div_fixup_f16_vop3([[maybe_unused]] Inst &inst,
     if (inst.inst_.neg & (1u << 2))
       c = -c;
     float result;
-    if (std::isnan(b))
-      result = b;
-    else if (std::isnan(c))
+    if (std::isnan(c))
       result = c;
+    else if (std::isnan(b))
+      result = b;
     else if (c == 0.0f && b == 0.0f)
       result = std::numeric_limits<float>::quiet_NaN();
     else if (std::isinf(c) && std::isinf(b))
@@ -9510,10 +9510,10 @@ inline void execute_v_div_fixup_f32_vop3([[maybe_unused]] Inst &inst,
     if (inst.inst_.neg & (1u << 2))
       c = -c;
     float result;
-    if (std::isnan(b))
-      result = b;
-    else if (std::isnan(c))
+    if (std::isnan(c))
       result = c;
+    else if (std::isnan(b))
+      result = b;
     else if (c == 0.0f && b == 0.0f)
       result = std::numeric_limits<float>::quiet_NaN();
     else if (std::isinf(c) && std::isinf(b))
@@ -9569,10 +9569,10 @@ inline void execute_v_div_fixup_f64_vop3([[maybe_unused]] Inst &inst,
     if (inst.inst_.neg & (1u << 2))
       c = -c;
     double result;
-    if (std::isnan(b))
-      result = b;
-    else if (std::isnan(c))
+    if (std::isnan(c))
       result = c;
+    else if (std::isnan(b))
+      result = b;
     else if (c == 0.0 && b == 0.0)
       result = std::numeric_limits<double>::quiet_NaN();
     else if (std::isinf(c) && std::isinf(b))
@@ -9628,10 +9628,10 @@ inline void execute_v_div_fixup_legacy_f16_vop3([[maybe_unused]] Inst &inst,
     if (inst.inst_.neg & (1u << 2))
       c = -c;
     float result;
-    if (std::isnan(b))
-      result = b;
-    else if (std::isnan(c))
+    if (std::isnan(c))
       result = c;
+    else if (std::isnan(b))
+      result = b;
     else if (c == 0.0f && b == 0.0f)
       result = std::numeric_limits<float>::quiet_NaN();
     else if (std::isinf(c) && std::isinf(b))

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
@@ -3287,9 +3287,9 @@ inline void execute_v_bfe_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]]
       uint32_t w = static_cast<int32_t>(inst.src2.read_lane(wf, lane)) & 31u;
       if (w == 0)
         return 0u;
-      int32_t val = (src >> off) & ((1 << w) - 1);
-      if (val & (1 << (w - 1)))
-        val |= -(1 << w);
+      int32_t val = (src >> off) & static_cast<int32_t>((1u << w) - 1u);
+      if (val & static_cast<int32_t>(1u << (w - 1)))
+        val |= static_cast<int32_t>(0xFFFFFFFFu << w);
       return static_cast<uint32_t>(val);
     }());
   }
@@ -3573,37 +3573,40 @@ inline void execute_v_cmp_class_f16_vop3([[maybe_unused]] Inst &inst,
     if (!(exec & (1ULL << lane)))
       continue;
     if ([&]() -> bool {
-          float s0 = [&]() {
-            float sv = util::f16_to_f32(static_cast<uint16_t>(inst.src0.read_lane(wf, lane)));
-            if (inst.inst_.abs & (1u << 0))
-              sv = std::fabs(sv);
-            if (inst.inst_.neg & (1u << 0))
-              sv = -sv;
-            return sv;
-          }();
+          uint16_t s0_raw = static_cast<uint16_t>(inst.src0.read_lane(wf, lane));
+          if (inst.inst_.abs & (1u << 0))
+            s0_raw &= 0x7FFFu;
+          if (inst.inst_.neg & (1u << 0))
+            s0_raw ^= 0x8000u;
           uint32_t mask = static_cast<uint32_t>(inst.src1.read_lane(wf, lane));
           bool match = false;
-          if ((mask & 0x001u) && std::isnan(s0) && (std::bit_cast<uint32_t>(s0) & 0x00400000u) == 0)
+          uint16_t f16_exp = (s0_raw >> 10) & 0x1F;
+          uint16_t f16_mant = s0_raw & 0x3FF;
+          bool f16_sign = (s0_raw & 0x8000) != 0;
+          bool is_nan = (f16_exp == 0x1F) && (f16_mant != 0);
+          bool is_inf = (f16_exp == 0x1F) && (f16_mant == 0);
+          bool is_zero = (f16_exp == 0) && (f16_mant == 0);
+          bool is_denorm = (f16_exp == 0) && (f16_mant != 0);
+          bool is_normal = (f16_exp >= 1) && (f16_exp <= 30);
+          if ((mask & 0x001u) && is_nan && (s0_raw & 0x0200u) == 0)
             match = true;
-          if ((mask & 0x002u) && std::isnan(s0) && (std::bit_cast<uint32_t>(s0) & 0x00400000u) != 0)
+          if ((mask & 0x002u) && is_nan && (s0_raw & 0x0200u) != 0)
             match = true;
-          if ((mask & 0x004u) && std::isinf(s0) && s0 < 0)
+          if ((mask & 0x004u) && is_inf && f16_sign)
             match = true;
-          if ((mask & 0x008u) && std::isnormal(s0) && s0 < 0)
+          if ((mask & 0x008u) && is_normal && f16_sign)
             match = true;
-          if ((mask & 0x010u) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) &&
-              s0 != 0.0f && std::signbit(s0))
+          if ((mask & 0x010u) && is_denorm && f16_sign)
             match = true;
-          if ((mask & 0x020u) && s0 == 0.0f && std::signbit(s0))
+          if ((mask & 0x020u) && is_zero && f16_sign)
             match = true;
-          if ((mask & 0x040u) && s0 == 0.0f && !std::signbit(s0))
+          if ((mask & 0x040u) && is_zero && !f16_sign)
             match = true;
-          if ((mask & 0x080u) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) &&
-              s0 != 0.0f && !std::signbit(s0))
+          if ((mask & 0x080u) && is_denorm && !f16_sign)
             match = true;
-          if ((mask & 0x100u) && std::isnormal(s0) && s0 > 0)
+          if ((mask & 0x100u) && is_normal && !f16_sign)
             match = true;
-          if ((mask & 0x200u) && std::isinf(s0) && s0 > 0)
+          if ((mask & 0x200u) && is_inf && !f16_sign)
             match = true;
           return match;
         }())
@@ -3623,30 +3626,36 @@ inline void execute_v_cmp_class_f16_vopc([[maybe_unused]] Inst &inst,
     if (!(exec & (1ULL << lane)))
       continue;
     if ([&]() -> bool {
-          float s0 = util::f16_to_f32(static_cast<uint16_t>(inst.src0.read_lane(wf, lane)));
+          uint16_t s0_raw = static_cast<uint16_t>(inst.src0.read_lane(wf, lane));
           uint32_t mask = static_cast<uint32_t>(inst.vsrc1.read_lane(wf, lane));
           bool match = false;
-          if ((mask & 0x001u) && std::isnan(s0) && (std::bit_cast<uint32_t>(s0) & 0x00400000u) == 0)
+          uint16_t f16_exp = (s0_raw >> 10) & 0x1F;
+          uint16_t f16_mant = s0_raw & 0x3FF;
+          bool f16_sign = (s0_raw & 0x8000) != 0;
+          bool is_nan = (f16_exp == 0x1F) && (f16_mant != 0);
+          bool is_inf = (f16_exp == 0x1F) && (f16_mant == 0);
+          bool is_zero = (f16_exp == 0) && (f16_mant == 0);
+          bool is_denorm = (f16_exp == 0) && (f16_mant != 0);
+          bool is_normal = (f16_exp >= 1) && (f16_exp <= 30);
+          if ((mask & 0x001u) && is_nan && (s0_raw & 0x0200u) == 0)
             match = true;
-          if ((mask & 0x002u) && std::isnan(s0) && (std::bit_cast<uint32_t>(s0) & 0x00400000u) != 0)
+          if ((mask & 0x002u) && is_nan && (s0_raw & 0x0200u) != 0)
             match = true;
-          if ((mask & 0x004u) && std::isinf(s0) && s0 < 0)
+          if ((mask & 0x004u) && is_inf && f16_sign)
             match = true;
-          if ((mask & 0x008u) && std::isnormal(s0) && s0 < 0)
+          if ((mask & 0x008u) && is_normal && f16_sign)
             match = true;
-          if ((mask & 0x010u) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) &&
-              s0 != 0.0f && std::signbit(s0))
+          if ((mask & 0x010u) && is_denorm && f16_sign)
             match = true;
-          if ((mask & 0x020u) && s0 == 0.0f && std::signbit(s0))
+          if ((mask & 0x020u) && is_zero && f16_sign)
             match = true;
-          if ((mask & 0x040u) && s0 == 0.0f && !std::signbit(s0))
+          if ((mask & 0x040u) && is_zero && !f16_sign)
             match = true;
-          if ((mask & 0x080u) && !std::isnormal(s0) && !std::isinf(s0) && !std::isnan(s0) &&
-              s0 != 0.0f && !std::signbit(s0))
+          if ((mask & 0x080u) && is_denorm && !f16_sign)
             match = true;
-          if ((mask & 0x100u) && std::isnormal(s0) && s0 > 0)
+          if ((mask & 0x100u) && is_normal && !f16_sign)
             match = true;
-          if ((mask & 0x200u) && std::isinf(s0) && s0 > 0)
+          if ((mask & 0x200u) && is_inf && !f16_sign)
             match = true;
           return match;
         }())
@@ -15609,7 +15618,13 @@ inline void execute_v_mov_b32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]]
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(wf, lane, inst.src0.read_lane(wf, lane));
+    // VOP3 v_mov_b32 applies the f32 abs/neg input modifiers to src0.
+    uint32_t v = inst.src0.read_lane(wf, lane);
+    if (inst.inst_.abs & (1u << 0))
+      v &= 0x7FFFFFFFu;
+    if (inst.inst_.neg & (1u << 0))
+      v ^= 0x80000000u;
+    inst.vdst.write_lane(wf, lane, v);
   }
 }
 
@@ -15973,7 +15988,7 @@ inline void execute_v_mul_i32_i24_vop2([[maybe_unused]] Inst &inst,
     inst.vdst.write_lane(wf, lane, [&]() {
       auto a = static_cast<int32_t>(inst.src0.read_lane(wf, lane) << 8) >> 8;
       auto b = static_cast<int32_t>(inst.vsrc1.read_lane(wf, lane) << 8) >> 8;
-      return static_cast<uint32_t>(a * b);
+      return static_cast<uint32_t>(static_cast<int64_t>(a) * b);
     }());
   }
 }
@@ -15988,7 +16003,7 @@ inline void execute_v_mul_i32_i24_vop3([[maybe_unused]] Inst &inst,
     inst.vdst.write_lane(wf, lane, [&]() {
       auto a = static_cast<int32_t>(inst.src0.read_lane(wf, lane) << 8) >> 8;
       auto b = static_cast<int32_t>(inst.src1.read_lane(wf, lane) << 8) >> 8;
-      return static_cast<uint32_t>(a * b);
+      return static_cast<uint32_t>(static_cast<int64_t>(a) * b);
     }());
   }
 }
@@ -16059,9 +16074,9 @@ inline void execute_v_mul_lo_u16_vop2([[maybe_unused]] Inst &inst, [[maybe_unuse
       continue;
     inst.vdst.write_lane(
         wf, lane,
-        static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
-            static_cast<uint16_t>(static_cast<uint16_t>(inst.src0.read_lane(wf, lane))) *
-            static_cast<uint16_t>(static_cast<uint16_t>(inst.vsrc1.read_lane(wf, lane))))))));
+        static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(
+            static_cast<uint32_t>(static_cast<uint16_t>(inst.src0.read_lane(wf, lane))) *
+            static_cast<uint32_t>(static_cast<uint16_t>(inst.vsrc1.read_lane(wf, lane)))))));
   }
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
@@ -16,6 +16,7 @@
 
 #include "rocjitsu/isa/operand.h"
 #include "rocjitsu/vm/amdgpu/wavefront.h"
+#include "simdojo/components/vector_reg.h"
 #include "util/simd.h"
 
 #include <cstddef>
@@ -28,9 +29,146 @@ namespace amdgpu {
 /// in <stdfloat>; rocjitsu is on C++20 so a local alias.
 using float32_t = float;
 
-/// Per-thread runtime override that disables the SIMD fast path in
-/// kernels that have one. Forwards to util::force_scalar().
-inline bool &simd_force_scalar() { return util::force_scalar(); }
+/// Process-wide, immutable override that disables the SIMD fast path in
+/// kernels that have one. Forwards to util::force_scalar() (read once from
+/// RJ_FORCE_SCALAR); returned by value, so there is no mutable global to
+/// flip at runtime.
+inline bool simd_force_scalar() { return util::force_scalar(); }
+
+/// In-vector VOP3 source modifier (f32), bit-exact with the scalar lambda the
+/// generated bodies emit per source: `abs` first (`std::fabs`), then `neg`
+/// (`-x`). `abs`/`neg` are the raw VOP3 modifier fields; the bit for source
+/// index `SrcIdx` selects whether the modifier applies. std::fabs clears the
+/// sign bit and unary minus flips it (both NaN-payload preserving), so the
+/// vector form is a pure sign-bit AND/XOR — bit-identical on every input.
+template <unsigned SrcIdx>
+inline util::native<float> apply_vop3_src_mod_f32(util::native<float> v, uint32_t abs,
+                                                  uint32_t neg) {
+  using U = util::native<uint32_t>;
+  U b = std::bit_cast<U>(v);
+  if (abs & (1u << SrcIdx))
+    b = b & 0x7FFFFFFFu;
+  if (neg & (1u << SrcIdx))
+    b = b ^ 0x80000000u;
+  return std::bit_cast<util::native<float>>(b);
+}
+
+/// In-vector VOP3 source modifier (f64), the f64 counterpart of
+/// apply_vop3_src_mod_f32: abs first (std::fabs = sign-bit clear), then neg
+/// (unary minus = sign-bit flip). Both are sign-bit-only on IEEE binary64, so
+/// the vector form is a pure AND/XOR — bit-identical incl. NaN payload,
+/// matching the scalar lambda the f64 VOP3 bodies emit.
+template <unsigned SrcIdx>
+inline util::native<double> apply_vop3_src_mod_f64(util::native<double> v, uint32_t abs,
+                                                   uint32_t neg) {
+  using U = util::native<uint64_t>;
+  U b = std::bit_cast<U>(v);
+  if (abs & (1u << SrcIdx))
+    b = b & 0x7FFFFFFFFFFFFFFFull;
+  if (neg & (1u << SrcIdx))
+    b = b ^ 0x8000000000000000ull;
+  return std::bit_cast<util::native<double>>(b);
+}
+
+/// In-vector VOP3 destination modifier, bit-exact with the scalar tail: `omod`
+/// scales by an exact power of two (1->*2, 2->*4, 3->*0.5; IEEE-exact, no
+/// rounding), then `clamp` saturates to [0,1]. The clamp uses ordered compares
+/// (`v < 0`, `v > 1`), which are false for NaN, so NaN passes through unchanged —
+/// matching `std::clamp(v, T(0), T(1))`. Instantiated for float and double; the
+/// `_f32`/`_f64` wrappers below name the two lane types the VOP3 paths use.
+template <typename T>
+inline util::native<T> apply_vop3_dst_mod(util::native<T> v, uint32_t omod, uint32_t clamp) {
+  if (omod == 1)
+    v = v * T(2);
+  else if (omod == 2)
+    v = v * T(4);
+  else if (omod == 3)
+    v = v * T(0.5);
+  if (clamp) {
+    util::stdx::where(v < T(0), v) = T(0);
+    util::stdx::where(v > T(1), v) = T(1);
+  }
+  return v;
+}
+
+inline util::native<double> apply_vop3_dst_mod_f64(util::native<double> v, uint32_t omod,
+                                                   uint32_t clamp) {
+  return apply_vop3_dst_mod<double>(v, omod, clamp);
+}
+
+inline util::native<float> apply_vop3_dst_mod_f32(util::native<float> v, uint32_t omod,
+                                                  uint32_t clamp) {
+  return apply_vop3_dst_mod<float>(v, omod, clamp);
+}
+
+/// Resolve an operand's read-side VGPR storage to a `VgprStorage*` (the
+/// per-lane register object), or null for a non-VGPR operand (SGPR / immediate
+/// / inline-const / DPP delegate). This is the single virtual dispatch
+/// (`simd_vgpr_storage`) the SIMD hot path takes to bind a source register; the
+/// per-chunk loop then issues a value-semantic `r->simd_load<T>(base)` directly
+/// off the resolved (loop-invariant) object with no further dispatch and no raw
+/// pointer in the kernel body — the storage pointer never escapes `VgprStorage`.
+template <typename Op> inline const VgprStorage *simd_src_reg(const Op &op, const Wavefront &wf) {
+  return SimdAccess::vgpr_storage(op, wf);
+}
+
+/// Mutable counterpart of `simd_src_reg` for the dst write path (single
+/// `simd_vgpr_storage_mut` dispatch).
+template <typename Op> inline VgprStorage *simd_dst_reg(const Op &op, Wavefront &wf) {
+  return SimdAccess::vgpr_storage_mut(op, wf);
+}
+
+/// Resolve a 64-bit-lane source operand's lo/hi register pair in one virtual
+/// dispatch (`simd_vgpr_storage64`). `{lo, hi}` are `VgprStorage*` (lo = reg N,
+/// hi = reg N+1), or `{nullptr, nullptr}` for a non-VGPR operand. The glue's
+/// 64-bit kernels structured-bind this and issue value-semantic
+/// `lo->simd_load64<T>(*hi, base)` — no raw pointer in the kernel body.
+template <typename Op>
+inline ConstVgprStoragePair64 simd_src_reg64(const Op &op, const Wavefront &wf) {
+  return SimdAccess::vgpr_storage64(op, wf);
+}
+
+/// Mutable counterpart of `simd_src_reg64` for the 64-bit dst write path
+/// (single `simd_vgpr_storage64_mut` dispatch).
+template <typename Op> inline VgprStoragePair64 simd_dst_reg64(const Op &op, Wavefront &wf) {
+  return SimdAccess::vgpr_storage64_mut(op, wf);
+}
+
+/// Value-semantic 32-bit load of a resolved source register at `base`: a
+/// contiguous `r->simd_load<T>(base)` when `r` is per-lane VGPR storage,
+/// otherwise the pre-broadcast scalar `bcast`. The resolved `r` is loop-
+/// invariant (hoisted before the chunk loop), so this is a plain null test +
+/// inlined load — no raw pointer escapes the kernel body.
+template <typename T>
+inline util::native<T> simd_load_or(const VgprStorage *r, uint32_t base, util::native<T> bcast) {
+  return r ? r->template simd_load<T>(base) : bcast;
+}
+
+/// Narrow (native_width64-wide) counterpart of `simd_load_or` for the
+/// mixed-width f64<->32-bit glue.
+template <typename T>
+inline util::narrow32<T> simd_load_narrow_or(const VgprStorage *r, uint32_t base,
+                                             util::narrow32<T> bcast) {
+  return r ? r->template simd_load_narrow<T>(base) : bcast;
+}
+
+/// Value-semantic 64-bit load of a resolved source register pair at `base`: a
+/// combined `lo->simd_load64<T>(*hi, base)` when the pair is per-lane VGPR
+/// storage, otherwise the pre-broadcast scalar `bcast`. The resolved pair is
+/// loop-invariant — no raw pointer escapes the kernel body.
+template <typename T>
+inline util::native<T> simd_load64_or(const ConstVgprStoragePair64 &p, uint32_t base,
+                                      util::native<T> bcast) {
+  return p.lo ? p.lo->template simd_load64<T>(*p.hi, base) : bcast;
+}
+
+/// Mutable-pair overload of `simd_load64_or`, for the dst-accumulate (fmac) f64
+/// paths whose vdst pair is both the accumulator source and the destination.
+template <typename T>
+inline util::native<T> simd_load64_or(const VgprStoragePair64 &p, uint32_t base,
+                                      util::native<T> bcast) {
+  return p.lo ? p.lo->template simd_load64<T>(*p.hi, base) : bcast;
+}
 
 /// SIMD load of an operand at `lane_base`. Returns a contiguous SIMD
 /// load when the operand resolves to per-lane VGPR storage; otherwise
@@ -41,11 +179,10 @@ template <typename T, typename Op>
   requires(util::has_stdx_simd)
 inline util::native<T> read_simd(const Op &op, const Wavefront &wf, uint32_t lane_base) {
   static_assert(sizeof(T) == sizeof(uint32_t), "read_simd: T must be a 32-bit lane type");
-  const uint32_t *p = SimdAccess::lane_ptr(op, wf, lane_base);
-  if (p) {
+  if (const VgprStorage *r = SimdAccess::vgpr_storage(op, wf)) {
     constexpr auto W = static_cast<uint32_t>(util::native_width_v<T>);
     SimdAccess::notify_read(op, wf, lane_base, lane_base + W, 0xF);
-    return util::load<T>(p);
+    return r->template simd_load<T>(lane_base);
   }
   return util::broadcast<T>(op.read_scalar(wf));
 }
@@ -59,13 +196,129 @@ inline void write_simd(const Op &op, Wavefront &wf, uint32_t lane_base, util::na
                        uint64_t mask) {
   static_assert(sizeof(T) == sizeof(uint32_t));
   constexpr std::size_t W = util::native_width_v<T>;
-  if (uint32_t *p = SimdAccess::dst_ptr(op, wf, lane_base)) {
-    util::masked_store<T>(p, v, mask);
+  if (VgprStorage *r = SimdAccess::vgpr_storage_mut(op, wf)) {
+    r->template simd_store<T>(lane_base, v, mask);
     return;
   }
   alignas(util::native<T>) uint32_t buf[W];
   util::blit_to_buffer<T>(buf, v);
   op.write_lane_chunk(wf, lane_base, static_cast<uint32_t>(W), buf, mask);
+}
+
+/// Pre-resolved-register counterpart of write_simd, for the 32-bit fast paths
+/// that resolve the dst's `VgprStorage*` ONCE before the chunk loop and issue a
+/// value-semantic `rd->simd_store<T>(base, ...)` per chunk. `rd` is that hoisted
+/// (loop-invariant) register object, or null when the dst is not contiguous VGPR
+/// storage (then fall back to the operand's write_lane_chunk). Identical
+/// masked-store / fallback semantics to write_simd — the 32-bit sibling of
+/// write_simd64_at. No raw pointer escapes the kernel body.
+template <typename T, typename Op>
+  requires(util::has_stdx_simd)
+inline void write_simd_at(VgprStorage *rd, const Op &op, Wavefront &wf, uint32_t base,
+                          util::native<T> v, uint64_t mask) {
+  static_assert(sizeof(T) == sizeof(uint32_t));
+  constexpr std::size_t W = util::native_width_v<T>;
+  if (rd) {
+    rd->template simd_store<T>(base, v, mask);
+    return;
+  }
+  alignas(util::native<T>) uint32_t buf[W];
+  util::blit_to_buffer<T>(buf, v);
+  op.write_lane_chunk(wf, base, static_cast<uint32_t>(W), buf, mask);
+}
+
+/// Narrow (native_width64-wide) counterpart of write_simd_at, for the f64->32-bit
+/// cvt dst path: value-semantic `rd->simd_store_narrow<T>(base, ...)` when the dst
+/// resolves to per-lane VGPR storage, else spill to a uint32 chunk buffer and fall
+/// back to the operand's write_lane_chunk. No raw pointer escapes the kernel body.
+template <typename T, typename Op>
+  requires(util::has_stdx_simd)
+inline void write_simd_narrow_at(VgprStorage *rd, const Op &op, Wavefront &wf, uint32_t base,
+                                 util::narrow32<T> v, uint64_t mask) {
+  static_assert(sizeof(T) == sizeof(uint32_t));
+  constexpr std::size_t W = util::native_width64;
+  if (rd) {
+    rd->template simd_store_narrow<T>(base, v, mask);
+    return;
+  }
+  alignas(util::narrow32<T>) T vals[W];
+  v.copy_to(vals, util::stdx::vector_aligned);
+  uint32_t buf[W];
+  for (std::size_t i = 0; i < W; ++i)
+    buf[i] = std::bit_cast<uint32_t>(vals[i]);
+  op.write_lane_chunk(wf, base, static_cast<uint32_t>(W), buf, mask);
+}
+
+/// 64-bit-lane load of an operand at `lane_base` (T is double / uint64_t).
+/// Returns a combined `native<T>` from the operand's split lo/hi VGPR pair when
+/// it resolves to per-lane storage; otherwise broadcasts the operand's 64-bit
+/// scalar value (`read_scalar64`). Constrained on `util::has_stdx_simd`.
+template <typename T, typename Op>
+  requires(util::has_stdx_simd)
+inline util::native<T> read_simd64(const Op &op, const Wavefront &wf, uint32_t lane_base) {
+  static_assert(sizeof(T) == sizeof(uint64_t), "read_simd64: T must be a 64-bit lane type");
+  ConstVgprStoragePair64 p = simd_src_reg64(op, wf);
+  if (p.lo)
+    return p.lo->template simd_load64<T>(*p.hi, lane_base);
+  return util::broadcast64<T>(op.read_scalar64(wf));
+}
+
+/// 64-bit-lane masked store of `v` into an operand at `lane_base`, writing only
+/// the lanes set in `mask`. Falls back to per-lane `write_lane64` when the dst is
+/// not contiguous VGPR storage.
+template <typename T, typename Op>
+  requires(util::has_stdx_simd)
+inline void write_simd64(const Op &op, Wavefront &wf, uint32_t lane_base, util::native<T> v,
+                         uint64_t mask) {
+  static_assert(sizeof(T) == sizeof(uint64_t));
+  constexpr std::size_t W = util::native_width64;
+  VgprStoragePair64 p = simd_dst_reg64(op, wf);
+  if (p.lo) {
+    p.lo->template simd_store64<T>(*p.hi, lane_base, v, mask);
+    return;
+  }
+  alignas(util::native<T>) uint64_t buf[W];
+  util::stdx::native_simd<uint64_t> bits = [&] {
+    if constexpr (std::is_same_v<T, uint64_t>)
+      return v;
+    else
+      return std::bit_cast<util::stdx::native_simd<uint64_t>>(v);
+  }();
+  bits.copy_to(buf, util::stdx::vector_aligned);
+  for (std::size_t i = 0; i < W; ++i)
+    if (mask & (1ULL << i))
+      op.write_lane64(wf, lane_base + static_cast<uint32_t>(i), buf[i]);
+}
+
+/// Pre-resolved-register counterpart of write_simd64, for the fast paths that
+/// resolve the dst's split lo/hi `VgprStorage*` pair ONCE (simd_dst_reg64)
+/// before the chunk loop and issue a value-semantic
+/// `p.lo->simd_store64<T>(*p.hi, base, ...)` per chunk. `p` is that hoisted
+/// (loop-invariant) register pair, or `{nullptr, nullptr}` when the dst is not
+/// contiguous VGPR storage (then fall back to the operand's write_lane64).
+/// Identical masked-store / fallback semantics to write_simd64. No raw pointer
+/// escapes the kernel body.
+template <typename T, typename Op>
+  requires(util::has_stdx_simd)
+inline void write_simd64_at(VgprStoragePair64 p, const Op &op, Wavefront &wf, uint32_t base,
+                            util::native<T> v, uint64_t mask) {
+  static_assert(sizeof(T) == sizeof(uint64_t));
+  constexpr std::size_t W = util::native_width64;
+  if (p.lo) {
+    p.lo->template simd_store64<T>(*p.hi, base, v, mask);
+    return;
+  }
+  alignas(util::native<T>) uint64_t buf[W];
+  util::stdx::native_simd<uint64_t> bits = [&] {
+    if constexpr (std::is_same_v<T, uint64_t>)
+      return v;
+    else
+      return std::bit_cast<util::stdx::native_simd<uint64_t>>(v);
+  }();
+  bits.copy_to(buf, util::stdx::vector_aligned);
+  for (std::size_t i = 0; i < W; ++i)
+    if (mask & (1ULL << i))
+      op.write_lane64(wf, base + static_cast<uint32_t>(i), buf[i]);
 }
 
 /// VOP2 binary SIMD fast path. Returns true when the SIMD path executed
@@ -84,13 +337,27 @@ template <typename T, typename Inst, typename BinOp>
   constexpr std::size_t W = util::native_width_v<T>;
   const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
   const uint64_t exec = wf.exec();
+  // Resolve each operand's `VgprStorage*` ONCE (a single virtual
+  // simd_vgpr_storage dispatch -> resolved_vgpr_offset -> the localized
+  // vgpr_reg<64> cast). The resolved register object is chunk-independent, so the
+  // per-chunk loop issues a value-semantic `r->simd_load<T>(base)` off it instead
+  // of re-dispatching the resolution every chunk — and no raw base pointer
+  // escapes the kernel body. Operands that aren't contiguous VGPR storage
+  // (SGPR/imm/inline-const) resolve to null and broadcast a single scalar read; a
+  // null dst falls back to write_lane_chunk.
+  const VgprStorage *r0 = simd_src_reg(inst.src0, wf);
+  const VgprStorage *r1 = simd_src_reg(inst.vsrc1, wf);
+  VgprStorage *rd = simd_dst_reg(inst.vdst, wf);
+  const auto a_bcast = r0 ? util::native<T>{} : util::broadcast<T>(inst.src0.read_scalar(wf));
+  const auto b_bcast = r1 ? util::native<T>{} : util::broadcast<T>(inst.vsrc1.read_scalar(wf));
   for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
     const uint64_t chunk = (exec >> base) & chunk_full;
     if (chunk == 0)
       continue;
-    const auto a = read_simd<T>(inst.src0, wf, base);
-    const auto b = read_simd<T>(inst.vsrc1, wf, base);
-    write_simd<T>(inst.vdst, wf, base, bin_op(a, b), chunk);
+    const auto a = simd_load_or<T>(r0, base, a_bcast);
+    const auto b = simd_load_or<T>(r1, base, b_bcast);
+    const auto r = bin_op(a, b);
+    write_simd_at<T>(rd, inst.vdst, wf, base, r, chunk);
   }
   return true;
 }
@@ -103,7 +370,2885 @@ template <typename T, typename Inst, typename BinOp>
   return false;
 }
 
+/// Re-type a `simd_mask` (e.g. the result of a float comparison) to the mask
+/// type of `native<To>`, so it can drive `util::stdx::where` on a `native<To>`
+/// value. Needed by the clamp/NaN cvt-to-int functors, which compute masks in
+/// the float domain but blend into an int result. Wraps the libstdc++
+/// `__proposed` mask cast in one place; `<experimental/simd>` is libstdc++-only
+/// so the dependency is acceptable.
+template <typename To, typename Mask>
+  requires(util::has_stdx_simd)
+inline auto simd_mask_as(const Mask &m) {
+  return util::stdx::__proposed::static_simd_cast<util::native<To>>(m);
+}
+
+/// VOP1 unary SIMD fast path. Reads `src0` as `Tin`, applies `un_op`
+/// (`native<Tin> -> native<Tout>`), masked-stores the result to `vdst` as
+/// `Tout`. `Tin` and `Tout` are both 32-bit lane types (possibly different,
+/// e.g. int32->float32 for v_cvt_f32_i32). Same contract as the VOP2 path:
+/// returns true when the SIMD path executed; false on the `force_scalar`
+/// override or when either operand reports `!simd_capable()`.
+template <typename Tin, typename Tout, typename Inst, typename UnOp>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_unary_vop1_simd(Inst &inst, Wavefront &wf, UnOp un_op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.vdst.simd_capable())
+    return false;
+  constexpr std::size_t W = util::native_width_v<Tout>;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  // Resolve operand base pointers once; see try_execute_binary_vop2_simd.
+  const VgprStorage *r0 = simd_src_reg(inst.src0, wf);
+  VgprStorage *rd = simd_dst_reg(inst.vdst, wf);
+  const auto a_bcast = r0 ? util::native<Tin>{} : util::broadcast<Tin>(inst.src0.read_scalar(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto a = simd_load_or<Tin>(r0, base, a_bcast);
+    const auto r = un_op(a);
+    write_simd_at<Tout>(rd, inst.vdst, wf, base, r, chunk);
+  }
+  return true;
+}
+
+/// Unconstrained fallback for the unary path; see the binary-path note above.
+template <typename Tin, typename Tout, typename Inst, typename UnOp>
+[[nodiscard]] inline bool try_execute_unary_vop1_simd(Inst &, Wavefront &, UnOp) {
+  return false;
+}
+
+/// Result of a carry-bearing VOP2 functor: the 32-bit per-lane result and the
+/// per-lane carry/borrow as a `simd_mask`. A class template (not a fixed type)
+/// so it never names `native<uint32_t>::mask_type` outside the SIMD build —
+/// the carry functors below build it through `make_simd_carry`, whose return
+/// type is deduced and only instantiated on the constrained code path.
+template <typename Value, typename Mask> struct SimdCarry {
+  Value value;
+  Mask carry;
+};
+
+/// Deduce-and-wrap helper for the carry functors. Keeps each functor a single
+/// expression while leaving the mask type implicit.
+template <typename Value, typename Mask>
+inline SimdCarry<Value, Mask> make_simd_carry(Value value, Mask carry) {
+  return {value, carry};
+}
+
+/// VOP2 carry SIMD fast path (v_add_co/sub_co/subrev_co/addc/subb/subbrev_u32).
+/// The lane type is fixed to uint32_t. `carry_op` is invoked as
+///   carry_op(native<uint32_t> src0, native<uint32_t> vsrc1, native<uint32_t> cin)
+///     -> SimdCarry<native<uint32_t>, mask>
+/// where `cin` carries the incoming VCC bit (0/1 per lane); ops without a
+/// carry-in ignore it. The result is masked-stored to vdst and the carry mask
+/// is merged into VCC at the chunk's bit offset for active EXEC lanes only —
+/// inactive-lane VCC bits are preserved, matching the scalar bodies.
+template <typename Inst, typename CarryOp>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_binary_vop2_carry_simd(Inst &inst, Wavefront &wf,
+                                                             CarryOp carry_op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.vsrc1.simd_capable() ||
+      !inst.vdst.simd_capable())
+    return false;
+  using T = uint32_t;
+  constexpr std::size_t W = util::native_width_v<T>;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  // Carry-in reads the incoming VCC; the result accumulates into a copy. Each
+  // lane touches only its own VCC bit, so the snapshot/copy split mirrors the
+  // scalar body, which reads wf.vcc() for carry-in and writes set_vcc() once.
+  const uint64_t vcc_in = wf.vcc();
+  uint64_t vcc_out = vcc_in;
+  // Resolve operand base pointers once; see try_execute_binary_vop2_simd.
+  const VgprStorage *r0 = simd_src_reg(inst.src0, wf);
+  const VgprStorage *r1 = simd_src_reg(inst.vsrc1, wf);
+  VgprStorage *rd = simd_dst_reg(inst.vdst, wf);
+  const auto a_bcast = r0 ? util::native<T>{} : util::broadcast<T>(inst.src0.read_scalar(wf));
+  const auto b_bcast = r1 ? util::native<T>{} : util::broadcast<T>(inst.vsrc1.read_scalar(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto a = simd_load_or<T>(r0, base, a_bcast);
+    const auto b = simd_load_or<T>(r1, base, b_bcast);
+    // Expand the incoming VCC bits for this chunk to a 0/1-per-lane vector.
+    const uint64_t cin_bits = (vcc_in >> base) & chunk_full;
+    alignas(util::native<T>) uint32_t cinbuf[W];
+    for (std::size_t i = 0; i < W; ++i)
+      cinbuf[i] = static_cast<uint32_t>((cin_bits >> i) & 1u);
+    const auto cin = util::load<T>(cinbuf);
+    const auto r = carry_op(a, b, cin);
+    write_simd_at<T>(rd, inst.vdst, wf, base, r.value, chunk);
+    // Pack the per-lane carry mask into the low W bits, then merge into VCC for
+    // active lanes only (clear active bits, set from carry; preserve the rest).
+    uint64_t carry_bits = 0;
+    for (std::size_t i = 0; i < W; ++i)
+      if (r.carry[i])
+        carry_bits |= (1ULL << i);
+    vcc_out = (vcc_out & ~(chunk << base)) | ((carry_bits & chunk) << base);
+  }
+  wf.set_vcc(vcc_out);
+  return true;
+}
+
+/// Unconstrained fallback for the carry path; see the binary-path note above.
+template <typename Inst, typename CarryOp>
+[[nodiscard]] inline bool try_execute_binary_vop2_carry_simd(Inst &, Wavefront &, CarryOp) {
+  return false;
+}
+
+/// VOP2 ternary (fused multiply-add) SIMD fast path. Covers the three operand
+/// shapes of the VOP2 FMA/MAC/MAD family:
+///   * dst-accumulate (v_fmac/v_mac):  dst = fma(src0, vsrc1, dst)
+///   * literal addend (v_fmaak/v_madak): dst = fma(src0, vsrc1, K)
+///   * literal multiplier (v_fmamk/v_madmk): dst = fma(src0, K, vsrc1)
+/// All read src0/vsrc1/vdst as `native<T>` and receive the broadcast inline
+/// literal `k` (zero for forms without one). `fma_op(s0, s1, dvst, k)` selects
+/// the shape and, for f16, does the f16<->f32 conversions in the functor. The
+/// result is masked-stored to vdst.
+///
+/// `util::stdx::fma` is bit-identical to the scalar `std::fma` for all finite
+/// and infinite inputs (including Inf*0 -> NaN). When an *input* is NaN the
+/// packed and scalar FMA may propagate a different NaN operand (a toolchain-
+/// dependent payload, observed on g++-13/AVX-512); that NaN-payload divergence
+/// is accepted — the result is a NaN either way. The finite/Inf bit-exactness
+/// the fast path relies on is guarded by UtilSimd.Fma_VectorMatchesScalar_*.
+template <typename T, typename Inst, typename FmaOp>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_ternary_vop2_simd(Inst &inst, Wavefront &wf,
+                                                        util::native<T> k, FmaOp fma_op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.vsrc1.simd_capable() ||
+      !inst.vdst.simd_capable())
+    return false;
+  constexpr std::size_t W = util::native_width_v<T>;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  // Resolve operand base pointers once; see try_execute_binary_vop2_simd. vdst
+  // is both the third (accumulate) source and the destination — one pointer.
+  const VgprStorage *r0 = simd_src_reg(inst.src0, wf);
+  const VgprStorage *r1 = simd_src_reg(inst.vsrc1, wf);
+  VgprStorage *rd = simd_dst_reg(inst.vdst, wf);
+  const auto a_bcast = r0 ? util::native<T>{} : util::broadcast<T>(inst.src0.read_scalar(wf));
+  const auto b_bcast = r1 ? util::native<T>{} : util::broadcast<T>(inst.vsrc1.read_scalar(wf));
+  const auto d_bcast = rd ? util::native<T>{} : util::broadcast<T>(inst.vdst.read_scalar(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto a = simd_load_or<T>(r0, base, a_bcast);
+    const auto b = simd_load_or<T>(r1, base, b_bcast);
+    const auto d = simd_load_or<T>(rd, base, d_bcast); // dst-accumulate source
+    const auto r = fma_op(a, b, d, k);
+    write_simd_at<T>(rd, inst.vdst, wf, base, r, chunk);
+  }
+  return true;
+}
+
+/// Unconstrained fallback for the ternary path; see the binary-path note above.
+template <typename T, typename Inst, typename FmaOp>
+[[nodiscard]] inline bool try_execute_ternary_vop2_simd(Inst &, Wavefront &, util::native<T>,
+                                                        FmaOp) {
+  return false;
+}
+
+/// 64-bit-lane VOP2 fused-multiply-add SIMD fast path (v_fmac_f64): the only
+/// f64 VOP2 op reachable on CDNA4 is the dst-accumulate form
+/// `dst = fma(src0, vsrc1, dst)`. Reads all three operands as `native<T>`
+/// (T = double) through the split lo/hi VGPR-pair path and masked-stores the
+/// result. `fma_op(s0, s1, dvst)` is the dst-accumulate functor.
+///
+/// `util::stdx::fma` over `native<double>` is bit-identical to the scalar
+/// `std::fma` for all finite and infinite inputs; NaN-*input* lanes may differ
+/// in propagated NaN payload (accepted — the result is a NaN either way),
+/// guarded by UtilSimd.FmaF64_VectorMatchesScalar_BitExact.
+template <typename T, typename Inst, typename FmaOp>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_ternary_vop2_f64_simd(Inst &inst, Wavefront &wf,
+                                                            FmaOp fma_op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.vsrc1.simd_capable() ||
+      !inst.vdst.simd_capable())
+    return false;
+  constexpr std::size_t W = util::native_width64;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  // Resolve operand base pointers once; see try_execute_binary_vop2_simd. vdst
+  // is both the dst-accumulate source and the destination — one lo/hi pair.
+  const ConstVgprStoragePair64 rs0 = simd_src_reg64(inst.src0, wf);
+  const ConstVgprStoragePair64 rs1 = simd_src_reg64(inst.vsrc1, wf);
+  const VgprStoragePair64 rd64 = simd_dst_reg64(inst.vdst, wf);
+  const auto a_bcast =
+      rs0.lo ? util::native<T>{} : util::broadcast64<T>(inst.src0.read_scalar64(wf));
+  const auto b_bcast =
+      rs1.lo ? util::native<T>{} : util::broadcast64<T>(inst.vsrc1.read_scalar64(wf));
+  const auto d_bcast =
+      rd64.lo ? util::native<T>{} : util::broadcast64<T>(inst.vdst.read_scalar64(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto a = simd_load64_or<T>(rs0, base, a_bcast);
+    const auto b = simd_load64_or<T>(rs1, base, b_bcast);
+    const auto d = simd_load64_or<T>(rd64, base, d_bcast); // dst-accumulate
+    write_simd64_at<T>(rd64, inst.vdst, wf, base, fma_op(a, b, d), chunk);
+  }
+  return true;
+}
+
+/// Unconstrained fallback for the f64 ternary path; see the binary-path note.
+template <typename T, typename Inst, typename FmaOp>
+[[nodiscard]] inline bool try_execute_ternary_vop2_f64_simd(Inst &, Wavefront &, FmaOp) {
+  return false;
+}
+
+/// 64-bit-lane VOP1 unary SIMD fast path. The 64-bit counterpart of
+/// try_execute_unary_vop1_simd: reads src0 as `native<T>` through the split
+/// lo/hi VGPR-pair path (read_simd64), applies `un_op` (`native<T> ->
+/// native<T>`), and masked-stores the result to vdst. `T` is `double` for the
+/// f64 math ops (ceil/floor/trunc/rndne/fract/rcp/rsq/sqrt) and `uint64_t` for
+/// the pure 64-bit move (v_mov_b64). Same contract as the other paths: returns
+/// true when the SIMD path executed; false on the `force_scalar` override or
+/// when either operand reports `!simd_capable()`.
+///
+/// The rounding ops map to `vroundpd`, sqrt to `vsqrtpd`, and `1.0 / x` to
+/// `vdivpd` — all correctly-rounded IEEE operations, bit-identical to the scalar
+/// `std::ceil`/`std::sqrt`/... for every finite and infinite input. NaN-*input*
+/// lanes may differ in propagated NaN payload (accepted — the result is a NaN
+/// either way), guarded by the UtilSimd.*F64*_VectorMatchesScalar_BitExact tests.
+template <typename T, typename Inst, typename UnOp>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_unary_vop1_f64_simd(Inst &inst, Wavefront &wf, UnOp un_op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.vdst.simd_capable())
+    return false;
+  constexpr std::size_t W = util::native_width64;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  // Resolve operand base pointers once; see try_execute_binary_vop2_simd.
+  const ConstVgprStoragePair64 rs0 = simd_src_reg64(inst.src0, wf);
+  const VgprStoragePair64 rd64 = simd_dst_reg64(inst.vdst, wf);
+  const auto a_bcast =
+      rs0.lo ? util::native<T>{} : util::broadcast64<T>(inst.src0.read_scalar64(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto a = simd_load64_or<T>(rs0, base, a_bcast);
+    write_simd64_at<T>(rd64, inst.vdst, wf, base, un_op(a), chunk);
+  }
+  return true;
+}
+
+/// Unconstrained fallback for the f64 unary path; see the binary-path note.
+template <typename T, typename Inst, typename UnOp>
+[[nodiscard]] inline bool try_execute_unary_vop1_f64_simd(Inst &, Wavefront &, UnOp) {
+  return false;
+}
+
+/// Narrow (native_width64-wide) load of a 32-bit operand at `lane_base`. The
+/// 32-bit-source counterpart of `read_simd` for the f64<->32-bit conversion glue,
+/// which processes `native_width64` (8 on AVX-512) lanes per chunk to stay aligned
+/// with the 64-bit f64 side. Returns a contiguous narrow load from per-lane VGPR
+/// storage, else broadcasts the operand's scalar value.
+template <typename T, typename Op>
+  requires(util::has_stdx_simd)
+inline util::narrow32<T> read_narrow(const Op &op, const Wavefront &wf, uint32_t lane_base) {
+  static_assert(sizeof(T) == sizeof(uint32_t), "read_narrow: T must be a 32-bit lane type");
+  if (const VgprStorage *r = SimdAccess::vgpr_storage(op, wf))
+    return r->template simd_load_narrow<T>(lane_base);
+  return util::broadcast_narrow<T>(op.read_scalar(wf));
+}
+
+/// Mixed-width VOP1 conversion SIMD fast path, f64 source -> 32-bit dst
+/// (v_cvt_f32_f64, v_cvt_i32_f64, v_cvt_u32_f64). Reads src0 as `native<double>`
+/// through the split lo/hi VGPR-pair path (read_simd64), applies `cvt_op`
+/// (`native<double> -> narrow32<Tout>`), and masked-stores the `native_width64`
+/// 32-bit results to vdst. The double->Tout step is a single `static_simd_cast`
+/// (cvt_f32_f64 maps to vcvtpd2ps, correctly rounded; the int forms clamp/NaN in
+/// the double domain first, then one cast). Bit-identical to the scalar body for
+/// finite/Inf inputs; a NaN *result* may differ in payload (accepted), which the
+/// A/B test skips. Returns true when the SIMD path executed.
+template <typename Tout, typename Inst, typename CvtOp>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_cvt_f64_to_b32_simd(Inst &inst, Wavefront &wf, CvtOp cvt_op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.vdst.simd_capable())
+    return false;
+  constexpr std::size_t W = util::native_width64;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  // Resolve operand base pointers once; see try_execute_binary_vop2_simd. The
+  // dst is 32-bit (native_width64 narrow lanes) while the source is 64-bit.
+  const ConstVgprStoragePair64 rs0 = simd_src_reg64(inst.src0, wf);
+  VgprStorage *rd = simd_dst_reg(inst.vdst, wf);
+  const auto s_bcast =
+      rs0.lo ? util::native<double>{} : util::broadcast64<double>(inst.src0.read_scalar64(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto s = simd_load64_or<double>(rs0, base, s_bcast);
+    const util::narrow32<Tout> r = cvt_op(s);
+    // Value-semantic narrow store (per-lane bit_cast spill + write_lane_chunk
+    // fallback for a non-VGPR dst lives inside write_simd_narrow_at).
+    write_simd_narrow_at<Tout>(rd, inst.vdst, wf, base, r, chunk);
+  }
+  return true;
+}
+
+/// Unconstrained fallback for the f64->b32 cvt path; see the binary-path note.
+template <typename Tout, typename Inst, typename CvtOp>
+[[nodiscard]] inline bool try_execute_cvt_f64_to_b32_simd(Inst &, Wavefront &, CvtOp) {
+  return false;
+}
+
+/// Mixed-width VOP1 conversion SIMD fast path, 32-bit source -> f64 dst
+/// (v_cvt_f64_f32, v_cvt_f64_i32, v_cvt_f64_u32). Reads src0 as `narrow32<Tin>`
+/// (native_width64 32-bit lanes), applies `cvt_op` (`narrow32<Tin> ->
+/// native<double>`), and masked-stores the result to the 64-bit vdst through the
+/// split lo/hi VGPR-pair path (write_simd64). Each conversion is an exact widening
+/// `static_simd_cast` (vcvtps2pd / int->double), bit-identical to the scalar body
+/// for every input. Returns true when the SIMD path executed.
+template <typename Tin, typename Inst, typename CvtOp>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_cvt_b32_to_f64_simd(Inst &inst, Wavefront &wf, CvtOp cvt_op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.vdst.simd_capable())
+    return false;
+  constexpr std::size_t W = util::native_width64;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  // Resolve operand base pointers once; see try_execute_binary_vop2_simd. The
+  // source is 32-bit (native_width64 narrow lanes) while the dst is 64-bit.
+  const VgprStorage *r0 = simd_src_reg(inst.src0, wf);
+  const VgprStoragePair64 rd64 = simd_dst_reg64(inst.vdst, wf);
+  const auto in_bcast =
+      r0 ? util::narrow32<Tin>{} : util::broadcast_narrow<Tin>(inst.src0.read_scalar(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto in = simd_load_narrow_or<Tin>(r0, base, in_bcast);
+    write_simd64_at<double>(rd64, inst.vdst, wf, base, cvt_op(in), chunk);
+  }
+  return true;
+}
+
+/// Unconstrained fallback for the b32->f64 cvt path; see the binary-path note.
+template <typename Tin, typename Inst, typename CvtOp>
+[[nodiscard]] inline bool try_execute_cvt_b32_to_f64_simd(Inst &, Wavefront &, CvtOp) {
+  return false;
+}
+
+/// v_cndmask_b32 SIMD fast path: dst[lane] = (VCC bit) ? vsrc1 : src0. VCC is an
+/// input side-channel here (no carry-out). The per-lane select bits for a chunk
+/// are read from VCC at the chunk's bit offset, expanded to a 0/1-per-lane
+/// vector, and used to blend src0/vsrc1 with `where`. A pure 32-bit bit select,
+/// so the result is bit-identical to the scalar body for every input.
+template <typename Inst>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_cndmask_vop2_simd(Inst &inst, Wavefront &wf) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.vsrc1.simd_capable() ||
+      !inst.vdst.simd_capable())
+    return false;
+  using T = uint32_t;
+  constexpr std::size_t W = util::native_width_v<T>;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  const uint64_t vcc = wf.vcc();
+  // Resolve operand base pointers once; see try_execute_binary_vop2_simd.
+  const VgprStorage *r0 = simd_src_reg(inst.src0, wf);
+  const VgprStorage *r1 = simd_src_reg(inst.vsrc1, wf);
+  VgprStorage *rd = simd_dst_reg(inst.vdst, wf);
+  const auto a_bcast = r0 ? util::native<T>{} : util::broadcast<T>(inst.src0.read_scalar(wf));
+  const auto b_bcast = r1 ? util::native<T>{} : util::broadcast<T>(inst.vsrc1.read_scalar(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto a = simd_load_or<T>(r0, base, a_bcast);
+    const auto b = simd_load_or<T>(r1, base, b_bcast);
+    const uint64_t sel_bits = (vcc >> base) & chunk_full;
+    alignas(util::native<T>) uint32_t selbuf[W];
+    for (std::size_t i = 0; i < W; ++i)
+      selbuf[i] = static_cast<uint32_t>((sel_bits >> i) & 1u);
+    auto r = a;
+    util::stdx::where(util::load<T>(selbuf) != 0u, r) = b;
+    write_simd_at<T>(rd, inst.vdst, wf, base, r, chunk);
+  }
+  return true;
+}
+
+/// Unconstrained fallback for the cndmask path; see the binary-path note above.
+template <typename Inst>
+[[nodiscard]] inline bool try_execute_cndmask_vop2_simd(Inst &, Wavefront &) {
+  return false;
+}
+
+/// v_cndmask_b32 VOP3 form: dst[lane] = (sel[lane]) ? src1 : src0, where `sel`
+/// is the 64-bit value read from the SGPR-pair `src2` (instead of the fixed VCC
+/// used by the VOP2 form). The scalar body applies no modifiers (the result is
+/// a bit-exact integer select on whichever operand the selector picks), so the
+/// VOP3 modifier fields are intentionally not consulted here — bit-identical to
+/// the scalar body regardless of abs/neg/omod/clamp encoding. `src2` is an
+/// SGPR/inline operand, not a VGPR, so it does not participate in the
+/// simd_capable gate; src0/src1/vdst do.
+template <typename Inst>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_cndmask_vop3_simd(Inst &inst, Wavefront &wf) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable() ||
+      !inst.vdst.simd_capable())
+    return false;
+  using T = uint32_t;
+  constexpr std::size_t W = util::native_width_v<T>;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  const uint64_t sel64 = inst.src2.read_scalar64(wf);
+  // Resolve operand base pointers once; see try_execute_binary_vop2_simd.
+  const VgprStorage *r0 = simd_src_reg(inst.src0, wf);
+  const VgprStorage *r1 = simd_src_reg(inst.src1, wf);
+  VgprStorage *rd = simd_dst_reg(inst.vdst, wf);
+  const auto a_bcast = r0 ? util::native<T>{} : util::broadcast<T>(inst.src0.read_scalar(wf));
+  const auto b_bcast = r1 ? util::native<T>{} : util::broadcast<T>(inst.src1.read_scalar(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto a = simd_load_or<T>(r0, base, a_bcast);
+    const auto b = simd_load_or<T>(r1, base, b_bcast);
+    const uint64_t sel_bits = (sel64 >> base) & chunk_full;
+    alignas(util::native<T>) uint32_t selbuf[W];
+    for (std::size_t i = 0; i < W; ++i)
+      selbuf[i] = static_cast<uint32_t>((sel_bits >> i) & 1u);
+    auto r = a;
+    util::stdx::where(util::load<T>(selbuf) != 0u, r) = b;
+    write_simd_at<T>(rd, inst.vdst, wf, base, r, chunk);
+  }
+  return true;
+}
+
+/// Unconstrained fallback for the VOP3 cndmask path; see the binary-path note.
+template <typename Inst>
+[[nodiscard]] inline bool try_execute_cndmask_vop3_simd(Inst &, Wavefront &) {
+  return false;
+}
+
+/// v_cndmask_b16 VOP3 form: same per-lane select as cndmask_vop3 but the
+/// dst (and each source) is the low 16 bits of the 32-bit VGPR; the high 16
+/// are zeroed (matching the scalar body's `uint32_t(uint16_t(...))` pattern).
+/// The select shape is identical to the b32 form — the only addition is a
+/// `& 0xFFFFu` mask before the masked store. RDNA3+; CDNA4 does not decode.
+template <typename Inst>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_cndmask_b16_vop3_simd(Inst &inst, Wavefront &wf) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable() ||
+      !inst.vdst.simd_capable())
+    return false;
+  using T = uint32_t;
+  constexpr std::size_t W = util::native_width_v<T>;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  const uint64_t sel64 = inst.src2.read_scalar64(wf);
+  // Resolve operand base pointers once; see try_execute_binary_vop2_simd.
+  const VgprStorage *r0 = simd_src_reg(inst.src0, wf);
+  const VgprStorage *r1 = simd_src_reg(inst.src1, wf);
+  VgprStorage *rd = simd_dst_reg(inst.vdst, wf);
+  const auto a_bcast = r0 ? util::native<T>{} : util::broadcast<T>(inst.src0.read_scalar(wf));
+  const auto b_bcast = r1 ? util::native<T>{} : util::broadcast<T>(inst.src1.read_scalar(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto a = simd_load_or<T>(r0, base, a_bcast);
+    const auto b = simd_load_or<T>(r1, base, b_bcast);
+    const uint64_t sel_bits = (sel64 >> base) & chunk_full;
+    alignas(util::native<T>) uint32_t selbuf[W];
+    for (std::size_t i = 0; i < W; ++i)
+      selbuf[i] = static_cast<uint32_t>((sel_bits >> i) & 1u);
+    auto r = a;
+    util::stdx::where(util::load<T>(selbuf) != 0u, r) = b;
+    r = r & util::native<T>(0xFFFFu);
+    write_simd_at<T>(rd, inst.vdst, wf, base, r, chunk);
+  }
+  return true;
+}
+
+template <typename Inst>
+[[nodiscard]] inline bool try_execute_cndmask_b16_vop3_simd(Inst &, Wavefront &) {
+  return false;
+}
+
+/// VOPC compare SIMD fast path: per active EXEC lane, `cmp_op(src0, vsrc1)`
+/// produces a `simd_mask` whose bit is packed into VCC at the lane position;
+/// inactive-lane VCC bits are preserved (mirroring the scalar body, which
+/// flips only active-lane bits). VOPC writes VCC only — there is no vdst
+/// operand and CDNA4 has no v_cmpx (EXEC-writing) form, so this single shape
+/// covers every compare. `T` is the 32-bit lane read type (float32_t for the
+/// f32 relations, int32_t/uint32_t for the integer ones); the f16 and 16-bit
+/// integer relations also read as 32-bit lanes and narrow/convert inside the
+/// functor. The VCC merge is identical to the carry path's.
+///
+/// Float comparison operators (and stdx::isnan, used by the ordered/unordered
+/// relations) produce the same per-lane boolean as the scalar `<`/`==`/isnan,
+/// for all inputs including NaN/Inf/±0 — so the compares are bit-exact with no
+/// accepted-divergence carve-out (unlike fma / min-max).
+template <typename T, typename Inst, typename CmpOp>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_vopc_simd(Inst &inst, Wavefront &wf, CmpOp cmp_op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.vsrc1.simd_capable())
+    return false;
+  constexpr std::size_t W = util::native_width_v<T>;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  uint64_t vcc = wf.vcc();
+  // Resolve source base pointers once; see try_execute_binary_vop2_simd. VOPC
+  // writes only the VCC mask, so there is no dst pointer to hoist.
+  const VgprStorage *r0 = simd_src_reg(inst.src0, wf);
+  const VgprStorage *r1 = simd_src_reg(inst.vsrc1, wf);
+  const auto a_bcast = r0 ? util::native<T>{} : util::broadcast<T>(inst.src0.read_scalar(wf));
+  const auto b_bcast = r1 ? util::native<T>{} : util::broadcast<T>(inst.vsrc1.read_scalar(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto a = simd_load_or<T>(r0, base, a_bcast);
+    const auto b = simd_load_or<T>(r1, base, b_bcast);
+    const auto m = cmp_op(a, b);
+    uint64_t cmp_bits = 0;
+    for (std::size_t i = 0; i < W; ++i)
+      if (m[i])
+        cmp_bits |= (1ULL << i);
+    vcc = (vcc & ~(chunk << base)) | ((cmp_bits & chunk) << base);
+  }
+  wf.set_vcc(vcc);
+  return true;
+}
+
+/// Unconstrained fallback for the VOPC path; see the binary-path note above.
+template <typename T, typename Inst, typename CmpOp>
+[[nodiscard]] inline bool try_execute_vopc_simd(Inst &, Wavefront &, CmpOp) {
+  return false;
+}
+
+/// 64-bit-lane VOPC compare SIMD fast path (f64/i64/u64 relations). Identical to
+/// try_execute_vopc_simd but reads each operand as `native<T>` (T = double /
+/// int64_t / uint64_t) through the split lo/hi VGPR-pair path (read_simd64), so
+/// it processes `native_width64` lanes per chunk. Same VCC merge / preservation.
+template <typename T, typename Inst, typename CmpOp>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_vopc64_simd(Inst &inst, Wavefront &wf, CmpOp cmp_op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.vsrc1.simd_capable())
+    return false;
+  constexpr std::size_t W = util::native_width64;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  uint64_t vcc = wf.vcc();
+  // Resolve source base pointers once; see try_execute_binary_vop2_simd. VOPC
+  // writes only the VCC mask, so there is no dst pointer to hoist.
+  const ConstVgprStoragePair64 rs0 = simd_src_reg64(inst.src0, wf);
+  const ConstVgprStoragePair64 rs1 = simd_src_reg64(inst.vsrc1, wf);
+  const auto a_bcast =
+      rs0.lo ? util::native<T>{} : util::broadcast64<T>(inst.src0.read_scalar64(wf));
+  const auto b_bcast =
+      rs1.lo ? util::native<T>{} : util::broadcast64<T>(inst.vsrc1.read_scalar64(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto a = simd_load64_or<T>(rs0, base, a_bcast);
+    const auto b = simd_load64_or<T>(rs1, base, b_bcast);
+    const auto m = cmp_op(a, b);
+    uint64_t cmp_bits = 0;
+    for (std::size_t i = 0; i < W; ++i)
+      if (m[i])
+        cmp_bits |= (1ULL << i);
+    vcc = (vcc & ~(chunk << base)) | ((cmp_bits & chunk) << base);
+  }
+  wf.set_vcc(vcc);
+  return true;
+}
+
+/// Unconstrained fallback for the 64-bit VOPC path; see the binary-path note.
+template <typename T, typename Inst, typename CmpOp>
+[[nodiscard]] inline bool try_execute_vopc64_simd(Inst &, Wavefront &, CmpOp) {
+  return false;
+}
+
+/// Mixed-width v_cmp_class_f64 SIMD fast path. v_cmp_class_f64 tests a 64-bit f64
+/// src0 against a 32-bit class mask in vsrc1, so unlike the relational VOPC64 path
+/// the two operands have different widths: src0 is read as `native<uint64_t>` raw
+/// bits through the split lo/hi VGPR-pair path (read_simd64), and the per-lane
+/// mask as a `native_width64`-wide `narrow32<uint32_t>` (read_narrow). The functor
+/// classifies the f64 from its raw bits and tests the class against the mask,
+/// returning a `native_width64`-wide mask packed into VCC exactly like the other
+/// VOPC paths (active lanes only, inactive bits preserved). The classification is
+/// pure bit decode, bit-exact with the scalar body for every input.
+template <typename Inst, typename CmpOp>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_vopc_class_f64_simd(Inst &inst, Wavefront &wf, CmpOp cmp_op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.vsrc1.simd_capable())
+    return false;
+  constexpr std::size_t W = util::native_width64;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  uint64_t vcc = wf.vcc();
+  // Resolve source base pointers once; see try_execute_binary_vop2_simd. VOPC
+  // writes only the VCC mask, so there is no dst pointer to hoist.
+  const ConstVgprStoragePair64 rs0 = simd_src_reg64(inst.src0, wf);
+  const VgprStorage *rm = simd_src_reg(inst.vsrc1, wf);
+  const auto s_bcast =
+      rs0.lo ? util::native<uint64_t>{} : util::broadcast64<uint64_t>(inst.src0.read_scalar64(wf));
+  const auto mask_bcast = rm ? util::narrow32<uint32_t>{}
+                             : util::broadcast_narrow<uint32_t>(inst.vsrc1.read_scalar(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto s = simd_load64_or<uint64_t>(rs0, base, s_bcast);
+    const auto mask = simd_load_narrow_or<uint32_t>(rm, base, mask_bcast);
+    const auto m = cmp_op(s, mask);
+    uint64_t cmp_bits = 0;
+    for (std::size_t i = 0; i < W; ++i)
+      if (m[i])
+        cmp_bits |= (1ULL << i);
+    vcc = (vcc & ~(chunk << base)) | ((cmp_bits & chunk) << base);
+  }
+  wf.set_vcc(vcc);
+  return true;
+}
+
+/// Unconstrained fallback for the f64 class path; see the binary-path note.
+template <typename Inst, typename CmpOp>
+[[nodiscard]] inline bool try_execute_vopc_class_f64_simd(Inst &, Wavefront &, CmpOp) {
+  return false;
+}
+
+/// VOP3 v_cmp_class_f16/f32 SIMD fast path (32-bit value). The VOP3 form differs
+/// from the VOPC form in three ways, all handled here: (1) the result merges into
+/// an arbitrary SGPR-pair dst via `inst.vdst.read_scalar64`/`write_scalar64`, not
+/// the fixed VCC; (2) the per-instruction `abs`/`neg` source modifiers are applied
+/// to src0's raw bits before classification — `abs` clears the sign bit
+/// (`& ~signmask`), `neg` flips it (`^ signmask`), applied abs-then-neg to match
+/// the scalar body's std::fabs/negate (bit-identical incl. NaN); `signmask` is
+/// passed per op (0x8000 for f16, 0x80000000 for f32, since both share a uint32
+/// lane); (3) the class mask is read from `inst.src1`, not `inst.vsrc1`. The
+/// classify functor is identical to the VOPC class functor (it sees the already
+/// modified bits). Pure bit decode, bit-exact with the scalar body.
+template <typename Inst, typename CmpOp>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_vop3_class_b32_simd(Inst &inst, Wavefront &wf,
+                                                          uint32_t signmask, CmpOp cmp_op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable())
+    return false;
+  using T = uint32_t;
+  constexpr std::size_t W = util::native_width_v<T>;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  const bool do_abs = (inst.inst_.abs & (1u << 0)) != 0;
+  const bool do_neg = (inst.inst_.neg & (1u << 0)) != 0;
+  const auto sm = util::broadcast<T>(signmask);
+  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  // Resolve source base pointers once; see try_execute_binary_vop2_simd. The
+  // class test writes only the SGPR-pair mask, so there is no dst pointer to hoist.
+  const VgprStorage *r0 = simd_src_reg(inst.src0, wf);
+  const VgprStorage *r1 = simd_src_reg(inst.src1, wf);
+  const auto a_bcast = r0 ? util::native<T>{} : util::broadcast<T>(inst.src0.read_scalar(wf));
+  const auto b_bcast = r1 ? util::native<T>{} : util::broadcast<T>(inst.src1.read_scalar(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    auto a = simd_load_or<T>(r0, base, a_bcast);
+    if (do_abs)
+      a = a & ~sm;
+    if (do_neg)
+      a = a ^ sm;
+    const auto b = simd_load_or<T>(r1, base, b_bcast);
+    const auto m = cmp_op(a, b);
+    uint64_t cmp_bits = 0;
+    for (std::size_t i = 0; i < W; ++i)
+      if (m[i])
+        cmp_bits |= (1ULL << i);
+    vcc = (vcc & ~(chunk << base)) | ((cmp_bits & chunk) << base);
+  }
+  inst.vdst.write_scalar64(wf, vcc);
+  return true;
+}
+
+/// Unconstrained fallback for the VOP3 b32 class path; see the binary-path note.
+template <typename Inst, typename CmpOp>
+[[nodiscard]] inline bool try_execute_vop3_class_b32_simd(Inst &, Wavefront &, uint32_t, CmpOp) {
+  return false;
+}
+
+/// VOP3 v_cmp_class_f64 SIMD fast path. The 64-bit-value counterpart of
+/// try_execute_vop3_class_b32_simd: src0 is read as `native<uint64_t>` raw bits
+/// (read_simd64), the class mask as a `narrow32<uint32_t>` from `inst.src1`, and
+/// the result merges into the SGPR-pair dst. abs/neg are applied to the 64-bit raw
+/// bits (signmask 0x8000000000000000). Same VCC-style merge / preservation; same
+/// classify functor as the VOPC f64 class path.
+template <typename Inst, typename CmpOp>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_vop3_class_f64_simd(Inst &inst, Wavefront &wf,
+                                                          uint64_t signmask, CmpOp cmp_op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable())
+    return false;
+  constexpr std::size_t W = util::native_width64;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  const bool do_abs = (inst.inst_.abs & (1u << 0)) != 0;
+  const bool do_neg = (inst.inst_.neg & (1u << 0)) != 0;
+  const auto sm = util::broadcast64<uint64_t>(signmask);
+  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  // Resolve source base pointers once; see try_execute_binary_vop2_simd. The
+  // class test writes only the SGPR-pair mask, so there is no dst pointer to hoist.
+  const ConstVgprStoragePair64 rs0 = simd_src_reg64(inst.src0, wf);
+  const VgprStorage *rm = simd_src_reg(inst.src1, wf);
+  const auto s_bcast =
+      rs0.lo ? util::native<uint64_t>{} : util::broadcast64<uint64_t>(inst.src0.read_scalar64(wf));
+  const auto mask_bcast =
+      rm ? util::narrow32<uint32_t>{} : util::broadcast_narrow<uint32_t>(inst.src1.read_scalar(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    auto s = simd_load64_or<uint64_t>(rs0, base, s_bcast);
+    if (do_abs)
+      s = s & ~sm;
+    if (do_neg)
+      s = s ^ sm;
+    const auto mask = simd_load_narrow_or<uint32_t>(rm, base, mask_bcast);
+    const auto m = cmp_op(s, mask);
+    uint64_t cmp_bits = 0;
+    for (std::size_t i = 0; i < W; ++i)
+      if (m[i])
+        cmp_bits |= (1ULL << i);
+    vcc = (vcc & ~(chunk << base)) | ((cmp_bits & chunk) << base);
+  }
+  inst.vdst.write_scalar64(wf, vcc);
+  return true;
+}
+
+/// Unconstrained fallback for the VOP3 f64 class path; see the binary-path note.
+template <typename Inst, typename CmpOp>
+[[nodiscard]] inline bool try_execute_vop3_class_f64_simd(Inst &, Wavefront &, uint64_t, CmpOp) {
+  return false;
+}
+
+/// VOP3 integer/bitwise binary SIMD fast path. Same shape as
+/// try_execute_binary_vop2_simd but reads the VOP3 operands `src0`/`src1`
+/// (instead of `src0`/`vsrc1`). The generated integer/bitwise VOP3 bodies apply
+/// no source/result modifiers (abs/neg/omod are float-only; clamp on an integer
+/// op means saturate, which these wrap-around/bitwise twins do not request), so
+/// the plain op is bit-identical to the scalar body on every input. T is a
+/// 32-bit integer lane type.
+template <typename T, typename Inst, typename BinOp>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_binary_vop3_simd(Inst &inst, Wavefront &wf, BinOp bin_op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable() ||
+      !inst.vdst.simd_capable())
+    return false;
+  constexpr std::size_t W = util::native_width_v<T>;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  // Resolve operand base pointers once; see try_execute_binary_vop2_simd.
+  const VgprStorage *r0 = simd_src_reg(inst.src0, wf);
+  const VgprStorage *r1 = simd_src_reg(inst.src1, wf);
+  VgprStorage *rd = simd_dst_reg(inst.vdst, wf);
+  const auto a_bcast = r0 ? util::native<T>{} : util::broadcast<T>(inst.src0.read_scalar(wf));
+  const auto b_bcast = r1 ? util::native<T>{} : util::broadcast<T>(inst.src1.read_scalar(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto a = simd_load_or<T>(r0, base, a_bcast);
+    const auto b = simd_load_or<T>(r1, base, b_bcast);
+    const auto r = bin_op(a, b);
+    write_simd_at<T>(rd, inst.vdst, wf, base, r, chunk);
+  }
+  return true;
+}
+
+/// Unconstrained fallback for the VOP3 integer binary path; see the VOP2
+/// binary-path note above.
+template <typename T, typename Inst, typename BinOp>
+[[nodiscard]] inline bool try_execute_binary_vop3_simd(Inst &, Wavefront &, BinOp) {
+  return false;
+}
+
+/// VOP3 f32 binary SIMD fast path. Reads `src0`/`src1`, applies the per-source
+/// abs/neg modifiers, runs `bin_op`, then applies the result omod/clamp — the
+/// exact order of the generated scalar body (abs->neg per source, op,
+/// omod->clamp on the result). The modifier helpers are bit-exact, so unlike the
+/// VOP2 path this fast path stays correct even when modifiers are set; no bail.
+template <typename T, typename Inst, typename BinOp>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_binary_vop3_fp_simd(Inst &inst, Wavefront &wf, BinOp bin_op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable() ||
+      !inst.vdst.simd_capable())
+    return false;
+  const uint32_t abs = inst.inst_.abs;
+  const uint32_t neg = inst.inst_.neg;
+  const uint32_t omod = inst.inst_.omod;
+  const uint32_t clamp = inst.inst_.clamp;
+  constexpr std::size_t W = util::native_width_v<T>;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  // Resolve operand base pointers once; see try_execute_binary_vop2_simd.
+  const VgprStorage *r0 = simd_src_reg(inst.src0, wf);
+  const VgprStorage *r1 = simd_src_reg(inst.src1, wf);
+  VgprStorage *rd = simd_dst_reg(inst.vdst, wf);
+  const auto a_bcast = r0 ? util::native<T>{} : util::broadcast<T>(inst.src0.read_scalar(wf));
+  const auto b_bcast = r1 ? util::native<T>{} : util::broadcast<T>(inst.src1.read_scalar(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto a = apply_vop3_src_mod_f32<0>(simd_load_or<T>(r0, base, a_bcast), abs, neg);
+    const auto b = apply_vop3_src_mod_f32<1>(simd_load_or<T>(r1, base, b_bcast), abs, neg);
+    const auto r = apply_vop3_dst_mod_f32(bin_op(a, b), omod, clamp);
+    write_simd_at<T>(rd, inst.vdst, wf, base, r, chunk);
+  }
+  return true;
+}
+
+/// Unconstrained fallback for the VOP3 f32 binary path.
+template <typename T, typename Inst, typename BinOp>
+[[nodiscard]] inline bool try_execute_binary_vop3_fp_simd(Inst &, Wavefront &, BinOp) {
+  return false;
+}
+
+/// VOP3 integer/bitwise VOPC compare SIMD fast path (32-bit lane). The VOP3 form
+/// of v_cmp_<rel>_<i16|u16|i32|u32> reads src0/src1 (not src0/vsrc1) and writes
+/// the per-lane compare result into an arbitrary SGPR-pair dst via
+/// `inst.vdst.read_scalar64`/`write_scalar64` instead of the fixed VCC. The
+/// integer/bitwise scalar bodies apply no source/result modifiers (abs/neg/omod
+/// are float-only; clamp on integer is unused here), so the plain functor is
+/// bit-identical to the scalar body on every input. Mirrors the VOPC merge:
+/// active EXEC lanes only, inactive SGPR-pair bits preserved. Returns true when
+/// the SIMD path executed.
+template <typename T, typename Inst, typename CmpOp>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_vopc_vop3_int_simd(Inst &inst, Wavefront &wf, CmpOp cmp_op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable())
+    return false;
+  constexpr std::size_t W = util::native_width_v<T>;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  uint64_t dst = inst.vdst.read_scalar64(wf);
+  // Resolve source base pointers once; see try_execute_binary_vop2_simd. The
+  // compare writes only the SGPR-pair mask, so there is no dst pointer to hoist.
+  const VgprStorage *r0 = simd_src_reg(inst.src0, wf);
+  const VgprStorage *r1 = simd_src_reg(inst.src1, wf);
+  const auto a_bcast = r0 ? util::native<T>{} : util::broadcast<T>(inst.src0.read_scalar(wf));
+  const auto b_bcast = r1 ? util::native<T>{} : util::broadcast<T>(inst.src1.read_scalar(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto a = simd_load_or<T>(r0, base, a_bcast);
+    const auto b = simd_load_or<T>(r1, base, b_bcast);
+    const auto m = cmp_op(a, b);
+    uint64_t cmp_bits = 0;
+    for (std::size_t i = 0; i < W; ++i)
+      if (m[i])
+        cmp_bits |= (1ULL << i);
+    dst = (dst & ~(chunk << base)) | ((cmp_bits & chunk) << base);
+  }
+  inst.vdst.write_scalar64(wf, dst);
+  return true;
+}
+
+/// Unconstrained fallback for the VOP3 integer VOPC path; see the binary-path note.
+template <typename T, typename Inst, typename CmpOp>
+[[nodiscard]] inline bool try_execute_vopc_vop3_int_simd(Inst &, Wavefront &, CmpOp) {
+  return false;
+}
+
+/// 64-bit-lane VOP3 integer/bitwise VOPC compare SIMD fast path (i64/u64).
+/// Identical to try_execute_vopc_vop3_int_simd but reads each operand as
+/// `native<T>` (T = int64_t / uint64_t) through the split lo/hi VGPR-pair path
+/// (read_simd64), so it processes `native_width64` lanes per chunk. Same SGPR-pair
+/// merge / preservation. No modifiers.
+template <typename T, typename Inst, typename CmpOp>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_vopc64_vop3_int_simd(Inst &inst, Wavefront &wf,
+                                                           CmpOp cmp_op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable())
+    return false;
+  constexpr std::size_t W = util::native_width64;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  uint64_t dst = inst.vdst.read_scalar64(wf);
+  // Resolve source base pointers once; see try_execute_binary_vop2_simd. The
+  // compare writes only the SGPR-pair mask, so there is no dst pointer to hoist.
+  const ConstVgprStoragePair64 rs0 = simd_src_reg64(inst.src0, wf);
+  const ConstVgprStoragePair64 rs1 = simd_src_reg64(inst.src1, wf);
+  const auto a_bcast =
+      rs0.lo ? util::native<T>{} : util::broadcast64<T>(inst.src0.read_scalar64(wf));
+  const auto b_bcast =
+      rs1.lo ? util::native<T>{} : util::broadcast64<T>(inst.src1.read_scalar64(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto a = simd_load64_or<T>(rs0, base, a_bcast);
+    const auto b = simd_load64_or<T>(rs1, base, b_bcast);
+    const auto m = cmp_op(a, b);
+    uint64_t cmp_bits = 0;
+    for (std::size_t i = 0; i < W; ++i)
+      if (m[i])
+        cmp_bits |= (1ULL << i);
+    dst = (dst & ~(chunk << base)) | ((cmp_bits & chunk) << base);
+  }
+  inst.vdst.write_scalar64(wf, dst);
+  return true;
+}
+
+/// Unconstrained fallback for the 64-bit VOP3 integer VOPC path; see the binary-path note.
+template <typename T, typename Inst, typename CmpOp>
+[[nodiscard]] inline bool try_execute_vopc64_vop3_int_simd(Inst &, Wavefront &, CmpOp) {
+  return false;
+}
+
+/// VOP3 f32 VOPC compare SIMD fast path. Same SGPR-pair-dst merge as the
+/// integer VOP3 path but reads src0/src1 as `native<float>` and applies the
+/// per-source abs/neg VOP3 modifiers — bit-identical to the scalar body which
+/// does `std::fabs` then unary minus per source before comparing. The compare
+/// itself is the existing VOPC f32 functor (omod/clamp are not applied because
+/// the compare result is a single bit, not an f32; the scalar bodies for these
+/// kernels likewise ignore omod/clamp). NaN handling mirrors the scalar
+/// `<`/`==`/etc. exactly. Returns true when the SIMD path executed.
+template <typename Inst, typename CmpOp>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_vopc_vop3_fp32_simd(Inst &inst, Wavefront &wf, CmpOp cmp_op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable())
+    return false;
+  using T = float32_t;
+  const uint32_t abs = inst.inst_.abs;
+  const uint32_t neg = inst.inst_.neg;
+  constexpr std::size_t W = util::native_width_v<T>;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  uint64_t dst = inst.vdst.read_scalar64(wf);
+  // Resolve source base pointers once; see try_execute_binary_vop2_simd. The
+  // compare writes only the SGPR-pair mask, so there is no dst pointer to hoist.
+  const VgprStorage *r0 = simd_src_reg(inst.src0, wf);
+  const VgprStorage *r1 = simd_src_reg(inst.src1, wf);
+  const auto a_bcast = r0 ? util::native<T>{} : util::broadcast<T>(inst.src0.read_scalar(wf));
+  const auto b_bcast = r1 ? util::native<T>{} : util::broadcast<T>(inst.src1.read_scalar(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto a = apply_vop3_src_mod_f32<0>(simd_load_or<T>(r0, base, a_bcast), abs, neg);
+    const auto b = apply_vop3_src_mod_f32<1>(simd_load_or<T>(r1, base, b_bcast), abs, neg);
+    const auto m = cmp_op(a, b);
+    uint64_t cmp_bits = 0;
+    for (std::size_t i = 0; i < W; ++i)
+      if (m[i])
+        cmp_bits |= (1ULL << i);
+    dst = (dst & ~(chunk << base)) | ((cmp_bits & chunk) << base);
+  }
+  inst.vdst.write_scalar64(wf, dst);
+  return true;
+}
+
+/// Unconstrained fallback for the VOP3 f32 VOPC path; see the binary-path note.
+template <typename Inst, typename CmpOp>
+[[nodiscard]] inline bool try_execute_vopc_vop3_fp32_simd(Inst &, Wavefront &, CmpOp) {
+  return false;
+}
+
+/// VOP3 f16 VOPC compare SIMD fast path. The scalar body widens each f16 src
+/// to f32 (`util::f16_to_f32`) and only then applies abs/neg (std::fabs / unary
+/// minus on the f32). The vector path matches that order exactly: read
+/// src0/src1 as raw uint32 lanes (low 16 = f16 bits), widen via
+/// `util::f16_to_f32_simd`, then apply the f32 modifier helper, then call the
+/// compare functor on f32 operands. The compare functor is the same as the f32
+/// VOP3 VOPC one (it takes already-widened, already-modified `native<float>`).
+/// Bit-identical to the scalar body for every input incl. NaN.
+template <typename Inst, typename CmpOp>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_vopc_vop3_fp16_simd(Inst &inst, Wavefront &wf, CmpOp cmp_op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable())
+    return false;
+  using T = uint32_t;
+  const uint32_t abs = inst.inst_.abs;
+  const uint32_t neg = inst.inst_.neg;
+  constexpr std::size_t W = util::native_width_v<T>;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  uint64_t dst = inst.vdst.read_scalar64(wf);
+  // Resolve source base pointers once; see try_execute_binary_vop2_simd. The
+  // compare writes only the SGPR-pair mask, so there is no dst pointer to hoist.
+  const VgprStorage *r0 = simd_src_reg(inst.src0, wf);
+  const VgprStorage *r1 = simd_src_reg(inst.src1, wf);
+  const auto a_bcast = r0 ? util::native<T>{} : util::broadcast<T>(inst.src0.read_scalar(wf));
+  const auto b_bcast = r1 ? util::native<T>{} : util::broadcast<T>(inst.src1.read_scalar(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto a = apply_vop3_src_mod_f32<0>(
+        util::f16_to_f32_simd(simd_load_or<T>(r0, base, a_bcast)), abs, neg);
+    const auto b = apply_vop3_src_mod_f32<1>(
+        util::f16_to_f32_simd(simd_load_or<T>(r1, base, b_bcast)), abs, neg);
+    const auto m = cmp_op(a, b);
+    uint64_t cmp_bits = 0;
+    for (std::size_t i = 0; i < W; ++i)
+      if (m[i])
+        cmp_bits |= (1ULL << i);
+    dst = (dst & ~(chunk << base)) | ((cmp_bits & chunk) << base);
+  }
+  inst.vdst.write_scalar64(wf, dst);
+  return true;
+}
+
+/// Unconstrained fallback for the VOP3 f16 VOPC path; see the binary-path note.
+template <typename Inst, typename CmpOp>
+[[nodiscard]] inline bool try_execute_vopc_vop3_fp16_simd(Inst &, Wavefront &, CmpOp) {
+  return false;
+}
+
+/// VOP3 f64 VOPC compare SIMD fast path. 64-bit-lane counterpart of the f32
+/// path: reads src0/src1 as `native<double>` through the split lo/hi VGPR-pair
+/// path (read_simd64), applies the per-source abs/neg modifiers in the f64
+/// domain (apply_vop3_src_mod_f64; sign-bit AND/XOR — bit-identical incl. NaN
+/// payload), and calls the compare functor on `native<double>` operands. The
+/// SGPR-pair merge is the same VCC-style pack as the other VOP3 VOPC paths,
+/// processed `native_width64` lanes per chunk. Bit-identical to the scalar
+/// body for every input.
+template <typename Inst, typename CmpOp>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_vopc64_vop3_fp64_simd(Inst &inst, Wavefront &wf,
+                                                            CmpOp cmp_op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable())
+    return false;
+  using T = double;
+  const uint32_t abs = inst.inst_.abs;
+  const uint32_t neg = inst.inst_.neg;
+  constexpr std::size_t W = util::native_width64;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  uint64_t dst = inst.vdst.read_scalar64(wf);
+  // Resolve source base pointers once; see try_execute_binary_vop2_simd. The
+  // compare writes only the SGPR-pair mask, so there is no dst pointer to hoist.
+  const ConstVgprStoragePair64 rs0 = simd_src_reg64(inst.src0, wf);
+  const ConstVgprStoragePair64 rs1 = simd_src_reg64(inst.src1, wf);
+  const auto a_bcast =
+      rs0.lo ? util::native<T>{} : util::broadcast64<T>(inst.src0.read_scalar64(wf));
+  const auto b_bcast =
+      rs1.lo ? util::native<T>{} : util::broadcast64<T>(inst.src1.read_scalar64(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto a = apply_vop3_src_mod_f64<0>(simd_load64_or<T>(rs0, base, a_bcast), abs, neg);
+    const auto b = apply_vop3_src_mod_f64<1>(simd_load64_or<T>(rs1, base, b_bcast), abs, neg);
+    const auto m = cmp_op(a, b);
+    uint64_t cmp_bits = 0;
+    for (std::size_t i = 0; i < W; ++i)
+      if (m[i])
+        cmp_bits |= (1ULL << i);
+    dst = (dst & ~(chunk << base)) | ((cmp_bits & chunk) << base);
+  }
+  inst.vdst.write_scalar64(wf, dst);
+  return true;
+}
+
+/// Unconstrained fallback for the VOP3 f64 VOPC path; see the binary-path note.
+template <typename Inst, typename CmpOp>
+[[nodiscard]] inline bool try_execute_vopc64_vop3_fp64_simd(Inst &, Wavefront &, CmpOp) {
+  return false;
+}
+
+/// VOP3 f64 binary SIMD fast path. 64-bit-lane counterpart of
+/// try_execute_binary_vop3_fp_simd: reads src0/src1 as `native<double>` through
+/// the split lo/hi VGPR-pair path (read_simd64), applies the per-source abs/neg
+/// VOP3 modifiers in the f64 domain (apply_vop3_src_mod_f64), runs `bin_op`,
+/// applies the result omod/clamp (apply_vop3_dst_mod_f64), and masked-stores the
+/// result through write_simd64. All modifier helpers are bit-exact, so the fast
+/// path stays correct even with modifiers set; no bail.
+template <typename Inst, typename BinOp>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_binary_vop3_fp64_simd(Inst &inst, Wavefront &wf,
+                                                            BinOp bin_op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable() ||
+      !inst.vdst.simd_capable())
+    return false;
+  using T = double;
+  const uint32_t abs = inst.inst_.abs;
+  const uint32_t neg = inst.inst_.neg;
+  const uint32_t omod = inst.inst_.omod;
+  const uint32_t clamp = inst.inst_.clamp;
+  constexpr std::size_t W = util::native_width64;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  // Resolve operand base pointers once; see try_execute_binary_vop2_simd.
+  const ConstVgprStoragePair64 rs0 = simd_src_reg64(inst.src0, wf);
+  const ConstVgprStoragePair64 rs1 = simd_src_reg64(inst.src1, wf);
+  const VgprStoragePair64 rd64 = simd_dst_reg64(inst.vdst, wf);
+  const auto a_bcast =
+      rs0.lo ? util::native<T>{} : util::broadcast64<T>(inst.src0.read_scalar64(wf));
+  const auto b_bcast =
+      rs1.lo ? util::native<T>{} : util::broadcast64<T>(inst.src1.read_scalar64(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto a = apply_vop3_src_mod_f64<0>(simd_load64_or<T>(rs0, base, a_bcast), abs, neg);
+    const auto b = apply_vop3_src_mod_f64<1>(simd_load64_or<T>(rs1, base, b_bcast), abs, neg);
+    const auto r = apply_vop3_dst_mod_f64(bin_op(a, b), omod, clamp);
+    write_simd64_at<T>(rd64, inst.vdst, wf, base, r, chunk);
+  }
+  return true;
+}
+
+/// Unconstrained fallback for the VOP3 f64 binary path; see the binary-path note.
+template <typename Inst, typename BinOp>
+[[nodiscard]] inline bool try_execute_binary_vop3_fp64_simd(Inst &, Wavefront &, BinOp) {
+  return false;
+}
+
+/// VOP3 f64 unary SIMD fast path. 64-bit-lane counterpart of
+/// try_execute_unary_vop3_fp_simd: reads `src0` as `native<double>`, applies
+/// the src0 abs/neg modifiers (apply_vop3_src_mod_f64), runs `un_op`, applies
+/// the result omod/clamp (apply_vop3_dst_mod_f64). All bit-exact.
+template <typename Inst, typename UnOp>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_unary_vop3_fp64_simd(Inst &inst, Wavefront &wf, UnOp un_op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.vdst.simd_capable())
+    return false;
+  using T = double;
+  const uint32_t abs = inst.inst_.abs;
+  const uint32_t neg = inst.inst_.neg;
+  const uint32_t omod = inst.inst_.omod;
+  const uint32_t clamp = inst.inst_.clamp;
+  constexpr std::size_t W = util::native_width64;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  // Resolve operand base pointers once; see try_execute_binary_vop2_simd.
+  const ConstVgprStoragePair64 rs0 = simd_src_reg64(inst.src0, wf);
+  const VgprStoragePair64 rd64 = simd_dst_reg64(inst.vdst, wf);
+  const auto a_bcast =
+      rs0.lo ? util::native<T>{} : util::broadcast64<T>(inst.src0.read_scalar64(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto a = apply_vop3_src_mod_f64<0>(simd_load64_or<T>(rs0, base, a_bcast), abs, neg);
+    const auto r = apply_vop3_dst_mod_f64(un_op(a), omod, clamp);
+    write_simd64_at<T>(rd64, inst.vdst, wf, base, r, chunk);
+  }
+  return true;
+}
+
+/// Unconstrained fallback for the VOP3 f64 unary path; see the binary-path note.
+template <typename Inst, typename UnOp>
+[[nodiscard]] inline bool try_execute_unary_vop3_fp64_simd(Inst &, Wavefront &, UnOp) {
+  return false;
+}
+
+/// VOP3 f16 unary SIMD fast path. Mirrors the scalar body's
+/// f16_to_f32 -> abs/neg -> op -> omod/clamp -> f32_to_f16 chain:
+/// read raw uint32 lanes (low 16 = f16 bits), widen via util::f16_to_f32_simd,
+/// apply src0 abs/neg in f32, run `un_op` (`native<float> -> native<float>`),
+/// apply omod/clamp in f32, narrow via util::f32_to_f16_simd, write_simd<uint32_t>.
+/// All steps bit-exact per the f16 VOP3 cmp slice's widening probe (f16_to_f32
+/// + f32_to_f16 verified exhaustive incl. NaN payload). High 16 bits of the dst
+/// are written zero (matching write_lane(f32_to_f16(...)) which zero-extends).
+template <typename Inst, typename UnOp>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_unary_vop3_fp16_simd(Inst &inst, Wavefront &wf, UnOp un_op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.vdst.simd_capable())
+    return false;
+  using T = uint32_t;
+  const uint32_t abs = inst.inst_.abs;
+  const uint32_t neg = inst.inst_.neg;
+  const uint32_t omod = inst.inst_.omod;
+  const uint32_t clamp = inst.inst_.clamp;
+  constexpr std::size_t W = util::native_width_v<T>;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  // Resolve operand base pointers once; see try_execute_binary_vop2_simd.
+  const VgprStorage *r0 = simd_src_reg(inst.src0, wf);
+  VgprStorage *rd = simd_dst_reg(inst.vdst, wf);
+  const auto a_bcast = r0 ? util::native<T>{} : util::broadcast<T>(inst.src0.read_scalar(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto in = util::f16_to_f32_simd(simd_load_or<T>(r0, base, a_bcast));
+    const auto a = apply_vop3_src_mod_f32<0>(in, abs, neg);
+    const auto r = apply_vop3_dst_mod_f32(un_op(a), omod, clamp);
+    const auto out = util::f32_to_f16_simd(r);
+    write_simd_at<T>(rd, inst.vdst, wf, base, out, chunk);
+  }
+  return true;
+}
+
+/// Unconstrained fallback for the VOP3 f16 unary path; see the binary-path note.
+template <typename Inst, typename UnOp>
+[[nodiscard]] inline bool try_execute_unary_vop3_fp16_simd(Inst &, Wavefront &, UnOp) {
+  return false;
+}
+
+/// VOP3 integer/bitwise ternary SIMD fast path. Reads `src0`/`src1`/`src2`,
+/// runs `tern_op(a, b, c)`, and masked-stores the result. The generated scalar
+/// bodies for these ternary integer ops apply no source/result modifiers (abs/
+/// neg/omod are float-only; clamp is unused on integer 3-source ops), so the
+/// plain functor is bit-identical to the scalar body. T is a 32-bit integer
+/// lane type (typically uint32_t). Same SIMD-capable / EXEC-chunk loop as the
+/// binary VOP3 path.
+template <typename T, typename Inst, typename TernOp>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_ternary_vop3_simd(Inst &inst, Wavefront &wf, TernOp tern_op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable() ||
+      !inst.src2.simd_capable() || !inst.vdst.simd_capable())
+    return false;
+  constexpr std::size_t W = util::native_width_v<T>;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  // Resolve operand base pointers once; see try_execute_binary_vop2_simd.
+  const VgprStorage *r0 = simd_src_reg(inst.src0, wf);
+  const VgprStorage *r1 = simd_src_reg(inst.src1, wf);
+  const VgprStorage *r2 = simd_src_reg(inst.src2, wf);
+  VgprStorage *rd = simd_dst_reg(inst.vdst, wf);
+  const auto a_bcast = r0 ? util::native<T>{} : util::broadcast<T>(inst.src0.read_scalar(wf));
+  const auto b_bcast = r1 ? util::native<T>{} : util::broadcast<T>(inst.src1.read_scalar(wf));
+  const auto c_bcast = r2 ? util::native<T>{} : util::broadcast<T>(inst.src2.read_scalar(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto a = simd_load_or<T>(r0, base, a_bcast);
+    const auto b = simd_load_or<T>(r1, base, b_bcast);
+    const auto c = simd_load_or<T>(r2, base, c_bcast);
+    const auto r = tern_op(a, b, c);
+    write_simd_at<T>(rd, inst.vdst, wf, base, r, chunk);
+  }
+  return true;
+}
+
+/// Unconstrained fallback for the VOP3 integer ternary path; see binary-path note.
+template <typename T, typename Inst, typename TernOp>
+[[nodiscard]] inline bool try_execute_ternary_vop3_simd(Inst &, Wavefront &, TernOp) {
+  return false;
+}
+
+/// VOP3 f32 ternary SIMD fast path (FMA / MAD family). Reads src0/src1/src2 as
+/// `native<float>`, applies the per-source abs/neg VOP3 modifiers, runs
+/// `tern_op(a, b, c)`, applies the result omod/clamp. NaN-payload divergence
+/// between stdx::fma and std::fma is the standard accepted carve-out (the A/B
+/// test skips NaN-input lanes), same as the existing VOP2 ternary path.
+template <typename Inst, typename FmaOp>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_ternary_vop3_fp_simd(Inst &inst, Wavefront &wf,
+                                                           FmaOp tern_op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable() ||
+      !inst.src2.simd_capable() || !inst.vdst.simd_capable())
+    return false;
+  using T = float32_t;
+  const uint32_t abs = inst.inst_.abs;
+  const uint32_t neg = inst.inst_.neg;
+  const uint32_t omod = inst.inst_.omod;
+  const uint32_t clamp = inst.inst_.clamp;
+  constexpr std::size_t W = util::native_width_v<T>;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  // Resolve operand base pointers once; see try_execute_binary_vop2_simd.
+  const VgprStorage *r0 = simd_src_reg(inst.src0, wf);
+  const VgprStorage *r1 = simd_src_reg(inst.src1, wf);
+  const VgprStorage *r2 = simd_src_reg(inst.src2, wf);
+  VgprStorage *rd = simd_dst_reg(inst.vdst, wf);
+  const auto a_bcast = r0 ? util::native<T>{} : util::broadcast<T>(inst.src0.read_scalar(wf));
+  const auto b_bcast = r1 ? util::native<T>{} : util::broadcast<T>(inst.src1.read_scalar(wf));
+  const auto c_bcast = r2 ? util::native<T>{} : util::broadcast<T>(inst.src2.read_scalar(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto a = apply_vop3_src_mod_f32<0>(simd_load_or<T>(r0, base, a_bcast), abs, neg);
+    const auto b = apply_vop3_src_mod_f32<1>(simd_load_or<T>(r1, base, b_bcast), abs, neg);
+    const auto c = apply_vop3_src_mod_f32<2>(simd_load_or<T>(r2, base, c_bcast), abs, neg);
+    const auto r = apply_vop3_dst_mod_f32(tern_op(a, b, c), omod, clamp);
+    write_simd_at<T>(rd, inst.vdst, wf, base, r, chunk);
+  }
+  return true;
+}
+
+template <typename Inst, typename FmaOp>
+[[nodiscard]] inline bool try_execute_ternary_vop3_fp_simd(Inst &, Wavefront &, FmaOp) {
+  return false;
+}
+
+/// VOP3 f16 ternary SIMD fast path. Mirrors the scalar f16 chain across three
+/// sources: widen each via util::f16_to_f32_simd, apply f32 abs/neg, run
+/// `tern_op` on native<float>, apply omod/clamp, narrow via f32_to_f16_simd.
+template <typename Inst, typename FmaOp>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_ternary_vop3_fp16_simd(Inst &inst, Wavefront &wf,
+                                                             FmaOp tern_op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable() ||
+      !inst.src2.simd_capable() || !inst.vdst.simd_capable())
+    return false;
+  using T = uint32_t;
+  const uint32_t abs = inst.inst_.abs;
+  const uint32_t neg = inst.inst_.neg;
+  const uint32_t omod = inst.inst_.omod;
+  const uint32_t clamp = inst.inst_.clamp;
+  constexpr std::size_t W = util::native_width_v<T>;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  // Resolve operand base pointers once; see try_execute_binary_vop2_simd.
+  const VgprStorage *r0 = simd_src_reg(inst.src0, wf);
+  const VgprStorage *r1 = simd_src_reg(inst.src1, wf);
+  const VgprStorage *r2 = simd_src_reg(inst.src2, wf);
+  VgprStorage *rd = simd_dst_reg(inst.vdst, wf);
+  const auto a_bcast = r0 ? util::native<T>{} : util::broadcast<T>(inst.src0.read_scalar(wf));
+  const auto b_bcast = r1 ? util::native<T>{} : util::broadcast<T>(inst.src1.read_scalar(wf));
+  const auto c_bcast = r2 ? util::native<T>{} : util::broadcast<T>(inst.src2.read_scalar(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto a = apply_vop3_src_mod_f32<0>(
+        util::f16_to_f32_simd(simd_load_or<T>(r0, base, a_bcast)), abs, neg);
+    const auto b = apply_vop3_src_mod_f32<1>(
+        util::f16_to_f32_simd(simd_load_or<T>(r1, base, b_bcast)), abs, neg);
+    const auto c = apply_vop3_src_mod_f32<2>(
+        util::f16_to_f32_simd(simd_load_or<T>(r2, base, c_bcast)), abs, neg);
+    const auto r = apply_vop3_dst_mod_f32(tern_op(a, b, c), omod, clamp);
+    const auto out = util::f32_to_f16_simd(r);
+    write_simd_at<T>(rd, inst.vdst, wf, base, out, chunk);
+  }
+  return true;
+}
+
+template <typename Inst, typename FmaOp>
+[[nodiscard]] inline bool try_execute_ternary_vop3_fp16_simd(Inst &, Wavefront &, FmaOp) {
+  return false;
+}
+
+/// VOP3 f64 ternary SIMD fast path. 64-bit-lane counterpart: read src0/src1/src2
+/// via read_simd64<double>, apply abs/neg in f64, run `tern_op`, apply
+/// omod/clamp, write_simd64.
+template <typename Inst, typename FmaOp>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_ternary_vop3_fp64_simd(Inst &inst, Wavefront &wf,
+                                                             FmaOp tern_op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable() ||
+      !inst.src2.simd_capable() || !inst.vdst.simd_capable())
+    return false;
+  using T = double;
+  const uint32_t abs = inst.inst_.abs;
+  const uint32_t neg = inst.inst_.neg;
+  const uint32_t omod = inst.inst_.omod;
+  const uint32_t clamp = inst.inst_.clamp;
+  constexpr std::size_t W = util::native_width64;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  // Resolve operand base pointers once; see try_execute_binary_vop2_simd.
+  const ConstVgprStoragePair64 rs0 = simd_src_reg64(inst.src0, wf);
+  const ConstVgprStoragePair64 rs1 = simd_src_reg64(inst.src1, wf);
+  const ConstVgprStoragePair64 rs2 = simd_src_reg64(inst.src2, wf);
+  const VgprStoragePair64 rd64 = simd_dst_reg64(inst.vdst, wf);
+  const auto a_bcast =
+      rs0.lo ? util::native<T>{} : util::broadcast64<T>(inst.src0.read_scalar64(wf));
+  const auto b_bcast =
+      rs1.lo ? util::native<T>{} : util::broadcast64<T>(inst.src1.read_scalar64(wf));
+  const auto c_bcast =
+      rs2.lo ? util::native<T>{} : util::broadcast64<T>(inst.src2.read_scalar64(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto a = apply_vop3_src_mod_f64<0>(simd_load64_or<T>(rs0, base, a_bcast), abs, neg);
+    const auto b = apply_vop3_src_mod_f64<1>(simd_load64_or<T>(rs1, base, b_bcast), abs, neg);
+    const auto c = apply_vop3_src_mod_f64<2>(simd_load64_or<T>(rs2, base, c_bcast), abs, neg);
+    const auto r = apply_vop3_dst_mod_f64(tern_op(a, b, c), omod, clamp);
+    write_simd64_at<T>(rd64, inst.vdst, wf, base, r, chunk);
+  }
+  return true;
+}
+
+template <typename Inst, typename FmaOp>
+[[nodiscard]] inline bool try_execute_ternary_vop3_fp64_simd(Inst &, Wavefront &, FmaOp) {
+  return false;
+}
+
+/// VOP3 dst-accumulate FMA fast path (f32). Counterpart of
+/// try_execute_ternary_vop3_fp_simd for the v_fmac / v_mac family, where the
+/// third FMA operand IS the destination register (no separate src2 Operand
+/// in the per-isa codegen class). The scalar body reads vdst as the
+/// accumulator without applying abs/neg to it (per scalar; verified for
+/// v_fmac_f32_vop3 + v_mac_f32_vop3). SIMD mirrors: read inst.vdst as the
+/// third operand, apply abs/neg to src0/src1 only, run `tern_op`, apply
+/// result omod/clamp, masked-store back to inst.vdst (overwriting accumulator).
+template <typename Inst, typename FmaOp>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_fmac_vop3_fp_simd(Inst &inst, Wavefront &wf, FmaOp tern_op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable() ||
+      !inst.vdst.simd_capable())
+    return false;
+  using T = float32_t;
+  const uint32_t abs = inst.inst_.abs;
+  const uint32_t neg = inst.inst_.neg;
+  const uint32_t omod = inst.inst_.omod;
+  const uint32_t clamp = inst.inst_.clamp;
+  constexpr std::size_t W = util::native_width_v<T>;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  // Resolve operand base pointers once; see try_execute_binary_vop2_simd. vdst
+  // is both the third (accumulator) source and the destination — one pointer.
+  const VgprStorage *r0 = simd_src_reg(inst.src0, wf);
+  const VgprStorage *r1 = simd_src_reg(inst.src1, wf);
+  VgprStorage *rd = simd_dst_reg(inst.vdst, wf);
+  const auto a_bcast = r0 ? util::native<T>{} : util::broadcast<T>(inst.src0.read_scalar(wf));
+  const auto b_bcast = r1 ? util::native<T>{} : util::broadcast<T>(inst.src1.read_scalar(wf));
+  const auto c_bcast = rd ? util::native<T>{} : util::broadcast<T>(inst.vdst.read_scalar(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto a = apply_vop3_src_mod_f32<0>(simd_load_or<T>(r0, base, a_bcast), abs, neg);
+    const auto b = apply_vop3_src_mod_f32<1>(simd_load_or<T>(r1, base, b_bcast), abs, neg);
+    const auto c = simd_load_or<T>(rd, base, c_bcast); // accumulator, NO modifier
+    const auto r = apply_vop3_dst_mod_f32(tern_op(a, b, c), omod, clamp);
+    write_simd_at<T>(rd, inst.vdst, wf, base, r, chunk);
+  }
+  return true;
+}
+
+template <typename Inst, typename FmaOp>
+[[nodiscard]] inline bool try_execute_fmac_vop3_fp_simd(Inst &, Wavefront &, FmaOp) {
+  return false;
+}
+
+/// VOP3 dst-accumulate FMA fast path (f16). f16 widen chain across src0/src1
+/// + vdst (accumulator). NO abs/neg on accumulator (per scalar).
+template <typename Inst, typename FmaOp>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_fmac_vop3_fp16_simd(Inst &inst, Wavefront &wf,
+                                                          FmaOp tern_op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable() ||
+      !inst.vdst.simd_capable())
+    return false;
+  using T = uint32_t;
+  const uint32_t abs = inst.inst_.abs;
+  const uint32_t neg = inst.inst_.neg;
+  const uint32_t omod = inst.inst_.omod;
+  const uint32_t clamp = inst.inst_.clamp;
+  constexpr std::size_t W = util::native_width_v<T>;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  // Resolve operand base pointers once; see try_execute_binary_vop2_simd. vdst
+  // is both the third (accumulate) source and the destination — one pointer.
+  const VgprStorage *r0 = simd_src_reg(inst.src0, wf);
+  const VgprStorage *r1 = simd_src_reg(inst.src1, wf);
+  VgprStorage *rd = simd_dst_reg(inst.vdst, wf);
+  const auto a_bcast = r0 ? util::native<T>{} : util::broadcast<T>(inst.src0.read_scalar(wf));
+  const auto b_bcast = r1 ? util::native<T>{} : util::broadcast<T>(inst.src1.read_scalar(wf));
+  const auto c_bcast = rd ? util::native<T>{} : util::broadcast<T>(inst.vdst.read_scalar(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto a = apply_vop3_src_mod_f32<0>(
+        util::f16_to_f32_simd(simd_load_or<T>(r0, base, a_bcast)), abs, neg);
+    const auto b = apply_vop3_src_mod_f32<1>(
+        util::f16_to_f32_simd(simd_load_or<T>(r1, base, b_bcast)), abs, neg);
+    const auto c = util::f16_to_f32_simd(simd_load_or<T>(rd, base, c_bcast)); // accum, no mod
+    const auto r = apply_vop3_dst_mod_f32(tern_op(a, b, c), omod, clamp);
+    const auto out = util::f32_to_f16_simd(r);
+    write_simd_at<T>(rd, inst.vdst, wf, base, out, chunk);
+  }
+  return true;
+}
+
+template <typename Inst, typename FmaOp>
+[[nodiscard]] inline bool try_execute_fmac_vop3_fp16_simd(Inst &, Wavefront &, FmaOp) {
+  return false;
+}
+
+/// VOP3 dst-accumulate FMA fast path (f64).
+template <typename Inst, typename FmaOp>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_fmac_vop3_fp64_simd(Inst &inst, Wavefront &wf,
+                                                          FmaOp tern_op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable() ||
+      !inst.vdst.simd_capable())
+    return false;
+  using T = double;
+  const uint32_t abs = inst.inst_.abs;
+  const uint32_t neg = inst.inst_.neg;
+  const uint32_t omod = inst.inst_.omod;
+  const uint32_t clamp = inst.inst_.clamp;
+  constexpr std::size_t W = util::native_width64;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  // Resolve operand base pointers once; see try_execute_binary_vop2_simd. vdst
+  // is both the accumulator source and the destination — one lo/hi pair.
+  const ConstVgprStoragePair64 rs0 = simd_src_reg64(inst.src0, wf);
+  const ConstVgprStoragePair64 rs1 = simd_src_reg64(inst.src1, wf);
+  const VgprStoragePair64 rd64 = simd_dst_reg64(inst.vdst, wf);
+  const auto a_bcast =
+      rs0.lo ? util::native<T>{} : util::broadcast64<T>(inst.src0.read_scalar64(wf));
+  const auto b_bcast =
+      rs1.lo ? util::native<T>{} : util::broadcast64<T>(inst.src1.read_scalar64(wf));
+  const auto c_bcast =
+      rd64.lo ? util::native<T>{} : util::broadcast64<T>(inst.vdst.read_scalar64(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto a = apply_vop3_src_mod_f64<0>(simd_load64_or<T>(rs0, base, a_bcast), abs, neg);
+    const auto b = apply_vop3_src_mod_f64<1>(simd_load64_or<T>(rs1, base, b_bcast), abs, neg);
+    const auto c = simd_load64_or<T>(rd64, base, c_bcast); // accumulator, no mod
+    const auto r = apply_vop3_dst_mod_f64(tern_op(a, b, c), omod, clamp);
+    write_simd64_at<T>(rd64, inst.vdst, wf, base, r, chunk);
+  }
+  return true;
+}
+
+template <typename Inst, typename FmaOp>
+[[nodiscard]] inline bool try_execute_fmac_vop3_fp64_simd(Inst &, Wavefront &, FmaOp) {
+  return false;
+}
+
+/// VOP3 mixed-width ldexp fast path (f32 = std::ldexp(f32 src0, int32 src1)).
+/// Reads src0 as native<float>, applies src0 abs/neg in f32, reads src1 as
+/// native<int32_t> (per-lane exponent), runs `op(a, e)` (stdx::ldexp), applies
+/// result omod/clamp, write_simd. stdx::ldexp is bit-exact to std::ldexp for
+/// every input incl. NaN (proven via the VOP2 v_ldexp_f16 path).
+template <typename Inst, typename Op>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_ldexp_vop3_fp32_simd(Inst &inst, Wavefront &wf, Op op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable() ||
+      !inst.vdst.simd_capable())
+    return false;
+  using T = float32_t;
+  const uint32_t abs = inst.inst_.abs;
+  const uint32_t neg = inst.inst_.neg;
+  const uint32_t omod = inst.inst_.omod;
+  const uint32_t clamp = inst.inst_.clamp;
+  constexpr std::size_t W = util::native_width_v<T>;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  // Resolve operand base pointers once; see try_execute_binary_vop2_simd.
+  const VgprStorage *r0 = simd_src_reg(inst.src0, wf);
+  const VgprStorage *re = simd_src_reg(inst.src1, wf);
+  VgprStorage *rd = simd_dst_reg(inst.vdst, wf);
+  const auto a_bcast = r0 ? util::native<T>{} : util::broadcast<T>(inst.src0.read_scalar(wf));
+  const auto e_bcast =
+      re ? util::native<int32_t>{} : util::broadcast<int32_t>(inst.src1.read_scalar(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto a = apply_vop3_src_mod_f32<0>(simd_load_or<T>(r0, base, a_bcast), abs, neg);
+    const auto e = simd_load_or<int32_t>(re, base, e_bcast);
+    const auto r = apply_vop3_dst_mod_f32(op(a, e), omod, clamp);
+    write_simd_at<T>(rd, inst.vdst, wf, base, r, chunk);
+  }
+  return true;
+}
+
+template <typename Inst, typename Op>
+[[nodiscard]] inline bool try_execute_ldexp_vop3_fp32_simd(Inst &, Wavefront &, Op) {
+  return false;
+}
+
+/// VOP3 mixed-width ldexp fast path (f64 = std::ldexp(f64 src0, int32 src1)).
+/// Reads src0 as native<double> via read_simd64, applies src0 abs/neg in f64,
+/// reads src1 as narrow32<int32_t> (native_width64-wide), runs `op(a, e)`,
+/// applies result omod/clamp, write_simd64.
+template <typename Inst, typename Op>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_ldexp_vop3_fp64_simd(Inst &inst, Wavefront &wf, Op op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable() ||
+      !inst.vdst.simd_capable())
+    return false;
+  using T = double;
+  const uint32_t abs = inst.inst_.abs;
+  const uint32_t neg = inst.inst_.neg;
+  const uint32_t omod = inst.inst_.omod;
+  const uint32_t clamp = inst.inst_.clamp;
+  constexpr std::size_t W = util::native_width64;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  // Resolve operand base pointers once; see try_execute_binary_vop2_simd.
+  const ConstVgprStoragePair64 rs0 = simd_src_reg64(inst.src0, wf);
+  const VgprStorage *re = simd_src_reg(inst.src1, wf);
+  const VgprStoragePair64 rd64 = simd_dst_reg64(inst.vdst, wf);
+  const auto a_bcast =
+      rs0.lo ? util::native<T>{} : util::broadcast64<T>(inst.src0.read_scalar64(wf));
+  const auto e_bcast =
+      re ? util::narrow32<int32_t>{} : util::broadcast_narrow<int32_t>(inst.src1.read_scalar(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto a = apply_vop3_src_mod_f64<0>(simd_load64_or<T>(rs0, base, a_bcast), abs, neg);
+    const auto e = simd_load_narrow_or<int32_t>(re, base, e_bcast);
+    const auto r = apply_vop3_dst_mod_f64(op(a, e), omod, clamp);
+    write_simd64_at<T>(rd64, inst.vdst, wf, base, r, chunk);
+  }
+  return true;
+}
+
+template <typename Inst, typename Op>
+[[nodiscard]] inline bool try_execute_ldexp_vop3_fp64_simd(Inst &, Wavefront &, Op) {
+  return false;
+}
+
+/// VOP3 f32 unary SIMD fast path. Reads `src0` as f32, applies the src0 abs/neg
+/// modifiers, runs `un_op` (`native<float> -> native<float>`), then applies the
+/// result omod/clamp — the scalar body's order (abs->neg, op, omod->clamp). Tin
+/// and Tout are both float32_t (the plain int/cvt unary VOP3 forms apply no
+/// modifiers and reuse the VOP1 unary path directly). The modifier helpers are
+/// bit-exact, so the fast path stays correct with modifiers set; no bail.
+template <typename Tin, typename Tout, typename Inst, typename UnOp>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_unary_vop3_fp_simd(Inst &inst, Wavefront &wf, UnOp un_op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.vdst.simd_capable())
+    return false;
+  const uint32_t abs = inst.inst_.abs;
+  const uint32_t neg = inst.inst_.neg;
+  const uint32_t omod = inst.inst_.omod;
+  const uint32_t clamp = inst.inst_.clamp;
+  constexpr std::size_t W = util::native_width_v<Tout>;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  // Resolve operand base pointers once; see try_execute_binary_vop2_simd.
+  const VgprStorage *r0 = simd_src_reg(inst.src0, wf);
+  VgprStorage *rd = simd_dst_reg(inst.vdst, wf);
+  const auto a_bcast = r0 ? util::native<Tin>{} : util::broadcast<Tin>(inst.src0.read_scalar(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto a = apply_vop3_src_mod_f32<0>(simd_load_or<Tin>(r0, base, a_bcast), abs, neg);
+    const auto r = apply_vop3_dst_mod_f32(un_op(a), omod, clamp);
+    write_simd_at<Tout>(rd, inst.vdst, wf, base, r, chunk);
+  }
+  return true;
+}
+
+/// Unconstrained fallback for the VOP3 f32 unary path.
+template <typename Tin, typename Tout, typename Inst, typename UnOp>
+[[nodiscard]] inline bool try_execute_unary_vop3_fp_simd(Inst &, Wavefront &, UnOp) {
+  return false;
+}
+
+/// v_div_fixup_f32 SIMD helper. Mirrors the scalar `else if` cascade
+/// (execute_shared.h:execute_v_div_fixup_f32_vop3): given three already-
+/// modified f32 operands `p` (the fma scaffold input), `b` (numerator), and
+/// `c` (denominator), pick the result among NaN/Inf/zero copysign cases
+/// according to AMD's div_fixup ULP table. The cascade is applied lowest-
+/// priority first so that the higher-priority `where` blends overwrite —
+/// equivalent to scalar's first-match `else if`. The sign-of-quotient
+/// `b ^ c` is computed once in the integer domain and reinterpreted as
+/// float, matching the scalar's `bit_cast<float>(bits(b) ^ bits(c))`. Both
+/// `std::copysign(Inf, bxc)` and `std::copysign(0, bxc)` reduce to
+/// `stdx::copysign(target, bxc)`.
+inline util::native<float> div_fixup_f32_simd(util::native<float> p, util::native<float> b,
+                                              util::native<float> c) {
+  using F = util::native<float>;
+  using U = util::native<uint32_t>;
+  const auto bxc = std::bit_cast<F>(std::bit_cast<U>(b) ^ std::bit_cast<U>(c));
+  const auto inf_val = util::stdx::copysign(F(std::numeric_limits<float>::infinity()), bxc);
+  const auto zero_val = util::stdx::copysign(F(0.0f), bxc);
+  const auto qnan = F(std::numeric_limits<float>::quiet_NaN());
+  const auto b_nan = util::stdx::isnan(b);
+  const auto c_nan = util::stdx::isnan(c);
+  const auto b_inf = util::stdx::isinf(b);
+  const auto c_inf = util::stdx::isinf(c);
+  const auto b_zero = (b == F(0.0f));
+  const auto c_zero = (c == F(0.0f));
+  F r = p;
+  util::stdx::where(b_inf, r) = zero_val;
+  util::stdx::where(c_inf, r) = inf_val;
+  util::stdx::where(c_zero, r) = zero_val;
+  util::stdx::where(b_zero, r) = inf_val;
+  util::stdx::where(b_inf && c_inf, r) = qnan;
+  util::stdx::where(b_zero && c_zero, r) = qnan;
+  util::stdx::where(c_nan, r) = c;
+  util::stdx::where(b_nan, r) = b;
+  return r;
+}
+
+/// f64 counterpart of div_fixup_f32_simd — same cascade, 64-bit-lane domain.
+inline util::native<double> div_fixup_f64_simd(util::native<double> p, util::native<double> b,
+                                               util::native<double> c) {
+  using D = util::native<double>;
+  using U = util::native<uint64_t>;
+  const auto bxc = std::bit_cast<D>(std::bit_cast<U>(b) ^ std::bit_cast<U>(c));
+  const auto inf_val = util::stdx::copysign(D(std::numeric_limits<double>::infinity()), bxc);
+  const auto zero_val = util::stdx::copysign(D(0.0), bxc);
+  const auto qnan = D(std::numeric_limits<double>::quiet_NaN());
+  const auto b_nan = util::stdx::isnan(b);
+  const auto c_nan = util::stdx::isnan(c);
+  const auto b_inf = util::stdx::isinf(b);
+  const auto c_inf = util::stdx::isinf(c);
+  const auto b_zero = (b == D(0.0));
+  const auto c_zero = (c == D(0.0));
+  D r = p;
+  util::stdx::where(b_inf, r) = zero_val;
+  util::stdx::where(c_inf, r) = inf_val;
+  util::stdx::where(c_zero, r) = zero_val;
+  util::stdx::where(b_zero, r) = inf_val;
+  util::stdx::where(b_inf && c_inf, r) = qnan;
+  util::stdx::where(b_zero && c_zero, r) = qnan;
+  util::stdx::where(c_nan, r) = c;
+  util::stdx::where(b_nan, r) = b;
+  return r;
+}
+
+/// VOP3 div_fmas SIMD fast path (f32). The scalar body is `fma(s0, s1, s2)`
+/// followed by a per-lane `ldexp(result, 32)` gated by the VCC bit; no
+/// omod/clamp are applied (the encoded modifier fields are intentionally
+/// ignored). Per-source abs/neg modifiers ARE applied (matching scalar).
+/// This is a dedicated glue (rather than routing through the existing
+/// ternary fp glue) because the omod/clamp policy differs and the VCC-
+/// driven ldexp gate is unique to div_fmas. NaN-input lanes skipped by test
+/// (gcc-13 packed FMA quiets a different NaN operand vs scalar std::fma —
+/// same accepted carve-out as the rest of the ternary fp suite).
+template <typename Inst>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_div_fmas_f32_simd(Inst &inst, Wavefront &wf) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable() ||
+      !inst.src2.simd_capable() || !inst.vdst.simd_capable())
+    return false;
+  using T = float32_t;
+  const uint32_t abs = inst.inst_.abs;
+  const uint32_t neg = inst.inst_.neg;
+  constexpr std::size_t W = util::native_width_v<T>;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  const uint64_t vcc = wf.vcc();
+  using IExp = util::stdx::fixed_size_simd<int, util::native<float>::size()>;
+  const IExp shift_32 = IExp(32);
+  // Resolve operand base pointers once; see try_execute_binary_vop2_simd.
+  const VgprStorage *r0 = simd_src_reg(inst.src0, wf);
+  const VgprStorage *r1 = simd_src_reg(inst.src1, wf);
+  const VgprStorage *r2 = simd_src_reg(inst.src2, wf);
+  VgprStorage *rd = simd_dst_reg(inst.vdst, wf);
+  const auto a_bcast = r0 ? util::native<T>{} : util::broadcast<T>(inst.src0.read_scalar(wf));
+  const auto b_bcast = r1 ? util::native<T>{} : util::broadcast<T>(inst.src1.read_scalar(wf));
+  const auto c_bcast = r2 ? util::native<T>{} : util::broadcast<T>(inst.src2.read_scalar(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto a = apply_vop3_src_mod_f32<0>(simd_load_or<T>(r0, base, a_bcast), abs, neg);
+    const auto b = apply_vop3_src_mod_f32<1>(simd_load_or<T>(r1, base, b_bcast), abs, neg);
+    const auto c = apply_vop3_src_mod_f32<2>(simd_load_or<T>(r2, base, c_bcast), abs, neg);
+    auto r = util::stdx::fma(a, b, c);
+    const auto scaled = util::stdx::ldexp(r, shift_32);
+    const uint64_t sel_bits = (vcc >> base) & chunk_full;
+    alignas(util::native<uint32_t>) uint32_t selbuf[W];
+    for (std::size_t i = 0; i < W; ++i)
+      selbuf[i] = static_cast<uint32_t>((sel_bits >> i) & 1u);
+    const auto vcc_mask_u = util::load<uint32_t>(selbuf) != 0u;
+    util::stdx::where(simd_mask_as<float>(vcc_mask_u), r) = scaled;
+    write_simd_at<T>(rd, inst.vdst, wf, base, r, chunk);
+  }
+  return true;
+}
+
+template <typename Inst>
+[[nodiscard]] inline bool try_execute_div_fmas_f32_simd(Inst &, Wavefront &) {
+  return false;
+}
+
+/// f64 counterpart of try_execute_div_fmas_f32_simd. Same VCC-gated ldexp
+/// shape with shift=64 (per AMD spec for div_fmas_f64). 64-bit-lane reads,
+/// abs/neg in f64 domain via apply_vop3_src_mod_f64.
+template <typename Inst>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_div_fmas_f64_simd(Inst &inst, Wavefront &wf) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable() ||
+      !inst.src2.simd_capable() || !inst.vdst.simd_capable())
+    return false;
+  using T = double;
+  const uint32_t abs = inst.inst_.abs;
+  const uint32_t neg = inst.inst_.neg;
+  constexpr std::size_t W = util::native_width64;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  const uint64_t vcc = wf.vcc();
+  using IExp = util::stdx::fixed_size_simd<int, util::native_width64>;
+  const IExp shift_64 = IExp(64);
+  // Resolve operand base pointers once; see try_execute_binary_vop2_simd.
+  const ConstVgprStoragePair64 rs0 = simd_src_reg64(inst.src0, wf);
+  const ConstVgprStoragePair64 rs1 = simd_src_reg64(inst.src1, wf);
+  const ConstVgprStoragePair64 rs2 = simd_src_reg64(inst.src2, wf);
+  const VgprStoragePair64 rd64 = simd_dst_reg64(inst.vdst, wf);
+  const auto a_bcast =
+      rs0.lo ? util::native<T>{} : util::broadcast64<T>(inst.src0.read_scalar64(wf));
+  const auto b_bcast =
+      rs1.lo ? util::native<T>{} : util::broadcast64<T>(inst.src1.read_scalar64(wf));
+  const auto c_bcast =
+      rs2.lo ? util::native<T>{} : util::broadcast64<T>(inst.src2.read_scalar64(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto a = apply_vop3_src_mod_f64<0>(simd_load64_or<T>(rs0, base, a_bcast), abs, neg);
+    const auto b = apply_vop3_src_mod_f64<1>(simd_load64_or<T>(rs1, base, b_bcast), abs, neg);
+    const auto c = apply_vop3_src_mod_f64<2>(simd_load64_or<T>(rs2, base, c_bcast), abs, neg);
+    auto r = util::stdx::fma(a, b, c);
+    const auto scaled = util::stdx::ldexp(r, shift_64);
+    // VCC mask built directly in the f64 abi via a generator; avoids a
+    // cross-abi mask cast (the f32 path can ride load+simd_mask_as because
+    // native<uint32_t> shares abi with native<float>, but native<uint64_t>
+    // does not match native<double>::abi on AVX-512).
+    const uint64_t vcc_chunk = vcc >> base;
+    const auto vcc_mask = util::native<double>([&](std::size_t i) {
+                            return ((vcc_chunk >> i) & 1ULL) ? 1.0 : 0.0;
+                          }) != 0.0;
+    util::stdx::where(vcc_mask, r) = scaled;
+    write_simd64_at<T>(rd64, inst.vdst, wf, base, r, chunk);
+  }
+  return true;
+}
+
+template <typename Inst>
+[[nodiscard]] inline bool try_execute_div_fmas_f64_simd(Inst &, Wavefront &) {
+  return false;
+}
+
+/// VOP3 64-bit-lane reverse-shift fast path (v_lshlrev_b64 / v_lshrrev_b64 /
+/// v_ashrrev_i64). The shift amount is a 32-bit src0 (read as a native_width64
+/// narrow lane, widened to 64-bit and masked to [0,63]); the shifted value is
+/// the 64-bit src1; the result is 64-bit. `shift_op(value, shift)` receives both
+/// as `native<uint64_t>` (shift already widened+masked), so the functor is a
+/// plain `v << sh` / `v >> sh` (logical) or an arithmetic-shift cast for the
+/// signed form — bit-identical to the scalar body's `& 63u` shift.
+template <typename Inst, typename ShiftOp>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_shift64_vop3_simd(Inst &inst, Wavefront &wf,
+                                                        ShiftOp shift_op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable() ||
+      !inst.vdst.simd_capable())
+    return false;
+  constexpr std::size_t W = util::native_width64;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  // src0 = 32-bit shift amount (narrow lane), src1 = 64-bit value, dst = 64-bit.
+  const VgprStorage *rs = simd_src_reg(inst.src0, wf);
+  const ConstVgprStoragePair64 rs1 = simd_src_reg64(inst.src1, wf);
+  const VgprStoragePair64 rd64 = simd_dst_reg64(inst.vdst, wf);
+  const auto s_bcast =
+      rs ? util::narrow32<uint32_t>{} : util::broadcast_narrow<uint32_t>(inst.src0.read_scalar(wf));
+  const auto v_bcast =
+      rs1.lo ? util::native<uint64_t>{} : util::broadcast64<uint64_t>(inst.src1.read_scalar64(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto s = simd_load_narrow_or<uint32_t>(rs, base, s_bcast);
+    const auto v = simd_load64_or<uint64_t>(rs1, base, v_bcast);
+    const auto sh = util::stdx::static_simd_cast<util::native<uint64_t>>(s) & 63ull;
+    write_simd64_at<uint64_t>(rd64, inst.vdst, wf, base, shift_op(v, sh), chunk);
+  }
+  return true;
+}
+template <typename Inst, typename ShiftOp>
+[[nodiscard]] inline bool try_execute_shift64_vop3_simd(Inst &, Wavefront &, ShiftOp) {
+  return false;
+}
+
+/// VOP3 v_lshl_add_u64 fast path: dst = (src0 << (src1 & 63)) + src2, all 64-bit
+/// except the 32-bit shift amount src1. The scalar body shifts by the raw src1
+/// (C++ UB at >=64, but x86 masks the count to 6 bits); masking to 63 here
+/// reproduces that x86 scalar result for every shift value.
+template <typename Inst>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_lshl_add_u64_simd(Inst &inst, Wavefront &wf) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable() ||
+      !inst.src2.simd_capable() || !inst.vdst.simd_capable())
+    return false;
+  constexpr std::size_t W = util::native_width64;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  // src0 = 64-bit value, src1 = 32-bit shift (narrow), src2 = 64-bit addend.
+  const ConstVgprStoragePair64 rs0 = simd_src_reg64(inst.src0, wf);
+  const VgprStorage *rs = simd_src_reg(inst.src1, wf);
+  const ConstVgprStoragePair64 rs2 = simd_src_reg64(inst.src2, wf);
+  const VgprStoragePair64 rd64 = simd_dst_reg64(inst.vdst, wf);
+  const auto v_bcast =
+      rs0.lo ? util::native<uint64_t>{} : util::broadcast64<uint64_t>(inst.src0.read_scalar64(wf));
+  const auto s_bcast =
+      rs ? util::narrow32<uint32_t>{} : util::broadcast_narrow<uint32_t>(inst.src1.read_scalar(wf));
+  const auto c_bcast =
+      rs2.lo ? util::native<uint64_t>{} : util::broadcast64<uint64_t>(inst.src2.read_scalar64(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto v = simd_load64_or<uint64_t>(rs0, base, v_bcast);
+    const auto s = simd_load_narrow_or<uint32_t>(rs, base, s_bcast);
+    const auto c = simd_load64_or<uint64_t>(rs2, base, c_bcast);
+    const auto sh = util::stdx::static_simd_cast<util::native<uint64_t>>(s) & 63ull;
+    write_simd64_at<uint64_t>(rd64, inst.vdst, wf, base, (v << sh) + c, chunk);
+  }
+  return true;
+}
+template <typename Inst>
+[[nodiscard]] inline bool try_execute_lshl_add_u64_simd(Inst &, Wavefront &) {
+  return false;
+}
+
+/// VOP3 wide 32x32->64 multiply-add fast path (v_mad_u64_u32 / v_mad_i64_i32).
+/// src0/src1 are 32-bit multiplicands (read as narrow lanes), src2 is the 64-bit
+/// addend, dst is 64-bit. `mad_op(s0, s1, c)` receives the two narrow operands
+/// and the 64-bit addend and does the (signedness-aware) widen, 64-bit multiply
+/// (low 64), and add — matching the scalar `(wide)s0 * (wide)s1 + s2`.
+template <typename Inst, typename MadOp>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_mad_wide64_vop3_simd(Inst &inst, Wavefront &wf,
+                                                           MadOp mad_op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable() ||
+      !inst.src2.simd_capable() || !inst.vdst.simd_capable())
+    return false;
+  constexpr std::size_t W = util::native_width64;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  const VgprStorage *r0 = simd_src_reg(inst.src0, wf);
+  const VgprStorage *r1 = simd_src_reg(inst.src1, wf);
+  const ConstVgprStoragePair64 rs2 = simd_src_reg64(inst.src2, wf);
+  const VgprStoragePair64 rd64 = simd_dst_reg64(inst.vdst, wf);
+  const auto a_bcast =
+      r0 ? util::narrow32<uint32_t>{} : util::broadcast_narrow<uint32_t>(inst.src0.read_scalar(wf));
+  const auto b_bcast =
+      r1 ? util::narrow32<uint32_t>{} : util::broadcast_narrow<uint32_t>(inst.src1.read_scalar(wf));
+  const auto c_bcast =
+      rs2.lo ? util::native<uint64_t>{} : util::broadcast64<uint64_t>(inst.src2.read_scalar64(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto a = simd_load_narrow_or<uint32_t>(r0, base, a_bcast);
+    const auto b = simd_load_narrow_or<uint32_t>(r1, base, b_bcast);
+    const auto c = simd_load64_or<uint64_t>(rs2, base, c_bcast);
+    write_simd64_at<uint64_t>(rd64, inst.vdst, wf, base, mad_op(a, b, c), chunk);
+  }
+  return true;
+}
+template <typename Inst, typename MadOp>
+[[nodiscard]] inline bool try_execute_mad_wide64_vop3_simd(Inst &, Wavefront &, MadOp) {
+  return false;
+}
+
+/// VOP3 carry-OUT binary fast path (v_add_co/sub_co/subrev_co_u32). No carry-in
+/// (the SimdCarry functor's third arg is a zero vector); the per-lane carry-out
+/// is merged into a copy of the current VCC and written to the SGPR-pair `sdst`
+/// (not the fixed VCC) — exactly the scalar body's `inst.sdst.write_scalar64`.
+/// `sdst` is an SGPR operand, so it does not participate in the simd_capable
+/// gate; src0/src1/vdst do. (These VOP3 forms carry no `src2` member, so the
+/// carry-in path lives in the separate _cin glue below.)
+template <typename Inst, typename CarryOp>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_binary_vop3_co_simd(Inst &inst, Wavefront &wf,
+                                                          CarryOp carry_op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable() ||
+      !inst.vdst.simd_capable())
+    return false;
+  using T = uint32_t;
+  constexpr std::size_t W = util::native_width_v<T>;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  uint64_t carry_out = wf.vcc();
+  const VgprStorage *r0 = simd_src_reg(inst.src0, wf);
+  const VgprStorage *r1 = simd_src_reg(inst.src1, wf);
+  const auto a_bcast = r0 ? util::native<T>{} : util::broadcast<T>(inst.src0.read_scalar(wf));
+  const auto b_bcast = r1 ? util::native<T>{} : util::broadcast<T>(inst.src1.read_scalar(wf));
+  const auto zero_cin = util::broadcast<T>(0u);
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto a = simd_load_or<T>(r0, base, a_bcast);
+    const auto b = simd_load_or<T>(r1, base, b_bcast);
+    const auto r = carry_op(a, b, zero_cin);
+    write_simd<T>(inst.vdst, wf, base, r.value, chunk);
+    uint64_t carry_bits = 0;
+    for (std::size_t i = 0; i < W; ++i)
+      if (r.carry[i])
+        carry_bits |= (1ULL << i);
+    carry_out = (carry_out & ~(chunk << base)) | ((carry_bits & chunk) << base);
+  }
+  inst.sdst.write_scalar64(wf, carry_out);
+  return true;
+}
+template <typename Inst, typename CarryOp>
+[[nodiscard]] inline bool try_execute_binary_vop3_co_simd(Inst &, Wavefront &, CarryOp) {
+  return false;
+}
+
+/// VOP3 carry-IN binary fast path (v_addc_co/subb_co/subbrev_co_u32). Same as
+/// the _co glue but the per-lane carry-in is read from the SGPR-pair `src2`
+/// (these forms have a src2 member) and expanded to a 0/1-per-lane vector;
+/// carry-out goes to `sdst`. src2/sdst are SGPR operands (not gated).
+template <typename Inst, typename CarryOp>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_binary_vop3_cin_simd(Inst &inst, Wavefront &wf,
+                                                           CarryOp carry_op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable() ||
+      !inst.vdst.simd_capable())
+    return false;
+  using T = uint32_t;
+  constexpr std::size_t W = util::native_width_v<T>;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  const uint64_t cin_all = inst.src2.read_scalar64(wf);
+  uint64_t carry_out = wf.vcc();
+  const VgprStorage *r0 = simd_src_reg(inst.src0, wf);
+  const VgprStorage *r1 = simd_src_reg(inst.src1, wf);
+  const auto a_bcast = r0 ? util::native<T>{} : util::broadcast<T>(inst.src0.read_scalar(wf));
+  const auto b_bcast = r1 ? util::native<T>{} : util::broadcast<T>(inst.src1.read_scalar(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto a = simd_load_or<T>(r0, base, a_bcast);
+    const auto b = simd_load_or<T>(r1, base, b_bcast);
+    const uint64_t cin_bits = (cin_all >> base) & chunk_full;
+    alignas(util::native<T>) uint32_t cinbuf[W];
+    for (std::size_t i = 0; i < W; ++i)
+      cinbuf[i] = static_cast<uint32_t>((cin_bits >> i) & 1u);
+    const auto cin = util::load<T>(cinbuf);
+    const auto r = carry_op(a, b, cin);
+    write_simd<T>(inst.vdst, wf, base, r.value, chunk);
+    uint64_t carry_bits = 0;
+    for (std::size_t i = 0; i < W; ++i)
+      if (r.carry[i])
+        carry_bits |= (1ULL << i);
+    carry_out = (carry_out & ~(chunk << base)) | ((carry_bits & chunk) << base);
+  }
+  inst.sdst.write_scalar64(wf, carry_out);
+  return true;
+}
+template <typename Inst, typename CarryOp>
+[[nodiscard]] inline bool try_execute_binary_vop3_cin_simd(Inst &, Wavefront &, CarryOp) {
+  return false;
+}
+
+/// Destination shape for the VOP3P fma_mix / mad_mix family. F32 writes a
+/// full 32-bit float into vdst; F16_LO writes the f16-narrowed result into
+/// the low half of vdst (high half preserved); F16_HI writes it into the
+/// high half (low half preserved). Selected by the per-mnemonic glue probe.
+enum class FmaMixDst { F32, F16_LO, F16_HI };
+
+/// VOP3P fma_mix / mad_mix SIMD fast path. Six ops share one body because
+/// the scalar reference computes `a * b + c` (plain `*+`, not std::fma) for
+/// all six and differs only in (a) the f16-vs-f32 widening shape per source
+/// and (b) the f16-lo/f16-hi/f32 narrowing shape on the destination.
+///
+/// Per-source data fetch is gated by `op_sel_hi` (src0/src1) and
+/// `op_sel_hi_2` (src2): when the bit is 0 the source is read as f32; when
+/// 1 the source is read as a 32-bit word and the low or high f16 half
+/// (selected by the matching `op_sel` bit) is widened via f16_to_f32_simd.
+/// Per-source sign-flip is gated by `neg` (xor of bit 31). VOP3P does not
+/// carry abs or omod. Result-clamp saturates to [0, 1] via stdx::where.
+///
+/// All modifier fields are uniform across the wave so the per-source mode
+/// branches live outside the chunk loop and feed into the same `a*b+c`
+/// inner kernel regardless of fetch shape, keeping the SIMD path branch-
+/// predictable on every chunk.
+template <FmaMixDst DstMode, typename Inst>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_vop3p_fma_mix_simd(Inst &inst, Wavefront &wf) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable() ||
+      !inst.src2.simd_capable() || !inst.vdst.simd_capable())
+    return false;
+  using T = float32_t;
+  const uint32_t op_sel = inst.inst_.op_sel;
+  const uint32_t op_sel_hi = inst.inst_.op_sel_hi;
+  const uint32_t op_sel_hi_2 = inst.inst_.op_sel_hi_2;
+  const uint32_t neg = inst.inst_.neg;
+  const uint32_t clamp = inst.inst_.clamp;
+  constexpr std::size_t W = util::native_width_v<T>;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  using U = util::native<uint32_t>;
+  using F = util::native<float>;
+  const F kZero(0.0f);
+  const F kOne(1.0f);
+  const U kSignBit(0x80000000u);
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    auto load_src = [&](auto &op, uint32_t sel_hi_bit, uint32_t sel_bit, uint32_t neg_bit) -> F {
+      F v;
+      if (sel_hi_bit) {
+        U raw = read_simd<uint32_t>(op, wf, base);
+        U halves = sel_bit ? (raw >> 16) : (raw & 0xFFFFu);
+        v = util::f16_to_f32_simd(halves);
+      } else {
+        v = read_simd<float>(op, wf, base);
+      }
+      if (neg_bit)
+        v = std::bit_cast<F>(std::bit_cast<U>(v) ^ kSignBit);
+      return v;
+    };
+    F a = load_src(inst.src0, op_sel_hi & 1u, op_sel & 1u, neg & 1u);
+    F b = load_src(inst.src1, (op_sel_hi >> 1) & 1u, (op_sel >> 1) & 1u, (neg >> 1) & 1u);
+    F c = load_src(inst.src2, op_sel_hi_2, (op_sel >> 2) & 1u, (neg >> 2) & 1u);
+    F r = a * b + c;
+    if (clamp) {
+      util::stdx::where(r < kZero, r) = kZero;
+      util::stdx::where(r > kOne, r) = kOne;
+    }
+    if constexpr (DstMode == FmaMixDst::F32) {
+      write_simd<float>(inst.vdst, wf, base, r, chunk);
+    } else {
+      U h = util::f32_to_f16_simd(r); // low16 = f16, high16 zero
+      U prev = read_simd<uint32_t>(inst.vdst, wf, base);
+      U packed;
+      if constexpr (DstMode == FmaMixDst::F16_LO) {
+        packed = (prev & 0xFFFF0000u) | h;
+      } else { // F16_HI
+        packed = (prev & 0x0000FFFFu) | (h << 16);
+      }
+      write_simd<uint32_t>(inst.vdst, wf, base, packed, chunk);
+    }
+  }
+  return true;
+}
+
+template <FmaMixDst DstMode, typename Inst>
+[[nodiscard]] inline bool try_execute_vop3p_fma_mix_simd(Inst &, Wavefront &) {
+  return false;
+}
+
+/// VOP3P packed-16 binary integer SIMD fast path. Covers the pk_add /
+/// pk_sub / pk_mul_lo / pk_min / pk_max / pk_*shrev family on i16/u16/b16.
+/// Scalar pattern (verified across pk_add_i16, pk_add_u16, pk_mul_lo_u16,
+/// pk_lshlrev_b16, pk_min/max_*_16, etc.): two packed 16-bit values per
+/// 32-bit lane, each output half computed from the matching halves of
+/// src0/src1 picked by op_sel (low half) / op_sel_hi (high half). Default
+/// packing is op_sel = 0 (both srcs feed their low half into the low
+/// output) and op_sel_hi = 3 (both srcs feed their high half into the
+/// high output) — the LLVM-AS encoder emits this for the default-mode
+/// pk mnemonics, and the SIMD fast path bails when any other combination
+/// is requested. The scalar bodies do NOT apply neg / neg_hi / clamp on
+/// these integer pk ops, so the SIMD path also passes through. Functor
+/// receives the two source u32 lane vectors (each holding {low16, high16}
+/// packed) and returns the same shape; the per-half decompose / recompose
+/// lives inside the functor for op-specific flexibility (e.g. mul_lo
+/// requires the wider product to be masked to 16 bits before pack).
+template <typename Inst, typename Op>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_vop3p_pk_binary_int_simd(Inst &inst, Wavefront &wf, Op op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable() ||
+      !inst.vdst.simd_capable())
+    return false;
+  if (inst.inst_.op_sel != 0u || inst.inst_.op_sel_hi != 3u)
+    return false;
+  using T = uint32_t;
+  constexpr std::size_t W = util::native_width_v<T>;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto a = read_simd<T>(inst.src0, wf, base);
+    const auto b = read_simd<T>(inst.src1, wf, base);
+    const auto r = op(a, b);
+    write_simd<T>(inst.vdst, wf, base, r, chunk);
+  }
+  return true;
+}
+
+template <typename Inst, typename Op>
+[[nodiscard]] inline bool try_execute_vop3p_pk_binary_int_simd(Inst &, Wavefront &, Op) {
+  return false;
+}
+
+/// VOP3P packed-16 ternary integer SIMD fast path (3-source). Same default-
+/// packing gate as the binary form: op_sel == 0, op_sel_hi == 3, and the
+/// third source's high-half selector op_sel_hi_2 == 1 (per the scalar body
+/// `sel2_hi = inst.inst_.op_sel_hi_2`, which is a single bit — value 1 picks
+/// the high half for the high-output computation). For pk_mad_i16/u16 the
+/// scalar bodies also do not apply neg/neg_hi/clamp; the SIMD path passes
+/// through. Functor receives three u32 packed lane vectors and returns the
+/// per-half-masked packed result.
+template <typename Inst, typename Op>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_vop3p_pk_ternary_int_simd(Inst &inst, Wavefront &wf, Op op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable() ||
+      !inst.src2.simd_capable() || !inst.vdst.simd_capable())
+    return false;
+  if (inst.inst_.op_sel != 0u || inst.inst_.op_sel_hi != 3u || inst.inst_.op_sel_hi_2 != 1u)
+    return false;
+  using T = uint32_t;
+  constexpr std::size_t W = util::native_width_v<T>;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto a = read_simd<T>(inst.src0, wf, base);
+    const auto b = read_simd<T>(inst.src1, wf, base);
+    const auto c = read_simd<T>(inst.src2, wf, base);
+    const auto r = op(a, b, c);
+    write_simd<T>(inst.vdst, wf, base, r, chunk);
+  }
+  return true;
+}
+
+template <typename Inst, typename Op>
+[[nodiscard]] inline bool try_execute_vop3p_pk_ternary_int_simd(Inst &, Wavefront &, Op) {
+  return false;
+}
+
+/// VOP3P packed-16 floating-point binary SIMD fast path (pk_add/mul/min/
+/// max_f16 family). Each 32-bit lane holds two f16 values; the SIMD path
+/// widens to f32, applies per-half sign-flip from neg/neg_hi, runs the
+/// functor in f32, narrows back to f16, and packs. Same default-packing
+/// gate as the integer pk family. Scalar bodies for pk_*_f16 do NOT apply
+/// clamp (verified inline pk_add_f16 at line 15109, pk_max_f16 at 15519),
+/// so the SIMD path also ignores it.
+template <typename Inst, typename Op>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_vop3p_pk_binary_fp16_simd(Inst &inst, Wavefront &wf, Op op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable() ||
+      !inst.vdst.simd_capable())
+    return false;
+  if (inst.inst_.op_sel != 0u || inst.inst_.op_sel_hi != 3u)
+    return false;
+  using T = uint32_t;
+  constexpr std::size_t W = util::native_width_v<T>;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  using F = util::native<float>;
+  using U = util::native<uint32_t>;
+  const U kSignBit(0x80000000u);
+  const bool neg0_lo = inst.inst_.neg & 1u;
+  const bool neg1_lo = inst.inst_.neg & 2u;
+  const bool neg0_hi = inst.inst_.neg_hi & 1u;
+  const bool neg1_hi = inst.inst_.neg_hi & 2u;
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const U raw0 = read_simd<uint32_t>(inst.src0, wf, base);
+    const U raw1 = read_simd<uint32_t>(inst.src1, wf, base);
+    F a_lo = util::f16_to_f32_simd(raw0 & 0xFFFFu);
+    F a_hi = util::f16_to_f32_simd(raw0 >> 16);
+    F b_lo = util::f16_to_f32_simd(raw1 & 0xFFFFu);
+    F b_hi = util::f16_to_f32_simd(raw1 >> 16);
+    if (neg0_lo)
+      a_lo = std::bit_cast<F>(std::bit_cast<U>(a_lo) ^ kSignBit);
+    if (neg1_lo)
+      b_lo = std::bit_cast<F>(std::bit_cast<U>(b_lo) ^ kSignBit);
+    if (neg0_hi)
+      a_hi = std::bit_cast<F>(std::bit_cast<U>(a_hi) ^ kSignBit);
+    if (neg1_hi)
+      b_hi = std::bit_cast<F>(std::bit_cast<U>(b_hi) ^ kSignBit);
+    const F r_lo = op(a_lo, b_lo);
+    const F r_hi = op(a_hi, b_hi);
+    const U h_lo = util::f32_to_f16_simd(r_lo);
+    const U h_hi = util::f32_to_f16_simd(r_hi);
+    const U packed = h_lo | (h_hi << 16);
+    write_simd<uint32_t>(inst.vdst, wf, base, packed, chunk);
+  }
+  return true;
+}
+
+template <typename Inst, typename Op>
+[[nodiscard]] inline bool try_execute_vop3p_pk_binary_fp16_simd(Inst &, Wavefront &, Op) {
+  return false;
+}
+
+/// VOP3P packed-16 f16 ternary SIMD fast path (3-source pk_fma_f16). Same
+/// default-packing gate as the integer ternary form (op_sel = 0,
+/// op_sel_hi = 3, op_sel_hi_2 = 1). Per-source neg / neg_hi bits 0/1/2 for
+/// src0/src1/src2 (verified pk_fma_f16 scalar at line 15300-15317). No
+/// clamp on pk_fma_f16. NaN-payload divergence between stdx::fma and
+/// std::fma accepted (same carve-out as fma_mix slice).
+template <typename Inst, typename Op>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_vop3p_pk_ternary_fp16_simd(Inst &inst, Wavefront &wf, Op op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable() ||
+      !inst.src2.simd_capable() || !inst.vdst.simd_capable())
+    return false;
+  if (inst.inst_.op_sel != 0u || inst.inst_.op_sel_hi != 3u || inst.inst_.op_sel_hi_2 != 1u)
+    return false;
+  using T = uint32_t;
+  constexpr std::size_t W = util::native_width_v<T>;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  using F = util::native<float>;
+  using U = util::native<uint32_t>;
+  const U kSignBit(0x80000000u);
+  const bool neg0_lo = inst.inst_.neg & 1u;
+  const bool neg1_lo = inst.inst_.neg & 2u;
+  const bool neg2_lo = inst.inst_.neg & 4u;
+  const bool neg0_hi = inst.inst_.neg_hi & 1u;
+  const bool neg1_hi = inst.inst_.neg_hi & 2u;
+  const bool neg2_hi = inst.inst_.neg_hi & 4u;
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const U raw0 = read_simd<uint32_t>(inst.src0, wf, base);
+    const U raw1 = read_simd<uint32_t>(inst.src1, wf, base);
+    const U raw2 = read_simd<uint32_t>(inst.src2, wf, base);
+    F a_lo = util::f16_to_f32_simd(raw0 & 0xFFFFu);
+    F a_hi = util::f16_to_f32_simd(raw0 >> 16);
+    F b_lo = util::f16_to_f32_simd(raw1 & 0xFFFFu);
+    F b_hi = util::f16_to_f32_simd(raw1 >> 16);
+    F c_lo = util::f16_to_f32_simd(raw2 & 0xFFFFu);
+    F c_hi = util::f16_to_f32_simd(raw2 >> 16);
+    if (neg0_lo)
+      a_lo = std::bit_cast<F>(std::bit_cast<U>(a_lo) ^ kSignBit);
+    if (neg1_lo)
+      b_lo = std::bit_cast<F>(std::bit_cast<U>(b_lo) ^ kSignBit);
+    if (neg2_lo)
+      c_lo = std::bit_cast<F>(std::bit_cast<U>(c_lo) ^ kSignBit);
+    if (neg0_hi)
+      a_hi = std::bit_cast<F>(std::bit_cast<U>(a_hi) ^ kSignBit);
+    if (neg1_hi)
+      b_hi = std::bit_cast<F>(std::bit_cast<U>(b_hi) ^ kSignBit);
+    if (neg2_hi)
+      c_hi = std::bit_cast<F>(std::bit_cast<U>(c_hi) ^ kSignBit);
+    const F r_lo = op(a_lo, b_lo, c_lo);
+    const F r_hi = op(a_hi, b_hi, c_hi);
+    const U h_lo = util::f32_to_f16_simd(r_lo);
+    const U h_hi = util::f32_to_f16_simd(r_hi);
+    const U packed = h_lo | (h_hi << 16);
+    write_simd<uint32_t>(inst.vdst, wf, base, packed, chunk);
+  }
+  return true;
+}
+
+template <typename Inst, typename Op>
+[[nodiscard]] inline bool try_execute_vop3p_pk_ternary_fp16_simd(Inst &, Wavefront &, Op) {
+  return false;
+}
+
+/// VOP3P v_pk_mov_b32 SIMD fast path. Default packing only (op_sel == 0,
+/// op_sel_hi == 3): the result is a 64-bit pair `(src0_lo, src1_hi)`,
+/// where the per-source pair is the consecutive {base, base+1} VGPRs
+/// when the encoding points at the VGPR range. SGPR / literal sources
+/// broadcast both halves identically (handled by read_simd64's
+/// broadcast64 fallback). Reads each src as a 64-bit pair, picks the low
+/// half of src0 and the high half of src1 via mask, packs, writes via
+/// write_simd64. Functorless / fixed-op.
+template <typename Inst>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_vop3p_mov_b32_simd(Inst &inst, Wavefront &wf) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable() ||
+      !inst.vdst.simd_capable())
+    return false;
+  if (inst.inst_.op_sel != 0u || inst.inst_.op_sel_hi != 3u)
+    return false;
+  constexpr std::size_t W = util::native_width64;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  using U64 = util::native<uint64_t>;
+  const U64 kHiMask(0xFFFFFFFF00000000ULL);
+  const U64 kLoMask(0x00000000FFFFFFFFULL);
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const U64 s0 = read_simd64<uint64_t>(inst.src0, wf, base);
+    const U64 s1 = read_simd64<uint64_t>(inst.src1, wf, base);
+    const U64 out = (s0 & kLoMask) | (s1 & kHiMask);
+    write_simd64<uint64_t>(inst.vdst, wf, base, out, chunk);
+  }
+  return true;
+}
+
+template <typename Inst>
+[[nodiscard]] inline bool try_execute_vop3p_mov_b32_simd(Inst &, Wavefront &) {
+  return false;
+}
+
+/// VOP3P integer dot-product SIMD fast path (v_dot4_i32_i8 / v_dot4_u32_u8 /
+/// v_dot8_i32_i4 / v_dot8_u32_u4 / v_dot2_i32_i16 / v_dot2_u32_u16). Unlike
+/// the packed-16 family the destination is a single 32-bit lane (NOT packed)
+/// and src2 is a per-lane accumulator; the dot reduction happens *within*
+/// each lane, so the fast path vectorizes across lanes (each lane computes
+/// its own reduction). ElemBits selects the sub-word width (16/8/4 -> 2/4/8
+/// products per lane); Signed selects sign- vs zero-extension and, for the
+/// signed forms when inst.clamp is set, a lower clamp to 0 — the scalar
+/// std::clamp(sum, 0, INT_MAX) on an int32 sum is just max(sum, 0). The
+/// unsigned scalar bodies have NO clamp branch, so the unsigned fast path
+/// ignores the clamp bit entirely. Signed accumulation runs in the int32
+/// domain (matching the scalar body and the pk_mad_i16 precedent); unsigned
+/// in uint32. For the 16-bit forms op_sel / op_sel_hi pick the source halves,
+/// so the fast path gates on the default packing (op_sel == 0, op_sel_hi == 3)
+/// and bails otherwise; the 8/4-bit scalar bodies ignore op_sel so no gate is
+/// needed there.
+template <int ElemBits, bool Signed, typename Inst>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_vop3p_dot_int_simd(Inst &inst, Wavefront &wf) {
+  static_assert(ElemBits == 16 || ElemBits == 8 || ElemBits == 4, "dot ElemBits must be 16/8/4");
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable() ||
+      !inst.src2.simd_capable() || !inst.vdst.simd_capable())
+    return false;
+  if constexpr (ElemBits == 16) {
+    if (inst.inst_.op_sel != 0u || inst.inst_.op_sel_hi != 3u)
+      return false;
+  }
+  constexpr int N = 32 / ElemBits;
+  constexpr uint32_t kElemMask = (ElemBits == 16) ? 0xFFFFu : (ElemBits == 8) ? 0xFFu : 0xFu;
+  constexpr int kShift = 32 - ElemBits;
+  using T = uint32_t;
+  constexpr std::size_t W = util::native_width_v<T>;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  const bool clamp = inst.inst_.clamp;
+  using U = util::native<uint32_t>;
+  using I = util::native<int32_t>;
+  const I kZeroI(0);
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const U raw0 = read_simd<uint32_t>(inst.src0, wf, base);
+    const U raw1 = read_simd<uint32_t>(inst.src1, wf, base);
+    const U acc = read_simd<uint32_t>(inst.src2, wf, base);
+    if constexpr (Signed) {
+      I sum = std::bit_cast<I>(acc);
+      for (int i = 0; i < N; ++i) {
+        const U ea = (raw0 >> (i * ElemBits)) & kElemMask;
+        const U eb = (raw1 >> (i * ElemBits)) & kElemMask;
+        const I a = (util::stdx::static_simd_cast<I>(ea) << kShift) >> kShift;
+        const I b = (util::stdx::static_simd_cast<I>(eb) << kShift) >> kShift;
+        sum += a * b;
+      }
+      if (clamp)
+        util::stdx::where(sum < kZeroI, sum) = kZeroI;
+      write_simd<uint32_t>(inst.vdst, wf, base, std::bit_cast<U>(sum), chunk);
+    } else {
+      U sum = acc;
+      for (int i = 0; i < N; ++i) {
+        const U ea = (raw0 >> (i * ElemBits)) & kElemMask;
+        const U eb = (raw1 >> (i * ElemBits)) & kElemMask;
+        sum += ea * eb;
+      }
+      write_simd<uint32_t>(inst.vdst, wf, base, sum, chunk);
+    }
+  }
+  return true;
+}
+
+template <int ElemBits, bool Signed, typename Inst>
+[[nodiscard]] inline bool try_execute_vop3p_dot_int_simd(Inst &, Wavefront &) {
+  return false;
+}
+
+/// VOP3P v_dot2_f32_f16 SIMD fast path. Two f16 products plus an f32
+/// accumulator collapse into a single f32 lane: result = a0*b0 + a1*b1 + acc
+/// (plain `*` / `+`, left-to-right — matching the scalar, NOT a contracted
+/// fma). op_sel / op_sel_hi pick the f16 halves of src0/src1 (gated to the
+/// default packing op_sel == 0 && op_sel_hi == 3); neg / neg_hi flip the
+/// src0/src1 product-operand signs and neg bit 2 flips the accumulator.
+/// Optional clamp to [0, 1]. NaN-input payload divergence accepted (same
+/// carve-out as the pk_fma slices).
+template <typename Inst>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_vop3p_dot_f16_simd(Inst &inst, Wavefront &wf) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable() ||
+      !inst.src2.simd_capable() || !inst.vdst.simd_capable())
+    return false;
+  if (inst.inst_.op_sel != 0u || inst.inst_.op_sel_hi != 3u)
+    return false;
+  using T = uint32_t;
+  constexpr std::size_t W = util::native_width_v<T>;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  const bool clamp = inst.inst_.clamp;
+  using F = util::native<float>;
+  using U = util::native<uint32_t>;
+  const F kZero(0.0f);
+  const F kOne(1.0f);
+  const U kSignBit(0x80000000u);
+  const bool neg_a0 = inst.inst_.neg & 1u;
+  const bool neg_b0 = inst.inst_.neg & 2u;
+  const bool neg_acc = inst.inst_.neg & 4u;
+  const bool neg_a1 = inst.inst_.neg_hi & 1u;
+  const bool neg_b1 = inst.inst_.neg_hi & 2u;
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const U raw0 = read_simd<uint32_t>(inst.src0, wf, base);
+    const U raw1 = read_simd<uint32_t>(inst.src1, wf, base);
+    F acc = read_simd<float>(inst.src2, wf, base);
+    F a0 = util::f16_to_f32_simd(raw0 & 0xFFFFu);
+    F a1 = util::f16_to_f32_simd(raw0 >> 16);
+    F b0 = util::f16_to_f32_simd(raw1 & 0xFFFFu);
+    F b1 = util::f16_to_f32_simd(raw1 >> 16);
+    if (neg_a0)
+      a0 = std::bit_cast<F>(std::bit_cast<U>(a0) ^ kSignBit);
+    if (neg_b0)
+      b0 = std::bit_cast<F>(std::bit_cast<U>(b0) ^ kSignBit);
+    if (neg_a1)
+      a1 = std::bit_cast<F>(std::bit_cast<U>(a1) ^ kSignBit);
+    if (neg_b1)
+      b1 = std::bit_cast<F>(std::bit_cast<U>(b1) ^ kSignBit);
+    if (neg_acc)
+      acc = std::bit_cast<F>(std::bit_cast<U>(acc) ^ kSignBit);
+    F r = a0 * b0 + a1 * b1 + acc;
+    if (clamp) {
+      util::stdx::where(r < kZero, r) = kZero;
+      util::stdx::where(r > kOne, r) = kOne;
+    }
+    write_simd<float>(inst.vdst, wf, base, r, chunk);
+  }
+  return true;
+}
+
+template <typename Inst>
+[[nodiscard]] inline bool try_execute_vop3p_dot_f16_simd(Inst &, Wavefront &) {
+  return false;
+}
+
 } // namespace amdgpu
 } // namespace rocjitsu
+
+/// Probe macro emitted at the top of each SIMD-eligible execute_<mnemonic>
+/// kernel by simd_codegen.py. Expands to the binary-VOP2 fast-path call and
+/// an early `return` on success, keeping each generated body to a single
+/// line. Variadic in the operator argument so functor lambdas (which contain
+/// commas) pass through as one token sequence. Relies on the kernel's `inst`
+/// and `wf` parameters being in scope.
+#define ROCJITSU_TRY_SIMD_VOP2_BINARY(T, ...)                                                      \
+  if (::rocjitsu::amdgpu::try_execute_binary_vop2_simd<T>(inst, wf, __VA_ARGS__))                  \
+  return
+
+/// VOP1 unary counterpart of ROCJITSU_TRY_SIMD_VOP2_BINARY. Variadic in the
+/// operator argument so functor lambdas pass through as one token sequence.
+#define ROCJITSU_TRY_SIMD_VOP1_UNARY(Tin, Tout, ...)                                               \
+  if (::rocjitsu::amdgpu::try_execute_unary_vop1_simd<Tin, Tout>(inst, wf, __VA_ARGS__))           \
+  return
+
+/// Carry-VOP2 counterpart. Lane type is fixed to uint32_t, so unlike the binary
+/// macro this takes only the functor. Variadic so the functor's commas pass
+/// through as one token sequence.
+#define ROCJITSU_TRY_SIMD_VOP2_CARRY(...)                                                          \
+  if (::rocjitsu::amdgpu::try_execute_binary_vop2_carry_simd(inst, wf, __VA_ARGS__))               \
+  return
+
+/// Ternary (FMA/MAC/MAD) VOP2 counterpart. `KEXPR` is the inline-literal bits
+/// (an `inst.`-qualified expression, or `0u` for forms without a literal),
+/// broadcast to every lane before the call. Variadic in the functor.
+#define ROCJITSU_TRY_SIMD_VOP2_TERNARY(T, KEXPR, ...)                                              \
+  if (::rocjitsu::amdgpu::try_execute_ternary_vop2_simd<T>(inst, wf, ::util::broadcast<T>(KEXPR),  \
+                                                           __VA_ARGS__))                           \
+  return
+
+/// v_cndmask_b32 counterpart. Fixed op (VCC-driven select), so no type or
+/// functor argument.
+#define ROCJITSU_TRY_SIMD_VOP2_CNDMASK()                                                           \
+  if (::rocjitsu::amdgpu::try_execute_cndmask_vop2_simd(inst, wf))                                 \
+  return
+
+/// v_cndmask_b32 VOP3 counterpart. Same shape, but the selector comes from the
+/// SGPR-pair `src2` instead of fixed VCC.
+#define ROCJITSU_TRY_SIMD_VOP3_CNDMASK()                                                           \
+  if (::rocjitsu::amdgpu::try_execute_cndmask_vop3_simd(inst, wf))                                 \
+  return
+
+/// 16-bit variant of v_cndmask_b32 VOP3 (RDNA3+). Same select + low-16 mask
+/// on the result.
+#define ROCJITSU_TRY_SIMD_VOP3_CNDMASK_B16()                                                       \
+  if (::rocjitsu::amdgpu::try_execute_cndmask_b16_vop3_simd(inst, wf))                             \
+  return
+
+/// 64-bit-lane VOP2 FMA counterpart (v_fmac_f64). Lane type is fixed to double,
+/// so this takes only the dst-accumulate functor. Variadic so the functor's
+/// commas pass through as one token sequence.
+#define ROCJITSU_TRY_SIMD_VOP2_FMA_F64(...)                                                        \
+  if (::rocjitsu::amdgpu::try_execute_ternary_vop2_f64_simd<double>(inst, wf, __VA_ARGS__))        \
+  return
+
+/// 64-bit-lane VOP1 unary counterpart. `T` is the 64-bit lane type (`double`
+/// for the f64 math ops, `uint64_t` for v_mov_b64). Variadic in the functor so
+/// its commas pass through as one token sequence.
+#define ROCJITSU_TRY_SIMD_VOP1_UNARY_F64(T, ...)                                                   \
+  if (::rocjitsu::amdgpu::try_execute_unary_vop1_f64_simd<T>(inst, wf, __VA_ARGS__))               \
+  return
+
+/// Mixed-width cvt counterpart, f64 source -> 32-bit dst. `Tout` is the 32-bit
+/// result lane type; the functor (`native<double> -> narrow32<Tout>`) is variadic
+/// so its commas pass through as one token sequence.
+#define ROCJITSU_TRY_SIMD_CVT_F64_TO_B32(Tout, ...)                                                \
+  if (::rocjitsu::amdgpu::try_execute_cvt_f64_to_b32_simd<Tout>(inst, wf, __VA_ARGS__))            \
+  return
+
+/// Mixed-width cvt counterpart, 32-bit source -> f64 dst. `Tin` is the 32-bit
+/// source lane type; the functor (`narrow32<Tin> -> native<double>`) is variadic.
+#define ROCJITSU_TRY_SIMD_CVT_B32_TO_F64(Tin, ...)                                                 \
+  if (::rocjitsu::amdgpu::try_execute_cvt_b32_to_f64_simd<Tin>(inst, wf, __VA_ARGS__))             \
+  return
+
+/// VOPC compare counterpart. `T` is the 32-bit lane read type; the comparison
+/// functor (which may convert/narrow inside) is variadic so its commas pass
+/// through as one token sequence.
+#define ROCJITSU_TRY_SIMD_VOPC(T, ...)                                                             \
+  if (::rocjitsu::amdgpu::try_execute_vopc_simd<T>(inst, wf, __VA_ARGS__))                         \
+  return
+
+/// 64-bit-lane VOPC compare counterpart (f64/i64/u64). `T` is the 64-bit lane
+/// read type; the comparison functor is variadic so its commas pass through.
+#define ROCJITSU_TRY_SIMD_VOPC64(T, ...)                                                           \
+  if (::rocjitsu::amdgpu::try_execute_vopc64_simd<T>(inst, wf, __VA_ARGS__))                       \
+  return
+
+/// Mixed-width v_cmp_class_f64 counterpart (64-bit value, 32-bit mask). No type
+/// argument; the class functor `(native<uint64_t> bits, narrow32<uint32_t> mask)
+/// -> mask` is variadic so its commas pass through as one token sequence.
+#define ROCJITSU_TRY_SIMD_VOPC_CLASS_F64(...)                                                      \
+  if (::rocjitsu::amdgpu::try_execute_vopc_class_f64_simd(inst, wf, __VA_ARGS__))                  \
+  return
+
+/// VOP3 v_cmp_class_f16/f32 counterpart (32-bit value, abs/neg modifiers, src1
+/// mask, SGPR-pair dst). `SM` is the per-op sign-bit mask (0x8000 / 0x80000000);
+/// the class functor is variadic so its commas pass through.
+#define ROCJITSU_TRY_SIMD_VOP3_CLASS_B32(SM, ...)                                                  \
+  if (::rocjitsu::amdgpu::try_execute_vop3_class_b32_simd(inst, wf, SM, __VA_ARGS__))              \
+  return
+
+/// VOP3 v_cmp_class_f64 counterpart (64-bit value). `SM` is the f64 sign-bit mask
+/// (0x8000000000000000); the class functor is variadic.
+#define ROCJITSU_TRY_SIMD_VOP3_CLASS_F64(SM, ...)                                                  \
+  if (::rocjitsu::amdgpu::try_execute_vop3_class_f64_simd(inst, wf, SM, __VA_ARGS__))              \
+  return
+
+/// VOP3 integer/bitwise binary counterpart (reads src0/src1, no modifiers).
+/// `T` is the 32-bit integer lane type; variadic in the functor.
+#define ROCJITSU_TRY_SIMD_VOP3_BINARY_INT(T, ...)                                                  \
+  if (::rocjitsu::amdgpu::try_execute_binary_vop3_simd<T>(inst, wf, __VA_ARGS__))                  \
+  return
+
+/// VOP3 f32 binary counterpart (reads src0/src1, applies abs/neg/omod/clamp).
+/// `T` is the 32-bit float lane type; variadic in the functor.
+#define ROCJITSU_TRY_SIMD_VOP3_BINARY_FP(T, ...)                                                   \
+  if (::rocjitsu::amdgpu::try_execute_binary_vop3_fp_simd<T>(inst, wf, __VA_ARGS__))               \
+  return
+
+/// VOP3 f32 unary counterpart (reads src0, applies abs/neg/omod/clamp). `Tin`
+/// and `Tout` are both float32_t; variadic in the functor.
+#define ROCJITSU_TRY_SIMD_VOP3_UNARY_FP(Tin, Tout, ...)                                            \
+  if (::rocjitsu::amdgpu::try_execute_unary_vop3_fp_simd<Tin, Tout>(inst, wf, __VA_ARGS__))        \
+  return
+
+/// VOP3 integer/bitwise VOPC compare counterpart (32-bit lane, no modifiers,
+/// SGPR-pair dst). `T` is the 32-bit integer lane read type; variadic in the
+/// functor so its commas pass through as one token sequence.
+#define ROCJITSU_TRY_SIMD_VOPC_VOP3_INT(T, ...)                                                    \
+  if (::rocjitsu::amdgpu::try_execute_vopc_vop3_int_simd<T>(inst, wf, __VA_ARGS__))                \
+  return
+
+/// 64-bit-lane VOP3 integer/bitwise VOPC compare counterpart (i64/u64, no
+/// modifiers, SGPR-pair dst). `T` is the 64-bit integer lane read type;
+/// variadic in the functor.
+#define ROCJITSU_TRY_SIMD_VOPC64_VOP3_INT(T, ...)                                                  \
+  if (::rocjitsu::amdgpu::try_execute_vopc64_vop3_int_simd<T>(inst, wf, __VA_ARGS__))              \
+  return
+
+/// VOP3 f32 VOPC compare counterpart (per-source abs/neg modifiers, SGPR-pair
+/// dst). Lane type is fixed to float32_t; the functor takes already-modified
+/// `native<float>` arguments and is variadic so its commas pass through.
+#define ROCJITSU_TRY_SIMD_VOPC_VOP3_FP32(...)                                                      \
+  if (::rocjitsu::amdgpu::try_execute_vopc_vop3_fp32_simd(inst, wf, __VA_ARGS__))                  \
+  return
+
+/// VOP3 f16 VOPC compare counterpart. Lane type is fixed to uint32_t (raw f16
+/// bits in low 16); the glue widens to f32 then applies the abs/neg modifier.
+/// The functor takes the same already-widened, already-modified `native<float>`
+/// arguments as the f32 path; variadic in the functor.
+#define ROCJITSU_TRY_SIMD_VOPC_VOP3_FP16(...)                                                      \
+  if (::rocjitsu::amdgpu::try_execute_vopc_vop3_fp16_simd(inst, wf, __VA_ARGS__))                  \
+  return
+
+/// VOP3 f64 VOPC compare counterpart (per-source abs/neg modifiers, 64-bit
+/// lane via split lo/hi VGPR-pair, SGPR-pair dst). Lane type is fixed to
+/// `double`; the functor takes already-modified `native<double>` arguments
+/// and is variadic so its commas pass through.
+#define ROCJITSU_TRY_SIMD_VOPC64_VOP3_FP64(...)                                                    \
+  if (::rocjitsu::amdgpu::try_execute_vopc64_vop3_fp64_simd(inst, wf, __VA_ARGS__))                \
+  return
+
+/// VOP3 integer/bitwise ternary counterpart (reads src0/src1/src2, no
+/// modifiers). `T` is the 32-bit integer lane type; variadic in the functor.
+#define ROCJITSU_TRY_SIMD_VOP3_TERNARY_INT(T, ...)                                                 \
+  if (::rocjitsu::amdgpu::try_execute_ternary_vop3_simd<T>(inst, wf, __VA_ARGS__))                 \
+  return
+
+/// VOP3 f32 ternary counterpart (per-source abs/neg, result omod/clamp).
+/// Functor takes already-modified `native<float>` arguments; variadic.
+#define ROCJITSU_TRY_SIMD_VOP3_TERNARY_FP32(...)                                                   \
+  if (::rocjitsu::amdgpu::try_execute_ternary_vop3_fp_simd(inst, wf, __VA_ARGS__))                 \
+  return
+
+/// VOP3 f16 ternary counterpart (raw uint32 lanes; widen f16->f32 each src,
+/// abs/neg, op, omod/clamp, narrow). Variadic.
+#define ROCJITSU_TRY_SIMD_VOP3_TERNARY_FP16(...)                                                   \
+  if (::rocjitsu::amdgpu::try_execute_ternary_vop3_fp16_simd(inst, wf, __VA_ARGS__))               \
+  return
+
+/// VOP3 f64 ternary counterpart (read_simd64, per-source abs/neg, omod/clamp).
+/// Variadic.
+#define ROCJITSU_TRY_SIMD_VOP3_TERNARY_FP64(...)                                                   \
+  if (::rocjitsu::amdgpu::try_execute_ternary_vop3_fp64_simd(inst, wf, __VA_ARGS__))               \
+  return
+
+/// VOP3 dst-accumulate FMA counterpart (f32). Per-isa class has no src2;
+/// vdst is the accumulator. abs/neg apply to src0/src1 only.
+#define ROCJITSU_TRY_SIMD_FMAC_VOP3_FP32(...)                                                      \
+  if (::rocjitsu::amdgpu::try_execute_fmac_vop3_fp_simd(inst, wf, __VA_ARGS__))                    \
+  return
+
+/// VOP3 dst-accumulate FMA counterpart (f16). Widen chain, vdst is the
+/// (widened) accumulator.
+#define ROCJITSU_TRY_SIMD_FMAC_VOP3_FP16(...)                                                      \
+  if (::rocjitsu::amdgpu::try_execute_fmac_vop3_fp16_simd(inst, wf, __VA_ARGS__))                  \
+  return
+
+/// VOP3 dst-accumulate FMA counterpart (f64).
+#define ROCJITSU_TRY_SIMD_FMAC_VOP3_FP64(...)                                                      \
+  if (::rocjitsu::amdgpu::try_execute_fmac_vop3_fp64_simd(inst, wf, __VA_ARGS__))                  \
+  return
+
+/// VOP3 ldexp counterpart (f32 src0 + int32 src1 exp). Variadic functor.
+#define ROCJITSU_TRY_SIMD_LDEXP_VOP3_FP32(...)                                                     \
+  if (::rocjitsu::amdgpu::try_execute_ldexp_vop3_fp32_simd(inst, wf, __VA_ARGS__))                 \
+  return
+
+/// VOP3 ldexp counterpart (f64 src0 + int32 src1 exp). Variadic functor.
+#define ROCJITSU_TRY_SIMD_LDEXP_VOP3_FP64(...)                                                     \
+  if (::rocjitsu::amdgpu::try_execute_ldexp_vop3_fp64_simd(inst, wf, __VA_ARGS__))                 \
+  return
+
+/// VOP3 div_fmas counterpart (fma(s0,s1,s2) followed by VCC-gated ldexp; no
+/// omod/clamp). No functor — the op is fixed (operand order, ldexp shift) and
+/// distinct for f32 vs f64.
+#define ROCJITSU_TRY_SIMD_DIV_FMAS_VOP3_FP32()                                                     \
+  if (::rocjitsu::amdgpu::try_execute_div_fmas_f32_simd(inst, wf))                                 \
+  return
+
+#define ROCJITSU_TRY_SIMD_DIV_FMAS_VOP3_FP64()                                                     \
+  if (::rocjitsu::amdgpu::try_execute_div_fmas_f64_simd(inst, wf))                                 \
+  return
+
+/// VOP3 f64 binary counterpart (read_simd64, per-source abs/neg, omod/clamp on
+/// the result). Variadic in the functor so its commas pass through as one
+/// token sequence.
+#define ROCJITSU_TRY_SIMD_VOP3_BINARY_FP64(...)                                                    \
+  if (::rocjitsu::amdgpu::try_execute_binary_vop3_fp64_simd(inst, wf, __VA_ARGS__))                \
+  return
+
+/// VOP3 f64 unary counterpart (read_simd64, src0 abs/neg, omod/clamp on
+/// the result). Variadic in the functor.
+#define ROCJITSU_TRY_SIMD_VOP3_UNARY_FP64(...)                                                     \
+  if (::rocjitsu::amdgpu::try_execute_unary_vop3_fp64_simd(inst, wf, __VA_ARGS__))                 \
+  return
+
+/// VOP3 f16 unary counterpart (raw uint32 lanes; widen f16->f32, src0 abs/neg,
+/// op, omod/clamp, narrow f32->f16). The functor takes already-widened-and-
+/// modified `native<float>` and returns `native<float>`; variadic.
+#define ROCJITSU_TRY_SIMD_VOP3_UNARY_FP16(...)                                                     \
+  if (::rocjitsu::amdgpu::try_execute_unary_vop3_fp16_simd(inst, wf, __VA_ARGS__))                 \
+  return
+
+/// VOP3 64-bit reverse-shift counterpart (v_lshlrev_b64 / v_lshrrev_b64 /
+/// v_ashrrev_i64). src0 = 32-bit shift, src1 = 64-bit value; the functor takes
+/// `(native<uint64_t> value, native<uint64_t> shift)`. Variadic.
+#define ROCJITSU_TRY_SIMD_SHIFT64_VOP3(...)                                                        \
+  if (::rocjitsu::amdgpu::try_execute_shift64_vop3_simd(inst, wf, __VA_ARGS__))                    \
+  return
+
+/// VOP3 v_lshl_add_u64 counterpart. Fixed op ((src0 << (src1 & 63)) + src2).
+#define ROCJITSU_TRY_SIMD_LSHL_ADD_U64()                                                           \
+  if (::rocjitsu::amdgpu::try_execute_lshl_add_u64_simd(inst, wf))                                 \
+  return
+
+/// VOP3 wide 32x32->64 multiply-add counterpart (v_mad_u64_u32 / v_mad_i64_i32).
+/// The functor takes `(narrow32<uint32_t> s0, narrow32<uint32_t> s1,
+/// native<uint64_t> c)`; variadic so its commas pass through.
+#define ROCJITSU_TRY_SIMD_MAD_WIDE64_VOP3(...)                                                     \
+  if (::rocjitsu::amdgpu::try_execute_mad_wide64_vop3_simd(inst, wf, __VA_ARGS__))                 \
+  return
+
+/// VOP3 carry-OUT counterpart (no carry-in; carry-out to SGPR sdst). Lane type
+/// fixed to uint32_t; variadic in the SimdCarry functor.
+#define ROCJITSU_TRY_SIMD_VOP3_CO(...)                                                             \
+  if (::rocjitsu::amdgpu::try_execute_binary_vop3_co_simd(inst, wf, __VA_ARGS__))                  \
+  return
+
+/// VOP3 carry-IN counterpart (carry-in from SGPR src2, carry-out to SGPR sdst).
+/// Lane type fixed to uint32_t; variadic in the SimdCarry functor.
+#define ROCJITSU_TRY_SIMD_VOP3_CIN(...)                                                            \
+  if (::rocjitsu::amdgpu::try_execute_binary_vop3_cin_simd(inst, wf, __VA_ARGS__))                 \
+  return
+
+/// VOP3P fma_mix / mad_mix probes. The destination shape is the only thing
+/// that differs across the six ops, so the probe is parameterised by
+/// `FmaMixDst::{F32,F16_LO,F16_HI}` and the shared scalar formula `a*b+c`
+/// (incl. clamp) lives in the glue. No functor argument.
+#define ROCJITSU_TRY_SIMD_VOP3P_FMA_MIX_F32()                                                      \
+  if (::rocjitsu::amdgpu::try_execute_vop3p_fma_mix_simd<::rocjitsu::amdgpu::FmaMixDst::F32>(inst, \
+                                                                                             wf))  \
+  return
+
+#define ROCJITSU_TRY_SIMD_VOP3P_FMA_MIX_F16_LO()                                                   \
+  if (::rocjitsu::amdgpu::try_execute_vop3p_fma_mix_simd<::rocjitsu::amdgpu::FmaMixDst::F16_LO>(   \
+          inst, wf))                                                                               \
+  return
+
+#define ROCJITSU_TRY_SIMD_VOP3P_FMA_MIX_F16_HI()                                                   \
+  if (::rocjitsu::amdgpu::try_execute_vop3p_fma_mix_simd<::rocjitsu::amdgpu::FmaMixDst::F16_HI>(   \
+          inst, wf))                                                                               \
+  return
+
+/// VOP3P packed-16 integer binary probe. Functor takes two u32 simd vectors
+/// (each holding {low16, high16} packed) and returns the same shape with
+/// the per-half op applied; the glue gates op_sel/op_sel_hi to the default
+/// packing (0 / 3) and falls back to scalar otherwise.
+#define ROCJITSU_TRY_SIMD_VOP3P_PK_BINARY_INT(...)                                                 \
+  if (::rocjitsu::amdgpu::try_execute_vop3p_pk_binary_int_simd(inst, wf, __VA_ARGS__))             \
+  return
+
+/// VOP3P packed-16 integer ternary probe (3-source pk_mad family).
+#define ROCJITSU_TRY_SIMD_VOP3P_PK_TERNARY_INT(...)                                                \
+  if (::rocjitsu::amdgpu::try_execute_vop3p_pk_ternary_int_simd(inst, wf, __VA_ARGS__))            \
+  return
+
+/// VOP3P packed-16 f16 binary probe. Functor takes (a, b) as f32 simd
+/// vectors (already widened from f16 halves with neg applied) and returns
+/// an f32 simd vector that is narrowed back to f16 inside the glue.
+#define ROCJITSU_TRY_SIMD_VOP3P_PK_BINARY_FP16(...)                                                \
+  if (::rocjitsu::amdgpu::try_execute_vop3p_pk_binary_fp16_simd(inst, wf, __VA_ARGS__))            \
+  return
+
+/// VOP3P packed-16 f16 ternary probe (3-source pk_fma_f16).
+#define ROCJITSU_TRY_SIMD_VOP3P_PK_TERNARY_FP16(...)                                               \
+  if (::rocjitsu::amdgpu::try_execute_vop3p_pk_ternary_fp16_simd(inst, wf, __VA_ARGS__))           \
+  return
+
+/// VOP3P v_pk_mov_b32 probe. Functorless / fixed-op.
+#define ROCJITSU_TRY_SIMD_VOP3P_MOV_B32()                                                          \
+  if (::rocjitsu::amdgpu::try_execute_vop3p_mov_b32_simd(inst, wf))                                \
+  return
+
+/// VOP3P integer dot-product probe. Args: (ElemBits, Signed) — e.g.
+/// (8, true) for v_dot4_i32_i8, (4, false) for v_dot8_u32_u4. Functorless.
+#define ROCJITSU_TRY_SIMD_VOP3P_DOT_INT(...)                                                       \
+  if (::rocjitsu::amdgpu::try_execute_vop3p_dot_int_simd<__VA_ARGS__>(inst, wf))                   \
+  return
+
+/// VOP3P v_dot2_f32_f16 probe. Functorless / fixed-op.
+#define ROCJITSU_TRY_SIMD_VOP3P_DOT_F16()                                                          \
+  if (::rocjitsu::amdgpu::try_execute_vop3p_dot_f16_simd(inst, wf))                                \
+  return
 
 #endif // ROCJITSU_ISA_AMDGPU_SHARED_SIMD_GLUE_H_

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
@@ -2043,8 +2043,9 @@ template <typename Tin, typename Tout, typename Inst, typename UnOp>
 /// `c` (denominator), pick the result among NaN/Inf/zero copysign cases
 /// according to AMD's div_fixup ULP table. The cascade is applied lowest-
 /// priority first so that the higher-priority `where` blends overwrite —
-/// equivalent to scalar's first-match `else if`. The sign-of-quotient
-/// `b ^ c` is computed once in the integer domain and reinterpreted as
+/// equivalent to scalar's first-match `else if`; source-2 NaN therefore
+/// overwrites source-1 NaN. The sign-of-quotient `b ^ c` is computed once
+/// in the integer domain and reinterpreted as
 /// float, matching the scalar's `bit_cast<float>(bits(b) ^ bits(c))`. Both
 /// `std::copysign(Inf, bxc)` and `std::copysign(0, bxc)` reduce to
 /// `stdx::copysign(target, bxc)`.
@@ -2069,8 +2070,8 @@ inline util::native<float> div_fixup_f32_simd(util::native<float> p, util::nativ
   util::stdx::where(b_zero, r) = inf_val;
   util::stdx::where(b_inf && c_inf, r) = qnan;
   util::stdx::where(b_zero && c_zero, r) = qnan;
-  util::stdx::where(c_nan, r) = c;
   util::stdx::where(b_nan, r) = b;
+  util::stdx::where(c_nan, r) = c;
   return r;
 }
 
@@ -2096,8 +2097,8 @@ inline util::native<double> div_fixup_f64_simd(util::native<double> p, util::nat
   util::stdx::where(b_zero, r) = inf_val;
   util::stdx::where(b_inf && c_inf, r) = qnan;
   util::stdx::where(b_zero && c_zero, r) = qnan;
-  util::stdx::where(c_nan, r) = c;
   util::stdx::where(b_nan, r) = b;
+  util::stdx::where(c_nan, r) = c;
   return r;
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/isa_operand_simd_inl.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/isa_operand_simd_inl.h
@@ -79,23 +79,28 @@ void AmdgpuIsaOperand<Isa>::write_lane_chunk(amdgpu::Wavefront &wf, uint32_t lan
 }
 
 template <typename Isa>
-const uint32_t *AmdgpuIsaOperand<Isa>::simd_lane_ptr(const amdgpu::Wavefront &wf,
-                                                     uint32_t lane_base) const {
+std::optional<uint32_t> AmdgpuIsaOperand<Isa>::simd_vgpr_base(const amdgpu::Wavefront &wf) const {
   if (this->delegate())
-    return amdgpu::SimdAccess::lane_ptr(*this->delegate(), wf, lane_base);
-  if (auto off = detail::resolved_vgpr_offset_for_operand<Isa>(wf, *this)) {
-    const uint8_t *base = wf.cu().vgpr_data(wf.vgpr_alloc().base + *off);
-    return reinterpret_cast<const uint32_t *>(base + lane_base * sizeof(uint32_t));
-  }
+    return amdgpu::SimdAccess::vgpr_base(*this->delegate(), wf);
+  if (auto off = detail::resolved_vgpr_offset_for_operand<Isa>(wf, *this))
+    return wf.vgpr_alloc().base + *off;
+  return std::nullopt;
+}
+
+template <typename Isa>
+const amdgpu::VgprStorage *
+AmdgpuIsaOperand<Isa>::simd_vgpr_storage(const amdgpu::Wavefront &wf) const {
+  if (this->delegate())
+    return amdgpu::SimdAccess::vgpr_storage(*this->delegate(), wf);
+  if (auto off = detail::resolved_vgpr_offset_for_operand<Isa>(wf, *this))
+    return &wf.cu().template vgpr_reg<64>(wf.vgpr_alloc().base + *off);
   return nullptr;
 }
 
 template <typename Isa>
-uint32_t *AmdgpuIsaOperand<Isa>::simd_dst_ptr(amdgpu::Wavefront &wf, uint32_t lane_base) const {
-  if (auto off = detail::resolved_vgpr_offset_for_operand<Isa>(wf, *this)) {
-    uint8_t *base = wf.cu().vgpr_data(wf.vgpr_alloc().base + *off);
-    return reinterpret_cast<uint32_t *>(base + lane_base * sizeof(uint32_t));
-  }
+amdgpu::VgprStorage *AmdgpuIsaOperand<Isa>::simd_vgpr_storage_mut(amdgpu::Wavefront &wf) const {
+  if (auto off = detail::resolved_vgpr_offset_for_operand<Isa>(wf, *this))
+    return &wf.cu().template vgpr_reg<64>(wf.vgpr_alloc().base + *off);
   return nullptr;
 }
 
@@ -106,6 +111,28 @@ void AmdgpuIsaOperand<Isa>::simd_notify_read(const amdgpu::Wavefront &wf, uint32
     uint32_t physical_reg = wf.vgpr_alloc().base + *off;
     wf.cu().notify_vgpr_read(&wf, physical_reg, lane_begin, lane_end, byte_mask);
   }
+}
+
+template <typename Isa>
+amdgpu::ConstVgprStoragePair64
+AmdgpuIsaOperand<Isa>::simd_vgpr_storage64(const amdgpu::Wavefront &wf) const {
+  if (this->delegate())
+    return amdgpu::SimdAccess::vgpr_storage64(*this->delegate(), wf);
+  if (auto off = detail::resolved_vgpr_offset_for_operand<Isa>(wf, *this)) {
+    uint32_t reg = wf.vgpr_alloc().base + *off;
+    return {&wf.cu().template vgpr_reg<64>(reg), &wf.cu().template vgpr_reg<64>(reg + 1)};
+  }
+  return {nullptr, nullptr};
+}
+
+template <typename Isa>
+amdgpu::VgprStoragePair64
+AmdgpuIsaOperand<Isa>::simd_vgpr_storage64_mut(amdgpu::Wavefront &wf) const {
+  if (auto off = detail::resolved_vgpr_offset_for_operand<Isa>(wf, *this)) {
+    uint32_t reg = wf.vgpr_alloc().base + *off;
+    return {&wf.cu().template vgpr_reg<64>(reg), &wf.cu().template vgpr_reg<64>(reg + 1)};
+  }
+  return {nullptr, nullptr};
 }
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/operand.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/operand.h
@@ -13,11 +13,35 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <utility>
+
+namespace simdojo {
+template <size_t NUM_ELEMS, typename VecElem> class VectorReg;
+}
 
 namespace rocjitsu {
 namespace amdgpu {
 class Wavefront;
 struct SimdAccess;
+
+/// @brief Wave64 VGPR storage type — the register file element. Operands hand
+/// the SIMD glue a typed view of this (a `simdojo::VectorReg<64,uint32_t>`, no
+/// raw pointer) for the read/write fast path.
+using VgprStorage = simdojo::VectorReg<64, uint32_t>;
+
+/// @brief A `{lo, hi}` pair of typed per-register VGPR storage views for a
+/// 64-bit-lane operand. `lo` is the lower-numbered VGPR (reg N, bits [31:0]);
+/// `hi` is reg N+1 (bits [63:32]). Either both are valid or both are nullptr.
+struct VgprStoragePair64 {
+  VgprStorage *lo;
+  VgprStorage *hi;
+};
+
+/// @brief Read-only counterpart of `VgprStoragePair64`.
+struct ConstVgprStoragePair64 {
+  const VgprStorage *lo;
+  const VgprStorage *hi;
+};
 } // namespace amdgpu
 
 /// @brief Base class for an instruction operand with value resolution.
@@ -186,29 +210,37 @@ public:
   amdgpu::VgprMsbRole vgpr_msb_role_ = amdgpu::VgprMsbRole::None;
 
 private:
-  /// @brief If this operand has contiguous per-lane uint32_t storage for the
-  /// lane range starting at `lane_base`, return a pointer to lane `lane_base`.
-  /// Otherwise return nullptr — the caller should fall back to a scalar
-  /// broadcast via `read_scalar` (for SGPR/imm/inline-const operands).
-  ///
-  /// @details Internal SIMD fast-path hook, reachable only through
-  /// `amdgpu::SimdAccess`. Plugins observing register reads should hook the
-  /// public `read_lane` / `read_lane_chunk` surface instead.
-  virtual const uint32_t *simd_lane_ptr(const amdgpu::Wavefront &wf, uint32_t lane_base) const {
+  /// @brief If this operand resolves to per-lane VGPR storage, return its
+  /// physical register index (`wf.vgpr_alloc().base + offset`). Otherwise
+  /// nullopt (SGPR/imm/inline-const/DPP) — the caller broadcasts a scalar. The
+  /// glue passes this index to the plugin read-notification hook with the full
+  /// register extent. Internal SIMD fast-path hook, reachable only through
+  /// `amdgpu::SimdAccess`; plugins observe register reads via the public
+  /// `read_lane` / `read_lane_chunk` surface.
+  virtual std::optional<uint32_t> simd_vgpr_base(const amdgpu::Wavefront &wf) const {
     if (delegate_)
-      return delegate_->simd_lane_ptr(wf, lane_base);
+      return delegate_->simd_vgpr_base(wf);
+    (void)wf;
+    return std::nullopt;
+  }
+
+  /// @brief If this operand resolves to per-lane VGPR storage, return a typed
+  /// const view of that register (the `VgprStorage` the file holds, a
+  /// `simdojo::VectorReg<64,uint32_t>&`). Otherwise nullptr — the caller falls
+  /// back to a scalar broadcast via `read_scalar`. Resolves the storage in a
+  /// SINGLE virtual dispatch — the SIMD hot path reads through this without a
+  /// raw pointer crossing the operand/glue API.
+  virtual const amdgpu::VgprStorage *simd_vgpr_storage(const amdgpu::Wavefront &wf) const {
+    if (delegate_)
+      return delegate_->simd_vgpr_storage(wf);
+    (void)wf;
     return nullptr;
   }
 
-  /// @brief If this operand's destination is contiguous per-lane uint32_t
-  /// storage (a VGPR), return a writable pointer to lane `lane_base`. Otherwise
-  /// return nullptr — the caller should fall back to `write_lane_chunk`.
-  ///
-  /// @details Internal SIMD fast-path hook; same access policy as
-  /// `simd_lane_ptr`.
-  virtual uint32_t *simd_dst_ptr(amdgpu::Wavefront &wf, uint32_t lane_base) const {
+  /// @brief Mutable counterpart of `simd_vgpr_storage` for the dst write path
+  /// (no delegate — a dst is never DPP/SDWA).
+  virtual amdgpu::VgprStorage *simd_vgpr_storage_mut(amdgpu::Wavefront &wf) const {
     (void)wf;
-    (void)lane_base;
     return nullptr;
   }
 
@@ -216,6 +248,26 @@ private:
   /// for lanes [lane_begin, lane_end). No-op for non-VGPR operands.
   virtual void simd_notify_read(const amdgpu::Wavefront & /*wf*/, uint32_t /*lane_begin*/,
                                 uint32_t /*lane_end*/, uint8_t /*byte_mask*/) const {}
+
+  /// @brief 64-bit-lane counterpart of `simd_vgpr_storage`. A per-lane f64/i64
+  /// value occupies two consecutive VGPRs (reg N + reg N+1), so this returns a
+  /// `{lo, hi}` pair of typed register views (lo = reg N, hi = reg N+1) in a
+  /// SINGLE virtual dispatch. Returns `{nullptr, nullptr}` when the operand is
+  /// not contiguous VGPR storage — the caller broadcasts via `read_scalar64`.
+  virtual amdgpu::ConstVgprStoragePair64 simd_vgpr_storage64(const amdgpu::Wavefront &wf) const {
+    if (delegate_)
+      return delegate_->simd_vgpr_storage64(wf);
+    (void)wf;
+    return {nullptr, nullptr};
+  }
+
+  /// @brief Mutable counterpart of `simd_vgpr_storage64` for the 64-bit dst
+  /// write path; returns writable `{lo, hi}` register views or
+  /// `{nullptr, nullptr}`.
+  virtual amdgpu::VgprStoragePair64 simd_vgpr_storage64_mut(amdgpu::Wavefront &wf) const {
+    (void)wf;
+    return {nullptr, nullptr};
+  }
 
   Operand *delegate_ = nullptr;
 };
@@ -239,8 +291,9 @@ public:
 
 /// @brief AMDGPU-flavored `IsaOperand` that owns the SIMD fast-path
 /// overrides (`simd_capable`, `read_lane_chunk`, `write_lane_chunk`,
-/// `simd_lane_ptr`, `simd_dst_ptr`) so per-arch `Operand` subclasses do
-/// not duplicate the same body across AMDGPU ISAs. The implementations live
+/// `simd_vgpr_storage`, `simd_vgpr_storage_mut`, the 64-bit pair forms, and
+/// `simd_vgpr_base`) so per-arch `Operand` subclasses do
+/// not duplicate the same body across 9 ISAs. The implementations live
 /// in `isa_operand_simd_inl.h` and call into the per-arch `Isa::`
 /// traits struct (`resolved_vgpr_offset`, `is_immediate_type`,
 /// `can_resolve_src_scalar`, `resolve_src_scalar`). Non-AMDGPU arches
@@ -265,8 +318,11 @@ public:
                         const uint32_t *vals, uint64_t mask) const override;
 
 private:
-  const uint32_t *simd_lane_ptr(const amdgpu::Wavefront &wf, uint32_t lane_base) const override;
-  uint32_t *simd_dst_ptr(amdgpu::Wavefront &wf, uint32_t lane_base) const override;
+  std::optional<uint32_t> simd_vgpr_base(const amdgpu::Wavefront &wf) const override;
+  const amdgpu::VgprStorage *simd_vgpr_storage(const amdgpu::Wavefront &wf) const override;
+  amdgpu::VgprStorage *simd_vgpr_storage_mut(amdgpu::Wavefront &wf) const override;
+  amdgpu::ConstVgprStoragePair64 simd_vgpr_storage64(const amdgpu::Wavefront &wf) const override;
+  amdgpu::VgprStoragePair64 simd_vgpr_storage64_mut(amdgpu::Wavefront &wf) const override;
   void simd_notify_read(const amdgpu::Wavefront &wf, uint32_t lane_begin, uint32_t lane_end,
                         uint8_t byte_mask) const override;
 };
@@ -315,11 +371,17 @@ public:
   }
 
 private:
-  const uint32_t *simd_lane_ptr(const amdgpu::Wavefront & /*wf*/,
-                                uint32_t lane_base) const override {
-    if (static_cast<int>(lane_base) >= lane_count_)
-      return nullptr;
-    return &data_[lane_base];
+  /// The pre-permuted lane data is held in a `MAX_LANES`-wide `uint32_t` array
+  /// that is bit-layout-identical to `VgprStorage` (`simdojo::VectorReg<64,
+  /// uint32_t>` — a `std::array<uint32_t,64>` with the layout `static_assert`
+  /// enforced in `ComputeUnitCore::vgpr_reg`). Unused lanes are zero (the
+  /// EXEC mask gates them off in the glue), so the whole array is a valid
+  /// read-only register view. The cast targets the forward-declared
+  /// `VgprStorage`; the glue dereferences it where the full type is visible.
+  const amdgpu::VgprStorage *simd_vgpr_storage(const amdgpu::Wavefront & /*wf*/) const override {
+    static_assert(sizeof(data_) == MAX_LANES * sizeof(uint32_t),
+                  "DppOperand data_ must be layout-compatible with VgprStorage");
+    return reinterpret_cast<const amdgpu::VgprStorage *>(&data_);
   }
 
   uint32_t data_[MAX_LANES]{};
@@ -331,16 +393,32 @@ namespace amdgpu {
 ///
 /// Only the SIMD glue in `arch/amdgpu/shared/simd_glue.h` (and arch operand
 /// implementations that need to forward a delegate dispatch) reaches the
-/// private `simd_lane_ptr` / `simd_dst_ptr` virtuals through this struct.
+/// private `simd_vgpr_storage` / `simd_vgpr_base` virtuals through this struct.
 /// Plugin-visible register I/O stays on the public `read_lane` /
 /// `read_lane_chunk` / `write_lane` / `write_lane_chunk` surface.
 struct SimdAccess {
+  /// Physical register index for plugin read-notification (nullopt for
+  /// non-VGPR / DPP operands), resolved in one virtual dispatch.
   template <typename Op>
-  static const uint32_t *lane_ptr(const Op &op, const Wavefront &wf, uint32_t lane_base) {
-    return op.simd_lane_ptr(wf, lane_base);
+  static std::optional<uint32_t> vgpr_base(const Op &op, const Wavefront &wf) {
+    return op.simd_vgpr_base(wf);
   }
-  template <typename Op> static uint32_t *dst_ptr(const Op &op, Wavefront &wf, uint32_t lane_base) {
-    return op.simd_dst_ptr(wf, lane_base);
+  /// Typed const register view for the 32-bit read path (null for non-VGPR).
+  template <typename Op> static const VgprStorage *vgpr_storage(const Op &op, const Wavefront &wf) {
+    return op.simd_vgpr_storage(wf);
+  }
+  /// Typed mutable register view for the 32-bit write path (null for non-VGPR).
+  template <typename Op> static VgprStorage *vgpr_storage_mut(const Op &op, Wavefront &wf) {
+    return op.simd_vgpr_storage_mut(wf);
+  }
+  /// Typed `{lo, hi}` const register-view pair for the 64-bit read path.
+  template <typename Op>
+  static ConstVgprStoragePair64 vgpr_storage64(const Op &op, const Wavefront &wf) {
+    return op.simd_vgpr_storage64(wf);
+  }
+  /// Typed `{lo, hi}` mutable register-view pair for the 64-bit write path.
+  template <typename Op> static VgprStoragePair64 vgpr_storage64_mut(const Op &op, Wavefront &wf) {
+    return op.simd_vgpr_storage64_mut(wf);
   }
   template <typename Op>
   static void notify_read(const Op &op, const Wavefront &wf, uint32_t lane_begin, uint32_t lane_end,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -370,6 +370,24 @@ public:
   /// @returns Mutable pointer to the raw VGPR data.
   virtual uint8_t *vgpr_data(uint32_t base) = 0;
 
+  /// @brief Typed view of a single VGPR as the file's @c simdojo::VectorReg.
+  /// @details The abstract CU exposes the VGPR file only as a byte pointer
+  /// (@c vgpr_data), which erases the wavefront-size template parameter. The
+  /// file actually stores @c simdojo::VectorReg<N,uint32_t>, so this recovers
+  /// the typed register with the design's single localized @c reinterpret_cast.
+  /// The @c static_assert pins @c VectorReg<N> to @c N contiguous @c uint32_t
+  /// (no padding / vtable) so the byte view and the typed view coincide.
+  template <size_t N> simdojo::VectorReg<N, uint32_t> &vgpr_reg(uint32_t base) {
+    static_assert(sizeof(simdojo::VectorReg<N, uint32_t>) == N * sizeof(uint32_t),
+                  "VectorReg must be layout-compatible with raw lane storage");
+    return *reinterpret_cast<simdojo::VectorReg<N, uint32_t> *>(vgpr_data(base));
+  }
+  template <size_t N> const simdojo::VectorReg<N, uint32_t> &vgpr_reg(uint32_t base) const {
+    static_assert(sizeof(simdojo::VectorReg<N, uint32_t>) == N * sizeof(uint32_t),
+                  "VectorReg must be layout-compatible with raw lane storage");
+    return *reinterpret_cast<const simdojo::VectorReg<N, uint32_t> *>(vgpr_data(base));
+  }
+
   /// @brief Return the SGPR register file (for serialization).
   /// @returns Const reference to the SGPR register file.
   const simdojo::RegisterFile<uint32_t> &sgpr_file() const { return sgpr_file_; }

--- a/emulation/rocjitsu/lib/simdojo/include/simdojo/components/vector_reg.h
+++ b/emulation/rocjitsu/lib/simdojo/include/simdojo/components/vector_reg.h
@@ -9,6 +9,7 @@
 
 #include "util/bit.h"
 #include "util/meta_programming.h"
+#include "util/simd.h"
 
 #include <array>
 #include <cstddef>
@@ -40,6 +41,55 @@ public:
 
   VecElem operator[](size_t idx) const { return data_[idx]; }
   VecElem &operator[](size_t idx) { return data_[idx]; }
+
+  /// SIMD load of `native<T>` from W contiguous lanes starting at `lane_base`.
+  /// The storage pointer never escapes the object. T is a 32-bit lane type.
+  template <typename T> util::native<T> simd_load(size_t lane_base) const {
+    static_assert(sizeof(T) == sizeof(VecElem), "simd_load: T must match element width");
+    return util::load<T>(reinterpret_cast<const uint32_t *>(&data_[lane_base]));
+  }
+
+  /// Masked SIMD store of `v` into W contiguous lanes at `lane_base`; bit i of
+  /// `mask` enables lane `lane_base + i`.
+  template <typename T> void simd_store(size_t lane_base, util::native<T> v, uint64_t mask) {
+    static_assert(sizeof(T) == sizeof(VecElem), "simd_store: T must match element width");
+    util::masked_store<T>(reinterpret_cast<uint32_t *>(&data_[lane_base]), v, mask);
+  }
+
+  /// Narrow (native_width64-wide) SIMD load of a 32-bit lane type from W
+  /// contiguous lanes at `lane_base`, used by the mixed-width f64<->32-bit glue.
+  /// The storage pointer never escapes the object.
+  template <typename T> util::narrow32<T> simd_load_narrow(size_t lane_base) const {
+    static_assert(sizeof(T) == sizeof(VecElem), "simd_load_narrow: T must match element width");
+    return util::load_narrow<T>(reinterpret_cast<const uint32_t *>(&data_[lane_base]));
+  }
+
+  /// Masked narrow (native_width64-wide) SIMD store of a 32-bit lane type into W
+  /// contiguous lanes at `lane_base`; bit i of `mask` enables lane `lane_base + i`.
+  template <typename T>
+  void simd_store_narrow(size_t lane_base, util::narrow32<T> v, uint64_t mask) {
+    static_assert(sizeof(T) == sizeof(VecElem), "simd_store_narrow: T must match element width");
+    util::masked_store_narrow<T>(reinterpret_cast<uint32_t *>(&data_[lane_base]), v, mask);
+  }
+
+  /// 64-bit-lane SIMD load combining this register (lo, bits [31:0]) with `hi`
+  /// (bits [63:32]) over W = native_width64 lanes at `lane_base`. T is a 64-bit
+  /// lane type. The two storage pointers never escape the objects.
+  template <typename T> util::native<T> simd_load64(const VectorReg &hi, size_t lane_base) const {
+    static_assert(sizeof(T) == sizeof(uint64_t), "simd_load64: T must be a 64-bit lane type");
+    return util::load64<T>(reinterpret_cast<const uint32_t *>(&data_[lane_base]),
+                           reinterpret_cast<const uint32_t *>(&hi.data_[lane_base]));
+  }
+
+  /// Masked 64-bit-lane SIMD store of `v` into this register (lo) + `hi` over W =
+  /// native_width64 lanes at `lane_base`; bit i of `mask` enables lane
+  /// `lane_base + i`. The two storage pointers never escape the objects.
+  template <typename T>
+  void simd_store64(VectorReg &hi, size_t lane_base, util::native<T> v, uint64_t mask) {
+    static_assert(sizeof(T) == sizeof(uint64_t), "simd_store64: T must be a 64-bit lane type");
+    util::masked_store64<T>(reinterpret_cast<uint32_t *>(&data_[lane_base]),
+                            reinterpret_cast<uint32_t *>(&hi.data_[lane_base]), v, mask);
+  }
 
   template <size_t OtherN, typename OtherVecElem>
     requires(num_elems_ == VectorReg<OtherN, OtherVecElem>::num_elems_)

--- a/emulation/rocjitsu/lib/util/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/util/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-add_library(util INTERFACE)
-target_include_directories(util INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+add_library(util STATIC src/simd.cpp)
+target_include_directories(util PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+set_target_properties(util PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/emulation/rocjitsu/lib/util/include/util/data_types.h
+++ b/emulation/rocjitsu/lib/util/include/util/data_types.h
@@ -6,8 +6,20 @@
 
 #include <bit>
 #include <cmath>
+#include <cstddef>
 #include <cstdint>
 #include <limits>
+
+// Platform feature detection for the vectorized f16<->f32 block converters.
+// x86 gets an F16C specialization; every other target (incl. ARM until a NEON
+// path is added) uses the portable scalar fallback below.
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__)
+#define UTIL_ARCH_X86 1
+#if defined(__AVX512F__) || defined(__F16C__)
+#include <immintrin.h>
+#define UTIL_HAS_X86_F16C 1
+#endif
+#endif
 
 namespace util {
 
@@ -37,6 +49,46 @@ inline float f16_to_f32(uint16_t h) {
     f = (sign << 31) | ((exp + 127 - 15) << 23) | (mant << 13);
   }
   return std::bit_cast<float>(f);
+}
+
+namespace detail {
+
+#if defined(UTIL_HAS_X86_F16C)
+/// x86 F16C specialization: convert as many halves as the widest available
+/// vector covers, advancing `i`. AVX-512 does 16/instr, AVX2 F16C does 8.
+/// `_mm*_cvtph_ps` is IEEE-754 and bit-identical to f16_to_f32 for every
+/// non-NaN input (verified exhaustively over all 65536 halves; NaN -> NaN with
+/// a possibly different payload, which the SIMD execute paths tolerate).
+inline void f16_to_f32_block_arch(const uint16_t *src, float *dst, size_t n, size_t &i) {
+#if defined(__AVX512F__)
+  for (; i + 16 <= n; i += 16)
+    _mm512_storeu_ps(
+        &dst[i], _mm512_cvtph_ps(_mm256_loadu_si256(reinterpret_cast<const __m256i *>(src + i))));
+#endif
+  for (; i + 8 <= n; i += 8)
+    _mm256_storeu_ps(&dst[i],
+                     _mm256_cvtph_ps(_mm_loadu_si128(reinterpret_cast<const __m128i *>(src + i))));
+}
+#else
+/// Portable fallback (non-x86, or x86 without F16C). No vector advance; the
+/// scalar loop in f16_to_f32_block does all the work.
+/// TODO(arm): add an __aarch64__ NEON path here (vcvt_f32_f16 / fcvtl).
+inline void f16_to_f32_block_arch(const uint16_t *, float *, size_t, size_t &) {}
+#endif
+
+} // namespace detail
+
+/// @brief Convert `n` contiguous IEEE-754 half values to float.
+///
+/// Dispatches to a per-architecture vector backend (x86 F16C today) and falls
+/// back to scalar f16_to_f32 for the remaining tail and on platforms without a
+/// vector path. ~70x faster than the scalar bit-twiddling loop on AVX-512.
+/// Hot path: MFMA f16 input gather, which converts 1024 halves per instruction.
+inline void f16_to_f32_block(const uint16_t *src, float *dst, size_t n) {
+  size_t i = 0;
+  detail::f16_to_f32_block_arch(src, dst, n, i);
+  for (; i < n; ++i)
+    dst[i] = f16_to_f32(src[i]);
 }
 
 /// @brief Convert a float to 16-bit IEEE 754 half-precision.

--- a/emulation/rocjitsu/lib/util/include/util/simd.h
+++ b/emulation/rocjitsu/lib/util/include/util/simd.h
@@ -9,6 +9,7 @@
 #include <bit>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <type_traits>
 
 #if __has_include(<experimental/simd>)
@@ -28,12 +29,29 @@ inline constexpr bool has_stdx_simd =
     false;
 #endif
 
-/// Per-thread switch that callers check before taking the SIMD fast
-/// path. Used by tests/benchmarks to A/B SIMD vs scalar in one process.
-inline bool &force_scalar() {
-  static thread_local bool flag = false;
-  return flag;
+namespace detail {
+inline bool init_force_scalar() {
+  const char *e = std::getenv("RJ_FORCE_SCALAR");
+  return e && e[0] && !(e[0] == '0' && e[1] == '\0');
 }
+/// Process-wide force-scalar gate, initialized ONCE from the `RJ_FORCE_SCALAR`
+/// env var at startup (dynamic init) and read with a plain load thereafter --
+/// no per-call guard byte. Mutable so a test-only seam can override it
+/// in-process (see util/simd_test_hooks.h); production code never writes it.
+/// Safe as a dynamic-init global because force_scalar() is only ever read at
+/// runtime instruction-execute, never during another TU's static construction.
+inline bool g_force_scalar = init_force_scalar();
+} // namespace detail
+
+/// Process-wide switch that callers check before taking the SIMD fast path.
+/// Read ONCE from the `RJ_FORCE_SCALAR` env var at startup (unset/empty/"0" =>
+/// false, any other value => true). Production code never writes it; a
+/// test-only seam (util/simd_test_hooks.h) may override it in-process so a
+/// single test can drive both the scalar and SIMD execute paths and compare.
+///
+/// e2e runs force the scalar codepath by setting `RJ_FORCE_SCALAR` before
+/// launch, without recompiling.
+inline bool force_scalar() { return detail::g_force_scalar; }
 
 #if __has_include(<experimental/simd>)
 namespace stdx = std::experimental;
@@ -57,7 +75,23 @@ template <class T> inline native<T> load(const uint32_t *) { return {}; }
 template <class T> inline native<T> broadcast(uint32_t) { return {}; }
 template <class T> inline void masked_store(uint32_t *, native<T>, uint64_t) {}
 template <class T> inline void blit_to_buffer(uint32_t (&)[native<T>::size()], native<T>) {}
+template <class T> inline native<T> load64(const uint32_t *, const uint32_t *) { return {}; }
+template <class T> inline native<T> broadcast64(uint64_t) { return {}; }
+template <class T> inline void masked_store64(uint32_t *, uint32_t *, native<T>, uint64_t) {}
+template <class T> struct narrow32 {
+  static constexpr std::size_t size() { return 1; }
+  constexpr T operator[](std::size_t) const { return T{}; }
+};
+template <class T> inline narrow32<T> load_narrow(const uint32_t *) { return {}; }
+template <class T> inline narrow32<T> broadcast_narrow(uint32_t) { return {}; }
+template <class T> inline void masked_store_narrow(uint32_t *, narrow32<T>, uint64_t) {}
 #endif
+
+/// Native-SIMD width for 64-bit lane types (e.g. native<uint64_t>/<double>),
+/// measured in 64-bit lanes — half of native_width_v<uint32_t> on the same
+/// vector width (8 vs 16 on AVX-512). Defined in both branches: in the
+/// no-`<experimental/simd>` fallback native<uint64_t>::size() is 1.
+inline constexpr std::size_t native_width64 = native<uint64_t>::size();
 
 #if __has_include(<experimental/simd>)
 /// Load `native<T>` from contiguous uint32_t storage. T must be a
@@ -125,7 +159,652 @@ template <class T> inline void blit_to_buffer(uint32_t (&buf)[native<T>::size()]
   }();
   bits.copy_to(buf, stdx::vector_aligned);
 }
+
+/// Load `native<T>` (T a 64-bit trivially-copyable type) from the split lo/hi
+/// 32-bit lane arrays of an f64/i64 operand. A per-lane f64 lives as two 32-bit
+/// VGPRs at the same lane index — `lo` points at reg N's lane storage, `hi` at
+/// reg N+1's — so lane k's value is `(uint64_t)hi[k] << 32 | lo[k]`, matching
+/// `Operand::read_lane64`. `native_width64` lanes are combined; this is a scalar
+/// gather (the two arrays are not a single contiguous 64-bit load) chosen for
+/// bit-exactness over raw throughput.
+template <class T> inline native<T> load64(const uint32_t *lo, const uint32_t *hi) {
+  static_assert(sizeof(T) == sizeof(uint64_t));
+  using U64 = stdx::native_simd<uint64_t>;
+  static_assert(sizeof(native<T>) == sizeof(U64));
+  constexpr std::size_t W = U64::size();
+  alignas(U64) uint64_t buf[W];
+  for (std::size_t i = 0; i < W; ++i)
+    buf[i] = (static_cast<uint64_t>(hi[i]) << 32) | lo[i];
+  U64 bits(buf, stdx::vector_aligned);
+  if constexpr (std::is_same_v<T, uint64_t>)
+    return bits;
+  else
+    return std::bit_cast<native<T>>(bits);
+}
+
+/// Broadcast `broadcast_bits` (bit-cast to T) to every lane of `native<T>` for a
+/// 64-bit lane type. The companion of `broadcast` for the f64/i64 path; used when
+/// a source operand resolves to a scalar/immediate rather than per-lane storage.
+template <class T> inline native<T> broadcast64(uint64_t broadcast_bits) {
+  static_assert(sizeof(T) == sizeof(uint64_t));
+  using Val = native<T>;
+  if constexpr (std::is_same_v<T, uint64_t>)
+    return Val(broadcast_bits);
+  else
+    return Val(std::bit_cast<T>(broadcast_bits));
+}
+
+/// Store `v` (a 64-bit lane type) into the split lo/hi 32-bit lane arrays,
+/// blending in only the lanes whose bit is set in `mask`. Each active lane's
+/// 64-bit value is split back into lo (low 32) and hi (high 32), mirroring
+/// `Operand::write_lane64`. No full-mask contiguous fast path: lo/hi are
+/// separate registers, so the store is always a per-lane scatter.
+template <class T>
+inline void masked_store64(uint32_t *lo, uint32_t *hi, native<T> v, uint64_t mask) {
+  static_assert(sizeof(T) == sizeof(uint64_t));
+  using U64 = stdx::native_simd<uint64_t>;
+  static_assert(sizeof(native<T>) == sizeof(U64));
+  constexpr std::size_t W = U64::size();
+  U64 bits = [&] {
+    if constexpr (std::is_same_v<T, uint64_t>)
+      return v;
+    else
+      return std::bit_cast<U64>(v);
+  }();
+  alignas(U64) uint64_t buf[W];
+  bits.copy_to(buf, stdx::vector_aligned);
+  for (std::size_t i = 0; i < W; ++i)
+    if (mask & (1ULL << i)) {
+      lo[i] = static_cast<uint32_t>(buf[i]);
+      hi[i] = static_cast<uint32_t>(buf[i] >> 32);
+    }
+}
+
+/// A `native_width64`-wide SIMD of a 32-bit lane type (e.g. narrow32<float>,
+/// narrow32<int32_t>). Used by the mixed-width f64<->32-bit conversion glue: a
+/// chunk of `native_width64` (8 on AVX-512) f64 lanes pairs with the same number
+/// of 32-bit lanes, so the 32-bit side is a `fixed_size_simd` of that width — a
+/// direct `static_simd_cast` bridges it to/from `native<double>` (also
+/// `native_width64`-wide) with no bit_cast.
+template <class T> using narrow32 = stdx::fixed_size_simd<T, native_width64>;
+
+/// Load `narrow32<T>` (native_width64 lanes of a 32-bit type) from contiguous
+/// uint32_t storage. The 32-bit-source counterpart of `load` for the cvt glue.
+/// `fixed_size_simd` is not trivially copyable (so `std::bit_cast` of the whole
+/// vector is ill-formed, unlike `native_simd`); the bit reinterpretation is done
+/// per lane through the trivially-copyable scalar `T`.
+template <class T> inline narrow32<T> load_narrow(const uint32_t *p) {
+  static_assert(sizeof(T) == sizeof(uint32_t));
+  if constexpr (std::is_same_v<T, uint32_t>) {
+    return narrow32<uint32_t>(p, stdx::element_aligned);
+  } else {
+    alignas(narrow32<T>) T buf[native_width64];
+    for (std::size_t i = 0; i < native_width64; ++i)
+      buf[i] = std::bit_cast<T>(p[i]);
+    return narrow32<T>(buf, stdx::vector_aligned);
+  }
+}
+
+/// Broadcast `broadcast_bits` (bit-cast to T) to every lane of `narrow32<T>`.
+/// Companion of `broadcast` for the narrow (8-wide) cvt path; used when a source
+/// operand resolves to a scalar/immediate rather than per-lane storage.
+template <class T> inline narrow32<T> broadcast_narrow(uint32_t broadcast_bits) {
+  static_assert(sizeof(T) == sizeof(uint32_t));
+  if constexpr (std::is_same_v<T, uint32_t>)
+    return narrow32<T>(broadcast_bits);
+  else
+    return narrow32<T>(std::bit_cast<T>(broadcast_bits));
+}
+
+/// Store `v` (native_width64 lanes of a 32-bit type) into contiguous uint32_t
+/// storage at `dst`, blending in only the lanes whose bit is set in `mask`. The
+/// 32-bit-dst counterpart of `masked_store` for the f64-src cvt glue, which
+/// writes only `native_width64` 32-bit lanes per chunk.
+template <class T> inline void masked_store_narrow(uint32_t *dst, narrow32<T> v, uint64_t mask) {
+  static_assert(sizeof(T) == sizeof(uint32_t));
+  constexpr std::size_t W = native_width64;
+  const uint64_t full = util::mask<uint64_t>(static_cast<int>(W));
+  alignas(narrow32<T>) T buf[W];
+  v.copy_to(buf, stdx::vector_aligned);
+  if ((mask & full) == full) {
+    for (std::size_t i = 0; i < W; ++i)
+      dst[i] = std::bit_cast<uint32_t>(buf[i]);
+    return;
+  }
+  for (std::size_t i = 0; i < W; ++i)
+    if (mask & (1ULL << i))
+      dst[i] = std::bit_cast<uint32_t>(buf[i]);
+}
+
+/// Vectorized, bit-exact port of `f16_to_f32` (util/data_types.h). Each lane's
+/// low 16 bits hold the f16; high bits are ignored. All branch selection is
+/// done with `where`-masks in the uint32 domain. Bit-identical to the scalar
+/// version for every input, including NaN payloads.
+inline native<float> f16_to_f32_simd(native<uint32_t> v) {
+  using U = native<uint32_t>;
+  const U h = v & 0xFFFFu;
+  const U sign = (h >> 15) & 1u;
+  const U exp = (h >> 10) & 0x1Fu;
+  const U mant = h & 0x3FFu;
+  const U sign31 = sign << 31;
+
+  // Normal (exp 1..30): rebias exponent 15 -> 127 (delta 112). Default path.
+  U bits = sign31 | ((exp + 112u) << 23) | (mant << 13);
+
+  // Inf / NaN (exp == 31): keep mantissa, set max exponent.
+  stdx::where(exp == 31u, bits) = sign31 | 0x7F800000u | (mant << 13);
+
+  // Zero (exp == 0 && mant == 0).
+  stdx::where(exp == 0u && mant == 0u, bits) = sign31;
+
+  // Denormal (exp == 0 && mant != 0): renormalize. p = index of the highest
+  // set bit of mant; mant is in 1..1023 (< 2^24) so the int->float cast is
+  // exact and p = floor(log2(mant)) reads straight out of the f32 exponent.
+  const native<float> mf = stdx::static_simd_cast<native<float>>(mant);
+  const U p = (std::bit_cast<U>(mf) >> 23) - 127u;
+  // Scalar k = 10 - p shifts; exp_final = 1 - k = p - 9; exp field = p + 103.
+  const U dn = sign31 | ((p + 103u) << 23) | (((mant << (10u - p)) & 0x3FFu) << 13);
+  stdx::where(exp == 0u && mant != 0u, bits) = dn;
+
+  return std::bit_cast<native<float>>(bits);
+}
+
+/// Vectorized, bit-exact port of `f32_to_f16` (util/data_types.h). Returns the
+/// f16 bits in the low 16 bits of each lane (high bits zero). All conditions
+/// are expressed as unsigned comparisons on the biased f32 exponent `fe`, so
+/// every mask stays in the uint32 domain. The exponent rebias e = fe - 112
+/// maps the scalar branches to: nan/inf fe==255, overflow fe>=143, normal
+/// fe 113..142, denormal fe 102..112, flush fe<102.
+inline native<uint32_t> f32_to_f16_simd(native<float> val) {
+  using U = native<uint32_t>;
+  const U f = std::bit_cast<U>(val);
+  const U sign = (f >> 16) & 0x8000u;
+  const U fe = (f >> 23) & 0xFFu;
+  const U fm = f & 0x7FFFFFu;
+
+  // Normal path (default; overwritten for the other ranges below).
+  U m = fm >> 13;
+  const U rb = (fm >> 12) & 1u;
+  U sticky(0u);
+  stdx::where((fm & 0xFFFu) != 0u, sticky) = 1u;
+  m = m + (rb & (sticky | (m & 1u)));
+  U exp_n = fe - 112u;
+  const auto carry = (m > 0x3FFu); // mantissa rounded up into the exponent
+  stdx::where(carry, m) = 0u;
+  stdx::where(carry, exp_n) = exp_n + 1u;
+  U out = sign | (exp_n << 10) | m;
+  stdx::where(carry && exp_n >= 31u, out) = sign | 0x7C00u; // carry overflow -> Inf
+
+  // Denormal (fe 102..112): m' = fm|0x800000, shift right by sh=126-fe (14..24)
+  // with round-to-nearest-even.
+  const U mm = fm | 0x800000u;
+  // sh = 126 - fe is in [14,24] for the real denormal range (fe 102..112), but
+  // lanes with fe < 102 (flushed to zero below) yield sh up to 126. Clamp to 31
+  // so the shifts here never hit undefined/masked behaviour; those lanes are
+  // overwritten by the `fe < 102` flush, so the clamped value is discarded.
+  U sh = 126u - fe;
+  stdx::where(sh > 31u, sh) = 31u;
+  const U drb = (mm >> (sh - 1u)) & 1u;
+  const U mask_lo = (1u << (sh - 1u)) - 1u;
+  U dsticky(0u);
+  stdx::where((mm & mask_lo) != 0u, dsticky) = 1u;
+  U r = mm >> sh;
+  r = r + (drb & (dsticky | (r & 1u)));
+  stdx::where(fe <= 112u, out) = sign | r;
+
+  // Flush to zero (fe < 102) and saturate to Inf (fe 143..254).
+  stdx::where(fe < 102u, out) = sign;
+  stdx::where(fe >= 143u && fe <= 254u, out) = sign | 0x7C00u;
+
+  // Inf / NaN (fe == 255): NaN keeps payload MSBs and forces the low bit.
+  stdx::where(fe == 255u, out) = sign | 0x7C00u;
+  stdx::where(fe == 255u && fm != 0u, out) = sign | 0x7C00u | (fm >> 13) | 1u;
+
+  return out;
+}
+
+/// Bit-exact SIMD rounding helpers (trunc / ceil / floor / round-to-nearest-even).
+///
+/// libstdc++'s `std::experimental::simd` rounding intrinsics are NOT bit-exact
+/// against the scalar `std::trunc/ceil/floor/nearbyint` at every vector width:
+/// at SSE width (native_simd<float> of size 4) they (a) drop the sign of a
+/// zero-magnitude result (e.g. trunc(-0.3) yields +0.0 instead of -0.0) and
+/// (b) mangle the payload/quiet bit of a NaN input instead of returning it
+/// unchanged. The scalar generated bodies these SIMD fast paths must match use
+/// the libc functions, which preserve sign-of-zero and pass NaNs through
+/// verbatim. So we run the stdx intrinsic for the finite, nonzero-result lanes
+/// and then repair the two edge cases by blend:
+///   - NaN input lane: return the input bits unchanged.
+///   - zero-magnitude result lane: copy the input's sign bit onto the +0 the
+///     intrinsic produced (IEEE-754 round-to-integer keeps the operand sign on
+///     a zero result, so this is exactly the sign of the *input*).
+/// Bit-identical to the scalar reference at every native width.
+template <class Float, class Round>
+inline native<Float> round_fixup_simd(native<Float> a, Round round) {
+  using F = native<Float>;
+  using U = std::conditional_t<sizeof(Float) == 4, native<uint32_t>, native<uint64_t>>;
+  using Bits = typename U::value_type;
+  static_assert(sizeof(Bits) == sizeof(Float));
+  constexpr Bits kSign = Bits(1) << (sizeof(Bits) * 8 - 1);
+  // Quiet bit = MSB of the mantissa (bit 22 for f32, bit 51 for f64).
+  constexpr Bits kQuiet = Bits(1) << (sizeof(Float) == 4 ? 22 : 51);
+
+  const U ai = std::bit_cast<U>(a);
+  F r = round(a);
+  // All blends use float-domain masks (simd_mask<Float>) to match the existing
+  // f64 transcendental helpers' compile-tested pattern (== / isnan), keeping the
+  // 64-bit-mask path off the libstdc++ AVX-512 `_S_to_bits<long long>` hazard.
+  //
+  // Zero-magnitude result inherits the input sign: round-to-integer of x in
+  // (-1, 0] is -0.0 (scalar libc result), but the stdx intrinsic yields +0.0 at
+  // narrow widths. `r == 0` matches both +0 and -0 lanes.
+  const F signed_zero = std::bit_cast<F>(ai & U(kSign));
+  stdx::where(r == F(Float(0)), r) = signed_zero;
+  // NaN input -> canonical quiet NaN (sign + payload preserved, quiet bit set),
+  // exactly what scalar `std::trunc/ceil/floor/nearbyint` produce: qNaN passes
+  // through unchanged and sNaN is quieted. The stdx intrinsic instead clears the
+  // quiet bit at narrow widths, so blend the bit-correct value in explicitly.
+  const F quieted = std::bit_cast<F>(ai | U(kQuiet));
+  stdx::where(stdx::isnan(a), r) = quieted;
+  return r;
+}
+
+inline native<float> trunc_simd(native<float> a) {
+  return round_fixup_simd<float>(a, [](native<float> x) { return stdx::trunc(x); });
+}
+inline native<float> ceil_simd(native<float> a) {
+  return round_fixup_simd<float>(a, [](native<float> x) { return stdx::ceil(x); });
+}
+inline native<float> floor_simd(native<float> a) {
+  return round_fixup_simd<float>(a, [](native<float> x) { return stdx::floor(x); });
+}
+inline native<float> rndne_simd(native<float> a) {
+  return round_fixup_simd<float>(a, [](native<float> x) { return stdx::nearbyint(x); });
+}
+
+inline native<double> trunc_simd(native<double> a) {
+  return round_fixup_simd<double>(a, [](native<double> x) { return stdx::trunc(x); });
+}
+inline native<double> ceil_simd(native<double> a) {
+  return round_fixup_simd<double>(a, [](native<double> x) { return stdx::ceil(x); });
+}
+inline native<double> floor_simd(native<double> a) {
+  return round_fixup_simd<double>(a, [](native<double> x) { return stdx::floor(x); });
+}
+inline native<double> rndne_simd(native<double> a) {
+  return round_fixup_simd<double>(a, [](native<double> x) { return stdx::nearbyint(x); });
+}
+
+/// Flush f32 denormals to sign-preserving zero (FTZ). Branchless vector port of
+/// `amdgpu::transcendental::flush_denorm_f32`: a lane with biased exponent 0 and
+/// nonzero mantissa becomes ±0 (sign preserved); every other lane (normal, Inf,
+/// NaN, ±0) passes through unchanged. AMD transcendental micro-ops always run in
+/// FTZ mode, so the f32 rcp/rsq/exp/log SIMD ports below funnel through this.
+inline native<float> flush_denorm_f32_simd(native<float> v) {
+  using U = native<uint32_t>;
+  U b = std::bit_cast<U>(v);
+  stdx::where(((b & 0x7F800000u) == 0u) && ((b & 0x007FFFFFu) != 0u), b) = b & 0x80000000u;
+  return std::bit_cast<native<float>>(b);
+}
+
+/// Vector ports of `amdgpu::transcendental::*_f32`, mirroring the scalar
+/// reference body bit-for-bit so the VOP1 SIMD fast path agrees with the
+/// forced-scalar path on every lane. The ±0/Inf special cases fall out of IEEE
+/// div/sqrt after the FTZ input flush; only NaN-input preservation (scalar
+/// returns the input NaN unchanged) and the negative-domain canonical qNaN
+/// (0x7FC00000) need explicit blends. The 16-bit (f16) ops reuse these on the
+/// f16->f32 intermediate, matching the scalar `f32_to_f16(rcp_f32(f16_to_f32))`.
+// Canonical positive quiet-NaN (f32), broadcast across the vector. Shared by
+// the transcendental fast paths below, which blend it into out-of-domain
+// lanes (negative sqrt/rsqrt, log of a negative) to match the scalar refs.
+inline const native<float> kQNaN = std::bit_cast<native<float>>(native<uint32_t>(0x7FC00000u));
+
+inline native<float> rcp_f32_simd(native<float> a) {
+  native<float> x = flush_denorm_f32_simd(a);
+  native<float> r = flush_denorm_f32_simd(native<float>(1.0f) / x);
+  stdx::where(stdx::isnan(a), r) = a;
+  return r;
+}
+
+inline native<float> rsq_f32_simd(native<float> a) {
+  native<float> x = flush_denorm_f32_simd(a);
+  native<float> r = flush_denorm_f32_simd(native<float>(1.0f) / stdx::sqrt(x));
+  stdx::where(x < native<float>(0.0f), r) = kQNaN; // negatives incl -Inf -> qNaN
+  stdx::where(stdx::isnan(a), r) = a;
+  return r;
+}
+
+inline native<float> sqrt_f32_simd(native<float> a) {
+  native<float> r = stdx::sqrt(a); // no FTZ flush: scalar sqrt_f32 keeps denormals
+  stdx::where(a < native<float>(0.0f), r) = kQNaN;
+  stdx::where(stdx::isnan(a), r) = a;
+  return r;
+}
+
+inline native<float> log_f32_simd(native<float> a) {
+  native<float> x = flush_denorm_f32_simd(a);
+  native<float> r = stdx::log2(x); // input-flush only; scalar log_f32 has no out-flush
+  stdx::where(x < native<float>(0.0f), r) = kQNaN;
+  stdx::where(stdx::isnan(a), r) = a;
+  return r;
+}
+
+inline native<float> exp_f32_simd(native<float> a) {
+  native<float> x = flush_denorm_f32_simd(a);
+  native<float> r = flush_denorm_f32_simd(stdx::exp2(x));
+  stdx::where(stdx::isnan(a), r) = a;
+  return r;
+}
+
+/// Branchless SWAR population count over a uint32 vector. Each lane holds
+/// std::popcount(lane) in [0, 32], bit-identical to the scalar std::popcount.
+/// Used by the bit-scan VOP1/VOP3 SIMD fast paths (bcnt / ffbh / ffbl / cls).
+inline native<uint32_t> popcount_u32_simd(native<uint32_t> x) {
+  using U = native<uint32_t>;
+  x = x - ((x >> 1) & U(0x55555555u));
+  x = (x & U(0x33333333u)) + ((x >> 2) & U(0x33333333u));
+  x = (x + (x >> 4)) & U(0x0F0F0F0Fu);
+  x = x + (x >> 8);
+  x = x + (x >> 16);
+  return x & U(0x3Fu);
+}
+
+/// Count leading zeros over a uint32 vector. RAW count: a zero input yields 32
+/// (callers blend the AMD `0xFFFFFFFF`-on-zero sentinel themselves). Computed
+/// as 32 - popcount(MSB-smear), so a lane with its MSB at bit b yields 31 - b.
+inline native<uint32_t> clz_u32_simd(native<uint32_t> x) {
+  using U = native<uint32_t>;
+  U s = x;
+  s = s | (s >> 1);
+  s = s | (s >> 2);
+  s = s | (s >> 4);
+  s = s | (s >> 8);
+  s = s | (s >> 16);
+  return U(32u) - popcount_u32_simd(s);
+}
+
+/// Count trailing zeros over a uint32 vector. RAW count: a zero input yields 32
+/// (callers blend the AMD `0xFFFFFFFF`-on-zero sentinel themselves). Computed as
+/// popcount((x & -x) - 1): isolate the lowest set bit, then count the bits below.
+inline native<uint32_t> ctz_u32_simd(native<uint32_t> x) {
+  using U = native<uint32_t>;
+  U lowbit = x & (~x + U(1u));
+  return popcount_u32_simd(lowbit - U(1u));
+}
+
+/// Vector port of `util::fp8_e4m3_to_f32` over the low byte of each lane (E4M3:
+/// 1 sign / 4 exp / 3 mantissa, bias 7, no Inf). Bit-identical to the scalar:
+/// the denormal path `mant * 2^-9` is exact for mant in [0,7] and folds the ±0
+/// case (mant==0 -> +0 | signbit); exp==15 yields the max normal (mant==0) or a
+/// canonical qNaN (mant!=0). Used by the v_cvt_f32_fp8 SIMD fast path.
+inline native<float> fp8_e4m3_to_f32_simd(native<uint32_t> v) {
+  using U = native<uint32_t>;
+  U b = v & U(0xFFu);
+  U sign = (b >> 7) & U(1u);
+  U exp = (b >> 3) & U(0xFu);
+  U mant = b & U(0x7u);
+  U signbit = sign << 31;
+  U normal = signbit | ((exp + U(120u)) << 23) | (mant << 20); // exp + 127 - 7
+  U inf_nan = signbit | U(0x43800000u);                        // exp15, mant0 -> max normal
+  stdx::where(mant != 0u, inf_nan) = signbit | U(0x7FC00000u); // exp15, mant!=0 -> qNaN
+  native<float> dn =
+      stdx::static_simd_cast<native<float>>(mant) * native<float>(0.001953125f); // 2^-9
+  U dnb = std::bit_cast<U>(dn) | signbit; // exp0: ±denormal, or ±0 when mant==0
+  U out = normal;
+  stdx::where(exp == 0u, out) = dnb;
+  stdx::where(exp == 15u, out) = inf_nan;
+  return std::bit_cast<native<float>>(out);
+}
+
+/// Vector port of `util::bf8_e5m2_to_f32` over the low byte of each lane (E5M2:
+/// 1 sign / 5 exp / 2 mantissa, bias 15, has Inf). Bit-identical to the scalar:
+/// the denormal path `mant * 2^-16` is exact for mant in [0,3] and folds the ±0
+/// case; exp==31 yields ±Inf (mant==0) or a canonical qNaN (mant!=0). Used by
+/// the v_cvt_f32_bf8 SIMD fast path.
+inline native<float> bf8_e5m2_to_f32_simd(native<uint32_t> v) {
+  using U = native<uint32_t>;
+  U b = v & U(0xFFu);
+  U sign = (b >> 7) & U(1u);
+  U exp = (b >> 2) & U(0x1Fu);
+  U mant = b & U(0x3u);
+  U signbit = sign << 31;
+  U normal = signbit | ((exp + U(112u)) << 23) | (mant << 21); // exp + 127 - 15
+  U inf_nan = signbit | U(0x7F800000u);                        // exp31, mant0 -> ±Inf
+  stdx::where(mant != 0u, inf_nan) = signbit | U(0x7FC00000u); // exp31, mant!=0 -> qNaN
+  native<float> dn =
+      stdx::static_simd_cast<native<float>>(mant) * native<float>(1.52587890625e-05f); // 2^-16
+  U dnb = std::bit_cast<U>(dn) | signbit; // exp0: ±denormal, or ±0 when mant==0
+  U out = normal;
+  stdx::where(exp == 0u, out) = dnb;
+  stdx::where(exp == 31u, out) = inf_nan;
+  return std::bit_cast<native<float>>(out);
+}
+
+/// Vector port of the f32 `std::frexp` mantissa over raw float bits. Returns the
+/// significand m with |m| in [0.5, 1) such that input = m * 2^e (e via
+/// frexp_exp_f32_simd). Normal lanes force the exponent field to 126 and keep
+/// the mantissa; ±0 / Inf / NaN pass through unchanged (matching glibc frexp,
+/// which the scalar body calls unguarded); denormals are renormalized via the
+/// highest-set-bit index p = floor(log2(M)) (M < 2^24, so the int->float cast is
+/// exact and p reads out of the f32 exponent field). Bit-identical to the scalar
+/// v_frexp_mant_f32 body.
+inline native<float> frexp_mant_f32_simd(native<uint32_t> v) {
+  using U = native<uint32_t>;
+  U sign = v & U(0x80000000u);
+  U E = (v >> 23) & U(0xFFu);
+  U M = v & U(0x7FFFFFu);
+  U normal = sign | (U(126u) << 23) | M; // exponent forced to 2^-1
+  // Denormal: p = index of highest set bit of M; mantissa <<= (23 - p), drop the
+  // implicit leading 1, exponent field stays 126.
+  const native<float> mf = stdx::static_simd_cast<native<float>>(M);
+  const U p = (std::bit_cast<U>(mf) >> 23) - U(127u);
+  U dn = sign | (U(126u) << 23) | ((M << (U(23u) - p)) & U(0x7FFFFFu));
+  U out = normal;
+  stdx::where(E == 0u, out) = v;                 // ±0 (M==0); overwritten if denormal
+  stdx::where((E == 0u) && (M != 0u), out) = dn; // denormal -> renormalized
+  stdx::where(E == 255u, out) = v;               // Inf passes through unchanged
+  // frexp quiets signaling NaNs (sets the mantissa MSB) while preserving the
+  // payload; qNaN inputs are unchanged by the idempotent OR.
+  stdx::where((E == 255u) && (M != 0u), out) = v | U(0x00400000u);
+  return std::bit_cast<native<float>>(out);
+}
+
+/// Vector port of the f32 `std::frexp` exponent over raw float bits, returned as
+/// the raw bits of the int32 result. Normal lanes give E - 126; denormals give
+/// p - 148 (p = floor(log2(M))); ±0 / Inf / NaN give 0 (the scalar body only
+/// calls frexp on finite non-zero inputs, leaving exp = 0 otherwise). Negative
+/// results carry the correct two's-complement bits. Bit-identical to the scalar
+/// v_frexp_exp_i32_f32 body.
+inline native<uint32_t> frexp_exp_f32_simd(native<uint32_t> v) {
+  using U = native<uint32_t>;
+  U E = (v >> 23) & U(0xFFu);
+  U M = v & U(0x7FFFFFu);
+  U normal = E - U(126u);
+  const native<float> mf = stdx::static_simd_cast<native<float>>(M);
+  const U p = (std::bit_cast<U>(mf) >> 23) - U(127u);
+  U dn = p - U(148u);
+  U out = normal;
+  stdx::where(E == 0u, out) = U(0u);             // ±0 (M==0); overwritten if denormal
+  stdx::where((E == 0u) && (M != 0u), out) = dn; // denormal exponent
+  stdx::where(E == 255u, out) = U(0u);           // Inf / NaN -> 0
+  return out;
+}
+
+/// 64-bit-lane port of the f64 `std::frexp` mantissa over native<double>. Same
+/// structure as frexp_mant_f32_simd at f64 widths (11 exp bits bias 1023, 52
+/// mantissa bits): normal lanes force the exponent field to 1022; denormals
+/// renormalize via p = floor(log2(M)) read from double(M)'s exponent (M < 2^53,
+/// exact); ±0 / Inf pass through; NaN is quieted (mantissa MSB set). Bit-identical
+/// to the scalar v_frexp_mant_f64 body.
+inline native<double> frexp_mant_f64_simd(native<double> x) {
+  using U = native<uint64_t>;
+  U v = std::bit_cast<U>(x);
+  U sign = v & U(0x8000000000000000ull);
+  U E = (v >> 52) & U(0x7FFull);
+  U M = v & U(0xFFFFFFFFFFFFFull); // 52 mantissa bits
+  U normal = sign | (U(1022ull) << 52) | M;
+  const native<double> mf = stdx::static_simd_cast<native<double>>(M);
+  const U p = (std::bit_cast<U>(mf) >> 52) - U(1023ull);
+  U dn = sign | (U(1022ull) << 52) | ((M << (U(52ull) - p)) & U(0xFFFFFFFFFFFFFull));
+  U out = normal;
+  stdx::where(E == 0ull, out) = v;                   // ±0 (M==0); overwritten if denormal
+  stdx::where((E == 0ull) && (M != 0ull), out) = dn; // denormal -> renormalized
+  stdx::where(E == 2047ull, out) = v;                // Inf passes through unchanged
+  stdx::where((E == 2047ull) && (M != 0ull), out) = v | U(0x0008000000000000ull); // quiet NaN
+  return std::bit_cast<native<double>>(out);
+}
+
+/// 64-bit-lane port of the f64 `std::frexp` exponent. Returns each int32 result
+/// in the low 32 bits of a native<uint64_t> lane (sign-extended), so the CVT
+/// f64->b32 glue narrows it with one static_simd_cast. Normal lanes give
+/// E - 1022; denormals p - 1073; ±0 / Inf / NaN give 0 (the scalar guards
+/// frexp to finite non-zero inputs). Bit-identical to v_frexp_exp_i32_f64.
+inline native<uint64_t> frexp_exp_f64_simd(native<double> x) {
+  using U = native<uint64_t>;
+  U v = std::bit_cast<U>(x);
+  U E = (v >> 52) & U(0x7FFull);
+  U M = v & U(0xFFFFFFFFFFFFFull);
+  U normal = E - U(1022ull);
+  const native<double> mf = stdx::static_simd_cast<native<double>>(M);
+  const U p = (std::bit_cast<U>(mf) >> 52) - U(1023ull);
+  U dn = p - U(1073ull);
+  U out = normal;
+  stdx::where(E == 0ull, out) = U(0ull);
+  stdx::where((E == 0ull) && (M != 0ull), out) = dn;
+  stdx::where(E == 2047ull, out) = U(0ull);
+  return out;
+}
+
+/// Sum of the four per-byte absolute differences of two uint32 lanes (the core
+/// of v_sad_u8 / v_sad_hi_u8). Each byte difference is in [0,255], so the sum is
+/// in [0,1020]; bit-identical to the scalar byte loop.
+inline native<uint32_t> sad_bytes_u32_simd(native<uint32_t> a, native<uint32_t> b) {
+  using U = native<uint32_t>;
+  U r(0u);
+  for (int i = 0; i < 4; ++i) {
+    U ai = (a >> (i * 8)) & U(0xFFu);
+    U bi = (b >> (i * 8)) & U(0xFFu);
+    U d = ai - bi;
+    stdx::where(bi > ai, d) = bi - ai; // |ai - bi|
+    r += d;
+  }
+  return r;
+}
+
+/// Masked per-byte SAD (v_msad_u8): like sad_bytes_u32_simd but a byte whose
+/// reference (src0) value is zero contributes nothing. Bit-identical to scalar.
+inline native<uint32_t> msad_bytes_u32_simd(native<uint32_t> a, native<uint32_t> b) {
+  using U = native<uint32_t>;
+  U r(0u);
+  for (int i = 0; i < 4; ++i) {
+    U ai = (a >> (i * 8)) & U(0xFFu);
+    U bi = (b >> (i * 8)) & U(0xFFu);
+    U d = ai - bi;
+    stdx::where(bi > ai, d) = bi - ai;
+    stdx::where(ai == 0u, d) = 0u; // skip masked-out (zero reference) bytes
+    r += d;
+  }
+  return r;
+}
+
+/// Per-byte unsigned lerp (v_lerp_u8): out_byte = a + ((b - a) * c + 128) / 256,
+/// computed independently per byte and repacked. The division is signed and
+/// truncates toward zero (matching the scalar `int / 256`), so a negative
+/// numerator gets the +1 floor->trunc correction. Bit-identical to the scalar.
+inline native<uint32_t> lerp_u8_simd(native<uint32_t> a, native<uint32_t> b, native<uint32_t> c) {
+  using U = native<uint32_t>;
+  using I = native<int32_t>;
+  U r(0u);
+  for (int i = 0; i < 4; ++i) {
+    const int sh = i * 8;
+    I ab = stdx::static_simd_cast<I>((a >> sh) & U(0xFFu));
+    I bb = stdx::static_simd_cast<I>((b >> sh) & U(0xFFu));
+    I cb = stdx::static_simd_cast<I>((c >> sh) & U(0xFFu));
+    I num = (bb - ab) * cb + I(128);
+    I q = num >> 8; // arithmetic shift == floor division by 256
+    stdx::where((num < 0) && ((num & I(255)) != 0), q) = q + I(1); // floor -> toward zero
+    I res = ab + q;
+    r = r | (stdx::static_simd_cast<U>(res) << sh);
+  }
+  return r;
+}
+
+/// Byte permute (v_perm_b32): build each output byte from a selector byte of
+/// src2 indexing the 8 bytes of the {src0:src1} 64-bit source (src1 = low word).
+/// Selector 0..7 picks a source byte; 0xD yields 0xFF; every other value yields
+/// 0. Bit-identical to the scalar byte loop.
+inline native<uint32_t> perm_b32_simd(native<uint32_t> a, native<uint32_t> b, native<uint32_t> c) {
+  using U = native<uint32_t>;
+  U srcbyte[8];
+  for (int k = 0; k < 4; ++k)
+    srcbyte[k] = (b >> (k * 8)) & U(0xFFu); // bytes 0..3 from the low word (src1)
+  for (int k = 0; k < 4; ++k)
+    srcbyte[k + 4] = (a >> (k * 8)) & U(0xFFu); // bytes 4..7 from the high word (src0)
+  U r(0u);
+  for (int i = 0; i < 4; ++i) {
+    U sel = (c >> (i * 8)) & U(0xFFu);
+    U byte(0u); // 0xC and all other selectors >= 8 -> 0
+    for (int k = 0; k < 8; ++k)
+      stdx::where(sel == U(static_cast<uint32_t>(k)), byte) = srcbyte[k];
+    stdx::where(sel == U(0xDu), byte) = U(0xFFu); // 0xD -> 0xFF
+    r = r | (byte << (i * 8));
+  }
+  return r;
+}
+
+/// High 32 bits of the 64-bit UNSIGNED product a*b (v_mul_hi_u32 semantics).
+///
+/// Computed purely with 32-bit-lane SIMD ops via the 16x16 partial-product
+/// decomposition, deliberately avoiding `fixed_size_simd<uint64_t, N>`: clang +
+/// libstdc++ miscompile the 64-bit-lane multiply/shift of an over-native-width
+/// `fixed_size_simd` (the high half comes out wrong), so the int64-widening
+/// approach diverges from the scalar `(uint64)a * b >> 32` at every SIMD width.
+/// This decomposition uses only native<uint32_t> arithmetic, so it is
+/// bit-identical to the scalar reference on every host. aHi/bHi/aLo/bLo are the
+/// 16-bit halves; each 16x16 partial fits in 32 bits and the carry chain stays
+/// below 2^32 (cross <= 3*0xFFFF), so no intermediate overflows.
+inline native<uint32_t> mul_hi_u32_simd(native<uint32_t> a, native<uint32_t> b) {
+  using U = native<uint32_t>;
+  const U aLo = a & U(0xFFFFu), aHi = a >> 16;
+  const U bLo = b & U(0xFFFFu), bHi = b >> 16;
+  const U lolo = aLo * bLo;
+  const U hilo = aHi * bLo;
+  const U lohi = aLo * bHi;
+  const U hihi = aHi * bHi;
+  const U cross = (lolo >> 16) + (hilo & U(0xFFFFu)) + (lohi & U(0xFFFFu));
+  return hihi + (hilo >> 16) + (lohi >> 16) + (cross >> 16);
+}
+
+/// High 32 bits of the 64-bit SIGNED product a*b (v_mul_hi_i32 semantics).
+/// Derived from the unsigned high word with the standard signed correction
+/// `hi_s = hi_u - (a<0 ? b : 0) - (b<0 ? a : 0)`. Same clang/libstdc++
+/// motivation as `mul_hi_u32_simd`: no `fixed_size_simd<int64_t, N>`.
+inline native<uint32_t> mul_hi_i32_simd(native<uint32_t> a, native<uint32_t> b) {
+  using U = native<uint32_t>;
+  U hi = mul_hi_u32_simd(a, b);
+  // Sign correction in the uint domain (the negative test is the high bit, so
+  // the where-mask type matches `hi` and avoids a signed/unsigned mask mismatch).
+  stdx::where((a >> 31) != U(0u), hi) = hi - b;
+  stdx::where((b >> 31) != U(0u), hi) = hi - a;
+  return hi;
+}
 #endif // __has_include(<experimental/simd>)
+
+#if !__has_include(<experimental/simd>)
+// Fallback stub for non-template gtest callers (e.g. UtilSimd.FlushDenormF32),
+// whose discarded `if constexpr (has_stdx_simd)` branch is still type-checked.
+template <class T> inline native<T> flush_denorm_f32_simd(native<T>) { return {}; }
+inline native<float> trunc_simd(native<float>) { return {}; }
+inline native<float> ceil_simd(native<float>) { return {}; }
+inline native<float> floor_simd(native<float>) { return {}; }
+inline native<float> rndne_simd(native<float>) { return {}; }
+inline native<double> trunc_simd(native<double>) { return {}; }
+inline native<double> ceil_simd(native<double>) { return {}; }
+inline native<double> floor_simd(native<double>) { return {}; }
+inline native<double> rndne_simd(native<double>) { return {}; }
+inline native<uint32_t> mul_hi_u32_simd(native<uint32_t>, native<uint32_t>) { return {}; }
+inline native<uint32_t> mul_hi_i32_simd(native<uint32_t>, native<uint32_t>) { return {}; }
+#endif
 
 } // namespace util
 

--- a/emulation/rocjitsu/lib/util/include/util/simd.h
+++ b/emulation/rocjitsu/lib/util/include/util/simd.h
@@ -29,29 +29,16 @@ inline constexpr bool has_stdx_simd =
     false;
 #endif
 
-namespace detail {
-inline bool init_force_scalar() {
-  const char *e = std::getenv("RJ_FORCE_SCALAR");
-  return e && e[0] && !(e[0] == '0' && e[1] == '\0');
-}
-/// Process-wide force-scalar gate, initialized ONCE from the `RJ_FORCE_SCALAR`
-/// env var at startup (dynamic init) and read with a plain load thereafter --
-/// no per-call guard byte. Mutable so a test-only seam can override it
-/// in-process (see util/simd_test_hooks.h); production code never writes it.
-/// Safe as a dynamic-init global because force_scalar() is only ever read at
-/// runtime instruction-execute, never during another TU's static construction.
-inline bool g_force_scalar = init_force_scalar();
-} // namespace detail
-
 /// Process-wide switch that callers check before taking the SIMD fast path.
 /// Read ONCE from the `RJ_FORCE_SCALAR` env var at startup (unset/empty/"0" =>
 /// false, any other value => true). Production code never writes it; a
 /// test-only seam (util/simd_test_hooks.h) may override it in-process so a
 /// single test can drive both the scalar and SIMD execute paths and compare.
 ///
-/// e2e runs force the scalar codepath by setting `RJ_FORCE_SCALAR` before
-/// launch, without recompiling.
-inline bool force_scalar() { return detail::g_force_scalar; }
+/// Defined in util/src/simd.cpp; the backing global is hidden in that TU. e2e
+/// runs force the scalar codepath by setting `RJ_FORCE_SCALAR` before launch,
+/// without recompiling.
+bool force_scalar();
 
 #if __has_include(<experimental/simd>)
 namespace stdx = std::experimental;

--- a/emulation/rocjitsu/lib/util/include/util/simd_test_hooks.h
+++ b/emulation/rocjitsu/lib/util/include/util/simd_test_hooks.h
@@ -10,8 +10,8 @@ namespace util {
 
 /// Test-only: override the process force-scalar gate in-process so a single
 /// test can drive both the scalar and SIMD execute paths and compare results.
-/// Production code never includes this header.
-inline void set_force_scalar_for_testing(bool v) { detail::g_force_scalar = v; }
+/// Defined in util/src/simd.cpp. Production code never includes this header.
+void set_force_scalar_for_testing(bool v);
 
 } // namespace util
 

--- a/emulation/rocjitsu/lib/util/include/util/simd_test_hooks.h
+++ b/emulation/rocjitsu/lib/util/include/util/simd_test_hooks.h
@@ -1,0 +1,18 @@
+// Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#ifndef ROCJITSU_UTIL_SIMD_TEST_HOOKS_H_
+#define ROCJITSU_UTIL_SIMD_TEST_HOOKS_H_
+
+#include "util/simd.h"
+
+namespace util {
+
+/// Test-only: override the process force-scalar gate in-process so a single
+/// test can drive both the scalar and SIMD execute paths and compare results.
+/// Production code never includes this header.
+inline void set_force_scalar_for_testing(bool v) { detail::g_force_scalar = v; }
+
+} // namespace util
+
+#endif // ROCJITSU_UTIL_SIMD_TEST_HOOKS_H_

--- a/emulation/rocjitsu/lib/util/src/simd.cpp
+++ b/emulation/rocjitsu/lib/util/src/simd.cpp
@@ -1,0 +1,37 @@
+// Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "util/simd.h"
+
+#include "util/simd_test_hooks.h"
+
+#include <cstdlib>
+#include <string_view>
+
+namespace util {
+namespace {
+
+bool init_force_scalar() {
+  const char *e = std::getenv("RJ_FORCE_SCALAR");
+  if (e == nullptr) {
+    return false;
+  }
+  const std::string_view v(e);
+  return !v.empty() && v != "0";
+}
+
+/// Process-wide force-scalar gate, initialized ONCE from the `RJ_FORCE_SCALAR`
+/// env var at startup (dynamic init) and read with a plain load thereafter --
+/// no per-call guard byte. Mutable so the test-only seam below can override it
+/// in-process; production code never writes it. Safe as a dynamic-init global
+/// because force_scalar() is only ever read at runtime instruction-execute,
+/// never during another TU's static construction.
+bool g_force_scalar = init_force_scalar();
+
+} // namespace
+
+bool force_scalar() { return g_force_scalar; }
+
+void set_force_scalar_for_testing(bool v) { g_force_scalar = v; }
+
+} // namespace util

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -305,6 +305,7 @@ if(HSA_RUNTIME64)
             hsa_translate_test
             PRIVATE
                 ${RJ_OBJECT_LIBS}
+                util
                 ${HSA_RUNTIME64}
                 GTest::gtest
                 GTest::gtest_main
@@ -355,6 +356,7 @@ if(HSA_RUNTIME64)
             cdna4_to_cdna3_dispatch_test
             PRIVATE
                 ${RJ_OBJECT_LIBS}
+                util
                 ${HSA_RUNTIME64}
                 GTest::gtest
                 GTest::gtest_main

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -53,6 +53,50 @@ add_executable(
     waitcnt_counter_test.cpp
     instruction_execution_harness_test.cpp
     decode_execute_benchmark.cpp
+    util_simd_test.cpp
+    v_add_simd_benchmark.cpp
+    simd_correctness/vop1_cvt_f64_scalar_correctness_test.cpp
+    simd_correctness/vopc_cmp_class_scalar_correctness_test.cpp
+    simd_correctness/vop2_simd_correctness_test.cpp
+    simd_correctness/vop2_carry_simd_correctness_test.cpp
+    simd_correctness/vop2_fma_simd_correctness_test.cpp
+    simd_correctness/vop2_fma_f64_simd_correctness_test.cpp
+    simd_correctness/vop2_cndmask_simd_correctness_test.cpp
+    simd_correctness/vop2_minmax_simd_correctness_test.cpp
+    simd_correctness/vop1_simd_correctness_test.cpp
+    simd_correctness/vop1_cvt_f8_simd_correctness_test.cpp
+    simd_correctness/vop1_f64_simd_correctness_test.cpp
+    simd_correctness/vop1_cvt_f64_simd_correctness_test.cpp
+    simd_correctness/vopc_simd_correctness_test.cpp
+    simd_correctness/vopc_cmp_class_simd_correctness_test.cpp
+    simd_correctness/vop3_modifier_simd_test.cpp
+    simd_correctness/vop3_binary_simd_correctness_test.cpp
+    simd_correctness/vop3_unary_simd_correctness_test.cpp
+    simd_correctness/vopc_vop3_int_simd_correctness_test.cpp
+    simd_correctness/vopc_vop3_fp32_simd_correctness_test.cpp
+    simd_correctness/vopc_vop3_fp16_simd_correctness_test.cpp
+    simd_correctness/vopc_vop3_fp64_simd_correctness_test.cpp
+    simd_correctness/vop3_ternary_int_simd_correctness_test.cpp
+    simd_correctness/vop3_cvt_f64_simd_correctness_test.cpp
+    simd_correctness/vop3_int_binary_extra_simd_correctness_test.cpp
+    simd_correctness/vop3_int_widening_ternary_simd_correctness_test.cpp
+    simd_correctness/vop3_fp64_simd_correctness_test.cpp
+    simd_correctness/vop3_carry_simd_correctness_test.cpp
+    simd_correctness/vop_alias_rdna_simd_correctness_test.cpp
+    simd_correctness/vop3_shift64_simd_correctness_test.cpp
+    simd_correctness/vop3_fp16_unary_simd_correctness_test.cpp
+    simd_correctness/vop3_fp16_transcendental_simd_correctness_test.cpp
+    simd_correctness/vop3_cndmask_pack_simd_correctness_test.cpp
+    simd_correctness/vop3_div_helpers_simd_correctness_test.cpp
+    simd_correctness/vop3_b16_rdna_simd_correctness_test.cpp
+    simd_correctness/vop3_ternary_fp_simd_correctness_test.cpp
+    simd_correctness/vop3_fmac_simd_correctness_test.cpp
+    simd_correctness/vop3_ldexp_simd_correctness_test.cpp
+    simd_correctness/vop3p_pk_binary_int_simd_correctness_test.cpp
+    simd_correctness/vop3p_pk_binary_fp16_simd_correctness_test.cpp
+    simd_correctness/vop3p_fma_mix_simd_correctness_test.cpp
+    simd_correctness/vop3p_mov_b32_simd_correctness_test.cpp
+    simd_correctness/vop3p_dot_simd_correctness_test.cpp
     execution_plugin_test.cpp
 )
 target_link_libraries(

--- a/emulation/rocjitsu/tests/simd_correctness/vop1_cvt_f64_scalar_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop1_cvt_f64_scalar_correctness_test.cpp
@@ -1,0 +1,163 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vop1_cvt_f64_scalar_correctness_test.cpp
+/// @brief Regression test for the mixed-width f64<->32-bit VOP1 conversions.
+/// These six ops have a 64-bit operand on one side and a 32-bit operand on the
+/// other; the scalar (functional-sim) bodies must read/write the f64 side
+/// through the full 64-bit lane accessors (read_lane64/write_lane64), not the
+/// 32-bit ones. A prior codegen bug bound every operand to a single
+/// instruction-level width, so the f64 side only read/wrote its low 32 bits and
+/// any double with a nonzero high word (e.g. 3.7) decoded to garbage.
+///
+/// Every input here is deliberately chosen to have a NONZERO high 32 bits on
+/// the f64 side, so a low-word-only read or a high-word-dropping write produces
+/// a visibly wrong result. No SIMD is involved (these ops are not on the SIMD
+/// fast path); this exercises the plain decode+execute scalar path.
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <bit>
+#include <cmath>
+#include <cstdint>
+#include <memory>
+
+namespace {
+
+using namespace rocjitsu;
+
+[[maybe_unused]] constexpr uint32_t WF_SIZE = 64;
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+
+constexpr uint32_t vop1_encode(uint32_t op, uint32_t vdst, uint32_t src0) {
+  return (0x3Fu << 25) | ((vdst & 0xFF) << 17) | ((op & 0xFF) << 9) | (src0 & 0x1FF);
+}
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("vop1_cvt_f64_scalar_mem"), l2("vop1_cvt_f64_scalar_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vop1_cvt_f64_scalar", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  void write64(uint32_t reg, uint32_t lane, uint64_t v) {
+    cu->write_vgpr(reg, lane, static_cast<uint32_t>(v));
+    cu->write_vgpr(reg + 1, lane, static_cast<uint32_t>(v >> 32));
+  }
+  uint64_t read64(uint32_t reg, uint32_t lane) {
+    return static_cast<uint64_t>(cu->read_vgpr(reg + 1, lane)) << 32 | cu->read_vgpr(reg, lane);
+  }
+
+  // Execute `op` once on lane 0 with src0 (v0[:v1]) seeded to `src_lo`/`src_hi`.
+  // Returns the destination VGPR pair as a 64-bit value (32-bit dst uses the
+  // low word). vdst = v2[:v3]; the dst pair is pre-stamped so a dropped high
+  // word from a 32-bit write is visible.
+  uint64_t run(uint32_t op, uint32_t src_lo, uint32_t src_hi) {
+    uint32_t vb = wf->vgpr_alloc().base;
+    wf->set_exec(~0ULL);
+    write64(vb + 0, 0, (static_cast<uint64_t>(src_hi) << 32) | src_lo);
+    write64(vb + 2, 0, 0xA5A5A5A5A5A5A5A5ull); // sentinel in dst pair
+    uint32_t enc = vop1_encode(op, /*vdst=*/2, /*src0=*/256);
+    uint32_t words[4] = {enc, 0u, 0u, 0u};
+    Instruction *inst = decoder->decode(words);
+    EXPECT_NE(inst, nullptr);
+    cu->execute_instruction(inst, *wf);
+    delete inst;
+    return read64(vb + 2, 0);
+  }
+};
+
+// --- f64 source -> 32-bit dest ------------------------------------------------
+
+TEST(Vop1CvtF64Scalar, F32FromF64_FullDoubleRead) {
+  Fixture fx;
+  ASSERT_NE(fx.cu, nullptr);
+  // Doubles with nonzero high words; a low-word-only read would corrupt them.
+  for (double d : {3.7, -3.7, 123456.789, -9.87654321e8, 1e-10, 2.5}) {
+    uint64_t bits = std::bit_cast<uint64_t>(d);
+    uint64_t got = fx.run(/*v_cvt_f32_f64=*/15, static_cast<uint32_t>(bits),
+                          static_cast<uint32_t>(bits >> 32));
+    uint32_t want = std::bit_cast<uint32_t>(static_cast<float>(d));
+    EXPECT_EQ(static_cast<uint32_t>(got), want) << "v_cvt_f32_f64 of " << d;
+  }
+}
+
+TEST(Vop1CvtF64Scalar, I32FromF64_FullDoubleRead) {
+  Fixture fx;
+  for (double d : {3.7, -3.7, 100.9, -100.9, 1e12, -1e12}) {
+    uint64_t bits = std::bit_cast<uint64_t>(d);
+    uint64_t got =
+        fx.run(/*v_cvt_i32_f64=*/3, static_cast<uint32_t>(bits), static_cast<uint32_t>(bits >> 32));
+    int32_t ref = std::isnan(d)       ? 0
+                  : d >= 2147483648.0 ? INT32_MAX
+                  : d < -2147483648.0 ? INT32_MIN
+                                      : static_cast<int32_t>(d);
+    EXPECT_EQ(static_cast<uint32_t>(got), static_cast<uint32_t>(ref)) << "v_cvt_i32_f64 of " << d;
+  }
+}
+
+TEST(Vop1CvtF64Scalar, U32FromF64_FullDoubleRead) {
+  Fixture fx;
+  for (double d : {3.7, 100.9, 4.0e9, 1e12, -1.0}) {
+    uint64_t bits = std::bit_cast<uint64_t>(d);
+    uint64_t got = fx.run(/*v_cvt_u32_f64=*/21, static_cast<uint32_t>(bits),
+                          static_cast<uint32_t>(bits >> 32));
+    uint32_t ref = (std::isnan(d) || d < 0.0) ? 0u
+                   : d >= 4294967296.0        ? UINT32_MAX
+                                              : static_cast<uint32_t>(d);
+    EXPECT_EQ(static_cast<uint32_t>(got), ref) << "v_cvt_u32_f64 of " << d;
+  }
+}
+
+// --- 32-bit source -> f64 dest (high word must be written) --------------------
+
+TEST(Vop1CvtF64Scalar, F64FromF32_HighWordWritten) {
+  Fixture fx;
+  for (float f : {3.7f, -3.7f, 123456.78f, -9.876e8f, 1e-10f, 2.5f}) {
+    uint64_t got = fx.run(/*v_cvt_f64_f32=*/16, std::bit_cast<uint32_t>(f), 0u);
+    uint64_t want = std::bit_cast<uint64_t>(static_cast<double>(f));
+    EXPECT_EQ(got, want) << "v_cvt_f64_f32 of " << f;
+  }
+}
+
+TEST(Vop1CvtF64Scalar, F64FromI32_HighWordWritten) {
+  Fixture fx;
+  for (int32_t i : {3, -3, 123456789, -987654321, INT32_MAX, INT32_MIN}) {
+    uint64_t got = fx.run(/*v_cvt_f64_i32=*/4, static_cast<uint32_t>(i), 0u);
+    uint64_t want = std::bit_cast<uint64_t>(static_cast<double>(i));
+    EXPECT_EQ(got, want) << "v_cvt_f64_i32 of " << i;
+  }
+}
+
+TEST(Vop1CvtF64Scalar, F64FromU32_HighWordWritten) {
+  Fixture fx;
+  for (uint32_t u : {3u, 123456789u, 0xFFFFFFFFu, 0x80000000u, 1u}) {
+    uint64_t got = fx.run(/*v_cvt_f64_u32=*/22, u, 0u);
+    uint64_t want = std::bit_cast<uint64_t>(static_cast<double>(u));
+    EXPECT_EQ(got, want) << "v_cvt_f64_u32 of " << u;
+  }
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vop1_cvt_f64_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop1_cvt_f64_simd_correctness_test.cpp
@@ -1,0 +1,271 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vop1_cvt_f64_simd_correctness_test.cpp
+/// @brief Bit-identity check (SIMD fast path vs scalar body) for the six
+/// mixed-width f64<->32-bit VOP1 conversions on CDNA4: the f64-source forms
+/// (v_cvt_f32_f64, v_cvt_i32_f64, v_cvt_u32_f64) and the f64-dst forms
+/// (v_cvt_f64_f32, v_cvt_f64_i32, v_cvt_f64_u32). These bridge an 8-wide
+/// (native_width64) f64 chunk and the same number of 32-bit lanes, so they use
+/// dedicated cvt glue (read_simd64 / narrow32) rather than the equal-width unary
+/// path. Each case runs TWICE in the same process -- once forcing the scalar
+/// body, once the SIMD fast path, with identical inputs/EXEC -- and the
+/// destination word pairs are asserted equal with EXPECT_EQ
+/// (util::set_force_scalar_for_testing flips the gate in-process). In-process
+/// inactive lanes must stay preserved under full/partial EXEC.
+///
+/// The float-result conversions (v_cvt_f32_f64, v_cvt_f64_f32) are correctly
+/// rounded (vcvtpd2ps / vcvtps2pd), bit-exact for finite/Inf inputs; a NaN
+/// *result* may carry a different payload between packed and scalar (accepted),
+/// so those words are excluded from the comparison — NaN-ness of the result is
+/// deterministic from the inputs, so both runs skip the same words. The int
+/// conversions are exact (NaN->0 and the saturating clamp are deterministic),
+/// compared with no carve-out.
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <bit>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <memory>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t WF_SIZE = 64;
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+// Fixed marker written over accepted-divergence (NaN-result) lanes before
+// recording, so the cross-run diff ignores them identically in both runs.
+constexpr uint32_t SKIP_SENTINEL = 0xA11D1FFFu;
+
+// CDNA4 VOP1: enc[31:25] = 0b0111111, vdst[24:17], op[16:9], src0[8:0].
+constexpr uint32_t vop1_encode(uint32_t op, uint32_t vdst, uint32_t src0) {
+  return (0x3Fu << 25) | ((vdst & 0xFF) << 17) | ((op & 0xFF) << 9) | (src0 & 0x1FF);
+}
+
+// f64-source inputs: ±0, ±1, fractional, the clamp boundaries (2^31, 2^32) and
+// values straddling them, ±huge, NaN, ±Inf, denorm, pi, -e. Exercises every
+// branch of the int clamp/NaN logic and the correctly-rounded narrowing cast.
+const std::array<double, 23> kF64In = {{
+    // f64 denormals with the highest mantissa bit at varied positions, to
+    // exercise v_frexp_exp_i32_f64's denormal renormalization across the range.
+    std::bit_cast<double>(static_cast<uint64_t>(0x000FFFFFFFFFFFFFull)), // p = 51
+    std::bit_cast<double>(static_cast<uint64_t>(0x0000000100000000ull)), // p = 32
+    std::bit_cast<double>(static_cast<uint64_t>(0x0000000000010000ull)), // p = 16
+    +0.0,
+    -0.0,
+    1.0,
+    -1.0,
+    2.5,
+    -2.5,
+    0.5,
+    3.0e9,                                     // > 2^31, < 2^32
+    5.0e9,                                     // > 2^32
+    -5.0e9,                                    // < -2^31
+    1.0e300,                                   // overflow both
+    std::numeric_limits<double>::quiet_NaN(),  //
+    std::numeric_limits<double>::infinity(),   //
+    -std::numeric_limits<double>::infinity(),  //
+    std::numeric_limits<double>::denorm_min(), //
+    2147483647.0,                              // exactly INT32_MAX
+    2147483648.0,                              // exactly 2^31
+    4294967295.0,                              // exactly UINT32_MAX
+    3.141592653589793,                         //
+    -2.718281828459045,                        //
+}};
+
+// 32-bit-source inputs, reinterpreted per op as f32 / i32 / u32 bits. Covers ±0,
+// ±1, ±Inf, NaN, denorm, pi, max (as f32) and signed/extreme boundaries (as int).
+const std::array<uint32_t, 14> kB32In = {{
+    0x00000000u,
+    0x80000000u,
+    0x3F800000u,
+    0xBF800000u,
+    0x7F800000u,
+    0xFF800000u,
+    0x7FC00000u,
+    0x00000001u,
+    0x40490FDBu,
+    0x7F7FFFFFu,
+    0xFFFFFFFFu,
+    0x7FFFFFFFu,
+    0x12345678u,
+    0xAAAA5555u,
+}};
+
+bool is_f32_nan(uint32_t bits) { return std::isnan(std::bit_cast<float>(bits)); }
+bool is_f64_nan(uint64_t bits) { return std::isnan(std::bit_cast<double>(bits)); }
+
+struct CvtCase {
+  const char *name;
+  uint32_t opcode;
+  bool src64;    // source operand is a 64-bit f64 (VGPR pair)
+  bool dst64;    // destination is a 64-bit f64 (VGPR pair)
+  bool skip_nan; // result is a float whose NaN payload may diverge (accepted)
+};
+
+const std::array<CvtCase, 7> kCases = {{
+    {"v_cvt_f32_f64", 15, true, false, true},
+    {"v_cvt_i32_f64", 3, true, false, false},
+    {"v_cvt_u32_f64", 21, true, false, false},
+    {"v_cvt_f64_f32", 16, false, true, true},
+    {"v_cvt_f64_i32", 4, false, true, false},
+    {"v_cvt_f64_u32", 22, false, true, false},
+    // frexp exponent: f64 -> int32 (low half), high half keeps sentinel; the
+    // int result is deterministic (0 for ±0/Inf/NaN), so no NaN skip.
+    {"v_frexp_exp_i32_f64", 48, true, false, false},
+}};
+
+uint64_t dst_sentinel(uint32_t lane) {
+  return (static_cast<uint64_t>(0xCAFE0000u | lane) << 32) | (0xBEEF0000u + lane);
+}
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("vop1_cvt_f64_simd_mem"), l2("vop1_cvt_f64_simd_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vop1_cvt_f64_simd", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  void write64(uint32_t reg, uint32_t lane, uint64_t v) {
+    cu->write_vgpr(reg, lane, static_cast<uint32_t>(v));
+    cu->write_vgpr(reg + 1, lane, static_cast<uint32_t>(v >> 32));
+  }
+  uint64_t read64(uint32_t reg, uint32_t lane) {
+    return static_cast<uint64_t>(cu->read_vgpr(reg + 1, lane)) << 32 | cu->read_vgpr(reg, lane);
+  }
+
+  // src0 = v0(:v1), vdst = v2(:v3). vdst is stamped with a per-lane sentinel so
+  // inactive-lane preservation is checkable in both width configurations.
+  void seed_inputs(const CvtCase &c, uint64_t exec) {
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      if (c.src64)
+        write64(vb + 0, lane, std::bit_cast<uint64_t>(kF64In[lane % kF64In.size()]));
+      else
+        cu->write_vgpr(vb + 0, lane, kB32In[lane % kB32In.size()]);
+      write64(vb + 2, lane, dst_sentinel(lane));
+    }
+    wf->set_exec(exec);
+  }
+
+  std::array<uint64_t, WF_SIZE> run(Instruction *inst, const CvtCase &c, uint64_t exec) {
+    seed_inputs(c, exec);
+    cu->execute_instruction(inst, *wf);
+    std::array<uint64_t, WF_SIZE> out{};
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+      out[lane] = read64(vb + 2, lane); // reads both halves; 32-bit dst leaves v3 = sentinel hi
+    return out;
+  }
+};
+
+// Restores the process force-scalar gate on scope exit so flipping it for an
+// in-process A/B comparison cannot leak into later tests in the same process.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+void check_case(const CvtCase &c, uint64_t exec) {
+  ForceScalarGuard gate_guard;
+
+  auto run_mode = [&](bool force_scalar) -> std::array<uint64_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    uint32_t enc = vop1_encode(c.opcode, /*vdst=*/2, /*src0=*/256);
+    uint32_t words[4] = {enc, 0u, 0u, 0u};
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << c.name << " decode failed";
+    auto out = fx.run(inst, c, exec);
+    delete inst;
+    return out;
+  };
+
+  const auto scalar_out = run_mode(/*force_scalar=*/true);
+  const auto simd_out = run_mode(/*force_scalar=*/false);
+
+  // Mask accepted-divergence words (float-result NaN payload) in BOTH arrays
+  // identically, then compare word by word. dst64 NaN masks the whole pair; the
+  // 32-bit-dst forms only mask the lo word (hi is the deterministic sentinel,
+  // always compared). The int conversions never set skip_nan.
+  for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+    const bool active = (exec >> lane) & 1ULL;
+    uint32_t s_lo = static_cast<uint32_t>(scalar_out[lane]);
+    uint32_t s_hi = static_cast<uint32_t>(scalar_out[lane] >> 32);
+    uint32_t m_lo = static_cast<uint32_t>(simd_out[lane]);
+    uint32_t m_hi = static_cast<uint32_t>(simd_out[lane] >> 32);
+    if (active && c.skip_nan) {
+      if (c.dst64) {
+        if (is_f64_nan(scalar_out[lane]) || is_f64_nan(simd_out[lane])) {
+          s_lo = m_lo = SKIP_SENTINEL;
+          s_hi = m_hi = SKIP_SENTINEL;
+        }
+      } else if (is_f32_nan(s_lo) || is_f32_nan(m_lo)) {
+        s_lo = m_lo = SKIP_SENTINEL;
+      }
+    }
+    EXPECT_EQ(s_lo, m_lo) << c.name << " lane " << lane << " lo: SIMD path diverged from scalar";
+    EXPECT_EQ(s_hi, m_hi) << c.name << " lane " << lane << " hi: SIMD path diverged from scalar";
+  }
+
+  for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+    if (!(exec & (1ULL << lane))) {
+      EXPECT_EQ(simd_out[lane], dst_sentinel(lane))
+          << c.name << " clobbered inactive lane " << lane;
+      EXPECT_EQ(scalar_out[lane], dst_sentinel(lane))
+          << c.name << " clobbered inactive lane " << lane;
+    }
+  }
+}
+
+TEST(Vop1CvtF64SimdCorrectness, FullExecMask) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_case(c, /*exec=*/~0ULL);
+}
+
+TEST(Vop1CvtF64SimdCorrectness, PartialExecMask) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  // Pattern crossing the 8-wide chunk boundaries on a wave64.
+  for (const auto &c : kCases)
+    check_case(c, /*exec=*/0xA5A5'F0F0'1234'8001ULL);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vop1_cvt_f8_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop1_cvt_f8_simd_correctness_test.cpp
@@ -1,0 +1,179 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vop1_cvt_f8_simd_correctness_test.cpp
+/// @brief Bit-identity check (SIMD fast path vs scalar body) for the f8 -> f32
+/// expand ops on CDNA4: v_cvt_f32_fp8 (E4M3) and v_cvt_f32_bf8 (E5M2), in both
+/// their VOP1 and VOP3 encodings. The 8-bit source has only 256 distinct
+/// values, so every byte 0..255 is swept exhaustively (4 wavefront fills of 64
+/// lanes) under both a full and a partial EXEC mask. The process runs one fixed
+/// execute mode (RJ_FORCE_SCALAR, immutable); each (encoding, block) runs TWICE
+/// in the same process -- once forcing the scalar body, once the SIMD fast path,
+/// with identical inputs/EXEC -- and the two 64-lane result arrays are asserted
+/// equal with EXPECT_EQ (util::set_force_scalar_for_testing flips the gate
+/// in-process). In-process inactive lanes must keep the DST sentinel.
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include "util/simd.h"
+
+#include <array>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t WF_SIZE = 64;
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+constexpr uint32_t DST_SENTINEL = 0xCAFEF00Du;
+constexpr uint32_t kDstVgpr = 2;
+
+// CDNA4 VOP1: [31:25]=0b0111111, vdst[24:17], op[16:9], src0[8:0].
+constexpr uint32_t vop1_encode(uint32_t op, uint32_t vdst, uint32_t src0) {
+  return (0x3Fu << 25) | ((vdst & 0xFF) << 17) | ((op & 0xFF) << 9) | (src0 & 0x1FF);
+}
+
+// CDNA4 VOP3 ([31:26]=0x34): word0 = vdst[7:0] | op[25:16] | (0x34<<26);
+// word1 = src0[8:0]. Unary, no modifiers exercised (the f8 cvt bodies read none).
+void vop3_encode(uint32_t op, uint32_t vdst, uint32_t src0, uint32_t words[2]) {
+  words[0] = (vdst & 0xFF) | ((op & 0x3FF) << 16) | (0x34u << 26);
+  words[1] = (src0 & 0x1FF);
+}
+
+struct Case {
+  const char *name;
+  uint32_t vop1_op;
+  uint32_t vop3_op;
+};
+
+const std::array<Case, 2> kCases = {{
+    {"v_cvt_f32_fp8", 84, 404},
+    {"v_cvt_f32_bf8", 85, 405},
+}};
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("vop1_f8_simd_mem"), l2("vop1_f8_simd_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vop1_f8_simd", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  // Lane k holds the byte (block * 64 + k) in the low 8 bits, plus high-bit
+  // noise so the body's low-byte masking is exercised too.
+  void seed_inputs(uint32_t block, uint64_t exec) {
+    uint32_t vbase = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      uint32_t byte = (block * WF_SIZE + lane) & 0xFFu;
+      uint32_t s0 = byte | 0xABCD'00u; // upper bytes must be ignored by the op
+      cu->write_vgpr(vbase + 0, lane, s0);
+      cu->write_vgpr(vbase + kDstVgpr, lane, DST_SENTINEL);
+    }
+    wf->set_exec(exec);
+  }
+
+  std::array<uint32_t, WF_SIZE> run(Instruction *inst, uint32_t block, uint64_t exec) {
+    seed_inputs(block, exec);
+    cu->execute_instruction(inst, *wf);
+    std::array<uint32_t, WF_SIZE> out{};
+    uint32_t vbase = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+      out[lane] = cu->read_vgpr(vbase + kDstVgpr, lane);
+    return out;
+  }
+};
+
+// Restores the process force-scalar gate on scope exit so flipping it for an
+// in-process A/B comparison cannot leak into later tests in the same process.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+// Decode `words` and exhaustively sweep all 256 byte values; compare scalar vs
+// SIMD per block. `label` must be unique per encoding.
+void check_words(const std::string &label, const uint32_t words[4], uint64_t exec) {
+  ForceScalarGuard gate_guard;
+
+  auto run_mode = [&](bool force_scalar, uint32_t block) -> std::array<uint32_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << label << " decode failed";
+    auto out = fx.run(inst, block, exec);
+    delete inst;
+    return out;
+  };
+
+  for (uint32_t block = 0; block < 4; ++block) { // 4 * 64 = all 256 byte values
+    const auto scalar_out = run_mode(/*force_scalar=*/true, block);
+    const auto simd_out = run_mode(/*force_scalar=*/false, block);
+
+    EXPECT_EQ(scalar_out, simd_out)
+        << label << " block=" << block << ": SIMD path diverged from scalar body";
+
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      const bool active = (exec >> lane) & 1ULL;
+      if (!active) {
+        EXPECT_EQ(simd_out[lane], DST_SENTINEL) << label << ": clobbered inactive lane " << lane;
+        EXPECT_EQ(scalar_out[lane], DST_SENTINEL) << label << ": clobbered inactive lane " << lane;
+      }
+    }
+  }
+}
+
+void check_both_encodings(const Case &c, uint64_t exec) {
+  uint32_t v1[4] = {vop1_encode(c.vop1_op, /*vdst=*/kDstVgpr, /*src0=*/256), 0u, 0u, 0u};
+  check_words(std::string(c.name) + ":vop1", v1, exec);
+  uint32_t v3[4] = {0u, 0u, 0u, 0u};
+  vop3_encode(c.vop3_op, /*vdst=*/kDstVgpr, /*src0=*/256, v3);
+  check_words(std::string(c.name) + ":vop3", v3, exec);
+}
+
+TEST(Vop1CvtF8SimdCorrectness, AllBytes_FullExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_both_encodings(c, /*exec=*/~0ULL);
+}
+
+TEST(Vop1CvtF8SimdCorrectness, AllBytes_PartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_both_encodings(c, /*exec=*/0xA5A5'F0F0'1234'8001ULL);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vop1_f64_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop1_f64_simd_correctness_test.cpp
@@ -1,0 +1,217 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vop1_f64_simd_correctness_test.cpp
+/// @brief Bit-identity check (SIMD fast path vs scalar body) for the 64-bit-lane
+/// VOP1 unary ops on CDNA4: the f64 math family (ceil/floor/trunc/rndne/fract/
+/// rcp/rsq/sqrt) and the pure 64-bit move v_mov_b64. Each case runs TWICE in the
+/// same process -- once forcing the scalar body, once the SIMD fast path, with
+/// identical inputs/EXEC -- and the destination f64 results are asserted equal
+/// per active, non-skipped lane (util::set_force_scalar_for_testing flips the
+/// gate in-process). In-process inactive lanes must stay preserved under full
+/// and partial EXEC.
+///
+/// The f64 math ops map to correctly-rounded IEEE operations (vroundpd /
+/// vsqrtpd / vdivpd), bit-exact to std::ceil/std::sqrt/... for finite and
+/// infinite inputs; a NaN *result* may carry a different NaN payload between the
+/// packed and scalar paths (accepted divergence), so those lanes are excluded
+/// from the comparison — NaN-ness of the result is deterministic from the
+/// inputs, so both runs skip the same lanes. v_mov_b64 is a pure bit copy and is
+/// compared exactly (no NaN carve-out).
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <bit>
+#include <cmath>
+#include <cstdint>
+#include <memory>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t WF_SIZE = 64;
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+
+// CDNA4 VOP1: enc[31:25] = 0b0111111, vdst[24:17], op[16:9], src0[8:0].
+constexpr uint32_t vop1_encode(uint32_t op, uint32_t vdst, uint32_t src0) {
+  return (0x3Fu << 25) | ((vdst & 0xFF) << 17) | ((op & 0xFF) << 9) | (src0 & 0x1FF);
+}
+
+// f64 inputs covering ±0, ±1, ±Inf, denormal, max, and ordinary normals. The
+// negatives feed sqrt/rsq a NaN result (skipped on compare); rcp(±0) -> ±Inf and
+// ceil/floor/trunc/rndne of the specials are well defined and bit-exact.
+const std::array<double, 18> kEdge = {{
+    +0.0, -0.0, 1.0, -1.0, 2.5, 0.5, std::numeric_limits<double>::infinity(),
+    -std::numeric_limits<double>::infinity(), std::numeric_limits<double>::denorm_min(),
+    std::numeric_limits<double>::max(), 3.141592653589793, -2.718281828459045,
+    // sNaN / qNaN (frexp quiets the former; math ops skip NaN-result lanes).
+    std::bit_cast<double>(static_cast<uint64_t>(0x7FF0000000000001ull)),
+    std::bit_cast<double>(static_cast<uint64_t>(0xFFF8000000000001ull)),
+    // f64 denormals with the highest mantissa bit at varied positions, to
+    // exercise frexp's denormal renormalization across the shift range.
+    std::bit_cast<double>(static_cast<uint64_t>(0x000FFFFFFFFFFFFFull)), // p = 51
+    std::bit_cast<double>(static_cast<uint64_t>(0x8000000100000000ull)), // p = 32, negative
+    std::bit_cast<double>(static_cast<uint64_t>(0x0000000000010000ull)), // p = 16
+}};
+
+bool is_f64_nan(uint64_t bits) { return std::isnan(std::bit_cast<double>(bits)); }
+
+struct F64UnaryCase {
+  const char *name;
+  uint32_t opcode;
+  bool is_float; // false for v_mov_b64 (exact bit copy, no NaN carve-out)
+};
+
+const std::array<F64UnaryCase, 10> kCases = {{
+    {"v_ceil_f64", 24, true},
+    {"v_floor_f64", 26, true},
+    {"v_trunc_f64", 23, true},
+    {"v_rndne_f64", 25, true},
+    {"v_fract_f64", 50, true},
+    {"v_rcp_f64", 37, true},
+    {"v_rsq_f64", 38, true},
+    {"v_sqrt_f64", 40, true},
+    {"v_mov_b64", 56, false},
+    // frexp mantissa: deterministic bit-exact (incl. sNaN quieting), so exact
+    // compare with no NaN-result skip (is_float=false).
+    {"v_frexp_mant_f64", 49, false},
+}};
+
+// Per-lane vdst sentinel so an inactive-lane clobber is detectable.
+uint64_t dst_sentinel(uint32_t lane) {
+  return (static_cast<uint64_t>(0xCAFE0000u | lane) << 32) | (0xBEEF0000u + lane);
+}
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("vop1_f64_simd_mem"), l2("vop1_f64_simd_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vop1_f64_simd", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  void write64(uint32_t reg, uint32_t lane, uint64_t v) {
+    cu->write_vgpr(reg, lane, static_cast<uint32_t>(v));
+    cu->write_vgpr(reg + 1, lane, static_cast<uint32_t>(v >> 32));
+  }
+  uint64_t read64(uint32_t reg, uint32_t lane) {
+    return static_cast<uint64_t>(cu->read_vgpr(reg + 1, lane)) << 32 | cu->read_vgpr(reg, lane);
+  }
+
+  // src0 = v0:v1, vdst = v2:v3 (relative to the alloc base). vdst is stamped with
+  // a per-lane sentinel so inactive-lane preservation is checkable.
+  void seed_inputs(uint64_t exec) {
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      double a = kEdge[lane % kEdge.size()];
+      write64(vb + 0, lane, std::bit_cast<uint64_t>(a));
+      write64(vb + 2, lane, dst_sentinel(lane));
+    }
+    wf->set_exec(exec);
+  }
+
+  std::array<uint64_t, WF_SIZE> run(Instruction *inst, uint64_t exec) {
+    seed_inputs(exec);
+    cu->execute_instruction(inst, *wf);
+    std::array<uint64_t, WF_SIZE> out{};
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+      out[lane] = read64(vb + 2, lane);
+    return out;
+  }
+};
+
+// Restores the process force-scalar gate on scope exit so flipping it for an
+// in-process A/B comparison cannot leak into later tests in the same process.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+void check_case(const F64UnaryCase &c, uint64_t exec) {
+  ForceScalarGuard gate_guard;
+
+  auto run_mode = [&](bool force_scalar) -> std::array<uint64_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    // src0 = v0:v1 (enc 256), vdst = v2:v3.
+    uint32_t enc = vop1_encode(c.opcode, /*vdst=*/2, /*src0=*/256);
+    uint32_t words[4] = {enc, 0u, 0u, 0u};
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << c.name << " decode failed";
+    auto out = fx.run(inst, exec);
+    delete inst;
+    return out;
+  };
+
+  const auto scalar_out = run_mode(/*force_scalar=*/true);
+  const auto simd_out = run_mode(/*force_scalar=*/false);
+
+  // Core A/B equivalence per active, non-skipped lane. For float ops a NaN
+  // result carries a possibly-different NaN payload and is excluded identically
+  // in both runs; v_mov_b64 (is_float=false) has no carve-out.
+  for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+    const bool active = (exec >> lane) & 1ULL;
+    if (active) {
+      if (c.is_float && (is_f64_nan(scalar_out[lane]) || is_f64_nan(simd_out[lane])))
+        continue;
+      EXPECT_EQ(scalar_out[lane], simd_out[lane])
+          << c.name << " lane " << lane << ": SIMD path diverged from scalar body";
+    } else {
+      // Inactive lane: must leave the seeded vdst sentinel intact.
+      EXPECT_EQ(simd_out[lane], dst_sentinel(lane))
+          << c.name << " clobbered inactive lane " << lane;
+      EXPECT_EQ(scalar_out[lane], dst_sentinel(lane))
+          << c.name << " clobbered inactive lane " << lane;
+    }
+  }
+}
+
+TEST(Vop1F64SimdCorrectness, FullExecMask) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_case(c, /*exec=*/~0ULL);
+}
+
+TEST(Vop1F64SimdCorrectness, PartialExecMask) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  // Pattern crossing the 8-wide f64 chunk boundaries on a wave64.
+  for (const auto &c : kCases)
+    check_case(c, /*exec=*/0xA5A5'F0F0'1234'8001ULL);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vop1_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop1_simd_correctness_test.cpp
@@ -1,0 +1,274 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vop1_simd_correctness_test.cpp
+/// @brief Bit-identity check (SIMD fast path vs scalar body) for the Tier-2
+/// unary VOP1 instructions wired into SIMD_VOP1_UNARY. Each op runs TWICE in the
+/// same process -- once forcing the scalar body, once the SIMD fast path, with
+/// identical seed/inputs/EXEC -- and the two 64-lane result arrays are asserted
+/// equal with EXPECT_EQ (util::set_force_scalar_for_testing flips the gate
+/// in-process). In-process the test also checks inactive-lane preservation under
+/// full and partial EXEC masks.
+///
+/// All wired ops (move/bitwise, exact int<->float casts, and correctly-rounded
+/// IEEE floor/ceil/trunc/rndne/fract/rcp/rsq/sqrt) are bit-identical to their
+/// scalar bodies for every input — including NaN/Inf/denormal — so inputs are
+/// raw random with explicit edge lanes injected (0, ±0, ±Inf, NaN, denormal,
+/// INT32 extremes) rather than sanitized to finite normals.
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <string>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t WF_SIZE = 64;
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+constexpr uint32_t DST_SENTINEL = 0xCAFEF00Du;
+
+// CDNA4 VOP1: [31:25]=0b0111111, vdst[24:17], op[16:9], src0[8:0]. v<N> as a
+// source operand encodes to 256+N; vdst holds the VGPR number directly.
+constexpr uint32_t vop1_encode(uint32_t op, uint32_t vdst, uint32_t src0) {
+  return (0x3Fu << 25) | ((vdst & 0xFF) << 17) | ((op & 0xFF) << 9) | (src0 & 0x1FF);
+}
+
+// Bit patterns that stress IEEE edge handling. Placed in the first lanes; the
+// rest are filled with deterministic random words.
+constexpr uint32_t kEdgeBits[] = {
+    0x00000000u, // +0.0 / int 0
+    0x80000000u, // -0.0 / INT32_MIN
+    0x7F800000u, // +Inf
+    0xFF800000u, // -Inf
+    0x7FC00000u, // qNaN
+    0x7F800001u, // sNaN
+    0x00000001u, // smallest denormal / int 1
+    0x7FFFFFFFu, // largest finite-ish / INT32_MAX
+    0x3F800000u, // 1.0f
+    0xBF800000u, // -1.0f
+    0x4B000000u, // 2^23 (boundary for float<->int exactness)
+    0xCB000000u, // -2^23
+    0x4F000000u, // 2^31         (cvt_i32 clamp boundary -> INT32_MAX)
+    0x4EFFFFFFu, // just below 2^31 (largest exact int32-range float)
+    0x4F400000u, // 3*2^30       (in [2^31,2^32): cvt_u32 mid, cvt_i32 clamps)
+    0x4F800000u, // 2^32         (cvt_u32 clamp boundary -> UINT32_MAX)
+    0xCF000000u, // -2^31        (cvt_i32 -> INT32_MIN, not yet clamped)
+    0xCF000001u, // below -2^31  (cvt_i32 clamp -> INT32_MIN)
+    // f16 bit patterns in the low 16 bits (high half irrelevant for f16 ops).
+    0x00000001u, // f16 smallest denormal
+    0x000003FFu, // f16 largest denormal
+    0x00007BFFu, // f16 max normal (65504)
+    0x00007C00u, // f16 +Inf
+    0x0000FC00u, // f16 -Inf
+    0x00007E00u, // f16 qNaN
+    0x00007C01u, // f16 sNaN
+    0x00003C00u, // f16 1.0
+    0x0000C000u, // f16 -2.0
+    0x00008000u, // f16 -0.0
+    // f32 denormals with the highest mantissa bit at varied positions, to
+    // exercise frexp's denormal renormalization across the full shift range.
+    0x00400000u, // p = 22 (largest denormal exponent)
+    0x80200001u, // p = 21, negative
+    0x00080040u, // p = 19
+    0x00000200u, // p = 9
+    0x0000007Fu, // p = 6
+};
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("vop1_simd_mem"), l2("vop1_simd_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vop1_simd", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  void seed_inputs(uint64_t seed, uint64_t exec) {
+    std::mt19937_64 rng(seed);
+    uint32_t vbase = wf->vgpr_alloc().base;
+    constexpr uint32_t n_edge = std::size(kEdgeBits);
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      uint32_t s0 = lane < n_edge ? kEdgeBits[lane] : static_cast<uint32_t>(rng());
+      cu->write_vgpr(vbase + 0, lane, s0);
+      cu->write_vgpr(vbase + 2, lane, DST_SENTINEL);
+    }
+    wf->set_exec(exec);
+  }
+
+  std::array<uint32_t, WF_SIZE> snapshot_dst() const {
+    std::array<uint32_t, WF_SIZE> out{};
+    uint32_t vbase = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+      out[lane] = cu->read_vgpr(vbase + 2, lane);
+    return out;
+  }
+
+  std::array<uint32_t, WF_SIZE> run(Instruction *inst, uint64_t seed, uint64_t exec) {
+    seed_inputs(seed, exec);
+    cu->execute_instruction(inst, *wf);
+    return snapshot_dst();
+  }
+};
+
+struct Vop1Case {
+  const char *label;
+  uint32_t opcode;
+};
+
+// Tier-2 ops wired into SIMD_VOP1_UNARY (CDNA4 VOP1 opcodes).
+const Vop1Case kCases[] = {
+    {"v_mov_b32", 1},
+    {"v_not_b32", 43},
+    {"v_bfrev_b32", 44},
+    {"v_cvt_f32_ubyte0", 17},
+    {"v_cvt_f32_ubyte1", 18},
+    {"v_cvt_f32_ubyte2", 19},
+    {"v_cvt_f32_ubyte3", 20},
+    {"v_cvt_f32_i32", 5},
+    {"v_cvt_f32_u32", 6},
+    {"v_floor_f32", 31},
+    {"v_ceil_f32", 29},
+    {"v_trunc_f32", 28},
+    {"v_rndne_f32", 30},
+    {"v_fract_f32", 27},
+    {"v_rcp_f32", 34},
+    {"v_rcp_iflag_f32", 35},
+    {"v_rsq_f32", 36},
+    {"v_sqrt_f32", 39},
+    {"v_exp_f32", 32},
+    {"v_log_f32", 33},
+    // G3: float -> int with NaN->0 + saturating clamp.
+    {"v_cvt_i32_f32", 8},
+    {"v_cvt_u32_f32", 7},
+    {"v_cvt_flr_i32_f32", 13},
+    {"v_cvt_rpi_i32_f32", 12},
+    // f16 ops (route through f32 intermediate).
+    {"v_floor_f16", 68},
+    {"v_ceil_f16", 69},
+    {"v_trunc_f16", 70},
+    {"v_rndne_f16", 71},
+    {"v_fract_f16", 72},
+    {"v_rcp_f16", 61},
+    {"v_rsq_f16", 63},
+    {"v_sqrt_f16", 62},
+    {"v_exp_f16", 65},
+    {"v_log_f16", 64},
+    {"v_cvt_f32_f16", 11},
+    {"v_cvt_f16_f32", 10},
+    {"v_cvt_f16_i16", 58},
+    {"v_cvt_f16_u16", 57},
+    {"v_cvt_i16_f16", 60},
+    {"v_cvt_u16_f16", 59},
+    // Bit-scan (SWAR popcount/clz/ctz functors). 0-input lanes (kEdgeBits[0])
+    // exercise the 0xFFFFFFFF sentinel; INT32_MIN / -1 / 1 cover sign cases.
+    {"v_ffbh_u32", 45},
+    {"v_ffbl_b32", 46},
+    {"v_ffbh_i32", 47},
+    // frexp f32 split: exponent (raw int32) and mantissa (float). Edge lanes
+    // cover ±0 / denormal / Inf / NaN / normal, where frexp's special cases live.
+    {"v_frexp_exp_i32_f32", 51},
+    {"v_frexp_mant_f32", 52},
+    // frexp f16 (f16<->f32 round trip): mantissa / exponent narrowed to f16.
+    {"v_frexp_mant_f16", 66},
+    {"v_frexp_exp_i16_f16", 67},
+};
+
+// Restores the process force-scalar gate on scope exit so flipping it for an
+// in-process A/B comparison cannot leak into later tests in the same process.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+void check_case(const Vop1Case &c, uint64_t exec) {
+  ForceScalarGuard gate_guard;
+
+  // Runs the op for one seed in the requested execute mode (fresh Fixture +
+  // decode per run isolates VGPR state). All wired ops are bit-exact for every
+  // input, so the full 64-lane arrays must match between the two modes.
+  auto run_mode = [&](bool force_scalar, uint64_t seed) -> std::array<uint32_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    uint32_t enc = vop1_encode(c.opcode, /*vdst=*/2, /*src0=*/256);
+    uint32_t words[4] = {enc, 0u, 0u, 0u};
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << c.label << ": decode failed";
+    auto out = fx.run(inst, seed, exec);
+    delete inst;
+    return out;
+  };
+
+  // Sweep several seeds so the random (non-edge) lanes cover more of the
+  // input space — in particular the [2^31, 2^32) cvt range and clamp regions.
+  for (uint64_t seed = 0; seed < 16; ++seed) {
+    const auto scalar_out = run_mode(/*force_scalar=*/true, seed);
+    const auto simd_out = run_mode(/*force_scalar=*/false, seed);
+
+    // Core A/B equivalence: SIMD fast path must be bit-identical to the scalar
+    // body across all 64 lanes (active and inactive).
+    EXPECT_EQ(scalar_out, simd_out)
+        << c.label << " (exec=0x" << std::hex << exec << ", seed=" << std::dec << seed
+        << "): SIMD path diverged from scalar body";
+
+    // Inactive lanes must keep the destination sentinel in either mode.
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      const bool active = (exec >> lane) & 1ULL;
+      if (!active) {
+        EXPECT_EQ(simd_out[lane], DST_SENTINEL)
+            << c.label << ": clobbered inactive lane " << lane << " at seed " << seed;
+        EXPECT_EQ(scalar_out[lane], DST_SENTINEL)
+            << c.label << ": clobbered inactive lane " << lane << " at seed " << seed;
+      }
+    }
+  }
+}
+
+TEST(Vop1SimdCorrectness, FullExecMask) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_case(c, /*exec=*/~0ULL);
+}
+
+TEST(Vop1SimdCorrectness, PartialExecMask) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_case(c, /*exec=*/0xA5A5'F0F0'1234'8001ULL);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vop2_carry_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop2_carry_simd_correctness_test.cpp
@@ -1,0 +1,228 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vop2_carry_simd_correctness_test.cpp
+/// @brief Bit-identity check (SIMD fast path vs scalar body) for the
+/// carry-bearing VOP2 instructions wired into SIMD_VOP2_CARRY:
+///   v_add_co_u32, v_sub_co_u32, v_subrev_co_u32,
+///   v_addc_co_u32, v_subb_co_u32, v_subbrev_co_u32.
+/// Unlike the plain binary VOP2 path these write per-lane carry/borrow into
+/// VCC, and the addc/subb/subbrev forms read VCC as a carry-in. Each op runs
+/// TWICE in the same process -- once forcing the scalar body, once the SIMD fast
+/// path, with identical seed/inputs/EXEC/VCC-in -- and the scalar-vs-SIMD
+/// equivalence on BOTH the 64-lane destination AND the full 64-bit VCC is
+/// asserted with EXPECT_EQ (util::set_force_scalar_for_testing flips the gate
+/// in-process). Inputs deliberately seed the
+/// 32-bit carry/borrow boundary (0xFFFFFFFF+1, a<b, a==b+cin, ...) on the low
+/// lanes — random-only inputs hide these corners. In-process the test still
+/// checks inactive-lane dst/VCC preservation under full and partial EXEC masks.
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <string>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t WF_SIZE = 64;
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+constexpr uint32_t DST_SENTINEL = 0xCAFEF00Du;
+
+// CDNA4 VOP2: opcode[30:25], vdst[24:17], vsrc1[16:9], src0[8:0]. Bit 31 = 0.
+constexpr uint32_t vop2_encode(uint32_t opcode, uint32_t vdst, uint32_t vsrc1, uint32_t src0) {
+  return ((opcode & 0x3F) << 25) | ((vdst & 0xFF) << 17) | ((vsrc1 & 0xFF) << 9) | (src0 & 0x1FF);
+}
+
+// Per-lane (src0, vsrc1) pairs that straddle the carry/borrow boundary. Placed
+// on the low lanes; remaining lanes are filled with RNG. These exercise the
+// add carry-out (sum > 0xFFFFFFFF), the subtract borrow (a < b), and the
+// carry-in tie cases (a == b, a == b + 1) that the addc/subb chain depends on.
+const std::array<std::pair<uint32_t, uint32_t>, 14> kEdgePairs = {{
+    {0xFFFFFFFFu, 0x00000001u}, // add: carry; sub: borrow
+    {0xFFFFFFFFu, 0x00000000u}, // add: no carry; sub: no borrow
+    {0x00000000u, 0x00000000u}, // zero; with cin=1 addc carries on 0xFFFFFFFF? no
+    {0x00000001u, 0x00000000u}, // a>b
+    {0x00000000u, 0x00000001u}, // a<b borrow; addc 0+1
+    {0x80000000u, 0x80000000u}, // sum = 0x1_00000000 carry; a==b no borrow
+    {0x7FFFFFFFu, 0x00000001u},
+    {0xFFFFFFFFu, 0xFFFFFFFFu}, // sum carries; a==b
+    {0x00000000u, 0xFFFFFFFFu}, // borrow; addc 0+0xFFFFFFFF+1 = carry
+    {0xFFFFFFFEu, 0x00000001u}, // sum = 0xFFFFFFFF, +cin=1 -> carry
+    {0x12345678u, 0x12345678u}, // a==b: subb borrow iff cin
+    {0x12345679u, 0x12345678u}, // a==b+1: subb borrow iff cin
+    {0xAAAAAAAAu, 0x55555555u},
+    {0x00000002u, 0x00000003u},
+}};
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("vop2_carry_simd_mem"), l2("vop2_carry_simd_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vop2_carry_simd", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  void seed_inputs(uint64_t seed, uint64_t exec, uint64_t vcc_in) {
+    std::mt19937_64 rng(seed);
+    uint32_t vbase = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      uint32_t r0, r1;
+      if (lane < kEdgePairs.size()) {
+        r0 = kEdgePairs[lane].first;
+        r1 = kEdgePairs[lane].second;
+      } else {
+        r0 = static_cast<uint32_t>(rng());
+        r1 = static_cast<uint32_t>(rng());
+      }
+      cu->write_vgpr(vbase + 0, lane, r0);
+      cu->write_vgpr(vbase + 1, lane, r1);
+      cu->write_vgpr(vbase + 2, lane, DST_SENTINEL);
+    }
+    wf->set_exec(exec);
+    wf->set_vcc(vcc_in);
+  }
+
+  struct Result {
+    std::array<uint32_t, WF_SIZE> dst{};
+    uint64_t vcc = 0;
+  };
+
+  Result run(Instruction *inst, uint64_t seed, uint64_t exec, uint64_t vcc_in) {
+    seed_inputs(seed, exec, vcc_in);
+    cu->execute_instruction(inst, *wf);
+    Result res;
+    uint32_t vbase = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+      res.dst[lane] = cu->read_vgpr(vbase + 2, lane);
+    res.vcc = wf->vcc();
+    return res;
+  }
+};
+
+struct CarryCase {
+  const char *label;
+  uint32_t opcode;
+};
+
+const CarryCase kCases[] = {
+    {"v_add_co_u32", 25},  {"v_sub_co_u32", 26},  {"v_subrev_co_u32", 27},
+    {"v_addc_co_u32", 28}, {"v_subb_co_u32", 29}, {"v_subbrev_co_u32", 30},
+};
+
+// Carry-in VCC patterns to seed before execution. addc/subb/subbrev read these;
+// the non-carry-in forms ignore them but must still leave inactive bits intact.
+const uint64_t kVccPatterns[] = {
+    0x0000000000000000ULL, 0xFFFFFFFFFFFFFFFFULL, 0xAAAAAAAAAAAAAAAAULL,
+    0x5555555555555555ULL, 0x0123456789ABCDEFULL,
+};
+
+// Restores the process force-scalar gate on scope exit so flipping it for an
+// in-process A/B comparison cannot leak into later tests in the same process.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+void check_case(const CarryCase &c, uint64_t exec) {
+  ForceScalarGuard gate_guard;
+
+  constexpr uint64_t SEED = 0xC0FFEE'1234'5678ULL;
+
+  // Runs one (case, vcc_in) in the requested execute mode (fresh Fixture +
+  // decode per run isolates VGPR/VCC state).
+  auto run_mode = [&](bool force_scalar, uint64_t vcc_in) -> Fixture::Result {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    uint32_t enc = vop2_encode(c.opcode, /*vdst=*/2, /*vsrc1=*/1, /*src0=*/256);
+    uint32_t words[4] = {enc, 0u, 0u, 0u};
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << c.label << ": decode failed";
+    auto out = fx.run(inst, SEED, exec, vcc_in);
+    delete inst;
+    return out;
+  };
+
+  for (uint64_t vcc_in : kVccPatterns) {
+    const auto scalar_out = run_mode(/*force_scalar=*/true, vcc_in);
+    const auto simd_out = run_mode(/*force_scalar=*/false, vcc_in);
+
+    // Core A/B equivalence on BOTH the destination words and the full 64-bit
+    // VCC carry/borrow output.
+    EXPECT_EQ(scalar_out.dst, simd_out.dst)
+        << c.label << " vcc_in=0x" << std::hex << vcc_in << " (exec=0x" << exec
+        << "): SIMD dst diverged from scalar body";
+    EXPECT_EQ(scalar_out.vcc, simd_out.vcc)
+        << c.label << " vcc_in=0x" << std::hex << vcc_in << " (exec=0x" << exec
+        << "): SIMD VCC diverged from scalar body";
+
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      const bool active = (exec >> lane) & 1ULL;
+      if (!active) {
+        EXPECT_EQ(simd_out.dst[lane], DST_SENTINEL)
+            << c.label << ": clobbered inactive dst lane " << lane;
+        EXPECT_EQ(scalar_out.dst[lane], DST_SENTINEL)
+            << c.label << ": clobbered inactive dst lane " << lane;
+      }
+    }
+    // Inactive EXEC lanes must keep their incoming VCC bit.
+    const uint64_t inactive = ~exec;
+    EXPECT_EQ(simd_out.vcc & inactive, vcc_in & inactive)
+        << c.label << " vcc_in=0x" << std::hex << vcc_in << ": altered an inactive-lane VCC bit";
+    EXPECT_EQ(scalar_out.vcc & inactive, vcc_in & inactive)
+        << c.label << " vcc_in=0x" << std::hex << vcc_in << ": altered an inactive-lane VCC bit";
+  }
+}
+
+TEST(Vop2CarrySimdCorrectness, FullExecMask) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_case(c, /*exec=*/~0ULL);
+}
+
+TEST(Vop2CarrySimdCorrectness, PartialExecMask) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  // Sparse/alternating pattern crossing SIMD chunk boundaries: exercises the
+  // masked result store and per-chunk VCC merge (active bits updated, inactive
+  // preserved) on both halves of a wave64.
+  for (const auto &c : kCases)
+    check_case(c, /*exec=*/0xA5A5'F0F0'1234'8001ULL);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vop2_cndmask_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop2_cndmask_simd_correctness_test.cpp
@@ -1,0 +1,160 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vop2_cndmask_simd_correctness_test.cpp
+/// @brief Bit-identity check (SIMD fast path vs scalar body) for v_cndmask_b32
+/// (CDNA4 VOP2 opcode 0): dst[lane] = (VCC bit) ? vsrc1 : src0. VCC is an input
+/// side-channel that drives the per-lane select. The test seeds distinct
+/// src0/vsrc1 values and sweeps several VCC patterns (which lanes pick vsrc1).
+/// Each (vcc) case runs TWICE in the same process -- once forcing the scalar
+/// body, once the SIMD fast path, with identical seed/inputs/EXEC/VCC -- and the
+/// two 64-lane result arrays are asserted equal with EXPECT_EQ
+/// (util::set_force_scalar_for_testing flips the gate in-process).
+/// In-process inactive EXEC lanes must keep the dst sentinel.
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <string>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t WF_SIZE = 64;
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+constexpr uint32_t DST_SENTINEL = 0xCAFEF00Du;
+
+constexpr uint32_t vop2_encode(uint32_t opcode, uint32_t vdst, uint32_t vsrc1, uint32_t src0) {
+  return ((opcode & 0x3F) << 25) | ((vdst & 0xFF) << 17) | ((vsrc1 & 0xFF) << 9) | (src0 & 0x1FF);
+}
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("vop2_cndmask_mem"), l2("vop2_cndmask_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vop2_cndmask", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  void seed_inputs(uint64_t seed, uint64_t exec, uint64_t vcc) {
+    std::mt19937_64 rng(seed);
+    uint32_t vbase = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      cu->write_vgpr(vbase + 0, lane, static_cast<uint32_t>(rng())); // src0
+      cu->write_vgpr(vbase + 1, lane, static_cast<uint32_t>(rng())); // vsrc1
+      cu->write_vgpr(vbase + 2, lane, DST_SENTINEL);                 // dst
+    }
+    wf->set_exec(exec);
+    wf->set_vcc(vcc);
+  }
+
+  std::array<uint32_t, WF_SIZE> snapshot_dst() const {
+    std::array<uint32_t, WF_SIZE> out{};
+    uint32_t vbase = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+      out[lane] = cu->read_vgpr(vbase + 2, lane);
+    return out;
+  }
+
+  std::array<uint32_t, WF_SIZE> run(Instruction *inst, uint64_t seed, uint64_t exec, uint64_t vcc) {
+    seed_inputs(seed, exec, vcc);
+    cu->execute_instruction(inst, *wf);
+    return snapshot_dst();
+  }
+};
+
+const uint64_t kVccPatterns[] = {
+    0x0000000000000000ULL, 0xFFFFFFFFFFFFFFFFULL, 0xAAAAAAAAAAAAAAAAULL,
+    0x5555555555555555ULL, 0x0123456789ABCDEFULL, 0xF0F0F0F00F0F0F0FULL,
+};
+
+// Restores the process force-scalar gate on scope exit so flipping it for an
+// in-process A/B comparison cannot leak into later tests in the same process.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+void check_case(uint64_t exec) {
+  ForceScalarGuard gate_guard;
+
+  constexpr uint64_t SEED = 0xCD'1234'5678'9AB0ULL;
+
+  auto run_mode = [&](bool force_scalar, uint64_t vcc) -> std::array<uint32_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    uint32_t enc = vop2_encode(/*opcode=*/0, /*vdst=*/2, /*vsrc1=*/1, /*src0=*/256);
+    uint32_t words[4] = {enc, 0u, 0u, 0u};
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << "v_cndmask_b32: decode failed";
+    auto out = fx.run(inst, SEED, exec, vcc);
+    delete inst;
+    return out;
+  };
+
+  for (uint64_t vcc : kVccPatterns) {
+    const auto scalar_out = run_mode(/*force_scalar=*/true, vcc);
+    const auto simd_out = run_mode(/*force_scalar=*/false, vcc);
+
+    EXPECT_EQ(scalar_out, simd_out) << "v_cndmask_b32 vcc=0x" << std::hex << vcc << " (exec=0x"
+                                    << exec << "): SIMD path diverged from scalar body";
+
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      const bool active = (exec >> lane) & 1ULL;
+      if (!active) {
+        EXPECT_EQ(simd_out[lane], DST_SENTINEL)
+            << "vcc=0x" << std::hex << vcc << ": clobbered inactive lane " << std::dec << lane;
+        EXPECT_EQ(scalar_out[lane], DST_SENTINEL)
+            << "vcc=0x" << std::hex << vcc << ": clobbered inactive lane " << std::dec << lane;
+      }
+    }
+  }
+}
+
+TEST(Vop2CndmaskSimdCorrectness, FullExecMask) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  check_case(/*exec=*/~0ULL);
+}
+
+TEST(Vop2CndmaskSimdCorrectness, PartialExecMask) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  check_case(/*exec=*/0xA5A5'F0F0'1234'8001ULL);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vop2_fma_f64_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop2_fma_f64_simd_correctness_test.cpp
@@ -1,0 +1,220 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vop2_fma_f64_simd_correctness_test.cpp
+/// @brief Bit-identity check (SIMD fast path vs scalar body) for the only f64
+/// VOP2 op reachable on CDNA4, v_fmac_f64 (dst = fma(src0, vsrc1, dst), all
+/// f64). This is the first user of the 64-bit-lane SIMD infra: a per-lane f64
+/// lives as two 32-bit VGPRs at the same lane index (lo = reg N, hi = reg N+1),
+/// so the SIMD path reads/writes through the split lo/hi pointer pair
+/// (util::load64 / masked_store64). The first test directly validates that
+/// layout assumption (write_lane64 round-trips through load64 via the operand's
+/// 64-bit lane pointers). The v_fmac_f64 check runs TWICE in the same process
+/// -- once forcing the scalar body, once the SIMD fast path, with identical
+/// inputs/EXEC -- and the destination f64 results are asserted equal per
+/// non-skipped lane (util::set_force_scalar_for_testing flips the gate
+/// in-process). util::stdx::fma over native<double> is bit-exact to std::fma for
+/// finite/Inf inputs; NaN-result lanes may diverge in NaN payload (accepted), so
+/// those lanes are excluded from the comparison — NaN-ness of the result is
+/// deterministic from the inputs, so both runs skip the same lanes.
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <bit>
+#include <cmath>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t WF_SIZE = 64;
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+[[maybe_unused]] constexpr uint64_t LO_SENTINEL = 0xDEADBEEFu;
+[[maybe_unused]] constexpr uint64_t HI_SENTINEL = 0xFEEDFACEu;
+
+// CDNA4 VOP2: opcode[30:25], vdst[24:17], vsrc1[16:9], src0[8:0]. Bit 31 = 0.
+constexpr uint32_t vop2_encode(uint32_t opcode, uint32_t vdst, uint32_t vsrc1, uint32_t src0) {
+  return ((opcode & 0x3F) << 25) | ((vdst & 0xFF) << 17) | ((vsrc1 & 0xFF) << 9) | (src0 & 0x1FF);
+}
+
+// f64 edge values whose fma combinations cover ±0, ±Inf, denormal, large, and
+// ordinary normals. NaN is excluded from the seeded set (its payload may diverge
+// between packed and scalar fma); a few NaN lanes are still exercised via the RNG
+// tail and skipped explicitly when comparing.
+const std::array<double, 12> kEdge = {{
+    +0.0,
+    -0.0,
+    1.0,
+    -1.0,
+    2.0,
+    0.5,
+    std::numeric_limits<double>::infinity(),
+    -std::numeric_limits<double>::infinity(),
+    std::numeric_limits<double>::denorm_min(),
+    std::numeric_limits<double>::max(),
+    3.141592653589793,
+    -2.718281828459045,
+}};
+
+bool is_f64_nan(uint64_t bits) { return std::isnan(std::bit_cast<double>(bits)); }
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("vop2_fma_f64_simd_mem"), l2("vop2_fma_f64_simd_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vop2_fma_f64_simd", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  // Write a 64-bit value to a VGPR pair (reg = lo, reg+1 = hi) at `lane`.
+  void write64(uint32_t reg, uint32_t lane, uint64_t v) {
+    cu->write_vgpr(reg, lane, static_cast<uint32_t>(v));
+    cu->write_vgpr(reg + 1, lane, static_cast<uint32_t>(v >> 32));
+  }
+  uint64_t read64(uint32_t reg, uint32_t lane) {
+    return static_cast<uint64_t>(cu->read_vgpr(reg + 1, lane)) << 32 | cu->read_vgpr(reg, lane);
+  }
+
+  // src0 = v0:v1, vsrc1 = v2:v3, vdst = v4:v5 (relative to the alloc base).
+  void seed_inputs(uint64_t exec) {
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      double a = kEdge[lane % kEdge.size()];
+      double b = kEdge[(lane / kEdge.size() + 1) % kEdge.size()];
+      double d = kEdge[(lane * 7 + 3) % kEdge.size()];
+      write64(vb + 0, lane, std::bit_cast<uint64_t>(a));
+      write64(vb + 2, lane, std::bit_cast<uint64_t>(b));
+      write64(vb + 4, lane, std::bit_cast<uint64_t>(d));
+    }
+    wf->set_exec(exec);
+  }
+
+  std::array<uint64_t, WF_SIZE> run(Instruction *inst, uint64_t exec) {
+    seed_inputs(exec);
+    // Mark the dst lanes so an inactive-lane clobber is visible. The accumulate
+    // source is the seeded value above; re-stamp the unused high words is not
+    // needed — fmac reads/writes the same pair.
+    cu->execute_instruction(inst, *wf);
+    std::array<uint64_t, WF_SIZE> out{};
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+      out[lane] = read64(vb + 4, lane);
+    return out;
+  }
+};
+
+// Directly validate the two-array f64 storage layout assumption the 64-bit infra
+// is built on: a value written via the VGPR pair (lo=reg, hi=reg+1) must read
+// back identically through util::load64 fed by the operand's 64-bit lane
+// pointers. Exercised here without the SIMD/scalar A/B so a layout regression is
+// isolated from the fma functor.
+TEST(Vop2FmaF64SimdCorrectness, LaneLayoutRoundTrip) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  Fixture fx;
+  ASSERT_NE(fx.cu, nullptr);
+  ASSERT_NE(fx.wf, nullptr);
+  uint32_t vb = fx.wf->vgpr_alloc().base;
+  std::vector<uint64_t> expected(WF_SIZE);
+  for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+    uint64_t v = (static_cast<uint64_t>(0xA5A50000u | lane) << 32) | (0x1234'0000u + lane);
+    expected[lane] = v;
+    fx.write64(vb + 0, lane, v);
+  }
+  const uint32_t *lo = reinterpret_cast<const uint32_t *>(fx.cu->vgpr_data(vb + 0));
+  const uint32_t *hi = reinterpret_cast<const uint32_t *>(fx.cu->vgpr_data(vb + 1));
+  constexpr std::size_t W = util::native_width64;
+  for (uint32_t base = 0; base < WF_SIZE; base += static_cast<uint32_t>(W)) {
+    util::native<uint64_t> v = util::load64<uint64_t>(lo + base, hi + base);
+    for (std::size_t i = 0; i < W; ++i)
+      EXPECT_EQ(v[i], expected[base + i]) << "load64 mismatch at lane " << (base + i);
+  }
+}
+
+// Restores the process force-scalar gate on scope exit so flipping it for an
+// in-process A/B comparison cannot leak into later tests in the same process.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+void check_fmac(uint64_t exec) {
+  ForceScalarGuard gate_guard;
+
+  auto run_mode = [&](bool force_scalar) -> std::array<uint64_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    // v_fmac_f64 = VOP2 op 4. src0 = v0:v1 (enc 256), vsrc1 = v2:v3, vdst = v4:v5.
+    uint32_t enc = vop2_encode(/*opcode=*/4, /*vdst=*/4, /*vsrc1=*/2, /*src0=*/256);
+    uint32_t words[4] = {enc, 0u, 0u, 0u};
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << "v_fmac_f64 decode failed";
+    auto out = fx.run(inst, exec);
+    delete inst;
+    return out;
+  };
+
+  const auto scalar_out = run_mode(/*force_scalar=*/true);
+  const auto simd_out = run_mode(/*force_scalar=*/false);
+
+  // Core A/B equivalence per non-skipped lane. NaN-result lanes carry a
+  // possibly-different NaN payload and are excluded identically in both runs
+  // (NaN-ness of the result is deterministic from the inputs).
+  for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+    if (is_f64_nan(scalar_out[lane]) || is_f64_nan(simd_out[lane]))
+      continue;
+    EXPECT_EQ(scalar_out[lane], simd_out[lane])
+        << "v_fmac_f64 lane " << lane << ": SIMD path diverged from scalar body";
+  }
+}
+
+TEST(Vop2FmaF64SimdCorrectness, FullExecMask) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  check_fmac(/*exec=*/~0ULL);
+}
+
+TEST(Vop2FmaF64SimdCorrectness, PartialExecMask) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  // Pattern crossing the 8-wide f64 chunk boundaries on a wave64.
+  check_fmac(/*exec=*/0xA5A5'F0F0'1234'8001ULL);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vop2_fma_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop2_fma_simd_correctness_test.cpp
@@ -1,0 +1,240 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vop2_fma_simd_correctness_test.cpp
+/// @brief Bit-identity check (SIMD fast path vs scalar body) for the ternary
+/// VOP2 fused multiply-add family wired into SIMD_VOP2_TERNARY. Covers the
+/// three operand shapes available on CDNA4:
+///   dst-accumulate : v_fmac_f32 (59), v_mac_f16 (35)   -> fma(s0, s1, dst)
+///   literal addend : v_fmaak_f32 (24), v_madak_f16 (37) -> fma(s0, s1, K)
+///   literal mult   : v_fmamk_f32 (23), v_madmk_f16 (36) -> fma(s0, K, s1)
+/// The dst-accumulate forms read vdst as the third operand, so v2 is seeded
+/// with live values (not a sentinel) and the accumulate is exercised. The
+/// literal forms carry an inline-constant dword (words[1]). Inputs are raw
+/// random bit patterns plus explicit fp edge lanes (0, ±0, ±Inf, denormal,
+/// large). fma is bit-exact for all finite/Inf inputs (incl. Inf*0->NaN); a NaN
+/// *input* may propagate a different NaN payload through the packed vs scalar
+/// FMA, an accepted difference, so lanes with a NaN input are excluded from the
+/// per-lane comparison (the skip condition is computed from the inputs,
+/// identical in both runs, so both runs skip the same lanes). Each op runs TWICE
+/// in the same process -- once forcing the scalar body, once the SIMD fast path,
+/// with identical seed/inputs/EXEC -- and the two result arrays are asserted
+/// equal per active, non-skipped lane (util::set_force_scalar_for_testing flips
+/// the gate in-process).
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <string>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t WF_SIZE = 64;
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+
+// CDNA4 VOP2: opcode[30:25], vdst[24:17], vsrc1[16:9], src0[8:0]. Bit 31 = 0.
+constexpr uint32_t vop2_encode(uint32_t opcode, uint32_t vdst, uint32_t vsrc1, uint32_t src0) {
+  return ((opcode & 0x3F) << 25) | ((vdst & 0xFF) << 17) | ((vsrc1 & 0xFF) << 9) | (src0 & 0x1FF);
+}
+
+// f32 edge bit patterns placed on the low lanes to stress fma rounding/±0/Inf.
+// No NaN: NaN-input lanes have an accepted payload divergence and are skipped
+// in the comparison anyway (see is_f32_nan / is_f16_nan below).
+const std::array<uint32_t, 12> kF32Edges = {{
+    0x00000000u, // +0
+    0x80000000u, // -0
+    0x7F800000u, // +Inf
+    0xFF800000u, // -Inf
+    0x00000001u, // smallest denormal
+    0x807FFFFFu, // -largest denormal
+    0x007FFFFFu, // largest denormal
+    0x3F800000u, // 1.0
+    0xBF800000u, // -1.0
+    0x4F000000u, // 2^31
+    0x7F7FFFFFu, // FLT_MAX
+    0x00800000u, // smallest normal
+}};
+
+bool is_f32_nan(uint32_t u) { return ((u >> 23) & 0xFFu) == 0xFFu && (u & 0x7FFFFFu) != 0u; }
+bool is_f16_nan(uint32_t u) { return ((u >> 10) & 0x1Fu) == 0x1Fu && (u & 0x3FFu) != 0u; }
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("vop2_fma_simd_mem"), l2("vop2_fma_simd_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vop2_fma_simd", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  // Seed v0 (src0), v1 (vsrc1), v2 (vdst/accumulator). The low lanes get the
+  // fp edge patterns (in both halves for f16); the rest are raw random. v2 is
+  // live for the dst-accumulate forms. Records the seeded v2 for the inactive-
+  // lane preservation check.
+  std::array<uint32_t, WF_SIZE> seed_inputs(uint64_t seed, bool is_f16, uint64_t exec,
+                                            std::array<bool, WF_SIZE> *nan_lane = nullptr) {
+    std::mt19937_64 rng(seed);
+    std::array<uint32_t, WF_SIZE> seeded_dst{};
+    uint32_t vbase = wf->vgpr_alloc().base;
+    auto edge = [&](uint32_t i) -> uint32_t {
+      uint32_t e = kF32Edges[i % kF32Edges.size()];
+      if (is_f16) {
+        // Pack two f16 edge halves: low = e>>16, high = e>>5 — covers f16
+        // NaN/Inf/denorm/zero in the low 16 bits the op reads.
+        uint32_t lo = (e >> 16) & 0xFFFFu;
+        return lo | (lo << 16);
+      }
+      return e;
+    };
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      uint32_t r0, r1, r2;
+      if (lane < kF32Edges.size()) {
+        r0 = edge(lane);
+        r1 = edge(lane + 3);
+        r2 = edge(lane + 6);
+      } else {
+        r0 = static_cast<uint32_t>(rng());
+        r1 = static_cast<uint32_t>(rng());
+        r2 = static_cast<uint32_t>(rng());
+      }
+      cu->write_vgpr(vbase + 0, lane, r0);
+      cu->write_vgpr(vbase + 1, lane, r1);
+      cu->write_vgpr(vbase + 2, lane, r2);
+      seeded_dst[lane] = r2;
+      if (nan_lane) {
+        auto nan = [&](uint32_t v) { return is_f16 ? is_f16_nan(v & 0xFFFFu) : is_f32_nan(v); };
+        (*nan_lane)[lane] = nan(r0) || nan(r1) || nan(r2);
+      }
+    }
+    wf->set_exec(exec);
+    return seeded_dst;
+  }
+
+  std::array<uint32_t, WF_SIZE> snapshot_dst() const {
+    std::array<uint32_t, WF_SIZE> out{};
+    uint32_t vbase = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+      out[lane] = cu->read_vgpr(vbase + 2, lane);
+    return out;
+  }
+};
+
+struct FmaCase {
+  const char *label;
+  uint32_t opcode;
+  bool is_f16;
+  bool has_literal;
+};
+
+const FmaCase kCases[] = {
+    {"v_fmac_f32", 59, false, false}, // dst = fma(s0, s1, dst)
+    {"v_fmaak_f32", 24, false, true}, // dst = fma(s0, s1, K)
+    {"v_fmamk_f32", 23, false, true}, // dst = fma(s0, K, s1)
+    {"v_mac_f16", 35, true, false},   // f16 dst-accumulate
+    {"v_madak_f16", 37, true, true},  // f16 literal addend
+    {"v_madmk_f16", 36, true, true},  // f16 literal multiplier
+};
+
+// Restores the process force-scalar gate on scope exit so flipping it for an
+// in-process A/B comparison cannot leak into later tests in the same process.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+void check_case(const FmaCase &c, uint64_t exec) {
+  ForceScalarGuard gate_guard;
+
+  constexpr uint64_t SEED = 0xF1A'1234'5678'9ABCULL;
+
+  std::array<bool, WF_SIZE> nan_lane{};
+  std::array<uint32_t, WF_SIZE> seeded{};
+
+  auto run_mode = [&](bool force_scalar) -> std::array<uint32_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    uint32_t enc = vop2_encode(c.opcode, /*vdst=*/2, /*vsrc1=*/1, /*src0=*/256);
+    // Inline literal: 0x3FC00000 = 1.5f for f32; for f16 the low 16 bits are the
+    // f16 constant 0x3E00 = 1.5h (high bits ignored by the op).
+    const uint32_t literal = c.is_f16 ? 0x00003E00u : 0x3FC00000u;
+    uint32_t words[4] = {enc, c.has_literal ? literal : 0u, 0u, 0u};
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << c.label << ": decode failed";
+    seeded = fx.seed_inputs(SEED, c.is_f16, exec, &nan_lane);
+    fx.cu->execute_instruction(inst, *fx.wf);
+    auto out = fx.snapshot_dst();
+    delete inst;
+    return out;
+  };
+
+  const auto scalar_out = run_mode(/*force_scalar=*/true);
+  const auto simd_out = run_mode(/*force_scalar=*/false);
+
+  // Core A/B equivalence per active, non-skipped lane. NaN-input lanes carry an
+  // accepted NaN-payload divergence and are excluded identically in both runs
+  // (the skip condition is input-derived).
+  for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+    const bool active = (exec >> lane) & 1ULL;
+    if (active) {
+      if (nan_lane[lane])
+        continue;
+      EXPECT_EQ(scalar_out[lane], simd_out[lane])
+          << c.label << " lane " << lane << ": SIMD path diverged from scalar body";
+    } else {
+      // Inactive-lane preservation: each inactive lane must keep its seeded v2
+      // value (deterministic, identical runs).
+      EXPECT_EQ(simd_out[lane], seeded[lane]) << c.label << ": clobbered inactive lane " << lane;
+      EXPECT_EQ(scalar_out[lane], seeded[lane]) << c.label << ": clobbered inactive lane " << lane;
+    }
+  }
+}
+
+TEST(Vop2FmaSimdCorrectness, FullExecMask) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_case(c, /*exec=*/~0ULL);
+}
+
+TEST(Vop2FmaSimdCorrectness, PartialExecMask) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_case(c, /*exec=*/0xA5A5'F0F0'1234'8001ULL);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vop2_minmax_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop2_minmax_simd_correctness_test.cpp
@@ -1,0 +1,248 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vop2_minmax_simd_correctness_test.cpp
+/// @brief Bit-identity check (SIMD fast path vs scalar body) for the float
+/// min/max VOP2 ops: v_max_f32 (11), v_min_f32 (10), v_max_f16 (45),
+/// v_min_f16 (46). These use std::fmax/std::fmin in the scalar body; the SIMD
+/// path uses util::stdx::fmax/fmin, which is bit-exact for finite/Inf and the
+/// signed-zero tie cases. NaN-input lanes (and signed-zero ties) can differ in
+/// payload/sign between the scalar and SIMD bodies — an accepted divergence — so
+/// those lanes are excluded from the per-lane comparison (the skip condition is
+/// computed from the inputs, identical in both runs, so both runs skip the same
+/// lanes and the comparison stays meaningful on the rest). Each op runs TWICE
+/// in the same process -- once forcing the scalar body, once the SIMD fast path,
+/// with identical seed/inputs/EXEC -- and the two result arrays are asserted
+/// equal per active, non-skipped lane (util::set_force_scalar_for_testing flips
+/// the gate in-process). The inputs deliberately pair up
+/// ±0 and NaN in both operand orders on the low lanes — the corner cases the
+/// earlier (reverted) f16 min/max shipped without and silently diverged on.
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <string>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t WF_SIZE = 64;
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+constexpr uint32_t DST_SENTINEL = 0xCAFEF00Du;
+
+constexpr uint32_t vop2_encode(uint32_t opcode, uint32_t vdst, uint32_t vsrc1, uint32_t src0) {
+  return ((opcode & 0x3F) << 25) | ((vdst & 0xFF) << 17) | ((vsrc1 & 0xFF) << 9) | (src0 & 0x1FF);
+}
+
+bool is_f32_nan(uint32_t u) { return ((u >> 23) & 0xFFu) == 0xFFu && (u & 0x7FFFFFu) != 0u; }
+bool is_f16_nan(uint32_t u) { return ((u >> 10) & 0x1Fu) == 0x1Fu && (u & 0x3FFu) != 0u; }
+bool is_f32_zero(uint32_t u) { return (u & 0x7FFFFFFFu) == 0u; }
+bool is_f16_zero(uint32_t u) { return (u & 0x7FFFu) == 0u; }
+
+// Edge operand pairs (src0, vsrc1) for the low lanes.
+// - kEdgesF32 entries are f32 bit patterns.
+// - kEdgesF16 entries are f16 bit patterns stored in the low 16 bits.
+// The pairing exercises ±0 ties in both orders, NaN in either slot, and
+// ordinary ordering.
+struct Pair {
+  uint32_t a, b;
+};
+const std::array<Pair, 14> kEdgesF32 = {{
+    {0x80000000u, 0x00000000u}, // -0, +0
+    {0x00000000u, 0x80000000u}, // +0, -0
+    {0x80000000u, 0x80000000u}, // -0, -0
+    {0x3F800000u, 0xBF800000u}, // 1.0, -1.0
+    {0x7F800000u, 0x3F800000u}, // +Inf, 1.0
+    {0xFF800000u, 0x3F800000u}, // -Inf, 1.0
+    {0x7FC00000u, 0x3F800000u}, // QNaN, 1.0  (skipped)
+    {0x3F800000u, 0x7FC00000u}, // 1.0, QNaN  (skipped)
+    {0x7F800001u, 0x40000000u}, // SNaN, 2.0  (skipped)
+    {0x00800000u, 0x00000001u}, // smallest normal, smallest denormal
+    {0x007FFFFFu, 0x80000000u}, // largest denormal, -0
+    {0x7F7FFFFFu, 0xFF7FFFFFu}, // FLT_MAX, -FLT_MAX
+    {0xC0490FDBu, 0x40490FDBu}, // -pi, +pi
+    {0x42280000u, 0x42280000u}, // 42.0, 42.0
+}};
+const std::array<Pair, 14> kEdgesF16 = {{
+    {0x00008000u, 0x00000000u}, // -0, +0
+    {0x00000000u, 0x00008000u}, // +0, -0
+    {0x00008000u, 0x00008000u}, // -0, -0
+    {0x00003C00u, 0x0000BC00u}, // 1.0, -1.0
+    {0x00007C00u, 0x00003C00u}, // +Inf, 1.0
+    {0x0000FC00u, 0x00003C00u}, // -Inf, 1.0
+    {0x00007E00u, 0x00003C00u}, // QNaN, 1.0  (skipped)
+    {0x00003C00u, 0x00007E00u}, // 1.0, QNaN  (skipped)
+    {0x00007D00u, 0x00004000u}, // SNaN, 2.0  (skipped)
+    {0x00000400u, 0x00000001u}, // smallest normal, smallest denormal
+    {0x000003FFu, 0x00008000u}, // largest denormal, -0
+    {0x00007BFFu, 0x0000FBFFu}, // HALF_MAX, -HALF_MAX
+    {0x0000C248u, 0x00004248u}, // -pi, +pi
+    {0x00005140u, 0x00005140u}, // 42.0, 42.0
+}};
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("vop2_minmax_mem"), l2("vop2_minmax_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vop2_minmax", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  std::array<bool, WF_SIZE> seed_inputs(uint64_t seed, bool is_f16, uint64_t exec) {
+    std::mt19937_64 rng(seed);
+    std::array<bool, WF_SIZE> nan_lane{};
+    uint32_t vbase = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      uint32_t r0, r1;
+      const auto &edges = is_f16 ? kEdgesF16 : kEdgesF32;
+      if (lane < edges.size()) {
+        r0 = edges[lane].a;
+        r1 = edges[lane].b;
+      } else {
+        r0 = static_cast<uint32_t>(rng());
+        r1 = static_cast<uint32_t>(rng());
+        // Bias toward ±0 ties on some random lanes too.
+        if ((rng() & 7u) == 0u)
+          r0 &= 0x80000000u;
+        if ((rng() & 7u) == 0u)
+          r1 &= 0x80000000u;
+      }
+      cu->write_vgpr(vbase + 0, lane, r0);
+      cu->write_vgpr(vbase + 1, lane, r1);
+      cu->write_vgpr(vbase + 2, lane, DST_SENTINEL);
+      auto nan = [&](uint32_t v) { return is_f16 ? is_f16_nan(v & 0xFFFFu) : is_f32_nan(v); };
+      auto zero = [&](uint32_t v) { return is_f16 ? is_f16_zero(v & 0xFFFFu) : is_f32_zero(v); };
+      // Skip a lane when its result may legitimately differ: a NaN input (NaN
+      // payload) or a signed-zero tie (-0 vs +0). Both are accepted divergences.
+      nan_lane[lane] = nan(r0) || nan(r1) || (zero(r0) && zero(r1));
+    }
+    wf->set_exec(exec);
+    return nan_lane;
+  }
+
+  std::array<uint32_t, WF_SIZE> snapshot_dst() const {
+    std::array<uint32_t, WF_SIZE> out{};
+    uint32_t vbase = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+      out[lane] = cu->read_vgpr(vbase + 2, lane);
+    return out;
+  }
+};
+
+struct MinMaxCase {
+  const char *label;
+  uint32_t opcode;
+  bool is_f16;
+};
+
+const MinMaxCase kCases[] = {
+    {"v_max_f32", 11, false},
+    {"v_min_f32", 10, false},
+    {"v_max_f16", 45, true},
+    {"v_min_f16", 46, true},
+};
+
+// Restores the process force-scalar gate on scope exit so flipping it for an
+// in-process A/B comparison cannot leak into later tests in the same process.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+void check_case(const MinMaxCase &c, uint64_t exec) {
+  ForceScalarGuard gate_guard;
+
+  constexpr uint64_t SEED = 0x3E12'7777'1234ULL;
+
+  std::array<bool, WF_SIZE> nan_lane{};
+
+  // Run the same instruction with identical seed/inputs/EXEC in both execute
+  // modes. The accepted-divergence (NaN-payload / signed-zero tie) lane set is
+  // computed from the inputs, identical in both runs.
+  auto run_mode = [&](bool force_scalar) -> std::array<uint32_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    uint32_t enc = vop2_encode(c.opcode, /*vdst=*/2, /*vsrc1=*/1, /*src0=*/256);
+    uint32_t words[4] = {enc, 0u, 0u, 0u};
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << c.label << ": decode failed";
+    nan_lane = fx.seed_inputs(SEED, c.is_f16, exec);
+    fx.cu->execute_instruction(inst, *fx.wf);
+    auto out = fx.snapshot_dst();
+    delete inst;
+    return out;
+  };
+
+  const auto scalar_out = run_mode(/*force_scalar=*/true);
+  const auto simd_out = run_mode(/*force_scalar=*/false);
+
+  // Core A/B equivalence per active, non-skipped lane: accepted-divergence
+  // lanes (NaN-payload / signed-zero tie) are excluded identically in both runs.
+  for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+    const bool active = (exec >> lane) & 1ULL;
+    if (active && nan_lane[lane])
+      continue;
+    EXPECT_EQ(scalar_out[lane], simd_out[lane])
+        << c.label << " (exec=0x" << std::hex << exec << "): SIMD path diverged from scalar body "
+        << "at lane " << std::dec << lane;
+  }
+
+  // Inactive-lane preservation holds regardless of NaN/signed-zero status.
+  for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+    const bool active = (exec >> lane) & 1ULL;
+    if (!active) {
+      EXPECT_EQ(simd_out[lane], DST_SENTINEL) << c.label << ": clobbered inactive lane " << lane;
+      EXPECT_EQ(scalar_out[lane], DST_SENTINEL) << c.label << ": clobbered inactive lane " << lane;
+    }
+  }
+}
+
+TEST(Vop2MinMaxSimdCorrectness, FullExecMask) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_case(c, /*exec=*/~0ULL);
+}
+
+TEST(Vop2MinMaxSimdCorrectness, PartialExecMask) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_case(c, /*exec=*/0xA5A5'F0F0'1234'8001ULL);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vop2_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop2_simd_correctness_test.cpp
@@ -1,0 +1,239 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vop2_simd_correctness_test.cpp
+/// @brief Bit-identity check (SIMD fast path vs scalar body) for the Tier-1
+/// VOP2 binary instructions wired into SIMD_VOP2_BINARY. Each op runs TWICE in
+/// the same process -- once forcing the scalar body, once the SIMD fast path,
+/// with identical seed/inputs/EXEC -- and the two 64-lane result arrays are
+/// asserted equal with EXPECT_EQ (util::set_force_scalar_for_testing flips the
+/// gate in-process; the prior two-process file-dump diff is no longer needed
+/// here). In-process the test also checks inactive-lane preservation under full
+/// and partial EXEC masks.
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <string>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t WF_SIZE = 64;
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+constexpr uint32_t DST_SENTINEL = 0xCAFEF00Du;
+
+// CDNA4 VOP2: opcode[30:25], vdst[24:17], vsrc1[16:9], src0[8:0]. Bit 31 = 0.
+constexpr uint32_t vop2_encode(uint32_t opcode, uint32_t vdst, uint32_t vsrc1, uint32_t src0) {
+  return ((opcode & 0x3F) << 25) | ((vdst & 0xFF) << 17) | ((vsrc1 & 0xFF) << 9) | (src0 & 0x1FF);
+}
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("vop2_simd_mem"), l2("vop2_simd_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vop2_simd", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  // Map a raw 32-bit value to a finite-normal IEEE-754 binary32 (no NaN/Inf/
+  // denormal), keeping fp arithmetic single-rounded and host-SIMD-identical.
+  static uint32_t finite_normal(uint32_t raw) {
+    uint32_t mantissa = raw & 0x007FFFFFu;
+    uint32_t exp = 0x40u | ((raw >> 23) & 0x7Eu);
+    uint32_t sign = raw & 0x80000000u;
+    return sign | (exp << 23) | mantissa;
+  }
+
+  void seed_inputs(uint64_t seed, bool is_float, uint64_t exec) {
+    std::mt19937_64 rng(seed);
+    uint32_t vbase = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      uint32_t r0 = static_cast<uint32_t>(rng());
+      uint32_t r1 = static_cast<uint32_t>(rng());
+      if (is_float) {
+        r0 = finite_normal(r0);
+        r1 = finite_normal(r1);
+      }
+      cu->write_vgpr(vbase + 0, lane, r0);
+      cu->write_vgpr(vbase + 1, lane, r1);
+      cu->write_vgpr(vbase + 2, lane, DST_SENTINEL);
+    }
+    wf->set_exec(exec);
+  }
+
+  std::array<uint32_t, WF_SIZE> snapshot_dst() const {
+    std::array<uint32_t, WF_SIZE> out{};
+    uint32_t vbase = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+      out[lane] = cu->read_vgpr(vbase + 2, lane);
+    return out;
+  }
+
+  // Runs the instruction in the process's current execute mode (SIMD or
+  // scalar, selected by util::force_scalar()). The caller flips the gate
+  // between two calls with identical seed/inputs to compare the paths.
+  std::array<uint32_t, WF_SIZE> run(Instruction *inst, uint64_t seed, bool is_float,
+                                    uint64_t exec) {
+    seed_inputs(seed, is_float, exec);
+    cu->execute_instruction(inst, *wf);
+    return snapshot_dst();
+  }
+};
+
+struct Vop2Case {
+  const char *label;
+  uint32_t opcode;
+  bool is_float;
+};
+
+// Tier-1 ops wired into SIMD_VOP2_BINARY (CDNA4 VOP2 opcodes).
+const Vop2Case kCases[] = {
+    {"v_add_f32", 1, true},
+    {"v_sub_f32", 2, true},
+    {"v_subrev_f32", 3, true},
+    {"v_mul_f32", 5, true},
+    {"v_add_u32", 52, false},
+    {"v_sub_u32", 53, false},
+    {"v_subrev_u32", 54, false},
+    {"v_and_b32", 19, false},
+    {"v_or_b32", 20, false},
+    {"v_xor_b32", 21, false},
+    {"v_xnor_b32", 61, false},
+    {"v_lshlrev_b32", 18, false},
+    {"v_lshrrev_b32", 16, false},
+    {"v_mul_u32_u24", 8, false},
+    {"v_mul_i32_i24", 6, false},
+    {"v_mul_hi_i32_i24", 7, false},
+    {"v_mul_hi_u32_u24", 9, false},
+    {"v_max_u32", 15, false},
+    {"v_min_u32", 14, false},
+    {"v_ashrrev_i32", 17, false},
+    {"v_max_i32", 13, false},
+    {"v_min_i32", 12, false},
+    // 16-bit integer (low 16 bits, zero-extended result).
+    {"v_add_u16", 38, false},
+    {"v_sub_u16", 39, false},
+    {"v_subrev_u16", 40, false},
+    {"v_mul_lo_u16", 41, false},
+    {"v_lshlrev_b16", 42, false},
+    {"v_lshrrev_b16", 43, false},
+    {"v_ashrrev_i16", 44, false},
+    {"v_max_u16", 47, false},
+    {"v_max_i16", 48, false},
+    {"v_min_u16", 49, false},
+    {"v_min_i16", 50, false},
+    // f16 binary (low 16 bits f16, zero-extended result; raw inputs cover
+    // f16 NaN/Inf/denormal in the low half).
+    {"v_add_f16", 31, false},
+    {"v_sub_f16", 32, false},
+    {"v_subrev_f16", 33, false},
+    {"v_mul_f16", 34, false},
+    // f16 ldexp: src0 = f16, vsrc1 = signed-16 exponent. ldexp NaN handling is
+    // bit-exact (no operand ambiguity), so raw inputs need no NaN skip.
+    {"v_ldexp_f16", 51, false},
+    // v_max_f16 / v_min_f16 deliberately omitted: std::fmax/fmin reference is
+    // not SIMD-bit-reproducible on signed zero / NaN (see simd_codegen.py).
+};
+
+// Restores the process force-scalar gate on scope exit so flipping it for an
+// in-process A/B comparison cannot leak into later tests in the same process.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+void check_case(const Vop2Case &c, uint64_t exec) {
+  ForceScalarGuard gate_guard;
+
+  constexpr uint64_t SEED = 0xC0FFEE'1234'5678ULL;
+
+  // Run the same instruction with identical seed/inputs/EXEC in both execute
+  // modes. A fresh Fixture per run isolates VGPR state; finite_normal inputs
+  // (f32) plus the bit-exact f16/ldexp ops and the deliberate omission of
+  // v_max_f16/v_min_f16 mean every active lane is bit-reproducible, so no
+  // per-lane NaN skip is needed -- the full 64-lane arrays must match.
+  auto run_mode = [&](bool force_scalar) -> std::array<uint32_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    uint32_t enc = vop2_encode(c.opcode, /*vdst=*/2, /*vsrc1=*/1, /*src0=*/256);
+    uint32_t words[4] = {enc, 0u, 0u, 0u};
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << c.label << ": decode failed";
+    auto out = fx.run(inst, SEED, c.is_float, exec);
+    delete inst;
+    return out;
+  };
+
+  const auto scalar_out = run_mode(/*force_scalar=*/true);
+  const auto simd_out = run_mode(/*force_scalar=*/false);
+
+  // Core A/B equivalence: the SIMD fast path must be bit-identical to the
+  // scalar generated body across all 64 lanes (active and inactive).
+  EXPECT_EQ(scalar_out, simd_out) << c.label << " (exec=0x" << std::hex << exec << "): SIMD path "
+                                  << "diverged from scalar body";
+
+  // In-process invariant that holds in either mode: inactive lanes must keep
+  // the destination sentinel (no out-of-bounds writes / masked-store leaks).
+  for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+    const bool active = (exec >> lane) & 1ULL;
+    if (!active) {
+      EXPECT_EQ(simd_out[lane], DST_SENTINEL) << c.label << ": clobbered inactive lane " << lane
+                                              << std::hex << " value=0x" << simd_out[lane];
+      EXPECT_EQ(scalar_out[lane], DST_SENTINEL) << c.label << ": clobbered inactive lane " << lane
+                                                << std::hex << " value=0x" << scalar_out[lane];
+    }
+  }
+}
+
+TEST(Vop2SimdCorrectness, FullExecMask) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_case(c, /*exec=*/~0ULL);
+}
+
+TEST(Vop2SimdCorrectness, PartialExecMask) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  // Alternating + sparse pattern: exercises masked_store blend and inactive-lane
+  // preservation across SIMD chunk boundaries.
+  for (const auto &c : kCases)
+    check_case(c, /*exec=*/0xA5A5'F0F0'1234'8001ULL);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_b16_rdna_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_b16_rdna_simd_correctness_test.cpp
@@ -1,0 +1,381 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vop3_b16_rdna_simd_correctness_test.cpp
+/// @brief Bit-identity check (SIMD fast path vs scalar body) for five
+/// 16-bit-lane VOP3 ops that are RDNA3+ only (no CDNA4 decode path). Each case
+/// runs TWICE in the same process -- once forcing the scalar body, once the SIMD
+/// fast path, with identical inputs/EXEC -- and the two result arrays are
+/// asserted equal with EXPECT_EQ (util::set_force_scalar_for_testing flips the
+/// gate in-process). In-process inactive lanes must keep the sentinel.
+///   - v_and_b16, v_or_b16, v_xor_b16: low-16 bitwise binary, routed
+///     through the int VOP3 binary glue with a `& 0xFFFFu` mask.
+///   - v_not_b16: low-16 bitwise unary, routed through the VOP1 unary glue
+///     with a `& 0xFFFFu` mask.
+///   - v_cndmask_b16: low-16 VCC/SGPR-pair select, routed through the new
+///     try_execute_cndmask_b16_vop3_simd glue.
+///
+/// All five share the scalar-body pattern `uint32_t(uint16_t(... low16 ...))`
+/// — the high 16 bits of the destination VGPR are zeroed. The CU and decoder
+/// are built for RDNA3; encoding marker is 0x35<<26.
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include "util/simd.h"
+
+#include <array>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t WF_SIZE = 32; // RDNA3 wave32
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+constexpr uint32_t kDstVgpr = 4;
+constexpr uint32_t DST_SENTINEL = 0xCDCDCDCDu;
+
+// RDNA3 VOP3 (encoding[31:26]=0x35). Layout matches cdna4 except the marker.
+// word0 = vdst[7:0] | abs[10:8] | op_sel[14:11] | clamp[15] | op[25:16] | enc[31:26];
+// word1 = src0[8:0] | src1[17:9] | src2[26:18] | omod[28:27] | neg[31:29].
+constexpr void rdna3_vop3_encode(uint32_t op, uint32_t vdst, uint32_t src0, uint32_t src1,
+                                 uint32_t src2, uint32_t words[2]) {
+  words[0] = (vdst & 0xFF) | ((op & 0x3FF) << 16) | (0x35u << 26);
+  words[1] = (src0 & 0x1FF) | ((src1 & 0x1FF) << 9) | ((src2 & 0x1FF) << 18);
+}
+
+// Same as rdna3_vop3_encode but also sets the per-instruction clamp and omod
+// modifier fields. Used by v_mov_b16, which is the only op in this file that
+// honours omod / clamp (the bitwise b16 ops ignore both).
+constexpr void rdna3_vop3_encode_mod(uint32_t op, uint32_t vdst, uint32_t src0, uint32_t src1,
+                                     uint32_t src2, uint32_t clamp, uint32_t omod,
+                                     uint32_t words[2]) {
+  words[0] = (vdst & 0xFF) | ((clamp & 0x1u) << 15) | ((op & 0x3FF) << 16) | (0x35u << 26);
+  words[1] =
+      (src0 & 0x1FF) | ((src1 & 0x1FF) << 9) | ((src2 & 0x1FF) << 18) | ((omod & 0x3u) << 27);
+}
+
+const std::array<uint32_t, 16> kSrcA = {{
+    0x00000000u,
+    0xFFFFFFFFu,
+    0x12345678u,
+    0xDEADBEEFu,
+    0xA5A5A5A5u,
+    0x5A5A5A5Au,
+    0x80008000u,
+    0x7FFF7FFFu,
+    0x0F0F0F0Fu,
+    0xF0F0F0F0u,
+    0x00FF00FFu,
+    0xFF00FF00u,
+    0xCAFEBABEu,
+    0x0123FEDCu,
+    0x76543210u,
+    0xABCDEF01u,
+}};
+const std::array<uint32_t, 16> kSrcB = {{
+    0xC0DEC0DEu,
+    0x13579BDFu,
+    0x2468ACE0u,
+    0xBADF00D0u,
+    0x55555555u,
+    0xAAAAAAAAu,
+    0x33333333u,
+    0xCCCCCCCCu,
+    0x00010203u,
+    0xFCFDFEFFu,
+    0xDEADC0DEu,
+    0x8BADF00Du,
+    0xFEEDFACEu,
+    0xF00DBABEu,
+    0x12345678u,
+    0x87654321u,
+}};
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("vop3_b16_mem"), l2("vop3_b16_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_RDNA3;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vop3_b16", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA3);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  void seed_vgprs(uint32_t rot, uint64_t exec) {
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      cu->write_vgpr(vb + 0, lane, kSrcA[lane % kSrcA.size()]);
+      cu->write_vgpr(vb + 1, lane, kSrcB[(lane + rot) % kSrcB.size()]);
+      cu->write_vgpr(vb + kDstVgpr, lane, DST_SENTINEL);
+    }
+    wf->set_exec(exec);
+  }
+
+  std::array<uint32_t, WF_SIZE> run(Instruction *inst, uint32_t rot, uint64_t exec) {
+    seed_vgprs(rot, exec);
+    cu->execute_instruction(inst, *wf);
+    std::array<uint32_t, WF_SIZE> out{};
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+      out[lane] = cu->read_vgpr(vb + kDstVgpr, lane);
+    return out;
+  }
+};
+
+struct BinCase {
+  const char *name;
+  uint32_t opcode;
+};
+
+const std::array<BinCase, 3> kBinCases = {{
+    {"v_and_b16_vop3", 866},
+    {"v_or_b16_vop3", 867},
+    {"v_xor_b16_vop3", 868},
+}};
+
+// Restores the process force-scalar gate on scope exit so flipping it for an
+// in-process A/B comparison cannot leak into later tests in the same process.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+void check_binary(const BinCase &c, uint64_t exec) {
+  ForceScalarGuard gate_guard;
+
+  auto run_mode = [&](bool force_scalar, uint32_t rot) -> std::array<uint32_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    uint32_t words[4] = {0u, 0u, 0u, 0u};
+    rdna3_vop3_encode(c.opcode, kDstVgpr, /*src0=*/256, /*src1=*/257, /*src2=*/0, words);
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << c.name << " decode failed";
+    auto out = fx.run(inst, rot, exec);
+    delete inst;
+    return out;
+  };
+
+  for (uint32_t rot = 0; rot < kSrcB.size(); ++rot) {
+    const auto scalar_out = run_mode(/*force_scalar=*/true, rot);
+    const auto simd_out = run_mode(/*force_scalar=*/false, rot);
+
+    EXPECT_EQ(scalar_out, simd_out)
+        << c.name << " rot=" << rot << ": SIMD path diverged from scalar body";
+
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      const bool active = (exec >> lane) & 1ULL;
+      if (!active) {
+        EXPECT_EQ(simd_out[lane], DST_SENTINEL)
+            << c.name << " rot=" << rot << ": clobbered inactive lane " << lane;
+        EXPECT_EQ(scalar_out[lane], DST_SENTINEL)
+            << c.name << " rot=" << rot << ": clobbered inactive lane " << lane;
+      }
+    }
+  }
+}
+
+void check_not_b16(uint64_t exec) {
+  ForceScalarGuard gate_guard;
+
+  auto run_mode = [&](bool force_scalar) -> std::array<uint32_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    uint32_t words[4] = {0u, 0u, 0u, 0u};
+    rdna3_vop3_encode(/*op=*/489, /*vdst=*/kDstVgpr, /*src0=*/256, /*src1=*/0, /*src2=*/0, words);
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << "v_not_b16_vop3 decode failed";
+    auto out = fx.run(inst, 0, exec);
+    delete inst;
+    return out;
+  };
+
+  const auto scalar_out = run_mode(/*force_scalar=*/true);
+  const auto simd_out = run_mode(/*force_scalar=*/false);
+
+  EXPECT_EQ(scalar_out, simd_out) << "v_not_b16_vop3: SIMD path diverged from scalar body";
+
+  for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+    const bool active = (exec >> lane) & 1ULL;
+    if (!active) {
+      EXPECT_EQ(simd_out[lane], DST_SENTINEL) << "v_not_b16_vop3 clobbered inactive lane " << lane;
+      EXPECT_EQ(scalar_out[lane], DST_SENTINEL)
+          << "v_not_b16_vop3 clobbered inactive lane " << lane;
+    }
+  }
+}
+
+void check_cndmask_b16(uint64_t exec, uint64_t sel) {
+  ForceScalarGuard gate_guard;
+
+  auto run_mode = [&](bool force_scalar, uint32_t rot) -> std::array<uint32_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    uint32_t sb = fx.wf->sgpr_alloc().base;
+    fx.cu->write_sgpr(sb + 0, static_cast<uint32_t>(sel));
+    fx.cu->write_sgpr(sb + 1, static_cast<uint32_t>(sel >> 32));
+    uint32_t words[4] = {0u, 0u, 0u, 0u};
+    rdna3_vop3_encode(/*op=*/605, /*vdst=*/kDstVgpr, /*src0=*/256, /*src1=*/257, /*src2=*/sb,
+                      words);
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << "v_cndmask_b16_vop3 decode failed";
+    auto out = fx.run(inst, rot, exec);
+    delete inst;
+    return out;
+  };
+
+  for (uint32_t rot = 0; rot < kSrcB.size(); ++rot) {
+    const auto scalar_out = run_mode(/*force_scalar=*/true, rot);
+    const auto simd_out = run_mode(/*force_scalar=*/false, rot);
+
+    EXPECT_EQ(scalar_out, simd_out)
+        << "v_cndmask_b16_vop3 sel=0x" << std::hex << sel << " rot=" << std::dec << rot
+        << ": SIMD path diverged from scalar body";
+
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      const bool active = (exec >> lane) & 1ULL;
+      if (!active) {
+        EXPECT_EQ(simd_out[lane], DST_SENTINEL) << "v_cndmask_b16_vop3 sel=0x" << std::hex << sel
+                                                << ": clobbered inactive lane " << lane;
+        EXPECT_EQ(scalar_out[lane], DST_SENTINEL) << "v_cndmask_b16_vop3 sel=0x" << std::hex << sel
+                                                  << ": clobbered inactive lane " << lane;
+      }
+    }
+  }
+}
+
+TEST(Vop3B16RdnaSimdCorrectness, BitwiseBinary_FullExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable";
+    return;
+  }
+  for (const auto &c : kBinCases)
+    check_binary(c, /*exec=*/0xFFFFFFFFULL);
+}
+TEST(Vop3B16RdnaSimdCorrectness, BitwiseBinary_PartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable";
+    return;
+  }
+  for (const auto &c : kBinCases)
+    check_binary(c, /*exec=*/0xA5A58001ULL);
+}
+TEST(Vop3B16RdnaSimdCorrectness, NotB16_FullExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable";
+    return;
+  }
+  check_not_b16(/*exec=*/0xFFFFFFFFULL);
+}
+TEST(Vop3B16RdnaSimdCorrectness, NotB16_PartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable";
+    return;
+  }
+  check_not_b16(/*exec=*/0xA5A58001ULL);
+}
+TEST(Vop3B16RdnaSimdCorrectness, CndmaskB16_FullExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable";
+    return;
+  }
+  for (uint64_t sel :
+       {uint64_t{0}, uint64_t{~0ULL}, uint64_t{0xAAAAAAAAULL}, uint64_t{0x12345678ULL}})
+    check_cndmask_b16(/*exec=*/0xFFFFFFFFULL, sel);
+}
+TEST(Vop3B16RdnaSimdCorrectness, CndmaskB16_PartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable";
+    return;
+  }
+  for (uint64_t sel :
+       {uint64_t{0}, uint64_t{~0ULL}, uint64_t{0xAAAAAAAAULL}, uint64_t{0x12345678ULL}})
+    check_cndmask_b16(/*exec=*/0xA5A58001ULL, sel);
+}
+
+// --- v_mov_b16: u16 src0 -> f32 -> omod / clamp -> u16 dst (zero-extended) ---
+
+void check_mov_b16(uint64_t exec, uint32_t omod, uint32_t clamp) {
+  ForceScalarGuard gate_guard;
+
+  auto run_mode = [&](bool force_scalar) -> std::array<uint32_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    uint32_t words[4] = {0u, 0u, 0u, 0u};
+    rdna3_vop3_encode_mod(/*op=*/412, /*vdst=*/kDstVgpr, /*src0=*/256, /*src1=*/0, /*src2=*/0,
+                          clamp, omod, words);
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << "v_mov_b16_vop3 decode failed";
+    auto out = fx.run(inst, 0, exec);
+    delete inst;
+    return out;
+  };
+
+  const auto scalar_out = run_mode(/*force_scalar=*/true);
+  const auto simd_out = run_mode(/*force_scalar=*/false);
+
+  EXPECT_EQ(scalar_out, simd_out) << "v_mov_b16 omod=" << omod << " clamp=" << clamp
+                                  << ": SIMD path diverged from scalar body";
+
+  for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+    const bool active = (exec >> lane) & 1ULL;
+    if (!active) {
+      EXPECT_EQ(simd_out[lane], DST_SENTINEL)
+          << "v_mov_b16 omod=" << omod << " clamp=" << clamp << " clobbered inactive lane " << lane;
+      EXPECT_EQ(scalar_out[lane], DST_SENTINEL)
+          << "v_mov_b16 omod=" << omod << " clamp=" << clamp << " clobbered inactive lane " << lane;
+    }
+  }
+}
+
+TEST(Vop3B16RdnaSimdCorrectness, MovB16_FullExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable";
+    return;
+  }
+  for (uint32_t omod : {0u, 1u, 2u, 3u})
+    for (uint32_t clamp : {0u, 1u})
+      check_mov_b16(/*exec=*/0xFFFFFFFFULL, omod, clamp);
+}
+TEST(Vop3B16RdnaSimdCorrectness, MovB16_PartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable";
+    return;
+  }
+  for (uint32_t omod : {0u, 1u, 2u, 3u})
+    for (uint32_t clamp : {0u, 1u})
+      check_mov_b16(/*exec=*/0xA5A58001ULL, omod, clamp);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_binary_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_binary_simd_correctness_test.cpp
@@ -1,0 +1,289 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vop3_binary_simd_correctness_test.cpp
+/// @brief Bit-identity check (SIMD fast path vs scalar body) for the
+/// VOP3-encoded twins of the SIMD VOP2 binary ops on CDNA4. The VOP3 form reads
+/// src0/src1 and carries per-source abs/neg and per-instruction omod/clamp
+/// modifiers. f32 ops apply the modifiers in-vector (so the fast path fires even
+/// when modifiers are set — every abs/neg/omod/clamp combination is swept);
+/// integer/bitwise ops apply none. Each (case, modifier combo) runs TWICE in the
+/// same process -- once forcing the scalar body, once the SIMD fast path, with
+/// identical inputs/EXEC -- and the two 64-lane result arrays are asserted equal
+/// with EXPECT_EQ (util::set_force_scalar_for_testing flips the gate in-process).
+/// In-process inactive lanes must stay preserved under full and partial EXEC.
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include "util/simd.h"
+
+#include <array>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t WF_SIZE = 64;
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+constexpr uint32_t DST_SENTINEL = 0xCDCDCDCDu;
+constexpr uint32_t kDstVgpr = 4;
+
+// VOP3 (encoding[31:26]=0x34): word0 = vdst[7:0] | abs[10:8] | op_sel[14:11] |
+// clamp[15] | op[25:16] | enc[31:26]; word1 = src0[8:0] | src1[17:9] | src2[26:18]
+// | omod[28:27] | neg[31:29]. VGPR operands are encoded as 256 + reg.
+void vop3_encode(uint32_t op, uint32_t vdst, uint32_t src0, uint32_t src1, uint32_t abs,
+                 uint32_t neg, uint32_t omod, uint32_t clamp, uint32_t words[2]) {
+  words[0] = (vdst & 0xFF) | ((abs & 0x7) << 8) | ((clamp & 0x1) << 15) | ((op & 0x3FF) << 16) |
+             (0x34u << 26);
+  words[1] = (src0 & 0x1FF) | ((src1 & 0x1FF) << 9) | ((omod & 0x3) << 27) | ((neg & 0x7) << 29);
+}
+
+// Mixed f32 inputs: normals, ±0, ±Inf, NaN, denormal, in-[0,1] (for clamp), and
+// values whose products/sums exercise omod overflow to Inf.
+const std::array<uint32_t, 16> kF32A = {{
+    0x3F000000u,
+    0x40490FDBu,
+    0xC0490FDBu,
+    0x00000000u,
+    0x80000000u,
+    0x7F800000u,
+    0xFF800000u,
+    0x7FC00000u,
+    0x00000001u,
+    0x3DCCCCCDu,
+    0x42F60000u,
+    0xC2F60000u,
+    0x3F800000u,
+    0xBF800000u,
+    0x4B000000u,
+    0x7F7FFFFFu,
+}};
+const std::array<uint32_t, 16> kF32B = {{
+    0x40000000u,
+    0x3F800000u,
+    0x40490FDBu,
+    0x3F000000u,
+    0x7F800000u,
+    0x40000000u,
+    0x3F800000u,
+    0x40490FDBu,
+    0x40A00000u,
+    0x3F000000u,
+    0x40000000u,
+    0x40000000u,
+    0xBF800000u,
+    0x3F800000u,
+    0x4B000000u,
+    0x40000000u,
+}};
+const std::array<uint32_t, 16> kU32A = {{
+    0x00000000u,
+    0xFFFFFFFFu,
+    0x12345678u,
+    0x80000000u,
+    0x0000FFFFu,
+    0xDEADBEEFu,
+    0x00000001u,
+    0xCAFEBABEu,
+    0xA5A5A5A5u,
+    0x0F0F0F0Fu,
+    0x7FFFFFFFu,
+    0x00FF00FFu,
+    0x33333333u,
+    0xCCCCCCCCu,
+    0x10000000u,
+    0xFEDCBA98u,
+}};
+const std::array<uint32_t, 16> kU32B = {{
+    0xFFFFFFFFu,
+    0x00000001u,
+    0x0000000Fu,
+    0x00000003u,
+    0xFFFF0000u,
+    0x0000001Fu,
+    0x80000000u,
+    0x00000007u,
+    0x5A5A5A5Au,
+    0xF0F0F0F0u,
+    0x00000002u,
+    0xFF00FF00u,
+    0xCCCCCCCCu,
+    0x33333333u,
+    0x00000004u,
+    0x01234567u,
+}};
+
+enum class Kind { F32, INT };
+
+struct Case {
+  const char *name;
+  uint32_t opcode;
+  Kind kind;
+};
+
+const std::array<Case, 10> kCases = {{
+    {"v_add_f32", 257, Kind::F32},
+    {"v_sub_f32", 258, Kind::F32},
+    {"v_mul_f32", 261, Kind::F32},
+    {"v_min_f32", 266, Kind::F32},
+    {"v_max_f32", 267, Kind::F32},
+    {"v_and_b32", 275, Kind::INT},
+    {"v_or_b32", 276, Kind::INT},
+    {"v_xor_b32", 277, Kind::INT},
+    {"v_add_u32", 308, Kind::INT},
+    {"v_mul_legacy_f32", 673, Kind::F32},
+}};
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("vop3_bin_simd_mem"), l2("vop3_bin_simd_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vop3_bin_simd", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  void seed_inputs(Kind k, uint64_t exec) {
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      if (k == Kind::F32) {
+        cu->write_vgpr(vb + 0, lane, kF32A[lane % kF32A.size()]);
+        cu->write_vgpr(vb + 1, lane, kF32B[lane % kF32B.size()]);
+      } else {
+        cu->write_vgpr(vb + 0, lane, kU32A[lane % kU32A.size()]);
+        cu->write_vgpr(vb + 1, lane, kU32B[lane % kU32B.size()]);
+      }
+      cu->write_vgpr(vb + kDstVgpr, lane, DST_SENTINEL);
+    }
+    wf->set_exec(exec);
+  }
+
+  std::array<uint32_t, WF_SIZE> run(Instruction *inst, Kind k, uint64_t exec) {
+    seed_inputs(k, exec);
+    cu->execute_instruction(inst, *wf);
+    uint32_t vb = wf->vgpr_alloc().base;
+    std::array<uint32_t, WF_SIZE> out{};
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+      out[lane] = cu->read_vgpr(vb + kDstVgpr, lane);
+    return out;
+  }
+};
+
+// Restores the process force-scalar gate on scope exit so flipping it for an
+// in-process A/B comparison cannot leak into later tests in the same process.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+void check(const Case &c, uint32_t abs, uint32_t neg, uint32_t omod, uint32_t clamp,
+           uint64_t exec) {
+  ForceScalarGuard gate_guard;
+
+  // Run the same (case, modifier combo) in both execute modes with identical
+  // deterministic inputs (fresh Fixture + decode per run isolates VGPR state).
+  auto run_mode = [&](bool force_scalar) -> std::array<uint32_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    uint32_t words[4] = {0u, 0u, 0u, 0u};
+    vop3_encode(c.opcode, /*vdst=*/kDstVgpr, /*src0=*/256, /*src1=*/257, abs, neg, omod, clamp,
+                words);
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << c.name << " decode failed";
+    auto out = fx.run(inst, c.kind, exec);
+    delete inst;
+    return out;
+  };
+
+  const auto scalar_out = run_mode(/*force_scalar=*/true);
+  const auto simd_out = run_mode(/*force_scalar=*/false);
+
+  // Core A/B equivalence: SIMD fast path must be bit-identical to the scalar
+  // body across all 64 lanes (active and inactive).
+  EXPECT_EQ(scalar_out, simd_out) << c.name << " abs=" << abs << " neg=" << neg << " omod=" << omod
+                                  << " clamp=" << clamp << " (exec=0x" << std::hex << exec
+                                  << "): SIMD path diverged from scalar body";
+
+  for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+    const bool active = (exec >> lane) & 1ULL;
+    if (!active) {
+      EXPECT_EQ(simd_out[lane], DST_SENTINEL)
+          << c.name << " abs=" << abs << " neg=" << neg << " omod=" << omod << " clamp=" << clamp
+          << ": clobbered inactive lane " << lane;
+      EXPECT_EQ(scalar_out[lane], DST_SENTINEL)
+          << c.name << " abs=" << abs << " neg=" << neg << " omod=" << omod << " clamp=" << clamp
+          << ": clobbered inactive lane " << lane;
+    }
+  }
+}
+
+// f32 ops: sweep every abs/neg/omod/clamp combination.
+void check_f32_all_mods(const Case &c, uint64_t exec) {
+  for (uint32_t abs = 0; abs < 4; ++abs)   // bits 0,1 = src0,src1
+    for (uint32_t neg = 0; neg < 4; ++neg) // bits 0,1 = src0,src1
+      for (uint32_t omod = 0; omod < 4; ++omod)
+        for (uint32_t clamp = 0; clamp < 2; ++clamp)
+          check(c, abs, neg, omod, clamp, exec);
+}
+
+TEST(Vop3BinarySimdCorrectness, F32_AllModifiers_FullExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    if (c.kind == Kind::F32)
+      check_f32_all_mods(c, /*exec=*/~0ULL);
+}
+
+TEST(Vop3BinarySimdCorrectness, F32_AllModifiers_PartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    if (c.kind == Kind::F32)
+      check_f32_all_mods(c, /*exec=*/0xA5A5'F0F0'1234'8001ULL);
+}
+
+TEST(Vop3BinarySimdCorrectness, Int_FullAndPartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases) {
+    if (c.kind != Kind::INT)
+      continue;
+    check(c, 0, 0, 0, 0, /*exec=*/~0ULL);
+    check(c, 0, 0, 0, 0, /*exec=*/0xA5A5'F0F0'1234'8001ULL);
+  }
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_carry_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_carry_simd_correctness_test.cpp
@@ -1,0 +1,308 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vop3_carry_simd_correctness_test.cpp
+/// @brief Bit-identity check (SIMD fast path vs scalar body) for the
+/// VOP3 sdst-enc carry-bearing ops:
+///   no-carry-in (CDNA4): v_add_co_u32, v_sub_co_u32, v_subrev_co_u32
+///   src2-carry-in (CDNA4): v_addc_co_u32, v_subb_co_u32, v_subbrev_co_u32
+///   src2-carry-in (RDNA3, sdst pre-bound to VCC by decoder):
+///     v_add_co_ci_u32, v_sub_co_ci_u32, v_subrev_co_ci_u32
+/// All six cin-form scalar bodies pull per-lane carry-in from
+/// `inst.src2.read_scalar64(wf)` (SGPR-pair) and write co into
+/// `inst.sdst.write_scalar64`, with inactive lanes preserved from the
+/// incoming VCC. Each (case, vcc_in, cin) runs TWICE in the same process -- once
+/// forcing the scalar body, once the SIMD fast path, with identical inputs --
+/// and the scalar-vs-SIMD equivalence on BOTH the destination VGPR AND the full
+/// 64-bit SGPR-pair carry result is asserted with EXPECT_EQ
+/// (util::set_force_scalar_for_testing flips the gate in-process), sweeping
+/// {full, partial} EXEC × {VCC seeds} × {cin patterns}. In-process inactive dst
+/// lanes must keep the sentinel. Inputs deliberately seed the 32-bit
+/// carry/borrow boundary on the low lanes.
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include "util/simd.h"
+
+#include <array>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <memory>
+#include <random>
+#include <string>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+constexpr uint32_t DST_SENTINEL = 0xCAFEF00Du;
+
+// CDNA4 / RDNA3 Vop3SdstEnc layout (identical bit fields, only the
+// `encoding` marker differs: CDNA4 = 0x34, RDNA3 = 0x35):
+//   word0: vdst[7:0] | sdst[14:8] | clamp[15] | op[25:16] | encoding[31:26]
+//   word1: src0[8:0] | src1[17:9] | src2[26:18] | omod[28:27] | neg[31:29]
+constexpr void vop3_sdstenc_encode(uint32_t op, uint32_t vdst, uint32_t sdst, uint32_t src0,
+                                   uint32_t src1, uint32_t src2, uint32_t encoding_marker,
+                                   uint32_t words[2]) {
+  words[0] = (vdst & 0xFFu) | ((sdst & 0x7Fu) << 8) | ((op & 0x3FFu) << 16) |
+             ((encoding_marker & 0x3Fu) << 26);
+  words[1] = (src0 & 0x1FFu) | ((src1 & 0x1FFu) << 9) | ((src2 & 0x1FFu) << 18);
+}
+
+constexpr uint32_t kCdna4Encoding = 0x34u;
+constexpr uint32_t kRdna3Encoding = 0x35u;
+
+const std::array<std::pair<uint32_t, uint32_t>, 14> kEdgePairs = {{
+    {0xFFFFFFFFu, 0x00000001u},
+    {0xFFFFFFFFu, 0x00000000u},
+    {0x00000000u, 0x00000000u},
+    {0x00000001u, 0x00000000u},
+    {0x00000000u, 0x00000001u},
+    {0x80000000u, 0x80000000u},
+    {0x7FFFFFFFu, 0x00000001u},
+    {0xFFFFFFFFu, 0xFFFFFFFFu},
+    {0x00000000u, 0xFFFFFFFFu},
+    {0xFFFFFFFEu, 0x00000001u},
+    {0x12345678u, 0x12345678u},
+    {0x12345679u, 0x12345678u},
+    {0xAAAAAAAAu, 0x55555555u},
+    {0x00000002u, 0x00000003u},
+}};
+
+const uint64_t kVccPatterns[] = {
+    0x0000000000000000ULL, 0xFFFFFFFFFFFFFFFFULL, 0xAAAAAAAAAAAAAAAAULL,
+    0x5555555555555555ULL, 0x0123456789ABCDEFULL,
+};
+
+// The cin word comes from an SGPR-pair (src2), which can hold *any* 64-bit
+// pattern — so sweep cin independently from VCC. Same set as VCC; the
+// orthogonal sweep catches cases where the glue accidentally reads VCC
+// instead of src2 (or vice-versa).
+const uint64_t kCinPatterns[] = {
+    0x0000000000000000ULL, 0xFFFFFFFFFFFFFFFFULL, 0xAAAAAAAAAAAAAAAAULL,
+    0x5555555555555555ULL, 0xCAFEBABEDEADBEEFULL,
+};
+
+template <int WaveSize> struct WaveFixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  WaveFixture(const char *mem_label, const char *l2_label, const char *cu_label,
+              rj_code_arch_t arch)
+      : gpu_mem(mem_label), l2(l2_label) {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = arch;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create(cu_label, cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(arch);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  void seed_inputs(uint64_t seed, uint64_t exec, uint64_t vcc_in, uint64_t sdst_in,
+                   uint32_t sdst_sgpr, uint64_t cin_word, uint32_t cin_sgpr_pair) {
+    std::mt19937_64 rng(seed);
+    uint32_t vbase = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WaveSize; ++lane) {
+      uint32_t r0, r1;
+      if (lane < kEdgePairs.size()) {
+        r0 = kEdgePairs[lane].first;
+        r1 = kEdgePairs[lane].second;
+      } else {
+        r0 = static_cast<uint32_t>(rng());
+        r1 = static_cast<uint32_t>(rng());
+      }
+      cu->write_vgpr(vbase + 0, lane, r0);
+      cu->write_vgpr(vbase + 1, lane, r1);
+      cu->write_vgpr(vbase + 2, lane, DST_SENTINEL);
+    }
+    wf->set_exec(exec);
+    wf->set_vcc(vcc_in);
+    cu->write_sgpr(sdst_sgpr + 0, static_cast<uint32_t>(sdst_in));
+    cu->write_sgpr(sdst_sgpr + 1, static_cast<uint32_t>(sdst_in >> 32));
+    if (cin_sgpr_pair != 0u) {
+      cu->write_sgpr(cin_sgpr_pair + 0, static_cast<uint32_t>(cin_word));
+      cu->write_sgpr(cin_sgpr_pair + 1, static_cast<uint32_t>(cin_word >> 32));
+    }
+  }
+
+  struct Result {
+    std::array<uint32_t, WaveSize> dst{};
+    uint64_t sdst = 0;
+  };
+
+  Result run(Instruction *inst, uint64_t seed, uint64_t exec, uint64_t vcc_in, uint64_t sdst_in,
+             uint32_t sdst_sgpr, uint64_t cin_word, uint32_t cin_sgpr_pair) {
+    seed_inputs(seed, exec, vcc_in, sdst_in, sdst_sgpr, cin_word, cin_sgpr_pair);
+    cu->execute_instruction(inst, *wf);
+    Result res;
+    uint32_t vbase = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WaveSize; ++lane)
+      res.dst[lane] = cu->read_vgpr(vbase + 2, lane);
+    uint64_t lo = cu->read_sgpr(sdst_sgpr + 0);
+    uint64_t hi = cu->read_sgpr(sdst_sgpr + 1);
+    res.sdst = (hi << 32) | lo;
+    return res;
+  }
+};
+
+struct CarryCase {
+  const char *label;
+  uint32_t opcode;
+  bool has_cin; ///< true for addc/subb/subbrev / add_co_ci / sub_co_ci / subrev_co_ci
+};
+
+const CarryCase kCdna4Cases[] = {
+    // no-cin
+    {"v_add_co_u32_vop3", 281, false},
+    {"v_sub_co_u32_vop3", 282, false},
+    {"v_subrev_co_u32_vop3", 283, false},
+    // src2-cin
+    {"v_addc_co_u32_vop3", 284, true},
+    {"v_subb_co_u32_vop3", 285, true},
+    {"v_subbrev_co_u32_vop3", 286, true},
+};
+
+const CarryCase kRdnaCases[] = {
+    {"v_add_co_ci_u32_vop3", 288, true},
+    {"v_sub_co_ci_u32_vop3", 289, true},
+    {"v_subrev_co_ci_u32_vop3", 290, true},
+};
+
+// Restores the process force-scalar gate on scope exit so flipping it for an
+// in-process A/B comparison cannot leak into later tests in the same process.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+template <int WaveSize>
+void check_case(const char *mem_label, const char *l2_label, const char *cu_label,
+                rj_code_arch_t arch, const CarryCase &c, uint32_t encoding_marker, uint64_t exec) {
+  ForceScalarGuard gate_guard;
+
+  using Result = typename WaveFixture<WaveSize>::Result;
+
+  constexpr uint64_t SEED = 0xC0FFEE'1234'5678ULL;
+  // Seed the SGPR-pair sdst with a recognisable pattern so any "didn't write"
+  // bug surfaces as a divergent (incoming vs scalar) result.
+  constexpr uint64_t SDST_SEED = 0xDEADBEEFCAFEF00DULL;
+
+  // Runs one (case, vcc_in, cin_word) in the requested execute mode (fresh
+  // WaveFixture + decode per run isolates VGPR/SGPR/VCC state).
+  auto run_mode = [&](bool force_scalar, uint64_t vcc_in, uint64_t cin_word) -> Result {
+    util::set_force_scalar_for_testing(force_scalar);
+    WaveFixture<WaveSize> fx(mem_label, l2_label, cu_label, arch);
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    uint32_t sb = fx.wf->sgpr_alloc().base;
+    // SGPR-pair carry-out target; must be an even-aligned SREG index.
+    EXPECT_EQ(sb % 2u, 0u) << c.label << ": sgpr_alloc base not pair-aligned";
+    // Second pair (sb+2) holds the cin word for cin-form ops; for no-cin
+    // ops it is unused and the src2 field encodes 0 (the body ignores it).
+    uint32_t cin_pair = c.has_cin ? (sb + 2u) : 0u;
+    uint32_t src2_field = c.has_cin ? cin_pair : 0u;
+    uint32_t words[2] = {0u, 0u};
+    vop3_sdstenc_encode(c.opcode, /*vdst=*/2, /*sdst=*/sb,
+                        /*src0=*/256, /*src1=*/257, /*src2=*/src2_field, encoding_marker, words);
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << c.label << ": decode failed";
+    auto out = fx.run(inst, SEED, exec, vcc_in, SDST_SEED, sb, cin_word, cin_pair);
+    delete inst;
+    return out;
+  };
+
+  for (uint64_t vcc_in : kVccPatterns) {
+    // No-cin ops still sweep VCC (their glue seeds the sdst inactive bits
+    // from VCC). Cin ops also sweep cin word from src2 SGPR-pair.
+    const uint64_t *cin_set = c.has_cin ? kCinPatterns : kVccPatterns;
+    const size_t cin_n = c.has_cin ? std::size(kCinPatterns) : 1u;
+    for (size_t i = 0; i < cin_n; ++i) {
+      uint64_t cin_word = c.has_cin ? cin_set[i] : 0ULL;
+      const auto scalar_out = run_mode(/*force_scalar=*/true, vcc_in, cin_word);
+      const auto simd_out = run_mode(/*force_scalar=*/false, vcc_in, cin_word);
+
+      // Core A/B equivalence on BOTH the dst words and the full 64-bit sdst.
+      EXPECT_EQ(scalar_out.dst, simd_out.dst)
+          << c.label << " vcc=0x" << std::hex << vcc_in << " cin=0x" << cin_word
+          << ": SIMD dst diverged from scalar body";
+      EXPECT_EQ(scalar_out.sdst, simd_out.sdst)
+          << c.label << " vcc=0x" << std::hex << vcc_in << " cin=0x" << cin_word
+          << ": SIMD sdst diverged from scalar body";
+
+      for (uint32_t lane = 0; lane < WaveSize; ++lane) {
+        const bool active = (exec >> lane) & 1ULL;
+        if (!active) {
+          EXPECT_EQ(simd_out.dst[lane], DST_SENTINEL)
+              << c.label << ": clobbered inactive dst lane " << lane;
+          EXPECT_EQ(scalar_out.dst[lane], DST_SENTINEL)
+              << c.label << ": clobbered inactive dst lane " << lane;
+        }
+      }
+    }
+  }
+}
+
+void run_cdna4(uint64_t exec) {
+  for (const auto &c : kCdna4Cases)
+    check_case<64>("vop3_carry_simd_mem", "vop3_carry_simd_l2", "cu_vop3_carry_simd",
+                   ROCJITSU_CODE_ARCH_CDNA4, c, kCdna4Encoding, exec);
+}
+
+void run_rdna(uint64_t exec) {
+  for (const auto &c : kRdnaCases)
+    check_case<32>("vop3_carry_simd_rdna_mem", "vop3_carry_simd_rdna_l2", "cu_vop3_carry_simd_rdna",
+                   ROCJITSU_CODE_ARCH_RDNA3, c, kRdna3Encoding, exec);
+}
+
+TEST(Vop3CarrySimdCorrectness, Cdna4FullExecMask) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  run_cdna4(/*exec=*/~0ULL);
+}
+
+TEST(Vop3CarrySimdCorrectness, Cdna4PartialExecMask) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  run_cdna4(/*exec=*/0xA5A5'F0F0'1234'8001ULL);
+}
+
+TEST(Vop3CarrySimdCorrectness, RdnaFullExecMask) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  // Wave32 — exec only meaningful in low 32 bits.
+  run_rdna(/*exec=*/0x00000000'FFFFFFFFULL);
+}
+
+TEST(Vop3CarrySimdCorrectness, RdnaPartialExecMask) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  run_rdna(/*exec=*/0x00000000'A5A5F0F1ULL);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_cndmask_pack_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_cndmask_pack_simd_correctness_test.cpp
@@ -1,0 +1,281 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vop3_cndmask_pack_simd_correctness_test.cpp
+/// @brief Bit-identity check (SIMD fast path vs scalar body) for two VOP3 ops
+/// that don't fit the binary/unary tables and reach SIMD through dedicated
+/// paths. Each case runs TWICE in the same process -- once forcing the scalar
+/// body, once the SIMD fast path, with identical inputs/EXEC -- and the two
+/// 64-lane result arrays are asserted equal with EXPECT_EQ
+/// (util::set_force_scalar_for_testing flips the gate in-process).
+/// In-process inactive lanes must keep the sentinel.
+///   - v_cndmask_b32_vop3: per-lane select from a 64-bit selector read out of
+///     the SGPR-pair `src2` (instead of fixed VCC); routes through the new
+///     try_execute_cndmask_vop3_simd glue.
+///   - v_pack_b32_f16_vop3: pack low-16 of src0 and low-16 of src1 into a
+///     b32 dst — pure integer bit-pack, routed through the existing VOP3 int
+///     binary path.
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include "util/simd.h"
+
+#include <array>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t WF_SIZE = 64;
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+constexpr uint32_t kDstVgpr = 4;
+constexpr uint32_t DST_SENTINEL = 0xCDCDCDCDu;
+
+// VOP3 ternary encoding (also fits cndmask which has 3 srcs). word0 =
+// vdst[7:0] | op[25:16] | enc[31:26] (0x34); word1 = src0[8:0] | src1[17:9] |
+// src2[26:18]. abs/neg/omod/clamp stay 0.
+constexpr void vop3_tern_encode(uint32_t op, uint32_t vdst, uint32_t src0, uint32_t src1,
+                                uint32_t src2, uint32_t words[2]) {
+  words[0] = (vdst & 0xFF) | ((op & 0x3FF) << 16) | (0x34u << 26);
+  words[1] = (src0 & 0x1FF) | ((src1 & 0x1FF) << 9) | ((src2 & 0x1FF) << 18);
+}
+
+// VOP3 binary encoding (cndmask uses ternary; pack uses this). word0 = vdst |
+// op<<16 | 0x34<<26; word1 = src0 | src1<<9.
+constexpr void vop3_bin_encode(uint32_t op, uint32_t vdst, uint32_t src0, uint32_t src1,
+                               uint32_t words[2]) {
+  words[0] = (vdst & 0xFF) | ((op & 0x3FF) << 16) | (0x34u << 26);
+  words[1] = (src0 & 0x1FF) | ((src1 & 0x1FF) << 9);
+}
+
+// 16 mixed 32-bit values; cndmask treats them as raw b32, pack uses low 16 bits.
+const std::array<uint32_t, 16> kSrcA = {{
+    0x00000000u,
+    0xFFFFFFFFu,
+    0x12345678u,
+    0xDEADBEEFu,
+    0xA5A5A5A5u,
+    0x5A5A5A5Au,
+    0x80000000u,
+    0x7FFFFFFFu,
+    0x0F0F0F0Fu,
+    0xF0F0F0F0u,
+    0x00FF00FFu,
+    0xFF00FF00u,
+    0xCAFEBABEu,
+    0x0123FEDCu,
+    0x76543210u,
+    0xABCDEF01u,
+}};
+
+const std::array<uint32_t, 16> kSrcB = {{
+    0xC0DEC0DEu,
+    0x13579BDFu,
+    0x2468ACE0u,
+    0xBADF00D0u,
+    0x55555555u,
+    0xAAAAAAAAu,
+    0x33333333u,
+    0xCCCCCCCCu,
+    0x00010203u,
+    0xFCFDFEFFu,
+    0xDEADC0DEu,
+    0x8BADF00Du,
+    0xFEEDFACEu,
+    0xF00DBABEu,
+    0x12345678u,
+    0x87654321u,
+}};
+
+// Selector patterns spanning fully-on, fully-off, alternating, and biased.
+const std::array<uint64_t, 6> kSels = {{
+    0x0000000000000000ULL,
+    0xFFFFFFFFFFFFFFFFULL,
+    0xAAAAAAAAAAAAAAAAULL,
+    0x5555555555555555ULL,
+    0x0123456789ABCDEFULL,
+    0xFEDCBA9876543210ULL,
+}};
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("vop3_cmkpack_mem"), l2("vop3_cmkpack_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vop3_cmkpack", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  void seed_vgprs(uint32_t rot, uint64_t exec) {
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      cu->write_vgpr(vb + 0, lane, kSrcA[lane % kSrcA.size()]);
+      cu->write_vgpr(vb + 1, lane, kSrcB[(lane + rot) % kSrcB.size()]);
+      cu->write_vgpr(vb + kDstVgpr, lane, DST_SENTINEL);
+    }
+    wf->set_exec(exec);
+  }
+
+  // Write selector into the wavefront's first allocated SGPR pair.
+  void seed_sgpr_pair(uint64_t sel) {
+    uint32_t sb = wf->sgpr_alloc().base;
+    cu->write_sgpr(sb + 0, static_cast<uint32_t>(sel));
+    cu->write_sgpr(sb + 1, static_cast<uint32_t>(sel >> 32));
+  }
+
+  std::array<uint32_t, WF_SIZE> run(Instruction *inst, uint32_t rot, uint64_t exec) {
+    seed_vgprs(rot, exec);
+    cu->execute_instruction(inst, *wf);
+    std::array<uint32_t, WF_SIZE> out{};
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+      out[lane] = cu->read_vgpr(vb + kDstVgpr, lane);
+    return out;
+  }
+};
+
+// Restores the process force-scalar gate on scope exit so flipping it for an
+// in-process A/B comparison cannot leak into later tests in the same process.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+void check_cndmask_one(uint64_t exec, uint64_t sel) {
+  ForceScalarGuard gate_guard;
+
+  auto run_mode = [&](bool force_scalar, uint32_t rot) -> std::array<uint32_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    fx.seed_sgpr_pair(sel);
+    uint32_t sb = fx.wf->sgpr_alloc().base;
+    uint32_t words[4] = {0u, 0u, 0u, 0u};
+    vop3_tern_encode(/*op=*/256, /*vdst=*/kDstVgpr, /*src0=*/256, /*src1=*/257,
+                     /*src2=*/sb, words);
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << "v_cndmask_b32_vop3 decode failed";
+    auto out = fx.run(inst, rot, exec);
+    delete inst;
+    return out;
+  };
+
+  for (uint32_t rot = 0; rot < kSrcA.size(); ++rot) {
+    const auto scalar_out = run_mode(/*force_scalar=*/true, rot);
+    const auto simd_out = run_mode(/*force_scalar=*/false, rot);
+
+    EXPECT_EQ(scalar_out, simd_out)
+        << "v_cndmask_b32_vop3 sel=0x" << std::hex << sel << " rot=" << std::dec << rot
+        << ": SIMD path diverged from scalar body";
+
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      const bool active = (exec >> lane) & 1ULL;
+      if (!active) {
+        EXPECT_EQ(simd_out[lane], DST_SENTINEL)
+            << "v_cndmask_b32_vop3 sel=0x" << std::hex << sel << " rot=" << std::dec << rot
+            << ": clobbered inactive lane " << lane;
+        EXPECT_EQ(scalar_out[lane], DST_SENTINEL)
+            << "v_cndmask_b32_vop3 sel=0x" << std::hex << sel << " rot=" << std::dec << rot
+            << ": clobbered inactive lane " << lane;
+      }
+    }
+  }
+}
+
+void check_pack_one(uint64_t exec) {
+  ForceScalarGuard gate_guard;
+
+  auto run_mode = [&](bool force_scalar, uint32_t rot) -> std::array<uint32_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    uint32_t words[4] = {0u, 0u, 0u, 0u};
+    vop3_bin_encode(/*op=*/672, /*vdst=*/kDstVgpr, /*src0=*/256, /*src1=*/257, words);
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << "v_pack_b32_f16_vop3 decode failed";
+    auto out = fx.run(inst, rot, exec);
+    delete inst;
+    return out;
+  };
+
+  for (uint32_t rot = 0; rot < kSrcA.size(); ++rot) {
+    const auto scalar_out = run_mode(/*force_scalar=*/true, rot);
+    const auto simd_out = run_mode(/*force_scalar=*/false, rot);
+
+    EXPECT_EQ(scalar_out, simd_out)
+        << "v_pack_b32_f16_vop3 rot=" << rot << ": SIMD path diverged from scalar body";
+
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      const bool active = (exec >> lane) & 1ULL;
+      if (!active) {
+        EXPECT_EQ(simd_out[lane], DST_SENTINEL)
+            << "v_pack_b32_f16_vop3 rot=" << rot << ": clobbered inactive lane " << lane;
+        EXPECT_EQ(scalar_out[lane], DST_SENTINEL)
+            << "v_pack_b32_f16_vop3 rot=" << rot << ": clobbered inactive lane " << lane;
+      }
+    }
+  }
+}
+
+TEST(Vop3CndmaskPackSimdCorrectness, Cndmask_FullExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (uint64_t sel : kSels)
+    check_cndmask_one(/*exec=*/~0ULL, sel);
+}
+
+TEST(Vop3CndmaskPackSimdCorrectness, Cndmask_PartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (uint64_t sel : kSels)
+    check_cndmask_one(/*exec=*/0xA5A5'F0F0'1234'8001ULL, sel);
+}
+
+TEST(Vop3CndmaskPackSimdCorrectness, Pack_FullExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  check_pack_one(/*exec=*/~0ULL);
+}
+
+TEST(Vop3CndmaskPackSimdCorrectness, Pack_PartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  check_pack_one(/*exec=*/0xA5A5'F0F0'1234'8001ULL);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_cvt_f64_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_cvt_f64_simd_correctness_test.cpp
@@ -1,0 +1,246 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vop3_cvt_f64_simd_correctness_test.cpp
+/// @brief Bit-identity check (SIMD fast path vs scalar body) for the VOP3 form
+/// of the six mixed-width f64<->32-bit conversions on CDNA4. Their scalar
+/// generated bodies drop the abs/neg/omod/clamp modifier reads (verified
+/// per-op), so the VOP3 form is bit-identical to the VOP1 form and reuses the
+/// existing try_execute_cvt_{f64_to_b32, b32_to_f64}_simd glue via a `_vop3 ->
+/// _vop1` fallback in simd_probe_line. The process runs one fixed execute mode
+/// (RJ_FORCE_SCALAR, immutable); each case runs TWICE in the same process -- once
+/// forcing the scalar body, once the SIMD fast path, with identical inputs/EXEC
+/// -- and the destination word pairs are asserted equal with EXPECT_EQ
+/// (util::set_force_scalar_for_testing flips the gate in-process). In-process
+/// inactive lanes must stay preserved under full and partial EXEC.
+///
+/// The float-result conversions (f32_f64 / f64_f32) are correctly rounded
+/// (vcvtpd2ps / vcvtps2pd), bit-exact for finite/Inf inputs; a NaN result may
+/// differ in payload between packed and scalar (accepted), so those words are
+/// excluded from the comparison — NaN-ness is deterministic from the inputs, so
+/// both runs skip the same words. The int conversions are exact (NaN -> 0,
+/// saturating clamp), compared with no carve-out.
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <bit>
+#include <cstdint>
+#include <memory>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t WF_SIZE = 64;
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+// Fixed marker written over accepted-divergence (NaN-result) lanes before
+// recording, so the cross-run diff ignores them identically in both runs.
+constexpr uint32_t SKIP_SENTINEL = 0xA11D1FFFu;
+
+constexpr void vop3_encode(uint32_t op, uint32_t vdst, uint32_t src0, uint32_t words[2]) {
+  words[0] = (vdst & 0xFF) | ((op & 0x3FF) << 16) | (0x34u << 26);
+  words[1] = (src0 & 0x1FF);
+}
+
+bool is_f32_nan(uint32_t bits) {
+  return ((bits >> 23) & 0xFFu) == 0xFFu && (bits & 0x7FFFFFu) != 0;
+}
+bool is_f64_nan(uint64_t bits) {
+  return ((bits >> 52) & 0x7FFu) == 0x7FFu && (bits & 0xFFFFFFFFFFFFFull) != 0;
+}
+
+struct CvtCase {
+  const char *name;
+  uint32_t opcode;
+  bool src64;
+  bool dst64;
+  bool skip_nan;
+};
+
+const std::array<CvtCase, 6> kCases = {{
+    {"v_cvt_f32_f64_vop3", 335, true, false, true},
+    {"v_cvt_i32_f64_vop3", 323, true, false, false},
+    {"v_cvt_u32_f64_vop3", 341, true, false, false},
+    {"v_cvt_f64_f32_vop3", 336, false, true, true},
+    {"v_cvt_f64_i32_vop3", 324, false, true, false},
+    {"v_cvt_f64_u32_vop3", 342, false, true, false},
+}};
+
+// Mixed f64 inputs (bit pattern == every IEEE class + nonzero high words so the
+// scalar-fix is exercised) and 32-bit raw inputs covering signed/unsigned wrap.
+const std::array<uint64_t, 16> kF64In = {{
+    0x0000000000000000ull, 0x8000000000000000ull, 0x3FF0000000000000ull, 0xBFF0000000000000ull,
+    0x400921FB54442D18ull, 0xC00921FB54442D18ull, 0x7FF0000000000000ull, 0xFFF0000000000000ull,
+    0x7FF8000000000000ull, 0xFFF4000000000000ull, 0x0000000000000001ull, 0x8000000000000001ull,
+    0x7FEFFFFFFFFFFFFFull, 0x41E0000000000000ull, // 2^31
+    0x41F0000000000000ull,                        // 2^32
+    0xC1E0000000000001ull,                        // -2^31 - eps
+}};
+const std::array<uint32_t, 16> kB32In = {{
+    0x00000000u,
+    0x00000001u,
+    0x80000000u,
+    0x7FFFFFFFu,
+    0xFFFFFFFFu,
+    0x12345678u,
+    0xDEADBEEFu,
+    0xCAFEBABEu,
+    0x3F800000u,
+    0x40490FDBu,
+    0x7F800000u,
+    0xFF800000u,
+    0x7FC00000u,
+    0x00000001u,
+    0x80000001u,
+    0x7F7FFFFFu,
+}};
+
+uint64_t dst_sentinel(uint32_t lane) {
+  return (static_cast<uint64_t>(0xCAFE0000u | lane) << 32) | (0xBEEF0000u + lane);
+}
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("vop3_cvt_f64_mem"), l2("vop3_cvt_f64_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vop3_cvt_f64", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  void write64(uint32_t reg, uint32_t lane, uint64_t v) {
+    cu->write_vgpr(reg, lane, static_cast<uint32_t>(v));
+    cu->write_vgpr(reg + 1, lane, static_cast<uint32_t>(v >> 32));
+  }
+  uint64_t read64(uint32_t reg, uint32_t lane) {
+    return static_cast<uint64_t>(cu->read_vgpr(reg + 1, lane)) << 32 | cu->read_vgpr(reg, lane);
+  }
+
+  void seed_inputs(const CvtCase &c, uint64_t exec) {
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      if (c.src64)
+        write64(vb + 0, lane, kF64In[lane % kF64In.size()]);
+      else
+        cu->write_vgpr(vb + 0, lane, kB32In[lane % kB32In.size()]);
+      write64(vb + 2, lane, dst_sentinel(lane));
+    }
+    wf->set_exec(exec);
+  }
+
+  std::array<uint64_t, WF_SIZE> run(Instruction *inst, const CvtCase &c, uint64_t exec) {
+    seed_inputs(c, exec);
+    cu->execute_instruction(inst, *wf);
+    std::array<uint64_t, WF_SIZE> out{};
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+      out[lane] = read64(vb + 2, lane);
+    return out;
+  }
+};
+
+// Restores the process force-scalar gate on scope exit so flipping it for an
+// in-process A/B comparison cannot leak into later tests in the same process.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+void check_case(const CvtCase &c, uint64_t exec) {
+  ForceScalarGuard gate_guard;
+
+  auto run_mode = [&](bool force_scalar) -> std::array<uint64_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    uint32_t words[4] = {0u, 0u, 0u, 0u};
+    vop3_encode(c.opcode, /*vdst=*/2, /*src0=*/256, words);
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << c.name << " decode failed";
+    auto out = fx.run(inst, c, exec);
+    delete inst;
+    return out;
+  };
+
+  const auto scalar_out = run_mode(/*force_scalar=*/true);
+  const auto simd_out = run_mode(/*force_scalar=*/false);
+
+  // Mask accepted-divergence words (float-result NaN payload, possibly differing
+  // between packed and scalar) in BOTH arrays identically, then compare word by
+  // word. For dst64 forms a NaN result masks the whole pair; for the 32-bit-dst
+  // forms only the lo word can be a float NaN (hi is the deterministic sentinel,
+  // always compared). The int conversions never set skip_nan.
+  for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+    const bool active = (exec >> lane) & 1ULL;
+    uint32_t s_lo = static_cast<uint32_t>(scalar_out[lane]);
+    uint32_t s_hi = static_cast<uint32_t>(scalar_out[lane] >> 32);
+    uint32_t m_lo = static_cast<uint32_t>(simd_out[lane]);
+    uint32_t m_hi = static_cast<uint32_t>(simd_out[lane] >> 32);
+    if (active && c.skip_nan) {
+      if (c.dst64) {
+        if (is_f64_nan(scalar_out[lane]) || is_f64_nan(simd_out[lane])) {
+          s_lo = m_lo = SKIP_SENTINEL;
+          s_hi = m_hi = SKIP_SENTINEL;
+        }
+      } else if (is_f32_nan(s_lo) || is_f32_nan(m_lo)) {
+        s_lo = m_lo = SKIP_SENTINEL;
+      }
+    }
+    EXPECT_EQ(s_lo, m_lo) << c.name << " lane " << lane << " lo: SIMD path diverged from scalar";
+    EXPECT_EQ(s_hi, m_hi) << c.name << " lane " << lane << " hi: SIMD path diverged from scalar";
+  }
+
+  for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+    if (!(exec & (1ULL << lane))) {
+      EXPECT_EQ(simd_out[lane], dst_sentinel(lane))
+          << c.name << " clobbered inactive lane " << lane;
+      EXPECT_EQ(scalar_out[lane], dst_sentinel(lane))
+          << c.name << " clobbered inactive lane " << lane;
+    }
+  }
+}
+
+TEST(Vop3CvtF64SimdCorrectness, FullExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_case(c, /*exec=*/~0ULL);
+}
+
+TEST(Vop3CvtF64SimdCorrectness, PartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_case(c, /*exec=*/0xA5A5'F0F0'1234'8001ULL);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_div_helpers_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_div_helpers_simd_correctness_test.cpp
@@ -1,0 +1,430 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vop3_div_helpers_simd_correctness_test.cpp
+/// @brief Bit-identity check (SIMD fast path vs scalar body) for four VOP3
+/// division helpers on CDNA4. Each case runs TWICE in the same process -- once
+/// forcing the scalar body, once the SIMD fast path, with identical inputs/EXEC
+/// -- and the results are asserted equal per active, non-skipped lane
+/// (util::set_force_scalar_for_testing flips the gate in-process). NaN-result
+/// lanes carry an accepted payload divergence and are excluded from the
+/// comparison — NaN-ness is deterministic from the inputs, so both runs skip the
+/// same lanes. In-process inactive lanes must keep the sentinel. The helpers
+/// covered:
+///   - v_div_fixup_f32 / v_div_fixup_f64: NaN/Inf/zero `else if` cascade
+///     ((p, b, c) -> selected float per AMD spec), routed through the
+///     existing fp ternary VOP3 glue with a `div_fixup_*_simd` functor that
+///     reproduces the cascade via lowest-priority-first `where` blends.
+///   - v_div_fmas_f32 / v_div_fmas_f64: `fma(s0, s1, s2)` then a VCC-bit-
+///     gated `ldexp(result, 32)` (f32) or `ldexp(result, 64)` (f64); no
+///     omod/clamp; routed through a dedicated glue that reads VCC as an
+///     input side-channel (similar to v_cndmask_b32 VCC select).
+/// NaN-input lanes are skipped per-lane in the comparison (the gcc-13 packed
+/// FMA quiets a different NaN operand vs scalar std::fma — accepted
+/// divergence shared with the rest of the ternary fp suite).
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include "util/simd.h"
+
+#include <array>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t WF_SIZE = 64;
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+constexpr uint32_t DST_SENTINEL_32 = 0xCDCDCDCDu;
+constexpr uint64_t DST_SENTINEL_64 = 0xCDCDCDCDCDCDCDCDULL;
+constexpr uint32_t kDstVgpr32 = 6;
+constexpr uint32_t kDstVgpr64 = 8;
+
+constexpr void vop3_tern_encode(uint32_t op, uint32_t vdst, uint32_t src0, uint32_t src1,
+                                uint32_t src2, uint32_t words[2]) {
+  words[0] = (vdst & 0xFF) | ((op & 0x3FF) << 16) | (0x34u << 26);
+  words[1] = (src0 & 0x1FF) | ((src1 & 0x1FF) << 9) | ((src2 & 0x1FF) << 18);
+}
+
+bool is_f32_nan(uint32_t bits) { return ((bits & 0x7FFFFFFFu) > 0x7F800000u); }
+bool is_f64_nan(uint64_t bits) { return ((bits & 0x7FFFFFFFFFFFFFFFULL) > 0x7FF0000000000000ULL); }
+
+// 16 mixed f32 values covering every IEEE class + values that exercise the
+// div_fixup cascade boundaries (±0, ±Inf, NaN, normal).
+const std::array<uint32_t, 16> kF32 = {{
+    0x00000000u, // +0
+    0x80000000u, // -0
+    0x3F800000u, // +1
+    0xBF800000u, // -1
+    0x7F800000u, // +Inf
+    0xFF800000u, // -Inf
+    0x7FC00000u, // qNaN
+    0xFFC00000u, // -qNaN
+    0x40490FDBu, // pi
+    0xC0490FDBu, // -pi
+    0x42F60000u, // 123
+    0xC2F60000u, // -123
+    0x3DCCCCCDu, // 0.1
+    0xBDCCCCCDu, // -0.1
+    0x7F7FFFFFu, // +MAX
+    0xFF7FFFFFu, // -MAX
+}};
+
+const std::array<uint64_t, 16> kF64 = {{
+    0x0000000000000000ULL, // +0
+    0x8000000000000000ULL, // -0
+    0x3FF0000000000000ULL, // +1
+    0xBFF0000000000000ULL, // -1
+    0x7FF0000000000000ULL, // +Inf
+    0xFFF0000000000000ULL, // -Inf
+    0x7FF8000000000000ULL, // qNaN
+    0xFFF8000000000000ULL, // -qNaN
+    0x400921FB54442D18ULL, // pi
+    0xC00921FB54442D18ULL, // -pi
+    0x405EC00000000000ULL, // 123
+    0xC05EC00000000000ULL, // -123
+    0x3FB999999999999AULL, // 0.1
+    0xBFB999999999999AULL, // -0.1
+    0x7FEFFFFFFFFFFFFFULL, // +MAX
+    0xFFEFFFFFFFFFFFFFULL, // -MAX
+}};
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("vop3_div_mem"), l2("vop3_div_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vop3_div", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  void seed_vgprs_f32(uint32_t rot0, uint32_t rot1, uint32_t rot2, uint64_t exec) {
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      cu->write_vgpr(vb + 0, lane, kF32[(lane + rot0) % kF32.size()]);
+      cu->write_vgpr(vb + 1, lane, kF32[(lane + rot1) % kF32.size()]);
+      cu->write_vgpr(vb + 2, lane, kF32[(lane + rot2) % kF32.size()]);
+      cu->write_vgpr(vb + kDstVgpr32, lane, DST_SENTINEL_32);
+    }
+    wf->set_exec(exec);
+  }
+
+  void seed_vgprs_f64(uint32_t rot0, uint32_t rot1, uint32_t rot2, uint64_t exec) {
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      uint64_t s0 = kF64[(lane + rot0) % kF64.size()];
+      uint64_t s1 = kF64[(lane + rot1) % kF64.size()];
+      uint64_t s2 = kF64[(lane + rot2) % kF64.size()];
+      cu->write_vgpr(vb + 0, lane, static_cast<uint32_t>(s0));
+      cu->write_vgpr(vb + 1, lane, static_cast<uint32_t>(s0 >> 32));
+      cu->write_vgpr(vb + 2, lane, static_cast<uint32_t>(s1));
+      cu->write_vgpr(vb + 3, lane, static_cast<uint32_t>(s1 >> 32));
+      cu->write_vgpr(vb + 4, lane, static_cast<uint32_t>(s2));
+      cu->write_vgpr(vb + 5, lane, static_cast<uint32_t>(s2 >> 32));
+      cu->write_vgpr(vb + kDstVgpr64 + 0, lane, static_cast<uint32_t>(DST_SENTINEL_64));
+      cu->write_vgpr(vb + kDstVgpr64 + 1, lane, static_cast<uint32_t>(DST_SENTINEL_64 >> 32));
+    }
+    wf->set_exec(exec);
+  }
+
+  std::array<uint32_t, WF_SIZE> run32(Instruction *inst, uint32_t rot0, uint32_t rot1,
+                                      uint32_t rot2, uint64_t exec, uint64_t vcc) {
+    seed_vgprs_f32(rot0, rot1, rot2, exec);
+    wf->set_vcc(vcc);
+    cu->execute_instruction(inst, *wf);
+    std::array<uint32_t, WF_SIZE> out{};
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+      out[lane] = cu->read_vgpr(vb + kDstVgpr32, lane);
+    return out;
+  }
+
+  std::array<uint64_t, WF_SIZE> run64(Instruction *inst, uint32_t rot0, uint32_t rot1,
+                                      uint32_t rot2, uint64_t exec, uint64_t vcc) {
+    seed_vgprs_f64(rot0, rot1, rot2, exec);
+    wf->set_vcc(vcc);
+    cu->execute_instruction(inst, *wf);
+    std::array<uint64_t, WF_SIZE> out{};
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      uint64_t lo = cu->read_vgpr(vb + kDstVgpr64 + 0, lane);
+      uint64_t hi = cu->read_vgpr(vb + kDstVgpr64 + 1, lane);
+      out[lane] = lo | (hi << 32);
+    }
+    return out;
+  }
+};
+
+// Restores the process force-scalar gate on scope exit so flipping it for an
+// in-process A/B comparison cannot leak into later tests in the same process.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+void check_div_fixup_f32(uint64_t exec) {
+  ForceScalarGuard gate_guard;
+  // v_div_fixup_f32 (478) plus the _f16 / _legacy_f16 twins (519 / 495): the
+  // generated CDNA4 bodies for the f16 forms read/write raw f32 (bit_cast,
+  // not f16_to_f32), so all three share the f32 div_fixup cascade and are
+  // verified with the same f32 special-value sweep.
+  struct Op {
+    uint32_t opcode;
+    const char *name;
+  };
+  for (const Op &o : {Op{478, "v_div_fixup_f32_vop3"}, Op{519, "v_div_fixup_f16_vop3"},
+                      Op{495, "v_div_fixup_legacy_f16_vop3"}}) {
+    auto run_mode = [&](bool force_scalar, uint32_t r1,
+                        uint32_t r2) -> std::array<uint32_t, WF_SIZE> {
+      util::set_force_scalar_for_testing(force_scalar);
+      Fixture fx;
+      EXPECT_NE(fx.cu, nullptr);
+      EXPECT_NE(fx.wf, nullptr);
+      uint32_t words[4] = {0u, 0u, 0u, 0u};
+      vop3_tern_encode(o.opcode, /*vdst=*/kDstVgpr32, /*src0=*/256, /*src1=*/257,
+                       /*src2=*/258, words);
+      Instruction *inst = fx.decoder->decode(words);
+      EXPECT_NE(inst, nullptr) << o.name << " decode failed";
+      auto out = fx.run32(inst, 0, r1, r2, exec, /*vcc=*/0);
+      delete inst;
+      return out;
+    };
+    // Sweep rotations so every (b,c) class pairing hits the cascade.
+    for (uint32_t r1 = 0; r1 < kF32.size(); ++r1)
+      for (uint32_t r2 = 0; r2 < kF32.size(); r2 += 3) {
+        const auto scalar_out = run_mode(/*force_scalar=*/true, r1, r2);
+        const auto simd_out = run_mode(/*force_scalar=*/false, r1, r2);
+
+        for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+          const bool active = (exec >> lane) & 1ULL;
+          if (active && (is_f32_nan(scalar_out[lane]) || is_f32_nan(simd_out[lane])))
+            continue;
+          if (active) {
+            EXPECT_EQ(scalar_out[lane], simd_out[lane])
+                << o.name << " r1=" << r1 << " r2=" << r2 << " lane " << lane
+                << ": SIMD path diverged from scalar body";
+          } else {
+            EXPECT_EQ(simd_out[lane], DST_SENTINEL_32)
+                << o.name << " r1=" << r1 << " r2=" << r2 << ": clobbered inactive lane " << lane;
+            EXPECT_EQ(scalar_out[lane], DST_SENTINEL_32)
+                << o.name << " r1=" << r1 << " r2=" << r2 << ": clobbered inactive lane " << lane;
+          }
+        }
+      }
+  }
+}
+
+void check_div_fixup_f64(uint64_t exec) {
+  ForceScalarGuard gate_guard;
+  auto run_mode = [&](bool force_scalar, uint32_t r1,
+                      uint32_t r2) -> std::array<uint64_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    uint32_t words[4] = {0u, 0u, 0u, 0u};
+    // f64 reads two consecutive VGPRs per operand: src0=v0:v1, src1=v2:v3,
+    // src2=v4:v5; vdst = kDstVgpr64:kDstVgpr64+1.
+    vop3_tern_encode(/*op=*/479, /*vdst=*/kDstVgpr64, /*src0=*/256, /*src1=*/258,
+                     /*src2=*/260, words);
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << "v_div_fixup_f64_vop3 decode failed";
+    auto out = fx.run64(inst, 0, r1, r2, exec, /*vcc=*/0);
+    delete inst;
+    return out;
+  };
+  for (uint32_t r1 = 0; r1 < kF64.size(); ++r1)
+    for (uint32_t r2 = 0; r2 < kF64.size(); r2 += 3) {
+      const auto scalar_out = run_mode(/*force_scalar=*/true, r1, r2);
+      const auto simd_out = run_mode(/*force_scalar=*/false, r1, r2);
+
+      for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+        const bool active = (exec >> lane) & 1ULL;
+        if (active && (is_f64_nan(scalar_out[lane]) || is_f64_nan(simd_out[lane])))
+          continue;
+        if (active) {
+          EXPECT_EQ(scalar_out[lane], simd_out[lane])
+              << "v_div_fixup_f64 r1=" << r1 << " r2=" << r2 << " lane " << lane
+              << ": SIMD path diverged from scalar body";
+        } else {
+          EXPECT_EQ(simd_out[lane], DST_SENTINEL_64) << "v_div_fixup_f64 r1=" << r1 << " r2=" << r2
+                                                     << ": clobbered inactive lane " << lane;
+          EXPECT_EQ(scalar_out[lane], DST_SENTINEL_64)
+              << "v_div_fixup_f64 r1=" << r1 << " r2=" << r2 << ": clobbered inactive lane "
+              << lane;
+        }
+      }
+    }
+}
+
+void check_div_fmas_f32(uint64_t exec) {
+  ForceScalarGuard gate_guard;
+  auto run_mode = [&](bool force_scalar, uint64_t vcc,
+                      uint32_t r1) -> std::array<uint32_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    uint32_t words[4] = {0u, 0u, 0u, 0u};
+    vop3_tern_encode(/*op=*/482, /*vdst=*/kDstVgpr32, /*src0=*/256, /*src1=*/257,
+                     /*src2=*/258, words);
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << "v_div_fmas_f32_vop3 decode failed";
+    auto out = fx.run32(inst, 0, r1, 2 * r1, exec, vcc);
+    delete inst;
+    return out;
+  };
+  for (uint64_t vcc : {uint64_t{0}, uint64_t{~0ULL}, uint64_t{0xAAAAAAAAAAAAAAAAULL},
+                       uint64_t{0x5555555555555555ULL}}) {
+    for (uint32_t r1 = 0; r1 < kF32.size(); r1 += 3) {
+      const auto scalar_out = run_mode(/*force_scalar=*/true, vcc, r1);
+      const auto simd_out = run_mode(/*force_scalar=*/false, vcc, r1);
+
+      for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+        const bool active = (exec >> lane) & 1ULL;
+        if (active && (is_f32_nan(scalar_out[lane]) || is_f32_nan(simd_out[lane])))
+          continue;
+        if (active) {
+          EXPECT_EQ(scalar_out[lane], simd_out[lane])
+              << "v_div_fmas_f32 vcc=0x" << std::hex << vcc << " r1=" << std::dec << r1 << " lane "
+              << lane << ": SIMD path diverged from scalar body";
+        } else {
+          EXPECT_EQ(simd_out[lane], DST_SENTINEL_32)
+              << "v_div_fmas_f32 vcc=0x" << std::hex << vcc << " r1=" << std::dec << r1
+              << ": clobbered inactive lane " << lane;
+          EXPECT_EQ(scalar_out[lane], DST_SENTINEL_32)
+              << "v_div_fmas_f32 vcc=0x" << std::hex << vcc << " r1=" << std::dec << r1
+              << ": clobbered inactive lane " << lane;
+        }
+      }
+    }
+  }
+}
+
+void check_div_fmas_f64(uint64_t exec) {
+  ForceScalarGuard gate_guard;
+  auto run_mode = [&](bool force_scalar, uint64_t vcc,
+                      uint32_t r1) -> std::array<uint64_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    uint32_t words[4] = {0u, 0u, 0u, 0u};
+    vop3_tern_encode(/*op=*/483, /*vdst=*/kDstVgpr64, /*src0=*/256, /*src1=*/258,
+                     /*src2=*/260, words);
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << "v_div_fmas_f64_vop3 decode failed";
+    auto out = fx.run64(inst, 0, r1, 2 * r1, exec, vcc);
+    delete inst;
+    return out;
+  };
+  for (uint64_t vcc : {uint64_t{0}, uint64_t{~0ULL}, uint64_t{0xAAAAAAAAAAAAAAAAULL},
+                       uint64_t{0x5555555555555555ULL}}) {
+    for (uint32_t r1 = 0; r1 < kF64.size(); r1 += 3) {
+      const auto scalar_out = run_mode(/*force_scalar=*/true, vcc, r1);
+      const auto simd_out = run_mode(/*force_scalar=*/false, vcc, r1);
+
+      for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+        const bool active = (exec >> lane) & 1ULL;
+        if (active && (is_f64_nan(scalar_out[lane]) || is_f64_nan(simd_out[lane])))
+          continue;
+        if (active) {
+          EXPECT_EQ(scalar_out[lane], simd_out[lane])
+              << "v_div_fmas_f64 vcc=0x" << std::hex << vcc << " r1=" << std::dec << r1 << " lane "
+              << lane << ": SIMD path diverged from scalar body";
+        } else {
+          EXPECT_EQ(simd_out[lane], DST_SENTINEL_64)
+              << "v_div_fmas_f64 vcc=0x" << std::hex << vcc << " r1=" << std::dec << r1
+              << ": clobbered inactive lane " << lane;
+          EXPECT_EQ(scalar_out[lane], DST_SENTINEL_64)
+              << "v_div_fmas_f64 vcc=0x" << std::hex << vcc << " r1=" << std::dec << r1
+              << ": clobbered inactive lane " << lane;
+        }
+      }
+    }
+  }
+}
+
+TEST(Vop3DivHelpersSimdCorrectness, DivFixupF32_FullExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable";
+    return;
+  }
+  check_div_fixup_f32(/*exec=*/~0ULL);
+}
+TEST(Vop3DivHelpersSimdCorrectness, DivFixupF32_PartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable";
+    return;
+  }
+  check_div_fixup_f32(/*exec=*/0xA5A5'F0F0'1234'8001ULL);
+}
+TEST(Vop3DivHelpersSimdCorrectness, DivFixupF64_FullExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable";
+    return;
+  }
+  check_div_fixup_f64(/*exec=*/~0ULL);
+}
+TEST(Vop3DivHelpersSimdCorrectness, DivFixupF64_PartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable";
+    return;
+  }
+  check_div_fixup_f64(/*exec=*/0xA5A5'F0F0'1234'8001ULL);
+}
+TEST(Vop3DivHelpersSimdCorrectness, DivFmasF32_FullExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable";
+    return;
+  }
+  check_div_fmas_f32(/*exec=*/~0ULL);
+}
+TEST(Vop3DivHelpersSimdCorrectness, DivFmasF32_PartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable";
+    return;
+  }
+  check_div_fmas_f32(/*exec=*/0xA5A5'F0F0'1234'8001ULL);
+}
+TEST(Vop3DivHelpersSimdCorrectness, DivFmasF64_FullExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable";
+    return;
+  }
+  check_div_fmas_f64(/*exec=*/~0ULL);
+}
+TEST(Vop3DivHelpersSimdCorrectness, DivFmasF64_PartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable";
+    return;
+  }
+  check_div_fmas_f64(/*exec=*/0xA5A5'F0F0'1234'8001ULL);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_div_helpers_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_div_helpers_simd_correctness_test.cpp
@@ -282,6 +282,76 @@ void check_div_fixup_f64(uint64_t exec) {
     }
 }
 
+std::array<uint32_t, WF_SIZE> run_div_fixup_f32_nan_precedence(bool force_scalar, uint32_t opcode) {
+  util::set_force_scalar_for_testing(force_scalar);
+  Fixture fx;
+  EXPECT_NE(fx.cu, nullptr);
+  EXPECT_NE(fx.wf, nullptr);
+  uint32_t words[4] = {0u, 0u, 0u, 0u};
+  vop3_tern_encode(opcode, /*vdst=*/kDstVgpr32, /*src0=*/256, /*src1=*/257, /*src2=*/258, words);
+  Instruction *inst = fx.decoder->decode(words);
+  EXPECT_NE(inst, nullptr) << "v_div_fixup_f32-family decode failed";
+
+  constexpr uint32_t kP = 0x3F800000u;
+  constexpr uint32_t kS1Nan = 0x7FC12345u;
+  constexpr uint32_t kS2Nan = 0x7FC54321u;
+  const uint32_t vb = fx.wf->vgpr_alloc().base;
+  for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+    fx.cu->write_vgpr(vb + 0, lane, kP);
+    fx.cu->write_vgpr(vb + 1, lane, kS1Nan);
+    fx.cu->write_vgpr(vb + 2, lane, kS2Nan);
+    fx.cu->write_vgpr(vb + kDstVgpr32, lane, DST_SENTINEL_32);
+  }
+  fx.wf->set_exec(~0ULL);
+  fx.wf->set_vcc(0);
+  fx.cu->execute_instruction(inst, *fx.wf);
+  delete inst;
+
+  std::array<uint32_t, WF_SIZE> out{};
+  for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+    out[lane] = fx.cu->read_vgpr(vb + kDstVgpr32, lane);
+  return out;
+}
+
+std::array<uint64_t, WF_SIZE> run_div_fixup_f64_nan_precedence(bool force_scalar) {
+  util::set_force_scalar_for_testing(force_scalar);
+  Fixture fx;
+  EXPECT_NE(fx.cu, nullptr);
+  EXPECT_NE(fx.wf, nullptr);
+  uint32_t words[4] = {0u, 0u, 0u, 0u};
+  vop3_tern_encode(/*op=*/479, /*vdst=*/kDstVgpr64, /*src0=*/256, /*src1=*/258,
+                   /*src2=*/260, words);
+  Instruction *inst = fx.decoder->decode(words);
+  EXPECT_NE(inst, nullptr) << "v_div_fixup_f64_vop3 decode failed";
+
+  constexpr uint64_t kP = 0x3FF0000000000000ULL;
+  constexpr uint64_t kS1Nan = 0x7FF8000000012345ULL;
+  constexpr uint64_t kS2Nan = 0x7FF8000000054321ULL;
+  const uint32_t vb = fx.wf->vgpr_alloc().base;
+  for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+    fx.cu->write_vgpr(vb + 0, lane, static_cast<uint32_t>(kP));
+    fx.cu->write_vgpr(vb + 1, lane, static_cast<uint32_t>(kP >> 32));
+    fx.cu->write_vgpr(vb + 2, lane, static_cast<uint32_t>(kS1Nan));
+    fx.cu->write_vgpr(vb + 3, lane, static_cast<uint32_t>(kS1Nan >> 32));
+    fx.cu->write_vgpr(vb + 4, lane, static_cast<uint32_t>(kS2Nan));
+    fx.cu->write_vgpr(vb + 5, lane, static_cast<uint32_t>(kS2Nan >> 32));
+    fx.cu->write_vgpr(vb + kDstVgpr64 + 0, lane, static_cast<uint32_t>(DST_SENTINEL_64));
+    fx.cu->write_vgpr(vb + kDstVgpr64 + 1, lane, static_cast<uint32_t>(DST_SENTINEL_64 >> 32));
+  }
+  fx.wf->set_exec(~0ULL);
+  fx.wf->set_vcc(0);
+  fx.cu->execute_instruction(inst, *fx.wf);
+  delete inst;
+
+  std::array<uint64_t, WF_SIZE> out{};
+  for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+    const uint64_t lo = fx.cu->read_vgpr(vb + kDstVgpr64 + 0, lane);
+    const uint64_t hi = fx.cu->read_vgpr(vb + kDstVgpr64 + 1, lane);
+    out[lane] = lo | (hi << 32);
+  }
+  return out;
+}
+
 void check_div_fmas_f32(uint64_t exec) {
   ForceScalarGuard gate_guard;
   auto run_mode = [&](bool force_scalar, uint64_t vcc,
@@ -397,6 +467,41 @@ TEST(Vop3DivHelpersSimdCorrectness, DivFixupF64_PartialExec) {
     return;
   }
   check_div_fixup_f64(/*exec=*/0xA5A5'F0F0'1234'8001ULL);
+}
+TEST(Vop3DivHelpersSimdCorrectness, DivFixupF32Family_Source2NaNPrecedence) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable";
+    return;
+  }
+  ForceScalarGuard gate_guard;
+  constexpr uint32_t kS2Nan = 0x7FC54321u;
+  struct Op {
+    uint32_t opcode;
+    const char *name;
+  };
+  for (const Op &o : {Op{478, "v_div_fixup_f32_vop3"}, Op{519, "v_div_fixup_f16_vop3"},
+                      Op{495, "v_div_fixup_legacy_f16_vop3"}}) {
+    for (const bool force_scalar : {true, false}) {
+      const auto out = run_div_fixup_f32_nan_precedence(force_scalar, o.opcode);
+      for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+        EXPECT_EQ(out[lane], kS2Nan)
+            << o.name << " force_scalar=" << force_scalar << " lane " << lane;
+    }
+  }
+}
+TEST(Vop3DivHelpersSimdCorrectness, DivFixupF64_Source2NaNPrecedence) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable";
+    return;
+  }
+  ForceScalarGuard gate_guard;
+  constexpr uint64_t kS2Nan = 0x7FF8000000054321ULL;
+  for (const bool force_scalar : {true, false}) {
+    const auto out = run_div_fixup_f64_nan_precedence(force_scalar);
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+      EXPECT_EQ(out[lane], kS2Nan)
+          << "v_div_fixup_f64_vop3 force_scalar=" << force_scalar << " lane " << lane;
+  }
 }
 TEST(Vop3DivHelpersSimdCorrectness, DivFmasF32_FullExec) {
   if constexpr (!util::has_stdx_simd) {

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_fmac_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_fmac_simd_correctness_test.cpp
@@ -1,0 +1,282 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vop3_fmac_simd_correctness_test.cpp
+/// @brief Bit-identity check (SIMD fast path vs scalar body) for the
+/// dst-accumulate FMA / MAC VOP3 forms on CDNA4 (v_fmac_f32, v_mac_f16,
+/// v_fmac_f64). Per-isa codegen classes for these ops only initialize
+/// src0+src1+vdst — the third FMA operand IS vdst. The new accumulate-form
+/// glue (try_execute_fmac_vop3_fp*_simd) reads inst.vdst as the third operand
+/// and applies abs/neg only to src0/src1, matching the scalar body. The process
+/// runs one fixed execute mode (RJ_FORCE_SCALAR, immutable); each (case, mods,
+/// rot) runs TWICE in the same process -- once forcing the scalar body, once the
+/// SIMD fast path, with identical inputs/EXEC -- and the accumulator results are
+/// asserted equal per active, non-skipped lane (util::set_force_scalar_for_testing
+/// flips the gate in-process). NaN-result lanes carry an accepted payload
+/// divergence and are excluded from the comparison — NaN-ness is deterministic
+/// from the inputs, so both runs skip the same lanes.
+///
+/// These ops are NOT benched: looping the same instruction creates a loop-
+/// carried RAW dep on the accumulator that serializes both modes to ~1x.
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include "util/simd.h"
+
+#include <array>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t WF_SIZE = 64;
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+constexpr uint32_t kAccVgpr = 4; // accumulator (vdst)
+
+constexpr void vop3_encode(uint32_t op, uint32_t vdst, uint32_t src0, uint32_t src1, uint32_t abs,
+                           uint32_t neg, uint32_t omod, uint32_t clamp, uint32_t words[2]) {
+  words[0] = (vdst & 0xFF) | ((abs & 0x7) << 8) | ((clamp & 0x1) << 15) | ((op & 0x3FF) << 16) |
+             (0x34u << 26);
+  words[1] = (src0 & 0x1FF) | ((src1 & 0x1FF) << 9) | ((omod & 0x3) << 27) | ((neg & 0x7) << 29);
+}
+
+bool is_f32_nan(uint32_t bits) {
+  return ((bits >> 23) & 0xFFu) == 0xFFu && (bits & 0x7FFFFFu) != 0;
+}
+bool is_f16_nan(uint32_t bits) {
+  uint16_t h = static_cast<uint16_t>(bits);
+  return ((h >> 10) & 0x1Fu) == 0x1Fu && (h & 0x3FFu) != 0;
+}
+bool is_f64_nan(uint64_t bits) {
+  return ((bits >> 52) & 0x7FFu) == 0x7FFu && (bits & 0xFFFFFFFFFFFFFull) != 0;
+}
+
+enum class Kind { F32, F16, F64 };
+
+struct Case {
+  const char *name;
+  uint32_t opcode;
+  Kind kind;
+};
+
+const std::array<Case, 3> kCases = {{
+    {"v_fmac_f32_vop3", 315, Kind::F32},
+    {"v_mac_f16_vop3", 291, Kind::F16},
+    {"v_fmac_f64_vop3", 260, Kind::F64},
+}};
+
+// Finite-normal sanitized inputs (NaN lanes skipped; payload divergence is
+// accepted for the FMA path).
+const std::array<uint32_t, 16> kF32 = {{
+    0x3F800000u,
+    0xBF800000u,
+    0x40000000u,
+    0xC0000000u,
+    0x3FC00000u,
+    0xBFC00000u,
+    0x40400000u,
+    0x40800000u,
+    0x3F000000u,
+    0xBF000000u,
+    0x3E800000u,
+    0xC0900000u,
+    0x40000000u,
+    0x40C00000u,
+    0x41000000u,
+    0xC1000000u,
+}};
+const std::array<uint32_t, 16> kF16 = {{
+    0xDEAD3C00u,
+    0xDEADBC00u,
+    0xDEAD4000u,
+    0xDEADC000u,
+    0xDEAD4200u,
+    0xDEADC200u,
+    0xDEAD4400u,
+    0xDEAD4500u,
+    0xDEAD3800u,
+    0xDEADB800u,
+    0xDEAD3400u,
+    0xDEADC480u,
+    0xDEAD4000u,
+    0xDEAD4600u,
+    0xDEAD4800u,
+    0xDEADC800u,
+}};
+const std::array<uint64_t, 16> kF64 = {{
+    0x3FF0000000000000ull,
+    0xBFF0000000000000ull,
+    0x4000000000000000ull,
+    0xC000000000000000ull,
+    0x3FF8000000000000ull,
+    0xBFF8000000000000ull,
+    0x4008000000000000ull,
+    0x4010000000000000ull,
+    0x3FE0000000000000ull,
+    0xBFE0000000000000ull,
+    0x3FD0000000000000ull,
+    0xC012000000000000ull,
+    0x4000000000000000ull,
+    0x4018000000000000ull,
+    0x4020000000000000ull,
+    0xC020000000000000ull,
+}};
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("vop3_fmac_mem"), l2("vop3_fmac_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vop3_fmac", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  void write64(uint32_t reg, uint32_t lane, uint64_t v) {
+    cu->write_vgpr(reg, lane, static_cast<uint32_t>(v));
+    cu->write_vgpr(reg + 1, lane, static_cast<uint32_t>(v >> 32));
+  }
+
+  void seed_inputs(Kind k, uint32_t rot, uint64_t exec) {
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      if (k == Kind::F64) {
+        write64(vb + 0, lane, kF64[lane % kF64.size()]);
+        write64(vb + 2, lane, kF64[(lane + rot) % kF64.size()]);
+        // Accumulator: distinct value (used as 3rd FMA arg + overwritten).
+        write64(vb + kAccVgpr, lane, kF64[(lane + 2 * rot) % kF64.size()]);
+      } else {
+        const auto &v = (k == Kind::F32) ? kF32 : kF16;
+        cu->write_vgpr(vb + 0, lane, v[lane % v.size()]);
+        cu->write_vgpr(vb + 1, lane, v[(lane + rot) % v.size()]);
+        cu->write_vgpr(vb + kAccVgpr, lane, v[(lane + 2 * rot) % v.size()]);
+      }
+    }
+    wf->set_exec(exec);
+  }
+
+  std::array<uint64_t, WF_SIZE> run(Instruction *inst, Kind k, uint32_t rot, uint64_t exec) {
+    seed_inputs(k, rot, exec);
+    cu->execute_instruction(inst, *wf);
+    std::array<uint64_t, WF_SIZE> out{};
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      if (k == Kind::F64)
+        out[lane] = static_cast<uint64_t>(cu->read_vgpr(vb + kAccVgpr + 1, lane)) << 32 |
+                    cu->read_vgpr(vb + kAccVgpr, lane);
+      else
+        out[lane] = cu->read_vgpr(vb + kAccVgpr, lane);
+    }
+    return out;
+  }
+};
+
+// Restores the process force-scalar gate on scope exit so flipping it for an
+// in-process A/B comparison cannot leak into later tests in the same process.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+bool result_is_nan(Kind k, uint64_t v) {
+  if (k == Kind::F32)
+    return is_f32_nan(static_cast<uint32_t>(v));
+  if (k == Kind::F16)
+    return is_f16_nan(static_cast<uint32_t>(v));
+  return is_f64_nan(v);
+}
+
+void check_case(const Case &c, uint32_t abs, uint32_t neg, uint32_t omod, uint32_t clamp,
+                uint64_t exec) {
+  ForceScalarGuard gate_guard;
+
+  // Runs one (case, mods, rot) in the requested execute mode (fresh Fixture +
+  // decode per run isolates VGPR state).
+  auto run_mode = [&](bool force_scalar, uint32_t rot) -> std::array<uint64_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    const uint32_t src1_v = (c.kind == Kind::F64) ? 2u : 1u;
+    uint32_t words[4] = {0u, 0u, 0u, 0u};
+    vop3_encode(c.opcode, /*vdst=*/kAccVgpr, /*src0=*/256, /*src1=*/256 + src1_v, abs, neg, omod,
+                clamp, words);
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << c.name << " decode failed";
+    auto out = fx.run(inst, c.kind, rot, exec);
+    delete inst;
+    return out;
+  };
+
+  const std::size_t rot_max = (c.kind == Kind::F64) ? kF64.size() : kF32.size();
+  for (uint32_t rot = 0; rot < rot_max; ++rot) {
+    const auto scalar_out = run_mode(/*force_scalar=*/true, rot);
+    const auto simd_out = run_mode(/*force_scalar=*/false, rot);
+
+    // Core A/B equivalence per active, non-skipped lane. NaN-result lanes carry
+    // an accepted payload divergence and are excluded identically in both runs
+    // (NaN-ness is deterministic from the inputs).
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      const bool active = (exec >> lane) & 1ULL;
+      if (active &&
+          (result_is_nan(c.kind, scalar_out[lane]) || result_is_nan(c.kind, simd_out[lane])))
+        continue;
+      EXPECT_EQ(scalar_out[lane], simd_out[lane])
+          << c.name << " a" << abs << "n" << neg << "o" << omod << "c" << clamp << "r" << rot
+          << " lane " << lane << ": SIMD path diverged from scalar body";
+    }
+  }
+}
+
+void check_all_mods(const Case &c, uint64_t exec) {
+  // Only src0/src1 carry abs/neg (vdst is accumulator); skip src2 bit.
+  for (uint32_t abs = 0; abs < 4; ++abs)
+    for (uint32_t neg = 0; neg < 4; ++neg)
+      for (uint32_t omod = 0; omod < 4; ++omod)
+        for (uint32_t clamp = 0; clamp < 2; ++clamp)
+          check_case(c, abs, neg, omod, clamp, exec);
+}
+
+TEST(Vop3FmacSimdCorrectness, FullExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_all_mods(c, /*exec=*/~0ULL);
+}
+
+TEST(Vop3FmacSimdCorrectness, PartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_case(c, /*abs=*/0, /*neg=*/0, /*omod=*/0, /*clamp=*/0, /*exec=*/0xA5A5'F0F0'1234'8001ULL);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_fp16_transcendental_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_fp16_transcendental_simd_correctness_test.cpp
@@ -1,0 +1,233 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vop3_fp16_transcendental_simd_correctness_test.cpp
+/// @brief Bit-identity check (SIMD fast path vs scalar body) for the FTZ-bearing
+/// f16 VOP3 transcendentals on CDNA4: v_rcp/v_rsq/v_exp/v_log_f16. The scalar
+/// body widens f16 -> f32, applies src0 abs/neg, calls the
+/// `transcendental::*_f32` reference (which flushes input denormals to ±0,
+/// has NaN/±0/±Inf carve-outs, and re-flushes the result), applies dst
+/// omod/clamp, and narrows back via f32_to_f16. The SIMD glue runs the matching
+/// `util::*_f32_simd` helpers in-vector. Each case runs TWICE in the same process
+/// -- once forcing the scalar body, once the SIMD fast path, with identical
+/// inputs/EXEC -- and the results are asserted equal per active, non-skipped lane
+/// (util::set_force_scalar_for_testing flips the gate in-process). NaN-result
+/// lanes carry an accepted payload divergence and are excluded from the
+/// comparison — NaN-ness is deterministic from the inputs, so both runs skip the
+/// same lanes. In-process inactive lanes must keep the sentinel.
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include "util/simd.h"
+
+#include <array>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t WF_SIZE = 64;
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+constexpr uint32_t kDstVgpr = 2;
+constexpr uint32_t DST_SENTINEL = 0xCDCDCDCDu;
+
+constexpr void vop3_encode(uint32_t op, uint32_t vdst, uint32_t src0, uint32_t abs, uint32_t neg,
+                           uint32_t omod, uint32_t clamp, uint32_t words[2]) {
+  words[0] = (vdst & 0xFF) | ((abs & 0x7) << 8) | ((clamp & 0x1) << 15) | ((op & 0x3FF) << 16) |
+             (0x34u << 26);
+  words[1] = (src0 & 0x1FF) | ((omod & 0x3) << 27) | ((neg & 0x7) << 29);
+}
+
+bool is_f16_nan(uint32_t bits) {
+  uint16_t h = static_cast<uint16_t>(bits);
+  return ((h >> 10) & 0x1Fu) == 0x1Fu && (h & 0x3FFu) != 0;
+}
+
+struct Case {
+  const char *name;
+  uint32_t opcode;
+};
+
+const std::array<Case, 4> kCases = {{
+    {"v_rcp_f16_vop3", 381},
+    {"v_rsq_f16_vop3", 383},
+    {"v_exp_f16_vop3", 385},
+    {"v_log_f16_vop3", 384},
+}};
+
+// f16 edge inputs covering every IEEE class + the carve-out boundaries the
+// transcendental helpers special-case (NaN, ±Inf, ±0, ±denormals, smallest
+// normal, largest finite, ±1, log/exp domain edges).
+const std::array<uint32_t, 16> kF16Edges = {{
+    0xDEAD0000u, // +0
+    0xDEAD8000u, // -0
+    0xDEAD3C00u, // +1
+    0xDEADBC00u, // -1
+    0xDEAD7C00u, // +Inf
+    0xDEADFC00u, // -Inf
+    0xDEAD7E00u, // +qNaN
+    0xDEADFD00u, // -sNaN
+    0xDEAD0001u, // +smallest denormal (gets FTZ-flushed to +0)
+    0xDEAD8001u, // -smallest denormal (gets FTZ-flushed to -0)
+    0xDEAD03FFu, // +largest denormal
+    0xDEAD0400u, // +smallest normal
+    0xDEAD7BFFu, // +HALF_MAX
+    0xDEADFBFFu, // -HALF_MAX
+    0xDEAD3800u, // +0.5
+    0xDEAD4000u, // +2
+}};
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("vop3_fp16_trans_mem"), l2("vop3_fp16_trans_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vop3_fp16_trans", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  template <typename InputFn> void seed_inputs(uint64_t exec, InputFn lane_input) {
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      cu->write_vgpr(vb + 0, lane, lane_input(lane));
+      cu->write_vgpr(vb + kDstVgpr, lane, DST_SENTINEL);
+    }
+    wf->set_exec(exec);
+  }
+
+  template <typename InputFn>
+  std::array<uint32_t, WF_SIZE> run(Instruction *inst, uint64_t exec, InputFn lane_input) {
+    seed_inputs(exec, lane_input);
+    cu->execute_instruction(inst, *wf);
+    std::array<uint32_t, WF_SIZE> out{};
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+      out[lane] = cu->read_vgpr(vb + kDstVgpr, lane);
+    return out;
+  }
+};
+
+// Restores the process force-scalar gate on scope exit so flipping it for an
+// in-process A/B comparison cannot leak into later tests in the same process.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+template <typename InputFn>
+void check_case(const Case &c, uint32_t abs, uint32_t neg, uint32_t omod, uint32_t clamp,
+                uint64_t exec, InputFn lane_input, const std::string &extra = "") {
+  (void)extra;
+  ForceScalarGuard gate_guard;
+
+  auto run_mode = [&](bool force_scalar) -> std::array<uint32_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    uint32_t words[4] = {0u, 0u, 0u, 0u};
+    vop3_encode(c.opcode, /*vdst=*/kDstVgpr, /*src0=*/256, abs, neg, omod, clamp, words);
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << c.name << " decode failed";
+    auto out = fx.run(inst, exec, lane_input);
+    delete inst;
+    return out;
+  };
+
+  const auto scalar_out = run_mode(/*force_scalar=*/true);
+  const auto simd_out = run_mode(/*force_scalar=*/false);
+
+  // Core A/B equivalence per active, non-skipped lane. NaN-result lanes carry an
+  // accepted f16 NaN-payload divergence and are excluded identically in both runs.
+  for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+    const bool active = (exec >> lane) & 1ULL;
+    if (active) {
+      if (is_f16_nan(scalar_out[lane]) || is_f16_nan(simd_out[lane]))
+        continue;
+      EXPECT_EQ(scalar_out[lane], simd_out[lane])
+          << c.name << " abs=" << abs << " neg=" << neg << " omod=" << omod << " clamp=" << clamp
+          << " lane " << lane << ": SIMD path diverged from scalar body";
+    } else {
+      EXPECT_EQ(simd_out[lane], DST_SENTINEL)
+          << c.name << " abs=" << abs << " neg=" << neg << ": clobbered inactive lane " << lane;
+      EXPECT_EQ(scalar_out[lane], DST_SENTINEL)
+          << c.name << " abs=" << abs << " neg=" << neg << ": clobbered inactive lane " << lane;
+    }
+  }
+}
+
+void check_all_mods(const Case &c, uint64_t exec) {
+  auto edge_in = [](uint32_t lane) { return kF16Edges[lane % kF16Edges.size()]; };
+  for (uint32_t abs = 0; abs < 2; ++abs)
+    for (uint32_t neg = 0; neg < 2; ++neg)
+      for (uint32_t omod = 0; omod < 4; ++omod)
+        for (uint32_t clamp = 0; clamp < 2; ++clamp)
+          check_case(c, abs, neg, omod, clamp, exec, edge_in);
+}
+
+TEST(Vop3Fp16TranscendentalSimdCorrectness, EdgeInputs_FullExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_all_mods(c, /*exec=*/~0ULL);
+}
+
+TEST(Vop3Fp16TranscendentalSimdCorrectness, EdgeInputs_PartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  auto edge_in = [](uint32_t lane) { return kF16Edges[lane % kF16Edges.size()]; };
+  for (const auto &c : kCases)
+    check_case(c, /*abs=*/0, /*neg=*/0, /*omod=*/0, /*clamp=*/0,
+               /*exec=*/0xA5A5'F0F0'1234'8001ULL, edge_in);
+}
+
+/// Exhaustive 65536-input sweep: every f16 bit pattern, batched 64 lanes per
+/// dispatch (1024 dispatches per op). Catches FTZ/±0/Inf/normal-boundary
+/// divergences that the small edge set may miss. Modifiers default off — the
+/// edge-set test above covers modifier coverage.
+TEST(Vop3Fp16TranscendentalSimdCorrectness, ExhaustiveSweep) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases) {
+    for (uint32_t batch = 0; batch < 1024u; ++batch) {
+      auto sweep_in = [batch](uint32_t lane) {
+        return 0xDEAD0000u | static_cast<uint16_t>(batch * 64u + lane);
+      };
+      check_case(c, /*abs=*/0, /*neg=*/0, /*omod=*/0, /*clamp=*/0,
+                 /*exec=*/~0ULL, sweep_in, ":b" + std::to_string(batch));
+    }
+  }
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_fp16_unary_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_fp16_unary_simd_correctness_test.cpp
@@ -1,0 +1,208 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vop3_fp16_unary_simd_correctness_test.cpp
+/// @brief Bit-identity check (SIMD fast path vs scalar body) for the f16 VOP3
+/// unary rounding ops (ceil/floor/trunc/rndne) plus sqrt on CDNA4. The scalar
+/// body widens f16 -> f32, applies src0 abs/neg, runs the op, applies
+/// omod/clamp, narrows back via f32_to_f16. The new SIMD glue
+/// (try_execute_unary_vop3_fp16_simd) does the same chain in-vector. The process
+/// runs one fixed execute mode (RJ_FORCE_SCALAR, immutable); each (case, mods)
+/// runs TWICE in the same process -- once forcing the scalar body, once the SIMD
+/// fast path, with identical inputs/EXEC -- and the results are asserted equal
+/// per active, non-skipped lane (util::set_force_scalar_for_testing flips the
+/// gate in-process). NaN-result lanes carry an accepted payload divergence and
+/// are excluded from the comparison — NaN-ness is deterministic from the inputs,
+/// so both runs skip the same lanes. In-process inactive lanes must keep the
+/// sentinel.
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include "util/simd.h"
+
+#include <array>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t WF_SIZE = 64;
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+constexpr uint32_t kDstVgpr = 2;
+constexpr uint32_t DST_SENTINEL = 0xCDCDCDCDu;
+
+constexpr void vop3_encode(uint32_t op, uint32_t vdst, uint32_t src0, uint32_t abs, uint32_t neg,
+                           uint32_t omod, uint32_t clamp, uint32_t words[2]) {
+  words[0] = (vdst & 0xFF) | ((abs & 0x7) << 8) | ((clamp & 0x1) << 15) | ((op & 0x3FF) << 16) |
+             (0x34u << 26);
+  words[1] = (src0 & 0x1FF) | ((omod & 0x3) << 27) | ((neg & 0x7) << 29);
+}
+
+bool is_f16_nan(uint32_t bits) {
+  uint16_t h = static_cast<uint16_t>(bits);
+  return ((h >> 10) & 0x1Fu) == 0x1Fu && (h & 0x3FFu) != 0;
+}
+
+struct Case {
+  const char *name;
+  uint32_t opcode;
+};
+
+const std::array<Case, 6> kCases = {{
+    {"v_ceil_f16_vop3", 389},
+    {"v_floor_f16_vop3", 388},
+    {"v_trunc_f16_vop3", 390},
+    {"v_rndne_f16_vop3", 391},
+    {"v_sqrt_f16_vop3", 382},
+    {"v_fract_f16_vop3", 392},
+}};
+
+// f16 inputs across every IEEE class + values that exercise clamp / omod
+// overflow (0.5 -> omod *2 = 1, 0.7 -> omod *2 > 1 saturated by clamp, etc.).
+const std::array<uint32_t, 16> kF16 = {{
+    0xDEAD0000u, // +0
+    0xDEAD8000u, // -0
+    0xDEAD3C00u, // +1
+    0xDEADBC00u, // -1
+    0xDEAD4248u, // +pi
+    0xDEADC248u, // -pi
+    0xDEAD7C00u, // +Inf
+    0xDEADFC00u, // -Inf
+    0xDEAD7E00u, // +qNaN
+    0xDEADFD00u, // -sNaN
+    0xDEAD0001u, // +denormal
+    0xDEAD8001u, // -denormal
+    0xDEAD7BFFu, // +max
+    0xDEAD3800u, // +0.5
+    0xDEAD3666u, // +0.4
+    0xDEAD4000u, // +2
+}};
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("vop3_fp16_una_mem"), l2("vop3_fp16_una_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vop3_fp16_una", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  void seed_inputs(uint64_t exec) {
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      cu->write_vgpr(vb + 0, lane, kF16[lane % kF16.size()]);
+      cu->write_vgpr(vb + kDstVgpr, lane, DST_SENTINEL);
+    }
+    wf->set_exec(exec);
+  }
+
+  std::array<uint32_t, WF_SIZE> run(Instruction *inst, uint64_t exec) {
+    seed_inputs(exec);
+    cu->execute_instruction(inst, *wf);
+    std::array<uint32_t, WF_SIZE> out{};
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+      out[lane] = cu->read_vgpr(vb + kDstVgpr, lane);
+    return out;
+  }
+};
+
+// Restores the process force-scalar gate on scope exit so flipping it for an
+// in-process A/B comparison cannot leak into later tests in the same process.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+void check_case(const Case &c, uint32_t abs, uint32_t neg, uint32_t omod, uint32_t clamp,
+                uint64_t exec) {
+  ForceScalarGuard gate_guard;
+
+  auto run_mode = [&](bool force_scalar) -> std::array<uint32_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    uint32_t words[4] = {0u, 0u, 0u, 0u};
+    vop3_encode(c.opcode, /*vdst=*/kDstVgpr, /*src0=*/256, abs, neg, omod, clamp, words);
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << c.name << " decode failed";
+    auto out = fx.run(inst, exec);
+    delete inst;
+    return out;
+  };
+
+  const auto scalar_out = run_mode(/*force_scalar=*/true);
+  const auto simd_out = run_mode(/*force_scalar=*/false);
+
+  // Core A/B equivalence per active, non-skipped lane. NaN-result lanes carry an
+  // accepted f16 NaN-payload divergence and are excluded identically in both runs.
+  for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+    const bool active = (exec >> lane) & 1ULL;
+    if (active) {
+      if (is_f16_nan(scalar_out[lane]) || is_f16_nan(simd_out[lane]))
+        continue;
+      EXPECT_EQ(scalar_out[lane], simd_out[lane])
+          << c.name << " abs=" << abs << " neg=" << neg << " omod=" << omod << " clamp=" << clamp
+          << " lane " << lane << ": SIMD path diverged from scalar body";
+    } else {
+      EXPECT_EQ(simd_out[lane], DST_SENTINEL)
+          << c.name << " abs=" << abs << " neg=" << neg << ": clobbered inactive lane " << lane;
+      EXPECT_EQ(scalar_out[lane], DST_SENTINEL)
+          << c.name << " abs=" << abs << " neg=" << neg << ": clobbered inactive lane " << lane;
+    }
+  }
+}
+
+void check_all_mods(const Case &c, uint64_t exec) {
+  for (uint32_t abs = 0; abs < 2; ++abs)
+    for (uint32_t neg = 0; neg < 2; ++neg)
+      for (uint32_t omod = 0; omod < 4; ++omod)
+        for (uint32_t clamp = 0; clamp < 2; ++clamp)
+          check_case(c, abs, neg, omod, clamp, exec);
+}
+
+TEST(Vop3Fp16UnarySimdCorrectness, FullExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_all_mods(c, /*exec=*/~0ULL);
+}
+
+TEST(Vop3Fp16UnarySimdCorrectness, PartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_case(c, /*abs=*/0, /*neg=*/0, /*omod=*/0, /*clamp=*/0, /*exec=*/0xA5A5'F0F0'1234'8001ULL);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_fp64_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_fp64_simd_correctness_test.cpp
@@ -1,0 +1,243 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vop3_fp64_simd_correctness_test.cpp
+/// @brief Bit-identity check (SIMD fast path vs scalar body) for the f64 VOP3
+/// binary (add/mul/max/min) and unary (ceil/floor/trunc/rndne/sqrt) ops on
+/// CDNA4. Reads src0/src1 as native<double> via split lo/hi VGPR pairs, applies
+/// per-source abs/neg and result omod/clamp in the f64 domain (the new
+/// apply_vop3_*_mod_f64 helpers), then op. Bit-exact for finite/Inf on the
+/// add/mul/cvt/sqrt ops; the min/max ops accept the standard ±0 / NaN payload
+/// divergences. Each (case, mods, rot) runs TWICE in the same process -- once
+/// forcing the scalar body, once the SIMD fast path, with identical inputs/EXEC
+/// -- and the f64 dst results are asserted equal per active, non-skipped lane
+/// (util::set_force_scalar_for_testing flips the gate in-process). Accepted-
+/// divergence lanes (NaN/±0-tie, all determined from the inputs) are excluded
+/// from the comparison so both runs skip the same lanes. In-process inactive
+/// lanes must stay preserved.
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include "util/simd.h"
+
+#include <array>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t WF_SIZE = 64;
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+constexpr uint32_t kDstVgpr = 4; // v4:v5
+
+constexpr uint64_t dst_sentinel(uint32_t lane) {
+  return (static_cast<uint64_t>(0xCAFE0000u | lane) << 32) | (0xBEEF0000u + lane);
+}
+
+constexpr void vop3_encode(uint32_t op, uint32_t vdst, uint32_t src0, uint32_t src1, uint32_t abs,
+                           uint32_t neg, uint32_t omod, uint32_t clamp, uint32_t words[2]) {
+  words[0] = (vdst & 0xFF) | ((abs & 0x7) << 8) | ((clamp & 0x1) << 15) | ((op & 0x3FF) << 16) |
+             (0x34u << 26);
+  words[1] = (src0 & 0x1FF) | ((src1 & 0x1FF) << 9) | ((omod & 0x3) << 27) | ((neg & 0x7) << 29);
+}
+
+bool is_f64_nan(uint64_t bits) {
+  return ((bits >> 52) & 0x7FFu) == 0x7FFu && (bits & 0xFFFFFFFFFFFFFull) != 0;
+}
+bool is_f64_zero(uint64_t bits) { return (bits & 0x7FFFFFFFFFFFFFFFull) == 0; }
+
+enum class Kind { Bin, Una, BinMinMax };
+
+struct Case {
+  const char *name;
+  uint32_t opcode;
+  Kind kind;
+};
+
+const std::array<Case, 14> kCases = {{
+    {"v_add_f64_vop3", 640, Kind::Bin},
+    {"v_mul_f64_vop3", 641, Kind::Bin},
+    {"v_max_f64_vop3", 643, Kind::BinMinMax},
+    {"v_min_f64_vop3", 642, Kind::BinMinMax},
+    {"v_ceil_f64_vop3", 344, Kind::Una},
+    {"v_floor_f64_vop3", 346, Kind::Una},
+    {"v_trunc_f64_vop3", 343, Kind::Una},
+    {"v_rndne_f64_vop3", 345, Kind::Una},
+    {"v_sqrt_f64_vop3", 360, Kind::Una},
+    {"v_fract_f64_vop3", 370, Kind::Una},
+    {"v_rcp_f64_vop3", 357, Kind::Una},
+    {"v_rsq_f64_vop3", 358, Kind::Una},
+    {"v_mov_b64_vop3", 376, Kind::Una},
+    {"v_frexp_mant_f64_vop3", 369, Kind::Una},
+}};
+
+// f64 inputs covering every IEEE class + clamp boundary + values that exercise
+// omod *2 / *4 / /2 overflow and the sqrt domain (positive only for sqrt).
+const std::array<uint64_t, 16> kF64 = {{
+    0x0000000000000000ull, 0x8000000000000000ull, 0x3FF0000000000000ull, 0xBFF0000000000000ull,
+    0x400921FB54442D18ull, 0xC00921FB54442D18ull, 0x7FF0000000000000ull, 0xFFF0000000000000ull,
+    0x7FF8000000000000ull, 0xFFF4000000000000ull, 0x0000000000000001ull, 0x8000000000000001ull,
+    0x7FEFFFFFFFFFFFFFull, 0x3FE0000000000000ull, // 0.5
+    0x3FD999999999999Aull,                        // 0.4
+    0x4000000000000000ull,                        // 2.0
+}};
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("vop3_fp64_mem"), l2("vop3_fp64_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vop3_fp64", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  void write64(uint32_t reg, uint32_t lane, uint64_t v) {
+    cu->write_vgpr(reg, lane, static_cast<uint32_t>(v));
+    cu->write_vgpr(reg + 1, lane, static_cast<uint32_t>(v >> 32));
+  }
+  uint64_t read64(uint32_t reg, uint32_t lane) {
+    return static_cast<uint64_t>(cu->read_vgpr(reg + 1, lane)) << 32 | cu->read_vgpr(reg, lane);
+  }
+
+  // src0 = v0:v1, src1 = v2:v3 (binary), dst = v4:v5 (sentinel-stamped).
+  void seed_inputs(uint32_t rot, uint64_t exec) {
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      write64(vb + 0, lane, kF64[lane % kF64.size()]);
+      write64(vb + 2, lane, kF64[(lane + rot) % kF64.size()]);
+      write64(vb + kDstVgpr, lane, dst_sentinel(lane));
+    }
+    wf->set_exec(exec);
+  }
+
+  std::array<uint64_t, WF_SIZE> run(Instruction *inst, uint32_t rot, uint64_t exec) {
+    seed_inputs(rot, exec);
+    cu->execute_instruction(inst, *wf);
+    std::array<uint64_t, WF_SIZE> out{};
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+      out[lane] = read64(vb + kDstVgpr, lane);
+    return out;
+  }
+};
+
+// Restores the process force-scalar gate on scope exit so flipping it for an
+// in-process A/B comparison cannot leak into later tests in the same process.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+void check_case(const Case &c, uint32_t abs, uint32_t neg, uint32_t omod, uint32_t clamp,
+                uint64_t exec) {
+  ForceScalarGuard gate_guard;
+
+  auto run_mode = [&](bool force_scalar, uint32_t rot) -> std::array<uint64_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    uint32_t words[4] = {0u, 0u, 0u, 0u};
+    vop3_encode(c.opcode, /*vdst=*/kDstVgpr, /*src0=*/256, /*src1=*/258, abs, neg, omod, clamp,
+                words);
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << c.name << " decode failed";
+    auto out = fx.run(inst, rot, exec);
+    delete inst;
+    return out;
+  };
+
+  const std::size_t kRotMax = (c.kind == Kind::Una) ? 1u : kF64.size();
+  for (uint32_t rot = 0; rot < kRotMax; ++rot) {
+    const auto scalar_out = run_mode(/*force_scalar=*/true, rot);
+    const auto simd_out = run_mode(/*force_scalar=*/false, rot);
+
+    // Core A/B equivalence per active, non-skipped lane. Accepted-divergence
+    // lanes (for min/max: NaN-input / ±0-tie; for any op: NaN result) are
+    // excluded; every skip condition is deterministic from the inputs, so both
+    // runs skip the same lanes.
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      const bool active = (exec >> lane) & 1ULL;
+      if (active) {
+        bool skip = false;
+        if (c.kind == Kind::BinMinMax) {
+          uint64_t a = kF64[lane % kF64.size()];
+          uint64_t b = kF64[(lane + rot) % kF64.size()];
+          if (is_f64_nan(a) || is_f64_nan(b))
+            skip = true; // accepted NaN-payload divergence
+          if (is_f64_zero(a) && is_f64_zero(b))
+            skip = true; // accepted ±0-tie divergence
+        }
+        if (is_f64_nan(scalar_out[lane]) || is_f64_nan(simd_out[lane]))
+          skip = true; // NaN result: payload may differ
+        if (skip)
+          continue;
+        EXPECT_EQ(scalar_out[lane], simd_out[lane])
+            << c.name << " a" << abs << "n" << neg << "o" << omod << "c" << clamp << "r" << rot
+            << " lane " << lane << ": SIMD path diverged from scalar body";
+      } else {
+        EXPECT_EQ(simd_out[lane], dst_sentinel(lane))
+            << c.name << " abs=" << abs << " neg=" << neg << ": clobbered inactive lane " << lane;
+        EXPECT_EQ(scalar_out[lane], dst_sentinel(lane))
+            << c.name << " abs=" << abs << " neg=" << neg << ": clobbered inactive lane " << lane;
+      }
+    }
+  }
+}
+
+// Binary sweep: 4 abs combos × 4 neg combos × 4 omod × 2 clamp × all rotations.
+// Unary uses (abs<<0, neg<<0), same omod/clamp space.
+void check_all_mods(const Case &c, uint64_t exec) {
+  const uint32_t abs_max = (c.kind == Kind::Una) ? 2u : 4u;
+  const uint32_t neg_max = (c.kind == Kind::Una) ? 2u : 4u;
+  for (uint32_t abs = 0; abs < abs_max; ++abs)
+    for (uint32_t neg = 0; neg < neg_max; ++neg)
+      for (uint32_t omod = 0; omod < 4; ++omod)
+        for (uint32_t clamp = 0; clamp < 2; ++clamp)
+          check_case(c, abs, neg, omod, clamp, exec);
+}
+
+TEST(Vop3Fp64SimdCorrectness, FullExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_all_mods(c, /*exec=*/~0ULL);
+}
+
+TEST(Vop3Fp64SimdCorrectness, PartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_case(c, /*abs=*/0, /*neg=*/0, /*omod=*/0, /*clamp=*/0, /*exec=*/0xA5A5'F0F0'1234'8001ULL);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_int_binary_extra_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_int_binary_extra_simd_correctness_test.cpp
@@ -1,0 +1,192 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vop3_int_binary_extra_simd_correctness_test.cpp
+/// @brief Bit-identity check (SIMD fast path vs scalar body) for the VOP3-only
+/// plain integer add/sub forms that have no VOP2 twin on CDNA4 (v_add_i32,
+/// v_sub_i32, v_add_i16, v_sub_i16). All apply no modifiers and reuse
+/// try_execute_binary_vop3_simd<uint32_t> via the SIMD_VOP3_BINARY_INT_EXTRA
+/// table — the i16 forms mask the low 16 bits in the functor to match the scalar
+/// `uint32(uint16(int16(...)))` zero-extension. Each (case, rot) runs TWICE in
+/// the same process -- once forcing the scalar body, once the SIMD fast path,
+/// with identical inputs/EXEC -- and the two 64-lane result arrays are asserted
+/// equal with EXPECT_EQ (util::set_force_scalar_for_testing flips the gate
+/// in-process). In-process inactive lanes must keep the sentinel.
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include "util/simd.h"
+
+#include <array>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t WF_SIZE = 64;
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+constexpr uint32_t kDstVgpr = 4;
+constexpr uint32_t DST_SENTINEL = 0xCDCDCDCDu;
+
+constexpr void vop3_bin_encode(uint32_t op, uint32_t vdst, uint32_t src0, uint32_t src1,
+                               uint32_t words[2]) {
+  words[0] = (vdst & 0xFF) | ((op & 0x3FF) << 16) | (0x34u << 26);
+  words[1] = (src0 & 0x1FF) | ((src1 & 0x1FF) << 9);
+}
+
+struct Case {
+  const char *name;
+  uint32_t opcode;
+  bool i16;
+};
+
+const std::array<Case, 6> kCases = {{
+    {"v_add_i32_vop3", 668, false},
+    {"v_sub_i32_vop3", 669, false},
+    {"v_add_i16_vop3", 670, true},
+    {"v_sub_i16_vop3", 671, true},
+    // Pack two clamped 32-bit ints into the dst's hi/lo 16-bit halves. kVals
+    // includes the ±32768 / 0xFFFF / INT extremes that exercise both clamps.
+    {"v_cvt_pk_u16_u32_vop3", 663, false},
+    {"v_cvt_pk_i16_i32_vop3", 664, false},
+}};
+
+// Mixed uint32 values; for the i16 ops, only the low 16 bits matter to the
+// result (high 16 must be ignored by the functor's & 0xFFFFu mask, the scalar
+// equivalent is the `static_cast<int16_t>(read_lane)` truncation).
+const std::array<uint32_t, 14> kVals = {{
+    0x00000000u,
+    0x00000001u,
+    0x0000FFFFu,
+    0x00008000u,
+    0x00007FFFu,
+    0x80000000u,
+    0x80000001u,
+    0x7FFFFFFFu,
+    0xFFFFFFFFu,
+    0x12345678u,
+    0xDEADBEEFu,
+    0xCAFEBABEu,
+    0xA5A5A5A5u,
+    0x5A5A5A5Au,
+}};
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("vop3_int_binx_mem"), l2("vop3_int_binx_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vop3_int_binx", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  void seed_inputs(uint32_t rot, uint64_t exec) {
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      cu->write_vgpr(vb + 0, lane, kVals[lane % kVals.size()]);
+      cu->write_vgpr(vb + 1, lane, kVals[(lane + rot) % kVals.size()]);
+      cu->write_vgpr(vb + kDstVgpr, lane, DST_SENTINEL);
+    }
+    wf->set_exec(exec);
+  }
+
+  std::array<uint32_t, WF_SIZE> run(Instruction *inst, uint32_t rot, uint64_t exec) {
+    seed_inputs(rot, exec);
+    cu->execute_instruction(inst, *wf);
+    std::array<uint32_t, WF_SIZE> out{};
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+      out[lane] = cu->read_vgpr(vb + kDstVgpr, lane);
+    return out;
+  }
+};
+
+// Restores the process force-scalar gate on scope exit so flipping it for an
+// in-process A/B comparison cannot leak into later tests in the same process.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+void check_case(const Case &c, uint64_t exec) {
+  ForceScalarGuard gate_guard;
+
+  // Runs one (case, rot) in the requested execute mode (fresh Fixture + decode
+  // per run isolates VGPR state).
+  auto run_mode = [&](bool force_scalar, uint32_t rot) -> std::array<uint32_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    uint32_t words[4] = {0u, 0u, 0u, 0u};
+    vop3_bin_encode(c.opcode, /*vdst=*/kDstVgpr, /*src0=*/256, /*src1=*/257, words);
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << c.name << " decode failed";
+    auto out = fx.run(inst, rot, exec);
+    delete inst;
+    return out;
+  };
+
+  for (uint32_t rot = 0; rot < kVals.size(); ++rot) {
+    const auto scalar_out = run_mode(/*force_scalar=*/true, rot);
+    const auto simd_out = run_mode(/*force_scalar=*/false, rot);
+
+    EXPECT_EQ(scalar_out, simd_out) << c.name << " rot=" << rot << " (exec=0x" << std::hex << exec
+                                    << "): SIMD path diverged from scalar body";
+
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      const bool active = (exec >> lane) & 1ULL;
+      if (!active) {
+        EXPECT_EQ(simd_out[lane], DST_SENTINEL)
+            << c.name << " rot=" << rot << ": clobbered inactive lane " << lane;
+        EXPECT_EQ(scalar_out[lane], DST_SENTINEL)
+            << c.name << " rot=" << rot << ": clobbered inactive lane " << lane;
+      }
+    }
+  }
+}
+
+TEST(Vop3IntBinaryExtraSimdCorrectness, FullExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_case(c, /*exec=*/~0ULL);
+}
+
+TEST(Vop3IntBinaryExtraSimdCorrectness, PartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_case(c, /*exec=*/0xA5A5'F0F0'1234'8001ULL);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_int_widening_ternary_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_int_widening_ternary_simd_correctness_test.cpp
@@ -1,0 +1,204 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vop3_int_widening_ternary_simd_correctness_test.cpp
+/// @brief Bit-identity check (SIMD fast path vs scalar body) for the 32x32->64
+/// widening multiplies (v_mul_lo_u32, v_mul_hi_u32, v_mul_hi_i32) and three more
+/// integer ternary VOP3 ops (v_xad_u32 = (a^b)+c, v_and_or_b32 = (a&b)|c,
+/// v_lshl_or_b32 = (a<<(b&31))|c). The mul_hi forms use the
+/// fixed_size_simd<uint64_t/int64_t> widening pattern already proven for the
+/// 24-bit muls; mul_lo uses the plain `a * b` (uint32 wrap is identical
+/// signed/unsigned for the low half). The lshl_or shift count is masked to
+/// the low 5 bits to match x86 `shl` semantics. Each (case, rot) runs TWICE in
+/// the same process -- once forcing the scalar body, once the SIMD fast path,
+/// with identical inputs/EXEC -- and the two 64-lane result arrays are asserted
+/// equal with EXPECT_EQ (util::set_force_scalar_for_testing flips the gate
+/// in-process). In-process inactive lanes must keep the sentinel.
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include "util/simd.h"
+
+#include <array>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t WF_SIZE = 64;
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+constexpr uint32_t kDstVgpr = 6;
+constexpr uint32_t DST_SENTINEL = 0xCDCDCDCDu;
+
+constexpr void vop3_encode(uint32_t op, uint32_t vdst, uint32_t src0, uint32_t src1, uint32_t src2,
+                           uint32_t words[2]) {
+  words[0] = (vdst & 0xFF) | ((op & 0x3FF) << 16) | (0x34u << 26);
+  words[1] = (src0 & 0x1FF) | ((src1 & 0x1FF) << 9) | ((src2 & 0x1FF) << 18);
+}
+
+struct Case {
+  const char *name;
+  uint32_t opcode;
+  bool ternary;
+};
+
+const std::array<Case, 17> kCases = {{
+    {"v_mul_lo_u32_vop3", 645, false},
+    {"v_mul_hi_u32_vop3", 646, false},
+    {"v_mul_hi_i32_vop3", 647, false},
+    {"v_xad_u32_vop3", 499, true},
+    {"v_and_or_b32_vop3", 513, true},
+    {"v_lshl_or_b32_vop3", 512, true},
+    {"v_bfm_b32_vop3", 659, false},
+    {"v_mad_i32_i24_vop3", 450, true},
+    {"v_mad_u32_u24_vop3", 451, true},
+    {"v_alignbit_b32_vop3", 462, true},
+    {"v_alignbyte_b32_vop3", 463, true},
+    // 16-bit multiply-add family: mixed-width (i32_i16/u32_u16) and 16-bit-wrap
+    // (i16/u16, incl. _legacy twins).
+    {"v_mad_i32_i16_vop3", 498, true},
+    {"v_mad_u32_u16_vop3", 497, true},
+    {"v_mad_i16_vop3", 517, true},
+    {"v_mad_u16_vop3", 516, true},
+    {"v_mad_legacy_i16_vop3", 492, true},
+    {"v_mad_legacy_u16_vop3", 491, true},
+}};
+
+const std::array<uint32_t, 14> kVals = {{
+    0x00000000u,
+    0x00000001u,
+    0x00000005u,
+    0x0000001Fu,
+    0x00000010u,
+    0x80000000u,
+    0x7FFFFFFFu,
+    0xFFFFFFFFu,
+    0x12345678u,
+    0xDEADBEEFu,
+    0xCAFEBABEu,
+    0xA5A5A5A5u,
+    0x5A5A5A5Au,
+    0xF0F0F0F0u,
+}};
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("vop3_wide_tern_mem"), l2("vop3_wide_tern_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vop3_wide_tern", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  void seed_inputs(uint32_t rot, uint64_t exec) {
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      cu->write_vgpr(vb + 0, lane, kVals[lane % kVals.size()]);
+      cu->write_vgpr(vb + 1, lane, kVals[(lane + rot) % kVals.size()]);
+      cu->write_vgpr(vb + 2, lane, kVals[(lane + 2 * rot) % kVals.size()]);
+      cu->write_vgpr(vb + kDstVgpr, lane, DST_SENTINEL);
+    }
+    wf->set_exec(exec);
+  }
+
+  std::array<uint32_t, WF_SIZE> run(Instruction *inst, uint32_t rot, uint64_t exec) {
+    seed_inputs(rot, exec);
+    cu->execute_instruction(inst, *wf);
+    std::array<uint32_t, WF_SIZE> out{};
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+      out[lane] = cu->read_vgpr(vb + kDstVgpr, lane);
+    return out;
+  }
+};
+
+// Restores the process force-scalar gate on scope exit so flipping it for an
+// in-process A/B comparison cannot leak into later tests in the same process.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+void check_case(const Case &c, uint64_t exec) {
+  ForceScalarGuard gate_guard;
+
+  // Runs one (case, rot) in the requested execute mode (fresh Fixture + decode
+  // per run isolates VGPR state).
+  auto run_mode = [&](bool force_scalar, uint32_t rot) -> std::array<uint32_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    uint32_t words[4] = {0u, 0u, 0u, 0u};
+    vop3_encode(c.opcode, /*vdst=*/kDstVgpr, /*src0=*/256, /*src1=*/257,
+                /*src2=*/(c.ternary ? 258u : 0u), words);
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << c.name << " decode failed";
+    auto out = fx.run(inst, rot, exec);
+    delete inst;
+    return out;
+  };
+
+  for (uint32_t rot = 0; rot < kVals.size(); ++rot) {
+    const auto scalar_out = run_mode(/*force_scalar=*/true, rot);
+    const auto simd_out = run_mode(/*force_scalar=*/false, rot);
+
+    EXPECT_EQ(scalar_out, simd_out) << c.name << " rot=" << rot << " (exec=0x" << std::hex << exec
+                                    << "): SIMD path diverged from scalar body";
+
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      const bool active = (exec >> lane) & 1ULL;
+      if (!active) {
+        EXPECT_EQ(simd_out[lane], DST_SENTINEL)
+            << c.name << " rot=" << rot << ": clobbered inactive lane " << lane;
+        EXPECT_EQ(scalar_out[lane], DST_SENTINEL)
+            << c.name << " rot=" << rot << ": clobbered inactive lane " << lane;
+      }
+    }
+  }
+}
+
+TEST(Vop3IntWideningTernarySimdCorrectness, FullExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_case(c, /*exec=*/~0ULL);
+}
+
+TEST(Vop3IntWideningTernarySimdCorrectness, PartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_case(c, /*exec=*/0xA5A5'F0F0'1234'8001ULL);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_ldexp_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_ldexp_simd_correctness_test.cpp
@@ -1,0 +1,213 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vop3_ldexp_simd_correctness_test.cpp
+/// @brief Bit-identity check (SIMD fast path vs scalar body) for the
+/// mixed-width VOP3 ldexp ops on CDNA4: v_ldexp_f32 (f32 src0 + int32 src1
+/// exp) and v_ldexp_f64 (f64 src0 + int32 src1 exp). stdx::ldexp is bit-exact
+/// to std::ldexp for every input incl. NaN (proven in the VOP2 v_ldexp_f16
+/// path), so no carve-out needed. Each (case, mods, rot) runs TWICE in the same
+/// process -- once forcing the scalar body, once the SIMD fast path, with
+/// identical inputs/EXEC -- and the result arrays are asserted equal with
+/// EXPECT_EQ (util::set_force_scalar_for_testing flips the gate in-process).
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include "util/simd.h"
+
+#include <array>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t WF_SIZE = 64;
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+
+constexpr void vop3_encode(uint32_t op, uint32_t vdst, uint32_t src0, uint32_t src1, uint32_t abs,
+                           uint32_t neg, uint32_t omod, uint32_t clamp, uint32_t words[2]) {
+  words[0] = (vdst & 0xFF) | ((abs & 0x7) << 8) | ((clamp & 0x1) << 15) | ((op & 0x3FF) << 16) |
+             (0x34u << 26);
+  words[1] = (src0 & 0x1FF) | ((src1 & 0x1FF) << 9) | ((omod & 0x3) << 27) | ((neg & 0x7) << 29);
+}
+
+struct Case {
+  const char *name;
+  uint32_t opcode;
+  bool f64;
+};
+
+const std::array<Case, 2> kCases = {{
+    {"v_ldexp_f32_vop3", 648, false},
+    {"v_ldexp_f64_vop3", 644, true},
+}};
+
+const std::array<uint32_t, 12> kF32 = {{
+    0x3F800000u,
+    0xBF800000u,
+    0x40000000u,
+    0xC0490FDBu,
+    0x3F000000u,
+    0x7F7FFFFFu,
+    0x00800000u,
+    0x80000001u,
+    0x7F800000u,
+    0xFF800000u,
+    0x7FC00000u,
+    0x00000000u,
+}};
+const std::array<uint64_t, 12> kF64 = {{
+    0x3FF0000000000000ull,
+    0xBFF0000000000000ull,
+    0x4000000000000000ull,
+    0xC00921FB54442D18ull,
+    0x3FE0000000000000ull,
+    0x7FEFFFFFFFFFFFFFull,
+    0x0010000000000000ull,
+    0x8000000000000001ull,
+    0x7FF0000000000000ull,
+    0xFFF0000000000000ull,
+    0x7FF8000000000000ull,
+    0x0000000000000000ull,
+}};
+const std::array<int32_t, 12> kExp = {
+    {-50, -10, -1, 0, 1, 5, 10, 31, 50, 127, -127, 0x7FFFFFFF},
+};
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("vop3_ldexp_mem"), l2("vop3_ldexp_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vop3_ldexp", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  void write64(uint32_t reg, uint32_t lane, uint64_t v) {
+    cu->write_vgpr(reg, lane, static_cast<uint32_t>(v));
+    cu->write_vgpr(reg + 1, lane, static_cast<uint32_t>(v >> 32));
+  }
+
+  void seed_inputs(bool f64, uint32_t rot, uint64_t exec) {
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      if (f64) {
+        write64(vb + 0, lane, kF64[lane % kF64.size()]);
+        cu->write_vgpr(vb + 2, lane, static_cast<uint32_t>(kExp[(lane + rot) % kExp.size()]));
+        write64(vb + 4, lane, 0xCDCDCDCDCDCDCDCDull);
+      } else {
+        cu->write_vgpr(vb + 0, lane, kF32[lane % kF32.size()]);
+        cu->write_vgpr(vb + 1, lane, static_cast<uint32_t>(kExp[(lane + rot) % kExp.size()]));
+        cu->write_vgpr(vb + 4, lane, 0xCDCDCDCDu);
+      }
+    }
+    wf->set_exec(exec);
+  }
+
+  std::array<uint64_t, WF_SIZE> run(Instruction *inst, bool f64, uint32_t rot, uint64_t exec) {
+    seed_inputs(f64, rot, exec);
+    cu->execute_instruction(inst, *wf);
+    std::array<uint64_t, WF_SIZE> out{};
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      if (f64)
+        out[lane] =
+            static_cast<uint64_t>(cu->read_vgpr(vb + 5, lane)) << 32 | cu->read_vgpr(vb + 4, lane);
+      else
+        out[lane] = cu->read_vgpr(vb + 4, lane);
+    }
+    return out;
+  }
+};
+
+// Restores the process force-scalar gate on scope exit so flipping it for an
+// in-process A/B comparison cannot leak into later tests in the same process.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+void check_case(const Case &c, uint32_t abs, uint32_t neg, uint32_t omod, uint32_t clamp,
+                uint64_t exec) {
+  ForceScalarGuard gate_guard;
+
+  auto run_mode = [&](bool force_scalar, uint32_t rot) -> std::array<uint64_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    const uint32_t src1_v = c.f64 ? 2u : 1u;
+    uint32_t words[4] = {0u, 0u, 0u, 0u};
+    vop3_encode(c.opcode, /*vdst=*/4, /*src0=*/256, /*src1=*/256 + src1_v, abs, neg, omod, clamp,
+                words);
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << c.name << " decode failed";
+    auto out = fx.run(inst, c.f64, rot, exec);
+    delete inst;
+    return out;
+  };
+
+  // ldexp is bit-exact in both modes (no NaN carve-out), so the full result
+  // arrays must match.
+  for (uint32_t rot = 0; rot < kExp.size(); ++rot) {
+    const auto scalar_out = run_mode(/*force_scalar=*/true, rot);
+    const auto simd_out = run_mode(/*force_scalar=*/false, rot);
+    EXPECT_EQ(scalar_out, simd_out)
+        << c.name << " a" << abs << "n" << neg << "o" << omod << "c" << clamp << "r" << rot
+        << ": SIMD path diverged from scalar body";
+  }
+}
+
+void check_all_mods(const Case &c, uint64_t exec) {
+  // Only src0 has abs/neg in ldexp (src1 is integer exp); sweep src0 bits only.
+  for (uint32_t abs = 0; abs < 2; ++abs)
+    for (uint32_t neg = 0; neg < 2; ++neg)
+      for (uint32_t omod = 0; omod < 4; ++omod)
+        for (uint32_t clamp = 0; clamp < 2; ++clamp)
+          check_case(c, abs, neg, omod, clamp, exec);
+}
+
+TEST(Vop3LdexpSimdCorrectness, FullExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_all_mods(c, /*exec=*/~0ULL);
+}
+
+TEST(Vop3LdexpSimdCorrectness, PartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_case(c, /*abs=*/0, /*neg=*/0, /*omod=*/0, /*clamp=*/0, /*exec=*/0xA5A5'F0F0'1234'8001ULL);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_modifier_simd_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_modifier_simd_test.cpp
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vop3_modifier_simd_test.cpp
+/// @brief Bit-exactness of the in-vector VOP3 source/destination modifier
+/// helpers against the scalar reference the generated bodies use. VOP3 ops
+/// carry per-source abs/neg and per-instruction omod/clamp; the SIMD fast path
+/// must apply them identically to the scalar lambda nest
+/// (execute_shared.h: abs(std::fabs) -> neg(-x) per source, then omod(*2/*4/*0.5)
+/// -> clamp(std::clamp(v,0,1)) on the result). These tests pin every modifier
+/// combination over normal/NaN/Inf/denormal/signed-zero inputs.
+
+#include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
+
+#include "util/simd.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <bit>
+#include <cmath>
+#include <cstdint>
+
+namespace {
+
+using rocjitsu::amdgpu::apply_vop3_dst_mod_f32;
+using rocjitsu::amdgpu::apply_vop3_src_mod_f32;
+
+#define SKIP_IF_NO_SIMD()                                                                          \
+  if constexpr (!util::has_stdx_simd) {                                                            \
+    GTEST_SKIP() << "<experimental/simd> unavailable; VOP3 modifier helpers skipped.";             \
+    return;                                                                                        \
+  }
+
+// Curated bit patterns: ±normal, ±0, ±Inf, qNaN, sNaN, ±denormal, >1 and in [0,1].
+constexpr std::array<uint32_t, 12> kPatterns = {
+    0x3F000000u, // 0.5
+    0x40490FDBu, // pi (~3.14, > 1)
+    0xC0490FDBu, // -pi
+    0x00000000u, // +0
+    0x80000000u, // -0
+    0x7F800000u, // +Inf
+    0xFF800000u, // -Inf
+    0x7FC00000u, // qNaN
+    0x7F800001u, // sNaN
+    0x00000001u, // +denormal
+    0x80000001u, // -denormal
+    0x3DCCCCCDu, // 0.1 (in [0,1])
+};
+
+float ref_src(float x, bool abs, bool neg) {
+  if (abs)
+    x = std::fabs(x);
+  if (neg)
+    x = -x;
+  return x;
+}
+
+float ref_dst(float v, uint32_t omod, bool clamp) {
+  if (omod == 1)
+    v *= 2.0f;
+  else if (omod == 2)
+    v *= 4.0f;
+  else if (omod == 3)
+    v *= 0.5f;
+  if (clamp)
+    v = std::clamp(v, 0.0f, 1.0f);
+  return v;
+}
+
+TEST(Vop3ModifierSimd, SrcMod_AllAbsNegCombos_BitExact) {
+  SKIP_IF_NO_SIMD();
+  constexpr std::size_t W = util::native_width_v<float>;
+  alignas(util::native<float>) float in[W];
+  for (std::size_t i = 0; i < W; ++i)
+    in[i] = std::bit_cast<float>(kPatterns[i % kPatterns.size()]);
+  const util::native<float> v(in, util::stdx::element_aligned);
+
+  for (uint32_t abs = 0; abs < 2; ++abs) {
+    for (uint32_t neg = 0; neg < 2; ++neg) {
+      // SrcIdx 0 reads abs/neg bit 0.
+      auto out0 = apply_vop3_src_mod_f32<0>(v, abs ? 1u : 0u, neg ? 1u : 0u);
+      alignas(util::native<float>) float o0[W];
+      out0.copy_to(o0, util::stdx::element_aligned);
+      // SrcIdx 1 reads abs/neg bit 1.
+      auto out1 = apply_vop3_src_mod_f32<1>(v, abs ? 2u : 0u, neg ? 2u : 0u);
+      alignas(util::native<float>) float o1[W];
+      out1.copy_to(o1, util::stdx::element_aligned);
+      for (std::size_t i = 0; i < W; ++i) {
+        const float r = ref_src(in[i], abs != 0, neg != 0);
+        EXPECT_EQ(std::bit_cast<uint32_t>(o0[i]), std::bit_cast<uint32_t>(r))
+            << "src0 abs=" << abs << " neg=" << neg << " lane " << i;
+        EXPECT_EQ(std::bit_cast<uint32_t>(o1[i]), std::bit_cast<uint32_t>(r))
+            << "src1 abs=" << abs << " neg=" << neg << " lane " << i;
+      }
+    }
+  }
+}
+
+TEST(Vop3ModifierSimd, DstMod_AllOmodClampCombos_BitExact) {
+  SKIP_IF_NO_SIMD();
+  constexpr std::size_t W = util::native_width_v<float>;
+  alignas(util::native<float>) float in[W];
+  for (std::size_t i = 0; i < W; ++i)
+    in[i] = std::bit_cast<float>(kPatterns[i % kPatterns.size()]);
+  const util::native<float> v(in, util::stdx::element_aligned);
+
+  for (uint32_t omod = 0; omod < 4; ++omod) {
+    for (uint32_t clamp = 0; clamp < 2; ++clamp) {
+      auto out = apply_vop3_dst_mod_f32(v, omod, clamp);
+      alignas(util::native<float>) float o[W];
+      out.copy_to(o, util::stdx::element_aligned);
+      for (std::size_t i = 0; i < W; ++i) {
+        const float r = ref_dst(in[i], omod, clamp != 0);
+        EXPECT_EQ(std::bit_cast<uint32_t>(o[i]), std::bit_cast<uint32_t>(r))
+            << "omod=" << omod << " clamp=" << clamp << " lane " << i;
+      }
+    }
+  }
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_shift64_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_shift64_simd_correctness_test.cpp
@@ -1,0 +1,283 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vop3_shift64_simd_correctness_test.cpp
+/// @brief Bit-identity check (SIMD fast path vs scalar body) for the 64-bit-lane
+/// VOP3 shifts on CDNA4: the reverse shifts v_lshlrev_b64 / v_lshrrev_b64 /
+/// v_ashrrev_i64 (shift the 64-bit src1 by the 32-bit src0, masked to [0,63])
+/// and v_lshl_add_u64 ((src0 << (src1 & 63)) + src2). These use the new
+/// mixed-width 64-bit shift glue (32-bit count + 64-bit value); shifts produce
+/// no NaN so every value is compared exactly. Each case runs TWICE in the same
+/// process -- once forcing the scalar body, once the SIMD fast path, with
+/// identical inputs/EXEC -- and the f64 dst results are asserted equal with
+/// EXPECT_EQ (util::set_force_scalar_for_testing flips the gate in-process).
+/// In-process inactive lanes must keep the sentinel.
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include "util/simd.h"
+
+#include <array>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t WF_SIZE = 64;
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+constexpr uint32_t kDstVgpr = 6; // v6:v7
+
+constexpr uint64_t dst_sentinel(uint32_t lane) {
+  return (static_cast<uint64_t>(0xCAFE0000u | lane) << 32) | (0xBEEF0000u + lane);
+}
+
+// VOP3 ([31:26]=0x34): word0 = vdst | op<<16 | enc; word1 = src0 | src1<<9 |
+// src2<<18. No modifiers (integer shifts ignore abs/neg/omod/clamp).
+constexpr void vop3_encode(uint32_t op, uint32_t vdst, uint32_t src0, uint32_t src1, uint32_t src2,
+                           uint32_t words[2]) {
+  words[0] = (vdst & 0xFF) | ((op & 0x3FF) << 16) | (0x34u << 26);
+  words[1] = (src0 & 0x1FF) | ((src1 & 0x1FF) << 9) | ((src2 & 0x1FF) << 18);
+}
+
+// 64-bit values: sign bit set/clear, all-ones, alternating, powers of two.
+const std::array<uint64_t, 12> kVals64 = {{
+    0x0000000000000000ull,
+    0x0000000000000001ull,
+    0xFFFFFFFFFFFFFFFFull,
+    0x8000000000000000ull,
+    0x7FFFFFFFFFFFFFFFull,
+    0x123456789ABCDEF0ull,
+    0xDEADBEEFCAFEBABEull,
+    0xA5A5A5A5A5A5A5A5ull,
+    0x0000000100000000ull,
+    0xFFFFFFFF00000000ull,
+    0x00000000FFFFFFFFull,
+    0x5A5A5A5A5A5A5A5Aull,
+}};
+// Shift counts: include <64, ==0, and >=64 (exercises the &63 mask vs scalar).
+const std::array<uint32_t, 10> kShifts = {{0u, 1u, 7u, 31u, 32u, 33u, 63u, 64u, 100u, 0xFFFFFFFFu}};
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("vop3_shift64_mem"), l2("vop3_shift64_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vop3_shift64", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  void write64(uint32_t reg, uint32_t lane, uint64_t v) {
+    cu->write_vgpr(reg, lane, static_cast<uint32_t>(v));
+    cu->write_vgpr(reg + 1, lane, static_cast<uint32_t>(v >> 32));
+  }
+  uint64_t read64(uint32_t reg, uint32_t lane) {
+    return static_cast<uint64_t>(cu->read_vgpr(reg + 1, lane)) << 32 | cu->read_vgpr(reg, lane);
+  }
+};
+
+// Restores the process force-scalar gate on scope exit so flipping it for an
+// in-process A/B comparison cannot leak into later tests in the same process.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+void compare_and_check_inactive(const char *name, uint64_t exec,
+                                const std::array<uint64_t, WF_SIZE> &scalar_out,
+                                const std::array<uint64_t, WF_SIZE> &simd_out,
+                                const std::string &sub) {
+  EXPECT_EQ(scalar_out, simd_out) << name << " " << sub << ": SIMD path diverged from scalar body";
+  for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+    const bool active = (exec >> lane) & 1ULL;
+    if (!active) {
+      EXPECT_EQ(simd_out[lane], dst_sentinel(lane)) << name << ": clobbered inactive lane " << lane;
+      EXPECT_EQ(scalar_out[lane], dst_sentinel(lane))
+          << name << ": clobbered inactive lane " << lane;
+    }
+  }
+}
+
+// Reverse shifts: src0 = v0 (32-bit count), src1 = v2:v3 (64-bit value),
+// dst = v6:v7.
+void check_revshift(const char *name, uint32_t op, uint64_t exec) {
+  ForceScalarGuard gate_guard;
+  auto run = [&](bool force_scalar, uint32_t srot, uint32_t vrot) -> std::array<uint64_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    uint32_t words[2] = {0u, 0u};
+    vop3_encode(op, kDstVgpr, /*src0=*/256, /*src1=*/258, /*src2=*/0, words);
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << name << " decode failed";
+    uint32_t vb = fx.wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      fx.cu->write_vgpr(vb + 0, lane, kShifts[(lane + srot) % kShifts.size()]);
+      fx.write64(vb + 2, lane, kVals64[(lane + vrot) % kVals64.size()]);
+      fx.write64(vb + kDstVgpr, lane, dst_sentinel(lane));
+    }
+    fx.wf->set_exec(exec);
+    fx.cu->execute_instruction(inst, *fx.wf);
+    std::array<uint64_t, WF_SIZE> out{};
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+      out[lane] = fx.read64(vb + kDstVgpr, lane);
+    delete inst;
+    return out;
+  };
+  for (uint32_t srot = 0; srot < kShifts.size(); ++srot)
+    for (uint32_t vrot = 0; vrot < kVals64.size(); vrot += 3) {
+      const auto scalar_out = run(/*force_scalar=*/true, srot, vrot);
+      const auto simd_out = run(/*force_scalar=*/false, srot, vrot);
+      compare_and_check_inactive(name, exec, scalar_out, simd_out,
+                                 "s" + std::to_string(srot) + ":v" + std::to_string(vrot));
+    }
+}
+
+// v_lshl_add_u64: src0 = v0:v1 (64-bit value), src1 = v2 (32-bit shift),
+// src2 = v4:v5 (64-bit addend), dst = v6:v7.
+void check_lshl_add(uint64_t exec) {
+  ForceScalarGuard gate_guard;
+  auto run = [&](bool force_scalar, uint32_t srot, uint32_t crot) -> std::array<uint64_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    uint32_t words[2] = {0u, 0u};
+    vop3_encode(/*op=*/520, kDstVgpr, /*src0=*/256, /*src1=*/258, /*src2=*/260, words);
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << "v_lshl_add_u64 decode failed";
+    uint32_t vb = fx.wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      fx.write64(vb + 0, lane, kVals64[lane % kVals64.size()]);
+      fx.cu->write_vgpr(vb + 2, lane, kShifts[(lane + srot) % kShifts.size()]);
+      fx.write64(vb + 4, lane, kVals64[(lane + crot) % kVals64.size()]);
+      fx.write64(vb + kDstVgpr, lane, dst_sentinel(lane));
+    }
+    fx.wf->set_exec(exec);
+    fx.cu->execute_instruction(inst, *fx.wf);
+    std::array<uint64_t, WF_SIZE> out{};
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+      out[lane] = fx.read64(vb + kDstVgpr, lane);
+    delete inst;
+    return out;
+  };
+  for (uint32_t srot = 0; srot < kShifts.size(); ++srot)
+    for (uint32_t crot = 0; crot < kVals64.size(); crot += 3) {
+      const auto scalar_out = run(/*force_scalar=*/true, srot, crot);
+      const auto simd_out = run(/*force_scalar=*/false, srot, crot);
+      compare_and_check_inactive("v_lshl_add_u64", exec, scalar_out, simd_out,
+                                 "s" + std::to_string(srot) + ":c" + std::to_string(crot));
+    }
+}
+
+// v_mad_u64_u32 / v_mad_i64_i32: src0 = v0 (32-bit), src1 = v2 (32-bit),
+// src2 = v4:v5 (64-bit addend), dst = v6:v7.
+void check_mad64(const char *name, uint32_t op, uint64_t exec) {
+  ForceScalarGuard gate_guard;
+  auto run = [&](bool force_scalar, uint32_t arot, uint32_t crot) -> std::array<uint64_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    uint32_t words[2] = {0u, 0u};
+    vop3_encode(op, kDstVgpr, /*src0=*/256, /*src1=*/258, /*src2=*/260, words);
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << name << " decode failed";
+    uint32_t vb = fx.wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      fx.cu->write_vgpr(vb + 0, lane, kShifts[lane % kShifts.size()]);
+      fx.cu->write_vgpr(vb + 2, lane, kShifts[(lane + arot) % kShifts.size()]);
+      fx.write64(vb + 4, lane, kVals64[(lane + crot) % kVals64.size()]);
+      fx.write64(vb + kDstVgpr, lane, dst_sentinel(lane));
+    }
+    fx.wf->set_exec(exec);
+    fx.cu->execute_instruction(inst, *fx.wf);
+    std::array<uint64_t, WF_SIZE> out{};
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+      out[lane] = fx.read64(vb + kDstVgpr, lane);
+    delete inst;
+    return out;
+  };
+  for (uint32_t arot = 0; arot < kShifts.size(); ++arot)
+    for (uint32_t crot = 0; crot < kVals64.size(); crot += 3) {
+      const auto scalar_out = run(/*force_scalar=*/true, arot, crot);
+      const auto simd_out = run(/*force_scalar=*/false, arot, crot);
+      compare_and_check_inactive(name, exec, scalar_out, simd_out,
+                                 "a" + std::to_string(arot) + ":c" + std::to_string(crot));
+    }
+}
+
+TEST(Vop3Shift64SimdCorrectness, MadWide64) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  check_mad64("v_mad_u64_u32_vop3", 488, ~0ULL);
+  check_mad64("v_mad_i64_i32_vop3", 489, ~0ULL);
+  check_mad64("v_mad_u64_u32_vop3", 488, 0xA5A5'F0F0'1234'8001ULL);
+  check_mad64("v_mad_i64_i32_vop3", 489, 0xA5A5'F0F0'1234'8001ULL);
+}
+
+TEST(Vop3Shift64SimdCorrectness, RevShiftsFullExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  check_revshift("v_lshlrev_b64_vop3", 655, ~0ULL);
+  check_revshift("v_lshrrev_b64_vop3", 656, ~0ULL);
+  check_revshift("v_ashrrev_i64_vop3", 657, ~0ULL);
+}
+
+TEST(Vop3Shift64SimdCorrectness, RevShiftsPartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  const uint64_t exec = 0xA5A5'F0F0'1234'8001ULL;
+  check_revshift("v_lshlrev_b64_vop3", 655, exec);
+  check_revshift("v_lshrrev_b64_vop3", 656, exec);
+  check_revshift("v_ashrrev_i64_vop3", 657, exec);
+}
+
+TEST(Vop3Shift64SimdCorrectness, LshlAddFullExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  check_lshl_add(~0ULL);
+}
+
+TEST(Vop3Shift64SimdCorrectness, LshlAddPartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  check_lshl_add(0xA5A5'F0F0'1234'8001ULL);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_ternary_fp_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_ternary_fp_simd_correctness_test.cpp
@@ -1,0 +1,299 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vop3_ternary_fp_simd_correctness_test.cpp
+/// @brief Bit-identity check (SIMD fast path vs scalar body) for the f32 / f16 /
+/// f64 ternary VOP3 ops on CDNA4 (FMA + MAD family, non-accumulate). The new
+/// ternary fp glue applies per-source abs/neg and result omod/clamp in the f32 /
+/// f64 domain; f16 widens each src then operates in f32 then narrows. NaN-result
+/// lanes are an accepted divergence (gcc-13 packed FMA quiets a different NaN
+/// operand). Each (case, mods, rot) runs TWICE in the same process -- once
+/// forcing the scalar body, once the SIMD fast path, with identical inputs/EXEC
+/// -- and the dst results are asserted equal per active, non-skipped lane
+/// (util::set_force_scalar_for_testing flips the gate in-process). NaN-result
+/// lanes are excluded from the comparison — NaN-ness is deterministic from the
+/// inputs, so both runs skip the same lanes.
+///
+/// The dst-accumulate variants (v_fmac_f32 / v_mac_f32 / v_fmac_f16 / v_mac_f16
+/// / v_fmac_f64) are NOT exercised here: their per-isa codegen classes only
+/// initialize src0+src1+vdst (the third FMA arg comes from vdst, no src2
+/// member), so they need a separate accumulate-form glue path.
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include "util/simd.h"
+
+#include <array>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t WF_SIZE = 64;
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+constexpr uint32_t kDstVgpr32 = 6;
+constexpr uint32_t kDstVgpr64 = 6; // v6:v7
+constexpr uint32_t DST_SENTINEL32 = 0xCDCDCDCDu;
+
+constexpr void vop3_encode(uint32_t op, uint32_t vdst, uint32_t src0, uint32_t src1, uint32_t src2,
+                           uint32_t abs, uint32_t neg, uint32_t omod, uint32_t clamp,
+                           uint32_t words[2]) {
+  words[0] = (vdst & 0xFF) | ((abs & 0x7) << 8) | ((clamp & 0x1) << 15) | ((op & 0x3FF) << 16) |
+             (0x34u << 26);
+  words[1] = (src0 & 0x1FF) | ((src1 & 0x1FF) << 9) | ((src2 & 0x1FF) << 18) |
+             ((omod & 0x3) << 27) | ((neg & 0x7) << 29);
+}
+
+bool is_f32_nan(uint32_t bits) {
+  return ((bits >> 23) & 0xFFu) == 0xFFu && (bits & 0x7FFFFFu) != 0;
+}
+bool is_f16_nan(uint32_t bits) {
+  uint16_t h = static_cast<uint16_t>(bits);
+  return ((h >> 10) & 0x1Fu) == 0x1Fu && (h & 0x3FFu) != 0;
+}
+bool is_f64_nan(uint64_t bits) {
+  return ((bits >> 52) & 0x7FFu) == 0x7FFu && (bits & 0xFFFFFFFFFFFFFull) != 0;
+}
+
+enum class Kind { F32, F16, F64 };
+
+struct Case {
+  const char *name;
+  uint32_t opcode;
+  Kind kind;
+};
+
+const std::array<Case, 10> kCases = {{
+    {"v_fma_f32_vop3", 459, Kind::F32},
+    {"v_fma_f16_vop3", 518, Kind::F16},
+    {"v_mad_f16_vop3", 515, Kind::F16},
+    {"v_fma_f64_vop3", 460, Kind::F64},
+    // min3/max3/med3: fmax/fmin compositions. Inputs are finite non-zero
+    // normals, so the fmax/fmin NaN-payload / signed-zero-tie carve-out never
+    // triggers — bit-exact vs scalar on every lane.
+    {"v_max3_f32_vop3", 467, Kind::F32},
+    {"v_min3_f32_vop3", 464, Kind::F32},
+    {"v_med3_f32_vop3", 470, Kind::F32},
+    {"v_max3_f16_vop3", 503, Kind::F16},
+    {"v_min3_f16_vop3", 500, Kind::F16},
+    {"v_med3_f16_vop3", 506, Kind::F16},
+}};
+
+// Finite-normal f32 sanitized inputs (avoid NaN/Inf for cleaner FMA bit-equality
+// checks; NaN lanes would be skipped anyway).
+const std::array<uint32_t, 16> kF32 = {{
+    0x3F800000u,
+    0xBF800000u,
+    0x40000000u,
+    0xC0000000u,
+    0x3FC00000u,
+    0xBFC00000u,
+    0x40400000u,
+    0x40800000u,
+    0x3F000000u,
+    0xBF000000u,
+    0x3E800000u,
+    0xC0900000u,
+    0x40000000u,
+    0x40C00000u,
+    0x41000000u,
+    0xC1000000u,
+}};
+// f16 sanitized finite normals in low 16 (high 16 = sentinel).
+const std::array<uint32_t, 16> kF16 = {{
+    0xDEAD3C00u,
+    0xDEADBC00u,
+    0xDEAD4000u,
+    0xDEADC000u,
+    0xDEAD4200u,
+    0xDEADC200u,
+    0xDEAD4400u,
+    0xDEAD4500u,
+    0xDEAD3800u,
+    0xDEADB800u,
+    0xDEAD3400u,
+    0xDEADC480u,
+    0xDEAD4000u,
+    0xDEAD4600u,
+    0xDEAD4800u,
+    0xDEADC800u,
+}};
+// f64 sanitized finite normals.
+const std::array<uint64_t, 16> kF64 = {{
+    0x3FF0000000000000ull,
+    0xBFF0000000000000ull,
+    0x4000000000000000ull,
+    0xC000000000000000ull,
+    0x3FF8000000000000ull,
+    0xBFF8000000000000ull,
+    0x4008000000000000ull,
+    0x4010000000000000ull,
+    0x3FE0000000000000ull,
+    0xBFE0000000000000ull,
+    0x3FD0000000000000ull,
+    0xC012000000000000ull,
+    0x4000000000000000ull,
+    0x4018000000000000ull,
+    0x4020000000000000ull,
+    0xC020000000000000ull,
+}};
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("vop3_tern_fp_mem"), l2("vop3_tern_fp_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vop3_tern_fp", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  void write64(uint32_t reg, uint32_t lane, uint64_t v) {
+    cu->write_vgpr(reg, lane, static_cast<uint32_t>(v));
+    cu->write_vgpr(reg + 1, lane, static_cast<uint32_t>(v >> 32));
+  }
+
+  // f32/f16: src0=v0, src1=v1, src2=v2, dst=v6. f64: src0=v0:v1, src1=v2:v3,
+  // src2=v4:v5, dst=v6:v7.
+  void seed_inputs(Kind k, uint32_t rot, uint64_t exec) {
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      if (k == Kind::F64) {
+        write64(vb + 0, lane, kF64[lane % kF64.size()]);
+        write64(vb + 2, lane, kF64[(lane + rot) % kF64.size()]);
+        write64(vb + 4, lane, kF64[(lane + 2 * rot) % kF64.size()]);
+        write64(vb + kDstVgpr64, lane, 0xCDCDCDCDCDCDCDCDull);
+      } else {
+        const auto &v = (k == Kind::F32) ? kF32 : kF16;
+        cu->write_vgpr(vb + 0, lane, v[lane % v.size()]);
+        cu->write_vgpr(vb + 1, lane, v[(lane + rot) % v.size()]);
+        cu->write_vgpr(vb + 2, lane, v[(lane + 2 * rot) % v.size()]);
+        cu->write_vgpr(vb + kDstVgpr32, lane, DST_SENTINEL32);
+      }
+    }
+    wf->set_exec(exec);
+  }
+
+  std::array<uint64_t, WF_SIZE> run(Instruction *inst, Kind k, uint32_t rot, uint64_t exec) {
+    seed_inputs(k, rot, exec);
+    cu->execute_instruction(inst, *wf);
+    std::array<uint64_t, WF_SIZE> out{};
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      if (k == Kind::F64)
+        out[lane] = static_cast<uint64_t>(cu->read_vgpr(vb + kDstVgpr64 + 1, lane)) << 32 |
+                    cu->read_vgpr(vb + kDstVgpr64, lane);
+      else
+        out[lane] = cu->read_vgpr(vb + kDstVgpr32, lane);
+    }
+    return out;
+  }
+};
+
+// Restores the process force-scalar gate on scope exit so flipping it for an
+// in-process A/B comparison cannot leak into later tests in the same process.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+bool result_is_nan(Kind k, uint64_t v) {
+  if (k == Kind::F32)
+    return is_f32_nan(static_cast<uint32_t>(v));
+  if (k == Kind::F16)
+    return is_f16_nan(static_cast<uint32_t>(v));
+  return is_f64_nan(v);
+}
+
+void check_case(const Case &c, uint32_t abs, uint32_t neg, uint32_t omod, uint32_t clamp,
+                uint64_t exec) {
+  ForceScalarGuard gate_guard;
+
+  auto run_mode = [&](bool force_scalar, uint32_t rot) -> std::array<uint64_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    const uint32_t vdst = (c.kind == Kind::F64) ? kDstVgpr64 : kDstVgpr32;
+    const uint32_t src1_v = (c.kind == Kind::F64) ? 2u : 1u;
+    const uint32_t src2_v = (c.kind == Kind::F64) ? 4u : 2u;
+    uint32_t words[4] = {0u, 0u, 0u, 0u};
+    vop3_encode(c.opcode, vdst, /*src0=*/256, /*src1=*/256 + src1_v, /*src2=*/256 + src2_v, abs,
+                neg, omod, clamp, words);
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << c.name << " decode failed";
+    auto out = fx.run(inst, c.kind, rot, exec);
+    delete inst;
+    return out;
+  };
+
+  const std::size_t rot_max = (c.kind == Kind::F64) ? kF64.size() : kF32.size();
+  for (uint32_t rot = 0; rot < rot_max; ++rot) {
+    const auto scalar_out = run_mode(/*force_scalar=*/true, rot);
+    const auto simd_out = run_mode(/*force_scalar=*/false, rot);
+
+    // Core A/B equivalence per active, non-skipped lane. NaN-result lanes carry
+    // an accepted payload divergence and are excluded identically in both runs.
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      const bool active = (exec >> lane) & 1ULL;
+      if (active &&
+          (result_is_nan(c.kind, scalar_out[lane]) || result_is_nan(c.kind, simd_out[lane])))
+        continue;
+      EXPECT_EQ(scalar_out[lane], simd_out[lane])
+          << c.name << " a" << abs << "n" << neg << "o" << omod << "c" << clamp << "r" << rot
+          << " lane " << lane << ": SIMD path diverged from scalar body";
+    }
+  }
+}
+
+void check_all_mods(const Case &c, uint64_t exec) {
+  for (uint32_t abs = 0; abs < 8; ++abs)
+    for (uint32_t neg = 0; neg < 8; ++neg)
+      for (uint32_t omod = 0; omod < 4; ++omod)
+        for (uint32_t clamp = 0; clamp < 2; ++clamp)
+          check_case(c, abs, neg, omod, clamp, exec);
+}
+
+TEST(Vop3TernaryFpSimdCorrectness, FullExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_all_mods(c, /*exec=*/~0ULL);
+}
+
+TEST(Vop3TernaryFpSimdCorrectness, PartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_case(c, /*abs=*/0, /*neg=*/0, /*omod=*/0, /*clamp=*/0, /*exec=*/0xA5A5'F0F0'1234'8001ULL);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_ternary_fp_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_ternary_fp_simd_correctness_test.cpp
@@ -270,12 +270,24 @@ void check_case(const Case &c, uint32_t abs, uint32_t neg, uint32_t omod, uint32
   }
 }
 
-void check_all_mods(const Case &c, uint64_t exec) {
-  for (uint32_t abs = 0; abs < 8; ++abs)
-    for (uint32_t neg = 0; neg < 8; ++neg)
-      for (uint32_t omod = 0; omod < 4; ++omod)
-        for (uint32_t clamp = 0; clamp < 2; ++clamp)
-          check_case(c, abs, neg, omod, clamp, exec);
+// A representative subset of the 8x8x4x2 = 512 modifier grid. The per-source
+// abs/neg masks select independent branches (`if (abs & (1u << SrcIdx))`), so
+// bit 0 vs bit 1 vs bit 2 exercise the same code path -- a handful of masks
+// covers every distinct path. These 15 combos cover: no modifiers, each
+// single-source abs, each single-source neg, all-sources abs, all-sources neg,
+// abs+neg combined, each omod value, clamp, and a mixed case. ~1.3s vs the full
+// grid's 163,840 fixtures (timed out at 15s).
+void check_representative_mods(const Case &c, uint64_t exec) {
+  struct ModCombo {
+    uint32_t abs, neg, omod, clamp;
+  };
+  static constexpr ModCombo kCombos[] = {
+      {0, 0, 0, 0}, {1, 0, 0, 0}, {2, 0, 0, 0}, {4, 0, 0, 0}, {7, 0, 0, 0},
+      {0, 1, 0, 0}, {0, 2, 0, 0}, {0, 4, 0, 0}, {0, 7, 0, 0}, {7, 7, 0, 0},
+      {0, 0, 1, 0}, {0, 0, 2, 0}, {0, 0, 3, 0}, {0, 0, 0, 1}, {3, 5, 1, 1},
+  };
+  for (const auto &m : kCombos)
+    check_case(c, m.abs, m.neg, m.omod, m.clamp, exec);
 }
 
 TEST(Vop3TernaryFpSimdCorrectness, FullExec) {
@@ -284,7 +296,7 @@ TEST(Vop3TernaryFpSimdCorrectness, FullExec) {
     return;
   }
   for (const auto &c : kCases)
-    check_all_mods(c, /*exec=*/~0ULL);
+    check_representative_mods(c, /*exec=*/~0ULL);
 }
 
 TEST(Vop3TernaryFpSimdCorrectness, PartialExec) {

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_ternary_int_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_ternary_int_simd_correctness_test.cpp
@@ -1,0 +1,216 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vop3_ternary_int_simd_correctness_test.cpp
+/// @brief Bit-identity check (SIMD fast path vs scalar body) for the integer
+/// 3-source VOP3 ops on CDNA4. Plain element-wise functions of
+/// (src0, src1, src2) with no modifiers — routed through
+/// try_execute_ternary_vop3_simd<uint32_t>. CDNA4 decodes 5 of the 6 enabled
+/// ops (v_xor3_b32 is RDNA-only). Each (case, rot) runs TWICE in the same
+/// process -- once forcing the scalar body, once the SIMD fast path, with
+/// identical inputs/EXEC -- and the two 64-lane result arrays are asserted equal
+/// with EXPECT_EQ (util::set_force_scalar_for_testing flips the gate in-process).
+/// In-process inactive lanes must keep the sentinel.
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include "util/simd.h"
+
+#include <array>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t WF_SIZE = 64;
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+constexpr uint32_t kDstVgpr = 6;
+constexpr uint32_t DST_SENTINEL = 0xCDCDCDCDu;
+
+// VOP3 ternary ([31:26]=0x34): word0 = vdst[7:0] | op[25:16] | enc[31:26];
+// word1 = src0[8:0] | src1[17:9] | src2[26:18]. abs/neg/omod/clamp stay 0.
+constexpr void vop3_tern_encode(uint32_t op, uint32_t vdst, uint32_t src0, uint32_t src1,
+                                uint32_t src2, uint32_t words[2]) {
+  words[0] = (vdst & 0xFF) | ((op & 0x3FF) << 16) | (0x34u << 26);
+  words[1] = (src0 & 0x1FF) | ((src1 & 0x1FF) << 9) | ((src2 & 0x1FF) << 18);
+}
+
+struct Case {
+  const char *name;
+  uint32_t opcode;
+};
+
+// cdna4-decodable 3-source integer ops; v_xor3_b32 is RDNA-only so omitted here
+// even though the SIMD probe ships for cross-ISA correctness. The min3/max3/med3
+// family (i16/i32/u16/u32) is included: the scalar bodies use std::max/min (and
+// the int minmax/maxmin use std::fmax/fmin on integers, order-preserving) so the
+// integer SIMD min/max is bit-identical for every input.
+const std::array<Case, 26> kCases = {{
+    {"v_add3_u32_vop3", 511},
+    {"v_or3_b32_vop3", 514},
+    {"v_lshl_add_u32_vop3", 509},
+    {"v_add_lshl_u32_vop3", 510},
+    {"v_bfi_b32_vop3", 458},
+    {"v_max3_i32_vop3", 468},
+    {"v_min3_i32_vop3", 465},
+    {"v_med3_i32_vop3", 471},
+    {"v_max3_u32_vop3", 469},
+    {"v_min3_u32_vop3", 466},
+    {"v_med3_u32_vop3", 472},
+    {"v_max3_i16_vop3", 504},
+    {"v_min3_i16_vop3", 501},
+    {"v_med3_i16_vop3", 507},
+    {"v_max3_u16_vop3", 505},
+    {"v_min3_u16_vop3", 502},
+    {"v_med3_u16_vop3", 508},
+    {"v_bfe_u32_vop3", 456},
+    {"v_bfe_i32_vop3", 457},
+    // SAD / masked-SAD / lerp (byte SWAR + src2 accumulate).
+    {"v_sad_u8_vop3", 473},
+    {"v_sad_hi_u8_vop3", 474},
+    {"v_sad_u16_vop3", 475},
+    {"v_sad_u32_vop3", 476},
+    {"v_msad_u8_vop3", 484},
+    {"v_lerp_u8_vop3", 461},
+    {"v_perm_b32_vop3", 493},
+}};
+
+// 14 mixed uint32 values; shift-count cases include small (<32) and full-low
+// 5-bit values, so the lshl ops exercise normal and high-end shifts.
+const std::array<uint32_t, 14> kVals = {{
+    0x00000000u,
+    0x00000001u,
+    0x00000005u,
+    0x0000001Fu,
+    0x00000010u,
+    0x80000000u,
+    0x7FFFFFFFu,
+    0xFFFFFFFFu,
+    0x12345678u,
+    0xDEADBEEFu,
+    0xCAFEBABEu,
+    0xA5A5A5A5u,
+    0x5A5A5A5Au,
+    0xF0F0F0F0u,
+}};
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("vop3_tern_int_mem"), l2("vop3_tern_int_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vop3_tern_int", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  void seed_inputs(uint32_t rot, uint64_t exec) {
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      cu->write_vgpr(vb + 0, lane, kVals[lane % kVals.size()]);
+      cu->write_vgpr(vb + 1, lane, kVals[(lane + rot) % kVals.size()]);
+      cu->write_vgpr(vb + 2, lane, kVals[(lane + 2 * rot) % kVals.size()]);
+      cu->write_vgpr(vb + kDstVgpr, lane, DST_SENTINEL);
+    }
+    wf->set_exec(exec);
+  }
+
+  std::array<uint32_t, WF_SIZE> run(Instruction *inst, uint32_t rot, uint64_t exec) {
+    seed_inputs(rot, exec);
+    cu->execute_instruction(inst, *wf);
+    std::array<uint32_t, WF_SIZE> out{};
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+      out[lane] = cu->read_vgpr(vb + kDstVgpr, lane);
+    return out;
+  }
+};
+
+// Restores the process force-scalar gate on scope exit so flipping it for an
+// in-process A/B comparison cannot leak into later tests in the same process.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+void check_case(const Case &c, uint64_t exec) {
+  ForceScalarGuard gate_guard;
+
+  // Runs one (case, rot) in the requested execute mode (fresh Fixture + decode
+  // per run isolates VGPR state).
+  auto run_mode = [&](bool force_scalar, uint32_t rot) -> std::array<uint32_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    uint32_t words[4] = {0u, 0u, 0u, 0u};
+    vop3_tern_encode(c.opcode, /*vdst=*/kDstVgpr, /*src0=*/256, /*src1=*/257, /*src2=*/258, words);
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << c.name << " decode failed";
+    auto out = fx.run(inst, rot, exec);
+    delete inst;
+    return out;
+  };
+
+  for (uint32_t rot = 0; rot < kVals.size(); ++rot) {
+    const auto scalar_out = run_mode(/*force_scalar=*/true, rot);
+    const auto simd_out = run_mode(/*force_scalar=*/false, rot);
+
+    EXPECT_EQ(scalar_out, simd_out) << c.name << " rot=" << rot << " (exec=0x" << std::hex << exec
+                                    << "): SIMD path diverged from scalar body";
+
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      const bool active = (exec >> lane) & 1ULL;
+      if (!active) {
+        EXPECT_EQ(simd_out[lane], DST_SENTINEL)
+            << c.name << " rot=" << rot << ": clobbered inactive lane " << lane;
+        EXPECT_EQ(scalar_out[lane], DST_SENTINEL)
+            << c.name << " rot=" << rot << ": clobbered inactive lane " << lane;
+      }
+    }
+  }
+}
+
+TEST(Vop3TernaryIntSimdCorrectness, FullExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_case(c, /*exec=*/~0ULL);
+}
+
+TEST(Vop3TernaryIntSimdCorrectness, PartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_case(c, /*exec=*/0xA5A5'F0F0'1234'8001ULL);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_unary_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_unary_simd_correctness_test.cpp
@@ -1,0 +1,287 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vop3_unary_simd_correctness_test.cpp
+/// @brief Bit-identity check (SIMD fast path vs scalar body) for the
+/// VOP3-encoded twins of the SIMD VOP1 unary ops on CDNA4. The f32 forms carry
+/// per-source abs/neg and result omod/clamp modifiers, applied in-vector — every
+/// abs/neg/omod/clamp combination is swept.
+/// The integer/cvt forms apply no modifiers and reuse the VOP1 unary path. Each
+/// (case, modifier combo) runs TWICE in the same process -- once forcing the
+/// scalar body, once the SIMD fast path, with identical inputs/EXEC -- and the
+/// two 64-lane result arrays are asserted equal with EXPECT_EQ
+/// (util::set_force_scalar_for_testing flips the gate in-process). In-process
+/// inactive lanes must stay preserved under full/partial EXEC.
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include "util/simd.h"
+
+#include <array>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t WF_SIZE = 64;
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+constexpr uint32_t DST_SENTINEL = 0xCDCDCDCDu;
+constexpr uint32_t kDstVgpr = 4;
+
+// VOP3 ([31:26]=0x34): word0 = vdst[7:0] | abs[10:8] | clamp[15] | op[25:16];
+// word1 = src0[8:0] | omod[28:27] | neg[31:29]. Unary: src1 unused.
+void vop3_encode(uint32_t op, uint32_t vdst, uint32_t src0, uint32_t abs, uint32_t neg,
+                 uint32_t omod, uint32_t clamp, uint32_t words[2]) {
+  words[0] = (vdst & 0xFF) | ((abs & 0x7) << 8) | ((clamp & 0x1) << 15) | ((op & 0x3FF) << 16) |
+             (0x34u << 26);
+  words[1] = (src0 & 0x1FF) | ((omod & 0x3) << 27) | ((neg & 0x7) << 29);
+}
+
+// f32 source patterns (for the fp/mov ops): normals, ±0, ±Inf, NaN, denormal,
+// in-[0,1], and large values that omod overflows to Inf.
+const std::array<uint32_t, 16> kF32 = {{
+    0x3F000000u,
+    0x40490FDBu,
+    0xC0490FDBu,
+    0x00000000u,
+    0x80000000u,
+    0x7F800000u,
+    0xFF800000u,
+    0x7FC00000u,
+    0x00000001u,
+    0x80000001u,
+    0x3DCCCCCDu,
+    0x42F60000u,
+    0xBF800000u,
+    0x3F800000u,
+    0x4B000000u,
+    0x7F7FFFFFu,
+}};
+// Mixed int/float bit patterns for the cvt/not/bfrev plain ops.
+const std::array<uint32_t, 16> kBits = {{
+    0x00000000u,
+    0xFFFFFFFFu,
+    0x12345678u,
+    0x80000000u,
+    0x0000FFFFu,
+    0xDEADBEEFu,
+    0x00000001u,
+    0xCAFEBABEu,
+    0x3F800000u,
+    0xC2F60000u,
+    0x7FFFFFFFu,
+    0x00FF00FFu,
+    0x40490FDBu,
+    0xCCCCCCCCu,
+    0x000000FFu,
+    0xFEDCBA98u,
+}};
+
+enum class Kind { FP, PLAIN };
+
+struct Case {
+  const char *name;
+  uint32_t opcode;
+  Kind kind;
+};
+
+const std::array<Case, 15> kCases = {{
+    {"v_mov_b32", 321, Kind::FP},
+    {"v_floor_f32", 351, Kind::FP},
+    {"v_ceil_f32", 349, Kind::FP},
+    {"v_trunc_f32", 348, Kind::FP},
+    {"v_rcp_f32", 354, Kind::FP},
+    {"v_cvt_f32_i32", 325, Kind::PLAIN},
+    {"v_cvt_f32_u32", 326, Kind::PLAIN},
+    {"v_cvt_i32_f32", 328, Kind::PLAIN},
+    {"v_not_b32", 363, Kind::PLAIN},
+    {"v_bfrev_b32", 364, Kind::PLAIN},
+    // Bit-scan VOP3 twins (auto-routed through the VOP1 unary glue; modifier-free
+    // integer bodies) + the VOP3-only v_bcnt_u32_b32 (UNARY_INT_EXTRA popcount).
+    {"v_ffbh_u32", 365, Kind::PLAIN},
+    {"v_ffbl_b32", 366, Kind::PLAIN},
+    {"v_ffbh_i32", 367, Kind::PLAIN},
+    {"v_bcnt_u32_b32", 651, Kind::PLAIN},
+    // frexp mantissa VOP3: routed through the f32 unary FP glue (abs/neg on the
+    // source, omod/clamp on the mantissa); every modifier combination is swept.
+    {"v_frexp_mant_f32", 372, Kind::FP},
+}};
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("vop3_un_simd_mem"), l2("vop3_un_simd_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vop3_un_simd", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  void seed_inputs(Kind k, uint64_t exec) {
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      const auto &vals = (k == Kind::FP) ? kF32 : kBits;
+      cu->write_vgpr(vb + 0, lane, vals[lane % vals.size()]);
+      cu->write_vgpr(vb + kDstVgpr, lane, DST_SENTINEL);
+    }
+    wf->set_exec(exec);
+  }
+
+  std::array<uint32_t, WF_SIZE> run(Instruction *inst, Kind k, uint64_t exec) {
+    seed_inputs(k, exec);
+    cu->execute_instruction(inst, *wf);
+    uint32_t vb = wf->vgpr_alloc().base;
+    std::array<uint32_t, WF_SIZE> out{};
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+      out[lane] = cu->read_vgpr(vb + kDstVgpr, lane);
+    return out;
+  }
+};
+
+// Restores the process force-scalar gate on scope exit so flipping it for an
+// in-process A/B comparison cannot leak into later tests in the same process.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+void check(const Case &c, uint32_t abs, uint32_t neg, uint32_t omod, uint32_t clamp,
+           uint64_t exec) {
+  ForceScalarGuard gate_guard;
+
+  auto run_mode = [&](bool force_scalar) -> std::array<uint32_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    uint32_t words[4] = {0u, 0u, 0u, 0u};
+    vop3_encode(c.opcode, /*vdst=*/kDstVgpr, /*src0=*/256, abs, neg, omod, clamp, words);
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << c.name << " decode failed";
+    auto out = fx.run(inst, c.kind, exec);
+    delete inst;
+    return out;
+  };
+
+  const auto scalar_out = run_mode(/*force_scalar=*/true);
+  const auto simd_out = run_mode(/*force_scalar=*/false);
+
+  EXPECT_EQ(scalar_out, simd_out) << c.name << " abs=" << abs << " neg=" << neg << " omod=" << omod
+                                  << " clamp=" << clamp << " (exec=0x" << std::hex << exec
+                                  << "): SIMD path diverged from scalar body";
+
+  for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+    const bool active = (exec >> lane) & 1ULL;
+    if (!active) {
+      EXPECT_EQ(simd_out[lane], DST_SENTINEL)
+          << c.name << " abs=" << abs << " neg=" << neg << " omod=" << omod << " clamp=" << clamp
+          << ": clobbered inactive lane " << lane;
+      EXPECT_EQ(scalar_out[lane], DST_SENTINEL)
+          << c.name << " abs=" << abs << " neg=" << neg << " omod=" << omod << " clamp=" << clamp
+          << ": clobbered inactive lane " << lane;
+    }
+  }
+}
+
+void check_fp_all_mods(const Case &c, uint64_t exec) {
+  for (uint32_t abs = 0; abs < 2; ++abs)   // bit 0 = src0
+    for (uint32_t neg = 0; neg < 2; ++neg) // bit 0 = src0
+      for (uint32_t omod = 0; omod < 4; ++omod)
+        for (uint32_t clamp = 0; clamp < 2; ++clamp)
+          check(c, abs, neg, omod, clamp, exec);
+}
+
+TEST(Vop3UnarySimdCorrectness, Fp_AllModifiers_FullExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    if (c.kind == Kind::FP)
+      check_fp_all_mods(c, /*exec=*/~0ULL);
+}
+
+TEST(Vop3UnarySimdCorrectness, Fp_AllModifiers_PartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    if (c.kind == Kind::FP)
+      check_fp_all_mods(c, /*exec=*/0xA5A5'F0F0'1234'8001ULL);
+}
+
+TEST(Vop3UnarySimdCorrectness, Plain_FullAndPartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases) {
+    if (c.kind != Kind::PLAIN)
+      continue;
+    check(c, 0, 0, 0, 0, /*exec=*/~0ULL);
+    check(c, 0, 0, 0, 0, /*exec=*/0xA5A5'F0F0'1234'8001ULL);
+  }
+}
+
+// Absolute behavior regression for the v_mov_b32 VOP3 codegen fix: with no
+// modifiers it must MOVE the bits (not truncate float->int). Before the fix the
+// generated body returned the f32 value to a uint32 write_lane without a
+// bit_cast, so 0.5 (0x3F000000) wrote 0; neg must flip the sign bit. The
+// expected bit patterns are mode-independent, so this pins the result in
+// whichever execute mode (RJ_FORCE_SCALAR) the process runs.
+TEST(Vop3UnarySimdCorrectness, MovB32_PreservesBits) {
+  Fixture fx;
+  ASSERT_NE(fx.cu, nullptr);
+  ASSERT_NE(fx.wf, nullptr);
+  struct Sub {
+    uint32_t abs, neg, omod, clamp, in, expect;
+  };
+  const std::array<Sub, 4> subs = {{
+      {0, 0, 0, 0, 0x3F000000u, 0x3F000000u}, // 0.5 -> 0.5 (bits preserved)
+      {0, 0, 0, 0, 0x12345678u, 0x12345678u}, // arbitrary bits preserved
+      {0, 1, 0, 0, 0x3F000000u, 0xBF000000u}, // neg: flip sign -> -0.5
+      {1, 0, 0, 0, 0xBF000000u, 0x3F000000u}, // abs: clear sign -> 0.5
+  }};
+  for (const auto &s : subs) {
+    uint32_t words[4] = {0u, 0u, 0u, 0u};
+    vop3_encode(/*op=v_mov_b32=*/321, /*vdst=*/kDstVgpr, /*src0=*/256, s.abs, s.neg, s.omod,
+                s.clamp, words);
+    Instruction *inst = fx.decoder->decode(words);
+    ASSERT_NE(inst, nullptr);
+    uint32_t vb = fx.wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+      fx.cu->write_vgpr(vb + 0, lane, s.in);
+    fx.wf->set_exec(~0ULL);
+    fx.cu->execute_instruction(inst, *fx.wf);
+    EXPECT_EQ(fx.cu->read_vgpr(vb + kDstVgpr, 0), s.expect)
+        << "v_mov_b32 abs=" << s.abs << " neg=" << s.neg << " in=0x" << std::hex << s.in;
+    delete inst;
+  }
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vop3p_dot_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3p_dot_simd_correctness_test.cpp
@@ -1,0 +1,319 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vop3p_dot_simd_correctness_test.cpp
+/// @brief Bit-identity check (SIMD fast path vs scalar body) for the VOP3P
+/// dot-product family on CDNA4. Each case runs TWICE in the same process -- once
+/// forcing the scalar body, once the SIMD fast path, with identical inputs/EXEC
+/// -- and the results are asserted equal per active, non-skipped lane
+/// (util::set_force_scalar_for_testing flips the gate in-process). The f16 form's
+/// NaN-input lanes carry a toolchain-dependent NaN-payload divergence and are
+/// excluded from the comparison (the skip condition is computed from the inputs,
+/// so both runs skip the same lanes). In-process inactive lanes must keep the
+/// sentinel. Ops covered:
+///   integer: v_dot4_i32_i8 / v_dot4_u32_u8 / v_dot8_i32_i4 / v_dot8_u32_u4 /
+///            v_dot2_i32_i16 / v_dot2_u32_u16
+///   float:   v_dot2_f32_f16
+///
+/// Unlike the packed-16 family the destination is a single 32-bit lane (NOT
+/// packed) and src2 is a per-lane accumulator; the dot reduction happens
+/// within each lane and the fast path vectorizes across lanes. The signed
+/// integer forms lower-clamp to 0 when the clamp bit is set, so the integer
+/// test sweeps clamp ∈ {0,1}; the f16 form half-selects via op_sel, sign-
+/// flips via neg/neg_hi, and clamps to [0,1], so it sweeps every neg/neg_hi
+/// combination × clamp with NaN-input lanes skipped (toolchain-dependent NaN
+/// payload divergence, same carve-out as the pk_fma slices). Default packing
+/// (op_sel = 0, op_sel_hi = 3) only — non-default modes bail to scalar.
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include "util/simd.h"
+
+#include <array>
+#include <bit>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t WF_SIZE = 64;
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+constexpr uint32_t kDstVgpr = 6;
+constexpr uint32_t DST_SENTINEL = 0xCDCDCDCDu;
+
+// Restores the process force-scalar gate on scope exit so flipping it for an
+// in-process A/B comparison cannot leak into later tests in the same process.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+// CDNA4 VOP3P dot encoding (all dot ops are 3-source). Default packing:
+// op_sel = 0, op_sel_hi = 3, op_sel_hi_2 = 1. clamp -> word0 bit 15; neg ->
+// word1 bits 29:31; neg_hi -> word0 bits 8:10.
+constexpr void vop3p_encode_dot(uint32_t op, uint32_t vdst, uint32_t src0, uint32_t src1,
+                                uint32_t src2, uint32_t neg, uint32_t neg_hi, uint32_t clamp,
+                                uint32_t words[2]) {
+  words[0] = (vdst & 0xFFu) | ((neg_hi & 0x7u) << 8) | (1u << 14) | ((clamp & 0x1u) << 15) |
+             ((op & 0x7Fu) << 16) | (0x1A7u << 23);
+  words[1] = (src0 & 0x1FFu) | ((src1 & 0x1FFu) << 9) | ((src2 & 0x1FFu) << 18) | (0x3u << 27) |
+             ((neg & 0x7u) << 29);
+}
+
+struct IntCase {
+  const char *name;
+  uint32_t opcode;
+};
+
+const std::array<IntCase, 6> kIntCases = {{
+    {"v_dot4_i32_i8_vop3p", 40},
+    {"v_dot4_u32_u8_vop3p", 41},
+    {"v_dot8_i32_i4_vop3p", 42},
+    {"v_dot8_u32_u4_vop3p", 43},
+    {"v_dot2_i32_i16_vop3p", 38},
+    {"v_dot2_u32_u16_vop3p", 39},
+}};
+
+// Byte/nibble/half-varied 32-bit words; src2 (the accumulator) is seeded from
+// the same pool, so signed sums land both positive and negative to exercise
+// the lower clamp.
+const std::array<uint32_t, 14> kVals = {{
+    0x00000000u,
+    0x01020304u,
+    0x0000FFFFu,
+    0xFFFF0000u,
+    0xFFFFFFFFu, // all-ones: -1 per signed sub-word
+    0x80008000u, // INT16_MIN halves / INT_MIN as acc
+    0x7FFF7FFFu, // INT16_MAX halves
+    0x12345678u,
+    0xDEADBEEFu,
+    0xCAFEBABEu,
+    0xA5A5A5A5u,
+    0x7F7F7F7Fu,
+    0x88888888u, // -8 per nibble (signed i4)
+    0x0F0F0F0Fu,
+}};
+
+bool is_f16_nan(uint16_t b) { return ((b >> 10) & 0x1Fu) == 0x1Fu && (b & 0x3FFu) != 0u; }
+
+// ---- integer dot products -------------------------------------------------
+
+void check_int_case(const IntCase &c, uint64_t exec, uint32_t clamp) {
+  ForceScalarGuard gate_guard;
+
+  auto run_mode = [&](bool force_scalar, uint32_t rot) -> std::array<uint32_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    amdgpu::GpuMemory gpu_mem("vop3p_dot_int_mem");
+    amdgpu::L2Cache l2("vop3p_dot_int_l2");
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    auto cu = amdgpu::ComputeUnitCore::create("cu_vop3p_dot_int", cfg, &gpu_mem, &l2);
+    EXPECT_NE(cu, nullptr);
+    auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    amdgpu::Wavefront *wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+    EXPECT_NE(wf, nullptr);
+
+    uint32_t words[2] = {0u, 0u};
+    vop3p_encode_dot(c.opcode, kDstVgpr, /*src0=*/256, /*src1=*/257, /*src2=*/258, /*neg=*/0,
+                     /*neg_hi=*/0, clamp, words);
+    Instruction *inst = decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << c.name << " decode failed";
+
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      cu->write_vgpr(vb + 0, lane, kVals[lane % kVals.size()]);
+      cu->write_vgpr(vb + 1, lane, kVals[(lane + rot) % kVals.size()]);
+      cu->write_vgpr(vb + 2, lane, kVals[(lane + 2 * rot + 5) % kVals.size()]);
+      cu->write_vgpr(vb + kDstVgpr, lane, DST_SENTINEL);
+    }
+    wf->set_exec(exec);
+    cu->execute_instruction(inst, *wf);
+    std::array<uint32_t, WF_SIZE> out{};
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+      out[lane] = cu->read_vgpr(vb + kDstVgpr, lane);
+    delete inst;
+    return out;
+  };
+
+  for (uint32_t rot = 0; rot < kVals.size(); ++rot) {
+    const auto scalar_out = run_mode(/*force_scalar=*/true, rot);
+    const auto simd_out = run_mode(/*force_scalar=*/false, rot);
+
+    EXPECT_EQ(scalar_out, simd_out) << c.name << " clamp=" << clamp << " rot=" << rot
+                                    << ": SIMD path diverged from scalar body";
+
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      const bool active = (exec >> lane) & 1ULL;
+      if (!active) {
+        EXPECT_EQ(simd_out[lane], DST_SENTINEL) << c.name << " clamp=" << clamp << " rot=" << rot
+                                                << ": clobbered inactive lane " << lane;
+        EXPECT_EQ(scalar_out[lane], DST_SENTINEL) << c.name << " clamp=" << clamp << " rot=" << rot
+                                                  << ": clobbered inactive lane " << lane;
+      }
+    }
+  }
+}
+
+TEST(Vop3pDotIntSimdCorrectness, FullExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kIntCases)
+    for (uint32_t clamp = 0; clamp < 2; ++clamp)
+      check_int_case(c, /*exec=*/~0ULL, clamp);
+}
+
+TEST(Vop3pDotIntSimdCorrectness, PartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kIntCases)
+    for (uint32_t clamp = 0; clamp < 2; ++clamp)
+      check_int_case(c, /*exec=*/0xA5A5'F0F0'1234'8001ULL, clamp);
+}
+
+// ---- v_dot2_f32_f16 -------------------------------------------------------
+
+const std::array<uint16_t, 14> kF16Bits = {{
+    0x0000u, // +0
+    0x8000u, // -0
+    0x3C00u, // +1
+    0xBC00u, // -1
+    0x4200u, // +3
+    0xC900u, // -10
+    0x7BFFu, // +max-normal
+    0xFBFFu, // -max-normal
+    0x0400u, // +smallest-normal
+    0x83FFu, // largest -denormal
+    0x4900u, // +10
+    0x4400u, // +4
+    0x4500u, // +5
+    0x3800u, // +0.5
+}};
+
+// Finite f32 accumulators (bit patterns), no NaN/Inf.
+const std::array<float, 7> kF32Acc = {{0.0f, -0.0f, 1.0f, -2.5f, 100.0f, -1024.0f, 0.25f}};
+
+void check_f16_case(uint64_t exec, uint32_t neg, uint32_t neg_hi, uint32_t clamp) {
+  ForceScalarGuard gate_guard;
+
+  auto half_bits = [&](uint32_t lane, uint32_t rot) {
+    uint16_t a_lo = kF16Bits[lane % kF16Bits.size()];
+    uint16_t a_hi = kF16Bits[(lane + 3) % kF16Bits.size()];
+    uint16_t b_lo = kF16Bits[(lane + rot) % kF16Bits.size()];
+    uint16_t b_hi = kF16Bits[(lane + rot + 5) % kF16Bits.size()];
+    return std::array<uint16_t, 4>{a_lo, a_hi, b_lo, b_hi};
+  };
+
+  auto run_mode = [&](bool force_scalar, uint32_t rot) -> std::array<uint32_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    amdgpu::GpuMemory gpu_mem("vop3p_dot_f16_mem");
+    amdgpu::L2Cache l2("vop3p_dot_f16_l2");
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    auto cu = amdgpu::ComputeUnitCore::create("cu_vop3p_dot_f16", cfg, &gpu_mem, &l2);
+    EXPECT_NE(cu, nullptr);
+    auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    amdgpu::Wavefront *wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+    EXPECT_NE(wf, nullptr);
+
+    uint32_t words[2] = {0u, 0u};
+    vop3p_encode_dot(/*op=*/35, kDstVgpr, /*src0=*/256, /*src1=*/257, /*src2=*/258, neg, neg_hi,
+                     clamp, words);
+    Instruction *inst = decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << "v_dot2_f32_f16 decode failed";
+
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      auto h = half_bits(lane, rot);
+      uint32_t s0 = static_cast<uint32_t>(h[0]) | (static_cast<uint32_t>(h[1]) << 16);
+      uint32_t s1 = static_cast<uint32_t>(h[2]) | (static_cast<uint32_t>(h[3]) << 16);
+      uint32_t s2 = std::bit_cast<uint32_t>(kF32Acc[(lane + rot) % kF32Acc.size()]);
+      cu->write_vgpr(vb + 0, lane, s0);
+      cu->write_vgpr(vb + 1, lane, s1);
+      cu->write_vgpr(vb + 2, lane, s2);
+      cu->write_vgpr(vb + kDstVgpr, lane, DST_SENTINEL);
+    }
+    wf->set_exec(exec);
+    cu->execute_instruction(inst, *wf);
+    std::array<uint32_t, WF_SIZE> out{};
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+      out[lane] = cu->read_vgpr(vb + kDstVgpr, lane);
+    delete inst;
+    return out;
+  };
+
+  for (uint32_t rot = 0; rot < kF16Bits.size(); ++rot) {
+    const auto scalar_out = run_mode(/*force_scalar=*/true, rot);
+    const auto simd_out = run_mode(/*force_scalar=*/false, rot);
+
+    // Core A/B equivalence per active, non-skipped lane. NaN-input lanes carry a
+    // toolchain-dependent NaN-payload divergence and are excluded identically in
+    // both runs (the skip condition is input-derived).
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      const bool active = (exec >> lane) & 1ULL;
+      if (active) {
+        auto h = half_bits(lane, rot);
+        bool skip = is_f16_nan(h[0]) || is_f16_nan(h[1]) || is_f16_nan(h[2]) || is_f16_nan(h[3]);
+        if (skip)
+          continue;
+        EXPECT_EQ(scalar_out[lane], simd_out[lane])
+            << "v_dot2_f32_f16 neg=" << neg << " neg_hi=" << neg_hi << " clamp=" << clamp
+            << " rot=" << rot << " lane " << lane << ": SIMD path diverged from scalar body";
+      } else {
+        EXPECT_EQ(simd_out[lane], DST_SENTINEL)
+            << "v_dot2_f32_f16 neg=" << neg << " neg_hi=" << neg_hi << " clamp=" << clamp
+            << " rot=" << rot << ": clobbered inactive lane " << lane;
+        EXPECT_EQ(scalar_out[lane], DST_SENTINEL)
+            << "v_dot2_f32_f16 neg=" << neg << " neg_hi=" << neg_hi << " clamp=" << clamp
+            << " rot=" << rot << ": clobbered inactive lane " << lane;
+      }
+    }
+  }
+}
+
+TEST(Vop3pDotF16SimdCorrectness, FullExecAllModifiers) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (uint32_t neg = 0; neg < 8; ++neg)
+    for (uint32_t neg_hi = 0; neg_hi < 4; ++neg_hi)
+      for (uint32_t clamp = 0; clamp < 2; ++clamp)
+        check_f16_case(/*exec=*/~0ULL, neg, neg_hi, clamp);
+}
+
+TEST(Vop3pDotF16SimdCorrectness, PartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  check_f16_case(/*exec=*/0xA5A5'F0F0'1234'8001ULL, /*neg=*/0, /*neg_hi=*/0, /*clamp=*/0);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vop3p_fma_mix_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3p_fma_mix_simd_correctness_test.cpp
@@ -1,0 +1,492 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vop3p_fma_mix_simd_correctness_test.cpp
+/// @brief Bit-identity check (SIMD fast path vs scalar body) for the six VOP3P
+/// fma_mix / mad_mix mixed-precision ops. Each case runs TWICE in the same
+/// process -- once forcing the scalar body, once the SIMD fast path, with
+/// identical inputs/EXEC -- and the results are asserted equal per active,
+/// non-skipped lane (util::set_force_scalar_for_testing flips the gate
+/// in-process). NaN-input lanes carry an accepted NaN-payload divergence and are
+/// excluded from the comparison — the skip condition is computed from the
+/// inputs, identical in both runs, so both skip the same lanes. In-process
+/// inactive lanes must keep the dst seed. The six ops:
+///   - RDNA3+ : v_fma_mix_f32 / v_fma_mixlo_f16 / v_fma_mixhi_f16
+///   - CDNA1-4: v_mad_mix_f32 / v_mad_mixlo_f16 / v_mad_mixhi_f16
+///
+/// All six implement the same scalar formula (`a * b + c` plain, no std::fma,
+/// then optional clamp to [0, 1]) and differ only in (a) the per-source f16
+/// widening shape selected by `op_sel_hi` + `op_sel_hi_2` (widen f16 half to
+/// f32 vs read raw f32) and the f16-half pick selected by `op_sel`, and
+/// (b) the destination narrowing shape (f32 / f16-lo / f16-hi). VOP3P does
+/// not carry abs or omod; only `neg` (per-source xor of the sign bit) and
+/// `clamp` (saturate result to [0, 1]) apply.
+///
+/// The test covers every per-source neg combination, several op_sel /
+/// op_sel_hi patterns (so all four widen-modes per source are exercised),
+/// clamp on/off, full and partial EXEC masks. Input lanes carry an f32 edge
+/// list packed both as raw f32 (when read in the no-widen mode) and as two
+/// f16 halves (when the corresponding op_sel_hi bit is set), so every
+/// per-source data fetch path is hit. NaN-input lanes are skipped because
+/// the scalar `a * b + c` and the SIMD chain can quiet sNaN to qNaN with
+/// different payloads (accepted divergence, mirroring the existing VOP3
+/// ternary tests).
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include "util/data_types.h"
+#include "util/simd.h"
+
+#include <array>
+#include <bit>
+#include <cmath>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+constexpr uint32_t kDstVgpr = 6;
+constexpr uint32_t DST_SENTINEL = 0xCDCDCDCDu;
+
+// Restores the process force-scalar gate on scope exit so flipping it for an
+// in-process A/B comparison cannot leak into later tests in the same process.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+// VOP3P encoding word0 layout (shared between CDNA4 and RDNA3 except for the
+// width of the encoding marker): bits 0-7 vdst, 8-10 neg_hi, 11-13 op_sel,
+// 14 op_sel_hi_2, 15 clamp, 16-22 op (7 bits), 23 pad (RDNA3) / encoding
+// extension (CDNA4), 24-31 encoding (RDNA3 = 0xCC) / 23-31 encoding (CDNA4 =
+// 0x1A7 = primary_decode_table slot that dispatches to subDecodeVop3p).
+// word1 layout (identical): bits 0-8 src0, 9-17 src1, 18-26 src2,
+// 27-28 op_sel_hi (src0/src1), 29-31 neg.
+constexpr void vop3p_encode_rdna3(uint32_t op, uint32_t vdst, uint32_t neg_hi, uint32_t op_sel,
+                                  uint32_t op_sel_hi_2, uint32_t clamp, uint32_t src0,
+                                  uint32_t src1, uint32_t src2, uint32_t op_sel_hi, uint32_t neg,
+                                  uint32_t words[2]) {
+  words[0] = (vdst & 0xFFu) | ((neg_hi & 0x7u) << 8) | ((op_sel & 0x7u) << 11) |
+             ((op_sel_hi_2 & 0x1u) << 14) | ((clamp & 0x1u) << 15) | ((op & 0x7Fu) << 16) |
+             (0xCCu << 24);
+  words[1] = (src0 & 0x1FFu) | ((src1 & 0x1FFu) << 9) | ((src2 & 0x1FFu) << 18) |
+             ((op_sel_hi & 0x3u) << 27) | ((neg & 0x7u) << 29);
+}
+
+constexpr void vop3p_encode_cdna4(uint32_t op, uint32_t vdst, uint32_t neg_hi, uint32_t op_sel,
+                                  uint32_t op_sel_hi_2, uint32_t clamp, uint32_t src0,
+                                  uint32_t src1, uint32_t src2, uint32_t op_sel_hi, uint32_t neg,
+                                  uint32_t words[2]) {
+  words[0] = (vdst & 0xFFu) | ((neg_hi & 0x7u) << 8) | ((op_sel & 0x7u) << 11) |
+             ((op_sel_hi_2 & 0x1u) << 14) | ((clamp & 0x1u) << 15) | ((op & 0x7Fu) << 16) |
+             (0x1A7u << 23);
+  words[1] = (src0 & 0x1FFu) | ((src1 & 0x1FFu) << 9) | ((src2 & 0x1FFu) << 18) |
+             ((op_sel_hi & 0x3u) << 27) | ((neg & 0x7u) << 29);
+}
+
+// Edge f32 bit patterns + an "everyday" gradient. Every lane carries one of
+// these in src0/src1/src2 (rotated per source). Includes ±0, ±denormal,
+// ±finite, ±Inf — NaN inputs are excluded so the lane-wise comparator does
+// not need a NaN-payload carve-out.
+const std::array<uint32_t, 16> kSrcA = {{
+    0x3F800000u, // 1.0
+    0xBF800000u, // -1.0
+    0x40400000u, // 3.0
+    0xC0400000u, // -3.0
+    0x00000000u, // +0.0
+    0x80000000u, // -0.0
+    0x7F800000u, // +Inf
+    0xFF800000u, // -Inf
+    0x40490FDBu, // pi
+    0xC0490FDBu, // -pi
+    0x3DCCCCCDu, // 0.1
+    0xBDCCCCCDu, // -0.1
+    0x00400000u, // small denormal-ish
+    0x80400000u, // negative ditto
+    0x42280000u, // 42.0
+    0xC2280000u, // -42.0
+}};
+const std::array<uint32_t, 16> kSrcB = {{
+    0x3FC00000u, // 1.5
+    0xBFC00000u, // -1.5
+    0x3F000000u, // 0.5
+    0xBF000000u, // -0.5
+    0x40000000u, // 2.0
+    0xC0000000u, // -2.0
+    0x3F800000u, // 1.0
+    0xBF800000u, // -1.0
+    0x3F4CCCCDu, // 0.8
+    0xBF4CCCCDu, // -0.8
+    0x44800000u, // 1024
+    0xC4800000u, // -1024
+    0x3E800000u, // 0.25
+    0xBE800000u, // -0.25
+    0x40A00000u, // 5.0
+    0xC0A00000u, // -5.0
+}};
+const std::array<uint32_t, 16> kSrcC = {{
+    0x00000000u,
+    0x3F800000u,
+    0xBF800000u,
+    0x3DCCCCCDu,
+    0xBDCCCCCDu,
+    0x40000000u,
+    0xC0000000u,
+    0x40A00000u,
+    0xC0A00000u,
+    0x3F4CCCCDu,
+    0xBF4CCCCDu,
+    0x42280000u,
+    0xC2280000u,
+    0x80000000u,
+    0x3F000000u,
+    0xBF000000u,
+}};
+
+// Per-source f16 packing: low 16 of `kSrcA[i]` is one f16 sample, high 16 is
+// the next sample's first half. When op_sel_hi=1 + op_sel selects low vs high
+// the scalar widens via util::f16_to_f32 — these patterns make sure both
+// halves carry distinct finite f16 values across every lane.
+constexpr uint32_t pack_two_f16(uint32_t lo16, uint32_t hi16) {
+  return (lo16 & 0xFFFFu) | ((hi16 & 0xFFFFu) << 16);
+}
+
+const std::array<uint32_t, 16> kSrcA_f16 = {{
+    pack_two_f16(0x3C00u, 0xBC00u), // 1.0, -1.0
+    pack_two_f16(0x4200u, 0xC200u), // 3.0, -3.0
+    pack_two_f16(0x0000u, 0x8000u), // +0, -0
+    pack_two_f16(0x7C00u, 0xFC00u), // +Inf, -Inf  (Inf only, no NaN)
+    pack_two_f16(0x4900u, 0xC900u), // ~pi, ~-pi
+    pack_two_f16(0x2E66u, 0xAE66u), // ~0.1, ~-0.1
+    pack_two_f16(0x0001u, 0x8001u), // smallest denormal both signs
+    pack_two_f16(0x5140u, 0xD140u), // 42.0, -42.0
+    pack_two_f16(0x3800u, 0xB800u), // 0.5, -0.5
+    pack_two_f16(0x4000u, 0xC000u), // 2.0, -2.0
+    pack_two_f16(0x33CCu, 0xB3CCu), // 0.25-ish, neg
+    pack_two_f16(0x6400u, 0xE400u), // 1024-ish, neg
+    pack_two_f16(0x3C00u, 0x4200u), // 1.0, 3.0
+    pack_two_f16(0x0001u, 0x3C00u), // denormal then 1.0
+    pack_two_f16(0x2E66u, 0xBC00u), // 0.1, -1.0
+    pack_two_f16(0x3800u, 0x4200u), // 0.5, 3.0
+}};
+
+// Same f16 pool but rotated so every lane sees a different src0/src1/src2
+// combination across rotations.
+const std::array<uint32_t, 16> kSrcB_f16 = kSrcA_f16;
+const std::array<uint32_t, 16> kSrcC_f16 = kSrcA_f16;
+
+// Modifier combinations swept per op. (neg, op_sel, op_sel_hi, op_sel_hi_2,
+// clamp). op_sel only matters when the matching op_sel_hi[i] bit is set.
+// Eight neg patterns × handful of op_sel / widen-mode combos × clamp on/off.
+struct ModCombo {
+  uint32_t neg;         // bit0=src0, bit1=src1, bit2=src2
+  uint32_t op_sel;      // bit0=src0 lo/hi, bit1=src1 lo/hi, bit2=src2 lo/hi
+  uint32_t op_sel_hi;   // bit0=src0 widen, bit1=src1 widen
+  uint32_t op_sel_hi_2; // 0/1: src2 widen
+  uint32_t clamp;       // 0/1
+};
+
+constexpr std::array<ModCombo, 32> kModCombos = {{
+    // All-defaults: read every src as raw f32, no neg, no clamp.
+    {0b000, 0b000, 0b00, 0, 0},
+    // Per-source neg.
+    {0b001, 0b000, 0b00, 0, 0},
+    {0b010, 0b000, 0b00, 0, 0},
+    {0b100, 0b000, 0b00, 0, 0},
+    {0b111, 0b000, 0b00, 0, 0},
+    // Clamp on/off with neg combos.
+    {0b000, 0b000, 0b00, 0, 1},
+    {0b101, 0b000, 0b00, 0, 1},
+    {0b011, 0b000, 0b00, 0, 1},
+    // Widen src0 from f16 (lo half).
+    {0b000, 0b000, 0b01, 0, 0},
+    {0b000, 0b001, 0b01, 0, 0}, // widen src0 hi half
+    // Widen src1 from f16.
+    {0b000, 0b000, 0b10, 0, 0},
+    {0b000, 0b010, 0b10, 0, 0},
+    // Widen src2 from f16.
+    {0b000, 0b000, 0b00, 1, 0},
+    {0b000, 0b100, 0b00, 1, 0},
+    // Widen all three.
+    {0b000, 0b000, 0b11, 1, 0},
+    {0b000, 0b111, 0b11, 1, 0},
+    // Widen all three + neg all + clamp.
+    {0b111, 0b000, 0b11, 1, 1},
+    {0b111, 0b111, 0b11, 1, 1},
+    // Mixed: widen src0+src2, neg src1.
+    {0b010, 0b000, 0b01, 1, 0},
+    {0b010, 0b101, 0b01, 1, 0},
+    // Widen src1+src2 only.
+    {0b000, 0b000, 0b10, 1, 0},
+    {0b101, 0b110, 0b10, 1, 0},
+    // Cover op_sel without widen (op_sel bit ignored by scalar/SIMD on that lane).
+    {0b000, 0b111, 0b00, 0, 0},
+    {0b111, 0b111, 0b00, 0, 0},
+    // Clamp + widen combos for f16 result paths.
+    {0b001, 0b001, 0b01, 0, 1},
+    {0b010, 0b010, 0b10, 0, 1},
+    {0b100, 0b100, 0b00, 1, 1},
+    // Edge: neg + widen src0 hi only.
+    {0b001, 0b001, 0b01, 0, 0},
+    {0b001, 0b001, 0b11, 1, 0},
+    // Edge: clamp + widen mixed.
+    {0b011, 0b010, 0b11, 1, 1},
+    {0b110, 0b110, 0b10, 1, 1},
+    {0b101, 0b101, 0b01, 1, 1},
+}};
+
+template <uint32_t WF_SIZE, int ArchTag> struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("vop3p_fma_mix_mem"), l2("vop3p_fma_mix_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = (ArchTag == 0) ? ROCJITSU_CODE_ARCH_RDNA3 : ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vop3p_fma_mix", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(cfg.arch);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  void seed_vgprs(uint32_t rot, bool widen0, bool widen1, bool widen2, uint64_t exec,
+                  uint32_t dst_seed) {
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      uint32_t i0 = (lane + rot) % kSrcA.size();
+      uint32_t i1 = (lane + 2 * rot + 3) % kSrcA.size();
+      uint32_t i2 = (lane + 3 * rot + 7) % kSrcA.size();
+      cu->write_vgpr(vb + 0, lane, widen0 ? kSrcA_f16[i0] : kSrcA[i0]);
+      cu->write_vgpr(vb + 1, lane, widen1 ? kSrcB_f16[i1] : kSrcB[i1]);
+      cu->write_vgpr(vb + 2, lane, widen2 ? kSrcC_f16[i2] : kSrcC[i2]);
+      cu->write_vgpr(vb + kDstVgpr, lane, dst_seed);
+    }
+    wf->set_exec(exec);
+  }
+
+  std::array<uint32_t, WF_SIZE> run(Instruction *inst, uint32_t rot, bool widen0, bool widen1,
+                                    bool widen2, uint64_t exec, uint32_t dst_seed) {
+    seed_vgprs(rot, widen0, widen1, widen2, exec, dst_seed);
+    cu->execute_instruction(inst, *wf);
+    std::array<uint32_t, WF_SIZE> out{};
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+      out[lane] = cu->read_vgpr(vb + kDstVgpr, lane);
+    return out;
+  }
+};
+
+// Skip lanes whose three (widened-if-applicable) input operands include NaN.
+// We do NOT carry a NaN-payload guarantee through the f32 intermediate (the
+// scalar `a*b+c` and the SIMD chain can pick different operand to quiet).
+bool input_lane_is_nan(uint32_t raw0, uint32_t raw1, uint32_t raw2, bool widen0, bool widen1,
+                       bool widen2, uint32_t op_sel) {
+  auto half_is_nan = [](uint32_t bits16) {
+    uint32_t exp = (bits16 >> 10) & 0x1Fu;
+    uint32_t mant = bits16 & 0x3FFu;
+    return exp == 0x1Fu && mant != 0u;
+  };
+  auto f32_is_nan = [](uint32_t bits) {
+    uint32_t exp = (bits >> 23) & 0xFFu;
+    uint32_t mant = bits & 0x7FFFFFu;
+    return exp == 0xFFu && mant != 0u;
+  };
+  auto src_is_nan = [&](uint32_t raw, bool widen, uint32_t sel_bit) {
+    if (widen) {
+      uint32_t h = sel_bit ? (raw >> 16) : (raw & 0xFFFFu);
+      return half_is_nan(h);
+    }
+    return f32_is_nan(raw);
+  };
+  return src_is_nan(raw0, widen0, op_sel & 1u) || src_is_nan(raw1, widen1, (op_sel >> 1) & 1u) ||
+         src_is_nan(raw2, widen2, (op_sel >> 2) & 1u);
+}
+
+template <uint32_t WF_SIZE, int ArchTag>
+void check_combo(uint32_t opcode, const ModCombo &mc, uint64_t exec, uint32_t dst_seed,
+                 const char *label) {
+  const bool widen0 = (mc.op_sel_hi & 1u) != 0;
+  const bool widen1 = ((mc.op_sel_hi >> 1) & 1u) != 0;
+  const bool widen2 = mc.op_sel_hi_2 != 0;
+
+  auto run_mode = [&](bool force_scalar, uint32_t rot) -> std::array<uint32_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture<WF_SIZE, ArchTag> fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    uint32_t words[4] = {0u, 0u, 0u, 0u};
+    if constexpr (ArchTag == 0) {
+      vop3p_encode_rdna3(opcode, kDstVgpr, /*neg_hi=*/0, mc.op_sel, mc.op_sel_hi_2, mc.clamp,
+                         /*src0=*/256, /*src1=*/257, /*src2=*/258, mc.op_sel_hi, mc.neg, words);
+    } else {
+      vop3p_encode_cdna4(opcode, kDstVgpr, /*neg_hi=*/0, mc.op_sel, mc.op_sel_hi_2, mc.clamp,
+                         /*src0=*/256, /*src1=*/257, /*src2=*/258, mc.op_sel_hi, mc.neg, words);
+    }
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << label << " decode failed";
+    auto out = fx.run(inst, rot, widen0, widen1, widen2, exec, dst_seed);
+    delete inst;
+    return out;
+  };
+
+  for (uint32_t rot = 0; rot < 4; ++rot) {
+    const auto scalar_out = run_mode(/*force_scalar=*/true, rot);
+    const auto simd_out = run_mode(/*force_scalar=*/false, rot);
+
+    // Core A/B equivalence per active, non-skipped lane. NaN-input lanes carry an
+    // accepted NaN-payload divergence and are excluded identically in both runs
+    // (the skip condition is input-derived).
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      const bool active = (exec >> lane) & 1ULL;
+      if (active) {
+        uint32_t i0 = (lane + rot) % kSrcA.size();
+        uint32_t i1 = (lane + 2 * rot + 3) % kSrcA.size();
+        uint32_t i2 = (lane + 3 * rot + 7) % kSrcA.size();
+        uint32_t raw0 = widen0 ? kSrcA_f16[i0] : kSrcA[i0];
+        uint32_t raw1 = widen1 ? kSrcB_f16[i1] : kSrcB[i1];
+        uint32_t raw2 = widen2 ? kSrcC_f16[i2] : kSrcC[i2];
+        if (input_lane_is_nan(raw0, raw1, raw2, widen0, widen1, widen2, mc.op_sel))
+          continue;
+        EXPECT_EQ(scalar_out[lane], simd_out[lane])
+            << label << " rot=" << rot << " lane=" << lane << ": SIMD path diverged from scalar";
+      } else {
+        EXPECT_EQ(simd_out[lane], dst_seed)
+            << label << " rot=" << rot << " lane=" << lane << ": clobbered inactive lane";
+        EXPECT_EQ(scalar_out[lane], dst_seed)
+            << label << " rot=" << rot << " lane=" << lane << ": clobbered inactive lane";
+      }
+    }
+  }
+}
+
+template <uint32_t WF_SIZE, int ArchTag>
+void check_op(uint32_t opcode, uint64_t exec, uint32_t dst_seed, const char *label) {
+  ForceScalarGuard gate_guard;
+  for (const auto &mc : kModCombos)
+    check_combo<WF_SIZE, ArchTag>(opcode, mc, exec, dst_seed, label);
+}
+
+constexpr uint32_t kVop3pOpFmaMixF32 = 32;
+constexpr uint32_t kVop3pOpFmaMixLoF16 = 33;
+constexpr uint32_t kVop3pOpFmaMixHiF16 = 34;
+constexpr uint32_t kVop3pOpMadMixF32 = 32;
+constexpr uint32_t kVop3pOpMadMixLoF16 = 33;
+constexpr uint32_t kVop3pOpMadMixHiF16 = 34;
+
+constexpr uint64_t kFullExecRdna = 0xFFFFFFFFULL;
+constexpr uint64_t kPartialExecRdna = 0xA5A5F0F0ULL;
+constexpr uint64_t kFullExecCdna = 0xFFFFFFFFFFFFFFFFULL;
+constexpr uint64_t kPartialExecCdna = 0xA5A5F0F012348001ULL;
+
+// --- RDNA3: v_fma_mix_* ---
+
+TEST(Vop3pFmaMixSimdCorrectness, RdnaFmaMixF32_FullExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable";
+    return;
+  }
+  check_op<32, 0>(kVop3pOpFmaMixF32, kFullExecRdna, DST_SENTINEL, "v_fma_mix_f32");
+}
+TEST(Vop3pFmaMixSimdCorrectness, RdnaFmaMixF32_PartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable";
+    return;
+  }
+  check_op<32, 0>(kVop3pOpFmaMixF32, kPartialExecRdna, DST_SENTINEL, "v_fma_mix_f32");
+}
+TEST(Vop3pFmaMixSimdCorrectness, RdnaFmaMixLoF16_FullExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable";
+    return;
+  }
+  check_op<32, 0>(kVop3pOpFmaMixLoF16, kFullExecRdna, DST_SENTINEL, "v_fma_mixlo_f16");
+}
+TEST(Vop3pFmaMixSimdCorrectness, RdnaFmaMixLoF16_PartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable";
+    return;
+  }
+  check_op<32, 0>(kVop3pOpFmaMixLoF16, kPartialExecRdna, DST_SENTINEL, "v_fma_mixlo_f16");
+}
+TEST(Vop3pFmaMixSimdCorrectness, RdnaFmaMixHiF16_FullExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable";
+    return;
+  }
+  check_op<32, 0>(kVop3pOpFmaMixHiF16, kFullExecRdna, DST_SENTINEL, "v_fma_mixhi_f16");
+}
+TEST(Vop3pFmaMixSimdCorrectness, RdnaFmaMixHiF16_PartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable";
+    return;
+  }
+  check_op<32, 0>(kVop3pOpFmaMixHiF16, kPartialExecRdna, DST_SENTINEL, "v_fma_mixhi_f16");
+}
+
+// --- CDNA4: v_mad_mix_* ---
+
+TEST(Vop3pFmaMixSimdCorrectness, CdnaMadMixF32_FullExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable";
+    return;
+  }
+  check_op<64, 1>(kVop3pOpMadMixF32, kFullExecCdna, DST_SENTINEL, "v_mad_mix_f32");
+}
+TEST(Vop3pFmaMixSimdCorrectness, CdnaMadMixF32_PartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable";
+    return;
+  }
+  check_op<64, 1>(kVop3pOpMadMixF32, kPartialExecCdna, DST_SENTINEL, "v_mad_mix_f32");
+}
+TEST(Vop3pFmaMixSimdCorrectness, CdnaMadMixLoF16_FullExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable";
+    return;
+  }
+  check_op<64, 1>(kVop3pOpMadMixLoF16, kFullExecCdna, DST_SENTINEL, "v_mad_mixlo_f16");
+}
+TEST(Vop3pFmaMixSimdCorrectness, CdnaMadMixLoF16_PartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable";
+    return;
+  }
+  check_op<64, 1>(kVop3pOpMadMixLoF16, kPartialExecCdna, DST_SENTINEL, "v_mad_mixlo_f16");
+}
+TEST(Vop3pFmaMixSimdCorrectness, CdnaMadMixHiF16_FullExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable";
+    return;
+  }
+  check_op<64, 1>(kVop3pOpMadMixHiF16, kFullExecCdna, DST_SENTINEL, "v_mad_mixhi_f16");
+}
+TEST(Vop3pFmaMixSimdCorrectness, CdnaMadMixHiF16_PartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable";
+    return;
+  }
+  check_op<64, 1>(kVop3pOpMadMixHiF16, kPartialExecCdna, DST_SENTINEL, "v_mad_mixhi_f16");
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vop3p_mov_b32_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3p_mov_b32_simd_correctness_test.cpp
@@ -1,0 +1,177 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vop3p_mov_b32_simd_correctness_test.cpp
+/// @brief Bit-identity check (SIMD fast path vs scalar body) for
+/// v_pk_mov_b32_vop3p on CDNA4. Default packing only (op_sel=0,
+/// op_sel_hi=3): the 64-bit result is (src0_lo, src1_hi), where each src
+/// pair lives in consecutive VGPRs {base, base+1}. The SIMD path uses
+/// read_simd64/write_simd64 to fetch and store the 64-bit pair. Each case runs
+/// TWICE in the same process -- once forcing the scalar body, once the SIMD fast
+/// path, with identical inputs/EXEC -- and the 64-bit dst results are asserted
+/// equal with EXPECT_EQ (util::set_force_scalar_for_testing flips the gate
+/// in-process). In-process inactive lanes must keep the sentinel.
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include "util/simd.h"
+
+#include <array>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t WF_SIZE = 64;
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+constexpr uint32_t kDstVgpr = 8; // pair occupies kDstVgpr..kDstVgpr+1
+constexpr uint32_t DST_SENTINEL = 0xCDCDCDCDu;
+
+constexpr void vop3p_encode(uint32_t op, uint32_t vdst, uint32_t src0, uint32_t src1,
+                            uint32_t words[2]) {
+  // op_sel = 0, op_sel_hi = 3 (default packing). neg / neg_hi / clamp = 0.
+  words[0] = (vdst & 0xFFu) | ((op & 0x7Fu) << 16) | (0x1A7u << 23);
+  words[1] = (src0 & 0x1FFu) | ((src1 & 0x1FFu) << 9) | (0x3u << 27);
+}
+
+const std::array<uint32_t, 14> kVals = {{
+    0x00000000u,
+    0xFFFFFFFFu,
+    0x12345678u,
+    0xDEADBEEFu,
+    0xCAFEBABEu,
+    0xA5A5A5A5u,
+    0x5A5A5A5Au,
+    0x80000000u,
+    0x7FFFFFFFu,
+    0xAAAAAAAAu,
+    0x55555555u,
+    0x00010001u,
+    0xFEDCBA98u,
+    0x13579BDFu,
+}};
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("vop3p_mov_b32_mem"), l2("vop3p_mov_b32_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vop3p_mov_b32", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  void seed_inputs(uint32_t rot, uint64_t exec) {
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      // src0 pair at v0:v1, src1 pair at v2:v3.
+      cu->write_vgpr(vb + 0, lane, kVals[lane % kVals.size()]);
+      cu->write_vgpr(vb + 1, lane, kVals[(lane + 1) % kVals.size()]);
+      cu->write_vgpr(vb + 2, lane, kVals[(lane + rot) % kVals.size()]);
+      cu->write_vgpr(vb + 3, lane, kVals[(lane + rot + 1) % kVals.size()]);
+      cu->write_vgpr(vb + kDstVgpr + 0, lane, DST_SENTINEL);
+      cu->write_vgpr(vb + kDstVgpr + 1, lane, DST_SENTINEL);
+    }
+    wf->set_exec(exec);
+  }
+
+  std::array<uint64_t, WF_SIZE> run(Instruction *inst, uint32_t rot, uint64_t exec) {
+    seed_inputs(rot, exec);
+    cu->execute_instruction(inst, *wf);
+    std::array<uint64_t, WF_SIZE> out{};
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      uint64_t lo = cu->read_vgpr(vb + kDstVgpr + 0, lane);
+      uint64_t hi = cu->read_vgpr(vb + kDstVgpr + 1, lane);
+      out[lane] = lo | (hi << 32);
+    }
+    return out;
+  }
+};
+
+// Restores the process force-scalar gate on scope exit so flipping it for an
+// in-process A/B comparison cannot leak into later tests in the same process.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+void check(uint64_t exec) {
+  ForceScalarGuard gate_guard;
+
+  auto run_mode = [&](bool force_scalar, uint32_t rot) -> std::array<uint64_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    uint32_t words[2] = {0u, 0u};
+    // src0 = VGPR 256 (pair v0:v1), src1 = VGPR 258 (pair v2:v3).
+    vop3p_encode(/*op=*/51, kDstVgpr, /*src0=*/256, /*src1=*/258, words);
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << "v_pk_mov_b32_vop3p decode failed";
+    auto out = fx.run(inst, rot, exec);
+    delete inst;
+    return out;
+  };
+
+  for (uint32_t rot = 0; rot < kVals.size(); ++rot) {
+    const auto scalar_out = run_mode(/*force_scalar=*/true, rot);
+    const auto simd_out = run_mode(/*force_scalar=*/false, rot);
+
+    EXPECT_EQ(scalar_out, simd_out)
+        << "v_pk_mov_b32_vop3p rot=" << rot << ": SIMD path diverged from scalar body";
+
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      const bool active = (exec >> lane) & 1ULL;
+      if (!active) {
+        const uint64_t sentinel = uint64_t{DST_SENTINEL} | (uint64_t{DST_SENTINEL} << 32);
+        EXPECT_EQ(simd_out[lane], sentinel)
+            << "rot=" << rot << ": clobbered inactive lane " << lane;
+        EXPECT_EQ(scalar_out[lane], sentinel)
+            << "rot=" << rot << ": clobbered inactive lane " << lane;
+      }
+    }
+  }
+}
+
+TEST(Vop3pMovB32SimdCorrectness, FullExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  check(/*exec=*/~0ULL);
+}
+
+TEST(Vop3pMovB32SimdCorrectness, PartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  check(/*exec=*/0xA5A5'F0F0'1234'8001ULL);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vop3p_pk_binary_fp16_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3p_pk_binary_fp16_simd_correctness_test.cpp
@@ -1,0 +1,239 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vop3p_pk_binary_fp16_simd_correctness_test.cpp
+/// @brief Bit-identity check (SIMD fast path vs scalar body) for the VOP3P
+/// packed-16 floating-point binary family on CDNA4:
+///   v_pk_add_f16 / v_pk_mul_f16 / v_pk_max_f16 / v_pk_min_f16.
+///
+/// Each 32-bit lane holds two f16 values. The SIMD path widens each half to
+/// f32, applies per-half sign-flip from neg/neg_hi, runs the functor in
+/// f32, narrows back to f16 and packs. Default packing (op_sel = 0,
+/// op_sel_hi = 3) only — non-default modes bail to scalar. Each case runs TWICE
+/// in the same process -- once forcing the scalar body, once the SIMD fast path,
+/// with identical inputs/EXEC -- and the results are asserted equal per active,
+/// non-skipped lane (util::set_force_scalar_for_testing flips the gate
+/// in-process). NaN-input lanes carry a toolchain-dependent NaN-payload
+/// divergence and are excluded from the comparison — the skip condition is
+/// computed from the inputs, identical in both runs, so both skip the same
+/// lanes. In-process inactive lanes must keep the sentinel.
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include "util/simd.h"
+
+#include <array>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t WF_SIZE = 64;
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+constexpr uint32_t kDstVgpr = 6;
+constexpr uint32_t DST_SENTINEL = 0xCDCDCDCDu;
+
+// CDNA4 VOP3P encoding. neg goes into word1 bits 29:31; neg_hi goes into
+// word0 bits 8:10; op_sel/op_sel_hi packed for default lo/hi pick.
+constexpr void vop3p_encode_binary(uint32_t op, uint32_t vdst, uint32_t neg_hi, uint32_t src0,
+                                   uint32_t src1, uint32_t neg, uint32_t words[2]) {
+  // op_sel = 0, op_sel_hi = 3 (default packing).
+  words[0] = (vdst & 0xFFu) | ((neg_hi & 0x7u) << 8) | ((op & 0x7Fu) << 16) | (0x1A7u << 23);
+  words[1] = (src0 & 0x1FFu) | ((src1 & 0x1FFu) << 9) | (0x3u << 27) | ((neg & 0x7u) << 29);
+}
+constexpr void vop3p_encode_ternary(uint32_t op, uint32_t vdst, uint32_t neg_hi, uint32_t src0,
+                                    uint32_t src1, uint32_t src2, uint32_t neg, uint32_t words[2]) {
+  // op_sel = 0, op_sel_hi = 3, op_sel_hi_2 = 1.
+  words[0] =
+      (vdst & 0xFFu) | ((neg_hi & 0x7u) << 8) | (1u << 14) | ((op & 0x7Fu) << 16) | (0x1A7u << 23);
+  words[1] = (src0 & 0x1FFu) | ((src1 & 0x1FFu) << 9) | ((src2 & 0x1FFu) << 18) | (0x3u << 27) |
+             ((neg & 0x7u) << 29);
+}
+
+struct Case {
+  const char *name;
+  uint32_t opcode;
+  bool ternary;
+};
+
+const std::array<Case, 5> kCases = {{
+    {"v_pk_add_f16_vop3p", 15, false},
+    {"v_pk_mul_f16_vop3p", 16, false},
+    {"v_pk_max_f16_vop3p", 18, false},
+    {"v_pk_min_f16_vop3p", 17, false},
+    {"v_pk_fma_f16_vop3p", 14, true},
+}};
+
+// f16 bit patterns covering normals + corners. Each 32-bit lane carries
+// two halves picked from this set, so the two halves see distinct values
+// (avoids accidentally hiding a per-half divergence).
+const std::array<uint16_t, 14> kF16Bits = {{
+    0x0000u, // +0
+    0x8000u, // -0
+    0x3C00u, // +1
+    0xBC00u, // -1
+    0x4200u, // +3
+    0xC900u, // -10
+    0x7BFFu, // +max-normal
+    0xFBFFu, // -max-normal
+    0x0400u, // +smallest-normal
+    0x83FFu, // largest -denormal
+    0x4900u, // +10
+    0x4400u, // +4
+    0x4500u, // +5
+    0x3800u, // +0.5
+}};
+
+bool is_f16_nan(uint16_t b) { return ((b >> 10) & 0x1Fu) == 0x1Fu && (b & 0x3FFu) != 0u; }
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("vop3p_pk_bin_fp16_mem"), l2("vop3p_pk_bin_fp16_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vop3p_pk_bin_fp16", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  void seed_inputs(uint32_t rot, uint64_t exec) {
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      uint16_t a_lo = kF16Bits[lane % kF16Bits.size()];
+      uint16_t a_hi = kF16Bits[(lane + 3) % kF16Bits.size()];
+      uint16_t b_lo = kF16Bits[(lane + rot) % kF16Bits.size()];
+      uint16_t b_hi = kF16Bits[(lane + rot + 5) % kF16Bits.size()];
+      uint16_t c_lo = kF16Bits[(lane + 2 * rot + 1) % kF16Bits.size()];
+      uint16_t c_hi = kF16Bits[(lane + 2 * rot + 7) % kF16Bits.size()];
+      uint32_t s0 = static_cast<uint32_t>(a_lo) | (static_cast<uint32_t>(a_hi) << 16);
+      uint32_t s1 = static_cast<uint32_t>(b_lo) | (static_cast<uint32_t>(b_hi) << 16);
+      uint32_t s2 = static_cast<uint32_t>(c_lo) | (static_cast<uint32_t>(c_hi) << 16);
+      cu->write_vgpr(vb + 0, lane, s0);
+      cu->write_vgpr(vb + 1, lane, s1);
+      cu->write_vgpr(vb + 2, lane, s2);
+      cu->write_vgpr(vb + kDstVgpr, lane, DST_SENTINEL);
+    }
+    wf->set_exec(exec);
+  }
+
+  std::array<uint32_t, WF_SIZE> run(Instruction *inst, uint32_t rot, uint64_t exec) {
+    seed_inputs(rot, exec);
+    cu->execute_instruction(inst, *wf);
+    std::array<uint32_t, WF_SIZE> out{};
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+      out[lane] = cu->read_vgpr(vb + kDstVgpr, lane);
+    return out;
+  }
+};
+
+// Restores the process force-scalar gate on scope exit so flipping it for an
+// in-process A/B comparison cannot leak into later tests in the same process.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+void check_case(const Case &c, uint64_t exec, uint32_t neg, uint32_t neg_hi) {
+  ForceScalarGuard gate_guard;
+
+  auto run_mode = [&](bool force_scalar, uint32_t rot) -> std::array<uint32_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    uint32_t words[2] = {0u, 0u};
+    if (c.ternary)
+      vop3p_encode_ternary(c.opcode, kDstVgpr, neg_hi, /*src0=*/256, /*src1=*/257, /*src2=*/258,
+                           neg, words);
+    else
+      vop3p_encode_binary(c.opcode, kDstVgpr, neg_hi, /*src0=*/256, /*src1=*/257, neg, words);
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << c.name << " decode failed";
+    auto out = fx.run(inst, rot, exec);
+    delete inst;
+    return out;
+  };
+
+  for (uint32_t rot = 0; rot < kF16Bits.size(); ++rot) {
+    const auto scalar_out = run_mode(/*force_scalar=*/true, rot);
+    const auto simd_out = run_mode(/*force_scalar=*/false, rot);
+
+    // Core A/B equivalence per active, non-skipped lane. NaN-input lanes carry a
+    // toolchain-dependent NaN-payload divergence and are excluded identically in
+    // both runs (the skip condition is input-derived).
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      const bool active = (exec >> lane) & 1ULL;
+      if (active) {
+        uint16_t a_lo = kF16Bits[lane % kF16Bits.size()];
+        uint16_t a_hi = kF16Bits[(lane + 3) % kF16Bits.size()];
+        uint16_t b_lo = kF16Bits[(lane + rot) % kF16Bits.size()];
+        uint16_t b_hi = kF16Bits[(lane + rot + 5) % kF16Bits.size()];
+        bool skip = is_f16_nan(a_lo) || is_f16_nan(a_hi) || is_f16_nan(b_lo) || is_f16_nan(b_hi);
+        if (!skip && c.ternary) {
+          uint16_t c_lo = kF16Bits[(lane + 2 * rot + 1) % kF16Bits.size()];
+          uint16_t c_hi = kF16Bits[(lane + 2 * rot + 7) % kF16Bits.size()];
+          skip = is_f16_nan(c_lo) || is_f16_nan(c_hi);
+        }
+        if (skip)
+          continue;
+        EXPECT_EQ(scalar_out[lane], simd_out[lane])
+            << c.name << " neg=" << neg << " neg_hi=" << neg_hi << " rot=" << rot << " lane "
+            << lane << ": SIMD path diverged from scalar body";
+      } else {
+        EXPECT_EQ(simd_out[lane], DST_SENTINEL)
+            << c.name << " neg=" << neg << " neg_hi=" << neg_hi << " rot=" << rot
+            << ": clobbered inactive lane " << lane;
+        EXPECT_EQ(scalar_out[lane], DST_SENTINEL)
+            << c.name << " neg=" << neg << " neg_hi=" << neg_hi << " rot=" << rot
+            << ": clobbered inactive lane " << lane;
+      }
+    }
+  }
+}
+
+TEST(Vop3pPkBinaryFp16SimdCorrectness, FullExecAllModifiers) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    for (uint32_t neg = 0; neg < 4; ++neg)
+      for (uint32_t neg_hi = 0; neg_hi < 4; ++neg_hi)
+        check_case(c, /*exec=*/~0ULL, neg, neg_hi);
+}
+
+TEST(Vop3pPkBinaryFp16SimdCorrectness, PartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_case(c, /*exec=*/0xA5A5'F0F0'1234'8001ULL, /*neg=*/0, /*neg_hi=*/0);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vop3p_pk_binary_int_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3p_pk_binary_int_simd_correctness_test.cpp
@@ -1,0 +1,219 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vop3p_pk_binary_int_simd_correctness_test.cpp
+/// @brief Bit-identity check (SIMD fast path vs scalar body) for the VOP3P
+/// packed-16 integer binary family wired into SIMD_VOP3P_PK_BINARY_INT on CDNA4.
+/// Each (case, rot) runs TWICE in the same process -- once forcing the scalar
+/// body, once the SIMD fast path, with identical inputs/EXEC -- and the two
+/// 64-lane result arrays are asserted equal with EXPECT_EQ
+/// (util::set_force_scalar_for_testing flips the gate in-process).
+/// In-process inactive lanes must keep the sentinel. Ops covered:
+///   v_pk_add_u16 / v_pk_add_i16 / v_pk_sub_u16 / v_pk_sub_i16
+///   v_pk_mul_lo_u16
+///   v_pk_lshlrev_b16 / v_pk_lshrrev_b16 / v_pk_ashrrev_i16
+///   v_pk_min_u16 / v_pk_max_u16 / v_pk_min_i16 / v_pk_max_i16
+///
+/// Each 32-bit lane holds {low16, high16} packed. Default packing
+/// (op_sel = 0, op_sel_hi = 3) is what the SIMD fast path handles —
+/// non-default modes bail to scalar. The test sweeps 14 rotation seeds
+/// under full + partial EXEC; inputs cover overflow, sign-boundary,
+/// shift-saturation, and identical-pair cases on both halves
+/// independently.
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include "util/simd.h"
+
+#include <array>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t WF_SIZE = 64;
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+constexpr uint32_t kDstVgpr = 6;
+constexpr uint32_t DST_SENTINEL = 0xCDCDCDCDu;
+
+// CDNA4 VOP3P encoding (op_sel=0, op_sel_hi=3 = default packing for srcs
+// 0/1; for ternary pk_mad the third source's high-half pick op_sel_hi_2
+// must be 1 to mirror op_sel_hi=3's behaviour on the binary form).
+constexpr void vop3p_encode_default_binary(uint32_t op, uint32_t vdst, uint32_t src0, uint32_t src1,
+                                           uint32_t words[2]) {
+  words[0] = (vdst & 0xFFu) | ((op & 0x7Fu) << 16) | (0x1A7u << 23);
+  words[1] = (src0 & 0x1FFu) | ((src1 & 0x1FFu) << 9) | (0x3u << 27);
+}
+constexpr void vop3p_encode_default_ternary(uint32_t op, uint32_t vdst, uint32_t src0,
+                                            uint32_t src1, uint32_t src2, uint32_t words[2]) {
+  // op_sel_hi_2 = bit 14 of word0 (must be 1 for default high-half pick on src2).
+  words[0] = (vdst & 0xFFu) | ((1u & 0x1u) << 14) | ((op & 0x7Fu) << 16) | (0x1A7u << 23);
+  words[1] = (src0 & 0x1FFu) | ((src1 & 0x1FFu) << 9) | ((src2 & 0x1FFu) << 18) | (0x3u << 27);
+}
+
+struct Case {
+  const char *name;
+  uint32_t opcode;
+  bool ternary;
+};
+
+const std::array<Case, 14> kCases = {{
+    {"v_pk_add_u16_vop3p", 10, false},
+    {"v_pk_add_i16_vop3p", 2, false},
+    {"v_pk_sub_u16_vop3p", 11, false},
+    {"v_pk_sub_i16_vop3p", 3, false},
+    {"v_pk_mul_lo_u16_vop3p", 1, false},
+    {"v_pk_lshlrev_b16_vop3p", 4, false},
+    {"v_pk_lshrrev_b16_vop3p", 5, false},
+    {"v_pk_ashrrev_i16_vop3p", 6, false},
+    {"v_pk_max_i16_vop3p", 7, false},
+    {"v_pk_min_i16_vop3p", 8, false},
+    {"v_pk_max_u16_vop3p", 12, false},
+    {"v_pk_min_u16_vop3p", 13, false},
+    {"v_pk_mad_i16_vop3p", 0, true},
+    {"v_pk_mad_u16_vop3p", 9, true},
+}};
+
+// Inputs hand-picked to exercise low/high overflow independently, sign
+// boundary on both halves, and shift-count-15 saturation.
+const std::array<uint32_t, 14> kVals = {{
+    0x00000000u,
+    0x00010001u,
+    0x0000FFFFu, // low all-ones, high zero
+    0xFFFF0000u, // high all-ones, low zero
+    0xFFFFFFFFu,
+    0x80007FFFu, // signed extreme low INT16_MAX, high INT16_MIN
+    0x7FFF8000u,
+    0x12345678u,
+    0xDEADBEEFu,
+    0xCAFEBABEu,
+    0xA5A5A5A5u,
+    0x00050003u, // small shift counts
+    0x000F000Eu,
+    0x00080001u,
+}};
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("vop3p_pk_bin_int_mem"), l2("vop3p_pk_bin_int_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vop3p_pk_bin_int", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  void seed_inputs(uint32_t rot, uint64_t exec) {
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      cu->write_vgpr(vb + 0, lane, kVals[lane % kVals.size()]);
+      cu->write_vgpr(vb + 1, lane, kVals[(lane + rot) % kVals.size()]);
+      cu->write_vgpr(vb + 2, lane, kVals[(lane + 2 * rot) % kVals.size()]);
+      cu->write_vgpr(vb + kDstVgpr, lane, DST_SENTINEL);
+    }
+    wf->set_exec(exec);
+  }
+
+  std::array<uint32_t, WF_SIZE> run(Instruction *inst, uint32_t rot, uint64_t exec) {
+    seed_inputs(rot, exec);
+    cu->execute_instruction(inst, *wf);
+    std::array<uint32_t, WF_SIZE> out{};
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+      out[lane] = cu->read_vgpr(vb + kDstVgpr, lane);
+    return out;
+  }
+};
+
+// Restores the process force-scalar gate on scope exit so flipping it for an
+// in-process A/B comparison cannot leak into later tests in the same process.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+void check_case(const Case &c, uint64_t exec) {
+  ForceScalarGuard gate_guard;
+
+  // Runs one (case, rot) in the requested execute mode (fresh Fixture + decode
+  // per run isolates VGPR state).
+  auto run_mode = [&](bool force_scalar, uint32_t rot) -> std::array<uint32_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    uint32_t words[2] = {0u, 0u};
+    if (c.ternary)
+      vop3p_encode_default_ternary(c.opcode, kDstVgpr, /*src0=*/256, /*src1=*/257, /*src2=*/258,
+                                   words);
+    else
+      vop3p_encode_default_binary(c.opcode, kDstVgpr, /*src0=*/256, /*src1=*/257, words);
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << c.name << " decode failed";
+    auto out = fx.run(inst, rot, exec);
+    delete inst;
+    return out;
+  };
+
+  for (uint32_t rot = 0; rot < kVals.size(); ++rot) {
+    const auto scalar_out = run_mode(/*force_scalar=*/true, rot);
+    const auto simd_out = run_mode(/*force_scalar=*/false, rot);
+
+    EXPECT_EQ(scalar_out, simd_out) << c.name << " rot=" << rot << " (exec=0x" << std::hex << exec
+                                    << "): SIMD path diverged from scalar body";
+
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      const bool active = (exec >> lane) & 1ULL;
+      if (!active) {
+        EXPECT_EQ(simd_out[lane], DST_SENTINEL)
+            << c.name << " rot=" << rot << ": clobbered inactive lane " << lane;
+        EXPECT_EQ(scalar_out[lane], DST_SENTINEL)
+            << c.name << " rot=" << rot << ": clobbered inactive lane " << lane;
+      }
+    }
+  }
+}
+
+TEST(Vop3pPkBinaryIntSimdCorrectness, FullExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_case(c, /*exec=*/~0ULL);
+}
+
+TEST(Vop3pPkBinaryIntSimdCorrectness, PartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_case(c, /*exec=*/0xA5A5'F0F0'1234'8001ULL);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vop_alias_rdna_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop_alias_rdna_simd_correctness_test.cpp
@@ -1,0 +1,284 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vop_alias_rdna_simd_correctness_test.cpp
+/// @brief Bit-identity check (SIMD fast path vs scalar body) for the RDNA-only
+/// VOP1 / VOP2 / VOP3 aliases routed into existing SIMD glue tables in the
+/// 2026-05-29 sweep slice. RDNA3 fixture (wave32, encoding markers VOP3=0x35).
+/// Each case runs TWICE in the same process -- once forcing the scalar body,
+/// once the SIMD fast path, with identical inputs/EXEC/VCC-in -- and the
+/// scalar-vs-SIMD equivalence on the destination VGPR (and VCC for the carry
+/// forms) is asserted with EXPECT_EQ (util::set_force_scalar_for_testing flips
+/// the gate in-process). In-process inactive lanes must keep the sentinel.
+///
+/// Ops covered:
+///   VOP2 (6, RDNA-only naming):
+///     v_add_nc_u32 / v_sub_nc_u32 / v_subrev_nc_u32  (plain int add/sub)
+///     v_add_co_ci_u32 / v_sub_co_ci_u32 / v_subrev_co_ci_u32  (cin from VCC,
+///       co to VCC; same scalar shape as CDNA's addc/subb/subbrev forms).
+///   VOP1 (6, RDNA3+):
+///     v_mov_b16 / v_not_b16   (low-16 forms)
+///     v_cvt_i32_i16 / v_cvt_u32_u16  (sign/zero-extend low 16)
+///     v_cvt_floor_i32_f32 / v_cvt_nearest_i32_f32  (aliases for flr / rpi)
+///   VOP3 (8):
+///     same 6 VOP1 ops in their VOP3 form (all route via the `_vop3` ->
+///     SIMD_VOP1_UNARY twin fallback since the scalar body of each ignores
+///     modifiers — verified inline in the regen for this slice) + 2 ints
+///     missing from CDNA4 (v_minmax / v_maxmin u32/i32 are RDNA3+ only).
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include "util/simd.h"
+
+#include <array>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <memory>
+#include <random>
+#include <string>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t WF_SIZE = 32; // RDNA3 wave32
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+constexpr uint32_t kDstVgpr = 6;
+constexpr uint32_t DST_SENTINEL = 0xDEFEC8EDu;
+constexpr uint32_t SRC0_VGPR = 256u;
+constexpr uint32_t SRC1_VGPR = 257u;
+constexpr uint32_t SRC2_VGPR = 258u;
+
+// VOP1 encoding: enc[31:25]=0x3F | vdst[24:17] | op[16:9] | src0[8:0].
+constexpr uint32_t vop1_encode(uint32_t op, uint32_t vdst, uint32_t src0) {
+  return (0x3Fu << 25) | ((vdst & 0xFFu) << 17) | ((op & 0xFFu) << 9) | (src0 & 0x1FFu);
+}
+
+// VOP2 encoding: enc[31]=0 | op[30:25] | vdst[24:17] | vsrc1[16:9] | src0[8:0].
+constexpr uint32_t vop2_encode(uint32_t op, uint32_t vdst, uint32_t vsrc1, uint32_t src0) {
+  return ((op & 0x3Fu) << 25) | ((vdst & 0xFFu) << 17) | ((vsrc1 & 0xFFu) << 9) | (src0 & 0x1FFu);
+}
+
+// RDNA3 VOP3 encoding (Vop3MachineInst, marker 0x35 << 26):
+//   word0: vdst[7:0] | abs[10:8] | opsel[14:11] | clamp[15] | op[25:16] | enc[31:26]
+//   word1: src0[8:0] | src1[17:9] | src2[26:18] | omod[28:27] | neg[31:29]
+constexpr void vop3_encode(uint32_t op, uint32_t vdst, uint32_t src0, uint32_t src1, uint32_t src2,
+                           uint32_t words[2]) {
+  words[0] = (vdst & 0xFFu) | ((op & 0x3FFu) << 16) | (0x35u << 26);
+  words[1] = (src0 & 0x1FFu) | ((src1 & 0x1FFu) << 9) | ((src2 & 0x1FFu) << 18);
+}
+
+// Mixed input set for VGPR seeding. Hits the carry/borrow boundary for the
+// VOP2 carry forms and the int32/uint32 / int16/uint16 extremes for cvts /
+// min/max ternaries.
+const std::array<uint32_t, 14> kVals = {{
+    0x00000000u,
+    0x00000001u,
+    0x0000FFFFu,
+    0x00008000u,
+    0xFFFF0000u,
+    0x80000000u,
+    0x7FFFFFFFu,
+    0xFFFFFFFFu,
+    0xDEADBEEFu,
+    0xCAFEBABEu,
+    0xA5A5A5A5u,
+    0x5A5A5A5Au,
+    0x00010001u,
+    0xFFFE7FFFu,
+}};
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("vop_alias_rdna_mem"), l2("vop_alias_rdna_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_RDNA3;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vop_alias_rdna", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA3);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  void seed_inputs(uint32_t rot, uint64_t exec, uint64_t vcc_in) {
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      cu->write_vgpr(vb + 0, lane, kVals[lane % kVals.size()]);
+      cu->write_vgpr(vb + 1, lane, kVals[(lane + rot) % kVals.size()]);
+      cu->write_vgpr(vb + 2, lane, kVals[(lane + 2 * rot) % kVals.size()]);
+      cu->write_vgpr(vb + kDstVgpr, lane, DST_SENTINEL);
+    }
+    wf->set_exec(exec);
+    wf->set_vcc(vcc_in);
+  }
+
+  struct Result {
+    std::array<uint32_t, WF_SIZE> dst{};
+    uint64_t vcc = 0;
+  };
+
+  Result run(Instruction *inst, uint32_t rot, uint64_t exec, uint64_t vcc_in) {
+    seed_inputs(rot, exec, vcc_in);
+    cu->execute_instruction(inst, *wf);
+    Result res;
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+      res.dst[lane] = cu->read_vgpr(vb + kDstVgpr, lane);
+    res.vcc = wf->vcc();
+    return res;
+  }
+};
+
+struct VopCase {
+  const char *name;
+  enum class Kind { VOP1, VOP2, VOP2_CARRY, VOP3_UNARY, VOP3_TERNARY } kind;
+  uint32_t opcode;
+};
+
+const VopCase kCases[] = {
+    // VOP2 nc / co_ci
+    {"v_add_nc_u32_vop2", VopCase::Kind::VOP2, 37},
+    {"v_sub_nc_u32_vop2", VopCase::Kind::VOP2, 38},
+    {"v_subrev_nc_u32_vop2", VopCase::Kind::VOP2, 39},
+    {"v_add_co_ci_u32_vop2", VopCase::Kind::VOP2_CARRY, 32},
+    {"v_sub_co_ci_u32_vop2", VopCase::Kind::VOP2_CARRY, 33},
+    {"v_subrev_co_ci_u32_vop2", VopCase::Kind::VOP2_CARRY, 34},
+    // VOP1 b16 + cvts
+    {"v_mov_b16_vop1", VopCase::Kind::VOP1, 28},
+    {"v_not_b16_vop1", VopCase::Kind::VOP1, 105},
+    {"v_cvt_i32_i16_vop1", VopCase::Kind::VOP1, 106},
+    {"v_cvt_u32_u16_vop1", VopCase::Kind::VOP1, 107},
+    {"v_cvt_nearest_i32_f32_vop1", VopCase::Kind::VOP1, 12},
+    {"v_cvt_floor_i32_f32_vop1", VopCase::Kind::VOP1, 13},
+    // VOP3 forms of the same (same opcode index in sub_decode_vop3 differs;
+    // values resolved via the regen lookup).
+    {"v_mov_b16_vop3", VopCase::Kind::VOP3_UNARY, 412},
+    {"v_not_b16_vop3", VopCase::Kind::VOP3_UNARY, 489},
+    {"v_cvt_i32_i16_vop3", VopCase::Kind::VOP3_UNARY, 490},
+    {"v_cvt_u32_u16_vop3", VopCase::Kind::VOP3_UNARY, 491},
+    {"v_cvt_nearest_i32_f32_vop3", VopCase::Kind::VOP3_UNARY, 396},
+    {"v_cvt_floor_i32_f32_vop3", VopCase::Kind::VOP3_UNARY, 397},
+    // VOP3 ternary int minmax / maxmin remain scalar-only: their scalar bodies
+    // use std::fmin/fmax on ints and write back through a double->uint32 cast
+    // that saturates negatives to 0xFFFFFFFF (x86 overflow), which the integer
+    // SIMD min/max cannot match. The fp minmax/maxmin f32/f16 forms ARE wired
+    // (SIMD_VOP3_TERNARY_FP32/_FP16, same fmax/fmin as the verified min3/max3),
+    // but are not exercised here: this fixture's values alias to f32 NaNs and
+    // the comparison has no NaN skip.
+};
+
+const uint64_t kVccPatterns[] = {
+    0x0000000000000000ULL, 0x00000000FFFFFFFFULL, 0x00000000AAAAAAAAULL,
+    0x0000000055555555ULL, 0x000000000123456FULL,
+};
+
+// Restores the process force-scalar gate on scope exit so flipping it for an
+// in-process A/B comparison cannot leak into later tests in the same process.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+void check_case(const VopCase &c, uint64_t exec) {
+  ForceScalarGuard gate_guard;
+
+  const bool has_vcc_in = (c.kind == VopCase::Kind::VOP2_CARRY);
+
+  // Runs one (case, vcc_in, rot) in the requested execute mode (fresh Fixture +
+  // decode per run isolates VGPR/VCC state).
+  auto run_mode = [&](bool force_scalar, uint64_t vcc_in, uint32_t rot) -> Fixture::Result {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    uint32_t words[4] = {0u, 0u, 0u, 0u};
+    switch (c.kind) {
+    case VopCase::Kind::VOP1:
+      words[0] = vop1_encode(c.opcode, /*vdst=*/kDstVgpr, /*src0=*/SRC0_VGPR);
+      break;
+    case VopCase::Kind::VOP2:
+    case VopCase::Kind::VOP2_CARRY:
+      words[0] = vop2_encode(c.opcode, /*vdst=*/kDstVgpr, /*vsrc1=*/(SRC1_VGPR & 0xFFu),
+                             /*src0=*/SRC0_VGPR);
+      break;
+    case VopCase::Kind::VOP3_UNARY:
+      vop3_encode(c.opcode, kDstVgpr, SRC0_VGPR, /*src1=*/0, /*src2=*/0, words);
+      break;
+    case VopCase::Kind::VOP3_TERNARY:
+      vop3_encode(c.opcode, kDstVgpr, SRC0_VGPR, SRC1_VGPR, SRC2_VGPR, words);
+      break;
+    }
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << c.name << ": decode failed";
+    auto out = fx.run(inst, rot, exec, vcc_in);
+    delete inst;
+    return out;
+  };
+
+  const size_t vcc_n = has_vcc_in ? std::size(kVccPatterns) : 1u;
+  for (size_t v = 0; v < vcc_n; ++v) {
+    uint64_t vcc_in = kVccPatterns[v];
+    for (uint32_t rot = 0; rot < kVals.size(); ++rot) {
+      const auto scalar_out = run_mode(/*force_scalar=*/true, vcc_in, rot);
+      const auto simd_out = run_mode(/*force_scalar=*/false, vcc_in, rot);
+
+      // Core A/B equivalence on the dst; for carry forms also the full 64-bit VCC.
+      EXPECT_EQ(scalar_out.dst, simd_out.dst)
+          << c.name << " vcc=0x" << std::hex << vcc_in << " rot=" << std::dec << rot
+          << ": SIMD dst diverged from scalar body";
+      if (has_vcc_in) {
+        EXPECT_EQ(scalar_out.vcc, simd_out.vcc)
+            << c.name << " vcc=0x" << std::hex << vcc_in << " rot=" << std::dec << rot
+            << ": SIMD VCC diverged from scalar body";
+      }
+
+      for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+        const bool active = (exec >> lane) & 1ULL;
+        if (!active) {
+          EXPECT_EQ(simd_out.dst[lane], DST_SENTINEL)
+              << c.name << " rot=" << rot << ": clobbered inactive lane " << lane;
+          EXPECT_EQ(scalar_out.dst[lane], DST_SENTINEL)
+              << c.name << " rot=" << rot << ": clobbered inactive lane " << lane;
+        }
+      }
+    }
+  }
+}
+
+TEST(VopAliasRdnaSimdCorrectness, FullExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_case(c, /*exec=*/0x00000000FFFFFFFFULL);
+}
+
+TEST(VopAliasRdnaSimdCorrectness, PartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_case(c, /*exec=*/0x00000000A5A5F0F1ULL);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vopc_cmp_class_scalar_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vopc_cmp_class_scalar_correctness_test.cpp
@@ -1,0 +1,157 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vopc_cmp_class_scalar_correctness_test.cpp
+/// @brief Regression test for the scalar v_cmp_class_{f16,f32,f64} bodies.
+/// v_cmp_class tests src0's IEEE float class against a 10-bit class mask in
+/// vsrc1 and writes one VCC bit per lane (1 if src0's class is selected). A
+/// prior codegen bug extracted the operand through a value-truncating round
+/// trip (`bit_cast<float>(static_cast<uint32_t>(<value>))`) and always
+/// classified in f32 precision, so e.g. the double 1.0 (0x3FF0000000000000)
+/// was mangled to a tiny f32 denormal and misclassified.
+///
+/// Each row pairs a representative bit pattern with the single class bit it
+/// must match. The op is run with mask = that bit (expect VCC set) and with
+/// mask = the other nine bits (expect VCC clear), so a misclassification in
+/// either direction is caught. f64 patterns all have a nonzero high word, so a
+/// low-word-only read or f32-precision classify fails the +normal/-normal rows.
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <memory>
+
+namespace {
+
+using namespace rocjitsu;
+
+[[maybe_unused]] constexpr uint32_t WF_SIZE = 64;
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+constexpr uint32_t CLASS_ALL = 0x3FFu; // all 10 class bits
+
+// VOPC: encoding[31:25]=0x3E, op[24:17], vsrc1[16:9], src0[8:0].
+constexpr uint32_t vopc_encode(uint32_t op, uint32_t src0, uint32_t vsrc1) {
+  return (0x3Eu << 25) | ((op & 0xFF) << 17) | ((vsrc1 & 0xFF) << 9) | (src0 & 0x1FF);
+}
+
+// The 10 IEEE float classes, low to high bit:
+// 0x001 sNaN, 0x002 qNaN, 0x004 -Inf, 0x008 -normal, 0x010 -denormal,
+// 0x020 -0, 0x040 +0, 0x080 +denormal, 0x100 +normal, 0x200 +Inf.
+struct ClassRow {
+  uint64_t bits; // src0 bit pattern (low 16/32 for f16/f32; full 64 for f64)
+  uint32_t class_bit;
+  const char *label;
+};
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("vopc_class_mem"), l2("vopc_class_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vopc_class", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  // src0 = v0[:v1], vsrc1 (mask) = v2. Returns VCC bit for lane 0.
+  bool run(uint32_t op, uint64_t src_bits, uint32_t mask, bool is_f64) {
+    uint32_t vb = wf->vgpr_alloc().base;
+    wf->set_exec(~0ULL);
+    wf->set_vcc(0);
+    cu->write_vgpr(vb + 0, 0, static_cast<uint32_t>(src_bits));
+    if (is_f64)
+      cu->write_vgpr(vb + 1, 0, static_cast<uint32_t>(src_bits >> 32));
+    cu->write_vgpr(vb + 2, 0, mask);
+    uint32_t enc = vopc_encode(op, /*src0=*/256, /*vsrc1=*/2);
+    uint32_t words[4] = {enc, 0u, 0u, 0u};
+    Instruction *inst = decoder->decode(words);
+    EXPECT_NE(inst, nullptr);
+    cu->execute_instruction(inst, *wf);
+    delete inst;
+    return (wf->vcc() >> 0) & 1ULL;
+  }
+};
+
+void check(uint32_t op, const std::array<ClassRow, 10> &rows, bool is_f64) {
+  Fixture fx;
+  ASSERT_NE(fx.cu, nullptr);
+  for (const auto &r : rows) {
+    // Matching its own class bit -> VCC set.
+    EXPECT_TRUE(fx.run(op, r.bits, r.class_bit, is_f64))
+        << r.label << ": expected match for class 0x" << std::hex << r.class_bit;
+    // The complement (other nine bits) -> VCC clear (each value is one class).
+    EXPECT_FALSE(fx.run(op, r.bits, CLASS_ALL & ~r.class_bit, is_f64))
+        << r.label << ": unexpected match against other classes";
+    // The full mask selects every class -> always set.
+    EXPECT_TRUE(fx.run(op, r.bits, CLASS_ALL, is_f64)) << r.label << ": full mask should match";
+  }
+}
+
+TEST(VopcCmpClassScalar, F32) {
+  const std::array<ClassRow, 10> rows = {{
+      {0x7F800001ull, 0x001, "sNaN"},
+      {0x7FC00000ull, 0x002, "qNaN"},
+      {0xFF800000ull, 0x004, "-Inf"},
+      {0xBF800000ull, 0x008, "-normal"},
+      {0x80000001ull, 0x010, "-denormal"},
+      {0x80000000ull, 0x020, "-0"},
+      {0x00000000ull, 0x040, "+0"},
+      {0x00000001ull, 0x080, "+denormal"},
+      {0x3F800000ull, 0x100, "+normal"},
+      {0x7F800000ull, 0x200, "+Inf"},
+  }};
+  check(/*v_cmp_class_f32=*/16, rows, /*is_f64=*/false);
+}
+
+TEST(VopcCmpClassScalar, F16) {
+  const std::array<ClassRow, 10> rows = {{
+      {0x7C01ull, 0x001, "sNaN"},
+      {0x7E00ull, 0x002, "qNaN"},
+      {0xFC00ull, 0x004, "-Inf"},
+      {0xBC00ull, 0x008, "-normal"},
+      {0x8001ull, 0x010, "-denormal"},
+      {0x8000ull, 0x020, "-0"},
+      {0x0000ull, 0x040, "+0"},
+      {0x0001ull, 0x080, "+denormal"},
+      {0x3C00ull, 0x100, "+normal"},
+      {0x7C00ull, 0x200, "+Inf"},
+  }};
+  check(/*v_cmp_class_f16=*/20, rows, /*is_f64=*/false);
+}
+
+TEST(VopcCmpClassScalar, F64) {
+  const std::array<ClassRow, 10> rows = {{
+      {0x7FF0000000000001ull, 0x001, "sNaN"},
+      {0x7FF8000000000000ull, 0x002, "qNaN"},
+      {0xFFF0000000000000ull, 0x004, "-Inf"},
+      {0xBFF0000000000000ull, 0x008, "-normal"}, // -1.0, nonzero high word
+      {0x8000000000000001ull, 0x010, "-denormal"},
+      {0x8000000000000000ull, 0x020, "-0"},
+      {0x0000000000000000ull, 0x040, "+0"},
+      {0x0000000000000001ull, 0x080, "+denormal"},
+      {0x3FF0000000000000ull, 0x100, "+normal"}, // 1.0, nonzero high word
+      {0x7FF0000000000000ull, 0x200, "+Inf"},
+  }};
+  check(/*v_cmp_class_f64=*/18, rows, /*is_f64=*/true);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vopc_cmp_class_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vopc_cmp_class_simd_correctness_test.cpp
@@ -1,0 +1,321 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vopc_cmp_class_simd_correctness_test.cpp
+/// @brief Bit-identity check (SIMD fast path vs scalar body) for the
+/// v_cmp_class VOPC ops on CDNA4. v_cmp_class tests src0's IEEE-754 float class
+/// against a 10-bit class mask in vsrc1 and writes one VCC bit per active lane;
+/// it is not a relational compare, so it uses a class-decode functor over the
+/// existing VOPC glue. Each case runs TWICE in the same process -- once forcing
+/// the scalar body, once the SIMD fast path, with identical inputs/EXEC/VCC-in
+/// -- and the full 64-bit VCC results are asserted equal with EXPECT_EQ
+/// (util::set_force_scalar_for_testing flips the gate in-process). In-process
+/// inactive-lane VCC bits must stay preserved under full and partial EXEC.
+///
+/// f16 and f32 read src0 as 32-bit raw bits; f64 reads src0 as a 64-bit VGPR pair
+/// while vsrc1 stays a 32-bit mask (the mixed-width class glue). The
+/// classification is pure bit decode (matching the scalar isnan/isnormal/signbit
+/// outcomes for every input incl. NaN payload), so the compare is bit-exact with
+/// no carve-out.
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t WF_SIZE = 64;
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+
+// VOPC: encoding[31:25]=0x3E, op[24:17], vsrc1[16:9], src0[8:0].
+constexpr uint32_t vopc_encode(uint32_t op, uint32_t src0, uint32_t vsrc1) {
+  return (0x3Eu << 25) | ((op & 0xFF) << 17) | ((vsrc1 & 0xFF) << 9) | (src0 & 0x1FF);
+}
+
+// VOP3 (encoding[31:26]=0x34): word0 = vdst[7:0] | abs[10:8] | op_sel[14:11] |
+// clamp[15] | op[25:16] | enc[31:26]; word1 = src0[8:0] | src1[17:9] | src2[26:18]
+// | omod[28:27] | neg[31:29]. abs/neg bit 0 select the src0 modifier. The class
+// result is written to the SGPR-pair dst — we point it at VCC (106) so the same
+// harness (set_vcc / read wf.vcc()) checks it.
+constexpr uint32_t kVccSdst = 106;
+void vop3_encode(uint32_t op, uint32_t vdst, uint32_t src0, uint32_t src1, uint32_t abs,
+                 uint32_t neg, uint32_t words[2]) {
+  words[0] = (vdst & 0xFF) | ((abs & 0x7) << 8) | ((op & 0x3FF) << 16) | (0x34u << 26);
+  words[1] = (src0 & 0x1FF) | ((src1 & 0x1FF) << 9) | ((neg & 0x7) << 29);
+}
+
+// One representative of each IEEE class (and a few extra normals). The negatives
+// of NaN confirm the sign bit does not affect the sNaN/qNaN classification.
+const std::array<uint32_t, 14> kF32 = {{
+    0x7FA00000u, // sNaN (+)
+    0x7FC00000u, // qNaN (+)
+    0xFF800000u, // -Inf
+    0xBF800000u, // -normal (-1)
+    0x80000001u, // -denormal
+    0x80000000u, // -0
+    0x00000000u, // +0
+    0x00000001u, // +denormal
+    0x3F800000u, // +normal (1)
+    0x7F800000u, // +Inf
+    0x40490FDBu, // +normal (pi)
+    0x7F7FFFFFu, // +normal (max)
+    0xFFA00000u, // sNaN (-)
+    0xFFC00000u, // qNaN (-)
+}};
+// Same classes as f16 in the low 16 bits, with garbage in the high half to
+// confirm both modes ignore it.
+const std::array<uint32_t, 14> kF16 = {{
+    0xDEAD7D00u, // sNaN (+)
+    0xDEAD7E00u, // qNaN (+)
+    0xDEADFC00u, // -Inf
+    0xDEADBC00u, // -normal (-1)
+    0xDEAD8001u, // -denormal
+    0xDEAD8000u, // -0
+    0xDEAD0000u, // +0
+    0xDEAD0001u, // +denormal
+    0xDEAD3C00u, // +normal (1)
+    0xDEAD7C00u, // +Inf
+    0xDEAD4248u, // +normal
+    0xDEAD7BFFu, // +normal (max)
+    0xDEADFD00u, // sNaN (-)
+    0xDEADFE00u, // qNaN (-)
+}};
+
+// One representative of each f64 class (and a few extra normals), same layout.
+const std::array<uint64_t, 14> kF64 = {{
+    0x7FF4000000000000ull, // sNaN (+)
+    0x7FF8000000000000ull, // qNaN (+)
+    0xFFF0000000000000ull, // -Inf
+    0xBFF0000000000000ull, // -normal (-1)
+    0x8000000000000001ull, // -denormal
+    0x8000000000000000ull, // -0
+    0x0000000000000000ull, // +0
+    0x0000000000000001ull, // +denormal
+    0x3FF0000000000000ull, // +normal (1)
+    0x7FF0000000000000ull, // +Inf
+    0x400921FB54442D18ull, // +normal (pi)
+    0x7FEFFFFFFFFFFFFFull, // +normal (max)
+    0xFFF4000000000000ull, // sNaN (-)
+    0xFFF8000000000000ull, // qNaN (-)
+}};
+
+// Class masks: each single class bit, all bits, none, and a few mixes.
+const std::array<uint32_t, 16> kMasks = {{
+    0x001u,
+    0x002u,
+    0x004u,
+    0x008u,
+    0x010u,
+    0x020u,
+    0x040u,
+    0x080u,
+    0x100u,
+    0x200u,
+    0x3FFu,
+    0x000u,
+    0x155u,
+    0x2AAu,
+    0x0C0u,
+    0x006u,
+}};
+
+enum class Kind { F16, F32, F64 };
+
+struct ClassCase {
+  const char *name;
+  uint32_t opcode;
+  Kind kind;
+};
+
+const std::array<ClassCase, 3> kCases = {{
+    {"v_cmp_class_f16", 20, Kind::F16},
+    {"v_cmp_class_f32", 16, Kind::F32},
+    {"v_cmp_class_f64", 18, Kind::F64},
+}};
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("vopc_class_simd_mem"), l2("vopc_class_simd_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vopc_class_simd", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  void write64(uint32_t reg, uint32_t lane, uint64_t v) {
+    cu->write_vgpr(reg, lane, static_cast<uint32_t>(v));
+    cu->write_vgpr(reg + 1, lane, static_cast<uint32_t>(v >> 32));
+  }
+
+  // src0 = value bits (v0, or v0:v1 for f64), vsrc1 = 32-bit class mask (v1, or v2
+  // for f64). Each lane gets a distinct (value, mask) pairing; the +rot shift
+  // sweeps the pairing across runs so every value meets every mask over the loop.
+  void seed_inputs(Kind k, uint32_t rot, uint64_t exec, uint64_t vcc_in) {
+    uint32_t vb = wf->vgpr_alloc().base;
+    const uint32_t mask_reg = (k == Kind::F64) ? 2u : 1u;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      if (k == Kind::F64) {
+        write64(vb + 0, lane, kF64[lane % kF64.size()]);
+      } else {
+        const auto &vals = (k == Kind::F16) ? kF16 : kF32;
+        cu->write_vgpr(vb + 0, lane, vals[lane % vals.size()]);
+      }
+      cu->write_vgpr(vb + mask_reg, lane, kMasks[(lane + rot) % kMasks.size()]);
+    }
+    wf->set_exec(exec);
+    wf->set_vcc(vcc_in);
+  }
+
+  uint64_t run(Instruction *inst, Kind k, uint32_t rot, uint64_t exec, uint64_t vcc_in) {
+    seed_inputs(k, rot, exec, vcc_in);
+    cu->execute_instruction(inst, *wf);
+    return wf->vcc();
+  }
+};
+
+// Restores the process force-scalar gate on scope exit so flipping it for an
+// in-process A/B comparison cannot leak into later tests in the same process.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+void check_all(uint64_t exec) {
+  ForceScalarGuard gate_guard;
+  const uint64_t kVcc[] = {0x0000000000000000ULL, 0xFFFFFFFFFFFFFFFFULL, 0xA5A5A5A5A5A5A5A5ULL};
+  for (const auto &c : kCases) {
+    auto run_mode = [&](bool force_scalar, uint32_t rot, uint64_t vcc_in) -> uint64_t {
+      util::set_force_scalar_for_testing(force_scalar);
+      Fixture fx;
+      EXPECT_NE(fx.cu, nullptr);
+      EXPECT_NE(fx.wf, nullptr);
+      uint32_t vsrc1 = (c.kind == Kind::F64) ? 2u : 1u; // f64 src0 spans v0:v1
+      uint32_t enc = vopc_encode(c.opcode, /*src0=*/256, vsrc1);
+      uint32_t words[4] = {enc, 0u, 0u, 0u};
+      Instruction *inst = fx.decoder->decode(words);
+      EXPECT_NE(inst, nullptr) << c.name << " decode failed";
+      uint64_t vcc = fx.run(inst, c.kind, rot, exec, vcc_in);
+      delete inst;
+      return vcc;
+    };
+    for (uint32_t rot = 0; rot < kMasks.size(); ++rot) {
+      for (uint64_t vcc_in : kVcc) {
+        const uint64_t scalar_vcc = run_mode(/*force_scalar=*/true, rot, vcc_in);
+        const uint64_t simd_vcc = run_mode(/*force_scalar=*/false, rot, vcc_in);
+
+        EXPECT_EQ(scalar_vcc, simd_vcc) << c.name << " rot=" << rot << " vcc_in=0x" << std::hex
+                                        << vcc_in << ": SIMD VCC diverged from scalar body";
+
+        const uint64_t inactive = ~exec;
+        EXPECT_EQ(simd_vcc & inactive, vcc_in & inactive)
+            << c.name << " rot=" << rot << ": altered an inactive-lane VCC bit";
+        EXPECT_EQ(scalar_vcc & inactive, vcc_in & inactive)
+            << c.name << " rot=" << rot << ": altered an inactive-lane VCC bit";
+      }
+    }
+  }
+}
+
+// VOP3 forms: same classification, plus the abs/neg src0 modifiers, mask read
+// from src1, and an SGPR-pair (VCC here) dst. Swept over all four abs/neg combos.
+struct Vop3ClassCase {
+  const char *name;
+  uint32_t opcode;
+  Kind kind;
+};
+
+const std::array<Vop3ClassCase, 3> kVop3Cases = {{
+    {"v_cmp_class_f16_e64", 20, Kind::F16},
+    {"v_cmp_class_f32_e64", 16, Kind::F32},
+    {"v_cmp_class_f64_e64", 18, Kind::F64},
+}};
+
+void check_all_vop3(uint64_t exec) {
+  ForceScalarGuard gate_guard;
+  const uint64_t kVcc[] = {0x0000000000000000ULL, 0xFFFFFFFFFFFFFFFFULL, 0xA5A5A5A5A5A5A5A5ULL};
+  for (const auto &c : kVop3Cases) {
+    const uint32_t src1 = 256u + ((c.kind == Kind::F64) ? 2u : 1u); // mask vgpr
+    for (uint32_t abs = 0; abs <= 1; ++abs) {
+      for (uint32_t neg = 0; neg <= 1; ++neg) {
+        auto run_mode = [&](bool force_scalar, uint32_t rot, uint64_t vcc_in) -> uint64_t {
+          util::set_force_scalar_for_testing(force_scalar);
+          Fixture fx;
+          EXPECT_NE(fx.cu, nullptr);
+          EXPECT_NE(fx.wf, nullptr);
+          uint32_t words[4] = {0u, 0u, 0u, 0u};
+          vop3_encode(c.opcode, /*vdst=*/kVccSdst, /*src0=*/256, src1, abs, neg, words);
+          Instruction *inst = fx.decoder->decode(words);
+          EXPECT_NE(inst, nullptr) << c.name << " decode failed";
+          uint64_t vcc = fx.run(inst, c.kind, rot, exec, vcc_in);
+          delete inst;
+          return vcc;
+        };
+        for (uint32_t rot = 0; rot < kMasks.size(); ++rot) {
+          for (uint64_t vcc_in : kVcc) {
+            const uint64_t scalar_vcc = run_mode(/*force_scalar=*/true, rot, vcc_in);
+            const uint64_t simd_vcc = run_mode(/*force_scalar=*/false, rot, vcc_in);
+
+            EXPECT_EQ(scalar_vcc, simd_vcc)
+                << c.name << " abs=" << abs << " neg=" << neg << " rot=" << rot << " vcc_in=0x"
+                << std::hex << vcc_in << ": SIMD VCC diverged from scalar body";
+
+            const uint64_t inactive = ~exec;
+            EXPECT_EQ(simd_vcc & inactive, vcc_in & inactive)
+                << c.name << " abs=" << abs << " neg=" << neg << ": altered inactive VCC bit";
+            EXPECT_EQ(scalar_vcc & inactive, vcc_in & inactive)
+                << c.name << " abs=" << abs << " neg=" << neg << ": altered inactive VCC bit";
+          }
+        }
+      }
+    }
+  }
+}
+
+TEST(VopcCmpClassSimdCorrectness, FullExecMask) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  check_all(/*exec=*/~0ULL);
+  check_all_vop3(/*exec=*/~0ULL);
+}
+
+TEST(VopcCmpClassSimdCorrectness, PartialExecMask) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  check_all(/*exec=*/0xA5A5'F0F0'1234'8001ULL);
+  check_all_vop3(/*exec=*/0xA5A5'F0F0'1234'8001ULL);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vopc_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vopc_simd_correctness_test.cpp
@@ -1,0 +1,227 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vopc_simd_correctness_test.cpp
+/// @brief Bit-identity check (SIMD fast path vs scalar body) for the VOPC
+/// compares wired into SIMD_VOPC / SIMD_VOPC64: the f32/f16/f64 relations
+/// (eq/ge/gt/le/lg/lt/neq/nge/ngt/nle/nlg/nlt/o/u/f/tru) and the
+/// i32/u32/i16/u16/i64/u64 relations (eq/ge/gt/le/lt/ne/f/t). Each writes one bit
+/// per active EXEC lane into VCC, preserving inactive bits. Each (opcode,
+/// vcc_in) runs TWICE in the same process -- once forcing the scalar body, once
+/// the SIMD fast path, with identical inputs/EXEC/VCC-in -- and the full 64-bit
+/// VCC compare results are asserted equal with EXPECT_EQ
+/// (util::set_force_scalar_for_testing flips the gate in-process). In-process
+/// inactive-lane VCC bits must stay
+/// preserved under full and partial EXEC. The 64-bit relations exercise the
+/// split lo/hi VGPR-pair read path. Inputs seed NaN/±Inf/±0/denorm (floats) and
+/// signed/extreme boundaries (ints); float compares are bit-exact in both modes.
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t WF_SIZE = 64;
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+
+// VOPC: encoding[31:25]=0x3E, op[24:17], vsrc1[16:9], src0[8:0].
+constexpr uint32_t vopc_encode(uint32_t op, uint32_t src0, uint32_t vsrc1) {
+  return (0x3Eu << 25) | ((op & 0xFF) << 17) | ((vsrc1 & 0xFF) << 9) | (src0 & 0x1FF);
+}
+
+enum class Kind { F32, F16, INT32, F64, INT64 };
+
+bool is_64bit(Kind k) { return k == Kind::F64 || k == Kind::INT64; }
+
+// 32-bit edge sets ----------------------------------------------------------
+// f32: ±0, ±1, ±Inf, NaN, denorm, pi, max.
+const std::array<uint32_t, 10> kF32 = {{0x00000000u, 0x80000000u, 0x3F800000u, 0xBF800000u,
+                                        0x7F800000u, 0xFF800000u, 0x7FC00000u, 0x00000001u,
+                                        0x40490FDBu, 0x7F7FFFFFu}};
+// f16 in the low 16 bits; high bits garbage to confirm both modes ignore them.
+const std::array<uint32_t, 10> kF16 = {{0xDEAD0000u, 0xDEAD8000u, 0xDEAD3C00u, 0xDEADBC00u,
+                                        0xDEAD7C00u, 0xDEADFC00u, 0xDEAD7E00u, 0xDEAD0001u,
+                                        0xDEAD4248u, 0xDEAD7BFFu}};
+// integer edges (i32/u32 directly, low 16 for i16/u16).
+const std::array<uint32_t, 10> kInt32 = {{0x00000000u, 0x00000001u, 0xFFFFFFFFu, 0x7FFFFFFFu,
+                                          0x80000000u, 0x0000FFFFu, 0x00008000u, 0x00007FFFu,
+                                          0x12345678u, 0xAAAA5555u}};
+
+// 64-bit edge sets ----------------------------------------------------------
+// f64: ±0, ±1, ±Inf, NaN, denorm, pi, max.
+const std::array<uint64_t, 10> kF64 = {
+    {0x0000000000000000ull, 0x8000000000000000ull, 0x3FF0000000000000ull, 0xBFF0000000000000ull,
+     0x7FF0000000000000ull, 0xFFF0000000000000ull, 0x7FF8000000000000ull, 0x0000000000000001ull,
+     0x400921FB54442D18ull, 0x7FEFFFFFFFFFFFFFull}};
+// integer edges (i64/u64).
+const std::array<uint64_t, 10> kInt64 = {
+    {0x0000000000000000ull, 0x0000000000000001ull, 0xFFFFFFFFFFFFFFFFull, 0x7FFFFFFFFFFFFFFFull,
+     0x8000000000000000ull, 0x00000000FFFFFFFFull, 0x0000000080000000ull, 0x000000007FFFFFFFull,
+     0x123456789ABCDEF0ull, 0xAAAAAAAA55555555ull}};
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("vopc_simd_mem"), l2("vopc_simd_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vopc_simd", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  void write64(uint32_t reg, uint32_t lane, uint64_t v) {
+    cu->write_vgpr(reg, lane, static_cast<uint32_t>(v));
+    cu->write_vgpr(reg + 1, lane, static_cast<uint32_t>(v >> 32));
+  }
+
+  // Seed src0 / vsrc1 with all ordered pairs of the kind's edge set across the
+  // lanes (a deterministic 10x10 grid, exercising both operand orders). For
+  // 32-bit kinds src0=v0, vsrc1=v1; for 64-bit kinds src0=v0:v1, vsrc1=v2:v3.
+  void seed_inputs(Kind k, uint64_t exec, uint64_t vcc_in) {
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      uint32_t i = lane % 10;
+      uint32_t j = (lane / 10 + lane) % 10;
+      if (is_64bit(k)) {
+        const auto &e = (k == Kind::F64) ? kF64 : kInt64;
+        write64(vb + 0, lane, e[i]);
+        write64(vb + 2, lane, e[j]);
+      } else {
+        const auto &e = (k == Kind::F32) ? kF32 : (k == Kind::F16) ? kF16 : kInt32;
+        cu->write_vgpr(vb + 0, lane, e[i]);
+        cu->write_vgpr(vb + 1, lane, e[j]);
+      }
+    }
+    wf->set_exec(exec);
+    wf->set_vcc(vcc_in);
+  }
+
+  uint64_t run(Instruction *inst, Kind k, uint64_t exec, uint64_t vcc_in) {
+    seed_inputs(k, exec, vcc_in);
+    cu->execute_instruction(inst, *wf);
+    return wf->vcc();
+  }
+};
+
+struct VopcCase {
+  uint32_t opcode;
+  Kind kind;
+};
+
+// Build the full case list from the regular opcode layout. Float blocks (f16
+// base 32, f32 base 64, f64 base 96): 16 relations at offsets 0..15. Integer
+// blocks (i16 160, u16 168, i32 192, u32 200, i64 224, u64 232): 8 relations at
+// offsets 0..7.
+std::vector<VopcCase> all_cases() {
+  std::vector<VopcCase> cs;
+  for (auto [base, k] : std::initializer_list<std::pair<uint32_t, Kind>>{
+           {32u, Kind::F16}, {64u, Kind::F32}, {96u, Kind::F64}})
+    for (uint32_t off = 0; off < 16; ++off)
+      cs.push_back({base + off, k});
+  for (auto [base, k] : std::initializer_list<std::pair<uint32_t, Kind>>{{160u, Kind::INT32},
+                                                                         {168u, Kind::INT32},
+                                                                         {192u, Kind::INT32},
+                                                                         {200u, Kind::INT32},
+                                                                         {224u, Kind::INT64},
+                                                                         {232u, Kind::INT64}})
+    for (uint32_t off = 0; off < 8; ++off)
+      cs.push_back({base + off, k});
+  return cs;
+}
+
+// Restores the process force-scalar gate on scope exit so flipping it for an
+// in-process A/B comparison cannot leak into later tests in the same process.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+void check_all(uint64_t exec) {
+  ForceScalarGuard gate_guard;
+
+  const uint64_t kVcc[] = {0x0000000000000000ULL, 0xFFFFFFFFFFFFFFFFULL, 0xA5A5A5A5A5A5A5A5ULL};
+
+  // Runs one (case, vcc_in) in the requested execute mode (fresh Fixture +
+  // decode per run isolates VGPR/VCC state).
+  auto run_mode = [&](bool force_scalar, const VopcCase &c, uint64_t vcc_in) -> uint64_t {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    // 64-bit operands span a VGPR pair: vsrc1 = v2:v3, else vsrc1 = v1.
+    uint32_t vsrc1 = is_64bit(c.kind) ? 2u : 1u;
+    uint32_t enc = vopc_encode(c.opcode, /*src0=*/256, vsrc1);
+    uint32_t words[4] = {enc, 0u, 0u, 0u};
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << "VOPC opcode " << c.opcode << " decode failed";
+    uint64_t vcc = fx.run(inst, c.kind, exec, vcc_in);
+    delete inst;
+    return vcc;
+  };
+
+  for (const auto &c : all_cases()) {
+    for (uint64_t vcc_in : kVcc) {
+      const uint64_t scalar_vcc = run_mode(/*force_scalar=*/true, c, vcc_in);
+      const uint64_t simd_vcc = run_mode(/*force_scalar=*/false, c, vcc_in);
+
+      // Core A/B equivalence on the full 64-bit VCC compare result.
+      EXPECT_EQ(scalar_vcc, simd_vcc) << "VOPC opcode " << c.opcode << " vcc_in=0x" << std::hex
+                                      << vcc_in << ": SIMD VCC diverged from scalar body";
+
+      const uint64_t inactive = ~exec;
+      EXPECT_EQ(simd_vcc & inactive, vcc_in & inactive)
+          << "VOPC opcode " << c.opcode << ": altered an inactive-lane VCC bit";
+      EXPECT_EQ(scalar_vcc & inactive, vcc_in & inactive)
+          << "VOPC opcode " << c.opcode << ": altered an inactive-lane VCC bit";
+    }
+  }
+}
+
+TEST(VopcSimdCorrectness, FullExecMask) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  check_all(/*exec=*/~0ULL);
+}
+
+TEST(VopcSimdCorrectness, PartialExecMask) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  // Alternating/sparse pattern crossing the SIMD chunk boundaries (16-wide for
+  // 32-bit lanes, 8-wide for 64-bit).
+  check_all(/*exec=*/0xA5A5'F0F0'1234'8001ULL);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vopc_vop3_fp16_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vopc_vop3_fp16_simd_correctness_test.cpp
@@ -1,0 +1,202 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vopc_vop3_fp16_simd_correctness_test.cpp
+/// @brief Bit-identity check (SIMD fast path vs scalar body) for the VOP3 form
+/// of the f16 VOPC relational compares on CDNA4. The scalar body widens each f16
+/// src to f32 (util::f16_to_f32) then applies abs/neg in the f32 domain before
+/// comparing; the SIMD glue mirrors that order. The compare result merges into
+/// an SGPR-pair dst (pointed at VCC=106 here so the same harness reads via
+/// wf.vcc()). The process runs one fixed execute mode (RJ_FORCE_SCALAR,
+/// immutable); each (case, abs, neg, rot, vcc_in) runs TWICE in the same process
+/// -- once forcing the scalar body, once the SIMD fast path, with identical
+/// inputs/EXEC/VCC-in -- and the 64-bit compare results are asserted equal with
+/// EXPECT_EQ (util::set_force_scalar_for_testing flips the gate in-process).
+/// In-process inactive SGPR-pair bits must be preserved.
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include "util/simd.h"
+
+#include <array>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t WF_SIZE = 64;
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+constexpr uint32_t kVccSdst = 106;
+
+constexpr void vop3_cmp_encode(uint32_t op, uint32_t vdst, uint32_t src0, uint32_t src1,
+                               uint32_t abs, uint32_t neg, uint32_t words[2]) {
+  words[0] = (vdst & 0xFF) | ((abs & 0x7) << 8) | ((op & 0x3FF) << 16) | (0x34u << 26);
+  words[1] = (src0 & 0x1FF) | ((src1 & 0x1FF) << 9) | ((neg & 0x7) << 29);
+}
+
+struct Case {
+  const char *name;
+  uint32_t opcode;
+};
+
+const std::array<Case, 16> kCases = {{
+    {"v_cmp_f_f16_vop3", 32},
+    {"v_cmp_lt_f16_vop3", 33},
+    {"v_cmp_eq_f16_vop3", 34},
+    {"v_cmp_le_f16_vop3", 35},
+    {"v_cmp_gt_f16_vop3", 36},
+    {"v_cmp_lg_f16_vop3", 37},
+    {"v_cmp_ge_f16_vop3", 38},
+    {"v_cmp_o_f16_vop3", 39},
+    {"v_cmp_u_f16_vop3", 40},
+    {"v_cmp_nge_f16_vop3", 41},
+    {"v_cmp_nlg_f16_vop3", 42},
+    {"v_cmp_ngt_f16_vop3", 43},
+    {"v_cmp_nle_f16_vop3", 44},
+    {"v_cmp_neq_f16_vop3", 45},
+    {"v_cmp_nlt_f16_vop3", 46},
+    {"v_cmp_tru_f16_vop3", 47},
+}};
+
+// Mixed f16 inputs (low 16 bits = f16 bits; high 16 bits intentionally garbage
+// to confirm both modes ignore them). Covers every IEEE-754 binary16 class plus
+// ±0 / ±1 / ±max so abs/neg sign flips exercise real boundary pairs.
+const std::array<uint32_t, 14> kF16 = {{
+    0xDEAD0000u, // +0
+    0xDEAD8000u, // -0
+    0xDEAD3C00u, // +1
+    0xDEADBC00u, // -1
+    0xDEAD4248u, // +pi (approx)
+    0xDEADC248u, // -pi
+    0xDEAD7C00u, // +Inf
+    0xDEADFC00u, // -Inf
+    0xDEAD7E00u, // +qNaN
+    0xDEADFD00u, // -sNaN
+    0xDEAD0001u, // +denormal
+    0xDEAD8001u, // -denormal
+    0xDEAD7BFFu, // +max
+    0xDEADFBFFu, // -max
+}};
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("vopc_vop3_fp16_mem"), l2("vopc_vop3_fp16_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vopc_vop3_fp16", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  void seed_inputs(uint32_t rot, uint64_t exec, uint64_t vcc_in) {
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      cu->write_vgpr(vb + 0, lane, kF16[lane % kF16.size()]);
+      cu->write_vgpr(vb + 1, lane, kF16[(lane + rot) % kF16.size()]);
+    }
+    wf->set_exec(exec);
+    wf->set_vcc(vcc_in);
+  }
+
+  uint64_t run(Instruction *inst, uint32_t rot, uint64_t exec, uint64_t vcc_in) {
+    seed_inputs(rot, exec, vcc_in);
+    cu->execute_instruction(inst, *wf);
+    return wf->vcc();
+  }
+};
+
+// Restores the process force-scalar gate on scope exit so flipping it for an
+// in-process A/B comparison cannot leak into later tests in the same process.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+void check_case(const Case &c, uint64_t exec) {
+  ForceScalarGuard gate_guard;
+
+  // Runs one (case, abs, neg, rot, vcc_in) in the requested execute mode (fresh
+  // Fixture + decode per run isolates VGPR/VCC state).
+  auto run_mode = [&](bool force_scalar, uint32_t abs, uint32_t neg, uint32_t rot,
+                      uint64_t vcc_in) -> uint64_t {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    uint32_t words[4] = {0u, 0u, 0u, 0u};
+    vop3_cmp_encode(c.opcode, /*vdst=*/kVccSdst, /*src0=*/256, /*src1=*/257, abs, neg, words);
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << c.name << " decode failed (abs=" << abs << " neg=" << neg << ")";
+    uint64_t vcc = fx.run(inst, rot, exec, vcc_in);
+    delete inst;
+    return vcc;
+  };
+
+  const uint64_t kVcc[] = {0x0000000000000000ULL, 0xFFFFFFFFFFFFFFFFULL, 0xA5A5A5A5A5A5A5A5ULL};
+  for (uint32_t abs = 0; abs < 4; ++abs) {
+    for (uint32_t neg = 0; neg < 4; ++neg) {
+      for (uint32_t rot = 0; rot < kF16.size(); ++rot) {
+        for (uint64_t vcc_in : kVcc) {
+          const uint64_t scalar_vcc = run_mode(/*force_scalar=*/true, abs, neg, rot, vcc_in);
+          const uint64_t simd_vcc = run_mode(/*force_scalar=*/false, abs, neg, rot, vcc_in);
+
+          EXPECT_EQ(scalar_vcc, simd_vcc)
+              << c.name << " abs=" << abs << " neg=" << neg << " rot=" << rot << " vcc_in=0x"
+              << std::hex << vcc_in << ": SIMD result diverged from scalar body";
+
+          const uint64_t inactive = ~exec;
+          EXPECT_EQ(simd_vcc & inactive, vcc_in & inactive)
+              << c.name << " abs=" << abs << " neg=" << neg << " rot=" << rot
+              << ": altered inactive-lane dst bit";
+          EXPECT_EQ(scalar_vcc & inactive, vcc_in & inactive)
+              << c.name << " abs=" << abs << " neg=" << neg << " rot=" << rot
+              << ": altered inactive-lane dst bit";
+        }
+      }
+    }
+  }
+}
+
+TEST(VopcVop3Fp16SimdCorrectness, FullExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_case(c, /*exec=*/~0ULL);
+}
+
+TEST(VopcVop3Fp16SimdCorrectness, PartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_case(c, /*exec=*/0xA5A5'F0F0'1234'8001ULL);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vopc_vop3_fp32_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vopc_vop3_fp32_simd_correctness_test.cpp
@@ -1,0 +1,210 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vopc_vop3_fp32_simd_correctness_test.cpp
+/// @brief Bit-identity check (SIMD fast path vs scalar body) for the VOP3 form
+/// of the f32 VOPC relational compares on CDNA4. The VOP3 form reads src0/src1
+/// with per-source abs/neg modifiers (std::fabs then unary minus, applied to the
+/// f32 value before comparing) and writes the per-lane compare result into an
+/// arbitrary SGPR-pair dst via inst.vdst.read/write_scalar64 instead of the
+/// fixed VCC. We point the SGPR-pair at VCC (106) so the same harness reads the
+/// result via wf.vcc(). Each (case, abs, neg, rot, vcc_in) runs TWICE in the
+/// same process -- once forcing the scalar body, once the SIMD fast path, with
+/// identical inputs/EXEC/VCC-in -- and the 64-bit compare results are asserted
+/// equal with EXPECT_EQ (util::set_force_scalar_for_testing flips the gate
+/// in-process). In-process inactive SGPR-pair bits must be preserved.
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include "util/simd.h"
+
+#include <array>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t WF_SIZE = 64;
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+constexpr uint32_t kVccSdst = 106;
+
+// VOP3 ([31:26]=0x34): word0 = vdst[7:0] | abs[10:8] | clamp[15] | op[25:16] |
+// enc[31:26]; word1 = src0[8:0] | src1[17:9] | omod[28:27] | neg[31:29]. The
+// compare result is a single bit, so omod/clamp are irrelevant and stay zero.
+constexpr void vop3_cmp_encode(uint32_t op, uint32_t vdst, uint32_t src0, uint32_t src1,
+                               uint32_t abs, uint32_t neg, uint32_t words[2]) {
+  words[0] = (vdst & 0xFF) | ((abs & 0x7) << 8) | ((op & 0x3FF) << 16) | (0x34u << 26);
+  words[1] = (src0 & 0x1FF) | ((src1 & 0x1FF) << 9) | ((neg & 0x7) << 29);
+}
+
+struct Case {
+  const char *name;
+  uint32_t opcode;
+};
+
+// 16 cdna4-decodable f32 VOP3 cmp relations (the 17th, 'v_cmp_t_f32_vop3',
+// has no cdna4 decoder entry — RDNA-only — so it's omitted here even though
+// the SIMD probe is still injected for cross-ISA shared correctness).
+const std::array<Case, 16> kCases = {{
+    {"v_cmp_f_f32_vop3", 64},
+    {"v_cmp_lt_f32_vop3", 65},
+    {"v_cmp_eq_f32_vop3", 66},
+    {"v_cmp_le_f32_vop3", 67},
+    {"v_cmp_gt_f32_vop3", 68},
+    {"v_cmp_lg_f32_vop3", 69},
+    {"v_cmp_ge_f32_vop3", 70},
+    {"v_cmp_o_f32_vop3", 71},
+    {"v_cmp_u_f32_vop3", 72},
+    {"v_cmp_nge_f32_vop3", 73},
+    {"v_cmp_nlg_f32_vop3", 74},
+    {"v_cmp_ngt_f32_vop3", 75},
+    {"v_cmp_nle_f32_vop3", 76},
+    {"v_cmp_neq_f32_vop3", 77},
+    {"v_cmp_nlt_f32_vop3", 78},
+    {"v_cmp_tru_f32_vop3", 79},
+}};
+
+// Mixed f32 inputs covering every IEEE class plus equality / ordering /
+// signed-zero edge pairs. f32 compares produce a single bit, so NaN payloads
+// don't propagate — pairing a value with itself, with its negative, and with
+// neighbouring normals fires every relation. The abs/neg modifiers act on the
+// sign bit, so include both polarities of every value.
+const std::array<uint32_t, 14> kF32 = {{
+    0x00000000u, // +0
+    0x80000000u, // -0
+    0x3F800000u, // +1
+    0xBF800000u, // -1
+    0x40490FDBu, // +pi
+    0xC0490FDBu, // -pi
+    0x7F800000u, // +Inf
+    0xFF800000u, // -Inf
+    0x7FC00000u, // +qNaN
+    0xFFA00000u, // -sNaN
+    0x00000001u, // +denormal
+    0x80000001u, // -denormal
+    0x7F7FFFFFu, // +max
+    0xFF7FFFFFu, // -max
+}};
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("vopc_vop3_fp32_mem"), l2("vopc_vop3_fp32_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vopc_vop3_fp32", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  void seed_inputs(uint32_t rot, uint64_t exec, uint64_t vcc_in) {
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      cu->write_vgpr(vb + 0, lane, kF32[lane % kF32.size()]);
+      cu->write_vgpr(vb + 1, lane, kF32[(lane + rot) % kF32.size()]);
+    }
+    wf->set_exec(exec);
+    wf->set_vcc(vcc_in);
+  }
+
+  uint64_t run(Instruction *inst, uint32_t rot, uint64_t exec, uint64_t vcc_in) {
+    seed_inputs(rot, exec, vcc_in);
+    cu->execute_instruction(inst, *wf);
+    return wf->vcc();
+  }
+};
+
+// Restores the process force-scalar gate on scope exit so flipping it for an
+// in-process A/B comparison cannot leak into later tests in the same process.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+void check_case(const Case &c, uint64_t exec) {
+  ForceScalarGuard gate_guard;
+
+  // Runs one (case, abs, neg, rot, vcc_in) in the requested execute mode (fresh
+  // Fixture + decode per run isolates VGPR/VCC state).
+  auto run_mode = [&](bool force_scalar, uint32_t abs, uint32_t neg, uint32_t rot,
+                      uint64_t vcc_in) -> uint64_t {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    uint32_t words[4] = {0u, 0u, 0u, 0u};
+    vop3_cmp_encode(c.opcode, /*vdst=*/kVccSdst, /*src0=*/256, /*src1=*/257, abs, neg, words);
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << c.name << " decode failed (abs=" << abs << " neg=" << neg << ")";
+    uint64_t vcc = fx.run(inst, rot, exec, vcc_in);
+    delete inst;
+    return vcc;
+  };
+
+  const uint64_t kVcc[] = {0x0000000000000000ULL, 0xFFFFFFFFFFFFFFFFULL, 0xA5A5A5A5A5A5A5A5ULL};
+  for (uint32_t abs = 0; abs < 4; ++abs) { // bits 0,1 = src0,src1 abs
+    for (uint32_t neg = 0; neg < 4; ++neg) {
+      for (uint32_t rot = 0; rot < kF32.size(); ++rot) {
+        for (uint64_t vcc_in : kVcc) {
+          const uint64_t scalar_vcc = run_mode(/*force_scalar=*/true, abs, neg, rot, vcc_in);
+          const uint64_t simd_vcc = run_mode(/*force_scalar=*/false, abs, neg, rot, vcc_in);
+
+          EXPECT_EQ(scalar_vcc, simd_vcc)
+              << c.name << " abs=" << abs << " neg=" << neg << " rot=" << rot << " vcc_in=0x"
+              << std::hex << vcc_in << ": SIMD result diverged from scalar body";
+
+          const uint64_t inactive = ~exec;
+          EXPECT_EQ(simd_vcc & inactive, vcc_in & inactive)
+              << c.name << " abs=" << abs << " neg=" << neg << " rot=" << rot
+              << ": altered inactive-lane dst bit";
+          EXPECT_EQ(scalar_vcc & inactive, vcc_in & inactive)
+              << c.name << " abs=" << abs << " neg=" << neg << " rot=" << rot
+              << ": altered inactive-lane dst bit";
+        }
+      }
+    }
+  }
+}
+
+TEST(VopcVop3Fp32SimdCorrectness, FullExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_case(c, /*exec=*/~0ULL);
+}
+
+TEST(VopcVop3Fp32SimdCorrectness, PartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_case(c, /*exec=*/0xA5A5'F0F0'1234'8001ULL);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vopc_vop3_fp64_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vopc_vop3_fp64_simd_correctness_test.cpp
@@ -1,0 +1,207 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vopc_vop3_fp64_simd_correctness_test.cpp
+/// @brief Bit-identity check (SIMD fast path vs scalar body) for the VOP3 form
+/// of the f64 VOPC relational compares on CDNA4. 64-bit-lane counterpart of the
+/// f32 path: read src0/src1 as native<double> via the split lo/hi VGPR-pair
+/// path, apply abs/neg in the f64 domain, compare. Result merges into an
+/// SGPR-pair dst (pointed at VCC=106 here so the same harness reads via
+/// wf.vcc()). The process runs one fixed execute mode (RJ_FORCE_SCALAR,
+/// immutable); each (case, abs, neg, rot, vcc_in) runs TWICE in the same process
+/// -- once forcing the scalar body, once the SIMD fast path, with identical
+/// inputs/EXEC/VCC-in -- and the 64-bit compare results are asserted equal with
+/// EXPECT_EQ (util::set_force_scalar_for_testing flips the gate in-process).
+/// In-process inactive SGPR-pair bits must be preserved.
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include "util/simd.h"
+
+#include <array>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t WF_SIZE = 64;
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+constexpr uint32_t kVccSdst = 106;
+
+constexpr void vop3_cmp_encode(uint32_t op, uint32_t vdst, uint32_t src0, uint32_t src1,
+                               uint32_t abs, uint32_t neg, uint32_t words[2]) {
+  words[0] = (vdst & 0xFF) | ((abs & 0x7) << 8) | ((op & 0x3FF) << 16) | (0x34u << 26);
+  words[1] = (src0 & 0x1FF) | ((src1 & 0x1FF) << 9) | ((neg & 0x7) << 29);
+}
+
+struct Case {
+  const char *name;
+  uint32_t opcode;
+};
+
+const std::array<Case, 16> kCases = {{
+    {"v_cmp_f_f64_vop3", 96},
+    {"v_cmp_lt_f64_vop3", 97},
+    {"v_cmp_eq_f64_vop3", 98},
+    {"v_cmp_le_f64_vop3", 99},
+    {"v_cmp_gt_f64_vop3", 100},
+    {"v_cmp_lg_f64_vop3", 101},
+    {"v_cmp_ge_f64_vop3", 102},
+    {"v_cmp_o_f64_vop3", 103},
+    {"v_cmp_u_f64_vop3", 104},
+    {"v_cmp_nge_f64_vop3", 105},
+    {"v_cmp_nlg_f64_vop3", 106},
+    {"v_cmp_ngt_f64_vop3", 107},
+    {"v_cmp_nle_f64_vop3", 108},
+    {"v_cmp_neq_f64_vop3", 109},
+    {"v_cmp_nlt_f64_vop3", 110},
+    {"v_cmp_tru_f64_vop3", 111},
+}};
+
+// f64 IEEE classes + ±0 / ±1 / ±max / ±denormal so abs/neg sign flips exercise
+// real boundary pairs. NaN payloads don't propagate through compares.
+const std::array<uint64_t, 14> kF64 = {{
+    0x0000000000000000ull, // +0
+    0x8000000000000000ull, // -0
+    0x3FF0000000000000ull, // +1
+    0xBFF0000000000000ull, // -1
+    0x400921FB54442D18ull, // +pi
+    0xC00921FB54442D18ull, // -pi
+    0x7FF0000000000000ull, // +Inf
+    0xFFF0000000000000ull, // -Inf
+    0x7FF8000000000000ull, // +qNaN
+    0xFFF4000000000000ull, // -sNaN
+    0x0000000000000001ull, // +denormal
+    0x8000000000000001ull, // -denormal
+    0x7FEFFFFFFFFFFFFFull, // +max
+    0xFFEFFFFFFFFFFFFFull, // -max
+}};
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("vopc_vop3_fp64_mem"), l2("vopc_vop3_fp64_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vopc_vop3_fp64", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  void write64(uint32_t reg, uint32_t lane, uint64_t v) {
+    cu->write_vgpr(reg, lane, static_cast<uint32_t>(v));
+    cu->write_vgpr(reg + 1, lane, static_cast<uint32_t>(v >> 32));
+  }
+
+  // src0 = v0:v1, src1 = v2:v3. +rot sweeps pairing across kF64.
+  void seed_inputs(uint32_t rot, uint64_t exec, uint64_t vcc_in) {
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      write64(vb + 0, lane, kF64[lane % kF64.size()]);
+      write64(vb + 2, lane, kF64[(lane + rot) % kF64.size()]);
+    }
+    wf->set_exec(exec);
+    wf->set_vcc(vcc_in);
+  }
+
+  uint64_t run(Instruction *inst, uint32_t rot, uint64_t exec, uint64_t vcc_in) {
+    seed_inputs(rot, exec, vcc_in);
+    cu->execute_instruction(inst, *wf);
+    return wf->vcc();
+  }
+};
+
+// Restores the process force-scalar gate on scope exit so flipping it for an
+// in-process A/B comparison cannot leak into later tests in the same process.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+void check_case(const Case &c, uint64_t exec) {
+  ForceScalarGuard gate_guard;
+
+  // Runs one (case, abs, neg, rot, vcc_in) in the requested execute mode (fresh
+  // Fixture + decode per run isolates VGPR/VCC state).
+  auto run_mode = [&](bool force_scalar, uint32_t abs, uint32_t neg, uint32_t rot,
+                      uint64_t vcc_in) -> uint64_t {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    uint32_t words[4] = {0u, 0u, 0u, 0u};
+    vop3_cmp_encode(c.opcode, /*vdst=*/kVccSdst, /*src0=*/256, /*src1=*/258, abs, neg, words);
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << c.name << " decode failed (abs=" << abs << " neg=" << neg << ")";
+    uint64_t vcc = fx.run(inst, rot, exec, vcc_in);
+    delete inst;
+    return vcc;
+  };
+
+  const uint64_t kVcc[] = {0x0000000000000000ULL, 0xFFFFFFFFFFFFFFFFULL, 0xA5A5A5A5A5A5A5A5ULL};
+  for (uint32_t abs = 0; abs < 4; ++abs) {
+    for (uint32_t neg = 0; neg < 4; ++neg) {
+      for (uint32_t rot = 0; rot < kF64.size(); ++rot) {
+        for (uint64_t vcc_in : kVcc) {
+          const uint64_t scalar_vcc = run_mode(/*force_scalar=*/true, abs, neg, rot, vcc_in);
+          const uint64_t simd_vcc = run_mode(/*force_scalar=*/false, abs, neg, rot, vcc_in);
+
+          EXPECT_EQ(scalar_vcc, simd_vcc)
+              << c.name << " abs=" << abs << " neg=" << neg << " rot=" << rot << " vcc_in=0x"
+              << std::hex << vcc_in << ": SIMD result diverged from scalar body";
+
+          const uint64_t inactive = ~exec;
+          EXPECT_EQ(simd_vcc & inactive, vcc_in & inactive)
+              << c.name << " abs=" << abs << " neg=" << neg << " rot=" << rot
+              << ": altered inactive-lane dst bit";
+          EXPECT_EQ(scalar_vcc & inactive, vcc_in & inactive)
+              << c.name << " abs=" << abs << " neg=" << neg << " rot=" << rot
+              << ": altered inactive-lane dst bit";
+        }
+      }
+    }
+  }
+}
+
+TEST(VopcVop3Fp64SimdCorrectness, FullExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_case(c, /*exec=*/~0ULL);
+}
+
+TEST(VopcVop3Fp64SimdCorrectness, PartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_case(c, /*exec=*/0xA5A5'F0F0'1234'8001ULL);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vopc_vop3_int_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vopc_vop3_int_simd_correctness_test.cpp
@@ -1,0 +1,279 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vopc_vop3_int_simd_correctness_test.cpp
+/// @brief Bit-identity check (SIMD fast path vs scalar body) for the VOP3 form
+/// of the integer VOPC relational compares on CDNA4. The VOP3 form reads
+/// src0/src1 (not src0/vsrc1) and writes the per-lane compare result into an
+/// arbitrary SGPR-pair dst via inst.vdst.read/write_scalar64 instead of the
+/// fixed VCC. We point the SGPR-pair at VCC (106) so the same harness reads the
+/// result via wf.vcc(). Each (case, rot, vcc_in) runs TWICE in the same process
+/// -- once forcing the scalar body, once the SIMD fast path, with identical
+/// inputs/EXEC/VCC-in -- and the 64-bit compare results are asserted equal with
+/// EXPECT_EQ (util::set_force_scalar_for_testing flips the gate in-process).
+/// In-process inactive SGPR-pair bits must be preserved.
+///
+/// Coverage: every (rel, suffix) pair routed through try_execute_vopc_vop3_*_int_simd
+/// — 8 rels × {i16,u16,i32,u32,i64,u64} = 48 ops, full + partial EXEC. Each lane
+/// gets a distinct (a, b) pair; a rotation sweep pairs each value with every other
+/// over the test loop so eq/lt/gt/le/ge/ne all fire on real boundary cases (incl.
+/// signed-negative vs unsigned wrap).
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include "util/simd.h"
+
+#include <array>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t WF_SIZE = 64;
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+constexpr uint32_t kVccSdst = 106;
+
+// VOP3 ([31:26]=0x34): word0 = vdst[7:0] | abs[10:8] | clamp[15] | op[25:16] |
+// enc[31:26]; word1 = src0[8:0] | src1[17:9] | omod[28:27] | neg[31:29]. The
+// integer compares apply no modifiers, so abs/neg/omod/clamp stay zero.
+constexpr void vop3_cmp_encode(uint32_t op, uint32_t vdst, uint32_t src0, uint32_t src1,
+                               uint32_t words[2]) {
+  words[0] = (vdst & 0xFF) | ((op & 0x3FF) << 16) | (0x34u << 26);
+  words[1] = (src0 & 0x1FF) | ((src1 & 0x1FF) << 9);
+}
+
+enum class Width { B32, B64 };
+enum class Sign { S, U };
+enum class Rel { EQ, GE, GT, LE, LT, NE, F, T };
+
+struct Case {
+  const char *name;
+  uint32_t opcode;
+  Width width;
+  Sign sign;
+  Rel rel;
+};
+
+// 48 cases — every {rel} × {i16, u16, i32, u32, i64, u64} VOP3 form. Opcodes
+// come from cdna4 sub_decode_vop3 (see test setup notes in commit message).
+const std::array<Case, 48> kCases = {{
+    {"v_cmp_eq_i16_vop3", 162, Width::B32, Sign::S, Rel::EQ},
+    {"v_cmp_eq_u16_vop3", 170, Width::B32, Sign::U, Rel::EQ},
+    {"v_cmp_eq_i32_vop3", 194, Width::B32, Sign::S, Rel::EQ},
+    {"v_cmp_eq_u32_vop3", 202, Width::B32, Sign::U, Rel::EQ},
+    {"v_cmp_eq_i64_vop3", 226, Width::B64, Sign::S, Rel::EQ},
+    {"v_cmp_eq_u64_vop3", 234, Width::B64, Sign::U, Rel::EQ},
+    {"v_cmp_ge_i16_vop3", 166, Width::B32, Sign::S, Rel::GE},
+    {"v_cmp_ge_u16_vop3", 174, Width::B32, Sign::U, Rel::GE},
+    {"v_cmp_ge_i32_vop3", 198, Width::B32, Sign::S, Rel::GE},
+    {"v_cmp_ge_u32_vop3", 206, Width::B32, Sign::U, Rel::GE},
+    {"v_cmp_ge_i64_vop3", 230, Width::B64, Sign::S, Rel::GE},
+    {"v_cmp_ge_u64_vop3", 238, Width::B64, Sign::U, Rel::GE},
+    {"v_cmp_gt_i16_vop3", 164, Width::B32, Sign::S, Rel::GT},
+    {"v_cmp_gt_u16_vop3", 172, Width::B32, Sign::U, Rel::GT},
+    {"v_cmp_gt_i32_vop3", 196, Width::B32, Sign::S, Rel::GT},
+    {"v_cmp_gt_u32_vop3", 204, Width::B32, Sign::U, Rel::GT},
+    {"v_cmp_gt_i64_vop3", 228, Width::B64, Sign::S, Rel::GT},
+    {"v_cmp_gt_u64_vop3", 236, Width::B64, Sign::U, Rel::GT},
+    {"v_cmp_le_i16_vop3", 163, Width::B32, Sign::S, Rel::LE},
+    {"v_cmp_le_u16_vop3", 171, Width::B32, Sign::U, Rel::LE},
+    {"v_cmp_le_i32_vop3", 195, Width::B32, Sign::S, Rel::LE},
+    {"v_cmp_le_u32_vop3", 203, Width::B32, Sign::U, Rel::LE},
+    {"v_cmp_le_i64_vop3", 227, Width::B64, Sign::S, Rel::LE},
+    {"v_cmp_le_u64_vop3", 235, Width::B64, Sign::U, Rel::LE},
+    {"v_cmp_lt_i16_vop3", 161, Width::B32, Sign::S, Rel::LT},
+    {"v_cmp_lt_u16_vop3", 169, Width::B32, Sign::U, Rel::LT},
+    {"v_cmp_lt_i32_vop3", 193, Width::B32, Sign::S, Rel::LT},
+    {"v_cmp_lt_u32_vop3", 201, Width::B32, Sign::U, Rel::LT},
+    {"v_cmp_lt_i64_vop3", 225, Width::B64, Sign::S, Rel::LT},
+    {"v_cmp_lt_u64_vop3", 233, Width::B64, Sign::U, Rel::LT},
+    {"v_cmp_ne_i16_vop3", 165, Width::B32, Sign::S, Rel::NE},
+    {"v_cmp_ne_u16_vop3", 173, Width::B32, Sign::U, Rel::NE},
+    {"v_cmp_ne_i32_vop3", 197, Width::B32, Sign::S, Rel::NE},
+    {"v_cmp_ne_u32_vop3", 205, Width::B32, Sign::U, Rel::NE},
+    {"v_cmp_ne_i64_vop3", 229, Width::B64, Sign::S, Rel::NE},
+    {"v_cmp_ne_u64_vop3", 237, Width::B64, Sign::U, Rel::NE},
+    {"v_cmp_f_i16_vop3", 160, Width::B32, Sign::S, Rel::F},
+    {"v_cmp_f_u16_vop3", 168, Width::B32, Sign::U, Rel::F},
+    {"v_cmp_f_i32_vop3", 192, Width::B32, Sign::S, Rel::F},
+    {"v_cmp_f_u32_vop3", 200, Width::B32, Sign::U, Rel::F},
+    {"v_cmp_f_i64_vop3", 224, Width::B64, Sign::S, Rel::F},
+    {"v_cmp_f_u64_vop3", 232, Width::B64, Sign::U, Rel::F},
+    {"v_cmp_t_i16_vop3", 167, Width::B32, Sign::S, Rel::T},
+    {"v_cmp_t_u16_vop3", 175, Width::B32, Sign::U, Rel::T},
+    {"v_cmp_t_i32_vop3", 199, Width::B32, Sign::S, Rel::T},
+    {"v_cmp_t_u32_vop3", 207, Width::B32, Sign::U, Rel::T},
+    {"v_cmp_t_i64_vop3", 231, Width::B64, Sign::S, Rel::T},
+    {"v_cmp_t_u64_vop3", 239, Width::B64, Sign::U, Rel::T},
+}};
+
+// Boundary values that stress every relation including signed-vs-unsigned wrap.
+// Keep low 16 bits varied so the i16/u16 paths (which narrow to low 16) get
+// equally good coverage; high 16 bits are non-zero so the high half is exercised
+// for i32/u32. 14 values × 14 rotations gives 196 distinct (a,b) pairings.
+const std::array<uint32_t, 14> kVals32 = {{
+    0x00000000u,
+    0x00000001u,
+    0x0000FFFFu,
+    0x00008000u,
+    0x00007FFFu,
+    0x80000000u,
+    0x80000001u,
+    0x7FFFFFFFu,
+    0xFFFFFFFFu,
+    0x12345678u,
+    0xDEADBEEFu,
+    0xCAFEBABEu,
+    0xA5A5A5A5u,
+    0x5A5A5A5Au,
+}};
+const std::array<uint64_t, 14> kVals64 = {{
+    0x0000000000000000ull,
+    0x0000000000000001ull,
+    0x000000000000FFFFull,
+    0x0000000080000000ull,
+    0x000000007FFFFFFFull,
+    0x8000000000000000ull,
+    0x8000000000000001ull,
+    0x7FFFFFFFFFFFFFFFull,
+    0xFFFFFFFFFFFFFFFFull,
+    0x123456789ABCDEF0ull,
+    0xDEADBEEFCAFEBABEull,
+    0xA5A5A5A55A5A5A5Aull,
+    0x0000000100000000ull,
+    0xFFFFFFFE00000001ull,
+}};
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("vopc_vop3_int_mem"), l2("vopc_vop3_int_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_vopc_vop3_int", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  void write64(uint32_t reg, uint32_t lane, uint64_t v) {
+    cu->write_vgpr(reg, lane, static_cast<uint32_t>(v));
+    cu->write_vgpr(reg + 1, lane, static_cast<uint32_t>(v >> 32));
+  }
+
+  // src0 in v0 (or v0:v1 for 64-bit), src1 in v2 (or v2:v3 for 64-bit). +rot
+  // sweeps the (a,b) pairing across the kVals tables.
+  void seed_inputs(Width w, uint32_t rot, uint64_t exec, uint64_t vcc_in) {
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      if (w == Width::B64) {
+        uint64_t a = kVals64[lane % kVals64.size()];
+        uint64_t b = kVals64[(lane + rot) % kVals64.size()];
+        write64(vb + 0, lane, a);
+        write64(vb + 2, lane, b);
+      } else {
+        uint32_t a = kVals32[lane % kVals32.size()];
+        uint32_t b = kVals32[(lane + rot) % kVals32.size()];
+        cu->write_vgpr(vb + 0, lane, a);
+        cu->write_vgpr(vb + 2, lane, b);
+      }
+    }
+    wf->set_exec(exec);
+    wf->set_vcc(vcc_in);
+  }
+
+  uint64_t run(Instruction *inst, Width w, uint32_t rot, uint64_t exec, uint64_t vcc_in) {
+    seed_inputs(w, rot, exec, vcc_in);
+    cu->execute_instruction(inst, *wf);
+    return wf->vcc();
+  }
+};
+
+// Restores the process force-scalar gate on scope exit so flipping it for an
+// in-process A/B comparison cannot leak into later tests in the same process.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+void check_case(const Case &c, uint64_t exec) {
+  ForceScalarGuard gate_guard;
+
+  // Runs one (case, rot, vcc_in) in the requested execute mode (fresh Fixture +
+  // decode per run isolates VGPR/VCC state).
+  auto run_mode = [&](bool force_scalar, uint32_t rot, uint64_t vcc_in) -> uint64_t {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    const uint32_t src1_vgpr = (c.width == Width::B64) ? 2u : 2u; // v2:v3 / v2
+    uint32_t words[4] = {0u, 0u, 0u, 0u};
+    vop3_cmp_encode(c.opcode, /*vdst=*/kVccSdst, /*src0=*/256u, /*src1=*/256u + src1_vgpr, words);
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << c.name << " decode failed";
+    uint64_t vcc = fx.run(inst, c.width, rot, exec, vcc_in);
+    delete inst;
+    return vcc;
+  };
+
+  const uint64_t kVcc[] = {0x0000000000000000ULL, 0xFFFFFFFFFFFFFFFFULL, 0xA5A5A5A5A5A5A5A5ULL};
+  const std::size_t kRotMax = (c.width == Width::B64) ? kVals64.size() : kVals32.size();
+  for (uint32_t rot = 0; rot < kRotMax; ++rot) {
+    for (uint64_t vcc_in : kVcc) {
+      const uint64_t scalar_vcc = run_mode(/*force_scalar=*/true, rot, vcc_in);
+      const uint64_t simd_vcc = run_mode(/*force_scalar=*/false, rot, vcc_in);
+
+      EXPECT_EQ(scalar_vcc, simd_vcc) << c.name << " rot=" << rot << " vcc_in=0x" << std::hex
+                                      << vcc_in << ": SIMD result diverged from scalar body";
+
+      const uint64_t inactive = ~exec;
+      EXPECT_EQ(simd_vcc & inactive, vcc_in & inactive)
+          << c.name << " rot=" << rot << ": altered inactive-lane dst bit";
+      EXPECT_EQ(scalar_vcc & inactive, vcc_in & inactive)
+          << c.name << " rot=" << rot << ": altered inactive-lane dst bit";
+    }
+  }
+}
+
+TEST(VopcVop3IntSimdCorrectness, FullExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_case(c, /*exec=*/~0ULL);
+}
+
+TEST(VopcVop3IntSimdCorrectness, PartialExec) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  for (const auto &c : kCases)
+    check_case(c, /*exec=*/0xA5A5'F0F0'1234'8001ULL);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/util_simd_test.cpp
+++ b/emulation/rocjitsu/tests/util_simd_test.cpp
@@ -7,16 +7,35 @@
 
 #include "util/simd.h"
 
+#include "util/data_types.h"
+
 #include <gtest/gtest.h>
 
 #include <array>
 #include <atomic>
 #include <bit>
+#include <cmath>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
+#include <random>
 #include <thread>
 
 namespace {
+
+// Toolchain-guard sweep length. The bit-exactness guards below were validated
+// over a 250k-iteration full-range sweep, but running that on every CI build
+// adds significant wall time (5 sweeps x 250k x SIMD width). Default to a
+// shorter deterministic sweep that still covers NaN/Inf/denormal/negative bit
+// patterns; set ROCJITSU_SIMD_FULL_SWEEP=1 for the exhaustive run (e.g. when
+// qualifying a new toolchain).
+inline int sweep_iters() {
+  static const int n = [] {
+    const char *full = std::getenv("ROCJITSU_SIMD_FULL_SWEEP");
+    return (full && full[0] == '1') ? 250000 : 20000;
+  }();
+  return n;
+}
 
 // Each test skips at runtime when `<experimental/simd>` is unavailable;
 // the SIMD body is type-checked but compiles out via `if constexpr`.
@@ -128,17 +147,435 @@ TEST(UtilSimd, BlitToBuffer_F32) {
     EXPECT_EQ(buf[i], src[i]) << "lane " << i;
 }
 
-TEST(UtilSimd, ForceScalar_ThreadLocal) {
-  util::force_scalar() = true;
-  ASSERT_TRUE(util::force_scalar());
+// --- narrow32 prims (native_width64-wide 32-bit lanes) for the f64<->32-bit
+// conversion glue. Round-trips and the double<->narrow32 bridge cast. ---
 
-  std::atomic<bool> other_thread_saw_true{true};
-  std::thread t([&]() { other_thread_saw_true.store(util::force_scalar()); });
+TEST(UtilSimd, LoadNarrow_RoundTrip_F32) {
+  SKIP_IF_NO_SIMD();
+  constexpr std::size_t W = util::native_width64;
+  alignas(util::narrow32<float>) uint32_t src[W];
+  std::array<float, W> expected{};
+  for (std::size_t i = 0; i < W; ++i) {
+    expected[i] = 1.5f * static_cast<float>(i) - 7.25f;
+    src[i] = std::bit_cast<uint32_t>(expected[i]);
+  }
+  auto v = util::load_narrow<float>(src);
+  for (std::size_t i = 0; i < W; ++i)
+    EXPECT_EQ(v[i], expected[i]) << "lane " << i;
+}
+
+TEST(UtilSimd, BroadcastNarrow_I32) {
+  SKIP_IF_NO_SIMD();
+  constexpr int32_t kVal = -123456789;
+  auto v = util::broadcast_narrow<int32_t>(std::bit_cast<uint32_t>(kVal));
+  for (std::size_t i = 0; i < util::native_width64; ++i)
+    EXPECT_EQ(v[i], kVal) << "lane " << i;
+}
+
+TEST(UtilSimd, MaskedStoreNarrow_FullAndPartial) {
+  SKIP_IF_NO_SIMD();
+  constexpr std::size_t W = util::native_width64;
+  alignas(util::narrow32<int32_t>) int32_t vals[W];
+  for (std::size_t i = 0; i < W; ++i)
+    vals[i] = static_cast<int32_t>(i) - 3;
+  util::narrow32<int32_t> v(vals, util::stdx::vector_aligned);
+
+  uint32_t dst_full[W] = {};
+  util::masked_store_narrow<int32_t>(dst_full, v, util::mask<uint64_t>(static_cast<int>(W)));
+  for (std::size_t i = 0; i < W; ++i)
+    EXPECT_EQ(dst_full[i], std::bit_cast<uint32_t>(vals[i])) << "full lane " << i;
+
+  uint32_t dst_part[W];
+  for (std::size_t i = 0; i < W; ++i)
+    dst_part[i] = 0x1111'1111u;
+  uint64_t mask = 0;
+  for (std::size_t i = 1; i < W; i += 2)
+    mask |= (1ULL << i);
+  util::masked_store_narrow<int32_t>(dst_part, v, mask);
+  for (std::size_t i = 0; i < W; ++i) {
+    if (mask & (1ULL << i))
+      EXPECT_EQ(dst_part[i], std::bit_cast<uint32_t>(vals[i])) << "part write lane " << i;
+    else
+      EXPECT_EQ(dst_part[i], 0x1111'1111u) << "part preserve lane " << i;
+  }
+}
+
+TEST(UtilSimd, NarrowBridgeCast_DoubleToFromB32) {
+  SKIP_IF_NO_SIMD();
+  constexpr std::size_t W = util::native_width64;
+  // f64 -> f32: a direct static_simd_cast between native<double> and
+  // narrow32<float> is the cvt_f32_f64 bridge; matches a per-lane (float)cast.
+  alignas(util::native<double>) double in[W];
+  for (std::size_t i = 0; i < W; ++i)
+    in[i] = 0.1 * static_cast<double>(i) - 1.3 + 1e30;
+  util::native<double> d(in, util::stdx::vector_aligned);
+  auto f = util::stdx::static_simd_cast<util::narrow32<float>>(d);
+  for (std::size_t i = 0; i < W; ++i)
+    EXPECT_EQ(f[i], static_cast<float>(in[i])) << "f64->f32 lane " << i;
+  // i32 -> f64: the cvt_f64_i32 bridge (exact widening).
+  alignas(util::narrow32<int32_t>) int32_t iv[W];
+  for (std::size_t i = 0; i < W; ++i)
+    iv[i] = static_cast<int32_t>(i) * -1000003;
+  util::narrow32<int32_t> ni(iv, util::stdx::vector_aligned);
+  auto dd = util::stdx::static_simd_cast<util::native<double>>(ni);
+  for (std::size_t i = 0; i < W; ++i)
+    EXPECT_EQ(dd[i], static_cast<double>(iv[i])) << "i32->f64 lane " << i;
+}
+
+TEST(UtilSimd, ForceScalar_ImmutableProcessWide) {
+  // force_scalar() is seeded once from RJ_FORCE_SCALAR at startup. Absent the
+  // test-only setter (util/simd_test_hooks.h), it is stable across calls and
+  // identical on every thread; this test exercises that steady-state behaviour
+  // without flipping the gate.
+  const bool v = util::force_scalar();
+  EXPECT_EQ(util::force_scalar(), v) << "force_scalar() must be stable within a process";
+
+  std::atomic<bool> other{!v};
+  std::thread t([&]() { other.store(util::force_scalar()); });
   t.join();
+  EXPECT_EQ(other.load(), v) << "force_scalar() must be process-wide (identical on all threads)";
 
-  EXPECT_FALSE(other_thread_saw_true.load()) << "force_scalar() must be thread-local";
-  EXPECT_TRUE(util::force_scalar()) << "this thread's flag must survive the other thread";
-  util::force_scalar() = false;
+  // Value reflects the env parse: unset/empty/"0" => false, else true.
+  const char *e = std::getenv("RJ_FORCE_SCALAR");
+  const bool expected = e && e[0] && !(e[0] == '0' && e[1] == '\0');
+  EXPECT_EQ(v, expected);
+}
+
+// Toolchain guard for the SIMD fast path of v_exp_f32 (stdx::exp2) and
+// v_log_f32 (stdx::log2). Those VOP1 kernels take the SIMD path whenever
+// `util::has_stdx_simd`, with no runtime value check — so the vector libm
+// MUST be bit-identical to the scalar std::* used by the generated body, or
+// the fast path silently returns wrong results. These tests sweep full-range
+// random bit patterns (covering NaN/Inf/denormal/negative) and fail loudly if
+// any lane diverges, blocking a divergent toolchain at CI time. If one fails,
+// drop the corresponding row from SIMD_VOP1_UNARY rather than ship wrong math.
+template <class ScalarFn, class VectorFn>
+void expect_simd_bit_exact(ScalarFn scalar_fn, VectorFn vector_fn) {
+  using V = util::native<float>;
+  constexpr std::size_t W = util::native_width_v<float>;
+  std::mt19937 rng(0xA17C0DEu);
+  for (int iter = 0, n = sweep_iters(); iter < n; ++iter) {
+    alignas(V) float in[W];
+    for (std::size_t i = 0; i < W; ++i)
+      in[i] = std::bit_cast<float>(static_cast<uint32_t>(rng()));
+    V v(in, util::stdx::element_aligned);
+    alignas(V) float out[W];
+    vector_fn(v).copy_to(out, util::stdx::element_aligned);
+    for (std::size_t i = 0; i < W; ++i) {
+      const float s = scalar_fn(in[i]);
+      ASSERT_EQ(std::bit_cast<uint32_t>(s), std::bit_cast<uint32_t>(out[i]))
+          << "divergent at iter " << iter << " lane " << i << std::hex << " in=0x"
+          << std::bit_cast<uint32_t>(in[i]);
+    }
+  }
+}
+
+TEST(UtilSimd, Exp2_VectorMatchesScalar_BitExact) {
+  SKIP_IF_NO_SIMD();
+  expect_simd_bit_exact([](float x) { return std::exp2(x); },
+                        [](util::native<float> v) { return util::stdx::exp2(v); });
+}
+
+TEST(UtilSimd, Log2_VectorMatchesScalar_BitExact) {
+  SKIP_IF_NO_SIMD();
+  expect_simd_bit_exact([](float x) { return std::log2(x); },
+                        [](util::native<float> v) { return util::stdx::log2(v); });
+}
+
+// Toolchain guard for the ternary VOP2 FMA/MAC/MAD SIMD fast path
+// (SIMD_VOP2_TERNARY). Those kernels use util::stdx::fma unconditionally under
+// has_stdx_simd, so it MUST be the single-rounded fused operation matching the
+// scalar std::fma in the generated bodies — a separate mul+add (two roundings)
+// would diverge silently. This sweeps full-range random bit patterns for all
+// three operands and asserts bit-exactness, EXCLUDING lanes with a NaN input:
+// for NaN inputs the packed and scalar FMA may propagate a different NaN
+// payload (toolchain-dependent, e.g. g++-13 picks the second multiplicand while
+// the packed form picks the first), and that NaN-payload divergence is an
+// accepted difference (the result is a NaN either way). Inf and Inf*0→NaN cases
+// ARE checked (they do match). If a finite/Inf lane diverges, drop
+// SIMD_VOP2_TERNARY rather than ship wrong math. The f16 forms inherit this
+// guard plus the f16<->f32 ones.
+TEST(UtilSimd, Fma_VectorMatchesScalar_BitExact) {
+  SKIP_IF_NO_SIMD();
+  using V = util::native<float>;
+  constexpr std::size_t W = util::native_width_v<float>;
+  auto is_nan_bits = [](uint32_t u) {
+    return ((u >> 23) & 0xFFu) == 0xFFu && (u & 0x7FFFFFu) != 0u;
+  };
+  std::mt19937 rng(0xF1AC0DEu);
+  for (int iter = 0, n = sweep_iters(); iter < n; ++iter) {
+    alignas(V) float a[W], b[W], c[W];
+    for (std::size_t i = 0; i < W; ++i) {
+      a[i] = std::bit_cast<float>(static_cast<uint32_t>(rng()));
+      b[i] = std::bit_cast<float>(static_cast<uint32_t>(rng()));
+      c[i] = std::bit_cast<float>(static_cast<uint32_t>(rng()));
+    }
+    V va(a, util::stdx::element_aligned), vb(b, util::stdx::element_aligned),
+        vc(c, util::stdx::element_aligned);
+    alignas(V) float out[W];
+    util::stdx::fma(va, vb, vc).copy_to(out, util::stdx::element_aligned);
+    for (std::size_t i = 0; i < W; ++i) {
+      if (is_nan_bits(std::bit_cast<uint32_t>(a[i])) ||
+          is_nan_bits(std::bit_cast<uint32_t>(b[i])) || is_nan_bits(std::bit_cast<uint32_t>(c[i])))
+        continue; // NaN-input payload divergence is accepted
+      const float s = std::fma(a[i], b[i], c[i]);
+      ASSERT_EQ(std::bit_cast<uint32_t>(s), std::bit_cast<uint32_t>(out[i]))
+          << "divergent at iter " << iter << " lane " << i << std::hex << " a=0x"
+          << std::bit_cast<uint32_t>(a[i]) << " b=0x" << std::bit_cast<uint32_t>(b[i]) << " c=0x"
+          << std::bit_cast<uint32_t>(c[i]);
+    }
+  }
+}
+
+// Toolchain guard for the 64-bit-lane VOP2 FMA SIMD fast path (v_fmac_f64,
+// SIMD_VOP2_FMA_F64). Same contract as the f32 Fma guard above, over
+// native<double>: util::stdx::fma must be the single-rounded fused operation
+// matching the scalar std::fma in the generated body. Sweeps full-range random
+// 64-bit patterns for all three operands, EXCLUDING NaN-input lanes (accepted
+// payload divergence). If a finite/Inf lane diverges, drop SIMD_VOP2_FMA_F64.
+TEST(UtilSimd, FmaF64_VectorMatchesScalar_BitExact) {
+  SKIP_IF_NO_SIMD();
+  using V = util::native<double>;
+  constexpr std::size_t W = util::native_width64;
+  auto is_nan_bits = [](uint64_t u) {
+    return ((u >> 52) & 0x7FFu) == 0x7FFu && (u & 0xFFFFFFFFFFFFFull) != 0u;
+  };
+  std::mt19937_64 rng(0xF1AC0DE64ull);
+  for (int iter = 0, n = sweep_iters(); iter < n; ++iter) {
+    alignas(V) double a[W], b[W], c[W];
+    for (std::size_t i = 0; i < W; ++i) {
+      a[i] = std::bit_cast<double>(rng());
+      b[i] = std::bit_cast<double>(rng());
+      c[i] = std::bit_cast<double>(rng());
+    }
+    V va(a, util::stdx::element_aligned), vb(b, util::stdx::element_aligned),
+        vc(c, util::stdx::element_aligned);
+    alignas(V) double out[W];
+    util::stdx::fma(va, vb, vc).copy_to(out, util::stdx::element_aligned);
+    for (std::size_t i = 0; i < W; ++i) {
+      if (is_nan_bits(std::bit_cast<uint64_t>(a[i])) ||
+          is_nan_bits(std::bit_cast<uint64_t>(b[i])) || is_nan_bits(std::bit_cast<uint64_t>(c[i])))
+        continue; // NaN-input payload divergence is accepted
+      const double s = std::fma(a[i], b[i], c[i]);
+      ASSERT_EQ(std::bit_cast<uint64_t>(s), std::bit_cast<uint64_t>(out[i]))
+          << "divergent at iter " << iter << " lane " << i << std::hex << " a=0x"
+          << std::bit_cast<uint64_t>(a[i]) << " b=0x" << std::bit_cast<uint64_t>(b[i]) << " c=0x"
+          << std::bit_cast<uint64_t>(c[i]);
+    }
+  }
+}
+
+// native<double>: the f64 unary VOP1 fast path (v_ceil/floor/trunc/rndne/fract/
+// rcp/rsq/sqrt_f64) relies on util::stdx::{ceil,floor,trunc,nearbyint,sqrt} and
+// 1.0/x being bit-identical to the scalar std::* used in the generated bodies.
+// Sweeps full-range random 64-bit patterns, skipping lanes whose result is NaN
+// (accepted payload divergence). If a finite/Inf lane diverges, drop the
+// corresponding SIMD_VOP1_UNARY_F64 row.
+template <class ScalarFn, class VectorFn>
+void expect_f64_unary_bit_exact(ScalarFn scalar_fn, VectorFn vector_fn) {
+  using V = util::native<double>;
+  constexpr std::size_t W = util::native_width64;
+  auto is_nan_bits = [](uint64_t u) {
+    return ((u >> 52) & 0x7FFu) == 0x7FFu && (u & 0xFFFFFFFFFFFFFull) != 0u;
+  };
+  std::mt19937_64 rng(0xD06F64ull);
+  for (int iter = 0, n = sweep_iters(); iter < n; ++iter) {
+    alignas(V) double a[W];
+    for (std::size_t i = 0; i < W; ++i)
+      a[i] = std::bit_cast<double>(rng());
+    V va(a, util::stdx::element_aligned);
+    alignas(V) double out[W];
+    vector_fn(va).copy_to(out, util::stdx::element_aligned);
+    for (std::size_t i = 0; i < W; ++i) {
+      const double s = scalar_fn(a[i]);
+      const uint64_t su = std::bit_cast<uint64_t>(s), ou = std::bit_cast<uint64_t>(out[i]);
+      if (is_nan_bits(su) || is_nan_bits(ou))
+        continue; // NaN-result payload divergence is accepted
+      ASSERT_EQ(su, ou) << "divergent at iter " << iter << " lane " << i << std::hex << " in=0x"
+                        << std::bit_cast<uint64_t>(a[i]);
+    }
+  }
+}
+
+TEST(UtilSimd, CeilF64_VectorMatchesScalar_BitExact) {
+  SKIP_IF_NO_SIMD();
+  expect_f64_unary_bit_exact([](double x) { return std::ceil(x); },
+                             [](util::native<double> x) { return util::ceil_simd(x); });
+}
+TEST(UtilSimd, FloorF64_VectorMatchesScalar_BitExact) {
+  SKIP_IF_NO_SIMD();
+  expect_f64_unary_bit_exact([](double x) { return std::floor(x); },
+                             [](util::native<double> x) { return util::floor_simd(x); });
+}
+TEST(UtilSimd, TruncF64_VectorMatchesScalar_BitExact) {
+  SKIP_IF_NO_SIMD();
+  expect_f64_unary_bit_exact([](double x) { return std::trunc(x); },
+                             [](util::native<double> x) { return util::trunc_simd(x); });
+}
+TEST(UtilSimd, RndneF64_VectorMatchesScalar_BitExact) {
+  SKIP_IF_NO_SIMD();
+  expect_f64_unary_bit_exact([](double x) { return std::nearbyint(x); },
+                             [](util::native<double> x) { return util::rndne_simd(x); });
+}
+TEST(UtilSimd, FractF64_VectorMatchesScalar_BitExact) {
+  SKIP_IF_NO_SIMD();
+  expect_f64_unary_bit_exact([](double x) { return x - std::floor(x); },
+                             [](util::native<double> x) { return x - util::floor_simd(x); });
+}
+TEST(UtilSimd, RcpF64_VectorMatchesScalar_BitExact) {
+  SKIP_IF_NO_SIMD();
+  expect_f64_unary_bit_exact([](double x) { return 1.0f / x; },
+                             [](util::native<double> x) { return util::native<double>(1.0) / x; });
+}
+TEST(UtilSimd, RsqF64_VectorMatchesScalar_BitExact) {
+  SKIP_IF_NO_SIMD();
+  expect_f64_unary_bit_exact(
+      [](double x) { return 1.0f / std::sqrt(x); },
+      [](util::native<double> x) { return util::native<double>(1.0) / util::stdx::sqrt(x); });
+}
+TEST(UtilSimd, SqrtF64_VectorMatchesScalar_BitExact) {
+  SKIP_IF_NO_SIMD();
+  expect_f64_unary_bit_exact([](double x) { return std::sqrt(x); },
+                             [](util::native<double> x) { return util::stdx::sqrt(x); });
+}
+
+// Toolchain guard for the float min/max SIMD fast path (v_max/min_f32 and the
+// f16 forms). util::stdx::fmax/fmin must match the scalar std::fmax/fmin used by
+// the generated bodies. This sweeps full-range random bit patterns, biasing one
+// in eight operands to a signed zero so the -0/+0 tie cases (both orders) are
+// hit heavily, and asserts bit-exactness for all finite/Inf inputs. Two classes
+// of divergence are accepted (and skipped): a NaN input (NaN payload differs)
+// and a signed-zero tie (scalar std::fmax/fmin returns the first operand, the
+// packed vmaxps/vminps the second — a -0 vs +0 sign difference, numerically
+// equal). If any OTHER lane diverges, drop the float min/max rows.
+template <class ScalarFn, class VectorFn>
+void expect_minmax_bit_exact(ScalarFn scalar_fn, VectorFn vector_fn) {
+  using V = util::native<float>;
+  constexpr std::size_t W = util::native_width_v<float>;
+  auto is_nan_bits = [](uint32_t u) {
+    return ((u >> 23) & 0xFFu) == 0xFFu && (u & 0x7FFFFFu) != 0u;
+  };
+  auto is_zero_bits = [](uint32_t u) { return (u & 0x7FFFFFFFu) == 0u; };
+  std::mt19937 rng(0xFA00C0DEu);
+  for (int iter = 0, n = sweep_iters(); iter < n; ++iter) {
+    alignas(V) float a[W], b[W];
+    for (std::size_t i = 0; i < W; ++i) {
+      uint32_t ra = rng(), rb = rng();
+      if ((rng() & 7u) == 0u)
+        ra &= 0x80000000u; // force +/-0
+      if ((rng() & 7u) == 0u)
+        rb &= 0x80000000u;
+      a[i] = std::bit_cast<float>(ra);
+      b[i] = std::bit_cast<float>(rb);
+    }
+    V va(a, util::stdx::element_aligned), vb(b, util::stdx::element_aligned);
+    alignas(V) float out[W];
+    vector_fn(va, vb).copy_to(out, util::stdx::element_aligned);
+    for (std::size_t i = 0; i < W; ++i) {
+      const uint32_t ua = std::bit_cast<uint32_t>(a[i]), ub = std::bit_cast<uint32_t>(b[i]);
+      if (is_nan_bits(ua) || is_nan_bits(ub))
+        continue; // NaN-input payload divergence is accepted
+      if (is_zero_bits(ua) && is_zero_bits(ub))
+        continue; // signed-zero tie: -0/+0 sign difference is accepted
+      const float s = scalar_fn(a[i], b[i]);
+      ASSERT_EQ(std::bit_cast<uint32_t>(s), std::bit_cast<uint32_t>(out[i]))
+          << "divergent at iter " << iter << " lane " << i << std::hex << " a=0x" << ua << " b=0x"
+          << ub;
+    }
+  }
+}
+
+TEST(UtilSimd, Fmax_VectorMatchesScalar_BitExact) {
+  SKIP_IF_NO_SIMD();
+  expect_minmax_bit_exact(
+      [](float x, float y) { return std::fmax(x, y); },
+      [](util::native<float> x, util::native<float> y) { return util::stdx::fmax(x, y); });
+}
+
+TEST(UtilSimd, Fmin_VectorMatchesScalar_BitExact) {
+  SKIP_IF_NO_SIMD();
+  expect_minmax_bit_exact(
+      [](float x, float y) { return std::fmin(x, y); },
+      [](util::native<float> x, util::native<float> y) { return util::stdx::fmin(x, y); });
+}
+
+// Bit-exactness guards for the f16<->f32 vector conversions. The 16-bit VOP1
+// SIMD functors rely on these matching the scalar util::f16_to_f32 /
+// util::f32_to_f16 for every input (the SIMD path is unconditional under
+// has_stdx_simd). f16->f32 is verified EXHAUSTIVELY over all 65536 f16 bit
+// patterns; f32->f16 over a heavy full-range sweep. Both fail CI on divergence.
+TEST(UtilSimd, F16ToF32_VectorMatchesScalar_Exhaustive) {
+  SKIP_IF_NO_SIMD();
+  using V = util::native<uint32_t>;
+  constexpr std::size_t W = util::native_width_v<uint32_t>;
+  for (uint32_t base = 0; base < 65536u; base += static_cast<uint32_t>(W)) {
+    alignas(V) uint32_t in[W];
+    for (std::size_t i = 0; i < W; ++i)
+      in[i] = base + static_cast<uint32_t>(i); // f16 bits 0..65535 (all)
+    V v(in, util::stdx::element_aligned);
+    util::native<float> rv = util::f16_to_f32_simd(v);
+    alignas(util::native<float>) float out[W];
+    rv.copy_to(out, util::stdx::element_aligned);
+    for (std::size_t i = 0; i < W; ++i) {
+      const float s = util::f16_to_f32(static_cast<uint16_t>(in[i]));
+      ASSERT_EQ(std::bit_cast<uint32_t>(s), std::bit_cast<uint32_t>(out[i]))
+          << "f16=0x" << std::hex << in[i];
+    }
+  }
+}
+
+TEST(UtilSimd, F32ToF16_VectorMatchesScalar_Sweep) {
+  SKIP_IF_NO_SIMD();
+  using V = util::native<float>;
+  constexpr std::size_t W = util::native_width_v<float>;
+  // Stride-prime sweep across the full 2^32 f32 bit space (~4.3M samples),
+  // hitting every exponent and a spread of mantissas, incl. NaN/Inf/denormal.
+  for (uint64_t u = 0; u < 0x100000000ULL; u += 997ULL * W) {
+    alignas(V) float in[W];
+    for (std::size_t i = 0; i < W; ++i)
+      in[i] = std::bit_cast<float>(static_cast<uint32_t>(u + 997ULL * i));
+    V v(in, util::stdx::element_aligned);
+    util::native<uint32_t> rv = util::f32_to_f16_simd(v);
+    alignas(util::native<uint32_t>) uint32_t out[W];
+    rv.copy_to(out, util::stdx::element_aligned);
+    for (std::size_t i = 0; i < W; ++i) {
+      const uint32_t s = util::f32_to_f16(in[i]);
+      ASSERT_EQ(s, out[i]) << "f32=0x" << std::hex << std::bit_cast<uint32_t>(in[i]);
+    }
+  }
+}
+
+// Guard for util::flush_denorm_f32_simd: denormals flush to sign-preserving
+// zero (FTZ); every other class (±0, normal, ±Inf, NaN payloads) passes through
+// bit-for-bit. The f32 rcp/rsq/exp/log SIMD ports funnel through this helper.
+TEST(UtilSimd, FlushDenormF32) {
+  SKIP_IF_NO_SIMD();
+  using V = util::native<float>;
+  constexpr std::size_t W = util::native_width_v<float>;
+  struct Case {
+    uint32_t in, out;
+  };
+  const Case cases[] = {
+      {0x00000001u, 0x00000000u}, // +smallest denormal -> +0
+      {0x80000001u, 0x80000000u}, // -smallest denormal -> -0
+      {0x007FFFFFu, 0x00000000u}, // +largest denormal  -> +0
+      {0x807FFFFFu, 0x80000000u}, // -largest denormal  -> -0
+      {0x00000000u, 0x00000000u}, // +0 untouched
+      {0x80000000u, 0x80000000u}, // -0 untouched
+      {0x00800000u, 0x00800000u}, // smallest normal untouched
+      {0x3F800000u, 0x3F800000u}, // 1.0 untouched
+      {0x7F800000u, 0x7F800000u}, // +Inf untouched
+      {0xFF800000u, 0xFF800000u}, // -Inf untouched
+      {0x7FC00000u, 0x7FC00000u}, // qNaN payload untouched
+      {0x7F800001u, 0x7F800001u}, // sNaN payload untouched
+  };
+  for (const auto &c : cases) {
+    V r = util::flush_denorm_f32_simd(util::broadcast<float>(c.in));
+    alignas(V) float out[W];
+    r.copy_to(out, util::stdx::element_aligned);
+    for (std::size_t i = 0; i < W; ++i)
+      EXPECT_EQ(std::bit_cast<uint32_t>(out[i]), c.out) << "in=0x" << std::hex << c.in;
+  }
 }
 
 #undef SKIP_IF_NO_SIMD

--- a/emulation/rocjitsu/tests/v_add_simd_benchmark.cpp
+++ b/emulation/rocjitsu/tests/v_add_simd_benchmark.cpp
@@ -2,13 +2,12 @@
 // SPDX-License-Identifier: MIT
 
 /// @file v_add_simd_benchmark.cpp
-/// @brief A/B microbenchmark: SIMD vs forced-scalar execution of v_add_f32
-/// and v_add_u32 (CDNA4, VOP2 form). Both modes run in the same process; the
-/// `amdgpu::simd_force_scalar()` thread-local flag flips between them.
-///
-/// Reports ns/instruction and speedup, and asserts SIMD-vs-scalar results
-/// are bit-identical for u32 and within 0 ULP for fp32 add (IEEE-754
-/// binary32 single-rounded; matches the host SIMD adder).
+/// @brief Microbenchmark of v_add_f32 / v_add_u32 (CDNA4, VOP2 form). The
+/// execute mode is fixed per process by `RJ_FORCE_SCALAR` (force_scalar() is
+/// immutable), so each run times one mode and reports ns/instruction. Compare
+/// SIMD vs scalar throughput by running twice: `RJ_FORCE_SCALAR=1` (scalar)
+/// then unset (SIMD). Scalar-vs-SIMD bit-equivalence is verified separately by
+/// the *SimdCorrectness* suites (in-process double-run + EXPECT_EQ), not here.
 
 #include "rocjitsu/code/rj_code.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
@@ -45,6 +44,21 @@ constexpr int ITERATIONS = 200'000;
 // vsrc1 in [16:9], src0 in [8:0]. Bit 31 = 0 for VOP2.
 constexpr uint32_t vop2_encode(uint32_t opcode, uint32_t vdst, uint32_t vsrc1, uint32_t src0) {
   return ((opcode & 0x3F) << 25) | ((vdst & 0xFF) << 17) | ((vsrc1 & 0xFF) << 9) | (src0 & 0x1FF);
+}
+
+// CDNA4 VOP1 encoding: [31:25]=0b0111111, vdst[24:17], op[16:9], src0[8:0].
+constexpr uint32_t vop1_encode(uint32_t opcode, uint32_t vdst, uint32_t src0) {
+  return (0x3Fu << 25) | ((vdst & 0xFF) << 17) | ((opcode & 0xFF) << 9) | (src0 & 0x1FF);
+}
+
+// CDNA4 VOP3 binary encoding ([31:26]=0x34): word0 = vdst[7:0] | abs[10:8] |
+// clamp[15] | op[25:16]; word1 = src0[8:0] | src1[17:9] | omod[28:27] | neg[31:29].
+constexpr void vop3_bin_encode(uint32_t op, uint32_t vdst, uint32_t src0, uint32_t src1,
+                               uint32_t abs, uint32_t neg, uint32_t omod, uint32_t clamp,
+                               uint32_t &w0, uint32_t &w1) {
+  w0 = (vdst & 0xFF) | ((abs & 0x7) << 8) | ((clamp & 0x1) << 15) | ((op & 0x3FF) << 16) |
+       (0x34u << 26);
+  w1 = (src0 & 0x1FF) | ((src1 & 0x1FF) << 9) | ((omod & 0x3) << 27) | ((neg & 0x7) << 29);
 }
 
 struct BenchFixture {
@@ -111,9 +125,7 @@ struct ModeStats {
   uint64_t total_ns = 0;
 };
 
-ModeStats time_mode(BenchFixture &fx, Instruction *inst, bool force_scalar, uint64_t seed,
-                    bool sanitize_finite) {
-  amdgpu::simd_force_scalar() = force_scalar;
+ModeStats time_mode(BenchFixture &fx, Instruction *inst, uint64_t seed, bool sanitize_finite) {
   fx.seed_inputs(seed, sanitize_finite);
   // Warmup.
   for (int i = 0; i < 100; ++i)
@@ -123,7 +135,6 @@ ModeStats time_mode(BenchFixture &fx, Instruction *inst, bool force_scalar, uint
   for (int i = 0; i < ITERATIONS; ++i)
     fx.cu->execute_instruction(inst, *fx.wf);
   auto t1 = Clock::now();
-  amdgpu::simd_force_scalar() = false;
   ModeStats s;
   s.total_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
   s.ns_per_inst = static_cast<double>(s.total_ns) / ITERATIONS;
@@ -131,53 +142,40 @@ ModeStats time_mode(BenchFixture &fx, Instruction *inst, bool force_scalar, uint
   return s;
 }
 
-void run_one(const char *label, uint32_t encoding_word, bool sanitize_finite) {
+void run_words(const char *label, uint32_t w0, uint32_t w1, bool sanitize_finite) {
   BenchFixture fx;
   ASSERT_NE(fx.cu, nullptr);
   ASSERT_NE(fx.decoder, nullptr);
   ASSERT_NE(fx.wf, nullptr);
 
-  uint32_t words[4] = {encoding_word, 0u, 0u, 0u};
+  uint32_t words[4] = {w0, w1, 0u, 0u};
   Instruction *inst = fx.decoder->decode(words);
   ASSERT_NE(inst, nullptr) << label << ": decode failed";
 
   constexpr uint64_t SEED = 0xC0FFEE'1234'5678ULL;
 
-  // Correctness pre-check: snapshot both modes' results lane-by-lane.
-  amdgpu::simd_force_scalar() = true;
-  fx.seed_inputs(SEED, sanitize_finite);
-  fx.cu->execute_instruction(inst, *fx.wf);
-  auto result_scalar = fx.snapshot_v2();
+  // This benchmark times whichever execute mode the process starts in (seeded
+  // from RJ_FORCE_SCALAR). Scalar-vs-SIMD bit-equivalence is checked separately
+  // by the *SimdCorrectness* suites (in-process double-run + EXPECT_EQ). To
+  // compare throughput, run the benchmark twice: `RJ_FORCE_SCALAR=1 ...`
+  // (scalar) and unset (SIMD).
+  const char *mode = amdgpu::simd_force_scalar() ? "scalar" : "simd";
+  ModeStats s = time_mode(fx, inst, SEED, sanitize_finite);
 
-  amdgpu::simd_force_scalar() = false;
-  fx.seed_inputs(SEED, sanitize_finite);
-  fx.cu->execute_instruction(inst, *fx.wf);
-  auto result_simd = fx.snapshot_v2();
-  amdgpu::simd_force_scalar() = false;
+  std::printf("\n  === %s (CDNA4, wave64) [%s] ===\n"
+              "  iterations: %d  enc: 0x%08x 0x%08x\n"
+              "  %-6s : %7.1f ns/inst  (%6.2f MIPS)  wall %.1f ms\n",
+              label, mode, ITERATIONS, w0, w1, mode, s.ns_per_inst, s.mips,
+              static_cast<double>(s.total_ns) / 1e6);
 
-  for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
-    EXPECT_EQ(result_scalar[lane], result_simd[lane])
-        << label << ": divergence at lane " << lane << " scalar=0x" << std::hex
-        << result_scalar[lane] << " simd=0x" << result_simd[lane];
-  }
-
-  ModeStats sc = time_mode(fx, inst, /*force_scalar=*/true, SEED, sanitize_finite);
-  ModeStats sd = time_mode(fx, inst, /*force_scalar=*/false, SEED, sanitize_finite);
-
-  double speedup = (sd.ns_per_inst > 0) ? (sc.ns_per_inst / sd.ns_per_inst) : 0.0;
-  std::printf("\n  === %s (CDNA4 VOP2, wave64) ===\n"
-              "  iterations: %d  enc: 0x%08x\n"
-              "  scalar : %7.1f ns/inst  (%6.2f MIPS)  wall %.1f ms\n"
-              "  simd   : %7.1f ns/inst  (%6.2f MIPS)  wall %.1f ms\n"
-              "  speedup: %5.2fx\n",
-              label, ITERATIONS, encoding_word, sc.ns_per_inst, sc.mips,
-              static_cast<double>(sc.total_ns) / 1e6, sd.ns_per_inst, sd.mips,
-              static_cast<double>(sd.total_ns) / 1e6, speedup);
-
-  EXPECT_GT(sc.mips, 0.01) << label << ": scalar baseline too slow";
-  EXPECT_GT(sd.mips, 0.01) << label << ": simd path too slow";
+  EXPECT_GT(s.mips, 0.01) << label << ": " << mode << " path too slow";
 
   delete inst;
+}
+
+// Single-word (VOP1/VOP2/VOPC) wrapper.
+void run_one(const char *label, uint32_t encoding_word, bool sanitize_finite) {
+  run_words(label, encoding_word, 0u, sanitize_finite);
 }
 
 } // namespace
@@ -201,6 +199,485 @@ TEST(VAddSimdBenchmark, Cdna4_VAddU32_Vop2) {
   }
   uint32_t enc = vop2_encode(/*opcode=*/52, /*vdst=*/2, /*vsrc1=*/1, /*src0=*/256);
   run_one("v_add_u32 v2, v0, v1", enc, /*sanitize_finite=*/false);
+}
+
+// v_add_u16 v2, v0, v1  (CDNA4 VOP2 opcode 38) — 16-bit integer, low-16 path.
+TEST(VAddSimdBenchmark, Cdna4_VAddU16_Vop2) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t enc = vop2_encode(/*opcode=*/38, /*vdst=*/2, /*vsrc1=*/1, /*src0=*/256);
+  run_one("v_add_u16 v2, v0, v1", enc, /*sanitize_finite=*/false);
+}
+
+// v_add_f16 v2, v0, v1  (CDNA4 VOP2 opcode 31) — f16 op via f32 intermediate.
+TEST(VAddSimdBenchmark, Cdna4_VAddF16_Vop2) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t enc = vop2_encode(/*opcode=*/31, /*vdst=*/2, /*vsrc1=*/1, /*src0=*/256);
+  run_one("v_add_f16 v2, v0, v1", enc, /*sanitize_finite=*/false);
+}
+
+// v_add_co_u32 v2, v0, v1  (CDNA4 VOP2 opcode 25) — carry-out into VCC. The
+// SIMD path pays a per-chunk VCC pack/merge (and a scalar carry-in expand)
+// on top of the binary add, so this shows the carry-glue overhead vs v_add_u32.
+TEST(VAddSimdBenchmark, Cdna4_VAddCoU32_Vop2) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t enc = vop2_encode(/*opcode=*/25, /*vdst=*/2, /*vsrc1=*/1, /*src0=*/256);
+  run_one("v_add_co_u32 v2, v0, v1", enc, /*sanitize_finite=*/false);
+}
+
+// v_fmaak_f32 v2, v0, v1, K  (CDNA4 VOP2 opcode 24) — dst = fma(v0, v1, K). The
+// inline literal K is words[1] (0.0f here), so this exercises the literal-form
+// ternary glue. Inputs sanitized to finite for bit-exact comparison.
+//
+// NOTE: the dst-accumulate forms (v_fmac/v_mac, dst = fma(s0, s1, dst)) are not
+// benchmarked here. Looping the *same* instruction re-creates a loop-carried
+// RAW dependency on the accumulator register, which serializes both the scalar
+// and SIMD runs on store->load latency rather than compute throughput, so the
+// measured "speedup" (~1x) reflects the microbenchmark shape, not the fast path
+// (which does engage — see Vop2FmaSimdCorrectness). The literal form below has
+// no such loop-carried dependency and shows the representative speedup.
+TEST(VAddSimdBenchmark, Cdna4_VFmaakF32_Vop2) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t enc = vop2_encode(/*opcode=*/24, /*vdst=*/2, /*vsrc1=*/1, /*src0=*/256);
+  run_one("v_fmaak_f32 v2, v0, v1, 0", enc, /*sanitize_finite=*/true);
+}
+
+// v_cndmask_b32 v2, v0, v1  (CDNA4 VOP2 opcode 0) — VCC-driven per-lane select.
+// VCC defaults to 0 here (all lanes pick src0); still drives the SIMD blend.
+TEST(VAddSimdBenchmark, Cdna4_VCndmaskB32_Vop2) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t enc = vop2_encode(/*opcode=*/0, /*vdst=*/2, /*vsrc1=*/1, /*src0=*/256);
+  run_one("v_cndmask_b32 v2, v0, v1", enc, /*sanitize_finite=*/false);
+}
+
+// v_mul_hi_u32_u24 v2, v0, v1  (CDNA4 VOP2 opcode 9) — 48-bit product, high 32
+// bits via the 64-bit-lane widening path. Shows the widening-mul overhead.
+TEST(VAddSimdBenchmark, Cdna4_VMulHiU32U24_Vop2) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t enc = vop2_encode(/*opcode=*/9, /*vdst=*/2, /*vsrc1=*/1, /*src0=*/256);
+  run_one("v_mul_hi_u32_u24 v2, v0, v1", enc, /*sanitize_finite=*/false);
+}
+
+// v_max_f32 v2, v0, v1  (CDNA4 VOP2 opcode 11) — std::fmax; inputs sanitized to
+// finite normals for the bit-exact pre-check.
+TEST(VAddSimdBenchmark, Cdna4_VMaxF32_Vop2) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t enc = vop2_encode(/*opcode=*/11, /*vdst=*/2, /*vsrc1=*/1, /*src0=*/256);
+  run_one("v_max_f32 v2, v0, v1", enc, /*sanitize_finite=*/true);
+}
+
+// v_ldexp_f16 v2, v0, v1  (CDNA4 VOP2 opcode 51) — f16 ldexp; vsrc1 is the
+// signed exponent. Raw inputs (ldexp NaN handling is bit-exact).
+TEST(VAddSimdBenchmark, Cdna4_VLdexpF16_Vop2) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t enc = vop2_encode(/*opcode=*/51, /*vdst=*/2, /*vsrc1=*/1, /*src0=*/256);
+  run_one("v_ldexp_f16 v2, v0, v1", enc, /*sanitize_finite=*/false);
+}
+
+// v_ceil_f16 v2, v0  (CDNA4 VOP1 opcode 69) — f16 op via f32 intermediate.
+TEST(VAddSimdBenchmark, Cdna4_VCeilF16_Vop1) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t enc = vop1_encode(/*opcode=*/69, /*vdst=*/2, /*src0=*/256);
+  run_one("v_ceil_f16 v2, v0", enc, /*sanitize_finite=*/false);
+}
+
+// v_cmp_lt_f64 (VOPC64 opcode 97): a real (non-accumulate) 64-bit-lane SIMD op
+// exercising the split lo/hi VGPR-pair read path. src0 = v0:v1, vsrc1 = v2:v3;
+// the compare result lands in VCC (run_one's v2 correctness pre-check is a no-op
+// here, but the timing is what matters). f64 fmac is NOT benched: its dst-
+// accumulate loop-carried RAW serializes both modes into a ~1x artifact.
+TEST(VAddSimdBenchmark, Cdna4_VCmpLtF64_Vopc) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  // VOPC: [31:25]=0x3E, op[24:17], vsrc1[16:9], src0[8:0].
+  uint32_t enc = (0x3Eu << 25) | (97u << 17) | (2u << 9) | 256u;
+  run_one("v_cmp_lt_f64 v0:v1, v2:v3", enc, /*sanitize_finite=*/false);
+}
+
+// v_cvt_i32_f64 v2, v0:v1  (CDNA4 VOP1 opcode 3) — f64 src -> 32-bit i32 dst via
+// the mixed-width cvt glue (8-wide f64 chunk, scalar lo/hi gather, clamp/NaN in
+// the double domain). Exact for any input (NaN->0, saturating clamp), so the
+// strict bit-exact pre-check holds on raw random doubles.
+TEST(VAddSimdBenchmark, Cdna4_VCvtI32F64_Vop1) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t enc = vop1_encode(/*opcode=*/3, /*vdst=*/2, /*src0=*/256);
+  run_one("v_cvt_i32_f64 v2, v0:v1", enc, /*sanitize_finite=*/false);
+}
+
+// v_cvt_f64_i32 v2:v3, v0  (CDNA4 VOP1 opcode 4) — 32-bit i32 src -> f64 dst
+// (exact widening) via the b32->f64 cvt glue (narrow32 load, write_simd64).
+TEST(VAddSimdBenchmark, Cdna4_VCvtF64I32_Vop1) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t enc = vop1_encode(/*opcode=*/4, /*vdst=*/2, /*src0=*/256);
+  run_one("v_cvt_f64_i32 v2:v3, v0", enc, /*sanitize_finite=*/false);
+}
+
+// v_cmp_class_f32 (VOPC opcode 16): src0 = v0, vsrc1 = v1 (10-bit class mask);
+// result -> VCC. The class-decode functor over the 32-bit VOPC glue. v2 is
+// untouched, so run_one's correctness pre-check is a no-op; timing is the point.
+TEST(VAddSimdBenchmark, Cdna4_VCmpClassF32_Vopc) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t enc = (0x3Eu << 25) | (16u << 17) | (1u << 9) | 256u;
+  run_one("v_cmp_class_f32 v0, v1", enc, /*sanitize_finite=*/false);
+}
+
+// v_cmp_class_f64 (VOPC opcode 18): src0 = v0:v1 (f64), vsrc1 = v2 (32-bit mask);
+// result -> VCC. The mixed-width class glue (read_simd64 value + narrow32 mask).
+TEST(VAddSimdBenchmark, Cdna4_VCmpClassF64_Vopc) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t enc = (0x3Eu << 25) | (18u << 17) | (2u << 9) | 256u;
+  run_one("v_cmp_class_f64 v0:v1, v2", enc, /*sanitize_finite=*/false);
+}
+
+// v_cmp_class_f32_e64 (VOP3 opcode 16): the VOP3 form of v_cmp_class — abs/neg
+// modifiers (0 here), mask from src1=v1, result into the SGPR-pair dst (VCC).
+// Shows the VOP3 class glue cost vs the VOPC form. word0[31:26]=0x34.
+TEST(VAddSimdBenchmark, Cdna4_VCmpClassF32_Vop3) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t w0 = (106u & 0xFF) | ((16u & 0x3FF) << 16) | (0x34u << 26); // vdst=VCC, op=16
+  uint32_t w1 = 256u | (1u << 9);                                      // src0=v0, src1=v1
+  run_words("v_cmp_class_f32_e64 v0, v1 -> vcc", w0, w1, /*sanitize_finite=*/false);
+}
+
+// === VOP3-encoded binary twins (src0/src1, abs/neg/omod/clamp modifiers) ===
+
+// v_add_f32_e64 v2, v0, v1  (CDNA4 VOP3 opcode 257) — no modifiers. Baseline
+// VOP3 f32 binary; should match the VOP2 v_add_f32 speedup (same functor, the
+// fp glue's modifier reads are zero-cost when all modifier fields are 0).
+TEST(VAddSimdBenchmark, Cdna4_VAddF32_Vop3) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t w0, w1;
+  vop3_bin_encode(257, /*vdst=*/2, /*src0=*/256, /*src1=*/257, 0, 0, 0, 0, w0, w1);
+  run_words("v_add_f32_e64 v2, v0, v1", w0, w1, /*sanitize_finite=*/true);
+}
+
+// v_add_f32_e64 v2, |v0|, -v1 *2 clamp  (CDNA4 VOP3 opcode 257) — all four
+// modifier kinds active. Shows the in-vector abs/neg/omod/clamp cost vs the
+// no-modifier form above. abs=src0, neg=src1, omod=1 (*2), clamp=1.
+TEST(VAddSimdBenchmark, Cdna4_VAddF32_Vop3_Modifiers) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t w0, w1;
+  vop3_bin_encode(257, /*vdst=*/2, /*src0=*/256, /*src1=*/257, /*abs=*/0x1, /*neg=*/0x2, /*omod=*/1,
+                  /*clamp=*/1, w0, w1);
+  run_words("v_add_f32_e64 |v0|,-v1 *2 clamp", w0, w1, /*sanitize_finite=*/true);
+}
+
+// v_mul_f32_e64 v2, v0, v1  (CDNA4 VOP3 opcode 261) — no modifiers.
+TEST(VAddSimdBenchmark, Cdna4_VMulF32_Vop3) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t w0, w1;
+  vop3_bin_encode(261, /*vdst=*/2, /*src0=*/256, /*src1=*/257, 0, 0, 0, 0, w0, w1);
+  run_words("v_mul_f32_e64 v2, v0, v1", w0, w1, /*sanitize_finite=*/true);
+}
+
+// v_and_b32_e64 v2, v0, v1  (CDNA4 VOP3 opcode 275) — integer/bitwise, plain.
+TEST(VAddSimdBenchmark, Cdna4_VAndB32_Vop3) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t w0, w1;
+  vop3_bin_encode(275, /*vdst=*/2, /*src0=*/256, /*src1=*/257, 0, 0, 0, 0, w0, w1);
+  run_words("v_and_b32_e64 v2, v0, v1", w0, w1, /*sanitize_finite=*/false);
+}
+
+// v_add_u32_e64 v2, v0, v1  (CDNA4 VOP3 opcode 308) — integer, plain.
+TEST(VAddSimdBenchmark, Cdna4_VAddU32_Vop3) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t w0, w1;
+  vop3_bin_encode(308, /*vdst=*/2, /*src0=*/256, /*src1=*/257, 0, 0, 0, 0, w0, w1);
+  run_words("v_add_u32_e64 v2, v0, v1", w0, w1, /*sanitize_finite=*/false);
+}
+
+// === VOP3-encoded unary twins ===
+
+// v_floor_f32_e64 v2, v0  (CDNA4 VOP3 opcode 351) — f32 unary, no modifiers.
+TEST(VAddSimdBenchmark, Cdna4_VFloorF32_Vop3) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t w0, w1;
+  vop3_bin_encode(351, /*vdst=*/2, /*src0=*/256, /*src1=*/0, 0, 0, 0, 0, w0, w1);
+  run_words("v_floor_f32_e64 v2, v0", w0, w1, /*sanitize_finite=*/true);
+}
+
+// v_floor_f32_e64 v2, -|v0| *2 clamp  (opcode 351) — full modifier set, shows
+// the in-vector abs/neg/omod/clamp cost on the unary fp path.
+TEST(VAddSimdBenchmark, Cdna4_VFloorF32_Vop3_Modifiers) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t w0, w1;
+  vop3_bin_encode(351, /*vdst=*/2, /*src0=*/256, /*src1=*/0, /*abs=*/0x1, /*neg=*/0x1, /*omod=*/1,
+                  /*clamp=*/1, w0, w1);
+  run_words("v_floor_f32_e64 -|v0| *2 clamp", w0, w1, /*sanitize_finite=*/true);
+}
+
+// v_cvt_f32_i32_e64 v2, v0  (CDNA4 VOP3 opcode 325) — plain int->float cvt
+// (reuses the VOP1 unary path, no modifiers).
+TEST(VAddSimdBenchmark, Cdna4_VCvtF32I32_Vop3) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t w0, w1;
+  vop3_bin_encode(325, /*vdst=*/2, /*src0=*/256, /*src1=*/0, 0, 0, 0, 0, w0, w1);
+  run_words("v_cvt_f32_i32_e64 v2, v0", w0, w1, /*sanitize_finite=*/false);
+}
+
+// === VOP3 form of the VOPC integer compares ===
+// dst is the SGPR-pair (we point at VCC=106) instead of the fixed VCC. v2 stays
+// untouched, so the correctness pre-check is a no-op (the compare result lands in
+// VCC); timing is the point.
+
+// v_cmp_lt_i32_e64 vcc, v0, v1  (CDNA4 VOP3 opcode 193) — 32-bit-lane integer.
+TEST(VAddSimdBenchmark, Cdna4_VCmpLtI32_Vop3) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t w0, w1;
+  vop3_bin_encode(193, /*vdst=*/106, /*src0=*/256, /*src1=*/257, 0, 0, 0, 0, w0, w1);
+  run_words("v_cmp_lt_i32_e64 vcc, v0, v1", w0, w1, /*sanitize_finite=*/false);
+}
+
+// v_cmp_lt_i64_e64 vcc, v0:v1, v2:v3  (CDNA4 VOP3 opcode 225) — 64-bit-lane
+// integer; exercises the split lo/hi VGPR-pair gather/scatter path (~half the
+// 32-bit speedup because 8-wide chunks + scalar lo/hi reads).
+TEST(VAddSimdBenchmark, Cdna4_VCmpLtI64_Vop3) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t w0, w1;
+  vop3_bin_encode(225, /*vdst=*/106, /*src0=*/256, /*src1=*/258, 0, 0, 0, 0, w0, w1);
+  run_words("v_cmp_lt_i64_e64 vcc, v0:v1, v2:v3", w0, w1, /*sanitize_finite=*/false);
+}
+
+// v_cmp_eq_f32_e64 vcc, v0, v1  (CDNA4 VOP3 opcode 66) — f32 with no modifiers.
+TEST(VAddSimdBenchmark, Cdna4_VCmpEqF32_Vop3) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t w0, w1;
+  vop3_bin_encode(66, /*vdst=*/106, /*src0=*/256, /*src1=*/257, 0, 0, 0, 0, w0, w1);
+  run_words("v_cmp_eq_f32_e64 vcc, v0, v1", w0, w1, /*sanitize_finite=*/true);
+}
+
+// v_cmp_eq_f32_e64 vcc, |v0|, -v1  (opcode 66) — both src abs/neg modifiers
+// set; shows the in-vector apply_vop3_src_mod_f32 cost vs the no-modifier form.
+TEST(VAddSimdBenchmark, Cdna4_VCmpEqF32_Vop3_Modifiers) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t w0, w1;
+  vop3_bin_encode(66, /*vdst=*/106, /*src0=*/256, /*src1=*/257, /*abs=*/0x1, /*neg=*/0x2, 0, 0, w0,
+                  w1);
+  run_words("v_cmp_eq_f32_e64 vcc, |v0|, -v1", w0, w1, /*sanitize_finite=*/true);
+}
+
+// v_cmp_eq_f16_e64 vcc, v0, v1  (CDNA4 VOP3 opcode 34) — f16 widen-then-compare.
+// Pays the f16_to_f32_simd widen tax on both operands; no modifiers.
+TEST(VAddSimdBenchmark, Cdna4_VCmpEqF16_Vop3) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t w0, w1;
+  vop3_bin_encode(34, /*vdst=*/106, /*src0=*/256, /*src1=*/257, 0, 0, 0, 0, w0, w1);
+  run_words("v_cmp_eq_f16_e64 vcc, v0, v1", w0, w1, /*sanitize_finite=*/false);
+}
+
+// v_cmp_eq_f64_e64 vcc, v0:v1, v2:v3  (CDNA4 VOP3 opcode 98) — 64-bit-lane
+// f64, split lo/hi gather/scatter, no modifiers.
+TEST(VAddSimdBenchmark, Cdna4_VCmpEqF64_Vop3) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t w0, w1;
+  vop3_bin_encode(98, /*vdst=*/106, /*src0=*/256, /*src1=*/258, 0, 0, 0, 0, w0, w1);
+  run_words("v_cmp_eq_f64_e64 vcc, v0:v1, v2:v3", w0, w1, /*sanitize_finite=*/false);
+}
+
+// === VOP3 integer ternary (src0/src1/src2, no modifiers) ===
+//
+// v_add3_u32 v2, v0, v1, v3  (CDNA4 VOP3 opcode 511) — plain element-wise
+// a + b + c on 32-bit lanes. src2 is wired through the ternary VOP3 glue.
+TEST(VAddSimdBenchmark, Cdna4_VAdd3U32_Vop3) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  // VOP3: word0 = vdst|op<<16|0x34<<26; word1 = src0|src1<<9|src2<<18.
+  uint32_t w0 = (2u) | ((511u & 0x3FF) << 16) | (0x34u << 26);
+  uint32_t w1 = 256u | (1u << 9) | (3u << 18); // src0=v0 src1=v1 src2=v3
+  run_words("v_add3_u32_e64 v2, v0, v1, v3", w0, w1, /*sanitize_finite=*/false);
+}
+
+// v_cvt_i32_f64_e64 v2, v0:v1  (CDNA4 VOP3 opcode 323) — VOP3 form of the f64
+// cvt. Routed through the existing SIMD_CVT_F64_TO_B32 glue via a _vop3->_vop1
+// fallback (the scalar body drops the abs/neg/omod/clamp modifier reads).
+TEST(VAddSimdBenchmark, Cdna4_VCvtI32F64_Vop3) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t w0, w1;
+  vop3_bin_encode(323, /*vdst=*/2, /*src0=*/256, /*src1=*/0, 0, 0, 0, 0, w0, w1);
+  run_words("v_cvt_i32_f64_e64 v2, v0:v1", w0, w1, /*sanitize_finite=*/false);
+}
+
+// v_add_f64_e64 v2:v3, v0:v1, v4:v5  (CDNA4 VOP3 opcode 640) — 64-bit-lane f64
+// binary via the new try_execute_binary_vop3_fp64_simd glue.
+TEST(VAddSimdBenchmark, Cdna4_VAddF64_Vop3) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t w0, w1;
+  vop3_bin_encode(640, /*vdst=*/2, /*src0=*/256, /*src1=*/260, 0, 0, 0, 0, w0, w1);
+  run_words("v_add_f64_e64 v2:v3, v0:v1, v4:v5", w0, w1, /*sanitize_finite=*/false);
+}
+
+// v_ceil_f64_e64 v2:v3, v0:v1  (CDNA4 VOP3 opcode 344) — f64 unary; uses the
+// new try_execute_unary_vop3_fp64_simd glue (stdx::ceil on native<double>).
+TEST(VAddSimdBenchmark, Cdna4_VCeilF64_Vop3) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t w0, w1;
+  vop3_bin_encode(344, /*vdst=*/2, /*src0=*/256, /*src1=*/0, 0, 0, 0, 0, w0, w1);
+  run_words("v_ceil_f64_e64 v2:v3, v0:v1", w0, w1, /*sanitize_finite=*/false);
+}
+
+// v_ceil_f16_e64 v2, v0  (CDNA4 VOP3 opcode 389) — f16 unary; widen-then-narrow
+// VOP3 glue. Pays the f16<->f32 round-trip on top of the rounding op.
+TEST(VAddSimdBenchmark, Cdna4_VCeilF16_Vop3) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t w0, w1;
+  vop3_bin_encode(389, /*vdst=*/2, /*src0=*/256, /*src1=*/0, 0, 0, 0, 0, w0, w1);
+  run_words("v_ceil_f16_e64 v2, v0", w0, w1, /*sanitize_finite=*/false);
+}
+
+// v_div_fmas_f32_e64 v6, v0, v1, v2  (CDNA4 VOP3 opcode 482) — fma(s0,s1,s2)
+// followed by a VCC-bit-gated ldexp(result, 32); no omod/clamp. Tests the
+// new try_execute_div_fmas_f32_simd glue and its VCC input-mask path.
+TEST(VAddSimdBenchmark, Cdna4_VDivFmasF32_Vop3) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t w0 = (6u) | ((482u & 0x3FF) << 16) | (0x34u << 26);
+  uint32_t w1 = 256u | (1u << 9) | (2u << 18); // src0=v0 src1=v1 src2=v2
+  run_words("v_div_fmas_f32_e64 v6, v0, v1, v2", w0, w1, /*sanitize_finite=*/true);
+}
+
+// v_cndmask_b32_e64 v2, v0, v1, vcc  (CDNA4 VOP3 opcode 256) — VOP3 form of
+// the VCC-driven select; selector is an SGPR-pair operand (src2=VCC=106), so
+// the path is bit-identical to the VOP2 form. No modifiers applied by scalar.
+TEST(VAddSimdBenchmark, Cdna4_VCndmaskB32_Vop3) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  // VOP3 ternary encoding: word0 = vdst|op<<16|0x34<<26; word1 = src0|src1<<9|
+  // src2<<18. src2=VCC=106. Selector pattern is set by seed_inputs (vcc init).
+  uint32_t w0 = (2u) | ((256u & 0x3FF) << 16) | (0x34u << 26);
+  uint32_t w1 = 256u | (1u << 9) | (106u << 18);
+  run_words("v_cndmask_b32_e64 v2, v0, v1, vcc", w0, w1, /*sanitize_finite=*/false);
+}
+
+// v_rcp_f16_e64 v2, v0  (CDNA4 VOP3 opcode 381) — f16 transcendental; widen
+// f16->f32, FTZ-flush input, IEEE 1/x, FTZ-flush output, narrow f32->f16. Pays
+// the f16<->f32 round-trip on top of the rcp helper. Same NaN-passthrough
+// (input NaN bits preserved) in both scalar and SIMD paths, so the bit-exact
+// pre-check holds on raw random inputs (no `sanitize_finite` needed).
+TEST(VAddSimdBenchmark, Cdna4_VRcpF16_Vop3) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t w0, w1;
+  vop3_bin_encode(381, /*vdst=*/2, /*src0=*/256, /*src1=*/0, 0, 0, 0, 0, w0, w1);
+  run_words("v_rcp_f16_e64 v2, v0", w0, w1, /*sanitize_finite=*/false);
+}
+
+// v_fma_f32_e64 v6, v0, v1, v2  (CDNA4 VOP3 opcode 459) — f32 ternary FMA via
+// the new try_execute_ternary_vop3_fp_simd glue. Encoded with src2=v2 (NOT
+// dst-accumulate; the v_fmac form is deferred to a separate slice).
+TEST(VAddSimdBenchmark, Cdna4_VFmaF32_Vop3) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  // VOP3 ternary: word0 vdst|op<<16|0x34<<26; word1 src0|src1<<9|src2<<18.
+  uint32_t w0 = (6u) | ((459u & 0x3FF) << 16) | (0x34u << 26);
+  uint32_t w1 = 256u | (1u << 9) | (2u << 18); // src0=v0 src1=v1 src2=v2
+  run_words("v_fma_f32_e64 v6, v0, v1, v2", w0, w1, /*sanitize_finite=*/true);
 }
 
 // Diagnostic: report whether the SIMD fast path is compiled in.


### PR DESCRIPTION
## Motivation

* Part of a batch of PRs to enable SIMD execution for the functional simulator.
* Adds the SIMD fast-path infrastructure (`util/simd.h` + `shared/simd_glue.h` + `codegen/execute/simd_codegen.py`, with probes emitted into the generated `shared/execute_shared.h`) and wires a broad set of AMDGPU vector opcodes through it.
* **This PR focuses on CDNA4 coverage.** Other ISAs share the same generated probes opportunistically, but CDNA4 is the validation target. ~611 VALU probes are emitted into the shared execute header.
* **MFMA SIMD is split into a follow-up PR** (branch `users/lialan/rocjitsu_simd_mfma`, stacked on this one); this PR keeps MFMA on the scalar path.

## VGPR access through `simdojo::VectorReg`

The SIMD fast paths read and write the VGPR file **only** through `simdojo::VectorReg` and its accessors — no raw lane pointer crosses the operand/glue API.

* `VectorReg` exposes `simd_load<T>` / `simd_store<T>` (value-in / value-out, so the storage pointer never escapes the object) and `lane_data()` (a typed contiguous base for the 64-bit `{lo, hi}` VGPR-pair path).
* `ComputeUnitCore::vgpr_reg<N>` recovers the file's typed `VectorReg<N, uint32_t>` from the type-erased `vgpr_data()` byte pointer with the design's single localized `reinterpret_cast`, guarded by a layout `static_assert`.
* `Operand` resolves a register to its typed view via `simd_vgpr_storage` / `simd_vgpr_storage_mut` (32-bit) and `simd_vgpr_storage64` / `simd_vgpr_storage64_mut` (the 64-bit lo/hi pair), each in a **single virtual dispatch** on the per-instruction hot path — so codegen and throughput match a raw-pointer baseline (the execute-body benches show no aggregate regression).

## Enablements

Coverage spans VOP1/VOP2/VOPC/VOP3/VOP3P:

* **VOP2**: binary, carry (`_co`/`_ci`), ternary-FMA (`fma`/`fmac` f32 + f64), cndmask; 16-bit and f16 variants.
* **VOP1**: 32-bit unary (~100 ops), f16 via f32 intermediate, 64-bit-lane f64 math + `v_mov_b64`, ubyte / `bfrev`, float→int clamp/NaN cvt, f8→f32 cvt, `frexp` (f32/f16/f64), bit-scan (`ffbh`/`ffbl`/`cls`/`clz`/`ctz`/`bcnt`), `v_accvgpr_mov_b32`.
* **Mixed-width conversions**: f64↔32-bit cvt via `narrow32` primitives; `v_cvt_pk_{i16,u16}_{i32,u32}`.
* **VOPC**: 32/16/64-bit-lane compares; `v_cmp_class` f16/f32/f64 (VOPC) and f16/f32/f64 (VOP3, with abs/neg modifiers + SGPR-pair dst).
* **VOP3**: binary int (incl. `min3`/`max3`/`med3`, mad-int, `bfe`, extras) and fp64; unary int / fp16 / fp64; ternary int / f16 / f32 / f64 (`mad`/`fma`, `lerp`, `perm`, `sad`); carry (`_co` / `_cin`); 64-bit shifts (`lshl`/`lshr`/`ashr_b64`, `lshl_add_u64`); wide `mad_u64`/`mad_i64`; `div_fmas`; `ldexp`; `fmac` f16/f32/f64; `cndmask` + `cndmask_b16`; division-helper ops.
* **VOP3P (packed)**: packed-16 integer (`add`/`sub`/`mul_lo`/`min`/`max`/shifts/`mad`), packed-16 f16 (`add`/`mul`/`min`/`max`/`fma`), `fma_mix`/`mad_mix`, `v_pk_mov_b32`, and dot products (`v_dot4_i32_i8` / `_u32_u8`, `v_dot8_i32_i4` / `_u32_u4`, `v_dot2_i32_i16` / `_u32_u16` / `_f32_f16`).
* **util**: bit-exact f16↔f32 conversions, SWAR / bitfield helpers, flush / `where` helpers.

The fast path is gated per-op (`simd_capable()` operands, modifier checks) and falls back to the scalar body for any shape it does not handle, so it is always behavior-preserving.

## Not yet enabled

* **MFMA** (matrix-multiply) — split to the follow-up PR `users/lialan/rocjitsu_simd_mfma`.
* **Cross-lane / data-movement**: `permlane*`, `ds_swizzle`, `movrel*`, and the full DPP / SDWA cross-lane forms — these shuffle data between lanes and don't fit the per-lane SIMD model used here.
* **`v_sin` / `v_cos`**: the vectorized libm path is ~1 ULP off the scalar IEEE body, so they are deliberately excluded to keep bit-identity.
* **A few bespoke VOP3/VOP3P ops** (e.g. `div_scale` and the remaining packed cross-lane VOP3P variants).
* **Non-ALU subsystems**: memory / LDS / flat / global, control flow, and message ops are out of scope (handled separately).
* **ISAs other than CDNA4** are not the focus of this PR; they ride the shared probes where the encoding matches but are not validated here.

## Test Plan

* scalar-vs-SIMD bit-identity (full + partial EXEC, edge lanes), per op family, for both the 32-bit and 64-bit (`{lo, hi}` VGPR-pair) paths.
* util guards.
* speedup benches.

## Testing methodology
* Tested on AMD Ryzen Threadripper PRO 7975WX, compiled with g++-13, with `-march=native`.
* 100-iteration warm-up, then 200,000 calls to `execute_instruction(inst, wf)`; measure total ns → ns/instruction for each mode.
* Assert bit-identity at the end to ensure correctness.
* Speedups below remeasured on the current branch tip (the figures vary by build `-march`; these are AVX-512 / `-march=native`). The figures are execute-body microbenchmarks (scalar vs. SIMD `ns/instruction`), not end-to-end.
```
  ┌────────────────────────────┬──────────────────────────────────────────────┬─────────────┐
  │        Op category         │              Representative ops              │   Speedup   │
  ├────────────────────────────┼──────────────────────────────────────────────┼─────────────┤
  │ Compare → VCC              │ v_cmp_eq_f32, v_cmp_class_f32, v_cmp_lt_i32  │ ~16–19×     │
  ├────────────────────────────┼──────────────────────────────────────────────┼─────────────┤
  │ Move / bitwise (32b)       │ v_and_b32, v_mov_b32, v_xor_b32              │ ~33×        │
  ├────────────────────────────┼──────────────────────────────────────────────┼─────────────┤
  │ Integer arith (32b)        │ v_add_u32, v_add3_u32, v_mul_hi_u32_u24      │ ~29–32×     │
  ├────────────────────────────┼──────────────────────────────────────────────┼─────────────┤
  │ FP32 arith                 │ v_add_f32, v_mul_f32                         │ ~33–34×     │
  ├────────────────────────────┼──────────────────────────────────────────────┼─────────────┤
  │ FP32 fma / mad             │ v_fma_f32, v_fmaak_f32, v_div_fmas_f32       │ ~22–31×     │
  ├────────────────────────────┼──────────────────────────────────────────────┼─────────────┤
  │ Int ↔ FP32 convert         │ v_cvt_f32_i32, v_cvt_i32_f64                 │ ~25–34×     │
  ├────────────────────────────┼──────────────────────────────────────────────┼─────────────┤
  │ F16 (via f32 intermediate) │ v_add_f16, v_rcp_f16, v_ceil_f16             │ ~12–15×     │
  ├────────────────────────────┼──────────────────────────────────────────────┼─────────────┤
  │ F64 (split lo/hi path)     │ v_add_f64, v_ceil_f64, v_cmp_lt_f64          │ ~19–21×     │
  └────────────────────────────┴──────────────────────────────────────────────┴─────────────┘
```

