### PR TITLE
[DNM] Add CODEOWNERS entry for profiler-hub

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -65,7 +65,7 @@
 /emulation/mirage/                                                    @atgutier @amd-arosa
 
 # Profilers
-/profilers/profiler-hub                                               @adanalis-amd
+/profilers/profiler-hub                                               @ROCm/rocm-profiler-hub
 
 # Documentation-specific ownership by project (last to take precedence)
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -64,6 +64,9 @@
 /emulation/                                                           @atgutier
 /emulation/mirage/                                                    @atgutier @amd-arosa
 
+# Profilers
+/profilers/profiler-hub                                               @adanalis-amd
+
 # Documentation-specific ownership by project (last to take precedence)
 
 /projects/clr/**/*.md                                                 @ROCm/clr-reviewers @ROCm/lrt-docs-reviewers


### PR DESCRIPTION
Testing workflows. Do not merge. 

Expected: TheROCK CI should **not** trigger.