### PR TITLE
[rocprofiler-compute] Exclude from top-level pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ exclude: |
     | projects/amdsmi/
     | projects/rdc/
     | projects/rocm-smi-lib/
+    | projects/rocprofiler-compute/
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
## Motivation

The project ships its own [`projects/rocprofiler-compute/.pre-commit-config.yaml`](https://github.com/ROCm/rocm-systems/blob/develop/projects/rocprofiler-compute/.pre-commit-config.yaml) with project-specific hook versions and local checks. Exclude the path here so the top-level black/clang-format/gersemi don't run on rocprofiler-compute files, matching what amdsmi/rdc/rocm-smi-lib already do.

## Technical Details

- Add `projects/rocprofiler-compute/` to the global `exclude` block in `.pre-commit-config.yaml`.

## JIRA ID

## Test Plan

- [x] Run top-level pre-commit on the commit; verify rocprofiler-compute files are skipped.

## Test Result

- [x] Pre-commit hooks skipped (no files to check) on the commit.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.