### PR TITLE
[rocprofiler-sdk] Fail cleanly when attach helper thread is missing

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
@@ -262,8 +262,8 @@ setup(int pid)
         if(target_tid < 0)
         {
             ROCP_ERROR << "[rocprofiler-sdk-rocattach] Cannot attach to process " << pid
-                       << ": 'rocp-bg-attach' thread not found. The target process was not "
-                          "started with attach support enabled. Start the target with "
+                       << ": 'rocp-bg-attach' thread not found. The target process does not "
+                          "appear to have attach support enabled. Start the target with "
                           "ROCP_TOOL_ATTACH=1, or use a rocprofiler-register build configured "
                           "with ROCPROFILER_REGISTER_BUILD_DEFAULT_ATTACHMENT=ON.";
             return ROCATTACH_STATUS_ERROR;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
@@ -225,8 +225,8 @@ resolve_attach_tid(pid_t pid)
 
     if(ec)
     {
-        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Failed to scan " << task_dir << ": "
-                   << ec.message();
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Failed to scan " << task_dir
+                   << " for 'rocp-bg-attach' thread: " << ec.message();
     }
     else
     {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
@@ -201,6 +201,7 @@ build_environment_buffer()
     return environment_buffer;
 }
 
+// Returns the TID of the 'rocp-bg-attach' thread if found, or -1 if not found
 pid_t
 resolve_attach_tid(pid_t pid)
 {
@@ -222,9 +223,18 @@ resolve_attach_tid(pid_t pid)
         }
     }
 
-    ROCP_WARNING << "[rocprofiler-sdk-rocattach] Could not find 'rocp-bg-attach' thread in "
-                 << task_dir << ", falling back to pid " << pid;
-    return pid;
+    if(ec)
+    {
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Failed to scan " << task_dir << ": "
+                   << ec.message();
+    }
+    else
+    {
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Could not find 'rocp-bg-attach' thread in "
+                   << task_dir;
+    }
+
+    return -1;
 }
 
 rocattach_status_t
@@ -248,6 +258,17 @@ setup(int pid)
         }
 
         auto target_tid = resolve_attach_tid(pid);
+
+        if(target_tid < 0)
+        {
+            ROCP_ERROR << "[rocprofiler-sdk-rocattach] Cannot attach to process " << pid
+                       << ": 'rocp-bg-attach' thread not found. The target process was not "
+                          "started with attach support enabled. Start the target with "
+                          "ROCP_TOOL_ATTACH=1, or use a rocprofiler-register build configured "
+                          "with ROCPROFILER_REGISTER_BUILD_DEFAULT_ATTACHMENT=ON.";
+            return ROCATTACH_STATUS_ERROR;
+        }
+
         ROCP_INFO << "[rocprofiler-sdk-rocattach] Attaching to PID " << pid
                   << " via background thread TID " << target_tid;
         sessions->emplace(pid, target_tid);

