### PR TITLE
feat(rccl): in-tree device coverage via HSA introspection drain

### DIFF
--- a/projects/rccl-tests/install.sh
+++ b/projects/rccl-tests/install.sh
@@ -18,6 +18,9 @@ function display_help()
     echo "    [--hip_compiler] Specify path to HIP compiler (default: \$HIP_COMPILER if set,"
     echo "                     else /opt/rocm/llvm/bin/amdclang++)"
     echo "    [--gpu_targets] Specify GPU targets (default:gfx906,gfx908,gfx90a,gfx942,gfx950,gfx1030,gfx1100,gfx1101,gfx1102,gfx1151,gfx1200,gfx1201)"
+    echo "    [--enable-device-coverage] Build with host + device LLVM source-based coverage"
+    echo "                               instrumentation (requires --hip_compiler to point at a"
+    echo "                               clang built from llvm-decouple or equivalent)"
 }
 
 # #################################################
@@ -34,6 +37,7 @@ mpi_dir=""
 # overridable via --hip_compiler.
 hip_compiler=${HIP_COMPILER:-${rocm_dir}/llvm/bin/amdclang++}
 gpu_targets=""
+enable_device_coverage=false
 
 # #################################################
 # Parameter parsing
@@ -42,7 +46,7 @@ gpu_targets=""
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ $? -eq 4 ]]; then
-  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,mpi,test,enable-device-api,rocm_home:,rccl_home:,mpi_home:,hip_compiler:,gpu_targets: --options hmt -- "$@")
+  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,mpi,test,enable-device-api,rocm_home:,rccl_home:,mpi_home:,hip_compiler:,gpu_targets:,enable-device-coverage --options hmt -- "$@")
 else
   echo "Need a new version of getopt"
   exit 1
@@ -84,6 +88,9 @@ while true; do
     --gpu_targets)
        gpu_targets=${2}
        shift 2 ;;
+    --enable-device-coverage)
+       enable_device_coverage=true
+       shift ;;
     --) shift ; break ;;
     *)  echo "Unexpected command line parameter received; aborting";
     exit 1 ;;
@@ -142,6 +149,12 @@ if ($device_api_enabled); then
   DEVICE_API="ENABLE_DEVICE_API=1"
 fi
 
+COVERAGE_MAKE_ARG=""
+if [[ "${enable_device_coverage}" == true ]]; then
+  COVERAGE_MAKE_ARG="ENABLE_DEVICE_COVERAGE=1"
+  echo "[INFO] Building with host + device LLVM source-based coverage instrumentation"
+fi
+
 if ($mpi_enabled); then
   if [[ ${mpi_dir} == "" ]]; then
     echo "[ERROR] MPI flag enabled but path to MPI installation not specified.  See --mpi_home command line argument." >&2
@@ -149,12 +162,12 @@ if ($mpi_enabled); then
   else
     echo "[INFO] Compiling with MPI support (Using MPI from ${mpi_dir})"
     echo
-    make NCCL_HOME=${rccl_dir} CUSTOM_RCCL_LIB=${rccl_dir}/lib/librccl.so MPI=1 MPI_HOME=${mpi_dir} HIPCC=${hip_compiler} ${GPU_TARGETS} ${DEVICE_API} -j$(nproc)
+    make NCCL_HOME=${rccl_dir} CUSTOM_RCCL_LIB=${rccl_dir}/lib/librccl.so MPI=1 MPI_HOME=${mpi_dir} HIPCC=${hip_compiler} ${GPU_TARGETS} ${DEVICE_API} ${COVERAGE_MAKE_ARG} -j$(nproc)
   fi
 else
   echo "[INFO] Compiling without MPI support (MPI support requires -m and --mpi_home)"
   echo
-  make NCCL_HOME=${rccl_dir} CUSTOM_RCCL_LIB=${rccl_dir}/lib/librccl.so HIPCC=${hip_compiler} ${GPU_TARGETS} ${DEVICE_API} -j$(nproc)
+  make NCCL_HOME=${rccl_dir} CUSTOM_RCCL_LIB=${rccl_dir}/lib/librccl.so HIPCC=${hip_compiler} ${GPU_TARGETS} ${DEVICE_API} ${COVERAGE_MAKE_ARG} -j$(nproc)
 fi
 check_exit_code "$?"
 

--- a/projects/rccl-tests/src/Makefile
+++ b/projects/rccl-tests/src/Makefile
@@ -142,6 +142,16 @@ ifeq ($(ENABLE_DEVICE_API), 1)
 HIPCUFLAGS += -DENABLE_DEVICE_API
 endif
 
+# Enable LLVM source-based coverage instrumentation on both host and device
+# sides. The patched clang driver in llvm-decouple auto-links the per-arch
+# device profile runtime (libclang_rt.profile.a) and force-links the host-side
+# drain symbol (__llvm_profile_hip_collect_device_data), which registers an
+# atexit handler to walk loaded ELF code objects via HSA introspection.
+ifeq ($(ENABLE_DEVICE_COVERAGE), 1)
+HIPCUFLAGS += -fprofile-instr-generate -fcoverage-mapping
+HIPLDFLAGS += -fprofile-generate
+endif
+
 LIBRARIES += rccl dl
 HIPLDFLAGS += $(LIBRARIES:%=-l%)
 

