### PR TITLE
rocr/aie: Avoid mapping allocate-only memory

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -706,23 +706,19 @@ XdnaDriver::AllocateMemory(const core::MemoryRegion &mem_region,
 
   if (use_bo_share) {
     if (alloc_flags & core::MemoryRegion::AllocateMemoryOnly) {
-      /// TODO: We create an anonymous mapping to get a unique virtual address since the memory
-      /// handle mapping, i.e., Runtime::memory_handle_map_, is indexed using DriverHandle which is
-      /// driver-agnostic and just a pointer to the virtual address space. We waste a page, but it
-      /// ensures uniqueness across drivers.
-      bo_handle.vaddr =
-          mmap(nullptr, MemoryRegion::GetPageSize(), PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-      if (bo_handle.vaddr == MAP_FAILED) {
-        return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
-      }
+      // We do not map the BO.
+      bo_handle.vaddr = nullptr;
+      bo_handle.unmap_vaddr = false;
     } else {
+      // We map the BO to the host address space. The BO will be automatically unmapped when the BO
+      // handle is destroyed.
       bo_handle.vaddr =
           mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd_, get_bo_info_args.map_offset);
       if (bo_handle.vaddr == MAP_FAILED) {
         return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
       }
+      bo_handle.unmap_vaddr = true;
     }
-    bo_handle.unmap_vaddr = true;
   } else {
     /// This is dev heap and is already mapped. See InitDeviceHeap().
     bo_handle.vaddr = reinterpret_cast<void*>(get_bo_info_args.vaddr);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -725,13 +725,14 @@ XdnaDriver::AllocateMemory(const core::MemoryRegion &mem_region,
     bo_handle.unmap_vaddr = false;
   }
 
-  // FreeMemory, pass only the memory address and not a BO handle so we need something that looks like an address. When
-  // there is no mapped vaddr (AllocateMemoryOnly), synthesize a unique key from the BO handle with the MSB set so
-  // it cannot collide with a real userspace virtual address and so multiple unmapped BOs each get their own entry.
+  // FreeMemory, pass only the memory address and not a BO handle so we need something that looks
+  // like an address. When there is no mapped vaddr (AllocateMemoryOnly), synthesize a unique key
+  // from the BO handle with the MSB set so it cannot collide with a real userspace virtual address
+  // and so multiple unmapped BOs each get their own entry.
   void* map_key = bo_handle.vaddr;
   if (map_key == nullptr) {
-    map_key = reinterpret_cast<void*>(static_cast<uint64_t>(bo_handle.handle) |
-                                      (uint64_t{1} << 63));
+    map_key =
+        reinterpret_cast<void*>(static_cast<uint64_t>(bo_handle.handle) | (uint64_t{1} << 63));
   }
   vmem_addr_mappings.emplace(map_key, bo_handle);
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -725,13 +725,19 @@ XdnaDriver::AllocateMemory(const core::MemoryRegion &mem_region,
     bo_handle.unmap_vaddr = false;
   }
 
-  // We keep a mapping from VA memory addresses to BO handles because some operations, e.g.,
-  // FreeMemory, pass only the memory address and not a BO handle.
-  vmem_addr_mappings.emplace(bo_handle.vaddr, bo_handle);
+  // FreeMemory, pass only the memory address and not a BO handle so we need something that looks like an address. When
+  // there is no mapped vaddr (AllocateMemoryOnly), synthesize a unique key from the BO handle with the MSB set so
+  // it cannot collide with a real userspace virtual address and so multiple unmapped BOs each get their own entry.
+  void* map_key = bo_handle.vaddr;
+  if (map_key == nullptr) {
+    map_key = reinterpret_cast<void*>(static_cast<uint64_t>(bo_handle.handle) |
+                                      (uint64_t{1} << 63));
+  }
+  vmem_addr_mappings.emplace(map_key, bo_handle);
 
   bo_guard.Dismiss();
 
-  *mem = bo_handle.vaddr;
+  *mem = map_key;
 
   return HSA_STATUS_SUCCESS;
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
@@ -51,6 +51,7 @@
 #include <unordered_map>
 #include <memory>
 #include <tuple>
+#include <unordered_map>
 #include <utility>
 #include <thread>
 #include <mutex>
@@ -1036,6 +1037,7 @@ class Runtime {
     bool is_fabric_handle;
     MemoryRegion::AllocateFlags alloc_flag;
   };
+
   // hsa_amd_vmem_alloc_handle_t (MemoryHandle*) to MemoryHandle mapping. Owns MemoryHandle
   // lifetime. Uniqueness is guaranteed by the runtime, independent of any driver-supplied
   // identifier.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
@@ -51,7 +51,6 @@
 #include <unordered_map>
 #include <memory>
 #include <tuple>
-#include <unordered_map>
 #include <utility>
 #include <thread>
 #include <mutex>


### PR DESCRIPTION
## Motivation

`Runtime::memory_handle_map_` indexes MemoryHandle records produced by `hsa_amd_vmem_handle_create`. The key was a driver-supplied `ThunkHandle` (`typedef void*`), with uniqueness guaranteed by the underlying allocator returning a distinct pointer per allocation.

The XDNA driver does not satisfy this contract - its DRM GEM handles are `uint32_t` values that can collide across driver instances and with KFD non-canonical handles. The current workaround (amd_xdna_driver.cpp) is to `mmap(PROT_NONE, ...)` an anonymous page per AllocateMemoryOnly allocation purely to obtain a void* which can still create a collision.

## Technical Details

Instead of converting between `ThunkHandle` (map key) and `hsa_amd_vmem_alloc_handle_t` (public handle), heap allocate a `MemoryHandle` and use the pointer as the unique handle. Store the `MemoryHandle*` and `std::unique_ptr<MemoryHandle>` in the map to 1) create a unique handle to `MemoryHandle` object and 2) manage the lifetime of the `MemoryHandle` seamlessly.

