### PR TITLE
Add CODEOWNERS file to CI configuration

### DIFF
--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -135,6 +135,7 @@ SKIPPABLE_PATH_PATTERNS = [
     "shared/*/docs/*",
     "shared/*/.gitignore",
     "experimental/python/perfxpert/*",
+    ".github/CODEOWNERS",
     ".github/label*.yml",
     ".github/workflows/labeler.yml",
 ]


### PR DESCRIPTION
## Motivation

I noticed that a change the CODEOWNERS file triggered a whole rebuild of the ROCm stack. This seems wasteful. 

## Technical Details

- Add `.github/CODEOWNERS` to the skippable paths.

## JIRA ID

n / a 

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Create a draft PR onto this branch and verify that build is skipped.

## Test Result

<!-- Briefly summarize test outcomes. -->
--> **Before**: Full build started: https://github.com/ROCm/rocm-systems/actions/runs/26645756526/job/78530954111?pr=6581
--> **After**: Now Skipped: https://github.com/ROCm/rocm-systems/pull/6585

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
