### PR TITLE
add hip-test disable cases on amd_wsl

### DIFF
--- a/projects/hip-tests/catch/config/configs/unit/assertion.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/assertion.yaml
@@ -3,7 +3,7 @@ assertion:
   Unit_StaticAssert_Positive_Basic_RTC:
     <<: *level_2
     # Below tests fail in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/210
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [deviceLib]
   Unit_StaticAssert_Negative_Basic_RTC:
     <<: *level_2
@@ -12,4 +12,4 @@ assertion:
   Unit_Assert_Positive_Basic_KernelFail:
     <<: *level_2
     # === Below tests fail in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/210 ===
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]

--- a/projects/hip-tests/catch/config/configs/unit/atomics.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/atomics.yaml
@@ -334,7 +334,7 @@ atomics:
     <<: *level_2
     tags: [deviceLib, system, multigpu]
     # Rock_Linux_Failures_on_gfx94X
-    disabled: [amd_linux]
+    disabled: [amd_linux, amd_wsl]
   Unit_atomicAdd_system_Positive_Host_And_GPU:
     <<: *level_2
     tags: [deviceLib, system]

--- a/projects/hip-tests/catch/config/configs/unit/clock.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/clock.yaml
@@ -3,12 +3,12 @@ clock:
   Unit_hipClock64_Positive_Basic:
     <<: *level_2
     # SWDEV-555665
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [deviceLib, timing]
   Unit_hipClock_Positive_Basic:
     <<: *level_2
     # SWDEV-555665
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [deviceLib, timing]
   Unit_hipWallClock64_Positive_Basic:
     <<: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/compiler.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/compiler.yaml
@@ -36,10 +36,10 @@ compiler:
   Unit_test_generic_target_only_in_compressed_fatbin:
     <<: *level_2
     # Rock_Linux_Failures_on_gfx94X
-    disabled: [amd_linux]
+    disabled: [amd_linux, amd_wsl]
     tags: [integration, rtc]
   Unit_test_generic_target_only_in_regular_fatbin:
     <<: *level_2
     # Rock_Linux_Failures_on_gfx94X
-    disabled: [amd_linux]
+    disabled: [amd_linux, amd_wsl]
     tags: [integration, rtc]

--- a/projects/hip-tests/catch/config/configs/unit/cooperativeGrps.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/cooperativeGrps.yaml
@@ -3,7 +3,7 @@ cooperativeGrps:
   Unit_Thread_Block_Getters_Positive_Basic:
     <<: *level_2
     # Below tests are failing PSDB
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [cooperative, groups]
   Unit_Thread_Block_Getters_Via_Base_Type_Positive_Basic:
     <<: *level_2
@@ -17,59 +17,59 @@ cooperativeGrps:
   Unit_Thread_Block_Tile_Getters_Positive_Basic:
     <<: *level_2
     # SWDEV-441604: Below tests take long time to run in stress test on 12/01/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [cooperative, groups]
   Unit_Thread_Block_Tile_Dynamic_Getters_Positive_Basic:
     <<: *level_2
     # SWDEV-441604: Below tests take long time to run in stress test on 12/01/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [cooperative, groups]
   Unit_Thread_Block_Tile_Shfl_Up_Positive_Basic:
     <<: *level_2
     # SWDEV-441604: Below tests take long time to run in stress test on 12/01/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [cooperative, ops]
   Unit_Thread_Block_Tile_Shfl_Down_Positive_Basic:
     <<: *level_2
     # SWDEV-441604: Below tests take long time to run in stress test on 12/01/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [cooperative, ops]
   Unit_Thread_Block_Tile_Shfl_XOR_Positive_Basic:
     <<: *level_2
     # SWDEV-441604: Below tests take long time to run in stress test on 12/01/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [cooperative, ops]
   Unit_Thread_Block_Tile_Shfl_Positive_Basic:
     <<: *level_2
     # SWDEV-441604: Below tests take long time to run in stress test on 12/01/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [cooperative, ops]
   Unit_Thread_Block_Tile_Sync_Positive_Basic:
     <<: *level_2
     # Below tests hang in Jenkins PSDB
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [cooperative, ops]
   Unit_Coalesced_Group_Tiled_Partition_Getters_Positive_Basic:
     <<: *level_2
     # SWDEV-486448 - Following tests disabled due to taking too much time to execute, ~700s per test
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [cooperative, groups]
   Unit_Coalesced_Group_Tiled_Partition_Shfl_Up_Positive_Basic:
     <<: *level_2
     # SWDEV-486448 - Following tests disabled due to taking too much time to execute, ~700s per test
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [cooperative, ops]
   Unit_Coalesced_Group_Tiled_Partition_Shfl_Down_Positive_Basic:
     <<: *level_2
     # SWDEV-486448 - Following tests disabled due to taking too much time to execute, ~700s per test
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [cooperative, ops]
   Unit_Coalesced_Group_Tiled_Partition_Shfl_Positive_Basic:
     <<: *level_2
     tags: [cooperative, ops]
   Unit_Coalesced_Group_Tiled_Partition_Sync_Positive_Basic:
     <<: *level_2
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [cooperative, ops]
   Unit_hipCGThreadBlockType:
     <<: *level_2
@@ -98,7 +98,7 @@ cooperativeGrps:
   Unit_coalesced_groups:
     <<: *level_2
     # Below tests hang in Jenkins PSDB
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [cooperative, groups]
   Unit_hipLaunchCooperativeKernel_Basic:
     <<: *level_2
@@ -121,12 +121,12 @@ cooperativeGrps:
   Unit_coalesced_groups_shfl_down:
     <<: *level_2
     # Below tests hang in Jenkins PSDB
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [cooperative, ops]
   Unit_coalesced_groups_shfl_up:
     <<: *level_2
     # Below tests hang in Jenkins PSDB
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [cooperative, ops]
   Unit_Coalesced_Group_Getters_Positive_Basic:
     <<: *level_2
@@ -155,7 +155,7 @@ cooperativeGrps:
   Unit_Coalesced_Group_Sync_Positive_Basic:
     <<: *level_2
     # SWDEV-434171: Below tests took long time to complete in stress test on 17/11/23
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [cooperative, ops]
   Unit_Grid_Group_Getters_Positive_Basic:
     <<: *level_2
@@ -207,40 +207,40 @@ cooperativeGrps:
   Unit_Thread_Block_Coalesced_Reduce_arithmetic:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Thread_Block_Coalesced_Reduce_boolean:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Thread_Block_Tile_Reduce_All_Parameter_Sizes:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Thread_Block_Tile_Reduce_Basic:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Thread_Block_Tile_Reduce_Custom_Op:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Thread_Block_Tile_Reduce_Standard_Op_Custom_Type:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Thread_Block_Tile_Reduce_Trivially_Copyable_Parameters:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Thread_Block_Tile_Reduce_All_Parameter_Sizes:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Thread_Block_Tile_Reduce_Random_arithmetic:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Thread_Block_Tile_Reduce_Random_boolean:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]

--- a/projects/hip-tests/catch/config/configs/unit/device.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/device.yaml
@@ -159,12 +159,12 @@ device:
   Unit_Uuid_FntlTstsFor_SetEnv_HIP_VISIBLE_DEVICES:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [query]
   Unit_UUID_setEnv_Thread:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [query]
   Unit_hipDeviceAPUCheck:
     <<: *level_2
@@ -370,7 +370,7 @@ device:
     <<: *level_2
     # (amd_linux) SWDEV-511679 : Below tests fail in stress test
     # (amd_wsl) Note: hsa_amd_ipc_ is dummy
-    disabled: [amd_linux]
+    disabled: [amd_linux, amd_wsl]
   Unit_hipIpcCloseMemHandle_Negative_Close_In_Originating_Process:
     <<: *level_2
     # Note: Windows disabled

--- a/projects/hip-tests/catch/config/configs/unit/deviceLib.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/deviceLib.yaml
@@ -243,7 +243,7 @@ deviceLib:
   Unit_Test_makechar_functionality:
     <<: *level_2
     # Rock_Linux_Failures_on_gfx94X
-    disabled: [amd_linux]
+    disabled: [amd_linux, amd_wsl]
     tags: [types]
   Unit_bf16_basic:
     <<: *level_2
@@ -488,4 +488,4 @@ deviceLib:
     # "============================TheRock_Bump_Windows_timeout #4547==========================="
     # "=== This is newly added test to check ASAN memory errors deduced from rocDecode ==="
     # "=== during ASAN/memleak detection work on Linux ==="
-    disabled: [amd_linux, amd_windows]
+    disabled: [amd_linux, amd_windows, amd_wsl]

--- a/projects/hip-tests/catch/config/configs/unit/device_memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/device_memory.yaml
@@ -3,7 +3,7 @@ device_memory:
   Unit_Device_memcpy_Positive:
     <<: *level_2
     # Rock_Linux_Failures_on_gfx94X
-    disabled: [amd_linux]
+    disabled: [amd_linux, amd_wsl]
   Unit_Device_memcpy_Negative_Parameters_RTC:
     <<: *level_2
     tags: [device_lang]

--- a/projects/hip-tests/catch/config/configs/unit/dynamicLoading.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/dynamicLoading.yaml
@@ -3,7 +3,7 @@ dynamicLoading:
   Unit_dynamic_loading_device_kernels_from_library:
     <<: *level_2
     # Rock_Linux_Failures_on_gfx94X
-    disabled: [amd_linux]
+    disabled: [amd_linux, amd_wsl]
     tags: [module]
   Unit_hipApiDynamicLoad_hipGetProcAddress:
     <<: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/errorHandling.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/errorHandling.yaml
@@ -14,7 +14,9 @@ errorHandling:
     <<: *level_2
     tags: [multigpu]
   Unit_hipGetLastError_with_hipMemcpyDtoHAsync: *level_2
-  Unit_hipGetLastError_with_hipMemcpyParam2DAsync: *level_2
+  Unit_hipGetLastError_with_hipMemcpyParam2DAsync:
+    <<: *level_2
+    disabled: [amd_wsl]
   Unit_hipGetLastError_with_hipDrvMemcpy3DAsync: *level_2
   Unit_hipGetLastError_with_hipMemcpy3DAsync:
     <<: *level_2
@@ -24,7 +26,9 @@ errorHandling:
   Unit_hipGetLastError_with_hipWaitExternalSemaphoresAsync: *level_2
   Unit_hipGetLastError_with_hipSignalExternalSemaphoresAsync: *level_2
   Unit_hipGetLastError_with_hipMemPrefetchAsync: *level_2
-  Unit_hipGetLastError_with_hipMemcpy2DAsync: *level_2
+  Unit_hipGetLastError_with_hipMemcpy2DAsync:
+    <<: *level_2
+    disabled: [amd_wsl]
   Unit_hipGetLastError_with_hipMemsetAsync: *level_2
   Unit_hipGetLastError_with_MemCpyAsync: *level_2
   Unit_hipGetLastError_with_MemCpyAsync_thread: *level_2
@@ -60,7 +64,9 @@ errorHandling:
     <<: *level_2
     tags: [multigpu]
   Unit_hipExtGetLastError_with_hipMemcpyDtoHAsync: *level_2
-  Unit_hipExtGetLastError_with_hipMemcpyParam2DAsync: *level_2
+  Unit_hipExtGetLastError_with_hipMemcpyParam2DAsync:
+    <<: *level_2
+    disabled: [amd_wsl]
   Unit_hipExtGetLastError_with_hipDrvMemcpy3DAsync: *level_2
   Unit_hipExtGetLastError_with_hipMemcpy3DAsync:
     <<: *level_2
@@ -70,7 +76,9 @@ errorHandling:
   Unit_hipExtGetLastError_with_hipWaitExternalSemaphoresAsync: *level_2
   Unit_hipExtGetLastError_with_hipSignalExternalSemaphoresAsync: *level_2
   Unit_hipExtGetLastError_with_hipMemPrefetchAsync: *level_2