--- a/projects/rccl/CMakeLists.txt
+++ b/projects/rccl/CMakeLists.txt
@@ -87,6 +87,28 @@ option(BUILD_TESTS                             "Build unit test programs"       
 option(BUILD_EXT_EXAMPLES                      "Build ext-{net,tuner,profiler} example plugins" OFF)
 option(DUMP_ASM                                "Disassemble and dump"                          OFF)
 option(ENABLE_CODE_COVERAGE                    "Enable code coverage"                          OFF)
+option(ENABLE_DEVICE_COVERAGE                  "Enable device-side coverage (implies ENABLE_CODE_COVERAGE)" OFF)
+if(ENABLE_DEVICE_COVERAGE AND NOT ENABLE_CODE_COVERAGE)
+  message(STATUS "ENABLE_DEVICE_COVERAGE=ON implies ENABLE_CODE_COVERAGE=ON")
+  set(ENABLE_CODE_COVERAGE ON CACHE BOOL "Enable code coverage" FORCE)
+endif()
+
+# Coverage requires Debug build type (src/CMakeLists.txt enforces it).
+# When the caller asked for coverage but didn't pick a build type, default
+# to Debug and replace the toolchain's -g -O1 with -gline-tables-only -O1:
+# llvm-cov needs line tables for source mapping, but full DWARF on
+# coverage-instrumented per-kernel TUs explodes assembly size. If the
+# caller explicitly picked Debug they get the toolchain's -g (they asked
+# for it). Explicit non-Debug + coverage still hits the fatal_error below.
+if(ENABLE_CODE_COVERAGE AND NOT CMAKE_BUILD_TYPE)
+  message(STATUS "ENABLE_CODE_COVERAGE=ON: forcing CMAKE_BUILD_TYPE=Debug with CMAKE_CXX_FLAGS_DEBUG=\"-gline-tables-only -O1\"")
+  set(CMAKE_BUILD_TYPE Debug CACHE STRING "Build type forced by coverage" FORCE)
+  set(CMAKE_CXX_FLAGS_DEBUG "-gline-tables-only -O1" CACHE STRING "Coverage debug flags" FORCE)
+  set(CMAKE_C_FLAGS_DEBUG   "-gline-tables-only -O1" CACHE STRING "Coverage debug flags" FORCE)
+  # Signal to DeviceLinker.cmake so DL_OPT_FLAGS matches (the RCCLDEV
+  # custom language has its own hardcoded -O1 -g default it'll otherwise use).
+  set(RCCL_COVERAGE_FORCED_LITE_DEBUG ON CACHE BOOL "Coverage auto-forced lite debug" FORCE)
+endif()
 option(ENABLE_IFC                              "Enable indirect function call"                 OFF)
 option(ENABLE_DEVICE_LINKER                    "Build with assembly-extract device linker"     ON)
 option(EMIT_LLVM_IR                            "Emit LLVM IR/bitcode for nccl_device APIs"     OFF)

--- a/projects/rccl/cmake/DeviceLinker.cmake
+++ b/projects/rccl/cmake/DeviceLinker.cmake
@@ -20,9 +20,21 @@ list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 enable_language(RCCLDEV)
 
 # Tell the driver where to find the real compiler.
+#
+# When ENABLE_DEVICE_COVERAGE=ON we pin DL_CLANG to CMAKE_CXX_COMPILER: the
+# user picked their compiler precisely because it carries the in-tree HSA
+# introspection drain + the per-arch device profile RT (libclang_rt.profile.a
+# under <resource-dir>/lib/amdgcn-amd-amdhsa/). Falling back to the ROCm
+# amdclang++ at this point would silently regress to a toolchain without the
+# device profile RT and no -fcoverage-mapping forwarding.
 get_filename_component(_dl_compiler_dir "${CMAKE_CXX_COMPILER}" DIRECTORY)
-find_program(DL_CLANG NAMES amdclang++ clang++
-  HINTS "${_dl_compiler_dir}" "${ROCM_PATH}/bin" REQUIRED)
+if(ENABLE_DEVICE_COVERAGE)
+  set(DL_CLANG "${CMAKE_CXX_COMPILER}" CACHE FILEPATH "Device-linker clang driver" FORCE)
+  message(STATUS "Device Linker: DL_CLANG pinned to CMAKE_CXX_COMPILER for device coverage = ${DL_CLANG}")
+else()
+  find_program(DL_CLANG NAMES amdclang++ clang++
+    HINTS "${_dl_compiler_dir}" "${ROCM_PATH}/bin" REQUIRED)
+endif()
 find_program(DL_BUNDLER NAMES clang-offload-bundler
   HINTS "${_dl_compiler_dir}" "${_dl_compiler_dir}/../lib/llvm/bin"
         "${ROCM_PATH}/llvm/bin" REQUIRED)
@@ -60,11 +72,58 @@ message(STATUS "Device Linker: GPU targets = ${DL_GPU_TARGETS}")
 
 # ---------------------------------------------------------------------------
 # Optimization flags (passed to both compile and link modes of the driver)
+#
+# When the top-level CMakeLists.txt auto-forces lite debug for coverage
+# (RCCL_COVERAGE_FORCED_LITE_DEBUG=ON), match it here: full DWARF on
+# coverage-instrumented per-kernel TUs balloons the .s and crushes build
+# time. An explicit Debug + coverage build (user passed --debug) still
+# gets -g so debugging works.
 # ---------------------------------------------------------------------------
-if(CMAKE_BUILD_TYPE MATCHES "Debug")
+if(RCCL_COVERAGE_FORCED_LITE_DEBUG)
+  set(DL_OPT_FLAGS -O1 -gline-tables-only)
+elseif(CMAKE_BUILD_TYPE MATCHES "Debug")
   set(DL_OPT_FLAGS -O1 -g)
 else()
   set(DL_OPT_FLAGS -O3)
+endif()
+
+# ---------------------------------------------------------------------------
+# Device-side coverage instrumentation (ENABLE_DEVICE_COVERAGE).
+#
+# We thread -fprofile-instr-generate / -fcoverage-mapping through every
+# device compile in this pipeline (per-kernel RCCLDEV compiles, dispatcher
+# compile inside --link, and the standalone fat-object compiles below).
+# The assembly-extract pass passes them through to the underlying clang
+# invocation; the LLVM profile metadata sections (__llvm_prf_*, __llvm_cov*)
+# survive extraction because the extractor only strips the amdhsa_kernel /
+# amdgpu_metadata ranges.
+#
+# For the per-arch device.elf to link cleanly we must also resolve the
+# `__llvm_profile_runtime` reference emitted by each instrumented TU. We
+# locate the per-arch device profile runtime archive (libclang_rt.profile.a
+# under the amdgcn-amd-amdhsa resource sub-directory) and pass it to the
+# rccl-device-compile driver, which forwards it to ld.lld.
+# ---------------------------------------------------------------------------
+set(DL_COVERAGE_FLAGS "")
+set(DL_DEVICE_PROFILE_RT "")
+if(ENABLE_DEVICE_COVERAGE)
+  set(DL_COVERAGE_FLAGS -fprofile-instr-generate -fcoverage-mapping)
+  execute_process(
+    COMMAND ${DL_CLANG} --target=amdgcn-amd-amdhsa -print-resource-dir
+    OUTPUT_VARIABLE _dl_amdgcn_resource_dir
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    RESULT_VARIABLE _dl_amdgcn_resource_rc)
+  if(NOT _dl_amdgcn_resource_rc EQUAL 0 OR _dl_amdgcn_resource_dir STREQUAL "")
+    message(WARNING "Device Linker: failed to query amdgcn resource-dir from ${DL_CLANG}")
+  else()
+    set(_dl_candidate "${_dl_amdgcn_resource_dir}/lib/amdgcn-amd-amdhsa/libclang_rt.profile.a")
+    if(EXISTS "${_dl_candidate}")
+      set(DL_DEVICE_PROFILE_RT "${_dl_candidate}")
+      message(STATUS "Device Linker: coverage enabled, device profile RT = ${DL_DEVICE_PROFILE_RT}")
+    else()
+      message(WARNING "Device Linker: ENABLE_DEVICE_COVERAGE=ON but no archive at ${_dl_candidate}")
+    endif()
+  endif()
 endif()
 
 # ---------------------------------------------------------------------------
@@ -236,6 +295,7 @@ foreach(DL_GPU_TARGET ${DL_GPU_TARGETS})
     --arch=${DL_GPU_TARGET}
     --clang=${DL_CLANG}
     ${DL_OPT_FLAGS}
+    ${DL_COVERAGE_FLAGS}
     -std=c++17
     ${DL_HIP_COMPILER_FLAGS}
   )
