### PR TITLE
[RCCL] bootstrap: enable bidirectional socket AllGather by default

### DIFF
--- a/projects/rccl/CHANGELOG.md
+++ b/projects/rccl/CHANGELOG.md
@@ -20,6 +20,7 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 * MSCCL and NPKIT are deprecated and will be removed in a future release of RCCL.
 * Changed GPU Direct RDMA mode selection logic to prefer peermem over DMAbuf by default. `NCCL_DMABUF_ENABLE` now defaults to 1 (previously 0). When both peermem and DMAbuf are available, RCCL will use peermem. If peermem is unavailable, RCCL will automatically fall back to DMAbuf (if available and enabled). Setting `RCCL_FORCE_ENABLE_DMABUF=1` forces DMAbuf usage exclusively, skipping peermem even if available, and disables GPU Direct RDMA if DMAbuf is unavailable.
 * CTS offload is now controlled per-connection rather than globally, allowing P2P connections to fall back to standard RDMA writes while non-P2P traffic continues to use CTS.
+* The bootstrap AllGather now uses the bidirectional ring (N/2 steps) by default on the socket OOB path. `NCCL_BOOTSTRAP_BIDIR_ALLGATHER` now defaults to `1`; set it to `0` to fall back to the unidirectional ring. The net OOB path (`NCCL_OOB_NET_ENABLE`) and its bidirectional variant (`NCCL_BOOTSTRAP_BIDIR_NET`) remain off by default.
 
 ### Resolved Issues
 * Fixed MSCCLPP_ENABLE_CLIP CMake build flag, which was not being properly honored.

--- a/projects/rccl/docs/api-reference/env-variables.rst
+++ b/projects/rccl/docs/api-reference/env-variables.rst
@@ -34,6 +34,36 @@ in the following table.
       - | String value for host identification
         | Used for host hash generation
 
+    * - | ``NCCL_BOOTSTRAP_BIDIR_ALLGATHER``
+        | Enables the bidirectional ring AllGather (N/2 steps) on the socket OOB path
+          during bootstrap. The unidirectional ring (N-1 steps) is kept as a fallback.
+          Has no effect when net OOB is in use; see ``NCCL_BOOTSTRAP_BIDIR_NET``.
+      - | ``0``: Force unidirectional ring.
+        | ``1``: Force bidirectional ring (default).
+
+    * - | ``NCCL_BOOTSTRAP_BIDIR_NET``
+        | Enables the bidirectional ring AllGather on the net OOB path during bootstrap.
+          Requires net OOB to be active (``NCCL_OOB_NET_ENABLE``). The net plugin's MR
+          registration plus the reverse-pair connect setup is heavy enough that small
+          comms regress, hence the threshold gate when set to ``-1``.
+      - | ``-1``: Auto — enabled when ``nranks >= NCCL_BOOTSTRAP_BIDIR_THRESHOLD``.
+        | ``0``: Force off (default).
+        | ``1``: Force on regardless of scale.
+
+    * - | ``NCCL_BOOTSTRAP_BIDIR_THRESHOLD``
+        | Rank-count threshold consulted by ``NCCL_BOOTSTRAP_BIDIR_NET`` and
+          ``NCCL_OOB_NET_ENABLE`` when those knobs are in auto (``-1``) mode.
+      - | Positive integer rank count.
+        | Default: ``128`` (≈ 16 nodes at 8 ppn).
+
+    * - | ``NCCL_OOB_NET_ENABLE``
+        | Selects the out-of-band transport used by the bootstrap AllGather. ``0`` uses
+          the TCP socket OOB path; ``1`` uses the IB/OFI net plugin; ``-1`` enables
+          net OOB once ``nranks >= NCCL_BOOTSTRAP_BIDIR_THRESHOLD``.
+      - | ``-1``: Auto, threshold-gated.
+        | ``0``: Socket OOB (default).
+        | ``1``: Net OOB.
+
 Logging and debugging
 =====================
 

--- a/projects/rccl/docs/api-reference/env-variables.rst
+++ b/projects/rccl/docs/api-reference/env-variables.rst
@@ -37,32 +37,9 @@ in the following table.
     * - | ``NCCL_BOOTSTRAP_BIDIR_ALLGATHER``
         | Enables the bidirectional ring AllGather (N/2 steps) on the socket OOB path
           during bootstrap. The unidirectional ring (N-1 steps) is kept as a fallback.
-          Has no effect when net OOB is in use; see ``NCCL_BOOTSTRAP_BIDIR_NET``.
+          Has no effect when net OOB is in use.
       - | ``0``: Force unidirectional ring.
         | ``1``: Force bidirectional ring (default).