-  Unit_hipExtGetLastError_with_hipMemcpy2DAsync: *level_2
+  Unit_hipExtGetLastError_with_hipMemcpy2DAsync:
+    <<: *level_2
+    disabled: [amd_wsl]
   Unit_hipExtGetLastError_with_hipMemsetAsync: *level_2
   Unit_hipExtGetLastError_with_MemCpyAsync: *level_2
   Unit_hipExtGetLastError_with_MemCpyAsync_thread: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/errorHandling.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/errorHandling.yaml
@@ -81,8 +81,8 @@ errorHandling:
   Unit_hipDynamicLogging_Positive_Basic:
     <<: *level_2
     # Following tests disabled as it should be a local perf test
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_hipDynamicLogging_Positive_MultipleEnableDisable:
     <<: *level_2
     # Following tests disabled as it should be a local perf test
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]

--- a/projects/hip-tests/catch/config/configs/unit/event.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/event.yaml
@@ -45,7 +45,7 @@ event:
     tags: [synchronization]
   Unit_hipEventRecord:
     <<: *level_2
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [synchronization]
   Unit_hipEventRecord_Negative:
     <<: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/executionControl.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/executionControl.yaml
@@ -3,7 +3,7 @@ executionControl:
   Unit_hipFuncGetAttributes_Positive_Basic:
     <<: *level_2
     # NOTE: The following test is disabled due to defect - EXSWHTEC-242
-    disabled: [amd_linux, amd_windows]
+    disabled: [amd_linux, amd_windows, amd_wsl]
     tags: [attributes, kernel]
   Unit_hipFuncGetAttributes_Negative_Parameters:
     <<: *level_2
@@ -17,7 +17,7 @@ executionControl:
   Unit_hipLaunchKernel_Negative_Parameters:
     <<: *level_2
     # Below tests are failing PSDB
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [kernel, launch]
   Unit_hipLaunchKernel_Verify_Capture: *level_2
   Unit_hipLaunchCooperativeKernel_Positive_Basic:
@@ -58,7 +58,7 @@ executionControl:
     <<: *level_2
     tags: [kernel, launch]
     # NOTE: The following test is disabled due to defect - EXSWHTEC-244
-    disabled: [amd_linux, amd_windows]
+    disabled: [amd_linux, amd_windows, amd_wsl]
   Unit_hipExtLaunchMultiKernelMultiDevice_Negative_MultiKernelSameDevice:
     <<: *level_2
     tags: [kernel, launch]

--- a/projects/hip-tests/catch/config/configs/unit/executionControl.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/executionControl.yaml
@@ -74,6 +74,7 @@ executionControl:
   Unit_hipLaunchByPtr_Verify_Capture: *level_2
   Unit_hipGetProcAddress_KernelLaunchApis:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [kernel]
   Unit_hipGetProcAddress_CallbackActivityAPIs:
     <<: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/executionctx.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/executionctx.yaml
@@ -12,7 +12,7 @@ executionctx:
     <<: *level_2
   Unit_hipExecutionCtxStreamDestroy_Negative:
     <<: *level_2
-    disabled: [amd_linux, amd_windows]
+    disabled: [amd_linux, amd_windows, amd_wsl]
   Unit_hipExecutionCtxRecordWaitEvent_Sanity:
     <<: *level_2
   Unit_hipExecutionCtxRecordEventFunctional:

--- a/projects/hip-tests/catch/config/configs/unit/graph.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/graph.yaml
@@ -92,7 +92,7 @@ graph:
   Unit_hipGraphAddMemcpyNode_Negative_Parameters:
     <<: *level_2
     # NOTE: The following test is disabled due to defect - EXSWHTEC-245
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [node, image]
   Unit_hipGraphClone_Negative:
     <<: *level_2
@@ -113,7 +113,7 @@ graph:
     <<: *level_2
     tags: [lifecycle, multigpu]
     # Enable the below test when multi-device graph launches are fully supported
-    disabled: [amd_linux]
+    disabled: [amd_linux, amd_wsl]
   Unit_hipGraphInstantiateWithFlags_StreamCapture:
     <<: *level_2
     tags: [lifecycle, multigpu]
@@ -121,7 +121,7 @@ graph:
     <<: *level_2
     tags: [lifecycle, multigpu]
     # SWDEV-445928: These tests fail in PSDB stress test on 09/02/2024
-    disabled: [amd_linux]
+    disabled: [amd_linux, amd_wsl]
   Unit_hipGraphInstantiateWithFlags_FlagAutoFreeOnLaunch_check:
     <<: *level_2
     # SWDEV-402082 - PAL Backend fails to reserve address on GPU except first one
@@ -130,22 +130,22 @@ graph:
   Unit_hipGraphInstantiateWithFlags_AutoFreeOnLaunchInLoop:
     <<: *level_2
     # SWDEV-517063 Below tests are temporarily disabled due to PSDB failure
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [lifecycle]
   Unit_hipGraphInstantiateWithFlags_AutoFreeOnLaunchFillKernel:
     <<: *level_2
     # SWDEV-517063 Below tests are temporarily disabled due to PSDB failure
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [lifecycle]
   Unit_hipGraphInstantiateWithFlags_AutoFreeOnLaunchDoubleKernel:
     <<: *level_2
     # SWDEV-517063 Below tests are temporarily disabled due to PSDB failure
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [lifecycle]
   Unit_hipGraphInstantiateWithFlags_WithDefaultAndAutoFreeOnLaunch:
     <<: *level_2
     # SWDEV-517063 Below tests are temporarily disabled due to PSDB failure
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [lifecycle]
   Unit_hipGraphInstantiateWithParams_Negative:
     <<: *level_2
@@ -513,7 +513,7 @@ graph:
     <<: *level_2
     tags: [exec, multigpu]
     # SWDEV-446588 - Disable graph multi gpu testcases until graph has support for it
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_hipGraphExecUpdate_Functional_KernelFunction_Changed:
     <<: *level_2
     tags: [exec]
@@ -795,7 +795,7 @@ graph:
   Unit_hipGraphMemFreeNodeGetParams_InvalidArgs:
     <<: *level_2
     # Rock_Linux_Failures_on_gfx94X
-    disabled: [amd_linux]
+    disabled: [amd_linux, amd_wsl]
     tags: [query]
   Unit_hipGraphUserObj_Int_float_Objects:
     <<: *level_2
@@ -809,7 +809,7 @@ graph:
   Unit_hipGraphUserObj_ClonedGraph:
     <<: *level_2
     # Test Unit_hipGraphUserObj_ClonedGraph disabled due to SWDEV-483112
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [userobj]
   Unit_hipGraphUserObj_ManualGraph:
     <<: *level_2
@@ -850,7 +850,7 @@ graph:
   Unit_hipStreamBeginCaptureToGraph_CaptureDepGraph:
     <<: *level_2
     # SWDEV-454245, SWDEV-454247 : Below tests fail on 29/03/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [capture]
   Unit_hipStreamBeginCaptureToGraph_ComplexGraph:
     <<: *level_2
@@ -888,7 +888,7 @@ graph:
   Unit_hipStreamBeginCaptureToGraph_IndepGraphsThreads:
     <<: *level_2
     # SWDEV-454245, SWDEV-454247 : Below tests fail on 29/03/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [capture]
   Unit_hipGetProcAddress_GraphAPIs_StreamCapture:
     <<: *level_2
@@ -1353,7 +1353,7 @@ graph:
     tags: [exec]
     # (amd_linux) SWDEV-553920 disabled until multi device graph issues are resolved
     # (amd_windows) SWDEV-446588 - Disable graph multi gpu testcases until graph has support for it
-    disabled: [amd_linux, amd_windows]
+    disabled: [amd_linux, amd_windows, amd_wsl]
   Unit_hipGraphUpload_Functional_With_Priority_Stream:
     <<: *level_2
     tags: [exec]
@@ -1462,14 +1462,14 @@ graph:
     <<: *level_2
     tags: [query]
     # SWDEV-446588 - Disable graph multi gpu testcases until graph has support for it
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_hipGraphMem_Alloc_Free_NodeGetParams_Functional_2:
     <<: *level_2
     tags: [query]
   Unit_hipGraphMem_Alloc_Free_NodeGetParams_Functional_3:
     <<: *level_2
     # Below tests are failing PSDB
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [query]
   Unit_hipGraphMem_Alloc_Free_NodeGetParams_Negative:
     <<: *level_2
@@ -1486,7 +1486,7 @@ graph:
   Unit_hipGraphAddMemAllocNode_Positive_FreeInGraph:
     <<: *level_2
     # Below tests are failing PSDB
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [node]
   Unit_hipGraphAddMemAllocNode_Positive_FreeOutsideStream:
     <<: *level_2
@@ -1519,7 +1519,7 @@ graph:
     <<: *level_2
     # (amd_linux) SWDEV-457316 Below test is skipped due ref count logic (Discussed with German)
     # (amd_windows) SWDEV-457316 Below test is skipped due ref count logic (Discussed with German)
-    disabled: [amd_linux, amd_windows]
+    disabled: [amd_linux, amd_windows, amd_wsl]
     tags: [node]
   Unit_hipGraphAddMemAllocNode_Negative_With_Cloneed_Graph:
     <<: *level_2
@@ -1530,7 +1530,7 @@ graph:
   Unit_hipGraphAddMemFreeNode_Negative_NotSupported:
     <<: *level_2
     # SWDEV-457316 Below tests are disabled temporarily to avoid combined PSDB
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [node]
   Unit_hipGraphAddMemFreeNode_Functional:
     <<: *level_2
@@ -1619,32 +1619,32 @@ graph:
   Unit_hipDrvGraphAddMemsetNode_hipMallocPitch_2D:
     <<: *level_2
     # Below tests are failing PSDB
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [node]
   Unit_hipDrvGraphAddMemsetNode_hipMallocPitch_1D:
     <<: *level_2
     # Below tests are failing PSDB
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [node]
   Unit_hipDrvGraphAddMemsetNode_hipMalloc3D_2D:
     <<: *level_2
     # Below tests are failing PSDB
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [node]
   Unit_hipDrvGraphAddMemsetNode_hipMalloc3D_1D:
     <<: *level_2
     # Below tests are failing PSDB
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [node]
   Unit_hipDrvGraphAddMemsetNode_hipMalloc_1D:
     <<: *level_2
     # Below tests are failing PSDB
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [node]
   Unit_hipDrvGraphAddMemsetNode_hipMallocManaged:
     <<: *level_2
     # Below tests are failing PSDB
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [node]
   Unit_hipDrvGraphAddMemcpyNode_Negative:
     <<: *level_2
@@ -1698,7 +1698,7 @@ graph:
     tags: [node]
   Unit_hipGraphAllocNodeMemReuse_MallocWithoutFree_NoReuse:
     <<: *level_2
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [node]
   Unit_hipGraphAllocNodeMemReuse_DifferentStreams_Reuse:
     <<: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/graph.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/graph.yaml
@@ -242,7 +242,9 @@ graph:
   Unit_hipGraphAddMemcpyNodeToSymbol_Negative_Parameters:
     <<: *level_2
     tags: [node]
-  Unit_hipGraphExecMemsetNodeSetParams_Positive_Basic: *level_2
+  Unit_hipGraphExecMemsetNodeSetParams_Positive_Basic:
+    <<: *level_2
+    disabled: [amd_wsl]
   Unit_hipGraphExecMemsetNodeSetParams_Negative_Parameters:
     <<: *level_2
     tags: [exec]
@@ -252,7 +254,9 @@ graph:
     disabled: [amd_windows, amd_wsl]
     tags: [exec]
   Unit_hipGraphMemsetNodeSetParams_FlatAlloc_2D_Positive: *level_2
