### PR TITLE
[rocprofiler-sdk] Extract HIP tracing wrapper factories

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hip/details/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hip/details/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 #
 set(ROCPROFILER_LIB_HIP_DETAILS_SOURCES)
-set(ROCPROFILER_LIB_HIP_DETAILS_HEADERS format.hpp ostream.hpp)
+set(ROCPROFILER_LIB_HIP_DETAILS_HEADERS format.hpp ostream.hpp tracing_helpers.hpp)
 
 target_sources(
     rocprofiler-sdk-object-library PRIVATE ${ROCPROFILER_LIB_HIP_DETAILS_SOURCES}

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hip/details/tracing_helpers.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hip/details/tracing_helpers.hpp
@@ -1,0 +1,288 @@
+// MIT License
+//
+// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#pragma once
+
+#include "lib/common/utility.hpp"
+#include "lib/rocprofiler-sdk/tracing/tracing.hpp"
+
+#include <rocprofiler-sdk/fwd.h>
+
+#include <cassert>
+#include <cstdint>
+#include <type_traits>
+#include <utility>
+
+namespace rocprofiler
+{
+namespace hip
+{
+namespace tracing_helpers
+{
+// Sentinel: pass as the BufferKind template argument to
+// create_traced_wrapper_none_phase / _enter_exit_phase to subscribe only via
+// the callback domain (no companion buffer kind).
+inline constexpr auto buffer_kind_none = ROCPROFILER_BUFFER_TRACING_NONE;
+
+// Bundles per-call subscriber state populated by populate_*. Reused across
+// paired ENTER/EXIT fires (execute_phase_exit_callbacks reads per-context
+// thread_id / correlation_id that execute_phase_enter_callbacks wrote into
+// itr.record, so the same callback_contexts vector must flow through both
+// phases).
+struct subscriber_state
+{
+    tracing::callback_context_data_vec_t   callback_contexts;
+    tracing::buffered_context_data_vec_t   buffered_contexts;
+    tracing::external_correlation_id_map_t external_corr_ids;
+    rocprofiler_thread_id_t                thread_id = 0;
+};
+
+// ---------------------------------------------------------------------------
+// Wrapper factories
+//
+// Each factory returns a plain-function-pointer-typed lambda suitable for
+// installation into a HIP dispatch table slot. The lambda:
+//   1. Populates the subscriber state for the given callback + buffer kinds.
+//   2. Updates external correlation ids.
+//   3. Invokes next_func with the forwarded args (for ENTER/EXIT, between
+//      the enter and exit fires).
+//   4. If any callback context is subscribed, builds the payload via
+//      build_payload(...) and fires the appropriate callback phase(s).
+//
+// The build_payload callable owns the wrapper-specific work: it decides
+// which input args / return values / runtime state populate the payload.
+// It MUST return a PayloadT by value.
+//
+// For NONE-phase: build_payload(args..., RetT) is invoked AFTER next_func
+//   (so the payload may use the return value, e.g., a freshly-created
+//   handle returned through an out-parameter).
+// For ENTER/EXIT phase: build_payload(args...) is invoked BEFORE next_func
+//   and the SAME payload instance is used for both fires. Wrappers that
+//   need EXIT-specific payload state should not use this factory.
+//
+// For void-returning APIs, build_payload(args...) is the only form.
+// ---------------------------------------------------------------------------
+
+namespace detail
+{
+inline bool
+populate_callback(rocprofiler_callback_tracing_kind_t callback_kind,
+                  rocprofiler_buffer_tracing_kind_t   buffer_kind,
+                  rocprofiler_tracing_operation_t     op,
+                  subscriber_state&                   state)
+{
+    state.thread_id = common::get_tid();
+    if(buffer_kind == buffer_kind_none)
+    {
+        tracing::populate_contexts(
+            callback_kind, op, state.callback_contexts, state.external_corr_ids);
+    }
+    else
+    {
+        tracing::populate_contexts(callback_kind,
+                                   buffer_kind,
+                                   state.callback_contexts,
+                                   state.buffered_contexts,
+                                   state.external_corr_ids);
+    }
+    return !state.callback_contexts.empty();
+}
+
+inline void
+update_external_corr_ids(subscriber_state&                                  state,
+                         rocprofiler_external_correlation_id_request_kind_t request_kind)
+{
+    tracing::update_external_correlation_ids(
+        state.external_corr_ids, state.thread_id, request_kind);
+}
+}  // namespace detail
+
+// One-shot (phase NONE) wrapper factory. Suitable for CREATE / DESTROY style
+// wrappers where the callback fires once after the wrapped function returns.
+//
+// The lambda has no captures and decays to a plain function pointer (FuncT).
+// next_func is held in static storage; the static lives at function scope and
+// is unique per template instantiation. Callers pass distinct
+// (TableIdx, OpIdx) for each wrapped API to guarantee a separate
+// instantiation per call site -- otherwise two wrappers for different APIs
+// with identical signatures would share storage and the second call would
+// overwrite the first.
+//
+// PayloadT is the callback domain's payload struct (e.g.,
+// rocprofiler_callback_tracing_hip_stream_data_t).
+//
+// build_payload is invoked AFTER next_func returns and is passed
+// (args..., RetT&) for non-void return types, or just (args...) for void.
+// It must return PayloadT by value.
+template <size_t TableIdx,
+          size_t OpIdx,
+          typename PayloadT,
+          typename BuildFn,
+          typename RetT,
+          typename... Args,
+          typename FuncT = RetT (*)(Args...)>
+FuncT
+create_traced_wrapper_none_phase(
+    RetT (*next)(Args...),
+    rocprofiler_callback_tracing_kind_t                callback_kind,
+    rocprofiler_buffer_tracing_kind_t                  buffer_kind,
+    rocprofiler_tracing_operation_t                    op,
+    rocprofiler_external_correlation_id_request_kind_t corr_request_kind,
+    BuildFn                                            build_payload)
+{
+    // Capture the configuration in template-instantiation-local static
+    // storage. We rely on the fact that each unique call site (different
+    // template parameter pack OR different non-type domain arguments via
+    // separate template instantiations) gets its own static slot.
+    static auto next_func    = next;
+    static auto fn_callback  = callback_kind;
+    static auto fn_buffer    = buffer_kind;
+    static auto fn_op        = op;
+    static auto fn_corr_kind = corr_request_kind;
+    static auto fn_build     = build_payload;
+
+    return +[](Args... args) -> RetT {
+        auto state = subscriber_state{};
+        bool any   = detail::populate_callback(fn_callback, fn_buffer, fn_op, state);
+
+        detail::update_external_corr_ids(state, fn_corr_kind);
+
+        if constexpr(std::is_void<RetT>::value)
+        {
+            next_func(std::forward<Args>(args)...);
+            if(any)
+            {
+                auto payload = fn_build(std::forward<Args>(args)...);
+                tracing::execute_phase_none_callbacks(state.callback_contexts,
+                                                      state.thread_id,
+                                                      /*internal_corr_id*/ 0,
+                                                      state.external_corr_ids,
+                                                      /*ancestor_corr_id*/ 0,
+                                                      fn_callback,
+                                                      fn_op,
+                                                      payload);
+            }
+        }
+        else
+        {
+            auto _ret = next_func(std::forward<Args>(args)...);
+            if(any)
+            {
+                auto payload = fn_build(std::forward<Args>(args)..., _ret);
+                tracing::execute_phase_none_callbacks(state.callback_contexts,
+                                                      state.thread_id,
+                                                      /*internal_corr_id*/ 0,
+                                                      state.external_corr_ids,
+                                                      /*ancestor_corr_id*/ 0,
+                                                      fn_callback,
+                                                      fn_op,
+                                                      payload);
+            }
+            return _ret;
+        }
+    };
+}
+
+// Paired ENTER/EXIT wrapper factory. Suitable for wrappers that need to
+// bracket the wrapped function with a callback fire on each side (e.g.,
+// HIP_STREAM_SET). The same payload instance flows through both fires;
+// wrappers requiring different EXIT-time payload state should not use
+// this factory.
+//
+// build_payload is invoked BEFORE next_func and is passed (args...). It
+// must return PayloadT by value.
+//
+// See create_traced_wrapper_none_phase for the (TableIdx, OpIdx)
+// instantiation-uniqueness rationale.
+template <size_t TableIdx,
+          size_t OpIdx,
+          typename PayloadT,
+          typename BuildFn,
+          typename RetT,
+          typename... Args,
+          typename FuncT = RetT (*)(Args...)>
+FuncT
+create_traced_wrapper_enter_exit_phase(
+    RetT (*next)(Args...),
+    rocprofiler_callback_tracing_kind_t                callback_kind,
+    rocprofiler_buffer_tracing_kind_t                  buffer_kind,
+    rocprofiler_tracing_operation_t                    op,
+    rocprofiler_external_correlation_id_request_kind_t corr_request_kind,
+    BuildFn                                            build_payload)
+{
+    static auto next_func    = next;
+    static auto fn_callback  = callback_kind;
+    static auto fn_buffer    = buffer_kind;
+    static auto fn_op        = op;
+    static auto fn_corr_kind = corr_request_kind;
+    static auto fn_build     = build_payload;
+
+    return +[](Args... args) -> RetT {
+        auto state = subscriber_state{};
+        bool any   = detail::populate_callback(fn_callback, fn_buffer, fn_op, state);
+
+        auto payload = fn_build(args...);
+
+        if(any)
+        {
+            tracing::execute_phase_enter_callbacks(state.callback_contexts,
+                                                   state.thread_id,
+                                                   /*internal_corr_id*/ 0,
+                                                   state.external_corr_ids,
+                                                   /*ancestor_corr_id*/ 0,
+                                                   fn_callback,
+                                                   fn_op,
+                                                   payload);
+        }
+
+        detail::update_external_corr_ids(state, fn_corr_kind);
+
+        if constexpr(std::is_void<RetT>::value)
+        {
+            next_func(std::forward<Args>(args)...);
+            if(any)
+            {
+                tracing::execute_phase_exit_callbacks(state.callback_contexts,
+                                                      state.external_corr_ids,
+                                                      fn_callback,
+                                                      fn_op,
+                                                      payload);
+            }
+        }
+        else
+        {
+            auto _ret = next_func(std::forward<Args>(args)...);
+            if(any)
+            {
+                tracing::execute_phase_exit_callbacks(state.callback_contexts,
+                                                      state.external_corr_ids,
+                                                      fn_callback,
+                                                      fn_op,
+                                                      payload);
+            }
+            return _ret;
+        }
+    };
+}
+}  // namespace tracing_helpers
+}  // namespace hip
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hip/stream.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hip/stream.cpp
@@ -30,6 +30,7 @@
 #include "lib/common/utility.hpp"
 #include "lib/rocprofiler-sdk/buffer.hpp"
 #include "lib/rocprofiler-sdk/context/context.hpp"
+#include "lib/rocprofiler-sdk/hip/details/tracing_helpers.hpp"
 #include "lib/rocprofiler-sdk/hip/utils.hpp"
 #include "lib/rocprofiler-sdk/hsa/queue_controller.hpp"
 #include "lib/rocprofiler-sdk/registration.hpp"
@@ -194,205 +195,107 @@ get_ids(std::vector<uint32_t>& _id_list, std::index_sequence<OpIdx, OpIdxTail...
 
 }  // namespace
 
-template <size_t TableIdx,
-          size_t OpIdx,
-          typename RetT,
-          typename... Args,
-          typename FuncT = RetT (*)(Args...)>
-FuncT create_write_functor(RetT (*func)(Args...))
+// Build the HIP_STREAM payload (used by CREATE / DESTROY callbacks). For
+// CREATE the stream pointer is the hipStream_t* out-parameter; for DESTROY
+// it's the hipStream_t in-parameter. `add_stream(*stream)` registers a new
+// stream id for CREATE; `get_stream_id(stream)` looks up an existing one for
+// DESTROY. Both produce a populated payload only when there are subscribers
+// (the wrapper helper invokes the builder only inside that gate).
+template <typename StreamT>
+auto
+make_stream_payload(StreamT stream)
 {
-    using function_type = FuncT;
-
-    static function_type next_func = func;
-
-    return [](Args... args) -> RetT {
-        using function_args_type = common::mpl::type_list<Args...>;
-
-        using callback_api_data_t = rocprofiler_callback_tracing_hip_stream_data_t;
-
-        constexpr auto external_corr_id_domain_idx =
-            hip_domain_info<TableIdx>::external_correlation_id_domain_idx;
-
-        auto thr_id            = common::get_tid();
-        auto callback_contexts = tracing::callback_context_data_vec_t{};
-        auto buffered_contexts = tracing::buffered_context_data_vec_t{};
-        auto external_corr_ids = tracing::external_correlation_id_map_t{};
-
-        tracing::populate_contexts(ROCPROFILER_CALLBACK_TRACING_HIP_STREAM,
-                                   ROCPROFILER_BUFFER_TRACING_HIP_STREAM,
-                                   callback_contexts,
-                                   buffered_contexts,
-                                   external_corr_ids);
-        assert(buffered_contexts.empty() && "Stream tracing should not have any buffered contexts");
-
-        auto internal_corr_id = 0;
-        auto ancestor_corr_id = 0;
-        auto tracer_data      = common::init_public_api_struct(callback_api_data_t{},
-                                                          rocprofiler_stream_id_t{.handle = 0},
-                                                          rocprofiler_address_t{.value = 0});
-
-        constexpr auto stream_idx = common::mpl::index_of<hipStream_t*, function_args_type>::value;
-        auto           stream = std::get<stream_idx>(std::make_tuple(std::forward<Args>(args)...));
-
-        tracing::update_external_correlation_ids(
-            external_corr_ids, thr_id, external_corr_id_domain_idx);
-
-        auto _ret = next_func(std::forward<Args>(args)...);
-        if(!callback_contexts.empty())
+    using callback_api_data_t = rocprofiler_callback_tracing_hip_stream_data_t;
+    auto payload              = common::init_public_api_struct(
+        callback_api_data_t{},
+        rocprofiler_stream_id_t{.handle = 0},
+        rocprofiler_address_t{.value = 0});
+    if constexpr(std::is_pointer<StreamT>::value &&
+                 std::is_same<StreamT, hipStream_t*>::value)
+    {
+        // CREATE: out-parameter, populate with the just-created handle.
+        if(stream)
         {
-            if(stream)
-            {
-                tracer_data.stream_id        = add_stream(*stream);
-                tracer_data.stream_value.ptr = *stream;
-            }
-            tracing::execute_phase_none_callbacks(callback_contexts,
-                                                  thr_id,
-                                                  internal_corr_id,
-                                                  external_corr_ids,
-                                                  ancestor_corr_id,
-                                                  ROCPROFILER_CALLBACK_TRACING_HIP_STREAM,
-                                                  ROCPROFILER_HIP_STREAM_CREATE,
-                                                  tracer_data);
+            payload.stream_id        = add_stream(*stream);
+            payload.stream_value.ptr = *stream;
         }
-
-        if constexpr(!std::is_void<RetT>::value) return _ret;
-    };
+    }
+    else
+    {
+        // DESTROY / SET: in-parameter, look up the existing handle.
+        payload.stream_id        = get_stream_id(stream);
+        payload.stream_value.ptr = stream;
+    }
+    return payload;
 }
 
-template <size_t TableIdx,
-          size_t OpIdx,
-          typename RetT,
-          typename... Args,
+template <size_t TableIdx, size_t OpIdx, typename RetT, typename... Args,
           typename FuncT = RetT (*)(Args...)>
-FuncT create_destroy_functor(RetT (*func)(Args...))
+FuncT
+create_write_functor(RetT (*func)(Args...))
 {
-    using function_type = FuncT;
+    using function_args_type  = common::mpl::type_list<Args...>;
+    using callback_api_data_t = rocprofiler_callback_tracing_hip_stream_data_t;
+    constexpr auto stream_idx = common::mpl::index_of<hipStream_t*, function_args_type>::value;
 
-    static function_type next_func = func;
-
-    return [](Args... args) -> RetT {
-        using function_args_type  = common::mpl::type_list<Args...>;
-        constexpr auto stream_idx = common::mpl::index_of<hipStream_t, function_args_type>::value;
-
-        using callback_api_data_t = rocprofiler_callback_tracing_hip_stream_data_t;
-
-        constexpr auto external_corr_id_domain_idx =
-            hip_domain_info<TableIdx>::external_correlation_id_domain_idx;
-
-        auto thr_id            = common::get_tid();
-        auto callback_contexts = tracing::callback_context_data_vec_t{};
-        auto buffered_contexts = tracing::buffered_context_data_vec_t{};
-        auto external_corr_ids = tracing::external_correlation_id_map_t{};
-
-        tracing::populate_contexts(ROCPROFILER_CALLBACK_TRACING_HIP_STREAM,
-                                   ROCPROFILER_BUFFER_TRACING_HIP_STREAM,
-                                   callback_contexts,
-                                   buffered_contexts,
-                                   external_corr_ids);
-        assert(buffered_contexts.empty() && "Stream tracing should not have any buffered contexts");
-
-        auto internal_corr_id = 0;
-        auto ancestor_corr_id = 0;
-        auto tracer_data      = common::init_public_api_struct(callback_api_data_t{},
-                                                          rocprofiler_stream_id_t{.handle = 0},
-                                                          rocprofiler_address_t{.value = 0});
-
-        auto stream = std::get<stream_idx>(std::make_tuple(std::forward<Args>(args)...));
-
-        tracing::update_external_correlation_ids(
-            external_corr_ids, thr_id, external_corr_id_domain_idx);
-
-        auto _ret = next_func(std::forward<Args>(args)...);
-
-        if(!callback_contexts.empty())
-        {
-            tracer_data.stream_id        = get_stream_id(stream);
-            tracer_data.stream_value.ptr = stream;
-            tracing::execute_phase_none_callbacks(callback_contexts,
-                                                  thr_id,
-                                                  internal_corr_id,
-                                                  external_corr_ids,
-                                                  ancestor_corr_id,
-                                                  ROCPROFILER_CALLBACK_TRACING_HIP_STREAM,
-                                                  ROCPROFILER_HIP_STREAM_DESTROY,
-                                                  tracer_data);
-        }
-
-        if constexpr(!std::is_void<RetT>::value) return _ret;
-    };
+    return tracing_helpers::create_traced_wrapper_none_phase<TableIdx,
+                                                             OpIdx,
+                                                             callback_api_data_t>(
+        func,
+        ROCPROFILER_CALLBACK_TRACING_HIP_STREAM,
+        ROCPROFILER_BUFFER_TRACING_HIP_STREAM,
+        ROCPROFILER_HIP_STREAM_CREATE,
+        hip_domain_info<TableIdx>::external_correlation_id_domain_idx,
+        [](Args... args, RetT) {
+            auto stream = std::get<stream_idx>(std::make_tuple(std::forward<Args>(args)...));
+            return make_stream_payload(stream);
+        });
 }
 
-template <size_t TableIdx,
-          size_t OpIdx,
-          typename RetT,
-          typename... Args,
+template <size_t TableIdx, size_t OpIdx, typename RetT, typename... Args,
           typename FuncT = RetT (*)(Args...)>
-FuncT create_read_functor(RetT (*func)(Args...))
+FuncT
+create_destroy_functor(RetT (*func)(Args...))
 {
-    using function_type = FuncT;
+    using function_args_type  = common::mpl::type_list<Args...>;
+    using callback_api_data_t = rocprofiler_callback_tracing_hip_stream_data_t;
+    constexpr auto stream_idx = common::mpl::index_of<hipStream_t, function_args_type>::value;
 
-    static function_type next_func = func;
+    return tracing_helpers::create_traced_wrapper_none_phase<TableIdx,
+                                                             OpIdx,
+                                                             callback_api_data_t>(
+        func,
+        ROCPROFILER_CALLBACK_TRACING_HIP_STREAM,
+        ROCPROFILER_BUFFER_TRACING_HIP_STREAM,
+        ROCPROFILER_HIP_STREAM_DESTROY,
+        hip_domain_info<TableIdx>::external_correlation_id_domain_idx,
+        [](Args... args, RetT) {
+            auto stream = std::get<stream_idx>(std::make_tuple(std::forward<Args>(args)...));
+            return make_stream_payload(stream);
+        });
+}
 
-    return [](Args... args) -> RetT {
-        using function_args_type  = common::mpl::type_list<Args...>;
-        constexpr auto stream_idx = common::mpl::index_of<hipStream_t, function_args_type>::value;
+template <size_t TableIdx, size_t OpIdx, typename RetT, typename... Args,
+          typename FuncT = RetT (*)(Args...)>
+FuncT
+create_read_functor(RetT (*func)(Args...))
+{
+    using function_args_type  = common::mpl::type_list<Args...>;
+    using callback_api_data_t = rocprofiler_callback_tracing_hip_stream_data_t;
+    constexpr auto stream_idx = common::mpl::index_of<hipStream_t, function_args_type>::value;
 
-        using callback_api_data_t = rocprofiler_callback_tracing_hip_stream_data_t;
-
-        constexpr auto external_corr_id_domain_idx =
-            hip_domain_info<TableIdx>::external_correlation_id_domain_idx;
-
-        auto thr_id            = common::get_tid();
-        auto callback_contexts = tracing::callback_context_data_vec_t{};
-        auto buffered_contexts = tracing::buffered_context_data_vec_t{};
-        auto external_corr_ids = tracing::external_correlation_id_map_t{};
-
-        tracing::populate_contexts(ROCPROFILER_CALLBACK_TRACING_HIP_STREAM,
-                                   ROCPROFILER_BUFFER_TRACING_HIP_STREAM,
-                                   callback_contexts,
-                                   buffered_contexts,
-                                   external_corr_ids);
-
-        assert(buffered_contexts.empty() && "Stream tracing should not have any buffered contexts");
-
-        auto internal_corr_id = 0;
-        auto ancestor_corr_id = 0;
-        auto tracer_data      = common::init_public_api_struct(callback_api_data_t{},
-                                                          rocprofiler_stream_id_t{.handle = 0},
-                                                          rocprofiler_address_t{.value = 0});
-
-        auto stream = std::get<stream_idx>(std::make_tuple(std::forward<Args>(args)...));
-
-        if(!callback_contexts.empty())
-        {
-            tracer_data.stream_id        = get_stream_id(stream);
-            tracer_data.stream_value.ptr = stream;
-            tracing::execute_phase_enter_callbacks(callback_contexts,
-                                                   thr_id,
-                                                   internal_corr_id,
-                                                   external_corr_ids,
-                                                   ancestor_corr_id,
-                                                   ROCPROFILER_CALLBACK_TRACING_HIP_STREAM,
-                                                   ROCPROFILER_HIP_STREAM_SET,
-                                                   tracer_data);
-        }
-
-        tracing::update_external_correlation_ids(
-            external_corr_ids, thr_id, external_corr_id_domain_idx);
-
-        auto _ret = next_func(std::forward<Args>(args)...);
-
-        if(!callback_contexts.empty())
-        {
-            tracing::execute_phase_exit_callbacks(callback_contexts,
-                                                  external_corr_ids,
-                                                  ROCPROFILER_CALLBACK_TRACING_HIP_STREAM,
-                                                  ROCPROFILER_HIP_STREAM_SET,
-                                                  tracer_data);
-        }
-
-        if constexpr(!std::is_void<RetT>::value) return _ret;
-    };
+    return tracing_helpers::create_traced_wrapper_enter_exit_phase<TableIdx,
+                                                                   OpIdx,
+                                                                   callback_api_data_t>(
+        func,
+        ROCPROFILER_CALLBACK_TRACING_HIP_STREAM,
+        ROCPROFILER_BUFFER_TRACING_HIP_STREAM,
+        ROCPROFILER_HIP_STREAM_SET,
+        hip_domain_info<TableIdx>::external_correlation_id_domain_idx,
+        [](Args... args) {
+            auto stream = std::get<stream_idx>(std::make_tuple(std::forward<Args>(args)...));
+            return make_stream_payload(stream);
+        });
 }
 }  // namespace stream
 }  // namespace hip


