### PR TITLE
[rocprofiler-sdk] Warn instead of abort on invalid LOG_LEVEL value

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/common/logging.cpp
+++ b/projects/rocprofiler-sdk/source/lib/common/logging.cpp
@@ -125,11 +125,15 @@ init_logging(std::string_view env_prefix, logging_config cfg)
         else if(!loglvl.empty())
         {
             if(env_opts.find(loglvl) == env_opts.end())
-                throw std::runtime_error{fmt::format(
-                    "invalid specifier for {}_LOG_LEVEL: {}. Supported: {}",
-                    env_prefix,
-                    loglvl,
-                    fmt::format("{}", fmt::join(supported.begin(), supported.end(), ", ")))};
+            {
+                // Write directly to stderr: absl logging is not yet initialized at this point.
+                fmt::print(stderr,
+                           "[rocprofiler-sdk][warning] invalid specifier for {}_LOG_LEVEL: "
+                           "{}. Supported: {}. Falling back to default log level.\n",
+                           env_prefix,
+                           loglvl,
+                           fmt::join(supported.begin(), supported.end(), ", "));
+            }
             else
             {
                 loglvl_v   = env_opts.at(loglvl).severity_level;


### PR DESCRIPTION
## Summary
Replace the `std::runtime_error` thrown for unrecognized `*_LOG_LEVEL` values with a warning written to stderr, falling back to the default log level instead of aborting the host process.

## Root Cause
`init_logging()` in `source/lib/common/logging.cpp` threw `std::runtime_error` when the resolved env var (e.g. `ROCPROFILER_LOG_LEVEL`, `ROCPROF_LOG_LEVEL`) contained an unrecognized non-numeric value. Because the core SDK calls `init_logging("ROCPROFILER", ...)` at shared library load time via `init_logging_at_load` (`registration.cpp:857`), the uncaught exception aborted **any** process that loaded `librocprofiler-sdk.so` - not just `rocprofv3`.

### Reproducer (pre-fix, on `develop` @ `d713a93d65`)
```
$ ROCPROFILER_LOG_LEVEL=bogus ./bin/buffered-api-tracing
terminate called after throwing an instance of 'std::runtime_error'
  what():  invalid specifier for ROCPROFILER_LOG_LEVEL: bogus. Supported: fatal, error, warning, info, trace
Aborted (core dumped)   # exit 134
```

## Fix
`projects/rocprofiler-sdk/source/lib/common/logging.cpp` (line 127): replace the throw with a `fmt::print(stderr, ...)` warning that names the offending env var, lists the supported values, and explicitly notes the fallback. `cfg.loglevel` / `cfg.vlog_level` keep their initialized defaults.

## Behavior After Fix
| Scenario | Before | After |
|---|---|---|
| `ROCPROFILER_LOG_LEVEL=nope` + sample | exit 134 (SIGABRT) | exit 0, prints warning |
| `ROCPROF_LOG_LEVEL=bogus` + rocprofv3 | exit 134 (SIGABRT) | runs, prints warning |
| Both env vars bad simultaneously | exit 134 | runs, prints both warnings |
| Valid value (`info`) | works | still works |

Example:
```
$ ROCPROFILER_LOG_LEVEL=nope ./bin/buffered-api-tracing
[rocprofiler-sdk][warning] invalid specifier for ROCPROFILER_LOG_LEVEL: nope. Supported: fatal, error, warning, info, trace. Falling back to default log level.
...
Outputting collected data to api_buffered_trace.log...
```

## Testing
Built and verified on `banff-ccs-aus-g05-05` (MI325X / gfx942) inside a TheRock ROCm 7.13.0 container against `develop` @ `d713a93d65`. All four scenarios above produce the expected behavior; valid log-level values continue to be honored.