### PR TITLE
[rocjitsu] Close raw-pointer escape in SIMD read path

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
@@ -32,18 +32,19 @@ using float32_t = float;
 /// kernels that have one. Forwards to util::force_scalar().
 inline bool &simd_force_scalar() { return util::force_scalar(); }
 
-/// SIMD load of an operand at `lane_base`. Returns a contiguous SIMD
-/// load when the operand resolves to per-lane VGPR storage; otherwise
-/// broadcasts the operand's scalar value. Constrained on
-/// `util::has_stdx_simd` so toolchains without `<experimental/simd>`
-/// remove this overload from the candidate set entirely.
+/// SIMD load of an operand at `lane_base`. Copies lane data into an
+/// aligned local buffer via `SimdAccess::read_lanes` (which also fires
+/// the plugin notification), then SIMD-loads from the buffer. No raw
+/// pointer to the register file escapes this function. For non-VGPR
+/// operands, broadcasts the scalar value instead.
 template <typename T, typename Op>
   requires(util::has_stdx_simd)
 inline util::native<T> read_simd(const Op &op, const Wavefront &wf, uint32_t lane_base) {
   static_assert(sizeof(T) == sizeof(uint32_t), "read_simd: T must be a 32-bit lane type");
-  const uint32_t *p = SimdAccess::lane_ptr(op, wf, lane_base);
-  if (p)
-    return util::load<T>(p);
+  constexpr auto W = static_cast<uint32_t>(util::native_width_v<T>);
+  alignas(util::native<T>) uint32_t buf[W];
+  if (SimdAccess::read_lanes(op, wf, lane_base, W, buf))
+    return util::load<T>(buf);
   return util::broadcast<T>(op.read_scalar(wf));
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/isa_operand_simd_inl.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/isa_operand_simd_inl.h
@@ -33,11 +33,8 @@ void AmdgpuIsaOperand<Isa>::read_lane_chunk(const amdgpu::Wavefront &wf, uint32_
     this->delegate()->read_lane_chunk(wf, lane_base, count, out);
     return;
   }
-  if (auto off = Isa::resolved_vgpr_offset(this->opr_type_, this->encoding_value_)) {
-    const uint8_t *src = wf.cu().vgpr_data(wf.vgpr_alloc().base + *off);
-    std::memcpy(out, src + lane_base * sizeof(uint32_t), count * sizeof(uint32_t));
+  if (simd_read_lanes(wf, lane_base, count, out))
     return;
-  }
   std::fill_n(out, count, Isa::simd_broadcast_value(wf, this->opr_type_, this->encoding_value_));
 }
 
@@ -63,15 +60,18 @@ void AmdgpuIsaOperand<Isa>::write_lane_chunk(amdgpu::Wavefront &wf, uint32_t lan
 }
 
 template <typename Isa>