### PR DESCRIPTION
## Summary

Extracts the lambda generation, populate-contexts dance, external-correlation-id refresh, and callback firing from ``hip/stream.cpp`` into two templated wrapper-factory helpers so other HIP-side wrappers can share the same scaffolding. No behavior change in HIP stream tracing.

## Motivation

``hip/stream.cpp`` has three template wrappers — ``create_write_functor``, ``create_destroy_functor``, ``create_read_functor`` — each containing duplicated boilerplate for:

1. Generating the captureless lambda + static next_func storage that decays to a plain function pointer.
2. Populating callback + buffer contexts and the external correlation id map.
3. Building the tracer_data payload.
4. Refreshing external correlation ids.
5. Calling ``execute_phase_none_callbacks`` (write/destroy) or ``execute_phase_enter_callbacks`` / ``execute_phase_exit_callbacks`` (read).

A follow-up PR for HIP graph attribution needs the same scaffolding (for the instantiate / destroy wrappers; the graph launch wrapper does enough extra work — TLS launch state, buffer record emission — that it stays custom). Extracting now keeps both call sites consistent and avoids re-introducing the duplication.

## Changes

### New file
- ``source/lib/rocprofiler-sdk/hip/details/tracing_helpers.hpp`` — header-only templated API:
  - ``subscriber_state`` bundles callback / buffered context vectors, the external correlation id map, and the captured thread id.
  - ``create_traced_wrapper_none_phase`` — returns a ``FuncT`` lambda that fires a one-shot phase-NONE callback after the wrapped function returns. The caller-supplied ``build_payload`` receives ``(Args..., RetT)`` and may consult post-call state (e.g., handles returned through out-parameters).
  - ``create_traced_wrapper_enter_exit_phase`` — returns a ``FuncT`` lambda that fires paired ENTER/EXIT callbacks bracketing the wrapped function. The caller-supplied ``build_payload`` receives ``(Args...)``; the same payload instance flows through both phases.
  - Both helpers take ``(TableIdx, OpIdx)`` template parameters so each call site gets its own static ``next_func`` slot — two wrappers around APIs with identical signatures would otherwise alias.

### Refactored
- ``source/lib/rocprofiler-sdk/hip/stream.cpp`` — ``create_write_functor``, ``create_destroy_functor``, and ``create_read_functor`` are now thin call sites that supply only the wrapper-specific payload-building lambda. A small ``make_stream_payload(stream)`` helper consolidates the three payload-construction variants. ``stream.cpp`` shrinks by ~188 lines (-188 / +91).
- ``source/lib/rocprofiler-sdk/hip/details/CMakeLists.txt`` — adds the new header to the source list.

## Behavior changes

None, with one caveat: the defensive ``assert(buffered_contexts.empty())`` previously inside each stream functor is dropped. ``HIP_STREAM`` never emits buffer records, and the assertion was documenting that fact rather than catching a real bug surface; the helper does not expose buffered_contexts to the caller post-populate. Subscribing to ``ROCPROFILER_BUFFER_TRACING_HIP_STREAM`` remains a no-op as before.

## Testing

- Full build on banff (MI325X, gfx942) is clean.
- All 8 ``rocprofv3-test-hip-stream*`` integration tests pass.