### PR TITLE
Use kernel's wave front size for kernel queries.

### DIFF
--- a/projects/clr/opencl/amdocl/cl_program.cpp
+++ b/projects/clr/opencl/amdocl/cl_program.cpp
@@ -1952,7 +1952,9 @@ RUNTIME_ENTRY(cl_int, clGetKernelSubGroupInfo,
       }
 
       // Get the subgroup size. GPU devices sub-groups are wavefronts.
-      size_t subGroupSize = as_amd(device)->info().wavefrontWidth_;
+      // Use the kernel's wavefront size — it can differ from the device's
+      // native width when the kernel is built with -mwavefrontsize32/64.
+      size_t subGroupSize = devKernel->workGroupInfo()->wavefrontSize_;
 
       size_t numSubGroups = (workGroupSize + subGroupSize - 1) / subGroupSize;
 
@@ -1967,7 +1969,7 @@ RUNTIME_ENTRY(cl_int, clGetKernelSubGroupInfo,
       return amd::clGetInfo(numSubGroups, param_value_size, param_value, param_value_size_ret);
     }
     case CL_KERNEL_MAX_NUM_SUB_GROUPS: {
-      size_t waveSize = as_amd(device)->info().wavefrontWidth_;
+      size_t waveSize = devKernel->workGroupInfo()->wavefrontSize_;
       size_t numSubGroups = (devKernel->workGroupInfo()->size_ + waveSize - 1) / waveSize;
       return amd::clGetInfo(numSubGroups, param_value_size, param_value, param_value_size_ret);
     }
@@ -1985,7 +1987,7 @@ RUNTIME_ENTRY(cl_int, clGetKernelSubGroupInfo,
       *not_null(param_value_size_ret) = param_value_size;
 
       size_t localSize;
-      localSize = numSubGroups * as_amd(device)->info().wavefrontWidth_;
+      localSize = numSubGroups * devKernel->workGroupInfo()->wavefrontSize_;
       if (localSize > devKernel->workGroupInfo()->size_) {
         ::memset(param_value, '\0', dims * sizeof(size_t));
         return CL_SUCCESS;


### PR DESCRIPTION
## Motivation

clGetKernelSubGroupInfo on AMD OpenCL was reading the device's native wavefront width to answer kernel-object queries. On GFX10+ (RDNA), a kernel built with -mwavefrontsize64 (e.g. via GPU_ENABLE_WAVE32_MODE=0) has a wave size that differs from the device's HSA-reported native width (32 on Navi). As a result, the four CL_KERNEL_* subgroup queries returned values inconsistent with how the kernel actually runs, breaking apps and frameworks that pick local sizes / subgroup counts based on these queries.   
Per the OpenCL 2.x spec, these are kernel-object queries, not device queries, so the per-kernel wave size must be used.  

## Technical Details

projects/clr/opencl/amdocl/cl_program.cpp — clGetKernelSubGroupInfo updated to read devKernel->workGroupInfo()->wavefrontSize_ (populated from the kernel's own AMDGPU metadata in devkernel.cpp:311, :555) instead of                                     
  as_amd(device)->info().wavefrontWidth_. Affects four param_name branches:
                                                                                                                                                                                                                                                             
  - CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE                                                                                                                                                                                                                 
  - CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE
  - CL_KERNEL_MAX_NUM_SUB_GROUPS                                                                                                                                                                                                                             
  - CL_KERNEL_LOCAL_SIZE_FOR_SUB_GROUP_COUNT                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                             
The HIP path (hipamd/src/hip_platform.cpp) already reads from the kernel object and is unaffected. The warpSize field on hipDeviceProp_t (a device-level property by API contract) intentionally continues to read from device info. 

## JIRA ID

https://github.com/ROCm/rocm-systems/issues/4445

## Test Plan

Manual reproducer (full source available on request) — a small OCL program that builds a trivial kernel and prints all four affected queries for an lws of 256 with target_count=4. Run twice on RDNA hardware to force kernel/device wave-size divergence:
                                                                                                                                                                                                                                                             
  # Pass A — default (wave32 kernel on Navi)                                                                                                                                                                                                                 
  OCL_ICD_VENDORS=$HOME/icd-patched ./test_subgroup_info                                                                                                                                                                                                     
                                                                                                                                                                                                                                                             
  # Pass B — wave64 kernel on Navi (device still reports native=32)                                                                                                                                                                                          
  GPU_ENABLE_WAVE32_MODE=0 OCL_ICD_VENDORS=$HOME/icd-patched ./test_subgroup_info                                                                                                                                                                            
                                                                                                                                                                                                                                                             
  The patched libamdocl64.so was deployed via a private ICD vendor directory (OCL_ICD_VENDORS). 

## Test Result

  Verified on gfx1201 (RDNA4). Native wavefrontWidth = 32.                                                                                                                                                                                                   
  
  Before fix (stock libs): both passes return identical, device-derived values — the bug:                                                                                                                                                                    
                                                            
  [Pass A — wave32 kernel] 32 / 8 / 8 / 128    ✓ correct (matches device)                                                                                                                                                                                    
  [Pass B — wave64 kernel] 32 / 8 / 8 / 128    ✗ WRONG (should be 64/4/4/256)                                                                                                                                                                                
                                                                                                                                                                                                                                                             
  After fix (patched libs): values reflect the kernel's actual wave size:                                                                                                                                                                                    
                                                                                                                                                                                                                                                             
  [Pass A — wave32 kernel] 32 / 8 / 8 / 128    ✓ unchanged (no regression)                                                                                                                                                                                   
  [Pass B — wave64 kernel] 64 / 4 / 4 / 256    ✓ FIXED                                                                                                                                                                                                       
                                                                                                                                                                                                                                                             
  Also smoke-tested on gfx942 (MI300X, wave64-only CDNA) — all four queries return 64 with both stock and patched libs (no regression on wave64-only parts).  

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