@@ -309,6 +369,11 @@ foreach(DL_GPU_TARGET ${DL_GPU_TARGETS})
     endif()
   endif()
 
+  set(_dl_profile_rt_arg "")
+  if(DL_DEVICE_PROFILE_RT)
+    set(_dl_profile_rt_arg "--profile-rt=${DL_DEVICE_PROFILE_RT}")
+  endif()
+
   add_custom_command(
     OUTPUT  ${ARCH_DEVICE_ELF}
     COMMAND ${CMAKE_RCCLDEV_COMPILER}
@@ -318,9 +383,11 @@ foreach(DL_GPU_TARGET ${DL_GPU_TARGETS})
       ${DL_HIP_COMPILER_FLAGS}
       --dispatcher=${HIPIFY_DIR}/src/device/common.cu.cpp
       ${_rocshmem_bitcode_arg}
+      ${_dl_profile_rt_arg}
       ${_link_def_flags}
       ${_link_inc_flags}
       ${DL_OPT_FLAGS}
+      ${DL_COVERAGE_FLAGS}
       -std=c++17
       -o ${ARCH_DEVICE_ELF}
       @${_link_rsp}
@@ -333,6 +400,21 @@ foreach(DL_GPU_TARGET ${DL_GPU_TARGETS})
   list(APPEND ALL_DEVICE_ELFS "${ARCH_DEVICE_ELF}")
   list(APPEND DL_BUNDLER_TARGETS "hip-amdgcn-amd-amdhsa--${DL_GPU_TARGET}")
   list(APPEND DL_BUNDLER_INPUTS "--input=${ARCH_DEVICE_ELF}")
+
+  # Friendly symlink next to librccl.so: device-${arch}.elf -> device_build/<dir>/device.elf
+  # Lets coverage workflows (and inspection in general) reference the per-arch
+  # device ELF without the leading-hyphen directory wart we use for CDNA build
+  # scheduling. Same byte content that ends up packed into .hip_fatbin; llvm-cov
+  # only needs this file + the merged .profdata for device-side reports.
+  set(_dev_elf_link "${PROJECT_BINARY_DIR}/device-${DL_GPU_TARGET}.elf")
+  add_custom_command(
+    OUTPUT  ${_dev_elf_link}
+    COMMAND ${CMAKE_COMMAND} -E create_symlink ${ARCH_DEVICE_ELF} ${_dev_elf_link}
+    DEPENDS ${ARCH_DEVICE_ELF}
+    COMMENT "DL [${DL_GPU_TARGET}] symlink: device-${DL_GPU_TARGET}.elf -> device_build/.../device.elf"
+    VERBATIM
+  )
+  list(APPEND DEVICE_ELF_SYMLINKS "${_dev_elf_link}")
 
   # =========================================================================
   # Optional: emit LLVM IR for specialized kernels (ninja device_ir)
@@ -438,6 +520,7 @@ add_custom_command(
     ${_link_def_flags}
     ${_host_inc_flags}
     ${DL_OPT_FLAGS}
+    ${DL_COVERAGE_FLAGS}
     -std=c++17
     -fPIC
     -w
@@ -463,6 +546,7 @@ add_custom_command(
     ${_link_def_flags}
     ${_host_inc_flags}
     ${DL_OPT_FLAGS}
+    ${DL_COVERAGE_FLAGS}
     -std=c++17
     -fPIC
     -w
@@ -497,6 +581,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.20")
       ${_link_def_flags}
       ${_host_inc_flags}
       ${DL_OPT_FLAGS}
+      ${DL_COVERAGE_FLAGS}
       -std=c++17
       -fPIC
       -w
@@ -518,6 +603,7 @@ else()
       ${_link_def_flags}
       ${_host_inc_flags}
       ${DL_OPT_FLAGS}
+      ${DL_COVERAGE_FLAGS}
       -std=c++17
       -fPIC
       -w
@@ -548,6 +634,7 @@ add_custom_command(
     ${_link_def_flags}
     ${_host_inc_flags}
     ${DL_OPT_FLAGS}
+    ${DL_COVERAGE_FLAGS}
     -std=c++17
     -fPIC
     -w
@@ -649,6 +736,7 @@ if(GENERATE_SYM_KERNELS)
         ${_link_def_flags}
         ${_host_inc_flags}
         ${DL_OPT_FLAGS}
+        ${DL_COVERAGE_FLAGS}
         -std=c++17
         -fPIC
         -w
@@ -666,7 +754,7 @@ endif()
 # Top-level target
 # ===========================================================================
 add_custom_target(device_linker_build ALL
-  DEPENDS ${COMMON_FAT_OBJ} ${ONERANK_FAT_OBJ} ${COLLECTIVES_FAT_OBJ} ${DDA_ALL_REDUCE_IPC_FAT_OBJ} ${DDA_REDUCE_SCATTER_IPC_FAT_OBJ} ${DDA_ALL_GATHER_IPC_FAT_OBJ} ${DDA_ALLTOALL_IPC_FAT_OBJ} ${SYM_FAT_OBJS}
+  DEPENDS ${COMMON_FAT_OBJ} ${ONERANK_FAT_OBJ} ${COLLECTIVES_FAT_OBJ} ${DDA_ALL_REDUCE_IPC_FAT_OBJ} ${DDA_REDUCE_SCATTER_IPC_FAT_OBJ} ${DDA_ALL_GATHER_IPC_FAT_OBJ} ${DDA_ALLTOALL_IPC_FAT_OBJ} ${SYM_FAT_OBJS} ${DEVICE_ELF_SYMLINKS}
 )
 add_dependencies(device_linker_build hipify_all copy_nccl_device_headers)
 

--- a/projects/rccl/install.sh
+++ b/projects/rccl/install.sh
@@ -14,6 +14,7 @@ build_local_gpu_only=false
 build_amdgpu_targets=""
 build_package=false
 build_release=true
+debug_explicit=false
 debug_fast=false
 build_static=false
 build_tests=false
@@ -21,6 +22,7 @@ build_verbose=false
 clean_build=true
 dump_asm=false
 enable_code_coverage=false
+enable_device_coverage=false
 enable_ninja=""
 install_dependencies=false
 install_library=false
@@ -62,7 +64,12 @@ function display_help()
     echo "       --disable-sym-kernels   Disable symmetric memory kernels"
     echo "       --disable-warp-speed    Disable WARP_SPEED kernel optimizations"
     echo "       --dump-asm              Disassemble code and dump assembly with inline code"
-    echo "    -c|--enable-code-coverage  Enable code coverage"
+    echo "    -c|--enable-code-coverage  Enable host-side code coverage instrumentation"
+    echo "       --enable-device-coverage Enable host + device code coverage (in-tree HSA introspection drain;"
+    echo "                                 requires a clang built from llvm-decouple or equivalent)."
+    echo "                                 Forces Debug build type. Without explicit --debug uses"
+    echo "                                 -gline-tables-only -O1 (enough for llvm-cov source mapping,"
+    echo "                                 no per-kernel .s blow-up). Pass --debug to opt in to full -g."
     echo "       --enable_backtrace      Build with custom backtrace support"
     echo "       --enable-mpi-tests      Enable MPI-based tests (requires --debug and MPI installation; set MPI_PATH if not in /opt/ompi)"
     echo "    -f|--fast                  Quick-build RCCL (local gpu arch only, no backtrace)"
@@ -116,7 +123,7 @@ function display_help()
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ "$?" -eq 4 ]]; then
-    GETOPT_PARSE=$(getopt --name "${0}" --options cdfhij:lprtq --longoptions address-sanitizer,amdgpu_targets:,cmake-options:,debug,debug-fast,dependencies,device-linker,disable-roctx,disable-sym-kernels,disable-warp-speed,dump-asm,enable-code-coverage,enable_backtrace,enable-mpi-tests,fast,force-reduce-pipeline,generate-sym-kernels,help,install,jobs:,kernel-resource-use,local_gpu_only,log-trace,ninja,no_clean,no-device-linker,openmp-test-enable,package_build,prefix:,quiet-warnings,rm-legacy-include-dir,rocshmem,roctx-enable,run_tests_all,run_tests_quick,static,tests_build,time-trace,verbose -- "$@")
+    GETOPT_PARSE=$(getopt --name "${0}" --options cdfhij:lprtq --longoptions address-sanitizer,amdgpu_targets:,cmake-options:,debug,debug-fast,dependencies,device-linker,disable-roctx,disable-sym-kernels,disable-warp-speed,dump-asm,enable-code-coverage,enable-device-coverage,enable_backtrace,enable-mpi-tests,fast,force-reduce-pipeline,generate-sym-kernels,help,install,jobs:,kernel-resource-use,local_gpu_only,log-trace,ninja,no_clean,no-device-linker,openmp-test-enable,package_build,prefix:,quiet-warnings,rm-legacy-include-dir,rocshmem,roctx-enable,run_tests_all,run_tests_quick,static,tests_build,time-trace,verbose -- "$@")
 else
     echo "Need a new version of getopt"
     exit 1
@@ -134,8 +141,8 @@ while true; do
          --address-sanitizer)        build_address_sanitizer=true;                                                                     shift ;;
          --amdgpu_targets)           build_amdgpu_targets=${2};                                                                        shift 2 ;;
          --cmake-options)            custom_cmake_options=${2};                                                                        shift 2 ;;