`std::unordered_map` was chosen over `std::map` as there is no implied order between the keys as before, although that aspect was not used. `std::unordered_map` is cheaper on all operations compared to `std::map`, esp. when it comes to iteration as required by `VMemoryImportShareableHandle`

These changes allows `XdnaDriver` (and other future drivers) to correctly create VMem handles w/out mapping. However, we still create a vaddr-looking key since `FreeMemory()` accepts an address. This will be addressed in a future PR with a driver memory handle that returns both vaddr and BO handles and can be used for deallocation.

We can switch to `std::unordered_set<std::unique_ptr<MemHandle>>` with C++20, since `unordered_set.find(Key)` can accept a pointer as the key and compare against a `unique_ptr`.

Other alternatives considered:
- Using a monotonically incrementing integral value (`uint64_t`). This is a viable solution, but it's unclear if the available handles would be enough for long running applications.
- Using a pair of integral values, one for the driver type and one for the BO handle. Rejected, as ThunkHandle may use the whole 64-bit space.
- Fit `XdnaDriver` BOs in holes in ThunkHandle. Rejected since it creates coupling between unrelated drivers.

## JIRA ID

NA

## Test Plan

./rocrtst64, tests and microbenchmarks from https://github.com/ROCm/rocm-systems/tree/users/ypapadop-amd/aie-tests/projects/rocr-runtime/rocrtst/suites/aie

## Test Result

Tests run successfully.

Benchmark on AMD Ryzen 9 7940HS w/ Radeon 780M Graphics, 4k bytes allocation, N allocations per benchmark iteration (marked by `BenchmarkName+Device/N`):

develop:
```
2026-05-28T12:54:02-04:00
Running ./vmem-alloc-hsa
Run on (16 X 1100.95 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x8)
  L1 Instruction 32 KiB (x8)
  L2 Unified 1024 KiB (x8)
  L3 Unified 16384 KiB (x1)
Load Average: 1.26, 2.43, 1.94
-----------------------------------------------------------------------------------
Benchmark                         Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------
VMemAllocReleaseAIE/1          10.4 us         10.1 us        68552 bytes_per_second=385.478Mi/s items_per_second=98.6823k/s
VMemAllocReleaseAIE/2          20.4 us         20.0 us        34596 bytes_per_second=391.416Mi/s items_per_second=100.202k/s
VMemAllocReleaseAIE/4          43.2 us         42.1 us        16884 bytes_per_second=371.434Mi/s items_per_second=95.0872k/s
VMemAllocReleaseAIE/8          86.6 us         83.8 us         8224 bytes_per_second=372.878Mi/s items_per_second=95.4569k/s
VMemAllocReleaseAIE/16          177 us          171 us         4076 bytes_per_second=364.709Mi/s items_per_second=93.3656k/s
VMemAllocReleaseAIE/32          360 us          347 us         2008 bytes_per_second=360.488Mi/s items_per_second=92.2849k/s
VMemAllocReleaseAIE/64          740 us          711 us          949 bytes_per_second=351.607Mi/s items_per_second=90.0113k/s
VMemAllocReleaseAIE/128        1523 us         1461 us          471 bytes_per_second=342.23Mi/s items_per_second=87.611k/s
VMemAllocReleaseAIE/256        3113 us         2988 us          234 bytes_per_second=334.681Mi/s items_per_second=85.6784k/s
VMemAllocReleaseAIE/512        6447 us         6161 us          113 bytes_per_second=324.613Mi/s items_per_second=83.101k/s
VMemAllocReleaseAIE/1024      13017 us        12456 us           54 bytes_per_second=321.118Mi/s items_per_second=82.2062k/s
VMemAllocReleaseGPU/1          5.82 us         5.82 us       118664 bytes_per_second=670.899Mi/s items_per_second=171.75k/s
VMemAllocReleaseGPU/2          11.5 us         11.5 us        60537 bytes_per_second=680.14Mi/s items_per_second=174.116k/s
VMemAllocReleaseGPU/4          23.6 us         23.6 us        30364 bytes_per_second=660.974Mi/s items_per_second=169.209k/s
VMemAllocReleaseGPU/8          45.8 us         45.8 us        15379 bytes_per_second=682.828Mi/s items_per_second=174.804k/s
VMemAllocReleaseGPU/16         92.1 us         92.1 us         7531 bytes_per_second=678.555Mi/s items_per_second=173.71k/s
VMemAllocReleaseGPU/32          186 us          185 us         3770 bytes_per_second=673.961Mi/s items_per_second=172.534k/s
VMemAllocReleaseGPU/64          381 us          381 us         1817 bytes_per_second=655.621Mi/s items_per_second=167.839k/s
VMemAllocReleaseGPU/128         809 us          808 us          882 bytes_per_second=618.538Mi/s items_per_second=158.346k/s
VMemAllocReleaseGPU/256        1625 us         1624 us          416 bytes_per_second=615.596Mi/s items_per_second=157.593k/s
VMemAllocReleaseGPU/512        3412 us         3411 us          203 bytes_per_second=586.273Mi/s items_per_second=150.086k/s
VMemAllocReleaseGPU/1024       7427 us         7426 us           89 bytes_per_second=538.634Mi/s items_per_second=137.89k/s
```

