### PR TITLE
Implement ISA table append from internal JSON configuration

### DIFF
--- a/projects/clr/rocclr/CMakeLists.txt
+++ b/projects/clr/rocclr/CMakeLists.txt
@@ -10,3 +10,21 @@ endif()
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 include(ROCclr)
+
+# Install ISA table schema for documentation
+install(FILES
+  ${CMAKE_CURRENT_SOURCE_DIR}/device/isa_table_schema.json
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/share/rocclr
+  COMPONENT development
+  OPTIONAL
+)
+
+# Install internal ISA table if it exists (for internal builds with additional ISAs)
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/device/isa_table_internal.json)
+  install(FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/device/isa_table_internal.json
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/share/rocclr
+    COMPONENT runtime
+  )
+  message(STATUS "Will install internal ISA table")
+endif()

--- a/projects/clr/rocclr/cmake/ROCclr.cmake
+++ b/projects/clr/rocclr/cmake/ROCclr.cmake
@@ -49,6 +49,7 @@ target_sources(rocclr PRIVATE
   ${ROCCLR_SRC_DIR}/device/devhcprintf.cpp
   ${ROCCLR_SRC_DIR}/device/devhostcall.cpp
   ${ROCCLR_SRC_DIR}/device/device.cpp
+  ${ROCCLR_SRC_DIR}/device/isa_loader.cpp
   ${ROCCLR_SRC_DIR}/device/devkernel.cpp
   ${ROCCLR_SRC_DIR}/device/devprogram.cpp
   ${ROCCLR_SRC_DIR}/elf/elf.cpp

--- a/projects/clr/rocclr/device/device.cpp
+++ b/projects/clr/rocclr/device/device.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "device/device.hpp"
+#include "device/isa_loader.hpp"
 #include "thread/monitor.hpp"
 #include "utils/options.hpp"
 #include "comgrctx.hpp"
@@ -74,13 +75,20 @@ static_assert(static_cast<uint32_t>(device::Memory::MemAccess::kMemAccessReadWri
 namespace amd {
 
 std::recursive_mutex Device::lockP2P_;
-std::pair<const Isa*, const Isa*> Isa::supportedIsas() {
-  constexpr amd::Isa::Feature NONE = amd::Isa::Feature::Unsupported;
-  constexpr amd::Isa::Feature ANY = amd::Isa::Feature::Any;
-  constexpr amd::Isa::Feature OFF = amd::Isa::Feature::Disabled;
-  constexpr amd::Isa::Feature ON = amd::Isa::Feature::Enabled;
 
-  static constexpr Isa supportedIsas_[] = {
+// Static member initialization for ISA loader
+std::vector<Isa> Isa::runtimeIsas_;
+std::vector<std::string> Isa::targetIdStorage_;
+std::once_flag Isa::initFlag_;
+
+void Isa::initializeIsaTable() {
+  const amd::Isa::Feature NONE = amd::Isa::Feature::Unsupported;
+  const amd::Isa::Feature ANY = amd::Isa::Feature::Any;
+  const amd::Isa::Feature OFF = amd::Isa::Feature::Disabled;
+  const amd::Isa::Feature ON = amd::Isa::Feature::Enabled;
+
+  // Hardcoded ISA table - this is ALWAYS loaded first
+  static const Isa supportedIsas_[] = {
 
       // NOTE: Add new targets by adding rows for each permutation of the SRAMECC
       // and XNACK target feature values. If the target does not support the
@@ -248,7 +256,66 @@ std::pair<const Isa*, const Isa*> Isa::supportedIsas() {
       {"gfx1250", true, true, 12, 5, 0, NONE, NONE, 4, 32, 1, 256, 320* Ki, 64, 1024},
       {"gfx12-generic", true, true, 12, 0, 0, NONE, NONE, 2, 32, 1, 256, 64 * Ki, 32, 1024},
   };
-  return std::make_pair(std::begin(supportedIsas_), std::end(supportedIsas_));
+
+  // Step 1: Copy all hardcoded ISAs to runtime table
+  for (const auto& isa : supportedIsas_) {
+    targetIdStorage_.push_back(isa.targetId());
+  }
+
+  // Create runtime ISAs with stable pointers from storage
+  for (size_t i = 0; i < std::size(supportedIsas_); ++i) {
+    const auto& src = supportedIsas_[i];
+    runtimeIsas_.emplace_back(
+      targetIdStorage_[i].c_str(),
+      src.runtimeRocSupported(), src.runtimePalSupported(),
+      src.versionMajor(), src.versionMinor(), src.versionStepping(),
+      src.sramecc(), src.xnack(),
+      src.simdPerCU(), src.simdWidth(), src.simdInstructionWidth(),
+      src.memChannelBankWidth(), src.localMemSizePerCU(),
+      src.localMemBanks(), src.ldsAlignment()
+    );
+  }
+
+  size_t hardcodedCount = runtimeIsas_.size();
+  ClPrint(amd::LOG_INFO, amd::LOG_INIT, "Loaded %zu hardcoded ISAs", hardcodedCount);
+
+  // Step 2: Check for additional ISAs in .json file
+  std::string configFile = IsaLoader::findConfigFile();
+  if (!configFile.empty()) {
+    std::string errorMsg;
+    std::vector<Isa> additionalIsas;
+
+    if (IsaLoader::loadFromFile(configFile, additionalIsas,
+                                targetIdStorage_, errorMsg)) {
+      // Append additional ISAs to runtime table
+      runtimeIsas_.insert(runtimeIsas_.end(),
+                         additionalIsas.begin(),
+                         additionalIsas.end());
+
+      ClPrint(amd::LOG_INFO, amd::LOG_INIT, "Appended %zu ISAs from %s (total: %zu)",
+              additionalIsas.size(), configFile.c_str(), runtimeIsas_.size());
+    } else {
+      ClPrint(amd::LOG_WARNING, amd::LOG_INIT,
+              "Failed to load additional ISAs from %s: %s. Using hardcoded table only.",
+              configFile.c_str(), errorMsg.c_str());
+    }
+  } else {
+    ClPrint(amd::LOG_INFO, amd::LOG_INIT,
+            "No additional ISA config file found. Using %zu hardcoded ISAs only.",
+            hardcodedCount);
+  }
+}
+
+std::pair<const Isa*, const Isa*> Isa::supportedIsas() {
+  // Initialize ISA table on first call (thread-safe)
+  std::call_once(initFlag_, initializeIsaTable);
+
+  if (runtimeIsas_.empty()) {
+    return std::make_pair(nullptr, nullptr);
+  }
+
+  return std::make_pair(runtimeIsas_.data(),
+                       runtimeIsas_.data() + runtimeIsas_.size());
 }
 
 std::string Isa::processorName() const {

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -1632,12 +1632,12 @@ class Isa {
   /// @returns Iterator for one past the end isa.
   static const Isa* end();
 
- private:
-  constexpr Isa(const char* targetId, bool runtimeRocSupported, bool runtimePalSupported,
-                uint32_t versionMajor, uint32_t versionMinor, uint32_t versionStepping,
-                Feature sramecc, Feature xnack, uint32_t simdPerCU, uint32_t simdWidth,
-                uint32_t simdInstructionWidth, uint32_t memChannelBankWidth,
-                uint32_t localMemSizePerCU, uint32_t localMemBanks, uint32_t ldsAlignment)
+  // Constructor for runtime ISA creation
+  Isa(const char* targetId, bool runtimeRocSupported, bool runtimePalSupported,
+      uint32_t versionMajor, uint32_t versionMinor, uint32_t versionStepping,
+      Feature sramecc, Feature xnack, uint32_t simdPerCU, uint32_t simdWidth,
+      uint32_t simdInstructionWidth, uint32_t memChannelBankWidth,
+      uint32_t localMemSizePerCU, uint32_t localMemBanks, uint32_t ldsAlignment)
       : targetId_(targetId),
         runtimeRocSupported_(runtimeRocSupported),
         runtimePalSupported_(runtimePalSupported),
@@ -1654,8 +1654,21 @@ class Isa {
         localMemBanks_(localMemBanks),
         ldsAlignment_(ldsAlignment) {}
 
+ private:
   // @brief Returns the begin and end iterators for the suppported ISAs.
   static std::pair<const Isa*, const Isa*> supportedIsas();
+
+  // @brief Initialize ISA table from hardcoded entries and optional config file
+  static void initializeIsaTable();
+
+  // Runtime ISA table storage (hardcoded + appended from JSON)
+  static std::vector<Isa> runtimeIsas_;
+
+  // String storage for targetId pointers (ensures pointer stability)
+  static std::vector<std::string> targetIdStorage_;
+
+  // Initialization state
+  static std::once_flag initFlag_;
 
   // @brief Isa's target ID name. Used for LLVM COde Object Manager
   // compilations.

--- a/projects/clr/rocclr/device/isa_loader.cpp
+++ b/projects/clr/rocclr/device/isa_loader.cpp
@@ -1,0 +1,430 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "isa_loader.hpp"
+#include "device.hpp"
+#include "utils/debug.hpp"
+
+#include <fstream>
+#include <sstream>
+#include <algorithm>
+#include <cstdlib>
+#include <sys/stat.h>
+
+#ifdef __linux__
+#include <dlfcn.h>
+#include <libgen.h>
+#endif
+
+namespace amd {
+
+// Simple JSON parser for ISA table
+// This is a minimal implementation specific to our schema
+namespace {
+
+// Trim whitespace from string
+std::string trim(const std::string& str) {
+  size_t start = str.find_first_not_of(" \t\n\r");
+  if (start == std::string::npos) return "";
+  size_t end = str.find_last_not_of(" \t\n\r");
+  return str.substr(start, end - start + 1);
+}
+
+// Extract string value from JSON (handles "value" format)
+bool extractString(const std::string& json, size_t& pos, std::string& value) {
+  pos = json.find('"', pos);
+  if (pos == std::string::npos) return false;
+  pos++;  // Skip opening quote
+
+  size_t end = pos;
+  while (end < json.length()) {
+    if (json[end] == '"' && (end == 0 || json[end-1] != '\\')) {
+      value = json.substr(pos, end - pos);
+      pos = end + 1;
+      return true;
+    }
+    end++;
+  }
+  return false;
+}
+
+// Extract integer value from JSON
+bool extractInt(const std::string& json, size_t& pos, uint32_t& value) {
+  size_t start = json.find_first_of("0123456789", pos);
+  if (start == std::string::npos) return false;
+
+  size_t end = start;
+  while (end < json.length() && isdigit(json[end])) {
+    end++;
+  }
+
+  try {
+    value = std::stoul(json.substr(start, end - start));
+    pos = end;
+    return true;
+  } catch (...) {
+    return false;
+  }
+}
+
+// Extract boolean value from JSON
+bool extractBool(const std::string& json, size_t& pos, bool& value) {
+  size_t truePos = json.find("true", pos);
+  size_t falsePos = json.find("false", pos);
+
+  if (truePos != std::string::npos && (falsePos == std::string::npos || truePos < falsePos)) {
+    if (truePos - pos < 20) {  // Reasonable proximity
+      value = true;
+      pos = truePos + 4;
+      return true;
+    }
+  }
+  if (falsePos != std::string::npos && (truePos == std::string::npos || falsePos < truePos)) {
+    if (falsePos - pos < 20) {
+      value = false;
+      pos = falsePos + 5;
+      return true;
+    }
+  }
+  return false;
+}
+
+// Find next occurrence of a key in JSON
+size_t findKey(const std::string& json, const std::string& key, size_t start = 0) {
+  std::string searchStr = "\"" + key + "\"";
+  return json.find(searchStr, start);
+}
+
+}  // anonymous namespace
+
+bool IsaLoader::parseJson(const std::string& jsonContent,
+                         std::vector<IsaConfigEntry>& entries,
+                         std::string& errorMsg) {
+  // Find the "isas" array
+  size_t isasPos = findKey(jsonContent, "isas");
+  if (isasPos == std::string::npos) {
+    errorMsg = "Missing required 'isas' array in JSON";
+    return false;
+  }
+
+  // Find the array start
+  size_t arrayStart = jsonContent.find('[', isasPos);
+  if (arrayStart == std::string::npos) {
+    errorMsg = "Invalid 'isas' array format";
+    return false;
+  }
+
+  size_t arrayEnd = jsonContent.find(']', arrayStart);
+  if (arrayEnd == std::string::npos) {
+    errorMsg = "Unterminated 'isas' array";
+    return false;
+  }
+
+  // Parse each ISA entry (objects within the array)
+  size_t pos = arrayStart + 1;
+  int entryIndex = 0;
+
+  while (pos < arrayEnd) {
+    // Find next object start
+    size_t objStart = jsonContent.find('{', pos);
+    if (objStart == std::string::npos || objStart >= arrayEnd) {
+      break;  // No more entries
+    }
+
+    // Find corresponding object end
+    int braceCount = 1;
+    size_t objEnd = objStart + 1;
+    while (objEnd < arrayEnd && braceCount > 0) {
+      if (jsonContent[objEnd] == '{') braceCount++;
+      else if (jsonContent[objEnd] == '}') braceCount--;
+      objEnd++;
+    }
+
+    if (braceCount != 0) {
+      errorMsg = "Malformed JSON object at entry " + std::to_string(entryIndex);
+      return false;
+    }
+
+    // Parse this entry
+    IsaConfigEntry entry;
+    size_t entryPos = objStart;
+
+    // Parse each required field
+    #define PARSE_STRING_FIELD(name) \
+      { \
+        size_t keyPos = findKey(jsonContent, #name, entryPos); \
+        if (keyPos == std::string::npos || keyPos >= objEnd) { \
+          errorMsg = "Missing required field '" #name "' in ISA entry " + std::to_string(entryIndex); \
+          return false; \
+        } \
+        size_t valPos = keyPos; \
+        if (!extractString(jsonContent, valPos, entry.name)) { \
+          errorMsg = "Invalid value for '" #name "' in ISA entry " + std::to_string(entryIndex); \
+          return false; \
+        } \
+      }
+
+    #define PARSE_INT_FIELD(name) \
+      { \
+        size_t keyPos = findKey(jsonContent, #name, entryPos); \
+        if (keyPos == std::string::npos || keyPos >= objEnd) { \
+          errorMsg = "Missing required field '" #name "' in ISA entry " + std::to_string(entryIndex); \
+          return false; \
+        } \
+        size_t valPos = keyPos; \
+        if (!extractInt(jsonContent, valPos, entry.name)) { \
+          errorMsg = "Invalid value for '" #name "' in ISA entry " + std::to_string(entryIndex); \
+          return false; \
+        } \
+      }
+
+    #define PARSE_BOOL_FIELD(name) \
+      { \
+        size_t keyPos = findKey(jsonContent, #name, entryPos); \
+        if (keyPos == std::string::npos || keyPos >= objEnd) { \
+          errorMsg = "Missing required field '" #name "' in ISA entry " + std::to_string(entryIndex); \
+          return false; \
+        } \
+        size_t valPos = keyPos; \
+        if (!extractBool(jsonContent, valPos, entry.name)) { \
+          errorMsg = "Invalid value for '" #name "' in ISA entry " + std::to_string(entryIndex); \
+          return false; \
+        } \
+      }
+
+    PARSE_STRING_FIELD(targetId);
+    PARSE_BOOL_FIELD(runtimeRocSupported);
+    PARSE_BOOL_FIELD(runtimePalSupported);
+    PARSE_INT_FIELD(versionMajor);
+    PARSE_INT_FIELD(versionMinor);
+    PARSE_INT_FIELD(versionStepping);
+    PARSE_STRING_FIELD(sramecc);
+    PARSE_STRING_FIELD(xnack);
+    PARSE_INT_FIELD(simdPerCU);
+    PARSE_INT_FIELD(simdWidth);
+    PARSE_INT_FIELD(simdInstructionWidth);
+    PARSE_INT_FIELD(memChannelBankWidth);
+    PARSE_INT_FIELD(localMemSizePerCU);
+    PARSE_INT_FIELD(localMemBanks);
+    PARSE_INT_FIELD(ldsAlignment);
+
+    #undef PARSE_STRING_FIELD
+    #undef PARSE_INT_FIELD
+    #undef PARSE_BOOL_FIELD
+
+    entries.push_back(entry);
+    entryIndex++;
+    pos = objEnd;
+  }
+
+  return true;
+}
+
+int IsaLoader::parseFeature(const std::string& str) {
+  if (str == "Unsupported") return static_cast<int>(Isa::Feature::Unsupported);
+  if (str == "Any") return static_cast<int>(Isa::Feature::Any);
+  if (str == "Disabled") return static_cast<int>(Isa::Feature::Disabled);
+  if (str == "Enabled") return static_cast<int>(Isa::Feature::Enabled);
+  return static_cast<int>(Isa::Feature::Unsupported);  // Default fallback
+}
+
+bool IsaLoader::validateIsaEntry(const IsaConfigEntry& entry,
+                                const std::vector<IsaConfigEntry>& existingIsas,
+                                std::string& error) {
+  // Validate targetId format
+  if (entry.targetId.empty() || entry.targetId.substr(0, 3) != "gfx") {
+    error = "Invalid targetId '" + entry.targetId + "': must start with 'gfx'";
+    return false;
+  }
+
+  // Validate version ranges
+  if (entry.versionMajor > 255 || entry.versionMinor > 255 || entry.versionStepping > 255) {
+    error = "Invalid version " + std::to_string(entry.versionMajor) + "." +
+            std::to_string(entry.versionMinor) + "." +
+            std::to_string(entry.versionStepping) + ": values must be 0-255";
+    return false;
+  }
+
+  // Validate feature values
+  if (entry.sramecc != "Unsupported" && entry.sramecc != "Any" &&
+      entry.sramecc != "Disabled" && entry.sramecc != "Enabled") {
+    error = "Invalid sramecc value '" + entry.sramecc + "': must be Unsupported/Any/Disabled/Enabled";
+    return false;
+  }
+
+  if (entry.xnack != "Unsupported" && entry.xnack != "Any" &&
+      entry.xnack != "Disabled" && entry.xnack != "Enabled") {
+    error = "Invalid xnack value '" + entry.xnack + "': must be Unsupported/Any/Disabled/Enabled";
+    return false;
+  }
+
+  // Validate feature/targetId consistency
+  bool hasSrameccPlus = entry.targetId.find(":sramecc+") != std::string::npos;
+  bool hasSrameccMinus = entry.targetId.find(":sramecc-") != std::string::npos;
+  bool hasXnackPlus = entry.targetId.find(":xnack+") != std::string::npos;
+  bool hasXnackMinus = entry.targetId.find(":xnack-") != std::string::npos;
+
+  if (hasSrameccPlus && entry.sramecc != "Enabled") {
+    error = "targetId '" + entry.targetId + "' contains 'sramecc+' but field is '" + entry.sramecc + "'";
+    return false;
+  }
+
+  if (hasSrameccMinus && entry.sramecc != "Disabled") {
+    error = "targetId '" + entry.targetId + "' contains 'sramecc-' but field is '" + entry.sramecc + "'";
+    return false;
+  }
+
+  if (hasXnackPlus && entry.xnack != "Enabled") {
+    error = "targetId '" + entry.targetId + "' contains 'xnack+' but field is '" + entry.xnack + "'";
+    return false;
+  }
+
+  if (hasXnackMinus && entry.xnack != "Disabled") {
+    error = "targetId '" + entry.targetId + "' contains 'xnack-' but field is '" + entry.xnack + "'";
+    return false;
+  }
+
+  // Check for duplicates in loaded entries
+  for (const auto& existing : existingIsas) {
+    if (existing.targetId == entry.targetId) {
+      error = "Duplicate targetId '" + entry.targetId + "' found in JSON";
+      return false;
+    }
+  }
+
+  // Validate hardware properties
+  if (entry.simdPerCU != 2 && entry.simdPerCU != 4) {
+    ClPrint(amd::LOG_WARNING, amd::LOG_INIT,
+            "Unusual simdPerCU value %u for ISA '%s' (expected 2 or 4)",
+            entry.simdPerCU, entry.targetId.c_str());
+  }
+
+  if (entry.simdWidth != 16 && entry.simdWidth != 32 && entry.simdWidth != 64) {
+    ClPrint(amd::LOG_WARNING, amd::LOG_INIT,
+            "Unusual simdWidth value %u for ISA '%s' (expected 16, 32, or 64)",
+            entry.simdWidth, entry.targetId.c_str());
+  }
+
+  return true;
+}
+
+bool IsaLoader::fileExists(const std::string& path) {
+  struct stat buffer;
+  return (stat(path.c_str(), &buffer) == 0);
+}
+
+bool IsaLoader::readFile(const std::string& path, std::string& content) {
+  std::ifstream file(path);
+  if (!file.is_open()) {
+    return false;
+  }
+
+  std::stringstream buffer;
+  buffer << file.rdbuf();
+  content = buffer.str();
+  return true;
+}
+
+std::string IsaLoader::parentDir(const std::string& path) {
+#ifdef __linux__
+  char* pathCopy = strdup(path.c_str());
+  char* dir = dirname(pathCopy);
+  std::string result(dir);
+  free(pathCopy);
+  return result;
+#else
+  size_t pos = path.find_last_of("/\\");
+  if (pos == std::string::npos) return ".";
+  return path.substr(0, pos);
+#endif
+}
+
+std::string IsaLoader::findConfigFile() {
+  // 1. Check environment variable override
+  const char* envPath = std::getenv("ROCCLR_ISA_CONFIG_FILE");
+  if (envPath && fileExists(envPath)) {
+    return std::string(envPath);
+  }
+
+  // 2. Check ROCm install location
+  const char* rocmPath = std::getenv("ROCM_PATH");
+  std::string installPath = rocmPath ? rocmPath : "/opt/rocm";
+  std::string configPath = installPath + "/share/rocclr/isa_table_internal.json";
+  if (fileExists(configPath)) {
+    return configPath;
+  }
+
+  // 3. Check development build location (relative to library)
+#ifdef __linux__
+  Dl_info dlInfo;
+  if (dladdr(reinterpret_cast<void*>(&IsaLoader::findConfigFile), &dlInfo)) {
+    std::string libPath = dlInfo.dli_fname;
+    std::string devPath = parentDir(libPath) + "/../share/rocclr/isa_table_internal.json";
+    if (fileExists(devPath)) {
+      return devPath;
+    }
+  }
+#endif
+
+  // Not found - this is OK, hardcoded table is sufficient
+  return "";
+}
+
+bool IsaLoader::loadFromFile(const std::string& filePath,
+                            std::vector<Isa>& isas,
+                            std::vector<std::string>& stringStorage,
+                            std::string& errorMsg) {
+  // Read file content
+  std::string jsonContent;
+  if (!readFile(filePath, jsonContent)) {
+    errorMsg = "Failed to read file: " + filePath;
+    return false;
+  }
+
+  // Parse JSON
+  std::vector<IsaConfigEntry> entries;
+  if (!parseJson(jsonContent, entries, errorMsg)) {
+    return false;
+  }
+
+  // Validate and convert each entry
+  for (size_t i = 0; i < entries.size(); ++i) {
+    const auto& entry = entries[i];
+
+    // Validate against previously loaded entries
+    std::vector<IsaConfigEntry> previousEntries(entries.begin(), entries.begin() + i);
+    if (!validateIsaEntry(entry, previousEntries, errorMsg)) {
+      return false;
+    }
+
+    // Store targetId string for pointer stability
+    stringStorage.push_back(entry.targetId);
+    const char* targetIdPtr = stringStorage.back().c_str();
+
+    // Create Isa with stable pointer
+    isas.emplace_back(
+      targetIdPtr,
+      entry.runtimeRocSupported,
+      entry.runtimePalSupported,
+      entry.versionMajor,
+      entry.versionMinor,
+      entry.versionStepping,
+      static_cast<Isa::Feature>(parseFeature(entry.sramecc)),
+      static_cast<Isa::Feature>(parseFeature(entry.xnack)),
+      entry.simdPerCU,
+      entry.simdWidth,
+      entry.simdInstructionWidth,
+      entry.memChannelBankWidth,
+      entry.localMemSizePerCU,
+      entry.localMemBanks,
+      entry.ldsAlignment
+    );
+  }
+
+  return true;
+}
+
+}  // namespace amd

--- a/projects/clr/rocclr/device/isa_loader.hpp
+++ b/projects/clr/rocclr/device/isa_loader.hpp
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef ISA_LOADER_HPP_
+#define ISA_LOADER_HPP_
+
+#include <string>
+#include <vector>
+#include <cstdint>
+
+namespace amd {
+
+// Forward declaration
+class Isa;
+
+// Intermediate representation for ISA entries from JSON
+struct IsaConfigEntry {
+  std::string targetId;
+  bool runtimeRocSupported;
+  bool runtimePalSupported;
+  uint32_t versionMajor;
+  uint32_t versionMinor;
+  uint32_t versionStepping;
+  std::string sramecc;  // "Unsupported", "Any", "Disabled", "Enabled"
+  std::string xnack;    // "Unsupported", "Any", "Disabled", "Enabled"
+  uint32_t simdPerCU;
+  uint32_t simdWidth;
+  uint32_t simdInstructionWidth;
+  uint32_t memChannelBankWidth;
+  uint32_t localMemSizePerCU;
+  uint32_t localMemBanks;
+  uint32_t ldsAlignment;
+};
+
+/**
+ * @brief ISA configuration loader
+ *
+ * Responsible for loading, parsing, and validating ISA configurations
+ * from internal JSON files. These ISAs are appended to the hardcoded
+ * ISA table at runtime.
+ */
+class IsaLoader {
+ public:
+  /**
+   * @brief Load ISAs from JSON file
+   *
+   * @param filePath Path to JSON configuration file
+   * @param isas Output vector to append loaded ISA objects
+   * @param stringStorage String storage for targetId stability
+   * @param errorMsg Output error message if loading fails
+   * @return true if loading succeeded, false otherwise
+   */
+  static bool loadFromFile(const std::string& filePath,
+                          std::vector<Isa>& isas,
+                          std::vector<std::string>& stringStorage,
+                          std::string& errorMsg);
+
+  /**
+   * @brief Find ISA configuration file location
+   *
+   * Searches in order:
+   * 1. ROCCLR_ISA_CONFIG_FILE environment variable
+   * 2. $ROCM_PATH/share/rocclr/isa_table_internal.json
+   * 3. Relative to library location (for development builds)
+   *
+   * @return Path to config file, or empty string if not found
+   */
+  static std::string findConfigFile();
+
+  /**
+   * @brief Validate ISA entry for consistency
+   *
+   * Checks:
+   * - Feature/targetId consistency (e.g., sramecc+ must have Enabled)
+   * - Version ranges
+   * - Hardware property ranges
+   *
+   * @param entry ISA configuration entry to validate
+   * @param existingIsas Existing ISAs to check for duplicates
+   * @param error Output error message if validation fails
+   * @return true if valid, false otherwise
+   */
+  static bool validateIsaEntry(const IsaConfigEntry& entry,
+                               const std::vector<IsaConfigEntry>& existingIsas,
+                               std::string& error);
+
+ private:
+  /**
+   * @brief Parse JSON content to intermediate representation
+   *
+   * @param jsonContent JSON file content as string
+   * @param entries Output vector of parsed ISA entries
+   * @param errorMsg Output error message if parsing fails
+   * @return true if parsing succeeded, false otherwise
+   */
+  static bool parseJson(const std::string& jsonContent,
+                       std::vector<IsaConfigEntry>& entries,
+                       std::string& errorMsg);
+
+  /**
+   * @brief Convert feature string to Feature enum
+   *
+   * @param str Feature string ("Unsupported", "Any", "Disabled", "Enabled")
+   * @return Corresponding Isa::Feature enum value
+   */
+  static int parseFeature(const std::string& str);
+
+  /**
+   * @brief Check if file exists
+   *
+   * @param path File path to check
+   * @return true if file exists and is readable
+   */
+  static bool fileExists(const std::string& path);
+
+  /**
+   * @brief Read entire file into string
+   *
+   * @param path File path to read
+   * @param content Output file content
+   * @return true if read succeeded, false otherwise
+   */
+  static bool readFile(const std::string& path, std::string& content);
+
+  /**
+   * @brief Get parent directory of a path
+   *
+   * @param path File or directory path
+   * @return Parent directory path
+   */
+  static std::string parentDir(const std::string& path);
+};
+
+}  // namespace amd
+
+#endif  // ISA_LOADER_HPP_

--- a/projects/clr/rocclr/device/isa_table_internal_example.json
+++ b/projects/clr/rocclr/device/isa_table_internal_example.json
@@ -1,0 +1,40 @@
+{
+  "version": "1.0",
+  "comment": "Example ISA table - demonstrates the append functionality for adding additional GPU architectures. Rename to isa_table_internal.json to activate.",
+  "isas": [
+    {
+      "targetId": "gfx9999",
+      "runtimeRocSupported": true,
+      "runtimePalSupported": false,
+      "versionMajor": 9,
+      "versionMinor": 99,
+      "versionStepping": 9,
+      "sramecc": "Any",
+      "xnack": "Any",
+      "simdPerCU": 4,
+      "simdWidth": 16,
+      "simdInstructionWidth": 1,
+      "memChannelBankWidth": 256,
+      "localMemSizePerCU": 65536,
+      "localMemBanks": 32,
+      "ldsAlignment": 512
+    },
+    {
+      "targetId": "gfx9999:sramecc+:xnack-",
+      "runtimeRocSupported": true,
+      "runtimePalSupported": false,
+      "versionMajor": 9,
+      "versionMinor": 99,
+      "versionStepping": 9,
+      "sramecc": "Enabled",
+      "xnack": "Disabled",
+      "simdPerCU": 4,
+      "simdWidth": 16,
+      "simdInstructionWidth": 1,
+      "memChannelBankWidth": 256,
+      "localMemSizePerCU": 65536,
+      "localMemBanks": 32,
+      "ldsAlignment": 512
+    }
+  ]
+}

--- a/projects/clr/rocclr/device/isa_table_schema.json
+++ b/projects/clr/rocclr/device/isa_table_schema.json
@@ -1,0 +1,125 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ROCclr ISA Table Schema",
+  "description": "Schema for additional ISA (Instruction Set Architecture) definitions to append to the hardcoded ISA table",
+  "type": "object",
+  "required": ["version", "isas"],
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "Schema version for compatibility checking",
+      "pattern": "^[0-9]+\\.[0-9]+$"
+    },
+    "comment": {
+      "type": "string",
+      "description": "Optional comment describing the purpose of this ISA table"
+    },
+    "isas": {
+      "type": "array",
+      "description": "Array of ISA specifications to append to hardcoded table",
+      "items": {
+        "type": "object",
+        "required": [
+          "targetId",
+          "runtimeRocSupported",
+          "runtimePalSupported",
+          "versionMajor",
+          "versionMinor",
+          "versionStepping",
+          "sramecc",
+          "xnack",
+          "simdPerCU",
+          "simdWidth",
+          "simdInstructionWidth",
+          "memChannelBankWidth",
+          "localMemSizePerCU",
+          "localMemBanks",
+          "ldsAlignment"
+        ],
+        "properties": {
+          "targetId": {
+            "type": "string",
+            "description": "Target ID string (e.g., 'gfx942:sramecc+:xnack-'). Must start with 'gfx' followed by digits, optionally followed by feature flags.",
+            "pattern": "^gfx[0-9]+(-generic)?(:[a-z]+[+-])*$"
+          },
+          "runtimeRocSupported": {
+            "type": "boolean",
+            "description": "Whether ROCm runtime supports this ISA"
+          },
+          "runtimePalSupported": {
+            "type": "boolean",
+            "description": "Whether PAL runtime supports this ISA"
+          },
+          "versionMajor": {
+            "type": "integer",
+            "description": "ISA major version (0-255)",
+            "minimum": 0,
+            "maximum": 255
+          },
+          "versionMinor": {
+            "type": "integer",
+            "description": "ISA minor version (0-255)",
+            "minimum": 0,
+            "maximum": 255
+          },
+          "versionStepping": {
+            "type": "integer",
+            "description": "ISA stepping version (0-255)",
+            "minimum": 0,
+            "maximum": 255
+          },
+          "sramecc": {
+            "type": "string",
+            "description": "SRAM ECC feature status",
+            "enum": ["Unsupported", "Any", "Disabled", "Enabled"]
+          },
+          "xnack": {
+            "type": "string",
+            "description": "XNACK feature status",
+            "enum": ["Unsupported", "Any", "Disabled", "Enabled"]
+          },
+          "simdPerCU": {
+            "type": "integer",
+            "description": "Number of SIMDs per compute unit",
+            "minimum": 1,
+            "maximum": 16
+          },
+          "simdWidth": {
+            "type": "integer",
+            "description": "Number of workitems processed per SIMD",
+            "minimum": 1,
+            "maximum": 128
+          },
+          "simdInstructionWidth": {
+            "type": "integer",
+            "description": "Number of instructions processed per SIMD",
+            "minimum": 1,
+            "maximum": 16
+          },
+          "memChannelBankWidth": {
+            "type": "integer",
+            "description": "Memory channel bank width in bytes",
+            "minimum": 1
+          },
+          "localMemSizePerCU": {
+            "type": "integer",
+            "description": "Local memory (LDS) size per compute unit in bytes",
+            "minimum": 0
+          },
+          "localMemBanks": {
+            "type": "integer",
+            "description": "Number of banks of local memory",
+            "minimum": 1
+          },
+          "ldsAlignment": {
+            "type": "integer",
+            "description": "LDS alignment requirement in bytes",
+            "minimum": 1
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
Key changes:
- Keep all 167 hardcoded ISAs in device.cpp (unchanged for performance)
- Add IsaLoader class to parse and validate JSON ISA configurations
- Append ISAs from isa_table_internal.json if present (internal builds only)
- Validate JSON schema and ISA entry consistency at load time
- Use std::vector for runtime storage with stable pointer guarantees

Architecture:
- Public/develop: No .json file → only 167 hardcoded ISAs used
- Internal branch: With .json file → hardcoded + appended ISAs
- Release process: Move ISAs from .json to device.cpp for optimal performance

Files added:
- rocclr/device/isa_loader.hpp: ISA loader interface
- rocclr/device/isa_loader.cpp: JSON parsing and validation logic
- rocclr/device/isa_table_schema.json: JSON schema for validation
- rocclr/device/isa_table_internal_example.json: Example internal ISA table

Files modified:
- rocclr/device/device.hpp: Add runtime storage and initialization
- rocclr/device/device.cpp: Implement append logic in initializeIsaTable()
- rocclr/cmake/ROCclr.cmake: Add isa_loader.cpp to build
- rocclr/CMakeLists.txt: Install schema and optional internal table

Configuration:
- Default: /opt/rocm/share/rocclr/isa_table_internal.json
- Override: ROCCLR_ISA_CONFIG_FILE environment variable
- Graceful fallback: Works perfectly without .json file

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
