### PR TITLE
kfdtest: stop SDMA queue test after helper failures

### DIFF
--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/BaseQueue.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/BaseQueue.cpp
@@ -130,13 +130,26 @@ HSAKMT_STATUS BaseQueue::Destroy() {
 }
 
 void BaseQueue::PlaceAndSubmitPacket(const BasePacket &packet) {
-    PlacePacket(packet);
+    /*
+     * Do not ring the doorbell if PlacePacket failed. ASSERT_* inside
+     * PlacePacket is fatal only to PlacePacket if we propergate it here
+     */
+    ASSERT_NO_FATAL_FAILURE(PlacePacket(packet));
     SubmitPacket();
 }
 
 void BaseQueue::Wait4PacketConsumption(HsaEvent *event, unsigned int timeOut) {
     ASSERT_TRUE(!event) << "Not supported!" << std::endl;
-    ASSERT_TRUE(WaitOnValue(m_Resources.Queue_read_ptr, RptrWhenConsumed(), timeOut));
+
+    const unsigned int expectedRptr = RptrWhenConsumed();
+    ASSERT_TRUE(WaitOnValue(m_Resources.Queue_read_ptr, expectedRptr, timeOut))
+        << "Timed out waiting for queue consumption"
+        << " queueId="       << m_Resources.QueueId
+        << " expectedRptr="  << expectedRptr
+        << " actualRptr="    << m_Resources.Queue_read_ptr
+        << " wptr="          << Wptr()
+        << " pendingWptr="   << m_pendingWptr
+        << " pendingWptr64=" << m_pendingWptr64;
 }
 
 bool BaseQueue::AllPacketsSubmitted() {
@@ -144,6 +157,7 @@ bool BaseQueue::AllPacketsSubmitted() {
 }
 
 void BaseQueue::PlacePacket(const BasePacket &packet) {
+    ASSERT_NOTNULL(m_QueueBuf);
     ASSERT_EQ(packet.PacketType(), PacketTypeSupported())
         << "Cannot add a packet since packet type doesn't match queue";
 
@@ -161,7 +175,15 @@ void BaseQueue::PlacePacket(const BasePacket &packet) {
     }
 
     unsigned int dwordsAvailable = (readPtr - 1 - writePtr + queueSizeInDWord) % queueSizeInDWord;
-    ASSERT_GE(dwordsAvailable, dwordsRequired) << "Cannot add a packet, buffer overrun";
+    ASSERT_GE(dwordsAvailable, dwordsRequired)
+        << "Cannot add a packet, buffer overrun"
+        << " queueId="       << m_Resources.QueueId
+        << " readPtr="       << readPtr
+        << " writePtr="      << writePtr
+        << " pendingWptr="   << m_pendingWptr
+        << " pendingWptr64=" << m_pendingWptr64
+        << " packetDwords="  << packetSizeInDwords
+        << " queueDwords="   << queueSizeInDWord;
 
     ASSERT_GE(queueSizeInDWord, packetSizeInDwords) << "Cannot add a packet, packet size too large";
 

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDQMTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDQMTest.cpp
@@ -465,9 +465,9 @@ void KFDQMTest::SdmaConcurrentCopies(int gpuNode) {
         }
 
         for (unsigned j = 0; j < NPACKETS; j++)
-            queue.PlacePacket(
+            ASSERT_NO_FATAL_FAILURE(queue.PlacePacket(
                 SDMACopyDataPacket(queue.GetFamilyId(), dstBuf.As<char *>()+COPY_SIZE*j,
-                                   srcBuf.As<char *>()+COPY_SIZE*j, COPY_SIZE));
+                                   srcBuf.As<char *>()+COPY_SIZE*j, COPY_SIZE)));
         queue.SubmitPacket();
 
         /* Waste a variable amount of time. Submission timing
@@ -481,12 +481,12 @@ void KFDQMTest::SdmaConcurrentCopies(int gpuNode) {
          * run concurrently for a bit without getting too far ahead
          */
         if ((i & 0x7) == 0)
-            queue.Wait4PacketConsumption();
+            ASSERT_NO_FATAL_FAILURE(queue.Wait4PacketConsumption());
     }
     log << "Done." << std::endl;
 
