### PR TITLE
[hipfile] Add file and buffer registration stats collection.

### DIFF
--- a/projects/hipfile/docs/stats_collection.rst
+++ b/projects/hipfile/docs/stats_collection.rst
@@ -33,6 +33,8 @@ Value Description
 
 Stats Collected
 ---------------
+* Basic: Number of file handle registrations.
+* Basic: Number of buffer registrations.
 * Basic: Bytes read/written on the fastpath/fallback backends.
 * Basic: Bandwidth for reads/writes on the fastpath/fallback backends.
 * Basic: Latency for reads/writes on the fastpath/fallback backends.
@@ -47,6 +49,9 @@ Example output shape: ::
 
     AIS-STATS Version: 1
     HipFile Stats Level: 1
+    File Handle Registrations: 1
+    Buffer Registrations: 1
+
     Total Fastpath Read Size (B): 67108864
     Average Fastpath Read Bandwidth (GiB/s): 0.776272
     Average Fastpath Read Latency (us): 1258.02

--- a/projects/hipfile/src/amd_detail/hipfile.cpp
+++ b/projects/hipfile/src/amd_detail/hipfile.cpp
@@ -15,6 +15,7 @@
 #include "hipfile-warnings.h"
 #include "io.h"
 #include "state.h"
+#include "stats.h"
 
 #include <cerrno>
 #include <cstdint>
@@ -78,6 +79,7 @@ try {
         case hipFileHandleTypeOpaqueFD: {
             UnregisteredFile uf{descr->handle.fd};
             *fh = Context<DriverState>::get()->registerFile(std::move(uf));
+            Context<StatsCollection>::get()->fileRegistration();
             return {hipFileSuccess, hipSuccess};
         }
         case hipFileHandleTypeOpaqueWin32:
@@ -113,6 +115,7 @@ hipFileBufRegister(const void *buffer_base, size_t length, int flags)
 try {
     hipFileInit();
     Context<DriverState>::get()->registerBuffer(buffer_base, length, flags);
+    Context<StatsCollection>::get()->bufferRegistration();
     return {hipFileSuccess, hipSuccess};
 }
 catch (const BufferAlreadyRegistered &) {

--- a/projects/hipfile/src/amd_detail/stats.cpp
+++ b/projects/hipfile/src/amd_detail/stats.cpp
@@ -361,6 +361,10 @@ StatsClient::generateReportV1(std::ostream &stream, const StatsV1 *stats)
     if (stats == nullptr) {
         return;
     }
+
+    stream << "File Handle Registrations: " << stats->getFileRegistrations().load() << '\n';
+    stream << "Buffer Registrations: " << stats->getBufferRegistrations().load() << "\n\n";
+
     static constexpr IoType       ioTypes[]{IoType::Read, IoType::Write};
     static constexpr StatsBackend backends[]{StatsBackend::Fastpath, StatsBackend::Fallback};
     for (const auto &backend : backends) {
@@ -516,5 +520,25 @@ StatsCollection::error(IoType ioType, StatsBackend backend, uint64_t bytes) cons
     size_t bucket = StatsHistogram::toHistogramBucket(bytes);
     errorCountHist->buckets[bucket].fetch_add(1, std::memory_order_relaxed);
     perGpuStats->inUse.store(1, std::memory_order_relaxed);
+}
+
+void
+StatsCollection::fileRegistration() const noexcept
+{
+    Stats *stats{Context<IStatsServer>::get()->getStats()};
+    if (stats == nullptr || stats->getLevel() < StatsLevel::Basic) {
+        return;
+    }
+    stats->getFileRegistrations().fetch_add(1, std::memory_order_relaxed);
+}
+
+void
+StatsCollection::bufferRegistration() const noexcept
+{
+    Stats *stats{Context<IStatsServer>::get()->getStats()};
+    if (stats == nullptr || stats->getLevel() < StatsLevel::Basic) {
+        return;
+    }
+    stats->getBufferRegistrations().fetch_add(1, std::memory_order_relaxed);
 }
 }

--- a/projects/hipfile/src/amd_detail/stats.h
+++ b/projects/hipfile/src/amd_detail/stats.h
@@ -149,10 +149,32 @@ public:
                            [](const PerGpuStats &stats) { return stats.inUse.load() != 0; });
     }
 
+    std::atomic_uint64_t &getFileRegistrations() noexcept
+    {
+        return m_fileRegistrations;
+    }
+
+    const std::atomic_uint64_t &getFileRegistrations() const noexcept
+    {
+        return m_fileRegistrations;
+    }
+
+    std::atomic_uint64_t &getBufferRegistrations() noexcept
+    {
+        return m_bufferRegistrations;
+    }
+
+    const std::atomic_uint64_t &getBufferRegistrations() const noexcept
+    {
+        return m_bufferRegistrations;
+    }
+
 private:
-    const uint64_t   m_version{PerGpuStatsT::version};
-    StatsLevel       m_level{};
-    PerGpuStatsArray m_perGpuStats{};
+    const uint64_t       m_version{PerGpuStatsT::version};
+    StatsLevel           m_level{};
+    std::atomic_uint64_t m_fileRegistrations{};
+    std::atomic_uint64_t m_bufferRegistrations{};
+    PerGpuStatsArray     m_perGpuStats{};
 };
 
 using StatsV1 = StatsTemplate<PerGpuStatsV1, 16>;
@@ -266,5 +288,7 @@ public:
     virtual ~StatsCollection() = default;
     virtual void addIo(IoType ioType, StatsBackend backend, uint64_t bytes, uint64_t timeUs) const noexcept;
     virtual void error(IoType ioType, StatsBackend backend, uint64_t bytes) const noexcept;
+    virtual void fileRegistration() const noexcept;
+    virtual void bufferRegistration() const noexcept;
 };
 }

--- a/projects/hipfile/test/amd_detail/mstats.h
+++ b/projects/hipfile/test/amd_detail/mstats.h
@@ -32,5 +32,7 @@ public:
                 (const, noexcept, override));
     MOCK_METHOD(void, error, (IoType ioType, StatsBackend backend, uint64_t bytes),
                 (const, noexcept, override));
+    MOCK_METHOD(void, fileRegistration, (), (const, noexcept, override));
+    MOCK_METHOD(void, bufferRegistration, (), (const, noexcept, override));
 };
 }

--- a/projects/hipfile/test/amd_detail/stats.cpp
+++ b/projects/hipfile/test/amd_detail/stats.cpp
@@ -86,6 +86,36 @@ TEST_F(HipFileStats, StatsCollectionError)
                      .load());
 }
 
+TEST_F(HipFileStats, StatsCollectionFileRegistration)
+{
+    Stats                    stats{};
+    StrictMock<MStatsServer> mstats{};
+    EXPECT_CALL(mstats, getStats).WillRepeatedly(testing::Return(&stats));
+    stats.setLevel(StatsLevel::Basic);
+    Context<StatsCollection>::get()->fileRegistration();
+    ASSERT_EQ(1, stats.getFileRegistrations().load());
+    Context<StatsCollection>::get()->fileRegistration();
+    ASSERT_EQ(2, stats.getFileRegistrations().load());
+    stats.setLevel(StatsLevel::Disabled);
+    Context<StatsCollection>::get()->fileRegistration();
+    ASSERT_EQ(2, stats.getFileRegistrations().load());
+}
+
+TEST_F(HipFileStats, StatsCollectionBufferRegistration)
+{
+    Stats                    stats{};
+    StrictMock<MStatsServer> mstats{};
+    EXPECT_CALL(mstats, getStats).WillRepeatedly(testing::Return(&stats));
+    stats.setLevel(StatsLevel::Basic);
+    Context<StatsCollection>::get()->bufferRegistration();
+    ASSERT_EQ(1, stats.getBufferRegistrations().load());
+    Context<StatsCollection>::get()->bufferRegistration();
+    ASSERT_EQ(2, stats.getBufferRegistrations().load());
+    stats.setLevel(StatsLevel::Disabled);
+    Context<StatsCollection>::get()->bufferRegistration();
+    ASSERT_EQ(2, stats.getBufferRegistrations().load());
+}
+
 TEST_F(HipFileStats, StatsContainer)
 {
     StrictMock<MSys>           msys{};
@@ -145,7 +175,9 @@ TEST_F(HipFileStats, GenerateReportV1)
         .buckets[0] = 3;
     stats.getPerGpuStats(0, StatsBackend::Fallback)
         ->errorCount[static_cast<size_t>(IoType::Write)]
-        .buckets[0] = 4;
+        .buckets[0]                = 4;
+    stats.getBufferRegistrations() = 10;
+    stats.getFileRegistrations()   = 20;
     StatsClient::generateReportV1(os, &stats);
     std::string str{os.str()};
     ASSERT_GT(std::string::npos, str.find("Total Fastpath Read Size (B): 2"));
@@ -156,6 +188,8 @@ TEST_F(HipFileStats, GenerateReportV1)
     ASSERT_GT(std::string::npos, str.find("Total Fastpath Write Errors: 2"));
     ASSERT_GT(std::string::npos, str.find("Total Fallback Read Errors: 3"));
     ASSERT_GT(std::string::npos, str.find("Total Fallback Write Errors: 4"));
+    ASSERT_GT(std::string::npos, str.find("Buffer Registrations: 10"));
+    ASSERT_GT(std::string::npos, str.find("File Handle Registrations: 20"));
 }
 
 TEST_F(HipFileStats, GenerateReportV1TwoGpus)


### PR DESCRIPTION
## Motivation

This change adds counters to hipFileHandleRegister() and hipFileBufRegister() for profiler telemetry.

## Technical Details

Added two new counters to StatsTemplate and methods to StatsCollection to increment the file handle and buffer registration counts. StatsClient::generateReportV1() reports these values, and stats_collection.rst was updated to include them as well.

## JIRA ID

AIHIPFILE-99

## Test Plan

Ran aiscp under ais-stats to observe file and buffer registrations.

## Test Result

ais-stats report showed correct number of registrations.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
