### PR TITLE
[hip-tests] Unit_hipEventOverFlow_PerfTest support multi gpu

### DIFF
--- a/projects/hip-tests/catch/performance/scenarios/event/hipEventOverflowPerf.cc
+++ b/projects/hip-tests/catch/performance/scenarios/event/hipEventOverflowPerf.cc
@@ -35,7 +35,7 @@ void rocm_null_gpu_job(void* stream) {
 std::vector<std::vector<hipStream_t>> stream_pool;
 std::atomic<int> counter(0);
 bool do_kill = false;
-std::chrono::system_clock::time_point thread_reports[16];
+std::vector<std::chrono::system_clock::time_point> thread_reports;
 void thread_job(int dev, int virt) {
   HIP_CHECK_PERF(hipSetDevice(dev));  // use dev
   uint8_t* mem;
@@ -96,7 +96,7 @@ HIP_TEST_CASE(Performance_hipEventOverflow) {
   HIP_CHECK_PERF(hipGetDeviceCount(&mgpu));
   stream_pool.resize(mgpu);
   HIP_CHECK_PERF(hipSetDeviceFlags(hipDeviceScheduleSpin));
-  std::vector<uint8_t*> memory_buffers[2];
+  std::vector<std::vector<uint8_t*>> memory_buffers(mgpu);
   for (int i = 0; i < mgpu; i++) {
     HIP_CHECK_PERF(hipSetDevice(i));
     stream_pool[i].resize(12);
@@ -106,6 +106,7 @@ HIP_TEST_CASE(Performance_hipEventOverflow) {
     for (int j = 0; j < 128; j++)
       HIP_CHECK_PERF(hipMalloc(&memory_buffers[i][j], 4096 * ((j & 1) + 1)));
   }
+  thread_reports.resize(mgpu * 4);
   for (int nDev = 1; nDev <= mgpu; nDev++) {
     counter = 0;
     printf("RUNNING ON %d DEVICES\n", nDev);
@@ -140,6 +141,11 @@ HIP_TEST_CASE(Performance_hipEventOverflow) {
       HIP_CHECK_PERF(hipSetDevice(i));
       HIP_CHECK_PERF(hipDeviceSynchronize());
     }
+  }
+  for (int i = 0; i < mgpu; i++) {
+    HIP_CHECK_PERF(hipSetDevice(i));
+    for (auto* buf : memory_buffers[i]) HIP_CHECK_PERF(hipFree(buf));
+    for (auto s : stream_pool[i]) HIP_CHECK_PERF(hipStreamDestroy(s));
   }
 }
 /**

--- a/projects/hip-tests/catch/performance/scenarios/event/hipEventOverflowPerf.cc
+++ b/projects/hip-tests/catch/performance/scenarios/event/hipEventOverflowPerf.cc
@@ -10,14 +10,7 @@
 #include <hip_test_defgroups.hh>
 #include <unistd.h>
 #include <vector>
-#define HIP_CHECK_PERF(a)                                                                          \
-  {                                                                                                \
-    auto err = a;                                                                                  \
-    if ((err != hipSuccess) && (err != hipErrorNotReady)) {                                        \
-      printf(#a "= Error! %s\n", hipGetErrorString(err));                                          \
-      exit(1);                                                                                     \
-    }                                                                                              \
-  }
+#include "hipPerfCommon.hh"
 /**
  * @addtogroup hipEventRecord hipEventRecord
  * @{
@@ -34,8 +27,8 @@ void rocm_null_gpu_job(void* stream) {
 }
 std::vector<std::vector<hipStream_t>> stream_pool;
 std::atomic<int> counter(0);
-bool do_kill = false;
-std::vector<std::chrono::system_clock::time_point> thread_reports;
+std::atomic<bool> do_kill{false};
+std::vector<PaddedTimestamp> thread_reports;
 void thread_job(int dev, int virt) {
   HIP_CHECK_PERF(hipSetDevice(dev));  // use dev
   uint8_t* mem;
@@ -63,7 +56,11 @@ void thread_job(int dev, int virt) {
       HIP_CHECK_PERF(hipStreamSynchronize(exec_stream));
       HIP_CHECK_PERF(hipStreamSynchronize(h2d_stream));
       HIP_CHECK_PERF(hipStreamSynchronize(d2h_stream));
-      thread_reports[dev * 4 + virt] = std::chrono::system_clock::now();
+      thread_reports[dev * 4 + virt].ns.store(
+          std::chrono::duration_cast<std::chrono::nanoseconds>(
+              std::chrono::system_clock::now().time_since_epoch())
+              .count(),
+          std::memory_order_relaxed);
     }
     counter++;
   }
@@ -106,7 +103,9 @@ HIP_TEST_CASE(Performance_hipEventOverflow) {
     for (int j = 0; j < 128; j++)
       HIP_CHECK_PERF(hipMalloc(&memory_buffers[i][j], 4096 * ((j & 1) + 1)));
   }
-  thread_reports.resize(mgpu * 4);
+  // std::atomic is non-movable, so the vector cannot be resized — construct
+  // it at the required size and move-assign it into the global.
+  thread_reports = std::vector<PaddedTimestamp>(mgpu * 4);
   for (int nDev = 1; nDev <= mgpu; nDev++) {
     counter = 0;
     printf("RUNNING ON %d DEVICES\n", nDev);
@@ -123,9 +122,12 @@ HIP_TEST_CASE(Performance_hipEventOverflow) {
       auto t2 = std::chrono::system_clock::now();
       auto duration = std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count();
       int count2 = int(counter);
+      int64_t t2_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                          t2.time_since_epoch())
+                          .count();
       for (int i = 0; i < nDev * 4; i++) {
-        if (std::chrono::duration_cast<std::chrono::microseconds>(t2 - thread_reports[i]).count() >=
-            1000000) {
+        int64_t slot_ns = thread_reports[i].ns.load(std::memory_order_relaxed);
+        if ((t2_ns - slot_ns) / 1000 >= 1000000) {
           printf("Thread %d/%d is stuck\n", i / 4, i % 4);
         }
       }

--- a/projects/hip-tests/catch/performance/scenarios/event/hipEventOverflowPerf.cc
+++ b/projects/hip-tests/catch/performance/scenarios/event/hipEventOverflowPerf.cc
@@ -144,8 +144,8 @@ HIP_TEST_CASE(Performance_hipEventOverflow) {
       HIP_CHECK_PERF(hipDeviceSynchronize());
     }
   }
+  HIP_CHECK_PERF(hipSetDevice(0));
   for (int i = 0; i < mgpu; i++) {
-    HIP_CHECK_PERF(hipSetDevice(i));
     for (auto* buf : memory_buffers[i]) HIP_CHECK_PERF(hipFree(buf));
     for (auto s : stream_pool[i]) HIP_CHECK_PERF(hipStreamDestroy(s));
   }

--- a/projects/hip-tests/catch/performance/scenarios/event/hipKernelLookupPerf.cc
+++ b/projects/hip-tests/catch/performance/scenarios/event/hipKernelLookupPerf.cc
@@ -113,8 +113,8 @@ HIP_TEST_CASE(Performance_hipKernelLookup) {
       HIP_CHECK_PERF(hipDeviceSynchronize());
     }
   }
+  HIP_CHECK_PERF(hipSetDevice(0));
   for (int i = 0; i < mgpu; i++) {
-    HIP_CHECK_PERF(hipSetDevice(i));
     for (auto s : stream_pools[i]) HIP_CHECK_PERF(hipStreamDestroy(s));
   }
 }

--- a/projects/hip-tests/catch/performance/scenarios/event/hipKernelLookupPerf.cc
+++ b/projects/hip-tests/catch/performance/scenarios/event/hipKernelLookupPerf.cc
@@ -10,14 +10,7 @@
 #include <hip_test_defgroups.hh>
 #include <unistd.h>
 #include <vector>
-#define HIP_CHECK_PERF(a)                                                                          \
-  {                                                                                                \
-    auto err = a;                                                                                  \
-    if ((err != hipSuccess) && (err != hipErrorNotReady)) {                                        \
-      printf(#a "= Error! %s\n", hipGetErrorString(err));                                          \
-      exit(1);                                                                                     \
-    }                                                                                              \
-  }
+#include "hipPerfCommon.hh"
 /**
  * @addtogroup hipLaunchKernelGGL hipLaunchKernelGGL
  * @{
@@ -32,8 +25,8 @@ void rocm_empty_gpu_job(void* stream) {
 }
 std::vector<std::vector<hipStream_t>> stream_pools;
 std::atomic<int> count(0);
-bool kill = false;
-std::chrono::system_clock::time_point thread_report[16];
+std::atomic<bool> kill{false};
+std::vector<PaddedTimestamp> thread_report;
 void thread_jobs(int dev, int virt) {
   HIP_CHECK_PERF(hipSetDevice(dev));
   hipStream_t exec_stream = stream_pools[dev][virt];
@@ -43,7 +36,11 @@ void thread_jobs(int dev, int virt) {
     n++;
     if ((n & 150) == 0) {
       HIP_CHECK_PERF(hipStreamSynchronize(exec_stream));
-      thread_report[dev * 4 + virt] = std::chrono::system_clock::now();
+      thread_report[dev * 4 + virt].ns.store(
+          std::chrono::duration_cast<std::chrono::nanoseconds>(
+              std::chrono::system_clock::now().time_since_epoch())
+              .count(),
+          std::memory_order_relaxed);
     }
     count++;
   }
@@ -75,6 +72,9 @@ HIP_TEST_CASE(Performance_hipKernelLookup) {
     for (int j = 0; j < 12; j++)
       HIP_CHECK_PERF(hipStreamCreateWithFlags(&stream_pools[i][j], hipStreamNonBlocking));
   }
+  // std::atomic is non-movable, so the vector cannot be resized — construct
+  // it at the required size and move-assign it into the global.
+  thread_report = std::vector<PaddedTimestamp>(mgpu * 4);
   for (int nDev = 1; nDev <= mgpu; nDev++) {
     count = 0;
     INFO("RUNNING ON " << nDev << " DEVICES\n");
@@ -91,9 +91,12 @@ HIP_TEST_CASE(Performance_hipKernelLookup) {
       auto t2 = std::chrono::system_clock::now();
       auto duration = std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count();
       int counter2 = int(count);
+      int64_t t2_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                          t2.time_since_epoch())
+                          .count();
       for (int i = 0; i < nDev * 4; i++) {
-        if (std::chrono::duration_cast<std::chrono::microseconds>(t2 - thread_report[i]).count() >=
-            1000000) {
+        int64_t slot_ns = thread_report[i].ns.load(std::memory_order_relaxed);
+        if ((t2_ns - slot_ns) / 1000 >= 1000000) {
           INFO("Thread " << i / 4 << "/" << i % 4 << " is stuck\n");
         }
       }
@@ -109,6 +112,10 @@ HIP_TEST_CASE(Performance_hipKernelLookup) {
       HIP_CHECK_PERF(hipSetDevice(i));
       HIP_CHECK_PERF(hipDeviceSynchronize());
     }
+  }
+  for (int i = 0; i < mgpu; i++) {
+    HIP_CHECK_PERF(hipSetDevice(i));
+    for (auto s : stream_pools[i]) HIP_CHECK_PERF(hipStreamDestroy(s));
   }
 }
 /**

--- a/projects/hip-tests/catch/performance/scenarios/event/hipPerfCommon.hh
+++ b/projects/hip-tests/catch/performance/scenarios/event/hipPerfCommon.hh
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+
+#define HIP_CHECK_PERF(a)                                                                          \
+  {                                                                                                \
+    auto err = a;                                                                                  \
+    if ((err != hipSuccess) && (err != hipErrorNotReady)) {                                        \
+      printf(#a "= Error! %s\n", hipGetErrorString(err));                                          \
+      exit(1);                                                                                     \
+    }                                                                                              \
+  }
+
+// Padded atomic timestamp slot. Each slot holds nanoseconds-since-epoch and is
+// aligned/padded to a cache line so that adjacent worker threads writing their
+// own slots do not invalidate each other's cache lines (false sharing).
+#ifdef __cpp_lib_hardware_interference_size
+static constexpr size_t kCacheLineSize = std::hardware_destructive_interference_size;
+#else
+static constexpr size_t kCacheLineSize = 64;
+#endif
+struct alignas(kCacheLineSize) PaddedTimestamp {
+  std::atomic<int64_t> ns{0};
+  // Pad out the rest of the cache line so neighboring slots live on
+  // independent lines and writes from one thread don't ping-pong another's
+  // cache line.
+  char pad[kCacheLineSize - sizeof(std::atomic<int64_t>)];
+};


### PR DESCRIPTION
## Motivation

Unit_hipEventOverFlow_PerfTest fails on machines with more than one GPU.

## Technical Details

Update the test to dynamically resize variables based on the nubmer of devices

## JIRA ID

ROCM-25208

## Test Plan

Perf test runs on 8 GPU machine 

## Test Result

No longer returns error codes

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
