### PR TITLE
[RCCL][test_runner] Run all net-ib tests through ib-cast plugin

### DIFF
--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -1496,6 +1496,67 @@
           "test_filter": "CeFaultInjTest.MultipleFaultsArmedAndCleared"
         }
       ]
+    },
+
+    "net_ib_initialization_cast": {
+      "extends": "net_ib_initialization",
+      "env_variables": { "NCCL_NET": "ib-cast" }
+    },
+    "net_ib_properties_cast": {
+      "extends": "net_ib_properties",
+      "env_variables": { "NCCL_NET": "ib-cast" }
+    },
+    "net_ib_connection_cast": {
+      "extends": "net_ib_connection",
+      "env_variables": { "NCCL_NET": "ib-cast" }
+    },
+    "net_ib_memory_cast": {
+      "extends": "net_ib_memory",
+      "env_variables": { "NCCL_NET": "ib-cast" }
+    },
+    "net_ib_transfer_cast": {
+      "extends": "net_ib_transfer",
+      "env_variables": { "NCCL_NET": "ib-cast" }
+    },
+    "net_ib_multirecv_cast": {
+      "extends": "net_ib_multirecv",
+      "env_variables": { "NCCL_NET": "ib-cast" }
+    },
+    "net_ib_cts_stress_cast": {
+      "extends": "net_ib_cts_stress",
+      "env_variables": { "NCCL_NET": "ib-cast" }
+    },
+    "net_ib_branch_coverage_cast": {
+      "extends": "net_ib_branch_coverage",
+      "env_variables": { "NCCL_NET": "ib-cast" }
+    },
+    "net_ib_stress_cast": {
+      "extends": "net_ib_stress",
+      "env_variables": { "NCCL_NET": "ib-cast" }
+    },
+    "net_ib_stress_4rank_cast": {
+      "extends": "net_ib_stress_4rank",
+      "env_variables": { "NCCL_NET": "ib-cast" }
+    },
+    "net_ib_stress_multi_qp_split_cast": {
+      "extends": "net_ib_stress_multi_qp_split",
+      "env_variables": { "NCCL_NET": "ib-cast" }
+    },
+    "net_ib_stress_multi_qp_nosplit_cast": {
+      "extends": "net_ib_stress_multi_qp_nosplit",
+      "env_variables": { "NCCL_NET": "ib-cast" }
+    },
+    "net_ib_stress_multi_qp_fanin_cast": {
+      "extends": "net_ib_stress_multi_qp_fanin",
+      "env_variables": { "NCCL_NET": "ib-cast" }
+    },
+    "net_ib_stress_ar_cast": {
+      "extends": "net_ib_stress_ar",
+      "env_variables": { "NCCL_NET": "ib-cast" }
+    },
+    "net_ib_stress_inline_cast": {
+      "extends": "net_ib_stress_inline",
+      "env_variables": { "NCCL_NET": "ib-cast" }
     }
   },
   "test_suites": [
@@ -1761,6 +1822,96 @@
       "name": "CE Fault Injection Tests",
       "description": "Per-function error injection for CE code paths (ENABLE_FAULT_INJECTION build). Verifies ncclSystemError propagation and recovery for Init, SyncPrep, and LaunchOp faults.",
       "config": "ce_fault_injection",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Initialization Tests (ib-cast)",
+      "description": "InfiniBand plugin initialization and device enumeration via ib-cast plugin (NCCL_NET=ib-cast)",
+      "config": "net_ib_initialization_cast",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Device Properties (ib-cast)",
+      "description": "InfiniBand device properties via ib-cast plugin (NCCL_NET=ib-cast)",
+      "config": "net_ib_properties_cast",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Connection Setup (ib-cast)",
+      "description": "InfiniBand connection setup via ib-cast plugin (NCCL_NET=ib-cast)",
+      "config": "net_ib_connection_cast",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Memory Registration (ib-cast)",
+      "description": "InfiniBand memory registration via ib-cast plugin (NCCL_NET=ib-cast)",
+      "config": "net_ib_memory_cast",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Data Transfer (ib-cast)",
+      "description": "InfiniBand data transfer via ib-cast plugin (NCCL_NET=ib-cast)",
+      "config": "net_ib_transfer_cast",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - MultiRecv (ib-cast)",
+      "description": "InfiniBand multi-recv path via ib-cast plugin (NCCL_NET=ib-cast)",
+      "config": "net_ib_multirecv_cast",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - CTS Depth Stress (ib-cast)",
+      "description": "InfiniBand CTS depth stress via ib-cast plugin (NCCL_NET=ib-cast)",
+      "config": "net_ib_cts_stress_cast",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Branch Coverage (ib-cast)",
+      "description": "InfiniBand branch coverage tests via ib-cast plugin (NCCL_NET=ib-cast)",
+      "config": "net_ib_branch_coverage_cast",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Stress (2-rank) (ib-cast)",
+      "description": "InfiniBand 2-rank stress via ib-cast plugin (NCCL_NET=ib-cast)",
+      "config": "net_ib_stress_cast",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Stress (4-rank) (ib-cast)",
+      "description": "InfiniBand 4-rank stress via ib-cast plugin (NCCL_NET=ib-cast)",
+      "config": "net_ib_stress_4rank_cast",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Stress Multi-QP Split (ib-cast)",
+      "description": "InfiniBand multi-QP split-data stress via ib-cast plugin (NCCL_NET=ib-cast)",
+      "config": "net_ib_stress_multi_qp_split_cast",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Stress Multi-QP NoSplit (ib-cast)",
+      "description": "InfiniBand multi-QP no-split stress via ib-cast plugin (NCCL_NET=ib-cast)",
+      "config": "net_ib_stress_multi_qp_nosplit_cast",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Stress Multi-QP Fan-In (ib-cast)",
+      "description": "InfiniBand multi-QP fan-in stress via ib-cast plugin (NCCL_NET=ib-cast)",
+      "config": "net_ib_stress_multi_qp_fanin_cast",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Stress AR Threshold (ib-cast)",
+      "description": "InfiniBand AR threshold stress via ib-cast plugin (NCCL_NET=ib-cast)",
+      "config": "net_ib_stress_ar_cast",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Stress Inline CTS (ib-cast)",
+      "description": "InfiniBand inline CTS stress via ib-cast plugin (NCCL_NET=ib-cast)",
+      "config": "net_ib_stress_inline_cast",
       "enabled": true
     }
   ]


