### PR TITLE
[rocprofiler-systems] Fix bugs in output filtering logic when rank detection failed

### DIFF
--- a/projects/rocprofiler-systems/CHANGELOG.md
+++ b/projects/rocprofiler-systems/CHANGELOG.md
@@ -54,6 +54,8 @@ Full documentation for ROCm Systems Profiler is available at [https://rocm.docs.
 - Minimum required C++ standard raised from C++17 to C++20. timemory now builds
   against the `rocprofiler-systems-cppstd20` branch and spdlog was bumped to
   v1.17.0 (bundled fmt v12).
+- Supported environment variables for rank detection: removed MPI_RANK and
+  MPI_LOCALRANKID, added PMI_RANK and SLURM_PROCID.
 
 ### Resolved issues
 

--- a/projects/rocprofiler-systems/docs/how-to/communication-runtime-profiling.rst
+++ b/projects/rocprofiler-systems/docs/how-to/communication-runtime-profiling.rst
@@ -149,6 +149,16 @@ Supported rank specification syntax (same for both filters):
 - **Combined**: Mix of individual ranks and ranges (e.g., ``0-3,8,10-15``)
 - **Empty value**: Enables output for all ranks (the default).
 
+The rank values in the filter are **not** validated against the actual number of MPI ranks in the job.
+Ranks outside the valid range are accepted, but since they do not actually exist, they produce no output.
+Specifying correct rank values is the user's responsibility.
+
+.. code-block:: bash
+
+    # Rank 100 in filter specification is accepted, but there are only 16 actual ranks in the MPI job,
+    # so only rank 1 produces output
+    mpirun -n 16 rocprof-sys-sample --rank-filter-output "1,100" -- <application_path>
+
 Supported rank identification variables:
 
 - **MPI_RANK**

--- a/projects/rocprofiler-systems/docs/how-to/communication-runtime-profiling.rst
+++ b/projects/rocprofiler-systems/docs/how-to/communication-runtime-profiling.rst
@@ -151,7 +151,7 @@ Supported rank specification syntax (same for both filters):
 
 When the total number of MPI ranks (world size) can be determined from the launcher environment
 (``OMPI_COMM_WORLD_SIZE``, ``MV2_COMM_WORLD_SIZE``, ``PMI_SIZE``, ``SLURM_NTASKS``, or ``SLURM_NPROCS``),
-any filter value outside the valid range ``[0, world_size)`` triggers a warning and is ignored.
+any filter value outside the valid range ``[0, world_size - 1]`` triggers a warning and is ignored.
 If every value in the filter is out of range, filtering is disabled and output is produced for all ranks.
 When the world size cannot be determined, no such validation is performed and specifying correct
 rank values is the user's responsibility.
@@ -171,7 +171,7 @@ Supported rank identification variables:
 - **SLURM_PROCID**
 
 If rank detection fails, both filters are disabled and output is produced for all ranks.
-The same applies if the detected rank is itself outside ``[0, world_size)``:
+The same applies if the detected rank is itself outside ``[0, world_size - 1]``:
 filtering is disabled for that rank and it produces output.
 
 .. note::

--- a/projects/rocprofiler-systems/docs/how-to/communication-runtime-profiling.rst
+++ b/projects/rocprofiler-systems/docs/how-to/communication-runtime-profiling.rst
@@ -150,7 +150,7 @@ Supported rank specification syntax (same for both filters):
 - **Empty value**: Enables output for all ranks (the default).
 
 When the total number of MPI ranks (world size) can be determined from the launcher environment
-(for example ``OMPI_COMM_WORLD_SIZE``, ``MV2_COMM_WORLD_SIZE``, ``PMI_SIZE``, or ``SLURM_NTASKS``),
+(``OMPI_COMM_WORLD_SIZE``, ``MV2_COMM_WORLD_SIZE``, ``PMI_SIZE``, ``SLURM_NTASKS``, or ``SLURM_NPROCS``),
 any filter value outside the valid range ``[0, world_size)`` triggers a warning and is ignored.
 If every value in the filter is out of range, filtering is disabled and output is produced for all ranks.
 When the world size cannot be determined, no such validation is performed and specifying correct
@@ -164,13 +164,15 @@ rank values is the user's responsibility.
 
 Supported rank identification variables:
 
-- **MPI_RANK**
-- **MPI_LOCALRANKID**
 - **MPI_RANKID**
+- **PMI_RANK**
 - **MV2_COMM_WORLD_RANK**
 - **OMPI_COMM_WORLD_RANK**
+- **SLURM_PROCID**
 
 If rank detection fails, both filters are disabled and output is produced for all ranks.
+The same applies if the detected rank is itself outside ``[0, world_size)``:
+filtering is disabled for that rank and it produces output.
 
 .. note::
 

--- a/projects/rocprofiler-systems/docs/how-to/communication-runtime-profiling.rst
+++ b/projects/rocprofiler-systems/docs/how-to/communication-runtime-profiling.rst
@@ -149,13 +149,16 @@ Supported rank specification syntax (same for both filters):
 - **Combined**: Mix of individual ranks and ranges (e.g., ``0-3,8,10-15``)
 - **Empty value**: Enables output for all ranks (the default).
 
-The rank values in the filter are **not** validated against the actual number of MPI ranks in the job.
-Ranks outside the valid range are accepted, but since they do not actually exist, they produce no output.
-Specifying correct rank values is the user's responsibility.
+When the total number of MPI ranks (world size) can be determined from the launcher environment
+(for example ``OMPI_COMM_WORLD_SIZE``, ``MV2_COMM_WORLD_SIZE``, ``PMI_SIZE``, or ``SLURM_NTASKS``),
+any filter value outside the valid range ``[0, world_size)`` triggers a warning and is ignored.
+If every value in the filter is out of range, filtering is disabled and output is produced for all ranks.
+When the world size cannot be determined, no such validation is performed and specifying correct
+rank values is the user's responsibility.
 
 .. code-block:: bash
 
-    # Rank 100 in filter specification is accepted, but there are only 16 actual ranks in the MPI job,
+    # Rank 100 is out of range for a 16-rank job: it is reported and ignored,
     # so only rank 1 produces output
     mpirun -n 16 rocprof-sys-sample --rank-filter-output "1,100" -- <application_path>
 

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -42,6 +42,7 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <charconv>
 #include <csignal>
 #include <cstdint>
 #include <cstdio>

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -2807,6 +2807,14 @@ is_rank_in_filter(std::string enabled_ranks_str)
 
     const auto enabled_ranks = rocprofsys::utility::parse_numeric_range<
         std::int64_t, std::unordered_set<std::int64_t>>(enabled_ranks_str, "ranks", 1L);
+    // empty enabled_ranks for non-empty && not "none" enabled_ranks_str (checked above)
+    // -> filter string parsing error
+    if(enabled_ranks.empty())
+    {
+        LOG_WARNING("MPI output filtering DISABLED: invalid filter specification '{}'",
+                    enabled_ranks_str);
+        return true;
+    }
 
     const auto is_enabled = enabled_ranks.count(current_rank.value()) != 0;
     LOG_DEBUG("Output for MPI rank {} is {}", current_rank.value(),

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -2825,15 +2825,22 @@ is_rank_in_filter(std::string enabled_ranks_str)
 
     // Check current_rank and enabled_ranks against total number of existing MPI ranks
     const auto world_size = get_mpi_world_size_from_env();
-    if(world_size)
+    if(world_size.has_value())
     {
+        if(world_size.value() == 0)
+        {
+            LOG_WARNING("MPI output filtering DISABLED: total number of MPI ranks (world "
+                        "size) is 0");
+            return true;
+        }
+
         for(auto it = enabled_ranks.begin(); it != enabled_ranks.end();)
         {
             if(*it < 0 || static_cast<std::uint64_t>(*it) >= world_size.value())
             {
-                LOG_WARNING("MPI output filtering: rank {} is out of range [0, {}); "
-                            "ignoring",
-                            *it, world_size.value());
+                LOG_WARNING("MPI output filtering: requested MPI rank {} not in range of "
+                            "existing ranks [0-{}]. Ignoring",
+                            *it, world_size.value() - 1);
                 it = enabled_ranks.erase(it);
             }
             else
@@ -2844,9 +2851,9 @@ is_rank_in_filter(std::string enabled_ranks_str)
 
         if(current_rank.value() >= world_size.value())
         {
-            LOG_WARNING("MPI output filtering DISABLED: MPI rank {} >= total number of "
-                        "MPI ranks {}",
-                        current_rank.value(), world_size.value());
+            LOG_WARNING("MPI output filtering DISABLED: MPI rank {} not in range of "
+                        "existing ranks [0-{}]",
+                        current_rank.value(), world_size.value() - 1);
             return true;
         }
     }

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -2751,30 +2751,27 @@ get_rank_filter_logs()
 #endif
 
 #if ROCPROFSYS_MPI_OR_MPI_HEADERS_ENABLED
+// Return the first env var in `env_var_options` that holds an unsigned integer.
+// `label` is used only for logging (e.g. "MPI rank", "world size").
 std::optional<std::uint64_t>
-get_mpi_rank_from_env()
+get_first_uint_from_env(const std::vector<std::string>& env_var_options,
+                        const std::string&              label)
 {
-    const std::vector<std::string> rank_env_var_options = {
-        // rank env vars: user-provided then most generic to most runtime-specific
-        get_rank_filter_id(),  "MPI_RANK",
-        "MPI_LOCALRANKID",     "MPI_RANKID",
-        "MV2_COMM_WORLD_RANK", "OMPI_COMM_WORLD_RANK"
-    };
-
-    for(const auto& env_var : rank_env_var_options)
+    for(const auto& env_var : env_var_options)
     {
-        const std::string rank_str = get_env(env_var, std::string{});
+        const std::string value_str = get_env(env_var, std::string{});
 
-        if(rank_str.empty()) continue;
+        if(value_str.empty()) continue;
         try
         {
-            const auto rank = std::stoul(rank_str);
-            LOG_DEBUG("MPI output filtering: using MPI rank = {} from {}", rank, env_var);
-            return rank;
+            const auto value = std::stoul(value_str);
+            LOG_DEBUG("MPI output filtering: using {} = {} from {}", label, value,
+                      env_var);
+            return value;
         } catch(const std::exception& e)
         {
-            LOG_WARNING("MPI output filtering: failed to get MPI rank from {}='{}': {}",
-                        env_var, rank_str, e.what());
+            LOG_WARNING("MPI output filtering: failed to get {} from {}='{}': {}", label,
+                        env_var, value_str, e.what());
         }
     }
 
@@ -2782,32 +2779,21 @@ get_mpi_rank_from_env()
 }
 
 std::optional<std::uint64_t>
+get_mpi_rank_from_env()
+{
+    // global rank env-vars: user-provided, then runtime-specific
+    return get_first_uint_from_env({ get_rank_filter_id(), "MPI_RANKID", "PMI_RANK",
+                                     "MV2_COMM_WORLD_RANK", "OMPI_COMM_WORLD_RANK",
+                                     "SLURM_PROCID" },
+                                   "MPI rank");
+}
+
+std::optional<std::uint64_t>
 get_mpi_world_size_from_env()
 {
-    const std::vector<std::string> size_env_var_options = {
-        // world-size env vars: most runtime-specific to most generic
-        "OMPI_COMM_WORLD_SIZE", "MV2_COMM_WORLD_SIZE", "PMI_SIZE", "SLURM_NTASKS"
-    };
-
-    for(const auto& env_var : size_env_var_options)
-    {
-        const std::string size_str = get_env(env_var, std::string{}, false);
-
-        if(size_str.empty()) continue;
-        try
-        {
-            const auto size = std::stoul(size_str);
-            LOG_DEBUG("MPI output filtering: using world size = {} from {}", size,
-                      env_var);
-            return size;
-        } catch(const std::exception& e)
-        {
-            LOG_WARNING("MPI output filtering: failed to get world size from {}='{}': {}",
-                        env_var, size_str, e.what());
-        }
-    }
-
-    return std::nullopt;
+    return get_first_uint_from_env({ "OMPI_COMM_WORLD_SIZE", "MV2_COMM_WORLD_SIZE",
+                                     "PMI_SIZE", "SLURM_NTASKS", "SLURM_NPROCS" },
+                                   "world size");
 }
 #endif
 }  // namespace
@@ -2837,10 +2823,7 @@ is_rank_in_filter(std::string enabled_ranks_str)
     auto enabled_ranks = rocprofsys::utility::parse_numeric_range<
         std::int64_t, std::unordered_set<std::int64_t>>(enabled_ranks_str, "ranks", 1L);
 
-    // Drop ranks that cannot exist in this job. World size is read from launcher
-    // env vars; when it is unknown, no validation is performed (user's
-    // responsibility). NOTE: assumes the detected rank and world size share the
-    // same (global) numbering space.
+    // Drop enabled ranks that are out of range of existing MPI ranks
     const auto world_size = get_mpi_world_size_from_env();
     if(world_size)
     {
@@ -2854,16 +2837,15 @@ is_rank_in_filter(std::string enabled_ranks_str)
                 it = enabled_ranks.erase(it);
             }
             else
+            {
                 ++it;
+            }
         }
     }
 
