### PR TITLE
rocjitsu: improve DBT diagnostics and translation debugging

### DIFF
--- a/emulation/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/CMakeLists.txt
@@ -8,6 +8,10 @@ include(rj_default_compiler)
 
 project(rocm_jit_suite)
 
+# Generate compile_commands.json for clangd, clang-tidy, and other tooling that
+# needs the exact compiler invocations from the configured build tree.
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # Default install prefix to /opt/rocm, matching other ROCm projects.
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     if(DEFINED ENV{ROCM_PATH})
@@ -204,6 +208,9 @@ target_link_libraries(
 )
 target_include_directories(rocjitsu_shared PRIVATE ${GENERATED_DIR})
 add_dependencies(rocjitsu_shared flatbuffers_schemas)
+
+# Developer and test workflow tools.
+add_subdirectory(tools)
 
 # Tests and scaling tools.
 if(BUILD_TESTING)

--- a/emulation/rocjitsu/docs/rj_dbt_translate.md
+++ b/emulation/rocjitsu/docs/rj_dbt_translate.md
@@ -39,9 +39,7 @@ Options:
 - `--list-code-objects`: list extractable code objects and exit.
 - `--help`: print command-line help.
 
-Supported target names are `gfx908`, `gfx90a`, `gfx940`, `gfx941`, `gfx942`,
-`gfx950`, `gfx1010`, `gfx1030`, `gfx1100`, `gfx1150`, `gfx1200`, and
-`gfx1201`.
+Supported target names are `gfx942`, `gfx950`, `gfx1200`, and `gfx1201`.
 
 ## Output
 

--- a/emulation/rocjitsu/docs/rj_dbt_translate.md
+++ b/emulation/rocjitsu/docs/rj_dbt_translate.md
@@ -1,0 +1,117 @@
+# rj_dbt_translate
+
+`rj_dbt_translate` inspects or translates an AMDGPU code object with the DBT
+pipeline. It accepts either a standalone AMDGPU code object or a host object
+containing bundled AMDGPU code objects.
+
+This tool is mostly meant as a debugging tool for DBT developers and agents.
+Start with `--output-mode diff` when investigating translation behavior; it
+shows what changed without requiring you to compare full disassemblies by hand.
+
+## Usage
+
+```text
+rj_dbt_translate INPUT --input-target TARGET --output-target TARGET [options]
+```
+
+Required arguments:
+
+- `INPUT`: input file path. For host objects, the tool extracts an embedded
+  AMDGPU code object for the selected input target.
+- `--input-target TARGET`: input LLVM machine name, such as `gfx950`.
+- `--output-target TARGET`: output LLVM machine name, such as `gfx1200`.
+
+Options:
+
+- `--code-object-index N`: code-object index for executable inputs. Defaults to
+  `0`.
+- `--output-mode MODE`: output format. `disasm` prints translated
+  disassembly, `code-object` writes the translated code-object bytes, and
+  `diff` prints a compact source-to-target translation report. Defaults to
+  `disasm`.
+- `--debug-conservative-liveness N`: leave liveness dataflow unchanged, but make
+  VGPR scratch allocation skip every register below `N`. Pass the
+  descriptor-declared ordinary VGPR count when checking whether a semantic
+  lowering clobbers guest VGPRs.
+- `--debug-continue-after-failure`: keep scanning instructions after recoverable
+  translation failures so one run can report multiple diagnostics. The output
+  code object is still left unchanged when any error diagnostic is emitted.
+- `--list-code-objects`: list extractable code objects and exit.
+- `--help`: print command-line help.
+
+Supported target names are `gfx908`, `gfx90a`, `gfx940`, `gfx941`, `gfx942`,
+`gfx950`, `gfx1010`, `gfx1030`, `gfx1100`, `gfx1150`, `gfx1200`, and
+`gfx1201`.
+
+## Output
+
+All selected output is written to stdout. Use shell redirection when a file is
+needed:
+
+```sh
+rj_dbt_translate vector_add.o --input-target gfx950 --output-target gfx1200 \
+  --output-mode code-object > vector_add.gfx1200.co
+```
+
+Structured translation diagnostics and validation errors are written to stderr.
+Error diagnostics make the command fail.
+
+## Diff Mode
+
+`diff` mode is the primary debugging mode. It prints a compact translation
+report with enough context to answer the usual DBT questions:
+
+- Did the instruction change, lower, expand, or get copied unchanged?
+- Which source words produced the change?
+- Which target words did the translator emit?
+- Did expanded code stay in `.text`, or move into `.rj_translations`?
+- Did source or translated decode validation fail?
+
+Run it with:
+
+```sh
+rj_dbt_translate vector_add.o --input-target gfx950 --output-target gfx1200 \
+  --output-mode diff
+```
+
+The report starts with source and translated code-object summaries, then lists
+the shown instruction translations. Identity translations are omitted unless
+their words changed or they were emitted through the code cave, so the report
+stays focused on places worth inspecting.
+
+Each shown translation uses this order:
+
+```text
+source_words: bf8cc07f
+source: s_waitcnt vmcnt(63) expcnt(7) lgkmcnt(0)
+target_words: bfc900f0 bfc70000
+target: s_wait_storecnt_dscnt 240
+target: s_wait_kmcnt 0
+```
+
+Read `source_words` and `target_words` as the exact machine words, not as a
+re-encoding of the printed assembly. This is useful when checking literal
+operands, opcode substitution, wait-counter lowering, and instruction-size
+changes. Multiple `target:` lines mean one source instruction lowered to a
+target instruction sequence.
+
+## Examples
+
+Print translated disassembly:
+
+```sh
+rj_dbt_translate vector_add.o --input-target gfx950 --output-target gfx1200
+```
+
+Print a compact translation diff:
+
+```sh
+rj_dbt_translate vector_add.o --input-target gfx950 --output-target gfx1200 \
+  --output-mode diff
+```
+
+List bundled code objects in an executable input:
+
+```sh
+rj_dbt_translate vector_add.o --list-code-objects
+```

