### PR TITLE
[rocjitsu] Add CI workflow (TheRock tarball approach)

### DIFF
--- a/.github/workflows/rocjitsu-ci.yml
+++ b/.github/workflows/rocjitsu-ci.yml
@@ -70,12 +70,12 @@ jobs:
         run: >
           cmake -B build -G Ninja
           -S emulation/rocjitsu
-          -DCMAKE_C_COMPILER=$ROCM_PATH/lib/llvm/bin/clang
-          -DCMAKE_CXX_COMPILER=$ROCM_PATH/lib/llvm/bin/clang++
+          -DCMAKE_C_COMPILER="$ROCM_PATH/lib/llvm/bin/clang"
+          -DCMAKE_CXX_COMPILER="$ROCM_PATH/lib/llvm/bin/clang++"
           -DCMAKE_BUILD_TYPE=Release
 
       - name: Build
-        run: cmake --build build -j$(nproc)
+        run: cmake --build build
 
       - name: Test
         run: >

--- a/.github/workflows/rocjitsu-ci.yml
+++ b/.github/workflows/rocjitsu-ci.yml
@@ -73,7 +73,6 @@ jobs:
           -DCMAKE_C_COMPILER=$ROCM_PATH/lib/llvm/bin/clang
           -DCMAKE_CXX_COMPILER=$ROCM_PATH/lib/llvm/bin/clang++
           -DCMAKE_BUILD_TYPE=Release
-          -DCMAKE_CXX_FLAGS="-Werror"
 
       - name: Build
         run: cmake --build build -j$(nproc)

--- a/.github/workflows/rocjitsu-ci.yml
+++ b/.github/workflows/rocjitsu-ci.yml
@@ -2,8 +2,8 @@
 #
 # How it works:
 #   1. Sparse-checkout emulation/rocjitsu
-#   2. Download a TheRock nightly tarball (provides amdclang++, device
-#      libraries, and rocBLAS for compiling and running tests)
+#   2. Fetch the latest TheRock nightly tarball (provides amdclang++,
+#      device libraries, and rocBLAS for compiling and running tests)
 #   3. Build with TheRock's clang + ninja in Release mode
 #   4. Run the full ctest suite on the CPU emulator
 #