### PR DESCRIPTION
## Motivation

Mirror every net_ib_* test group in mi300x_mellanox_ib.json into a matching *_cast variant that sets NCCL_NET=ib-cast, and add suite entries for the runner. Covers: init, properties, connection, memory, transfer, multirecv, cts_stress, branch_coverage and the six stress groups (2-rank/4-rank/multi_qp_split/nosplit/fanin/ar/inline).

This brings mi300x_mellanox_ib.json in line with net_ib_transport.json which already exposes the ib-cast plugin path through *_cast configs.

## Test result

CI run:

```
NET IB - Initialization Tests (ib-cast)  NetIB_Init_Plugin                        PASSED     2.320 seconds
NET IB - Initialization Tests (ib-cast)  NetIB_Init_GetDeviceCount                PASSED     2.371 seconds
NET IB - Device Properties (ib-cast)     NetIB_Props_GetProperties                PASSED     2.522 seconds
NET IB - Device Properties (ib-cast)     NetIB_Props_InvalidDevice                PASSED     2.371 seconds
NET IB - Connection Setup (ib-cast)      NetIB_Conn_MultipleSequential            PASSED     8.088 seconds
NET IB - Connection Setup (ib-cast)      NetIB_Conn_RapidConnectDisconnect        SKIPPED    2.571 seconds
NET IB - Memory Registration (ib-cast)   NetIB_Mem_RegisterHost                   PASSED     8.188 seconds
NET IB - Memory Registration (ib-cast)   NetIB_Mem_RegisterGpu                    PASSED     2.822 seconds
NET IB - Data Transfer (ib-cast)         NetIB_Xfer_SimpleSendRecv                PASSED     2.821 seconds
NET IB - Data Transfer (ib-cast)         NetIB_Xfer_MultipleSizes                 PASSED     2.871 seconds
NET IB - Data Transfer (ib-cast)         NetIB_Stress_LargeTransfer               PASSED     2.872 seconds
NET IB - Data Transfer (ib-cast)         NetIB_Xfer_DifferentMemoryTypes          SKIPPED    2.573 seconds
NET IB - Data Transfer (ib-cast)         NetIB_Xfer_MultipleSizesFusion           SKIPPED    7.907 seconds
NET IB - Data Transfer (ib-cast)         NetIB_Xfer_MultipleOutstanding           SKIPPED    7.623 seconds
NET IB - MultiRecv (ib-cast)             NetIB_MultiRecv                          PASSED     5.830 seconds
NET IB - MultiRecv (ib-cast)             NetIB_MultiRecvShuffled                  PASSED     5.678 seconds
NET IB - MultiRecv (ib-cast)             NetIB_MultiRecvGPUShuffled               SKIPPED    2.671 seconds
NET IB - CTS Depth Stress (ib-cast)      NetIB_CtsDepthStress                     PASSED     4.224 seconds
NET IB - Branch Coverage (ib-cast)       NetIB_Branch_InvalidRecvCount            PASSED     2.822 seconds
NET IB - Branch Coverage (ib-cast)       NetIB_Branch_MrCacheRefCount             PASSED     2.771 seconds
NET IB - Branch Coverage (ib-cast)       NetIB_Branch_SendSizeClamping            PASSED     2.823 seconds
NET IB - Branch Coverage (ib-cast)       NetIB_Branch_NullCommClose               PASSED     7.787 seconds
NET IB - Branch Coverage (ib-cast)       NetIB_Branch_SetNetAttrNoOp              PASSED     2.421 seconds
NET IB - Stress (2-rank) (ib-cast)       NetIB_Stress_TagZeroReuse                PASSED     9.241 seconds
NET IB - Stress (2-rank) (ib-cast)       NetIB_Stress_FifoPressureSenderFast      PASSED     13.152 seconds
NET IB - Stress (2-rank) (ib-cast)       NetIB_Stress_MixedSizeBarrage            PASSED     3.422 seconds
NET IB - Stress (2-rank) (ib-cast)       NetIB_Stress_RequestSlotExhaustion       PASSED     3.174 seconds
NET IB - Stress (2-rank) (ib-cast)       NetIB_Stress_MemoryRegistrationStorm     PASSED     2.970 seconds
NET IB - Stress (2-rank) (ib-cast)       NetIB_Stress_ConcurrentMultiConnection   PASSED     8.890 seconds
NET IB - Stress (2-rank) (ib-cast)       NetIB_Stress_ConnectionChurn             PASSED     62.137 seconds
NET IB - Stress (2-rank) (ib-cast)       NetIB_Stress_ConnectionBatch             PASSED     63.101 seconds
NET IB - Stress (2-rank) (ib-cast)       NetIB_Stress_BidirectionalSaturation     PASSED     9.543 seconds
NET IB - Stress (2-rank) (ib-cast)       NetIB_Stress_LongRunningEndurance        PASSED     176.084 seconds
NET IB - Stress (2-rank) (ib-cast)       NetIB_Stress_GpuMemoryTransfer           PASSED     8.689 seconds
NET IB - Stress (2-rank) (ib-cast)       NetIB_Stress_RapidRecvPostDrain          PASSED     35.462 seconds
NET IB - Stress (4-rank) (ib-cast)       NetIB_Stress_FanIn                       PASSED     12.995 seconds
NET IB - Stress (4-rank) (ib-cast)       NetIB_Stress_FanOut                      PASSED     7.078 seconds
NET IB - Stress (4-rank) (ib-cast)       NetIB_Stress_AllToAll                    PASSED     12.089 seconds
NET IB - Stress (4-rank) (ib-cast)       NetIB_Stress_BidirectionalMultiRank      PASSED     19.348 seconds
NET IB - Stress (4-rank) (ib-cast)       NetIB_Stress_LongRunningMultiRank        PASSED     62.671 seconds
NET IB - Stress Multi-QP Split (ib-cast) NetIB_Stress_MultiQpSplitData            PASSED     10.042 seconds
NET IB - Stress Multi-QP NoSplit (ib-cast) NetIB_Stress_MultiQpNoSplit              PASSED     10.490 seconds
NET IB - Stress Multi-QP Fan-In (ib-cast) NetIB_Stress_MultiQpFanIn                PASSED     13.495 seconds
NET IB - Stress AR Threshold (ib-cast)   NetIB_Stress_ARThreshold                 PASSED     8.481 seconds
NET IB - Stress Inline CTS (ib-cast)     NetIB_Stress_InlineSend                  PASSED     8.129 seconds
------------------------------------------------------------------------------------------------------------------------
Total Tests:   289
Passed:        269
Failed:        1
Skipped:       19
Timeout:       0
Skipped:       19
Total Time:    4 hr 48 min 47.26 sec
========================================================================================================================
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
