### PR TITLE
[RCCL] Show HIP/ROCm runtime versions in NCCL_DEBUG

### DIFF
--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -988,6 +988,10 @@ else()
 endif()
 target_link_libraries(rccl PRIVATE   dl)
 target_link_libraries(rccl PRIVATE   ${SMI_LIBRARIES})
+# librocm-core provides getROCmVersion() for reporting the runtime ROCm version.
+if(ROCM_MAJOR_VERSION GREATER_EQUAL 6)
+  target_link_libraries(rccl PRIVATE -L${ROCM_PATH}/lib -lrocm-core)
+endif()
 # Wrap fmt in $<BUILD_INTERFACE:...> so it's only used while building rccl
 # and is omitted from the exported rccl-targets export set. Without this,
 # a FetchContent-built fmt-header-only target leaks into rccl's link

--- a/projects/rccl/src/include/hip_rocm_version_info.h
+++ b/projects/rccl/src/include/hip_rocm_version_info.h
@@ -55,4 +55,42 @@ THE SOFTWARE.
    #endif
 #endif
 
+// Header-only helpers for runtime version reporting.
+#include <string>
+#include <fmt/format.h>
+
+// A version with `valid` cleared when the originating query failed.
+struct VersionInfo {
+  bool valid;
+  unsigned major;
+  unsigned minor;
+  unsigned patch;
+};
+
+// Decode hipRuntimeGetVersion(): MAJOR*10000000 + MINOR*100000 + PATCH.
+inline VersionInfo decodeHipVer(int v) {
+  return VersionInfo{true, (unsigned)(v / 10000000),
+                     (unsigned)((v / 100000) % 100), (unsigned)(v % 100000)};
+}
+
+inline bool sameVer(const VersionInfo& a, const VersionInfo& b) {
+  return a.major == b.major && a.minor == b.minor && a.patch == b.patch;
+}
+
+// Runtime values appended only when valid and different from compile-time.
+inline std::string fmtExtVer(
+    const std::string& hipBase, const VersionInfo& hipRt, const VersionInfo& hipCt,
+    const std::string& rocmBase, const VersionInfo& rocmRt, const VersionInfo& rocmCt) {
+  // Determine the maximum width of the base strings for alignment.
+  const size_t width = hipBase.size() > rocmBase.size() ? hipBase.size() : rocmBase.size();
+  auto line = [width](const std::string& base, const char* label,
+                      const VersionInfo& rt, const VersionInfo& ct) {
+    if (!rt.valid || sameVer(rt, ct))
+      return base;
+    return fmt::format("{:<{}} / {} : {}.{}.{}", base, width, label, rt.major, rt.minor, rt.patch);
+  };
+  return line(hipBase,  "HIP runtime ", hipRt,  hipCt) + '\n'
+       + line(rocmBase, "ROCm runtime", rocmRt, rocmCt);
+}
+
 #endif

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -918,40 +918,56 @@ fail:
 // Pre-process the string so that running "strings" on the lib can quickly reveal the version.
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
 #define VERSION_STRING "RCCL version : " STR(NCCL_MAJOR) "." STR(NCCL_MINOR) "." STR(NCCL_PATCH) NCCL_SUFFIX