-    // empty enabled_ranks for non-empty && not "none" enabled_ranks_str (checked above)
-    // -> filter string parsing error or all ranks out of range
     if(enabled_ranks.empty())
     {
-        LOG_WARNING("MPI output filtering DISABLED: invalid filter specification '{}'",
-                    enabled_ranks_str);
+        LOG_WARNING("MPI output filtering DISABLED: no valid enabled ranks provided");
         return true;
     }
 

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -2752,27 +2752,32 @@ get_rank_filter_logs()
 
 #if ROCPROFSYS_MPI_OR_MPI_HEADERS_ENABLED
 // Return the first env var in `env_var_options` that holds an unsigned integer.
-// `label` is used only for logging (e.g. "MPI rank", "world size").
+// `label` is used only for logging (e.g. "MPI rank", "MPI world size").
 std::optional<std::uint64_t>
-get_first_uint_from_env(const std::vector<std::string>& env_var_options,
-                        const std::string&              label)
+get_first_mpi_env_uint(const std::vector<std::string>& env_var_options,
+                       const std::string&              label)
 {
     for(const auto& env_var : env_var_options)
     {
         const std::string value_str = get_env(env_var, std::string{});
 
         if(value_str.empty()) continue;
-        try
+
+        std::uint64_t value  = 0;
+        const char*   first  = value_str.data();
+        const char*   last   = first + value_str.size();
+        const auto    result = std::from_chars(first, last, value);
+
+        if(result.ec != std::errc{} || result.ptr != last)
         {
-            const auto value = std::stoul(value_str);
-            LOG_DEBUG("MPI output filtering: using {} = {} from {}", label, value,
-                      env_var);
-            return value;
-        } catch(const std::exception& e)
-        {
-            LOG_WARNING("MPI output filtering: failed to get {} from {}='{}': {}", label,
-                        env_var, value_str, e.what());
+            LOG_WARNING("MPI output filtering: failed to parse {} from {}='{}' as a "
+                        "non-negative integer",
+                        label, env_var, value_str);
+            continue;
         }
+
+        LOG_DEBUG("MPI output filtering: using {} = {} from {}", label, value, env_var);
+        return value;
     }
 
     return std::nullopt;
@@ -2782,18 +2787,18 @@ std::optional<std::uint64_t>
 get_mpi_rank_from_env()
 {
     // global rank env-vars: user-provided, then runtime-specific
-    return get_first_uint_from_env({ get_rank_filter_id(), "MPI_RANKID", "PMI_RANK",
-                                     "MV2_COMM_WORLD_RANK", "OMPI_COMM_WORLD_RANK",
-                                     "SLURM_PROCID" },
-                                   "MPI rank");
+    return get_first_mpi_env_uint({ get_rank_filter_id(), "MPI_RANKID", "PMI_RANK",
+                                    "MV2_COMM_WORLD_RANK", "OMPI_COMM_WORLD_RANK",
+                                    "SLURM_PROCID" },
+                                  "MPI rank");
 }
 
 std::optional<std::uint64_t>
 get_mpi_world_size_from_env()
 {
-    return get_first_uint_from_env({ "OMPI_COMM_WORLD_SIZE", "MV2_COMM_WORLD_SIZE",
-                                     "PMI_SIZE", "SLURM_NTASKS", "SLURM_NPROCS" },
-                                   "world size");
+    return get_first_mpi_env_uint({ "OMPI_COMM_WORLD_SIZE", "MV2_COMM_WORLD_SIZE",
+                                    "PMI_SIZE", "SLURM_NTASKS", "SLURM_NPROCS" },
+                                  "MPI world size");
 }
 #endif
 }  // namespace

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -2780,6 +2780,35 @@ get_mpi_rank_from_env()
 
     return std::nullopt;
 }
