### PR TITLE
[kpack] Add per-arch hip-kernel-provider ASM kernel splitting handler (ALMIOPEN-1929)

### DIFF
--- a/shared/kpack/python/rocm_kpack/database_handlers.py
+++ b/shared/kpack/python/rocm_kpack/database_handlers.py
@@ -222,6 +222,64 @@ class AotritonHandler(DatabaseHandler):
         return None
 
 
+class HipKernelProviderAsmHandler(DatabaseHandler):
+    """Handler for hip-kernel-provider ASM kernel code objects.
+
+    The hipDNN ASM SDPA engine ships .co code objects in
+    per-architecture directories under the hipDNN engine plugin tree:
+        lib/hipdnn_plugins/engines/hip_kernel_provider/asm_kernels/gfx942/fmha_v3_fwd/MI300/fwd_hd128_bf16_rtne.co
+        lib/hipdnn_plugins/engines/hip_kernel_provider/asm_kernels/gfx950/fmha_v3_fwd/fwd_hd128_bf16.co
+    (bin/ instead of lib/ on Windows.)
+
+    Architecture is the directory component immediately following
+    asm_kernels/. Both forward (fmha_v3_fwd) and backward (fmha_v3_bwd)
+    kernels live under the same per-arch tree, so this single handler
+    covers both passes.
+
+    These are single-arch HSA code objects (not fat binaries), so without
+    a handler they would default into the generic artifact. Detecting them
+    here routes each arch's kernels into the matching per-arch artifact.
+
+    The asm_kernels/<arch>/ directories use exact target names (gfx942,
+    gfx950) which are already valid bundle keys, so they pass through
+    unchanged.
+    """
+
+    # Directory marker whose immediately-following component is the arch.
+    _MARKER_DIR = "asm_kernels"
+    # The marker's parent component, required to avoid false positives on
+    # any unrelated "asm_kernels" directory elsewhere in the tree.
+    _MARKER_PARENT = "hip_kernel_provider"
+
+    def name(self) -> str:
+        return "hip-kernel-provider-asm"
+
+    def detect(self, path: Path, prefix_root: Path) -> Optional[str]:
+        """
+        Detect hip-kernel-provider ASM kernel code objects.
+
+        Pattern: */hip_kernel_provider/asm_kernels/<arch>/...
+
+        Returns:
+            Architecture bundle key (e.g., 'gfx942', 'gfx950') or None.
+        """
+        path_str = self._relative_path(path, prefix_root)
+        path_parts = Path(path_str).parts
+
+        for i, part in enumerate(path_parts[:-1]):
+            if part != self._MARKER_DIR or i + 1 >= len(path_parts):
+                continue
+            # Require the expected parent directory to scope the match.
+            if i == 0 or path_parts[i - 1] != self._MARKER_PARENT:
+                continue
+            arch_dir = path_parts[i + 1]
+            if _GFX_ARCH_PATTERN.fullmatch(arch_dir):
+                return arch_dir
+            break
+
+        return None
+
+
 class MIOpenHandler(DatabaseHandler):
     """Handler for MIOpen performance database and model files.
 
@@ -285,6 +343,7 @@ AVAILABLE_HANDLERS = {
     "hipblaslt": HipBLASLtHandler,
     "hipsparselt": HipSparseLtHandler,
     "aotriton": AotritonHandler,
+    "hip-kernel-provider-asm": HipKernelProviderAsmHandler,
     "miopen": MIOpenHandler,
 }
 
@@ -297,6 +356,7 @@ WHEEL_TYPE_PRESETS = {
         "hipblaslt",
         "hipsparselt",
         "aotriton",
+        "hip-kernel-provider-asm",
         "miopen",
     ],
 }

--- a/shared/kpack/tests/test_database_handlers.py
+++ b/shared/kpack/tests/test_database_handlers.py
@@ -9,6 +9,7 @@ from rocm_kpack.database_handlers import (
     HipBLASLtHandler,
     HipSparseLtHandler,
     AotritonHandler,
+    HipKernelProviderAsmHandler,
     MIOpenHandler,
     WHEEL_TYPE_PRESETS,
     get_database_handlers,
@@ -521,6 +522,117 @@ class TestAotritonHandler:
         assert result is None
 
 
+class TestHipKernelProviderAsmHandler:
+    """Tests for HipKernelProviderAsmHandler (AITER ASM kernels) detection logic."""
+
+    # Relative install root for the ASM kernels (Linux layout).
+    _ROOT = "lib/hipdnn_plugins/engines/hip_kernel_provider/asm_kernels"
+
+    @pytest.fixture
+    def handler(self):
+        return HipKernelProviderAsmHandler()
+
+    @pytest.fixture
+    def prefix_root(self, tmp_path):
+        """Create a temporary prefix root directory."""
+        root = tmp_path / "prefix"
+        root.mkdir()
+        return root
+
+    def test_name(self, handler):
+        """Test handler name."""
+        assert handler.name() == "hip-kernel-provider-asm"
+
+    def test_detect_fwd_co_with_sku(self, handler, prefix_root):
+        """Forward .co under a per-SKU subdirectory resolves to its arch."""
+        file_path = (
+            prefix_root
+            / f"{self._ROOT}/gfx942/fmha_v3_fwd/MI300/fwd_hd128_bf16_rtne.co"
+        )
+        file_path.parent.mkdir(parents=True)
+        file_path.touch()
+
+        assert handler.detect(file_path, prefix_root) == "gfx942"
+
+    def test_detect_bwd_co_with_sku(self, handler, prefix_root):
+        """Backward .co (covers ALMIOPEN-1930) resolves to its arch too."""
+        file_path = (
+            prefix_root / f"{self._ROOT}/gfx942/fmha_v3_bwd/MI300/bwd_hd128_odo_bf16.co"
+        )
+        file_path.parent.mkdir(parents=True)
+        file_path.touch()
+
+        assert handler.detect(file_path, prefix_root) == "gfx942"
+
+    def test_detect_co_without_sku(self, handler, prefix_root):
+        """Kernels installed directly under the kernel-family dir resolve."""
+        file_path = prefix_root / f"{self._ROOT}/gfx950/fmha_v3_fwd/fwd_hd128_bf16.co"
+        file_path.parent.mkdir(parents=True)
+        file_path.touch()
+
+        assert handler.detect(file_path, prefix_root) == "gfx950"
+
+    def test_detect_various_architectures(self, handler, prefix_root):
+        """All supported ASM SDPA architectures are detected."""
+        for arch in ("gfx942", "gfx950"):
+            file_path = prefix_root / f"{self._ROOT}/{arch}/fmha_v3_fwd/kernel.co"
+            file_path.parent.mkdir(parents=True, exist_ok=True)
+            file_path.touch()
+
+            assert handler.detect(file_path, prefix_root) == arch, f"Failed {arch}"
+
+    def test_detect_windows_bin_layout(self, handler, prefix_root):
+        """Windows installs under bin/ rather than lib/ — still detected."""
+        file_path = (
+            prefix_root
+            / "bin/hipdnn_plugins/engines/hip_kernel_provider/asm_kernels"
+            / "gfx942/fmha_v3_fwd/kernel.co"
+        )
+        file_path.parent.mkdir(parents=True)
+        file_path.touch()
+
+        assert handler.detect(file_path, prefix_root) == "gfx942"
+
+    def test_reject_no_arch_subdir(self, handler, prefix_root):
+        """A file directly under asm_kernels/ (no arch dir) is not matched."""
+        file_path = prefix_root / f"{self._ROOT}/README.txt"
+        file_path.parent.mkdir(parents=True)
+        file_path.touch()
+
+        assert handler.detect(file_path, prefix_root) is None
+
+    def test_reject_non_arch_subdir(self, handler, prefix_root):
+        """A non-gfx directory under asm_kernels/ is not matched."""
+        file_path = prefix_root / f"{self._ROOT}/common/kernel.co"
+        file_path.parent.mkdir(parents=True)
+        file_path.touch()
+
+        assert handler.detect(file_path, prefix_root) is None
+
+    def test_reject_wrong_parent_directory(self, handler, prefix_root):
+        """An asm_kernels/ dir not under hip_kernel_provider/ is not matched."""
+        file_path = prefix_root / "lib/other/asm_kernels/gfx942/kernel.co"
+        file_path.parent.mkdir(parents=True)
+        file_path.touch()
+
+        assert handler.detect(file_path, prefix_root) is None
+
+    def test_reject_unrelated_file(self, handler, prefix_root):
+        """An unrelated host file elsewhere in the tree is not matched."""
+        file_path = prefix_root / "lib/libhip_kernel_provider.so"
+        file_path.parent.mkdir(parents=True)
+        file_path.touch()
+
+        assert handler.detect(file_path, prefix_root) is None
+
+    def test_reject_file_outside_prefix(self, handler, prefix_root):
+        """Files outside prefix root are a caller bug — must raise."""
+        file_path = Path("/tmp/asm_kernels/gfx942/kernel.co")
+
+        with pytest.raises(ValueError, match="is not under prefix_root"):
+            handler.detect(file_path, prefix_root)
+
+
 class TestMIOpenHandler:
     """Tests for MIOpenHandler detection logic."""
 
@@ -763,8 +875,9 @@ class TestDatabaseHandlerRegistry:
         assert "hipblaslt" in handlers
         assert "hipsparselt" in handlers
         assert "aotriton" in handlers
+        assert "hip-kernel-provider-asm" in handlers
         assert "miopen" in handlers
-        assert len(handlers) == 5
+        assert len(handlers) == 6
 
     def test_get_database_handlers_single(self):
         """Test getting a single handler by name."""
@@ -782,20 +895,28 @@ class TestDatabaseHandlerRegistry:
     def test_get_database_handlers_all(self):
         """Test getting all handlers."""
         handlers = get_database_handlers(
-            ["rocblas", "hipblaslt", "hipsparselt", "aotriton", "miopen"]
+            [
+                "rocblas",
+                "hipblaslt",
+                "hipsparselt",
+                "aotriton",
+                "hip-kernel-provider-asm",
+                "miopen",
+            ]
         )
-        assert len(handlers) == 5
+        assert len(handlers) == 6
         assert isinstance(handlers[0], RocBLASHandler)
         assert isinstance(handlers[1], HipBLASLtHandler)
         assert isinstance(handlers[2], HipSparseLtHandler)
         assert isinstance(handlers[3], AotritonHandler)
-        assert isinstance(handlers[4], MIOpenHandler)
+        assert isinstance(handlers[4], HipKernelProviderAsmHandler)
+        assert isinstance(handlers[5], MIOpenHandler)
 
     def test_wheel_type_preset(self):
         """Test that wheel type presets resolve to valid handlers."""
         names = WHEEL_TYPE_PRESETS["torch-fat"]
         handlers = get_database_handlers(names)
-        assert len(handlers) == 5
+        assert len(handlers) == 6
 
     def test_get_database_handlers_unknown(self):
         """Test that unknown handler name raises ValueError."""


### PR DESCRIPTION
## Summary

Adds a `HipKernelProviderAsmHandler` to the kpack artifact splitter so the hipDNN ASM SDPA engine's AITER `.co` kernel code objects are split into per-architecture artifacts. The handler routes files under `hip_kernel_provider/asm_kernels/<arch>/` to the matching arch, following the per-arch convention established for [MIOpen CK shared libraries](https://github.com/ROCm/rocm-systems/commit/ef7af4714fd0b07ad6b9891576e47d2443490590). It is consumed by TheRock via `split_databases = ["hip-kernel-provider-asm"]`.

## Risk Assessment

Low risk. This is an additive change: a new handler registered as `hip-kernel-provider-asm` plus its tests. Existing handlers are unmodified, and the handler only matches files under `hip_kernel_provider/asm_kernels/<arch>/`, so it is inert for artifacts that do not contain that tree.

## Testing Summary

- Unit tests for the new handler, covering forward/backward kernels, per-SKU nesting, the Windows `bin/` layout, and negative cases (wrong parent dir, no arch subdir, unrelated host files).
- End-to-end split of a synthetic `hipkernelprovider_lib` artifact built from real AITER `.co` files, exercising `split_artifacts.py` with the exact arguments TheRock's CMake uses; verified per-arch routing with no cross-arch leakage and no `.co` left in the generic artifact.

## Testing Checklist

- [x] kpack database handler unit tests - `python -m pytest tests/test_database_handlers.py` - Status: Passed (86)
- [x] End-to-end artifact split - `split_artifacts.py --split-databases hip-kernel-provider-asm --gpu-targets gfx942 gfx950` - Status: Passed
- [ ] PR CI - GitHub PR checks - Status: Pending

## Technical Changes

- Adds `HipKernelProviderAsmHandler` to `shared/kpack/python/rocm_kpack/database_handlers.py`, detecting `.co`/`.hsaco` code objects by the architecture directory immediately following `asm_kernels/`, scoped to a `hip_kernel_provider` parent to avoid false positives. Both forward (`fmha_v3_fwd`) and backward (`fmha_v3_bwd`) kernels live under the same per-arch tree and are covered by the single handler.
- Registers the handler as `hip-kernel-provider-asm` in `AVAILABLE_HANDLERS` and the `torch-fat` wheel preset.
- Adds a `TestHipKernelProviderAsmHandler` unit suite and updates the handler registry tests.
