### PR TITLE
[AMD-SMI] Fabric telemetry: status-returning ID lookup + binary-compat guard

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -30,7 +30,7 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 - **Added IFoE/UALoE fabric telemetry and topology support**.  
   - New `amd-smi fabric` CLI subcommand with `--topology`/`-t` and `--info`/`-i` flags for querying fabric (UALoE) information.
-  - New C APIs: `amdsmi_alloc_fabric_telemetry()`, `amdsmi_get_fabric_telemetry_data()`, `amdsmi_free_fabric_telemetry()`, `amdsmi_fabric_telem_id_to_string()`, and `amdsmi_get_gpu_fabric_info()`.
+  - New C APIs: `amdsmi_alloc_fabric_telemetry()`, `amdsmi_get_fabric_telemetry_data()`, `amdsmi_free_fabric_telemetry()`, `amdsmi_get_gpu_fabric_info()`, and `amdsmi_fabric_telem_id_to_string()` — the last returns `amdsmi_status_t` and writes the telemetry-item name through an output parameter (`AMDSMI_STATUS_INVAL` on a NULL parameter, `AMDSMI_STATUS_NOT_FOUND` for an unrecognized ID).
   - New Python APIs: `amdsmi_get_fabric_telemetry_data()` and `amdsmi_get_gpu_fabric_info()`.
   - Fabric telemetry category masks and size constants converted from preprocessor `#define`s to enums so they are exposed through the Python wrapper.
 