-  Unit_hipGraphMemsetNodeSetParams_PitchedAlloc_OverExtent_Negative: *level_2
+  Unit_hipGraphMemsetNodeSetParams_PitchedAlloc_OverExtent_Negative:
+    <<: *level_2
+    disabled: [amd_wsl]
   Unit_hipGraphExecUpdate_FlatAlloc_2DMemset_Idempotent: *level_2
   Unit_hipGraphExecUpdate_2DMemset_ShapeChange_Negative: *level_2
   Unit_hipGraphExecUpdate_2DMemset_ValueAndDst_Positive: *level_2
@@ -540,6 +544,7 @@ graph:
     tags: [node]
   Unit_hipGraphMemsetNodeGetParams_Negative_Parameters:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [query]
   Unit_hipGraphMemsetNodeSetParams_Positive_Basic:
     <<: *level_2
@@ -898,9 +903,11 @@ graph:
     tags: [query]
   Unit_hipGetProcAddress_GraphAPIs_AddMemsetMemcpyNodes:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [query]
   Unit_hipGetProcAddress_GraphAPIs_SetGetParamsMemsetMemcpy:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [query]
   Unit_hipGetProcAddress_GraphAPIs_KernelNodeSetGetParams:
     <<: *level_2
@@ -922,6 +929,7 @@ graph:
     tags: [query]
   Unit_hipGetProcAddress_GraphAPIs_ExecMemsetMemcpySetParams:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [query]
   Unit_hipGraphExecNodeSetParams_Negative_Parameters:
     <<: *level_2
@@ -1009,20 +1017,25 @@ graph:
     tags: [exec]
   Unit_hipGraphAddMemsetNode_Positive_Basic:
     <<: *level_2
+    disabled: [amd_wsl]
   Unit_hipGraphAddMemsetNode_Negative_Parameters:
     <<: *level_2
     tags: [node]
   Unit_hipGraphAddMemsetNode_hipMallocPitch_2D:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [node]
   Unit_hipGraphAddMemsetNode_hipMallocPitch_1D:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [node]
   Unit_hipGraphAddMemsetNode_hipMalloc3D_2D:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [node]
   Unit_hipGraphAddMemsetNode_hipMalloc3D_1D:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [node]
   Unit_hipGraphAddMemsetNode_hipMalloc_1D:
     <<: *level_2
@@ -1047,6 +1060,7 @@ graph:
     tags: [node]
   Unit_hipGraphMemcpyNodeGetParams_Negative_Parameters:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [query]
   Unit_hipGraphMemcpyNodeGetParams_Negative:
     <<: *level_2
@@ -1059,6 +1073,7 @@ graph:
     tags: [node, image]
   Unit_hipGraphMemcpyNodeSetParams_Negative_Parameters:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [node]
   Unit_hipGraphKernelNodeGetParams_Negative:
     <<: *level_2
@@ -1537,18 +1552,21 @@ graph:
     tags: [node]
   Unit_hipDrvGraphMemcpyNodeGetParams_Negative_Parameters:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [query]
   Unit_hipDrvGraphMemcpyNodeGetParams_Positive:
     <<: *level_2
     tags: [query]
   Unit_hipDrvGraphMemcpyNodeSetParams_Positive_Basic:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [node]
   Unit_hipDrvGraphMemcpyNodeSetParams_Positive_Array:
     <<: *level_2
     tags: [node, image]
   Unit_hipDrvGraphMemcpyNodeSetParams_Negative_Parameters:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [node]
   Unit_hipDeviceSetGraphMemAttribute_Positive_Default:
     <<: *level_2
@@ -1582,11 +1600,15 @@ graph:
     tags: [exec]
   Unit_hipDrvGraphExecMemsetNodeSetParams_BasicPositive:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [exec]
   Unit_hipDrvGraphExecMemsetNodeSetParams_Negative:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [exec]
-  Unit_hipGraphAddNodeTypeMemset_Positive_Basic: *level_2
+  Unit_hipGraphAddNodeTypeMemset_Positive_Basic:
+    <<: *level_2
+    disabled: [amd_wsl]
   Unit_hipGraphAddNodeTypeKernel_Positive_Basic:
     <<: *level_2
     tags: [node]
@@ -1613,6 +1635,7 @@ graph:
     tags: [node]
   Unit_hipDrvGraphAddMemsetNode_Positive_Basic:
     <<: *level_2
+    disabled: [amd_wsl]
   Unit_hipDrvGraphAddMemsetNode_Negative_Parameters:
     <<: *level_2
     tags: [node]
@@ -1663,6 +1686,7 @@ graph:
     tags: [node, image]
   Unit_hipDrvGraphAddMemcpyNode_Negative_Parameters:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [node]
   Unit_hipEventQuery_GlobalCapture_DefaultMode_NormalEvent: *level_2
   Unit_hipEventQuery_GlobalCapture_DefaultMode_CapturedEvent: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/kernel.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/kernel.yaml
@@ -12,7 +12,7 @@ kernel:
   Unit_hipDynamicShared:
     <<: *level_2
     # Below tests are failing PSDB
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [memory]
   Unit_hipDynamicShared2:
     <<: *level_2
@@ -85,7 +85,7 @@ kernel:
     tags: [launch]
   Unit_hipGridLaunch_ExceedMaxGridDim_Negative:
     <<: *level_2
-    disabled: [amd_windows, amd_linux]
+    disabled: [amd_windows, amd_linux, amd_wsl]
     tags: [launch]
   Unit_hipExtDynDataPrefetch_NegativeTests:
     <<: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/launchBounds.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/launchBounds.yaml
@@ -6,10 +6,10 @@ launchBounds:
   Unit_Kernel_Launch_bounds_Negative_OutOfBounds:
     <<: *level_2
     # Below tests are failing PSDB
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [attributes, kernel]
   Unit_Kernel_Launch_bounds_Negative_Parameters_RTC:
     <<: *level_2
     # Below tests are failing PSDB
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [attributes, kernel]

--- a/projects/hip-tests/catch/config/configs/unit/math.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/math.yaml
@@ -64,7 +64,7 @@ math:
   Unit_Device_sinpi_Accuracy_Positive_double:
     <<: *level_2
     # special values test, fix: comment out [HEX_DBL(-, 1, fffffffffffff, +, 31), HEX_DBL(+, 1, fffffffffffff, +, 31)]
-    disabled: [amd_linux, nvidia_linux]
+    disabled: [amd_linux, nvidia_linux, amd_wsl]
   Unit_Device_sinpi_sinpif_Negative_RTC:
     <<: *level_2
     tags: [deviceLib]
@@ -72,7 +72,7 @@ math:
   Unit_Device_cospi_Accuracy_Positive_double:
     <<: *level_2
     # special values test, fix: comment out [HEX_DBL(-, 1, fffffffffffff, +, 31), HEX_DBL(+, 1, fffffffffffff, +, 31)]
-    disabled: [amd_linux, nvidia_linux]
+    disabled: [amd_linux, nvidia_linux, amd_wsl]
   Unit_Device_cospi_cospif_Negative_RTC:
     <<: *level_2
     tags: [deviceLib]
@@ -89,7 +89,7 @@ math:
   Unit_Device_sincospi_Accuracy_Positive_double:
     <<: *level_2
     # special values test, fix: comment out [HEX_DBL(-, 1, fffffffffffff, +, 31), HEX_DBL(+, 1, fffffffffffff, +, 31)]
-    disabled: [amd_linux, nvidia_linux]
+    disabled: [amd_linux, nvidia_linux, amd_wsl]
   Unit_Device_sincospi_sincospif_Negative_RTC:
     <<: *level_2
     tags: [deviceLib]
@@ -117,7 +117,7 @@ math:
   Unit_Device_fma_Accuracy_Positive:
     <<: *level_2
     # special values test, fix: comment out [-3.0f, -1.5f, HEX_FLT(-, 0, 00000c, -, 126), HEX_FLT(-, 0, 000006, -, 126), +3.0f, 1.5f, HEX_FLT(+, 0, 00000c, -, 126), HEX_FLT(+, 0, 000006, -, 126),]
-    disabled: [amd_linux, nvidia_linux]
+    disabled: [amd_linux, nvidia_linux, amd_wsl]
   Unit_Device_fma_fmaf_Negative_RTC:
     <<: *level_2
     tags: [deviceLib]
@@ -158,7 +158,7 @@ math:
   Unit_Device_fdim_Accuracy_Positive:
     <<: *level_2
     # special values test, fix: comment out [HEX_DBL(-, 1, fffffffffffff, +, 31), HEX_DBL(-, 1, fffffffffffff, +, 30), HEX_DBL(+, 1, fffffffffffff, +, 31), HEX_DBL(+, 1, fffffffffffff, +, 30)]
-    disabled: [amd_linux, nvidia_linux]
+    disabled: [amd_linux, nvidia_linux, amd_wsl]
   Unit_Device_fdim_fdimf_Negative_RTC:
     <<: *level_2
     tags: [deviceLib]
@@ -215,7 +215,7 @@ math:
   Unit_Device_remquo_Accuracy_Positive:
     <<: *level_2
     # TODO special value test error, fix: comment out special value test
-    disabled: [amd_linux, nvidia_linux]
+    disabled: [amd_linux, nvidia_linux, amd_wsl]
   Unit_Device_remquo_remquof_Negative_RTC:
     <<: *level_2
     tags: [deviceLib]
@@ -224,116 +224,116 @@ math:
   Unit_Device_modf_modff_Negative_RTC:
     <<: *level_2
     # float* can be casted to double* [math_remainder_rounding_negative_kernels_rtc.hh:247]
-    disabled: [amd_linux, nvidia_linux]
+    disabled: [amd_linux, nvidia_linux, amd_wsl]
     tags: [deviceLib]
   Unit_Device___frcp_rn_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___fsqrt_rn_Accuracy_Positive:
     <<: *level_2
     # (amd_linux) TODO round error
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_linux, amd_windows]
+    disabled: [amd_linux, amd_windows, amd_wsl]
   Unit_Device___frsqrt_rn_Accuracy_Positive:
     <<: *level_2
     # (amd_linux) TODO round error
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
     # (nvidia_linux) TODO round error
-    disabled: [amd_linux, amd_windows, nvidia_linux]
+    disabled: [amd_linux, amd_windows, nvidia_linux, amd_wsl]
   Unit_Device___expf_Accuracy_Positive:
     <<: *level_2
     # (amd_linux) TODO terminated, ulp formula seems to be wrong [produces ulp of 4294967298]
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
     # (nvidia_linux) TODO terminated, ulp formula seems to be wrong [produces ulp of 4294967298]
-    disabled: [amd_linux, amd_windows, nvidia_linux]
+    disabled: [amd_linux, amd_windows, nvidia_linux, amd_wsl]
   Unit_Device___exp10f_Accuracy_Positive:
     <<: *level_2
     # (amd_linux) TODO terminated, ulp formula seems to be wrong [produces ulp of 4294967298]
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
     # (nvidia_linux) TODO terminated, ulp formula seems to be wrong [produces ulp of 4294967298]
-    disabled: [amd_linux, amd_windows, nvidia_linux]
+    disabled: [amd_linux, amd_windows, nvidia_linux, amd_wsl]
   Unit_Device___logf_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___log2f_Accuracy_Positive:
     <<: *level_2
     # (amd_linux) TODO error, input +-1.40129846e-45
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_linux, amd_windows]
+    disabled: [amd_linux, amd_windows, amd_wsl]
   Unit_Device___log10f_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___sinf_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___sincosf_sin_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___cosf_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___sincosf_cos_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___fadd_rn_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___fsub_rn_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___fmul_rn_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___fdiv_rn_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___fdividef_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___fmaf_rn_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___drcp_rn_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___dsqrt_rn_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___dadd_rn_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___dsub_rn_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___dmul_rn_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___ddiv_rn_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___fma_rn_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___brev_Sanity_Positive:
     <<: *level_2
     tags: [deviceLib]
