### PR TITLE
rocjitsu: add CDNA4->CDNA3 semantic DBT rules

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/CMakeLists.txt
@@ -12,6 +12,7 @@ rj_add_object_library(rocjitsu_code
     dbt/hazard_tracker.cpp
     dbt/kernel_descriptor_translator.cpp
     dbt/lane_permutation.cpp
+    dbt/semantic/cdna4_to_cdna3.cpp
     dbt/semantic/cdna4_to_rdna_common.cpp
     dbt/semantic/cdna4_to_rdna3.cpp
     dbt/semantic/cdna4_to_rdna4.cpp

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/cdna4_to_cdna3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/cdna4_to_cdna3.cpp
@@ -202,7 +202,9 @@ void emit_s_mov_b64(std::vector<uint32_t> &words, uint8_t sdst, uint16_t ssrc0) 
   words.push_back(build_s_mov_b64(sdst, ssrc0));
 }
 
-[[maybe_unused]] void emit_cdna3_exec_mask(std::vector<uint32_t> &words, uint64_t mask) {
+void emit_cdna3_exec_mask(std::vector<uint32_t> &words, uint64_t mask) {
+  // TODO: Optimize the common all-lanes case by emitting one s_mov_b64 -1
+  // instead of two literal s_mov_b32 instructions.
   emit_s_mov_b32_lit(words, kExecLo, static_cast<uint32_t>(mask));
   emit_s_mov_b32_lit(words, kExecLo + 1, static_cast<uint32_t>(mask >> 32));
 }
@@ -860,6 +862,9 @@ ExpandResult lower_ds_read_b64_tr_b16_cdna4_to_cdna3(const Instruction &inst,
   emit_cdna3_vop3(words, kCdna3OpOrB32, halfword_selector, vgpr_src(halfword_selector),
                   vgpr_src(tmp));
 
+  // TODO: Gather both destination halfword pairs in one pass to reduce the
+  // number of dependent ds_bpermute/VALU operations in this correctness-first
+  // lowering.
   emit_cdna3_b16_transpose_halfword(words, halfword_lo, gather_tmp, lane_base, raw_lo, raw_hi,
                                     halfword_selector);
   emit_cdna3_vop3(words, kCdna3OpAddU32, tmp, scalar_positive_inline_u32(16), vgpr_src(lane_base));
@@ -913,6 +918,12 @@ ExpandResult lower_ds_read_b64_tr_b16_cdna4_to_cdna3(const Instruction &inst,
          "Treat the LDS write as the architectural destination; do not assume raw VDATA is "
          "a real VGPR result when lds=1."});
   }
+  if (num_dwords == 2) {
+    return failed_existing_expand_rule(
+        inst, "CDNA4 LDS-destination MUBUF docs do not list buffer_load_dwordx2",
+        {"CDNA4 LDS-destination MUBUF documentation does not list buffer_load_dwordx2.",
+         "Add an ISA-backed test before enabling a synthetic dwordx2 LDS lowering."});
+  }
 
   const uint8_t data_count = num_dwords;
   // LDS-destination MUBUF loads use the vector address operands for the global
@@ -952,12 +963,6 @@ ExpandResult lower_ds_read_b64_tr_b16_cdna4_to_cdna3(const Instruction &inst,
   // uses inside buffer descriptors, and clobbering one of those descriptors for
   // a temporary save can redirect later global loads.
   const uint8_t saved_exec = static_cast<uint8_t>((context.num_sgprs + 1u) & ~1u);
-  if (num_dwords == 2) {
-    return failed_existing_expand_rule(
-        inst, "CDNA4 LDS-destination MUBUF docs do not list buffer_load_dwordx2",
-        {"CDNA4 LDS-destination MUBUF documentation does not list buffer_load_dwordx2.",
-         "Add an ISA-backed test before enabling a synthetic dwordx2 LDS lowering."});
-  }
 
   const uint8_t load_op = static_cast<uint8_t>(19 + num_dwords);
   uint8_t ds_op = kCdna3DsOpWriteB32;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/cdna4_to_cdna3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/cdna4_to_cdna3.cpp
@@ -1,0 +1,1139 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file semantic/cdna4_to_cdna3.cpp
+/// @brief CDNA4-to-CDNA3 handwritten semantic expansion rules.
+
+#include "rocjitsu/code/dbt/semantic/rules.h"
+
+#include "rocjitsu/analysis/liveness.h"
+#include "rocjitsu/code/patch/instruction_builder.h"
+#include "rocjitsu/isa/arch/amdgpu/cdna3/machine_insts.h"
+#include "rocjitsu/isa/arch/amdgpu/cdna4/machine_insts.h"
+#include "rocjitsu/isa/arch/amdgpu/cdna4/vop3.h"
+#include "rocjitsu/isa/instruction.h"
+
+#include <algorithm>
+#include <array>
+#include <bit>
+#include <cstring>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace rocjitsu {
+namespace {
+
+// CDNA3 instruction builders used by the narrow semantic rules below. These
+// helpers intentionally only cover the encodings the lowering emits; keeping
+// them local avoids adding a broad assembler abstraction for a handful of
+// code-cave sequences.
+
+[[nodiscard]] std::pair<uint32_t, uint32_t>
+build_cdna3_vop3(uint16_t op, uint8_t vdst, uint16_t src0, uint16_t src1 = 0, uint16_t src2 = 0) {
+  cdna3::Vop3MachineInst dst{};
+  dst.encoding = 0x34;
+  dst.op = op;
+  dst.vdst = vdst;
+  dst.src0 = src0 & 0x1FF;
+  dst.src1 = src1 & 0x1FF;
+  dst.src2 = src2 & 0x1FF;
+
+  uint32_t words[2]{};
+  std::memcpy(words, &dst, sizeof(dst));
+  return {words[0], words[1]};
+}
+
+/// @brief Build a CDNA3 VOP3P-MFMA instruction word pair.
+/// @details The wide-K lowering materializes A/B operands in ordinary VGPRs, so
+/// the emitted narrow MFMA clears the source ACC selector while preserving the
+/// destination AccVGPR selector from the CDNA4 instruction.
+[[nodiscard]] std::pair<uint32_t, uint32_t>
+build_cdna3_vop3p_mfma(uint8_t op, const cdna4::Vop3pMfmaMachineInst &src, uint8_t vdst,
+                       uint8_t acc_cd, uint16_t src0, uint16_t src1, uint16_t src2) {
+  cdna3::Vop3pMfmaMachineInst dst{};
+  dst.encoding = 0x1A7;
+  dst.op = op;
+  dst.vdst = vdst;
+  dst.cbsz = src.cbsz;
+  dst.abid = src.abid;
+  dst.acc_cd = acc_cd;
+  dst.src0 = src0 & 0x1FF;
+  dst.src1 = src1 & 0x1FF;
+  dst.src2 = src2 & 0x1FF;
+  dst.acc = 0;
+  dst.blgp = src.blgp;
+
+  uint32_t words[2]{};
+  std::memcpy(words, &dst, sizeof(dst));
+  return {words[0], words[1]};
+}
+
+[[nodiscard]] std::pair<uint32_t, uint32_t> build_cdna3_ds(uint8_t op, uint8_t vdst, uint8_t addr,
+                                                           uint8_t data0 = 0, uint8_t data1 = 0,
+                                                           uint8_t offset0 = 0,
+                                                           uint8_t offset1 = 0) {
+  cdna3::DsMachineInst dst{};
+  dst.encoding = 0x36;
+  dst.op = op;
+  dst.offset0 = offset0;
+  dst.offset1 = offset1;
+  dst.addr = addr;
+  dst.data0 = data0;
+  dst.data1 = data1;
+  dst.vdst = vdst;
+
+  uint32_t words[2]{};
+  std::memcpy(words, &dst, sizeof(dst));
+  return {words[0], words[1]};
+}
+
+[[nodiscard]] std::pair<uint32_t, uint32_t> build_cdna3_mubuf(const cdna4::MubufMachineInst &src,
+                                                              uint8_t op, uint8_t vdata) {
+  cdna3::MubufMachineInst dst{};
+  dst.encoding = 0x38;
+  dst.op = op;
+  dst.offset = src.offset;
+  dst.offen = src.offen;
+  dst.idxen = src.idxen;
+  dst.sc0 = src.sc0;
+  dst.sc1 = src.sc1;
+  dst.lds = 0;
+  dst.nt = src.nt;
+  dst.vaddr = src.vaddr;
+  dst.vdata = vdata;
+  dst.srsrc = src.srsrc;
+  dst.acc = 0;
+  dst.soffset = src.soffset;
+
+  uint32_t words[2]{};
+  std::memcpy(words, &dst, sizeof(dst));
+  return {words[0], words[1]};
+}
+
+[[nodiscard]] constexpr std::pair<uint32_t, uint32_t> build_s_mov_b32_lit(uint8_t sdst,
+                                                                          uint32_t literal) {
+  return {pack_sop1(0, sdst, 0xFF), literal};
+}
+
+[[nodiscard]] constexpr uint32_t build_s_mov_b64(uint8_t sdst, uint16_t ssrc0) {
+  return pack_sop1(1, sdst, ssrc0);
+}
+
+constexpr uint8_t kExecLo = 126;
+constexpr uint16_t kInlineConst0 = 128;
+constexpr uint16_t kInlineConstNeg1 = 193;
+constexpr uint16_t kM0 = 124;
+
+// CDNA3 VOP3 opcodes used by the bitop3, wide-K, and DS transpose expansions.
+constexpr uint16_t kCdna3OpCvtF16F32 = 330;
+constexpr uint16_t kCdna3OpMovB32 = 321;
+constexpr uint16_t kCdna3OpLshrrevB32 = 272;
+constexpr uint16_t kCdna3OpLshlrevB32 = 274;
+constexpr uint16_t kCdna3OpAndB32 = 275;
+constexpr uint16_t kCdna3OpOrB32 = 276;
+constexpr uint16_t kCdna3OpXorB32 = 277;
+constexpr uint16_t kCdna3OpAddU32 = 308;
+constexpr uint16_t kCdna3OpPermB32 = 493;
+constexpr uint16_t kCdna3OpMbcntLoU32B32 = 652;
+constexpr uint16_t kCdna3OpMbcntHiU32B32 = 653;
+
+// CDNA3 VOP3P-MFMA opcodes used by CDNA4 wide-K MFMA expansion.
+constexpr uint8_t kCdna3OpMfmaF32_32x32x8F16 = 76;
+constexpr uint8_t kCdna3OpMfmaF32_16x16x16F16 = 77;
+
+// CDNA3 DS opcodes used to synthesize CDNA4 transposed LDS reads.
+constexpr uint8_t kCdna3DsOpBpermuteB32 = 63;
+constexpr uint8_t kCdna3DsOpReadB64 = 118;
+constexpr uint8_t kCdna3DsOpWriteB32 = 13;
+constexpr uint8_t kCdna3DsOpWriteB96 = 222;
+constexpr uint8_t kCdna3DsOpWriteB128 = 223;
+
+constexpr uint8_t kCdna3SoppOpWaitcnt = 12;
+constexpr uint16_t kCdnaWaitcntLgkmcnt0 = 0xC07F;
+constexpr uint16_t kCdnaWaitcntAll0 = 0x0000;
+
+void emit_cdna3_vop3(std::vector<uint32_t> &words, uint16_t op, uint8_t vdst, uint16_t src0,
+                     uint16_t src1 = 0, uint16_t src2 = 0) {
+  auto [w0, w1] = build_cdna3_vop3(op, vdst, src0, src1, src2);
+  words.push_back(w0);
+  words.push_back(w1);
+}
+
+void emit_cdna3_ds(std::vector<uint32_t> &words, uint8_t op, uint8_t vdst, uint8_t addr,
+                   uint8_t data0 = 0, uint8_t data1 = 0, uint8_t offset0 = 0, uint8_t offset1 = 0) {
+  auto [w0, w1] = build_cdna3_ds(op, vdst, addr, data0, data1, offset0, offset1);
+  words.push_back(w0);
+  words.push_back(w1);
+}
+
+void emit_cdna3_lgkm_wait(std::vector<uint32_t> &words) {
+  // GFX9/CDNA s_waitcnt encodes "lgkmcnt(0)" as lgkm=0 while leaving VM/EXP at
+  // their no-wait maxima. The DS read/bpermute sequences below require the
+  // loaded/permuted data before issuing dependent VALU instructions.
+  words.push_back(pack_sopp(kCdna3SoppOpWaitcnt, kCdnaWaitcntLgkmcnt0));
+}
+
+void emit_cdna3_wait_all(std::vector<uint32_t> &words) {
+  // The load-to-LDS expansion below consumes a just-issued VMEM load through a
+  // following DS write.  Waiting all counters is stronger than the hardware
+  // `vmcnt(0)` dependency we strictly need, but it keeps this first lowering
+  // conservative and matches the monolithic CDNA waitcnt encoding.
+  words.push_back(pack_sopp(kCdna3SoppOpWaitcnt, kCdnaWaitcntAll0));
+}
+
+[[nodiscard]] constexpr uint16_t vgpr_src(uint8_t reg) { return static_cast<uint16_t>(256 + reg); }
+
+void emit_cdna3_mubuf(std::vector<uint32_t> &words, const cdna4::MubufMachineInst &src, uint8_t op,
+                      uint8_t vdata) {
+  auto [w0, w1] = build_cdna3_mubuf(src, op, vdata);
+  words.push_back(w0);
+  words.push_back(w1);
+}
+
+void emit_s_mov_b32_lit(std::vector<uint32_t> &words, uint8_t sdst, uint32_t literal) {
+  auto [w0, w1] = build_s_mov_b32_lit(sdst, literal);
+  words.push_back(w0);
+  words.push_back(w1);
+}
+
+void emit_s_mov_b64(std::vector<uint32_t> &words, uint8_t sdst, uint16_t ssrc0) {
+  words.push_back(build_s_mov_b64(sdst, ssrc0));
+}
+
+[[maybe_unused]] void emit_cdna3_exec_mask(std::vector<uint32_t> &words, uint64_t mask) {
+  emit_s_mov_b32_lit(words, kExecLo, static_cast<uint32_t>(mask));
+  emit_s_mov_b32_lit(words, kExecLo + 1, static_cast<uint32_t>(mask >> 32));
+}
+
+void emit_cdna3_mfma(std::vector<uint32_t> &words, uint8_t op,
+                     const cdna4::Vop3pMfmaMachineInst &src, uint16_t src0, uint16_t src1,
+                     uint16_t src2) {
+  auto [w0, w1] = build_cdna3_vop3p_mfma(op, src, static_cast<uint8_t>(src.vdst),
+                                         static_cast<uint8_t>(src.acc_cd), src0, src1, src2);
+  words.push_back(w0);
+  words.push_back(w1);
+}
+
+void emit_cdna3_mfma_to_vgpr(std::vector<uint32_t> &words, uint8_t op,
+                             const cdna4::Vop3pMfmaMachineInst &src, uint8_t vdst, uint16_t src0,
+                             uint16_t src1, uint16_t src2) {
+  auto [w0, w1] = build_cdna3_vop3p_mfma(op, src, vdst, 0, src0, src1, src2);
+  words.push_back(w0);
+  words.push_back(w1);
+}
+
+[[nodiscard]] ExpandResult failed_existing_expand_rule(const Instruction &inst,
+                                                       const std::string &problem,
+                                                       std::vector<std::string> work = {}) {
+  if (work.empty()) {
+    work = {"Check this rule's operand restrictions and scratch allocation.",
+            "Implement the unsupported form or add a narrower legalization entry."};
+  }
+  return ExpandResult::failed(std::string(inst.mnemonic()) + ": " + problem, std::move(work));
+}
+
+// -----------------------------------------------------------------------------
+// V_BITOP3 expansions.
+// -----------------------------------------------------------------------------
+
+/// @brief Convert the 3-input truth table into algebraic-normal-form coefficients.
+/// @details Truth-table bit index is {S0[i], S1[i], S2[i]}: bit 2 is S0, bit 1
+/// is S1, and bit 0 is S2. ANF lets CDNA3 synthesize the LUT from AND/XOR.
+[[nodiscard]] std::array<uint8_t, 8> bitop3_anf_coefficients(uint8_t truth_table) {
+  std::array<uint8_t, 8> coeff{};
+  for (uint8_t mask = 0; mask < coeff.size(); ++mask)
+    coeff[mask] = static_cast<uint8_t>((truth_table >> mask) & 0x1);
+
+  for (uint8_t variable_mask : {uint8_t{4}, uint8_t{2}, uint8_t{1}}) {
+    for (uint8_t mask = 0; mask < coeff.size(); ++mask) {
+      if ((mask & variable_mask) != 0)
+        coeff[mask] ^= coeff[mask ^ variable_mask];
+    }
+  }
+  return coeff;
+}
+
+[[nodiscard]] bool vdst_aliases_any_vgpr_source(uint8_t vdst, const std::array<uint16_t, 3> &src) {
+  const uint16_t encoded_vdst = static_cast<uint16_t>(256 + vdst);
+  return src[0] == encoded_vdst || src[1] == encoded_vdst || src[2] == encoded_vdst;
+}
+
+[[nodiscard]] bool bitop3_needs_product_term(const std::array<uint8_t, 8> &coeff) {
+  for (uint8_t mask = 1; mask < coeff.size(); ++mask) {
+    if (coeff[mask] != 0 && std::popcount(mask) >= 2)
+      return true;
+  }
+  return false;
+}
+
+template <typename Bitop3Inst>
+ExpandResult lower_cdna4_bitop3_to_cdna3(const Bitop3Inst &inst, const LivenessAnalysis &liveness,
+                                         TranslationContext &context, bool is_b16) {
+  // V_BITOP3 is a three-input bitwise LUT. CDNA4 encodes the eight LUT bits in
+  // VOP3 modifier fields; CDNA3 has no equivalent instruction, so the lowering
+  // emits the LUT as algebraic normal form over GF(2):
+  //
+  //   ttbl_index = (S0_bit << 2) | (S1_bit << 1) | S2_bit
+  //   coeff[] = mobius_transform(ttbl[])
+  //   result = coeff[0]
+  //          ^ coeff[1] & S2
+  //          ^ coeff[2] & S1
+  //          ^ coeff[3] & S1 & S2
+  //          ^ coeff[4] & S0
+  //          ^ coeff[5] & S0 & S2
+  //          ^ coeff[6] & S0 & S1
+  //          ^ coeff[7] & S0 & S1 & S2
+  //
+  // Multiplication in that expression is bitwise AND, addition is XOR, and a
+  // constant one term is materialized as -1 so every lane bit sees true. The B16
+  // form computes the same 32-bit LUT, then clears the high half with a
+  // left/right shift pair.
+  const uint8_t vdst = static_cast<uint8_t>(inst.vdst.encoding_value());
+  const std::array<uint16_t, 3> src = {static_cast<uint16_t>(inst.src0.encoding_value()),
+                                       static_cast<uint16_t>(inst.src1.encoding_value()),
+                                       static_cast<uint16_t>(inst.src2.encoding_value())};
+
+  if (is_b16 && inst.inst_.op_sel != 0)
+    // NYI: OP_SEL selects B16 source/destination halves. Source-half selection
+    // can be lowered by shifting selected high halves down before the LUT, but
+    // OP_SEL[3] is read-modify-write: it writes the high half of vdst while
+    // preserving the old low half. The generated operand metadata currently
+    // treats vdst only as a destination, so liveness may allocate vdst as
+    // scratch and clobber the implicit source value. Until that implicit vdst
+    // read is modeled, only lower the canonical OP_SEL=0 form instead of
+    // silently producing wrong code.
+    return failed_existing_expand_rule(
+        inst, "B16 form has non-zero op_sel",
+        {
+            "Implement OP_SEL handling for canonical vdst read-modify-write lowering.",
+        });
+  // V_BITOP3 overloads VOP3 modifier fields as TTBL bits instead of ordinary
+  // arithmetic modifiers: {OMOD[1:0], ABS[2:0], NEG[2:0]}.
+  const uint8_t truth_table = static_cast<uint8_t>(
+      ((inst.inst_.omod & 0x3) << 6) | ((inst.inst_.abs & 0x7) << 3) | (inst.inst_.neg & 0x7));
+  const auto coeff = bitop3_anf_coefficients(truth_table);
+
+  const bool needs_acc_temp = vdst_aliases_any_vgpr_source(vdst, src);
+  const bool needs_term_temp = bitop3_needs_product_term(coeff);
+
+  // Scratch policy:
+  //   - No product terms and no vdst/source alias: use vdst as the accumulator.
+  //   - vdst/source alias only: use one scratch accumulator, then copy to vdst.
+  //   - Any product term: use two scratch VGPRs, one accumulator and one AND
+  //     term. This keeps the generated sequence simple and prevents the AND temp
+  //     from aliasing the accumulator. Liveness may choose vdst as scratch when
+  //     vdst is dead before the original instruction; that is fine because the
+  //     final result still lands in vdst.
+  const uint16_t scratch_count =
+      needs_term_temp ? 2 : static_cast<uint16_t>(needs_acc_temp ? 1 : 0);
+
+  uint8_t acc = vdst;
+  uint8_t term = 0;
+  if (scratch_count != 0) {
+    auto scratch = liveness.find_free_run(&inst, scratch_count);
+    if (!scratch)
+      return failed_existing_expand_rule(
+          inst, "No free VGPR run for temporary bitop temporaries",
+          {"Check scratch-pressure assumptions and test with higher debug_min_free_vgpr.",
+           "Add spill-backed lowering for high-pressure callers."});
+
+    acc = static_cast<uint8_t>(*scratch);
+    if (needs_term_temp)
+      term = static_cast<uint8_t>(*scratch + 1);
+    // Scratch may be above the original ordinary VGPR allocation. Feed that
+    // exact window back to descriptor translation so the patched kernel can
+    // legally address the generated temporaries and, for CDNA targets with
+    // AccVGPRs, so ACCUM_OFFSET can move above the ordinary scratch window.
+    context.require_vgprs(static_cast<uint32_t>(*scratch) + scratch_count);
+  }
+
+  std::vector<uint32_t> words;
+
+  auto src_for_variable = [&](uint8_t variable_mask) -> uint16_t {
+    switch (variable_mask) {
+    case 4:
+      return src[0];
+    case 2:
+      return src[1];
+    default:
+      return src[2];
+    }
+  };
+
+  auto emit_mov = [&](uint8_t dst, uint16_t src0) {
+    emit_cdna3_vop3(words, kCdna3OpMovB32, dst, src0);
+  };
+  auto emit_and = [&](uint8_t dst, uint16_t src0, uint16_t src1) {
+    emit_cdna3_vop3(words, kCdna3OpAndB32, dst, src0, src1);
+  };
+  auto emit_xor = [&](uint8_t dst, uint16_t src0, uint16_t src1) {
+    emit_cdna3_vop3(words, kCdna3OpXorB32, dst, src0, src1);
+  };
+
+  bool acc_initialized = false;
+  if (coeff[0] != 0) {
+    emit_mov(acc, kInlineConstNeg1);
+    acc_initialized = true;
+  }
+
+  for (uint8_t mask = 1; mask < coeff.size(); ++mask) {
+    if (coeff[mask] == 0)
+      continue;
+
+    std::array<uint16_t, 3> variables{};
+    uint8_t variable_count = 0;
+    for (uint8_t variable_mask : {uint8_t{4}, uint8_t{2}, uint8_t{1}}) {
+      if ((mask & variable_mask) != 0)
+        variables[variable_count++] = src_for_variable(variable_mask);
+    }
+
+    uint16_t term_src = variables[0];
+    if (variable_count >= 2) {
+      emit_and(term, variables[0], variables[1]);
+      if (variable_count == 3)
+        emit_and(term, vgpr_src(term), variables[2]);
+      term_src = vgpr_src(term);
+    }
+
+    if (!acc_initialized) {
+      emit_mov(acc, term_src);
+      acc_initialized = true;
+    } else {
+      emit_xor(acc, vgpr_src(acc), term_src);
+    }
+  }
+
+  if (!acc_initialized)
+    emit_mov(acc, kInlineConst0);
+
+  if (is_b16) {
+    // The B16 form writes a zero-extended low half. Shift left then logical
+    // shift right to clear bits 31:16 without needing a separate 0xffff mask,
+    // which CDNA3 cannot encode as an inline VALU operand.
+    const uint16_t shift16 = scalar_positive_inline_u32(16);
+    emit_cdna3_vop3(words, kCdna3OpLshlrevB32, acc, shift16, vgpr_src(acc));
+    emit_cdna3_vop3(words, kCdna3OpLshrrevB32, acc, shift16, vgpr_src(acc));
+  }
+
+  if (acc != vdst)
+    emit_mov(vdst, vgpr_src(acc));
+
+  return ExpandResult::success(std::move(words));
+}
+
+// -----------------------------------------------------------------------------
+// V_PERMLANE*_SWAP expansions.
+// -----------------------------------------------------------------------------
+
+ExpandResult lower_permlane32_swap_b32_cdna4_to_cdna3(const Instruction &inst,
+                                                      const LivenessAnalysis &liveness,
+                                                      TranslationContext &context) {
+  const auto *raw = inst.raw_encoding();
+  if (!raw || static_cast<size_t>(inst.size()) < sizeof(cdna4::Vop1MachineInst))
+    return failed_existing_expand_rule(
+        inst, "No decodable VOP1 instruction encoding",
+        {"Decode the source VOP1 instruction before applying the swap lowering."});
+
+  cdna4::Vop1MachineInst src{};
+  std::memcpy(&src, raw, sizeof(src));
+  if (src.src0 < 256 || src.src0 > 511)
+    // Only plain VGPR sources have been validated for this first lowering.
+    // Scalar sources, literals, DPP, and SDWA encodings need separate operand
+    // handling before they can be lowered safely.
+    return failed_existing_expand_rule(
+        inst, "swap source is not plain VGPR form",
+        {"Add lowerings for scalar/LITERAL/DPP/SDWA source operands before enabling this form.",
+         "Keep this rule limited to VOP1/e32 VGPR swap until operand decoding is complete."});
+
+  const uint8_t vdst = static_cast<uint8_t>(src.vdst);
+  const uint8_t vsrc = static_cast<uint8_t>(src.src0 - 256);
+
+  // The generated CDNA4 metadata models this swap instruction as two outputs,
+  // but semantically both operands are also read before either is overwritten.
+  // Start VGPR scratch after both architectural operands so liveness cannot
+  // hand us vdst/vsrc merely because their old values are not represented as
+  // ordinary source uses.
+  const uint16_t scratch_start =
+      static_cast<uint16_t>(std::max<uint16_t>(vdst, vsrc) + uint16_t{1});
+  auto scratch = liveness.find_free_run(&inst, 3, scratch_start);
+  if (!scratch)
+    return failed_existing_expand_rule(
+        inst, "No free VGPR scratch window for swap temporaries",
+        {"Provide one SGPR pair for EXEC save/restore and three temporary VGPRs for lane address "
+         "and pre-write swap values."});
+
+  const uint8_t lane = static_cast<uint8_t>(*scratch);
+  const uint8_t partner_addr = static_cast<uint8_t>(*scratch + 1);
+  const uint8_t from_dst_high = static_cast<uint8_t>(*scratch + 2);
+  const uint8_t from_src_low = lane;
+  // Use a descriptor-backed SGPR pair for EXEC save/restore. The CDNA4 metadata
+  // does not model all implicit SGPR buffer-resource lifetimes, so a
+  // liveness-selected guest pair can corrupt later memory operations.
+  const uint8_t saved_exec = static_cast<uint8_t>((context.num_sgprs + 1u) & ~1u);
+
+  context.require_sgprs(static_cast<uint32_t>(saved_exec) + 2);
+  context.require_vgprs(static_cast<uint32_t>(*scratch) + 3);
+
+  std::vector<uint32_t> words;
+
+  // CDNA4 v_permlane32_swap_b32 ignores EXEC and swaps rows 2/3 of VDST with
+  // rows 0/1 of SRC0:
+  //
+  //   SRC0 lanes  0..31 = old VDST lanes 32..63
+  //   VDST lanes 32..63 = old SRC0 lanes  0..31
+  //
+  // CDNA3 has no row-swap instruction.  Run the data-gather portion with EXEC
+  // forced to all lanes so mbcnt() produces physical lane IDs and ds_bpermute
+  // can read both source half-waves.  Only after both old values are captured do
+  // we narrow EXEC to the low and high halves for the two destructive writes.
+  emit_s_mov_b64(words, saved_exec, kExecLo);
+  emit_cdna3_exec_mask(words, UINT64_MAX);
+
+  emit_cdna3_vop3(words, kCdna3OpMbcntLoU32B32, lane, kInlineConstNeg1, kInlineConst0);
+  emit_cdna3_vop3(words, kCdna3OpMbcntHiU32B32, lane, kInlineConstNeg1, vgpr_src(lane));
+  emit_cdna3_vop3(words, kCdna3OpXorB32, partner_addr, scalar_positive_inline_u32(32),
+                  vgpr_src(lane));
+  emit_cdna3_vop3(words, kCdna3OpLshlrevB32, partner_addr, scalar_positive_inline_u32(2),
+                  vgpr_src(partner_addr));
+
+  emit_cdna3_ds(words, kCdna3DsOpBpermuteB32, from_dst_high, partner_addr, vdst);
+  emit_cdna3_ds(words, kCdna3DsOpBpermuteB32, from_src_low, partner_addr, vsrc);
+  emit_cdna3_lgkm_wait(words);
+
+  emit_cdna3_exec_mask(words, 0x00000000FFFFFFFFull);
+  emit_cdna3_vop3(words, kCdna3OpMovB32, vsrc, vgpr_src(from_dst_high));
+
+  emit_cdna3_exec_mask(words, 0xFFFFFFFF00000000ull);
+  emit_cdna3_vop3(words, kCdna3OpMovB32, vdst, vgpr_src(from_src_low));
+
+  emit_s_mov_b64(words, kExecLo, saved_exec);
+  return ExpandResult::success(std::move(words));
+}
+
+ExpandResult lower_cvt_pk_f16_f32_cdna4_to_cdna3(const Instruction &inst,
+                                                 const LivenessAnalysis &liveness,
+                                                 TranslationContext &context) {
+  const auto *raw = inst.raw_encoding();
+  if (!raw || static_cast<size_t>(inst.size()) < sizeof(cdna4::Vop3MachineInst))
+    return failed_existing_expand_rule(inst, "No decodable VOP3 instruction encoding",
+                                       {"Decode the source VOP3 instruction before lowering."});
+
+  cdna4::Vop3MachineInst src{};
+  std::memcpy(&src, raw, sizeof(src));
+  if (src.abs != 0 || src.op_sel != 0 || src.clamp != 0 || src.omod != 0 || src.neg != 0)
+    // Source modifiers would have to be replayed on the two scalar conversions
+    // before packing, so reject them until this form is implemented and tested.
+    return failed_existing_expand_rule(
+        inst, "Unsupported modifiers on packed F16 conversion (abs/op_sel/clamp/omod/neg)",
+        {"Implement modifier handling when source modifiers are present."});
+  if (src.src0 < 256 || src.src0 > 511 || src.src1 < 256 || src.src1 > 511)
+    // Keep this first lowering to ordinary VGPR sources. The CDNA3 scalar
+    // v_cvt_f16_f32 instruction can accept other operand classes, but the
+    // scratch/alias reasoning below has only been validated for VGPR operands.
+    return failed_existing_expand_rule(
+        inst, "Packed F16 conversion operands are not both VGPR registers",
+        {"Add operand-class-specific lowering for scalar, literal, DPP, or SDWA forms."});
+
+  const uint8_t vdst = static_cast<uint8_t>(src.vdst);
+  const uint8_t src0_vgpr = static_cast<uint8_t>(src.src0 - 256);
+  const uint8_t src1_vgpr = static_cast<uint8_t>(src.src1 - 256);
+  const uint16_t scratch_start =
+      static_cast<uint16_t>(std::max<uint16_t>({vdst, src0_vgpr, src1_vgpr}) + uint16_t{1});
+  auto scratch = liveness.find_free_run(&inst, 2, scratch_start);
+  if (!scratch)
+    return failed_existing_expand_rule(
+        inst, "No free VGPR scratch window for packed conversion temporaries",
+        {"Provide two temporary VGPRs so destination/source aliases are safe."});
+
+  const uint8_t lo = static_cast<uint8_t>(*scratch);
+  const uint8_t hi = static_cast<uint8_t>(*scratch + 1);
+  context.require_vgprs(static_cast<uint32_t>(*scratch) + 2);
+
+  std::vector<uint32_t> words;
+  // CDNA4 v_cvt_pk_f16_f32 packs two f32-to-f16 conversions into one VGPR:
+  //
+  //   VDST[15:0]  = f32_to_f16(SRC0)
+  //   VDST[31:16] = f32_to_f16(SRC1)
+  //
+  // CDNA3 lacks this exact packed instruction but has the scalar
+  // v_cvt_f16_f32 with the same conversion helper used by the generated VM
+  // model. Convert both sources before writing VDST so forms such as
+  // `v_cvt_pk_f16_f32 v31, v31, v32` do not clobber a still-needed source.
+  emit_cdna3_vop3(words, kCdna3OpCvtF16F32, lo, static_cast<uint16_t>(src.src0));
+  emit_cdna3_vop3(words, kCdna3OpCvtF16F32, hi, static_cast<uint16_t>(src.src1));
+  emit_cdna3_vop3(words, kCdna3OpLshlrevB32, hi, scalar_positive_inline_u32(16), vgpr_src(hi));
+  emit_cdna3_vop3(words, kCdna3OpOrB32, vdst, vgpr_src(lo), vgpr_src(hi));
+  return ExpandResult::success(std::move(words));
+}
+
+// -----------------------------------------------------------------------------
+// Wide-K MFMA expansions.
+// -----------------------------------------------------------------------------
+
+enum class WideKMfmaShape {
+  F32_16x16x32_F16,
+  F32_32x32x16_F16,
+};
+
+struct WideKMfmaLowering {
+  WideKMfmaShape shape;
+  uint8_t narrow_op;
+  uint8_t dst_regs;
+  uint8_t wide_src_regs;
+  uint8_t narrow_src_regs;
+};
+
+[[nodiscard]] constexpr WideKMfmaLowering lowering_for_shape(WideKMfmaShape shape) {
+  switch (shape) {
+  case WideKMfmaShape::F32_16x16x32_F16:
+    return {shape, kCdna3OpMfmaF32_16x16x16F16, 4, 4, 2};
+  case WideKMfmaShape::F32_32x32x16_F16:
+    return {shape, kCdna3OpMfmaF32_32x32x8F16, 16, 4, 2};
+  }
+  return {shape, 0, 0, 0, 0};
+}
+
+[[nodiscard]] bool ranges_overlap(uint16_t lhs_base, uint16_t lhs_count, uint16_t rhs_base,
+                                  uint16_t rhs_count) {
+  return lhs_base < rhs_base + rhs_count && rhs_base < lhs_base + lhs_count;
+}
+
+[[nodiscard]] bool wide_mfma_needs_partial_accum_scratch(const cdna4::Vop3pMfmaMachineInst &mfma,
+                                                         const WideKMfmaLowering &lowering) {
+  // acc_cd=1 writes the AccVGPR bank. Because this lowering currently rejects
+  // ACC-selected A/B sources, the original A/B operands are ordinary VGPRs and
+  // cannot be clobbered by an AccVGPR partial accumulator.
+  if (mfma.acc_cd != 0)
+    return false;
+
+  const uint16_t dst_base = static_cast<uint16_t>(mfma.vdst);
+  const uint16_t src0_base = static_cast<uint16_t>(mfma.src0 - 256);
+  const uint16_t src1_base = static_cast<uint16_t>(mfma.src1 - 256);
+  return ranges_overlap(dst_base, lowering.dst_regs, src0_base, lowering.wide_src_regs) ||
+         ranges_overlap(dst_base, lowering.dst_regs, src1_base, lowering.wide_src_regs);
+}
+
+ExpandResult lower_wide_k_mfma_f16_cdna4_to_cdna3(const Instruction &inst,
+                                                  const LivenessAnalysis &liveness,
+                                                  TranslationContext &context,
+                                                  WideKMfmaShape shape) {
+  const auto *raw = inst.raw_encoding();
+  if (!raw || static_cast<size_t>(inst.size()) < sizeof(cdna4::Vop3pMfmaMachineInst))
+    return failed_existing_expand_rule(
+        inst, "Could not decode wide-K MFMA instruction encoding",
+        {"Decode the source instruction before lowering this MFMA form."});
+
+  cdna4::Vop3pMfmaMachineInst mfma{};
+  std::memcpy(&mfma, raw, sizeof(mfma));
+  const WideKMfmaLowering lowering = lowering_for_shape(shape);
+  if (lowering.narrow_op == 0)
+    return failed_existing_expand_rule(
+        inst, "Unsupported wide-K MFMA shape",
+        {"Implement a lowering path for this wide-K MFMA shape before enabling this path."});
+
+  // CDNA4's wide-K F16 forms double the K dimension by doubling each contiguous
+  // A/B VGPR source window. CDNA3 has the same output layout for the narrower-K
+  // forms, so the lowering emits two narrow MFMAs over the low and high halves
+  // of the source windows:
+  //
+  //   partial = mfma_narrow(A[0:1], B[0:1], C)
+  //   D       = mfma_narrow(A[2:3], B[2:3], partial)
+  //
+  // When D is an AccVGPR destination, `partial` is the final destination and the
+  // second instruction reads it back through src2. CDNA3 resolves src2 encodings
+  // 256-511 to the AccVGPR bank when acc_cd=1. When D is an ordinary VGPR
+  // destination that overlaps either full A/B source window, the first MFMA must
+  // instead write a dead VGPR run; otherwise it could clobber source registers
+  // that the second MFMA has not read yet.
+  //
+  // NYI: non-default cbsz/abid/blgp/acc modifiers need validation against the
+  // two-instruction expansion before this can preserve them safely.
+  if (mfma.cbsz != 0 || mfma.abid != 0 || mfma.blgp != 0 || mfma.acc != 0)
+    return failed_existing_expand_rule(
+        inst, "MFMA wide-K lowering only supports default cbsz/abid/blgp/acc modifiers",
+        {"Validate and implement non-default MFMA modifiers before enabling this form."});
+  // SRC0/SRC1 are OPR_SRC_VGPR_OR_ACCVGPR operands. The ISA defines the CDNA4
+  // wide forms as 128-bit source windows and the CDNA3 narrow forms as 64-bit
+  // source windows; the operand value is the base of that contiguous window, and
+  // 64-bit-or-wider VGPR/AccVGPR operands are even-aligned by the ISA. Since this
+  // rule rejects ACC-selected A/B sources above and assumes the original CDNA4
+  // instruction is well-formed, the split can use src and src + narrow_src_regs
+  // directly without a packing step.
+  // The original accumulator is only consumed by the first narrow MFMA; the
+  // second consumes the partial accumulator produced by the first. Forward src2
+  // unchanged and rely on the original CDNA4 instruction being well-formed.
+  // VDST has the same operand size in the CDNA4 wide form and the emitted CDNA3
+  // narrow form. Forward the original destination base and acc_cd; destination
+  // window validity is part of the source instruction's ISA contract.
+
+  const bool needs_scratch = wide_mfma_needs_partial_accum_scratch(mfma, lowering);
+  uint8_t partial_vdst = static_cast<uint8_t>(mfma.vdst);
+  uint16_t partial_src2 = static_cast<uint16_t>(256 + mfma.vdst);
+  if (needs_scratch) {
+    std::optional<uint16_t> scratch = liveness.find_free_run(&inst, lowering.dst_regs);
+    // NYI: if no dead VGPR run exists, the general solution is to spill a live
+    // VGPR range and use it for the partial accumulator. That waits on spill
+    // manager integration, so reject for now rather than clobbering live inputs.
+    if (!scratch)
+      return failed_existing_expand_rule(inst,
+                                         "No free VGPR window for partial accumulator scratch",
+                                         {"Add spill-backed lowering for partial accumulator "
+                                          "when live inputs consume scratch registers."});
+    partial_vdst = static_cast<uint8_t>(*scratch);
+    partial_src2 = static_cast<uint16_t>(256 + partial_vdst);
+    // The partial accumulator is an ordinary VGPR tuple emitted only by this
+    // lowering. If liveness selects registers outside the descriptor's original
+    // ordinary VGPR count, descriptor feedback must grow the allocation before
+    // the translated code object is launched.
+    context.require_vgprs(static_cast<uint32_t>(*scratch) + lowering.dst_regs);
+  }
+
+  std::vector<uint32_t> words;
+  if (needs_scratch) {
+    emit_cdna3_mfma_to_vgpr(words, lowering.narrow_op, mfma, partial_vdst,
+                            static_cast<uint16_t>(mfma.src0), static_cast<uint16_t>(mfma.src1),
+                            static_cast<uint16_t>(mfma.src2));
+  } else {
+    emit_cdna3_mfma(words, lowering.narrow_op, mfma, static_cast<uint16_t>(mfma.src0),
+                    static_cast<uint16_t>(mfma.src1), static_cast<uint16_t>(mfma.src2));
+  }
+  emit_cdna3_mfma(words, lowering.narrow_op, mfma,
+                  static_cast<uint16_t>(mfma.src0 + lowering.narrow_src_regs),
+                  static_cast<uint16_t>(mfma.src1 + lowering.narrow_src_regs), partial_src2);
+  return ExpandResult::success(std::move(words));
+}
+
+// -----------------------------------------------------------------------------
+// DS transpose expansions.
+// -----------------------------------------------------------------------------
+
+void emit_cdna3_b16_transpose_halfword(std::vector<uint32_t> &words, uint8_t halfword_dst,
+                                       uint8_t gather_tmp, uint8_t lane_byte_addr, uint8_t raw_lo,
+                                       uint8_t raw_hi, uint8_t halfword_selector) {
+  emit_cdna3_ds(words, kCdna3DsOpBpermuteB32, halfword_dst, lane_byte_addr, raw_lo);
+  emit_cdna3_ds(words, kCdna3DsOpBpermuteB32, gather_tmp, lane_byte_addr, raw_hi);
+  emit_cdna3_lgkm_wait(words);
+  emit_cdna3_vop3(words, kCdna3OpPermB32, halfword_dst, vgpr_src(gather_tmp),
+                  vgpr_src(halfword_dst), vgpr_src(halfword_selector));
+}
+
+void emit_cdna3_pack_low_b16_pair(std::vector<uint32_t> &words, uint8_t dst, uint8_t halfword_lo,
+                                  uint8_t halfword_hi, uint8_t shifted_hi_tmp, uint8_t mask_tmp) {
+  // Pack the low 16 bits of two VGPR values into a raw 32-bit payload. This is
+  // not an FP16 conversion; `v_pack_b32_f16` can canonicalize/change FP
+  // payloads, so build the packed destination with integer operations:
+  //
+  //   dst = (halfword_hi[15:0] << 16) | halfword_lo[15:0]
+  //
+  // CDNA3 cannot inline 0xffff as a VALU source, so synthesize the mask from
+  // -1 >> 16. The helper may clobber halfword_lo, shifted_hi_tmp, and mask_tmp.
+  emit_cdna3_vop3(words, kCdna3OpMovB32, mask_tmp, kInlineConstNeg1);
+  emit_cdna3_vop3(words, kCdna3OpLshrrevB32, mask_tmp, scalar_positive_inline_u32(16),
+                  vgpr_src(mask_tmp));
+  emit_cdna3_vop3(words, kCdna3OpAndB32, halfword_lo, vgpr_src(mask_tmp), vgpr_src(halfword_lo));
+  emit_cdna3_vop3(words, kCdna3OpAndB32, shifted_hi_tmp, vgpr_src(mask_tmp), vgpr_src(halfword_hi));
+  emit_cdna3_vop3(words, kCdna3OpLshlrevB32, shifted_hi_tmp, scalar_positive_inline_u32(16),
+                  vgpr_src(shifted_hi_tmp));
+  emit_cdna3_vop3(words, kCdna3OpOrB32, dst, vgpr_src(halfword_lo), vgpr_src(shifted_hi_tmp));
+}
+
+ExpandResult lower_ds_read_b64_tr_b16_cdna4_to_cdna3(const Instruction &inst,
+                                                     const LivenessAnalysis &liveness,
+                                                     TranslationContext &context) {
+  const auto *raw = inst.raw_encoding();
+  if (!raw || static_cast<size_t>(inst.size()) < sizeof(cdna4::DsMachineInst))
+    return failed_existing_expand_rule(inst, "No decodable DS instruction encoding",
+                                       {"Decode the source DS instruction before lowering."});
+
+  cdna4::DsMachineInst src{};
+  std::memcpy(&src, raw, sizeof(src));
+  if (src.gds != 0)
+    // CDNA4 DS encodings can select GDS, but CDNA3 reserves GDS=1 for this
+    // instruction. Do not translate that variant into an illegal CDNA3 encoding.
+    return failed_existing_expand_rule(
+        inst, "DS transpose lower reads from GDS, which is illegal on CDNA3",
+        {"Ensure the source DS read uses ordinary LDS addressing before enabling this rule."});
+  if (src.acc != 0)
+    // DS ACC redirects VDST into the AccVGPR file. This lowering rebuilds the
+    // result with ordinary VALU writes, so AccVGPR destinations need a separate
+    // implementation before they can be translated safely.
+    return failed_existing_expand_rule(
+        inst, "DS transpose lowering does not support destination ACCVGPR results",
+        {"Define an AccVGPR destination path for transposed DS read lowering."});
+
+  const uint8_t vdst = static_cast<uint8_t>(src.vdst);
+  const uint8_t addr = static_cast<uint8_t>(src.addr);
+  // VDST is a 64-bit destination, so it names a contiguous two-register pair.
+  // Pair validity is part of the source instruction's ISA contract.
+
+  constexpr uint16_t kScratchCount = 8;
+  uint16_t scratch_start =
+      std::max<uint16_t>(static_cast<uint16_t>(vdst + 2), static_cast<uint16_t>(addr + 1));
+  if ((scratch_start & 1) != 0)
+    ++scratch_start;
+
+  std::optional<uint16_t> scratch;
+  // The pack helper wants several even/odd register relationships to stay
+  // simple, so search only for an even-aligned run. If liveness first reports
+  // an odd free run, advance past it and keep looking instead of accepting a
+  // scratch layout that would make the emitted DS transpose sequence harder to
+  // reason about.
+  for (uint16_t search = scratch_start;;) {
+    auto candidate = liveness.find_free_run(&inst, kScratchCount, search);
+    if (!candidate)
+      break;
+    if ((*candidate & 1) == 0) {
+      scratch = candidate;
+      break;
+    }
+    search = static_cast<uint16_t>(*candidate + 1);
+    if ((search & 1) != 0)
+      ++search;
+  }
+  if (!scratch)
+    return failed_existing_expand_rule(
+        inst, "No even-aligned VGPR window found for transpose scratch",
+        {"Provide enough aligned scratch registers or add a spill-backed "
+         "transpose lowering."});
+
+  const uint8_t raw_lo = static_cast<uint8_t>(*scratch + 0);
+  const uint8_t raw_hi = static_cast<uint8_t>(*scratch + 1);
+  const uint8_t lane_base = static_cast<uint8_t>(*scratch + 2);
+  const uint8_t halfword_selector = static_cast<uint8_t>(*scratch + 3);
+  const uint8_t tmp = static_cast<uint8_t>(*scratch + 4);
+  const uint8_t halfword_lo = static_cast<uint8_t>(*scratch + 5);
+  const uint8_t halfword_hi = static_cast<uint8_t>(*scratch + 6);
+  const uint8_t gather_tmp = static_cast<uint8_t>(*scratch + 7);
+  // Liveness may choose a scratch window beyond the guest kernel's original
+  // VGPR allocation. The kernel descriptor must be grown to cover those
+  // generated temporaries before the translated CDNA3 code can legally use them.
+  context.require_vgprs(static_cast<uint32_t>(*scratch) + kScratchCount);
+
+  std::vector<uint32_t> words;
+
+  // CDNA4 ds_read_b64_tr_b16 loads four transposed halfwords per lane from the
+  // LDS read footprint. CDNA3 only has the non-transposed ds_read_b64, so the
+  // expansion reconstructs the transposed result through the DS crossbar:
+  //
+  //   raw_lo:raw_hi = ds_read_b64(addr, offset0, offset1)
+  //   lane          = mbcnt(exec)
+  //   selector      = ((lane & 3) * 2) | (((lane & 3) * 2 + 1) << 8)
+  //   lane_base     = ((lane & 0x30) << 2) | (lane & 0x0c)
+  //   h0            = halfword_at(lane_base +  0, selector, raw_lo, raw_hi)
+  //   h1            = halfword_at(lane_base + 16, selector, raw_lo, raw_hi)
+  //   h2            = halfword_at(lane_base + 32, selector, raw_lo, raw_hi)
+  //   h3            = halfword_at(lane_base + 48, selector, raw_lo, raw_hi)
+  //   vdst          = pack_u16_pair(h0, h1)
+  //   vdst+1        = pack_u16_pair(h2, h3)
+  //
+  // halfword_at() is emitted as two ds_bpermute_b32 operations followed by
+  // v_perm_b32 so the selector can choose the required halfword from either
+  // 32-bit half of the original b64 read. pack_u16_pair() is deliberately
+  // integer mask/shift/or instead of v_pack_b32_f16 because this DS op moves
+  // raw 16-bit payloads, not FP16 values.
+  emit_cdna3_ds(words, kCdna3DsOpReadB64, raw_lo, addr, 0, 0, src.offset0, src.offset1);
+  emit_cdna3_lgkm_wait(words);
+
+  emit_cdna3_vop3(words, kCdna3OpMbcntLoU32B32, tmp, kInlineConstNeg1, kInlineConst0);
+  emit_cdna3_vop3(words, kCdna3OpMbcntHiU32B32, tmp, kInlineConstNeg1, vgpr_src(tmp));
+
+  // Build the ds_bpermute byte addresses that recover each halfword in the
+  // transposed 4x16-lane pattern, then pack pairs of halfwords back into the
+  // two 32-bit destination registers produced by ds_read_b64_tr_b16.
+  emit_cdna3_vop3(words, kCdna3OpAndB32, halfword_selector, scalar_positive_inline_u32(3),
+                  vgpr_src(tmp));
+  emit_cdna3_vop3(words, kCdna3OpLshlrevB32, halfword_selector, scalar_positive_inline_u32(1),
+                  vgpr_src(halfword_selector));
+
+  emit_cdna3_vop3(words, kCdna3OpAndB32, lane_base, scalar_positive_inline_u32(0x30),
+                  vgpr_src(tmp));
+  emit_cdna3_vop3(words, kCdna3OpLshlrevB32, lane_base, scalar_positive_inline_u32(2),
+                  vgpr_src(lane_base));
+  emit_cdna3_vop3(words, kCdna3OpAndB32, tmp, scalar_positive_inline_u32(0x0c), vgpr_src(tmp));
+  emit_cdna3_vop3(words, kCdna3OpOrB32, lane_base, vgpr_src(lane_base), vgpr_src(tmp));
+
+  emit_cdna3_vop3(words, kCdna3OpAddU32, tmp, scalar_positive_inline_u32(1),
+                  vgpr_src(halfword_selector));
+  emit_cdna3_vop3(words, kCdna3OpLshlrevB32, tmp, scalar_positive_inline_u32(8), vgpr_src(tmp));
+  emit_cdna3_vop3(words, kCdna3OpOrB32, halfword_selector, vgpr_src(halfword_selector),
+                  vgpr_src(tmp));
+
+  emit_cdna3_b16_transpose_halfword(words, halfword_lo, gather_tmp, lane_base, raw_lo, raw_hi,
+                                    halfword_selector);
+  emit_cdna3_vop3(words, kCdna3OpAddU32, tmp, scalar_positive_inline_u32(16), vgpr_src(lane_base));
+  emit_cdna3_b16_transpose_halfword(words, halfword_hi, gather_tmp, tmp, raw_lo, raw_hi,
+                                    halfword_selector);
+  emit_cdna3_pack_low_b16_pair(words, vdst, halfword_lo, halfword_hi, tmp, gather_tmp);
+
+  emit_cdna3_vop3(words, kCdna3OpAddU32, tmp, scalar_positive_inline_u32(32), vgpr_src(lane_base));
+  emit_cdna3_b16_transpose_halfword(words, halfword_lo, gather_tmp, tmp, raw_lo, raw_hi,
+                                    halfword_selector);
+  emit_cdna3_vop3(words, kCdna3OpAddU32, tmp, scalar_positive_inline_u32(48), vgpr_src(lane_base));
+  emit_cdna3_b16_transpose_halfword(words, halfword_hi, gather_tmp, tmp, raw_lo, raw_hi,
+                                    halfword_selector);
+  emit_cdna3_pack_low_b16_pair(words, static_cast<uint8_t>(vdst + 1), halfword_lo, halfword_hi, tmp,
+                               gather_tmp);
+
+  return ExpandResult::success(std::move(words));
+}
+
+[[nodiscard]] ExpandResult expand_mubuf_load_to_lds_cdna4_to_cdna3(const Instruction &inst,
+                                                                   const LivenessAnalysis &liveness,
+                                                                   TranslationContext &context,
+                                                                   uint8_t num_dwords) {
+  const auto *raw = inst.raw_encoding();
+  if (!raw || static_cast<size_t>(inst.size()) < sizeof(cdna4::MubufMachineInst))
+    return failed_existing_expand_rule(inst, "Could not decode source MUBUF fields",
+                                       {"Decode the source MUBUF fields before lowering."});
+
+  cdna4::MubufMachineInst src{};
+  std::memcpy(&src, raw, sizeof(src));
+  if (src.lds == 0)
+    return ExpandResult::not_handled();
+  if (src.offen != 0 && src.idxen != 0) {
+    return failed_existing_expand_rule(
+        inst, "MUBUF LDS destination lowering does not support combined offen+idxen",
+        {"Add an assembler/ISA test before enabling the combined offen+idxen LDS form.",
+         "Verify how the MUBUF address tuple maps when VDATA is reserved by LDS DMA."});
+  }
+  if (src.acc != 0) {
+    return failed_existing_expand_rule(
+        inst, "MUBUF LDS destination lowering does not support ACC source modifier",
+        {"Add tests for MUBUF LDS forms with ACC modifiers before enabling them.",
+         "Keep the scratch VGPR load destination in ordinary VGPRs, then define how the "
+         "source ACC bit should interact with an LDS architectural destination."});
+  }
+  if (src.vdata != 0) {
+    return failed_existing_expand_rule(
+        inst, "MUBUF LDS destination lowering only supports raw VDATA field = 0",
+        {"Validate nonzero raw VDATA bits for MUBUF LDS-destination forms before enabling "
+         "this lowering.",
+         "Treat the LDS write as the architectural destination; do not assume raw VDATA is "
+         "a real VGPR result when lds=1."});
+  }
+
+  const uint8_t data_count = num_dwords;
+  // LDS-destination MUBUF loads use the vector address operands for the global
+  // memory request and write the response to LDS at:
+  //
+  //   DWORD:  LDS[m0 + lane_id * 4 ...]
+  //   DWORDX3/DWORDX4: LDS[m0 + lane_id * 16 ...]
+  //
+  // The CDNA3 fallback materializes the response in scratch VGPRs, waits for
+  // it, computes the same per-lane LDS byte address, and stores the contiguous
+  // payload with the matching DS write width.  dwordx3 writes the low 12 bytes
+  // of the 16-byte lane slot and leaves the fourth dword untouched; dwordx4
+  // writes the full slot.  `vdata` is deliberately scratch: in the LDS form the
+  // architectural destination is LDS, not the source instruction's vdata
+  // register tuple.
+  //
+  // Start scratch after the ordinary VGPRs, not after the existing AccVGPR
+  // window. If the chosen scratch overlaps the source accumulator window,
+  // require_vgprs() records the new ordinary VGPR end and descriptor
+  // recomputation moves ACCUM_OFFSET above it while preserving num_agprs.
+  const uint8_t vaddr_count = (src.offen && src.idxen) ? 2 : ((src.offen || src.idxen) ? 1 : 0);
+  const uint16_t scratch_count = static_cast<uint16_t>(data_count + 1);
+  const uint16_t scratch_start =
+      static_cast<uint16_t>(std::max<uint32_t>(src.vaddr + vaddr_count, context.num_vgprs));
+  auto scratch = liveness.find_free_run(&inst, scratch_count, scratch_start);
+  if (!scratch) {
+    return failed_existing_expand_rule(
+        inst, "No scratch VGPR window found for temporary global-load destination and LDS address",
+        {"Provide scratch VGPRs for the temporary global-load destination and LDS address.",
+         "Add a spill-backed lowering for high-pressure inputs if no dead VGPR run exists."});
+  }
+
+  const uint8_t data = static_cast<uint8_t>(*scratch);
+  const uint8_t lds_addr = static_cast<uint8_t>(*scratch + data_count);
+  // Use a new descriptor-backed SGPR pair for EXEC save/restore instead of a
+  // liveness-selected guest pair.  The LDS form hides important SGPR resource
+  // uses inside buffer descriptors, and clobbering one of those descriptors for
+  // a temporary save can redirect later global loads.
+  const uint8_t saved_exec = static_cast<uint8_t>((context.num_sgprs + 1u) & ~1u);
+  if (num_dwords == 2) {
+    return failed_existing_expand_rule(
+        inst, "CDNA4 LDS-destination MUBUF docs do not list buffer_load_dwordx2",
+        {"CDNA4 LDS-destination MUBUF documentation does not list buffer_load_dwordx2.",
+         "Add an ISA-backed test before enabling a synthetic dwordx2 LDS lowering."});
+  }
+
+  const uint8_t load_op = static_cast<uint8_t>(19 + num_dwords);
+  uint8_t ds_op = kCdna3DsOpWriteB32;
+  uint16_t lane_stride_shift = 2;
+  switch (num_dwords) {
+  case 1:
+    ds_op = kCdna3DsOpWriteB32;
+    lane_stride_shift = 2;
+    break;
+  case 3:
+    ds_op = kCdna3DsOpWriteB96;
+    lane_stride_shift = 4;
+    break;
+  case 4:
+    ds_op = kCdna3DsOpWriteB128;
+    lane_stride_shift = 4;
+    break;
+  default:
+    return failed_existing_expand_rule(inst,
+                                       "Unsupported MUBUF LDS load width in CDNA4->CDNA3 lowering",
+                                       {"Unsupported MUBUF LDS load width."});
+  }
+  context.require_sgprs(static_cast<uint32_t>(saved_exec) + 2);
+  context.require_vgprs(static_cast<uint32_t>(*scratch) + scratch_count);
+
+  std::vector<uint32_t> words;
+  // MUBUF-to-LDS uses physical TID-in-wave for the LDS lane slot, not the
+  // active-lane prefix.  Compute that address with EXEC forced to all lanes,
+  // then restore the original EXEC before issuing the global load and DS write
+  // so inactive lanes keep the same side-effect behavior as the source
+  // instruction.
+  emit_s_mov_b64(words, saved_exec, kExecLo);
+  emit_cdna3_exec_mask(words, UINT64_MAX);
+  emit_cdna3_vop3(words, kCdna3OpMbcntLoU32B32, lds_addr, kInlineConstNeg1, kInlineConst0);
+  emit_cdna3_vop3(words, kCdna3OpMbcntHiU32B32, lds_addr, kInlineConstNeg1, vgpr_src(lds_addr));
+  emit_cdna3_vop3(words, kCdna3OpLshlrevB32, lds_addr,
+                  scalar_positive_inline_u32(lane_stride_shift), vgpr_src(lds_addr));
+  emit_cdna3_vop3(words, kCdna3OpAddU32, lds_addr, kM0, vgpr_src(lds_addr));
+  emit_s_mov_b64(words, kExecLo, saved_exec);
+
+  emit_cdna3_mubuf(words, src, load_op, data);
+  emit_cdna3_wait_all(words);
+  emit_cdna3_ds(words, ds_op, 0, lds_addr, data);
+  // Native buffer_load_* ... lds exposes a VMEM-completed LDS side effect. The
+  // fallback sequence creates that side effect with an explicit DS write, so
+  // wait for the DS operation here before branching back to code that was
+  // scheduled around the original LDS-DMA instruction.
+  emit_cdna3_lgkm_wait(words);
+
+  return ExpandResult::success(std::move(words));
+}
+
+ExpandResult expand_v_bitop3_b16_cdna4_to_cdna3(const Instruction &inst, uint32_t, uint64_t,
+                                                const LivenessAnalysis &liveness,
+                                                TranslationContext &context, const LaneLayout *,
+                                                const LaneLayout *) {
+  // The rule table only routes V_BITOP3_B16 here, so use the generated
+  // instruction type directly instead of re-decoding ordinary operands.
+  return lower_cdna4_bitop3_to_cdna3(static_cast<const cdna4::VBitop3B16Vop3 &>(inst), liveness,
+                                     context, true);
+}
+
+ExpandResult expand_v_bitop3_b32_cdna4_to_cdna3(const Instruction &inst, uint32_t, uint64_t,
+                                                const LivenessAnalysis &liveness,
+                                                TranslationContext &context, const LaneLayout *,
+                                                const LaneLayout *) {
+  // The rule table only routes V_BITOP3_B32 here, so use the generated
+  // instruction type directly instead of re-decoding ordinary operands.
+  return lower_cdna4_bitop3_to_cdna3(static_cast<const cdna4::VBitop3B32Vop3 &>(inst), liveness,
+                                     context, false);
+}
+
+ExpandResult expand_permlane32_swap_b32_cdna4_to_cdna3(const Instruction &inst, uint32_t, uint64_t,
+                                                       const LivenessAnalysis &liveness,
+                                                       TranslationContext &context,
+                                                       const LaneLayout *, const LaneLayout *) {
+  return lower_permlane32_swap_b32_cdna4_to_cdna3(inst, liveness, context);
+}
+
+ExpandResult expand_cvt_pk_f16_f32_cdna4_to_cdna3(const Instruction &inst, uint32_t, uint64_t,
+                                                  const LivenessAnalysis &liveness,
+                                                  TranslationContext &context, const LaneLayout *,
+                                                  const LaneLayout *) {
+  return lower_cvt_pk_f16_f32_cdna4_to_cdna3(inst, liveness, context);
+}
+
+ExpandResult expand_ds_read_b64_tr_b16_cdna4_to_cdna3(const Instruction &inst, uint32_t, uint64_t,
+                                                      const LivenessAnalysis &liveness,
+                                                      TranslationContext &context,
+                                                      const LaneLayout *, const LaneLayout *) {
+  return lower_ds_read_b64_tr_b16_cdna4_to_cdna3(inst, liveness, context);
+}
+
+ExpandResult expand_mfma_f32_16x16x32_f16_cdna4_to_cdna3(const Instruction &inst, uint32_t,
+                                                         uint64_t, const LivenessAnalysis &liveness,
+                                                         TranslationContext &context,
+                                                         const LaneLayout *, const LaneLayout *) {
+  return lower_wide_k_mfma_f16_cdna4_to_cdna3(inst, liveness, context,
+                                              WideKMfmaShape::F32_16x16x32_F16);
+}
+
+ExpandResult expand_mfma_f32_32x32x16_f16_cdna4_to_cdna3(const Instruction &inst, uint32_t,
+                                                         uint64_t, const LivenessAnalysis &liveness,
+                                                         TranslationContext &context,
+                                                         const LaneLayout *, const LaneLayout *) {
+  return lower_wide_k_mfma_f16_cdna4_to_cdna3(inst, liveness, context,
+                                              WideKMfmaShape::F32_32x32x16_F16);
+}
+
+ExpandResult expand_buffer_load_dwordx3_lds_cdna4_to_cdna3(const Instruction &inst, uint32_t,
+                                                           uint64_t,
+                                                           const LivenessAnalysis &liveness,
+                                                           TranslationContext &context,
+                                                           const LaneLayout *, const LaneLayout *) {
+  return expand_mubuf_load_to_lds_cdna4_to_cdna3(inst, liveness, context, 3);
+}
+
+ExpandResult expand_buffer_load_dwordx4_lds_cdna4_to_cdna3(const Instruction &inst, uint32_t,
+                                                           uint64_t,
+                                                           const LivenessAnalysis &liveness,
+                                                           TranslationContext &context,
+                                                           const LaneLayout *, const LaneLayout *) {
+  return expand_mubuf_load_to_lds_cdna4_to_cdna3(inst, liveness, context, 4);
+}
+
+constexpr uint16_t kEncVop3 = 0x1A4;
+constexpr uint16_t kEncVop3pMfma = 0x1A7;
+constexpr uint16_t kEncVop1 = 0xFC;
+constexpr uint16_t kEncVop1Hi1 = 0xFD;
+constexpr uint16_t kEncVop1Hi2 = 0xFE;
+constexpr uint16_t kEncVop1Hi3 = 0xFF;
+constexpr uint16_t kEncDsReadB64TrB16 = 0x1B3;
+constexpr uint16_t kEncMubuf = 0x1C0;
+
+constexpr uint16_t kCdna4Op_v_mfma_f32_16x16x32_f16 = 84;
+constexpr uint16_t kCdna4Op_v_mfma_f32_32x32x16_f16 = 85;
+constexpr uint16_t kCdna4Op_v_permlane32_swap_b32 = 90;
+constexpr uint16_t kCdna4Op_v_bitop3_b16 = 563;
+constexpr uint16_t kCdna4Op_v_bitop3_b32 = 564;
+constexpr uint16_t kCdna4Op_v_cvt_pk_f16_f32 = 615;
+constexpr uint16_t kCdna4Op_ds_read_b64_tr_b16 = 227;
+constexpr uint16_t kCdna4Op_buffer_load_dwordx3 = 22;
+constexpr uint16_t kCdna4Op_buffer_load_dwordx4 = 23;
+
+// Table MUST be sorted by (src_encoding_id, src_opcode) for binary search.
+const TranslationRule kExpandRules_cdna4_to_cdna3[] = {
+    {kEncVop1, kCdna4Op_v_permlane32_swap_b32, RuleAction::Expand, 0, 0, nullptr,
+     expand_permlane32_swap_b32_cdna4_to_cdna3, nullptr, nullptr},
+    {kEncVop1Hi1, kCdna4Op_v_permlane32_swap_b32, RuleAction::Expand, 0, 0, nullptr,
+     expand_permlane32_swap_b32_cdna4_to_cdna3, nullptr, nullptr},
+    {kEncVop1Hi2, kCdna4Op_v_permlane32_swap_b32, RuleAction::Expand, 0, 0, nullptr,
+     expand_permlane32_swap_b32_cdna4_to_cdna3, nullptr, nullptr},
+    {kEncVop1Hi3, kCdna4Op_v_permlane32_swap_b32, RuleAction::Expand, 0, 0, nullptr,
+     expand_permlane32_swap_b32_cdna4_to_cdna3, nullptr, nullptr},
+    {kEncVop3, kCdna4Op_v_bitop3_b16, RuleAction::Expand, 0, 0, nullptr,
+     expand_v_bitop3_b16_cdna4_to_cdna3, nullptr, nullptr},
+    {kEncVop3, kCdna4Op_v_bitop3_b32, RuleAction::Expand, 0, 0, nullptr,
+     expand_v_bitop3_b32_cdna4_to_cdna3, nullptr, nullptr},
+    {kEncVop3, kCdna4Op_v_cvt_pk_f16_f32, RuleAction::Expand, 0, 0, nullptr,
+     expand_cvt_pk_f16_f32_cdna4_to_cdna3, nullptr, nullptr},
+    {kEncVop3pMfma, kCdna4Op_v_mfma_f32_16x16x32_f16, RuleAction::Expand, 0, 0, nullptr,
+     expand_mfma_f32_16x16x32_f16_cdna4_to_cdna3, nullptr, nullptr},
+    {kEncVop3pMfma, kCdna4Op_v_mfma_f32_32x32x16_f16, RuleAction::Expand, 0, 0, nullptr,
+     expand_mfma_f32_32x32x16_f16_cdna4_to_cdna3, nullptr, nullptr},
+    {kEncDsReadB64TrB16, kCdna4Op_ds_read_b64_tr_b16, RuleAction::Expand, 0, 0, nullptr,
+     expand_ds_read_b64_tr_b16_cdna4_to_cdna3, nullptr, nullptr},
+    {kEncMubuf, kCdna4Op_buffer_load_dwordx3, RuleAction::Expand, 0, 0, nullptr,
+     expand_buffer_load_dwordx3_lds_cdna4_to_cdna3, nullptr, nullptr},
+    {kEncMubuf, kCdna4Op_buffer_load_dwordx4, RuleAction::Expand, 0, 0, nullptr,
+     expand_buffer_load_dwordx4_lds_cdna4_to_cdna3, nullptr, nullptr},
+};
+
+} // namespace
+
+std::span<const TranslationRule> semantic_expand_rules_cdna4_to_cdna3() {
+  return std::span<const TranslationRule>(kExpandRules_cdna4_to_cdna3);
+}
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/rules.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic/rules.h
@@ -15,6 +15,9 @@ namespace rocjitsu {
 /// @brief CDNA4 source rules for the RDNA4 target.
 [[nodiscard]] std::span<const TranslationRule> semantic_expand_rules_cdna4_to_rdna4();
 
+/// @brief CDNA4 source rules for the CDNA3 target.
+[[nodiscard]] std::span<const TranslationRule> semantic_expand_rules_cdna4_to_cdna3();
+
 /// @brief CDNA4 source rules for the RDNA3 target.
 [[nodiscard]] std::span<const TranslationRule> semantic_expand_rules_cdna4_to_rdna3();
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/semantic_translator.cpp
@@ -22,6 +22,8 @@ namespace {
                                                                          rj_code_arch_t host) {
   if (guest == ROCJITSU_CODE_ARCH_CDNA4 && host == ROCJITSU_CODE_ARCH_RDNA4)
     return semantic_expand_rules_cdna4_to_rdna4();
+  if (guest == ROCJITSU_CODE_ARCH_CDNA4 && host == ROCJITSU_CODE_ARCH_CDNA3)
+    return semantic_expand_rules_cdna4_to_cdna3();
   if (guest == ROCJITSU_CODE_ARCH_CDNA4 && host == ROCJITSU_CODE_ARCH_RDNA3)
     return semantic_expand_rules_cdna4_to_rdna3();
   return {};

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
@@ -507,6 +507,9 @@ bool CodeObjectPatcher::apply_kernel_descriptor_translation(const KdTranslation 
     // by the ordinary VGPR count. KernelDescriptorTranslator decides whether the
     // base must move up to make room for semantic-lowering scratch; the patcher
     // only materializes that already-translated target base.
+    assert(translation.target_accvgpr_base >= 4 &&
+           "ACCUM_OFFSET base must encode at least 4 VGPRs");
+    assert(translation.target_accvgpr_base % 4 == 0 && "ACCUM_OFFSET base must be 4-VGPR aligned");
     AMDHSA_BITS_SET(desc->compute_pgm_rsrc3, kd::COMPUTE_PGM_RSRC3_GFX90A_ACCUM_OFFSET,
                     (translation.target_accvgpr_base / 4 - 1));
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
@@ -502,6 +502,13 @@ bool CodeObjectPatcher::apply_kernel_descriptor_translation(const KdTranslation 
       AMDHSA_BITS_SET(desc->compute_pgm_rsrc3, kd::COMPUTE_PGM_RSRC3_GFX10_PLUS_INST_PREF_SIZE,
                       inst_pref);
     }
+  } else if (target_uses_gfx90a_accum_offset(target_arch) && translation.target_accvgpr_base != 0) {
+    // On GFX90A/GFX942/GFX950, AccVGPRs are placed by ACCUM_OFFSET rather than
+    // by the ordinary VGPR count. KernelDescriptorTranslator decides whether the
+    // base must move up to make room for semantic-lowering scratch; the patcher
+    // only materializes that already-translated target base.
+    AMDHSA_BITS_SET(desc->compute_pgm_rsrc3, kd::COMPUTE_PGM_RSRC3_GFX90A_ACCUM_OFFSET,
+                    (translation.target_accvgpr_base / 4 - 1));
   }
 
   desc->private_segment_fixed_size = translation.target_private_size;

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -241,6 +241,7 @@ if(HSA_RUNTIME64)
             PATH_SUFFIXES bin
         )
         set(HAS_DBT_VECTOR_ADD_GPU FALSE)
+        set(HAS_CDNA3_GPU FALSE)
         set(HAS_RDNA4_GPU FALSE)
         if(ROCM_AGENT_ENUM)
             execute_process(
@@ -255,6 +256,9 @@ if(HSA_RUNTIME64)
                 AND _agents MATCHES "gfx94[012]|gfx1100|gfx120[01]"
             )
                 set(HAS_DBT_VECTOR_ADD_GPU TRUE)
+            endif()
+            if(_agent_rc EQUAL 0 AND _agents MATCHES "gfx94[012]")
+                set(HAS_CDNA3_GPU TRUE)
             endif()
             if(_agent_rc EQUAL 0 AND _agents MATCHES "gfx120[01]")
                 set(HAS_RDNA4_GPU TRUE)
@@ -326,6 +330,118 @@ if(HSA_RUNTIME64)
                 STATUS
                 "HSA translate MFMA test built but NOT registered with CTest "
                 "(no RDNA4 GPU)"
+            )
+        endif()
+
+        add_executable(
+            cdna4_to_cdna3_dispatch_test
+            dbt/cdna4_to_cdna3_dispatch_test.cpp
+        )
+        target_include_directories(
+            cdna4_to_cdna3_dispatch_test
+            PRIVATE
+                ${CMAKE_SOURCE_DIR}/lib/rocjitsu/include
+                ${CMAKE_SOURCE_DIR}/lib/rocjitsu/src
+                ${CMAKE_SOURCE_DIR}/lib/util/include
+                ${RJ_HSA_INCLUDE_DIR}
+        )
+        target_link_libraries(
+            cdna4_to_cdna3_dispatch_test
+            PRIVATE
+                ${RJ_OBJECT_LIBS}
+                ${HSA_RUNTIME64}
+                GTest::gtest
+                GTest::gtest_main
+        )
+        target_link_options(
+            cdna4_to_cdna3_dispatch_test
+            PRIVATE -Wl,-rpath,${RJ_HSA_LIBRARY_DIR}
+        )
+        target_compile_definitions(
+            cdna4_to_cdna3_dispatch_test
+            PRIVATE HAS_HOST_AMDGPU=1 KERNEL_DIR="${KERNEL_OUTPUT_DIR}"
+        )
+        add_dependencies(cdna4_to_cdna3_dispatch_test device_kernels)
+        rj_configure_target(cdna4_to_cdna3_dispatch_test TEST)
+
+        add_test(
+            NAME "Cdna4ToCdna3DispatchTest.TritonBufferAsyncMatmulTranslates"
+            COMMAND
+                cdna4_to_cdna3_dispatch_test
+                --gtest_filter=Cdna4ToCdna3DispatchTest.TritonBufferAsyncMatmulTranslates
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        )
+        set_tests_properties(
+            "Cdna4ToCdna3DispatchTest.TritonBufferAsyncMatmulTranslates"
+            PROPERTIES TIMEOUT 120
+        )
+
+        if(HAS_CDNA3_GPU)
+            add_test(
+                NAME "Cdna4ToCdna3DispatchTest.DynamicCopyLoopDispatchAndRun"
+                COMMAND
+                    cdna4_to_cdna3_dispatch_test
+                    --gtest_filter=Cdna4ToCdna3DispatchTest.DynamicCopyLoopDispatchAndRun
+                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            )
+            add_test(
+                NAME
+                    "Cdna4ToCdna3DispatchTest.TritonDynamicMatmulDispatchAndRun"
+                COMMAND
+                    cdna4_to_cdna3_dispatch_test
+                    --gtest_filter=Cdna4ToCdna3DispatchTest.TritonDynamicMatmulDispatchAndRun
+                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            )
+            add_test(
+                NAME
+                    "Cdna4ToCdna3DispatchTest.TritonBufferAsyncMatmulDispatchAndRun"
+                COMMAND
+                    cdna4_to_cdna3_dispatch_test
+                    --gtest_filter=Cdna4ToCdna3DispatchTest.TritonBufferAsyncMatmulDispatchAndRun
+                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            )
+            add_test(
+                NAME
+                    "Cdna4ToCdna3DispatchTest.TritonBufferAsyncMatmulConservativeLivenessDispatchAndRun"
+                COMMAND
+                    cdna4_to_cdna3_dispatch_test
+                    --gtest_filter=Cdna4ToCdna3DispatchTest.TritonBufferAsyncMatmulConservativeLivenessDispatchAndRun
+                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            )
+            add_test(
+                NAME
+                    "Cdna4ToCdna3DispatchTest.TritonFlashAttentionNoAsyncDispatchAndRun"
+                COMMAND
+                    cdna4_to_cdna3_dispatch_test
+                    --gtest_filter=Cdna4ToCdna3DispatchTest.TritonFlashAttentionNoAsyncDispatchAndRun
+                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            )
+            add_test(
+                NAME
+                    "Cdna4ToCdna3DispatchTest.TritonFlashAttentionBufferAsyncDispatchAndRun"
+                COMMAND
+                    cdna4_to_cdna3_dispatch_test
+                    --gtest_filter=Cdna4ToCdna3DispatchTest.TritonFlashAttentionBufferAsyncDispatchAndRun
+                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            )
+            set_tests_properties(
+                "Cdna4ToCdna3DispatchTest.DynamicCopyLoopDispatchAndRun"
+                "Cdna4ToCdna3DispatchTest.TritonDynamicMatmulDispatchAndRun"
+                "Cdna4ToCdna3DispatchTest.TritonBufferAsyncMatmulDispatchAndRun"
+                "Cdna4ToCdna3DispatchTest.TritonBufferAsyncMatmulConservativeLivenessDispatchAndRun"
+                "Cdna4ToCdna3DispatchTest.TritonFlashAttentionNoAsyncDispatchAndRun"
+                "Cdna4ToCdna3DispatchTest.TritonFlashAttentionBufferAsyncDispatchAndRun"
+                PROPERTIES TIMEOUT 120
+            )
+            message(
+                STATUS
+                "CDNA4->CDNA3 dispatch tests enabled (CDNA3 GPU detected)"
+            )
+        else()
+            message(
+                STATUS
+                "CDNA4->CDNA3 dispatch tests built but NOT registered with CTest "
+                "(no CDNA3 GPU)"
             )
         endif()
     endif()

--- a/emulation/rocjitsu/tests/dbt/cdna4_to_cdna3_dispatch_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/cdna4_to_cdna3_dispatch_test.cpp
@@ -1,0 +1,1049 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file cdna4_to_cdna3_dispatch_test.cpp
+/// @brief End-to-end dispatch tests for CDNA4-to-CDNA3 DBT.
+
+#include "rocjitsu/base/rj_compiler.h"
+RJ_DIAGNOSTIC_PUSH
+RJ_DIAGNOSTIC_IGNORE_PEDANTIC
+#include <hsa/hsa.h>
+#include <hsa/hsa_ext_amd.h>
+RJ_DIAGNOSTIC_POP
+
+#include "rocjitsu/code/amdgpu_elf.h"
+#include "rocjitsu/code/dbt/binary_translator.h"
+#include "rocjitsu/code/executable.h"
+#include "rocjitsu/code/rj_code.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <iterator>
+#include <random>
+#include <string>
+#include <vector>
+
+#ifdef HAS_HOST_AMDGPU
+using namespace rocjitsu;
+
+namespace {
+
+std::string kernel_path(const char *name) { return std::string(KERNEL_DIR) + "/" + name + ".o"; }
+std::string kernel_hsaco_path(const char *name) {
+  return std::string(KERNEL_DIR) + "/" + name + ".hsaco";
+}
+
+std::vector<uint8_t> load_kernel_hsaco_bytes(const char *name) {
+  std::ifstream file(kernel_hsaco_path(name), std::ios::binary);
+  if (!file)
+    return {};
+  return std::vector<uint8_t>(std::istreambuf_iterator<char>(file),
+                              std::istreambuf_iterator<char>());
+}
+
+struct TritonMatmulCase {
+  uint32_t m;
+  uint32_t n;
+  uint32_t k;
+};
+
+void expect_float_vectors_near(const std::vector<float> &actual, const std::vector<float> &expected,
+                               float tolerance, const char *label) {
+  ASSERT_EQ(actual.size(), expected.size()) << label;
+  uint32_t mismatches = 0;
+  for (size_t i = 0; i < actual.size(); ++i) {
+    const float diff = std::fabs(actual[i] - expected[i]);
+    if (diff > tolerance) {
+      if (mismatches < 8)
+        ADD_FAILURE() << label << " mismatch at i=" << i << ": got=" << actual[i]
+                      << " expected=" << expected[i] << " diff=" << diff;
+      ++mismatches;
+    }
+  }
+  EXPECT_EQ(mismatches, 0u) << mismatches << " " << label << " mismatches";
+}
+
+void fill_seeded_half_inputs(std::vector<uint16_t> &values, uint32_t seed) {
+  // Generate finite fp16 values directly in [-1, 1].  Sampling the raw
+  // magnitude bits up to fp16 1.0 keeps this reproducible without baking in a
+  // small fixed table of hand-picked values.
+  std::mt19937 rng(seed);
+  std::uniform_int_distribution<uint16_t> sign_dist(0, 1);
+  std::uniform_int_distribution<uint16_t> magnitude_dist(0, 0x3c00);
+  for (uint16_t &value : values) {
+    const uint16_t sign = static_cast<uint16_t>(sign_dist(rng) << 15);
+    value = static_cast<uint16_t>(sign | magnitude_dist(rng));
+  }
+}
+
+hsa_agent_t find_cpu_agent() {
+  hsa_agent_t cpu{};
+  hsa_iterate_agents(
+      [](hsa_agent_t agent, void *data) -> hsa_status_t {
+        hsa_device_type_t type;
+        hsa_agent_get_info(agent, HSA_AGENT_INFO_DEVICE, &type);
+        if (type == HSA_DEVICE_TYPE_CPU) {
+          *static_cast<hsa_agent_t *>(data) = agent;
+          return HSA_STATUS_INFO_BREAK;
+        }
+        return HSA_STATUS_SUCCESS;
+      },
+      &cpu);
+  return cpu;
+}
+
+hsa_amd_memory_pool_t find_pool(hsa_agent_t agent, hsa_amd_segment_t segment,
+                                bool host_accessible = false) {
+  struct Ctx {
+    hsa_amd_segment_t seg;
+    bool host_acc;
+    hsa_amd_memory_pool_t pool;
+  } ctx{segment, host_accessible, {}};
+
+  hsa_amd_agent_iterate_memory_pools(
+      agent,
+      [](hsa_amd_memory_pool_t pool, void *data) -> hsa_status_t {
+        auto *c = static_cast<Ctx *>(data);
+        hsa_amd_segment_t seg;
+        hsa_amd_memory_pool_get_info(pool, HSA_AMD_MEMORY_POOL_INFO_SEGMENT, &seg);
+        if (seg != c->seg)
+          return HSA_STATUS_SUCCESS;
+        if (c->host_acc) {
+          bool acc = false;
+          hsa_amd_memory_pool_get_info(pool, HSA_AMD_MEMORY_POOL_INFO_ACCESSIBLE_BY_ALL, &acc);
+          if (!acc)
+            return HSA_STATUS_SUCCESS;
+        }
+        c->pool = pool;
+        return HSA_STATUS_INFO_BREAK;
+      },
+      &ctx);
+  return ctx.pool;
+}
+
+struct Cdna3Target {
+  hsa_agent_t agent{};
+  uint32_t mach = 0;
+  std::string isa_name;
+  std::vector<std::string> seen_gpu_isas;
+};
+
+uint32_t cdna3_mach_for_isa_name(const char *name) {
+  if (std::strstr(name, "gfx940"))
+    return EF_AMDGPU_MACH_AMDGCN_GFX940;
+  if (std::strstr(name, "gfx941"))
+    return EF_AMDGPU_MACH_AMDGCN_GFX941;
+  if (std::strstr(name, "gfx942"))
+    return EF_AMDGPU_MACH_AMDGCN_GFX942;
+  return 0;
+}
+
+Cdna3Target find_cdna3_target() {
+  Cdna3Target target;
+  hsa_iterate_agents(
+      [](hsa_agent_t agent, void *data) -> hsa_status_t {
+        auto *t = static_cast<Cdna3Target *>(data);
+        hsa_device_type_t type;
+        hsa_agent_get_info(agent, HSA_AGENT_INFO_DEVICE, &type);
+        if (type != HSA_DEVICE_TYPE_GPU)
+          return HSA_STATUS_SUCCESS;
+
+        hsa_isa_t isa{};
+        char isa_name[128]{};
+        hsa_agent_get_info(agent, HSA_AGENT_INFO_ISA, &isa);
+        hsa_isa_get_info_alt(isa, HSA_ISA_INFO_NAME, isa_name);
+        t->seen_gpu_isas.emplace_back(isa_name);
+
+        const uint32_t mach = cdna3_mach_for_isa_name(isa_name);
+        if (mach == 0)
+          return HSA_STATUS_SUCCESS;
+
+        t->agent = agent;
+        t->mach = mach;
+        t->isa_name = isa_name;
+        return HSA_STATUS_INFO_BREAK;
+      },
+      &target);
+  return target;
+}
+
+std::string join_seen_isas(const std::vector<std::string> &isas) {
+  if (isas.empty())
+    return "<none>";
+  std::string out = isas.front();
+  for (size_t i = 1; i < isas.size(); ++i)
+    out += ", " + isas[i];
+  return out;
+}
+
+struct HsaShutdownGuard {
+  ~HsaShutdownGuard() { hsa_shut_down(); }
+};
+
+void run_dynamic_copy_loop(const std::vector<uint8_t> &elf_bytes, const Cdna3Target &target) {
+  hsa_agent_t cpu = find_cpu_agent();
+  ASSERT_NE(cpu.handle, 0u) << "No CPU agent found";
+
+  hsa_code_object_reader_t reader{};
+  auto st = hsa_code_object_reader_create_from_memory(elf_bytes.data(), elf_bytes.size(), &reader);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+
+  hsa_executable_t executable{};
+  st = hsa_executable_create_alt(HSA_PROFILE_FULL, HSA_DEFAULT_FLOAT_ROUNDING_MODE_DEFAULT, nullptr,
+                                 &executable);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+  st = hsa_executable_load_agent_code_object(executable, target.agent, reader, nullptr, nullptr);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+  st = hsa_executable_freeze(executable, nullptr);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+
+  hsa_executable_symbol_t symbol{};
+  st =
+      hsa_executable_get_symbol_by_name(executable, "dynamic_copy_loop.kd", &target.agent, &symbol);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+
+  uint64_t kernel_object = 0;
+  hsa_executable_symbol_get_info(symbol, HSA_EXECUTABLE_SYMBOL_INFO_KERNEL_OBJECT, &kernel_object);
+  ASSERT_NE(kernel_object, 0u);
+
+  constexpr uint32_t kMaxN = 8193;
+  constexpr uint32_t kWorkgroupSize = 64;
+  constexpr uint32_t kDispatchWorkItems = 256;
+  constexpr size_t kMaxBytes = kMaxN * sizeof(uint32_t);
+  constexpr uint32_t kSentinel = 0xDEADBEEFu;
+
+  auto gpu_pool = find_pool(target.agent, HSA_AMD_SEGMENT_GLOBAL);
+  ASSERT_NE(gpu_pool.handle, 0u);
+  uint32_t *src_dev = nullptr;
+  uint32_t *dst_dev = nullptr;
+  ASSERT_EQ(
+      hsa_amd_memory_pool_allocate(gpu_pool, kMaxBytes, 0, reinterpret_cast<void **>(&src_dev)),
+      HSA_STATUS_SUCCESS);
+  ASSERT_EQ(
+      hsa_amd_memory_pool_allocate(gpu_pool, kMaxBytes, 0, reinterpret_cast<void **>(&dst_dev)),
+      HSA_STATUS_SUCCESS);
+
+  hsa_agent_t both[] = {cpu, target.agent};
+  ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, src_dev), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, dst_dev), HSA_STATUS_SUCCESS);
+
+  auto kernarg_pool = find_pool(cpu, HSA_AMD_SEGMENT_GLOBAL, true);
+  ASSERT_NE(kernarg_pool.handle, 0u);
+  void *kernarg = nullptr;
+  ASSERT_EQ(hsa_amd_memory_pool_allocate(kernarg_pool, 256, 0, &kernarg), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, kernarg), HSA_STATUS_SUCCESS);
+  std::memset(kernarg, 0, 256);
+
+  struct __attribute__((packed)) KernArgs {
+    const uint32_t *src;
+    uint32_t *dst;
+    uint32_t n;
+    uint32_t workgroup_size;
+    uint32_t stride;
+  };
+  auto *args = static_cast<KernArgs *>(kernarg);
+  args->src = src_dev;
+  args->dst = dst_dev;
+  // The kernel is launched through raw HSA rather than the HIP runtime, so pass
+  // the packet workgroup size explicitly instead of relying on blockDim.x.
+  args->workgroup_size = kWorkgroupSize;
+  args->stride = kDispatchWorkItems;
+
+  hsa_queue_t *queue = nullptr;
+  uint32_t queue_size = 0;
+  hsa_agent_get_info(target.agent, HSA_AGENT_INFO_QUEUE_MAX_SIZE, &queue_size);
+  st = hsa_queue_create(target.agent, queue_size, HSA_QUEUE_TYPE_SINGLE, nullptr, nullptr,
+                        UINT32_MAX, UINT32_MAX, &queue);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+
+  hsa_signal_t signal{};
+  ASSERT_EQ(hsa_signal_create(1, 0, nullptr, &signal), HSA_STATUS_SUCCESS);
+
+  const std::array<uint32_t, 12> shapes = {0, 1, 17, 63, 64, 65, 255, 256, 257, 1024, 4097, kMaxN};
+  std::vector<uint32_t> src_host(kMaxN);
+  std::vector<uint32_t> dst_init(kMaxN, kSentinel);
+  std::vector<uint32_t> dst_host(kMaxN);
+
+  for (size_t iter = 0; iter < shapes.size(); ++iter) {
+    const uint32_t n = shapes[iter];
+    SCOPED_TRACE(::testing::Message()
+                 << "shape N=" << n << " iter=" << iter << " host=" << target.isa_name);
+
+    for (uint32_t i = 0; i < kMaxN; ++i)
+      src_host[i] = 0x12340000u ^ (static_cast<uint32_t>(iter) << 12) ^ i;
+    std::fill(dst_init.begin(), dst_init.end(), kSentinel);
+
+    ASSERT_EQ(hsa_memory_copy(src_dev, src_host.data(), kMaxBytes), HSA_STATUS_SUCCESS);
+    ASSERT_EQ(hsa_memory_copy(dst_dev, dst_init.data(), kMaxBytes), HSA_STATUS_SUCCESS);
+
+    args->n = n;
+    hsa_signal_store_relaxed(signal, 1);
+
+    const uint64_t write_idx = hsa_queue_add_write_index_relaxed(queue, 1);
+    auto *aql = static_cast<hsa_kernel_dispatch_packet_t *>(queue->base_address) +
+                (write_idx & (queue->size - 1));
+    std::memset(aql, 0, sizeof(*aql));
+    aql->setup = 1;
+    aql->workgroup_size_x = kWorkgroupSize;
+    aql->workgroup_size_y = 1;
+    aql->workgroup_size_z = 1;
+    aql->grid_size_x = kDispatchWorkItems;
+    aql->grid_size_y = 1;
+    aql->grid_size_z = 1;
+    aql->kernel_object = kernel_object;
+    aql->kernarg_address = kernarg;
+    aql->completion_signal = signal;
+
+    uint16_t header = HSA_PACKET_TYPE_KERNEL_DISPATCH << HSA_PACKET_HEADER_TYPE;
+    header |= 1 << HSA_PACKET_HEADER_BARRIER;
+    header |= HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_ACQUIRE_FENCE_SCOPE;
+    header |= HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_RELEASE_FENCE_SCOPE;
+    __atomic_store_n(reinterpret_cast<uint16_t *>(aql), header, __ATOMIC_RELEASE);
+    hsa_signal_store_relaxed(queue->doorbell_signal, write_idx);
+
+    const hsa_signal_value_t val = hsa_signal_wait_scacquire(
+        signal, HSA_SIGNAL_CONDITION_LT, 1, 5'000'000'000ULL, HSA_WAIT_STATE_BLOCKED);
+    ASSERT_EQ(val, 0) << "Kernel dispatch timed out or failed";
+
+    ASSERT_EQ(hsa_memory_copy(dst_host.data(), dst_dev, kMaxBytes), HSA_STATUS_SUCCESS);
+
+    uint32_t mismatches = 0;
+    for (uint32_t i = 0; i < kMaxN; ++i) {
+      const uint32_t expected = (i < n) ? src_host[i] : kSentinel;
+      if (dst_host[i] != expected) {
+        if (mismatches < 8) {
+          ADD_FAILURE() << "mismatch at i=" << i << ": got=0x" << std::hex << dst_host[i]
+                        << " expected=0x" << expected << std::dec;
+        }
+        ++mismatches;
+      }
+    }
+    EXPECT_EQ(mismatches, 0u) << mismatches << " mismatches for N=" << n;
+  }
+
+  hsa_signal_destroy(signal);
+  hsa_queue_destroy(queue);
+  hsa_amd_memory_pool_free(kernarg);
+  hsa_amd_memory_pool_free(src_dev);
+  hsa_amd_memory_pool_free(dst_dev);
+  hsa_executable_destroy(executable);
+  hsa_code_object_reader_destroy(reader);
+}
+
+void translate_triton_fixture(const char *name, uint32_t mach, std::vector<uint8_t> &elf_bytes,
+                              BinaryTranslatorOptions options = {}) {
+  Executable exec(kernel_hsaco_path(name));
+  ASSERT_TRUE(exec.is_valid());
+  ASSERT_GT(exec.num_code_objects(ROCJITSU_CODE_TARGET_GFX950), 0u);
+  const auto *co = exec.code_object(ROCJITSU_CODE_TARGET_GFX950, 0);
+  ASSERT_NE(co, nullptr);
+
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_CDNA3, mach, options);
+  auto translated = translator.translate(*co);
+  ASSERT_FALSE(translated.elf_bytes.empty());
+  ASSERT_TRUE(translated.ok()) << (translated.diagnostics.empty()
+                                       ? "Translation failed without diagnostics"
+                                       : translated.diagnostics.front().message);
+  elf_bytes = std::move(translated.elf_bytes);
+}
+
+void translate_dynamic_triton_matmul(uint32_t mach, std::vector<uint8_t> &elf_bytes) {
+  translate_triton_fixture("triton_cdna4_matmul_dynamic_32x32x64", mach, elf_bytes);
+}
+
+void run_triton_matmul(const std::vector<uint8_t> &elf_bytes, const Cdna3Target &target,
+                       const TritonMatmulCase &test_case, uint32_t shared_bytes,
+                       std::vector<float> *observed = nullptr) {
+  hsa_agent_t cpu = find_cpu_agent();
+  ASSERT_NE(cpu.handle, 0u) << "No CPU agent found";
+
+  hsa_code_object_reader_t reader{};
+  auto st = hsa_code_object_reader_create_from_memory(elf_bytes.data(), elf_bytes.size(), &reader);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+
+  hsa_executable_t executable{};
+  st = hsa_executable_create_alt(HSA_PROFILE_FULL, HSA_DEFAULT_FLOAT_ROUNDING_MODE_DEFAULT, nullptr,
+                                 &executable);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+  st = hsa_executable_load_agent_code_object(executable, target.agent, reader, nullptr, nullptr);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+  st = hsa_executable_freeze(executable, nullptr);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+
+  hsa_executable_symbol_t symbol{};
+  st = hsa_executable_get_symbol_by_name(executable, "triton_cdna4_matmul_kernel.kd", &target.agent,
+                                         &symbol);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+
+  uint64_t kernel_object = 0;
+  hsa_executable_symbol_get_info(symbol, HSA_EXECUTABLE_SYMBOL_INFO_KERNEL_OBJECT, &kernel_object);
+  ASSERT_NE(kernel_object, 0u);
+
+  const uint32_t kM = test_case.m;
+  const uint32_t kN = test_case.n;
+  const uint32_t kK = test_case.k;
+  constexpr uint32_t kBlockM = 32;
+  constexpr uint32_t kBlockN = 32;
+  constexpr uint32_t kWorkgroupSize = 256;
+  const uint32_t kGroupsM = (kM + kBlockM - 1) / kBlockM;
+  const uint32_t kGroupsN = (kN + kBlockN - 1) / kBlockN;
+  constexpr float kSentinel = -12345.0f;
+  const size_t kAElements = static_cast<size_t>(kM) * kK;
+  const size_t kBElements = static_cast<size_t>(kK) * kN;
+  const size_t kCElements = static_cast<size_t>(kM) * kN;
+  const size_t kABytes = kAElements * sizeof(uint16_t);
+  const size_t kBBytes = kBElements * sizeof(uint16_t);
+  const size_t kCBytes = kCElements * sizeof(float);
+
+  auto gpu_pool = find_pool(target.agent, HSA_AMD_SEGMENT_GLOBAL);
+  ASSERT_NE(gpu_pool.handle, 0u);
+  uint16_t *a_dev = nullptr;
+  uint16_t *b_dev = nullptr;
+  float *c_dev = nullptr;
+  ASSERT_EQ(hsa_amd_memory_pool_allocate(gpu_pool, kABytes, 0, reinterpret_cast<void **>(&a_dev)),
+            HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_memory_pool_allocate(gpu_pool, kBBytes, 0, reinterpret_cast<void **>(&b_dev)),
+            HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_memory_pool_allocate(gpu_pool, kCBytes, 0, reinterpret_cast<void **>(&c_dev)),
+            HSA_STATUS_SUCCESS);
+
+  hsa_agent_t both[] = {cpu, target.agent};
+  ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, a_dev), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, b_dev), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, c_dev), HSA_STATUS_SUCCESS);
+
+  auto kernarg_pool = find_pool(cpu, HSA_AMD_SEGMENT_GLOBAL, true);
+  ASSERT_NE(kernarg_pool.handle, 0u);
+  void *kernarg = nullptr;
+  ASSERT_EQ(hsa_amd_memory_pool_allocate(kernarg_pool, 256, 0, &kernarg), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, kernarg), HSA_STATUS_SUCCESS);
+  std::memset(kernarg, 0, 256);
+
+  struct __attribute__((packed)) DynamicKernArgs {
+    const uint16_t *a;
+    const uint16_t *b;
+    float *c;
+    uint32_t m;
+    uint32_t n;
+    uint32_t k;
+    uint32_t padding;
+    const void *unused0;
+    const void *unused1;
+  };
+  static_assert(sizeof(DynamicKernArgs) == 56, "Dynamic Triton matmul kernarg layout changed");
+
+  auto *args = static_cast<DynamicKernArgs *>(kernarg);
+  args->a = a_dev;
+  args->b = b_dev;
+  args->c = c_dev;
+  args->m = kM;
+  args->n = kN;
+  args->k = kK;
+
+  std::vector<uint16_t> a_host(kAElements);
+  std::vector<uint16_t> b_host(kBElements);
+  std::vector<float> c_init(kCElements, kSentinel);
+  std::vector<float> c_host(kCElements);
+  fill_seeded_half_inputs(a_host, 0xA0D4'0001u ^ kM ^ (kK << 8));
+  fill_seeded_half_inputs(b_host, 0xB0D4'0001u ^ kN ^ (kK << 8));
+  ASSERT_EQ(hsa_memory_copy(a_dev, a_host.data(), kABytes), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_memory_copy(b_dev, b_host.data(), kBBytes), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_memory_copy(c_dev, c_init.data(), kCBytes), HSA_STATUS_SUCCESS);
+
+  hsa_queue_t *queue = nullptr;
+  uint32_t queue_size = 0;
+  hsa_agent_get_info(target.agent, HSA_AGENT_INFO_QUEUE_MAX_SIZE, &queue_size);
+  st = hsa_queue_create(target.agent, queue_size, HSA_QUEUE_TYPE_SINGLE, nullptr, nullptr,
+                        UINT32_MAX, UINT32_MAX, &queue);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+
+  hsa_signal_t signal{};
+  ASSERT_EQ(hsa_signal_create(1, 0, nullptr, &signal), HSA_STATUS_SUCCESS);
+  hsa_signal_store_relaxed(signal, 1);
+
+  const uint64_t write_idx = hsa_queue_add_write_index_relaxed(queue, 1);
+  auto *aql = static_cast<hsa_kernel_dispatch_packet_t *>(queue->base_address) +
+              (write_idx & (queue->size - 1));
+  std::memset(aql, 0, sizeof(*aql));
+  aql->setup = 2;
+  aql->workgroup_size_x = kWorkgroupSize;
+  aql->workgroup_size_y = 1;
+  aql->workgroup_size_z = 1;
+  aql->grid_size_x = kGroupsM * kWorkgroupSize;
+  aql->grid_size_y = kGroupsN;
+  aql->grid_size_z = 1;
+  aql->group_segment_size = shared_bytes;
+  aql->kernel_object = kernel_object;
+  aql->kernarg_address = kernarg;
+  aql->completion_signal = signal;
+
+  uint16_t header = HSA_PACKET_TYPE_KERNEL_DISPATCH << HSA_PACKET_HEADER_TYPE;
+  header |= 1 << HSA_PACKET_HEADER_BARRIER;
+  header |= HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_ACQUIRE_FENCE_SCOPE;
+  header |= HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_RELEASE_FENCE_SCOPE;
+  __atomic_store_n(reinterpret_cast<uint16_t *>(aql), header, __ATOMIC_RELEASE);
+  hsa_signal_store_relaxed(queue->doorbell_signal, write_idx);
+
+  const hsa_signal_value_t val = hsa_signal_wait_scacquire(
+      signal, HSA_SIGNAL_CONDITION_LT, 1, 5'000'000'000ULL, HSA_WAIT_STATE_BLOCKED);
+  ASSERT_EQ(val, 0) << "Kernel dispatch timed out or failed";
+
+  ASSERT_EQ(hsa_memory_copy(c_host.data(), c_dev, kCBytes), HSA_STATUS_SUCCESS);
+
+  if (observed)
+    *observed = std::move(c_host);
+
+  hsa_signal_destroy(signal);
+  hsa_queue_destroy(queue);
+  hsa_amd_memory_pool_free(kernarg);
+  hsa_amd_memory_pool_free(a_dev);
+  hsa_amd_memory_pool_free(b_dev);
+  hsa_amd_memory_pool_free(c_dev);
+  hsa_executable_destroy(executable);
+  hsa_code_object_reader_destroy(reader);
+}
+
+void run_buffer_async_triton_matmul(const std::vector<uint8_t> &elf_bytes,
+                                    const Cdna3Target &target, uint32_t shared_bytes,
+                                    std::vector<float> *observed = nullptr) {
+  hsa_agent_t cpu = find_cpu_agent();
+  ASSERT_NE(cpu.handle, 0u) << "No CPU agent found";
+
+  hsa_code_object_reader_t reader{};
+  auto st = hsa_code_object_reader_create_from_memory(elf_bytes.data(), elf_bytes.size(), &reader);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+
+  hsa_executable_t executable{};
+  st = hsa_executable_create_alt(HSA_PROFILE_FULL, HSA_DEFAULT_FLOAT_ROUNDING_MODE_DEFAULT, nullptr,
+                                 &executable);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+  st = hsa_executable_load_agent_code_object(executable, target.agent, reader, nullptr, nullptr);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+  st = hsa_executable_freeze(executable, nullptr);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+
+  hsa_executable_symbol_t symbol{};
+  st = hsa_executable_get_symbol_by_name(executable, "matmul_async_buffer_load_lds.kd",
+                                         &target.agent, &symbol);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+
+  uint64_t kernel_object = 0;
+  hsa_executable_symbol_get_info(symbol, HSA_EXECUTABLE_SYMBOL_INFO_KERNEL_OBJECT, &kernel_object);
+  ASSERT_NE(kernel_object, 0u);
+
+  constexpr uint32_t kM = 1024;
+  constexpr uint32_t kN = 1024;
+  constexpr uint32_t kK = 1024;
+  constexpr uint32_t kBlockM = 64;
+  constexpr uint32_t kBlockN = 64;
+  constexpr uint32_t kWorkgroupSize = 256;
+  constexpr uint32_t kGroups = ((kM + kBlockM - 1) / kBlockM) * ((kN + kBlockN - 1) / kBlockN);
+  // Triton emits buffer-load-to-LDS instructions in this fixture, but the
+  // metadata currently reports zero fixed LDS.  Give the dispatch the target
+  // gfx942 maximum LDS footprint so the generated dynamic LDS offsets are
+  // legal while still exercising real buffer-load-to-LDS execution.
+  constexpr float kSentinel = -12345.0f;
+  const size_t kAElements = static_cast<size_t>(kM) * kK;
+  const size_t kBElements = static_cast<size_t>(kK) * kN;
+  const size_t kCElements = static_cast<size_t>(kM) * kN;
+  const size_t kABytes = kAElements * sizeof(uint16_t);
+  const size_t kBBytes = kBElements * sizeof(uint16_t);
+  const size_t kCBytes = kCElements * sizeof(float);
+
+  auto gpu_pool = find_pool(target.agent, HSA_AMD_SEGMENT_GLOBAL);
+  ASSERT_NE(gpu_pool.handle, 0u);
+  uint16_t *a_dev = nullptr;
+  uint16_t *b_dev = nullptr;
+  float *c_dev = nullptr;
+  ASSERT_EQ(hsa_amd_memory_pool_allocate(gpu_pool, kABytes, 0, reinterpret_cast<void **>(&a_dev)),
+            HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_memory_pool_allocate(gpu_pool, kBBytes, 0, reinterpret_cast<void **>(&b_dev)),
+            HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_memory_pool_allocate(gpu_pool, kCBytes, 0, reinterpret_cast<void **>(&c_dev)),
+            HSA_STATUS_SUCCESS);
+
+  hsa_agent_t both[] = {cpu, target.agent};
+  ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, a_dev), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, b_dev), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, c_dev), HSA_STATUS_SUCCESS);
+
+  auto kernarg_pool = find_pool(cpu, HSA_AMD_SEGMENT_GLOBAL, true);
+  ASSERT_NE(kernarg_pool.handle, 0u);
+  void *kernarg = nullptr;
+  ASSERT_EQ(hsa_amd_memory_pool_allocate(kernarg_pool, 64, 0, &kernarg), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, kernarg), HSA_STATUS_SUCCESS);
+  std::memset(kernarg, 0, 64);
+
+  struct __attribute__((packed)) BufferAsyncKernArgs {
+    const uint16_t *a;
+    const uint16_t *b;
+    float *c;
+    const void *unused0;
+    const void *unused1;
+  };
+  static_assert(sizeof(BufferAsyncKernArgs) == 40,
+                "Buffer async Triton matmul kernarg layout changed");
+
+  auto *args = static_cast<BufferAsyncKernArgs *>(kernarg);
+  args->a = a_dev;
+  args->b = b_dev;
+  args->c = c_dev;
+
+  std::vector<uint16_t> a_host(kAElements);
+  std::vector<uint16_t> b_host(kBElements);
+  std::vector<float> c_init(kCElements, kSentinel);
+  std::vector<float> c_host(kCElements);
+  fill_seeded_half_inputs(a_host, 0xA0D4'1001u);
+  fill_seeded_half_inputs(b_host, 0xB0D4'1001u);
+  ASSERT_EQ(hsa_memory_copy(a_dev, a_host.data(), kABytes), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_memory_copy(b_dev, b_host.data(), kBBytes), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_memory_copy(c_dev, c_init.data(), kCBytes), HSA_STATUS_SUCCESS);
+
+  hsa_queue_t *queue = nullptr;
+  uint32_t queue_size = 0;
+  hsa_agent_get_info(target.agent, HSA_AGENT_INFO_QUEUE_MAX_SIZE, &queue_size);
+  st = hsa_queue_create(target.agent, queue_size, HSA_QUEUE_TYPE_SINGLE, nullptr, nullptr,
+                        UINT32_MAX, UINT32_MAX, &queue);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+
+  hsa_signal_t signal{};
+  ASSERT_EQ(hsa_signal_create(1, 0, nullptr, &signal), HSA_STATUS_SUCCESS);
+  hsa_signal_store_relaxed(signal, 1);
+
+  const uint64_t write_idx = hsa_queue_add_write_index_relaxed(queue, 1);
+  auto *aql = static_cast<hsa_kernel_dispatch_packet_t *>(queue->base_address) +
+              (write_idx & (queue->size - 1));
+  std::memset(aql, 0, sizeof(*aql));
+  aql->setup = 1;
+  aql->workgroup_size_x = kWorkgroupSize;
+  aql->workgroup_size_y = 1;
+  aql->workgroup_size_z = 1;
+  aql->grid_size_x = kGroups * kWorkgroupSize;
+  aql->grid_size_y = 1;
+  aql->grid_size_z = 1;
+  aql->group_segment_size = shared_bytes;
+  aql->kernel_object = kernel_object;
+  aql->kernarg_address = kernarg;
+  aql->completion_signal = signal;
+
+  uint16_t header = HSA_PACKET_TYPE_KERNEL_DISPATCH << HSA_PACKET_HEADER_TYPE;
+  header |= 1 << HSA_PACKET_HEADER_BARRIER;
+  header |= HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_ACQUIRE_FENCE_SCOPE;
+  header |= HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_RELEASE_FENCE_SCOPE;
+  __atomic_store_n(reinterpret_cast<uint16_t *>(aql), header, __ATOMIC_RELEASE);
+  hsa_signal_store_relaxed(queue->doorbell_signal, write_idx);
+
+  const hsa_signal_value_t val = hsa_signal_wait_scacquire(
+      signal, HSA_SIGNAL_CONDITION_LT, 1, 10'000'000'000ULL, HSA_WAIT_STATE_BLOCKED);
+  ASSERT_EQ(val, 0) << "Kernel dispatch timed out or failed";
+
+  ASSERT_EQ(hsa_memory_copy(c_host.data(), c_dev, kCBytes), HSA_STATUS_SUCCESS);
+
+  if (observed)
+    *observed = std::move(c_host);
+
+  hsa_signal_destroy(signal);
+  hsa_queue_destroy(queue);
+  hsa_amd_memory_pool_free(kernarg);
+  hsa_amd_memory_pool_free(a_dev);
+  hsa_amd_memory_pool_free(b_dev);
+  hsa_amd_memory_pool_free(c_dev);
+  hsa_executable_destroy(executable);
+  hsa_code_object_reader_destroy(reader);
+}
+
+void run_flash_attention_triton(const std::vector<uint8_t> &elf_bytes, const Cdna3Target &target,
+                                const char *symbol_name, uint32_t shared_bytes,
+                                std::vector<float> *observed = nullptr) {
+  hsa_agent_t cpu = find_cpu_agent();
+  ASSERT_NE(cpu.handle, 0u) << "No CPU agent found";
+  ASSERT_LE(shared_bytes, 65536u)
+      << "gfx942 dispatch must stay within the 64 KiB LDS limit until LDS virtualization exists";
+
+  hsa_code_object_reader_t reader{};
+  auto st = hsa_code_object_reader_create_from_memory(elf_bytes.data(), elf_bytes.size(), &reader);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+
+  hsa_executable_t executable{};
+  st = hsa_executable_create_alt(HSA_PROFILE_FULL, HSA_DEFAULT_FLOAT_ROUNDING_MODE_DEFAULT, nullptr,
+                                 &executable);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+  st = hsa_executable_load_agent_code_object(executable, target.agent, reader, nullptr, nullptr);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+  st = hsa_executable_freeze(executable, nullptr);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+
+  hsa_executable_symbol_t symbol{};
+  st = hsa_executable_get_symbol_by_name(executable, symbol_name, &target.agent, &symbol);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+
+  uint64_t kernel_object = 0;
+  hsa_executable_symbol_get_info(symbol, HSA_EXECUTABLE_SYMBOL_INFO_KERNEL_OBJECT, &kernel_object);
+  ASSERT_NE(kernel_object, 0u);
+
+  constexpr uint32_t kQ = 1024;
+  constexpr uint32_t kKV = 1024;
+  constexpr uint32_t kHeadDim = 64;
+  constexpr uint32_t kBlockM = 64;
+  constexpr uint32_t kWorkgroupSize = 256;
+  constexpr uint32_t kGroups = (kQ + kBlockM - 1) / kBlockM;
+  const size_t kQElements = static_cast<size_t>(kQ) * kHeadDim;
+  const size_t kKVElements = static_cast<size_t>(kKV) * kHeadDim;
+  const size_t kOElements = static_cast<size_t>(kQ) * kHeadDim;
+  const size_t kQBytes = kQElements * sizeof(uint16_t);
+  const size_t kKVBytes = kKVElements * sizeof(uint16_t);
+  const size_t kOBytes = kOElements * sizeof(float);
+
+  auto gpu_pool = find_pool(target.agent, HSA_AMD_SEGMENT_GLOBAL);
+  ASSERT_NE(gpu_pool.handle, 0u);
+  uint16_t *q_dev = nullptr;
+  uint16_t *k_dev = nullptr;
+  uint16_t *v_dev = nullptr;
+  float *o_dev = nullptr;
+  ASSERT_EQ(hsa_amd_memory_pool_allocate(gpu_pool, kQBytes, 0, reinterpret_cast<void **>(&q_dev)),
+            HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_memory_pool_allocate(gpu_pool, kKVBytes, 0, reinterpret_cast<void **>(&k_dev)),
+            HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_memory_pool_allocate(gpu_pool, kKVBytes, 0, reinterpret_cast<void **>(&v_dev)),
+            HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_memory_pool_allocate(gpu_pool, kOBytes, 0, reinterpret_cast<void **>(&o_dev)),
+            HSA_STATUS_SUCCESS);
+
+  hsa_agent_t both[] = {cpu, target.agent};
+  ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, q_dev), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, k_dev), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, v_dev), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, o_dev), HSA_STATUS_SUCCESS);
+
+  auto kernarg_pool = find_pool(cpu, HSA_AMD_SEGMENT_GLOBAL, true);
+  ASSERT_NE(kernarg_pool.handle, 0u);
+  void *kernarg = nullptr;
+  ASSERT_EQ(hsa_amd_memory_pool_allocate(kernarg_pool, 64, 0, &kernarg), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_amd_agents_allow_access(2, both, nullptr, kernarg), HSA_STATUS_SUCCESS);
+  std::memset(kernarg, 0, 64);
+
+  struct __attribute__((packed)) FlashAttentionKernArgs {
+    const uint16_t *q;
+    const uint16_t *k;
+    const uint16_t *v;
+    float *o;
+    float softmax_scale;
+    uint32_t padding;
+    const void *unused0;
+    const void *unused1;
+  };
+  static_assert(sizeof(FlashAttentionKernArgs) == 56,
+                "Triton flash attention kernarg layout changed");
+
+  auto *args = static_cast<FlashAttentionKernArgs *>(kernarg);
+  args->q = q_dev;
+  args->k = k_dev;
+  args->v = v_dev;
+  args->o = o_dev;
+  args->softmax_scale = 1.0f;
+
+  std::vector<uint16_t> q_host(kQElements);
+  std::vector<uint16_t> k_host(kKVElements);
+  std::vector<uint16_t> v_host(kKVElements);
+  std::vector<float> o_init(kOElements, -12345.0f);
+  std::vector<float> o_host(kOElements);
+  fill_seeded_half_inputs(q_host, 0xF1A5'0001u);
+  fill_seeded_half_inputs(k_host, 0xF1A5'0002u);
+  fill_seeded_half_inputs(v_host, 0xF1A5'0003u);
+  ASSERT_EQ(hsa_memory_copy(q_dev, q_host.data(), kQBytes), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_memory_copy(k_dev, k_host.data(), kKVBytes), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_memory_copy(v_dev, v_host.data(), kKVBytes), HSA_STATUS_SUCCESS);
+  ASSERT_EQ(hsa_memory_copy(o_dev, o_init.data(), kOBytes), HSA_STATUS_SUCCESS);
+
+  hsa_queue_t *queue = nullptr;
+  uint32_t queue_size = 0;
+  hsa_agent_get_info(target.agent, HSA_AGENT_INFO_QUEUE_MAX_SIZE, &queue_size);
+  st = hsa_queue_create(target.agent, queue_size, HSA_QUEUE_TYPE_SINGLE, nullptr, nullptr,
+                        UINT32_MAX, UINT32_MAX, &queue);
+  ASSERT_EQ(st, HSA_STATUS_SUCCESS);
+
+  hsa_signal_t signal{};
+  ASSERT_EQ(hsa_signal_create(1, 0, nullptr, &signal), HSA_STATUS_SUCCESS);
+  hsa_signal_store_relaxed(signal, 1);
+
+  const uint64_t write_idx = hsa_queue_add_write_index_relaxed(queue, 1);
+  auto *aql = static_cast<hsa_kernel_dispatch_packet_t *>(queue->base_address) +
+              (write_idx & (queue->size - 1));
+  std::memset(aql, 0, sizeof(*aql));
+  aql->setup = 1;
+  aql->workgroup_size_x = kWorkgroupSize;
+  aql->workgroup_size_y = 1;
+  aql->workgroup_size_z = 1;
+  aql->grid_size_x = kGroups * kWorkgroupSize;
+  aql->grid_size_y = 1;
+  aql->grid_size_z = 1;
+  aql->group_segment_size = shared_bytes;
+  aql->kernel_object = kernel_object;
+  aql->kernarg_address = kernarg;
+  aql->completion_signal = signal;
+
+  uint16_t header = HSA_PACKET_TYPE_KERNEL_DISPATCH << HSA_PACKET_HEADER_TYPE;
+  header |= 1 << HSA_PACKET_HEADER_BARRIER;
+  header |= HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_ACQUIRE_FENCE_SCOPE;
+  header |= HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_RELEASE_FENCE_SCOPE;
+  __atomic_store_n(reinterpret_cast<uint16_t *>(aql), header, __ATOMIC_RELEASE);
+  hsa_signal_store_relaxed(queue->doorbell_signal, write_idx);
+
+  const hsa_signal_value_t val = hsa_signal_wait_scacquire(
+      signal, HSA_SIGNAL_CONDITION_LT, 1, 10'000'000'000ULL, HSA_WAIT_STATE_BLOCKED);
+  ASSERT_EQ(val, 0) << "Kernel dispatch timed out or failed";
+
+  ASSERT_EQ(hsa_memory_copy(o_host.data(), o_dev, kOBytes), HSA_STATUS_SUCCESS);
+
+  if (observed)
+    *observed = std::move(o_host);
+
+  hsa_signal_destroy(signal);
+  hsa_queue_destroy(queue);
+  hsa_amd_memory_pool_free(kernarg);
+  hsa_amd_memory_pool_free(q_dev);
+  hsa_amd_memory_pool_free(k_dev);
+  hsa_amd_memory_pool_free(v_dev);
+  hsa_amd_memory_pool_free(o_dev);
+  hsa_executable_destroy(executable);
+  hsa_code_object_reader_destroy(reader);
+}
+
+} // namespace
+
+TEST(Cdna4ToCdna3DispatchTest, DynamicCopyLoopTranslates) {
+  Executable exec(kernel_path("dynamic_copy_loop"));
+  ASSERT_TRUE(exec.is_valid());
+  ASSERT_GT(exec.num_code_objects(ROCJITSU_CODE_TARGET_GFX950), 0u);
+  const auto *co = exec.code_object(ROCJITSU_CODE_TARGET_GFX950, 0);
+  ASSERT_NE(co, nullptr);
+
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_CDNA3,
+                              EF_AMDGPU_MACH_AMDGCN_GFX942);
+  auto translated = translator.translate(*co);
+  ASSERT_FALSE(translated.elf_bytes.empty());
+  ASSERT_TRUE(translated.ok()) << "Translation diagnostic: "
+                               << translated.diagnostics.front().message;
+}
+
+TEST(Cdna4ToCdna3DispatchTest, TritonDynamicMatmulTranslates) {
+  std::vector<uint8_t> translated;
+  ASSERT_NO_FATAL_FAILURE(
+      translate_dynamic_triton_matmul(EF_AMDGPU_MACH_AMDGCN_GFX942, translated));
+}
+
+TEST(Cdna4ToCdna3DispatchTest, TritonBufferAsyncMatmulTranslates) {
+  std::vector<uint8_t> translated;
+  ASSERT_NO_FATAL_FAILURE(translate_triton_fixture("triton_cdna4_matmul_buffer_async_1024",
+                                                   EF_AMDGPU_MACH_AMDGCN_GFX942, translated));
+}
+
+TEST(Cdna4ToCdna3DispatchTest, TritonFlashAttentionNoAsyncTranslates) {
+  std::vector<uint8_t> translated;
+  ASSERT_NO_FATAL_FAILURE(translate_triton_fixture("triton_cdna4_flash_attention_no_async_1024",
+                                                   EF_AMDGPU_MACH_AMDGCN_GFX942, translated));
+}
+
+TEST(Cdna4ToCdna3DispatchTest, TritonFlashAttentionBufferAsyncTranslates) {
+  std::vector<uint8_t> translated;
+  ASSERT_NO_FATAL_FAILURE(translate_triton_fixture("triton_cdna4_flash_attention_buffer_async_1024",
+                                                   EF_AMDGPU_MACH_AMDGCN_GFX942, translated));
+}
+
+TEST(Cdna4ToCdna3DispatchTest, DynamicCopyLoopDispatchAndRun) {
+  const hsa_status_t init_status = hsa_init();
+  if (init_status != HSA_STATUS_SUCCESS)
+    GTEST_SKIP() << "hsa_init failed with status " << init_status
+                 << "; CDNA4->CDNA3 dispatch verification requires an HSA-capable host";
+  const HsaShutdownGuard shutdown;
+
+  Cdna3Target target = find_cdna3_target();
+  if (target.agent.handle == 0)
+    GTEST_SKIP() << "Test requires a CDNA3 GPU agent (gfx940/gfx941/gfx942); found: "
+                 << join_seen_isas(target.seen_gpu_isas);
+
+  Executable exec(kernel_path("dynamic_copy_loop"));
+  ASSERT_TRUE(exec.is_valid());
+  ASSERT_GT(exec.num_code_objects(ROCJITSU_CODE_TARGET_GFX950), 0u);
+  const auto *co = exec.code_object(ROCJITSU_CODE_TARGET_GFX950, 0);
+  ASSERT_NE(co, nullptr);
+
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_CDNA3, target.mach);
+  auto translated = translator.translate(*co);
+  ASSERT_FALSE(translated.elf_bytes.empty());
+  ASSERT_TRUE(translated.ok()) << "Translation diagnostic: "
+                               << translated.diagnostics.front().message;
+
+  ASSERT_NO_FATAL_FAILURE(run_dynamic_copy_loop(translated.elf_bytes, target));
+}
+
+TEST(Cdna4ToCdna3DispatchTest, TritonDynamicMatmulDispatchAndRun) {
+  const std::array<TritonMatmulCase, 11> cases = {{
+      {32, 32, 64},
+      {32, 32, 65},
+      {32, 32, 66},
+      {32, 32, 128},
+      {32, 32, 130},
+      {32, 32, 192},
+      {32, 32, 512},
+      {512, 512, 512},
+      {31, 31, 64},
+      {32, 32, 63},
+      {257, 129, 130},
+  }};
+
+  const hsa_status_t init_status = hsa_init();
+  if (init_status != HSA_STATUS_SUCCESS)
+    GTEST_SKIP() << "hsa_init failed with status " << init_status
+                 << "; CDNA4->CDNA3 dispatch verification requires an HSA-capable host";
+  const HsaShutdownGuard shutdown;
+
+  Cdna3Target target = find_cdna3_target();
+  if (target.agent.handle == 0)
+    GTEST_SKIP() << "Test requires a CDNA3 GPU agent (gfx940/gfx941/gfx942); found: "
+                 << join_seen_isas(target.seen_gpu_isas);
+
+  std::vector<uint8_t> translated;
+  ASSERT_NO_FATAL_FAILURE(translate_dynamic_triton_matmul(target.mach, translated));
+  std::vector<uint8_t> native = load_kernel_hsaco_bytes("triton_cdna3_matmul_dynamic_32x32x64");
+  ASSERT_FALSE(native.empty());
+
+  for (const TritonMatmulCase &test_case : cases) {
+    SCOPED_TRACE(::testing::Message()
+                 << "M=" << test_case.m << " N=" << test_case.n << " K=" << test_case.k);
+    std::vector<float> translated_out;
+    std::vector<float> native_out;
+    ASSERT_NO_FATAL_FAILURE(
+        run_triton_matmul(translated, target, test_case, 8192, &translated_out));
+    ASSERT_NO_FATAL_FAILURE(run_triton_matmul(native, target, test_case, 4096, &native_out));
+    expect_float_vectors_near(translated_out, native_out, 0.02f,
+                              "translated-vs-native dynamic Triton matmul");
+  }
+}
+
+TEST(Cdna4ToCdna3DispatchTest, TritonBufferAsyncMatmulDispatchAndRun) {
+  const hsa_status_t init_status = hsa_init();
+  if (init_status != HSA_STATUS_SUCCESS)
+    GTEST_SKIP() << "hsa_init failed with status " << init_status
+                 << "; CDNA4->CDNA3 dispatch verification requires an HSA-capable host";
+  const HsaShutdownGuard shutdown;
+
+  Cdna3Target target = find_cdna3_target();
+  if (target.agent.handle == 0)
+    GTEST_SKIP() << "Test requires a CDNA3 GPU agent (gfx940/gfx941/gfx942); found: "
+                 << join_seen_isas(target.seen_gpu_isas);
+
+  std::vector<uint8_t> translated;
+  ASSERT_NO_FATAL_FAILURE(
+      translate_triton_fixture("triton_cdna4_matmul_buffer_async_1024", target.mach, translated));
+  std::vector<uint8_t> native = load_kernel_hsaco_bytes("triton_cdna3_matmul_buffer_async_1024");
+  ASSERT_FALSE(native.empty());
+
+  std::vector<float> translated_out;
+  std::vector<float> native_out;
+  ASSERT_NO_FATAL_FAILURE(
+      run_buffer_async_triton_matmul(translated, target, 65536, &translated_out));
+  ASSERT_NO_FATAL_FAILURE(run_buffer_async_triton_matmul(native, target, 8192, &native_out));
+  expect_float_vectors_near(translated_out, native_out, 0.02f,
+                            "translated-vs-native buffer async Triton matmul");
+}
+
+TEST(Cdna4ToCdna3DispatchTest, TritonBufferAsyncMatmulConservativeLivenessDispatchAndRun) {
+  const hsa_status_t init_status = hsa_init();
+  if (init_status != HSA_STATUS_SUCCESS)
+    GTEST_SKIP() << "hsa_init failed with status " << init_status
+                 << "; CDNA4->CDNA3 dispatch verification requires an HSA-capable host";
+  const HsaShutdownGuard shutdown;
+
+  Cdna3Target target = find_cdna3_target();
+  if (target.agent.handle == 0)
+    GTEST_SKIP() << "Test requires a CDNA3 GPU agent (gfx940/gfx941/gfx942); found: "
+                 << join_seen_isas(target.seen_gpu_isas);
+
+  BinaryTranslatorOptions options;
+  // The source descriptor declares 88 ordinary VGPRs and places AccVGPRs above
+  // that window. For this debug run, force semantic scratch above the ordinary
+  // VGPR range without changing the actual live-before sets.
+  options.debug_min_free_vgpr = 88;
+
+  std::vector<uint8_t> translated;
+  ASSERT_NO_FATAL_FAILURE(translate_triton_fixture("triton_cdna4_matmul_buffer_async_1024",
+                                                   target.mach, translated, options));
+  std::vector<uint8_t> native = load_kernel_hsaco_bytes("triton_cdna3_matmul_buffer_async_1024");
+  ASSERT_FALSE(native.empty());
+
+  std::vector<float> translated_out;
+  std::vector<float> native_out;
+  ASSERT_NO_FATAL_FAILURE(
+      run_buffer_async_triton_matmul(translated, target, 65536, &translated_out));
+  ASSERT_NO_FATAL_FAILURE(run_buffer_async_triton_matmul(native, target, 8192, &native_out));
+  expect_float_vectors_near(
+      translated_out, native_out, 0.02f,
+      "translated-vs-native conservative-liveness buffer async Triton matmul");
+}
+
+TEST(Cdna4ToCdna3DispatchTest, TritonFlashAttentionNoAsyncDispatchAndRun) {
+  const hsa_status_t init_status = hsa_init();
+  if (init_status != HSA_STATUS_SUCCESS)
+    GTEST_SKIP() << "hsa_init failed with status " << init_status
+                 << "; CDNA4->CDNA3 dispatch verification requires an HSA-capable host";
+  const HsaShutdownGuard shutdown;
+
+  Cdna3Target target = find_cdna3_target();
+  if (target.agent.handle == 0)
+    GTEST_SKIP() << "Test requires a CDNA3 GPU agent (gfx940/gfx941/gfx942); found: "
+                 << join_seen_isas(target.seen_gpu_isas);
+
+  std::vector<uint8_t> translated;
+  ASSERT_NO_FATAL_FAILURE(translate_triton_fixture("triton_cdna4_flash_attention_no_async_1024",
+                                                   target.mach, translated));
+  std::vector<uint8_t> native =
+      load_kernel_hsaco_bytes("triton_cdna3_flash_attention_no_async_1024");
+  ASSERT_FALSE(native.empty());
+
+  std::vector<float> translated_out;
+  std::vector<float> native_out;
+  ASSERT_NO_FATAL_FAILURE(run_flash_attention_triton(
+      translated, target, "flash_attention_fwd_no_async_kernel.kd", 65536, &translated_out));
+  ASSERT_NO_FATAL_FAILURE(run_flash_attention_triton(
+      native, target, "flash_attention_fwd_no_async_kernel.kd", 8192, &native_out));
+  expect_float_vectors_near(translated_out, native_out, 0.02f,
+                            "translated-vs-native flash attention no-async");
+}
+
+TEST(Cdna4ToCdna3DispatchTest, TritonFlashAttentionBufferAsyncDispatchAndRun) {
+  const hsa_status_t init_status = hsa_init();
+  if (init_status != HSA_STATUS_SUCCESS)
+    GTEST_SKIP() << "hsa_init failed with status " << init_status
+                 << "; CDNA4->CDNA3 dispatch verification requires an HSA-capable host";
+  const HsaShutdownGuard shutdown;
+
+  Cdna3Target target = find_cdna3_target();
+  if (target.agent.handle == 0)
+    GTEST_SKIP() << "Test requires a CDNA3 GPU agent (gfx940/gfx941/gfx942); found: "
+                 << join_seen_isas(target.seen_gpu_isas);
+
+  std::vector<uint8_t> translated;
+  ASSERT_NO_FATAL_FAILURE(translate_triton_fixture("triton_cdna4_flash_attention_buffer_async_1024",
+                                                   target.mach, translated));
+  std::vector<uint8_t> native =
+      load_kernel_hsaco_bytes("triton_cdna3_flash_attention_buffer_async_1024");
+  ASSERT_FALSE(native.empty());
+
+  std::vector<float> translated_out;
+  std::vector<float> native_out;
+  ASSERT_NO_FATAL_FAILURE(run_flash_attention_triton(
+      translated, target, "flash_attention_fwd_async_buffer_kernel.kd", 65536, &translated_out));
+  ASSERT_NO_FATAL_FAILURE(run_flash_attention_triton(
+      native, target, "flash_attention_fwd_async_buffer_kernel.kd", 8192, &native_out));
+  expect_float_vectors_near(translated_out, native_out, 0.02f,
+                            "translated-vs-native flash attention buffer-async");
+}
+
+#endif // HAS_HOST_AMDGPU

--- a/emulation/rocjitsu/tests/dbt/device_kernels_translate_tests.cpp
+++ b/emulation/rocjitsu/tests/dbt/device_kernels_translate_tests.cpp
@@ -486,6 +486,9 @@ TEST(BinaryTranslatorE2E, DescriptorPrologueRedirectsEntryWithoutOverwritingOrig
 
   EXPECT_GT(translated_info->entry_text_offset, original_info->entry_text_offset)
       << "CDNA4 workgroup-id SGPRs must be materialized from RDNA4's TTMP launch payload";
+  EXPECT_GE(translated_info->guest_vgpr_count, original_info->guest_vgpr_count)
+      << "Descriptor translation should not fabricate conservative VGPR headroom; semantic "
+         "lowerings grow the descriptor through explicit resource feedback when needed";
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
   ASSERT_NE(decoder, nullptr);

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -52,8 +52,13 @@
 #include "rocjitsu/code/dbt/generated/legalization_rdna4_to_cdna4.h"
 #include "rocjitsu/code/dbt/generated/legalization_types.h"
 #include "rocjitsu/code/dbt/kernel_descriptor_translator.h"
+#include "rocjitsu/code/dbt/semantic/rules.h"
 #include "rocjitsu/code/patch/code_object_patcher.h"
 #include "rocjitsu/code/patch/instruction_builder.h"
+#include "rocjitsu/isa/arch/amdgpu/cdna3/machine_insts.h"
+#include "rocjitsu/isa/arch/amdgpu/cdna4/machine_insts.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
 
 #include "rocjitsu/base/rj_compiler.h"
 RJ_DIAGNOSTIC_PUSH
@@ -72,6 +77,7 @@ RJ_DIAGNOSTIC_POP
 #include <iostream>
 #include <iterator>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -285,11 +291,12 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_load_segments() {
   return image;
 }
 
-std::vector<uint8_t> make_minimal_amdgpu_elf_with_descriptor_after_text() {
+std::vector<uint8_t>
+make_minimal_amdgpu_elf_with_descriptor_after_text(const std::vector<uint32_t> &text_words) {
   using KD = rocr::llvm::amdhsa::kernel_descriptor_t;
   constexpr uint64_t text_offset = 0x100;
   constexpr uint64_t text_vaddr = 0x1100;
-  constexpr uint64_t text_size = 8;
+  const uint64_t text_size = text_words.size() * sizeof(uint32_t);
   constexpr uint64_t load_align = 0x1000;
   constexpr uint64_t rodata_size = sizeof(KD);
 
@@ -353,7 +360,6 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_descriptor_after_text() {
   phdrs[1].p_align = load_align;
   std::memcpy(image.data() + ehdr.e_phoff, phdrs.data(), phdrs.size() * sizeof(Elf64_Phdr));
 
-  const std::array<uint32_t, 2> text_words = {0xBF800000u, 0xBF800000u};
   std::memcpy(image.data() + text_offset, text_words.data(), text_size);
 
   KD kd{};
@@ -412,6 +418,10 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_descriptor_after_text() {
 
   std::memcpy(image.data() + shoff, shdrs.data(), shdrs.size() * sizeof(Elf64_Shdr));
   return image;
+}
+
+std::vector<uint8_t> make_minimal_amdgpu_elf_with_descriptor_after_text() {
+  return make_minimal_amdgpu_elf_with_descriptor_after_text({0xBF800000u, 0xBF800000u});
 }
 
 std::vector<uint8_t> make_minimal_amdgpu_elf_with_two_kernel_descriptors() {
@@ -1305,6 +1315,510 @@ TEST(WaitcntTranslator, EncodeVmcnt0EmitsLoadcntAndStorecnt) {
   EXPECT_TRUE(has_storecnt_dscnt);
 }
 
+constexpr uint16_t kAnyExpectedField = 0xffff;
+
+enum class ExpectedCdna3Kind {
+  Vop3,
+  Vop1,
+  Sop1,
+  Vop3pMfma,
+  Ds,
+  Mubuf,
+  Sopp,
+};
+
+struct ExpectedCdna3Inst {
+  ExpectedCdna3Kind kind = ExpectedCdna3Kind::Vop3;
+  uint16_t op = 0;
+  uint16_t vdst = kAnyExpectedField;
+  uint16_t acc_cd = kAnyExpectedField;
+  uint16_t src0 = kAnyExpectedField;
+  uint16_t src1 = kAnyExpectedField;
+  uint16_t src2 = kAnyExpectedField;
+};
+
+struct Cdna4ToCdna3SemanticRuleCase {
+  const char *name = "";
+  uint16_t encoding_id = 0;
+  uint16_t opcode = 0;
+  std::array<uint32_t, 2> words{};
+  std::vector<ExpectedCdna3Inst> expected{};
+};
+
+ExpectedCdna3Inst expect_vop3(uint16_t op) {
+  ExpectedCdna3Inst inst{};
+  inst.kind = ExpectedCdna3Kind::Vop3;
+  inst.op = op;
+  return inst;
+}
+
+ExpectedCdna3Inst expect_vop1(uint16_t op) {
+  ExpectedCdna3Inst inst{};
+  inst.kind = ExpectedCdna3Kind::Vop1;
+  inst.op = op;
+  return inst;
+}
+
+ExpectedCdna3Inst expect_sop1(uint16_t op) {
+  ExpectedCdna3Inst inst{};
+  inst.kind = ExpectedCdna3Kind::Sop1;
+  inst.op = op;
+  return inst;
+}
+
+ExpectedCdna3Inst expect_mfma(uint16_t op, uint16_t vdst, uint16_t acc_cd, uint16_t src0,
+                              uint16_t src1, uint16_t src2) {
+  ExpectedCdna3Inst inst{};
+  inst.kind = ExpectedCdna3Kind::Vop3pMfma;
+  inst.op = op;
+  inst.vdst = vdst;
+  inst.acc_cd = acc_cd;
+  inst.src0 = src0;
+  inst.src1 = src1;
+  inst.src2 = src2;
+  return inst;
+}
+
+ExpectedCdna3Inst expect_ds(uint16_t op) {
+  ExpectedCdna3Inst inst{};
+  inst.kind = ExpectedCdna3Kind::Ds;
+  inst.op = op;
+  return inst;
+}
+
+ExpectedCdna3Inst expect_mubuf(uint16_t op) {
+  ExpectedCdna3Inst inst{};
+  inst.kind = ExpectedCdna3Kind::Mubuf;
+  inst.op = op;
+  return inst;
+}
+
+ExpectedCdna3Inst expect_sopp(uint16_t op) {
+  ExpectedCdna3Inst inst{};
+  inst.kind = ExpectedCdna3Kind::Sopp;
+  inst.op = op;
+  return inst;
+}
+
+std::vector<ExpectedCdna3Inst> expected_cdna3_bitop3_sequence(bool b16) {
+  // Truth table 0xde lowers to S2 ^ S1 ^ (S1 & S2) ^ S0 ^ (S0 & S1).
+  std::vector<ExpectedCdna3Inst> expected = {
+      expect_vop3(321), // v_mov_b32
+      expect_vop3(277), // v_xor_b32
+      expect_vop3(275), // v_and_b32
+      expect_vop3(277), // v_xor_b32
+      expect_vop3(277), // v_xor_b32
+      expect_vop3(275), // v_and_b32
+      expect_vop3(277), // v_xor_b32
+  };
+  if (b16) {
+    expected.push_back(expect_vop3(274)); // v_lshlrev_b32
+    expected.push_back(expect_vop3(272)); // v_lshrrev_b32
+  }
+  expected.push_back(expect_vop3(321)); // v_mov_b32 copy scratch accumulator to vdst.
+  expected.push_back(expect_sopp(2));   // s_branch back to original fallthrough.
+  return expected;
+}
+
+std::vector<ExpectedCdna3Inst> expected_cdna3_mfma_sequence(uint16_t narrow_op,
+                                                            uint16_t src2 = 128) {
+  return {
+      expect_mfma(narrow_op, 0, 1, 256, 260, src2),
+      expect_mfma(narrow_op, 0, 1, 258, 262, 256),
+      expect_sopp(2),
+  };
+}
+
+std::vector<ExpectedCdna3Inst> expected_cdna3_buffer_load_lds_sequence(uint16_t mubuf_op,
+                                                                       uint16_t ds_op) {
+  return {
+      expect_sop1(1),         // s_mov_b64 save EXEC.
+      expect_sop1(0),         // s_mov_b32 exec_lo, -1.
+      expect_sop1(0),         // s_mov_b32 exec_hi, -1.
+      expect_vop3(652),       // v_mbcnt_lo_u32_b32
+      expect_vop3(653),       // v_mbcnt_hi_u32_b32
+      expect_vop3(274),       // v_lshlrev_b32 lane_id, 4
+      expect_vop3(308),       // v_add_u32 m0, lane_offset
+      expect_sop1(1),         // s_mov_b64 restore EXEC.
+      expect_mubuf(mubuf_op), // buffer_load_dwordx{3,4} into scratch VGPRs.
+      expect_sopp(12),        // s_waitcnt 0 before consuming VMEM data.
+      expect_ds(ds_op),       // ds_write_b96/b128
+      expect_sopp(12),        // s_waitcnt lgkmcnt(0) for the explicit DS write.
+      expect_sopp(2),         // s_branch back to original fallthrough.
+  };
+}
+
+std::vector<ExpectedCdna3Inst> expected_cdna3_permlane32_swap_sequence() {
+  return {
+      expect_sop1(1),   // s_mov_b64 save EXEC.
+      expect_sop1(0),   // s_mov_b32 exec_lo, -1.
+      expect_sop1(0),   // s_mov_b32 exec_hi, -1.
+      expect_vop3(652), // v_mbcnt_lo_u32_b32
+      expect_vop3(653), // v_mbcnt_hi_u32_b32
+      expect_vop3(277), // v_xor_b32 lane, 32.
+      expect_vop3(274), // v_lshlrev_b32 byte address.
+      expect_ds(63),    // ds_bpermute_b32 from old vdst high half.
+      expect_ds(63),    // ds_bpermute_b32 from old src low half.
+      expect_sopp(12),  // s_waitcnt lgkmcnt(0).
+      expect_sop1(0),   // s_mov_b32 exec_lo, low-half mask.
+      expect_sop1(0),   // s_mov_b32 exec_hi, low-half mask.
+      expect_vop3(321), // v_mov_b32 src <- old vdst high.
+      expect_sop1(0),   // s_mov_b32 exec_lo, high-half mask.
+      expect_sop1(0),   // s_mov_b32 exec_hi, high-half mask.
+      expect_vop3(321), // v_mov_b32 vdst <- old src low.
+      expect_sop1(1),   // s_mov_b64 restore EXEC.
+      expect_sopp(2),   // s_branch back to original fallthrough.
+  };
+}
+
+std::vector<ExpectedCdna3Inst> expected_cdna3_raw_b16_pack_sequence() {
+  return {
+      expect_vop3(321), // v_mov_b32 -1
+      expect_vop3(272), // v_lshrrev_b32 16, mask
+      expect_vop3(275), // v_and_b32 low half
+      expect_vop3(275), // v_and_b32 high half
+      expect_vop3(274), // v_lshlrev_b32 16, high half
+      expect_vop3(276), // v_or_b32
+  };
+}
+
+std::vector<ExpectedCdna3Inst> expected_cdna3_cvt_pk_f16_f32_sequence() {
+  return {
+      expect_vop3(330), // v_cvt_f16_f32 low half into scratch.
+      expect_vop3(330), // v_cvt_f16_f32 high half into scratch.
+      expect_vop3(274), // v_lshlrev_b32 16, high half.
+      expect_vop3(276), // v_or_b32 pack low/high halves into vdst.
+      expect_sopp(2),   // s_branch back to original fallthrough.
+  };
+}
+
+std::vector<ExpectedCdna3Inst> expected_cdna3_ds_read_b64_tr_b16_sequence() {
+  std::vector<ExpectedCdna3Inst> expected = {
+      expect_ds(118),   // ds_read_b64
+      expect_sopp(12),  // s_waitcnt lgkmcnt(0)
+      expect_vop3(652), // v_mbcnt_lo_u32_b32
+      expect_vop3(653), // v_mbcnt_hi_u32_b32
+      expect_vop3(275), // v_and_b32
+      expect_vop3(274), // v_lshlrev_b32
+      expect_vop3(275), // v_and_b32
+      expect_vop3(274), // v_lshlrev_b32
+      expect_vop3(275), // v_and_b32
+      expect_vop3(276), // v_or_b32
+      expect_vop3(308), // v_add_u32
+      expect_vop3(274), // v_lshlrev_b32
+      expect_vop3(276), // v_or_b32
+      expect_ds(63),    // ds_bpermute_b32
+      expect_ds(63),    // ds_bpermute_b32
+      expect_sopp(12),  // s_waitcnt lgkmcnt(0)
+      expect_vop3(493), // v_perm_b32
+      expect_vop3(308), // v_add_u32
+      expect_ds(63),    expect_ds(63), expect_sopp(12), expect_vop3(493),
+  };
+
+  auto first_pack = expected_cdna3_raw_b16_pack_sequence();
+  expected.insert(expected.end(), first_pack.begin(), first_pack.end());
+  expected.insert(expected.end(), {
+                                      expect_vop3(308),
+                                      expect_ds(63),
+                                      expect_ds(63),
+                                      expect_sopp(12),
+                                      expect_vop3(493),
+                                      expect_vop3(308),
+                                      expect_ds(63),
+                                      expect_ds(63),
+                                      expect_sopp(12),
+                                      expect_vop3(493),
+                                  });
+  auto second_pack = expected_cdna3_raw_b16_pack_sequence();
+  expected.insert(expected.end(), second_pack.begin(), second_pack.end());
+  expected.push_back(expect_sopp(2));
+  return expected;
+}
+
+template <typename MachineInst>
+std::array<uint32_t, 2> encode_two_word_inst(const MachineInst &inst) {
+  std::array<uint32_t, 2> words{};
+  std::memcpy(words.data(), &inst, sizeof(inst));
+  return words;
+}
+
+std::array<uint32_t, 2> make_cdna4_bitop3_words(uint16_t opcode, uint8_t vdst) {
+  rocjitsu::cdna4::Vop3MachineInst inst{};
+  inst.encoding = 0x34;
+  inst.op = opcode;
+  inst.vdst = vdst;
+  inst.src0 = static_cast<uint16_t>(256 + vdst + 1);
+  inst.src1 = static_cast<uint16_t>(256 + vdst + 2);
+  inst.src2 = static_cast<uint16_t>(256 + vdst + 3);
+
+  // Use a non-trivial LUT so the generic expansion emits real AND/XOR work and
+  // cannot accidentally pass by lowering to a simple move.
+  constexpr uint8_t kTruthTable = 0xde;
+  inst.omod = kTruthTable >> 6;
+  inst.abs = (kTruthTable >> 3) & 0x7;
+  inst.neg = kTruthTable & 0x7;
+  return encode_two_word_inst(inst);
+}
+
+std::array<uint32_t, 2> make_cdna4_bitop3_b16_unsupported_op_sel_words() {
+  rocjitsu::cdna4::Vop3MachineInst inst{};
+  inst.encoding = 0x34;
+  inst.op = 563;
+  inst.vdst = 8;
+  inst.src0 = 256 + 9;
+  inst.src1 = 256 + 10;
+  inst.src2 = 256 + 11;
+  inst.op_sel = 1;
+  inst.omod = 1;
+  return encode_two_word_inst(inst);
+}
+
+std::array<uint32_t, 2> make_cdna4_cvt_pk_f16_f32_words() {
+  rocjitsu::cdna4::Vop3MachineInst inst{};
+  inst.encoding = 0x34;
+  inst.op = 615;
+  inst.vdst = 0;
+  inst.src0 = 256 + 1;
+  inst.src1 = 256 + 2;
+  return encode_two_word_inst(inst);
+}
+
+std::array<uint32_t, 2> make_cdna4_permlane32_swap_b32_words(uint16_t encoding_id) {
+  rocjitsu::cdna4::Vop1MachineInst inst{};
+  // The legalization table's VOP1 encoding ids (0xfc..0xff) are the generated
+  // primary-decode ids, not the raw 7-bit VOP1 selector.  Primary decode looks
+  // at bits 31:23, so VOP1 contributes its fixed selector in bits 31:25 and
+  // VDST[7:6] in bits 24:23.  Keep the real VOP1 selector at 0x3f and vary
+  // VDST's high bits to exercise each generated semantic rule.
+  inst.encoding = 0x3f;
+  inst.op = 90;
+  inst.vdst = static_cast<uint8_t>((encoding_id - 0xFCu) << 6);
+  inst.src0 = 256 + 1;
+  return encode_two_word_inst(inst);
+}
+
+std::array<uint32_t, 2> make_cdna4_mfma_words(uint8_t opcode, uint8_t vdst, uint16_t src0,
+                                              uint16_t src1, uint16_t src2 = 128) {
+  rocjitsu::cdna4::Vop3pMfmaMachineInst inst{};
+  inst.encoding = 0x1A7;
+  inst.op = opcode;
+  inst.vdst = vdst;
+  inst.acc_cd = 1;
+  inst.src0 = src0;
+  inst.src1 = src1;
+  inst.src2 = src2;
+  return encode_two_word_inst(inst);
+}
+
+std::array<uint32_t, 2> make_cdna4_mfma_vgpr_dst_alias_words() {
+  rocjitsu::cdna4::Vop3pMfmaMachineInst inst{};
+  inst.encoding = 0x1A7;
+  inst.op = 84;
+  inst.vdst = 0;
+  inst.acc_cd = 0;
+  // Ordinary-VGPR destination v[0:3] overlaps the first wide source window.
+  // The lowering must therefore place the first narrow MFMA's partial result in
+  // scratch and report that scratch through TranslationContext::require_vgprs().
+  inst.src0 = 256;
+  inst.src1 = 260;
+  inst.src2 = 128;
+  return encode_two_word_inst(inst);
+}
+
+std::array<uint32_t, 2> make_cdna4_dot2c_unimplemented_expand_words() {
+  // v_dot2c_f32_bf16 is present in CDNA4 and not CDNA3. The generated
+  // legalization table marks raw encoding-id 88/opcode 22 as EXPAND, but no
+  // handwritten semantic rule exists yet.
+  return {0x2C000000U, 0x00000000U};
+}
+
+std::array<uint32_t, 2> make_cdna4_ds_read_b64_tr_b16_words() {
+  rocjitsu::cdna4::DsMachineInst inst{};
+  inst.encoding = 0x36;
+  inst.op = 227;
+  inst.addr = 2;
+  inst.vdst = 0;
+  return encode_two_word_inst(inst);
+}
+
+std::array<uint32_t, 2> make_cdna4_buffer_load_lds_words(uint8_t op) {
+  rocjitsu::cdna4::MubufMachineInst inst{};
+  inst.encoding = 0x38;
+  inst.op = op;
+  inst.lds = 1;
+  inst.offen = 1;
+  inst.vaddr = 2;
+  inst.vdata = 0;
+  inst.srsrc = 4;
+  inst.soffset = 0;
+  return encode_two_word_inst(inst);
+}
+
+std::vector<Cdna4ToCdna3SemanticRuleCase> cdna4_to_cdna3_semantic_rule_cases() {
+  return {
+      {"VBitop3B16", 0x1A4, 563, make_cdna4_bitop3_words(563, 8),
+       expected_cdna3_bitop3_sequence(true)},
+      {"VBitop3B32", 0x1A4, 564, make_cdna4_bitop3_words(564, 16),
+       expected_cdna3_bitop3_sequence(false)},
+      {"VCvtPkF16F32", 0x1A4, 615, make_cdna4_cvt_pk_f16_f32_words(),
+       expected_cdna3_cvt_pk_f16_f32_sequence()},
+      {"VPermlane32SwapB32E32", 0xFC, 90, make_cdna4_permlane32_swap_b32_words(0xFC),
+       expected_cdna3_permlane32_swap_sequence()},
+      {"VPermlane32SwapB32E32Hi1", 0xFD, 90, make_cdna4_permlane32_swap_b32_words(0xFD),
+       expected_cdna3_permlane32_swap_sequence()},
+      {"VPermlane32SwapB32E32Hi2", 0xFE, 90, make_cdna4_permlane32_swap_b32_words(0xFE),
+       expected_cdna3_permlane32_swap_sequence()},
+      {"VPermlane32SwapB32E32Hi3", 0xFF, 90, make_cdna4_permlane32_swap_b32_words(0xFF),
+       expected_cdna3_permlane32_swap_sequence()},
+      {"MfmaF32_16x16x32F16", 0x1A7, 84, make_cdna4_mfma_words(84, 0, 256, 260),
+       expected_cdna3_mfma_sequence(77)},
+      {"MfmaF32_32x32x16F16", 0x1A7, 85, make_cdna4_mfma_words(85, 0, 256, 260),
+       expected_cdna3_mfma_sequence(76)},
+      {"MfmaF32_16x16x32F16AccumVgpr", 0x1A7, 84, make_cdna4_mfma_words(84, 0, 256, 260, 272),
+       expected_cdna3_mfma_sequence(77, 272)},
+      {"MfmaF32_32x32x16F16AccumVgpr", 0x1A7, 85, make_cdna4_mfma_words(85, 0, 256, 260, 272),
+       expected_cdna3_mfma_sequence(76, 272)},
+      {"DsReadB64TrB16", 0x1B3, 227, make_cdna4_ds_read_b64_tr_b16_words(),
+       expected_cdna3_ds_read_b64_tr_b16_sequence()},
+      {"BufferLoadDwordx3Lds", 0x1C0, 22, make_cdna4_buffer_load_lds_words(22),
+       expected_cdna3_buffer_load_lds_sequence(22, 222)},
+      {"BufferLoadDwordx4Lds", 0x1C0, 23, make_cdna4_buffer_load_lds_words(23),
+       expected_cdna3_buffer_load_lds_sequence(23, 223)},
+  };
+}
+
+bool has_cdna4_to_cdna3_semantic_rule(uint16_t encoding_id, uint16_t opcode) {
+  for (const auto &rule : rocjitsu::semantic_expand_rules_cdna4_to_cdna3()) {
+    if (rule.src_encoding_id == encoding_id && rule.src_opcode == opcode)
+      return true;
+  }
+  return false;
+}
+
+bool has_cdna4_to_cdna3_semantic_rule_case(uint16_t encoding_id, uint16_t opcode) {
+  for (const auto &test_case : cdna4_to_cdna3_semantic_rule_cases()) {
+    if (test_case.encoding_id == encoding_id && test_case.opcode == opcode)
+      return true;
+  }
+  return false;
+}
+
+void expect_field_matches(uint16_t expected, uint16_t actual, std::string_view field_name) {
+  if (expected != kAnyExpectedField)
+    EXPECT_EQ(actual, expected) << field_name;
+}
+
+void expect_cdna3_instruction_matches(const rocjitsu::Instruction &inst,
+                                      const ExpectedCdna3Inst &expected) {
+  const uint32_t *raw = inst.raw_encoding();
+  ASSERT_NE(raw, nullptr);
+
+  switch (expected.kind) {
+  case ExpectedCdna3Kind::Vop3: {
+    rocjitsu::cdna3::Vop3MachineInst actual{};
+    std::memcpy(&actual, raw, sizeof(actual));
+    EXPECT_EQ(actual.encoding, 0x34u);
+    EXPECT_EQ(actual.op, expected.op);
+    expect_field_matches(expected.vdst, static_cast<uint16_t>(actual.vdst), "vdst");
+    expect_field_matches(expected.src0, static_cast<uint16_t>(actual.src0), "src0");
+    expect_field_matches(expected.src1, static_cast<uint16_t>(actual.src1), "src1");
+    expect_field_matches(expected.src2, static_cast<uint16_t>(actual.src2), "src2");
+    break;
+  }
+  case ExpectedCdna3Kind::Vop1: {
+    rocjitsu::cdna3::Vop1MachineInst actual{};
+    std::memcpy(&actual, raw, sizeof(actual));
+    EXPECT_EQ(actual.op, expected.op);
+    break;
+  }
+  case ExpectedCdna3Kind::Sop1: {
+    rocjitsu::cdna3::Sop1MachineInst actual{};
+    std::memcpy(&actual, raw, sizeof(actual));
+    EXPECT_EQ(actual.encoding, 0x17Du);
+    EXPECT_EQ(actual.op, expected.op);
+    break;
+  }
+  case ExpectedCdna3Kind::Vop3pMfma: {
+    rocjitsu::cdna3::Vop3pMfmaMachineInst actual{};
+    std::memcpy(&actual, raw, sizeof(actual));
+    EXPECT_EQ(actual.encoding, 0x1A7u);
+    EXPECT_EQ(actual.op, expected.op);
+    expect_field_matches(expected.vdst, static_cast<uint16_t>(actual.vdst), "vdst");
+    expect_field_matches(expected.acc_cd, static_cast<uint16_t>(actual.acc_cd), "acc_cd");
+    expect_field_matches(expected.src0, static_cast<uint16_t>(actual.src0), "src0");
+    expect_field_matches(expected.src1, static_cast<uint16_t>(actual.src1), "src1");
+    expect_field_matches(expected.src2, static_cast<uint16_t>(actual.src2), "src2");
+    break;
+  }
+  case ExpectedCdna3Kind::Ds: {
+    rocjitsu::cdna3::DsMachineInst actual{};
+    std::memcpy(&actual, raw, sizeof(actual));
+    EXPECT_EQ(actual.encoding, 0x36u);
+    EXPECT_EQ(actual.op, expected.op);
+    expect_field_matches(expected.vdst, static_cast<uint16_t>(actual.vdst), "vdst");
+    break;
+  }
+  case ExpectedCdna3Kind::Mubuf: {
+    rocjitsu::cdna3::MubufMachineInst actual{};
+    std::memcpy(&actual, raw, sizeof(actual));
+    EXPECT_EQ(actual.encoding, 0x38u);
+    EXPECT_EQ(actual.op, expected.op);
+    EXPECT_EQ(actual.lds, 0u);
+    break;
+  }
+  case ExpectedCdna3Kind::Sopp: {
+    rocjitsu::cdna3::SoppMachineInst actual{};
+    std::memcpy(&actual, raw, sizeof(actual));
+    EXPECT_EQ(actual.encoding, 0x17Fu);
+    EXPECT_EQ(actual.op, expected.op);
+    break;
+  }
+  }
+}
+
+void expect_cdna3_code_cave_matches(const rocjitsu::Section &translations,
+                                    const std::vector<ExpectedCdna3Inst> &expected) {
+  ASSERT_EQ(translations.size() % sizeof(uint32_t), 0u);
+  ASSERT_GT(translations.size(), 0u);
+
+  auto decoder = rocjitsu::Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
+  ASSERT_NE(decoder, nullptr);
+
+  const auto *words = reinterpret_cast<const uint32_t *>(translations.data());
+  const size_t word_count = translations.size() / sizeof(uint32_t);
+  std::vector<std::unique_ptr<rocjitsu::Instruction>> actual;
+  for (size_t pc = 0; pc < word_count;) {
+    SCOPED_TRACE(pc);
+    auto inst = std::unique_ptr<rocjitsu::Instruction>(decoder->decode(&words[pc]));
+    ASSERT_NE(inst, nullptr);
+    ASSERT_GT(inst->size(), 0u);
+    ASSERT_EQ(inst->size() % sizeof(uint32_t), 0u);
+    ASSERT_LE(pc + inst->size() / sizeof(uint32_t), word_count);
+    pc += inst->size() / sizeof(uint32_t);
+    actual.push_back(std::move(inst));
+  }
+
+  ASSERT_EQ(actual.size(), expected.size());
+  for (size_t i = 0; i < expected.size(); ++i) {
+    SCOPED_TRACE(i);
+    expect_cdna3_instruction_matches(*actual[i], expected[i]);
+  }
+}
+
+void expect_cdna3_translated_descriptor_vgprs_at_least(const std::vector<uint8_t> &image,
+                                                       uint32_t expected_minimum) {
+  rocjitsu::AmdGpuCodeObject translated(image.data(), image.size());
+  ASSERT_TRUE(translated.is_valid());
+  ASSERT_FALSE(translated.text_sections().empty());
+
+  rocjitsu::KernelDescriptorTranslator parser(ROCJITSU_CODE_ARCH_CDNA3, ROCJITSU_CODE_ARCH_CDNA3);
+  const auto infos = parser.translate_image(image, translated.text_sections()[0]->sectionOffset(),
+                                            translated.text_sections()[0]->size(),
+                                            rocjitsu::KernelDescriptorTranslationOptions{});
+  ASSERT_EQ(infos.size(), 1u);
+  EXPECT_GE(infos[0].target_vgpr_count, expected_minimum);
+}
+
 // --- Synthetic BinaryTranslator integration tests ---
 TEST(BinaryTranslatorE2E, TranslatesMultiKernelCodeObject) {
   using KD = rocr::llvm::amdhsa::kernel_descriptor_t;
@@ -1369,6 +1883,185 @@ TEST(BinaryTranslatorE2E, TranslatesMultiKernelCodeObject) {
   std::ranges::sort(translated_descriptor_offsets);
   EXPECT_EQ(translated_entries, (std::vector<uint64_t>{0, sizeof(uint32_t)}));
   EXPECT_EQ(translated_descriptor_offsets, original_descriptor_offsets);
+}
+
+TEST(BinaryTranslatorE2E, Cdna4ToCdna3SemanticExpandRulesHaveTranslationFixtures) {
+  const auto test_cases = cdna4_to_cdna3_semantic_rule_cases();
+  const auto rules = rocjitsu::semantic_expand_rules_cdna4_to_cdna3();
+
+  for (const auto &rule : rules) {
+    EXPECT_TRUE(has_cdna4_to_cdna3_semantic_rule_case(rule.src_encoding_id, rule.src_opcode))
+        << "missing fixture for CDNA4->CDNA3 semantic rule encoding=0x" << std::hex
+        << rule.src_encoding_id << " opcode=" << rule.src_opcode << std::dec;
+  }
+  for (const auto &test_case : test_cases) {
+    EXPECT_TRUE(has_cdna4_to_cdna3_semantic_rule(test_case.encoding_id, test_case.opcode))
+        << "test fixture has no CDNA4->CDNA3 semantic rule: " << test_case.name;
+  }
+}
+
+class Cdna4ToCdna3SemanticRuleTranslationTest
+    : public ::testing::TestWithParam<Cdna4ToCdna3SemanticRuleCase> {};
+
+TEST_P(Cdna4ToCdna3SemanticRuleTranslationTest, TranslatesSingleInstruction) {
+  const auto &test_case = GetParam();
+  SCOPED_TRACE(test_case.name);
+
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text();
+  rocjitsu::AmdGpuCodeObject source_layout(image.data(), image.size());
+  ASSERT_TRUE(source_layout.is_valid());
+  ASSERT_FALSE(source_layout.text_sections().empty());
+
+  const auto *source_text = source_layout.text_sections()[0];
+  ASSERT_EQ(source_text->size(), test_case.words.size() * sizeof(uint32_t));
+  std::memcpy(image.data() + source_text->sectionOffset(), test_case.words.data(),
+              test_case.words.size() * sizeof(uint32_t));
+
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_CDNA3);
+  auto result = translator.translate(source);
+  ASSERT_FALSE(result.elf_bytes.empty());
+  ASSERT_TRUE(result.ok()) << result.diagnostics.front().message;
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_TRUE(translated.is_valid());
+  const rocjitsu::Section *translations = rocjitsu::find_section(translated, ".rj_translations");
+  ASSERT_NE(translations, nullptr);
+  expect_cdna3_code_cave_matches(*translations, test_case.expected);
+}
+
+INSTANTIATE_TEST_SUITE_P(ImplementedRules, Cdna4ToCdna3SemanticRuleTranslationTest,
+                         ::testing::ValuesIn(cdna4_to_cdna3_semantic_rule_cases()),
+                         [](const ::testing::TestParamInfo<Cdna4ToCdna3SemanticRuleCase> &info) {
+                           return std::string(info.param.name);
+                         });
+
+TEST(BinaryTranslatorE2E, Cdna4ToCdna3Bitop3ScratchGrowsDescriptor) {
+  constexpr uint16_t kScratchFloor = 120;
+  const auto words = make_cdna4_bitop3_words(564, 16);
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text({words[0], words[1]});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslatorOptions options;
+  options.debug_min_free_vgpr = kScratchFloor;
+  rocjitsu::BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_CDNA3, 0,
+                                        options);
+  auto result = translator.translate(source);
+
+  ASSERT_TRUE(result.ok()) << result.diagnostics.front().message;
+  ASSERT_FALSE(result.elf_bytes.empty());
+  // This fixture's LUT needs a two-VGPR scratch run. The conservative liveness
+  // floor forces that run above the descriptor's original allocation, so missing
+  // require_vgprs() feedback would leave the patched descriptor too small.
+  expect_cdna3_translated_descriptor_vgprs_at_least(result.elf_bytes, kScratchFloor + 2);
+}
+
+TEST(BinaryTranslatorE2E, Cdna4ToCdna3MfmaPartialScratchGrowsDescriptor) {
+  constexpr uint16_t kScratchFloor = 120;
+  const auto words = make_cdna4_mfma_vgpr_dst_alias_words();
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text({words[0], words[1]});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslatorOptions options;
+  options.debug_min_free_vgpr = kScratchFloor;
+  rocjitsu::BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_CDNA3, 0,
+                                        options);
+  auto result = translator.translate(source);
+
+  ASSERT_TRUE(result.ok()) << result.diagnostics.front().message;
+  ASSERT_FALSE(result.elf_bytes.empty());
+  // The 16x16x32 F16 lowering uses a four-VGPR partial accumulator when an
+  // ordinary destination overlaps the still-needed wide A/B source window.
+  expect_cdna3_translated_descriptor_vgprs_at_least(result.elf_bytes, kScratchFloor + 4);
+}
+
+TEST(BinaryTranslatorE2E, ExpandLegalizationWithoutSemanticRuleFails) {
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text();
+  rocjitsu::AmdGpuCodeObject source_layout(image.data(), image.size());
+  ASSERT_TRUE(source_layout.is_valid());
+  ASSERT_FALSE(source_layout.text_sections().empty());
+
+  const auto words = make_cdna4_dot2c_unimplemented_expand_words();
+  const auto *source_text = source_layout.text_sections()[0];
+  ASSERT_EQ(source_text->size(), words.size() * sizeof(uint32_t));
+  std::memcpy(image.data() + source_text->sectionOffset(), words.data(),
+              words.size() * sizeof(uint32_t));
+
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_CDNA3);
+  auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  ASSERT_FALSE(result.diagnostics.empty());
+  const auto diagnostic = std::ranges::find_if(result.diagnostics, [](const auto &d) {
+    return d.kind == rocjitsu::DiagnosticKind::ExpandMissing;
+  });
+  ASSERT_NE(diagnostic, result.diagnostics.end());
+  EXPECT_EQ(diagnostic->severity, rocjitsu::DiagnosticSeverity::Error);
+  EXPECT_EQ(diagnostic->guest_offset, std::optional<uint64_t>(0));
+  EXPECT_FALSE(diagnostic->required_work.empty());
+}
+
+TEST(BinaryTranslatorE2E, DebugContinueAfterFailureCollectsMultipleExpandDiagnostics) {
+  const auto first = make_cdna4_dot2c_unimplemented_expand_words();
+  const auto second = make_cdna4_dot2c_unimplemented_expand_words();
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(
+      {first[0], first[1], second[0], second[1]});
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslatorOptions options;
+  options.debug_continue_after_failure = true;
+  rocjitsu::BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_CDNA3, 0,
+                                        options);
+  auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.elf_bytes, image)
+      << "continued-failure diagnostics must not emit partially translated code";
+
+  std::vector<uint64_t> expand_offsets;
+  for (const auto &diagnostic : result.diagnostics) {
+    if (diagnostic.kind == rocjitsu::DiagnosticKind::ExpandMissing &&
+        diagnostic.guest_offset.has_value())
+      expand_offsets.push_back(*diagnostic.guest_offset);
+  }
+  EXPECT_EQ(expand_offsets, (std::vector<uint64_t>{0, 8}));
+}
+
+TEST(BinaryTranslatorE2E, MatchedSemanticExpandRuleFailureIsDiagnostic) {
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text();
+  rocjitsu::AmdGpuCodeObject source_layout(image.data(), image.size());
+  ASSERT_TRUE(source_layout.is_valid());
+  ASSERT_FALSE(source_layout.text_sections().empty());
+
+  const auto words = make_cdna4_bitop3_b16_unsupported_op_sel_words();
+  const auto *source_text = source_layout.text_sections()[0];
+  ASSERT_EQ(source_text->size(), words.size() * sizeof(uint32_t));
+  std::memcpy(image.data() + source_text->sectionOffset(), words.data(),
+              words.size() * sizeof(uint32_t));
+
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_CDNA3);
+  auto result = translator.translate(source);
+
+  EXPECT_FALSE(result.ok());
+  ASSERT_FALSE(result.diagnostics.empty());
+  const auto diagnostic = std::ranges::find_if(result.diagnostics, [](const auto &d) {
+    return d.kind == rocjitsu::DiagnosticKind::ExpandFailed;
+  });
+  ASSERT_NE(diagnostic, result.diagnostics.end());
+  EXPECT_EQ(diagnostic->severity, rocjitsu::DiagnosticSeverity::Error);
+  EXPECT_EQ(diagnostic->guest_offset, std::optional<uint64_t>(0));
+  EXPECT_FALSE(diagnostic->message.empty());
 }
 
 TEST(KernelDescriptorTranslator, IgnoresNonAllocExecutableSectionsForEntryRange) {

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -1704,8 +1704,9 @@ bool has_cdna4_to_cdna3_semantic_rule_case(uint16_t encoding_id, uint16_t opcode
 }
 
 void expect_field_matches(uint16_t expected, uint16_t actual, std::string_view field_name) {
-  if (expected != kAnyExpectedField)
+  if (expected != kAnyExpectedField) {
     EXPECT_EQ(actual, expected) << field_name;
+  }
 }
 
 void expect_cdna3_instruction_matches(const rocjitsu::Instruction &inst,

--- a/emulation/rocjitsu/tests/kernels/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/kernels/CMakeLists.txt
@@ -57,6 +57,42 @@ rj_add_device_kernel(matmul_mfma gfx950)
 rj_add_device_kernel(matmul_mfma_16x16 gfx950)
 rj_add_device_kernel(matmul_tiled gfx950)
 rj_add_device_kernel(vector_add gfx950)
+rj_add_device_kernel(dynamic_copy_loop gfx950)
+
+# Triton-generated assembly fixtures. The checked-in assembly records the
+# original Triton-generated kernels, so normal test builds only need the ROCm
+# assembler/linker and do not depend on a Python/Triton install.
+function(rj_add_triton_asm_fixture name target)
+    set(asm_obj ${KERNEL_OUTPUT_DIR}/${name}.asm.o)
+    set(hsaco ${KERNEL_OUTPUT_DIR}/${name}.hsaco)
+    add_custom_command(
+        OUTPUT ${asm_obj}
+        COMMAND
+            ${AMDCLANG} -x assembler -target amdgcn-amd-amdhsa -mcpu=${target}
+            --rocm-path=${ROCM_PATH} -c -o ${asm_obj}
+            ${CMAKE_CURRENT_SOURCE_DIR}/${name}.s
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${name}.s
+        COMMENT "Assembling Triton fixture: ${name} (${target})"
+    )
+    add_custom_command(
+        OUTPUT ${hsaco}
+        COMMAND
+            ${AMDCLANG} -target amdgcn-amd-amdhsa -mcpu=${target}
+            --rocm-path=${ROCM_PATH} -nostdlib -shared -o ${hsaco} ${asm_obj}
+        DEPENDS ${asm_obj}
+        COMMENT "Linking Triton fixture: ${name} (${target})"
+    )
+    add_custom_target(kernel_${name} DEPENDS ${hsaco})
+endfunction()
+
+rj_add_triton_asm_fixture(triton_cdna4_matmul_dynamic_32x32x64 gfx950)
+rj_add_triton_asm_fixture(triton_cdna4_matmul_buffer_async_1024 gfx950)
+rj_add_triton_asm_fixture(triton_cdna4_flash_attention_no_async_1024 gfx950)
+rj_add_triton_asm_fixture(triton_cdna4_flash_attention_buffer_async_1024 gfx950)
+rj_add_triton_asm_fixture(triton_cdna3_matmul_dynamic_32x32x64 gfx942)
+rj_add_triton_asm_fixture(triton_cdna3_matmul_buffer_async_1024 gfx942)
+rj_add_triton_asm_fixture(triton_cdna3_flash_attention_no_async_1024 gfx942)
+rj_add_triton_asm_fixture(triton_cdna3_flash_attention_buffer_async_1024 gfx942)
 
 # Umbrella target for all device kernels.
 add_custom_target(
@@ -67,6 +103,15 @@ add_custom_target(
         kernel_matmul_mfma_16x16
         kernel_matmul_tiled
         kernel_vector_add
+        kernel_dynamic_copy_loop
+        kernel_triton_cdna4_matmul_dynamic_32x32x64
+        kernel_triton_cdna4_matmul_buffer_async_1024
+        kernel_triton_cdna4_flash_attention_no_async_1024
+        kernel_triton_cdna4_flash_attention_buffer_async_1024
+        kernel_triton_cdna3_matmul_dynamic_32x32x64
+        kernel_triton_cdna3_matmul_buffer_async_1024
+        kernel_triton_cdna3_flash_attention_no_async_1024
+        kernel_triton_cdna3_flash_attention_buffer_async_1024
 )
 
 # Export variables to the parent scope so the test executable can use them.

--- a/emulation/rocjitsu/tests/kernels/dynamic_copy_loop.hip
+++ b/emulation/rocjitsu/tests/kernels/dynamic_copy_loop.hip
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <hip/hip_runtime.h>
+
+/// Runtime-sized copy kernel used by CDNA4->CDNA3 DBT dispatch tests.
+///
+/// The grid is intentionally allowed to be smaller than N. Each lane walks an
+/// explicit-stride loop, so the host test can dispatch the same kernel object
+/// for many dynamic sizes without recompiling or changing the workgroup shape.
+///
+/// The stride is passed as a normal kernarg instead of reading gridDim.x. These
+/// tests dispatch the code object through raw HSA, not the HIP runtime, and raw
+/// HSA launchers do not provide every HIP implicit runtime field.
+extern "C" __global__
+void dynamic_copy_loop(const unsigned *__restrict__ src, unsigned *__restrict__ dst, unsigned n,
+                       unsigned workgroup_size, unsigned stride) {
+  // The raw HSA dispatch path does not reliably materialize HIP's blockDim.x
+  // implicit field, so the host passes the packet workgroup size explicitly.
+  const unsigned first = blockIdx.x * workgroup_size + threadIdx.x;
+
+  for (unsigned i = first; i < n; i += stride)
+    dst[i] = src[i];
+}

--- a/emulation/rocjitsu/tests/kernels/triton_cdna3_flash_attention_buffer_async_1024.s
+++ b/emulation/rocjitsu/tests/kernels/triton_cdna3_flash_attention_buffer_async_1024.s
@@ -1,0 +1,2022 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// Native CDNA3/gfx942 Triton golden fixture generated from the same source and
+// constexprs as the corresponding gfx950 DBT input fixture.
+//
+// Recorded fixture metadata:
+//   kernel: flash_attention_fwd_async_buffer_kernel
+//   target: gfx942, wavefront_size: 64
+//   Triton metadata shared: 8192
+//   num_warps: 4
+//   num_stages: 2
+
+	.amdgcn_target "amdgcn-amd-amdhsa--gfx942"
+	.amdhsa_code_object_version 5
+	.text
+	.globl	flash_attention_fwd_async_buffer_kernel ; -- Begin function flash_attention_fwd_async_buffer_kernel
+	.p2align	8
+	.type	flash_attention_fwd_async_buffer_kernel,@function
+flash_attention_fwd_async_buffer_kernel: ; @flash_attention_fwd_async_buffer_kernel
+.Lfunc_begin0:
+	.cfi_sections .debug_frame
+	.cfi_startproc
+; %bb.37:
+	.file	1 "/tmp" "generate_rocjitsu_triton_fixtures.py"
+	.loc	1 122 0 prologue_end            ; generate_rocjitsu_triton_fixtures.py:122:0
+	s_load_dwordx2 s[2:3], s[0:1], 0x0
+	s_load_dwordx8 s[4:11], s[0:1], 0x8
+	s_load_dwordx4 s[12:15], s[0:1], 0x28
+	s_waitcnt lgkmcnt(0)
+	s_branch .LBB0_0
+	.loc	1 0 0 is_stmt 0                 ; :0:0
+.Ltmp0:
+	.p2align	8
+; %bb.38:
+.LBB0_0:
+.Ltmp1:
+	.loc	1 135 22 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:135:22
+	s_lshl_b32 s11, s16, 6
+	.loc	1 135 45 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:135:45
+	v_lshrrev_b32_e32 v1, 6, v0
+	s_mov_b64 s[0:1], s[6:7]
+	.loc	1 135 32                        ; generate_rocjitsu_triton_fixtures.py:135:32
+	v_or_b32_e32 v3, s11, v1
+	s_movk_i32 s6, 0x400
+	.loc	1 138 53 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:138:53
+	v_and_b32_e32 v2, 63, v0
+	.loc	1 139 59                        ; generate_rocjitsu_triton_fixtures.py:139:59
+	v_cmp_gt_i32_e32 vcc, s6, v3
+	v_mov_b32_e32 v5, 0
+	v_mov_b32_e32 v6, 0
+	.loc	1 139 16 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:139:16
+	s_and_saveexec_b64 s[6:7], vcc
+	s_cbranch_execz .LBB0_2
+; %bb.1:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	v_lshl_or_b32 v6, v3, 6, v2
+	v_ashrrev_i32_e32 v7, 31, v6
+	v_lshl_add_u64 v[6:7], v[6:7], 1, s[2:3]
+	.loc	1 139 16                        ; generate_rocjitsu_triton_fixtures.py:139:16
+	global_load_ushort v6, v[6:7], off
+.LBB0_2:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_or_b64 exec, exec, s[6:7]
+	v_lshlrev_b32_e32 v3, 6, v3
+	.loc	1 139 16                        ; generate_rocjitsu_triton_fixtures.py:139:16
+	s_and_saveexec_b64 s[6:7], vcc
+	s_cbranch_execz .LBB0_4
+; %bb.3:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_movk_i32 s12, 0x100
+	.loc	1 138 46 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:138:46
+	v_or3_b32 v4, v3, v2, s12
+	.loc	1 139 24                        ; generate_rocjitsu_triton_fixtures.py:139:24
+	v_ashrrev_i32_e32 v5, 31, v4
+	v_lshl_add_u64 v[4:5], v[4:5], 1, s[2:3]
+	.loc	1 139 16 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:139:16
+	global_load_ushort v5, v[4:5], off
+.LBB0_4:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_or_b64 exec, exec, s[6:7]
+	v_mov_b32_e32 v7, 0
+	v_mov_b32_e32 v8, 0
+	.loc	1 139 16                        ; generate_rocjitsu_triton_fixtures.py:139:16
+	s_and_saveexec_b64 s[6:7], vcc
+	s_cbranch_execz .LBB0_6
+; %bb.5:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_movk_i32 s12, 0x200
+	.loc	1 138 46 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:138:46
+	v_or3_b32 v8, v3, v2, s12
+	.loc	1 139 24                        ; generate_rocjitsu_triton_fixtures.py:139:24
+	v_ashrrev_i32_e32 v9, 31, v8
+	v_lshl_add_u64 v[8:9], v[8:9], 1, s[2:3]
+	.loc	1 139 16 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:139:16
+	global_load_ushort v8, v[8:9], off
+.LBB0_6:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_or_b64 exec, exec, s[6:7]
+	.loc	1 139 16                        ; generate_rocjitsu_triton_fixtures.py:139:16
+	s_and_saveexec_b64 s[6:7], vcc
+	s_cbranch_execz .LBB0_8
+; %bb.7:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_movk_i32 s12, 0x300
+	.loc	1 138 46 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:138:46
+	v_or3_b32 v10, v3, v2, s12
+	.loc	1 139 24                        ; generate_rocjitsu_triton_fixtures.py:139:24
+	v_ashrrev_i32_e32 v11, 31, v10
+	v_lshl_add_u64 v[10:11], v[10:11], 1, s[2:3]
+	.loc	1 139 16 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:139:16
+	global_load_ushort v7, v[10:11], off
+.LBB0_8:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_or_b64 exec, exec, s[6:7]
+	v_mov_b32_e32 v9, 0
+	v_mov_b32_e32 v10, 0
+	.loc	1 139 16                        ; generate_rocjitsu_triton_fixtures.py:139:16
+	s_and_saveexec_b64 s[6:7], vcc
+	s_cbranch_execz .LBB0_10
+; %bb.9:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_movk_i32 s12, 0x400
+	.loc	1 138 46 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:138:46
+	v_or3_b32 v10, v3, v2, s12
+	.loc	1 139 24                        ; generate_rocjitsu_triton_fixtures.py:139:24
+	v_ashrrev_i32_e32 v11, 31, v10
+	v_lshl_add_u64 v[10:11], v[10:11], 1, s[2:3]
+	.loc	1 139 16 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:139:16
+	global_load_ushort v10, v[10:11], off
+.LBB0_10:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_or_b64 exec, exec, s[6:7]
+	.loc	1 139 16                        ; generate_rocjitsu_triton_fixtures.py:139:16
+	s_and_saveexec_b64 s[6:7], vcc
+	s_cbranch_execz .LBB0_12
+; %bb.11:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_movk_i32 s12, 0x500
+	.loc	1 138 46 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:138:46
+	v_or3_b32 v12, v3, v2, s12
+	.loc	1 139 24                        ; generate_rocjitsu_triton_fixtures.py:139:24
+	v_ashrrev_i32_e32 v13, 31, v12
+	v_lshl_add_u64 v[12:13], v[12:13], 1, s[2:3]
+	.loc	1 139 16 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:139:16
+	global_load_ushort v9, v[12:13], off
+.LBB0_12:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_or_b64 exec, exec, s[6:7]
+	v_mov_b32_e32 v11, 0
+	v_mov_b32_e32 v12, 0
+	.loc	1 139 16                        ; generate_rocjitsu_triton_fixtures.py:139:16
+	s_and_saveexec_b64 s[6:7], vcc
+	s_cbranch_execz .LBB0_14
+; %bb.13:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_movk_i32 s12, 0x600
+	.loc	1 138 46 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:138:46
+	v_or3_b32 v12, v3, v2, s12
+	.loc	1 139 24                        ; generate_rocjitsu_triton_fixtures.py:139:24
+	v_ashrrev_i32_e32 v13, 31, v12
+	v_lshl_add_u64 v[12:13], v[12:13], 1, s[2:3]
+	.loc	1 139 16 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:139:16
+	global_load_ushort v12, v[12:13], off
+.LBB0_14:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_or_b64 exec, exec, s[6:7]
+	.loc	1 139 16                        ; generate_rocjitsu_triton_fixtures.py:139:16
+	s_and_saveexec_b64 s[6:7], vcc
+	s_cbranch_execz .LBB0_16
+; %bb.15:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_movk_i32 s12, 0x700
+	.loc	1 138 46 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:138:46
+	v_or3_b32 v14, v3, v2, s12
+	.loc	1 139 24                        ; generate_rocjitsu_triton_fixtures.py:139:24
+	v_ashrrev_i32_e32 v15, 31, v14
+	v_lshl_add_u64 v[14:15], v[14:15], 1, s[2:3]
+	.loc	1 139 16 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:139:16
+	global_load_ushort v11, v[14:15], off
+.LBB0_16:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_or_b64 exec, exec, s[6:7]
+	v_mov_b32_e32 v13, 0
+	v_mov_b32_e32 v14, 0
+	.loc	1 139 16                        ; generate_rocjitsu_triton_fixtures.py:139:16
+	s_and_saveexec_b64 s[6:7], vcc
+	s_cbranch_execz .LBB0_18
+; %bb.17:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_movk_i32 s12, 0x800
+	.loc	1 138 46 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:138:46
+	v_or3_b32 v14, v3, v2, s12
+	.loc	1 139 24                        ; generate_rocjitsu_triton_fixtures.py:139:24
+	v_ashrrev_i32_e32 v15, 31, v14
+	v_lshl_add_u64 v[14:15], v[14:15], 1, s[2:3]
+	.loc	1 139 16 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:139:16
+	global_load_ushort v14, v[14:15], off
+.LBB0_18:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_or_b64 exec, exec, s[6:7]
+	.loc	1 139 16                        ; generate_rocjitsu_triton_fixtures.py:139:16
+	s_and_saveexec_b64 s[6:7], vcc
+	s_cbranch_execz .LBB0_20
+; %bb.19:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_movk_i32 s12, 0x900
+	.loc	1 138 46 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:138:46
+	v_or3_b32 v16, v3, v2, s12
+	.loc	1 139 24                        ; generate_rocjitsu_triton_fixtures.py:139:24
+	v_ashrrev_i32_e32 v17, 31, v16
+	v_lshl_add_u64 v[16:17], v[16:17], 1, s[2:3]
+	.loc	1 139 16 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:139:16
+	global_load_ushort v13, v[16:17], off
+.LBB0_20:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_or_b64 exec, exec, s[6:7]
+	v_mov_b32_e32 v15, 0
+	v_mov_b32_e32 v16, 0
+	.loc	1 139 16                        ; generate_rocjitsu_triton_fixtures.py:139:16
+	s_and_saveexec_b64 s[6:7], vcc
+	s_cbranch_execz .LBB0_22
+; %bb.21:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_movk_i32 s12, 0xa00
+	.loc	1 138 46 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:138:46
+	v_or3_b32 v16, v3, v2, s12
+	.loc	1 139 24                        ; generate_rocjitsu_triton_fixtures.py:139:24
+	v_ashrrev_i32_e32 v17, 31, v16
+	v_lshl_add_u64 v[16:17], v[16:17], 1, s[2:3]
+	.loc	1 139 16 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:139:16
+	global_load_ushort v16, v[16:17], off
+.LBB0_22:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_or_b64 exec, exec, s[6:7]
+	.loc	1 139 16                        ; generate_rocjitsu_triton_fixtures.py:139:16
+	s_and_saveexec_b64 s[6:7], vcc
+	s_cbranch_execz .LBB0_24
+; %bb.23:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_movk_i32 s12, 0xb00
+	.loc	1 138 46 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:138:46
+	v_or3_b32 v18, v3, v2, s12
+	.loc	1 139 24                        ; generate_rocjitsu_triton_fixtures.py:139:24
+	v_ashrrev_i32_e32 v19, 31, v18
+	v_lshl_add_u64 v[18:19], v[18:19], 1, s[2:3]
+	.loc	1 139 16 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:139:16
+	global_load_ushort v15, v[18:19], off
+.LBB0_24:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_or_b64 exec, exec, s[6:7]
+	v_mov_b32_e32 v17, 0
+	v_mov_b32_e32 v18, 0
+	.loc	1 139 16                        ; generate_rocjitsu_triton_fixtures.py:139:16
+	s_and_saveexec_b64 s[6:7], vcc
+	s_cbranch_execz .LBB0_26
+; %bb.25:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_movk_i32 s12, 0xc00
+	.loc	1 138 46 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:138:46
+	v_or3_b32 v18, v3, v2, s12
+	.loc	1 139 24                        ; generate_rocjitsu_triton_fixtures.py:139:24
+	v_ashrrev_i32_e32 v19, 31, v18
+	v_lshl_add_u64 v[18:19], v[18:19], 1, s[2:3]
+	.loc	1 139 16 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:139:16
+	global_load_ushort v18, v[18:19], off
+.LBB0_26:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_or_b64 exec, exec, s[6:7]
+	.loc	1 139 16                        ; generate_rocjitsu_triton_fixtures.py:139:16
+	s_and_saveexec_b64 s[6:7], vcc
+	s_cbranch_execz .LBB0_28
+; %bb.27:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_movk_i32 s12, 0xd00
+	.loc	1 138 46 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:138:46
+	v_or3_b32 v20, v3, v2, s12
+	.loc	1 139 24                        ; generate_rocjitsu_triton_fixtures.py:139:24
+	v_ashrrev_i32_e32 v21, 31, v20
+	v_lshl_add_u64 v[20:21], v[20:21], 1, s[2:3]
+	.loc	1 139 16 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:139:16
+	global_load_ushort v17, v[20:21], off
+.LBB0_28:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_or_b64 exec, exec, s[6:7]
+	v_mov_b32_e32 v19, 0
+	v_mov_b32_e32 v20, 0
+	.loc	1 139 16                        ; generate_rocjitsu_triton_fixtures.py:139:16
+	s_and_saveexec_b64 s[6:7], vcc
+	s_cbranch_execz .LBB0_30
+; %bb.29:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_movk_i32 s12, 0xe00
+	.loc	1 138 46 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:138:46
+	v_or3_b32 v20, v3, v2, s12
+	.loc	1 139 24                        ; generate_rocjitsu_triton_fixtures.py:139:24
+	v_ashrrev_i32_e32 v21, 31, v20
+	v_lshl_add_u64 v[20:21], v[20:21], 1, s[2:3]
+	.loc	1 139 16 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:139:16
+	global_load_ushort v20, v[20:21], off
+.LBB0_30:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_or_b64 exec, exec, s[6:7]
+	v_and_b32_e32 v4, 0xc0, v0
+	.loc	1 139 16                        ; generate_rocjitsu_triton_fixtures.py:139:16
+	s_and_saveexec_b64 s[6:7], vcc
+	s_cbranch_execz .LBB0_32
+; %bb.31:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_movk_i32 s12, 0xf00
+	.loc	1 138 46 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:138:46
+	v_or3_b32 v22, v3, v2, s12
+	.loc	1 139 24                        ; generate_rocjitsu_triton_fixtures.py:139:24
+	v_ashrrev_i32_e32 v23, 31, v22
+	v_lshl_add_u64 v[22:23], v[22:23], 1, s[2:3]
+	.loc	1 139 16 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:139:16
+	global_load_ushort v19, v[22:23], off
+.LBB0_32:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_or_b64 exec, exec, s[6:7]
+	.loc	1 135 45 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:135:45
+	v_and_b32_e32 v3, 64, v0
+	v_and_b32_e32 v67, 31, v0
+	v_lshrrev_b32_e32 v65, 1, v3
+	.loc	1 135 32 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:135:32
+	v_or3_b32 v21, s11, v67, v65
+	s_movk_i32 s2, 0x400
+	.loc	1 139 59 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:139:59
+	v_cmp_gt_i32_e32 vcc, s2, v21
+	.loc	1 139 16 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:139:16
+	v_lshlrev_b32_e32 v21, 1, v0
+	v_lshrrev_b32_e32 v4, 3, v4
+	v_xor_b32_e32 v21, v21, v4
+	v_add_u32_e32 v69, 0, v21
+	s_waitcnt vmcnt(0)
+	ds_write_b16 v69, v6
+	ds_write_b16 v69, v10 offset:2048
+	ds_write_b16 v69, v14 offset:4096
+	ds_write_b16 v69, v18 offset:6144
+	v_xor_b32_e32 v6, 32, v21
+	v_add_u32_e32 v70, 0, v6
+	ds_write_b16 v70, v5 offset:512
+	ds_write_b16 v70, v9 offset:2560
+	ds_write_b16 v70, v13 offset:4608
+	ds_write_b16 v70, v17 offset:6656
+	v_xor_b32_e32 v5, 64, v21
+	v_add_u32_e32 v71, 0, v5
+	v_xor_b32_e32 v5, 0x60, v21
+	.loc	1 135 45 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:135:45
+	v_and_b32_e32 v66, 32, v0
+	.loc	1 139 16                        ; generate_rocjitsu_triton_fixtures.py:139:16
+	v_add_u32_e32 v72, 0, v5
+	v_and_b32_e32 v6, 15, v0
+	ds_write_b16 v71, v8 offset:1024
+	ds_write_b16 v71, v12 offset:3072
+	ds_write_b16 v71, v16 offset:5120
+	ds_write_b16 v71, v20 offset:7168
+	ds_write_b16 v72, v7 offset:1536
+	ds_write_b16 v72, v11 offset:3584
+	ds_write_b16 v72, v15 offset:5632
+	ds_write_b16 v72, v19 offset:7680
+	v_lshlrev_b32_e32 v7, 3, v6
+	v_lshrrev_b32_e32 v8, 2, v66
+	v_lshlrev_b32_e32 v5, 7, v67
+	v_lshlrev_b32_e32 v9, 6, v3
+	v_xor_b32_e32 v10, v7, v8
+	v_or3_b32 v9, v10, v9, v5
+	.loc	1 135 45                        ; generate_rocjitsu_triton_fixtures.py:135:45
+	v_and_b32_e32 v68, 0x80, v0
+	.loc	1 139 16                        ; generate_rocjitsu_triton_fixtures.py:139:16
+	v_add_u32_e32 v10, 0, v9
+	v_xad_u32 v11, v9, 16, 0
+	v_xad_u32 v12, v9, 32, 0
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	v_xad_u32 v13, v9, 48, 0
+	ds_read_b64 v[16:17], v10
+	ds_read_b64 v[18:19], v11
+	ds_read_b64 v[20:21], v12
+	ds_read_b64 v[22:23], v13
+	v_xad_u32 v10, v9, 64, 0
+	v_xor_b32_e32 v11, 0x50, v9
+	v_xor_b32_e32 v12, 0x60, v9
+	v_xor_b32_e32 v9, 0x70, v9
+	v_lshlrev_b32_e32 v15, 2, v0
+	v_lshl_add_u32 v34, v66, 4, 0
+	v_lshrrev_b32_e32 v35, 1, v68
+	.loc	1 135 45                        ; generate_rocjitsu_triton_fixtures.py:135:45
+	v_bfe_i32 v32, v0, 6, 1
+	.loc	1 139 16                        ; generate_rocjitsu_triton_fixtures.py:139:16
+	v_add_u32_e32 v11, 0, v11
+	v_add_u32_e32 v12, 0, v12
+	v_add_u32_e32 v9, 0, v9
+	ds_read_b64 v[24:25], v10
+	ds_read_b64 v[26:27], v11
+	ds_read_b64 v[28:29], v12
+	ds_read_b64 v[30:31], v9
+	v_or_b32_e32 v5, v5, v7
+	v_xor_b32_e32 v76, 0x80, v15
+	v_lshlrev_b32_e32 v15, 1, v3
+	v_add_u32_e32 v3, v34, v3
+	v_add_u32_e32 v34, v34, v35
+	v_lshrrev_b32_e32 v35, 1, v0
+	v_bfe_i32 v0, v0, 4, 1
+	s_movk_i32 s2, 0x1010
+	v_xor_b32_e32 v75, v5, v8
+	v_and_b32_e32 v35, 24, v35
+	v_and_b32_e32 v0, 0x808, v0
+	v_and_or_b32 v8, v32, s2, v8
+	v_xor_b32_e32 v35, v7, v35
+	v_xor_b32_e32 v0, v0, v8
+	v_xor_b32_e32 v4, v35, v4
+	v_xor_b32_e32 v0, v0, v7
+	.loc	1 144 31                        ; generate_rocjitsu_triton_fixtures.py:144:31
+	v_mov_b32_e32 v9, 0x3fb8aa3b
+	v_lshl_or_b32 v78, v2, 7, v4
+	v_lshl_or_b32 v79, v6, 7, v0
+	v_mul_f32_e32 v73, s10, v9
+	s_mov_b32 s7, 0x27000
+	s_mov_b32 s6, 0x7ffffffe
+	v_lshlrev_b32_e32 v74, 1, v2
+	v_xor_b32_e32 v5, 16, v75
+	v_xor_b32_e32 v9, 32, v75
+	v_xor_b32_e32 v10, 48, v75
+	v_xor_b32_e32 v11, 64, v75
+	v_xor_b32_e32 v12, 0x50, v75
+	v_xor_b32_e32 v13, 0x60, v75
+	v_xor_b32_e32 v14, 0x70, v75
+	v_lshl_add_u32 v77, v67, 2, 0
+	v_lshlrev_b32_e32 v33, 1, v67
+	v_xor_b32_e32 v2, 32, v78
+	v_xor_b32_e32 v4, 64, v78
+	v_xor_b32_e32 v35, 0x60, v78
+	v_xor_b32_e32 v0, 16, v79
+	v_xor_b32_e32 v6, 32, v79
+	v_xor_b32_e32 v7, 48, v79
+	v_xor_b32_e32 v8, 64, v79
+	v_xor_b32_e32 v32, 0x50, v79
+	v_xor_b32_e32 v36, 0x60, v79
+	v_xor_b32_e32 v37, 0x70, v79
+	s_and_b32 s5, s5, 0xffff
+	s_and_b32 s1, s1, 0xffff
+	.loc	1 145 48                        ; generate_rocjitsu_triton_fixtures.py:145:48
+	v_lshlrev_b32_e32 v80, 9, v1
+	v_lshlrev_b32_e32 v81, 7, v1
+	v_mov_b32_e32 v82, 0xe0ad78ec
+	v_mov_b32_e32 v103, 0
+	v_accvgpr_write_b32 a15, 0
+	v_accvgpr_write_b32 a14, 0
+	v_accvgpr_write_b32 a13, 0
+	v_accvgpr_write_b32 a12, 0
+	v_accvgpr_write_b32 a11, 0
+	v_accvgpr_write_b32 a10, 0
+	v_accvgpr_write_b32 a9, 0
+	v_accvgpr_write_b32 a8, 0
+	v_accvgpr_write_b32 a7, 0
+	v_accvgpr_write_b32 a6, 0
+	v_accvgpr_write_b32 a5, 0
+	v_accvgpr_write_b32 a4, 0
+	v_accvgpr_write_b32 a3, 0
+	v_accvgpr_write_b32 a2, 0
+	v_accvgpr_write_b32 a1, 0
+	v_accvgpr_write_b32 a0, 0
+	s_movk_i32 s10, 0xffc0
+	v_add_u32_e32 v83, 0, v5
+	v_add_u32_e32 v84, 0, v9
+	v_add_u32_e32 v85, 0, v10
+	v_add_u32_e32 v86, 0, v11
+	v_add_u32_e32 v87, 0, v12
+	v_add_u32_e32 v88, 0, v13
+	v_add_u32_e32 v89, 0, v14
+	s_mov_b32 s2, s6
+	s_mov_b32 s3, s7
+	v_add_u32_e32 v90, v3, v33
+	v_add_u32_e32 v91, v34, v33
+	s_mov_b32 s12, 0x5040100
+	v_add_u32_e32 v92, 0, v2
+	v_add_u32_e32 v94, 0, v4
+	v_add_u32_e32 v95, 0, v35
+	v_add_u32_e32 v96, 0, v0
+	v_add_u32_e32 v97, 0, v6
+	v_add_u32_e32 v98, 0, v7
+	v_add_u32_e32 v99, 0, v8
+	v_add_u32_e32 v100, 0, v32
+	v_add_u32_e32 v101, 0, v36
+	v_add_u32_e32 v102, 0, v37
+	v_add_u32_e32 v93, v77, v15
+	v_mov_b32_e32 v33, 0xe0ad78ec
+.LBB0_33:                               ; =>This Inner Loop Header: Depth=1
+	.loc	1 0 48 is_stmt 0                ; generate_rocjitsu_triton_fixtures.py:0:48
+	v_mov_b32_e32 v32, v103
+	.loc	1 145 48                        ; generate_rocjitsu_triton_fixtures.py:145:48
+	s_nop 3
+	v_accvgpr_read_b32 v15, a15
+	v_accvgpr_read_b32 v14, a14
+	v_accvgpr_read_b32 v13, a13
+	v_accvgpr_read_b32 v12, a12
+	v_accvgpr_read_b32 v11, a11
+	v_accvgpr_read_b32 v10, a10
+	v_accvgpr_read_b32 v9, a9
+	v_accvgpr_read_b32 v8, a8
+	v_accvgpr_read_b32 v7, a7
+	v_accvgpr_read_b32 v6, a6
+	v_accvgpr_read_b32 v5, a5
+	v_accvgpr_read_b32 v4, a4
+	v_accvgpr_read_b32 v3, a3
+	v_accvgpr_read_b32 v2, a2
+	v_accvgpr_read_b32 v1, a1
+	v_accvgpr_read_b32 v0, a0
+	; sched_barrier mask(0x00000000)
+	.loc	1 149 20 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:149:20
+	v_add_u32_e32 v34, v74, v81
+	buffer_load_ushort v35, v34, s[4:7], 0 offen
+	buffer_load_ushort v36, v34, s[4:7], 0 offen offset:512
+	buffer_load_ushort v37, v34, s[4:7], 0 offen offset:1024
+	buffer_load_ushort v38, v34, s[4:7], 0 offen offset:1536
+	buffer_load_ushort v39, v34, s[4:7], 0 offen offset:2048
+	buffer_load_ushort v40, v34, s[4:7], 0 offen offset:2560
+	buffer_load_ushort v41, v34, s[4:7], 0 offen offset:3072
+	buffer_load_ushort v42, v34, s[4:7], 0 offen offset:3584
+	v_add_u32_e32 v34, 0x1000, v34
+	buffer_load_ushort v43, v34, s[4:7], 0 offen
+	buffer_load_ushort v44, v34, s[4:7], 0 offen offset:512
+	buffer_load_ushort v45, v34, s[4:7], 0 offen offset:1024
+	buffer_load_ushort v46, v34, s[4:7], 0 offen offset:1536
+	buffer_load_ushort v47, v34, s[4:7], 0 offen offset:2048
+	buffer_load_ushort v48, v34, s[4:7], 0 offen offset:2560
+	buffer_load_ushort v49, v34, s[4:7], 0 offen offset:3072
+	buffer_load_ushort v50, v34, s[4:7], 0 offen offset:3584
+                                        ; kill: killed $vgpr34
+	v_add_u32_e32 v34, 0, v75
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	; iglp_opt mask(0x00000002)
+	s_waitcnt vmcnt(15)
+	ds_write_b16 v69, v35
+	s_waitcnt vmcnt(14)
+	ds_write_b16 v70, v36 offset:512
+	s_waitcnt vmcnt(13)
+	ds_write_b16 v71, v37 offset:1024
+	s_waitcnt vmcnt(12)
+	ds_write_b16 v72, v38 offset:1536
+	s_waitcnt vmcnt(11)
+	ds_write_b16 v69, v39 offset:2048
+	s_waitcnt vmcnt(10)
+	ds_write_b16 v70, v40 offset:2560
+	s_waitcnt vmcnt(9)
+	ds_write_b16 v71, v41 offset:3072
+	s_waitcnt vmcnt(8)
+	ds_write_b16 v72, v42 offset:3584
+	s_waitcnt vmcnt(7)
+	ds_write_b16 v69, v43 offset:4096
+	s_waitcnt vmcnt(6)
+	ds_write_b16 v70, v44 offset:4608
+	s_waitcnt vmcnt(5)
+	ds_write_b16 v71, v45 offset:5120
+	s_waitcnt vmcnt(4)
+	ds_write_b16 v72, v46 offset:5632
+	s_waitcnt vmcnt(3)
+	ds_write_b16 v69, v47 offset:6144
+	s_waitcnt vmcnt(2)
+	ds_write_b16 v70, v48 offset:6656
+	s_waitcnt vmcnt(1)
+	ds_write_b16 v71, v49 offset:7168
+	s_waitcnt vmcnt(0)
+	ds_write_b16 v72, v50 offset:7680
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	ds_read2st64_b64 v[34:37], v34 offset1:8
+	ds_read2st64_b64 v[38:41], v83 offset1:8
+	.loc	1 151 23                        ; generate_rocjitsu_triton_fixtures.py:151:23
+	s_waitcnt lgkmcnt(1)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[34:35], v[16:17], 0
+	.loc	1 149 20                        ; generate_rocjitsu_triton_fixtures.py:149:20
+	ds_read2st64_b64 v[42:45], v84 offset1:8
+	ds_read2st64_b64 v[46:49], v85 offset1:8
+	ds_read2st64_b64 v[50:53], v86 offset1:8
+	ds_read2st64_b64 v[54:57], v87 offset1:8
+	ds_read2st64_b64 v[58:61], v88 offset1:8
+	ds_read2st64_b64 v[104:107], v89 offset1:8
+	.loc	1 151 23                        ; generate_rocjitsu_triton_fixtures.py:151:23
+	s_waitcnt lgkmcnt(6)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[38:39], v[18:19], a[0:15]
+	s_waitcnt lgkmcnt(5)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[42:43], v[20:21], a[0:15]
+	s_waitcnt lgkmcnt(4)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[46:47], v[22:23], a[0:15]
+	s_waitcnt lgkmcnt(3)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[50:51], v[24:25], a[0:15]
+	s_waitcnt lgkmcnt(2)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[54:55], v[26:27], a[0:15]
+	s_waitcnt lgkmcnt(1)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[58:59], v[28:29], a[0:15]
+	s_waitcnt lgkmcnt(0)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[104:105], v[30:31], a[0:15]
+	s_nop 10
+	v_accvgpr_read_b32 v34, a0
+	v_accvgpr_read_b32 v35, a1
+	v_accvgpr_read_b32 v38, a2
+	v_accvgpr_read_b32 v39, a3
+	v_accvgpr_read_b32 v42, a4
+	v_accvgpr_read_b32 v43, a5
+	v_accvgpr_read_b32 v46, a6
+	v_accvgpr_read_b32 v47, a7
+	v_accvgpr_read_b32 v50, a8
+	v_accvgpr_read_b32 v51, a9
+	v_accvgpr_read_b32 v54, a10
+	v_accvgpr_read_b32 v55, a11
+	v_accvgpr_read_b32 v58, a12
+	v_accvgpr_read_b32 v59, a13
+	v_accvgpr_read_b32 v62, a14
+	v_accvgpr_read_b32 v63, a15
+	v_mfma_f32_32x32x8_f16 a[0:15], v[36:37], v[16:17], 0
+	.loc	1 151 50 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:151:50
+	v_mul_f32_e32 v34, v73, v34
+	v_mul_f32_e32 v35, v73, v35
+	v_mul_f32_e32 v38, v73, v38
+	v_mul_f32_e32 v39, v73, v39
+	.loc	1 152 77 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:152:77
+	v_cndmask_b32_e32 v34, v82, v34, vcc
+	v_cndmask_b32_e32 v35, v82, v35, vcc
+	.loc	1 151 50                        ; generate_rocjitsu_triton_fixtures.py:151:50
+	v_mul_f32_e32 v42, v73, v42
+	.loc	1 151 23 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:151:23
+	v_mfma_f32_32x32x8_f16 a[0:15], v[40:41], v[18:19], a[0:15]
+	.loc	1 151 50                        ; generate_rocjitsu_triton_fixtures.py:151:50
+	v_mul_f32_e32 v43, v73, v43
+	.loc	1 152 77 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:152:77
+	v_cndmask_b32_e32 v38, v82, v38, vcc
+	v_cndmask_b32_e32 v39, v82, v39, vcc
+.Ltmp2:
+	.file	2 "/home/kunwar/Work/runtime-evolution/rocm-systems-rocjitsu-register-feedback/emulation/rocjitsu/.env/lib/python3.12/site-packages/triton/language" "standard.py"
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ generate_rocjitsu_triton_fixtures.py:153:39 ] ]
+	v_max_f32_e32 v104, v34, v35
+.Ltmp3:
+	.loc	1 151 50                        ; generate_rocjitsu_triton_fixtures.py:151:50
+	v_mul_f32_e32 v46, v73, v46
+	v_mul_f32_e32 v47, v73, v47
+	.loc	1 152 77                        ; generate_rocjitsu_triton_fixtures.py:152:77
+	v_cndmask_b32_e32 v42, v82, v42, vcc
+	.loc	1 151 23                        ; generate_rocjitsu_triton_fixtures.py:151:23
+	v_mfma_f32_32x32x8_f16 a[0:15], v[44:45], v[20:21], a[0:15]
+	.loc	1 152 77                        ; generate_rocjitsu_triton_fixtures.py:152:77
+	v_cndmask_b32_e32 v43, v82, v43, vcc
+.Ltmp4:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ generate_rocjitsu_triton_fixtures.py:153:39 ] ]
+	v_max3_f32 v104, v104, v38, v39
+.Ltmp5:
+	.loc	1 151 50                        ; generate_rocjitsu_triton_fixtures.py:151:50
+	v_mul_f32_e32 v50, v73, v50
+	v_mul_f32_e32 v51, v73, v51
+	.loc	1 152 77                        ; generate_rocjitsu_triton_fixtures.py:152:77
+	v_cndmask_b32_e32 v46, v82, v46, vcc
+	v_cndmask_b32_e32 v47, v82, v47, vcc
+.Ltmp6:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ generate_rocjitsu_triton_fixtures.py:153:39 ] ]
+	v_max3_f32 v104, v104, v42, v43
+.Ltmp7:
+	.loc	1 151 23                        ; generate_rocjitsu_triton_fixtures.py:151:23
+	v_mfma_f32_32x32x8_f16 a[0:15], v[48:49], v[22:23], a[0:15]
+	.loc	1 151 50 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:151:50
+	v_mul_f32_e32 v54, v73, v54
+	v_mul_f32_e32 v55, v73, v55
+	.loc	1 152 77 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:152:77
+	v_cndmask_b32_e32 v50, v82, v50, vcc
+	v_cndmask_b32_e32 v51, v82, v51, vcc
+.Ltmp8:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ generate_rocjitsu_triton_fixtures.py:153:39 ] ]
+	v_max3_f32 v104, v104, v46, v47
+.Ltmp9:
+	.loc	1 151 50                        ; generate_rocjitsu_triton_fixtures.py:151:50
+	v_mul_f32_e32 v58, v73, v58
+	v_mul_f32_e32 v59, v73, v59
+	.loc	1 151 23 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:151:23
+	v_mfma_f32_32x32x8_f16 a[0:15], v[52:53], v[24:25], a[0:15]
+	.loc	1 152 77 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:152:77
+	v_cndmask_b32_e32 v54, v82, v54, vcc
+	v_cndmask_b32_e32 v55, v82, v55, vcc
+.Ltmp10:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ generate_rocjitsu_triton_fixtures.py:153:39 ] ]
+	v_max3_f32 v104, v104, v50, v51
+.Ltmp11:
+	.loc	1 151 50                        ; generate_rocjitsu_triton_fixtures.py:151:50
+	v_mul_f32_e32 v62, v73, v62
+	v_mul_f32_e32 v63, v73, v63
+	.loc	1 152 77                        ; generate_rocjitsu_triton_fixtures.py:152:77
+	v_cndmask_b32_e32 v58, v82, v58, vcc
+	v_cndmask_b32_e32 v59, v82, v59, vcc
+	.loc	1 151 23                        ; generate_rocjitsu_triton_fixtures.py:151:23
+	v_mfma_f32_32x32x8_f16 a[0:15], v[56:57], v[26:27], a[0:15]
+.Ltmp12:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ generate_rocjitsu_triton_fixtures.py:153:39 ] ]
+	v_max3_f32 v104, v104, v54, v55
+.Ltmp13:
+	.loc	1 152 77                        ; generate_rocjitsu_triton_fixtures.py:152:77
+	v_cndmask_b32_e32 v62, v82, v62, vcc
+	v_cndmask_b32_e32 v63, v82, v63, vcc
+.Ltmp14:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ generate_rocjitsu_triton_fixtures.py:153:39 ] ]
+	v_max3_f32 v104, v104, v58, v59
+	v_max3_f32 v104, v104, v62, v63
+.Ltmp15:
+	.loc	1 151 23                        ; generate_rocjitsu_triton_fixtures.py:151:23
+	v_mfma_f32_32x32x8_f16 a[0:15], v[60:61], v[28:29], a[0:15]
+	v_mfma_f32_32x32x8_f16 a[0:15], v[106:107], v[30:31], a[0:15]
+	s_nop 10
+	v_accvgpr_read_b32 v36, a0
+	v_accvgpr_read_b32 v37, a1
+	v_accvgpr_read_b32 v40, a2
+	v_accvgpr_read_b32 v41, a3
+	.loc	1 151 50 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:151:50
+	v_mul_f32_e32 v36, v73, v36
+	v_mul_f32_e32 v37, v73, v37
+	.loc	1 151 23                        ; generate_rocjitsu_triton_fixtures.py:151:23
+	v_accvgpr_read_b32 v44, a4
+	v_accvgpr_read_b32 v45, a5
+	.loc	1 151 50                        ; generate_rocjitsu_triton_fixtures.py:151:50
+	v_mul_f32_e32 v40, v73, v40
+	v_mul_f32_e32 v41, v73, v41
+	.loc	1 152 77 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:152:77
+	v_cndmask_b32_e32 v36, v82, v36, vcc
+	v_cndmask_b32_e32 v37, v82, v37, vcc
+	.loc	1 151 23                        ; generate_rocjitsu_triton_fixtures.py:151:23
+	v_accvgpr_read_b32 v48, a6
+	v_accvgpr_read_b32 v49, a7
+	.loc	1 151 50 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:151:50
+	v_mul_f32_e32 v44, v73, v44
+	v_mul_f32_e32 v45, v73, v45
+	.loc	1 152 77 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:152:77
+	v_cndmask_b32_e32 v40, v82, v40, vcc
+	v_cndmask_b32_e32 v41, v82, v41, vcc
+.Ltmp16:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ generate_rocjitsu_triton_fixtures.py:153:39 ] ]
+	v_max3_f32 v104, v104, v36, v37
+.Ltmp17:
+	.loc	1 151 23                        ; generate_rocjitsu_triton_fixtures.py:151:23
+	v_accvgpr_read_b32 v52, a8
+	v_accvgpr_read_b32 v53, a9
+	.loc	1 151 50 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:151:50
+	v_mul_f32_e32 v48, v73, v48
+	v_mul_f32_e32 v49, v73, v49
+	.loc	1 152 77 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:152:77
+	v_cndmask_b32_e32 v44, v82, v44, vcc
+	v_cndmask_b32_e32 v45, v82, v45, vcc
+.Ltmp18:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ generate_rocjitsu_triton_fixtures.py:153:39 ] ]
+	v_max3_f32 v104, v104, v40, v41
+.Ltmp19:
+	.loc	1 151 23                        ; generate_rocjitsu_triton_fixtures.py:151:23
+	v_accvgpr_read_b32 v56, a10
+	v_accvgpr_read_b32 v57, a11
+	.loc	1 151 50 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:151:50
+	v_mul_f32_e32 v52, v73, v52
+	v_mul_f32_e32 v53, v73, v53
+	.loc	1 152 77 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:152:77
+	v_cndmask_b32_e32 v48, v82, v48, vcc
+	v_cndmask_b32_e32 v49, v82, v49, vcc
+.Ltmp20:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ generate_rocjitsu_triton_fixtures.py:153:39 ] ]
+	v_max3_f32 v104, v104, v44, v45
+.Ltmp21:
+	.loc	1 151 23                        ; generate_rocjitsu_triton_fixtures.py:151:23
+	v_accvgpr_read_b32 v60, a12
+	v_accvgpr_read_b32 v61, a13
+	.loc	1 151 50 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:151:50
+	v_mul_f32_e32 v56, v73, v56
+	v_mul_f32_e32 v57, v73, v57
+	.loc	1 152 77 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:152:77
+	v_cndmask_b32_e32 v52, v82, v52, vcc
+	v_cndmask_b32_e32 v53, v82, v53, vcc
+.Ltmp22:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ generate_rocjitsu_triton_fixtures.py:153:39 ] ]
+	v_max3_f32 v104, v104, v48, v49
+.Ltmp23:
+	.loc	1 151 23                        ; generate_rocjitsu_triton_fixtures.py:151:23
+	v_accvgpr_read_b32 v64, a14
+	v_accvgpr_read_b32 v103, a15
+	.loc	1 151 50 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:151:50
+	v_mul_f32_e32 v60, v73, v60
+	v_mul_f32_e32 v61, v73, v61
+	.loc	1 152 77 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:152:77
+	v_cndmask_b32_e32 v56, v82, v56, vcc
+	v_cndmask_b32_e32 v57, v82, v57, vcc
+.Ltmp24:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ generate_rocjitsu_triton_fixtures.py:153:39 ] ]
+	v_max3_f32 v104, v104, v52, v53
+.Ltmp25:
+	.loc	1 151 50                        ; generate_rocjitsu_triton_fixtures.py:151:50
+	v_mul_f32_e32 v64, v73, v64
+	v_mul_f32_e32 v103, v73, v103
+	.loc	1 152 77                        ; generate_rocjitsu_triton_fixtures.py:152:77
+	v_cndmask_b32_e32 v60, v82, v60, vcc
+	v_cndmask_b32_e32 v61, v82, v61, vcc
+.Ltmp26:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ generate_rocjitsu_triton_fixtures.py:153:39 ] ]
+	v_max3_f32 v104, v104, v56, v57
+.Ltmp27:
+	.loc	1 152 77                        ; generate_rocjitsu_triton_fixtures.py:152:77
+	v_cndmask_b32_e32 v64, v82, v64, vcc
+	v_cndmask_b32_e32 v103, v82, v103, vcc
+.Ltmp28:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ generate_rocjitsu_triton_fixtures.py:153:39 ] ]
+	v_max3_f32 v104, v104, v60, v61
+	v_max3_f32 v104, v104, v64, v103
+.Ltmp29:
+	.loc	2 191 40                        ; standard.py:191:40 @[ generate_rocjitsu_triton_fixtures.py:153:39 ]
+	ds_bpermute_b32 v105, v76, v104
+.Ltmp30:
+	.loc	1 153 32                        ; generate_rocjitsu_triton_fixtures.py:153:32
+	s_waitcnt lgkmcnt(0)
+	v_max3_f32 v104, v33, v104, v105
+	.loc	1 155 30                        ; generate_rocjitsu_triton_fixtures.py:155:30
+	v_sub_f32_e32 v34, v34, v104
+	v_sub_f32_e32 v35, v35, v104
+	v_sub_f32_e32 v38, v38, v104
+	.loc	1 155 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:155:25
+	v_exp_f32_e32 v34, v34
+	v_exp_f32_e32 v35, v35
+	.loc	1 155 30                        ; generate_rocjitsu_triton_fixtures.py:155:30
+	v_sub_f32_e32 v39, v39, v104
+	.loc	1 155 25                        ; generate_rocjitsu_triton_fixtures.py:155:25
+	v_exp_f32_e32 v38, v38
+	.loc	1 155 30                        ; generate_rocjitsu_triton_fixtures.py:155:30
+	v_sub_f32_e32 v42, v42, v104
+	.loc	1 155 25                        ; generate_rocjitsu_triton_fixtures.py:155:25
+	v_exp_f32_e32 v39, v39
+	.loc	1 155 30                        ; generate_rocjitsu_triton_fixtures.py:155:30
+	v_sub_f32_e32 v43, v43, v104
+	v_sub_f32_e32 v64, v64, v104
+	.loc	1 155 25                        ; generate_rocjitsu_triton_fixtures.py:155:25
+	v_exp_f32_e32 v42, v42
+	.loc	1 155 30                        ; generate_rocjitsu_triton_fixtures.py:155:30
+	v_sub_f32_e32 v46, v46, v104
+	.loc	1 155 25                        ; generate_rocjitsu_triton_fixtures.py:155:25
+	v_exp_f32_e32 v43, v43
+	v_exp_f32_e32 v106, v64
+.Ltmp31:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:156:37 ] ]
+	v_add_f32_e32 v64, v34, v35
+.Ltmp32:
+	.loc	1 155 30                        ; generate_rocjitsu_triton_fixtures.py:155:30
+	v_sub_f32_e32 v47, v47, v104
+	.loc	1 155 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:155:25
+	v_exp_f32_e32 v46, v46
+.Ltmp33:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:156:37 ] ]
+	v_add_f32_e32 v64, v38, v64
+.Ltmp34:
+	.loc	1 155 30                        ; generate_rocjitsu_triton_fixtures.py:155:30
+	v_sub_f32_e32 v50, v50, v104
+	.loc	1 155 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:155:25
+	v_exp_f32_e32 v47, v47
+.Ltmp35:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:156:37 ] ]
+	v_add_f32_e32 v64, v39, v64
+.Ltmp36:
+	.loc	1 155 30                        ; generate_rocjitsu_triton_fixtures.py:155:30
+	v_sub_f32_e32 v51, v51, v104
+	.loc	1 155 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:155:25
+	v_exp_f32_e32 v50, v50
+.Ltmp37:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:156:37 ] ]
+	v_add_f32_e32 v64, v42, v64
+.Ltmp38:
+	.loc	1 155 30                        ; generate_rocjitsu_triton_fixtures.py:155:30
+	v_sub_f32_e32 v54, v54, v104
+	.loc	1 155 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:155:25
+	v_exp_f32_e32 v51, v51
+.Ltmp39:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:156:37 ] ]
+	v_add_f32_e32 v64, v43, v64
+.Ltmp40:
+	.loc	1 155 30                        ; generate_rocjitsu_triton_fixtures.py:155:30
+	v_sub_f32_e32 v55, v55, v104
+	.loc	1 155 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:155:25
+	v_exp_f32_e32 v54, v54
+.Ltmp41:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:156:37 ] ]
+	v_add_f32_e32 v64, v46, v64
+.Ltmp42:
+	.loc	1 155 30                        ; generate_rocjitsu_triton_fixtures.py:155:30
+	v_sub_f32_e32 v58, v58, v104
+	.loc	1 155 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:155:25
+	v_exp_f32_e32 v55, v55
+.Ltmp43:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:156:37 ] ]
+	v_add_f32_e32 v64, v47, v64
+.Ltmp44:
+	.loc	1 155 30                        ; generate_rocjitsu_triton_fixtures.py:155:30
+	v_sub_f32_e32 v59, v59, v104
+	.loc	1 155 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:155:25
+	v_exp_f32_e32 v58, v58
+.Ltmp45:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:156:37 ] ]
+	v_add_f32_e32 v64, v50, v64
+.Ltmp46:
+	.loc	1 155 30                        ; generate_rocjitsu_triton_fixtures.py:155:30
+	v_sub_f32_e32 v62, v62, v104
+	.loc	1 155 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:155:25
+	v_exp_f32_e32 v59, v59
+.Ltmp47:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:156:37 ] ]
+	v_add_f32_e32 v64, v51, v64
+.Ltmp48:
+	.loc	1 155 30                        ; generate_rocjitsu_triton_fixtures.py:155:30
+	v_sub_f32_e32 v63, v63, v104
+	.loc	1 155 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:155:25
+	v_exp_f32_e32 v62, v62
+.Ltmp49:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:156:37 ] ]
+	v_add_f32_e32 v64, v54, v64
+.Ltmp50:
+	.loc	1 155 30                        ; generate_rocjitsu_triton_fixtures.py:155:30
+	v_sub_f32_e32 v36, v36, v104
+	.loc	1 155 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:155:25
+	v_exp_f32_e32 v63, v63
+.Ltmp51:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:156:37 ] ]
+	v_add_f32_e32 v64, v55, v64
+.Ltmp52:
+	.loc	1 155 30                        ; generate_rocjitsu_triton_fixtures.py:155:30
+	v_sub_f32_e32 v37, v37, v104
+	.loc	1 155 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:155:25
+	v_exp_f32_e32 v36, v36
+.Ltmp53:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:156:37 ] ]
+	v_add_f32_e32 v64, v58, v64
+.Ltmp54:
+	.loc	1 155 30                        ; generate_rocjitsu_triton_fixtures.py:155:30
+	v_sub_f32_e32 v40, v40, v104
+	.loc	1 155 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:155:25
+	v_exp_f32_e32 v37, v37
+.Ltmp55:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:156:37 ] ]
+	v_add_f32_e32 v64, v59, v64
+.Ltmp56:
+	.loc	1 155 30                        ; generate_rocjitsu_triton_fixtures.py:155:30
+	v_sub_f32_e32 v41, v41, v104
+	.loc	1 155 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:155:25
+	v_exp_f32_e32 v40, v40
+.Ltmp57:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:156:37 ] ]
+	v_add_f32_e32 v64, v62, v64
+.Ltmp58:
+	.loc	1 155 30                        ; generate_rocjitsu_triton_fixtures.py:155:30
+	v_sub_f32_e32 v44, v44, v104
+	.loc	1 155 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:155:25
+	v_exp_f32_e32 v41, v41
+.Ltmp59:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:156:37 ] ]
+	v_add_f32_e32 v64, v63, v64
+.Ltmp60:
+	.loc	1 155 30                        ; generate_rocjitsu_triton_fixtures.py:155:30
+	v_sub_f32_e32 v45, v45, v104
+	.loc	1 155 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:155:25
+	v_exp_f32_e32 v44, v44
+.Ltmp61:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:156:37 ] ]
+	v_add_f32_e32 v64, v36, v64
+.Ltmp62:
+	.loc	1 155 30                        ; generate_rocjitsu_triton_fixtures.py:155:30
+	v_sub_f32_e32 v48, v48, v104
+	.loc	1 155 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:155:25
+	v_exp_f32_e32 v45, v45
+.Ltmp63:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:156:37 ] ]
+	v_add_f32_e32 v64, v37, v64
+.Ltmp64:
+	.loc	1 155 30                        ; generate_rocjitsu_triton_fixtures.py:155:30
+	v_sub_f32_e32 v49, v49, v104
+	.loc	1 155 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:155:25
+	v_exp_f32_e32 v48, v48
+.Ltmp65:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:156:37 ] ]
+	v_add_f32_e32 v64, v40, v64
+.Ltmp66:
+	.loc	1 155 30                        ; generate_rocjitsu_triton_fixtures.py:155:30
+	v_sub_f32_e32 v52, v52, v104
+	.loc	1 155 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:155:25
+	v_exp_f32_e32 v49, v49
+.Ltmp67:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:156:37 ] ]
+	v_add_f32_e32 v64, v41, v64
+.Ltmp68:
+	.loc	1 155 30                        ; generate_rocjitsu_triton_fixtures.py:155:30
+	v_sub_f32_e32 v53, v53, v104
+	.loc	1 155 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:155:25
+	v_exp_f32_e32 v52, v52
+.Ltmp69:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:156:37 ] ]
+	v_add_f32_e32 v64, v44, v64
+.Ltmp70:
+	.loc	1 155 30                        ; generate_rocjitsu_triton_fixtures.py:155:30
+	v_sub_f32_e32 v56, v56, v104
+	.loc	1 155 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:155:25
+	v_exp_f32_e32 v53, v53
+.Ltmp71:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:156:37 ] ]
+	v_add_f32_e32 v64, v45, v64
+.Ltmp72:
+	.loc	1 155 30                        ; generate_rocjitsu_triton_fixtures.py:155:30
+	v_sub_f32_e32 v57, v57, v104
+	.loc	1 155 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:155:25
+	v_exp_f32_e32 v56, v56
+.Ltmp73:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:156:37 ] ]
+	v_add_f32_e32 v64, v48, v64
+.Ltmp74:
+	.loc	1 155 30                        ; generate_rocjitsu_triton_fixtures.py:155:30
+	v_sub_f32_e32 v60, v60, v104
+	.loc	1 155 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:155:25
+	v_exp_f32_e32 v57, v57
+.Ltmp75:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:156:37 ] ]
+	v_add_f32_e32 v64, v49, v64
+.Ltmp76:
+	.loc	1 155 30                        ; generate_rocjitsu_triton_fixtures.py:155:30
+	v_sub_f32_e32 v61, v61, v104
+	.loc	1 155 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:155:25
+	v_exp_f32_e32 v60, v60
+.Ltmp77:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:156:37 ] ]
+	v_add_f32_e32 v64, v52, v64
+.Ltmp78:
+	.loc	1 155 25                        ; generate_rocjitsu_triton_fixtures.py:155:25
+	v_exp_f32_e32 v61, v61
+.Ltmp79:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:156:37 ] ]
+	v_add_f32_e32 v64, v53, v64
+.Ltmp80:
+	.loc	1 155 30                        ; generate_rocjitsu_triton_fixtures.py:155:30
+	v_sub_f32_e32 v103, v103, v104
+.Ltmp81:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:156:37 ] ]
+	v_add_f32_e32 v64, v56, v64
+.Ltmp82:
+	.loc	1 155 25                        ; generate_rocjitsu_triton_fixtures.py:155:25
+	v_exp_f32_e32 v107, v103
+.Ltmp83:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:156:37 ] ]
+	v_add_f32_e32 v64, v57, v64
+	v_add_f32_e32 v64, v60, v64
+	v_add_f32_e32 v64, v61, v64
+	v_add_f32_e32 v64, v106, v64
+	v_add_f32_e32 v64, v107, v64
+.Ltmp84:
+	.loc	2 293 36                        ; standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:156:37 ]
+	ds_bpermute_b32 v103, v76, v64
+.Ltmp85:
+	.loc	1 154 35                        ; generate_rocjitsu_triton_fixtures.py:154:35
+	v_sub_f32_e32 v33, v33, v104
+	.loc	1 154 29 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:154:29
+	v_exp_f32_e32 v33, v33
+	.loc	1 161 26 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:161:26
+	v_cvt_f16_f32_e32 v36, v36
+	v_cvt_f16_f32_e32 v37, v37
+.Ltmp86:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:156:37 ] ]
+	s_waitcnt lgkmcnt(0)
+	v_add_f32_e32 v103, v64, v103
+.Ltmp87:
+	.loc	1 156 30                        ; generate_rocjitsu_triton_fixtures.py:156:30
+	v_fmac_f32_e32 v103, v32, v33
+	.loc	1 158 20                        ; generate_rocjitsu_triton_fixtures.py:158:20
+	v_add_u32_e32 v32, v74, v80
+	buffer_load_ushort v108, v32, s[0:3], 0 offen
+	buffer_load_ushort v109, v32, s[0:3], 0 offen offset:128
+	buffer_load_ushort v110, v32, s[0:3], 0 offen offset:256
+	buffer_load_ushort v111, v32, s[0:3], 0 offen offset:384
+	buffer_load_ushort v112, v32, s[0:3], 0 offen offset:2048
+	buffer_load_ushort v113, v32, s[0:3], 0 offen offset:2176
+	buffer_load_ushort v114, v32, s[0:3], 0 offen offset:2304
+	buffer_load_ushort v115, v32, s[0:3], 0 offen offset:2432
+	v_add_u32_e32 v32, 0x1000, v32
+	buffer_load_ushort v116, v32, s[0:3], 0 offen
+	buffer_load_ushort v117, v32, s[0:3], 0 offen offset:128
+	buffer_load_ushort v118, v32, s[0:3], 0 offen offset:256
+	buffer_load_ushort v119, v32, s[0:3], 0 offen offset:384
+	buffer_load_ushort v120, v32, s[0:3], 0 offen offset:2048
+	buffer_load_ushort v121, v32, s[0:3], 0 offen offset:2176
+	buffer_load_ushort v122, v32, s[0:3], 0 offen offset:2304
+	buffer_load_ushort v123, v32, s[0:3], 0 offen offset:2432
+                                        ; kill: killed $vgpr32
+	.loc	1 160 20                        ; generate_rocjitsu_triton_fixtures.py:160:20
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	ds_write_b32 v93, v33
+	.loc	1 161 26                        ; generate_rocjitsu_triton_fixtures.py:161:26
+	v_cvt_f16_f32_e32 v32, v34
+	v_cvt_f16_f32_e32 v33, v35
+	v_cvt_f16_f32_e32 v34, v38
+	v_cvt_f16_f32_e32 v35, v39
+	v_cvt_f16_f32_e32 v38, v42
+	v_cvt_f16_f32_e32 v39, v43
+	v_cvt_f16_f32_e32 v42, v46
+	v_cvt_f16_f32_e32 v43, v47
+	v_cvt_f16_f32_e32 v46, v50
+	v_cvt_f16_f32_e32 v47, v51
+	v_cvt_f16_f32_e32 v50, v54
+	v_cvt_f16_f32_e32 v51, v55
+	v_cvt_f16_f32_e32 v54, v58
+	v_cvt_f16_f32_e32 v55, v59
+	v_cvt_f16_f32_e32 v58, v62
+	v_cvt_f16_f32_e32 v59, v63
+	v_cvt_f16_f32_e32 v40, v40
+	v_cvt_f16_f32_e32 v41, v41
+	v_cvt_f16_f32_e32 v44, v44
+	v_cvt_f16_f32_e32 v45, v45
+	v_cvt_f16_f32_e32 v48, v48
+	v_cvt_f16_f32_e32 v49, v49
+	v_cvt_f16_f32_e32 v52, v52
+	v_cvt_f16_f32_e32 v53, v53
+	v_cvt_f16_f32_e32 v56, v56
+	v_cvt_f16_f32_e32 v57, v57
+	v_cvt_f16_f32_e32 v60, v60
+	v_cvt_f16_f32_e32 v61, v61
+	v_cvt_f16_f32_e32 v62, v106
+	v_cvt_f16_f32_e32 v63, v107
+	.loc	1 160 20                        ; generate_rocjitsu_triton_fixtures.py:160:20
+	v_add_u32_e32 v105, v77, v68
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	ds_read_b32 v64, v105
+	.loc	1 161 26                        ; generate_rocjitsu_triton_fixtures.py:161:26
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	ds_write_b16 v90, v32
+	ds_write_b16 v90, v33 offset:128
+	ds_write_b16 v90, v34 offset:256
+	.loc	1 158 20                        ; generate_rocjitsu_triton_fixtures.py:158:20
+	v_add_u32_e32 v34, 0, v78
+	.loc	1 161 26                        ; generate_rocjitsu_triton_fixtures.py:161:26
+	ds_write_b16 v90, v35 offset:384
+	ds_write_b16 v90, v38 offset:1024
+	ds_write_b16 v90, v39 offset:1152
+	ds_write_b16 v90, v42 offset:1280
+	ds_write_b16 v90, v43 offset:1408
+	ds_write_b16 v90, v46 offset:2048
+	ds_write_b16 v90, v47 offset:2176
+	ds_write_b16 v90, v50 offset:2304
+	ds_write_b16 v90, v51 offset:2432
+	ds_write_b16 v90, v54 offset:3072
+	ds_write_b16 v90, v55 offset:3200
+	ds_write_b16 v90, v58 offset:3328
+	ds_write_b16 v90, v59 offset:3456
+	ds_write_b16 v90, v36 offset:4096
+	ds_write_b16 v90, v37 offset:4224
+	ds_write_b16 v90, v40 offset:4352
+	ds_write_b16 v90, v41 offset:4480
+	ds_write_b16 v90, v44 offset:5120
+	ds_write_b16 v90, v45 offset:5248
+	ds_write_b16 v90, v48 offset:5376
+	.loc	1 158 20                        ; generate_rocjitsu_triton_fixtures.py:158:20
+	s_waitcnt vmcnt(14)
+	v_perm_b32 v32, v109, v108, s12
+	.loc	1 161 26                        ; generate_rocjitsu_triton_fixtures.py:161:26
+	ds_write_b16 v90, v49 offset:5504
+	.loc	1 158 20                        ; generate_rocjitsu_triton_fixtures.py:158:20
+	s_waitcnt vmcnt(12)
+	v_perm_b32 v33, v111, v110, s12
+	.loc	1 161 26                        ; generate_rocjitsu_triton_fixtures.py:161:26
+	ds_write_b16 v90, v52 offset:6144
+	ds_write_b16 v90, v53 offset:6272
+	ds_write_b16 v90, v56 offset:6400
+	ds_write_b16 v90, v57 offset:6528
+	ds_write_b16 v90, v60 offset:7168
+	ds_write_b16 v90, v61 offset:7296
+	ds_write_b16 v90, v62 offset:7424
+	ds_write_b16 v90, v63 offset:7552
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	ds_read_u16 v36, v91
+	ds_read_u16 v37, v91 offset:128
+	ds_read_u16 v38, v91 offset:256
+	ds_read_u16 v39, v91 offset:384
+	ds_read_u16 v42, v91 offset:1024
+	ds_read_u16 v43, v91 offset:1152
+	ds_read_u16 v46, v91 offset:1280
+	ds_read_u16 v47, v91 offset:1408
+	ds_read_u16 v50, v91 offset:2048
+	ds_read_u16 v51, v91 offset:2176
+	ds_read_u16 v54, v91 offset:2304
+	ds_read_u16 v55, v91 offset:2432
+	ds_read_u16 v106, v91 offset:3072
+	ds_read_u16 v107, v91 offset:3200
+	ds_read_u16 v124, v91 offset:3328
+	ds_read_u16 v125, v91 offset:3456
+	ds_read_u16 v126, v91 offset:4096
+	ds_read_u16 v127, v91 offset:4224
+	ds_read_u16 v128, v91 offset:4352
+	ds_read_u16 v129, v91 offset:4480
+	ds_read_u16 v130, v91 offset:5120
+	ds_read_u16 v131, v91 offset:5248
+	ds_read_u16 v132, v91 offset:5376
+	ds_read_u16 v133, v91 offset:5504
+	ds_read_u16 v134, v91 offset:6144
+	ds_read_u16 v135, v91 offset:6272
+	ds_read_u16 v136, v91 offset:6400
+	ds_read_u16 v137, v91 offset:6528
+	ds_read_u16 v138, v91 offset:7168
+	ds_read_u16 v139, v91 offset:7296
+	ds_read_u16 v140, v91 offset:7424
+	ds_read_u16 v141, v91 offset:7552
+	.loc	1 158 20                        ; generate_rocjitsu_triton_fixtures.py:158:20
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	ds_write_b64 v34, v[32:33]
+	s_waitcnt vmcnt(8)
+	v_perm_b32 v33, v115, v114, s12
+	v_perm_b32 v32, v113, v112, s12
+	ds_write_b64 v92, v[32:33]
+	s_waitcnt vmcnt(4)
+	v_perm_b32 v33, v119, v118, s12
+	v_perm_b32 v32, v117, v116, s12
+	ds_write_b64 v94, v[32:33]
+	s_waitcnt vmcnt(0)
+	v_perm_b32 v33, v123, v122, s12
+	v_perm_b32 v32, v121, v120, s12
+	ds_write_b64 v95, v[32:33]
+	v_add_u32_e32 v32, 0, v79
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	ds_read_b64 v[60:61], v32
+	.loc	1 161 42                        ; generate_rocjitsu_triton_fixtures.py:161:42
+	v_pk_mul_f32 v[0:1], v[0:1], v[64:65] op_sel_hi:[1,0]
+	v_pk_mul_f32 v[14:15], v[14:15], v[64:65] op_sel_hi:[1,0]
+	v_pk_mul_f32 v[12:13], v[12:13], v[64:65] op_sel_hi:[1,0]
+	v_pk_mul_f32 v[10:11], v[10:11], v[64:65] op_sel_hi:[1,0]
+	v_pk_mul_f32 v[8:9], v[8:9], v[64:65] op_sel_hi:[1,0]
+	v_pk_mul_f32 v[6:7], v[6:7], v[64:65] op_sel_hi:[1,0]
+	v_pk_mul_f32 v[4:5], v[4:5], v[64:65] op_sel_hi:[1,0]
+	v_pk_mul_f32 v[2:3], v[2:3], v[64:65] op_sel_hi:[1,0]
+	.loc	1 158 20                        ; generate_rocjitsu_triton_fixtures.py:158:20
+	ds_read_b64 v[56:57], v96
+	.loc	1 161 42                        ; generate_rocjitsu_triton_fixtures.py:161:42
+	v_accvgpr_write_b32 a0, v0
+	v_perm_b32 v63, v39, v38, s12
+	v_perm_b32 v62, v37, v36, s12
+	v_accvgpr_write_b32 a1, v1
+	v_accvgpr_write_b32 a2, v2
+	v_accvgpr_write_b32 a3, v3
+	v_accvgpr_write_b32 a4, v4
+	v_accvgpr_write_b32 a5, v5
+	v_accvgpr_write_b32 a6, v6
+	v_accvgpr_write_b32 a7, v7
+	v_accvgpr_write_b32 a8, v8
+	v_accvgpr_write_b32 a9, v9
+	v_accvgpr_write_b32 a10, v10
+	v_accvgpr_write_b32 a11, v11
+	v_accvgpr_write_b32 a12, v12
+	v_accvgpr_write_b32 a13, v13
+	v_accvgpr_write_b32 a14, v14
+	v_accvgpr_write_b32 a15, v15
+	.loc	1 158 20                        ; generate_rocjitsu_triton_fixtures.py:158:20
+	ds_read_b64 v[52:53], v97
+	.loc	1 161 42                        ; generate_rocjitsu_triton_fixtures.py:161:42
+	v_perm_b32 v59, v47, v46, s12
+	s_waitcnt lgkmcnt(2)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[60:61], v[62:63], a[0:15]
+	v_perm_b32 v58, v43, v42, s12
+	.loc	1 158 20                        ; generate_rocjitsu_triton_fixtures.py:158:20
+	ds_read_b64 v[48:49], v98
+	.loc	1 161 42                        ; generate_rocjitsu_triton_fixtures.py:161:42
+	v_perm_b32 v55, v55, v54, s12
+	v_perm_b32 v54, v51, v50, s12
+	.loc	1 158 20                        ; generate_rocjitsu_triton_fixtures.py:158:20
+	ds_read_b64 v[44:45], v99
+	.loc	1 161 42                        ; generate_rocjitsu_triton_fixtures.py:161:42
+	v_perm_b32 v51, v125, v124, s12
+	v_perm_b32 v50, v107, v106, s12
+	s_waitcnt lgkmcnt(3)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[56:57], v[58:59], a[0:15]
+	.loc	1 158 20                        ; generate_rocjitsu_triton_fixtures.py:158:20
+	ds_read_b64 v[40:41], v100
+	.loc	1 161 42                        ; generate_rocjitsu_triton_fixtures.py:161:42
+	v_perm_b32 v47, v129, v128, s12
+	v_perm_b32 v46, v127, v126, s12
+	.loc	1 158 20                        ; generate_rocjitsu_triton_fixtures.py:158:20
+	ds_read_b64 v[34:35], v101
+	.loc	1 161 42                        ; generate_rocjitsu_triton_fixtures.py:161:42
+	v_perm_b32 v43, v133, v132, s12
+	v_perm_b32 v42, v131, v130, s12
+	.loc	1 158 20                        ; generate_rocjitsu_triton_fixtures.py:158:20
+	ds_read_b64 v[32:33], v102
+	.loc	1 161 42                        ; generate_rocjitsu_triton_fixtures.py:161:42
+	s_waitcnt lgkmcnt(5)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[52:53], v[54:55], a[0:15]
+	v_perm_b32 v39, v137, v136, s12
+	v_perm_b32 v38, v135, v134, s12
+	v_perm_b32 v37, v141, v140, s12
+	v_perm_b32 v36, v139, v138, s12
+	s_waitcnt lgkmcnt(4)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[48:49], v[50:51], a[0:15]
+	s_waitcnt lgkmcnt(3)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[44:45], v[46:47], a[0:15]
+	s_waitcnt lgkmcnt(2)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[40:41], v[42:43], a[0:15]
+	s_waitcnt lgkmcnt(1)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[34:35], v[38:39], a[0:15]
+	s_waitcnt lgkmcnt(0)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[32:33], v[36:37], a[0:15]
+	; sched_barrier mask(0x00000000)
+	.loc	1 145 48                        ; generate_rocjitsu_triton_fixtures.py:145:48
+	s_add_i32 s10, s10, 64
+	v_add_u32_e32 v80, 0x2000, v80
+	v_add_u32_e32 v81, 0x2000, v81
+	s_cmpk_lt_u32 s10, 0x3c0
+	v_mov_b32_e32 v33, v104
+	s_cbranch_scc1 .LBB0_33
+; %bb.34:
+	.loc	1 135 45                        ; generate_rocjitsu_triton_fixtures.py:135:45
+	v_lshrrev_b32_e32 v16, 2, v68
+	.loc	1 161 42                        ; generate_rocjitsu_triton_fixtures.py:161:42
+	s_nop 3
+	v_accvgpr_read_b32 v0, a0
+	.loc	1 135 32                        ; generate_rocjitsu_triton_fixtures.py:135:32
+	v_or3_b32 v16, v67, v16, s11
+	s_movk_i32 s0, 0x400
+	.loc	1 161 42                        ; generate_rocjitsu_triton_fixtures.py:161:42
+	v_accvgpr_read_b32 v1, a1
+	v_accvgpr_read_b32 v2, a2
+	v_accvgpr_read_b32 v3, a3
+	v_accvgpr_read_b32 v4, a4
+	v_accvgpr_read_b32 v5, a5
+	v_accvgpr_read_b32 v6, a6
+	v_accvgpr_read_b32 v7, a7
+	v_accvgpr_read_b32 v8, a8
+	v_accvgpr_read_b32 v9, a9
+	v_accvgpr_read_b32 v10, a10
+	v_accvgpr_read_b32 v11, a11
+	v_accvgpr_read_b32 v12, a12
+	v_accvgpr_read_b32 v13, a13
+	v_accvgpr_read_b32 v14, a14
+	v_accvgpr_read_b32 v15, a15
+	.loc	1 139 59                        ; generate_rocjitsu_triton_fixtures.py:139:59
+	v_cmp_gt_i32_e32 vcc, s0, v16
+	.loc	1 164 16                        ; generate_rocjitsu_triton_fixtures.py:164:16
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	ds_write_b32 v93, v103
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	.loc	1 166 32                        ; generate_rocjitsu_triton_fixtures.py:166:32
+	s_and_saveexec_b64 s[0:1], vcc
+	s_cbranch_execz .LBB0_36
+; %bb.35:                               ; %.critedge
+	.loc	1 164 16                        ; generate_rocjitsu_triton_fixtures.py:164:16
+	ds_read_b32 v18, v105
+	.loc	1 135 45                        ; generate_rocjitsu_triton_fixtures.py:135:45
+	v_lshrrev_b32_e32 v17, 3, v66
+	.loc	1 138 34                        ; generate_rocjitsu_triton_fixtures.py:138:34
+	v_lshlrev_b32_e32 v16, 6, v16
+	.loc	1 138 46 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:138:46
+	v_or3_b32 v16, v17, v16, v65
+	.loc	1 166 21 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:166:21
+	v_ashrrev_i32_e32 v17, 31, v16
+	.loc	1 164 16                        ; generate_rocjitsu_triton_fixtures.py:164:16
+	s_waitcnt lgkmcnt(0)
+	v_div_scale_f32 v19, s[0:1], v18, v18, v15
+	v_rcp_f32_e32 v20, v19
+	.loc	1 166 21                        ; generate_rocjitsu_triton_fixtures.py:166:21
+	v_lshl_add_u64 v[16:17], v[16:17], 2, s[8:9]
+	.loc	1 164 16                        ; generate_rocjitsu_triton_fixtures.py:164:16
+	v_fma_f32 v21, -v19, v20, 1.0
+	v_fmac_f32_e32 v20, v21, v20
+	v_div_scale_f32 v21, vcc, v15, v18, v15
+	v_mul_f32_e32 v22, v21, v20
+	v_fma_f32 v23, -v19, v22, v21
+	v_fmac_f32_e32 v22, v23, v20
+	v_fma_f32 v19, -v19, v22, v21
+	v_div_scale_f32 v21, s[0:1], v18, v18, v14
+	v_rcp_f32_e32 v23, v21
+	v_div_fmas_f32 v19, v19, v20, v22
+	v_div_fixup_f32 v15, v19, v18, v15
+	v_fma_f32 v19, -v21, v23, 1.0
+	v_fmac_f32_e32 v23, v19, v23
+	v_div_scale_f32 v19, vcc, v14, v18, v14
+	v_mul_f32_e32 v20, v19, v23
+	v_fma_f32 v22, -v21, v20, v19
+	v_fmac_f32_e32 v20, v22, v23
+	v_fma_f32 v19, -v21, v20, v19
+	v_div_scale_f32 v21, s[0:1], v18, v18, v13
+	v_rcp_f32_e32 v22, v21
+	v_div_fmas_f32 v19, v19, v23, v20
+	v_div_fixup_f32 v14, v19, v18, v14
+	v_fma_f32 v19, -v21, v22, 1.0
+	v_fmac_f32_e32 v22, v19, v22
+	v_div_scale_f32 v19, vcc, v13, v18, v13
+	v_mul_f32_e32 v20, v19, v22
+	v_fma_f32 v23, -v21, v20, v19
+	v_fmac_f32_e32 v20, v23, v22
+	v_fma_f32 v19, -v21, v20, v19
+	v_div_scale_f32 v21, s[0:1], v18, v18, v12
+	v_rcp_f32_e32 v23, v21
+	v_div_fmas_f32 v19, v19, v22, v20
+	v_div_fixup_f32 v13, v19, v18, v13
+	v_fma_f32 v19, -v21, v23, 1.0
+	v_fmac_f32_e32 v23, v19, v23
+	v_div_scale_f32 v19, vcc, v12, v18, v12
+	v_mul_f32_e32 v20, v19, v23
+	v_fma_f32 v22, -v21, v20, v19
+	v_fmac_f32_e32 v20, v22, v23
+	v_fma_f32 v19, -v21, v20, v19
+	v_div_scale_f32 v21, s[0:1], v18, v18, v11
+	v_rcp_f32_e32 v22, v21
+	v_div_fmas_f32 v19, v19, v23, v20
+	v_div_fixup_f32 v12, v19, v18, v12
+	v_fma_f32 v19, -v21, v22, 1.0
+	v_fmac_f32_e32 v22, v19, v22
+	v_div_scale_f32 v19, vcc, v11, v18, v11
+	v_mul_f32_e32 v20, v19, v22
+	v_fma_f32 v23, -v21, v20, v19
+	v_fmac_f32_e32 v20, v23, v22
+	v_fma_f32 v19, -v21, v20, v19
+	v_div_scale_f32 v21, s[0:1], v18, v18, v10
+	v_rcp_f32_e32 v23, v21
+	v_div_fmas_f32 v19, v19, v22, v20
+	v_div_fixup_f32 v11, v19, v18, v11
+	v_fma_f32 v19, -v21, v23, 1.0
+	v_fmac_f32_e32 v23, v19, v23
+	v_div_scale_f32 v19, vcc, v10, v18, v10
+	v_mul_f32_e32 v20, v19, v23
+	v_fma_f32 v22, -v21, v20, v19
+	v_fmac_f32_e32 v20, v22, v23
+	v_fma_f32 v19, -v21, v20, v19
+	v_div_scale_f32 v21, s[0:1], v18, v18, v9
+	v_rcp_f32_e32 v22, v21
+	v_div_fmas_f32 v19, v19, v23, v20
+	v_div_fixup_f32 v10, v19, v18, v10
+	v_fma_f32 v19, -v21, v22, 1.0
+	v_fmac_f32_e32 v22, v19, v22
+	v_div_scale_f32 v19, vcc, v9, v18, v9
+	v_mul_f32_e32 v20, v19, v22
+	v_fma_f32 v23, -v21, v20, v19
+	v_fmac_f32_e32 v20, v23, v22
+	v_fma_f32 v19, -v21, v20, v19
+	v_div_scale_f32 v21, s[0:1], v18, v18, v8
+	v_rcp_f32_e32 v23, v21
+	v_div_fmas_f32 v19, v19, v22, v20
+	v_div_fixup_f32 v9, v19, v18, v9
+	v_fma_f32 v19, -v21, v23, 1.0
+	v_fmac_f32_e32 v23, v19, v23
+	v_div_scale_f32 v19, vcc, v8, v18, v8
+	v_mul_f32_e32 v20, v19, v23
+	v_fma_f32 v22, -v21, v20, v19
+	v_fmac_f32_e32 v20, v22, v23
+	v_fma_f32 v19, -v21, v20, v19
+	v_div_scale_f32 v21, s[0:1], v18, v18, v7
+	v_rcp_f32_e32 v22, v21
+	v_div_fmas_f32 v19, v19, v23, v20
+	v_div_fixup_f32 v8, v19, v18, v8
+	v_fma_f32 v19, -v21, v22, 1.0
+	v_fmac_f32_e32 v22, v19, v22
+	v_div_scale_f32 v19, vcc, v7, v18, v7
+	v_mul_f32_e32 v20, v19, v22
+	v_fma_f32 v23, -v21, v20, v19
+	v_fmac_f32_e32 v20, v23, v22
+	v_fma_f32 v19, -v21, v20, v19
+	v_div_scale_f32 v21, s[0:1], v18, v18, v6
+	v_rcp_f32_e32 v23, v21
+	v_div_fmas_f32 v19, v19, v22, v20
+	v_div_fixup_f32 v7, v19, v18, v7
+	v_fma_f32 v19, -v21, v23, 1.0
+	v_fmac_f32_e32 v23, v19, v23
+	v_div_scale_f32 v19, vcc, v6, v18, v6
+	v_mul_f32_e32 v20, v19, v23
+	v_fma_f32 v22, -v21, v20, v19
+	v_fmac_f32_e32 v20, v22, v23
+	v_fma_f32 v19, -v21, v20, v19
+	v_div_scale_f32 v21, s[0:1], v18, v18, v5
+	v_rcp_f32_e32 v22, v21
+	v_div_fmas_f32 v19, v19, v23, v20
+	v_div_fixup_f32 v6, v19, v18, v6
+	v_fma_f32 v19, -v21, v22, 1.0
+	v_fmac_f32_e32 v22, v19, v22
+	v_div_scale_f32 v19, vcc, v5, v18, v5
+	v_mul_f32_e32 v20, v19, v22
+	v_fma_f32 v23, -v21, v20, v19
+	v_fmac_f32_e32 v20, v23, v22
+	v_fma_f32 v19, -v21, v20, v19
+	v_div_scale_f32 v21, s[0:1], v18, v18, v4
+	v_rcp_f32_e32 v23, v21
+	v_div_fmas_f32 v19, v19, v22, v20
+	v_div_fixup_f32 v5, v19, v18, v5
+	v_fma_f32 v19, -v21, v23, 1.0
+	v_fmac_f32_e32 v23, v19, v23
+	v_div_scale_f32 v19, vcc, v4, v18, v4
+	v_mul_f32_e32 v20, v19, v23
+	v_fma_f32 v22, -v21, v20, v19
+	v_fmac_f32_e32 v20, v22, v23
+	v_fma_f32 v19, -v21, v20, v19
+	v_div_scale_f32 v21, s[0:1], v18, v18, v3
+	v_rcp_f32_e32 v22, v21
+	v_div_fmas_f32 v19, v19, v23, v20
+	v_div_fixup_f32 v4, v19, v18, v4
+	v_fma_f32 v19, -v21, v22, 1.0
+	v_fmac_f32_e32 v22, v19, v22
+	v_div_scale_f32 v19, vcc, v3, v18, v3
+	v_mul_f32_e32 v20, v19, v22
+	v_fma_f32 v23, -v21, v20, v19
+	v_fmac_f32_e32 v20, v23, v22
+	v_fma_f32 v19, -v21, v20, v19
+	v_div_scale_f32 v21, s[0:1], v18, v18, v2
+	v_rcp_f32_e32 v23, v21
+	v_div_fmas_f32 v19, v19, v22, v20
+	v_div_fixup_f32 v3, v19, v18, v3
+	v_fma_f32 v19, -v21, v23, 1.0
+	v_fmac_f32_e32 v23, v19, v23
+	v_div_scale_f32 v19, vcc, v2, v18, v2
+	v_mul_f32_e32 v20, v19, v23
+	v_fma_f32 v22, -v21, v20, v19
+	v_fmac_f32_e32 v20, v22, v23
+	v_fma_f32 v19, -v21, v20, v19
+	v_div_scale_f32 v21, s[0:1], v18, v18, v0
+	v_rcp_f32_e32 v22, v21
+	v_div_fmas_f32 v19, v19, v23, v20
+	v_div_fixup_f32 v2, v19, v18, v2
+	v_fma_f32 v19, -v21, v22, 1.0
+	v_fmac_f32_e32 v22, v19, v22
+	v_div_scale_f32 v19, vcc, v0, v18, v0
+	v_mul_f32_e32 v20, v19, v22
+	v_fma_f32 v23, -v21, v20, v19
+	v_fmac_f32_e32 v20, v23, v22
+	v_fma_f32 v19, -v21, v20, v19
+	v_div_scale_f32 v21, s[0:1], v18, v18, v1
+	v_rcp_f32_e32 v23, v21
+	v_div_fmas_f32 v19, v19, v22, v20
+	v_div_fixup_f32 v0, v19, v18, v0
+	v_fma_f32 v19, -v21, v23, 1.0
+	v_fmac_f32_e32 v23, v19, v23
+	v_div_scale_f32 v19, vcc, v1, v18, v1
+	v_mul_f32_e32 v20, v19, v23
+	v_fma_f32 v22, -v21, v20, v19
+	v_fmac_f32_e32 v20, v22, v23
+	v_fma_f32 v19, -v21, v20, v19
+	v_div_fmas_f32 v19, v19, v23, v20
+	v_div_fixup_f32 v1, v19, v18, v1
+	.loc	1 166 32                        ; generate_rocjitsu_triton_fixtures.py:166:32
+	global_store_dwordx4 v[16:17], v[0:3], off
+	global_store_dwordx4 v[16:17], v[4:7], off offset:32
+	global_store_dwordx4 v[16:17], v[8:11], off offset:64
+	global_store_dwordx4 v[16:17], v[12:15], off offset:96
+.LBB0_36:                               ; %.critedge28
+	.loc	1 166 4 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:166:4
+	s_endpgm
+.Ltmp88:
+	.section	.rodata,"a",@progbits
+	.p2align	6, 0x0
+	.amdhsa_kernel flash_attention_fwd_async_buffer_kernel
+		.amdhsa_group_segment_fixed_size 0
+		.amdhsa_private_segment_fixed_size 0
+		.amdhsa_kernarg_size 56
+		.amdhsa_user_sgpr_count 16
+		.amdhsa_user_sgpr_dispatch_ptr 0
+		.amdhsa_user_sgpr_queue_ptr 0
+		.amdhsa_user_sgpr_kernarg_segment_ptr 1
+		.amdhsa_user_sgpr_dispatch_id 0
+		.amdhsa_user_sgpr_kernarg_preload_length 14
+		.amdhsa_user_sgpr_kernarg_preload_offset 0
+		.amdhsa_user_sgpr_private_segment_size 0
+		.amdhsa_uses_dynamic_stack 0
+		.amdhsa_enable_private_segment 0
+		.amdhsa_system_sgpr_workgroup_id_x 1
+		.amdhsa_system_sgpr_workgroup_id_y 0
+		.amdhsa_system_sgpr_workgroup_id_z 0
+		.amdhsa_system_sgpr_workgroup_info 0
+		.amdhsa_system_vgpr_workitem_id 0
+		.amdhsa_next_free_vgpr 160
+		.amdhsa_next_free_sgpr 17
+		.amdhsa_accum_offset 144
+		.amdhsa_reserve_vcc 1
+		.amdhsa_reserve_xnack_mask 1
+		.amdhsa_float_round_mode_32 0
+		.amdhsa_float_round_mode_16_64 0
+		.amdhsa_float_denorm_mode_32 3
+		.amdhsa_float_denorm_mode_16_64 3
+		.amdhsa_dx10_clamp 1
+		.amdhsa_ieee_mode 1
+		.amdhsa_fp16_overflow 0
+		.amdhsa_tg_split 0
+		.amdhsa_exception_fp_ieee_invalid_op 0
+		.amdhsa_exception_fp_denorm_src 0
+		.amdhsa_exception_fp_ieee_div_zero 0
+		.amdhsa_exception_fp_ieee_overflow 0
+		.amdhsa_exception_fp_ieee_underflow 0
+		.amdhsa_exception_fp_ieee_inexact 0
+		.amdhsa_exception_int_div_zero 0
+	.end_amdhsa_kernel
+	.text
+.Lfunc_end0:
+	.size	flash_attention_fwd_async_buffer_kernel, .Lfunc_end0-flash_attention_fwd_async_buffer_kernel
+	.cfi_endproc
+                                        ; -- End function
+	.set flash_attention_fwd_async_buffer_kernel.num_vgpr, 142
+	.set flash_attention_fwd_async_buffer_kernel.num_agpr, 16
+	.set flash_attention_fwd_async_buffer_kernel.numbered_sgpr, 17
+	.set flash_attention_fwd_async_buffer_kernel.num_named_barrier, 0
+	.set flash_attention_fwd_async_buffer_kernel.private_seg_size, 0
+	.set flash_attention_fwd_async_buffer_kernel.uses_vcc, 1
+	.set flash_attention_fwd_async_buffer_kernel.uses_flat_scratch, 0
+	.set flash_attention_fwd_async_buffer_kernel.has_dyn_sized_stack, 0
+	.set flash_attention_fwd_async_buffer_kernel.has_recursion, 0
+	.set flash_attention_fwd_async_buffer_kernel.has_indirect_call, 0
+	.section	.AMDGPU.csdata,"",@progbits
+; Kernel info:
+; codeLenInByte = 6664
+; TotalNumSgprs: 23
+; NumVgprs: 142
+; NumAgprs: 16
+; TotalNumVgprs: 160
+; ScratchSize: 0
+; MemoryBound: 0
+; FloatMode: 240
+; IeeeMode: 1
+; LDSByteSize: 0 bytes/workgroup (compile time only)
+; SGPRBlocks: 2
+; VGPRBlocks: 19
+; NumSGPRsForWavesPerEU: 23
+; NumVGPRsForWavesPerEU: 160
+; AccumOffset: 144
+; Occupancy: 3
+; WaveLimiterHint : 0
+; COMPUTE_PGM_RSRC2:SCRATCH_EN: 0
+; COMPUTE_PGM_RSRC2:USER_SGPR: 16
+; COMPUTE_PGM_RSRC2:TRAP_HANDLER: 0
+; COMPUTE_PGM_RSRC2:TGID_X_EN: 1
+; COMPUTE_PGM_RSRC2:TGID_Y_EN: 0
+; COMPUTE_PGM_RSRC2:TGID_Z_EN: 0
+; COMPUTE_PGM_RSRC2:TIDIG_COMP_CNT: 0
+; COMPUTE_PGM_RSRC3_GFX90A:ACCUM_OFFSET: 35
+; COMPUTE_PGM_RSRC3_GFX90A:TG_SPLIT: 0
+	.text
+	.p2alignl 6, 3212836864
+	.fill 256, 4, 3212836864
+	.section	.AMDGPU.gpr_maximums,"",@progbits
+	.set amdgpu.max_num_vgpr, 0
+	.set amdgpu.max_num_agpr, 0
+	.set amdgpu.max_num_sgpr, 0
+	.text
+	.section	.debug_abbrev,"",@progbits
+	.byte	1                               ; Abbreviation Code
+	.byte	17                              ; DW_TAG_compile_unit
+	.byte	1                               ; DW_CHILDREN_yes
+	.byte	37                              ; DW_AT_producer
+	.byte	14                              ; DW_FORM_strp
+	.byte	19                              ; DW_AT_language
+	.byte	5                               ; DW_FORM_data2
+	.byte	3                               ; DW_AT_name
+	.byte	14                              ; DW_FORM_strp
+	.byte	16                              ; DW_AT_stmt_list
+	.byte	23                              ; DW_FORM_sec_offset
+	.byte	27                              ; DW_AT_comp_dir
+	.byte	14                              ; DW_FORM_strp
+	.byte	17                              ; DW_AT_low_pc
+	.byte	1                               ; DW_FORM_addr
+	.byte	18                              ; DW_AT_high_pc
+	.byte	6                               ; DW_FORM_data4
+	.byte	0                               ; EOM(1)
+	.byte	0                               ; EOM(2)
+	.byte	2                               ; Abbreviation Code
+	.byte	46                              ; DW_TAG_subprogram
+	.byte	0                               ; DW_CHILDREN_no
+	.byte	3                               ; DW_AT_name
+	.byte	14                              ; DW_FORM_strp
+	.byte	32                              ; DW_AT_inline
+	.byte	11                              ; DW_FORM_data1
+	.byte	0                               ; EOM(1)
+	.byte	0                               ; EOM(2)
+	.byte	3                               ; Abbreviation Code
+	.byte	46                              ; DW_TAG_subprogram
+	.byte	1                               ; DW_CHILDREN_yes
+	.byte	17                              ; DW_AT_low_pc
+	.byte	1                               ; DW_FORM_addr
+	.byte	18                              ; DW_AT_high_pc
+	.byte	6                               ; DW_FORM_data4
+	.byte	49                              ; DW_AT_abstract_origin
+	.byte	19                              ; DW_FORM_ref4
+	.byte	0                               ; EOM(1)
+	.byte	0                               ; EOM(2)
+	.byte	4                               ; Abbreviation Code
+	.byte	29                              ; DW_TAG_inlined_subroutine
+	.byte	1                               ; DW_CHILDREN_yes
+	.byte	49                              ; DW_AT_abstract_origin
+	.byte	19                              ; DW_FORM_ref4
+	.byte	85                              ; DW_AT_ranges
+	.byte	23                              ; DW_FORM_sec_offset
+	.byte	88                              ; DW_AT_call_file
+	.byte	11                              ; DW_FORM_data1
+	.byte	89                              ; DW_AT_call_line
+	.byte	11                              ; DW_FORM_data1
+	.byte	87                              ; DW_AT_call_column
+	.byte	11                              ; DW_FORM_data1
+	.byte	0                               ; EOM(1)
+	.byte	0                               ; EOM(2)
+	.byte	5                               ; Abbreviation Code
+	.byte	29                              ; DW_TAG_inlined_subroutine
+	.byte	0                               ; DW_CHILDREN_no
+	.byte	49                              ; DW_AT_abstract_origin
+	.byte	19                              ; DW_FORM_ref4
+	.byte	85                              ; DW_AT_ranges
+	.byte	23                              ; DW_FORM_sec_offset
+	.byte	88                              ; DW_AT_call_file
+	.byte	11                              ; DW_FORM_data1
+	.byte	89                              ; DW_AT_call_line
+	.byte	11                              ; DW_FORM_data1
+	.byte	87                              ; DW_AT_call_column
+	.byte	11                              ; DW_FORM_data1
+	.byte	0                               ; EOM(1)
+	.byte	0                               ; EOM(2)
+	.byte	6                               ; Abbreviation Code
+	.byte	29                              ; DW_TAG_inlined_subroutine
+	.byte	0                               ; DW_CHILDREN_no
+	.byte	49                              ; DW_AT_abstract_origin
+	.byte	19                              ; DW_FORM_ref4
+	.byte	85                              ; DW_AT_ranges
+	.byte	23                              ; DW_FORM_sec_offset
+	.byte	88                              ; DW_AT_call_file
+	.byte	11                              ; DW_FORM_data1
+	.byte	89                              ; DW_AT_call_line
+	.byte	5                               ; DW_FORM_data2
+	.byte	87                              ; DW_AT_call_column
+	.byte	11                              ; DW_FORM_data1
+	.byte	0                               ; EOM(1)
+	.byte	0                               ; EOM(2)
+	.byte	0                               ; EOM(3)
+	.section	.debug_info,"",@progbits
+.Lcu_begin0:
+	.long	.Ldebug_info_end0-.Ldebug_info_start0 ; Length of Unit
+.Ldebug_info_start0:
+	.short	4                               ; DWARF version number
+	.long	.debug_abbrev                   ; Offset Into Abbrev. Section
+	.byte	8                               ; Address Size (in bytes)
+	.byte	1                               ; Abbrev [1] 0xb:0x6b DW_TAG_compile_unit
+	.long	.Linfo_string0                  ; DW_AT_producer
+	.short	2                               ; DW_AT_language
+	.long	.Linfo_string1                  ; DW_AT_name
+	.long	.Lline_table_start0             ; DW_AT_stmt_list
+	.long	.Linfo_string2                  ; DW_AT_comp_dir
+	.quad	.Lfunc_begin0                   ; DW_AT_low_pc
+	.long	.Lfunc_end0-.Lfunc_begin0       ; DW_AT_high_pc
+	.byte	2                               ; Abbrev [2] 0x2a:0x6 DW_TAG_subprogram
+	.long	.Linfo_string3                  ; DW_AT_name
+	.byte	1                               ; DW_AT_inline
+	.byte	3                               ; Abbrev [3] 0x30:0x45 DW_TAG_subprogram
+	.quad	.Lfunc_begin0                   ; DW_AT_low_pc
+	.long	.Lfunc_end0-.Lfunc_begin0       ; DW_AT_high_pc
+	.long	42                              ; DW_AT_abstract_origin
+	.byte	4                               ; Abbrev [4] 0x41:0x19 DW_TAG_inlined_subroutine
+	.long	42                              ; DW_AT_abstract_origin
+	.long	.Ldebug_ranges0                 ; DW_AT_ranges
+	.byte	1                               ; DW_AT_call_file
+	.byte	153                             ; DW_AT_call_line
+	.byte	39                              ; DW_AT_call_column
+	.byte	5                               ; Abbrev [5] 0x4d:0xc DW_TAG_inlined_subroutine
+	.long	42                              ; DW_AT_abstract_origin
+	.long	.Ldebug_ranges1                 ; DW_AT_ranges
+	.byte	2                               ; DW_AT_call_file
+	.byte	191                             ; DW_AT_call_line
+	.byte	40                              ; DW_AT_call_column
+	.byte	0                               ; End Of Children Mark
+	.byte	4                               ; Abbrev [4] 0x5a:0x1a DW_TAG_inlined_subroutine
+	.long	42                              ; DW_AT_abstract_origin
+	.long	.Ldebug_ranges2                 ; DW_AT_ranges
+	.byte	1                               ; DW_AT_call_file
+	.byte	156                             ; DW_AT_call_line
+	.byte	37                              ; DW_AT_call_column
+	.byte	6                               ; Abbrev [6] 0x66:0xd DW_TAG_inlined_subroutine
+	.long	42                              ; DW_AT_abstract_origin
+	.long	.Ldebug_ranges3                 ; DW_AT_ranges
+	.byte	2                               ; DW_AT_call_file
+	.short	293                             ; DW_AT_call_line
+	.byte	36                              ; DW_AT_call_column
+	.byte	0                               ; End Of Children Mark
+	.byte	0                               ; End Of Children Mark
+	.byte	0                               ; End Of Children Mark
+.Ldebug_info_end0:
+	.section	.debug_ranges,"",@progbits
+.Ldebug_ranges0:
+	.quad	.Ltmp2-.Lfunc_begin0
+	.quad	.Ltmp3-.Lfunc_begin0
+	.quad	.Ltmp4-.Lfunc_begin0
+	.quad	.Ltmp5-.Lfunc_begin0
+	.quad	.Ltmp6-.Lfunc_begin0
+	.quad	.Ltmp7-.Lfunc_begin0
+	.quad	.Ltmp8-.Lfunc_begin0
+	.quad	.Ltmp9-.Lfunc_begin0
+	.quad	.Ltmp10-.Lfunc_begin0
+	.quad	.Ltmp11-.Lfunc_begin0
+	.quad	.Ltmp12-.Lfunc_begin0
+	.quad	.Ltmp13-.Lfunc_begin0
+	.quad	.Ltmp14-.Lfunc_begin0
+	.quad	.Ltmp15-.Lfunc_begin0
+	.quad	.Ltmp16-.Lfunc_begin0
+	.quad	.Ltmp17-.Lfunc_begin0
+	.quad	.Ltmp18-.Lfunc_begin0
+	.quad	.Ltmp19-.Lfunc_begin0
+	.quad	.Ltmp20-.Lfunc_begin0
+	.quad	.Ltmp21-.Lfunc_begin0
+	.quad	.Ltmp22-.Lfunc_begin0
+	.quad	.Ltmp23-.Lfunc_begin0
+	.quad	.Ltmp24-.Lfunc_begin0
+	.quad	.Ltmp25-.Lfunc_begin0
+	.quad	.Ltmp26-.Lfunc_begin0
+	.quad	.Ltmp27-.Lfunc_begin0
+	.quad	.Ltmp28-.Lfunc_begin0
+	.quad	.Ltmp30-.Lfunc_begin0
+	.quad	0
+	.quad	0
+.Ldebug_ranges1:
+	.quad	.Ltmp2-.Lfunc_begin0
+	.quad	.Ltmp3-.Lfunc_begin0
+	.quad	.Ltmp4-.Lfunc_begin0
+	.quad	.Ltmp5-.Lfunc_begin0
+	.quad	.Ltmp6-.Lfunc_begin0
+	.quad	.Ltmp7-.Lfunc_begin0
+	.quad	.Ltmp8-.Lfunc_begin0
+	.quad	.Ltmp9-.Lfunc_begin0
+	.quad	.Ltmp10-.Lfunc_begin0
+	.quad	.Ltmp11-.Lfunc_begin0
+	.quad	.Ltmp12-.Lfunc_begin0
+	.quad	.Ltmp13-.Lfunc_begin0
+	.quad	.Ltmp14-.Lfunc_begin0
+	.quad	.Ltmp15-.Lfunc_begin0
+	.quad	.Ltmp16-.Lfunc_begin0
+	.quad	.Ltmp17-.Lfunc_begin0
+	.quad	.Ltmp18-.Lfunc_begin0
+	.quad	.Ltmp19-.Lfunc_begin0
+	.quad	.Ltmp20-.Lfunc_begin0
+	.quad	.Ltmp21-.Lfunc_begin0
+	.quad	.Ltmp22-.Lfunc_begin0
+	.quad	.Ltmp23-.Lfunc_begin0
+	.quad	.Ltmp24-.Lfunc_begin0
+	.quad	.Ltmp25-.Lfunc_begin0
+	.quad	.Ltmp26-.Lfunc_begin0
+	.quad	.Ltmp27-.Lfunc_begin0
+	.quad	.Ltmp28-.Lfunc_begin0
+	.quad	.Ltmp29-.Lfunc_begin0
+	.quad	0
+	.quad	0
+.Ldebug_ranges2:
+	.quad	.Ltmp31-.Lfunc_begin0
+	.quad	.Ltmp32-.Lfunc_begin0
+	.quad	.Ltmp33-.Lfunc_begin0
+	.quad	.Ltmp34-.Lfunc_begin0
+	.quad	.Ltmp35-.Lfunc_begin0
+	.quad	.Ltmp36-.Lfunc_begin0
+	.quad	.Ltmp37-.Lfunc_begin0
+	.quad	.Ltmp38-.Lfunc_begin0
+	.quad	.Ltmp39-.Lfunc_begin0
+	.quad	.Ltmp40-.Lfunc_begin0
+	.quad	.Ltmp41-.Lfunc_begin0
+	.quad	.Ltmp42-.Lfunc_begin0
+	.quad	.Ltmp43-.Lfunc_begin0
+	.quad	.Ltmp44-.Lfunc_begin0
+	.quad	.Ltmp45-.Lfunc_begin0
+	.quad	.Ltmp46-.Lfunc_begin0
+	.quad	.Ltmp47-.Lfunc_begin0
+	.quad	.Ltmp48-.Lfunc_begin0
+	.quad	.Ltmp49-.Lfunc_begin0
+	.quad	.Ltmp50-.Lfunc_begin0
+	.quad	.Ltmp51-.Lfunc_begin0
+	.quad	.Ltmp52-.Lfunc_begin0
+	.quad	.Ltmp53-.Lfunc_begin0
+	.quad	.Ltmp54-.Lfunc_begin0
+	.quad	.Ltmp55-.Lfunc_begin0
+	.quad	.Ltmp56-.Lfunc_begin0
+	.quad	.Ltmp57-.Lfunc_begin0
+	.quad	.Ltmp58-.Lfunc_begin0
+	.quad	.Ltmp59-.Lfunc_begin0
+	.quad	.Ltmp60-.Lfunc_begin0
+	.quad	.Ltmp61-.Lfunc_begin0
+	.quad	.Ltmp62-.Lfunc_begin0
+	.quad	.Ltmp63-.Lfunc_begin0
+	.quad	.Ltmp64-.Lfunc_begin0
+	.quad	.Ltmp65-.Lfunc_begin0
+	.quad	.Ltmp66-.Lfunc_begin0
+	.quad	.Ltmp67-.Lfunc_begin0
+	.quad	.Ltmp68-.Lfunc_begin0
+	.quad	.Ltmp69-.Lfunc_begin0
+	.quad	.Ltmp70-.Lfunc_begin0
+	.quad	.Ltmp71-.Lfunc_begin0
+	.quad	.Ltmp72-.Lfunc_begin0
+	.quad	.Ltmp73-.Lfunc_begin0
+	.quad	.Ltmp74-.Lfunc_begin0
+	.quad	.Ltmp75-.Lfunc_begin0
+	.quad	.Ltmp76-.Lfunc_begin0
+	.quad	.Ltmp77-.Lfunc_begin0
+	.quad	.Ltmp78-.Lfunc_begin0
+	.quad	.Ltmp79-.Lfunc_begin0
+	.quad	.Ltmp80-.Lfunc_begin0
+	.quad	.Ltmp81-.Lfunc_begin0
+	.quad	.Ltmp82-.Lfunc_begin0
+	.quad	.Ltmp83-.Lfunc_begin0
+	.quad	.Ltmp85-.Lfunc_begin0
+	.quad	.Ltmp86-.Lfunc_begin0
+	.quad	.Ltmp87-.Lfunc_begin0
+	.quad	0
+	.quad	0
+.Ldebug_ranges3:
+	.quad	.Ltmp31-.Lfunc_begin0
+	.quad	.Ltmp32-.Lfunc_begin0
+	.quad	.Ltmp33-.Lfunc_begin0
+	.quad	.Ltmp34-.Lfunc_begin0
+	.quad	.Ltmp35-.Lfunc_begin0
+	.quad	.Ltmp36-.Lfunc_begin0
+	.quad	.Ltmp37-.Lfunc_begin0
+	.quad	.Ltmp38-.Lfunc_begin0
+	.quad	.Ltmp39-.Lfunc_begin0
+	.quad	.Ltmp40-.Lfunc_begin0
+	.quad	.Ltmp41-.Lfunc_begin0
+	.quad	.Ltmp42-.Lfunc_begin0
+	.quad	.Ltmp43-.Lfunc_begin0
+	.quad	.Ltmp44-.Lfunc_begin0
+	.quad	.Ltmp45-.Lfunc_begin0
+	.quad	.Ltmp46-.Lfunc_begin0
+	.quad	.Ltmp47-.Lfunc_begin0
+	.quad	.Ltmp48-.Lfunc_begin0
+	.quad	.Ltmp49-.Lfunc_begin0
+	.quad	.Ltmp50-.Lfunc_begin0
+	.quad	.Ltmp51-.Lfunc_begin0
+	.quad	.Ltmp52-.Lfunc_begin0
+	.quad	.Ltmp53-.Lfunc_begin0
+	.quad	.Ltmp54-.Lfunc_begin0
+	.quad	.Ltmp55-.Lfunc_begin0
+	.quad	.Ltmp56-.Lfunc_begin0
+	.quad	.Ltmp57-.Lfunc_begin0
+	.quad	.Ltmp58-.Lfunc_begin0
+	.quad	.Ltmp59-.Lfunc_begin0
+	.quad	.Ltmp60-.Lfunc_begin0
+	.quad	.Ltmp61-.Lfunc_begin0
+	.quad	.Ltmp62-.Lfunc_begin0
+	.quad	.Ltmp63-.Lfunc_begin0
+	.quad	.Ltmp64-.Lfunc_begin0
+	.quad	.Ltmp65-.Lfunc_begin0
+	.quad	.Ltmp66-.Lfunc_begin0
+	.quad	.Ltmp67-.Lfunc_begin0
+	.quad	.Ltmp68-.Lfunc_begin0
+	.quad	.Ltmp69-.Lfunc_begin0
+	.quad	.Ltmp70-.Lfunc_begin0
+	.quad	.Ltmp71-.Lfunc_begin0
+	.quad	.Ltmp72-.Lfunc_begin0
+	.quad	.Ltmp73-.Lfunc_begin0
+	.quad	.Ltmp74-.Lfunc_begin0
+	.quad	.Ltmp75-.Lfunc_begin0
+	.quad	.Ltmp76-.Lfunc_begin0
+	.quad	.Ltmp77-.Lfunc_begin0
+	.quad	.Ltmp78-.Lfunc_begin0
+	.quad	.Ltmp79-.Lfunc_begin0
+	.quad	.Ltmp80-.Lfunc_begin0
+	.quad	.Ltmp81-.Lfunc_begin0
+	.quad	.Ltmp82-.Lfunc_begin0
+	.quad	.Ltmp83-.Lfunc_begin0
+	.quad	.Ltmp84-.Lfunc_begin0
+	.quad	.Ltmp86-.Lfunc_begin0
+	.quad	.Ltmp87-.Lfunc_begin0
+	.quad	0
+	.quad	0
+	.section	.debug_str,"MS",@progbits,1
+.Linfo_string0:
+	.asciz	"triton"                        ; string offset=0
+.Linfo_string1:
+	.asciz	"generate_rocjitsu_triton_fixtures.py" ; string offset=7
+.Linfo_string2:
+	.asciz	"/tmp"                          ; string offset=44
+.Linfo_string3:
+	.asciz	"flash_attention_fwd_async_buffer_kernel" ; string offset=49
+	.section	".note.GNU-stack","",@progbits
+	.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .agpr_count:     16
+    .args:
+      - .address_space:  global
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .address_space:  global
+        .offset:         8
+        .size:           8
+        .value_kind:     global_buffer
+      - .address_space:  global
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .address_space:  global
+        .offset:         24
+        .size:           8
+        .value_kind:     global_buffer
+      - .offset:         32
+        .size:           4
+        .value_kind:     by_value
+      - .address_space:  global
+        .offset:         40
+        .size:           8
+        .value_kind:     global_buffer
+      - .address_space:  global
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+    .group_segment_fixed_size: 0
+    .kernarg_segment_align: 8
+    .kernarg_segment_size: 56
+    .max_flat_workgroup_size: 256
+    .name:           flash_attention_fwd_async_buffer_kernel
+    .private_segment_fixed_size: 0
+    .sgpr_count:     23
+    .sgpr_spill_count: 0
+    .symbol:         flash_attention_fwd_async_buffer_kernel.kd
+    .uniform_work_group_size: 1
+    .uses_dynamic_stack: false
+    .vgpr_count:     160
+    .vgpr_spill_count: 0
+    .wavefront_size: 64
+amdhsa.target:   amdgcn-amd-amdhsa--gfx942
+amdhsa.version:
+  - 1
+  - 2
+...
+
+	.end_amdgpu_metadata
+	.section	.debug_line,"",@progbits
+.Lline_table_start0:

--- a/emulation/rocjitsu/tests/kernels/triton_cdna3_flash_attention_no_async_1024.s
+++ b/emulation/rocjitsu/tests/kernels/triton_cdna3_flash_attention_no_async_1024.s
@@ -1,0 +1,2032 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// Native CDNA3/gfx942 Triton golden fixture generated from the same source and
+// constexprs as the corresponding gfx950 DBT input fixture.
+//
+// Recorded fixture metadata:
+//   kernel: flash_attention_fwd_no_async_kernel
+//   target: gfx942, wavefront_size: 64
+//   Triton metadata shared: 8192
+//   num_warps: 4
+//   num_stages: 2
+
+	.amdgcn_target "amdgcn-amd-amdhsa--gfx942"
+	.amdhsa_code_object_version 5
+	.text
+	.globl	flash_attention_fwd_no_async_kernel ; -- Begin function flash_attention_fwd_no_async_kernel
+	.p2align	8
+	.type	flash_attention_fwd_no_async_kernel,@function
+flash_attention_fwd_no_async_kernel:    ; @flash_attention_fwd_no_async_kernel
+.Lfunc_begin0:
+	.cfi_sections .debug_frame
+	.cfi_startproc
+; %bb.37:
+	.file	1 "/tmp" "generate_rocjitsu_triton_fixtures.py"
+	.loc	1 77 0 prologue_end             ; generate_rocjitsu_triton_fixtures.py:77:0
+	s_load_dwordx2 s[2:3], s[0:1], 0x0
+	s_load_dwordx8 s[4:11], s[0:1], 0x8
+	s_load_dwordx4 s[12:15], s[0:1], 0x28
+	s_waitcnt lgkmcnt(0)
+	s_branch .LBB0_0
+	.loc	1 0 0 is_stmt 0                 ; :0:0
+.Ltmp0:
+	.p2align	8
+; %bb.38:
+.LBB0_0:
+.Ltmp1:
+	.loc	1 90 21 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:90:21
+	s_lshl_b32 s11, s16, 6
+	.loc	1 90 44 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:90:44
+	v_lshrrev_b32_e32 v1, 6, v0
+	.loc	1 90 31                         ; generate_rocjitsu_triton_fixtures.py:90:31
+	v_or_b32_e32 v3, s11, v1
+	s_movk_i32 s0, 0x400
+	.loc	1 94 57 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:94:57
+	v_and_b32_e32 v2, 63, v0
+	.loc	1 94 40 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:94:40
+	v_cmp_gt_i32_e32 vcc, s0, v3
+	.loc	1 93 54 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:93:54
+	v_mov_b32_e32 v5, 0
+	v_lshlrev_b32_e32 v16, 1, v2
+	v_mov_b32_e32 v6, 0
+	.loc	1 93 16 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:93:16
+	s_and_saveexec_b64 s[0:1], vcc
+	s_cbranch_execz .LBB0_2
+; %bb.1:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	v_lshlrev_b32_e32 v6, 6, v3
+	v_ashrrev_i32_e32 v7, 31, v6
+	v_lshl_add_u64 v[6:7], v[6:7], 1, s[2:3]
+	v_mov_b32_e32 v17, 0
+	v_lshl_add_u64 v[6:7], v[6:7], 0, v[16:17]
+	.loc	1 93 16                         ; generate_rocjitsu_triton_fixtures.py:93:16
+	global_load_ushort v6, v[6:7], off
+.LBB0_2:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_or_b64 exec, exec, s[0:1]
+	.loc	1 93 16                         ; generate_rocjitsu_triton_fixtures.py:93:16
+	s_and_saveexec_b64 s[0:1], vcc
+	s_cbranch_execz .LBB0_4
+; %bb.3:
+	.loc	1 93 42                         ; generate_rocjitsu_triton_fixtures.py:93:42
+	v_mov_b32_e32 v4, 0x100
+	v_lshl_or_b32 v4, v3, 6, v4
+	.loc	1 93 24                         ; generate_rocjitsu_triton_fixtures.py:93:24
+	v_ashrrev_i32_e32 v5, 31, v4
+	v_lshl_add_u64 v[4:5], v[4:5], 1, s[2:3]
+	.loc	1 93 54                         ; generate_rocjitsu_triton_fixtures.py:93:54
+	v_mov_b32_e32 v17, 0
+	v_lshl_add_u64 v[4:5], v[4:5], 0, v[16:17]
+	.loc	1 93 16                         ; generate_rocjitsu_triton_fixtures.py:93:16
+	global_load_ushort v5, v[4:5], off
+.LBB0_4:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_or_b64 exec, exec, s[0:1]
+	v_mov_b32_e32 v7, 0
+	v_mov_b32_e32 v8, 0
+	.loc	1 93 16                         ; generate_rocjitsu_triton_fixtures.py:93:16
+	s_and_saveexec_b64 s[0:1], vcc
+	s_cbranch_execz .LBB0_6
+; %bb.5:
+	.loc	1 93 42                         ; generate_rocjitsu_triton_fixtures.py:93:42
+	v_mov_b32_e32 v4, 0x200
+	v_lshl_or_b32 v8, v3, 6, v4
+	.loc	1 93 24                         ; generate_rocjitsu_triton_fixtures.py:93:24
+	v_ashrrev_i32_e32 v9, 31, v8
+	v_lshl_add_u64 v[8:9], v[8:9], 1, s[2:3]
+	.loc	1 93 54                         ; generate_rocjitsu_triton_fixtures.py:93:54
+	v_mov_b32_e32 v17, 0
+	v_lshl_add_u64 v[8:9], v[8:9], 0, v[16:17]
+	.loc	1 93 16                         ; generate_rocjitsu_triton_fixtures.py:93:16
+	global_load_ushort v8, v[8:9], off
+.LBB0_6:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_or_b64 exec, exec, s[0:1]
+	.loc	1 93 16                         ; generate_rocjitsu_triton_fixtures.py:93:16
+	s_and_saveexec_b64 s[0:1], vcc
+	s_cbranch_execz .LBB0_8
+; %bb.7:
+	.loc	1 93 42                         ; generate_rocjitsu_triton_fixtures.py:93:42
+	v_mov_b32_e32 v4, 0x300
+	v_lshl_or_b32 v10, v3, 6, v4
+	.loc	1 93 24                         ; generate_rocjitsu_triton_fixtures.py:93:24
+	v_ashrrev_i32_e32 v11, 31, v10
+	v_lshl_add_u64 v[10:11], v[10:11], 1, s[2:3]
+	.loc	1 93 54                         ; generate_rocjitsu_triton_fixtures.py:93:54
+	v_mov_b32_e32 v17, 0
+	v_lshl_add_u64 v[10:11], v[10:11], 0, v[16:17]
+	.loc	1 93 16                         ; generate_rocjitsu_triton_fixtures.py:93:16
+	global_load_ushort v7, v[10:11], off
+.LBB0_8:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_or_b64 exec, exec, s[0:1]
+	v_mov_b32_e32 v9, 0
+	v_mov_b32_e32 v10, 0
+	.loc	1 93 16                         ; generate_rocjitsu_triton_fixtures.py:93:16
+	s_and_saveexec_b64 s[0:1], vcc
+	s_cbranch_execz .LBB0_10
+; %bb.9:
+	.loc	1 93 42                         ; generate_rocjitsu_triton_fixtures.py:93:42
+	v_mov_b32_e32 v4, 0x400
+	v_lshl_or_b32 v10, v3, 6, v4
+	.loc	1 93 24                         ; generate_rocjitsu_triton_fixtures.py:93:24
+	v_ashrrev_i32_e32 v11, 31, v10
+	v_lshl_add_u64 v[10:11], v[10:11], 1, s[2:3]
+	.loc	1 93 54                         ; generate_rocjitsu_triton_fixtures.py:93:54
+	v_mov_b32_e32 v17, 0
+	v_lshl_add_u64 v[10:11], v[10:11], 0, v[16:17]
+	.loc	1 93 16                         ; generate_rocjitsu_triton_fixtures.py:93:16
+	global_load_ushort v10, v[10:11], off
+.LBB0_10:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_or_b64 exec, exec, s[0:1]
+	.loc	1 93 16                         ; generate_rocjitsu_triton_fixtures.py:93:16
+	s_and_saveexec_b64 s[0:1], vcc
+	s_cbranch_execz .LBB0_12
+; %bb.11:
+	.loc	1 93 42                         ; generate_rocjitsu_triton_fixtures.py:93:42
+	v_mov_b32_e32 v4, 0x500
+	v_lshl_or_b32 v12, v3, 6, v4
+	.loc	1 93 24                         ; generate_rocjitsu_triton_fixtures.py:93:24
+	v_ashrrev_i32_e32 v13, 31, v12
+	v_lshl_add_u64 v[12:13], v[12:13], 1, s[2:3]
+	.loc	1 93 54                         ; generate_rocjitsu_triton_fixtures.py:93:54
+	v_mov_b32_e32 v17, 0
+	v_lshl_add_u64 v[12:13], v[12:13], 0, v[16:17]
+	.loc	1 93 16                         ; generate_rocjitsu_triton_fixtures.py:93:16
+	global_load_ushort v9, v[12:13], off
+.LBB0_12:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_or_b64 exec, exec, s[0:1]
+	v_mov_b32_e32 v11, 0
+	v_mov_b32_e32 v12, 0
+	.loc	1 93 16                         ; generate_rocjitsu_triton_fixtures.py:93:16
+	s_and_saveexec_b64 s[0:1], vcc
+	s_cbranch_execz .LBB0_14
+; %bb.13:
+	.loc	1 93 42                         ; generate_rocjitsu_triton_fixtures.py:93:42
+	v_mov_b32_e32 v4, 0x600
+	v_lshl_or_b32 v12, v3, 6, v4
+	.loc	1 93 24                         ; generate_rocjitsu_triton_fixtures.py:93:24
+	v_ashrrev_i32_e32 v13, 31, v12
+	v_lshl_add_u64 v[12:13], v[12:13], 1, s[2:3]
+	.loc	1 93 54                         ; generate_rocjitsu_triton_fixtures.py:93:54
+	v_mov_b32_e32 v17, 0
+	v_lshl_add_u64 v[12:13], v[12:13], 0, v[16:17]
+	.loc	1 93 16                         ; generate_rocjitsu_triton_fixtures.py:93:16
+	global_load_ushort v12, v[12:13], off
+.LBB0_14:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_or_b64 exec, exec, s[0:1]
+	.loc	1 93 16                         ; generate_rocjitsu_triton_fixtures.py:93:16
+	s_and_saveexec_b64 s[0:1], vcc
+	s_cbranch_execz .LBB0_16
+; %bb.15:
+	.loc	1 93 42                         ; generate_rocjitsu_triton_fixtures.py:93:42
+	v_mov_b32_e32 v4, 0x700
+	v_lshl_or_b32 v14, v3, 6, v4
+	.loc	1 93 24                         ; generate_rocjitsu_triton_fixtures.py:93:24
+	v_ashrrev_i32_e32 v15, 31, v14
+	v_lshl_add_u64 v[14:15], v[14:15], 1, s[2:3]
+	.loc	1 93 54                         ; generate_rocjitsu_triton_fixtures.py:93:54
+	v_mov_b32_e32 v17, 0
+	v_lshl_add_u64 v[14:15], v[14:15], 0, v[16:17]
+	.loc	1 93 16                         ; generate_rocjitsu_triton_fixtures.py:93:16
+	global_load_ushort v11, v[14:15], off
+.LBB0_16:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_or_b64 exec, exec, s[0:1]
+	v_mov_b32_e32 v13, 0
+	v_mov_b32_e32 v14, 0
+	.loc	1 93 16                         ; generate_rocjitsu_triton_fixtures.py:93:16
+	s_and_saveexec_b64 s[0:1], vcc
+	s_cbranch_execz .LBB0_18
+; %bb.17:
+	.loc	1 93 42                         ; generate_rocjitsu_triton_fixtures.py:93:42
+	v_mov_b32_e32 v4, 0x800
+	v_lshl_or_b32 v14, v3, 6, v4
+	.loc	1 93 24                         ; generate_rocjitsu_triton_fixtures.py:93:24
+	v_ashrrev_i32_e32 v15, 31, v14
+	v_lshl_add_u64 v[14:15], v[14:15], 1, s[2:3]
+	.loc	1 93 54                         ; generate_rocjitsu_triton_fixtures.py:93:54
+	v_mov_b32_e32 v17, 0
+	v_lshl_add_u64 v[14:15], v[14:15], 0, v[16:17]
+	.loc	1 93 16                         ; generate_rocjitsu_triton_fixtures.py:93:16
+	global_load_ushort v14, v[14:15], off
+.LBB0_18:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_or_b64 exec, exec, s[0:1]
+	.loc	1 93 16                         ; generate_rocjitsu_triton_fixtures.py:93:16
+	s_and_saveexec_b64 s[0:1], vcc
+	s_cbranch_execz .LBB0_20
+; %bb.19:
+	.loc	1 93 42                         ; generate_rocjitsu_triton_fixtures.py:93:42
+	v_mov_b32_e32 v4, 0x900
+	v_lshl_or_b32 v18, v3, 6, v4
+	.loc	1 93 24                         ; generate_rocjitsu_triton_fixtures.py:93:24
+	v_ashrrev_i32_e32 v19, 31, v18
+	v_lshl_add_u64 v[18:19], v[18:19], 1, s[2:3]
+	.loc	1 93 54                         ; generate_rocjitsu_triton_fixtures.py:93:54
+	v_mov_b32_e32 v17, 0
+	v_lshl_add_u64 v[18:19], v[18:19], 0, v[16:17]
+	.loc	1 93 16                         ; generate_rocjitsu_triton_fixtures.py:93:16
+	global_load_ushort v13, v[18:19], off
+.LBB0_20:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_or_b64 exec, exec, s[0:1]
+	v_mov_b32_e32 v15, 0
+	v_mov_b32_e32 v18, 0
+	.loc	1 93 16                         ; generate_rocjitsu_triton_fixtures.py:93:16
+	s_and_saveexec_b64 s[0:1], vcc
+	s_cbranch_execz .LBB0_22
+; %bb.21:
+	.loc	1 93 42                         ; generate_rocjitsu_triton_fixtures.py:93:42
+	v_mov_b32_e32 v4, 0xa00
+	v_lshl_or_b32 v18, v3, 6, v4
+	.loc	1 93 24                         ; generate_rocjitsu_triton_fixtures.py:93:24
+	v_ashrrev_i32_e32 v19, 31, v18
+	v_lshl_add_u64 v[18:19], v[18:19], 1, s[2:3]
+	.loc	1 93 54                         ; generate_rocjitsu_triton_fixtures.py:93:54
+	v_mov_b32_e32 v17, 0
+	v_lshl_add_u64 v[18:19], v[18:19], 0, v[16:17]
+	.loc	1 93 16                         ; generate_rocjitsu_triton_fixtures.py:93:16
+	global_load_ushort v18, v[18:19], off
+.LBB0_22:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_or_b64 exec, exec, s[0:1]
+	.loc	1 93 16                         ; generate_rocjitsu_triton_fixtures.py:93:16
+	s_and_saveexec_b64 s[0:1], vcc
+	s_cbranch_execz .LBB0_24
+; %bb.23:
+	.loc	1 93 42                         ; generate_rocjitsu_triton_fixtures.py:93:42
+	v_mov_b32_e32 v4, 0xb00
+	v_lshl_or_b32 v20, v3, 6, v4
+	.loc	1 93 24                         ; generate_rocjitsu_triton_fixtures.py:93:24
+	v_ashrrev_i32_e32 v21, 31, v20
+	v_lshl_add_u64 v[20:21], v[20:21], 1, s[2:3]
+	.loc	1 93 54                         ; generate_rocjitsu_triton_fixtures.py:93:54
+	v_mov_b32_e32 v17, 0
+	v_lshl_add_u64 v[20:21], v[20:21], 0, v[16:17]
+	.loc	1 93 16                         ; generate_rocjitsu_triton_fixtures.py:93:16
+	global_load_ushort v15, v[20:21], off
+.LBB0_24:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_or_b64 exec, exec, s[0:1]
+	v_mov_b32_e32 v19, 0
+	v_mov_b32_e32 v20, 0
+	.loc	1 93 16                         ; generate_rocjitsu_triton_fixtures.py:93:16
+	s_and_saveexec_b64 s[0:1], vcc
+	s_cbranch_execz .LBB0_26
+; %bb.25:
+	.loc	1 93 42                         ; generate_rocjitsu_triton_fixtures.py:93:42
+	v_mov_b32_e32 v4, 0xc00
+	v_lshl_or_b32 v20, v3, 6, v4
+	.loc	1 93 24                         ; generate_rocjitsu_triton_fixtures.py:93:24
+	v_ashrrev_i32_e32 v21, 31, v20
+	v_lshl_add_u64 v[20:21], v[20:21], 1, s[2:3]
+	.loc	1 93 54                         ; generate_rocjitsu_triton_fixtures.py:93:54
+	v_mov_b32_e32 v17, 0
+	v_lshl_add_u64 v[20:21], v[20:21], 0, v[16:17]
+	.loc	1 93 16                         ; generate_rocjitsu_triton_fixtures.py:93:16
+	global_load_ushort v20, v[20:21], off
+.LBB0_26:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_or_b64 exec, exec, s[0:1]
+	.loc	1 93 16                         ; generate_rocjitsu_triton_fixtures.py:93:16
+	s_and_saveexec_b64 s[0:1], vcc
+	s_cbranch_execz .LBB0_28
+; %bb.27:
+	.loc	1 93 42                         ; generate_rocjitsu_triton_fixtures.py:93:42
+	v_mov_b32_e32 v4, 0xd00
+	v_lshl_or_b32 v22, v3, 6, v4
+	.loc	1 93 24                         ; generate_rocjitsu_triton_fixtures.py:93:24
+	v_ashrrev_i32_e32 v23, 31, v22
+	v_lshl_add_u64 v[22:23], v[22:23], 1, s[2:3]
+	.loc	1 93 54                         ; generate_rocjitsu_triton_fixtures.py:93:54
+	v_mov_b32_e32 v17, 0
+	v_lshl_add_u64 v[22:23], v[22:23], 0, v[16:17]
+	.loc	1 93 16                         ; generate_rocjitsu_triton_fixtures.py:93:16
+	global_load_ushort v19, v[22:23], off
+.LBB0_28:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_or_b64 exec, exec, s[0:1]
+	v_mov_b32_e32 v21, 0
+	v_mov_b32_e32 v22, 0
+	.loc	1 93 16                         ; generate_rocjitsu_triton_fixtures.py:93:16
+	s_and_saveexec_b64 s[0:1], vcc
+	s_cbranch_execz .LBB0_30
+; %bb.29:
+	.loc	1 93 42                         ; generate_rocjitsu_triton_fixtures.py:93:42
+	v_mov_b32_e32 v4, 0xe00
+	v_lshl_or_b32 v22, v3, 6, v4
+	.loc	1 93 24                         ; generate_rocjitsu_triton_fixtures.py:93:24
+	v_ashrrev_i32_e32 v23, 31, v22
+	v_lshl_add_u64 v[22:23], v[22:23], 1, s[2:3]
+	.loc	1 93 54                         ; generate_rocjitsu_triton_fixtures.py:93:54
+	v_mov_b32_e32 v17, 0
+	v_lshl_add_u64 v[22:23], v[22:23], 0, v[16:17]
+	.loc	1 93 16                         ; generate_rocjitsu_triton_fixtures.py:93:16
+	global_load_ushort v22, v[22:23], off
+.LBB0_30:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_or_b64 exec, exec, s[0:1]
+	v_and_b32_e32 v4, 0xc0, v0
+	.loc	1 93 16                         ; generate_rocjitsu_triton_fixtures.py:93:16
+	s_and_saveexec_b64 s[0:1], vcc
+	s_cbranch_execz .LBB0_32
+; %bb.31:
+	.loc	1 93 42                         ; generate_rocjitsu_triton_fixtures.py:93:42
+	v_mov_b32_e32 v17, 0xf00
+	v_lshl_or_b32 v24, v3, 6, v17
+	.loc	1 93 24                         ; generate_rocjitsu_triton_fixtures.py:93:24
+	v_ashrrev_i32_e32 v25, 31, v24
+	v_lshl_add_u64 v[24:25], v[24:25], 1, s[2:3]
+	.loc	1 93 54                         ; generate_rocjitsu_triton_fixtures.py:93:54
+	v_mov_b32_e32 v17, 0
+	v_lshl_add_u64 v[24:25], v[24:25], 0, v[16:17]
+	.loc	1 93 16                         ; generate_rocjitsu_triton_fixtures.py:93:16
+	global_load_ushort v21, v[24:25], off
+.LBB0_32:
+	.loc	1 0 16                          ; generate_rocjitsu_triton_fixtures.py:0:16
+	s_or_b64 exec, exec, s[0:1]
+	.loc	1 90 44 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:90:44
+	v_and_b32_e32 v3, 64, v0
+	v_and_b32_e32 v49, 31, v0
+	v_lshrrev_b32_e32 v47, 1, v3
+	.loc	1 90 31 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:90:31
+	v_or3_b32 v23, s11, v49, v47
+	s_movk_i32 s0, 0x400
+	.loc	1 94 40 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:94:40
+	v_cmp_gt_i32_e32 vcc, s0, v23
+	.loc	1 93 16                         ; generate_rocjitsu_triton_fixtures.py:93:16
+	v_lshlrev_b32_e32 v23, 1, v0
+	v_lshrrev_b32_e32 v4, 3, v4
+	v_xor_b32_e32 v23, v23, v4
+	v_add_u32_e32 v51, 0, v23
+	s_waitcnt vmcnt(0)
+	ds_write_b16 v51, v6
+	ds_write_b16 v51, v10 offset:2048
+	ds_write_b16 v51, v14 offset:4096
+	ds_write_b16 v51, v20 offset:6144
+	v_xor_b32_e32 v6, 32, v23
+	v_add_u32_e32 v52, 0, v6
+	ds_write_b16 v52, v5 offset:512
+	ds_write_b16 v52, v9 offset:2560
+	ds_write_b16 v52, v13 offset:4608
+	ds_write_b16 v52, v19 offset:6656
+	v_xor_b32_e32 v5, 64, v23
+	v_add_u32_e32 v53, 0, v5
+	v_xor_b32_e32 v5, 0x60, v23
+	.loc	1 90 44                         ; generate_rocjitsu_triton_fixtures.py:90:44
+	v_and_b32_e32 v48, 32, v0
+	.loc	1 93 16                         ; generate_rocjitsu_triton_fixtures.py:93:16
+	v_add_u32_e32 v54, 0, v5
+	v_and_b32_e32 v6, 15, v0
+	.loc	1 90 44                         ; generate_rocjitsu_triton_fixtures.py:90:44
+	v_and_b32_e32 v50, 0x80, v0
+	.loc	1 93 16                         ; generate_rocjitsu_triton_fixtures.py:93:16
+	ds_write_b16 v53, v8 offset:1024
+	ds_write_b16 v53, v12 offset:3072
+	ds_write_b16 v53, v18 offset:5120
+	ds_write_b16 v53, v22 offset:7168
+	ds_write_b16 v54, v7 offset:1536
+	ds_write_b16 v54, v11 offset:3584
+	ds_write_b16 v54, v15 offset:5632
+	ds_write_b16 v54, v21 offset:7680
+	v_lshlrev_b32_e32 v7, 3, v6
+	v_lshrrev_b32_e32 v8, 2, v48
+	v_lshlrev_b32_e32 v15, 2, v0
+	v_lshl_add_u32 v34, v48, 4, 0
+	v_lshlrev_b32_e32 v5, 7, v49
+	v_lshlrev_b32_e32 v9, 6, v3
+	v_xor_b32_e32 v10, v7, v8
+	v_xor_b32_e32 v57, 0x80, v15
+	v_lshlrev_b32_e32 v15, 1, v3
+	v_add_u32_e32 v39, v34, v3
+	v_lshrrev_b32_e32 v3, 1, v50
+	v_or3_b32 v9, v10, v9, v5
+	v_add_u32_e32 v40, v34, v3
+	v_lshrrev_b32_e32 v3, 1, v0
+	v_add_u32_e32 v10, 0, v9
+	v_xad_u32 v11, v9, 16, 0
+	v_xad_u32 v12, v9, 32, 0
+	v_and_b32_e32 v3, 24, v3
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	v_xad_u32 v13, v9, 48, 0
+	ds_read_b64 v[18:19], v10
+	ds_read_b64 v[20:21], v11
+	ds_read_b64 v[22:23], v12
+	ds_read_b64 v[24:25], v13
+	v_xad_u32 v10, v9, 64, 0
+	v_xor_b32_e32 v11, 0x50, v9
+	v_xor_b32_e32 v12, 0x60, v9
+	v_xor_b32_e32 v9, 0x70, v9
+	v_xor_b32_e32 v3, v7, v3
+	.loc	1 90 44                         ; generate_rocjitsu_triton_fixtures.py:90:44
+	v_bfe_i32 v17, v0, 6, 1
+	.loc	1 93 16                         ; generate_rocjitsu_triton_fixtures.py:93:16
+	v_add_u32_e32 v11, 0, v11
+	v_add_u32_e32 v12, 0, v12
+	v_add_u32_e32 v9, 0, v9
+	ds_read_b64 v[26:27], v10
+	ds_read_b64 v[28:29], v11
+	ds_read_b64 v[30:31], v12
+	ds_read_b64 v[32:33], v9
+	v_xor_b32_e32 v3, v3, v4
+	v_bfe_i32 v0, v0, 4, 1
+	s_movk_i32 s0, 0x1010
+	v_lshl_or_b32 v59, v2, 7, v3
+	v_and_b32_e32 v0, 0x808, v0
+	v_and_or_b32 v2, v17, s0, v8
+	v_xor_b32_e32 v0, v0, v2
+	v_or_b32_e32 v5, v5, v7
+	v_xor_b32_e32 v0, v0, v7
+	.loc	1 98 31                         ; generate_rocjitsu_triton_fixtures.py:98:31
+	v_mov_b32_e32 v9, 0x3fb8aa3b
+	v_xor_b32_e32 v56, v5, v8
+	v_lshl_or_b32 v60, v6, 7, v0
+	.loc	1 99 48                         ; generate_rocjitsu_triton_fixtures.py:99:48
+	v_mov_b32_e32 v17, 0
+	.loc	1 98 31                         ; generate_rocjitsu_triton_fixtures.py:98:31
+	v_mul_f32_e32 v55, s10, v9
+	v_xor_b32_e32 v5, 16, v56
+	v_xor_b32_e32 v9, 32, v56
+	v_xor_b32_e32 v10, 48, v56
+	v_xor_b32_e32 v11, 64, v56
+	v_xor_b32_e32 v12, 0x50, v56
+	v_xor_b32_e32 v13, 0x60, v56
+	v_xor_b32_e32 v14, 0x70, v56
+	v_lshl_add_u32 v58, v49, 2, 0
+	v_lshlrev_b32_e32 v38, 1, v49
+	v_xor_b32_e32 v4, 32, v59
+	v_xor_b32_e32 v41, 64, v59
+	v_xor_b32_e32 v42, 0x60, v59
+	v_xor_b32_e32 v6, 16, v60
+	v_xor_b32_e32 v7, 32, v60
+	v_xor_b32_e32 v8, 48, v60
+	v_xor_b32_e32 v43, 64, v60
+	v_xor_b32_e32 v44, 0x50, v60
+	v_xor_b32_e32 v45, 0x60, v60
+	v_xor_b32_e32 v46, 0x70, v60
+	.loc	1 99 48                         ; generate_rocjitsu_triton_fixtures.py:99:48
+	v_lshlrev_b32_e32 v2, 7, v1
+	v_mov_b32_e32 v3, v17
+	v_lshlrev_b32_e32 v0, 9, v1
+	v_mov_b32_e32 v1, v17
+	v_accvgpr_write_b32 a15, 0
+	v_accvgpr_write_b32 a14, 0
+	v_accvgpr_write_b32 a13, 0
+	v_accvgpr_write_b32 a12, 0
+	v_accvgpr_write_b32 a11, 0
+	v_accvgpr_write_b32 a10, 0
+	v_accvgpr_write_b32 a9, 0
+	v_accvgpr_write_b32 a8, 0
+	v_accvgpr_write_b32 a7, 0
+	v_accvgpr_write_b32 a6, 0
+	v_accvgpr_write_b32 a5, 0
+	v_accvgpr_write_b32 a4, 0
+	v_accvgpr_write_b32 a3, 0
+	v_accvgpr_write_b32 a2, 0
+	v_accvgpr_write_b32 a1, 0
+	v_accvgpr_write_b32 a0, 0
+	v_lshl_add_u64 v[34:35], s[4:5], 0, v[2:3]
+	v_lshl_add_u64 v[36:37], s[6:7], 0, v[0:1]
+	v_mov_b32_e32 v61, 0xe0ad78ec
+	s_movk_i32 s4, 0xffc0
+	s_movk_i32 s5, 0x1000
+	v_add_u32_e32 v62, 0, v5
+	v_add_u32_e32 v63, 0, v9
+	v_add_u32_e32 v64, 0, v10
+	v_add_u32_e32 v65, 0, v11
+	v_add_u32_e32 v66, 0, v12
+	v_add_u32_e32 v67, 0, v13
+	v_add_u32_e32 v68, 0, v14
+	v_add_u32_e32 v69, v39, v38
+	v_add_u32_e32 v70, v40, v38
+	s_mov_b32 s6, 0x5040100
+	v_add_u32_e32 v71, 0, v4
+	v_add_u32_e32 v72, 0, v41
+	v_add_u32_e32 v74, 0, v42
+	v_add_u32_e32 v75, 0, v6
+	v_add_u32_e32 v76, 0, v7
+	v_add_u32_e32 v77, 0, v8
+	v_add_u32_e32 v78, 0, v43
+	v_add_u32_e32 v79, 0, v44
+	v_add_u32_e32 v80, 0, v45
+	v_add_u32_e32 v81, 0, v46
+	s_mov_b64 s[2:3], 0x2000
+	v_add_u32_e32 v73, v58, v15
+	v_mov_b32_e32 v83, v17
+	v_mov_b32_e32 v8, 0xe0ad78ec
+.LBB0_33:                               ; =>This Inner Loop Header: Depth=1
+	.loc	1 0 48 is_stmt 0                ; generate_rocjitsu_triton_fixtures.py:0:48
+	v_mov_b32_e32 v84, v83
+	.loc	1 99 48                         ; generate_rocjitsu_triton_fixtures.py:99:48
+	s_nop 8
+	v_accvgpr_read_b32 v1, a15
+	v_accvgpr_read_b32 v0, a14
+	v_accvgpr_read_b32 v3, a13
+	v_accvgpr_read_b32 v2, a12
+	v_accvgpr_read_b32 v5, a11
+	v_accvgpr_read_b32 v4, a10
+	v_accvgpr_read_b32 v7, a9
+	v_accvgpr_read_b32 v6, a8
+	v_accvgpr_read_b32 v39, a7
+	v_accvgpr_read_b32 v38, a6
+	v_accvgpr_read_b32 v41, a5
+	v_accvgpr_read_b32 v40, a4
+	v_accvgpr_read_b32 v43, a3
+	v_accvgpr_read_b32 v42, a2
+	v_accvgpr_read_b32 v45, a1
+	v_accvgpr_read_b32 v44, a0
+	; sched_barrier mask(0x00000000)
+	.loc	1 102 53 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:102:53
+	v_lshl_add_u64 v[10:11], v[34:35], 0, v[16:17]
+	; iglp_opt mask(0x00000002)
+	; sched_barrier mask(0x00000000)
+	.loc	1 102 20 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:102:20
+	global_load_ushort v9, v[10:11], off
+	global_load_ushort v12, v[10:11], off offset:512
+	global_load_ushort v13, v[10:11], off offset:1024
+	global_load_ushort v14, v[10:11], off offset:1536
+	global_load_ushort v15, v[10:11], off offset:2048
+	global_load_ushort v46, v[10:11], off offset:2560
+	global_load_ushort v82, v[10:11], off offset:3072
+	global_load_ushort v83, v[10:11], off offset:3584
+	v_add_co_u32_e64 v10, s[0:1], s5, v10
+	.loc	1 99 48 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:99:48
+	s_add_i32 s4, s4, 64
+	.loc	1 102 20                        ; generate_rocjitsu_triton_fixtures.py:102:20
+	s_nop 0
+	v_addc_co_u32_e64 v11, s[0:1], 0, v11, s[0:1]
+	global_load_ushort v85, v[10:11], off
+	global_load_ushort v86, v[10:11], off offset:512
+	global_load_ushort v87, v[10:11], off offset:1024
+	global_load_ushort v88, v[10:11], off offset:1536
+	global_load_ushort v89, v[10:11], off offset:2048
+	global_load_ushort v90, v[10:11], off offset:2560
+	global_load_ushort v91, v[10:11], off offset:3072
+	global_load_ushort v92, v[10:11], off offset:3584
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+                                        ; kill: killed $vgpr10 killed $vgpr11
+	.loc	1 99 48                         ; generate_rocjitsu_triton_fixtures.py:99:48
+	v_lshl_add_u64 v[34:35], v[34:35], 0, s[2:3]
+	s_cmpk_lt_u32 s4, 0x3c0
+	.loc	1 102 20                        ; generate_rocjitsu_triton_fixtures.py:102:20
+	s_waitcnt vmcnt(15)
+	ds_write_b16 v51, v9
+	v_add_u32_e32 v9, 0, v56
+	s_waitcnt vmcnt(14)
+	ds_write_b16 v52, v12 offset:512
+	s_waitcnt vmcnt(13)
+	ds_write_b16 v53, v13 offset:1024
+	s_waitcnt vmcnt(11)
+	ds_write_b16 v51, v15 offset:2048
+	s_waitcnt vmcnt(10)
+	ds_write_b16 v52, v46 offset:2560
+	s_waitcnt vmcnt(9)
+	ds_write_b16 v53, v82 offset:3072
+	ds_write_b16 v54, v14 offset:1536
+	s_waitcnt vmcnt(8)
+	ds_write_b16 v54, v83 offset:3584
+	s_waitcnt vmcnt(7)
+	ds_write_b16 v51, v85 offset:4096
+	s_waitcnt vmcnt(6)
+	ds_write_b16 v52, v86 offset:4608
+	s_waitcnt vmcnt(5)
+	ds_write_b16 v53, v87 offset:5120
+	s_waitcnt vmcnt(4)
+	ds_write_b16 v54, v88 offset:5632
+	s_waitcnt vmcnt(3)
+	ds_write_b16 v51, v89 offset:6144
+	s_waitcnt vmcnt(2)
+	ds_write_b16 v52, v90 offset:6656
+	s_waitcnt vmcnt(1)
+	ds_write_b16 v53, v91 offset:7168
+	s_waitcnt vmcnt(0)
+	ds_write_b16 v54, v92 offset:7680
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	ds_read2st64_b64 v[10:13], v9 offset1:8
+	ds_read2st64_b64 v[86:89], v62 offset1:8
+	.loc	1 104 23                        ; generate_rocjitsu_triton_fixtures.py:104:23
+	s_waitcnt lgkmcnt(1)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[10:11], v[18:19], 0
+	.loc	1 102 20                        ; generate_rocjitsu_triton_fixtures.py:102:20
+	ds_read2st64_b64 v[90:93], v63 offset1:8
+	ds_read2st64_b64 v[94:97], v64 offset1:8
+	ds_read2st64_b64 v[98:101], v65 offset1:8
+	ds_read2st64_b64 v[102:105], v66 offset1:8
+	ds_read2st64_b64 v[106:109], v67 offset1:8
+	ds_read2st64_b64 v[110:113], v68 offset1:8
+	.loc	1 104 23                        ; generate_rocjitsu_triton_fixtures.py:104:23
+	s_waitcnt lgkmcnt(6)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[86:87], v[20:21], a[0:15]
+	s_waitcnt lgkmcnt(5)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[90:91], v[22:23], a[0:15]
+	s_waitcnt lgkmcnt(4)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[94:95], v[24:25], a[0:15]
+	s_waitcnt lgkmcnt(3)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[98:99], v[26:27], a[0:15]
+	s_waitcnt lgkmcnt(2)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[102:103], v[28:29], a[0:15]
+	s_waitcnt lgkmcnt(1)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[106:107], v[30:31], a[0:15]
+	s_waitcnt lgkmcnt(0)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[110:111], v[32:33], a[0:15]
+	s_nop 10
+	v_accvgpr_read_b32 v9, a0
+	v_accvgpr_read_b32 v10, a1
+	v_accvgpr_read_b32 v11, a2
+	v_accvgpr_read_b32 v14, a3
+	v_accvgpr_read_b32 v15, a4
+	v_accvgpr_read_b32 v46, a5
+	v_accvgpr_read_b32 v82, a6
+	v_accvgpr_read_b32 v83, a7
+	v_accvgpr_read_b32 v85, a8
+	v_accvgpr_read_b32 v86, a9
+	v_accvgpr_read_b32 v87, a10
+	v_accvgpr_read_b32 v90, a11
+	v_accvgpr_read_b32 v91, a12
+	v_accvgpr_read_b32 v94, a13
+	v_accvgpr_read_b32 v95, a14
+	v_accvgpr_read_b32 v98, a15
+	v_mfma_f32_32x32x8_f16 a[0:15], v[12:13], v[18:19], 0
+	.loc	1 104 50 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:104:50
+	v_mul_f32_e32 v9, v55, v9
+	v_mul_f32_e32 v10, v55, v10
+	v_mul_f32_e32 v11, v55, v11
+	v_mul_f32_e32 v14, v55, v14
+	v_mul_f32_e32 v46, v55, v46
+	.loc	1 105 77 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:105:77
+	v_cndmask_b32_e32 v9, v61, v9, vcc
+	v_cndmask_b32_e32 v10, v61, v10, vcc
+	.loc	1 104 23                        ; generate_rocjitsu_triton_fixtures.py:104:23
+	v_mfma_f32_32x32x8_f16 a[0:15], v[88:89], v[20:21], a[0:15]
+	.loc	1 104 50 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:104:50
+	v_mul_f32_e32 v15, v55, v15
+	.loc	1 105 77 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:105:77
+	v_cndmask_b32_e32 v11, v61, v11, vcc
+	v_cndmask_b32_e32 v14, v61, v14, vcc
+	v_cndmask_b32_e32 v107, v61, v46, vcc
+.Ltmp2:
+	.file	2 "/home/kunwar/Work/runtime-evolution/rocm-systems-rocjitsu-register-feedback/emulation/rocjitsu/.env/lib/python3.12/site-packages/triton/language" "standard.py"
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ generate_rocjitsu_triton_fixtures.py:106:39 ] ]
+	v_max_f32_e32 v46, v9, v10
+.Ltmp3:
+	.loc	1 104 50                        ; generate_rocjitsu_triton_fixtures.py:104:50
+	v_mul_f32_e32 v82, v55, v82
+	v_mul_f32_e32 v83, v55, v83
+	.loc	1 104 23 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:104:23
+	v_mfma_f32_32x32x8_f16 a[0:15], v[92:93], v[22:23], a[0:15]
+	.loc	1 105 77 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:105:77
+	v_cndmask_b32_e32 v15, v61, v15, vcc
+.Ltmp4:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ generate_rocjitsu_triton_fixtures.py:106:39 ] ]
+	v_max3_f32 v46, v46, v11, v14
+.Ltmp5:
+	.loc	1 104 50                        ; generate_rocjitsu_triton_fixtures.py:104:50
+	v_mul_f32_e32 v85, v55, v85
+	v_mul_f32_e32 v86, v55, v86
+	.loc	1 105 77                        ; generate_rocjitsu_triton_fixtures.py:105:77
+	v_cndmask_b32_e32 v83, v61, v83, vcc
+.Ltmp6:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ generate_rocjitsu_triton_fixtures.py:106:39 ] ]
+	v_max3_f32 v46, v46, v15, v107
+.Ltmp7:
+	.loc	1 104 50                        ; generate_rocjitsu_triton_fixtures.py:104:50
+	v_mul_f32_e32 v87, v55, v87
+	.loc	1 104 23 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:104:23
+	v_mfma_f32_32x32x8_f16 a[0:15], v[96:97], v[24:25], a[0:15]
+	.loc	1 104 50                        ; generate_rocjitsu_triton_fixtures.py:104:50
+	v_mul_f32_e32 v90, v55, v90
+	.loc	1 105 77 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:105:77
+	v_cndmask_b32_e32 v85, v61, v85, vcc
+	v_cndmask_b32_e32 v86, v61, v86, vcc
+	.loc	1 104 50                        ; generate_rocjitsu_triton_fixtures.py:104:50
+	v_mul_f32_e32 v91, v55, v91
+	v_mul_f32_e32 v94, v55, v94
+	.loc	1 105 77                        ; generate_rocjitsu_triton_fixtures.py:105:77
+	v_cndmask_b32_e32 v87, v61, v87, vcc
+	v_cndmask_b32_e32 v90, v61, v90, vcc
+	.loc	1 104 23                        ; generate_rocjitsu_triton_fixtures.py:104:23
+	v_mfma_f32_32x32x8_f16 a[0:15], v[100:101], v[26:27], a[0:15]
+	.loc	1 104 50 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:104:50
+	v_mul_f32_e32 v95, v55, v95
+	v_mul_f32_e32 v98, v55, v98
+	.loc	1 105 77 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:105:77
+	v_cndmask_b32_e32 v91, v61, v91, vcc
+	v_cndmask_b32_e32 v94, v61, v94, vcc
+	v_cndmask_b32_e32 v95, v61, v95, vcc
+	v_cndmask_b32_e32 v98, v61, v98, vcc
+	.loc	1 104 23                        ; generate_rocjitsu_triton_fixtures.py:104:23
+	v_mfma_f32_32x32x8_f16 a[0:15], v[104:105], v[28:29], a[0:15]
+	v_mfma_f32_32x32x8_f16 a[0:15], v[108:109], v[30:31], a[0:15]
+	.loc	1 105 77                        ; generate_rocjitsu_triton_fixtures.py:105:77
+	v_cndmask_b32_e32 v108, v61, v82, vcc
+.Ltmp8:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ generate_rocjitsu_triton_fixtures.py:106:39 ] ]
+	v_max3_f32 v46, v46, v108, v83
+	v_max3_f32 v46, v46, v85, v86
+	v_max3_f32 v46, v46, v87, v90
+	v_max3_f32 v46, v46, v91, v94
+	v_max3_f32 v46, v46, v95, v98
+.Ltmp9:
+	.loc	1 104 23                        ; generate_rocjitsu_triton_fixtures.py:104:23
+	v_mfma_f32_32x32x8_f16 a[0:15], v[112:113], v[32:33], a[0:15]
+	s_nop 10
+	v_accvgpr_read_b32 v12, a0
+	v_accvgpr_read_b32 v13, a1
+	v_accvgpr_read_b32 v88, a2
+	v_accvgpr_read_b32 v89, a3
+	.loc	1 104 50 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:104:50
+	v_mul_f32_e32 v12, v55, v12
+	v_mul_f32_e32 v13, v55, v13
+	.loc	1 104 23                        ; generate_rocjitsu_triton_fixtures.py:104:23
+	v_accvgpr_read_b32 v92, a4
+	v_accvgpr_read_b32 v93, a5
+	.loc	1 104 50                        ; generate_rocjitsu_triton_fixtures.py:104:50
+	v_mul_f32_e32 v88, v55, v88
+	v_mul_f32_e32 v89, v55, v89
+	.loc	1 105 77 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:105:77
+	v_cndmask_b32_e32 v12, v61, v12, vcc
+	v_cndmask_b32_e32 v13, v61, v13, vcc
+	.loc	1 104 23                        ; generate_rocjitsu_triton_fixtures.py:104:23
+	v_accvgpr_read_b32 v96, a6
+	v_accvgpr_read_b32 v97, a7
+	.loc	1 104 50 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:104:50
+	v_mul_f32_e32 v92, v55, v92
+	v_mul_f32_e32 v93, v55, v93
+	.loc	1 105 77 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:105:77
+	v_cndmask_b32_e32 v88, v61, v88, vcc
+	v_cndmask_b32_e32 v89, v61, v89, vcc
+.Ltmp10:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ generate_rocjitsu_triton_fixtures.py:106:39 ] ]
+	v_max3_f32 v46, v46, v12, v13
+.Ltmp11:
+	.loc	1 104 23                        ; generate_rocjitsu_triton_fixtures.py:104:23
+	v_accvgpr_read_b32 v99, a8
+	v_accvgpr_read_b32 v100, a9
+	.loc	1 104 50 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:104:50
+	v_mul_f32_e32 v96, v55, v96
+	v_mul_f32_e32 v97, v55, v97
+	.loc	1 105 77 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:105:77
+	v_cndmask_b32_e32 v92, v61, v92, vcc
+	v_cndmask_b32_e32 v93, v61, v93, vcc
+.Ltmp12:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ generate_rocjitsu_triton_fixtures.py:106:39 ] ]
+	v_max3_f32 v46, v46, v88, v89
+.Ltmp13:
+	.loc	1 104 23                        ; generate_rocjitsu_triton_fixtures.py:104:23
+	v_accvgpr_read_b32 v101, a10
+	v_accvgpr_read_b32 v102, a11
+	.loc	1 104 50 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:104:50
+	v_mul_f32_e32 v99, v55, v99
+	v_mul_f32_e32 v100, v55, v100
+	.loc	1 105 77 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:105:77
+	v_cndmask_b32_e32 v96, v61, v96, vcc
+	v_cndmask_b32_e32 v97, v61, v97, vcc
+.Ltmp14:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ generate_rocjitsu_triton_fixtures.py:106:39 ] ]
+	v_max3_f32 v46, v46, v92, v93
+.Ltmp15:
+	.loc	1 104 23                        ; generate_rocjitsu_triton_fixtures.py:104:23
+	v_accvgpr_read_b32 v103, a12
+	v_accvgpr_read_b32 v104, a13
+	.loc	1 104 50 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:104:50
+	v_mul_f32_e32 v101, v55, v101
+	v_mul_f32_e32 v102, v55, v102
+	.loc	1 105 77 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:105:77
+	v_cndmask_b32_e32 v99, v61, v99, vcc
+	v_cndmask_b32_e32 v100, v61, v100, vcc
+.Ltmp16:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ generate_rocjitsu_triton_fixtures.py:106:39 ] ]
+	v_max3_f32 v46, v46, v96, v97
+.Ltmp17:
+	.loc	1 104 23                        ; generate_rocjitsu_triton_fixtures.py:104:23
+	v_accvgpr_read_b32 v105, a14
+	v_accvgpr_read_b32 v106, a15
+	.loc	1 104 50 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:104:50
+	v_mul_f32_e32 v103, v55, v103
+	v_mul_f32_e32 v104, v55, v104
+	.loc	1 105 77 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:105:77
+	v_cndmask_b32_e32 v101, v61, v101, vcc
+	v_cndmask_b32_e32 v102, v61, v102, vcc
+.Ltmp18:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ generate_rocjitsu_triton_fixtures.py:106:39 ] ]
+	v_max3_f32 v46, v46, v99, v100
+.Ltmp19:
+	.loc	1 104 50                        ; generate_rocjitsu_triton_fixtures.py:104:50
+	v_mul_f32_e32 v105, v55, v105
+	v_mul_f32_e32 v106, v55, v106
+	.loc	1 105 77                        ; generate_rocjitsu_triton_fixtures.py:105:77
+	v_cndmask_b32_e32 v103, v61, v103, vcc
+	v_cndmask_b32_e32 v104, v61, v104, vcc
+.Ltmp20:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ generate_rocjitsu_triton_fixtures.py:106:39 ] ]
+	v_max3_f32 v46, v46, v101, v102
+.Ltmp21:
+	.loc	1 105 77                        ; generate_rocjitsu_triton_fixtures.py:105:77
+	v_cndmask_b32_e32 v105, v61, v105, vcc
+	v_cndmask_b32_e32 v106, v61, v106, vcc
+.Ltmp22:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ generate_rocjitsu_triton_fixtures.py:106:39 ] ]
+	v_max3_f32 v46, v46, v103, v104
+	v_max3_f32 v46, v46, v105, v106
+.Ltmp23:
+	.loc	2 191 40                        ; standard.py:191:40 @[ generate_rocjitsu_triton_fixtures.py:106:39 ]
+	ds_bpermute_b32 v82, v57, v46
+.Ltmp24:
+	.loc	1 106 32                        ; generate_rocjitsu_triton_fixtures.py:106:32
+	s_waitcnt lgkmcnt(0)
+	v_max3_f32 v82, v8, v46, v82
+	.loc	1 107 35                        ; generate_rocjitsu_triton_fixtures.py:107:35
+	v_sub_f32_e32 v8, v8, v82
+	.loc	1 107 29 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:107:29
+	v_exp_f32_e32 v46, v8
+	.loc	1 108 30 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:108:30
+	v_sub_f32_e32 v8, v9, v82
+	v_sub_f32_e32 v9, v10, v82
+	v_sub_f32_e32 v10, v11, v82
+	.loc	1 108 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:108:25
+	v_exp_f32_e32 v8, v8
+	v_exp_f32_e32 v9, v9
+	.loc	1 108 30                        ; generate_rocjitsu_triton_fixtures.py:108:30
+	v_sub_f32_e32 v11, v14, v82
+	.loc	1 108 25                        ; generate_rocjitsu_triton_fixtures.py:108:25
+	v_exp_f32_e32 v10, v10
+	.loc	1 108 30                        ; generate_rocjitsu_triton_fixtures.py:108:30
+	v_sub_f32_e32 v14, v15, v82
+	.loc	1 108 25                        ; generate_rocjitsu_triton_fixtures.py:108:25
+	v_exp_f32_e32 v11, v11
+	.loc	1 108 30                        ; generate_rocjitsu_triton_fixtures.py:108:30
+	v_sub_f32_e32 v15, v107, v82
+	v_sub_f32_e32 v107, v108, v82
+	v_sub_f32_e32 v83, v83, v82
+	v_sub_f32_e32 v108, v12, v82
+	.loc	1 108 25                        ; generate_rocjitsu_triton_fixtures.py:108:25
+	v_exp_f32_e32 v12, v14
+	.loc	1 108 30                        ; generate_rocjitsu_triton_fixtures.py:108:30
+	v_sub_f32_e32 v109, v13, v82
+	.loc	1 108 25                        ; generate_rocjitsu_triton_fixtures.py:108:25
+	v_exp_f32_e32 v13, v15
+	v_exp_f32_e32 v15, v83
+.Ltmp25:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:109:37 ] ]
+	v_add_f32_e32 v83, v8, v9
+.Ltmp26:
+	.loc	1 108 25                        ; generate_rocjitsu_triton_fixtures.py:108:25
+	v_exp_f32_e32 v14, v107
+.Ltmp27:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:109:37 ] ]
+	v_add_f32_e32 v83, v10, v83
+.Ltmp28:
+	.loc	1 108 30                        ; generate_rocjitsu_triton_fixtures.py:108:30
+	v_sub_f32_e32 v85, v85, v82
+.Ltmp29:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:109:37 ] ]
+	v_add_f32_e32 v83, v11, v83
+.Ltmp30:
+	.loc	1 108 30                        ; generate_rocjitsu_triton_fixtures.py:108:30
+	v_sub_f32_e32 v86, v86, v82
+	.loc	1 108 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:108:25
+	v_exp_f32_e32 v85, v85
+.Ltmp31:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:109:37 ] ]
+	v_add_f32_e32 v83, v12, v83
+.Ltmp32:
+	.loc	1 108 30                        ; generate_rocjitsu_triton_fixtures.py:108:30
+	v_sub_f32_e32 v87, v87, v82
+	.loc	1 108 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:108:25
+	v_exp_f32_e32 v86, v86
+.Ltmp33:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:109:37 ] ]
+	v_add_f32_e32 v83, v13, v83
+.Ltmp34:
+	.loc	1 108 30                        ; generate_rocjitsu_triton_fixtures.py:108:30
+	v_sub_f32_e32 v90, v90, v82
+	.loc	1 108 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:108:25
+	v_exp_f32_e32 v87, v87
+.Ltmp35:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:109:37 ] ]
+	v_add_f32_e32 v83, v14, v83
+.Ltmp36:
+	.loc	1 108 30                        ; generate_rocjitsu_triton_fixtures.py:108:30
+	v_sub_f32_e32 v91, v91, v82
+	v_sub_f32_e32 v110, v88, v82
+	.loc	1 108 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:108:25
+	v_exp_f32_e32 v88, v90
+.Ltmp37:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:109:37 ] ]
+	v_add_f32_e32 v83, v15, v83
+.Ltmp38:
+	.loc	1 108 30                        ; generate_rocjitsu_triton_fixtures.py:108:30
+	v_sub_f32_e32 v94, v94, v82
+	v_sub_f32_e32 v111, v89, v82
+	.loc	1 108 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:108:25
+	v_exp_f32_e32 v89, v91
+.Ltmp39:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:109:37 ] ]
+	v_add_f32_e32 v83, v85, v83
+.Ltmp40:
+	.loc	1 108 30                        ; generate_rocjitsu_triton_fixtures.py:108:30
+	v_sub_f32_e32 v95, v95, v82
+	.loc	1 108 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:108:25
+	v_exp_f32_e32 v90, v94
+.Ltmp41:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:109:37 ] ]
+	v_add_f32_e32 v83, v86, v83
+.Ltmp42:
+	.loc	1 108 30                        ; generate_rocjitsu_triton_fixtures.py:108:30
+	v_sub_f32_e32 v98, v98, v82
+	.loc	1 108 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:108:25
+	v_exp_f32_e32 v91, v95
+.Ltmp43:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:109:37 ] ]
+	v_add_f32_e32 v83, v87, v83
+.Ltmp44:
+	.loc	1 108 30                        ; generate_rocjitsu_triton_fixtures.py:108:30
+	v_sub_f32_e32 v112, v92, v82
+	.loc	1 108 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:108:25
+	v_exp_f32_e32 v92, v98
+.Ltmp45:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:109:37 ] ]
+	v_add_f32_e32 v83, v88, v83
+.Ltmp46:
+	.loc	1 108 30                        ; generate_rocjitsu_triton_fixtures.py:108:30
+	v_sub_f32_e32 v113, v93, v82
+	.loc	1 108 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:108:25
+	v_exp_f32_e32 v93, v108
+.Ltmp47:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:109:37 ] ]
+	v_add_f32_e32 v83, v89, v83
+.Ltmp48:
+	.loc	1 108 25                        ; generate_rocjitsu_triton_fixtures.py:108:25
+	v_exp_f32_e32 v94, v109
+.Ltmp49:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:109:37 ] ]
+	v_add_f32_e32 v83, v90, v83
+.Ltmp50:
+	.loc	1 108 25                        ; generate_rocjitsu_triton_fixtures.py:108:25
+	v_exp_f32_e32 v95, v110
+.Ltmp51:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:109:37 ] ]
+	v_add_f32_e32 v83, v91, v83
+.Ltmp52:
+	.loc	1 108 30                        ; generate_rocjitsu_triton_fixtures.py:108:30
+	v_sub_f32_e32 v114, v96, v82
+	.loc	1 108 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:108:25
+	v_exp_f32_e32 v96, v111
+.Ltmp53:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:109:37 ] ]
+	v_add_f32_e32 v83, v92, v83
+.Ltmp54:
+	.loc	1 108 30                        ; generate_rocjitsu_triton_fixtures.py:108:30
+	v_sub_f32_e32 v115, v97, v82
+	.loc	1 108 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:108:25
+	v_exp_f32_e32 v97, v112
+.Ltmp55:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:109:37 ] ]
+	v_add_f32_e32 v83, v93, v83
+.Ltmp56:
+	.loc	1 108 25                        ; generate_rocjitsu_triton_fixtures.py:108:25
+	v_exp_f32_e32 v98, v113
+.Ltmp57:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:109:37 ] ]
+	v_add_f32_e32 v83, v94, v83
+.Ltmp58:
+	.loc	1 108 30                        ; generate_rocjitsu_triton_fixtures.py:108:30
+	v_sub_f32_e32 v116, v99, v82
+	.loc	1 108 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:108:25
+	v_exp_f32_e32 v99, v114
+.Ltmp59:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:109:37 ] ]
+	v_add_f32_e32 v83, v95, v83
+.Ltmp60:
+	.loc	1 108 30                        ; generate_rocjitsu_triton_fixtures.py:108:30
+	v_sub_f32_e32 v117, v100, v82
+	.loc	1 108 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:108:25
+	v_exp_f32_e32 v100, v115
+.Ltmp61:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:109:37 ] ]
+	v_add_f32_e32 v83, v96, v83
+.Ltmp62:
+	.loc	1 108 30                        ; generate_rocjitsu_triton_fixtures.py:108:30
+	v_sub_f32_e32 v118, v101, v82
+	.loc	1 108 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:108:25
+	v_exp_f32_e32 v101, v116
+.Ltmp63:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:109:37 ] ]
+	v_add_f32_e32 v83, v97, v83
+.Ltmp64:
+	.loc	1 108 30                        ; generate_rocjitsu_triton_fixtures.py:108:30
+	v_sub_f32_e32 v119, v102, v82
+	.loc	1 108 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:108:25
+	v_exp_f32_e32 v102, v117
+.Ltmp65:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:109:37 ] ]
+	v_add_f32_e32 v83, v98, v83
+.Ltmp66:
+	.loc	1 108 30                        ; generate_rocjitsu_triton_fixtures.py:108:30
+	v_sub_f32_e32 v120, v103, v82
+	.loc	1 108 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:108:25
+	v_exp_f32_e32 v103, v118
+.Ltmp67:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:109:37 ] ]
+	v_add_f32_e32 v83, v99, v83
+.Ltmp68:
+	.loc	1 108 30                        ; generate_rocjitsu_triton_fixtures.py:108:30
+	v_sub_f32_e32 v121, v104, v82
+	.loc	1 108 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:108:25
+	v_exp_f32_e32 v104, v119
+.Ltmp69:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:109:37 ] ]
+	v_add_f32_e32 v83, v100, v83
+.Ltmp70:
+	.loc	1 108 30                        ; generate_rocjitsu_triton_fixtures.py:108:30
+	v_sub_f32_e32 v122, v105, v82
+	.loc	1 108 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:108:25
+	v_exp_f32_e32 v105, v120
+.Ltmp71:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:109:37 ] ]
+	v_add_f32_e32 v83, v101, v83
+.Ltmp72:
+	.loc	1 108 30                        ; generate_rocjitsu_triton_fixtures.py:108:30
+	v_sub_f32_e32 v123, v106, v82
+	.loc	1 108 25 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:108:25
+	v_exp_f32_e32 v106, v121
+.Ltmp73:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:109:37 ] ]
+	v_add_f32_e32 v83, v102, v83
+.Ltmp74:
+	.loc	1 108 25                        ; generate_rocjitsu_triton_fixtures.py:108:25
+	v_exp_f32_e32 v107, v122
+.Ltmp75:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:109:37 ] ]
+	v_add_f32_e32 v83, v103, v83
+.Ltmp76:
+	.loc	1 108 25                        ; generate_rocjitsu_triton_fixtures.py:108:25
+	v_exp_f32_e32 v108, v123
+.Ltmp77:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:109:37 ] ]
+	v_add_f32_e32 v83, v104, v83
+	v_add_f32_e32 v83, v105, v83
+	v_add_f32_e32 v83, v106, v83
+	v_add_f32_e32 v83, v107, v83
+	v_add_f32_e32 v83, v108, v83
+.Ltmp78:
+	.loc	2 293 36                        ; standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:109:37 ]
+	ds_bpermute_b32 v109, v57, v83
+.Ltmp79:
+	.loc	1 110 53                        ; generate_rocjitsu_triton_fixtures.py:110:53
+	v_lshl_add_u64 v[114:115], v[36:37], 0, v[16:17]
+	.loc	1 110 20 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:110:20
+	global_load_ushort v121, v[114:115], off
+	global_load_ushort v124, v[114:115], off offset:128
+	global_load_ushort v125, v[114:115], off offset:256
+	global_load_ushort v126, v[114:115], off offset:384
+	global_load_ushort v110, v[114:115], off offset:2176
+	global_load_ushort v111, v[114:115], off offset:2304
+	global_load_ushort v113, v[114:115], off offset:2432
+	v_add_co_u32_e64 v122, s[0:1], s5, v114
+.Ltmp80:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ generate_rocjitsu_triton_fixtures.py:109:37 ] ]
+	s_waitcnt lgkmcnt(0)
+	v_add_f32_e32 v83, v83, v109
+.Ltmp81:
+	.loc	1 110 20                        ; generate_rocjitsu_triton_fixtures.py:110:20
+	global_load_ushort v109, v[114:115], off offset:2048
+	v_addc_co_u32_e64 v123, s[0:1], 0, v115, s[0:1]
+	global_load_ushort v112, v[122:123], off
+	global_load_ushort v114, v[122:123], off offset:128
+	global_load_ushort v117, v[122:123], off offset:256
+	global_load_ushort v118, v[122:123], off offset:384
+	global_load_ushort v115, v[122:123], off offset:2048
+	global_load_ushort v116, v[122:123], off offset:2176
+	global_load_ushort v119, v[122:123], off offset:2304
+	global_load_ushort v120, v[122:123], off offset:2432
+	.loc	1 113 26                        ; generate_rocjitsu_triton_fixtures.py:113:26
+	v_cvt_f16_f32_e32 v8, v8
+	v_cvt_f16_f32_e32 v9, v9
+	v_cvt_f16_f32_e32 v86, v86
+	v_cvt_f16_f32_e32 v10, v10
+	v_cvt_f16_f32_e32 v11, v11
+	v_cvt_f16_f32_e32 v12, v12
+	v_cvt_f16_f32_e32 v13, v13
+	v_cvt_f16_f32_e32 v14, v14
+	v_cvt_f16_f32_e32 v15, v15
+	v_cvt_f16_f32_e32 v85, v85
+	v_cvt_f16_f32_e32 v87, v87
+	v_cvt_f16_f32_e32 v88, v88
+	v_cvt_f16_f32_e32 v89, v89
+	v_cvt_f16_f32_e32 v90, v90
+	v_cvt_f16_f32_e32 v91, v91
+	v_cvt_f16_f32_e32 v92, v92
+	v_cvt_f16_f32_e32 v93, v93
+	v_cvt_f16_f32_e32 v94, v94
+	v_cvt_f16_f32_e32 v95, v95
+	v_cvt_f16_f32_e32 v96, v96
+	v_cvt_f16_f32_e32 v97, v97
+	v_cvt_f16_f32_e32 v98, v98
+	v_cvt_f16_f32_e32 v99, v99
+	v_cvt_f16_f32_e32 v100, v100
+	v_cvt_f16_f32_e32 v101, v101
+	v_cvt_f16_f32_e32 v102, v102
+	v_cvt_f16_f32_e32 v103, v103
+	v_cvt_f16_f32_e32 v104, v104
+	v_cvt_f16_f32_e32 v105, v105
+	v_cvt_f16_f32_e32 v106, v106
+	v_cvt_f16_f32_e32 v107, v107
+	v_cvt_f16_f32_e32 v108, v108
+	.loc	1 109 30                        ; generate_rocjitsu_triton_fixtures.py:109:30
+	v_fmac_f32_e32 v83, v84, v46
+	.loc	1 112 20                        ; generate_rocjitsu_triton_fixtures.py:112:20
+	v_add_u32_e32 v84, v58, v50
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	ds_write_b32 v73, v46
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	ds_read_b32 v46, v84
+	.loc	1 113 26                        ; generate_rocjitsu_triton_fixtures.py:113:26
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	ds_write_b16 v69, v8
+	ds_write_b16 v69, v9 offset:128
+	ds_write_b16 v69, v86 offset:2176
+	.loc	1 110 20                        ; generate_rocjitsu_triton_fixtures.py:110:20
+	v_add_u32_e32 v86, 0, v59
+                                        ; kill: killed $vgpr122 killed $vgpr123
+	.loc	1 113 26                        ; generate_rocjitsu_triton_fixtures.py:113:26
+	ds_write_b16 v69, v10 offset:256
+	ds_write_b16 v69, v11 offset:384
+	ds_write_b16 v69, v12 offset:1024
+	ds_write_b16 v69, v13 offset:1152
+	ds_write_b16 v69, v14 offset:1280
+	ds_write_b16 v69, v15 offset:1408
+	ds_write_b16 v69, v85 offset:2048
+	ds_write_b16 v69, v87 offset:2304
+	ds_write_b16 v69, v88 offset:2432
+	ds_write_b16 v69, v89 offset:3072
+	ds_write_b16 v69, v90 offset:3200
+	ds_write_b16 v69, v91 offset:3328
+	ds_write_b16 v69, v92 offset:3456
+	.loc	1 110 20                        ; generate_rocjitsu_triton_fixtures.py:110:20
+	s_waitcnt vmcnt(14)
+	v_perm_b32 v8, v124, v121, s6
+	.loc	1 113 26                        ; generate_rocjitsu_triton_fixtures.py:113:26
+	ds_write_b16 v69, v93 offset:4096
+	.loc	1 110 20                        ; generate_rocjitsu_triton_fixtures.py:110:20
+	s_waitcnt vmcnt(12)
+	v_perm_b32 v9, v126, v125, s6
+	.loc	1 113 26                        ; generate_rocjitsu_triton_fixtures.py:113:26
+	ds_write_b16 v69, v94 offset:4224
+	ds_write_b16 v69, v95 offset:4352
+	ds_write_b16 v69, v96 offset:4480
+	ds_write_b16 v69, v97 offset:5120
+	ds_write_b16 v69, v98 offset:5248
+	ds_write_b16 v69, v99 offset:5376
+	ds_write_b16 v69, v100 offset:5504
+	ds_write_b16 v69, v101 offset:6144
+	ds_write_b16 v69, v102 offset:6272
+	ds_write_b16 v69, v103 offset:6400
+	ds_write_b16 v69, v104 offset:6528
+	ds_write_b16 v69, v105 offset:7168
+	ds_write_b16 v69, v106 offset:7296
+	ds_write_b16 v69, v107 offset:7424
+	ds_write_b16 v69, v108 offset:7552
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	ds_read_u16 v10, v70
+	ds_read_u16 v11, v70 offset:128
+	ds_read_u16 v12, v70 offset:256
+	ds_read_u16 v13, v70 offset:384
+	ds_read_u16 v14, v70 offset:1024
+	ds_read_u16 v15, v70 offset:1152
+	ds_read_u16 v85, v70 offset:1280
+	ds_read_u16 v104, v70 offset:1408
+	ds_read_u16 v106, v70 offset:2048
+	ds_read_u16 v108, v70 offset:2176
+	ds_read_u16 v107, v70 offset:2304
+	ds_read_u16 v122, v70 offset:2432
+	ds_read_u16 v123, v70 offset:3072
+	ds_read_u16 v127, v70 offset:3200
+	ds_read_u16 v128, v70 offset:3328
+	ds_read_u16 v129, v70 offset:3456
+	ds_read_u16 v130, v70 offset:4096
+	ds_read_u16 v131, v70 offset:4224
+	ds_read_u16 v132, v70 offset:4352
+	ds_read_u16 v133, v70 offset:4480
+	ds_read_u16 v134, v70 offset:5120
+	ds_read_u16 v135, v70 offset:5248
+	ds_read_u16 v136, v70 offset:5376
+	ds_read_u16 v137, v70 offset:5504
+	ds_read_u16 v138, v70 offset:6144
+	ds_read_u16 v139, v70 offset:6272
+	ds_read_u16 v140, v70 offset:6400
+	ds_read_u16 v141, v70 offset:6528
+	ds_read_u16 v142, v70 offset:7168
+	ds_read_u16 v143, v70 offset:7296
+	ds_read_u16 v144, v70 offset:7424
+	ds_read_u16 v145, v70 offset:7552
+	.loc	1 110 20                        ; generate_rocjitsu_triton_fixtures.py:110:20
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	ds_write_b64 v86, v[8:9]
+	s_waitcnt vmcnt(9)
+	v_perm_b32 v9, v113, v111, s6
+	s_waitcnt vmcnt(8)
+	v_perm_b32 v8, v110, v109, s6
+	ds_write_b64 v71, v[8:9]
+	s_waitcnt vmcnt(4)
+	v_perm_b32 v9, v118, v117, s6
+	v_perm_b32 v8, v114, v112, s6
+	ds_write_b64 v72, v[8:9]
+	s_waitcnt vmcnt(0)
+	v_perm_b32 v9, v120, v119, s6
+	v_perm_b32 v8, v116, v115, s6
+	ds_write_b64 v74, v[8:9]
+	v_add_u32_e32 v8, 0, v60
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	ds_read_b64 v[86:87], v8
+	ds_read_b64 v[88:89], v75
+	ds_read_b64 v[90:91], v76
+	ds_read_b64 v[92:93], v77
+	.loc	1 113 42                        ; generate_rocjitsu_triton_fixtures.py:113:42
+	v_perm_b32 v105, v104, v85, s6
+	v_perm_b32 v104, v15, v14, s6
+	v_pk_mul_f32 v[14:15], v[0:1], v[46:47] op_sel_hi:[1,0]
+	v_pk_mul_f32 v[0:1], v[44:45], v[46:47] op_sel_hi:[1,0]
+	v_perm_b32 v103, v13, v12, s6
+	v_perm_b32 v102, v11, v10, s6
+	v_pk_mul_f32 v[12:13], v[2:3], v[46:47] op_sel_hi:[1,0]
+	v_pk_mul_f32 v[10:11], v[4:5], v[46:47] op_sel_hi:[1,0]
+	v_pk_mul_f32 v[8:9], v[6:7], v[46:47] op_sel_hi:[1,0]
+	v_pk_mul_f32 v[6:7], v[38:39], v[46:47] op_sel_hi:[1,0]
+	v_pk_mul_f32 v[4:5], v[40:41], v[46:47] op_sel_hi:[1,0]
+	v_pk_mul_f32 v[2:3], v[42:43], v[46:47] op_sel_hi:[1,0]
+	v_perm_b32 v107, v122, v107, s6
+	v_accvgpr_write_b32 a0, v0
+	v_accvgpr_write_b32 a1, v1
+	v_accvgpr_write_b32 a2, v2
+	v_accvgpr_write_b32 a3, v3
+	v_accvgpr_write_b32 a4, v4
+	v_accvgpr_write_b32 a5, v5
+	v_accvgpr_write_b32 a6, v6
+	v_accvgpr_write_b32 a7, v7
+	v_accvgpr_write_b32 a8, v8
+	v_accvgpr_write_b32 a9, v9
+	v_accvgpr_write_b32 a10, v10
+	v_accvgpr_write_b32 a11, v11
+	v_accvgpr_write_b32 a12, v12
+	v_accvgpr_write_b32 a13, v13
+	v_accvgpr_write_b32 a14, v14
+	v_accvgpr_write_b32 a15, v15
+	v_perm_b32 v106, v108, v106, s6
+	.loc	1 110 20                        ; generate_rocjitsu_triton_fixtures.py:110:20
+	ds_read_b64 v[94:95], v78
+	ds_read_b64 v[96:97], v79
+	ds_read_b64 v[98:99], v80
+	ds_read_b64 v[100:101], v81
+	.loc	1 113 42                        ; generate_rocjitsu_triton_fixtures.py:113:42
+	s_waitcnt lgkmcnt(7)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[86:87], v[102:103], a[0:15]
+	v_perm_b32 v109, v129, v128, s6
+	v_perm_b32 v108, v127, v123, s6
+	v_perm_b32 v111, v133, v132, s6
+	v_perm_b32 v110, v131, v130, s6
+	v_perm_b32 v113, v137, v136, s6
+	v_perm_b32 v112, v135, v134, s6
+	v_perm_b32 v115, v141, v140, s6
+	s_waitcnt lgkmcnt(6)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[88:89], v[104:105], a[0:15]
+	v_perm_b32 v114, v139, v138, s6
+	v_perm_b32 v117, v145, v144, s6
+	v_perm_b32 v116, v143, v142, s6
+	.loc	1 99 48                         ; generate_rocjitsu_triton_fixtures.py:99:48
+	v_lshl_add_u64 v[36:37], v[36:37], 0, s[2:3]
+	v_mov_b32_e32 v8, v82
+	.loc	1 113 42                        ; generate_rocjitsu_triton_fixtures.py:113:42
+	s_waitcnt lgkmcnt(5)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[90:91], v[106:107], a[0:15]
+	s_waitcnt lgkmcnt(4)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[92:93], v[108:109], a[0:15]
+	s_waitcnt lgkmcnt(3)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[94:95], v[110:111], a[0:15]
+	s_waitcnt lgkmcnt(2)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[96:97], v[112:113], a[0:15]
+	s_waitcnt lgkmcnt(1)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[98:99], v[114:115], a[0:15]
+	s_waitcnt lgkmcnt(0)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[100:101], v[116:117], a[0:15]
+	.loc	1 99 48                         ; generate_rocjitsu_triton_fixtures.py:99:48
+	s_cbranch_scc1 .LBB0_33
+; %bb.34:
+	.loc	1 90 44                         ; generate_rocjitsu_triton_fixtures.py:90:44
+	v_lshrrev_b32_e32 v16, 2, v50
+	.loc	1 113 42                        ; generate_rocjitsu_triton_fixtures.py:113:42
+	s_nop 8
+	v_accvgpr_read_b32 v0, a0
+	.loc	1 90 31                         ; generate_rocjitsu_triton_fixtures.py:90:31
+	v_or3_b32 v16, v49, v16, s11
+	s_movk_i32 s0, 0x400
+	.loc	1 113 42                        ; generate_rocjitsu_triton_fixtures.py:113:42
+	v_accvgpr_read_b32 v1, a1
+	v_accvgpr_read_b32 v2, a2
+	v_accvgpr_read_b32 v3, a3
+	v_accvgpr_read_b32 v4, a4
+	v_accvgpr_read_b32 v5, a5
+	v_accvgpr_read_b32 v6, a6
+	v_accvgpr_read_b32 v7, a7
+	v_accvgpr_read_b32 v8, a8
+	v_accvgpr_read_b32 v9, a9
+	v_accvgpr_read_b32 v10, a10
+	v_accvgpr_read_b32 v11, a11
+	v_accvgpr_read_b32 v12, a12
+	v_accvgpr_read_b32 v13, a13
+	v_accvgpr_read_b32 v14, a14
+	v_accvgpr_read_b32 v15, a15
+	.loc	1 94 40                         ; generate_rocjitsu_triton_fixtures.py:94:40
+	v_cmp_gt_i32_e32 vcc, s0, v16
+	.loc	1 116 16                        ; generate_rocjitsu_triton_fixtures.py:116:16
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	ds_write_b32 v73, v83
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	.loc	1 117 80                        ; generate_rocjitsu_triton_fixtures.py:117:80
+	s_and_saveexec_b64 s[0:1], vcc
+	s_cbranch_execz .LBB0_36
+; %bb.35:                               ; %.critedge
+	.loc	1 116 16                        ; generate_rocjitsu_triton_fixtures.py:116:16
+	ds_read_b32 v20, v84
+	.loc	1 90 44                         ; generate_rocjitsu_triton_fixtures.py:90:44
+	v_lshrrev_b32_e32 v17, 3, v48
+	.loc	1 93 42                         ; generate_rocjitsu_triton_fixtures.py:93:42
+	v_lshlrev_b32_e32 v16, 6, v16
+	.loc	1 94 57                         ; generate_rocjitsu_triton_fixtures.py:94:57
+	v_or_b32_e32 v18, v17, v47
+	.loc	1 117 21                        ; generate_rocjitsu_triton_fixtures.py:117:21
+	v_ashrrev_i32_e32 v17, 31, v16
+	.loc	1 116 16                        ; generate_rocjitsu_triton_fixtures.py:116:16
+	s_waitcnt lgkmcnt(0)
+	v_div_scale_f32 v21, s[0:1], v20, v20, v15
+	v_rcp_f32_e32 v22, v21
+	.loc	1 117 21                        ; generate_rocjitsu_triton_fixtures.py:117:21
+	v_lshl_add_u64 v[16:17], v[16:17], 2, s[8:9]
+	.loc	1 117 51 is_stmt 0              ; generate_rocjitsu_triton_fixtures.py:117:51
+	v_lshlrev_b32_e32 v18, 2, v18
+	v_mov_b32_e32 v19, 0
+	v_lshl_add_u64 v[16:17], v[16:17], 0, v[18:19]
+	.loc	1 116 16 is_stmt 1              ; generate_rocjitsu_triton_fixtures.py:116:16
+	v_fma_f32 v18, -v21, v22, 1.0
+	v_fmac_f32_e32 v22, v18, v22
+	v_div_scale_f32 v18, vcc, v15, v20, v15
+	v_mul_f32_e32 v19, v18, v22
+	v_fma_f32 v23, -v21, v19, v18
+	v_fmac_f32_e32 v19, v23, v22
+	v_fma_f32 v18, -v21, v19, v18
+	v_div_scale_f32 v21, s[0:1], v20, v20, v14
+	v_rcp_f32_e32 v23, v21
+	v_div_fmas_f32 v18, v18, v22, v19
+	v_div_fixup_f32 v15, v18, v20, v15
+	v_fma_f32 v18, -v21, v23, 1.0
+	v_fmac_f32_e32 v23, v18, v23
+	v_div_scale_f32 v18, vcc, v14, v20, v14
+	v_mul_f32_e32 v19, v18, v23
+	v_fma_f32 v22, -v21, v19, v18
+	v_fmac_f32_e32 v19, v22, v23
+	v_fma_f32 v18, -v21, v19, v18
+	v_div_scale_f32 v21, s[0:1], v20, v20, v13
+	v_rcp_f32_e32 v22, v21
+	v_div_fmas_f32 v18, v18, v23, v19
+	v_div_fixup_f32 v14, v18, v20, v14
+	v_fma_f32 v18, -v21, v22, 1.0
+	v_fmac_f32_e32 v22, v18, v22
+	v_div_scale_f32 v18, vcc, v13, v20, v13
+	v_mul_f32_e32 v19, v18, v22
+	v_fma_f32 v23, -v21, v19, v18
+	v_fmac_f32_e32 v19, v23, v22
+	v_fma_f32 v18, -v21, v19, v18
+	v_div_scale_f32 v21, s[0:1], v20, v20, v12
+	v_rcp_f32_e32 v23, v21
+	v_div_fmas_f32 v18, v18, v22, v19
+	v_div_fixup_f32 v13, v18, v20, v13
+	v_fma_f32 v18, -v21, v23, 1.0
+	v_fmac_f32_e32 v23, v18, v23
+	v_div_scale_f32 v18, vcc, v12, v20, v12
+	v_mul_f32_e32 v19, v18, v23
+	v_fma_f32 v22, -v21, v19, v18
+	v_fmac_f32_e32 v19, v22, v23
+	v_fma_f32 v18, -v21, v19, v18
+	v_div_scale_f32 v21, s[0:1], v20, v20, v11
+	v_rcp_f32_e32 v22, v21
+	v_div_fmas_f32 v18, v18, v23, v19
+	v_div_fixup_f32 v12, v18, v20, v12
+	v_fma_f32 v18, -v21, v22, 1.0
+	v_fmac_f32_e32 v22, v18, v22
+	v_div_scale_f32 v18, vcc, v11, v20, v11
+	v_mul_f32_e32 v19, v18, v22
+	v_fma_f32 v23, -v21, v19, v18
+	v_fmac_f32_e32 v19, v23, v22
+	v_fma_f32 v18, -v21, v19, v18
+	v_div_scale_f32 v21, s[0:1], v20, v20, v10
+	v_rcp_f32_e32 v23, v21
+	v_div_fmas_f32 v18, v18, v22, v19
+	v_div_fixup_f32 v11, v18, v20, v11
+	v_fma_f32 v18, -v21, v23, 1.0
+	v_fmac_f32_e32 v23, v18, v23
+	v_div_scale_f32 v18, vcc, v10, v20, v10
+	v_mul_f32_e32 v19, v18, v23
+	v_fma_f32 v22, -v21, v19, v18
+	v_fmac_f32_e32 v19, v22, v23
+	v_fma_f32 v18, -v21, v19, v18
+	v_div_scale_f32 v21, s[0:1], v20, v20, v9
+	v_rcp_f32_e32 v22, v21
+	v_div_fmas_f32 v18, v18, v23, v19
+	v_div_fixup_f32 v10, v18, v20, v10
+	v_fma_f32 v18, -v21, v22, 1.0
+	v_fmac_f32_e32 v22, v18, v22
+	v_div_scale_f32 v18, vcc, v9, v20, v9
+	v_mul_f32_e32 v19, v18, v22
+	v_fma_f32 v23, -v21, v19, v18
+	v_fmac_f32_e32 v19, v23, v22
+	v_fma_f32 v18, -v21, v19, v18
+	v_div_scale_f32 v21, s[0:1], v20, v20, v8
+	v_rcp_f32_e32 v23, v21
+	v_div_fmas_f32 v18, v18, v22, v19
+	v_div_fixup_f32 v9, v18, v20, v9
+	v_fma_f32 v18, -v21, v23, 1.0
+	v_fmac_f32_e32 v23, v18, v23
+	v_div_scale_f32 v18, vcc, v8, v20, v8
+	v_mul_f32_e32 v19, v18, v23
+	v_fma_f32 v22, -v21, v19, v18
+	v_fmac_f32_e32 v19, v22, v23
+	v_fma_f32 v18, -v21, v19, v18
+	v_div_scale_f32 v21, s[0:1], v20, v20, v7
+	v_rcp_f32_e32 v22, v21
+	v_div_fmas_f32 v18, v18, v23, v19
+	v_div_fixup_f32 v8, v18, v20, v8
+	v_fma_f32 v18, -v21, v22, 1.0
+	v_fmac_f32_e32 v22, v18, v22
+	v_div_scale_f32 v18, vcc, v7, v20, v7
+	v_mul_f32_e32 v19, v18, v22
+	v_fma_f32 v23, -v21, v19, v18
+	v_fmac_f32_e32 v19, v23, v22
+	v_fma_f32 v18, -v21, v19, v18
+	v_div_scale_f32 v21, s[0:1], v20, v20, v6
+	v_rcp_f32_e32 v23, v21
+	v_div_fmas_f32 v18, v18, v22, v19
+	v_div_fixup_f32 v7, v18, v20, v7
+	v_fma_f32 v18, -v21, v23, 1.0
+	v_fmac_f32_e32 v23, v18, v23
+	v_div_scale_f32 v18, vcc, v6, v20, v6
+	v_mul_f32_e32 v19, v18, v23
+	v_fma_f32 v22, -v21, v19, v18
+	v_fmac_f32_e32 v19, v22, v23
+	v_fma_f32 v18, -v21, v19, v18
+	v_div_scale_f32 v21, s[0:1], v20, v20, v5
+	v_rcp_f32_e32 v22, v21
+	v_div_fmas_f32 v18, v18, v23, v19
+	v_div_fixup_f32 v6, v18, v20, v6
+	v_fma_f32 v18, -v21, v22, 1.0
+	v_fmac_f32_e32 v22, v18, v22
+	v_div_scale_f32 v18, vcc, v5, v20, v5
+	v_mul_f32_e32 v19, v18, v22
+	v_fma_f32 v23, -v21, v19, v18
+	v_fmac_f32_e32 v19, v23, v22
+	v_fma_f32 v18, -v21, v19, v18
+	v_div_scale_f32 v21, s[0:1], v20, v20, v4
+	v_rcp_f32_e32 v23, v21
+	v_div_fmas_f32 v18, v18, v22, v19
+	v_div_fixup_f32 v5, v18, v20, v5
+	v_fma_f32 v18, -v21, v23, 1.0
+	v_fmac_f32_e32 v23, v18, v23
+	v_div_scale_f32 v18, vcc, v4, v20, v4
+	v_mul_f32_e32 v19, v18, v23
+	v_fma_f32 v22, -v21, v19, v18
+	v_fmac_f32_e32 v19, v22, v23
+	v_fma_f32 v18, -v21, v19, v18
+	v_div_scale_f32 v21, s[0:1], v20, v20, v3
+	v_rcp_f32_e32 v22, v21
+	v_div_fmas_f32 v18, v18, v23, v19
+	v_div_fixup_f32 v4, v18, v20, v4
+	v_fma_f32 v18, -v21, v22, 1.0
+	v_fmac_f32_e32 v22, v18, v22
+	v_div_scale_f32 v18, vcc, v3, v20, v3
+	v_mul_f32_e32 v19, v18, v22
+	v_fma_f32 v23, -v21, v19, v18
+	v_fmac_f32_e32 v19, v23, v22
+	v_fma_f32 v18, -v21, v19, v18
+	v_div_scale_f32 v21, s[0:1], v20, v20, v2
+	v_rcp_f32_e32 v23, v21
+	v_div_fmas_f32 v18, v18, v22, v19
+	v_div_fixup_f32 v3, v18, v20, v3
+	v_fma_f32 v18, -v21, v23, 1.0
+	v_fmac_f32_e32 v23, v18, v23
+	v_div_scale_f32 v18, vcc, v2, v20, v2
+	v_mul_f32_e32 v19, v18, v23
+	v_fma_f32 v22, -v21, v19, v18
+	v_fmac_f32_e32 v19, v22, v23
+	v_fma_f32 v18, -v21, v19, v18
+	v_div_scale_f32 v21, s[0:1], v20, v20, v0
+	v_rcp_f32_e32 v22, v21
+	v_div_fmas_f32 v18, v18, v23, v19
+	v_div_fixup_f32 v2, v18, v20, v2
+	v_fma_f32 v18, -v21, v22, 1.0
+	v_fmac_f32_e32 v22, v18, v22
+	v_div_scale_f32 v18, vcc, v0, v20, v0
+	v_mul_f32_e32 v19, v18, v22
+	v_fma_f32 v23, -v21, v19, v18
+	v_fmac_f32_e32 v19, v23, v22
+	v_fma_f32 v18, -v21, v19, v18
+	v_div_scale_f32 v21, s[0:1], v20, v20, v1
+	v_rcp_f32_e32 v23, v21
+	v_div_fmas_f32 v18, v18, v22, v19
+	v_div_fixup_f32 v0, v18, v20, v0
+	v_fma_f32 v18, -v21, v23, 1.0
+	v_fmac_f32_e32 v23, v18, v23
+	v_div_scale_f32 v18, vcc, v1, v20, v1
+	v_mul_f32_e32 v19, v18, v23
+	v_fma_f32 v22, -v21, v19, v18
+	v_fmac_f32_e32 v19, v22, v23
+	v_fma_f32 v18, -v21, v19, v18
+	v_div_fmas_f32 v18, v18, v23, v19
+	v_div_fixup_f32 v1, v18, v20, v1
+	.loc	1 117 80                        ; generate_rocjitsu_triton_fixtures.py:117:80
+	global_store_dwordx4 v[16:17], v[0:3], off
+	global_store_dwordx4 v[16:17], v[4:7], off offset:32
+	global_store_dwordx4 v[16:17], v[8:11], off offset:64
+	global_store_dwordx4 v[16:17], v[12:15], off offset:96
+.LBB0_36:                               ; %.critedge28
+	.loc	1 117 4 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:117:4
+	s_endpgm
+.Ltmp82:
+	.section	.rodata,"a",@progbits
+	.p2align	6, 0x0
+	.amdhsa_kernel flash_attention_fwd_no_async_kernel
+		.amdhsa_group_segment_fixed_size 0
+		.amdhsa_private_segment_fixed_size 0
+		.amdhsa_kernarg_size 56
+		.amdhsa_user_sgpr_count 16
+		.amdhsa_user_sgpr_dispatch_ptr 0
+		.amdhsa_user_sgpr_queue_ptr 0
+		.amdhsa_user_sgpr_kernarg_segment_ptr 1
+		.amdhsa_user_sgpr_dispatch_id 0
+		.amdhsa_user_sgpr_kernarg_preload_length 14
+		.amdhsa_user_sgpr_kernarg_preload_offset 0
+		.amdhsa_user_sgpr_private_segment_size 0
+		.amdhsa_uses_dynamic_stack 0
+		.amdhsa_enable_private_segment 0
+		.amdhsa_system_sgpr_workgroup_id_x 1
+		.amdhsa_system_sgpr_workgroup_id_y 0
+		.amdhsa_system_sgpr_workgroup_id_z 0
+		.amdhsa_system_sgpr_workgroup_info 0
+		.amdhsa_system_vgpr_workitem_id 0
+		.amdhsa_next_free_vgpr 164
+		.amdhsa_next_free_sgpr 17
+		.amdhsa_accum_offset 148
+		.amdhsa_reserve_vcc 1
+		.amdhsa_reserve_xnack_mask 1
+		.amdhsa_float_round_mode_32 0
+		.amdhsa_float_round_mode_16_64 0
+		.amdhsa_float_denorm_mode_32 3
+		.amdhsa_float_denorm_mode_16_64 3
+		.amdhsa_dx10_clamp 1
+		.amdhsa_ieee_mode 1
+		.amdhsa_fp16_overflow 0
+		.amdhsa_tg_split 0
+		.amdhsa_exception_fp_ieee_invalid_op 0
+		.amdhsa_exception_fp_denorm_src 0
+		.amdhsa_exception_fp_ieee_div_zero 0
+		.amdhsa_exception_fp_ieee_overflow 0
+		.amdhsa_exception_fp_ieee_underflow 0
+		.amdhsa_exception_fp_ieee_inexact 0
+		.amdhsa_exception_int_div_zero 0
+	.end_amdhsa_kernel
+	.text
+.Lfunc_end0:
+	.size	flash_attention_fwd_no_async_kernel, .Lfunc_end0-flash_attention_fwd_no_async_kernel
+	.cfi_endproc
+                                        ; -- End function
+	.set flash_attention_fwd_no_async_kernel.num_vgpr, 146
+	.set flash_attention_fwd_no_async_kernel.num_agpr, 16
+	.set flash_attention_fwd_no_async_kernel.numbered_sgpr, 17
+	.set flash_attention_fwd_no_async_kernel.num_named_barrier, 0
+	.set flash_attention_fwd_no_async_kernel.private_seg_size, 0
+	.set flash_attention_fwd_no_async_kernel.uses_vcc, 1
+	.set flash_attention_fwd_no_async_kernel.uses_flat_scratch, 0
+	.set flash_attention_fwd_no_async_kernel.has_dyn_sized_stack, 0
+	.set flash_attention_fwd_no_async_kernel.has_recursion, 0
+	.set flash_attention_fwd_no_async_kernel.has_indirect_call, 0
+	.section	.AMDGPU.csdata,"",@progbits
+; Kernel info:
+; codeLenInByte = 6944
+; TotalNumSgprs: 23
+; NumVgprs: 146
+; NumAgprs: 16
+; TotalNumVgprs: 164
+; ScratchSize: 0
+; MemoryBound: 0
+; FloatMode: 240
+; IeeeMode: 1
+; LDSByteSize: 0 bytes/workgroup (compile time only)
+; SGPRBlocks: 2
+; VGPRBlocks: 20
+; NumSGPRsForWavesPerEU: 23
+; NumVGPRsForWavesPerEU: 164
+; AccumOffset: 148
+; Occupancy: 3
+; WaveLimiterHint : 1
+; COMPUTE_PGM_RSRC2:SCRATCH_EN: 0
+; COMPUTE_PGM_RSRC2:USER_SGPR: 16
+; COMPUTE_PGM_RSRC2:TRAP_HANDLER: 0
+; COMPUTE_PGM_RSRC2:TGID_X_EN: 1
+; COMPUTE_PGM_RSRC2:TGID_Y_EN: 0
+; COMPUTE_PGM_RSRC2:TGID_Z_EN: 0
+; COMPUTE_PGM_RSRC2:TIDIG_COMP_CNT: 0
+; COMPUTE_PGM_RSRC3_GFX90A:ACCUM_OFFSET: 36
+; COMPUTE_PGM_RSRC3_GFX90A:TG_SPLIT: 0
+	.text
+	.p2alignl 6, 3212836864
+	.fill 256, 4, 3212836864
+	.section	.AMDGPU.gpr_maximums,"",@progbits
+	.set amdgpu.max_num_vgpr, 0
+	.set amdgpu.max_num_agpr, 0
+	.set amdgpu.max_num_sgpr, 0
+	.text
+	.section	.debug_abbrev,"",@progbits
+	.byte	1                               ; Abbreviation Code
+	.byte	17                              ; DW_TAG_compile_unit
+	.byte	1                               ; DW_CHILDREN_yes
+	.byte	37                              ; DW_AT_producer
+	.byte	14                              ; DW_FORM_strp
+	.byte	19                              ; DW_AT_language
+	.byte	5                               ; DW_FORM_data2
+	.byte	3                               ; DW_AT_name
+	.byte	14                              ; DW_FORM_strp
+	.byte	16                              ; DW_AT_stmt_list
+	.byte	23                              ; DW_FORM_sec_offset
+	.byte	27                              ; DW_AT_comp_dir
+	.byte	14                              ; DW_FORM_strp
+	.byte	17                              ; DW_AT_low_pc
+	.byte	1                               ; DW_FORM_addr
+	.byte	18                              ; DW_AT_high_pc
+	.byte	6                               ; DW_FORM_data4
+	.byte	0                               ; EOM(1)
+	.byte	0                               ; EOM(2)
+	.byte	2                               ; Abbreviation Code
+	.byte	46                              ; DW_TAG_subprogram
+	.byte	0                               ; DW_CHILDREN_no
+	.byte	3                               ; DW_AT_name
+	.byte	14                              ; DW_FORM_strp
+	.byte	32                              ; DW_AT_inline
+	.byte	11                              ; DW_FORM_data1
+	.byte	0                               ; EOM(1)
+	.byte	0                               ; EOM(2)
+	.byte	3                               ; Abbreviation Code
+	.byte	46                              ; DW_TAG_subprogram
+	.byte	1                               ; DW_CHILDREN_yes
+	.byte	17                              ; DW_AT_low_pc
+	.byte	1                               ; DW_FORM_addr
+	.byte	18                              ; DW_AT_high_pc
+	.byte	6                               ; DW_FORM_data4
+	.byte	49                              ; DW_AT_abstract_origin
+	.byte	19                              ; DW_FORM_ref4
+	.byte	0                               ; EOM(1)
+	.byte	0                               ; EOM(2)
+	.byte	4                               ; Abbreviation Code
+	.byte	29                              ; DW_TAG_inlined_subroutine
+	.byte	1                               ; DW_CHILDREN_yes
+	.byte	49                              ; DW_AT_abstract_origin
+	.byte	19                              ; DW_FORM_ref4
+	.byte	85                              ; DW_AT_ranges
+	.byte	23                              ; DW_FORM_sec_offset
+	.byte	88                              ; DW_AT_call_file
+	.byte	11                              ; DW_FORM_data1
+	.byte	89                              ; DW_AT_call_line
+	.byte	11                              ; DW_FORM_data1
+	.byte	87                              ; DW_AT_call_column
+	.byte	11                              ; DW_FORM_data1
+	.byte	0                               ; EOM(1)
+	.byte	0                               ; EOM(2)
+	.byte	5                               ; Abbreviation Code
+	.byte	29                              ; DW_TAG_inlined_subroutine
+	.byte	0                               ; DW_CHILDREN_no
+	.byte	49                              ; DW_AT_abstract_origin
+	.byte	19                              ; DW_FORM_ref4
+	.byte	85                              ; DW_AT_ranges
+	.byte	23                              ; DW_FORM_sec_offset
+	.byte	88                              ; DW_AT_call_file
+	.byte	11                              ; DW_FORM_data1
+	.byte	89                              ; DW_AT_call_line
+	.byte	11                              ; DW_FORM_data1
+	.byte	87                              ; DW_AT_call_column
+	.byte	11                              ; DW_FORM_data1
+	.byte	0                               ; EOM(1)
+	.byte	0                               ; EOM(2)
+	.byte	6                               ; Abbreviation Code
+	.byte	29                              ; DW_TAG_inlined_subroutine
+	.byte	0                               ; DW_CHILDREN_no
+	.byte	49                              ; DW_AT_abstract_origin
+	.byte	19                              ; DW_FORM_ref4
+	.byte	85                              ; DW_AT_ranges
+	.byte	23                              ; DW_FORM_sec_offset
+	.byte	88                              ; DW_AT_call_file
+	.byte	11                              ; DW_FORM_data1
+	.byte	89                              ; DW_AT_call_line
+	.byte	5                               ; DW_FORM_data2
+	.byte	87                              ; DW_AT_call_column
+	.byte	11                              ; DW_FORM_data1
+	.byte	0                               ; EOM(1)
+	.byte	0                               ; EOM(2)
+	.byte	0                               ; EOM(3)
+	.section	.debug_info,"",@progbits
+.Lcu_begin0:
+	.long	.Ldebug_info_end0-.Ldebug_info_start0 ; Length of Unit
+.Ldebug_info_start0:
+	.short	4                               ; DWARF version number
+	.long	.debug_abbrev                   ; Offset Into Abbrev. Section
+	.byte	8                               ; Address Size (in bytes)
+	.byte	1                               ; Abbrev [1] 0xb:0x6b DW_TAG_compile_unit
+	.long	.Linfo_string0                  ; DW_AT_producer
+	.short	2                               ; DW_AT_language
+	.long	.Linfo_string1                  ; DW_AT_name
+	.long	.Lline_table_start0             ; DW_AT_stmt_list
+	.long	.Linfo_string2                  ; DW_AT_comp_dir
+	.quad	.Lfunc_begin0                   ; DW_AT_low_pc
+	.long	.Lfunc_end0-.Lfunc_begin0       ; DW_AT_high_pc
+	.byte	2                               ; Abbrev [2] 0x2a:0x6 DW_TAG_subprogram
+	.long	.Linfo_string3                  ; DW_AT_name
+	.byte	1                               ; DW_AT_inline
+	.byte	3                               ; Abbrev [3] 0x30:0x45 DW_TAG_subprogram
+	.quad	.Lfunc_begin0                   ; DW_AT_low_pc
+	.long	.Lfunc_end0-.Lfunc_begin0       ; DW_AT_high_pc
+	.long	42                              ; DW_AT_abstract_origin
+	.byte	4                               ; Abbrev [4] 0x41:0x19 DW_TAG_inlined_subroutine
+	.long	42                              ; DW_AT_abstract_origin
+	.long	.Ldebug_ranges0                 ; DW_AT_ranges
+	.byte	1                               ; DW_AT_call_file
+	.byte	106                             ; DW_AT_call_line
+	.byte	39                              ; DW_AT_call_column
+	.byte	5                               ; Abbrev [5] 0x4d:0xc DW_TAG_inlined_subroutine
+	.long	42                              ; DW_AT_abstract_origin
+	.long	.Ldebug_ranges1                 ; DW_AT_ranges
+	.byte	2                               ; DW_AT_call_file
+	.byte	191                             ; DW_AT_call_line
+	.byte	40                              ; DW_AT_call_column
+	.byte	0                               ; End Of Children Mark
+	.byte	4                               ; Abbrev [4] 0x5a:0x1a DW_TAG_inlined_subroutine
+	.long	42                              ; DW_AT_abstract_origin
+	.long	.Ldebug_ranges2                 ; DW_AT_ranges
+	.byte	1                               ; DW_AT_call_file
+	.byte	109                             ; DW_AT_call_line
+	.byte	37                              ; DW_AT_call_column
+	.byte	6                               ; Abbrev [6] 0x66:0xd DW_TAG_inlined_subroutine
+	.long	42                              ; DW_AT_abstract_origin
+	.long	.Ldebug_ranges3                 ; DW_AT_ranges
+	.byte	2                               ; DW_AT_call_file
+	.short	293                             ; DW_AT_call_line
+	.byte	36                              ; DW_AT_call_column
+	.byte	0                               ; End Of Children Mark
+	.byte	0                               ; End Of Children Mark
+	.byte	0                               ; End Of Children Mark
+.Ldebug_info_end0:
+	.section	.debug_ranges,"",@progbits
+.Ldebug_ranges0:
+	.quad	.Ltmp2-.Lfunc_begin0
+	.quad	.Ltmp3-.Lfunc_begin0
+	.quad	.Ltmp4-.Lfunc_begin0
+	.quad	.Ltmp5-.Lfunc_begin0
+	.quad	.Ltmp6-.Lfunc_begin0
+	.quad	.Ltmp7-.Lfunc_begin0
+	.quad	.Ltmp8-.Lfunc_begin0
+	.quad	.Ltmp9-.Lfunc_begin0
+	.quad	.Ltmp10-.Lfunc_begin0
+	.quad	.Ltmp11-.Lfunc_begin0
+	.quad	.Ltmp12-.Lfunc_begin0
+	.quad	.Ltmp13-.Lfunc_begin0
+	.quad	.Ltmp14-.Lfunc_begin0
+	.quad	.Ltmp15-.Lfunc_begin0
+	.quad	.Ltmp16-.Lfunc_begin0
+	.quad	.Ltmp17-.Lfunc_begin0
+	.quad	.Ltmp18-.Lfunc_begin0
+	.quad	.Ltmp19-.Lfunc_begin0
+	.quad	.Ltmp20-.Lfunc_begin0
+	.quad	.Ltmp21-.Lfunc_begin0
+	.quad	.Ltmp22-.Lfunc_begin0
+	.quad	.Ltmp24-.Lfunc_begin0
+	.quad	0
+	.quad	0
+.Ldebug_ranges1:
+	.quad	.Ltmp2-.Lfunc_begin0
+	.quad	.Ltmp3-.Lfunc_begin0
+	.quad	.Ltmp4-.Lfunc_begin0
+	.quad	.Ltmp5-.Lfunc_begin0
+	.quad	.Ltmp6-.Lfunc_begin0
+	.quad	.Ltmp7-.Lfunc_begin0
+	.quad	.Ltmp8-.Lfunc_begin0
+	.quad	.Ltmp9-.Lfunc_begin0
+	.quad	.Ltmp10-.Lfunc_begin0
+	.quad	.Ltmp11-.Lfunc_begin0
+	.quad	.Ltmp12-.Lfunc_begin0
+	.quad	.Ltmp13-.Lfunc_begin0
+	.quad	.Ltmp14-.Lfunc_begin0
+	.quad	.Ltmp15-.Lfunc_begin0
+	.quad	.Ltmp16-.Lfunc_begin0
+	.quad	.Ltmp17-.Lfunc_begin0
+	.quad	.Ltmp18-.Lfunc_begin0
+	.quad	.Ltmp19-.Lfunc_begin0
+	.quad	.Ltmp20-.Lfunc_begin0
+	.quad	.Ltmp21-.Lfunc_begin0
+	.quad	.Ltmp22-.Lfunc_begin0
+	.quad	.Ltmp23-.Lfunc_begin0
+	.quad	0
+	.quad	0
+.Ldebug_ranges2:
+	.quad	.Ltmp25-.Lfunc_begin0
+	.quad	.Ltmp26-.Lfunc_begin0
+	.quad	.Ltmp27-.Lfunc_begin0
+	.quad	.Ltmp28-.Lfunc_begin0
+	.quad	.Ltmp29-.Lfunc_begin0
+	.quad	.Ltmp30-.Lfunc_begin0
+	.quad	.Ltmp31-.Lfunc_begin0
+	.quad	.Ltmp32-.Lfunc_begin0
+	.quad	.Ltmp33-.Lfunc_begin0
+	.quad	.Ltmp34-.Lfunc_begin0
+	.quad	.Ltmp35-.Lfunc_begin0
+	.quad	.Ltmp36-.Lfunc_begin0
+	.quad	.Ltmp37-.Lfunc_begin0
+	.quad	.Ltmp38-.Lfunc_begin0
+	.quad	.Ltmp39-.Lfunc_begin0
+	.quad	.Ltmp40-.Lfunc_begin0
+	.quad	.Ltmp41-.Lfunc_begin0
+	.quad	.Ltmp42-.Lfunc_begin0
+	.quad	.Ltmp43-.Lfunc_begin0
+	.quad	.Ltmp44-.Lfunc_begin0
+	.quad	.Ltmp45-.Lfunc_begin0
+	.quad	.Ltmp46-.Lfunc_begin0
+	.quad	.Ltmp47-.Lfunc_begin0
+	.quad	.Ltmp48-.Lfunc_begin0
+	.quad	.Ltmp49-.Lfunc_begin0
+	.quad	.Ltmp50-.Lfunc_begin0
+	.quad	.Ltmp51-.Lfunc_begin0
+	.quad	.Ltmp52-.Lfunc_begin0
+	.quad	.Ltmp53-.Lfunc_begin0
+	.quad	.Ltmp54-.Lfunc_begin0
+	.quad	.Ltmp55-.Lfunc_begin0
+	.quad	.Ltmp56-.Lfunc_begin0
+	.quad	.Ltmp57-.Lfunc_begin0
+	.quad	.Ltmp58-.Lfunc_begin0
+	.quad	.Ltmp59-.Lfunc_begin0
+	.quad	.Ltmp60-.Lfunc_begin0
+	.quad	.Ltmp61-.Lfunc_begin0
+	.quad	.Ltmp62-.Lfunc_begin0
+	.quad	.Ltmp63-.Lfunc_begin0
+	.quad	.Ltmp64-.Lfunc_begin0
+	.quad	.Ltmp65-.Lfunc_begin0
+	.quad	.Ltmp66-.Lfunc_begin0
+	.quad	.Ltmp67-.Lfunc_begin0
+	.quad	.Ltmp68-.Lfunc_begin0
+	.quad	.Ltmp69-.Lfunc_begin0
+	.quad	.Ltmp70-.Lfunc_begin0
+	.quad	.Ltmp71-.Lfunc_begin0
+	.quad	.Ltmp72-.Lfunc_begin0
+	.quad	.Ltmp73-.Lfunc_begin0
+	.quad	.Ltmp74-.Lfunc_begin0
+	.quad	.Ltmp75-.Lfunc_begin0
+	.quad	.Ltmp76-.Lfunc_begin0
+	.quad	.Ltmp77-.Lfunc_begin0
+	.quad	.Ltmp79-.Lfunc_begin0
+	.quad	.Ltmp80-.Lfunc_begin0
+	.quad	.Ltmp81-.Lfunc_begin0
+	.quad	0
+	.quad	0
+.Ldebug_ranges3:
+	.quad	.Ltmp25-.Lfunc_begin0
+	.quad	.Ltmp26-.Lfunc_begin0
+	.quad	.Ltmp27-.Lfunc_begin0
+	.quad	.Ltmp28-.Lfunc_begin0
+	.quad	.Ltmp29-.Lfunc_begin0
+	.quad	.Ltmp30-.Lfunc_begin0
+	.quad	.Ltmp31-.Lfunc_begin0
+	.quad	.Ltmp32-.Lfunc_begin0
+	.quad	.Ltmp33-.Lfunc_begin0
+	.quad	.Ltmp34-.Lfunc_begin0
+	.quad	.Ltmp35-.Lfunc_begin0
+	.quad	.Ltmp36-.Lfunc_begin0
+	.quad	.Ltmp37-.Lfunc_begin0
+	.quad	.Ltmp38-.Lfunc_begin0
+	.quad	.Ltmp39-.Lfunc_begin0
+	.quad	.Ltmp40-.Lfunc_begin0
+	.quad	.Ltmp41-.Lfunc_begin0
+	.quad	.Ltmp42-.Lfunc_begin0
+	.quad	.Ltmp43-.Lfunc_begin0
+	.quad	.Ltmp44-.Lfunc_begin0
+	.quad	.Ltmp45-.Lfunc_begin0
+	.quad	.Ltmp46-.Lfunc_begin0
+	.quad	.Ltmp47-.Lfunc_begin0
+	.quad	.Ltmp48-.Lfunc_begin0
+	.quad	.Ltmp49-.Lfunc_begin0
+	.quad	.Ltmp50-.Lfunc_begin0
+	.quad	.Ltmp51-.Lfunc_begin0
+	.quad	.Ltmp52-.Lfunc_begin0
+	.quad	.Ltmp53-.Lfunc_begin0
+	.quad	.Ltmp54-.Lfunc_begin0
+	.quad	.Ltmp55-.Lfunc_begin0
+	.quad	.Ltmp56-.Lfunc_begin0
+	.quad	.Ltmp57-.Lfunc_begin0
+	.quad	.Ltmp58-.Lfunc_begin0
+	.quad	.Ltmp59-.Lfunc_begin0
+	.quad	.Ltmp60-.Lfunc_begin0
+	.quad	.Ltmp61-.Lfunc_begin0
+	.quad	.Ltmp62-.Lfunc_begin0
+	.quad	.Ltmp63-.Lfunc_begin0
+	.quad	.Ltmp64-.Lfunc_begin0
+	.quad	.Ltmp65-.Lfunc_begin0
+	.quad	.Ltmp66-.Lfunc_begin0
+	.quad	.Ltmp67-.Lfunc_begin0
+	.quad	.Ltmp68-.Lfunc_begin0
+	.quad	.Ltmp69-.Lfunc_begin0
+	.quad	.Ltmp70-.Lfunc_begin0
+	.quad	.Ltmp71-.Lfunc_begin0
+	.quad	.Ltmp72-.Lfunc_begin0
+	.quad	.Ltmp73-.Lfunc_begin0
+	.quad	.Ltmp74-.Lfunc_begin0
+	.quad	.Ltmp75-.Lfunc_begin0
+	.quad	.Ltmp76-.Lfunc_begin0
+	.quad	.Ltmp77-.Lfunc_begin0
+	.quad	.Ltmp78-.Lfunc_begin0
+	.quad	.Ltmp80-.Lfunc_begin0
+	.quad	.Ltmp81-.Lfunc_begin0
+	.quad	0
+	.quad	0
+	.section	.debug_str,"MS",@progbits,1
+.Linfo_string0:
+	.asciz	"triton"                        ; string offset=0
+.Linfo_string1:
+	.asciz	"generate_rocjitsu_triton_fixtures.py" ; string offset=7
+.Linfo_string2:
+	.asciz	"/tmp"                          ; string offset=44
+.Linfo_string3:
+	.asciz	"flash_attention_fwd_no_async_kernel" ; string offset=49
+	.section	".note.GNU-stack","",@progbits
+	.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .agpr_count:     16
+    .args:
+      - .address_space:  global
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .address_space:  global
+        .offset:         8
+        .size:           8
+        .value_kind:     global_buffer
+      - .address_space:  global
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .address_space:  global
+        .offset:         24
+        .size:           8
+        .value_kind:     global_buffer
+      - .offset:         32
+        .size:           4
+        .value_kind:     by_value
+      - .address_space:  global
+        .offset:         40
+        .size:           8
+        .value_kind:     global_buffer
+      - .address_space:  global
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+    .group_segment_fixed_size: 0
+    .kernarg_segment_align: 8
+    .kernarg_segment_size: 56
+    .max_flat_workgroup_size: 256
+    .name:           flash_attention_fwd_no_async_kernel
+    .private_segment_fixed_size: 0
+    .sgpr_count:     23
+    .sgpr_spill_count: 0
+    .symbol:         flash_attention_fwd_no_async_kernel.kd
+    .uniform_work_group_size: 1
+    .uses_dynamic_stack: false
+    .vgpr_count:     164
+    .vgpr_spill_count: 0
+    .wavefront_size: 64
+amdhsa.target:   amdgcn-amd-amdhsa--gfx942
+amdhsa.version:
+  - 1
+  - 2
+...
+
+	.end_amdgpu_metadata
+	.section	.debug_line,"",@progbits
+.Lline_table_start0:

--- a/emulation/rocjitsu/tests/kernels/triton_cdna3_matmul_buffer_async_1024.s
+++ b/emulation/rocjitsu/tests/kernels/triton_cdna3_matmul_buffer_async_1024.s
@@ -1,0 +1,824 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// Native CDNA3/gfx942 Triton golden fixture generated from the same source and
+// constexprs as the corresponding gfx950 DBT input fixture.
+//
+// Recorded fixture metadata:
+//   kernel: matmul_async_buffer_load_lds
+//   target: gfx942, wavefront_size: 64
+//   Triton metadata shared: 8192
+//   num_warps: 4
+//   num_stages: 3
+
+	.amdgcn_target "amdgcn-amd-amdhsa--gfx942"
+	.amdhsa_code_object_version 5
+	.text
+	.globl	matmul_async_buffer_load_lds    ; -- Begin function matmul_async_buffer_load_lds
+	.p2align	8
+	.type	matmul_async_buffer_load_lds,@function
+matmul_async_buffer_load_lds:           ; @matmul_async_buffer_load_lds
+.Lfunc_begin0:
+	.cfi_sections .debug_frame
+	.cfi_startproc
+; %bb.5:
+	.file	1 "/tmp" "generate_rocjitsu_triton_fixtures.py"
+	.loc	1 48 0 prologue_end             ; generate_rocjitsu_triton_fixtures.py:48:0
+	s_load_dwordx2 s[2:3], s[0:1], 0x0
+	s_load_dwordx8 s[4:11], s[0:1], 0x8
+	s_waitcnt lgkmcnt(0)
+	s_branch .LBB0_0
+	.loc	1 0 0 is_stmt 0                 ; :0:0
+.Ltmp0:
+	.p2align	8
+; %bb.6:
+.LBB0_0:
+.Ltmp1:
+	.loc	1 39 22 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:39:22 @[ generate_rocjitsu_triton_fixtures.py:56:56 ]
+	s_ashr_i32 s0, s12, 31
+	s_lshr_b32 s0, s0, 26
+	s_add_i32 s0, s12, s0
+	s_ashr_i32 s1, s0, 6
+	.loc	1 40 29                         ; generate_rocjitsu_triton_fixtures.py:40:29 @[ generate_rocjitsu_triton_fixtures.py:56:56 ]
+	s_lshl_b32 s1, s1, 2
+	.loc	1 41 37                         ; generate_rocjitsu_triton_fixtures.py:41:37 @[ generate_rocjitsu_triton_fixtures.py:56:56 ]
+	s_sub_i32 s8, 16, s1
+	.loc	1 41 50 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:41:50 @[ generate_rocjitsu_triton_fixtures.py:56:56 ]
+	s_min_i32 s9, s8, 4
+	.loc	1 43 34 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:43:34 @[ generate_rocjitsu_triton_fixtures.py:56:56 ]
+	s_abs_i32 s10, s9
+	v_cvt_f32_u32_e32 v1, s10
+	s_sub_i32 s13, 0, s10
+	.loc	1 42 34                         ; generate_rocjitsu_triton_fixtures.py:42:34 @[ generate_rocjitsu_triton_fixtures.py:56:56 ]
+	s_andn2_b32 s0, s0, 63
+	s_sub_i32 s0, s12, s0
+	.loc	1 43 34                         ; generate_rocjitsu_triton_fixtures.py:43:34 @[ generate_rocjitsu_triton_fixtures.py:56:56 ]
+	v_rcp_iflag_f32_e32 v1, v1
+	s_abs_i32 s12, s0
+	s_xor_b32 s11, s0, s9
+	s_ashr_i32 s11, s11, 31
+	v_mul_f32_e32 v1, 0x4f7ffffe, v1
+	v_cvt_u32_f32_e32 v1, v1
+.Ltmp2:
+	.loc	1 57 44                         ; generate_rocjitsu_triton_fixtures.py:57:44
+	v_lshrrev_b32_e32 v2, 6, v0
+	v_and_b32_e32 v59, 63, v0
+	v_and_b32_e32 v50, 0xc0, v0
+.Ltmp3:
+	.loc	1 43 34                         ; generate_rocjitsu_triton_fixtures.py:43:34 @[ generate_rocjitsu_triton_fixtures.py:56:56 ]
+	v_readfirstlane_b32 s14, v1
+	s_mul_i32 s13, s13, s14
+	s_mul_hi_u32 s13, s14, s13
+	s_add_i32 s14, s14, s13
+	s_mul_hi_u32 s13, s12, s14
+	s_mul_i32 s14, s13, s10
+	s_sub_i32 s12, s12, s14
+	s_add_i32 s14, s13, 1
+	s_sub_i32 s15, s12, s10
+	s_cmp_ge_u32 s12, s10
+	s_cselect_b32 s13, s14, s13
+	s_cselect_b32 s12, s15, s12
+	s_add_i32 s14, s13, 1
+	s_cmp_ge_u32 s12, s10
+	s_cselect_b32 s10, s14, s13
+	s_xor_b32 s10, s10, s11
+	s_sub_i32 s10, s10, s11
+	.loc	1 42 48                         ; generate_rocjitsu_triton_fixtures.py:42:48 @[ generate_rocjitsu_triton_fixtures.py:56:56 ]
+	s_mul_i32 s9, s10, s9
+	s_sub_i32 s0, s0, s9
+	.loc	1 42 27 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:42:27 @[ generate_rocjitsu_triton_fixtures.py:56:56 ]
+	s_add_i32 s0, s0, s1
+.Ltmp4:
+	.loc	1 57 21 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:57:21
+	s_lshl_b32 s9, s0, 6
+	.loc	1 58 21                         ; generate_rocjitsu_triton_fixtures.py:58:21
+	s_lshl_b32 s10, s10, 6
+	.loc	1 57 31                         ; generate_rocjitsu_triton_fixtures.py:57:31
+	v_or_b32_e32 v3, s9, v2
+	.loc	1 58 31                         ; generate_rocjitsu_triton_fixtures.py:58:31
+	v_or_b32_e32 v2, s10, v59
+	s_movk_i32 s0, 0x400
+	.loc	1 61 31                         ; generate_rocjitsu_triton_fixtures.py:61:31
+	v_cmp_gt_i32_e32 vcc, s0, v2
+	.loc	1 57 31                         ; generate_rocjitsu_triton_fixtures.py:57:31
+	v_lshlrev_b32_e32 v5, 10, v3
+	.loc	1 57 44 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:57:44
+	v_and_b32_e32 v1, 15, v0
+	.loc	1 61 42 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:61:42
+	v_cndmask_b32_e32 v2, 0, v2, vcc
+	.loc	1 60 31                         ; generate_rocjitsu_triton_fixtures.py:60:31
+	v_cmp_gt_i32_e32 vcc, s0, v3
+	.loc	1 67 47                         ; generate_rocjitsu_triton_fixtures.py:67:47
+	v_or_b32_e32 v3, 0x1000, v5
+	.loc	1 57 44                         ; generate_rocjitsu_triton_fixtures.py:57:44
+	v_and_b32_e32 v54, 0x80, v0
+	.loc	1 60 42                         ; generate_rocjitsu_triton_fixtures.py:60:42
+	v_cndmask_b32_e32 v6, 0, v3, vcc
+	.loc	1 67 47                         ; generate_rocjitsu_triton_fixtures.py:67:47
+	v_or_b32_e32 v3, 0x2000, v5
+	.loc	1 60 42                         ; generate_rocjitsu_triton_fixtures.py:60:42
+	v_cndmask_b32_e32 v8, 0, v3, vcc
+	.loc	1 67 47                         ; generate_rocjitsu_triton_fixtures.py:67:47
+	v_or_b32_e32 v3, 0x3000, v5
+	.loc	1 60 42                         ; generate_rocjitsu_triton_fixtures.py:60:42
+	v_cndmask_b32_e32 v10, 0, v3, vcc
+	.loc	1 67 47                         ; generate_rocjitsu_triton_fixtures.py:67:47
+	v_or_b32_e32 v3, 0x4000, v5
+	.loc	1 60 42                         ; generate_rocjitsu_triton_fixtures.py:60:42
+	v_cndmask_b32_e32 v12, 0, v3, vcc
+	.loc	1 67 47                         ; generate_rocjitsu_triton_fixtures.py:67:47
+	v_or_b32_e32 v3, 0x5000, v5
+	.loc	1 60 42                         ; generate_rocjitsu_triton_fixtures.py:60:42
+	v_cndmask_b32_e32 v14, 0, v3, vcc
+	.loc	1 67 47                         ; generate_rocjitsu_triton_fixtures.py:67:47
+	v_or_b32_e32 v3, 0x6000, v5
+	.loc	1 60 42                         ; generate_rocjitsu_triton_fixtures.py:60:42
+	v_cndmask_b32_e32 v16, 0, v3, vcc
+	.loc	1 67 47                         ; generate_rocjitsu_triton_fixtures.py:67:47
+	v_or_b32_e32 v3, 0x7000, v5
+	.loc	1 60 42                         ; generate_rocjitsu_triton_fixtures.py:60:42
+	v_cndmask_b32_e32 v32, 0, v3, vcc
+	.loc	1 67 47                         ; generate_rocjitsu_triton_fixtures.py:67:47
+	v_or_b32_e32 v3, 0x8000, v5
+	.loc	1 60 42                         ; generate_rocjitsu_triton_fixtures.py:60:42
+	v_cndmask_b32_e32 v34, 0, v3, vcc
+	.loc	1 67 47                         ; generate_rocjitsu_triton_fixtures.py:67:47
+	v_or_b32_e32 v3, 0x9000, v5
+	.loc	1 60 42                         ; generate_rocjitsu_triton_fixtures.py:60:42
+	v_cndmask_b32_e32 v36, 0, v3, vcc
+	.loc	1 67 47                         ; generate_rocjitsu_triton_fixtures.py:67:47
+	v_or_b32_e32 v3, 0xa000, v5
+	.loc	1 60 42                         ; generate_rocjitsu_triton_fixtures.py:60:42
+	v_cndmask_b32_e32 v38, 0, v3, vcc
+	.loc	1 67 47                         ; generate_rocjitsu_triton_fixtures.py:67:47
+	v_or_b32_e32 v3, 0xb000, v5
+	.loc	1 60 42                         ; generate_rocjitsu_triton_fixtures.py:60:42
+	v_cndmask_b32_e32 v40, 0, v3, vcc
+	.loc	1 67 47                         ; generate_rocjitsu_triton_fixtures.py:67:47
+	v_or_b32_e32 v3, 0xc000, v5
+	.loc	1 60 42                         ; generate_rocjitsu_triton_fixtures.py:60:42
+	v_cndmask_b32_e32 v42, 0, v3, vcc
+	.loc	1 67 47                         ; generate_rocjitsu_triton_fixtures.py:67:47
+	v_or_b32_e32 v3, 0xd000, v5
+	.loc	1 67 29 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:67:29
+	v_ashrrev_i32_e32 v9, 31, v8
+	.loc	1 60 42 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:60:42
+	v_cndmask_b32_e32 v4, 0, v5, vcc
+	v_cndmask_b32_e32 v44, 0, v3, vcc
+	.loc	1 67 47                         ; generate_rocjitsu_triton_fixtures.py:67:47
+	v_or_b32_e32 v3, 0xe000, v5
+	.loc	1 67 29 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:67:29
+	v_lshl_add_u64 v[22:23], v[8:9], 1, s[2:3]
+	v_ashrrev_i32_e32 v15, 31, v14
+	v_lshrrev_b32_e32 v9, 1, v0
+	.loc	1 60 42 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:60:42
+	v_cndmask_b32_e32 v46, 0, v3, vcc
+	.loc	1 67 47                         ; generate_rocjitsu_triton_fixtures.py:67:47
+	v_or_b32_e32 v3, 0xf000, v5
+	.loc	1 67 29 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:67:29
+	v_ashrrev_i32_e32 v5, 31, v4
+	v_ashrrev_i32_e32 v11, 31, v10
+	v_lshl_add_u64 v[28:29], v[14:15], 1, s[2:3]
+	v_lshlrev_b32_e32 v8, 3, v1
+	v_and_b32_e32 v9, 24, v9
+	v_bfe_i32 v15, v0, 6, 1
+	v_lshl_add_u64 v[18:19], v[4:5], 1, s[2:3]
+	v_lshl_add_u64 v[24:25], v[10:11], 1, s[2:3]
+	v_lshlrev_b32_e32 v4, 1, v0
+	v_lshrrev_b32_e32 v5, 3, v50
+	v_mul_u32_u24_e32 v10, 0x88, v1
+	v_xor_b32_e32 v8, v8, v9
+	v_and_b32_e32 v15, 0x808, v15
+	.loc	1 65 38 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:65:38
+	v_lshlrev_b32_e32 v50, 7, v0
+	.loc	1 60 42                         ; generate_rocjitsu_triton_fixtures.py:60:42
+	v_cndmask_b32_e32 v48, 0, v3, vcc
+	v_ashrrev_i32_e32 v3, 31, v2
+	v_xor_b32_e32 v55, v4, v5
+	v_xor_b32_e32 v11, v10, v9
+	v_xor_b32_e32 v5, v8, v5
+	v_xor_b32_e32 v9, v15, v9
+	.loc	1 65 38                         ; generate_rocjitsu_triton_fixtures.py:65:38
+	v_and_b32_e32 v50, 0x6000, v50
+	v_mov_b32_e32 v51, 0
+	.loc	1 67 29                         ; generate_rocjitsu_triton_fixtures.py:67:29
+	v_ashrrev_i32_e32 v7, 31, v6
+	v_ashrrev_i32_e32 v13, 31, v12
+	v_ashrrev_i32_e32 v17, 31, v16
+	v_lshl_or_b32 v56, v54, 4, v11
+	v_lshl_or_b32 v57, v59, 7, v5
+	v_xor_b32_e32 v58, v9, v10
+	.loc	1 65 38                         ; generate_rocjitsu_triton_fixtures.py:65:38
+	v_lshl_add_u64 v[2:3], v[2:3], 1, v[50:51]
+	.loc	1 67 29                         ; generate_rocjitsu_triton_fixtures.py:67:29
+	v_lshl_add_u64 v[20:21], v[6:7], 1, s[2:3]
+	v_lshl_add_u64 v[26:27], v[12:13], 1, s[2:3]
+	v_lshl_add_u64 v[30:31], v[16:17], 1, s[2:3]
+	v_ashrrev_i32_e32 v33, 31, v32
+	v_ashrrev_i32_e32 v35, 31, v34
+	v_ashrrev_i32_e32 v37, 31, v36
+	v_ashrrev_i32_e32 v39, 31, v38
+	v_ashrrev_i32_e32 v41, 31, v40
+	v_ashrrev_i32_e32 v43, 31, v42
+	v_ashrrev_i32_e32 v45, 31, v44
+	v_ashrrev_i32_e32 v47, 31, v46
+	v_ashrrev_i32_e32 v49, 31, v48
+	v_xor_b32_e32 v4, 32, v55
+	v_xor_b32_e32 v6, 64, v55
+	v_xor_b32_e32 v7, 0x60, v55
+	v_xor_b32_e32 v11, 32, v56
+	v_xor_b32_e32 v12, 64, v56
+	v_xor_b32_e32 v13, 0x60, v56
+	v_xor_b32_e32 v5, 32, v57
+	v_xor_b32_e32 v8, 64, v57
+	v_xor_b32_e32 v14, 0x60, v57
+	v_xor_b32_e32 v9, 32, v58
+	v_xor_b32_e32 v10, 64, v58
+	v_xor_b32_e32 v15, 0x60, v58
+	v_xor_b32_e32 v16, 16, v58
+	v_xor_b32_e32 v17, 48, v58
+	v_xor_b32_e32 v73, 0x50, v58
+	v_xor_b32_e32 v74, 0x70, v58
+	.loc	1 65 38                         ; generate_rocjitsu_triton_fixtures.py:65:38
+	v_lshl_add_u64 v[2:3], v[2:3], 0, s[4:5]
+	s_mov_b64 s[0:1], 0x19800
+	s_movk_i32 s8, 0xffc0
+	.loc	1 67 29                         ; generate_rocjitsu_triton_fixtures.py:67:29
+	v_lshl_add_u64 v[32:33], v[32:33], 1, s[2:3]
+	v_lshl_add_u64 v[34:35], v[34:35], 1, s[2:3]
+	v_lshl_add_u64 v[36:37], v[36:37], 1, s[2:3]
+	v_lshl_add_u64 v[38:39], v[38:39], 1, s[2:3]
+	v_lshl_add_u64 v[40:41], v[40:41], 1, s[2:3]
+	v_lshl_add_u64 v[42:43], v[42:43], 1, s[2:3]
+	v_lshl_add_u64 v[44:45], v[44:45], 1, s[2:3]
+	v_lshl_add_u64 v[46:47], v[46:47], 1, s[2:3]
+	v_lshl_add_u64 v[48:49], v[48:49], 1, s[2:3]
+	v_accvgpr_write_b32 a3, 0
+	v_accvgpr_write_b32 a2, 0
+	v_accvgpr_write_b32 a1, 0
+	v_accvgpr_write_b32 a0, 0
+	v_accvgpr_write_b32 a11, 0
+	v_accvgpr_write_b32 a10, 0
+	v_accvgpr_write_b32 a9, 0
+	v_accvgpr_write_b32 a8, 0
+	v_accvgpr_write_b32 a7, 0
+	v_accvgpr_write_b32 a6, 0
+	v_accvgpr_write_b32 a5, 0
+	v_accvgpr_write_b32 a4, 0
+	v_accvgpr_write_b32 a15, 0
+	v_accvgpr_write_b32 a14, 0
+	v_accvgpr_write_b32 a13, 0
+	v_accvgpr_write_b32 a12, 0
+	.loc	1 65 38                         ; generate_rocjitsu_triton_fixtures.py:65:38
+	v_lshl_add_u64 v[52:53], v[2:3], 0, s[0:1]
+	v_lshlrev_b32_e32 v50, 1, v59
+	s_mov_b32 s4, 0xfffe7000
+	s_mov_b32 s5, 0xfffe8000
+	s_mov_b32 s11, 0xfffef000
+	s_mov_b32 s12, 0xffff0000
+	s_mov_b32 s13, 0xffff7000
+	s_movk_i32 s14, 0x8000
+	s_movk_i32 s15, 0xf000
+	v_add_u32_e32 v59, 0, v4
+	v_add_u32_e32 v60, 0, v6
+	v_add_u32_e32 v61, 0, v7
+	v_add_u32_e32 v62, 0, v11
+	v_add_u32_e32 v63, 0, v12
+	v_add_u32_e32 v64, 0, v13
+	s_mov_b32 s16, 0x5040100
+	v_add_u32_e32 v65, 0, v5
+	v_add_u32_e32 v66, 0, v8
+	v_add_u32_e32 v67, 0, v14
+	v_add_u32_e32 v68, 0, v9
+	v_add_u32_e32 v69, 0, v10
+	v_add_u32_e32 v70, 0, v15
+	v_add_u32_e32 v71, 0, v16
+	v_add_u32_e32 v72, 0, v17
+	v_add_u32_e32 v73, 0, v73
+	v_add_u32_e32 v74, 0, v74
+	s_mov_b64 s[0:1], 0x20000
+	s_mov_b64 s[2:3], 0x80
+.LBB0_1:                                ; =>This Inner Loop Header: Depth=1
+	.loc	1 67 51                         ; generate_rocjitsu_triton_fixtures.py:67:51
+	v_lshl_add_u64 v[2:3], v[20:21], 0, v[50:51]
+	v_lshl_add_u64 v[4:5], v[22:23], 0, v[50:51]
+	.loc	1 67 25 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:67:25
+	v_lshl_add_u64 v[78:79], v[18:19], 0, v[50:51]
+	.loc	1 67 51                         ; generate_rocjitsu_triton_fixtures.py:67:51
+	v_lshl_add_u64 v[6:7], v[24:25], 0, v[50:51]
+	v_lshl_add_u64 v[8:9], v[26:27], 0, v[50:51]
+	v_lshl_add_u64 v[12:13], v[30:31], 0, v[50:51]
+	v_lshl_add_u64 v[14:15], v[32:33], 0, v[50:51]
+	v_lshl_add_u64 v[16:17], v[34:35], 0, v[50:51]
+	.loc	1 67 25                         ; generate_rocjitsu_triton_fixtures.py:67:25
+	global_load_ushort v75, v[78:79], off
+	global_load_ushort v80, v[2:3], off
+	.loc	1 67 51                         ; generate_rocjitsu_triton_fixtures.py:67:51
+	v_lshl_add_u64 v[2:3], v[38:39], 0, v[50:51]
+	.loc	1 67 25                         ; generate_rocjitsu_triton_fixtures.py:67:25
+	global_load_ushort v78, v[4:5], off
+	global_load_ushort v79, v[6:7], off
+	.loc	1 67 51                         ; generate_rocjitsu_triton_fixtures.py:67:51
+	v_lshl_add_u64 v[4:5], v[40:41], 0, v[50:51]
+	v_lshl_add_u64 v[10:11], v[28:29], 0, v[50:51]
+	v_lshl_add_u64 v[76:77], v[36:37], 0, v[50:51]
+	.loc	1 67 25                         ; generate_rocjitsu_triton_fixtures.py:67:25
+	global_load_ushort v81, v[8:9], off
+	global_load_ushort v82, v[10:11], off
+	global_load_ushort v83, v[12:13], off
+	global_load_ushort v84, v[14:15], off
+	s_nop 0
+	global_load_ushort v12, v[16:17], off
+	global_load_ushort v13, v[76:77], off
+	global_load_ushort v14, v[2:3], off
+	global_load_ushort v15, v[4:5], off
+	.loc	1 69 25 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:69:25
+	v_add_co_u32_e32 v4, vcc, s4, v52
+	.loc	1 67 51                         ; generate_rocjitsu_triton_fixtures.py:67:51
+	v_lshl_add_u64 v[6:7], v[42:43], 0, v[50:51]
+	v_lshl_add_u64 v[10:11], v[46:47], 0, v[50:51]
+	v_lshl_add_u64 v[2:3], v[48:49], 0, v[50:51]
+	.loc	1 69 25                         ; generate_rocjitsu_triton_fixtures.py:69:25
+	v_addc_co_u32_e32 v5, vcc, -1, v53, vcc
+	.loc	1 67 51                         ; generate_rocjitsu_triton_fixtures.py:67:51
+	v_lshl_add_u64 v[8:9], v[44:45], 0, v[50:51]
+	.loc	1 67 25 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:67:25
+	global_load_ushort v16, v[6:7], off
+	global_load_ushort v17, v[8:9], off
+	s_nop 0
+	global_load_ushort v6, v[10:11], off
+	global_load_ushort v7, v[2:3], off
+	.loc	1 69 25 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:69:25
+	v_add_co_u32_e32 v2, vcc, s5, v52
+	v_accvgpr_mov_b32 a17, a11
+	s_nop 0
+	v_addc_co_u32_e32 v3, vcc, -1, v53, vcc
+	global_load_ushort v8, v[4:5], off offset:-2048
+	global_load_ushort v9, v[2:3], off offset:-4096
+	global_load_ushort v10, v[2:3], off offset:-2048
+	global_load_ushort v11, v[2:3], off
+	v_add_co_u32_e32 v2, vcc, s11, v52
+	v_accvgpr_mov_b32 a16, a10
+	s_nop 0
+	v_addc_co_u32_e32 v3, vcc, -1, v53, vcc
+	global_load_ushort v85, v[2:3], off offset:-2048
+	v_add_co_u32_e32 v2, vcc, s12, v52
+	.loc	1 71 30                         ; generate_rocjitsu_triton_fixtures.py:71:30
+	v_accvgpr_mov_b32 a10, a12
+	.loc	1 69 25                         ; generate_rocjitsu_triton_fixtures.py:69:25
+	s_nop 0
+	v_addc_co_u32_e32 v3, vcc, -1, v53, vcc
+	global_load_ushort v86, v[2:3], off offset:-4096
+	global_load_ushort v87, v[2:3], off offset:-2048
+	global_load_ushort v88, v[2:3], off
+	v_add_co_u32_e32 v2, vcc, s13, v52
+	.loc	1 71 30                         ; generate_rocjitsu_triton_fixtures.py:71:30
+	v_accvgpr_mov_b32 a11, a13
+	.loc	1 69 25                         ; generate_rocjitsu_triton_fixtures.py:69:25
+	s_nop 0
+	v_addc_co_u32_e32 v3, vcc, -1, v53, vcc
+	global_load_ushort v89, v[2:3], off offset:-2048
+	v_add_co_u32_e32 v2, vcc, s15, v52
+	.loc	1 71 30                         ; generate_rocjitsu_triton_fixtures.py:71:30
+	v_accvgpr_mov_b32 a12, a14
+	.loc	1 69 25                         ; generate_rocjitsu_triton_fixtures.py:69:25
+	s_nop 0
+	v_addc_co_u32_e32 v3, vcc, -1, v53, vcc
+	global_load_ushort v90, v[2:3], off offset:-2048
+	v_add_co_u32_e32 v2, vcc, s14, v52
+	.loc	1 71 30                         ; generate_rocjitsu_triton_fixtures.py:71:30
+	v_accvgpr_mov_b32 a13, a15
+	.loc	1 69 25                         ; generate_rocjitsu_triton_fixtures.py:69:25
+	s_nop 0
+	v_addc_co_u32_e32 v3, vcc, -1, v53, vcc
+	global_load_ushort v91, v[2:3], off offset:-4096
+	global_load_ushort v92, v[2:3], off offset:-2048
+	global_load_ushort v93, v[2:3], off
+	global_load_ushort v94, v[52:53], off offset:-2048
+	global_load_ushort v95, v[52:53], off
+	global_load_ushort v96, v[52:53], off offset:-4096
+	.loc	1 67 25                         ; generate_rocjitsu_triton_fixtures.py:67:25
+	v_add_u32_e32 v2, 0, v55
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	v_accvgpr_mov_b32 a15, a9
+	v_accvgpr_mov_b32 a14, a8
+	v_accvgpr_mov_b32 a9, a3
+	v_accvgpr_mov_b32 a8, a2
+	.loc	1 71 30                         ; generate_rocjitsu_triton_fixtures.py:71:30
+	v_accvgpr_mov_b32 a2, a4
+	v_accvgpr_mov_b32 a3, a5
+	v_accvgpr_mov_b32 a4, a6
+	v_accvgpr_mov_b32 a5, a7
+	v_accvgpr_mov_b32 a7, a1
+	v_accvgpr_mov_b32 a6, a0
+	.loc	1 65 38                         ; generate_rocjitsu_triton_fixtures.py:65:38
+	s_add_i32 s8, s8, 64
+	v_lshl_add_u64 v[20:21], v[20:21], 0, s[2:3]
+	v_lshl_add_u64 v[18:19], v[18:19], 0, s[2:3]
+	v_lshl_add_u64 v[48:49], v[48:49], 0, s[2:3]
+	v_lshl_add_u64 v[46:47], v[46:47], 0, s[2:3]
+	.loc	1 67 25                         ; generate_rocjitsu_triton_fixtures.py:67:25
+	s_waitcnt vmcnt(31)
+	ds_write_b16 v2, v75
+	s_waitcnt vmcnt(27)
+	ds_write_b16 v2, v81 offset:2048
+	s_waitcnt vmcnt(23)
+	ds_write_b16 v2, v12 offset:4096
+	s_waitcnt vmcnt(19)
+	ds_write_b16 v2, v16 offset:6144
+	ds_write_b16 v59, v80 offset:512
+	ds_write_b16 v59, v82 offset:2560
+	ds_write_b16 v59, v13 offset:4608
+	s_waitcnt vmcnt(18)
+	ds_write_b16 v59, v17 offset:6656
+	ds_write_b16 v60, v78 offset:1024
+	ds_write_b16 v60, v83 offset:3072
+	ds_write_b16 v60, v14 offset:5120
+	s_waitcnt vmcnt(17)
+	ds_write_b16 v60, v6 offset:7168
+	ds_write_b16 v61, v79 offset:1536
+	v_add_u32_e32 v2, 0, v56
+	ds_write_b16 v61, v84 offset:3584
+	ds_write_b16 v61, v15 offset:5632
+	s_waitcnt vmcnt(16)
+	ds_write_b16 v61, v7 offset:7680
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	ds_read2st64_b64 v[14:17], v2 offset1:8
+	.loc	1 69 25                         ; generate_rocjitsu_triton_fixtures.py:69:25
+	s_waitcnt vmcnt(14)
+	v_perm_b32 v76, v9, v8, s16
+	s_waitcnt vmcnt(12)
+	v_perm_b32 v77, v11, v10, s16
+	v_add_u32_e32 v75, 0, v57
+	.loc	1 67 25                         ; generate_rocjitsu_triton_fixtures.py:67:25
+	ds_read2st64_b64 v[10:13], v62 offset1:8
+	ds_read2st64_b64 v[6:9], v63 offset1:8
+	ds_read2st64_b64 v[2:5], v64 offset1:8
+	.loc	1 69 25                         ; generate_rocjitsu_triton_fixtures.py:69:25
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	ds_write_b64 v75, v[76:77]
+	v_add_u32_e32 v75, 0, v58
+	.loc	1 65 38                         ; generate_rocjitsu_triton_fixtures.py:65:38
+	v_lshl_add_u64 v[44:45], v[44:45], 0, s[2:3]
+	v_lshl_add_u64 v[42:43], v[42:43], 0, s[2:3]
+	v_lshl_add_u64 v[40:41], v[40:41], 0, s[2:3]
+	.loc	1 69 25                         ; generate_rocjitsu_triton_fixtures.py:69:25
+	s_waitcnt vmcnt(10)
+	v_perm_b32 v76, v86, v85, s16
+	.loc	1 65 38                         ; generate_rocjitsu_triton_fixtures.py:65:38
+	v_lshl_add_u64 v[38:39], v[38:39], 0, s[2:3]
+	.loc	1 69 25                         ; generate_rocjitsu_triton_fixtures.py:69:25
+	s_waitcnt vmcnt(8)
+	v_perm_b32 v77, v88, v87, s16
+	ds_write_b64 v65, v[76:77]
+	.loc	1 65 38                         ; generate_rocjitsu_triton_fixtures.py:65:38
+	v_lshl_add_u64 v[36:37], v[36:37], 0, s[2:3]
+	v_lshl_add_u64 v[34:35], v[34:35], 0, s[2:3]
+	v_lshl_add_u64 v[32:33], v[32:33], 0, s[2:3]
+	v_lshl_add_u64 v[30:31], v[30:31], 0, s[2:3]
+	v_lshl_add_u64 v[28:29], v[28:29], 0, s[2:3]
+	v_lshl_add_u64 v[26:27], v[26:27], 0, s[2:3]
+	v_lshl_add_u64 v[24:25], v[24:25], 0, s[2:3]
+	v_lshl_add_u64 v[22:23], v[22:23], 0, s[2:3]
+	s_cmpk_lt_u32 s8, 0x3c0
+	v_lshl_add_u64 v[52:53], v[52:53], 0, s[0:1]
+	.loc	1 69 25                         ; generate_rocjitsu_triton_fixtures.py:69:25
+	s_waitcnt vmcnt(5)
+	v_perm_b32 v78, v91, v89, s16
+	s_waitcnt vmcnt(3)
+	v_perm_b32 v79, v93, v92, s16
+	ds_write_b64 v66, v[78:79]
+	s_waitcnt vmcnt(1)
+	v_perm_b32 v81, v95, v94, s16
+	s_waitcnt vmcnt(0)
+	v_perm_b32 v80, v96, v90, s16
+	ds_write_b64 v67, v[80:81]
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	ds_read_b64 v[76:77], v75
+	ds_read_b64 v[78:79], v68
+	ds_read_b64 v[80:81], v69
+	ds_read_b64 v[82:83], v70
+	.loc	1 71 30                         ; generate_rocjitsu_triton_fixtures.py:71:30
+	s_waitcnt lgkmcnt(3)
+	v_mfma_f32_16x16x16_f16 a[10:13], v[76:77], v[14:15], a[10:13]
+	v_mfma_f32_16x16x16_f16 a[14:17], v[76:77], v[16:17], a[14:17]
+	.loc	1 69 25                         ; generate_rocjitsu_triton_fixtures.py:69:25
+	ds_read_b64 v[76:77], v71 offset:4096
+	ds_read_b64 v[84:85], v72 offset:4096
+	ds_read_b64 v[86:87], v73 offset:4096
+	ds_read_b64 v[88:89], v74 offset:4096
+	.loc	1 71 30                         ; generate_rocjitsu_triton_fixtures.py:71:30
+	s_waitcnt lgkmcnt(3)
+	v_mfma_f32_16x16x16_f16 a[2:5], v[76:77], v[14:15], a[2:5]
+	v_mfma_f32_16x16x16_f16 a[6:9], v[76:77], v[16:17], a[6:9]
+	v_mfma_f32_16x16x16_f16 a[10:13], v[78:79], v[10:11], a[10:13]
+	v_mfma_f32_16x16x16_f16 a[14:17], v[78:79], v[12:13], a[14:17]
+	s_waitcnt lgkmcnt(2)
+	v_mfma_f32_16x16x16_f16 a[0:3], v[84:85], v[10:11], a[2:5]
+	v_mfma_f32_16x16x16_f16 a[4:7], v[84:85], v[12:13], a[6:9]
+	v_mfma_f32_16x16x16_f16 a[8:11], v[80:81], v[6:7], a[10:13]
+	s_waitcnt lgkmcnt(1)
+	v_mfma_f32_16x16x16_f16 a[0:3], v[86:87], v[6:7], a[0:3]
+	v_mfma_f32_16x16x16_f16 a[16:19], v[80:81], v[8:9], a[14:17]
+	v_mfma_f32_16x16x16_f16 a[20:23], v[86:87], v[8:9], a[4:7]
+	v_mfma_f32_16x16x16_f16 a[12:15], v[82:83], v[2:3], a[8:11]
+	s_waitcnt lgkmcnt(0)
+	v_mfma_f32_16x16x16_f16 a[4:7], v[88:89], v[2:3], a[0:3]
+	v_mfma_f32_16x16x16_f16 a[8:11], v[82:83], v[4:5], a[16:19]
+	v_mfma_f32_16x16x16_f16 a[0:3], v[88:89], v[4:5], a[20:23]
+	.loc	1 65 38                         ; generate_rocjitsu_triton_fixtures.py:65:38
+	s_cbranch_scc1 .LBB0_1
+; %bb.2:
+	.loc	1 57 44                         ; generate_rocjitsu_triton_fixtures.py:57:44
+	v_lshrrev_b32_e32 v2, 3, v54
+	v_or_b32_e32 v1, v2, v1
+	v_lshrrev_b32_e32 v0, 2, v0
+	.loc	1 57 31 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:57:31
+	v_or_b32_e32 v2, s9, v1
+	.loc	1 58 31 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:58:31
+	v_and_or_b32 v0, v0, 28, s10
+	.loc	1 73 43                         ; generate_rocjitsu_triton_fixtures.py:73:43
+	v_max_i32_e32 v1, v2, v0
+	s_movk_i32 s0, 0x400
+	v_cmp_gt_i32_e32 vcc, s0, v1
+	.loc	1 72 56                         ; generate_rocjitsu_triton_fixtures.py:72:56
+	s_and_saveexec_b64 s[0:1], vcc
+	s_cbranch_execz .LBB0_4
+; %bb.3:                                ; %.critedge
+	.loc	1 72 35 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:72:35
+	v_mov_b32_e32 v1, 0x8000
+	v_lshl_or_b32 v4, v2, 10, v1
+	v_lshlrev_b32_e32 v2, 10, v2
+	.loc	1 72 17                         ; generate_rocjitsu_triton_fixtures.py:72:17
+	v_ashrrev_i32_e32 v5, 31, v4
+	.loc	1 72 39                         ; generate_rocjitsu_triton_fixtures.py:72:39
+	v_ashrrev_i32_e32 v1, 31, v0
+	.loc	1 72 17                         ; generate_rocjitsu_triton_fixtures.py:72:17
+	v_ashrrev_i32_e32 v3, 31, v2
+	v_lshl_add_u64 v[4:5], v[4:5], 2, s[6:7]
+	.loc	1 72 39                         ; generate_rocjitsu_triton_fixtures.py:72:39
+	v_lshlrev_b64 v[0:1], 2, v[0:1]
+	.loc	1 72 17                         ; generate_rocjitsu_triton_fixtures.py:72:17
+	v_lshl_add_u64 v[2:3], v[2:3], 2, s[6:7]
+	.loc	1 72 39                         ; generate_rocjitsu_triton_fixtures.py:72:39
+	v_lshl_add_u64 v[4:5], v[4:5], 0, v[0:1]
+	v_lshl_add_u64 v[0:1], v[2:3], 0, v[0:1]
+	.loc	1 72 56                         ; generate_rocjitsu_triton_fixtures.py:72:56
+	global_store_dwordx4 v[0:1], a[12:15], off
+	global_store_dwordx4 v[0:1], a[4:7], off offset:128
+	global_store_dwordx4 v[4:5], a[8:11], off
+	global_store_dwordx4 v[4:5], a[0:3], off offset:128
+.LBB0_4:                                ; %.critedge28
+	.loc	1 72 4                          ; generate_rocjitsu_triton_fixtures.py:72:4
+	s_endpgm
+.Ltmp5:
+	.section	.rodata,"a",@progbits
+	.p2align	6, 0x0
+	.amdhsa_kernel matmul_async_buffer_load_lds
+		.amdhsa_group_segment_fixed_size 0
+		.amdhsa_private_segment_fixed_size 0
+		.amdhsa_kernarg_size 40
+		.amdhsa_user_sgpr_count 12
+		.amdhsa_user_sgpr_dispatch_ptr 0
+		.amdhsa_user_sgpr_queue_ptr 0
+		.amdhsa_user_sgpr_kernarg_segment_ptr 1
+		.amdhsa_user_sgpr_dispatch_id 0
+		.amdhsa_user_sgpr_kernarg_preload_length 10
+		.amdhsa_user_sgpr_kernarg_preload_offset 0
+		.amdhsa_user_sgpr_private_segment_size 0
+		.amdhsa_uses_dynamic_stack 0
+		.amdhsa_enable_private_segment 0
+		.amdhsa_system_sgpr_workgroup_id_x 1
+		.amdhsa_system_sgpr_workgroup_id_y 0
+		.amdhsa_system_sgpr_workgroup_id_z 0
+		.amdhsa_system_sgpr_workgroup_info 0
+		.amdhsa_system_vgpr_workitem_id 0
+		.amdhsa_next_free_vgpr 124
+		.amdhsa_next_free_sgpr 17
+		.amdhsa_accum_offset 100
+		.amdhsa_reserve_vcc 1
+		.amdhsa_reserve_xnack_mask 1
+		.amdhsa_float_round_mode_32 0
+		.amdhsa_float_round_mode_16_64 0
+		.amdhsa_float_denorm_mode_32 3
+		.amdhsa_float_denorm_mode_16_64 3
+		.amdhsa_dx10_clamp 1
+		.amdhsa_ieee_mode 1
+		.amdhsa_fp16_overflow 0
+		.amdhsa_tg_split 0
+		.amdhsa_exception_fp_ieee_invalid_op 0
+		.amdhsa_exception_fp_denorm_src 0
+		.amdhsa_exception_fp_ieee_div_zero 0
+		.amdhsa_exception_fp_ieee_overflow 0
+		.amdhsa_exception_fp_ieee_underflow 0
+		.amdhsa_exception_fp_ieee_inexact 0
+		.amdhsa_exception_int_div_zero 0
+	.end_amdhsa_kernel
+	.text
+.Lfunc_end0:
+	.size	matmul_async_buffer_load_lds, .Lfunc_end0-matmul_async_buffer_load_lds
+	.cfi_endproc
+                                        ; -- End function
+	.set matmul_async_buffer_load_lds.num_vgpr, 97
+	.set matmul_async_buffer_load_lds.num_agpr, 24
+	.set matmul_async_buffer_load_lds.numbered_sgpr, 17
+	.set matmul_async_buffer_load_lds.num_named_barrier, 0
+	.set matmul_async_buffer_load_lds.private_seg_size, 0
+	.set matmul_async_buffer_load_lds.uses_vcc, 1
+	.set matmul_async_buffer_load_lds.uses_flat_scratch, 0
+	.set matmul_async_buffer_load_lds.has_dyn_sized_stack, 0
+	.set matmul_async_buffer_load_lds.has_recursion, 0
+	.set matmul_async_buffer_load_lds.has_indirect_call, 0
+	.section	.AMDGPU.csdata,"",@progbits
+; Kernel info:
+; codeLenInByte = 2760
+; TotalNumSgprs: 23
+; NumVgprs: 97
+; NumAgprs: 24
+; TotalNumVgprs: 124
+; ScratchSize: 0
+; MemoryBound: 0
+; FloatMode: 240
+; IeeeMode: 1
+; LDSByteSize: 0 bytes/workgroup (compile time only)
+; SGPRBlocks: 2
+; VGPRBlocks: 15
+; NumSGPRsForWavesPerEU: 23
+; NumVGPRsForWavesPerEU: 124
+; AccumOffset: 100
+; Occupancy: 4
+; WaveLimiterHint : 1
+; COMPUTE_PGM_RSRC2:SCRATCH_EN: 0
+; COMPUTE_PGM_RSRC2:USER_SGPR: 12
+; COMPUTE_PGM_RSRC2:TRAP_HANDLER: 0
+; COMPUTE_PGM_RSRC2:TGID_X_EN: 1
+; COMPUTE_PGM_RSRC2:TGID_Y_EN: 0
+; COMPUTE_PGM_RSRC2:TGID_Z_EN: 0
+; COMPUTE_PGM_RSRC2:TIDIG_COMP_CNT: 0
+; COMPUTE_PGM_RSRC3_GFX90A:ACCUM_OFFSET: 24
+; COMPUTE_PGM_RSRC3_GFX90A:TG_SPLIT: 0
+	.text
+	.p2alignl 6, 3212836864
+	.fill 256, 4, 3212836864
+	.section	.AMDGPU.gpr_maximums,"",@progbits
+	.set amdgpu.max_num_vgpr, 0
+	.set amdgpu.max_num_agpr, 0
+	.set amdgpu.max_num_sgpr, 0
+	.text
+	.section	.debug_abbrev,"",@progbits
+	.byte	1                               ; Abbreviation Code
+	.byte	17                              ; DW_TAG_compile_unit
+	.byte	1                               ; DW_CHILDREN_yes
+	.byte	37                              ; DW_AT_producer
+	.byte	14                              ; DW_FORM_strp
+	.byte	19                              ; DW_AT_language
+	.byte	5                               ; DW_FORM_data2
+	.byte	3                               ; DW_AT_name
+	.byte	14                              ; DW_FORM_strp
+	.byte	16                              ; DW_AT_stmt_list
+	.byte	23                              ; DW_FORM_sec_offset
+	.byte	27                              ; DW_AT_comp_dir
+	.byte	14                              ; DW_FORM_strp
+	.byte	17                              ; DW_AT_low_pc
+	.byte	1                               ; DW_FORM_addr
+	.byte	18                              ; DW_AT_high_pc
+	.byte	6                               ; DW_FORM_data4
+	.byte	0                               ; EOM(1)
+	.byte	0                               ; EOM(2)
+	.byte	2                               ; Abbreviation Code
+	.byte	46                              ; DW_TAG_subprogram
+	.byte	0                               ; DW_CHILDREN_no
+	.byte	3                               ; DW_AT_name
+	.byte	14                              ; DW_FORM_strp
+	.byte	32                              ; DW_AT_inline
+	.byte	11                              ; DW_FORM_data1
+	.byte	0                               ; EOM(1)
+	.byte	0                               ; EOM(2)
+	.byte	3                               ; Abbreviation Code
+	.byte	46                              ; DW_TAG_subprogram
+	.byte	1                               ; DW_CHILDREN_yes
+	.byte	17                              ; DW_AT_low_pc
+	.byte	1                               ; DW_FORM_addr
+	.byte	18                              ; DW_AT_high_pc
+	.byte	6                               ; DW_FORM_data4
+	.byte	49                              ; DW_AT_abstract_origin
+	.byte	19                              ; DW_FORM_ref4
+	.byte	0                               ; EOM(1)
+	.byte	0                               ; EOM(2)
+	.byte	4                               ; Abbreviation Code
+	.byte	29                              ; DW_TAG_inlined_subroutine
+	.byte	0                               ; DW_CHILDREN_no
+	.byte	49                              ; DW_AT_abstract_origin
+	.byte	19                              ; DW_FORM_ref4
+	.byte	85                              ; DW_AT_ranges
+	.byte	23                              ; DW_FORM_sec_offset
+	.byte	88                              ; DW_AT_call_file
+	.byte	11                              ; DW_FORM_data1
+	.byte	89                              ; DW_AT_call_line
+	.byte	11                              ; DW_FORM_data1
+	.byte	87                              ; DW_AT_call_column
+	.byte	11                              ; DW_FORM_data1
+	.byte	0                               ; EOM(1)
+	.byte	0                               ; EOM(2)
+	.byte	0                               ; EOM(3)
+	.section	.debug_info,"",@progbits
+.Lcu_begin0:
+	.long	.Ldebug_info_end0-.Ldebug_info_start0 ; Length of Unit
+.Ldebug_info_start0:
+	.short	4                               ; DWARF version number
+	.long	.debug_abbrev                   ; Offset Into Abbrev. Section
+	.byte	8                               ; Address Size (in bytes)
+	.byte	1                               ; Abbrev [1] 0xb:0x44 DW_TAG_compile_unit
+	.long	.Linfo_string0                  ; DW_AT_producer
+	.short	2                               ; DW_AT_language
+	.long	.Linfo_string1                  ; DW_AT_name
+	.long	.Lline_table_start0             ; DW_AT_stmt_list
+	.long	.Linfo_string2                  ; DW_AT_comp_dir
+	.quad	.Lfunc_begin0                   ; DW_AT_low_pc
+	.long	.Lfunc_end0-.Lfunc_begin0       ; DW_AT_high_pc
+	.byte	2                               ; Abbrev [2] 0x2a:0x6 DW_TAG_subprogram
+	.long	.Linfo_string3                  ; DW_AT_name
+	.byte	1                               ; DW_AT_inline
+	.byte	3                               ; Abbrev [3] 0x30:0x1e DW_TAG_subprogram
+	.quad	.Lfunc_begin0                   ; DW_AT_low_pc
+	.long	.Lfunc_end0-.Lfunc_begin0       ; DW_AT_high_pc
+	.long	42                              ; DW_AT_abstract_origin
+	.byte	4                               ; Abbrev [4] 0x41:0xc DW_TAG_inlined_subroutine
+	.long	42                              ; DW_AT_abstract_origin
+	.long	.Ldebug_ranges0                 ; DW_AT_ranges
+	.byte	1                               ; DW_AT_call_file
+	.byte	56                              ; DW_AT_call_line
+	.byte	56                              ; DW_AT_call_column
+	.byte	0                               ; End Of Children Mark
+	.byte	0                               ; End Of Children Mark
+.Ldebug_info_end0:
+	.section	.debug_ranges,"",@progbits
+.Ldebug_ranges0:
+	.quad	.Ltmp1-.Lfunc_begin0
+	.quad	.Ltmp2-.Lfunc_begin0
+	.quad	.Ltmp3-.Lfunc_begin0
+	.quad	.Ltmp4-.Lfunc_begin0
+	.quad	0
+	.quad	0
+	.section	.debug_str,"MS",@progbits,1
+.Linfo_string0:
+	.asciz	"triton"                        ; string offset=0
+.Linfo_string1:
+	.asciz	"generate_rocjitsu_triton_fixtures.py" ; string offset=7
+.Linfo_string2:
+	.asciz	"/tmp"                          ; string offset=44
+.Linfo_string3:
+	.asciz	"matmul_async_buffer_load_lds"  ; string offset=49
+	.section	".note.GNU-stack","",@progbits
+	.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .agpr_count:     24
+    .args:
+      - .address_space:  global
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .address_space:  global
+        .offset:         8
+        .size:           8
+        .value_kind:     global_buffer
+      - .address_space:  global
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .address_space:  global
+        .offset:         24
+        .size:           8
+        .value_kind:     global_buffer
+      - .address_space:  global
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+    .group_segment_fixed_size: 0
+    .kernarg_segment_align: 8
+    .kernarg_segment_size: 40
+    .max_flat_workgroup_size: 256
+    .name:           matmul_async_buffer_load_lds
+    .private_segment_fixed_size: 0
+    .sgpr_count:     23
+    .sgpr_spill_count: 0
+    .symbol:         matmul_async_buffer_load_lds.kd
+    .uniform_work_group_size: 1
+    .uses_dynamic_stack: false
+    .vgpr_count:     124
+    .vgpr_spill_count: 0
+    .wavefront_size: 64
+amdhsa.target:   amdgcn-amd-amdhsa--gfx942
+amdhsa.version:
+  - 1
+  - 2
+...
+
+	.end_amdgpu_metadata
+	.section	.debug_line,"",@progbits
+.Lline_table_start0:

--- a/emulation/rocjitsu/tests/kernels/triton_cdna3_matmul_dynamic_32x32x64.s
+++ b/emulation/rocjitsu/tests/kernels/triton_cdna3_matmul_dynamic_32x32x64.s
@@ -1,0 +1,1064 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// Native CDNA3/gfx942 Triton golden fixture generated from the same source and
+// constexprs as the corresponding gfx950 DBT input fixture.
+//
+// Recorded fixture metadata:
+//   kernel: triton_cdna4_matmul_kernel
+//   target: gfx942, wavefront_size: 64
+//   Triton metadata shared: 4096
+//   num_warps: 4
+//   num_stages: 2
+
+	.amdgcn_target "amdgcn-amd-amdhsa--gfx942"
+	.amdhsa_code_object_version 5
+	.text
+	.globl	triton_cdna4_matmul_kernel      ; -- Begin function triton_cdna4_matmul_kernel
+	.p2align	8
+	.type	triton_cdna4_matmul_kernel,@function
+triton_cdna4_matmul_kernel:             ; @triton_cdna4_matmul_kernel
+.Lfunc_begin0:
+	.cfi_sections .debug_frame
+	.cfi_startproc
+; %bb.69:
+	.file	1 "/tmp" "generate_rocjitsu_triton_fixtures.py"
+	.loc	1 14 0 prologue_end             ; generate_rocjitsu_triton_fixtures.py:14:0
+	s_load_dwordx2 s[2:3], s[0:1], 0x0
+	s_load_dwordx8 s[4:11], s[0:1], 0x8
+	s_load_dwordx4 s[12:15], s[0:1], 0x28
+	s_waitcnt lgkmcnt(0)
+	s_branch .LBB0_0
+	.loc	1 0 0 is_stmt 0                 ; :0:0
+.Ltmp0:
+	.p2align	8
+; %bb.70:
+.LBB0_0:
+.Ltmp1:
+	.loc	1 18 21 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:18:21
+	s_lshl_b32 s11, s16, 5
+	.loc	1 19 21                         ; generate_rocjitsu_triton_fixtures.py:19:21
+	s_lshl_b32 s28, s17, 5
+	.loc	1 18 44                         ; generate_rocjitsu_triton_fixtures.py:18:44
+	v_and_b32_e32 v20, 0xc0, v0
+	v_and_b32_e32 v21, 31, v0
+	.loc	1 22 29                         ; generate_rocjitsu_triton_fixtures.py:22:29
+	s_cmp_lt_i32 s10, 1
+	.loc	1 18 44                         ; generate_rocjitsu_triton_fixtures.py:18:44
+	v_and_b32_e32 v22, 32, v0
+	.loc	1 22 29                         ; generate_rocjitsu_triton_fixtures.py:22:29
+	s_cbranch_scc1 .LBB0_35
+; %bb.1:                                ; %.lr.ph
+	.loc	1 18 44                         ; generate_rocjitsu_triton_fixtures.py:18:44
+	v_lshrrev_b32_e32 v1, 6, v20
+	.loc	1 18 31 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:18:31
+	v_or_b32_e32 v1, s11, v1
+	.loc	1 20 26 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:20:26
+	v_and_b32_e32 v27, 0xe0, v0
+	v_and_b32_e32 v28, 15, v0
+	.loc	1 18 31                         ; generate_rocjitsu_triton_fixtures.py:18:31
+	v_or_b32_e32 v2, 4, v1
+	.loc	1 20 26                         ; generate_rocjitsu_triton_fixtures.py:20:26
+	v_lshrrev_b32_e32 v24, 3, v27
+	v_lshlrev_b32_e32 v29, 3, v28
+	v_lshrrev_b32_e32 v26, 2, v22
+	v_lshrrev_b32_e32 v27, 2, v27
+	v_bfe_i32 v31, v0, 4, 1
+	.loc	1 18 31                         ; generate_rocjitsu_triton_fixtures.py:18:31
+	v_or_b32_e32 v3, 8, v1
+	v_or_b32_e32 v4, 12, v1
+	v_or_b32_e32 v5, 16, v1
+	v_or_b32_e32 v6, 20, v1
+	v_or_b32_e32 v7, 24, v1
+	v_or_b32_e32 v8, 28, v1
+	.loc	1 20 26                         ; generate_rocjitsu_triton_fixtures.py:20:26
+	v_and_b32_e32 v23, 63, v0
+	.loc	1 25 49                         ; generate_rocjitsu_triton_fixtures.py:25:49
+	v_cmp_gt_i32_e32 vcc, s8, v1
+	v_cmp_gt_i32_e64 s[0:1], s8, v2
+	.loc	1 24 47                         ; generate_rocjitsu_triton_fixtures.py:24:47
+	v_mul_lo_u32 v2, s10, v1
+	s_lshl_b32 s16, s10, 2
+	v_lshlrev_b32_e32 v1, 1, v0
+	v_xor_b32_e32 v30, v29, v26
+	v_and_b32_e32 v31, 0x808, v31
+	v_xor_b32_e32 v27, v29, v27
+	.loc	1 22 29                         ; generate_rocjitsu_triton_fixtures.py:22:29
+	v_lshrrev_b32_e32 v0, 5, v0
+	.loc	1 25 49                         ; generate_rocjitsu_triton_fixtures.py:25:49
+	v_cmp_gt_i32_e64 s[20:21], s8, v4
+	.loc	1 24 47                         ; generate_rocjitsu_triton_fixtures.py:24:47
+	v_add_u32_e32 v4, s16, v2
+	v_lshlrev_b32_e32 v28, 7, v28
+	v_xor_b32_e32 v27, v27, v31
+	v_xor_b32_e32 v29, v30, v31
+	.loc	1 22 29                         ; generate_rocjitsu_triton_fixtures.py:22:29
+	v_mul_lo_u32 v0, s9, v0
+	.loc	1 25 49                         ; generate_rocjitsu_triton_fixtures.py:25:49
+	v_cmp_gt_i32_e64 s[26:27], s8, v6
+	.loc	1 24 47                         ; generate_rocjitsu_triton_fixtures.py:24:47
+	v_add_u32_e32 v6, s16, v4
+	v_or_b32_e32 v27, v27, v28
+	v_or_b32_e32 v28, v29, v28
+	.loc	1 22 29                         ; generate_rocjitsu_triton_fixtures.py:22:29
+	v_lshlrev_b32_e32 v29, 2, v0
+	v_or_b32_e32 v0, 2, v24
+	.loc	1 25 49                         ; generate_rocjitsu_triton_fixtures.py:25:49
+	v_cmp_gt_i32_e64 s[14:15], s8, v8
+	.loc	1 24 47                         ; generate_rocjitsu_triton_fixtures.py:24:47
+	v_add_u32_e32 v8, s16, v6
+	v_lshl_or_b32 v26, v21, 7, v30
+	.loc	1 22 29                         ; generate_rocjitsu_triton_fixtures.py:22:29
+	v_mul_lo_u32 v30, s9, v0
+	v_or_b32_e32 v0, 3, v24
+	.loc	1 24 47                         ; generate_rocjitsu_triton_fixtures.py:24:47
+	v_add_u32_e32 v10, s16, v8
+	.loc	1 22 29                         ; generate_rocjitsu_triton_fixtures.py:22:29
+	v_mul_lo_u32 v31, s9, v0
+	v_or_b32_e32 v0, 32, v24
+	.loc	1 24 47                         ; generate_rocjitsu_triton_fixtures.py:24:47
+	v_add_u32_e32 v12, s16, v10
+	.loc	1 22 29                         ; generate_rocjitsu_triton_fixtures.py:22:29
+	v_mul_lo_u32 v32, s9, v0
+	v_or_b32_e32 v0, 33, v24
+	.loc	1 24 47                         ; generate_rocjitsu_triton_fixtures.py:24:47
+	v_add_u32_e32 v14, s16, v12
+	v_lshrrev_b32_e32 v25, 3, v20
+	.loc	1 22 29                         ; generate_rocjitsu_triton_fixtures.py:22:29
+	v_mul_lo_u32 v33, s9, v0
+	v_or_b32_e32 v0, 34, v24
+	.loc	1 19 31                         ; generate_rocjitsu_triton_fixtures.py:19:31
+	v_or_b32_e32 v18, s28, v21
+	.loc	1 24 47                         ; generate_rocjitsu_triton_fixtures.py:24:47
+	v_add_u32_e32 v16, s16, v14
+	v_xor_b32_e32 v25, v1, v25
+	.loc	1 22 29                         ; generate_rocjitsu_triton_fixtures.py:22:29
+	v_mul_lo_u32 v34, s9, v0
+	v_or_b32_e32 v0, 35, v24
+	.loc	1 25 49                         ; generate_rocjitsu_triton_fixtures.py:25:49
+	v_cmp_gt_i32_e64 s[22:23], s8, v3
+	v_cmp_gt_i32_e64 s[24:25], s8, v5
+	v_cmp_gt_i32_e64 s[12:13], s8, v7
+	.loc	1 24 29                         ; generate_rocjitsu_triton_fixtures.py:24:29
+	v_ashrrev_i32_e32 v3, 31, v2
+	v_ashrrev_i32_e32 v5, 31, v4
+	v_ashrrev_i32_e32 v7, 31, v6
+	v_ashrrev_i32_e32 v9, 31, v8
+	v_ashrrev_i32_e32 v11, 31, v10
+	v_ashrrev_i32_e32 v13, 31, v12
+	v_ashrrev_i32_e32 v15, 31, v14
+	v_ashrrev_i32_e32 v17, 31, v16
+	v_ashrrev_i32_e32 v19, 31, v18
+	v_xor_b32_e32 v1, 32, v25
+	v_xor_b32_e32 v38, 64, v25
+	v_xor_b32_e32 v39, 0x60, v25
+	v_xor_b32_e32 v40, 16, v26
+	v_xor_b32_e32 v41, 32, v26
+	v_xor_b32_e32 v42, 48, v26
+	v_xor_b32_e32 v43, 64, v26
+	v_xor_b32_e32 v44, 0x50, v26
+	v_xor_b32_e32 v45, 0x60, v26
+	v_xor_b32_e32 v46, 0x70, v26
+	v_xor_b32_e32 v47, 64, v27
+	v_xor_b32_e32 v48, 16, v28
+	v_xor_b32_e32 v49, 32, v28
+	v_xor_b32_e32 v50, 48, v28
+	v_xor_b32_e32 v51, 64, v28
+	v_xor_b32_e32 v52, 0x50, v28
+	v_xor_b32_e32 v53, 0x60, v28
+	v_xor_b32_e32 v54, 0x70, v28
+	.loc	1 22 29                         ; generate_rocjitsu_triton_fixtures.py:22:29
+	v_mul_lo_u32 v35, s9, v0
+	v_mul_lo_u32 v0, s9, v24
+	.loc	1 24 29                         ; generate_rocjitsu_triton_fixtures.py:24:29
+	v_lshl_add_u64 v[2:3], v[2:3], 1, s[2:3]
+	v_lshl_add_u64 v[4:5], v[4:5], 1, s[2:3]
+	v_lshl_add_u64 v[6:7], v[6:7], 1, s[2:3]
+	v_lshl_add_u64 v[8:9], v[8:9], 1, s[2:3]
+	v_lshl_add_u64 v[10:11], v[10:11], 1, s[2:3]
+	v_lshl_add_u64 v[12:13], v[12:13], 1, s[2:3]
+	v_lshl_add_u64 v[14:15], v[14:15], 1, s[2:3]
+	v_lshl_add_u64 v[16:17], v[16:17], 1, s[2:3]
+	.loc	1 27 73                         ; generate_rocjitsu_triton_fixtures.py:27:73
+	v_cmp_gt_i32_e64 s[16:17], s9, v18
+	.loc	1 22 29                         ; generate_rocjitsu_triton_fixtures.py:22:29
+	v_lshl_add_u64 v[18:19], v[18:19], 1, s[4:5]
+	s_lshl_b32 s4, s9, 6
+	v_add_u32_e32 v36, s9, v0
+	v_accvgpr_write_b32 a15, 0
+	v_accvgpr_write_b32 a14, 0
+	v_accvgpr_write_b32 a13, 0
+	v_accvgpr_write_b32 a12, 0
+	v_accvgpr_write_b32 a11, 0
+	v_accvgpr_write_b32 a10, 0
+	v_accvgpr_write_b32 a9, 0
+	v_accvgpr_write_b32 a8, 0
+	v_accvgpr_write_b32 a7, 0
+	v_accvgpr_write_b32 a6, 0
+	v_accvgpr_write_b32 a5, 0
+	v_accvgpr_write_b32 a4, 0
+	v_accvgpr_write_b32 a3, 0
+	v_accvgpr_write_b32 a2, 0
+	v_accvgpr_write_b32 a1, 0
+	v_accvgpr_write_b32 a0, 0
+	s_mov_b32 s5, 0
+	v_add_u32_e32 v37, 0, v1
+	v_add_u32_e32 v38, 0, v38
+	v_add_u32_e32 v39, 0, v39
+	v_add_u32_e32 v40, 0, v40
+	v_add_u32_e32 v41, 0, v41
+	v_add_u32_e32 v42, 0, v42
+	v_add_u32_e32 v43, 0, v43
+	v_add_u32_e32 v44, 0, v44
+	v_add_u32_e32 v45, 0, v45
+	v_add_u32_e32 v46, 0, v46
+	s_mov_b32 s29, 0x5040100
+	v_add_u32_e32 v47, 0, v47
+	v_add_u32_e32 v48, 0, v48
+	v_add_u32_e32 v49, 0, v49
+	v_add_u32_e32 v50, 0, v50
+	v_add_u32_e32 v51, 0, v51
+	v_add_u32_e32 v52, 0, v52
+	v_add_u32_e32 v53, 0, v53
+	v_add_u32_e32 v54, 0, v54
+	s_mov_b32 s30, 0
+	s_branch .LBB0_3
+.LBB0_2:                                ;   in Loop: Header=BB0_3 Depth=1
+	.loc	1 0 29 is_stmt 0                ; generate_rocjitsu_triton_fixtures.py:0:29
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 24 25 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:24:25
+	v_add_u32_e32 v69, 0, v25
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	s_waitcnt vmcnt(0)
+	ds_write_b16 v69, v61
+	ds_write_b16 v69, v65 offset:2048
+	ds_write_b16 v37, v63 offset:512
+	ds_write_b16 v37, v67 offset:2560
+	ds_write_b16 v38, v62 offset:1024
+	ds_write_b16 v38, v66 offset:3072
+	ds_write_b16 v39, v64 offset:1536
+	ds_write_b16 v39, v68 offset:3584
+	v_add_u32_e32 v61, 0, v26
+	.loc	1 26 25                         ; generate_rocjitsu_triton_fixtures.py:26:25
+	v_perm_b32 v1, v58, v1, s29
+	v_perm_b32 v0, v0, v55, s29
+	v_add_u32_e32 v55, 0, v27
+	.loc	1 24 25                         ; generate_rocjitsu_triton_fixtures.py:24:25
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	ds_read_b64 v[62:63], v61
+	ds_read_b64 v[64:65], v40
+	ds_read_b64 v[66:67], v41
+	ds_read_b64 v[68:69], v42
+	ds_read_b64 v[70:71], v43
+	ds_read_b64 v[72:73], v44
+	ds_read_b64 v[74:75], v45
+	ds_read_b64 v[76:77], v46
+	.loc	1 26 25                         ; generate_rocjitsu_triton_fixtures.py:26:25
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	ds_write_b64 v55, v[0:1]
+	v_perm_b32 v0, v60, v57, s29
+	v_perm_b32 v1, v56, v59, s29
+	ds_write_b64 v47, v[0:1]
+	v_add_u32_e32 v0, 0, v28
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	ds_read_b64 v[0:1], v0
+	ds_read_b64 v[56:57], v48
+	ds_read_b64 v[58:59], v49
+	ds_read_b64 v[60:61], v50
+	.loc	1 28 30                         ; generate_rocjitsu_triton_fixtures.py:28:30
+	s_waitcnt lgkmcnt(3)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[0:1], v[62:63], a[0:15]
+	.loc	1 22 29                         ; generate_rocjitsu_triton_fixtures.py:22:29
+	s_add_i32 s30, s30, 64
+	s_add_i32 s5, s5, s4
+	s_cmp_lt_i32 s30, s10
+	.loc	1 28 30                         ; generate_rocjitsu_triton_fixtures.py:28:30
+	s_waitcnt lgkmcnt(2)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[56:57], v[64:65], a[0:15]
+	s_waitcnt lgkmcnt(1)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[58:59], v[66:67], a[0:15]
+	s_waitcnt lgkmcnt(0)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[60:61], v[68:69], a[0:15]
+	.loc	1 26 25                         ; generate_rocjitsu_triton_fixtures.py:26:25
+	ds_read_b64 v[0:1], v51
+	ds_read_b64 v[56:57], v52
+	ds_read_b64 v[58:59], v53
+	ds_read_b64 v[60:61], v54
+	.loc	1 28 30                         ; generate_rocjitsu_triton_fixtures.py:28:30
+	s_waitcnt lgkmcnt(3)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[0:1], v[70:71], a[0:15]
+	s_waitcnt lgkmcnt(2)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[56:57], v[72:73], a[0:15]
+	s_waitcnt lgkmcnt(1)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[58:59], v[74:75], a[0:15]
+	s_waitcnt lgkmcnt(0)
+	v_mfma_f32_32x32x8_f16 a[0:15], v[60:61], v[76:77], a[0:15]
+	.loc	1 22 29                         ; generate_rocjitsu_triton_fixtures.py:22:29
+	s_cbranch_scc0 .LBB0_36
+.LBB0_3:                                ; =>This Inner Loop Header: Depth=1
+	.loc	1 23 22                         ; generate_rocjitsu_triton_fixtures.py:23:22
+	v_add_u32_e32 v0, s30, v23
+	.loc	1 25 73                         ; generate_rocjitsu_triton_fixtures.py:25:73
+	v_cmp_gt_i32_e64 s[18:19], s10, v0
+	.loc	1 25 55 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:25:55
+	s_and_b64 s[34:35], vcc, s[18:19]
+	.loc	1 24 51 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:24:51
+	v_ashrrev_i32_e32 v1, 31, v0
+	v_mov_b32_e32 v61, 0
+	.loc	1 24 25 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:24:25
+	s_and_saveexec_b64 s[2:3], s[34:35]
+	s_cbranch_execz .LBB0_5
+; %bb.4:                                ;   in Loop: Header=BB0_3 Depth=1
+	.loc	1 0 25                          ; generate_rocjitsu_triton_fixtures.py:0:25
+	v_lshl_add_u64 v[56:57], v[0:1], 1, v[2:3]
+	.loc	1 24 25                         ; generate_rocjitsu_triton_fixtures.py:24:25
+	global_load_ushort v61, v[56:57], off
+.LBB0_5:                                ;   in Loop: Header=BB0_3 Depth=1
+	.loc	1 0 25                          ; generate_rocjitsu_triton_fixtures.py:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 25 55 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:25:55
+	s_and_b64 s[34:35], s[0:1], s[18:19]
+	v_mov_b32_e32 v62, 0
+	v_mov_b32_e32 v63, 0
+	.loc	1 24 25                         ; generate_rocjitsu_triton_fixtures.py:24:25
+	s_and_saveexec_b64 s[2:3], s[34:35]
+	s_cbranch_execz .LBB0_7
+; %bb.6:                                ;   in Loop: Header=BB0_3 Depth=1
+	.loc	1 24 51 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:24:51
+	v_lshl_add_u64 v[56:57], v[0:1], 1, v[4:5]
+	.loc	1 24 25                         ; generate_rocjitsu_triton_fixtures.py:24:25
+	global_load_ushort v63, v[56:57], off
+.LBB0_7:                                ;   in Loop: Header=BB0_3 Depth=1
+	.loc	1 0 25                          ; generate_rocjitsu_triton_fixtures.py:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 25 55 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:25:55
+	s_and_b64 s[34:35], s[22:23], s[18:19]
+	.loc	1 24 25                         ; generate_rocjitsu_triton_fixtures.py:24:25
+	s_and_saveexec_b64 s[2:3], s[34:35]
+	s_cbranch_execz .LBB0_9
+; %bb.8:                                ;   in Loop: Header=BB0_3 Depth=1
+	.loc	1 24 51 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:24:51
+	v_lshl_add_u64 v[56:57], v[0:1], 1, v[6:7]
+	.loc	1 24 25                         ; generate_rocjitsu_triton_fixtures.py:24:25
+	global_load_ushort v62, v[56:57], off
+.LBB0_9:                                ;   in Loop: Header=BB0_3 Depth=1
+	.loc	1 0 25                          ; generate_rocjitsu_triton_fixtures.py:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 25 55 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:25:55
+	s_and_b64 s[34:35], s[20:21], s[18:19]
+	v_mov_b32_e32 v65, 0
+	v_mov_b32_e32 v64, 0
+	.loc	1 24 25                         ; generate_rocjitsu_triton_fixtures.py:24:25
+	s_and_saveexec_b64 s[2:3], s[34:35]
+	s_cbranch_execz .LBB0_11
+; %bb.10:                               ;   in Loop: Header=BB0_3 Depth=1
+	.loc	1 24 51 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:24:51
+	v_lshl_add_u64 v[56:57], v[0:1], 1, v[8:9]
+	.loc	1 24 25                         ; generate_rocjitsu_triton_fixtures.py:24:25
+	global_load_ushort v64, v[56:57], off
+.LBB0_11:                               ;   in Loop: Header=BB0_3 Depth=1
+	.loc	1 0 25                          ; generate_rocjitsu_triton_fixtures.py:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 25 55 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:25:55
+	s_and_b64 s[34:35], s[24:25], s[18:19]
+	.loc	1 24 25                         ; generate_rocjitsu_triton_fixtures.py:24:25
+	s_and_saveexec_b64 s[2:3], s[34:35]
+	s_cbranch_execz .LBB0_13
+; %bb.12:                               ;   in Loop: Header=BB0_3 Depth=1
+	.loc	1 24 51 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:24:51
+	v_lshl_add_u64 v[56:57], v[0:1], 1, v[10:11]
+	.loc	1 24 25                         ; generate_rocjitsu_triton_fixtures.py:24:25
+	global_load_ushort v65, v[56:57], off
+.LBB0_13:                               ;   in Loop: Header=BB0_3 Depth=1
+	.loc	1 0 25                          ; generate_rocjitsu_triton_fixtures.py:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 25 55 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:25:55
+	s_and_b64 s[34:35], s[26:27], s[18:19]
+	v_mov_b32_e32 v66, 0
+	v_mov_b32_e32 v67, 0
+	.loc	1 24 25                         ; generate_rocjitsu_triton_fixtures.py:24:25
+	s_and_saveexec_b64 s[2:3], s[34:35]
+	s_cbranch_execz .LBB0_15
+; %bb.14:                               ;   in Loop: Header=BB0_3 Depth=1
+	.loc	1 24 51 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:24:51
+	v_lshl_add_u64 v[56:57], v[0:1], 1, v[12:13]
+	.loc	1 24 25                         ; generate_rocjitsu_triton_fixtures.py:24:25
+	global_load_ushort v67, v[56:57], off
+.LBB0_15:                               ;   in Loop: Header=BB0_3 Depth=1
+	.loc	1 0 25                          ; generate_rocjitsu_triton_fixtures.py:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 25 55 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:25:55
+	s_and_b64 s[34:35], s[12:13], s[18:19]
+	.loc	1 24 25                         ; generate_rocjitsu_triton_fixtures.py:24:25
+	s_and_saveexec_b64 s[2:3], s[34:35]
+	s_cbranch_execz .LBB0_17
+; %bb.16:                               ;   in Loop: Header=BB0_3 Depth=1
+	.loc	1 24 51 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:24:51
+	v_lshl_add_u64 v[56:57], v[0:1], 1, v[14:15]
+	.loc	1 24 25                         ; generate_rocjitsu_triton_fixtures.py:24:25
+	global_load_ushort v66, v[56:57], off
+.LBB0_17:                               ;   in Loop: Header=BB0_3 Depth=1
+	.loc	1 0 25                          ; generate_rocjitsu_triton_fixtures.py:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 25 55 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:25:55
+	s_and_b64 s[18:19], s[14:15], s[18:19]
+	v_mov_b32_e32 v55, 0
+	v_mov_b32_e32 v68, 0
+	.loc	1 24 25                         ; generate_rocjitsu_triton_fixtures.py:24:25
+	s_and_saveexec_b64 s[2:3], s[18:19]
+	s_cbranch_execz .LBB0_19
+; %bb.18:                               ;   in Loop: Header=BB0_3 Depth=1
+	.loc	1 24 51 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:24:51
+	v_lshl_add_u64 v[0:1], v[0:1], 1, v[16:17]
+	.loc	1 24 25                         ; generate_rocjitsu_triton_fixtures.py:24:25
+	global_load_ushort v68, v[0:1], off
+.LBB0_19:                               ;   in Loop: Header=BB0_3 Depth=1
+	.loc	1 0 25                          ; generate_rocjitsu_triton_fixtures.py:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 23 22 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:23:22
+	v_add_u32_e32 v56, s30, v24
+	.loc	1 27 49                         ; generate_rocjitsu_triton_fixtures.py:27:49
+	v_cmp_gt_i32_e64 s[2:3], s10, v56
+	.loc	1 27 55 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:27:55
+	s_and_b64 s[18:19], s[16:17], s[2:3]
+	.loc	1 26 25 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:26:25
+	s_and_saveexec_b64 s[2:3], s[18:19]
+	s_cbranch_execz .LBB0_21
+; %bb.20:                               ;   in Loop: Header=BB0_3 Depth=1
+	.loc	1 0 25 is_stmt 0                ; generate_rocjitsu_triton_fixtures.py:0:25
+	v_add_u32_e32 v0, s5, v29
+	v_ashrrev_i32_e32 v1, 31, v0
+	v_lshl_add_u64 v[0:1], v[0:1], 1, v[18:19]
+	.loc	1 26 25                         ; generate_rocjitsu_triton_fixtures.py:26:25
+	global_load_ushort v55, v[0:1], off
+.LBB0_21:                               ;   in Loop: Header=BB0_3 Depth=1
+	.loc	1 0 25                          ; generate_rocjitsu_triton_fixtures.py:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 23 22 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:23:22
+	v_add_u32_e32 v0, 1, v56
+	.loc	1 27 49                         ; generate_rocjitsu_triton_fixtures.py:27:49
+	v_cmp_gt_i32_e64 s[2:3], s10, v0
+	.loc	1 27 55 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:27:55
+	s_and_b64 s[18:19], s[16:17], s[2:3]
+	v_mov_b32_e32 v1, 0
+	v_mov_b32_e32 v0, 0
+	.loc	1 26 25 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:26:25
+	s_and_saveexec_b64 s[2:3], s[18:19]
+	s_cbranch_execz .LBB0_23
+; %bb.22:                               ;   in Loop: Header=BB0_3 Depth=1
+	.loc	1 26 47 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:26:47
+	v_add_u32_e32 v58, s5, v36
+	.loc	1 26 29                         ; generate_rocjitsu_triton_fixtures.py:26:29
+	v_ashrrev_i32_e32 v59, 31, v58
+	.loc	1 26 51                         ; generate_rocjitsu_triton_fixtures.py:26:51
+	v_lshl_add_u64 v[58:59], v[58:59], 1, v[18:19]
+	.loc	1 26 25                         ; generate_rocjitsu_triton_fixtures.py:26:25
+	global_load_ushort v0, v[58:59], off
+.LBB0_23:                               ;   in Loop: Header=BB0_3 Depth=1
+	.loc	1 0 25                          ; generate_rocjitsu_triton_fixtures.py:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 23 22 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:23:22
+	v_add_u32_e32 v57, 2, v56
+	.loc	1 27 49                         ; generate_rocjitsu_triton_fixtures.py:27:49
+	v_cmp_gt_i32_e64 s[2:3], s10, v57
+	.loc	1 27 55 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:27:55
+	s_and_b64 s[18:19], s[16:17], s[2:3]
+	.loc	1 26 25 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:26:25
+	s_and_saveexec_b64 s[2:3], s[18:19]
+	s_cbranch_execz .LBB0_25
+; %bb.24:                               ;   in Loop: Header=BB0_3 Depth=1
+	.loc	1 26 47 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:26:47
+	v_add_u32_e32 v58, s5, v30
+	.loc	1 26 29                         ; generate_rocjitsu_triton_fixtures.py:26:29
+	v_ashrrev_i32_e32 v59, 31, v58
+	.loc	1 26 51                         ; generate_rocjitsu_triton_fixtures.py:26:51
+	v_lshl_add_u64 v[58:59], v[58:59], 1, v[18:19]
+	.loc	1 26 25                         ; generate_rocjitsu_triton_fixtures.py:26:25
+	global_load_ushort v1, v[58:59], off
+.LBB0_25:                               ;   in Loop: Header=BB0_3 Depth=1
+	.loc	1 0 25                          ; generate_rocjitsu_triton_fixtures.py:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 23 22 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:23:22
+	v_add_u32_e32 v57, 3, v56
+	.loc	1 27 49                         ; generate_rocjitsu_triton_fixtures.py:27:49
+	v_cmp_gt_i32_e64 s[2:3], s10, v57
+	.loc	1 27 55 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:27:55
+	s_and_b64 s[18:19], s[16:17], s[2:3]
+	v_mov_b32_e32 v57, 0
+	v_mov_b32_e32 v58, 0
+	.loc	1 26 25 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:26:25
+	s_and_saveexec_b64 s[2:3], s[18:19]
+	s_cbranch_execz .LBB0_27
+; %bb.26:                               ;   in Loop: Header=BB0_3 Depth=1
+	.loc	1 26 47 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:26:47
+	v_add_u32_e32 v58, s5, v31
+	.loc	1 26 29                         ; generate_rocjitsu_triton_fixtures.py:26:29
+	v_ashrrev_i32_e32 v59, 31, v58
+	.loc	1 26 51                         ; generate_rocjitsu_triton_fixtures.py:26:51
+	v_lshl_add_u64 v[58:59], v[58:59], 1, v[18:19]
+	.loc	1 26 25                         ; generate_rocjitsu_triton_fixtures.py:26:25
+	global_load_ushort v58, v[58:59], off
+.LBB0_27:                               ;   in Loop: Header=BB0_3 Depth=1
+	.loc	1 0 25                          ; generate_rocjitsu_triton_fixtures.py:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 23 22 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:23:22
+	v_add_u32_e32 v59, 32, v56
+	.loc	1 27 49                         ; generate_rocjitsu_triton_fixtures.py:27:49
+	v_cmp_gt_i32_e64 s[2:3], s10, v59
+	.loc	1 27 55 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:27:55
+	s_and_b64 s[18:19], s[16:17], s[2:3]
+	.loc	1 26 25 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:26:25
+	s_and_saveexec_b64 s[2:3], s[18:19]
+	s_cbranch_execz .LBB0_29
+; %bb.28:                               ;   in Loop: Header=BB0_3 Depth=1
+	.loc	1 26 47 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:26:47
+	v_add_u32_e32 v70, s5, v32
+	.loc	1 26 29                         ; generate_rocjitsu_triton_fixtures.py:26:29
+	v_ashrrev_i32_e32 v71, 31, v70
+	.loc	1 26 51                         ; generate_rocjitsu_triton_fixtures.py:26:51
+	v_lshl_add_u64 v[70:71], v[70:71], 1, v[18:19]
+	.loc	1 26 25                         ; generate_rocjitsu_triton_fixtures.py:26:25
+	global_load_ushort v57, v[70:71], off
+.LBB0_29:                               ;   in Loop: Header=BB0_3 Depth=1
+	.loc	1 0 25                          ; generate_rocjitsu_triton_fixtures.py:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 23 22 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:23:22
+	v_add_u32_e32 v59, 33, v56
+	.loc	1 27 49                         ; generate_rocjitsu_triton_fixtures.py:27:49
+	v_cmp_gt_i32_e64 s[2:3], s10, v59
+	.loc	1 27 55 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:27:55
+	s_and_b64 s[18:19], s[16:17], s[2:3]
+	v_mov_b32_e32 v59, 0
+	v_mov_b32_e32 v60, 0
+	.loc	1 26 25 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:26:25
+	s_and_saveexec_b64 s[2:3], s[18:19]
+	s_cbranch_execz .LBB0_31
+; %bb.30:                               ;   in Loop: Header=BB0_3 Depth=1
+	.loc	1 26 47 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:26:47
+	v_add_u32_e32 v70, s5, v33
+	.loc	1 26 29                         ; generate_rocjitsu_triton_fixtures.py:26:29
+	v_ashrrev_i32_e32 v71, 31, v70
+	.loc	1 26 51                         ; generate_rocjitsu_triton_fixtures.py:26:51
+	v_lshl_add_u64 v[70:71], v[70:71], 1, v[18:19]
+	.loc	1 26 25                         ; generate_rocjitsu_triton_fixtures.py:26:25
+	global_load_ushort v60, v[70:71], off
+.LBB0_31:                               ;   in Loop: Header=BB0_3 Depth=1
+	.loc	1 0 25                          ; generate_rocjitsu_triton_fixtures.py:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 23 22 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:23:22
+	v_add_u32_e32 v69, 34, v56
+	.loc	1 27 49                         ; generate_rocjitsu_triton_fixtures.py:27:49
+	v_cmp_gt_i32_e64 s[2:3], s10, v69
+	.loc	1 27 55 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:27:55
+	s_and_b64 s[18:19], s[16:17], s[2:3]
+	.loc	1 26 25 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:26:25
+	s_and_saveexec_b64 s[2:3], s[18:19]
+	s_cbranch_execz .LBB0_33
+; %bb.32:                               ;   in Loop: Header=BB0_3 Depth=1
+	.loc	1 26 47 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:26:47
+	v_add_u32_e32 v70, s5, v34
+	.loc	1 26 29                         ; generate_rocjitsu_triton_fixtures.py:26:29
+	v_ashrrev_i32_e32 v71, 31, v70
+	.loc	1 26 51                         ; generate_rocjitsu_triton_fixtures.py:26:51
+	v_lshl_add_u64 v[70:71], v[70:71], 1, v[18:19]
+	.loc	1 26 25                         ; generate_rocjitsu_triton_fixtures.py:26:25
+	global_load_ushort v59, v[70:71], off
+.LBB0_33:                               ;   in Loop: Header=BB0_3 Depth=1
+	.loc	1 0 25                          ; generate_rocjitsu_triton_fixtures.py:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 25 73 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:25:73
+	v_add_u32_e32 v56, 35, v56
+	.loc	1 27 49                         ; generate_rocjitsu_triton_fixtures.py:27:49
+	v_cmp_gt_i32_e64 s[2:3], s10, v56
+	.loc	1 27 55 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:27:55
+	s_and_b64 s[18:19], s[16:17], s[2:3]
+	v_mov_b32_e32 v56, 0
+	.loc	1 26 25 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:26:25
+	s_and_saveexec_b64 s[2:3], s[18:19]
+	s_cbranch_execz .LBB0_2
+; %bb.34:                               ;   in Loop: Header=BB0_3 Depth=1
+	.loc	1 26 29 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:26:29
+	v_add_u32_e32 v70, s5, v35
+	v_ashrrev_i32_e32 v71, 31, v70
+	.loc	1 26 51                         ; generate_rocjitsu_triton_fixtures.py:26:51
+	v_lshl_add_u64 v[70:71], v[70:71], 1, v[18:19]
+	.loc	1 26 25                         ; generate_rocjitsu_triton_fixtures.py:26:25
+	global_load_ushort v56, v[70:71], off
+	s_branch .LBB0_2
+.LBB0_35:
+	.loc	1 0 25                          ; generate_rocjitsu_triton_fixtures.py:0:25
+	v_accvgpr_write_b32 a0, 0
+	v_accvgpr_write_b32 a1, 0
+	v_accvgpr_write_b32 a2, 0
+	v_accvgpr_write_b32 a3, 0
+	v_accvgpr_write_b32 a4, 0
+	v_accvgpr_write_b32 a5, 0
+	v_accvgpr_write_b32 a6, 0
+	v_accvgpr_write_b32 a7, 0
+	v_accvgpr_write_b32 a8, 0
+	v_accvgpr_write_b32 a9, 0
+	v_accvgpr_write_b32 a10, 0
+	v_accvgpr_write_b32 a11, 0
+	v_accvgpr_write_b32 a12, 0
+	v_accvgpr_write_b32 a13, 0
+	v_accvgpr_write_b32 a14, 0
+	v_accvgpr_write_b32 a15, 0
+.LBB0_36:                               ; %._crit_edge
+	.loc	1 18 44 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:18:44
+	v_lshrrev_b32_e32 v0, 3, v22
+	.loc	1 18 31 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:18:31
+	v_or_b32_e32 v1, s11, v21
+	.loc	1 19 31 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:19:31
+	v_or_b32_e32 v0, s28, v0
+	.loc	1 29 35                         ; generate_rocjitsu_triton_fixtures.py:29:35
+	v_mul_lo_u32 v2, s9, v1
+	.loc	1 30 37                         ; generate_rocjitsu_triton_fixtures.py:30:37
+	v_cmp_gt_i32_e32 vcc, s8, v1
+	.loc	1 30 61 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:30:61
+	v_cmp_gt_i32_e64 s[0:1], s9, v0
+	.loc	1 29 17 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:29:17
+	v_ashrrev_i32_e32 v3, 31, v2
+	.loc	1 30 43                         ; generate_rocjitsu_triton_fixtures.py:30:43
+	s_and_b64 s[2:3], vcc, s[0:1]
+	.loc	1 29 17                         ; generate_rocjitsu_triton_fixtures.py:29:17
+	v_lshl_add_u64 v[2:3], v[2:3], 2, s[6:7]
+	.loc	1 29 39 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:29:39
+	v_ashrrev_i32_e32 v1, 31, v0
+	.loc	1 29 56                         ; generate_rocjitsu_triton_fixtures.py:29:56
+	v_cmp_eq_u32_e64 s[0:1], 0, v20
+	.loc	1 29 39                         ; generate_rocjitsu_triton_fixtures.py:29:39
+	v_lshl_add_u64 v[2:3], v[0:1], 2, v[2:3]
+	.loc	1 29 56                         ; generate_rocjitsu_triton_fixtures.py:29:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_38
+; %bb.37:
+	global_store_dword v[2:3], a0, off
+.LBB0_38:
+	.loc	1 0 56                          ; generate_rocjitsu_triton_fixtures.py:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 31 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:19:31
+	v_or_b32_e32 v1, 1, v0
+	.loc	1 30 61                         ; generate_rocjitsu_triton_fixtures.py:30:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v1
+	.loc	1 30 43 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:30:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 29 56 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:29:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_40
+; %bb.39:
+	global_store_dword v[2:3], a1, off offset:4
+.LBB0_40:
+	.loc	1 0 56 is_stmt 0                ; generate_rocjitsu_triton_fixtures.py:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 31 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:19:31
+	v_or_b32_e32 v1, 2, v0
+	.loc	1 30 61                         ; generate_rocjitsu_triton_fixtures.py:30:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v1
+	.loc	1 30 43 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:30:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 29 56 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:29:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_42
+; %bb.41:
+	global_store_dword v[2:3], a2, off offset:8
+.LBB0_42:
+	.loc	1 0 56 is_stmt 0                ; generate_rocjitsu_triton_fixtures.py:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 31 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:19:31
+	v_or_b32_e32 v1, 3, v0
+	.loc	1 30 61                         ; generate_rocjitsu_triton_fixtures.py:30:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v1
+	.loc	1 30 43 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:30:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 29 56 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:29:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_44
+; %bb.43:
+	global_store_dword v[2:3], a3, off offset:12
+.LBB0_44:
+	.loc	1 0 56 is_stmt 0                ; generate_rocjitsu_triton_fixtures.py:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 31 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:19:31
+	v_or_b32_e32 v1, 8, v0
+	.loc	1 30 61                         ; generate_rocjitsu_triton_fixtures.py:30:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v1
+	.loc	1 30 43 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:30:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 29 56 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:29:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_46
+; %bb.45:
+	global_store_dword v[2:3], a4, off offset:32
+.LBB0_46:
+	.loc	1 0 56 is_stmt 0                ; generate_rocjitsu_triton_fixtures.py:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 31 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:19:31
+	v_or_b32_e32 v1, 9, v0
+	.loc	1 30 61                         ; generate_rocjitsu_triton_fixtures.py:30:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v1
+	.loc	1 30 43 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:30:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 29 56 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:29:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_48
+; %bb.47:
+	global_store_dword v[2:3], a5, off offset:36
+.LBB0_48:
+	.loc	1 0 56 is_stmt 0                ; generate_rocjitsu_triton_fixtures.py:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 31 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:19:31
+	v_or_b32_e32 v1, 10, v0
+	.loc	1 30 61                         ; generate_rocjitsu_triton_fixtures.py:30:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v1
+	.loc	1 30 43 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:30:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 29 56 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:29:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_50
+; %bb.49:
+	global_store_dword v[2:3], a6, off offset:40
+.LBB0_50:
+	.loc	1 0 56 is_stmt 0                ; generate_rocjitsu_triton_fixtures.py:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 31 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:19:31
+	v_or_b32_e32 v1, 11, v0
+	.loc	1 30 61                         ; generate_rocjitsu_triton_fixtures.py:30:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v1
+	.loc	1 30 43 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:30:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 29 56 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:29:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_52
+; %bb.51:
+	global_store_dword v[2:3], a7, off offset:44
+.LBB0_52:
+	.loc	1 0 56 is_stmt 0                ; generate_rocjitsu_triton_fixtures.py:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 31 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:19:31
+	v_or_b32_e32 v1, 16, v0
+	.loc	1 30 61                         ; generate_rocjitsu_triton_fixtures.py:30:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v1
+	.loc	1 30 43 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:30:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 29 56 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:29:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_54
+; %bb.53:
+	global_store_dword v[2:3], a8, off offset:64
+.LBB0_54:
+	.loc	1 0 56 is_stmt 0                ; generate_rocjitsu_triton_fixtures.py:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 31 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:19:31
+	v_or_b32_e32 v1, 17, v0
+	.loc	1 30 61                         ; generate_rocjitsu_triton_fixtures.py:30:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v1
+	.loc	1 30 43 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:30:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 29 56 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:29:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_56
+; %bb.55:
+	global_store_dword v[2:3], a9, off offset:68
+.LBB0_56:
+	.loc	1 0 56 is_stmt 0                ; generate_rocjitsu_triton_fixtures.py:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 31 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:19:31
+	v_or_b32_e32 v1, 18, v0
+	.loc	1 30 61                         ; generate_rocjitsu_triton_fixtures.py:30:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v1
+	.loc	1 30 43 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:30:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 29 56 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:29:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_58
+; %bb.57:
+	global_store_dword v[2:3], a10, off offset:72
+.LBB0_58:
+	.loc	1 0 56 is_stmt 0                ; generate_rocjitsu_triton_fixtures.py:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 31 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:19:31
+	v_or_b32_e32 v1, 19, v0
+	.loc	1 30 61                         ; generate_rocjitsu_triton_fixtures.py:30:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v1
+	.loc	1 30 43 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:30:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 29 56 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:29:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_60
+; %bb.59:
+	global_store_dword v[2:3], a11, off offset:76
+.LBB0_60:
+	.loc	1 0 56 is_stmt 0                ; generate_rocjitsu_triton_fixtures.py:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 31 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:19:31
+	v_or_b32_e32 v1, 24, v0
+	.loc	1 30 61                         ; generate_rocjitsu_triton_fixtures.py:30:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v1
+	.loc	1 30 43 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:30:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 29 56 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:29:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_62
+; %bb.61:
+	global_store_dword v[2:3], a12, off offset:96
+.LBB0_62:
+	.loc	1 0 56 is_stmt 0                ; generate_rocjitsu_triton_fixtures.py:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 31 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:19:31
+	v_or_b32_e32 v1, 25, v0
+	.loc	1 30 61                         ; generate_rocjitsu_triton_fixtures.py:30:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v1
+	.loc	1 30 43 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:30:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 29 56 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:29:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_64
+; %bb.63:
+	global_store_dword v[2:3], a13, off offset:100
+.LBB0_64:
+	.loc	1 0 56 is_stmt 0                ; generate_rocjitsu_triton_fixtures.py:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 31 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:19:31
+	v_or_b32_e32 v1, 26, v0
+	.loc	1 30 61                         ; generate_rocjitsu_triton_fixtures.py:30:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v1
+	.loc	1 30 43 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:30:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 29 56 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:29:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_66
+; %bb.65:
+	global_store_dword v[2:3], a14, off offset:104
+.LBB0_66:
+	.loc	1 0 56 is_stmt 0                ; generate_rocjitsu_triton_fixtures.py:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 31 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:19:31
+	v_or_b32_e32 v0, 27, v0
+	.loc	1 30 61                         ; generate_rocjitsu_triton_fixtures.py:30:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v0
+	.loc	1 30 43 is_stmt 0               ; generate_rocjitsu_triton_fixtures.py:30:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 29 56 is_stmt 1               ; generate_rocjitsu_triton_fixtures.py:29:56
+	s_and_b64 s[0:1], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[0:1]
+	s_cbranch_execz .LBB0_68
+; %bb.67:
+	global_store_dword v[2:3], a15, off offset:108
+.LBB0_68:
+	.loc	1 29 4 is_stmt 0                ; generate_rocjitsu_triton_fixtures.py:29:4
+	s_endpgm
+.Ltmp2:
+	.section	.rodata,"a",@progbits
+	.p2align	6, 0x0
+	.amdhsa_kernel triton_cdna4_matmul_kernel
+		.amdhsa_group_segment_fixed_size 0
+		.amdhsa_private_segment_fixed_size 0
+		.amdhsa_kernarg_size 56
+		.amdhsa_user_sgpr_count 16
+		.amdhsa_user_sgpr_dispatch_ptr 0
+		.amdhsa_user_sgpr_queue_ptr 0
+		.amdhsa_user_sgpr_kernarg_segment_ptr 1
+		.amdhsa_user_sgpr_dispatch_id 0
+		.amdhsa_user_sgpr_kernarg_preload_length 14
+		.amdhsa_user_sgpr_kernarg_preload_offset 0
+		.amdhsa_user_sgpr_private_segment_size 0
+		.amdhsa_uses_dynamic_stack 0
+		.amdhsa_enable_private_segment 0
+		.amdhsa_system_sgpr_workgroup_id_x 1
+		.amdhsa_system_sgpr_workgroup_id_y 1
+		.amdhsa_system_sgpr_workgroup_id_z 0
+		.amdhsa_system_sgpr_workgroup_info 0
+		.amdhsa_system_vgpr_workitem_id 0
+		.amdhsa_next_free_vgpr 96
+		.amdhsa_next_free_sgpr 36
+		.amdhsa_accum_offset 80
+		.amdhsa_reserve_vcc 1
+		.amdhsa_reserve_xnack_mask 1
+		.amdhsa_float_round_mode_32 0
+		.amdhsa_float_round_mode_16_64 0
+		.amdhsa_float_denorm_mode_32 3
+		.amdhsa_float_denorm_mode_16_64 3
+		.amdhsa_dx10_clamp 1
+		.amdhsa_ieee_mode 1
+		.amdhsa_fp16_overflow 0
+		.amdhsa_tg_split 0
+		.amdhsa_exception_fp_ieee_invalid_op 0
+		.amdhsa_exception_fp_denorm_src 0
+		.amdhsa_exception_fp_ieee_div_zero 0
+		.amdhsa_exception_fp_ieee_overflow 0
+		.amdhsa_exception_fp_ieee_underflow 0
+		.amdhsa_exception_fp_ieee_inexact 0
+		.amdhsa_exception_int_div_zero 0
+	.end_amdhsa_kernel
+	.text
+.Lfunc_end0:
+	.size	triton_cdna4_matmul_kernel, .Lfunc_end0-triton_cdna4_matmul_kernel
+	.cfi_endproc
+                                        ; -- End function
+	.set triton_cdna4_matmul_kernel.num_vgpr, 78
+	.set triton_cdna4_matmul_kernel.num_agpr, 16
+	.set triton_cdna4_matmul_kernel.numbered_sgpr, 36
+	.set triton_cdna4_matmul_kernel.num_named_barrier, 0
+	.set triton_cdna4_matmul_kernel.private_seg_size, 0
+	.set triton_cdna4_matmul_kernel.uses_vcc, 1
+	.set triton_cdna4_matmul_kernel.uses_flat_scratch, 0
+	.set triton_cdna4_matmul_kernel.has_dyn_sized_stack, 0
+	.set triton_cdna4_matmul_kernel.has_recursion, 0
+	.set triton_cdna4_matmul_kernel.has_indirect_call, 0
+	.section	.AMDGPU.csdata,"",@progbits
+; Kernel info:
+; codeLenInByte = 3044
+; TotalNumSgprs: 42
+; NumVgprs: 78
+; NumAgprs: 16
+; TotalNumVgprs: 96
+; ScratchSize: 0
+; MemoryBound: 0
+; FloatMode: 240
+; IeeeMode: 1
+; LDSByteSize: 0 bytes/workgroup (compile time only)
+; SGPRBlocks: 5
+; VGPRBlocks: 11
+; NumSGPRsForWavesPerEU: 42
+; NumVGPRsForWavesPerEU: 96
+; AccumOffset: 80
+; Occupancy: 5
+; WaveLimiterHint : 0
+; COMPUTE_PGM_RSRC2:SCRATCH_EN: 0
+; COMPUTE_PGM_RSRC2:USER_SGPR: 16
+; COMPUTE_PGM_RSRC2:TRAP_HANDLER: 0
+; COMPUTE_PGM_RSRC2:TGID_X_EN: 1
+; COMPUTE_PGM_RSRC2:TGID_Y_EN: 1
+; COMPUTE_PGM_RSRC2:TGID_Z_EN: 0
+; COMPUTE_PGM_RSRC2:TIDIG_COMP_CNT: 0
+; COMPUTE_PGM_RSRC3_GFX90A:ACCUM_OFFSET: 19
+; COMPUTE_PGM_RSRC3_GFX90A:TG_SPLIT: 0
+	.text
+	.p2alignl 6, 3212836864
+	.fill 256, 4, 3212836864
+	.section	.AMDGPU.gpr_maximums,"",@progbits
+	.set amdgpu.max_num_vgpr, 0
+	.set amdgpu.max_num_agpr, 0
+	.set amdgpu.max_num_sgpr, 0
+	.text
+	.section	.debug_abbrev,"",@progbits
+	.byte	1                               ; Abbreviation Code
+	.byte	17                              ; DW_TAG_compile_unit
+	.byte	0                               ; DW_CHILDREN_no
+	.byte	37                              ; DW_AT_producer
+	.byte	14                              ; DW_FORM_strp
+	.byte	19                              ; DW_AT_language
+	.byte	5                               ; DW_FORM_data2
+	.byte	3                               ; DW_AT_name
+	.byte	14                              ; DW_FORM_strp
+	.byte	16                              ; DW_AT_stmt_list
+	.byte	23                              ; DW_FORM_sec_offset
+	.byte	27                              ; DW_AT_comp_dir
+	.byte	14                              ; DW_FORM_strp
+	.byte	17                              ; DW_AT_low_pc
+	.byte	1                               ; DW_FORM_addr
+	.byte	18                              ; DW_AT_high_pc
+	.byte	6                               ; DW_FORM_data4
+	.byte	0                               ; EOM(1)
+	.byte	0                               ; EOM(2)
+	.byte	0                               ; EOM(3)
+	.section	.debug_info,"",@progbits
+.Lcu_begin0:
+	.long	.Ldebug_info_end0-.Ldebug_info_start0 ; Length of Unit
+.Ldebug_info_start0:
+	.short	4                               ; DWARF version number
+	.long	.debug_abbrev                   ; Offset Into Abbrev. Section
+	.byte	8                               ; Address Size (in bytes)
+	.byte	1                               ; Abbrev [1] 0xb:0x1f DW_TAG_compile_unit
+	.long	.Linfo_string0                  ; DW_AT_producer
+	.short	2                               ; DW_AT_language
+	.long	.Linfo_string1                  ; DW_AT_name
+	.long	.Lline_table_start0             ; DW_AT_stmt_list
+	.long	.Linfo_string2                  ; DW_AT_comp_dir
+	.quad	.Lfunc_begin0                   ; DW_AT_low_pc
+	.long	.Lfunc_end0-.Lfunc_begin0       ; DW_AT_high_pc
+.Ldebug_info_end0:
+	.section	.debug_str,"MS",@progbits,1
+.Linfo_string0:
+	.asciz	"triton"                        ; string offset=0
+.Linfo_string1:
+	.asciz	"generate_rocjitsu_triton_fixtures.py" ; string offset=7
+.Linfo_string2:
+	.asciz	"/tmp"                          ; string offset=44
+	.section	".note.GNU-stack","",@progbits
+	.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .agpr_count:     16
+    .args:
+      - .address_space:  global
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .address_space:  global
+        .offset:         8
+        .size:           8
+        .value_kind:     global_buffer
+      - .address_space:  global
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .offset:         24
+        .size:           4
+        .value_kind:     by_value
+      - .offset:         28
+        .size:           4
+        .value_kind:     by_value
+      - .offset:         32
+        .size:           4
+        .value_kind:     by_value
+      - .address_space:  global
+        .offset:         40
+        .size:           8
+        .value_kind:     global_buffer
+      - .address_space:  global
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+    .group_segment_fixed_size: 0
+    .kernarg_segment_align: 8
+    .kernarg_segment_size: 56
+    .max_flat_workgroup_size: 256
+    .name:           triton_cdna4_matmul_kernel
+    .private_segment_fixed_size: 0
+    .sgpr_count:     42
+    .sgpr_spill_count: 0
+    .symbol:         triton_cdna4_matmul_kernel.kd
+    .uniform_work_group_size: 1
+    .uses_dynamic_stack: false
+    .vgpr_count:     96
+    .vgpr_spill_count: 0
+    .wavefront_size: 64
+amdhsa.target:   amdgcn-amd-amdhsa--gfx942
+amdhsa.version:
+  - 1
+  - 2
+...
+
+	.end_amdgpu_metadata
+	.section	.debug_line,"",@progbits
+.Lline_table_start0:

--- a/emulation/rocjitsu/tests/kernels/triton_cdna4_flash_attention_buffer_async_1024.s
+++ b/emulation/rocjitsu/tests/kernels/triton_cdna4_flash_attention_buffer_async_1024.s
@@ -1,0 +1,2662 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// Reproduction information for this checked-in assembly fixture.
+// The original source used to generate this assembly is embedded here
+// as comments so normal builds do not need Python, Torch, or Triton.
+//
+// --- begin tests/kernels/triton/flash_attention.py ---
+// """Triton flash-attention kernels for DBT compile stress tests.
+//
+// This file is intentionally source-only: it does not register tests or change
+// the kernel CMake flow.  The kernels below are small fp16 forward kernels for a
+// single Q/K/V/O matrix pair with explicit row/feature strides.  They are meant to
+// exercise instruction decoding/translation paths when compiled with AMD Triton,
+// not to be a production attention implementation.
+//
+// The async/buffer variant uses AMD Triton backend options that are intended to
+// select the desired lowering.  The final instruction spelling is compiler-build
+// dependent, so verify generated assembly with compile_fixtures.py:
+//
+//   AMDGCN_USE_BUFFER_OPS=1
+//       Run pointer canonicalization and conversion to AMDGPU buffer ops.
+//
+//   TRITON_HIP_USE_ASYNC_COPY=1
+//       Prefer the async global-to-LDS copy pipeline.
+//
+// For best buffer-load vectorization, pass compact test tensors with feature
+// strides of one for Q/K/V/O and 16-byte-aligned base pointers.
+// """
+//
+// # Recorded async-buffer fixture metadata:
+// #   kernel: flash_attention_fwd_async_buffer_kernel
+// #   target: gfx950, wavefront_size: 64
+// #   launch sharedMemBytes used by cdna4_to_cdna3_dispatch_test: 65536
+// #   amdhsa_group_segment_fixed_size: 0
+// #   max_flat_workgroup_size: 256
+// #   kernarg_segment_size: 56
+// #   registers: vgpr_count=156, agpr_count=32, sgpr_count=31
+//
+// import triton
+// import triton.language as tl
+//
+//
+// TARGET_ARCH = "gfx950"
+// DEFAULT_Q_LEN = 1024
+// DEFAULT_KV_LEN = 1024
+// DEFAULT_HEAD_DIM = 64
+// DEFAULT_BLOCK_M = 64
+// DEFAULT_BLOCK_N = 64
+// DEFAULT_BLOCK_D = 64
+// DEFAULT_STRIDE_QM = DEFAULT_HEAD_DIM
+// DEFAULT_STRIDE_QD = 1
+// DEFAULT_STRIDE_KN = DEFAULT_HEAD_DIM
+// DEFAULT_STRIDE_KD = 1
+// DEFAULT_STRIDE_VN = DEFAULT_HEAD_DIM
+// DEFAULT_STRIDE_VD = 1
+// DEFAULT_STRIDE_OM = DEFAULT_HEAD_DIM
+// DEFAULT_STRIDE_OD = 1
+//
+// NO_ASYNC_ENV = {
+//     "TRITON_HIP_USE_ASYNC_COPY": "0",
+//     "AMDGCN_USE_BUFFER_OPS": "0",
+// }
+// ASYNC_BUFFER_ENV = {
+//     "TRITON_HIP_USE_ASYNC_COPY": "1",
+//     "AMDGCN_USE_BUFFER_OPS": "1",
+// }
+// COMMON_HIP_OPTIONS = {
+//     "num_warps": 4,
+//     "num_stages": 2,
+//     # The attention scheduler hint is local to the AMD backend and is useful
+//     # for avoiding spills in the generated stress fixture.
+//     "schedule_hint": "attention",
+// }
+//
+//
+// @triton.jit
+// def flash_attention_fwd_no_async_kernel(
+//     q_ptr,
+//     k_ptr,
+//     v_ptr,
+//     o_ptr,
+//     stride_qm: tl.constexpr,
+//     stride_qd: tl.constexpr,
+//     stride_kn: tl.constexpr,
+//     stride_kd: tl.constexpr,
+//     stride_vn: tl.constexpr,
+//     stride_vd: tl.constexpr,
+//     stride_om: tl.constexpr,
+//     stride_od: tl.constexpr,
+//     softmax_scale,
+//     Q_LEN: tl.constexpr,
+//     KV_LEN: tl.constexpr,
+//     HEAD_DIM: tl.constexpr,
+//     BLOCK_M: tl.constexpr,
+//     BLOCK_N: tl.constexpr,
+//     BLOCK_D: tl.constexpr,
+// ):
+//     """Plain blockwise flash attention.
+//
+//     Compile this variant with TRITON_HIP_USE_ASYNC_COPY=0 when the test should
+//     avoid AMD's async global-to-LDS lowering.  The loop also uses one stage so
+//     the source itself does not request Triton loop pipelining.
+//     """
+//
+//     tl.static_assert(BLOCK_M >= 64)
+//     tl.static_assert(BLOCK_N >= 64)
+//     tl.static_assert(BLOCK_D >= 64)
+//     tl.static_assert(BLOCK_D >= HEAD_DIM)
+//
+//     pid_m = tl.program_id(0)
+//     offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+//     offs_n = tl.arange(0, BLOCK_N)
+//     offs_d = tl.arange(0, BLOCK_D)
+//
+//     q_mask = (offs_m[:, None] < Q_LEN) & (offs_d[None, :] < HEAD_DIM)
+//     q = tl.load(
+//         q_ptr + offs_m[:, None] * stride_qm + offs_d[None, :] * stride_qd,
+//         mask=q_mask,
+//         other=0.0,
+//     )
+//
+//     # The online softmax state follows the FlashAttention recurrence.  A large
+//     # finite negative sentinel avoids inf - inf when the last program block has
+//     # rows outside Q_LEN; those rows are masked on store.
+//     m_i = tl.full((BLOCK_M,), -1.0e20, tl.float32)
+//     l_i = tl.zeros((BLOCK_M,), tl.float32)
+//     acc = tl.zeros((BLOCK_M, BLOCK_D), tl.float32)
+//
+//     # exp2 is the path used by Triton attention examples; convert the caller's
+//     # natural-exp scale once so the recurrence remains mathematically standard.
+//     qk_scale = softmax_scale * 1.4426950408889634
+//
+//     for start_n in tl.range(0, KV_LEN, BLOCK_N, num_stages=1):
+//         start_n = tl.multiple_of(start_n, BLOCK_N)
+//         n = start_n + offs_n
+//
+//         k_mask = (n[None, :] < KV_LEN) & (offs_d[:, None] < HEAD_DIM)
+//         k = tl.load(
+//             k_ptr + n[None, :] * stride_kn + offs_d[:, None] * stride_kd,
+//             mask=k_mask,
+//             other=0.0,
+//         )
+//
+//         qk = tl.dot(q, k, out_dtype=tl.float32) * qk_scale
+//         qk = tl.where((offs_m[:, None] < Q_LEN) & (n[None, :] < KV_LEN), qk, -1.0e20)
+//
+//         m_new = tl.maximum(m_i, tl.max(qk, axis=1))
+//         alpha = tl.math.exp2(m_i - m_new)
+//         p = tl.math.exp2(qk - m_new[:, None])
+//         l_new = l_i * alpha + tl.sum(p, axis=1)
+//
+//         v_mask = (n[:, None] < KV_LEN) & (offs_d[None, :] < HEAD_DIM)
+//         v = tl.load(
+//             v_ptr + n[:, None] * stride_vn + offs_d[None, :] * stride_vd,
+//             mask=v_mask,
+//             other=0.0,
+//         )
+//
+//         acc = acc * alpha[:, None]
+//         acc = tl.dot(p.to(tl.float16), v, acc, out_dtype=tl.float32)
+//         m_i = m_new
+//         l_i = l_new
+//
+//     out = acc / l_i[:, None]
+//     o_mask = (offs_m[:, None] < Q_LEN) & (offs_d[None, :] < HEAD_DIM)
+//     tl.store(
+//         o_ptr + offs_m[:, None] * stride_om + offs_d[None, :] * stride_od,
+//         out,
+//         mask=o_mask,
+//     )
+//
+//
+// @triton.jit
+// def flash_attention_fwd_async_buffer_kernel(
+//     q_ptr,
+//     k_ptr,
+//     v_ptr,
+//     o_ptr,
+//     stride_qm: tl.constexpr,
+//     stride_qd: tl.constexpr,
+//     stride_kn: tl.constexpr,
+//     stride_kd: tl.constexpr,
+//     stride_vn: tl.constexpr,
+//     stride_vd: tl.constexpr,
+//     stride_om: tl.constexpr,
+//     stride_od: tl.constexpr,
+//     softmax_scale,
+//     Q_LEN: tl.constexpr,
+//     KV_LEN: tl.constexpr,
+//     HEAD_DIM: tl.constexpr,
+//     BLOCK_M: tl.constexpr,
+//     BLOCK_N: tl.constexpr,
+//     BLOCK_D: tl.constexpr,
+// ):
+//     """Blockwise flash attention shaped for AMD buffer ops plus async DMA.
+//
+//     The math matches flash_attention_fwd_no_async_kernel.  Strides are
+//     constexpr so the fixture compiler can model compact contiguous tensors and
+//     keep address expressions simple enough for AMD buffer-op lowering.
+//     """
+//
+//     tl.static_assert(BLOCK_M >= 64)
+//     tl.static_assert(BLOCK_N >= 64)
+//     tl.static_assert(BLOCK_D >= 64)
+//     tl.static_assert(BLOCK_D >= HEAD_DIM)
+//
+//     pid_m = tl.program_id(0)
+//     offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int32)
+//     offs_n = tl.arange(0, BLOCK_N).to(tl.int32)
+//     offs_d = tl.max_contiguous(tl.arange(0, BLOCK_D), BLOCK_D).to(tl.int32)
+//
+//     q_offsets = offs_m[:, None] * stride_qm + offs_d[None, :] * stride_qd
+//     q_mask = (offs_m[:, None] < Q_LEN) & (offs_d[None, :] < HEAD_DIM)
+//     q = tl.load(q_ptr + q_offsets, mask=q_mask, other=0.0)
+//
+//     m_i = tl.full((BLOCK_M,), -1.0e20, tl.float32)
+//     l_i = tl.zeros((BLOCK_M,), tl.float32)
+//     acc = tl.zeros((BLOCK_M, BLOCK_D), tl.float32)
+//     qk_scale = softmax_scale * 1.4426950408889634
+//
+//     # num_stages=2 marks this as a pipelined loop in the source.  When launched
+//     # with num_stages=2 and AMD async-copy knobs enabled, the backend has the
+//     # information it needs to choose buffer-load-to-LDS for eligible K/V loads.
+//     for start_n in tl.range(0, KV_LEN, BLOCK_N, num_stages=2):
+//         start_n = tl.multiple_of(start_n, BLOCK_N)
+//         n = (start_n + offs_n).to(tl.int32)
+//
+//         k_offsets = n[None, :] * stride_kn + offs_d[:, None] * stride_kd
+//         k_mask = (n[None, :] < KV_LEN) & (offs_d[:, None] < HEAD_DIM)
+//         k = tl.load(k_ptr + k_offsets, mask=k_mask, other=0.0)
+//
+//         qk = tl.dot(q, k, out_dtype=tl.float32) * qk_scale
+//         qk = tl.where((offs_m[:, None] < Q_LEN) & (n[None, :] < KV_LEN), qk, -1.0e20)
+//
+//         m_new = tl.maximum(m_i, tl.max(qk, axis=1))
+//         alpha = tl.math.exp2(m_i - m_new)
+//         p = tl.math.exp2(qk - m_new[:, None])
+//         l_new = l_i * alpha + tl.sum(p, axis=1)
+//
+//         v_offsets = n[:, None] * stride_vn + offs_d[None, :] * stride_vd
+//         v_mask = (n[:, None] < KV_LEN) & (offs_d[None, :] < HEAD_DIM)
+//         v = tl.load(v_ptr + v_offsets, mask=v_mask, other=0.0)
+//
+//         acc = acc * alpha[:, None]
+//         acc = tl.dot(p.to(tl.float16), v, acc, out_dtype=tl.float32)
+//         m_i = m_new
+//         l_i = l_new
+//
+//     o_offsets = offs_m[:, None] * stride_om + offs_d[None, :] * stride_od
+//     out = acc / l_i[:, None]
+//     o_mask = (offs_m[:, None] < Q_LEN) & (offs_d[None, :] < HEAD_DIM)
+//     tl.store(o_ptr + o_offsets, out, mask=o_mask)
+//
+//
+// def flash_attention_grid(q_len=DEFAULT_Q_LEN, block_m=DEFAULT_BLOCK_M):
+//     return (triton.cdiv(q_len, block_m),)
+//
+//
+// __all__ = [
+//     "ASYNC_BUFFER_ENV",
+//     "COMMON_HIP_OPTIONS",
+//     "DEFAULT_BLOCK_D",
+//     "DEFAULT_BLOCK_M",
+//     "DEFAULT_BLOCK_N",
+//     "DEFAULT_HEAD_DIM",
+//     "DEFAULT_KV_LEN",
+//     "DEFAULT_Q_LEN",
+//     "DEFAULT_STRIDE_KD",
+//     "DEFAULT_STRIDE_KN",
+//     "DEFAULT_STRIDE_OD",
+//     "DEFAULT_STRIDE_OM",
+//     "DEFAULT_STRIDE_QD",
+//     "DEFAULT_STRIDE_QM",
+//     "DEFAULT_STRIDE_VD",
+//     "DEFAULT_STRIDE_VN",
+//     "NO_ASYNC_ENV",
+//     "TARGET_ARCH",
+//     "flash_attention_fwd_async_buffer_kernel",
+//     "flash_attention_fwd_no_async_kernel",
+//     "flash_attention_grid",
+// ]
+// --- end tests/kernels/triton/flash_attention.py ---
+
+	.amdgcn_target "amdgcn-amd-amdhsa--gfx950"
+	.amdhsa_code_object_version 5
+	.text
+	.globl	flash_attention_fwd_async_buffer_kernel ; -- Begin function flash_attention_fwd_async_buffer_kernel
+	.p2align	8
+	.type	flash_attention_fwd_async_buffer_kernel,@function
+flash_attention_fwd_async_buffer_kernel: ; @flash_attention_fwd_async_buffer_kernel
+.Lfunc_begin0:
+	.cfi_sections .debug_frame
+	.cfi_startproc
+; %bb.3:
+	.file	1 "/home/kunwar/Work/runtime-evolution/rocm-systems-rocjitsu-register-feedback/emulation/rocjitsu/tests/kernels/triton" "flash_attention.py"
+	.loc	1 160 0 prologue_end            ; flash_attention.py:160:0
+	s_load_dwordx2 s[2:3], s[0:1], 0x0
+	s_load_dwordx8 s[4:11], s[0:1], 0x8
+	s_load_dwordx4 s[12:15], s[0:1], 0x28
+	s_waitcnt lgkmcnt(0)
+	s_branch .LBB0_0
+	.loc	1 0 0 is_stmt 0                 ; :0:0
+.Ltmp0:
+	.p2align	8
+; %bb.4:
+.LBB0_0:
+.Ltmp1:
+	.loc	1 198 53 is_stmt 1              ; flash_attention.py:198:53
+	v_lshlrev_b32_e32 v11, 3, v0
+	.loc	1 194 45                        ; flash_attention.py:194:45
+	v_lshrrev_b32_e32 v1, 3, v0
+	.loc	1 198 53                        ; flash_attention.py:198:53
+	v_and_b32_e32 v3, 56, v11
+	.loc	1 194 22                        ; flash_attention.py:194:22
+	s_lshl_b32 s17, s16, 6
+	.loc	1 200 24                        ; flash_attention.py:200:24
+	s_lshl_b32 s11, s16, 12
+	v_lshl_or_b32 v41, v1, 6, v3
+	s_mov_b64 s[12:13], s[6:7]
+	.loc	1 194 32                        ; flash_attention.py:194:32
+	v_or_b32_e32 v2, s17, v1
+	s_movk_i32 s6, 0x400
+	.loc	1 200 24                        ; flash_attention.py:200:24
+	v_or_b32_e32 v1, 0x800, v41
+	v_or_b32_e32 v3, s11, v41
+	s_mov_b64 s[0:1], s[2:3]
+	v_or_b32_e32 v4, s11, v1
+	.loc	1 200 16 is_stmt 0              ; flash_attention.py:200:16
+	v_lshlrev_b32_e32 v3, 1, v3
+	v_bfrev_b32_e32 v42, 1
+	.loc	1 199 32 is_stmt 1              ; flash_attention.py:199:32
+	v_cmp_gt_i32_e32 vcc, s6, v2
+	.loc	1 200 16                        ; flash_attention.py:200:16
+	s_and_b32 s1, s1, 0xffff
+	s_mov_b32 s3, 0x27000
+	s_mov_b32 s2, 0x7ffffffe
+	v_cndmask_b32_e32 v10, v42, v3, vcc
+	v_lshlrev_b32_e32 v2, 1, v4
+	v_cndmask_b32_e32 v12, v42, v2, vcc
+	buffer_load_dwordx4 v[2:5], v10, s[0:3], 0 offen
+	buffer_load_dwordx4 v[6:9], v12, s[0:3], 0 offen
+	v_lshlrev_b32_e32 v10, 4, v0
+	v_and_b32_e32 v12, 0x70, v0
+	v_xad_u32 v15, v10, v12, 0
+	.loc	1 230 28                        ; flash_attention.py:230:28
+	v_lshlrev_b32_e32 v33, 1, v0
+	.loc	1 194 45                        ; flash_attention.py:194:45
+	v_and_b32_e32 v32, 64, v0
+	v_and_b32_e32 v46, 32, v0
+	v_and_b32_e32 v45, 31, v0
+	.loc	1 200 16                        ; flash_attention.py:200:16
+	v_and_b32_e32 v36, 0x70, v11
+	v_lshrrev_b32_e32 v37, 1, v46
+	v_lshlrev_b32_e32 v10, 6, v32
+	.loc	1 216 20                        ; flash_attention.py:216:20
+	v_lshrrev_b32_e32 v12, 1, v12
+	s_movk_i32 s0, 0x60
+	.loc	1 200 16                        ; flash_attention.py:200:16
+	v_lshlrev_b32_e32 v35, 7, v45
+	v_bitop3_b32 v10, v36, v10, v37 bitop3:0xde
+	.loc	1 216 20                        ; flash_attention.py:216:20
+	v_xor_b32_e32 v12, v11, v12
+	.loc	1 200 16                        ; flash_attention.py:200:16
+	v_or_b32_e32 v13, v10, v35
+	v_bitop3_b32 v10, v10, s0, v35 bitop3:0x36
+	.loc	1 216 20                        ; flash_attention.py:216:20
+	v_sub_u32_e32 v12, v12, v11
+	.loc	1 194 45                        ; flash_attention.py:194:45
+	v_and_b32_e32 v14, 63, v0
+	.loc	1 200 16                        ; flash_attention.py:200:16
+	v_add_u32_e32 v19, 0, v10
+	.loc	1 216 20                        ; flash_attention.py:216:20
+	v_ashrrev_i32_e32 v10, 3, v12
+	v_add_u32_e32 v10, v10, v14
+	.loc	1 200 16                        ; flash_attention.py:200:16
+	v_add_u32_e32 v16, 0, v13
+	v_xad_u32 v17, v13, 32, 0
+	v_xad_u32 v18, v13, 64, 0
+	.loc	1 216 20                        ; flash_attention.py:216:20
+	v_lshlrev_b32_e32 v51, 2, v10
+	v_lshrrev_b64 v[12:13], v10, exec
+	ds_bpermute_b32 v13, v51, v41
+	ds_bpermute_b32 v1, v51, v1
+	s_movk_i32 s1, 0x1c0
+	.loc	1 230 20                        ; flash_attention.py:230:20
+	v_readfirstlane_b32 s7, v0
+	.loc	1 198 53                        ; flash_attention.py:198:53
+	v_lshlrev_b32_e32 v34, 1, v45
+	.loc	1 230 20                        ; flash_attention.py:230:20
+	s_bfe_u32 s19, s7, 0x20006
+	.loc	1 230 28 is_stmt 0              ; flash_attention.py:230:28
+	v_and_or_b32 v50, v33, s1, v34
+	.loc	1 216 20 is_stmt 1              ; flash_attention.py:216:20
+	v_and_b32_e32 v12, 1, v12
+	s_lshl_b32 s16, s19, 10
+	s_waitcnt lgkmcnt(1)
+	v_lshlrev_b32_e32 v13, 1, v13
+	s_waitcnt lgkmcnt(0)
+	v_lshlrev_b32_e32 v1, 1, v1
+	v_cmp_eq_u32_e32 vcc, 1, v12
+	s_and_b32 s5, s5, 0xffff
+	s_add_i32 s7, s16, 0
+	v_cndmask_b32_e32 v12, v42, v13, vcc
+	v_cndmask_b32_e32 v1, v42, v1, vcc
+	.loc	1 230 28                        ; flash_attention.py:230:28
+	v_or_b32_e32 v38, 0x200, v50
+	.loc	1 216 20                        ; flash_attention.py:216:20
+	s_mov_b32 s0, s4
+	s_mov_b32 s1, s5
+	s_mov_b32 m0, s7
+	.loc	1 230 20                        ; flash_attention.py:230:20
+	s_and_b32 s13, s13, 0xffff
+	s_mov_b32 s14, s2
+	s_mov_b32 s15, s3
+	.loc	1 230 28 is_stmt 0              ; flash_attention.py:230:28
+	v_or_b32_e32 v13, 0xa00, v50
+	v_or_b32_e32 v39, 0xe00, v50
+	.loc	1 194 45 is_stmt 1              ; flash_attention.py:194:45
+	v_lshrrev_b32_e32 v47, 1, v32
+	v_bitop3_b32 v62, v35, v37, v36 bitop3:0x36
+	s_mov_b32 s18, 0
+	.loc	1 216 20                        ; flash_attention.py:216:20
+	v_mov_b32_e32 v53, 0
+	.loc	1 210 48                        ; flash_attention.py:210:48
+	v_accvgpr_write_b32 a15, 0
+	v_accvgpr_write_b32 a14, 0
+	v_accvgpr_write_b32 a13, 0
+	v_accvgpr_write_b32 a12, 0
+	v_accvgpr_write_b32 a11, 0
+	v_accvgpr_write_b32 a10, 0
+	v_accvgpr_write_b32 a9, 0
+	.loc	1 200 16                        ; flash_attention.py:200:16
+	s_waitcnt vmcnt(1)
+	ds_write_b128 v15, v[2:5]
+	s_waitcnt vmcnt(0)
+	ds_write_b128 v15, v[6:9] offset:4096
+	.loc	1 230 20                        ; flash_attention.py:230:20
+	v_lshrrev_b32_e32 v2, 4, v0
+	v_bitop3_b32 v2, v33, v2, 12 bitop3:0x78
+	v_xor_b32_e32 v5, 0x210, v2
+	v_sub_u32_e32 v5, v5, v33
+	v_add_u32_e32 v5, 0xfffffe00, v5
+	v_ashrrev_i32_e32 v6, 1, v5
+	v_xor_b32_e32 v5, 0x610, v2
+	v_sub_u32_e32 v5, v5, v33
+	v_add_u32_e32 v5, 0xfffffa00, v5
+	v_sub_u32_e32 v4, v2, v33
+	v_ashrrev_i32_e32 v8, 1, v5
+	v_xor_b32_e32 v5, 0xa10, v2
+	v_xor_b32_e32 v2, 0xe10, v2
+	v_sub_u32_e32 v2, v2, v33
+	v_ashrrev_i32_e32 v4, 1, v4
+	v_sub_u32_e32 v5, v5, v33
+	v_add_u32_e32 v2, 0xfffff200, v2
+	v_add_u32_e32 v5, 0xfffff600, v5
+	v_ashrrev_i32_e32 v43, 1, v2
+	v_add_u32_e32 v2, v4, v14
+	v_ashrrev_i32_e32 v40, 1, v5
+	v_lshlrev_b32_e32 v54, 2, v2
+	v_lshrrev_b64 v[4:5], v2, exec
+	ds_bpermute_b32 v7, v54, v50
+	v_and_b32_e32 v4, 1, v4
+	v_cmp_eq_u32_e32 vcc, 1, v4
+	v_add_u32_e32 v4, v6, v14
+	v_lshlrev_b32_e32 v55, 2, v4
+	.loc	1 200 16                        ; flash_attention.py:200:16
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	ds_read_b128 v[28:31], v16
+	ds_read_b128 v[24:27], v17
+	ds_read_b128 v[20:23], v18
+	ds_read_b128 v[16:19], v19
+	.loc	1 216 20                        ; flash_attention.py:216:20
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	buffer_load_dwordx4 v12, s[0:3], 0 offen lds
+	s_add_i32 m0, s7, 0x1000
+	.loc	1 230 20                        ; flash_attention.py:230:20
+	ds_bpermute_b32 v9, v55, v38
+	.loc	1 216 20                        ; flash_attention.py:216:20
+	buffer_load_dwordx4 v1, s[0:3], 0 offen lds
+	.loc	1 230 20                        ; flash_attention.py:230:20
+	s_mul_i32 s0, s19, 0xfffffd00
+	s_add_i32 s7, s7, s0
+	v_lshlrev_b32_e32 v5, 1, v7
+	s_add_i32 m0, s7, 0x4000
+	v_cndmask_b32_e32 v5, v42, v5, vcc
+	v_lshrrev_b64 v[6:7], v4, exec
+	.loc	1 230 28 is_stmt 0              ; flash_attention.py:230:28
+	v_or_b32_e32 v1, 0x400, v50
+	.loc	1 230 20                        ; flash_attention.py:230:20
+	buffer_load_dword v5, s[12:15], 0 offen lds
+	v_and_b32_e32 v5, 1, v6
+	s_waitcnt lgkmcnt(0)
+	v_lshlrev_b32_e32 v6, 1, v9
+	ds_bpermute_b32 v1, v54, v1
+	v_cmp_eq_u32_e64 s[0:1], 1, v5
+	.loc	1 230 28                        ; flash_attention.py:230:28
+	v_or_b32_e32 v3, 0x600, v50
+	v_or_b32_e32 v12, 0x800, v50
+	.loc	1 230 20                        ; flash_attention.py:230:20
+	v_cndmask_b32_e64 v5, v42, v6, s[0:1]
+	v_add_u32_e32 v6, v8, v14
+	v_lshlrev_b32_e32 v56, 2, v6
+	ds_bpermute_b32 v3, v56, v3
+	s_add_i32 m0, s7, 0x4400
+	s_waitcnt lgkmcnt(1)
+	v_lshlrev_b32_e32 v1, 1, v1
+	buffer_load_dword v5, s[12:15], 0 offen lds
+	s_add_i32 m0, s7, 0x4800
+	v_cndmask_b32_e32 v1, v42, v1, vcc
+	v_lshrrev_b64 v[8:9], v6, exec
+	ds_bpermute_b32 v5, v54, v12
+	buffer_load_dword v1, s[12:15], 0 offen lds
+	v_and_b32_e32 v1, 1, v8
+	v_add_u32_e32 v8, v40, v14
+	s_waitcnt lgkmcnt(1)
+	v_lshlrev_b32_e32 v3, 1, v3
+	v_cmp_eq_u32_e64 s[0:1], 1, v1
+	v_lshlrev_b32_e32 v57, 2, v8
+	s_add_i32 m0, s7, 0x4c00
+	v_cndmask_b32_e64 v1, v42, v3, s[0:1]
+	ds_bpermute_b32 v3, v57, v13
+	.loc	1 230 28                        ; flash_attention.py:230:28
+	v_or_b32_e32 v15, 0xc00, v50
+	.loc	1 230 20                        ; flash_attention.py:230:20
+	buffer_load_dword v1, s[12:15], 0 offen lds
+	s_waitcnt lgkmcnt(1)
+	v_lshlrev_b32_e32 v1, 1, v5
+	s_add_i32 m0, s7, 0x5000
+	v_cndmask_b32_e32 v1, v42, v1, vcc
+	v_lshrrev_b64 v[12:13], v8, exec
+	ds_bpermute_b32 v5, v54, v15
+	buffer_load_dword v1, s[12:15], 0 offen lds
+	v_and_b32_e32 v1, 1, v12
+	v_add_u32_e32 v12, v43, v14
+	s_waitcnt lgkmcnt(1)
+	v_lshlrev_b32_e32 v3, 1, v3
+	v_cmp_eq_u32_e64 s[0:1], 1, v1
+	v_lshlrev_b32_e32 v58, 2, v12
+	s_add_i32 m0, s7, 0x5400
+	v_cndmask_b32_e64 v1, v42, v3, s[0:1]
+	ds_bpermute_b32 v3, v58, v39
+	buffer_load_dword v1, s[12:15], 0 offen lds
+	s_waitcnt lgkmcnt(1)
+	v_lshlrev_b32_e32 v1, 1, v5
+	s_add_i32 m0, s7, 0x5800
+	v_cndmask_b32_e32 v1, v42, v1, vcc
+	v_lshrrev_b64 v[14:15], v12, exec
+	buffer_load_dword v1, s[12:15], 0 offen lds
+	v_and_b32_e32 v1, 1, v14
+	s_waitcnt lgkmcnt(0)
+	v_lshlrev_b32_e32 v3, 1, v3
+	v_cmp_eq_u32_e32 vcc, 1, v1
+	s_add_i32 m0, s7, 0x5c00
+	s_movk_i32 s0, 0x210
+	v_cndmask_b32_e32 v1, v42, v3, vcc
+	buffer_load_dword v1, s[12:15], 0 offen lds
+	.loc	1 194 32 is_stmt 1              ; flash_attention.py:194:32
+	v_or3_b32 v3, s17, v45, v47
+	.loc	1 194 45 is_stmt 0              ; flash_attention.py:194:45
+	v_bfe_i32 v1, v0, 5, 1
+	.loc	1 199 32 is_stmt 1              ; flash_attention.py:199:32
+	v_cmp_gt_i32_e32 vcc, s6, v3
+	.loc	1 205 31                        ; flash_attention.py:205:31
+	v_mov_b32_e32 v3, 0x3fb8aa3b
+	.loc	1 194 45                        ; flash_attention.py:194:45
+	v_and_b32_e32 v40, 0x80, v0
+	.loc	1 205 31                        ; flash_attention.py:205:31
+	v_mul_f32_e32 v52, s10, v3
+	v_lshlrev_b32_e32 v3, 5, v0
+	v_and_b32_e32 v5, 24, v11
+	v_and_b32_e32 v7, 0x48, v0
+	v_and_b32_e32 v11, 0x210, v1
+	v_bitop3_b32 v1, v1, v34, s0 bitop3:0x6c
+	v_bfe_i32 v0, v0, 3, 1
+	s_movk_i32 s0, 0x108
+	s_movk_i32 s1, 0x180
+	v_bitop3_b32 v0, v0, v5, s0 bitop3:0x6c
+	v_and_or_b32 v13, v3, s1, v5
+	v_and_b32_e32 v3, 0x80, v3
+	v_xor_b32_e32 v0, v0, v11
+	v_lshrrev_b32_e32 v5, 1, v40
+	v_and_b32_e32 v9, 32, v33
+	v_or3_b32 v0, v3, v5, v0
+	v_or_b32_e32 v64, v1, v32
+	v_bitop3_b32 v65, v1, 8, v32 bitop3:0x36
+	v_bitop3_b32 v66, v1, 32, v32 bitop3:0x36
+	v_bitop3_b32 v67, v1, 40, v32 bitop3:0x36
+	v_or_b32_e32 v68, v0, v9
+	v_bitop3_b32 v69, v0, 32, v33 bitop3:0x34
+	v_lshrrev_b64 v[0:1], v10, exec
+	v_and_b32_e32 v72, 1, v0
+	v_lshrrev_b64 v[0:1], v2, exec
+	v_and_b32_e32 v74, 1, v0
+	v_lshrrev_b64 v[0:1], v4, exec
+	v_and_b32_e32 v75, 1, v0
+	v_lshrrev_b64 v[0:1], v6, exec
+	v_and_b32_e32 v76, 1, v0
+	v_lshrrev_b64 v[0:1], v8, exec
+	v_bitop3_b32 v7, v11, v13, v7 bitop3:0x36
+	v_lshlrev_b32_e32 v43, 2, v45
+	v_and_b32_e32 v77, 1, v0
+	v_lshrrev_b64 v[0:1], v12, exec
+	.loc	1 216 20                        ; flash_attention.py:216:20
+	s_mov_b32 s6, s2
+	s_mov_b32 s7, s3
+	.loc	1 210 48                        ; flash_attention.py:210:48
+	v_accvgpr_write_b32 a8, 0
+	v_accvgpr_write_b32 a7, 0
+	v_accvgpr_write_b32 a6, 0
+	v_accvgpr_write_b32 a5, 0
+	v_accvgpr_write_b32 a4, 0
+	v_accvgpr_write_b32 a3, 0
+	v_accvgpr_write_b32 a2, 0
+	v_accvgpr_write_b32 a1, 0
+	v_accvgpr_write_b32 a0, 0
+	.loc	1 230 20                        ; flash_attention.py:230:20
+	s_lshl_b32 s19, s19, 8
+	v_xor_b32_e32 v61, 32, v62
+	v_xor_b32_e32 v60, 64, v62
+	v_xor_b32_e32 v59, 0x60, v62
+	v_or_b32_e32 v48, v7, v9
+	v_lshlrev_b32_e32 v44, 1, v32
+	v_add_u32_e32 v63, 0, v43
+	v_bitop3_b32 v49, v7, 32, v33 bitop3:0x34
+	.loc	1 210 48                        ; flash_attention.py:210:48
+	v_or_b32_e32 v70, 0x1e00, v50
+	v_or_b32_e32 v71, 0x1600, v50
+	s_add_i32 s22, 0, 0x4000
+	v_mov_b32_e32 v73, 0xe0ad78ec
+	s_movk_i32 s20, 0xffc0
+	v_and_b32_e32 v78, 1, v0
+	s_mov_b32 s10, 0
+	s_mov_b32 s21, 0
+	v_mov_b32_e32 v79, 0xe0ad78ec
+.LBB0_1:                                ; =>This Inner Loop Header: Depth=1
+	.loc	1 0 48 is_stmt 0                ; flash_attention.py:0:48
+	v_mov_b32_e32 v104, v79
+	v_mov_b32_e32 v105, v53
+	s_mov_b32 s2, s10
+	.loc	1 210 48                        ; flash_attention.py:210:48
+	s_nop 7
+	v_accvgpr_read_b32 v1, a15
+	v_accvgpr_read_b32 v0, a14
+	v_accvgpr_read_b32 v3, a13
+	v_accvgpr_read_b32 v2, a12
+	v_accvgpr_read_b32 v5, a11
+	v_accvgpr_read_b32 v4, a10
+	v_accvgpr_read_b32 v7, a9
+	v_accvgpr_read_b32 v6, a8
+	v_accvgpr_read_b32 v33, a7
+	v_accvgpr_read_b32 v32, a6
+	v_accvgpr_read_b32 v35, a5
+	v_accvgpr_read_b32 v34, a4
+	v_accvgpr_read_b32 v37, a3
+	v_accvgpr_read_b32 v36, a2
+	v_accvgpr_read_b32 v39, a1
+	v_accvgpr_read_b32 v38, a0
+	; sched_barrier mask(0x00000000)
+	s_add_i32 s3, s21, 1
+	s_cmp_lt_i32 s3, 2
+	s_cselect_b32 s21, s3, 0
+	.loc	1 216 28 is_stmt 1              ; flash_attention.py:216:28
+	v_add_u32_e32 v8, s18, v41
+	.loc	1 216 20 is_stmt 0              ; flash_attention.py:216:20
+	s_lshl_b32 s3, s21, 13
+	.loc	1 216 28                        ; flash_attention.py:216:28
+	v_add_u32_e32 v9, 0x1000, v8
+	.loc	1 216 20                        ; flash_attention.py:216:20
+	s_add_i32 s10, s3, 0
+	s_waitcnt vmcnt(0) lgkmcnt(0)
+	s_barrier
+	v_cmp_eq_u32_e64 s[0:1], 1, v72
+	; iglp_opt mask(0x00000002)
+	v_add_u32_e32 v8, 0x1800, v8
+	ds_bpermute_b32 v9, v51, v9
+	s_add_i32 s3, s10, s16
+	; sched_barrier mask(0x00000000)
+	ds_bpermute_b32 v8, v51, v8
+	s_waitcnt lgkmcnt(1)
+	v_lshlrev_b32_e32 v9, 1, v9
+	v_cndmask_b32_e64 v9, v42, v9, s[0:1]
+	s_mov_b32 m0, s3
+	v_add_u32_e32 v12, s2, v62
+	s_waitcnt lgkmcnt(0)
+	v_lshlrev_b32_e32 v8, 1, v8
+	buffer_load_dwordx4 v9, s[4:7], 0 offen lds
+	s_add_i32 m0, s3, 0x1000
+	v_cndmask_b32_e64 v8, v42, v8, s[0:1]
+	buffer_load_dwordx4 v8, s[4:7], 0 offen lds
+	ds_read_b128 v[8:11], v12
+	v_add_u32_e32 v53, s2, v61
+	ds_read_b128 v[80:83], v53
+	ds_read_b128 v[84:87], v53 offset:4096
+	v_add_u32_e32 v53, s2, v60
+	ds_read_b128 v[12:15], v12 offset:4096
+	ds_read_b128 v[88:91], v53
+	.loc	1 218 23 is_stmt 1              ; flash_attention.py:218:23
+	s_waitcnt lgkmcnt(4)
+	v_mfma_f32_32x32x16_f16 a[0:15], v[8:11], v[28:31], 0
+	.loc	1 216 20                        ; flash_attention.py:216:20
+	ds_read_b128 v[92:95], v53 offset:4096
+	v_add_u32_e32 v53, s2, v59
+	ds_read_b128 v[96:99], v53
+	ds_read_b128 v[100:103], v53 offset:4096
+	.loc	1 230 20                        ; flash_attention.py:230:20
+	s_add_i32 s24, s10, s19
+	v_cmp_eq_u32_e64 s[0:1], 1, v74
+	s_add_i32 m0, s24, 0x4000
+	.loc	1 218 23                        ; flash_attention.py:218:23
+	s_waitcnt lgkmcnt(6)
+	v_mfma_f32_32x32x16_f16 a[0:15], v[80:83], v[24:27], a[0:15]
+	.loc	1 230 20                        ; flash_attention.py:230:20
+	s_mov_b32 s14, s6
+	s_mov_b32 s15, s7
+	v_cmp_eq_u32_e64 s[2:3], 1, v75
+	s_add_i32 s23, s10, 0x4000
+	.loc	1 210 48                        ; flash_attention.py:210:48
+	s_add_i32 s20, s20, 64
+	.loc	1 218 23                        ; flash_attention.py:218:23
+	s_waitcnt lgkmcnt(3)
+	v_mfma_f32_32x32x16_f16 a[0:15], v[88:91], v[20:23], a[0:15]
+	s_waitcnt lgkmcnt(1)
+	v_mfma_f32_32x32x16_f16 a[0:15], v[96:99], v[16:19], a[0:15]
+	s_nop 11
+	v_accvgpr_read_b32 v8, a0
+	v_accvgpr_read_b32 v9, a1
+	v_accvgpr_read_b32 v10, a2
+	v_accvgpr_read_b32 v11, a3
+	v_accvgpr_read_b32 v53, a4
+	v_accvgpr_read_b32 v79, a5
+	v_accvgpr_read_b32 v80, a6
+	v_accvgpr_read_b32 v81, a7
+	v_accvgpr_read_b32 v82, a8
+	v_accvgpr_read_b32 v83, a9
+	v_accvgpr_read_b32 v88, a10
+	v_accvgpr_read_b32 v89, a11
+	v_accvgpr_read_b32 v90, a12
+	v_accvgpr_read_b32 v91, a13
+	v_accvgpr_read_b32 v96, a14
+	v_accvgpr_read_b32 v97, a15
+	v_mfma_f32_32x32x16_f16 a[0:15], v[12:15], v[28:31], 0
+	.loc	1 218 50 is_stmt 0              ; flash_attention.py:218:50
+	v_mul_f32_e32 v8, v52, v8
+	v_mul_f32_e32 v9, v52, v9
+	v_mul_f32_e32 v10, v52, v10
+	v_mul_f32_e32 v11, v52, v11
+	.loc	1 220 67 is_stmt 1              ; flash_attention.py:220:67
+	v_cndmask_b32_e32 v9, v73, v9, vcc
+	.loc	1 218 50                        ; flash_attention.py:218:50
+	v_mul_f32_e32 v53, v52, v53
+	v_mul_f32_e32 v79, v52, v79
+	.loc	1 218 23 is_stmt 0              ; flash_attention.py:218:23
+	v_mfma_f32_32x32x16_f16 a[0:15], v[84:87], v[24:27], a[0:15]
+	.loc	1 220 67 is_stmt 1              ; flash_attention.py:220:67
+	v_cndmask_b32_e32 v10, v73, v10, vcc
+	v_cndmask_b32_e32 v11, v73, v11, vcc
+	.loc	1 218 50                        ; flash_attention.py:218:50
+	v_mul_f32_e32 v80, v52, v80
+	v_mul_f32_e32 v81, v52, v81
+	.loc	1 220 67                        ; flash_attention.py:220:67
+	v_cndmask_b32_e32 v53, v73, v53, vcc
+	.loc	1 218 50                        ; flash_attention.py:218:50
+	v_mul_f32_e32 v82, v52, v82
+	v_mul_f32_e32 v83, v52, v83
+	.loc	1 218 23 is_stmt 0              ; flash_attention.py:218:23
+	v_mfma_f32_32x32x16_f16 a[0:15], v[92:95], v[20:23], a[0:15]
+	.loc	1 220 67 is_stmt 1              ; flash_attention.py:220:67
+	v_cndmask_b32_e32 v80, v73, v80, vcc
+	v_cndmask_b32_e32 v81, v73, v81, vcc
+	.loc	1 218 50                        ; flash_attention.py:218:50
+	v_mul_f32_e32 v88, v52, v88
+	v_mul_f32_e32 v89, v52, v89
+	.loc	1 220 67                        ; flash_attention.py:220:67
+	v_cndmask_b32_e32 v82, v73, v82, vcc
+	v_cndmask_b32_e32 v83, v73, v83, vcc
+	.loc	1 218 50                        ; flash_attention.py:218:50
+	v_mul_f32_e32 v90, v52, v90
+	.loc	1 218 23 is_stmt 0              ; flash_attention.py:218:23
+	s_waitcnt lgkmcnt(0)
+	v_mfma_f32_32x32x16_f16 a[0:15], v[100:103], v[16:19], a[0:15]
+	.loc	1 220 67 is_stmt 1              ; flash_attention.py:220:67
+	v_cndmask_b32_e32 v102, v73, v8, vcc
+.Ltmp2:
+	.file	2 "/home/kunwar/Work/runtime-evolution/rocm-systems-rocjitsu-register-feedback/emulation/rocjitsu/.env/lib/python3.12/site-packages/triton/language" "standard.py"
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ flash_attention.py:223:39 ] ]
+	v_max_f32_e32 v8, v102, v9
+.Ltmp3:
+	.loc	1 220 67                        ; flash_attention.py:220:67
+	v_cndmask_b32_e32 v103, v73, v79, vcc
+.Ltmp4:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ flash_attention.py:223:39 ] ]
+	v_max3_f32 v8, v8, v10, v11
+	v_max3_f32 v8, v8, v53, v103
+	v_max3_f32 v8, v8, v80, v81
+.Ltmp5:
+	.loc	1 218 50                        ; flash_attention.py:218:50
+	v_mul_f32_e32 v91, v52, v91
+	.loc	1 220 67                        ; flash_attention.py:220:67
+	v_cndmask_b32_e32 v88, v73, v88, vcc
+	v_cndmask_b32_e32 v89, v73, v89, vcc
+.Ltmp6:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ flash_attention.py:223:39 ] ]
+	v_max3_f32 v8, v8, v82, v83
+.Ltmp7:
+	.loc	1 218 50                        ; flash_attention.py:218:50
+	v_mul_f32_e32 v96, v52, v96
+	v_mul_f32_e32 v97, v52, v97
+	.loc	1 218 23 is_stmt 0              ; flash_attention.py:218:23
+	v_accvgpr_read_b32 v12, a0
+	v_accvgpr_read_b32 v13, a1
+	.loc	1 220 67 is_stmt 1              ; flash_attention.py:220:67
+	v_cndmask_b32_e32 v90, v73, v90, vcc
+	v_cndmask_b32_e32 v91, v73, v91, vcc
+.Ltmp8:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ flash_attention.py:223:39 ] ]
+	v_max3_f32 v8, v8, v88, v89
+.Ltmp9:
+	.loc	1 218 23                        ; flash_attention.py:218:23
+	v_accvgpr_read_b32 v14, a2
+	v_accvgpr_read_b32 v15, a3
+	.loc	1 218 50 is_stmt 0              ; flash_attention.py:218:50
+	v_mul_f32_e32 v12, v52, v12
+	v_mul_f32_e32 v13, v52, v13
+	.loc	1 220 67 is_stmt 1              ; flash_attention.py:220:67
+	v_cndmask_b32_e32 v96, v73, v96, vcc
+	v_cndmask_b32_e32 v97, v73, v97, vcc
+.Ltmp10:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ flash_attention.py:223:39 ] ]
+	v_max3_f32 v8, v8, v90, v91
+.Ltmp11:
+	.loc	1 218 23                        ; flash_attention.py:218:23
+	v_accvgpr_read_b32 v84, a4
+	v_accvgpr_read_b32 v85, a5
+	.loc	1 218 50 is_stmt 0              ; flash_attention.py:218:50
+	v_mul_f32_e32 v14, v52, v14
+	v_mul_f32_e32 v15, v52, v15
+	.loc	1 220 67 is_stmt 1              ; flash_attention.py:220:67
+	v_cndmask_b32_e32 v12, v73, v12, vcc
+	v_cndmask_b32_e32 v13, v73, v13, vcc
+.Ltmp12:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ flash_attention.py:223:39 ] ]
+	v_max3_f32 v8, v8, v96, v97
+.Ltmp13:
+	.loc	1 218 23                        ; flash_attention.py:218:23
+	v_accvgpr_read_b32 v86, a6
+	v_accvgpr_read_b32 v87, a7
+	.loc	1 218 50 is_stmt 0              ; flash_attention.py:218:50
+	v_mul_f32_e32 v84, v52, v84
+	v_mul_f32_e32 v85, v52, v85
+	.loc	1 220 67 is_stmt 1              ; flash_attention.py:220:67
+	v_cndmask_b32_e32 v14, v73, v14, vcc
+	v_cndmask_b32_e32 v15, v73, v15, vcc
+.Ltmp14:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ flash_attention.py:223:39 ] ]
+	v_max3_f32 v8, v8, v12, v13
+.Ltmp15:
+	.loc	1 218 23                        ; flash_attention.py:218:23
+	v_accvgpr_read_b32 v92, a8
+	v_accvgpr_read_b32 v93, a9
+	.loc	1 218 50 is_stmt 0              ; flash_attention.py:218:50
+	v_mul_f32_e32 v86, v52, v86
+	v_mul_f32_e32 v87, v52, v87
+	.loc	1 220 67 is_stmt 1              ; flash_attention.py:220:67
+	v_cndmask_b32_e32 v84, v73, v84, vcc
+	v_cndmask_b32_e32 v85, v73, v85, vcc
+.Ltmp16:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ flash_attention.py:223:39 ] ]
+	v_max3_f32 v8, v8, v14, v15
+.Ltmp17:
+	.loc	1 218 23                        ; flash_attention.py:218:23
+	v_accvgpr_read_b32 v94, a10
+	v_accvgpr_read_b32 v95, a11
+	.loc	1 218 50 is_stmt 0              ; flash_attention.py:218:50
+	v_mul_f32_e32 v92, v52, v92
+	v_mul_f32_e32 v93, v52, v93
+	.loc	1 220 67 is_stmt 1              ; flash_attention.py:220:67
+	v_cndmask_b32_e32 v86, v73, v86, vcc
+	v_cndmask_b32_e32 v87, v73, v87, vcc
+.Ltmp18:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ flash_attention.py:223:39 ] ]
+	v_max3_f32 v8, v8, v84, v85
+.Ltmp19:
+	.loc	1 218 23                        ; flash_attention.py:218:23
+	v_accvgpr_read_b32 v98, a12
+	v_accvgpr_read_b32 v99, a13
+	.loc	1 218 50 is_stmt 0              ; flash_attention.py:218:50
+	v_mul_f32_e32 v94, v52, v94
+	v_mul_f32_e32 v95, v52, v95
+	.loc	1 220 67 is_stmt 1              ; flash_attention.py:220:67
+	v_cndmask_b32_e32 v92, v73, v92, vcc
+	v_cndmask_b32_e32 v93, v73, v93, vcc
+.Ltmp20:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ flash_attention.py:223:39 ] ]
+	v_max3_f32 v8, v8, v86, v87
+.Ltmp21:
+	.loc	1 218 23                        ; flash_attention.py:218:23
+	v_accvgpr_read_b32 v100, a14
+	v_accvgpr_read_b32 v101, a15
+	.loc	1 218 50 is_stmt 0              ; flash_attention.py:218:50
+	v_mul_f32_e32 v98, v52, v98
+	v_mul_f32_e32 v99, v52, v99
+	.loc	1 220 67 is_stmt 1              ; flash_attention.py:220:67
+	v_cndmask_b32_e32 v94, v73, v94, vcc
+	v_cndmask_b32_e32 v95, v73, v95, vcc
+.Ltmp22:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ flash_attention.py:223:39 ] ]
+	v_max3_f32 v8, v8, v92, v93
+.Ltmp23:
+	.loc	1 218 50                        ; flash_attention.py:218:50
+	v_mul_f32_e32 v100, v52, v100
+	v_mul_f32_e32 v101, v52, v101
+	.loc	1 220 67                        ; flash_attention.py:220:67
+	v_cndmask_b32_e32 v98, v73, v98, vcc
+	v_cndmask_b32_e32 v99, v73, v99, vcc
+.Ltmp24:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ flash_attention.py:223:39 ] ]
+	v_max3_f32 v8, v8, v94, v95
+.Ltmp25:
+	.loc	1 220 67                        ; flash_attention.py:220:67
+	v_cndmask_b32_e32 v100, v73, v100, vcc
+	v_cndmask_b32_e32 v101, v73, v101, vcc
+.Ltmp26:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ flash_attention.py:223:39 ] ]
+	v_max3_f32 v8, v8, v98, v99
+	v_max3_f32 v8, v8, v100, v101
+.Ltmp27:
+	.loc	2 191 40                        ; standard.py:191:40 @[ flash_attention.py:223:39 ]
+	v_mov_b32_e32 v79, v8
+	s_nop 1
+	v_permlane32_swap_b32_e32 v8, v79
+.Ltmp28:
+	.loc	1 223 32                        ; flash_attention.py:223:32
+	v_max3_f32 v79, v104, v8, v79
+	.loc	1 224 35                        ; flash_attention.py:224:35
+	v_sub_f32_e32 v8, v104, v79
+	.loc	1 225 30                        ; flash_attention.py:225:30
+	v_sub_f32_e32 v102, v102, v79
+	v_sub_f32_e32 v104, v9, v79
+	v_sub_f32_e32 v106, v10, v79
+	.loc	1 225 25 is_stmt 0              ; flash_attention.py:225:25
+	v_exp_f32_e32 v9, v102
+	v_exp_f32_e32 v10, v104
+	.loc	1 225 30                        ; flash_attention.py:225:30
+	v_sub_f32_e32 v107, v11, v79
+	.loc	1 225 25                        ; flash_attention.py:225:25
+	v_exp_f32_e32 v11, v106
+	.loc	1 225 30                        ; flash_attention.py:225:30
+	v_sub_f32_e32 v53, v53, v79
+	v_sub_f32_e32 v108, v12, v79
+	.loc	1 225 25                        ; flash_attention.py:225:25
+	v_exp_f32_e32 v12, v107
+	.loc	1 225 30                        ; flash_attention.py:225:30
+	v_sub_f32_e32 v103, v103, v79
+	v_sub_f32_e32 v109, v13, v79
+	.loc	1 225 25                        ; flash_attention.py:225:25
+	v_exp_f32_e32 v13, v53
+	.loc	1 225 30                        ; flash_attention.py:225:30
+	v_sub_f32_e32 v80, v80, v79
+	v_sub_f32_e32 v110, v14, v79
+	.loc	1 225 25                        ; flash_attention.py:225:25
+	v_exp_f32_e32 v14, v103
+.Ltmp29:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v53, v9, v10
+.Ltmp30:
+	.loc	1 225 30                        ; flash_attention.py:225:30
+	v_sub_f32_e32 v81, v81, v79
+	v_sub_f32_e32 v111, v15, v79
+	.loc	1 225 25 is_stmt 0              ; flash_attention.py:225:25
+	v_exp_f32_e32 v15, v80
+.Ltmp31:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v53, v11, v53
+.Ltmp32:
+	.loc	1 225 30                        ; flash_attention.py:225:30
+	v_sub_f32_e32 v82, v82, v79
+	.loc	1 225 25 is_stmt 0              ; flash_attention.py:225:25
+	v_exp_f32_e32 v80, v81
+.Ltmp33:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v53, v12, v53
+.Ltmp34:
+	.loc	1 225 30                        ; flash_attention.py:225:30
+	v_sub_f32_e32 v83, v83, v79
+	.loc	1 225 25 is_stmt 0              ; flash_attention.py:225:25
+	v_exp_f32_e32 v81, v82
+.Ltmp35:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v53, v13, v53
+.Ltmp36:
+	.loc	1 225 30                        ; flash_attention.py:225:30
+	v_sub_f32_e32 v88, v88, v79
+	.loc	1 225 25 is_stmt 0              ; flash_attention.py:225:25
+	v_exp_f32_e32 v82, v83
+.Ltmp37:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v53, v14, v53
+.Ltmp38:
+	.loc	1 225 30                        ; flash_attention.py:225:30
+	v_sub_f32_e32 v89, v89, v79
+	.loc	1 225 25 is_stmt 0              ; flash_attention.py:225:25
+	v_exp_f32_e32 v83, v88
+.Ltmp39:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v53, v15, v53
+.Ltmp40:
+	.loc	1 225 30                        ; flash_attention.py:225:30
+	v_sub_f32_e32 v90, v90, v79
+	v_sub_f32_e32 v112, v84, v79
+	.loc	1 225 25 is_stmt 0              ; flash_attention.py:225:25
+	v_exp_f32_e32 v84, v89
+.Ltmp41:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v53, v80, v53
+.Ltmp42:
+	.loc	1 225 30                        ; flash_attention.py:225:30
+	v_sub_f32_e32 v91, v91, v79
+	v_sub_f32_e32 v113, v85, v79
+	.loc	1 225 25 is_stmt 0              ; flash_attention.py:225:25
+	v_exp_f32_e32 v85, v90
+.Ltmp43:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v53, v81, v53
+.Ltmp44:
+	.loc	1 225 30                        ; flash_attention.py:225:30
+	v_sub_f32_e32 v96, v96, v79
+	v_sub_f32_e32 v114, v86, v79
+	.loc	1 225 25 is_stmt 0              ; flash_attention.py:225:25
+	v_exp_f32_e32 v86, v91
+.Ltmp45:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v53, v82, v53
+.Ltmp46:
+	.loc	1 225 30                        ; flash_attention.py:225:30
+	v_sub_f32_e32 v97, v97, v79
+	v_sub_f32_e32 v115, v87, v79
+	.loc	1 225 25 is_stmt 0              ; flash_attention.py:225:25
+	v_exp_f32_e32 v87, v96
+.Ltmp47:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v53, v83, v53
+.Ltmp48:
+	.loc	1 225 25                        ; flash_attention.py:225:25
+	v_exp_f32_e32 v88, v97
+.Ltmp49:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v53, v84, v53
+.Ltmp50:
+	.loc	1 225 25                        ; flash_attention.py:225:25
+	v_exp_f32_e32 v89, v108
+.Ltmp51:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v53, v85, v53
+.Ltmp52:
+	.loc	1 225 25                        ; flash_attention.py:225:25
+	v_exp_f32_e32 v90, v109
+.Ltmp53:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v53, v86, v53
+.Ltmp54:
+	.loc	1 225 25                        ; flash_attention.py:225:25
+	v_exp_f32_e32 v91, v110
+.Ltmp55:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v53, v87, v53
+.Ltmp56:
+	.loc	1 225 30                        ; flash_attention.py:225:30
+	v_sub_f32_e32 v116, v92, v79
+	.loc	1 225 25 is_stmt 0              ; flash_attention.py:225:25
+	v_exp_f32_e32 v92, v111
+.Ltmp57:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v53, v88, v53
+.Ltmp58:
+	.loc	1 225 30                        ; flash_attention.py:225:30
+	v_sub_f32_e32 v117, v93, v79
+	.loc	1 225 25 is_stmt 0              ; flash_attention.py:225:25
+	v_exp_f32_e32 v93, v112
+.Ltmp59:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v53, v89, v53
+.Ltmp60:
+	.loc	1 225 30                        ; flash_attention.py:225:30
+	v_sub_f32_e32 v118, v94, v79
+	.loc	1 225 25 is_stmt 0              ; flash_attention.py:225:25
+	v_exp_f32_e32 v94, v113
+.Ltmp61:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v53, v90, v53
+.Ltmp62:
+	.loc	1 225 30                        ; flash_attention.py:225:30
+	v_sub_f32_e32 v119, v95, v79
+	.loc	1 225 25 is_stmt 0              ; flash_attention.py:225:25
+	v_exp_f32_e32 v95, v114
+.Ltmp63:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v53, v91, v53
+.Ltmp64:
+	.loc	1 225 25                        ; flash_attention.py:225:25
+	v_exp_f32_e32 v96, v115
+.Ltmp65:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v53, v92, v53
+.Ltmp66:
+	.loc	1 225 25                        ; flash_attention.py:225:25
+	v_exp_f32_e32 v97, v116
+.Ltmp67:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v53, v93, v53
+.Ltmp68:
+	.loc	1 225 30                        ; flash_attention.py:225:30
+	v_sub_f32_e32 v120, v98, v79
+	.loc	1 225 25 is_stmt 0              ; flash_attention.py:225:25
+	v_exp_f32_e32 v98, v117
+.Ltmp69:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v53, v94, v53
+.Ltmp70:
+	.loc	1 225 30                        ; flash_attention.py:225:30
+	v_sub_f32_e32 v121, v99, v79
+	.loc	1 225 25 is_stmt 0              ; flash_attention.py:225:25
+	v_exp_f32_e32 v99, v118
+.Ltmp71:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v53, v95, v53
+.Ltmp72:
+	.loc	1 225 30                        ; flash_attention.py:225:30
+	v_sub_f32_e32 v122, v100, v79
+	.loc	1 225 25 is_stmt 0              ; flash_attention.py:225:25
+	v_exp_f32_e32 v100, v119
+.Ltmp73:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v53, v96, v53
+.Ltmp74:
+	.loc	1 225 30                        ; flash_attention.py:225:30
+	v_sub_f32_e32 v123, v101, v79
+	.loc	1 225 25 is_stmt 0              ; flash_attention.py:225:25
+	v_exp_f32_e32 v101, v120
+.Ltmp75:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v53, v97, v53
+.Ltmp76:
+	.loc	1 225 25                        ; flash_attention.py:225:25
+	v_exp_f32_e32 v102, v121
+.Ltmp77:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v53, v98, v53
+.Ltmp78:
+	.loc	1 225 25                        ; flash_attention.py:225:25
+	v_exp_f32_e32 v103, v122
+.Ltmp79:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v53, v99, v53
+.Ltmp80:
+	.loc	1 225 25                        ; flash_attention.py:225:25
+	v_exp_f32_e32 v104, v123
+.Ltmp81:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v53, v100, v53
+	v_add_f32_e32 v53, v101, v53
+	v_add_f32_e32 v53, v102, v53
+	v_add_f32_e32 v53, v103, v53
+.Ltmp82:
+	.loc	1 224 29                        ; flash_attention.py:224:29
+	v_exp_f32_e32 v8, v8
+.Ltmp83:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v53, v104, v53
+.Ltmp84:
+	.loc	2 293 36                        ; standard.py:293:36 @[ flash_attention.py:226:37 ]
+	v_mov_b32_e32 v106, v53
+	s_nop 1
+	v_permlane32_swap_b32_e32 v53, v106
+.Ltmp85:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v53, v53, v106
+.Ltmp86:
+	.loc	1 226 30                        ; flash_attention.py:226:30
+	v_fmac_f32_e32 v53, v105, v8
+	.loc	1 230 28                        ; flash_attention.py:230:28
+	v_add_u32_e32 v105, s18, v50
+	v_add_u32_e32 v106, 0x1000, v105
+	.loc	1 230 20 is_stmt 0              ; flash_attention.py:230:20
+	ds_bpermute_b32 v106, v54, v106
+	.loc	1 230 28                        ; flash_attention.py:230:28
+	v_add_u32_e32 v107, 0x1200, v105
+	v_add_u32_e32 v108, 0x1400, v105
+	v_add_u32_e32 v109, s18, v71
+	v_add_u32_e32 v110, 0x1800, v105
+	.loc	1 230 20                        ; flash_attention.py:230:20
+	s_waitcnt lgkmcnt(0)
+	v_lshlrev_b32_e32 v106, 1, v106
+	v_cndmask_b32_e64 v106, v42, v106, s[0:1]
+	buffer_load_dword v106, s[12:15], 0 offen lds
+	ds_bpermute_b32 v106, v55, v107
+	s_add_i32 m0, s24, 0x4400
+	.loc	1 230 28                        ; flash_attention.py:230:28
+	v_add_u32_e32 v111, 0x1a00, v105
+	v_add_u32_e32 v105, 0x1c00, v105
+	.loc	1 230 20                        ; flash_attention.py:230:20
+	ds_bpermute_b32 v105, v54, v105
+	s_waitcnt lgkmcnt(1)
+	v_lshlrev_b32_e32 v106, 1, v106
+	v_cndmask_b32_e64 v106, v42, v106, s[2:3]
+	buffer_load_dword v106, s[12:15], 0 offen lds
+	ds_bpermute_b32 v106, v54, v108
+	s_add_i32 m0, s24, 0x4800
+	v_cmp_eq_u32_e64 s[2:3], 1, v76
+	s_waitcnt lgkmcnt(1)
+	v_lshlrev_b32_e32 v105, 1, v105
+	v_add_u32_e32 v112, s18, v70
+	s_waitcnt lgkmcnt(0)
+	v_lshlrev_b32_e32 v106, 1, v106
+	v_cndmask_b32_e64 v106, v42, v106, s[0:1]
+	buffer_load_dword v106, s[12:15], 0 offen lds
+	ds_bpermute_b32 v106, v56, v109
+	s_add_i32 m0, s24, 0x4c00
+	v_cndmask_b32_e64 v105, v42, v105, s[0:1]
+	.loc	1 210 48 is_stmt 1              ; flash_attention.py:210:48
+	s_addk_i32 s18, 0x1000
+	.loc	1 230 20                        ; flash_attention.py:230:20
+	s_waitcnt lgkmcnt(0)
+	v_lshlrev_b32_e32 v106, 1, v106
+	v_cndmask_b32_e64 v106, v42, v106, s[2:3]
+	buffer_load_dword v106, s[12:15], 0 offen lds
+	ds_bpermute_b32 v106, v54, v110
+	s_add_i32 m0, s24, 0x5000
+	v_cmp_eq_u32_e64 s[2:3], 1, v77
+	s_waitcnt lgkmcnt(0)
+	v_lshlrev_b32_e32 v106, 1, v106
+	v_cndmask_b32_e64 v106, v42, v106, s[0:1]
+	buffer_load_dword v106, s[12:15], 0 offen lds
+	ds_bpermute_b32 v106, v57, v111
+	s_add_i32 m0, s24, 0x5400
+	v_cmp_eq_u32_e64 s[0:1], 1, v78
+	s_waitcnt lgkmcnt(0)
+	v_lshlrev_b32_e32 v106, 1, v106
+	v_cndmask_b32_e64 v106, v42, v106, s[2:3]
+	buffer_load_dword v106, s[12:15], 0 offen lds
+	s_add_i32 m0, s24, 0x5800
+	s_nop 0
+	buffer_load_dword v105, s[12:15], 0 offen lds
+	ds_bpermute_b32 v105, v58, v112
+	s_add_i32 m0, s24, 0x5c00
+	.loc	1 210 48                        ; flash_attention.py:210:48
+	s_cmpk_lt_u32 s20, 0x380
+	.loc	1 230 20                        ; flash_attention.py:230:20
+	s_waitcnt lgkmcnt(0)
+	v_lshlrev_b32_e32 v105, 1, v105
+	v_cndmask_b32_e64 v105, v42, v105, s[0:1]
+	buffer_load_dword v105, s[12:15], 0 offen lds
+	v_add_u32_e32 v105, s22, v48
+	ds_read_b64_tr_b16 v[108:109], v105
+	ds_read_b64_tr_b16 v[112:113], v105 offset:2048
+	ds_read_b64_tr_b16 v[116:117], v105 offset:4096
+	ds_read_b64_tr_b16 v[120:121], v105 offset:6144
+	v_add_u32_e32 v105, s22, v49
+	ds_read_b64_tr_b16 v[110:111], v105 offset:1024
+	ds_read_b64_tr_b16 v[114:115], v105 offset:3072
+	ds_read_b64_tr_b16 v[118:119], v105 offset:5120
+	ds_read_b64_tr_b16 v[122:123], v105 offset:7168
+	.loc	1 232 20                        ; flash_attention.py:232:20
+	v_add_u32_e32 v105, v63, v44
+	s_waitcnt vmcnt(0)
+	ds_write_b32 v105, v8 offset:32768
+	v_add_u32_e32 v8, v63, v40
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	ds_read_b32 v106, v8 offset:32768
+	.loc	1 233 26                        ; flash_attention.py:233:26
+	v_cvt_pk_f16_f32 v8, v9, v10
+	v_cvt_pk_f16_f32 v9, v11, v12
+	v_cvt_pk_f16_f32 v11, v15, v80
+	v_cvt_pk_f16_f32 v12, v81, v82
+	v_cvt_pk_f16_f32 v81, v89, v90
+	v_add_u32_e32 v80, 0, v64
+	v_cvt_pk_f16_f32 v82, v91, v92
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	ds_write_b16 v80, v81 offset:36864
+	ds_write_b16_d16_hi v80, v81 offset:36992
+	v_add_u32_e32 v81, 0, v65
+	v_cvt_pk_f16_f32 v10, v13, v14
+	v_cvt_pk_f16_f32 v13, v83, v84
+	v_cvt_pk_f16_f32 v83, v93, v94
+	ds_write_b16 v81, v82 offset:37120
+	ds_write_b16_d16_hi v81, v82 offset:37248
+	v_add_u32_e32 v82, 0, v66
+	v_cvt_pk_f16_f32 v14, v85, v86
+	v_cvt_pk_f16_f32 v84, v95, v96
+	v_cvt_pk_f16_f32 v85, v97, v98
+	ds_write_b16 v82, v83 offset:37888
+	ds_write_b16_d16_hi v82, v83 offset:38016
+	v_add_u32_e32 v83, 0, v67
+	v_cvt_pk_f16_f32 v15, v87, v88
+	v_cvt_pk_f16_f32 v86, v99, v100
+	v_cvt_pk_f16_f32 v87, v101, v102
+	v_cvt_pk_f16_f32 v88, v103, v104
+	ds_write_b16 v80, v85 offset:38912
+	ds_write_b16_d16_hi v80, v85 offset:39040
+	ds_write_b16 v83, v84 offset:38144
+	ds_write_b16_d16_hi v83, v84 offset:38272
+	v_add_u32_e32 v84, 0, v68
+	v_add_u32_e32 v85, 0, v69
+	ds_write_b16 v80, v8 offset:32768
+	ds_write_b16_d16_hi v80, v8 offset:32896
+	ds_write_b16 v80, v12 offset:34816
+	ds_write_b16_d16_hi v80, v12 offset:34944
+	ds_write_b16 v81, v9 offset:33024
+	ds_write_b16_d16_hi v81, v9 offset:33152
+	ds_write_b16 v81, v13 offset:35072
+	ds_write_b16_d16_hi v81, v13 offset:35200
+	ds_write_b16 v81, v86 offset:39168
+	ds_write_b16_d16_hi v81, v86 offset:39296
+	ds_write_b16 v82, v10 offset:33792
+	ds_write_b16_d16_hi v82, v10 offset:33920
+	ds_write_b16 v82, v14 offset:35840
+	ds_write_b16_d16_hi v82, v14 offset:35968
+	ds_write_b16 v82, v87 offset:39936
+	ds_write_b16_d16_hi v82, v87 offset:40064
+	ds_write_b16 v83, v11 offset:34048
+	ds_write_b16_d16_hi v83, v11 offset:34176
+	ds_write_b16 v83, v15 offset:36096
+	ds_write_b16_d16_hi v83, v15 offset:36224
+	ds_write_b16 v83, v88 offset:40192
+	ds_write_b16_d16_hi v83, v88 offset:40320
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	ds_read_b64_tr_b16 v[86:87], v84 offset:32768
+	ds_read_b64_tr_b16 v[90:91], v84 offset:34816
+	ds_read_b64_tr_b16 v[94:95], v84 offset:36864
+	ds_read_b64_tr_b16 v[98:99], v84 offset:38912
+	ds_read_b64_tr_b16 v[88:89], v85 offset:33792
+	ds_read_b64_tr_b16 v[92:93], v85 offset:35840
+	ds_read_b64_tr_b16 v[96:97], v85 offset:37888
+	ds_read_b64_tr_b16 v[100:101], v85 offset:39936
+	.loc	1 233 42 is_stmt 0              ; flash_attention.py:233:42
+	v_pk_mul_f32 v[14:15], v[0:1], v[106:107] op_sel_hi:[1,0]
+	v_pk_mul_f32 v[0:1], v[38:39], v[106:107] op_sel_hi:[1,0]
+	v_pk_mul_f32 v[12:13], v[2:3], v[106:107] op_sel_hi:[1,0]
+	v_pk_mul_f32 v[10:11], v[4:5], v[106:107] op_sel_hi:[1,0]
+	v_pk_mul_f32 v[8:9], v[6:7], v[106:107] op_sel_hi:[1,0]
+	v_pk_mul_f32 v[6:7], v[32:33], v[106:107] op_sel_hi:[1,0]
+	v_pk_mul_f32 v[4:5], v[34:35], v[106:107] op_sel_hi:[1,0]
+	v_pk_mul_f32 v[2:3], v[36:37], v[106:107] op_sel_hi:[1,0]
+	s_mov_b32 s22, s23
+	v_accvgpr_write_b32 a0, v0
+	v_accvgpr_write_b32 a1, v1
+	v_accvgpr_write_b32 a2, v2
+	v_accvgpr_write_b32 a3, v3
+	v_accvgpr_write_b32 a4, v4
+	v_accvgpr_write_b32 a5, v5
+	v_accvgpr_write_b32 a6, v6
+	v_accvgpr_write_b32 a7, v7
+	v_accvgpr_write_b32 a8, v8
+	v_accvgpr_write_b32 a9, v9
+	v_accvgpr_write_b32 a10, v10
+	v_accvgpr_write_b32 a11, v11
+	v_accvgpr_write_b32 a12, v12
+	v_accvgpr_write_b32 a13, v13
+	v_accvgpr_write_b32 a14, v14
+	v_accvgpr_write_b32 a15, v15
+	s_waitcnt lgkmcnt(3)
+	s_nop 0
+	v_mfma_f32_32x32x16_f16 a[0:15], v[108:111], v[86:89], a[0:15]
+	s_waitcnt lgkmcnt(2)
+	v_mfma_f32_32x32x16_f16 a[0:15], v[112:115], v[90:93], a[0:15]
+	s_waitcnt lgkmcnt(1)
+	v_mfma_f32_32x32x16_f16 a[0:15], v[116:119], v[94:97], a[0:15]
+	s_waitcnt lgkmcnt(0)
+	v_mfma_f32_32x32x16_f16 a[0:15], v[120:123], v[98:101], a[0:15]
+	.loc	1 210 48 is_stmt 1              ; flash_attention.py:210:48
+	s_cbranch_scc1 .LBB0_1
+; %bb.2:
+	.loc	1 216 20                        ; flash_attention.py:216:20
+	v_add_u32_e32 v4, s10, v62
+	s_waitcnt vmcnt(0) lgkmcnt(0)
+	s_barrier
+	ds_read_b128 v[0:3], v4
+	v_add_u32_e32 v5, s10, v61
+	ds_read_b128 v[32:35], v4 offset:4096
+	v_add_u32_e32 v4, s10, v60
+	ds_read_b128 v[36:39], v5 offset:4096
+	ds_read_b128 v[54:57], v4 offset:4096
+	.loc	1 218 23                        ; flash_attention.py:218:23
+	s_waitcnt lgkmcnt(3)
+	v_mfma_f32_32x32x16_f16 a[16:31], v[0:3], v[28:31], 0
+	.loc	1 216 20                        ; flash_attention.py:216:20
+	ds_read_b128 v[0:3], v5
+	v_add_u32_e32 v5, s10, v59
+	.loc	1 194 45                        ; flash_attention.py:194:45
+	v_lshrrev_b32_e32 v41, 2, v40
+	s_movk_i32 s0, 0x400
+	.loc	1 240 32                        ; flash_attention.py:240:32
+	s_and_b32 s9, s9, 0xffff
+	.loc	1 218 23                        ; flash_attention.py:218:23
+	s_waitcnt lgkmcnt(0)
+	v_mfma_f32_32x32x16_f16 a[16:31], v[0:3], v[24:27], a[16:31]
+	.loc	1 216 20                        ; flash_attention.py:216:20
+	ds_read_b128 v[0:3], v4
+	.loc	1 218 23                        ; flash_attention.py:218:23
+	s_waitcnt lgkmcnt(0)
+	v_mfma_f32_32x32x16_f16 a[16:31], v[0:3], v[20:23], a[16:31]
+	.loc	1 216 20                        ; flash_attention.py:216:20
+	ds_read_b128 v[0:3], v5
+	ds_read_b128 v[58:61], v5 offset:4096
+	.loc	1 218 23                        ; flash_attention.py:218:23
+	s_waitcnt lgkmcnt(1)
+	v_mfma_f32_32x32x16_f16 a[16:31], v[0:3], v[16:19], a[16:31]
+	.loc	1 233 42                        ; flash_attention.py:233:42
+	v_accvgpr_read_b32 v0, a0
+	v_accvgpr_read_b32 v1, a1
+	v_accvgpr_read_b32 v2, a2
+	v_accvgpr_read_b32 v3, a3
+	v_accvgpr_read_b32 v4, a4
+	v_accvgpr_read_b32 v5, a5
+	v_accvgpr_read_b32 v6, a6
+	v_accvgpr_read_b32 v7, a7
+	v_accvgpr_read_b32 v8, a8
+	v_accvgpr_read_b32 v9, a9
+	v_accvgpr_read_b32 v10, a10
+	v_accvgpr_read_b32 v11, a11
+	v_accvgpr_read_b32 v12, a12
+	v_accvgpr_read_b32 v13, a13
+	v_accvgpr_read_b32 v14, a14
+	v_accvgpr_read_b32 v15, a15
+	.loc	1 218 23                        ; flash_attention.py:218:23
+	v_mfma_f32_32x32x16_f16 a[0:15], v[32:35], v[28:31], 0
+	.loc	1 194 45                        ; flash_attention.py:194:45
+	v_lshrrev_b32_e32 v28, 3, v46
+	v_or_b32_e32 v30, v41, v45
+	.loc	1 198 53                        ; flash_attention.py:198:53
+	v_or_b32_e32 v29, v28, v47
+	.loc	1 218 23                        ; flash_attention.py:218:23
+	v_accvgpr_read_b32 v31, a16
+	v_accvgpr_read_b32 v32, a17
+	v_accvgpr_read_b32 v33, a22
+	v_accvgpr_read_b32 v34, a23
+	v_mfma_f32_32x32x16_f16 a[0:15], v[36:39], v[24:27], a[0:15]
+	v_accvgpr_read_b32 v24, a18
+	v_accvgpr_read_b32 v25, a19
+	v_accvgpr_read_b32 v26, a20
+	v_accvgpr_read_b32 v27, a21
+	v_accvgpr_read_b32 v35, a24
+	v_accvgpr_read_b32 v36, a29
+	v_accvgpr_read_b32 v37, a30
+	v_mfma_f32_32x32x16_f16 a[0:15], v[54:57], v[20:23], a[0:15]
+	v_accvgpr_read_b32 v20, a25
+	v_accvgpr_read_b32 v21, a26
+	v_accvgpr_read_b32 v22, a27
+	v_accvgpr_read_b32 v23, a28
+	v_accvgpr_read_b32 v38, a31
+	.loc	1 218 50 is_stmt 0              ; flash_attention.py:218:50
+	v_mul_f32_e32 v31, v52, v31
+	v_mul_f32_e32 v32, v52, v32
+	.loc	1 218 23                        ; flash_attention.py:218:23
+	s_waitcnt lgkmcnt(0)
+	v_mfma_f32_32x32x16_f16 a[0:15], v[58:61], v[16:19], a[0:15]
+	.loc	1 218 50                        ; flash_attention.py:218:50
+	v_mul_f32_e32 v24, v52, v24
+	v_mul_f32_e32 v25, v52, v25
+	v_mul_f32_e32 v26, v52, v26
+	v_mul_f32_e32 v27, v52, v27
+	v_mul_f32_e32 v33, v52, v33
+	v_mul_f32_e32 v34, v52, v34
+	v_mul_f32_e32 v35, v52, v35
+	v_mul_f32_e32 v20, v52, v20
+	v_mul_f32_e32 v21, v52, v21
+	v_mul_f32_e32 v22, v52, v22
+	v_mul_f32_e32 v23, v52, v23
+	v_mul_f32_e32 v36, v52, v36
+	.loc	1 218 23                        ; flash_attention.py:218:23
+	v_accvgpr_read_b32 v16, a0
+	v_accvgpr_read_b32 v17, a1
+	v_accvgpr_read_b32 v18, a2
+	v_accvgpr_read_b32 v19, a3
+	v_accvgpr_read_b32 v39, a4
+	v_accvgpr_read_b32 v41, a5
+	v_accvgpr_read_b32 v42, a6
+	v_accvgpr_read_b32 v45, a7
+	v_accvgpr_read_b32 v46, a8
+	v_accvgpr_read_b32 v47, a9
+	v_accvgpr_read_b32 v50, a10
+	v_accvgpr_read_b32 v51, a11
+	v_accvgpr_read_b32 v54, a12
+	v_accvgpr_read_b32 v55, a13
+	v_accvgpr_read_b32 v56, a14
+	v_accvgpr_read_b32 v57, a15
+	.loc	1 218 50                        ; flash_attention.py:218:50
+	v_mul_f32_e32 v37, v52, v37
+	v_mul_f32_e32 v38, v52, v38
+	v_mul_f32_e32 v16, v52, v16
+	v_mul_f32_e32 v17, v52, v17
+	v_mul_f32_e32 v18, v52, v18
+	v_mul_f32_e32 v19, v52, v19
+	v_mul_f32_e32 v39, v52, v39
+	v_mul_f32_e32 v41, v52, v41
+	v_mul_f32_e32 v42, v52, v42
+	v_mul_f32_e32 v45, v52, v45
+	v_mul_f32_e32 v46, v52, v46
+	v_mul_f32_e32 v47, v52, v47
+	v_mul_f32_e32 v50, v52, v50
+	v_mul_f32_e32 v51, v52, v51
+	v_mul_f32_e32 v54, v52, v54
+	v_mul_f32_e32 v55, v52, v55
+	v_mul_f32_e32 v56, v52, v56
+	v_mul_f32_e32 v52, v52, v57
+	.loc	1 220 67 is_stmt 1              ; flash_attention.py:220:67
+	v_mov_b32_e32 v57, 0xe0ad78ec
+	v_cndmask_b32_e32 v31, v57, v31, vcc
+	v_cndmask_b32_e32 v32, v57, v32, vcc
+	v_cndmask_b32_e32 v24, v57, v24, vcc
+	v_cndmask_b32_e32 v25, v57, v25, vcc
+	v_cndmask_b32_e32 v26, v57, v26, vcc
+	v_cndmask_b32_e32 v27, v57, v27, vcc
+	v_cndmask_b32_e32 v33, v57, v33, vcc
+	v_cndmask_b32_e32 v34, v57, v34, vcc
+	v_cndmask_b32_e32 v35, v57, v35, vcc
+	v_cndmask_b32_e32 v20, v57, v20, vcc
+	v_cndmask_b32_e32 v21, v57, v21, vcc
+	v_cndmask_b32_e32 v22, v57, v22, vcc
+	v_cndmask_b32_e32 v23, v57, v23, vcc
+	v_cndmask_b32_e32 v36, v57, v36, vcc
+	v_cndmask_b32_e32 v37, v57, v37, vcc
+	v_cndmask_b32_e32 v38, v57, v38, vcc
+	v_cndmask_b32_e32 v16, v57, v16, vcc
+	v_cndmask_b32_e32 v17, v57, v17, vcc
+	v_cndmask_b32_e32 v18, v57, v18, vcc
+	v_cndmask_b32_e32 v19, v57, v19, vcc
+	v_cndmask_b32_e32 v39, v57, v39, vcc
+	v_cndmask_b32_e32 v41, v57, v41, vcc
+	v_cndmask_b32_e32 v42, v57, v42, vcc
+	v_cndmask_b32_e32 v45, v57, v45, vcc
+	v_cndmask_b32_e32 v46, v57, v46, vcc
+	v_cndmask_b32_e32 v47, v57, v47, vcc
+	v_cndmask_b32_e32 v50, v57, v50, vcc
+	v_cndmask_b32_e32 v51, v57, v51, vcc
+	v_cndmask_b32_e32 v54, v57, v54, vcc
+	v_cndmask_b32_e32 v55, v57, v55, vcc
+	v_cndmask_b32_e32 v56, v57, v56, vcc
+	v_cndmask_b32_e32 v52, v57, v52, vcc
+.Ltmp87:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ flash_attention.py:223:39 ] ]
+	v_max_f32_e32 v57, v31, v32
+	v_max3_f32 v57, v57, v24, v25
+	v_max3_f32 v57, v57, v26, v27
+	v_max3_f32 v57, v57, v33, v34
+	v_max3_f32 v57, v57, v35, v20
+	v_max3_f32 v57, v57, v21, v22
+	v_max3_f32 v57, v57, v23, v36
+	v_max3_f32 v57, v57, v37, v38
+	v_max3_f32 v57, v57, v16, v17
+	v_max3_f32 v57, v57, v18, v19
+	v_max3_f32 v57, v57, v39, v41
+	v_max3_f32 v57, v57, v42, v45
+	v_max3_f32 v57, v57, v46, v47
+	v_max3_f32 v57, v57, v50, v51
+	v_max3_f32 v57, v57, v54, v55
+	v_max3_f32 v57, v57, v56, v52
+.Ltmp88:
+	.loc	2 191 40                        ; standard.py:191:40 @[ flash_attention.py:223:39 ]
+	v_mov_b32_e32 v58, v57
+	s_nop 1
+	v_permlane32_swap_b32_e32 v57, v58
+.Ltmp89:
+	.loc	1 223 32                        ; flash_attention.py:223:32
+	v_max3_f32 v57, v79, v57, v58
+	.loc	1 225 30                        ; flash_attention.py:225:30
+	v_sub_f32_e32 v31, v31, v57
+	v_sub_f32_e32 v32, v32, v57
+	v_sub_f32_e32 v24, v24, v57
+	.loc	1 225 25 is_stmt 0              ; flash_attention.py:225:25
+	v_exp_f32_e32 v31, v31
+	v_exp_f32_e32 v32, v32
+	.loc	1 225 30                        ; flash_attention.py:225:30
+	v_sub_f32_e32 v25, v25, v57
+	.loc	1 225 25                        ; flash_attention.py:225:25
+	v_exp_f32_e32 v24, v24
+	.loc	1 225 30                        ; flash_attention.py:225:30
+	v_sub_f32_e32 v26, v26, v57
+	.loc	1 225 25                        ; flash_attention.py:225:25
+	v_exp_f32_e32 v25, v25
+	.loc	1 225 30                        ; flash_attention.py:225:30
+	v_sub_f32_e32 v27, v27, v57
+	v_sub_f32_e32 v16, v16, v57
+	.loc	1 225 25                        ; flash_attention.py:225:25
+	v_exp_f32_e32 v26, v26
+	.loc	1 224 35 is_stmt 1              ; flash_attention.py:224:35
+	v_sub_f32_e32 v58, v79, v57
+	.loc	1 225 30                        ; flash_attention.py:225:30
+	v_sub_f32_e32 v33, v33, v57
+	v_sub_f32_e32 v34, v34, v57
+	v_sub_f32_e32 v35, v35, v57
+	v_sub_f32_e32 v20, v20, v57
+	v_sub_f32_e32 v21, v21, v57
+	v_sub_f32_e32 v22, v22, v57
+	v_sub_f32_e32 v23, v23, v57
+	v_sub_f32_e32 v36, v36, v57
+	v_sub_f32_e32 v37, v37, v57
+	v_sub_f32_e32 v38, v38, v57
+	v_sub_f32_e32 v17, v17, v57
+	v_sub_f32_e32 v18, v18, v57
+	v_sub_f32_e32 v19, v19, v57
+	v_sub_f32_e32 v39, v39, v57
+	v_sub_f32_e32 v41, v41, v57
+	v_sub_f32_e32 v42, v42, v57
+	v_sub_f32_e32 v45, v45, v57
+	v_sub_f32_e32 v46, v46, v57
+	v_sub_f32_e32 v47, v47, v57
+	v_sub_f32_e32 v50, v50, v57
+	v_sub_f32_e32 v51, v51, v57
+	v_sub_f32_e32 v54, v54, v57
+	v_sub_f32_e32 v55, v55, v57
+	v_sub_f32_e32 v56, v56, v57
+	v_sub_f32_e32 v52, v52, v57
+	.loc	1 225 25 is_stmt 0              ; flash_attention.py:225:25
+	v_exp_f32_e32 v27, v27
+	v_exp_f32_e32 v57, v16
+.Ltmp90:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v16, v31, v32
+.Ltmp91:
+	.loc	1 225 25                        ; flash_attention.py:225:25
+	v_exp_f32_e32 v33, v33
+.Ltmp92:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v16, v24, v16
+.Ltmp93:
+	.loc	1 225 25                        ; flash_attention.py:225:25
+	v_exp_f32_e32 v34, v34
+.Ltmp94:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v16, v25, v16
+.Ltmp95:
+	.loc	1 225 25                        ; flash_attention.py:225:25
+	v_exp_f32_e32 v35, v35
+.Ltmp96:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v16, v26, v16
+.Ltmp97:
+	.loc	1 225 25                        ; flash_attention.py:225:25
+	v_exp_f32_e32 v20, v20
+.Ltmp98:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v16, v27, v16
+.Ltmp99:
+	.loc	1 225 25                        ; flash_attention.py:225:25
+	v_exp_f32_e32 v21, v21
+.Ltmp100:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v16, v33, v16
+.Ltmp101:
+	.loc	1 225 25                        ; flash_attention.py:225:25
+	v_exp_f32_e32 v22, v22
+.Ltmp102:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v16, v34, v16
+.Ltmp103:
+	.loc	1 225 25                        ; flash_attention.py:225:25
+	v_exp_f32_e32 v23, v23
+.Ltmp104:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v16, v35, v16
+.Ltmp105:
+	.loc	1 225 25                        ; flash_attention.py:225:25
+	v_exp_f32_e32 v36, v36
+.Ltmp106:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v16, v20, v16
+.Ltmp107:
+	.loc	1 225 25                        ; flash_attention.py:225:25
+	v_exp_f32_e32 v37, v37
+.Ltmp108:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v16, v21, v16
+.Ltmp109:
+	.loc	1 225 25                        ; flash_attention.py:225:25
+	v_exp_f32_e32 v38, v38
+.Ltmp110:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v16, v22, v16
+	v_add_f32_e32 v16, v23, v16
+	v_add_f32_e32 v16, v36, v16
+	v_add_f32_e32 v16, v37, v16
+	v_add_f32_e32 v59, v38, v16
+.Ltmp111:
+	.loc	1 230 20                        ; flash_attention.py:230:20
+	v_add_u32_e32 v16, s10, v48
+	.loc	1 224 29                        ; flash_attention.py:224:29
+	v_exp_f32_e32 v58, v58
+	.loc	1 230 20                        ; flash_attention.py:230:20
+	ds_read_b64_tr_b16 v[60:61], v16 offset:16384
+	ds_read_b64_tr_b16 v[64:65], v16 offset:18432
+	ds_read_b64_tr_b16 v[68:69], v16 offset:20480
+	ds_read_b64_tr_b16 v[72:73], v16 offset:22528
+	v_add_u32_e32 v16, s10, v49
+	ds_read_b64_tr_b16 v[62:63], v16 offset:17408
+	ds_read_b64_tr_b16 v[66:67], v16 offset:19456
+	ds_read_b64_tr_b16 v[70:71], v16 offset:21504
+	ds_read_b64_tr_b16 v[74:75], v16 offset:23552
+	.loc	1 232 20                        ; flash_attention.py:232:20
+	v_or_b32_e32 v16, v43, v44
+	v_add_u32_e32 v44, 0, v16
+	v_or_b32_e32 v16, v43, v40
+	v_add_u32_e32 v40, 0, v16
+	ds_write_b32 v44, v58 offset:32768
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	ds_read_b32 v16, v40 offset:32768
+	.loc	1 225 25                        ; flash_attention.py:225:25
+	v_exp_f32_e32 v17, v17
+	v_exp_f32_e32 v18, v18
+	v_exp_f32_e32 v19, v19
+	v_exp_f32_e32 v39, v39
+	v_exp_f32_e32 v41, v41
+	v_exp_f32_e32 v42, v42
+	v_exp_f32_e32 v45, v45
+	v_exp_f32_e32 v46, v46
+	v_exp_f32_e32 v47, v47
+	v_exp_f32_e32 v50, v50
+	v_exp_f32_e32 v51, v51
+	v_exp_f32_e32 v54, v54
+	v_exp_f32_e32 v55, v55
+	v_exp_f32_e32 v56, v56
+	v_exp_f32_e32 v52, v52
+	.loc	1 233 26                        ; flash_attention.py:233:26
+	v_cvt_pk_f16_f32 v31, v31, v32
+	v_cvt_pk_f16_f32 v24, v24, v25
+	v_cvt_pk_f16_f32 v25, v26, v27
+	v_cvt_pk_f16_f32 v26, v33, v34
+	v_cvt_pk_f16_f32 v20, v35, v20
+	v_cvt_pk_f16_f32 v21, v21, v22
+	v_cvt_pk_f16_f32 v22, v23, v36
+	v_cvt_pk_f16_f32 v23, v37, v38
+	v_cvt_pk_f16_f32 v27, v57, v17
+	v_cvt_pk_f16_f32 v32, v18, v19
+	v_cvt_pk_f16_f32 v33, v39, v41
+	v_cvt_pk_f16_f32 v34, v42, v45
+	v_cvt_pk_f16_f32 v35, v46, v47
+	.loc	1 233 42 is_stmt 0              ; flash_attention.py:233:42
+	s_waitcnt lgkmcnt(0)
+	v_pk_mul_f32 v[0:1], v[0:1], v[16:17] op_sel_hi:[1,0]
+	.loc	1 233 26                        ; flash_attention.py:233:26
+	v_cvt_pk_f16_f32 v36, v50, v51
+	v_cvt_pk_f16_f32 v37, v54, v55
+	v_cvt_pk_f16_f32 v38, v56, v52
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	ds_write_b16 v80, v31 offset:32768
+	ds_write_b16_d16_hi v80, v31 offset:32896
+	ds_write_b16 v80, v20 offset:34816
+	ds_write_b16_d16_hi v80, v20 offset:34944
+	ds_write_b16 v80, v27 offset:36864
+	ds_write_b16_d16_hi v80, v27 offset:36992
+	ds_write_b16 v80, v35 offset:38912
+	ds_write_b16_d16_hi v80, v35 offset:39040
+	ds_write_b16 v81, v24 offset:33024
+	ds_write_b16_d16_hi v81, v24 offset:33152
+	ds_write_b16 v81, v21 offset:35072
+	ds_write_b16_d16_hi v81, v21 offset:35200
+	ds_write_b16 v81, v32 offset:37120
+	ds_write_b16_d16_hi v81, v32 offset:37248
+	ds_write_b16 v81, v36 offset:39168
+	ds_write_b16_d16_hi v81, v36 offset:39296
+	ds_write_b16 v82, v25 offset:33792
+	ds_write_b16_d16_hi v82, v25 offset:33920
+	ds_write_b16 v82, v22 offset:35840
+	ds_write_b16_d16_hi v82, v22 offset:35968
+	ds_write_b16 v82, v33 offset:37888
+	ds_write_b16_d16_hi v82, v33 offset:38016
+	ds_write_b16 v82, v37 offset:39936
+	ds_write_b16_d16_hi v82, v37 offset:40064
+	ds_write_b16 v83, v26 offset:34048
+	ds_write_b16_d16_hi v83, v26 offset:34176
+	ds_write_b16 v83, v23 offset:36096
+	ds_write_b16_d16_hi v83, v23 offset:36224
+	ds_write_b16 v83, v34 offset:38144
+	ds_write_b16_d16_hi v83, v34 offset:38272
+	ds_write_b16 v83, v38 offset:40192
+	ds_write_b16_d16_hi v83, v38 offset:40320
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	ds_read_b64_tr_b16 v[20:21], v84 offset:32768
+	ds_read_b64_tr_b16 v[24:25], v84 offset:34816
+	ds_read_b64_tr_b16 v[32:33], v84 offset:36864
+	ds_read_b64_tr_b16 v[76:77], v84 offset:38912
+	ds_read_b64_tr_b16 v[22:23], v85 offset:33792
+	ds_read_b64_tr_b16 v[26:27], v85 offset:35840
+	ds_read_b64_tr_b16 v[34:35], v85 offset:37888
+	ds_read_b64_tr_b16 v[78:79], v85 offset:39936
+	.loc	1 233 42                        ; flash_attention.py:233:42
+	v_pk_mul_f32 v[14:15], v[14:15], v[16:17] op_sel_hi:[1,0]
+	v_pk_mul_f32 v[12:13], v[12:13], v[16:17] op_sel_hi:[1,0]
+	v_pk_mul_f32 v[10:11], v[10:11], v[16:17] op_sel_hi:[1,0]
+	v_pk_mul_f32 v[8:9], v[8:9], v[16:17] op_sel_hi:[1,0]
+	v_pk_mul_f32 v[6:7], v[6:7], v[16:17] op_sel_hi:[1,0]
+	v_pk_mul_f32 v[4:5], v[4:5], v[16:17] op_sel_hi:[1,0]
+	v_pk_mul_f32 v[2:3], v[2:3], v[16:17] op_sel_hi:[1,0]
+	.loc	1 194 32 is_stmt 1              ; flash_attention.py:194:32
+	v_or_b32_e32 v28, s17, v30
+	.loc	1 233 42                        ; flash_attention.py:233:42
+	v_accvgpr_write_b32 a0, v0
+	v_accvgpr_write_b32 a1, v1
+	v_accvgpr_write_b32 a2, v2
+	v_accvgpr_write_b32 a3, v3
+	v_accvgpr_write_b32 a4, v4
+	v_accvgpr_write_b32 a5, v5
+	v_accvgpr_write_b32 a6, v6
+	v_accvgpr_write_b32 a7, v7
+	v_accvgpr_write_b32 a8, v8
+	v_accvgpr_write_b32 a9, v9
+	v_accvgpr_write_b32 a10, v10
+	v_accvgpr_write_b32 a11, v11
+	v_accvgpr_write_b32 a12, v12
+	v_accvgpr_write_b32 a13, v13
+	v_accvgpr_write_b32 a14, v14
+	v_accvgpr_write_b32 a15, v15
+.Ltmp112:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v0, v57, v59
+	v_add_f32_e32 v0, v17, v0
+.Ltmp113:
+	.loc	1 233 42                        ; flash_attention.py:233:42
+	s_waitcnt lgkmcnt(3)
+	v_mfma_f32_32x32x16_f16 a[0:15], v[60:63], v[20:23], a[0:15]
+.Ltmp114:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v0, v18, v0
+	v_add_f32_e32 v0, v19, v0
+	v_add_f32_e32 v0, v39, v0
+	v_add_f32_e32 v0, v41, v0
+	v_add_f32_e32 v0, v42, v0
+	v_add_f32_e32 v0, v45, v0
+	v_add_f32_e32 v0, v46, v0
+.Ltmp115:
+	.loc	1 233 42                        ; flash_attention.py:233:42
+	s_waitcnt lgkmcnt(2)
+	v_mfma_f32_32x32x16_f16 a[0:15], v[64:67], v[24:27], a[0:15]
+.Ltmp116:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v0, v47, v0
+	v_add_f32_e32 v0, v50, v0
+	v_add_f32_e32 v0, v51, v0
+	v_add_f32_e32 v0, v54, v0
+	v_add_f32_e32 v0, v55, v0
+	v_add_f32_e32 v0, v56, v0
+	v_add_f32_e32 v0, v52, v0
+.Ltmp117:
+	.loc	1 233 42                        ; flash_attention.py:233:42
+	s_waitcnt lgkmcnt(1)
+	v_mfma_f32_32x32x16_f16 a[0:15], v[68:71], v[32:35], a[0:15]
+.Ltmp118:
+	.loc	2 293 36                        ; standard.py:293:36 @[ flash_attention.py:226:37 ]
+	v_mov_b32_e32 v1, v0
+	s_nop 1
+	v_permlane32_swap_b32_e32 v0, v1
+.Ltmp119:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:226:37 ] ]
+	v_add_f32_e32 v0, v0, v1
+.Ltmp120:
+	.loc	1 226 30                        ; flash_attention.py:226:30
+	v_fmac_f32_e32 v0, v53, v58
+	.loc	1 238 16                        ; flash_attention.py:238:16
+	ds_write_b32 v44, v0
+	s_waitcnt lgkmcnt(0)
+	.loc	1 233 42                        ; flash_attention.py:233:42
+	v_mfma_f32_32x32x16_f16 a[0:15], v[72:75], v[76:79], a[0:15]
+	.loc	1 238 16                        ; flash_attention.py:238:16
+	s_barrier
+	ds_read_b32 v15, v40
+	s_mov_b32 s10, 0x7ffffffe
+	.loc	1 233 42                        ; flash_attention.py:233:42
+	s_nop 8
+	v_accvgpr_read_b32 v1, a0
+	.loc	1 238 16                        ; flash_attention.py:238:16
+	s_waitcnt lgkmcnt(0)
+	v_div_scale_f32 v0, s[2:3], v15, v15, v1
+	v_rcp_f32_e32 v14, v0
+	.loc	1 233 42                        ; flash_attention.py:233:42
+	v_accvgpr_read_b32 v2, a1
+	v_accvgpr_read_b32 v3, a2
+	v_accvgpr_read_b32 v4, a3
+	.loc	1 238 16                        ; flash_attention.py:238:16
+	v_fma_f32 v19, -v0, v14, 1.0
+	v_fmac_f32_e32 v14, v19, v14
+	v_div_scale_f32 v19, vcc, v1, v15, v1
+	v_mul_f32_e32 v20, v19, v14
+	v_fma_f32 v21, -v0, v20, v19
+	v_fmac_f32_e32 v20, v21, v14
+	v_fma_f32 v0, -v0, v20, v19
+	v_div_scale_f32 v19, s[2:3], v15, v15, v2
+	v_rcp_f32_e32 v21, v19
+	v_div_fmas_f32 v0, v0, v14, v20
+	v_div_fixup_f32 v0, v0, v15, v1
+	.loc	1 233 42                        ; flash_attention.py:233:42
+	v_accvgpr_read_b32 v5, a4
+	.loc	1 238 16                        ; flash_attention.py:238:16
+	v_fma_f32 v1, -v19, v21, 1.0
+	v_fmac_f32_e32 v21, v1, v21
+	v_div_scale_f32 v1, vcc, v2, v15, v2
+	v_mul_f32_e32 v14, v1, v21
+	v_fma_f32 v20, -v19, v14, v1
+	v_fmac_f32_e32 v14, v20, v21
+	v_fma_f32 v1, -v19, v14, v1
+	v_div_scale_f32 v19, s[2:3], v15, v15, v3
+	v_rcp_f32_e32 v20, v19
+	v_div_fmas_f32 v1, v1, v21, v14
+	v_div_fixup_f32 v1, v1, v15, v2
+	.loc	1 233 42                        ; flash_attention.py:233:42
+	v_accvgpr_read_b32 v6, a5
+	.loc	1 238 16                        ; flash_attention.py:238:16
+	v_fma_f32 v2, -v19, v20, 1.0
+	v_fmac_f32_e32 v20, v2, v20
+	v_div_scale_f32 v2, vcc, v3, v15, v3
+	v_mul_f32_e32 v14, v2, v20
+	v_fma_f32 v21, -v19, v14, v2
+	v_fmac_f32_e32 v14, v21, v20
+	v_fma_f32 v2, -v19, v14, v2
+	v_div_scale_f32 v19, s[2:3], v15, v15, v4
+	v_rcp_f32_e32 v21, v19
+	v_div_fmas_f32 v2, v2, v20, v14
+	v_div_fixup_f32 v2, v2, v15, v3
+	.loc	1 233 42                        ; flash_attention.py:233:42
+	v_accvgpr_read_b32 v7, a6
+	.loc	1 238 16                        ; flash_attention.py:238:16
+	v_fma_f32 v3, -v19, v21, 1.0
+	v_fmac_f32_e32 v21, v3, v21
+	v_div_scale_f32 v3, vcc, v4, v15, v4
+	v_mul_f32_e32 v14, v3, v21
+	v_fma_f32 v20, -v19, v14, v3
+	v_fmac_f32_e32 v14, v20, v21
+	v_fma_f32 v3, -v19, v14, v3
+	v_div_scale_f32 v19, s[2:3], v15, v15, v5
+	v_rcp_f32_e32 v20, v19
+	v_div_fmas_f32 v3, v3, v21, v14
+	v_div_fixup_f32 v3, v3, v15, v4
+	.loc	1 233 42                        ; flash_attention.py:233:42
+	v_accvgpr_read_b32 v8, a7
+	.loc	1 238 16                        ; flash_attention.py:238:16
+	v_fma_f32 v4, -v19, v20, 1.0
+	v_fmac_f32_e32 v20, v4, v20
+	v_div_scale_f32 v4, vcc, v5, v15, v5
+	v_mul_f32_e32 v14, v4, v20
+	v_fma_f32 v21, -v19, v14, v4
+	v_fmac_f32_e32 v14, v21, v20
+	v_fma_f32 v4, -v19, v14, v4
+	v_div_scale_f32 v19, s[2:3], v15, v15, v6
+	v_rcp_f32_e32 v21, v19
+	v_div_fmas_f32 v4, v4, v20, v14
+	v_div_fixup_f32 v4, v4, v15, v5
+	.loc	1 233 42                        ; flash_attention.py:233:42
+	v_accvgpr_read_b32 v9, a8
+	.loc	1 238 16                        ; flash_attention.py:238:16
+	v_fma_f32 v5, -v19, v21, 1.0
+	v_fmac_f32_e32 v21, v5, v21
+	v_div_scale_f32 v5, vcc, v6, v15, v6
+	v_mul_f32_e32 v14, v5, v21
+	v_fma_f32 v20, -v19, v14, v5
+	v_fmac_f32_e32 v14, v20, v21
+	v_fma_f32 v5, -v19, v14, v5
+	v_div_scale_f32 v19, s[2:3], v15, v15, v7
+	v_rcp_f32_e32 v20, v19
+	v_div_fmas_f32 v5, v5, v21, v14
+	v_div_fixup_f32 v5, v5, v15, v6
+	.loc	1 233 42                        ; flash_attention.py:233:42
+	v_accvgpr_read_b32 v10, a9
+	.loc	1 238 16                        ; flash_attention.py:238:16
+	v_fma_f32 v6, -v19, v20, 1.0
+	v_fmac_f32_e32 v20, v6, v20
+	v_div_scale_f32 v6, vcc, v7, v15, v7
+	v_mul_f32_e32 v14, v6, v20
+	v_fma_f32 v21, -v19, v14, v6
+	v_fmac_f32_e32 v14, v21, v20
+	v_fma_f32 v6, -v19, v14, v6
+	v_div_scale_f32 v19, s[2:3], v15, v15, v8
+	v_rcp_f32_e32 v21, v19
+	v_div_fmas_f32 v6, v6, v20, v14
+	v_div_fixup_f32 v6, v6, v15, v7
+	.loc	1 233 42                        ; flash_attention.py:233:42
+	v_accvgpr_read_b32 v11, a10
+	.loc	1 238 16                        ; flash_attention.py:238:16
+	v_fma_f32 v7, -v19, v21, 1.0
+	v_fmac_f32_e32 v21, v7, v21
+	v_div_scale_f32 v7, vcc, v8, v15, v8
+	v_mul_f32_e32 v14, v7, v21
+	v_fma_f32 v20, -v19, v14, v7
+	v_fmac_f32_e32 v14, v20, v21
+	v_fma_f32 v7, -v19, v14, v7
+	v_div_scale_f32 v19, s[2:3], v15, v15, v9
+	v_rcp_f32_e32 v20, v19
+	v_div_fmas_f32 v7, v7, v21, v14
+	v_div_fixup_f32 v7, v7, v15, v8
+	.loc	1 233 42                        ; flash_attention.py:233:42
+	v_accvgpr_read_b32 v12, a11
+	.loc	1 238 16                        ; flash_attention.py:238:16
+	v_fma_f32 v8, -v19, v20, 1.0
+	v_fmac_f32_e32 v20, v8, v20
+	v_div_scale_f32 v8, vcc, v9, v15, v9
+	v_mul_f32_e32 v14, v8, v20
+	v_fma_f32 v21, -v19, v14, v8
+	v_fmac_f32_e32 v14, v21, v20
+	v_fma_f32 v8, -v19, v14, v8
+	v_div_scale_f32 v19, s[2:3], v15, v15, v10
+	v_rcp_f32_e32 v21, v19
+	v_div_fmas_f32 v8, v8, v20, v14
+	v_div_fixup_f32 v8, v8, v15, v9
+	.loc	1 233 42                        ; flash_attention.py:233:42
+	v_accvgpr_read_b32 v13, a12
+	.loc	1 238 16                        ; flash_attention.py:238:16
+	v_fma_f32 v9, -v19, v21, 1.0
+	v_fmac_f32_e32 v21, v9, v21
+	v_div_scale_f32 v9, vcc, v10, v15, v10
+	v_mul_f32_e32 v14, v9, v21
+	v_fma_f32 v20, -v19, v14, v9
+	v_fmac_f32_e32 v14, v20, v21
+	v_fma_f32 v9, -v19, v14, v9
+	v_div_scale_f32 v19, s[2:3], v15, v15, v11
+	v_rcp_f32_e32 v20, v19
+	v_div_fmas_f32 v9, v9, v21, v14
+	v_div_fixup_f32 v9, v9, v15, v10
+	.loc	1 233 42                        ; flash_attention.py:233:42
+	v_accvgpr_read_b32 v16, a13
+	.loc	1 238 16                        ; flash_attention.py:238:16
+	v_fma_f32 v10, -v19, v20, 1.0
+	v_fmac_f32_e32 v20, v10, v20
+	v_div_scale_f32 v10, vcc, v11, v15, v11
+	v_mul_f32_e32 v14, v10, v20
+	v_fma_f32 v21, -v19, v14, v10
+	v_fmac_f32_e32 v14, v21, v20
+	v_fma_f32 v10, -v19, v14, v10
+	v_div_scale_f32 v19, s[2:3], v15, v15, v12
+	v_rcp_f32_e32 v21, v19
+	v_div_fmas_f32 v10, v10, v20, v14
+	v_div_fixup_f32 v10, v10, v15, v11
+	.loc	1 233 42                        ; flash_attention.py:233:42
+	v_accvgpr_read_b32 v17, a14
+	.loc	1 238 16                        ; flash_attention.py:238:16
+	v_fma_f32 v11, -v19, v21, 1.0
+	v_fmac_f32_e32 v21, v11, v21
+	v_div_scale_f32 v11, vcc, v12, v15, v12
+	v_mul_f32_e32 v14, v11, v21
+	v_fma_f32 v20, -v19, v14, v11
+	v_fmac_f32_e32 v14, v20, v21
+	v_fma_f32 v11, -v19, v14, v11
+	v_div_scale_f32 v19, s[2:3], v15, v15, v13
+	v_rcp_f32_e32 v20, v19
+	v_div_fmas_f32 v11, v11, v21, v14
+	v_div_fixup_f32 v11, v11, v15, v12
+	.loc	1 233 42                        ; flash_attention.py:233:42
+	v_accvgpr_read_b32 v18, a15
+	.loc	1 238 16                        ; flash_attention.py:238:16
+	v_fma_f32 v12, -v19, v20, 1.0
+	v_fmac_f32_e32 v20, v12, v20
+	v_div_scale_f32 v12, vcc, v13, v15, v13
+	v_mul_f32_e32 v14, v12, v20
+	v_fma_f32 v21, -v19, v14, v12
+	v_fmac_f32_e32 v14, v21, v20
+	v_fma_f32 v12, -v19, v14, v12
+	v_div_scale_f32 v19, s[2:3], v15, v15, v16
+	v_rcp_f32_e32 v21, v19
+	v_div_fmas_f32 v12, v12, v20, v14
+	v_div_fixup_f32 v12, v12, v15, v13
+	v_fma_f32 v13, -v19, v21, 1.0
+	v_fmac_f32_e32 v21, v13, v21
+	v_div_scale_f32 v13, vcc, v16, v15, v16
+	v_mul_f32_e32 v14, v13, v21
+	v_fma_f32 v20, -v19, v14, v13
+	v_fmac_f32_e32 v14, v20, v21
+	v_fma_f32 v13, -v19, v14, v13
+	v_div_scale_f32 v19, s[2:3], v15, v15, v17
+	v_rcp_f32_e32 v20, v19
+	v_div_fmas_f32 v13, v13, v21, v14
+	v_div_fixup_f32 v13, v13, v15, v16
+	v_fma_f32 v14, -v19, v20, 1.0
+	v_fmac_f32_e32 v20, v14, v20
+	v_div_scale_f32 v14, vcc, v17, v15, v17
+	v_mul_f32_e32 v16, v14, v20
+	v_fma_f32 v21, -v19, v16, v14
+	v_fmac_f32_e32 v16, v21, v20
+	v_fma_f32 v14, -v19, v16, v14
+	v_div_scale_f32 v19, s[2:3], v15, v15, v18
+	v_rcp_f32_e32 v21, v19
+	v_div_fmas_f32 v14, v14, v20, v16
+	v_div_fixup_f32 v14, v14, v15, v17
+	v_fma_f32 v16, -v19, v21, 1.0
+	v_fmac_f32_e32 v21, v16, v21
+	v_div_scale_f32 v16, vcc, v18, v15, v18
+	v_mul_f32_e32 v17, v16, v21
+	v_fma_f32 v20, -v19, v17, v16
+	v_fmac_f32_e32 v17, v20, v21
+	v_fma_f32 v16, -v19, v17, v16
+	v_div_fmas_f32 v16, v16, v21, v17
+	v_div_fixup_f32 v15, v16, v15, v18
+	.loc	1 240 21                        ; flash_attention.py:240:21
+	v_lshlrev_b32_e32 v16, 6, v30
+	v_or3_b32 v17, v29, v16, s11
+	.loc	1 240 32 is_stmt 0              ; flash_attention.py:240:32
+	v_lshlrev_b32_e32 v17, 2, v17
+	v_bfrev_b32_e32 v18, 1
+	.loc	1 199 32 is_stmt 1              ; flash_attention.py:199:32
+	v_cmp_gt_i32_e32 vcc, s0, v28
+	.loc	1 240 21                        ; flash_attention.py:240:21
+	v_or3_b32 v16, s11, v29, v16
+	s_mov_b32 s11, 0x27000
+	.loc	1 240 32 is_stmt 0              ; flash_attention.py:240:32
+	v_cndmask_b32_e32 v17, v18, v17, vcc
+	buffer_store_dwordx4 v[0:3], v17, s[8:11], 0 offen
+	s_nop 1
+	v_lshlrev_b32_e32 v0, 2, v16
+	v_or_b32_e32 v1, 32, v0
+	v_cndmask_b32_e32 v1, v18, v1, vcc
+	buffer_store_dwordx4 v[4:7], v1, s[8:11], 0 offen
+	v_or_b32_e32 v1, 64, v0
+	v_or_b32_e32 v0, 0x60, v0
+	v_cndmask_b32_e32 v1, v18, v1, vcc
+	v_cndmask_b32_e32 v0, v18, v0, vcc
+	buffer_store_dwordx4 v[8:11], v1, s[8:11], 0 offen
+	buffer_store_dwordx4 v[12:15], v0, s[8:11], 0 offen
+	.loc	1 240 4                         ; flash_attention.py:240:4
+	s_endpgm
+.Ltmp121:
+	.section	.rodata,"a",@progbits
+	.p2align	6, 0x0
+	.amdhsa_kernel flash_attention_fwd_async_buffer_kernel
+		.amdhsa_group_segment_fixed_size 0
+		.amdhsa_private_segment_fixed_size 0
+		.amdhsa_kernarg_size 56
+		.amdhsa_user_sgpr_count 16
+		.amdhsa_user_sgpr_dispatch_ptr 0
+		.amdhsa_user_sgpr_queue_ptr 0
+		.amdhsa_user_sgpr_kernarg_segment_ptr 1
+		.amdhsa_user_sgpr_dispatch_id 0
+		.amdhsa_user_sgpr_kernarg_preload_length 14
+		.amdhsa_user_sgpr_kernarg_preload_offset 0
+		.amdhsa_user_sgpr_private_segment_size 0
+		.amdhsa_uses_dynamic_stack 0
+		.amdhsa_enable_private_segment 0
+		.amdhsa_system_sgpr_workgroup_id_x 1
+		.amdhsa_system_sgpr_workgroup_id_y 0
+		.amdhsa_system_sgpr_workgroup_id_z 0
+		.amdhsa_system_sgpr_workgroup_info 0
+		.amdhsa_system_vgpr_workitem_id 0
+		.amdhsa_next_free_vgpr 156
+		.amdhsa_next_free_sgpr 25
+		.amdhsa_accum_offset 124
+		.amdhsa_reserve_vcc 1
+		.amdhsa_reserve_xnack_mask 1
+		.amdhsa_float_round_mode_32 0
+		.amdhsa_float_round_mode_16_64 0
+		.amdhsa_float_denorm_mode_32 3
+		.amdhsa_float_denorm_mode_16_64 3
+		.amdhsa_dx10_clamp 1
+		.amdhsa_ieee_mode 1
+		.amdhsa_fp16_overflow 0
+		.amdhsa_tg_split 0
+		.amdhsa_exception_fp_ieee_invalid_op 0
+		.amdhsa_exception_fp_denorm_src 0
+		.amdhsa_exception_fp_ieee_div_zero 0
+		.amdhsa_exception_fp_ieee_overflow 0
+		.amdhsa_exception_fp_ieee_underflow 0
+		.amdhsa_exception_fp_ieee_inexact 0
+		.amdhsa_exception_int_div_zero 0
+	.end_amdhsa_kernel
+	.text
+.Lfunc_end0:
+	.size	flash_attention_fwd_async_buffer_kernel, .Lfunc_end0-flash_attention_fwd_async_buffer_kernel
+	.cfi_endproc
+                                        ; -- End function
+	.set flash_attention_fwd_async_buffer_kernel.num_vgpr, 124
+	.set flash_attention_fwd_async_buffer_kernel.num_agpr, 32
+	.set flash_attention_fwd_async_buffer_kernel.numbered_sgpr, 25
+	.set flash_attention_fwd_async_buffer_kernel.num_named_barrier, 0
+	.set flash_attention_fwd_async_buffer_kernel.private_seg_size, 0
+	.set flash_attention_fwd_async_buffer_kernel.uses_vcc, 1
+	.set flash_attention_fwd_async_buffer_kernel.uses_flat_scratch, 0
+	.set flash_attention_fwd_async_buffer_kernel.has_dyn_sized_stack, 0
+	.set flash_attention_fwd_async_buffer_kernel.has_recursion, 0
+	.set flash_attention_fwd_async_buffer_kernel.has_indirect_call, 0
+	.section	.AMDGPU.csdata,"",@progbits
+; Kernel info:
+; codeLenInByte = 8328
+; TotalNumSgprs: 31
+; NumVgprs: 124
+; NumAgprs: 32
+; TotalNumVgprs: 156
+; ScratchSize: 0
+; MemoryBound: 0
+; FloatMode: 240
+; IeeeMode: 1
+; LDSByteSize: 0 bytes/workgroup (compile time only)
+; SGPRBlocks: 3
+; VGPRBlocks: 19
+; NumSGPRsForWavesPerEU: 31
+; NumVGPRsForWavesPerEU: 156
+; AccumOffset: 124
+; Occupancy: 3
+; WaveLimiterHint : 0
+; COMPUTE_PGM_RSRC2:SCRATCH_EN: 0
+; COMPUTE_PGM_RSRC2:USER_SGPR: 16
+; COMPUTE_PGM_RSRC2:TRAP_HANDLER: 0
+; COMPUTE_PGM_RSRC2:TGID_X_EN: 1
+; COMPUTE_PGM_RSRC2:TGID_Y_EN: 0
+; COMPUTE_PGM_RSRC2:TGID_Z_EN: 0
+; COMPUTE_PGM_RSRC2:TIDIG_COMP_CNT: 0
+; COMPUTE_PGM_RSRC3_GFX90A:ACCUM_OFFSET: 30
+; COMPUTE_PGM_RSRC3_GFX90A:TG_SPLIT: 0
+	.text
+	.p2alignl 6, 3212836864
+	.fill 256, 4, 3212836864
+	.section	.AMDGPU.gpr_maximums,"",@progbits
+	.set amdgpu.max_num_vgpr, 0
+	.set amdgpu.max_num_agpr, 0
+	.set amdgpu.max_num_sgpr, 0
+	.text
+	.section	.debug_abbrev,"",@progbits
+	.byte	1                               ; Abbreviation Code
+	.byte	17                              ; DW_TAG_compile_unit
+	.byte	1                               ; DW_CHILDREN_yes
+	.byte	37                              ; DW_AT_producer
+	.byte	14                              ; DW_FORM_strp
+	.byte	19                              ; DW_AT_language
+	.byte	5                               ; DW_FORM_data2
+	.byte	3                               ; DW_AT_name
+	.byte	14                              ; DW_FORM_strp
+	.byte	16                              ; DW_AT_stmt_list
+	.byte	23                              ; DW_FORM_sec_offset
+	.byte	27                              ; DW_AT_comp_dir
+	.byte	14                              ; DW_FORM_strp
+	.byte	17                              ; DW_AT_low_pc
+	.byte	1                               ; DW_FORM_addr
+	.byte	18                              ; DW_AT_high_pc
+	.byte	6                               ; DW_FORM_data4
+	.byte	0                               ; EOM(1)
+	.byte	0                               ; EOM(2)
+	.byte	2                               ; Abbreviation Code
+	.byte	46                              ; DW_TAG_subprogram
+	.byte	0                               ; DW_CHILDREN_no
+	.byte	3                               ; DW_AT_name
+	.byte	14                              ; DW_FORM_strp
+	.byte	32                              ; DW_AT_inline
+	.byte	11                              ; DW_FORM_data1
+	.byte	0                               ; EOM(1)
+	.byte	0                               ; EOM(2)
+	.byte	3                               ; Abbreviation Code
+	.byte	46                              ; DW_TAG_subprogram
+	.byte	1                               ; DW_CHILDREN_yes
+	.byte	17                              ; DW_AT_low_pc
+	.byte	1                               ; DW_FORM_addr
+	.byte	18                              ; DW_AT_high_pc
+	.byte	6                               ; DW_FORM_data4
+	.byte	49                              ; DW_AT_abstract_origin
+	.byte	19                              ; DW_FORM_ref4
+	.byte	0                               ; EOM(1)
+	.byte	0                               ; EOM(2)
+	.byte	4                               ; Abbreviation Code
+	.byte	29                              ; DW_TAG_inlined_subroutine
+	.byte	1                               ; DW_CHILDREN_yes
+	.byte	49                              ; DW_AT_abstract_origin
+	.byte	19                              ; DW_FORM_ref4
+	.byte	85                              ; DW_AT_ranges
+	.byte	23                              ; DW_FORM_sec_offset
+	.byte	88                              ; DW_AT_call_file
+	.byte	11                              ; DW_FORM_data1
+	.byte	89                              ; DW_AT_call_line
+	.byte	11                              ; DW_FORM_data1
+	.byte	87                              ; DW_AT_call_column
+	.byte	11                              ; DW_FORM_data1
+	.byte	0                               ; EOM(1)
+	.byte	0                               ; EOM(2)
+	.byte	5                               ; Abbreviation Code
+	.byte	29                              ; DW_TAG_inlined_subroutine
+	.byte	0                               ; DW_CHILDREN_no
+	.byte	49                              ; DW_AT_abstract_origin
+	.byte	19                              ; DW_FORM_ref4
+	.byte	85                              ; DW_AT_ranges
+	.byte	23                              ; DW_FORM_sec_offset
+	.byte	88                              ; DW_AT_call_file
+	.byte	11                              ; DW_FORM_data1
+	.byte	89                              ; DW_AT_call_line
+	.byte	11                              ; DW_FORM_data1
+	.byte	87                              ; DW_AT_call_column
+	.byte	11                              ; DW_FORM_data1
+	.byte	0                               ; EOM(1)
+	.byte	0                               ; EOM(2)
+	.byte	6                               ; Abbreviation Code
+	.byte	29                              ; DW_TAG_inlined_subroutine
+	.byte	0                               ; DW_CHILDREN_no
+	.byte	49                              ; DW_AT_abstract_origin
+	.byte	19                              ; DW_FORM_ref4
+	.byte	85                              ; DW_AT_ranges
+	.byte	23                              ; DW_FORM_sec_offset
+	.byte	88                              ; DW_AT_call_file
+	.byte	11                              ; DW_FORM_data1
+	.byte	89                              ; DW_AT_call_line
+	.byte	5                               ; DW_FORM_data2
+	.byte	87                              ; DW_AT_call_column
+	.byte	11                              ; DW_FORM_data1
+	.byte	0                               ; EOM(1)
+	.byte	0                               ; EOM(2)
+	.byte	0                               ; EOM(3)
+	.section	.debug_info,"",@progbits
+.Lcu_begin0:
+	.long	.Ldebug_info_end0-.Ldebug_info_start0 ; Length of Unit
+.Ldebug_info_start0:
+	.short	4                               ; DWARF version number
+	.long	.debug_abbrev                   ; Offset Into Abbrev. Section
+	.byte	8                               ; Address Size (in bytes)
+	.byte	1                               ; Abbrev [1] 0xb:0x6b DW_TAG_compile_unit
+	.long	.Linfo_string0                  ; DW_AT_producer
+	.short	2                               ; DW_AT_language
+	.long	.Linfo_string1                  ; DW_AT_name
+	.long	.Lline_table_start0             ; DW_AT_stmt_list
+	.long	.Linfo_string2                  ; DW_AT_comp_dir
+	.quad	.Lfunc_begin0                   ; DW_AT_low_pc
+	.long	.Lfunc_end0-.Lfunc_begin0       ; DW_AT_high_pc
+	.byte	2                               ; Abbrev [2] 0x2a:0x6 DW_TAG_subprogram
+	.long	.Linfo_string3                  ; DW_AT_name
+	.byte	1                               ; DW_AT_inline
+	.byte	3                               ; Abbrev [3] 0x30:0x45 DW_TAG_subprogram
+	.quad	.Lfunc_begin0                   ; DW_AT_low_pc
+	.long	.Lfunc_end0-.Lfunc_begin0       ; DW_AT_high_pc
+	.long	42                              ; DW_AT_abstract_origin
+	.byte	4                               ; Abbrev [4] 0x41:0x19 DW_TAG_inlined_subroutine
+	.long	42                              ; DW_AT_abstract_origin
+	.long	.Ldebug_ranges0                 ; DW_AT_ranges
+	.byte	1                               ; DW_AT_call_file
+	.byte	223                             ; DW_AT_call_line
+	.byte	39                              ; DW_AT_call_column
+	.byte	5                               ; Abbrev [5] 0x4d:0xc DW_TAG_inlined_subroutine
+	.long	42                              ; DW_AT_abstract_origin
+	.long	.Ldebug_ranges1                 ; DW_AT_ranges
+	.byte	2                               ; DW_AT_call_file
+	.byte	191                             ; DW_AT_call_line
+	.byte	40                              ; DW_AT_call_column
+	.byte	0                               ; End Of Children Mark
+	.byte	4                               ; Abbrev [4] 0x5a:0x1a DW_TAG_inlined_subroutine
+	.long	42                              ; DW_AT_abstract_origin
+	.long	.Ldebug_ranges2                 ; DW_AT_ranges
+	.byte	1                               ; DW_AT_call_file
+	.byte	226                             ; DW_AT_call_line
+	.byte	37                              ; DW_AT_call_column
+	.byte	6                               ; Abbrev [6] 0x66:0xd DW_TAG_inlined_subroutine
+	.long	42                              ; DW_AT_abstract_origin
+	.long	.Ldebug_ranges3                 ; DW_AT_ranges
+	.byte	2                               ; DW_AT_call_file
+	.short	293                             ; DW_AT_call_line
+	.byte	36                              ; DW_AT_call_column
+	.byte	0                               ; End Of Children Mark
+	.byte	0                               ; End Of Children Mark
+	.byte	0                               ; End Of Children Mark
+.Ldebug_info_end0:
+	.section	.debug_ranges,"",@progbits
+.Ldebug_ranges0:
+	.quad	.Ltmp2-.Lfunc_begin0
+	.quad	.Ltmp3-.Lfunc_begin0
+	.quad	.Ltmp4-.Lfunc_begin0
+	.quad	.Ltmp5-.Lfunc_begin0
+	.quad	.Ltmp6-.Lfunc_begin0
+	.quad	.Ltmp7-.Lfunc_begin0
+	.quad	.Ltmp8-.Lfunc_begin0
+	.quad	.Ltmp9-.Lfunc_begin0
+	.quad	.Ltmp10-.Lfunc_begin0
+	.quad	.Ltmp11-.Lfunc_begin0
+	.quad	.Ltmp12-.Lfunc_begin0
+	.quad	.Ltmp13-.Lfunc_begin0
+	.quad	.Ltmp14-.Lfunc_begin0
+	.quad	.Ltmp15-.Lfunc_begin0
+	.quad	.Ltmp16-.Lfunc_begin0
+	.quad	.Ltmp17-.Lfunc_begin0
+	.quad	.Ltmp18-.Lfunc_begin0
+	.quad	.Ltmp19-.Lfunc_begin0
+	.quad	.Ltmp20-.Lfunc_begin0
+	.quad	.Ltmp21-.Lfunc_begin0
+	.quad	.Ltmp22-.Lfunc_begin0
+	.quad	.Ltmp23-.Lfunc_begin0
+	.quad	.Ltmp24-.Lfunc_begin0
+	.quad	.Ltmp25-.Lfunc_begin0
+	.quad	.Ltmp26-.Lfunc_begin0
+	.quad	.Ltmp28-.Lfunc_begin0
+	.quad	.Ltmp87-.Lfunc_begin0
+	.quad	.Ltmp89-.Lfunc_begin0
+	.quad	0
+	.quad	0
+.Ldebug_ranges1:
+	.quad	.Ltmp2-.Lfunc_begin0
+	.quad	.Ltmp3-.Lfunc_begin0
+	.quad	.Ltmp4-.Lfunc_begin0
+	.quad	.Ltmp5-.Lfunc_begin0
+	.quad	.Ltmp6-.Lfunc_begin0
+	.quad	.Ltmp7-.Lfunc_begin0
+	.quad	.Ltmp8-.Lfunc_begin0
+	.quad	.Ltmp9-.Lfunc_begin0
+	.quad	.Ltmp10-.Lfunc_begin0
+	.quad	.Ltmp11-.Lfunc_begin0
+	.quad	.Ltmp12-.Lfunc_begin0
+	.quad	.Ltmp13-.Lfunc_begin0
+	.quad	.Ltmp14-.Lfunc_begin0
+	.quad	.Ltmp15-.Lfunc_begin0
+	.quad	.Ltmp16-.Lfunc_begin0
+	.quad	.Ltmp17-.Lfunc_begin0
+	.quad	.Ltmp18-.Lfunc_begin0
+	.quad	.Ltmp19-.Lfunc_begin0
+	.quad	.Ltmp20-.Lfunc_begin0
+	.quad	.Ltmp21-.Lfunc_begin0
+	.quad	.Ltmp22-.Lfunc_begin0
+	.quad	.Ltmp23-.Lfunc_begin0
+	.quad	.Ltmp24-.Lfunc_begin0
+	.quad	.Ltmp25-.Lfunc_begin0
+	.quad	.Ltmp26-.Lfunc_begin0
+	.quad	.Ltmp27-.Lfunc_begin0
+	.quad	.Ltmp87-.Lfunc_begin0
+	.quad	.Ltmp88-.Lfunc_begin0
+	.quad	0
+	.quad	0
+.Ldebug_ranges2:
+	.quad	.Ltmp29-.Lfunc_begin0
+	.quad	.Ltmp30-.Lfunc_begin0
+	.quad	.Ltmp31-.Lfunc_begin0
+	.quad	.Ltmp32-.Lfunc_begin0
+	.quad	.Ltmp33-.Lfunc_begin0
+	.quad	.Ltmp34-.Lfunc_begin0
+	.quad	.Ltmp35-.Lfunc_begin0
+	.quad	.Ltmp36-.Lfunc_begin0
+	.quad	.Ltmp37-.Lfunc_begin0
+	.quad	.Ltmp38-.Lfunc_begin0
+	.quad	.Ltmp39-.Lfunc_begin0
+	.quad	.Ltmp40-.Lfunc_begin0
+	.quad	.Ltmp41-.Lfunc_begin0
+	.quad	.Ltmp42-.Lfunc_begin0
+	.quad	.Ltmp43-.Lfunc_begin0
+	.quad	.Ltmp44-.Lfunc_begin0
+	.quad	.Ltmp45-.Lfunc_begin0
+	.quad	.Ltmp46-.Lfunc_begin0
+	.quad	.Ltmp47-.Lfunc_begin0
+	.quad	.Ltmp48-.Lfunc_begin0
+	.quad	.Ltmp49-.Lfunc_begin0
+	.quad	.Ltmp50-.Lfunc_begin0
+	.quad	.Ltmp51-.Lfunc_begin0
+	.quad	.Ltmp52-.Lfunc_begin0
+	.quad	.Ltmp53-.Lfunc_begin0
+	.quad	.Ltmp54-.Lfunc_begin0
+	.quad	.Ltmp55-.Lfunc_begin0
+	.quad	.Ltmp56-.Lfunc_begin0
+	.quad	.Ltmp57-.Lfunc_begin0
+	.quad	.Ltmp58-.Lfunc_begin0
+	.quad	.Ltmp59-.Lfunc_begin0
+	.quad	.Ltmp60-.Lfunc_begin0
+	.quad	.Ltmp61-.Lfunc_begin0
+	.quad	.Ltmp62-.Lfunc_begin0
+	.quad	.Ltmp63-.Lfunc_begin0
+	.quad	.Ltmp64-.Lfunc_begin0
+	.quad	.Ltmp65-.Lfunc_begin0
+	.quad	.Ltmp66-.Lfunc_begin0
+	.quad	.Ltmp67-.Lfunc_begin0
+	.quad	.Ltmp68-.Lfunc_begin0
+	.quad	.Ltmp69-.Lfunc_begin0
+	.quad	.Ltmp70-.Lfunc_begin0
+	.quad	.Ltmp71-.Lfunc_begin0
+	.quad	.Ltmp72-.Lfunc_begin0
+	.quad	.Ltmp73-.Lfunc_begin0
+	.quad	.Ltmp74-.Lfunc_begin0
+	.quad	.Ltmp75-.Lfunc_begin0
+	.quad	.Ltmp76-.Lfunc_begin0
+	.quad	.Ltmp77-.Lfunc_begin0
+	.quad	.Ltmp78-.Lfunc_begin0
+	.quad	.Ltmp79-.Lfunc_begin0
+	.quad	.Ltmp80-.Lfunc_begin0
+	.quad	.Ltmp81-.Lfunc_begin0
+	.quad	.Ltmp82-.Lfunc_begin0
+	.quad	.Ltmp83-.Lfunc_begin0
+	.quad	.Ltmp86-.Lfunc_begin0
+	.quad	.Ltmp90-.Lfunc_begin0
+	.quad	.Ltmp91-.Lfunc_begin0
+	.quad	.Ltmp92-.Lfunc_begin0
+	.quad	.Ltmp93-.Lfunc_begin0
+	.quad	.Ltmp94-.Lfunc_begin0
+	.quad	.Ltmp95-.Lfunc_begin0
+	.quad	.Ltmp96-.Lfunc_begin0
+	.quad	.Ltmp97-.Lfunc_begin0
+	.quad	.Ltmp98-.Lfunc_begin0
+	.quad	.Ltmp99-.Lfunc_begin0
+	.quad	.Ltmp100-.Lfunc_begin0
+	.quad	.Ltmp101-.Lfunc_begin0
+	.quad	.Ltmp102-.Lfunc_begin0
+	.quad	.Ltmp103-.Lfunc_begin0
+	.quad	.Ltmp104-.Lfunc_begin0
+	.quad	.Ltmp105-.Lfunc_begin0
+	.quad	.Ltmp106-.Lfunc_begin0
+	.quad	.Ltmp107-.Lfunc_begin0
+	.quad	.Ltmp108-.Lfunc_begin0
+	.quad	.Ltmp109-.Lfunc_begin0
+	.quad	.Ltmp110-.Lfunc_begin0
+	.quad	.Ltmp111-.Lfunc_begin0
+	.quad	.Ltmp112-.Lfunc_begin0
+	.quad	.Ltmp113-.Lfunc_begin0
+	.quad	.Ltmp114-.Lfunc_begin0
+	.quad	.Ltmp115-.Lfunc_begin0
+	.quad	.Ltmp116-.Lfunc_begin0
+	.quad	.Ltmp117-.Lfunc_begin0
+	.quad	.Ltmp118-.Lfunc_begin0
+	.quad	.Ltmp120-.Lfunc_begin0
+	.quad	0
+	.quad	0
+.Ldebug_ranges3:
+	.quad	.Ltmp29-.Lfunc_begin0
+	.quad	.Ltmp30-.Lfunc_begin0
+	.quad	.Ltmp31-.Lfunc_begin0
+	.quad	.Ltmp32-.Lfunc_begin0
+	.quad	.Ltmp33-.Lfunc_begin0
+	.quad	.Ltmp34-.Lfunc_begin0
+	.quad	.Ltmp35-.Lfunc_begin0
+	.quad	.Ltmp36-.Lfunc_begin0
+	.quad	.Ltmp37-.Lfunc_begin0
+	.quad	.Ltmp38-.Lfunc_begin0
+	.quad	.Ltmp39-.Lfunc_begin0
+	.quad	.Ltmp40-.Lfunc_begin0
+	.quad	.Ltmp41-.Lfunc_begin0
+	.quad	.Ltmp42-.Lfunc_begin0
+	.quad	.Ltmp43-.Lfunc_begin0
+	.quad	.Ltmp44-.Lfunc_begin0
+	.quad	.Ltmp45-.Lfunc_begin0
+	.quad	.Ltmp46-.Lfunc_begin0
+	.quad	.Ltmp47-.Lfunc_begin0
+	.quad	.Ltmp48-.Lfunc_begin0
+	.quad	.Ltmp49-.Lfunc_begin0
+	.quad	.Ltmp50-.Lfunc_begin0
+	.quad	.Ltmp51-.Lfunc_begin0
+	.quad	.Ltmp52-.Lfunc_begin0
+	.quad	.Ltmp53-.Lfunc_begin0
+	.quad	.Ltmp54-.Lfunc_begin0
+	.quad	.Ltmp55-.Lfunc_begin0
+	.quad	.Ltmp56-.Lfunc_begin0
+	.quad	.Ltmp57-.Lfunc_begin0
+	.quad	.Ltmp58-.Lfunc_begin0
+	.quad	.Ltmp59-.Lfunc_begin0
+	.quad	.Ltmp60-.Lfunc_begin0
+	.quad	.Ltmp61-.Lfunc_begin0
+	.quad	.Ltmp62-.Lfunc_begin0
+	.quad	.Ltmp63-.Lfunc_begin0
+	.quad	.Ltmp64-.Lfunc_begin0
+	.quad	.Ltmp65-.Lfunc_begin0
+	.quad	.Ltmp66-.Lfunc_begin0
+	.quad	.Ltmp67-.Lfunc_begin0
+	.quad	.Ltmp68-.Lfunc_begin0
+	.quad	.Ltmp69-.Lfunc_begin0
+	.quad	.Ltmp70-.Lfunc_begin0
+	.quad	.Ltmp71-.Lfunc_begin0
+	.quad	.Ltmp72-.Lfunc_begin0
+	.quad	.Ltmp73-.Lfunc_begin0
+	.quad	.Ltmp74-.Lfunc_begin0
+	.quad	.Ltmp75-.Lfunc_begin0
+	.quad	.Ltmp76-.Lfunc_begin0
+	.quad	.Ltmp77-.Lfunc_begin0
+	.quad	.Ltmp78-.Lfunc_begin0
+	.quad	.Ltmp79-.Lfunc_begin0
+	.quad	.Ltmp80-.Lfunc_begin0
+	.quad	.Ltmp81-.Lfunc_begin0
+	.quad	.Ltmp82-.Lfunc_begin0
+	.quad	.Ltmp83-.Lfunc_begin0
+	.quad	.Ltmp84-.Lfunc_begin0
+	.quad	.Ltmp85-.Lfunc_begin0
+	.quad	.Ltmp86-.Lfunc_begin0
+	.quad	.Ltmp90-.Lfunc_begin0
+	.quad	.Ltmp91-.Lfunc_begin0
+	.quad	.Ltmp92-.Lfunc_begin0
+	.quad	.Ltmp93-.Lfunc_begin0
+	.quad	.Ltmp94-.Lfunc_begin0
+	.quad	.Ltmp95-.Lfunc_begin0
+	.quad	.Ltmp96-.Lfunc_begin0
+	.quad	.Ltmp97-.Lfunc_begin0
+	.quad	.Ltmp98-.Lfunc_begin0
+	.quad	.Ltmp99-.Lfunc_begin0
+	.quad	.Ltmp100-.Lfunc_begin0
+	.quad	.Ltmp101-.Lfunc_begin0
+	.quad	.Ltmp102-.Lfunc_begin0
+	.quad	.Ltmp103-.Lfunc_begin0
+	.quad	.Ltmp104-.Lfunc_begin0
+	.quad	.Ltmp105-.Lfunc_begin0
+	.quad	.Ltmp106-.Lfunc_begin0
+	.quad	.Ltmp107-.Lfunc_begin0
+	.quad	.Ltmp108-.Lfunc_begin0
+	.quad	.Ltmp109-.Lfunc_begin0
+	.quad	.Ltmp110-.Lfunc_begin0
+	.quad	.Ltmp111-.Lfunc_begin0
+	.quad	.Ltmp112-.Lfunc_begin0
+	.quad	.Ltmp113-.Lfunc_begin0
+	.quad	.Ltmp114-.Lfunc_begin0
+	.quad	.Ltmp115-.Lfunc_begin0
+	.quad	.Ltmp116-.Lfunc_begin0
+	.quad	.Ltmp117-.Lfunc_begin0
+	.quad	.Ltmp119-.Lfunc_begin0
+	.quad	.Ltmp120-.Lfunc_begin0
+	.quad	0
+	.quad	0
+	.section	.debug_str,"MS",@progbits,1
+.Linfo_string0:
+	.asciz	"triton"                        ; string offset=0
+.Linfo_string1:
+	.asciz	"flash_attention.py"            ; string offset=7
+.Linfo_string2:
+	.asciz	"/home/kunwar/Work/runtime-evolution/rocm-systems-rocjitsu-register-feedback/emulation/rocjitsu/tests/kernels/triton" ; string offset=26
+.Linfo_string3:
+	.asciz	"flash_attention_fwd_async_buffer_kernel" ; string offset=142
+	.section	".note.GNU-stack","",@progbits
+	.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .agpr_count:     32
+    .args:
+      - .address_space:  global
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .address_space:  global
+        .offset:         8
+        .size:           8
+        .value_kind:     global_buffer
+      - .address_space:  global
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .address_space:  global
+        .offset:         24
+        .size:           8
+        .value_kind:     global_buffer
+      - .offset:         32
+        .size:           4
+        .value_kind:     by_value
+      - .address_space:  global
+        .offset:         40
+        .size:           8
+        .value_kind:     global_buffer
+      - .address_space:  global
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+    .group_segment_fixed_size: 0
+    .kernarg_segment_align: 8
+    .kernarg_segment_size: 56
+    .max_flat_workgroup_size: 256
+    .name:           flash_attention_fwd_async_buffer_kernel
+    .private_segment_fixed_size: 0
+    .sgpr_count:     31
+    .sgpr_spill_count: 0
+    .symbol:         flash_attention_fwd_async_buffer_kernel.kd
+    .uniform_work_group_size: 1
+    .uses_dynamic_stack: false
+    .vgpr_count:     156
+    .vgpr_spill_count: 0
+    .wavefront_size: 64
+amdhsa.target:   amdgcn-amd-amdhsa--gfx950
+amdhsa.version:
+  - 1
+  - 2
+...
+
+	.end_amdgpu_metadata
+	.section	.debug_line,"",@progbits
+.Lline_table_start0:

--- a/emulation/rocjitsu/tests/kernels/triton_cdna4_flash_attention_no_async_1024.s
+++ b/emulation/rocjitsu/tests/kernels/triton_cdna4_flash_attention_no_async_1024.s
@@ -1,0 +1,1833 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// Reproduction information for this checked-in assembly fixture.
+// The original source used to generate this assembly is embedded here
+// as comments so normal builds do not need Python, Torch, or Triton.
+//
+// --- begin tests/kernels/triton/flash_attention.py ---
+// """Triton flash-attention kernels for DBT compile stress tests.
+//
+// This file is intentionally source-only: it does not register tests or change
+// the kernel CMake flow.  The kernels below are small fp16 forward kernels for a
+// single Q/K/V/O matrix pair with explicit row/feature strides.  They are meant to
+// exercise instruction decoding/translation paths when compiled with AMD Triton,
+// not to be a production attention implementation.
+//
+// The async/buffer variant uses AMD Triton backend options that are intended to
+// select the desired lowering.  The final instruction spelling is compiler-build
+// dependent, so verify generated assembly with compile_fixtures.py:
+//
+//   AMDGCN_USE_BUFFER_OPS=1
+//       Run pointer canonicalization and conversion to AMDGPU buffer ops.
+//
+//   TRITON_HIP_USE_ASYNC_COPY=1
+//       Prefer the async global-to-LDS copy pipeline.
+//
+// For best buffer-load vectorization, pass compact test tensors with feature
+// strides of one for Q/K/V/O and 16-byte-aligned base pointers.
+// """
+//
+// # Recorded no-async fixture metadata:
+// #   kernel: flash_attention_fwd_no_async_kernel
+// #   target: gfx950, wavefront_size: 64
+// #   launch sharedMemBytes used by cdna4_to_cdna3_dispatch_test: 65536
+// #   amdhsa_group_segment_fixed_size: 0
+// #   max_flat_workgroup_size: 256
+// #   kernarg_segment_size: 56
+// #   registers: vgpr_count=132, agpr_count=16, sgpr_count=23
+//
+// import triton
+// import triton.language as tl
+//
+//
+// TARGET_ARCH = "gfx950"
+// DEFAULT_Q_LEN = 1024
+// DEFAULT_KV_LEN = 1024
+// DEFAULT_HEAD_DIM = 64
+// DEFAULT_BLOCK_M = 64
+// DEFAULT_BLOCK_N = 64
+// DEFAULT_BLOCK_D = 64
+// DEFAULT_STRIDE_QM = DEFAULT_HEAD_DIM
+// DEFAULT_STRIDE_QD = 1
+// DEFAULT_STRIDE_KN = DEFAULT_HEAD_DIM
+// DEFAULT_STRIDE_KD = 1
+// DEFAULT_STRIDE_VN = DEFAULT_HEAD_DIM
+// DEFAULT_STRIDE_VD = 1
+// DEFAULT_STRIDE_OM = DEFAULT_HEAD_DIM
+// DEFAULT_STRIDE_OD = 1
+//
+// NO_ASYNC_ENV = {
+//     "TRITON_HIP_USE_ASYNC_COPY": "0",
+//     "AMDGCN_USE_BUFFER_OPS": "0",
+// }
+// ASYNC_BUFFER_ENV = {
+//     "TRITON_HIP_USE_ASYNC_COPY": "1",
+//     "AMDGCN_USE_BUFFER_OPS": "1",
+// }
+// COMMON_HIP_OPTIONS = {
+//     "num_warps": 4,
+//     "num_stages": 2,
+//     # The attention scheduler hint is local to the AMD backend and is useful
+//     # for avoiding spills in the generated stress fixture.
+//     "schedule_hint": "attention",
+// }
+//
+//
+// @triton.jit
+// def flash_attention_fwd_no_async_kernel(
+//     q_ptr,
+//     k_ptr,
+//     v_ptr,
+//     o_ptr,
+//     stride_qm: tl.constexpr,
+//     stride_qd: tl.constexpr,
+//     stride_kn: tl.constexpr,
+//     stride_kd: tl.constexpr,
+//     stride_vn: tl.constexpr,
+//     stride_vd: tl.constexpr,
+//     stride_om: tl.constexpr,
+//     stride_od: tl.constexpr,
+//     softmax_scale,
+//     Q_LEN: tl.constexpr,
+//     KV_LEN: tl.constexpr,
+//     HEAD_DIM: tl.constexpr,
+//     BLOCK_M: tl.constexpr,
+//     BLOCK_N: tl.constexpr,
+//     BLOCK_D: tl.constexpr,
+// ):
+//     """Plain blockwise flash attention.
+//
+//     Compile this variant with TRITON_HIP_USE_ASYNC_COPY=0 when the test should
+//     avoid AMD's async global-to-LDS lowering.  The loop also uses one stage so
+//     the source itself does not request Triton loop pipelining.
+//     """
+//
+//     tl.static_assert(BLOCK_M >= 64)
+//     tl.static_assert(BLOCK_N >= 64)
+//     tl.static_assert(BLOCK_D >= 64)
+//     tl.static_assert(BLOCK_D >= HEAD_DIM)
+//
+//     pid_m = tl.program_id(0)
+//     offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+//     offs_n = tl.arange(0, BLOCK_N)
+//     offs_d = tl.arange(0, BLOCK_D)
+//
+//     q_mask = (offs_m[:, None] < Q_LEN) & (offs_d[None, :] < HEAD_DIM)
+//     q = tl.load(
+//         q_ptr + offs_m[:, None] * stride_qm + offs_d[None, :] * stride_qd,
+//         mask=q_mask,
+//         other=0.0,
+//     )
+//
+//     # The online softmax state follows the FlashAttention recurrence.  A large
+//     # finite negative sentinel avoids inf - inf when the last program block has
+//     # rows outside Q_LEN; those rows are masked on store.
+//     m_i = tl.full((BLOCK_M,), -1.0e20, tl.float32)
+//     l_i = tl.zeros((BLOCK_M,), tl.float32)
+//     acc = tl.zeros((BLOCK_M, BLOCK_D), tl.float32)
+//
+//     # exp2 is the path used by Triton attention examples; convert the caller's
+//     # natural-exp scale once so the recurrence remains mathematically standard.
+//     qk_scale = softmax_scale * 1.4426950408889634
+//
+//     for start_n in tl.range(0, KV_LEN, BLOCK_N, num_stages=1):
+//         start_n = tl.multiple_of(start_n, BLOCK_N)
+//         n = start_n + offs_n
+//
+//         k_mask = (n[None, :] < KV_LEN) & (offs_d[:, None] < HEAD_DIM)
+//         k = tl.load(
+//             k_ptr + n[None, :] * stride_kn + offs_d[:, None] * stride_kd,
+//             mask=k_mask,
+//             other=0.0,
+//         )
+//
+//         qk = tl.dot(q, k, out_dtype=tl.float32) * qk_scale
+//         qk = tl.where((offs_m[:, None] < Q_LEN) & (n[None, :] < KV_LEN), qk, -1.0e20)
+//
+//         m_new = tl.maximum(m_i, tl.max(qk, axis=1))
+//         alpha = tl.math.exp2(m_i - m_new)
+//         p = tl.math.exp2(qk - m_new[:, None])
+//         l_new = l_i * alpha + tl.sum(p, axis=1)
+//
+//         v_mask = (n[:, None] < KV_LEN) & (offs_d[None, :] < HEAD_DIM)
+//         v = tl.load(
+//             v_ptr + n[:, None] * stride_vn + offs_d[None, :] * stride_vd,
+//             mask=v_mask,
+//             other=0.0,
+//         )
+//
+//         acc = acc * alpha[:, None]
+//         acc = tl.dot(p.to(tl.float16), v, acc, out_dtype=tl.float32)
+//         m_i = m_new
+//         l_i = l_new
+//
+//     out = acc / l_i[:, None]
+//     o_mask = (offs_m[:, None] < Q_LEN) & (offs_d[None, :] < HEAD_DIM)
+//     tl.store(
+//         o_ptr + offs_m[:, None] * stride_om + offs_d[None, :] * stride_od,
+//         out,
+//         mask=o_mask,
+//     )
+//
+//
+// @triton.jit
+// def flash_attention_fwd_async_buffer_kernel(
+//     q_ptr,
+//     k_ptr,
+//     v_ptr,
+//     o_ptr,
+//     stride_qm: tl.constexpr,
+//     stride_qd: tl.constexpr,
+//     stride_kn: tl.constexpr,
+//     stride_kd: tl.constexpr,
+//     stride_vn: tl.constexpr,
+//     stride_vd: tl.constexpr,
+//     stride_om: tl.constexpr,
+//     stride_od: tl.constexpr,
+//     softmax_scale,
+//     Q_LEN: tl.constexpr,
+//     KV_LEN: tl.constexpr,
+//     HEAD_DIM: tl.constexpr,
+//     BLOCK_M: tl.constexpr,
+//     BLOCK_N: tl.constexpr,
+//     BLOCK_D: tl.constexpr,
+// ):
+//     """Blockwise flash attention shaped for AMD buffer ops plus async DMA.
+//
+//     The math matches flash_attention_fwd_no_async_kernel.  Strides are
+//     constexpr so the fixture compiler can model compact contiguous tensors and
+//     keep address expressions simple enough for AMD buffer-op lowering.
+//     """
+//
+//     tl.static_assert(BLOCK_M >= 64)
+//     tl.static_assert(BLOCK_N >= 64)
+//     tl.static_assert(BLOCK_D >= 64)
+//     tl.static_assert(BLOCK_D >= HEAD_DIM)
+//
+//     pid_m = tl.program_id(0)
+//     offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int32)
+//     offs_n = tl.arange(0, BLOCK_N).to(tl.int32)
+//     offs_d = tl.max_contiguous(tl.arange(0, BLOCK_D), BLOCK_D).to(tl.int32)
+//
+//     q_offsets = offs_m[:, None] * stride_qm + offs_d[None, :] * stride_qd
+//     q_mask = (offs_m[:, None] < Q_LEN) & (offs_d[None, :] < HEAD_DIM)
+//     q = tl.load(q_ptr + q_offsets, mask=q_mask, other=0.0)
+//
+//     m_i = tl.full((BLOCK_M,), -1.0e20, tl.float32)
+//     l_i = tl.zeros((BLOCK_M,), tl.float32)
+//     acc = tl.zeros((BLOCK_M, BLOCK_D), tl.float32)
+//     qk_scale = softmax_scale * 1.4426950408889634
+//
+//     # num_stages=2 marks this as a pipelined loop in the source.  When launched
+//     # with num_stages=2 and AMD async-copy knobs enabled, the backend has the
+//     # information it needs to choose buffer-load-to-LDS for eligible K/V loads.
+//     for start_n in tl.range(0, KV_LEN, BLOCK_N, num_stages=2):
+//         start_n = tl.multiple_of(start_n, BLOCK_N)
+//         n = (start_n + offs_n).to(tl.int32)
+//
+//         k_offsets = n[None, :] * stride_kn + offs_d[:, None] * stride_kd
+//         k_mask = (n[None, :] < KV_LEN) & (offs_d[:, None] < HEAD_DIM)
+//         k = tl.load(k_ptr + k_offsets, mask=k_mask, other=0.0)
+//
+//         qk = tl.dot(q, k, out_dtype=tl.float32) * qk_scale
+//         qk = tl.where((offs_m[:, None] < Q_LEN) & (n[None, :] < KV_LEN), qk, -1.0e20)
+//
+//         m_new = tl.maximum(m_i, tl.max(qk, axis=1))
+//         alpha = tl.math.exp2(m_i - m_new)
+//         p = tl.math.exp2(qk - m_new[:, None])
+//         l_new = l_i * alpha + tl.sum(p, axis=1)
+//
+//         v_offsets = n[:, None] * stride_vn + offs_d[None, :] * stride_vd
+//         v_mask = (n[:, None] < KV_LEN) & (offs_d[None, :] < HEAD_DIM)
+//         v = tl.load(v_ptr + v_offsets, mask=v_mask, other=0.0)
+//
+//         acc = acc * alpha[:, None]
+//         acc = tl.dot(p.to(tl.float16), v, acc, out_dtype=tl.float32)
+//         m_i = m_new
+//         l_i = l_new
+//
+//     o_offsets = offs_m[:, None] * stride_om + offs_d[None, :] * stride_od
+//     out = acc / l_i[:, None]
+//     o_mask = (offs_m[:, None] < Q_LEN) & (offs_d[None, :] < HEAD_DIM)
+//     tl.store(o_ptr + o_offsets, out, mask=o_mask)
+//
+//
+// def flash_attention_grid(q_len=DEFAULT_Q_LEN, block_m=DEFAULT_BLOCK_M):
+//     return (triton.cdiv(q_len, block_m),)
+//
+//
+// __all__ = [
+//     "ASYNC_BUFFER_ENV",
+//     "COMMON_HIP_OPTIONS",
+//     "DEFAULT_BLOCK_D",
+//     "DEFAULT_BLOCK_M",
+//     "DEFAULT_BLOCK_N",
+//     "DEFAULT_HEAD_DIM",
+//     "DEFAULT_KV_LEN",
+//     "DEFAULT_Q_LEN",
+//     "DEFAULT_STRIDE_KD",
+//     "DEFAULT_STRIDE_KN",
+//     "DEFAULT_STRIDE_OD",
+//     "DEFAULT_STRIDE_OM",
+//     "DEFAULT_STRIDE_QD",
+//     "DEFAULT_STRIDE_QM",
+//     "DEFAULT_STRIDE_VD",
+//     "DEFAULT_STRIDE_VN",
+//     "NO_ASYNC_ENV",
+//     "TARGET_ARCH",
+//     "flash_attention_fwd_async_buffer_kernel",
+//     "flash_attention_fwd_no_async_kernel",
+//     "flash_attention_grid",
+// ]
+// --- end tests/kernels/triton/flash_attention.py ---
+
+	.amdgcn_target "amdgcn-amd-amdhsa--gfx950"
+	.amdhsa_code_object_version 5
+	.text
+	.globl	flash_attention_fwd_no_async_kernel ; -- Begin function flash_attention_fwd_no_async_kernel
+	.p2align	8
+	.type	flash_attention_fwd_no_async_kernel,@function
+flash_attention_fwd_no_async_kernel:    ; @flash_attention_fwd_no_async_kernel
+.Lfunc_begin0:
+	.cfi_sections .debug_frame
+	.cfi_startproc
+; %bb.9:
+	.file	1 "/home/kunwar/Work/runtime-evolution/rocm-systems-rocjitsu-register-feedback/emulation/rocjitsu/tests/kernels/triton" "flash_attention.py"
+	.loc	1 61 0 prologue_end             ; flash_attention.py:61:0
+	s_load_dwordx2 s[2:3], s[0:1], 0x0
+	s_load_dwordx8 s[4:11], s[0:1], 0x8
+	s_load_dwordx4 s[12:15], s[0:1], 0x28
+	s_waitcnt lgkmcnt(0)
+	s_branch .LBB0_0
+	.loc	1 0 0 is_stmt 0                 ; :0:0
+.Ltmp0:
+	.p2align	8
+; %bb.10:
+.LBB0_0:
+.Ltmp1:
+	.loc	1 95 21 is_stmt 1               ; flash_attention.py:95:21
+	s_lshl_b32 s11, s16, 6
+	.loc	1 95 44 is_stmt 0               ; flash_attention.py:95:44
+	v_lshrrev_b32_e32 v1, 3, v0
+	.loc	1 95 31                         ; flash_attention.py:95:31
+	v_or_b32_e32 v4, s11, v1
+	.loc	1 99 49 is_stmt 1               ; flash_attention.py:99:49
+	v_lshlrev_b32_e32 v1, 3, v0
+	s_movk_i32 s0, 0x400
+	v_and_b32_e32 v2, 56, v1
+	.loc	1 99 32 is_stmt 0               ; flash_attention.py:99:32
+	v_cmp_gt_i32_e32 vcc, s0, v4
+	.loc	1 101 46 is_stmt 1              ; flash_attention.py:101:46
+	v_mov_b32_e32 v6, 0
+	v_lshlrev_b32_e32 v2, 1, v2
+	v_mov_b32_e32 v10, 0
+	v_mov_b32_e32 v11, 0
+	v_mov_b32_e32 v12, 0
+	v_mov_b32_e32 v13, 0
+	.loc	1 101 8 is_stmt 0               ; flash_attention.py:101:8
+	s_and_saveexec_b64 s[0:1], vcc
+	s_cbranch_execz .LBB0_2
+; %bb.1:
+	.loc	1 0 8                           ; flash_attention.py:0:8
+	v_lshlrev_b32_e32 v8, 6, v4
+	v_ashrrev_i32_e32 v9, 31, v8
+	v_lshl_add_u64 v[8:9], v[8:9], 1, s[2:3]
+	v_mov_b32_e32 v3, v6
+	v_lshl_add_u64 v[8:9], v[8:9], 0, v[2:3]
+	.loc	1 101 8                         ; flash_attention.py:101:8
+	global_load_dwordx4 v[10:13], v[8:9], off
+.LBB0_2:
+	.loc	1 0 8                           ; flash_attention.py:0:8
+	s_or_b64 exec, exec, s[0:1]
+	v_mov_b32_e32 v7, 0
+	v_mov_b32_e32 v8, 0
+	v_mov_b32_e32 v9, 0
+	.loc	1 101 8                         ; flash_attention.py:101:8
+	s_and_saveexec_b64 s[0:1], vcc
+	s_cbranch_execz .LBB0_4
+; %bb.3:
+	.loc	1 101 34                        ; flash_attention.py:101:34
+	v_mov_b32_e32 v3, 0x800
+	v_lshl_or_b32 v4, v4, 6, v3
+	.loc	1 101 16                        ; flash_attention.py:101:16
+	v_ashrrev_i32_e32 v5, 31, v4
+	v_lshl_add_u64 v[4:5], v[4:5], 1, s[2:3]
+	.loc	1 101 46                        ; flash_attention.py:101:46
+	v_mov_b32_e32 v3, 0
+	v_lshl_add_u64 v[2:3], v[4:5], 0, v[2:3]
+	.loc	1 101 8                         ; flash_attention.py:101:8
+	global_load_dwordx4 v[6:9], v[2:3], off
+.LBB0_4:
+	.loc	1 0 8                           ; flash_attention.py:0:8
+	s_or_b64 exec, exec, s[0:1]
+	.loc	1 95 44 is_stmt 1               ; flash_attention.py:95:44
+	v_and_b32_e32 v2, 64, v0
+	v_and_b32_e32 v52, 31, v0
+	v_lshrrev_b32_e32 v50, 1, v2
+	.loc	1 95 31 is_stmt 0               ; flash_attention.py:95:31
+	v_or3_b32 v4, s11, v52, v50
+	s_movk_i32 s0, 0x400
+	.loc	1 99 32 is_stmt 1               ; flash_attention.py:99:32
+	v_cmp_gt_i32_e32 vcc, s0, v4
+	.loc	1 101 8                         ; flash_attention.py:101:8
+	v_lshlrev_b32_e32 v4, 4, v0
+	s_movk_i32 s0, 0x70
+	v_bitop3_b32 v14, v4, v0, s0 bitop3:0x78
+	.loc	1 95 44                         ; flash_attention.py:95:44
+	v_and_b32_e32 v51, 32, v0
+	.loc	1 101 8                         ; flash_attention.py:101:8
+	v_add_u32_e32 v54, 0, v14
+	s_waitcnt vmcnt(0)
+	ds_write_b128 v54, v[10:13]
+	ds_write_b128 v54, v[6:9] offset:4096
+	v_and_b32_e32 v7, 0x70, v1
+	v_lshrrev_b32_e32 v8, 1, v51
+	v_lshlrev_b32_e32 v9, 6, v2
+	v_lshlrev_b32_e32 v6, 7, v52
+	v_bitop3_b32 v9, v7, v9, v8 bitop3:0xde
+	v_or_b32_e32 v10, v9, v6
+	s_movk_i32 s0, 0x60
+	v_add_u32_e32 v11, 0, v10
+	v_xad_u32 v12, v10, 32, 0
+	v_xad_u32 v10, v10, 64, 0
+	v_bitop3_b32 v9, v9, s0, v6 bitop3:0x36
+	.loc	1 95 44                         ; flash_attention.py:95:44
+	v_bfe_i32 v3, v0, 5, 1
+	.loc	1 101 8                         ; flash_attention.py:101:8
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	ds_read_b128 v[16:19], v11
+	ds_read_b128 v[20:23], v12
+	v_add_u32_e32 v9, 0, v9
+	ds_read_b128 v[24:27], v10
+	ds_read_b128 v[28:31], v9
+	v_lshlrev_b32_e32 v10, 1, v52
+	s_movk_i32 s0, 0x210
+	.loc	1 115 31                        ; flash_attention.py:115:31
+	v_mov_b32_e32 v9, 0x3fb8aa3b
+	v_and_b32_e32 v11, 0x210, v3
+	v_bitop3_b32 v3, v3, v10, s0 bitop3:0x6c
+	v_and_b32_e32 v1, 24, v1
+	v_bfe_i32 v15, v0, 3, 1
+	s_movk_i32 s0, 0x108
+	.loc	1 95 44                         ; flash_attention.py:95:44
+	v_and_b32_e32 v53, 0x80, v0
+	.loc	1 115 31                        ; flash_attention.py:115:31
+	v_mul_f32_e32 v55, s10, v9
+	v_lshlrev_b32_e32 v9, 1, v2
+	v_or_b32_e32 v10, v3, v2
+	v_bitop3_b32 v12, v3, 8, v2 bitop3:0x36
+	v_bitop3_b32 v13, v3, 32, v2 bitop3:0x36
+	v_bitop3_b32 v2, v3, 40, v2 bitop3:0x36
+	v_lshlrev_b32_e32 v3, 5, v0
+	v_bitop3_b32 v15, v15, v1, s0 bitop3:0x6c
+	.loc	1 101 8                         ; flash_attention.py:101:8
+	v_and_b32_e32 v5, 0x70, v0
+	v_and_b32_e32 v14, 0x80, v3
+	v_lshrrev_b32_e32 v34, 1, v53
+	v_xor_b32_e32 v15, v15, v11
+	s_movk_i32 s0, 0x180
+	v_lshlrev_b32_e32 v32, 1, v0
+	v_or3_b32 v14, v14, v34, v15
+	v_lshrrev_b32_e32 v5, 1, v5
+	v_and_b32_e32 v34, 0x48, v0
+	v_and_or_b32 v1, v3, s0, v1
+	.loc	1 117 48                        ; flash_attention.py:117:48
+	v_and_b32_e32 v0, 7, v0
+	v_bitop3_b32 v56, v6, v8, v7 bitop3:0x36
+	v_and_b32_e32 v33, 32, v32
+	v_xor_b32_e32 v58, v4, v5
+	v_bitop3_b32 v1, v11, v1, v34 bitop3:0x36
+	v_and_b32_e32 v4, 0xf80, v4
+	v_lshlrev_b32_e32 v0, 4, v0
+	s_movk_i32 s0, 0x1000
+	v_xor_b32_e32 v6, 32, v56
+	v_xor_b32_e32 v7, 64, v56
+	v_xor_b32_e32 v8, 0x60, v56
+	v_lshl_add_u32 v57, v52, 2, 0
+	v_or_b32_e32 v15, v14, v33
+	v_bitop3_b32 v14, v14, 32, v32 bitop3:0x34
+	v_xor_b32_e32 v5, 8, v58
+	v_or_b32_e32 v3, v1, v33
+	v_bitop3_b32 v1, v1, 32, v32 bitop3:0x34
+	v_or3_b32 v36, v4, v0, s0
+	v_mov_b32_e32 v37, 0
+	.loc	1 119 22                        ; flash_attention.py:119:22
+	v_accvgpr_write_b32 a15, 0
+	v_accvgpr_write_b32 a14, 0
+	v_accvgpr_write_b32 a13, 0
+	v_accvgpr_write_b32 a12, 0
+	v_accvgpr_write_b32 a11, 0
+	v_accvgpr_write_b32 a10, 0
+	v_accvgpr_write_b32 a9, 0
+	v_accvgpr_write_b32 a8, 0
+	v_accvgpr_write_b32 a7, 0
+	v_accvgpr_write_b32 a6, 0
+	v_accvgpr_write_b32 a5, 0
+	v_accvgpr_write_b32 a4, 0
+	v_accvgpr_write_b32 a3, 0
+	v_accvgpr_write_b32 a2, 0
+	v_accvgpr_write_b32 a1, 0
+	v_accvgpr_write_b32 a0, 0
+	.loc	1 117 48                        ; flash_attention.py:117:48
+	v_lshl_add_u64 v[32:33], s[6:7], 0, v[36:37]
+	v_lshl_add_u64 v[34:35], s[4:5], 0, v[36:37]
+	v_mov_b32_e32 v36, 0xe0ad78ec
+	s_movk_i32 s2, 0xffc0
+	v_add_u32_e32 v59, 0, v6
+	v_add_u32_e32 v60, 0, v7
+	v_add_u32_e32 v61, 0, v8
+	v_add_u32_e32 v62, 0, v10
+	v_add_u32_e32 v64, 0, v12
+	v_add_u32_e32 v65, 0, v13
+	v_add_u32_e32 v66, 0, v2
+	v_add_u32_e32 v67, 0, v15
+	v_add_u32_e32 v68, 0, v14
+	v_add_u32_e32 v69, 0, v5
+	v_add_u32_e32 v70, 0, v3
+	v_add_u32_e32 v71, 0, v1
+	s_mov_b64 s[0:1], 0x2000
+	v_add_u32_e32 v63, v57, v9
+	v_mov_b32_e32 v0, 0xe0ad78ec
+.LBB0_5:                                ; =>This Inner Loop Header: Depth=1
+	.loc	1 123 12                        ; flash_attention.py:123:12
+	global_load_dwordx4 v[2:5], v[34:35], off offset:-4096
+	global_load_dwordx4 v[12:15], v[34:35], off
+	v_add_u32_e32 v6, 0, v56
+	.loc	1 119 22                        ; flash_attention.py:119:22
+	s_nop 7
+	v_accvgpr_read_b32 v9, a15
+	v_accvgpr_read_b32 v8, a14
+	v_accvgpr_read_b32 v11, a13
+	v_accvgpr_read_b32 v10, a12
+	v_accvgpr_read_b32 v39, a11
+	v_accvgpr_read_b32 v38, a10
+	v_accvgpr_read_b32 v41, a9
+	v_accvgpr_read_b32 v40, a8
+	v_accvgpr_read_b32 v43, a7
+	v_accvgpr_read_b32 v42, a6
+	v_accvgpr_read_b32 v45, a5
+	v_accvgpr_read_b32 v44, a4
+	v_accvgpr_read_b32 v47, a3
+	v_accvgpr_read_b32 v46, a2
+	v_accvgpr_read_b32 v49, a1
+	v_accvgpr_read_b32 v48, a0
+	.loc	1 123 12                        ; flash_attention.py:123:12
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	v_mov_b32_e32 v1, v37
+	.loc	1 117 48                        ; flash_attention.py:117:48
+	s_add_i32 s2, s2, 64
+	v_lshl_add_u64 v[34:35], v[34:35], 0, s[0:1]
+	s_cmpk_lt_u32 s2, 0x3c0
+	.loc	1 123 12                        ; flash_attention.py:123:12
+	s_waitcnt vmcnt(1)
+	ds_write_b128 v54, v[2:5]
+	s_waitcnt vmcnt(0)
+	ds_write_b128 v54, v[12:15] offset:4096
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	ds_read_b128 v[2:5], v6
+	ds_read_b128 v[12:15], v6 offset:4096
+	ds_read_b128 v[72:75], v59
+	ds_read_b128 v[76:79], v59 offset:4096
+	ds_read_b128 v[80:83], v60
+	ds_read_b128 v[84:87], v60 offset:4096
+	ds_read_b128 v[88:91], v61
+	ds_read_b128 v[92:95], v61 offset:4096
+	.loc	1 128 23                        ; flash_attention.py:128:23
+	s_waitcnt lgkmcnt(7)
+	v_mfma_f32_32x32x16_f16 a[0:15], v[2:5], v[16:19], 0
+	s_waitcnt lgkmcnt(5)
+	v_mfma_f32_32x32x16_f16 a[0:15], v[72:75], v[20:23], a[0:15]
+	s_waitcnt lgkmcnt(3)
+	v_mfma_f32_32x32x16_f16 a[0:15], v[80:83], v[24:27], a[0:15]
+	s_waitcnt lgkmcnt(1)
+	v_mfma_f32_32x32x16_f16 a[0:15], v[88:91], v[28:31], a[0:15]
+	s_nop 11
+	v_accvgpr_read_b32 v2, a0
+	v_accvgpr_read_b32 v3, a1
+	v_accvgpr_read_b32 v4, a2
+	v_accvgpr_read_b32 v5, a3
+	v_accvgpr_read_b32 v6, a4
+	v_accvgpr_read_b32 v7, a5
+	v_accvgpr_read_b32 v37, a6
+	v_accvgpr_read_b32 v72, a7
+	v_accvgpr_read_b32 v73, a8
+	v_accvgpr_read_b32 v74, a9
+	v_accvgpr_read_b32 v75, a10
+	v_accvgpr_read_b32 v80, a11
+	v_accvgpr_read_b32 v81, a12
+	v_accvgpr_read_b32 v82, a13
+	v_accvgpr_read_b32 v83, a14
+	v_accvgpr_read_b32 v88, a15
+	v_mfma_f32_32x32x16_f16 a[0:15], v[12:15], v[16:19], 0
+	.loc	1 128 50 is_stmt 0              ; flash_attention.py:128:50
+	v_mul_f32_e32 v2, v55, v2
+	v_mul_f32_e32 v3, v55, v3
+	v_mul_f32_e32 v4, v55, v4
+	v_mul_f32_e32 v5, v55, v5
+	v_mul_f32_e32 v72, v55, v72
+	.loc	1 130 67 is_stmt 1              ; flash_attention.py:130:67
+	v_cndmask_b32_e32 v2, v36, v2, vcc
+	v_cndmask_b32_e32 v3, v36, v3, vcc
+	.loc	1 128 23                        ; flash_attention.py:128:23
+	v_mfma_f32_32x32x16_f16 a[0:15], v[76:79], v[20:23], a[0:15]
+	.loc	1 128 50 is_stmt 0              ; flash_attention.py:128:50
+	v_mul_f32_e32 v6, v55, v6
+	v_mul_f32_e32 v7, v55, v7
+	.loc	1 130 67 is_stmt 1              ; flash_attention.py:130:67
+	v_cndmask_b32_e32 v4, v36, v4, vcc
+	v_cndmask_b32_e32 v5, v36, v5, vcc
+	.loc	1 128 50                        ; flash_attention.py:128:50
+	v_mul_f32_e32 v37, v55, v37
+	.loc	1 130 67                        ; flash_attention.py:130:67
+	v_cndmask_b32_e32 v6, v36, v6, vcc
+	v_cndmask_b32_e32 v7, v36, v7, vcc
+	.loc	1 128 23                        ; flash_attention.py:128:23
+	v_mfma_f32_32x32x16_f16 a[0:15], v[84:87], v[24:27], a[0:15]
+	.loc	1 128 50 is_stmt 0              ; flash_attention.py:128:50
+	v_mul_f32_e32 v73, v55, v73
+	v_mul_f32_e32 v74, v55, v74
+	.loc	1 130 67 is_stmt 1              ; flash_attention.py:130:67
+	v_cndmask_b32_e32 v37, v36, v37, vcc
+	.loc	1 128 50                        ; flash_attention.py:128:50
+	v_mul_f32_e32 v75, v55, v75
+	v_mul_f32_e32 v80, v55, v80
+	.loc	1 130 67                        ; flash_attention.py:130:67
+	v_cndmask_b32_e32 v73, v36, v73, vcc
+	v_cndmask_b32_e32 v74, v36, v74, vcc
+	.loc	1 128 23                        ; flash_attention.py:128:23
+	s_waitcnt lgkmcnt(0)
+	v_mfma_f32_32x32x16_f16 a[0:15], v[92:95], v[28:31], a[0:15]
+	.loc	1 130 67                        ; flash_attention.py:130:67
+	v_cndmask_b32_e32 v93, v36, v72, vcc
+.Ltmp2:
+	.file	2 "/home/kunwar/Work/runtime-evolution/rocm-systems-rocjitsu-register-feedback/emulation/rocjitsu/.env/lib/python3.12/site-packages/triton/language" "standard.py"
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ flash_attention.py:133:39 ] ]
+	v_max_f32_e32 v72, v2, v3
+	v_max3_f32 v72, v72, v4, v5
+	v_max3_f32 v72, v72, v6, v7
+	v_max3_f32 v72, v72, v37, v93
+.Ltmp3:
+	.loc	1 128 50                        ; flash_attention.py:128:50
+	v_mul_f32_e32 v81, v55, v81
+	v_mul_f32_e32 v82, v55, v82
+	.loc	1 130 67                        ; flash_attention.py:130:67
+	v_cndmask_b32_e32 v75, v36, v75, vcc
+	v_cndmask_b32_e32 v80, v36, v80, vcc
+.Ltmp4:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ flash_attention.py:133:39 ] ]
+	v_max3_f32 v72, v72, v73, v74
+.Ltmp5:
+	.loc	1 128 50                        ; flash_attention.py:128:50
+	v_mul_f32_e32 v83, v55, v83
+	v_mul_f32_e32 v88, v55, v88
+	.loc	1 128 23 is_stmt 0              ; flash_attention.py:128:23
+	v_accvgpr_read_b32 v12, a0
+	v_accvgpr_read_b32 v13, a1
+	.loc	1 130 67 is_stmt 1              ; flash_attention.py:130:67
+	v_cndmask_b32_e32 v81, v36, v81, vcc
+	v_cndmask_b32_e32 v82, v36, v82, vcc
+.Ltmp6:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ flash_attention.py:133:39 ] ]
+	v_max3_f32 v72, v72, v75, v80
+.Ltmp7:
+	.loc	1 128 23                        ; flash_attention.py:128:23
+	v_accvgpr_read_b32 v14, a2
+	v_accvgpr_read_b32 v15, a3
+	.loc	1 128 50 is_stmt 0              ; flash_attention.py:128:50
+	v_mul_f32_e32 v12, v55, v12
+	v_mul_f32_e32 v13, v55, v13
+	.loc	1 130 67 is_stmt 1              ; flash_attention.py:130:67
+	v_cndmask_b32_e32 v83, v36, v83, vcc
+	v_cndmask_b32_e32 v88, v36, v88, vcc
+.Ltmp8:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ flash_attention.py:133:39 ] ]
+	v_max3_f32 v72, v72, v81, v82
+.Ltmp9:
+	.loc	1 128 23                        ; flash_attention.py:128:23
+	v_accvgpr_read_b32 v76, a4
+	v_accvgpr_read_b32 v77, a5
+	.loc	1 128 50 is_stmt 0              ; flash_attention.py:128:50
+	v_mul_f32_e32 v14, v55, v14
+	v_mul_f32_e32 v15, v55, v15
+	.loc	1 130 67 is_stmt 1              ; flash_attention.py:130:67
+	v_cndmask_b32_e32 v12, v36, v12, vcc
+	v_cndmask_b32_e32 v13, v36, v13, vcc
+.Ltmp10:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ flash_attention.py:133:39 ] ]
+	v_max3_f32 v72, v72, v83, v88
+.Ltmp11:
+	.loc	1 128 23                        ; flash_attention.py:128:23
+	v_accvgpr_read_b32 v78, a6
+	v_accvgpr_read_b32 v79, a7
+	.loc	1 128 50 is_stmt 0              ; flash_attention.py:128:50
+	v_mul_f32_e32 v76, v55, v76
+	v_mul_f32_e32 v77, v55, v77
+	.loc	1 130 67 is_stmt 1              ; flash_attention.py:130:67
+	v_cndmask_b32_e32 v14, v36, v14, vcc
+	v_cndmask_b32_e32 v15, v36, v15, vcc
+.Ltmp12:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ flash_attention.py:133:39 ] ]
+	v_max3_f32 v72, v72, v12, v13
+.Ltmp13:
+	.loc	1 128 23                        ; flash_attention.py:128:23
+	v_accvgpr_read_b32 v84, a8
+	v_accvgpr_read_b32 v85, a9
+	.loc	1 128 50 is_stmt 0              ; flash_attention.py:128:50
+	v_mul_f32_e32 v78, v55, v78
+	v_mul_f32_e32 v79, v55, v79
+	.loc	1 130 67 is_stmt 1              ; flash_attention.py:130:67
+	v_cndmask_b32_e32 v76, v36, v76, vcc
+	v_cndmask_b32_e32 v77, v36, v77, vcc
+.Ltmp14:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ flash_attention.py:133:39 ] ]
+	v_max3_f32 v72, v72, v14, v15
+.Ltmp15:
+	.loc	1 128 23                        ; flash_attention.py:128:23
+	v_accvgpr_read_b32 v86, a10
+	v_accvgpr_read_b32 v87, a11
+	.loc	1 128 50 is_stmt 0              ; flash_attention.py:128:50
+	v_mul_f32_e32 v84, v55, v84
+	v_mul_f32_e32 v85, v55, v85
+	.loc	1 130 67 is_stmt 1              ; flash_attention.py:130:67
+	v_cndmask_b32_e32 v78, v36, v78, vcc
+	v_cndmask_b32_e32 v79, v36, v79, vcc
+.Ltmp16:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ flash_attention.py:133:39 ] ]
+	v_max3_f32 v72, v72, v76, v77
+.Ltmp17:
+	.loc	1 128 23                        ; flash_attention.py:128:23
+	v_accvgpr_read_b32 v89, a12
+	v_accvgpr_read_b32 v90, a13
+	.loc	1 128 50 is_stmt 0              ; flash_attention.py:128:50
+	v_mul_f32_e32 v86, v55, v86
+	v_mul_f32_e32 v87, v55, v87
+	.loc	1 130 67 is_stmt 1              ; flash_attention.py:130:67
+	v_cndmask_b32_e32 v84, v36, v84, vcc
+	v_cndmask_b32_e32 v85, v36, v85, vcc
+.Ltmp18:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ flash_attention.py:133:39 ] ]
+	v_max3_f32 v72, v72, v78, v79
+.Ltmp19:
+	.loc	1 128 23                        ; flash_attention.py:128:23
+	v_accvgpr_read_b32 v91, a14
+	v_accvgpr_read_b32 v92, a15
+	.loc	1 128 50 is_stmt 0              ; flash_attention.py:128:50
+	v_mul_f32_e32 v89, v55, v89
+	v_mul_f32_e32 v90, v55, v90
+	.loc	1 130 67 is_stmt 1              ; flash_attention.py:130:67
+	v_cndmask_b32_e32 v86, v36, v86, vcc
+	v_cndmask_b32_e32 v87, v36, v87, vcc
+.Ltmp20:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ flash_attention.py:133:39 ] ]
+	v_max3_f32 v72, v72, v84, v85
+.Ltmp21:
+	.loc	1 128 50                        ; flash_attention.py:128:50
+	v_mul_f32_e32 v91, v55, v91
+	v_mul_f32_e32 v92, v55, v92
+	.loc	1 130 67                        ; flash_attention.py:130:67
+	v_cndmask_b32_e32 v89, v36, v89, vcc
+	v_cndmask_b32_e32 v90, v36, v90, vcc
+.Ltmp22:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ flash_attention.py:133:39 ] ]
+	v_max3_f32 v72, v72, v86, v87
+.Ltmp23:
+	.loc	1 130 67                        ; flash_attention.py:130:67
+	v_cndmask_b32_e32 v91, v36, v91, vcc
+	v_cndmask_b32_e32 v92, v36, v92, vcc
+.Ltmp24:
+	.loc	2 170 27                        ; standard.py:170:27 @[ standard.py:191:40 @[ flash_attention.py:133:39 ] ]
+	v_max3_f32 v72, v72, v89, v90
+	v_max3_f32 v72, v72, v91, v92
+.Ltmp25:
+	.loc	2 191 40                        ; standard.py:191:40 @[ flash_attention.py:133:39 ]
+	v_mov_b32_e32 v94, v72
+	s_nop 1
+	v_permlane32_swap_b32_e32 v72, v94
+.Ltmp26:
+	.loc	1 133 32                        ; flash_attention.py:133:32
+	v_max3_f32 v72, v0, v72, v94
+	.loc	1 134 35                        ; flash_attention.py:134:35
+	v_sub_f32_e32 v0, v0, v72
+	.loc	1 134 29 is_stmt 0              ; flash_attention.py:134:29
+	v_exp_f32_e32 v102, v0
+	.loc	1 135 30 is_stmt 1              ; flash_attention.py:135:30
+	v_sub_f32_e32 v0, v2, v72
+	v_sub_f32_e32 v2, v3, v72
+	v_sub_f32_e32 v3, v4, v72
+	v_sub_f32_e32 v99, v12, v72
+	v_sub_f32_e32 v100, v13, v72
+	.loc	1 135 25 is_stmt 0              ; flash_attention.py:135:25
+	v_exp_f32_e32 v12, v0
+	v_exp_f32_e32 v13, v2
+	.loc	1 135 30                        ; flash_attention.py:135:30
+	v_sub_f32_e32 v4, v5, v72
+	v_sub_f32_e32 v101, v14, v72
+	.loc	1 135 25                        ; flash_attention.py:135:25
+	v_exp_f32_e32 v14, v3
+	.loc	1 135 30                        ; flash_attention.py:135:30
+	v_sub_f32_e32 v5, v6, v72
+	v_sub_f32_e32 v103, v15, v72
+	.loc	1 135 25                        ; flash_attention.py:135:25
+	v_exp_f32_e32 v15, v4
+	.loc	1 135 30                        ; flash_attention.py:135:30
+	v_sub_f32_e32 v6, v7, v72
+	v_sub_f32_e32 v7, v37, v72
+	v_sub_f32_e32 v37, v93, v72
+	v_sub_f32_e32 v93, v74, v72
+	.loc	1 135 25                        ; flash_attention.py:135:25
+	v_exp_f32_e32 v74, v5
+	.loc	1 135 30                        ; flash_attention.py:135:30
+	v_sub_f32_e32 v94, v75, v72
+	.loc	1 135 25                        ; flash_attention.py:135:25
+	v_exp_f32_e32 v75, v6
+.Ltmp27:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:136:37 ] ]
+	v_add_f32_e32 v0, v12, v13
+.Ltmp28:
+	.loc	1 135 30                        ; flash_attention.py:135:30
+	v_sub_f32_e32 v104, v76, v72
+	.loc	1 135 25 is_stmt 0              ; flash_attention.py:135:25
+	v_exp_f32_e32 v76, v7
+.Ltmp29:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:136:37 ] ]
+	v_add_f32_e32 v0, v14, v0
+.Ltmp30:
+	.loc	1 135 30                        ; flash_attention.py:135:30
+	v_sub_f32_e32 v73, v73, v72
+	v_sub_f32_e32 v105, v77, v72
+	.loc	1 135 25 is_stmt 0              ; flash_attention.py:135:25
+	v_exp_f32_e32 v77, v37
+.Ltmp31:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:136:37 ] ]
+	v_add_f32_e32 v0, v15, v0
+.Ltmp32:
+	.loc	1 135 30                        ; flash_attention.py:135:30
+	v_sub_f32_e32 v106, v78, v72
+	.loc	1 135 25 is_stmt 0              ; flash_attention.py:135:25
+	v_exp_f32_e32 v78, v73
+.Ltmp33:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:136:37 ] ]
+	v_add_f32_e32 v0, v74, v0
+.Ltmp34:
+	.loc	1 135 30                        ; flash_attention.py:135:30
+	v_sub_f32_e32 v107, v79, v72
+	.loc	1 135 25 is_stmt 0              ; flash_attention.py:135:25
+	v_exp_f32_e32 v79, v93
+.Ltmp35:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:136:37 ] ]
+	v_add_f32_e32 v0, v75, v0
+.Ltmp36:
+	.loc	1 135 30                        ; flash_attention.py:135:30
+	v_sub_f32_e32 v95, v80, v72
+	.loc	1 135 25 is_stmt 0              ; flash_attention.py:135:25
+	v_exp_f32_e32 v80, v94
+.Ltmp37:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:136:37 ] ]
+	v_add_f32_e32 v0, v76, v0
+.Ltmp38:
+	.loc	1 135 30                        ; flash_attention.py:135:30
+	v_sub_f32_e32 v96, v81, v72
+	.loc	1 135 25 is_stmt 0              ; flash_attention.py:135:25
+	v_exp_f32_e32 v81, v95
+.Ltmp39:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:136:37 ] ]
+	v_add_f32_e32 v0, v77, v0
+.Ltmp40:
+	.loc	1 135 30                        ; flash_attention.py:135:30
+	v_sub_f32_e32 v97, v82, v72
+	.loc	1 135 25 is_stmt 0              ; flash_attention.py:135:25
+	v_exp_f32_e32 v82, v96
+.Ltmp41:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:136:37 ] ]
+	v_add_f32_e32 v0, v78, v0
+.Ltmp42:
+	.loc	1 135 30                        ; flash_attention.py:135:30
+	v_sub_f32_e32 v98, v83, v72
+	.loc	1 135 25 is_stmt 0              ; flash_attention.py:135:25
+	v_exp_f32_e32 v83, v97
+.Ltmp43:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:136:37 ] ]
+	v_add_f32_e32 v0, v79, v0
+.Ltmp44:
+	.loc	1 135 30                        ; flash_attention.py:135:30
+	v_sub_f32_e32 v88, v88, v72
+	v_sub_f32_e32 v108, v84, v72
+	.loc	1 135 25 is_stmt 0              ; flash_attention.py:135:25
+	v_exp_f32_e32 v84, v98
+.Ltmp45:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:136:37 ] ]
+	v_add_f32_e32 v0, v80, v0
+.Ltmp46:
+	.loc	1 135 30                        ; flash_attention.py:135:30
+	v_sub_f32_e32 v109, v85, v72
+	.loc	1 135 25 is_stmt 0              ; flash_attention.py:135:25
+	v_exp_f32_e32 v85, v88
+.Ltmp47:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:136:37 ] ]
+	v_add_f32_e32 v0, v81, v0
+.Ltmp48:
+	.loc	1 135 30                        ; flash_attention.py:135:30
+	v_sub_f32_e32 v110, v86, v72
+	.loc	1 135 25 is_stmt 0              ; flash_attention.py:135:25
+	v_exp_f32_e32 v86, v99
+.Ltmp49:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:136:37 ] ]
+	v_add_f32_e32 v0, v82, v0
+.Ltmp50:
+	.loc	1 135 30                        ; flash_attention.py:135:30
+	v_sub_f32_e32 v111, v87, v72
+	.loc	1 135 25 is_stmt 0              ; flash_attention.py:135:25
+	v_exp_f32_e32 v87, v100
+.Ltmp51:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:136:37 ] ]
+	v_add_f32_e32 v0, v83, v0
+.Ltmp52:
+	.loc	1 135 25                        ; flash_attention.py:135:25
+	v_exp_f32_e32 v88, v101
+.Ltmp53:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:136:37 ] ]
+	v_add_f32_e32 v0, v84, v0
+.Ltmp54:
+	.loc	1 135 30                        ; flash_attention.py:135:30
+	v_sub_f32_e32 v112, v89, v72
+	.loc	1 135 25 is_stmt 0              ; flash_attention.py:135:25
+	v_exp_f32_e32 v89, v103
+.Ltmp55:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:136:37 ] ]
+	v_add_f32_e32 v0, v85, v0
+.Ltmp56:
+	.loc	1 135 30                        ; flash_attention.py:135:30
+	v_sub_f32_e32 v113, v90, v72
+	.loc	1 135 25 is_stmt 0              ; flash_attention.py:135:25
+	v_exp_f32_e32 v90, v104
+.Ltmp57:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:136:37 ] ]
+	v_add_f32_e32 v0, v86, v0
+.Ltmp58:
+	.loc	1 135 30                        ; flash_attention.py:135:30
+	v_sub_f32_e32 v114, v91, v72
+	.loc	1 135 25 is_stmt 0              ; flash_attention.py:135:25
+	v_exp_f32_e32 v91, v105
+.Ltmp59:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:136:37 ] ]
+	v_add_f32_e32 v0, v87, v0
+.Ltmp60:
+	.loc	1 135 30                        ; flash_attention.py:135:30
+	v_sub_f32_e32 v115, v92, v72
+	.loc	1 135 25 is_stmt 0              ; flash_attention.py:135:25
+	v_exp_f32_e32 v92, v106
+.Ltmp61:
+	.loc	2 263 15 is_stmt 1              ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:136:37 ] ]
+	v_add_f32_e32 v0, v88, v0
+.Ltmp62:
+	.loc	1 135 25                        ; flash_attention.py:135:25
+	v_exp_f32_e32 v93, v107
+.Ltmp63:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:136:37 ] ]
+	v_add_f32_e32 v0, v89, v0
+.Ltmp64:
+	.loc	1 135 25                        ; flash_attention.py:135:25
+	v_exp_f32_e32 v94, v108
+.Ltmp65:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:136:37 ] ]
+	v_add_f32_e32 v0, v90, v0
+.Ltmp66:
+	.loc	1 135 25                        ; flash_attention.py:135:25
+	v_exp_f32_e32 v95, v109
+.Ltmp67:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:136:37 ] ]
+	v_add_f32_e32 v0, v91, v0
+.Ltmp68:
+	.loc	1 135 25                        ; flash_attention.py:135:25
+	v_exp_f32_e32 v96, v110
+.Ltmp69:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:136:37 ] ]
+	v_add_f32_e32 v0, v92, v0
+.Ltmp70:
+	.loc	1 135 25                        ; flash_attention.py:135:25
+	v_exp_f32_e32 v97, v111
+.Ltmp71:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:136:37 ] ]
+	v_add_f32_e32 v0, v93, v0
+.Ltmp72:
+	.loc	1 135 25                        ; flash_attention.py:135:25
+	v_exp_f32_e32 v98, v112
+.Ltmp73:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:136:37 ] ]
+	v_add_f32_e32 v0, v94, v0
+.Ltmp74:
+	.loc	1 135 25                        ; flash_attention.py:135:25
+	v_exp_f32_e32 v99, v113
+.Ltmp75:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:136:37 ] ]
+	v_add_f32_e32 v0, v95, v0
+.Ltmp76:
+	.loc	1 135 25                        ; flash_attention.py:135:25
+	v_exp_f32_e32 v100, v114
+.Ltmp77:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:136:37 ] ]
+	v_add_f32_e32 v0, v96, v0
+.Ltmp78:
+	.loc	1 135 25                        ; flash_attention.py:135:25
+	v_exp_f32_e32 v101, v115
+.Ltmp79:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:136:37 ] ]
+	v_add_f32_e32 v0, v97, v0
+	v_add_f32_e32 v0, v98, v0
+	v_add_f32_e32 v0, v99, v0
+	v_add_f32_e32 v0, v100, v0
+	v_add_f32_e32 v0, v101, v0
+.Ltmp80:
+	.loc	2 293 36                        ; standard.py:293:36 @[ flash_attention.py:136:37 ]
+	v_mov_b32_e32 v2, v0
+	s_nop 1
+	v_permlane32_swap_b32_e32 v0, v2
+.Ltmp81:
+	.loc	2 263 15                        ; standard.py:263:15 @[ standard.py:293:36 @[ flash_attention.py:136:37 ] ]
+	v_add_f32_e32 v37, v0, v2
+.Ltmp82:
+	.loc	1 136 30                        ; flash_attention.py:136:30
+	v_fmac_f32_e32 v37, v1, v102
+	.loc	1 140 12                        ; flash_attention.py:140:12
+	global_load_dwordx4 v[0:3], v[32:33], off offset:-4096
+	global_load_dwordx4 v[4:7], v[32:33], off
+	.loc	1 145 20                        ; flash_attention.py:145:20
+	v_add_u32_e32 v73, v57, v53
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	ds_write_b32 v63, v102
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	ds_read_b32 v102, v73
+	.loc	1 146 26                        ; flash_attention.py:146:26
+	v_cvt_pk_f16_f32 v12, v12, v13
+	v_cvt_pk_f16_f32 v13, v14, v15
+	v_cvt_pk_f16_f32 v14, v74, v75
+	v_cvt_pk_f16_f32 v15, v76, v77
+	v_cvt_pk_f16_f32 v74, v78, v79
+	v_cvt_pk_f16_f32 v75, v80, v81
+	v_cvt_pk_f16_f32 v76, v82, v83
+	v_cvt_pk_f16_f32 v77, v84, v85
+	v_cvt_pk_f16_f32 v78, v86, v87
+	v_cvt_pk_f16_f32 v79, v88, v89
+	v_cvt_pk_f16_f32 v80, v90, v91
+	v_cvt_pk_f16_f32 v81, v92, v93
+	v_cvt_pk_f16_f32 v82, v94, v95
+	v_cvt_pk_f16_f32 v83, v96, v97
+	v_cvt_pk_f16_f32 v84, v98, v99
+	v_cvt_pk_f16_f32 v85, v100, v101
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	ds_write_b16 v62, v12
+	ds_write_b16_d16_hi v62, v12 offset:128
+	ds_write_b16 v62, v74 offset:2048
+	ds_write_b16_d16_hi v62, v74 offset:2176
+	ds_write_b16 v62, v78 offset:4096
+	ds_write_b16_d16_hi v62, v78 offset:4224
+	ds_write_b16 v62, v82 offset:6144
+	ds_write_b16_d16_hi v62, v82 offset:6272
+	ds_write_b16 v64, v13 offset:256
+	ds_write_b16_d16_hi v64, v13 offset:384
+	ds_write_b16 v64, v75 offset:2304
+	ds_write_b16_d16_hi v64, v75 offset:2432
+	ds_write_b16 v64, v79 offset:4352
+	ds_write_b16_d16_hi v64, v79 offset:4480
+	ds_write_b16 v64, v83 offset:6400
+	ds_write_b16_d16_hi v64, v83 offset:6528
+	ds_write_b16 v65, v14 offset:1024
+	ds_write_b16_d16_hi v65, v14 offset:1152
+	ds_write_b16 v65, v76 offset:3072
+	ds_write_b16_d16_hi v65, v76 offset:3200
+	ds_write_b16 v65, v80 offset:5120
+	ds_write_b16_d16_hi v65, v80 offset:5248
+	ds_write_b16 v65, v84 offset:7168
+	ds_write_b16_d16_hi v65, v84 offset:7296
+	ds_write_b16 v66, v15 offset:1280
+	ds_write_b16_d16_hi v66, v15 offset:1408
+	ds_write_b16 v66, v77 offset:3328
+	ds_write_b16_d16_hi v66, v77 offset:3456
+	ds_write_b16 v66, v81 offset:5376
+	ds_write_b16_d16_hi v66, v81 offset:5504
+	ds_write_b16 v66, v85 offset:7424
+	ds_write_b16_d16_hi v66, v85 offset:7552
+	.loc	1 140 12                        ; flash_attention.py:140:12
+	v_add_u32_e32 v12, 0, v58
+	.loc	1 146 26                        ; flash_attention.py:146:26
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	ds_read_b64_tr_b16 v[74:75], v67
+	ds_read_b64_tr_b16 v[78:79], v67 offset:2048
+	ds_read_b64_tr_b16 v[82:83], v67 offset:4096
+	ds_read_b64_tr_b16 v[86:87], v67 offset:6144
+	ds_read_b64_tr_b16 v[76:77], v68 offset:1024
+	ds_read_b64_tr_b16 v[80:81], v68 offset:3072
+	ds_read_b64_tr_b16 v[84:85], v68 offset:5120
+	ds_read_b64_tr_b16 v[88:89], v68 offset:7168
+	.loc	1 140 12                        ; flash_attention.py:140:12
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	s_waitcnt vmcnt(0)
+	ds_write2st64_b64 v12, v[0:1], v[4:5] offset1:8
+	ds_write2st64_b64 v69, v[2:3], v[6:7] offset1:8
+	.loc	1 146 42                        ; flash_attention.py:146:42
+	v_pk_mul_f32 v[0:1], v[48:49], v[102:103] op_sel_hi:[1,0]
+	.loc	1 140 12                        ; flash_attention.py:140:12
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	ds_read_b64_tr_b16 v[90:91], v70
+	ds_read_b64_tr_b16 v[94:95], v70 offset:2048
+	ds_read_b64_tr_b16 v[98:99], v70 offset:4096
+	ds_read_b64_tr_b16 v[104:105], v70 offset:6144
+	ds_read_b64_tr_b16 v[92:93], v71 offset:1024
+	ds_read_b64_tr_b16 v[96:97], v71 offset:3072
+	ds_read_b64_tr_b16 v[100:101], v71 offset:5120
+	ds_read_b64_tr_b16 v[106:107], v71 offset:7168
+	.loc	1 146 42                        ; flash_attention.py:146:42
+	v_pk_mul_f32 v[14:15], v[8:9], v[102:103] op_sel_hi:[1,0]
+	v_pk_mul_f32 v[12:13], v[10:11], v[102:103] op_sel_hi:[1,0]
+	v_pk_mul_f32 v[10:11], v[38:39], v[102:103] op_sel_hi:[1,0]
+	v_pk_mul_f32 v[8:9], v[40:41], v[102:103] op_sel_hi:[1,0]
+	v_pk_mul_f32 v[6:7], v[42:43], v[102:103] op_sel_hi:[1,0]
+	v_pk_mul_f32 v[4:5], v[44:45], v[102:103] op_sel_hi:[1,0]
+	v_pk_mul_f32 v[2:3], v[46:47], v[102:103] op_sel_hi:[1,0]
+	.loc	1 117 48                        ; flash_attention.py:117:48
+	v_lshl_add_u64 v[32:33], v[32:33], 0, s[0:1]
+	.loc	1 146 42                        ; flash_attention.py:146:42
+	v_accvgpr_write_b32 a0, v0
+	v_accvgpr_write_b32 a1, v1
+	v_accvgpr_write_b32 a2, v2
+	v_accvgpr_write_b32 a3, v3
+	v_accvgpr_write_b32 a4, v4
+	v_accvgpr_write_b32 a5, v5
+	v_accvgpr_write_b32 a6, v6
+	v_accvgpr_write_b32 a7, v7
+	v_accvgpr_write_b32 a8, v8
+	v_accvgpr_write_b32 a9, v9
+	v_accvgpr_write_b32 a10, v10
+	v_accvgpr_write_b32 a11, v11
+	v_accvgpr_write_b32 a12, v12
+	v_accvgpr_write_b32 a13, v13
+	v_accvgpr_write_b32 a14, v14
+	v_accvgpr_write_b32 a15, v15
+	v_mov_b32_e32 v0, v72
+	s_waitcnt lgkmcnt(3)
+	v_mfma_f32_32x32x16_f16 a[0:15], v[90:93], v[74:77], a[0:15]
+	s_waitcnt lgkmcnt(2)
+	v_mfma_f32_32x32x16_f16 a[0:15], v[94:97], v[78:81], a[0:15]
+	s_waitcnt lgkmcnt(1)
+	v_mfma_f32_32x32x16_f16 a[0:15], v[98:101], v[82:85], a[0:15]
+	s_waitcnt lgkmcnt(0)
+	v_mfma_f32_32x32x16_f16 a[0:15], v[104:107], v[86:89], a[0:15]
+	.loc	1 117 48                        ; flash_attention.py:117:48
+	s_cbranch_scc1 .LBB0_5
+; %bb.6:
+	.loc	1 95 44                         ; flash_attention.py:95:44
+	v_lshrrev_b32_e32 v16, 2, v53
+	.loc	1 146 42                        ; flash_attention.py:146:42
+	s_nop 9
+	v_accvgpr_read_b32 v0, a0
+	.loc	1 95 31                         ; flash_attention.py:95:31
+	v_or3_b32 v16, v52, v16, s11
+	s_movk_i32 s0, 0x400
+	.loc	1 146 42                        ; flash_attention.py:146:42
+	v_accvgpr_read_b32 v1, a1
+	v_accvgpr_read_b32 v2, a2
+	v_accvgpr_read_b32 v3, a3
+	v_accvgpr_read_b32 v4, a4
+	v_accvgpr_read_b32 v5, a5
+	v_accvgpr_read_b32 v6, a6
+	v_accvgpr_read_b32 v7, a7
+	v_accvgpr_read_b32 v8, a8
+	v_accvgpr_read_b32 v9, a9
+	v_accvgpr_read_b32 v10, a10
+	v_accvgpr_read_b32 v11, a11
+	v_accvgpr_read_b32 v12, a12
+	v_accvgpr_read_b32 v13, a13
+	v_accvgpr_read_b32 v14, a14
+	v_accvgpr_read_b32 v15, a15
+	.loc	1 99 32                         ; flash_attention.py:99:32
+	v_cmp_gt_i32_e32 vcc, s0, v16
+	.loc	1 150 16                        ; flash_attention.py:150:16
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	ds_write_b32 v63, v37
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	.loc	1 154 8                         ; flash_attention.py:154:8
+	s_and_saveexec_b64 s[0:1], vcc
+	s_cbranch_execz .LBB0_8
+; %bb.7:                                ; %.critedge
+	.loc	1 150 16                        ; flash_attention.py:150:16
+	ds_read_b32 v20, v73
+	.loc	1 95 44                         ; flash_attention.py:95:44
+	v_lshrrev_b32_e32 v17, 3, v51
+	.loc	1 101 34                        ; flash_attention.py:101:34
+	v_lshlrev_b32_e32 v16, 6, v16
+	.loc	1 99 49                         ; flash_attention.py:99:49
+	v_or_b32_e32 v18, v17, v50
+	.loc	1 153 16                        ; flash_attention.py:153:16
+	v_ashrrev_i32_e32 v17, 31, v16
+	.loc	1 150 16                        ; flash_attention.py:150:16
+	s_waitcnt lgkmcnt(0)
+	v_div_scale_f32 v21, s[0:1], v20, v20, v15
+	v_rcp_f32_e32 v22, v21
+	.loc	1 153 16                        ; flash_attention.py:153:16
+	v_lshl_add_u64 v[16:17], v[16:17], 2, s[8:9]
+	.loc	1 153 46 is_stmt 0              ; flash_attention.py:153:46
+	v_lshlrev_b32_e32 v18, 2, v18
+	v_mov_b32_e32 v19, 0
+	v_lshl_add_u64 v[16:17], v[16:17], 0, v[18:19]
+	.loc	1 150 16 is_stmt 1              ; flash_attention.py:150:16
+	v_fma_f32 v18, -v21, v22, 1.0
+	v_fmac_f32_e32 v22, v18, v22
+	v_div_scale_f32 v18, vcc, v15, v20, v15
+	v_mul_f32_e32 v19, v18, v22
+	v_fma_f32 v23, -v21, v19, v18
+	v_fmac_f32_e32 v19, v23, v22
+	v_fma_f32 v18, -v21, v19, v18
+	v_div_scale_f32 v21, s[0:1], v20, v20, v14
+	v_rcp_f32_e32 v23, v21
+	v_div_fmas_f32 v18, v18, v22, v19
+	v_div_fixup_f32 v15, v18, v20, v15
+	v_fma_f32 v18, -v21, v23, 1.0
+	v_fmac_f32_e32 v23, v18, v23
+	v_div_scale_f32 v18, vcc, v14, v20, v14
+	v_mul_f32_e32 v19, v18, v23
+	v_fma_f32 v22, -v21, v19, v18
+	v_fmac_f32_e32 v19, v22, v23
+	v_fma_f32 v18, -v21, v19, v18
+	v_div_scale_f32 v21, s[0:1], v20, v20, v13
+	v_rcp_f32_e32 v22, v21
+	v_div_fmas_f32 v18, v18, v23, v19
+	v_div_fixup_f32 v14, v18, v20, v14
+	v_fma_f32 v18, -v21, v22, 1.0
+	v_fmac_f32_e32 v22, v18, v22
+	v_div_scale_f32 v18, vcc, v13, v20, v13
+	v_mul_f32_e32 v19, v18, v22
+	v_fma_f32 v23, -v21, v19, v18
+	v_fmac_f32_e32 v19, v23, v22
+	v_fma_f32 v18, -v21, v19, v18
+	v_div_scale_f32 v21, s[0:1], v20, v20, v12
+	v_rcp_f32_e32 v23, v21
+	v_div_fmas_f32 v18, v18, v22, v19
+	v_div_fixup_f32 v13, v18, v20, v13
+	v_fma_f32 v18, -v21, v23, 1.0
+	v_fmac_f32_e32 v23, v18, v23
+	v_div_scale_f32 v18, vcc, v12, v20, v12
+	v_mul_f32_e32 v19, v18, v23
+	v_fma_f32 v22, -v21, v19, v18
+	v_fmac_f32_e32 v19, v22, v23
+	v_fma_f32 v18, -v21, v19, v18
+	v_div_scale_f32 v21, s[0:1], v20, v20, v11
+	v_rcp_f32_e32 v22, v21
+	v_div_fmas_f32 v18, v18, v23, v19
+	v_div_fixup_f32 v12, v18, v20, v12
+	v_fma_f32 v18, -v21, v22, 1.0
+	v_fmac_f32_e32 v22, v18, v22
+	v_div_scale_f32 v18, vcc, v11, v20, v11
+	v_mul_f32_e32 v19, v18, v22
+	v_fma_f32 v23, -v21, v19, v18
+	v_fmac_f32_e32 v19, v23, v22
+	v_fma_f32 v18, -v21, v19, v18
+	v_div_scale_f32 v21, s[0:1], v20, v20, v10
+	v_rcp_f32_e32 v23, v21
+	v_div_fmas_f32 v18, v18, v22, v19
+	v_div_fixup_f32 v11, v18, v20, v11
+	v_fma_f32 v18, -v21, v23, 1.0
+	v_fmac_f32_e32 v23, v18, v23
+	v_div_scale_f32 v18, vcc, v10, v20, v10
+	v_mul_f32_e32 v19, v18, v23
+	v_fma_f32 v22, -v21, v19, v18
+	v_fmac_f32_e32 v19, v22, v23
+	v_fma_f32 v18, -v21, v19, v18
+	v_div_scale_f32 v21, s[0:1], v20, v20, v9
+	v_rcp_f32_e32 v22, v21
+	v_div_fmas_f32 v18, v18, v23, v19
+	v_div_fixup_f32 v10, v18, v20, v10
+	v_fma_f32 v18, -v21, v22, 1.0
+	v_fmac_f32_e32 v22, v18, v22
+	v_div_scale_f32 v18, vcc, v9, v20, v9
+	v_mul_f32_e32 v19, v18, v22
+	v_fma_f32 v23, -v21, v19, v18
+	v_fmac_f32_e32 v19, v23, v22
+	v_fma_f32 v18, -v21, v19, v18
+	v_div_scale_f32 v21, s[0:1], v20, v20, v8
+	v_rcp_f32_e32 v23, v21
+	v_div_fmas_f32 v18, v18, v22, v19
+	v_div_fixup_f32 v9, v18, v20, v9
+	v_fma_f32 v18, -v21, v23, 1.0
+	v_fmac_f32_e32 v23, v18, v23
+	v_div_scale_f32 v18, vcc, v8, v20, v8
+	v_mul_f32_e32 v19, v18, v23
+	v_fma_f32 v22, -v21, v19, v18
+	v_fmac_f32_e32 v19, v22, v23
+	v_fma_f32 v18, -v21, v19, v18
+	v_div_scale_f32 v21, s[0:1], v20, v20, v0
+	v_rcp_f32_e32 v22, v21
+	v_div_fmas_f32 v18, v18, v23, v19
+	v_div_fixup_f32 v8, v18, v20, v8
+	v_fma_f32 v18, -v21, v22, 1.0
+	v_fmac_f32_e32 v22, v18, v22
+	v_div_scale_f32 v18, vcc, v0, v20, v0
+	v_mul_f32_e32 v19, v18, v22
+	v_fma_f32 v23, -v21, v19, v18
+	v_fmac_f32_e32 v19, v23, v22
+	v_fma_f32 v18, -v21, v19, v18
+	v_div_scale_f32 v21, s[0:1], v20, v20, v1
+	v_rcp_f32_e32 v23, v21
+	v_div_fmas_f32 v18, v18, v22, v19
+	v_div_fixup_f32 v0, v18, v20, v0
+	v_fma_f32 v18, -v21, v23, 1.0
+	v_fmac_f32_e32 v23, v18, v23
+	v_div_scale_f32 v18, vcc, v1, v20, v1
+	v_mul_f32_e32 v19, v18, v23
+	v_fma_f32 v22, -v21, v19, v18
+	v_fmac_f32_e32 v19, v22, v23
+	v_fma_f32 v18, -v21, v19, v18
+	v_div_scale_f32 v21, s[0:1], v20, v20, v2
+	v_rcp_f32_e32 v22, v21
+	v_div_fmas_f32 v18, v18, v23, v19
+	v_div_fixup_f32 v1, v18, v20, v1
+	v_fma_f32 v18, -v21, v22, 1.0
+	v_fmac_f32_e32 v22, v18, v22
+	v_div_scale_f32 v18, vcc, v2, v20, v2
+	v_mul_f32_e32 v19, v18, v22
+	v_fma_f32 v23, -v21, v19, v18
+	v_fmac_f32_e32 v19, v23, v22
+	v_fma_f32 v18, -v21, v19, v18
+	v_div_scale_f32 v21, s[0:1], v20, v20, v3
+	v_rcp_f32_e32 v23, v21
+	v_div_fmas_f32 v18, v18, v22, v19
+	v_div_fixup_f32 v2, v18, v20, v2
+	v_fma_f32 v18, -v21, v23, 1.0
+	v_fmac_f32_e32 v23, v18, v23
+	v_div_scale_f32 v18, vcc, v3, v20, v3
+	v_mul_f32_e32 v19, v18, v23
+	v_fma_f32 v22, -v21, v19, v18
+	v_fmac_f32_e32 v19, v22, v23
+	v_fma_f32 v18, -v21, v19, v18
+	v_div_scale_f32 v21, s[0:1], v20, v20, v7
+	v_rcp_f32_e32 v22, v21
+	v_div_fmas_f32 v18, v18, v23, v19
+	v_div_fixup_f32 v3, v18, v20, v3
+	v_fma_f32 v18, -v21, v22, 1.0
+	v_fmac_f32_e32 v22, v18, v22
+	v_div_scale_f32 v18, vcc, v7, v20, v7
+	v_mul_f32_e32 v19, v18, v22
+	v_fma_f32 v23, -v21, v19, v18
+	v_fmac_f32_e32 v19, v23, v22
+	v_fma_f32 v18, -v21, v19, v18
+	v_div_scale_f32 v21, s[0:1], v20, v20, v6
+	v_rcp_f32_e32 v23, v21
+	v_div_fmas_f32 v18, v18, v22, v19
+	v_div_fixup_f32 v7, v18, v20, v7
+	v_fma_f32 v18, -v21, v23, 1.0
+	v_fmac_f32_e32 v23, v18, v23
+	v_div_scale_f32 v18, vcc, v6, v20, v6
+	v_mul_f32_e32 v19, v18, v23
+	v_fma_f32 v22, -v21, v19, v18
+	v_fmac_f32_e32 v19, v22, v23
+	v_fma_f32 v18, -v21, v19, v18
+	v_div_scale_f32 v21, s[0:1], v20, v20, v5
+	v_rcp_f32_e32 v22, v21
+	v_div_fmas_f32 v18, v18, v23, v19
+	v_div_fixup_f32 v6, v18, v20, v6
+	v_fma_f32 v18, -v21, v22, 1.0
+	v_fmac_f32_e32 v22, v18, v22
+	v_div_scale_f32 v18, vcc, v5, v20, v5
+	v_mul_f32_e32 v19, v18, v22
+	v_fma_f32 v23, -v21, v19, v18
+	v_fmac_f32_e32 v19, v23, v22
+	v_fma_f32 v18, -v21, v19, v18
+	v_div_scale_f32 v21, s[0:1], v20, v20, v4
+	v_rcp_f32_e32 v23, v21
+	v_div_fmas_f32 v18, v18, v22, v19
+	v_div_fixup_f32 v5, v18, v20, v5
+	v_fma_f32 v18, -v21, v23, 1.0
+	v_fmac_f32_e32 v23, v18, v23
+	v_div_scale_f32 v18, vcc, v4, v20, v4
+	v_mul_f32_e32 v19, v18, v23
+	v_fma_f32 v22, -v21, v19, v18
+	v_fmac_f32_e32 v19, v22, v23
+	v_fma_f32 v18, -v21, v19, v18
+	v_div_fmas_f32 v18, v18, v23, v19
+	v_div_fixup_f32 v4, v18, v20, v4
+	.loc	1 154 8                         ; flash_attention.py:154:8
+	global_store_dwordx4 v[16:17], v[0:3], off
+	global_store_dwordx4 v[16:17], v[4:7], off offset:32
+	global_store_dwordx4 v[16:17], v[8:11], off offset:64
+	global_store_dwordx4 v[16:17], v[12:15], off offset:96
+.LBB0_8:                                ; %.critedge4
+	.loc	1 152 4                         ; flash_attention.py:152:4
+	s_endpgm
+.Ltmp83:
+	.section	.rodata,"a",@progbits
+	.p2align	6, 0x0
+	.amdhsa_kernel flash_attention_fwd_no_async_kernel
+		.amdhsa_group_segment_fixed_size 0
+		.amdhsa_private_segment_fixed_size 0
+		.amdhsa_kernarg_size 56
+		.amdhsa_user_sgpr_count 16
+		.amdhsa_user_sgpr_dispatch_ptr 0
+		.amdhsa_user_sgpr_queue_ptr 0
+		.amdhsa_user_sgpr_kernarg_segment_ptr 1
+		.amdhsa_user_sgpr_dispatch_id 0
+		.amdhsa_user_sgpr_kernarg_preload_length 14
+		.amdhsa_user_sgpr_kernarg_preload_offset 0
+		.amdhsa_user_sgpr_private_segment_size 0
+		.amdhsa_uses_dynamic_stack 0
+		.amdhsa_enable_private_segment 0
+		.amdhsa_system_sgpr_workgroup_id_x 1
+		.amdhsa_system_sgpr_workgroup_id_y 0
+		.amdhsa_system_sgpr_workgroup_id_z 0
+		.amdhsa_system_sgpr_workgroup_info 0
+		.amdhsa_system_vgpr_workitem_id 0
+		.amdhsa_next_free_vgpr 132
+		.amdhsa_next_free_sgpr 17
+		.amdhsa_accum_offset 116
+		.amdhsa_reserve_vcc 1
+		.amdhsa_reserve_xnack_mask 1
+		.amdhsa_float_round_mode_32 0
+		.amdhsa_float_round_mode_16_64 0
+		.amdhsa_float_denorm_mode_32 3
+		.amdhsa_float_denorm_mode_16_64 3
+		.amdhsa_dx10_clamp 1
+		.amdhsa_ieee_mode 1
+		.amdhsa_fp16_overflow 0
+		.amdhsa_tg_split 0
+		.amdhsa_exception_fp_ieee_invalid_op 0
+		.amdhsa_exception_fp_denorm_src 0
+		.amdhsa_exception_fp_ieee_div_zero 0
+		.amdhsa_exception_fp_ieee_overflow 0
+		.amdhsa_exception_fp_ieee_underflow 0
+		.amdhsa_exception_fp_ieee_inexact 0
+		.amdhsa_exception_int_div_zero 0
+	.end_amdhsa_kernel
+	.text
+.Lfunc_end0:
+	.size	flash_attention_fwd_no_async_kernel, .Lfunc_end0-flash_attention_fwd_no_async_kernel
+	.cfi_endproc
+                                        ; -- End function
+	.set flash_attention_fwd_no_async_kernel.num_vgpr, 116
+	.set flash_attention_fwd_no_async_kernel.num_agpr, 16
+	.set flash_attention_fwd_no_async_kernel.numbered_sgpr, 17
+	.set flash_attention_fwd_no_async_kernel.num_named_barrier, 0
+	.set flash_attention_fwd_no_async_kernel.private_seg_size, 0
+	.set flash_attention_fwd_no_async_kernel.uses_vcc, 1
+	.set flash_attention_fwd_no_async_kernel.uses_flat_scratch, 0
+	.set flash_attention_fwd_no_async_kernel.has_dyn_sized_stack, 0
+	.set flash_attention_fwd_no_async_kernel.has_recursion, 0
+	.set flash_attention_fwd_no_async_kernel.has_indirect_call, 0
+	.section	.AMDGPU.csdata,"",@progbits
+; Kernel info:
+; codeLenInByte = 4840
+; TotalNumSgprs: 23
+; NumVgprs: 116
+; NumAgprs: 16
+; TotalNumVgprs: 132
+; ScratchSize: 0
+; MemoryBound: 0
+; FloatMode: 240
+; IeeeMode: 1
+; LDSByteSize: 0 bytes/workgroup (compile time only)
+; SGPRBlocks: 2
+; VGPRBlocks: 16
+; NumSGPRsForWavesPerEU: 23
+; NumVGPRsForWavesPerEU: 132
+; AccumOffset: 116
+; Occupancy: 3
+; WaveLimiterHint : 1
+; COMPUTE_PGM_RSRC2:SCRATCH_EN: 0
+; COMPUTE_PGM_RSRC2:USER_SGPR: 16
+; COMPUTE_PGM_RSRC2:TRAP_HANDLER: 0
+; COMPUTE_PGM_RSRC2:TGID_X_EN: 1
+; COMPUTE_PGM_RSRC2:TGID_Y_EN: 0
+; COMPUTE_PGM_RSRC2:TGID_Z_EN: 0
+; COMPUTE_PGM_RSRC2:TIDIG_COMP_CNT: 0
+; COMPUTE_PGM_RSRC3_GFX90A:ACCUM_OFFSET: 28
+; COMPUTE_PGM_RSRC3_GFX90A:TG_SPLIT: 0
+	.text
+	.p2alignl 6, 3212836864
+	.fill 256, 4, 3212836864
+	.section	.AMDGPU.gpr_maximums,"",@progbits
+	.set amdgpu.max_num_vgpr, 0
+	.set amdgpu.max_num_agpr, 0
+	.set amdgpu.max_num_sgpr, 0
+	.text
+	.section	.debug_abbrev,"",@progbits
+	.byte	1                               ; Abbreviation Code
+	.byte	17                              ; DW_TAG_compile_unit
+	.byte	1                               ; DW_CHILDREN_yes
+	.byte	37                              ; DW_AT_producer
+	.byte	14                              ; DW_FORM_strp
+	.byte	19                              ; DW_AT_language
+	.byte	5                               ; DW_FORM_data2
+	.byte	3                               ; DW_AT_name
+	.byte	14                              ; DW_FORM_strp
+	.byte	16                              ; DW_AT_stmt_list
+	.byte	23                              ; DW_FORM_sec_offset
+	.byte	27                              ; DW_AT_comp_dir
+	.byte	14                              ; DW_FORM_strp
+	.byte	17                              ; DW_AT_low_pc
+	.byte	1                               ; DW_FORM_addr
+	.byte	18                              ; DW_AT_high_pc
+	.byte	6                               ; DW_FORM_data4
+	.byte	0                               ; EOM(1)
+	.byte	0                               ; EOM(2)
+	.byte	2                               ; Abbreviation Code
+	.byte	46                              ; DW_TAG_subprogram
+	.byte	0                               ; DW_CHILDREN_no
+	.byte	3                               ; DW_AT_name
+	.byte	14                              ; DW_FORM_strp
+	.byte	32                              ; DW_AT_inline
+	.byte	11                              ; DW_FORM_data1
+	.byte	0                               ; EOM(1)
+	.byte	0                               ; EOM(2)
+	.byte	3                               ; Abbreviation Code
+	.byte	46                              ; DW_TAG_subprogram
+	.byte	1                               ; DW_CHILDREN_yes
+	.byte	17                              ; DW_AT_low_pc
+	.byte	1                               ; DW_FORM_addr
+	.byte	18                              ; DW_AT_high_pc
+	.byte	6                               ; DW_FORM_data4
+	.byte	49                              ; DW_AT_abstract_origin
+	.byte	19                              ; DW_FORM_ref4
+	.byte	0                               ; EOM(1)
+	.byte	0                               ; EOM(2)
+	.byte	4                               ; Abbreviation Code
+	.byte	29                              ; DW_TAG_inlined_subroutine
+	.byte	1                               ; DW_CHILDREN_yes
+	.byte	49                              ; DW_AT_abstract_origin
+	.byte	19                              ; DW_FORM_ref4
+	.byte	85                              ; DW_AT_ranges
+	.byte	23                              ; DW_FORM_sec_offset
+	.byte	88                              ; DW_AT_call_file
+	.byte	11                              ; DW_FORM_data1
+	.byte	89                              ; DW_AT_call_line
+	.byte	11                              ; DW_FORM_data1
+	.byte	87                              ; DW_AT_call_column
+	.byte	11                              ; DW_FORM_data1
+	.byte	0                               ; EOM(1)
+	.byte	0                               ; EOM(2)
+	.byte	5                               ; Abbreviation Code
+	.byte	29                              ; DW_TAG_inlined_subroutine
+	.byte	0                               ; DW_CHILDREN_no
+	.byte	49                              ; DW_AT_abstract_origin
+	.byte	19                              ; DW_FORM_ref4
+	.byte	85                              ; DW_AT_ranges
+	.byte	23                              ; DW_FORM_sec_offset
+	.byte	88                              ; DW_AT_call_file
+	.byte	11                              ; DW_FORM_data1
+	.byte	89                              ; DW_AT_call_line
+	.byte	11                              ; DW_FORM_data1
+	.byte	87                              ; DW_AT_call_column
+	.byte	11                              ; DW_FORM_data1
+	.byte	0                               ; EOM(1)
+	.byte	0                               ; EOM(2)
+	.byte	6                               ; Abbreviation Code
+	.byte	29                              ; DW_TAG_inlined_subroutine
+	.byte	0                               ; DW_CHILDREN_no
+	.byte	49                              ; DW_AT_abstract_origin
+	.byte	19                              ; DW_FORM_ref4
+	.byte	85                              ; DW_AT_ranges
+	.byte	23                              ; DW_FORM_sec_offset
+	.byte	88                              ; DW_AT_call_file
+	.byte	11                              ; DW_FORM_data1
+	.byte	89                              ; DW_AT_call_line
+	.byte	5                               ; DW_FORM_data2
+	.byte	87                              ; DW_AT_call_column
+	.byte	11                              ; DW_FORM_data1
+	.byte	0                               ; EOM(1)
+	.byte	0                               ; EOM(2)
+	.byte	0                               ; EOM(3)
+	.section	.debug_info,"",@progbits
+.Lcu_begin0:
+	.long	.Ldebug_info_end0-.Ldebug_info_start0 ; Length of Unit
+.Ldebug_info_start0:
+	.short	4                               ; DWARF version number
+	.long	.debug_abbrev                   ; Offset Into Abbrev. Section
+	.byte	8                               ; Address Size (in bytes)
+	.byte	1                               ; Abbrev [1] 0xb:0x6b DW_TAG_compile_unit
+	.long	.Linfo_string0                  ; DW_AT_producer
+	.short	2                               ; DW_AT_language
+	.long	.Linfo_string1                  ; DW_AT_name
+	.long	.Lline_table_start0             ; DW_AT_stmt_list
+	.long	.Linfo_string2                  ; DW_AT_comp_dir
+	.quad	.Lfunc_begin0                   ; DW_AT_low_pc
+	.long	.Lfunc_end0-.Lfunc_begin0       ; DW_AT_high_pc
+	.byte	2                               ; Abbrev [2] 0x2a:0x6 DW_TAG_subprogram
+	.long	.Linfo_string3                  ; DW_AT_name
+	.byte	1                               ; DW_AT_inline
+	.byte	3                               ; Abbrev [3] 0x30:0x45 DW_TAG_subprogram
+	.quad	.Lfunc_begin0                   ; DW_AT_low_pc
+	.long	.Lfunc_end0-.Lfunc_begin0       ; DW_AT_high_pc
+	.long	42                              ; DW_AT_abstract_origin
+	.byte	4                               ; Abbrev [4] 0x41:0x19 DW_TAG_inlined_subroutine
+	.long	42                              ; DW_AT_abstract_origin
+	.long	.Ldebug_ranges0                 ; DW_AT_ranges
+	.byte	1                               ; DW_AT_call_file
+	.byte	133                             ; DW_AT_call_line
+	.byte	39                              ; DW_AT_call_column
+	.byte	5                               ; Abbrev [5] 0x4d:0xc DW_TAG_inlined_subroutine
+	.long	42                              ; DW_AT_abstract_origin
+	.long	.Ldebug_ranges1                 ; DW_AT_ranges
+	.byte	2                               ; DW_AT_call_file
+	.byte	191                             ; DW_AT_call_line
+	.byte	40                              ; DW_AT_call_column
+	.byte	0                               ; End Of Children Mark
+	.byte	4                               ; Abbrev [4] 0x5a:0x1a DW_TAG_inlined_subroutine
+	.long	42                              ; DW_AT_abstract_origin
+	.long	.Ldebug_ranges2                 ; DW_AT_ranges
+	.byte	1                               ; DW_AT_call_file
+	.byte	136                             ; DW_AT_call_line
+	.byte	37                              ; DW_AT_call_column
+	.byte	6                               ; Abbrev [6] 0x66:0xd DW_TAG_inlined_subroutine
+	.long	42                              ; DW_AT_abstract_origin
+	.long	.Ldebug_ranges3                 ; DW_AT_ranges
+	.byte	2                               ; DW_AT_call_file
+	.short	293                             ; DW_AT_call_line
+	.byte	36                              ; DW_AT_call_column
+	.byte	0                               ; End Of Children Mark
+	.byte	0                               ; End Of Children Mark
+	.byte	0                               ; End Of Children Mark
+.Ldebug_info_end0:
+	.section	.debug_ranges,"",@progbits
+.Ldebug_ranges0:
+	.quad	.Ltmp2-.Lfunc_begin0
+	.quad	.Ltmp3-.Lfunc_begin0
+	.quad	.Ltmp4-.Lfunc_begin0
+	.quad	.Ltmp5-.Lfunc_begin0
+	.quad	.Ltmp6-.Lfunc_begin0
+	.quad	.Ltmp7-.Lfunc_begin0
+	.quad	.Ltmp8-.Lfunc_begin0
+	.quad	.Ltmp9-.Lfunc_begin0
+	.quad	.Ltmp10-.Lfunc_begin0
+	.quad	.Ltmp11-.Lfunc_begin0
+	.quad	.Ltmp12-.Lfunc_begin0
+	.quad	.Ltmp13-.Lfunc_begin0
+	.quad	.Ltmp14-.Lfunc_begin0
+	.quad	.Ltmp15-.Lfunc_begin0
+	.quad	.Ltmp16-.Lfunc_begin0
+	.quad	.Ltmp17-.Lfunc_begin0
+	.quad	.Ltmp18-.Lfunc_begin0
+	.quad	.Ltmp19-.Lfunc_begin0
+	.quad	.Ltmp20-.Lfunc_begin0
+	.quad	.Ltmp21-.Lfunc_begin0
+	.quad	.Ltmp22-.Lfunc_begin0
+	.quad	.Ltmp23-.Lfunc_begin0
+	.quad	.Ltmp24-.Lfunc_begin0
+	.quad	.Ltmp26-.Lfunc_begin0
+	.quad	0
+	.quad	0
+.Ldebug_ranges1:
+	.quad	.Ltmp2-.Lfunc_begin0
+	.quad	.Ltmp3-.Lfunc_begin0
+	.quad	.Ltmp4-.Lfunc_begin0
+	.quad	.Ltmp5-.Lfunc_begin0
+	.quad	.Ltmp6-.Lfunc_begin0
+	.quad	.Ltmp7-.Lfunc_begin0
+	.quad	.Ltmp8-.Lfunc_begin0
+	.quad	.Ltmp9-.Lfunc_begin0
+	.quad	.Ltmp10-.Lfunc_begin0
+	.quad	.Ltmp11-.Lfunc_begin0
+	.quad	.Ltmp12-.Lfunc_begin0
+	.quad	.Ltmp13-.Lfunc_begin0
+	.quad	.Ltmp14-.Lfunc_begin0
+	.quad	.Ltmp15-.Lfunc_begin0
+	.quad	.Ltmp16-.Lfunc_begin0
+	.quad	.Ltmp17-.Lfunc_begin0
+	.quad	.Ltmp18-.Lfunc_begin0
+	.quad	.Ltmp19-.Lfunc_begin0
+	.quad	.Ltmp20-.Lfunc_begin0
+	.quad	.Ltmp21-.Lfunc_begin0
+	.quad	.Ltmp22-.Lfunc_begin0
+	.quad	.Ltmp23-.Lfunc_begin0
+	.quad	.Ltmp24-.Lfunc_begin0
+	.quad	.Ltmp25-.Lfunc_begin0
+	.quad	0
+	.quad	0
+.Ldebug_ranges2:
+	.quad	.Ltmp27-.Lfunc_begin0
+	.quad	.Ltmp28-.Lfunc_begin0
+	.quad	.Ltmp29-.Lfunc_begin0
+	.quad	.Ltmp30-.Lfunc_begin0
+	.quad	.Ltmp31-.Lfunc_begin0
+	.quad	.Ltmp32-.Lfunc_begin0
+	.quad	.Ltmp33-.Lfunc_begin0
+	.quad	.Ltmp34-.Lfunc_begin0
+	.quad	.Ltmp35-.Lfunc_begin0
+	.quad	.Ltmp36-.Lfunc_begin0
+	.quad	.Ltmp37-.Lfunc_begin0
+	.quad	.Ltmp38-.Lfunc_begin0
+	.quad	.Ltmp39-.Lfunc_begin0
+	.quad	.Ltmp40-.Lfunc_begin0
+	.quad	.Ltmp41-.Lfunc_begin0
+	.quad	.Ltmp42-.Lfunc_begin0
+	.quad	.Ltmp43-.Lfunc_begin0
+	.quad	.Ltmp44-.Lfunc_begin0
+	.quad	.Ltmp45-.Lfunc_begin0
+	.quad	.Ltmp46-.Lfunc_begin0
+	.quad	.Ltmp47-.Lfunc_begin0
+	.quad	.Ltmp48-.Lfunc_begin0
+	.quad	.Ltmp49-.Lfunc_begin0
+	.quad	.Ltmp50-.Lfunc_begin0
+	.quad	.Ltmp51-.Lfunc_begin0
+	.quad	.Ltmp52-.Lfunc_begin0
+	.quad	.Ltmp53-.Lfunc_begin0
+	.quad	.Ltmp54-.Lfunc_begin0
+	.quad	.Ltmp55-.Lfunc_begin0
+	.quad	.Ltmp56-.Lfunc_begin0
+	.quad	.Ltmp57-.Lfunc_begin0
+	.quad	.Ltmp58-.Lfunc_begin0
+	.quad	.Ltmp59-.Lfunc_begin0
+	.quad	.Ltmp60-.Lfunc_begin0
+	.quad	.Ltmp61-.Lfunc_begin0
+	.quad	.Ltmp62-.Lfunc_begin0
+	.quad	.Ltmp63-.Lfunc_begin0
+	.quad	.Ltmp64-.Lfunc_begin0
+	.quad	.Ltmp65-.Lfunc_begin0
+	.quad	.Ltmp66-.Lfunc_begin0
+	.quad	.Ltmp67-.Lfunc_begin0
+	.quad	.Ltmp68-.Lfunc_begin0
+	.quad	.Ltmp69-.Lfunc_begin0
+	.quad	.Ltmp70-.Lfunc_begin0
+	.quad	.Ltmp71-.Lfunc_begin0
+	.quad	.Ltmp72-.Lfunc_begin0
+	.quad	.Ltmp73-.Lfunc_begin0
+	.quad	.Ltmp74-.Lfunc_begin0
+	.quad	.Ltmp75-.Lfunc_begin0
+	.quad	.Ltmp76-.Lfunc_begin0
+	.quad	.Ltmp77-.Lfunc_begin0
+	.quad	.Ltmp78-.Lfunc_begin0
+	.quad	.Ltmp79-.Lfunc_begin0
+	.quad	.Ltmp82-.Lfunc_begin0
+	.quad	0
+	.quad	0
+.Ldebug_ranges3:
+	.quad	.Ltmp27-.Lfunc_begin0
+	.quad	.Ltmp28-.Lfunc_begin0
+	.quad	.Ltmp29-.Lfunc_begin0
+	.quad	.Ltmp30-.Lfunc_begin0
+	.quad	.Ltmp31-.Lfunc_begin0
+	.quad	.Ltmp32-.Lfunc_begin0
+	.quad	.Ltmp33-.Lfunc_begin0
+	.quad	.Ltmp34-.Lfunc_begin0
+	.quad	.Ltmp35-.Lfunc_begin0
+	.quad	.Ltmp36-.Lfunc_begin0
+	.quad	.Ltmp37-.Lfunc_begin0
+	.quad	.Ltmp38-.Lfunc_begin0
+	.quad	.Ltmp39-.Lfunc_begin0
+	.quad	.Ltmp40-.Lfunc_begin0
+	.quad	.Ltmp41-.Lfunc_begin0
+	.quad	.Ltmp42-.Lfunc_begin0
+	.quad	.Ltmp43-.Lfunc_begin0
+	.quad	.Ltmp44-.Lfunc_begin0
+	.quad	.Ltmp45-.Lfunc_begin0
+	.quad	.Ltmp46-.Lfunc_begin0
+	.quad	.Ltmp47-.Lfunc_begin0
+	.quad	.Ltmp48-.Lfunc_begin0
+	.quad	.Ltmp49-.Lfunc_begin0
+	.quad	.Ltmp50-.Lfunc_begin0
+	.quad	.Ltmp51-.Lfunc_begin0
+	.quad	.Ltmp52-.Lfunc_begin0
+	.quad	.Ltmp53-.Lfunc_begin0
+	.quad	.Ltmp54-.Lfunc_begin0
+	.quad	.Ltmp55-.Lfunc_begin0
+	.quad	.Ltmp56-.Lfunc_begin0
+	.quad	.Ltmp57-.Lfunc_begin0
+	.quad	.Ltmp58-.Lfunc_begin0
+	.quad	.Ltmp59-.Lfunc_begin0
+	.quad	.Ltmp60-.Lfunc_begin0
+	.quad	.Ltmp61-.Lfunc_begin0
+	.quad	.Ltmp62-.Lfunc_begin0
+	.quad	.Ltmp63-.Lfunc_begin0
+	.quad	.Ltmp64-.Lfunc_begin0
+	.quad	.Ltmp65-.Lfunc_begin0
+	.quad	.Ltmp66-.Lfunc_begin0
+	.quad	.Ltmp67-.Lfunc_begin0
+	.quad	.Ltmp68-.Lfunc_begin0
+	.quad	.Ltmp69-.Lfunc_begin0
+	.quad	.Ltmp70-.Lfunc_begin0
+	.quad	.Ltmp71-.Lfunc_begin0
+	.quad	.Ltmp72-.Lfunc_begin0
+	.quad	.Ltmp73-.Lfunc_begin0
+	.quad	.Ltmp74-.Lfunc_begin0
+	.quad	.Ltmp75-.Lfunc_begin0
+	.quad	.Ltmp76-.Lfunc_begin0
+	.quad	.Ltmp77-.Lfunc_begin0
+	.quad	.Ltmp78-.Lfunc_begin0
+	.quad	.Ltmp79-.Lfunc_begin0
+	.quad	.Ltmp80-.Lfunc_begin0
+	.quad	.Ltmp81-.Lfunc_begin0
+	.quad	.Ltmp82-.Lfunc_begin0
+	.quad	0
+	.quad	0
+	.section	.debug_str,"MS",@progbits,1
+.Linfo_string0:
+	.asciz	"triton"                        ; string offset=0
+.Linfo_string1:
+	.asciz	"flash_attention.py"            ; string offset=7
+.Linfo_string2:
+	.asciz	"/home/kunwar/Work/runtime-evolution/rocm-systems-rocjitsu-register-feedback/emulation/rocjitsu/tests/kernels/triton" ; string offset=26
+.Linfo_string3:
+	.asciz	"flash_attention_fwd_no_async_kernel" ; string offset=142
+	.section	".note.GNU-stack","",@progbits
+	.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .agpr_count:     16
+    .args:
+      - .address_space:  global
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .address_space:  global
+        .offset:         8
+        .size:           8
+        .value_kind:     global_buffer
+      - .address_space:  global
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .address_space:  global
+        .offset:         24
+        .size:           8
+        .value_kind:     global_buffer
+      - .offset:         32
+        .size:           4
+        .value_kind:     by_value
+      - .address_space:  global
+        .offset:         40
+        .size:           8
+        .value_kind:     global_buffer
+      - .address_space:  global
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+    .group_segment_fixed_size: 0
+    .kernarg_segment_align: 8
+    .kernarg_segment_size: 56
+    .max_flat_workgroup_size: 256
+    .name:           flash_attention_fwd_no_async_kernel
+    .private_segment_fixed_size: 0
+    .sgpr_count:     23
+    .sgpr_spill_count: 0
+    .symbol:         flash_attention_fwd_no_async_kernel.kd
+    .uniform_work_group_size: 1
+    .uses_dynamic_stack: false
+    .vgpr_count:     132
+    .vgpr_spill_count: 0
+    .wavefront_size: 64
+amdhsa.target:   amdgcn-amd-amdhsa--gfx950
+amdhsa.version:
+  - 1
+  - 2
+...
+
+	.end_amdgpu_metadata
+	.section	.debug_line,"",@progbits
+.Lline_table_start0:

--- a/emulation/rocjitsu/tests/kernels/triton_cdna4_matmul_buffer_async_1024.s
+++ b/emulation/rocjitsu/tests/kernels/triton_cdna4_matmul_buffer_async_1024.s
@@ -1,0 +1,1879 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// Reproduction information for this checked-in assembly fixture.
+// The original source used to generate this assembly is embedded here
+// as comments so normal builds do not need Python, Torch, or Triton.
+//
+// --- begin tests/kernels/triton/matmul_async_dma.py ---
+// # Copyright (c) 2026 Advanced Micro Devices, Inc.
+// # SPDX-License-Identifier: MIT
+//
+// """Triton matmul sources for DBT buffer-load-to-LDS stress fixtures.
+//
+// This file intentionally contains source kernels only.  The tests that consume
+// these kernels can choose whether to JIT them at runtime or compile them offline
+// to assembly/hsaco fixtures.
+//
+// The kernel is an ordinary fp16-input matmul shaped to give the AMD Triton
+// pipeline enough regular LDS traffic to choose a buffer-load-to-LDS lowering.
+// The instruction spelling is still a compiler outcome, not a source-level
+// guarantee; use compile_fixtures.py to verify what a particular Triton build
+// emits.
+//
+// Compile for gfx950/CDNA4 with `TRITON_HIP_USE_ASYNC_COPY=1` and
+// `AMDGCN_USE_BUFFER_OPS=1`. Buffer lowering also needs the base pointers to be
+// eligible for 32-bit buffer offsets; runtime JIT normally supplies that through
+// `tt.pointer_range=32` for tensors smaller than 2 GiB, while offline compilation
+// may need equivalent pointer attributes or small static/range-analysis bounds.
+// That is the backend configuration intended to select
+// `buffer_load_lds_dwordx4`.
+// """
+//
+// # Recorded fixture metadata:
+// #   kernel: matmul_async_buffer_load_lds
+// #   target: gfx950, wavefront_size: 64
+// #   launch sharedMemBytes used by cdna4_to_cdna3_dispatch_test: 65536
+// #   amdhsa_group_segment_fixed_size: 0
+// #   max_flat_workgroup_size: 256
+// #   kernarg_segment_size: 40
+// #   registers: vgpr_count=68, agpr_count=16, sgpr_count=32
+//
+// import triton
+// import triton.language as tl
+//
+//
+// # Environment knobs the fixture compiler should set around `triton.compile`.
+// TARGET_ARCH = "gfx950"
+// DEFAULT_M = 1024
+// DEFAULT_N = 1024
+// DEFAULT_K = 1024
+// COMMON_HIP_OPTIONS = {
+//     "num_warps": 4,
+//     "num_stages": 3,
+//     # Keep this explicit for fixture generation.  It is a backend compile
+//     # option, not a Triton kernel meta-parameter.
+//     "matrix_instr_nonkdim": 16,
+//     "waves_per_eu": 0,
+// }
+// BUFFER_LOAD_LDS_ENV = {
+//     "TRITON_HIP_USE_ASYNC_COPY": "1",
+//     "AMDGCN_USE_BUFFER_OPS": "1",
+// }
+//
+//
+// # Suggested compile-time meta/options.  BLOCK_M, BLOCK_N, and BLOCK_K are kept
+// # at 64 so the generated dynamic LDS footprint fits gfx942's 64 KiB per-workgroup
+// # limit while still giving the AMD backend enough contiguous data to select wide
+// # buffer-load-to-LDS traffic.  NUM_STAGES must be at least 2 because the AMD
+// # scheduler only pipelines loops with multiple stages.
+// BUFFER_LOAD_LDS_CONFIG = triton.Config(
+//     {
+//         "BLOCK_M": 64,
+//         "BLOCK_N": 64,
+//         "BLOCK_K": 64,
+//         "GROUP_M": 4,
+//         "NUM_STAGES": 3,
+//     },
+//     num_warps=4,
+//     num_stages=3,
+// )
+//
+//
+// @triton.jit
+// def _program_ids(
+//     M, N, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, GROUP_M: tl.constexpr
+// ):
+//     """Group M programs together so neighboring CTAs reuse the same B tile."""
+//     pid = tl.program_id(0)
+//     num_pid_m = tl.cdiv(M, BLOCK_M)
+//     num_pid_n = tl.cdiv(N, BLOCK_N)
+//     group_size = GROUP_M * num_pid_n
+//     group_id = pid // group_size
+//     first_pid_m = group_id * GROUP_M
+//     group_m = tl.minimum(num_pid_m - first_pid_m, GROUP_M)
+//     pid_m = first_pid_m + ((pid % group_size) % group_m)
+//     pid_n = (pid % group_size) // group_m
+//     return pid_m, pid_n
+//
+//
+// @triton.jit
+// def matmul_async_buffer_load_lds(
+//     a,
+//     b,
+//     c,
+//     M: tl.constexpr,
+//     N: tl.constexpr,
+//     K: tl.constexpr,
+//     BLOCK_M: tl.constexpr,
+//     BLOCK_N: tl.constexpr,
+//     BLOCK_K: tl.constexpr,
+//     GROUP_M: tl.constexpr,
+//     NUM_STAGES: tl.constexpr,
+// ):
+//     """C[M, N] = A[M, K] x B[K, N], compiled with AMD buffer-op lowering."""
+//     tl.static_assert(BLOCK_M >= 64, "BLOCK_M must be at least 64")
+//     tl.static_assert(BLOCK_N >= 64, "BLOCK_N must be at least 64")
+//     tl.static_assert(BLOCK_K >= 64, "BLOCK_K must be at least 64")
+//     tl.static_assert(NUM_STAGES >= 2, "async load-to-LDS needs a pipelined loop")
+//
+//     # The source uses contiguous row-major A, B, and C.  Contiguous fp16 runs
+//     # along K for A and along N for B give the AMD backend the vector shape it
+//     # needs to coalesce eligible async copies into buffer-load-to-LDS ops.
+//     pid_m, pid_n = _program_ids(M, N, BLOCK_M, BLOCK_N, GROUP_M)
+//     offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+//     offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+//     offs_k = tl.arange(0, BLOCK_K)
+//     load_m = tl.where(offs_m < M, offs_m, 0)
+//     load_n = tl.where(offs_n < N, offs_n, 0)
+//     load_m = tl.max_contiguous(tl.multiple_of(load_m, BLOCK_M), BLOCK_M)
+//     load_n = tl.max_contiguous(tl.multiple_of(load_n, BLOCK_N), BLOCK_N)
+//
+//     acc = tl.zeros((BLOCK_M, BLOCK_N), tl.float32)
+//     for k0 in tl.range(0, K, BLOCK_K, num_stages=NUM_STAGES):
+//         k_idxs = k0 + offs_k
+//         a_tile = tl.load(
+//             a + load_m[:, None] * K + k_idxs[None, :],
+//             mask=k_idxs[None, :] < K,
+//             other=0.0,
+//         )
+//         b_tile = tl.load(
+//             b + k_idxs[:, None] * N + load_n[None, :],
+//             mask=k_idxs[:, None] < K,
+//             other=0.0,
+//         )
+//         acc += tl.dot(a_tile, b_tile, out_dtype=tl.float32)
+//
+//     tl.store(
+//         c + offs_m[:, None] * N + offs_n[None, :],
+//         acc,
+//         mask=(offs_m[:, None] < M) & (offs_n[None, :] < N),
+//     )
+//
+//
+// __all__ = [
+//     "BUFFER_LOAD_LDS_ENV",
+//     "BUFFER_LOAD_LDS_CONFIG",
+//     "COMMON_HIP_OPTIONS",
+//     "DEFAULT_K",
+//     "DEFAULT_M",
+//     "DEFAULT_N",
+//     "TARGET_ARCH",
+//     "matmul_async_buffer_load_lds",
+// ]
+// --- end tests/kernels/triton/matmul_async_dma.py ---
+
+	.amdgcn_target "amdgcn-amd-amdhsa--gfx950"
+	.amdhsa_code_object_version 5
+	.text
+	.globl	matmul_async_buffer_load_lds    ; -- Begin function matmul_async_buffer_load_lds
+	.p2align	8
+	.type	matmul_async_buffer_load_lds,@function
+matmul_async_buffer_load_lds:           ; @matmul_async_buffer_load_lds
+.Lfunc_begin0:
+	.cfi_sections .debug_frame
+	.cfi_startproc
+; %bb.1:
+	.file	1 "/home/kunwar/Work/runtime-evolution/rocm-systems-rocjitsu-register-feedback/emulation/rocjitsu/tests/kernels/triton" "matmul_async_dma.py"
+	.loc	1 84 0 prologue_end             ; matmul_async_dma.py:84:0
+	s_load_dwordx2 s[2:3], s[0:1], 0x0
+	s_load_dwordx8 s[4:11], s[0:1], 0x8
+	s_waitcnt lgkmcnt(0)
+	s_branch .LBB0_0
+	.loc	1 0 0 is_stmt 0                 ; :0:0
+.Ltmp0:
+	.p2align	8
+; %bb.2:
+.LBB0_0:
+	s_mov_b64 s[8:9], s[2:3]
+.Ltmp1:
+	.loc	1 75 22 is_stmt 1               ; matmul_async_dma.py:75:22 @[ matmul_async_dma.py:106:56 ]
+	s_ashr_i32 s2, s12, 31
+	s_lshr_b32 s2, s2, 26
+	s_add_i32 s2, s12, s2
+	s_ashr_i32 s3, s2, 6
+	.loc	1 76 29                         ; matmul_async_dma.py:76:29 @[ matmul_async_dma.py:106:56 ]
+	s_lshl_b32 s3, s3, 2
+	s_mov_b64 s[0:1], s[6:7]
+	.loc	1 77 37                         ; matmul_async_dma.py:77:37 @[ matmul_async_dma.py:106:56 ]
+	s_sub_i32 s6, 16, s3
+	.loc	1 77 50 is_stmt 0               ; matmul_async_dma.py:77:50 @[ matmul_async_dma.py:106:56 ]
+	s_min_i32 s6, s6, 4
+	.loc	1 79 34 is_stmt 1               ; matmul_async_dma.py:79:34 @[ matmul_async_dma.py:106:56 ]
+	s_abs_i32 s7, s6
+	v_cvt_f32_u32_e32 v1, s7
+	.loc	1 78 34                         ; matmul_async_dma.py:78:34 @[ matmul_async_dma.py:106:56 ]
+	s_andn2_b32 s2, s2, 63
+	s_sub_i32 s2, s12, s2
+	.loc	1 79 34                         ; matmul_async_dma.py:79:34 @[ matmul_async_dma.py:106:56 ]
+	s_sub_i32 s12, 0, s7
+	v_rcp_iflag_f32_e32 v1, v1
+	s_abs_i32 s11, s2
+	s_xor_b32 s10, s2, s6
+	s_ashr_i32 s10, s10, 31
+	v_mul_f32_e32 v1, 0x4f7ffffe, v1
+	v_cvt_u32_f32_e32 v1, v1
+.Ltmp2:
+	.loc	1 107 44                        ; matmul_async_dma.py:107:44
+	v_lshlrev_b32_e32 v9, 3, v0
+	v_lshrrev_b32_e32 v5, 3, v0
+	v_and_b32_e32 v3, 56, v9
+.Ltmp3:
+	.loc	1 79 34                         ; matmul_async_dma.py:79:34 @[ matmul_async_dma.py:106:56 ]
+	v_readfirstlane_b32 s13, v1
+	s_mul_i32 s12, s12, s13
+	s_mul_hi_u32 s12, s13, s12
+	s_add_i32 s13, s13, s12
+	s_mul_hi_u32 s12, s11, s13
+	s_mul_i32 s13, s12, s7
+	s_sub_i32 s11, s11, s13
+	s_add_i32 s13, s12, 1
+	s_sub_i32 s15, s11, s7
+	s_cmp_ge_u32 s11, s7
+	s_cselect_b32 s12, s13, s12
+	s_cselect_b32 s11, s15, s11
+	s_add_i32 s13, s12, 1
+	s_cmp_ge_u32 s11, s7
+	s_cselect_b32 s7, s13, s12
+	s_xor_b32 s7, s7, s10
+	s_sub_i32 s7, s7, s10
+	.loc	1 78 48                         ; matmul_async_dma.py:78:48 @[ matmul_async_dma.py:106:56 ]
+	s_mul_i32 s6, s7, s6
+	s_sub_i32 s2, s2, s6
+	.loc	1 78 27 is_stmt 0               ; matmul_async_dma.py:78:27 @[ matmul_async_dma.py:106:56 ]
+	s_add_i32 s2, s2, s3
+.Ltmp4:
+	.loc	1 108 21 is_stmt 1              ; matmul_async_dma.py:108:21
+	s_lshl_b32 s13, s7, 6
+	.loc	1 107 21                        ; matmul_async_dma.py:107:21
+	s_lshl_b32 s3, s2, 6
+	.loc	1 107 44 is_stmt 0              ; matmul_async_dma.py:107:44
+	v_or_b32_e32 v7, 32, v5
+	.loc	1 108 31 is_stmt 1              ; matmul_async_dma.py:108:31
+	v_or_b32_e32 v8, s13, v3
+	s_movk_i32 s12, 0x400
+	.loc	1 107 31                        ; matmul_async_dma.py:107:31
+	v_or_b32_e32 v4, s3, v5
+	v_or_b32_e32 v6, s3, v7
+	.loc	1 111 31                        ; matmul_async_dma.py:111:31
+	v_cmp_gt_i32_e32 vcc, s12, v8
+	.loc	1 119 38                        ; matmul_async_dma.py:119:38
+	v_lshlrev_b32_e32 v6, 10, v6
+	.loc	1 107 44                        ; matmul_async_dma.py:107:44
+	v_and_b32_e32 v1, 0x70, v0
+	.loc	1 111 42                        ; matmul_async_dma.py:111:42
+	v_cndmask_b32_e32 v10, 0, v8, vcc
+	.loc	1 119 38                        ; matmul_async_dma.py:119:38
+	v_lshlrev_b32_e32 v8, 10, v4
+	.loc	1 110 31                        ; matmul_async_dma.py:110:31
+	v_cmp_gt_i32_e32 vcc, s12, v4
+	.loc	1 107 44                        ; matmul_async_dma.py:107:44
+	v_and_b32_e32 v2, 63, v0
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	v_readfirstlane_b32 s14, v0
+	.loc	1 110 42                        ; matmul_async_dma.py:110:42
+	v_cndmask_b32_e32 v4, 0, v8, vcc
+	v_cndmask_b32_e32 v6, 0, v6, vcc
+	.loc	1 119 38                        ; matmul_async_dma.py:119:38
+	v_or_b32_e32 v11, v4, v3
+	v_or_b32_e32 v8, v6, v3
+	.loc	1 119 12 is_stmt 0              ; matmul_async_dma.py:119:12
+	v_lshrrev_b32_e32 v3, 1, v1
+	v_xor_b32_e32 v3, v9, v3
+	v_sub_u32_e32 v3, v3, v9
+	v_ashrrev_i32_e32 v3, 3, v3
+	v_add_u32_e32 v2, v3, v2
+	v_lshlrev_b32_e32 v4, 2, v2
+	ds_bpermute_b32 v6, v4, v11
+	ds_bpermute_b32 v12, v4, v8
+	s_lshl_b32 s6, s14, 4
+	v_lshrrev_b64 v[2:3], v2, exec
+	s_and_b32 s6, s6, 0xc00
+	v_and_b32_e32 v3, 1, v2
+	s_add_i32 s17, s6, 0
+	s_waitcnt lgkmcnt(1)
+	v_lshlrev_b32_e32 v6, 1, v6
+	v_bfrev_b32_e32 v2, 1
+	v_cmp_eq_u32_e32 vcc, 1, v3
+	s_and_b32 s9, s9, 0xffff
+	s_mov_b32 s11, 0x27000
+	s_mov_b32 s10, 0x7ffffffe
+	v_cndmask_b32_e32 v3, v2, v6, vcc
+	s_mov_b32 m0, s17
+	s_add_i32 s14, s17, 0x1000
+	buffer_load_dwordx4 v3, s[8:11], 0 offen lds
+	s_waitcnt lgkmcnt(0)
+	v_lshlrev_b32_e32 v3, 1, v12
+	v_cndmask_b32_e32 v3, v2, v3, vcc
+	s_mov_b32 m0, s14
+	.loc	1 124 38 is_stmt 1              ; matmul_async_dma.py:124:38
+	v_lshl_add_u32 v6, v5, 10, v10
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	buffer_load_dwordx4 v3, s[8:11], 0 offen lds
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_bpermute_b32 v3, v4, v6
+	.loc	1 124 38 is_stmt 0              ; matmul_async_dma.py:124:38
+	v_lshl_add_u32 v5, v7, 10, v10
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_bpermute_b32 v7, v4, v5
+	s_add_i32 s15, s17, 0x6000
+	s_and_b32 s5, s5, 0xffff
+	s_waitcnt lgkmcnt(1)
+	v_lshlrev_b32_e32 v3, 1, v3
+	s_mov_b32 s6, s10
+	s_mov_b32 s7, s11
+	v_cndmask_b32_e32 v3, v2, v3, vcc
+	s_mov_b32 m0, s15
+	s_add_i32 s16, s17, 0x7000
+	buffer_load_dwordx4 v3, s[4:7], 0 offen lds
+	s_waitcnt lgkmcnt(0)
+	v_lshlrev_b32_e32 v3, 1, v7
+	v_cndmask_b32_e32 v3, v2, v3, vcc
+	s_mov_b32 m0, s16
+	.loc	1 119 38 is_stmt 1              ; matmul_async_dma.py:119:38
+	v_or_b32_e32 v7, 64, v8
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	buffer_load_dwordx4 v3, s[4:7], 0 offen lds
+	.loc	1 119 38                        ; matmul_async_dma.py:119:38
+	v_or_b32_e32 v3, 64, v11
+	.loc	1 119 12 is_stmt 0              ; matmul_async_dma.py:119:12
+	ds_bpermute_b32 v3, v4, v3
+	ds_bpermute_b32 v7, v4, v7
+	s_add_i32 s19, s17, 0x2000
+	s_mov_b32 m0, s19
+	s_waitcnt lgkmcnt(0)
+	v_lshlrev_b32_e32 v3, 1, v3
+	v_cndmask_b32_e32 v3, v2, v3, vcc
+	s_barrier
+	buffer_load_dwordx4 v3, s[8:11], 0 offen lds
+	s_add_i32 s20, s17, 0x3000
+	v_lshlrev_b32_e32 v3, 1, v7
+	v_cndmask_b32_e32 v3, v2, v3, vcc
+	.loc	1 124 38 is_stmt 1              ; matmul_async_dma.py:124:38
+	v_add_u32_e32 v7, 0x10000, v6
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	s_mov_b32 m0, s20
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_bpermute_b32 v7, v4, v7
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	buffer_load_dwordx4 v3, s[8:11], 0 offen lds
+	.loc	1 124 38                        ; matmul_async_dma.py:124:38
+	v_add_u32_e32 v3, 0x10000, v5
+	.loc	1 124 12 is_stmt 0              ; matmul_async_dma.py:124:12
+	ds_bpermute_b32 v3, v4, v3
+	s_add_i32 s21, s17, 0x8000
+	s_waitcnt lgkmcnt(1)
+	v_lshlrev_b32_e32 v7, 1, v7
+	v_cndmask_b32_e32 v7, v2, v7, vcc
+	s_mov_b32 m0, s21
+	s_add_i32 s22, s17, 0x9000
+	s_waitcnt lgkmcnt(0)
+	v_lshlrev_b32_e32 v3, 1, v3
+	buffer_load_dwordx4 v7, s[4:7], 0 offen lds
+	v_cndmask_b32_e32 v3, v2, v3, vcc
+	s_mov_b32 m0, s22
+	v_lshrrev_b32_e32 v7, 1, v0
+	buffer_load_dwordx4 v3, s[4:7], 0 offen lds
+	v_lshlrev_b32_e32 v3, 6, v0
+	s_movk_i32 s18, 0x820
+	.loc	1 119 38 is_stmt 1              ; matmul_async_dma.py:119:38
+	v_or_b32_e32 v13, 0x80, v11
+	v_bitop3_b32 v3, v3, s18, v7 bitop3:0xc8
+	v_lshlrev_b32_e32 v7, 5, v0
+	v_bfe_i32 v10, v0, 4, 1
+	.loc	1 119 12 is_stmt 0              ; matmul_async_dma.py:119:12
+	ds_bpermute_b32 v13, v4, v13
+	v_and_b32_e32 v7, 0x80, v7
+	v_and_b32_e32 v10, 0x440, v10
+	v_or3_b32 v12, v3, v7, v10
+	v_bfe_i32 v3, v0, 3, 1
+	v_and_b32_e32 v7, 24, v9
+	s_movk_i32 s18, 0x110
+	v_bitop3_b32 v15, v3, v7, s18 bitop3:0x6c
+	.loc	1 107 44 is_stmt 1              ; matmul_async_dma.py:107:44
+	v_and_b32_e32 v3, 15, v0
+	v_and_b32_e32 v7, 0x70, v9
+	v_and_b32_e32 v9, 48, v0
+	v_and_b32_e32 v0, 0x80, v0
+	v_lshl_or_b32 v7, v3, 7, v7
+	v_lshlrev_b32_e32 v14, 4, v0
+	v_or_b32_e32 v10, v12, v15
+	v_bitop3_b32 v7, v7, v14, v9 bitop3:0xde
+	.loc	1 119 38                        ; matmul_async_dma.py:119:38
+	v_or_b32_e32 v9, 0x80, v8
+	.loc	1 119 12 is_stmt 0              ; matmul_async_dma.py:119:12
+	s_waitcnt lgkmcnt(0)
+	v_lshlrev_b32_e32 v13, 1, v13
+	s_movk_i32 s23, 0x60
+	v_cndmask_b32_e32 v32, v2, v13, vcc
+	ds_bpermute_b32 v33, v4, v9
+	v_add_u32_e32 v9, 0, v7
+	v_xad_u32 v7, v7, 64, 0
+	.loc	1 124 12 is_stmt 1              ; matmul_async_dma.py:124:12
+	v_add_u32_e32 v13, 0, v10
+	v_xad_u32 v14, v10, 32, 0
+	v_xad_u32 v10, v10, 64, 0
+	v_bitop3_b32 v12, v12, s23, v15 bitop3:0x36
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	s_waitcnt vmcnt(4) lgkmcnt(0)
+	s_barrier
+	ds_read_b128 v[16:19], v9
+	ds_read_b128 v[20:23], v9 offset:4096
+	ds_read_b128 v[24:27], v7
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[34:35], v13 offset:24576
+	ds_read_b64_tr_b16 v[36:37], v14 offset:25088
+	ds_read_b64_tr_b16 v[38:39], v13 offset:28672
+	ds_read_b64_tr_b16 v[40:41], v14 offset:29184
+	v_add_u32_e32 v12, 0, v12
+	ds_read_b64_tr_b16 v[42:43], v10 offset:24576
+	ds_read_b64_tr_b16 v[44:45], v12 offset:25088
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	s_add_i32 s18, s17, 0x4000
+	s_mov_b32 m0, s18
+	s_add_i32 s23, s17, 0x5000
+	v_lshlrev_b32_e32 v15, 1, v33
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	s_waitcnt lgkmcnt(4)
+	v_mfma_f32_16x16x32_f16 a[0:3], v[34:37], v[16:19], 0
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_read_b128 v[28:31], v7 offset:4096
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[46:47], v10 offset:28672
+	ds_read_b64_tr_b16 v[48:49], v12 offset:29184
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	buffer_load_dwordx4 v32, s[8:11], 0 offen lds
+	v_cndmask_b32_e32 v15, v2, v15, vcc
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	s_waitcnt lgkmcnt(3)
+	v_mfma_f32_16x16x32_f16 a[4:7], v[42:45], v[16:19], 0
+	.loc	1 124 38                        ; matmul_async_dma.py:124:38
+	v_add_u32_e32 v16, 0x20000, v6
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	s_mov_b32 m0, s23
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_bpermute_b32 v16, v4, v16
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	buffer_load_dwordx4 v15, s[8:11], 0 offen lds
+	.loc	1 124 38                        ; matmul_async_dma.py:124:38
+	v_add_u32_e32 v15, 0x20000, v5
+	.loc	1 124 12 is_stmt 0              ; matmul_async_dma.py:124:12
+	ds_bpermute_b32 v15, v4, v15
+	s_add_i32 s24, s17, 0xa000
+	s_waitcnt lgkmcnt(1)
+	v_lshlrev_b32_e32 v16, 1, v16
+	v_cndmask_b32_e32 v16, v2, v16, vcc
+	s_mov_b32 m0, s24
+	s_add_i32 s25, s17, 0xb000
+	s_waitcnt lgkmcnt(0)
+	v_lshlrev_b32_e32 v15, 1, v15
+	buffer_load_dwordx4 v16, s[4:7], 0 offen lds
+	v_cndmask_b32_e32 v15, v2, v15, vcc
+	s_mov_b32 m0, s25
+	.loc	1 128 30 is_stmt 1              ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[8:11], v[34:37], v[20:23], 0
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	buffer_load_dwordx4 v15, s[4:7], 0 offen lds
+	.loc	1 119 38                        ; matmul_async_dma.py:119:38
+	v_or_b32_e32 v15, 0xc0, v11
+	.loc	1 119 12 is_stmt 0              ; matmul_async_dma.py:119:12
+	ds_bpermute_b32 v15, v4, v15
+	.loc	1 119 38                        ; matmul_async_dma.py:119:38
+	v_or_b32_e32 v16, 0xc0, v8
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_bpermute_b32 v32, v4, v16
+	.loc	1 128 30 is_stmt 1              ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[0:3], v[38:41], v[24:27], a[0:3]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	s_waitcnt vmcnt(4) lgkmcnt(0)
+	s_barrier
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[4:7], v[46:49], v[24:27], a[4:7]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[34:35], v13 offset:32768
+	ds_read_b64_tr_b16 v[36:37], v14 offset:33280
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	v_lshlrev_b32_e32 v15, 1, v15
+	v_cndmask_b32_e32 v15, v2, v15, vcc
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[8:11], v[38:41], v[28:31], a[8:11]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	s_mov_b32 m0, s17
+	.loc	1 107 44                        ; matmul_async_dma.py:107:44
+	v_lshrrev_b32_e32 v0, 3, v0
+	v_lshrrev_b32_e32 v1, 2, v1
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[12:15], v[42:45], v[20:23], 0
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[38:39], v13 offset:36864
+	ds_read_b64_tr_b16 v[40:41], v14 offset:37376
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_read_b128 v[16:19], v9 offset:8192
+	ds_read_b128 v[20:23], v9 offset:12288
+	ds_read_b128 v[24:27], v7 offset:8192
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[42:43], v10 offset:32768
+	ds_read_b64_tr_b16 v[44:45], v12 offset:33280
+	.loc	1 107 44                        ; matmul_async_dma.py:107:44
+	v_or_b32_e32 v0, v0, v3
+	.loc	1 107 31 is_stmt 0              ; matmul_async_dma.py:107:31
+	v_or_b32_e32 v3, s3, v0
+	.loc	1 128 30 is_stmt 1              ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[12:15], v[46:49], v[28:31], a[12:15]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_read_b128 v[28:31], v7 offset:12288
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[46:47], v10 offset:36864
+	ds_read_b64_tr_b16 v[48:49], v12 offset:37376
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	buffer_load_dwordx4 v15, s[8:11], 0 offen lds
+	v_lshlrev_b32_e32 v15, 1, v32
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	s_waitcnt lgkmcnt(7)
+	v_mfma_f32_16x16x32_f16 a[0:3], v[34:37], v[16:19], a[0:3]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	v_cndmask_b32_e32 v15, v2, v15, vcc
+	s_mov_b32 m0, s14
+	.loc	1 131 12                        ; matmul_async_dma.py:131:12
+	s_lshl_b32 s2, s2, 16
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	s_waitcnt lgkmcnt(3)
+	v_mfma_f32_16x16x32_f16 a[4:7], v[42:45], v[16:19], a[4:7]
+	.loc	1 124 38                        ; matmul_async_dma.py:124:38
+	v_add_u32_e32 v16, 0x30000, v6
+	.loc	1 124 12 is_stmt 0              ; matmul_async_dma.py:124:12
+	ds_bpermute_b32 v16, v4, v16
+	.loc	1 119 12 is_stmt 1              ; matmul_async_dma.py:119:12
+	buffer_load_dwordx4 v15, s[8:11], 0 offen lds
+	.loc	1 124 38                        ; matmul_async_dma.py:124:38
+	v_add_u32_e32 v15, 0x30000, v5
+	.loc	1 124 12 is_stmt 0              ; matmul_async_dma.py:124:12
+	ds_bpermute_b32 v15, v4, v15
+	s_mov_b32 m0, s15
+	s_waitcnt lgkmcnt(1)
+	v_lshlrev_b32_e32 v16, 1, v16
+	v_cndmask_b32_e32 v16, v2, v16, vcc
+	buffer_load_dwordx4 v16, s[4:7], 0 offen lds
+	s_waitcnt lgkmcnt(0)
+	v_lshlrev_b32_e32 v15, 1, v15
+	v_cndmask_b32_e32 v15, v2, v15, vcc
+	s_mov_b32 m0, s16
+	.loc	1 128 30 is_stmt 1              ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[8:11], v[34:37], v[20:23], a[8:11]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	buffer_load_dwordx4 v15, s[4:7], 0 offen lds
+	.loc	1 119 38                        ; matmul_async_dma.py:119:38
+	v_or_b32_e32 v15, 0x100, v11
+	.loc	1 119 12 is_stmt 0              ; matmul_async_dma.py:119:12
+	ds_bpermute_b32 v15, v4, v15
+	.loc	1 119 38                        ; matmul_async_dma.py:119:38
+	v_or_b32_e32 v16, 0x100, v8
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_bpermute_b32 v32, v4, v16
+	.loc	1 128 30 is_stmt 1              ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[0:3], v[38:41], v[24:27], a[0:3]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	s_waitcnt vmcnt(4) lgkmcnt(0)
+	s_barrier
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[4:7], v[46:49], v[24:27], a[4:7]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[34:35], v13 offset:40960
+	ds_read_b64_tr_b16 v[36:37], v14 offset:41472
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	v_lshlrev_b32_e32 v15, 1, v15
+	v_cndmask_b32_e32 v15, v2, v15, vcc
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[8:11], v[38:41], v[28:31], a[8:11]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	s_mov_b32 m0, s19
+	.loc	1 131 34                        ; matmul_async_dma.py:131:34
+	v_lshlrev_b32_e32 v0, 10, v0
+	.loc	1 132 8                         ; matmul_async_dma.py:132:8
+	s_and_b32 s1, s1, 0xffff
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[12:15], v[42:45], v[20:23], a[12:15]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[38:39], v13 offset:45056
+	ds_read_b64_tr_b16 v[40:41], v14 offset:45568
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_read_b128 v[16:19], v9 offset:16384
+	ds_read_b128 v[20:23], v9 offset:20480
+	ds_read_b128 v[24:27], v7 offset:16384
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[42:43], v10 offset:40960
+	ds_read_b64_tr_b16 v[44:45], v12 offset:41472
+	.loc	1 132 8                         ; matmul_async_dma.py:132:8
+	s_mov_b32 s3, s11
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[12:15], v[46:49], v[28:31], a[12:15]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_read_b128 v[28:31], v7 offset:20480
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[46:47], v10 offset:45056
+	ds_read_b64_tr_b16 v[48:49], v12 offset:45568
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	buffer_load_dwordx4 v15, s[8:11], 0 offen lds
+	v_lshlrev_b32_e32 v15, 1, v32
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	s_waitcnt lgkmcnt(7)
+	v_mfma_f32_16x16x32_f16 a[0:3], v[34:37], v[16:19], a[0:3]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	v_cndmask_b32_e32 v15, v2, v15, vcc
+	s_mov_b32 m0, s20
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	s_waitcnt lgkmcnt(3)
+	v_mfma_f32_16x16x32_f16 a[4:7], v[42:45], v[16:19], a[4:7]
+	.loc	1 124 38                        ; matmul_async_dma.py:124:38
+	v_add_u32_e32 v16, 0x40000, v6
+	.loc	1 124 12 is_stmt 0              ; matmul_async_dma.py:124:12
+	ds_bpermute_b32 v16, v4, v16
+	.loc	1 119 12 is_stmt 1              ; matmul_async_dma.py:119:12
+	buffer_load_dwordx4 v15, s[8:11], 0 offen lds
+	.loc	1 124 38                        ; matmul_async_dma.py:124:38
+	v_add_u32_e32 v15, 0x40000, v5
+	.loc	1 124 12 is_stmt 0              ; matmul_async_dma.py:124:12
+	ds_bpermute_b32 v15, v4, v15
+	s_mov_b32 m0, s21
+	s_waitcnt lgkmcnt(1)
+	v_lshlrev_b32_e32 v16, 1, v16
+	v_cndmask_b32_e32 v16, v2, v16, vcc
+	buffer_load_dwordx4 v16, s[4:7], 0 offen lds
+	s_waitcnt lgkmcnt(0)
+	v_lshlrev_b32_e32 v15, 1, v15
+	v_cndmask_b32_e32 v15, v2, v15, vcc
+	s_mov_b32 m0, s22
+	.loc	1 128 30 is_stmt 1              ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[8:11], v[34:37], v[20:23], a[8:11]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	buffer_load_dwordx4 v15, s[4:7], 0 offen lds
+	.loc	1 119 38                        ; matmul_async_dma.py:119:38
+	v_or_b32_e32 v15, 0x140, v11
+	.loc	1 119 12 is_stmt 0              ; matmul_async_dma.py:119:12
+	ds_bpermute_b32 v15, v4, v15
+	.loc	1 119 38                        ; matmul_async_dma.py:119:38
+	v_or_b32_e32 v16, 0x140, v8
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_bpermute_b32 v32, v4, v16
+	.loc	1 128 30 is_stmt 1              ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[0:3], v[38:41], v[24:27], a[0:3]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	s_waitcnt vmcnt(4) lgkmcnt(0)
+	s_barrier
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[4:7], v[46:49], v[24:27], a[4:7]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[34:35], v13 offset:24576
+	ds_read_b64_tr_b16 v[36:37], v14 offset:25088
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	v_lshlrev_b32_e32 v15, 1, v15
+	v_cndmask_b32_e32 v15, v2, v15, vcc
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[8:11], v[38:41], v[28:31], a[8:11]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	s_mov_b32 m0, s18
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[12:15], v[42:45], v[20:23], a[12:15]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[38:39], v13 offset:28672
+	ds_read_b64_tr_b16 v[40:41], v14 offset:29184
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_read_b128 v[16:19], v9
+	ds_read_b128 v[20:23], v9 offset:4096
+	ds_read_b128 v[24:27], v7
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[42:43], v10 offset:24576
+	ds_read_b64_tr_b16 v[44:45], v12 offset:25088
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[12:15], v[46:49], v[28:31], a[12:15]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_read_b128 v[28:31], v7 offset:4096
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[46:47], v10 offset:28672
+	ds_read_b64_tr_b16 v[48:49], v12 offset:29184
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	buffer_load_dwordx4 v15, s[8:11], 0 offen lds
+	v_lshlrev_b32_e32 v15, 1, v32
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	s_waitcnt lgkmcnt(7)
+	v_mfma_f32_16x16x32_f16 a[0:3], v[34:37], v[16:19], a[0:3]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	v_cndmask_b32_e32 v15, v2, v15, vcc
+	s_mov_b32 m0, s23
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	s_waitcnt lgkmcnt(3)
+	v_mfma_f32_16x16x32_f16 a[4:7], v[42:45], v[16:19], a[4:7]
+	.loc	1 124 38                        ; matmul_async_dma.py:124:38
+	v_add_u32_e32 v16, 0x50000, v6
+	.loc	1 124 12 is_stmt 0              ; matmul_async_dma.py:124:12
+	ds_bpermute_b32 v16, v4, v16
+	.loc	1 119 12 is_stmt 1              ; matmul_async_dma.py:119:12
+	buffer_load_dwordx4 v15, s[8:11], 0 offen lds
+	.loc	1 124 38                        ; matmul_async_dma.py:124:38
+	v_add_u32_e32 v15, 0x50000, v5
+	.loc	1 124 12 is_stmt 0              ; matmul_async_dma.py:124:12
+	ds_bpermute_b32 v15, v4, v15
+	s_mov_b32 m0, s24
+	s_waitcnt lgkmcnt(1)
+	v_lshlrev_b32_e32 v16, 1, v16
+	v_cndmask_b32_e32 v16, v2, v16, vcc
+	buffer_load_dwordx4 v16, s[4:7], 0 offen lds
+	s_waitcnt lgkmcnt(0)
+	v_lshlrev_b32_e32 v15, 1, v15
+	v_cndmask_b32_e32 v15, v2, v15, vcc
+	s_mov_b32 m0, s25
+	.loc	1 128 30 is_stmt 1              ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[8:11], v[34:37], v[20:23], a[8:11]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	buffer_load_dwordx4 v15, s[4:7], 0 offen lds
+	.loc	1 119 38                        ; matmul_async_dma.py:119:38
+	v_or_b32_e32 v15, 0x180, v11
+	.loc	1 119 12 is_stmt 0              ; matmul_async_dma.py:119:12
+	ds_bpermute_b32 v15, v4, v15
+	.loc	1 119 38                        ; matmul_async_dma.py:119:38
+	v_or_b32_e32 v16, 0x180, v8
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_bpermute_b32 v32, v4, v16
+	.loc	1 128 30 is_stmt 1              ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[0:3], v[38:41], v[24:27], a[0:3]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	s_waitcnt vmcnt(4) lgkmcnt(0)
+	s_barrier
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[4:7], v[46:49], v[24:27], a[4:7]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[34:35], v13 offset:32768
+	ds_read_b64_tr_b16 v[36:37], v14 offset:33280
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	v_lshlrev_b32_e32 v15, 1, v15
+	v_cndmask_b32_e32 v15, v2, v15, vcc
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[8:11], v[38:41], v[28:31], a[8:11]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	s_mov_b32 m0, s17
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[12:15], v[42:45], v[20:23], a[12:15]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[38:39], v13 offset:36864
+	ds_read_b64_tr_b16 v[40:41], v14 offset:37376
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_read_b128 v[16:19], v9 offset:8192
+	ds_read_b128 v[20:23], v9 offset:12288
+	ds_read_b128 v[24:27], v7 offset:8192
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[42:43], v10 offset:32768
+	ds_read_b64_tr_b16 v[44:45], v12 offset:33280
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[12:15], v[46:49], v[28:31], a[12:15]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_read_b128 v[28:31], v7 offset:12288
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[46:47], v10 offset:36864
+	ds_read_b64_tr_b16 v[48:49], v12 offset:37376
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	buffer_load_dwordx4 v15, s[8:11], 0 offen lds
+	v_lshlrev_b32_e32 v15, 1, v32
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	s_waitcnt lgkmcnt(7)
+	v_mfma_f32_16x16x32_f16 a[0:3], v[34:37], v[16:19], a[0:3]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	v_cndmask_b32_e32 v15, v2, v15, vcc
+	s_mov_b32 m0, s14
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	s_waitcnt lgkmcnt(3)
+	v_mfma_f32_16x16x32_f16 a[4:7], v[42:45], v[16:19], a[4:7]
+	.loc	1 124 38                        ; matmul_async_dma.py:124:38
+	v_add_u32_e32 v16, 0x60000, v6
+	.loc	1 124 12 is_stmt 0              ; matmul_async_dma.py:124:12
+	ds_bpermute_b32 v16, v4, v16
+	.loc	1 119 12 is_stmt 1              ; matmul_async_dma.py:119:12
+	buffer_load_dwordx4 v15, s[8:11], 0 offen lds
+	.loc	1 124 38                        ; matmul_async_dma.py:124:38
+	v_add_u32_e32 v15, 0x60000, v5
+	.loc	1 124 12 is_stmt 0              ; matmul_async_dma.py:124:12
+	ds_bpermute_b32 v15, v4, v15
+	s_mov_b32 m0, s15
+	s_waitcnt lgkmcnt(1)
+	v_lshlrev_b32_e32 v16, 1, v16
+	v_cndmask_b32_e32 v16, v2, v16, vcc
+	buffer_load_dwordx4 v16, s[4:7], 0 offen lds
+	s_waitcnt lgkmcnt(0)
+	v_lshlrev_b32_e32 v15, 1, v15
+	v_cndmask_b32_e32 v15, v2, v15, vcc
+	s_mov_b32 m0, s16
+	.loc	1 128 30 is_stmt 1              ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[8:11], v[34:37], v[20:23], a[8:11]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	buffer_load_dwordx4 v15, s[4:7], 0 offen lds
+	.loc	1 119 38                        ; matmul_async_dma.py:119:38
+	v_or_b32_e32 v15, 0x1c0, v11
+	.loc	1 119 12 is_stmt 0              ; matmul_async_dma.py:119:12
+	ds_bpermute_b32 v15, v4, v15
+	.loc	1 119 38                        ; matmul_async_dma.py:119:38
+	v_or_b32_e32 v16, 0x1c0, v8
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_bpermute_b32 v32, v4, v16
+	.loc	1 128 30 is_stmt 1              ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[0:3], v[38:41], v[24:27], a[0:3]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	s_waitcnt vmcnt(4) lgkmcnt(0)
+	s_barrier
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[4:7], v[46:49], v[24:27], a[4:7]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[34:35], v13 offset:40960
+	ds_read_b64_tr_b16 v[36:37], v14 offset:41472
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	v_lshlrev_b32_e32 v15, 1, v15
+	v_cndmask_b32_e32 v15, v2, v15, vcc
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[8:11], v[38:41], v[28:31], a[8:11]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	s_mov_b32 m0, s19
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[12:15], v[42:45], v[20:23], a[12:15]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[38:39], v13 offset:45056
+	ds_read_b64_tr_b16 v[40:41], v14 offset:45568
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_read_b128 v[16:19], v9 offset:16384
+	ds_read_b128 v[20:23], v9 offset:20480
+	ds_read_b128 v[24:27], v7 offset:16384
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[42:43], v10 offset:40960
+	ds_read_b64_tr_b16 v[44:45], v12 offset:41472
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[12:15], v[46:49], v[28:31], a[12:15]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_read_b128 v[28:31], v7 offset:20480
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[46:47], v10 offset:45056
+	ds_read_b64_tr_b16 v[48:49], v12 offset:45568
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	buffer_load_dwordx4 v15, s[8:11], 0 offen lds
+	v_lshlrev_b32_e32 v15, 1, v32
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	s_waitcnt lgkmcnt(7)
+	v_mfma_f32_16x16x32_f16 a[0:3], v[34:37], v[16:19], a[0:3]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	v_cndmask_b32_e32 v15, v2, v15, vcc
+	s_mov_b32 m0, s20
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	s_waitcnt lgkmcnt(3)
+	v_mfma_f32_16x16x32_f16 a[4:7], v[42:45], v[16:19], a[4:7]
+	.loc	1 124 38                        ; matmul_async_dma.py:124:38
+	v_add_u32_e32 v16, 0x70000, v6
+	.loc	1 124 12 is_stmt 0              ; matmul_async_dma.py:124:12
+	ds_bpermute_b32 v16, v4, v16
+	.loc	1 119 12 is_stmt 1              ; matmul_async_dma.py:119:12
+	buffer_load_dwordx4 v15, s[8:11], 0 offen lds
+	.loc	1 124 38                        ; matmul_async_dma.py:124:38
+	v_add_u32_e32 v15, 0x70000, v5
+	.loc	1 124 12 is_stmt 0              ; matmul_async_dma.py:124:12
+	ds_bpermute_b32 v15, v4, v15
+	s_mov_b32 m0, s21
+	s_waitcnt lgkmcnt(1)
+	v_lshlrev_b32_e32 v16, 1, v16
+	v_cndmask_b32_e32 v16, v2, v16, vcc
+	buffer_load_dwordx4 v16, s[4:7], 0 offen lds
+	s_waitcnt lgkmcnt(0)
+	v_lshlrev_b32_e32 v15, 1, v15
+	v_cndmask_b32_e32 v15, v2, v15, vcc
+	s_mov_b32 m0, s22
+	.loc	1 128 30 is_stmt 1              ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[8:11], v[34:37], v[20:23], a[8:11]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	buffer_load_dwordx4 v15, s[4:7], 0 offen lds
+	.loc	1 119 38                        ; matmul_async_dma.py:119:38
+	v_or_b32_e32 v15, 0x200, v11
+	.loc	1 119 12 is_stmt 0              ; matmul_async_dma.py:119:12
+	ds_bpermute_b32 v15, v4, v15
+	.loc	1 119 38                        ; matmul_async_dma.py:119:38
+	v_or_b32_e32 v16, 0x200, v8
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_bpermute_b32 v32, v4, v16
+	.loc	1 128 30 is_stmt 1              ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[0:3], v[38:41], v[24:27], a[0:3]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	s_waitcnt vmcnt(4) lgkmcnt(0)
+	s_barrier
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[4:7], v[46:49], v[24:27], a[4:7]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[34:35], v13 offset:24576
+	ds_read_b64_tr_b16 v[36:37], v14 offset:25088
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	v_lshlrev_b32_e32 v15, 1, v15
+	v_cndmask_b32_e32 v15, v2, v15, vcc
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[8:11], v[38:41], v[28:31], a[8:11]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	s_mov_b32 m0, s18
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[12:15], v[42:45], v[20:23], a[12:15]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[38:39], v13 offset:28672
+	ds_read_b64_tr_b16 v[40:41], v14 offset:29184
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_read_b128 v[16:19], v9
+	ds_read_b128 v[20:23], v9 offset:4096
+	ds_read_b128 v[24:27], v7
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[42:43], v10 offset:24576
+	ds_read_b64_tr_b16 v[44:45], v12 offset:25088
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[12:15], v[46:49], v[28:31], a[12:15]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_read_b128 v[28:31], v7 offset:4096
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[46:47], v10 offset:28672
+	ds_read_b64_tr_b16 v[48:49], v12 offset:29184
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	buffer_load_dwordx4 v15, s[8:11], 0 offen lds
+	v_lshlrev_b32_e32 v15, 1, v32
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	s_waitcnt lgkmcnt(7)
+	v_mfma_f32_16x16x32_f16 a[0:3], v[34:37], v[16:19], a[0:3]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	v_cndmask_b32_e32 v15, v2, v15, vcc
+	s_mov_b32 m0, s23
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	s_waitcnt lgkmcnt(3)
+	v_mfma_f32_16x16x32_f16 a[4:7], v[42:45], v[16:19], a[4:7]
+	.loc	1 124 38                        ; matmul_async_dma.py:124:38
+	v_add_u32_e32 v16, 0x80000, v6
+	.loc	1 124 12 is_stmt 0              ; matmul_async_dma.py:124:12
+	ds_bpermute_b32 v16, v4, v16
+	.loc	1 119 12 is_stmt 1              ; matmul_async_dma.py:119:12
+	buffer_load_dwordx4 v15, s[8:11], 0 offen lds
+	.loc	1 124 38                        ; matmul_async_dma.py:124:38
+	v_add_u32_e32 v15, 0x80000, v5
+	.loc	1 124 12 is_stmt 0              ; matmul_async_dma.py:124:12
+	ds_bpermute_b32 v15, v4, v15
+	s_mov_b32 m0, s24
+	s_waitcnt lgkmcnt(1)
+	v_lshlrev_b32_e32 v16, 1, v16
+	v_cndmask_b32_e32 v16, v2, v16, vcc
+	buffer_load_dwordx4 v16, s[4:7], 0 offen lds
+	s_waitcnt lgkmcnt(0)
+	v_lshlrev_b32_e32 v15, 1, v15
+	v_cndmask_b32_e32 v15, v2, v15, vcc
+	s_mov_b32 m0, s25
+	.loc	1 128 30 is_stmt 1              ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[8:11], v[34:37], v[20:23], a[8:11]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	buffer_load_dwordx4 v15, s[4:7], 0 offen lds
+	.loc	1 119 38                        ; matmul_async_dma.py:119:38
+	v_or_b32_e32 v15, 0x240, v11
+	.loc	1 119 12 is_stmt 0              ; matmul_async_dma.py:119:12
+	ds_bpermute_b32 v15, v4, v15
+	.loc	1 119 38                        ; matmul_async_dma.py:119:38
+	v_or_b32_e32 v16, 0x240, v8
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_bpermute_b32 v32, v4, v16
+	.loc	1 128 30 is_stmt 1              ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[0:3], v[38:41], v[24:27], a[0:3]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	s_waitcnt vmcnt(4) lgkmcnt(0)
+	s_barrier
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[4:7], v[46:49], v[24:27], a[4:7]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[34:35], v13 offset:32768
+	ds_read_b64_tr_b16 v[36:37], v14 offset:33280
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	v_lshlrev_b32_e32 v15, 1, v15
+	v_cndmask_b32_e32 v15, v2, v15, vcc
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[8:11], v[38:41], v[28:31], a[8:11]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	s_mov_b32 m0, s17
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[12:15], v[42:45], v[20:23], a[12:15]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[38:39], v13 offset:36864
+	ds_read_b64_tr_b16 v[40:41], v14 offset:37376
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_read_b128 v[16:19], v9 offset:8192
+	ds_read_b128 v[20:23], v9 offset:12288
+	ds_read_b128 v[24:27], v7 offset:8192
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[42:43], v10 offset:32768
+	ds_read_b64_tr_b16 v[44:45], v12 offset:33280
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[12:15], v[46:49], v[28:31], a[12:15]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_read_b128 v[28:31], v7 offset:12288
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[46:47], v10 offset:36864
+	ds_read_b64_tr_b16 v[48:49], v12 offset:37376
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	buffer_load_dwordx4 v15, s[8:11], 0 offen lds
+	v_lshlrev_b32_e32 v15, 1, v32
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	s_waitcnt lgkmcnt(7)
+	v_mfma_f32_16x16x32_f16 a[0:3], v[34:37], v[16:19], a[0:3]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	v_cndmask_b32_e32 v15, v2, v15, vcc
+	s_mov_b32 m0, s14
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	s_waitcnt lgkmcnt(3)
+	v_mfma_f32_16x16x32_f16 a[4:7], v[42:45], v[16:19], a[4:7]
+	.loc	1 124 38                        ; matmul_async_dma.py:124:38
+	v_add_u32_e32 v16, 0x90000, v6
+	.loc	1 124 12 is_stmt 0              ; matmul_async_dma.py:124:12
+	ds_bpermute_b32 v16, v4, v16
+	.loc	1 119 12 is_stmt 1              ; matmul_async_dma.py:119:12
+	buffer_load_dwordx4 v15, s[8:11], 0 offen lds
+	.loc	1 124 38                        ; matmul_async_dma.py:124:38
+	v_add_u32_e32 v15, 0x90000, v5
+	.loc	1 124 12 is_stmt 0              ; matmul_async_dma.py:124:12
+	ds_bpermute_b32 v15, v4, v15
+	s_mov_b32 m0, s15
+	s_waitcnt lgkmcnt(1)
+	v_lshlrev_b32_e32 v16, 1, v16
+	v_cndmask_b32_e32 v16, v2, v16, vcc
+	buffer_load_dwordx4 v16, s[4:7], 0 offen lds
+	s_waitcnt lgkmcnt(0)
+	v_lshlrev_b32_e32 v15, 1, v15
+	v_cndmask_b32_e32 v15, v2, v15, vcc
+	s_mov_b32 m0, s16
+	.loc	1 128 30 is_stmt 1              ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[8:11], v[34:37], v[20:23], a[8:11]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	buffer_load_dwordx4 v15, s[4:7], 0 offen lds
+	.loc	1 119 38                        ; matmul_async_dma.py:119:38
+	v_or_b32_e32 v15, 0x280, v11
+	.loc	1 119 12 is_stmt 0              ; matmul_async_dma.py:119:12
+	ds_bpermute_b32 v15, v4, v15
+	.loc	1 119 38                        ; matmul_async_dma.py:119:38
+	v_or_b32_e32 v16, 0x280, v8
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_bpermute_b32 v32, v4, v16
+	.loc	1 128 30 is_stmt 1              ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[0:3], v[38:41], v[24:27], a[0:3]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	s_waitcnt vmcnt(4) lgkmcnt(0)
+	s_barrier
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[4:7], v[46:49], v[24:27], a[4:7]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[34:35], v13 offset:40960
+	ds_read_b64_tr_b16 v[36:37], v14 offset:41472
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	v_lshlrev_b32_e32 v15, 1, v15
+	v_cndmask_b32_e32 v15, v2, v15, vcc
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[8:11], v[38:41], v[28:31], a[8:11]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	s_mov_b32 m0, s19
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[12:15], v[42:45], v[20:23], a[12:15]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[38:39], v13 offset:45056
+	ds_read_b64_tr_b16 v[40:41], v14 offset:45568
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_read_b128 v[16:19], v9 offset:16384
+	ds_read_b128 v[20:23], v9 offset:20480
+	ds_read_b128 v[24:27], v7 offset:16384
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[42:43], v10 offset:40960
+	ds_read_b64_tr_b16 v[44:45], v12 offset:41472
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[12:15], v[46:49], v[28:31], a[12:15]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_read_b128 v[28:31], v7 offset:20480
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[46:47], v10 offset:45056
+	ds_read_b64_tr_b16 v[48:49], v12 offset:45568
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	buffer_load_dwordx4 v15, s[8:11], 0 offen lds
+	v_lshlrev_b32_e32 v15, 1, v32
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	s_waitcnt lgkmcnt(7)
+	v_mfma_f32_16x16x32_f16 a[0:3], v[34:37], v[16:19], a[0:3]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	v_cndmask_b32_e32 v15, v2, v15, vcc
+	s_mov_b32 m0, s20
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	s_waitcnt lgkmcnt(3)
+	v_mfma_f32_16x16x32_f16 a[4:7], v[42:45], v[16:19], a[4:7]
+	.loc	1 124 38                        ; matmul_async_dma.py:124:38
+	v_add_u32_e32 v16, 0xa0000, v6
+	.loc	1 124 12 is_stmt 0              ; matmul_async_dma.py:124:12
+	ds_bpermute_b32 v16, v4, v16
+	.loc	1 119 12 is_stmt 1              ; matmul_async_dma.py:119:12
+	buffer_load_dwordx4 v15, s[8:11], 0 offen lds
+	.loc	1 124 38                        ; matmul_async_dma.py:124:38
+	v_add_u32_e32 v15, 0xa0000, v5
+	.loc	1 124 12 is_stmt 0              ; matmul_async_dma.py:124:12
+	ds_bpermute_b32 v15, v4, v15
+	s_mov_b32 m0, s21
+	s_waitcnt lgkmcnt(1)
+	v_lshlrev_b32_e32 v16, 1, v16
+	v_cndmask_b32_e32 v16, v2, v16, vcc
+	buffer_load_dwordx4 v16, s[4:7], 0 offen lds
+	s_waitcnt lgkmcnt(0)
+	v_lshlrev_b32_e32 v15, 1, v15
+	v_cndmask_b32_e32 v15, v2, v15, vcc
+	s_mov_b32 m0, s22
+	.loc	1 128 30 is_stmt 1              ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[8:11], v[34:37], v[20:23], a[8:11]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	buffer_load_dwordx4 v15, s[4:7], 0 offen lds
+	.loc	1 119 38                        ; matmul_async_dma.py:119:38
+	v_or_b32_e32 v15, 0x2c0, v11
+	.loc	1 119 12 is_stmt 0              ; matmul_async_dma.py:119:12
+	ds_bpermute_b32 v15, v4, v15
+	.loc	1 119 38                        ; matmul_async_dma.py:119:38
+	v_or_b32_e32 v16, 0x2c0, v8
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_bpermute_b32 v32, v4, v16
+	.loc	1 128 30 is_stmt 1              ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[0:3], v[38:41], v[24:27], a[0:3]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	s_waitcnt vmcnt(4) lgkmcnt(0)
+	s_barrier
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[4:7], v[46:49], v[24:27], a[4:7]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[34:35], v13 offset:24576
+	ds_read_b64_tr_b16 v[36:37], v14 offset:25088
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	v_lshlrev_b32_e32 v15, 1, v15
+	v_cndmask_b32_e32 v15, v2, v15, vcc
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[8:11], v[38:41], v[28:31], a[8:11]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	s_mov_b32 m0, s18
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[12:15], v[42:45], v[20:23], a[12:15]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[38:39], v13 offset:28672
+	ds_read_b64_tr_b16 v[40:41], v14 offset:29184
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_read_b128 v[16:19], v9
+	ds_read_b128 v[20:23], v9 offset:4096
+	ds_read_b128 v[24:27], v7
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[42:43], v10 offset:24576
+	ds_read_b64_tr_b16 v[44:45], v12 offset:25088
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[12:15], v[46:49], v[28:31], a[12:15]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_read_b128 v[28:31], v7 offset:4096
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[46:47], v10 offset:28672
+	ds_read_b64_tr_b16 v[48:49], v12 offset:29184
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	buffer_load_dwordx4 v15, s[8:11], 0 offen lds
+	v_lshlrev_b32_e32 v15, 1, v32
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	s_waitcnt lgkmcnt(7)
+	v_mfma_f32_16x16x32_f16 a[0:3], v[34:37], v[16:19], a[0:3]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	v_cndmask_b32_e32 v15, v2, v15, vcc
+	s_mov_b32 m0, s23
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	s_waitcnt lgkmcnt(3)
+	v_mfma_f32_16x16x32_f16 a[4:7], v[42:45], v[16:19], a[4:7]
+	.loc	1 124 38                        ; matmul_async_dma.py:124:38
+	v_add_u32_e32 v16, 0xb0000, v6
+	.loc	1 124 12 is_stmt 0              ; matmul_async_dma.py:124:12
+	ds_bpermute_b32 v16, v4, v16
+	.loc	1 119 12 is_stmt 1              ; matmul_async_dma.py:119:12
+	buffer_load_dwordx4 v15, s[8:11], 0 offen lds
+	.loc	1 124 38                        ; matmul_async_dma.py:124:38
+	v_add_u32_e32 v15, 0xb0000, v5
+	.loc	1 124 12 is_stmt 0              ; matmul_async_dma.py:124:12
+	ds_bpermute_b32 v15, v4, v15
+	s_mov_b32 m0, s24
+	s_waitcnt lgkmcnt(1)
+	v_lshlrev_b32_e32 v16, 1, v16
+	v_cndmask_b32_e32 v16, v2, v16, vcc
+	buffer_load_dwordx4 v16, s[4:7], 0 offen lds
+	s_waitcnt lgkmcnt(0)
+	v_lshlrev_b32_e32 v15, 1, v15
+	v_cndmask_b32_e32 v15, v2, v15, vcc
+	s_mov_b32 m0, s25
+	.loc	1 128 30 is_stmt 1              ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[8:11], v[34:37], v[20:23], a[8:11]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	buffer_load_dwordx4 v15, s[4:7], 0 offen lds
+	.loc	1 119 38                        ; matmul_async_dma.py:119:38
+	v_or_b32_e32 v15, 0x300, v11
+	.loc	1 119 12 is_stmt 0              ; matmul_async_dma.py:119:12
+	ds_bpermute_b32 v15, v4, v15
+	.loc	1 119 38                        ; matmul_async_dma.py:119:38
+	v_or_b32_e32 v16, 0x300, v8
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_bpermute_b32 v32, v4, v16
+	.loc	1 128 30 is_stmt 1              ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[0:3], v[38:41], v[24:27], a[0:3]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	s_waitcnt vmcnt(4) lgkmcnt(0)
+	s_barrier
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[4:7], v[46:49], v[24:27], a[4:7]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[34:35], v13 offset:32768
+	ds_read_b64_tr_b16 v[36:37], v14 offset:33280
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	v_lshlrev_b32_e32 v15, 1, v15
+	v_cndmask_b32_e32 v15, v2, v15, vcc
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[8:11], v[38:41], v[28:31], a[8:11]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	s_mov_b32 m0, s17
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[12:15], v[42:45], v[20:23], a[12:15]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[38:39], v13 offset:36864
+	ds_read_b64_tr_b16 v[40:41], v14 offset:37376
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_read_b128 v[16:19], v9 offset:8192
+	ds_read_b128 v[20:23], v9 offset:12288
+	ds_read_b128 v[24:27], v7 offset:8192
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[42:43], v10 offset:32768
+	ds_read_b64_tr_b16 v[44:45], v12 offset:33280
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[12:15], v[46:49], v[28:31], a[12:15]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_read_b128 v[28:31], v7 offset:12288
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[46:47], v10 offset:36864
+	ds_read_b64_tr_b16 v[48:49], v12 offset:37376
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	buffer_load_dwordx4 v15, s[8:11], 0 offen lds
+	v_lshlrev_b32_e32 v15, 1, v32
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	s_waitcnt lgkmcnt(7)
+	v_mfma_f32_16x16x32_f16 a[0:3], v[34:37], v[16:19], a[0:3]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	v_cndmask_b32_e32 v15, v2, v15, vcc
+	s_mov_b32 m0, s14
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	s_waitcnt lgkmcnt(3)
+	v_mfma_f32_16x16x32_f16 a[4:7], v[42:45], v[16:19], a[4:7]
+	.loc	1 124 38                        ; matmul_async_dma.py:124:38
+	v_add_u32_e32 v16, 0xc0000, v6
+	.loc	1 124 12 is_stmt 0              ; matmul_async_dma.py:124:12
+	ds_bpermute_b32 v16, v4, v16
+	.loc	1 119 12 is_stmt 1              ; matmul_async_dma.py:119:12
+	buffer_load_dwordx4 v15, s[8:11], 0 offen lds
+	.loc	1 124 38                        ; matmul_async_dma.py:124:38
+	v_add_u32_e32 v15, 0xc0000, v5
+	.loc	1 124 12 is_stmt 0              ; matmul_async_dma.py:124:12
+	ds_bpermute_b32 v15, v4, v15
+	s_mov_b32 m0, s15
+	s_waitcnt lgkmcnt(1)
+	v_lshlrev_b32_e32 v16, 1, v16
+	v_cndmask_b32_e32 v16, v2, v16, vcc
+	buffer_load_dwordx4 v16, s[4:7], 0 offen lds
+	s_waitcnt lgkmcnt(0)
+	v_lshlrev_b32_e32 v15, 1, v15
+	v_cndmask_b32_e32 v15, v2, v15, vcc
+	s_mov_b32 m0, s16
+	.loc	1 128 30 is_stmt 1              ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[8:11], v[34:37], v[20:23], a[8:11]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	buffer_load_dwordx4 v15, s[4:7], 0 offen lds
+	.loc	1 119 38                        ; matmul_async_dma.py:119:38
+	v_or_b32_e32 v15, 0x340, v11
+	.loc	1 119 12 is_stmt 0              ; matmul_async_dma.py:119:12
+	ds_bpermute_b32 v15, v4, v15
+	.loc	1 119 38                        ; matmul_async_dma.py:119:38
+	v_or_b32_e32 v16, 0x340, v8
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_bpermute_b32 v32, v4, v16
+	.loc	1 128 30 is_stmt 1              ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[0:3], v[38:41], v[24:27], a[0:3]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	s_waitcnt vmcnt(4) lgkmcnt(0)
+	s_barrier
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[4:7], v[46:49], v[24:27], a[4:7]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[34:35], v13 offset:40960
+	ds_read_b64_tr_b16 v[36:37], v14 offset:41472
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	v_lshlrev_b32_e32 v15, 1, v15
+	v_cndmask_b32_e32 v15, v2, v15, vcc
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[8:11], v[38:41], v[28:31], a[8:11]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	s_mov_b32 m0, s19
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[12:15], v[42:45], v[20:23], a[12:15]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[38:39], v13 offset:45056
+	ds_read_b64_tr_b16 v[40:41], v14 offset:45568
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_read_b128 v[16:19], v9 offset:16384
+	ds_read_b128 v[20:23], v9 offset:20480
+	ds_read_b128 v[24:27], v7 offset:16384
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[42:43], v10 offset:40960
+	ds_read_b64_tr_b16 v[44:45], v12 offset:41472
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[12:15], v[46:49], v[28:31], a[12:15]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_read_b128 v[28:31], v7 offset:20480
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[46:47], v10 offset:45056
+	ds_read_b64_tr_b16 v[48:49], v12 offset:45568
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	buffer_load_dwordx4 v15, s[8:11], 0 offen lds
+	v_lshlrev_b32_e32 v15, 1, v32
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	s_waitcnt lgkmcnt(7)
+	v_mfma_f32_16x16x32_f16 a[0:3], v[34:37], v[16:19], a[0:3]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	v_cndmask_b32_e32 v15, v2, v15, vcc
+	s_mov_b32 m0, s20
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	s_waitcnt lgkmcnt(3)
+	v_mfma_f32_16x16x32_f16 a[4:7], v[42:45], v[16:19], a[4:7]
+	.loc	1 124 38                        ; matmul_async_dma.py:124:38
+	v_add_u32_e32 v16, 0xd0000, v6
+	.loc	1 124 12 is_stmt 0              ; matmul_async_dma.py:124:12
+	ds_bpermute_b32 v16, v4, v16
+	.loc	1 119 12 is_stmt 1              ; matmul_async_dma.py:119:12
+	buffer_load_dwordx4 v15, s[8:11], 0 offen lds
+	.loc	1 124 38                        ; matmul_async_dma.py:124:38
+	v_add_u32_e32 v15, 0xd0000, v5
+	.loc	1 124 12 is_stmt 0              ; matmul_async_dma.py:124:12
+	ds_bpermute_b32 v15, v4, v15
+	s_mov_b32 m0, s21
+	s_waitcnt lgkmcnt(1)
+	v_lshlrev_b32_e32 v16, 1, v16
+	v_cndmask_b32_e32 v16, v2, v16, vcc
+	buffer_load_dwordx4 v16, s[4:7], 0 offen lds
+	s_waitcnt lgkmcnt(0)
+	v_lshlrev_b32_e32 v15, 1, v15
+	v_cndmask_b32_e32 v15, v2, v15, vcc
+	s_mov_b32 m0, s22
+	.loc	1 128 30 is_stmt 1              ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[8:11], v[34:37], v[20:23], a[8:11]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	buffer_load_dwordx4 v15, s[4:7], 0 offen lds
+	.loc	1 119 38                        ; matmul_async_dma.py:119:38
+	v_or_b32_e32 v15, 0x380, v11
+	.loc	1 119 12 is_stmt 0              ; matmul_async_dma.py:119:12
+	ds_bpermute_b32 v15, v4, v15
+	.loc	1 119 38                        ; matmul_async_dma.py:119:38
+	v_or_b32_e32 v16, 0x380, v8
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_bpermute_b32 v32, v4, v16
+	.loc	1 128 30 is_stmt 1              ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[0:3], v[38:41], v[24:27], a[0:3]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	s_waitcnt vmcnt(4) lgkmcnt(0)
+	s_barrier
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[4:7], v[46:49], v[24:27], a[4:7]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[34:35], v13 offset:24576
+	ds_read_b64_tr_b16 v[36:37], v14 offset:25088
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	v_lshlrev_b32_e32 v15, 1, v15
+	v_cndmask_b32_e32 v15, v2, v15, vcc
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[8:11], v[38:41], v[28:31], a[8:11]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	s_mov_b32 m0, s18
+	.loc	1 119 38 is_stmt 0              ; matmul_async_dma.py:119:38
+	v_or_b32_e32 v11, 0x3c0, v11
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_bpermute_b32 v11, v4, v11
+	.loc	1 128 30 is_stmt 1              ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[12:15], v[42:45], v[20:23], a[12:15]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[38:39], v13 offset:28672
+	ds_read_b64_tr_b16 v[40:41], v14 offset:29184
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_read_b128 v[16:19], v9
+	ds_read_b128 v[20:23], v9 offset:4096
+	ds_read_b128 v[24:27], v7
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[42:43], v10 offset:24576
+	ds_read_b64_tr_b16 v[44:45], v12 offset:25088
+	.loc	1 119 38                        ; matmul_async_dma.py:119:38
+	v_or_b32_e32 v8, 0x3c0, v8
+	.loc	1 119 12 is_stmt 0              ; matmul_async_dma.py:119:12
+	ds_bpermute_b32 v8, v4, v8
+	.loc	1 128 30 is_stmt 1              ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[12:15], v[46:49], v[28:31], a[12:15]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_read_b128 v[28:31], v7 offset:4096
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[46:47], v10 offset:28672
+	ds_read_b64_tr_b16 v[48:49], v12 offset:29184
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	buffer_load_dwordx4 v15, s[8:11], 0 offen lds
+	v_lshlrev_b32_e32 v15, 1, v32
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	s_waitcnt lgkmcnt(8)
+	v_mfma_f32_16x16x32_f16 a[0:3], v[34:37], v[16:19], a[0:3]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	v_cndmask_b32_e32 v15, v2, v15, vcc
+	s_mov_b32 m0, s23
+	v_lshlrev_b32_e32 v11, 1, v11
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	s_waitcnt lgkmcnt(4)
+	v_mfma_f32_16x16x32_f16 a[4:7], v[42:45], v[16:19], a[4:7]
+	.loc	1 124 38                        ; matmul_async_dma.py:124:38
+	v_add_u32_e32 v16, 0xe0000, v6
+	.loc	1 124 12 is_stmt 0              ; matmul_async_dma.py:124:12
+	ds_bpermute_b32 v16, v4, v16
+	.loc	1 119 12 is_stmt 1              ; matmul_async_dma.py:119:12
+	buffer_load_dwordx4 v15, s[8:11], 0 offen lds
+	.loc	1 124 38                        ; matmul_async_dma.py:124:38
+	v_add_u32_e32 v15, 0xe0000, v5
+	.loc	1 124 12 is_stmt 0              ; matmul_async_dma.py:124:12
+	ds_bpermute_b32 v15, v4, v15
+	.loc	1 124 38                        ; matmul_async_dma.py:124:38
+	v_add_u32_e32 v6, 0xf0000, v6
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_bpermute_b32 v6, v4, v6
+	.loc	1 124 38                        ; matmul_async_dma.py:124:38
+	v_add_u32_e32 v5, 0xf0000, v5
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	s_waitcnt lgkmcnt(2)
+	v_lshlrev_b32_e32 v16, 1, v16
+	ds_bpermute_b32 v4, v4, v5
+	.loc	1 128 30 is_stmt 1              ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[8:11], v[34:37], v[20:23], a[8:11]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	v_cndmask_b32_e32 v16, v2, v16, vcc
+	s_mov_b32 m0, s24
+	s_waitcnt lgkmcnt(2)
+	v_lshlrev_b32_e32 v15, 1, v15
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[12:15], v[42:45], v[20:23], a[12:15]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	buffer_load_dwordx4 v16, s[4:7], 0 offen lds
+	v_cndmask_b32_e32 v15, v2, v15, vcc
+	s_mov_b32 m0, s25
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	v_cndmask_b32_e32 v11, v2, v11, vcc
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	buffer_load_dwordx4 v15, s[4:7], 0 offen lds
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	s_mov_b32 m0, s17
+	v_lshlrev_b32_e32 v8, 1, v8
+	s_waitcnt vmcnt(4) lgkmcnt(0)
+	s_barrier
+	buffer_load_dwordx4 v11, s[8:11], 0 offen lds
+	v_cndmask_b32_e32 v8, v2, v8, vcc
+	s_mov_b32 m0, s14
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	v_lshlrev_b32_e32 v6, 1, v6
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[0:3], v[38:41], v[24:27], a[0:3]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[32:33], v13 offset:32768
+	ds_read_b64_tr_b16 v[34:35], v14 offset:33280
+	v_cndmask_b32_e32 v5, v2, v6, vcc
+	v_lshlrev_b32_e32 v4, 1, v4
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[4:7], v[46:49], v[24:27], a[4:7]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	v_cndmask_b32_e32 v4, v2, v4, vcc
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[8:11], v[38:41], v[28:31], a[8:11]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[36:37], v13 offset:36864
+	ds_read_b64_tr_b16 v[38:39], v14 offset:37376
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_read_b128 v[16:19], v9 offset:8192
+	ds_read_b128 v[20:23], v9 offset:12288
+	ds_read_b128 v[24:27], v7 offset:8192
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[40:41], v10 offset:32768
+	ds_read_b64_tr_b16 v[42:43], v12 offset:33280
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[12:15], v[46:49], v[28:31], a[12:15]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_read_b128 v[28:31], v7 offset:12288
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[44:45], v10 offset:36864
+	ds_read_b64_tr_b16 v[46:47], v12 offset:37376
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	buffer_load_dwordx4 v8, s[8:11], 0 offen lds
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	s_mov_b32 m0, s15
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	s_waitcnt lgkmcnt(7)
+	v_mfma_f32_16x16x32_f16 a[0:3], v[32:35], v[16:19], a[0:3]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	buffer_load_dwordx4 v5, s[4:7], 0 offen lds
+	s_mov_b32 m0, s16
+	.loc	1 108 31                        ; matmul_async_dma.py:108:31
+	v_or_b32_e32 v8, s13, v1
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	buffer_load_dwordx4 v4, s[4:7], 0 offen lds
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	s_waitcnt lgkmcnt(3)
+	v_mfma_f32_16x16x32_f16 a[4:7], v[40:43], v[16:19], a[4:7]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	s_waitcnt vmcnt(4) lgkmcnt(0)
+	s_barrier
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[8:11], v[32:35], v[20:23], a[8:11]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[32:33], v13 offset:40960
+	ds_read_b64_tr_b16 v[34:35], v14 offset:41472
+	.loc	1 133 38                        ; matmul_async_dma.py:133:38
+	v_max_i32_e32 v3, v3, v8
+	.loc	1 131 34                        ; matmul_async_dma.py:131:34
+	s_add_i32 s4, s2, s13
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[12:15], v[40:43], v[20:23], a[12:15]
+	.loc	1 133 38                        ; matmul_async_dma.py:133:38
+	v_cmp_gt_i32_e32 vcc, s12, v3
+	.loc	1 132 8                         ; matmul_async_dma.py:132:8
+	s_mov_b32 s2, s10
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[0:3], v[36:39], v[24:27], a[0:3]
+	v_mfma_f32_16x16x32_f16 a[4:7], v[44:47], v[24:27], a[4:7]
+	v_mfma_f32_16x16x32_f16 a[8:11], v[36:39], v[28:31], a[8:11]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[36:37], v13 offset:45056
+	ds_read_b64_tr_b16 v[38:39], v14 offset:45568
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_read_b128 v[16:19], v9 offset:16384
+	ds_read_b128 v[20:23], v9 offset:20480
+	ds_read_b128 v[24:27], v7 offset:16384
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[12:15], v[44:47], v[28:31], a[12:15]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[40:41], v10 offset:40960
+	ds_read_b64_tr_b16 v[42:43], v12 offset:41472
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_read_b128 v[28:31], v7 offset:20480
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[44:45], v10 offset:45056
+	ds_read_b64_tr_b16 v[46:47], v12 offset:45568
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	s_waitcnt vmcnt(0) lgkmcnt(7)
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[0:3], v[32:35], v[16:19], a[0:3]
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[4:7], v[40:43], v[16:19], a[4:7]
+	v_mfma_f32_16x16x32_f16 a[8:11], v[32:35], v[20:23], a[8:11]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[32:33], v13 offset:24576
+	ds_read_b64_tr_b16 v[34:35], v14 offset:25088
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	v_mfma_f32_16x16x32_f16 a[12:15], v[40:43], v[20:23], a[12:15]
+	v_mfma_f32_16x16x32_f16 a[0:3], v[36:39], v[24:27], a[0:3]
+	v_mfma_f32_16x16x32_f16 a[4:7], v[44:47], v[24:27], a[4:7]
+	v_mfma_f32_16x16x32_f16 a[8:11], v[36:39], v[28:31], a[8:11]
+	v_mfma_f32_16x16x32_f16 a[12:15], v[44:47], v[28:31], a[12:15]
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[26:27], v13 offset:28672
+	ds_read_b64_tr_b16 v[28:29], v14 offset:29184
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_read_b128 v[14:17], v9
+	ds_read_b128 v[18:21], v9 offset:4096
+	ds_read_b128 v[22:25], v7
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[36:37], v10 offset:24576
+	ds_read_b64_tr_b16 v[38:39], v12 offset:25088
+	.loc	1 119 12                        ; matmul_async_dma.py:119:12
+	ds_read_b128 v[4:7], v7 offset:4096
+	.loc	1 124 12                        ; matmul_async_dma.py:124:12
+	ds_read_b64_tr_b16 v[10:11], v10 offset:28672
+	ds_read_b64_tr_b16 v[12:13], v12 offset:29184
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	s_waitcnt lgkmcnt(7)
+	v_mfma_f32_16x16x32_f16 a[0:3], v[32:35], v[14:17], a[0:3]
+	.loc	1 107 44                        ; matmul_async_dma.py:107:44
+	v_or_b32_e32 v9, 32, v1
+	.loc	1 128 30                        ; matmul_async_dma.py:128:30
+	s_waitcnt lgkmcnt(3)
+	v_mfma_f32_16x16x32_f16 a[4:7], v[36:39], v[14:17], a[4:7]
+	v_mfma_f32_16x16x32_f16 a[8:11], v[32:35], v[18:21], a[8:11]
+	v_mfma_f32_16x16x32_f16 a[12:15], v[36:39], v[18:21], a[12:15]
+	v_mfma_f32_16x16x32_f16 a[0:3], v[26:29], v[22:25], a[0:3]
+	s_waitcnt lgkmcnt(0)
+	v_mfma_f32_16x16x32_f16 a[4:7], v[10:13], v[22:25], a[4:7]
+	v_mfma_f32_16x16x32_f16 a[8:11], v[26:29], v[4:7], a[8:11]
+	v_mfma_f32_16x16x32_f16 a[12:15], v[10:13], v[4:7], a[12:15]
+	.loc	1 131 34                        ; matmul_async_dma.py:131:34
+	v_or_b32_e32 v4, 0x8000, v0
+	v_or_b32_e32 v5, v0, v1
+	v_or_b32_e32 v0, v0, v9
+	.loc	1 132 8                         ; matmul_async_dma.py:132:8
+	v_add_lshl_u32 v5, v5, s4, 2
+	v_add_lshl_u32 v0, v0, s4, 2
+	.loc	1 131 34                        ; matmul_async_dma.py:131:34
+	v_or_b32_e32 v1, v4, v1
+	.loc	1 132 8                         ; matmul_async_dma.py:132:8
+	v_cndmask_b32_e32 v3, v2, v5, vcc
+	v_cndmask_b32_e32 v0, v2, v0, vcc
+	buffer_store_dwordx4 a[0:3], v3, s[0:3], 0 offen
+	buffer_store_dwordx4 a[4:7], v0, s[0:3], 0 offen
+	v_add_lshl_u32 v0, v1, s4, 2
+	.loc	1 131 34                        ; matmul_async_dma.py:131:34
+	v_or_b32_e32 v4, v4, v9
+	.loc	1 132 8                         ; matmul_async_dma.py:132:8
+	v_cndmask_b32_e32 v0, v2, v0, vcc
+	buffer_store_dwordx4 a[8:11], v0, s[0:3], 0 offen
+	v_add_lshl_u32 v0, v4, s4, 2
+	v_cndmask_b32_e32 v0, v2, v0, vcc
+	buffer_store_dwordx4 a[12:15], v0, s[0:3], 0 offen
+	.loc	1 130 4                         ; matmul_async_dma.py:130:4
+	s_endpgm
+.Ltmp5:
+	.section	.rodata,"a",@progbits
+	.p2align	6, 0x0
+	.amdhsa_kernel matmul_async_buffer_load_lds
+		.amdhsa_group_segment_fixed_size 0
+		.amdhsa_private_segment_fixed_size 0
+		.amdhsa_kernarg_size 40
+		.amdhsa_user_sgpr_count 12
+		.amdhsa_user_sgpr_dispatch_ptr 0
+		.amdhsa_user_sgpr_queue_ptr 0
+		.amdhsa_user_sgpr_kernarg_segment_ptr 1
+		.amdhsa_user_sgpr_dispatch_id 0
+		.amdhsa_user_sgpr_kernarg_preload_length 10
+		.amdhsa_user_sgpr_kernarg_preload_offset 0
+		.amdhsa_user_sgpr_private_segment_size 0
+		.amdhsa_uses_dynamic_stack 0
+		.amdhsa_enable_private_segment 0
+		.amdhsa_system_sgpr_workgroup_id_x 1
+		.amdhsa_system_sgpr_workgroup_id_y 0
+		.amdhsa_system_sgpr_workgroup_id_z 0
+		.amdhsa_system_sgpr_workgroup_info 0
+		.amdhsa_system_vgpr_workitem_id 0
+		.amdhsa_next_free_vgpr 68
+		.amdhsa_next_free_sgpr 26
+		.amdhsa_accum_offset 52
+		.amdhsa_reserve_vcc 1
+		.amdhsa_reserve_xnack_mask 1
+		.amdhsa_float_round_mode_32 0
+		.amdhsa_float_round_mode_16_64 0
+		.amdhsa_float_denorm_mode_32 3
+		.amdhsa_float_denorm_mode_16_64 3
+		.amdhsa_dx10_clamp 1
+		.amdhsa_ieee_mode 1
+		.amdhsa_fp16_overflow 0
+		.amdhsa_tg_split 0
+		.amdhsa_exception_fp_ieee_invalid_op 0
+		.amdhsa_exception_fp_denorm_src 0
+		.amdhsa_exception_fp_ieee_div_zero 0
+		.amdhsa_exception_fp_ieee_overflow 0
+		.amdhsa_exception_fp_ieee_underflow 0
+		.amdhsa_exception_fp_ieee_inexact 0
+		.amdhsa_exception_int_div_zero 0
+	.end_amdhsa_kernel
+	.text
+.Lfunc_end0:
+	.size	matmul_async_buffer_load_lds, .Lfunc_end0-matmul_async_buffer_load_lds
+	.cfi_endproc
+                                        ; -- End function
+	.set matmul_async_buffer_load_lds.num_vgpr, 50
+	.set matmul_async_buffer_load_lds.num_agpr, 16
+	.set matmul_async_buffer_load_lds.numbered_sgpr, 26
+	.set matmul_async_buffer_load_lds.num_named_barrier, 0
+	.set matmul_async_buffer_load_lds.private_seg_size, 0
+	.set matmul_async_buffer_load_lds.uses_vcc, 1
+	.set matmul_async_buffer_load_lds.uses_flat_scratch, 0
+	.set matmul_async_buffer_load_lds.has_dyn_sized_stack, 0
+	.set matmul_async_buffer_load_lds.has_recursion, 0
+	.set matmul_async_buffer_load_lds.has_indirect_call, 0
+	.section	.AMDGPU.csdata,"",@progbits
+; Kernel info:
+; codeLenInByte = 6280
+; TotalNumSgprs: 32
+; NumVgprs: 50
+; NumAgprs: 16
+; TotalNumVgprs: 68
+; ScratchSize: 0
+; MemoryBound: 0
+; FloatMode: 240
+; IeeeMode: 1
+; LDSByteSize: 0 bytes/workgroup (compile time only)
+; SGPRBlocks: 3
+; VGPRBlocks: 8
+; NumSGPRsForWavesPerEU: 32
+; NumVGPRsForWavesPerEU: 68
+; AccumOffset: 52
+; Occupancy: 7
+; WaveLimiterHint : 0
+; COMPUTE_PGM_RSRC2:SCRATCH_EN: 0
+; COMPUTE_PGM_RSRC2:USER_SGPR: 12
+; COMPUTE_PGM_RSRC2:TRAP_HANDLER: 0
+; COMPUTE_PGM_RSRC2:TGID_X_EN: 1
+; COMPUTE_PGM_RSRC2:TGID_Y_EN: 0
+; COMPUTE_PGM_RSRC2:TGID_Z_EN: 0
+; COMPUTE_PGM_RSRC2:TIDIG_COMP_CNT: 0
+; COMPUTE_PGM_RSRC3_GFX90A:ACCUM_OFFSET: 12
+; COMPUTE_PGM_RSRC3_GFX90A:TG_SPLIT: 0
+	.text
+	.p2alignl 6, 3212836864
+	.fill 256, 4, 3212836864
+	.section	.AMDGPU.gpr_maximums,"",@progbits
+	.set amdgpu.max_num_vgpr, 0
+	.set amdgpu.max_num_agpr, 0
+	.set amdgpu.max_num_sgpr, 0
+	.text
+	.section	.debug_abbrev,"",@progbits
+	.byte	1                               ; Abbreviation Code
+	.byte	17                              ; DW_TAG_compile_unit
+	.byte	1                               ; DW_CHILDREN_yes
+	.byte	37                              ; DW_AT_producer
+	.byte	14                              ; DW_FORM_strp
+	.byte	19                              ; DW_AT_language
+	.byte	5                               ; DW_FORM_data2
+	.byte	3                               ; DW_AT_name
+	.byte	14                              ; DW_FORM_strp
+	.byte	16                              ; DW_AT_stmt_list
+	.byte	23                              ; DW_FORM_sec_offset
+	.byte	27                              ; DW_AT_comp_dir
+	.byte	14                              ; DW_FORM_strp
+	.byte	17                              ; DW_AT_low_pc
+	.byte	1                               ; DW_FORM_addr
+	.byte	18                              ; DW_AT_high_pc
+	.byte	6                               ; DW_FORM_data4
+	.byte	0                               ; EOM(1)
+	.byte	0                               ; EOM(2)
+	.byte	2                               ; Abbreviation Code
+	.byte	46                              ; DW_TAG_subprogram
+	.byte	0                               ; DW_CHILDREN_no
+	.byte	3                               ; DW_AT_name
+	.byte	14                              ; DW_FORM_strp
+	.byte	32                              ; DW_AT_inline
+	.byte	11                              ; DW_FORM_data1
+	.byte	0                               ; EOM(1)
+	.byte	0                               ; EOM(2)
+	.byte	3                               ; Abbreviation Code
+	.byte	46                              ; DW_TAG_subprogram
+	.byte	1                               ; DW_CHILDREN_yes
+	.byte	17                              ; DW_AT_low_pc
+	.byte	1                               ; DW_FORM_addr
+	.byte	18                              ; DW_AT_high_pc
+	.byte	6                               ; DW_FORM_data4
+	.byte	49                              ; DW_AT_abstract_origin
+	.byte	19                              ; DW_FORM_ref4
+	.byte	0                               ; EOM(1)
+	.byte	0                               ; EOM(2)
+	.byte	4                               ; Abbreviation Code
+	.byte	29                              ; DW_TAG_inlined_subroutine
+	.byte	0                               ; DW_CHILDREN_no
+	.byte	49                              ; DW_AT_abstract_origin
+	.byte	19                              ; DW_FORM_ref4
+	.byte	85                              ; DW_AT_ranges
+	.byte	23                              ; DW_FORM_sec_offset
+	.byte	88                              ; DW_AT_call_file
+	.byte	11                              ; DW_FORM_data1
+	.byte	89                              ; DW_AT_call_line
+	.byte	11                              ; DW_FORM_data1
+	.byte	87                              ; DW_AT_call_column
+	.byte	11                              ; DW_FORM_data1
+	.byte	0                               ; EOM(1)
+	.byte	0                               ; EOM(2)
+	.byte	0                               ; EOM(3)
+	.section	.debug_info,"",@progbits
+.Lcu_begin0:
+	.long	.Ldebug_info_end0-.Ldebug_info_start0 ; Length of Unit
+.Ldebug_info_start0:
+	.short	4                               ; DWARF version number
+	.long	.debug_abbrev                   ; Offset Into Abbrev. Section
+	.byte	8                               ; Address Size (in bytes)
+	.byte	1                               ; Abbrev [1] 0xb:0x44 DW_TAG_compile_unit
+	.long	.Linfo_string0                  ; DW_AT_producer
+	.short	2                               ; DW_AT_language
+	.long	.Linfo_string1                  ; DW_AT_name
+	.long	.Lline_table_start0             ; DW_AT_stmt_list
+	.long	.Linfo_string2                  ; DW_AT_comp_dir
+	.quad	.Lfunc_begin0                   ; DW_AT_low_pc
+	.long	.Lfunc_end0-.Lfunc_begin0       ; DW_AT_high_pc
+	.byte	2                               ; Abbrev [2] 0x2a:0x6 DW_TAG_subprogram
+	.long	.Linfo_string3                  ; DW_AT_name
+	.byte	1                               ; DW_AT_inline
+	.byte	3                               ; Abbrev [3] 0x30:0x1e DW_TAG_subprogram
+	.quad	.Lfunc_begin0                   ; DW_AT_low_pc
+	.long	.Lfunc_end0-.Lfunc_begin0       ; DW_AT_high_pc
+	.long	42                              ; DW_AT_abstract_origin
+	.byte	4                               ; Abbrev [4] 0x41:0xc DW_TAG_inlined_subroutine
+	.long	42                              ; DW_AT_abstract_origin
+	.long	.Ldebug_ranges0                 ; DW_AT_ranges
+	.byte	1                               ; DW_AT_call_file
+	.byte	106                             ; DW_AT_call_line
+	.byte	56                              ; DW_AT_call_column
+	.byte	0                               ; End Of Children Mark
+	.byte	0                               ; End Of Children Mark
+.Ldebug_info_end0:
+	.section	.debug_ranges,"",@progbits
+.Ldebug_ranges0:
+	.quad	.Ltmp1-.Lfunc_begin0
+	.quad	.Ltmp2-.Lfunc_begin0
+	.quad	.Ltmp3-.Lfunc_begin0
+	.quad	.Ltmp4-.Lfunc_begin0
+	.quad	0
+	.quad	0
+	.section	.debug_str,"MS",@progbits,1
+.Linfo_string0:
+	.asciz	"triton"                        ; string offset=0
+.Linfo_string1:
+	.asciz	"matmul_async_dma.py"           ; string offset=7
+.Linfo_string2:
+	.asciz	"/home/kunwar/Work/runtime-evolution/rocm-systems-rocjitsu-register-feedback/emulation/rocjitsu/tests/kernels/triton" ; string offset=27
+.Linfo_string3:
+	.asciz	"matmul_async_buffer_load_lds"  ; string offset=143
+	.section	".note.GNU-stack","",@progbits
+	.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .agpr_count:     16
+    .args:
+      - .address_space:  global
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .address_space:  global
+        .offset:         8
+        .size:           8
+        .value_kind:     global_buffer
+      - .address_space:  global
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .address_space:  global
+        .offset:         24
+        .size:           8
+        .value_kind:     global_buffer
+      - .address_space:  global
+        .offset:         32
+        .size:           8
+        .value_kind:     global_buffer
+    .group_segment_fixed_size: 0
+    .kernarg_segment_align: 8
+    .kernarg_segment_size: 40
+    .max_flat_workgroup_size: 256
+    .name:           matmul_async_buffer_load_lds
+    .private_segment_fixed_size: 0
+    .sgpr_count:     32
+    .sgpr_spill_count: 0
+    .symbol:         matmul_async_buffer_load_lds.kd
+    .uniform_work_group_size: 1
+    .uses_dynamic_stack: false
+    .vgpr_count:     68
+    .vgpr_spill_count: 0
+    .wavefront_size: 64
+amdhsa.target:   amdgcn-amd-amdhsa--gfx950
+amdhsa.version:
+  - 1
+  - 2
+...
+
+	.end_amdgpu_metadata
+	.section	.debug_line,"",@progbits
+.Lline_table_start0:

--- a/emulation/rocjitsu/tests/kernels/triton_cdna4_matmul_dynamic_32x32x64.s
+++ b/emulation/rocjitsu/tests/kernels/triton_cdna4_matmul_dynamic_32x32x64.s
@@ -1,0 +1,1836 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// Generated with Triton 3.6.0 for gfx950/CDNA4 from this source:
+//
+//   import triton
+//   from triton import language as tl
+//
+//   @triton.jit
+//   def triton_cdna4_matmul_kernel(a, b, c, M, N, K,
+//                                  BLOCK_M: tl.constexpr,
+//                                  BLOCK_N: tl.constexpr,
+//                                  BLOCK_K: tl.constexpr):
+//       pid_m = tl.program_id(0)
+//       pid_n = tl.program_id(1)
+//       offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+//       offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+//       offs_k = tl.arange(0, BLOCK_K)
+//       acc = tl.zeros((BLOCK_M, BLOCK_N), tl.float32)
+//       for k0 in tl.range(0, K, BLOCK_K):
+//           k_idxs = k0 + offs_k
+//           a_tile = tl.load(a + offs_m[:, None] * K + k_idxs[None, :],
+//                            mask=(offs_m[:, None] < M) & (k_idxs[None, :] < K),
+//                            other=0.0)
+//           b_tile = tl.load(b + k_idxs[:, None] * N + offs_n[None, :],
+//                            mask=(k_idxs[:, None] < K) & (offs_n[None, :] < N),
+//                            other=0.0)
+//           acc += tl.dot(a_tile, b_tile, out_dtype=tl.float32)
+//       tl.store(c + offs_m[:, None] * N + offs_n[None, :], acc,
+//                mask=(offs_m[:, None] < M) & (offs_n[None, :] < N))
+//
+//   triton.compile(ASTSource(...,
+//                            signature={"a": '*fp16', "b": '*fp16', "c": '*fp32', "M": 'i32', "N": 'i32', "K": 'i32'},
+//                            constexprs={"BLOCK_M": 32, "BLOCK_N": 32, "BLOCK_K": 64}),
+//                  target=GPUTarget("hip", "gfx950", 64),
+//                  options={"num_warps": 4})
+//
+// Recorded fixture metadata:
+//   kernel: triton_cdna4_matmul_kernel
+//   target: gfx950, wavefront_size: 64
+//   launch sharedMemBytes used by cdna4_to_cdna3_dispatch_test: 8192
+//   amdhsa_group_segment_fixed_size: 0
+//   max_flat_workgroup_size: 256
+//   kernarg_segment_size: 56
+//   registers: vgpr_count=112, agpr_count=16, sgpr_count=44
+
+	.amdgcn_target "amdgcn-amd-amdhsa--gfx950"
+	.amdhsa_code_object_version 5
+	.text
+	.globl	triton_cdna4_matmul_kernel      ; -- Begin function triton_cdna4_matmul_kernel
+	.p2align	8
+	.type	triton_cdna4_matmul_kernel,@function
+triton_cdna4_matmul_kernel:             ; @triton_cdna4_matmul_kernel
+.Lfunc_begin0:
+	.cfi_sections .debug_frame
+	.cfi_startproc
+; %bb.140:
+	.file	1 "tests/kernels" "triton_cdna4_matmul_source"
+	.loc	1 6 0 prologue_end              ; triton_cdna4_matmul_source:6:0
+	s_load_dwordx2 s[2:3], s[0:1], 0x0
+	s_load_dwordx8 s[4:11], s[0:1], 0x8
+	s_load_dwordx4 s[12:15], s[0:1], 0x28
+	s_waitcnt lgkmcnt(0)
+	s_branch .LBB0_0
+	.loc	1 0 0 is_stmt 0                 ; :0:0
+.Ltmp0:
+	.p2align	8
+; %bb.141:
+.LBB0_0:
+.Ltmp1:
+	.loc	1 12 21 is_stmt 1               ; triton_cdna4_matmul_source:12:21
+	s_lshl_b32 s11, s16, 5
+	.loc	1 12 44 is_stmt 0               ; triton_cdna4_matmul_source:12:44
+	v_lshrrev_b32_e32 v1, 6, v0
+	.loc	1 12 31                         ; triton_cdna4_matmul_source:12:31
+	v_or_b32_e32 v1, s11, v1
+	.loc	1 14 26 is_stmt 1               ; triton_cdna4_matmul_source:14:26
+	v_and_b32_e32 v53, 63, v0
+	.loc	1 18 47                         ; triton_cdna4_matmul_source:18:47
+	v_mul_lo_u32 v4, s10, v1
+	.loc	1 19 49                         ; triton_cdna4_matmul_source:19:49
+	v_cmp_gt_i32_e64 s[0:1], s8, v1
+	.loc	1 18 29                         ; triton_cdna4_matmul_source:18:29
+	v_ashrrev_i32_e32 v5, 31, v4
+	.loc	1 19 73                         ; triton_cdna4_matmul_source:19:73
+	v_cmp_gt_i32_e32 vcc, s10, v53
+	.loc	1 18 29                         ; triton_cdna4_matmul_source:18:29
+	v_lshl_add_u64 v[18:19], v[4:5], 1, s[2:3]
+	.loc	1 19 55                         ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[14:15], s[0:1], vcc
+	.loc	1 18 51                         ; triton_cdna4_matmul_source:18:51
+	v_mov_b32_e32 v42, 0
+	v_lshlrev_b32_e32 v2, 1, v53
+	v_mov_b32_e32 v43, 0
+	.loc	1 18 25 is_stmt 0               ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[12:13], s[14:15]
+	s_cbranch_execz .LBB0_2
+; %bb.1:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	v_mov_b32_e32 v3, 0
+	v_lshl_add_u64 v[6:7], v[18:19], 0, v[2:3]
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	global_load_ushort v43, v[6:7], off
+.LBB0_2:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[12:13]
+	.loc	1 18 47                         ; triton_cdna4_matmul_source:18:47
+	s_lshl_b32 s16, s10, 2
+	v_add_u32_e32 v6, s16, v4
+	.loc	1 12 31 is_stmt 1               ; triton_cdna4_matmul_source:12:31
+	v_or_b32_e32 v3, 4, v1
+	.loc	1 18 29                         ; triton_cdna4_matmul_source:18:29
+	v_ashrrev_i32_e32 v7, 31, v6
+	.loc	1 19 49                         ; triton_cdna4_matmul_source:19:49
+	v_cmp_gt_i32_e64 s[24:25], s8, v3
+	.loc	1 18 29                         ; triton_cdna4_matmul_source:18:29
+	v_lshl_add_u64 v[20:21], v[6:7], 1, s[2:3]
+	.loc	1 18 51 is_stmt 0               ; triton_cdna4_matmul_source:18:51
+	v_mov_b32_e32 v3, v42
+	.loc	1 19 55 is_stmt 1               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[14:15], s[24:25], vcc
+	.loc	1 18 51                         ; triton_cdna4_matmul_source:18:51
+	v_lshl_add_u64 v[4:5], v[20:21], 0, v[2:3]
+	.loc	1 18 25 is_stmt 0               ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[12:13], s[14:15]
+	s_cbranch_execz .LBB0_4
+; %bb.3:
+	global_load_ushort v42, v[4:5], off
+.LBB0_4:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[12:13]
+	.loc	1 18 47                         ; triton_cdna4_matmul_source:18:47
+	v_add_u32_e32 v10, s16, v6
+	.loc	1 12 31 is_stmt 1               ; triton_cdna4_matmul_source:12:31
+	v_or_b32_e32 v3, 8, v1
+	.loc	1 18 29                         ; triton_cdna4_matmul_source:18:29
+	v_ashrrev_i32_e32 v11, 31, v10
+	.loc	1 19 49                         ; triton_cdna4_matmul_source:19:49
+	v_cmp_gt_i32_e64 s[20:21], s8, v3
+	.loc	1 18 29                         ; triton_cdna4_matmul_source:18:29
+	v_lshl_add_u64 v[22:23], v[10:11], 1, s[2:3]
+	.loc	1 18 51 is_stmt 0               ; triton_cdna4_matmul_source:18:51
+	v_mov_b32_e32 v3, 0
+	.loc	1 19 55 is_stmt 1               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[14:15], s[20:21], vcc
+	.loc	1 18 51                         ; triton_cdna4_matmul_source:18:51
+	v_lshl_add_u64 v[6:7], v[22:23], 0, v[2:3]
+	v_mov_b32_e32 v44, v3
+	.loc	1 18 25 is_stmt 0               ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[12:13], s[14:15]
+	s_cbranch_execz .LBB0_6
+; %bb.5:
+	global_load_ushort v44, v[6:7], off
+.LBB0_6:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[12:13]
+	.loc	1 12 31 is_stmt 1               ; triton_cdna4_matmul_source:12:31
+	v_or_b32_e32 v8, 12, v1
+	.loc	1 19 49                         ; triton_cdna4_matmul_source:19:49
+	v_cmp_gt_i32_e64 s[26:27], s8, v8
+	.loc	1 18 47                         ; triton_cdna4_matmul_source:18:47
+	v_mul_lo_u32 v8, s10, v8
+	.loc	1 18 29 is_stmt 0               ; triton_cdna4_matmul_source:18:29
+	v_ashrrev_i32_e32 v9, 31, v8
+	v_lshl_add_u64 v[24:25], v[8:9], 1, s[2:3]
+	.loc	1 19 55 is_stmt 1               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[14:15], s[26:27], vcc
+	.loc	1 18 51                         ; triton_cdna4_matmul_source:18:51
+	v_lshl_add_u64 v[8:9], v[24:25], 0, v[2:3]
+	.loc	1 18 25 is_stmt 0               ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[12:13], s[14:15]
+	s_cbranch_execz .LBB0_8
+; %bb.7:
+	global_load_ushort v3, v[8:9], off
+.LBB0_8:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[12:13]
+	.loc	1 18 47                         ; triton_cdna4_matmul_source:18:47
+	v_lshl_add_u32 v12, s10, 3, v10
+	.loc	1 12 31 is_stmt 1               ; triton_cdna4_matmul_source:12:31
+	v_or_b32_e32 v11, 16, v1
+	.loc	1 18 29                         ; triton_cdna4_matmul_source:18:29
+	v_ashrrev_i32_e32 v13, 31, v12
+	.loc	1 19 49                         ; triton_cdna4_matmul_source:19:49
+	v_cmp_gt_i32_e64 s[28:29], s8, v11
+	.loc	1 18 29                         ; triton_cdna4_matmul_source:18:29
+	v_lshl_add_u64 v[26:27], v[12:13], 1, s[2:3]
+	.loc	1 18 51 is_stmt 0               ; triton_cdna4_matmul_source:18:51
+	v_mov_b32_e32 v37, 0
+	v_mov_b32_e32 v36, v2
+	.loc	1 19 55 is_stmt 1               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[14:15], s[28:29], vcc
+	.loc	1 18 51                         ; triton_cdna4_matmul_source:18:51
+	v_lshl_add_u64 v[10:11], v[26:27], 0, v[36:37]
+	v_mov_b32_e32 v45, v37
+	.loc	1 18 25 is_stmt 0               ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[12:13], s[14:15]
+	s_cbranch_execz .LBB0_10
+; %bb.9:
+	global_load_ushort v45, v[10:11], off
+.LBB0_10:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[12:13]
+	.loc	1 18 47                         ; triton_cdna4_matmul_source:18:47
+	v_add_u32_e32 v14, s16, v12
+	.loc	1 12 31 is_stmt 1               ; triton_cdna4_matmul_source:12:31
+	v_or_b32_e32 v13, 20, v1
+	.loc	1 18 29                         ; triton_cdna4_matmul_source:18:29
+	v_ashrrev_i32_e32 v15, 31, v14
+	.loc	1 19 49                         ; triton_cdna4_matmul_source:19:49
+	v_cmp_gt_i32_e64 s[12:13], s8, v13
+	.loc	1 18 29                         ; triton_cdna4_matmul_source:18:29
+	v_lshl_add_u64 v[28:29], v[14:15], 1, s[2:3]
+	.loc	1 19 55                         ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[18:19], s[12:13], vcc
+	.loc	1 18 51                         ; triton_cdna4_matmul_source:18:51
+	v_lshl_add_u64 v[12:13], v[28:29], 0, v[36:37]
+	.loc	1 18 25 is_stmt 0               ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[14:15], s[18:19]
+	s_cbranch_execz .LBB0_12
+; %bb.11:
+	global_load_ushort v37, v[12:13], off
+.LBB0_12:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[14:15]
+	.loc	1 12 31 is_stmt 1               ; triton_cdna4_matmul_source:12:31
+	v_or_b32_e32 v15, 24, v1
+	.loc	1 18 47                         ; triton_cdna4_matmul_source:18:47
+	v_add_u32_e32 v14, s16, v14
+	.loc	1 19 49                         ; triton_cdna4_matmul_source:19:49
+	v_cmp_gt_i32_e64 s[14:15], s8, v15
+	.loc	1 18 29                         ; triton_cdna4_matmul_source:18:29
+	v_ashrrev_i32_e32 v15, 31, v14
+	v_lshl_add_u64 v[30:31], v[14:15], 1, s[2:3]
+	.loc	1 18 51 is_stmt 0               ; triton_cdna4_matmul_source:18:51
+	v_mov_b32_e32 v39, 0
+	v_mov_b32_e32 v38, v2
+	.loc	1 19 55 is_stmt 1               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[22:23], s[14:15], vcc
+	.loc	1 18 51                         ; triton_cdna4_matmul_source:18:51
+	v_lshl_add_u64 v[14:15], v[30:31], 0, v[38:39]
+	v_mov_b32_e32 v36, v39
+	.loc	1 18 25 is_stmt 0               ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[18:19], s[22:23]
+	s_cbranch_execz .LBB0_14
+; %bb.13:
+	global_load_ushort v36, v[14:15], off
+.LBB0_14:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[18:19]
+	.loc	1 12 31 is_stmt 1               ; triton_cdna4_matmul_source:12:31
+	v_or_b32_e32 v1, 28, v1
+	.loc	1 18 47                         ; triton_cdna4_matmul_source:18:47
+	v_mul_lo_u32 v16, s10, v1
+	.loc	1 18 29 is_stmt 0               ; triton_cdna4_matmul_source:18:29
+	v_ashrrev_i32_e32 v17, 31, v16
+	.loc	1 19 49 is_stmt 1               ; triton_cdna4_matmul_source:19:49
+	v_cmp_gt_i32_e64 s[30:31], s8, v1
+	.loc	1 18 29                         ; triton_cdna4_matmul_source:18:29
+	v_lshl_add_u64 v[32:33], v[16:17], 1, s[2:3]
+	.loc	1 19 55                         ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[18:19], s[30:31], vcc
+	.loc	1 18 51                         ; triton_cdna4_matmul_source:18:51
+	v_lshl_add_u64 v[34:35], v[32:33], 0, v[38:39]
+	.loc	1 18 25 is_stmt 0               ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[2:3], s[18:19]
+	s_cbranch_execz .LBB0_16
+; %bb.15:
+	global_load_ushort v39, v[34:35], off
+.LBB0_16:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 12 44 is_stmt 1               ; triton_cdna4_matmul_source:12:44
+	v_and_b32_e32 v1, 31, v0
+	.loc	1 13 21                         ; triton_cdna4_matmul_source:13:21
+	s_lshl_b32 s33, s17, 5
+	.loc	1 13 31 is_stmt 0               ; triton_cdna4_matmul_source:13:31
+	v_or_b32_e32 v16, s33, v1
+	.loc	1 14 26 is_stmt 1               ; triton_cdna4_matmul_source:14:26
+	v_lshrrev_b32_e32 v47, 5, v0
+	.loc	1 22 73                         ; triton_cdna4_matmul_source:22:73
+	v_cmp_gt_i32_e64 s[18:19], s9, v16
+	.loc	1 22 49 is_stmt 0               ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v47
+	.loc	1 22 55                         ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[16:17], s[18:19], vcc
+	.loc	1 21 51 is_stmt 1               ; triton_cdna4_matmul_source:21:51
+	v_ashrrev_i32_e32 v17, 31, v16
+	v_mov_b32_e32 v38, 0
+	v_mov_b32_e32 v48, 0
+	.loc	1 21 25 is_stmt 0               ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[2:3], s[16:17]
+	s_cbranch_execz .LBB0_18
+; %bb.17:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	v_mul_lo_u32 v40, s9, v47
+	v_ashrrev_i32_e32 v41, 31, v40
+	v_lshl_add_u64 v[40:41], v[40:41], 1, s[4:5]
+	v_lshl_add_u64 v[40:41], v[16:17], 1, v[40:41]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v48, v[40:41], off
+.LBB0_18:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 14 26 is_stmt 1               ; triton_cdna4_matmul_source:14:26
+	v_or_b32_e32 v40, 8, v47
+	.loc	1 16 29                         ; triton_cdna4_matmul_source:16:29
+	s_cmp_gt_i32 s10, 0
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v40
+	.loc	1 16 29                         ; triton_cdna4_matmul_source:16:29
+	s_cselect_b64 s[2:3], -1, 0
+	.loc	1 22 55                         ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[16:17], s[18:19], vcc
+	.loc	1 21 47                         ; triton_cdna4_matmul_source:21:47
+	v_mul_lo_u32 v40, s9, v40
+	.loc	1 16 29                         ; triton_cdna4_matmul_source:16:29
+	s_and_b64 s[22:23], s[2:3], s[16:17]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[16:17], s[22:23]
+	s_cbranch_execz .LBB0_20
+; %bb.19:
+	.loc	1 21 29 is_stmt 0               ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v41, 31, v40
+	v_lshl_add_u64 v[50:51], v[40:41], 1, s[4:5]
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[50:51], v[16:17], 1, v[50:51]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v38, v[50:51], off
+.LBB0_20:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[16:17]
+	.loc	1 14 26 is_stmt 1               ; triton_cdna4_matmul_source:14:26
+	v_or_b32_e32 v41, 16, v47
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v41
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[16:17], s[18:19], vcc
+	.loc	1 21 47 is_stmt 1               ; triton_cdna4_matmul_source:21:47
+	s_lshl_b32 s34, s9, 3
+	v_add_u32_e32 v40, s34, v40
+	.loc	1 16 29                         ; triton_cdna4_matmul_source:16:29
+	s_and_b64 s[22:23], s[2:3], s[16:17]
+	v_mov_b32_e32 v54, 0
+	v_mov_b32_e32 v55, 0
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[16:17], s[22:23]
+	s_cbranch_execz .LBB0_22
+; %bb.21:
+	.loc	1 21 29 is_stmt 0               ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v41, 31, v40
+	v_lshl_add_u64 v[50:51], v[40:41], 1, s[4:5]
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[50:51], v[16:17], 1, v[50:51]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v55, v[50:51], off
+.LBB0_22:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[16:17]
+	.loc	1 14 26 is_stmt 1               ; triton_cdna4_matmul_source:14:26
+	v_or_b32_e32 v58, 24, v47
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v58
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[16:17], s[18:19], vcc
+	.loc	1 16 29 is_stmt 1               ; triton_cdna4_matmul_source:16:29
+	s_and_b64 s[22:23], s[2:3], s[16:17]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[16:17], s[22:23]
+	s_cbranch_execz .LBB0_24
+; %bb.23:
+	.loc	1 21 47 is_stmt 0               ; triton_cdna4_matmul_source:21:47
+	v_mul_lo_u32 v50, s9, v58
+	.loc	1 21 29                         ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v51, 31, v50
+	v_lshl_add_u64 v[50:51], v[50:51], 1, s[4:5]
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[50:51], v[16:17], 1, v[50:51]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v54, v[50:51], off
+.LBB0_24:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[16:17]
+	.loc	1 14 26 is_stmt 1               ; triton_cdna4_matmul_source:14:26
+	v_or_b32_e32 v41, 32, v47
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v41
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[16:17], s[18:19], vcc
+	.loc	1 21 47 is_stmt 1               ; triton_cdna4_matmul_source:21:47
+	s_lshl_b32 s35, s9, 4
+	v_add_u32_e32 v40, s35, v40
+	.loc	1 16 29                         ; triton_cdna4_matmul_source:16:29
+	s_and_b64 s[22:23], s[2:3], s[16:17]
+	v_mov_b32_e32 v56, 0
+	v_mov_b32_e32 v57, 0
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[16:17], s[22:23]
+	s_cbranch_execz .LBB0_26
+; %bb.25:
+	.loc	1 21 29 is_stmt 0               ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v41, 31, v40
+	v_lshl_add_u64 v[50:51], v[40:41], 1, s[4:5]
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[50:51], v[16:17], 1, v[50:51]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v57, v[50:51], off
+.LBB0_26:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[16:17]
+	.loc	1 14 26 is_stmt 1               ; triton_cdna4_matmul_source:14:26
+	v_or_b32_e32 v41, 40, v47
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v41
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[16:17], s[18:19], vcc
+	.loc	1 21 47 is_stmt 1               ; triton_cdna4_matmul_source:21:47
+	v_add_u32_e32 v40, s34, v40
+	.loc	1 16 29                         ; triton_cdna4_matmul_source:16:29
+	s_and_b64 s[22:23], s[2:3], s[16:17]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[16:17], s[22:23]
+	s_cbranch_execz .LBB0_28
+; %bb.27:
+	.loc	1 21 29 is_stmt 0               ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v41, 31, v40
+	v_lshl_add_u64 v[50:51], v[40:41], 1, s[4:5]
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[50:51], v[16:17], 1, v[50:51]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v56, v[50:51], off
+.LBB0_28:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[16:17]
+	.loc	1 14 26 is_stmt 1               ; triton_cdna4_matmul_source:14:26
+	v_or_b32_e32 v41, 48, v47
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v41
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[16:17], s[18:19], vcc
+	.loc	1 16 29 is_stmt 1               ; triton_cdna4_matmul_source:16:29
+	s_and_b64 s[22:23], s[2:3], s[16:17]
+	v_mov_b32_e32 v41, 0
+	v_mov_b32_e32 v61, 0
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[16:17], s[22:23]
+	s_cbranch_execz .LBB0_30
+; %bb.29:
+	.loc	1 21 47 is_stmt 0               ; triton_cdna4_matmul_source:21:47
+	v_add_u32_e32 v50, s34, v40
+	.loc	1 21 29                         ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v51, 31, v50
+	v_lshl_add_u64 v[50:51], v[50:51], 1, s[4:5]
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[50:51], v[16:17], 1, v[50:51]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v61, v[50:51], off
+.LBB0_30:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[16:17]
+	.loc	1 14 26 is_stmt 1               ; triton_cdna4_matmul_source:14:26
+	v_or_b32_e32 v59, 56, v47
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v59
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[16:17], s[18:19], vcc
+	.loc	1 16 29 is_stmt 1               ; triton_cdna4_matmul_source:16:29
+	s_and_b64 s[16:17], s[2:3], s[16:17]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[2:3], s[16:17]
+	s_cbranch_execz .LBB0_32
+; %bb.31:
+	.loc	1 21 47 is_stmt 0               ; triton_cdna4_matmul_source:21:47
+	v_mul_lo_u32 v40, s9, v59
+	.loc	1 21 29                         ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v41, 31, v40
+	v_lshl_add_u64 v[40:41], v[40:41], 1, s[4:5]
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[40:41], v[16:17], 1, v[40:41]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v41, v[40:41], off
+.LBB0_32:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 18 25 is_stmt 1               ; triton_cdna4_matmul_source:18:25
+	v_lshlrev_b32_e32 v60, 1, v0
+	v_and_b32_e32 v40, 0xfe, v60
+	v_bfe_i32 v49, v0, 7, 1
+	s_movk_i32 s2, 0x110
+	v_bitop3_b32 v40, v49, v40, s2 bitop3:0x6c
+	v_add_u32_e32 v49, 0, v40
+	s_waitcnt vmcnt(0)
+	ds_write_b16 v49, v43
+	ds_write_b16 v49, v45 offset:2048
+	v_xor_b32_e32 v43, 32, v40
+	v_add_u32_e32 v50, 0, v43
+	ds_write_b16 v50, v42 offset:512
+	ds_write_b16 v50, v37 offset:2560
+	v_xor_b32_e32 v37, 64, v40
+	v_add_u32_e32 v51, 0, v37
+	ds_write_b16 v51, v44 offset:1024
+	ds_write_b16 v51, v36 offset:3072
+	v_xor_b32_e32 v36, 0x60, v40
+	.loc	1 12 44                         ; triton_cdna4_matmul_source:12:44
+	v_and_b32_e32 v46, 32, v0
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	v_add_u32_e32 v52, 0, v36
+	.loc	1 16 29                         ; triton_cdna4_matmul_source:16:29
+	s_sub_i32 s16, s10, 64
+	.loc	1 12 44                         ; triton_cdna4_matmul_source:12:44
+	v_cmp_eq_u32_e64 s[22:23], 0, v46
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	ds_write_b16 v52, v3 offset:1536
+	ds_write_b16 v52, v39 offset:3584
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	ds_write_b16 v49, v48 offset:4096
+	ds_write_b16 v49, v55 offset:5120
+	ds_write_b16 v49, v57 offset:6144
+	ds_write_b16 v49, v61 offset:7168
+	ds_write_b16 v50, v38 offset:4608
+	ds_write_b16 v50, v54 offset:5632
+	ds_write_b16 v50, v56 offset:6656
+	ds_write_b16 v50, v41 offset:7680
+	.loc	1 16 29                         ; triton_cdna4_matmul_source:16:29
+	s_cmp_gt_i32 s16, 0
+	v_lshlrev_b32_e32 v61, 4, v0
+	v_lshlrev_b32_e32 v48, 3, v0
+	s_cbranch_scc1 .LBB0_34
+; %bb.33:                               ; %.._crit_edge_crit_edge
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	v_lshlrev_b32_e32 v3, 3, v0
+	v_mov_b32_e32 v37, 0x220
+	v_and_b32_e32 v36, 24, v3
+	v_cndmask_b32_e64 v37, v37, 0, s[22:23]
+	s_movk_i32 s3, 0xc0
+	v_and_or_b32 v38, v61, s3, v36
+	v_bitop3_b32 v37, v37, v60, 32 bitop3:0x78
+	v_or_b32_e32 v36, v38, v37
+	v_bitop3_b32 v37, v38, s2, v37 bitop3:0x36
+	s_mov_b64 s[2:3], 0
+	s_branch .LBB0_35
+.LBB0_34:
+	.loc	1 0 25 is_stmt 0                ; triton_cdna4_matmul_source:0:25
+	s_mov_b64 s[2:3], -1
+                                        ; implicit-def: $vgpr3
+                                        ; implicit-def: $vgpr36
+                                        ; implicit-def: $vgpr37
+.LBB0_35:                               ; %Flow126
+	v_mov_b32_e32 v62, 0
+	v_accvgpr_write_b32 a0, 0
+	v_accvgpr_write_b32 a1, 0
+	v_accvgpr_write_b32 a2, 0
+	v_accvgpr_write_b32 a3, 0
+	v_accvgpr_write_b32 a4, 0
+	v_accvgpr_write_b32 a5, 0
+	v_accvgpr_write_b32 a6, 0
+	v_accvgpr_write_b32 a7, 0
+	v_accvgpr_write_b32 a8, 0
+	v_accvgpr_write_b32 a9, 0
+	v_accvgpr_write_b32 a10, 0
+	v_accvgpr_write_b32 a11, 0
+	v_accvgpr_write_b32 a12, 0
+	v_accvgpr_write_b32 a13, 0
+	v_accvgpr_write_b32 a14, 0
+	s_andn2_b64 vcc, exec, s[2:3]
+	v_accvgpr_write_b32 a15, 0
+	s_cbranch_vccnz .LBB0_105
+; %bb.36:                               ; %.lr.ph
+	.loc	1 17 22 is_stmt 1               ; triton_cdna4_matmul_source:17:22
+	v_or_b32_e32 v3, 64, v53
+	.loc	1 19 73                         ; triton_cdna4_matmul_source:19:73
+	v_cmp_gt_i32_e32 vcc, s10, v3
+	.loc	1 19 55 is_stmt 0               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[36:37], s[0:1], vcc
+	v_mov_b32_e32 v63, 0
+	.loc	1 18 25 is_stmt 1               ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[2:3], s[36:37]
+	s_cbranch_execz .LBB0_38
+; %bb.37:
+	.loc	1 0 25 is_stmt 0                ; triton_cdna4_matmul_source:0:25
+	v_mov_b32_e32 v3, 0
+	v_lshl_add_u64 v[2:3], v[18:19], 0, v[2:3]
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	global_load_ushort v63, v[2:3], off offset:128
+.LBB0_38:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 55 is_stmt 1               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[36:37], s[24:25], vcc
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[2:3], s[36:37]
+	s_cbranch_execz .LBB0_40
+; %bb.39:
+	global_load_ushort v62, v[4:5], off offset:128
+.LBB0_40:
+	.loc	1 0 25 is_stmt 0                ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 55 is_stmt 1               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[36:37], s[20:21], vcc
+	v_mov_b32_e32 v64, 0
+	v_mov_b32_e32 v65, 0
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[2:3], s[36:37]
+	s_cbranch_execz .LBB0_42
+; %bb.41:
+	global_load_ushort v65, v[6:7], off offset:128
+.LBB0_42:
+	.loc	1 0 25 is_stmt 0                ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 55 is_stmt 1               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[36:37], s[26:27], vcc
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[2:3], s[36:37]
+	s_cbranch_execz .LBB0_44
+; %bb.43:
+	global_load_ushort v64, v[8:9], off offset:128
+.LBB0_44:
+	.loc	1 0 25 is_stmt 0                ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 55 is_stmt 1               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[36:37], s[28:29], vcc
+	v_mov_b32_e32 v66, 0
+	v_mov_b32_e32 v67, 0
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[2:3], s[36:37]
+	s_cbranch_execz .LBB0_46
+; %bb.45:
+	global_load_ushort v67, v[10:11], off offset:128
+.LBB0_46:
+	.loc	1 0 25 is_stmt 0                ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 55 is_stmt 1               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[36:37], s[12:13], vcc
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[2:3], s[36:37]
+	s_cbranch_execz .LBB0_48
+; %bb.47:
+	global_load_ushort v66, v[12:13], off offset:128
+.LBB0_48:
+	.loc	1 0 25 is_stmt 0                ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 55 is_stmt 1               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[36:37], s[14:15], vcc
+	v_mov_b32_e32 v68, 0
+	v_mov_b32_e32 v69, 0
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[2:3], s[36:37]
+	s_cbranch_execz .LBB0_50
+; %bb.49:
+	global_load_ushort v69, v[14:15], off offset:128
+.LBB0_50:
+	.loc	1 0 25 is_stmt 0                ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 55 is_stmt 1               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[36:37], s[30:31], vcc
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[2:3], s[36:37]
+	s_cbranch_execz .LBB0_52
+; %bb.51:
+	global_load_ushort v68, v[34:35], off offset:128
+.LBB0_52:
+	.loc	1 0 25 is_stmt 0                ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	s_movk_i32 s2, 0x70
+	v_lshrrev_b32_e32 v4, 1, v46
+	v_lshlrev_b32_e32 v2, 7, v1
+	v_and_b32_e32 v3, 0x70, v48
+	v_bitop3_b32 v5, v48, v4, s2 bitop3:0x6c
+	v_bitop3_b32 v3, v3, v2, v4 bitop3:0xde
+	v_bitop3_b32 v6, v5, 64, v2 bitop3:0x36
+	s_movk_i32 s2, 0x60
+	v_bitop3_b32 v4, v5, 32, v2 bitop3:0x36
+	v_bitop3_b32 v2, v5, s2, v2 bitop3:0x36
+	.loc	1 17 22 is_stmt 1               ; triton_cdna4_matmul_source:17:22
+	v_or_b32_e32 v37, 0x48, v47
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	v_add_u32_e32 v54, 0, v3
+	v_add_u32_e32 v56, 0, v6
+	.loc	1 16 29                         ; triton_cdna4_matmul_source:16:29
+	v_lshl_add_u64 v[34:35], v[16:17], 1, s[4:5]
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	v_add_u32_e32 v55, 0, v4
+	ds_read_b128 v[14:17], v54
+	ds_read_b128 v[10:13], v55
+	v_add_u32_e32 v57, 0, v2
+	ds_read_b128 v[6:9], v56
+	ds_read_b128 v[2:5], v57
+	.loc	1 21 47                         ; triton_cdna4_matmul_source:21:47
+	v_mul_lo_u32 v44, v37, s9
+	v_add_u32_e32 v42, s34, v44
+	.loc	1 17 22                         ; triton_cdna4_matmul_source:17:22
+	v_or_b32_e32 v36, 64, v47
+	.loc	1 21 47                         ; triton_cdna4_matmul_source:21:47
+	v_add_u32_e32 v40, s35, v42
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v36
+	.loc	1 21 47                         ; triton_cdna4_matmul_source:21:47
+	v_add_u32_e32 v38, s34, v40
+	.loc	1 22 55                         ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[4:5], s[18:19], vcc
+	.loc	1 21 47                         ; triton_cdna4_matmul_source:21:47
+	v_add_u32_e32 v36, s34, v38
+	v_mov_b32_e32 v45, 0
+	v_mov_b32_e32 v70, 0
+	.loc	1 21 25 is_stmt 0               ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_54
+; %bb.53:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_mul_i32 s4, s9, 0xffffffd0
+	v_add_u32_e32 v70, s4, v36
+	v_ashrrev_i32_e32 v71, 31, v70
+	v_lshl_add_u64 v[70:71], v[70:71], 1, v[34:35]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v70, v[70:71], off
+.LBB0_54:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 22 49 is_stmt 1               ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v37
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[4:5], s[18:19], vcc
+	.loc	1 21 25 is_stmt 1               ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_56
+; %bb.55:
+	.loc	1 21 29 is_stmt 0               ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v45, 31, v44
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[44:45], v[44:45], 1, v[34:35]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v45, v[44:45], off
+.LBB0_56:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 17 22 is_stmt 1               ; triton_cdna4_matmul_source:17:22
+	v_or_b32_e32 v37, 0x50, v47
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v37
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[4:5], s[18:19], vcc
+	v_mov_b32_e32 v44, 0
+	v_mov_b32_e32 v43, 0
+	.loc	1 21 25 is_stmt 1               ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_58
+; %bb.57:
+	.loc	1 21 29 is_stmt 0               ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v43, 31, v42
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[42:43], v[42:43], 1, v[34:35]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v43, v[42:43], off
+.LBB0_58:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 17 22 is_stmt 1               ; triton_cdna4_matmul_source:17:22
+	v_or_b32_e32 v37, 0x58, v47
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v37
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[4:5], s[18:19], vcc
+	.loc	1 21 25 is_stmt 1               ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_60
+; %bb.59:
+	.loc	1 21 47 is_stmt 0               ; triton_cdna4_matmul_source:21:47
+	v_mul_lo_u32 v72, v37, s9
+	.loc	1 21 29                         ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v73, 31, v72
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[72:73], v[72:73], 1, v[34:35]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v44, v[72:73], off
+.LBB0_60:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 17 22 is_stmt 1               ; triton_cdna4_matmul_source:17:22
+	v_or_b32_e32 v37, 0x60, v47
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v37
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[4:5], s[18:19], vcc
+	v_mov_b32_e32 v42, 0
+	v_mov_b32_e32 v41, 0
+	.loc	1 21 25 is_stmt 1               ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_62
+; %bb.61:
+	.loc	1 21 29 is_stmt 0               ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v41, 31, v40
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[40:41], v[40:41], 1, v[34:35]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v41, v[40:41], off
+.LBB0_62:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 17 22 is_stmt 1               ; triton_cdna4_matmul_source:17:22
+	v_or_b32_e32 v37, 0x68, v47
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v37
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[4:5], s[18:19], vcc
+	.loc	1 21 25 is_stmt 1               ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_64
+; %bb.63:
+	.loc	1 21 29 is_stmt 0               ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v39, 31, v38
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[38:39], v[38:39], 1, v[34:35]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v42, v[38:39], off
+.LBB0_64:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 17 22 is_stmt 1               ; triton_cdna4_matmul_source:17:22
+	v_or_b32_e32 v37, 0x70, v47
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v37
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[4:5], s[18:19], vcc
+	v_mov_b32_e32 v71, 0
+	v_mov_b32_e32 v72, 0
+	.loc	1 21 25 is_stmt 1               ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_66
+; %bb.65:
+	.loc	1 21 29 is_stmt 0               ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v37, 31, v36
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[36:37], v[36:37], 1, v[34:35]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v72, v[36:37], off
+.LBB0_66:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 17 22 is_stmt 1               ; triton_cdna4_matmul_source:17:22
+	v_or_b32_e32 v36, 0x78, v47
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v36
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[4:5], s[18:19], vcc
+	.loc	1 21 25 is_stmt 1               ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_68
+; %bb.67:
+	.loc	1 21 47 is_stmt 0               ; triton_cdna4_matmul_source:21:47
+	v_mul_lo_u32 v36, v36, s9
+	.loc	1 21 29                         ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v37, 31, v36
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[36:37], v[36:37], 1, v[34:35]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v71, v[36:37], off
+.LBB0_68:
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	v_mov_b32_e32 v37, 0x220
+	v_and_b32_e32 v36, 24, v48
+	v_cndmask_b32_e64 v38, v37, 0, s[22:23]
+	s_movk_i32 s2, 0xc0
+	v_and_or_b32 v37, v61, s2, v36
+	v_bitop3_b32 v38, v38, v60, 32 bitop3:0x78
+	v_bitop3_b32 v40, v37, 16, v38 bitop3:0x36
+	v_or_b32_e32 v36, v37, v38
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	v_add_u32_e32 v40, 0, v40
+	v_add_u32_e32 v39, 0, v36
+	ds_read_b64_tr_b16 v[76:77], v40 offset:4352
+	ds_read_b64_tr_b16 v[74:75], v39 offset:4096
+	ds_read_b64_tr_b16 v[78:79], v39 offset:5120
+	ds_read_b64_tr_b16 v[82:83], v39 offset:6144
+	ds_read_b64_tr_b16 v[86:87], v39 offset:7168
+	ds_read_b64_tr_b16 v[80:81], v40 offset:5376
+	ds_read_b64_tr_b16 v[84:85], v40 offset:6400
+	ds_read_b64_tr_b16 v[88:89], v40 offset:7424
+	.loc	1 24 30 is_stmt 1               ; triton_cdna4_matmul_source:24:30
+	s_waitcnt lgkmcnt(6)
+	v_mfma_f32_32x32x16_f16 a[0:15], v[74:77], v[14:17], 0
+	s_movk_i32 s4, 0x110
+	s_mov_b32 s5, 0
+	.loc	1 16 29                         ; triton_cdna4_matmul_source:16:29
+	s_cmpk_lt_u32 s16, 0x41
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	s_waitcnt vmcnt(0)
+	ds_write_b16 v49, v63
+	ds_write_b16 v49, v67 offset:2048
+	ds_write_b16 v50, v62 offset:512
+	ds_write_b16 v50, v66 offset:2560
+	ds_write_b16 v51, v65 offset:1024
+	ds_write_b16 v51, v69 offset:3072
+	ds_write_b16 v52, v64 offset:1536
+	ds_write_b16 v52, v68 offset:3584
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	ds_write_b16 v49, v70 offset:4096
+	.loc	1 24 30                         ; triton_cdna4_matmul_source:24:30
+	v_mfma_f32_32x32x16_f16 a[0:15], v[78:81], v[10:13], a[0:15]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	ds_write_b16 v49, v43 offset:5120
+	ds_write_b16 v49, v41 offset:6144
+	ds_write_b16 v49, v72 offset:7168
+	ds_write_b16 v50, v45 offset:4608
+	ds_write_b16 v50, v44 offset:5632
+	ds_write_b16 v50, v42 offset:6656
+	ds_write_b16 v50, v71 offset:7680
+	.loc	1 24 30                         ; triton_cdna4_matmul_source:24:30
+	v_mfma_f32_32x32x16_f16 a[0:15], v[82:85], v[6:9], a[0:15]
+	v_mfma_f32_32x32x16_f16 a[0:15], v[86:89], v[2:5], a[0:15]
+	.loc	1 16 29                         ; triton_cdna4_matmul_source:16:29
+	s_cbranch_scc1 .LBB0_104
+; %bb.69:                               ; %.peel.next
+	v_or_b32_e32 v2, 0xb0, v47
+	v_mul_lo_u32 v43, s9, v2
+	v_or_b32_e32 v2, 0xa8, v47
+	v_mul_lo_u32 v44, s9, v2
+	v_or_b32_e32 v2, 0xa0, v47
+	v_mul_lo_u32 v45, s9, v2
+	v_or_b32_e32 v2, 0x90, v47
+	v_mul_lo_u32 v60, s9, v2
+	v_or_b32_e32 v2, 0x88, v47
+	v_or_b32_e32 v41, 0x80, v59
+	v_or_b32_e32 v58, 0x80, v58
+	v_mul_lo_u32 v61, s9, v2
+	v_or_b32_e32 v2, 0x80, v47
+	v_mul_lo_u32 v42, s9, v41
+	s_lshl_b32 s17, s9, 6
+	v_mul_lo_u32 v59, s9, v58
+	v_mul_lo_u32 v62, s9, v2
+	v_or_b32_e32 v53, 0x80, v53
+	s_mov_b32 s22, 0
+.LBB0_70:                               ; =>This Inner Loop Header: Depth=1
+	.loc	1 17 22                         ; triton_cdna4_matmul_source:17:22
+	v_add_u32_e32 v2, s22, v53
+	.loc	1 19 73                         ; triton_cdna4_matmul_source:19:73
+	v_cmp_gt_i32_e32 vcc, s10, v2
+	.loc	1 19 55 is_stmt 0               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[34:35], s[0:1], vcc
+	.loc	1 18 51 is_stmt 1               ; triton_cdna4_matmul_source:18:51
+	v_ashrrev_i32_e32 v3, 31, v2
+	v_mov_b32_e32 v64, 0
+	v_mov_b32_e32 v65, 0
+	.loc	1 18 25 is_stmt 0               ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[2:3], s[34:35]
+	s_cbranch_execz .LBB0_72
+; %bb.71:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	v_lshl_add_u64 v[4:5], v[2:3], 1, v[18:19]
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	global_load_ushort v65, v[4:5], off
+.LBB0_72:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 55 is_stmt 1               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[34:35], s[24:25], vcc
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[2:3], s[34:35]
+	s_cbranch_execz .LBB0_74
+; %bb.73:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 18 51 is_stmt 0               ; triton_cdna4_matmul_source:18:51
+	v_lshl_add_u64 v[4:5], v[2:3], 1, v[20:21]
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	global_load_ushort v64, v[4:5], off
+.LBB0_74:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 55 is_stmt 1               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[34:35], s[20:21], vcc
+	v_mov_b32_e32 v66, 0
+	v_mov_b32_e32 v67, 0
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[2:3], s[34:35]
+	s_cbranch_execz .LBB0_76
+; %bb.75:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 18 51 is_stmt 0               ; triton_cdna4_matmul_source:18:51
+	v_lshl_add_u64 v[4:5], v[2:3], 1, v[22:23]
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	global_load_ushort v67, v[4:5], off
+.LBB0_76:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 55 is_stmt 1               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[34:35], s[26:27], vcc
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[2:3], s[34:35]
+	s_cbranch_execz .LBB0_78
+; %bb.77:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 18 51 is_stmt 0               ; triton_cdna4_matmul_source:18:51
+	v_lshl_add_u64 v[4:5], v[2:3], 1, v[24:25]
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	global_load_ushort v66, v[4:5], off
+.LBB0_78:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 55 is_stmt 1               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[34:35], s[28:29], vcc
+	v_mov_b32_e32 v68, 0
+	v_mov_b32_e32 v69, 0
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[2:3], s[34:35]
+	s_cbranch_execz .LBB0_80
+; %bb.79:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 18 51 is_stmt 0               ; triton_cdna4_matmul_source:18:51
+	v_lshl_add_u64 v[4:5], v[2:3], 1, v[26:27]
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	global_load_ushort v69, v[4:5], off
+.LBB0_80:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 55 is_stmt 1               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[34:35], s[12:13], vcc
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[2:3], s[34:35]
+	s_cbranch_execz .LBB0_82
+; %bb.81:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 18 51 is_stmt 0               ; triton_cdna4_matmul_source:18:51
+	v_lshl_add_u64 v[4:5], v[2:3], 1, v[28:29]
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	global_load_ushort v68, v[4:5], off
+.LBB0_82:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 55 is_stmt 1               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[34:35], s[14:15], vcc
+	v_mov_b32_e32 v70, 0
+	v_mov_b32_e32 v71, 0
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[2:3], s[34:35]
+	s_cbranch_execz .LBB0_84
+; %bb.83:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 18 51 is_stmt 0               ; triton_cdna4_matmul_source:18:51
+	v_lshl_add_u64 v[4:5], v[2:3], 1, v[30:31]
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	global_load_ushort v71, v[4:5], off
+.LBB0_84:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 55 is_stmt 1               ; triton_cdna4_matmul_source:19:55
+	s_and_b64 s[34:35], s[30:31], vcc
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	s_and_saveexec_b64 s[2:3], s[34:35]
+	s_cbranch_execz .LBB0_86
+; %bb.85:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 18 51 is_stmt 0               ; triton_cdna4_matmul_source:18:51
+	v_lshl_add_u64 v[2:3], v[2:3], 1, v[32:33]
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	global_load_ushort v70, v[2:3], off
+.LBB0_86:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	ds_read_b128 v[14:17], v54
+	ds_read_b128 v[10:13], v55
+	ds_read_b128 v[6:9], v56
+	ds_read_b128 v[2:5], v57
+	.loc	1 17 22 is_stmt 1               ; triton_cdna4_matmul_source:17:22
+	v_add_u32_e32 v63, s22, v47
+	v_add_u32_e32 v72, 0x80, v63
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v72
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[34:35], s[18:19], vcc
+	v_mov_b32_e32 v72, 0
+	v_mov_b32_e32 v73, 0
+	.loc	1 21 25 is_stmt 1               ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[2:3], s[34:35]
+	s_cbranch_execz .LBB0_88
+; %bb.87:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 0 25 is_stmt 0                ; triton_cdna4_matmul_source:0:25
+	v_add_u32_e32 v74, s5, v62
+	v_ashrrev_i32_e32 v75, 31, v74
+	v_lshl_add_u64 v[74:75], v[74:75], 1, v[34:35]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v73, v[74:75], off
+.LBB0_88:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 17 22 is_stmt 1               ; triton_cdna4_matmul_source:17:22
+	v_add_u32_e32 v74, 0x88, v63
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v74
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[34:35], s[18:19], vcc
+	.loc	1 21 25 is_stmt 1               ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[2:3], s[34:35]
+	s_cbranch_execz .LBB0_90
+; %bb.89:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 21 47 is_stmt 0               ; triton_cdna4_matmul_source:21:47
+	v_add_u32_e32 v74, s5, v61
+	.loc	1 21 29                         ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v75, 31, v74
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[74:75], v[74:75], 1, v[34:35]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v72, v[74:75], off
+.LBB0_90:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 17 22 is_stmt 1               ; triton_cdna4_matmul_source:17:22
+	v_add_u32_e32 v74, 0x90, v63
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v74
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[34:35], s[18:19], vcc
+	v_mov_b32_e32 v74, 0
+	v_mov_b32_e32 v75, 0
+	.loc	1 21 25 is_stmt 1               ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[2:3], s[34:35]
+	s_cbranch_execz .LBB0_92
+; %bb.91:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 21 47 is_stmt 0               ; triton_cdna4_matmul_source:21:47
+	v_add_u32_e32 v76, s5, v60
+	.loc	1 21 29                         ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v77, 31, v76
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[76:77], v[76:77], 1, v[34:35]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v75, v[76:77], off
+.LBB0_92:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 17 22 is_stmt 1               ; triton_cdna4_matmul_source:17:22
+	v_add_u32_e32 v76, s22, v58
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v76
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[34:35], s[18:19], vcc
+	.loc	1 21 25 is_stmt 1               ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[2:3], s[34:35]
+	s_cbranch_execz .LBB0_94
+; %bb.93:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 21 47 is_stmt 0               ; triton_cdna4_matmul_source:21:47
+	v_add_u32_e32 v76, s5, v59
+	.loc	1 21 29                         ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v77, 31, v76
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[76:77], v[76:77], 1, v[34:35]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v74, v[76:77], off
+.LBB0_94:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 17 22 is_stmt 1               ; triton_cdna4_matmul_source:17:22
+	v_add_u32_e32 v76, 0xa0, v63
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v76
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[34:35], s[18:19], vcc
+	v_mov_b32_e32 v76, 0
+	v_mov_b32_e32 v77, 0
+	.loc	1 21 25 is_stmt 1               ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[2:3], s[34:35]
+	s_cbranch_execz .LBB0_96
+; %bb.95:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 21 47 is_stmt 0               ; triton_cdna4_matmul_source:21:47
+	v_add_u32_e32 v78, s5, v45
+	.loc	1 21 29                         ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v79, 31, v78
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[78:79], v[78:79], 1, v[34:35]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v77, v[78:79], off
+.LBB0_96:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 17 22 is_stmt 1               ; triton_cdna4_matmul_source:17:22
+	v_add_u32_e32 v78, 0xa8, v63
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v78
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[34:35], s[18:19], vcc
+	.loc	1 21 25 is_stmt 1               ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[2:3], s[34:35]
+	s_cbranch_execz .LBB0_98
+; %bb.97:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 21 47 is_stmt 0               ; triton_cdna4_matmul_source:21:47
+	v_add_u32_e32 v78, s5, v44
+	.loc	1 21 29                         ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v79, 31, v78
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[78:79], v[78:79], 1, v[34:35]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v76, v[78:79], off
+.LBB0_98:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 17 22 is_stmt 1               ; triton_cdna4_matmul_source:17:22
+	v_add_u32_e32 v63, 0xb0, v63
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v63
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[34:35], s[18:19], vcc
+	v_mov_b32_e32 v63, 0
+	v_mov_b32_e32 v78, 0
+	.loc	1 21 25 is_stmt 1               ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[2:3], s[34:35]
+	s_cbranch_execz .LBB0_100
+; %bb.99:                               ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 21 47 is_stmt 0               ; triton_cdna4_matmul_source:21:47
+	v_add_u32_e32 v78, s5, v43
+	.loc	1 21 29                         ; triton_cdna4_matmul_source:21:29
+	v_ashrrev_i32_e32 v79, 31, v78
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[78:79], v[78:79], 1, v[34:35]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v78, v[78:79], off
+.LBB0_100:                              ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 19 73 is_stmt 1               ; triton_cdna4_matmul_source:19:73
+	v_add_u32_e32 v79, s22, v41
+	.loc	1 22 49                         ; triton_cdna4_matmul_source:22:49
+	v_cmp_gt_i32_e32 vcc, s10, v79
+	.loc	1 22 55 is_stmt 0               ; triton_cdna4_matmul_source:22:55
+	s_and_b64 s[34:35], s[18:19], vcc
+	.loc	1 21 25 is_stmt 1               ; triton_cdna4_matmul_source:21:25
+	s_and_saveexec_b64 s[2:3], s[34:35]
+	s_cbranch_execz .LBB0_102
+; %bb.101:                              ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 21 29 is_stmt 0               ; triton_cdna4_matmul_source:21:29
+	v_add_u32_e32 v80, s5, v42
+	v_ashrrev_i32_e32 v81, 31, v80
+	.loc	1 21 51                         ; triton_cdna4_matmul_source:21:51
+	v_lshl_add_u64 v[80:81], v[80:81], 1, v[34:35]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	global_load_ushort v63, v[80:81], off
+.LBB0_102:                              ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 0 25                          ; triton_cdna4_matmul_source:0:25
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	ds_read_b64_tr_b16 v[82:83], v40 offset:4352
+	ds_read_b64_tr_b16 v[80:81], v39 offset:4096
+	ds_read_b64_tr_b16 v[84:85], v39 offset:5120
+	ds_read_b64_tr_b16 v[88:89], v39 offset:6144
+	ds_read_b64_tr_b16 v[92:93], v39 offset:7168
+	ds_read_b64_tr_b16 v[86:87], v40 offset:5376
+	ds_read_b64_tr_b16 v[90:91], v40 offset:6400
+	ds_read_b64_tr_b16 v[94:95], v40 offset:7424
+	.loc	1 24 30 is_stmt 1               ; triton_cdna4_matmul_source:24:30
+	s_waitcnt lgkmcnt(6)
+	v_mfma_f32_32x32x16_f16 a[0:15], v[80:83], v[14:17], a[0:15]
+	.loc	1 16 29                         ; triton_cdna4_matmul_source:16:29
+	s_add_i32 s2, s22, 64
+	s_add_i32 s3, s22, 0x80
+	s_add_i32 s5, s5, s17
+	s_cmp_lt_i32 s3, s16
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	s_waitcnt vmcnt(0)
+	ds_write_b16 v49, v65
+	ds_write_b16 v49, v69 offset:2048
+	ds_write_b16 v50, v64 offset:512
+	ds_write_b16 v50, v68 offset:2560
+	ds_write_b16 v51, v67 offset:1024
+	.loc	1 24 30                         ; triton_cdna4_matmul_source:24:30
+	v_mfma_f32_32x32x16_f16 a[0:15], v[84:87], v[10:13], a[0:15]
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	ds_write_b16 v51, v71 offset:3072
+	ds_write_b16 v52, v66 offset:1536
+	ds_write_b16 v52, v70 offset:3584
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	ds_write_b16 v49, v73 offset:4096
+	ds_write_b16 v49, v75 offset:5120
+	ds_write_b16 v49, v77 offset:6144
+	ds_write_b16 v49, v78 offset:7168
+	ds_write_b16 v50, v72 offset:4608
+	ds_write_b16 v50, v74 offset:5632
+	ds_write_b16 v50, v76 offset:6656
+	ds_write_b16 v50, v63 offset:7680
+	.loc	1 24 30                         ; triton_cdna4_matmul_source:24:30
+	v_mfma_f32_32x32x16_f16 a[0:15], v[88:91], v[6:9], a[0:15]
+	v_mfma_f32_32x32x16_f16 a[0:15], v[92:95], v[2:5], a[0:15]
+	.loc	1 16 29                         ; triton_cdna4_matmul_source:16:29
+	s_cbranch_scc0 .LBB0_104
+; %bb.103:                              ;   in Loop: Header=BB0_70 Depth=1
+	.loc	1 0 29 is_stmt 0                ; triton_cdna4_matmul_source:0:29
+	s_mov_b32 s22, s2
+	.loc	1 16 29                         ; triton_cdna4_matmul_source:16:29
+	s_branch .LBB0_70
+.LBB0_104:                              ; %Flow125
+	.loc	1 0 29                          ; triton_cdna4_matmul_source:0:29
+	v_bitop3_b32 v37, v37, s4, v38 bitop3:0x36
+	v_mov_b32_e32 v3, v48
+.LBB0_105:                              ; %._crit_edge
+	.loc	1 21 25 is_stmt 1               ; triton_cdna4_matmul_source:21:25
+	v_add_u32_e32 v2, 0, v36
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	s_waitcnt lgkmcnt(0)
+	s_barrier
+	.loc	1 21 25                         ; triton_cdna4_matmul_source:21:25
+	ds_read_b64_tr_b16 v[32:33], v2 offset:4096
+	ds_read_b64_tr_b16 v[28:29], v2 offset:5120
+	ds_read_b64_tr_b16 v[24:25], v2 offset:6144
+	ds_read_b64_tr_b16 v[20:21], v2 offset:7168
+	v_add_u32_e32 v2, 0, v37
+	ds_read_b64_tr_b16 v[34:35], v2 offset:4096
+	ds_read_b64_tr_b16 v[30:31], v2 offset:5120
+	ds_read_b64_tr_b16 v[26:27], v2 offset:6144
+	ds_read_b64_tr_b16 v[22:23], v2 offset:7168
+	.loc	1 16 29                         ; triton_cdna4_matmul_source:16:29
+	s_add_i32 s10, s10, 63
+	s_cmp_lt_i32 s10, 64
+	.loc	1 24 30                         ; triton_cdna4_matmul_source:24:30
+	s_cbranch_scc1 .LBB0_107
+; %bb.106:
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	v_lshlrev_b32_e32 v2, 7, v1
+	v_and_b32_e32 v36, 0x70, v3
+	v_lshrrev_b32_e32 v40, 1, v46
+	v_bitop3_b32 v41, v36, v2, v40 bitop3:0xde
+	v_add_u32_e32 v36, 0, v41
+	ds_read_b128 v[36:39], v36
+	v_accvgpr_read_b32 v4, a0
+	v_accvgpr_read_b32 v5, a1
+	v_accvgpr_read_b32 v6, a2
+	v_accvgpr_read_b32 v7, a3
+	v_accvgpr_read_b32 v8, a4
+	v_accvgpr_read_b32 v9, a5
+	v_accvgpr_read_b32 v10, a6
+	v_accvgpr_read_b32 v11, a7
+	v_accvgpr_read_b32 v12, a8
+	v_accvgpr_read_b32 v13, a9
+	v_accvgpr_read_b32 v14, a10
+	v_accvgpr_read_b32 v15, a11
+	v_accvgpr_read_b32 v16, a12
+	v_accvgpr_read_b32 v17, a13
+	v_accvgpr_read_b32 v18, a14
+	v_accvgpr_read_b32 v19, a15
+	.loc	1 24 30                         ; triton_cdna4_matmul_source:24:30
+	v_accvgpr_write_b32 a0, v4
+	v_accvgpr_write_b32 a1, v5
+	v_accvgpr_write_b32 a2, v6
+	v_accvgpr_write_b32 a3, v7
+	v_accvgpr_write_b32 a4, v8
+	v_accvgpr_write_b32 a5, v9
+	v_accvgpr_write_b32 a6, v10
+	v_accvgpr_write_b32 a7, v11
+	v_accvgpr_write_b32 a8, v12
+	v_accvgpr_write_b32 a9, v13
+	v_accvgpr_write_b32 a10, v14
+	v_accvgpr_write_b32 a11, v15
+	v_accvgpr_write_b32 a12, v16
+	v_accvgpr_write_b32 a13, v17
+	v_accvgpr_write_b32 a14, v18
+	v_accvgpr_write_b32 a15, v19
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	v_xad_u32 v4, v41, 32, 0
+	ds_read_b128 v[4:7], v4
+	.loc	1 24 30                         ; triton_cdna4_matmul_source:24:30
+	s_waitcnt lgkmcnt(1)
+	v_mfma_f32_32x32x16_f16 a[0:15], v[32:35], v[36:39], a[0:15]
+	s_movk_i32 s0, 0x70
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	v_bitop3_b32 v3, v3, v40, s0 bitop3:0x6c
+	s_movk_i32 s0, 0x60
+	v_bitop3_b32 v2, v3, s0, v2 bitop3:0x36
+	v_add_u32_e32 v2, 0, v2
+	.loc	1 24 30                         ; triton_cdna4_matmul_source:24:30
+	s_waitcnt lgkmcnt(0)
+	v_mfma_f32_32x32x16_f16 a[0:15], v[28:31], v[4:7], a[0:15]
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	v_xad_u32 v4, v41, 64, 0
+	ds_read_b128 v[4:7], v4
+	.loc	1 24 30                         ; triton_cdna4_matmul_source:24:30
+	s_waitcnt lgkmcnt(0)
+	v_mfma_f32_32x32x16_f16 a[0:15], v[24:27], v[4:7], a[0:15]
+	.loc	1 18 25                         ; triton_cdna4_matmul_source:18:25
+	ds_read_b128 v[2:5], v2
+	.loc	1 24 30                         ; triton_cdna4_matmul_source:24:30
+	s_waitcnt lgkmcnt(0)
+	v_mfma_f32_32x32x16_f16 a[0:15], v[20:23], v[2:5], a[0:15]
+.LBB0_107:                              ; %._crit_edge._crit_edge
+	.loc	1 12 44                         ; triton_cdna4_matmul_source:12:44
+	v_lshrrev_b32_e32 v2, 3, v46
+	.loc	1 12 31 is_stmt 0               ; triton_cdna4_matmul_source:12:31
+	v_or_b32_e32 v1, s11, v1
+	.loc	1 13 31 is_stmt 1               ; triton_cdna4_matmul_source:13:31
+	v_or_b32_e32 v2, s33, v2
+	.loc	1 25 35                         ; triton_cdna4_matmul_source:25:35
+	v_mul_lo_u32 v4, s9, v1
+	.loc	1 26 37                         ; triton_cdna4_matmul_source:26:37
+	v_cmp_gt_i32_e32 vcc, s8, v1
+	.loc	1 26 61 is_stmt 0               ; triton_cdna4_matmul_source:26:61
+	v_cmp_gt_i32_e64 s[0:1], s9, v2
+	.loc	1 25 17 is_stmt 1               ; triton_cdna4_matmul_source:25:17
+	v_ashrrev_i32_e32 v5, 31, v4
+	.loc	1 25 56 is_stmt 0               ; triton_cdna4_matmul_source:25:56
+	v_and_b32_e32 v0, 0xc0, v0
+	.loc	1 26 43 is_stmt 1               ; triton_cdna4_matmul_source:26:43
+	s_and_b64 s[2:3], vcc, s[0:1]
+	.loc	1 25 17                         ; triton_cdna4_matmul_source:25:17
+	v_lshl_add_u64 v[4:5], v[4:5], 2, s[6:7]
+	.loc	1 25 39 is_stmt 0               ; triton_cdna4_matmul_source:25:39
+	v_ashrrev_i32_e32 v3, 31, v2
+	.loc	1 25 56                         ; triton_cdna4_matmul_source:25:56
+	v_cmp_eq_u32_e64 s[0:1], 0, v0
+	.loc	1 25 39                         ; triton_cdna4_matmul_source:25:39
+	v_lshl_add_u64 v[4:5], v[2:3], 2, v[4:5]
+	.loc	1 25 56                         ; triton_cdna4_matmul_source:25:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_109
+; %bb.108:
+	global_store_dword v[4:5], a0, off
+.LBB0_109:
+	.loc	1 0 56                          ; triton_cdna4_matmul_source:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 13 31 is_stmt 1               ; triton_cdna4_matmul_source:13:31
+	v_or_b32_e32 v0, 1, v2
+	.loc	1 26 61                         ; triton_cdna4_matmul_source:26:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v0
+	.loc	1 26 43 is_stmt 0               ; triton_cdna4_matmul_source:26:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 25 56 is_stmt 1               ; triton_cdna4_matmul_source:25:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_111
+; %bb.110:
+	global_store_dword v[4:5], a1, off offset:4
+.LBB0_111:
+	.loc	1 0 56 is_stmt 0                ; triton_cdna4_matmul_source:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 13 31 is_stmt 1               ; triton_cdna4_matmul_source:13:31
+	v_or_b32_e32 v0, 2, v2
+	.loc	1 26 61                         ; triton_cdna4_matmul_source:26:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v0
+	.loc	1 26 43 is_stmt 0               ; triton_cdna4_matmul_source:26:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 25 56 is_stmt 1               ; triton_cdna4_matmul_source:25:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_113
+; %bb.112:
+	global_store_dword v[4:5], a2, off offset:8
+.LBB0_113:
+	.loc	1 0 56 is_stmt 0                ; triton_cdna4_matmul_source:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 13 31 is_stmt 1               ; triton_cdna4_matmul_source:13:31
+	v_or_b32_e32 v0, 3, v2
+	.loc	1 26 61                         ; triton_cdna4_matmul_source:26:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v0
+	.loc	1 26 43 is_stmt 0               ; triton_cdna4_matmul_source:26:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 25 56 is_stmt 1               ; triton_cdna4_matmul_source:25:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_115
+; %bb.114:
+	global_store_dword v[4:5], a3, off offset:12
+.LBB0_115:
+	.loc	1 0 56 is_stmt 0                ; triton_cdna4_matmul_source:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 13 31 is_stmt 1               ; triton_cdna4_matmul_source:13:31
+	v_or_b32_e32 v0, 8, v2
+	.loc	1 26 61                         ; triton_cdna4_matmul_source:26:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v0
+	.loc	1 26 43 is_stmt 0               ; triton_cdna4_matmul_source:26:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 25 56 is_stmt 1               ; triton_cdna4_matmul_source:25:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_117
+; %bb.116:
+	global_store_dword v[4:5], a4, off offset:32
+.LBB0_117:
+	.loc	1 0 56 is_stmt 0                ; triton_cdna4_matmul_source:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 13 31 is_stmt 1               ; triton_cdna4_matmul_source:13:31
+	v_or_b32_e32 v0, 9, v2
+	.loc	1 26 61                         ; triton_cdna4_matmul_source:26:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v0
+	.loc	1 26 43 is_stmt 0               ; triton_cdna4_matmul_source:26:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 25 56 is_stmt 1               ; triton_cdna4_matmul_source:25:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_119
+; %bb.118:
+	global_store_dword v[4:5], a5, off offset:36
+.LBB0_119:
+	.loc	1 0 56 is_stmt 0                ; triton_cdna4_matmul_source:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 13 31 is_stmt 1               ; triton_cdna4_matmul_source:13:31
+	v_or_b32_e32 v0, 10, v2
+	.loc	1 26 61                         ; triton_cdna4_matmul_source:26:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v0
+	.loc	1 26 43 is_stmt 0               ; triton_cdna4_matmul_source:26:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 25 56 is_stmt 1               ; triton_cdna4_matmul_source:25:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_121
+; %bb.120:
+	global_store_dword v[4:5], a6, off offset:40
+.LBB0_121:
+	.loc	1 0 56 is_stmt 0                ; triton_cdna4_matmul_source:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 13 31 is_stmt 1               ; triton_cdna4_matmul_source:13:31
+	v_or_b32_e32 v0, 11, v2
+	.loc	1 26 61                         ; triton_cdna4_matmul_source:26:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v0
+	.loc	1 26 43 is_stmt 0               ; triton_cdna4_matmul_source:26:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 25 56 is_stmt 1               ; triton_cdna4_matmul_source:25:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_123
+; %bb.122:
+	global_store_dword v[4:5], a7, off offset:44
+.LBB0_123:
+	.loc	1 0 56 is_stmt 0                ; triton_cdna4_matmul_source:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 13 31 is_stmt 1               ; triton_cdna4_matmul_source:13:31
+	v_or_b32_e32 v0, 16, v2
+	.loc	1 26 61                         ; triton_cdna4_matmul_source:26:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v0
+	.loc	1 26 43 is_stmt 0               ; triton_cdna4_matmul_source:26:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 25 56 is_stmt 1               ; triton_cdna4_matmul_source:25:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_125
+; %bb.124:
+	global_store_dword v[4:5], a8, off offset:64
+.LBB0_125:
+	.loc	1 0 56 is_stmt 0                ; triton_cdna4_matmul_source:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 13 31 is_stmt 1               ; triton_cdna4_matmul_source:13:31
+	v_or_b32_e32 v0, 17, v2
+	.loc	1 26 61                         ; triton_cdna4_matmul_source:26:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v0
+	.loc	1 26 43 is_stmt 0               ; triton_cdna4_matmul_source:26:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 25 56 is_stmt 1               ; triton_cdna4_matmul_source:25:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_127
+; %bb.126:
+	global_store_dword v[4:5], a9, off offset:68
+.LBB0_127:
+	.loc	1 0 56 is_stmt 0                ; triton_cdna4_matmul_source:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 13 31 is_stmt 1               ; triton_cdna4_matmul_source:13:31
+	v_or_b32_e32 v0, 18, v2
+	.loc	1 26 61                         ; triton_cdna4_matmul_source:26:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v0
+	.loc	1 26 43 is_stmt 0               ; triton_cdna4_matmul_source:26:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 25 56 is_stmt 1               ; triton_cdna4_matmul_source:25:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_129
+; %bb.128:
+	global_store_dword v[4:5], a10, off offset:72
+.LBB0_129:
+	.loc	1 0 56 is_stmt 0                ; triton_cdna4_matmul_source:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 13 31 is_stmt 1               ; triton_cdna4_matmul_source:13:31
+	v_or_b32_e32 v0, 19, v2
+	.loc	1 26 61                         ; triton_cdna4_matmul_source:26:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v0
+	.loc	1 26 43 is_stmt 0               ; triton_cdna4_matmul_source:26:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 25 56 is_stmt 1               ; triton_cdna4_matmul_source:25:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_131
+; %bb.130:
+	global_store_dword v[4:5], a11, off offset:76
+.LBB0_131:
+	.loc	1 0 56 is_stmt 0                ; triton_cdna4_matmul_source:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 13 31 is_stmt 1               ; triton_cdna4_matmul_source:13:31
+	v_or_b32_e32 v0, 24, v2
+	.loc	1 26 61                         ; triton_cdna4_matmul_source:26:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v0
+	.loc	1 26 43 is_stmt 0               ; triton_cdna4_matmul_source:26:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 25 56 is_stmt 1               ; triton_cdna4_matmul_source:25:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_133
+; %bb.132:
+	global_store_dword v[4:5], a12, off offset:96
+.LBB0_133:
+	.loc	1 0 56 is_stmt 0                ; triton_cdna4_matmul_source:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 13 31 is_stmt 1               ; triton_cdna4_matmul_source:13:31
+	v_or_b32_e32 v0, 25, v2
+	.loc	1 26 61                         ; triton_cdna4_matmul_source:26:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v0
+	.loc	1 26 43 is_stmt 0               ; triton_cdna4_matmul_source:26:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 25 56 is_stmt 1               ; triton_cdna4_matmul_source:25:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_135
+; %bb.134:
+	global_store_dword v[4:5], a13, off offset:100
+.LBB0_135:
+	.loc	1 0 56 is_stmt 0                ; triton_cdna4_matmul_source:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 13 31 is_stmt 1               ; triton_cdna4_matmul_source:13:31
+	v_or_b32_e32 v0, 26, v2
+	.loc	1 26 61                         ; triton_cdna4_matmul_source:26:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v0
+	.loc	1 26 43 is_stmt 0               ; triton_cdna4_matmul_source:26:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 25 56 is_stmt 1               ; triton_cdna4_matmul_source:25:56
+	s_and_b64 s[4:5], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[4:5]
+	s_cbranch_execz .LBB0_137
+; %bb.136:
+	global_store_dword v[4:5], a14, off offset:104
+.LBB0_137:
+	.loc	1 0 56 is_stmt 0                ; triton_cdna4_matmul_source:0:56
+	s_or_b64 exec, exec, s[2:3]
+	.loc	1 13 31 is_stmt 1               ; triton_cdna4_matmul_source:13:31
+	v_or_b32_e32 v0, 27, v2
+	.loc	1 26 61                         ; triton_cdna4_matmul_source:26:61
+	v_cmp_gt_i32_e64 s[2:3], s9, v0
+	.loc	1 26 43 is_stmt 0               ; triton_cdna4_matmul_source:26:43
+	s_and_b64 s[2:3], vcc, s[2:3]
+	.loc	1 25 56 is_stmt 1               ; triton_cdna4_matmul_source:25:56
+	s_and_b64 s[0:1], s[0:1], s[2:3]
+	s_and_saveexec_b64 s[2:3], s[0:1]
+	s_cbranch_execz .LBB0_139
+; %bb.138:
+	global_store_dword v[4:5], a15, off offset:108
+.LBB0_139:
+	.loc	1 25 4 is_stmt 0                ; triton_cdna4_matmul_source:25:4
+	s_endpgm
+.Ltmp2:
+	.section	.rodata,"a",@progbits
+	.p2align	6, 0x0
+	.amdhsa_kernel triton_cdna4_matmul_kernel
+		.amdhsa_group_segment_fixed_size 0
+		.amdhsa_private_segment_fixed_size 0
+		.amdhsa_kernarg_size 56
+		.amdhsa_user_sgpr_count 16
+		.amdhsa_user_sgpr_dispatch_ptr 0
+		.amdhsa_user_sgpr_queue_ptr 0
+		.amdhsa_user_sgpr_kernarg_segment_ptr 1
+		.amdhsa_user_sgpr_dispatch_id 0
+		.amdhsa_user_sgpr_kernarg_preload_length 14
+		.amdhsa_user_sgpr_kernarg_preload_offset 0
+		.amdhsa_user_sgpr_private_segment_size 0
+		.amdhsa_uses_dynamic_stack 0
+		.amdhsa_enable_private_segment 0
+		.amdhsa_system_sgpr_workgroup_id_x 1
+		.amdhsa_system_sgpr_workgroup_id_y 1
+		.amdhsa_system_sgpr_workgroup_id_z 0
+		.amdhsa_system_sgpr_workgroup_info 0
+		.amdhsa_system_vgpr_workitem_id 0
+		.amdhsa_next_free_vgpr 112
+		.amdhsa_next_free_sgpr 38
+		.amdhsa_accum_offset 96
+		.amdhsa_reserve_vcc 1
+		.amdhsa_reserve_xnack_mask 1
+		.amdhsa_float_round_mode_32 0
+		.amdhsa_float_round_mode_16_64 0
+		.amdhsa_float_denorm_mode_32 3
+		.amdhsa_float_denorm_mode_16_64 3
+		.amdhsa_dx10_clamp 1
+		.amdhsa_ieee_mode 1
+		.amdhsa_fp16_overflow 0
+		.amdhsa_tg_split 0
+		.amdhsa_exception_fp_ieee_invalid_op 0
+		.amdhsa_exception_fp_denorm_src 0
+		.amdhsa_exception_fp_ieee_div_zero 0
+		.amdhsa_exception_fp_ieee_overflow 0
+		.amdhsa_exception_fp_ieee_underflow 0
+		.amdhsa_exception_fp_ieee_inexact 0
+		.amdhsa_exception_int_div_zero 0
+	.end_amdhsa_kernel
+	.text
+.Lfunc_end0:
+	.size	triton_cdna4_matmul_kernel, .Lfunc_end0-triton_cdna4_matmul_kernel
+	.cfi_endproc
+                                        ; -- End function
+	.set triton_cdna4_matmul_kernel.num_vgpr, 96
+	.set triton_cdna4_matmul_kernel.num_agpr, 16
+	.set triton_cdna4_matmul_kernel.numbered_sgpr, 38
+	.set triton_cdna4_matmul_kernel.num_named_barrier, 0
+	.set triton_cdna4_matmul_kernel.private_seg_size, 0
+	.set triton_cdna4_matmul_kernel.uses_vcc, 1
+	.set triton_cdna4_matmul_kernel.uses_flat_scratch, 0
+	.set triton_cdna4_matmul_kernel.has_dyn_sized_stack, 0
+	.set triton_cdna4_matmul_kernel.has_recursion, 0
+	.set triton_cdna4_matmul_kernel.has_indirect_call, 0
+	.section	.AMDGPU.csdata,"",@progbits
+; Kernel info:
+; codeLenInByte = 5384
+; TotalNumSgprs: 44
+; NumVgprs: 96
+; NumAgprs: 16
+; TotalNumVgprs: 112
+; ScratchSize: 0
+; MemoryBound: 0
+; FloatMode: 240
+; IeeeMode: 1
+; LDSByteSize: 0 bytes/workgroup (compile time only)
+; SGPRBlocks: 5
+; VGPRBlocks: 13
+; NumSGPRsForWavesPerEU: 44
+; NumVGPRsForWavesPerEU: 112
+; AccumOffset: 96
+; Occupancy: 4
+; WaveLimiterHint : 0
+; COMPUTE_PGM_RSRC2:SCRATCH_EN: 0
+; COMPUTE_PGM_RSRC2:USER_SGPR: 16
+; COMPUTE_PGM_RSRC2:TRAP_HANDLER: 0
+; COMPUTE_PGM_RSRC2:TGID_X_EN: 1
+; COMPUTE_PGM_RSRC2:TGID_Y_EN: 1
+; COMPUTE_PGM_RSRC2:TGID_Z_EN: 0
+; COMPUTE_PGM_RSRC2:TIDIG_COMP_CNT: 0
+; COMPUTE_PGM_RSRC3_GFX90A:ACCUM_OFFSET: 23
+; COMPUTE_PGM_RSRC3_GFX90A:TG_SPLIT: 0
+	.text
+	.p2alignl 6, 3212836864
+	.fill 256, 4, 3212836864
+	.section	.AMDGPU.gpr_maximums,"",@progbits
+	.set amdgpu.max_num_vgpr, 0
+	.set amdgpu.max_num_agpr, 0
+	.set amdgpu.max_num_sgpr, 0
+	.text
+	.section	.debug_abbrev,"",@progbits
+	.byte	1                               ; Abbreviation Code
+	.byte	17                              ; DW_TAG_compile_unit
+	.byte	0                               ; DW_CHILDREN_no
+	.byte	37                              ; DW_AT_producer
+	.byte	14                              ; DW_FORM_strp
+	.byte	19                              ; DW_AT_language
+	.byte	5                               ; DW_FORM_data2
+	.byte	3                               ; DW_AT_name
+	.byte	14                              ; DW_FORM_strp
+	.byte	16                              ; DW_AT_stmt_list
+	.byte	23                              ; DW_FORM_sec_offset
+	.byte	27                              ; DW_AT_comp_dir
+	.byte	14                              ; DW_FORM_strp
+	.byte	17                              ; DW_AT_low_pc
+	.byte	1                               ; DW_FORM_addr
+	.byte	18                              ; DW_AT_high_pc
+	.byte	6                               ; DW_FORM_data4
+	.byte	0                               ; EOM(1)
+	.byte	0                               ; EOM(2)
+	.byte	0                               ; EOM(3)
+	.section	.debug_info,"",@progbits
+.Lcu_begin0:
+	.long	.Ldebug_info_end0-.Ldebug_info_start0 ; Length of Unit
+.Ldebug_info_start0:
+	.short	4                               ; DWARF version number
+	.long	.debug_abbrev                   ; Offset Into Abbrev. Section
+	.byte	8                               ; Address Size (in bytes)
+	.byte	1                               ; Abbrev [1] 0xb:0x1f DW_TAG_compile_unit
+	.long	.Linfo_string0                  ; DW_AT_producer
+	.short	2                               ; DW_AT_language
+	.long	.Linfo_string1                  ; DW_AT_name
+	.long	.Lline_table_start0             ; DW_AT_stmt_list
+	.long	.Linfo_string2                  ; DW_AT_comp_dir
+	.quad	.Lfunc_begin0                   ; DW_AT_low_pc
+	.long	.Lfunc_end0-.Lfunc_begin0       ; DW_AT_high_pc
+.Ldebug_info_end0:
+	.section	.debug_str,"MS",@progbits,1
+.Linfo_string0:
+	.asciz	"triton"                        ; string offset=0
+.Linfo_string1:
+	.asciz	"triton_cdna4_matmul_source"    ; string offset=7
+.Linfo_string2:
+	.asciz	"tests/kernels"                 ; string offset=34
+	.section	".note.GNU-stack","",@progbits
+	.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .agpr_count:     16
+    .args:
+      - .address_space:  global
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+      - .address_space:  global
+        .offset:         8
+        .size:           8
+        .value_kind:     global_buffer
+      - .address_space:  global
+        .offset:         16
+        .size:           8
+        .value_kind:     global_buffer
+      - .offset:         24
+        .size:           4
+        .value_kind:     by_value
+      - .offset:         28
+        .size:           4
+        .value_kind:     by_value
+      - .offset:         32
+        .size:           4
+        .value_kind:     by_value
+      - .address_space:  global
+        .offset:         40
+        .size:           8
+        .value_kind:     global_buffer
+      - .address_space:  global
+        .offset:         48
+        .size:           8
+        .value_kind:     global_buffer
+    .group_segment_fixed_size: 0
+    .kernarg_segment_align: 8
+    .kernarg_segment_size: 56
+    .max_flat_workgroup_size: 256
+    .name:           triton_cdna4_matmul_kernel
+    .private_segment_fixed_size: 0
+    .sgpr_count:     44
+    .sgpr_spill_count: 0
+    .symbol:         triton_cdna4_matmul_kernel.kd
+    .uniform_work_group_size: 1
+    .uses_dynamic_stack: false
+    .vgpr_count:     112
+    .vgpr_spill_count: 0
+    .wavefront_size: 64
+amdhsa.target:   amdgcn-amd-amdhsa--gfx950
+amdhsa.version:
+  - 1
+  - 2
+...
+
+	.end_amdgpu_metadata
+	.section	.debug_line,"",@progbits
+.Lline_table_start0:


### PR DESCRIPTION
Wire the semantic translator to a new CDNA4->CDNA3 expansion table and teach the code object patcher to materialize GFX90A-style ACCUM_OFFSET updates when semantic scratch pushes the target AccVGPR base.

Instruction lowerings added:

- v_bitop3_b16 and v_bitop3_b32 into CDNA3 boolean instruction sequences.

- v_cvt_pk_f16_f32 into two v_cvt_f16_f32 conversions plus explicit halfword packing.

- v_permlane32_swap_b32 for the E32 and Hi1/Hi2/Hi3 VOP1 encodings using mbcnt/ds_bpermute lane exchange.

- v_mfma_f32_16x16x32_f16 and v_mfma_f32_32x32x16_f16 into paired CDNA3 narrow-K MFMAs, including ordinary VGPR and AccVGPR accumulator forms.

- ds_read_b64_tr_b16 into ds_read_b64 plus LDS lane/halfword permutation.

- buffer_load_dwordx3 lds and buffer_load_dwordx4 lds into scratch MUBUF loads followed by ds_write_b96/ds_write_b128.

Tests added:

- BinaryTranslatorE2E coverage that requires every CDNA4->CDNA3 expand rule to have a fixture, translates each single-instruction fixture, and checks the decoded CDNA3 code-cave sequence.

- Negative diagnostics for missing semantic rules, continue-after-failure collection, and matched-rule expansion failure.

- Device-kernel fixtures for dynamic_copy_loop and checked-in Triton gfx950 matmul/flash-attention assemblies.

- cdna4_to_cdna3_dispatch_test translation cases for dynamic_copy_loop, Triton dynamic matmul, buffer-async matmul, flash attention no-async, and flash attention buffer-async.

- CTest registration for the buffer-async translation smoke test, plus CDNA3-gated dispatch runs for dynamic_copy_loop, Triton dynamic matmul, buffer-async matmul, conservative-liveness buffer-async matmul, flash attention no-async, and flash attention buffer-async.
