### PR TITLE
[ci] Adding multi arch CI ASAN to rocm-systems

### DIFF
--- a/.github/workflows/therock_multi_arch_ci_asan.yml
+++ b/.github/workflows/therock_multi_arch_ci_asan.yml
@@ -1,13 +1,18 @@
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
+# Multi-Arch CI Host ASAN for rocm-systems
+#
+# This workflow runs host Address Sanitizer (ASAN) builds and tests
+# using TheRock's multi-arch CI pipeline.
+
 name: TheRock Multi-Arch CI ASAN
 
 on:
   push:
     branches:
       - develop
-      - users/geomin12/host-asan # TODO: remove after testing
+      - users/geomin12/host-asan
   workflow_dispatch:
     inputs:
       linux_amdgpu_families:
@@ -50,16 +55,44 @@ jobs:
   linux_build_and_test:
     name: Linux::${{ fromJSON(needs.setup.outputs.linux_build_config || '{}').build_variant_label || 'skip' }}
     needs: setup
-    if: ${{ needs.setup.outputs.linux_build_config != '' && needs.setup.outputs.enable_build_jobs == 'true' }}
+    if: >-
+      ${{
+        needs.setup.outputs.linux_build_config != '' &&
+        needs.setup.outputs.enable_build_jobs == 'true'
+      }}
     uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@685f8c3b89006309b34a7c16de17e841400f0d76 # 2026-05-29 commit
     secrets: inherit
     with:
       build_config: ${{ needs.setup.outputs.linux_build_config }}
       test_labels: ${{ needs.setup.outputs.linux_test_labels }}
       rocm_package_version: ${{ needs.setup.outputs.rocm_package_version }}
-      rocm_deb_package_version: ${{ needs.setup.outputs.rocm_deb_package_version }}
-      rocm_rpm_package_version: ${{ needs.setup.outputs.rocm_rpm_package_version }}
       test_type: ${{ needs.setup.outputs.test_type }}
+      external_repo_config: ${{ needs.setup.outputs.external_repo_config }}
+      repository: ROCm/TheRock
+      ref: "685f8c3b89006309b34a7c16de17e841400f0d76" # 2026-05-29 commit
     permissions:
       contents: read
       id-token: write
+
+  multi_arch_ci_summary:
+    name: Multi-Arch CI Summary
+    if: always()
+    needs:
+      - setup
+      - linux_build_and_test
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout TheRock repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: "ROCm/TheRock"
+          ref: "685f8c3b89006309b34a7c16de17e841400f0d76" # 2026-05-29 commit
+          sparse-checkout: build_tools/github_actions
+          sparse-checkout-cone-mode: true
+
+      - name: Evaluate workflow results
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python build_tools/github_actions/workflow_summary.py \
+            --needs-json '${{ toJSON(needs) }}'

--- a/.github/workflows/therock_multi_arch_ci_asan.yml
+++ b/.github/workflows/therock_multi_arch_ci_asan.yml
@@ -1,0 +1,40 @@
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+name: TheRock Multi-Arch CI ASAN
+
+on:
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  setup:
+    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@685f8c3b89006309b34a7c16de17e841400f0d76 # 2026-05-29 commit
+    with:
+      build_variant: "host-asan"
+
+  linux_build_and_test:
+    name: Linux::${{ fromJSON(needs.setup.outputs.linux_build_config || '{}').build_variant_label || 'skip' }}
+    needs: setup
+    if: ${{ needs.setup.outputs.linux_build_config != '' && needs.setup.outputs.enable_build_jobs == 'true' }}
+    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@685f8c3b89006309b34a7c16de17e841400f0d76 # 2026-05-29 commit
+    secrets: inherit
+    with:
+      build_config: ${{ needs.setup.outputs.linux_build_config }}
+      test_labels: ${{ needs.setup.outputs.linux_test_labels }}
+      rocm_package_version: ${{ needs.setup.outputs.rocm_package_version }}
+      rocm_deb_package_version: ${{ needs.setup.outputs.rocm_deb_package_version }}
+      rocm_rpm_package_version: ${{ needs.setup.outputs.rocm_rpm_package_version }}
+      test_type: ${{ needs.setup.outputs.test_type }}
+    permissions:
+      contents: read
+      id-token: write

