### PR TITLE
No more DIEExpressions in rocm 7.13 and later, reenable full Dwarf

### DIFF
--- a/projects/rocshmem/CMakeLists.txt
+++ b/projects/rocshmem/CMakeLists.txt
@@ -331,7 +331,7 @@ if (NOT BUILD_TESTS_ONLY)
     PRIVATE
       -Wall
       -Wextra
-      -ffile-prefix-map=${CMAKE_CURRENT_SOURCE_DIR}/=
+      -fmacro-prefix-map=${CMAKE_CURRENT_SOURCE_DIR}/=
   )
 
   target_include_directories(

--- a/projects/rocshmem/src/CMakeLists.txt
+++ b/projects/rocshmem/src/CMakeLists.txt
@@ -82,13 +82,17 @@ target_compile_options(${PROJECT_NAME} PUBLIC ${ROCSHMEM_COMPILE_FLAGS})
 # DIExpressions are emitted instead and pass the verifier.  The flag is passed
 # only to the device sub-pass via -Xarch_device; the host sub-pass continues
 # to receive full -g.
-set_property(
-  SOURCE rocshmem_gpu.cpp rocshmem_tile_gpu.cpp team.cpp
-  TARGET_DIRECTORY ${PROJECT_NAME}
-  APPEND PROPERTY COMPILE_OPTIONS
-    "$<$<CONFIG:Debug,RelWithDebInfo>:-Xarch_device>"
-    "$<$<CONFIG:Debug,RelWithDebInfo>:-gno-heterogeneous-dwarf>"
-)
+#
+# Fixed in ROCm 7.13 — guard removed for newer compilers.
+if(ROCM_MAJOR_VERSION LESS 7 OR (ROCM_MAJOR_VERSION EQUAL 7 AND ROCM_MINOR_VERSION LESS 13))
+  set_property(
+    SOURCE rocshmem_gpu.cpp rocshmem_tile_gpu.cpp team.cpp
+    TARGET_DIRECTORY ${PROJECT_NAME}
+    APPEND PROPERTY COMPILE_OPTIONS
+      "$<$<CONFIG:Debug,RelWithDebInfo>:-Xarch_device>"
+      "$<$<CONFIG:Debug,RelWithDebInfo>:-gno-heterogeneous-dwarf>"
+  )
+endif()
 
 ###############################################################################
 # ROCSHMEM TARGET FOR BACKENDS


### PR DESCRIPTION
decorators

## Motivation

We had to disable some dwarf decorators on rocm 7 to 7.12, after testing the fix to the compiler made it to 7.13 and we can build Debug normally again.

## Technical Details

Keep the workaround for older rocm.
Also disable the ffile-map that causes the device linker to substitute the relative path of the build directory to the source directory and prevent stepping 

## JIRA ID

AIROCSHMEM-29

## Test Plan

Build with Debug

## Test Result

* Build works on 7.13 Docker
* rocgdb can attach and debug symbols are present
* can step in device functions including gda


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