-         --debug)                    build_release=false;                                                                              shift ;;
-         --debug-fast)               build_release=false; debug_fast=true;                                                             shift ;;
+         --debug)                    build_release=false; debug_explicit=true;                                                         shift ;;
+         --debug-fast)               build_release=false; debug_fast=true; debug_explicit=true;                                        shift ;;
     -d | --dependencies)             install_dependencies=true;                                                                        shift ;;
          --device-linker)            device_linker=true;                                                                               shift ;;
          --disable-roctx)            roctx_enabled=false;                                                                              shift ;;
@@ -143,6 +150,7 @@ while true; do
          --disable-warp-speed)       warp_speed_enabled=false;                                                                         shift ;;
          --dump-asm)                 dump_asm=true;                                                                                    shift ;;
     -c | --enable-code-coverage)     enable_code_coverage=true;                                                                        shift ;;
+         --enable-device-coverage)   enable_code_coverage=true; enable_device_coverage=true;                                            shift ;;
          --enable_backtrace)         build_bfd=true;                                                                                   shift ;;
          --enable-mpi-tests)         enable_mpi_tests=true;                                                                            shift ;;
     -f | --fast)                     build_local_gpu_only=true;                                                                        shift ;;
@@ -295,6 +303,21 @@ fi
 mkdir -p build; cd build
 
 # Create and go to build type directory
