### PR TITLE
[RCCL] Fix: Process-isolated test runner with code coverage support

### DIFF
--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -939,6 +939,11 @@ if(ENABLE_CODE_COVERAGE)
 
   target_link_options(rccl PRIVATE ${COVERAGE_SHARED_LINKER_FLAGS})
   target_link_options(rccl PRIVATE ${COVERAGE_EXE_LINKER_FLAGS})
+
+  # Expose explicit profile-flush wrappers so test harnesses that bypass
+  # atexit() handlers (e.g. ProcessIsolatedTestRunner using _exit()) can
+  # still flush librccl's private LLVM profile runtime instance.
+  target_sources(rccl PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/misc/coverage_flush.cc)
 elseif(BUILD_TESTS) # Enable default/hidden visibility based on build type and ROCM_VERSION
   if (ROCM_VERSION VERSION_GREATER_EQUAL "60400" AND CMAKE_BUILD_TYPE MATCHES "Debug")
     target_compile_options(rccl PRIVATE -fvisibility=default)

--- a/projects/rccl/src/misc/coverage_flush.cc
+++ b/projects/rccl/src/misc/coverage_flush.cc
@@ -1,0 +1,23 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Exported wrapper around the LLVM source-based coverage profile runtime,
+// compiled into librccl.so only when ENABLE_CODE_COVERAGE is on.
+//
+// librccl.so and the test binaries each statically link libclang_rt.profile.a,
+// giving each its own private profile runtime instance. The test binary cannot
+// reach librccl's __llvm_profile_write_file via dlsym because the runtime
+// symbols have hidden visibility. This default-visibility wrapper lets the
+// process-isolated test harness explicitly flush librccl's coverage before
+// calling _exit().
+
+extern "C" int __llvm_profile_write_file(void);
+
+extern "C" __attribute__((visibility("default")))
+int rcclCoverageWriteFile(void)
+{
+    return __llvm_profile_write_file();
+}

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -19,6 +19,9 @@ if(BUILD_TESTS)
   if (ENABLE_CODE_COVERAGE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-instr-generate -fcoverage-mapping")
     set(HIPCC_COMPILE_FLAGS "${HIPCC_COMPILE_FLAGS} -fprofile-instr-generate -fcoverage-mapping")
+    # Allow ProcessIsolatedTestRunner.cpp to call __llvm_profile_write_file()
+    # explicitly before _exit() so child-process coverage data is flushed.
+    add_compile_definitions(RCCL_TEST_CODE_COVERAGE=1)
   endif()
 
   find_package(hsa-runtime64 PATHS /opt/rocm )

--- a/projects/rccl/test/EnqueueCountTests.cpp
+++ b/projects/rccl/test/EnqueueCountTests.cpp
@@ -33,7 +33,7 @@ TEST_F(EnqueueCountTests, ncclFuncSendCount_AllTests)
                 size_t result = ncclFuncSendCount(ncclFuncAllReduce, nRanks, count);
                 EXPECT_EQ(result, count);
             }
-        ),
+        ).withNumGpus(0),
 
         ProcessIsolatedTestRunner::TestConfig(
             "ncclFuncSendCount_Broadcast",
@@ -44,7 +44,7 @@ TEST_F(EnqueueCountTests, ncclFuncSendCount_AllTests)
                 size_t result = ncclFuncSendCount(ncclFuncBroadcast, nRanks, count);
                 EXPECT_EQ(result, count);
             }
-        ),
+        ).withNumGpus(0),
 
         ProcessIsolatedTestRunner::TestConfig(
             "ncclFuncSendCount_Reduce",
@@ -55,7 +55,7 @@ TEST_F(EnqueueCountTests, ncclFuncSendCount_AllTests)
                 size_t result = ncclFuncSendCount(ncclFuncReduce, nRanks, count);
                 EXPECT_EQ(result, count);
             }
-        ),
+        ).withNumGpus(0),
 
         ProcessIsolatedTestRunner::TestConfig(
             "ncclFuncSendCount_AllGather",
@@ -66,7 +66,7 @@ TEST_F(EnqueueCountTests, ncclFuncSendCount_AllTests)
                 size_t result = ncclFuncSendCount(ncclFuncAllGather, nRanks, count);
                 EXPECT_EQ(result, count);
             }
-        ),
+        ).withNumGpus(0),
 
         ProcessIsolatedTestRunner::TestConfig(
             "ncclFuncSendCount_ReduceScatter",
@@ -77,7 +77,7 @@ TEST_F(EnqueueCountTests, ncclFuncSendCount_AllTests)
                 size_t result = ncclFuncSendCount(ncclFuncReduceScatter, nRanks, count);
                 EXPECT_EQ(result, count * nRanks);
             }
-        ),
+        ).withNumGpus(0),
 
         ProcessIsolatedTestRunner::TestConfig(
             "ncclFuncSendCount_ZeroCount",
@@ -86,7 +86,7 @@ TEST_F(EnqueueCountTests, ncclFuncSendCount_AllTests)
                 size_t result = ncclFuncSendCount(ncclFuncAllReduce, 4, 0);
                 EXPECT_EQ(result, 0);
             }
-        )
+        ).withNumGpus(0)
     );
 }
 
@@ -107,7 +107,7 @@ TEST_F(EnqueueCountTests, ncclFuncRecvCount_AllTests)
                 size_t result = ncclFuncRecvCount(ncclFuncAllReduce, nRanks, count);
                 EXPECT_EQ(result, count);
             }
-        ),
+        ).withNumGpus(0),
 
         ProcessIsolatedTestRunner::TestConfig(
             "ncclFuncRecvCount_Broadcast",
@@ -118,7 +118,7 @@ TEST_F(EnqueueCountTests, ncclFuncRecvCount_AllTests)
                 size_t result = ncclFuncRecvCount(ncclFuncBroadcast, nRanks, count);
                 EXPECT_EQ(result, count);
             }
-        ),
+        ).withNumGpus(0),
 
         ProcessIsolatedTestRunner::TestConfig(
             "ncclFuncRecvCount_Reduce",
@@ -129,7 +129,7 @@ TEST_F(EnqueueCountTests, ncclFuncRecvCount_AllTests)
                 size_t result = ncclFuncRecvCount(ncclFuncReduce, nRanks, count);
                 EXPECT_EQ(result, count);
             }
-        ),
+        ).withNumGpus(0),
 
         ProcessIsolatedTestRunner::TestConfig(
             "ncclFuncRecvCount_AllGather",
@@ -140,7 +140,7 @@ TEST_F(EnqueueCountTests, ncclFuncRecvCount_AllTests)
                 size_t result = ncclFuncRecvCount(ncclFuncAllGather, nRanks, count);
                 EXPECT_EQ(result, count * nRanks);
             }
-        ),
+        ).withNumGpus(0),
 
         ProcessIsolatedTestRunner::TestConfig(
             "ncclFuncRecvCount_ReduceScatter",
@@ -151,7 +151,7 @@ TEST_F(EnqueueCountTests, ncclFuncRecvCount_AllTests)
                 size_t result = ncclFuncRecvCount(ncclFuncReduceScatter, nRanks, count);
                 EXPECT_EQ(result, count);
             }
-        ),
+        ).withNumGpus(0),
 
         ProcessIsolatedTestRunner::TestConfig(
             "ncclFuncRecvCount_ZeroCount",
@@ -160,7 +160,7 @@ TEST_F(EnqueueCountTests, ncclFuncRecvCount_AllTests)
                 size_t result = ncclFuncRecvCount(ncclFuncAllReduce, 4, 0);
                 EXPECT_EQ(result, 0);
             }
-        )
+        ).withNumGpus(0)
     );
 }
 
@@ -181,7 +181,7 @@ TEST_F(EnqueueCountTests, ncclFuncMaxSendRecvCount_AllTests)
                 size_t result = ncclFuncMaxSendRecvCount(ncclFuncAllReduce, nRanks, count);
                 EXPECT_EQ(result, count);
             }
-        ),
+        ).withNumGpus(0),
 
         ProcessIsolatedTestRunner::TestConfig(
             "ncclFuncMaxSendRecvCount_AllGather",
@@ -192,7 +192,7 @@ TEST_F(EnqueueCountTests, ncclFuncMaxSendRecvCount_AllTests)
                 size_t result = ncclFuncMaxSendRecvCount(ncclFuncAllGather, nRanks, count);
                 EXPECT_EQ(result, count * nRanks);
             }
-        ),
+        ).withNumGpus(0),
 
         ProcessIsolatedTestRunner::TestConfig(
             "ncclFuncMaxSendRecvCount_ReduceScatter",
@@ -203,7 +203,7 @@ TEST_F(EnqueueCountTests, ncclFuncMaxSendRecvCount_AllTests)
                 size_t result = ncclFuncMaxSendRecvCount(ncclFuncReduceScatter, nRanks, count);
                 EXPECT_EQ(result, count * nRanks);
             }
-        ),
+        ).withNumGpus(0),
 
         ProcessIsolatedTestRunner::TestConfig(
             "ncclFuncMaxSendRecvCount_ZeroCount",
@@ -212,7 +212,7 @@ TEST_F(EnqueueCountTests, ncclFuncMaxSendRecvCount_AllTests)
                 size_t result = ncclFuncMaxSendRecvCount(ncclFuncAllReduce, 4, 0);
                 EXPECT_EQ(result, 0);
             }
-        )
+        ).withNumGpus(0)
     );
 }
 
@@ -234,7 +234,7 @@ TEST_F(EnqueueCountTests, ncclFuncCounts_EdgeCases)
                 EXPECT_EQ(ncclFuncRecvCount(ncclFuncAllReduce, nRanks, count), count);
                 EXPECT_EQ(ncclFuncMaxSendRecvCount(ncclFuncAllReduce, nRanks, count), count);
             }
-        ),
+        ).withNumGpus(0),
 
         ProcessIsolatedTestRunner::TestConfig(
             "ncclFuncCounts_LargeRankCount",
@@ -249,7 +249,7 @@ TEST_F(EnqueueCountTests, ncclFuncCounts_EdgeCases)
                     count * nRanks
                 );
             }
-        )
+        ).withNumGpus(0)
     );
 }
 

--- a/projects/rccl/test/NetSocketTests.cpp
+++ b/projects/rccl/test/NetSocketTests.cpp
@@ -893,6 +893,7 @@ TEST_F(NetSocketTests, TestConcurrentOperationsTaskCreation) {
                           {"NCCL_NSOCKS_PERTHREAD", "2"},
                           {"NCCL_DEBUG", "TRACE"},
                           {"NCCL_DEBUG_SUBSYS", "ALL"}})
+        .withNumGpus(0)
   );
 }
 
@@ -1219,6 +1220,7 @@ TEST_F(NetSocketTests, TestExcessiveThreadConfig) {
                           {"NCCL_NSOCKS_PERTHREAD", "1"},
                           {"NCCL_DEBUG", "TRACE"},
                           {"NCCL_DEBUG_SUBSYS", "ALL"}})
+        .withNumGpus(0)
   );
 }
 
@@ -1338,6 +1340,7 @@ TEST_F(NetSocketTests, TestExcessiveSocketConfig) {
                           {"NCCL_NSOCKS_PERTHREAD", "10"},
                           {"NCCL_DEBUG", "TRACE"},
                           {"NCCL_DEBUG_SUBSYS", "ALL"}})
+        .withNumGpus(0)
   );
 }
 

--- a/projects/rccl/test/RcclWrapTests.cpp
+++ b/projects/rccl/test/RcclWrapTests.cpp
@@ -1181,6 +1181,7 @@ TEST(Rcclwrap, AllrcclSetP2pNetChunkSizeTests)
                     }()
                 )
                 .withTimeout(std::chrono::seconds(60))
+                .withNumGpus(0)
         );
     }
 
@@ -1294,6 +1295,7 @@ TEST(Rcclwrap, AllPxnTests)
                         return env;
                     }()
                 )
+                .withNumGpus(0)
         );
     }
 
@@ -1440,6 +1442,7 @@ TEST(Rcclwrap, RcclUseAllGatherDirectNodeCountTests)
                     }()
                 )
                 .withTimeout(std::chrono::seconds(60))
+                .withNumGpus(0)
         );
     }
 

--- a/projects/rccl/test/common/EnvVars.cpp
+++ b/projects/rccl/test/common/EnvVars.cpp
@@ -6,6 +6,7 @@
 
 #include "EnvVars.hpp"
 #include "CollectiveArgs.hpp"
+#include "ProcessIsolatedTestRunner.hpp"
 #include <cstdlib>
 #include <unistd.h>
 #include <sys/wait.h>
