### PR TITLE
AIRUNTIME-2154 - Resolve librocm_smi64.so at runtime in P2P test

### DIFF
--- a/projects/hip-tests/catch/CMakeLists.txt
+++ b/projects/hip-tests/catch/CMakeLists.txt
@@ -80,9 +80,6 @@ if(HIP_HIPCC_EXECUTABLE)
   add_definitions(-DHIP_HIPCC_EXECUTABLE="${HIP_HIPCC_EXECUTABLE}")
 endif()
 
-# Make Rocm lib path available for runtime dlopen (e.g., librocm_smi64.so)
-add_definitions(-DROCM_SMI_LIB_DIR="${ROCM_PATH}/lib")
-
 if(TEST_CLOCK_CYCLE)
   add_definitions(-DTEST_CLOCK_CYCLE)
 endif()

--- a/projects/hip-tests/catch/unit/p2p/hipP2pLinkTypeAndHopFunc.cc
+++ b/projects/hip-tests/catch/unit/p2p/hipP2pLinkTypeAndHopFunc.cc
@@ -195,13 +195,15 @@ bool testhipLinkTypeHopcountDevice(int numDevices) {
   rsmi_status_t (*fntopo_init)(uint64_t);
   rsmi_status_t (*fntopo_shut_down)();
 
-  // Use ROCM_SMI_LIB_DIR from CMake instead of hardcoding to /opt/rocm
-#ifdef ROCM_SMI_LIB_DIR
-  std::string rocm_smi_path = std::string(ROCM_SMI_LIB_DIR) + "/librocm_smi64.so";
-#else
-  std::string rocm_smi_path = "librocm_smi64.so";
-#endif
-  lib_rocm_smi_hdl = dlopen(rocm_smi_path.c_str(), RTLD_LAZY);
+  lib_rocm_smi_hdl = dlopen("librocm_smi64.so", RTLD_LAZY);
+  if (lib_rocm_smi_hdl == nullptr) {
+    if (const char* rocmPath = std::getenv("ROCM_PATH")) {
+      std::string libPath = std::string(rocmPath) + "/lib/librocm_smi64.so";
+      lib_rocm_smi_hdl = dlopen(libPath.c_str(), RTLD_LAZY);
+    } else {
+      lib_rocm_smi_hdl = dlopen("/opt/rocm/lib/librocm_smi64.so", RTLD_LAZY);
+    }
+  }
   REQUIRE(lib_rocm_smi_hdl);
 
   void* fnsym = dlsym(lib_rocm_smi_hdl, "rsmi_topo_get_link_type");


### PR DESCRIPTION
## Motivation

`Unit_hipP2pLinkTypeAndHopFunc` fails on TheRock-built ROCm distributions because the test searches for `librocm_smi64.so` at a path baked in at compile time, which may not exist on the machine where the tests are executed. This PR changes the logic to resolve the library at runtime as opposed to a path determined at build time.

## Technical Details

The single dlopen call with the compile-time path is now replaced with a runtime fallback chain. First, we check the bare soname (which will search for the shared library in the RUNPATH and LD_LIBRARY_PATH paths). Second, we check `$ROCM_PATH/lib/librocm_smi64.so`. Finally, if ROCM_PATH is not set, we check `/opt/rocm/lib/librocm_smi64.so` as a last resort. This mirrors the existing convention in catch/unit/dynamicLoading/hipGetProcAddress.cc, which performs the same three-stage lookup for libamdhip64.so. 

The now-unused `add_definitions(-DROCM_SMI_LIB_DIR=...)` line in catch/CMakeLists.txt is removed.

## JIRA ID

AIRUNTIME-2154

## Test Plan

Build HIP and run P2P tests locally.

## Test Result

Build succeeds and tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
