### PR TITLE
[RCCL] Detect CE batch APIs via build-time symbol checks with runtime fallback

### DIFF
--- a/projects/rccl/CMakeLists.txt
+++ b/projects/rccl/CMakeLists.txt
@@ -326,6 +326,9 @@ check_cxx_source_compiles("
   }
 " HIP_FABRIC_HANDLE_TYPE)
 
+### Check for hipMemcpyBatchAsync support (Copy Engine batch API)
+check_symbol_exists("hipMemcpyBatchAsync" "hip/hip_runtime_api.h" HIP_MEMCPY_BATCH_ASYNC)
+
 unset(CMAKE_REQUIRED_LIBRARIES)
 
 ### Check for indirect function call support
@@ -347,6 +350,17 @@ if("${hip_version_string}" VERSION_GREATER_EQUAL "6.1.33591")
   message(STATUS "RCCL LL128 protocol enabled")
 else()
   message(STATUS "RCCL LL128 protocol disabled - requires HIP version >= 6.1.33591")
+endif()
+
+## Check for Copy Engine (CE) batch API support
+## hipMemcpyBatchAsync symbol presence is the sole gate: if the SDK exposes the
+## symbol, CE is supported regardless of the exact version string.
+if(HIP_MEMCPY_BATCH_ASYNC)
+  set(CE_ENABLED ON)
+  message(STATUS "Copy Engine (CE) batch API enabled")
+else()
+  set(CE_ENABLED OFF)
+  message(STATUS "Copy Engine (CE) batch API disabled - hipMemcpyBatchAsync not found in hip/hip_runtime_api.h")
 endif()
 
 ## Check for hsa-runtime64

--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -819,6 +819,10 @@ endif()
 if(LL128_ENABLED)
   target_compile_definitions(rccl PRIVATE ENABLE_LL128)
 endif()
+if(CE_ENABLED)
+  target_compile_definitions(rccl PRIVATE CE_BATCH_ASYNC_SUPPORTED)
+  message(STATUS "CE_BATCH_ASYNC_SUPPORTED compile definition enabled")
+endif()
 
 ## Set RCCL compile options
 if (HAVE_PARALLEL_JOBS)

