### PR TITLE
RCCL: add ncclCommGrow test configurations to CI

### DIFF
--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -1496,6 +1496,219 @@
           "test_filter": "CeFaultInjTest.MultipleFaultsArmedAndCleared"
         }
       ]
+    },
+
+    "grow_mpi_tests": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 2,
+      "num_nodes": 1,
+      "num_gpus": 2,
+      "timeout": 180,
+      "env_variables": {
+        "NCCL_DEBUG": "INFO",
+        "RCCL_MPI_LOG_ALL_RANKS": "1"
+      },
+      "tests": [
+        {
+          "name": "Grow_SendRecv",
+          "description": "Single grow (N-1 -> N), verify data with SendRecv ring on the grown communicator",
+          "test_filter": "GrowMPITest.Grow_SendRecv"
+        },
+        {
+          "name": "Grow_ThenAbort",
+          "description": "Grow then ncclCommAbort on the grown communicator must succeed cleanly on all ranks",
+          "test_filter": "GrowMPITest.Grow_ThenAbort"
+        },
+        {
+          "name": "Grow_RankPreservation",
+          "description": "After grow, existing ranks retain their original rank index and the new rank gets the expected index",
+          "test_filter": "GrowMPITest.Grow_RankPreservation"
+        },
+        {
+          "name": "Grow_ConfigInheritance",
+          "description": "Grown communicator inherits config (splitShare) from the parent via copyCommConfig path",
+          "test_filter": "GrowMPITest.Grow_ConfigInheritance"
+        },
+        {
+          "name": "Grow_NonBlocking",
+          "description": "Non-blocking grow via ncclConfig_t.blocking=0; poll ncclCommGetAsyncError until ncclSuccess, then AllReduce",
+          "test_filter": "GrowMPITest.Grow_NonBlocking"
+        },
+        {
+          "name": "Grow_ParentDestroyAfterGrow",
+          "description": "Destroy the parent communicator after grow; the grown communicator must still run AllReduce successfully",
+          "test_filter": "GrowMPITest.Grow_ParentDestroyAfterGrow"
+        },
+        {
+          "name": "Grow_ErrorRecoveryRegrow",
+          "description": "Abort grown and parent comms (simulated error), then recreate and grow again (torchcomms error recovery path)",
+          "test_filter": "GrowMPITest.Grow_ErrorRecoveryRegrow"
+        },
+        {
+          "name": "Grow_InvalidArguments",
+          "description": "ncclCommGrow with newcomm==NULL, nRanks<=0, or nRanks<=existing must return ncclInvalidArgument before GroupStart",
+          "test_filter": "GrowMPITest.Grow_InvalidArguments"
+        },
+        {
+          "name": "Grow_NewRankInvalidArgsThenSuccess",
+          "description": "New-rank validation (rank<0, uniqueId==NULL, rank>=nRanks) rejects correctly and leaves group counter balanced for a subsequent valid grow",
+          "test_filter": "GrowMPITest.Grow_NewRankInvalidArgsThenSuccess"
+        },
+        {
+          "name": "Grow_SingleRankParent",
+          "description": "1-rank parent comm exercises bcastGrowHandle early-return path (nRanks==1, coordinator is both rank 0 and nRanks-1)",
+          "test_filter": "GrowMPITest.Grow_SingleRankParent"
+        },
+        {
+          "name": "Grow_ExistingRankCustomConfig",
+          "description": "Existing rank passes non-NULL ncclConfig_t to ncclCommGrow, exercising parseCommConfig path instead of copyCommConfig",
+          "test_filter": "GrowMPITest.Grow_ExistingRankCustomConfig"
+        },
+        {
+          "name": "Grow_ExistingRankBadRankArg",
+          "description": "Existing-rank callers (comm != NULL) must pass rank=-1; any other value returns ncclInvalidArgument",
+          "test_filter": "GrowMPITest.Grow_ExistingRankBadRankArg"
+        },
+        {
+          "name": "Grow_NewRankNRanksEqualExisting",
+          "description": "nRanks == existing nRanks (not a grow) must be rejected with ncclInvalidArgument",
+          "test_filter": "GrowMPITest.Grow_NewRankNRanksEqualExisting"
+        },
+        {
+          "name": "GetUniqueId_NullComm",
+          "description": "ncclCommGetUniqueId with NULL comm must return ncclInvalidArgument (CommCheck early-return)",
+          "test_filter": "GrowMPITest.GetUniqueId_NullComm"
+        },
+        {
+          "name": "GetUniqueId_NullUniqueId",
+          "description": "ncclCommGetUniqueId with NULL uniqueId pointer must return ncclInvalidArgument (PtrCheck early-return)",
+          "test_filter": "GrowMPITest.GetUniqueId_NullUniqueId"
+        },
+        {
+          "name": "GetUniqueId_NullArgs_Combined",
+          "description": "Both CommCheck(nullptr) and PtrCheck(nullptr) paths, then a valid call succeeds after the failures",
+          "test_filter": "GrowMPITest.GetUniqueId_NullArgs_Combined"
+        },
+        {
+          "name": "GetUniqueId_NcclCommIdEnvRejection",
+          "description": "When NCCL_COMM_ID env is set, ncclCommGetUniqueId must return ncclInvalidUsage (bootstrapGetUniqueId env guard)",
+          "test_filter": "GrowMPITest.GetUniqueId_NcclCommIdEnvRejection"
+        }
+      ]
+    },
+
+    "grow_mpi_tests_8rank": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 8,
+      "num_nodes": 1,
+      "num_gpus": 8,
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_DEBUG": "INFO",
+        "RCCL_MPI_LOG_ALL_RANKS": "1"
+      },
+      "tests": [
+        {
+          "name": "Grow_CoordinatorOnlyUniqueId",
+          "description": "Only the coordinator passes uniqueId to ncclCommGrow; other existing ranks pass nullptr (NCCL convention)",
+          "test_filter": "GrowMPITest.Grow_CoordinatorOnlyUniqueId"
+        },
+        {
+          "name": "Grow_ThenShrink",
+          "description": "Grow N-1 -> N then ncclCommShrink back to N-1 (elastic scale-up/down cycle with NCCL_SHRINK_DEFAULT)",
+          "test_filter": "GrowMPITest.Grow_ThenShrink"
+        },
+        {
+          "name": "Grow_ThenShrinkAbort",
+          "description": "Grow then ncclCommShrink with NCCL_SHRINK_ABORT flag (torchcomms convention); AllReduce on shrunk comm",
+          "test_filter": "GrowMPITest.Grow_ThenShrinkAbort"
+        },
+        {
+          "name": "Grow_CoordinatorAtLastRank",
+          "description": "Coordinator is the last rank of the parent comm; exercises bcastGrowHandle self-send via unex queue",
+          "test_filter": "GrowMPITest.Grow_CoordinatorAtLastRank"
+        },
+        {
+          "name": "DoubleGrow_AllReduce",
+          "description": "Double grow (N-2 -> N-1 -> N) with AllReduce verification on the final communicator",
+          "test_filter": "GrowMPITest.DoubleGrow_AllReduce"
+        },
+        {
+          "name": "GetUniqueId_DistinctHandles",
+          "description": "Two sequential ncclCommGetUniqueId calls on the same parent produce distinct magic fields (childCount chain)",
+          "test_filter": "GrowMPITest.GetUniqueId_DistinctHandles"
+        },
+        {
+          "name": "ShrinkThenGrow",
+          "description": "Shrink N -> N-1 then grow back to N; verifies grow works on a communicator produced by shrink",
+          "test_filter": "GrowMPITest.ShrinkThenGrow"
+        },
+        {
+          "name": "GrowShrinkGrowCycle",
+          "description": "Full elastic cycle: grow N-1->N, shrink N->N-1, grow N-1->N again with AllReduce at each phase",
+          "test_filter": "GrowMPITest.GrowShrinkGrowCycle"
+        },
+        {
+          "name": "GetUniqueId_MagicChainThree",
+          "description": "Three sequential grows with distinct magic chain; verifies hashCombine(comm->magic, childCount+1) across 3 levels",
+          "test_filter": "GrowMPITest.GetUniqueId_MagicChainThree"
+        },
+        {
+          "name": "Grow_MultiRankJump",
+          "description": "Grow by 4 ranks at once (N-4 -> N); exercises bootstrapInit multi-root path with a larger new-rank segment",
+          "test_filter": "GrowMPITest.Grow_MultiRankJump"
+        }
+      ]
+    },
+
+    "grow_mpi_tests_multinode": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 4,
+      "num_nodes": 2,
+      "num_gpus": 2,
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_DEBUG": "INFO",
+        "RCCL_MPI_LOG_ALL_RANKS": "1"
+      },
+      "tests": [
+        {
+          "name": "Grow_SendRecv",
+          "description": "Single grow over IB transport; SendRecv ring verifies data path through network buffers on the grown communicator",
+          "test_filter": "GrowMPITest.Grow_SendRecv"
+        },
+        {
+          "name": "DoubleGrow_AllReduce",
+          "description": "Double grow (N-2 -> N-1 -> N) over IB transport; AllReduce on the final communicator verifies multi-hop bootstrap and QP setup",
+          "test_filter": "GrowMPITest.DoubleGrow_AllReduce"
+        },
+        {
+          "name": "Grow_ParentDestroyAfterGrow",
+          "description": "Destroy parent after grow over IB; verifies IB resource teardown on parent does not corrupt the grown communicator's QPs",
+          "test_filter": "GrowMPITest.Grow_ParentDestroyAfterGrow"
+        },
+        {
+          "name": "Grow_ThenShrink",
+          "description": "Grow then shrink over IB transport; exercises network buffer teardown and rebuild across the elastic cycle",
+          "test_filter": "GrowMPITest.Grow_ThenShrink"
+        },
+        {
+          "name": "GrowShrinkGrowCycle",
+          "description": "Full elastic cycle over IB: grow, shrink, grow again; verifies no leaked IB resources across multiple topology changes",
+          "test_filter": "GrowMPITest.GrowShrinkGrowCycle"
+        },
+        {
+          "name": "Grow_NonBlocking",
+          "description": "Non-blocking grow over IB transport; async-job worker thread must handle IB connection setup without races",
+          "test_filter": "GrowMPITest.Grow_NonBlocking"
+        }
+      ]
     }
   },
   "test_suites": [
@@ -1761,6 +1974,24 @@
       "name": "CE Fault Injection Tests",
       "description": "Per-function error injection for CE code paths (ENABLE_FAULT_INJECTION build). Verifies ncclSystemError propagation and recovery for Init, SyncPrep, and LaunchOp faults.",
       "config": "ce_fault_injection",
+      "enabled": true
+    },
+    {
+      "name": "Grow MPI Tests (2-rank)",
+      "description": "ncclCommGrow coverage at 2 ranks on a single node: argument validation, rank preservation, config inheritance, non-blocking grow, parent destroy lifecycle, error recovery regrow, and ncclCommGetUniqueId edge cases",
+      "config": "grow_mpi_tests",
+      "enabled": true
+    },
+    {
+      "name": "Grow MPI Tests (8-rank, single-node)",
+      "description": "ncclCommGrow scenarios requiring 3-8 ranks on one node: coordinator-only uniqueId (NCCL convention), elastic grow/shrink cycles, double/triple grow with magic chain verification, multi-rank jump (4 ranks at once), and coordinator-at-last-rank bootstrap path",
+      "config": "grow_mpi_tests_8rank",
+      "enabled": true
+    },
+    {
+      "name": "Grow MPI Tests - Multi-Node (4-rank, 2-node)",
+      "description": "ncclCommGrow multi-node scenarios over IB transport: grow with SendRecv/AllReduce over network, parent destroy with IB teardown, elastic grow/shrink cycles over IB, and non-blocking grow with IB connection setup",
+      "config": "grow_mpi_tests_multinode",
       "enabled": true
     }
   ]


