### PR TITLE
AIRUNTIME-2228 - Allow VRAM over-commit on Windows/DXG 

### DIFF
--- a/projects/rocr-runtime/libhsakmt/include/impl/wddm/gpu_memory.h
+++ b/projects/rocr-runtime/libhsakmt/include/impl/wddm/gpu_memory.h
@@ -221,6 +221,11 @@ public:
   ErrorCode MapMemoryToVirtualAddress(bool create_phys_mem = true);
   ErrorCode MakeResident();
   ErrorCode Evict();
+
+  // Pin/unpin kSystem allocations into RAM via D3DKMTLock2/Unlock2. Held for
+  // the allocation lifetime to prevent KMD-side eviction/trim of backing pages.
+  ErrorCode LockSystemMemory();
+  ErrorCode UnlockSystemMemory();
   ErrorCode CreatePhysicalMemory();
   ErrorCode FreePhysicalMemory();
 
@@ -258,6 +263,7 @@ private:
   int mem_fd_; // IPC sigal's sys mem fd
 
   bool is_phymem_created = false; // status of physical memory allocation
+  bool is_sysmem_locked_ = false; // kSystem allocation pinned via D3DKMTLock2
 
   DISALLOW_COPY_AND_ASSIGN(GpuMemory);
 };

--- a/projects/rocr-runtime/libhsakmt/include/impl/wddm/thunks.h
+++ b/projects/rocr-runtime/libhsakmt/include/impl/wddm/thunks.h
@@ -200,6 +200,14 @@ inline ErrorCode Evict(EvictArgs *args) {
   return TranslateNtStatus(DXCORE_CALL(D3DKMTEvict(args)));
 }
 
