### PR TITLE
rocrtst: Skip IPC/coredump tests under ASAN as fork() is unsupported

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/functional/gpu_coredump.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/gpu_coredump.cc
@@ -170,6 +170,15 @@ bool GpuCoreDumpTest::CheckPrerequisites() {
 void GpuCoreDumpTest::SetUp(void) {
   if (!checkPlatformFiltering()) return;
 
+#ifdef ROCRTST_ASAN
+  // Under ASAN, these tests fork children (unsupported in ASAN) that trigger
+  // GPU faults and are killed after timeout, leaving leaked GPU queues/signals
+  // that corrupt kernel-level state for subsequent tests.
+  std::cout << "SKIPPED: GpuCoreDump tests disabled under ASan (fork+SIGKILL leaks KFD resources)" << std::endl;
+  prerequisites_met_ = false;
+  return;
+#endif
+
   // Don't call TestBase::SetUp() - we don't want hsa_init() in parent
 
   // Check prerequisites first

--- a/projects/rocr-runtime/rocrtst/suites/functional/ipc.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/ipc.cc
@@ -189,6 +189,14 @@ static void ClearShared(Shared *s) {
 void IPCTest::SetUp(void) {
   if (!checkPlatformFiltering()) return;
 
+#ifdef ROCRTST_ASAN
+  // IPC test uses fork() which is unsupported under ASAN as ASAN's shadow
+  // memory state becomes inconsistent after fork, causing failure on free
+  std::cout << "Skipping IPC test under ASAN (fork unsupported)." << std::endl;
+  test_skipped_ = true;
+  return;
+#endif
+
   hsa_status_t err;
 
   // Allow user to trigger a failure


### PR DESCRIPTION
## Motivation

The current implementation of the for IPC and GPU core dump tests utilize
`fork()` to create a child process.. As well-documented already in the docs,
the behavior with `fork()` is messy when we use ASAN build and process may
hang or cause segmentation fault.

## Technical Details

One solution is to change the process of spawning a child but that seems
unnecessary as gpu_coredump.cc has tests for VM faults and core dump
generation, which is not what we target in ASan normally, it is for memory-
safety of the runtime APIs. So, I will skip these tests under AddressSanitizer 
and make `test_skipped_` true as AddressSanitizer does not support `fork()`.

## JIRA IDs

[ROCM-25352](https://amd-hub.atlassian.net/browse/ROCM-25352)
[ROCM-25258](https://amd-hub.atlassian.net/browse/ROCM-25258)

[ROCM-25352]: https://amd-hub.atlassian.net/browse/ROCM-25352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROCM-25258]: https://amd-hub.atlassian.net/browse/ROCM-25258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