### PR DESCRIPTION
## Summary

Adds CI test configurations for the upcoming `ncclCommGrow` API (elastic communicator scaling). The Grow tests are being developed on `users/shwetjha/nccl-sync-v2-29-x` and are not yet merged to `develop` — this PR prepares the CI config so it is ready when the tests land.

**Why a config-only PR?** The test source (`GrowMPITests.cpp`) lives on the sync branch and will arrive via the NCCL v2.29.x sync. Creating the CI config separately allows:
- Follows the same pattern established by PR #6457 (revoke tests CI integration)

## Test suites (33 tests)

| Suite | Ranks | GPUs | Nodes | Tests | Coverage |
|-------|-------|------|-------|-------|----------|
| `grow_mpi_tests` | 2 | 2 | 1 | 17 | Arg validation, rank preservation, config inheritance, non-blocking grow, parent destroy lifecycle, error recovery regrow, GetUniqueId edge cases |
| `grow_mpi_tests_8rank` | 8 | 8 | 1 | 10 | Coordinator-only uniqueId (NCCL convention), elastic grow/shrink cycles, double/triple grow with magic chain, multi-rank jump (4 ranks at once), coordinator-at-last-rank bootstrap |
| `grow_mpi_tests_multinode` | 4 | 2 | 2 | 6 | Grow over IB transport: SendRecv/AllReduce, parent destroy with IB teardown, elastic cycles, non-blocking grow with IB connection setup |
