### PR TITLE
RCCL: add standalone revoke_tests.json config for targeted CI runs [NOT FOR MERGE]

### DIFF
--- a/projects/rccl/tools/scripts/test_runner/configs/revoke_tests.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/revoke_tests.json
@@ -1,0 +1,237 @@
+{
+  "system_configurations": {
+    "name": "RCCL-Tests-Revoke",
+    "description": "ncclCommRevoke test config. Runs all RevokeMPITest and RevokeNonBlockingMPITest tests across 2-rank, 4-rank single-node, and 4-rank multi-node configurations."
+  },
+  "paths": {
+    "workdir": "${WORKDIR:-$PWD}",
+    "rocm_path": "${ROCM_PATH:-/opt/rocm}",
+    "mpi_path": "${MPI_PATH}"
+  },
+  "auto_detect_hosts": true,
+  "mpi_args": {
+    "mellanox": "--mca oob_tcp_if_include eth1 --mca btl_tcp_if_include eth1 --mca btl ^vader,openib --bind-to none",
+    "ainic": "--mca oob_tcp_if_include eno0 --mca btl_tcp_if_include eno0 --mca btl ^vader,openib --bind-to none",
+    "thor2": "--oversubscribe --mca plm_rsh_agent srun --mca oob_tcp_if_include eno8303 --mca btl_tcp_if_include eno8303 --mca btl ^openib --bind-to none"
+  },
+  "env_variables": {
+    "NCCL_DEBUG": "INFO"
+  },
+  "system_env_variables": {
+    "mellanox": {
+      "HSA_NO_SCRATCH_RECLAIM": "1",
+      "NCCL_SOCKET_IFNAME": "eth0,eth1",
+      "NCCL_IB_HCA": "mlx_5_5,mlx_5_7,mlx5_2,mlx_5_1,mlx_5_7",
+      "NCCL_NET_FORCE_MERGE": "mlx5_0,mlx5_1;mlx5_5,mlx5_6"
+    },
+    "ainic": {
+      "NCCL_SOCKET_IFNAME": "eno0",
+      "NCCL_IB_HCA": "rdma0,rdma1,rdma2,rdma3",
+      "NCCL_NET_FORCE_MERGE": "rdma0,rdma1;rdma2,rdma3"
+    },
+    "thor2": {
+      "NCCL_SOCKET_IFNAME": "eno8303",
+      "NCCL_IB_HCA": "bnxt_re0,bnxt_re1,bnxt_re5,bnxt_re6",
+      "NCCL_NET_FORCE_MERGE": "bnxt_re0,bnxt_re1;bnxt_re5,bnxt_re6"
+    }
+  },
+  "build_configuration": {
+    "install_flags": ["--debug", "-t", "-l", "--log-trace", "--enable-code-coverage", "--enable-mpi-tests", "--no_clean"],
+    "cmake_options": "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
+    "parallel_jobs": 64
+  },
+  "test_configurations": {
+    "default": {
+      "env_variables": {
+        "NCCL_LAUNCH_MODE": "GROUP"
+      }
+    },
+
+    "revoke_mpi_tests": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 2,
+      "num_nodes": 1,
+      "num_gpus": 2,
+      "timeout": 180,
+      "env_variables": {
+        "NCCL_DEBUG": "INFO",
+        "RCCL_MPI_LOG_ALL_RANKS": "1"
+      },
+      "tests": [
+        {
+          "name": "Revoke_NullComm_Rejected",
+          "description": "ncclCommRevoke with null handle must return ncclInvalidArgument",
+          "test_filter": "RevokeMPITest.Revoke_NullComm_Rejected"
+        },
+        {
+          "name": "Revoke_BadFlags_Rejected",
+          "description": "ncclCommRevoke with unsupported revokeFlags must return ncclInvalidArgument",
+          "test_filter": "RevokeMPITest.Revoke_BadFlags_Rejected"
+        },
+        {
+          "name": "Revoke_RejectsCollectives",
+          "description": "After revoke, collective operations must return ncclInvalidUsage on all ranks",
+          "test_filter": "RevokeMPITest.Revoke_RejectsCollectives"
+        },
+        {
+          "name": "Revoke_DoubleRevoke_Rejected",
+          "description": "Revoking the same communicator twice must be rejected with ncclInvalidArgument",
+          "test_filter": "RevokeMPITest.Revoke_DoubleRevoke_Rejected"
+        },
+        {
+          "name": "Revoke_ThenFinalize_Rejected",
+          "description": "ncclCommFinalize on a revoked communicator must be rejected with ncclInvalidUsage",
+          "test_filter": "RevokeMPITest.Revoke_ThenFinalize_Rejected"
+        },
+        {
+          "name": "Revoke_ThenDestroy_CleanLifecycle",
+          "description": "Revoke leaves the communicator safe for explicit ncclCommDestroy on every rank",
+          "test_filter": "RevokeMPITest.Revoke_ThenDestroy_CleanLifecycle"
+        },
+        {
+          "name": "Revoke_ThenSplit_ChildWorks",
+          "description": "After revoke, ncclCommSplit on the parent yields a child that runs AllReduce successfully",
+          "test_filter": "RevokeMPITest.Revoke_ThenSplit_ChildWorks"
+        },
+        {
+          "name": "InFlightCollective_Revoke_Destroy_Clean",
+          "description": "In-flight collective then revoke then ncclCommDestroy must return ncclSuccess on every rank (revoke != abort)",
+          "test_filter": "RevokeMPITest.InFlightCollective_Revoke_Destroy_Clean",
+          "timeout": 240
+        },
+        {
+          "name": "Revoke_NonBlocking_ReturnsInProgress",
+          "description": "Non-blocking revoke must return ncclSuccess or ncclInProgress and drain to ncclSuccess via ncclCommGetAsyncError; later collectives must be rejected",
+          "test_filter": "RevokeNonBlockingMPITest.Revoke_NonBlocking_ReturnsInProgress"
+        },
+        {
+          "name": "Revoke_NonBlocking_AbortedMidFlight",
+          "description": "ncclCommAbort issued mid-flight on a non-blocking revoke must wind down the async-job worker via its abortFlag and return without hanging",
+          "test_filter": "RevokeNonBlockingMPITest.Revoke_NonBlocking_AbortedMidFlight"
+        }
+      ]
+    },
+
+    "revoke_mpi_tests_4rank": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 4,
+      "num_nodes": 1,
+      "num_gpus": 4,
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_DEBUG": "INFO",
+        "RCCL_MPI_LOG_ALL_RANKS": "1"
+      },
+      "tests": [
+        {
+          "name": "RevokeThenShrink_ChildWorks",
+          "description": "After revoke, ncclCommShrink on the parent excludes the last rank and the 3-rank child runs AllReduce successfully",
+          "test_filter": "RevokeMPITest.RevokeThenShrink_ChildWorks"
+        },
+        {
+          "name": "Collective_Revoke_Shrink_Collective",
+          "description": "In-flight AllReduce followed by revoke, shrink to a 3-rank child, and a second AllReduce on the child (real ring topology)",
+          "test_filter": "RevokeMPITest.Collective_Revoke_Shrink_Collective"
+        },
+        {
+          "name": "P2P_Revoke_Shrink_P2P",
+          "description": "In-flight P2P send/recv pairs, revoke parent, shrink to a 3-rank child, and exchange P2P on the child (at least one rank pair active)",
+          "test_filter": "RevokeMPITest.P2P_Revoke_Shrink_P2P"
+        },
+        {
+          "name": "IncompleteCollective_Revoke_Shrink_Collective",
+          "description": "Rank np-1 skips AllReduce so the collective is truly in-flight when revoke fires; verifies device-side abortFlag path and recovery via shrink",
+          "test_filter": "RevokeMPITest.IncompleteCollective_Revoke_Shrink_Collective"
+        },
+        {
+          "name": "ShrinkAbort_InFlight_ChildWorks_RankRenumbering",
+          "description": "ncclCommShrink with NCCL_SHRINK_ABORT terminates in-flight collective and the child reports correct renumbered rank/size and runs AllReduce",
+          "test_filter": "RevokeMPITest.ShrinkAbort_InFlight_ChildWorks_RankRenumbering"
+        },
+        {
+          "name": "Revoke_NonBlocking_ThenShrink_NoRace",
+          "description": "Race commRevokeAsync worker thread against an immediate ncclCommShrink on the same parent across 10 iterations; shrink must succeed",
+          "test_filter": "RevokeNonBlockingMPITest.Revoke_NonBlocking_ThenShrink_NoRace",
+          "timeout": 300
+        }
+      ]
+    },
+
+    "revoke_mpi_tests_multinode": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 4,
+      "num_nodes": 2,
+      "num_gpus": 2,
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_DEBUG": "INFO",
+        "RCCL_MPI_LOG_ALL_RANKS": "1"
+      },
+      "tests": [
+        {
+          "name": "InFlightCollective_Revoke_Destroy_Clean",
+          "description": "In-flight collective then revoke then ncclCommDestroy must return ncclSuccess on every rank (revoke != abort); over IB transport verifies QP cleanup with network buffers in flight",
+          "test_filter": "RevokeMPITest.InFlightCollective_Revoke_Destroy_Clean",
+          "timeout": 240
+        },
+        {
+          "name": "Collective_Revoke_Shrink_Collective",
+          "description": "In-flight AllReduce followed by revoke, shrink to a 3-rank child, and a second AllReduce on the child; over IB transport verifies network buffer teardown and rebuild",
+          "test_filter": "RevokeMPITest.Collective_Revoke_Shrink_Collective"
+        },
+        {
+          "name": "P2P_Revoke_Shrink_P2P",
+          "description": "In-flight P2P send/recv pairs, revoke parent, shrink to a 3-rank child, and exchange P2P on the child; over IB transport tests different teardown path than SHM/P2P",
+          "test_filter": "RevokeMPITest.P2P_Revoke_Shrink_P2P"
+        },
+        {
+          "name": "IncompleteCollective_Revoke_Shrink_Collective",
+          "description": "Rank np-1 skips AllReduce so the collective is truly in-flight when revoke fires; over IB the device-side abortFlag must interrupt a network wait",
+          "test_filter": "RevokeMPITest.IncompleteCollective_Revoke_Shrink_Collective"
+        },
+        {
+          "name": "Revoke_NonBlocking_ThenShrink_NoRace",
+          "description": "Race commRevokeAsync worker thread against an immediate ncclCommShrink on the same parent across 10 iterations over IB transport; shrink must succeed",
+          "test_filter": "RevokeNonBlockingMPITest.Revoke_NonBlocking_ThenShrink_NoRace",
+          "timeout": 300
+        },
+        {
+          "name": "Collective_Revoke_AsymmetricShrink_Collective",
+          "description": "Asymmetric shrink across nodes (unequal per-node GPU counts) forces ring-only topology after revoke; AllReduce must succeed on the child",
+          "test_filter": "RevokeMPITest.Collective_Revoke_AsymmetricShrink_Collective"
+        },
+        {
+          "name": "RepeatedRevokeShrinkCycles_ResourceCleanup",
+          "description": "Revoke parent then shrink then collective then revoke child then destroy across multiple generations; verifies no leaked resources",
+          "test_filter": "RevokeMPITest.RepeatedRevokeShrinkCycles_ResourceCleanup"
+        }
+      ]
+    }
+  },
+  "test_suites": [
+    {
+      "name": "Revoke MPI Tests (2-rank)",
+      "description": "ncclCommRevoke blocking and non-blocking coverage at 2 ranks on a single node: argument validation, lifecycle (revoke -> destroy/finalize/split), in-flight collective recovery, and async-job worker thread behavior",
+      "config": "revoke_mpi_tests",
+      "enabled": true
+    },
+    {
+      "name": "Revoke MPI Tests (4-rank, single-node)",
+      "description": "ncclCommRevoke scenarios requiring 4 ranks on one node: truly in-flight collective recovery via shrink (device-side abortFlag path), NCCL_SHRINK_ABORT child rank renumbering, and non-blocking revoke/shrink race coverage",
+      "config": "revoke_mpi_tests_4rank",
+      "enabled": true
+    },
+    {
+      "name": "Revoke MPI Tests - Multi-Node (4-rank, 2-node)",
+      "description": "ncclCommRevoke multi-node scenarios over IB transport: in-flight collective/P2P teardown, asymmetric shrink across nodes (ring-only topology after revoke), non-blocking revoke/shrink race, and repeated revoke/shrink generations to verify no leaked resources",
+      "config": "revoke_mpi_tests_multinode",
+      "enabled": true
+    }
+  ]
+}


### PR DESCRIPTION
## Motivation

Add a standalone test runner config for revoke tests, similar to `net_ib_transport.json`. This allows running only revoke tests without the full `mi300x_mellanox_ib.json` pipeline (which takes ~4.5h with debug build + code coverage).

## Technical Details

New config file: `projects/rccl/tools/scripts/test_runner/configs/revoke_tests.json`

Includes all 23 revoke tests across 3 suites:

1. **revoke_mpi_tests** (2-rank, 1 node) — 10 tests
   - Argument validation, lifecycle, in-flight collective recovery, non-blocking revoke

2. **revoke_mpi_tests_4rank** (4-rank, 1 node) — 6 tests
   - Shrink scenarios, rank renumbering, non-blocking revoke/shrink race

3. **revoke_mpi_tests_multinode** (4-rank, 2 nodes) — 7 tests
   - IB transport teardown/rebuild, asymmetric cross-node shrink, resource cleanup

Usage:
```bash
python test_runner.py --config configs/revoke_tests.json --no-build
```

## JIRA ID

AICOMNET-224

## Test Plan

- Run `revoke_tests.json` via test_runner on MI300X nodes to confirm all 23 tests execute and pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.