### PR TITLE
[rocprofiler-compute] Defer counter setup until HSA loads

### DIFF
--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/rocprofiler_compute_tool.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/rocprofiler_compute_tool.cpp
@@ -85,24 +85,36 @@ void tool_tracing_callback(rocprofiler_callback_tracing_record_t record,
     g_sdk_callbacks->tool_tracing_callback(record, callback_data);
 }
 
-int tool_init(rocprofiler_client_finalize_t, void* user_data)
+void on_hsa_runtime_loaded(rocprofiler_intercept_table_t /*type*/,
+                           uint64_t /*lib_version*/,
+                           uint64_t /*lib_instance*/,
+                           void** /*tables*/,
+                           uint64_t /*num_tables*/,
+                           void* user_data)
 {
-    std::clog << "[rocprofiler-compute] In tool init\n";
-    g_sdk_wrapper->create_context(&get_client_ctx());
-
+    // Counter collection and context start require HSA to be alive. Defer
+    // them until HSA actually loads so that LD_PRELOAD'd shells (which never
+    // touch HSA) do not initialize HSA worker threads, which would otherwise
+    // deadlock on fork() inside subshell/command-substitution.
     g_sdk_wrapper->configure_callback_dispatch_counting_service(get_client_ctx(),
                                                                 dispatch_callback,
                                                                 user_data,
                                                                 record_callback,
                                                                 user_data);
+    g_sdk_wrapper->start_context(get_client_ctx());
+}
+
+int tool_init(rocprofiler_client_finalize_t, void* user_data)
+{
+    std::clog << "[rocprofiler-compute] In tool init\n";
+    g_sdk_wrapper->create_context(&get_client_ctx());
+
     g_sdk_wrapper->configure_callback_tracing_service(get_client_ctx(),
                                                       ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT,
                                                       nullptr,
                                                       0,
                                                       tool_tracing_callback,
                                                       user_data);
-    g_sdk_wrapper->start_context(get_client_ctx());
-
     return 0;
 }
 
@@ -241,12 +253,19 @@ rocprofiler_tool_configure_result_t* rocprofiler_configure(uint32_t             
 
     // create configure data
     if (!g_cfg)
-        g_cfg = std::make_shared<rocprofiler_tool_configure_result_t>(
+    {
+        auto* tool_data_ptr = new std::unique_ptr<tool_data_t>(std::move(tool_data));
+        g_cfg               = std::make_shared<rocprofiler_tool_configure_result_t>(
             rocprofiler_tool_configure_result_t{sizeof(rocprofiler_tool_configure_result_t),
                                                 &tool_init,
                                                 &tool_fini,
-                                                static_cast<void*>(new std::unique_ptr<tool_data_t>(
-                                                    std::move(tool_data)))});
+                                                static_cast<void*>(tool_data_ptr)});
+
+        // Defer HSA-touching counter setup until HSA actually loads in the
+        // process. See on_hsa_runtime_loaded for rationale.
+        g_sdk_wrapper->at_intercept_table_registration_hsa(&rocprofiler_compute_tool::on_hsa_runtime_loaded,
+                                                           static_cast<void*>(tool_data_ptr));
+    }
 
     return g_cfg.get();
 }

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/rocprofiler_compute_tool.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/rocprofiler_compute_tool.cpp
@@ -10,6 +10,7 @@
 
 #include <unistd.h>
 
+#include <atomic>
 #include <fstream>
 #include <iostream>
 #include <sstream>
@@ -22,6 +23,8 @@ static std::shared_ptr<SdkWrapper>      g_sdk_wrapper      = std::make_shared<Sd
 static std::shared_ptr<SdkCallbacks> g_sdk_callbacks = std::make_shared<SdkCallbacksImpl>(g_sdk_wrapper);
 static std::shared_ptr<CountersWriter> g_counters_writer = std::make_shared<CsvCountersWriter>();
 static std::shared_ptr<rocprofiler_tool_configure_result_t> g_cfg;