-
-    * - | ``NCCL_BOOTSTRAP_BIDIR_NET``
-        | Enables the bidirectional ring AllGather on the net OOB path during bootstrap.
-          Requires net OOB to be active (``NCCL_OOB_NET_ENABLE``). The net plugin's MR
-          registration plus the reverse-pair connect setup is heavy enough that small
-          comms regress, hence the threshold gate when set to ``-1``.
-      - | ``-1``: Auto — enabled when ``nranks >= NCCL_BOOTSTRAP_BIDIR_THRESHOLD``.
-        | ``0``: Force off (default).
-        | ``1``: Force on regardless of scale.
-
-    * - | ``NCCL_BOOTSTRAP_BIDIR_THRESHOLD``
-        | Rank-count threshold consulted by ``NCCL_BOOTSTRAP_BIDIR_NET`` and
-          ``NCCL_OOB_NET_ENABLE`` when those knobs are in auto (``-1``) mode.
-      - | Positive integer rank count.
-        | Default: ``128`` (≈ 16 nodes at 8 ppn).
-
-    * - | ``NCCL_OOB_NET_ENABLE``
-        | Selects the out-of-band transport used by the bootstrap AllGather. ``0`` uses
-          the TCP socket OOB path; ``1`` uses the IB/OFI net plugin; ``-1`` enables
-          net OOB once ``nranks >= NCCL_BOOTSTRAP_BIDIR_THRESHOLD``.
-      - | ``-1``: Auto, threshold-gated.
-        | ``0``: Socket OOB (default).
-        | ``1``: Net OOB.
 
 Logging and debugging
 =====================

