### PR TITLE
Fix cross device graph execution path

### DIFF
--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -59,6 +59,97 @@ amd::Monitor UserObject::UserObjectLock_{};
 // Guards mem map add/remove against work thread
 amd::Monitor GraphNode::WorkerThreadLock_{};
 
+static hip::Stream* FindExecStreamForNode(
+    Node node, hip::Stream* launch_stream,
+    const std::unordered_map<int, std::vector<hip::Stream*>>& parallel_streams) {
+  if (node->GetDeviceId() == launch_stream->DeviceId()) {
+    return launch_stream;
+  }
+  auto streams = parallel_streams.find(node->GetDeviceId());
+  if (streams == parallel_streams.end() || streams->second.empty()) {
+    return nullptr;
+  }
+  return streams->second.front();
+}
+
+static hipError_t SyncRootNodesWithLaunchStream(
+    const std::vector<Node>& topo_order, hip::Stream* launch_stream,
+    const std::unordered_map<int, std::vector<hip::Stream*>>& parallel_streams) {
+  constexpr bool kRetainCommand = true;
+  amd::Command* launch_last = launch_stream->getLastQueuedCommand(kRetainCommand);
+  if (launch_last == nullptr) {
+    return hipSuccess;
+  }
+
+  std::unordered_set<hip::Stream*> fenced_streams;
+  amd::Command::EventWaitList wait_list;
+  wait_list.push_back(launch_last);
+
+  for (auto* node : topo_order) {
+    if (!node->GetDependencies().empty()) {
+      continue;
+    }
+    hip::Stream* stream = FindExecStreamForNode(node, launch_stream, parallel_streams);
+    if (stream == nullptr) {
+      launch_last->release();
+      LogPrintfError("No internal graph stream for device id:%d", node->GetDeviceId());
+      return hipErrorInvalidDevice;
+    }
+    if (stream == launch_stream) {
+      continue;
+    }
+    if (fenced_streams.insert(stream).second) {
+      auto* start_marker = new amd::Marker(*stream, true, wait_list);
+      start_marker->enqueue();
+      start_marker->release();
+    }
+  }
+
+  launch_last->release();
+  return hipSuccess;
+}
+
+static hipError_t EnqueueNodeOnExecStream(
+    Node node, hip::Stream* launch_stream,
+    const std::unordered_map<int, std::vector<hip::Stream*>>& parallel_streams) {
+  hip::Stream* stream = FindExecStreamForNode(node, launch_stream, parallel_streams);
+  if (stream == nullptr) {
+    LogPrintfError("No internal graph stream for device id:%d", node->GetDeviceId());
+    return hipErrorInvalidDevice;
+  }
+
+  amd::Command::EventWaitList wait_list;
+  for (auto* dep : node->GetDependencies()) {
+    for (auto* command : dep->GetCommands()) {
+      wait_list.push_back(command);
+    }
+  }
+
+  node->SetStream(stream);
+  hipError_t status = node->CreateCommand(node->GetQueue());
+  if (status != hipSuccess) {
+    for (auto* command : wait_list) {
+      command->release();
+    }
+    return status;
+  }
+
+  if (!wait_list.empty()) {
+    node->UpdateEventWaitLists(wait_list);
+  }
+  node->EnqueueCommands(stream);
+  for (auto* command : wait_list) {
+    command->release();
+  }
+
+  for (size_t i = 0; i < node->GetEdges().size(); ++i) {
+    for (auto* command : node->GetCommands()) {
+      command->retain();
+    }
+  }
+  return hipSuccess;
+}
+
 hipError_t GraphMemcpyNode1D::ValidateParams(void* dst, const void* src, size_t count,
                                              hipMemcpyKind kind) {
   if (dst == nullptr || src == nullptr) {
@@ -1018,8 +1109,9 @@ hipError_t GraphExec::CreateStreams(uint32_t num_streams, int devId) {
   // num_streams is already capped by Init() but guard here defensively.
   // For the instantiation device one slot is occupied by the launch stream,
   // so create one fewer extra stream. Other devices use all slots as parallel streams.
+  // Keep the single slot when capped == 1 so cross-device launches still have a stream.
   uint32_t capped = std::min(num_streams, DEBUG_HIP_FORCE_GRAPH_QUEUES);
-  uint32_t max_streams = (devId == instantiateDeviceId_ && capped > 0) ? capped - 1 : capped;
+  uint32_t max_streams = (devId == instantiateDeviceId_ && capped > 1) ? capped - 1 : capped;
   if (max_streams == 0) {
     return hipSuccess;
   }
@@ -2513,11 +2605,50 @@ hipError_t GraphExec::Run(hip::Stream* launch_stream) {
     // already imply all parallel work is done). Our reference is released after
     // the callback is registered below; the queue keeps it alive until done.
     completion_cmd = last_cmd;
-  } else if (max_streams_ == 1 && instantiateDeviceId_ != launch_stream->DeviceId()) {
-    for (int i = 0; i < topoOrder_.size(); i++) {
-      topoOrder_[i]->SetStream(launch_stream);
-      status = topoOrder_[i]->CreateCommand(topoOrder_[i]->GetQueue());
-      topoOrder_[i]->EnqueueCommands(launch_stream);
+  } else if (instantiateDeviceId_ != launch_stream->DeviceId()) {
+    // Cross-device launch: graph was instantiated on one device but launched from another.
+    // Route each node to the stream that matches the device it was captured on so that
+    // helper kernels (fillBuffer, copyBuffer) resolve against the correct device's program
+    // and kernarg pool. Covers both max_streams==1 and max_streams>1 cases - the latter
+    // would otherwise fall into RunNodes which asserts on stream_id_==-1 for explicitly
+    // added nodes (hipGraphAdd* does not initialize stream_id_).
+    ClPrint(amd::LOG_DEBUG, amd::LOG_CODE,
+            "[hipGraph] Cross-device launch: instantiateDeviceId_=%d launch_stream->DeviceId()=%d"
+            " launch_stream=%p",
+            instantiateDeviceId_, launch_stream->DeviceId(), launch_stream);
+    status = SyncRootNodesWithLaunchStream(topoOrder_, launch_stream, parallel_streams_);
+    if (status != hipSuccess) {
+      this->release();
+      return status;
+    }
+    for (auto* node : topoOrder_) {
+      status = EnqueueNodeOnExecStream(node, launch_stream, parallel_streams_);
+      if (status != hipSuccess) {
+        this->release();
+        return status;
+      }
+    }
+    // Completion fence: make launch_stream wait for all non-launch streams so that
+    // hipStreamSynchronize(launch_stream) and the ref-count callback marker both
+    // observe full graph completion. Pattern mirrors Graph::RunNodes leaf-collection.
+    amd::Command::EventWaitList end_wl;
+    for (auto& [dev, streams] : parallel_streams_) {
+      for (auto* ps : streams) {
+        if (ps == launch_stream) continue;
+        if (amd::Command* last = ps->getLastQueuedCommand(true)) {
+          end_wl.push_back(last);
+        }
+      }
+    }
+    if (!end_wl.empty()) {
+      auto* fence = new amd::Marker(*launch_stream, kMarkerDisableFlush, end_wl);
+      fence->enqueue();
+      fence->release();
+      for (auto* cmd : end_wl) cmd->release();
+      ClPrint(amd::LOG_DEBUG, amd::LOG_CODE,
+              "[hipGraph] Cross-device launch: completion fence enqueued on launch_stream=%p"
+              " waiting on %zu cross-stream command(s)",
+              launch_stream, end_wl.size());
     }
   } else {
     // Execute all nodes in the graph

--- a/projects/hip-tests/catch/config/configs/unit/graph.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/graph.yaml
@@ -1386,6 +1386,15 @@ graph:
     # SWDEV-434878: Below tests failed in stress test on 24/11/23
     disabled: [amd_windows, amd_wsl]
     tags: [exec]
+  Unit_hipGraphCrossDeviceLaunch_CrossStreamDependencyOrdering:
+    <<: *level_2
+    tags: [exec, multigpu]
+  Unit_hipGraphCrossDeviceLaunch_ExplicitNodes:
+    <<: *level_2
+    tags: [exec, multigpu]
+  Unit_hipGraphCrossDeviceLaunch_LaunchStreamStartOrdering:
+    <<: *level_2
+    tags: [exec, multigpu]
   Unit_hipGraphKernelNodeCopyAttributes_Functional:
     <<: *level_2
     tags: [node]

--- a/projects/hip-tests/catch/unit/graph/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/graph/CMakeLists.txt
@@ -130,6 +130,7 @@ set(TEST_SRC
   hipGraphNodeGetEnabled.cc
   hipGraphExecDestroy.cc
   hipGraphUpload.cc
+  hipGraphCrossDeviceLaunch.cc
   hipGraphKernelNodeCopyAttributes.cc
   hipGraphCycle.cc
   hipGraphPerf.cc
@@ -145,6 +146,7 @@ set(TEST_SRC
   hipDeviceGetGraphMemAttribute.cc
   hipDeviceGraphMemTrim.cc
   hipDrvGraphExecMemsetNodeSetParams.cc
+  hipGraphMultiDevice.cc
 )
 
 if(HIP_PLATFORM MATCHES "amd")

--- a/projects/hip-tests/catch/unit/graph/hipGraphCrossDeviceLaunch.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphCrossDeviceLaunch.cc
@@ -1,0 +1,301 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Tests for hipGraphLaunch when the launch stream's device differs from the
+ * device on which the graph was instantiated (cross-device launch). This
+ * exercises the Path B branch in GraphExec::Run, including dependency waits
+ * between work submitted to instantiate-device streams and launch-device streams.
+ */
+
+#include <cstdint>
+
+#include <hip_test_common.hh>
+#include <hip_test_checkers.hh>
+#include <hip_test_kernels.hh>
+#include <utils.hh>
+
+// ---------------------------------------------------------------------------
+// Helper: set up a cross-device launch context.
+// cap_stream  - created on inst_dev, used for capture (caller-owned)
+// launch_stream - created on launch_dev (caller-owned)
+// ---------------------------------------------------------------------------
+static void setupCrossDeviceStreams(int inst_dev, int launch_dev, hipStream_t& cap_stream,
+                                    hipStream_t& launch_stream) {
+  HIP_CHECK(hipSetDevice(launch_dev));
+  HIP_CHECK(hipStreamCreate(&launch_stream));
+  HIP_CHECK(hipSetDevice(inst_dev));
+  HIP_CHECK(hipStreamCreate(&cap_stream));
+}
+
+struct HostCheckContext {
+  int* value = nullptr;
+  int expected = 0;
+  int observed = 0;
+};
+
+static void recordHostValue(void* user_data) {
+  auto* context = reinterpret_cast<HostCheckContext*>(user_data);
+  context->observed = *context->value;
+}
+
+static void setHostValue(void* user_data) {
+  auto* context = reinterpret_cast<HostCheckContext*>(user_data);
+  *context->value = context->expected;
+}
+
+// ---------------------------------------------------------------------------
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Cross-stream dependency ordering: a host node on the launch-device stream depends on work
+ *    dispatched to the instantiate-device stream. The host node observes a D2H result that is only
+ *    valid if the delay, kernel, and memcpy dependencies completed first.
+ * ------------------------
+ *  - catch/unit/graph/hipGraphCrossDeviceLaunch.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 7.2
+ *  - Multi-device
+ */
+HIP_TEST_CASE(Unit_hipGraphCrossDeviceLaunch_CrossStreamDependencyOrdering) {
+  int nGpus = 0;
+  HIP_CHECK(hipGetDeviceCount(&nGpus));
+  if (nGpus < 2) HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+
+  hipStream_t cap_stream, launch_stream;
+  setupCrossDeviceStreams(1, 0, cap_stream, launch_stream);
+
+  int clockrate = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&clockrate, hipDeviceAttributeMemoryClockRate, 1));
+  constexpr uint32_t delay_ms = 200;
+  uint32_t delay_arg = delay_ms;
+  uint32_t ticks_per_ms = static_cast<uint32_t>(clockrate);
+
+  HIP_CHECK(hipSetDevice(1));
+  hipGraph_t graph = nullptr;
+  HIP_CHECK(hipGraphCreate(&graph, 0));
+  int* d_value = nullptr;
+  HIP_CHECK(hipMalloc(&d_value, sizeof(int)));
+  int h_value = 0;
+
+  hipGraphNode_t delay_node = nullptr;
+  hipKernelNodeParams kernel_params{};
+  void* kernel_args[] = {&delay_arg, &ticks_per_ms};
+  kernel_params.func = reinterpret_cast<void*>(Delay);
+  kernel_params.gridDim = dim3(1);
+  kernel_params.blockDim = dim3(1);
+  kernel_params.kernelParams = reinterpret_cast<void**>(kernel_args);
+  HIP_CHECK(hipGraphAddKernelNode(&delay_node, graph, nullptr, 0, &kernel_params));
+
+  constexpr int expected_value = 1234;
+  hipGraphNode_t set_node = nullptr;
+  hipKernelNodeParams set_params{};
+  int set_value = expected_value;
+  size_t count = 1;
+  void* set_args[] = {&d_value, &set_value, &count};
+  set_params.func = reinterpret_cast<void*>(VectorSet<int>);
+  set_params.gridDim = dim3(1);
+  set_params.blockDim = dim3(1);
+  set_params.kernelParams = reinterpret_cast<void**>(set_args);
+  HIP_CHECK(hipGraphAddKernelNode(&set_node, graph, &delay_node, 1, &set_params));
+
+  hipGraphNode_t memcpy_node = nullptr;
+  HIP_CHECK(hipGraphAddMemcpyNode1D(&memcpy_node, graph, &set_node, 1, &h_value, d_value,
+                                    sizeof(int), hipMemcpyDeviceToHost));
+
+  HostCheckContext context;
+  context.value = &h_value;
+  context.expected = expected_value;
+  hipGraphNode_t host_node = nullptr;
+  hipHostNodeParams host_params = {0, 0};
+  host_params.fn = recordHostValue;
+  host_params.userData = &context;
+
+  HIP_CHECK(hipSetDevice(0));
+  HIP_CHECK(hipGraphAddHostNode(&host_node, graph, &memcpy_node, 1, &host_params));
+
+  HIP_CHECK(hipSetDevice(1));
+  hipGraphExec_t graph_exec = nullptr;
+  HIP_CHECK(hipGraphInstantiate(&graph_exec, graph, nullptr, nullptr, 0));
+
+  HIP_CHECK(hipSetDevice(0));
+  HIP_CHECK(hipGraphLaunch(graph_exec, launch_stream));
+  HIP_CHECK(hipStreamSynchronize(launch_stream));
+
+  REQUIRE(context.observed == context.expected);
+
+  HIP_CHECK(hipGraphExecDestroy(graph_exec));
+  HIP_CHECK(hipGraphDestroy(graph));
+  HIP_CHECK(hipFree(d_value));
+  HIP_CHECK(hipStreamDestroy(cap_stream));
+  HIP_CHECK(hipStreamDestroy(launch_stream));
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Launch-stream start ordering: work queued on the launch stream before hipGraphLaunch must
+ *    complete before root nodes on the instantiate device begin. A delay kernel and host callback
+ *    on the launch stream update a host value; the graph root H2D must observe the updated value.
+ * ------------------------
+ *  - catch/unit/graph/hipGraphCrossDeviceLaunch.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 7.2
+ *  - Multi-device
+ */
+HIP_TEST_CASE(Unit_hipGraphCrossDeviceLaunch_LaunchStreamStartOrdering) {
+  int nGpus = 0;
+  HIP_CHECK(hipGetDeviceCount(&nGpus));
+  if (nGpus < 2) HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+
+  hipStream_t cap_stream, launch_stream;
+  setupCrossDeviceStreams(1, 0, cap_stream, launch_stream);
+
+  int clockrate = 0;
+  HIP_CHECK(hipDeviceGetAttribute(&clockrate, hipDeviceAttributeMemoryClockRate, 0));
+  constexpr uint32_t delay_ms = 200;
+  uint32_t delay_arg = delay_ms;
+  uint32_t ticks_per_ms = static_cast<uint32_t>(clockrate);
+
+  constexpr int expected_value = 42;
+  int* h_value = nullptr;
+  int* h_check = nullptr;
+  HIP_CHECK(hipHostMalloc(&h_value, sizeof(int)));
+  HIP_CHECK(hipHostMalloc(&h_check, sizeof(int)));
+  *h_value = 0;
+  *h_check = 0;
+
+  HostCheckContext set_context;
+  set_context.value = h_value;
+  set_context.expected = expected_value;
+
+  HostCheckContext check_context;
+  check_context.value = h_check;
+  check_context.expected = expected_value;
+
+  void* delay_args[] = {&delay_arg, &ticks_per_ms};
+
+  HIP_CHECK(hipSetDevice(1));
+  hipGraph_t graph = nullptr;
+  HIP_CHECK(hipGraphCreate(&graph, 0));
+  int* d_value = nullptr;
+  HIP_CHECK(hipMalloc(&d_value, sizeof(int)));
+
+  hipGraphNode_t h2d_node = nullptr;
+  HIP_CHECK(hipGraphAddMemcpyNode1D(&h2d_node, graph, nullptr, 0, d_value, h_value, sizeof(int),
+                                    hipMemcpyHostToDevice));
+
+  hipGraphNode_t d2h_node = nullptr;
+  HIP_CHECK(hipGraphAddMemcpyNode1D(&d2h_node, graph, &h2d_node, 1, h_check, d_value, sizeof(int),
+                                    hipMemcpyDeviceToHost));
+
+  hipGraphNode_t host_node = nullptr;
+  hipHostNodeParams host_params = {0, 0};
+  host_params.fn = recordHostValue;
+  host_params.userData = &check_context;
+  HIP_CHECK(hipGraphAddHostNode(&host_node, graph, &d2h_node, 1, &host_params));
+
+  hipGraphExec_t graph_exec = nullptr;
+  HIP_CHECK(hipGraphInstantiate(&graph_exec, graph, nullptr, nullptr, 0));
+
+  HIP_CHECK(hipSetDevice(0));
+  *h_value = 0;
+  *h_check = 0;
+  HIP_CHECK(hipLaunchKernel(reinterpret_cast<void*>(Delay), dim3(1), dim3(1), delay_args, 0,
+                            launch_stream));
+  HIP_CHECK(hipLaunchHostFunc(launch_stream, setHostValue, &set_context));
+  HIP_CHECK(hipGraphLaunch(graph_exec, launch_stream));
+  HIP_CHECK(hipStreamSynchronize(launch_stream));
+
+  REQUIRE(check_context.observed == check_context.expected);
+
+  HIP_CHECK(hipGraphExecDestroy(graph_exec));
+  HIP_CHECK(hipGraphDestroy(graph));
+  HIP_CHECK(hipFree(d_value));
+  HIP_CHECK(hipHostFree(h_value));
+  HIP_CHECK(hipHostFree(h_check));
+  HIP_CHECK(hipStreamDestroy(cap_stream));
+  HIP_CHECK(hipStreamDestroy(launch_stream));
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Explicit-node graph (hipGraphAdd*): verifies cross-device launch works
+ *    for graphs built via hipGraphAdd* rather than stream capture. These nodes
+ *    have stream_id_==-1, which previously caused an assertion failure in
+ *    RunNodes() when max_streams > 1; the cross-device branch must handle them.
+ * ------------------------
+ *  - catch/unit/graph/hipGraphCrossDeviceLaunch.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 7.2
+ *  - Multi-device
+ */
+HIP_TEST_CASE(Unit_hipGraphCrossDeviceLaunch_ExplicitNodes) {
+  int nGpus = 0;
+  HIP_CHECK(hipGetDeviceCount(&nGpus));
+  if (nGpus < 2) HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
+
+  constexpr size_t N = 1024;
+  constexpr size_t Nbytes = N * sizeof(int);
+  constexpr auto blocksPerCU = 6;
+  constexpr auto threadsPerBlock = 256;
+
+  hipStream_t cap_stream, launch_stream;
+  setupCrossDeviceStreams(1, 0, cap_stream, launch_stream);
+
+  HIP_CHECK(hipSetDevice(1));
+  int *A_d, *B_d, *C_d;
+  int *A_h, *B_h, *C_h;
+  HipTest::initArrays(&A_d, &B_d, &C_d, &A_h, &B_h, &C_h, N, false);
+  unsigned blocks = HipTest::setNumBlocks(blocksPerCU, threadsPerBlock, N);
+
+  hipGraph_t graph = nullptr;
+  HIP_CHECK(hipGraphCreate(&graph, 0));
+
+  hipGraphNode_t memcpy_A, memcpy_B, kernel_node, memcpy_C;
+  HIP_CHECK(hipGraphAddMemcpyNode1D(&memcpy_A, graph, nullptr, 0, A_d, A_h, Nbytes,
+                                    hipMemcpyHostToDevice));
+  HIP_CHECK(hipGraphAddMemcpyNode1D(&memcpy_B, graph, nullptr, 0, B_d, B_h, Nbytes,
+                                    hipMemcpyHostToDevice));
+
+  size_t NElem = N;
+  void* kernelArgs[] = {&A_d, &B_d, &C_d, reinterpret_cast<void*>(&NElem)};
+  hipKernelNodeParams kNodeParams{};
+  kNodeParams.func = reinterpret_cast<void*>(HipTest::vectorADD<int>);
+  kNodeParams.gridDim = dim3(blocks);
+  kNodeParams.blockDim = dim3(threadsPerBlock);
+  kNodeParams.kernelParams = reinterpret_cast<void**>(kernelArgs);
+  HIP_CHECK(hipGraphAddKernelNode(&kernel_node, graph, nullptr, 0, &kNodeParams));
+
+  HIP_CHECK(hipGraphAddMemcpyNode1D(&memcpy_C, graph, nullptr, 0, C_h, C_d, Nbytes,
+                                    hipMemcpyDeviceToHost));
+
+  HIP_CHECK(hipGraphAddDependencies(graph, &memcpy_A, &kernel_node, 1));
+  HIP_CHECK(hipGraphAddDependencies(graph, &memcpy_B, &kernel_node, 1));
+  HIP_CHECK(hipGraphAddDependencies(graph, &kernel_node, &memcpy_C, 1));
+
+  HIP_CHECK(hipSetDevice(1));
+  hipGraphExec_t graph_exec = nullptr;
+  HIP_CHECK(hipGraphInstantiate(&graph_exec, graph, nullptr, nullptr, 0));
+
+  HIP_CHECK(hipSetDevice(0));
+  HIP_CHECK(hipGraphLaunch(graph_exec, launch_stream));
+  HIP_CHECK(hipStreamSynchronize(launch_stream));
+
+  HipTest::checkVectorADD(A_h, B_h, C_h, N);
+
+  HipTest::freeArrays(A_d, B_d, C_d, A_h, B_h, C_h, false);
+  HIP_CHECK(hipGraphExecDestroy(graph_exec));
+  HIP_CHECK(hipGraphDestroy(graph));
+  HIP_CHECK(hipStreamDestroy(cap_stream));
+  HIP_CHECK(hipStreamDestroy(launch_stream));
+}
+

--- a/projects/hip-tests/catch/unit/graph/hipGraphMultiDevice.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphMultiDevice.cc
@@ -106,7 +106,7 @@ HIP_TEST_CASE(Unit_hipGraphMultiDevice) {
   HIP_CHECK(hipStreamSynchronize(streamdev1));
 
   HIP_CHECK(hipSetDevice(1));
-  HIP_CHECK(hipMemcpy(outbuf_h, buf_d2, sizeof(int) * buffer_size, hipMemcpyHostToDevice));
+  HIP_CHECK(hipMemcpy(outbuf_h, buf_d2, sizeof(int) * buffer_size, hipMemcpyDeviceToHost));
   check_output(ibuf_h, outbuf_h, buffer_size);
 
   HIP_CHECK(hipGraphExecDestroy(graph_exec));


### PR DESCRIPTION
## Motivation

Fix cross-device HIP graph launches so graph work submitted to internal streams correctly waits for work already queued on the user’s launch stream. This preserves stream ordering semantics when a graph is instantiated on one device and launched from another device’s stream. This fixes Unit_hipGraphUpload_Functional_multidevice_test.

## Technical Details

Added cross-device graph launch stream routing so each node runs on the stream associated with its node device instead of forcing all nodes onto the launch stream.
Added a start fence for cross-device graph launches: root graph nodes on non-launch streams now wait on the launch stream’s previously queued command before graph execution begins.
Kept the completion fence so hipStreamSynchronize(launch_stream) observes work submitted to internal graph streams.
Fixed internal stream creation so cross-device launches still have an internal stream when the graph uses a single stream slot.
Added focused cross-device graph launch tests covering dependency ordering, explicit-node graphs, and launch-stream start ordering.
Registered the new tests in graph.yaml with exec and multigpu tags

## JIRA ID

AIRUNTIME-572

## Test Plan
Run Unit_hipGraphUpload_Functional_multidevice_test. Added new tests in hipGraphCrossDeviceLaunch.cc


## Test Result

All tests passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