+
+std::optional<std::uint64_t>
+get_mpi_world_size_from_env()
+{
+    const std::vector<std::string> size_env_var_options = {
+        // world-size env vars: most runtime-specific to most generic
+        "OMPI_COMM_WORLD_SIZE", "MV2_COMM_WORLD_SIZE", "PMI_SIZE", "SLURM_NTASKS"
+    };
+
+    for(const auto& env_var : size_env_var_options)
+    {
+        const std::string size_str = get_env(env_var, std::string{}, false);
+
+        if(size_str.empty()) continue;
+        try
+        {
+            const auto size = std::stoul(size_str);
+            LOG_DEBUG("MPI output filtering: using world size = {} from {}", size,
+                      env_var);
+            return size;
+        } catch(const std::exception& e)
+        {
+            LOG_WARNING("MPI output filtering: failed to get world size from {}='{}': {}",
+                        env_var, size_str, e.what());
+        }
+    }
+
+    return std::nullopt;
+}
 #endif
 }  // namespace
 
@@ -2805,10 +2834,32 @@ is_rank_in_filter(std::string enabled_ranks_str)
         return true;
     }
 
-    const auto enabled_ranks = rocprofsys::utility::parse_numeric_range<
+    auto enabled_ranks = rocprofsys::utility::parse_numeric_range<
         std::int64_t, std::unordered_set<std::int64_t>>(enabled_ranks_str, "ranks", 1L);