--- a/projects/amdsmi/example/amd_smi_fabric_example.cc
+++ b/projects/amdsmi/example/amd_smi_fabric_example.cc
@@ -201,9 +201,13 @@ int main() {
               // Display items for this instance
               for (uint32_t item_idx = 0; item_idx < instance->item_count; item_idx++) {
                 auto& item = instance->items[item_idx];
+                const char* item_name = nullptr;
+                amdsmi_status_t name_status = amdsmi_fabric_telem_id_to_string(item.id, &item_name);
+                if (name_status != AMDSMI_STATUS_SUCCESS) {
+                  item_name = "UNKNOWN";
+                }
                 std::cout << "\t\t\t\t\t\tItem " << item_idx << ": "
-                          << "ID=0x" << std::hex << item.id << std::dec << "("
-                          << amdsmi_fabric_telem_id_to_string(item.id) << ")"
+                          << "ID=0x" << std::hex << item.id << std::dec << "(" << item_name << ")"
                           << ", Value=" << item.value << std::endl;
               }
             }

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -5714,18 +5714,21 @@ amdsmi_status_t amdsmi_get_fabric_telemetry_data(amdsmi_processor_handle process
  *
  *  @platform{gpu_bm_linux}
  *
- *  @details Given a telemetry item ID @p telem_id,
- *  this function returns a pointer to a string containing the human-readable name
- *  for the specified telemetry item. The returned string is statically allocated
- *  and should not be freed by the caller.
+ *  @details Given a telemetry item ID @p telem_id, this function writes a
+ *  pointer to the statically allocated, human-readable name string for the
+ *  specified telemetry item into @p name.
  *
+ *  @param[in] telem_id - The telemetry item ID for which the name is requested
  *
- *  @param[in] telem_id The telemetry item ID for which the name is requested
+ *  @param[out] name - Pointer to a string pointer. On success @p *name is set to
+ *  the statically allocated item name; on ::AMDSMI_STATUS_NOT_FOUND @p *name is
+ *  set to NULL. The string must not be freed by the caller.
  *
- *  @return const char* | Pointer to string containing the telemetry item name,
- *  or UNKNOWN if the category or telemetry ID is not recognized
+ *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success,
+ *  ::AMDSMI_STATUS_INVAL if @p name is NULL,
+ *  ::AMDSMI_STATUS_NOT_FOUND if @p telem_id is not recognized.
  */
-const char* amdsmi_fabric_telem_id_to_string(uint64_t telem_id);
+amdsmi_status_t amdsmi_fabric_telem_id_to_string(uint64_t telem_id, const char** name);
 
 /**
  *  @brief Free Fabric telemetry storage

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -7028,20 +7028,17 @@ def amdsmi_get_fabric_telemetry_data(
                 for item_idx in range(inst.item_count):
                     item = inst.items[item_idx]
                     telem_id = item.id
-                    name_ptr = amdsmi_wrapper.amdsmi_fabric_telem_id_to_string(telem_id)
-                    # Handle both c_char_p (string) and POINTER(c_char) (pointer) return types
-                    if name_ptr:
-                        if isinstance(name_ptr, bytes):
-                            name_str = name_ptr.decode("utf-8")
-                        elif hasattr(name_ptr, "value"):
-                            # c_char_p has a .value attribute
-                            name_str = (
-                                name_ptr.value.decode("utf-8") if name_ptr.value else "UNKNOWN"
-                            )
-                        else:
-                            # POINTER(c_char) - dereference and convert to string
-                            name_str = ctypes.string_at(name_ptr).decode("utf-8")
+                    name_ptr = ctypes.POINTER(ctypes.c_char)()
+                    name_status = amdsmi_wrapper.amdsmi_fabric_telem_id_to_string(
+                        telem_id, ctypes.byref(name_ptr)
+                    )
+                    if name_status == amdsmi_wrapper.AMDSMI_STATUS_SUCCESS and name_ptr:
+                        name_str = ctypes.string_at(name_ptr).decode("utf-8")
+                    elif name_status == amdsmi_wrapper.AMDSMI_STATUS_NOT_FOUND:
+                        name_str = "UNKNOWN"
                     else:
+                        # Only SUCCESS/NOT_FOUND are expected; surface anything else.
+                        _check_res(name_status)
                         name_str = "UNKNOWN"
                     items.append({"id": telem_id, "name": name_str, "value": item.value})
                 instances.append(

--- a/projects/amdsmi/py-interface/amdsmi_wrapper.py
+++ b/projects/amdsmi/py-interface/amdsmi_wrapper.py
@@ -3564,8 +3564,8 @@ except AttributeError:
     pass
 try:
     amdsmi_fabric_telem_id_to_string = _libraries['libamd_smi.so'].amdsmi_fabric_telem_id_to_string
-    amdsmi_fabric_telem_id_to_string.restype = ctypes.POINTER(ctypes.c_char)
-    amdsmi_fabric_telem_id_to_string.argtypes = [uint64_t]
+    amdsmi_fabric_telem_id_to_string.restype = amdsmi_status_t
+    amdsmi_fabric_telem_id_to_string.argtypes = [uint64_t, ctypes.POINTER(ctypes.POINTER(ctypes.c_char))]
 except AttributeError:
     pass
 try:

--- a/projects/amdsmi/rust-interface/src/amdsmi_wrapper.rs
+++ b/projects/amdsmi/rust-interface/src/amdsmi_wrapper.rs
@@ -4392,7 +4392,10 @@ extern "C" {
     ) -> AmdsmiStatusT;
 }
 extern "C" {
-    pub fn amdsmi_fabric_telem_id_to_string(telem_id: u64) -> *const ::std::os::raw::c_char;
+    pub fn amdsmi_fabric_telem_id_to_string(
+        telem_id: u64,
+        name: *mut *const ::std::os::raw::c_char,
+    ) -> AmdsmiStatusT;
 }
 extern "C" {
     pub fn amdsmi_free_fabric_telemetry(

--- a/projects/amdsmi/src/amd_smi/amd_smi_ualoe.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_ualoe.cc
@@ -38,6 +38,7 @@ extern "C" {
 }
 
 #include <algorithm>
+#include <cstddef>
 #include <unordered_map>
 
 /**
@@ -630,7 +631,42 @@ amdsmi_status_t amdsmi_alloc_fabric_telemetry(amdsmi_processor_handle processor_
     return convert_errno_to_amdsmi_status(ret);
   }
 
-  // Cast UALoE telemetry directly to AMDSMI telemetry since structures are now binary compatible
+  // Cast UALoE telemetry directly to AMDSMI telemetry since structures are now
+  // binary compatible. The cast is traversed as datasets -> instances -> items,
+  // so guard size and alignment of every struct in that chain at compile time.
+  static_assert(sizeof(amdsmi_fabric_telemetry_t) == sizeof(ualoe_telemetry_t),
+                "amdsmi_fabric_telemetry_t and ualoe_telemetry_t must be binary compatible");
+  static_assert(alignof(amdsmi_fabric_telemetry_t) == alignof(ualoe_telemetry_t),
+                "amdsmi_fabric_telemetry_t and ualoe_telemetry_t must have matching alignment");
+  static_assert(
+      sizeof(amdsmi_fabric_telemetry_dataset_t) == sizeof(ualoe_telemetry_dataset_t),
+      "amdsmi_fabric_telemetry_dataset_t and ualoe_telemetry_dataset_t must be binary compatible");
+  static_assert(alignof(amdsmi_fabric_telemetry_dataset_t) == alignof(ualoe_telemetry_dataset_t),
+                "amdsmi_fabric_telemetry_dataset_t and ualoe_telemetry_dataset_t must have "
+                "matching alignment");
+  static_assert(sizeof(amdsmi_fabric_telemetry_instance_t) == sizeof(ualoe_telemetry_instance_t),
+                "amdsmi_fabric_telemetry_instance_t and ualoe_telemetry_instance_t must be binary "
+                "compatible");
+  static_assert(alignof(amdsmi_fabric_telemetry_instance_t) == alignof(ualoe_telemetry_instance_t),
+                "amdsmi_fabric_telemetry_instance_t and ualoe_telemetry_instance_t must have "
+                "matching alignment");
+  static_assert(
+      sizeof(amdsmi_fabric_telemetry_item_t) == sizeof(ualoe_telemetry_item_t),
+      "amdsmi_fabric_telemetry_item_t and ualoe_telemetry_item_t must be binary compatible");
+  static_assert(
+      alignof(amdsmi_fabric_telemetry_item_t) == alignof(ualoe_telemetry_item_t),
+      "amdsmi_fabric_telemetry_item_t and ualoe_telemetry_item_t must have matching alignment");
+  // Size and alignment alone can miss independent field reordering, so pin the
+  // offset of the pointer members the cast dereferences and one trailing scalar.
+  static_assert(offsetof(amdsmi_fabric_telemetry_dataset_t, instances) ==
+                    offsetof(ualoe_telemetry_dataset_t, instances),
+                "dataset instances pointer must be at the same offset");
+  static_assert(offsetof(amdsmi_fabric_telemetry_instance_t, items) ==
+                    offsetof(ualoe_telemetry_instance_t, items),
+                "instance items pointer must be at the same offset");
+  static_assert(
+      offsetof(amdsmi_fabric_telemetry_item_t, value) == offsetof(ualoe_telemetry_item_t, value),
+      "item value must be at the same offset");
   *telemetry = reinterpret_cast<amdsmi_fabric_telemetry_t*>(ualoe_tel);
 
   return AMDSMI_STATUS_SUCCESS;

--- a/projects/amdsmi/src/amd_smi/amd_smi_ualoe.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_ualoe.cc
@@ -562,12 +562,17 @@ static const std::unordered_map<uint64_t, const char*> telemetry_id_map = {
      "NETPORT_FEC_CW_SYMBOL_ERRS_UNCORRECTABLE"},
 };
 
-const char* amdsmi_fabric_telem_id_to_string(uint64_t telem_id) {
-  auto it = telemetry_id_map.find(telem_id);
-  if (it != telemetry_id_map.end()) {
-    return it->second;
+amdsmi_status_t amdsmi_fabric_telem_id_to_string(uint64_t telem_id, const char** name) {
+  if (name == nullptr) {
+    return AMDSMI_STATUS_INVAL;
   }
-  return "UNKNOWN";
+  auto it = telemetry_id_map.find(telem_id);
+  if (it == telemetry_id_map.end()) {
+    *name = nullptr;
+    return AMDSMI_STATUS_NOT_FOUND;
+  }
+  *name = it->second;
+  return AMDSMI_STATUS_SUCCESS;
 }
 
 // Note: AMDSMI and UALoE telemetry structures are now designed to be binary compatible

--- a/projects/amdsmi/tests/amd_smi_test/functional/fabric_read.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/fabric_read.cc
@@ -175,30 +175,38 @@ void TestFabricRead::Run(void) {
     }
     CHK_ERR_ASRT(err)
 
-    IF_VERB(STANDARD) {
-      // Walk datasets and print a sample of telemetry items
-      for (uint32_t cat = 0; cat < AMDSMI_FABRIC_TELEMETRY_CATEGORY_MAX; ++cat) {
-        if (!tel->datasets[cat]) continue;
-        const auto& ds = *tel->datasets[cat];
+    // Walk datasets, resolving every telemetry item id. The id->name lookup
+    // must succeed for every valid id the driver reports, so assert
+    // unconditionally; the human-readable dump stays verbose-only.
+    for (uint32_t cat = 0; cat < AMDSMI_FABRIC_TELEMETRY_CATEGORY_MAX; ++cat) {
+      if (!tel->datasets[cat]) continue;
+      const auto& ds = *tel->datasets[cat];
+      IF_VERB(STANDARD) {
         std::cout << "\t\tcategory[" << cat << "]"
                   << "  instances=" << ds.instance_count << "  gen_count=" << ds.generation_count
                   << "\n";
+      }
 
-        for (uint32_t inst = 0; inst < ds.instance_count; ++inst) {
-          const auto& in = ds.instances[inst];
+      for (uint32_t inst = 0; inst < ds.instance_count; ++inst) {
+        const auto& in = ds.instances[inst];
+        IF_VERB(STANDARD) {
           std::cout << "\t\t  instance[" << inst << "] " << in.name.text
                     << "  logical_idx=" << in.logical_idx << "  items=" << in.item_count << "\n";
+        }
 
-          // ── amdsmi_fabric_telem_id_to_string ─────────────────────────────
-          for (uint32_t item = 0; item < in.item_count; ++item) {
-            const auto& it = in.items[item];
-            const char* name = amdsmi_fabric_telem_id_to_string(it.id);
+        for (uint32_t item = 0; item < in.item_count; ++item) {
+          const auto& it = in.items[item];
+          const char* name = nullptr;
+          amdsmi_status_t name_status = amdsmi_fabric_telem_id_to_string(it.id, &name);
+
+          // amdsmi_fabric_telem_id_to_string must succeed and return a
+          // non-null string for any valid id obtained from the driver
+          ASSERT_EQ(name_status, AMDSMI_STATUS_SUCCESS);
+          ASSERT_NE(name, nullptr);
+
+          IF_VERB(STANDARD) {
             std::cout << "\t\t    [" << item << "] id=0x" << std::hex << it.id << std::dec
                       << "  name=" << (name ? name : "NULL") << "  value=" << it.value << "\n";
-
-            // amdsmi_fabric_telem_id_to_string must return a non-null string
-            // for any valid id obtained from the driver
-            ASSERT_NE(name, nullptr);
           }
         }
       }
@@ -215,4 +223,14 @@ void TestFabricRead::Run(void) {
     err = amdsmi_free_fabric_telemetry(device, nullptr);
     ASSERT_EQ(err, AMDSMI_STATUS_INVAL);
   }
+
+  // amdsmi_fabric_telem_id_to_string negative paths require no device, so run
+  // them outside the per-device loop where they execute unconditionally.
+  err = amdsmi_fabric_telem_id_to_string(0, nullptr);
+  ASSERT_EQ(err, AMDSMI_STATUS_INVAL);
+
+  const char* bad_name = nullptr;
+  err = amdsmi_fabric_telem_id_to_string(0xBAADF00DDEADBEEFULL, &bad_name);
+  ASSERT_EQ(err, AMDSMI_STATUS_NOT_FOUND);
+  ASSERT_EQ(bad_name, nullptr);
 }

--- a/projects/amdsmi/tests/python/functional/ifoe/test_telemetry.py
+++ b/projects/amdsmi/tests/python/functional/ifoe/test_telemetry.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) Advanced Micro Devices. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""Functional tests for fabric (UALoE) telemetry and fabric info."""
+
+import unittest
+
+import common.common as common
+from common.common import amdsmi
+
+# Union of all known fabric telemetry category masks.
+ALL_CATEGORIES = amdsmi.amdsmi_wrapper.AMDSMI_FABRIC_TELEMETRY_CATEGORY_MASK_ALL_KNOWN
+
+
+class TestIfoeTelemetry(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.common = common.Common(common.verbose)
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            amdsmi.amdsmi_shut_down()
+        except amdsmi.AmdSmiLibraryException:
+            pass
+
+    def setUp(self):
+        self.raise_exception = None
+        self.common.amdsmi_smart_init()
+        self.common.processors = amdsmi.amdsmi_get_processor_handles()
+
+    def tearDown(self):
+        amdsmi.amdsmi_shut_down()
+
+    def test_fabric_telemetry(self):
+        """Exercise alloc/get/free + amdsmi_fabric_telem_id_to_string round-trip.
+
+        On systems without an IFoE driver the API returns DRIVER_NOT_LOADED or
+        NOT_SUPPORTED; treat either as a pass condition rather than a hard
+        failure.
+        """
+        self.common.print_func_name("")
+
+        expected_unavailable_statuses = (
+            amdsmi.AmdSmiStatus.DRIVER_NOT_LOADED,
+            amdsmi.AmdSmiStatus.NOT_SUPPORTED,
+        )
+
+        for i, gpu in enumerate(self.common.processors):
+            self.common.print_device_header(i)
+
+            msg = f"\t### amdsmi_get_fabric_telemetry_data(gpu={i}):"
+            try:
+                telem = amdsmi.amdsmi_get_fabric_telemetry_data(gpu, ALL_CATEGORIES)
+                self.common.print(msg, telem)
+                self.common.check_ret("", "", self.common.PASS)
+                self.assertIsInstance(telem, list)
+                for category in telem:
+                    self.assertIn("category", category)
+                    self.assertIn("instances", category)
+                    for instance in category["instances"]:
+                        for item in instance["items"]:
+                            self.assertIn("id", item)
+                            self.assertIn("name", item)
+                            self.assertIsInstance(item["name"], str)
+                            # Every driver-provided id must resolve to a known
+                            # name; a fallback of "UNKNOWN" indicates a gap.
+                            self.assertNotEqual(item["name"], "UNKNOWN")
+            except amdsmi.AmdSmiLibraryException as e:
+                if e.get_error_code() in expected_unavailable_statuses:
+                    self.common.print(msg, f"skipped: {e}")
+                    self.common.check_ret("", "", self.common.PASS)
+                elif self.common.check_ret(msg, e, self.common.PASS):
+                    self.raise_exception = e
+            except amdsmi.AmdSmiParameterException as e:
+                if self.common.check_ret(msg, e, self.common.PASS):
+                    self.raise_exception = e
+
+            msg = f"\t### amdsmi_get_gpu_fabric_info(gpu={i}):"
+            try:
+                info = amdsmi.amdsmi_get_gpu_fabric_info(gpu)
+                self.common.print(msg, info)
+                self.common.check_ret("", "", self.common.PASS)
+                self.assertIsInstance(info, dict)
+                self.assertIn("version", info)
+                self.assertIn("fabric_type", info)
+            except amdsmi.AmdSmiLibraryException as e:
+                if e.get_error_code() in expected_unavailable_statuses:
+                    self.common.print(msg, f"skipped: {e}")
+                    self.common.check_ret("", "", self.common.PASS)
+                elif self.common.check_ret(msg, e, self.common.PASS):
+                    self.raise_exception = e
+            except amdsmi.AmdSmiParameterException as e:
+                if self.common.check_ret(msg, e, self.common.PASS):
+                    self.raise_exception = e
+
+        if self.raise_exception:
+            raise self.raise_exception
+        return
+
+    def test_get_fabric_telemetry_data(self):
+        self.common.print_func_name("")
+        self.common.Test_API_Per_GPU(
+            amdsmi_get_fabric_telemetry_data=amdsmi.amdsmi_get_fabric_telemetry_data,
+            category_mask=ALL_CATEGORIES,
+        )
+        return
+
+    def test_get_gpu_fabric_info(self):
+        self.common.print_func_name("")
+        self.common.Test_API_Per_GPU(amdsmi_get_gpu_fabric_info=amdsmi.amdsmi_get_gpu_fabric_info)
+        return
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/projects/amdsmi/tests/python/unit/gpu/test_fabric.py
+++ b/projects/amdsmi/tests/python/unit/gpu/test_fabric.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) Advanced Micro Devices. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""Hardware-free unit tests for the fabric telemetry Python binding."""
+
+from __future__ import annotations
+
+import ctypes
+import unittest
+from unittest import mock
+
+from common.common import amdsmi
+
+ALL_CATEGORIES = amdsmi.amdsmi_wrapper.AMDSMI_FABRIC_TELEMETRY_CATEGORY_MASK_ALL_KNOWN
+
+
+class TestGpuFabricTelemetry(unittest.TestCase):
+    def test_fabric_telemetry_unknown_name_fallback(self):
+        """An unrecognized telemetry id resolves to a name of "UNKNOWN"."""
+        wrapper = amdsmi.amdsmi_wrapper
+
+        item = wrapper.amdsmi_fabric_telemetry_item_t(id=0xDEADBEEF, value=7)
+        instance = wrapper.amdsmi_fabric_telemetry_instance_t()
+        instance.item_count = 1
+        instance.items = ctypes.pointer(item)
+        dataset = wrapper.amdsmi_fabric_telemetry_dataset_t()
+        dataset.instance_count = 1
+        dataset.instances = ctypes.pointer(instance)
+        telemetry = wrapper.amdsmi_fabric_telemetry_t()
+        telemetry.datasets[0] = ctypes.pointer(dataset)
+        # Keep the ctypes object graph alive for the duration of the call.
+        keepalive = (item, instance, dataset, telemetry)  # noqa: F841
+
+        def fake_alloc(handle, mask, tel_ref):
+            tel_ref._obj.contents = telemetry
+            return wrapper.AMDSMI_STATUS_SUCCESS
+
+        with (
+            mock.patch.object(wrapper, "amdsmi_alloc_fabric_telemetry", side_effect=fake_alloc),
+            mock.patch.object(
+                wrapper,
+                "amdsmi_get_fabric_telemetry_data",
+                return_value=wrapper.AMDSMI_STATUS_SUCCESS,
+            ),
+            mock.patch.object(
+                wrapper,
+                "amdsmi_fabric_telem_id_to_string",
+                return_value=wrapper.AMDSMI_STATUS_NOT_FOUND,
+            ),
+            mock.patch.object(
+                wrapper, "amdsmi_free_fabric_telemetry", return_value=wrapper.AMDSMI_STATUS_SUCCESS
+            ),
+        ):
+            handle = wrapper.amdsmi_processor_handle()
+            result = amdsmi.amdsmi_get_fabric_telemetry_data(handle, ALL_CATEGORIES)
+
+        self.assertEqual(result[0]["instances"][0]["items"][0]["name"], "UNKNOWN")
+        return
+
+    def test_fabric_telemetry_resolved_name(self):
+        """A recognized telemetry id decodes to the name written through the out-param."""
+        wrapper = amdsmi.amdsmi_wrapper
+
+        item = wrapper.amdsmi_fabric_telemetry_item_t(id=0x1, value=42)
+        instance = wrapper.amdsmi_fabric_telemetry_instance_t()
+        instance.item_count = 1
+        instance.items = ctypes.pointer(item)
+        dataset = wrapper.amdsmi_fabric_telemetry_dataset_t()
+        dataset.instance_count = 1
+        dataset.instances = ctypes.pointer(instance)
+        telemetry = wrapper.amdsmi_fabric_telemetry_t()
+        telemetry.datasets[0] = ctypes.pointer(dataset)
+        name_buf = ctypes.create_string_buffer(b"NETPORT_FEC_CW")
+        # Keep the ctypes object graph alive for the duration of the call.
+        keepalive = (item, instance, dataset, telemetry, name_buf)  # noqa: F841
+
+        def fake_alloc(handle, mask, tel_ref):
+            tel_ref._obj.contents = telemetry
+            return wrapper.AMDSMI_STATUS_SUCCESS
+
+        def fake_id_to_string(telem_id, name_ref):
+            # Write name_buf's address into the caller's POINTER(c_char), the
+            # same contract the C function fulfills on success.
+            addr_slot = ctypes.cast(
+                ctypes.addressof(name_ref._obj), ctypes.POINTER(ctypes.c_void_p)
+            )
+            addr_slot[0] = ctypes.addressof(name_buf)
+            return wrapper.AMDSMI_STATUS_SUCCESS
+
+        with (
+            mock.patch.object(wrapper, "amdsmi_alloc_fabric_telemetry", side_effect=fake_alloc),
+            mock.patch.object(
+                wrapper,
+                "amdsmi_get_fabric_telemetry_data",
+                return_value=wrapper.AMDSMI_STATUS_SUCCESS,
+            ),
+            mock.patch.object(
+                wrapper, "amdsmi_fabric_telem_id_to_string", side_effect=fake_id_to_string
+            ),
+            mock.patch.object(
+                wrapper, "amdsmi_free_fabric_telemetry", return_value=wrapper.AMDSMI_STATUS_SUCCESS
+            ),
+        ):
+            handle = wrapper.amdsmi_processor_handle()
+            result = amdsmi.amdsmi_get_fabric_telemetry_data(handle, ALL_CATEGORIES)
+
+        self.assertEqual(result[0]["instances"][0]["items"][0]["name"], "NETPORT_FEC_CW")
+        return
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Add `static_assert` for fabric telemetry binary compatibility so the reinterpret_cast between the driver struct and the public API struct is checked at compile time.
- Change `amdsmi_fabric_telem_id_to_string` from `const char* (uint64_t)` to `amdsmi_status_t (uint64_t, const char**)` so callers can distinguish unknown IDs from valid ones and check for invalid output pointers; updates the public header, implementation, C++ tests, example, Python ctypes wrapper (regenerated via `tools/update_wrapper.sh`), and the Python interface caller.
- Add Python tests for fabric telemetry and GPU fabric info: unit-test entries exercising `amdsmi_get_fabric_telemetry` and `amdsmi_get_gpu_fabric_info` via the standard `Test_API_Per_GPU` harness, plus an integration test that validates the returned shapes and treats `DRIVER_NOT_LOADED` / `NOT_SUPPORTED` (boxes without IFoE) as pass.

Signed-off-by: Maisam Arif <Maisam.Arif@amd.com>
