### PR TITLE
[rocprofiler-systems] Throw if no proper root in config JSON passed through --config or ROCPROFSYS_CONFIG_FILE

### DIFF
--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -169,7 +169,25 @@ inline namespace config
 namespace
 {
 auto cfg_fini_callbacks = std::vector<std::function<void()>>{};
+
+// Returns true if `path` is a .json file that lacks the top-level TIMEMORY_PROJECT_NAME
+// ("rocprofiler-systems") root object that timemory's cereal reader requires.
+bool
+config_json_missing_expected_root(const std::string& path)
+{
+    if(path.find(".json") == std::string::npos) return false;
+    std::ifstream ifs{ path };
+    if(!ifs.is_open()) return false;
+    try
+    {
+        auto json = nlohmann::json::parse(ifs);
+        return json.is_object() && !json.contains(TIMEMORY_PROJECT_NAME);
+    } catch(const nlohmann::json::exception&)
+    {
+        return false;
+    }
 }
+}  // namespace
 
 void
 finalize()
@@ -1093,12 +1111,22 @@ configure_settings(bool _init)
     {
         if(_config->get_suppress_config()) continue;
 
+        auto fitr = settings::format(itr, _config->get_tag());
+
+        // Timemory's read() silently drops JSON config files without proper root
+        if(_main_proc && config_json_missing_expected_root(fitr))
+        {
+            LOG_WARNING("Config file '{}' is missing the expected '{}' root object and "
+                        "will not be applied. If this is a hierarchical preset "
+                        "configuration, pass it via --preset instead.",
+                        fitr, TIMEMORY_PROJECT_NAME);
+        }
+
         LOG_DEBUG("Reading config file {}", itr);
         if(_config->read(itr) && _main_proc &&
            ((_config->get<bool>("ROCPROFSYS_CI") && settings::verbose() >= 0) ||
             settings::verbose() >= 1 || settings::debug()))
         {
-            auto              fitr = settings::format(itr, _config->get_tag());
             std::ifstream     _in{ fitr };
             std::stringstream _iss{};
             while(_in)

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -170,18 +170,18 @@ namespace
 {
 auto cfg_fini_callbacks = std::vector<std::function<void()>>{};
 
-// Returns true if `path` is a .json file that lacks the top-level TIMEMORY_PROJECT_NAME
-// ("rocprofiler-systems") root object that timemory's cereal reader requires.
 bool
-is_json_without_project_name_root(const std::string& path)
+json_has_project_name_root(const std::string& json_path)
 {
-    if(!path.ends_with(".json")) return false;
-    std::ifstream ifs{ path };
-    if(!ifs.is_open()) return false;
+    std::ifstream ifs{ json_path };
+    if(!ifs.is_open())
+    {
+        return false;
+    }
     try
     {
         auto json = nlohmann::json::parse(ifs);
-        return json.is_object() && !json.contains(TIMEMORY_PROJECT_NAME);
+        return json.is_object() && json.contains(TIMEMORY_PROJECT_NAME);
     } catch(const nlohmann::json::exception&)
     {
         return false;
@@ -1106,29 +1106,32 @@ configure_settings(bool _init)
     auto _proc      = mproc::get_concurrent_processes(_ppid);
     bool _main_proc = (_proc.size() < 2 || *_proc.begin() == _pid);
 
-    for(auto&& itr :
+    for(auto&& filename :
         tim::delimit(_config->get<std::string>("ROCPROFSYS_CONFIG_FILE"), ";:"))
     {
         if(_config->get_suppress_config()) continue;
 
-        auto fitr = settings::format(itr, _config->get_tag());
+        const auto expanded_filename = settings::format(filename, _config->get_tag());
 
-        // Timemory's read() will silently drop JSON config files without proper root
-        if(is_json_without_project_name_root(fitr))
+        // Prevent Timemory's read() silently dropping JSON config files without proper
+        // root. Non-existing JSONs should not throw: default ROCPROFSYS_CONFIG_FILE
+        // includes '~/.rocprofiler-systems.json' that can be missing
+        if(expanded_filename.ends_with(".json") && filepath::exists(expanded_filename) &&
+           !json_has_project_name_root(expanded_filename))
         {
-            LOG_CRITICAL("Config file '{}' is missing the expected '{}' root object and "
-                         "cannot be loaded. If this is a hierarchical preset "
-                         "configuration, pass it via --preset instead.",
-                         fitr, TIMEMORY_PROJECT_NAME);
-            std::exit(EXIT_FAILURE);
+            throw std::runtime_error(
+                fmt::format("Config file '{}' is missing the expected '{}' root object "
+                            "and cannot be loaded. If this is a hierarchical preset "
+                            "configuration, pass it via --preset instead.",
+                            expanded_filename, TIMEMORY_PROJECT_NAME));
         }
 
-        LOG_DEBUG("Reading config file {}", itr);
-        if(_config->read(itr) && _main_proc &&
+        LOG_DEBUG("Reading config file {}", filename);
+        if(_config->read(filename) && _main_proc &&
            ((_config->get<bool>("ROCPROFSYS_CI") && settings::verbose() >= 0) ||
             settings::verbose() >= 1 || settings::debug()))
         {
-            std::ifstream     _in{ fitr };
+            std::ifstream     _in{ expanded_filename };
             std::stringstream _iss{};
             while(_in)
             {
@@ -1138,7 +1141,7 @@ configure_settings(bool _init)
             }
             if(!_iss.str().empty())
             {
-                LOG_DEBUG("config file '{}': {}", fitr, _iss.str());
+                LOG_DEBUG("config file '{}': {}", expanded_filename, _iss.str());
             }
         }
     }

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -173,7 +173,7 @@ auto cfg_fini_callbacks = std::vector<std::function<void()>>{};
 // Returns true if `path` is a .json file that lacks the top-level TIMEMORY_PROJECT_NAME
 // ("rocprofiler-systems") root object that timemory's cereal reader requires.
 bool
-config_json_missing_expected_root(const std::string& path)
+is_json_without_project_name_root(const std::string& path)
 {
     if(!path.ends_with(".json")) return false;
     std::ifstream ifs{ path };
@@ -1114,7 +1114,7 @@ configure_settings(bool _init)
         auto fitr = settings::format(itr, _config->get_tag());
 
         // Timemory's read() will silently drop JSON config files without proper root
-        if(config_json_missing_expected_root(fitr))
+        if(is_json_without_project_name_root(fitr))
         {
             LOG_CRITICAL("Config file '{}' is missing the expected '{}' root object and "
                          "cannot be loaded. If this is a hierarchical preset "

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -175,7 +175,7 @@ auto cfg_fini_callbacks = std::vector<std::function<void()>>{};
 bool
 config_json_missing_expected_root(const std::string& path)
 {
-    if(path.find(".json") == std::string::npos) return false;
+    if(!path.ends_with(".json")) return false;
     std::ifstream ifs{ path };
     if(!ifs.is_open()) return false;
     try

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -1113,13 +1113,14 @@ configure_settings(bool _init)
 
         auto fitr = settings::format(itr, _config->get_tag());
 
-        // Timemory's read() silently drops JSON config files without proper root
-        if(_main_proc && config_json_missing_expected_root(fitr))
+        // Timemory's read() will silently drop JSON config files without proper root
+        if(config_json_missing_expected_root(fitr))
         {
-            LOG_WARNING("Config file '{}' is missing the expected '{}' root object and "
-                        "will not be applied. If this is a hierarchical preset "
-                        "configuration, pass it via --preset instead.",
-                        fitr, TIMEMORY_PROJECT_NAME);
+            LOG_CRITICAL("Config file '{}' is missing the expected '{}' root object and "
+                         "cannot be loaded. If this is a hierarchical preset "
+                         "configuration, pass it via --preset instead.",
+                         fitr, TIMEMORY_PROJECT_NAME);
+            std::exit(EXIT_FAILURE);
         }
 
         LOG_DEBUG("Reading config file {}", itr);

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -180,7 +180,7 @@ json_has_project_name_root(const std::string& json_path)
     }
     try
     {
-        auto json = nlohmann::json::parse(ifs);
+        const auto json = nlohmann::json::parse(ifs);
         return json.is_object() && json.contains(TIMEMORY_PROJECT_NAME);
     } catch(const nlohmann::json::exception&)
     {


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

If hierarchical .json config (preset) file is passed using `--config` cli argument or `ROCPROFSYS_CONFIG_FILE` env var, then it is not parsed correctly, and settings from that file are not applied. This PR fixes this by checking if the provided .json file is hierarchical, and if it is, stops the execution with a message to the user that such files should be passed using `--preset` cli argument.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
AIPROFSYST-483

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

- Should build without errors
- No regression should be observed in existing ctest suite

## Test Result

- Build without errors
- Existing ctest suite passes

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