+# Coverage requires Debug build type (src/CMakeLists.txt has a fatal_error
+# otherwise). If the caller asked for coverage but didn't pass --debug,
+# *don't* pass -DCMAKE_BUILD_TYPE=Debug here: leave CMAKE_BUILD_TYPE unset
+# so the CMakeLists.txt coverage block can set Debug *and* override
+# CMAKE_CXX_FLAGS_DEBUG to "-gline-tables-only -O1" (avoids the full-DWARF
+# per-kernel assembly blow-up under -fcoverage-mapping). We still cd into
+# the debug/ build dir so subsequent install/test paths line up. Explicit
+# --debug means the caller wants -g; honor it.
+coverage_forced_debug=false
+if [[ "${enable_code_coverage}" == true && "${debug_explicit}" == false ]]; then
+    build_release=false
+    coverage_forced_debug=true
+    echo "install.sh: coverage requested without --debug; CMakeLists.txt will default CMAKE_BUILD_TYPE=Debug with -gline-tables-only -O1 (pass --debug to opt in to full -g)"
+fi
+
 if [[ "${build_release}" == true ]]; then
     mkdir -p release; cd release
 else
@@ -304,12 +327,12 @@ fi
 # build type
 if [[ "${build_release}" == true ]]; then
     cmake_common_options="${cmake_common_options} -DCMAKE_BUILD_TYPE=Release"
