### PR TITLE
[rocprofiler-compute] Extract PC sampling into standalone profiler

### DIFF
--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -78,6 +78,8 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 * Fixed empirical roofline benchmark to correctly produce double the Matrix BF16 Gflop/s on gfx90a (MI 200 series) GPUs
 
+* PC sampling collection now runs when requested via the `pc_sampling` block alias (`--block pc_sampling`), instead of being silently skipped
+
 ### Upcoming changes
 
 * Roofline support for RDNA 3.5 gfx1151 devices

--- a/projects/rocprofiler-compute/CMakeLists.txt
+++ b/projects/rocprofiler-compute/CMakeLists.txt
@@ -709,6 +709,18 @@ add_test(
 )
 
 # -----------------------------------
+# PC sampling profiler unit tests
+# -----------------------------------
+
+add_test(
+    NAME test_pc_sampling_profile
+    COMMAND
+        ${PYTHON_TEST_COMMAND} -m pytest ${STANDALONEBINARY_TEST_OPTION}
+        --junitxml=tests/test_pc_sampling_profile.xml ${COV_OPTION}
+        tests/test_pc_sampling_profile.py ${WORKING_DIR_OPTION}
+)
+
+# -----------------------------------
 # SoC base counter allocation tests
 # -----------------------------------
 
