### PR TITLE
rocr: replase isa_ with supported_isas[0]

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
@@ -457,7 +457,7 @@ class GpuAgent : public GpuAgentInt {
   __forceinline uint32_t enumeration_index() const { return enum_index_; }
 
   // @brief returns true if agent uses MES scheduler
-  __forceinline const bool isMES() const { return (isa_->GetMajorVersion() >= 11) ? true : false; };
+  __forceinline const bool isMES() const { return (supported_isas()[0]->GetMajorVersion() >= 11) ? true : false; };
 
   // @brief returns the libdrm device handle
   __forceinline amdgpu_device_handle libDrmDev() const { return ldrm_dev_; }
@@ -490,8 +490,8 @@ class GpuAgent : public GpuAgentInt {
   const size_t MAX_SCRATCH_APERTURE_PER_XCC_GFX12 = (2ULL << 32); // 8GB
   __forceinline size_t MaxScratchDevice() const {
     return properties_.NumXcc *
-          (isa_->GetMajorVersion() >= 12 ? MAX_SCRATCH_APERTURE_PER_XCC_GFX12 :
-                                            MAX_SCRATCH_APERTURE_PER_XCC);
+          (supported_isas()[0]->GetMajorVersion() >= 12 ? MAX_SCRATCH_APERTURE_PER_XCC_GFX12 :
+                                                           MAX_SCRATCH_APERTURE_PER_XCC);
   }
 
   void ReserveScratch();
@@ -731,8 +731,6 @@ class GpuAgent : public GpuAgentInt {
 
   // @brief Array of regions owned by this agent.
   std::vector<std::shared_ptr<const core::MemoryRegion>> regions_;
-
-  core::Isa* isa_;
 
   // @brief HSA profile.
   hsa_profile_t profile_;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -186,30 +186,31 @@ GpuAgent::GpuAgent(HSAuint32 node, const HsaNodeProperties& node_props, bool xna
                       : core::IsaFeature::Disabled;
   }
 
+  const core::Isa* isa;
   if (node_props.OverrideEngineId.Value != 0) {
-    isa_ = (core::Isa*)core::IsaRegistry::GetIsa(
+    isa = core::IsaRegistry::GetIsa(
           core::Isa::Version(node_props.OverrideEngineId.ui32.Major, node_props.OverrideEngineId.ui32.Minor,
                              node_props.OverrideEngineId.ui32.Stepping), sramecc, xnack);
   } else {
   // Set instruction set architecture via node property, only on GPU device.
-    isa_ = (core::Isa*)core::IsaRegistry::GetIsa(
+    isa = core::IsaRegistry::GetIsa(
           core::Isa::Version(node_props.EngineId.ui32.Major, node_props.EngineId.ui32.Minor,
                              node_props.EngineId.ui32.Stepping), sramecc, xnack);
   }
 
-  assert(isa_ != nullptr && "ISA registry inconsistency.");
+  assert(isa != nullptr && "ISA registry inconsistency.");
 
-  supported_isas_.push_back(isa_);
-  if (!isa_->GetIsaGeneric().empty()) {
-    supported_isas_.push_back(core::IsaRegistry::GetIsa(isa_->GetIsaGeneric()));
+  supported_isas_.push_back(isa);
+  if (!supported_isas_[0]->GetIsaGeneric().empty()) {
+    supported_isas_.push_back(core::IsaRegistry::GetIsa(supported_isas_[0]->GetIsaGeneric()));
   }
 
-  if (isa_->GetMajorVersion() == 12 && isa_->GetMinorVersion() >= 5) {
+  if (supported_isas_[0]->GetMajorVersion() == 12 && supported_isas_[0]->GetMinorVersion() >= 5) {
     extended_aql_dispatch_supported_ = true;
     workgroup_clusters_supported_ = true;
   }
 
-  if (isa_->GetMajorVersion() >= 12)
+  if (supported_isas_[0]->GetMajorVersion() >= 12)
     kern_cluster_max_dim_ = { UINT32_MAX, UINT16_MAX, UINT16_MAX };
 
   if (workgroup_clusters_supported_) {
@@ -217,7 +218,7 @@ GpuAgent::GpuAgent(HSAuint32 node, const HsaNodeProperties& node_props, bool xna
     cluster_max_dim_ = { num_cu_per_se, num_cu_per_se, num_cu_per_se };
   }
 
-  max_wave_scratch_ = (isa_->GetMajorVersion() >= 12) ? MAX_WAVE_SCRATCH_GFX12 : MAX_WAVE_SCRATCH;
+  max_wave_scratch_ = (supported_isas_[0]->GetMajorVersion() >= 12) ? MAX_WAVE_SCRATCH_GFX12 : MAX_WAVE_SCRATCH;
 
   current_coherency_type((profile_ == HSA_PROFILE_FULL)
                              ? HSA_AMD_COHERENCY_TYPE_COHERENT
@@ -381,7 +382,7 @@ void GpuAgent::AssembleShader(const char* func_name, AssembleTarget assemble_tar
 
   ASICShader* asic_shader = NULL;
 
-  switch (isa_->GetMajorVersion()) {
+  switch (supported_isas()[0]->GetMajorVersion()) {
     case 7:
       asic_shader = &compiled_shader_it->second.compute_7;
       break;
@@ -389,16 +390,16 @@ void GpuAgent::AssembleShader(const char* func_name, AssembleTarget assemble_tar
       asic_shader = &compiled_shader_it->second.compute_8;
       break;
     case 9:
-      if((isa_->GetMinorVersion() == 0) && (isa_->GetStepping() == 10)) {
+      if((supported_isas()[0]->GetMinorVersion() == 0) && (supported_isas()[0]->GetStepping() == 10)) {
         asic_shader = &compiled_shader_it->second.compute_90a;
-      } else if(isa_->GetMinorVersion() == 4 || isa_->GetMinorVersion() == 5) {
+      } else if(supported_isas()[0]->GetMinorVersion() == 4 || supported_isas()[0]->GetMinorVersion() == 5) {
         asic_shader = &compiled_shader_it->second.compute_942;
       } else {
         asic_shader = &compiled_shader_it->second.compute_9;
       }
       break;
     case 10:
-      if(isa_->GetMinorVersion() == 1)
+      if(supported_isas()[0]->GetMinorVersion() == 1)
         asic_shader = &compiled_shader_it->second.compute_1010;
       else
         asic_shader = &compiled_shader_it->second.compute_10;
@@ -407,7 +408,7 @@ void GpuAgent::AssembleShader(const char* func_name, AssembleTarget assemble_tar
         asic_shader = &compiled_shader_it->second.compute_11;
       break;
     case 12:
-        if(isa_->GetMinorVersion() >= 5)
+        if(supported_isas()[0]->GetMinorVersion() >= 5)
           asic_shader = &compiled_shader_it->second.compute_1250;
         else
           asic_shader = &compiled_shader_it->second.compute_12;
@@ -444,7 +445,7 @@ void GpuAgent::AssembleShader(const char* func_name, AssembleTarget assemble_tar
     // ENABLE_WAVEFRONT_SIZE32 must match the wavefront size used to compile blit shaders.
     AMD_HSA_BITS_SET(header->kernel_code_properties,
                      AMD_KERNEL_CODE_PROPERTIES_ENABLE_WAVEFRONT_SIZE32,
-                     isa_->GetWavefront().IsWavefrontSize64() ? 0 : 1);
+                     supported_isas()[0]->GetWavefront().IsWavefrontSize64() ? 0 : 1);
     AMD_HSA_BITS_SET(header->compute_pgm_rsrc1,
                      AMD_COMPUTE_PGM_RSRC_ONE_GRANULATED_WAVEFRONT_SGPR_COUNT,
                      gran_sgprs);
@@ -461,9 +462,9 @@ void GpuAgent::AssembleShader(const char* func_name, AssembleTarget assemble_tar
                      AMD_COMPUTE_PGM_RSRC_TWO_ENABLE_SGPR_WORKGROUP_ID_X, 1);
 
     // gfx90a, gfx942, gfx950
-    if ((isa_->GetMajorVersion() == 9) &&
-        (((isa_->GetMinorVersion() == 0) && (isa_->GetStepping() == 10)) ||
-        (isa_->GetMinorVersion() == 4 || isa_->GetMinorVersion() == 5))) {
+    if ((supported_isas()[0]->GetMajorVersion() == 9) &&
+        (((supported_isas()[0]->GetMinorVersion() == 0) && (supported_isas()[0]->GetStepping() == 10)) ||
+        (supported_isas()[0]->GetMinorVersion() == 4 || supported_isas()[0]->GetMinorVersion() == 5))) {
       // Program COMPUTE_PGM_RSRC3.ACCUM_OFFSET for 0 ACC VGPRs on gfx90a.
       // FIXME: Assemble code objects from source at build time
       int gran_accvgprs = ((gran_vgprs + 1) * 8) / 4 - 1;
@@ -508,7 +509,7 @@ void GpuAgent::InitRegionList() {
 
           if (region->IsLocalMemory()) {
             // Extended Fine-Grain memory
-            if (!(isa_->GetMajorVersion() == 12 && isa_->GetMinorVersion() == 0))
+            if (!(supported_isas()[0]->GetMajorVersion() == 12 && supported_isas()[0]->GetMinorVersion() == 0))
               regions_.push_back(
                   std::make_shared<MemoryRegion>(false, false, false, true, true, this, mem_props[mem_idx]));
 
@@ -811,23 +812,23 @@ core::Blit* GpuAgent::CreateBlitSdma(bool use_xgmi, int rec_eng) {
    */
   auto isDXG = core::Runtime::runtime_singleton_->thunkLoader()->IsDXG();
 
-  switch (isa_->GetMajorVersion()) {
+  switch (supported_isas()[0]->GetMajorVersion()) {
     case 9:
       sdma = new BlitSdmaV4();
-      copy_size_override = (isa_->GetMinorVersion() >= 4 ||
-                            (isa_->GetMinorVersion() == 0 && isa_->GetStepping() == 10)) ?
+      copy_size_override = (supported_isas()[0]->GetMinorVersion() >= 4 ||
+                            (supported_isas()[0]->GetMinorVersion() == 0 && supported_isas()[0]->GetStepping() == 10)) ?
                             copy_size_overrides[1] : copy_size_overrides[0];
       break;
     case 10:
       sdma = (isDXG ? static_cast<BlitSdmaBase*>(new BlitSdmaV4()) : static_cast<BlitSdmaBase*>(new BlitSdmaV5()));
-      copy_size_override = isa_->GetMinorVersion() < 3 ? copy_size_overrides[0] :
+      copy_size_override = supported_isas()[0]->GetMinorVersion() < 3 ? copy_size_overrides[0] :
                                                          copy_size_overrides[1];
       break;
     case 11:
     case 12:
       if (core::Runtime::runtime_singleton_->thunkLoader()->IsDXG()) {
         sdma = static_cast<BlitSdmaBase*>(new BlitSdmaV4());
-      } else if (isa_->GetMinorVersion() >= 5) {
+      } else if (supported_isas()[0]->GetMinorVersion() >= 5) {
         sdma = static_cast<BlitSdmaBase*>(new BlitSdmaV6());
       } else {
         sdma = static_cast<BlitSdmaBase*>(new BlitSdmaV5());
@@ -897,19 +898,19 @@ void GpuAgent::InitDma() {
 
     // User SDMA queues are unstable on gfx8 and unsupported on gfx1013.
     bool use_sdma =
-        ((isa_->GetMajorVersion() != 8) && (isa_->GetVersion() != std::make_tuple(10, 1, 3)));
+        ((supported_isas()[0]->GetMajorVersion() != 8) && (supported_isas()[0]->GetVersion() != std::make_tuple(10, 1, 3)));
     if (sdma_override != Flag::SDMA_DEFAULT) use_sdma = (sdma_override == Flag::SDMA_ENABLE);
 
     if (use_sdma && (HSA_PROFILE_BASE == profile_)) {
       // On gfx90a ensure that HostToDevice queue is created first and so is placed on SDMA0.
-      if ((!prefer_xgmi) && (!isHostToDev) && (isa_->GetMajorVersion() == 9) &&
-          (isa_->GetMinorVersion() == 0) && (isa_->GetStepping() == 10)) {
+      if ((!prefer_xgmi) && (!isHostToDev) && (supported_isas()[0]->GetMajorVersion() == 9) &&
+          (supported_isas()[0]->GetMinorVersion() == 0) && (supported_isas()[0]->GetStepping() == 10)) {
         GetBlitObject(BlitHostToDev);
         *blits_[BlitHostToDev];
       }
 
       // gfx94x is more efficient with reverse order of SDMA0/1 for host<->device copies
-      if (!prefer_xgmi && isa_->GetMajorVersion() == 9 && isa_->GetMinorVersion() >= 4)
+      if (!prefer_xgmi && supported_isas()[0]->GetMajorVersion() == 9 && supported_isas()[0]->GetMinorVersion() >= 4)
         rec_eng = (rec_eng + 1) % properties_.NumSdmaEngines;
 
       // Check support for targeted SDMA engines
@@ -921,8 +922,8 @@ void GpuAgent::InitDma() {
 
       // Observing strange behavior when fixing host<->device engines
       // on GFX9 devices older than GFX90a, so bypass engine fix.
-      if (!prefer_xgmi && isa_->GetMajorVersion() == 9 && isa_->GetMinorVersion() == 0
-          && isa_->GetStepping() < 10)
+      if (!prefer_xgmi && supported_isas()[0]->GetMajorVersion() == 9 && supported_isas()[0]->GetMinorVersion() == 0
+          && supported_isas()[0]->GetStepping() < 10)
         rec_eng = -1;
 
       // devices without dedicated xGMI SDMA engines should not target specific
@@ -1111,7 +1112,7 @@ void GpuAgent::RegisterRecSdmaEngIdMaskPeer(core::Agent& peer, uint32_t rec_sdma
   uses_rec_sdma_eng_id_mask_ = (kfd_version.KernelInterfaceMajorVersion > 1 ||
                                  (kfd_version.KernelInterfaceMajorVersion == 1 &&
                                   kfd_version.KernelInterfaceMinorVersion >= 17)) &&
-                               isa_->GetMajorVersion() == 9 && isa_->GetMinorVersion() >= 4 &&
+                               supported_isas()[0]->GetMajorVersion() == 9 && supported_isas()[0]->GetMinorVersion() >= 4 &&
                                IsPowerOfTwo(rec_sdma_eng_id_mask) && rec_eng_enabled;
 
   rec_sdma_eng_id_peers_info_[peer.public_handle().handle] = uses_rec_sdma_eng_id_mask_ ?
@@ -1269,7 +1270,7 @@ hsa_status_t GpuAgent::DmaCopyOnEngine(void* dst, core::Agent& dst_agent,
     // Due to a RAS issue, GFX90a can only support H2D copies on SDMA0
     bool is_h2d_blit = (src_agent.device_type() == core::Agent::kAmdCpuDevice &&
       dst_agent.device_type() == core::Agent::kAmdGpuDevice);
-    bool limit_h2d_blit = isa_->GetVersion() == core::Isa::Version(9, 0, 10);
+    bool limit_h2d_blit = supported_isas()[0]->GetVersion() == core::Isa::Version(9, 0, 10);
 
     // Ensure engine selection is within proper range based on transfer type
     if ((use_p2p_engines && !rec_sdma_eng_override_ && engine_offset <= num_h2d_d2h_engines_) ||
@@ -1350,7 +1351,7 @@ hsa_status_t GpuAgent::DmaCopyStatus(core::Agent& dst_agent, core::Agent& src_ag
     bool is_h2d_blit = (src_agent.device_type() == core::Agent::kAmdCpuDevice &&
       dst_agent.device_type() == core::Agent::kAmdGpuDevice);
     // Due to a RAS issue, GFX90a can only support H2D copies on SDMA0
-    bool limit_h2d_blit = isa_->GetVersion() == core::Isa::Version(9, 0, 10);
+    bool limit_h2d_blit = supported_isas()[0]->GetVersion() == core::Isa::Version(9, 0, 10);
 
     // Check if H2D is free
     if (DmaEngineIsFree(BlitHostToDev)) {
@@ -1380,7 +1381,7 @@ hsa_status_t GpuAgent::DmaPreferredEngine(core::Agent& dst_agent, core::Agent& s
                                           uint32_t *recommended_ids_mask) {
   // gfx1250+: all SDMA engines are equivalent and there are no XGMI engines, we prefer first 2 engines
   // for h2d/d2h and remaining for p2p.
-  if (isa_->GetMajorVersion() == 12 && isa_->GetMinorVersion() >= 5) {
+  if (supported_isas()[0]->GetMajorVersion() == 12 && supported_isas()[0]->GetMinorVersion() >= 5) {
     bool is_p2p = (src_agent.device_type() == core::Agent::kAmdGpuDevice &&
                   dst_agent.device_type() == core::Agent::kAmdGpuDevice);
 
@@ -1394,8 +1395,8 @@ hsa_status_t GpuAgent::DmaPreferredEngine(core::Agent& dst_agent, core::Agent& s
   }
 
   // From the collected data, gfx94x performance is better only for first 3 SDMA engines
-  bool isGfx94x = (isa_->GetMajorVersion() == 9 &&
-                  (isa_->GetMinorVersion() == 4 || isa_->GetMinorVersion() == 5));
+  bool isGfx94x = (supported_isas()[0]->GetMajorVersion() == 9 &&
+                  (supported_isas()[0]->GetMinorVersion() == 4 || supported_isas()[0]->GetMinorVersion() == 5));
 
   if (isGfx94x &&
       ((src_agent.device_type() == core::Agent::kAmdCpuDevice &&
@@ -2012,7 +2013,7 @@ hsa_status_t GpuAgent::DmaCopyRect(const hsa_pitched_ptr_t* dst, const hsa_dim3_
                                    const hsa_dim3_t* range, hsa_amd_copy_direction_t dir,
                                    std::vector<core::Signal*>& dep_signals,
                                    core::Signal& out_signal) {
-  if (isa_->GetMajorVersion() < 9) return HSA_STATUS_ERROR_INVALID_AGENT;
+  if (supported_isas()[0]->GetMajorVersion() < 9) return HSA_STATUS_ERROR_INVALID_AGENT;
 
   SetCopyRequestRefCount(true);
   MAKE_SCOPE_GUARD([&]() { SetCopyRequestRefCount(false); });
@@ -2092,7 +2093,7 @@ hsa_status_t GpuAgent::GetInfo(hsa_agent_info_t attribute, void* value) const {
 
   switch (attribute_u) {
     case HSA_AGENT_INFO_NAME: {
-      const std::string& name = isa_->GetProcessorName();
+      const std::string& name = supported_isas()[0]->GetProcessorName();
       const size_t n = std::min(name.size(), hsa_name_size);
       std::memset(value, 0, hsa_name_size + 1);
       std::memcpy(value, name.data(), n);
@@ -2118,7 +2119,7 @@ hsa_status_t GpuAgent::GetInfo(hsa_agent_info_t attribute, void* value) const {
           HSA_DEFAULT_FLOAT_ROUNDING_MODE_NEAR;
       break;
     case HSA_AGENT_INFO_FAST_F16_OPERATION:
-      if (isa_->GetMajorVersion() >= 8) {
+      if (supported_isas()[0]->GetMajorVersion() >= 8) {
         *((bool*)value) = true;
       } else {
         *((bool*)value) = false;
@@ -2200,7 +2201,7 @@ hsa_status_t GpuAgent::GetInfo(hsa_agent_info_t attribute, void* value) const {
       }
     } break;
     case HSA_AGENT_INFO_ISA:
-      *((hsa_isa_t*)value) = core::Isa::Handle(isa_);
+      *((hsa_isa_t*)value) = core::Isa::Handle(supported_isas()[0]);
       break;
     case HSA_AGENT_INFO_EXTENSIONS: {
       memset(value, 0, sizeof(uint8_t) * 128);
@@ -2247,23 +2248,23 @@ hsa_status_t GpuAgent::GetInfo(hsa_agent_info_t attribute, void* value) const {
     case HSA_EXT_AGENT_INFO_IMAGE_2DADEPTH_MAX_ELEMENTS:
     case HSA_EXT_AGENT_INFO_IMAGE_3D_MAX_ELEMENTS:
     case HSA_EXT_AGENT_INFO_IMAGE_ARRAY_MAX_LAYERS:
-      if (!isa_->HasImageSupport())
+      if (!supported_isas()[0]->HasImageSupport())
         *((uint32_t*)value) = 0;
       else
         return hsa_amd_image_get_info_max_dim(public_handle(), attribute, value);
       break;
     case HSA_EXT_AGENT_INFO_MAX_IMAGE_RD_HANDLES:
       // TODO: hardcode based on OCL constants.
-      *((uint32_t*)value) = isa_->HasImageSupport() ? 128 : 0;
+      *((uint32_t*)value) = supported_isas()[0]->HasImageSupport() ? 128 : 0;
       break;
     case HSA_EXT_AGENT_INFO_MAX_IMAGE_RORW_HANDLES:
-      *((uint32_t*)value) = isa_->HasImageSupport() ? 64 : 0;
+      *((uint32_t*)value) = supported_isas()[0]->HasImageSupport() ? 64 : 0;
       break;
     case HSA_EXT_AGENT_INFO_MAX_SAMPLER_HANDLERS:
-      *((uint32_t*)value) = isa_->HasImageSupport() ? 16 : 0;
+      *((uint32_t*)value) = supported_isas()[0]->HasImageSupport() ? 16 : 0;
       break;
     case HSA_EXT_AGENT_INFO_IMAGE_SUPPORT:
-      *((uint32_t*)value) = isa_->HasImageSupport();
+      *((uint32_t*)value) = supported_isas()[0]->HasImageSupport();
       break;
     case HSA_AMD_AGENT_INFO_CHIP_ID:
       *((uint32_t*)value) = properties_.DeviceId;
@@ -2370,8 +2371,8 @@ hsa_status_t GpuAgent::GetInfo(hsa_agent_info_t attribute, void* value) const {
       }
 
       if (core::Runtime::runtime_singleton_->flag().coop_cu_count() &&
-          (isa_->GetMajorVersion() == 9) && (isa_->GetMinorVersion() == 0) &&
-          (isa_->GetStepping() == 10)) {
+          (supported_isas()[0]->GetMajorVersion() == 9) && (supported_isas()[0]->GetMinorVersion() == 0) &&
+          (supported_isas()[0]->GetStepping() == 10)) {
         uint32_t count = 0;
         [[maybe_unused]] hsa_status_t cu_err =
             GetInfo((hsa_agent_info_t)HSA_AMD_AGENT_INFO_COMPUTE_UNIT_COUNT, &count);
@@ -2494,7 +2495,7 @@ hsa_status_t GpuAgent::GetInfo(hsa_agent_info_t attribute, void* value) const {
       *((uint64_t*)value) = cluster_max_dim_.x;
       break;
     case HSA_AMD_AGENT_INFO_MAX_DATA_PREFETCH_REGIONS:
-      if (isa_->GetMajorVersion() == 12 && isa_->GetMinorVersion() >= 5) {
+      if (supported_isas()[0]->GetMajorVersion() == 12 && supported_isas()[0]->GetMinorVersion() >= 5) {
         *((uint32_t*)value) = AMD_LAUNCH_DESCRIPTOR_MAX_PREFETCH_REGIONS;
       } else {
         *((uint32_t*)value) = 0;
@@ -2654,7 +2655,7 @@ void GpuAgent::UnregisterAqlQueue(core::Queue* queue) {
 void GpuAgent::AcquireQueueMainScratch(ScratchInfo& scratch) {
   assert(scratch.main_queue_base == nullptr &&
          "AcquireQueueMainScratch called while holding scratch.");
-  bool need_queue_scratch_base = (isa_->GetMajorVersion() > 8);
+  bool need_queue_scratch_base = (supported_isas()[0]->GetMajorVersion() > 8);
 
   if (scratch.main_size == 0) {
     scratch.main_size = queue_scratch_len_;
@@ -2701,7 +2702,7 @@ void GpuAgent::AcquireQueueMainScratch(ScratchInfo& scratch) {
             ((scratch_pool_.size() - scratch_pool_.remaining() - scratch_cache_.free_bytes() +
              scratch.main_size) > small_limit));
 
-  if ((isa_->GetMajorVersion() < 8) ||
+  if ((supported_isas()[0]->GetMajorVersion() < 8) ||
       core::Runtime::runtime_singleton_->flag().no_scratch_reclaim()) {
     large = false;
     use_reclaim = false;
@@ -3151,7 +3152,7 @@ hsa_status_t GpuAgent::UpdateTrapHandlerWithPCS(pcs_sampling_data_t* pcs_hosttra
 }
 
 void GpuAgent::BindTrapHandler() {
-  if (isa_->GetMajorVersion() == 7) {
+  if (supported_isas()[0]->GetMajorVersion() == 7) {
     // No trap handler support on Gfx7, soft error.
     return;
   }
@@ -3164,11 +3165,11 @@ void GpuAgent::BindTrapHandler() {
     AssembleShader("TrapHandlerKfdExceptions", AssembleTarget::ISA, trap_code_buf_,
                    trap_code_buf_size_);
   } else {
-    if (isa_->GetMajorVersion() >= 11 ||
-       (isa_->GetMajorVersion() == 9 &&
-        (isa_->GetMinorVersion() == 4 || isa_->GetMinorVersion() == 5)) ||
-       (isa_->GetMajorVersion() == 10 && isa_->GetMinorVersion() == 3 &&
-        isa_->GetStepping() == 6)) {
+    if (supported_isas()[0]->GetMajorVersion() >= 11 ||
+       (supported_isas()[0]->GetMajorVersion() == 9 &&
+        (supported_isas()[0]->GetMinorVersion() == 4 || supported_isas()[0]->GetMinorVersion() == 5)) ||
+       (supported_isas()[0]->GetMajorVersion() == 10 && supported_isas()[0]->GetMinorVersion() == 3 &&
+        supported_isas()[0]->GetStepping() == 6)) {
       // No trap handler support without exception handling, soft error.
       // gfx1036 (Granite Ridge iGPU): KMD does not support the trap handler escape.
       return;
@@ -3200,17 +3201,17 @@ void GpuAgent::BindTrapHandler() {
 void GpuAgent::InvalidateCodeCaches(void *ptr, size_t size) {
   // Check for microcode cache invalidation support.
   // This is deprecated in later microcode builds.
-  if (isa_->GetMajorVersion() == 7) {
+  if (supported_isas()[0]->GetMajorVersion() == 7) {
     if (properties_.EngineId.ui32.uCode < 420) {
       // Microcode is handling code cache invalidation.
       return;
     }
-  } else if (isa_->GetMajorVersion() == 8 && isa_->GetMinorVersion() == 0) {
+  } else if (supported_isas()[0]->GetMajorVersion() == 8 && supported_isas()[0]->GetMinorVersion() == 0) {
     if (properties_.EngineId.ui32.uCode < 685) {
       // Microcode is handling code cache invalidation.
       return;
     }
-  } else if (isa_->GetMajorVersion() > 12) {
+  } else if (supported_isas()[0]->GetMajorVersion() > 12) {
     assert(false && "Code cache invalidation not implemented for this agent");
   }
 
@@ -3218,7 +3219,7 @@ void GpuAgent::InvalidateCodeCaches(void *ptr, size_t size) {
   uint32_t cache_inv[8] = {0};
   uint32_t cache_inv_size_dw;
 
-  if (isa_->GetMajorVersion() < 10) {
+  if (supported_isas()[0]->GetMajorVersion() < 10) {
       cache_inv[1] = PM4_ACQUIRE_MEM_DW1_COHER_CNTL(
           PM4_ACQUIRE_MEM_COHER_CNTL_SH_ICACHE_ACTION_ENA |
           PM4_ACQUIRE_MEM_COHER_CNTL_SH_KCACHE_ACTION_ENA |
@@ -3238,7 +3239,7 @@ void GpuAgent::InvalidateCodeCaches(void *ptr, size_t size) {
   }
 
   cache_inv[0] = PM4_HDR(PM4_HDR_IT_OPCODE_ACQUIRE_MEM, cache_inv_size_dw,
-             isa_->GetMajorVersion());
+             supported_isas()[0]->GetMajorVersion());
 
   if (ptr) {
     size_t size_granule = (size + 0xFF) >> 8;
@@ -4063,7 +4064,7 @@ hsa_status_t GpuAgent::PcSamplingFlushDeviceBuffers(
    *    done.
    */
 
-  cmd_data[i++] = PM4_HDR(PM4_HDR_IT_OPCODE_ATOMIC_MEM, atomic_ex_cmd_sz, isa_->GetMajorVersion());
+  cmd_data[i++] = PM4_HDR(PM4_HDR_IT_OPCODE_ATOMIC_MEM, atomic_ex_cmd_sz, supported_isas()[0]->GetMajorVersion());
   cmd_data[i++] = PM4_ATOMIC_MEM_DW1_ATOMIC(PM4_ATOMIC_MEM_GL2_OP_ATOMIC_SWAP_RTN_64);
   cmd_data[i++] = PM4_ATOMIC_MEM_DW2_ADDR_LO(buf_write_val);
   cmd_data[i++] = PM4_ATOMIC_MEM_DW3_ADDR_HI((buf_write_val) >> 32);
@@ -4071,7 +4072,7 @@ hsa_status_t GpuAgent::PcSamplingFlushDeviceBuffers(
   cmd_data[i++] = PM4_ATOMIC_MEM_DW5_SRC_DATA_HI(((uint64_t)reset_write_val) >> 32);
   i += 3;
   /* copy data */
-  cmd_data[i++] = PM4_HDR(PM4_HDR_IT_OPCODE_COPY_DATA, copy_data_cmd_sz, isa_->GetMajorVersion());
+  cmd_data[i++] = PM4_HDR(PM4_HDR_IT_OPCODE_COPY_DATA, copy_data_cmd_sz, supported_isas()[0]->GetMajorVersion());
   cmd_data[i++] =
       PM4_COPY_DATA_DW1(PM4_COPY_DATA_SRC_SEL_ATOMIC_RETURN_DATA | PM4_COPY_DATA_DST_SEL_TC_12 |
                         PM4_COPY_DATA_COUNT_SEL | PM4_COPY_DATA_WR_CONFIRM);
@@ -4081,7 +4082,7 @@ hsa_status_t GpuAgent::PcSamplingFlushDeviceBuffers(
 
   if (properties_.NumXcc > 1) {
     cmd_data[0] =
-      PM4_HDR(PM4_HDR_IT_OPCODE_PRED_EXEC, pred_exec_cmd_sz, isa_->GetMajorVersion());
+      PM4_HDR(PM4_HDR_IT_OPCODE_PRED_EXEC, pred_exec_cmd_sz, supported_isas()[0]->GetMajorVersion());
     cmd_data[1] =
       PM4_PRED_EXEC_DW2_EXEC_COUNT(i - pred_exec_cmd_sz) | PM4_PRED_EXEC_DW2_VIRTUALXCCID_SELECT(0x1);
   }
@@ -4131,7 +4132,7 @@ hsa_status_t GpuAgent::PcSamplingFlushDeviceBuffers(
 
   /* WAIT_REG_MEM, wait on buf_written_val */
   cmd_data[i++] =
-      PM4_HDR(PM4_HDR_IT_OPCODE_WAIT_REG_MEM, wait_reg_mem_cmd_sz, isa_->GetMajorVersion());
+      PM4_HDR(PM4_HDR_IT_OPCODE_WAIT_REG_MEM, wait_reg_mem_cmd_sz, supported_isas()[0]->GetMajorVersion());
   cmd_data[i++] = PM4_WAIT_REG_MEM_DW1(PM4_WAIT_REG_MEM_FUNCTION_EQUAL_TO_REFERENCE |
                                        PM4_WAIT_REG_MEM_MEM_SPACE_MEMORY_SPACE |
                                        PM4_WAIT_REG_MEM_OPERATION_WAIT_REG_MEM);
@@ -4145,10 +4146,10 @@ hsa_status_t GpuAgent::PcSamplingFlushDeviceBuffers(
   // For GFX1200 and GFX1201 - add an ACQUIRE_MEM packet to flush L2 cache before DMA
   // This ensures that any data written by the trap handler is visible to the DMA engine.
   // On GFX1250 - The flush is needed only until we can enable MTYPE_RW.
-  if (isa_->GetMajorVersion() == 12 &&
-      (isa_->GetMinorVersion() == 0 || isa_->GetMinorVersion() == 5)) {
+  if (supported_isas()[0]->GetMajorVersion() == 12 &&
+      (supported_isas()[0]->GetMinorVersion() == 0 || supported_isas()[0]->GetMinorVersion() == 5)) {
     cmd_data[i++] =
-        PM4_HDR(PM4_HDR_IT_OPCODE_ACQUIRE_MEM, acquire_mem_cmd_sz, isa_->GetMajorVersion());
+        PM4_HDR(PM4_HDR_IT_OPCODE_ACQUIRE_MEM, acquire_mem_cmd_sz, supported_isas()[0]->GetMajorVersion());
     cmd_data[i++] = 0;                                // DW1: COHER_CNTL
     cmd_data[i++] = 0;                                // DW2: COHER_SIZE
     cmd_data[i++] = 0;                                // DW3: COHER_SIZE_HI
@@ -4164,7 +4165,7 @@ hsa_status_t GpuAgent::PcSamplingFlushDeviceBuffers(
        to_copy -= copy_bytes) {
 
     /* DMA_DATA PACKETS, copy buffer using CPDMA */
-    cmd_data[i++] = PM4_HDR(PM4_HDR_IT_OPCODE_DMA_DATA, dma_data_cmd_sz, isa_->GetMajorVersion());
+    cmd_data[i++] = PM4_HDR(PM4_HDR_IT_OPCODE_DMA_DATA, dma_data_cmd_sz, supported_isas()[0]->GetMajorVersion());
     cmd_data[i++] = PM4_DMA_DATA_DW1(PM4_DMA_DATA_DST_SEL_DST_ADDR_USING_L2 |
                                      PM4_DMA_DATA_SRC_SEL_SRC_ADDR_USING_L2);
     cmd_data[i++] = PM4_DMA_DATA_DW2_SRC_ADDR_LO((uint64_t)buffer_temp);
@@ -4183,7 +4184,7 @@ hsa_status_t GpuAgent::PcSamplingFlushDeviceBuffers(
   }
 
   /* WRITE_DATA, Reset buf_written_val */
-  cmd_data[i++] = PM4_HDR(PM4_HDR_IT_OPCODE_WRITE_DATA, write_data_cmd_sz, isa_->GetMajorVersion());
+  cmd_data[i++] = PM4_HDR(PM4_HDR_IT_OPCODE_WRITE_DATA, write_data_cmd_sz, supported_isas()[0]->GetMajorVersion());
   cmd_data[i++] = PM4_WRITE_DATA_DW1(PM4_WRITE_DATA_DST_SEL_TC_L2 |
                                      PM4_WRITE_DATA_WR_CONFIRM_WAIT_CONFIRMATION);
   cmd_data[i++] = PM4_WRITE_DATA_DW2_DST_MEM_ADDR_LO(buf_written_val[which_buffer]);
@@ -4192,7 +4193,7 @@ hsa_status_t GpuAgent::PcSamplingFlushDeviceBuffers(
 
   if (properties_.NumXcc > 1) {
     cmd_data[0] =
-      PM4_HDR(PM4_HDR_IT_OPCODE_PRED_EXEC, pred_exec_cmd_sz, isa_->GetMajorVersion());
+      PM4_HDR(PM4_HDR_IT_OPCODE_PRED_EXEC, pred_exec_cmd_sz, supported_isas()[0]->GetMajorVersion());
     cmd_data[1] =
       PM4_PRED_EXEC_DW2_EXEC_COUNT(i - pred_exec_cmd_sz) | PM4_PRED_EXEC_DW2_VIRTUALXCCID_SELECT(0x1);
   }


### PR DESCRIPTION
Remove isa_ member from GpuAgent as we do not want to have two lists of ISAs per agent. The first member of supported_isas is the default ISA.