--- a/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/code/rj_code.h
+++ b/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/code/rj_code.h
@@ -97,9 +97,13 @@ RJ_API_EXPORT rj_status_t rj_code_decoder_decode(rj_code_decoder_t *decoder,
 /// @brief GPU target identifiers.
 typedef enum rj_code_target_id_t {
   /// @brief gfx942 target ID (CDNA3).
-  ROCJITSU_CODE_TARGET_GFX942 = 0,
+  ROCJITSU_CODE_TARGET_GFX942,
   /// @brief gfx950 target ID (CDNA4).
-  ROCJITSU_CODE_TARGET_GFX950 = 1,
+  ROCJITSU_CODE_TARGET_GFX950,
+  /// @brief gfx1200 target ID (RDNA4).
+  ROCJITSU_CODE_TARGET_GFX1200,
+  /// @brief gfx1201 target ID (RDNA4).
+  ROCJITSU_CODE_TARGET_GFX1201,
   /// @brief Sentinel value representing an invalid target.
   ROCJITSU_CODE_TARGET_INVALID
 } rj_code_target_id_t;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/liveness.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/liveness.cpp
@@ -96,7 +96,10 @@ std::vector<const BasicBlock *> reverse_post_order(KernelBlockScope blocks) {
   return postorder;
 }
 
-LivenessAnalysis::LivenessAnalysis(KernelBlockScope blocks) { analyze(blocks); }
+LivenessAnalysis::LivenessAnalysis(KernelBlockScope blocks, LivenessAnalysisOptions options) {
+  min_free_vgpr_ = options.min_free_vgpr;
+  analyze(blocks);
+}
 
 void LivenessAnalysis::analyze(KernelBlockScope blocks) {
   liveness_.resize(blocks.size());
@@ -220,7 +223,8 @@ std::optional<uint16_t> LivenessAnalysis::find_free_run(const Instruction *inst,
     return std::nullopt;
 
   const RegisterSet &live = live_it->second;
-  for (size_t base = search_start; base + count <= REGISTER_SET_MAX_VGPRS; ++base) {
+  const size_t first_candidate = std::max<size_t>(search_start, min_free_vgpr_);
+  for (size_t base = first_candidate; base + count <= REGISTER_SET_MAX_VGPRS; ++base) {
     if (!any_live_in_range(live, RegClass::VGPR, static_cast<uint16_t>(base), count))
       return static_cast<uint16_t>(base);
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/liveness.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/analysis/liveness.h
@@ -44,6 +44,17 @@ struct BlockLiveness {
   RegisterSet kill;
 };
 
+/// @brief Optional controls for liveness construction.
+struct LivenessAnalysisOptions {
+  /// @brief Lowest VGPR index that find_free_run() may return.
+  ///
+  /// @details This is a debug-oriented allocation floor, not a dataflow fact.
+  /// The computed live-before sets remain the normal kernel liveness result,
+  /// while scratch allocation can be forced above a descriptor-declared VGPR
+  /// range to test whether semantic lowerings clobber guest registers.
+  uint16_t min_free_vgpr = 0;
+};
+
 /// @brief Reverse-post-order traversal of one kernel's implicit CFG.
 ///
 /// @details The CFG is embedded in the BasicBlock objects returned by
@@ -62,7 +73,7 @@ public:
   /// entry being translated, not every block decoded from the containing code
   /// object.
   /// @param blocks Blocks in one kernel CFG scope.
-  LivenessAnalysis(KernelBlockScope blocks);
+  LivenessAnalysis(KernelBlockScope blocks, LivenessAnalysisOptions options = {});
 
   /// @brief Block liveness by block object.
   [[nodiscard]] const BlockLiveness &block_liveness(const BasicBlock &block) const;
@@ -96,6 +107,7 @@ public:
 private:
   void analyze(KernelBlockScope blocks);
 
+  uint16_t min_free_vgpr_ = 0;
   std::vector<BlockLiveness> liveness_;
   std::unordered_map<const BasicBlock *, size_t> block_index_;
   std::unordered_map<const Instruction *, RegisterSet> live_before_;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_code_object.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_code_object.cpp
@@ -54,6 +54,10 @@ rj_code_target_id_t target_from_machine_flags(uint32_t flags) {
     return ROCJITSU_CODE_TARGET_GFX942;
   if (mach == EF_AMDGPU_MACH_AMDGCN_GFX950)
     return ROCJITSU_CODE_TARGET_GFX950;
+  if (mach == EF_AMDGPU_MACH_AMDGCN_GFX1200)
+    return ROCJITSU_CODE_TARGET_GFX1200;
+  if (mach == EF_AMDGPU_MACH_AMDGCN_GFX1201)
+    return ROCJITSU_CODE_TARGET_GFX1201;
   return ROCJITSU_CODE_TARGET_INVALID;
 }
 
@@ -62,6 +66,10 @@ rj_code_target_id_t target_from_triple(const std::string &triple) {
     return ROCJITSU_CODE_TARGET_GFX942;
   if (triple == "gfx950")
     return ROCJITSU_CODE_TARGET_GFX950;
+  if (triple == "gfx1200")
+    return ROCJITSU_CODE_TARGET_GFX1200;
+  if (triple == "gfx1201")
+    return ROCJITSU_CODE_TARGET_GFX1201;
   return ROCJITSU_CODE_TARGET_INVALID;
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -26,15 +26,16 @@
 #include <cstring>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <span>
+#include <string>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 namespace rocjitsu {
 
 namespace {
-
-constexpr uint32_t kConservativeLoweringMinimumVgprs = 128;
 
 EncodingTranslateFn select_encoding_translator(rj_code_arch_t guest, rj_code_arch_t host) {
   if (guest == ROCJITSU_CODE_ARCH_CDNA4 && host == ROCJITSU_CODE_ARCH_RDNA4)
@@ -101,6 +102,44 @@ LegalizationLookupFn select_legalization(rj_code_arch_t guest, rj_code_arch_t ho
   return true;
 }
 
+[[nodiscard]] std::vector<uint32_t> raw_words_for_inst(const Instruction &inst) {
+  const uint32_t *raw = inst.raw_encoding();
+  if (!raw)
+    return {};
+  return {raw, raw + inst.size() / sizeof(uint32_t)};
+}
+
+[[nodiscard]] bool words_changed(std::span<const uint32_t> before,
+                                 std::span<const uint32_t> after) {
+  if (before.size() != after.size())
+    return true;
+  return !std::ranges::equal(before, after);
+}
+
+void append_diagnostic(std::vector<TranslationDiagnostic> &diagnostics, DiagnosticSeverity severity,
+                       DiagnosticKind kind, std::string message,
+                       std::optional<uint64_t> guest_offset = std::nullopt,
+                       std::string mnemonic = {}, std::vector<std::string> required_work = {}) {
+  diagnostics.push_back({.severity = severity,
+                         .kind = kind,
+                         .guest_offset = guest_offset,
+                         .mnemonic = std::move(mnemonic),
+                         .message = std::move(message),
+                         .required_work = std::move(required_work)});
+}
+
+void append_error(std::vector<TranslationDiagnostic> &diagnostics, DiagnosticKind kind,
+                  std::string message, std::optional<uint64_t> guest_offset = std::nullopt,
+                  std::string mnemonic = {}, std::vector<std::string> required_work = {}) {
+  append_diagnostic(diagnostics, DiagnosticSeverity::Error, kind, std::move(message), guest_offset,
+                    std::move(mnemonic), std::move(required_work));
+}
+
+void append_diagnostics(std::vector<TranslationDiagnostic> &dst,
+                        const std::vector<TranslationDiagnostic> &src) {
+  dst.insert(dst.end(), src.begin(), src.end());
+}
+
 [[nodiscard]] std::vector<uint64_t> kernel_entry_offsets(std::span<const KdTranslation> kernels) {
   std::vector<uint64_t> offsets;
   offsets.reserve(kernels.size());
@@ -113,7 +152,7 @@ LegalizationLookupFn select_legalization(rj_code_arch_t guest, rj_code_arch_t ho
 }
 
 struct KernelTranslationScope {
-  const KdTranslation *translation = nullptr;
+  KdTranslation *translation = nullptr;
   BasicBlock *entry = nullptr;
   std::vector<BasicBlock *> blocks;
 };
@@ -151,17 +190,17 @@ reachable_kernel_blocks(const std::vector<std::unique_ptr<BasicBlock>> &blocks, 
 
 [[nodiscard]] std::vector<KernelTranslationScope>
 kernel_translation_scopes(const std::vector<std::unique_ptr<BasicBlock>> &blocks,
-                          std::span<const KdTranslation> kernels) {
+                          std::span<KdTranslation> kernels) {
   std::vector<KernelTranslationScope> scopes;
   const auto entries = kernel_entry_offsets(kernels);
   if (entries.empty())
     return scopes;
 
   std::unordered_set<uint64_t> entry_set(entries.begin(), entries.end());
-  std::vector<const KdTranslation *> ordered_kernels;
+  std::vector<KdTranslation *> ordered_kernels;
   ordered_kernels.reserve(kernels.size());
   std::unordered_set<uint64_t> seen_entries;
-  for (const KdTranslation &kernel : kernels) {
+  for (KdTranslation &kernel : kernels) {
     if (seen_entries.insert(kernel.entry_text_offset).second)
       ordered_kernels.push_back(&kernel);
   }
@@ -171,7 +210,7 @@ kernel_translation_scopes(const std::vector<std::unique_ptr<BasicBlock>> &blocks
   });
 
   scopes.reserve(ordered_kernels.size());
-  for (const KdTranslation *kernel : ordered_kernels) {
+  for (KdTranslation *kernel : ordered_kernels) {
     BasicBlock *entry = block_for_offset(blocks, kernel->entry_text_offset);
     if (entry == nullptr)
       continue;
@@ -186,66 +225,60 @@ kernel_translation_scopes(const std::vector<std::unique_ptr<BasicBlock>> &blocks
 BinaryTranslator::~BinaryTranslator() = default;
 
 BinaryTranslator::BinaryTranslator(rj_code_arch_t guest_arch, rj_code_arch_t host_arch,
-                                   uint32_t target_mach)
+                                   uint32_t target_mach, BinaryTranslatorOptions options)
     : guest_arch_(guest_arch), host_arch_(host_arch),
-      target_mach_(target_mach ? target_mach : elf_mach_for_arch(host_arch)),
+      target_mach_(target_mach ? target_mach : elf_mach_for_arch(host_arch)), options_(options),
       encoding_translate_(select_encoding_translator(guest_arch, host_arch)),
       legalization_lookup_(select_legalization(guest_arch, host_arch)),
       semantic_translator_(std::make_unique<SemanticTranslator>(guest_arch, host_arch)) {}
 
+void BinaryTranslator::set_trace_callback(TranslationTraceCallback callback) {
+  trace_callback_ = std::move(callback);
+}
+
 TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   TranslatedCodeObject result;
   result.host_arch = host_arch_;
-  warnings_ = &result.warnings;
-
-  auto leave_unchanged = [&]() {
-    const auto *image = reinterpret_cast<const uint8_t *>(obj.image_data());
-    result.elf_bytes.assign(image, image + obj.image_size());
-    warnings_ = nullptr;
-    return result;
-  };
+  diagnostics_ = &result.diagnostics;
 
   CodeObjectPatcher patcher(obj);
+  auto leave_unchanged = [&]() {
+    diagnostics_ = nullptr;
+    const auto *image = reinterpret_cast<const uint8_t *>(obj.image_data());
+    result.elf_bytes.assign(image, image + obj.image_size());
+    return result;
+  };
   auto text = patcher.text_bytes();
   if (text.empty()) {
-    result.elf_bytes = patcher.emit();
-    return result;
+    return leave_unchanged();
   }
 
   auto decoder = Decoder::create(guest_arch_);
   if (!decoder) {
-    result.warnings.push_back("unsupported guest_arch: no decoder available");
-    result.elf_bytes = patcher.emit();
-    return result;
+    append_error(result.diagnostics, DiagnosticKind::UnsupportedGuestArch,
+                 "unsupported guest_arch: no decoder available");
+    return leave_unchanged();
   }
   KernelDescriptorTranslator descriptor_translator(guest_arch_, host_arch_);
-  KernelDescriptorTranslationOptions descriptor_options;
-  // Semantic lowerings allocate temporary VGPRs from liveness. Descriptor
-  // translation runs before those choices are known, so keep the historical
-  // 128-VGPR headroom for now.
-  // TODO: Have lowerings report their actual highest temporary VGPR demand and
-  // use that instead of this conservative floor.
-  descriptor_options.minimum_vgprs = kConservativeLoweringMinimumVgprs;
-  const auto descriptor_translations = descriptor_translator.translate_image(
-      patcher.image_bytes(), patcher.text_offset(), patcher.text_size(), descriptor_options);
+  auto descriptor_translations = descriptor_translator.translate_image(
+      patcher.image_bytes(), patcher.text_offset(), patcher.text_size(),
+      KernelDescriptorTranslationOptions{});
   bool descriptors_supported = true;
   for (const auto &translation : descriptor_translations) {
-    result.warnings.insert(result.warnings.end(), translation.warnings.begin(),
-                           translation.warnings.end());
+    append_diagnostics(result.diagnostics, translation.diagnostics);
     descriptors_supported &= translation.supported;
   }
   if (!descriptors_supported) {
-    result.warnings.push_back("kernel descriptor translation requires unsupported resource or ABI "
-                              "virtualization; leaving code object unchanged");
-    result.elf_bytes = patcher.emit();
-    warnings_ = nullptr;
-    return result;
+    append_error(result.diagnostics, DiagnosticKind::KernelDescriptor,
+                 "kernel descriptor translation requires unsupported resource or ABI "
+                 "virtualization; leaving code object unchanged");
+    return leave_unchanged();
   }
 
   if (descriptor_translations.empty()) {
-    result.warnings.push_back("kernel descriptors are required for kernel-level translation");
-    warnings_ = nullptr;
-    return result;
+    append_error(result.diagnostics, DiagnosticKind::KernelDescriptor,
+                 "kernel descriptors are required for kernel-level translation");
+    return leave_unchanged();
   }
 
   const auto entry_offsets = kernel_entry_offsets(descriptor_translations);
@@ -253,13 +286,41 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   auto scopes = kernel_translation_scopes(blocks, descriptor_translations);
 
   if (scopes.size() != entry_offsets.size()) {
-    result.warnings.push_back(
-        "kernel descriptor entry offsets are required to map to decoded text blocks");
-    warnings_ = nullptr;
-    return result;
+    append_error(result.diagnostics, DiagnosticKind::KernelDescriptor,
+                 "kernel descriptor entry offsets are required to map to decoded text blocks");
+    return leave_unchanged();
   }
 
   std::vector<uint8_t> translated_text(text.begin(), text.end());
+  const bool continue_after_failure = options_.debug_continue_after_failure;
+
+  auto copy_original_instruction = [&](const Instruction &inst, uint64_t offset) {
+    const uint32_t inst_size = inst.size();
+    std::memcpy(translated_text.data() + offset, text.data() + offset, inst_size);
+    if (!trace_callback_)
+      return;
+
+    // Continued-failure mode is diagnostic-only. Emit an explicit copy event so
+    // diff reports make it clear which failed source instruction was preserved.
+    const auto source_words = raw_words_for_inst(inst);
+    trace_callback_({.source_offset = offset,
+                     .source_size = inst_size,
+                     .source_words = source_words,
+                     .legalization = nullptr,
+                     .copied_original = true,
+                     .semantic_lowering = false,
+                     .changed = false,
+                     .emitted_in_cave = false,
+                     .target_offset = offset,
+                     .target_words = source_words});
+  };
+
+  auto continue_after_instruction_error = [&](const Instruction &inst, uint64_t offset) {
+    if (!continue_after_failure)
+      return false;
+    copy_original_instruction(inst, offset);
+    return true;
+  };
 
   // Code caves live in a separate executable section that is placed immediately
   // after the original .text bytes. Treating that section as a .text-relative
@@ -268,24 +329,28 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   patcher.set_cave_start(text.size());
 
   std::unordered_set<const BasicBlock *> translated_blocks;
-  bool warned_shared_blocks = false;
   for (const KernelTranslationScope &scope : scopes) {
     if (scope.blocks.empty())
       continue;
 
-    LivenessAnalysis liveness(KernelBlockScope(scope.blocks));
+    TranslationContext kernel_context(
+        scope.translation->target_vgpr_count, scope.translation->target_agpr_count,
+        scope.translation->target_accvgpr_base, scope.translation->target_sgpr_count);
+    LivenessAnalysisOptions liveness_options;
+    if (options_.debug_min_free_vgpr)
+      liveness_options.min_free_vgpr = *options_.debug_min_free_vgpr;
+    LivenessAnalysis liveness(KernelBlockScope(scope.blocks), liveness_options);
 
     for (BasicBlock *block : scope.blocks) {
       if (block == nullptr)
         continue;
       if (!translated_blocks.insert(block).second) {
-        if (!warned_shared_blocks) {
-          result.warnings.push_back(
-              "basic block is reachable from multiple kernel entries; using first kernel "
-              "liveness for shared code");
-          warned_shared_blocks = true;
-        }
-        continue;
+        append_error(result.diagnostics, DiagnosticKind::Legalization,
+                     "basic block is reachable from multiple kernel entries; shared kernel text "
+                     "translation is not implemented");
+        if (continue_after_failure)
+          continue;
+        return leave_unchanged();
       }
 
       uint64_t offset = block->start_offset();
@@ -296,6 +361,18 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
         const uint32_t *raw = inst.raw_encoding();
         if (!raw) {
           std::memcpy(translated_text.data() + offset, text.data() + offset, inst_size);
+          if (trace_callback_) {
+            trace_callback_({.source_offset = offset,
+                             .source_size = inst_size,
+                             .source_words = {},
+                             .legalization = nullptr,
+                             .copied_original = true,
+                             .semantic_lowering = false,
+                             .changed = false,
+                             .emitted_in_cave = false,
+                             .target_offset = offset,
+                             .target_words = {}});
+          }
           offset += inst_size;
           continue;
         }
@@ -306,43 +383,146 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
 
         const uint16_t dst_opcode = leg ? leg->target_opcode : inst.opcode();
 
-        // Try semantic lowering for Expand and Lower actions.
-        // For Expand: must lower (NOP-fill if unhandled).
-        // For Lower: try lowering first, fall through to encoding if unhandled.
+        // Try semantic lowering before raw encoding translation. A matched
+        // semantic rule that cannot safely emit code is a translation error:
+        // falling through would silently preserve guest semantics on the wrong
+        // host ISA.
         {
-          auto expansion = semantic_translator_->try_lower_expand(inst, offset, liveness);
-          if (!expansion.empty()) {
-            SemanticReplacement repl{offset, offset + inst_size, std::move(expansion)};
-            if (!apply_semantic(repl, translated_text, patcher))
+          auto expansion =
+              semantic_translator_->try_lower_expand(inst, offset, liveness, kernel_context);
+          if (expansion.status == ExpandStatus::Failed) {
+            append_error(result.diagnostics, DiagnosticKind::ExpandFailed,
+                         expansion.message.empty()
+                             ? "semantic EXPAND rule matched, but could not safely lower"
+                             : expansion.message,
+                         offset, std::string(inst.mnemonic()), std::move(expansion.required_work));
+            if (continue_after_instruction_error(inst, offset)) {
+              offset += inst_size;
+              continue;
+            }
+            return leave_unchanged();
+          }
+
+          if (expansion.status == ExpandStatus::Success) {
+            const bool emitted_in_cave = expansion.words.size() * sizeof(uint32_t) > inst_size;
+            const uint64_t target_offset =
+                emitted_in_cave ? patcher.cave_start() + patcher.cave_body_size() : offset;
+            SemanticReplacement repl{offset, offset + inst_size, std::move(expansion.words)};
+            if (!apply_semantic(repl, translated_text, patcher)) {
+              if (continue_after_instruction_error(inst, offset)) {
+                offset += inst_size;
+                continue;
+              }
               return leave_unchanged();
+            }
+            if (trace_callback_) {
+              const auto source_words = raw_words_for_inst(inst);
+              trace_callback_({.source_offset = offset,
+                               .source_size = inst_size,
+                               .source_words = source_words,
+                               .legalization = leg,
+                               .copied_original = false,
+                               .semantic_lowering = true,
+                               .changed = true,
+                               .emitted_in_cave = emitted_in_cave,
+                               .target_offset = target_offset,
+                               .target_words = repl.target_words});
+            }
             offset += inst_size;
             continue;
           }
         }
 
         if (leg && leg->action == Action::Expand) {
-          result.warnings.push_back("EXPAND not yet implemented for " +
-                                    std::string(inst.mnemonic()));
-          const uint32_t nop = build_s_nop(0, host_arch_);
-          for (uint32_t i = 0; i < inst_size; i += 4)
-            std::memcpy(translated_text.data() + offset + i, &nop, 4);
-          offset += inst_size;
-          continue;
+          append_error(result.diagnostics, DiagnosticKind::ExpandMissing,
+                       "legalization requires EXPAND, but no expansion rule is implemented", offset,
+                       std::string(inst.mnemonic()),
+                       {"Add a semantic expansion rule for this mnemonic."});
+          if (continue_after_instruction_error(inst, offset)) {
+            offset += inst_size;
+            continue;
+          }
+          return leave_unchanged();
         }
 
-        if (!handle_encoding(inst, offset, translated_text, dst_opcode, patcher, text))
+        if (!handle_encoding(inst, offset, translated_text, dst_opcode, patcher, text, leg)) {
+          if (continue_after_instruction_error(inst, offset)) {
+            offset += inst_size;
+            continue;
+          }
           return leave_unchanged();
+        }
         offset += inst_size;
       }
     }
+
+    if (continue_after_failure && has_error_diagnostic(result.diagnostics))
+      continue;
+
+    if (kernel_context.required_vgpr_count > kernel_context.num_vgprs)
+      scope.translation->target_vgpr_count = kernel_context.required_vgpr_count;
+    if (kernel_context.required_sgpr_count > kernel_context.num_sgprs)
+      scope.translation->target_sgpr_count = kernel_context.required_sgpr_count;
+
+    if (scope.translation->target_vgpr_count != kernel_context.num_vgprs ||
+        scope.translation->target_sgpr_count != kernel_context.num_sgprs) {
+      // Semantic rules may allocate descriptor-backed scratch registers beyond
+      // the kernel's original SGPR/VGPR counts. Recompute the descriptor with
+      // those larger minimums before patching it into the output image.
+      KernelDescriptorTranslationOptions descriptor_options;
+      descriptor_options.minimum_vgprs = scope.translation->target_vgpr_count;
+      descriptor_options.minimum_sgprs = scope.translation->target_sgpr_count;
+
+      // Descriptor growth is intentionally done after instruction lowering so each
+      // kernel is translated once. The descriptor translator keeps ordinary
+      // VGPR count and CDNA AccVGPR allocation windows separate, so an ordinary
+      // VGPR growth request can move ACCUM_OFFSET without pretending AGPRs are
+      // part of target_vgpr_count.
+      const auto final_translations = descriptor_translator.translate_image(
+          patcher.image_bytes(), patcher.text_offset(), patcher.text_size(), descriptor_options);
+      const auto final_translation =
+          std::ranges::find_if(final_translations, [&](const KdTranslation &candidate) {
+            return candidate.descriptor_file_offset == scope.translation->descriptor_file_offset;
+          });
+      if (final_translation == final_translations.end()) {
+        append_error(result.diagnostics, DiagnosticKind::KernelDescriptor,
+                     "kernel descriptor translation could not be recomputed; leaving code object "
+                     "unchanged");
+        return leave_unchanged();
+      }
+
+      append_diagnostics(result.diagnostics, final_translation->diagnostics);
+      if (!final_translation->supported) {
+        append_error(result.diagnostics, DiagnosticKind::KernelDescriptor,
+                     "kernel descriptor translation requires unsupported resource or ABI "
+                     "virtualization; leaving code object unchanged");
+        return leave_unchanged();
+      }
+
+      for (KdTranslation &translation : descriptor_translations) {
+        if (translation.entry_text_offset != scope.translation->entry_text_offset)
+          continue;
+
+        const auto updated =
+            std::ranges::find_if(final_translations, [&](const KdTranslation &candidate) {
+              return candidate.descriptor_file_offset == translation.descriptor_file_offset;
+            });
+        if (updated != final_translations.end())
+          translation = *updated;
+      }
+    }
   }
+
+  if (continue_after_failure && has_error_diagnostic(result.diagnostics))
+    return leave_unchanged();
 
   std::unordered_set<uint64_t> applied_descriptors;
   for (const KdTranslation &translation : descriptor_translations) {
     if (applied_descriptors.insert(translation.descriptor_file_offset).second) {
       if (!patcher.apply_kernel_descriptor_translation(translation, host_arch_)) {
-        result.warnings.push_back("kernel descriptor translation could not be applied safely; "
-                                  "leaving code object unchanged");
+        append_error(result.diagnostics, DiagnosticKind::KernelDescriptor,
+                     "kernel descriptor translation could not be applied safely; leaving code "
+                     "object unchanged");
         return leave_unchanged();
       }
     }
@@ -350,16 +530,17 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
 
   patcher.overwrite_text(translated_text);
   if (!patcher.append_cave_section()) {
-    result.warnings.push_back(
-        "code cave section could not be materialized safely; leaving code object unchanged");
+    append_error(result.diagnostics, DiagnosticKind::ResourceLimit,
+                 "code cave section could not be materialized safely; leaving code object "
+                 "unchanged");
     return leave_unchanged();
   }
 
   if (target_mach_)
     patcher.update_elf_flags(target_mach_);
 
+  diagnostics_ = nullptr;
   result.elf_bytes = patcher.emit();
-  warnings_ = nullptr;
   return result;
 }
 
@@ -386,9 +567,10 @@ bool BinaryTranslator::apply_semantic(const SemanticReplacement &repl, std::vect
   // s_branch simm16 targets (PC + 4 + simm16*4).
   int16_t fwd_dwords = 0;
   if (!compute_sopp_branch_offset(branch_pc, cave_byte_offset, fwd_dwords)) {
-    if (warnings_)
-      warnings_->push_back("code cave branch range exceeds s_branch simm16; leaving code object "
-                           "unchanged");
+    if (diagnostics_)
+      append_error(*diagnostics_, DiagnosticKind::ResourceLimit,
+                   "code cave branch range exceeds s_branch simm16; leaving code object unchanged",
+                   repl.start_offset);
     return false;
   }
 
@@ -403,9 +585,11 @@ bool BinaryTranslator::apply_semantic(const SemanticReplacement &repl, std::vect
   int16_t ret_dwords = 0;
   const uint64_t return_branch_pc = cave_byte_offset + cave_words.size() * sizeof(uint32_t);
   if (!compute_sopp_branch_offset(return_branch_pc, stub_next, ret_dwords)) {
-    if (warnings_)
-      warnings_->push_back("code cave return branch range exceeds s_branch simm16; leaving code "
-                           "object unchanged");
+    if (diagnostics_)
+      append_error(*diagnostics_, DiagnosticKind::ResourceLimit,
+                   "code cave return branch range exceeds s_branch simm16; leaving code object "
+                   "unchanged",
+                   repl.start_offset);
     return false;
   }
   cave_words.push_back(build_s_branch(ret_dwords, host_arch_));
@@ -417,11 +601,32 @@ bool BinaryTranslator::apply_semantic(const SemanticReplacement &repl, std::vect
 bool BinaryTranslator::handle_encoding(const Instruction &inst, uint64_t offset,
                                        std::vector<uint8_t> &text, uint16_t dst_opcode,
                                        CodeObjectPatcher &patcher,
-                                       std::span<const uint8_t> orig_text) {
+                                       std::span<const uint8_t> orig_text,
+                                       const InstructionLegalization *leg) {
   const uint32_t *raw = inst.raw_encoding();
   assert(raw && "handle_encoding called without raw encoding");
+  const bool tracing = static_cast<bool>(trace_callback_);
+  const auto source_words = tracing ? raw_words_for_inst(inst) : std::vector<uint32_t>{};
+
+  auto emit_trace = [&](bool copied_original, bool changed, bool emitted_in_cave,
+                        uint64_t target_offset, std::span<const uint32_t> target_words) {
+    if (!trace_callback_)
+      return;
+    trace_callback_({.source_offset = offset,
+                     .source_size = static_cast<uint32_t>(inst.size()),
+                     .source_words = source_words,
+                     .legalization = leg,
+                     .copied_original = copied_original,
+                     .semantic_lowering = false,
+                     .changed = changed,
+                     .emitted_in_cave = emitted_in_cave,
+                     .target_offset = target_offset,
+                     .target_words = target_words});
+  };
+
   if (!encoding_translate_) {
     std::memcpy(text.data() + offset, raw, inst.size());
+    emit_trace(true, false, false, offset, source_words);
     return true;
   }
 
@@ -433,6 +638,7 @@ bool BinaryTranslator::handle_encoding(const Instruction &inst, uint64_t offset,
 
   if (tr.word_count == 0) {
     std::memcpy(text.data() + offset, raw, inst.size());
+    emit_trace(true, false, false, offset, source_words);
     return true;
   }
 
@@ -452,6 +658,12 @@ bool BinaryTranslator::handle_encoding(const Instruction &inst, uint64_t offset,
   }
 
   const uint32_t target_size = tr.word_count * 4u;
+  const auto target_words = std::span<const uint32_t>(tr.words, tr.word_count);
+  const bool emitted_in_cave = target_size > orig_bytes;
+  const uint64_t target_offset =
+      emitted_in_cave ? patcher.cave_start() + patcher.cave_body_size() : offset;
+  const bool changed = tracing && words_changed(source_words, target_words);
+
   if (target_size <= orig_bytes) {
     std::memcpy(text.data() + offset, tr.words, target_size);
   } else {
@@ -459,6 +671,7 @@ bool BinaryTranslator::handle_encoding(const Instruction &inst, uint64_t offset,
     if (!apply_semantic(repl, text, patcher))
       return false;
   }
+  emit_trace(false, changed, emitted_in_cave, target_offset, target_words);
   return true;
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -473,42 +473,42 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       descriptor_options.minimum_vgprs = scope.translation->target_vgpr_count;
       descriptor_options.minimum_sgprs = scope.translation->target_sgpr_count;
 
-      // Descriptor growth is intentionally done after instruction lowering so each
-      // kernel is translated once. The descriptor translator keeps ordinary
-      // VGPR count and CDNA AccVGPR allocation windows separate, so an ordinary
-      // VGPR growth request can move ACCUM_OFFSET without pretending AGPRs are
-      // part of target_vgpr_count.
-      const auto final_translations = descriptor_translator.translate_image(
-          patcher.image_bytes(), patcher.text_offset(), patcher.text_size(), descriptor_options);
-      const auto final_translation =
-          std::ranges::find_if(final_translations, [&](const KdTranslation &candidate) {
-            return candidate.descriptor_file_offset == scope.translation->descriptor_file_offset;
-          });
-      if (final_translation == final_translations.end()) {
-        append_error(result.diagnostics, DiagnosticKind::KernelDescriptor,
-                     "kernel descriptor translation could not be recomputed; leaving code object "
-                     "unchanged");
-        return leave_unchanged();
-      }
-
-      append_diagnostics(result.diagnostics, final_translation->diagnostics);
-      if (!final_translation->supported) {
-        append_error(result.diagnostics, DiagnosticKind::KernelDescriptor,
-                     "kernel descriptor translation requires unsupported resource or ABI "
-                     "virtualization; leaving code object unchanged");
-        return leave_unchanged();
-      }
-
+      // Descriptor growth is intentionally done after instruction lowering so
+      // each kernel is translated once. Only descriptors that enter this code
+      // scope need the larger floor; rescanning the whole image would also
+      // recompute unrelated kernels and risks mixing diagnostics across scopes.
+      bool recomputed_descriptor = false;
       for (KdTranslation &translation : descriptor_translations) {
         if (translation.entry_text_offset != scope.translation->entry_text_offset)
           continue;
 
-        const auto updated =
-            std::ranges::find_if(final_translations, [&](const KdTranslation &candidate) {
-              return candidate.descriptor_file_offset == translation.descriptor_file_offset;
-            });
-        if (updated != final_translations.end())
-          translation = *updated;
+        auto updated = descriptor_translator.translate_descriptor(
+            patcher.image_bytes(), translation.descriptor_file_offset,
+            translation.entry_text_offset, descriptor_options);
+        if (!updated) {
+          append_error(result.diagnostics, DiagnosticKind::KernelDescriptor,
+                       "kernel descriptor translation could not be recomputed; leaving code object "
+                       "unchanged");
+          return leave_unchanged();
+        }
+
+        append_diagnostics(result.diagnostics, updated->diagnostics);
+        if (!updated->supported) {
+          append_error(result.diagnostics, DiagnosticKind::KernelDescriptor,
+                       "kernel descriptor translation requires unsupported resource or ABI "
+                       "virtualization; leaving code object unchanged");
+          return leave_unchanged();
+        }
+
+        translation = std::move(*updated);
+        recomputed_descriptor = true;
+      }
+
+      if (!recomputed_descriptor) {
+        append_error(result.diagnostics, DiagnosticKind::KernelDescriptor,
+                     "kernel descriptor translation could not be recomputed; leaving code object "
+                     "unchanged");
+        return leave_unchanged();
       }
     }
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.h
@@ -23,12 +23,15 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <memory>
+#include <optional>
 #include <span>
 #include <string>
 #include <vector>
 
 #include "rocjitsu/code/dbt/encoding_translator.h"
+#include "rocjitsu/code/dbt/translation_diagnostic.h"
 #include "rocjitsu/code/rj_code.h"
 
 namespace rocjitsu {
@@ -67,11 +70,56 @@ using EncodingTranslateFn = TranslationResult (*)(uint32_t encoding_id, uint32_t
 using LegalizationLookupFn = const InstructionLegalization *(*)(uint16_t encoding_id,
                                                                 uint16_t opcode);
 
+/// @brief One source instruction trace event emitted by BinaryTranslator.
+///
+/// @details Offsets are .text-relative. When emitted_in_cave is true,
+/// target_offset points into the logical .text continuation that later becomes
+/// `.rj_translations`; subtracting the original .text size gives the offset in
+/// that cave section. source_words and target_words are only valid for the
+/// duration of the callback; callers that need to retain them must copy the
+/// spans.
+struct TranslationTraceEvent {
+  uint64_t source_offset = 0;
+  uint32_t source_size = 0;
+  std::span<const uint32_t> source_words;
+  const InstructionLegalization *legalization = nullptr;
+  bool copied_original = false;
+  bool semantic_lowering = false;
+  bool changed = false;
+  bool emitted_in_cave = false;
+  uint64_t target_offset = 0;
+  std::span<const uint32_t> target_words;
+};
+
+using TranslationTraceCallback = std::function<void(const TranslationTraceEvent &)>;
+
+/// @brief Optional controls for DBT translation.
+struct BinaryTranslatorOptions {
+  /// @brief Force liveness-based VGPR scratch allocation above a debug floor.
+  ///
+  /// @details This debug mode leaves normal liveness dataflow untouched, but
+  /// makes find_free_run() skip VGPRs below this floor. It is useful when
+  /// investigating register clobbers caused by overly optimistic liveness.
+  std::optional<uint16_t> debug_min_free_vgpr;
+
+  /// @brief Keep scanning instructions after recoverable translation failures.
+  ///
+  /// @details This is a diagnostics-only mode. The translator preserves the
+  /// original instruction at each failed source location and continues so one run
+  /// can report multiple missing EXPAND rules or resource-limit failures. If any
+  /// error diagnostic is collected, the final code object is still left unchanged
+  /// because the partially translated text is only useful for finding failures,
+  /// not for execution.
+  bool debug_continue_after_failure = false;
+};
+
 /// @brief Result of translating a code object.
 struct TranslatedCodeObject {
-  std::vector<uint8_t> elf_bytes;    ///< Translated ELF for the host ISA.
-  rj_code_arch_t host_arch;          ///< Host ISA architecture.
-  std::vector<std::string> warnings; ///< Non-fatal translation issues.
+  std::vector<uint8_t> elf_bytes;                        ///< Translated ELF for the host ISA.
+  rj_code_arch_t host_arch = ROCJITSU_CODE_ARCH_INVALID; ///< Host ISA architecture.
+  std::vector<TranslationDiagnostic> diagnostics;        ///< Translation warnings/errors.
+
+  [[nodiscard]] bool ok() const { return !has_error_diagnostic(diagnostics); }
 };
 
 /// @brief Top-level dynamic binary translator.
@@ -93,12 +141,16 @@ public:
   /// @param host_arch     Target ISA architecture.
   /// @param target_mach   EF_AMDGPU_MACH value for the target GPU stepping.
   ///                      0 = auto-detect from host_arch (default GFX1200 for RDNA4).
-  BinaryTranslator(rj_code_arch_t guest_arch, rj_code_arch_t host_arch, uint32_t target_mach = 0);
+  BinaryTranslator(rj_code_arch_t guest_arch, rj_code_arch_t host_arch, uint32_t target_mach = 0,
+                   BinaryTranslatorOptions options = {});
   ~BinaryTranslator();
+
+  /// @brief Install an optional callback for per-instruction debugging.
+  void set_trace_callback(TranslationTraceCallback callback);
 
   /// @brief Translate a decoded code object.
   /// @param obj  The guest code object to translate.
-  /// @returns TranslatedCodeObject with the host ELF bytes and any warnings.
+  /// @returns TranslatedCodeObject with the host ELF bytes and diagnostics.
   [[nodiscard]] TranslatedCodeObject translate(const AmdGpuCodeObject &obj);
 
 private:
@@ -134,16 +186,18 @@ private:
   ///          the code cave.
   [[nodiscard]] bool handle_encoding(const Instruction &inst, uint64_t offset,
                                      std::vector<uint8_t> &text, uint16_t dst_opcode,
-                                     CodeObjectPatcher &patcher,
-                                     std::span<const uint8_t> orig_text);
+                                     CodeObjectPatcher &patcher, std::span<const uint8_t> orig_text,
+                                     const InstructionLegalization *leg);
 
   rj_code_arch_t guest_arch_;                               ///< Source ISA.
   rj_code_arch_t host_arch_;                                ///< Target ISA.
   uint32_t target_mach_;                                    ///< ELF MACH flag for target stepping.
+  TranslationTraceCallback trace_callback_;                 ///< Optional debug trace callback.
+  BinaryTranslatorOptions options_;                         ///< Optional translation controls.
   EncodingTranslateFn encoding_translate_;                  ///< Per-pair encoding translator.
   LegalizationLookupFn legalization_lookup_;                ///< Per-pair legalization table.
   std::unique_ptr<SemanticTranslator> semantic_translator_; ///< Per-pair semantic rule engine.
-  std::vector<std::string> *warnings_ = nullptr;            ///< Points to active result's warnings.
+  std::vector<TranslationDiagnostic> *diagnostics_ = nullptr; ///< Active result diagnostics.
 };
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.cpp
@@ -15,6 +15,7 @@
 #include "rocjitsu/isa/arch/amdgpu/rdna3_5/isa.h"
 #include "rocjitsu/isa/arch/amdgpu/rdna4/isa.h"
 #include "rocjitsu/isa/isa_traits.h"
+#include "util/bit.h"
 
 #include "rocjitsu/base/rj_compiler.h"
 RJ_DIAGNOSTIC_PUSH
@@ -418,11 +419,6 @@ void visit_kernel_descriptors(std::span<const uint8_t> image, uint64_t text_offs
   return (registers + granularity - 1) / granularity - 1;
 }
 
-[[nodiscard]] uint32_t align_up(uint32_t value, uint32_t alignment) {
-  alignment = std::max(alignment, 1u);
-  return ((value + alignment - 1) / alignment) * alignment;
-}
-
 [[nodiscard]] uint16_t accum_vgpr_base(const KD &desc, rj_code_arch_t guest_arch) {
   if (!uses_gfx90a_accum_offset(guest_arch) || !arch_has_accvgpr(guest_arch))
     return 0;
@@ -619,7 +615,7 @@ translate_one_descriptor(rj_code_arch_t guest_arch, rj_code_arch_t host_arch,
   if (arch_has_accvgpr(guest_arch) && arch_has_accvgpr(host_arch) &&
       uses_gfx90a_accum_offset(host_arch) && result.accvgpr_base != 0) {
     if (result.target_agpr_count != 0 && options.minimum_vgprs > result.accvgpr_base) {
-      result.target_accvgpr_base = align_up(options.minimum_vgprs, 4);
+      result.target_accvgpr_base = util::align_up(options.minimum_vgprs, 4u);
       if (result.target_accvgpr_base > 256) {
         append_descriptor_error(result,
                                 "required AccVGPR offset exceeds GFX90A descriptor field range; "
@@ -704,6 +700,18 @@ std::vector<KdTranslation> KernelDescriptorTranslator::translate_image(
       });
 
   return translations;
+}
+
+std::optional<KdTranslation> KernelDescriptorTranslator::translate_descriptor(
+    std::span<const uint8_t> image, uint64_t descriptor_file_offset, uint64_t entry_text_offset,
+    const KernelDescriptorTranslationOptions &options) const {
+  if (descriptor_file_offset > image.size() || image.size() - descriptor_file_offset < sizeof(KD))
+    return std::nullopt;
+
+  KD desc{};
+  std::memcpy(&desc, image.data() + descriptor_file_offset, sizeof(desc));
+  return translate_one_descriptor(guest_arch_, host_arch_, descriptor_file_offset,
+                                  entry_text_offset, desc, options);
 }
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.cpp
@@ -27,7 +27,9 @@ RJ_DIAGNOSTIC_POP
 #include <functional>
 #include <limits>
 #include <optional>
+#include <string>
 #include <unordered_set>
+#include <utility>
 
 namespace rocjitsu {
 
@@ -416,6 +418,11 @@ void visit_kernel_descriptors(std::span<const uint8_t> image, uint64_t text_offs
   return (registers + granularity - 1) / granularity - 1;
 }
 
+[[nodiscard]] uint32_t align_up(uint32_t value, uint32_t alignment) {
+  alignment = std::max(alignment, 1u);
+  return ((value + alignment - 1) / alignment) * alignment;
+}
+
 [[nodiscard]] uint16_t accum_vgpr_base(const KD &desc, rj_code_arch_t guest_arch) {
   if (!uses_gfx90a_accum_offset(guest_arch) || !arch_has_accvgpr(guest_arch))
     return 0;
@@ -509,15 +516,24 @@ build_kernel_entry_prologue(const KD &src, rj_code_arch_t guest_arch, rj_code_ar
 // Descriptor translation.
 // -----------------------------------------------------------------------------
 
-[[nodiscard]] uint32_t clamp_granulated(uint32_t value, uint32_t max_value,
-                                        std::vector<std::string> &warnings, const char *field_name,
-                                        bool &supported) {
+void append_descriptor_error(KdTranslation &result, std::string message) {
+  result.diagnostics.push_back({.severity = DiagnosticSeverity::Error,
+                                .kind = DiagnosticKind::KernelDescriptor,
+                                .guest_offset = std::nullopt,
+                                .mnemonic = {},
+                                .message = std::move(message),
+                                .required_work = {}});
+  result.supported = false;
+}
+
+[[nodiscard]] uint32_t clamp_granulated(uint32_t value, uint32_t max_value, KdTranslation &result,
+                                        const char *field_name) {
   if (value <= max_value)
     return value;
 
-  warnings.push_back(std::string(field_name) +
-                     " exceeds descriptor field width; resource virtualization is not implemented");
-  supported = false;
+  append_descriptor_error(
+      result, std::string(field_name) +
+                  " exceeds descriptor field width; resource virtualization is not implemented");
   return max_value;
 }
 
@@ -539,9 +555,9 @@ translate_one_descriptor(rj_code_arch_t guest_arch, rj_code_arch_t host_arch,
   result.target_wave_size = result.host_wavefront_size;
   result.force_wave64 = is_rdna_arch(host_arch) && result.target_wave_size == 64;
   if (result.guest_wavefront_size != result.host_wavefront_size) {
-    result.warnings.push_back("guest and host wavefront sizes differ; descriptor was translated "
-                              "but instruction-level wave-size emulation is not implemented");
-    result.supported = false;
+    append_descriptor_error(result,
+                            "guest and host wavefront sizes differ; descriptor was translated "
+                            "but instruction-level wave-size emulation is not implemented");
   }
 
   // CDNA MFMA kernels may address accumulator registers through a separate
@@ -550,6 +566,7 @@ translate_one_descriptor(rj_code_arch_t guest_arch, rj_code_arch_t host_arch,
   // The descriptor translator records the first unified VGPR index that must be
   // reserved for those remapped accumulator registers.
   result.accvgpr_base = accum_vgpr_base(src, guest_arch);
+  result.target_accvgpr_base = result.accvgpr_base;
 
   // Descriptor ABI fixes that require instructions, not bitfield changes, are
   // emitted as prologue words. CodeObjectPatcher decides where to place them and
@@ -568,28 +585,67 @@ translate_one_descriptor(rj_code_arch_t guest_arch, rj_code_arch_t host_arch,
 
   const uint32_t guest_vgpr_granulated =
       AMDHSA_BITS_GET(src.compute_pgm_rsrc1, kd::COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT);
-  result.guest_vgpr_count =
+  result.guest_vgpr_allocation_count =
       granulated_count_to_registers(guest_vgpr_granulated, guest_vgpr_granularity);
+  if (arch_has_accvgpr(guest_arch) && result.accvgpr_base != 0 &&
+      result.guest_vgpr_allocation_count > result.accvgpr_base) {
+    result.guest_agpr_count = result.guest_vgpr_allocation_count - result.accvgpr_base;
+  }
+  result.guest_vgpr_count = result.guest_vgpr_allocation_count - result.guest_agpr_count;
 
-  // Start from the guest's required VGPR allocation. Then grow it for semantic
-  // lowering requirements: AccVGPR unification needs enough unified VGPRs to
-  // cover the remapped accumulator window, and instruction lowering may request
-  // additional scratch temporaries through options.minimum_vgprs.
+  // Start from the guest's ordinary VGPR count. Keep the descriptor allocation
+  // count separate: CDNA kernels with AccVGPRs encode a unified allocation end
+  // in COMPUTE_PGM_RSRC1, but liveness and scratch allocation need the ordinary
+  // VGPR count only.
+  //
+  // - CDNA-to-RDNA unifies AccVGPRs into the ordinary VGPR namespace, so the
+  //   target needs enough VGPRs to cover the remapped accumulator window.
+  //
+  // - CDNA-to-CDNA keeps a real AccVGPR bank. On GFX90A/GFX942/GFX950 the
+  //   ACCUM_OFFSET descriptor field selects where that bank starts in the
+  //   unified register file. If a semantic lowering needs new ordinary VGPRs
+  //   at or above the original offset, merely increasing ordinary VGPRs is not enough:
+  //   those temporary VGPRs would alias a0, a1, ... at runtime. Move the
+  //   accumulator base up and preserve the original accumulator-window size.
+  //
+  // - instruction lowering may request additional scratch temporaries through
+  //   options.minimum_vgprs.
   uint32_t required_vgprs = result.guest_vgpr_count;
+  result.target_agpr_count = arch_has_accvgpr(host_arch) ? result.guest_agpr_count : 0;
+  uint32_t required_vgpr_allocation = result.guest_vgpr_allocation_count;
   if (arch_has_accvgpr(guest_arch) && !arch_has_accvgpr(host_arch) && result.accvgpr_base != 0)
-    required_vgprs = std::max(required_vgprs, result.accvgpr_base + result.guest_vgpr_count);
+    required_vgprs = std::max(required_vgprs, result.accvgpr_base + result.guest_agpr_count);
   required_vgprs = std::max(required_vgprs, options.minimum_vgprs);
+  if (arch_has_accvgpr(guest_arch) && arch_has_accvgpr(host_arch) &&
+      uses_gfx90a_accum_offset(host_arch) && result.accvgpr_base != 0) {
+    if (result.target_agpr_count != 0 && options.minimum_vgprs > result.accvgpr_base) {
+      result.target_accvgpr_base = align_up(options.minimum_vgprs, 4);
+      if (result.target_accvgpr_base > 256) {
+        append_descriptor_error(result,
+                                "required AccVGPR offset exceeds GFX90A descriptor field range; "
+                                "AccVGPR base virtualization is not implemented");
+      }
+    }
+  }
+  if (arch_has_accvgpr(host_arch) && result.target_agpr_count != 0) {
+    required_vgpr_allocation =
+        std::max(required_vgprs, result.target_accvgpr_base + result.target_agpr_count);
+  } else {
+    required_vgpr_allocation = required_vgprs;
+  }
   result.host_vgpr_count = required_vgprs;
+  result.host_vgpr_allocation_count = required_vgpr_allocation;
   result.target_vgpr_count = required_vgprs;
-  if (arch_max_vgprs(host_arch) != 0 && required_vgprs > arch_max_vgprs(host_arch)) {
-    result.warnings.push_back("required VGPR count exceeds target limit; spill tiers are not "
-                              "implemented for this descriptor");
-    result.supported = false;
+  result.target_vgpr_allocation_count = required_vgpr_allocation;
+  if (arch_max_vgprs(host_arch) != 0 && required_vgpr_allocation > arch_max_vgprs(host_arch)) {
+    append_descriptor_error(result,
+                            "required VGPR allocation exceeds target limit; spill tiers are "
+                            "not implemented for this descriptor");
   }
 
   result.target_vgpr_granulated = clamp_granulated(
-      register_count_to_granulated(required_vgprs, host_vgpr_granularity), kMaxVgprGranulatedField,
-      result.warnings, "GRANULATED_WORKITEM_VGPR_COUNT", result.supported);
+      register_count_to_granulated(required_vgpr_allocation, host_vgpr_granularity),
+      kMaxVgprGranulatedField, result, "GRANULATED_WORKITEM_VGPR_COUNT");
 
   // SGPR counts are also stored as a granulated value, but the descriptor
   // granularity is fixed at eight SGPRs for the architectures handled here.
@@ -602,16 +658,15 @@ translate_one_descriptor(rj_code_arch_t guest_arch, rj_code_arch_t host_arch,
   result.host_sgpr_count = std::max(result.guest_sgpr_count, options.minimum_sgprs);
   result.target_sgpr_count = result.host_sgpr_count;
   if (arch_max_sgprs(host_arch) != 0 && result.host_sgpr_count > arch_max_sgprs(host_arch)) {
-    result.warnings.push_back("required SGPR count exceeds target limit; spill tiers are not "
-                              "implemented for this descriptor");
-    result.supported = false;
+    append_descriptor_error(result, "required SGPR count exceeds target limit; spill tiers are not "
+                                    "implemented for this descriptor");
   }
 
   if (!uses_gfx10_plus_rsrc3(host_arch)) {
     result.target_sgpr_granulated = register_count_to_granulated(result.host_sgpr_count, 8);
     result.target_sgpr_granulated =
-        clamp_granulated(result.target_sgpr_granulated, kMaxSgprGranulatedField, result.warnings,
-                         "GRANULATED_WAVEFRONT_SGPR_COUNT", result.supported);
+        clamp_granulated(result.target_sgpr_granulated, kMaxSgprGranulatedField, result,
+                         "GRANULATED_WAVEFRONT_SGPR_COUNT");
   }
 
   // LDS/private sizes are copied from the source descriptor and extended by

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.h
@@ -10,6 +10,7 @@
 #include "rocjitsu/code/rj_code.h"
 
 #include <cstdint>
+#include <optional>
 #include <span>
 #include <vector>
 
@@ -33,17 +34,41 @@ struct KdTranslation {
   uint64_t descriptor_file_offset = 0;
   uint64_t entry_text_offset = 0;
 
-  /// Ordinary architectural VGPRs required by translated code.
+  /// @brief Ordinary architectural VGPRs required by translated code.
+  ///
+  /// @details This excludes any target AccVGPR window. Liveness analysis,
+  /// semantic scratch allocation, and descriptor growth requests should use
+  /// this field when they mean normal v0..vN VGPR demand.
   uint32_t target_vgpr_count = 0;
-  /// Descriptor allocation end encoded in COMPUTE_PGM_RSRC1.  On CDNA kernels
-  /// with AccVGPRs this may be larger than target_vgpr_count because it also
-  /// reserves the AccVGPR window selected by ACCUM_OFFSET.
+
+  /// @brief Unified VGPR allocation encoded in COMPUTE_PGM_RSRC1.
+  ///
+  /// @details On targets with AccVGPRs this may be larger than
+  /// @c target_vgpr_count because the descriptor allocation must cover both
+  /// ordinary VGPRs and the AccVGPR window selected by ACCUM_OFFSET. Use this
+  /// field only for descriptor encoding/resource-limit checks, not ordinary
+  /// VGPR liveness.
   uint32_t target_vgpr_allocation_count = 0;
+
+  /// @brief Encoded target COMPUTE_PGM_RSRC1.GRANULATED_WORKITEM_VGPR_COUNT.
   uint32_t target_vgpr_granulated = 0;
+
+  /// @brief First unified VGPR index reserved for target AccVGPRs.
+  ///
+  /// @details For CDNA-to-CDNA translations semantic scratch may force this
+  /// base upward so ordinary temporary VGPRs do not alias a0, a1, ...
   uint32_t target_accvgpr_base = 0;
+
+  /// @brief Guest AccVGPR base decoded from the source descriptor.
   uint32_t accvgpr_base = 0;
+
+  /// @brief Number of target AccVGPRs preserved as a real AccVGPR window.
   uint32_t target_agpr_count = 0;
+
+  /// @brief Future spill tier: number of VGPRs to virtualize through LDS.
   uint32_t vgpr_spill_to_lds_count = 0;
+
+  /// @brief Future spill tier: number of VGPRs to virtualize through scratch memory.
   uint32_t vgpr_spill_to_scratch_count = 0;
 
   uint32_t target_sgpr_count = 0;
@@ -71,12 +96,36 @@ struct KdTranslation {
   uint8_t guest_wavefront_size = 64;
   uint8_t host_wavefront_size = 64;
 
+  /// @brief Ordinary guest VGPR count decoded from the source descriptor.
+  ///
+  /// @details This excludes any source AccVGPR window. It is the right source
+  /// floor for ordinary VGPR liveness and scratch reasoning.
   uint32_t guest_vgpr_count = 0;
+
+  /// @brief Source descriptor's unified VGPR allocation count.
+  ///
+  /// @details This is decoded from COMPUTE_PGM_RSRC1 and may include the
+  /// AccVGPR window on CDNA descriptors. Use it when preserving or re-encoding
+  /// descriptor allocation size, not when asking how many ordinary VGPRs the
+  /// guest program used.
   uint32_t guest_vgpr_allocation_count = 0;
+
+  /// @brief Source AccVGPR count derived from allocation count and ACCUM_OFFSET.
   uint32_t guest_agpr_count = 0;
+
+  /// @brief Ordinary host VGPR count after translation requirements are applied.
   uint32_t host_vgpr_count = 0;
+
+  /// @brief Host descriptor's unified VGPR allocation count.
+  ///
+  /// @details Mirrors @c target_vgpr_allocation_count for diagnostics/reporting
+  /// and includes any preserved target AccVGPR window.
   uint32_t host_vgpr_allocation_count = 0;
+
+  /// @brief Ordinary guest SGPR count decoded from the source descriptor.
   uint32_t guest_sgpr_count = 0;
+
+  /// @brief Ordinary host SGPR count after translation requirements are applied.
   uint32_t host_sgpr_count = 0;
 
   uint32_t source_occupancy = 0;
@@ -94,6 +143,19 @@ public:
   [[nodiscard]] std::vector<KdTranslation>
   translate_image(std::span<const uint8_t> image, uint64_t text_offset, uint64_t text_size,
                   const KernelDescriptorTranslationOptions &options) const;
+
+  /// @brief Recompute one already-discovered kernel descriptor.
+  ///
+  /// @details BinaryTranslator uses this after instruction lowering discovers
+  /// additional per-kernel SGPR/VGPR requirements. The descriptor's file offset
+  /// and entry offset come from the original image-wide descriptor discovery, so
+  /// this avoids rescanning or recomputing unrelated kernel descriptors.
+  /// @returns A translated descriptor plan, or std::nullopt if @p descriptor_file_offset
+  /// does not point at a complete AMDHSA kernel descriptor in @p image.
+  [[nodiscard]] std::optional<KdTranslation>
+  translate_descriptor(std::span<const uint8_t> image, uint64_t descriptor_file_offset,
+                       uint64_t entry_text_offset,
+                       const KernelDescriptorTranslationOptions &options) const;
 
 private:
   rj_code_arch_t guest_arch_;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.h
@@ -6,11 +6,11 @@
 
 #pragma once
 
+#include "rocjitsu/code/dbt/translation_diagnostic.h"
 #include "rocjitsu/code/rj_code.h"
 
 #include <cstdint>
 #include <span>
-#include <string>
 #include <vector>
 
 namespace rocjitsu {
@@ -33,9 +33,16 @@ struct KdTranslation {
   uint64_t descriptor_file_offset = 0;
   uint64_t entry_text_offset = 0;
 
+  /// Ordinary architectural VGPRs required by translated code.
   uint32_t target_vgpr_count = 0;
+  /// Descriptor allocation end encoded in COMPUTE_PGM_RSRC1.  On CDNA kernels
+  /// with AccVGPRs this may be larger than target_vgpr_count because it also
+  /// reserves the AccVGPR window selected by ACCUM_OFFSET.
+  uint32_t target_vgpr_allocation_count = 0;
   uint32_t target_vgpr_granulated = 0;
+  uint32_t target_accvgpr_base = 0;
   uint32_t accvgpr_base = 0;
+  uint32_t target_agpr_count = 0;
   uint32_t vgpr_spill_to_lds_count = 0;
   uint32_t vgpr_spill_to_scratch_count = 0;
 
@@ -65,7 +72,10 @@ struct KdTranslation {
   uint8_t host_wavefront_size = 64;
 
   uint32_t guest_vgpr_count = 0;
+  uint32_t guest_vgpr_allocation_count = 0;
+  uint32_t guest_agpr_count = 0;
   uint32_t host_vgpr_count = 0;
+  uint32_t host_vgpr_allocation_count = 0;
   uint32_t guest_sgpr_count = 0;
   uint32_t host_sgpr_count = 0;
 
@@ -73,7 +83,7 @@ struct KdTranslation {
   uint32_t target_occupancy = 0;
 
   bool supported = true;
-  std::vector<std::string> warnings;
+  std::vector<TranslationDiagnostic> diagnostics;
 };
 
 /// @brief Compute descriptor patches and semantic metadata for one DBT pair.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/cdna4_to_rdna3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/cdna4_to_rdna3.cpp
@@ -6,9 +6,11 @@
 
 #include "rocjitsu/code/dbt/semantic/cdna4_to_rdna_common.h"
 #include "rocjitsu/code/dbt/semantic/rules.h"
+#include "rocjitsu/code/dbt/translation_rule.h"
 #include "rocjitsu/code/patch/instruction_builder.h"
 #include "rocjitsu/isa/instruction.h"
 
+#include <string>
 #include <vector>
 
 namespace rocjitsu {
@@ -26,15 +28,16 @@ constexpr uint16_t kCdna4Op_v_lshl_add_u64 = 520;
 /// @details The counter-bit layouts differ, so opcode substitution alone can
 /// create a weaker wait. Until we add precise GFX11 re-encoding, emit a
 /// conservative full-drain wait, which is slower but preserves correctness.
-std::vector<uint32_t> expand_waitcnt_gfx9_to_gfx11(const Instruction &inst, uint32_t, uint64_t,
-                                                   const LivenessAnalysis &, const LaneLayout *,
-                                                   const LaneLayout *) {
+ExpandResult expand_waitcnt_gfx9_to_gfx11(const Instruction &inst, uint32_t, uint64_t,
+                                          const LivenessAnalysis &, TranslationContext &,
+                                          const LaneLayout *, const LaneLayout *) {
   constexpr uint16_t kEncSoppValue = 0x17F;
   if (inst.encoding_id() != kEncSoppValue)
-    return {};
+    return ExpandResult::failed(std::string(inst.mnemonic()) +
+                                " matched the waitcnt expansion rule with an unexpected encoding");
 
   constexpr uint32_t kRdna3SoppOp_s_waitcnt = 9;
-  return {pack_sopp(kRdna3SoppOp_s_waitcnt, 0)};
+  return ExpandResult::success({pack_sopp(kRdna3SoppOp_s_waitcnt, 0)});
 }
 
 // Table MUST be sorted by (src_encoding_id, src_opcode) for binary search.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/cdna4_to_rdna4.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/cdna4_to_rdna4.cpp
@@ -19,6 +19,7 @@
 #include <bit>
 #include <cassert>
 #include <cstring>
+#include <string>
 #include <string_view>
 #include <utility>
 #include <vector>
@@ -134,7 +135,8 @@ constexpr uint8_t kOpWmmaF32_16x16x16_F16 = 64;
 /// MFMA layout. The ds_bpermute tail corrects the affected lanes using the
 /// generated matrix conversion table.
 std::vector<uint32_t> lower_mfma_f32_16x16x16_f16(const Instruction &inst,
-                                                  const LivenessAnalysis &liveness) {
+                                                  const LivenessAnalysis &liveness,
+                                                  TranslationContext &context) {
   const auto *raw = inst.raw_encoding();
   if (!raw || inst.size() < 8)
     return {};
@@ -166,6 +168,13 @@ std::vector<uint32_t> lower_mfma_f32_16x16x16_f16(const Instruction &inst,
   if (!free_reg)
     return {};
   const uint8_t vaddr = static_cast<uint8_t>(*free_reg);
+
+  // Record feedback only after the full scratch allocation succeeds. A failed
+  // lowering returns empty and should not grow descriptor resources for code
+  // that was never emitted.
+  context.require_sgprs(static_cast<uint32_t>(kExecSave) + 2);
+  context.require_sgprs(static_cast<uint32_t>(kTmpSgpr) + 1);
+  context.require_vgprs(static_cast<uint32_t>(vaddr) + 1);
 
   std::vector<uint32_t> words;
 
@@ -232,33 +241,45 @@ std::vector<uint32_t> lower_mfma_f32_16x16x16_f16(const Instruction &inst,
   return words;
 }
 
-std::vector<uint32_t> expand_waitcnt(const Instruction &inst, uint32_t, uint64_t,
-                                     const LivenessAnalysis &, const LaneLayout *,
-                                     const LaneLayout *) {
+ExpandResult expand_waitcnt(const Instruction &inst, uint32_t, uint64_t, const LivenessAnalysis &,
+                            TranslationContext &, const LaneLayout *, const LaneLayout *) {
   if (!inst.raw_encoding())
-    return {};
+    return ExpandResult::failed(std::string(inst.mnemonic()) +
+                                " matched the waitcnt expansion rule without raw encoding");
   const auto &sopp = *reinterpret_cast<const cdna4::SoppMachineInst *>(inst.raw_encoding());
-  return encode_waitcnt_gfx12(decode_waitcnt_gfx9(sopp.simm16));
+  return ExpandResult::success(encode_waitcnt_gfx12(decode_waitcnt_gfx9(sopp.simm16)));
 }
 
-std::vector<uint32_t> expand_accvgpr_read(const Instruction &inst, uint32_t, uint64_t,
-                                          const LivenessAnalysis &, const LaneLayout *,
-                                          const LaneLayout *) {
-  return lower_accvgpr_read(inst);
+ExpandResult expand_accvgpr_read(const Instruction &inst, uint32_t, uint64_t,
+                                 const LivenessAnalysis &, TranslationContext &, const LaneLayout *,
+                                 const LaneLayout *) {
+  auto words = lower_accvgpr_read(inst);
+  if (!words.empty())
+    return ExpandResult::success(std::move(words));
+  return ExpandResult::failed(
+      std::string(inst.mnemonic()) +
+      " matched the AccVGPR read expansion rule, but the instruction form is unsupported");
 }
 
-std::vector<uint32_t> expand_accvgpr_write(const Instruction &, uint32_t, uint64_t,
-                                           const LivenessAnalysis &, const LaneLayout *,
-                                           const LaneLayout *) {
+ExpandResult expand_accvgpr_write(const Instruction &, uint32_t, uint64_t, const LivenessAnalysis &,
+                                  TranslationContext &, const LaneLayout *, const LaneLayout *) {
   // AccVGPR writes are already represented by the unified VGPR mapping that
   // descriptor translation reserves for RDNA targets.
-  return {build_s_nop()};
+  return ExpandResult::success({build_s_nop()});
 }
 
-std::vector<uint32_t> expand_mfma_f32_16x16x16_f16(const Instruction &inst, uint32_t, uint64_t,
-                                                   const LivenessAnalysis &liveness,
-                                                   const LaneLayout *, const LaneLayout *) {
-  return lower_mfma_f32_16x16x16_f16(inst, liveness);
+ExpandResult expand_mfma_f32_16x16x16_f16(const Instruction &inst, uint32_t, uint64_t,
+                                          const LivenessAnalysis &liveness,
+                                          TranslationContext &context, const LaneLayout *,
+                                          const LaneLayout *) {
+  auto words = lower_mfma_f32_16x16x16_f16(inst, liveness, context);
+  if (!words.empty())
+    return ExpandResult::success(std::move(words));
+  return ExpandResult::failed(
+      std::string(inst.mnemonic()) +
+          " matched the MFMA expansion rule, but scratch allocation or operand validation failed",
+      {"Check whether conservative liveness leaves a free SGPR pair and VGPR scratch.",
+       "Add a more general lowering or spill path for this MFMA form."});
 }
 
 // CDNA4 encoding IDs (encoding_id = w0 >> 23, from CDNA4 instruction words).

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/cdna4_to_rdna4.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/cdna4_to_rdna4.cpp
@@ -17,7 +17,6 @@
 #include "rocjitsu/code/dbt/generated/matrix_conversions.h"
 
 #include <bit>
-#include <cassert>
 #include <cstring>
 #include <string>
 #include <string_view>
@@ -96,23 +95,30 @@ build_vop3(uint16_t op, uint8_t vdst, uint16_t src0, uint16_t src1 = 0, uint16_t
 /// @details AccVGPR N is represented as unified VGPR N+256 in the current
 /// descriptor translation model. If the destination already aliases that
 /// unified register, a NOP preserves the source instruction slot.
-std::vector<uint32_t> lower_accvgpr_read(const Instruction &inst) {
+ExpandResult lower_accvgpr_read(const Instruction &inst) {
   const auto *raw = inst.raw_encoding();
   if (!raw || inst.size() < 8)
-    return {};
+    return ExpandResult::failed(std::string(inst.mnemonic()) +
+                                " cannot lower AccVGPR read without a complete 64-bit raw "
+                                "encoding");
 
   cdna4::Vop3pMachineInst src{};
   std::memcpy(&src, raw, sizeof(src));
 
   const uint16_t dst_vgpr = src.vdst;
   const uint16_t src_acc = src.src0;
-  assert(src_acc >= 768 && src_acc <= 1023);
+  if (src_acc < 768 || src_acc > 1023)
+    return ExpandResult::failed(std::string(inst.mnemonic()) +
+                                " AccVGPR read lowering expected src0 in the AccVGPR operand "
+                                "range 768..1023, got " +
+                                std::to_string(src_acc));
   const uint16_t src_unified = src_acc - 512;
 
   if (dst_vgpr == src_unified)
-    return {build_s_nop()};
+    return ExpandResult::success({build_s_nop()});
 
-  return {build_v_mov_b32(static_cast<uint8_t>(dst_vgpr), 256 + src_unified)};
+  return ExpandResult::success(
+      {build_v_mov_b32(static_cast<uint8_t>(dst_vgpr), static_cast<uint16_t>(256 + src_unified))});
 }
 
 constexpr uint8_t kSoppWaitIdle = 0x0A;
@@ -134,12 +140,12 @@ constexpr uint8_t kOpWmmaF32_16x16x16_F16 = 64;
 /// @details WMMA Wave64 writes all 64 lanes but swaps rows 4-7 and 8-11 vs
 /// MFMA layout. The ds_bpermute tail corrects the affected lanes using the
 /// generated matrix conversion table.
-std::vector<uint32_t> lower_mfma_f32_16x16x16_f16(const Instruction &inst,
-                                                  const LivenessAnalysis &liveness,
-                                                  TranslationContext &context) {
+ExpandResult lower_mfma_f32_16x16x16_f16(const Instruction &inst, const LivenessAnalysis &liveness,
+                                         TranslationContext &context) {
   const auto *raw = inst.raw_encoding();
   if (!raw || inst.size() < 8)
-    return {};
+    return ExpandResult::failed(std::string(inst.mnemonic()) +
+                                " cannot lower MFMA without a complete 64-bit raw encoding");
 
   cdna4::Vop3pMfmaMachineInst mfma{};
   std::memcpy(&mfma, raw, sizeof(mfma));
@@ -150,23 +156,45 @@ std::vector<uint32_t> lower_mfma_f32_16x16x16_f16(const Instruction &inst,
   const uint16_t src2 = mfma.src2;
 
   if (src2 >= 256)
-    return {};
+    return ExpandResult::failed(
+        std::string(inst.mnemonic()) +
+            " MFMA lowering only supports a VGPR accumulator source; got src2 operand " +
+            std::to_string(src2),
+        {"Add an MFMA lowering path for non-VGPR accumulator operands."});
 
-  assert(src0 >= 256 && src1 >= 256 && "MFMA VGPR sources expected");
+  if (src0 < 256 || src1 < 256)
+    return ExpandResult::failed(std::string(inst.mnemonic()) +
+                                    " MFMA lowering expected VGPR matrix sources, got src0=" +
+                                    std::to_string(src0) + " src1=" + std::to_string(src1),
+                                {"Add an MFMA lowering path for scalar or inline-constant "
+                                 "matrix operands."});
 
   auto exec_save_opt = liveness.find_free_sgpr_pair(&inst);
   if (!exec_save_opt)
-    return {};
+    return ExpandResult::failed(
+        std::string(inst.mnemonic()) +
+            " MFMA lowering could not find a free SGPR pair to save EXEC",
+        {"Reduce SGPR pressure, improve liveness, or add scalar spill support for semantic "
+         "lowerings."});
   const uint8_t kExecSave = static_cast<uint8_t>(*exec_save_opt);
 
   auto tmp_sgpr_opt = liveness.find_free_sgpr(&inst, kExecSave + 2);
   if (!tmp_sgpr_opt)
-    return {};
+    return ExpandResult::failed(
+        std::string(inst.mnemonic()) +
+            " MFMA lowering could not find a temporary SGPR after the EXEC save pair",
+        {"Reduce SGPR pressure, improve liveness, or add scalar spill support for semantic "
+         "lowerings."});
   const uint8_t kTmpSgpr = static_cast<uint8_t>(*tmp_sgpr_opt);
 
   auto free_reg = liveness.find_free_run(&inst, 1, vdst + 4);
   if (!free_reg)
-    return {};
+    return ExpandResult::failed(
+        std::string(inst.mnemonic()) +
+            " MFMA lowering could not find a free VGPR for ds_bpermute addresses at or above v" +
+            std::to_string(vdst + 4),
+        {"Reduce VGPR pressure, improve liveness, or add VGPR spill support for semantic "
+         "lowerings."});
   const uint8_t vaddr = static_cast<uint8_t>(*free_reg);
 
   // Record feedback only after the full scratch allocation succeeds. A failed
@@ -238,7 +266,7 @@ std::vector<uint32_t> lower_mfma_f32_16x16x16_f16(const Instruction &inst,
 
   words.push_back(build_s_mov_b64(kExecLo, kExecSave));
 
-  return words;
+  return ExpandResult::success(std::move(words));
 }
 
 ExpandResult expand_waitcnt(const Instruction &inst, uint32_t, uint64_t, const LivenessAnalysis &,
@@ -246,6 +274,10 @@ ExpandResult expand_waitcnt(const Instruction &inst, uint32_t, uint64_t, const L
   if (!inst.raw_encoding())
     return ExpandResult::failed(std::string(inst.mnemonic()) +
                                 " matched the waitcnt expansion rule without raw encoding");
+  if (static_cast<size_t>(inst.size()) < sizeof(cdna4::SoppMachineInst))
+    return ExpandResult::failed(std::string(inst.mnemonic()) +
+                                " matched the waitcnt expansion rule with a truncated SOPP "
+                                "encoding");
   const auto &sopp = *reinterpret_cast<const cdna4::SoppMachineInst *>(inst.raw_encoding());
   return ExpandResult::success(encode_waitcnt_gfx12(decode_waitcnt_gfx9(sopp.simm16)));
 }
@@ -253,12 +285,7 @@ ExpandResult expand_waitcnt(const Instruction &inst, uint32_t, uint64_t, const L
 ExpandResult expand_accvgpr_read(const Instruction &inst, uint32_t, uint64_t,
                                  const LivenessAnalysis &, TranslationContext &, const LaneLayout *,
                                  const LaneLayout *) {
-  auto words = lower_accvgpr_read(inst);
-  if (!words.empty())
-    return ExpandResult::success(std::move(words));
-  return ExpandResult::failed(
-      std::string(inst.mnemonic()) +
-      " matched the AccVGPR read expansion rule, but the instruction form is unsupported");
+  return lower_accvgpr_read(inst);
 }
 
 ExpandResult expand_accvgpr_write(const Instruction &, uint32_t, uint64_t, const LivenessAnalysis &,
@@ -272,14 +299,7 @@ ExpandResult expand_mfma_f32_16x16x16_f16(const Instruction &inst, uint32_t, uin
                                           const LivenessAnalysis &liveness,
                                           TranslationContext &context, const LaneLayout *,
                                           const LaneLayout *) {
-  auto words = lower_mfma_f32_16x16x16_f16(inst, liveness, context);
-  if (!words.empty())
-    return ExpandResult::success(std::move(words));
-  return ExpandResult::failed(
-      std::string(inst.mnemonic()) +
-          " matched the MFMA expansion rule, but scratch allocation or operand validation failed",
-      {"Check whether conservative liveness leaves a free SGPR pair and VGPR scratch.",
-       "Add a more general lowering or spill path for this MFMA form."});
+  return lower_mfma_f32_16x16x16_f16(inst, liveness, context);
 }
 
 // CDNA4 encoding IDs (encoding_id = w0 >> 23, from CDNA4 instruction words).

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/cdna4_to_rdna_common.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/cdna4_to_rdna_common.cpp
@@ -6,12 +6,14 @@
 
 #include "rocjitsu/code/dbt/semantic/cdna4_to_rdna_common.h"
 
+#include "rocjitsu/code/dbt/translation_rule.h"
 #include "rocjitsu/code/patch/instruction_builder.h"
 #include "rocjitsu/code/rj_code.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna4/machine_insts.h"
 #include "rocjitsu/isa/instruction.h"
 
 #include <cstring>
+#include <string>
 #include <utility>
 
 namespace rocjitsu {
@@ -43,6 +45,11 @@ std::vector<uint32_t> lower_v_lshl_add_u64(const Instruction &inst, rj_code_arch
   constexpr uint16_t kOpAddCoCiU32 = 288;
   constexpr uint8_t kSoppWaitAlu = 8;
 
+  // This lowering introduces VCC as the explicit carry register. VCC is special
+  // scalar state, not a liveness-allocated scratch SGPR pair, so it must not
+  // grow the ordinary SGPR descriptor allocation. Treating it as normal SGPRs
+  // makes valid RDNA targets look unsupported once diagnostics become fatal.
+
   std::vector<uint32_t> words;
 
   // v_add_co_u32 writes VCC, then v_add_co_ci_u32 consumes VCC as carry-in.
@@ -73,11 +80,16 @@ std::vector<uint32_t> lower_v_lshl_add_u64(const Instruction &inst, rj_code_arch
 
 } // namespace
 
-std::vector<uint32_t> expand_cdna4_v_lshl_add_u64_for_rdna(const Instruction &inst,
-                                                           uint32_t host_arch, uint64_t,
-                                                           const LivenessAnalysis &,
-                                                           const LaneLayout *, const LaneLayout *) {
-  return lower_v_lshl_add_u64(inst, static_cast<rj_code_arch_t>(host_arch));
+ExpandResult expand_cdna4_v_lshl_add_u64_for_rdna(const Instruction &inst, uint32_t host_arch,
+                                                  uint64_t, const LivenessAnalysis &,
+                                                  TranslationContext &, const LaneLayout *,
+                                                  const LaneLayout *) {
+  auto words = lower_v_lshl_add_u64(inst, static_cast<rj_code_arch_t>(host_arch));
+  if (!words.empty())
+    return ExpandResult::success(std::move(words));
+  return ExpandResult::failed(std::string(inst.mnemonic()) +
+                              " matched a semantic expansion rule, but the rule rejected "
+                              "this instruction form as unsupported.");
 }
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/cdna4_to_rdna_common.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/cdna4_to_rdna_common.cpp
@@ -29,16 +29,26 @@ build_rdna_vop3(uint16_t op, uint8_t vdst, uint16_t src0, uint16_t src1 = 0, uin
   return {w0, w1};
 }
 
-std::vector<uint32_t> lower_v_lshl_add_u64(const Instruction &inst, rj_code_arch_t host_arch) {
+ExpandResult lower_v_lshl_add_u64(const Instruction &inst, rj_code_arch_t host_arch) {
   const auto *raw = inst.raw_encoding();
   if (!raw || inst.size() < 8)
-    return {};
+    return ExpandResult::failed(std::string(inst.mnemonic()) +
+                                " cannot lower v_lshl_add_u64 without a complete 64-bit raw "
+                                "encoding");
 
   cdna4::Vop3MachineInst src{};
   std::memcpy(&src, raw, sizeof(src));
   const uint16_t vdst = src.vdst;
   const uint16_t src0 = src.src0;
   const uint16_t src2 = src.src2;
+
+  if (host_arch != ROCJITSU_CODE_ARCH_RDNA3 && host_arch != ROCJITSU_CODE_ARCH_RDNA4)
+    return ExpandResult::failed(std::string(inst.mnemonic()) +
+                                " v_lshl_add_u64 lowering only supports RDNA3/RDNA4 hosts");
+  if (vdst == 255)
+    return ExpandResult::failed(std::string(inst.mnemonic()) +
+                                " v_lshl_add_u64 lowering needs two destination VGPRs but vdst "
+                                "is v255");
 
   constexpr uint16_t kVccLo = 106;
   constexpr uint16_t kOpAddCoU32 = 768;
@@ -75,7 +85,7 @@ std::vector<uint32_t> lower_v_lshl_add_u64(const Instruction &inst, rj_code_arch
     words.push_back(w1);
   }
 
-  return words;
+  return ExpandResult::success(std::move(words));
 }
 
 } // namespace
@@ -84,12 +94,7 @@ ExpandResult expand_cdna4_v_lshl_add_u64_for_rdna(const Instruction &inst, uint3
                                                   uint64_t, const LivenessAnalysis &,
                                                   TranslationContext &, const LaneLayout *,
                                                   const LaneLayout *) {
-  auto words = lower_v_lshl_add_u64(inst, static_cast<rj_code_arch_t>(host_arch));
-  if (!words.empty())
-    return ExpandResult::success(std::move(words));
-  return ExpandResult::failed(std::string(inst.mnemonic()) +
-                              " matched a semantic expansion rule, but the rule rejected "
-                              "this instruction form as unsupported.");
+  return lower_v_lshl_add_u64(inst, static_cast<rj_code_arch_t>(host_arch));
 }
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/cdna4_to_rdna_common.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/cdna4_to_rdna_common.h
@@ -7,19 +7,20 @@
 #pragma once
 
 #include <cstdint>
-#include <vector>
 
 namespace rocjitsu {
 
 class Instruction;
 class LivenessAnalysis;
+struct ExpandResult;
 struct LaneLayout;
+struct TranslationContext;
 
 /// @brief Expand CDNA4 v_lshl_add_u64 into the RDNA carry-chain sequence.
-std::vector<uint32_t> expand_cdna4_v_lshl_add_u64_for_rdna(const Instruction &inst,
-                                                           uint32_t host_arch, uint64_t offset,
-                                                           const LivenessAnalysis &liveness,
-                                                           const LaneLayout *guest_layout,
-                                                           const LaneLayout *host_layout);
+ExpandResult expand_cdna4_v_lshl_add_u64_for_rdna(const Instruction &inst, uint32_t host_arch,
+                                                  uint64_t offset, const LivenessAnalysis &liveness,
+                                                  TranslationContext &context,
+                                                  const LaneLayout *guest_layout,
+                                                  const LaneLayout *host_layout);
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic_translator.cpp
@@ -32,17 +32,18 @@ namespace {
 SemanticTranslator::SemanticTranslator(rj_code_arch_t guest, rj_code_arch_t host)
     : expand_rules_(semantic_expand_rules_for(guest, host)), host_arch_(host) {}
 
-std::vector<uint32_t> SemanticTranslator::try_lower_expand(const Instruction &inst, uint64_t offset,
-                                                           const LivenessAnalysis &liveness) const {
+ExpandResult SemanticTranslator::try_lower_expand(const Instruction &inst, uint64_t offset,
+                                                  const LivenessAnalysis &liveness,
+                                                  TranslationContext &context) const {
   const uint16_t eid = inst.encoding_id();
   const uint16_t op = inst.opcode();
   TranslationRule key{eid, op, RuleAction::Expand, 0, 0, nullptr, nullptr, nullptr, nullptr};
   auto it = std::lower_bound(expand_rules_.begin(), expand_rules_.end(), key);
   if (it != expand_rules_.end() && it->src_encoding_id == eid && it->src_opcode == op &&
       it->expand_fn)
-    return it->expand_fn(inst, static_cast<uint32_t>(host_arch_), offset, liveness,
+    return it->expand_fn(inst, static_cast<uint32_t>(host_arch_), offset, liveness, context,
                          it->guest_layout, it->host_layout);
-  return {};
+  return ExpandResult::not_handled();
 }
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic_translator.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic_translator.h
@@ -63,9 +63,10 @@ public:
   /// @param inst      The decoded instruction.
   /// @param offset    Byte offset of the instruction in .text.
   /// @param liveness  Kernel-scoped live-before data used for scratch register allocation.
-  /// @returns Replacement instruction words on success, empty vector if no rule matches.
-  [[nodiscard]] std::vector<uint32_t> try_lower_expand(const Instruction &inst, uint64_t offset,
-                                                       const LivenessAnalysis &liveness) const;
+  /// @returns Structured expansion status and replacement words.
+  [[nodiscard]] ExpandResult try_lower_expand(const Instruction &inst, uint64_t offset,
+                                              const LivenessAnalysis &liveness,
+                                              TranslationContext &context) const;
 
   [[nodiscard]] bool has_rules() const { return !expand_rules_.empty(); }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/translation_diagnostic.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/translation_diagnostic.h
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file translation_diagnostic.h
+/// @brief Structured diagnostics reported by the DBT pipeline.
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace rocjitsu {
+
+/// @brief Severity for a translation diagnostic.
+enum class DiagnosticSeverity {
+  Warning,
+  Error,
+};
+
+/// @brief Broad subsystem or failure class for a translation diagnostic.
+enum class DiagnosticKind {
+  UnsupportedGuestArch,
+  KernelDescriptor,
+  Legalization,
+  ExpandMissing,
+  ExpandFailed,
+  ResourceLimit,
+};
+
+/// @brief One user/developer-facing DBT diagnostic.
+///
+/// @details Instruction diagnostics use @c guest_offset and @c mnemonic to point
+/// at the original guest instruction. Whole-image failures such as descriptor
+/// translation can leave those fields empty. @c required_work is intentionally a
+/// short checklist for EXPAND failures so missing lowerings document the next
+/// implementation steps instead of only reporting that translation failed.
+struct TranslationDiagnostic {
+  DiagnosticSeverity severity = DiagnosticSeverity::Warning;
+  DiagnosticKind kind = DiagnosticKind::Legalization;
+  std::optional<uint64_t> guest_offset;
+  std::string mnemonic;
+  std::string message;
+  std::vector<std::string> required_work;
+};
+
+[[nodiscard]] inline bool
+has_error_diagnostic(const std::vector<TranslationDiagnostic> &diagnostics) {
+  return std::ranges::any_of(diagnostics, [](const TranslationDiagnostic &diagnostic) {
+    return diagnostic.severity == DiagnosticSeverity::Error;
+  });
+}
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/translation_rule.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/translation_rule.h
@@ -25,12 +25,88 @@
 #include <compare>
 #include <cstdint>
 #include <span>
+#include <string>
+#include <utility>
 #include <vector>
 
 namespace rocjitsu {
 
 class Instruction;
 class LivenessAnalysis;
+
+/// @brief Per-kernel resource feedback collected while semantic lowerings run.
+///
+/// @details Descriptor translation happens before instruction translation, but
+/// semantic lowerings only know their actual scratch choices after liveness has
+/// been computed. Each kernel is lowered once while recording the highest
+/// SGPR/VGPR count required by those lowerings here; BinaryTranslator then
+/// recomputes the affected descriptor translations with those larger minimums
+/// before patching descriptors into the output image. A second instruction pass
+/// is only needed if a future lowering depends on descriptor-derived register
+/// numbers that can change during that recomputation.
+struct TranslationContext {
+  uint32_t num_vgprs = 0;
+  uint32_t num_agprs = 0;
+  uint32_t accum_offset = 0;
+  uint32_t num_sgprs = 0;
+  uint32_t required_vgpr_count = 0;
+  uint32_t required_sgpr_count = 0;
+
+  TranslationContext() = default;
+  TranslationContext(uint32_t vgprs, uint32_t sgprs)
+      : num_vgprs(vgprs), num_sgprs(sgprs), required_vgpr_count(0), required_sgpr_count(0) {}
+  TranslationContext(uint32_t vgprs, uint32_t agprs, uint32_t accum_base, uint32_t sgprs)
+      : num_vgprs(vgprs), num_agprs(agprs), accum_offset(accum_base), num_sgprs(sgprs),
+        required_vgpr_count(0), required_sgpr_count(0) {}
+
+  void require_vgprs(uint32_t count) {
+    if (required_vgpr_count < count)
+      required_vgpr_count = count;
+  }
+
+  void require_sgprs(uint32_t count) {
+    if (required_sgpr_count < count)
+      required_sgpr_count = count;
+  }
+};
+
+/// @brief Status returned by a semantic EXPAND rule lookup or expansion.
+enum class ExpandStatus {
+  NotHandled, ///< No rule matched this instruction.
+  Success,    ///< A rule emitted replacement instruction words.
+  Failed,     ///< A rule matched but could not safely emit a lowering.
+};
+
+/// @brief Structured result from a semantic EXPAND rule.
+///
+/// @details Empty replacement words are no longer overloaded to mean both
+/// "there is no rule" and "a rule exists but failed." BinaryTranslator uses the
+/// status to hard-fail unimplemented or failed EXPAND legalizations with useful
+/// diagnostics instead of silently NOP-filling the source instruction.
+struct ExpandResult {
+  ExpandStatus status = ExpandStatus::NotHandled;
+  std::vector<uint32_t> words;
+  std::string message;
+  std::vector<std::string> required_work;
+
+  [[nodiscard]] static ExpandResult not_handled() { return {}; }
+
+  [[nodiscard]] static ExpandResult success(std::vector<uint32_t> replacement_words) {
+    ExpandResult result;
+    result.status = ExpandStatus::Success;
+    result.words = std::move(replacement_words);
+    return result;
+  }
+
+  [[nodiscard]] static ExpandResult failed(std::string failure_message,
+                                           std::vector<std::string> work = {}) {
+    ExpandResult result;
+    result.status = ExpandStatus::Failed;
+    result.message = std::move(failure_message);
+    result.required_work = std::move(work);
+    return result;
+  }
+};
 
 // ---------------------------------------------------------------------------
 // Tier 1: Instruction Descriptor
@@ -124,11 +200,10 @@ struct LaneLayout;
 /// @param liveness      Kernel-scoped live-before data for safe scratch register allocation.
 /// @param guest_layout  Source matrix lane layout (nullptr if not a matrix op).
 /// @param host_layout   Target matrix lane layout (nullptr if not a matrix op).
-/// @returns Replacement instruction words, or empty vector if unhandled.
-using ExpandFn = std::vector<uint32_t> (*)(const Instruction &inst, uint32_t arch, uint64_t offset,
-                                           const LivenessAnalysis &liveness,
-                                           const LaneLayout *guest_layout,
-                                           const LaneLayout *host_layout);
+/// @returns Structured expansion status and replacement words.
+using ExpandFn = ExpandResult (*)(const Instruction &inst, uint32_t arch, uint64_t offset,
+                                  const LivenessAnalysis &liveness, TranslationContext &context,
+                                  const LaneLayout *guest_layout, const LaneLayout *host_layout);
 
 /// @brief A single translation rule for one (source, target) instruction.
 ///

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/translation_rule.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/translation_rule.h
@@ -34,36 +34,84 @@ namespace rocjitsu {
 class Instruction;
 class LivenessAnalysis;
 
-/// @brief Per-kernel resource feedback collected while semantic lowerings run.
+/// @brief Per-kernel register resource state shared by semantic lowerings.
 ///
-/// @details Descriptor translation happens before instruction translation, but
-/// semantic lowerings only know their actual scratch choices after liveness has
-/// been computed. Each kernel is lowered once while recording the highest
-/// SGPR/VGPR count required by those lowerings here; BinaryTranslator then
-/// recomputes the affected descriptor translations with those larger minimums
-/// before patching descriptors into the output image. A second instruction pass
-/// is only needed if a future lowering depends on descriptor-derived register
-/// numbers that can change during that recomputation.
+/// @details TranslationContext is created once per kernel from the current
+/// target kernel descriptor translation, then passed through every semantic
+/// EXPAND rule for that kernel. The `num_*` fields describe the descriptor
+/// state the lowering started from. The `required_*` fields are feedback from
+/// lowerings that allocated scratch registers beyond those descriptor counts.
+///
+/// Descriptor translation happens before instruction translation, but semantic
+/// lowerings only know their actual scratch choices after liveness has been
+/// computed. Each kernel is lowered once while recording the highest SGPR/VGPR
+/// count required by those lowerings here; BinaryTranslator then recomputes the
+/// affected descriptor translations with those larger minimums before patching
+/// descriptors into the output image. A second instruction pass is only needed
+/// if a future lowering depends on descriptor-derived register numbers that can
+/// change during that recomputation.
 struct TranslationContext {
+  /// @brief Initial target ordinary VGPR count from descriptor translation.
   uint32_t num_vgprs = 0;
+
+  /// @brief Initial target AccVGPR count from descriptor translation.
   uint32_t num_agprs = 0;
+
+  /// @brief Initial target AccVGPR base used by descriptor-backed AccVGPR allocation.
   uint32_t accum_offset = 0;
+
+  /// @brief Initial target SGPR count from descriptor translation.
   uint32_t num_sgprs = 0;
+
+  /// @brief Minimum ordinary VGPR count required after all semantic lowerings.
+  ///
+  /// @details Lowerings update this with require_vgprs() when a chosen scratch
+  /// VGPR is outside the descriptor's initial ordinary VGPR allocation. The
+  /// value is a count, not a register index, so callers pass the highest used
+  /// VGPR index plus one.
   uint32_t required_vgpr_count = 0;
+
+  /// @brief Minimum SGPR count required after all semantic lowerings.
+  ///
+  /// @details Lowerings update this with require_sgprs() when a chosen scratch
+  /// SGPR is outside the descriptor's initial SGPR allocation. The value is a
+  /// count, not a register index, so callers pass the highest used SGPR index
+  /// plus one.
   uint32_t required_sgpr_count = 0;
 
+  /// @brief Construct an empty context for tests or call sites without descriptor feedback.
   TranslationContext() = default;
+
+  /// @brief Construct a context for kernels that only need VGPR/SGPR descriptor state.
+  ///
+  /// @param vgprs Initial target ordinary VGPR count.
+  /// @param sgprs Initial target SGPR count.
   TranslationContext(uint32_t vgprs, uint32_t sgprs)
       : num_vgprs(vgprs), num_sgprs(sgprs), required_vgpr_count(0), required_sgpr_count(0) {}
+
+  /// @brief Construct a full context from target kernel descriptor translation.
+  ///
+  /// @param vgprs Initial target ordinary VGPR count.
+  /// @param agprs Initial target AccVGPR count.
+  /// @param accum_base Initial target AccVGPR base.
+  /// @param sgprs Initial target SGPR count.
   TranslationContext(uint32_t vgprs, uint32_t agprs, uint32_t accum_base, uint32_t sgprs)
       : num_vgprs(vgprs), num_agprs(agprs), accum_offset(accum_base), num_sgprs(sgprs),
         required_vgpr_count(0), required_sgpr_count(0) {}
 
+  /// @brief Record that semantic lowering requires at least @p count ordinary VGPRs.
+  ///
+  /// @details This is monotonic across all lowerings for the kernel. It only
+  /// raises the required count and never reduces an earlier requirement.
   void require_vgprs(uint32_t count) {
     if (required_vgpr_count < count)
       required_vgpr_count = count;
   }
 
+  /// @brief Record that semantic lowering requires at least @p count SGPRs.
+  ///
+  /// @details This is monotonic across all lowerings for the kernel. It only
+  /// raises the required count and never reduces an earlier requirement.
   void require_sgprs(uint32_t count) {
     if (required_sgpr_count < count)
       required_sgpr_count = count;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
@@ -190,6 +190,11 @@ void insert_file_bytes(std::vector<uint8_t> &image, Elf64_Ehdr &ehdr,
   return target_supports_wave32(arch);
 }
 
+[[nodiscard]] bool target_uses_gfx90a_accum_offset(rj_code_arch_t arch) {
+  return arch == ROCJITSU_CODE_ARCH_CDNA2 || arch == ROCJITSU_CODE_ARCH_CDNA3 ||
+         arch == ROCJITSU_CODE_ARCH_CDNA4;
+}
+
 [[nodiscard]] bool target_clears_rsrc1_mode_bits(rj_code_arch_t arch) {
   // DX10_CLAMP and IEEE_MODE are deprecated on GFX12. Preserve them for GFX10
   // and GFX11 targets where they still affect floating-point behavior.
@@ -462,6 +467,16 @@ bool CodeObjectPatcher::apply_kernel_descriptor_translation(const KdTranslation 
                   translation.target_vgpr_granulated);
   AMDHSA_BITS_SET(desc->compute_pgm_rsrc1, kd::COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT,
                   translation.target_sgpr_granulated);
+
+  if (target_uses_gfx90a_accum_offset(target_arch) && translation.target_accvgpr_base != 0) {
+    // GFX90A-style descriptors encode the first AccVGPR as (field + 1) * 4.
+    // KernelDescriptorTranslator may move this base upward when semantic
+    // lowering needs ordinary VGPR scratch above the source AccVGPR window, so
+    // the patcher must write the recomputed base alongside the VGPR allocation.
+    const uint32_t encoded_accum_offset = (translation.target_accvgpr_base / 4) - 1;
+    AMDHSA_BITS_SET(desc->compute_pgm_rsrc3, kd::COMPUTE_PGM_RSRC3_GFX90A_ACCUM_OFFSET,
+                    encoded_accum_offset);
+  }
 
   if (target_uses_gfx10_plus_mode_bits(target_arch)) {
     if (target_clears_rsrc1_mode_bits(target_arch)) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/rj_code.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/rj_code.cpp
@@ -14,6 +14,7 @@ namespace {
 Decoder *create_decoder_for_target(rj_code_target_id_t target) {
   static thread_local std::unique_ptr<Decoder> cdna3_decoder;
   static thread_local std::unique_ptr<Decoder> cdna4_decoder;
+  static thread_local std::unique_ptr<Decoder> rdna4_decoder;
 
   switch (target) {
   case ROCJITSU_CODE_TARGET_GFX942:
@@ -24,6 +25,11 @@ Decoder *create_decoder_for_target(rj_code_target_id_t target) {
     if (!cdna4_decoder)
       cdna4_decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
     return cdna4_decoder.get();
+  case ROCJITSU_CODE_TARGET_GFX1200:
+  case ROCJITSU_CODE_TARGET_GFX1201:
+    if (!rdna4_decoder)
+      rdna4_decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
+    return rdna4_decoder.get();
   default:
     return nullptr;
   }

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -85,6 +85,7 @@ target_include_directories(
         ${CMAKE_SOURCE_DIR}/lib/rocjitsu/include
         ${CMAKE_SOURCE_DIR}/lib/rocjitsu/src
 )
+target_link_libraries(rj_dbt_translate_smoke_test PRIVATE GTest::gtest)
 rj_configure_target(rj_dbt_translate_smoke_test TEST)
 add_dependencies(rj_dbt_translate_smoke_test rj_dbt_translate)
 add_test(

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -75,6 +75,24 @@ rj_configure_target(rocjitsu_tests TEST)
 include(GoogleTest)
 gtest_discover_tests(rocjitsu_tests)
 
+add_executable(
+    rj_dbt_translate_smoke_test
+    tools/rj_dbt_translate_smoke_test.cpp
+)
+target_include_directories(
+    rj_dbt_translate_smoke_test
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}/lib/rocjitsu/include
+        ${CMAKE_SOURCE_DIR}/lib/rocjitsu/src
+)
+rj_configure_target(rj_dbt_translate_smoke_test TEST)
+add_dependencies(rj_dbt_translate_smoke_test rj_dbt_translate)
+add_test(
+    NAME "RjDbtTranslate.Smoke"
+    COMMAND rj_dbt_translate_smoke_test $<TARGET_FILE:rj_dbt_translate>
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+)
+
 # --- Scaling test (standalone executable) ---
 
 add_executable(scaling_test scaling_test.cpp)

--- a/emulation/rocjitsu/tests/analysis/liveness_test.cpp
+++ b/emulation/rocjitsu/tests/analysis/liveness_test.cpp
@@ -326,6 +326,22 @@ TEST(LivenessAnalysis, FindsDeadSgprAfterLiveSgpr) {
   EXPECT_EQ(liveness.find_free_sgpr(&use, 4), 5);
 }
 
+TEST(LivenessAnalysis, MinFreeVgprForcesScratchAllocationAboveFloor) {
+  auto blocks = build_test_blocks({TestOpcode::UseSgpr4, TestOpcode::End});
+  auto scope = block_scope(blocks);
+
+  LivenessAnalysisOptions options;
+  options.min_free_vgpr = 4;
+
+  LivenessAnalysis liveness(KernelBlockScope(scope), options);
+
+  const Instruction &use = *blocks[0]->instructions().begin();
+  EXPECT_FALSE(liveness.is_live_before(use, {RegClass::VGPR, 0, 4}));
+  EXPECT_EQ(liveness.find_free_sgpr(&use, 0), 0);
+  EXPECT_EQ(liveness.find_free_run(&use, 1, 0), 4);
+  EXPECT_EQ(liveness.find_free_run(&use, 1, 7), 7);
+}
+
 TEST(LivenessAnalysis, ReadWriteSameRegisterIsLiveBeforeInstruction) {
   auto blocks = build_test_blocks({TestOpcode::ReadWriteSgpr4, TestOpcode::End});
   LivenessAnalysis liveness = analyze_scope(blocks);

--- a/emulation/rocjitsu/tests/dbt/device_kernels_translate_tests.cpp
+++ b/emulation/rocjitsu/tests/dbt/device_kernels_translate_tests.cpp
@@ -467,6 +467,7 @@ TEST(BinaryTranslatorE2E, DescriptorPrologueRedirectsEntryWithoutOverwritingOrig
   BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_RDNA4);
   auto result = translator.translate(*co);
   ASSERT_FALSE(result.elf_bytes.empty());
+  ASSERT_TRUE(result.ok());
 
   rocjitsu::AmdGpuCodeObject translated_co(result.elf_bytes.data(), result.elf_bytes.size());
   ASSERT_TRUE(translated_co.is_valid());
@@ -485,8 +486,6 @@ TEST(BinaryTranslatorE2E, DescriptorPrologueRedirectsEntryWithoutOverwritingOrig
 
   EXPECT_GT(translated_info->entry_text_offset, original_info->entry_text_offset)
       << "CDNA4 workgroup-id SGPRs must be materialized from RDNA4's TTMP launch payload";
-  EXPECT_GE(translated_info->guest_vgpr_count, 128u)
-      << "DBT semantic lowerings need conservative temporary VGPR headroom in the descriptor";
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
   ASSERT_NE(decoder, nullptr);

--- a/emulation/rocjitsu/tests/dbt/device_kernels_translate_tests.cpp
+++ b/emulation/rocjitsu/tests/dbt/device_kernels_translate_tests.cpp
@@ -87,10 +87,10 @@ mutable_kernel_descriptor(MutableKernelDescriptorImage &fixture) {
 
 std::vector<rocjitsu::KdTranslation>
 translate_mutable_descriptor(const MutableKernelDescriptorImage &fixture, rj_code_arch_t guest_arch,
-                             rj_code_arch_t host_arch) {
+                             rj_code_arch_t host_arch,
+                             const rocjitsu::KernelDescriptorTranslationOptions &options = {}) {
   rocjitsu::KernelDescriptorTranslator translator(guest_arch, host_arch);
-  return translator.translate_image(fixture.image, fixture.text_offset, fixture.text_size,
-                                    rocjitsu::KernelDescriptorTranslationOptions{});
+  return translator.translate_image(fixture.image, fixture.text_offset, fixture.text_size, options);
 }
 
 } // namespace
@@ -112,13 +112,12 @@ TEST(BinaryTranslatorE2E, TranslateVectorAddCdna4ToRdna4) {
 
   EXPECT_FALSE(result.elf_bytes.empty()) << "Translation produced empty ELF";
   EXPECT_EQ(result.host_arch, ROCJITSU_CODE_ARCH_RDNA4);
+  ASSERT_TRUE(result.ok()) << "Translation diagnostic: " << result.diagnostics.front().message;
 
-  // Verify ELF machine flags contain GFX1200.
-  ASSERT_GE(result.elf_bytes.size(), 48u);
-  uint32_t e_flags = 0;
-  std::memcpy(&e_flags, result.elf_bytes.data() + 48, sizeof(e_flags));
-  constexpr uint32_t kEfAmdgpuMachGfx1200 = 0x48;
-  EXPECT_EQ(e_flags & 0xFF, kEfAmdgpuMachGfx1200)
+  // Verify ELF machine flags through the typed header so the bounds check covers e_flags.
+  ASSERT_GE(result.elf_bytes.size(), sizeof(rocjitsu::Elf64_Ehdr));
+  const auto *ehdr = reinterpret_cast<const rocjitsu::Elf64_Ehdr *>(result.elf_bytes.data());
+  EXPECT_EQ(ehdr->e_flags & rocjitsu::EF_AMDGPU_MACH, rocjitsu::EF_AMDGPU_MACH_AMDGCN_GFX1200)
       << "ELF e_flags should contain GFX1200 machine type";
 }
 
@@ -135,14 +134,12 @@ TEST(BinaryTranslatorE2E, TranslateVectorAddCdna4ToCdna3) {
 
   EXPECT_FALSE(result.elf_bytes.empty()) << "Translation produced empty ELF";
   EXPECT_EQ(result.host_arch, ROCJITSU_CODE_ARCH_CDNA3);
-  EXPECT_TRUE(result.warnings.empty())
-      << "Vector-add CDNA4→CDNA3 translation should not require unhandled lowering";
+  EXPECT_TRUE(result.ok())
+      << "Vector-add CDNA4->CDNA3 translation should not require unhandled lowering";
 
-  ASSERT_GE(result.elf_bytes.size(), 48u);
-  uint32_t e_flags = 0;
-  std::memcpy(&e_flags, result.elf_bytes.data() + 48, sizeof(e_flags));
-  constexpr uint32_t kEfAmdgpuMachGfx942 = 0x4C;
-  EXPECT_EQ(e_flags & 0xFF, kEfAmdgpuMachGfx942)
+  ASSERT_GE(result.elf_bytes.size(), sizeof(rocjitsu::Elf64_Ehdr));
+  const auto *ehdr = reinterpret_cast<const rocjitsu::Elf64_Ehdr *>(result.elf_bytes.data());
+  EXPECT_EQ(ehdr->e_flags & rocjitsu::EF_AMDGPU_MACH, rocjitsu::EF_AMDGPU_MACH_AMDGCN_GFX942)
       << "ELF e_flags should contain GFX942 machine type";
 
   ASSERT_FALSE(co->text_sections().empty());
@@ -339,7 +336,7 @@ TEST(KernelDescriptorTranslator, CdnaAccVgprExpansionGrowsUnifiedVgprAllocationF
     auto *kd = mutable_kernel_descriptor(fixture);
     kd->compute_pgm_rsrc1 = 0;
     kd->compute_pgm_rsrc3 = 0;
-    AMDHSA_BITS_SET(kd->compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT, 7);
+    AMDHSA_BITS_SET(kd->compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT, 15);
     AMDHSA_BITS_SET(kd->compute_pgm_rsrc3, COMPUTE_PGM_RSRC3_GFX90A_ACCUM_OFFSET, 15);
 
     const auto translations =
@@ -351,9 +348,51 @@ TEST(KernelDescriptorTranslator, CdnaAccVgprExpansionGrowsUnifiedVgprAllocationF
     ASSERT_NE(translated, translations.end());
     EXPECT_EQ(translated->accvgpr_base, 64u);
     EXPECT_EQ(translated->guest_vgpr_count, 64u);
+    EXPECT_EQ(translated->guest_agpr_count, 64u);
     EXPECT_EQ(translated->target_vgpr_count, 128u);
+    EXPECT_EQ(translated->target_vgpr_allocation_count, 128u);
     EXPECT_EQ(translated->target_vgpr_granulated, 31u);
   }
+}
+
+TEST(KernelDescriptorTranslator, CdnaToCdnaMovesAccVgprBaseAboveSemanticScratch) {
+  using namespace rocr::llvm::amdhsa;
+
+  auto fixture = mutable_vector_add_descriptor(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_TRUE(fixture.valid);
+
+  auto *kd = mutable_kernel_descriptor(fixture);
+  kd->compute_pgm_rsrc1 = 0;
+  kd->compute_pgm_rsrc3 = 0;
+  AMDHSA_BITS_SET(kd->compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT, 13);
+  AMDHSA_BITS_SET(kd->compute_pgm_rsrc3, COMPUTE_PGM_RSRC3_GFX90A_ACCUM_OFFSET, 23);
+
+  rocjitsu::KernelDescriptorTranslationOptions options;
+  options.minimum_vgprs = 128;
+  const auto translations = translate_mutable_descriptor(fixture, ROCJITSU_CODE_ARCH_CDNA4,
+                                                         ROCJITSU_CODE_ARCH_CDNA3, options);
+  const auto translated =
+      std::find_if(translations.begin(), translations.end(), [&fixture](const auto &translation) {
+        return translation.descriptor_file_offset == fixture.kd_file_off;
+      });
+  ASSERT_NE(translated, translations.end());
+  EXPECT_EQ(translated->accvgpr_base, 96u);
+  EXPECT_EQ(translated->target_accvgpr_base, 128u);
+  EXPECT_EQ(translated->target_vgpr_count, 128u);
+  EXPECT_EQ(translated->target_agpr_count, 16u);
+  EXPECT_EQ(translated->target_vgpr_allocation_count, 144u);
+  EXPECT_EQ(translated->target_vgpr_granulated, 17u);
+
+  rocjitsu::AmdGpuCodeObject mutated(fixture.image.data(), fixture.image.size());
+  ASSERT_TRUE(mutated.is_valid());
+  rocjitsu::CodeObjectPatcher patcher(mutated);
+  ASSERT_TRUE(patcher.apply_kernel_descriptor_translation(*translated, ROCJITSU_CODE_ARCH_CDNA3));
+
+  const auto patched_image = patcher.emit();
+  const auto *patched_kd =
+      reinterpret_cast<const kernel_descriptor_t *>(patched_image.data() + fixture.kd_file_off);
+  EXPECT_EQ(AMDHSA_BITS_GET(patched_kd->compute_pgm_rsrc3, COMPUTE_PGM_RSRC3_GFX90A_ACCUM_OFFSET),
+            31u);
 }
 
 TEST(KernelDescriptorTranslator, RdnaWave64UsesAmdhsaDescriptorVgprEncoding) {
@@ -806,9 +845,9 @@ TEST(BinaryTranslatorE2E, DumpTranslation) {
     dump("RDNA4 translated", reinterpret_cast<const uint8_t *>(sec->data()), sec->size(),
          ROCJITSU_CODE_ARCH_RDNA4);
 
-  if (!result.warnings.empty()) {
-    printf("\n--- Warnings (%zu) ---\n", result.warnings.size());
-    for (const auto &w : result.warnings)
-      printf("  %s\n", w.c_str());
+  if (!result.diagnostics.empty()) {
+    printf("\n--- Diagnostics (%zu) ---\n", result.diagnostics.size());
+    for (const auto &diagnostic : result.diagnostics)
+      printf("  %s\n", diagnostic.message.c_str());
   }
 }

--- a/emulation/rocjitsu/tests/dbt/hsa_translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/hsa_translate_test.cpp
@@ -156,7 +156,7 @@ TEST(HsaTranslateTest, TranslateAndDispatchVectorAdd) {
   BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, target.arch, target.mach);
   auto result = translator.translate(*co);
   ASSERT_FALSE(result.elf_bytes.empty());
-  EXPECT_TRUE(result.warnings.empty()) << "Translation warnings: " << result.warnings.front();
+  EXPECT_TRUE(result.ok()) << "Translation diagnostic: " << result.diagnostics.front().message;
 
   // 2. Load via HSA.
   hsa_agent_t cpu = find_cpu_agent();

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -1230,12 +1230,15 @@ TEST(BinaryTranslator, CaveBranchOverflowLeavesCodeObjectUnchanged) {
   auto result = translator.translate(co);
 
   EXPECT_EQ(result.elf_bytes, image);
-  const bool warned =
-      std::any_of(result.warnings.begin(), result.warnings.end(), [](const std::string &warning) {
-        return warning.find("branch range") != std::string::npos &&
-               warning.find("leaving code object unchanged") != std::string::npos;
+  const bool diagnosed = std::any_of(
+      result.diagnostics.begin(), result.diagnostics.end(),
+      [](const TranslationDiagnostic &diagnostic) {
+        return diagnostic.severity == DiagnosticSeverity::Error &&
+               diagnostic.kind == DiagnosticKind::ResourceLimit &&
+               diagnostic.message.find("branch range") != std::string::npos &&
+               diagnostic.message.find("leaving code object unchanged") != std::string::npos;
       });
-  EXPECT_TRUE(warned);
+  EXPECT_TRUE(diagnosed);
 }
 
 } // namespace
@@ -1335,7 +1338,7 @@ TEST(BinaryTranslatorE2E, TranslatesMultiKernelCodeObject) {
   rocjitsu::BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_RDNA4);
   auto result = translator.translate(co);
   ASSERT_FALSE(result.elf_bytes.empty());
-  EXPECT_TRUE(result.warnings.empty());
+  EXPECT_TRUE(result.ok());
 
   rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
   ASSERT_TRUE(translated.is_valid());

--- a/emulation/rocjitsu/tests/tools/rj_dbt_translate_smoke_test.cpp
+++ b/emulation/rocjitsu/tests/tools/rj_dbt_translate_smoke_test.cpp
@@ -7,6 +7,8 @@
 #include "rocjitsu/code/amdgpu_elf.h"
 #include "rocjitsu/code/rj_code.h"
 
+#include <gtest/gtest.h>
+
 #include <array>
 #include <cstdint>
 #include <cstdlib>
@@ -18,12 +20,25 @@
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include <sys/wait.h>
 #include <unistd.h>
 
 namespace {
+
+std::filesystem::path g_translate_tool;
+
+struct TempDir {
+  std::filesystem::path path;
+
+  explicit TempDir(std::filesystem::path temp_path) : path(std::move(temp_path)) {
+    std::filesystem::create_directories(path);
+  }
+
+  ~TempDir() { std::filesystem::remove_all(path); }
+};
 
 uint32_t add_elf_name(std::vector<uint8_t> &names, std::string_view name) {
   const uint32_t offset = static_cast<uint32_t>(names.size());
@@ -205,20 +220,14 @@ bool command_succeeded(int status) {
 
 } // namespace
 
-int main(int argc, char **argv) {
-  if (argc != 2) {
-    std::cerr << "usage: rj_dbt_translate_smoke_test <rj_dbt_translate>\n";
-    return 2;
-  }
-
-  const std::filesystem::path temp_dir =
+TEST(RjDbtTranslate, Smoke) {
+  const TempDir temp_dir(
       std::filesystem::temp_directory_path() /
-      ("rj_dbt_translate_smoke_" + std::to_string(static_cast<long long>(getpid())));
-  std::filesystem::create_directories(temp_dir);
+      ("rj_dbt_translate_smoke_" + std::to_string(static_cast<long long>(getpid()))));
 
-  const auto input = temp_dir / "smoke_gfx950.co";
-  const auto output = temp_dir / "stdout.txt";
-  const auto error = temp_dir / "stderr.txt";
+  const auto input = temp_dir.path / "smoke_gfx950.co";
+  const auto output = temp_dir.path / "stdout.txt";
+  const auto error = temp_dir.path / "stderr.txt";
 
   {
     const auto image = make_smoke_code_object();
@@ -228,7 +237,7 @@ int main(int argc, char **argv) {
   }
 
   const std::string command =
-      shell_quote(argv[1]) + " " + shell_quote(input.string()) +
+      shell_quote(g_translate_tool.string()) + " " + shell_quote(input.string()) +
       " --input-target gfx950 --output-target gfx1200 --output-mode diff > " +
       shell_quote(output.string()) + " 2> " + shell_quote(error.string());
 
@@ -236,30 +245,29 @@ int main(int argc, char **argv) {
   const std::string stdout_text = read_text_file(output);
   const std::string stderr_text = read_text_file(error);
 
-  std::filesystem::remove_all(temp_dir);
-
-  if (!command_succeeded(status)) {
-    std::cerr << "rj_dbt_translate failed\nstderr:\n"
-              << stderr_text << "\nstdout:\n"
-              << stdout_text;
-    return 1;
-  }
-
-  if (!stderr_text.empty()) {
-    std::cerr << "expected empty stderr, got:\n" << stderr_text;
-    return 1;
-  }
+  ASSERT_TRUE(command_succeeded(status)) << "stderr:\n"
+                                         << stderr_text << "\nstdout:\n"
+                                         << stdout_text;
+  EXPECT_TRUE(stderr_text.empty()) << stderr_text;
 
   const std::array<std::string_view, 5> expected = {
       "rj_dbt_translate: ok", "source_words: bf8cc07f", "source: s_waitcnt",
       "target_words:",        "target: s_wait",
   };
   for (const std::string_view needle : expected) {
-    if (!contains(stdout_text, needle)) {
-      std::cerr << "missing expected output fragment: " << needle << "\noutput:\n" << stdout_text;
-      return 1;
-    }
+    EXPECT_TRUE(contains(stdout_text, needle))
+        << "missing expected output fragment: " << needle << "\noutput:\n"
+        << stdout_text;
+  }
+}
+
+int main(int argc, char **argv) {
+  if (argc < 2) {
+    std::cerr << "usage: rj_dbt_translate_smoke_test <rj_dbt_translate>\n";
+    return 2;
   }
 
-  return 0;
+  g_translate_tool = argv[1];
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
 }

--- a/emulation/rocjitsu/tests/tools/rj_dbt_translate_smoke_test.cpp
+++ b/emulation/rocjitsu/tests/tools/rj_dbt_translate_smoke_test.cpp
@@ -1,0 +1,265 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file rj_dbt_translate_smoke_test.cpp
+/// @brief End-to-end smoke test for the rj_dbt_translate command-line tool.
+
+#include "rocjitsu/code/amdgpu_elf.h"
+#include "rocjitsu/code/rj_code.h"
+
+#include <array>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <sys/wait.h>
+#include <unistd.h>
+
+namespace {
+
+uint32_t add_elf_name(std::vector<uint8_t> &names, std::string_view name) {
+  const uint32_t offset = static_cast<uint32_t>(names.size());
+  names.insert(names.end(), name.begin(), name.end());
+  names.push_back('\0');
+  return offset;
+}
+
+uint64_t align_up(uint64_t value, uint64_t alignment) {
+  const uint64_t remainder = value % alignment;
+  return remainder == 0 ? value : value + alignment - remainder;
+}
+
+std::vector<uint8_t> make_smoke_code_object() {
+  using namespace rocjitsu;
+
+  constexpr uint64_t text_offset = 0x100;
+  constexpr uint64_t text_vaddr = 0x1100;
+  constexpr uint64_t text_size = 8;
+  constexpr uint64_t load_align = 0x1000;
+  constexpr uint64_t kernel_descriptor_size = 64;
+
+  std::vector<uint8_t> shstrtab{'\0'};
+  const uint32_t text_name = add_elf_name(shstrtab, ".text");
+  const uint32_t rodata_name = add_elf_name(shstrtab, ".rodata");
+  const uint32_t symtab_name = add_elf_name(shstrtab, ".symtab");
+  const uint32_t strtab_name = add_elf_name(shstrtab, ".strtab");
+  const uint32_t shstrtab_name = add_elf_name(shstrtab, ".shstrtab");
+
+  std::vector<uint8_t> strtab{'\0'};
+  const uint32_t kd_symbol_name = add_elf_name(strtab, "smoke.kd");
+
+  const uint64_t rodata_offset = text_offset + text_size;
+  const uint64_t rodata_vaddr = text_vaddr + text_size + load_align;
+  const uint64_t strtab_offset = rodata_offset + kernel_descriptor_size;
+  const uint64_t symtab_offset = align_up(strtab_offset + strtab.size(), 8);
+  constexpr size_t sym_count = 2;
+  const uint64_t shstrtab_offset = symtab_offset + sym_count * sizeof(Elf64_Sym);
+  const uint64_t shoff = align_up(shstrtab_offset + shstrtab.size(), 8);
+  constexpr uint16_t section_count = 6;
+  constexpr uint16_t phdr_count = 2;
+
+  std::vector<uint8_t> image(shoff + section_count * sizeof(Elf64_Shdr), 0);
+
+  Elf64_Ehdr ehdr{};
+  std::memcpy(ehdr.e_ident, EI_MAGIC, EI_MAGIC_SIZE);
+  ehdr.e_ident[EI_CLASS] = ELFCLASS64;
+  ehdr.e_ident[EI_DATA] = 1;
+  ehdr.e_ident[EI_VERSION] = 1;
+  ehdr.e_ident[EI_OSABI] = ELFOSABI_AMDGPU_HSA;
+  ehdr.e_ident[EI_ABIVERSION] = ELFABIVERSION_AMDGPU_HSA_V5;
+  ehdr.e_type = ET_DYN;
+  ehdr.e_machine = EM_AMDGPU;
+  ehdr.e_version = 1;
+  ehdr.e_phoff = sizeof(Elf64_Ehdr);
+  ehdr.e_shoff = shoff;
+  ehdr.e_flags = EF_AMDGPU_MACH_AMDGCN_GFX950;
+  ehdr.e_ehsize = sizeof(Elf64_Ehdr);
+  ehdr.e_phentsize = sizeof(Elf64_Phdr);
+  ehdr.e_phnum = phdr_count;
+  ehdr.e_shentsize = sizeof(Elf64_Shdr);
+  ehdr.e_shnum = section_count;
+  ehdr.e_shstrndx = 5;
+  std::memcpy(image.data(), &ehdr, sizeof(ehdr));
+
+  std::array<Elf64_Phdr, phdr_count> phdrs{};
+  phdrs[0].p_type = PT_LOAD;
+  phdrs[0].p_flags = 0x5; // PF_R | PF_X
+  phdrs[0].p_offset = text_offset;
+  phdrs[0].p_vaddr = text_vaddr;
+  phdrs[0].p_paddr = text_vaddr;
+  phdrs[0].p_filesz = text_size;
+  phdrs[0].p_memsz = text_size;
+  phdrs[0].p_align = load_align;
+
+  phdrs[1].p_type = PT_LOAD;
+  phdrs[1].p_flags = 0x4; // PF_R
+  phdrs[1].p_offset = rodata_offset;
+  phdrs[1].p_vaddr = rodata_vaddr;
+  phdrs[1].p_paddr = rodata_vaddr;
+  phdrs[1].p_filesz = kernel_descriptor_size;
+  phdrs[1].p_memsz = kernel_descriptor_size;
+  phdrs[1].p_align = load_align;
+  std::memcpy(image.data() + ehdr.e_phoff, phdrs.data(), phdrs.size() * sizeof(Elf64_Phdr));
+
+  // Use a CDNA4 waitcnt that lowers to split RDNA4 wait instructions so the
+  // diff report is guaranteed to contain a shown source/target pair.
+  const std::array<uint32_t, 2> text_words = {0xbf8cc07fu, 0xbf810000u};
+  std::memcpy(image.data() + text_offset, text_words.data(), text_size);
+
+  // The DBT pipeline translates kernel entry offsets through AMDHSA kernel
+  // descriptors. For this smoke fixture only the entry offset must be valid;
+  // the remaining descriptor fields can stay zero.
+  constexpr size_t kernel_code_entry_byte_offset_offset = 16;
+  std::array<uint8_t, kernel_descriptor_size> kernel_descriptor{};
+  const int64_t entry_offset =
+      static_cast<int64_t>(text_vaddr) - static_cast<int64_t>(rodata_vaddr);
+  std::memcpy(kernel_descriptor.data() + kernel_code_entry_byte_offset_offset, &entry_offset,
+              sizeof(entry_offset));
+  std::memcpy(image.data() + rodata_offset, kernel_descriptor.data(), kernel_descriptor.size());
+  std::memcpy(image.data() + strtab_offset, strtab.data(), strtab.size());
+
+  std::array<Elf64_Sym, sym_count> syms{};
+  syms[1].st_name = kd_symbol_name;
+  syms[1].st_info = elf_symbol_info(kElfSymbolBindGlobal, kElfSymbolTypeObject);
+  syms[1].st_shndx = 2;
+  syms[1].st_value = rodata_vaddr;
+  syms[1].st_size = kernel_descriptor.size();
+  std::memcpy(image.data() + symtab_offset, syms.data(), syms.size() * sizeof(Elf64_Sym));
+
+  std::memcpy(image.data() + shstrtab_offset, shstrtab.data(), shstrtab.size());
+
+  std::array<Elf64_Shdr, section_count> shdrs{};
+  shdrs[1].sh_name = text_name;
+  shdrs[1].sh_type = SHT_PROGBITS;
+  shdrs[1].sh_flags = SHF_ALLOC | SHF_EXECINSTR;
+  shdrs[1].sh_addr = text_vaddr;
+  shdrs[1].sh_offset = text_offset;
+  shdrs[1].sh_size = text_size;
+  shdrs[1].sh_addralign = sizeof(uint32_t);
+
+  shdrs[2].sh_name = rodata_name;
+  shdrs[2].sh_type = SHT_PROGBITS;
+  shdrs[2].sh_flags = SHF_ALLOC;
+  shdrs[2].sh_addr = rodata_vaddr;
+  shdrs[2].sh_offset = rodata_offset;
+  shdrs[2].sh_size = kernel_descriptor_size;
+  shdrs[2].sh_addralign = 64;
+
+  shdrs[3].sh_name = symtab_name;
+  shdrs[3].sh_type = SHT_SYMTAB;
+  shdrs[3].sh_offset = symtab_offset;
+  shdrs[3].sh_size = syms.size() * sizeof(Elf64_Sym);
+  shdrs[3].sh_link = 4;
+  shdrs[3].sh_info = 1;
+  shdrs[3].sh_addralign = 8;
+  shdrs[3].sh_entsize = sizeof(Elf64_Sym);
+
+  shdrs[4].sh_name = strtab_name;
+  shdrs[4].sh_type = SHT_STRTAB;
+  shdrs[4].sh_offset = strtab_offset;
+  shdrs[4].sh_size = strtab.size();
+  shdrs[4].sh_addralign = 1;
+
+  shdrs[5].sh_name = shstrtab_name;
+  shdrs[5].sh_type = SHT_STRTAB;
+  shdrs[5].sh_offset = shstrtab_offset;
+  shdrs[5].sh_size = shstrtab.size();
+  shdrs[5].sh_addralign = 1;
+
+  std::memcpy(image.data() + shoff, shdrs.data(), shdrs.size() * sizeof(Elf64_Shdr));
+  return image;
+}
+
+std::string shell_quote(std::string_view text) {
+  std::string quoted = "'";
+  for (const char ch : text) {
+    if (ch == '\'')
+      quoted += "'\\''";
+    else
+      quoted += ch;
+  }
+  quoted += "'";
+  return quoted;
+}
+
+std::string read_text_file(const std::filesystem::path &path) {
+  std::ifstream in(path, std::ios::binary);
+  return {std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>()};
+}
+
+bool contains(std::string_view haystack, std::string_view needle) {
+  return haystack.find(needle) != std::string_view::npos;
+}
+
+bool command_succeeded(int status) {
+  return status != -1 && WIFEXITED(status) && WEXITSTATUS(status) == 0;
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+  if (argc != 2) {
+    std::cerr << "usage: rj_dbt_translate_smoke_test <rj_dbt_translate>\n";
+    return 2;
+  }
+
+  const std::filesystem::path temp_dir =
+      std::filesystem::temp_directory_path() /
+      ("rj_dbt_translate_smoke_" + std::to_string(static_cast<long long>(getpid())));
+  std::filesystem::create_directories(temp_dir);
+
+  const auto input = temp_dir / "smoke_gfx950.co";
+  const auto output = temp_dir / "stdout.txt";
+  const auto error = temp_dir / "stderr.txt";
+
+  {
+    const auto image = make_smoke_code_object();
+    std::ofstream out(input, std::ios::binary);
+    out.write(reinterpret_cast<const char *>(image.data()),
+              static_cast<std::streamsize>(image.size()));
+  }
+
+  const std::string command =
+      shell_quote(argv[1]) + " " + shell_quote(input.string()) +
+      " --input-target gfx950 --output-target gfx1200 --output-mode diff > " +
+      shell_quote(output.string()) + " 2> " + shell_quote(error.string());
+
+  const int status = std::system(command.c_str());
+  const std::string stdout_text = read_text_file(output);
+  const std::string stderr_text = read_text_file(error);
+
+  std::filesystem::remove_all(temp_dir);
+
+  if (!command_succeeded(status)) {
+    std::cerr << "rj_dbt_translate failed\nstderr:\n"
+              << stderr_text << "\nstdout:\n"
+              << stdout_text;
+    return 1;
+  }
+
+  if (!stderr_text.empty()) {
+    std::cerr << "expected empty stderr, got:\n" << stderr_text;
+    return 1;
+  }
+
+  const std::array<std::string_view, 5> expected = {
+      "rj_dbt_translate: ok", "source_words: bf8cc07f", "source: s_waitcnt",
+      "target_words:",        "target: s_wait",
+  };
+  for (const std::string_view needle : expected) {
+    if (!contains(stdout_text, needle)) {
+      std::cerr << "missing expected output fragment: " << needle << "\noutput:\n" << stdout_text;
+      return 1;
+    }
+  }
+
+  return 0;
+}

--- a/emulation/rocjitsu/tools/CMakeLists.txt
+++ b/emulation/rocjitsu/tools/CMakeLists.txt
@@ -1,0 +1,38 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+include(rj_configure_target)
+
+set(RJ_TOOL_OBJECT_LIBS
+    rocjitsu_analysis
+    rocjitsu_code
+    rocjitsu_isa
+    rocjitsu_isa_cdna1
+    rocjitsu_isa_cdna2
+    rocjitsu_isa_cdna3
+    rocjitsu_isa_cdna4
+    rocjitsu_isa_rdna1
+    rocjitsu_isa_rdna2
+    rocjitsu_isa_rdna3
+    rocjitsu_isa_rdna3_5
+    rocjitsu_isa_rdna4
+    # The DBT tool only needs generated AMDGPU decoders/disassemblers, but
+    # those object files currently also contain instruction execute methods.
+    # Until generated ISA decode/disassembly is split from VM execution, the
+    # linker needs the AMDGPU VM support referenced by those execute methods.
+    simdojo
+    rocjitsu_vm_amdgpu
+)
+
+add_library(rocjitsu_tooling STATIC dbt_translate.cpp)
+target_include_directories(rocjitsu_tooling PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(rocjitsu_tooling PUBLIC ${CMAKE_SOURCE_DIR})
+target_link_libraries(
+    rocjitsu_tooling
+    PUBLIC ${RJ_TOOL_OBJECT_LIBS} util flatbuffers Threads::Threads
+)
+rj_configure_target(rocjitsu_tooling TOOL)
+
+add_executable(rj_dbt_translate dbt_translate_main.cpp)
+target_link_libraries(rj_dbt_translate PRIVATE rocjitsu_tooling)
+rj_configure_target(rj_dbt_translate TOOL)

--- a/emulation/rocjitsu/tools/dbt_translate.cpp
+++ b/emulation/rocjitsu/tools/dbt_translate.cpp
@@ -1,0 +1,385 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "tools/dbt_translate.h"
+
+#include "rocjitsu/code/amdgpu_code_object.h"
+#include "rocjitsu/code/amdgpu_elf.h"
+#include "rocjitsu/code/dbt/binary_translator.h"
+#include "rocjitsu/code/executable.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+
+#include <exception>
+#include <iomanip>
+#include <memory>
+#include <span>
+#include <sstream>
+#include <utility>
+
+namespace rocjitsu::tools {
+
+namespace {
+
+constexpr int kInputError = 2;
+constexpr int kTranslationError = 3;
+constexpr int kValidationError = 5;
+
+void add_error(ToolResult<TranslateOutput> &result, int exit_code, std::string message) {
+  result.errors.push_back({exit_code, std::move(message)});
+}
+
+struct CodeObjectInspection {
+  CodeObjectReport report;
+  std::string disassembly;
+};
+
+void record_decode_failure(CodeSectionReport &section_report, size_t byte_offset,
+                           std::string message) {
+  ++section_report.decode_failure_count;
+  if (!section_report.has_first_decode_failure) {
+    section_report.has_first_decode_failure = true;
+    section_report.first_decode_failure_offset = byte_offset;
+    section_report.first_decode_failure_message = std::move(message);
+  }
+}
+
+[[nodiscard]] CodeObjectInspection inspect_code_object(const AmdGpuCodeObject &obj,
+                                                       rj_code_arch_t arch,
+                                                       const std::string &label,
+                                                       bool include_disassembly) {
+  CodeObjectInspection inspection;
+  inspection.report.available = true;
+
+  std::ostringstream os;
+  if (include_disassembly)
+    os << "--- " << label << " ---\n";
+
+  auto decoder = Decoder::create(arch);
+  inspection.report.decoder_available = decoder != nullptr;
+  if (!decoder) {
+    if (include_disassembly)
+      os << "decoder unavailable\n";
+    for (const auto *section : obj.code_sections()) {
+      CodeSectionReport section_report;
+      section_report.name = section->name();
+      section_report.size_bytes = section->size();
+      inspection.report.sections.push_back(std::move(section_report));
+    }
+    inspection.disassembly = os.str();
+    return inspection;
+  }
+
+  for (const auto *section : obj.code_sections()) {
+    CodeSectionReport section_report;
+    section_report.name = section->name();
+    section_report.size_bytes = section->size();
+
+    if (include_disassembly)
+      os << "section " << section->name() << " size=" << section->size() << "\n";
+
+    const auto *words = reinterpret_cast<const uint32_t *>(section->data());
+    const size_t word_count = section->size() / sizeof(uint32_t);
+    size_t pc = 0;
+
+    while (pc < word_count) {
+      try {
+        std::unique_ptr<Instruction> inst(decoder->decode(&words[pc]));
+        if (!inst) {
+          record_decode_failure(section_report, pc * sizeof(uint32_t), "decode returned null");
+          if (include_disassembly) {
+            os << "  0x" << std::hex << std::setw(4) << std::setfill('0') << pc * 4
+               << ": <decode returned null>\n"
+               << std::dec << std::setfill(' ');
+          }
+          ++pc;
+          continue;
+        }
+
+        const uint32_t inst_words = inst->size() / sizeof(uint32_t);
+        ++section_report.instruction_count;
+        if (include_disassembly) {
+          os << "  0x" << std::hex << std::setw(4) << std::setfill('0') << pc * 4 << ": "
+             << std::dec << std::setfill(' ') << inst->disassemble() << " [";
+          for (uint32_t i = 0; i < inst_words && pc + i < word_count; ++i) {
+            if (i != 0)
+              os << ' ';
+            os << std::hex << std::setw(8) << std::setfill('0') << words[pc + i];
+          }
+          os << std::dec << std::setfill(' ') << "]\n";
+        }
+        pc += inst_words == 0 ? 1 : inst_words;
+      } catch (const std::exception &e) {
+        record_decode_failure(section_report, pc * sizeof(uint32_t), e.what());
+        if (include_disassembly) {
+          os << "  0x" << std::hex << std::setw(4) << std::setfill('0') << pc * 4
+             << ": <decode error: " << e.what() << ">\n"
+             << std::dec << std::setfill(' ');
+        }
+        ++pc;
+      }
+    }
+
+    inspection.report.sections.push_back(std::move(section_report));
+  }
+
+  inspection.disassembly = os.str();
+  return inspection;
+}
+
+[[nodiscard]] std::string format_offset(size_t offset) {
+  std::ostringstream os;
+  os << "0x" << std::hex << offset;
+  return os.str();
+}
+
+[[nodiscard]] bool validate_host_decode(const CodeObjectReport &report, std::string &error) {
+  if (!report.available) {
+    error = "translated output was not inspected";
+    return false;
+  }
+  if (!report.decoder_available) {
+    error = "host decoder unavailable";
+    return false;
+  }
+
+  size_t inst_count = 0;
+  size_t failures = 0;
+  const CodeSectionReport *first_failed_section = nullptr;
+  for (const auto &section : report.sections) {
+    inst_count += section.instruction_count;
+    failures += section.decode_failure_count;
+    if (first_failed_section == nullptr && section.has_first_decode_failure)
+      first_failed_section = &section;
+  }
+
+  if (inst_count == 0) {
+    error = "translated output contains no decodable host instructions";
+    return false;
+  }
+  if (failures != 0) {
+    error = std::to_string(failures) + " translated instructions failed host decode";
+    if (first_failed_section != nullptr) {
+      error += " (first failure in " + first_failed_section->name + " at " +
+               format_offset(first_failed_section->first_decode_failure_offset) + ": " +
+               first_failed_section->first_decode_failure_message + ")";
+    }
+    return false;
+  }
+
+  return true;
+}
+
+[[nodiscard]] std::string disassemble_source_instruction(const AmdGpuCodeObject &obj,
+                                                         uint64_t offset, rj_code_arch_t arch) {
+  auto decoder = Decoder::create(arch);
+  if (!decoder)
+    return "<decoder unavailable>";
+
+  const auto &text_sections = obj.text_sections();
+  if (text_sections.empty())
+    return "<source section unavailable>";
+
+  // BinaryTranslator trace offsets are relative to the original .text section.
+  // Use text_sections() instead of code_sections() so the DBT cave never shifts
+  // source locations when a translated object is inspected again.
+  const auto *text = text_sections.front();
+  if (offset % sizeof(uint32_t) != 0)
+    return "<source offset unaligned>";
+  if (offset + sizeof(uint32_t) > text->size())
+    return "<source offset out of range>";
+
+  const auto *words = reinterpret_cast<const uint32_t *>(text->data());
+  try {
+    std::unique_ptr<Instruction> inst(decoder->decode(&words[offset / sizeof(uint32_t)]));
+    if (!inst)
+      return "<decode returned null>";
+    return inst->disassemble();
+  } catch (const std::exception &e) {
+    return std::string("<decode error: ") + e.what() + ">";
+  }
+}
+
+[[nodiscard]] std::vector<std::string> disassemble_words(std::span<const uint32_t> words,
+                                                         rj_code_arch_t arch) {
+  std::vector<std::string> lines;
+  auto decoder = Decoder::create(arch);
+  if (!decoder) {
+    lines.push_back("<decoder unavailable>");
+    return lines;
+  }
+
+  size_t pc = 0;
+  while (pc < words.size()) {
+    try {
+      std::unique_ptr<Instruction> inst(decoder->decode(&words[pc]));
+      if (!inst) {
+        lines.push_back("<decode returned null>");
+        ++pc;
+        continue;
+      }
+
+      lines.push_back(inst->disassemble());
+      const uint32_t inst_words = inst->size() / sizeof(uint32_t);
+      pc += inst_words == 0 ? 1 : inst_words;
+    } catch (const std::exception &e) {
+      lines.push_back(std::string("<decode error: ") + e.what() + ">");
+      ++pc;
+    }
+  }
+
+  return lines;
+}
+
+[[nodiscard]] InstructionTranslationReport
+build_instruction_report(const TranslationTraceEvent &trace, const AmdGpuCodeObject &source,
+                         rj_code_arch_t guest_arch, rj_code_arch_t host_arch) {
+  InstructionTranslationReport report;
+  report.source_offset = trace.source_offset;
+  report.source_size = trace.source_size;
+  report.source_words.assign(trace.source_words.begin(), trace.source_words.end());
+  report.source_instruction =
+      disassemble_source_instruction(source, trace.source_offset, guest_arch);
+  report.has_legalization = trace.legalization != nullptr;
+  report.action = trace.legalization ? trace.legalization->action : Action::Identity;
+  report.copied_original = trace.copied_original;
+  report.semantic_lowering = trace.semantic_lowering;
+  report.changed = trace.changed;
+  report.emitted_in_cave = trace.emitted_in_cave;
+  report.target_offset = trace.target_offset;
+  report.target_words.assign(trace.target_words.begin(), trace.target_words.end());
+  report.target_instructions = disassemble_words(report.target_words, host_arch);
+  return report;
+}
+
+struct SelectedInput {
+  std::unique_ptr<Executable> executable;
+  std::unique_ptr<AmdGpuCodeObject> direct_code_object;
+  const AmdGpuCodeObject *code_object = nullptr;
+};
+
+[[nodiscard]] SelectedInput select_input(const TranslateOptions &options, std::string &error) {
+  SelectedInput selected;
+
+  selected.executable = std::make_unique<Executable>(options.input_path);
+  if (selected.executable->is_valid()) {
+    if (options.input_target == ROCJITSU_CODE_TARGET_INVALID) {
+      error = "input target is not selectable from executable inputs: " + options.input_path;
+      selected.executable.reset();
+      return selected;
+    }
+
+    selected.code_object =
+        selected.executable->code_object(options.input_target, options.code_object_index);
+    if (selected.code_object != nullptr)
+      return selected;
+
+    error = "failed to select requested code object from executable: " + options.input_path;
+    selected.executable.reset();
+    return selected;
+  }
+
+  // Try executable inputs first, then standalone AMDGPU code-object ELFs. This
+  // keeps the CLI convenient for both HIP objects and already-extracted DBT
+  // outputs without exposing a mode flag.
+  selected.executable.reset();
+  selected.direct_code_object = std::make_unique<AmdGpuCodeObject>(options.input_path);
+  if (!selected.direct_code_object->is_valid()) {
+    error = "failed to parse input as an AMDGPU code object: " + options.input_path;
+    selected.direct_code_object.reset();
+    return selected;
+  }
+
+  selected.code_object = selected.direct_code_object.get();
+  return selected;
+}
+
+} // namespace
+
+ToolResult<TranslateOutput> translate_code_object(const TranslateOptions &options) {
+  ToolResult<TranslateOutput> output;
+  output.value.host_arch = options.host_arch;
+  output.value.target_mach =
+      options.target_mach ? options.target_mach : elf_mach_for_arch(options.host_arch);
+
+  if (options.input_path.empty()) {
+    add_error(output, kInputError, "input path is required");
+    return output;
+  }
+
+  std::string error;
+  SelectedInput input = select_input(options, error);
+  if (input.code_object == nullptr) {
+    add_error(output, kInputError, error.empty() ? "failed to load input" : error);
+    return output;
+  }
+
+  const bool need_report = options.collect_diagnostics;
+  const bool need_source_disassembly = options.disassembly == DisassemblyMode::Source ||
+                                       options.disassembly == DisassemblyMode::Both;
+  const bool need_translated_disassembly = options.disassembly == DisassemblyMode::Translated ||
+                                           options.disassembly == DisassemblyMode::Both;
+
+  if (need_report || need_source_disassembly) {
+    auto source_inspection = inspect_code_object(*input.code_object, options.guest_arch, "source",
+                                                 need_source_disassembly);
+    output.value.source_report = std::move(source_inspection.report);
+    output.value.disassembly += source_inspection.disassembly;
+  }
+
+  try {
+    BinaryTranslatorOptions translator_options;
+    translator_options.debug_min_free_vgpr = options.debug_min_free_vgpr;
+    translator_options.debug_continue_after_failure = options.debug_continue_after_failure;
+    BinaryTranslator translator(options.guest_arch, options.host_arch, options.target_mach,
+                                translator_options);
+    if (need_report) {
+      output.value.instruction_translations.clear();
+      translator.set_trace_callback([&](const TranslationTraceEvent &trace) {
+        output.value.instruction_translations.push_back(build_instruction_report(
+            trace, *input.code_object, options.guest_arch, options.host_arch));
+      });
+    }
+    auto translated = translator.translate(*input.code_object);
+    output.value.elf_bytes = std::move(translated.elf_bytes);
+    output.value.host_arch = translated.host_arch;
+    output.value.target_mach =
+        options.target_mach ? options.target_mach : elf_mach_for_arch(output.value.host_arch);
+    output.value.diagnostics = std::move(translated.diagnostics);
+  } catch (const std::exception &e) {
+    add_error(output, kTranslationError, std::string("translation threw exception: ") + e.what());
+    return output;
+  }
+
+  if (has_error_diagnostic(output.value.diagnostics)) {
+    add_error(output, kTranslationError, "translation failed");
+    return output;
+  }
+
+  if (output.value.elf_bytes.empty()) {
+    add_error(output, kTranslationError, "translation produced an empty ELF image");
+    return output;
+  }
+
+  AmdGpuCodeObject translated_obj(output.value.elf_bytes.data(), output.value.elf_bytes.size());
+  if (!translated_obj.is_valid()) {
+    add_error(output, kTranslationError, "translation produced an invalid AMDGPU code object");
+    return output;
+  }
+
+  {
+    auto translated_inspection = inspect_code_object(translated_obj, options.host_arch,
+                                                     "translated", need_translated_disassembly);
+    output.value.translated_report = std::move(translated_inspection.report);
+    output.value.disassembly += translated_inspection.disassembly;
+  }
+
+  if (!validate_host_decode(output.value.translated_report, error)) {
+    add_error(output, kValidationError, error);
+    return output;
+  }
+
+  return output;
+}
+
+} // namespace rocjitsu::tools

--- a/emulation/rocjitsu/tools/dbt_translate.h
+++ b/emulation/rocjitsu/tools/dbt_translate.h
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file dbt_translate.h
+/// @brief Internal entry point for the rj_dbt_translate CLI and tests.
+
+#ifndef ROCJITSU_TOOLS_DBT_TRANSLATE_H_
+#define ROCJITSU_TOOLS_DBT_TRANSLATE_H_
+
+#include "rocjitsu/code/dbt/generated/legalization_types.h"
+#include "rocjitsu/code/dbt/translation_diagnostic.h"
+#include "rocjitsu/code/rj_code.h"
+#include "tools/tool_result.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace rocjitsu::tools {
+
+enum class DisassemblyMode {
+  None,
+  Source,
+  Translated,
+  Both,
+};
+
+struct CodeSectionReport {
+  std::string name;
+  size_t size_bytes = 0;
+  size_t instruction_count = 0;
+  size_t decode_failure_count = 0;
+
+  // Store the first failing offset so the text report points developers at a
+  // concrete location without retaining every failed decode in memory.
+  bool has_first_decode_failure = false;
+  size_t first_decode_failure_offset = 0;
+  std::string first_decode_failure_message;
+};
+
+struct CodeObjectReport {
+  bool available = false;
+  bool decoder_available = false;
+  std::vector<CodeSectionReport> sections;
+};
+
+struct InstructionTranslationReport {
+  uint64_t source_offset = 0;
+  uint32_t source_size = 0;
+  std::vector<uint32_t> source_words;
+  std::string source_instruction;
+  bool has_legalization = false;
+  Action action = Action::Identity;
+  bool copied_original = false;
+  bool semantic_lowering = false;
+  bool changed = false;
+  bool emitted_in_cave = false;
+  uint64_t target_offset = 0;
+  std::vector<uint32_t> target_words;
+  std::vector<std::string> target_instructions;
+};
+
+struct TranslateOptions {
+  std::string input_path;
+
+  rj_code_target_id_t input_target = ROCJITSU_CODE_TARGET_GFX950;
+  uint32_t code_object_index = 0;
+
+  rj_code_arch_t guest_arch = ROCJITSU_CODE_ARCH_CDNA4;
+  rj_code_arch_t host_arch = ROCJITSU_CODE_ARCH_RDNA4;
+  uint32_t target_mach = 0;
+
+  bool collect_diagnostics = false;
+  std::optional<uint16_t> debug_min_free_vgpr;
+  bool debug_continue_after_failure = false;
+  DisassemblyMode disassembly = DisassemblyMode::None;
+};
+
+struct TranslateOutput {
+  std::vector<uint8_t> elf_bytes;
+  rj_code_arch_t host_arch = ROCJITSU_CODE_ARCH_INVALID;
+  uint32_t target_mach = 0;
+  CodeObjectReport source_report;
+  CodeObjectReport translated_report;
+  std::vector<InstructionTranslationReport> instruction_translations;
+  std::vector<TranslationDiagnostic> diagnostics;
+  std::string disassembly;
+};
+
+/// @brief Translate one AMDGPU code object using the DBT pipeline.
+///
+/// This is an internal repo-facing API. It is deliberately small and mirrors the
+/// CLI behavior so tests can avoid process management when they need direct
+/// access to translated bytes or structured diagnostics.
+[[nodiscard]] ToolResult<TranslateOutput> translate_code_object(const TranslateOptions &options);
+
+} // namespace rocjitsu::tools
+
+#endif // ROCJITSU_TOOLS_DBT_TRANSLATE_H_

--- a/emulation/rocjitsu/tools/dbt_translate_main.cpp
+++ b/emulation/rocjitsu/tools/dbt_translate_main.cpp
@@ -7,6 +7,7 @@
 #include "rocjitsu/code/amdgpu_elf.h"
 #include "rocjitsu/code/executable.h"
 
+#include <array>
 #include <charconv>
 #include <cstdint>
 #include <iomanip>
@@ -37,6 +38,15 @@ struct TargetInfo {
   rj_code_target_id_t code_object_target;
 };
 
+constexpr std::array<TargetInfo, 4> kTargetInfos = {{
+    {"gfx942", ROCJITSU_CODE_ARCH_CDNA3, EF_AMDGPU_MACH_AMDGCN_GFX942, ROCJITSU_CODE_TARGET_GFX942},
+    {"gfx950", ROCJITSU_CODE_ARCH_CDNA4, EF_AMDGPU_MACH_AMDGCN_GFX950, ROCJITSU_CODE_TARGET_GFX950},
+    {"gfx1200", ROCJITSU_CODE_ARCH_RDNA4, EF_AMDGPU_MACH_AMDGCN_GFX1200,
+     ROCJITSU_CODE_TARGET_GFX1200},
+    {"gfx1201", ROCJITSU_CODE_ARCH_RDNA4, EF_AMDGPU_MACH_AMDGCN_GFX1201,
+     ROCJITSU_CODE_TARGET_GFX1201},
+}};
+
 struct CliOptions {
   TranslateOptions translate;
   std::string input_target_name;
@@ -49,6 +59,14 @@ struct CliOptions {
   bool saw_output_target = false;
 };
 
+void print_supported_targets(std::ostream &os) {
+  for (size_t i = 0; i < kTargetInfos.size(); ++i) {
+    if (i != 0)
+      os << ", ";
+    os << kTargetInfos[i].name;
+  }
+}
+
 void print_help() {
   std::cout
       << "Usage: rj_dbt_translate INPUT --input-target TARGET --output-target TARGET "
@@ -58,12 +76,13 @@ void print_help() {
       << "  --output-target TARGET          Output LLVM machine, e.g. gfx1200\n"
       << "  --code-object-index N           Code-object index for executable input (default: 0)\n"
       << "  --output-mode MODE              disasm, code-object, or diff (default: disasm)\n"
-      << "  --debug-conservative-liveness N  Only allocate free VGPR scratch at or above N\n"
+      << "  --debug-conservative-liveness N Only allocate free VGPR scratch at or above N\n"
       << "  --debug-continue-after-failure Continue collecting diagnostics after failures\n"
       << "  --list-code-objects             List extractable code objects and exit\n"
       << "  --help                          Show this help\n\n"
-      << "Supported target names: gfx908, gfx90a, gfx940, gfx941, gfx942, gfx950, "
-         "gfx1010, gfx1030, gfx1100, gfx1150, gfx1200, gfx1201.\n";
+      << "Supported target names: ";
+  print_supported_targets(std::cout);
+  std::cout << ".\n";
 }
 
 [[nodiscard]] bool parse_u32(std::string_view text, uint32_t &value) {
@@ -79,42 +98,10 @@ void print_help() {
 }
 
 [[nodiscard]] std::optional<TargetInfo> parse_target_info(std::string_view value) {
-  if (value == "gfx908")
-    return TargetInfo{value, ROCJITSU_CODE_ARCH_CDNA1, EF_AMDGPU_MACH_AMDGCN_GFX908,
-                      ROCJITSU_CODE_TARGET_INVALID};
-  if (value == "gfx90a")
-    return TargetInfo{value, ROCJITSU_CODE_ARCH_CDNA2, EF_AMDGPU_MACH_AMDGCN_GFX90A,
-                      ROCJITSU_CODE_TARGET_INVALID};
-  if (value == "gfx940")
-    return TargetInfo{value, ROCJITSU_CODE_ARCH_CDNA3, EF_AMDGPU_MACH_AMDGCN_GFX940,
-                      ROCJITSU_CODE_TARGET_INVALID};
-  if (value == "gfx941")
-    return TargetInfo{value, ROCJITSU_CODE_ARCH_CDNA3, EF_AMDGPU_MACH_AMDGCN_GFX941,
-                      ROCJITSU_CODE_TARGET_INVALID};
-  if (value == "gfx942")
-    return TargetInfo{value, ROCJITSU_CODE_ARCH_CDNA3, EF_AMDGPU_MACH_AMDGCN_GFX942,
-                      ROCJITSU_CODE_TARGET_GFX942};
-  if (value == "gfx950")
-    return TargetInfo{value, ROCJITSU_CODE_ARCH_CDNA4, EF_AMDGPU_MACH_AMDGCN_GFX950,
-                      ROCJITSU_CODE_TARGET_GFX950};
-  if (value == "gfx1010")
-    return TargetInfo{value, ROCJITSU_CODE_ARCH_RDNA1, EF_AMDGPU_MACH_AMDGCN_GFX1010,
-                      ROCJITSU_CODE_TARGET_INVALID};
-  if (value == "gfx1030")
-    return TargetInfo{value, ROCJITSU_CODE_ARCH_RDNA2, EF_AMDGPU_MACH_AMDGCN_GFX1030,
-                      ROCJITSU_CODE_TARGET_INVALID};
-  if (value == "gfx1100")
-    return TargetInfo{value, ROCJITSU_CODE_ARCH_RDNA3, EF_AMDGPU_MACH_AMDGCN_GFX1100,
-                      ROCJITSU_CODE_TARGET_INVALID};
-  if (value == "gfx1150")
-    return TargetInfo{value, ROCJITSU_CODE_ARCH_RDNA3_5, EF_AMDGPU_MACH_AMDGCN_GFX1150,
-                      ROCJITSU_CODE_TARGET_INVALID};
-  if (value == "gfx1200")
-    return TargetInfo{value, ROCJITSU_CODE_ARCH_RDNA4, EF_AMDGPU_MACH_AMDGCN_GFX1200,
-                      ROCJITSU_CODE_TARGET_INVALID};
-  if (value == "gfx1201")
-    return TargetInfo{value, ROCJITSU_CODE_ARCH_RDNA4, EF_AMDGPU_MACH_AMDGCN_GFX1201,
-                      ROCJITSU_CODE_TARGET_INVALID};
+  for (const TargetInfo &target : kTargetInfos) {
+    if (value == target.name)
+      return target;
+  }
   return std::nullopt;
 }
 
@@ -481,8 +468,10 @@ int list_code_objects(const CliOptions &options) {
 
   Executable executable(options.translate.input_path);
   if (executable.is_valid()) {
-    std::cout << "gfx942: " << executable.num_code_objects(ROCJITSU_CODE_TARGET_GFX942) << "\n";
-    std::cout << "gfx950: " << executable.num_code_objects(ROCJITSU_CODE_TARGET_GFX950) << "\n";
+    for (const TargetInfo &target : kTargetInfos) {
+      std::cout << target.name << ": " << executable.num_code_objects(target.code_object_target)
+                << "\n";
+    }
     return 0;
   }
 

--- a/emulation/rocjitsu/tools/dbt_translate_main.cpp
+++ b/emulation/rocjitsu/tools/dbt_translate_main.cpp
@@ -1,0 +1,559 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "tools/dbt_translate.h"
+
+#include "rocjitsu/code/amdgpu_code_object.h"
+#include "rocjitsu/code/amdgpu_elf.h"
+#include "rocjitsu/code/executable.h"
+
+#include <charconv>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <string_view>
+
+using namespace rocjitsu;
+using namespace rocjitsu::tools;
+
+namespace {
+
+constexpr int kUsageError = 1;
+constexpr int kOutputError = 4;
+
+enum class OutputMode {
+  Disasm,
+  CodeObject,
+  Diff,
+};
+
+struct TargetInfo {
+  std::string_view name;
+  rj_code_arch_t arch;
+  uint32_t mach;
+  rj_code_target_id_t code_object_target;
+};
+
+struct CliOptions {
+  TranslateOptions translate;
+  std::string input_target_name;
+  std::string output_target_name;
+  OutputMode output_mode = OutputMode::Disasm;
+  bool list_code_objects = false;
+  bool show_help = false;
+  bool saw_input = false;
+  bool saw_input_target = false;
+  bool saw_output_target = false;
+};
+
+void print_help() {
+  std::cout
+      << "Usage: rj_dbt_translate INPUT --input-target TARGET --output-target TARGET "
+         "[options]\n\n"
+      << "Options:\n"
+      << "  --input-target TARGET           Input LLVM machine, e.g. gfx950\n"
+      << "  --output-target TARGET          Output LLVM machine, e.g. gfx1200\n"
+      << "  --code-object-index N           Code-object index for executable input (default: 0)\n"
+      << "  --output-mode MODE              disasm, code-object, or diff (default: disasm)\n"
+      << "  --debug-conservative-liveness N  Only allocate free VGPR scratch at or above N\n"
+      << "  --debug-continue-after-failure Continue collecting diagnostics after failures\n"
+      << "  --list-code-objects             List extractable code objects and exit\n"
+      << "  --help                          Show this help\n\n"
+      << "Supported target names: gfx908, gfx90a, gfx940, gfx941, gfx942, gfx950, "
+         "gfx1010, gfx1030, gfx1100, gfx1150, gfx1200, gfx1201.\n";
+}
+
+[[nodiscard]] bool parse_u32(std::string_view text, uint32_t &value) {
+  int base = 10;
+  if (text.size() > 2 && text[0] == '0' && (text[1] == 'x' || text[1] == 'X')) {
+    text.remove_prefix(2);
+    base = 16;
+  }
+  auto *begin = text.data();
+  auto *end = text.data() + text.size();
+  auto [ptr, ec] = std::from_chars(begin, end, value, base);
+  return ec == std::errc{} && ptr == end;
+}
+
+[[nodiscard]] std::optional<TargetInfo> parse_target_info(std::string_view value) {
+  if (value == "gfx908")
+    return TargetInfo{value, ROCJITSU_CODE_ARCH_CDNA1, EF_AMDGPU_MACH_AMDGCN_GFX908,
+                      ROCJITSU_CODE_TARGET_INVALID};
+  if (value == "gfx90a")
+    return TargetInfo{value, ROCJITSU_CODE_ARCH_CDNA2, EF_AMDGPU_MACH_AMDGCN_GFX90A,
+                      ROCJITSU_CODE_TARGET_INVALID};
+  if (value == "gfx940")
+    return TargetInfo{value, ROCJITSU_CODE_ARCH_CDNA3, EF_AMDGPU_MACH_AMDGCN_GFX940,
+                      ROCJITSU_CODE_TARGET_INVALID};
+  if (value == "gfx941")
+    return TargetInfo{value, ROCJITSU_CODE_ARCH_CDNA3, EF_AMDGPU_MACH_AMDGCN_GFX941,
+                      ROCJITSU_CODE_TARGET_INVALID};
+  if (value == "gfx942")
+    return TargetInfo{value, ROCJITSU_CODE_ARCH_CDNA3, EF_AMDGPU_MACH_AMDGCN_GFX942,
+                      ROCJITSU_CODE_TARGET_GFX942};
+  if (value == "gfx950")
+    return TargetInfo{value, ROCJITSU_CODE_ARCH_CDNA4, EF_AMDGPU_MACH_AMDGCN_GFX950,
+                      ROCJITSU_CODE_TARGET_GFX950};
+  if (value == "gfx1010")
+    return TargetInfo{value, ROCJITSU_CODE_ARCH_RDNA1, EF_AMDGPU_MACH_AMDGCN_GFX1010,
+                      ROCJITSU_CODE_TARGET_INVALID};
+  if (value == "gfx1030")
+    return TargetInfo{value, ROCJITSU_CODE_ARCH_RDNA2, EF_AMDGPU_MACH_AMDGCN_GFX1030,
+                      ROCJITSU_CODE_TARGET_INVALID};
+  if (value == "gfx1100")
+    return TargetInfo{value, ROCJITSU_CODE_ARCH_RDNA3, EF_AMDGPU_MACH_AMDGCN_GFX1100,
+                      ROCJITSU_CODE_TARGET_INVALID};
+  if (value == "gfx1150")
+    return TargetInfo{value, ROCJITSU_CODE_ARCH_RDNA3_5, EF_AMDGPU_MACH_AMDGCN_GFX1150,
+                      ROCJITSU_CODE_TARGET_INVALID};
+  if (value == "gfx1200")
+    return TargetInfo{value, ROCJITSU_CODE_ARCH_RDNA4, EF_AMDGPU_MACH_AMDGCN_GFX1200,
+                      ROCJITSU_CODE_TARGET_INVALID};
+  if (value == "gfx1201")
+    return TargetInfo{value, ROCJITSU_CODE_ARCH_RDNA4, EF_AMDGPU_MACH_AMDGCN_GFX1201,
+                      ROCJITSU_CODE_TARGET_INVALID};
+  return std::nullopt;
+}
+
+[[nodiscard]] std::optional<OutputMode> parse_output_mode(std::string_view value) {
+  if (value == "disasm")
+    return OutputMode::Disasm;
+  if (value == "code-object")
+    return OutputMode::CodeObject;
+  if (value == "diff")
+    return OutputMode::Diff;
+  return std::nullopt;
+}
+
+[[nodiscard]] bool require_value(int argc, char **argv, int &index, std::string_view flag,
+                                 std::string_view &value) {
+  if (index + 1 >= argc) {
+    std::cerr << "missing value for " << flag << "\n";
+    return false;
+  }
+  ++index;
+  value = argv[index];
+  return true;
+}
+
+[[nodiscard]] bool parse_args(int argc, char **argv, CliOptions &options) {
+  for (int i = 1; i < argc; ++i) {
+    std::string_view arg = argv[i];
+    std::string_view value;
+
+    if (arg == "--help" || arg == "-h") {
+      options.show_help = true;
+      return true;
+    }
+    if (arg == "--list-code-objects") {
+      options.list_code_objects = true;
+      continue;
+    }
+    if (arg == "--debug-conservative-liveness") {
+      if (!require_value(argc, argv, i, arg, value))
+        return false;
+      uint32_t min_free_vgpr = 0;
+      if (!parse_u32(value, min_free_vgpr) || min_free_vgpr > UINT16_MAX) {
+        std::cerr << "invalid minimum free VGPR for " << arg << ": " << value << "\n";
+        return false;
+      }
+      options.translate.debug_min_free_vgpr = static_cast<uint16_t>(min_free_vgpr);
+      continue;
+    }
+    if (arg == "--debug-continue-after-failure") {
+      options.translate.debug_continue_after_failure = true;
+      continue;
+    }
+
+    if (arg == "--input-target") {
+      if (!require_value(argc, argv, i, arg, value))
+        return false;
+      auto target = parse_target_info(value);
+      if (!target) {
+        std::cerr << "invalid input target: " << value << "\n";
+        return false;
+      }
+      options.translate.guest_arch = target->arch;
+      options.translate.input_target = target->code_object_target;
+      options.input_target_name = std::string(target->name);
+      options.saw_input_target = true;
+    } else if (arg == "--output-target") {
+      if (!require_value(argc, argv, i, arg, value))
+        return false;
+      auto target = parse_target_info(value);
+      if (!target) {
+        std::cerr << "invalid output target: " << value << "\n";
+        return false;
+      }
+      options.translate.host_arch = target->arch;
+      options.translate.target_mach = target->mach;
+      options.output_target_name = std::string(target->name);
+      options.saw_output_target = true;
+    } else if (arg == "--code-object-index") {
+      if (!require_value(argc, argv, i, arg, value))
+        return false;
+      if (!parse_u32(value, options.translate.code_object_index)) {
+        std::cerr << "invalid code-object index: " << value << "\n";
+        return false;
+      }
+    } else if (arg == "--output-mode") {
+      if (!require_value(argc, argv, i, arg, value))
+        return false;
+      auto mode = parse_output_mode(value);
+      if (!mode) {
+        std::cerr << "invalid output mode: " << value << "\n";
+        return false;
+      }
+      options.output_mode = *mode;
+    } else {
+      if (!arg.empty() && arg.front() != '-') {
+        if (options.saw_input) {
+          std::cerr << "unexpected positional argument: " << arg << "\n";
+          return false;
+        }
+        options.translate.input_path = std::string(arg);
+        options.saw_input = true;
+        continue;
+      }
+      std::cerr << "unknown option: " << arg << "\n";
+      return false;
+    }
+  }
+
+  return true;
+}
+
+struct ReportTotals {
+  size_t size_bytes = 0;
+  size_t instruction_count = 0;
+  size_t decode_failure_count = 0;
+};
+
+[[nodiscard]] ReportTotals report_totals(const CodeObjectReport &report) {
+  ReportTotals totals;
+  for (const auto &section : report.sections) {
+    totals.size_bytes += section.size_bytes;
+    totals.instruction_count += section.instruction_count;
+    totals.decode_failure_count += section.decode_failure_count;
+  }
+  return totals;
+}
+
+[[nodiscard]] size_t text_section_size(const CodeObjectReport &report) {
+  for (const auto &section : report.sections) {
+    if (section.name == ".text")
+      return section.size_bytes;
+  }
+  return 0;
+}
+
+[[nodiscard]] std::string hex_offset(uint64_t value) {
+  std::ostringstream os;
+  os << "0x" << std::hex << std::setw(4) << std::setfill('0') << value;
+  return os.str();
+}
+
+[[nodiscard]] std::string words_text(const std::vector<uint32_t> &words) {
+  std::ostringstream os;
+  for (size_t i = 0; i < words.size(); ++i) {
+    if (i != 0)
+      os << ' ';
+    os << std::hex << std::setw(8) << std::setfill('0') << words[i];
+  }
+  return os.str();
+}
+
+[[nodiscard]] const char *diagnostic_severity_name(DiagnosticSeverity severity) {
+  switch (severity) {
+  case DiagnosticSeverity::Warning:
+    return "warning";
+  case DiagnosticSeverity::Error:
+    return "error";
+  }
+  return "diagnostic";
+}
+
+[[nodiscard]] const char *diagnostic_kind_name(DiagnosticKind kind) {
+  switch (kind) {
+  case DiagnosticKind::UnsupportedGuestArch:
+    return "unsupported-guest-arch";
+  case DiagnosticKind::KernelDescriptor:
+    return "kernel-descriptor";
+  case DiagnosticKind::Legalization:
+    return "legalization";
+  case DiagnosticKind::ExpandMissing:
+    return "expand-missing";
+  case DiagnosticKind::ExpandFailed:
+    return "expand-failed";
+  case DiagnosticKind::ResourceLimit:
+    return "resource-limit";
+  }
+  return "unknown";
+}
+
+void print_diagnostic(std::ostream &os, const TranslationDiagnostic &diagnostic) {
+  os << diagnostic_severity_name(diagnostic.severity) << ": "
+     << diagnostic_kind_name(diagnostic.kind);
+  if (diagnostic.guest_offset)
+    os << " .text+" << hex_offset(*diagnostic.guest_offset);
+  if (!diagnostic.mnemonic.empty())
+    os << " " << diagnostic.mnemonic;
+  os << ": " << diagnostic.message << "\n";
+  for (const auto &item : diagnostic.required_work)
+    os << "  required: " << item << "\n";
+}
+
+[[nodiscard]] const char *legalization_action_name(Action action) {
+  switch (action) {
+  case Action::Identity:
+    return "identity";
+  case Action::Substitute:
+    return "substitute";
+  case Action::Lower:
+    return "lower";
+  case Action::Expand:
+    return "expand";
+  case Action::Illegal:
+    return "illegal";
+  }
+  return "unknown";
+}
+
+[[nodiscard]] std::string translation_action_text(const InstructionTranslationReport &translation) {
+  if (translation.copied_original)
+    return "copy_original";
+  if (!translation.has_legalization)
+    return "encode";
+
+  std::string text = legalization_action_name(translation.action);
+  if (translation.semantic_lowering)
+    text += " semantic";
+  return text;
+}
+
+[[nodiscard]] bool should_show_translation(const InstructionTranslationReport &translation) {
+  if (translation.copied_original ||
+      (translation.has_legalization && translation.action == Action::Identity))
+    return translation.changed || translation.emitted_in_cave;
+  return true;
+}
+
+[[nodiscard]] size_t count_action(const std::vector<InstructionTranslationReport> &translations,
+                                  Action action) {
+  size_t count = 0;
+  for (const auto &translation : translations) {
+    if (!translation.copied_original && translation.has_legalization &&
+        translation.action == action)
+      ++count;
+  }
+  return count;
+}
+
+[[nodiscard]] size_t
+count_runtime_encode(const std::vector<InstructionTranslationReport> &translations) {
+  size_t count = 0;
+  for (const auto &translation : translations) {
+    if (!translation.copied_original && !translation.has_legalization)
+      ++count;
+  }
+  return count;
+}
+
+[[nodiscard]] size_t
+count_copied_original(const std::vector<InstructionTranslationReport> &translations) {
+  size_t count = 0;
+  for (const auto &translation : translations) {
+    if (translation.copied_original)
+      ++count;
+  }
+  return count;
+}
+
+[[nodiscard]] size_t
+count_semantic_lowerings(const std::vector<InstructionTranslationReport> &translations) {
+  size_t count = 0;
+  for (const auto &translation : translations) {
+    if (translation.semantic_lowering)
+      ++count;
+  }
+  return count;
+}
+
+[[nodiscard]] std::string target_location(const InstructionTranslationReport &translation,
+                                          size_t text_size) {
+  if (translation.emitted_in_cave && translation.target_offset >= text_size)
+    return ".rj_translations+" + hex_offset(translation.target_offset - text_size);
+  return ".text+" + hex_offset(translation.target_offset);
+}
+
+void print_code_object_report(std::ostream &os, std::string_view label,
+                              const CodeObjectReport &report) {
+  os << "\n" << label << ":\n";
+  if (!report.available) {
+    os << "  unavailable\n";
+    return;
+  }
+
+  const ReportTotals totals = report_totals(report);
+  os << "  decoder: " << (report.decoder_available ? "available" : "unavailable") << "\n";
+  os << "  sections: " << report.sections.size() << " bytes=" << totals.size_bytes
+     << " instructions=" << totals.instruction_count
+     << " decode_failures=" << totals.decode_failure_count << "\n";
+
+  for (const auto &section : report.sections) {
+    os << "  section " << section.name << " bytes=" << section.size_bytes
+       << " instructions=" << section.instruction_count
+       << " decode_failures=" << section.decode_failure_count;
+    if (section.has_first_decode_failure) {
+      os << " first_failure=0x" << std::hex << section.first_decode_failure_offset << std::dec
+         << " reason=" << section.first_decode_failure_message;
+    }
+    os << "\n";
+  }
+}
+
+void print_instruction_translation_report(std::ostream &os, const TranslateOutput &output) {
+  const auto &translations = output.instruction_translations;
+  size_t shown = 0;
+  size_t changed = 0;
+  for (const auto &translation : translations) {
+    if (translation.changed)
+      ++changed;
+    if (should_show_translation(translation))
+      ++shown;
+  }
+
+  os << "\ninstruction_translations:\n";
+  os << "  total=" << translations.size() << " changed=" << changed << " shown=" << shown << "\n";
+  os << "  actions:" << " copy_original=" << count_copied_original(translations)
+     << " encode=" << count_runtime_encode(translations)
+     << " identity=" << count_action(translations, Action::Identity)
+     << " substitute=" << count_action(translations, Action::Substitute)
+     << " lower=" << count_action(translations, Action::Lower)
+     << " expand=" << count_action(translations, Action::Expand)
+     << " illegal=" << count_action(translations, Action::Illegal)
+     << " semantic=" << count_semantic_lowerings(translations) << "\n";
+
+  const size_t text_size = text_section_size(output.source_report);
+  for (const auto &translation : translations) {
+    if (!should_show_translation(translation))
+      continue;
+
+    os << "  " << hex_offset(translation.source_offset) << " "
+       << translation_action_text(translation) << " .text+" << hex_offset(translation.source_offset)
+       << " -> " << target_location(translation, text_size) << "\n";
+    if (!translation.source_words.empty())
+      os << "    source_words: " << words_text(translation.source_words) << "\n";
+    os << "    source: " << translation.source_instruction << "\n";
+    if (!translation.target_words.empty())
+      os << "    target_words: " << words_text(translation.target_words) << "\n";
+    for (const auto &target_instruction : translation.target_instructions)
+      os << "    target: " << target_instruction << "\n";
+  }
+}
+
+void print_text_report(std::ostream &os, const CliOptions &options,
+                       const ToolResult<TranslateOutput> &result) {
+  const TranslateOutput &output = result.value;
+
+  os << "rj_dbt_translate: " << (result.ok() ? "ok" : "failed") << "\n";
+  os << "input: " << options.translate.input_path << "\n";
+  os << "input_target: " << options.input_target_name << "\n";
+  os << "output_target: " << options.output_target_name << "\n";
+  os << "output_elf_bytes: " << output.elf_bytes.size() << "\n";
+
+  print_code_object_report(os, "source", output.source_report);
+  print_code_object_report(os, "translated", output.translated_report);
+  print_instruction_translation_report(os, output);
+
+  os << "\ndiagnostics: " << output.diagnostics.size() << "\n";
+  os << "errors: " << result.errors.size() << "\n";
+}
+
+int list_code_objects(const CliOptions &options) {
+  if (options.translate.input_path.empty()) {
+    std::cerr << "input path is required with --list-code-objects\n";
+    return kUsageError;
+  }
+
+  Executable executable(options.translate.input_path);
+  if (executable.is_valid()) {
+    std::cout << "gfx942: " << executable.num_code_objects(ROCJITSU_CODE_TARGET_GFX942) << "\n";
+    std::cout << "gfx950: " << executable.num_code_objects(ROCJITSU_CODE_TARGET_GFX950) << "\n";
+    return 0;
+  }
+
+  AmdGpuCodeObject code_object(options.translate.input_path);
+  if (!code_object.is_valid()) {
+    std::cerr << "failed to parse input as executable or AMDGPU code object\n";
+    return 2;
+  }
+
+  std::cout << "standalone-code-object: target-id=" << static_cast<int>(code_object.target_id())
+            << "\n";
+  return 0;
+}
+
+[[nodiscard]] bool emit_output(const CliOptions &options, const TranslateOutput &output) {
+  if (options.output_mode == OutputMode::CodeObject) {
+    std::cout.write(reinterpret_cast<const char *>(output.elf_bytes.data()),
+                    static_cast<std::streamsize>(output.elf_bytes.size()));
+    return static_cast<bool>(std::cout);
+  }
+
+  std::cout << output.disassembly;
+  return static_cast<bool>(std::cout);
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+  CliOptions options;
+  if (!parse_args(argc, argv, options)) {
+    print_help();
+    return kUsageError;
+  }
+
+  if (options.show_help) {
+    print_help();
+    return 0;
+  }
+
+  if (options.list_code_objects)
+    return list_code_objects(options);
+
+  if (!options.saw_input || !options.saw_input_target || !options.saw_output_target) {
+    std::cerr << "input path, --input-target, and --output-target are required\n";
+    print_help();
+    return kUsageError;
+  }
+
+  options.translate.collect_diagnostics = options.output_mode == OutputMode::Diff;
+  options.translate.disassembly = options.output_mode == OutputMode::Disasm
+                                      ? DisassemblyMode::Translated
+                                      : DisassemblyMode::None;
+
+  auto result = translate_code_object(options.translate);
+
+  for (const auto &diagnostic : result.value.diagnostics)
+    print_diagnostic(std::cerr, diagnostic);
+
+  if (options.output_mode == OutputMode::Diff)
+    print_text_report(std::cout, options, result);
+
+  if (!result.ok()) {
+    for (const auto &error : result.errors)
+      std::cerr << "error: " << error.message << "\n";
+    return result.errors.front().exit_code;
+  }
+
+  if (options.output_mode != OutputMode::Diff && !emit_output(options, result.value)) {
+    std::cerr << "error: failed to write output\n";
+    return kOutputError;
+  }
+
+  return 0;
+}

--- a/emulation/rocjitsu/tools/tool_result.h
+++ b/emulation/rocjitsu/tools/tool_result.h
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file tool_result.h
+/// @brief Small result type shared by internal rocjitsu tool entry points.
+
+#ifndef ROCJITSU_TOOLS_TOOL_RESULT_H_
+#define ROCJITSU_TOOLS_TOOL_RESULT_H_
+
+#include <string>
+#include <vector>
+
+namespace rocjitsu::tools {
+
+/// @brief Structured error returned by a tool entry point.
+///
+/// The exit code is intentionally stored with the error so CLI wrappers can
+/// return the same code that in-process tests would assert on. This keeps tests
+/// from scraping stderr just to decide what failed.
+struct ToolError {
+  int exit_code = 1;
+  std::string message;
+};
+
+/// @brief Value-or-errors result for tool functions.
+template <typename T> struct ToolResult {
+  T value;
+  std::vector<ToolError> errors;
+
+  [[nodiscard]] bool ok() const { return errors.empty(); }
+};
+
+} // namespace rocjitsu::tools
+
+#endif // ROCJITSU_TOOLS_TOOL_RESULT_H_


### PR DESCRIPTION
This PR contains multiple improvements to DBT:

rj_dbt_translate:
- Add rj_dbt_translate as a DBT inspection tool with disassembly, code-object, diff reporting, bundled code-object selection, and smoke coverage.
- Add per-instruction translation tracing used by diff mode, including source words, target words, copied-original events, semantic lowerings, and code-cave emissions.

Structured Diagnostics:
- Replace string warnings with structured translation diagnostics so failures carry severity, kind, source offset, mnemonic, and required follow-up work. Make failed or missing EXPAND lowerings fatal instead of silently NOP-filling instructions.
- Update semantic EXPAND rules to return structured success/failure results and report actionable diagnostics for unsupported instruction forms or failed scratch allocation.

register allocations fixes / debug flags:
- Add debug controls for conservative VGPR scratch allocation and continuing after recoverable translation failures so one run can expose multiple missing rules.
- Track semantic-lowering register demand through TranslationContext and recompute kernel descriptors after lowering when SGPR/VGPR requirements grow.
- Fix descriptor accounting for CDNA AccVGPR windows by separating ordinary VGPR counts from descriptor allocation counts, preserving AGPR counts, and moving ACCUM_OFFSET above semantic scratch for CDNA-to-CDNA translation.

tests:
- Tighten tests around liveness scratch floors, descriptor growth, ELF machine flags, diagnostic reporting, multi-kernel translation, and the rj_dbt_translate CLI.