### PR TITLE
[ROCCLR] Mark VirtualMapCommand event complete after synchronous submit

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -3653,8 +3653,18 @@ void VirtualGPU::submitVirtualMap(amd::VirtualMapCommand& vcmd) {
       if (phys_mem_obj->getMemFlags() & ROCCLR_MEM_INTERPROCESS) {
         vaddr_sub_obj->setVmmImported(true);
       }
+      // hsa_amd_vmem_map is synchronous on the calling host thread; once it
+      // returns HSA_STATUS_SUCCESS the GPU page tables are already updated
+      // and the command has no asynchronous GPU completion to wait on. Mark
+      // the event CL_COMPLETE here so that a subsequent awaitCompletion()
+      // short-circuits and never enqueues a Marker on the device's NullStream. 
+      // Without this, the Marker's releaseGpuMemoryFence() / HwQueueTracker::WaitCurrent()   
+      // can transitively block on an unrelated in-flight collective kernel,
+      // producing a distributed deadlock under multi-rank IPC registration.
+      vcmd.setStatus(CL_COMPLETE);
     } else {
       LogError("HSA Command: hsa_amd_vmem_map failed!");
+      vcmd.setStatus(CL_INVALID_OPERATION);
     }
   } else {
     dispatchBarrierPacket(kBarrierPacketHeader, false);
@@ -3676,8 +3686,10 @@ void VirtualGPU::submitVirtualMap(amd::VirtualMapCommand& vcmd) {
       // Release sub_obj now that HW unmap is complete.
       // ~Memory releases parent va_ via parent_->release().
       vaddr_sub_obj->release();
+      vcmd.setStatus(CL_COMPLETE);
     } else {
       LogError("HSA Command: hsa_amd_vmem_unmap failed");
+      vcmd.setStatus(CL_INVALID_OPERATION);
     }
   }
 


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Fixes a distributed deadlock in hipMemMap() / hipMemUnmap() that hangs RCCL multi-segment IPC registration at ≥ 8 ranks.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
The fix is in `VirtualGPU::submitVirtualMap()`: mark the command's event CL_COMPLETE immediately after `Hsa::vmem_map / Hsa::vmem_unmap` return HSA_STATUS_SUCCESS, and CL_INVALID_OPERATION on failure. This causes the subsequent `Event::awaitCompletion()` short-circuit at the `status() > CL_COMPLETE` check, so the Marker is never enqueued and the entire deadlock-forming code path disappears for both APIs.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
ROCM-25387

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
rccl-UnitTestsMPI UMR_MultiSegment tests up to 8 ranks.

## Test Result

<!-- Briefly summarize test outcomes. -->
Pass / No hangs

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