-#define VERSION_STRING_EXTENDED "HIP version  : " HIP_BUILD_INFO "\nROCm version : " ROCM_BUILD_INFO
+#define HIP_VERSION_STRING  "HIP version  : " HIP_BUILD_INFO
+#define ROCM_VERSION_STRING "ROCm version : " ROCM_BUILD_INFO
+#define VERSION_STRING_EXTENDED HIP_VERSION_STRING "\n" ROCM_VERSION_STRING
 #else
 #define VERSION_STRING "NCCL version " STR(NCCL_MAJOR) "." STR(NCCL_MINOR) "." STR(NCCL_PATCH) NCCL_SUFFIX
 #define VERSION_STRING_EXTENDED "CUDA version " STR(CUDA_MAJOR) "." STR(CUDA_MINOR)
 #endif
 static void showVersion() {
-  char versionInfo[2048+2*HOST_NAME_MAX], hostInfo[HOST_NAME_MAX], libPathInfo[2048];
-
   // Retrieve Hostname info
-  if (gethostname(hostInfo, sizeof(hostInfo)-1) != 0) {
-    // Returns Unknown in hostInfo if function call unsuccessful
-    strncpy(hostInfo, "Unknown", sizeof(hostInfo)-1);
-  }
+  char hostBuf[HOST_NAME_MAX];
+  std::string hostInfo = (gethostname(hostBuf, sizeof(hostBuf)-1) == 0) ? hostBuf : "Unknown";
 
   // Retrieve librccl path
   Dl_info pathInfo;
-  if (dladdr((void*)ncclCommInitRank, &pathInfo)) {
-    strncpy(libPathInfo, pathInfo.dli_fname, sizeof(libPathInfo)-1);
-  } else {
-    // Sets libPath to Unknown if the above function call is not successful
-    strncpy(libPathInfo, "Unknown", sizeof(libPathInfo)-1);
-  }
+  std::string libPathInfo =
+      dladdr((void*)ncclCommInitRank, &pathInfo) ? pathInfo.dli_fname : "Unknown";
 
-  snprintf(versionInfo, sizeof(versionInfo),
-    "%s-%s\n%s\n"
-    "%-12s : %s\n%12s : %s",
-    VERSION_STRING, rcclGitHash, VERSION_STRING_EXTENDED,
-    "Hostname", hostInfo, "Librccl path", libPathInfo
-  );
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+  // Query the active HIP/ROCm runtime to report alongside the compile-time
+  // versions when they differ.
+  VersionInfo hipRt{};
+  int hipRuntimeVer = 0;
+  if (hipRuntimeGetVersion(&hipRuntimeVer) == hipSuccess)
+    hipRt = decodeHipVer(hipRuntimeVer);
+  const VersionInfo hipCt = {true, HIP_VERSION_MAJOR, HIP_VERSION_MINOR, HIP_VERSION_PATCH};
+
+  VersionInfo rocmRt{}, rocmCt{};
+#if ROCM_VERSION >= 60000
+  // getROCmVersion() is provided by librocm-core.
+  unsigned int rocmMajor = 0, rocmMinor = 0, rocmPatch = 0;
+  if (getROCmVersion(&rocmMajor, &rocmMinor, &rocmPatch) == VerSuccess)
+    rocmRt = VersionInfo{true, rocmMajor, rocmMinor, rocmPatch};
+  rocmCt = VersionInfo{true, ROCM_VERSION_MAJOR, ROCM_VERSION_MINOR, ROCM_VERSION_PATCH};
+#endif
+
+  std::string extendedInfo = fmtExtVer(HIP_VERSION_STRING, hipRt, hipCt,
+                                       ROCM_VERSION_STRING, rocmRt, rocmCt);
+#else
+  std::string extendedInfo = VERSION_STRING_EXTENDED;
+#endif
+
+  std::string versionInfo = fmt::format(
+    "{}-{}\n{}\n{:<12} : {}\n{:>12} : {}",
+    VERSION_STRING, rcclGitHash, extendedInfo,
+    "Hostname", hostInfo, "Librccl path", libPathInfo);
 
   if (ncclDebugLevel == NCCL_LOG_VERSION || ncclDebugLevel == NCCL_LOG_WARN) {
-    VERSION("%s", versionInfo);
+    VERSION("%s", versionInfo.c_str());
   } else {
-    INFO(NCCL_ALL,"%s", versionInfo);
+    INFO(NCCL_ALL,"%s", versionInfo.c_str());
   }
 }
 

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -222,6 +222,7 @@ if(BUILD_TESTS)
       RomeTopoConsensusTests.cpp
       EnqueueCountTests.cpp
       DdaCollCommonTests.cpp
+      VersionInfoTests.cpp
       device/TestOp128.cpp
       device/GinDeviceTests.cpp
       common/main_fixtures.cpp

--- a/projects/rccl/test/VersionInfoTests.cpp
+++ b/projects/rccl/test/VersionInfoTests.cpp
@@ -1,0 +1,76 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+#include "hip_rocm_version_info.h"
+#include "gtest/gtest.h"
+
+namespace RcclUnitTesting
+{
+    constexpr const char* kHipBase  = "HIP version  : 6.4.0";
+    constexpr const char* kRocmBase = "ROCm version : 6.4.0";
+
+    TEST(VersionInfoTests, DecodeHipVer)
+    {
+        VersionInfo v = decodeHipVer(60443210);
+        EXPECT_TRUE(v.valid);
+        EXPECT_EQ(v.major, 6u);
+        EXPECT_EQ(v.minor, 4u);
+        EXPECT_EQ(v.patch, 43210u);
+    }
+
+    TEST(VersionInfoTests, SameVer)
+    {
+        EXPECT_TRUE(sameVer({true, 6, 4, 0}, {true, 6, 4, 0}));
+        EXPECT_FALSE(sameVer({true, 6, 4, 0}, {true, 6, 4, 1}));
+        EXPECT_FALSE(sameVer({true, 6, 4, 0}, {true, 6, 3, 0}));
+        EXPECT_TRUE(sameVer({false, 6, 4, 0}, {true, 6, 4, 0}));
+    }
+
+    TEST(VersionInfoTests, OmitMatch)
+    {
+        std::string s = fmtExtVer(
+            kHipBase,  {true, 6, 4, 0}, {true, 6, 4, 0},
+            kRocmBase, {true, 6, 4, 0}, {true, 6, 4, 0});
+        EXPECT_EQ(s, "HIP version  : 6.4.0\nROCm version : 6.4.0");
+    }
+
+    TEST(VersionInfoTests, OmitInvalid)
+    {
+        std::string s = fmtExtVer(
+            kHipBase,  {false, 9, 9, 9}, {true, 6, 4, 0},
+            kRocmBase, {false, 9, 9, 9}, {true, 6, 4, 0});
+        EXPECT_EQ(s, "HIP version  : 6.4.0\nROCm version : 6.4.0");
+    }
+
+    TEST(VersionInfoTests, AppendDiffer)
+    {
+        std::string s = fmtExtVer(
+            kHipBase,  {true, 6, 5, 1}, {true, 6, 4, 0},
+            kRocmBase, {true, 6, 5, 0}, {true, 6, 4, 0});
+        EXPECT_EQ(s,
+            "HIP version  : 6.4.0 / HIP runtime  : 6.5.1\n"
+            "ROCm version : 6.4.0 / ROCm runtime : 6.5.0");
+    }
+
+    TEST(VersionInfoTests, PatchOnlyDiffer)
+    {
+        std::string s = fmtExtVer(
+            kHipBase,  {true, 6, 4, 1}, {true, 6, 4, 0},
+            kRocmBase, {true, 6, 4, 1}, {true, 6, 4, 0});
+        EXPECT_EQ(s,
+            "HIP version  : 6.4.0 / HIP runtime  : 6.4.1\n"
+            "ROCm version : 6.4.0 / ROCm runtime : 6.4.1");
+    }
+
+    TEST(VersionInfoTests, MixedDiffer)
+    {
+        std::string s = fmtExtVer(
+            kHipBase,  {true, 6, 5, 0}, {true, 6, 4, 0},
+            kRocmBase, {true, 6, 4, 0}, {true, 6, 4, 0});
+        EXPECT_EQ(s,
+            "HIP version  : 6.4.0 / HIP runtime  : 6.5.0\n"
+            "ROCm version : 6.4.0");
+    }
+}

