### PR TITLE
[rocprofiler-sdk] Re-enable kernel-tracing validation tests

### DIFF
--- a/projects/rocprofiler-sdk/tests/kernel-tracing/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/kernel-tracing/CMakeLists.txt
@@ -38,5 +38,4 @@ rocprofiler_add_integration_validate_test(
     TIMEOUT 45
     FIXTURES_REQUIRED kernel-tracing
     DISCOVERY_ARGS ${PYTEST_ARGS}
-    ARGS --input ${CMAKE_CURRENT_BINARY_DIR}/kernel-tracing-test.json
-    UNSTABLE)
+    ARGS --input ${CMAKE_CURRENT_BINARY_DIR}/kernel-tracing-test.json)


### PR DESCRIPTION
## Motivation

enable the kernel tracing tests (previously failed to async callback from rocr-runtime delated and caused sigabrt) and to make sure that they run fine on each rock ci runner

## Technical Details

removed UNSTABLE flag in the kernel-tracing/CMakeLists.txt

## JIRA ID

Resolves AIROCVAL-40

## Test Plan

Removed the UNSTABLE flag from the kernel-tracing validate test so the 9 stable validation cases run by default.

## Test Result

Verified stable on gfx942 (5/5 captures, all 9 cases pass).

## Submission Checklist

- [V] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