+inline ErrorCode Lock2(Lock2Args *args) {
+  return TranslateNtStatus(DXCORE_CALL(D3DKMTLock2(args)));
+}
+
+inline ErrorCode Unlock2(Unlock2Args *args) {
+  return TranslateNtStatus(DXCORE_CALL(D3DKMTUnlock2(args)));
+}
+
 inline ErrorCode ShareObjects(size_t num_allocations,
                                WinResourceHandle resource,
                                uint32_t flags,

--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/device.cpp
@@ -923,9 +923,11 @@ bool WDDMDevice::SubmitToAqlQueue(WDDMQueue* queue, uint64_t command_addr, uint6
   void* priv_data = alloca(priv_size);
   memset(priv_data, 0, priv_size);
   Wkmi::FillinAqlSubmitPrivData(priv_data, fence_value);
+  // HwQueueProgressFenceId is UINT64 in the DDI; drop the 32-bit
+  // truncation so the full fence value reaches WDDM.
   D3DKMT_SUBMITCOMMANDTOHWQUEUE args = {
       .hHwQueue = queue->queue,
-      .HwQueueProgressFenceId = static_cast<ULONG>(fence_value + 1),
+      .HwQueueProgressFenceId = fence_value + 1,
       .CommandBuffer = command_addr,
       .CommandLength = static_cast<UINT>(command_size),
       .PrivateDriverDataSize = static_cast<UINT>(priv_size),

--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/gpu_memory.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/gpu_memory.cpp
@@ -141,8 +141,10 @@ ErrorCode GpuMemory::Init(const GpuMemoryCreateInfo &create_info) {
     }
   }
 
-  if (!GetDevice()->WaitOnPagingFenceFromCpu())
+  if (!GetDevice()->WaitOnPagingFenceFromCpu()) {
+    (void)UnlockSystemMemory();
     code = ErrorCode::Unknown;
+  }
 
   return code;
 }

--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/gpu_memory.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/gpu_memory.cpp
@@ -54,6 +54,9 @@ GpuMemory::GpuMemory(WDDMDevice *device) : device_(device) {
 }
 
 GpuMemory::~GpuMemory() {
+  // Release the Lock2 pin before tearing down the allocation handles, since
+  // DestroyAllocation invalidates the handles Unlock2 needs.
+  UnlockSystemMemory();
   FreeGpuVirtualAddress(GpuAddress(), Size());
   FreePhysicalMemory();
   if (desc_.handle_ape_addr > 0)
@@ -127,6 +130,16 @@ ErrorCode GpuMemory::Init(const GpuMemoryCreateInfo &create_info) {
   code = MakeResident();
   if (code != ErrorCode::Success)
     return code;
+
+  // Pin kSystem backing pages via D3DKMTLock2 so KMD cannot evict/trim them.
+  // Excludes imported/exporter sysmem-fd paths which manage their own lifetime.
+  if (IsSystem() && !IsSysMemFd() && !IsSysMemExporter()) {
+    auto lock_code = LockSystemMemory();
+    if (lock_code != ErrorCode::Success) {
+      code = lock_code;
+      return code;
+    }
+  }
 
   if (!GetDevice()->WaitOnPagingFenceFromCpu())
     code = ErrorCode::Unknown;
@@ -435,6 +448,65 @@ ErrorCode GpuMemory::MakeResident() {
     code = ErrorCode::Success;
   }
   return code;
+}
+
+ErrorCode GpuMemory::LockSystemMemory() {
+  // Issue D3DKMTLock2 per allocation handle so KMD/VidMm pins the backing
+  // system-memory pages for the lifetime of the allocation.
+  if (is_sysmem_locked_)
+    return ErrorCode::Success;
+
+  const auto num_chunks = NumChunks();
+  for (size_t i = 0; i < num_chunks; i++) {
+    D3DKMT_LOCK2 args = {};
+    args.hDevice = device_->DeviceHandle();
+    args.hAllocation = GetAllocationHandle(i);
+
+    auto code = d3dthunk::Lock2(&args);
+    if (code != ErrorCode::Success) {
+      pr_err("[sysmem-lock] D3DKMTLock2 failed on chunk %zu/%zu (code=%d) "
+             "size=%llu mem_flags=0x%x\n",
+             i, num_chunks, static_cast<int>(code),
+             static_cast<unsigned long long>(desc_.size),
+             static_cast<unsigned>(desc_.mem_flags));
+
+      // Unwind the chunks we already locked so we don't leak pins.
+      for (size_t j = 0; j < i; j++) {
+        D3DKMT_UNLOCK2 unlock_args = {};
+        unlock_args.hDevice = device_->DeviceHandle();
+        unlock_args.hAllocation = GetAllocationHandle(j);
+        (void)d3dthunk::Unlock2(&unlock_args);
+      }
+      return code;
+    }
+  }
+
+  is_sysmem_locked_ = true;
+  return ErrorCode::Success;
+}
+
+ErrorCode GpuMemory::UnlockSystemMemory() {
+  if (!is_sysmem_locked_)
+    return ErrorCode::Success;
+
+  auto final_code = ErrorCode::Success;
+  const auto num_chunks = NumChunks();
+  for (size_t i = 0; i < num_chunks; i++) {
+    D3DKMT_UNLOCK2 args = {};
+    args.hDevice = device_->DeviceHandle();
+    args.hAllocation = GetAllocationHandle(i);
+
+    auto code = d3dthunk::Unlock2(&args);
+    if (code != ErrorCode::Success) {
+      pr_err("[sysmem-lock] D3DKMTUnlock2 failed on chunk %zu/%zu (code=%d)\n",
+             i, num_chunks, static_cast<int>(code));
+      final_code = code;
+      // Continue unlocking remaining chunks regardless.
+    }
+  }
+
+  is_sysmem_locked_ = false;
+  return final_code;
 }
 
 ErrorCode GpuMemory::Evict() {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -377,7 +377,12 @@ KfdDriver::AllocateMemory(const core::MemoryRegion &mem_region,
       (HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes(*mem, size, &alternate_va, map_flag,
                                              map_node_count, const_cast<uint32_t*>(map_node_id))) == HSAKMT_STATUS_SUCCESS);
 
+    // On Windows/DXG, allow allocations to succeed even if MakeResident
+    // is best-effort; WDDM will demand-page on GPU access.
+    const bool is_dxg =
+        core::Runtime::runtime_singleton_->thunkLoader()->IsDXG();
     const bool require_pinning =
+        !is_dxg &&
         (!m_region.full_profile() || m_region.IsLocalMemory() ||
          m_region.IsScratch());
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_memory_region.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_memory_region.cpp
@@ -148,10 +148,13 @@ hsa_status_t MemoryRegion::AllocateImpl(size_t& size, AllocateFlags alloc_flags,
     return HSA_STATUS_ERROR_INVALID_ALLOCATION;
   }
 
-  // Alocation requests for system memory considers aggregate
-  // memory available on all CPU devices
-  if (size > ((IsSystem() ?
-                max_sysmem_alloc_size_ : max_single_alloc_size_))) {
+  // Skip the per-region cap on Windows/DXG so over-commit requests can
+  // reach WDDM; system memory still enforces the cap.
+  const bool is_dxg = core::Runtime::runtime_singleton_->thunkLoader()->IsDXG();
+  if (IsSystem() && (size > max_sysmem_alloc_size_)) {
+    return HSA_STATUS_ERROR_INVALID_ALLOCATION;
+  }
+  if (!IsSystem() && !is_dxg && (size > max_single_alloc_size_)) {
     return HSA_STATUS_ERROR_INVALID_ALLOCATION;
   }
 


### PR DESCRIPTION
## Motivation

1. Bypasses the host-side residency pinning requirement and the per-region single-allocation size cap when running on the DXG/WDDM path, so over-commit allocation requests reach WDDM instead of being rejected up front.

2. Fix HwQueueProgressFenceId truncation in SubmitToAqlQueue : The DDI field HwQueueProgressFenceId is 64-bit, but the value was being narrowed with a static_cast<ULONG> before submission. Removes the 32-bit truncation so the full 64-bit fence value is passed to WDDM, preventing fence-ID wraparound/mismatch on long-running queues.

3. Lock System Memory handles to prevent trimming : After MakeResident succeeds for kSystem allocations, pins each allocation handle via D3DKMTLock2 (new d3dthunk::Lock2/Unlock2 wrappers) so KMD/VidMm cannot evict or trim the backing system-memory pages for the allocation's lifetime; the pin is released via D3DKMTUnlock2 in the destructor before the handles are destroyed. Excludes the imported/exporter sysmem-fd paths, which manage their own lifetime.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
