### PR TITLE
Users/mshanthagit/rocshmem hostipc amo no mpi

### DIFF
--- a/projects/rocshmem/scripts/functional_tests/driver.sh
+++ b/projects/rocshmem/scripts/functional_tests/driver.sh
@@ -466,7 +466,6 @@ TestAMO() {
 
   ExecTest  "amo_xor"          2       1            1
 
-  # JIRA-419: host-side AMO/fence/quiet in non-MPI IPC mode
   ExecTest  "host_amo_fadd"        2       1            1
   ExecTest  "host_amo_fcswap"      2       1            1
   ExecTest  "host_amo_fence_quiet" 2       1            1

--- a/projects/rocshmem/scripts/functional_tests/driver.sh
+++ b/projects/rocshmem/scripts/functional_tests/driver.sh
@@ -136,6 +136,9 @@ declare -A TEST_NUMBERS=(
   ["fence_putlargesmall"]="100"
   ["fence_fanout"]="101"
   ["fence_putwavenbichunks"]="102"
+  ["host_amo_fadd"]="103"
+  ["host_amo_fcswap"]="104"
+  ["host_amo_fence_quiet"]="105"
 )
 
 ExecTest() {
@@ -462,6 +465,11 @@ TestAMO() {
   ExecTest  "amo_fetchand"     2       1            1
 
   ExecTest  "amo_xor"          2       1            1
+
+  # JIRA-419: host-side AMO/fence/quiet in non-MPI IPC mode
+  ExecTest  "host_amo_fadd"        2       1            1
+  ExecTest  "host_amo_fcswap"      2       1            1
+  ExecTest  "host_amo_fence_quiet" 2       1            1
 }
 
 TestSigOps() {

--- a/projects/rocshmem/src/envvar.cpp
+++ b/projects/rocshmem/src/envvar.cpp
@@ -123,7 +123,7 @@ namespace envvar {
       32);
     const var<size_t> max_num_host_contexts("MAX_NUM_HOST_CONTEXTS",
       "Maximum number of host-side communication contexts",
-      8);
+      1);
     const var<size_t> max_num_teams("MAX_NUM_TEAMS",
       "Defines the number of teams an application can use.",
       40);

--- a/projects/rocshmem/src/envvar.cpp
+++ b/projects/rocshmem/src/envvar.cpp
@@ -123,7 +123,7 @@ namespace envvar {
       32);
     const var<size_t> max_num_host_contexts("MAX_NUM_HOST_CONTEXTS",
       "Maximum number of host-side communication contexts",
-      1);
+      8);
     const var<size_t> max_num_teams("MAX_NUM_TEAMS",
       "Defines the number of teams an application can use.",
       40);

--- a/projects/rocshmem/src/host/host.cpp
+++ b/projects/rocshmem/src/host/host.cpp
@@ -32,7 +32,9 @@
 #include "util.hpp"
 #include "log.hpp"
 
+#include <atomic>
 #include <cassert>
+#include <cstring>
 
 namespace rocshmem {
 
@@ -159,6 +161,12 @@ __host__ HostInterface::HostInterface(HdpPolicy* hdp_policy,
    */
   hdp_policy_ = hdp_policy;
 
+  /* Fine-grain staging buffer: GPU kernel writes the AMO result here;
+   * CPU reads it directly after hipDeviceSynchronize (no hipMemcpy needed). */
+  CHECK_HIP(hipExtMallocWithFlags(reinterpret_cast<void**>(&ipc_staging_buf_),
+                                  sizeof(uint64_t),
+                                  hipDeviceMallocFinegrained));
+
   /*
    * Allocate and initialize pool of windows for contexts
    */
@@ -194,6 +202,10 @@ __host__ HostInterface::~HostInterface() {
 
   if (host_comm_world_ != MPI_COMM_NULL) {
     mpilib_ftable_.Comm_free(&host_comm_world_);
+  }
+
+  if (ipc_staging_buf_ != nullptr) {
+    CHECK_HIP(hipFree(ipc_staging_buf_));
   }
 }
 
@@ -250,7 +262,11 @@ __host__ void HostInterface::getmem(void* dest, const void* source,
 __host__ void HostInterface::fence(WindowInfo* window_info) {
   WindowInfoMPI* window_info_mpi = dynamic_cast<WindowInfoMPI*>(window_info);
   if (!window_info_mpi) {
-    abort();
+    // IPC non-MPI: no MPI window to drain. HDP flush + CPU memory fence
+    // provide the same ordering guarantee for fine-grain shared memory.
+    hdp_policy_->hdp_flush();
+    std::atomic_thread_fence(std::memory_order_seq_cst);
+    return;
   }
   complete_all(window_info_mpi->get_win());
 
@@ -272,7 +288,11 @@ __host__ void HostInterface::fence(WindowInfo* window_info) {
 __host__ void HostInterface::quiet(WindowInfo* window_info) {
   WindowInfoMPI* window_info_mpi = dynamic_cast<WindowInfoMPI*>(window_info);
   if (!window_info_mpi) {
-    abort();
+    // IPC non-MPI: all host ops (memcpy/atomics) complete synchronously,
+    // so only a HDP flush and CPU fence are needed.
+    hdp_policy_->hdp_flush();
+    std::atomic_thread_fence(std::memory_order_seq_cst);
+    return;
   }
   complete_all(window_info_mpi->get_win());
 
@@ -476,6 +496,77 @@ __host__ void HostInterface::barrier_for_sync() {
   } else {
     host_bootstrap_->barrier();
   }
+}
+
+// ---------------------------------------------------------------------------
+// IPC non-MPI AMO kernels
+//
+// dst may be an IPC-mapped device address, which the CPU cannot access
+// directly. These single-thread kernels run on the GPU where the IPC mapping
+// is valid, perform the atomic, and write the old value to a fine-grain
+// staging buffer that the CPU can read after hipDeviceSynchronize().
+// ---------------------------------------------------------------------------
+
+__global__ static void ipc_amo_fetch_add_32_kernel(uint32_t* dst,
+                                                   uint32_t val,
+                                                   uint32_t* result) {
+  *result = atomicAdd(dst, val);
+}
+
+__global__ static void ipc_amo_fetch_add_64_kernel(unsigned long long* dst,
+                                                   unsigned long long val,
+                                                   unsigned long long* result) {
+  *result = atomicAdd(dst, val);
+}
+
+__global__ static void ipc_amo_fetch_cas_32_kernel(uint32_t* dst,
+                                                   uint32_t cond,
+                                                   uint32_t val,
+                                                   uint32_t* result) {
+  *result = atomicCAS(dst, cond, val);
+}
+
+__global__ static void ipc_amo_fetch_cas_64_kernel(unsigned long long* dst,
+                                                   unsigned long long cond,
+                                                   unsigned long long val,
+                                                   unsigned long long* result) {
+  *result = atomicCAS(dst, cond, val);
+}
+
+__host__ uint64_t HostInterface::ipc_amo_fetch_add(void* dst,
+                                                   uint64_t val,
+                                                   bool is_32bit) {
+  if (is_32bit) {
+    uint32_t u_val = static_cast<uint32_t>(val);
+    ipc_amo_fetch_add_32_kernel<<<1, 1>>>(reinterpret_cast<uint32_t*>(dst),
+                                          u_val,
+                                          reinterpret_cast<uint32_t*>(ipc_staging_buf_));
+  } else {
+    ipc_amo_fetch_add_64_kernel<<<1, 1>>>(reinterpret_cast<unsigned long long*>(dst),
+                                          static_cast<unsigned long long>(val),
+                                          reinterpret_cast<unsigned long long*>(ipc_staging_buf_));
+  }
+  CHECK_HIP(hipDeviceSynchronize());
+  return *ipc_staging_buf_;
+}
+
+__host__ uint64_t HostInterface::ipc_amo_fetch_cas(void* dst,
+                                                   uint64_t cond,
+                                                   uint64_t val,
+                                                   bool is_32bit) {
+  if (is_32bit) {
+    ipc_amo_fetch_cas_32_kernel<<<1, 1>>>(reinterpret_cast<uint32_t*>(dst),
+                                          static_cast<uint32_t>(cond),
+                                          static_cast<uint32_t>(val),
+                                          reinterpret_cast<uint32_t*>(ipc_staging_buf_));
+  } else {
+    ipc_amo_fetch_cas_64_kernel<<<1, 1>>>(reinterpret_cast<unsigned long long*>(dst),
+                                          static_cast<unsigned long long>(cond),
+                                          static_cast<unsigned long long>(val),
+                                          reinterpret_cast<unsigned long long*>(ipc_staging_buf_));
+  }
+  CHECK_HIP(hipDeviceSynchronize());
+  return *ipc_staging_buf_;
 }
 
 }  // namespace rocshmem

--- a/projects/rocshmem/src/host/host.cpp
+++ b/projects/rocshmem/src/host/host.cpp
@@ -47,9 +47,15 @@ __host__ HostContextWindowInfo::HostContextWindowInfo(MPI_Comm comm_world,
 __host__ HostContextWindowInfo::HostContextWindowInfo(SymmetricHeap* heap) {
   window_info_ =
       new WindowInfo(heap->get_local_heap_base(), heap->get_size());
+  CHECK_HIP(hipExtMallocWithFlags(
+      reinterpret_cast<void**>(&window_info_->ipc_staging_buf_),
+      sizeof(uint64_t), hipDeviceMallocFinegrained));
 }
 
 __host__ HostContextWindowInfo::~HostContextWindowInfo() {
+  if (window_info_->ipc_staging_buf_ != nullptr) {
+    CHECK_HIP(hipFree(window_info_->ipc_staging_buf_));
+  }
   delete window_info_;
 }
 
@@ -161,12 +167,6 @@ __host__ HostInterface::HostInterface(HdpPolicy* hdp_policy,
    */
   hdp_policy_ = hdp_policy;
 
-  /* Fine-grain staging buffer: GPU kernel writes the AMO result here;
-   * CPU reads it directly after hipDeviceSynchronize (no hipMemcpy needed). */
-  CHECK_HIP(hipExtMallocWithFlags(reinterpret_cast<void**>(&ipc_staging_buf_),
-                                  sizeof(uint64_t),
-                                  hipDeviceMallocFinegrained));
-
   /*
    * Allocate and initialize pool of windows for contexts
    */
@@ -204,9 +204,6 @@ __host__ HostInterface::~HostInterface() {
     mpilib_ftable_.Comm_free(&host_comm_world_);
   }
 
-  if (ipc_staging_buf_ != nullptr) {
-    CHECK_HIP(hipFree(ipc_staging_buf_));
-  }
 }
 
 __host__ void HostInterface::putmem_nbi(void* dest, const void* source,
@@ -535,38 +532,40 @@ __global__ static void ipc_amo_fetch_cas_64_kernel(unsigned long long* dst,
 
 __host__ uint64_t HostInterface::ipc_amo_fetch_add(void* dst,
                                                    uint64_t val,
-                                                   bool is_32bit) {
+                                                   bool is_32bit,
+                                                   uint64_t* staging_buf) {
   if (is_32bit) {
     uint32_t u_val = static_cast<uint32_t>(val);
     ipc_amo_fetch_add_32_kernel<<<1, 1>>>(reinterpret_cast<uint32_t*>(dst),
                                           u_val,
-                                          reinterpret_cast<uint32_t*>(ipc_staging_buf_));
+                                          reinterpret_cast<uint32_t*>(staging_buf));
   } else {
     ipc_amo_fetch_add_64_kernel<<<1, 1>>>(reinterpret_cast<unsigned long long*>(dst),
                                           static_cast<unsigned long long>(val),
-                                          reinterpret_cast<unsigned long long*>(ipc_staging_buf_));
+                                          reinterpret_cast<unsigned long long*>(staging_buf));
   }
   CHECK_HIP(hipDeviceSynchronize());
-  return *ipc_staging_buf_;
+  return *staging_buf;
 }
 
 __host__ uint64_t HostInterface::ipc_amo_fetch_cas(void* dst,
                                                    uint64_t cond,
                                                    uint64_t val,
-                                                   bool is_32bit) {
+                                                   bool is_32bit,
+                                                   uint64_t* staging_buf) {
   if (is_32bit) {
     ipc_amo_fetch_cas_32_kernel<<<1, 1>>>(reinterpret_cast<uint32_t*>(dst),
                                           static_cast<uint32_t>(cond),
                                           static_cast<uint32_t>(val),
-                                          reinterpret_cast<uint32_t*>(ipc_staging_buf_));
+                                          reinterpret_cast<uint32_t*>(staging_buf));
   } else {
     ipc_amo_fetch_cas_64_kernel<<<1, 1>>>(reinterpret_cast<unsigned long long*>(dst),
                                           static_cast<unsigned long long>(cond),
                                           static_cast<unsigned long long>(val),
-                                          reinterpret_cast<unsigned long long*>(ipc_staging_buf_));
+                                          reinterpret_cast<unsigned long long*>(staging_buf));
   }
   CHECK_HIP(hipDeviceSynchronize());
-  return *ipc_staging_buf_;
+  return *staging_buf;
 }
 
 }  // namespace rocshmem

--- a/projects/rocshmem/src/host/host.hpp
+++ b/projects/rocshmem/src/host/host.hpp
@@ -383,6 +383,17 @@ class HostInterface {
    */
   HostContextWindowInfo** host_window_context_pool_{nullptr};
 
+  /**
+   * @brief Fine-grain staging buffer for IPC non-MPI GPU atomic operations.
+   * The GPU kernel writes the old value here; the CPU reads it after sync.
+   * Null in the MPI path (only allocated by the TcpBootstrap constructor).
+   */
+  uint64_t* ipc_staging_buf_{nullptr};
+
+  __host__ uint64_t ipc_amo_fetch_add(void* dst, uint64_t val, bool is_32bit);
+  __host__ uint64_t ipc_amo_fetch_cas(void* dst, uint64_t cond, uint64_t val,
+                                      bool is_32bit);
+
   int find_win_info_in_pool(WindowInfo* window_info);
 
   int find_avail_pool_entry();

--- a/projects/rocshmem/src/host/host.hpp
+++ b/projects/rocshmem/src/host/host.hpp
@@ -383,16 +383,10 @@ class HostInterface {
    */
   HostContextWindowInfo** host_window_context_pool_{nullptr};
 
-  /**
-   * @brief Fine-grain staging buffer for IPC non-MPI GPU atomic operations.
-   * The GPU kernel writes the old value here; the CPU reads it after sync.
-   * Null in the MPI path (only allocated by the TcpBootstrap constructor).
-   */
-  uint64_t* ipc_staging_buf_{nullptr};
-
-  __host__ uint64_t ipc_amo_fetch_add(void* dst, uint64_t val, bool is_32bit);
+  __host__ uint64_t ipc_amo_fetch_add(void* dst, uint64_t val, bool is_32bit,
+                                      uint64_t* staging_buf);
   __host__ uint64_t ipc_amo_fetch_cas(void* dst, uint64_t cond, uint64_t val,
-                                      bool is_32bit);
+                                      bool is_32bit, uint64_t* staging_buf);
 
   int find_win_info_in_pool(WindowInfo* window_info);
 

--- a/projects/rocshmem/src/host/host_templates.hpp
+++ b/projects/rocshmem/src/host/host_templates.hpp
@@ -335,7 +335,8 @@ __host__ T HostInterface::amo_fetch_add(void* dst, T value, int pe,
     hdp_policy_->hdp_flush();
     uint64_t u_val{}, u_ret{};
     std::memcpy(&u_val, &value, sizeof(T));
-    u_ret = ipc_amo_fetch_add(dst, u_val, sizeof(T) == 4);
+    u_ret = ipc_amo_fetch_add(dst, u_val, sizeof(T) == 4,
+                               window_info->get_ipc_staging_buf());
     T ret{};
     std::memcpy(&ret, &u_ret, sizeof(T));
     return ret;
@@ -374,7 +375,8 @@ __host__ T HostInterface::amo_fetch_cas(void* dst, T value, T cond, int pe,
     uint64_t u_val{}, u_cond{}, u_ret{};
     std::memcpy(&u_val, &value, sizeof(T));
     std::memcpy(&u_cond, &cond, sizeof(T));
-    u_ret = ipc_amo_fetch_cas(dst, u_cond, u_val, sizeof(T) == 4);
+    u_ret = ipc_amo_fetch_cas(dst, u_cond, u_val, sizeof(T) == 4,
+                               window_info->get_ipc_staging_buf());
     T ret{};
     std::memcpy(&ret, &u_ret, sizeof(T));
     return ret;

--- a/projects/rocshmem/src/host/host_templates.hpp
+++ b/projects/rocshmem/src/host/host_templates.hpp
@@ -31,10 +31,43 @@
 #include "memory/window_info.hpp"
 #include "team.hpp"
 
-#include <utility>
+#include <atomic>
 #include <cassert>
+#include <cstdint>
+#include <cstring>
+#include <utility>
 
 namespace rocshmem {
+
+// __atomic_load_n rejects float/double pointer arguments. Type-pun through a
+// same-sized unsigned integer so the builtin accepts it while preserving the
+// requested memory order and generating identical machine code.
+template <typename T>
+static T atomic_load_any(T* src, int order) {
+  static_assert(sizeof(T) == 1 || sizeof(T) == 2 ||
+                sizeof(T) == 4 || sizeof(T) == 8, "unsupported type width");
+  if constexpr (sizeof(T) == 1) {
+    uint8_t raw = __atomic_load_n(reinterpret_cast<uint8_t*>(src), order);
+    T result;
+    std::memcpy(&result, &raw, sizeof(T));
+    return result;
+  } else if constexpr (sizeof(T) == 2) {
+    uint16_t raw = __atomic_load_n(reinterpret_cast<uint16_t*>(src), order);
+    T result;
+    std::memcpy(&result, &raw, sizeof(T));
+    return result;
+  } else if constexpr (sizeof(T) == 4) {
+    uint32_t raw = __atomic_load_n(reinterpret_cast<uint32_t*>(src), order);
+    T result;
+    std::memcpy(&result, &raw, sizeof(T));
+    return result;
+  } else {
+    uint64_t raw = __atomic_load_n(reinterpret_cast<uint64_t*>(src), order);
+    T result;
+    std::memcpy(&result, &raw, sizeof(T));
+    return result;
+  }
+}
 
 template <typename T>
 __host__ void HostInterface::p(T* dest, T value, int pe,
@@ -296,7 +329,16 @@ __host__ T HostInterface::amo_fetch_add(void* dst, T value, int pe,
                                         WindowInfo* window_info) {
   WindowInfoMPI* window_info_mpi = dynamic_cast<WindowInfoMPI*>(window_info);
   if (!window_info_mpi) {
-    abort();
+    // IPC non-MPI: dst may be an IPC-mapped device address (not CPU-accessible).
+    // Delegate to a single-thread GPU kernel that performs the atomic and writes
+    // the old value to a fine-grain staging buffer the CPU can read after sync.
+    hdp_policy_->hdp_flush();
+    uint64_t u_val{}, u_ret{};
+    std::memcpy(&u_val, &value, sizeof(T));
+    u_ret = ipc_amo_fetch_add(dst, u_val, sizeof(T) == 4);
+    T ret{};
+    std::memcpy(&ret, &u_ret, sizeof(T));
+    return ret;
   }
 
   /* Calculate offset of remote dest from base address of window */
@@ -325,7 +367,17 @@ __host__ T HostInterface::amo_fetch_cas(void* dst, T value, T cond, int pe,
                                         WindowInfo* window_info) {
   WindowInfoMPI* window_info_mpi = dynamic_cast<WindowInfoMPI*>(window_info);
   if (!window_info_mpi) {
-    abort();
+    // IPC non-MPI: dst may be an IPC-mapped device address (not CPU-accessible).
+    // Delegate to a single-thread GPU kernel that performs the CAS and writes
+    // the old value to a fine-grain staging buffer the CPU can read after sync.
+    hdp_policy_->hdp_flush();
+    uint64_t u_val{}, u_cond{}, u_ret{};
+    std::memcpy(&u_val, &value, sizeof(T));
+    std::memcpy(&u_cond, &cond, sizeof(T));
+    u_ret = ipc_amo_fetch_cas(dst, u_cond, u_val, sizeof(T) == 4);
+    T ret{};
+    std::memcpy(&ret, &u_ret, sizeof(T));
+    return ret;
   }
 
   /* Calculate offset of remote dest from base address of window */
@@ -468,10 +520,17 @@ template <typename T>
 __host__ void HostInterface::wait_until(T *ivars, int cmp, T val,
                                         WindowInfo* window_info) {
   WindowInfoMPI* window_info_mpi = dynamic_cast<WindowInfoMPI*>(window_info);
-  if (!window_info_mpi) {
-    abort();
-  }
   LOG_API("host::wait_until (ivars=%p, cmp=%d)", ivars, cmp);
+  if (!window_info_mpi) {
+    // IPC non-MPI: ivars is CPU-accessible fine-grain memory; spin with a
+    // plain atomic load until the condition is satisfied.
+    while (1) {
+      hdp_policy_->hdp_flush();
+      T fetched = atomic_load_any(ivars, __ATOMIC_SEQ_CST);
+      if (compare(cmp, fetched, val)) break;
+    }
+    return;
+  }
 
   /*
    * Find the offset of this memory in the window
@@ -725,10 +784,13 @@ template <typename T>
 __host__ int HostInterface::test(T* ivars, int cmp, T val,
                                  WindowInfo* window_info) {
   WindowInfoMPI* window_info_mpi = dynamic_cast<WindowInfoMPI*>(window_info);
-  if (!window_info_mpi) {
-    abort();
-  }
   LOG_API("host::test (ivars=%p, cmp=%d)", ivars, cmp);
+  if (!window_info_mpi) {
+    // IPC non-MPI: ivars is CPU-accessible fine-grain memory.
+    hdp_policy_->hdp_flush();
+    T fetched = atomic_load_any(ivars, __ATOMIC_SEQ_CST);
+    return compare(cmp, fetched, val);
+  }
 
   /*
    * Find the offset of this memory in the window

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_host.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_host.hpp
@@ -62,22 +62,26 @@ __host__ void IPCHostContext::get_nbi(T *dest, const T *source, size_t nelems, i
 
 template <typename T>
 __host__ void IPCHostContext::amo_add(void *dst, T value, int pe) {
-  host_interface->amo_add(shmem_ptr(dst, pe), value, pe, context_window_info);
+  bool is_mpi = dynamic_cast<WindowInfoMPI*>(context_window_info) != nullptr;
+  host_interface->amo_add(is_mpi ? dst : shmem_ptr(dst, pe), value, pe, context_window_info);
 }
 
 template <typename T>
 __host__ void IPCHostContext::amo_cas(void *dst, T value, T cond, int pe) {
-  host_interface->amo_cas(shmem_ptr(dst, pe), value, cond, pe, context_window_info);
+  bool is_mpi = dynamic_cast<WindowInfoMPI*>(context_window_info) != nullptr;
+  host_interface->amo_cas(is_mpi ? dst : shmem_ptr(dst, pe), value, cond, pe, context_window_info);
 }
 
 template <typename T>
 __host__ T IPCHostContext::amo_fetch_add(void *dst, T value, int pe) {
-  return host_interface->amo_fetch_add(shmem_ptr(dst, pe), value, pe, context_window_info);
+  bool is_mpi = dynamic_cast<WindowInfoMPI*>(context_window_info) != nullptr;
+  return host_interface->amo_fetch_add(is_mpi ? dst : shmem_ptr(dst, pe), value, pe, context_window_info);
 }
 
 template <typename T>
 __host__ T IPCHostContext::amo_fetch_cas(void *dst, T value, T cond, int pe) {
-  return host_interface->amo_fetch_cas(shmem_ptr(dst, pe), value, cond, pe, context_window_info);
+  bool is_mpi = dynamic_cast<WindowInfoMPI*>(context_window_info) != nullptr;
+  return host_interface->amo_fetch_cas(is_mpi ? dst : shmem_ptr(dst, pe), value, cond, pe, context_window_info);
 }
 
 template <typename T>

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_host.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_host.hpp
@@ -62,22 +62,22 @@ __host__ void IPCHostContext::get_nbi(T *dest, const T *source, size_t nelems, i
 
 template <typename T>
 __host__ void IPCHostContext::amo_add(void *dst, T value, int pe) {
-  host_interface->amo_add(dst, value, pe, context_window_info);
+  host_interface->amo_add(shmem_ptr(dst, pe), value, pe, context_window_info);
 }
 
 template <typename T>
 __host__ void IPCHostContext::amo_cas(void *dst, T value, T cond, int pe) {
-  host_interface->amo_cas(dst, value, cond, pe, context_window_info);
+  host_interface->amo_cas(shmem_ptr(dst, pe), value, cond, pe, context_window_info);
 }
 
 template <typename T>
 __host__ T IPCHostContext::amo_fetch_add(void *dst, T value, int pe) {
-  return host_interface->amo_fetch_add(dst, value, pe, context_window_info);
+  return host_interface->amo_fetch_add(shmem_ptr(dst, pe), value, pe, context_window_info);
 }
 
 template <typename T>
 __host__ T IPCHostContext::amo_fetch_cas(void *dst, T value, T cond, int pe) {
-  return host_interface->amo_fetch_cas(dst, value, cond, pe, context_window_info);
+  return host_interface->amo_fetch_cas(shmem_ptr(dst, pe), value, cond, pe, context_window_info);
 }
 
 template <typename T>

--- a/projects/rocshmem/src/memory/window_info.hpp
+++ b/projects/rocshmem/src/memory/window_info.hpp
@@ -125,6 +125,15 @@ class WindowInfo {
     return reinterpret_cast<ptrdiff_t>(reinterpret_cast<char*>(const_cast<void*>(dest)) - reinterpret_cast<char*>(win_start_));
   }
 
+ /**
+  * @brief Per-context staging buffer for IPC non-MPI GPU atomic operations.
+  * Allocated by HostContextWindowInfo for the non-MPI path; null otherwise.
+  * Each context owns its own staging buffer to avoid races between contexts.
+  */
+  uint64_t* ipc_staging_buf_{nullptr};
+
+  uint64_t* get_ipc_staging_buf() const { return ipc_staging_buf_; }
+
  protected:
   /**
    * @brief Raw pointer marking the start of window

--- a/projects/rocshmem/tests/functional_tests/CMakeLists.txt
+++ b/projects/rocshmem/tests/functional_tests/CMakeLists.txt
@@ -71,6 +71,7 @@ target_sources(
     device_bitcode_tester.cpp
     library_info_tester.cpp
     fence_ordering_tester.cpp
+    host_amo_tester.cpp
 )
 
 ###############################################################################

--- a/projects/rocshmem/tests/functional_tests/host_amo_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/host_amo_tester.cpp
@@ -44,36 +44,28 @@ void HostAMOTester::execute() {
   resetBuffers(sizeof(int));
   rocshmem_barrier_all();
 
-  rocshmem_ctx_t ctx;
-  rocshmem_ctx_create(0, &ctx);
-
   auto wall_start = std::chrono::high_resolution_clock::now();
 
   if (myid == 0) {
     for (int i = 0; i < num_loops + args.skip; i++) {
       switch (_type) {
         case HostAMOFAddTestType:
-          // PE 0 atomically adds 1 to PE 1's dest_
-          rocshmem_ctx_int_atomic_fetch_add(ctx, dest_, 1, /*pe=*/1);
+          rocshmem_int_atomic_fetch_add(dest_, 1, /*pe=*/1);
           break;
         case HostAMOFCswapTestType:
-          // PE 0 CAS: swap dest_ from i to i+1; succeeds each loop
-          rocshmem_ctx_int_atomic_compare_swap(ctx, dest_, i, i + 1, /*pe=*/1);
+          rocshmem_int_atomic_compare_swap(dest_, i, i + 1, /*pe=*/1);
           break;
         case HostAMOFenceQuietTestType:
-          // Verify fence and quiet do not crash in non-MPI IPC mode
-          rocshmem_ctx_int_atomic_fetch_add(ctx, dest_, 1, /*pe=*/1);
-          rocshmem_ctx_fence(ctx);
-          rocshmem_ctx_quiet(ctx);
+          rocshmem_int_atomic_fetch_add(dest_, 1, /*pe=*/1);
+          rocshmem_fence();
+          rocshmem_quiet();
           break;
         default:
           break;
       }
     }
-    rocshmem_ctx_quiet(ctx);
+    rocshmem_quiet();
   }
-
-  rocshmem_ctx_destroy(ctx);
 
   rocshmem_barrier_all();
 
@@ -97,7 +89,6 @@ void HostAMOTester::verifyResults([[maybe_unused]] uint64_t size) {
 
   if (myid != 1) return;
 
-  // All three test types perform (num_loops + args.skip) additions of 1 to dest_ on PE 1
   int expected = num_loops + args.skip;
 
   if (*dest_ != expected) {

--- a/projects/rocshmem/tests/functional_tests/host_amo_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/host_amo_tester.cpp
@@ -1,0 +1,109 @@
+/******************************************************************************
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *****************************************************************************/
+
+#include "host_amo_tester.hpp"
+
+#include <chrono>
+#include <iostream>
+#include <rocshmem/rocshmem.hpp>
+
+using namespace rocshmem;
+
+/******************************************************************************
+ * HOST TESTER CLASS METHODS
+ *****************************************************************************/
+
+HostAMOTester::HostAMOTester(TesterArguments args) : Tester(args) {
+  dest_ = (int*)rocshmem_malloc(sizeof(int));
+}
+
+HostAMOTester::~HostAMOTester() {
+  rocshmem_free(dest_);
+}
+
+void HostAMOTester::resetBuffers([[maybe_unused]] uint64_t size) {
+  *dest_ = 0;
+}
+
+void HostAMOTester::execute() {
+  int myid  = args.myid;
+  int n_pes = args.numprocs;
+
+  if (n_pes < 2) {
+    if (myid == 0)
+      std::cerr << "HostAMOTester requires at least 2 PEs\n";
+    return;
+  }
+
+  _print_results = (myid == 0);
+  num_loops = args.loop;
+
+  resetBuffers(sizeof(int));
+  rocshmem_barrier_all();
+
+  rocshmem_ctx_t ctx;
+  rocshmem_ctx_create(0, &ctx);
+
+  auto wall_start = std::chrono::high_resolution_clock::now();
+
+  if (myid == 0) {
+    for (int i = 0; i < num_loops + args.skip; i++) {
+      switch (_type) {
+        case HostAMOFAddTestType:
+          // PE 0 atomically adds 1 to PE 1's dest_
+          rocshmem_ctx_int_atomic_fetch_add(ctx, dest_, 1, /*pe=*/1);
+          break;
+        case HostAMOFCswapTestType:
+          // PE 0 CAS: swap dest_ from i to i+1; succeeds each loop
+          rocshmem_ctx_int_atomic_compare_swap(ctx, dest_, i, i + 1, /*pe=*/1);
+          break;
+        case HostAMOFenceQuietTestType:
+          // Verify fence and quiet do not crash in non-MPI IPC mode
+          rocshmem_ctx_int_atomic_fetch_add(ctx, dest_, 1, /*pe=*/1);
+          rocshmem_ctx_fence(ctx);
+          rocshmem_ctx_quiet(ctx);
+          break;
+        default:
+          break;
+      }
+    }
+    rocshmem_ctx_quiet(ctx);
+  }
+
+  rocshmem_ctx_destroy(ctx);
+
+  rocshmem_barrier_all();
+
+  auto wall_end = std::chrono::high_resolution_clock::now();
+  double elapsed_us =
+      std::chrono::duration<double, std::micro>(wall_end - wall_start).count();
+
+  if (args.verif)
+    verifyResults(sizeof(int));
+
+  rocshmem_barrier_all();
+
+  if (myid == 0) {
+    double latency = elapsed_us / num_loops;
+    std::cout << "### HostAMO avg latency per op: " << latency << " us ###\n";
+  }
+}
+
+void HostAMOTester::verifyResults([[maybe_unused]] uint64_t size) {
+  int myid = args.myid;
+
+  if (myid != 1) return;
+
+  // All three test types perform (num_loops + args.skip) additions of 1 to dest_ on PE 1
+  int expected = num_loops + args.skip;
+
+  if (*dest_ != expected) {
+    std::cerr << "PE 1 VERIFY FAILED: dest_=" << *dest_
+              << " expected=" << expected << "\n";
+    *verification_error = true;
+    exit(1);
+  }
+}

--- a/projects/rocshmem/tests/functional_tests/host_amo_tester.hpp
+++ b/projects/rocshmem/tests/functional_tests/host_amo_tester.hpp
@@ -12,9 +12,9 @@
 /**
  * @file host_amo_tester.hpp
  *
- * Functional tests for host-side AMO, fence, and quiet in IPC non-MPI mode
- * (JIRA-419). Unlike all other functional testers, these call the host API
- * directly from the CPU — no GPU kernel is launched.
+ * Functional tests for host-side AMO, fence, and quiet in IPC non-MPI mode.
+ * Unlike all other functional testers, these call the host API directly from
+ * the CPU — no GPU kernel is launched.
  *
  * Test coverage:
  *   HostAMOFAdd    — rocshmem_ctx_int_atomic_fetch_add via default context

--- a/projects/rocshmem/tests/functional_tests/host_amo_tester.hpp
+++ b/projects/rocshmem/tests/functional_tests/host_amo_tester.hpp
@@ -1,0 +1,45 @@
+/******************************************************************************
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *****************************************************************************/
+
+#ifndef _HOST_AMO_TESTER_HPP_
+#define _HOST_AMO_TESTER_HPP_
+
+#include "tester.hpp"
+
+/**
+ * @file host_amo_tester.hpp
+ *
+ * Functional tests for host-side AMO, fence, and quiet in IPC non-MPI mode
+ * (JIRA-419). Unlike all other functional testers, these call the host API
+ * directly from the CPU — no GPU kernel is launched.
+ *
+ * Test coverage:
+ *   HostAMOFAdd    — rocshmem_ctx_int_atomic_fetch_add via default context
+ *   HostAMOFCswap  — rocshmem_ctx_int_atomic_compare_swap via default context
+ *   HostAMOFenceQuiet — rocshmem_ctx_fence + rocshmem_ctx_quiet do not crash
+ */
+class HostAMOTester : public Tester {
+ public:
+  explicit HostAMOTester(TesterArguments args);
+  virtual ~HostAMOTester();
+
+  // Override execute() entirely: no GPU kernel, CPU-side timing.
+  void execute() override;
+
+ protected:
+  void resetBuffers(uint64_t size) override;
+
+  // Not used — execute() is overridden and drives the test directly.
+  void launchKernel(dim3 gridSize, dim3 blockSize, int loop,
+                    uint64_t size) override {}
+
+  void verifyResults(uint64_t size) override;
+
+ private:
+  int* dest_{nullptr};   // symmetric int buffer; PE 0 targets PE 1's copy
+};
+
+#endif  // _HOST_AMO_TESTER_HPP_

--- a/projects/rocshmem/tests/functional_tests/tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/tester.cpp
@@ -652,15 +652,15 @@ std::vector<Tester*> Tester::create(TesterArguments args) {
       testers.push_back(new FenceOrderingTester(args));
       break;
     case HostAMOFAddTestType:
-      test_name = "Host AMO Fetch-Add (JIRA-419)";
+      test_name = "Host AMO Fetch-Add";
       testers.push_back(new HostAMOTester(args));
       break;
     case HostAMOFCswapTestType:
-      test_name = "Host AMO Fetch-CAS (JIRA-419)";
+      test_name = "Host AMO Fetch-CAS";
       testers.push_back(new HostAMOTester(args));
       break;
     case HostAMOFenceQuietTestType:
-      test_name = "Host AMO Fence+Quiet (JIRA-419)";
+      test_name = "Host AMO Fence+Quiet";
       testers.push_back(new HostAMOTester(args));
       break;
     default:

--- a/projects/rocshmem/tests/functional_tests/tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/tester.cpp
@@ -71,6 +71,7 @@
 #include "device_bitcode_tester.hpp"
 #include "library_info_tester.hpp"
 #include "fence_ordering_tester.hpp"
+#include "host_amo_tester.hpp"
 
 #include "backend_bc.hpp"
 extern Backend* backend;
@@ -649,6 +650,18 @@ std::vector<Tester*> Tester::create(TesterArguments args) {
     case FenceOrderPutWaveNbiChunksTestType:
       test_name = "Fence PutWaveNbiChunks Ordering";
       testers.push_back(new FenceOrderingTester(args));
+      break;
+    case HostAMOFAddTestType:
+      test_name = "Host AMO Fetch-Add (JIRA-419)";
+      testers.push_back(new HostAMOTester(args));
+      break;
+    case HostAMOFCswapTestType:
+      test_name = "Host AMO Fetch-CAS (JIRA-419)";
+      testers.push_back(new HostAMOTester(args));
+      break;
+    case HostAMOFenceQuietTestType:
+      test_name = "Host AMO Fence+Quiet (JIRA-419)";
+      testers.push_back(new HostAMOTester(args));
       break;
     default:
       test_name = "Empty";

--- a/projects/rocshmem/tests/functional_tests/tester.hpp
+++ b/projects/rocshmem/tests/functional_tests/tester.hpp
@@ -144,7 +144,10 @@
   X(FenceOrderPutWaveSignal,   99)  \
   X(FenceOrderPutLargeSmall,   100) \
   X(FenceOrderFanout,          101) \
-  X(FenceOrderPutWaveNbiChunks, 102)
+  X(FenceOrderPutWaveNbiChunks, 102) \
+  X(HostAMOFAdd,               103) \
+  X(HostAMOFCswap,             104) \
+  X(HostAMOFenceQuiet,         105)
 
 #define _ROCSHMEM_ENUM_ENTRY(name, val) name##TestType = val,
 enum TestType {

--- a/projects/rocshmem/tests/functional_tests/tester_arguments.cpp
+++ b/projects/rocshmem/tests/functional_tests/tester_arguments.cpp
@@ -313,6 +313,9 @@ void TesterArguments::get_arguments() {
     case DeviceBitcodeTestType:
     case TeamCtxSharedInfraTestType:
     case FenceOrderFanoutTestType:
+    case HostAMOFAddTestType:
+    case HostAMOFCswapTestType:
+    case HostAMOFenceQuietTestType:
       requires_two_pes = false;
       break;
     default:

--- a/projects/rocshmem/tests/unit_tests/CMakeLists.txt
+++ b/projects/rocshmem/tests/unit_tests/CMakeLists.txt
@@ -74,13 +74,6 @@ if (USE_IPC)
   )
 endif()
 
-# Pass -DJIRA_419_FIXED=1 at cmake time to compile the post-fix functional
-# tests instead of the pre-fix death tests.
-if (JIRA_419_FIXED)
-  target_compile_definitions(${PROJECT_NAME} PRIVATE JIRA_419_FIXED)
-endif()
-
-
 if (USE_GDA)
   target_sources(
     ${PROJECT_NAME}

--- a/projects/rocshmem/tests/unit_tests/CMakeLists.txt
+++ b/projects/rocshmem/tests/unit_tests/CMakeLists.txt
@@ -70,7 +70,14 @@ if (USE_IPC)
       ipc_impl_simple_coarse_gtest.cpp
       ipc_impl_simple_fine_gtest.cpp
       ipc_impl_tiled_fine_gtest.cpp
+      ipc_host_amo_gtest.cpp
   )
+endif()
+
+# Pass -DJIRA_419_FIXED=1 at cmake time to compile the post-fix functional
+# tests instead of the pre-fix death tests.
+if (JIRA_419_FIXED)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE JIRA_419_FIXED)
 endif()
 
 

--- a/projects/rocshmem/tests/unit_tests/ipc_host_amo_gtest.cpp
+++ b/projects/rocshmem/tests/unit_tests/ipc_host_amo_gtest.cpp
@@ -227,12 +227,9 @@ TEST_F(IPCHostAMOFixture, PostFix_amo_fetch_add_remote) {
 
     int old_val = -1;
     if (my_pe_ == 0) {
-        // Translate PE 1's slot into PE 0's address space.
-        int* pe1_slot = reinterpret_cast<int*>(to_remote_ptr(local_slot, /*pe=*/1));
-        old_val = host_interface_->amo_fetch_add(static_cast<void*>(pe1_slot),
-                                                 kAddend,
-                                                 /*pe=*/1,
-                                                 context_window_info_);
+        // Pass local_slot directly — ctx_amo_fetch_add replicates
+        // IPCHostContext::amo_fetch_add and calls shmem_ptr internally.
+        old_val = ctx_amo_fetch_add(static_cast<void*>(local_slot), kAddend, /*pe=*/1);
         EXPECT_EQ(old_val, kInitial);
     }
     MPI_Barrier(MPI_COMM_WORLD);
@@ -261,12 +258,10 @@ TEST_F(IPCHostAMOFixture, PostFix_amo_fetch_cas_success) {
     MPI_Barrier(MPI_COMM_WORLD);
 
     if (my_pe_ == 0) {
-        int* pe1_slot = reinterpret_cast<int*>(to_remote_ptr(local_slot, /*pe=*/1));
-        int old = host_interface_->amo_fetch_cas(static_cast<void*>(pe1_slot),
-                                                 /*new_val=*/kNew,
-                                                 /*cond=*/kInitial,
-                                                 /*pe=*/1,
-                                                 context_window_info_);
+        // Pass local_slot directly — ctx_amo_fetch_cas replicates
+        // IPCHostContext::amo_fetch_cas and calls shmem_ptr internally.
+        int old = ctx_amo_fetch_cas(static_cast<void*>(local_slot),
+                                    /*value=*/kNew, /*cond=*/kInitial, /*pe=*/1);
         EXPECT_EQ(old, kInitial);
     }
     MPI_Barrier(MPI_COMM_WORLD);
@@ -291,12 +286,8 @@ TEST_F(IPCHostAMOFixture, PostFix_amo_fetch_cas_failure) {
     MPI_Barrier(MPI_COMM_WORLD);
 
     if (my_pe_ == 0) {
-        int* pe1_slot = reinterpret_cast<int*>(to_remote_ptr(local_slot, /*pe=*/1));
-        int old = host_interface_->amo_fetch_cas(static_cast<void*>(pe1_slot),
-                                                 kNew,
-                                                 /*cond=*/kWrong,  // won't match
-                                                 /*pe=*/1,
-                                                 context_window_info_);
+        int old = ctx_amo_fetch_cas(static_cast<void*>(local_slot),
+                                    kNew, /*cond=*/kWrong, /*pe=*/1);
         EXPECT_EQ(old, kInitial);  // old value returned unchanged
     }
     MPI_Barrier(MPI_COMM_WORLD);
@@ -403,7 +394,7 @@ TEST_F(IPCHostAMOFixture, PostFix_putmem_remote) {
 
     if (my_pe_ == 0) {
         int src = kValue;
-        int* pe1_slot = reinterpret_cast<int*>(to_remote_ptr(local_slot, /*pe=*/1));
+        int* pe1_slot = reinterpret_cast<int*>(shmem_ptr(local_slot, /*pe=*/1));
         EXPECT_NO_FATAL_FAILURE(
             host_interface_->putmem(static_cast<void*>(pe1_slot),
                                     &src, sizeof(int),

--- a/projects/rocshmem/tests/unit_tests/ipc_host_amo_gtest.cpp
+++ b/projects/rocshmem/tests/unit_tests/ipc_host_amo_gtest.cpp
@@ -1,0 +1,422 @@
+/******************************************************************************
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *****************************************************************************/
+
+/**
+ * @file ipc_host_amo_gtest.cpp
+ *
+ * Unit tests for JIRA-419: host-side AMO, fence, and quiet in IPC non-MPI mode.
+ *
+ * Test structure
+ * --------------
+ * Each test is written in two parts gated by a preprocessor macro:
+ *
+ *   JIRA_419_FIXED not defined  →  EXPECT_DEATH tests confirming the current
+ *                                   abort() behaviour (pre-fix regression tests)
+ *
+ *   JIRA_419_FIXED defined      →  Functional tests that verify correct values
+ *                                   after the fix is applied
+ *
+ * This lets the same source file serve as both "show it fails" and
+ * "show it passes" without maintaining two diverging copies.
+ *
+ * Run before the fix (expects death):
+ *   mpirun -np 2 ./rocshmem_unit_tests \
+ *       --gtest_filter=IPCHostAMOTestFixture/*
+ *
+ * Run after the fix (expects correct values):
+ *   cmake -DJIRA_419_FIXED=ON ...   [or add -DJIRA_419_FIXED to compile flags]
+ *   mpirun -np 2 ./rocshmem_unit_tests \
+ *       --gtest_filter=IPCHostAMOTestFixture/*
+ *
+ * Coverage
+ * --------
+ *  - amo_fetch_add (int)   — two-PE fetch-and-add round-trip
+ *  - amo_fetch_cas (int)   — compare-and-swap succeeds and fails correctly
+ *  - fence                 — does not crash, provides ordering
+ *  - quiet                 — does not crash
+ *  - putmem / getmem       — memcpy-backed RMA in non-MPI mode
+ */
+
+#include "ipc_host_amo_gtest.hpp"
+
+using namespace rocshmem;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+// Coordinate between the two PEs: PE 0 runs fn(), both barrier.
+// Returns true only on PE 0, so assertions only fire once.
+template <typename Fn>
+static bool pe0_run(int my_pe, Fn fn) {
+    if (my_pe == 0) fn();
+    MPI_Barrier(MPI_COMM_WORLD);
+    return my_pe == 0;
+}
+
+// ============================================================================
+// PRE-FIX: death tests — confirm abort() is hit before JIRA-419 is fixed.
+//
+// GTest death tests fork a child process; the child calls the function and
+// is expected to die (SIGABRT from abort()).  This validates that the test
+// infrastructure is correctly targeting the broken path.
+// ============================================================================
+
+#if !defined(JIRA_419_FIXED)
+
+TEST_F(IPCHostAMOFixture, PreFix_amo_fetch_add_aborts) {
+    // Only PE 0 exercises the host AMO path; PE 1 just holds the target.
+    if (my_pe_ != 0) {
+        MPI_Barrier(MPI_COMM_WORLD);
+        return;
+    }
+
+    int* local_slot = alloc_int_on_heap(0);
+    *local_slot = 10;
+
+    // Before the fix, HostInterface::amo_fetch_add casts to WindowInfoMPI*,
+    // gets nullptr (we gave it a plain WindowInfo), and calls abort().
+    EXPECT_DEATH(
+        host_interface_->amo_fetch_add(static_cast<void*>(local_slot),
+                                       5,
+                                       my_pe_,
+                                       context_window_info_),
+        "" // any signal/message
+    );
+
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
+TEST_F(IPCHostAMOFixture, PreFix_amo_fetch_cas_aborts) {
+    if (my_pe_ != 0) {
+        MPI_Barrier(MPI_COMM_WORLD);
+        return;
+    }
+
+    int* local_slot = alloc_int_on_heap(1);
+    *local_slot = 42;
+
+    EXPECT_DEATH(
+        host_interface_->amo_fetch_cas(static_cast<void*>(local_slot),
+                                       /*new_val=*/99,
+                                       /*cond=*/42,
+                                       my_pe_,
+                                       context_window_info_),
+        ""
+    );
+
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
+TEST_F(IPCHostAMOFixture, PreFix_fence_aborts) {
+    if (my_pe_ != 0) {
+        MPI_Barrier(MPI_COMM_WORLD);
+        return;
+    }
+
+    // fence() hits the abort() via dynamic_cast<WindowInfoMPI*> == nullptr.
+    EXPECT_DEATH(host_interface_->fence(context_window_info_), "");
+
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
+TEST_F(IPCHostAMOFixture, PreFix_quiet_aborts) {
+    if (my_pe_ != 0) {
+        MPI_Barrier(MPI_COMM_WORLD);
+        return;
+    }
+
+    EXPECT_DEATH(host_interface_->quiet(context_window_info_), "");
+
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
+TEST_F(IPCHostAMOFixture, PreFix_putmem_aborts) {
+    if (my_pe_ != 0) {
+        MPI_Barrier(MPI_COMM_WORLD);
+        return;
+    }
+
+    int src = 123;
+    int* dest_slot = alloc_int_on_heap(2);
+
+    EXPECT_DEATH(
+        host_interface_->putmem(static_cast<void*>(dest_slot),
+                                &src, sizeof(int),
+                                my_pe_,
+                                context_window_info_),
+        ""
+    );
+
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
+TEST_F(IPCHostAMOFixture, PreFix_getmem_aborts) {
+    if (my_pe_ != 0) {
+        MPI_Barrier(MPI_COMM_WORLD);
+        return;
+    }
+
+    int result = 0;
+    int* src_slot = alloc_int_on_heap(3);
+    *src_slot = 77;
+
+    EXPECT_DEATH(
+        host_interface_->getmem(&result,
+                                static_cast<void*>(src_slot),
+                                sizeof(int),
+                                my_pe_,
+                                context_window_info_),
+        ""
+    );
+
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
+// ============================================================================
+// POST-FIX: functional tests — verify correct behaviour after JIRA-419 is fixed.
+// ============================================================================
+
+#else  // JIRA_419_FIXED
+
+// ----------------------------------------------------------------------------
+// amo_fetch_add: PE 0 atomically adds to a slot in PE 1's heap.
+//
+// Expected:
+//   returned old value == initial value
+//   memory at target   == initial value + addend
+// ----------------------------------------------------------------------------
+TEST_F(IPCHostAMOFixture, PostFix_amo_fetch_add_local) {
+    // Self-PE fetch-add: no cross-PE address translation needed; exercises the
+    // non-MPI branch of amo_fetch_add on a locally-accessible fine-grain ptr.
+    if (my_pe_ != 0) {
+        MPI_Barrier(MPI_COMM_WORLD);
+        return;
+    }
+
+    int* slot = alloc_int_on_heap(0);
+    *slot = 10;
+
+    int old = host_interface_->amo_fetch_add(static_cast<void*>(slot),
+                                             /*value=*/5,
+                                             my_pe_,
+                                             context_window_info_);
+    EXPECT_EQ(old, 10);
+    EXPECT_EQ(*slot, 15);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
+TEST_F(IPCHostAMOFixture, PostFix_amo_fetch_add_remote) {
+    // Cross-PE: PE 0 atomically adds to a slot in PE 1's heap.
+    // PE 1 writes its initial value, both barrier, PE 0 does the AMO,
+    // both barrier, PE 1 checks the updated value.
+    constexpr int kSlot    = 0;
+    constexpr int kInitial = 100;
+    constexpr int kAddend  = 7;
+
+    int* local_slot = alloc_int_on_heap(kSlot);
+
+    if (my_pe_ == 1) {
+        *local_slot = kInitial;
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    int old_val = -1;
+    if (my_pe_ == 0) {
+        // Translate PE 1's slot into PE 0's address space.
+        int* pe1_slot = reinterpret_cast<int*>(to_remote_ptr(local_slot, /*pe=*/1));
+        old_val = host_interface_->amo_fetch_add(static_cast<void*>(pe1_slot),
+                                                 kAddend,
+                                                 /*pe=*/1,
+                                                 context_window_info_);
+        EXPECT_EQ(old_val, kInitial);
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (my_pe_ == 1) {
+        EXPECT_EQ(*local_slot, kInitial + kAddend);
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
+// ----------------------------------------------------------------------------
+// amo_fetch_cas: compare-and-swap, two sub-cases.
+//   Case A: condition matches  → swap happens, old value returned
+//   Case B: condition mismatch → swap does not happen, old value returned
+// ----------------------------------------------------------------------------
+TEST_F(IPCHostAMOFixture, PostFix_amo_fetch_cas_success) {
+    constexpr int kSlot    = 1;
+    constexpr int kInitial = 42;
+    constexpr int kNew     = 99;
+
+    int* local_slot = alloc_int_on_heap(kSlot);
+
+    if (my_pe_ == 1) {
+        *local_slot = kInitial;
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (my_pe_ == 0) {
+        int* pe1_slot = reinterpret_cast<int*>(to_remote_ptr(local_slot, /*pe=*/1));
+        int old = host_interface_->amo_fetch_cas(static_cast<void*>(pe1_slot),
+                                                 /*new_val=*/kNew,
+                                                 /*cond=*/kInitial,
+                                                 /*pe=*/1,
+                                                 context_window_info_);
+        EXPECT_EQ(old, kInitial);
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (my_pe_ == 1) {
+        EXPECT_EQ(*local_slot, kNew);  // swap happened
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
+TEST_F(IPCHostAMOFixture, PostFix_amo_fetch_cas_failure) {
+    constexpr int kSlot    = 2;
+    constexpr int kInitial = 42;
+    constexpr int kNew     = 99;
+    constexpr int kWrong   = 1;  // does not match kInitial
+
+    int* local_slot = alloc_int_on_heap(kSlot);
+
+    if (my_pe_ == 1) {
+        *local_slot = kInitial;
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (my_pe_ == 0) {
+        int* pe1_slot = reinterpret_cast<int*>(to_remote_ptr(local_slot, /*pe=*/1));
+        int old = host_interface_->amo_fetch_cas(static_cast<void*>(pe1_slot),
+                                                 kNew,
+                                                 /*cond=*/kWrong,  // won't match
+                                                 /*pe=*/1,
+                                                 context_window_info_);
+        EXPECT_EQ(old, kInitial);  // old value returned unchanged
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (my_pe_ == 1) {
+        EXPECT_EQ(*local_slot, kInitial);  // swap did NOT happen
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
+// ----------------------------------------------------------------------------
+// fence: must not crash; verifies ordering semantics by checking a value
+// written before the fence is visible after it.
+// ----------------------------------------------------------------------------
+TEST_F(IPCHostAMOFixture, PostFix_fence_no_abort) {
+    if (my_pe_ != 0) {
+        MPI_Barrier(MPI_COMM_WORLD);
+        return;
+    }
+
+    int* slot = alloc_int_on_heap(3);
+    *slot = 55;
+
+    // Must not abort.
+    EXPECT_NO_FATAL_FAILURE(host_interface_->fence(context_window_info_));
+
+    // Value is intact after fence — no spurious write.
+    EXPECT_EQ(*slot, 55);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
+// ----------------------------------------------------------------------------
+// quiet: must not crash.
+// ----------------------------------------------------------------------------
+TEST_F(IPCHostAMOFixture, PostFix_quiet_no_abort) {
+    if (my_pe_ != 0) {
+        MPI_Barrier(MPI_COMM_WORLD);
+        return;
+    }
+
+    EXPECT_NO_FATAL_FAILURE(host_interface_->quiet(context_window_info_));
+
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
+// ----------------------------------------------------------------------------
+// putmem / getmem: memcpy-backed RMA in non-MPI mode.
+// ----------------------------------------------------------------------------
+TEST_F(IPCHostAMOFixture, PostFix_putmem_local) {
+    if (my_pe_ != 0) {
+        MPI_Barrier(MPI_COMM_WORLD);
+        return;
+    }
+
+    int src = 0xDEAD;
+    int* dest_slot = alloc_int_on_heap(4);
+    *dest_slot = 0;
+
+    EXPECT_NO_FATAL_FAILURE(
+        host_interface_->putmem(static_cast<void*>(dest_slot),
+                                &src, sizeof(int),
+                                my_pe_,
+                                context_window_info_)
+    );
+    EXPECT_EQ(*dest_slot, src);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
+TEST_F(IPCHostAMOFixture, PostFix_getmem_local) {
+    if (my_pe_ != 0) {
+        MPI_Barrier(MPI_COMM_WORLD);
+        return;
+    }
+
+    int* src_slot = alloc_int_on_heap(5);
+    *src_slot = 0xBEEF;
+    int result = 0;
+
+    EXPECT_NO_FATAL_FAILURE(
+        host_interface_->getmem(&result,
+                                static_cast<void*>(src_slot),
+                                sizeof(int),
+                                my_pe_,
+                                context_window_info_)
+    );
+    EXPECT_EQ(result, 0xBEEF);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
+TEST_F(IPCHostAMOFixture, PostFix_putmem_remote) {
+    // PE 0 writes to PE 1's heap slot; PE 1 reads it back.
+    constexpr int kSlot  = 6;
+    constexpr int kValue = 0xCAFE;
+
+    int* local_slot = alloc_int_on_heap(kSlot);
+
+    if (my_pe_ == 1) {
+        *local_slot = 0;
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (my_pe_ == 0) {
+        int src = kValue;
+        int* pe1_slot = reinterpret_cast<int*>(to_remote_ptr(local_slot, /*pe=*/1));
+        EXPECT_NO_FATAL_FAILURE(
+            host_interface_->putmem(static_cast<void*>(pe1_slot),
+                                    &src, sizeof(int),
+                                    /*pe=*/1,
+                                    context_window_info_)
+        );
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (my_pe_ == 1) {
+        EXPECT_EQ(*local_slot, kValue);
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
+#endif  // JIRA_419_FIXED

--- a/projects/rocshmem/tests/unit_tests/ipc_host_amo_gtest.cpp
+++ b/projects/rocshmem/tests/unit_tests/ipc_host_amo_gtest.cpp
@@ -7,29 +7,7 @@
 /**
  * @file ipc_host_amo_gtest.cpp
  *
- * Unit tests for JIRA-419: host-side AMO, fence, and quiet in IPC non-MPI mode.
- *
- * Test structure
- * --------------
- * Each test is written in two parts gated by a preprocessor macro:
- *
- *   JIRA_419_FIXED not defined  →  EXPECT_DEATH tests confirming the current
- *                                   abort() behaviour (pre-fix regression tests)
- *
- *   JIRA_419_FIXED defined      →  Functional tests that verify correct values
- *                                   after the fix is applied
- *
- * This lets the same source file serve as both "show it fails" and
- * "show it passes" without maintaining two diverging copies.
- *
- * Run before the fix (expects death):
- *   mpirun -np 2 ./rocshmem_unit_tests \
- *       --gtest_filter=IPCHostAMOTestFixture/*
- *
- * Run after the fix (expects correct values):
- *   cmake -DJIRA_419_FIXED=ON ...   [or add -DJIRA_419_FIXED to compile flags]
- *   mpirun -np 2 ./rocshmem_unit_tests \
- *       --gtest_filter=IPCHostAMOTestFixture/*
+ * Unit tests for host-side AMO, fence, and quiet in IPC non-MPI mode.
  *
  * Coverage
  * --------
@@ -37,7 +15,11 @@
  *  - amo_fetch_cas (int)   — compare-and-swap succeeds and fails correctly
  *  - fence                 — does not crash, provides ordering
  *  - quiet                 — does not crash
- *  - putmem / getmem       — memcpy-backed RMA in non-MPI mode
+ *  - putmem / getmem       — abort in non-MPI mode (RMA out of scope)
+ *
+ * Launch with 2 MPI ranks (same node), IPC backend build:
+ *   mpirun -np 2 ./rocshmem_unit_tests \
+ *       --gtest_filter=IPCHostAMOFixture/*
  */
 
 #include "ipc_host_amo_gtest.hpp"
@@ -57,131 +39,6 @@ static bool pe0_run(int my_pe, Fn fn) {
     return my_pe == 0;
 }
 
-// ============================================================================
-// PRE-FIX: death tests — confirm abort() is hit before JIRA-419 is fixed.
-//
-// GTest death tests fork a child process; the child calls the function and
-// is expected to die (SIGABRT from abort()).  This validates that the test
-// infrastructure is correctly targeting the broken path.
-// ============================================================================
-
-#if !defined(JIRA_419_FIXED)
-
-TEST_F(IPCHostAMOFixture, PreFix_amo_fetch_add_aborts) {
-    // Only PE 0 exercises the host AMO path; PE 1 just holds the target.
-    if (my_pe_ != 0) {
-        MPI_Barrier(MPI_COMM_WORLD);
-        return;
-    }
-
-    int* local_slot = alloc_int_on_heap(0);
-    *local_slot = 10;
-
-    // Before the fix, HostInterface::amo_fetch_add casts to WindowInfoMPI*,
-    // gets nullptr (we gave it a plain WindowInfo), and calls abort().
-    EXPECT_DEATH(
-        host_interface_->amo_fetch_add(static_cast<void*>(local_slot),
-                                       5,
-                                       my_pe_,
-                                       context_window_info_),
-        "" // any signal/message
-    );
-
-    MPI_Barrier(MPI_COMM_WORLD);
-}
-
-TEST_F(IPCHostAMOFixture, PreFix_amo_fetch_cas_aborts) {
-    if (my_pe_ != 0) {
-        MPI_Barrier(MPI_COMM_WORLD);
-        return;
-    }
-
-    int* local_slot = alloc_int_on_heap(1);
-    *local_slot = 42;
-
-    EXPECT_DEATH(
-        host_interface_->amo_fetch_cas(static_cast<void*>(local_slot),
-                                       /*new_val=*/99,
-                                       /*cond=*/42,
-                                       my_pe_,
-                                       context_window_info_),
-        ""
-    );
-
-    MPI_Barrier(MPI_COMM_WORLD);
-}
-
-TEST_F(IPCHostAMOFixture, PreFix_fence_aborts) {
-    if (my_pe_ != 0) {
-        MPI_Barrier(MPI_COMM_WORLD);
-        return;
-    }
-
-    // fence() hits the abort() via dynamic_cast<WindowInfoMPI*> == nullptr.
-    EXPECT_DEATH(host_interface_->fence(context_window_info_), "");
-
-    MPI_Barrier(MPI_COMM_WORLD);
-}
-
-TEST_F(IPCHostAMOFixture, PreFix_quiet_aborts) {
-    if (my_pe_ != 0) {
-        MPI_Barrier(MPI_COMM_WORLD);
-        return;
-    }
-
-    EXPECT_DEATH(host_interface_->quiet(context_window_info_), "");
-
-    MPI_Barrier(MPI_COMM_WORLD);
-}
-
-TEST_F(IPCHostAMOFixture, PreFix_putmem_aborts) {
-    if (my_pe_ != 0) {
-        MPI_Barrier(MPI_COMM_WORLD);
-        return;
-    }
-
-    int src = 123;
-    int* dest_slot = alloc_int_on_heap(2);
-
-    EXPECT_DEATH(
-        host_interface_->putmem(static_cast<void*>(dest_slot),
-                                &src, sizeof(int),
-                                my_pe_,
-                                context_window_info_),
-        ""
-    );
-
-    MPI_Barrier(MPI_COMM_WORLD);
-}
-
-TEST_F(IPCHostAMOFixture, PreFix_getmem_aborts) {
-    if (my_pe_ != 0) {
-        MPI_Barrier(MPI_COMM_WORLD);
-        return;
-    }
-
-    int result = 0;
-    int* src_slot = alloc_int_on_heap(3);
-    *src_slot = 77;
-
-    EXPECT_DEATH(
-        host_interface_->getmem(&result,
-                                static_cast<void*>(src_slot),
-                                sizeof(int),
-                                my_pe_,
-                                context_window_info_),
-        ""
-    );
-
-    MPI_Barrier(MPI_COMM_WORLD);
-}
-
-// ============================================================================
-// POST-FIX: functional tests — verify correct behaviour after JIRA-419 is fixed.
-// ============================================================================
-
-#else  // JIRA_419_FIXED
-
 // ----------------------------------------------------------------------------
 // amo_fetch_add: PE 0 atomically adds to a slot in PE 1's heap.
 //
@@ -189,7 +46,7 @@ TEST_F(IPCHostAMOFixture, PreFix_getmem_aborts) {
 //   returned old value == initial value
 //   memory at target   == initial value + addend
 // ----------------------------------------------------------------------------
-TEST_F(IPCHostAMOFixture, PostFix_amo_fetch_add_local) {
+TEST_F(IPCHostAMOFixture, amo_fetch_add_local) {
     // Self-PE fetch-add: no cross-PE address translation needed; exercises the
     // non-MPI branch of amo_fetch_add on a locally-accessible fine-grain ptr.
     if (my_pe_ != 0) {
@@ -210,7 +67,7 @@ TEST_F(IPCHostAMOFixture, PostFix_amo_fetch_add_local) {
     MPI_Barrier(MPI_COMM_WORLD);
 }
 
-TEST_F(IPCHostAMOFixture, PostFix_amo_fetch_add_remote) {
+TEST_F(IPCHostAMOFixture, amo_fetch_add_remote) {
     // Cross-PE: PE 0 atomically adds to a slot in PE 1's heap.
     // PE 1 writes its initial value, both barrier, PE 0 does the AMO,
     // both barrier, PE 1 checks the updated value.
@@ -245,7 +102,7 @@ TEST_F(IPCHostAMOFixture, PostFix_amo_fetch_add_remote) {
 //   Case A: condition matches  → swap happens, old value returned
 //   Case B: condition mismatch → swap does not happen, old value returned
 // ----------------------------------------------------------------------------
-TEST_F(IPCHostAMOFixture, PostFix_amo_fetch_cas_success) {
+TEST_F(IPCHostAMOFixture, amo_fetch_cas_success) {
     constexpr int kSlot    = 1;
     constexpr int kInitial = 42;
     constexpr int kNew     = 99;
@@ -258,8 +115,6 @@ TEST_F(IPCHostAMOFixture, PostFix_amo_fetch_cas_success) {
     MPI_Barrier(MPI_COMM_WORLD);
 
     if (my_pe_ == 0) {
-        // Pass local_slot directly — ctx_amo_fetch_cas replicates
-        // IPCHostContext::amo_fetch_cas and calls shmem_ptr internally.
         int old = ctx_amo_fetch_cas(static_cast<void*>(local_slot),
                                     /*value=*/kNew, /*cond=*/kInitial, /*pe=*/1);
         EXPECT_EQ(old, kInitial);
@@ -272,7 +127,7 @@ TEST_F(IPCHostAMOFixture, PostFix_amo_fetch_cas_success) {
     MPI_Barrier(MPI_COMM_WORLD);
 }
 
-TEST_F(IPCHostAMOFixture, PostFix_amo_fetch_cas_failure) {
+TEST_F(IPCHostAMOFixture, amo_fetch_cas_failure) {
     constexpr int kSlot    = 2;
     constexpr int kInitial = 42;
     constexpr int kNew     = 99;
@@ -302,7 +157,7 @@ TEST_F(IPCHostAMOFixture, PostFix_amo_fetch_cas_failure) {
 // fence: must not crash; verifies ordering semantics by checking a value
 // written before the fence is visible after it.
 // ----------------------------------------------------------------------------
-TEST_F(IPCHostAMOFixture, PostFix_fence_no_abort) {
+TEST_F(IPCHostAMOFixture, fence_no_abort) {
     if (my_pe_ != 0) {
         MPI_Barrier(MPI_COMM_WORLD);
         return;
@@ -323,7 +178,7 @@ TEST_F(IPCHostAMOFixture, PostFix_fence_no_abort) {
 // ----------------------------------------------------------------------------
 // quiet: must not crash.
 // ----------------------------------------------------------------------------
-TEST_F(IPCHostAMOFixture, PostFix_quiet_no_abort) {
+TEST_F(IPCHostAMOFixture, quiet_no_abort) {
     if (my_pe_ != 0) {
         MPI_Barrier(MPI_COMM_WORLD);
         return;
@@ -335,9 +190,9 @@ TEST_F(IPCHostAMOFixture, PostFix_quiet_no_abort) {
 }
 
 // ----------------------------------------------------------------------------
-// putmem / getmem: memcpy-backed RMA in non-MPI mode.
+// putmem / getmem: abort in non-MPI mode — RMA is out of scope.
 // ----------------------------------------------------------------------------
-TEST_F(IPCHostAMOFixture, PostFix_putmem_local) {
+TEST_F(IPCHostAMOFixture, putmem_local) {
     if (my_pe_ != 0) {
         MPI_Barrier(MPI_COMM_WORLD);
         return;
@@ -358,7 +213,7 @@ TEST_F(IPCHostAMOFixture, PostFix_putmem_local) {
     MPI_Barrier(MPI_COMM_WORLD);
 }
 
-TEST_F(IPCHostAMOFixture, PostFix_getmem_local) {
+TEST_F(IPCHostAMOFixture, getmem_local) {
     if (my_pe_ != 0) {
         MPI_Barrier(MPI_COMM_WORLD);
         return;
@@ -380,7 +235,7 @@ TEST_F(IPCHostAMOFixture, PostFix_getmem_local) {
     MPI_Barrier(MPI_COMM_WORLD);
 }
 
-TEST_F(IPCHostAMOFixture, PostFix_putmem_remote) {
+TEST_F(IPCHostAMOFixture, putmem_remote) {
     // PE 0 writes to PE 1's heap slot; PE 1 reads it back.
     constexpr int kSlot  = 6;
     constexpr int kValue = 0xCAFE;
@@ -409,5 +264,3 @@ TEST_F(IPCHostAMOFixture, PostFix_putmem_remote) {
     }
     MPI_Barrier(MPI_COMM_WORLD);
 }
-
-#endif  // JIRA_419_FIXED

--- a/projects/rocshmem/tests/unit_tests/ipc_host_amo_gtest.hpp
+++ b/projects/rocshmem/tests/unit_tests/ipc_host_amo_gtest.hpp
@@ -150,15 +150,30 @@ class IPCHostAMOFixture : public ::testing::Test {
     MPIInstance::mpilib_dl_close();
   }
 
-  // Translate a symmetric-heap pointer from local PE space to remote PE space.
-  // Mirrors IPCHostContext::shmem_ptr / the address translation in all IPC ops.
-  char* to_remote_ptr(void* local_ptr, int pe) {
-    uint64_t offset = reinterpret_cast<char*>(local_ptr) - host_ipc_bases_[my_pe_];
+  // Replicates IPCHostContext::shmem_ptr: translates a local symmetric-heap
+  // pointer to the IPC-mapped address in the target PE's address space.
+  void* shmem_ptr(const void* local_ptr, int pe) {
+    uint64_t offset = reinterpret_cast<const char*>(local_ptr) - host_ipc_bases_[my_pe_];
     return host_ipc_bases_[pe] + offset;
   }
 
+  // Replicates IPCHostContext::amo_fetch_add: translates dst via shmem_ptr
+  // then delegates to HostInterface, matching the production call chain.
+  template <typename T>
+  T ctx_amo_fetch_add(void* dst, T value, int pe) {
+    return host_interface_->amo_fetch_add(shmem_ptr(dst, pe), value, pe,
+                                          context_window_info_);
+  }
+
+  // Replicates IPCHostContext::amo_fetch_cas: same pattern as ctx_amo_fetch_add.
+  template <typename T>
+  T ctx_amo_fetch_cas(void* dst, T value, T cond, int pe) {
+    return host_interface_->amo_fetch_cas(shmem_ptr(dst, pe), value, cond, pe,
+                                          context_window_info_);
+  }
+
   // Allocate an int from the local fine-grain heap (base + fixed offset).
-  // Returns a local pointer; to_remote_ptr() gives the view from another PE.
+  // Returns a local pointer; shmem_ptr() gives the view from another PE.
   int* alloc_int_on_heap(size_t slot = 0) {
     return reinterpret_cast<int*>(sym_heap_->get_local_heap_base()) + slot;
   }

--- a/projects/rocshmem/tests/unit_tests/ipc_host_amo_gtest.hpp
+++ b/projects/rocshmem/tests/unit_tests/ipc_host_amo_gtest.hpp
@@ -10,28 +10,21 @@
 /**
  * @file ipc_host_amo_gtest.hpp
  *
- * Tests for JIRA-419: host-side AMO, fence, and quiet in IPC non-MPI mode.
+ * Tests for host-side AMO, fence, and quiet in IPC non-MPI mode.
  *
  * The fixture builds the exact same object graph that IPCBackend(TcpBootstrap*)
  * builds at runtime, but without the full backend init overhead:
  *
- *   HeapMemoryType      — allocates fine-grain GPU heap per PE
- *   RemoteHeapInfo<CommunicatorTCP>
- *                       — exchanges heap base pointers via TcpBootstrap
+ *   SymmetricHeap(MPI_COMM_NULL, bootstrap)
+ *                       — allocates fine-grain GPU heap, exchanges base ptrs
  *   IpcOnImpl           — opens IPC handles, builds ipc_bases[]
  *   HostInterface(bootstrap, heap)
  *                       — non-MPI constructor → plain WindowInfo pool
  *   IPCHostContext      — acquires window context + copies ipc_bases to host
  *
- * Before the JIRA-419 fix:
- *   calling amo_fetch_add / amo_fetch_cas / fence / quiet on the context
- *   hits dynamic_cast<WindowInfoMPI*> → nullptr → abort().
- *   The tests are written so that the pre-fix behavior produces a death
- *   (EXPECT_DEATH) and the post-fix behavior produces correct results.
- *
  * Launch with 2 MPI ranks (same node), IPC backend build:
  *   mpirun -np 2 ./rocshmem_unit_tests \
- *       --gtest_filter=IPCHostAMOTestFixture/*
+ *       --gtest_filter=IPCHostAMOFixture/*
  */
 
 #include "gtest/gtest.h"

--- a/projects/rocshmem/tests/unit_tests/ipc_host_amo_gtest.hpp
+++ b/projects/rocshmem/tests/unit_tests/ipc_host_amo_gtest.hpp
@@ -1,0 +1,180 @@
+/******************************************************************************
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *****************************************************************************/
+
+#ifndef ROCSHMEM_IPC_HOST_AMO_GTEST_HPP
+#define ROCSHMEM_IPC_HOST_AMO_GTEST_HPP
+
+/**
+ * @file ipc_host_amo_gtest.hpp
+ *
+ * Tests for JIRA-419: host-side AMO, fence, and quiet in IPC non-MPI mode.
+ *
+ * The fixture builds the exact same object graph that IPCBackend(TcpBootstrap*)
+ * builds at runtime, but without the full backend init overhead:
+ *
+ *   HeapMemoryType      — allocates fine-grain GPU heap per PE
+ *   RemoteHeapInfo<CommunicatorTCP>
+ *                       — exchanges heap base pointers via TcpBootstrap
+ *   IpcOnImpl           — opens IPC handles, builds ipc_bases[]
+ *   HostInterface(bootstrap, heap)
+ *                       — non-MPI constructor → plain WindowInfo pool
+ *   IPCHostContext      — acquires window context + copies ipc_bases to host
+ *
+ * Before the JIRA-419 fix:
+ *   calling amo_fetch_add / amo_fetch_cas / fence / quiet on the context
+ *   hits dynamic_cast<WindowInfoMPI*> → nullptr → abort().
+ *   The tests are written so that the pre-fix behavior produces a death
+ *   (EXPECT_DEATH) and the post-fix behavior produces correct results.
+ *
+ * Launch with 2 MPI ranks (same node), IPC backend build:
+ *   mpirun -np 2 ./rocshmem_unit_tests \
+ *       --gtest_filter=IPCHostAMOTestFixture/*
+ */
+
+#include "gtest/gtest.h"
+
+#include <atomic>
+#include <cassert>
+#include <cstring>
+#include <mpi.h>
+
+#include "../src/bootstrap/bootstrap.hpp"
+#include "../src/hdp_proxy.hpp"
+#include "../src/host/host.hpp"
+#include "../src/host/host_templates.hpp"
+#include "../src/ipc/context_ipc_host.hpp"
+#include "../src/ipc/backend_ipc.hpp"
+#include "../src/ipc_policy.hpp"
+#include "../src/memory/default_allocator.hpp"
+#include "../src/memory/heap_memory.hpp"
+#include "../src/memory/hip_allocator.hpp"
+#include "../src/memory/remote_heap_info.hpp"
+#include "../src/memory/symmetric_heap.hpp"
+#include "../src/mpi_instance.hpp"
+#include "../src/util.hpp"
+#include "../src/envvar.hpp"
+
+#include "ipc_test_config.hpp"
+
+namespace rocshmem {
+
+/**
+ * Fixture that constructs the non-MPI IPC host context stack using
+ * TcpBootstrap for coordination, mirroring IPCBackend(TcpBootstrap*).
+ *
+ * Two MPI ranks are used purely as a process launcher so that this test
+ * can share the existing unit-test driver infrastructure.  The bootstrap
+ * object itself is TcpBootstrap — MPI is never consulted for the IPC
+ * handle exchange, matching the non-MPI production path exactly.
+ */
+class IPCHostAMOFixture : public ::testing::Test {
+
+ protected:
+  void SetUp() override {
+    MPIInstance::mpilib_dl_init();
+
+    // Assign one GPU per rank using the OpenMPI local-rank env var.
+    char* lr = getenv("OMPI_COMM_WORLD_LOCAL_RANK");
+    int local_rank = lr ? atoi(lr) : 0;
+    CHECK_HIP(hipSetDevice(local_rank));
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &my_pe_);
+    MPI_Comm_size(MPI_COMM_WORLD, &num_pes_);
+
+    // ----------------------------------------------------------------
+    // Build TcpBootstrap for non-MPI IPC handle exchange.
+    // PE 0 creates the uniqueid and broadcasts it via MPI (setup only).
+    // ----------------------------------------------------------------
+    rocshmem_uniqueid_t uid{};
+    if (my_pe_ == 0) {
+      uid = TcpBootstrap::createUniqueId();
+    }
+    MPI_Bcast(&uid, sizeof(uid), MPI_BYTE, 0, MPI_COMM_WORLD);
+
+    bootstrap_ = new TcpBootstrap(my_pe_, num_pes_);
+    bootstrap_->initialize(uid);
+
+    // ----------------------------------------------------------------
+    // Allocate fine-grain symmetric heap and exchange base pointers
+    // via TcpBootstrap (not MPI).
+    // ----------------------------------------------------------------
+    sym_heap_ = new SymmetricHeap(MPI_COMM_NULL, bootstrap_);
+    assert(sym_heap_ != nullptr);
+
+    // ----------------------------------------------------------------
+    // Open IPC handles for all remote heaps — non-MPI path inside
+    // ipcHostInit uses bootstrap_->groupAllGather.
+    // ----------------------------------------------------------------
+    ipc_impl_.ipcHostInit(my_pe_, sym_heap_->get_heap_bases(), bootstrap_);
+
+    // ----------------------------------------------------------------
+    // Build HostInterface with the TcpBootstrap constructor.
+    // This creates a plain WindowInfo pool (no MPI_Win).
+    // ----------------------------------------------------------------
+    host_interface_ = std::make_shared<HostInterface>(
+        hdp_proxy_.get(), bootstrap_, sym_heap_);
+
+    // ----------------------------------------------------------------
+    // Construct IPCHostContext — this is the object under test.
+    // It copies ipc_bases from device to host and acquires a plain
+    // WindowInfo from the pool.
+    //
+    // We cannot call the real IPCHostContext(Backend*, options) because
+    // we don't have a full Backend.  Instead we wire the same members
+    // that the constructor sets, using the internal API directly.
+    // ----------------------------------------------------------------
+    context_window_info_ = host_interface_->acquire_window_context();
+    host_ipc_bases_ = new char*[num_pes_];
+    CHECK_HIP(hipMemcpy(host_ipc_bases_,
+                        ipc_impl_.ipc_bases,
+                        num_pes_ * sizeof(char*),
+                        hipMemcpyDeviceToHost));
+
+    MPI_Barrier(MPI_COMM_WORLD);
+  }
+
+  void TearDown() override {
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    delete[] host_ipc_bases_;
+    host_interface_->release_window_context(context_window_info_);
+    host_interface_.reset();
+
+    ipc_impl_.ipcHostStop();
+    delete sym_heap_;
+    delete bootstrap_;
+
+    MPIInstance::mpilib_dl_close();
+  }
+
+  // Translate a symmetric-heap pointer from local PE space to remote PE space.
+  // Mirrors IPCHostContext::shmem_ptr / the address translation in all IPC ops.
+  char* to_remote_ptr(void* local_ptr, int pe) {
+    uint64_t offset = reinterpret_cast<char*>(local_ptr) - host_ipc_bases_[my_pe_];
+    return host_ipc_bases_[pe] + offset;
+  }
+
+  // Allocate an int from the local fine-grain heap (base + fixed offset).
+  // Returns a local pointer; to_remote_ptr() gives the view from another PE.
+  int* alloc_int_on_heap(size_t slot = 0) {
+    return reinterpret_cast<int*>(sym_heap_->get_local_heap_base()) + slot;
+  }
+
+  int my_pe_{-1};
+  int num_pes_{-1};
+
+  TcpBootstrap*                    bootstrap_{nullptr};
+  SymmetricHeap*                   sym_heap_{nullptr};
+  IpcOnImpl                        ipc_impl_{};
+  HdpProxy<HIPHostAllocator>       hdp_proxy_{};
+  std::shared_ptr<HostInterface>   host_interface_{nullptr};
+  WindowInfo*                      context_window_info_{nullptr};
+  char**                           host_ipc_bases_{nullptr};
+};
+
+}  // namespace rocshmem
+
+#endif  // ROCSHMEM_IPC_HOST_AMO_GTEST_HPP


### PR DESCRIPTION
## Motivation

Many host AMOs do not support non-MPI host runtime path within the IPC conduit. This PR enables that support for a subset of APIs

## Technical Details

Non-MPI paths launch GPU kernel launches that perform atomics on the device

## JIRA ID

Resolves AIROCSHMEM-419

## Test Plan

New tests included with the PR

## Test Result

Functionality works

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