@@ -208,7 +209,7 @@ namespace RcclUnitTesting
   {
     // Skip fork+HIP calls in re-exec'd children: GPU enumeration is irrelevant
     // there and concurrent hipGetDeviceCount forks cause KFD contention.
-    const bool isIsolatedChild = (std::getenv("RCCL_PIT_REEXEC_TEST") != nullptr);
+    const bool isIsolatedChild = (std::getenv(ProcessIsolatedTestRunner::kReexecMarkerEnvVar) != nullptr);
 
     // Collect number of GPUs available
     // NOTE: Cannot use HIP call prior to launching unless it is inside another child process

--- a/projects/rccl/test/common/EnvVars.cpp
+++ b/projects/rccl/test/common/EnvVars.cpp
@@ -206,19 +206,23 @@ namespace RcclUnitTesting
 
   EnvVars::EnvVars()
   {
+    // Skip fork+HIP calls in re-exec'd children: GPU enumeration is irrelevant
+    // there and concurrent hipGetDeviceCount forks cause KFD contention.
+    const bool isIsolatedChild = (std::getenv("RCCL_PIT_REEXEC_TEST") != nullptr);
+
     // Collect number of GPUs available
     // NOTE: Cannot use HIP call prior to launching unless it is inside another child process
     numDetectedGpus = 0;
-    getDeviceCount(&numDetectedGpus);
+    if(!isIsolatedChild) getDeviceCount(&numDetectedGpus);
     numDetectedGpus = min(numDetectedGpus, 16);
     isGfx94 = false;
-    getArchInfo(&isGfx94, "gfx94");
+    if(!isIsolatedChild) getArchInfo(&isGfx94, "gfx94");
     isGfx95 = false;
-    getArchInfo(&isGfx95, "gfx95");
+    if(!isIsolatedChild) getArchInfo(&isGfx95, "gfx95");
     isGfx12 = false;
-    getArchInfo(&isGfx12, "gfx12");
+    if(!isIsolatedChild) getArchInfo(&isGfx12, "gfx12");
     isGfx90 = false;
-    getArchInfo(&isGfx90, "gfx90");
+    if(!isIsolatedChild) getArchInfo(&isGfx90, "gfx90");
 
     debugPause     = GetEnvVar("UT_DEBUG_PAUSE" , 0);
     showNames      = GetEnvVar("UT_SHOW_NAMES"  , 1);
@@ -241,7 +245,7 @@ namespace RcclUnitTesting
       gpuPriorityOrder[i] = i;
     }
     bool isCpxMode = false;
-    if(isGfx94) {
+    if(isGfx94 && !isIsolatedChild) {
       getDeviceMode(&isCpxMode);
       if(isCpxMode) {
         getDevicePriority(&gpuPriorityOrder);

--- a/projects/rccl/test/common/ProcessIsolatedTestFramework.md
+++ b/projects/rccl/test/common/ProcessIsolatedTestFramework.md
@@ -274,7 +274,7 @@ By default, tests run one at a time (`maxParallelJobs = 1`). Setting `maxParalle
 ```cpp
 ProcessIsolatedTestRunner::ExecutionOptions opts;
 opts.maxParallelJobs = 4;   // up to 4 tests run at the same time
-                            // 0 = GPU pool size (or hardware_concurrency() if no pool)
+                            // kAutoParallelism = GPU pool size (or hardware_concurrency() if no pool)
                             // 1 = sequential (default)
 
 RUN_ISOLATED_TESTS_WITH_OPTIONS(opts,
@@ -482,7 +482,7 @@ static bool executeAllTests(
 **Execution mode** is controlled by `ExecutionOptions::maxParallelJobs`:
 - `1` (default) — sequential, one test at a time
 - `N > 1` — up to N tests run simultaneously with GPU-aware scheduling
-- `0` — parallelism = GPU pool size, or `std::thread::hardware_concurrency()` when no GPU pool is available
+- `ExecutionOptions::kAutoParallelism` (`0`) — parallelism = GPU pool size, or `std::thread::hardware_concurrency()` when no GPU pool is available
 
 **Note:** This method automatically clears all test registrations and results after execution, ensuring a clean state for the next test suite. Users do not need to call `clear()` manually.
 
@@ -550,7 +550,7 @@ TEST(MyTest, VerifyExecution) {
 |---|---|---|---|
 | `stopOnFirstFailure` | `bool` | `false` | Stop launching new tests after the first failure (in-flight tests finish) |
 | `verboseLogging` | `bool` | `true` | Print per-test status lines |
-| `maxParallelJobs` | `size_t` | `1` | Max concurrent child processes. `0` = GPU pool size (or `hardware_concurrency` if no pool), `1` = sequential |
+| `maxParallelJobs` | `size_t` | `1` | Max concurrent child processes. `kAutoParallelism` (`0`) = GPU pool size (or `hardware_concurrency` if no pool), `1` = sequential |
 | `gpuPool` | `vector<int>` | `{}` | Physical GPU indices to distribute. Empty = auto-detect |
 
 ### TestConfig Methods

--- a/projects/rccl/test/common/ProcessIsolatedTestFramework.md
+++ b/projects/rccl/test/common/ProcessIsolatedTestFramework.md
@@ -371,6 +371,10 @@ GPU slot management is skipped (no `HIP_VISIBLE_DEVICES` override) in two cases:
 
 In both cases tests see the full device list as usual.
 
+#### Interaction with `withEnvironment({{"HIP_VISIBLE_DEVICES", ...}})`
+
+In parallel mode, the runner injects `HIP_VISIBLE_DEVICES` **after** applying the test's own environment variables. Any `HIP_VISIBLE_DEVICES` set via `withEnvironment()` or `setVariable()` is overridden by the slot manager's assignment; a warning is logged to stderr when this happens. Use `withNumGpus(N)` to declare device requirements rather than hard-coding device indices.
+
 ---
 
 ## API Reference
@@ -441,7 +445,9 @@ RUN_ISOLATED_TESTS_WITH_OPTIONS(opts,
 ### Main Methods (For Manual Use)
 
 #### `registerTest()`
-Register a test for later execution.
+Register a test for later execution. Registration fails with a diagnostic if:
+- The name contains a null byte (would be silently truncated by `setenv`/`getenv`).
+- The name is a duplicate of an already-registered test (the re-exec child matches on the first occurrence, so the second would never run).
 
 ```cpp
 // Variant 1: Full configuration
@@ -1158,7 +1164,7 @@ EXPECT_EQ(results.size(), expectedTestCount)
 
 ### Why `fork()+execv()` instead of plain `fork()`
 
-Plain `fork()` after HIP has been initialized is unsafe — the GPU runtime state (device contexts, memory handles, threads) is copied into the child but is not valid there. `execv()` replaces the child's entire address space with a fresh binary image, so the child starts with no inherited runtime state. This also ensures the LLVM profile runtime initializes with the correct child PID, so `%p` in `LLVM_PROFILE_FILE` expands properly without any manual filename fixup.
+Plain `fork()` after HIP has been initialized is unsafe — the GPU runtime state (device contexts, memory handles, threads) is copied into the child but is not valid there. `execv()` replaces the child's entire address space with a fresh binary image, so the child starts with no inherited runtime state. This also ensures the LLVM profile runtime initializes with the correct child PID. Before `execv()` the fork child sets `LLVM_PROFILE_FILE=rccl_tests_%p_%m.profraw` (with `overwrite=0`) so each re-exec'd process writes a unique file. A `LLVM_PROFILE_FILE` already in the environment — from CI or via `withEnvironment()` — takes precedence.
 
 ### Exit Codes
 

--- a/projects/rccl/test/common/ProcessIsolatedTestFramework.md
+++ b/projects/rccl/test/common/ProcessIsolatedTestFramework.md
@@ -274,7 +274,7 @@ By default, tests run one at a time (`maxParallelJobs = 1`). Setting `maxParalle
 ```cpp
 ProcessIsolatedTestRunner::ExecutionOptions opts;
 opts.maxParallelJobs = 4;   // up to 4 tests run at the same time
-                            // 0 = std::thread::hardware_concurrency()
+                            // 0 = GPU pool size (or hardware_concurrency() if no pool)
                             // 1 = sequential (default)
 
 RUN_ISOLATED_TESTS_WITH_OPTIONS(opts,
@@ -291,15 +291,16 @@ RUN_ISOLATED_TESTS_WITH_OPTIONS(opts,
 
 ### GPU-aware scheduling
 
-When tests run in parallel, multiple child processes would otherwise all try to use the same GPU (e.g., device 0), conflicting with each other. The runner solves this by maintaining a **GPU slot pool** and assigning each child process a non-overlapping subset of physical device indices, injected as `HIP_VISIBLE_DEVICES` and `ROCR_VISIBLE_DEVICES` before `execv()`.
+When tests run in parallel, multiple child processes would otherwise all try to use the same GPU (e.g., device 0), conflicting with each other. The runner solves this by maintaining a **GPU slot pool** and assigning each child process a non-overlapping subset of physical device indices, injected as `HIP_VISIBLE_DEVICES` before `execv()`.
 
 #### How the pool is built
 
 `ExecutionOptions::gpuPool` holds the physical device indices to distribute. If left empty (the default), the runner auto-detects the pool in this priority order:
 
 1. Parse `HIP_VISIBLE_DEVICES` from the environment (comma-separated indices)
-2. Parse `ROCR_VISIBLE_DEVICES` from the environment
-3. Count `/dev/dri/renderD*` nodes → pool `[0, 1, ..., N-1]`
+2. Count GPU nodes in `/sys/class/kfd/kfd/topology/nodes` with a non-zero `gpu_id` → pool `[0, 1, ..., N-1]`
+
+If neither source yields a non-empty pool, `executeAllTests()` records a non-fatal GTest failure and returns `false` immediately.
 
 ```cpp
 // Override auto-detection to use only GPUs 0 and 1:
@@ -317,7 +318,7 @@ Each `TestConfig` declares how many GPU slots it needs via `withNumGpus()`:
 | `N` | exactly N GPU slots |
 | `N > pool size` | clamped to the full pool — test runs exclusively (all slots held) to prevent contention with restricted siblings |
 
-Before launching each child, the runner atomically waits until **both** a concurrency slot (`active < maxParallelJobs`) **and** enough free GPU slots are available. The assigned indices are written into `HIP_VISIBLE_DEVICES`/`ROCR_VISIBLE_DEVICES` inside the fork child so the re-exec'd process sees only its GPUs. When the child exits the slots are released and the next waiting test can proceed.
+Before launching each child, the runner atomically waits until **both** a concurrency slot (`active < maxParallelJobs`) **and** enough free GPU slots are available. The assigned indices are written into `HIP_VISIBLE_DEVICES` inside the fork child so the re-exec'd process sees only its GPUs. When the child exits the slots are released and the next waiting test can proceed.
 
 #### Example: parallel tests with per-test GPU declaration
 
@@ -481,7 +482,7 @@ static bool executeAllTests(
 **Execution mode** is controlled by `ExecutionOptions::maxParallelJobs`:
 - `1` (default) — sequential, one test at a time
 - `N > 1` — up to N tests run simultaneously with GPU-aware scheduling
-- `0` — parallelism = `std::thread::hardware_concurrency()`
+- `0` — parallelism = GPU pool size, or `std::thread::hardware_concurrency()` when no GPU pool is available
 
 **Note:** This method automatically clears all test registrations and results after execution, ensuring a clean state for the next test suite. Users do not need to call `clear()` manually.
 
@@ -549,7 +550,7 @@ TEST(MyTest, VerifyExecution) {
 |---|---|---|---|
 | `stopOnFirstFailure` | `bool` | `false` | Stop launching new tests after the first failure (in-flight tests finish) |
 | `verboseLogging` | `bool` | `true` | Print per-test status lines |
-| `maxParallelJobs` | `size_t` | `1` | Max concurrent child processes. `0` = `hardware_concurrency`, `1` = sequential |
+| `maxParallelJobs` | `size_t` | `1` | Max concurrent child processes. `0` = GPU pool size (or `hardware_concurrency` if no pool), `1` = sequential |
 | `gpuPool` | `vector<int>` | `{}` | Physical GPU indices to distribute. Empty = auto-detect |
 
 ### TestConfig Methods
@@ -596,7 +597,7 @@ TestConfig& withNumGpus(size_t n);
 | `N` | exactly N GPU slots — test blocks until N slots are free |
 | `0` | entire pool — test runs exclusively (no other test runs concurrently) |
 
-The runner injects `HIP_VISIBLE_DEVICES` / `ROCR_VISIBLE_DEVICES` into the child process with the assigned device indices. Has no effect in sequential mode (`maxParallelJobs = 1`).
+The runner injects `HIP_VISIBLE_DEVICES` into the child process with the assigned device indices. Has no effect in sequential mode (`maxParallelJobs = 1`).
 
 ```cpp
 ProcessIsolatedTestRunner::TestConfig("MultiGpuTest", []() {
@@ -1143,11 +1144,11 @@ EXPECT_EQ(results.size(), expectedTestCount)
    - Each test gets a `TestConfig` with name, logic, and environment
 
 2. **Execution Phase (exec-only isolation):**
-   - Parent detects the GPU pool (once, before the loop)
+   - Parent detects the GPU pool once (from `HIP_VISIBLE_DEVICES` or KFD sysfs); fails with a non-fatal GTest error and returns `false` if the pool is empty
    - For each test the parent:
      1. Acquires a concurrency slot (`active < maxParallelJobs`) and GPU slots (`numGpus` free indices) — atomically under one condition variable
      2. `fork()` creates a child
-     3. Inside the fork child: environment variables are applied, then `HIP_VISIBLE_DEVICES` / `ROCR_VISIBLE_DEVICES` is set to the assigned GPU indices, then `execv("/proc/self/exe")` re-executes the binary with `--gtest_filter` pointing at the parent test and a sentinel env var naming the specific isolated test to run
+     3. Inside the fork child: environment variables are applied, then `HIP_VISIBLE_DEVICES` is set to the assigned GPU indices, then `execv("/proc/self/exe")` re-executes the binary with `--gtest_filter` pointing at the parent test and a sentinel env var naming the specific isolated test to run
      4. The re-exec'd process finds the sentinel, runs the matching lambda, flushes coverage, and calls `_exit()`
      5. Parent thread drains stdout/stderr pipes and calls `waitpid()` for its child
      6. Concurrency and GPU slots are released; the next waiting test can start
@@ -1165,6 +1166,8 @@ EXPECT_EQ(results.size(), expectedTestCount)
 ### Why `fork()+execv()` instead of plain `fork()`
 
 Plain `fork()` after HIP has been initialized is unsafe — the GPU runtime state (device contexts, memory handles, threads) is copied into the child but is not valid there. `execv()` replaces the child's entire address space with a fresh binary image, so the child starts with no inherited runtime state. This also ensures the LLVM profile runtime initializes with the correct child PID. Before `execv()` the fork child sets `LLVM_PROFILE_FILE=rccl_tests_%p_%m.profraw` (with `overwrite=0`) so each re-exec'd process writes a unique file. A `LLVM_PROFILE_FILE` already in the environment — from CI or via `withEnvironment()` — takes precedence.
+
+The re-exec'd child skips GPU enumeration calls in `EnvVars` (e.g., `hipGetDeviceCount`, `getArchInfo`) because they are irrelevant there and concurrent `hipGetDeviceCount` forks cause KFD file-descriptor contention.
 
 ### Exit Codes
 

--- a/projects/rccl/test/common/ProcessIsolatedTestFramework.md
+++ b/projects/rccl/test/common/ProcessIsolatedTestFramework.md
@@ -313,10 +313,10 @@ Each `TestConfig` declares how many GPU slots it needs via `withNumGpus()`:
 
 | `numGpus` value | Meaning |
 |---|---|
-| `0` | no GPU slot needed — CPU-only test, runs freely without `HIP_VISIBLE_DEVICES` restriction |
-| `1` (default) | one dedicated GPU slot |
-| `N` | exactly N GPU slots |
-| `N > pool size` | clamped to the full pool — test runs exclusively (all slots held) to prevent contention with restricted siblings |
+| `0` (default) | CPU-only test — no GPU slot acquired, runs freely without `HIP_VISIBLE_DEVICES` restriction |
+| `1` | one dedicated GPU from the pool |
+| `N` | exactly N GPU slots — test blocks until N slots are free |
+| `N > pool size` | clamped to the full pool — test runs exclusively (all slots held) to prevent contention with siblings |
 
 Before launching each child, the runner atomically waits until **both** a concurrency slot (`active < maxParallelJobs`) **and** enough free GPU slots are available. The assigned indices are written into `HIP_VISIBLE_DEVICES` inside the fork child so the re-exec'd process sees only its GPUs. When the child exits the slots are released and the next waiting test can proceed.
 
@@ -346,10 +346,11 @@ RUN_ISOLATED_TESTS_WITH_OPTIONS(opts,
         /* ... */
     }).withNumGpus(2),
 
-    // This test requires exclusive access to all GPUs
+    // This test requires all 4 GPUs — blocks until every slot is free,
+    // so no other GPU test can run concurrently (exclusive execution).
     ProcessIsolatedTestRunner::TestConfig("ExclusiveTest", []() {
         /* ... */
-    }).withNumGpus(0)   // 0 = consume entire pool
+    }).withNumGpus(4)   // request entire 4-GPU pool → runs exclusively
 );
 ```
 
@@ -593,9 +594,10 @@ TestConfig& withNumGpus(size_t n);
 
 | Value | Meaning |
 |---|---|
-| `1` (default) | one GPU slot |
+| `0` (default) | CPU-only — no GPU slot acquired; `HIP_VISIBLE_DEVICES` is not overridden |
+| `1` | one dedicated GPU from the pool |
 | `N` | exactly N GPU slots — test blocks until N slots are free |
-| `0` | entire pool — test runs exclusively (no other test runs concurrently) |
+| `N > pool size` | clamped to pool size — test runs exclusively (holds all slots) |
 
 The runner injects `HIP_VISIBLE_DEVICES` into the child process with the assigned device indices. Has no effect in sequential mode (`maxParallelJobs = 1`).
 

--- a/projects/rccl/test/common/ProcessIsolatedTestFramework.md
+++ b/projects/rccl/test/common/ProcessIsolatedTestFramework.md
@@ -7,6 +7,7 @@ A lightweight C++ testing framework for running Google Test cases in isolated pr
 - [Why Use Process Isolation?](#why-use-process-isolation)
 - [Quick Start](#quick-start)
 - [Core Concepts](#core-concepts)
+- [Parallel Execution](#parallel-execution)
 - [API Reference](#api-reference)
 - [Examples](#examples)
 - [Best Practices](#best-practices)
@@ -16,15 +17,16 @@ A lightweight C++ testing framework for running Google Test cases in isolated pr
 
 ## Overview
 
-`ProcessIsolatedTestRunner` is a framework that executes tests in separate processes using `fork()`. This ensures complete isolation between tests, particularly useful when testing code with static variables or environment-dependent behavior.
+`ProcessIsolatedTestRunner` is a framework that executes tests in separate processes using `fork()+execv()`. This ensures complete isolation between tests, particularly useful when testing code with static variables, one-time initialization, or environment-dependent behavior.
 
 **Key Features:**
-- ✅ Process-based test isolation (each test runs in its own process)
+- ✅ Process-based test isolation via `fork()+execv()` (each test re-execs the binary fresh)
 - ✅ Per-test environment variable management
 - ✅ Configurable timeouts
-- ✅ Sequential or stop-on-failure execution
+- ✅ Sequential or parallel execution with bounded concurrency
+- ✅ GPU-aware parallel scheduling (non-overlapping GPU assignment across concurrent tests)
 - ✅ Thread-safe test registration
-- ✅ Detailed test result reporting
+- ✅ Detailed test result reporting in registration order
 
 **Location:** `test/common/ProcessIsolatedTestRunner.hpp`
 
@@ -263,6 +265,114 @@ struct TestResult {
 
 ---
 
+## Parallel Execution
+
+By default, tests run one at a time (`maxParallelJobs = 1`). Setting `maxParallelJobs > 1` launches up to that many child processes simultaneously, reducing total wall-clock time for large test suites.
+
+### Concurrency control
+
+```cpp
+ProcessIsolatedTestRunner::ExecutionOptions opts;
+opts.maxParallelJobs = 4;   // up to 4 tests run at the same time
+                            // 0 = std::thread::hardware_concurrency()
+                            // 1 = sequential (default)
+
+RUN_ISOLATED_TESTS_WITH_OPTIONS(opts,
+    ProcessIsolatedTestRunner::TestConfig("Test1", []() { ... }),
+    ProcessIsolatedTestRunner::TestConfig("Test2", []() { ... }),
+    ProcessIsolatedTestRunner::TestConfig("Test3", []() { ... }),
+    ProcessIsolatedTestRunner::TestConfig("Test4", []() { ... })
+);
+```
+
+**Output ordering:** Results are always printed and reported in registration order, regardless of which child process finishes first.
+
+**`stopOnFirstFailure`:** When set, the runner stops *launching* new tests once a failure is detected. Tests that are already running are allowed to finish normally — they are not killed early.
+
+### GPU-aware scheduling
+
+When tests run in parallel, multiple child processes would otherwise all try to use the same GPU (e.g., device 0), conflicting with each other. The runner solves this by maintaining a **GPU slot pool** and assigning each child process a non-overlapping subset of physical device indices, injected as `HIP_VISIBLE_DEVICES` and `ROCR_VISIBLE_DEVICES` before `execv()`.
+
+#### How the pool is built
+
+`ExecutionOptions::gpuPool` holds the physical device indices to distribute. If left empty (the default), the runner auto-detects the pool in this priority order:
+
+1. Parse `HIP_VISIBLE_DEVICES` from the environment (comma-separated indices)
+2. Parse `ROCR_VISIBLE_DEVICES` from the environment
+3. Count `/dev/dri/renderD*` nodes → pool `[0, 1, ..., N-1]`
+
+```cpp
+// Override auto-detection to use only GPUs 0 and 1:
+opts.gpuPool = {0, 1};
+```
+
+#### How slots are assigned
+
+Each `TestConfig` declares how many GPU slots it needs via `withNumGpus()`:
+
+| `numGpus` value | Meaning |
+|---|---|
+| `0` | no GPU slot needed — CPU-only test, runs freely without `HIP_VISIBLE_DEVICES` restriction |
+| `1` (default) | one dedicated GPU slot |
+| `N` | exactly N GPU slots |
+| `N > pool size` | clamped to the full pool — test runs exclusively (all slots held) to prevent contention with restricted siblings |
+
+Before launching each child, the runner atomically waits until **both** a concurrency slot (`active < maxParallelJobs`) **and** enough free GPU slots are available. The assigned indices are written into `HIP_VISIBLE_DEVICES`/`ROCR_VISIBLE_DEVICES` inside the fork child so the re-exec'd process sees only its GPUs. When the child exits the slots are released and the next waiting test can proceed.
+
+#### Example: parallel tests with per-test GPU declaration
+
+```cpp
+ProcessIsolatedTestRunner::ExecutionOptions opts;
+opts.maxParallelJobs = 4;
+// gpuPool auto-detected (e.g. [0,1,2,3] on a 4-GPU node)
+
+RUN_ISOLATED_TESTS_WITH_OPTIONS(opts,
+    // Each of these gets one GPU; up to 4 run simultaneously
+    ProcessIsolatedTestRunner::TestConfig("SingleGpuTest_A", []() {
+        // HIP_VISIBLE_DEVICES is set to e.g. "0" — test sees only that GPU
+        HIPCALL(hipSetDevice(0));  // device 0 here = whichever physical GPU was assigned
+        /* ... */
+    }),
+    ProcessIsolatedTestRunner::TestConfig("SingleGpuTest_B", []() {
+        HIPCALL(hipSetDevice(0));
+        /* ... */
+    }),
+
+    // This test needs 2 GPUs — it blocks until 2 slots are free
+    ProcessIsolatedTestRunner::TestConfig("TwoGpuTest", []() {
+        // HIP_VISIBLE_DEVICES = e.g. "2,3"
+        // hipGetDeviceCount() returns 2; hipSetDevice(0/1) map to physical 2/3
+        /* ... */
+    }).withNumGpus(2),
+
+    // This test requires exclusive access to all GPUs
+    ProcessIsolatedTestRunner::TestConfig("ExclusiveTest", []() {
+        /* ... */
+    }).withNumGpus(0)   // 0 = consume entire pool
+);
+```
+
+#### What the child process sees
+
+Inside the re-exec'd child, `HIP_VISIBLE_DEVICES` is set to the assigned indices (e.g. `"2,3"`). HIP then remaps those to logical device IDs 0 and 1. So a test that calls `hipSetDevice(0)` always gets the first device from its assigned subset — it never touches a GPU that belongs to another concurrent test.
+
+```
+System GPUs:  [0]  [1]  [2]  [3]
+              └─ Test A ─┘  └─ Test B ─┘   ← running simultaneously
+  HIP_VISIBLE_DEVICES="0,1"  "2,3"
+  hipSetDevice(0) → phys 0   hipSetDevice(0) → phys 2
+```
+
+#### When GPU slot management is disabled
+
+GPU slot management is skipped (no `HIP_VISIBLE_DEVICES` override) in two cases:
+- **Sequential mode** (`maxParallelJobs = 1`): no concurrent tests, no conflict possible.
+- **No GPUs detected**: auto-detection found zero devices.
+
+In both cases tests see the full device list as usual.
+
+---
+
 ## API Reference
 
 ### Macros (Recommended)
@@ -352,7 +462,7 @@ static void registerTest(
 ```
 
 #### `executeAllTests()`
-Execute all registered tests sequentially.
+Execute all registered tests.
 
 ```cpp
 static bool executeAllTests(
@@ -361,6 +471,11 @@ static bool executeAllTests(
 ```
 
 **Returns:** `true` if all tests passed, `false` if any failed.
+
+**Execution mode** is controlled by `ExecutionOptions::maxParallelJobs`:
+- `1` (default) — sequential, one test at a time
+- `N > 1` — up to N tests run simultaneously with GPU-aware scheduling
+- `0` — parallelism = `std::thread::hardware_concurrency()`
 
 **Note:** This method automatically clears all test registrations and results after execution, ensuring a clean state for the next test suite. Users do not need to call `clear()` manually.
 
@@ -422,6 +537,15 @@ TEST(MyTest, VerifyExecution) {
 }
 ```
 
+### ExecutionOptions Fields
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `stopOnFirstFailure` | `bool` | `false` | Stop launching new tests after the first failure (in-flight tests finish) |
+| `verboseLogging` | `bool` | `true` | Print per-test status lines |
+| `maxParallelJobs` | `size_t` | `1` | Max concurrent child processes. `0` = `hardware_concurrency`, `1` = sequential |
+| `gpuPool` | `vector<int>` | `{}` | Physical GPU indices to distribute. Empty = auto-detect |
+
 ### TestConfig Methods
 
 #### `withEnvironment()`
@@ -452,6 +576,30 @@ TestConfig& withCleanEnvironment(bool inherit = true);
 ```
 
 **Default:** `true` (inherits parent environment)
+
+#### `withNumGpus()`
+Declare how many GPU slots this test needs during parallel execution.
+
+```cpp
+TestConfig& withNumGpus(size_t n);
+```
+
+| Value | Meaning |
+|---|---|
+| `1` (default) | one GPU slot |
+| `N` | exactly N GPU slots — test blocks until N slots are free |
+| `0` | entire pool — test runs exclusively (no other test runs concurrently) |
+
+The runner injects `HIP_VISIBLE_DEVICES` / `ROCR_VISIBLE_DEVICES` into the child process with the assigned device indices. Has no effect in sequential mode (`maxParallelJobs = 1`).
+
+```cpp
+ProcessIsolatedTestRunner::TestConfig("MultiGpuTest", []() {
+    // Sees exactly 2 GPUs via HIP_VISIBLE_DEVICES
+    int count;
+    hipGetDeviceCount(&count);
+    EXPECT_EQ(count, 2);
+}).withNumGpus(2)
+```
 
 ---
 
@@ -836,7 +984,8 @@ When using process isolation, avoid initializing GPU resources in test fixture `
 class GPUTests : public ::testing::Test {
 protected:
   void SetUp() override {
-    hipMalloc(&gpuBuffer, 1024);  // Parent process - will pollute fork()!
+    hipMalloc(&gpuBuffer, 1024);  // Parent process — unsafe; HIP state
+                                  // must not be inherited across fork()+execv()
   }
   void* gpuBuffer;
 };
@@ -987,23 +1136,29 @@ EXPECT_EQ(results.size(), expectedTestCount)
    - Tests are registered into a static vector
    - Each test gets a `TestConfig` with name, logic, and environment
 
-2. **Execution Phase:**
-   - Parent process iterates through registered tests
-   - For each test:
-     - `fork()` creates a child process
-     - Child applies environment variables
-     - Child executes test logic
-     - Parent waits for child to complete
-     - Result is collected and stored
+2. **Execution Phase (exec-only isolation):**
+   - Parent detects the GPU pool (once, before the loop)
+   - For each test the parent:
+     1. Acquires a concurrency slot (`active < maxParallelJobs`) and GPU slots (`numGpus` free indices) — atomically under one condition variable
+     2. `fork()` creates a child
+     3. Inside the fork child: environment variables are applied, then `HIP_VISIBLE_DEVICES` / `ROCR_VISIBLE_DEVICES` is set to the assigned GPU indices, then `execv("/proc/self/exe")` re-executes the binary with `--gtest_filter` pointing at the parent test and a sentinel env var naming the specific isolated test to run
+     4. The re-exec'd process finds the sentinel, runs the matching lambda, flushes coverage, and calls `_exit()`
+     5. Parent thread drains stdout/stderr pipes and calls `waitpid()` for its child
+     6. Concurrency and GPU slots are released; the next waiting test can start
+   - In parallel mode, each test runs in a background `std::async` thread; the parent maintains a bounded sliding window of `maxParallelJobs` active tasks
 
 3. **Result Collection:**
    - Exit codes are captured from child processes
    - Timing information is recorded
-   - All results stored in static vector
+   - All results are stored and reported in registration order
 
 4. **Automatic Cleanup:**
    - After execution completes, `executeAllTests()` automatically clears all test registrations and results
    - This ensures a clean state for the next test suite without manual intervention
+
+### Why `fork()+execv()` instead of plain `fork()`
+
+Plain `fork()` after HIP has been initialized is unsafe — the GPU runtime state (device contexts, memory handles, threads) is copied into the child but is not valid there. `execv()` replaces the child's entire address space with a fresh binary image, so the child starts with no inherited runtime state. This also ensures the LLVM profile runtime initializes with the correct child PID, so `%p` in `LLVM_PROFILE_FILE` expands properly without any manual filename fixup.
 
 ### Exit Codes
 
@@ -1028,11 +1183,10 @@ The framework uses mutexes for thread-safe operations:
 
 ## Limitations
 
-1. **Process Overhead:** Each test creates a new process (fork overhead)
-2. **Sequential Execution:** Tests run one at a time (not parallel)
-3. **Linux/Unix Only:** Uses `fork()` - not available on Windows
-4. **Memory Duplication:** Each forked process duplicates memory
-5. **No Shared State:** Tests cannot share data between processes
+1. **Process Overhead:** Each test forks and re-execs the binary (higher overhead than plain `fork()`)
+2. **Linux/Unix Only:** Uses `fork()+execv()` — not available on Windows
+3. **No Shared State:** Tests cannot share data between processes
+4. **GPU pool is fixed at launch:** The GPU pool is detected once before the first test runs; hot-plug changes during a run are not reflected
 
 ---
 
@@ -1066,7 +1220,21 @@ A:
 
 **Q: Can I run tests in parallel?**
 
-A: No, the current implementation only supports sequential execution.
+A: Yes. Set `ExecutionOptions::maxParallelJobs` to a value greater than 1. The runner spawns up to that many child processes simultaneously and automatically assigns non-overlapping GPU subsets to each so concurrent tests do not interfere on the GPU. Results are always reported in registration order.
+
+```cpp
+ProcessIsolatedTestRunner::ExecutionOptions opts;
+opts.maxParallelJobs = 4;  // 4 concurrent tests
+
+RUN_ISOLATED_TESTS_WITH_OPTIONS(opts,
+    ProcessIsolatedTestRunner::TestConfig("A", []() { ... }),
+    ProcessIsolatedTestRunner::TestConfig("B", []() { ... }),
+    ProcessIsolatedTestRunner::TestConfig("C", []() { ... }),
+    ProcessIsolatedTestRunner::TestConfig("D", []() { ... })
+);
+```
+
+See the [Parallel Execution](#parallel-execution) section for full details on GPU slot management.
 
 **Q: Does this work with CTest/CMake?**
 

--- a/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
+++ b/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
@@ -215,8 +215,11 @@ int ProcessIsolatedTestRunner::runTestInProcess(const TestConfig& config)
 
     try
     {
-        // Apply environment variables
-        applyEnvironmentVariables(config);
+        // Environment was already applied in the fork child before execv().
+        // Do NOT call applyEnvironmentVariables() here: for configs with
+        // inheritParentEnv=false it would invoke clearenv() a second time,
+        // wiping HIP_VISIBLE_DEVICES that the parallel GPU slot manager
+        // injected before re-exec.
 
         // Thread-safe test execution with timeout protection
         std::atomic<bool>  testCompleted{false};

--- a/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
+++ b/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
@@ -567,6 +567,42 @@ void ProcessIsolatedTestRunner::displayCapturedOutput(
     }
 }
 
+// Re-exec child entrypoint.  If kReexecMarkerEnvVar is set this process is a
+// re-exec'd child: locate the matching test, run it, flush coverage, and
+// _exit().  Returns normally only when called from the original parent.
+void ProcessIsolatedTestRunner::handleReexecEntrypoint(
+    const std::vector<TestConfig>& tests)
+{
+    const char* target = std::getenv(kReexecMarkerEnvVar);
+    if(!target)
+        return;
+
+    // Unset so any nested RUN_ISOLATED_TESTS in the lambda doesn't recurse.
+    unsetenv(kReexecMarkerEnvVar);
+
+    for(const auto& testConfig : tests)
+    {
+        if(testConfig.name == target)
+        {
+            int result = runTestInProcess(testConfig);
+            fflush(NULL);
+#if defined(RCCL_TEST_CODE_COVERAGE)
+            __llvm_profile_write_file();
+            using WriteFn = int (*)(void);
+            auto libWrite = reinterpret_cast<WriteFn>(
+                dlsym(RTLD_DEFAULT, "rcclCoverageWriteFile"));
+            if(libWrite) libWrite();
+#endif
+            _exit(result);
+        }
+    }
+
+    std::cerr << "ProcessIsolatedTestRunner: re-exec target '" << target
+              << "' not found in registered tests" << std::endl;
+    fflush(NULL);
+    _exit(RCCL_TEST_INVALID);
+}
+
 // Execute all registered tests (simplified sequential execution only)
 bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
 {
@@ -584,37 +620,9 @@ bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
         testResults_.clear();
     }
 
-    // Re-exec child entrypoint. Every isolated test is spawned via
-    // fork()+execve() of the same binary with --gtest_filter set to the
-    // currently running TEST(). The re-exec'd process re-enters the TEST()
-    // body, calls RUN_ISOLATED_TESTS again, and lands here. The sentinel env
-    // var tells us to run the matching lambda inline (no further fork/exec)
-    // and exit with its result.
-    if(const char* target = std::getenv(kReexecMarkerEnvVar))
-    {
-        // Unset so any nested RUN_ISOLATED_TESTS in the lambda doesn't recurse.
-        unsetenv(kReexecMarkerEnvVar);
-        for(const auto& testConfig : testsToRun)
-        {
-            if(testConfig.name == target)
-            {
-                int result = runTestInProcess(testConfig);
-                fflush(NULL);
-#if defined(RCCL_TEST_CODE_COVERAGE)
-                __llvm_profile_write_file();
-                using WriteFn = int (*)(void);
-                auto libWrite = reinterpret_cast<WriteFn>(
-                    dlsym(RTLD_DEFAULT, "rcclCoverageWriteFile"));
-                if(libWrite) libWrite();
-#endif
-                _exit(result);
-            }
-        }
-        std::cerr << "ProcessIsolatedTestRunner: re-exec target '" << target
-                  << "' not found in registered tests" << std::endl;
-        fflush(NULL);
-        _exit(RCCL_TEST_INVALID);
-    }
+    // If this process is a re-exec child, handleReexecEntrypoint() runs the
+    // target test and calls _exit() — it returns only in the parent.
+    handleReexecEntrypoint(testsToRun);
 
     // Capture the gtest test-info once in the parent — current_test_info() is
     // a single global (not thread-local) and remains valid for the lifetime of

--- a/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
+++ b/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
@@ -11,17 +11,18 @@
 #include <poll.h>
 #include <unistd.h>
 
-#include <dirent.h>
-
 #include <algorithm>
 #include <atomic>
 #include <condition_variable>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <filesystem>
+#include <fstream>
 #include <future>
 #include <iostream>
 #include <mutex>
+#include <numeric>
 #include <sstream>
 #include <thread>
 
@@ -35,10 +36,6 @@ extern "C" int __llvm_profile_write_file(void);
 namespace RcclUnitTesting
 {
 
-// Env var set by fork child before execv(); signals the re-exec'd process to
-// run the named test lambda inline and _exit() with the result.
-static constexpr const char* kReexecMarkerEnvVar = "RCCL_PIT_REEXEC_TEST";
-
 // Exit codes for test process results
 enum RcclTestCode
 {
@@ -49,6 +46,19 @@ enum RcclTestCode
     RCCL_TEST_TIMEOUT           = 3,
     RCCL_TEST_SKIPPED           = 4
 };
+
+// Grace period given to a timed-out child after SIGTERM before SIGKILL.
+static constexpr int kSigtermGraceSeconds = 2;
+
+// Maximum poll(2) slice when draining child output with an active deadline.
+// Caps the wait so the deadline is re-checked regularly even if output is slow.
+static constexpr long long kPollSliceMs = 5000LL;
+
+// Number of pipe file descriptors polled per child process (stdout + stderr).
+static constexpr int kNumPipeFds = 2;
+
+// POSIX waitpid(2): exit code is stored in bits [15:8] of the status word.
+static constexpr int kWaitStatusExitShift = 8;
 
 // Define static members
 std::mutex                                         ProcessIsolatedTestRunner::testConfigsMutex_;
@@ -111,69 +121,66 @@ ProcessIsolatedTestRunner::TestConfig& ProcessIsolatedTestRunner::TestConfig::wi
     return *this;
 }
 
+// Returns GPU indices from HIP_VISIBLE_DEVICES, or empty if unset/invalid.
+static std::vector<int> gpuPoolFromEnv()
+{
+    const char* val = std::getenv("HIP_VISIBLE_DEVICES");
+    if(!val || !*val)
+        return {};
+
+    std::vector<int>   pool;
+    std::istringstream ss(val);
+    std::string        token;
+    while(std::getline(ss, token, ','))
+    {
+        try
+        {
+            pool.push_back(std::stoi(token));
+        }
+        catch(...)
+        {
+        }
+    }
+    return pool;
+}
+
+// Returns GPU indices from KFD topology sysfs, or empty if unavailable.
+// KFD topology nodes with gpu_id == 0 represent CPU or bridge nodes and are
+// skipped; only nodes with a non-zero gpu_id correspond to physical GPUs.
+// Uses sysfs rather than opening a KFD device file to avoid inheriting GPU
+// file descriptors in child processes.
+static std::vector<int> gpuPoolFromKfd()
+{
+    namespace fs = std::filesystem;
+    const fs::path nodesDir{"/sys/class/kfd/kfd/topology/nodes"};
+
+    int kfdCount = 0;
+    std::error_code ec;
+    for(const auto& entry : fs::directory_iterator(nodesDir, ec))
+    {
+        if(std::ifstream f{entry.path() / "gpu_id"})
+        {
+            unsigned gpuId = 0;
+            if(f >> gpuId && gpuId != 0)
+                ++kfdCount;
+        }
+    }
+    if(kfdCount == 0)
+        return {};
+
+    std::vector<int> pool(static_cast<size_t>(kfdCount));
+    std::iota(pool.begin(), pool.end(), 0);
+    return pool;
+}
+
 // Detects available GPU indices: first from HIP_VISIBLE_DEVICES, then from
 // KFD sysfs. Returns empty if neither source yields a pool.
 static std::vector<int> detectGpuPool()
 {
-    // Priority 1: HIP_VISIBLE_DEVICES
-    {
-        const char* val = std::getenv("HIP_VISIBLE_DEVICES");
-        if(val && *val)
-        {
-            std::vector<int>  pool;
-            std::istringstream ss(val);
-            std::string        token;
-            while(std::getline(ss, token, ','))
-            {
-                try
-                {
-                    pool.push_back(std::stoi(token));
-                }
-                catch(...)
-                {
-                }
-            }
-            if(!pool.empty())
-                return pool;
-        }
-    }
-
-    // Priority 2: KFD topology sysfs — counts GPU nodes with non-zero gpu_id.
-    // Does not open any GPU device file, avoiding KFD FD inheritance in children.
-    {
-        int kfdCount = 0;
-        if(DIR* dir = opendir("/sys/class/kfd/kfd/topology/nodes"))
-        {
-            while(struct dirent* e = readdir(dir))
-            {
-                if(e->d_name[0] == '.') continue;
-                char gpuIdPath[512];
-                std::snprintf(
-                    gpuIdPath, sizeof(gpuIdPath),
-                    "/sys/class/kfd/kfd/topology/nodes/%s/gpu_id", e->d_name
-                );
-                FILE* f = std::fopen(gpuIdPath, "r");
-                if(f)
-                {
-                    unsigned gpuId = 0;
-                    if(std::fscanf(f, "%u", &gpuId) == 1 && gpuId != 0)
-                        ++kfdCount;
-                    std::fclose(f);
-                }
-            }
-            closedir(dir);
-        }
-        if(kfdCount > 0)
-        {
-            std::vector<int> pool;
-            pool.reserve(static_cast<size_t>(kfdCount));
-            for(int i = 0; i < kfdCount; ++i)
-                pool.push_back(i);
-            return pool;
-        }
-    }
-
-    return {};
+    auto pool = gpuPoolFromEnv();
+    if(pool.empty())
+        pool = gpuPoolFromKfd();
+    return pool;
 }
 
 // Tracks which physical GPU device indices from a fixed pool are in use.
@@ -282,7 +289,6 @@ void ProcessIsolatedTestRunner::applyEnvironmentVariables(const TestConfig& conf
     }
 }
 
-// Execute a single test in a separate process
 int ProcessIsolatedTestRunner::runTestInProcess(const TestConfig& config)
 {
     pid_t processId = getpid();
@@ -295,9 +301,6 @@ int ProcessIsolatedTestRunner::runTestInProcess(const TestConfig& config)
 
     try
     {
-        // Environment was already applied before execv(); do NOT call
-        // applyEnvironmentVariables() again — it would wipe HIP_VISIBLE_DEVICES.
-
         // Thread-safe test execution with timeout protection
         std::atomic<bool>  testCompleted{false};
         std::exception_ptr testException = nullptr;
@@ -520,10 +523,10 @@ ProcessIsolatedTestRunner::CapturedOutput ProcessIsolatedTestRunner::captureProc
 
     // Drain stdout and stderr interleaved via poll() to avoid deadlock when
     // the child fills one pipe buffer (~64 KB) while the parent reads the other.
-    struct pollfd pfds[2];
+    struct pollfd pfds[kNumPipeFds];
     pfds[0] = {stdoutPipe[0], POLLIN, 0};
     pfds[1] = {stderrPipe[0], POLLIN, 0};
-    int openFds = 2;
+    int openFds = kNumPipeFds;
 
     bool timedOut = false;
 
@@ -540,12 +543,12 @@ ProcessIsolatedTestRunner::CapturedOutput ProcessIsolatedTestRunner::captureProc
                 timedOut = true;
                 break;
             }
-            // Cap to 5 s slices so we re-check the deadline regularly.
-            auto capMs = std::min<long long>(remaining.count(), 5000LL);
+            // Cap to kPollSliceMs so we re-check the deadline regularly.
+            auto capMs = std::min<long long>(remaining.count(), kPollSliceMs);
             pollMs     = static_cast<int>(capMs);
         }
 
-        int ready = poll(pfds, 2, pollMs);
+        int ready = poll(pfds, kNumPipeFds, pollMs);
         if(ready < 0)
         {
             if(errno == EINTR) continue;
@@ -556,7 +559,7 @@ ProcessIsolatedTestRunner::CapturedOutput ProcessIsolatedTestRunner::captureProc
             // poll timed out — re-check deadline next iteration
             continue;
         }
-        for(int i = 0; i < 2; ++i)
+        for(int i = 0; i < kNumPipeFds; ++i)
         {
             if(pfds[i].fd < 0) continue;
 
@@ -584,11 +587,11 @@ ProcessIsolatedTestRunner::CapturedOutput ProcessIsolatedTestRunner::captureProc
     {
         // Give the child a chance to exit cleanly, then force-kill it.
         kill(pid, SIGTERM);
-        std::this_thread::sleep_for(std::chrono::seconds(2));
+        std::this_thread::sleep_for(std::chrono::seconds(kSigtermGraceSeconds));
         kill(pid, SIGKILL);
 
         // Drain any last output flushed before death.
-        for(int i = 0; i < 2; ++i)
+        for(int i = 0; i < kNumPipeFds; ++i)
         {
             if(pfds[i].fd < 0) continue;
             // Non-blocking drain
@@ -603,9 +606,10 @@ ProcessIsolatedTestRunner::CapturedOutput ProcessIsolatedTestRunner::captureProc
 
         waitpid(pid, status, 0);
 
-        // Encode as if the child exited with RCCL_TEST_TIMEOUT so the caller
-        // path that checks WIFEXITED / WEXITSTATUS reports a TIMEOUT result.
-        *status = RCCL_TEST_TIMEOUT << 8;
+        // Synthesise a waitpid(2) status as if the child called exit(RCCL_TEST_TIMEOUT).
+        // POSIX encodes the exit code in bits [15:8] of the status word, so
+        // WIFEXITED(*status) is true and WEXITSTATUS(*status) == RCCL_TEST_TIMEOUT.
+        *status = RCCL_TEST_TIMEOUT << kWaitStatusExitShift;
         return output;
     }
 
@@ -1014,10 +1018,11 @@ bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
         return false;
     }
 
-    // When maxParallelJobs is 0, default to pool size (or hardware_concurrency()
-    // for CPU-only suites) to avoid threads piling up waiting for GPU slots.
+    // When maxParallelJobs is kAutoParallelism, default to pool size (or
+    // hardware_concurrency() for CPU-only suites) to avoid threads piling up
+    // waiting for GPU slots.
     const size_t parallelism
-        = (options.maxParallelJobs == 0)
+        = (options.maxParallelJobs == ExecutionOptions::kAutoParallelism)
               ? (detectedPool.empty()
                      ? static_cast<size_t>(std::thread::hardware_concurrency())
                      : detectedPool.size())

--- a/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
+++ b/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
@@ -604,6 +604,19 @@ bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
             if(!assignedGpus.empty())
             {
                 std::string ids = formatGpuList(assignedGpus);
+
+                // Warn when the slot manager overrides a value the test
+                // set via withEnvironment() / setVariable().  The override
+                // is intentional (isolation requires it) but should be
+                // visible so test authors can diagnose unexpected behaviour.
+                const char* existingHVD = std::getenv("HIP_VISIBLE_DEVICES");
+                if(existingHVD && *existingHVD)
+                    std::cerr
+                        << "ProcessIsolatedTestRunner: GPU slot manager overrides "
+                           "test-specified HIP_VISIBLE_DEVICES='" << existingHVD
+                        << "' with '" << ids
+                        << "' for parallel isolation\n";
+
                 setenv("HIP_VISIBLE_DEVICES", ids.c_str(), 1 /*overwrite*/);
                 setenv("ROCR_VISIBLE_DEVICES", ids.c_str(), 1);
             }

--- a/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
+++ b/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
@@ -528,6 +528,13 @@ bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
     // this TEST() body, including across background threads.
     const ::testing::TestInfo* gtestInfo
         = ::testing::UnitTest::GetInstance()->current_test_info();
+    if(!gtestInfo)
+    {
+        std::cerr << "ProcessIsolatedTestRunner: executeAllTests() must be "
+                     "called from within a gtest TEST() body; "
+                     "current_test_info() is null." << std::endl;
+        return false;
+    }
 
     // Per-test work unit: fork()+execv() the same binary with a gtest filter
     // and the sentinel env var, then drain the child's pipes and wait.
@@ -613,15 +620,8 @@ bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
 
             setenv(kReexecMarkerEnvVar, cfg.name.c_str(), 1);
 
-            if(!gtestInfo)
-            {
-                std::cerr << "ProcessIsolatedTestRunner: executeAllTests() must be "
-                             "called from within a gtest TEST() body; "
-                             "current_test_info() is null."
-                          << std::endl;
-                fflush(NULL);
-                _exit(RCCL_TEST_INVALID);
-            }
+            // gtestInfo was validated non-null in the parent before any
+            // fork; no need to re-check here.
             std::string filterArg = std::string("--gtest_filter=")
                                     + gtestInfo->test_suite_name() + "." + gtestInfo->name();
             // Disable ANSI color in the child: its output is captured via pipe

--- a/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
+++ b/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
@@ -163,6 +163,76 @@ static std::vector<int> detectGpuPool()
     return pool;
 }
 
+// ── GpuSlotManager ────────────────────────────────────────────────────────
+// Tracks which physical GPU device indices from a fixed pool are currently
+// in use.  acquire() and release() are NOT themselves thread-safe: the
+// caller is responsible for holding the shared mutex (cvMtx in
+// executeAllTests) whenever either method is invoked.
+class GpuSlotManager
+{
+public:
+    explicit GpuSlotManager(std::vector<int> pool)
+        : pool_(std::move(pool)), inUse_(pool_.size(), false)
+    {}
+
+    bool   empty() const { return pool_.empty(); }
+    size_t size()  const { return pool_.size(); }
+    const std::vector<int>& pool() const { return pool_; }
+
+    // Number of currently free slots.  Must be called with the external mutex held.
+    size_t freeSlots() const
+    {
+        return static_cast<size_t>(
+            std::count(inUse_.begin(), inUse_.end(), false));
+    }
+
+    // Assign up to `n` free slots; returns their physical device IDs.
+    // Must be called with the external mutex held.
+    std::vector<int> acquire(size_t n)
+    {
+        std::vector<int> assigned;
+        assigned.reserve(n);
+        for(size_t i = 0; i < pool_.size() && assigned.size() < n; ++i)
+        {
+            if(!inUse_[i])
+            {
+                inUse_[i] = true;
+                assigned.push_back(pool_[i]);
+            }
+        }
+        return assigned;
+    }
+
+    // Return previously acquired slots back to the pool.
+    // Must be called with the external mutex held.
+    void release(const std::vector<int>& physIds)
+    {
+        for(int id : physIds)
+            for(size_t i = 0; i < pool_.size(); ++i)
+                if(pool_[i] == id)
+                {
+                    inUse_[i] = false;
+                    break;
+                }
+    }
+
+    // Format a list of device indices as a comma-separated string.
+    static std::string formatList(const std::vector<int>& ids)
+    {
+        std::string s;
+        for(size_t i = 0; i < ids.size(); ++i)
+        {
+            if(i) s += ',';
+            s += std::to_string(ids[i]);
+        }
+        return s;
+    }
+
+private:
+    std::vector<int>  pool_;
+    std::vector<bool> inUse_;
+};
+
 // ExecutionOptions implementation
 ProcessIsolatedTestRunner::ExecutionOptions::ExecutionOptions()
     : stopOnFirstFailure(false), verboseLogging(true), maxParallelJobs(1)
@@ -574,18 +644,6 @@ bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
         CapturedOutput output;
     };
 
-    // Helper: build a comma-separated string from a list of GPU device ids.
-    auto formatGpuList = [](const std::vector<int>& ids) -> std::string
-    {
-        std::string s;
-        for(size_t i = 0; i < ids.size(); ++i)
-        {
-            if(i) s += ',';
-            s += std::to_string(ids[i]);
-        }
-        return s;
-    };
-
     // spawnOne: fork+execv a fresh copy of the binary to run a single isolated
     // test.  `assignedGpus` lists the physical device indices this child is
     // allowed to use; it is injected via HIP_VISIBLE_DEVICES / ROCR_VISIBLE_DEVICES
@@ -626,7 +684,7 @@ bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
             // Both env vars are set for compatibility across ROCm versions.
             if(!assignedGpus.empty())
             {
-                std::string ids = formatGpuList(assignedGpus);
+                std::string ids = GpuSlotManager::formatList(assignedGpus);
 
                 // Warn when the slot manager overrides a value the test
                 // set via withEnvironment() / setVariable().  The override
@@ -692,7 +750,7 @@ bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
         {
             std::string extras;
             if(!assignedGpus.empty())
-                extras += " GPUs: " + formatGpuList(assignedGpus);
+                extras += " GPUs: " + GpuSlotManager::formatList(assignedGpus);
             if(!cfg.environmentVariables.empty())
             {
                 std::string envVars;
@@ -830,51 +888,13 @@ bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
         // checked atomically to avoid TOCTOU races.
         // Use the pool that was already detected above -- same snapshot as
         // the parallelism calculation to avoid any TOCTOU divergence.
-        std::vector<int> gpuPool = detectedPool;
+        GpuSlotManager slots(detectedPool);
 
-        std::vector<bool> gpuSlotInUse(gpuPool.size(), false);
-
-        const bool gpuMgmtEnabled = !gpuPool.empty();
-
-        if(gpuMgmtEnabled)
+        if(!slots.empty())
             TEST_INFO(
                 "GPU slot manager: pool = [%s] (%zu device(s))",
-                formatGpuList(gpuPool).c_str(), gpuPool.size()
+                GpuSlotManager::formatList(slots.pool()).c_str(), slots.size()
             );
-
-        // Caller must hold cvMtx for all three helpers below.
-        auto gpuAcquireLocked = [&](size_t n) -> std::vector<int>
-        {
-            std::vector<int> assigned;
-            assigned.reserve(n);
-            for(size_t i = 0; i < gpuPool.size() && assigned.size() < n; ++i)
-            {
-                if(!gpuSlotInUse[i])
-                {
-                    gpuSlotInUse[i] = true;
-                    assigned.push_back(gpuPool[i]);
-                }
-            }
-            return assigned;
-        };
-
-        auto gpuReleaseLocked = [&](const std::vector<int>& physIds)
-        {
-            for(int id : physIds)
-                for(size_t i = 0; i < gpuPool.size(); ++i)
-                    if(gpuPool[i] == id)
-                    {
-                        gpuSlotInUse[i] = false;
-                        break;
-                    }
-        };
-
-        auto gpuFreeLocked = [&]() -> size_t
-        {
-            return static_cast<size_t>(
-                std::count(gpuSlotInUse.begin(), gpuSlotInUse.end(), false)
-            );
-        };
 
         std::mutex              cvMtx;
         std::condition_variable cv;
@@ -889,19 +909,19 @@ bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
         for(const auto& testConfig : testsToRun)
         {
             // 0 = CPU-only (no slot); > 0 = GPU slots needed.
-            const size_t need = (gpuMgmtEnabled && testConfig.numGpus > 0)
+            const size_t need = (!slots.empty() && testConfig.numGpus > 0)
                                     ? testConfig.numGpus
                                     : 0;
             // Clamp to pool size: over-requesting runs exclusively so no
             // sibling can hold a subset and cause resource contention.
-            const size_t effectiveNeed = std::min(need, gpuPool.size());
+            const size_t effectiveNeed = std::min(need, slots.size());
 
-            if(need > 0 && need > gpuPool.size())
+            if(need > 0 && need > slots.size())
             {
                 TEST_INFO(
                     "WARNING: test '%s' requests %zu GPU(s) but pool has only %zu — "
                     "assigning the entire pool and running exclusively",
-                    testConfig.name.c_str(), need, gpuPool.size()
+                    testConfig.name.c_str(), need, slots.size()
                 );
             }
 
@@ -912,7 +932,7 @@ bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
                 {
                     if(stopOnFirst && anyFailed.load()) return true;
                     if(active >= parallelism) return false;
-                    if(effectiveNeed > 0 && gpuFreeLocked() < effectiveNeed)
+                    if(effectiveNeed > 0 && slots.freeSlots() < effectiveNeed)
                         return false;
                     return true;
                 });
@@ -922,19 +942,19 @@ bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
 
                 ++active;
                 if(effectiveNeed > 0)
-                    assignedGpus = gpuAcquireLocked(effectiveNeed);
+                    assignedGpus = slots.acquire(effectiveNeed);
             }
 
             futures.push_back(std::async(
                 std::launch::async,
                 [testConfig, assignedGpus, stopOnFirst, &spawnOne, &active, &cv, &cvMtx,
-                 &gpuReleaseLocked, &anyFailed]() -> Outcome
+                 &slots, &anyFailed]() -> Outcome
                 {
                     auto so = spawnOne(testConfig, assignedGpus);
                     {
                         std::lock_guard<std::mutex> lk(cvMtx);
                         --active;
-                        gpuReleaseLocked(assignedGpus);
+                        slots.release(assignedGpus);
                         if(stopOnFirst && !so.result.passed && !so.result.skipped)
                             anyFailed.store(true);
                     }

--- a/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
+++ b/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
@@ -601,6 +601,16 @@ bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
                 setenv("ROCR_VISIBLE_DEVICES", ids.c_str(), 1);
             }
 
+            // Give each re-exec'd child its own profraw file so parallel
+            // runs don't clobber each other.  %p is expanded to the child
+            // PID by the LLVM profile runtime; %m adds the binary module
+            // hash so profiles from different test executables stay
+            // distinguishable when merging.  overwrite=0 preserves any
+            // LLVM_PROFILE_FILE already set by CI or the test config.
+#if defined(RCCL_TEST_CODE_COVERAGE)
+            setenv("LLVM_PROFILE_FILE", "rccl_tests_%p_%m.profraw", 0 /*no overwrite*/);
+#endif
+
             setenv(kReexecMarkerEnvVar, cfg.name.c_str(), 1);
 
             if(!gtestInfo)

--- a/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
+++ b/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
@@ -60,6 +60,24 @@ static constexpr int kNumPipeFds = 2;
 // POSIX waitpid(2): exit code is stored in bits [15:8] of the status word.
 static constexpr int kWaitStatusExitShift = 8;
 
+// Read buffer size for draining child stdout/stderr pipes.
+static constexpr int kPipeReadBufferSize = 4096;
+
+// poll(2) timeout sentinel: block indefinitely until an fd becomes ready.
+static constexpr int kPollBlockIndefinitely = -1;
+
+// pollfd.fd sentinel: poll(2) ignores entries with a negative fd.
+static constexpr int kDisabledFd = -1;
+
+// Default test timeout (seconds) if none is specified in TestConfig.
+static constexpr int kDefaultTestTimeoutSeconds = 30;
+
+// Unset process ID — used before a child is forked or when fork fails.
+static constexpr pid_t kInvalidPid = -1;
+
+// maxParallelJobs value that selects single-child sequential execution.
+static constexpr size_t kSequentialExecution = 1;
+
 // Define static members
 std::mutex                                         ProcessIsolatedTestRunner::testConfigsMutex_;
 std::vector<ProcessIsolatedTestRunner::TestConfig> ProcessIsolatedTestRunner::testConfigs_;
@@ -68,14 +86,14 @@ std::vector<ProcessIsolatedTestRunner::TestResult> ProcessIsolatedTestRunner::te
 
 // TestResult implementation
 ProcessIsolatedTestRunner::TestResult::TestResult()
-    : passed(false), skipped(false), exitCode(-1), processId(-1), duration(0)
+    : passed(false), skipped(false), exitCode(RCCL_TEST_INVALID), processId(kInvalidPid), duration(0)
 {}
 
 // TestConfig implementation
 ProcessIsolatedTestRunner::TestConfig::TestConfig(
     const std::string& testName, std::function<void()> logic
 )
-    : name(testName), testLogic(logic), timeout(30), inheritParentEnv(true), numGpus(0)
+    : name(testName), testLogic(logic), timeout(kDefaultTestTimeoutSeconds), inheritParentEnv(true), numGpus(0)
 {}
 
 ProcessIsolatedTestRunner::TestConfig& ProcessIsolatedTestRunner::TestConfig::withEnvironment(
@@ -94,9 +112,9 @@ ProcessIsolatedTestRunner::TestConfig&
 }
 
 ProcessIsolatedTestRunner::TestConfig&
-    ProcessIsolatedTestRunner::TestConfig::withCleanEnvironment(bool inherit)
+    ProcessIsolatedTestRunner::TestConfig::withCleanEnvironment(bool cleanEnv)
 {
-    inheritParentEnv = inherit;
+    inheritParentEnv = !cleanEnv;
     return *this;
 }
 
@@ -252,41 +270,21 @@ private:
 
 // ExecutionOptions implementation
 ProcessIsolatedTestRunner::ExecutionOptions::ExecutionOptions()
-    : stopOnFirstFailure(false), verboseLogging(true), maxParallelJobs(1)
+    : stopOnFirstFailure(false), verboseLogging(true), maxParallelJobs(kSequentialExecution)
 {}
 
 // Apply environment variables to current process
 void ProcessIsolatedTestRunner::applyEnvironmentVariables(const TestConfig& config)
 {
-    // Clear specified environment variables first
     for(const auto& varName : config.clearEnvVars)
-    {
         unsetenv(varName.c_str());
-    }
 
-    // If not inheriting parent environment, clear all environment variables
     if(!config.inheritParentEnv)
-    {
-        // Clear all existing environment variables
         if(clearenv() != 0)
-        {
-            std::cerr << "Warning: Failed to clear environment variables" << std::endl;
-        }
+            std::cerr << "Warning: Failed to clear environment variables\n";
 
-        // Set only the specified variables
-        for(const auto& [name, value] : config.environmentVariables)
-        {
-            setenv(name.c_str(), value.c_str(), 1);
-        }
-    }
-    else
-    {
-        // Just set/override the specified variables
-        for(const auto& [name, value] : config.environmentVariables)
-        {
-            setenv(name.c_str(), value.c_str(), 1);
-        }
-    }
+    for(const auto& [name, value] : config.environmentVariables)
+        setenv(name.c_str(), value.c_str(), 1);
 }
 
 int ProcessIsolatedTestRunner::runTestInProcess(const TestConfig& config)
@@ -301,93 +299,41 @@ int ProcessIsolatedTestRunner::runTestInProcess(const TestConfig& config)
 
     try
     {
-        // Thread-safe test execution with timeout protection
-        std::atomic<bool>  testCompleted{false};
-        std::exception_ptr testException = nullptr;
-        bool               testPassed    = true;
-        bool               testSkipped   = false;
+        const ::testing::UnitTest* unitTest            = ::testing::UnitTest::GetInstance();
+        const size_t               initialFailureCount = unitTest->failed_test_count();
+        const size_t               initialSkippedCount = unitTest->skipped_test_count();
 
-        // Run test in a separate thread to allow timeout handling
-        std::thread testThread(
-            [&]()
+        // Package the test as a future so wait_for() can enforce the deadline
+        // without a busy-wait loop.
+        std::packaged_task<int()> task(
+            [&]() -> int
             {
-                try
-                {
-                    // Get initial test state
-                    const ::testing::UnitTest* unitTest = ::testing::UnitTest::GetInstance();
-                    size_t                     initialFailureCount = unitTest->failed_test_count();
-                    size_t                     initialSkippedCount = unitTest->skipped_test_count();
-
-                    // Execute the test logic
-                    config.testLogic();
-
-                    // Check if any new test failures occurred
-                    size_t finalFailureCount = unitTest->failed_test_count();
-                    size_t finalSkippedCount = unitTest->skipped_test_count();
-
-                    testPassed  = (finalFailureCount == initialFailureCount);
-                    testSkipped = (finalSkippedCount > initialSkippedCount);
-
-                    testCompleted = true;
-                }
-                catch(...)
-                {
-                    testException = std::current_exception();
-                    testPassed    = false;
-                    testCompleted = true;
-                }
+                config.testLogic();
+                const bool passed  = (unitTest->failed_test_count()  == initialFailureCount);
+                const bool skipped = (unitTest->skipped_test_count()  >  initialSkippedCount);
+                return skipped ? RCCL_TEST_SKIPPED
+                     : passed  ? RCCL_TEST_SUCCESS
+                               : RCCL_TEST_FAILURE;
             }
         );
+        auto fut = task.get_future();
+        std::thread testThread(std::move(task));
 
-        // Wait for test completion with timeout
-        auto       start   = std::chrono::steady_clock::now();
-        const auto timeout = config.timeout;
-
-        while(!testCompleted.load())
+        if(fut.wait_for(config.timeout) == std::future_status::timeout)
         {
-            std::this_thread::sleep_for(std::chrono::milliseconds(100));
-            if(std::chrono::steady_clock::now() - start > timeout)
-            {
-                // Test timed out
-                TEST_INFO(
-                    "Test '%s' TIMED OUT after %ld seconds",
-                    config.name.c_str(),
-                    timeout.count()
-                );
-                fflush(NULL);
-                testThread.detach();
-                return RCCL_TEST_TIMEOUT;
-            }
+            TEST_INFO(
+                "Test '%s' TIMED OUT after %ld seconds",
+                config.name.c_str(),
+                config.timeout.count()
+            );
+            fflush(NULL);
+            testThread.detach();
+            return RCCL_TEST_TIMEOUT;
         }
 
-        // Wait for thread completion
-        if(testThread.joinable())
-        {
-            testThread.join();
-        }
-
-        // Check if test threw an exception
-        if(testException)
-        {
-            std::rethrow_exception(testException);
-        }
-
-        // Flush output before returning (needed before _exit())
+        testThread.join();
         fflush(NULL);
-
-        // Return appropriate exit code based on test result
-        if(testSkipped)
-        {
-            return RCCL_TEST_SKIPPED;
-        }
-        else if(testPassed)
-        {
-            return RCCL_TEST_SUCCESS;
-        }
-        else
-        {
-            return RCCL_TEST_FAILURE;
-        }
+        return fut.get(); // re-throws if the task threw
     }
     catch(const std::exception& e)
     {
@@ -511,7 +457,7 @@ ProcessIsolatedTestRunner::CapturedOutput ProcessIsolatedTestRunner::captureProc
     close(stderrPipe[1]);
 
     CapturedOutput output;
-    char           buffer[4096];
+    char           buffer[kPipeReadBufferSize];
     ssize_t        nbytes;
 
     using Clock    = std::chrono::steady_clock;
@@ -532,7 +478,7 @@ ProcessIsolatedTestRunner::CapturedOutput ProcessIsolatedTestRunner::captureProc
 
     while(openFds > 0)
     {
-        int pollMs = -1; // block indefinitely by default
+        int pollMs = kPollBlockIndefinitely;
         if(hasTimeout)
         {
             auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -576,7 +522,7 @@ ProcessIsolatedTestRunner::CapturedOutput ProcessIsolatedTestRunner::captureProc
                 {
                     // EOF or error -- no more data from this fd.
                     close(pfds[i].fd);
-                    pfds[i].fd = -1; // poll ignores negative fds
+                    pfds[i].fd = kDisabledFd;
                     --openFds;
                 }
             }
@@ -621,21 +567,16 @@ ProcessIsolatedTestRunner::CapturedOutput ProcessIsolatedTestRunner::captureProc
 
 // Helper method: Display captured output
 void ProcessIsolatedTestRunner::displayCapturedOutput(
-    const CapturedOutput& output, const std::string& testName
+    const CapturedOutput& output, const std::string& /*testName*/
 )
 {
-    if(!output.stdoutContent.empty())
-    {
-        std::cout << output.stdoutContent;
-        if(output.stdoutContent.back() != '\n')
-            std::cout << '\n';
-    }
-    if(!output.stderrContent.empty())
-    {
-        std::cerr << output.stderrContent;
-        if(output.stderrContent.back() != '\n')
-            std::cerr << '\n';
-    }
+    auto flush = [](std::ostream& os, const std::string& s) {
+        if(s.empty()) return;
+        os << s;
+        if(s.back() != '\n') os << '\n';
+    };
+    flush(std::cout, output.stdoutContent);
+    flush(std::cerr, output.stderrContent);
 }
 
 // Re-exec child entrypoint: if kReexecMarkerEnvVar is set, runs the named test
@@ -821,18 +762,20 @@ bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
     auto spawnOne = [&](const TestConfig& cfg, const std::vector<int>& assignedGpus)
         -> SpawnOutcome
     {
-        auto startTime = std::chrono::steady_clock::now();
-
-        int stdout_fd[2], stderr_fd[2];
-        if(!createOutputPipes(stdout_fd, stderr_fd))
-        {
+        auto makeError = [&](const char* msg) -> SpawnOutcome {
             TestResult r;
             r.testName     = cfg.name;
             r.passed       = false;
             r.exitCode     = RCCL_TEST_INVALID;
-            r.errorMessage = "Failed to create output pipes";
+            r.errorMessage = msg;
             return {r, {}};
-        }
+        };
+
+        auto startTime = std::chrono::steady_clock::now();
+
+        int stdout_fd[2], stderr_fd[2];
+        if(!createOutputPipes(stdout_fd, stderr_fd))
+            return makeError("Failed to create output pipes");
 
         // Flush all output before fork to prevent child from inheriting
         // unflushed stdio buffers.
@@ -891,19 +834,10 @@ bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
         }
         else if(pid < 0)
         {
-            close(stdout_fd[0]);
-            close(stdout_fd[1]);
-            close(stderr_fd[0]);
-            close(stderr_fd[1]);
-            TestResult r;
-            r.testName     = cfg.name;
-            r.passed       = false;
-            r.exitCode     = RCCL_TEST_INVALID;
-            r.processId    = RCCL_TEST_INVALID;
-            r.duration     = std::chrono::milliseconds(0);
-            r.errorMessage = "Failed to fork process";
+            close(stdout_fd[0]); close(stdout_fd[1]);
+            close(stderr_fd[0]); close(stderr_fd[1]);
             TEST_INFO("Failed to fork process for test '%s'", cfg.name.c_str());
-            return {r, {}};
+            return makeError("Failed to fork process");
         }
 
         // Parent: log launch, drain pipes, wait for child.
@@ -911,22 +845,12 @@ bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
             std::string extras;
             if(!assignedGpus.empty())
                 extras += " GPUs: " + GpuSlotManager::formatList(assignedGpus);
-            if(!cfg.environmentVariables.empty())
-            {
-                std::string envVars;
-                for(const auto& [name, value] : cfg.environmentVariables)
-                {
-                    if(!envVars.empty())
-                        envVars += ", ";
-                    envVars += name + "=" + value;
-                }
-                extras += " env: " + envVars;
-            }
+            for(const auto& [name, value] : cfg.environmentVariables)
+                extras += (extras.empty() ? " env: " : ", ") + name + "=" + value;
+
             if(!extras.empty())
-                TEST_INFO(
-                    "Running isolated test '%s' (PID: %d) with%s",
-                    cfg.name.c_str(), pid, extras.c_str()
-                );
+                TEST_INFO("Running isolated test '%s' (PID: %d) with%s",
+                          cfg.name.c_str(), pid, extras.c_str());
             else
                 TEST_INFO("Running isolated test '%s' (PID: %d)", cfg.name.c_str(), pid);
         }
@@ -1008,15 +932,6 @@ bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
     // manager always operate on the same snapshot.
     const std::vector<int> detectedPool
         = options.gpuPool.empty() ? detectGpuPool() : options.gpuPool;
-    if(detectedPool.empty())
-    {
-        TEST_INFO("Could not determine GPU pool.");
-        TEST_INFO("  Tried: HIP_VISIBLE_DEVICES (not set or empty),");
-        TEST_INFO("         /sys/class/kfd/kfd/topology/nodes (not found or no GPU nodes).");
-        TEST_INFO("  Fix: set HIP_VISIBLE_DEVICES=0,1,...  or ensure the KFD sysfs is mounted.");
-        ADD_FAILURE() << "Set HIP_VISIBLE_DEVICES or ensure /sys/class/kfd is mounted.";
-        return false;
-    }
 
     // When maxParallelJobs is kAutoParallelism, default to pool size (or
     // hardware_concurrency() for CPU-only suites) to avoid threads piling up
@@ -1028,8 +943,25 @@ bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
                      : detectedPool.size())
               : options.maxParallelJobs;
 
+    // A GPU pool is only required when running in parallel with tests that
+    // actually request GPU slots. Sequential runs and CPU-only suites proceed
+    // without one; kAutoParallelism falls back to hardware_concurrency().
+    const bool anyTestNeedsGpu = std::any_of(
+        testsToRun.begin(), testsToRun.end(),
+        [](const TestConfig& c) { return c.numGpus > TestConfig::kCpuOnly; }
+    );
+    if(detectedPool.empty() && parallelism > kSequentialExecution && anyTestNeedsGpu)
+    {
+        TEST_INFO("Could not determine GPU pool for parallel GPU tests.");
+        TEST_INFO("  Tried: HIP_VISIBLE_DEVICES (not set or empty),");
+        TEST_INFO("         /sys/class/kfd/kfd/topology/nodes (not found or no GPU nodes).");
+        TEST_INFO("  Fix: set HIP_VISIBLE_DEVICES=0,1,...  or ensure the KFD sysfs is mounted.");
+        ADD_FAILURE() << "Set HIP_VISIBLE_DEVICES or ensure /sys/class/kfd is mounted.";
+        return false;
+    }
+
     SpawnFn spawn = spawnOne;
-    if(parallelism <= 1)
+    if(parallelism <= kSequentialExecution)
         runSequential(testsToRun, options, spawn);
     else
         runParallel(testsToRun, options, parallelism, detectedPool, spawn);
@@ -1057,20 +989,21 @@ bool ProcessIsolatedTestRunner::generateReport(
     int                       failedTests  = 0;
     int                       skippedTests = 0;
     std::chrono::milliseconds totalDuration{0};
+    // Collect failure details inside the lock so we don't need a second pass.
+    std::vector<std::pair<std::string, std::string>> failureDetails;
 
     {
         std::lock_guard<std::mutex> lock(resultsMutex_);
         totalTests = static_cast<int>(testResults_.size());
-
         for(const auto& result : testResults_)
         {
-            if(result.skipped)
-                skippedTests++;
-            else if(result.passed)
-                passedTests++;
+            if(result.skipped)       ++skippedTests;
+            else if(result.passed)   ++passedTests;
             else
-                failedTests++;
-
+            {
+                ++failedTests;
+                failureDetails.emplace_back(result.testName, result.errorMessage);
+            }
             totalDuration += result.duration;
         }
     }
@@ -1083,36 +1016,16 @@ bool ProcessIsolatedTestRunner::generateReport(
             TEST_INFO(
                 "Process-Isolated Tests: %d passed, %d failed, %d skipped, "
                 "%d not run (stopped on first failure) (%ld ms total)",
-                passedTests,
-                failedTests,
-                skippedTests,
-                notRunTests,
-                totalDuration.count()
+                passedTests, failedTests, skippedTests, notRunTests, totalDuration.count()
             );
         else
             TEST_INFO(
                 "Process-Isolated Tests: %d passed, %d failed, %d skipped (%ld ms total)",
-                passedTests,
-                failedTests,
-                skippedTests,
-                totalDuration.count()
+                passedTests, failedTests, skippedTests, totalDuration.count()
             );
 
-        if(failedTests > 0)
-        {
-            std::lock_guard<std::mutex> lock(resultsMutex_);
-            for(const auto& result : testResults_)
-            {
-                if(!result.passed && !result.skipped)
-                {
-                    TEST_INFO(
-                        "  Failed: %s - %s",
-                        result.testName.c_str(),
-                        result.errorMessage.c_str()
-                    );
-                }
-            }
-        }
+        for(const auto& [name, msg] : failureDetails)
+            TEST_INFO("  Failed: %s - %s", name.c_str(), msg.c_str());
     }
 
     // notRunTests is shown in the summary but is not itself a failure;
@@ -1133,35 +1046,25 @@ void ProcessIsolatedTestRunner::clear()
     size_t registeredCount = 0;
     size_t executedCount   = 0;
 
-    // Check for unexecuted tests before clearing
     {
         std::lock_guard<std::mutex> lock(testConfigsMutex_);
         registeredCount = testConfigs_.size();
+        testConfigs_.clear();
     }
     {
         std::lock_guard<std::mutex> lock(resultsMutex_);
         executedCount = testResults_.size();
+        testResults_.clear();
     }
 
-    // Warn if tests were registered but not all executed
     if(registeredCount > 0 && executedCount < registeredCount)
     {
-        std::cerr << "\n⚠️  WARNING: ProcessIsolatedTestRunner::clear() called with "
+        std::cerr << "\n WARNING: ProcessIsolatedTestRunner::clear() called with "
                   << (registeredCount - executedCount) << " unexecuted test(s)!\n"
                   << "   Registered: " << registeredCount << " test(s)\n"
                   << "   Executed:   " << executedCount << " test(s)\n"
                   << "   Did you forget to call executeAllTests()?\n"
                   << std::endl;
-    }
-
-    // Clear the registrations and results
-    {
-        std::lock_guard<std::mutex> lock(testConfigsMutex_);
-        testConfigs_.clear();
-    }
-    {
-        std::lock_guard<std::mutex> lock(resultsMutex_);
-        testResults_.clear();
     }
 }
 

--- a/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
+++ b/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
@@ -603,6 +603,118 @@ void ProcessIsolatedTestRunner::handleReexecEntrypoint(
     _exit(RCCL_TEST_INVALID);
 }
 
+void ProcessIsolatedTestRunner::runSequential(
+    const std::vector<TestConfig>& tests,
+    const ExecutionOptions&        opts,
+    const SpawnFn&                 spawnFn)
+{
+    for(const auto& testConfig : tests)
+    {
+        auto outcome = spawnFn(testConfig, {});
+        displayCapturedOutput(outcome.output, testConfig.name);
+        recordTestResult(outcome.result);
+
+        if(opts.stopOnFirstFailure && !outcome.result.passed && !outcome.result.skipped)
+            break;
+    }
+}
+
+void ProcessIsolatedTestRunner::runParallel(
+    const std::vector<TestConfig>& tests,
+    const ExecutionOptions&        opts,
+    size_t                         parallelism,
+    const std::vector<int>&        gpuPool,
+    const SpawnFn&                 spawnFn)
+{
+    // Bounded sliding window: up to `parallelism` children run at once.
+    // GPU tests receive a non-overlapping slice of the pool via
+    // HIP_VISIBLE_DEVICES; concurrency and GPU slot availability are
+    // checked atomically to avoid TOCTOU races.
+    GpuSlotManager slots(gpuPool);
+
+    if(!slots.empty())
+        TEST_INFO(
+            "GPU slot manager: pool = [%s] (%zu device(s))",
+            GpuSlotManager::formatList(slots.pool()).c_str(), slots.size()
+        );
+
+    std::mutex              cvMtx;
+    std::condition_variable cv;
+    size_t                  active = 0;
+    std::atomic<bool>       anyFailed{false};
+    const bool              stopOnFirst = opts.stopOnFirstFailure;
+
+    using OutcomePair = std::pair<TestResult, CapturedOutput>;
+    std::vector<std::future<OutcomePair>> futures;
+    futures.reserve(tests.size());
+
+    for(const auto& testConfig : tests)
+    {
+        // 0 = CPU-only (no slot); > 0 = GPU slots needed.
+        const size_t need = (!slots.empty() && testConfig.numGpus > 0)
+                                ? testConfig.numGpus
+                                : 0;
+        // Clamp to pool size: over-requesting runs exclusively so no
+        // sibling can hold a subset and cause resource contention.
+        const size_t effectiveNeed = std::min(need, slots.size());
+
+        if(need > 0 && need > slots.size())
+        {
+            TEST_INFO(
+                "WARNING: test '%s' requests %zu GPU(s) but pool has only %zu — "
+                "assigning the entire pool and running exclusively",
+                testConfig.name.c_str(), need, slots.size()
+            );
+        }
+
+        std::vector<int> assignedGpus;
+        {
+            std::unique_lock<std::mutex> lk(cvMtx);
+            cv.wait(lk, [&]
+            {
+                if(stopOnFirst && anyFailed.load()) return true;
+                if(active >= parallelism) return false;
+                if(effectiveNeed > 0 && slots.freeSlots() < effectiveNeed)
+                    return false;
+                return true;
+            });
+
+            if(stopOnFirst && anyFailed.load())
+                break;
+
+            ++active;
+            if(effectiveNeed > 0)
+                assignedGpus = slots.acquire(effectiveNeed);
+        }
+
+        futures.push_back(std::async(
+            std::launch::async,
+            [testConfig, assignedGpus, stopOnFirst, &spawnFn, &active, &cv, &cvMtx,
+             &slots, &anyFailed]() -> OutcomePair
+            {
+                auto outcome = spawnFn(testConfig, assignedGpus);
+                {
+                    std::lock_guard<std::mutex> lk(cvMtx);
+                    --active;
+                    slots.release(assignedGpus);
+                    if(stopOnFirst && !outcome.result.passed && !outcome.result.skipped)
+                        anyFailed.store(true);
+                }
+                cv.notify_all();
+                return {std::move(outcome.result), std::move(outcome.output)};
+            }
+        ));
+    }
+
+    // Drain futures in registration order (including in-flight ones after a break).
+    for(auto& future : futures)
+    {
+        auto [result, output] = future.get();
+        displayCapturedOutput(output, result.testName);
+        recordTestResult(result);
+    }
+}
+
 // Execute all registered tests (simplified sequential execution only)
 bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
 {
@@ -646,12 +758,6 @@ bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
     // (applyEnvironmentVariables, setenv) happen inside the fork child which
     // is always single-threaded; the parent threads only touch their own pipe
     // file descriptors and the blocking waitpid() for their own child PID.
-    struct SpawnOutcome
-    {
-        TestResult     result;
-        CapturedOutput output;
-    };
-
     // spawnOne: fork+execv a fresh copy of the binary to run a single isolated
     // test.  `assignedGpus` lists the physical device indices this child is
     // allowed to use; it is injected via HIP_VISIBLE_DEVICES / ROCR_VISIBLE_DEVICES
@@ -876,110 +982,11 @@ bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
                      : detectedPool.size())
               : options.maxParallelJobs;
 
+    SpawnFn spawn = spawnOne;
     if(parallelism <= 1)
-    {
-        for(const auto& testConfig : testsToRun)
-        {
-            auto [result, output] = spawnOne(testConfig, {});
-            displayCapturedOutput(output, testConfig.name);
-            recordTestResult(result);
-
-            if(options.stopOnFirstFailure && !result.passed && !result.skipped)
-                break;
-        }
-    }
+        runSequential(testsToRun, options, spawn);
     else
-    {
-        // Bounded sliding window: up to `parallelism` children run at once.
-        // GPU tests receive a non-overlapping slice of the pool via
-        // HIP_VISIBLE_DEVICES; concurrency and GPU slot availability are
-        // checked atomically to avoid TOCTOU races.
-        // Use the pool that was already detected above -- same snapshot as
-        // the parallelism calculation to avoid any TOCTOU divergence.
-        GpuSlotManager slots(detectedPool);
-
-        if(!slots.empty())
-            TEST_INFO(
-                "GPU slot manager: pool = [%s] (%zu device(s))",
-                GpuSlotManager::formatList(slots.pool()).c_str(), slots.size()
-            );
-
-        std::mutex              cvMtx;
-        std::condition_variable cv;
-        size_t                  active = 0;
-        std::atomic<bool>       anyFailed{false};
-        const bool              stopOnFirst = options.stopOnFirstFailure;
-
-        using Outcome = std::pair<TestResult, CapturedOutput>;
-        std::vector<std::future<Outcome>> futures;
-        futures.reserve(testsToRun.size());
-
-        for(const auto& testConfig : testsToRun)
-        {
-            // 0 = CPU-only (no slot); > 0 = GPU slots needed.
-            const size_t need = (!slots.empty() && testConfig.numGpus > 0)
-                                    ? testConfig.numGpus
-                                    : 0;
-            // Clamp to pool size: over-requesting runs exclusively so no
-            // sibling can hold a subset and cause resource contention.
-            const size_t effectiveNeed = std::min(need, slots.size());
-
-            if(need > 0 && need > slots.size())
-            {
-                TEST_INFO(
-                    "WARNING: test '%s' requests %zu GPU(s) but pool has only %zu — "
-                    "assigning the entire pool and running exclusively",
-                    testConfig.name.c_str(), need, slots.size()
-                );
-            }
-
-            std::vector<int> assignedGpus;
-            {
-                std::unique_lock<std::mutex> lk(cvMtx);
-                cv.wait(lk, [&]
-                {
-                    if(stopOnFirst && anyFailed.load()) return true;
-                    if(active >= parallelism) return false;
-                    if(effectiveNeed > 0 && slots.freeSlots() < effectiveNeed)
-                        return false;
-                    return true;
-                });
-
-                if(stopOnFirst && anyFailed.load())
-                    break;
-
-                ++active;
-                if(effectiveNeed > 0)
-                    assignedGpus = slots.acquire(effectiveNeed);
-            }
-
-            futures.push_back(std::async(
-                std::launch::async,
-                [testConfig, assignedGpus, stopOnFirst, &spawnOne, &active, &cv, &cvMtx,
-                 &slots, &anyFailed]() -> Outcome
-                {
-                    auto so = spawnOne(testConfig, assignedGpus);
-                    {
-                        std::lock_guard<std::mutex> lk(cvMtx);
-                        --active;
-                        slots.release(assignedGpus);
-                        if(stopOnFirst && !so.result.passed && !so.result.skipped)
-                            anyFailed.store(true);
-                    }
-                    cv.notify_all();
-                    return {std::move(so.result), std::move(so.output)};
-                }
-            ));
-        }
-
-        // Drain futures in registration order (including in-flight ones after a break).
-        for(auto& future : futures)
-        {
-            auto [result, output] = future.get();
-            displayCapturedOutput(output, result.testName);
-            recordTestResult(result);
-        }
-    }
+        runParallel(testsToRun, options, parallelism, detectedPool, spawn);
 
     bool result = generateReport(options, testsToRun.size());
     {

--- a/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
+++ b/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
@@ -770,20 +770,22 @@ bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
     };
 
     // ── Determine parallelism ──────────────────────────────────────────────
-    // When maxParallelJobs is 0, default to the GPU pool size so threads don't
-    // pile up waiting for slots on GPU-test suites; fall back to
-    // hardware_concurrency() when no GPU pool exists.
-    auto computeDefaultParallelism = [&]() -> size_t
-    {
-        const std::vector<int> pool
-            = options.gpuPool.empty() ? detectGpuPool() : options.gpuPool;
-        return pool.empty() ? static_cast<size_t>(std::thread::hardware_concurrency())
-                            : pool.size();
-    };
+    // Detect the GPU pool once here so both the parallelism calculation and
+    // the slot manager always operate on the same snapshot.  A second call
+    // to detectGpuPool() inside the parallel block would re-parse env vars
+    // and re-scan /dev/dri independently, risking a TOCTOU divergence.
+    const std::vector<int> detectedPool
+        = options.gpuPool.empty() ? detectGpuPool() : options.gpuPool;
 
+    // When maxParallelJobs is 0, default to the GPU pool size so threads
+    // don't pile up waiting for slots on GPU-test suites; fall back to
+    // hardware_concurrency() when no GPU pool exists.
     const size_t parallelism
-        = (options.maxParallelJobs == 0) ? computeDefaultParallelism()
-                                         : options.maxParallelJobs;
+        = (options.maxParallelJobs == 0)
+              ? (detectedPool.empty()
+                     ? static_cast<size_t>(std::thread::hardware_concurrency())
+                     : detectedPool.size())
+              : options.maxParallelJobs;
 
     if(parallelism <= 1)
     {
@@ -803,8 +805,9 @@ bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
         // GPU tests receive a non-overlapping slice of the pool via
         // HIP_VISIBLE_DEVICES; concurrency and GPU slot availability are
         // checked atomically to avoid TOCTOU races.
-        std::vector<int> gpuPool
-            = options.gpuPool.empty() ? detectGpuPool() : options.gpuPool;
+        // Use the pool that was already detected above -- same snapshot as
+        // the parallelism calculation to avoid any TOCTOU divergence.
+        std::vector<int> gpuPool = detectedPool;
 
         std::vector<bool> gpuSlotInUse(gpuPool.size(), false);
 

--- a/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
+++ b/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
@@ -328,7 +328,30 @@ int ProcessIsolatedTestRunner::runTestInProcess(const TestConfig& config)
 // Register a test configuration
 void ProcessIsolatedTestRunner::registerTest(const TestConfig& config)
 {
+    // Null bytes are silently truncated by setenv()/getenv(), which would
+    // cause the re-exec child to fail to find its target test.
+    if(config.name.find('\0') != std::string::npos)
+    {
+        std::cerr << "ProcessIsolatedTestRunner: test name contains a null "
+                     "byte and cannot be registered: '" << config.name
+                  << "'\n";
+        return;
+    }
+
     std::lock_guard<std::mutex> lock(testConfigsMutex_);
+
+    // Duplicate names cause the re-exec child to always match the first
+    // registration and silently skip the second.
+    for(const auto& existing : testConfigs_)
+    {
+        if(existing.name == config.name)
+        {
+            std::cerr << "ProcessIsolatedTestRunner: duplicate test name '"
+                      << config.name << "' — second registration ignored.\n";
+            return;
+        }
+    }
+
     testConfigs_.push_back(config);
 }
 

--- a/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
+++ b/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
@@ -67,7 +67,7 @@ ProcessIsolatedTestRunner::TestResult::TestResult()
 ProcessIsolatedTestRunner::TestConfig::TestConfig(
     const std::string& testName, std::function<void()> logic
 )
-    : name(testName), testLogic(logic), timeout(30), inheritParentEnv(true), numGpus(1)
+    : name(testName), testLogic(logic), timeout(30), inheritParentEnv(true), numGpus(0)
 {}
 
 ProcessIsolatedTestRunner::TestConfig& ProcessIsolatedTestRunner::TestConfig::withEnvironment(
@@ -930,23 +930,20 @@ bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
         }
         else if(WIFSIGNALED(status))
         {
+            // With the re-exec model the child always calls _exit(code) after
+            // the test completes, so a signal means a genuine crash or an
+            // external kill (OOM killer, SIGKILL from CI timeout, SIGSEGV).
+            // The old fork-only model needed a 'PASSED' heuristic because GPU
+            // runtime atexit handlers could SIGTERM an already-successful child;
+            // _exit() bypasses atexit, so that case no longer applies.
             int signal = WTERMSIG(status);
-            if(output.stdoutContent.find("PASSED") != std::string::npos)
-            {
-                result.passed   = true;
-                result.exitCode = RCCL_TEST_SUCCESS;
-                TEST_INFO("Test '%s' PASSED (%ld ms)", cfg.name.c_str(), duration.count());
-            }
-            else
-            {
-                result.passed       = false;
-                result.exitCode     = -signal;
-                result.errorMessage = "Terminated by signal " + std::to_string(signal);
-                TEST_INFO(
-                    "Test '%s' (PID: %d) terminated by signal %d after %ld ms",
-                    cfg.name.c_str(), pid, signal, duration.count()
-                );
-            }
+            result.passed       = false;
+            result.exitCode     = -signal;
+            result.errorMessage = "Terminated by signal " + std::to_string(signal);
+            TEST_INFO(
+                "Test '%s' (PID: %d) terminated by signal %d after %ld ms",
+                cfg.name.c_str(), pid, signal, duration.count()
+            );
         }
         else
         {
@@ -1063,7 +1060,10 @@ bool ProcessIsolatedTestRunner::generateReport(
         }
     }
 
-    return failedTests == 0 && notRunTests == 0;
+    // notRunTests (stop-on-first-failure) is shown in the summary log
+    // but does not itself constitute a failure — the actual failing test
+    // already drives the false return.
+    return failedTests == 0;
 }
 
 // Get detailed test results (thread-safe)

--- a/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
+++ b/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
@@ -186,7 +186,8 @@ public:
             std::count(inUse_.begin(), inUse_.end(), false));
     }
 
-    // Assign up to `n` free slots; returns their physical device IDs.
+    // Assign `n` free slots; returns their physical device IDs.
+    // Precondition: n <= size() — callers must clamp before calling.
     // Must be called with the external mutex held.
     std::vector<int> acquire(size_t n)
     {
@@ -749,20 +750,13 @@ bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
         return false;
     }
 
-    // Per-test work unit: fork()+execv() the same binary with a gtest filter
-    // and the sentinel env var, then drain the child's pipes and wait.
-    // Captured as a lambda so it can be called from both the sequential and
-    // parallel paths without code duplication.
-    //
-    // Safe to call from multiple threads simultaneously: env modifications
-    // (applyEnvironmentVariables, setenv) happen inside the fork child which
-    // is always single-threaded; the parent threads only touch their own pipe
-    // file descriptors and the blocking waitpid() for their own child PID.
     // spawnOne: fork+execv a fresh copy of the binary to run a single isolated
     // test.  `assignedGpus` lists the physical device indices this child is
-    // allowed to use; it is injected via HIP_VISIBLE_DEVICES / ROCR_VISIBLE_DEVICES
-    // in the fork child so that concurrent tests never share a GPU.
-    // An empty `assignedGpus` means no restriction (sequential mode).
+    // allowed to use; injected via HIP_VISIBLE_DEVICES / ROCR_VISIBLE_DEVICES
+    // in the fork child so concurrent tests never share a GPU.
+    // Safe to call from multiple threads: env modifications happen inside the
+    // fork child (always single-threaded); parent threads only touch their own
+    // pipe fds and block in waitpid() for their own child PID.
     auto spawnOne = [&](const TestConfig& cfg, const std::vector<int>& assignedGpus)
         -> SpawnOutcome
     {

--- a/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
+++ b/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
@@ -10,17 +10,35 @@
 #include <gtest/gtest.h>
 #include <unistd.h>
 
+#include <dirent.h>
+
+#include <algorithm>
 #include <atomic>
+#include <condition_variable>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <future>
 #include <iostream>
+#include <mutex>
+#include <sstream>
 #include <thread>
 
 #include "ErrCode.hpp"
 
+#if defined(RCCL_TEST_CODE_COVERAGE)
+#include <dlfcn.h>
+extern "C" int __llvm_profile_write_file(void);
+#endif
+
 namespace RcclUnitTesting
 {
+
+// Sentinel environment variable set by the fork child before execv(). When
+// the re-exec'd process finds this variable set, executeAllTests() runs the
+// matching test lambda inline (no further fork/exec) then _exit()s with the
+// result.
+static constexpr const char* kReexecMarkerEnvVar = "RCCL_PIT_REEXEC_TEST";
 
 // Exit codes for test process results
 enum RcclTestCode
@@ -48,7 +66,7 @@ ProcessIsolatedTestRunner::TestResult::TestResult()
 ProcessIsolatedTestRunner::TestConfig::TestConfig(
     const std::string& testName, std::function<void()> logic
 )
-    : name(testName), testLogic(logic), timeout(30), inheritParentEnv(true)
+    : name(testName), testLogic(logic), timeout(30), inheritParentEnv(true), numGpus(1)
 {}
 
 ProcessIsolatedTestRunner::TestConfig& ProcessIsolatedTestRunner::TestConfig::withEnvironment(
@@ -88,9 +106,65 @@ ProcessIsolatedTestRunner::TestConfig& ProcessIsolatedTestRunner::TestConfig::se
     return *this;
 }
 
+ProcessIsolatedTestRunner::TestConfig& ProcessIsolatedTestRunner::TestConfig::withNumGpus(size_t n)
+{
+    numGpus = n;
+    return *this;
+}
+
+// Detect the set of physical GPU device indices available to this process.
+// Priority order:
+//   1. HIP_VISIBLE_DEVICES — parsed as a comma-separated list of device indices.
+//   2. ROCR_VISIBLE_DEVICES — same format (used by some ROCm versions).
+//   3. /dev/dri/renderD* node count — each node represents one GPU on ROCm/AMDGPU;
+//      produces pool [0, 1, ..., N-1].
+//
+// Returns an empty vector when no GPUs are detected, which disables GPU slot
+// management (tests run without HIP_VISIBLE_DEVICES restrictions).
+static std::vector<int> detectGpuPool()
+{
+    for(const char* envName : {"HIP_VISIBLE_DEVICES", "ROCR_VISIBLE_DEVICES"})
+    {
+        const char* val = std::getenv(envName);
+        if(val && *val)
+        {
+            std::vector<int>  pool;
+            std::istringstream ss(val);
+            std::string        token;
+            while(std::getline(ss, token, ','))
+            {
+                try
+                {
+                    pool.push_back(std::stoi(token));
+                }
+                catch(...)
+                {
+                }
+            }
+            if(!pool.empty())
+                return pool;
+        }
+    }
+
+    int count = 0;
+    if(DIR* dir = opendir("/dev/dri"))
+    {
+        while(struct dirent* e = readdir(dir))
+            if(std::strncmp(e->d_name, "renderD", 7) == 0)
+                ++count;
+        closedir(dir);
+    }
+
+    std::vector<int> pool;
+    pool.reserve(count);
+    for(int i = 0; i < count; ++i)
+        pool.push_back(i);
+    return pool;
+}
+
 // ExecutionOptions implementation
 ProcessIsolatedTestRunner::ExecutionOptions::ExecutionOptions()
-    : stopOnFirstFailure(false), verboseLogging(true)
+    : stopOnFirstFailure(false), verboseLogging(true), maxParallelJobs(1)
 {}
 
 // Apply environment variables to current process
@@ -389,192 +463,420 @@ bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
         testResults_.clear();
     }
 
-    // Sequential execution
-    for(const auto& testConfig : testsToRun)
+    // Re-exec child entrypoint. Every isolated test is spawned via
+    // fork()+execve() of the same binary with --gtest_filter set to the
+    // currently running TEST(). The re-exec'd process re-enters the TEST()
+    // body, calls RUN_ISOLATED_TESTS again, and lands here. The sentinel env
+    // var tells us to run the matching lambda inline (no further fork/exec)
+    // and exit with its result.
+    if(const char* target = std::getenv(kReexecMarkerEnvVar))
+    {
+        // Unset so any nested RUN_ISOLATED_TESTS in the lambda doesn't recurse.
+        unsetenv(kReexecMarkerEnvVar);
+        for(const auto& testConfig : testsToRun)
+        {
+            if(testConfig.name == target)
+            {
+                int result = runTestInProcess(testConfig);
+                fflush(NULL);
+#if defined(RCCL_TEST_CODE_COVERAGE)
+                __llvm_profile_write_file();
+                using WriteFn = int (*)(void);
+                auto libWrite = reinterpret_cast<WriteFn>(
+                    dlsym(RTLD_DEFAULT, "rcclCoverageWriteFile"));
+                if(libWrite) libWrite();
+#endif
+                _exit(result);
+            }
+        }
+        std::cerr << "ProcessIsolatedTestRunner: re-exec target '" << target
+                  << "' not found in registered tests" << std::endl;
+        fflush(NULL);
+        _exit(RCCL_TEST_INVALID);
+    }
+
+    // Capture the gtest test-info once in the parent — current_test_info() is
+    // a single global (not thread-local) and remains valid for the lifetime of
+    // this TEST() body, including across background threads.
+    const ::testing::TestInfo* gtestInfo
+        = ::testing::UnitTest::GetInstance()->current_test_info();
+
+    // Per-test work unit: fork()+execv() the same binary with a gtest filter
+    // and the sentinel env var, then drain the child's pipes and wait.
+    // Captured as a lambda so it can be called from both the sequential and
+    // parallel paths without code duplication.
+    //
+    // Safe to call from multiple threads simultaneously: env modifications
+    // (applyEnvironmentVariables, setenv) happen inside the fork child which
+    // is always single-threaded; the parent threads only touch their own pipe
+    // file descriptors and the blocking waitpid() for their own child PID.
+    struct SpawnOutcome
+    {
+        TestResult     result;
+        CapturedOutput output;
+    };
+
+    // Helper: build a comma-separated string from a list of GPU device ids.
+    auto formatGpuList = [](const std::vector<int>& ids) -> std::string
+    {
+        std::string s;
+        for(size_t i = 0; i < ids.size(); ++i)
+        {
+            if(i) s += ',';
+            s += std::to_string(ids[i]);
+        }
+        return s;
+    };
+
+    // spawnOne: fork+execv a fresh copy of the binary to run a single isolated
+    // test.  `assignedGpus` lists the physical device indices this child is
+    // allowed to use; it is injected via HIP_VISIBLE_DEVICES / ROCR_VISIBLE_DEVICES
+    // in the fork child so that concurrent tests never share a GPU.
+    // An empty `assignedGpus` means no restriction (sequential mode).
+    auto spawnOne = [&](const TestConfig& cfg, const std::vector<int>& assignedGpus)
+        -> SpawnOutcome
     {
         auto startTime = std::chrono::steady_clock::now();
 
         int stdout_fd[2], stderr_fd[2];
         if(!createOutputPipes(stdout_fd, stderr_fd))
         {
-            std::cerr << "Failed to create output files for test '" << testConfig.name << "'"
-                      << std::endl;
-            continue;
+            TestResult r;
+            r.testName     = cfg.name;
+            r.passed       = false;
+            r.exitCode     = RCCL_TEST_INVALID;
+            r.errorMessage = "Failed to create output pipes";
+            return {r, {}};
         }
 
-        // Flush all output before fork to prevent child from inheriting unflushed buffers
+        // Flush all output before fork to prevent child from inheriting
+        // unflushed stdio buffers.
         fflush(NULL);
 
         pid_t pid = fork();
 
         if(pid == 0)
         {
+            // Always re-exec: replace this child image with a fresh copy of
+            // the binary. execv() discards all counters before any coverage
+            // data is touched; flushing is handled in the re-exec entrypoint.
             redirectOutputToPipes(stdout_fd, stderr_fd);
-            int result = runTestInProcess(testConfig);
-            // Use _exit() instead of exit() to avoid atexit handlers
-            // This prevents GPU runtime cleanup issues after fork
-            _exit(result);
+            applyEnvironmentVariables(cfg);
+
+            // Restrict GPU visibility to the assigned subset so this child
+            // cannot accidentally use a GPU that a sibling test is using.
+            // Both env vars are set for compatibility across ROCm versions.
+            if(!assignedGpus.empty())
+            {
+                std::string ids = formatGpuList(assignedGpus);
+                setenv("HIP_VISIBLE_DEVICES", ids.c_str(), 1 /*overwrite*/);
+                setenv("ROCR_VISIBLE_DEVICES", ids.c_str(), 1);
+            }
+
+            setenv(kReexecMarkerEnvVar, cfg.name.c_str(), 1);
+
+            if(!gtestInfo)
+            {
+                std::cerr << "ProcessIsolatedTestRunner: executeAllTests() must be "
+                             "called from within a gtest TEST() body; "
+                             "current_test_info() is null."
+                          << std::endl;
+                fflush(NULL);
+                _exit(RCCL_TEST_INVALID);
+            }
+            std::string filterArg = std::string("--gtest_filter=")
+                                    + gtestInfo->test_suite_name() + "." + gtestInfo->name();
+            // Disable ANSI color in the child: its output is captured via pipe
+            // and replayed by the parent, so escape sequences are unwanted.
+            char  argv0[]    = "/proc/self/exe";
+            char  colorArg[] = "--gtest_color=no";
+            char* argv[]     = {argv0, filterArg.data(), colorArg, nullptr};
+            execv("/proc/self/exe", argv);
+            std::cerr << "ProcessIsolatedTestRunner: execv(/proc/self/exe) failed: "
+                      << strerror(errno) << std::endl;
+            fflush(NULL);
+            _exit(RCCL_TEST_INVALID);
         }
-        else if(pid > 0)
+        else if(pid < 0)
         {
-            // Log test start with environment variables if any
-            if(!testConfig.environmentVariables.empty())
+            close(stdout_fd[0]);
+            close(stdout_fd[1]);
+            close(stderr_fd[0]);
+            close(stderr_fd[1]);
+            TestResult r;
+            r.testName     = cfg.name;
+            r.passed       = false;
+            r.exitCode     = RCCL_TEST_INVALID;
+            r.processId    = RCCL_TEST_INVALID;
+            r.duration     = std::chrono::milliseconds(0);
+            r.errorMessage = "Failed to fork process";
+            TEST_INFO("Failed to fork process for test '%s'", cfg.name.c_str());
+            return {r, {}};
+        }
+
+        // Parent: log launch, drain pipes, wait for child.
+        {
+            std::string extras;
+            if(!assignedGpus.empty())
+                extras += " GPUs: " + formatGpuList(assignedGpus);
+            if(!cfg.environmentVariables.empty())
             {
                 std::string envVars;
-                for(const auto& [name, value] : testConfig.environmentVariables)
+                for(const auto& [name, value] : cfg.environmentVariables)
                 {
                     if(!envVars.empty())
                         envVars += ", ";
                     envVars += name + "=" + value;
                 }
+                extras += " env: " + envVars;
+            }
+            if(!extras.empty())
                 TEST_INFO(
-                    "Running isolated test '%s' (PID: %d) with env: %s",
-                    testConfig.name.c_str(),
-                    pid,
-                    envVars.c_str()
+                    "Running isolated test '%s' (PID: %d) with%s",
+                    cfg.name.c_str(), pid, extras.c_str()
                 );
+            else
+                TEST_INFO("Running isolated test '%s' (PID: %d)", cfg.name.c_str(), pid);
+        }
+
+        int            status;
+        CapturedOutput output = captureProcessOutput(stdout_fd, stderr_fd, pid, &status);
+
+        auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - startTime
+        );
+
+        TestResult result;
+        result.testName  = cfg.name;
+        result.processId = pid;
+        result.duration  = duration;
+
+        if(WIFEXITED(status))
+        {
+            int exitCode    = WEXITSTATUS(status);
+            result.exitCode = exitCode;
+            result.passed   = (exitCode == RCCL_TEST_SUCCESS);
+            result.skipped  = (exitCode == RCCL_TEST_SKIPPED);
+
+            if(exitCode == RCCL_TEST_SUCCESS)
+            {
+                TEST_INFO("Test '%s' PASSED (%ld ms)", cfg.name.c_str(), duration.count());
+            }
+            else if(exitCode == RCCL_TEST_TIMEOUT)
+            {
+                TEST_INFO(
+                    "Test '%s' (PID: %d) TIMED OUT after %ld ms",
+                    cfg.name.c_str(), pid, duration.count()
+                );
+                result.errorMessage = "Test timed out";
+            }
+            else if(exitCode == RCCL_TEST_SKIPPED)
+            {
+                TEST_INFO(
+                    "Test '%s' (PID: %d) SKIPPED in %ld ms",
+                    cfg.name.c_str(), pid, duration.count()
+                );
+                result.errorMessage = "Test skipped";
             }
             else
             {
-                TEST_INFO("Running isolated test '%s' (PID: %d)", testConfig.name.c_str(), pid);
+                TEST_INFO(
+                    "Test '%s' (PID: %d) FAILED with exit code %d after %ld ms",
+                    cfg.name.c_str(), pid, exitCode, duration.count()
+                );
+                result.errorMessage
+                    = "Test failed with exit code " + std::to_string(exitCode);
             }
-            // Flush parent's output before reading from child pipes to ensure proper ordering
-            fflush(stdout);
-            fflush(stderr);
-
-            int            status;
-            CapturedOutput output = captureProcessOutput(stdout_fd, stderr_fd, pid, &status);
-
-            auto endTime = std::chrono::steady_clock::now();
-            auto duration
-                = std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime);
-
-            // Display captured output BEFORE status messages for proper sequencing
-            displayCapturedOutput(output, testConfig.name);
-
-            TestResult testResult;
-            testResult.testName  = testConfig.name;
-            testResult.processId = pid;
-            testResult.duration  = duration;
-
-            if(WIFEXITED(status))
+        }
+        else if(WIFSIGNALED(status))
+        {
+            int signal = WTERMSIG(status);
+            if(output.stdoutContent.find("PASSED") != std::string::npos)
             {
-                int exitCode        = WEXITSTATUS(status);
-                testResult.exitCode = exitCode;
-                testResult.passed   = (exitCode == RCCL_TEST_SUCCESS);
-                testResult.skipped  = (exitCode == RCCL_TEST_SKIPPED);
-
-                if(exitCode == RCCL_TEST_SUCCESS)
-                {
-                    TEST_INFO("Test '%s' PASSED (%ld ms)", testConfig.name.c_str(), duration.count());
-                }
-                else if(exitCode == RCCL_TEST_TIMEOUT)
-                {
-                    TEST_INFO(
-                        "Test '%s' (PID: %d) TIMED OUT after %ld ms",
-                        testConfig.name.c_str(),
-                        pid,
-                        duration.count()
-                    );
-                    testResult.errorMessage = "Test timed out";
-                }
-                else if(exitCode == RCCL_TEST_SKIPPED)
-                {
-                    TEST_INFO(
-                        "Test '%s' (PID: %d) SKIPPED in %ld ms",
-                        testConfig.name.c_str(),
-                        pid,
-                        duration.count()
-                    );
-                    testResult.errorMessage = "Test skipped";
-                }
-                else
-                {
-                    TEST_INFO(
-                        "Test '%s' (PID: %d) FAILED with exit code %d after %ld ms",
-                        testConfig.name.c_str(),
-                        pid,
-                        exitCode,
-                        duration.count()
-                    );
-                    testResult.errorMessage
-                        = "Test failed with exit code " + std::to_string(exitCode);
-                }
-            }
-            else if(WIFSIGNALED(status))
-            {
-                int signal = WTERMSIG(status);
-
-                // Check if test reported success before signal termination
-                bool testPassed = (output.stdoutContent.find("PASSED") != std::string::npos);
-
-                if(testPassed)
-                {
-                    // Test completed successfully before signal (e.g., GPU runtime cleanup)
-                    testResult.passed   = true;
-                    testResult.skipped  = false;
-                    testResult.exitCode = RCCL_TEST_SUCCESS;
-                    TEST_INFO("Test '%s' PASSED (%ld ms)", testConfig.name.c_str(), duration.count());
-                }
-                else
-                {
-                    // Test terminated by signal before completion (crash)
-                    testResult.passed       = false;
-                    testResult.skipped      = false;
-                    testResult.exitCode     = -signal;
-                    testResult.errorMessage = "Terminated by signal " + std::to_string(signal);
-                    TEST_INFO(
-                        "Test '%s' (PID: %d) terminated by signal %d after %ld ms",
-                        testConfig.name.c_str(),
-                        pid,
-                        signal,
-                        duration.count()
-                    );
-                }
+                result.passed   = true;
+                result.exitCode = RCCL_TEST_SUCCESS;
+                TEST_INFO("Test '%s' PASSED (%ld ms)", cfg.name.c_str(), duration.count());
             }
             else
             {
-                testResult.passed       = false;
-                testResult.skipped      = false;
-                testResult.exitCode     = RCCL_TEST_INVALID;
-                testResult.errorMessage = "Failed to wait for process";
-            }
-
-            recordTestResult(testResult);
-
-            // Stop on first failure if requested
-            if(options.stopOnFirstFailure && !testResult.passed && !testResult.skipped)
-            {
-                break;
+                result.passed       = false;
+                result.exitCode     = -signal;
+                result.errorMessage = "Terminated by signal " + std::to_string(signal);
+                TEST_INFO(
+                    "Test '%s' (PID: %d) terminated by signal %d after %ld ms",
+                    cfg.name.c_str(), pid, signal, duration.count()
+                );
             }
         }
         else
         {
-            // Fork failed
-            TestResult testResult;
-            testResult.testName     = testConfig.name;
-            testResult.passed       = false;
-            testResult.skipped      = false;
-            testResult.exitCode     = RCCL_TEST_INVALID;
-            testResult.processId    = RCCL_TEST_INVALID;
-            testResult.duration     = std::chrono::milliseconds(0);
-            testResult.errorMessage = "Failed to fork process";
+            result.passed       = false;
+            result.exitCode     = RCCL_TEST_INVALID;
+            result.errorMessage = "Failed to wait for process";
+        }
 
-            recordTestResult(testResult);
-            TEST_INFO("Failed to fork process for test '%s'", testConfig.name.c_str());
+        return {result, output};
+    };
 
-            if(options.stopOnFirstFailure)
-            {
+    // ── Determine parallelism ──────────────────────────────────────────────
+    // When maxParallelJobs is 0, default to the GPU pool size so threads don't
+    // pile up waiting for slots on GPU-test suites; fall back to
+    // hardware_concurrency() when no GPU pool exists.
+    auto computeDefaultParallelism = [&]() -> size_t
+    {
+        const std::vector<int> pool
+            = options.gpuPool.empty() ? detectGpuPool() : options.gpuPool;
+        return pool.empty() ? static_cast<size_t>(std::thread::hardware_concurrency())
+                            : pool.size();
+    };
+
+    const size_t parallelism
+        = (options.maxParallelJobs == 0) ? computeDefaultParallelism()
+                                         : options.maxParallelJobs;
+
+    if(parallelism <= 1)
+    {
+        for(const auto& testConfig : testsToRun)
+        {
+            auto [result, output] = spawnOne(testConfig, {});
+            displayCapturedOutput(output, testConfig.name);
+            recordTestResult(result);
+
+            if(options.stopOnFirstFailure && !result.passed && !result.skipped)
                 break;
+        }
+    }
+    else
+    {
+        // Bounded sliding window: up to `parallelism` children run at once.
+        // GPU tests receive a non-overlapping slice of the pool via
+        // HIP_VISIBLE_DEVICES; concurrency and GPU slot availability are
+        // checked atomically to avoid TOCTOU races.
+        std::vector<int> gpuPool
+            = options.gpuPool.empty() ? detectGpuPool() : options.gpuPool;
+
+        std::vector<bool> gpuSlotInUse(gpuPool.size(), false);
+
+        const bool gpuMgmtEnabled = !gpuPool.empty();
+
+        if(gpuMgmtEnabled)
+            TEST_INFO(
+                "GPU slot manager: pool = [%s] (%zu device(s))",
+                formatGpuList(gpuPool).c_str(), gpuPool.size()
+            );
+
+        // Caller must hold cvMtx for all three helpers below.
+        auto gpuAcquireLocked = [&](size_t n) -> std::vector<int>
+        {
+            std::vector<int> assigned;
+            assigned.reserve(n);
+            for(size_t i = 0; i < gpuPool.size() && assigned.size() < n; ++i)
+            {
+                if(!gpuSlotInUse[i])
+                {
+                    gpuSlotInUse[i] = true;
+                    assigned.push_back(gpuPool[i]);
+                }
             }
+            return assigned;
+        };
+
+        auto gpuReleaseLocked = [&](const std::vector<int>& physIds)
+        {
+            for(int id : physIds)
+                for(size_t i = 0; i < gpuPool.size(); ++i)
+                    if(gpuPool[i] == id)
+                    {
+                        gpuSlotInUse[i] = false;
+                        break;
+                    }
+        };
+
+        auto gpuFreeLocked = [&]() -> size_t
+        {
+            return static_cast<size_t>(
+                std::count(gpuSlotInUse.begin(), gpuSlotInUse.end(), false)
+            );
+        };
+
+        std::mutex              cvMtx;
+        std::condition_variable cv;
+        size_t                  active = 0;
+        std::atomic<bool>       anyFailed{false};
+        const bool              stopOnFirst = options.stopOnFirstFailure;
+
+        using Outcome = std::pair<TestResult, CapturedOutput>;
+        std::vector<std::future<Outcome>> futures;
+        futures.reserve(testsToRun.size());
+
+        for(const auto& testConfig : testsToRun)
+        {
+            // 0 = CPU-only (no slot); > 0 = GPU slots needed.
+            const size_t need = (gpuMgmtEnabled && testConfig.numGpus > 0)
+                                    ? testConfig.numGpus
+                                    : 0;
+            // Clamp to pool size: over-requesting runs exclusively so no
+            // sibling can hold a subset and cause resource contention.
+            const size_t effectiveNeed = std::min(need, gpuPool.size());
+
+            if(need > 0 && need > gpuPool.size())
+            {
+                TEST_INFO(
+                    "WARNING: test '%s' requests %zu GPU(s) but pool has only %zu — "
+                    "assigning the entire pool and running exclusively",
+                    testConfig.name.c_str(), need, gpuPool.size()
+                );
+            }
+
+            std::vector<int> assignedGpus;
+            {
+                std::unique_lock<std::mutex> lk(cvMtx);
+                cv.wait(lk, [&]
+                {
+                    if(stopOnFirst && anyFailed.load()) return true;
+                    if(active >= parallelism) return false;
+                    if(effectiveNeed > 0 && gpuFreeLocked() < effectiveNeed)
+                        return false;
+                    return true;
+                });
+
+                if(stopOnFirst && anyFailed.load())
+                    break;
+
+                ++active;
+                if(effectiveNeed > 0)
+                    assignedGpus = gpuAcquireLocked(effectiveNeed);
+            }
+
+            futures.push_back(std::async(
+                std::launch::async,
+                [testConfig, assignedGpus, stopOnFirst, &spawnOne, &active, &cv, &cvMtx,
+                 &gpuReleaseLocked, &anyFailed]() -> Outcome
+                {
+                    auto so = spawnOne(testConfig, assignedGpus);
+                    {
+                        std::lock_guard<std::mutex> lk(cvMtx);
+                        --active;
+                        gpuReleaseLocked(assignedGpus);
+                        if(stopOnFirst && !so.result.passed && !so.result.skipped)
+                            anyFailed.store(true);
+                    }
+                    cv.notify_all();
+                    return {std::move(so.result), std::move(so.output)};
+                }
+            ));
+        }
+
+        // Drain futures in registration order (including in-flight ones after a break).
+        for(auto& future : futures)
+        {
+            auto [result, output] = future.get();
+            displayCapturedOutput(output, result.testName);
+            recordTestResult(result);
         }
     }
 
-    bool result = generateReport(options);
-
-    // Automatically clear test configurations and results after execution
-    // This ensures a clean state for the next test suite without requiring
-    // explicit clear() calls from test cases
+    bool result = generateReport(options, testsToRun.size());
     {
         std::lock_guard<std::mutex> lock(testConfigsMutex_);
         testConfigs_.clear();
@@ -588,7 +890,9 @@ bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
 }
 
 // Generate and display test report
-bool ProcessIsolatedTestRunner::generateReport(const ExecutionOptions& options)
+bool ProcessIsolatedTestRunner::generateReport(
+    const ExecutionOptions& options, size_t totalRegistered
+)
 {
     int                       totalTests   = 0;
     int                       passedTests  = 0;
@@ -598,36 +902,43 @@ bool ProcessIsolatedTestRunner::generateReport(const ExecutionOptions& options)
 
     {
         std::lock_guard<std::mutex> lock(resultsMutex_);
-        totalTests = testResults_.size();
+        totalTests = static_cast<int>(testResults_.size());
 
         for(const auto& result : testResults_)
         {
             if(result.skipped)
-            {
                 skippedTests++;
-            }
             else if(result.passed)
-            {
                 passedTests++;
-            }
             else
-            {
                 failedTests++;
-            }
+
             totalDuration += result.duration;
         }
     }
 
-    // Report summary only if there are failures or multiple tests
-    if(failedTests > 0 || totalTests > 1)
+    const int notRunTests = static_cast<int>(totalRegistered) - totalTests;
+
+    if(failedTests > 0 || totalTests > 1 || notRunTests > 0)
     {
-        TEST_INFO(
-            "Process-Isolated Tests: %d passed, %d failed, %d skipped (%ld ms total)",
-            passedTests,
-            failedTests,
-            skippedTests,
-            totalDuration.count()
-        );
+        if(notRunTests > 0)
+            TEST_INFO(
+                "Process-Isolated Tests: %d passed, %d failed, %d skipped, "
+                "%d not run (stopped on first failure) (%ld ms total)",
+                passedTests,
+                failedTests,
+                skippedTests,
+                notRunTests,
+                totalDuration.count()
+            );
+        else
+            TEST_INFO(
+                "Process-Isolated Tests: %d passed, %d failed, %d skipped (%ld ms total)",
+                passedTests,
+                failedTests,
+                skippedTests,
+                totalDuration.count()
+            );
 
         if(failedTests > 0)
         {
@@ -646,7 +957,7 @@ bool ProcessIsolatedTestRunner::generateReport(const ExecutionOptions& options)
         }
     }
 
-    return failedTests == 0;
+    return failedTests == 0 && notRunTests == 0;
 }
 
 // Get detailed test results (thread-safe)

--- a/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
+++ b/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
@@ -35,10 +35,8 @@ extern "C" int __llvm_profile_write_file(void);
 namespace RcclUnitTesting
 {
 
-// Sentinel environment variable set by the fork child before execv(). When
-// the re-exec'd process finds this variable set, executeAllTests() runs the
-// matching test lambda inline (no further fork/exec) then _exit()s with the
-// result.
+// Env var set by fork child before execv(); signals the re-exec'd process to
+// run the named test lambda inline and _exit() with the result.
 static constexpr const char* kReexecMarkerEnvVar = "RCCL_PIT_REEXEC_TEST";
 
 // Exit codes for test process results
@@ -113,20 +111,13 @@ ProcessIsolatedTestRunner::TestConfig& ProcessIsolatedTestRunner::TestConfig::wi
     return *this;
 }
 
-// Detect the set of physical GPU device indices available to this process.
-// Priority order:
-//   1. HIP_VISIBLE_DEVICES — parsed as a comma-separated list of device indices.
-//   2. ROCR_VISIBLE_DEVICES — same format (used by some ROCm versions).
-//   3. /dev/dri/renderD* node count — each node represents one GPU on ROCm/AMDGPU;
-//      produces pool [0, 1, ..., N-1].
-//
-// Returns an empty vector when no GPUs are detected, which disables GPU slot
-// management (tests run without HIP_VISIBLE_DEVICES restrictions).
+// Detects available GPU indices: first from HIP_VISIBLE_DEVICES, then from
+// KFD sysfs. Returns empty if neither source yields a pool.
 static std::vector<int> detectGpuPool()
 {
-    for(const char* envName : {"HIP_VISIBLE_DEVICES", "ROCR_VISIBLE_DEVICES"})
+    // Priority 1: HIP_VISIBLE_DEVICES
     {
-        const char* val = std::getenv(envName);
+        const char* val = std::getenv("HIP_VISIBLE_DEVICES");
         if(val && *val)
         {
             std::vector<int>  pool;
@@ -147,27 +138,46 @@ static std::vector<int> detectGpuPool()
         }
     }
 
-    int count = 0;
-    if(DIR* dir = opendir("/dev/dri"))
+    // Priority 2: KFD topology sysfs — counts GPU nodes with non-zero gpu_id.
+    // Does not open any GPU device file, avoiding KFD FD inheritance in children.
     {
-        while(struct dirent* e = readdir(dir))
-            if(std::strncmp(e->d_name, "renderD", 7) == 0)
-                ++count;
-        closedir(dir);
+        int kfdCount = 0;
+        if(DIR* dir = opendir("/sys/class/kfd/kfd/topology/nodes"))
+        {
+            while(struct dirent* e = readdir(dir))
+            {
+                if(e->d_name[0] == '.') continue;
+                char gpuIdPath[512];
+                std::snprintf(
+                    gpuIdPath, sizeof(gpuIdPath),
+                    "/sys/class/kfd/kfd/topology/nodes/%s/gpu_id", e->d_name
+                );
+                FILE* f = std::fopen(gpuIdPath, "r");
+                if(f)
+                {
+                    unsigned gpuId = 0;
+                    if(std::fscanf(f, "%u", &gpuId) == 1 && gpuId != 0)
+                        ++kfdCount;
+                    std::fclose(f);
+                }
+            }
+            closedir(dir);
+        }
+        if(kfdCount > 0)
+        {
+            std::vector<int> pool;
+            pool.reserve(static_cast<size_t>(kfdCount));
+            for(int i = 0; i < kfdCount; ++i)
+                pool.push_back(i);
+            return pool;
+        }
     }
 
-    std::vector<int> pool;
-    pool.reserve(count);
-    for(int i = 0; i < count; ++i)
-        pool.push_back(i);
-    return pool;
+    return {};
 }
 
-// ── GpuSlotManager ────────────────────────────────────────────────────────
-// Tracks which physical GPU device indices from a fixed pool are currently
-// in use.  acquire() and release() are NOT themselves thread-safe: the
-// caller is responsible for holding the shared mutex (cvMtx in
-// executeAllTests) whenever either method is invoked.
+// Tracks which physical GPU device indices from a fixed pool are in use.
+// acquire() and release() must be called with the external mutex (cvMtx) held.
 class GpuSlotManager
 {
 public:
@@ -186,9 +196,8 @@ public:
             std::count(inUse_.begin(), inUse_.end(), false));
     }
 
-    // Assign `n` free slots; returns their physical device IDs.
-    // Precondition: n <= size() — callers must clamp before calling.
-    // Must be called with the external mutex held.
+    // Assigns `n` free slots and returns their physical device IDs.
+    // Precondition: n <= size(); must be called with the external mutex held.
     std::vector<int> acquire(size_t n)
     {
         std::vector<int> assigned;
@@ -286,11 +295,8 @@ int ProcessIsolatedTestRunner::runTestInProcess(const TestConfig& config)
 
     try
     {
-        // Environment was already applied in the fork child before execv().
-        // Do NOT call applyEnvironmentVariables() here: for configs with
-        // inheritParentEnv=false it would invoke clearenv() a second time,
-        // wiping HIP_VISIBLE_DEVICES that the parallel GPU slot manager
-        // injected before re-exec.
+        // Environment was already applied before execv(); do NOT call
+        // applyEnvironmentVariables() again — it would wipe HIP_VISIBLE_DEVICES.
 
         // Thread-safe test execution with timeout protection
         std::atomic<bool>  testCompleted{false};
@@ -490,9 +496,11 @@ void ProcessIsolatedTestRunner::redirectOutputToPipes(int stdoutPipe[2], int std
     close(stderrPipe[1]);
 }
 
-// Helper method: Capture output from child process pipes
+// Reads stdout/stderr pipes until the child exits or the deadline is reached.
+// On timeout: SIGTERM, then SIGKILL after 2 s; *status set to RCCL_TEST_TIMEOUT.
 ProcessIsolatedTestRunner::CapturedOutput ProcessIsolatedTestRunner::captureProcessOutput(
-    int stdoutPipe[2], int stderrPipe[2], pid_t pid, int* status
+    int stdoutPipe[2], int stderrPipe[2], pid_t pid, int* status,
+    std::chrono::seconds timeout
 )
 {
     // Close write ends of pipes in parent process (not needed)
@@ -501,23 +509,52 @@ ProcessIsolatedTestRunner::CapturedOutput ProcessIsolatedTestRunner::captureProc
 
     CapturedOutput output;
     char           buffer[4096];
-    ssize_t        count;
+    ssize_t        nbytes;
 
-    // Drain stdout and stderr interleaved via poll() to avoid a deadlock
-    // where the child blocks writing one pipe while the parent is blocked
-    // reading the other (possible when either pipe buffer fills, ~64 KB).
+    using Clock    = std::chrono::steady_clock;
+    using TimePoint = Clock::time_point;
+
+    const bool    hasTimeout = (timeout.count() > 0);
+    const TimePoint deadline = hasTimeout ? Clock::now() + timeout
+                                          : TimePoint::max();
+
+    // Drain stdout and stderr interleaved via poll() to avoid deadlock when
+    // the child fills one pipe buffer (~64 KB) while the parent reads the other.
     struct pollfd pfds[2];
     pfds[0] = {stdoutPipe[0], POLLIN, 0};
     pfds[1] = {stderrPipe[0], POLLIN, 0};
     int openFds = 2;
 
+    bool timedOut = false;
+
     while(openFds > 0)
     {
-        int ready = poll(pfds, 2, -1 /*block indefinitely*/);
+        int pollMs = -1; // block indefinitely by default
+        if(hasTimeout)
+        {
+            auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(
+                deadline - Clock::now()
+            );
+            if(remaining.count() <= 0)
+            {
+                timedOut = true;
+                break;
+            }
+            // Cap to 5 s slices so we re-check the deadline regularly.
+            auto capMs = std::min<long long>(remaining.count(), 5000LL);
+            pollMs     = static_cast<int>(capMs);
+        }
+
+        int ready = poll(pfds, 2, pollMs);
         if(ready < 0)
         {
             if(errno == EINTR) continue;
             break; // unexpected error -- fall through to waitpid
+        }
+        if(ready == 0)
+        {
+            // poll timed out — re-check deadline next iteration
+            continue;
         }
         for(int i = 0; i < 2; ++i)
         {
@@ -525,10 +562,10 @@ ProcessIsolatedTestRunner::CapturedOutput ProcessIsolatedTestRunner::captureProc
 
             if(pfds[i].revents & (POLLIN | POLLHUP | POLLERR))
             {
-                count = read(pfds[i].fd, buffer, sizeof(buffer) - 1);
-                if(count > 0)
+                nbytes = read(pfds[i].fd, buffer, sizeof(buffer) - 1);
+                if(nbytes > 0)
                 {
-                    buffer[count] = '\0';
+                    buffer[nbytes] = '\0';
                     (i == 0 ? output.stdoutContent : output.stderrContent)
                         += buffer;
                 }
@@ -543,7 +580,36 @@ ProcessIsolatedTestRunner::CapturedOutput ProcessIsolatedTestRunner::captureProc
         }
     }
 
-    // Wait for child to exit (blocking).
+    if(timedOut)
+    {
+        // Give the child a chance to exit cleanly, then force-kill it.
+        kill(pid, SIGTERM);
+        std::this_thread::sleep_for(std::chrono::seconds(2));
+        kill(pid, SIGKILL);
+
+        // Drain any last output flushed before death.
+        for(int i = 0; i < 2; ++i)
+        {
+            if(pfds[i].fd < 0) continue;
+            // Non-blocking drain
+            fcntl(pfds[i].fd, F_SETFL, O_NONBLOCK);
+            while((nbytes = read(pfds[i].fd, buffer, sizeof(buffer) - 1)) > 0)
+            {
+                buffer[nbytes] = '\0';
+                (i == 0 ? output.stdoutContent : output.stderrContent) += buffer;
+            }
+            close(pfds[i].fd);
+        }
+
+        waitpid(pid, status, 0);
+
+        // Encode as if the child exited with RCCL_TEST_TIMEOUT so the caller
+        // path that checks WIFEXITED / WEXITSTATUS reports a TIMEOUT result.
+        *status = RCCL_TEST_TIMEOUT << 8;
+        return output;
+    }
+
+    // Normal path: wait for child to exit.
     waitpid(pid, status, 0);
 
     return output;
@@ -568,9 +634,8 @@ void ProcessIsolatedTestRunner::displayCapturedOutput(
     }
 }
 
-// Re-exec child entrypoint.  If kReexecMarkerEnvVar is set this process is a
-// re-exec'd child: locate the matching test, run it, flush coverage, and
-// _exit().  Returns normally only when called from the original parent.
+// Re-exec child entrypoint: if kReexecMarkerEnvVar is set, runs the named test
+// and _exit()s with the result. Returns normally only in the original parent.
 void ProcessIsolatedTestRunner::handleReexecEntrypoint(
     const std::vector<TestConfig>& tests)
 {
@@ -628,9 +693,7 @@ void ProcessIsolatedTestRunner::runParallel(
     const SpawnFn&                 spawnFn)
 {
     // Bounded sliding window: up to `parallelism` children run at once.
-    // GPU tests receive a non-overlapping slice of the pool via
-    // HIP_VISIBLE_DEVICES; concurrency and GPU slot availability are
-    // checked atomically to avoid TOCTOU races.
+    // GPU slot availability and active count are checked atomically.
     GpuSlotManager slots(gpuPool);
 
     if(!slots.empty())
@@ -737,9 +800,8 @@ bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
     // target test and calls _exit() — it returns only in the parent.
     handleReexecEntrypoint(testsToRun);
 
-    // Capture the gtest test-info once in the parent — current_test_info() is
-    // a single global (not thread-local) and remains valid for the lifetime of
-    // this TEST() body, including across background threads.
+    // Capture gtest test-info once in the parent; current_test_info() is a
+    // single global valid for the lifetime of this TEST() body.
     const ::testing::TestInfo* gtestInfo
         = ::testing::UnitTest::GetInstance()->current_test_info();
     if(!gtestInfo)
@@ -750,13 +812,8 @@ bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
         return false;
     }
 
-    // spawnOne: fork+execv a fresh copy of the binary to run a single isolated
-    // test.  `assignedGpus` lists the physical device indices this child is
-    // allowed to use; injected via HIP_VISIBLE_DEVICES / ROCR_VISIBLE_DEVICES
-    // in the fork child so concurrent tests never share a GPU.
-    // Safe to call from multiple threads: env modifications happen inside the
-    // fork child (always single-threaded); parent threads only touch their own
-    // pipe fds and block in waitpid() for their own child PID.
+    // spawnOne: fork+execv a fresh binary copy to run one isolated test.
+    // Thread-safe: env changes happen only in the fork child; parents own their pipe fds.
     auto spawnOne = [&](const TestConfig& cfg, const std::vector<int>& assignedGpus)
         -> SpawnOutcome
     {
@@ -781,23 +838,19 @@ bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
 
         if(pid == 0)
         {
-            // Always re-exec: replace this child image with a fresh copy of
-            // the binary. execv() discards all counters before any coverage
-            // data is touched; flushing is handled in the re-exec entrypoint.
+            // Always re-exec to get a fresh binary image; execv() discards
+            // all counters before coverage data is touched.
             redirectOutputToPipes(stdout_fd, stderr_fd);
             applyEnvironmentVariables(cfg);
 
             // Restrict GPU visibility to the assigned subset so this child
-            // cannot accidentally use a GPU that a sibling test is using.
-            // Both env vars are set for compatibility across ROCm versions.
+            // cannot accidentally share a GPU with a sibling test.
             if(!assignedGpus.empty())
             {
                 std::string ids = GpuSlotManager::formatList(assignedGpus);
 
-                // Warn when the slot manager overrides a value the test
-                // set via withEnvironment() / setVariable().  The override
-                // is intentional (isolation requires it) but should be
-                // visible so test authors can diagnose unexpected behaviour.
+                // Warn when the slot manager overrides a test-specified value;
+                // the override is intentional for isolation.
                 const char* existingHVD = std::getenv("HIP_VISIBLE_DEVICES");
                 if(existingHVD && *existingHVD)
                     std::cerr
@@ -807,15 +860,10 @@ bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
                         << "' for parallel isolation\n";
 
                 setenv("HIP_VISIBLE_DEVICES", ids.c_str(), 1 /*overwrite*/);
-                setenv("ROCR_VISIBLE_DEVICES", ids.c_str(), 1);
             }
 
-            // Give each re-exec'd child its own profraw file so parallel
-            // runs don't clobber each other.  %p is expanded to the child
-            // PID by the LLVM profile runtime; %m adds the binary module
-            // hash so profiles from different test executables stay
-            // distinguishable when merging.  overwrite=0 preserves any
-            // LLVM_PROFILE_FILE already set by CI or the test config.
+            // Give each child its own profraw file (%p=PID, %m=module hash).
+            // overwrite=0 preserves any LLVM_PROFILE_FILE already set by CI.
 #if defined(RCCL_TEST_CODE_COVERAGE)
             setenv("LLVM_PROFILE_FILE", "rccl_tests_%p_%m.profraw", 0 /*no overwrite*/);
 #endif
@@ -880,7 +928,8 @@ bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
         }
 
         int            status;
-        CapturedOutput output = captureProcessOutput(stdout_fd, stderr_fd, pid, &status);
+        CapturedOutput output = captureProcessOutput(stdout_fd, stderr_fd, pid, &status,
+                                                     cfg.timeout);
 
         auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
             std::chrono::steady_clock::now() - startTime
@@ -930,12 +979,8 @@ bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
         }
         else if(WIFSIGNALED(status))
         {
-            // With the re-exec model the child always calls _exit(code) after
-            // the test completes, so a signal means a genuine crash or an
-            // external kill (OOM killer, SIGKILL from CI timeout, SIGSEGV).
-            // The old fork-only model needed a 'PASSED' heuristic because GPU
-            // runtime atexit handlers could SIGTERM an already-successful child;
-            // _exit() bypasses atexit, so that case no longer applies.
+            // With re-exec the child always _exit()s after completion, so a
+            // signal indicates a genuine crash or external kill (OOM, SIGSEGV).
             int signal = WTERMSIG(status);
             result.passed       = false;
             result.exitCode     = -signal;
@@ -955,17 +1000,22 @@ bool ProcessIsolatedTestRunner::executeAllTests(const ExecutionOptions& options)
         return {result, output};
     };
 
-    // ── Determine parallelism ──────────────────────────────────────────────
-    // Detect the GPU pool once here so both the parallelism calculation and
-    // the slot manager always operate on the same snapshot.  A second call
-    // to detectGpuPool() inside the parallel block would re-parse env vars
-    // and re-scan /dev/dri independently, risking a TOCTOU divergence.
+    // Detect the GPU pool once so the parallelism calculation and slot
+    // manager always operate on the same snapshot.
     const std::vector<int> detectedPool
         = options.gpuPool.empty() ? detectGpuPool() : options.gpuPool;
+    if(detectedPool.empty())
+    {
+        TEST_INFO("Could not determine GPU pool.");
+        TEST_INFO("  Tried: HIP_VISIBLE_DEVICES (not set or empty),");
+        TEST_INFO("         /sys/class/kfd/kfd/topology/nodes (not found or no GPU nodes).");
+        TEST_INFO("  Fix: set HIP_VISIBLE_DEVICES=0,1,...  or ensure the KFD sysfs is mounted.");
+        ADD_FAILURE() << "Set HIP_VISIBLE_DEVICES or ensure /sys/class/kfd is mounted.";
+        return false;
+    }
 
-    // When maxParallelJobs is 0, default to the GPU pool size so threads
-    // don't pile up waiting for slots on GPU-test suites; fall back to
-    // hardware_concurrency() when no GPU pool exists.
+    // When maxParallelJobs is 0, default to pool size (or hardware_concurrency()
+    // for CPU-only suites) to avoid threads piling up waiting for GPU slots.
     const size_t parallelism
         = (options.maxParallelJobs == 0)
               ? (detectedPool.empty()
@@ -1060,9 +1110,8 @@ bool ProcessIsolatedTestRunner::generateReport(
         }
     }
 
-    // notRunTests (stop-on-first-failure) is shown in the summary log
-    // but does not itself constitute a failure — the actual failing test
-    // already drives the false return.
+    // notRunTests is shown in the summary but is not itself a failure;
+    // the actual failing test drives the false return.
     return failedTests == 0;
 }
 

--- a/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
+++ b/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
@@ -8,6 +8,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <gtest/gtest.h>
+#include <poll.h>
 #include <unistd.h>
 
 #include <dirent.h>
@@ -405,23 +406,47 @@ ProcessIsolatedTestRunner::CapturedOutput ProcessIsolatedTestRunner::captureProc
     char           buffer[4096];
     ssize_t        count;
 
-    // Read from stdout pipe
-    while((count = read(stdoutPipe[0], buffer, sizeof(buffer) - 1)) > 0)
-    {
-        buffer[count] = '\0';
-        output.stdoutContent += buffer;
-    }
-    close(stdoutPipe[0]);
+    // Drain stdout and stderr interleaved via poll() to avoid a deadlock
+    // where the child blocks writing one pipe while the parent is blocked
+    // reading the other (possible when either pipe buffer fills, ~64 KB).
+    struct pollfd pfds[2];
+    pfds[0] = {stdoutPipe[0], POLLIN, 0};
+    pfds[1] = {stderrPipe[0], POLLIN, 0};
+    int openFds = 2;
 
-    // Read from stderr pipe
-    while((count = read(stderrPipe[0], buffer, sizeof(buffer) - 1)) > 0)
+    while(openFds > 0)
     {
-        buffer[count] = '\0';
-        output.stderrContent += buffer;
-    }
-    close(stderrPipe[0]);
+        int ready = poll(pfds, 2, -1 /*block indefinitely*/);
+        if(ready < 0)
+        {
+            if(errno == EINTR) continue;
+            break; // unexpected error -- fall through to waitpid
+        }
+        for(int i = 0; i < 2; ++i)
+        {
+            if(pfds[i].fd < 0) continue;
 
-    // Wait for child to exit (blocking)
+            if(pfds[i].revents & (POLLIN | POLLHUP | POLLERR))
+            {
+                count = read(pfds[i].fd, buffer, sizeof(buffer) - 1);
+                if(count > 0)
+                {
+                    buffer[count] = '\0';
+                    (i == 0 ? output.stdoutContent : output.stderrContent)
+                        += buffer;
+                }
+                else
+                {
+                    // EOF or error -- no more data from this fd.
+                    close(pfds[i].fd);
+                    pfds[i].fd = -1; // poll ignores negative fds
+                    --openFds;
+                }
+            }
+        }
+    }
+
+    // Wait for child to exit (blocking).
     waitpid(pid, status, 0);
 
     return output;

--- a/projects/rccl/test/common/ProcessIsolatedTestRunner.hpp
+++ b/projects/rccl/test/common/ProcessIsolatedTestRunner.hpp
@@ -61,6 +61,12 @@ public:
         std::chrono::seconds     timeout;              ///< Test timeout
         bool                     inheritParentEnv;     ///< Whether to inherit parent environment
         std::vector<std::string> clearEnvVars; ///< Environment variables to explicitly clear
+        size_t                   numGpus; ///< GPU slots this test needs.
+                                         ///< 0 = no GPU slot needed; test runs without any
+                                         ///<     HIP_VISIBLE_DEVICES restriction and does not
+                                         ///<     consume a pool slot (use for CPU-only tests).
+                                         ///< 1 = one dedicated GPU from the pool (default).
+                                         ///< N = exactly N GPUs from the pool.
 
         /**
          * @brief Constructor
@@ -104,6 +110,22 @@ public:
          * @return Reference to this TestConfig for method chaining
          */
         TestConfig& setVariable(const std::string& name, const std::string& value);
+
+        /**
+         * @brief Declare how many GPU slots this test requires during parallel execution.
+         *
+         * When the runner executes tests in parallel it partitions the GPU pool
+         * (see ExecutionOptions::gpuPool) into non-overlapping subsets and injects
+         * HIP_VISIBLE_DEVICES / ROCR_VISIBLE_DEVICES into each child so that
+         * concurrent tests never share a physical device.
+         *
+         * @param n Number of GPUs needed.
+         *          0 = CPU-only test, no GPU slot acquired (runs freely in parallel).
+         *          1 = one dedicated GPU from the pool (default).
+         *          N = exactly N GPUs from the pool.
+         * @return Reference to this TestConfig for method chaining
+         */
+        TestConfig& withNumGpus(size_t n);
     };
 
     /**
@@ -111,8 +133,26 @@ public:
      */
     struct ExecutionOptions
     {
-        bool stopOnFirstFailure; ///< Stop execution on first test failure
-        bool verboseLogging;     ///< Enable verbose logging
+        bool   stopOnFirstFailure; ///< Stop execution on first test failure
+        bool   verboseLogging;     ///< Enable verbose logging
+        size_t maxParallelJobs;    ///< Maximum number of concurrent child processes.
+                                   ///< 1 = sequential (default).
+                                   ///< 0 = std::thread::hardware_concurrency().
+                                   ///< N > 1 = up to N tests run simultaneously.
+                                   ///< Results are always reported in registration order.
+
+        /// Physical GPU device indices available for distribution across parallel
+        /// test processes.  Each concurrent child is assigned a non-overlapping
+        /// subset and sees only its assigned GPUs via HIP_VISIBLE_DEVICES /
+        /// ROCR_VISIBLE_DEVICES so tests never contend on the same device.
+        ///
+        /// Empty (default): auto-detect from HIP_VISIBLE_DEVICES /
+        /// ROCR_VISIBLE_DEVICES environment variables; if those are unset, count
+        /// /dev/dri/renderD* nodes and build a pool [0, 1, ..., N-1].
+        ///
+        /// Only used when maxParallelJobs > 1.  Sequential runs (default) leave
+        /// device selection to the test itself.
+        std::vector<int> gpuPool;
 
         /**
          * @brief Default constructor with sensible defaults
@@ -120,7 +160,6 @@ public:
         ExecutionOptions();
     };
 
-private:
     /**
      * @brief Structure to hold captured process output
      */
@@ -130,6 +169,7 @@ private:
         std::string stderrContent; ///< Captured stderr content
     };
 
+private:
     // Thread-safe static members for test management
     static std::mutex              testConfigsMutex_;
     static std::vector<TestConfig> testConfigs_;
@@ -225,10 +265,13 @@ public:
 
     /**
      * @brief Generate and display test report
-     * @param options Execution options used for the test run
-     * @return True if all tests passed, false otherwise
+     * @param options          Execution options used for the test run
+     * @param totalRegistered  Total number of tests that were registered (may
+     *                         differ from the number actually run when
+     *                         stopOnFirstFailure is active)
+     * @return True if all tests passed and none were left unrun, false otherwise
      */
-    static bool generateReport(const ExecutionOptions& options);
+    static bool generateReport(const ExecutionOptions& options, size_t totalRegistered);
 
     /**
      * @brief Get detailed test results (thread-safe)

--- a/projects/rccl/test/common/ProcessIsolatedTestRunner.hpp
+++ b/projects/rccl/test/common/ProcessIsolatedTestRunner.hpp
@@ -23,7 +23,8 @@ namespace RcclUnitTesting
  * @brief Generic thread-safe process isolated test runner
  *
  * This class provides a framework for running tests in isolated processes
- * with clean environment settings and sequential execution.
+ * using fork()+execv(), with per-test environment control and optional
+ * parallel execution with GPU-aware slot scheduling.
  *
  */
 class ProcessIsolatedTestRunner
@@ -117,12 +118,12 @@ public:
          *
          * When the runner executes tests in parallel it partitions the GPU pool
          * (see ExecutionOptions::gpuPool) into non-overlapping subsets and injects
-         * HIP_VISIBLE_DEVICES / ROCR_VISIBLE_DEVICES into each child so that
-         * concurrent tests never share a physical device.
+         * HIP_VISIBLE_DEVICES into each child so that concurrent tests never
+         * share a physical device.
          *
          * @param n Number of GPUs needed.
-         *          0 = CPU-only test, no GPU slot acquired (runs freely in parallel).
-         *          1 = one dedicated GPU from the pool (default).
+         *          0 = CPU-only test, no GPU slot acquired (runs freely in parallel). Default.
+         *          1 = one dedicated GPU from the pool.
          *          N = exactly N GPUs from the pool.
          * @return Reference to this TestConfig for method chaining
          */
@@ -138,21 +139,17 @@ public:
         bool   verboseLogging;     ///< Enable verbose logging
         size_t maxParallelJobs;    ///< Maximum number of concurrent child processes.
                                    ///< 1 = sequential (default).
-                                   ///< 0 = std::thread::hardware_concurrency().
+                                   ///< 0 = GPU pool size, or hardware_concurrency() if no pool.
                                    ///< N > 1 = up to N tests run simultaneously.
                                    ///< Results are always reported in registration order.
 
         /// Physical GPU device indices available for distribution across parallel
         /// test processes.  Each concurrent child is assigned a non-overlapping
-        /// subset and sees only its assigned GPUs via HIP_VISIBLE_DEVICES /
-        /// ROCR_VISIBLE_DEVICES so tests never contend on the same device.
+        /// subset and sees only its assigned GPUs via HIP_VISIBLE_DEVICES so
+        /// tests never contend on the same device.
         ///
-        /// Empty (default): auto-detect from HIP_VISIBLE_DEVICES /
-        /// ROCR_VISIBLE_DEVICES environment variables; if those are unset, count
-        /// /dev/dri/renderD* nodes and build a pool [0, 1, ..., N-1].
-        ///
-        /// Only used when maxParallelJobs > 1.  Sequential runs (default) leave
-        /// device selection to the test itself.
+        /// Empty (default): auto-detect via HIP_VISIBLE_DEVICES, then KFD sysfs.
+        /// Only used when maxParallelJobs > 1.
         std::vector<int> gpuPool;
 
         /**
@@ -210,10 +207,18 @@ private:
      * @param stderrPipe Stderr pipe file descriptors [read, write]
      * @param pid Child process ID to monitor
      * @param status Pointer to status variable for waitpid
+     * @param timeout Wall-clock limit; 0 = unlimited.  On expiry the child is
+     *                SIGTERM'd (then SIGKILL'd) and *status is set to indicate
+     *                RCCL_TEST_TIMEOUT.
      * @return Captured output from stdout and stderr
      */
-    static CapturedOutput
-        captureProcessOutput(int stdoutPipe[2], int stderrPipe[2], pid_t pid, int* status);
+    static CapturedOutput captureProcessOutput(
+        int                  stdoutPipe[2],
+        int                  stderrPipe[2],
+        pid_t                pid,
+        int*                 status,
+        std::chrono::seconds timeout = std::chrono::seconds(0)
+    );
 
     /**
      * @brief Display captured output with formatted delimiters
@@ -296,9 +301,9 @@ public:
     static void recordTestResult(const TestResult& result);
 
     /**
-     * @brief Execute all registered tests sequentially
-     * @param options Execution options (defaults to continue on failure)
-     * @return True if all tests passed, false otherwise
+     * @brief Execute all registered tests (sequentially or in parallel)
+     * @param options Execution options (defaults to sequential, continue on failure)
+     * @return True if all tests passed, false if any failed or the GPU pool could not be detected
      * @note This method automatically clears all test registrations and results
      *       after execution, ensuring a clean state for the next test suite.
      */
@@ -310,7 +315,7 @@ public:
      * @param totalRegistered  Total number of tests that were registered (may
      *                         differ from the number actually run when
      *                         stopOnFirstFailure is active)
-     * @return True if all tests passed and none were left unrun, false otherwise
+     * @return True if no tests failed; tests not run due to stopOnFirstFailure do not count as failures
      */
     static bool generateReport(const ExecutionOptions& options, size_t totalRegistered);
 

--- a/projects/rccl/test/common/ProcessIsolatedTestRunner.hpp
+++ b/projects/rccl/test/common/ProcessIsolatedTestRunner.hpp
@@ -33,6 +33,9 @@ public:
     /// Env var set before execv(); its presence in a re-exec'd child selects the test to run.
     static constexpr const char* kReexecMarkerEnvVar = "RCCL_PIT_REEXEC_TEST";
 
+    /// Special value for captureProcessOutput timeout: no deadline, wait indefinitely.
+    static constexpr int kNoTimeoutSeconds = 0;
+
     /**
      * @brief Test execution result structure
      */
@@ -58,6 +61,9 @@ public:
      */
     struct TestConfig
     {
+        /// Special value for numGpus: CPU-only test, no GPU slot acquired.
+        static constexpr size_t kCpuOnly = 0;
+
         std::string           name;      ///< Test name
         std::function<void()> testLogic; ///< Test function to execute
         std::unordered_map<std::string, std::string>
@@ -65,13 +71,7 @@ public:
         std::chrono::seconds     timeout;              ///< Test timeout
         bool                     inheritParentEnv;     ///< Whether to inherit parent environment
         std::vector<std::string> clearEnvVars; ///< Environment variables to explicitly clear
-        size_t                   numGpus; ///< GPU slots this test needs.
-                                         ///< 0 = no GPU slot needed (default); test runs
-                                         ///<     without any HIP_VISIBLE_DEVICES restriction
-                                         ///<     and does not consume a pool slot.
-                                         ///< 1 = one dedicated GPU from the pool.
-                                         ///< N = exactly N GPUs from the pool.
-                                         ///< GPU tests should call withNumGpus(n) explicitly.
+        size_t                   numGpus; ///< GPU slots needed; see withNumGpus(). Default: kCpuOnly.
 
         /**
          * @brief Constructor
@@ -80,55 +80,34 @@ public:
          */
         TestConfig(const std::string& testName, std::function<void()> logic);
 
-        /**
-         * @brief Set environment variables for this test
-         * @param env Map of environment variable name-value pairs
-         * @return Reference to this TestConfig for method chaining
-         */
+        /// Set environment variables for this test.
         TestConfig& withEnvironment(const std::unordered_map<std::string, std::string>& env);
 
-        /**
-         * @brief Set timeout for this test
-         * @param timeoutSeconds Timeout in seconds
-         * @return Reference to this TestConfig for method chaining
-         */
+        /// Set the wall-clock timeout for this test.
         TestConfig& withTimeout(std::chrono::seconds timeoutSeconds);
 
         /**
-         * @brief Configure environment inheritance
-         * @param inherit Whether to inherit parent environment variables
-         * @return Reference to this TestConfig for method chaining
+         * @brief Configure environment inheritance.
+         * @param cleanEnv true (default) = start with a clean environment;
+         *                 false = inherit all parent environment variables.
          */
-        TestConfig& withCleanEnvironment(bool inherit = false);
+        TestConfig& withCleanEnvironment(bool cleanEnv = true);
 
-        /**
-         * @brief Clear a specific environment variable
-         * @param varName Name of the variable to clear
-         * @return Reference to this TestConfig for method chaining
-         */
+        /// Clear a specific environment variable before the test runs.
         TestConfig& clearVariable(const std::string& varName);
 
-        /**
-         * @brief Set a specific environment variable
-         * @param name Variable name
-         * @param value Variable value
-         * @return Reference to this TestConfig for method chaining
-         */
+        /// Set a specific environment variable for this test.
         TestConfig& setVariable(const std::string& name, const std::string& value);
 
         /**
          * @brief Declare how many GPU slots this test requires during parallel execution.
          *
-         * When the runner executes tests in parallel it partitions the GPU pool
-         * (see ExecutionOptions::gpuPool) into non-overlapping subsets and injects
-         * HIP_VISIBLE_DEVICES into each child so that concurrent tests never
-         * share a physical device.
+         * The runner partitions the GPU pool into non-overlapping subsets and injects
+         * HIP_VISIBLE_DEVICES so concurrent tests never share a physical device.
          *
-         * @param n Number of GPUs needed.
-         *          0 = CPU-only test, no GPU slot acquired (runs freely in parallel). Default.
-         *          1 = one dedicated GPU from the pool.
-         *          N = exactly N GPUs from the pool.
-         * @return Reference to this TestConfig for method chaining
+         * @param n kCpuOnly (0) = no slot acquired, runs freely in parallel (default).
+         *          1           = one dedicated GPU from the pool.
+         *          N           = exactly N GPUs from the pool.
          */
         TestConfig& withNumGpus(size_t n);
     };
@@ -225,7 +204,7 @@ private:
         int                  stderrPipe[2],
         pid_t                pid,
         int*                 status,
-        std::chrono::seconds timeout = std::chrono::seconds(0)
+        std::chrono::seconds timeout = std::chrono::seconds(kNoTimeoutSeconds)
     );
 
     /**
@@ -276,6 +255,15 @@ private:
         const std::vector<int>&        gpuPool,
         const SpawnFn&                 spawnFn);
 
+    /**
+     * @brief Generate and display test report
+     * @param options          Execution options used for the test run
+     * @param totalRegistered  Total number of tests registered (may differ from
+     *                         the number run when stopOnFirstFailure is active)
+     * @return True if no tests failed
+     */
+    static bool generateReport(const ExecutionOptions& options, size_t totalRegistered);
+
 public:
     /**
      * @brief Register a test configuration
@@ -316,16 +304,6 @@ public:
      *       after execution, ensuring a clean state for the next test suite.
      */
     static bool executeAllTests(const ExecutionOptions& options = ExecutionOptions());
-
-    /**
-     * @brief Generate and display test report
-     * @param options          Execution options used for the test run
-     * @param totalRegistered  Total number of tests that were registered (may
-     *                         differ from the number actually run when
-     *                         stopOnFirstFailure is active)
-     * @return True if no tests failed; tests not run due to stopOnFirstFailure do not count as failures
-     */
-    static bool generateReport(const ExecutionOptions& options, size_t totalRegistered);
 
     /**
      * @brief Get detailed test results (thread-safe)

--- a/projects/rccl/test/common/ProcessIsolatedTestRunner.hpp
+++ b/projects/rccl/test/common/ProcessIsolatedTestRunner.hpp
@@ -30,6 +30,9 @@ namespace RcclUnitTesting
 class ProcessIsolatedTestRunner
 {
 public:
+    /// Env var set before execv(); its presence in a re-exec'd child selects the test to run.
+    static constexpr const char* kReexecMarkerEnvVar = "RCCL_PIT_REEXEC_TEST";
+
     /**
      * @brief Test execution result structure
      */
@@ -135,11 +138,16 @@ public:
      */
     struct ExecutionOptions
     {
+        /// Special value for maxParallelJobs: use GPU pool size as the degree of
+        /// parallelism, falling back to std::thread::hardware_concurrency() when
+        /// no GPU pool is available.
+        static constexpr size_t kAutoParallelism = 0;
+
         bool   stopOnFirstFailure; ///< Stop execution on first test failure
         bool   verboseLogging;     ///< Enable verbose logging
         size_t maxParallelJobs;    ///< Maximum number of concurrent child processes.
                                    ///< 1 = sequential (default).
-                                   ///< 0 = GPU pool size, or hardware_concurrency() if no pool.
+                                   ///< kAutoParallelism (0) = GPU pool size, or hardware_concurrency() if no pool.
                                    ///< N > 1 = up to N tests run simultaneously.
                                    ///< Results are always reported in registration order.
 

--- a/projects/rccl/test/common/ProcessIsolatedTestRunner.hpp
+++ b/projects/rccl/test/common/ProcessIsolatedTestRunner.hpp
@@ -222,6 +222,17 @@ private:
      */
     static void displayCapturedOutput(const CapturedOutput& output, const std::string& testName);
 
+    /**
+     * @brief Handle re-exec child entrypoint
+     *
+     * If kReexecMarkerEnvVar is set, this process is a re-exec child:
+     * run the matching test lambda, flush coverage, and _exit().
+     * Returns normally only when called from the original parent process.
+     *
+     * @param tests Test configurations to search for the target
+     */
+    static void handleReexecEntrypoint(const std::vector<TestConfig>& tests);
+
 public:
     /**
      * @brief Register a test configuration

--- a/projects/rccl/test/common/ProcessIsolatedTestRunner.hpp
+++ b/projects/rccl/test/common/ProcessIsolatedTestRunner.hpp
@@ -62,11 +62,12 @@ public:
         bool                     inheritParentEnv;     ///< Whether to inherit parent environment
         std::vector<std::string> clearEnvVars; ///< Environment variables to explicitly clear
         size_t                   numGpus; ///< GPU slots this test needs.
-                                         ///< 0 = no GPU slot needed; test runs without any
-                                         ///<     HIP_VISIBLE_DEVICES restriction and does not
-                                         ///<     consume a pool slot (use for CPU-only tests).
-                                         ///< 1 = one dedicated GPU from the pool (default).
+                                         ///< 0 = no GPU slot needed (default); test runs
+                                         ///<     without any HIP_VISIBLE_DEVICES restriction
+                                         ///<     and does not consume a pool slot.
+                                         ///< 1 = one dedicated GPU from the pool.
                                          ///< N = exactly N GPUs from the pool.
+                                         ///< GPU tests should call withNumGpus(n) explicitly.
 
         /**
          * @brief Constructor
@@ -160,6 +161,7 @@ public:
         ExecutionOptions();
     };
 
+private:
     /**
      * @brief Structure to hold captured process output
      */
@@ -168,8 +170,6 @@ public:
         std::string stdoutContent; ///< Captured stdout content
         std::string stderrContent; ///< Captured stderr content
     };
-
-private:
     // Thread-safe static members for test management
     static std::mutex              testConfigsMutex_;
     static std::vector<TestConfig> testConfigs_;

--- a/projects/rccl/test/common/ProcessIsolatedTestRunner.hpp
+++ b/projects/rccl/test/common/ProcessIsolatedTestRunner.hpp
@@ -233,6 +233,36 @@ private:
      */
     static void handleReexecEntrypoint(const std::vector<TestConfig>& tests);
 
+    /// Return type for a single spawned test: result + captured output.
+    struct SpawnOutcome
+    {
+        TestResult     result;
+        CapturedOutput output;
+    };
+
+    /// Callable type for spawning one isolated test.
+    using SpawnFn = std::function<SpawnOutcome(const TestConfig&, const std::vector<int>&)>;
+
+    /**
+     * @brief Run tests one at a time (no GPU slot management).
+     */
+    static void runSequential(
+        const std::vector<TestConfig>& tests,
+        const ExecutionOptions&        opts,
+        const SpawnFn&                 spawnFn);
+
+    /**
+     * @brief Run tests with a bounded sliding window and GPU slot management.
+     * @param parallelism Maximum simultaneous child processes.
+     * @param gpuPool     Physical GPU indices available for slot assignment.
+     */
+    static void runParallel(
+        const std::vector<TestConfig>& tests,
+        const ExecutionOptions&        opts,
+        size_t                         parallelism,
+        const std::vector<int>&        gpuPool,
+        const SpawnFn&                 spawnFn);
+
 public:
     /**
      * @brief Register a test configuration

--- a/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
@@ -801,6 +801,11 @@ class TestExecutor:
         # an instrumented binary, writing per-PID profraw files on every process
         # exit is a significant overhead when many short-lived test processes
         # are spawned.
+        #
+        # %p  — unique per child PID (ProcessIsolatedTestRunner re-execs each
+        #        test as a separate process, so each gets its own file).
+        # %m  — binary/module signature (keeps test-binary and librccl.so
+        #        profiles in separate files since each has its own runtime).
         if self.args.coverage_report:
             env['LLVM_PROFILE_FILE'] = "rccl_tests_%p_%m.profraw"
 


### PR DESCRIPTION
## Motivation

The existing unit test framework ran all tests in a single process, making GPU resource conflicts and HIP state corruption between tests difficult to diagnose and impossible to avoid in parallel execution. This PR introduces a process-isolated test runner with coverage instrumentation support to enable reliable, parallelized GPU unit testing across all RCCL subsystems.

## Technical Details

ProcessIsolatedTestRunner (.cpp/.hpp) is redesigned around a fork+exec isolation model where each test is re-executed in a fresh child process with a dedicated GPU slot managed by GpuSlotManager, which sets HIP_VISIBLE_DEVICES to prevent multi-test GPU contention. Key fixes include: collision-free LLVM_PROFILE_FILE naming per process for code coverage (--coverage / -fprofile-arcs), poll-based interleaved pipe draining to eliminate deadlocks on large test output, null-byte/duplicate validation at test registration, and a single detectGpuPool() call shared between parallelism calculation and the slot manager. The monolithic executeAllTests was refactored into handleReexecEntrypoint, runSequential, and runParallel for clarity. Existing test files (EnqueueCountTests, NetSocketTests, RcclWrapTests) were updated to use the new exec model entry point macro.

## JIRA ID

[AICOMRCCL-1075]

## Test Plan

Ran the full RCCL unit test suite under both sequential and parallel modes (--parallel) on a multi-GPU system. Validated that each test receives an isolated GPU slot and that HIP_VISIBLE_DEVICES warnings fire correctly when an override is attempted.

## Test Result

All targeted unit tests pass in both sequential and parallel execution modes with no GPU resource conflicts; code coverage data is collected correctly per test process.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.


[AICOMRCCL-1075]: https://amd-hub.atlassian.net/browse/AICOMRCCL-1075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