### PR TITLE
clr: Fix stream capture invalidated state reset

### DIFF
--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -1222,7 +1222,8 @@ hipError_t hipStreamEndCapture_common(hipStream_t stream, hip::Graph** pGraph) {
     *pGraph = nullptr;
     // When capture is invalidated, graph should be deleted, otherwise it leaks
     s->ReleaseCaptureGraph();
-
+    // Reset capture state to None so the stream is usable after a failed capture
+    [[maybe_unused]] const auto err = s->EndCapture();
     return hipErrorStreamCaptureInvalidated;
   }
 

--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -1223,7 +1223,7 @@ hipError_t hipStreamEndCapture_common(hipStream_t stream, hip::Graph** pGraph) {
     // When capture is invalidated, graph should be deleted, otherwise it leaks
     s->ReleaseCaptureGraph();
     // Reset capture state to None so the stream is usable after a failed capture
-    [[maybe_unused]] const auto err = s->EndCapture();
+    (void)s->EndCapture();
     return hipErrorStreamCaptureInvalidated;
   }
 

--- a/projects/hip-tests/catch/config/configs/unit/graph.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/graph.yaml
@@ -972,6 +972,9 @@ graph:
   Unit_hipStreamEndCapture_Positive_Thread:
     <<: *level_2
     tags: [capture]
+  Unit_hipStreamEndCapture_Negative_InvalidatedStateReset:
+    <<: *level_2
+    tags: [capture]
   Unit_hipStreamEndCapture_Negative:
     <<: *level_2
     tags: [capture]

--- a/projects/hip-tests/catch/unit/graph/hipStreamEndCapture.cc
+++ b/projects/hip-tests/catch/unit/graph/hipStreamEndCapture.cc
@@ -187,6 +187,61 @@ HIP_TEST_CASE(Unit_hipStreamEndCapture_Positive_Thread) {
 }
 
 /**
+ * Test Description
+ * ------------------------
+ *    - Test to verify that after hipStreamEndCapture fails on an invalidated
+ * stream, the capture state is reset to None (not left as Invalidated), and
+ * subsequent stream operations succeed:
+ *        -# Begin capture on a stream
+ *        -# Perform an illegal hipStreamSynchronize during capture (invalidates stream)
+ *        -# Verify capture state is Invalidated
+ *        -# Call hipStreamEndCapture (expect hipErrorStreamCaptureInvalidated)
+ *        -# Verify hipGetLastError returns the error once then clears
+ *        -# Verify capture state is now None twice in a row (not still Invalidated)
+ *        -# Verify hipStreamSynchronize now succeeds (stream is no longer capturing)
+ * Test source
+ * ------------------------
+ *    - catch\unit\graph\hipStreamEndCapture.cc
+ * Test requirements
+ * ------------------------
+ *    - HIP_VERSION >= 5.2
+ */
+HIP_TEST_CASE(Unit_hipStreamEndCapture_Negative_InvalidatedStateReset) {
+  StreamGuard stream_guard(Streams::created);
+  hipStream_t stream = stream_guard.stream();
+  hipGraph_t graph{nullptr};
+  hipStreamCaptureStatus captureStatus{hipStreamCaptureStatusNone};
+
+  // Begin capture
+  HIP_CHECK(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal));
+  HIP_CHECK(hipStreamGetCaptureInfo(stream, &captureStatus, nullptr));
+  REQUIRE(captureStatus == hipStreamCaptureStatusActive);
+
+  // Illegal sync during capture — invalidates the stream
+  HIP_CHECK_ERROR(hipStreamSynchronize(stream), hipErrorStreamCaptureUnsupported);
+  HIP_CHECK(hipStreamGetCaptureInfo(stream, &captureStatus, nullptr));
+  REQUIRE(captureStatus == hipStreamCaptureStatusInvalidated);
+
+  // EndCapture on invalidated stream must fail with the appropriate error
+  HIP_CHECK_ERROR(hipStreamEndCapture(stream, &graph), hipErrorStreamCaptureInvalidated);
+  REQUIRE(graph == nullptr);
+
+  // GetLastError must return the error once, then clear it
+  REQUIRE(hipGetLastError() == hipErrorStreamCaptureInvalidated);
+  REQUIRE(hipGetLastError() == hipSuccess);
+
+  // Querying capture state twice must both return None (not Invalidated).
+  // Without the fix, the state stays Invalidated after the failed EndCapture.
+  HIP_CHECK(hipStreamGetCaptureInfo(stream, &captureStatus, nullptr));
+  REQUIRE(captureStatus == hipStreamCaptureStatusNone);
+  HIP_CHECK(hipStreamGetCaptureInfo(stream, &captureStatus, nullptr));
+  REQUIRE(captureStatus == hipStreamCaptureStatusNone);
+
+  // Stream must be usable again — sync should succeed
+  HIP_CHECK(hipStreamSynchronize(stream));
+}
+
+/**
  * End doxygen group GraphTest.
  * @}
  */


### PR DESCRIPTION
## Motivation
  hipStreamEndCapture on an invalidated stream was leaving the capture state as Invalidated instead of resetting it to None. This caused any subsequent hipStreamGetCaptureInfo call to still report Invalidated, and hipStreamSynchronize to spuriously fail with hipErrorStreamCaptureUnsupported — even though the failed capture had already been ended. CUDA resets the state to None in this case.
  
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
In hipStreamEndCapture_common (hipamd/src/hip_graph.cpp), the early-return path for an invalidated stream called only ReleaseCaptureGraph() (which deletes the in-progress graph object) but did not call EndCapture(), which is responsible for resetting captureStatus_ and all other capture state fields to their defaults. The fix adds the EndCapture() call after ReleaseCaptureGraph(). A new test Unit_hipStreamEndCapture_Negative_InvalidatedStateReset is
  added to hipStreamEndCapture.cc covering the full sequence from the standalone reproducer graph_failed_capture.cu.
<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
AIRUNTIME-2257
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
  - Run Unit_hipStreamEndCapture_Negative_InvalidatedStateReset on AMD GPU
   (gfx942)
  - Run full GraphsTest2 suite to check for regressions
  - Run graph_failed_capture.cu reproducer and verify output matches CUDA
  behavior
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
- graph_failed_capture.cu reproducer output now matches CUDA — After 
  StreamEndCapture 1/2 both show None, Sync stream after failed capture
  returns no error
  - Unit_hipStreamEndCapture_Negative_InvalidatedStateReset passes
  - No regressions in GraphsTest2
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
