### PR TITLE
[AMD-SMI] UALoE driver path and IFoE error reporting

### DIFF
--- a/projects/amdsmi/src/amd_smi/amd_smi_ualoe.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_ualoe.cc
@@ -596,7 +596,7 @@ amdsmi_status_t amdsmi_alloc_fabric_telemetry(amdsmi_processor_handle processor_
   ualoe_handle_t ualoe_handle = device->get_ualoe_handle();
 
   if (ualoe_handle == -1) {
-    return AMDSMI_STATUS_NOT_INIT;
+    return AMDSMI_STATUS_DRIVER_NOT_LOADED;
   }
 
   uint32_t ualoe_category_mask = category_mask;
@@ -631,7 +631,7 @@ amdsmi_status_t amdsmi_get_fabric_telemetry_data(amdsmi_processor_handle process
   ualoe_handle_t ualoe_handle = device->get_ualoe_handle();
 
   if (ualoe_handle == -1) {
-    return AMDSMI_STATUS_NOT_INIT;
+    return AMDSMI_STATUS_DRIVER_NOT_LOADED;
   }
 
   // Cast AMDSMI telemetry directly to UALoE telemetry since structures are now binary compatible
@@ -663,7 +663,7 @@ amdsmi_status_t amdsmi_free_fabric_telemetry(amdsmi_processor_handle processor_h
   ualoe_handle_t ualoe_handle = device->get_ualoe_handle();
 
   if (ualoe_handle == -1) {
-    return AMDSMI_STATUS_NOT_INIT;
+    return AMDSMI_STATUS_DRIVER_NOT_LOADED;
   }
 
   // Cast AMDSMI telemetry directly to UALoE telemetry since structures are now binary compatible

--- a/projects/amdsmi/tests/amd_smi_test/main.cc
+++ b/projects/amdsmi/tests/amd_smi_test/main.cc
@@ -38,6 +38,7 @@
 #include "functional/gpu_partition_metrics_read.h"
 #include "functional/hw_topology_read.h"
 #include "functional/id_info_read.h"
+#include "functional/ifoe_info_read.h"
 #include "functional/mem_page_info_read.h"
 #include "functional/mem_util_read.h"
 #include "functional/memory_read_write.h"
@@ -331,6 +332,11 @@ TEST(amdsmitstReadWrite, TestMemoryReadWrite) {
 
 TEST(amdsmitstReadOnly, TestFabricRead) {
   TestFabricRead tst;
+  RunGenericTest(&tst);
+}
+
+TEST(amdsmitstReadOnly, TestIfoeInfoRead) {
+  TestIfoeInfoRead tst;
   RunGenericTest(&tst);
 }
 


### PR DESCRIPTION
- Return `AMDSMI_STATUS_DRIVER_NOT_LOADED` (instead of `AMDSMI_STATUS_NOT_INIT`) from the fabric telemetry alloc/get/free APIs when no IFoE PCI driver is bound, so callers can distinguish a missing IFoE driver from an actual `amdsmi_init` failure.
- Register `TestIfoeInfoRead` in the gtest main so the IFoE info-read test actually runs.
- Fix use-after-free on the `ualoe_nl_open` cdev failure path.
- Validate driver telemetry counts to prevent OOB writes.
- Validate MAC attribute payload length in the netlink handler.
- Early-return `ENOENT` from `ualoe_cdev_close` on an unknown handle instead of dereferencing.

Signed-off-by: Maisam Arif <Maisam.Arif@amd.com>
