### PR TITLE
Fix ROCM-1353: allow zero-size hipAmdFileRead/Write to reach HSA

### DIFF
--- a/projects/clr/hipamd/src/hip_storage.cpp
+++ b/projects/clr/hipamd/src/hip_storage.cpp
@@ -13,11 +13,6 @@ hipError_t hipAmdFileRead(hipAmdFileHandle_t handle, void* devicePtr, uint64_t s
                        uint64_t* size_copied, int32_t* status) {
   HIP_INIT_VOID();
 
-  if (size == 0) {
-    // Skip if nothing needs reading.
-    return hipSuccess;
-  }
-
   auto* currentContext = hip::getCurrentDevice();
   amd::Device* device = nullptr;
 
@@ -46,11 +41,6 @@ hipError_t hipAmdFileWrite(hipAmdFileHandle_t handle, void* devicePtr, uint64_t 
                        uint64_t* size_copied, int32_t* status) {
   HIP_INIT_VOID();
 
-  if (size == 0) {
-    // Skip if nothing needs writing.
-    return hipSuccess;
-  }
-  
   auto* currentContext = hip::getCurrentDevice();
   amd::Device* device = nullptr;
 


### PR DESCRIPTION
## Summary
- Removes the `if (size == 0) return hipSuccess;` short-circuit from both `hipAmdFileRead` and `hipAmdFileWrite` in `projects/clr/hipamd/src/hip_storage.cpp` so zero-size calls now reach the HSA layer instead of silently succeeding.
- Single-file change, 10 deletions, no additions. Aligns the HIP runtime with the design note in `projects/hipfile/src/amd_detail/backend/fastpath.cpp` that calls out this short-circuit as the bug to fix for [ROCM-1353](https://amd-hub.atlassian.net/browse/ROCM-1353).
- HSA-side fix (`hsa_amd_ais_file_read` / `hsa_amd_ais_file_write` handling of `size == 0`) is intentionally out of scope and owned by the ROCr team.

## Test plan
- [x] `hipamd` builds cleanly with the change (verified via TheRock `hip-clr` target build).

## Verification
- Build: `hip-clr` rebuilt successfully against modified `hip_storage.cpp`.
- Diff scope: 2 hunks in 1 file, only the two short-circuit blocks removed; no surrounding logic touched.

## Known caveat
Until the HSA-side change lands, callers passing `size == 0` will surface `hipErrorUnknown` from HSA rather than the previous silent `hipSuccess`. This is the intended interim behavior — the short-circuit was hiding the real lack of HSA handling.

🤖 Claude Code 🤖

[ROCM-1353]: https://amd-hub.atlassian.net/browse/ROCM-1353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