+elif [[ "${coverage_forced_debug}" == true ]]; then
+    : # CMAKE_BUILD_TYPE intentionally unset; CMakeLists.txt coverage block sets Debug + lite-debug flags
+elif [[ "${debug_fast}" == true ]]; then
+    cmake_common_options="${cmake_common_options} -DCMAKE_BUILD_TYPE=Debug -DCMAKE_BUILD_SUBTYPE=DebugFast"
 else
-    if [[ "${debug_fast}" == true ]]; then
-	cmake_common_options="${cmake_common_options} -DCMAKE_BUILD_TYPE=Debug -DCMAKE_BUILD_SUBTYPE=DebugFast"
-    else
-	cmake_common_options="${cmake_common_options} -DCMAKE_BUILD_TYPE=Debug"
-    fi
+    cmake_common_options="${cmake_common_options} -DCMAKE_BUILD_TYPE=Debug"
 fi
 
 # Address sanitizer
@@ -320,6 +343,11 @@ fi
 # Enable code coverage
 if [[ "${enable_code_coverage}" == true ]]; then
     cmake_common_options="${cmake_common_options} -DENABLE_CODE_COVERAGE=ON"
+fi
+
+# Enable device-side code coverage (in-tree HSA introspection drain)
+if [[ "${enable_device_coverage}" == true ]]; then
+    cmake_common_options="${cmake_common_options} -DENABLE_DEVICE_COVERAGE=ON"
 fi
 
 # Backtrace support

--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -908,10 +908,24 @@ if(ENABLE_CODE_COVERAGE)
 
   message(STATUS "Code coverage is enabled with build type '${CMAKE_BUILD_TYPE}'.")
 
-  target_compile_options(rccl PRIVATE
-    -fvisibility=default
-    "SHELL:-Xarch_host -fprofile-instr-generate"
-    "SHELL:-Xarch_host -fcoverage-mapping")
+  if(ENABLE_DEVICE_COVERAGE)
+    message(STATUS "Device-side coverage is enabled (host + device instrumented).")
+    # Apply coverage flags to both host and device compilation. Sam Crow's
+    # clang-driver work forwards -fcoverage-mapping/-fprofile-instr-generate
+    # to the per-arch device cc1 invocation, so we deliberately drop the
+    # -Xarch_host qualifier here. The device-side libclang_rt.profile.a is
+    # auto-linked by the driver when -fprofile-instr-generate is set for
+    # offload arches.
+    target_compile_options(rccl PRIVATE
+      -fvisibility=default
+      -fprofile-instr-generate
+      -fcoverage-mapping)
+  else()
+    target_compile_options(rccl PRIVATE
+      -fvisibility=default
+      "SHELL:-Xarch_host -fprofile-instr-generate"
+      "SHELL:-Xarch_host -fcoverage-mapping")
+  endif()
 
   set(COVERAGE_SHARED_LINKER_FLAGS
     -fprofile-generate
@@ -930,6 +944,24 @@ if(ENABLE_CODE_COVERAGE)
   # atexit() handlers (e.g. ProcessIsolatedTestRunner using _exit()) can
   # still flush librccl's private LLVM profile runtime instance.
   target_sources(rccl PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/misc/coverage_flush.cc)
+
+  # Force-link the HIP device-data drain symbol so the host profile RT's
+  # InstrProfilingPlatformROCm.cpp.o gets pulled in (it's only included on
+  # demand). That .o registers the atexit hook which walks loaded HSA code
+  # objects, reads each device.elf's __llvm_prf_cnts via HSA introspection,
+  # and merges device counters into the same .profraw the host writes.
+  # Without this, .profraw contains host counters only and llvm-cov reports
+  # 0% on every device kernel.
+  #
+  # We add it on librccl's link rather than relying on the clang driver
+  # heuristic (the driver only force-links it for explicit `-x hip` link
+  # invocations; .o-only links from rccl-tests and friends don't qualify).
+  # One reference anywhere in the process is sufficient — once librccl is
+  # loaded, the atexit handler is registered for the whole process.
+  if(ENABLE_DEVICE_COVERAGE)
+    target_link_options(rccl PRIVATE
+      "LINKER:-u,__llvm_profile_hip_collect_device_data")
+  endif()
 elseif(BUILD_TESTS) # Enable default/hidden visibility based on build type and ROCM_VERSION
   if (ROCM_VERSION VERSION_GREATER_EQUAL "60400" AND CMAKE_BUILD_TYPE MATCHES "Debug")
     target_compile_options(rccl PRIVATE -fvisibility=default)

--- a/projects/rccl/tools/rccl-device-compile
+++ b/projects/rccl/tools/rccl-device-compile
@@ -156,6 +156,13 @@ def extract_device_function(asm_lines):
             continue
         if kernel_sym and re.match(r'\s*\.globl\s+' + re.escape(kernel_sym), stripped):
             continue
+        # Drop .no_dead_strip directives that reference a local-only symbol
+        # (.L*). amdclang++ emits these for __llvm_coverage_mapping under
+        # -fcoverage-mapping, but the AMDGPU ELF assembler rejects them with
+        # "non-local symbol required". The directive is advisory; the data
+        # section already carries SHF_ALLOC / SHF_GNU_RETAIN where needed.
+        if re.match(r'\s*\.no_dead_strip\s+\.L', stripped):
+            continue
         if not globl_inserted and mangled in line and '.type' in line and '@function' in line:
             out_lines.append(f'\t.globl\t{mangled}\n')
             globl_inserted = True
@@ -382,6 +389,23 @@ def _normalize_file_directives(lines):
             for line in lines]
 
 
