### PR TITLE
[rocprofiler-sdk] Fix json-tool finalization record loss and enable kernel-tracing validation tests

### DIFF
--- a/projects/rocprofiler-sdk/tests/kernel-tracing/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/kernel-tracing/CMakeLists.txt
@@ -22,8 +22,8 @@ rocprofiler_add_integration_execute_test(
     PRELOAD "$<TARGET_FILE:rocprofiler-sdk-json-tool>"
     FIXTURES_SETUP kernel-tracing)
 
-# Stable structural/logical kernel-tracing validation tests. test_total_runtime
-# is excluded here and registered as its own (unstable) test below.
+# Stable structural/logical kernel-tracing validation tests. test_total_runtime is
+# excluded here and registered as its own (unstable) test below.
 rocprofiler_add_integration_validate_test(
     kernel-tracing
     TEST_PATHS validate.py

--- a/projects/rocprofiler-sdk/tests/kernel-tracing/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/kernel-tracing/CMakeLists.txt
@@ -35,14 +35,6 @@ rocprofiler_add_integration_validate_test(
     DISCOVERY_ARGS -k "not test_total_runtime"
     ARGS --input ${CMAKE_CURRENT_BINARY_DIR}/kernel-tracing-test.json)
 
-# test_total_runtime asserts the profiler-measured total kernel-dispatch
-# runtime is within +/-20% of a host-time-derived 1 second target. Because the
-# reproducible-runtime workload budgets by host-measured time (which includes
-# launch/queue overhead) while this checks GPU-measured durations, the measured
-# sum drifts below the lower bound under system/GPU contention. It is therefore
-# registered separately and marked UNSTABLE (disabled when
-# ROCPROFILER_DISABLE_UNSTABLE_CTESTS=ON, the default) while reusing the
-# kernel-tracing execute fixture and its JSON output.
 rocprofiler_add_integration_validate_test(
     kernel-tracing-total-runtime
     TEST_PATHS validate.py

--- a/projects/rocprofiler-sdk/tests/kernel-tracing/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/kernel-tracing/CMakeLists.txt
@@ -10,13 +10,6 @@ project(
 
 find_package(rocprofiler-sdk REQUIRED)
 
-set(PYTEST_ARGS)
-if(ROCPROFILER_MEMCHECK MATCHES "(Address|Thread|UndefinedBehavior)Sanitizer"
-   OR ROCPROFILER_BUILD_CODECOV
-   OR ROCPROFILER_DISABLE_UNSTABLE_CTESTS)
-    set(PYTEST_ARGS -k "not test_total_runtime")
-endif()
-
 set(kernel-tracing-env "ROCPROFILER_TOOL_DISABLE_PERFETTO=1"
                        "ROCPROFILER_TOOL_OUTPUT_FILE=kernel-tracing-test.json")
 
@@ -29,6 +22,8 @@ rocprofiler_add_integration_execute_test(
     PRELOAD "$<TARGET_FILE:rocprofiler-sdk-json-tool>"
     FIXTURES_SETUP kernel-tracing)
 
+# Stable structural/logical kernel-tracing validation tests. test_total_runtime
+# is excluded here and registered as its own (unstable) test below.
 rocprofiler_add_integration_validate_test(
     kernel-tracing
     TEST_PATHS validate.py
@@ -37,6 +32,27 @@ rocprofiler_add_integration_validate_test(
     LABELS "integration-tests"
     TIMEOUT 45
     FIXTURES_REQUIRED kernel-tracing
-    DISCOVERY_ARGS ${PYTEST_ARGS}
+    DISCOVERY_ARGS -k "not test_total_runtime"
+    ARGS --input ${CMAKE_CURRENT_BINARY_DIR}/kernel-tracing-test.json)
+
+# test_total_runtime asserts the profiler-measured total kernel-dispatch
+# runtime is within +/-20% of a host-time-derived 1 second target. Because the
+# reproducible-runtime workload budgets by host-measured time (which includes
+# launch/queue overhead) while this checks GPU-measured durations, the measured
+# sum drifts below the lower bound under system/GPU contention. It is therefore
+# registered separately and marked UNSTABLE (disabled when
+# ROCPROFILER_DISABLE_UNSTABLE_CTESTS=ON, the default) while reusing the
+# kernel-tracing execute fixture and its JSON output.
+rocprofiler_add_integration_validate_test(
+    kernel-tracing-total-runtime
+    TEST_PATHS validate.py
+    COPY conftest.py
+    CONFIG pytest.ini
+    LABELS "integration-tests"
+    TIMEOUT 45
+    FIXTURES_REQUIRED kernel-tracing
+    DISCOVERY_ARGS -k "test_total_runtime"
     ARGS --input ${CMAKE_CURRENT_BINARY_DIR}/kernel-tracing-test.json
+    DISABLED_CODECOV
+    DISABLED_MEMCHECKS "(Address|Thread|UndefinedBehavior)Sanitizer"
     UNSTABLE)

--- a/projects/rocprofiler-sdk/tests/tools/json-tool.cpp
+++ b/projects/rocprofiler-sdk/tests/tools/json-tool.cpp
@@ -2149,6 +2149,14 @@ tool_fini(void* tool_data)
     static std::atomic_flag _once = ATOMIC_FLAG_INIT;
     if(_once.test_and_set()) return;
 
+    // Each rocprofiler buffer is double-buffered: a record can land in the
+    // currently-inactive half if a producer races a watermark flush that just
+    // swapped the active buffer. A single flush only drains the active half, so
+    // such a record would be silently lost at shutdown. Flushing, stopping, then
+    // flushing again drains *both* halves (each flush advances the active index),
+    // guaranteeing every emplaced record is delivered. This mirrors the
+    // finalization sequence used by the production rocprofv3 tool.
+    flush();
     stop();
     flush();
 

--- a/projects/rocprofiler-sdk/tests/tools/json-tool.cpp
+++ b/projects/rocprofiler-sdk/tests/tools/json-tool.cpp
@@ -2149,13 +2149,6 @@ tool_fini(void* tool_data)
     static std::atomic_flag _once = ATOMIC_FLAG_INIT;
     if(_once.test_and_set()) return;
 
-    // Each rocprofiler buffer is double-buffered: a record can land in the
-    // currently-inactive half if a producer races a watermark flush that just
-    // swapped the active buffer. A single flush only drains the active half, so
-    // such a record would be silently lost at shutdown. Flushing, stopping, then
-    // flushing again drains *both* halves (each flush advances the active index),
-    // guaranteeing every emplaced record is delivered. This mirrors the
-    // finalization sequence used by the production rocprofv3 tool.
     flush();
     stop();
     flush();


### PR DESCRIPTION
## Motivation

The `kernel-tracing` validation suite was registered as a single `UNSTABLE` test, so it never gated in CI. This PR fixes the underlying flakiness and enables the deterministic tests as a gating suite.

## Technical Details

1. **`tests/tools/json-tool.cpp`** — `tool_fini()` finalized with `stop(); flush();`. Since SDK buffers are double-buffered, a single flush after stop drains only one buffer half, leaving final correlation-ID retirement records stranded — the cause of intermittent `test_retired_correlation_ids` failures. Changed to `flush(); stop(); flush();`, matching the `rocprofv3` finalization pattern, so all records are delivered deterministically.
2. **`tests/kernel-tracing/CMakeLists.txt`** — split the `UNSTABLE` validate target into:
   - `kernel-tracing`: the 9 deterministic tests, now gating (no `UNSTABLE`).
   - `kernel-tracing-total-runtime`: isolates the timing-sensitive `test_total_runtime`, kept `UNSTABLE` (+ `DISABLED_CODECOV` / `DISABLED_MEMCHECKS`).
  
   Removes the obsolete `PYTEST_ARGS` block in favor of per-target `DISCOVERY_ARGS`.

## JIRA ID

Resolves AIROCVAL-40

## Test Plan

- Ran `ctest -R kernel-tracing -j 8` locally on a multi-GPU host, including a 20-iteration stability loop of the validation suite (exercises the previously-flaky `test_retired_correlation_ids`).
- Ran the suite alongside other tracing domains via `ctest --parallel` to confirm cross-domain contention does not reintroduce record loss.
- Cross-arch validation in progress on downstream CI across multiple gfx families (gfx90a, gfx94X, gfx103X, gfx110X, gfx1150, gfx1151, gfx120X).

## Test Result

- 20/20 stability-loop runs passed with no failures; `test_total_runtime` correctly reported as disabled. The 9 deterministic tests pass consistently with no loosened assertions.

## Submission Checklist

- [V] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
