### PR TITLE
rocr: Set the link type link for APU as XGMI instead of hardcoded pcie

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/dxg/topology.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/topology.cpp
@@ -176,7 +176,7 @@ static int32_t gpu_get_direct_link_cpu(uint32_t gpu_node,
     return -1;
 
   for (i = 0; i < node_props[gpu_node].node.NumIOLinks; i++)
-    if (props[i].IoLinkType == HSA_IOLINKTYPE_PCIEXPRESS &&
+    if ((props[i].IoLinkType == HSA_IOLINKTYPE_PCIEXPRESS || props[i].IoLinkType == HSA_IOLINK_TYPE_XGMI) &&
         props[i].Weight <= 20) /* >20 is GPU->CPU->GPU */
       return props[i].NodeTo;
 

--- a/projects/rocr-runtime/libhsakmt/src/dxg/topology.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/topology.cpp
@@ -88,16 +88,28 @@ HSAKMT_STATUS topology_sysfs_get_iolink_props(uint32_t node_id,
   assert(device);
 
   std::memset(&props, 0, sizeof(props));
-  props.IoLinkType = HSA_IOLINKTYPE_PCIEXPRESS;
   props.VersionMajor = props.VersionMinor = 0;
   props.NodeFrom = node_id;
   props.NodeTo = 0;
-  props.Weight = 20;
   props.Flags.ui32.Override = 1;
-  props.Flags.ui32.NonCoherent = 1;
-  props.Flags.ui32.NoAtomics32bit = !(device->SupportPlatformAtomic());
-  props.Flags.ui32.NoAtomics64bit = !(device->SupportPlatformAtomic());
   props.RecSdmaEngIdMask = 0;
+
+  // Differentiate between discrete GPU (dGPU) and integrated GPU (APU)
+  if (device->IsDgpu()) {
+    // Discrete GPU - PCIe link to CPU
+    props.IoLinkType = HSA_IOLINKTYPE_PCIEXPRESS;
+    props.Weight = 20;  // Higher latency for PCIe
+    props.Flags.ui32.NonCoherent = 1;
+    props.Flags.ui32.NoAtomics32bit = !(device->SupportPlatformAtomic());
+    props.Flags.ui32.NoAtomics64bit = !(device->SupportPlatformAtomic());
+  } else {
+    // APU/Integrated GPU - XGMI (Infinity Fabric) or direct coherent link
+    props.IoLinkType = HSA_IOLINK_TYPE_XGMI;
+    props.Weight = 10;  // Lower latency for direct fabric connection
+    props.Flags.ui32.NonCoherent = 0;  // APU has coherent memory access
+    props.Flags.ui32.NoAtomics32bit = 0;  // APU supports 32-bit atomics
+    props.Flags.ui32.NoAtomics64bit = 0;  // APU supports 64-bit atomics
+  }
 
   return HSAKMT_STATUS_SUCCESS;
 }


### PR DESCRIPTION
## Motivation
rocr: Set the link type link for APU as XGMI instead of hardcoded pcie

## Technical Details
Currently PCIE is set as the default link type between CPU and GPU causing some failures in apps.
APUs reside in the CPU so the link should be fast link. PCIE is a hardware link for dGPU.

## JIRA ID
https://amd-hub.atlassian.net/browse/AIRUNTIME-1994

## Test Plan
rocr on windows tests do not fail.

## Test Result
rocr on windows tests pass on both dGPUs and APUs

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