@@ -40,22 +40,31 @@ jobs:
     name: Linux (TheRock clang, Release)
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: emulation/rocjitsu
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y ninja-build libdrm-dev
+        run: sudo apt-get update && sudo apt-get install -y ninja-build libdrm-dev python3-pip
+
+      - name: Find latest TheRock tarball
+        id: therock
+        run: |
+          python3 -m pip install -U awscli
+          export PATH=~/.local/bin:$PATH
+          KEY=$(aws s3api list-objects-v2 \
+                --bucket therock-nightly-tarball \
+                --no-sign-request \
+                --output json \
+                --query "sort_by(Contents[?contains(Key, 'linux-multiarch')], &LastModified)[-1].Key")
+          KEY=${KEY//\"/}
+          test -n "$KEY" || { echo "No multiarch tarball found"; exit 1; }
+          echo "tarball=${KEY}" >> $GITHUB_OUTPUT
 
       - name: Install ROCm (TheRock tarball)
         run: |
-          # TheRock multiarch nightly: includes gfx942 (CDNA3) and
-          # gfx950 (CDNA4) device libraries and Tensile kernels.
-          # Browse available tarballs at:
-          #   https://rocm.nightlies.amd.com/tarball-multi-arch/
-          # TODO: pin to a stable release once TheRock publishes one.
-          TARBALL=therock-dist-linux-multiarch-7.14.0a20260527.tar.gz
-          wget -q "https://rocm.nightlies.amd.com/tarball-multi-arch/$TARBALL"
+          wget -q "https://therock-nightly-tarball.s3.us-east-2.amazonaws.com/${{ steps.therock.outputs.tarball }}"
+          TARBALL=$(basename "${{ steps.therock.outputs.tarball }}")
           mkdir rocm && tar xf "$TARBALL" -C rocm
           echo "ROCM_PATH=$PWD/rocm" >> $GITHUB_ENV
           echo "LD_LIBRARY_PATH=$PWD/rocm/lib" >> $GITHUB_ENV

--- a/.github/workflows/rocjitsu-ci.yml
+++ b/.github/workflows/rocjitsu-ci.yml
@@ -1,0 +1,86 @@
+# rocjitsu CI: build from source and run the full test suite.
+#
+# How it works:
+#   1. Sparse-checkout emulation/rocjitsu
+#   2. Download a TheRock nightly tarball (provides hipcc, amdclang++,
+#      device libraries, and rocBLAS for compiling and running tests)
+#   3. Build with clang + ninja in Release mode
+#   4. Run the full ctest suite on the CPU emulator
+#
+# No GPU hardware is needed. rocjitsu's tests run on its built-in
+# CPU emulator, which simulates AMD GPU execution. HIP kernels are
+# compiled for gfx950 by hipcc, then loaded and executed by the
+# emulator at test time.
+#
+# Excluded tests:
+#   RocminfoTest — spawns rocminfo under LD_PRELOAD with the KMD
+#   interposer, which requires /dev/kfd (unavailable on CI runners).
+#   RocblasGemmTest.Large_2048x2048 — times out on CI runners (the
+#   emulator is too slow for this matrix size).
+
+name: rocjitsu CI
+
+on:
+  pull_request:
+    paths:
+      - "emulation/rocjitsu/**"
+      - ".github/workflows/rocjitsu-ci.yml"
+  push:
+    branches: [develop]
+    paths:
+      - "emulation/rocjitsu/**"
+      - ".github/workflows/rocjitsu-ci.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-test:
+    name: Linux (clang, Release)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          sparse-checkout: emulation/rocjitsu
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y ninja-build clang libdrm-dev
+
+      - name: Install ROCm (TheRock tarball)
+        run: |
+          # TheRock multiarch nightly: includes gfx942 (CDNA3) and
+          # gfx950 (CDNA4) device libraries and Tensile kernels.
+          # Browse available tarballs at:
+          #   https://rocm.nightlies.amd.com/tarball-multi-arch/
+          # TODO: pin to a stable release once TheRock publishes one.
+          TARBALL=therock-dist-linux-multiarch-7.14.0a20260527.tar.gz
+          wget -q "https://rocm.nightlies.amd.com/tarball-multi-arch/$TARBALL"
+          mkdir rocm && tar xf "$TARBALL" -C rocm
+          echo "ROCM_PATH=$PWD/rocm" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$PWD/rocm/lib" >> $GITHUB_ENV
+
+          # Sanity check
+          rocm/bin/hipcc --version
+          echo '__global__ void k(){}' \
+            | rocm/bin/hipcc -x hip --offload-arch=gfx950 \
+              --cuda-device-only -c -o /dev/null -
+
+      - name: Configure
+        run: >
+          cmake -B build -G Ninja
+          -S emulation/rocjitsu
+          -DCMAKE_C_COMPILER=clang
+          -DCMAKE_CXX_COMPILER=clang++
+          -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_CXX_FLAGS="-Werror"
+
+      - name: Build
+        run: cmake --build build -j$(nproc)
+
+      - name: Test
+        run: >
+          ctest --test-dir build
+          --output-on-failure
+          --timeout 120
+          --exclude-regex "RocminfoTest|RocblasGemmTest.Large"

--- a/.github/workflows/rocjitsu-ci.yml
+++ b/.github/workflows/rocjitsu-ci.yml
@@ -2,14 +2,14 @@
 #
 # How it works:
 #   1. Sparse-checkout emulation/rocjitsu
-#   2. Download a TheRock nightly tarball (provides hipcc, amdclang++,
-#      device libraries, and rocBLAS for compiling and running tests)
-#   3. Build with clang + ninja in Release mode
+#   2. Download a TheRock nightly tarball (provides amdclang++, device
+#      libraries, and rocBLAS for compiling and running tests)
+#   3. Build with TheRock's clang + ninja in Release mode
 #   4. Run the full ctest suite on the CPU emulator
 #
 # No GPU hardware is needed. rocjitsu's tests run on its built-in
 # CPU emulator, which simulates AMD GPU execution. HIP kernels are
-# compiled for gfx950 by hipcc, then loaded and executed by the
+# compiled for gfx950 by amdclang++, then loaded and executed by the
 # emulator at test time.
 #
 # Excluded tests:
@@ -37,7 +37,7 @@ permissions:
 
 jobs:
   build-test:
-    name: Linux (clang, Release)
+    name: Linux (TheRock clang, Release)
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -45,7 +45,7 @@ jobs:
           sparse-checkout: emulation/rocjitsu
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y ninja-build clang libdrm-dev
+        run: sudo apt-get update && sudo apt-get install -y ninja-build libdrm-dev
 
       - name: Install ROCm (TheRock tarball)
         run: |
@@ -61,17 +61,17 @@ jobs:
           echo "LD_LIBRARY_PATH=$PWD/rocm/lib" >> $GITHUB_ENV
 
           # Sanity check
-          rocm/bin/hipcc --version
+          rocm/bin/amdclang++ --version
           echo '__global__ void k(){}' \
-            | rocm/bin/hipcc -x hip --offload-arch=gfx950 \
+            | rocm/bin/amdclang++ -x hip --offload-arch=gfx950 \
               --cuda-device-only -c -o /dev/null -
 
       - name: Configure
         run: >
           cmake -B build -G Ninja
           -S emulation/rocjitsu
-          -DCMAKE_C_COMPILER=clang
-          -DCMAKE_CXX_COMPILER=clang++
+          -DCMAKE_C_COMPILER=$ROCM_PATH/lib/llvm/bin/clang
+          -DCMAKE_CXX_COMPILER=$ROCM_PATH/lib/llvm/bin/clang++
           -DCMAKE_BUILD_TYPE=Release
           -DCMAKE_CXX_FLAGS="-Werror"
 

--- a/emulation/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.25)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 include(rj_default_compiler)
@@ -168,6 +168,7 @@ FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
     GIT_TAG v1.15.2
+    SYSTEM
 )
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
@@ -177,6 +178,7 @@ FetchContent_Declare(
     flatbuffers
     GIT_REPOSITORY https://github.com/google/flatbuffers.git
     GIT_TAG v24.3.25
+    SYSTEM
 )
 set(FLATBUFFERS_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 set(FLATBUFFERS_INSTALL OFF CACHE BOOL "" FORCE)

--- a/emulation/rocjitsu/tests/kernels/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/kernels/CMakeLists.txt
@@ -117,3 +117,5 @@ add_custom_target(
 # Export variables to the parent scope so the test executable can use them.
 set(HAS_DEVICE_KERNELS TRUE PARENT_SCOPE)
 set(KERNEL_OUTPUT_DIR ${KERNEL_OUTPUT_DIR} PARENT_SCOPE)
+set(AMDCLANG ${AMDCLANG} PARENT_SCOPE)
+set(ROCM_PATH ${ROCM_PATH} PARENT_SCOPE)


### PR DESCRIPTION
## Summary

Workflow that 
1) Downloads an all architectures wheel from TheRock (~10 GB -- 2x larger than apt installing rocm, but arguably cleaner). 
2) Builds (about 10 minutes, more than half of total workflow time)
3) Runs all tests (except the one large matmul test that takes 2+ minutes)