### PR TITLE
libhsakmt: include non-local memory into pool.

### DIFF
--- a/projects/hip-tests/catch/config/configs/unit/memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/memory.yaml
@@ -1505,7 +1505,7 @@ memory:
     # Rock_Window_Failures_on_gfx1151
     disabled: [amd_windows]
     tags: [alloc]
-  Unit_hipMalloc_Positive_APU_LargeAllocSpill:
+  Unit_hipMalloc_Positive_LargeAllocSpill:
     <<: *level_2
     tags: [alloc]
   Unit_hipMalloc_Allocate110PercentOfDeviceMemory: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/virtualMemoryManagement.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/virtualMemoryManagement.yaml
@@ -180,7 +180,7 @@ virtualMemoryManagement:
     # Patch which removes the typetraits implementation from std namespace in hiprtc is reverted
     disabled: [amd_wsl]
   Unit_hipMemGetAllocationPropertiesFromHandle_Capture: *level_2
-  Unit_hipMemMap_Positive_APU_LargeAllocSpill: *level_2
+  Unit_hipMemMap_Positive_LargeAllocSpill: *level_2
   Unit_hipMemMap_SameMemoryReuse:
     <<: *level_2
     # (amd_windows) SWDEV-444041: These tests fail randomly in gfx1030 MGU

--- a/projects/hip-tests/catch/unit/memory/hipMalloc.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMalloc.cc
@@ -165,27 +165,22 @@ HIP_TEST_CASE(Unit_hipMalloc_Allocate90PercentOfDeviceMemory) {
 /**
  * Test Description
  * ------------------------
- * - APU-only. Allocates a single device buffer expected to exceed the
- *   dedicated-VRAM carveout, then exercises it with memory operations
- *   (memset, copy back, verify head and tail). Validates that hipMalloc
- *   honours the spill path for large allocations on unified memory and
- *   that the resulting buffer remains accessible for those operations.
+ * - Allocates a single device buffer large enough to exercise the spill
+ *   path into non-local (GART) memory, then validates it with memory
+ *   operations (memset, copy back, verify head and tail). Exercises the
+ *   spill on APUs whose dedicated-VRAM carveout is smaller than the
+ *   request, and on dGPUs whose VRAM is smaller than the request.
  * Test source
  * ------------------------
  * - unit/memory/hipMalloc.cc
  */
-HIP_TEST_CASE(Unit_hipMalloc_Positive_APU_LargeAllocSpill) {
+HIP_TEST_CASE(Unit_hipMalloc_Positive_LargeAllocSpill) {
   hipDeviceProp_t prop{};
   HIP_CHECK(hipGetDeviceProperties(&prop, 0));
-  if (!prop.integrated) {
-    HIP_SKIP_TEST("dGPU --- APU spill regression test does not apply");
-    return;
-  }
-  // Assumes the dedicated-VRAM carveout is smaller than 5 GiB.
   constexpr size_t size = static_cast<size_t>(5) << 30;
   constexpr size_t headroom = static_cast<size_t>(1) << 30;
   if (prop.totalGlobalMem < size + headroom) {
-    HIP_SKIP_TEST("APU totalGlobalMem too small for this allocation plus headroom");
+    HIP_SKIP_TEST("totalGlobalMem too small for this allocation plus headroom");
     return;
   }
 

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemMap.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemMap.cc
@@ -704,23 +704,19 @@ HIP_TEST_CASE(Unit_hipMemMap_Capture) {
 /**
  * Test Description
  * ------------------------
- * - APU-only. Reserves a VA, creates a physical handle expected to exceed
- *   the dedicated-VRAM carveout, maps it, grants access, and exercises the
- *   buffer end-to-end (memset, copy back, verify head and tail). Mirrors
- *   Unit_hipMalloc_Positive_APU_LargeAllocSpill but through the VMEM API
- *   path that hipGraphAddMemAllocNode ultimately uses, so it guards the
- *   same spill behaviour for graph-based allocations.
+ * - Reserves a VA, creates a physical handle large enough to exercise the
+ *   spill path into non-local (GART) memory, maps it, grants access, and
+ *   exercises the buffer end-to-end (memset, copy back, verify head and
+ *   tail). Mirrors Unit_hipMalloc_Positive_LargeAllocSpill but through the
+ *   VMEM API path that hipGraphAddMemAllocNode ultimately uses, so it
+ *   guards the same spill behaviour for graph-based allocations.
  * Test source
  * ------------------------
  * - unit/virtualMemoryManagement/hipMemMap.cc
  */
-HIP_TEST_CASE(Unit_hipMemMap_Positive_APU_LargeAllocSpill) {
+HIP_TEST_CASE(Unit_hipMemMap_Positive_LargeAllocSpill) {
   hipDeviceProp_t prop{};
   HIP_CHECK(hipGetDeviceProperties(&prop, 0));
-  if (!prop.integrated) {
-    HIP_SKIP_TEST("dGPU --- APU spill regression test does not apply");
-    return;
-  }
   int vmm_supported = 0;
   HIP_CHECK(hipDeviceGetAttribute(&vmm_supported,
                                   hipDeviceAttributeVirtualMemoryManagementSupported, 0));
@@ -728,11 +724,10 @@ HIP_TEST_CASE(Unit_hipMemMap_Positive_APU_LargeAllocSpill) {
     HIP_SKIP_TEST("Device does not support virtual memory management");
     return;
   }
-  // Assumes the dedicated-VRAM carveout is smaller than 5 GiB.
   constexpr size_t requested = static_cast<size_t>(5) << 30;
   constexpr size_t headroom = static_cast<size_t>(1) << 30;
   if (prop.totalGlobalMem < requested + headroom) {
-    HIP_SKIP_TEST("APU totalGlobalMem too small for this allocation plus headroom");
+    HIP_SKIP_TEST("totalGlobalMem too small for this allocation plus headroom");
     return;
   }
 

--- a/projects/rocr-runtime/libhsakmt/src/dxg/topology.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/topology.cpp
@@ -840,12 +840,10 @@ HSAKMT_STATUS topology_sysfs_get_mem_props(uint32_t node_id, uint32_t mem_id,
   assert(device);
 
   props.HeapType = HSA_HEAPTYPE_FRAME_BUFFER_PRIVATE;
-  props.SizeInBytes = device->LocalHeapSize();
-  // On APU, allocations can spill from local to non-local via the GART fallback,
-  // so the effective per-allocation cap is local + non-local.
-  if (!device->IsDgpu()) {
-    props.SizeInBytes += device->NonLocalHeapSize();
-  }
+  // Allocations can spill from local to non-local via the GART fallback that
+  // WKMI appends as a tertiary heap on both APU and dGPU, so the effective
+  // per-allocation cap is local + non-local.
+  props.SizeInBytes = device->LocalHeapSize() + device->NonLocalHeapSize();
   props.Width = device->MemoryBusWidth();
   props.MemoryClockMax = device->MaxMemoryClockMhz();
 


### PR DESCRIPTION
## Motivation

Include non-local memory into pool as dGPU can also spill over sys memory.

## Technical Details

Include non-local memory into pool as dGPU can also spill over sys memory.

## JIRA ID

NA

## Test Plan

NA

## Test Result

NA

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
