### PR TITLE
[rocprofiler-sdk] Fix FindrocDecode/FindrocJPEG tests

### DIFF
--- a/projects/rocprofiler-sdk/cmake/Modules/FindrocDecode.cmake
+++ b/projects/rocprofiler-sdk/cmake/Modules/FindrocDecode.cmake
@@ -51,18 +51,22 @@ function(_rocdecode_read_version_header _VERSION_VAR)
                                  "${rocDecode_INCLUDE_DIR}/rocdecode/rocdecode_version.h")
         file(READ "${rocDecode_INCLUDE_DIR}/rocdecode/rocdecode_version.h"
              _rocdecode_version)
-        macro(_rocdecode_get_version_num _VAR _NAME)
-            string(REGEX MATCH "define([ \t]+)${_NAME}([ \t]+)([0-9]+)" _tmp
-                         "${_rocdecode_version}")
+        macro(_rocdecode_get_version_num _VAR _COMPONENT)
             set(${_VAR} 0)
-            if(_tmp MATCHES "([0-9]+)")
-                string(REGEX REPLACE "(.*${_NAME}[ ]+)([0-9]+)" "\\2" ${_VAR} "${_tmp}")
-            endif()
+            foreach(_NAME "ROCDECODE_VERSION_${_COMPONENT}"
+                          "ROCDECODE_${_COMPONENT}_VERSION")
+                string(REGEX MATCH "define[ \t]+${_NAME}[ \t]+([0-9]+)" _tmp
+                             "${_rocdecode_version}")
+                if(_tmp)
+                    set(${_VAR} "${CMAKE_MATCH_1}")
+                    break()
+                endif()
+            endforeach()
         endmacro()
 
-        _rocdecode_get_version_num(_major "ROCDECODE_MAJOR_VERSION")
-        _rocdecode_get_version_num(_minor "ROCDECODE_MINOR_VERSION")
-        _rocdecode_get_version_num(_patch "ROCDECODE_PATCH_VERSION")
+        _rocdecode_get_version_num(_major "MAJOR")
+        _rocdecode_get_version_num(_minor "MINOR")
+        _rocdecode_get_version_num(_patch "PATCH")
         set(${_VERSION_VAR}
             ${_major}.${_minor}.${_patch}
             PARENT_SCOPE)