+
+    // Drop ranks that cannot exist in this job. World size is read from launcher
+    // env vars; when it is unknown, no validation is performed (user's
+    // responsibility). NOTE: assumes the detected rank and world size share the
+    // same (global) numbering space.
+    const auto world_size = get_mpi_world_size_from_env();
+    if(world_size)
+    {
+        for(auto it = enabled_ranks.begin(); it != enabled_ranks.end();)
+        {
+            if(*it < 0 || static_cast<std::uint64_t>(*it) >= world_size.value())
+            {
+                LOG_WARNING("MPI output filtering: rank {} is out of range [0, {}); "
+                            "ignoring",
+                            *it, world_size.value());
+                it = enabled_ranks.erase(it);
+            }
+            else
+                ++it;
+        }
+    }
+
     // empty enabled_ranks for non-empty && not "none" enabled_ranks_str (checked above)
-    // -> filter string parsing error
+    // -> filter string parsing error or all ranks out of range
     if(enabled_ranks.empty())
     {
         LOG_WARNING("MPI output filtering DISABLED: invalid filter specification '{}'",

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -2823,7 +2823,7 @@ is_rank_in_filter(std::string enabled_ranks_str)
     auto enabled_ranks = rocprofsys::utility::parse_numeric_range<
         std::int64_t, std::unordered_set<std::int64_t>>(enabled_ranks_str, "ranks", 1L);
 
-    // Drop enabled ranks that are out of range of existing MPI ranks
+    // Check current_rank and enabled_ranks against total number of existing MPI ranks
     const auto world_size = get_mpi_world_size_from_env();
     if(world_size)
     {
@@ -2840,6 +2840,14 @@ is_rank_in_filter(std::string enabled_ranks_str)
             {
                 ++it;
             }
+        }
+
+        if(current_rank.value() >= world_size.value())
+        {
+            LOG_WARNING("MPI output filtering DISABLED: MPI rank {} >= total number of "
+                        "MPI ranks {}",
+                        current_rank.value(), world_size.value());
+            return true;
         }
     }
 

--- a/projects/rocprofiler-systems/source/lib/core/utility.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/utility.cpp
@@ -73,6 +73,8 @@ parse_numeric_range(std::string _input_string, const std::string& _label, Up _in
 
         if(_v.find('-') != std::string::npos)
         {
+            // split the string into two parts at the '-' character and check if the
+            // result is valid
             auto _vv = tim::delimit(_v, "-");
             if(_vv.size() != 2)
             {

--- a/projects/rocprofiler-systems/source/lib/core/utility.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/utility.cpp
@@ -83,6 +83,13 @@ parse_numeric_range(std::string _input_string, const std::string& _label, Up _in
 
             Tp _vn = _get_value(_vv.at(0));
             Tp _vN = _get_value(_vv.at(1));
+            if(_vn > _vN)
+            {
+                LOG_WARNING("Invalid {} range specification: {}. Start exceeds end; "
+                            "required format N-M with N <= M, e.g. 0-4. Ignoring {}...",
+                            _label, _v, _v);
+                continue;
+            }
             do
             {
                 emplace(_result, _vn);

--- a/projects/rocprofiler-systems/source/lib/core/utility.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/utility.cpp
@@ -76,9 +76,10 @@ parse_numeric_range(std::string _input_string, const std::string& _label, Up _in
             auto _vv = tim::delimit(_v, "-");
             if(_vv.size() != 2)
             {
-                throw std::runtime_error(fmt::format(
-                    "Invalid {} range specification: {}. Required format N-M, e.g. 0-4",
-                    _label, _v));
+                LOG_WARNING("Invalid {} range specification: {}. Required format N-M, "
+                            "e.g. 0-4. Ignoring {}...",
+                            _label, _v, _v);
+                continue;
             }
 
             Tp _vn = _get_value(_vv.at(0));

--- a/projects/rocprofiler-systems/tests/pytest/test_rank_filter.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_rank_filter.py
@@ -183,8 +183,8 @@ class TestRankFilter(RocprofsysTest):
 
     def test_invalid_filter_strings(self, rocpd_env):
         """Invalid filter specifications.
-        OUTPUT="garbage,10-0,2": 'garbage' is non-numeric and '10-0' is a reversed
-        range (both ignored); only rank 2 remains, so only rank 2 produces files.
+        OUTPUT="garbage,10-0,-1,2": 'garbage' is non-numeric, '10-0' is a reversed
+        range, '-1' is invalid (all ignored); only rank 2 remains, so only rank 2 produces files.
         LOGS="garbage": the only token is non-numeric and is ignored, so the
         filter parses to no valid ranks. An invalid specification disables log
         filtering entirely, so every rank emits a banner.
@@ -198,7 +198,7 @@ class TestRankFilter(RocprofsysTest):
             env=rocpd_env,
             sysrun_args=[
                 "--rank-filter-output",
-                "garbage,10-0,2",
+                "garbage,10-0,-1,2",
                 "--rank-filter-logs",
                 "garbage",
             ],

--- a/projects/rocprofiler-systems/tests/pytest/test_rank_filter.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_rank_filter.py
@@ -183,8 +183,9 @@ class TestRankFilter(RocprofsysTest):
 
     def test_invalid_filter_strings(self, rocpd_env):
         """Invalid filter specifications.
-        OUTPUT="garbage,10-0,-1,2": 'garbage' is non-numeric, '10-0' is a reversed
-        range, '-1' is invalid (all ignored); only rank 2 remains, so only rank 2 produces files.
+        OUTPUT="garbage,10-0,-1,2,50": 'garbage' is non-numeric, '10-0' is a reversed
+        range, '-1' is invalid (all ignored), 50 is out of range;
+        only rank 2 remains, so only rank 2 produces files.
         LOGS="garbage": the only token is non-numeric and is ignored, so the
         filter parses to no valid ranks. An invalid specification disables log
         filtering entirely, so every rank emits a banner.
@@ -198,7 +199,7 @@ class TestRankFilter(RocprofsysTest):
             env=rocpd_env,
             sysrun_args=[
                 "--rank-filter-output",
-                "garbage,10-0,-1,2",
+                "garbage,10-0,-1,2,50",
                 "--rank-filter-logs",
                 "garbage",
             ],
@@ -215,12 +216,34 @@ class TestRankFilter(RocprofsysTest):
             ranks_without_output=[0, 1],
         )
 
-    def test_custom_id_excludes_all(self, rocpd_env):
-        """Custom rank-ID forces every rank to identify as 10; filter is 0-2.
-        Since 10 is not in [0,2] for either filter, every rank is silenced
-        for both console and file output.
+    def test_all_ranks_out_of_range_disables_filter(self, rocpd_env):
+        """OUTPUT="5,6" on a 3-rank job: every value is out of range
+        (>= world size 3), so all are ignored and no valid ranks remain.
+        Filtering is then disabled and every rank produces output.
         """
-        rocpd_env["MY_CUSTOM_RANK"] = "10"
+        result = self.run_test(
+            "sys_run",
+            TARGET,
+            env=rocpd_env,
+            sysrun_args=["--rank-filter-output", "5,6"],
+            launcher="mpi",
+            num_procs=NUM_PROCS,
+        )
+        self.assert_regex(result)
+        assert (
+            banner_count(result.test_output) == 3
+        ), f"Expected 3 banners, got {banner_count(result.test_output)}"
+        assert_per_rank_outputs(
+            self.test_output_dir,
+            ranks_with_output=[0, 1, 2],
+            ranks_without_output=[],
+        )
+
+    def test_custom_id(self, rocpd_env):
+        """Custom rank-ID forces every rank to identify as 1; filter is 0-2.
+        Every rank produces both console and file output.
+        """
+        rocpd_env["MY_CUSTOM_RANK"] = "1"
         result = self.run_test(
             "sys_run",
             TARGET,
@@ -237,13 +260,43 @@ class TestRankFilter(RocprofsysTest):
             num_procs=NUM_PROCS,
         )
         self.assert_regex(result)
-        assert banner_count(result.test_output) == 0, (
-            f"Expected 0 banners, got " f"{banner_count(result.test_output)}"
+        assert banner_count(result.test_output) == 3, (
+            f"Expected 3 banners, got " f"{banner_count(result.test_output)}"
         )
         assert_per_rank_outputs(
             self.test_output_dir,
-            ranks_with_output=[],
-            ranks_without_output=[0, 1, 2],
+            ranks_with_output=[0, 1, 2],
+            ranks_without_output=[],
+        )
+
+    def test_rank_out_of_range_disables_filter(self, rocpd_env):
+        """Custom rank-ID forces every process to identify as 10 (>= world
+        size 3), so the current rank is itself out of range. Filtering is
+        disabled and every rank produces output, even though filter "0" would
+        otherwise select only rank 0.
+        """
+        rocpd_env["MY_CUSTOM_RANK"] = "10"
+        result = self.run_test(
+            "sys_run",
+            TARGET,
+            env=rocpd_env,
+            sysrun_args=[
+                "--rank-filter-id",
+                "MY_CUSTOM_RANK",
+                "--rank-filter-output",
+                "0",
+            ],
+            launcher="mpi",
+            num_procs=NUM_PROCS,
+        )
+        self.assert_regex(result)
+        assert (
+            banner_count(result.test_output) == 3
+        ), f"Expected 3 banners, got {banner_count(result.test_output)}"
+        assert_per_rank_outputs(
+            self.test_output_dir,
+            ranks_with_output=[0, 1, 2],
+            ranks_without_output=[],
         )
 
     def test_custom_id_requires_output_or_logs(self, rocpd_env):

--- a/projects/rocprofiler-systems/tests/pytest/test_rank_filter.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_rank_filter.py
@@ -181,6 +181,40 @@ class TestRankFilter(RocprofsysTest):
             ranks_without_output=[2],
         )
 
+    def test_invalid_filter_strings(self, rocpd_env):
+        """Invalid filter specifications.
+        OUTPUT="garbage,10-0,2": 'garbage' is non-numeric and '10-0' is a reversed
+        range (both ignored); only rank 2 remains, so only rank 2 produces files.
+        LOGS="garbage": the only token is non-numeric and is ignored, so the
+        filter parses to no valid ranks. An invalid specification disables log
+        filtering entirely, so every rank emits a banner.
+        Rank 0: banner, no file output
+        Rank 1: banner, no file output
+        Rank 2: banner AND file output
+        """
+        result = self.run_test(
+            "sys_run",
+            TARGET,
+            env=rocpd_env,
+            sysrun_args=[
+                "--rank-filter-output",
+                "garbage,10-0,2",
+                "--rank-filter-logs",
+                "garbage",
+            ],
+            launcher="mpi",
+            num_procs=NUM_PROCS,
+        )
+        self.assert_regex(result)
+        assert (
+            banner_count(result.test_output) == 3
+        ), f"Expected 3 banners, got {banner_count(result.test_output)}"
+        assert_per_rank_outputs(
+            self.test_output_dir,
+            ranks_with_output=[2],
+            ranks_without_output=[0, 1],
+        )
+
     def test_custom_id_excludes_all(self, rocpd_env):
         """Custom rank-ID forces every rank to identify as 10; filter is 0-2.
         Since 10 is not in [0,2] for either filter, every rank is silenced


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

When passing to --rank-filter-output the garbage string (i.e. unconvertible to range of integers, e.g. "garbage"), or reversed range (e.g. "10-0"), or negative value ("-1"), rank-based filtering should be disabled and output produced from all ranks, but no output was observed. This PR fixed this behavior, and also introduces checks that ranks in filter string and determined or user-provided rank do not exceed the actual number of MPI ranks, if this number can be obtained from the environment.

For consistent is-rank-in-range comparison, both determined rank and total number of ranks should be global, not local. Therefore, MPI_LOCALRANKID was removed from supported variables for rank detection, because it detects local rank.
MPI_RANK was also removed from the list of rank detection variables - it is not set by any widely used MPI launchers.
Instead, two rank detection variables were added that are set by MPI launchers: PMI_RANK and SLURM_PROCID.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

- `lib/core/utility.cpp::parse_numeric_range()` now checks for reversed ranges and rejects them; for negative values it does not throw any more but issues a warning.

- `lib/core/config.cpp::is_rank_in_filter()` now disables filtering if filter string parsing error happened

- Current rank (determined or user-provided) and ranks in filter are checked against MPI world size. If current rank is out-of-range, 'filtering disabled' warning is issued and this ranks produces output. If all ranks in filter are out-of-range, all ranks produce output.

- `lib/core/config.cpp::get_mpi_rank_from_env()` refactored to reuse part of code in a new function `get_mpi_world_size_from_env()`.

- tests added for garbage filter string values and for new check-rank-against-MPI-world-size functionality

- docs updated

- changelog updated

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
ROCM-25118
ROCM-25077

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

- new tests (added in this PR) should pass
- no regression in existing ctest suite should be observed

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