--- a/projects/rccl/src/bootstrap.cc
+++ b/projects/rccl/src/bootstrap.cc
@@ -146,7 +146,9 @@ static inline bool bootstrapNetEnabledEffective(int nranks) {
 // Socket path runs at any nranks>=3. Net path is tristate; when set to -1 the ring-count
 // threshold gates it, since the net plugin's MR registration + reverse-pair connect
 // overhead must be amortised over enough ranks. Defaults are documented above.
-static inline bool bootstrapBidirEnabled(int nranks, int kind) {
+//
+// Exposed (non-static) so test/BootstrapBidirTests.cpp can verify the env-var contract.
+bool bootstrapBidirEnabled(int nranks, int kind) {
   if (nranks < 3) return false;
   bool netOn = bootstrapNetEnabledEffective(nranks);
   if (kind == 0) return (ncclParamBootstrapBidirAllGather() != 0) && !netOn;

--- a/projects/rccl/src/bootstrap.cc
+++ b/projects/rccl/src/bootstrap.cc
@@ -115,12 +115,19 @@ static std::mutex bootstrapNetMutex;
 // Off by default; opt in explicitly via env var or set to -1 to use the threshold gate.
 NCCL_PARAM(BootstrapNetEnable,"OOB_NET_ENABLE", 0);
 
-// Bidirectional ring AllGather (N/2 steps). All three knobs are opt-in: socket-bidir
-// (BOOTSTRAP_BIDIR_ALLGATHER) is an on/off flag; net-bidir (BOOTSTRAP_BIDIR_NET) is a
-// tristate (-1 auto by threshold, 0 off, 1 on) and additionally requires net OOB to be
-// on. Defaults are all off; the threshold is consulted only when the corresponding
-// knob is set to -1 (auto).
-NCCL_PARAM(BootstrapBidirAllGather, "BOOTSTRAP_BIDIR_ALLGATHER",  0);
+// Bidirectional ring AllGather (N/2 steps).
+//   BOOTSTRAP_BIDIR_ALLGATHER : on/off flag for the socket OOB path. Default on; setting
+//                               it to 0 falls back to the unidirectional ring. Has no
+//                               effect when net OOB is enabled (the net path uses
+//                               BOOTSTRAP_BIDIR_NET instead).
+//   BOOTSTRAP_BIDIR_NET       : tristate for the net OOB path (-1 auto by threshold,
+//                               0 off, 1 on). Off by default; opt in explicitly. Also
+//                               requires net OOB itself to be active (NCCL_OOB_NET_ENABLE).
+//   BOOTSTRAP_BIDIR_THRESHOLD : rank threshold consulted only when the corresponding
+//                               knob is set to -1 (auto). Default 128 ranks (16 nodes
+//                               at 8 ppn), motivated by net-OOB plugin regMr/connect
+//                               setup overhead being too heavy to amortise below that.
+NCCL_PARAM(BootstrapBidirAllGather, "BOOTSTRAP_BIDIR_ALLGATHER",  1);
 NCCL_PARAM(BootstrapBidirNet,       "BOOTSTRAP_BIDIR_NET",        0);
 NCCL_PARAM(BootstrapBidirThreshold, "BOOTSTRAP_BIDIR_THRESHOLD", 128);
 
@@ -136,6 +143,9 @@ static inline bool bootstrapNetEnabledEffective(int nranks) {
 }
 
 // kind: 0 = socket OOB, 1 = net (IB) OOB. Setup, dispatch and cleanup all consult this.
+// Socket path runs at any nranks>=3. Net path is tristate; when set to -1 the ring-count
+// threshold gates it, since the net plugin's MR registration + reverse-pair connect
+// overhead must be amortised over enough ranks. Defaults are documented above.
 static inline bool bootstrapBidirEnabled(int nranks, int kind) {
   if (nranks < 3) return false;
   bool netOn = bootstrapNetEnabledEffective(nranks);
@@ -145,6 +155,7 @@ static inline bool bootstrapBidirEnabled(int nranks, int kind) {
     int64_t v = ncclParamBootstrapBidirNet();
     if (v == 0) return false;
     if (v >= 1) return true;
+    // v == -1: auto, threshold-gated.
     int64_t thr = ncclParamBootstrapBidirThreshold();
     return thr > 0 && nranks >= (int)thr;
   }
@@ -952,8 +963,8 @@ static ncclResult_t bootstrapBidirRingSetupFinish(struct ncclComm* comm, struct 
 static ncclResult_t bootstrapBidirRingSetup(struct ncclComm* comm, struct bootstrapState* state,
                                             const char* prevRevHandlePiggyback) {
   // Cheap exit when bidirectional net bootstrap is disabled, pointless (≤2 ranks) or below
-  // the BOOTSTRAP_BIDIR_THRESHOLD: the net plugin's regMr/connect setup is heavy enough that
-  // small comms regress without the threshold.
+  // the BOOTSTRAP_BIDIR_THRESHOLD in auto mode: the net plugin's regMr/connect setup is
+  // heavy enough that small comms regress.
   bool wantNetBidir = bootstrapBidirEnabled(state->nranks, 1);
   if (!wantNetBidir) return ncclSuccess;
 
@@ -1560,7 +1571,7 @@ exit:
   return res;
 }
 // Classic unidirectional ring AllGather over the socket OOB path (N-1 rounds).
-// Kept as the fallback when BOOTSTRAP_BIDIR_ALLGATHER=0 is set explicitly.
+// Used when BOOTSTRAP_BIDIR_ALLGATHER=0 is set explicitly.
 static ncclResult_t socketRingAllGatherUnidir(struct ncclSocket* sendSock, struct ncclSocket* recvSock, int rank, int nranks, char* data, int size) {
   ncclResult_t res = ncclSuccess;
   uint64_t tFirst = 0, tRest = 0;
@@ -1801,7 +1812,7 @@ ncclResult_t bootstrapIntraNodeAllGather(void* commState, int* ranks, int rank, 
 
   // Intra-node AllGather is socket-only and so cannot reuse bootstrapBidirEnabled
   // (its `!netOn` clause is geared to inter-node OOB selection). Gate purely on the
-  // BOOTSTRAP_BIDIR_ALLGATHER opt-in; socketRingAllGather handles nranks<3 itself
+  // BOOTSTRAP_BIDIR_ALLGATHER knob; socketRingAllGather handles nranks<3 itself
   // (nranks==2 → single bidirectional socketSendRecv; nranks==1 is short-circuited
   // earlier in this function).
   if (ncclParamBootstrapBidirAllGather() != 0) {

--- a/projects/rccl/src/bootstrap.cc
+++ b/projects/rccl/src/bootstrap.cc
@@ -148,6 +148,11 @@ static inline bool bootstrapNetEnabledEffective(int nranks) {
 // overhead must be amortised over enough ranks. Defaults are documented above.
 //
 // Exposed (non-static) so test/BootstrapBidirTests.cpp can verify the env-var contract.
+// The visibility("hidden") attribute keeps the symbol off librccl.so's exported
+// dynsym table even in BUILD_TESTS=ON Debug builds (which globally relax visibility
+// to let tests link against internal helpers). Defense-in-depth on top of the
+// production -fvisibility=hidden flag — see src/CMakeLists.txt visibility block.
+__attribute__((visibility("hidden")))
 bool bootstrapBidirEnabled(int nranks, int kind) {
   if (nranks < 3) return false;
   bool netOn = bootstrapNetEnabledEffective(nranks);
@@ -161,6 +166,9 @@ bool bootstrapBidirEnabled(int nranks, int kind) {
     int64_t thr = ncclParamBootstrapBidirThreshold();
     return thr > 0 && nranks >= (int)thr;
   }
+  // Any unrecognised kind (negative, >=2, etc.) falls through to false.
+  // This is the contract verified by BootstrapBidir.UnknownKind_ReturnsFalse:
+  // callers adding a third transport must extend this gate explicitly.
   return false;
 }
 

--- a/projects/rccl/src/include/bootstrap.h
+++ b/projects/rccl/src/include/bootstrap.h
@@ -36,11 +36,17 @@ ncclResult_t bootstrapClose(void* commState);
 ncclResult_t bootstrapAbort(void* commState);
 
 // Bootstrap bidirectional AllGather gating. Exposed for unit tests; production
-// callers go through bootstrapInit / bootstrapAllGather. Pure function: reads
-// NCCL_BOOTSTRAP_BIDIR_ALLGATHER, NCCL_BOOTSTRAP_BIDIR_NET,
-// NCCL_BOOTSTRAP_BIDIR_THRESHOLD and NCCL_OOB_NET_ENABLE param caches.
+// callers go through bootstrapInit / bootstrapAllGather. Reads (and depends on
+// the process-global cache of) NCCL_BOOTSTRAP_BIDIR_ALLGATHER,
+// NCCL_BOOTSTRAP_BIDIR_NET, NCCL_BOOTSTRAP_BIDIR_THRESHOLD and
+// NCCL_OOB_NET_ENABLE — same inputs as the dispatcher, so the test can verify
+// the exact contract production uses.
 //   nranks: total ranks in the comm (returns false unconditionally for < 3).
 //   kind:   0 = socket OOB path, 1 = net (IB/OFI) OOB path.
+// Marked visibility("hidden") so the symbol is linkable inside librccl.so for
+// the test TU but never exported in the final shared library; see the matching
+// attribute on the definition in src/bootstrap.cc.
+__attribute__((visibility("hidden")))
 bool bootstrapBidirEnabled(int nranks, int kind);
 
 #endif

--- a/projects/rccl/src/include/bootstrap.h
+++ b/projects/rccl/src/include/bootstrap.h
@@ -34,4 +34,13 @@ ncclResult_t bootstrapIntraNodeAllGather(void* commState, int *ranks, int rank, 
 ncclResult_t bootstrapIntraNodeBroadcast(void* commState, int *ranks, int rank, int nranks, int root, void* bcastData, int size);
 ncclResult_t bootstrapClose(void* commState);
 ncclResult_t bootstrapAbort(void* commState);
+
+// Bootstrap bidirectional AllGather gating. Exposed for unit tests; production
+// callers go through bootstrapInit / bootstrapAllGather. Pure function: reads
+// NCCL_BOOTSTRAP_BIDIR_ALLGATHER, NCCL_BOOTSTRAP_BIDIR_NET,
+// NCCL_BOOTSTRAP_BIDIR_THRESHOLD and NCCL_OOB_NET_ENABLE param caches.
+//   nranks: total ranks in the comm (returns false unconditionally for < 3).
+//   kind:   0 = socket OOB path, 1 = net (IB/OFI) OOB path.
+bool bootstrapBidirEnabled(int nranks, int kind);
+
 #endif

--- a/projects/rccl/test/BootstrapBidirTests.cpp
+++ b/projects/rccl/test/BootstrapBidirTests.cpp
@@ -6,12 +6,11 @@
 
 // Unit tests for the bootstrap bidirectional AllGather gating contract.
 //
-// Branch users/ilkosare/sock-bidir-default-on flipped NCCL_BOOTSTRAP_BIDIR_ALLGATHER
-// from 0 to 1 (socket bidir on by default) while leaving NCCL_OOB_NET_ENABLE and
-// NCCL_BOOTSTRAP_BIDIR_NET off. The pure helper `bootstrapBidirEnabled(nranks, kind)`
+// Socket bidir is on by default (NCCL_BOOTSTRAP_BIDIR_ALLGATHER=1); net OOB and
+// net bidir are off by default. The helper `bootstrapBidirEnabled(nranks, kind)`
 // in src/bootstrap.cc is the single source of truth that bootstrapInit,
 // bootstrapAllGather and bootstrapClose all consult; if its contract drifts the
-// runtime quietly diverges between setup and teardown.
+// runtime quietly diverges between setup and teardown, hence these tests pin it.
 //
 // Each case runs in an isolated process (via RUN_ISOLATED_TEST_WITH_ENV) because
 // NCCL_PARAM caches the env value on first read for the lifetime of the process,
@@ -19,10 +18,9 @@
 
 #include <gtest/gtest.h>
 #include "common/ProcessIsolatedTestRunner.hpp"
-
-// Forward-declared rather than #include "bootstrap.h" to keep the test TU light:
-// bootstrap.h drags in comm.h and nccl.h, neither of which we need here.
-extern bool bootstrapBidirEnabled(int nranks, int kind);
+#include "bootstrap.h"  // bootstrapBidirEnabled — single source of truth for the
+                        // signature; if it drifts we get a compile error here, not
+                        // a deferred linker error against librccl.so.
 
 namespace RcclUnitTesting {
 
@@ -249,8 +247,9 @@ TEST(BootstrapBidir, NetBidir_AutoThreshold_Zero_DisablesAuto)
 }
 
 // -----------------------------------------------------------------------------
-// BIDIR_NET explicit-zero: even when net OOB is enabled, BIDIR_NET=0 short-circuits
-// (line 147 v==0 branch). The other tests cover BIDIR_NET=1 / -1 only.
+// BIDIR_NET explicit-zero: even when net OOB is enabled, BIDIR_NET=0 must
+// short-circuit (the `v == 0` branch in bootstrapBidirEnabled's kind==1 arm).
+// Other tests only cover BIDIR_NET=1 / -1.
 // -----------------------------------------------------------------------------
 TEST(BootstrapBidir, NetBidir_ExplicitZero_With_NetOob_DisablesNet)
 {
@@ -268,9 +267,9 @@ TEST(BootstrapBidir, NetBidir_ExplicitZero_With_NetOob_DisablesNet)
 
 // -----------------------------------------------------------------------------
 // Net OOB auto path: NCCL_OOB_NET_ENABLE=-1 + threshold gates the underlying
-// bootstrapNetEnabledEffective helper. Without this case the v==-1 branch on
-// line 124 and the entire `thr > 0 && nranks >= thr` expression on line 127
-// in bootstrapNetEnabledEffective stay at zero hits.
+// bootstrapNetEnabledEffective helper. Without this case the auto (`v == -1`)
+// branch and the `thr > 0 && nranks >= thr` short-circuit inside
+// bootstrapNetEnabledEffective stay at zero hits in coverage.
 // -----------------------------------------------------------------------------
 TEST(BootstrapBidir, NetOob_Auto_Threshold_BelowAndAbove_GatesSocketShadow)
 {
@@ -297,7 +296,7 @@ TEST(BootstrapBidir, NetOob_Auto_Threshold_Zero_KeepsNetOff)
         {
             // thr==0 makes the auto-net-on path fail (never crosses), so socket
             // bidir is allowed unconditionally — covers the false branch of the
-            // `thr > 0 && ...` short-circuit on line 127.
+            // `thr > 0 && ...` short-circuit in bootstrapNetEnabledEffective.
             EXPECT_TRUE(bootstrapBidirEnabled(8,    kKindSocket));
             EXPECT_TRUE(bootstrapBidirEnabled(1024, kKindSocket));
         },

--- a/projects/rccl/test/BootstrapBidirTests.cpp
+++ b/projects/rccl/test/BootstrapBidirTests.cpp
@@ -1,0 +1,326 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Unit tests for the bootstrap bidirectional AllGather gating contract.
+//
+// Branch users/ilkosare/sock-bidir-default-on flipped NCCL_BOOTSTRAP_BIDIR_ALLGATHER
+// from 0 to 1 (socket bidir on by default) while leaving NCCL_OOB_NET_ENABLE and
+// NCCL_BOOTSTRAP_BIDIR_NET off. The pure helper `bootstrapBidirEnabled(nranks, kind)`
+// in src/bootstrap.cc is the single source of truth that bootstrapInit,
+// bootstrapAllGather and bootstrapClose all consult; if its contract drifts the
+// runtime quietly diverges between setup and teardown.
+//
+// Each case runs in an isolated process (via RUN_ISOLATED_TEST_WITH_ENV) because
+// NCCL_PARAM caches the env value on first read for the lifetime of the process,
+// so the only way to re-evaluate is to fork a fresh child.
+
+#include <gtest/gtest.h>
+#include "common/ProcessIsolatedTestRunner.hpp"
+
+// Forward-declared rather than #include "bootstrap.h" to keep the test TU light:
+// bootstrap.h drags in comm.h and nccl.h, neither of which we need here.
+extern bool bootstrapBidirEnabled(int nranks, int kind);
+
+namespace RcclUnitTesting {
+
+constexpr int kKindSocket = 0;
+constexpr int kKindNet    = 1;
+
+// -----------------------------------------------------------------------------
+// Tiny-comm short-circuit: nranks<3 is below the bidir threshold (one ring step
+// is degenerate at N==2 and undefined at N<2). Independent of any env var.
+// -----------------------------------------------------------------------------
+TEST(BootstrapBidir, TinyNranks_ReturnsFalse_Default)
+{
+    RUN_ISOLATED_TEST(
+        "BootstrapBidir.TinyNranks_ReturnsFalse_Default",
+        []()
+        {
+            EXPECT_FALSE(bootstrapBidirEnabled(0, kKindSocket));
+            EXPECT_FALSE(bootstrapBidirEnabled(1, kKindSocket));
+            EXPECT_FALSE(bootstrapBidirEnabled(2, kKindSocket));
+            EXPECT_FALSE(bootstrapBidirEnabled(0, kKindNet));
+            EXPECT_FALSE(bootstrapBidirEnabled(1, kKindNet));
+            EXPECT_FALSE(bootstrapBidirEnabled(2, kKindNet));
+        }
+    );
+}
+
+TEST(BootstrapBidir, TinyNranks_ReturnsFalse_EvenWithBidirForcedOn)
+{
+    RUN_ISOLATED_TEST_WITH_ENV(
+        "BootstrapBidir.TinyNranks_ReturnsFalse_EvenWithBidirForcedOn",
+        []()
+        {
+            EXPECT_FALSE(bootstrapBidirEnabled(0, kKindSocket));
+            EXPECT_FALSE(bootstrapBidirEnabled(2, kKindSocket));
+        },
+        {{"NCCL_BOOTSTRAP_BIDIR_ALLGATHER", "1"},
+         {"NCCL_OOB_NET_ENABLE", "0"}}
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Branch 1 default: with no env vars set, the socket bidir path is selected for
+// any nranks>=3. This is the headline behavioural change the branch introduces.
+// -----------------------------------------------------------------------------
+TEST(BootstrapBidir, SocketBidir_OnByDefault)
+{
+    RUN_ISOLATED_TEST(
+        "BootstrapBidir.SocketBidir_OnByDefault",
+        []()
+        {
+            // Span the realistic nranks range: small (3, 8), 2-node 8ppn (16),
+            // mid-scale (128), large (1024) - all should resolve to "on".
+            EXPECT_TRUE(bootstrapBidirEnabled(3,    kKindSocket));
+            EXPECT_TRUE(bootstrapBidirEnabled(8,    kKindSocket));
+            EXPECT_TRUE(bootstrapBidirEnabled(16,   kKindSocket));
+            EXPECT_TRUE(bootstrapBidirEnabled(128,  kKindSocket));
+            EXPECT_TRUE(bootstrapBidirEnabled(1024, kKindSocket));
+        }
+    );
+}
+
+TEST(BootstrapBidir, NetBidir_OffByDefault)
+{
+    RUN_ISOLATED_TEST(
+        "BootstrapBidir.NetBidir_OffByDefault",
+        []()
+        {
+            // Net OOB is off by default, so net bidir is unconditionally off
+            // regardless of nranks (the !netOn guard fires first).
+            EXPECT_FALSE(bootstrapBidirEnabled(8,    kKindNet));
+            EXPECT_FALSE(bootstrapBidirEnabled(128,  kKindNet));
+            EXPECT_FALSE(bootstrapBidirEnabled(1024, kKindNet));
+        }
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Off-switch: BIDIR_ALLGATHER=0 must produce the legacy unidir socket path
+// regardless of scale (and regardless of the threshold knob).
+// -----------------------------------------------------------------------------
+TEST(BootstrapBidir, SocketBidir_ExplicitOff_DisablesEverywhere)
+{
+    RUN_ISOLATED_TEST_WITH_ENV(
+        "BootstrapBidir.SocketBidir_ExplicitOff_DisablesEverywhere",
+        []()
+        {
+            EXPECT_FALSE(bootstrapBidirEnabled(8,    kKindSocket));
+            EXPECT_FALSE(bootstrapBidirEnabled(128,  kKindSocket));
+            EXPECT_FALSE(bootstrapBidirEnabled(1024, kKindSocket));
+        },
+        {{"NCCL_BOOTSTRAP_BIDIR_ALLGATHER", "0"}}
+    );
+}
+
+// Threshold knob applies only to the net path; for socket it must have no effect
+// (the helper short-circuits on the on/off semantics before consulting threshold).
+TEST(BootstrapBidir, SocketBidir_ThresholdKnob_HasNoEffect)
+{
+    RUN_ISOLATED_TEST_WITH_ENV(
+        "BootstrapBidir.SocketBidir_ThresholdKnob_HasNoEffect",
+        []()
+        {
+            // Threshold absurdly above any realistic nranks: still on.
+            EXPECT_TRUE(bootstrapBidirEnabled(8,   kKindSocket));
+            EXPECT_TRUE(bootstrapBidirEnabled(128, kKindSocket));
+        },
+        {{"NCCL_BOOTSTRAP_BIDIR_THRESHOLD", "1000000"}}
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Net OOB shadow: enabling net OOB transport must immediately disable the socket
+// bidir path (the dispatcher in bootstrapAllGather picks the net path instead).
+// This is the !netOn clause in bootstrapBidirEnabled(., kind=0).
+// -----------------------------------------------------------------------------
+TEST(BootstrapBidir, NetOob_ShadowsSocketBidir)
+{
+    RUN_ISOLATED_TEST_WITH_ENV(
+        "BootstrapBidir.NetOob_ShadowsSocketBidir",
+        []()
+        {
+            EXPECT_FALSE(bootstrapBidirEnabled(8,   kKindSocket));
+            EXPECT_FALSE(bootstrapBidirEnabled(128, kKindSocket));
+            EXPECT_FALSE(bootstrapBidirEnabled(1024, kKindSocket));
+        },
+        {{"NCCL_OOB_NET_ENABLE", "1"},
+         {"NCCL_BOOTSTRAP_BIDIR_ALLGATHER", "1"}}
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Net bidir requires net OOB. With OOB_NET_ENABLE=0, BIDIR_NET=1 must still
+// resolve to false: there is no second QP pair to drive Ring1 over.
+// -----------------------------------------------------------------------------
+TEST(BootstrapBidir, NetBidir_WithoutNetOob_ReturnsFalse)
+{
+    RUN_ISOLATED_TEST_WITH_ENV(
+        "BootstrapBidir.NetBidir_WithoutNetOob_ReturnsFalse",
+        []()
+        {
+            EXPECT_FALSE(bootstrapBidirEnabled(128,  kKindNet));
+            EXPECT_FALSE(bootstrapBidirEnabled(1024, kKindNet));
+        },
+        {{"NCCL_BOOTSTRAP_BIDIR_NET", "1"},
+         {"NCCL_OOB_NET_ENABLE", "0"}}
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Net bidir on (explicit): both knobs must be set; nranks threshold is bypassed
+// when the user has explicitly opted in (BIDIR_NET=1 vs the auto value -1).
+// -----------------------------------------------------------------------------
+TEST(BootstrapBidir, NetBidir_ExplicitOn_BypassesThreshold)
+{
+    RUN_ISOLATED_TEST_WITH_ENV(
+        "BootstrapBidir.NetBidir_ExplicitOn_BypassesThreshold",
+        []()
+        {
+            // Threshold absurdly above the asked nranks; explicit =1 must still
+            // win because it short-circuits before threshold logic.
+            EXPECT_TRUE(bootstrapBidirEnabled(8,   kKindNet));
+            EXPECT_TRUE(bootstrapBidirEnabled(128, kKindNet));
+        },
+        {{"NCCL_BOOTSTRAP_BIDIR_NET", "1"},
+         {"NCCL_OOB_NET_ENABLE", "1"},
+         {"NCCL_BOOTSTRAP_BIDIR_THRESHOLD", "1000000"}}
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Net bidir auto-threshold: BIDIR_NET=-1 (auto) + OOB_NET_ENABLE=1 with the
+// default threshold 128 must (a) be off below threshold, (b) on at and above it.
+// This protects the regression matrix: small comms shouldn't pay net-bidir setup
+// cost, but >=128 ranks should benefit.
+// -----------------------------------------------------------------------------
+TEST(BootstrapBidir, NetBidir_AutoThreshold_BelowAndAbove)
+{
+    RUN_ISOLATED_TEST_WITH_ENV(
+        "BootstrapBidir.NetBidir_AutoThreshold_BelowAndAbove",
+        []()
+        {
+            EXPECT_FALSE(bootstrapBidirEnabled(8,   kKindNet));
+            EXPECT_FALSE(bootstrapBidirEnabled(64,  kKindNet));
+            EXPECT_FALSE(bootstrapBidirEnabled(127, kKindNet));
+            EXPECT_TRUE (bootstrapBidirEnabled(128, kKindNet));
+            EXPECT_TRUE (bootstrapBidirEnabled(1024, kKindNet));
+        },
+        {{"NCCL_BOOTSTRAP_BIDIR_NET", "-1"},
+         {"NCCL_OOB_NET_ENABLE", "1"},
+         {"NCCL_BOOTSTRAP_BIDIR_THRESHOLD", "128"}}
+    );
+}
+
+TEST(BootstrapBidir, NetBidir_AutoThreshold_CustomValue)
+{
+    RUN_ISOLATED_TEST_WITH_ENV(
+        "BootstrapBidir.NetBidir_AutoThreshold_CustomValue",
+        []()
+        {
+            EXPECT_FALSE(bootstrapBidirEnabled(63, kKindNet));
+            EXPECT_TRUE (bootstrapBidirEnabled(64, kKindNet));
+            EXPECT_TRUE (bootstrapBidirEnabled(65, kKindNet));
+        },
+        {{"NCCL_BOOTSTRAP_BIDIR_NET", "-1"},
+         {"NCCL_OOB_NET_ENABLE", "1"},
+         {"NCCL_BOOTSTRAP_BIDIR_THRESHOLD", "64"}}
+    );
+}
+
+// Threshold==0 disables the auto path entirely (never crosses the gate).
+TEST(BootstrapBidir, NetBidir_AutoThreshold_Zero_DisablesAuto)
+{
+    RUN_ISOLATED_TEST_WITH_ENV(
+        "BootstrapBidir.NetBidir_AutoThreshold_Zero_DisablesAuto",
+        []()
+        {
+            EXPECT_FALSE(bootstrapBidirEnabled(128,  kKindNet));
+            EXPECT_FALSE(bootstrapBidirEnabled(1024, kKindNet));
+        },
+        {{"NCCL_BOOTSTRAP_BIDIR_NET", "-1"},
+         {"NCCL_OOB_NET_ENABLE", "1"},
+         {"NCCL_BOOTSTRAP_BIDIR_THRESHOLD", "0"}}
+    );
+}
+
+// -----------------------------------------------------------------------------
+// BIDIR_NET explicit-zero: even when net OOB is enabled, BIDIR_NET=0 short-circuits
+// (line 147 v==0 branch). The other tests cover BIDIR_NET=1 / -1 only.
+// -----------------------------------------------------------------------------
+TEST(BootstrapBidir, NetBidir_ExplicitZero_With_NetOob_DisablesNet)
+{
+    RUN_ISOLATED_TEST_WITH_ENV(
+        "BootstrapBidir.NetBidir_ExplicitZero_With_NetOob_DisablesNet",
+        []()
+        {
+            EXPECT_FALSE(bootstrapBidirEnabled(128,  kKindNet));
+            EXPECT_FALSE(bootstrapBidirEnabled(1024, kKindNet));
+        },
+        {{"NCCL_BOOTSTRAP_BIDIR_NET", "0"},
+         {"NCCL_OOB_NET_ENABLE", "1"}}
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Net OOB auto path: NCCL_OOB_NET_ENABLE=-1 + threshold gates the underlying
+// bootstrapNetEnabledEffective helper. Without this case the v==-1 branch on
+// line 124 and the entire `thr > 0 && nranks >= thr` expression on line 127
+// in bootstrapNetEnabledEffective stay at zero hits.
+// -----------------------------------------------------------------------------
+TEST(BootstrapBidir, NetOob_Auto_Threshold_BelowAndAbove_GatesSocketShadow)
+{
+    RUN_ISOLATED_TEST_WITH_ENV(
+        "BootstrapBidir.NetOob_Auto_Threshold_BelowAndAbove_GatesSocketShadow",
+        []()
+        {
+            // Below threshold: net OOB is auto-off, so socket bidir is allowed.
+            EXPECT_TRUE (bootstrapBidirEnabled(64,  kKindSocket));
+            // At/above threshold: net OOB auto-on, which shadows socket bidir.
+            EXPECT_FALSE(bootstrapBidirEnabled(128, kKindSocket));
+            EXPECT_FALSE(bootstrapBidirEnabled(256, kKindSocket));
+        },
+        {{"NCCL_OOB_NET_ENABLE", "-1"},
+         {"NCCL_BOOTSTRAP_BIDIR_THRESHOLD", "128"}}
+    );
+}
+
+TEST(BootstrapBidir, NetOob_Auto_Threshold_Zero_KeepsNetOff)
+{
+    RUN_ISOLATED_TEST_WITH_ENV(
+        "BootstrapBidir.NetOob_Auto_Threshold_Zero_KeepsNetOff",
+        []()
+        {
+            // thr==0 makes the auto-net-on path fail (never crosses), so socket
+            // bidir is allowed unconditionally — covers the false branch of the
+            // `thr > 0 && ...` short-circuit on line 127.
+            EXPECT_TRUE(bootstrapBidirEnabled(8,    kKindSocket));
+            EXPECT_TRUE(bootstrapBidirEnabled(1024, kKindSocket));
+        },
+        {{"NCCL_OOB_NET_ENABLE", "-1"},
+         {"NCCL_BOOTSTRAP_BIDIR_THRESHOLD", "0"}}
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Unknown 'kind' values must return false (defensive default for any future
+// caller that adds a third transport without updating this gate).
+// -----------------------------------------------------------------------------
+TEST(BootstrapBidir, UnknownKind_ReturnsFalse)
+{
+    RUN_ISOLATED_TEST(
+        "BootstrapBidir.UnknownKind_ReturnsFalse",
+        []()
+        {
+            EXPECT_FALSE(bootstrapBidirEnabled(128, 2));
+            EXPECT_FALSE(bootstrapBidirEnabled(128, -1));
+            EXPECT_FALSE(bootstrapBidirEnabled(128, 99));
+        }
+    );
+}
+
+} // namespace RcclUnitTesting

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -242,6 +242,7 @@ if(BUILD_TESTS)
       AllocTests.cpp
       ParamTests.cpp
       ArgCheckTests.cpp
+      BootstrapBidirTests.cpp
       EnqueueTests.cpp
       IpcsocketTests.cpp
       NetSocketTests.cpp


### PR DESCRIPTION
## Motivation

Enable faster bootstrap using bidirectional ring by default.

## Technical Details

Flip NCCL_BOOTSTRAP_BIDIR_ALLGATHER from 0 to 1. Net OOB and its bidir variant remain off by default.

## JIRA ID

AICOMNET-231

## Test Plan

Unit tests:  `rccl-UnitTestsFixturesDebug --gtest_filter="BootstrapBidir.*"`: 13 cases covering `bootstrapBidirEnabled` env-var contract, isolated-process per case to defeat `NCCL_PARAM` caching.

## Test Result

Modest saturating-exponential expectations approximated on real data:

```
  ┌─────────┬─────────┬────────────┬────────────┐
  │ N nodes │ N ranks │ ring gain  │ total gain │
  ├─────────┼─────────┼────────────┼────────────┤
  │       1 │       8 │  −10 …  +5%│   −4 … +3% │
  ├─────────┼─────────┼────────────┼────────────┤
  │       2 │      16 │  −12 … −5% │   −5 … +3% │
  ├─────────┼─────────┼────────────┼────────────┤
  │       4 │      32 │  −12 … −5% │   −5 … +3% │
  ├─────────┼─────────┼────────────┼────────────┤
  │       8 │      64 │  −12 … −5% │   −5 … +3% │
  ├─────────┼─────────┼────────────┼────────────┤
  │      16 │     128 │  −15 … −5% │   −8 … −2% │
  ├─────────┼─────────┼────────────┼────────────┤
  │      32 │     256 │  −15 … −5% │  −12 … −3% │
  ├─────────┼─────────┼────────────┼────────────┤
  │      48 │     384 │  −15 … −5% │  −14 … −5% │
  ├─────────┼─────────┼────────────┼────────────┤
  │      64 │     512 │ −25 … −10% │  −16 … −8% │
  ├─────────┼─────────┼────────────┼────────────┤
  │      96 │     768 │ −45 … −20% │ −18 … −10% │
  ├─────────┼─────────┼────────────┼────────────┤
  │     128 │    1024 │ −55 … −35% │ −25 … −12% │
  ├─────────┼─────────┼────────────┼────────────┤
  │     256 │    2048 │ −60 … −35% │ −32 … −15% │
  ├─────────┼─────────┼────────────┼────────────┤
  │     512 │    4096 │ −70 … −40% │ −36 … −20% │
  ├─────────┼─────────┼────────────┼────────────┤
  │    1024 │    8192 │ −75 … −45% │ −42 … −25% │
  └─────────┴─────────┴────────────┴────────────┘
```
See more results in https://amd.atlassian.net/wiki/spaces/MLSE/pages/1642418917/Bootstrap+Large-scale+WS

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
