### PR TITLE
Add CODEOWNERS entry for `profiler-hub` project

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -65,7 +65,7 @@
 /emulation/mirage/                                                    @atgutier @amd-arosa
 
 # Profilers
-/profilers/profiler-hub                                               @adanalis-amd
+/profilers/profiler-hub                                               @ROCm/rocm-profiler-hub
 
 # Documentation-specific ownership by project (last to take precedence)
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -64,6 +64,9 @@
 /emulation/                                                           @atgutier
 /emulation/mirage/                                                    @atgutier @amd-arosa
 
+# Profilers
+/profilers/profiler-hub                                               @adanalis-amd
+
 # Documentation-specific ownership by project (last to take precedence)
 
 /projects/clr/**/*.md                                                 @ROCm/clr-reviewers @ROCm/lrt-docs-reviewers


### PR DESCRIPTION
## Motivation

Now that it is a part of the `rocm-systems` repo, the ROCm Profiler Hub project should have a defined code owner defined in `.github/CODEOWNERS`.

## Technical Details

- Add `adanalis-amd` as `CODEOWNER` to `profilers/profiler-hub`

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