@@ -344,7 +344,7 @@ math:
   Unit_Device___clzll_Sanity_Positive:
     <<: *level_2
     # Rock_Linux_Failures_on_gfx94X
-    disabled: [amd_linux]
+    disabled: [amd_linux, amd_wsl]
   Unit_Device___ffs_Sanity_Positive: *level_2
   Unit_Device___ffsll_Sanity_Positive: *level_2
   Unit_Device___popc_Sanity_Positive:
@@ -374,22 +374,22 @@ math:
   Unit_Device___hadd_Sanity_Positive:
     <<: *level_2
     # Below 4 tests are disable due to defect EXSWHTEC-355
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [deviceLib]
   Unit_Device___uhadd_Sanity_Positive:
     <<: *level_2
     # Below 4 tests are disable due to defect EXSWHTEC-355
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [deviceLib]
   Unit_Device___rhadd_Sanity_Positive:
     <<: *level_2
     # Below 4 tests are disable due to defect EXSWHTEC-355
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [deviceLib]
   Unit_Device___urhadd_Sanity_Positive:
     <<: *level_2
     # Below 4 tests are disable due to defect EXSWHTEC-355
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [deviceLib]
   Unit_Device___mulhi_Sanity_Positive:
     <<: *level_2
@@ -495,7 +495,7 @@ math:
   Unit_Device_log1p_Accuracy_Positive_double:
     <<: *level_2
     # special values test, fix: comment out [HEX_DBL(-, 0, 0000000000001, -, 1022)]
-    disabled: [amd_linux]
+    disabled: [amd_linux, amd_wsl]
   Unit_Device_log1p_log1pf_Negative_RTC:
     <<: *level_2
     tags: [deviceLib]
@@ -507,12 +507,12 @@ math:
   Unit_Device_ilogbf_Accuracy_Positive:
     <<: *level_2
     # Below 2 tests are disable due to defect EXSWHTEC-369
-    disabled: [amd_linux, amd_windows]
+    disabled: [amd_linux, amd_windows, amd_wsl]
     tags: [deviceLib]
   Unit_Device_ilogb_Accuracy_Positive:
     <<: *level_2
     # Below 2 tests are disable due to defect EXSWHTEC-369
-    disabled: [amd_linux, amd_windows]
+    disabled: [amd_linux, amd_windows, amd_wsl]
     tags: [deviceLib]
   Unit_Device_ilogb_ilogbf_Negative_RTC:
     <<: *level_2
@@ -575,7 +575,7 @@ math:
   Unit_Device_tgammaf_Accuracy_Limited_Positive:
     <<: *level_2
     # TODO
-    disabled: [amd_linux]
+    disabled: [amd_linux, amd_wsl]
     tags: [deviceLib]
   Unit_Device_tgamma_Accuracy_Limited_Positive:
     <<: *level_2
@@ -835,266 +835,266 @@ math:
     <<: *level_2
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
     # (nvidia_linux) TODO rounding error
-    disabled: [amd_windows, nvidia_linux]
+    disabled: [amd_windows, nvidia_linux, amd_wsl]
   Unit_Device___half2int_rz_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___half2int_rd_Accuracy_Positive:
     <<: *level_2
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
     # (nvidia_linux) TODO rounding error
-    disabled: [amd_windows, nvidia_linux]
+    disabled: [amd_windows, nvidia_linux, amd_wsl]
   Unit_Device___half2int_ru_Accuracy_Positive:
     <<: *level_2
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
     # (nvidia_linux) TODO rounding error
-    disabled: [amd_windows, nvidia_linux]
+    disabled: [amd_windows, nvidia_linux, amd_wsl]
   Unit_Device___half2uint_rn_Accuracy_Positive:
     <<: *level_2
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
     # (nvidia_linux) TODO rounding error
-    disabled: [amd_windows, nvidia_linux]
+    disabled: [amd_windows, nvidia_linux, amd_wsl]
   Unit_Device___half2uint_rz_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___half2uint_rd_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___half2uint_ru_Accuracy_Positive:
     <<: *level_2
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
     # (nvidia_linux) TODO rounding error
-    disabled: [amd_windows, nvidia_linux]
+    disabled: [amd_windows, nvidia_linux, amd_wsl]
   Unit_Device___half2short_rn_Accuracy_Positive:
     <<: *level_2
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
     # (nvidia_linux) TODO rounding error
-    disabled: [amd_windows, nvidia_linux]
+    disabled: [amd_windows, nvidia_linux, amd_wsl]
   Unit_Device___half2short_rz_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___half2short_rd_Accuracy_Positive:
     <<: *level_2
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
     # (nvidia_linux) TODO rounding error
-    disabled: [amd_windows, nvidia_linux]
+    disabled: [amd_windows, nvidia_linux, amd_wsl]
   Unit_Device___half2short_ru_Accuracy_Positive:
     <<: *level_2
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
     # (nvidia_linux) TODO rounding error
-    disabled: [amd_windows, nvidia_linux]
+    disabled: [amd_windows, nvidia_linux, amd_wsl]
   Unit_Device___half2ushort_rn_Accuracy_Positive:
     <<: *level_2
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
     # (nvidia_linux) TODO rounding error
-    disabled: [amd_windows, nvidia_linux]
+    disabled: [amd_windows, nvidia_linux, amd_wsl]
   Unit_Device___half2ushort_rz_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___half2ushort_rd_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___half2ushort_ru_Accuracy_Positive:
     <<: *level_2
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
     # (nvidia_linux) TODO rounding error
-    disabled: [amd_windows, nvidia_linux]
+    disabled: [amd_windows, nvidia_linux, amd_wsl]
   Unit_Device___half2ll_rn_Accuracy_Positive:
     <<: *level_2
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
     # (nvidia_linux) TODO rounding error
-    disabled: [amd_windows, nvidia_linux]
+    disabled: [amd_windows, nvidia_linux, amd_wsl]
   Unit_Device___half2ll_rz_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___half2ll_rd_Accuracy_Positive:
     <<: *level_2
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
     # (nvidia_linux) TODO rounding error
-    disabled: [amd_windows, nvidia_linux]
+    disabled: [amd_windows, nvidia_linux, amd_wsl]
   Unit_Device___half2ll_ru_Accuracy_Positive:
     <<: *level_2
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
     # (nvidia_linux) TODO rounding error
-    disabled: [amd_windows, nvidia_linux]
+    disabled: [amd_windows, nvidia_linux, amd_wsl]
   Unit_Device___half2ull_rn_Accuracy_Positive:
     <<: *level_2
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
     # (nvidia_linux) TODO rounding error
-    disabled: [amd_windows, nvidia_linux]
+    disabled: [amd_windows, nvidia_linux, amd_wsl]
   Unit_Device___half2ull_rz_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___half2ull_rd_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___half2ull_ru_Accuracy_Positive:
     <<: *level_2
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
     # (nvidia_linux) TODO rounding error
-    disabled: [amd_windows, nvidia_linux]
+    disabled: [amd_windows, nvidia_linux, amd_wsl]
   Unit_Device___half_as_short_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [deviceLib]
   Unit_Device___half_as_ushort_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [deviceLib]
   Unit_Device___int2half_rn_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___int2half_rz_Accuracy_Positive:
     <<: *level_2
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
     # (nvidia_linux) TODO rounding error
-    disabled: [amd_windows, nvidia_linux]
+    disabled: [amd_windows, nvidia_linux, amd_wsl]
   Unit_Device___int2half_rd_Accuracy_Positive:
     <<: *level_2
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
     # (nvidia_linux) TODO rounding error
-    disabled: [amd_windows, nvidia_linux]
+    disabled: [amd_windows, nvidia_linux, amd_wsl]
   Unit_Device___int2half_ru_Accuracy_Positive:
     <<: *level_2
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
     # (nvidia_linux) TODO rounding error
-    disabled: [amd_windows, nvidia_linux]
+    disabled: [amd_windows, nvidia_linux, amd_wsl]
   Unit_Device___uint2half_rn_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___uint2half_rz_Accuracy_Positive:
     <<: *level_2
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
     # (nvidia_linux) TODO rounding error
-    disabled: [amd_windows, nvidia_linux]
+    disabled: [amd_windows, nvidia_linux, amd_wsl]
   Unit_Device___uint2half_rd_Accuracy_Positive:
     <<: *level_2
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
     # (nvidia_linux) TODO rounding error
-    disabled: [amd_windows, nvidia_linux]
+    disabled: [amd_windows, nvidia_linux, amd_wsl]
   Unit_Device___uint2half_ru_Accuracy_Positive:
     <<: *level_2
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
     # (nvidia_linux) TODO rounding error
-    disabled: [amd_windows, nvidia_linux]
+    disabled: [amd_windows, nvidia_linux, amd_wsl]
   Unit_Device___short2half_rn_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___short2half_rz_Accuracy_Positive:
     <<: *level_2
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
     # (nvidia_linux) TODO rounding error
-    disabled: [amd_windows, nvidia_linux]
+    disabled: [amd_windows, nvidia_linux, amd_wsl]
   Unit_Device___short2half_rd_Accuracy_Positive:
     <<: *level_2
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
     # (nvidia_linux) TODO rounding error
-    disabled: [amd_windows, nvidia_linux]
+    disabled: [amd_windows, nvidia_linux, amd_wsl]
   Unit_Device___short2half_ru_Accuracy_Positive:
     <<: *level_2
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
     # (nvidia_linux) TODO rounding error
-    disabled: [amd_windows, nvidia_linux]
+    disabled: [amd_windows, nvidia_linux, amd_wsl]
   Unit_Device___ushort2half_rn_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___ushort2half_rz_Accuracy_Positive:
     <<: *level_2
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
     # (nvidia_linux) TODO rounding error
-    disabled: [amd_windows, nvidia_linux]
+    disabled: [amd_windows, nvidia_linux, amd_wsl]
   Unit_Device___ushort2half_rd_Accuracy_Positive:
     <<: *level_2
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
     # (nvidia_linux) TODO rounding error
-    disabled: [amd_windows, nvidia_linux]
+    disabled: [amd_windows, nvidia_linux, amd_wsl]
   Unit_Device___ushort2half_ru_Accuracy_Positive:
     <<: *level_2
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
     # (nvidia_linux) TODO rounding error
-    disabled: [amd_windows, nvidia_linux]
+    disabled: [amd_windows, nvidia_linux, amd_wsl]
   Unit_Device___ll2half_rn_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___ll2half_rz_Accuracy_Positive:
     <<: *level_2
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
     # (nvidia_linux) TODO rounding error
-    disabled: [amd_windows, nvidia_linux]
+    disabled: [amd_windows, nvidia_linux, amd_wsl]
   Unit_Device___ll2half_rd_Accuracy_Positive:
     <<: *level_2
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
     # (nvidia_linux) TODO rounding error
-    disabled: [amd_windows, nvidia_linux]
+    disabled: [amd_windows, nvidia_linux, amd_wsl]
   Unit_Device___ll2half_ru_Accuracy_Positive:
     <<: *level_2
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
     # (nvidia_linux) TODO rounding error
-    disabled: [amd_windows, nvidia_linux]
+    disabled: [amd_windows, nvidia_linux, amd_wsl]
   Unit_Device___ull2half_rn_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___ull2half_rz_Accuracy_Positive:
     <<: *level_2
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
     # (nvidia_linux) TODO rounding error
-    disabled: [amd_windows, nvidia_linux]
+    disabled: [amd_windows, nvidia_linux, amd_wsl]
   Unit_Device___ull2half_rd_Accuracy_Positive:
     <<: *level_2
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
     # (nvidia_linux) TODO rounding error