+def _drop_local_no_dead_strip(lines):
+    """Strip '.no_dead_strip .L<local>' directives the AMDGPU assembler rejects.
+
+    Mirrors the per-kernel extractor: amdclang++ emits these for
+    __llvm_coverage_mapping / __llvm_prf_nm under -fcoverage-mapping, but the
+    AMDGPU ELF assembler bails with 'non-local symbol required'. The directive
+    is advisory; coverage data sections already carry SHF_ALLOC/SHF_GNU_RETAIN
+    where needed."""
+    out = []
+    pat = re.compile(r'\s*\.no_dead_strip\s+\.L')
+    for ln in lines:
+        if pat.match(ln):
+            continue
+        out.append(ln)
+    return out
+
+
 def patch_dispatcher(asm_lines, max_res):
     """Patch dispatcher assembly with aggregated resource values.
     Returns patched lines."""
@@ -390,6 +414,7 @@ def patch_dispatcher(asm_lines, max_res):
     lines = _patch_gpr_maximums(lines, max_res)
     lines = _patch_amdgpu_metadata(lines, max_res)
     lines = _normalize_file_directives(lines)
+    lines = _drop_local_no_dead_strip(lines)
     return lines
 
 
@@ -469,6 +494,12 @@ def do_compile(args, forwarded_flags):
     base = os.path.splitext(output)[0]
     json_out = base + '.resources.json'
 
+    # Make sure the output directory exists. With the RCCLDEV custom language
+    # there's no implicit cmake_link_script that pre-creates it, and we write
+    # the .resources.json sibling before make's own .o write would create it.
+    out_dir = os.path.dirname(output) or '.'
+    os.makedirs(out_dir, exist_ok=True)
+
     # Determine temp directory: alongside output if --keep-temps, else truly temp
     if keep_temps:
         asm_file = base + '.full.s'
@@ -546,6 +577,7 @@ def do_link(args, forwarded_flags):
     dispatcher = args.dispatcher
     keep_temps = args.keep_temps
     rocshmem_bitcode = getattr(args, 'rocshmem_bitcode', None)
+    profile_rt = getattr(args, 'profile_rt', None)
 
     if not dispatcher:
         raise SystemExit("ERROR: --link requires --dispatcher=<source>")
@@ -587,12 +619,15 @@ def do_link(args, forwarded_flags):
 
     try:
         # Step 2: Compile dispatcher to assembly
+        # Use -gline-tables-only (not -g) so source-line info is present for
+        # llvm-cov mapping without the full-DWARF blow-up that would otherwise
+        # explode every per-arch dispatcher TU under -fcoverage-mapping.
         disp_compile_cmd = [
             clang,
             '-x', 'hip',
             '--offload-device-only',
             f'--offload-arch={arch}',
-            '-g', '-w',
+            '-gline-tables-only', '-w',
         ] + forwarded_flags + [
             '-S', '-o', disp_asm, dispatcher,
         ]
@@ -650,6 +685,26 @@ def do_link(args, forwarded_flags):
             '-o', output,
             f'@{rsp_path}',
         ]
+        # When ENABLE_DEVICE_COVERAGE=ON, CMake passes --profile-rt=<archive>
+        # so lld can resolve __llvm_profile_runtime / __start___llvm_prf_*
+        # symbols from the per-arch libclang_rt.profile.a. lld pulls in only
+        # the members referenced by the instrumented TUs; host-only members
+        # of the archive (fopen, calloc, atexit, ...) stay unreferenced.
+        #
+        # The profile-rt archive ships as LLVM *bitcode* (not native amdgcn
+        # objects), so lld runs LTO codegen on pulled-in members. Without
+        # an explicit --plugin-opt=mcpu, that codegen defaults to the host
+        # triple and lld errors out with "incompatible mach". Pass mcpu so
+        # the LTO backend targets amdgcn-amd-amdhsa for this arch.
+        if profile_rt:
+            if not os.path.exists(profile_rt):
+                print(f"WARNING: --profile-rt={profile_rt} not found, skipping",
+                      file=sys.stderr)
+            else:
+                link_cmd.extend([
+                    f'--plugin-opt=mcpu={arch}',
+                    profile_rt,
+                ])
         run(link_cmd, f"link device.elf for {arch}")
 
         if not keep_temps:
@@ -705,6 +760,11 @@ def parse_compiler_flags(argv):
         elif arg == '--rocshmem-bitcode' and i + 1 < len(argv):
             our_args.extend([arg, argv[i + 1]])
             i += 1
+        elif arg.startswith('--profile-rt='):
+            our_args.append(arg)
+        elif arg == '--profile-rt' and i + 1 < len(argv):
+            our_args.extend([arg, argv[i + 1]])
+            i += 1
         elif arg == '-o' and i + 1 < len(argv):
             our_args.extend(['-o', argv[i + 1]])
             i += 1