-const uint32_t *AmdgpuIsaOperand<Isa>::simd_lane_ptr(const amdgpu::Wavefront &wf,
-                                                     uint32_t lane_base) const {
+bool AmdgpuIsaOperand<Isa>::simd_read_lanes(const amdgpu::Wavefront &wf, uint32_t lane_base,
+                                            uint32_t count, uint32_t *out) const {
   if (this->delegate())
-    return amdgpu::SimdAccess::lane_ptr(*this->delegate(), wf, lane_base);
-  if (auto off = Isa::resolved_vgpr_offset(this->opr_type_, this->encoding_value_)) {
-    const uint8_t *base = wf.cu().vgpr_data(wf.vgpr_alloc().base + *off);
-    return reinterpret_cast<const uint32_t *>(base + lane_base * sizeof(uint32_t));
-  }
-  return nullptr;
+    return amdgpu::SimdAccess::read_lanes(*this->delegate(), wf, lane_base, count, out);
+  auto off = Isa::resolved_vgpr_offset(this->opr_type_, this->encoding_value_);
+  if (!off)
+    return false;
+  uint32_t physical_reg = wf.vgpr_alloc().base + *off;
+  // Plugin notification hook goes here when the plugin system lands.
+  const uint8_t *src = wf.cu().vgpr_data(physical_reg);
+  std::memcpy(out, src + lane_base * sizeof(uint32_t), count * sizeof(uint32_t));
+  return true;
 }
 
 template <typename Isa>

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/operand.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/operand.h
@@ -175,26 +175,23 @@ public:
   bool is_vgpr_ = false;
 
 private:
-  /// @brief If this operand has contiguous per-lane uint32_t storage for the
-  /// lane range starting at `lane_base`, return a pointer to lane `lane_base`.
-  /// Otherwise return nullptr — the caller should fall back to a scalar
-  /// broadcast via `read_scalar` (for SGPR/imm/inline-const operands).
+  /// @brief Read VGPR lane data for lanes [lane_base, lane_base + count) into
+  /// @p out, notifying the plugin system. Returns true if this operand is a
+  /// VGPR (data was copied + plugins notified); false for non-VGPR operands
+  /// (caller should broadcast a scalar value instead).
   ///
-  /// @details Internal SIMD fast-path hook, reachable only through
-  /// `amdgpu::SimdAccess`. Plugins observing register reads should hook the
-  /// public `read_lane` / `read_lane_chunk` surface instead.
-  virtual const uint32_t *simd_lane_ptr(const amdgpu::Wavefront &wf, uint32_t lane_base) const {
+  /// @details No raw pointer to the register file escapes. The operand owns
+  /// both the read and the notification, guaranteeing they stay in sync.
+  virtual bool simd_read_lanes(const amdgpu::Wavefront &wf, uint32_t lane_base, uint32_t count,
+                               uint32_t *out) const {
     if (delegate_)
-      return delegate_->simd_lane_ptr(wf, lane_base);
-    return nullptr;
+      return delegate_->simd_read_lanes(wf, lane_base, count, out);
+    return false;
   }
 
   /// @brief If this operand's destination is contiguous per-lane uint32_t
   /// storage (a VGPR), return a writable pointer to lane `lane_base`. Otherwise
   /// return nullptr — the caller should fall back to `write_lane_chunk`.
-  ///
-  /// @details Internal SIMD fast-path hook; same access policy as
-  /// `simd_lane_ptr`.
   virtual uint32_t *simd_dst_ptr(amdgpu::Wavefront &wf, uint32_t lane_base) const {
     (void)wf;
     (void)lane_base;
@@ -249,7 +246,8 @@ public:
                         const uint32_t *vals, uint64_t mask) const override;
 
 private:
-  const uint32_t *simd_lane_ptr(const amdgpu::Wavefront &wf, uint32_t lane_base) const override;
+  bool simd_read_lanes(const amdgpu::Wavefront &wf, uint32_t lane_base, uint32_t count,
+                       uint32_t *out) const override;
   uint32_t *simd_dst_ptr(amdgpu::Wavefront &wf, uint32_t lane_base) const override;
 };
 
@@ -297,11 +295,17 @@ public:
   }
 
 private:
-  const uint32_t *simd_lane_ptr(const amdgpu::Wavefront & /*wf*/,
-                                uint32_t lane_base) const override {
-    if (static_cast<int>(lane_base) >= lane_count_)
-      return nullptr;
-    return &data_[lane_base];
+  // DPP reads from the pre-permuted buffer, not the register file, so no
+  // plugin notification is needed (the original read was hooked at
+  // construction time when the buffer was populated).
+  bool simd_read_lanes(const amdgpu::Wavefront & /*wf*/, uint32_t lane_base, uint32_t count,
+                       uint32_t *out) const override {
+    uint32_t lanes = static_cast<uint32_t>(lane_count_);
+    for (uint32_t i = 0; i < count; ++i) {
+      uint32_t l = lane_base + i;
+      out[i] = (l < lanes) ? data_[l] : 0u;
+    }
+    return true;
   }
 
   uint32_t data_[MAX_LANES]{};
@@ -311,15 +315,18 @@ private:
 namespace amdgpu {
 /// @brief Privileged accessor for the operand SIMD fast-path hooks.
 ///
-/// Only the SIMD glue in `arch/amdgpu/shared/simd_glue.h` (and arch operand
-/// implementations that need to forward a delegate dispatch) reaches the
-/// private `simd_lane_ptr` / `simd_dst_ptr` virtuals through this struct.
-/// Plugin-visible register I/O stays on the public `read_lane` /
-/// `read_lane_chunk` / `write_lane` / `write_lane_chunk` surface.
+/// Bridges the private `simd_read_lanes` / `simd_dst_ptr` virtuals on Operand
+/// to the SIMD glue in `simd_glue.h`. Read access goes through `read_lanes`,
+/// which copies data into a caller buffer — no raw pointer to the register
+/// file escapes. Write access still returns a raw pointer (`dst_ptr`) since
+/// there are no write-observation hooks to bypass.
 struct SimdAccess {
+  /// Copy lane data for [lane_base, lane_base + count) into @p out,
+  /// notifying the plugin system. Returns false for non-VGPR operands.
   template <typename Op>
-  static const uint32_t *lane_ptr(const Op &op, const Wavefront &wf, uint32_t lane_base) {
-    return op.simd_lane_ptr(wf, lane_base);
+  static bool read_lanes(const Op &op, const Wavefront &wf, uint32_t lane_base, uint32_t count,
+                         uint32_t *out) {
+    return op.simd_read_lanes(wf, lane_base, count, out);
   }
   template <typename Op> static uint32_t *dst_ptr(const Op &op, Wavefront &wf, uint32_t lane_base) {
     return op.simd_dst_ptr(wf, lane_base);


### PR DESCRIPTION
The SIMD fast path (PR #6199) reads VGPRs via SimdAccess::lane_ptr(), which returns a raw const uint32_t* into the register file. This pointer escapes to the caller (read_simd in simd_glue.h), bypassing any future per-register plugin hooks — plugins that observe register reads (e.g. race detection) would never see SIMD-path reads.

Making simd_lane_ptr private on Operand does not help: SimdAccess is a friend struct with public static template methods defined in operand.h. Any translation unit that includes operand.h can call SimdAccess::lane_ptr(op, wf, base) and obtain the raw pointer. The friend declaration makes the private virtual reachable through the public intermediary.

This commit replaces the two-step lane_ptr + load with a single simd_read_lanes private virtual that copies lane data into a caller- provided buffer. No raw pointer to the register file escapes the operand. SimdAccess no longer exposes lane_ptr — only read_lanes (which copies data out) and dst_ptr (writes, no hook to bypass).

Changes:
- Operand: replace simd_lane_ptr + simd_notify_read with simd_read_lanes(wf, lane_base, count, out) -> bool
- AmdgpuIsaOperand<Isa>: implement simd_read_lanes (memcpy from vgpr_data, with a hook site for future plugin notification)
- DppOperand: implement simd_read_lanes (copy from pre-permuted buffer; no notification needed since the original read was hooked at construction time)
- SimdAccess: expose read_lanes instead of lane_ptr
- read_simd (simd_glue.h): use aligned local buffer + read_lanes
- read_lane_chunk: delegate to simd_read_lanes instead of duplicating the vgpr_data access

Trade-off: an extra memcpy into a stack-allocated aligned buffer before the SIMD load. The compiler should see through the aligned- buffer + util::load<T> pattern and elide the copy, but this should be benchmarked (@lialan can you please benchmark this? You reported a slow down 9x - 4x on your first PR). 

Context: https://github.com/ROCm/rocm-systems/pull/6199#discussion_r3275613631