--- a/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
@@ -115,6 +115,7 @@ rocprofiler_add_integration_execute_test(
     ARGS $<TARGET_FILE:attachment-test> attach
     TIMEOUT 45
     DISABLED ${IS_DISABLED}
+    LABELS "attachment"
     PRELOAD "${PRELOAD_ENV}"
     ENVIRONMENT "${rocattach-without-env-test-env}"
     PASS_REGULAR_EXPRESSION "Test PASSED: attach failed cleanly without crashing target"
@@ -127,6 +128,7 @@ rocprofiler_add_integration_execute_test(
     ARGS $<TARGET_FILE:attachment-test> attach-tree
     TIMEOUT 45
     DISABLED ${IS_DISABLED}
+    LABELS "attachment"
     PRELOAD "${PRELOAD_ENV}"
     ENVIRONMENT "${rocattach-without-env-test-env}"
     PASS_REGULAR_EXPRESSION "Test PASSED: attach failed cleanly without crashing target"

--- a/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
@@ -91,7 +91,7 @@ rocprofiler_add_integration_execute_test(
     PASS_REGULAR_EXPRESSION "verified: grandchild pid [0-9]+ loaded the tool library"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")
 
-# Test that attach fails cleanly when target process lacks ROCP_TOOL_ATTACH=1. Verifies
+# Test that attach fails gracefully when target process lacks ROCP_TOOL_ATTACH=1. Verifies
 # that rocattach returns an error status without crashing the target.
 add_executable(rocattach-without-env-test)
 target_sources(rocattach-without-env-test PRIVATE attach_without_env.cpp)
@@ -118,7 +118,8 @@ rocprofiler_add_integration_execute_test(
     LABELS "attachment"
     PRELOAD "${PRELOAD_ENV}"
     ENVIRONMENT "${rocattach-without-env-test-env}"
-    PASS_REGULAR_EXPRESSION "Test PASSED: attach failed cleanly without crashing target"
+    PASS_REGULAR_EXPRESSION
+        "Test PASSED: attach failed gracefully without crashing target"
     FAIL_REGULAR_EXPRESSION "Test FAILED|error: attach succeeded|unexpected attach status"
     )
 
@@ -131,6 +132,7 @@ rocprofiler_add_integration_execute_test(
     LABELS "attachment"
     PRELOAD "${PRELOAD_ENV}"
     ENVIRONMENT "${rocattach-without-env-test-env}"
-    PASS_REGULAR_EXPRESSION "Test PASSED: attach failed cleanly without crashing target"
+    PASS_REGULAR_EXPRESSION
+        "Test PASSED: attach failed gracefully without crashing target"
     FAIL_REGULAR_EXPRESSION "Test FAILED|error: attach succeeded|unexpected attach status"
     )

--- a/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
@@ -90,3 +90,45 @@ rocprofiler_add_integration_execute_test(
     ENVIRONMENT "${rocattach-test-env}"
     PASS_REGULAR_EXPRESSION "verified: grandchild pid [0-9]+ loaded the tool library"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")
+
+# Test that attach fails cleanly when target process lacks ROCP_TOOL_ATTACH=1. Verifies
+# that rocattach returns an error status without crashing the target.
+add_executable(rocattach-without-env-test)
+target_sources(rocattach-without-env-test PRIVATE attach_without_env.cpp)
+target_link_libraries(
+    rocattach-without-env-test
+    PRIVATE rocprofiler-sdk::rocprofiler-sdk rocprofiler-sdk::tests-build-flags
+            rocprofiler-sdk::tests-common-library
+            rocprofiler-sdk::rocprofiler-sdk-rocattach-shared-library)
+
+# Deliberately omit ROCP_TOOL_ATTACH=1 to test error handling
+set(rocattach-without-env-test-env
+    "ROCPROFILER_REGISTER_LOG_LEVEL=${LOG_LEVEL}"
+    "ROCPROFILER_LOG_LEVEL=${LOG_LEVEL}"
+    "ROCATTACH_LOG_LEVEL=${LOG_LEVEL}"
+    "LD_LIBRARY_PATH=$<TARGET_FILE_DIR:rocprofiler-sdk::rocprofiler-sdk-shared-library>:$ENV{LD_LIBRARY_PATH}"
+    )
+
+rocprofiler_add_integration_execute_test(
+    rocattach-without-env-test-execute
+    TARGET rocattach-without-env-test
+    ARGS $<TARGET_FILE:attachment-test> attach
+    TIMEOUT 45
+    DISABLED ${IS_DISABLED}
+    PRELOAD "${PRELOAD_ENV}"
+    ENVIRONMENT "${rocattach-without-env-test-env}"
+    PASS_REGULAR_EXPRESSION "Test PASSED: attach failed cleanly without crashing target"
+    FAIL_REGULAR_EXPRESSION "Test FAILED|error: attach succeeded|unexpected attach status"
+    )
+
+rocprofiler_add_integration_execute_test(
+    rocattach-without-env-tree-test-execute
+    TARGET rocattach-without-env-test
+    ARGS $<TARGET_FILE:attachment-test> attach-tree
+    TIMEOUT 45
+    DISABLED ${IS_DISABLED}
+    PRELOAD "${PRELOAD_ENV}"
+    ENVIRONMENT "${rocattach-without-env-test-env}"
+    PASS_REGULAR_EXPRESSION "Test PASSED: attach failed cleanly without crashing target"
+    FAIL_REGULAR_EXPRESSION "Test FAILED|error: attach succeeded|unexpected attach status"
+    )

--- a/projects/rocprofiler-sdk/tests/rocattach/attach_without_env.cpp
+++ b/projects/rocprofiler-sdk/tests/rocattach/attach_without_env.cpp
@@ -1,0 +1,184 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Test that attach fails cleanly when ROCP_TOOL_ATTACH=1 is not set, instead of
+// crashing the target application.
+//
+// Spawns a child process WITHOUT setting ROCP_TOOL_ATTACH=1, then attempts to attach
+// using either rocattach_attach() or rocattach_attach_tree() (based on command-line arg).
+// The attach should fail with ROCATTACH_STATUS_ERROR and the child process should
+// continue running normally (not crash).
+//
+// Usage: attach_without_env <test_app> [attach|attach-tree]
+
+#include <rocprofiler-sdk-rocattach/defines.h>
+#include <rocprofiler-sdk-rocattach/rocattach.h>
+#include <rocprofiler-sdk-rocattach/types.h>
+
+#include <signal.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <iostream>
+#include <thread>
+
+int
+main(int argc, char** argv)
+{
+    if(argc < 2)
+    {
+        std::cout << "error: wrong number of arguments\n";
+        std::cout << "usage: " << argv[0] << " <test_application_path> [attach|attach-tree]\n";
+        return 1;
+    }
+
+    // Determine which attach function to test
+    bool use_tree_attach = false;
+    if(argc >= 3)
+    {
+        std::string mode{argv[2]};
+        if(mode == "attach-tree")
+        {
+            use_tree_attach = true;
+        }
+        else if(mode != "attach")
+        {
+            std::cout << "error: invalid mode '" << mode
+                      << "', expected 'attach' or 'attach-tree'\n";
+            return 1;
+        }
+    }
+
+    // Explicitly unset ROCP_TOOL_ATTACH to ensure the child process
+    // does NOT have the attach thread initialized
+    unsetenv("ROCP_TOOL_ATTACH");
+
+    pid_t child_pid = fork();
+    if(child_pid < 0)
+    {
+        std::cout << "error: fork failed\n";
+        return 1;
+    }
+
+    if(child_pid == 0)
+    {
+        // Child process: exec the test application WITHOUT ROCP_TOOL_ATTACH=1
+        std::cout << "child executing " << argv[1] << " (without ROCP_TOOL_ATTACH)\n";
+        int ret = execl(argv[1], argv[1], nullptr);
+        if(ret == -1)
+        {
+            std::cout << "error in execl(), errno=" << errno << std::endl;
+            _exit(1);  // Use _exit() after fork, not return
+        }
+    }
+    else
+    {
+        // Parent process: wait for child to exec
+        std::this_thread::sleep_for(std::chrono::milliseconds(2500));
+
+        const char* attach_mode_str =
+            use_tree_attach ? "rocattach_attach_tree" : "rocattach_attach";
+        std::cout << "attempting to attach to pid " << child_pid << " using " << attach_mode_str
+                  << " (should fail with ROCATTACH_STATUS_ERROR)\n";
+
+        // Attempt to attach - this should FAIL because bg-attach thread doesn't exist
+        rocattach_status_t status =
+            use_tree_attach ? rocattach_attach_tree(child_pid) : rocattach_attach(child_pid);
+
+        // Check attach result
+        if(status == ROCATTACH_STATUS_SUCCESS)
+        {
+            std::cout << "error: attach succeeded when it should have failed!\n";
+            std::cout << "The fix is not working correctly.\n";
+            if(use_tree_attach)
+                rocattach_detach_tree(child_pid);
+            else
+                rocattach_detach(child_pid);
+            kill(child_pid, SIGKILL);
+            waitpid(child_pid, nullptr, 0);
+            return 1;
+        }
+
+        if(status != ROCATTACH_STATUS_ERROR)
+        {
+            std::cout << "error: unexpected attach status " << status << "\n";
+            std::cout << "Expected ROCATTACH_STATUS_ERROR (1)\n";
+            kill(child_pid, SIGKILL);
+            waitpid(child_pid, nullptr, 0);
+            return 1;
+        }
+
+        std::cout << "SUCCESS: attach failed as expected with ROCATTACH_STATUS_ERROR\n";
+
+        // Check if child process is still running (reliable check using waitpid WNOHANG)
+        int  child_status = 0;
+        auto wait_ret     = waitpid(child_pid, &child_status, WNOHANG);
+
+        if(wait_ret == 0)
+        {
+            // Child is still running
+            std::cout << "VERIFIED: child process " << child_pid << " is still running\n";
+            std::cout << "Test PASSED: attach failed cleanly without crashing target\n";
+
+            // Clean up: kill the child
+            kill(child_pid, SIGTERM);
+            waitpid(child_pid, nullptr, 0);
+            return 0;
+        }
+        else if(wait_ret == child_pid)
+        {
+            // Child exited
+            std::cout << "Test FAILED: child process " << child_pid
+                      << " exited during failed attach\n";
+            if(WIFSIGNALED(child_status))
+            {
+                std::cout << "ERROR: child exited due to signal " << WTERMSIG(child_status);
+                if(WTERMSIG(child_status) == SIGSEGV)
+                {
+                    std::cout << " (SIGSEGV - segmentation fault)";
+                }
+                std::cout << "\n";
+            }
+            else if(WIFEXITED(child_status))
+            {
+                std::cout << "ERROR: child exited with status " << WEXITSTATUS(child_status)
+                          << "\n";
+            }
+            else
+            {
+                std::cout << "ERROR: child exited unexpectedly\n";
+            }
+            return 1;
+        }
+        else
+        {
+            std::cout << "Test FAILED: waitpid failed, errno=" << errno << "\n";
+            kill(child_pid, SIGKILL);
+            waitpid(child_pid, nullptr, 0);
+            return 1;
+        }
+    }
+
+    return 0;
+}

--- a/projects/rocprofiler-sdk/tests/rocattach/attach_without_env.cpp
+++ b/projects/rocprofiler-sdk/tests/rocattach/attach_without_env.cpp
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Test that attach fails cleanly when ROCP_TOOL_ATTACH=1 is not set, instead of
+// Test that attach fails gracefully when ROCP_TOOL_ATTACH=1 is not set, instead of
 // crashing the target application.
 //
 // Spawns a child process WITHOUT setting ROCP_TOOL_ATTACH=1, then attempts to attach
@@ -94,7 +94,10 @@ main(int argc, char** argv)
     }
     else
     {
-        // Parent process: wait for child to exec
+        // Parent process: heuristic wait for the child to execl(). This is a synchronization
+        // hack: if the child has not exec'd yet, the /proc scan can find no bg-attach thread
+        // and the test may pass for the wrong reason, since that is the expected outcome here.
+        // A pipe handshake would be more robust if this test becomes flaky or more critical.
         std::this_thread::sleep_for(std::chrono::milliseconds(2500));
 
         const char* attach_mode_str =
@@ -103,6 +106,12 @@ main(int argc, char** argv)
                   << " (should fail with ROCATTACH_STATUS_ERROR)\n";
 
         // Attempt to attach - this should FAIL because bg-attach thread doesn't exist
+        //
+        // NOTE: for the attach-tree mode, this test spawns a single child with no descendants,
+        // so rocattach_attach_tree() reduces to one setup() call and the returned last_status
+        // is deterministically ROCATTACH_STATUS_ERROR. If this test is extended to a real
+        // process tree, revisit this expectation because last_status only reflects the last
+        // failure encountered.
         rocattach_status_t status =
             use_tree_attach ? rocattach_attach_tree(child_pid) : rocattach_attach(child_pid);
 
@@ -139,7 +148,7 @@ main(int argc, char** argv)
         {
             // Child is still running
             std::cout << "VERIFIED: child process " << child_pid << " is still running\n";
-            std::cout << "Test PASSED: attach failed cleanly without crashing target\n";
+            std::cout << "Test PASSED: attach failed gracefully without crashing target\n";
 
             // Clean up: kill the child
             kill(child_pid, SIGTERM);


### PR DESCRIPTION
## Motivation

When the target process is not started with attach support enabled, rocattach may not find the expected `rocp-bg-attach` thread under `/proc/<pid>/task`.

Previously, rocattach fell back to using the process PID directly in this case. In the reproduced failure, that fallback path caused the target application to crash inside `rocprofiler_register_attach`.

This PR makes the failure mode safer by returning an error when the attach helper thread is missing, instead of attempting the unsafe fallback path.

## Technical Details

This PR updates rocattach behavior when resolving the target attach thread:

* `resolve_attach_tid()` now returns `-1` when `rocp-bg-attach` is not found.
* `setup()` detects this failure and returns `ROCATTACH_STATUS_ERROR`.
* The previous fallback-to-PID behavior is removed.
* The error message now explains that the target process does not appear to have attach support enabled and should be started with `ROCP_TOOL_ATTACH=1`, or use a `rocprofiler-register` build configured with `ROCPROFILER_REGISTER_BUILD_DEFAULT_ATTACHMENT=ON`.

Regarding `ROCATTACH_STATUS_ERROR` vs a dedicated status such as `ROCATTACH_STATUS_ERROR_NOT_ATTACHABLE`:
The latter would be cleaner for callers. I kept the generic `ROCATTACH_STATUS_ERROR` in this PR to keep the fix minimal and avoid changing the public status enum/API behavior in a regression fix. I can file/follow up separately if we want to expose a more specific attachability failure.

This aligns with the documented process attachment requirement that the target must have attach support enabled before attach is attempted.

## JIRA ID

ROCM-24403

## Test Plan

Added regression coverage for the missing attach-helper-thread case.

The new test starts the target application without `ROCP_TOOL_ATTACH=1` and verifies that rocattach fails cleanly without crashing the target process.

Covered both attach paths:

* `rocattach_attach()`
* `rocattach_attach_tree()`

Also manually verified the original repro using the HIP Jacobi application:

```bash
unset ROCP_TOOL_ATTACH
./Jacobi_hip -g 1 1 -m 16384
rocprofv3 --attach <pid>
```

And verified the positive attach case:

```bash
export ROCP_TOOL_ATTACH=1
./Jacobi_hip -g 1 1 -m 16384
rocprofv3 --attach <pid>
```

## Test Result

Without `ROCP_TOOL_ATTACH=1`, attach now fails cleanly with an error instead of crashing the target process.

With `ROCP_TOOL_ATTACH=1`, attach/detach succeeds and the target application continues running.

The added tests pass for both `rocattach_attach()` and `rocattach_attach_tree()`.

## Submission Checklist

* [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