+static std::atomic<bool>                                    g_tool_shutting_down{false};
+static std::atomic<bool>                                    g_hsa_intercept_done{false};
 
 void test_knobs::set_input_parameters(const std::shared_ptr<InputParameters>& input_parameters)
 {
@@ -41,6 +44,8 @@ void test_knobs::set_csv_writer(const std::shared_ptr<CountersWriter>& csv_write
 void test_knobs::reset_cfg()
 {
     g_cfg.reset();
+    g_tool_shutting_down.store(false, std::memory_order_release);
+    g_hsa_intercept_done.store(false, std::memory_order_release);
 }
 
 namespace rocprofiler_compute_tool
@@ -96,6 +101,12 @@ void on_hsa_runtime_loaded(rocprofiler_intercept_table_t /*type*/,
     // them until HSA actually loads so that LD_PRELOAD'd shells (which never
     // touch HSA) do not initialize HSA worker threads, which would otherwise
     // deadlock on fork() inside subshell/command-substitution.
+    if (g_tool_shutting_down.load(std::memory_order_acquire))
+        return;
+
+    if (g_hsa_intercept_done.exchange(true, std::memory_order_acq_rel))
+        return;
+
     g_sdk_wrapper->configure_callback_dispatch_counting_service(get_client_ctx(),
                                                                 dispatch_callback,
                                                                 user_data,
@@ -148,6 +159,7 @@ void generate_output(tool_data_t* tool_data)
 
 void tool_fini(void* user_data)
 {
+    g_tool_shutting_down.store(true, std::memory_order_release);
     assert(user_data);
     std::clog << "[rocprofiler-compute] In tool fini\n";
     rocprofiler_stop_context(get_client_ctx());

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/sdk_wrapper.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/sdk_wrapper.cpp
@@ -93,3 +93,10 @@ void SdkWrapperImpl::query_record_counter_id(rocprofiler_counter_instance_id_t i
 {
     ROCPROFILER_CALL(rocprofiler_query_record_counter_id(id, counter_id), "query record counter id");
 }
+
+void SdkWrapperImpl::at_intercept_table_registration_hsa(rocprofiler_intercept_library_cb_t callback,
+                                                         void* user_data)
+{
+    ROCPROFILER_CALL(rocprofiler_at_intercept_table_registration(callback, ROCPROFILER_HSA_TABLE, user_data),
+                     "register HSA intercept table callback");
+}

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/sdk_wrapper.h
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/sdk_wrapper.h
@@ -41,6 +41,9 @@ public:
 
     virtual void query_record_counter_id(rocprofiler_counter_instance_id_t id,
                                          rocprofiler_counter_id_t*         counter_id) = 0;
+
+    virtual void at_intercept_table_registration_hsa(rocprofiler_intercept_library_cb_t callback,
+                                                     void* user_data) = 0;
 };
 
 class SdkWrapperImpl : public SdkWrapper
@@ -72,5 +75,8 @@ public:
                                rocprofiler_counter_config_id_t* config_id) override;
     void query_record_counter_id(rocprofiler_counter_instance_id_t id,
                                  rocprofiler_counter_id_t*         counter_id) override;
+
+    void at_intercept_table_registration_hsa(rocprofiler_intercept_library_cb_t callback,
+                                             void*                              user_data) override;
 };
 }  // namespace rocprofiler_compute_tool

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.cpp
@@ -212,6 +212,18 @@ const std::vector<MockSdkWrapper::create_counter_config_info>& MockSdkWrapper::g
     return m_create_counter_config_info;
 }
 
+void MockSdkWrapper::at_intercept_table_registration_hsa(rocprofiler_intercept_library_cb_t callback,
+                                                         void* user_data)
+{
+    m_hsa_intercept_registration_info.push_back({callback, user_data});
+}
+
+const std::vector<MockSdkWrapper::hsa_intercept_registration_info>&
+    MockSdkWrapper::get_hsa_intercept_registration_info() const
+{
+    return m_hsa_intercept_registration_info;
+}
+
 const std::vector<MockSdkWrapper::query_counter_record_info>& MockSdkWrapper::get_query_counter_record_info() const
 {
     return m_query_counter_record_info;

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.h
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.h
@@ -98,23 +98,34 @@ public:
     void query_record_counter_id(rocprofiler_counter_instance_id_t id,
                                  rocprofiler_counter_id_t*         counter_id) override;
 
+    void at_intercept_table_registration_hsa(rocprofiler_intercept_library_cb_t callback,
+                                             void*                              user_data) override;
+
+    struct hsa_intercept_registration_info
+    {
+        rocprofiler_intercept_library_cb_t callback  = nullptr;
+        void*                              user_data = nullptr;
+    };
+
     // Test functions
     void set_available_counters(const std::vector<std::string>& counter_names);
-    const std::vector<uint64_t>&                       get_created_contexts() const;
-    const std::vector<uint64_t>&                       get_started_contexts() const;
-    const std::vector<dispatch_counting_service_info>& get_dispatch_counting_service_info() const;
-    const std::vector<create_counter_config_info>&     get_create_counter_config_info() const;
-    const std::vector<query_counter_record_info>&      get_query_counter_record_info() const;
+    const std::vector<uint64_t>&                        get_created_contexts() const;
+    const std::vector<uint64_t>&                        get_started_contexts() const;
+    const std::vector<dispatch_counting_service_info>&  get_dispatch_counting_service_info() const;
+    const std::vector<create_counter_config_info>&      get_create_counter_config_info() const;
+    const std::vector<query_counter_record_info>&       get_query_counter_record_info() const;
+    const std::vector<hsa_intercept_registration_info>& get_hsa_intercept_registration_info() const;
 
 private:
     std::vector<rocprofiler_counter_id_t> get_counters() const;
 
-    std::vector<uint64_t>                       m_created_contexts;
-    std::vector<uint64_t>                       m_started_contexts;
-    std::vector<dispatch_counting_service_info> m_dispatch_counting_service_info;
-    std ::vector<create_counter_config_info>    m_create_counter_config_info;
-    std::vector<query_counter_record_info>      m_query_counter_record_info;
-    std::vector<std::string>                    m_counter_names;
+    std::vector<uint64_t>                        m_created_contexts;
+    std::vector<uint64_t>                        m_started_contexts;
+    std::vector<dispatch_counting_service_info>  m_dispatch_counting_service_info;
+    std ::vector<create_counter_config_info>     m_create_counter_config_info;
+    std::vector<query_counter_record_info>       m_query_counter_record_info;
+    std::vector<std::string>                     m_counter_names;
+    std::vector<hsa_intercept_registration_info> m_hsa_intercept_registration_info;
 };
 
 class MockCountersWriter : public rocprofiler_compute_tool::CountersWriter

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_rocprofiler_compute_tool.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_rocprofiler_compute_tool.cpp
@@ -291,6 +291,36 @@ TEST_F(TestRocprofilerComputeTool, HsaInterceptCallback_StartsContextAndConfigur
     reg.callback(ROCPROFILER_HSA_TABLE, 0, 0, nullptr, 0, reg.user_data);
     EXPECT_EQ(m_sdk_wrapper->get_started_contexts().size(), 1u);
     EXPECT_EQ(m_sdk_wrapper->get_dispatch_counting_service_info().size(), 1u);
+    compare_counter_config_ids(m_sdk_wrapper->get_created_contexts(),
+                               m_sdk_wrapper->get_started_contexts());
+}
+
+// The SDK may fire the HSA intercept callback more than once. Counter setup
+// and context start must run exactly once per process.
+TEST_F(TestRocprofilerComputeTool, HsaInterceptCallback_IsIdempotent)
+{
+    const auto cfg = rocprofiler_configure(1, "", 1, &m_client_id);
+    ASSERT_EQ(cfg->initialize(nullptr, cfg->tool_data), 0);
+    ASSERT_EQ(m_sdk_wrapper->get_hsa_intercept_registration_info().size(), 1u);
+    const auto reg = m_sdk_wrapper->get_hsa_intercept_registration_info()[0];
+    reg.callback(ROCPROFILER_HSA_TABLE, 0, 0, nullptr, 0, reg.user_data);
+    reg.callback(ROCPROFILER_HSA_TABLE, 0, 0, nullptr, 0, reg.user_data);
+    EXPECT_EQ(m_sdk_wrapper->get_started_contexts().size(), 1u);
+    EXPECT_EQ(m_sdk_wrapper->get_dispatch_counting_service_info().size(), 1u);
+}
+
+// If HSA loads after tool_fini has run, the callback must not dereference
+// the freed tool_data pointer it captured at registration time.
+TEST_F(TestRocprofilerComputeTool, HsaInterceptCallback_AfterToolFini_IsNoOp)
+{
+    const auto cfg = rocprofiler_configure(1, "", 1, &m_client_id);
+    ASSERT_EQ(cfg->initialize(nullptr, cfg->tool_data), 0);
+    ASSERT_EQ(m_sdk_wrapper->get_hsa_intercept_registration_info().size(), 1u);
+    cfg->finalize(cfg->tool_data);
+    const auto reg = m_sdk_wrapper->get_hsa_intercept_registration_info()[0];
+    reg.callback(ROCPROFILER_HSA_TABLE, 0, 0, nullptr, 0, reg.user_data);
+    EXPECT_TRUE(m_sdk_wrapper->get_started_contexts().empty());
+    EXPECT_TRUE(m_sdk_wrapper->get_dispatch_counting_service_info().empty());
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_rocprofiler_compute_tool.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_rocprofiler_compute_tool.cpp
@@ -205,19 +205,21 @@ TEST_F(TestRocprofilerComputeTool, DISABLED_ProvidedIntersectingRanges_Throws)
     EXPECT_THROW(rocprofiler_configure(1, "", 1, &m_client_id), std::runtime_error);
 }
 
-TEST_F(TestRocprofilerComputeTool, OnToolInit_CreatesAndStartsContext)
+TEST_F(TestRocprofilerComputeTool, OnToolInit_CreatesContext)
 {
     const auto cfg = rocprofiler_configure(1, "", 1, &m_client_id);
     cfg->initialize(nullptr, cfg->tool_data);
-    compare_counter_config_ids(m_sdk_wrapper->get_created_contexts(),
-                               m_sdk_wrapper->get_started_contexts());
+    EXPECT_EQ(m_sdk_wrapper->get_created_contexts().size(), 1u);
 }
 
-TEST_F(TestRocprofilerComputeTool, OnToolInit_ConfiguresDispatchCountingService)
+TEST_F(TestRocprofilerComputeTool, OnHsaInterceptCallback_ConfiguresDispatchCountingService)
 {
     const auto cfg = rocprofiler_configure(1, "", 1, &m_client_id);
     cfg->initialize(nullptr, cfg->tool_data);
-    EXPECT_EQ(m_sdk_wrapper->get_dispatch_counting_service_info().size(), 1);
+    ASSERT_EQ(m_sdk_wrapper->get_hsa_intercept_registration_info().size(), 1u);
+    const auto reg = m_sdk_wrapper->get_hsa_intercept_registration_info()[0];
+    reg.callback(ROCPROFILER_HSA_TABLE, 0, 0, nullptr, 0, reg.user_data);
+    ASSERT_EQ(m_sdk_wrapper->get_dispatch_counting_service_info().size(), 1u);
     const auto& args = m_sdk_wrapper->get_dispatch_counting_service_info()[0];
     EXPECT_EQ(args.context, m_sdk_wrapper->get_created_contexts()[0]);
     EXPECT_TRUE(args.dispatch_callback != nullptr);
@@ -259,6 +261,36 @@ TEST_F(TestRocprofilerComputeTool, OnFiniWithNonEmptyCountersAndKernelFiltering_
     EXPECT_EQ(m_counters_writer->get_write_counters_info().size(), 1);
     EXPECT_EQ(m_counters_writer->get_write_counters_info()[0].counter_ids, std::vector{counter_id});
     EXPECT_EQ(m_counters_writer->get_write_counters_info()[0].kernel_id, std::vector{kernel_id0});
+}
+
+// Regression guard for the HSA-init-in-shell-then-fork deadlock: tool_init
+// must not call into HSA-touching SDK services. Counter collection setup and
+// context activation must only happen via the HSA intercept callback.
+TEST_F(TestRocprofilerComputeTool, ToolInit_DoesNotStartContextOrConfigureCountingService)
+{
+    const auto cfg = rocprofiler_configure(1, "", 1, &m_client_id);
+    ASSERT_EQ(cfg->initialize(nullptr, cfg->tool_data), 0);
+    EXPECT_TRUE(m_sdk_wrapper->get_started_contexts().empty());
+    EXPECT_TRUE(m_sdk_wrapper->get_dispatch_counting_service_info().empty());
+}
+
+TEST_F(TestRocprofilerComputeTool, RocprofilerConfigure_RegistersHsaInterceptCallback)
+{
+    const auto cfg = rocprofiler_configure(1, "", 1, &m_client_id);
+    ASSERT_EQ(m_sdk_wrapper->get_hsa_intercept_registration_info().size(), 1u);
+    EXPECT_NE(m_sdk_wrapper->get_hsa_intercept_registration_info()[0].callback, nullptr);
+    EXPECT_EQ(m_sdk_wrapper->get_hsa_intercept_registration_info()[0].user_data, cfg->tool_data);
+}
+
+TEST_F(TestRocprofilerComputeTool, HsaInterceptCallback_StartsContextAndConfiguresCountingService)
+{
+    const auto cfg = rocprofiler_configure(1, "", 1, &m_client_id);
+    ASSERT_EQ(cfg->initialize(nullptr, cfg->tool_data), 0);
+    ASSERT_EQ(m_sdk_wrapper->get_hsa_intercept_registration_info().size(), 1u);
+    const auto reg = m_sdk_wrapper->get_hsa_intercept_registration_info()[0];
+    reg.callback(ROCPROFILER_HSA_TABLE, 0, 0, nullptr, 0, reg.user_data);
+    EXPECT_EQ(m_sdk_wrapper->get_started_contexts().size(), 1u);
+    EXPECT_EQ(m_sdk_wrapper->get_dispatch_counting_service_info().size(), 1u);
 }
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
> [!NOTE]
> This PR is stacked on #6234. Before merging, change the base to `rocprofiler-compute-develop` and merge only after #6234 has landed.

## Motivation

`tool_init` runs in every `LD_PRELOAD`'d process, including shell wrappers that never use the GPU. Calling `start_context` there pulled HSA into bash; subsequent `fork()` for subshells deadlocked on inherited locked HSA mutexes, hanging any profiled workload whose entry point shells out.

## Technical Details

- Removed `configure_callback_dispatch_counting_service` and `start_context` from `tool_init`.
- Added `on_hsa_runtime_loaded` callback registered via `rocprofiler_at_intercept_table_registration(ROCPROFILER_HSA_TABLE)` in `rocprofiler_configure`; the SDK fires it only when HSA actually loads, so counter collection wires up exactly in processes that use the GPU.
- New `SdkWrapper::at_intercept_table_registration_hsa` keeps SDK calls behind the wrapper abstraction.

## JIRA ID

ROCM-21212

## Test Plan

- [x] Profile a workload launched through a shell wrapper that spawns subshells (`bash run.sh` invoking `module load`, `$(hostname)`, pipelines). Confirm no deadlock and counter output is produced.

## Test Result

- [x] Profiling completes end-to-end on the shell-wrapped workload; no deadlock, counter output produced as expected.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.