-    disabled: [amd_windows, nvidia_linux]
+    disabled: [amd_windows, nvidia_linux, amd_wsl]
   Unit_Device___ull2half_ru_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___short_as_half_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [deviceLib]
   Unit_Device___ushort_as_half_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [deviceLib]
   Unit_Device___float2half_rd_Accuracy_Limited_Positive:
     <<: *level_2
     # rounding float16 types not supported?
-    disabled: [amd_linux, nvidia_linux]
+    disabled: [amd_linux, nvidia_linux, amd_wsl]
   Unit_Device___float2half_rn_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___float2half_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___float2half_ru_Accuracy_Limited_Positive:
     <<: *level_2
     # rounding float16 types not supported?
-    disabled: [amd_linux, nvidia_linux]
+    disabled: [amd_linux, nvidia_linux, amd_wsl]
   Unit_Device___float2half_rz_Accuracy_Limited_Positive:
     <<: *level_2
     # rounding float16 types not supported?
-    disabled: [amd_linux, nvidia_linux]
+    disabled: [amd_linux, nvidia_linux, amd_wsl]
   Unit_Device___float2half_rd_SmallVals_Sanity_Positive:
     <<: *level_2
     tags: [deviceLib]
@@ -1107,7 +1107,7 @@ math:
   Unit_Device___half2float_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [deviceLib]
   Unit_Device_exp_Accuracy_Positive_float: *level_2
   Unit_Device_exp_Accuracy_Positive_double: *level_2
@@ -1161,476 +1161,476 @@ math:
   Unit_Device_scalbln_Accuracy_Positive:
     <<: *level_2
     # long int exponents are too large, works fine with int
-    disabled: [amd_linux]
+    disabled: [amd_linux, amd_wsl]
   Unit_Device_scalbln_scalblnf_Negative_RTC:
     <<: *level_2
     tags: [deviceLib]
   Unit_Device___half2half2_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [deviceLib]
   Unit_Device_make_half2_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [deviceLib]
   Unit_Device___halves2half2_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [deviceLib]
   Unit_Device___low2half_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [deviceLib]
   Unit_Device___high2half_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [deviceLib]
   Unit_Device___low2half2_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [deviceLib]
   Unit_Device___high2half2_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [deviceLib]
   Unit_Device___lowhigh2highlow_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [deviceLib]
   Unit_Device___lows2half2_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [deviceLib]
   Unit_Device___highs2half2_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [deviceLib]
   Unit_Device___float2half2_rn_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [deviceLib]
   Unit_Device___floats2half2_rn_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [deviceLib]
   Unit_Device___float22half2_rn_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [deviceLib]
   Unit_Device___low2float_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [deviceLib]
   Unit_Device___high2float_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [deviceLib]
   Unit_Device___half22float2_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [deviceLib]
   Unit_Device_hcos_Accuracy_Positive:
     <<: *level_2
     # (amd_linux) Float16 problem
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_linux, amd_windows]
+    disabled: [amd_linux, amd_windows, amd_wsl]
   Unit_Device_h2cos_Accuracy_Positive:
     <<: *level_2
     # (amd_linux) Float16 problem
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_linux, amd_windows]
+    disabled: [amd_linux, amd_windows, amd_wsl]
   Unit_Device_hsin_Accuracy_Positive:
     <<: *level_2
     # (amd_linux) Float16 problem
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_linux, amd_windows]
+    disabled: [amd_linux, amd_windows, amd_wsl]
   Unit_Device_h2sin_Accuracy_Positive:
     <<: *level_2
     # (amd_linux) Float16 problem
     # (amd_windows) Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_linux, amd_windows]
+    disabled: [amd_linux, amd_windows, amd_wsl]
   Unit_Device_hexp_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device_h2exp_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device_hexp10_Accuracy_Positive:
     <<: *level_2
     # === Below tests cause timeout in stress test of 09/02/24 ===
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device_h2exp10_Accuracy_Positive:
     <<: *level_2
     # === Below tests cause timeout in stress test of 09/02/24 ===
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device_hexp2_Accuracy_Positive:
     <<: *level_2
     # === Below tests cause timeout in stress test of 09/02/24 ===
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device_h2exp2_Accuracy_Positive:
     <<: *level_2
     # === Below tests cause timeout in stress test of 09/02/24 ===
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device_hlog_Accuracy_Positive:
     <<: *level_2
     # === Below tests cause timeout in stress test of 09/02/24 ===
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device_h2log_Accuracy_Positive:
     <<: *level_2
     # === Below tests cause timeout in stress test of 09/02/24 ===
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device_hlog10_Accuracy_Positive:
     <<: *level_2
     # === Below tests cause timeout in stress test of 09/02/24 ===
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device_h2log10_Accuracy_Positive:
     <<: *level_2
     # === Below tests cause timeout in stress test of 09/02/24 ===
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device_hlog2_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device_h2log2_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device_hsqrt_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device_h2sqrt_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device_hceil_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device_h2ceil_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device_hfloor_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device_h2floor_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device_htrunc_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device_h2trunc_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device_hrcp_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device_h2rcp_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device_hrsqrt_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device_h2rsqrt_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device_hrint_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device_h2rint_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___habs_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___habs2_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hneg_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hneg2_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hadd_wrapper_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hadd2_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hadd_sat_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hadd2_sat_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hsub_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hsub2_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hsub_sat_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hsub2_sat_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hmul_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hmul2_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hmul_sat_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hmul2_sat_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hdiv_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___h2div_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hfma_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hfma2_Accuracy_Positive:
     <<: *level_2
     # (amd_linux) TODO === fail on 100% test data
     # (amd_windows )Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_linux, amd_windows]
+    disabled: [amd_linux, amd_windows, amd_wsl]
   Unit_Device___hfma_sat_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hfma2_sat_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hisinf_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hisinf2_Accuracy_Positive:
     <<: *level_2
     # Below 2 tests are disable due to defect EXSWHTEC-356
-    disabled: [amd_linux, amd_windows]
+    disabled: [amd_linux, amd_windows, amd_wsl]
   Unit_Device___hisnan_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hisnan2_Accuracy_Positive:
     <<: *level_2
     # Below 2 tests are disable due to defect EXSWHTEC-356
-    disabled: [amd_linux, amd_windows]
+    disabled: [amd_linux, amd_windows, amd_wsl]
   Unit_Device___heq_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hbeq2_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hequ_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hbequ2_Accuracy_Positive:
     <<: *level_2
     # Below 2 tests are disable due to defect EXSWHTEC-356
-    disabled: [amd_linux, amd_windows]
+    disabled: [amd_linux, amd_windows, amd_wsl]
   Unit_Device___heq2_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hequ2_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hne_Accuracy_Positive:
     <<: *level_2
     # Below 2 tests are disable due to defect EXSWHTEC-356
-    disabled: [amd_linux, amd_windows]
+    disabled: [amd_linux, amd_windows, amd_wsl]
   Unit_Device___hbne2_Accuracy_Positive:
     <<: *level_2
     # Below 2 tests are disable due to defect EXSWHTEC-356
-    disabled: [amd_linux, amd_windows]
+    disabled: [amd_linux, amd_windows, amd_wsl]
   Unit_Device___hneu_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hbneu2_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hne2_Accuracy_Positive:
     <<: *level_2
     # Below 2 tests are disable due to defect EXSWHTEC-356
-    disabled: [amd_linux, amd_windows]
+    disabled: [amd_linux, amd_windows, amd_wsl]
   Unit_Device___hneu2_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hge_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hbge2_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hgeu_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hbgeu2_Accuracy_Positive:
     <<: *level_2
     # Below 2 tests are disable due to defect EXSWHTEC-356
-    disabled: [amd_linux, amd_windows]
+    disabled: [amd_linux, amd_windows, amd_wsl]
   Unit_Device___hge2_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hgeu2_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hgt_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hbgt2_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hgtu_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hbgtu2_Accuracy_Positive:
     <<: *level_2
     # Below 2 tests are disable due to defect EXSWHTEC-356
-    disabled: [amd_linux, amd_windows]
+    disabled: [amd_linux, amd_windows, amd_wsl]
   Unit_Device___hgt2_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hgtu2_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hle_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hble2_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hleu_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hbleu2_Accuracy_Positive:
     <<: *level_2
     # Below 2 tests are disable due to defect EXSWHTEC-356
-    disabled: [amd_linux, amd_windows]
+    disabled: [amd_linux, amd_windows, amd_wsl]
   Unit_Device___hle2_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hleu2_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hlt_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hblt2_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hltu_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hbltu2_Accuracy_Positive:
     <<: *level_2
     # Below 2 tests are disable due to defect EXSWHTEC-356
-    disabled: [amd_linux, amd_windows]
+    disabled: [amd_linux, amd_windows, amd_wsl]
   Unit_Device___hlt2_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hltu2_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hmax_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hmin_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hmax_nan_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Device___hmin_nan_Accuracy_Positive:
     <<: *level_2
     # Below tests cause timeout in stress test of 09/02/24
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]

--- a/projects/hip-tests/catch/config/configs/unit/memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/memory.yaml
@@ -155,15 +155,15 @@ memory:
   Unit_hipMemcpy2D_H2D_D2D_D2H:
     <<: *level_2
     # Below tests are failing PSDB
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_hipMemcpy2D_H2D_D2D_D2H_WithOffset:
     <<: *level_2
     # Below tests are failing PSDB
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_hipMemcpy2D_H2D_D2D_D2H_Managed_WithOffset:
     <<: *level_2
     # Below tests are failing PSDB
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_hipMemcpy2D_multiDevice_Basic_Size_Test:
     <<: *level_2
     tags: [transfer]
@@ -183,7 +183,7 @@ memory:
   Unit_hipMemcpy2DAsync_Host_N_PinnedMem:
     <<: *level_2
     # Below tests are failing PSDB
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_hipMemcpy2DAsync_multiDevice_StreamOnDiffDevice:
     <<: *level_2
     tags: [multigpu]
@@ -294,7 +294,7 @@ memory:
   Unit_hipMemcpyHtoAAsync_BasicTstsWithDiffStreams:
     <<: *level_2
     # Rock_Linux_Failures_on_gfx94X
-    disabled: [amd_linux]
+    disabled: [amd_linux, amd_wsl]
     tags: [transfer, image]
   Unit_hipMemcpyHtoAAsync_MultiDevice:
     <<: *level_2
@@ -324,13 +324,13 @@ memory:
     <<: *level_2
     # disabling due to flaky segfault in CI nightly https://github.com/ROCm/TheRock/issues/4111
     tags: []
-    disabled: [amd_linux]
+    disabled: [amd_linux, amd_wsl]
   Unit_hipHostRegister_DirectReferenceFromKernel: *level_2
   Unit_hipHostRegister_DirectReferenceMultGpu:
     <<: *level_2
     tags: []
     # Rock_Linux_Failures_on_gfx94X
-    disabled: [amd_linux]
+    disabled: [amd_linux, amd_wsl]
   Unit_hipHostRegister_SameChunkRepeat:
     <<: *level_2
     tags: [alloc]
@@ -347,7 +347,7 @@ memory:
     <<: *level_2
     tags: [alloc]
     # disabled due to flaky segfault in CI nightly https://github.com/ROCm/TheRock/issues/4111
-    disabled: [amd_linux]
+    disabled: [amd_linux, amd_wsl]
   Unit_hipHostRegister_AsyncApis:
     <<: *level_2
     tags: [alloc]
@@ -511,7 +511,7 @@ memory:
   Unit_hipMemset3DAsync_capturehipMemset3DAsync:
     <<: *level_2
     # Below tests are failing PSDB
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [memset]
   Unit_hipMemset3D_Capture: *level_2
   Unit_hipMemset2D_BasicFunctional:
@@ -526,7 +526,7 @@ memory:
   Unit_hipMemset2DAsync_capturehipMemset2DAsync:
     <<: *level_2
     # Below tests are failing PSDB
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [memset]
   Unit_hipMemset2D_Capture: *level_2
   Unit_hipHostMalloc_ArgValidation:
@@ -802,7 +802,7 @@ memory:
   Unit_hipMemcpy3DPeerAsync_BasicFunctional:
     <<: *level_2
     # Rock_Linux_Failures_on_gfx94X
-    disabled: [amd_linux]
+    disabled: [amd_linux, amd_wsl]
     tags: [multigpu, transfer, image]
   Unit_hipMemcpy3DPeerAsync_NegativeTsts:
     <<: *level_2
@@ -978,7 +978,7 @@ memory:
   Unit_hipPointerSetAttribute_Positive_SyncMemops:
     <<: *level_2
     # Below test is disabled due to defect EXSWHTEC-347
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [query]
   Unit_hipPointerSetAttribute_Negative_Parameters:
     <<: *level_2
@@ -1047,14 +1047,14 @@ memory:
   Unit_hipMemPoolSetGetAccess_Positive_MultipleGPU:
     <<: *level_2
     tags: [alloc, multigpu]
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_hipMemPoolSetGetAccess_Positive_P2P:
     <<: *level_2
     tags: [alloc, multigpu]
   Unit_hipMemPoolSetAccess_Negative_Parameters:
     <<: *level_2
     # SWDEV-435667: Below tests failing randomly in stress test on 08/12/23
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [alloc]
   Unit_hipMemPoolSetAccess_SetAccess:
     <<: *level_2
@@ -1065,7 +1065,7 @@ memory:
   Unit_hipMemPoolGetAccess_Negative_Parameters:
     <<: *level_2
     # Below tests are failing PSDB
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [alloc]
   Unit_hipMemPoolGetAccess_SetGet:
     <<: *level_2
@@ -1085,12 +1085,12 @@ memory:
   Unit_hipMemPoolSetAttribute_EventDependencies:
     <<: *level_2
     # mlsejenkins_Window_Failures_on_gfx1201
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [alloc]
   Unit_hipMemPoolSetAttribute_Negative_Parameters:
     <<: *level_2
     # Below tests are failing PSDB
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [alloc]
   Unit_hipMemPoolSetAttribute_ResetMemHighAttr:
     <<: *level_2
@@ -1098,7 +1098,7 @@ memory:
   Unit_hipMemPoolGetAttribute_Negative_Parameters:
     <<: *level_2
     # Below tests are failing PSDB
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [alloc]
   Unit_hipMemPoolGetAttribute_SetGet:
     <<: *level_2
@@ -1150,7 +1150,7 @@ memory:
     tags: [alloc, multigpu]
   Unit_hipMemPoolTrimTo_Multithreaded:
     <<: *level_2
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [alloc]
   Unit_hipMallocFromPoolAsync_Basic_OneAlloc:
     <<: *level_2
@@ -1187,11 +1187,11 @@ memory:
     tags: [alloc]
   Unit_hipMallocFromPoolAsync_MThread_MaxThresh:
     <<: *level_2
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [alloc]
   Unit_hipMallocFromPoolAsync_MThread_CommonMpool_DefaultMempool:
     <<: *level_2
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [alloc]
   Unit_hipMallocFromPoolAsync_MThread_CommonMpool_MaxThresh:
     <<: *level_2
@@ -1503,7 +1503,7 @@ memory:
   Unit_hipMalloc_Allocate90PercentOfDeviceMemory:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [alloc]
   Unit_hipMalloc_Allocate110PercentOfDeviceMemory: *level_2
   Unit_hipMalloc_AllocateAvailableVRAMAndPossibleRAM: *level_2
@@ -1767,7 +1767,7 @@ memory:
     tags: [query]
   Unit_hipMemPrefetchBatchAsync_LocationDistribution:
     <<: *level_2
-    disabled: [amd_windows, amd_linux]
+    disabled: [amd_windows, amd_linux, amd_wsl]
     tags: [query]
   Unit_hipMemPrefetchBatchAsync_RoundTripDataIntegrity:
     <<: *level_2
@@ -1912,7 +1912,7 @@ memory:
   Unit_hipMemAdvise_TstAlignedAllocMem_XNACK:
     <<: *level_2
     # Rock_Linux_Failures_on_gfx94X
-    disabled: [amd_linux]
+    disabled: [amd_linux, amd_wsl]
     tags: [query]
   Unit_hipMemAdvise_ReadMosltyMgpuTst:
     <<: *level_2
@@ -1958,12 +1958,12 @@ memory:
   Unit_hipFreeAsync_Negative_Parameters:
     <<: *level_2
     # Below tests are failing PSDB
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [alloc]
   Unit_hipFreeAsync_capturehipFreeAsync:
     <<: *level_2
     # Rock_Linux_Failures_on_gfx94X
-    disabled: [amd_linux]
+    disabled: [amd_linux, amd_wsl]
     tags: [alloc]
   Unit_hipFreeHost_InvalidMemory:
     <<: *level_2
@@ -2052,13 +2052,13 @@ memory:
   Unit_hipMallocMipmappedArray_DiffSizes:
     <<: *level_2
     # Below tests are failing PSDB
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [alloc]
   Unit_hipMallocMipmappedArray_MultiThread:
     <<: *level_2
     tags: [alloc]
     # Below tests are failing PSDB
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_hipMallocMipmappedArray_happy: *level_2
   Unit_hipMallocMipmappedArray_Negative_NullArrayPtr:
     <<: *level_2
@@ -2075,7 +2075,7 @@ memory:
   Unit_hipMallocMipmappedArray_Negative_InvalidFlags:
     <<: *level_2
     # Below tests are failing PSDB
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [alloc]
   Unit_hipMallocMipmappedArray_Negative_InvalidFormat:
     <<: *level_2
@@ -2112,7 +2112,7 @@ memory:
   Unit_hipGetMipmappedArrayLevel_Negative:
     <<: *level_2
     # Below tests are failing PSDB
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [alloc]
   Unit_hipFreeMipmappedArrayImplicitSyncArray: *level_2
   Unit_hipFreeMipmappedArray_Negative_Nullptr:
@@ -2121,7 +2121,7 @@ memory:
   Unit_hipFreeMipmappedArrayMultiTArray:
     <<: *level_2
     # Below tests are failing PSDB
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_hipMallocArray_DiffSizes:
     <<: *level_2
     tags: [alloc, image]
@@ -2191,27 +2191,27 @@ memory:
   Unit_hipHostAlloc_Basic:
     <<: *level_2
     # SWDEV-468258 Below tests are temporarily disabled - windows PSDB failed
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [alloc]
   Unit_hipHostAlloc_Default:
     <<: *level_2
     # SWDEV-468258 Below tests are temporarily disabled - windows PSDB failed
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [alloc]
   Unit_hipHostAlloc_Negative_NonCoherent:
     <<: *level_2
     # SWDEV-468258 Below tests are temporarily disabled - windows PSDB failed
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [alloc]
   Unit_hipHostAlloc_Negative_Coherent:
     <<: *level_2
     # SWDEV-468258 Below tests are temporarily disabled - windows PSDB failed
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [alloc]
   Unit_hipHostAlloc_Negative_NumaUser:
     <<: *level_2
     # SWDEV-468258 Below tests are temporarily disabled - windows PSDB failed
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [alloc]
   Unit_hipHostAlloc_ArgValidation:
     <<: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/memory.yaml
@@ -46,47 +46,57 @@ memory:
     tags: [multigpu, transfer, image]
   Unit_hipMemcpy3D_Positive_Basic:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipMemcpy3D_Positive_Synchronization_Behavior:
     <<: *level_2
     # Below tests tests fail in PSDB
-    disabled: [nvidia_windows]
+    disabled: [nvidia_windows, amd_wsl]
     tags: [transfer]
   Unit_hipMemcpy3D_Positive_DeviceToDevice_Synchronization_Behavior:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipMemcpy3D_Positive_Parameters:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipMemcpy3D_Positive_Array:
     <<: *level_2
     tags: [transfer, image]
   Unit_hipMemcpy3D_Negative_Parameters:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipMemcpy3D_Capture:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipMemcpy3D_multiDevice_Negative:
     <<: *level_2
     tags: [multigpu, image]
   Unit_hipMemcpy3DAsync_Positive_Basic:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipMemcpy3DAsync_Positive_Synchronization_Behavior:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipMemcpy3DAsync_Positive_Parameters:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipMemcpy3DAsync_Positive_Array:
     <<: *level_2
     tags: [transfer, image]
   Unit_hipMemcpy3DAsync_Negative_Parameters:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipMemcpy3DAsync_Capture:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipMemcpy3DAsync_multiDevice_Negative:
     <<: *level_2
@@ -96,61 +106,74 @@ memory:
     tags: [multigpu, image]
   Unit_hipMemcpyParam2D_Positive_Basic:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipMemcpyParam2D_Positive_Synchronization_Behavior:
     <<: *level_2
     # Below tests tests fail in PSDB
-    disabled: [nvidia_windows]
+    disabled: [nvidia_windows, amd_wsl]
     tags: [transfer]
   Unit_hipMemcpyParam2D_Positive_Parameters:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipMemcpyParam2D_Positive_Array:
     <<: *level_2
     tags: [transfer, image]
   Unit_hipMemcpyParam2D_Negative_Parameters:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipMemcpyParam2D_Capture:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipMemcpyParam2DAsync_Positive_Basic:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipMemcpyParam2DAsync_Positive_Synchronization_Behavior:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipMemcpyParam2DAsync_Positive_Parameters:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipMemcpyParam2DAsync_Positive_Array:
     <<: *level_2
     tags: [transfer, image]
   Unit_hipMemcpyParam2DAsync_Negative_Parameters:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipMemcpyParam2DAsync_Capture:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipMemcpyParam2DAsync_multiDevice_StreamOnDiffDevice:
     <<: *level_2
     tags: [multigpu, transfer]
   Unit_hipMemcpy2D_Positive_Basic:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipMemcpy2D_Positive_Synchronization_Behavior:
     <<: *level_2
     # Below tests tests fail in PSDB
-    disabled: [nvidia_windows]
+    disabled: [nvidia_windows, amd_wsl]
     tags: [transfer]
   Unit_hipMemcpy2D_Positive_Parameters:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipMemcpy2D_Negative_Parameters:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipMemcpy2D_Capture:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipMemcpy2D_H2D_D2D_D2H:
     <<: *level_2
@@ -169,17 +192,23 @@ memory:
     tags: [transfer]
   Unit_hipMemcpy2DAsync_Positive_Basic:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipMemcpy2DAsync_Positive_Synchronization_Behavior:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipMemcpy2DAsync_Positive_Parameters:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipMemcpy2DAsync_Negative_Parameters:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [transfer]
-  Unit_hipMemcpy2DAsync_Capture: *level_2
+  Unit_hipMemcpy2DAsync_Capture:
+    <<: *level_2
+    disabled: [amd_wsl]
   Unit_hipMemcpy2DAsync_Host_N_PinnedMem:
     <<: *level_2
     # Below tests are failing PSDB
@@ -469,24 +498,30 @@ memory:
     tags: [memset]
   Unit_hipMemset2D_Negative_InvalidPtr:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemset2D_Negative_InvalidSizes:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemset2D_Negative_OutOfBoundsPtr:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemset3D_Negative_InvalidPtr:
     <<: *level_2
     tags: [memset]
   Unit_hipMemset3D_Negative_ModifiedPtr:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemset3D_Negative_InvalidSizes:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemset3D_Negative_OutOfBounds:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemset_SetMemoryWithOffset:
     <<: *level_2
