### PR TITLE
[hipfile] Get version #s in hipfile.h from CMake

### DIFF
--- a/projects/hipfile/CMakeLists.txt
+++ b/projects/hipfile/CMakeLists.txt
@@ -16,20 +16,23 @@ endif()
 
 # Set the library version in a variable so we can use
 # it in *.in files and avoid version mismatch.
-set(AIS_LIBRARY_MAJOR 0)
-set(AIS_LIBRARY_MINOR 2)
-set(AIS_LIBRARY_PATCH 0)
-set(AIS_LIBRARY_VERSION "${AIS_LIBRARY_MAJOR}.${AIS_LIBRARY_MINOR}.${AIS_LIBRARY_PATCH}")
+set(HIPFILE_LIBRARY_MAJOR 0)
+set(HIPFILE_LIBRARY_MINOR 2)
+set(HIPFILE_LIBRARY_PATCH 0)
+set(HIPFILE_LIBRARY_VERSION "${HIPFILE_LIBRARY_MAJOR}.${HIPFILE_LIBRARY_MINOR}.${HIPFILE_LIBRARY_PATCH}")
+
+# Create the header file
+configure_file("include/hipfile.h.in" "${CMAKE_CURRENT_BINARY_DIR}/include/hipfile.h")
 
 # Set the SOVERSION to the major library version (this is the default
 # but we set it explicitly to convey intent).
 #
 # Changes to minor and patch releases must NEVER break the ABI. This
 # includes things like reordering struct fields that don't break the API.
-set(AIS_LIBRARY_SOVERSION "${AIS_LIBRARY_MAJOR}")
+set(HIPFILE_LIBRARY_SOVERSION "${HIPFILE_LIBRARY_MAJOR}")
 
 project("hipfile"
-    VERSION ${AIS_LIBRARY_VERSION}
+    VERSION ${HIPFILE_LIBRARY_VERSION}
     DESCRIPTION "Direct-to-GPU IO for AMD's ROCm platform"
     LANGUAGES C CXX HIP
 )
@@ -40,7 +43,7 @@ option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 # Set the path to the include directories for later use
 # Do this early so we can use these later, in functions, etc.
 set(HIPFILE_ROOT_PATH "${CMAKE_CURRENT_SOURCE_DIR}")
-set(HIPFILE_INCLUDE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/include")
+set(HIPFILE_INCLUDE_PATH "${CMAKE_CURRENT_BINARY_DIR}/include")
 set(HIPFILE_AMD_SOURCE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/src/amd_detail")
 set(HIPFILE_NVIDIA_SOURCE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/src/nvidia_detail")
 set(HIPFILE_SRC_COMMON_PATH "${CMAKE_CURRENT_SOURCE_DIR}/src/common")

--- a/projects/hipfile/cmake/AISAddLibraries.cmake
+++ b/projects/hipfile/cmake/AISAddLibraries.cmake
@@ -35,9 +35,9 @@ function(ais_add_libraries)
     set_target_properties(${arg_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
     # Add version numbers
-    set_target_properties(${arg_NAME} PROPERTIES VERSION ${AIS_LIBRARY_VERSION})
+    set_target_properties(${arg_NAME} PROPERTIES VERSION ${HIPFILE_LIBRARY_VERSION})
     if(BUILD_SHARED_LIBS)
-        set_target_properties(${arg_NAME} PROPERTIES SOVERSION ${AIS_LIBRARY_SOVERSION})
+        set_target_properties(${arg_NAME} PROPERTIES SOVERSION ${HIPFILE_LIBRARY_SOVERSION})
     endif()
 
     # Add dependencies on external libraries

--- a/projects/hipfile/cmake/AISInstall.cmake
+++ b/projects/hipfile/cmake/AISInstall.cmake
@@ -13,7 +13,7 @@ rocm_install(TARGETS hipfile)
 
 # Install the headers
 rocm_install(
-    DIRECTORY ${HIPFILE_ROOT_PATH}/include/
+    DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include/"
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 

--- a/projects/hipfile/docs/conf.py
+++ b/projects/hipfile/docs/conf.py
@@ -86,7 +86,7 @@ def generate_doxyfile(app, _):
         content = f.read()
 
     # Fix up version
-    content = content.replace("@AIS_LIBRARY_VERSION@", version_number)
+    content = content.replace("@HIPFILE_LIBRARY_VERSION@", version_number)
 
     # Fix up Doxygen markup location
     content = content.replace("@AIS_DOXYFILE_INPUT@", "../../include/hipfile.h")

--- a/projects/hipfile/docs/doxygen/Doxyfile.in
+++ b/projects/hipfile/docs/doxygen/Doxyfile.in
@@ -48,7 +48,7 @@ PROJECT_NAME           = "hipFile"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = @AIS_LIBRARY_VERSION@
+PROJECT_NUMBER         = @HIPFILE_LIBRARY_VERSION@
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/projects/hipfile/include/hipfile.h.in
+++ b/projects/hipfile/include/hipfile.h.in
@@ -77,17 +77,17 @@ extern "C" {
  * @brief hipFile major version number
  * @ingroup core
  */
-#define HIPFILE_VERSION_MAJOR 0
+#define HIPFILE_VERSION_MAJOR @HIPFILE_LIBRARY_MAJOR@
 /*!
  * @brief hipFile minor version number
  * @ingroup core
  */
-#define HIPFILE_VERSION_MINOR 2
+#define HIPFILE_VERSION_MINOR @HIPFILE_LIBRARY_MINOR@
 /*!
  * @brief hipFile patch version number
  * @ingroup core
  */
-#define HIPFILE_VERSION_PATCH 0
+#define HIPFILE_VERSION_PATCH @HIPFILE_LIBRARY_PATCH@
 
 // ***********************************************************************
 //  PLATFORM-INDEPENDENT TYPES


### PR DESCRIPTION
hipfile.h is now hipfile.h.in which gets its version numbers from CMake and is generated at configure time.

## Motivation

There should be a single source of truth for hipFile version numbers. The version numbers are currently specified in both CMake and hipfile.h.

## Technical Details

hipfile.h is now hipfile.h.in, which is modified by CMake at configure time to contain the version numbers, creating hipfile.h.

## JIRA ID

AIHIPFILE-198

## Test Plan

CI + manual verification of installed components

## Test Result

Everything passes

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
