### PR TITLE
feat(rocshmem) script to debug deadlocks can use stats profiling as a progress tracker

### DIFF
--- a/projects/rocshmem/scripts/debug/README.md
+++ b/projects/rocshmem/scripts/debug/README.md
@@ -172,6 +172,7 @@ After sourcing the script, the `rocshmem-deadlock-analyze` command is available:
 | `--cull` | Cull groups stuck in GPU barriers / gridsync using the built-in default pattern list |
 | `--cull=p1,p2,...` | Cull groups whose backtrace contains any of the comma-separated substrings |
 | `--check-lanes` | Enable lane-level parameter mismatch detection for `_wg` and `_wave` collective calls (slow; see below) |
+| `--stats` | Append a `=== rocSHMEM Stats ===` section with non-zero API call counters (requires `-DPROFILE=ON` build) |
 | `output_file` | Write report to this file instead of stdout |
 
 #### Cull option
@@ -280,6 +281,39 @@ must call with matching parameters). Different wavefronts — even in the same W
 may independently call any `_wave` function with different parameters; that is valid.
 Lane-level divergence within a wavefront is not visible from wavefront-level
 backtraces and requires `--check-lanes` to detect.
+
+#### Backend statistics (`--stats`)
+
+When `--stats` is given, the script reads the rocSHMEM API call counters
+directly from the stopped process's host memory without calling any function
+in the inferior.  The counters live in `Backend::globalStats` (device-side,
+written by GPU `atomicAdd`) and `Backend::globalHostStats` (host-side,
+written by `std::atomic`).  Both arrays are in `hipHostMalloc`-pinned
+memory, accessible to gdb without any cache flush.
+
+Only non-zero counters are printed, grouped by device and host:
+
+```
+=== rocSHMEM Stats ===
+  PE 1
+  (counters reflect activity since process start)
+  Device:
+    put           8192
+    quiet           64
+    barrier_all_wg   4
+  Host:
+    (all zero)
+```
+
+> **Requires `-DPROFILE=ON`** at CMake build time.  Without that flag
+> `ROCStats` and `ROCHostStats` are empty `NullStats<N>` structs (no
+> storage; all counters read as zero).  The section will note when this
+> is the case.
+
+The counters count operations since process start, not since the deadlock.
+They show what the application was doing before it got stuck — e.g. a high
+`barrier_all_wg` count with a non-zero `put` count suggests the collective
+stalled after a put-heavy phase.
 
 #### Lane-level parameter mismatch (`--check-lanes`)
 

--- a/projects/rocshmem/scripts/debug/attach_deadlock_analysis.sh
+++ b/projects/rocshmem/scripts/debug/attach_deadlock_analysis.sh
@@ -35,6 +35,7 @@
 #   --cull                 Cull groups stuck in GPU barriers / gridsync (built-in patterns)
 #   --cull=p1,p2,...       Cull groups whose backtrace contains any of the given substrings
 #   --check-lanes          Enable per-lane register divergence check inside each group
+#   --stats                Print per-group wavefront statistics
 #   --color                Force ANSI color output (default when stdout is a tty)
 #   --no-color             Disable ANSI color output
 #   --stdout               After analysis, emit all output files to stdout wrapped in
@@ -48,7 +49,7 @@
 #   ./attach_deadlock_analysis.sh rocshmem_functional_tests
 #   ./attach_deadlock_analysis.sh rocshmem_functional_tests --directory /tmp/my_analysis
 #   ./attach_deadlock_analysis.sh rocshmem_functional_tests --cull
-#   ./attach_deadlock_analysis.sh rocshmem_functional_tests --check-lanes
+#   ./attach_deadlock_analysis.sh rocshmem_functional_tests --check-lanes --stats
 #   ./attach_deadlock_analysis.sh rocshmem_functional_tests --directory /tmp/my_analysis --cull=__syncthreads,cooperative_groups
 #   ROCSHMEM_GDB_TIMEOUT=60 ./attach_deadlock_analysis.sh my_app
 ###############################################################################
@@ -64,7 +65,7 @@ GDB_SCRIPT="${SCRIPT_DIR}/rocgdb_deadlock_analysis.py"
 
 EXECUTABLE="${1:-}"
 if [[ -z "${EXECUTABLE}" ]]; then
-    echo "Usage: $0 <executable_name> [--directory <dir>] [--cull[=p1,p2,...]] [--check-lanes] [--color|--no-color]" >&2
+    echo "Usage: $0 <executable_name> [--directory <dir>] [--cull[=p1,p2,...]] [--check-lanes] [--stats] [--color|--no-color]" >&2
     echo "  Attaches rocgdb to all running <executable_name> processes on this host," >&2
     echo "  runs the rocSHMEM deadlock analysis, and saves output to the output dir." >&2
     exit 1
@@ -74,6 +75,7 @@ TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
 OUTPUT_DIR=""
 CULL_ENV=""
 CHECK_LANES_ENV="0"
+STATS_ENV="0"
 COLOR_ENV=""
 STDOUT_MODE="0"
 
