### PR TITLE
[rocprofiler-compute] Add code-review skill and tighten agent redirect chain

### DIFF
--- a/projects/rocprofiler-compute/.ai/skills/rocprof-compute-code-review.md
+++ b/projects/rocprofiler-compute/.ai/skills/rocprof-compute-code-review.md
@@ -1,0 +1,7 @@
+# Code Review Skill
+
+Follow **[`AGENTS.md`](../../AGENTS.md)** and the full redirect chain it references.
+
+Understand the changes made in this PR branch. Use the `gh` command to obtain
+the PR metadata and base branch, and to fetch the context of all review
+comments on the PR.

--- a/projects/rocprofiler-compute/.claude/commands/rocprof-compute-code-review.md
+++ b/projects/rocprofiler-compute/.claude/commands/rocprof-compute-code-review.md
@@ -1,0 +1,5 @@
+---
+description: Review the current PR branch against project guidelines.
+---
+
+Follow **[`../../.ai/skills/rocprof-compute-code-review.md`](../../.ai/skills/rocprof-compute-code-review.md)**.

--- a/projects/rocprofiler-compute/.claude/commands/rocprof-compute-code-review.md
+++ b/projects/rocprofiler-compute/.claude/commands/rocprof-compute-code-review.md
@@ -2,4 +2,4 @@
 description: Review the current PR branch against project guidelines.
 ---
 
-Follow **[`../../.ai/skills/rocprof-compute-code-review.md`](../../.ai/skills/rocprof-compute-code-review.md)**.
+Follow **[`.ai/skills/rocprof-compute-code-review.md`](../../.ai/skills/rocprof-compute-code-review.md)**.

--- a/projects/rocprofiler-compute/.cursor/commands/rocprof-compute-code-review.md
+++ b/projects/rocprofiler-compute/.cursor/commands/rocprof-compute-code-review.md
@@ -1,0 +1,5 @@
+---
+description: Review the current PR branch against project guidelines.
+---
+
+Follow [`.ai/skills/rocprof-compute-code-review.md`](../../.ai/skills/rocprof-compute-code-review.md).

--- a/projects/rocprofiler-compute/.cursor/rules/python-coding-style.mdc
+++ b/projects/rocprofiler-compute/.cursor/rules/python-coding-style.mdc
@@ -4,4 +4,4 @@ globs: ["**/*.py"]
 alwaysApply: true
 ---
 
-See **[`AGENTS.md`](../../AGENTS.md)**.
+Follow **[`AGENTS.md`](../../AGENTS.md)** and the full redirect chain it references.

--- a/projects/rocprofiler-compute/.github/copilot-instructions.md
+++ b/projects/rocprofiler-compute/.github/copilot-instructions.md
@@ -1,3 +1,3 @@
 # GitHub Copilot Instructions — rocprofiler-compute
 
-See **[`AGENTS.md`](../AGENTS.md)**.
+Follow **[`AGENTS.md`](../AGENTS.md)** and the full redirect chain it references.

--- a/projects/rocprofiler-compute/.github/prompts/rocprof-compute-code-review.prompt.md
+++ b/projects/rocprofiler-compute/.github/prompts/rocprof-compute-code-review.prompt.md
@@ -1,0 +1,6 @@
+---
+mode: agent
+description: Review the current PR branch against project guidelines.
+---
+
+Follow [`.ai/skills/rocprof-compute-code-review.md`](../../.ai/skills/rocprof-compute-code-review.md).

--- a/projects/rocprofiler-compute/AGENTS.md
+++ b/projects/rocprofiler-compute/AGENTS.md
@@ -1,5 +1,13 @@
 # AI Agent Guidelines — rocprofiler-compute
 
+## README
+
+**[`README.md`](README.md)** is the project's user-facing overview.
+
+## Contributing
+
+**[`CONTRIBUTING.md`](CONTRIBUTING.md)** is the project's contributor guide.
+
 ## Python Code Style
 
 Read and follow **[`.ai/rules/python-style.md`](.ai/rules/python-style.md)** before
@@ -24,3 +32,9 @@ for staging, commit message conventions, pre-commit hook handling, and branch sa
 
 When asked to create a pull request, follow **[`.ai/rules/pr-workflow.md`](.ai/rules/pr-workflow.md)**
 for PR template inference, JIRA handling, formatting, and repo identification.
+
+## Skills
+
+Reusable agent workflows live under **[`.ai/skills/`](.ai/skills/)** with
+tool-specific shims in `.claude/commands/`, `.github/prompts/`, and
+`.cursor/commands/`.

--- a/projects/rocprofiler-compute/CLAUDE.md
+++ b/projects/rocprofiler-compute/CLAUDE.md
@@ -1,3 +1,3 @@
 # Claude Code Guidelines — rocprofiler-compute
 
-See **[`AGENTS.md`](./AGENTS.md)**.
+Follow **[`AGENTS.md`](./AGENTS.md)** and the full redirect chain it references.


### PR DESCRIPTION
## Motivation

Adds a reusable `rocprof-compute-code-review` skill so Claude, Copilot, and Cursor all discover the same project-specific PR review workflow through their native auto-loaded files. Also tightens the existing redirect-chain wording so agents don't stop at `AGENTS.md` and miss the rules under `.ai/rules/`.

## Technical Details

- New canonical skill content at `.ai/skills/rocprof-compute-code-review.md` with tool-specific shims:
  - `.claude/commands/rocprof-compute-code-review.md`
  - `.github/prompts/rocprof-compute-code-review.prompt.md`
  - `.cursor/commands/rocprof-compute-code-review.md`
- `AGENTS.md`: add `README`, `Contributing`, and `Skills` sections so the entry point links contributors and agents at the project's user-facing and contributor docs and the skills index.
- `CLAUDE.md`, `.cursor/rules/python-coding-style.mdc`, `.github/copilot-instructions.md`: reword the redirect from "See AGENTS.md" to "Follow AGENTS.md and the full redirect chain it references" so an agent that opens only the shim still knows to descend into the rule files.

## JIRA ID

## Test Plan

- Verify each shim file points to a valid path.
- Run an agent (Claude, Copilot, Cursor) on this branch and confirm it picks up the redirect chain.

## Test Result

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.