@@ -504,66 +539,86 @@ memory:
   Unit_hipMemsetD8_Capture: *level_2
   Unit_hipMemset3D_BasicFunctional:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemset3DAsync_BasicFunctional:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemset3DAsync_capturehipMemset3DAsync:
     <<: *level_2
     # Below tests are failing PSDB
     disabled: [amd_windows, amd_wsl]
     tags: [memset]
-  Unit_hipMemset3D_Capture: *level_2
+  Unit_hipMemset3D_Capture:
+    <<: *level_2
+    disabled: [amd_wsl]
   Unit_hipMemset2D_BasicFunctional:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemset2DAsync_BasicFunctional:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemset2D_UniqueWidthHeight:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemset2DAsync_capturehipMemset2DAsync:
     <<: *level_2
     # Below tests are failing PSDB
     disabled: [amd_windows, amd_wsl]
     tags: [memset]
-  Unit_hipMemset2D_Capture: *level_2
+  Unit_hipMemset2D_Capture:
+    <<: *level_2
+    disabled: [amd_wsl]
   Unit_hipHostMalloc_ArgValidation:
     <<: *level_2
     tags: [alloc]
   Unit_hipMemset3D_MemsetWithExtent:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemset3DAsync_MemsetWithExtent:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemset3D_MemsetMaxValue:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemset3DAsync_MemsetMaxValue:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemset3D_SeekSetSlice:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemset3DAsync_SeekSetSlice:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemset3D_SeekSetArrayPortion:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemset3DAsync_SeekSetArrayPortion:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemset3D_RegressInLoop:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemset3DAsync_RegressInLoop:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemset3DAsync_ConcurrencyMthread:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMallocManaged_FlgParam:
     <<: *level_2
@@ -741,57 +796,75 @@ memory:
     tags: [transfer]
   Unit_hipMemsetD2D8_BasicFunctional:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemsetD2D8_UnEvenRowsCols:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemsetD2D8_NegTsts:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemsetD2D8Async_BasicFunctional:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemsetD2D8Async_UnEvenRowsCols:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemsetD2D8Async_NegTsts:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemsetD2D16_BasicFunctional:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemsetD2D16_UnEvenRowsCols:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemsetD2D16_NegTsts:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemsetD2D16Async_BasicFunctional:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemsetD2D16Async_UnEvenRowsCols:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemsetD2D16Async_NegTsts:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemsetD2D32_BasicFunctional:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemsetD2D32_UnEvenRowsCols:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemsetD2D32_NegTsts:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemsetD2D32Async_BasicFunctional:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemsetD2D32Async_UnEvenRowsCols:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemsetD2D32Async_NegTsts:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemcpy3DPeer_BasicFunctional:
     <<: *level_2
@@ -932,7 +1005,9 @@ memory:
   Unit_hipMemcpyDeviceToDeviceNoCU_Memcpy_Kernel_InParallel:
     <<: *level_2
     tags: [transfer]
-  Unit_hipGetProcAddress_MemoryApisMallocFree: *level_2
+  Unit_hipGetProcAddress_MemoryApisMallocFree:
+    <<: *level_2
+    disabled: [amd_wsl]
   Unit_hipGetProcAddress_MemoryApisRegisterUnReg: *level_2
   Unit_hipGetProcAddress_MemoryApisArrayRelated:
     <<: *level_2
@@ -941,13 +1016,19 @@ memory:
   Unit_hipGetProcAddress_MemoryApisMemCopy: *level_2
   Unit_hipGetProcAddress_MemoryApisMemCopyWithStreams: *level_2
   Unit_hipGetProcAddress_MemoryApisMemset: *level_2
-  Unit_hipGetProcAddress_MemoryApisMemset2D3D: *level_2
+  Unit_hipGetProcAddress_MemoryApisMemset2D3D:
+    <<: *level_2
+    disabled: [amd_wsl]
   Unit_hipGetProcAddress_MemoryApisGetMemInfoRelated: *level_2
-  Unit_hipGetProcAddress_MemoryApisMemcpy2DRelated: *level_2
+  Unit_hipGetProcAddress_MemoryApisMemcpy2DRelated:
+    <<: *level_2
+    disabled: [amd_wsl]
   Unit_hipGetProcAddress_MemoryApisMemcpy2DRelated_Array:
     <<: *level_2
     tags: [image]
-  Unit_hipGetProcAddress_MemoryApisMemcpy3DRelated: *level_2
+  Unit_hipGetProcAddress_MemoryApisMemcpy3DRelated:
+    <<: *level_2
+    disabled: [amd_wsl]
   Unit_hipGetProcAddress_MemoryApisAddressRelated: *level_2
   Unit_hipGetProcAddress_MemoryApisManagedMemory: *level_2
   Unit_hipGetProcAddress_MemoryApisStreamOrderedMemory: *level_2
@@ -1294,9 +1375,11 @@ memory:
     tags: [memset]
   Unit_hipMemset2DAsync_WithKernel:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemset2DAsync_MultiThread:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemcpyDtoD_Basic:
     <<: *level_2
@@ -1466,27 +1549,35 @@ memory:
     tags: [memset]
   Unit_hipMemsetFunctional_ZeroValue_2D:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemsetFunctional_SmallSize_2D:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemsetFunctional_ZeroSize_2D:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemsetFunctional_PartialSet_2D:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemsetFunctional_ZeroValue_3D:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemsetFunctional_SmallSize_3D:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemsetFunctional_ZeroSize_3D:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMemsetFunctional_PartialSet_3D:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [memset]
   Unit_hipMalloc_Positive_Basic:
     <<: *level_2
@@ -1521,6 +1612,7 @@ memory:
     tags: [alloc]
   Unit_hipMallocPitch_ValidatePitch:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [alloc]
   Unit_hipMalloc3D_Negative:
     <<: *level_2
@@ -1538,23 +1630,33 @@ memory:
     tags: [alloc]
   Unit_hipMallocPitch_Basic:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [alloc]
   Unit_hipMallocPitch_SmallandBigChunks:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [alloc]
-  Unit_hipMallocPitch_Memcpy2D: *level_2
+  Unit_hipMallocPitch_Memcpy2D:
+    <<: *level_2
+    disabled: [amd_wsl]
   Unit_hipMallocPitch_MultiThread:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [alloc]
-  Unit_hipMallocPitch_KernelLaunch: *level_2
+  Unit_hipMallocPitch_KernelLaunch:
+    <<: *level_2
+    disabled: [amd_wsl]
   Unit_hipMalloc3D_Basic:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [alloc]
   Unit_hipMalloc3D_SmallandBigChunks:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [alloc]
   Unit_hipMalloc3D_MultiThread:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [alloc]
   Unit_hipMalloc3DArray_DiffSizes:
     <<: *level_2
@@ -1647,14 +1749,16 @@ memory:
     tags: [image]
   Unit_hipDrvMemcpy3D_Positive_Basic:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipDrvMemcpy3D_Positive_Synchronization_Behavior:
     <<: *level_2
     # Below tests tests fail in PSDB
-    disabled: [nvidia_windows]
+    disabled: [nvidia_windows, amd_wsl]
     tags: [transfer]
   Unit_hipDrvMemcpy3D_Positive_Parameters:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipDrvMemcpy3D_Positive_Array:
     <<: *level_2
@@ -1663,9 +1767,11 @@ memory:
     tags: [transfer, image]
   Unit_hipDrvMemcpy3D_Negative_Parameters:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipDrvMemcpy3D_Capture:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipDrvMemcpy3D_MultipleDataTypes:
     <<: *level_2
@@ -1690,12 +1796,15 @@ memory:
     tags: [transfer, image]
   Unit_hipDrvMemcpy3DAsync_Positive_Basic:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipDrvMemcpy3DAsync_Positive_Synchronization_Behavior:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipDrvMemcpy3DAsync_Positive_Parameters:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipDrvMemcpy3DAsync_Positive_Array:
     <<: *level_2
@@ -1704,9 +1813,11 @@ memory:
     tags: [transfer, image]
   Unit_hipDrvMemcpy3DAsync_Negative_Parameters:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipDrvMemcpy3DAsync_Capture:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [transfer]
   Unit_hipDrvMemcpy3DAsync_H2DDeviceContextChange:
     <<: *level_2
@@ -1740,6 +1851,7 @@ memory:
     tags: [query]
   Unit_hipPointerGetAttribute_ipc_capable:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [query]
   Unit_hipPointerGetAttribute_ipc_capable_Array:
     <<: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/module.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/module.yaml
@@ -3,17 +3,17 @@ module:
   Unit_hipModuleLaunchCooperativeKernel_Positive_Basic:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [launch]
   Unit_hipModuleLaunchCooperativeKernel_Positive_Parameters:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [launch]
   Unit_hipModuleLaunchCooperativeKernel_Negative_Parameters:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [launch]
   Unit_hipModuleLaunchCooperativeKernel_Verify_Capture:
     <<: *level_2
@@ -21,17 +21,17 @@ module:
   Unit_hipModuleLaunchKernel_Positive_Basic:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [launch]
   Unit_hipModuleLaunchKernel_Positive_Parameters:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [launch]
   Unit_hipModuleLaunchKernel_Negative_Parameters:
     <<: *level_2
     # Below tests are failing PSDB
-    disabled: [amd_windows, amd_linux]
+    disabled: [amd_windows, amd_linux, amd_wsl]
     tags: [launch]
   Unit_hipModuleLaunchKernel_Fntl:
     <<: *level_2
@@ -39,7 +39,7 @@ module:
   Unit_hipModuleLaunchKernel_Verify_Capture:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [launch]
   Unit_hipExtLaunchKernelGGL_Functional:
     <<: *level_2
@@ -125,7 +125,7 @@ module:
   Unit_hipDrvLaunchKernelEx_With_CooperativeKernelWithArgs:
     <<: *level_2
     # Rock_Linux_Failures_on_gfx94X
-    disabled: [amd_linux]
+    disabled: [amd_linux, amd_wsl]
     tags: [launch]
   Unit_hipDrvLaunchKernelEx_With_MaxBlockDims:
     <<: *level_2
@@ -165,7 +165,7 @@ module:
   Unit_hipModuleUnload_Negative_Module_Is_Nullptr:
     <<: *level_2
     # Note: Test disabled due to defect - EXSWHTEC-152
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [load]
   Unit_hipModuleUnload_Negative_Double_Unload:
     <<: *level_2
@@ -179,7 +179,7 @@ module:
     <<: *level_2
     # (amd_linux) Rock_Linux_Failures_on_gfx94X
     # (amd_windows) Rock_Window_Failures_on_gfx1151
-    disabled: [amd_linux, amd_windows]
+    disabled: [amd_linux, amd_windows, amd_wsl]
     tags: [function]
   Unit_hipModuleGetFunctionCount_NegativeTsts:
     <<: *level_2
@@ -193,7 +193,7 @@ module:
   Unit_hip_linker_spirv_input:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [resource]
   Unit_hipLinkCreate_Negative:
     <<: *level_2
@@ -207,18 +207,18 @@ module:
   Unit_hipModuleLaunchCooperativeKernelMultiDevice_Positive_Basic:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [launch]
   Unit_hipModuleLaunchCooperativeKernelMultiDevice_Negative_Parameters:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [launch]
   Unit_hipModuleLaunchCooperativeKernelMultiDevice_Negative_MultiKernelSameDevice:
     <<: *level_2
     tags: [multigpu]
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_hipModuleGetGlobal_Positive_Basic:
     <<: *level_2
     tags: [resource]