This PR:
```
2026-05-28T13:22:20-04:00
Running ./vmem-alloc-hsa
Run on (16 X 3592.83 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x8)
  L1 Instruction 32 KiB (x8)
  L2 Unified 1024 KiB (x8)
  L3 Unified 16384 KiB (x1)
Load Average: 3.90, 1.06, 0.99
-----------------------------------------------------------------------------------
Benchmark                         Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------
Running ./vmem-alloc-hsa
Run on (16 X 3436.59 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x8)
  L1 Instruction 32 KiB (x8)
  L2 Unified 1024 KiB (x8)
  L3 Unified 16384 KiB (x1)
Load Average: 2.89, 1.24, 0.51
-----------------------------------------------------------------------------------
Benchmark                         Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------
VMemAllocReleaseAIE/1          7.72 us         7.43 us        93334 bytes_per_second=525.416Mi/s items_per_second=134.507k/s
VMemAllocReleaseAIE/2          15.4 us         14.9 us        46566 bytes_per_second=522.948Mi/s items_per_second=133.875k/s
VMemAllocReleaseAIE/4          32.4 us         31.1 us        23050 bytes_per_second=502.344Mi/s items_per_second=128.6k/s
VMemAllocReleaseAIE/8          61.9 us         59.7 us        11043 bytes_per_second=523.281Mi/s items_per_second=133.96k/s
VMemAllocReleaseAIE/16          124 us          120 us         5762 bytes_per_second=521.311Mi/s items_per_second=133.456k/s
VMemAllocReleaseAIE/32          251 us          241 us         2903 bytes_per_second=517.804Mi/s items_per_second=132.558k/s
VMemAllocReleaseAIE/64          506 us          487 us         1432 bytes_per_second=513.094Mi/s items_per_second=131.352k/s
VMemAllocReleaseAIE/128        1131 us         1092 us          630 bytes_per_second=457.889Mi/s items_per_second=117.22k/s
VMemAllocReleaseAIE/256        2159 us         2097 us          319 bytes_per_second=476.884Mi/s items_per_second=122.082k/s
VMemAllocReleaseAIE/512        4430 us         4312 us          163 bytes_per_second=463.805Mi/s items_per_second=118.734k/s
VMemAllocReleaseAIE/1024       8495 us         8255 us           84 bytes_per_second=484.575Mi/s items_per_second=124.051k/s
VMemAllocReleaseGPU/1          5.86 us         5.86 us       118559 bytes_per_second=666.659Mi/s items_per_second=170.665k/s
VMemAllocReleaseGPU/2          11.5 us         11.5 us        60159 bytes_per_second=680.455Mi/s items_per_second=174.197k/s
VMemAllocReleaseGPU/4          22.9 us         22.9 us        29504 bytes_per_second=682.944Mi/s items_per_second=174.834k/s
VMemAllocReleaseGPU/8          45.4 us         45.4 us        13801 bytes_per_second=687.754Mi/s items_per_second=176.065k/s
VMemAllocReleaseGPU/16         94.3 us         94.3 us         7309 bytes_per_second=662.53Mi/s items_per_second=169.608k/s
VMemAllocReleaseGPU/32          186 us          186 us         3683 bytes_per_second=673.366Mi/s items_per_second=172.382k/s
VMemAllocReleaseGPU/64          383 us          383 us         1827 bytes_per_second=652.635Mi/s items_per_second=167.075k/s
VMemAllocReleaseGPU/128         786 us          786 us          870 bytes_per_second=636.402Mi/s items_per_second=162.919k/s
VMemAllocReleaseGPU/256        1616 us         1614 us          424 bytes_per_second=619.603Mi/s items_per_second=158.618k/s
VMemAllocReleaseGPU/512        3488 us         3487 us          199 bytes_per_second=573.497Mi/s items_per_second=146.815k/s
VMemAllocReleaseGPU/1024       7548 us         7547 us           93 bytes_per_second=530.019Mi/s items_per_second=135.685k/s
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