--- a/projects/rocprofiler-sdk/cmake/Modules/FindrocJPEG.cmake
+++ b/projects/rocprofiler-sdk/cmake/Modules/FindrocJPEG.cmake
@@ -49,18 +49,23 @@ find_library(
 function(_rocjpeg_read_version_header _VERSION_VAR)
     if(rocJPEG_INCLUDE_DIR AND EXISTS "${rocJPEG_INCLUDE_DIR}/rocjpeg/rocjpeg_version.h")
         file(READ "${rocJPEG_INCLUDE_DIR}/rocjpeg/rocjpeg_version.h" _rocjpeg_version)
-        macro(_rocjpeg_get_version_num _VAR _NAME)
-            string(REGEX MATCH "define([ \t]+)${_NAME}([ \t]+)([0-9]+)" _tmp
-                         "${_rocjpeg_version}")
+        macro(_rocjpeg_get_version_num _VAR _COMPONENT)
             set(${_VAR} 0)
-            if(_tmp MATCHES "([0-9]+)")
-                string(REGEX REPLACE "(.*${_NAME}[ ]+)([0-9]+)" "\\2" ${_VAR} "${_tmp}")
-            endif()
+            # rocJPEG headers define the version as ROCJPEG_VERSION_<COMPONENT>. Also
+            # tolerate the alternate ROCJPEG_<COMPONENT>_VERSION ordering.
+            foreach(_NAME "ROCJPEG_VERSION_${_COMPONENT}" "ROCJPEG_${_COMPONENT}_VERSION")
+                string(REGEX MATCH "define[ \t]+${_NAME}[ \t]+([0-9]+)" _tmp
+                             "${_rocjpeg_version}")
+                if(_tmp)
+                    set(${_VAR} "${CMAKE_MATCH_1}")
+                    break()
+                endif()
+            endforeach()
         endmacro()
 
-        _rocjpeg_get_version_num(_major "ROCJPEG_MAJOR_VERSION")
-        _rocjpeg_get_version_num(_minor "ROCJPEG_MINOR_VERSION")
-        _rocjpeg_get_version_num(_patch "ROCJPEG_MICRO_VERSION")
+        _rocjpeg_get_version_num(_major "MAJOR")
+        _rocjpeg_get_version_num(_minor "MINOR")
+        _rocjpeg_get_version_num(_patch "PATCH")
         set(${_VERSION_VAR}
             ${_major}.${_minor}.${_patch}
             PARENT_SCOPE)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/rocjpeg-trace/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/rocjpeg-trace/CMakeLists.txt
@@ -55,8 +55,8 @@ rocprofiler_add_integration_execute_test(
     rocprofv3-test-rocjpeg-tracing
     COMMAND
         $<TARGET_FILE:rocprofiler-sdk::rocprofv3> --rocjpeg-trace -d
-        ${CMAKE_CURRENT_BINARY_DIR}/%tag%-trace -o out --output-format json csv
-        --log-level env --
+        ${CMAKE_CURRENT_BINARY_DIR}/%tag%-trace -o out --output-format json csv pftrace
+        otf2 --log-level env --
         $<IF:$<TARGET_EXISTS:rocjpeg-demo>,$<TARGET_FILE:rocjpeg-demo>,rocjpeg-demo> -i
         ${rocJPEG_IMAGE_DIR}
     DEPENDS rocjpeg-demo

--- a/projects/rocprofiler-sdk/tests/rocprofv3/rocjpeg-trace/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/rocjpeg-trace/CMakeLists.txt
@@ -38,7 +38,7 @@ string(REPLACE "LD_PRELOAD=" "ROCPROF_PRELOAD=" PRELOAD_ENV
 
 set(rocjpeg-tracing-env "${PRELOAD_ENV}")
 
-set(rocJPEG_IMAGE_DIR "${ROCM_PATH}/share/rocjpeg/images")
+set(rocJPEG_IMAGE_DIR "${rocJPEG_ROOT_DIR}/share/rocjpeg/images")
 if(TARGET rocjpeg-demo AND NOT EXISTS "${rocJPEG_IMAGE_DIR}")
     message(
         WARNING "Unable to find image directory for rocjpeg tests: ${rocJPEG_IMAGE_DIR}")


### PR DESCRIPTION
## Motivation

Fix FindrocDecode/FindrocJPEG tests

## Technical Details

- **Version detection** (`FindrocDecode.cmake`, `FindrocJPEG.cmake`): the parser matched `ROCDECODE_MAJOR_VERSION` / `ROCJPEG_MICRO_VERSION`, but the installed headers define `ROC{DECODE,JPEG}_VERSION_{MAJOR,MINOR,PATCH}`. The version always resolved to `0.0.0`, failing the `VERSION_GREATER 0.8.0` / `0.6.0` gate in `tests/bin/CMakeLists.txt`, so `rocdecode-demo` / `rocjpeg-demo` were never built and every tracing test stayed `DISABLED`. Now parses the real version (1.8.0 / 1.6.0) and the demo apps build.

- **Sample-data path** (`rocprofv3/rocjpeg-trace`): resolve the image directory via `rocJPEG_ROOT_DIR` instead of `ROCM_PATH`, matching how the other tracing tests locate their data.

- **Output formats** (`rocprofv3/rocjpeg-trace`): the execute step only emitted `json csv`, but the validators read `out_results.otf2` / `out_results.pftrace`. Added `pftrace otf2` to `--output-format` (matching `rocdecode-trace`) so the OTF2/Perfetto checks actually run instead of skipping on missing files.

## JIRA ID

AIROCVAL-41

## Test Plan

Run tests on TheRock CI and ensure they all pass

## Test Result

All tests are passing under TheRock CI

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