--- a/projects/rccl/src/ce_coll.cc
+++ b/projects/rccl/src/ce_coll.cc
@@ -25,6 +25,36 @@ static ncclResult_t ceFaultCheck(struct ncclComm* comm, uint32_t bit, const char
 #endif
 
 RCCL_PARAM(CeMultiStreams, "CE_MULTI_STREAMS", 0);
+RCCL_PARAM(CeBatchAsyncEnable, "CE_BATCH_ASYNC_ENABLE", -2);
+
+#ifdef CE_BATCH_ASYNC_SUPPORTED
+// Runtime detection: does the running driver actually implement hipMemcpyBatchAsync?
+//   ROCm 7.12+   → >= 71200000
+//   ROCm 7.0.2.x → [70051831, 70060000)  (backport range; no device-attribute
+//                  probe exists for the batch API, so the version range is the
+//                  only runtime guard and must include the backport runtime)
+static int ncclCeBatchAsyncSupported() {
+  int driverVersion;
+  if (ncclCudaDriverVersion(&driverVersion) != ncclSuccess) return 0;
+  return (driverVersion >= 71200000 || (driverVersion >= 70051831 && driverVersion < 70060000));
+}
+#endif
+
+static int ncclCeBatchAsyncEnable() {
+#ifdef CE_BATCH_ASYNC_SUPPORTED
+  int param = rcclParamCeBatchAsyncEnable();
+  int supported = ncclCeBatchAsyncSupported();
+  if (param > 0 && !supported) {
+    WARN("RCCL_CE_BATCH_ASYNC_ENABLE=1 is set but hipMemcpyBatchAsync is not supported at runtime; disabling CE batch path");
+    return 0;
+  }
+  return param >= 0 ? param : (param == -2 && supported);
+#else
+  if (rcclParamCeBatchAsyncEnable() > 0)
+    WARN("RCCL_CE_BATCH_ASYNC_ENABLE=1 is set but CE batch API not available; disabling");
+  return 0;
+#endif
+}
 // Static constant for graph synchronization
 static const uint32_t GRAPH_SYNC_VALUE = 1;
 
@@ -307,7 +337,7 @@ ncclResult_t ncclCeInitBatchOpsParams(struct ncclCeBatchOpsParams* params, int n
   params->sizes = nullptr;
   params->numOps = 0;
   params->intraBatchSync = false;
-#if CE_BATCH_API_SUPPORTED
+#ifdef CE_BATCH_ASYNC_SUPPORTED
   params->attrs = nullptr;
   params->attrIdxs = nullptr;
   params->numAttrs = 0;
@@ -316,7 +346,7 @@ ncclResult_t ncclCeInitBatchOpsParams(struct ncclCeBatchOpsParams* params, int n
   NCCLCHECKGOTO(ncclCalloc(&params->srcs, nRanks), ret, fail);
   NCCLCHECKGOTO(ncclCalloc(&params->dsts, nRanks), ret, fail);
   NCCLCHECKGOTO(ncclCalloc(&params->sizes, nRanks), ret, fail);
-#if CE_BATCH_API_SUPPORTED
+#ifdef CE_BATCH_ASYNC_SUPPORTED
   NCCLCHECKGOTO(ncclCalloc(&params->attrs, nRanks), ret, fail);
   NCCLCHECKGOTO(ncclCalloc(&params->attrIdxs, nRanks), ret, fail);
 #endif
@@ -330,7 +360,7 @@ void ncclCeFreeBatchOpsParams(struct ncclCeBatchOpsParams* params) {
   if (params->srcs) free(params->srcs);
   if (params->dsts) free(params->dsts);
   if (params->sizes) free(params->sizes);
-#if CE_BATCH_API_SUPPORTED
+#ifdef CE_BATCH_ASYNC_SUPPORTED
   if (params->attrs) free(params->attrs);
   if (params->attrIdxs) free(params->attrIdxs);
 #endif
@@ -351,9 +381,6 @@ ncclResult_t ncclCeLaunchBatchOps(struct ncclComm* comm, struct ncclCeBatchOpsPa
   // Check if we are in a CUDA graph capture
   bool capturing = ncclCudaGraphValid(comm->planner.capturingGraph);
 
-  int driverVersion;
-  NCCLCHECKGOTO(ncclCudaDriverVersion(&driverVersion), ret, fail);
-
   //--------------Graph capture--------------
   // cudaMemcpyBatchAsync is not supported during CUDA graph capture
   if (capturing) {
@@ -372,11 +399,8 @@ ncclResult_t ncclCeLaunchBatchOps(struct ncclComm* comm, struct ncclCeBatchOpsPa
   }
   //--------------No graph capture--------------
   else {
-    // driverVersion is reported as ~71200000 for ROCm 7.12 and values in
-    // [70051831, 70060000) for ROCm 7.0.2.x backport builds.
-    if (CE_BATCH_API_SUPPORTED &&
-        (driverVersion >= 71200000 || (driverVersion >= 70051831 && driverVersion < 70060000))) {
-#if CE_BATCH_API_SUPPORTED
+#ifdef CE_BATCH_ASYNC_SUPPORTED
+    if (ncclCeBatchAsyncEnable()) {
     params->attrs[0] = {};
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
     params->attrs[0].srcAccessOrder = hipMemcpySrcAccessOrderStream;
@@ -417,8 +441,9 @@ ncclResult_t ncclCeLaunchBatchOps(struct ncclComm* comm, struct ncclCeBatchOpsPa
         (void**)params->dsts, (void**)params->srcs, params->sizes, params->numOps,
         params->attrs, params->attrIdxs, params->numAttrs, nullptr, stream), ret, fail);
     }
-#endif
-    } else if (comm->ceColl.nCopyStreams > 0 && (int)params->numOps > 1 && !params->intraBatchSync) {
+    } else  // CE batch async disabled — fall through to non-batch paths below
+#endif // CE_BATCH_ASYNC_SUPPORTED
+    if (comm->ceColl.nCopyStreams > 0 && (int)params->numOps > 1 && !params->intraBatchSync) {
       int nStreams = comm->ceColl.nCopyStreams;
       int activeStreams = ((int)params->numOps < nStreams) ? (int)params->numOps : nStreams;
       INFO(NCCL_COLL, "CE: rank %d -> No-Batch Multi-Stream path (%d streams), numOps=%zu", comm->rank, activeStreams, params->numOps);

--- a/projects/rccl/src/ce_coll.cc
+++ b/projects/rccl/src/ce_coll.cc
@@ -7,6 +7,7 @@
 #include "comm.h"
 #include "register_inline.h"
 #include <algorithm>
+#include <atomic>
 #include <cuda.h>
 #include "rocmwrap.h"
 #include "ce_coll.h"
@@ -41,16 +42,19 @@ static int ncclCeBatchAsyncSupported() {
 #endif
 
 static int ncclCeBatchAsyncEnable() {
+  // Called once per CE collective; warn at most once to avoid flooding the log.
+  static std::atomic<bool> warnedUnsupported{false};
 #ifdef CE_BATCH_ASYNC_SUPPORTED
   int param = rcclParamCeBatchAsyncEnable();
   int supported = ncclCeBatchAsyncSupported();
   if (param > 0 && !supported) {
-    WARN("RCCL_CE_BATCH_ASYNC_ENABLE=1 is set but hipMemcpyBatchAsync is not supported at runtime; disabling CE batch path");
+    if (!warnedUnsupported.exchange(true))
+      WARN("RCCL_CE_BATCH_ASYNC_ENABLE=1 is set but hipMemcpyBatchAsync is not supported at runtime; disabling CE batch path");
     return 0;
   }
   return param >= 0 ? param : (param == -2 && supported);
 #else
-  if (rcclParamCeBatchAsyncEnable() > 0)
+  if (rcclParamCeBatchAsyncEnable() > 0 && !warnedUnsupported.exchange(true))
     WARN("RCCL_CE_BATCH_ASYNC_ENABLE=1 is set but CE batch API not available; disabling");
   return 0;
 #endif

--- a/projects/rccl/src/include/ce_coll.h
+++ b/projects/rccl/src/include/ce_coll.h
@@ -16,10 +16,6 @@
 #define NCCL_CE_SYNC_OPS_PER_RANK_UC 3
 #define RCCL_CE_NUM_COPY_STREAMS 8
 
-// hipMemcpyBatchAsync is available in ROCm 7.12+ and was backported to 7.0.2.x.
-// ROCM_VERSION encodes as (MAJOR*10000 + MINOR*100 + PATCH), so 7.0.2 → 70002.
-#define CE_BATCH_API_SUPPORTED (ROCM_VERSION >= 71200 || ROCM_VERSION == 70002)
-
 struct ncclCeColl {
   uint8_t* baseUCSymReadyPtr;
   uint8_t* baseUCSymComplPtr;
@@ -60,7 +56,7 @@ struct ncclCeBatchOpsParams {
   size_t* sizes;
   size_t numOps;
   bool intraBatchSync;
-#if CE_BATCH_API_SUPPORTED
+#ifdef CE_BATCH_ASYNC_SUPPORTED
   hipMemcpyAttributes* attrs;
   size_t* attrIdxs;
   size_t numAttrs;

--- a/projects/rccl/src/misc/rocmwrap.cc
+++ b/projects/rccl/src/misc/rocmwrap.cc
@@ -44,6 +44,16 @@ CUmemAllocationHandleType ncclCuMemHandleType = CU_MEM_HANDLE_TYPE_POSIX_FILE_DE
 
 static int ncclCuMemSupported = 0;
 
+// cuMem VMM API availability by HIP/driver version.
+#define NCCL_CUMEM_NATIVE_MIN_VERSION   71260540
+#define NCCL_CUMEM_BACKPORT_MIN_VERSION 70051831
+#define NCCL_CUMEM_BACKPORT_MAX_VERSION 70060000
+
+#define NCCL_CUMEM_VERSION_SUPPORTED(version)                  \
+  ((version) >= NCCL_CUMEM_NATIVE_MIN_VERSION ||               \
+   ((version) >= NCCL_CUMEM_BACKPORT_MIN_VERSION &&            \
+    (version) < NCCL_CUMEM_BACKPORT_MAX_VERSION))
+
 #define KERNEL_VERSION_CODE(major, minor) ((major << 16) | (minor << 8))
 
 static int ncclGetKernelVersionCode() {
@@ -72,10 +82,8 @@ int ncclIsCuMemSupported() {
   }
   CUDACHECKGOTO(cudaDriverGetVersion(&cudaDriverVersion), ret, error);
   {
-    // 70051831 = ROCm 7.0.2.2 backport build; [70051831, 70060000) covers 7.0.2.x range.
     // Block scope prevents the goto in CUDACHECKGOTO from jumping over the bool initialization.
-    bool cuMemSupported = (cudaDriverVersion >= 71260540) ||
-                          (cudaDriverVersion >= 70051831 && cudaDriverVersion < 70060000);
+    bool cuMemSupported = NCCL_CUMEM_VERSION_SUPPORTED(cudaDriverVersion);
     if (!cuMemSupported) {
       WARN("cuMem support requires HIP_VERSION >= 7.12.60540 (or ROCm 7.0.2.x backport)");
       supported = 0;
@@ -97,13 +105,13 @@ error:
 }
 
 int ncclCuMemEnable() {
-#if HIP_VERSION < 71260540
-  if (ncclParamCuMemEnable() > 0)
-    WARN("NCCL_CUMEM_ENABLE=1 is set but cuMem VMM APIs require ROCm 7.0 or later (HIP_VERSION=%d); disabling cuMem", HIP_VERSION);
-  return 0;
-#else
+#if NCCL_CUMEM_VERSION_SUPPORTED(HIP_VERSION)
   int param = ncclParamCuMemEnable();
   return param >= 0 ? param : (param == -2 && ncclCuMemSupported);
+#else
+  if (ncclParamCuMemEnable() > 0)
+    WARN("NCCL_CUMEM_ENABLE=1 is set but cuMem VMM APIs are unavailable in this build (HIP_VERSION=%d); disabling cuMem", HIP_VERSION);
+  return 0;
 #endif
 }
 

--- a/projects/rccl/test/ce/CeInternalMPITests.cpp
+++ b/projects/rccl/test/ce/CeInternalMPITests.cpp
@@ -54,7 +54,7 @@ protected:
         MPITestBase::SetUp();
 
         if(!isCeDispatchConfigured())
-            GTEST_SKIP() << "CE requires ROCm >= 7.12 or 7.0.2.x, "
+            GTEST_SKIP() << "CE not configured: need CE_BATCH_ASYNC_SUPPORTED build + "
                             "NCCL_CTA_POLICY=2, NCCL_LOCAL_REGISTER=0, NCCL_CUMEM_ENABLE=1";
 
         // Set debug env vars before ncclCommInitRank so the communicator picks them up.
@@ -455,7 +455,7 @@ TEST(CeInternalNeg, CeImplementedReturnsFalseForUnsupported)
 TEST(CeInternalNeg, CeImplementedReturnsTrueOnSupportedDriver)
 {
     if(!isCeDriverSupported())
-        GTEST_SKIP() << "CE not supported on this driver (need >= 7.12 or 7.0.2.x)";
+        GTEST_SKIP() << "CE not available (binary not compiled with CE_BATCH_ASYNC_SUPPORTED)";
 
     EXPECT_TRUE(ncclCeImplemented(ncclFuncAllGather, ncclDevSum, ncclFloat32));
     EXPECT_TRUE(ncclCeImplemented(ncclFuncAlltoAll,  ncclDevSum, ncclFloat32));

--- a/projects/rccl/test/ce/CeInternalMPITests.cpp
+++ b/projects/rccl/test/ce/CeInternalMPITests.cpp
@@ -456,6 +456,9 @@ TEST(CeInternalNeg, CeImplementedReturnsTrueOnSupportedDriver)
 {
     if(!isCeDriverSupported())
         GTEST_SKIP() << "CE not available (binary not compiled with CE_BATCH_ASYNC_SUPPORTED)";
+    if(!isCeRuntimeDriverSupported())
+        GTEST_SKIP() << "CE not supported on this runtime driver "
+                        "(need ROCm >= 7.12 or 7.0.2.x backport [70051831, 70060000))";
 
     EXPECT_TRUE(ncclCeImplemented(ncclFuncAllGather, ncclDevSum, ncclFloat32));
     EXPECT_TRUE(ncclCeImplemented(ncclFuncAlltoAll,  ncclDevSum, ncclFloat32));

--- a/projects/rccl/test/ce/CeTestHelpers.hpp
+++ b/projects/rccl/test/ce/CeTestHelpers.hpp
@@ -14,25 +14,24 @@
 #include "DeviceBufferHelpers.hpp"
 #include "MPIHelpers.hpp"
 
-// Driver-version check
-// Returns true when the HIP driver supports CE: ROCm ≥ 7.12 or the 7.0.2.x
-// backport range [7.0.2.2, 7.0.3.0).
-inline bool isCeDriverSupported()
+// Returns true when compiled with CE batch API support (CE_BATCH_ASYNC_SUPPORTED).
+// Gated at build time via check_symbol_exists(hipMemcpyBatchAsync); no runtime query needed.
+inline constexpr bool isCeDriverSupported()
 {
-    int driverVer = 0;
-    if(hipDriverGetVersion(&driverVer) != hipSuccess)
-        return false;
-    return (driverVer >= 71200000) ||
-           (driverVer >= 70051831 && driverVer < 70060000);
+#ifdef CE_BATCH_ASYNC_SUPPORTED
+    return true;
+#else
+    return false;
+#endif
 }
 
 // Full CE dispatch gate
 
-// Returns true when all four prerequisites for CE dispatch are satisfied:
-//   1. Driver version supports CE (ROCm ≥ 7.12 or 7.0.2.2).
-//   2. NCCL_CTA_POLICY=2     (CE dispatch mode).
-//   3. NCCL_LOCAL_REGISTER=0  (explicit buffer registration only).
-//   4. NCCL_CUMEM_ENABLE=1    (VMM-backed symmetric memory; default is 0).
+// Returns true when all prerequisites for CE dispatch are satisfied:
+//   1. Binary compiled with CE batch API support (CE_BATCH_ASYNC_SUPPORTED).
+//   2. NCCL_CTA_POLICY=2          (CE dispatch mode).
+//   3. NCCL_LOCAL_REGISTER=0      (explicit buffer registration only).
+//   4. NCCL_CUMEM_ENABLE=1        (VMM-backed symmetric memory; default is 0).
 //      Without this, comm->symmetricSupport is false and CE is never dispatched.
 //
 // Use this single check wherever a test needs to decide between asserting the
@@ -43,14 +42,14 @@ inline bool isCeDispatchConfigured()
     constexpr int kCtaPolicyCE     = 2; // NCCL_CTA_POLICY=2      → CE dispatch
     constexpr int kLocalRegisterCE = 0; // NCCL_LOCAL_REGISTER=0  → explicit registration
     constexpr int kCuMemEnable     = 1; // NCCL_CUMEM_ENABLE=1    → symmetric VMM memory
-    // NCCL compiled-in defaults (returned when the env var is unset)
-    constexpr int kCtaPolicyDefault     = 0; // SM path
-    constexpr int kLocalRegisterDefault = 1; // implicit registration enabled
-    constexpr int kCuMemEnableDefault   = 0; // VMM/symmetric memory disabled
+    // NCCL/RCCL compiled-in defaults (returned when the env var is unset)
+    constexpr int kCtaPolicyDefault         = 0;  // SM path
+    constexpr int kLocalRegisterDefault     = 1;  // implicit registration enabled
+    constexpr int kCuMemEnableDefault       = 0;  // VMM/symmetric memory disabled
     return isCeDriverSupported() &&
-           MPIHelpers::getEnvParam("NCCL_CTA_POLICY",    kCtaPolicyDefault)     == kCtaPolicyCE &&
-           MPIHelpers::getEnvParam("NCCL_LOCAL_REGISTER", kLocalRegisterDefault) == kLocalRegisterCE &&
-           MPIHelpers::getEnvParam("NCCL_CUMEM_ENABLE",   kCuMemEnableDefault)   == kCuMemEnable;
+           MPIHelpers::getEnvParam("NCCL_CTA_POLICY",           kCtaPolicyDefault)         == kCtaPolicyCE &&
+           MPIHelpers::getEnvParam("NCCL_LOCAL_REGISTER",        kLocalRegisterDefault)     == kLocalRegisterCE &&
+           MPIHelpers::getEnvParam("NCCL_CUMEM_ENABLE",          kCuMemEnableDefault)       == kCuMemEnable;
 }
 
 // Batch path prediction helpers

--- a/projects/rccl/test/ce/CeTestHelpers.hpp
+++ b/projects/rccl/test/ce/CeTestHelpers.hpp
@@ -14,6 +14,8 @@
 #include "DeviceBufferHelpers.hpp"
 #include "MPIHelpers.hpp"
 
+#include <hip/hip_runtime.h>
+
 // Returns true when compiled with CE batch API support (CE_BATCH_ASYNC_SUPPORTED).
 // Gated at build time via check_symbol_exists(hipMemcpyBatchAsync); no runtime query needed.
 inline constexpr bool isCeDriverSupported()
@@ -25,13 +27,24 @@ inline constexpr bool isCeDriverSupported()
 #endif
 }
 
+// Runtime driver-version gate mirroring ncclCeImplemented(): ROCm 7.12+ (>= 71200000) or the 7.0.2.x backport range [70051831, 70060000).
+inline bool isCeRuntimeDriverSupported()
+{
+    int driverVer = 0;
+    if(hipDriverGetVersion(&driverVer) != hipSuccess)
+        return false;
+    return (driverVer >= 71200000) ||
+           (driverVer >= 70051831 && driverVer < 70060000);
+}
+
 // Full CE dispatch gate
 
 // Returns true when all prerequisites for CE dispatch are satisfied:
 //   1. Binary compiled with CE batch API support (CE_BATCH_ASYNC_SUPPORTED).
-//   2. NCCL_CTA_POLICY=2          (CE dispatch mode).
-//   3. NCCL_LOCAL_REGISTER=0      (explicit buffer registration only).
-//   4. NCCL_CUMEM_ENABLE=1        (VMM-backed symmetric memory; default is 0).
+//   2. Running driver in the CE-supported range (matches ncclCeImplemented()).
+//   3. NCCL_CTA_POLICY=2          (CE dispatch mode).
+//   4. NCCL_LOCAL_REGISTER=0      (explicit buffer registration only).
+//   5. NCCL_CUMEM_ENABLE=1        (VMM-backed symmetric memory; default is 0).
 //      Without this, comm->symmetricSupport is false and CE is never dispatched.
 //
 // Use this single check wherever a test needs to decide between asserting the
@@ -47,6 +60,7 @@ inline bool isCeDispatchConfigured()
     constexpr int kLocalRegisterDefault     = 1;  // implicit registration enabled
     constexpr int kCuMemEnableDefault       = 0;  // VMM/symmetric memory disabled
     return isCeDriverSupported() &&
+           isCeRuntimeDriverSupported() &&
            MPIHelpers::getEnvParam("NCCL_CTA_POLICY",           kCtaPolicyDefault)         == kCtaPolicyCE &&
            MPIHelpers::getEnvParam("NCCL_LOCAL_REGISTER",        kLocalRegisterDefault)     == kLocalRegisterCE &&
            MPIHelpers::getEnvParam("NCCL_CUMEM_ENABLE",          kCuMemEnableDefault)       == kCuMemEnable;

--- a/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
@@ -266,13 +266,13 @@ class TestExecutor:
 
         if self.args.build_dir:
             # Use custom build directory from command line
-            self.build_dir = os.path.expanduser(os.path.expandvars(self.args.build_dir))
+            self.build_dir = os.path.abspath(os.path.expanduser(os.path.expandvars(self.args.build_dir)))
             self.using_custom_lib = True
             if self.args.verbose:
                 print(f"Using custom build directory from --build-dir: {self.build_dir}")
         elif custom_rccl_path:
             # Use custom library path from environment variable
-            self.build_dir = os.path.expanduser(os.path.expandvars(custom_rccl_path))
+            self.build_dir = os.path.abspath(os.path.expanduser(os.path.expandvars(custom_rccl_path)))
             self.using_custom_lib = True
             if self.args.verbose:
                 print(f"Using custom RCCL library path from environment: {self.build_dir}")


### PR DESCRIPTION
## Motivation

CE batch-copy support was gated by hard-coded `ROCM_VERSION` / `HIP_VERSION` macro comparisons (e.g. `CE_BATCH_API_SUPPORTED = (ROCM_VERSION >= 71200 || ROCM_VERSION == 70002)`). These compile-time version checks are brittle: they break across the ROCm 7.0.2.x backport and 7.12+ native streams, and a header that does not expose the expected version macro causes build failures or silently mis-detects the feature.

Separately, the cuMem VMM gate in `ncclCuMemEnable()` used `#if HIP_VERSION < 71260540`, which excludes the ROCm 7.0.2.x backport (HIP `7.0.51831`). On backport builds this disabled cuMem — and with it `comm->symmetricSupport`, the prerequisite for the Copy Engine dispatch path — so CE silently fell back to the SM path.

The goal is to detect the CE batch API by its actual symbol presence at build time and gate activation on real runtime support with a clean user override, and to make the cuMem version gate readable and backport-aware so CE dispatch works on both the native and backport ROCm streams.

## Technical Details

- CMake now probes the SDK directly with `check_symbol_exists()`:
  - `hipMemcpyBatchAsync` → `HIP_MEMCPY_BATCH_ASYNC` → `CE_ENABLED` → `CE_BATCH_ASYNC_SUPPORTED`

  Symbol presence is the sole build-time gate for the CE batch API; the exact version string is no longer consulted.
- New `RCCL_CE_BATCH_ASYNC_ENABLE` param (default `-2` = auto) plus `ncclCeBatchAsyncEnable()` / `ncclCeBatchAsyncSupported()`: compile-time macro + runtime driver check (`>= 71200000`, or the backport range `[70051831, 70060000)`) + env toggle, with warn-and-fallback to the multi-stream copy path. Removes the `CE_BATCH_API_SUPPORTED` macro from `ce_coll.h` and the inline version check from `ncclCeLaunchBatchOps()`; struct fields are now gated by `#ifdef CE_BATCH_ASYNC_SUPPORTED`.
- `rocmwrap.cc`: the cuMem version gate is refactored into a single readable macro, `NCCL_CUMEM_VERSION_SUPPORTED(version)`, covering the native range (`>= 7.12.60540`) and the 7.0.2.x backport range (`[7.0.51831, 7.0.60000)`). It is used by both the runtime `ncclIsCuMemSupported()` check and the compile-time `ncclCuMemEnable()` gate, replacing the prior `#if HIP_VERSION < 71260540` gate that disabled cuMem (and the symmetric-memory CE dispatch path) on the backport. No `hipMemCreate` symbol probe / `CUMEM_VMM_SUPPORTED` define is introduced.
- Test gating: `CeTestHelpers.hpp` `isCeDriverSupported()` is now a `constexpr` compile-time check on `CE_BATCH_ASYNC_SUPPORTED`; `isCeDispatchConfigured()` combines it with `NCCL_CTA_POLICY=2`, `NCCL_LOCAL_REGISTER=0`, `NCCL_CUMEM_ENABLE=1`. Skip messages in `CeInternalMPITests.cpp` updated to match the build-time gate.
- Test runner: `test_executor.py` resolves `--build-dir` to an absolute path so `LD_LIBRARY_PATH` still points at the built `librccl.so` after `mpirun` changes the working directory to `build/<type>/test` (fixes `undefined symbol: ncclNetIb`).

## cuMem version gate (`ncclCuMemEnable()` / `ncclIsCuMemSupported()`)

- Env var: `NCCL_CUMEM_ENABLE` (default `0` — opt-in)
- Version gate: `NCCL_CUMEM_VERSION_SUPPORTED(v)` — native `>= 71260540` **or** backport `[70051831, 70060000)`
- Runtime gate: `ncclCuMemSupported` (Linux kernel >= 6.8 + `cuMemCreate` function pointer + device VMM attribute)
- When the build version is outside the supported ranges, `NCCL_CUMEM_ENABLE=1` warns and falls back instead of failing.

## CE Batch (`ncclCeBatchAsyncEnable()`)

- Env var: `RCCL_CE_BATCH_ASYNC_ENABLE` (default `-2` — auto)
- Build gate: `CE_BATCH_ASYNC_SUPPORTED` (`hipMemcpyBatchAsync`)
- Runtime gate: driver version `>= 71200000` (ROCm 7.12+) or the 7.0.2.x backport range `[70051831, 70060000)`

When the batch path is disabled, CE still runs — it falls back to the multi-stream / single-stream `cudaMemcpyAsync` copy path. This env var only selects the copy mechanism *within* the CE path; it does **not** decide whether CE is dispatched (that is governed by `ncclCeImplemented()`, `NCCL_CTA_POLICY`, and symmetric-memory support).

## JIRA ID

AICOMRCCL-1147

## Test Plan

- Built RCCL debug with MPI tests in the ROCm 7.0.2.2 docker container
- Ran the full CE suite through the test runner

## Test Result

All CE tests passed.