--- a/projects/rccl/tools/scripts/test_runner/configs/ci-precheckin.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/ci-precheckin.json
@@ -174,6 +174,7 @@
         {"name": "CommTests", "description": "Communicator helper tests", "test_filter": "CommTests.*"},
         {"name": "EnqueueCountTests", "description": "Enqueue send/recv count helpers", "test_filter": "EnqueueCountTests.*"},
         {"name": "MiscTests.Sorter", "description": "Task coll sorter unit test", "test_filter": "MiscTests.Sorter"},
+        {"name": "VersionInfoTests", "description": "HIP/ROCm version string formatting tests", "test_filter": "VersionInfoTests.*"},
         {"name": "GinDeviceTest", "description": "GIN proxy backend device-leaf tests", "test_filter": "GinDeviceTest.*"}
       ]
     }


### PR DESCRIPTION
## Motivation

`NCCL_DEBUG=VERSION` previously printed only the compile-time HIP/ROCm versions. When the same `librccl.so` is reused across containers/nodes whose ROCm/HIP differs from the one RCCL was built against, the log gives no indication of the mismatch.

## Technical Details

- `showVersion()` queries `hipRuntimeGetVersion()` and `getROCmVersion()` (from `librocm-core`), and appends `HIP runtime` / `ROCm runtime` next to the compile-time versions only when they differ from compile-time `HIP_VERSION_{MAJOR,MINOR,PATCH}` / `ROCM_VERSION_{MAJOR,MINOR,PATCH}`. Applies to the VERSION, WARN, and INFO output paths.
- `getROCmVersion()` call is gated on `ROCM_VERSION >= 60000`; `target_link_libraries(rccl PRIVATE -lrocm-core)` is gated by `if(ROCM_MAJOR_VERSION GREATER_EQUAL 6)`.
- Version-string assembly moves to header-only helpers (`VersionInfo`, `decodeHipVer`, `sameVer`, `fmtExtVer`) in `hip_rocm_version_info.h`, so the logic is unit-testable without linking `librccl.so`. The runtime columns are padded to a common width so they align across the HIP/ROCm lines.
- `showVersion()` drops its fixed `char[]` buffers in favor of `std::string`/`fmt` for the hostname, librccl path, and version lines.
- Unit tests added under `rccl-UnitTestsFixtures` (`VersionInfoTests`) and registered in the `ci-precheckin` test-runner config.

## JIRA ID

Resolves AICOMRCCL-677.

## Test Plan

- Unit tests: `rccl-UnitTestsFixtures --gtest_filter=VersionInfoTests.*`.
- Build RCCL on a host with one ROCm version, run inside a Docker container with a different ROCm/HIP — verify the runtime lines appear and align. Run on the bare host (matching versions) — verify they're suppressed. Repeat across `NCCL_DEBUG=VERSION`, `WARN`, and `INFO`.

## Test Result

Host build ROCm 7.2.3 / HIP 7.2.53211, run inside `rocm/dev-ubuntu-24.04:7.1.1-complete` (ROCm 7.1.1 / HIP 7.1.52802):

```
HIP version  : 7.2.53211-c2d9476115  / HIP runtime  : 7.1.52802
ROCm version : 7.2.3.0-90-c2d9476115 / ROCm runtime : 7.1.1
```

On the bare host (compile-time == runtime) the runtime suffixes are suppressed. `VersionInfoTests`: 7/7 passing.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
