### PR TITLE
docker: install ccache in rocprof-sys CI images

### DIFF
--- a/projects/rocprofiler-systems/docker/Dockerfile.opensuse.ci
+++ b/projects/rocprofiler-systems/docker/Dockerfile.opensuse.ci
@@ -26,7 +26,7 @@ RUN set +e; \
 RUN zypper --non-interactive update -y && \
     zypper --non-interactive dist-upgrade -y && \
     zypper --non-interactive install -y -t pattern devel_basis && \
-    zypper --non-interactive install -y chrpath cmake curl dpkg-devel \
+    zypper --non-interactive install -y ccache chrpath cmake curl dpkg-devel \
         gcc-c++ gcc-fortran git gmock gtest iproute2 ninja nlohmann_json-devel \
         openmpi3-devel papi-devel python3-devel python3-pip rpm-build \
         sqlite3-devel vim wget libucp-devel libuct-devel && \

--- a/projects/rocprofiler-systems/docker/Dockerfile.rhel.ci
+++ b/projects/rocprofiler-systems/docker/Dockerfile.rhel.ci
@@ -25,7 +25,7 @@ RUN echo "* soft memlock unlimited" >> /etc/security/limits.conf && \
 RUN OS_VERSION_MAJOR=$(grep '^VERSION_ID=' /etc/os-release | cut -d'=' -f2 | tr -d '"' | cut -d'.' -f1) && \
     yum install -y epel-release && crb enable && \
     yum install -y --allowerasing \
-        autoconf automake chrpath cmake curl dpkg-devel elfutils-devel flex git glibc-devel \
+        autoconf automake ccache chrpath cmake curl dpkg-devel elfutils-devel flex git glibc-devel \
         gmock-devel gtest-devel iproute json-devel libdwarf-devel libdrm-devel libtool make \
         ninja-build numactl-devel openmpi-devel papi-devel pkgconf pkgconf-m4 \
         pkgconf-pkg-config python3-devel python3-pip redhat-rpm-config rpm-build rpm-sign \

--- a/projects/rocprofiler-systems/docker/Dockerfile.ubuntu.ci
+++ b/projects/rocprofiler-systems/docker/Dockerfile.ubuntu.ci
@@ -24,7 +24,7 @@ ENV CMAKE_PREFIX_PATH="/usr/local"
 RUN apt-get update && \
     apt-get dist-upgrade -y && \
     apt-get install -y autoconf autotools-dev bash-completion build-essential \
-        bzip2 chrpath cmake curl environment-modules flex gettext git-core gnupg2 \
+        bzip2 ccache chrpath cmake curl environment-modules flex gettext git-core gnupg2 \
         gzip iproute2 libgmock-dev libgtest-dev libiberty-dev libpapi-dev libpfm4-dev \
         libsqlite3-dev libtool locales lsb-release m4 ninja-build nlohmann-json3-dev \
         python3-pip software-properties-common unzip wget vim zip zlib1g-dev \


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Add `ccache` in the CI docker images, so they don't have to be done in each job. Part of https://github.com/ROCm/rocm-systems/pull/6490.

## Technical Details

Add `ccache` to the base package install in Dockerfile.ubuntu.ci, Dockerfile.rhel.ci, and Dockerfile.opensuse.ci so the workflow side no longer needs a per-job install step.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
Part of AIPROFSYST-497.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
