### PR TITLE
rocr: Fix blit shader wavefront size mismatch on GFX10/GFX11/GFX12

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/isa.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/isa.h
@@ -75,6 +75,12 @@ public:
   /// @brief Query value of requested @p attribute and record it in @p value.
   bool GetInfo(const hsa_wavefront_info_t &attribute, void *value) const;
 
+  /// @returns True if this wavefront is wave64, false if wave32.
+  bool IsWavefrontSize64() const {
+    assert((num_threads_ == 32 || num_threads_ == 64) && "Invalid wavefront size");
+    return num_threads_ == 64;
+  }
+
 private:
   uint32_t num_threads_;
   /// @brief Default constructor.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -436,9 +436,10 @@ void GpuAgent::AssembleShader(const char* func_name, AssembleTarget assemble_tar
     AMD_HSA_BITS_SET(header->kernel_code_properties,
                      AMD_KERNEL_CODE_PROPERTIES_ENABLE_SGPR_KERNARG_SEGMENT_PTR,
                      1);
+    // ENABLE_WAVEFRONT_SIZE32 must match the wavefront size used to compile blit shaders.
     AMD_HSA_BITS_SET(header->kernel_code_properties,
-                      AMD_KERNEL_CODE_PROPERTIES_ENABLE_WAVEFRONT_SIZE32,
-                      (isa_->GetMajorVersion() == 12 && isa_->GetMinorVersion() >= 5) ? 1 : 0);
+                     AMD_KERNEL_CODE_PROPERTIES_ENABLE_WAVEFRONT_SIZE32,
+                     isa_->GetWavefront().IsWavefrontSize64() ? 0 : 1);
     AMD_HSA_BITS_SET(header->compute_pgm_rsrc1,
                      AMD_COMPUTE_PGM_RSRC_ONE_GRANULATED_WAVEFRONT_SGPR_COUNT,
                      gran_sgprs);


### PR DESCRIPTION
The blit fill shader requires ENABLE_WAVEFRONT_SIZE32 to be set in the kernel code object header for GPUs with native wave32 execution (GFX10+).

Previously, this flag was only set for GFX12.5+, while wavefront_size was already correctly set to 32 for all GFX10+. This inconsistency caused the GPU to misinterpret wave lane assignments, resulting in incorrect fill values being written.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