--- a/.github/workflows/therock_multi_arch_ci_asan.yml
+++ b/.github/workflows/therock_multi_arch_ci_asan.yml
@@ -12,7 +12,6 @@ on:
   push:
     branches:
       - develop
-      - users/geomin12/host-asan
   workflow_dispatch:
     inputs:
       linux_amdgpu_families:

--- a/.github/workflows/therock_multi_arch_ci_asan.yml
+++ b/.github/workflows/therock_multi_arch_ci_asan.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - develop
+      - users/geomin12/host-asan # TODO: remove after testing
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/therock_multi_arch_ci_asan.yml
+++ b/.github/workflows/therock_multi_arch_ci_asan.yml
@@ -9,6 +9,23 @@ on:
       - develop
       - users/geomin12/host-asan # TODO: remove after testing
   workflow_dispatch:
+    inputs:
+      linux_amdgpu_families:
+        type: string
+        description: "Insert comma-separated list of Linux GPU families to build and test. ex: gfx94X, gfx120X"
+        default: ""
+      linux_test_labels:
+        type: string
+        description: "If enabled, reduce test set on Linux to the list of labels prefixed with 'test:'. ex: test:rocprim, test:hipcub"
+        default: ""
+      prebuilt_stages:
+        type: string
+        default: ""
+        description: "Comma-separated build stages to skip (or 'all' for all stages); artifacts are copied from baseline_run_id instead"
+      baseline_run_id:
+        type: string
+        default: ""
+        description: "Workflow run ID to copy prebuilt stage artifacts from; required when prebuilt_stages is set"
 
 permissions:
   contents: read
@@ -22,6 +39,13 @@ jobs:
     uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@685f8c3b89006309b34a7c16de17e841400f0d76 # 2026-05-29 commit
     with:
       build_variant: "host-asan"
+      linux_amdgpu_families: ${{ inputs.linux_amdgpu_families || 'gfx94X,gfx950' }}
+      linux_test_labels: ${{ inputs.linux_test_labels || '' }}
+      prebuilt_stages: ${{ inputs.prebuilt_stages || '' }}
+      baseline_run_id: ${{ inputs.baseline_run_id || '' }}
+      repository: ROCm/TheRock
+      ref: "685f8c3b89006309b34a7c16de17e841400f0d76" # 2026-05-29 commit
+      external_repo: '{"repository":"${{ github.repository }}","ref":"${{ github.sha }}"}'
 
   linux_build_and_test:
     name: Linux::${{ fromJSON(needs.setup.outputs.linux_build_config || '{}').build_variant_label || 'skip' }}

--- a/.github/workflows/therock_multi_arch_ci_asan.yml
+++ b/.github/workflows/therock_multi_arch_ci_asan.yml
@@ -35,7 +35,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -43,6 +43,8 @@ jobs:
     uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@685f8c3b89006309b34a7c16de17e841400f0d76 # 2026-05-29 commit
     with:
       build_variant: "host-asan"
+      # targets gfx94X and gfx950 are selected to replicate the ASAN coverage in TheRock
+      # as ASAN builds and tests require more resources, we only target these two architectures for the timebeing.
       linux_amdgpu_families: ${{ inputs.linux_amdgpu_families || 'gfx94X,gfx950' }}
       linux_test_labels: ${{ inputs.linux_test_labels || '' }}
       prebuilt_stages: ${{ inputs.prebuilt_stages || '' }}
@@ -75,6 +77,7 @@ jobs:
 
   multi_arch_ci_summary:
     name: Multi-Arch CI Summary
+    # always() is needed to show the job statuses regardless of failure
     if: always()
     needs:
       - setup


### PR DESCRIPTION
On post-submit, CI ASAN will run for host-asan to get signal

works here: https://github.com/ROCm/rocm-systems/actions/runs/26667553785/job/78604149328

cancelled CI as this is new workflow and irrelevant