@@ -751,6 +811,7 @@ def main():
     parser.add_argument('--clang', default=None)
     parser.add_argument('--dispatcher', default=None)
     parser.add_argument('--rocshmem-bitcode', default=None, dest='rocshmem_bitcode')
+    parser.add_argument('--profile-rt', default=None, dest='profile_rt')
     parser.add_argument('-o', '--output', required=False)
     parser.add_argument('--keep-temps', action='store_true')
     parser.add_argument('--version', action='store_true')


### PR DESCRIPTION
## Status

**Draft — for examination, not for merge.**

Build-system support for end-to-end LLVM source-based coverage (host + device)
of RCCL on AMDGPU.  The device-side drain that this plumbing exercises lives
in-tree in compiler-rt and is being proposed separately as
[ROCm/llvm-project#2743](https://github.com/ROCm/llvm-project/pull/2743)
(supersedes draft #2714).  This PR is the matching RCCL change.

## Summary

Adds a single new build switch, `--enable-device-coverage`
(`-DENABLE_DEVICE_COVERAGE=ON`), that wires LLVM source-based coverage
through every stage of RCCL's HIP build pipeline:

- Host `librccl.so` is instrumented with
  `-fprofile-instr-generate -fcoverage-mapping`.
- The per-architecture device kernels (assembly-extract device linker
  pipeline) get the same flags, no longer qualified with `-Xarch_host`.
- The amdgcn device profile runtime (`libclang_rt.profile-amdgcn.a`) is
  located in the toolchain resource dir and force-linked into each
  per-arch device ELF.
- `librccl.so` force-links the host runtime's
  `__llvm_profile_hip_collect_device_data` drain symbol so the atexit
  handler that walks loaded HSA code objects gets registered.

When coverage is enabled without an explicit `--debug`, the build
automatically uses `Debug` + `CMAKE_CXX_FLAGS_DEBUG="-gline-tables-only
-O1"` rather than full `-g`, so coverage gets line tables without
multi-GiB AMDGPU assembly blow-up on per-kernel TUs.

## Files touched

- `projects/rccl/install.sh` — new `--enable-device-coverage` switch,
  auto-Debug + lite-debug flags when coverage is on without `--debug`.
- `projects/rccl/CMakeLists.txt` — `ENABLE_DEVICE_COVERAGE` option,
  forced cache writes for the coverage-friendly debug flags, signal to
  the device-linker layer.
- `projects/rccl/src/CMakeLists.txt` — drop `-Xarch_host` on the
  instrumentation flags when device coverage is on; force-link the host
  drain symbol on the librccl link line.
- `projects/rccl/cmake/DeviceLinker.cmake` — thread the coverage flags
  through per-kernel device compiles, dispatcher compiles, and
  fat-object compiles; pin the device-linker compiler to
  `CMAKE_CXX_COMPILER`; locate `libclang_rt.profile-amdgcn.a` and pass
  it to the device link via the existing driver's `--profile-rt`
  argument.  Symlinks `device-<arch>.elf` next to `librccl.so` in the
  build root so coverage workflows can point `llvm-cov` at it without
  walking the leading-hyphen CDNA-scheduling directory.
- `projects/rccl/tools/rccl-device-compile` — accept
  `--profile-rt=<archive>` and emit the right LLD `--plugin-opt=mcpu=`
  for LTO on the bitcode profile runtime; strip the
  AMDGPU-assembler-incompatible `.no_dead_strip .L<local>` directives
  the coverage-mapping pass emits.
- `projects/rccl-tests/install.sh` + `projects/rccl-tests/src/Makefile`
  — matching `--enable-device-coverage` switch for the test
  binaries' own host code.

## Validation

Full `--enable-device-coverage` build on Linux x86_64 driving 4× AMD
Instinct MI210 (gfx90a), using clang 23.0.0git from ROCm/llvm-project
(the in-tree compiler-rt HSA-introspection drain,
[ROCm/llvm-project#2743](https://github.com/ROCm/llvm-project/pull/2743))
against the ROCm 7.1.0 HIP/HSA runtime.  Both host and device TUs build
with the auto-selected lite-debug flags (`-O1 -gline-tables-only`).

- Instrumented `librccl.so` carries `__llvm_prf_*` + `__llvm_covfun` +
  `__llvm_covmap` sections (18k+ profile symbols) and a defined
  `__llvm_profile_hip_collect_device_data` drain forwarder; the
  `device-gfx90a.elf` symlink is emitted next to the build's `librccl.so`.
- `all_reduce_perf` and `alltoall_perf`, `-g 4`, full 32 B → 1 GiB sweep
  (factor 2): both complete with `Out of bounds values : 0 OK`.
- Each run drains 1 host `.profraw` + 111 device `gfx90a.*.profraw`
  (one per loaded instrumented HSA code object across the four agents),
  written at process exit by the HSA-introspection atexit walk — 226
  profraws total across the two runs.
- `llvm-profdata merge` + `llvm-cov report` against the per-arch device
  ELF yield real device-side coverage: aggregate ~9.9% line / 18.2%
  region / 23.4% branch, with hot paths well covered (e.g.
  `device/sendrecv.h` 100% line, `device/prims_ll.h` 60.8% line,
  `device/prims_simple.h` 37.9% line).

No changes to any GPU target support paths.