-    queue.PlaceAndSubmitPacket(SDMAWriteDataPacket(queue.GetFamilyId(), srcBuf.As<unsigned *>(), 0x02020202));
-    queue.Wait4PacketConsumption();
+    ASSERT_NO_FATAL_FAILURE(queue.PlaceAndSubmitPacket(SDMAWriteDataPacket(queue.GetFamilyId(), srcBuf.As<unsigned *>(), 0x02020202)));
+    ASSERT_NO_FATAL_FAILURE(queue.Wait4PacketConsumption());
     EXPECT_TRUE_GPU(WaitOnValue(srcBuf.As<unsigned int*>(), 0x02020202), gpuNode);
 
     EXPECT_SUCCESS_GPU(queue.Destroy(), gpuNode);

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/PM4Queue.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/PM4Queue.cpp
@@ -73,10 +73,10 @@ void PM4Queue::SubmitPacket() {
 
 void PM4Queue::Wait4PacketConsumption(HsaEvent *event, unsigned int timeOut) {
     if (event) {
-        PlaceAndSubmitPacket(PM4ReleaseMemoryPacket(m_FamilyId, 0,
+        ASSERT_NO_FATAL_FAILURE(PlaceAndSubmitPacket(PM4ReleaseMemoryPacket(m_FamilyId, 0,
                     event->EventData.HWData2,
                     event->EventId,
-                    true));
+                    true)));
 
         EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtWaitOnEvent, m_KFDContext, event, timeOut));
     } else {

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/SDMAQueue.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/SDMAQueue.cpp
@@ -54,11 +54,16 @@ unsigned int SDMAQueue::Rptr() {
 }
 
 unsigned int SDMAQueue::RptrWhenConsumed() {
-    /* Rptr is same size and byte units as Wptr. Here we only care
-     * about the low 32-bits. When all packets are consumed, read and
-     * write pointers should have the same value.
+    /* SDMA queue pointer are byte pointers. BaseQueue tracks pending
+     * pointers in dwords, so convert the submitted pending pointer to the
+     * byte value expected in the HW read pointer.
+     *
+     * On AI+ the HW pointer is 64-bit. BaseQueue::Wait4PacketConsumption
+     * waits on the low 32 bits through Queue_read_ptr, matching the existing
+     * read-pointer handling for the small kfdtest rings.
      */
-    return *m_Resources.Queue_write_ptr;
+    return static_cast<unsigned int>(
+        (m_FamilyId < FAMILY_AI ? m_pendingWptr : m_pendingWptr64) * sizeof (unsigned int));
 }
 
 void SDMAQueue::SubmitPacket() {
@@ -82,9 +87,9 @@ void SDMAQueue::SubmitPacket() {
 
 void SDMAQueue::Wait4PacketConsumption(HsaEvent *event, unsigned int timeOut) {
     if (event) {
-        PlacePacket(SDMAFencePacket(m_FamilyId, (void*)event->EventData.HWData2, event->EventId));
+        ASSERT_NO_FATAL_FAILURE(PlacePacket(SDMAFencePacket(m_FamilyId, (void*)event->EventData.HWData2, event->EventId)));
 
-        PlaceAndSubmitPacket(SDMATrapPacket(event->EventId));
+        ASSERT_NO_FATAL_FAILURE(PlaceAndSubmitPacket(SDMATrapPacket(event->EventId)));
 
         EXPECT_SUCCESS(HSAKMT_CALL(hsaKmtWaitOnEvent, m_KFDContext, event, timeOut));
     } else {


### PR DESCRIPTION
## Motivation

`KFDQMTest.SdmaConcurrentCopies` can report a misleading "Cannot add a packet, buffer overrun" failure after `Wait4PacketConsumption()` has already timed out. The wait helper used fatal gtest assertions internally, but those assertions only abort the helper function, not the caller. As a result, the test loop continued to submit packets to a queue that was no longer draining, eventually filling the ring and obscuring the original failure.

These changes preserve the real timeout/failure point, avoid secondary ring-overrun noise, and add diagnostic state to make future queue stalls easier to debug.

## Technical Details

Wrap queue placement and wait hlper cals in `ASSERT_NO_FATAL_FAIURE` at all call sites so that the test aborts immediately when queue consumption fails. Also prevent `PlaceAndSubmitPacket()` from ringing the doorbell after a failed packet placement.

For SDMA queues, use the queue object's pending submitte write pointer to compute the expected consumed read pointer instead of reading the mutable exported write-pointer field. This makes the wait target explicit and consistent with the queue's internal dword-to-byte pointer handling.

## JIRA ID

## Test Plan

`./run_kfdtest.sh`

## Test Result

```
[----------] Global test environment tear-down
[==========] 171 tests from 20 test cases ran. (1425198 ms total)
[  PASSED  ] 171 tests.
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
