### PR TITLE
[hipfile] Update docker/login-action to 4.2.0

### DIFF
--- a/.github/workflows/hipfile-build-nvidia.yml
+++ b/.github/workflows/hipfile-build-nvidia.yml
@@ -54,7 +54,7 @@ jobs:
             projects/hipfile
             .github/workflows
       - name: Authenticating to GitHub Container Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/hipfile-build.yml
+++ b/.github/workflows/hipfile-build.yml
@@ -114,7 +114,7 @@ jobs:
             projects/hipfile
             .github/workflows
       - name: Authenticating to GitHub Container Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/hipfile-ci-system.yml
+++ b/.github/workflows/hipfile-ci-system.yml
@@ -81,7 +81,7 @@ jobs:
           name: hipfile-build-dir-${{ inputs.platform }}
           path: ${{ github.workspace }}/hipfile-build-dir
       - name: Authenticating to GitHub Container Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -282,7 +282,7 @@ jobs:
 #            }}
 #          merge-multiple: true
 #      - name: Authenticating to GitHub Container Registry
-#        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+#        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
 #        with:
 #          registry: ghcr.io
 #          username: ${{ github.actor }}

--- a/.github/workflows/hipfile-image-build.yml
+++ b/.github/workflows/hipfile-image-build.yml
@@ -118,7 +118,7 @@ jobs:
             .github/workflows
 
       - name: Authenticating to GitHub Container Registry.
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/hipfile-image-update.yml
+++ b/.github/workflows/hipfile-image-update.yml
@@ -63,7 +63,7 @@ jobs:
             .github/workflows
 
       - name: Authenticating to GitHub Container Registry.
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/hipfile-python-bindings.yml
+++ b/.github/workflows/hipfile-python-bindings.yml
@@ -73,7 +73,7 @@ jobs:
         with:
           name: ${{ inputs.ais_hipfile_pkg_dev_filename }}
       - name: Authenticating to GitHub Container Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
## Motivation

This just updates the docker/login-action to the latest version

## Technical Details

From 4.1.0 to 4.2.0

## JIRA ID

N/A (maintenance task)

## Test Plan

CI passes

## Test Result

Success

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
