### PR TITLE
[RCCL] net-ib: add NIC Fusion error-path/topology tests

### DIFF
--- a/projects/rccl/.claude/skills/feature-unit-testing/SKILL.md
+++ b/projects/rccl/.claude/skills/feature-unit-testing/SKILL.md
@@ -229,6 +229,11 @@ int ibv_poll_cq(struct ibv_cq *cq, int num, struct ibv_wc *wc) {
     return real_ibv_poll_cq(cq, num, wc);
 }
 ```
+LD_PRELOAD only works if the target calls the symbol through the PLT. It does **not** work when
+the code uses `dlopen`/`dlsym` to resolve symbols into private function pointers, or dispatches
+through a driver ops-struct (e.g. `cq->context->ops.poll_cq`) — both bypass interposition. Check
+the binary for `dlopen`/`dlsym` usage before planning a shim; if it's there, fall back to a
+compile-time fault hook instead.
 
 ---
 

--- a/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
+++ b/projects/rccl/test/transport/NetIbMPI/NetIbMPITestBase.hpp
@@ -31,6 +31,7 @@
 #include <iomanip>
 #include <iostream>
 #include <map>
+#include <set>
 #include <sstream>
 #include <string>
 #include <dirent.h>
@@ -399,6 +400,27 @@ protected:
         ASSERT_EQ(InitNetIb(), ncclSuccess);
         ASSERT_EQ(GetDeviceCount(p), ncclSuccess);
         ASSERT_GT(*p, 0);
+    }
+
+    // Count physical IB devices only. The plugin's devices()/GetDeviceCount
+    // returns ncclNMergedIbDevs, which GROWS as makeVDevice creates virtual
+    // NICs — so it is order-dependent across tests in the same process. Note a
+    // single-device vNIC (e.g. a deduped merge) also reports vProps.ndevs == 1,
+    // so ndevs alone cannot tell it apart from a physical NIC. Each physical NIC
+    // is registered with a unique underlying index in vProps.devs[0], while a
+    // 1-device vNIC reuses an existing physical index — so the count of DISTINCT
+    // single-device vProps.devs[0] values is the true physical device count.
+    int GetPhysicalDeviceCount() {
+        int n = 0;
+        if (GetDeviceCount(&n) != ncclSuccess) return 0;
+        std::set<int> physIdx;
+        for (int i = 0; i < n; i++) {
+            ncclNetProperties_t props;
+            memset(&props, 0, sizeof(props));
+            if (GetDeviceProperties(i, &props) != ncclSuccess) continue;
+            if (props.vProps.ndevs <= 1) physIdx.insert(props.vProps.devs[0]);
+        }
+        return (int)physIdx.size();
     }
 
     // Composite block: SetupConnection + wire up NetConnectionGuard for RAII cleanup.

--- a/projects/rccl/test/transport/NetIbMPI/NicFusionTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/NicFusionTests.cpp
@@ -297,6 +297,98 @@ TEST_F(NetIbMPITest, AsymmetricMerge_VNic) {
     }
 }
 
+TEST_F(NetIbMPITest, DisjointMergeRailLocal_VNic) {
+    // Exercises CheckVProps' rail-local mismatch + ndevs-swap arms on accept,
+    // reached when the two ranks' vNICs share no physical devices. Requires
+    // NCCL_IB_WARN_RAIL_LOCAL=1 (defaults off) and >=5 physical NICs.
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    ASSERT_EQ(InitNetIb(), ncclSuccess);
+
+    // Gather all skip reasons into one flag and agree across ranks BEFORE any
+    // MPI_Send/Recv, so the two ranks never diverge (one skipping while the
+    // other blocks in the handshake). Reasons: failover on (global device-table
+    // isolation, same caveat as AsymmetricMerge_VNic), WARN_RAIL_LOCAL not set,
+    // or too few PHYSICAL NICs (>=5 needed; the merged count would inflate this
+    // spuriously). Physical NIC count is min-reduced across ranks.
+    const char* failoverEnv = getenv("NCCL_IB_RESILIENCY_PORT_FAILOVER");
+    const char* warnEnv = getenv("NCCL_IB_WARN_RAIL_LOCAL");
+    int minNdev = GetPhysicalDeviceCount();
+    MPI_Allreduce(MPI_IN_PLACE, &minNdev, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD);
+    int skip = 0;
+    if (failoverEnv && strcmp(failoverEnv, "1") == 0) skip = 1;
+    if (!warnEnv || atoi(warnEnv) == 0) skip = 1;
+    if (minNdev < 5) skip = 1;
+    MPI_Allreduce(MPI_IN_PLACE, &skip, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+    if (skip) {
+        GTEST_SKIP() << "Need NCCL_IB_WARN_RAIL_LOCAL=1, failover off, and >=5 NICs "
+                     << "(have " << minNdev << ") for disjoint rail-local coverage";
+    }
+
+    int rank = MPIEnvironment::world_rank;
+    int peerRank = (rank + 1) % 2;
+
+    // Each rank merges a disjoint, asymmetric device set (rank0: 2 devs,
+    // rank1: 3 devs) so the empty intersection drives the rail-local warn arm
+    // and the size difference drives the ndevs-swap arm in ncclIbCheckVProps.
+    ncclNetVDeviceProps_t vProps;
+    if (rank == 0) { vProps.ndevs = 2; vProps.devs[0] = 0; vProps.devs[1] = 1; }
+    else           { vProps.ndevs = 3; vProps.devs[0] = 2; vProps.devs[1] = 3; vProps.devs[2] = 4; }
+
+    // Setup happens before the matched MPI_Send/Recv, so a unilateral fatal
+    // assert here would deadlock the peer. Use EXPECT, then MPI_Allreduce the
+    // local-setup status so both ranks abort together if either side failed.
+    int vdev = -1;
+    EXPECT_EQ(MakeVirtualDevice(&vdev, &vProps), ncclSuccess) << "Failed to create disjoint vNIC";
+    int setupOk = (vdev >= 0) ? 1 : 0;
+    ConnectionPair pair;
+    if (rank == 0 && setupOk) {
+        if (CreateListenComm(vdev, &pair.handle, &pair.listenComm) != ncclSuccess) setupOk = 0;
+    }
+    MPI_Allreduce(MPI_IN_PLACE, &setupOk, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD);
+    ASSERT_EQ(setupOk, 1) << "vNIC/listen setup failed on at least one rank";
+
+    int done = 0;
+    if (rank == 0) {
+        MPI_Send(&pair.handle, sizeof(ncclNetHandle_t), MPI_BYTE, peerRank, 0, MPI_COMM_WORLD);
+        auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(kConnectPollTimeoutSec);
+        while (!done && std::chrono::steady_clock::now() < deadline) {
+            if (AcceptConnection(pair.listenComm, &pair.recvComm) != ncclSuccess) break;
+            if (pair.recvComm != nullptr) done = 1;
+            else usleep(kPollIntervalUs);  // avoid busy-spin while accept is pending
+        }
+    } else {
+        MPI_Recv(&pair.handle, sizeof(ncclNetHandle_t), MPI_BYTE, peerRank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+        auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(kConnectPollTimeoutSec);
+        while (!done && std::chrono::steady_clock::now() < deadline) {
+            if (ConnectToRemote(vdev, &pair.handle, &pair.sendComm) != ncclSuccess) break;
+            if (pair.sendComm != nullptr) done = 1;
+            else usleep(kPollIntervalUs);  // avoid busy-spin while connect is pending
+        }
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    NetConnectionGuard connGuard(net_);
+    if (rank == 0) {
+        connGuard.setRecvComm(pair.recvComm);
+        connGuard.setListenComm(pair.listenComm);
+    } else {
+        connGuard.setSendComm(pair.sendComm);
+    }
+
+    // The coverage target (CheckVProps rail-local warn during accept) has run by
+    // now. Agree on completion across ranks so a one-sided timeout surfaces as a
+    // clear failure rather than a hang on the final barrier.
+    MPI_Allreduce(MPI_IN_PLACE, &done, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD);
+    EXPECT_EQ(done, 1) << "Disjoint-rail accept/connect did not complete within "
+                       << kConnectPollTimeoutSec << "s on at least one rank";
+
+    MPI_Barrier(MPI_COMM_WORLD);
+}
+
 TEST_F(NetIbMPITest, CloseWithoutTransfer_VNic) {
     ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
                                          false, kMinGpusPerNode, kNoNodeLimit))

--- a/projects/rccl/test/transport/NetIbMPI/NicFusionTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/NicFusionTests.cpp
@@ -78,6 +78,45 @@ TEST_F(NetIbMPITest, MakeVirtualDeviceOutOfRangeDev) {
     EXPECT_EQ(result, ncclInvalidUsage) << "Out-of-range physical device must be rejected";
 }
 
+TEST_F(NetIbMPITest, MakeVirtualDeviceDuplicateDevs) {
+    // Listing the same physical device twice must be deduped into a single-device
+    // vNIC rather than rejected or double-counted.
+    ASSERT_TRUE(validateTestPrerequisites(kMinProcessesForMPI, MPITestConstants::kNoProcessLimit,
+                                         kRequirePowerOfTwo, 1, kNoNodeLimit))
+        << "Test requirements not met";
+
+    // Dedup yields a 1-device vNIC, which requires merging to be enabled
+    // (NCCL_IB_MERGE_NICS defaults to 1). Skip only when it is explicitly off,
+    // otherwise the merge must succeed so the dedup arm is actually exercised.
+    const char* mergeEnv = getenv("NCCL_IB_MERGE_NICS");
+    if (mergeEnv && atoi(mergeEnv) == 0) {
+        GTEST_SKIP() << "NIC merging disabled (NCCL_IB_MERGE_NICS=0)";
+    }
+
+    int ndev = 0;
+    AssertInitAndGetDevices(&ndev);
+    if (ndev < 1) {
+        GTEST_SKIP() << "Need at least 1 device";
+    }
+
+    ncclNetVDeviceProps_t vProps;
+    vProps.ndevs = 2;
+    vProps.devs[0] = 0;
+    vProps.devs[1] = 0;  // duplicate -> exercises the used[] continue arm
+
+    int vdev = -1;
+    ASSERT_EQ(MakeVirtualDevice(&vdev, &vProps), ncclSuccess)
+        << "Deduped vNIC (same device twice) should be created";
+    ASSERT_GE(vdev, 0) << "Deduped virtual device ID should be non-negative";
+
+    // Verify the dedup actually collapsed the duplicate: the resulting vNIC must
+    // contain exactly one physical device. Without this, a silently-broken dedup
+    // (both entries added) would still return ncclSuccess and pass.
+    ncclNetProperties_t props;
+    memset(&props, 0, sizeof(props));
+    ASSERT_EQ(GetDeviceProperties(vdev, &props), ncclSuccess);
+    EXPECT_EQ(props.vProps.ndevs, 1) << "Dedup should yield a single-device vNIC";
+}
 
 // NIC Fusion (vNIC) Tests
 

--- a/projects/rccl/test/transport/NetIbMPI/NicFusionTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/NicFusionTests.cpp
@@ -57,6 +57,35 @@ TEST_F(NetIbMPITest, MakeVirtualDeviceInvalidProps) {
     EXPECT_EQ(result, ncclInvalidUsage) << "Should fail with zero devices";
 }
 
+TEST_F(NetIbMPITest, MakeVirtualDeviceMergeDisabled) {
+    // A multi-device merge must be rejected when NIC merging is disabled.
+    // Requires NCCL_IB_MERGE_NICS=0 (config default is 1) so GTEST_SKIP otherwise.
+    const char* mergeEnv = getenv("NCCL_IB_MERGE_NICS");
+    if (!mergeEnv || atoi(mergeEnv) != 0) {
+        GTEST_SKIP() << "Set NCCL_IB_MERGE_NICS=0 to exercise the merge-disabled guard";
+    }
+
+    ASSERT_TRUE(validateTestPrerequisites(kMinProcessesForMPI, MPITestConstants::kNoProcessLimit,
+                                         kRequirePowerOfTwo, 1, kNoNodeLimit))
+        << "Test requirements not met";
+
+    int ndev = 0;
+    AssertInitAndGetDevices(&ndev);
+    if (ndev < 2) {
+        GTEST_SKIP() << "Need at least 2 devices to request a 2-device merge";
+    }
+
+    ncclNetVDeviceProps_t vProps;
+    vProps.ndevs = 2;
+    vProps.devs[0] = 0;
+    vProps.devs[1] = 1;
+
+    int vdev = -1;
+    ncclResult_t result = MakeVirtualDevice(&vdev, &vProps);
+    EXPECT_EQ(result, ncclInvalidUsage)
+        << "Multi-device merge with NCCL_IB_MERGE_NICS=0 must be rejected";
+}
+
 TEST_F(NetIbMPITest, MakeVirtualDeviceOutOfRangeDev) {
     // Covers the physical-device bounds check in ncclIbMakeVDeviceInternal:
     // `if (props->devs[i] < 0 || props->devs[i] >= ncclNIbDevs) return ncclInvalidUsage;`

--- a/projects/rccl/test/transport/NetIbMPI/NicFusionTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/NicFusionTests.cpp
@@ -57,6 +57,28 @@ TEST_F(NetIbMPITest, MakeVirtualDeviceInvalidProps) {
     EXPECT_EQ(result, ncclInvalidUsage) << "Should fail with zero devices";
 }
 
+TEST_F(NetIbMPITest, MakeVirtualDeviceOutOfRangeDev) {
+    // Covers the physical-device bounds check in ncclIbMakeVDeviceInternal:
+    // `if (props->devs[i] < 0 || props->devs[i] >= ncclNIbDevs) return ncclInvalidUsage;`
+    // (net_ib.cc:724). Passing a device index >= ncclNIbDevs must be rejected.
+    ASSERT_TRUE(validateTestPrerequisites(kMinProcessesForMPI, MPITestConstants::kNoProcessLimit,
+                                         kRequirePowerOfTwo, 1, kNoNodeLimit))
+        << "Test requirements not met";
+
+    int ndev = 0;
+    AssertInitAndGetDevices(&ndev);
+
+    ncclNetVDeviceProps_t vProps;
+    vProps.ndevs = 2;
+    vProps.devs[0] = 0;
+    vProps.devs[1] = ndev;  // >= physical count -> guaranteed out of range
+
+    int vdev = -1;
+    ncclResult_t result = MakeVirtualDevice(&vdev, &vProps);
+    EXPECT_EQ(result, ncclInvalidUsage) << "Out-of-range physical device must be rejected";
+}
+
+
 // NIC Fusion (vNIC) Tests
 
 TEST_F(NetIbMPITest, ConnectAndTransfer_VNic) {

--- a/projects/rccl/test/transport/NetIbMPI/NicFusionTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/NicFusionTests.cpp
@@ -6,7 +6,12 @@
 
 #include "NetIbMPITestBase.hpp"
 
+#include <chrono>
+
 #ifdef MPI_TESTS_ENABLED
+
+// Deadline for the vNIC accept/connect poll loops in this file.
+static constexpr int kConnectPollTimeoutSec = 30;
 
 // Virtual Device Tests
 
@@ -86,10 +91,73 @@ TEST_F(NetIbMPITest, MakeVirtualDeviceMergeDisabled) {
         << "Multi-device merge with NCCL_IB_MERGE_NICS=0 must be rejected";
 }
 
+// Reads the NUMA node of a physical IB device from its sysfs pciPath
+// (<pciPath>/numa_node), mirroring ncclIbGetNumaNodeFromPath in net_ib.cc.
+// Returns -1 if unknown. Used to pick a genuinely cross-NUMA device pair
+// instead of hard-coding indices that assume a specific topology.
+static int ReadDeviceNumaNode(const ncclNetProperties_t& props) {
+    if (props.pciPath == nullptr) return -1;
+    std::string numaPath = std::string(props.pciPath) + "/numa_node";
+    FILE* f = fopen(numaPath.c_str(), "r");
+    if (f == nullptr) return -1;
+    int numa = -1;
+    if (fscanf(f, "%d", &numa) != 1) numa = -1;
+    fclose(f);
+    return numa;
+}
+
+TEST_F(NetIbMPITest, MakeVirtualDeviceCrossNuma) {
+    // Merging NICs on different NUMA nodes is warning-only, so the merge must
+    // still succeed. Picks a cross-NUMA pair by reading each device's numa_node
+    // from sysfs (correct on any layout, no fixed indices); skips when no such
+    // pair exists or merging is disabled.
+    ASSERT_TRUE(validateTestPrerequisites(kMinProcessesForMPI, MPITestConstants::kNoProcessLimit,
+                                         kRequirePowerOfTwo, 1, kNoNodeLimit))
+        << "Test requirements not met";
+
+    const char* mergeEnv = getenv("NCCL_IB_MERGE_NICS");
+    if (mergeEnv && atoi(mergeEnv) == 0) {
+        GTEST_SKIP() << "NIC merging disabled (NCCL_IB_MERGE_NICS=0)";
+    }
+
+    int ndev = 0;
+    AssertInitAndGetDevices(&ndev);
+
+    // Find two PHYSICAL devices on different NUMA nodes. Skip merged vNICs
+    // (vProps.ndevs > 1) that earlier tests may have left in the device table —
+    // they have no single NUMA node and their indices are order-dependent.
+    int devA = -1, numaA = -1, devB = -1;
+    for (int i = 0; i < ndev && devB < 0; i++) {
+        ncclNetProperties_t pi;
+        memset(&pi, 0, sizeof(pi));
+        if (GetDeviceProperties(i, &pi) != ncclSuccess) continue;
+        if (pi.vProps.ndevs > 1) continue;  // merged vNIC, not a physical NIC
+        int numaI = ReadDeviceNumaNode(pi);
+        if (numaI < 0) continue;
+        if (devA < 0) { devA = i; numaA = numaI; continue; }
+        if (numaI != numaA) devB = i;
+    }
+    if (devA < 0 || devB < 0) {
+        GTEST_SKIP() << "No cross-NUMA physical NIC pair available on this node";
+    }
+
+    ncclNetVDeviceProps_t vProps;
+    vProps.ndevs = 2;
+    vProps.devs[0] = devA;
+    vProps.devs[1] = devB;
+
+    int vdev = -1;
+    // Cross-NUMA is a warning, not an error: the merge must succeed.
+    ASSERT_EQ(MakeVirtualDevice(&vdev, &vProps), ncclSuccess)
+        << "Cross-NUMA vNIC (devs " << devA << "," << devB << ") should still be created";
+    EXPECT_GE(vdev, 0) << "Cross-NUMA vNIC ID should be non-negative";
+}
+
 TEST_F(NetIbMPITest, MakeVirtualDeviceOutOfRangeDev) {
-    // Covers the physical-device bounds check in ncclIbMakeVDeviceInternal:
-    // `if (props->devs[i] < 0 || props->devs[i] >= ncclNIbDevs) return ncclInvalidUsage;`
-    // (net_ib.cc:724). Passing a device index >= ncclNIbDevs must be rejected.
+    // Covers the device bounds check in ncclIbMakeVDeviceInternal that rejects a
+    // physical index >= the physical device count. The reported device count
+    // (merged) is always >= the physical count, so using it as the index is
+    // guaranteed out of range regardless of how many vNICs already exist.
     ASSERT_TRUE(validateTestPrerequisites(kMinProcessesForMPI, MPITestConstants::kNoProcessLimit,
                                          kRequirePowerOfTwo, 1, kNoNodeLimit))
         << "Test requirements not met";

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -286,6 +286,87 @@
         }
       ]
     },
+    "net_ib_coverage_env": {
+      "extends": "net_ib_base",
+      "timeout": 300,
+      "_comment": "Coverage-oriented re-run of core transfer tests under alternate IB env. GID_INDEX=-1 forces RoCE GID auto-select (the auto-select path is skipped when a fixed index is pinned); PCI_RELAXED_ORDERING=0 exercises the relaxed-ordering-disabled registration/connect paths; ADAPTIVE_ROUTING=1 reaches the adaptive-routing threshold path. Env knobs are NIC-agnostic.",
+      "env_variables": {
+        "NCCL_IB_GID_INDEX": "-1",
+        "NCCL_IB_PCI_RELAXED_ORDERING": "0",
+        "NCCL_IB_ADAPTIVE_ROUTING": "1"
+      },
+      "tests": [
+        {
+          "name": "NetIB_Cov_SimpleSendRecv",
+          "description": "Send/recv under GID auto-select + relaxed-ordering-off + adaptive routing",
+          "test_filter": "NetIbMPITest.SimpleSendRecv",
+          "timeout": 180
+        },
+        {
+          "name": "NetIB_Cov_MultipleSizes",
+          "description": "Multi-size transfer under alternate IB env (GID auto-select / RO off / AR on)",
+          "test_filter": "NetIbMPITest.SendRecvMultipleSizes",
+          "timeout": 300
+        },
+        {
+          "name": "NetIB_Cov_LargeTransfer",
+          "description": "Large transfer crossing the AR threshold under adaptive routing",
+          "test_filter": "NetIbMPITest.LargeTransfer",
+          "timeout": 300
+        },
+        {
+          "name": "NetIB_Cov_RegisterHost",
+          "description": "Host MR registration under relaxed-ordering-disabled path",
+          "test_filter": "NetIbMPITest.RegisterHostMemory",
+          "timeout": 180
+        }
+      ]
+    },
+    "net_ib_merge_disabled": {
+      "extends": "net_ib_base",
+      "timeout": 60,
+      "_comment": "Exercises the makeVDevice merge-disabled guard, which only runs with NCCL_IB_MERGE_NICS=0 (the rest of the suite uses 1). Without this entry MakeVirtualDeviceMergeDisabled always GTEST_SKIPs in CI.",
+      "env_variables": {
+        "NCCL_IB_MERGE_NICS": "0"
+      },
+      "tests": [
+        {
+          "name": "NetIB_VNic_MergeDisabledGuard",
+          "description": "makeVDevice with a multi-device request must be rejected when NCCL_IB_MERGE_NICS=0",
+          "test_filter": "NetIbMPITest.MakeVirtualDeviceMergeDisabled"
+        }
+      ]
+    },
+    "net_ib_vnic_validation": {
+      "extends": "net_ib_base",
+      "timeout": 120,
+      "_comment": "makeVDevice / CheckVProps validation and topology error paths. WARN_RAIL_LOCAL=1 so the rail-local mismatch arm in DisjointMergeRailLocal_VNic is reachable. Topology-dependent cases (cross-NUMA, disjoint >=5-NIC merge) GTEST_SKIP when the hardware doesn't provide them.",
+      "env_variables": {
+        "NCCL_IB_WARN_RAIL_LOCAL": "1"
+      },
+      "tests": [
+        {
+          "name": "NetIB_VNic_OutOfRangeDev",
+          "description": "makeVDevice rejects an out-of-range physical device index",
+          "test_filter": "NetIbMPITest.MakeVirtualDeviceOutOfRangeDev"
+        },
+        {
+          "name": "NetIB_VNic_DuplicateDevs",
+          "description": "makeVDevice dedups a repeated device into a single-device vNIC",
+          "test_filter": "NetIbMPITest.MakeVirtualDeviceDuplicateDevs"
+        },
+        {
+          "name": "NetIB_VNic_CrossNuma",
+          "description": "makeVDevice warns (but succeeds) merging NICs across NUMA nodes",
+          "test_filter": "NetIbMPITest.MakeVirtualDeviceCrossNuma"
+        },
+        {
+          "name": "NetIB_VNic_DisjointRailLocal",
+          "description": "CheckVProps rail-local mismatch + ndevs-swap on a disjoint asymmetric vNIC merge",
+          "test_filter": "NetIbMPITest.DisjointMergeRailLocal_VNic"
+        }
+      ]
+    },
     "net_ib_multirecv": {
       "extends": "net_ib_base",
       "timeout": 300,
@@ -1818,6 +1899,10 @@
       "extends": "net_ib_transfer",
       "env_variables": { "NCCL_NET": "ib-cast" }
     },
+    "net_ib_coverage_env_cast": {
+      "extends": "net_ib_coverage_env",
+      "env_variables": { "NCCL_NET": "ib-cast" }
+    },
     "net_ib_multirecv_cast": {
       "extends": "net_ib_multirecv",
       "env_variables": { "NCCL_NET": "ib-cast" }
@@ -1906,6 +1991,24 @@
       "name": "NET IB - Data Transfer",
       "description": "InfiniBand data transfer and stress tests",
       "config": "net_ib_transfer",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Coverage Env (GID auto-select / RO off / AR)",
+      "description": "Core transfer tests re-run under alternate IB env to cover GID auto-select, relaxed-ordering-disabled, and adaptive-routing branches",
+      "config": "net_ib_coverage_env",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - vNIC Merge Disabled Guard",
+      "description": "Exercises the makeVDevice merge-disabled guard under NCCL_IB_MERGE_NICS=0",
+      "config": "net_ib_merge_disabled",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - vNIC Validation",
+      "description": "makeVDevice/CheckVProps validation and topology error paths (bounds, dedup, cross-NUMA, rail-local)",
+      "config": "net_ib_vnic_validation",
       "enabled": true
     },
     {
@@ -2182,6 +2285,12 @@
       "name": "NET IB - Data Transfer (ib-cast)",
       "description": "InfiniBand data transfer via ib-cast plugin (NCCL_NET=ib-cast)",
       "config": "net_ib_transfer_cast",
+      "enabled": true
+    },
+    {
+      "name": "NET IB - Coverage Env (ib-cast)",
+      "description": "Coverage-env transfer tests via ib-cast plugin: exercises CAST GID auto-select and relaxed-ordering paths (NCCL_NET=ib-cast)",
+      "config": "net_ib_coverage_env_cast",
       "enabled": true
     },
     {


### PR DESCRIPTION
## Motivation

This PR adds targeted tests for uncovered decision points: validation, error-handling, and topology-mismatch branches of `ncclIbMakeVDeviceInternal` / `ncclIbCheckVProps`.

## JIRA ID

AICOMNET-243

## Test Plan

Five new tests in `test/transport/NetIbMPI/NicFusionTests.cpp`, each targeting a
specific branch in `src/transport/net_ib.cc`:

- `MakeVirtualDeviceOutOfRangeDev` — a physical device index past the device
  count is rejected with `ncclInvalidUsage` (bounds check).
- `MakeVirtualDeviceDuplicateDevs` — the same device listed twice is deduped into
  a single-device vNIC (verified via the resulting `vProps.ndevs`).
- `MakeVirtualDeviceMergeDisabled` — a multi-device merge with
  `NCCL_IB_MERGE_NICS=0` is rejected by the merge-disabled guard.
- `MakeVirtualDeviceCrossNuma` — merging NICs on different NUMA nodes triggers
  the cross-NUMA warning but still succeeds (warning, not error); the pair is
  chosen by reading each device's `numa_node` from sysfs.
- `DisjointMergeRailLocal_VNic` — two ranks merge disjoint, asymmetric device
  sets; on accept `ncclIbCheckVProps` takes both the ndevs-swap arm and the
  rail-local mismatch warning (gated on `NCCL_IB_WARN_RAIL_LOCAL=1`).

Tests that require specific hardware/config (>=5 NICs, NICs across NUMA domains,
or a particular env var) `GTEST_SKIP` with a clear reason when the prerequisite
is absent, keeping the suite portable across clusters. The new tests are wired
into CI via `net_ib_merge_disabled` and `net_ib_vnic_validation` suites.

Also adds a coverage-oriented test-runner suite `net_ib_coverage_env` (and its
`ib-cast` mirror) to `tools/scripts/test_runner/configs/mi300x_mellanox_ib.json`.
It re-runs the core transfer/memory tests under alternate IB env
(`NCCL_IB_GID_INDEX=-1` for RoCE GID auto-select, `NCCL_IB_PCI_RELAXED_ORDERING=0`,
`NCCL_IB_ADAPTIVE_ROUTING=1`) to reach config-gated branches without new test code.
Only the high-yield env knobs are kept; single-branch knobs were measured and
dropped to avoid extra suite runtime.

## Test Result

- NIC Fusion branch coverage: **51.7% -> 74.1%** (Standard -> Thorough tier) on a multi-NIC node.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