@@ -877,6 +889,13 @@ install(
 # src/rocprof_compute_profile
 install(
     DIRECTORY src/rocprof_compute_profile
+    DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME}
+    COMPONENT main
+    PATTERN "__pycache__" EXCLUDE
+)
+# src/pc_sampling
+install(
+    DIRECTORY src/pc_sampling
     DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/${PROJECT_NAME}
     COMPONENT main
     PATTERN "__pycache__" EXCLUDE

--- a/projects/rocprofiler-compute/src/pc_sampling/pc_sampling_profile.py
+++ b/projects/rocprofiler-compute/src/pc_sampling/pc_sampling_profile.py
@@ -1,0 +1,227 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
+import argparse
+import os
+import shlex
+import shutil
+import time
+from pathlib import Path
+from typing import Union, cast
+
+from utils.logger import console_debug, console_error, console_log
+from utils.utils_common import (
+    PC_SAMPLING_BLOCK_IDS,
+    capture_subprocess_output,
+    get_rocprof_cmd,
+    is_only_pc_sampling,
+    perform_attach_detach,
+)
+from utils.utils_profile import ProfilerOptions, is_live_attach
+
+
+class PCSamplingProfile:
+    """Standalone PC sampling profile pass.
+
+    Encapsulates the rocprof launch, env/option construction, output-path
+    cleanup, and timing/logging for a single PC sampling collection.
+    """
+
+    def __init__(
+        self,
+        args: argparse.Namespace,
+        profiler: str,
+        workload_dir: Union[str, Path],
+    ) -> None:
+        """Store the run config (args, profiler backend, output directory)."""
+        self._args = args
+        self._profiler = profiler
+        self._workload_dir = str(workload_dir)
+
+    def is_requested(self) -> bool:
+        """Return True if a PC sampling block (21 / pc_sampling) was requested."""
+        return any(block in PC_SAMPLING_BLOCK_IDS for block in self._args.filter_blocks)
+
+    def run(
+        self,
+        profiler_options: ProfilerOptions,
+        prior_run_count: int,
+    ) -> None:
+        """Execute the PC sampling pass and log timing."""
+        console_log(
+            f"[Run {prior_run_count + 1}/{prior_run_count + 1}]"
+            "[PC sampling profile run]"
+        )
+
+        self._cleanup_stale_output(profiler_options)
+
+        start_time = time.time()
+        self._launch(profiler_options)
+        duration = time.time() - start_time
+
+        console_debug(
+            "profiling",
+            f"The time of pc sampling profiling is {int(duration / 60)} m "
+            f"{duration % 60} sec",
+        )
+
+    def _cleanup_stale_output(
+        self,
+        profiler_options: ProfilerOptions,
+    ) -> None:
+        """Remove a leftover ROCPROF_OUTPUT_PATH in PC-sampling-only sdk runs."""
+        if not (
+            is_only_pc_sampling(self._args.filter_blocks)
+            and self._profiler == "rocprofiler-sdk"
+        ):
+            return
+        if not isinstance(profiler_options, dict):
+            return
+        rocprof_output_path = profiler_options.get("ROCPROF_OUTPUT_PATH")
+        if rocprof_output_path is None:
+            return
+        rocprof_output_path = Path(rocprof_output_path)
+        if rocprof_output_path.exists():
+            shutil.rmtree(rocprof_output_path, ignore_errors=True)
+            if rocprof_output_path.exists():
+                console_debug(
+                    "Failed to remove existing ROCProf output path: "
+                    f"{rocprof_output_path}"
+                )
+            else:
+                console_debug(
+                    f"Removed existing ROCProf output path: {rocprof_output_path}"
+                )
+
+    def _launch(
+        self,
+        profiler_options: ProfilerOptions,
+    ) -> None:
+        """Run rocprof with pc sampling. Current support v3 only."""
+        # Todo:
+        #   - precheck with rocprofv3 --list-avail
+        method = self._args.pc_sampling_method
+        interval = self._args.pc_sampling_interval
+        unit = "time" if method == "host_trap" else "cycles"
+
+        if self._profiler == "rocprofiler-sdk":
+            self._launch_sdk(
+                cast(dict[str, Union[str, list[str]]], profiler_options),
+                method,
+                interval,
+                unit,
+            )
+        else:
+            self._launch_v3(cast(list[str], profiler_options), method, interval, unit)
+
+    def _launch_sdk(
+        self,
+        profiler_options: dict[str, Union[str, list[str]]],
+        method: str,
+        interval: int,
+        unit: str,
+    ) -> None:
+        """Launch the rocprofiler-sdk backend for PC sampling via env vars."""
+        options = profiler_options.copy()
+        options.update({
+            # no counter collection for pc sampling
+            "ROCPROF_COUNTER_COLLECTION": "0",
+            "ROCPROF_KERNEL_TRACE": "1",
+            "ROCPROF_OUTPUT_FORMAT": "csv,json",
+            "ROCPROF_OUTPUT_PATH": self._workload_dir,
+            "ROCPROF_OUTPUT_FILE_NAME": "ps_file",
+            "ROCPROFILER_PC_SAMPLING_BETA_ENABLED": "1",
+            "ROCPROF_PC_SAMPLING_UNIT": unit,
+            "ROCPROF_PC_SAMPLING_INTERVAL": str(interval),
+            "ROCPROF_PC_SAMPLING_METHOD": method,
+        })
+        app_cmd = options.pop("APP_CMD") if "APP_CMD" in options else None
+        new_env = os.environ.copy()
+        for key, value in options.items():
+            new_env[key] = value
+        # Log only the os.environ delta to avoid leaking secrets in shared logs.
+        env_delta = {k: v for k, v in new_env.items() if os.environ.get(k) != v}
+        console_debug(f"pc sampling rocprof sdk env vars: {env_delta}")
+
+        if is_live_attach(profiler_options):
+            perform_attach_detach(new_env, options)
+            return
+
+        if app_cmd is None:
+            console_error(
+                "APP_CMD, the workload's executable must be provided "
+                "when not in live attach mode"
+            )
+            return
+
+        console_debug(f"pc sampling rocprof sdk user provided command: {app_cmd}")
+        success, _ = capture_subprocess_output(
+            app_cmd, new_env=new_env, profileMode=True
+        )
+        if not success:
+            console_error("PC sampling failed.")
+
+    def _launch_v3(
+        self,
+        profiler_options: list[str],
+        method: str,
+        interval: int,
+        unit: str,
+    ) -> None:
+        """Launch the rocprofv3 CLI backend for PC sampling via flags."""
+        options = [
+            "--kernel-trace",
+            "--pc-sampling-beta-enabled",
+            "--pc-sampling-method",
+            method,
+            "--pc-sampling-unit",
+            unit,
+            "--output-format",
+            "csv",
+            "json",
+            "--pc-sampling-interval",
+            str(interval),
+            "-d",
+            self._workload_dir,
+            "-o",
+            "ps_file",  # TODO: sync up with the name from source in 2100_.yaml
+        ]
+
+        if is_live_attach(profiler_options):
+            try:
+                pid_idx = profiler_options.index("--pid")
+                options += ["--pid", profiler_options[pid_idx + 1]]
+                if "--attach-duration-msec" in profiler_options:
+                    dur_idx = profiler_options.index("--attach-duration-msec")
+                    options += [
+                        "--attach-duration-msec",
+                        profiler_options[dur_idx + 1],
+                    ]
+            except (ValueError, IndexError):
+                console_error(
+                    "--pid or --attach-duration-msec option not found in "
+                    "profiler arguments for live attach mode"
+                )
+                return
+        else:
+            try:
+                app_cmd_with_separator = profiler_options[
+                    profiler_options.index("--") :
+                ]
+                options += app_cmd_with_separator
+            except ValueError:
+                console_error(
+                    "APP_CMD, the workload's executable must be provided "
+                    "when not in live attach mode"
+                )
+                return
+
+        rocprof_cmd = get_rocprof_cmd()
+        console_debug(f"rocprof command: {shlex.join([rocprof_cmd] + options)}")
+        success, _ = capture_subprocess_output(
+            [rocprof_cmd] + options,
+            new_env=os.environ.copy(),
+            profileMode=True,
+        )
+        if not success:
+            console_error("PC sampling failed.")

--- a/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_profile/profiler_base.py
@@ -11,6 +11,7 @@ from abc import abstractmethod
 from pathlib import Path
 from typing import Any, Optional, Union
 
+from pc_sampling.pc_sampling_profile import PCSamplingProfile
 from rocprof_compute_soc.soc_base import OmniSoC_Base
 from utils.logger import (
     console_debug,
@@ -31,7 +32,7 @@ from utils.utils_exceptions import (
     NoScriptInCommandError,
     PythonScriptNotFoundError,
 )
-from utils.utils_profile import gen_sysinfo, pc_sampling_prof, run_prof
+from utils.utils_profile import gen_sysinfo, run_prof
 from vendored import yaml
 
 
@@ -368,6 +369,12 @@ class RocProfCompute_Base:
         else:
             console_log("Filtered sections: All")
 
+        pc_sampling = PCSamplingProfile(
+            args=args,
+            profiler=self.__profiler,
+            workload_dir=args.output_directory,
+        )
+
         # Run profiling on each input file
         input_files = sorted(
             Path(args.output_directory).glob("perfmon/pmc_perf_*.yaml")
@@ -392,7 +399,7 @@ class RocProfCompute_Base:
 
         # Compute total workload runs including PC sampling for warning check
         total_workload_runs = total_runs
-        if any(block in ["21", "pc_sampling"] for block in args.filter_blocks):
+        if pc_sampling.is_requested():
             total_workload_runs += 1
 
         # Warn about multi-rank profiling when multiple workload runs are needed
@@ -473,51 +480,14 @@ class RocProfCompute_Base:
                 duration = self.profile(fname, options, total_runs)
                 total_profiling_time += duration
 
-        # PC sampling data is only collected when --pc-sampling is set
-        # (sanitize() injects "21" into filter_blocks when --pc-sampling is set).
-        if "21" not in args.filter_blocks:
+        if not pc_sampling.is_requested():
             console_warning(
                 "PC sampling data collection skipped as --pc-sampling is not specified."
             )
             return
 
-        total_runs = len(
-            list(Path(args.output_directory).glob("perfmon/pmc_perf_*.yaml"))
-        )
-
-        console_log(f"[Run {total_runs + 1}/{total_runs + 1}][PC sampling profile run]")
-
-        start_time = time.time()
         # No native tool for pc sampling
-        options = self.get_profiler_options()
-
-        if (
-            is_only_pc_sampling(args.filter_blocks)
-            and self.__profiler == "rocprofiler-sdk"
-            and (rocprof_output_path := getattr(options, "ROCPROF_OUTPUT_PATH", None))
-            is not None
-        ):
-            rocprof_output_path = Path(rocprof_output_path)
-            if rocprof_output_path.exists():
-                shutil.rmtree(rocprof_output_path, ignore_errors=True)
-                console_debug(
-                    f"Removed existing ROCProf output path: {rocprof_output_path}"
-                )
-
-        pc_sampling_prof(
-            profiler_options=options,
-            method=args.pc_sampling_method,
-            interval=args.pc_sampling_interval,
-            workload_dir=args.output_directory,
-        )
-        end_time = time.time()
-
-        duration = end_time - start_time
-        console_debug(
-            "profiling",
-            f"The time of pc sampling profiling is {int(duration / 60)} m "
-            f"{duration % 60} sec",
-        )
+        pc_sampling.run(self.get_profiler_options(), total_runs)
 
     def __get_native_tool_path(self, args: argparse.Namespace) -> str | None:
         try:

--- a/projects/rocprofiler-compute/src/utils/utils_common.py
+++ b/projects/rocprofiler-compute/src/utils/utils_common.py
@@ -35,6 +35,7 @@ from vendored import yaml
 
 # Global constants
 METRIC_ID_RE = re.compile(pattern=r"^\d{1,2}(?:\.\d{1,2}){0,2}$")
+PC_SAMPLING_BLOCK_IDS = ("21", "pc_sampling")
 
 
 def canonical_config_arch(gpu_arch: Optional[str]) -> Optional[str]:
@@ -622,9 +623,10 @@ def parse_pmc_perf(pmc_perf_file: str) -> list[str]:
 
 
 def is_only_pc_sampling(filter_blocks: list[str]) -> bool:
-    """Return True if all requested blocks are PC sampling (block 21)."""
+    """Return True if all requested blocks are PC sampling (block 21 or the
+    ``pc_sampling`` alias)."""
     return bool(filter_blocks) and all(
-        block in ["21", "pc_sampling"] for block in filter_blocks
+        block in PC_SAMPLING_BLOCK_IDS for block in filter_blocks
     )
 
 

--- a/projects/rocprofiler-compute/src/utils/utils_profile.py
+++ b/projects/rocprofiler-compute/src/utils/utils_profile.py
@@ -36,9 +36,11 @@ _PROFILER_INTERNAL_RE = re.compile(
     r"|^[WI]\d{8}\s"  # glog-style timestamps (W/I followed by YYYYMMDD)
 )
 
+ProfilerOptions = Union[list[str], dict[str, Union[str, list[str]]]]
 
-def _is_live_attach(
-    profiler_options: Union[list[str], dict[str, Union[str, list[str]]]],
+
+def is_live_attach(
+    profiler_options: ProfilerOptions,
 ) -> bool:
     """Return True if the profiler options indicate a live-attach (pid) mode."""
     return (isinstance(profiler_options, list) and "--pid" in profiler_options) or (
@@ -61,7 +63,7 @@ def _classify_output_line(line: str) -> None:
 
 def run_prof(
     fnames: Union[list[str], str],
-    profiler_options: Union[list[str], dict[str, Union[str, list[str]]]],
+    profiler_options: ProfilerOptions,
     workload_dir: str,
     loglevel: int,
     format_rocprof_output: str,
@@ -156,12 +158,12 @@ def run_prof(
         env_delta = {k: v for k, v in new_env.items() if os.environ.get(k) != v}
         console_debug(f"rocprof sdk env vars: {env_delta}")
 
-        if _is_live_attach(profiler_options):
+        if is_live_attach(profiler_options):
             perform_attach_detach(new_env, options)
         else:
             if app_cmd is None:
                 console_error(
-                    "APP_CMD, the workload's execuatble must be provided "
+                    "APP_CMD, the workload's executable must be provided "
                     "when not in live attach mode"
                 )
 
@@ -196,7 +198,7 @@ def run_prof(
     if new_env.get("ROCPROFILER_METRICS_PATH"):
         shutil.rmtree(new_env["ROCPROFILER_METRICS_PATH"], ignore_errors=True)
 
-    if (not _is_live_attach(profiler_options)) and (not success):
+    if (not is_live_attach(profiler_options)) and (not success):
         for line in output.splitlines():
             stripped = line.strip()
             if stripped:
@@ -400,114 +402,6 @@ def run_prof(
         csv_ops.write_csv_from_dicts(str(csv_path), rows)
     else:
         console_error(f"Unknown format_rocprof_output: {format_rocprof_output}")
-
-
-def pc_sampling_prof(
-    profiler_options: Union[list[str], dict[str, Union[str, list[str]]]],
-    method: str,
-    interval: int,
-    workload_dir: str,
-) -> None:
-    """
-    Run rocprof with pc sampling. Current support v3 only.
-    """
-    # Todo:
-    #   - precheck with rocprofv3 –-list-avail
-
-    unit = "time" if method == "host_trap" else "cycles"
-
-    if get_rocprof_cmd() == "rocprofiler-sdk":
-        options = cast(dict[str, Union[str, list[str]]], profiler_options).copy()
-        options.update({
-            # no counter collection for pc sampling
-            "ROCPROF_COUNTER_COLLECTION": "0",
-            "ROCPROF_KERNEL_TRACE": "1",
-            "ROCPROF_OUTPUT_FORMAT": "csv,json",
-            "ROCPROF_OUTPUT_PATH": workload_dir,
-            "ROCPROF_OUTPUT_FILE_NAME": "ps_file",
-            "ROCPROFILER_PC_SAMPLING_BETA_ENABLED": "1",
-            "ROCPROF_PC_SAMPLING_UNIT": unit,
-            "ROCPROF_PC_SAMPLING_INTERVAL": str(interval),
-            "ROCPROF_PC_SAMPLING_METHOD": method,
-        })
-        app_cmd = options.pop("APP_CMD") if "APP_CMD" in options else None
-        new_env = os.environ.copy()
-        for key, value in options.items():
-            new_env[key] = value
-        # Log only the os.environ delta to avoid leaking secrets in shared logs.
-        env_delta = {k: v for k, v in new_env.items() if os.environ.get(k) != v}
-        console_debug(f"pc sampling rocprof sdk env vars: {env_delta}")
-
-        if _is_live_attach(profiler_options):
-            perform_attach_detach(new_env, options)
-        else:
-            if app_cmd is None:
-                console_error(
-                    "APP_CMD, the workload's executable must be provided "
-                    "when not in live attach mode"
-                )
-
-            console_debug(f"pc sampling rocprof sdk user provided command: {app_cmd}")
-            success, output = capture_subprocess_output(
-                app_cmd, new_env=new_env, profileMode=True
-            )
-            if not success:
-                console_error("PC sampling failed.")
-    else:
-        profiler_options_list = cast(list[str], profiler_options)
-
-        options = [
-            "--kernel-trace",
-            "--pc-sampling-beta-enabled",
-            "--pc-sampling-method",
-            method,
-            "--pc-sampling-unit",
-            unit,
-            "--output-format",
-            "csv",
-            "json",
-            "--pc-sampling-interval",
-            str(interval),
-            "-d",
-            workload_dir,
-            "-o",
-            "ps_file",  # TODO: sync up with the name from source in 2100_.yaml
-        ]
-
-        if _is_live_attach(profiler_options):
-            try:
-                pid_idx = profiler_options_list.index("--pid")
-                options += ["--pid", profiler_options_list[pid_idx + 1]]
-                if "--attach-duration-msec" in profiler_options_list:
-                    dur_idx = profiler_options_list.index("--attach-duration-msec")
-                    options += [
-                        "--attach-duration-msec",
-                        profiler_options_list[dur_idx + 1],
-                    ]
-            except (ValueError, IndexError):
-                console_error(
-                    "--pid or --attach-duration-msec option not found in "
-                    "profiler arguments for live attach mode"
-                )
-        else:
-            try:
-                app_cmd_with_separator = profiler_options_list[
-                    profiler_options_list.index("--") :
-                ]
-                options += app_cmd_with_separator
-            except ValueError:
-                console_error(
-                    "APP_CMD, the workload's executable must be provided "
-                    "when not in live attach mode"
-                )
-
-        console_debug(f"rocprof command: {shlex.join([get_rocprof_cmd()] + options)}")
-        # profile the app
-        success, output = capture_subprocess_output(
-            [get_rocprof_cmd()] + options, new_env=os.environ.copy(), profileMode=True
-        )
-        if not success:
-            console_error("PC sampling failed.")
 
 
 @demarcate

--- a/projects/rocprofiler-compute/tests/common.py
+++ b/projects/rocprofiler-compute/tests/common.py
@@ -8,6 +8,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
+from unittest.mock import Mock
 
 import pandas as pd
 import pytest
@@ -237,6 +238,20 @@ def strip_ansi(s: str) -> str:
     return ansi_escape.sub("", s)
 
 
+def patch_console(monkeypatch, module, *names, **overrides):
+    """Patch ``module.console_<name>`` with a Mock for each name; return {name: Mock}.
+
+    Pass ``name=callable`` to substitute a specific mock (e.g. a record-and-raise
+    stub for the console_error exit path).
+    """
+    mocks = {}
+    for name in names:
+        mock = overrides.get(name, Mock())
+        monkeypatch.setattr(f"{module}.console_{name}", mock)
+        mocks[name] = mock
+    return mocks
+
+
 def gpu_soc():
     """Return (arch, model) from rocminfo, e.g. ('gfx942', 'MI300').
 
@@ -270,3 +285,12 @@ def skip_unsupported_pc_sampling_soc(is_stochastic=False):
 
     if soc in unsupported_socs:
         pytest.skip(f"PC sampling is not supported on {soc}")
+
+
+def require_pc_sampling_gpu(is_stochastic=False):
+    """Skip the test unless a GPU that supports the selected PC sampling mode is
+    present."""
+    _, soc = gpu_soc()
+    if not soc:
+        pytest.skip("GPU not supported")
+    skip_unsupported_pc_sampling_soc(is_stochastic=is_stochastic)

--- a/projects/rocprofiler-compute/tests/conftest.py
+++ b/projects/rocprofiler-compute/tests/conftest.py
@@ -48,6 +48,7 @@ class ProfileModeImportGuard:
         "rocprof_compute_analyze",
         "rocprof_compute_soc",
         "rocprof_compute_tui",
+        "pc_sampling",
         "utils",
         "vendored",
         "roofline",

--- a/projects/rocprofiler-compute/tests/test_categories.yaml
+++ b/projects/rocprofiler-compute/tests/test_categories.yaml
@@ -21,6 +21,7 @@ test_categories:
       - test_roofline_calc_ai_analyze
       - test_num_xcds_spec_class
       - test_profiler_base
+      - test_pc_sampling_profile
       - test_num_xcds_cli_output
       - test_mi_gpu_spec
       - test_utils_profile_csv
@@ -75,6 +76,7 @@ test_categories:
       - test_pc_sampling_analysis
       - test_utils_profile_csv
       - test_profiler_base
+      - test_pc_sampling_profile
       - test_mem_chart
       - test_native_tool_finder
       - test-rocprofiler-compute-tool
@@ -123,6 +125,7 @@ test_categories:
       - test_pc_sampling_analysis
       - test_utils_profile_csv
       - test_profiler_base
+      - test_pc_sampling_profile
       - test_mem_chart
       - test_native_tool_finder
       - test-rocprofiler-compute-tool
@@ -171,6 +174,7 @@ test_categories:
       - test_pc_sampling_analysis
       - test_utils_profile_csv
       - test_profiler_base
+      - test_pc_sampling_profile
       - test_mem_chart
       - test_native_tool_finder
       - test-rocprofiler-compute-tool

--- a/projects/rocprofiler-compute/tests/test_pc_sampling.py
+++ b/projects/rocprofiler-compute/tests/test_pc_sampling.py
@@ -1,7 +1,6 @@
 # Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier:  MIT
 
-import os
 from pathlib import Path
 
 import common
@@ -16,12 +15,6 @@ config["METRIC_COMPARE"] = False
 
 num_devices = 1
 
-_, soc = common.gpu_soc()
-
-if soc is None:
-    pytest.skip("GPU not supported", allow_module_level=True)
-
-os.environ["ROCPROF"] = "rocprofiler-sdk"
 
 PC_SAMPLING_HOST_TRAP_FILES = sorted([
     "ps_file_agent_info.csv",
@@ -54,11 +47,12 @@ def _skip_if_pc_sampling_unsupported(stdout, stderr, workload_dir):
         pytest.skip("PC sampling is not supported")
 
 
-def test_pc_sampling_host_trap(binary_handler_profile_rocprof_compute):
+def test_pc_sampling_host_trap(binary_handler_profile_rocprof_compute, monkeypatch):
     """
     Test that PC sampling works with --block 21 and --pc-sampling-method host_trap.
     """
-    common.skip_unsupported_pc_sampling_soc()
+    common.require_pc_sampling_gpu()
+    monkeypatch.setenv("ROCPROF", "rocprofiler-sdk")
 
     options = [
         "--experimental",
@@ -92,11 +86,12 @@ def test_pc_sampling_host_trap(binary_handler_profile_rocprof_compute):
     common.clean_output_dir(config["cleanup"], workload_dir)
 
 
-def test_pc_sampling_stochastic(binary_handler_profile_rocprof_compute):
+def test_pc_sampling_stochastic(binary_handler_profile_rocprof_compute, monkeypatch):
     """
     Test that PC sampling works with --block 21 and --pc-sampling-method stochastic.
     """
-    common.skip_unsupported_pc_sampling_soc(is_stochastic=True)
+    common.require_pc_sampling_gpu(is_stochastic=True)
+    monkeypatch.setenv("ROCPROF", "rocprofiler-sdk")
 
     options = [
         "--experimental",
@@ -137,7 +132,8 @@ def test_multi_rank_pc_sampling_only(
     Test that no multi-rank warning is printed when running with only
     --block 21 (PC sampling only mode requires a single pass) with multi-rank.
     """
-    common.skip_unsupported_pc_sampling_soc()
+    common.require_pc_sampling_gpu()
+    monkeypatch.setenv("ROCPROF", "rocprofiler-sdk")
 
     monkeypatch.setenv("OMPI_COMM_WORLD_RANK", "0")
     monkeypatch.setenv("OMPI_COMM_WORLD_SIZE", "2")
@@ -180,7 +176,8 @@ def test_multi_rank_warning_pc_sampling_with_counters(
     and another block (PC sampling with counters mode requires multiple passes)
     with multi-rank.
     """
-    common.skip_unsupported_pc_sampling_soc()
+    common.require_pc_sampling_gpu()
+    monkeypatch.setenv("ROCPROF", "rocprofiler-sdk")
 
     monkeypatch.setenv("OMPI_COMM_WORLD_RANK", "0")
     monkeypatch.setenv("OMPI_COMM_WORLD_SIZE", "2")
@@ -224,12 +221,14 @@ def test_pc_sampling_profile_then_analyze(
     binary_handler_profile_rocprof_compute,
     binary_handler_analyze_rocprof_compute,
     capsys,
+    monkeypatch,
 ):
     """
     End-to-end: profile with PC sampling (host_trap), then
     run analysis on the profiling output.
     """
-    common.skip_unsupported_pc_sampling_soc()
+    common.require_pc_sampling_gpu()
+    monkeypatch.setenv("ROCPROF", "rocprofiler-sdk")
 
     options = [
         "--experimental",
@@ -312,12 +311,15 @@ def test_pc_sampling_profile_then_analyze(
     common.clean_output_dir(config["cleanup"], workload_dir)
 
 
-def test_pc_sampling_with_sol_block(binary_handler_profile_rocprof_compute):
+def test_pc_sampling_with_sol_block(
+    binary_handler_profile_rocprof_compute, monkeypatch
+):
     """
     Test that PC sampling works with --block 21 and --block 2
     (PC sampling with counter collection)
     """
-    common.skip_unsupported_pc_sampling_soc()
+    common.require_pc_sampling_gpu()
+    monkeypatch.setenv("ROCPROF", "rocprofiler-sdk")
 
     options = [
         "--experimental",

--- a/projects/rocprofiler-compute/tests/test_pc_sampling_profile.py
+++ b/projects/rocprofiler-compute/tests/test_pc_sampling_profile.py
@@ -1,0 +1,468 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+from common import patch_console
+
+from pc_sampling.pc_sampling_profile import PCSamplingProfile
+
+MODULE = "pc_sampling.pc_sampling_profile"
+
+
+class MockArgs:
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+def _make_pc_sampling_profile(method, interval, workload_dir, profiler):
+    """Build a PCSamplingProfile with a minimal args namespace for launch tests."""
+    return PCSamplingProfile(
+        args=MockArgs(
+            pc_sampling_method=method,
+            pc_sampling_interval=interval,
+            filter_blocks=["21"],
+        ),
+        profiler=profiler,
+        workload_dir=workload_dir,
+    )
+
+
+def test_pc_sampling_profile_sdk_forwards_env_and_ld_preload(tmp_path, monkeypatch):
+    """sdk non-live-attach launch forwards LD_PRELOAD plus the PC sampling
+    env vars (method/interval and the host_trap->time unit mapping) into the
+    subprocess env on success."""
+    method = "host_trap"
+    interval = 1000
+    workload_dir = str(tmp_path)
+    options = {"APP_CMD": "my_app --arg"}
+
+    expected_tool_path = str(
+        tmp_path / "rocm_sdk" / "lib" / "rocprofiler-sdk" / "librocprofiler-sdk-tool.so"
+    )
+    options["LD_PRELOAD"] = expected_tool_path
+
+    mock_capture = Mock(return_value=(True, "Success output"))
+    monkeypatch.setattr(f"{MODULE}.capture_subprocess_output", mock_capture)
+    mock_error = patch_console(monkeypatch, MODULE, "debug", "error")["error"]
+
+    profiler = _make_pc_sampling_profile(
+        method, interval, workload_dir, "rocprofiler-sdk"
+    )
+    profiler._launch(options)
+
+    assert mock_capture.called
+    called_env = mock_capture.call_args.kwargs.get("new_env", {})
+
+    assert called_env["LD_PRELOAD"] == expected_tool_path
+    assert called_env["ROCPROF_PC_SAMPLING_METHOD"] == method
+    assert called_env["ROCPROF_PC_SAMPLING_UNIT"] == "time"
+    assert called_env["ROCPROF_PC_SAMPLING_INTERVAL"] == str(interval)
+    assert called_env["ROCPROF_OUTPUT_PATH"] == workload_dir
+    assert called_env["ROCPROF_OUTPUT_FILE_NAME"] == "ps_file"
+
+    mock_error.assert_not_called()
+
+
+def test_pc_sampling_profile_env_log_excludes_user_env(tmp_path, monkeypatch):
+    """The sdk launch must log only profiler-added env vars, never the user's
+    full environment, to avoid leaking secrets into shared workload logs."""
+    monkeypatch.setenv("LEAK_CANARY_TOKEN", "SHOULD_NOT_APPEAR")
+    mock_capture = Mock(return_value=(True, "Success output"))
+    monkeypatch.setattr(f"{MODULE}.capture_subprocess_output", mock_capture)
+    _mocks = patch_console(monkeypatch, MODULE, "debug", "error")
+    mock_debug, mock_error = _mocks["debug"], _mocks["error"]
+
+    profiler = _make_pc_sampling_profile(
+        "host_trap", 1000, str(tmp_path), "rocprofiler-sdk"
+    )
+    profiler._launch({"APP_CMD": "my_app"})
+
+    logs = [str(call.args[0]) for call in mock_debug.call_args_list]
+    env_log_lines = [m for m in logs if "env vars" in m]
+    assert env_log_lines
+    assert any("ROCPROF_PC_SAMPLING_METHOD" in m for m in env_log_lines)
+    assert not any("SHOULD_NOT_APPEAR" in m for m in logs)
+
+    mock_error.assert_not_called()
+
+
+def test_pc_sampling_profile_sdk_stochastic_unit_is_cycles(tmp_path, monkeypatch):
+    """A non-host_trap (stochastic) method maps to the ``cycles`` sampling unit
+    in the forwarded sdk env."""
+    method = "stochastic"
+    interval = 5000
+    workload_dir = str(tmp_path)
+    options = {"APP_CMD": "my_app"}
+
+    mock_capture = Mock(return_value=(True, "Success output"))
+    monkeypatch.setattr(f"{MODULE}.capture_subprocess_output", mock_capture)
+    mock_error = patch_console(monkeypatch, MODULE, "debug", "error")["error"]
+
+    profiler = _make_pc_sampling_profile(
+        method, interval, workload_dir, "rocprofiler-sdk"
+    )
+    profiler._launch(options)
+
+    called_env = mock_capture.call_args.kwargs.get("new_env", {})
+    assert called_env["ROCPROF_PC_SAMPLING_METHOD"] == method
+    assert called_env["ROCPROF_PC_SAMPLING_UNIT"] == "cycles"
+    assert called_env["ROCPROF_PC_SAMPLING_INTERVAL"] == str(interval)
+
+    mock_error.assert_not_called()
+
+
+def test_pc_sampling_profile_subprocess_fails(tmp_path, monkeypatch):
+    """
+    Edge Case: The capture_subprocess_output returns success=False.
+    This should trigger the console_error("PC sampling failed.").
+    """
+    console_error_calls = []
+
+    def mock_console_error(msg, exit=True):
+        console_error_calls.append(msg)
+        if exit:
+            raise RuntimeError("console_error called")
+
+    mock_capture = Mock()
+    monkeypatch.setattr(f"{MODULE}.capture_subprocess_output", mock_capture)
+    patch_console(monkeypatch, MODULE, "debug", "error", error=mock_console_error)
+
+    method = "stochastic"
+    interval = 5000
+    workload_dir = str(tmp_path)
+    options = ["another_app"]
+
+    profiler = _make_pc_sampling_profile(method, interval, workload_dir, "rocprofv3")
+    with pytest.raises(RuntimeError, match="console_error called"):
+        profiler._launch(options)
+
+    mock_capture.assert_not_called()
+    assert console_error_calls == [
+        "APP_CMD, the workload's executable must be provided "
+        "when not in live attach mode"
+    ]
+
+    mock_capture.reset_mock()
+    console_error_calls.clear()
+    options = {"APP_CMD": "another_app"}
+    sdk_lib_dir = tmp_path / "rocm_sdk_fail" / "lib"
+    sdk_lib_dir.mkdir(parents=True, exist_ok=True)
+    rocprofiler_sdk_tool_path_sdk = str(sdk_lib_dir / "librocprofiler_sdk.so")
+    Path(rocprofiler_sdk_tool_path_sdk).touch()
+
+    tool_dir = sdk_lib_dir / "rocprofiler-sdk"
+    tool_dir.mkdir(parents=True, exist_ok=True)
+    (tool_dir / "librocprofiler-sdk-tool.so").touch()
+
+    mock_capture.return_value = (False, "Error output from SDK subprocess")
+
+    profiler = _make_pc_sampling_profile(
+        method, interval, workload_dir, "rocprofiler-sdk"
+    )
+    with pytest.raises(RuntimeError, match="console_error called"):
+        profiler._launch(options)
+
+    mock_capture.assert_called_once()
+    assert console_error_calls == ["PC sampling failed."]
+
+
+def test_pc_sampling_profile_empty_appcmd(tmp_path, monkeypatch):
+    """
+    Edge Case: The appcmd is an empty string.
+    The function should still attempt to run it. The behavior of
+    capture_subprocess_output with an empty command is external to this function.
+    """
+    method = "host_trap"
+    interval = 100
+    workload_dir = str(tmp_path)
+    options = ["--"]
+
+    mock_capture = Mock(return_value=(True, "Output with empty appcmd"))
+    monkeypatch.setattr(f"{MODULE}.capture_subprocess_output", mock_capture)
+    mock_error = patch_console(monkeypatch, MODULE, "debug", "error")["error"]
+
+    profiler = _make_pc_sampling_profile(method, interval, workload_dir, "rocprofv3")
+    profiler._launch(options)
+
+    assert mock_capture.called
+    options_list = mock_capture.call_args[0][0]
+    assert options_list[-1] == "--"
+    mock_error.assert_not_called()
+
+    mock_capture.reset_mock()
+    mock_error.reset_mock()
+    sdk_lib_dir = tmp_path / "rocm_sdk_empty" / "lib"
+    sdk_lib_dir.mkdir(parents=True, exist_ok=True)
+    rocprofiler_sdk_tool_path_sdk = str(sdk_lib_dir / "librocprofiler_sdk.so")
+    Path(rocprofiler_sdk_tool_path_sdk).touch()
+    tool_dir = sdk_lib_dir / "rocprofiler-sdk"
+    tool_dir.mkdir(parents=True, exist_ok=True)
+    (tool_dir / "librocprofiler-sdk-tool.so").touch()
+
+    mock_capture.return_value = (True, "Output with empty appcmd SDK")
+    options = {"APP_CMD": ""}
+
+    profiler = _make_pc_sampling_profile(
+        method, interval, workload_dir, "rocprofiler-sdk"
+    )
+    profiler._launch(options)
+
+    assert mock_capture.called
+    assert mock_capture.call_args[0][0] == ""
+    mock_error.assert_not_called()
+
+
+def test_pc_sampling_profile_multiarg_appcmd(tmp_path, monkeypatch):
+    """All arguments after '--' in profiler_options must appear
+    in the subprocess call."""
+    monkeypatch.setattr("utils.utils_common._rocprof_cmd", "rocprof_cli_tool")
+    method = "host_trap"
+    interval = 100
+    workload_dir = str(tmp_path)
+    options = ["--kernel-trace", "--", "./myapp", "arg1", "arg2"]
+
+    mock_capture = Mock(return_value=(True, "Success"))
+    monkeypatch.setattr(f"{MODULE}.capture_subprocess_output", mock_capture)
+    mock_error = patch_console(monkeypatch, MODULE, "debug", "error")["error"]
+
+    profiler = _make_pc_sampling_profile(method, interval, workload_dir, "rocprofv3")
+    profiler._launch(options)
+
+    assert mock_capture.called
+    options_list = mock_capture.call_args[0][0]
+    assert options_list[0] == "rocprof_cli_tool"
+    separator_index = options_list.index("--")
+    assert options_list[separator_index:] == ["--", "./myapp", "arg1", "arg2"]
+    mock_error.assert_not_called()
+
+
+def test_pc_sampling_profile_is_requested():
+    workload_dir = "/tmp"
+    for blocks in (["21"], ["pc_sampling"], ["2", "21"]):
+        profiler = PCSamplingProfile(
+            args=MockArgs(filter_blocks=blocks),
+            profiler="rocprofv3",
+            workload_dir=workload_dir,
+        )
+        assert profiler.is_requested() is True
+
+    profiler = PCSamplingProfile(
+        args=MockArgs(filter_blocks=["2"]),
+        profiler="rocprofv3",
+        workload_dir=workload_dir,
+    )
+    assert profiler.is_requested() is False
+
+
+def test_pc_sampling_profile_cleanup_stale_output_removes_dir(tmp_path, monkeypatch):
+    """Exclusive sdk run with a dict ROCPROF_OUTPUT_PATH removes the stale dir."""
+    patch_console(monkeypatch, MODULE, "debug")
+    stale = tmp_path / "out" / "pmc_1"
+    stale.mkdir(parents=True, exist_ok=True)
+    options = {"ROCPROF_OUTPUT_PATH": str(stale)}
+
+    profiler = PCSamplingProfile(
+        args=MockArgs(filter_blocks=["21"]),
+        profiler="rocprofiler-sdk",
+        workload_dir=str(tmp_path),
+    )
+    profiler._cleanup_stale_output(options)
+
+    assert not stale.exists()
+
+
+def test_pc_sampling_profile_cleanup_stale_output_noop_cases(tmp_path, monkeypatch):
+    """Cleanup is a no-op outside the exclusive-sdk-dict-with-key case."""
+    patch_console(monkeypatch, MODULE, "debug")
+    sdk_args = MockArgs(filter_blocks=["21"])
+
+    # Non-sdk profiler: no removal even when exclusive.
+    stale = tmp_path / "non_sdk"
+    stale.mkdir(parents=True, exist_ok=True)
+    PCSamplingProfile(
+        args=sdk_args, profiler="rocprofv3", workload_dir=str(tmp_path)
+    )._cleanup_stale_output({"ROCPROF_OUTPUT_PATH": str(stale)})
+    assert stale.exists()
+
+    # Non-exclusive: no removal.
+    stale = tmp_path / "mixed"
+    stale.mkdir(parents=True, exist_ok=True)
+    PCSamplingProfile(
+        args=MockArgs(filter_blocks=["2", "21"]),
+        profiler="rocprofiler-sdk",
+        workload_dir=str(tmp_path),
+    )._cleanup_stale_output({"ROCPROF_OUTPUT_PATH": str(stale)})
+    assert stale.exists()
+
+    # List options (v3): no removal.
+    stale = tmp_path / "list_opts"
+    stale.mkdir(parents=True, exist_ok=True)
+    PCSamplingProfile(
+        args=sdk_args, profiler="rocprofiler-sdk", workload_dir=str(tmp_path)
+    )._cleanup_stale_output(["--kernel-trace"])
+    assert stale.exists()
+
+    # Missing key: no error, no removal.
+    PCSamplingProfile(
+        args=sdk_args, profiler="rocprofiler-sdk", workload_dir=str(tmp_path)
+    )._cleanup_stale_output({"APP_CMD": "app"})
+
+
+def test_pc_sampling_profile_v3_live_attach(tmp_path, monkeypatch):
+    """v3 live-attach appends --pid and --attach-duration-msec, no APP_CMD '--'."""
+    monkeypatch.setattr("utils.utils_common._rocprof_cmd", "rocprof_cli_tool")
+    options = ["--pid", "1234", "--attach-duration-msec", "500"]
+
+    mock_capture = Mock(return_value=(True, "Success"))
+    monkeypatch.setattr(f"{MODULE}.capture_subprocess_output", mock_capture)
+    mock_error = patch_console(monkeypatch, MODULE, "debug", "error")["error"]
+
+    profiler = _make_pc_sampling_profile("host_trap", 100, str(tmp_path), "rocprofv3")
+    profiler._launch(options)
+
+    assert mock_capture.called
+    options_list = mock_capture.call_args[0][0]
+    pid_idx = options_list.index("--pid")
+    assert options_list[pid_idx + 1] == "1234"
+    dur_idx = options_list.index("--attach-duration-msec")
+    assert options_list[dur_idx + 1] == "500"
+    assert "--" not in options_list
+    mock_error.assert_not_called()
+
+
+def test_pc_sampling_profile_v3_live_attach_missing_pid_value(tmp_path, monkeypatch):
+    """v3 live-attach with --pid but no trailing value triggers console_error."""
+    console_error_calls = []
+
+    def mock_console_error(msg, exit=True):
+        console_error_calls.append(msg)
+        if exit:
+            raise RuntimeError("console_error called")
+
+    mock_capture = Mock()
+    monkeypatch.setattr(f"{MODULE}.capture_subprocess_output", mock_capture)
+    patch_console(monkeypatch, MODULE, "debug", "error", error=mock_console_error)
+
+    profiler = _make_pc_sampling_profile("host_trap", 100, str(tmp_path), "rocprofv3")
+    with pytest.raises(RuntimeError, match="console_error called"):
+        profiler._launch(["--pid"])
+
+    assert console_error_calls == [
+        "--pid or --attach-duration-msec option not found in "
+        "profiler arguments for live attach mode"
+    ]
+    mock_capture.assert_not_called()
+
+
+def test_pc_sampling_profile_sdk_live_attach(tmp_path, monkeypatch):
+    """sdk live-attach calls perform_attach_detach and returns before launching."""
+    options = {
+        "ROCPROF_ATTACH_PID": "1234",
+        "ROCPROF_ATTACH_LIBRARY": "lib.so",
+    }
+
+    mock_capture = Mock()
+    mock_attach = Mock()
+    monkeypatch.setattr(f"{MODULE}.capture_subprocess_output", mock_capture)
+    monkeypatch.setattr(f"{MODULE}.perform_attach_detach", mock_attach)
+    mock_error = patch_console(monkeypatch, MODULE, "debug", "error")["error"]
+
+    profiler = _make_pc_sampling_profile(
+        "host_trap", 100, str(tmp_path), "rocprofiler-sdk"
+    )
+    profiler._launch(options)
+
+    mock_attach.assert_called_once()
+    mock_capture.assert_not_called()
+    mock_error.assert_not_called()
+
+
+def test_pc_sampling_profile_sdk_missing_app_cmd(tmp_path, monkeypatch):
+    """sdk non-live-attach without APP_CMD errors before launching."""
+    console_error_calls = []
+
+    def mock_console_error(msg, exit=True):
+        console_error_calls.append(msg)
+        if exit:
+            raise RuntimeError("console_error called")
+
+    mock_capture = Mock()
+    monkeypatch.setattr(f"{MODULE}.capture_subprocess_output", mock_capture)
+    patch_console(monkeypatch, MODULE, "debug", "error", error=mock_console_error)
+
+    profiler = _make_pc_sampling_profile(
+        "host_trap", 100, str(tmp_path), "rocprofiler-sdk"
+    )
+    with pytest.raises(RuntimeError, match="console_error called"):
+        profiler._launch({"LD_PRELOAD": "x"})
+
+    assert console_error_calls == [
+        "APP_CMD, the workload's executable must be provided "
+        "when not in live attach mode"
+    ]
+    mock_capture.assert_not_called()
+
+
+def test_pc_sampling_profile_v3_missing_separator(tmp_path, monkeypatch):
+    """v3 non-live-attach without a '--' separator errors before launching."""
+    console_error_calls = []
+
+    def mock_console_error(msg, exit=True):
+        console_error_calls.append(msg)
+        if exit:
+            raise RuntimeError("console_error called")
+
+    mock_capture = Mock()
+    monkeypatch.setattr(f"{MODULE}.capture_subprocess_output", mock_capture)
+    patch_console(monkeypatch, MODULE, "debug", "error", error=mock_console_error)
+
+    profiler = _make_pc_sampling_profile("host_trap", 100, str(tmp_path), "rocprofv3")
+    with pytest.raises(RuntimeError, match="console_error called"):
+        profiler._launch(["--something"])
+
+    assert console_error_calls == [
+        "APP_CMD, the workload's executable must be provided "
+        "when not in live attach mode"
+    ]
+    mock_capture.assert_not_called()
+
+
+def test_pc_sampling_profile_run_cleanup_before_launch(tmp_path, monkeypatch):
+    """run() removes stale output before reaching the subprocess launch seam, and
+    emits the run header and a timing debug."""
+    stale = tmp_path / "out" / "pmc_1"
+    stale.mkdir(parents=True, exist_ok=True)
+    options = {"ROCPROF_OUTPUT_PATH": str(stale), "APP_CMD": "my_app"}
+
+    profiler = _make_pc_sampling_profile(
+        "host_trap", 100, str(tmp_path), "rocprofiler-sdk"
+    )
+
+    stale_existed_at_launch = []
+
+    def record(*args, **kwargs):
+        # Cleanup must already have run by the time we launch the subprocess.
+        stale_existed_at_launch.append(stale.exists())
+        return (True, "")
+
+    mock_capture = Mock(side_effect=record)
+    mock_log = Mock()
+    monkeypatch.setattr(f"{MODULE}.capture_subprocess_output", mock_capture)
+    monkeypatch.setattr(f"{MODULE}.console_log", mock_log)
+    _mocks = patch_console(monkeypatch, MODULE, "debug", "error")
+    mock_debug, mock_error = _mocks["debug"], _mocks["error"]
+
+    profiler.run(options, prior_run_count=0)
+
+    assert stale_existed_at_launch == [False]
+    assert not stale.exists()
+    mock_error.assert_not_called()
+
+    mock_log.assert_any_call("[Run 1/1][PC sampling profile run]")
+    assert any(
+        call.args and call.args[0] == "profiling" for call in mock_debug.call_args_list
+    )

--- a/projects/rocprofiler-compute/tests/test_profiler_base.py
+++ b/projects/rocprofiler-compute/tests/test_profiler_base.py
@@ -3,7 +3,8 @@
 
 import argparse
 from pathlib import Path
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 import common
 import pytest
@@ -18,9 +19,14 @@ from utils.utils_exceptions import (
 )
 
 
-def _make_sanitize_args(remaining, torch_trace=False):
-    """Build a minimal argparse.Namespace for sanitize() unit tests."""
-    return argparse.Namespace(
+def _make_sanitize_args(remaining, torch_trace=False, **overrides):
+    """Build a minimal argparse.Namespace for profiler_base unit tests.
+
+    Defaults satisfy sanitize(); pass **overrides to set or replace fields the
+    run_profiling() tests need (e.g. output_directory, no_native_tool, kernel,
+    or a pre-joined string ``remaining``).
+    """
+    defaults = dict(
         filter_blocks=[],
         set_selected=None,
         roof_only=False,
@@ -33,7 +39,10 @@ def _make_sanitize_args(remaining, torch_trace=False):
         remaining=["--"] + remaining,
         torch_trace=torch_trace,
         dispatch=None,
+        kernel=None,
     )
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
 
 
 def _setup_test_files(tmp_path, remaining, setup):
@@ -397,3 +406,135 @@ def test_sanitize_block_experimental_gating(args, expect_error, expected_filter_
     else:
         instance.sanitize()
         assert args.filter_blocks == expected_filter_blocks
+
+
+# ---------------------------------------------------------------------------
+# run_profiling(): PC sampling gating / increment / delegation
+# ---------------------------------------------------------------------------
+def _make_run_profiling_profiler(tmp_path, filter_blocks, perfmon_files=0):
+    """Build a RocProfCompute_Base ready to drive run_profiling() in isolation.
+
+    Uses the rocprofv3 profiler mode so the native-tool path resolves to None
+    without touching the filesystem, and seeds `perfmon_files` empty pmc_perf
+    yaml files so total_runs reflects the counter-collection pass count.
+    """
+    if perfmon_files:
+        perfmon_dir = Path(tmp_path) / "perfmon"
+        perfmon_dir.mkdir(parents=True, exist_ok=True)
+        for i in range(perfmon_files):
+            (perfmon_dir / f"pmc_perf_{i}.yaml").write_text("")
+
+    args = _make_sanitize_args(
+        ["./app"],
+        filter_blocks=filter_blocks,
+        output_directory=str(tmp_path),
+        no_native_tool=True,
+    )
+    # run_profiling() consumes remaining as the already-joined command string.
+    args.remaining = "-- ./app"
+    soc = SimpleNamespace(_mspec=SimpleNamespace(gpu_model="MI300"))
+    profiler = RocProfCompute_Base(args, profiler_mode="rocprofv3", soc=soc)
+    profiler._filter_blocks = filter_blocks
+    return profiler
+
+
+@pytest.mark.parametrize(
+    "filter_blocks, perfmon_files, is_requested, ranks, "
+    "expect_run, expect_skip_warning, expect_multirank_warning",
+    [
+        # A requested PC sampling block delegates to PCSamplingProfile.run()
+        # and suppresses the skip warning.
+        pytest.param(
+            ["pc_sampling"],
+            0,
+            True,
+            (None, None),
+            True,
+            False,
+            False,
+            id="delegates_when_requested",
+        ),
+        # No PC sampling block requested -> skip warning, run() never called.
+        pytest.param(
+            ["2"],
+            1,
+            False,
+            (None, None),
+            False,
+            True,
+            False,
+            id="skips_when_not_requested",
+        ),
+        # Requested PC sampling adds a workload run, so 1 counter pass + 1 PC
+        # sampling pass = 2 runs with >=2 ranks -> multi-rank warning.
+        pytest.param(
+            ["21", "2"],
+            1,
+            True,
+            ("0", 2),
+            True,
+            False,
+            True,
+            id="multirank_warns_with_pc_sampling",
+        ),
+        # Not requested -> only the single counter pass -> no multi-rank warning.
+        pytest.param(
+            ["2"],
+            1,
+            False,
+            ("0", 2),
+            False,
+            True,
+            False,
+            id="multirank_silent_without_pc_sampling",
+        ),
+    ],
+)
+def test_run_profiling_pc_sampling_gating(
+    tmp_path,
+    monkeypatch,
+    filter_blocks,
+    perfmon_files,
+    is_requested,
+    ranks,
+    expect_run,
+    expect_skip_warning,
+    expect_multirank_warning,
+):
+    """run_profiling() delegates to PCSamplingProfile.run() only when a PC
+    sampling block is requested, emits the skip warning otherwise, and counts a
+    requested PC sampling pass as an extra workload run for the multi-rank
+    warning."""
+    profiler = _make_run_profiling_profiler(
+        tmp_path, filter_blocks, perfmon_files=perfmon_files
+    )
+    base = "rocprof_compute_profile.profiler_base"
+
+    mock_pc_cls = Mock()
+    instance = mock_pc_cls.return_value
+    instance.is_requested.return_value = is_requested
+    mock_warning = Mock()
+
+    monkeypatch.setattr(f"{base}.PCSamplingProfile", mock_pc_cls)
+    monkeypatch.setattr(f"{base}.print_status", Mock())
+    common.patch_console(
+        monkeypatch, base, "log", "debug", "warning", warning=mock_warning
+    )
+    monkeypatch.setattr(f"{base}.get_job_rank_and_size", Mock(return_value=ranks))
+    monkeypatch.setattr(RocProfCompute_Base, "profile", Mock(return_value=0.0))
+
+    profiler.run_profiling(version="1.0.0", prog="rocprof-compute")
+
+    assert instance.run.called is expect_run
+
+    skip_warned = any(
+        "PC sampling data collection skipped" in str(call)
+        for call in mock_warning.call_args_list
+    )
+    assert skip_warned is expect_skip_warning
+
+    multirank_warned = any(
+        "Multi-rank application detected" in str(call)
+        for call in mock_warning.call_args_list
+    )
+    assert multirank_warned is expect_multirank_warning

--- a/projects/rocprofiler-compute/tests/test_utils.py
+++ b/projects/rocprofiler-compute/tests/test_utils.py
@@ -1101,9 +1101,8 @@ def test_run_prof_success_rocprofiler_sdk(tmp_path, monkeypatch):
 
 
 def test_rocprofiler_sdk_env_log_excludes_user_env(tmp_path, monkeypatch):
-    """run_prof and pc_sampling_prof must log only profiler-added env vars,
-    never the user's full environment, to avoid leaking secrets into
-    shared workload logs."""
+    """run_prof must log only profiler-added env vars, never the user's full
+    environment, to avoid leaking secrets into shared workload logs."""
     monkeypatch.setenv("LEAK_CANARY_TOKEN", "SHOULD_NOT_APPEAR")
 
     logs = []
@@ -1138,11 +1137,8 @@ def test_rocprofiler_sdk_env_log_excludes_user_env(tmp_path, monkeypatch):
         logging.INFO,
         "csv",
     )
-    utils_profile.pc_sampling_prof(
-        {"APP_CMD": ["my_app", "--arg"]}, "host_trap", 1000, str(tmp_path)
-    )
 
-    assert sum("env vars" in m for m in logs) >= 2
+    assert sum("env vars" in m for m in logs) >= 1
     env_log_lines = [m for m in logs if "env vars" in m]
     assert any("ROCPROF_COUNTER_COLLECTION" in m for m in env_log_lines)
     assert not any("SHOULD_NOT_APPEAR" in m for m in logs)
@@ -4146,186 +4142,6 @@ def test_v3_to_v2_default_accum_vgpr_count(mock_console_debug, tmp_path):
     assert "Accum_VGPR" in result_df.columns
     assert result_df["Accum_VGPR"].iloc[0] == 0
     assert result_df["Accum_VGPR"].dtype == "int64"
-
-
-# ===================================================================
-# Test PC_sampling function
-# ===================================================================
-
-
-@mock.patch("utils.utils_profile.capture_subprocess_output")
-@mock.patch("utils.utils_profile.console_error")
-@mock.patch("utils.utils_profile.console_debug")
-def test_pc_sampling_prof_sdk_path_nonexistent_librocprofiler_sdk_tool(
-    mock_console_debug, mock_console_error, mock_capture_subprocess, tmp_path
-):
-    """
-    Edge Case: rocprofiler_sdk_tool_path is valid, but librocprofiler-sdk-tool.so
-    is NOT found next to it (or in rocprofiler-sdk subdir).
-    This test primarily checks if the paths are constructed. The actual check for
-    file existence before `capture_subprocess_output` is not in the provided snippet,
-    but we test the path construction.
-    """
-    with mock.patch("utils.utils_common._rocprof_cmd", "rocprofiler-sdk"):
-        method = "host_trap"
-        interval = 1000
-        workload_dir = str(tmp_path)
-        options = {"APP_CMD": "my_app --arg"}
-
-        sdk_lib_dir = tmp_path / "rocm_sdk" / "lib"
-        sdk_lib_dir.mkdir(parents=True, exist_ok=True)
-        rocprofiler_sdk_tool_path = str(sdk_lib_dir / "librocprofiler_sdk.so")
-        Path(rocprofiler_sdk_tool_path).touch()
-
-        expected_tool_path = str(
-            sdk_lib_dir / "rocprofiler-sdk" / "librocprofiler-sdk-tool.so"
-        )
-
-        options["LD_PRELOAD"] = expected_tool_path
-
-        mock_capture_subprocess.return_value = (True, "Success output")
-
-        utils_profile.pc_sampling_prof(options, method, interval, workload_dir)
-
-        assert mock_capture_subprocess.called
-        call_args = mock_capture_subprocess.call_args
-        called_env = call_args.kwargs.get("new_env", {})
-
-        assert "LD_PRELOAD" in called_env
-        assert called_env["LD_PRELOAD"] == expected_tool_path
-
-        mock_console_error.assert_not_called()
-
-
-@mock.patch("utils.utils_profile.capture_subprocess_output")
-@mock.patch("utils.utils_profile.console_debug")
-def test_pc_sampling_prof_subprocess_fails(
-    mock_console_debug, mock_capture_subprocess, tmp_path, monkeypatch
-):
-    """
-    Edge Case: The capture_subprocess_output returns success=False.
-    This should trigger the console_error("PC sampling failed.").
-    """
-    console_error_calls = []
-
-    def mock_console_error(msg, exit=True):
-        console_error_calls.append(msg)
-        if exit:
-            raise RuntimeError("console_error called")
-
-    monkeypatch.setattr("utils.utils_profile.console_error", mock_console_error)
-
-    with mock.patch("utils.utils_common._rocprof_cmd", "rocprof_cli_tool"):
-        method = "stochastic"
-        interval = 5000
-        workload_dir = str(tmp_path)
-        options = ["another_app"]
-
-        with pytest.raises(RuntimeError, match="console_error called"):
-            utils_profile.pc_sampling_prof(options, method, interval, workload_dir)
-
-        mock_capture_subprocess.assert_not_called()
-        assert console_error_calls == [
-            "APP_CMD, the workload's executable must be provided "
-            "when not in live attach mode"
-        ]
-
-    mock_capture_subprocess.reset_mock()
-    console_error_calls.clear()
-    with mock.patch("utils.utils_common._rocprof_cmd", "rocprofiler-sdk"):
-        options = {"APP_CMD": "another_app"}
-        sdk_lib_dir = tmp_path / "rocm_sdk_fail" / "lib"
-        sdk_lib_dir.mkdir(parents=True, exist_ok=True)
-        rocprofiler_sdk_tool_path_sdk = str(sdk_lib_dir / "librocprofiler_sdk.so")
-        Path(rocprofiler_sdk_tool_path_sdk).touch()
-
-        tool_dir = sdk_lib_dir / "rocprofiler-sdk"
-        tool_dir.mkdir(parents=True, exist_ok=True)
-        (tool_dir / "librocprofiler-sdk-tool.so").touch()
-
-        mock_capture_subprocess.return_value = (
-            False,
-            "Error output from SDK subprocess",
-        )
-
-        with pytest.raises(RuntimeError, match="console_error called"):
-            utils_profile.pc_sampling_prof(options, method, interval, workload_dir)
-
-        mock_capture_subprocess.assert_called_once()
-        assert console_error_calls == ["PC sampling failed."]
-
-
-@mock.patch("utils.utils_profile.capture_subprocess_output")
-@mock.patch("utils.utils_profile.console_error")
-@mock.patch("utils.utils_profile.console_debug")
-def test_pc_sampling_prof_empty_appcmd(
-    mock_console_debug, mock_console_error, mock_capture_subprocess, tmp_path
-):
-    """
-    Edge Case: The appcmd is an empty string.
-    The function should still attempt to run it. The behavior of
-    capture_subprocess_output with an empty command is external to this function.
-    """
-    with mock.patch("utils.utils_common._rocprof_cmd", "rocprof_cli_tool"):
-        method = "host_trap"
-        interval = 100
-        workload_dir = str(tmp_path)
-        options = ["--"]
-        rocprofiler_sdk_tool_path = "/some/path/librocprofiler_sdk.so"  # noqa: F841
-
-        mock_capture_subprocess.return_value = (True, "Output with empty appcmd")
-
-        utils_profile.pc_sampling_prof(options, method, interval, workload_dir)
-
-        assert mock_capture_subprocess.called
-        options_list = mock_capture_subprocess.call_args[0][0]
-        assert options_list[-1] == "--"
-        mock_console_error.assert_not_called()
-
-    mock_capture_subprocess.reset_mock()
-    mock_console_error.reset_mock()
-    with mock.patch("utils.utils_common._rocprof_cmd", "rocprofiler-sdk"):
-        sdk_lib_dir = tmp_path / "rocm_sdk_empty" / "lib"
-        sdk_lib_dir.mkdir(parents=True, exist_ok=True)
-        rocprofiler_sdk_tool_path_sdk = str(sdk_lib_dir / "librocprofiler_sdk.so")
-        Path(rocprofiler_sdk_tool_path_sdk).touch()
-        tool_dir = sdk_lib_dir / "rocprofiler-sdk"
-        tool_dir.mkdir(parents=True, exist_ok=True)
-        (tool_dir / "librocprofiler-sdk-tool.so").touch()
-
-        mock_capture_subprocess.return_value = (True, "Output with empty appcmd SDK")
-        options = {"APP_CMD": ""}
-
-        utils_profile.pc_sampling_prof(options, method, interval, workload_dir)
-
-        assert mock_capture_subprocess.called
-        assert mock_capture_subprocess.call_args[0][0] == ""
-        mock_console_error.assert_not_called()
-
-
-@mock.patch("utils.utils_profile.capture_subprocess_output")
-@mock.patch("utils.utils_profile.console_error")
-@mock.patch("utils.utils_profile.console_debug")
-def test_pc_sampling_prof_multiarg_appcmd(
-    mock_console_debug, mock_console_error, mock_capture_subprocess, tmp_path
-):
-    """All arguments after '--' in profiler_options must appear
-    in the subprocess call."""
-    with mock.patch("utils.utils_common._rocprof_cmd", "rocprof_cli_tool"):
-        method = "host_trap"
-        interval = 100
-        workload_dir = str(tmp_path)
-        options = ["--kernel-trace", "--", "./myapp", "arg1", "arg2"]
-
-        mock_capture_subprocess.return_value = (True, "Success")
-
-        utils_profile.pc_sampling_prof(options, method, interval, workload_dir)
-
-        assert mock_capture_subprocess.called
-        options_list = mock_capture_subprocess.call_args[0][0]
-        separator_index = options_list.index("--")
-        assert options_list[separator_index:] == ["--", "./myapp", "arg1", "arg2"]
-        mock_console_error.assert_not_called()
 
 
 def test_set_parser():


### PR DESCRIPTION
## Motivation

PC sampling logic was tangled into the counter-collection profiler base and a
free function branching on `get_rocprof_cmd()`. Extracting it into a dedicated
`PCSamplingProfile` class in its own `src/pc_sampling` package makes dispatch
explicit, isolates the backend-specific launch logic, and makes the whole flow
unit-testable without a GPU.

## Technical Details

- Add `PCSamplingProfile` (module `src/pc_sampling/pc_sampling_profile.py`)
  encapsulating launch/env/cleanup/timing for a single PC sampling pass; housed
  in its own package rather than under `rocprof_compute_profile` (which is
  reserved for `RocProfCompute_Base` and its children).
- Delegate from `profiler_base` via `is_requested()` / `run()`; gate on
  `is_only_pc_sampling()` directly (no `is_exclusive` shim).
- Make the `pc_sampling` block alias trigger collection (not just block `21`)
  and dedupe the alias list into a module-level `PC_SAMPLING_BLOCK_IDS` constant.
- Fix dead-code `ROCPROF_OUTPUT_PATH` cleanup (getattr-on-dict to `.get`) and
  only log "Removed" when the path is actually gone.
- Dedupe the `is_live_attach` helper (renamed from `_is_live_attach`) and fix an
  error-string typo.
- Return after the missing-`APP_CMD` errors in both launch paths so the guards
  are real, and bind `get_rocprof_cmd()` once in the v3 launch (no
  log-vs-exec divergence).
- Tighten the profiler-options type seam (`ProfilerOptions` alias, concrete
  launch params, single cast at dispatch).
- Thread the run count into `run()` instead of re-globbing the perfmon dir, and
  correct the stale "block 21" skip-warning text to mention the `pc_sampling`
  alias.

## Review feedback addressed

- Relocated the class to `src/pc_sampling/` and renamed it to `PCSamplingProfile`
  (with the matching module/test/CMake/`test_categories.yaml` names).
- Removed the `is_exclusive()` wrapper; callers use `is_only_pc_sampling()`.
- Moved `PC_SAMPLING_BLOCK_IDS` to the module's global-constants section.
- Added method docstrings and a launch-path `return` for symmetry.
- Split unit tests into `tests/test_pc_sampling_profile.py` (1:1 with source),
  leaving `tests/test_pc_sampling.py` for GPU integration tests.
- Shared the GPU-gating helper via `tests/common.require_pc_sampling_gpu` (no env
  patching) and standardized on `monkeypatch` over `unittest.mock`.

## JIRA ID

AIPROFCOMP-592

## Test Plan

- [x] pytest tests/test_pc_sampling_profile.py tests/test_profiler_base.py
- [x] pytest tests/test_pc_sampling.py (GPU integration; skips without a GPU)
- [x] ruff check on changed files

## Test Result

- [x] 42 unit tests pass (test_pc_sampling_profile.py + test_profiler_base.py)
- [x] GPU integration tests collect/skip cleanly without a supported GPU
- [x] ruff check clean

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