@@ -231,17 +231,17 @@ module:
   Unit_hipModuleGetGlobal_Negative_Hmod_Is_Nullptr:
     <<: *level_2
     # Note: Test disabled due to defect - EXSWHTEC-163
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [resource]
   Unit_hipModuleGetGlobal_Negative_Name_Is_Empty_String:
     <<: *level_2
     # Note: Test disabled due to defect - EXSWHTEC-164
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [resource]
   Unit_hipModuleGetGlobal_Negative_Dptr_And_Bytes_Are_Nullptr:
     <<: *level_2
     # Note: Test disabled due to defect - EXSWHTEC-165
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [resource]
   Unit_hipModuleGetGlobal_DiffDevice:
     <<: *level_2
@@ -253,22 +253,22 @@ module:
     <<: *level_2
     # (amd_windows) Below tests are failing PSDB
     # (nvidia_windows) Disabling tests which no longer behave the same on nvidia platform
-    disabled: [amd_windows, nvidia_windows]
+    disabled: [amd_windows, nvidia_windows, amd_wsl]
     tags: [resource, image]
   Unit_hipModuleGetTexRef_Negative_Parameters:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [resource, image]
   Unit_hipModuleGetTexRef_Negative_Hmod_Is_Nullptr:
     <<: *level_2
     # Note: Test disabled due to defect - EXSWHTEC-166
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [resource, image]
   Unit_hipModuleGetTexRef_Negative_Name_Is_Empty_String:
     <<: *level_2
     # Note: Test disabled due to defect - EXSWHTEC-167
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [resource, image]
   Unit_hipFuncSetAttribute_Basic:
     <<: *level_2
@@ -287,12 +287,12 @@ module:
   Unit_hipExtModuleLaunchKernel_Positive_Parameters:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [launch]
   Unit_hipExtModuleLaunchKernel_Negative_Parameters:
     <<: *level_2
     # Below tests are failing PSDB
-    disabled: [amd_windows, amd_linux]
+    disabled: [amd_windows, amd_linux, amd_wsl]
     tags: [launch]
   Unit_hipExtModuleLaunchKernel_Functional:
     <<: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/multiThread.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/multiThread.yaml
@@ -9,7 +9,7 @@ multiThread:
   Unit_hipMultiThreadDevice_SerialPyramid:
     <<: *level_2
     # Rock_Linux_Failures_on_gfx94X
-    disabled: [amd_linux]
+    disabled: [amd_linux, amd_wsl]
     tags: [device_mgmt]
   Unit_hipMultiThreadDevice_ParallelPyramid:
     <<: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/occupancy.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/occupancy.yaml
@@ -52,7 +52,7 @@ occupancy:
   Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_Functional:
     <<: *level_2
     # Below tests are failing PSDB
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_hipOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_ValidArgs: *level_2
   Unit_hipOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_InvalidArgs: *level_2
   Unit_hipOccupancyAvailableDynamicSMemPerBlock_Negative: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/printf.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/printf.yaml
@@ -3,11 +3,11 @@ printf:
   Unit_Printf_flags_Sanity_Positive:
     <<: *level_2
     # Below test fails in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/274
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Printf_length_Sanity_Positive:
     <<: *level_2
     # Below test fails in external CI for PR https://github.com/ROCm-Developer-Tools/hip-tests/pull/274
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_Printf_specifier_Sanity_Positive: *level_2
   Unit_Printf_Negative_Parameters_RTC: *level_2
   Unit_Buffered_Printf_Flags: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/rtc.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/rtc.yaml
@@ -42,7 +42,7 @@ rtc:
   Unit_RTC_LinkDestroy_Default:
     <<: *level_2
     # SWDEV-450909: Test failed in stress testing
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [link]
   Unit_RTC_LinkerAPI:
     <<: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/stream.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/stream.yaml
@@ -58,7 +58,7 @@ stream:
     <<: *level_2
     tags: [memory]
     # disabled due to flaky segfault in CI nightly https://github.com/ROCm/TheRock/issues/4111
-    disabled: [amd_linux]
+    disabled: [amd_linux, amd_wsl]
   Unit_hipStreamCreateWithFlags_Negative_NullStream:
     <<: *level_2
     tags: [lifecycle]
@@ -205,7 +205,7 @@ stream:
   Unit_hipLaunchHostFunc_streams:
     <<: *level_2
     # Rock_Linux_Failures_on_gfx94X
-    disabled: [amd_linux]
+    disabled: [amd_linux, amd_wsl]
     tags: [callback]
   Unit_hipLaunchHostFunc_multistreams:
     <<: *level_2
@@ -328,7 +328,7 @@ stream:
   Unit_hipExtStreamCreateWithCUMask_NegTst:
     <<: *level_2
     # Rock_Linux_Failures_on_gfx94X
-    disabled: [amd_linux]
+    disabled: [amd_linux, amd_wsl]
     tags: [properties]
   Unit_hipStreamAddCallback_MultipleThreads:
     <<: *level_2
@@ -368,17 +368,17 @@ stream:
   Unit_hipStreamQuery_spt_WithFinishedWork:
     <<: *level_2
     # Following tests disabled due to SWDEV-486363
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [synchronization, streamperthread]
   Unit_hipStreamQuery_spt_NegativeCases:
     <<: *level_2
     # Following tests disabled due to SWDEV-486363
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [synchronization, streamperthread]
   Unit_hipStreamQuery_spt_WithPendingWork:
     <<: *level_2
     # Following tests disabled due to SWDEV-486363
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [synchronization, streamperthread]
   Unit_hipStreamSynchronize_spt_EmptyStream:
     <<: *level_2
@@ -386,12 +386,12 @@ stream:
   Unit_hipStreamSynchronize_spt_FinishWork:
     <<: *level_2
     # Following tests disabled due to SWDEV-486363
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [synchronization, streamperthread]
   Unit_hipStreamSynchronize_spt_SynchronizeStreamAndQueryNullStream:
     <<: *level_2
     # Following tests disabled due to SWDEV-486363
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [synchronization, streamperthread]
   Unit_hipStreamBatchMemOp_Negative_Tests:
     <<: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/streamperthread.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/streamperthread.yaml
@@ -75,12 +75,14 @@ streamperthread:
     tags: [stream]
   Unit_hipGetProcAddress_spt_Memset2D3D:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [stream]
   Unit_hipGetProcAddress_spt_Memcpy2D:
     <<: *level_2
     tags: [stream, image]
   Unit_hipGetProcAddress_spt_Memcpy3D:
     <<: *level_2
+    disabled: [amd_wsl]
     tags: [stream]
   Unit_hipGetProcAddress_spt_LaunchKernel:
     <<: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/syncthreads.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/syncthreads.yaml
@@ -3,12 +3,12 @@ syncthreads:
   Unit___syncthreads_Positive_Basic:
     <<: *level_2
     # Below tests are failing PSDB
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [block, deviceLib, synchronization]
   Unit___syncthreads_count_Positive_Basic:
     <<: *level_2
     # Below tests are failing PSDB
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [block, deviceLib, synchronization]
   Unit___syncthreads_count_Positive_Predicate_Zero:
     <<: *level_2
@@ -31,7 +31,7 @@ syncthreads:
   Unit___syncthreads_and_Positive_Basic:
     <<: *level_2
     # Below tests are failing PSDB
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [block, deviceLib, synchronization]
   Unit___syncthreads_and_Positive_Predicate_Zero:
     <<: *level_2
@@ -54,7 +54,7 @@ syncthreads:
   Unit___syncthreads_or_Positive_Basic:
     <<: *level_2
     # Below tests are failing PSDB
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [block, deviceLib, synchronization]
   Unit___syncthreads_or_Positive_Predicate_Zero:
     <<: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/texture.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/texture.yaml
@@ -94,27 +94,27 @@ texture:
   Unit_hipTexRefSetArray_Positive:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [texref, image]
   Unit_hipTexRefSetArray_CheckData:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [texref, image]
   Unit_hipTexRefSetArray_Negative:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [texref, image]
   Unit_hipTexRefGetArray_Positive:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [texref, image]
   Unit_hipTexRefGetArray_Negative:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [texref, image]
   Unit_hipTexRefGetBorderColor_Positive:
     <<: *level_2
@@ -122,7 +122,7 @@ texture:
   Unit_hipTexRefGetBorderColor_Negative:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [texref, image]
   Unit_hipTexRefSetBorderColor_Positive:
     <<: *level_2
@@ -130,62 +130,62 @@ texture:
   Unit_hipTexRefSetBorderColor_Negative:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [texref, image]
   Unit_hipTexRefGetAddress_Positive:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [texref, image]
   Unit_hipTexRefGetAddress_Negative:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [texref, image]
   Unit_hipTexRefGetAddress_AdressNotSet:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [texref, image]
   Unit_hipTexRefSetAddress_Basic:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [texref, image]
   Unit_hipTexRefSetAddress_Positive:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [texref, image]
   Unit_hipTexRefSetAddress_Negative:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [texref, image]
   Unit_hipTexRefGetFormat_Basic:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [texref, image]
   Unit_hipTexRefGetFormat_Positive:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [texref, image]
   Unit_hipTexRefGetFormat_Negative:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [texref, image]
   Unit_hipTexRefSetFormat_Positive:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [texref, image]
   Unit_hipTexRefSetFormat_Negative:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [texref, image]
   Unit_hipCreateTextureObject_tex1DfetchVerification:
     <<: *level_2
@@ -295,32 +295,32 @@ texture:
   Unit_hipTexRefSetAddress2D_Negative_Parameters:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [texref, image]
   Unit_hipTexRefSetAddress2D_Positive:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [texref, image]
   Unit_hipTexRefSetMaxAnisotropy_Negative_Parameters:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [texref, image]
   Unit_hipTexRefSetMaxAnisotropy_Positive:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [texref, image]
   Unit_hipTexRefGetMaxAnisotropy_Negative_Parameters:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [texref, image]
   Unit_hipTexRefGetMaxAnisotropy_Positive:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [texref, image]
   Unit_hipUnbindTexture_Null_Texture:
     <<: *level_2
@@ -337,12 +337,12 @@ texture:
   Unit_hipTexRefSetFlags_Negative_Parameters:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [texref, image]
   Unit_hipTexRefSetFlags_Positive:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [texref, image]
   Unit_hipBindTextureToArray_Negative_Parameters:
     <<: *level_2
@@ -359,32 +359,32 @@ texture:
   Unit_hipTexRefGetFlags_Negative_Parameters:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [texref, image]
   Unit_hipTexRefGetFlags_Positive:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [texref, image]
   Unit_hipTexRefSetAddressMode_Negative_Parameters:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [texref, image]
   Unit_hipTexRefSetAddressMode_Positive:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [texref, image]
   Unit_hipTexRefGetAddressMode_Negative_Parameters:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [texref, image]
   Unit_hipTexRefGetAddressMode_Positive:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
     tags: [texref, image]
   Unit_hipTexRefSetGetFilterMode:
     <<: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/virtualMemoryManagement.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/virtualMemoryManagement.yaml
@@ -167,10 +167,10 @@ virtualMemoryManagement:
   Unit_hipMemSetAccessHostDevice_hostalloc:
     <<: *level_2
     # SWDEV-555665
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_hipMemSetAccessHost_devicealloc:
     <<: *level_2
-    disabled: [amd_windows]
+    disabled: [amd_windows, amd_wsl]
   Unit_hipMemGetAllocationPropertiesFromHandle_functional:
     <<: *level_2
     # Patch which removes the typetraits implementation from std namespace in hiprtc is reverted


### PR DESCRIPTION
## Motivation

Disable some hip-test cases on amd_wsl.

## Technical Details

Disabling cases on amd_wsl includes two categories:

1. Cases that have already been disabled on amd_windows and amd_linux, which are now also disabled on amd_wsl for consistency.
2. Cases related to image_support, as image support is not available on amd_wsl.

## Test Result

These cases can be successfully disabled in the amd_wsl environment.
