### PR TITLE
Update gfx942 runners names in ci-matrix.yml for systems and compute CI

### DIFF
--- a/projects/rocprofiler-compute/.github/ci-matrix.yml
+++ b/projects/rocprofiler-compute/.github/ci-matrix.yml
@@ -5,8 +5,8 @@ matrix-ubuntu-nightly:
   - { os-release: '22.04', gpu: 'mi355', arch: 'gfx950', runner: 'linux-mi355-1gpu-ossci-rocm' }
   - { os-release: '24.04', gpu: 'mi355', arch: 'gfx950', runner: 'linux-mi355-1gpu-ossci-rocm' }
   # MI325
-  - { os-release: '22.04', gpu: 'mi325', arch: 'gfx94X', runner: 'linux-gfx942-1gpu-ossci-rocm' }
-  - { os-release: '24.04', gpu: 'mi325', arch: 'gfx94X', runner: 'linux-gfx942-1gpu-ossci-rocm' }
+  - { os-release: '22.04', gpu: 'mi325', arch: 'gfx94X', runner: 'linux-gfx942-1gpu-core42-ossci-rocm' }
+  - { os-release: '24.04', gpu: 'mi325', arch: 'gfx94X', runner: 'linux-gfx942-1gpu-core42-ossci-rocm' }
   # Strix Halo
   - { os-release: '22.04', gpu: 'strix-halo', arch: 'gfx1151', runner: 'linux-strix-halo-gpu-rocm' }
   - { os-release: '24.04', gpu: 'strix-halo', arch: 'gfx1151', runner: 'linux-strix-halo-gpu-rocm' }

--- a/projects/rocprofiler-systems/.github/ci-matrix.yml
+++ b/projects/rocprofiler-systems/.github/ci-matrix.yml
@@ -5,8 +5,8 @@ matrix-nightly:
   - { os-release: '22.04', gpu: 'mi355', arch: 'gfx950', runner: 'linux-mi355-1gpu-ossci-rocm' }
   - { os-release: '24.04', gpu: 'mi355', arch: 'gfx950', runner: 'linux-mi355-1gpu-ossci-rocm' }
   # MI325
-  - { os-release: '22.04', gpu: 'mi325', arch: 'gfx94X', runner: 'linux-gfx942-1gpu-ossci-rocm' }
-  - { os-release: '24.04', gpu: 'mi325', arch: 'gfx94X', runner: 'linux-gfx942-1gpu-ossci-rocm' }
+  - { os-release: '22.04', gpu: 'mi325', arch: 'gfx94X', runner: 'linux-gfx942-1gpu-core42-ossci-rocm' }
+  - { os-release: '24.04', gpu: 'mi325', arch: 'gfx94X', runner: 'linux-gfx942-1gpu-core42-ossci-rocm' }
 matrix-ci:
   # MI355
   - { os-release: '24.04', gpu: 'mi355', arch: 'gfx950', runner: 'linux-mi355-1gpu-ossci-rocm' }


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
The runner name is being deprecated by EOD, so we need to migrate to `linux-gfx942-1gpu-core42-ossci-rocm` instead (same functionality)

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Update `ci-matrix.yml` files for both rocprofiler-systems and rocprofiler-compute to update gfx942 runner names to use the new label

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Ensure new labels function correctly and run/pass workflows

## Test Result

<!-- Briefly summarize test outcomes. -->
Workflows pass

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
