### PR TITLE
[AIRUNTIME-2229] - Fix stream assignment and execution path

### DIFF
--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -313,8 +313,8 @@ hipError_t Graph::ScheduleNodesIntoBatches() {
     return hipSuccess;
   }
 
-  // Find execution paths hierarchically (new approach)
-  auto hierarchical_paths = FindExecutionPathsHierarchical();
+  // Find execution paths via topological traversal (handles fork-join correctly)
+  auto hierarchical_paths = FindExecutionPathsTopological();
   if (hierarchical_paths.paths.empty()) {
     // If we have nodes but no paths, this indicates an invalid graph (likely a cycle)
     ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
@@ -331,18 +331,19 @@ hipError_t Graph::ScheduleNodesIntoBatches() {
     return hipErrorInvalidValue;
   }
 
-  // Verify that every graph node was assigned to a segment. The iterative DFS
-  // in FindPathsDFS uses a shared mutable current_path across stack frames; for
-  // fork-join graphs this can silently drop event/wait nodes that carry cache-
-  // coherency ordering. Missing nodes are never dispatched as AQL packets, so
-  // the GPU sees stale memory and produces wrong results. Fall back to the
-  // classic scheduling path which handles fork-join graphs correctly.
+  // Safety net: verify that every graph node was assigned to a segment.
+  // FindExecutionPathsTopological() should guarantee full coverage via Kahn's
+  // BFS, but if a cycle or other anomaly causes nodes to be skipped, fall back
+  // to the classic scheduling path rather than silently producing wrong results.
   if (node_to_segment_id_.size() < static_cast<size_t>(GetNodeCount()) &&
       DEBUG_HIP_GRAPH_SEGMENT_SCHEDULING != 2) {
-    ClPrint(amd::LOG_INFO, amd::LOG_CODE,
-            "[hipGraph] Segment DFS missed %zu/%zu node(s) - falling back to classic path",
+    ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
+            "[hipGraph] Topological traversal missed %zu/%zu node(s) - "
+            "graph likely contains a cycle; falling back to classic path",
             static_cast<size_t>(GetNodeCount()) - node_to_segment_id_.size(),
             static_cast<size_t>(GetNodeCount()));
+    // hipErrorNotReady is used here as an internal sentinel: ScheduleNodes()
+    // catches it and falls back to the classic (non-segment) scheduling path.
     return hipErrorNotReady;
   }
 
@@ -672,181 +673,92 @@ void Graph::CalculateSegmentTopoDependencyLevels() {
 }
 
 // ================================================================================================
-hip::Graph::GraphExecutionPaths Graph::FindExecutionPathsHierarchical() {
+hip::Graph::GraphExecutionPaths Graph::FindExecutionPathsTopological() {
   hip::Graph::GraphExecutionPaths graph_paths;
   graph_paths.graph_ptr = this;
 
-  // Find all root nodes (nodes with no dependencies)
-  const auto& root_nodes = GetRootNodes();
-
-  std::unordered_set<unsigned int> visited;
-  for (const auto& root : root_nodes) {
-    // For each root, find all possible paths starting from it
-    std::vector<Node> current_path;
-    FindPathsDFS(root, current_path, visited, graph_paths);
-  }
-  return graph_paths;
-}
-
-// ================================================================================================
-void Graph::FindPathsDFS(Node start, std::vector<Node>& current_path,
-                         std::unordered_set<unsigned int>& visited,
-                         hip::Graph::GraphExecutionPaths& graph_paths) {
-  // Lambda to save current path as a HierarchicalPath
-  auto savePath = [&graph_paths](std::vector<Node> path, int device_id,
-                                  Node child_node = nullptr, int child_index = -1) {
+  // Helper: emit a non-empty accumulated segment into graph_paths.
+  auto flushSegment = [&](std::vector<Node>& seg) {
+    if (seg.empty()) return;
     hip::Graph::HierarchicalPath h_path;
-    h_path.nodes = std::move(path);
-    h_path.device_id = device_id;
-    h_path.child_graph_node = child_node;
-    h_path.child_graph_paths_index = child_index;
+    h_path.device_id = seg.front()->GetDeviceId();
+    h_path.nodes = std::move(seg);
     graph_paths.paths.push_back(std::move(h_path));
+    seg.clear();
   };
 
-  if (!start) return;
+  // Kahn's BFS topological traversal — identical structure to TopologicalOrder()
+  // but used here to assign nodes to segments.  Every node is visited exactly
+  // once, in an order where all predecessors have already been processed, so
+  // fork-join diamonds are handled correctly.
+  std::queue<Node> q;
+  std::unordered_map<Node, int> in_degree;
+  in_degree.reserve(vertices_.size());
+  for (auto* v : vertices_) {
+    in_degree[v] = static_cast<int>(v->GetDependencies().size());
+    if (in_degree[v] == 0) q.push(v);
+  }
 
-  // Stack of nodes to process.
-  std::vector<Node> st;
-  st.push_back(start);
+  std::vector<Node> current_seg;
 
-  while (!st.empty()) {
-    Node node = st.back();
-    st.pop_back();
-    if (!node) continue;
+  while (!q.empty()) {
+    Node node = q.front();
+    q.pop();
 
-    // Check if already visited
-    if (visited.find(node->GetID()) != visited.end()) {
-      // Save any remaining path (treat visited as a branch end)
-      if (!current_path.empty()) {
-        int dev = current_path.back()->GetDeviceId();
-        savePath(std::move(current_path), dev);
-        current_path.clear();
-      }
-      continue;
+    const auto& edges = node->GetEdges();
+    const auto& deps  = node->GetDependencies();
+
+    bool is_fork = edges.size() > 1;
+    bool is_join = deps.size() > 1;
+
+    // A device change always forces a segment boundary before this node.
+    bool device_changed = !current_seg.empty() &&
+                          current_seg.back()->GetDeviceId() != node->GetDeviceId();
+
+    if (device_changed || is_join) {
+      flushSegment(current_seg);
     }
 
-    // Mark regular nodes as visited
-    visited.insert(node->GetID());
-
-    // Check if device ID changed from previous node in path
-    bool device_changed = false;
-    int current_device_id = node->GetDeviceId();
-    if (!current_path.empty()) {
-      int prev_device_id = current_path.back()->GetDeviceId();
-      if (prev_device_id != current_device_id) {
-        device_changed = true;
-        // Save current path before device change
-        savePath(std::move(current_path), prev_device_id);
-        current_path.clear();
-      }
-    }
-
-    // Handle child graph nodes specially
+    // Child-graph nodes are always their own segment (they expand recursively).
     if (node->GetType() == hipGraphNodeTypeGraph) {
-      // Save path before child graph node (if any)
-      if (!current_path.empty()) {
-        int dev = current_path.back()->GetDeviceId();
-        savePath(std::move(current_path), dev);
-        current_path.clear();
-      }
+      flushSegment(current_seg);
 
-      // Get the child graph and recursively process it
-      auto childGraphNode = reinterpret_cast<hip::ChildGraphNode*>(node);
-      auto childGraph = childGraphNode->GetChildGraph();
+      auto* childGraphNode = reinterpret_cast<hip::ChildGraphNode*>(node);
+      auto* childGraph     = childGraphNode->GetChildGraph();
 
       if (childGraph != nullptr) {
-        // Create a new GraphExecutionPaths for this child graph
-        hip::Graph::GraphExecutionPaths child_graph_exec_paths;
-        child_graph_exec_paths.graph_ptr = childGraph;
+        hip::Graph::GraphExecutionPaths child_paths =
+            childGraph->FindExecutionPathsTopological();
 
-        // Find all root nodes in the child graph
-        const auto& child_root_nodes = childGraph->GetRootNodes();
-        std::unordered_set<unsigned int> child_visited;
+        int child_index = static_cast<int>(graph_paths.child_graph_paths.size());
+        graph_paths.child_graph_paths.push_back(std::move(child_paths));
 
-        for (const auto& child_root : child_root_nodes) {
-          std::vector<Node> child_current_path;
-          childGraph->FindPathsDFS(child_root, child_current_path, child_visited,
-                                   child_graph_exec_paths);
-        }
-
-        // Store the child graph paths
-        int child_graph_index = static_cast<int>(graph_paths.child_graph_paths.size());
-        graph_paths.child_graph_paths.push_back(std::move(child_graph_exec_paths));
-
-        // Create a path containing just the child graph node
-        std::vector<Node> child_node_path = {childGraphNode};
-        savePath(child_node_path, current_device_id, childGraphNode, child_graph_index);
+        hip::Graph::HierarchicalPath h_path;
+        h_path.device_id              = node->GetDeviceId();
+        h_path.nodes                  = {childGraphNode};
+        h_path.child_graph_node       = childGraphNode;
+        h_path.child_graph_paths_index = child_index;
+        graph_paths.paths.push_back(std::move(h_path));
       }
-
-      // Clear current path and continue with edges from the child graph node
-      current_path.clear();
-      const auto& edges = node->GetEdges();
-      for (int i = static_cast<int>(edges.size()) - 1; i >= 0; --i) {
-        st.push_back(edges[static_cast<size_t>(i)]);
-      }
-
-      continue;
+    } else {
+      current_seg.push_back(node);
     }
 
-    // Regular node - add to current path
-    current_path.push_back(node);
-
-    // Edges are out degrees, Dependencies are in degrees
-    const auto& edges = node->GetEdges();
-    const auto& dependencies = node->GetDependencies();
-
-    // Check if this is a fork node (multiple outgoing edges)
-    bool is_fork = edges.size() > 1;
-    // Check if this is a join node (multiple incoming dependencies)
-    bool is_join = dependencies.size() > 1;
-
-    if (is_fork || is_join) {
-      // Save current path as a separate segment
-      if (!current_path.empty()) {
-        Node saved_join_node = nullptr;
-
-        // For join nodes, save path without the join node itself
-        // For fork nodes, save the complete path
-        if (is_join) {
-          saved_join_node = current_path.back();
-          current_path.pop_back();
-        }
-
-        if (!current_path.empty()) {
-          int dev = current_path.back()->GetDeviceId();
-          savePath(current_path, dev);
-        }
-        current_path.clear();
-
-        // For nodes that are both fork and join, save them as their own segment
-        if (saved_join_node != nullptr && is_fork) {
-          std::vector<Node> fork_join_segment = {saved_join_node};
-          savePath(std::move(fork_join_segment), saved_join_node->GetDeviceId());
-        }
-
-        // Put the join node back in current_path for further traversal
-        // But not if it's also a fork node, because we'll traverse branches separately
-        if (saved_join_node != nullptr && !is_fork) {
-          current_path.push_back(saved_join_node);
-        }
-      }
-
-      // Traverse each branch until it hits a join
-      for (int i = static_cast<int>(edges.size()) - 1; i >= 0; --i) {
-        st.push_back(edges[static_cast<size_t>(i)]);
-      }
-    } else if (edges.size() == 1) {
-      // Single edge - continue on same path
-      st.push_back(edges[0]);
+    // A fork or a leaf always closes the current segment.
+    if (is_fork || edges.empty()) {
+      flushSegment(current_seg);
     }
 
-    // Save any remaining path (handles leaf nodes and leaf join nodes)
-    if (!current_path.empty() && edges.size() == 0) {
-      int dev = current_path.back()->GetDeviceId();
-      savePath(std::move(current_path), dev);
-      current_path.clear();
+    // Enqueue successors whose in-degree reaches zero.
+    for (auto* edge : edges) {
+      if (--in_degree[edge] == 0) q.push(edge);
     }
   }
+
+  // Flush any trailing linear tail.
+  flushSegment(current_seg);
+
+  return graph_paths;
 }
 
 // ================================================================================================

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -378,35 +378,41 @@ void Graph::ResolveSegmentDependencies() {
   for (size_t i = 0; i < segments_.size(); ++i) {
     auto& segment = segments_[i];
 
-    // Only check first node for incoming dependencies
-    if (segment.first_node != nullptr) {
-      const auto& dependencies = segment.first_node->GetDependencies();
+    // Use a set for O(1) duplicate detection instead of linear search on the vector
+    std::unordered_set<int> dep_set(segment.segment_ids_dependencies.begin(),
+                                    segment.segment_ids_dependencies.end());
 
-      // Use a set for O(1) duplicate detection instead of linear search on the vector
-      std::unordered_set<int> dep_set(segment.segment_ids_dependencies.begin(),
-                                      segment.segment_ids_dependencies.end());
-
-      for (const auto& dep_node : dependencies) {
-        // Find which segment this dependency belongs to (within this graph)
+    // Walk all nodes in the segment: mid-segment wait-event nodes introduce
+    // cross-stream dependencies that are invisible if we only inspect first_node.
+    for (const auto& cur_node : segment.nodes) {
+      for (const auto& dep_node : cur_node->GetDependencies()) {
+        // Only cross-segment dependencies matter here
         auto dep_it = node_to_segment_id_.find(dep_node);
-        if (dep_it != node_to_segment_id_.end()) {
-          int dep_segment_id = dep_it->second;
+        if (dep_it == node_to_segment_id_.end()) {
+          continue;
+        }
 
-          // Validate segment ID is within bounds
-          if (dep_segment_id < 0 || dep_segment_id >= static_cast<int>(segments_.size())) {
-            ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
-                    "[hipGraph] Invalid segment ID %d (segments size: %zu)",
-                    dep_segment_id, segments_.size());
-            continue;  // Skip invalid segment ID
-          }
+        int dep_segment_id = dep_it->second;
 
-          // Add dependency if not already present (O(1) lookup)
-          if (dep_set.insert(dep_segment_id).second) {
-            segment.segment_ids_dependencies.push_back(dep_segment_id);
+        // Skip intra-segment edges (same segment)
+        if (dep_segment_id == static_cast<int>(i)) {
+          continue;
+        }
 
-            // Also add this segment as an edge of the dependency segment
-            segments_[dep_segment_id].segment_ids_edges.push_back(i);
-          }
+        // Validate segment ID is within bounds
+        if (dep_segment_id < 0 || dep_segment_id >= static_cast<int>(segments_.size())) {
+          ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
+                  "[hipGraph] Invalid segment ID %d (segments size: %zu)",
+                  dep_segment_id, segments_.size());
+          continue;
+        }
+
+        // Add dependency if not already present (O(1) lookup)
+        if (dep_set.insert(dep_segment_id).second) {
+          segment.segment_ids_dependencies.push_back(dep_segment_id);
+
+          // Also add this segment as an edge of the dependency segment
+          segments_[dep_segment_id].segment_ids_edges.push_back(i);
         }
       }
     }
@@ -1151,30 +1157,14 @@ void GraphExec::FindStreamsReqPerDevForSegments() {
 
 // ================================================================================================
 void GraphExec::PrecomputeStreamAssignment() {
-  // max_streams_dev_ holds the raw parallelism count per device as computed by
-  // FindStreamsReqPerDev[ForSegments]() and capped in Init(). CreateStreams() handles
-  // the -1 adjustment for the instantiation device internally, so the value here
-  // represents the total stream pool size for every device uniformly.
-  auto getPoolSize = [&](int dev_id) -> size_t {
-    auto it = max_streams_dev_.find(dev_id);
-    return (it != max_streams_dev_.end() && it->second > 0)
-               ? static_cast<size_t>(it->second) : 1;
-  };
-
-  for (int level = 0; level <= max_dependency_level_; ++level) {
-    auto it = segments_per_level_.find(level);
-    if (it == segments_per_level_.end()) continue;
-
-    // Per-device round-robin counters, reset per level so parallel segments on
-    // the same device spread evenly across that device's stream pool.
-    std::unordered_map<int, size_t> dev_idx;
-
-    for (int seg_id : it->second) {
-      if (seg_id >= 0 && seg_id < static_cast<int>(segments_.size())) {
-        auto& seg = segments_[seg_id];
-        seg.stream_id = static_cast<int>(dev_idx[seg.dev_id]++ % getPoolSize(seg.dev_id));
-      }
-    }
+  // Derive each segment's stream_id from its first node's capture-time stream_id_.
+  // ScheduleOneNode assigns stream_id_ once per node based on which capture stream
+  // it was enqueued on, so this is stable across all dependency levels. Using a
+  // per-level round-robin reset instead caused segments from different capture streams
+  // to collide onto the same stream_id at later levels, causing BuildSyncPlan to
+  // incorrectly drop cross-stream barriers between them.
+  for (auto& seg : segments_) {
+    seg.stream_id = (seg.first_node != nullptr) ? seg.first_node->stream_id_ : 0;
   }
 
   const bool leaf_sync_required = IsLeafNodeSyncRequired();

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -331,6 +331,21 @@ hipError_t Graph::ScheduleNodesIntoBatches() {
     return hipErrorInvalidValue;
   }
 
+  // Verify that every graph node was assigned to a segment. The iterative DFS
+  // in FindPathsDFS uses a shared mutable current_path across stack frames; for
+  // fork-join graphs this can silently drop event/wait nodes that carry cache-
+  // coherency ordering. Missing nodes are never dispatched as AQL packets, so
+  // the GPU sees stale memory and produces wrong results. Fall back to the
+  // classic scheduling path which handles fork-join graphs correctly.
+  if (node_to_segment_id_.size() < static_cast<size_t>(GetNodeCount()) &&
+      DEBUG_HIP_GRAPH_SEGMENT_SCHEDULING != 2) {
+    ClPrint(amd::LOG_INFO, amd::LOG_CODE,
+            "[hipGraph] Segment DFS missed %zu/%zu node(s) - falling back to classic path",
+            static_cast<size_t>(GetNodeCount()) - node_to_segment_id_.size(),
+            static_cast<size_t>(GetNodeCount()));
+    return hipErrorNotReady;
+  }
+
   // Check if this is a complex graph that would benefit from classic path
   // Complex graphs: 16+ segments with average segment length < 8
   const size_t kSegmentSizeThreshold = 16;
@@ -378,41 +393,35 @@ void Graph::ResolveSegmentDependencies() {
   for (size_t i = 0; i < segments_.size(); ++i) {
     auto& segment = segments_[i];
 
-    // Use a set for O(1) duplicate detection instead of linear search on the vector
-    std::unordered_set<int> dep_set(segment.segment_ids_dependencies.begin(),
-                                    segment.segment_ids_dependencies.end());
+    // Only check first node for incoming dependencies
+    if (segment.first_node != nullptr) {
+      const auto& dependencies = segment.first_node->GetDependencies();
 
-    // Walk all nodes in the segment: mid-segment wait-event nodes introduce
-    // cross-stream dependencies that are invisible if we only inspect first_node.
-    for (const auto& cur_node : segment.nodes) {
-      for (const auto& dep_node : cur_node->GetDependencies()) {
-        // Only cross-segment dependencies matter here
+      // Use a set for O(1) duplicate detection instead of linear search on the vector
+      std::unordered_set<int> dep_set(segment.segment_ids_dependencies.begin(),
+                                      segment.segment_ids_dependencies.end());
+
+      for (const auto& dep_node : dependencies) {
+        // Find which segment this dependency belongs to (within this graph)
         auto dep_it = node_to_segment_id_.find(dep_node);
-        if (dep_it == node_to_segment_id_.end()) {
-          continue;
-        }
+        if (dep_it != node_to_segment_id_.end()) {
+          int dep_segment_id = dep_it->second;
 
-        int dep_segment_id = dep_it->second;
+          // Validate segment ID is within bounds
+          if (dep_segment_id < 0 || dep_segment_id >= static_cast<int>(segments_.size())) {
+            ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
+                    "[hipGraph] Invalid segment ID %d (segments size: %zu)",
+                    dep_segment_id, segments_.size());
+            continue;  // Skip invalid segment ID
+          }
 
-        // Skip intra-segment edges (same segment)
-        if (dep_segment_id == static_cast<int>(i)) {
-          continue;
-        }
+          // Add dependency if not already present (O(1) lookup)
+          if (dep_set.insert(dep_segment_id).second) {
+            segment.segment_ids_dependencies.push_back(dep_segment_id);
 
-        // Validate segment ID is within bounds
-        if (dep_segment_id < 0 || dep_segment_id >= static_cast<int>(segments_.size())) {
-          ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
-                  "[hipGraph] Invalid segment ID %d (segments size: %zu)",
-                  dep_segment_id, segments_.size());
-          continue;
-        }
-
-        // Add dependency if not already present (O(1) lookup)
-        if (dep_set.insert(dep_segment_id).second) {
-          segment.segment_ids_dependencies.push_back(dep_segment_id);
-
-          // Also add this segment as an edge of the dependency segment
-          segments_[dep_segment_id].segment_ids_edges.push_back(i);
+            // Also add this segment as an edge of the dependency segment
+            segments_[dep_segment_id].segment_ids_edges.push_back(i);
+          }
         }
       }
     }
@@ -1157,14 +1166,30 @@ void GraphExec::FindStreamsReqPerDevForSegments() {
 
 // ================================================================================================
 void GraphExec::PrecomputeStreamAssignment() {
-  // Derive each segment's stream_id from its first node's capture-time stream_id_.
-  // ScheduleOneNode assigns stream_id_ once per node based on which capture stream
-  // it was enqueued on, so this is stable across all dependency levels. Using a
-  // per-level round-robin reset instead caused segments from different capture streams
-  // to collide onto the same stream_id at later levels, causing BuildSyncPlan to
-  // incorrectly drop cross-stream barriers between them.
-  for (auto& seg : segments_) {
-    seg.stream_id = (seg.first_node != nullptr) ? seg.first_node->stream_id_ : 0;
+  // Assign stream IDs via a per-device round-robin that is NOT reset between
+  // dependency levels. FindStreamsReqPerDevForSegments() sizes the pool to the
+  // maximum parallel fan-out at any single level, so the pool is always large
+  // enough to give each segment at a given level a distinct stream ID.
+  // Resetting dev_idx inside the level loop (the previous bug) caused segments
+  // at different levels to collide onto the same stream_id, leading
+  // BuildSyncPlan to incorrectly drop cross-stream barriers between them.
+  auto getPoolSize = [&](int dev_id) -> size_t {
+    auto it = max_streams_dev_.find(dev_id);
+    return (it != max_streams_dev_.end() && it->second > 0)
+               ? static_cast<size_t>(it->second) : 1;
+  };
+
+  std::unordered_map<int, size_t> dev_idx;
+  for (int level = 0; level <= max_dependency_level_; ++level) {
+    auto it = segments_per_level_.find(level);
+    if (it == segments_per_level_.end()) continue;
+
+    for (int seg_id : it->second) {
+      if (seg_id >= 0 && seg_id < static_cast<int>(segments_.size())) {
+        auto& seg = segments_[seg_id];
+        seg.stream_id = static_cast<int>(dev_idx[seg.dev_id]++ % getPoolSize(seg.dev_id));
+      }
+    }
   }
 
   const bool leaf_sync_required = IsLeafNodeSyncRequired();
@@ -2132,6 +2157,17 @@ hipError_t GraphExec::EnqueueSegment(const Segment& segment, hip::Stream* stream
       }
     } else {
       // Node doesn't support capture - execute individually.
+      // If the leading batch (batchIndex == 0) has pending content — in particular,
+      // dependency barrier packets prepended by BuildSyncPlan — dispatch it now,
+      // BEFORE the non-captured node's commands reach the HW queue.  Without this,
+      // the leading batch is only dispatched in the "drain remaining" loop after all
+      // nodes, meaning cross-stream barriers fire too late and the non-captured node
+      // (e.g. a memcpy) reads stale GPU memory written by parallel segments.
+      if (batchIndex == 0) {
+        status = dispatchCurrentBatch();
+        if (status != hipSuccess) return status;
+      }
+
       // Flat dispatch bypasses the Barriers() tracker (ActiveSignal is skipped).
       // Enqueue Markers before and after the non-captured node to:
       //   Before: resync the Barriers() tracker so releaseGpuMemoryFence/WaitCurrent

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -723,15 +723,12 @@ class Graph {
   //! Schedules nodes into batches for optimized execution
   hipError_t ScheduleNodesIntoBatches();
 
-  //! Find execution paths hierarchically, keeping child graphs separate
-  GraphExecutionPaths FindExecutionPathsHierarchical();
+  //! Find execution paths using a topological (Kahn's BFS) traversal.
+  //! Correctly handles fork-join graphs: every node is visited exactly once
+  //! after all its predecessors, so no node is ever silently dropped.
+  GraphExecutionPaths FindExecutionPathsTopological();
 
-  //! Find all paths from a node using an explicit DFS over a node stack, with
-  //! hierarchical handling of child graphs (only child graphs recurse)
-  void FindPathsDFS(Node node, std::vector<Node>& current_path,
-                    std::unordered_set<unsigned int>& visited, GraphExecutionPaths& graph_paths);
-
-  //! Create segments from hierarchical execution paths
+//! Create segments from hierarchical execution paths
   void CreateSegmentsFromPaths(const GraphExecutionPaths& exec_paths);
 
   //! Resolve dependencies between segments


### PR DESCRIPTION
## Motivation
Fix a regression on Navi48 where nested and reused stream-capture graph tests produced incorrect results (expected 7, got 4) due to missing GPU barriers between parallel graph segments. Two compounding bugs suppressed cross-stream synchronization, allowing parallel segments to race and read stale memory.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
The path-finding algorithm used a DFS with a shared visited set, which caused nodes where parallel branches merge to be skipped entirely - replaced with a standard topological sort that correctly processes every node once. The stream assignment logic was resetting its counter at each dependency level, so segments from different levels would get the same stream ID: since same-stream segments don't need barriers between them, required synchronization was silently dropped - fixed by keeping the counter running across all levels. A third fix ensures that barrier packets scheduled before a non-captured node actually reach the GPU before that node executes, rather than being flushed too late.

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
AIRUNTIME-2229
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
1. The tests should pass as is on existing Mi325 architecture
2. The tests should pass when running on Navi4X 
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
1. Waiting for PSDB
2. Passed when running tests manually on 9070XT, waiting for report from QA
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
