### PR TITLE
[RCCL] Honor useDmaBuf in legacy-HIP proxy channel buffer registration

### DIFF
--- a/projects/rccl/CHANGELOG.md
+++ b/projects/rccl/CHANGELOG.md
@@ -24,6 +24,7 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 ### Resolved Issues
 * Fixed MSCCLPP_ENABLE_CLIP CMake build flag, which was not being properly honored.
 * Fixed static build (`BUILD_SHARED_LIBS=OFF`) failing with `install(EXPORT "rccl-targets" ...)` error when `fmt` is fetched via `FetchContent`. The `fmt-header-only` target is now scoped to the build interface and excluded from RCCL's exported usage requirements.
+* Fixed proxy channel staging buffers ignoring the new GDR mode selection on HIP < 7.12 builds. The legacy `#else` branch in `sendProxyConnect` / `recvProxyConnect` now honors `resources->useDmaBuf`, so peermem-equipped hosts on older HIP no longer fall through to `hsa_amd_portable_export_dmabuf` when peermem was selected in `*ProxySetup`. Workaround for affected RCCL builds: `NCCL_DMABUF_ENABLE=0`.
 
 ## Unreleased - RCCL 2.27.7 for ROCm 7.2.0
 

--- a/projects/rccl/src/transport/net.cc
+++ b/projects/rccl/src/transport/net.cc
@@ -1244,7 +1244,7 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
 #else
       /* DMA-BUF support */
       int type = NCCL_NET_MAP_DEV_MEM(map, buffs[p]) ? NCCL_PTR_CUDA : NCCL_PTR_HOST;
-      if (type == NCCL_PTR_CUDA && proxyState->dmaBufSupport && pfn_hsa_amd_portable_export_dmabuf) {
+      if (type == NCCL_PTR_CUDA && resources->useDmaBuf && proxyState->dmaBufSupport && pfn_hsa_amd_portable_export_dmabuf) {
         int dmabuf_fd;
         uint64_t offset;
         HSACHECK(hsa_amd_portable_export_dmabuf((const void*)resources->buffers[p], resources->buffSizes[p], &dmabuf_fd, &offset));
@@ -1458,7 +1458,7 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
 #else
       /* DMA-BUF support */
       int type = NCCL_NET_MAP_DEV_MEM(map, buffs[p]) ? NCCL_PTR_CUDA : NCCL_PTR_HOST;
-      if (type == NCCL_PTR_CUDA && proxyState->dmaBufSupport && pfn_hsa_amd_portable_export_dmabuf) {
+      if (type == NCCL_PTR_CUDA && resources->useDmaBuf && proxyState->dmaBufSupport && pfn_hsa_amd_portable_export_dmabuf) {
         int dmabuf_fd;
         uint64_t offset;
         HSACHECK(hsa_amd_portable_export_dmabuf((const void*)resources->buffers[p], resources->buffSizes[p], &dmabuf_fd, &offset));


### PR DESCRIPTION
## Motivation

Follow-up fix to PR #3607 ([AICOMRCCL-667] rccl: Change GDR selection logic).

After #3607 flipped `NCCL_DMABUF_ENABLE` default from `0` to `1` and added the "prefer peermem" selection in `sendProxySetup` / `recvProxySetup`, a customer on HIP < 7.12 reported a >2x throughput regression on a peermem-equipped host. The new INFO line at `ncclIbAccept` correctly reads \"Using GPU Direct RDMA (peermem)\", but the channel staging buffers were silently still being registered via DMA-BUF. Setting `NCCL_DMABUF_ENABLE=0` restored performance, which pointed at the registration path rather than the IB plugin's QP setup.

## Root cause

The proxy channel-buffer registration in `sendProxyConnect` / `recvProxyConnect` has two arms gated by `#if CUDA_VERSION >= 11070 || HIP_VERSION >= 71260540`:

- The modern-HIP arm correctly gates on `resources->useDmaBuf && ncclCuMemEnable()` before calling `regMrDmaBuf`.
- The legacy-HIP `#else` arm (used on HIP < 7.12) gates only on `proxyState->dmaBufSupport && pfn_hsa_amd_portable_export_dmabuf`. It never consulted `resources->useDmaBuf`.

So on legacy-HIP hosts with the new default `NCCL_DMABUF_ENABLE=1`, `rocmLibraryInit()` succeeds and loads `pfn_hsa_amd_portable_export_dmabuf`, which makes the legacy `#else` arm fire unconditionally even when the selection in `*ProxySetup` chose peermem (`useDmaBuf=false`). The IB plugin's flush-MR path (separate code) is on peermem; the proxy staging buffers — which carry every byte of every collective — are on DMA-BUF.

`NCCL_DMABUF_ENABLE=0` "fixes" it as a side effect: it makes `rocmLibraryInit()` bail at the goto-error path, which leaves `pfn_hsa_amd_portable_export_dmabuf` NULL, which makes the legacy arm fall through to plain `regMr` (peermem).

## Fix

Add `resources->useDmaBuf &&` to the gate at the two `#else` sites in `sendProxyConnect` (net.cc:1247) and `recvProxyConnect` (net.cc:1461) so the legacy-HIP arm matches the modern-HIP arm and respects the per-connection GDR mode selection.

Two-token change. Modern-HIP customers see no behavior change (different arm). Legacy-HIP customers without peermem still get DMA-BUF as before (`useDmaBuf` stays true via the `forceDmaBuf || ncclCuMemEnable()` and `!peermemAvailable` branches in `*ProxySetup`). Legacy-HIP customers with peermem and the existing `RCCL_FORCE_ENABLE_DMABUF=1` workaround keep DMA-BUF (`useDmaBuf=true` via the `forceDmaBuf` branch). Only the regression case — legacy-HIP, peermem, default — is moved off DMA-BUF and onto peermem, matching the selection.

## JIRA ID

ROCM-25463

## Test Plan

- Customer-side: rerun the affected workload on the same HIP < 7.12 host with `librccl.so` from this branch. Expected: throughput matches the pre-#3607 numbers (\~2x current) without needing `NCCL_DMABUF_ENABLE=0`.
- Existing `rccl-tests all_reduce_perf` on a legacy-HIP host (peermem + DMA-BUF both supported): bus bandwidth at large sizes should match the `RCCL_FORCE_ENABLE_DMABUF=1` and the `NCCL_DMABUF_ENABLE=0` runs (both restore the pre-regression path through different mechanisms).
- Modern HIP: untouched code path, no expected behavior change.

## Test Result

Customer reproduced the regression (\~137 GB/s post-#3607 vs \~320 GB/s pre-#3607) and confirmed `NCCL_DMABUF_ENABLE=0` restores it, which validates the gate as the right lever. Awaiting binary-level confirmation with this fix on the same host.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

[AICOMRCCL-667]: https://amd-hub.atlassian.net/browse/AICOMRCCL-667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