### PR TITLE
rocrtst: fix ASan memory free by using hsa_amd_pointer_info base address

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/functional/memory_basic.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/memory_basic.cc
@@ -138,15 +138,12 @@ hsa_status_t MemoryTest::TestAllocate(hsa_amd_memory_pool_t pool, size_t sz) {
   err = hsa_amd_memory_pool_allocate(pool, sz, 0, &ptr);
 
   if (err == HSA_STATUS_SUCCESS) {
-#ifdef ROCRTST_ASAN
-    // Under ASAN, hsa_amd_memory_pool_allocate returns base+PAGE_SIZE (ASAN header offset).
-    // hsa_memory_free is not intercepted by the ASAN runtime, so it receives the offset pointer
-    // and fails to find it in allocation_map_. Use hsa_amd_memory_pool_free which IS intercepted
-    // and correctly strips the PAGE_SIZE offset before calling into ROCr.
-    err = hsa_amd_memory_pool_free(ptr);
-#else
-    err = hsa_memory_free(ptr);
-#endif
+    hsa_amd_pointer_info_t pi = {};
+    pi.size = sizeof(pi);
+    hsa_status_t info_err = hsa_amd_pointer_info(ptr, &pi, NULL, 0, NULL);
+    err = (info_err == HSA_STATUS_SUCCESS)
+        ? hsa_memory_free(pi.agentBaseAddress)
+        : info_err;
   }
 
   return err;
@@ -456,7 +453,13 @@ void MemoryTest::MemAvailableTest(hsa_agent_t ag, hsa_amd_memory_pool_t pool) {
   ASSERT_SUCCESS(hsa_amd_pointer_info(memPtr1, &info, NULL, 0, NULL));
 
   ASSERT_EQ(info.type, HSA_EXT_POINTER_TYPE_HSA);
+#ifdef ROCRTST_ASAN
+  // ASAN adds overhead to the underlying allocation, and hsa_amd_pointer_info
+  // reports that full backing size rather than the user-requested size.
+  ASSERT_GE(info.sizeInBytes, allocate_sz1);
+#else
   ASSERT_EQ(info.sizeInBytes, allocate_sz1);
+#endif
   ASSERT_EQ(info.agentOwner.handle, ag.handle);
   // ROCR may return a smaller size of info if it is an older version of ROCr and ROCr's
   // internal definition hsa_amd_pointer_info_t is smaller than the users. But ROCr cannot
@@ -506,15 +509,12 @@ void MemoryTest::MemAvailableTest(hsa_agent_t ag, hsa_amd_memory_pool_t pool) {
 
 
   err = hsa_amd_memory_pool_allocate(pool, allocate_sz2, 0, &memPtr2);
-#ifdef ROCRTST_ASAN
-  // Under ASAN, hsa_amd_memory_pool_allocate returns base+PAGE_SIZE (ASAN header offset).
-  // hsa_memory_free is not intercepted by the ASAN runtime, so it receives the offset pointer
-  // and fails to find it in allocation_map_. Use hsa_amd_memory_pool_free which IS intercepted
-  // and correctly strips the PAGE_SIZE offset before calling into ROCr.
-  if (err != HSA_STATUS_SUCCESS) hsa_amd_memory_pool_free(memPtr1);
-#else
-  if (err != HSA_STATUS_SUCCESS) hsa_memory_free(memPtr1);
-#endif
+  if (err != HSA_STATUS_SUCCESS) {
+    hsa_amd_pointer_info_t pi = {};
+    pi.size = sizeof(pi);
+    if (hsa_amd_pointer_info(memPtr1, &pi, NULL, 0, NULL) == HSA_STATUS_SUCCESS)
+      hsa_memory_free(pi.agentBaseAddress);
+  }
   ASSERT_EQ(err, HSA_STATUS_SUCCESS);
 
   err = hsa_agent_get_info(ag, (hsa_agent_info_t)HSA_AMD_AGENT_INFO_MEMORY_AVAIL,
@@ -531,27 +531,18 @@ void MemoryTest::MemAvailableTest(hsa_agent_t ag, hsa_amd_memory_pool_t pool) {
     std::cout << "   Available memory after: " << ag_avail_memory_after << std::endl;
   }
 
-#ifdef ROCRTST_ASAN
-  // Under ASAN, hsa_amd_memory_pool_allocate returns base+PAGE_SIZE (ASAN header offset).
-  // hsa_memory_free is not intercepted by the ASAN runtime, so it receives the offset pointer
-  // and fails to find it in allocation_map_. Use hsa_amd_memory_pool_free which IS intercepted
-  // and correctly strips the PAGE_SIZE offset before calling into ROCr.
-  err = hsa_amd_memory_pool_free(memPtr1);
-#else
-  err = hsa_memory_free(memPtr1);
-#endif
+  hsa_amd_pointer_info_t pi1 = {};
+  pi1.size = sizeof(pi1);
+  err = hsa_amd_pointer_info(memPtr1, &pi1, NULL, 0, NULL);
+  ASSERT_EQ(err, HSA_STATUS_SUCCESS);
+  err = hsa_memory_free(pi1.agentBaseAddress);
   ASSERT_EQ(err, HSA_STATUS_SUCCESS);
 
-#ifdef ROCRTST_ASAN
-  // Under ASAN, hsa_amd_memory_pool_allocate returns base+PAGE_SIZE (ASAN header offset).
-  // hsa_memory_free is not intercepted by the ASAN runtime, so it receives the offset pointer
-  // and fails to find it in allocation_map_. Use hsa_amd_memory_pool_free which IS intercepted
-  // and correctly strips the PAGE_SIZE offset before calling into ROCr.
-
-  err = hsa_amd_memory_pool_free(memPtr2);
-#else
-  err = hsa_memory_free(memPtr2);
-#endif
+  hsa_amd_pointer_info_t pi2 = {};
+  pi2.size = sizeof(pi2);
+  err = hsa_amd_pointer_info(memPtr2, &pi2, NULL, 0, NULL);
+  ASSERT_EQ(err, HSA_STATUS_SUCCESS);
+  err = hsa_memory_free(pi2.agentBaseAddress);
   ASSERT_EQ(err, HSA_STATUS_SUCCESS);
 
   err = hsa_agent_get_info(ag, (hsa_agent_info_t)HSA_AMD_AGENT_INFO_MEMORY_AVAIL,


### PR DESCRIPTION
Under ASan, the intercepted hsa_amd_memory_pool_allocate returns an
offset pointer (real_base + PAGE_SIZE). The intercepted free cannot
always reverse-map this back to the real base, causing "Can't find
address in allocation map" errors.

Fix by using hsa_amd_pointer_info to retrieve agentBaseAddress (the
real allocation base known to the runtime) and passing it directly to
hsa_memory_free (which is not intercepted). This approach works
correctly in both ASan and non-ASan builds, eliminating the need for
#ifdef blocks around free paths.

Also relax the sizeInBytes check under ASan (ASSERT_GE) since the
runtime reports the full backing size including ASan overhead.
   
**JIRA**: [ROCM-25264](https://amd-hub.atlassian.net/browse/ROCM-25264)

[ROCM-25264]: https://amd-hub.atlassian.net/browse/ROCM-25264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