@@ -97,6 +99,8 @@ while [[ ${_i} -lt ${#_args[@]} ]]; do
         CULL_ENV="${_arg#--cull=}"
     elif [[ "${_arg}" == "--check-lanes" ]]; then
         CHECK_LANES_ENV="1"
+    elif [[ "${_arg}" == "--stats" ]]; then
+        STATS_ENV="1"
     elif [[ "${_arg}" == "--color" ]]; then
         COLOR_ENV="always"
     elif [[ "${_arg}" == "--no-color" ]]; then
@@ -236,6 +240,7 @@ for PID in "${PIDS[@]}"; do
         ROCSHMEM_DEADLOCK_AUTO_ANALYZE=1
         ROCSHMEM_DEADLOCK_CULL="${CULL_ENV}"
         ROCSHMEM_DEADLOCK_CHECK_LANES="${CHECK_LANES_ENV}"
+        ROCSHMEM_DEADLOCK_STATS="${STATS_ENV}"
     )
     [[ -n "${COLOR_ENV}" ]] && _gdb_env+=(ROCSHMEM_DEADLOCK_COLOR="${COLOR_ENV}")
 

--- a/projects/rocshmem/scripts/debug/mpiexec_deadlock_analysis.sh
+++ b/projects/rocshmem/scripts/debug/mpiexec_deadlock_analysis.sh
@@ -39,6 +39,7 @@
 #   --cull                 Cull groups stuck in GPU barriers / gridsync
 #   --cull=p1,p2,...       Cull groups matching any of the given substrings
 #   --check-lanes          Enable per-lane register divergence check inside each group
+#   --stats                Print per-group wavefront statistics
 #   --color                Force ANSI color output
 #   --no-color             Disable ANSI color output
 #   --no-coalesce          Skip the cross-rank coalescing pass
@@ -91,6 +92,7 @@ TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
 OUTPUT_DIR=""
 CULL_ARG=""
 CHECK_LANES_ARG=""
+STATS_ARG=""
 COLOR_ARG=""
 RUN_COALESCE=1
 NO_SHARED_FS=0
@@ -117,6 +119,8 @@ while [[ ${_i} -lt ${#_args[@]} ]]; do
         CULL_ARG="${_arg}"
     elif [[ "${_arg}" == "--check-lanes" ]]; then
         CHECK_LANES_ARG="--check-lanes"
+    elif [[ "${_arg}" == "--stats" ]]; then
+        STATS_ARG="--stats"
     elif [[ "${_arg}" == "--color" ]]; then
         COLOR_ARG="--color"
     elif [[ "${_arg}" == "--no-color" ]]; then
@@ -169,6 +173,7 @@ echo "Output directory: ${OUTPUT_DIR}"
 [[ ${NO_SHARED_FS} -eq 1 ]]    && echo "Filesystem mode:  no shared fs (--output-filename)"
 [[ -n "${CULL_ARG}" ]]         && echo "Cull option:      ${CULL_ARG}"
 [[ -n "${CHECK_LANES_ARG}" ]]  && echo "Check lanes:      yes"
+[[ -n "${STATS_ARG}" ]]        && echo "Stats:            yes"
 [[ -n "${COLOR_ARG}" ]]        && echo "Color:            ${COLOR_ARG}"
 [[ ${#MPIEXEC_EXTRA_ARGS[@]} -gt 0 ]] && echo "mpiexec args:     ${MPIEXEC_EXTRA_ARGS[*]}"
 echo ""
@@ -186,6 +191,7 @@ else
 fi
 [[ -n "${CULL_ARG}" ]]        && _attach_args+=("${CULL_ARG}")
 [[ -n "${CHECK_LANES_ARG}" ]] && _attach_args+=("${CHECK_LANES_ARG}")
+[[ -n "${STATS_ARG}" ]]       && _attach_args+=("${STATS_ARG}")
 [[ -n "${COLOR_ARG}" ]]       && _attach_args+=("${COLOR_ARG}")
 
 # -pernode launches exactly one process per allocated node (supported by

--- a/projects/rocshmem/scripts/debug/rocgdb_deadlock_analysis.py
+++ b/projects/rocshmem/scripts/debug/rocgdb_deadlock_analysis.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 ###############################################################################
 # Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
 #
@@ -239,6 +240,63 @@ _DEFAULT_CULL_PATTERNS = [
     'cooperative_groups',       # HIP cooperative-groups (grid/thread_block/multi_grid)
 ]
 
+# ---------------------------------------------------------------------------
+# rocSHMEM backend statistics support
+# ---------------------------------------------------------------------------
+#
+# Stats are only meaningful when the library was built with -DPROFILE=ON.
+# Without that flag, ROCStats and ROCHostStats are both NullStats<N> (empty
+# structs, size 1), and every getStat() returns 0.
+#
+# Memory layout (PROFILE=ON):
+#   Context::ctxStats     — Stats<NUM_STATS>         — array of uint64_t
+#                           written by GPU wavefronts via device-side atomicAdd;
+#                           lives in hipMalloc device memory (rocgdb can read it).
+#   Context::ctxHostStats — HostStats<NUM_HOST_STATS> — array of atomic_ullong
+#                           written by host threads via std::atomic; lives in host
+#                           heap memory allocated with the Context object.
+#
+# Backend::globalStats and Backend::globalHostStats are always zero because
+# accumulateStats() is never called.  Stats are read by walking the per-context
+# objects directly: ctx_array (device pool) for device stats and list_of_ctxs
+# (host context vector) for host stats.
+#
+# Stat names and their array indices are read directly from the inferior's
+# DWARF debug info (rocshmem::rocshmem_stats and rocshmem::rocshmem_host_stats
+# enum types) so that new entries added to the enum are automatically picked
+# up without any change to this script.
+
+
+def _load_stat_enum(enum_type_name, strip_prefix, terminator_name):
+    """
+    Read a rocSHMEM stats enum from the inferior's debug info and return
+    a list of ``(index, display_name)`` pairs sorted by index.
+
+    ``strip_prefix`` is removed from the front of each enumerator name and
+    the result is lowercased to form the display name
+    (e.g. ``'NUM_BARRIER_ALL_WG'`` with prefix ``'NUM_'`` → ``'barrier_all_wg'``).
+    The ``terminator_name`` entry (e.g. ``'NUM_STATS'``) is excluded.
+
+    Returns ``None`` if the enum type cannot be found in the debug info.
+    """
+    try:
+        enum_type = gdb.lookup_type(enum_type_name)
+    except gdb.error:
+        return None
+
+    entries = []
+    for field in enum_type.fields():
+        # GDB may return namespace-qualified names (e.g. 'rocshmem::NUM_HOST_PUT').
+        # Strip any leading 'namespace::' qualifiers before comparing or slicing.
+        bare = field.name.rsplit('::', 1)[-1] if field.name else ''
+        if bare == terminator_name:
+            continue
+        display = bare[len(strip_prefix):].lower()
+        entries.append((int(field.enumval), display))
+
+    entries.sort(key=lambda x: x[0])
+    return entries
+
 # Hint rules: ordered most-specific first. First match wins.
 # Each entry: (substring_to_find_in_frame_text, hint_message)
 _HINT_RULES = [
@@ -351,7 +409,7 @@ class DeadlockAnalyzer:
     """
 
     def __init__(self, inferiors=None, output_file=None, color=None,
-                 cull_patterns=None, lane_check=False):
+                 cull_patterns=None, lane_check=False, show_stats=False):
         """
         Parameters
         ----------
@@ -379,6 +437,13 @@ class DeadlockAnalyzer:
             argument values, and report any lanes whose arguments differ.
             This is slow (up to 64 ``bt`` calls per wavefront) so it is
             disabled by default.  Enable with ``--check-lanes``.
+        show_stats : bool
+            When True, read the rocSHMEM backend statistics counters
+            (``Backend::globalStats`` and ``Backend::globalHostStats``) from
+            the stopped process and append a ``=== rocSHMEM Stats ===``
+            section to the report.  Requires the library to have been built
+            with ``-DPROFILE=ON``; without that flag all counters are zero
+            (``NullStats``).  Enabled with ``--stats``.
         """
         self.inferiors = inferiors
         self.out = output_file if output_file is not None else sys.stdout
@@ -392,6 +457,7 @@ class DeadlockAnalyzer:
         else:
             self.cull_patterns = list(cull_patterns)
         self.lane_check = lane_check
+        self.show_stats = show_stats
 
     # ------------------------------------------------------------------
     # Thread collection
@@ -925,6 +991,191 @@ class DeadlockAnalyzer:
         return result
 
     # ------------------------------------------------------------------
+    # Backend statistics
+    # ------------------------------------------------------------------
+
+    def collect_backend_stats(self):
+        """
+        Read rocSHMEM backend statistics from the stopped process.
+
+        ``backend->globalStats`` and ``backend->globalHostStats`` are always zero
+        because ``accumulateStats()`` is never called — GPU wavefronts write into
+        per-context ``ctxStats`` objects (in device memory) and host threads write
+        into per-context ``ctxHostStats`` objects (in host heap memory).
+
+        This method therefore walks the per-context stat objects directly:
+
+        * **Device stats** — cast ``backend`` to its concrete subclass
+          (``IPCBackend``, ``ROBackend``, or ``GDABackend``), access ``ctx_array``
+          (a ``hipMalloc``-allocated pool of device-context objects), and sum
+          ``ctxStats`` across all pool slots.  rocgdb can read device memory
+          directly; unused slots have all-zero stats so over-reading is safe.
+
+        * **Host stats** — walk ``backend->list_of_ctxs`` (a
+          ``std::vector<Context*>`` of all host-created contexts) and sum
+          ``ctxHostStats`` from each.
+
+        Returns a dict with keys:
+
+        ``'profile_on'`` — bool; False when the library was built without
+            ``-DPROFILE=ON`` (all counters would be zero anyway).
+        ``'my_pe'`` — int; the PE rank read from ``Backend::my_pe``.
+        ``'device'`` — dict mapping stat-name → non-zero count.
+        ``'host'`` — dict mapping stat-name → non-zero count.
+        ``'error'`` — str; present only when an error prevented reading.
+
+        Returns None if ``rocshmem::backend`` is not found (symbol absent or
+        the library was not initialised yet).
+        """
+        try:
+            backend_ptr = gdb.parse_and_eval('rocshmem::backend')
+        except gdb.error:
+            return None
+
+        if int(backend_ptr) == 0:
+            return None
+
+        # Detect PROFILE=ON via sizeof(ROCStats):
+        #   Stats<N>     (PROFILE=ON)  → N * sizeof(uint64_t) bytes (> 1)
+        #   NullStats<N> (PROFILE=OFF) → empty struct, sizeof == 1
+        try:
+            roc_stats_sz = int(gdb.parse_and_eval('sizeof(rocshmem::ROCStats)'))
+        except gdb.error:
+            roc_stats_sz = 0
+
+        profile_on = (roc_stats_sz > 1)
+
+        try:
+            backend_val = backend_ptr.dereference()
+            my_pe = int(backend_val['my_pe'])
+        except gdb.error as e:
+            return {'error': str(e), 'profile_on': profile_on}
+
+        result = {'profile_on': profile_on, 'my_pe': my_pe,
+                  'device': {}, 'host': {}}
+
+        if not profile_on:
+            return result
+
+        # Read enum field names and indices directly from the inferior's
+        # DWARF debug info so that new stats added to the enum are picked up
+        # automatically without any change to this script.
+        dev_names  = _load_stat_enum('rocshmem::rocshmem_stats',
+                                     'NUM_', 'NUM_STATS')
+        host_names = _load_stat_enum('rocshmem::rocshmem_host_stats',
+                                     'NUM_HOST_', 'NUM_HOST_STATS')
+
+        if dev_names is None or host_names is None:
+            result['error'] = ('rocshmem::rocshmem_stats or '
+                               'rocshmem::rocshmem_host_stats enum type not '
+                               'found in debug info')
+            return result
+
+        ull_ptr = gdb.lookup_type('unsigned long long').pointer()
+
+        # --- Device stats: walk the backend-specific ctx_array pool ---
+        # BackendType enum: GDA_BACKEND=0, RO_BACKEND=1, IPC_BACKEND=2
+        _BACKEND_SUBCLASS = {
+            0: ('rocshmem::GDABackend', 'rocshmem::GDAContext'),
+            1: ('rocshmem::ROBackend',  'rocshmem::ROContext'),
+            2: ('rocshmem::IPCBackend', 'rocshmem::IPCContext'),
+        }
+        try:
+            backend_type = int(backend_val['type'])
+            mapping = _BACKEND_SUBCLASS.get(backend_type)
+            if mapping is not None:
+                backend_cls, ctx_cls = mapping
+                sub_ptr = backend_ptr.cast(
+                    gdb.lookup_type(backend_cls).pointer())
+                sub = sub_ptr.dereference()
+                ctx_array = sub['ctx_array']  # IPCContext* / ROContext* / GDAContext*
+
+                # Pool size: envvar::max_num_contexts (a var<size_t> whose
+                # underlying value lives in the 'value' member field).
+                try:
+                    n_ctxs = int(gdb.parse_and_eval(
+                        'rocshmem::envvar::max_num_contexts.value'))
+                except gdb.error:
+                    n_ctxs = 32  # default from envvar.cpp
+
+                ctx_type = gdb.lookup_type(ctx_cls)
+                for i in range(n_ctxs):
+                    ctx = (ctx_array + i).dereference()
+                    dev_base = ctx['ctxStats'].address.cast(ull_ptr)
+                    for idx, name in dev_names:
+                        val = int((dev_base + idx).dereference())
+                        if val:
+                            result['device'][name] = (
+                                result['device'].get(name, 0) + val)
+        except gdb.error as e:
+            result['error'] = 'device stats: ' + str(e)
+
+        # --- Host stats: walk list_of_ctxs (all host-created contexts) ---
+        # std::vector<Context*> uses libstdc++ internal layout:
+        #   _M_impl._M_start  — pointer to first element
+        #   _M_impl._M_finish — pointer one past the last element
+        try:
+            vec = backend_val['list_of_ctxs']
+            vec_start  = vec['_M_impl']['_M_start']
+            vec_finish = vec['_M_impl']['_M_finish']
+            n_host_ctxs = int(vec_finish - vec_start)
+            for i in range(n_host_ctxs):
+                ctx_ptr = (vec_start + i).dereference()
+                ctx = ctx_ptr.dereference()
+                host_base = ctx['ctxHostStats'].address.cast(ull_ptr)
+                for idx, name in host_names:
+                    val = int((host_base + idx).dereference())
+                    if val:
+                        result['host'][name] = (
+                            result['host'].get(name, 0) + val)
+        except gdb.error as e:
+            prev = result.get('error', '')
+            result['error'] = (prev + '; ' if prev else '') + 'host stats: ' + str(e)
+
+        return result
+
+    def _format_stats(self, stats_result):
+        """Render the dict returned by ``collect_backend_stats`` as a string."""
+        c = self.c
+        lines = [f'{c.HEADER}=== rocSHMEM Stats ==={c.RESET}']
+
+        if stats_result is None:
+            lines.append('  (rocshmem::backend symbol not found — library not '
+                         'initialised or debug symbols absent)')
+            lines.append('')
+            return '\n'.join(lines)
+
+        if 'error' in stats_result:
+            lines.append(f'  (error reading stats: {stats_result["error"]})')
+            lines.append('')
+            return '\n'.join(lines)
+
+        pe = stats_result.get('my_pe', '?')
+        lines.append(f'  PE {pe}')
+
+        if not stats_result['profile_on']:
+            lines.append('  (library built without -DPROFILE=ON; all counters'
+                         ' are zero)')
+            lines.append('')
+            return '\n'.join(lines)
+
+        lines.append('  (counters reflect activity since process start)')
+
+        for section, data in (('Device', stats_result['device']),
+                               ('Host',   stats_result['host'])):
+            if not data:
+                lines.append(f'  {section}: (all zero)')
+                continue
+            lines.append(f'  {section}:')
+            # Compute column width for alignment
+            w = max(len(k) for k in data)
+            for name, val in data.items():
+                lines.append(f'    {name:<{w}}  {val}')
+
+        lines.append('')
+        return '\n'.join(lines)
+
+    # ------------------------------------------------------------------
     # Main report
     # ------------------------------------------------------------------
 
@@ -1043,6 +1294,11 @@ class DeadlockAnalyzer:
         if all_issues:
             print(self._format_collective_issues(all_issues), file=out)
 
+        # --- Backend stats (optional) ---
+        if self.show_stats:
+            stats_result = self.collect_backend_stats()
+            print(self._format_stats(stats_result), file=out)
+
         # --- Summary ---
         print(f'{c.HEADER}=== Summary ==={c.RESET}', file=out)
         stuck_str = f'{rocshmem_wf_count} wavefront(s) inside rocSHMEM'
@@ -1067,7 +1323,7 @@ class RocshmemDeadlockCommand(gdb.Command):
     """Analyze rocSHMEM deadlocks in the current inferior(s).
 
     Usage: rocshmem-deadlock-analyze [--color|--no-color] [--cull[=pat,...]]
-                                     [--check-lanes] [output_file]
+                                     [--check-lanes] [--stats] [output_file]
 
     --color           Force colored output even when writing to a file.
     --no-color        Disable colored output even on a TTY.
@@ -1081,6 +1337,12 @@ class RocshmemDeadlockCommand(gdb.Command):
                       a call, rocgdb switches to every active lane and compares
                       per-lane argument values (up to 64 bt calls per wavefront;
                       slow but thorough).
+    --stats           Append a rocSHMEM Stats section showing non-zero API call
+                      counters.  Device stats are summed across all slots in
+                      the backend ctx_array pool (rocgdb reads device memory
+                      directly); host stats are summed across all contexts in
+                      list_of_ctxs.  Requires -DPROFILE=ON; counters reflect
+                      activity since process start, not since the deadlock.
 
     When output_file is given the full report is written there;
     otherwise it is printed to stdout.  Color is auto-detected from the
@@ -1097,6 +1359,7 @@ class RocshmemDeadlockCommand(gdb.Command):
         color = None       # auto-detect
         cull_patterns = None  # culling disabled by default
         lane_check = False
+        show_stats = False
 
         remaining = []
         for a in args:
@@ -1110,6 +1373,8 @@ class RocshmemDeadlockCommand(gdb.Command):
                 cull_patterns = [p for p in a[len('--cull='):].split(',') if p]
             elif a == '--check-lanes':
                 lane_check = True
+            elif a == '--stats':
+                show_stats = True
             else:
                 remaining.append(a)
 
@@ -1122,7 +1387,8 @@ class RocshmemDeadlockCommand(gdb.Command):
         try:
             DeadlockAnalyzer(output_file=output_file, color=color,
                              cull_patterns=cull_patterns,
-                             lane_check=lane_check).report()
+                             lane_check=lane_check,
+                             show_stats=show_stats).report()
         finally:
             if output_file is not None:
                 output_file.close()
@@ -1155,6 +1421,10 @@ def _auto_analyzer_kwargs():
     ROCSHMEM_DEADLOCK_CHECK_LANES:
       "1"            — enable lane-level parameter mismatch detection
 
+    ROCSHMEM_DEADLOCK_STATS:
+      "1"            — call rocshmem_dump_stats() and append backend API
+                       call counters to the report (requires PROFILE=ON)
+
     ROCSHMEM_DEADLOCK_COLOR:
       handled by _color_enabled_default(); not overridden here so the
       DeadlockAnalyzer constructor auto-detects it as usual.
@@ -1167,6 +1437,8 @@ def _auto_analyzer_kwargs():
         kwargs['cull_patterns'] = [p for p in cull_env.split(',') if p]
     if os.environ.get('ROCSHMEM_DEADLOCK_CHECK_LANES', '0') == '1':
         kwargs['lane_check'] = True
+    if os.environ.get('ROCSHMEM_DEADLOCK_STATS', '0') == '1':
+        kwargs['show_stats'] = True
     return kwargs
 
 

--- a/projects/rocshmem/src/backend_bc.cpp
+++ b/projects/rocshmem/src/backend_bc.cpp
@@ -40,7 +40,9 @@
 #include "log.hpp"
 
 #include <cassert>
+#include <cstdarg>
 #include <cstdint>
+#include <cstdio>
 
 namespace rocshmem {
 
@@ -157,102 +159,168 @@ Backend::~Backend() {
 }
 
 void Backend::dump_stats() {
-  printf("PE %d\n", my_pe);
+#ifndef PROFILE
+  LOG_WARN("dump_stats() called but PROFILE=ON was not set at build time; all counters are zero");
+#endif
+  // Accumulate per-context stats into the global accumulators before printing.
+  // Reset first so repeated calls to dump_stats() do not double-count.
+  globalStats.resetStats();
+  globalHostStats.resetStats();
 
+  // Device stats: each backend copies ctx_array[i].ctxStats via hipMemcpy.
+  accumulate_ctx_device_stats();
+
+  // Host stats: walk list_of_ctxs and accumulate ctxHostStats from each,
+  // then include the default host context which is not in list_of_ctxs.
+  for (auto* ctx : list_of_ctxs) {
+    globalHostStats.accumulateStats(ctx->ctxHostStats);
+  }
+  accumulate_default_host_ctx_stats();
+
+  // Build each stats section into a buffer and emit with a single LOG_INFO per section.
+  char buf[8192];
+  int pos = 0;
+  auto append = [&](const char* fmt, ...) {
+    if (pos >= static_cast<int>(sizeof(buf)) - 1) return;
+    va_list args;
+    va_start(args, fmt);
+    int n = vsnprintf(buf + pos, sizeof(buf) - pos, fmt, args);
+    va_end(args);
+    if (n > 0) pos += n;
+  };
+
+  int n_printed = 0;
+  auto pstat = [&](const char* name, StatType val) {
+    if (val) { append("  %-30s %llu\n", name, static_cast<unsigned long long>(val)); ++n_printed; }
+  };
+
+  static_assert(NUM_STATS == 67,
+    "rocshmem_stats enum changed; update dump_stats device section");
   const auto& device_stats{globalStats};
-  printf("DEVICE STATS\n");
-  printf("Puts (Blocking/P/Nbi) %llu/%llu/%llu\n",
-         device_stats.getStat(NUM_PUT), device_stats.getStat(NUM_P),
-         device_stats.getStat(NUM_PUT_NBI));
-  printf("WG_Puts (Blocking/Nbi) %llu/%llu\n", device_stats.getStat(NUM_PUT_WG),
-         device_stats.getStat(NUM_PUT_NBI_WG));
-  printf("WAVE_Puts (Blocking/Nbi) %llu/%llu\n",
-         device_stats.getStat(NUM_PUT_WAVE),
-         device_stats.getStat(NUM_PUT_NBI_WAVE));
-  printf("Gets (Blocking/G/Nbi) %llu/%llu/%llu\n",
-         device_stats.getStat(NUM_GET), device_stats.getStat(NUM_G),
-         device_stats.getStat(NUM_GET_NBI));
-  printf("WG_Gets (Blocking/Nbi) %llu/%llu\n", device_stats.getStat(NUM_GET_WG),
-         device_stats.getStat(NUM_GET_NBI_WG));
-  printf("WAVE_Gets (Blocking/Nbi) %llu/%llu\n",
-         device_stats.getStat(NUM_GET_WAVE),
-         device_stats.getStat(NUM_GET_NBI_WAVE));
-  printf("Fences %llu\n", device_stats.getStat(NUM_FENCE));
-  printf("Quiets %llu\n", device_stats.getStat(NUM_QUIET));
-  printf("PE Quiets %llu\n", device_stats.getStat(NUM_PE_QUIET));
-  printf("ToAll %llu\n", device_stats.getStat(NUM_TO_ALL));
-  printf("BarrierAll %llu\n", device_stats.getStat(NUM_BARRIER_ALL));
-  printf("WAVE_BarrierAll %llu\n", device_stats.getStat(NUM_BARRIER_ALL_WAVE));
-  printf("WG_BarrierAll %llu\n", device_stats.getStat(NUM_BARRIER_ALL_WG));
-  printf("Barrier %llu\n", device_stats.getStat(NUM_BARRIER));
-  printf("WAVE_Barrier %llu\n", device_stats.getStat(NUM_BARRIER_WAVE));
-  printf("WG_Barrier %llu\n", device_stats.getStat(NUM_BARRIER_WG));
-  printf("Wait Until %llu\n", device_stats.getStat(NUM_WAIT_UNTIL));
-  printf("Wait Until Any %llu\n", device_stats.getStat(NUM_WAIT_UNTIL_ANY));
-  printf("Wait Until All %llu\n", device_stats.getStat(NUM_WAIT_UNTIL_ALL));
-  printf("Wait Until Some %llu\n", device_stats.getStat(NUM_WAIT_UNTIL_SOME));
-  printf("Wait Until All Vector %llu\n",
-         device_stats.getStat(NUM_WAIT_UNTIL_ALL_VECTOR));
-  printf("Wait Until Any Vector %llu\n",
-         device_stats.getStat(NUM_WAIT_UNTIL_ANY_VECTOR));
-  printf("Wait Until Some Vector %llu\n",
-         device_stats.getStat(NUM_WAIT_UNTIL_SOME_VECTOR));
-  printf("Finalizes %llu\n", device_stats.getStat(NUM_FINALIZE));
-  printf("Coalesced %llu\n", device_stats.getStat(NUM_MSG_COAL));
-  printf("Atomic_FAdd %llu\n", device_stats.getStat(NUM_ATOMIC_FADD));
-  printf("Atomic_FCswap %llu\n", device_stats.getStat(NUM_ATOMIC_FCSWAP));
-  printf("Atomic_FInc %llu\n", device_stats.getStat(NUM_ATOMIC_FINC));
-  printf("Atomic_Fetch %llu\n", device_stats.getStat(NUM_ATOMIC_FETCH));
-  printf("Atomic_Add %llu\n", device_stats.getStat(NUM_ATOMIC_ADD));
-  printf("Atomic_Set %llu\n", device_stats.getStat(NUM_ATOMIC_SET));
-  printf("Atomic_Cswap %llu\n", device_stats.getStat(NUM_ATOMIC_CSWAP));
-  printf("Atomic_Inc %llu\n", device_stats.getStat(NUM_ATOMIC_INC));
-  printf("Tests %llu\n", device_stats.getStat(NUM_TEST));
-  printf("SHMEM_PTR %llu\n", device_stats.getStat(NUM_SHMEM_PTR));
-  printf("SyncAll %llu\n", device_stats.getStat(NUM_SYNC_ALL));
-  printf("WAVE_SyncAll %llu\n", device_stats.getStat(NUM_SYNC_ALL_WAVE));
-  printf("WG_SyncAll %llu\n", device_stats.getStat(NUM_SYNC_ALL_WG));
-  printf("Sync %llu\n", device_stats.getStat(NUM_SYNC));
-  printf("WAVE_Sync %llu\n", device_stats.getStat(NUM_SYNC_WAVE));
-  printf("WG_Sync %llu\n", device_stats.getStat(NUM_SYNC_WG));
-  printf("Reduce %llu\n", device_stats.getStat(NUM_REDUCE));
+  uint64_t device_total = 0;
+  for (int i = 0; i < NUM_STATS; i++) device_total += device_stats.getStat(i);
+  if (device_total) {
+    n_printed = 0;
+    append("DEVICE STATS\n");
+    pstat("Put",                   device_stats.getStat(NUM_PUT));
+    pstat("Put_NBI",               device_stats.getStat(NUM_PUT_NBI));
+    pstat("P",                     device_stats.getStat(NUM_P));
+    pstat("WG_Put",                device_stats.getStat(NUM_PUT_WG));
+    pstat("WG_Put_NBI",            device_stats.getStat(NUM_PUT_NBI_WG));
+    pstat("WAVE_Put",              device_stats.getStat(NUM_PUT_WAVE));
+    pstat("WAVE_Put_NBI",          device_stats.getStat(NUM_PUT_NBI_WAVE));
+    pstat("Get",                   device_stats.getStat(NUM_GET));
+    pstat("Get_NBI",               device_stats.getStat(NUM_GET_NBI));
+    pstat("G",                     device_stats.getStat(NUM_G));
+    pstat("WG_Get",                device_stats.getStat(NUM_GET_WG));
+    pstat("WG_Get_NBI",            device_stats.getStat(NUM_GET_NBI_WG));
+    pstat("WAVE_Get",              device_stats.getStat(NUM_GET_WAVE));
+    pstat("WAVE_Get_NBI",          device_stats.getStat(NUM_GET_NBI_WAVE));
+    pstat("Fence",                 device_stats.getStat(NUM_FENCE));
+    pstat("Quiet",                 device_stats.getStat(NUM_QUIET));
+    pstat("PE_Quiet",              device_stats.getStat(NUM_PE_QUIET));
+    pstat("ToAll",                 device_stats.getStat(NUM_TO_ALL));
+    pstat("BarrierAll",            device_stats.getStat(NUM_BARRIER_ALL));
+    pstat("WAVE_BarrierAll",       device_stats.getStat(NUM_BARRIER_ALL_WAVE));
+    pstat("WG_BarrierAll",         device_stats.getStat(NUM_BARRIER_ALL_WG));
+    pstat("Barrier",               device_stats.getStat(NUM_BARRIER));
+    pstat("WAVE_Barrier",          device_stats.getStat(NUM_BARRIER_WAVE));
+    pstat("WG_Barrier",            device_stats.getStat(NUM_BARRIER_WG));
+    pstat("SyncAll",               device_stats.getStat(NUM_SYNC_ALL));
+    pstat("WAVE_SyncAll",          device_stats.getStat(NUM_SYNC_ALL_WAVE));
+    pstat("WG_SyncAll",            device_stats.getStat(NUM_SYNC_ALL_WG));
+    pstat("Sync",                  device_stats.getStat(NUM_SYNC));
+    pstat("WAVE_Sync",             device_stats.getStat(NUM_SYNC_WAVE));
+    pstat("WG_Sync",               device_stats.getStat(NUM_SYNC_WG));
+    pstat("Wait_Until",            device_stats.getStat(NUM_WAIT_UNTIL));
+    pstat("Wait_Until_Any",        device_stats.getStat(NUM_WAIT_UNTIL_ANY));
+    pstat("Wait_Until_All",        device_stats.getStat(NUM_WAIT_UNTIL_ALL));
+    pstat("Wait_Until_Some",       device_stats.getStat(NUM_WAIT_UNTIL_SOME));
+    pstat("Wait_Until_All_Vector", device_stats.getStat(NUM_WAIT_UNTIL_ALL_VECTOR));
+    pstat("Wait_Until_Any_Vector", device_stats.getStat(NUM_WAIT_UNTIL_ANY_VECTOR));
+    pstat("Wait_Until_Some_Vector",device_stats.getStat(NUM_WAIT_UNTIL_SOME_VECTOR));
+    pstat("Test",                  device_stats.getStat(NUM_TEST));
+    pstat("SHMEM_PTR",             device_stats.getStat(NUM_SHMEM_PTR));
+    pstat("Finalize",              device_stats.getStat(NUM_FINALIZE));
+    pstat("Msg_Coal",              device_stats.getStat(NUM_MSG_COAL));
+    pstat("Atomic_FAdd",           device_stats.getStat(NUM_ATOMIC_FADD));
+    pstat("Atomic_FCswap",         device_stats.getStat(NUM_ATOMIC_FCSWAP));
+    pstat("Atomic_FInc",           device_stats.getStat(NUM_ATOMIC_FINC));
+    pstat("Atomic_Fetch",          device_stats.getStat(NUM_ATOMIC_FETCH));
+    pstat("Atomic_Add",            device_stats.getStat(NUM_ATOMIC_ADD));
+    pstat("Atomic_Set",            device_stats.getStat(NUM_ATOMIC_SET));
+    pstat("Atomic_Swap",           device_stats.getStat(NUM_ATOMIC_SWAP));
+    pstat("Atomic_Cswap",          device_stats.getStat(NUM_ATOMIC_CSWAP));
+    pstat("Atomic_Inc",            device_stats.getStat(NUM_ATOMIC_INC));
+    pstat("Atomic_FetchAnd",       device_stats.getStat(NUM_ATOMIC_FETCH_AND));
+    pstat("Atomic_And",            device_stats.getStat(NUM_ATOMIC_AND));
+    pstat("Atomic_FetchOr",        device_stats.getStat(NUM_ATOMIC_FETCH_OR));
+    pstat("Atomic_Or",             device_stats.getStat(NUM_ATOMIC_OR));
+    pstat("Atomic_FetchXor",       device_stats.getStat(NUM_ATOMIC_FETCH_XOR));
+    pstat("Atomic_Xor",            device_stats.getStat(NUM_ATOMIC_XOR));
+    pstat("Broadcast",             device_stats.getStat(NUM_BROADCAST));
+    pstat("Alltoall",              device_stats.getStat(NUM_ALLTOALL));
+    pstat("Alltoallv",             device_stats.getStat(NUM_ALLTOALLV));
+    pstat("Fcollect",              device_stats.getStat(NUM_FCOLLECT));
+    pstat("Create",                device_stats.getStat(NUM_CREATE));
+    pstat("Put_Signal",            device_stats.getStat(NUM_PUT_SIGNAL));
+    pstat("WG_Put_Signal",         device_stats.getStat(NUM_PUT_SIGNAL_WG));
+    pstat("WAVE_Put_Signal",       device_stats.getStat(NUM_PUT_SIGNAL_WAVE));
+    pstat("Put_Signal_NBI",        device_stats.getStat(NUM_PUT_SIGNAL_NBI));
+    pstat("WG_Put_Signal_NBI",     device_stats.getStat(NUM_PUT_SIGNAL_NBI_WG));
+    pstat("WAVE_Put_Signal_NBI",   device_stats.getStat(NUM_PUT_SIGNAL_NBI_WAVE));
+    LOG_INFO("%s", buf);
+  }
 
+  static_assert(NUM_HOST_STATS == 38,
+    "rocshmem_host_stats enum changed; update dump_stats host section");
   const auto& host_stats{globalHostStats};
-  printf("HOST STATS\n");
-  printf("Puts (Blocking/P/Nbi) %llu/%llu/%llu\n",
-         host_stats.getStat(NUM_HOST_PUT), host_stats.getStat(NUM_HOST_P),
-         host_stats.getStat(NUM_HOST_PUT_NBI));
-  printf("Gets (Blocking/G/Nbi) (%llu/%llu/%llu)\n",
-         host_stats.getStat(NUM_HOST_GET), host_stats.getStat(NUM_HOST_G),
-         host_stats.getStat(NUM_HOST_GET_NBI));
-  printf("Fences %llu\n", host_stats.getStat(NUM_HOST_FENCE));
-  printf("Quiets %llu\n", host_stats.getStat(NUM_HOST_QUIET));
-  printf("ToAll %llu\n", host_stats.getStat(NUM_HOST_TO_ALL));
-  printf("BarrierAll %llu\n", host_stats.getStat(NUM_HOST_BARRIER_ALL));
-  printf("Wait Until %llu\n", host_stats.getStat(NUM_HOST_WAIT_UNTIL));
-  printf("Wait Until Any %llu\n", host_stats.getStat(NUM_HOST_WAIT_UNTIL_ANY));
-  printf("Wait Until All %llu\n", host_stats.getStat(NUM_HOST_WAIT_UNTIL_ALL));
-  printf("Wait Until Some %llu\n",
-         host_stats.getStat(NUM_HOST_WAIT_UNTIL_SOME));
-  printf("Wait Until All Vector %llu\n",
-         host_stats.getStat(NUM_HOST_WAIT_UNTIL_ALL_VECTOR));
-  printf("Wait Until Any Vector %llu\n",
-         host_stats.getStat(NUM_HOST_WAIT_UNTIL_ANY_VECTOR));
-  printf("Wait Until Some Vector %llu\n",
-         host_stats.getStat(NUM_HOST_WAIT_UNTIL_SOME_VECTOR));
-  printf("Finalizes %llu\n", host_stats.getStat(NUM_HOST_FINALIZE));
-  printf("Atomic_FAdd %llu\n", host_stats.getStat(NUM_HOST_ATOMIC_FADD));
-  printf("Atomic_FCswap %llu\n", host_stats.getStat(NUM_HOST_ATOMIC_FCSWAP));
-  printf("Atomic_FInc %llu\n", host_stats.getStat(NUM_HOST_ATOMIC_FINC));
-  printf("Atomic_Fetch %llu\n", host_stats.getStat(NUM_HOST_ATOMIC_FETCH));
-  printf("Atomic_Add %llu\n", host_stats.getStat(NUM_HOST_ATOMIC_ADD));
-  printf("Atomic_Set %llu\n", host_stats.getStat(NUM_ATOMIC_SET));
-  printf("Atomic_Cswap %llu\n", host_stats.getStat(NUM_HOST_ATOMIC_CSWAP));
-  printf("Atomic_Inc %llu\n", host_stats.getStat(NUM_HOST_ATOMIC_INC));
-  printf("Tests %llu\n", host_stats.getStat(NUM_HOST_TEST));
-  printf("SHMEM_PTR %llu\n", host_stats.getStat(NUM_HOST_SHMEM_PTR));
-  printf("SyncAll %llu\n", host_stats.getStat(NUM_HOST_SYNC_ALL));
-  printf("Reduce %llu\n", host_stats.getStat(NUM_HOST_REDUCE));
+  uint64_t host_total = 0;
+  for (int i = 0; i < NUM_HOST_STATS; i++) host_total += host_stats.getStat(i);
+  if (host_total) {
+    pos = 0;
+    n_printed = 0;
+    append("HOST STATS\n");
+    pstat("Put",                   host_stats.getStat(NUM_HOST_PUT));
+    pstat("Put_NBI",               host_stats.getStat(NUM_HOST_PUT_NBI));
+    pstat("P",                     host_stats.getStat(NUM_HOST_P));
+    pstat("Get",                   host_stats.getStat(NUM_HOST_GET));
+    pstat("Get_NBI",               host_stats.getStat(NUM_HOST_GET_NBI));
+    pstat("G",                     host_stats.getStat(NUM_HOST_G));
+    pstat("Fence",                 host_stats.getStat(NUM_HOST_FENCE));
+    pstat("Quiet",                 host_stats.getStat(NUM_HOST_QUIET));
+    pstat("ToAll",                 host_stats.getStat(NUM_HOST_TO_ALL));
+    pstat("BarrierAll",            host_stats.getStat(NUM_HOST_BARRIER_ALL));
+    pstat("SyncAll",               host_stats.getStat(NUM_HOST_SYNC_ALL));
+    pstat("Wait_Until",            host_stats.getStat(NUM_HOST_WAIT_UNTIL));
+    pstat("Wait_Until_Any",        host_stats.getStat(NUM_HOST_WAIT_UNTIL_ANY));
+    pstat("Wait_Until_All",        host_stats.getStat(NUM_HOST_WAIT_UNTIL_ALL));
+    pstat("Wait_Until_Some",       host_stats.getStat(NUM_HOST_WAIT_UNTIL_SOME));
+    pstat("Wait_Until_All_Vector", host_stats.getStat(NUM_HOST_WAIT_UNTIL_ALL_VECTOR));
+    pstat("Wait_Until_Any_Vector", host_stats.getStat(NUM_HOST_WAIT_UNTIL_ANY_VECTOR));
+    pstat("Wait_Until_Some_Vector",host_stats.getStat(NUM_HOST_WAIT_UNTIL_SOME_VECTOR));
+    pstat("Test",                  host_stats.getStat(NUM_HOST_TEST));
+    pstat("SHMEM_PTR",             host_stats.getStat(NUM_HOST_SHMEM_PTR));
+    pstat("Finalize",              host_stats.getStat(NUM_HOST_FINALIZE));
+    pstat("Atomic_FAdd",           host_stats.getStat(NUM_HOST_ATOMIC_FADD));
+    pstat("Atomic_FCswap",         host_stats.getStat(NUM_HOST_ATOMIC_FCSWAP));
+    pstat("Atomic_FInc",           host_stats.getStat(NUM_HOST_ATOMIC_FINC));
+    pstat("Atomic_Fetch",          host_stats.getStat(NUM_HOST_ATOMIC_FETCH));
+    pstat("Atomic_Add",            host_stats.getStat(NUM_HOST_ATOMIC_ADD));
+    pstat("Atomic_Set",            host_stats.getStat(NUM_HOST_ATOMIC_SET));
+    pstat("Atomic_Swap",           host_stats.getStat(NUM_HOST_ATOMIC_SWAP));
+    pstat("Atomic_Cswap",          host_stats.getStat(NUM_HOST_ATOMIC_CSWAP));
+    pstat("Atomic_Inc",            host_stats.getStat(NUM_HOST_ATOMIC_INC));
+    pstat("Atomic_FetchAnd",       host_stats.getStat(NUM_HOST_ATOMIC_FETCH_AND));
+    pstat("Atomic_And",            host_stats.getStat(NUM_HOST_ATOMIC_AND));
+    pstat("Atomic_FetchOr",        host_stats.getStat(NUM_HOST_ATOMIC_FETCH_OR));
+    pstat("Atomic_Or",             host_stats.getStat(NUM_HOST_ATOMIC_OR));
+    pstat("Atomic_FetchXor",       host_stats.getStat(NUM_HOST_ATOMIC_FETCH_XOR));
+    pstat("Atomic_Xor",            host_stats.getStat(NUM_HOST_ATOMIC_XOR));
+    pstat("Broadcast",             host_stats.getStat(NUM_HOST_BROADCAST));
+    pstat("Alltoall",              host_stats.getStat(NUM_HOST_ALLTOALL));
+    LOG_INFO("%s", buf);
+  }
 
   dump_backend_stats();
 }

--- a/projects/rocshmem/src/backend_bc.cpp
+++ b/projects/rocshmem/src/backend_bc.cpp
@@ -194,7 +194,7 @@ void Backend::dump_stats() {
     if (val) { append("  %-30s %llu\n", name, static_cast<unsigned long long>(val)); ++n_printed; }
   };
 
-  static_assert(NUM_STATS == 67,
+  static_assert(NUM_STATS == 68,
     "rocshmem_stats enum changed; update dump_stats device section");
   const auto& device_stats{globalStats};
   uint64_t device_total = 0;
@@ -272,7 +272,7 @@ void Backend::dump_stats() {
     LOG_INFO("%s", buf);
   }
 
-  static_assert(NUM_HOST_STATS == 38,
+  static_assert(NUM_HOST_STATS == 39,
     "rocshmem_host_stats enum changed; update dump_stats host section");
   const auto& host_stats{globalHostStats};
   uint64_t host_total = 0;

--- a/projects/rocshmem/src/backend_bc.hpp
+++ b/projects/rocshmem/src/backend_bc.hpp
@@ -320,14 +320,30 @@ class Backend {
   BackendType type;
 
   /**
-   * @brief Dumps derived class statistics.
+   * @brief Copies per-context device-side stats from the hipMalloc ctx_array
+   *        into globalStats via hipMemcpy, so that dump_stats() can read them
+   *        from the host.  Default implementation is a no-op for backends that
+   *        do not have a device ctx_array.
    */
-  virtual void dump_backend_stats() = 0;
+  virtual void accumulate_ctx_device_stats() {}
 
   /**
-   * @brief Resets derived class statistics.
+   * @brief Accumulates the default host context's ctxHostStats into
+   *        globalHostStats.  The default host context is not in list_of_ctxs
+   *        (to avoid a double-free with its owning unique_ptr), so it must be
+   *        handled separately.  Default is a no-op.
    */
-  virtual void reset_backend_stats() = 0;
+  virtual void accumulate_default_host_ctx_stats() {}
+
+  /**
+   * @brief Dumps derived class statistics. Default is a no-op.
+   */
+  virtual void dump_backend_stats() {}
+
+  /**
+   * @brief Resets derived class statistics. Default is a no-op.
+   */
+  virtual void reset_backend_stats() {}
 
  private:
   /**

--- a/projects/rocshmem/src/envvar.cpp
+++ b/projects/rocshmem/src/envvar.cpp
@@ -47,7 +47,11 @@ namespace envvar {
       "Debug output level (NONE, ERROR, WARN, ENV, VERSION, INFO, API, TRACE). "
       "Append modifiers: :noversion, :noenv, :noinfo, :nowarn, :notrace to suppress categories; "
       ":env[:all|:full] to enable/control env variable output; "
-      ":color (default) or :nocolor for ANSI colors (e.g. trace:noversion:nocolor, env:full)",
+      ":color (default) or :nocolor for ANSI colors; "
+      ":stats to print backend API call counters at finalize (requires -DPROFILE=ON; "
+      "output uses LOG_INFO so INFO level must also be active; "
+      "not implied by any verbosity level, must be specified explicitly, e.g. info:stats) "
+      "(e.g. trace:noversion:nocolor, env:full, info:stats)",
       types::debug_level::ERROR);
   }  // close _base temporarily to define log_flags after debug_level
 
@@ -67,6 +71,7 @@ namespace envvar {
     bool warn     = (lvl >= debug_level::WARN);
     bool trace    = (lvl >= debug_level::TRACE);
     bool color    = true;
+    bool stats    = false;  // opt-in only; never implied by verbosity level
 
     // Apply :modifier overrides
     const char* envstr = std::getenv("ROCSHMEM_DEBUG_LEVEL");
@@ -104,10 +109,11 @@ namespace envvar {
         else if (mod == "modified") env_mode = env_print_mode::MODIFIED;
         else if (mod == "color")    color = true;
         else if (mod == "nocolor")  color = false;
+        else if (mod == "stats")    stats = true;
         pos = next;
       }
     }
-    return {error, ver, env, env_mode, info, api, warn, trace, color};
+    return {error, ver, env, env_mode, info, api, warn, trace, color, stats};
   }
 
   const types::debug_flags log_flags = make_debug_flags();

--- a/projects/rocshmem/src/envvar.hpp
+++ b/projects/rocshmem/src/envvar.hpp
@@ -310,6 +310,9 @@ namespace envvar {
        *
        * Format: ROCSHMEM_DEBUG_LEVEL=<level>[:<modifier>]*
        * Modifiers: noversion, noenv, noinfo, nowarn, notrace, env:all, env:full
+       * Special opt-in: :stats — print backend API call statistics at finalize via LOG_INFO.
+       *   Requires INFO level to be active (e.g. ROCSHMEM_DEBUG_LEVEL=info:stats).
+       *   Not implied by any verbosity level; must be specified explicitly.
        */
       enum class env_print_mode { MODIFIED, ALL, FULL };
 
@@ -323,6 +326,7 @@ namespace envvar {
         const bool show_warn;
         const bool show_trace;
         const bool show_color;
+        const bool show_stats;
       };
     }  // inline namespace _debug
   }  // namespace types

--- a/projects/rocshmem/src/gda/backend_gda.cpp
+++ b/projects/rocshmem/src/gda/backend_gda.cpp
@@ -633,10 +633,6 @@ void GDABackend::buffer_unregister_all() {
   Backend::buffer_unregister_all();
 }
 
-void GDABackend::reset_backend_stats() {
-  assert(false);
-}
-
 void GDABackend::accumulate_default_host_ctx_stats() {
   globalHostStats.accumulateStats(default_host_ctx->ctxHostStats);
 }

--- a/projects/rocshmem/src/gda/backend_gda.cpp
+++ b/projects/rocshmem/src/gda/backend_gda.cpp
@@ -638,8 +638,14 @@ void GDABackend::reset_backend_stats() {
 }
 
 void GDABackend::accumulate_default_host_ctx_stats() {
-  if (default_host_ctx)
-    globalHostStats.accumulateStats(default_host_ctx->ctxHostStats);
+  globalHostStats.accumulateStats(default_host_ctx->ctxHostStats);
+}
+
+void GDABackend::reset_backend_stats() {
+  for (size_t i = 0; i < envvar::max_num_contexts; i++) {
+    CHECK_HIP(hipMemset(&ctx_array[i].ctxStats, 0, sizeof(ROCStats)));
+  }
+  default_host_ctx->ctxHostStats.resetStats();
 }
 
 

--- a/projects/rocshmem/src/gda/backend_gda.cpp
+++ b/projects/rocshmem/src/gda/backend_gda.cpp
@@ -614,6 +614,15 @@ int GDABackend::buffer_unregister(void *addr) {
   return err;
 }
 
+void GDABackend::accumulate_ctx_device_stats() {
+  ROCStats tmp;
+  for (size_t i = 0; i < envvar::max_num_contexts; i++) {
+    CHECK_HIP(hipMemcpy(&tmp, &ctx_array[i].ctxStats, sizeof(ROCStats),
+                        hipMemcpyDeviceToHost));
+    globalStats.hostAccumulateStats(tmp);
+  }
+}
+
 void GDABackend::buffer_unregister_all() {
   /* Deregister all buffers with QPs */
   for (size_t i = 0; i < num_qps; i++) {
@@ -628,9 +637,11 @@ void GDABackend::reset_backend_stats() {
   assert(false);
 }
 
-void GDABackend::dump_backend_stats() {
-  assert(false);
+void GDABackend::accumulate_default_host_ctx_stats() {
+  if (default_host_ctx)
+    globalHostStats.accumulateStats(default_host_ctx->ctxHostStats);
 }
+
 
 __host__ void GDABackend::global_exit(int status) {
   if (backend_comm != MPI_COMM_NULL)

--- a/projects/rocshmem/src/gda/backend_gda.hpp
+++ b/projects/rocshmem/src/gda/backend_gda.hpp
@@ -326,7 +326,13 @@ class GDABackend : public Backend {
    * @copydoc Backend::accumulate_ctx_device_stats()
    */
   void accumulate_ctx_device_stats() override;
+  /**
+   * @copydoc Backend::accumulate_default_host_ctx_stats()
+   */
   void accumulate_default_host_ctx_stats() override;
+  /**
+   * @copydoc Backend::reset_backend_stats()
+   */
   void reset_backend_stats() override;
 
 

--- a/projects/rocshmem/src/gda/backend_gda.hpp
+++ b/projects/rocshmem/src/gda/backend_gda.hpp
@@ -327,6 +327,7 @@ class GDABackend : public Backend {
    */
   void accumulate_ctx_device_stats() override;
   void accumulate_default_host_ctx_stats() override;
+  void reset_backend_stats() override;
 
 
 

--- a/projects/rocshmem/src/gda/backend_gda.hpp
+++ b/projects/rocshmem/src/gda/backend_gda.hpp
@@ -322,15 +322,13 @@ class GDABackend : public Backend {
   int *fence_pool{nullptr};
 
  protected:
-   /**
-   * @copydoc Backend::dump_backend_stats()
-   */
-  void dump_backend_stats() override;
-
   /**
-   * @copydoc Backend::reset_backend_stats()
+   * @copydoc Backend::accumulate_ctx_device_stats()
    */
-  void reset_backend_stats() override;
+  void accumulate_ctx_device_stats() override;
+  void accumulate_default_host_ctx_stats() override;
+
+
 
   /**
    * @brief Allocates uncacheable host memory for the hdp policy.

--- a/projects/rocshmem/src/ipc/backend_ipc.cpp
+++ b/projects/rocshmem/src/ipc/backend_ipc.cpp
@@ -345,13 +345,20 @@ void IPCBackend::ctx_destroy(Context *ctx) {
   delete ro_net_host_ctx;
 }
 
-void IPCBackend::reset_backend_stats() {
-  assert(false);
+void IPCBackend::accumulate_ctx_device_stats() {
+  ROCStats tmp;
+  for (size_t i = 0; i < envvar::max_num_contexts; i++) {
+    CHECK_HIP(hipMemcpy(&tmp, &ctx_array[i].ctxStats, sizeof(ROCStats),
+                        hipMemcpyDeviceToHost));
+    globalStats.hostAccumulateStats(tmp);
+  }
 }
 
-void IPCBackend::dump_backend_stats() {
-  assert(false);
+void IPCBackend::accumulate_default_host_ctx_stats() {
+  if (default_host_ctx)
+    globalHostStats.accumulateStats(default_host_ctx->ctxHostStats);
 }
+
 
 void IPCBackend::initIPC() {
   const auto &heap_bases{heap.get_heap_bases()};

--- a/projects/rocshmem/src/ipc/backend_ipc.cpp
+++ b/projects/rocshmem/src/ipc/backend_ipc.cpp
@@ -355,8 +355,14 @@ void IPCBackend::accumulate_ctx_device_stats() {
 }
 
 void IPCBackend::accumulate_default_host_ctx_stats() {
-  if (default_host_ctx)
-    globalHostStats.accumulateStats(default_host_ctx->ctxHostStats);
+  globalHostStats.accumulateStats(default_host_ctx->ctxHostStats);
+}
+
+void IPCBackend::reset_backend_stats() {
+  for (size_t i = 0; i < envvar::max_num_contexts; i++) {
+    CHECK_HIP(hipMemset(&ctx_array[i].ctxStats, 0, sizeof(ROCStats)));
+  }
+  default_host_ctx->ctxHostStats.resetStats();
 }
 
 

--- a/projects/rocshmem/src/ipc/backend_ipc.hpp
+++ b/projects/rocshmem/src/ipc/backend_ipc.hpp
@@ -171,7 +171,13 @@ class IPCBackend : public Backend {
    * @copydoc Backend::accumulate_ctx_device_stats()
    */
   void accumulate_ctx_device_stats() override;
+  /**
+   * @copydoc Backend::accumulate_default_host_ctx_stats()
+   */
   void accumulate_default_host_ctx_stats() override;
+  /**
+   * @copydoc Backend::reset_backend_stats()
+   */
   void reset_backend_stats() override;
 
 

--- a/projects/rocshmem/src/ipc/backend_ipc.hpp
+++ b/projects/rocshmem/src/ipc/backend_ipc.hpp
@@ -172,6 +172,7 @@ class IPCBackend : public Backend {
    */
   void accumulate_ctx_device_stats() override;
   void accumulate_default_host_ctx_stats() override;
+  void reset_backend_stats() override;
 
 
 

--- a/projects/rocshmem/src/ipc/backend_ipc.hpp
+++ b/projects/rocshmem/src/ipc/backend_ipc.hpp
@@ -168,14 +168,12 @@ class IPCBackend : public Backend {
 
  protected:
    /**
-   * @copydoc Backend::dump_backend_stats()
+   * @copydoc Backend::accumulate_ctx_device_stats()
    */
-  void dump_backend_stats() override;
+  void accumulate_ctx_device_stats() override;
+  void accumulate_default_host_ctx_stats() override;
 
-  /**
-   * @copydoc Backend::reset_backend_stats()
-   */
-  void reset_backend_stats() override;
+
 
   /**
    * @brief Allocates uncacheable host memory for the hdp policy.

--- a/projects/rocshmem/src/reverse_offload/backend_ro.cpp
+++ b/projects/rocshmem/src/reverse_offload/backend_ro.cpp
@@ -309,8 +309,7 @@ void ROBackend::accumulate_ctx_device_stats() {
 }
 
 void ROBackend::accumulate_default_host_ctx_stats() {
-  if (default_host_ctx)
-    globalHostStats.accumulateStats(default_host_ctx->ctxHostStats);
+  globalHostStats.accumulateStats(default_host_ctx->ctxHostStats);
 }
 
 void ROBackend::reset_backend_stats() {

--- a/projects/rocshmem/src/reverse_offload/backend_ro.cpp
+++ b/projects/rocshmem/src/reverse_offload/backend_ro.cpp
@@ -29,6 +29,7 @@
 #include <unistd.h>
 
 #include <cassert>
+#include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
 #include <memory>
@@ -298,6 +299,20 @@ void ROBackend::ctx_destroy(Context *ctx) {
   delete ro_net_host_ctx;
 }
 
+void ROBackend::accumulate_ctx_device_stats() {
+  ROCStats tmp;
+  for (size_t i = 0; i < envvar::max_num_contexts; i++) {
+    CHECK_HIP(hipMemcpy(&tmp, &ctx_array[i].ctxStats, sizeof(ROCStats),
+                        hipMemcpyDeviceToHost));
+    globalStats.hostAccumulateStats(tmp);
+  }
+}
+
+void ROBackend::accumulate_default_host_ctx_stats() {
+  if (default_host_ctx)
+    globalHostStats.accumulateStats(default_host_ctx->ctxHostStats);
+}
+
 void ROBackend::reset_backend_stats() {
   auto *bp{backend_proxy.get()};
 
@@ -311,6 +326,7 @@ void ROBackend::dump_backend_stats() {
   for (int i = 0; i < NUM_STATS; i++) {
     total += globalStats.getStat(i);
   }
+  if (!total) return;
 
   int device_id;
   CHECK_HIP(hipGetDevice(&device_id));
@@ -327,28 +343,40 @@ void ROBackend::dump_backend_stats() {
   auto *bp{backend_proxy.get()};
 
   for (size_t i = 0; i < envvar::max_num_contexts; i++) {
-    // Average latency as perceived from a thread
-    const ROStats &prof{bp->profiler[i]};
-    us_wait_slot += prof.getStat(WAITING_ON_SLOT) / gpu_frequency_mhz;
-    us_pack += prof.getStat(PACK_QUEUE) / gpu_frequency_mhz;
-    us_fence1 += prof.getStat(THREAD_FENCE_1) / gpu_frequency_mhz;
-    us_fence2 += prof.getStat(THREAD_FENCE_2) / gpu_frequency_mhz;
-    us_wait_host += prof.getStat(WAITING_ON_HOST) / gpu_frequency_mhz;
+    ROStats tmp;
+    CHECK_HIP(hipMemcpy(&tmp, bp->profiler + i, sizeof(ROStats), hipMemcpyDeviceToHost));
+    us_wait_slot += tmp.getStat(WAITING_ON_SLOT) / gpu_frequency_mhz;
+    us_pack      += tmp.getStat(PACK_QUEUE)      / gpu_frequency_mhz;
+    us_fence1    += tmp.getStat(THREAD_FENCE_1)  / gpu_frequency_mhz;
+    us_fence2    += tmp.getStat(THREAD_FENCE_2)  / gpu_frequency_mhz;
+    us_wait_host += tmp.getStat(WAITING_ON_HOST) / gpu_frequency_mhz;
   }
+  if (!us_wait_slot && !us_pack && !us_fence1 && !us_fence2 && !us_wait_host) return;
 
-  constexpr int FIELD_WIDTH{20};
-  constexpr int FLOAT_PRECISION{2};
+  char buf[1024];
+  int pos = 0;
+  auto append = [&](const char* fmt, ...) {
+    if (pos >= static_cast<int>(sizeof(buf)) - 1) return;
+    va_list args;
+    va_start(args, fmt);
+    int n = vsnprintf(buf + pos, sizeof(buf) - pos, fmt, args);
+    va_end(args);
+    if (n > 0) pos += n;
+  };
 
-  printf("%*s%*s%*s%*s%*s\n", FIELD_WIDTH + 1, "Wait On Slot (us)",
-         FIELD_WIDTH + 1, "Pack Queue (us)", FIELD_WIDTH + 1, "Fence 1 (us)",
-         FIELD_WIDTH + 1, "Fence 2 (us)", FIELD_WIDTH + 1, "Wait Host (us)");
+  auto pstat = [&](const char* name, uint64_t cycles) {
+    double us = static_cast<double>(cycles) / total;
+    if (us != 0.0) append("  %-30s %.2f us\n", name, us);
+  };
 
-  printf("%*.*f %*.*f %*.*f %*.*f %*.*f\n\n", FIELD_WIDTH, FLOAT_PRECISION,
-         static_cast<double>(us_wait_slot) / total, FIELD_WIDTH,
-         FLOAT_PRECISION, static_cast<double>(us_pack) / total, FIELD_WIDTH,
-         FLOAT_PRECISION, static_cast<double>(us_fence1) / total, FIELD_WIDTH,
-         FLOAT_PRECISION, static_cast<double>(us_fence2) / total, FIELD_WIDTH,
-         FLOAT_PRECISION, static_cast<double>(us_wait_host) / total);
+  append("PROXY STATS\n");
+  pstat("Wait_On_Slot",  us_wait_slot);
+  pstat("Pack_Queue",    us_pack);
+  pstat("Fence_1",       us_fence1);
+  pstat("Fence_2",       us_fence2);
+  pstat("Wait_Host",     us_wait_host);
+
+  LOG_INFO("%s", buf);
 }
 
 void ROBackend::ro_net_free_runtime() {

--- a/projects/rocshmem/src/reverse_offload/backend_ro.hpp
+++ b/projects/rocshmem/src/reverse_offload/backend_ro.hpp
@@ -163,6 +163,9 @@ class ROBackend : public Backend {
    * @copydoc Backend::accumulate_ctx_device_stats()
    */
   void accumulate_ctx_device_stats() override;
+  /**
+   * @copydoc Backend::accumulate_default_host_ctx_stats()
+   */
   void accumulate_default_host_ctx_stats() override;
 
   /**

--- a/projects/rocshmem/src/reverse_offload/backend_ro.hpp
+++ b/projects/rocshmem/src/reverse_offload/backend_ro.hpp
@@ -160,6 +160,12 @@ class ROBackend : public Backend {
 
  protected:
   /**
+   * @copydoc Backend::accumulate_ctx_device_stats()
+   */
+  void accumulate_ctx_device_stats() override;
+  void accumulate_default_host_ctx_stats() override;
+
+  /**
    * @copydoc Backend::dump_backend_stats()
    */
   void dump_backend_stats() override;

--- a/projects/rocshmem/src/rocshmem.cpp
+++ b/projects/rocshmem/src/rocshmem.cpp
@@ -640,6 +640,15 @@ __host__ void * rocshmem_ptr(const void * dest, int pe){
   VERIFY_BACKEND();
 
   /*
+   * Dump backend statistics if ROCSHMEM_DEBUG_LEVEL=...:stats was requested.
+   * Must be called before destroy_remaining_ctxs() so that list_of_ctxs
+   * is still populated for host-stats accumulation.
+   */
+  if (envvar::log_flags.show_stats) {
+    backend->dump_stats();
+  }
+
+  /*
    * Destroy all the ctxs that the user
    * created but did not manually destroy
    */

--- a/projects/rocshmem/src/stats.hpp
+++ b/projects/rocshmem/src/stats.hpp
@@ -176,7 +176,22 @@ class Stats {
     memset(&stats, 0, sizeof(StatType) * I);
   }
 
-  __host__ __device__ StatType getStat(int index) const { return stats[index]; }
+  __host__ __device__ StatType getStat(int index) const {
+#ifdef __HIP_DEVICE_COMPILE__
+    return stats[index];
+#else
+    // On weak-memory-order hosts (e.g. ARM/AArch64) the compiler or CPU may
+    // reorder or cache a plain load of this array, whose elements are written
+    // by GPU wavefronts via atomicAdd into hipHostMalloc-mapped host memory.
+    // Use an atomic acquire load so the host always observes the most recent
+    // GPU write: on x86 (TSO) this compiles to a plain MOV; on ARM it emits
+    // LDAR (load-acquire), which prevents later loads from being speculated
+    // before this one and ensures the value is read from the coherent memory
+    // subsystem rather than a stale CPU register or store buffer.
+    return __atomic_load_n(const_cast<StatType *>(&stats[index]),
+                           __ATOMIC_ACQUIRE);
+#endif
+  }
 };
 
 template <int I>

--- a/projects/rocshmem/src/stats.hpp
+++ b/projects/rocshmem/src/stats.hpp
@@ -251,7 +251,7 @@ typedef Stats<NUM_STATS> ROCStats;
 typedef HostStats<NUM_HOST_STATS> ROCHostStats;
 #else
 typedef NullStats<NUM_STATS> ROCStats;
-typedef NullStats<NUM_STATS> ROCHostStats;
+typedef NullStats<NUM_HOST_STATS> ROCHostStats;
 #endif
 
 }  // namespace rocshmem

--- a/projects/rocshmem/src/stats.hpp
+++ b/projects/rocshmem/src/stats.hpp
@@ -172,6 +172,14 @@ class Stats {
     for (int i = 0; i < I; i++) incStat(i, otherStats.getStat(i));
   }
 
+  // Host-side accumulation: plain addition into an already-host-accessible
+  // Stats object (e.g. globalStats in hipHostMalloc memory).  Not atomic —
+  // must only be called from the host when no GPU kernels are concurrently
+  // writing to this object or to otherStats.
+  __host__ void hostAccumulateStats(const Stats<I> &otherStats) {
+    for (int i = 0; i < I; i++) stats[i] += otherStats.getStat(i);
+  }
+
   __host__ __device__ void resetStats() {
     memset(&stats, 0, sizeof(StatType) * I);
   }
@@ -240,6 +248,7 @@ class NullStats {
   __host__ __device__ void endTimer(uint64_t start, int index) {}
   __host__ __device__ void incStat(int index, int value = 1) {}
   __host__ __device__ void accumulateStats(const NullStats<I> &otherStats) {}
+  __host__ void hostAccumulateStats(const NullStats<I> &otherStats) {}
   __host__ __device__ void resetStats() {}
   __host__ __device__ StatType getStat(int index) const { return 0; }
 };

--- a/projects/rocshmem/src/stats.hpp
+++ b/projects/rocshmem/src/stats.hpp
@@ -205,7 +205,9 @@ class HostStats {
     incStat(index, wtime() - start);
   }
 
-  __host__ void incStat(int index, int value = 1) { stats[index] += value; }
+  __host__ void incStat(int index, int value = 1) {
+    stats[index].fetch_add(value, std::memory_order_relaxed);
+  }
 
   __host__ void accumulateStats(const HostStats<I> &otherStats) {
     for (int i = 0; i < I; i++) incStat(i, otherStats.getStat(i));


### PR DESCRIPTION
## Motivation

When the program deadlocks it can be hard to know how much work was performed thus far, for example did it deadlock after only a couple of communication calls or after a long time, is there only 1 call of 1 type? etc. 

## Technical Details

builds with PROFILE=ON can produce call statistics (slowing down execution btw), this can be triggered from the gdb attachement to get the stat dump. 

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

modified a functional test to intentionally deadlock. build with Debug and PROFILE=ON.

```
ROCSHMEM_DEBUG_LEVEL=trace:stats ~/ompi/bin/mpirun -n 2 tests/functional_tests/rocshmem_functional_tests -n 1 -a 26  & (sleep 2; ../scripts/debug/attach_deadlock_analysis.sh rocshmem_functional_tests --stats )
```

Output file
```
=== rocSHMEM Deadlock Analysis ===
Process(es): 845512
Total GPU wavefronts analyzed: 1
Unique backtrace groups: 1

--- Group 1 (1 wavefront(s)) ---
  WFs: (0,0,0)/0
  Backtrace:
    #0  0x00007ae55f5afcf0 in rocshmem::uncached_load<long volatile> (src=0x7ae55fc04008) at src/assembly.hpp:125
    #1  rocshmem::Context::test<long> (this=0x7ae552407000, ivars=0x7ae55fc04008, cmp=0, val=1) at src/context_tmpl_device.hpp:432
    #2  rocshmem::Context::wait_until<long> (this=0x7ae552407000, ivars=0x7ae55fc04008, cmp=0, val=1) at src/context_tmpl_device.hpp:224
    #3  rocshmem::IPCContext::internal_direct_barrier (this=0x7ae552407000, pe=0, PE_start=0, stride=1, n_pes=2, pSync=0x7ae55fc04000) at build/src/ipc/context_ipc_device_coll.cpp:44
    #4  0x00007ae55f5b7c24 in rocshmem::IPCContext::internal_sync_wg (this=0x7ae552407000, pe=0, PE_start=0, stride=1, PE_size=2, pSync=0x7ae55fc04000) at build/src/ipc/context_ipc_device_coll.cpp:115
    #5  0x00007ae55f63d018 in rocshmem::IPCContext::sync_all_wg (this=0x7ae552407000) at build/src/ipc/context_ipc_device_coll.cpp:168
    #6  0x00007ae55f63d558 in rocshmem::IPCContext::barrier_all_wg (this=0x7ae552407000) at build/src/ipc/context_ipc_device_coll.cpp:187
    #7  0x00007ae55f63dedc in rocshmem::Context::barrier_all_wg (this=0x7ae552407000) at build/src/context_device.cpp:151
    #8  0x00007ae55f63e33c in rocshmem::rocshmem_barrier_all_wg () at build/src/rocshmem_gpu.cpp:885
    #9  0x00007ae55f6437cc in WorkGroupPrimitiveTest (loop=1, skip=10, start_time=0x7ae552431000, end_time=0x7ae552432000, source=0x7ae56d200480 "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqr"..., dest=0x7ae56d300500 "1", size=1, type=WGPutTestType, ctx_type=4) at /home/abouteil/rocm-systems/projects/rocshmem/tests/functional_tests/workgroup_primitives.cpp:72
  [HINT] Waiting for remote PE memory update (barrier/sync or user rocshmem_wait_until). Check if the remote PE is alive and making progress. (at: #2  rocshmem::Context::wait_until<long> (this=0x7ae552407000, ivars=0x7ae55fc04008, cmp=0, val=1) at src/context_tmpl_device.hpp:224)

=== rocSHMEM Stats ===
  PE 0
  (counters reflect activity since process start)
  Device:
    quiet   1
    put_wg  704
  Host: (all zero)

=== Summary ===
  1 wavefront(s) inside rocSHMEM
  0 wavefront(s) in user code / other
```
Note the == rocshmem Stats == section contains the number of put and quiet calls. 


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
