### PR TITLE
[rocprofiler-compute] Add native PC sampling collection with SDK-equivalent output

### DIFF
--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -10,6 +10,8 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 * Added backward compatibility for live attach mode to work with older ROCm 7.x.x releases.
 
+* Added native PC sampling collection to ``librocprofiler-compute-tool``, which gathers host-trap and stochastic PC samples directly through the rocprofiler-sdk PC sampling service and writes a ``ps_file_results.json`` compatible with the existing PC sampling analysis.
+
 ### Changed
 
 * Moved `--gui` and `--tui` analyze options to experimental status. These features now require the `--experimental` flag to be enabled (e.g., `rocprof-compute analyze --experimental --gui`).

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/CMakeLists.txt
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/CMakeLists.txt
@@ -10,6 +10,11 @@ add_library(
     code_object_translator.cpp
     code_object_writer.h
     code_object_writer.cpp
+    pc_sampling_record.h
+    ps_file_writer.h
+    ps_file_writer.cpp
+    pc_sample_record_collector.h
+    pc_sample_record_collector.cpp
 )
 
 target_include_directories(${target} PUBLIC .)

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/code_object_translator.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/code_object_translator.cpp
@@ -70,3 +70,25 @@ instruction_t code_object_translator_impl_t::get_instruction(size_t object_id, u
               << virtual_address << std::endl;
     return {};
 }
+
+uint64_t code_object_translator_impl_t::get_load_base(size_t object_id) const
+{
+    return m_obj_id_to_load_addr.at(object_id);
+}
+
+void rocprofiler_compute_tool::load_code_object(code_object_translator_t& translator,
+                                                const rocprofiler_callback_tracing_code_object_load_data_t& info)
+{
+    if (info.storage_type == ROCPROFILER_CODE_OBJECT_STORAGE_TYPE_FILE)
+    {
+        translator.add_code_object(info.uri, info.code_object_id, info.load_base, info.load_size);
+    }
+    else if (info.storage_type == ROCPROFILER_CODE_OBJECT_STORAGE_TYPE_MEMORY)
+    {
+        translator.add_code_object(info.memory_base,
+                                   info.memory_size,
+                                   info.code_object_id,
+                                   info.load_base,
+                                   info.load_size);
+    }
+}

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/code_object_translator.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/code_object_translator.h
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier:  MIT
 #pragma once
 
+#include <rocprofiler-sdk/rocprofiler.h>
+
 #include <cstddef>
 #include <cstdint>
 #include <map>
@@ -46,6 +48,7 @@ public:
     virtual const std::vector<size_t>& get_code_object_ids() const                          = 0;
     virtual std::vector<symbol_t>      get_symbols(size_t object_id) const                  = 0;
     virtual instruction_t get_instruction(size_t object_id, uint64_t virtual_address) const = 0;
+    virtual uint64_t      get_load_base(size_t object_id) const                             = 0;
 };
 
 class code_object_translator_impl_t : public code_object_translator_t
@@ -63,11 +66,18 @@ public:
     const std::vector<size_t>& get_code_object_ids() const override;
     std::vector<symbol_t>      get_symbols(size_t object_id) const override;
     instruction_t get_instruction(size_t object_id, uint64_t virtual_address) const override;
+    uint64_t      get_load_base(size_t object_id) const override;
 
 private:
     std::unique_ptr<rocprofiler::sdk::codeobj::disassembly::CodeobjAddressTranslate> m_translator;
     std::vector<size_t>                                                              m_obj_ids;
     std::map<size_t, uint64_t> m_obj_id_to_load_addr;
 };
+
+// Forward a code-object-load event to a translator, dispatching on the SDK
+// storage type. Shared by every collector so the FILE/MEMORY mapping lives in
+// one place.
+void load_code_object(code_object_translator_t&                                   translator,
+                      const rocprofiler_callback_tracing_code_object_load_data_t& info);
 
 }  // namespace rocprofiler_compute_tool

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sample_record_collector.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sample_record_collector.cpp
@@ -1,0 +1,96 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#include "pc_sample_record_collector.h"
+
+#include <iostream>
+#include <set>
+
+using namespace rocprofiler_compute_tool;
+
+pc_sample_record_collector_t::ptr pc_sample_record_collector_t::create(
+    std::shared_ptr<code_object_translator_t> translator)
+{
+    return std::make_shared<pc_sample_record_collector_impl_t>(std::move(translator));
+}
+
+pc_sample_record_collector_impl_t::pc_sample_record_collector_impl_t(
+    std::shared_ptr<code_object_translator_t> translator)
+    : m_translator(std::move(translator))
+{
+}
+
+void pc_sample_record_collector_impl_t::on_code_object_load(
+    const rocprofiler_callback_tracing_code_object_load_data_t& info)
+{
+    load_code_object(*m_translator, info);
+}
+
+void pc_sample_record_collector_impl_t::add_record(const pc_sampling_record_t& rec)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_records.push_back(rec);
+}
+
+void pc_sample_record_collector_impl_t::add_records(const std::vector<pc_sampling_record_t>& recs)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_records.reserve(m_records.size() + recs.size());
+    m_records.insert(m_records.end(), recs.begin(), recs.end());
+}
+
+void pc_sample_record_collector_impl_t::write(ps_file_writer_t& writer)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    const auto&            ids = m_translator->get_code_object_ids();
+    const std::set<size_t> known_ids(ids.begin(), ids.end());
+
+    for (const auto& rec : m_records)
+    {
+        if (known_ids.find(rec.code_object_id) == known_ids.end())
+        {
+            std::clog << "Dropping PC sample for unknown code object id " << rec.code_object_id
+                      << std::endl;
+            continue;
+        }
+        const auto key = std::make_pair(rec.code_object_id, rec.code_object_offset);
+        if (m_inst_index.find(key) == m_inst_index.end())
+        {
+            const int idx = static_cast<int>(m_instructions.size());
+            const uint64_t va = m_translator->get_load_base(rec.code_object_id) + rec.code_object_offset;
+            const auto inst = m_translator->get_instruction(rec.code_object_id, va);
+            m_instructions.push_back(inst.name);
+            m_comments.push_back(inst.comment);
+            m_inst_index[key] = idx;
+        }
+    }
+
+    writer.set_instruction_strings(m_instructions, m_comments);
+
+    for (const auto& id : ids)
+    {
+        for (const auto& sym : m_translator->get_symbols(id))
+        {
+            writer.add_kernel_symbol(id, sym.name);
+        }
+    }
+
+    for (const auto& rec : m_records)
+    {
+        const auto key = std::make_pair(rec.code_object_id, rec.code_object_offset);
+        const auto it  = m_inst_index.find(key);
+        if (it == m_inst_index.end())
+        {
+            continue;
+        }
+        const int idx = it->second;
+        if (rec.is_stochastic)
+        {
+            writer.add_stochastic_sample(idx, rec);
+        }
+        else
+        {
+            writer.add_host_trap_sample(idx, rec);
+        }
+    }
+}

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sample_record_collector.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sample_record_collector.h
@@ -1,0 +1,52 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#pragma once
+#include "code_object_translator.h"
+#include "pc_sampling_record.h"
+#include "ps_file_writer.h"
+
+#include <rocprofiler-sdk/rocprofiler.h>
+
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace rocprofiler_compute_tool
+{
+
+class pc_sample_record_collector_t
+{
+public:
+    using ptr = std::shared_ptr<pc_sample_record_collector_t>;
+    static ptr create(std::shared_ptr<code_object_translator_t> translator);
+
+    virtual ~pc_sample_record_collector_t() = default;
+    virtual void on_code_object_load(const rocprofiler_callback_tracing_code_object_load_data_t& info) = 0;
+    virtual void add_record(const pc_sampling_record_t& rec) = 0;
+    // Append a whole buffer batch under a single lock acquisition.
+    virtual void add_records(const std::vector<pc_sampling_record_t>& recs) = 0;
+    virtual void write(ps_file_writer_t& writer)                            = 0;
+};
+
+class pc_sample_record_collector_impl_t : public pc_sample_record_collector_t
+{
+public:
+    pc_sample_record_collector_impl_t(std::shared_ptr<code_object_translator_t> translator);
+    void on_code_object_load(const rocprofiler_callback_tracing_code_object_load_data_t& info) override;
+    void add_record(const pc_sampling_record_t& rec) override;
+    void add_records(const std::vector<pc_sampling_record_t>& recs) override;
+    void write(ps_file_writer_t& writer) override;
+
+private:
+    std::shared_ptr<code_object_translator_t>    m_translator;
+    std::mutex                                   m_mutex;
+    std::vector<pc_sampling_record_t>            m_records;
+    std::map<std::pair<uint64_t, uint64_t>, int> m_inst_index;
+    std::vector<std::string>                     m_instructions;
+    std::vector<std::string>                     m_comments;
+};
+
+}  // namespace rocprofiler_compute_tool

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sampling_collector.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sampling_collector.cpp
@@ -15,6 +15,12 @@ pc_sampling_collector_t::ptr pc_sampling_collector_t::create()
         std::make_shared<code_object_translator_impl_t>());
 }
 
+pc_sampling_collector_t::ptr pc_sampling_collector_t::create(
+    const std::shared_ptr<code_object_translator_t>& translator)
+{
+    return std::make_shared<pc_sampling_collector_impl_t>(translator);
+}
+
 pc_sampling_collector_impl_t::pc_sampling_collector_impl_t(
     const std::shared_ptr<code_object_translator_t>& translator)
     : m_translator(translator)
@@ -24,18 +30,7 @@ pc_sampling_collector_impl_t::pc_sampling_collector_impl_t(
 void pc_sampling_collector_impl_t::on_code_object_load(
     const rocprofiler_callback_tracing_code_object_load_data_t& info)
 {
-    if (info.storage_type == ROCPROFILER_CODE_OBJECT_STORAGE_TYPE_FILE)
-    {
-        m_translator->add_code_object(info.uri, info.code_object_id, info.load_base, info.load_size);
-    }
-    else if (info.storage_type == ROCPROFILER_CODE_OBJECT_STORAGE_TYPE_MEMORY)
-    {
-        m_translator->add_code_object(info.memory_base,
-                                      info.memory_size,
-                                      info.code_object_id,
-                                      info.load_base,
-                                      info.load_size);
-    }
+    load_code_object(*m_translator, info);
 }
 
 void pc_sampling_collector_impl_t::write(code_object_writer_t& writer)

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sampling_collector.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sampling_collector.h
@@ -23,10 +23,15 @@ class pc_sampling_collector_t
 public:
     using ptr = std::shared_ptr<pc_sampling_collector_t>;
     static ptr create();
+    // Share an existing translator so a single decode of each code object can be
+    // reused by both the code-object writer and the PC-sample collector.
+    static ptr create(const std::shared_ptr<code_object_translator_t>& translator);
 
     virtual ~pc_sampling_collector_t() = default;
     virtual void on_code_object_load(const rocprofiler_callback_tracing_code_object_load_data_t& info) = 0;
     virtual void write(code_object_writer_t& writer) = 0;
+    // The shared translator, so collaborators can decode the same code objects.
+    virtual std::shared_ptr<code_object_translator_t> translator() const = 0;
 };
 
 class pc_sampling_collector_impl_t : public pc_sampling_collector_t
@@ -35,6 +40,8 @@ public:
     pc_sampling_collector_impl_t(const std::shared_ptr<code_object_translator_t>& translator);
     void on_code_object_load(const rocprofiler_callback_tracing_code_object_load_data_t& info) override;
     void write(code_object_writer_t& writer) override;
+
+    std::shared_ptr<code_object_translator_t> translator() const override { return m_translator; }
 
 private:
     std::shared_ptr<code_object_translator_t> m_translator;

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sampling_record.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sampling_record.h
@@ -1,0 +1,23 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+namespace rocprofiler_compute_tool
+{
+struct pc_sampling_record_t
+{
+    uint64_t code_object_id     = 0;
+    uint64_t code_object_offset = 0;
+    uint64_t dispatch_id        = 0;
+    // Only stochastic samples carry an issued/not-issued bit. Host-trap records
+    // have no such field; leaving it unset omits "wave_issued" from the JSON so
+    // the output matches what the rocprofiler-sdk tool emits for host-trap.
+    std::optional<bool>        wave_issued;
+    bool                       is_stochastic = false;
+    std::optional<std::string> stall_reason;  // SDK string WITH full prefix; absent when issued
+};
+}  // namespace rocprofiler_compute_tool

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/ps_file_writer.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/ps_file_writer.cpp
@@ -1,0 +1,124 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#include "ps_file_writer.h"
+
+#include "gsl_assert.h"
+
+#include <fstream>
+#include <iostream>
+#include <utility>
+
+using namespace rocprofiler_compute_tool;
+
+nlohmann::json ps_file_writer_json_t::build_sample(int inst_index, const pc_sampling_record_t& rec)
+{
+    nlohmann::json snapshot = nlohmann::json::object();
+    if (rec.stall_reason.has_value())
+    {
+        snapshot["stall_reason"] = rec.stall_reason.value();
+    }
+
+    nlohmann::json record = nlohmann::json::object({
+        {"pc",
+         nlohmann::json::object({
+             {"code_object_id", rec.code_object_id},
+             {"code_object_offset", rec.code_object_offset},
+         })},
+        {"dispatch_id", rec.dispatch_id},
+        {"snapshot", std::move(snapshot)},
+    });
+
+    // Only stochastic records carry wave_issued; omit it for host-trap to match
+    // the rocprofiler-sdk tool's output exactly.
+    if (rec.wave_issued.has_value())
+    {
+        record["wave_issued"] = rec.wave_issued.value();
+    }
+
+    return nlohmann::json::object({
+        {"inst_index", inst_index},
+        {"record", std::move(record)},
+    });
+}
+
+void ps_file_writer_json_t::add_stochastic_sample(int inst_index, const pc_sampling_record_t& rec)
+{
+    m_stochastic_samples.push_back(build_sample(inst_index, rec));
+}
+
+void ps_file_writer_json_t::add_host_trap_sample(int inst_index, const pc_sampling_record_t& rec)
+{
+    m_host_trap_samples.push_back(build_sample(inst_index, rec));
+}
+
+void ps_file_writer_json_t::set_instruction_strings(const std::vector<std::string>& instructions,
+                                                    const std::vector<std::string>& comments)
+{
+    m_instructions = nlohmann::json::array();
+    for (const auto& inst : instructions)
+    {
+        m_instructions.push_back(inst);
+    }
+
+    m_comments = nlohmann::json::array();
+    for (const auto& comment : comments)
+    {
+        m_comments.push_back(comment);
+    }
+}
+
+void ps_file_writer_json_t::add_kernel_symbol(uint64_t           code_object_id,
+                                              const std::string& formatted_kernel_name)
+{
+    m_kernel_symbols.push_back(nlohmann::json::object({
+        {"code_object_id", code_object_id},
+        {"formatted_kernel_name", formatted_kernel_name},
+    }));
+}
+
+std::string ps_file_writer_json_t::get_result()
+{
+    nlohmann::json tool_entry = nlohmann::json::object({
+        {"buffer_records",
+         nlohmann::json::object({
+             {"pc_sample_stochastic", m_stochastic_samples},
+             {"pc_sample_host_trap", m_host_trap_samples},
+         })},
+        {"strings",
+         nlohmann::json::object({
+             {"pc_sample_instructions", m_instructions},
+             {"pc_sample_comments", m_comments},
+         })},
+        {"kernel_symbols", m_kernel_symbols},
+    });
+
+    return nlohmann::json{{"rocprofiler-sdk-tool", nlohmann::json::array({std::move(tool_entry)})}}.dump();
+}
+
+void ps_file_writer_json_t::flush(const std::filesystem::path& output_file_path)
+{
+    Expects(!output_file_path.empty());
+    create_parent_dir(output_file_path);
+
+    std::ofstream out_file(output_file_path, std::ios::out);
+    if (!out_file.is_open())
+    {
+        std::cerr << "Failed to open output file: " << output_file_path << "\n";
+        return;
+    }
+    out_file << get_result();
+    std::clog << "[rocprofiler-compute] [" << __FUNCTION__
+              << "] PC sampling data has been written to: " << output_file_path << "\n";
+}
+
+void ps_file_writer_json_t::create_parent_dir(const std::filesystem::path& output_file_path)
+{
+    Expects(output_file_path.has_parent_path());
+    std::error_code error;
+    std::filesystem::create_directories(output_file_path.parent_path(), error);
+    if (error)
+    {
+        throw std::runtime_error("Failed to create output directory: " + output_file_path.string() +
+                                 ", error: " + error.message());
+    }
+}

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/ps_file_writer.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/ps_file_writer.h
@@ -1,0 +1,47 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#pragma once
+#include "nlohmann/json.hpp"
+#include "pc_sampling_record.h"
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace rocprofiler_compute_tool
+{
+class ps_file_writer_t
+{
+public:
+    virtual ~ps_file_writer_t()                                                         = default;
+    virtual void add_stochastic_sample(int inst_index, const pc_sampling_record_t& rec) = 0;
+    virtual void add_host_trap_sample(int inst_index, const pc_sampling_record_t& rec)  = 0;
+    virtual void set_instruction_strings(const std::vector<std::string>& instructions,
+                                         const std::vector<std::string>& comments)      = 0;
+    virtual void add_kernel_symbol(uint64_t code_object_id, const std::string& formatted_kernel_name) = 0;
+    virtual std::string get_result()                                         = 0;
+    virtual void        flush(const std::filesystem::path& output_file_path) = 0;
+};
+
+class ps_file_writer_json_t : public ps_file_writer_t
+{
+public:
+    void add_stochastic_sample(int inst_index, const pc_sampling_record_t& rec) override;
+    void add_host_trap_sample(int inst_index, const pc_sampling_record_t& rec) override;
+    void set_instruction_strings(const std::vector<std::string>& instructions,
+                                 const std::vector<std::string>& comments) override;
+    void add_kernel_symbol(uint64_t code_object_id, const std::string& formatted_kernel_name) override;
+    std::string get_result() override;
+    void        flush(const std::filesystem::path& output_file_path) override;
+
+private:
+    static void           create_parent_dir(const std::filesystem::path& output_file_path);
+    static nlohmann::json build_sample(int inst_index, const pc_sampling_record_t& rec);
+
+    nlohmann::json::array_t m_stochastic_samples = nlohmann::json::array();
+    nlohmann::json::array_t m_host_trap_samples  = nlohmann::json::array();
+    nlohmann::json::array_t m_instructions       = nlohmann::json::array();
+    nlohmann::json::array_t m_comments           = nlohmann::json::array();
+    nlohmann::json::array_t m_kernel_symbols     = nlohmann::json::array();
+};
+}  // namespace rocprofiler_compute_tool

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/CMakeLists.txt
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/CMakeLists.txt
@@ -9,6 +9,10 @@ add_executable(
     test_pc_sampling_collector.cpp
     test_code_object_writer.h
     test_code_object_writer.cpp
+    test_ps_file_writer.h
+    test_ps_file_writer.cpp
+    test_pc_sample_record_collector.h
+    test_pc_sample_record_collector.cpp
     mocks.h
     mocks.cpp
 )

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/mocks.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/mocks.cpp
@@ -42,6 +42,20 @@ instruction_t mock_code_object_translator_t::get_instruction(size_t, uint64_t) c
     return m_instruction;
 }
 
+uint64_t mock_code_object_translator_t::get_load_base(size_t object_id) const
+{
+    if (const auto item = m_load_base_per_obj.find(object_id); item != m_load_base_per_obj.end())
+    {
+        return item->second;
+    }
+    return 0;
+}
+
+void mock_code_object_translator_t::set_load_base(size_t object_id, uint64_t load_base)
+{
+    m_load_base_per_obj[object_id] = load_base;
+}
+
 void mock_code_object_translator_t::add_symbols(size_t object_id,
                                                 const std::vector<rocprofiler_compute_tool::symbol_t>& symbols)
 {
@@ -120,4 +134,59 @@ const std::vector<instruction_t>& mock_code_object_writer_t::get_instruction_des
 uint32_t mock_code_object_writer_t::get_end_symbol_count() const
 {
     return m_end_symbol_count;
+}
+
+void mock_ps_file_writer_t::add_stochastic_sample(int inst_index, const pc_sampling_record_t& rec)
+{
+    m_stochastic_samples.emplace_back(inst_index, rec);
+}
+
+void mock_ps_file_writer_t::add_host_trap_sample(int inst_index, const pc_sampling_record_t& rec)
+{
+    m_host_trap_samples.emplace_back(inst_index, rec);
+}
+
+void mock_ps_file_writer_t::set_instruction_strings(const std::vector<std::string>& instructions,
+                                                    const std::vector<std::string>& comments)
+{
+    m_instructions = instructions;
+    m_comments     = comments;
+}
+
+void mock_ps_file_writer_t::add_kernel_symbol(uint64_t           code_object_id,
+                                              const std::string& formatted_kernel_name)
+{
+    m_kernel_symbols.emplace_back(code_object_id, formatted_kernel_name);
+}
+
+std::string mock_ps_file_writer_t::get_result()
+{
+    return {};
+}
+
+void mock_ps_file_writer_t::flush(const std::filesystem::path& output_file_path) {}
+
+const std::vector<std::pair<int, pc_sampling_record_t>>& mock_ps_file_writer_t::get_stochastic_samples() const
+{
+    return m_stochastic_samples;
+}
+
+const std::vector<std::pair<int, pc_sampling_record_t>>& mock_ps_file_writer_t::get_host_trap_samples() const
+{
+    return m_host_trap_samples;
+}
+
+const std::vector<std::string>& mock_ps_file_writer_t::get_instruction_strings() const
+{
+    return m_instructions;
+}
+
+const std::vector<std::string>& mock_ps_file_writer_t::get_comment_strings() const
+{
+    return m_comments;
+}
+
+const std::vector<std::pair<uint64_t, std::string>>& mock_ps_file_writer_t::get_kernel_symbols() const
+{
+    return m_kernel_symbols;
 }

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/mocks.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/mocks.h
@@ -3,9 +3,12 @@
 #pragma once
 #include "code_object_translator.h"
 #include "code_object_writer.h"
+#include "pc_sampling_record.h"
+#include "ps_file_writer.h"
 
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 class mock_code_object_translator_t : public rocprofiler_compute_tool::code_object_translator_t
@@ -39,9 +42,11 @@ public:
     std::vector<rocprofiler_compute_tool::symbol_t> get_symbols(size_t object_id) const override;
     rocprofiler_compute_tool::instruction_t get_instruction(size_t object_id,
                                                             uint64_t virtual_address) const override;
+    uint64_t get_load_base(size_t object_id) const override;
 
     void add_symbols(size_t object_id, const std::vector<rocprofiler_compute_tool::symbol_t>& symbols);
     void add_instruction(const rocprofiler_compute_tool::instruction_t& instruction);
+    void set_load_base(size_t object_id, uint64_t load_base);
 
     const std::vector<mem_code_object_info_t>&  get_mem_code_object_info() const;
     const std::vector<file_code_object_info_t>& get_file_code_object_info() const;
@@ -52,6 +57,7 @@ private:
     std::vector<size_t>                  m_code_object_ids;
     std::unordered_map<size_t, std::vector<rocprofiler_compute_tool::symbol_t>> m_symbols_per_obj;
     rocprofiler_compute_tool::instruction_t m_instruction = {"", "", 0, 0, 1};
+    std::unordered_map<size_t, uint64_t>    m_load_base_per_obj;
 };
 
 class mock_code_object_writer_t : public rocprofiler_compute_tool::code_object_writer_t
@@ -77,4 +83,31 @@ private:
     std::vector<rocprofiler_compute_tool::symbol_t>      m_symbol_descriptions;
     std::vector<rocprofiler_compute_tool::instruction_t> m_instructions;
     uint32_t                                             m_end_symbol_count = 0;
+};
+
+class mock_ps_file_writer_t : public rocprofiler_compute_tool::ps_file_writer_t
+{
+public:
+    void add_stochastic_sample(int                                                   inst_index,
+                               const rocprofiler_compute_tool::pc_sampling_record_t& rec) override;
+    void add_host_trap_sample(int                                                   inst_index,
+                              const rocprofiler_compute_tool::pc_sampling_record_t& rec) override;
+    void set_instruction_strings(const std::vector<std::string>& instructions,
+                                 const std::vector<std::string>& comments) override;
+    void add_kernel_symbol(uint64_t code_object_id, const std::string& formatted_kernel_name) override;
+    std::string get_result() override;
+    void        flush(const std::filesystem::path& output_file_path) override;
+
+    const std::vector<std::pair<int, rocprofiler_compute_tool::pc_sampling_record_t>>& get_stochastic_samples() const;
+    const std::vector<std::pair<int, rocprofiler_compute_tool::pc_sampling_record_t>>& get_host_trap_samples() const;
+    const std::vector<std::string>&                      get_instruction_strings() const;
+    const std::vector<std::string>&                      get_comment_strings() const;
+    const std::vector<std::pair<uint64_t, std::string>>& get_kernel_symbols() const;
+
+private:
+    std::vector<std::pair<int, rocprofiler_compute_tool::pc_sampling_record_t>> m_stochastic_samples;
+    std::vector<std::pair<int, rocprofiler_compute_tool::pc_sampling_record_t>> m_host_trap_samples;
+    std::vector<std::string>                                                    m_instructions;
+    std::vector<std::string>                                                    m_comments;
+    std::vector<std::pair<uint64_t, std::string>>                               m_kernel_symbols;
 };

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_pc_sample_record_collector.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_pc_sample_record_collector.cpp
@@ -1,0 +1,262 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#include "test_pc_sample_record_collector.h"
+
+#include "code_object_translator.h"
+#include "nlohmann/json.hpp"
+#include "ps_file_writer.h"
+
+#include <stdexcept>
+#include <thread>
+#include <vector>
+
+using namespace rocprofiler_compute_tool;
+
+namespace
+{
+pc_sampling_record_t make_record(uint64_t code_object_id,
+                                 uint64_t offset,
+                                 bool     is_stochastic,
+                                 uint64_t dispatch_id = 0)
+{
+    pc_sampling_record_t rec;
+    rec.code_object_id     = code_object_id;
+    rec.code_object_offset = offset;
+    rec.dispatch_id        = dispatch_id;
+    rec.wave_issued        = true;
+    rec.is_stochastic      = is_stochastic;
+    return rec;
+}
+}  // namespace
+
+TEST_F(test_pc_sample_record_collector_t, CollectorAssignsStableInstIndexPerPc)
+{
+    m_collector->add_record(make_record(k_code_object_id, k_offset_a, false));
+    m_collector->add_record(make_record(k_code_object_id, k_offset_a, false));
+    m_collector->write(m_writer);
+
+    const auto& host_trap = m_writer.get_host_trap_samples();
+    ASSERT_EQ(host_trap.size(), 2);
+    EXPECT_EQ(host_trap[0].first, host_trap[1].first);
+
+    // Only one unique PC -> a single instruction/comment entry.
+    EXPECT_EQ(m_writer.get_instruction_strings().size(), 1);
+    EXPECT_EQ(m_writer.get_comment_strings().size(), 1);
+
+    const int idx = host_trap[0].first;
+    ASSERT_GE(idx, 0);
+    ASSERT_LT(static_cast<size_t>(idx), m_writer.get_instruction_strings().size());
+    EXPECT_EQ(m_writer.get_instruction_strings()[idx], "inst0");
+    EXPECT_EQ(m_writer.get_comment_strings()[idx], "comment0");
+}
+
+TEST_F(test_pc_sample_record_collector_t, CollectorRoutesStochasticAndHostTrapSeparately)
+{
+    m_collector->add_record(make_record(k_code_object_id, k_offset_a, true));
+    m_collector->add_record(make_record(k_code_object_id, k_offset_a, false));
+    m_collector->write(m_writer);
+
+    EXPECT_EQ(m_writer.get_stochastic_samples().size(), 1);
+    EXPECT_EQ(m_writer.get_host_trap_samples().size(), 1);
+}
+
+TEST_F(test_pc_sample_record_collector_t, CollectorBuildsKernelSymbolsFromTranslator)
+{
+    const std::vector<symbol_t> symbols = {{"kern(int*)", k_offset_a, k_load_base + k_offset_a, 4}};
+    m_translator->add_symbols(k_code_object_id, symbols);
+
+    m_collector->add_record(make_record(k_code_object_id, k_offset_a, false));
+    m_collector->write(m_writer);
+
+    const auto& kernel_symbols = m_writer.get_kernel_symbols();
+    bool        found          = false;
+    for (const auto& [id, name] : kernel_symbols)
+    {
+        if (id == k_code_object_id && name == "kern(int*)")
+        {
+            found = true;
+        }
+    }
+    EXPECT_TRUE(found);
+}
+
+TEST_F(test_pc_sample_record_collector_t, CollectorBuildsCoIndexedInstructionAndCommentStrings)
+{
+    m_collector->add_record(make_record(k_code_object_id, k_offset_a, false));
+    m_collector->add_record(make_record(k_code_object_id, k_offset_b, false));
+    m_collector->write(m_writer);
+
+    EXPECT_EQ(m_writer.get_instruction_strings().size(), m_writer.get_comment_strings().size());
+    EXPECT_EQ(m_writer.get_instruction_strings().size(), 2);
+}
+
+TEST_F(test_pc_sample_record_collector_t, CollectorEmittedInstIndexInRange)
+{
+    m_collector->add_record(make_record(k_code_object_id, k_offset_a, true));
+    m_collector->add_record(make_record(k_code_object_id, k_offset_b, false));
+    m_collector->add_record(make_record(k_code_object_id, k_offset_a, false));
+    m_collector->write(m_writer);
+
+    const size_t inst_count = m_writer.get_instruction_strings().size();
+    ASSERT_GT(inst_count, 0u);
+
+    for (const auto& [idx, rec] : m_writer.get_stochastic_samples())
+    {
+        EXPECT_GE(idx, 0);
+        EXPECT_LT(static_cast<size_t>(idx), inst_count);
+    }
+    for (const auto& [idx, rec] : m_writer.get_host_trap_samples())
+    {
+        EXPECT_GE(idx, 0);
+        EXPECT_LT(static_cast<size_t>(idx), inst_count);
+    }
+}
+
+TEST_F(test_pc_sample_record_collector_t, CollectorConcurrentAddRecordIsThreadSafe)
+{
+    constexpr int            num_threads = 4;
+    constexpr int            per_thread  = 250;
+    std::vector<std::thread> threads;
+    threads.reserve(num_threads);
+    for (int t = 0; t < num_threads; ++t)
+    {
+        threads.emplace_back(
+            [this]()
+            {
+                for (int i = 0; i < per_thread; ++i)
+                {
+                    m_collector->add_record(make_record(k_code_object_id, k_offset_a, false));
+                }
+            });
+    }
+    for (auto& thread : threads)
+    {
+        thread.join();
+    }
+
+    m_collector->write(m_writer);
+
+    const size_t total = m_writer.get_stochastic_samples().size() +
+                         m_writer.get_host_trap_samples().size();
+    EXPECT_EQ(total, static_cast<size_t>(num_threads * per_thread));
+}
+
+TEST_F(test_pc_sample_record_collector_t, CollectorRoundTripsThroughJsonWriter)
+{
+    constexpr int         num_records = 5;
+    ps_file_writer_json_t json_writer;
+    for (int i = 0; i < num_records; ++i)
+    {
+        m_collector->add_record(make_record(k_code_object_id, k_offset_a, false, i));
+    }
+    m_collector->write(json_writer);
+
+    const auto  parsed         = nlohmann::json::parse(json_writer.get_result());
+    const auto& buffer_records = parsed.at("rocprofiler-sdk-tool").at(0).at("buffer_records");
+
+    const size_t stochastic = buffer_records.at("pc_sample_stochastic").size();
+    const size_t host_trap  = buffer_records.at("pc_sample_host_trap").size();
+    EXPECT_EQ(stochastic + host_trap, static_cast<size_t>(num_records));
+
+    for (const auto& sample : buffer_records.at("pc_sample_host_trap"))
+    {
+        const auto& pc = sample.at("record").at("pc");
+        EXPECT_EQ(pc.at("code_object_id").get<uint64_t>(), k_code_object_id);
+        EXPECT_EQ(pc.at("code_object_offset").get<uint64_t>(), k_offset_a);
+    }
+}
+
+TEST_F(test_pc_sample_record_collector_t, CollectorSkipsRecordsForUnknownCodeObject)
+{
+    constexpr uint64_t unknown_id = 999;
+    m_collector->add_record(make_record(unknown_id, k_offset_a, false));
+    EXPECT_NO_THROW(m_collector->write(m_writer));
+
+    EXPECT_TRUE(m_writer.get_stochastic_samples().empty());
+    EXPECT_TRUE(m_writer.get_host_trap_samples().empty());
+}
+
+TEST_F(test_pc_sample_record_collector_t, CollectorEmitsEmptyInstructionForUndecodablePc)
+{
+    // An undecodable PC: the translator returns an empty instruction (no name/comment).
+    const instruction_t empty_instruction = {"", "", k_load_base + k_offset_a, k_offset_a, 4};
+    m_translator->add_instruction(empty_instruction);
+
+    m_collector->add_record(make_record(k_code_object_id, k_offset_a, false));
+    m_collector->write(m_writer);
+
+    const auto& host_trap = m_writer.get_host_trap_samples();
+    ASSERT_EQ(host_trap.size(), 1);
+
+    const int idx = host_trap[0].first;
+    ASSERT_GE(idx, 0);
+    ASSERT_LT(static_cast<size_t>(idx), m_writer.get_instruction_strings().size());
+    EXPECT_EQ(m_writer.get_instruction_strings()[idx], "");
+}
+
+TEST_F(test_pc_sample_record_collector_t, CollectorAssignsDistinctInstIndexForDistinctPcs)
+{
+    m_collector->add_record(make_record(k_code_object_id, k_offset_a, false));
+    m_collector->add_record(make_record(k_code_object_id, k_offset_b, false));
+    m_collector->write(m_writer);
+
+    const auto& host_trap = m_writer.get_host_trap_samples();
+    ASSERT_EQ(host_trap.size(), 2);
+    EXPECT_NE(host_trap[0].first, host_trap[1].first);
+
+    const size_t inst_count = m_writer.get_instruction_strings().size();
+    for (const auto& [idx, rec] : host_trap)
+    {
+        EXPECT_GE(idx, 0);
+        EXPECT_LT(static_cast<size_t>(idx), inst_count);
+    }
+}
+
+TEST_F(test_pc_sample_record_collector_t, CollectorForwardsMemoryStorageCodeObject)
+{
+    rocprofiler_callback_tracing_code_object_load_data_t mem_info = {};
+    mem_info.storage_type   = ROCPROFILER_CODE_OBJECT_STORAGE_TYPE_MEMORY;
+    mem_info.memory_base    = 0x5000;
+    mem_info.memory_size    = 0x800;
+    mem_info.code_object_id = 444;
+    mem_info.load_base      = 0x6000;
+    mem_info.load_size      = 0x900;
+
+    m_collector->on_code_object_load(mem_info);
+
+    const auto& mem_info_captured = m_translator->get_mem_code_object_info();
+    ASSERT_FALSE(mem_info_captured.empty());
+    const auto& entry = mem_info_captured.back();
+    EXPECT_EQ(entry.memory_base, mem_info.memory_base);
+    EXPECT_EQ(entry.memory_size, mem_info.memory_size);
+    EXPECT_EQ(entry.id, mem_info.code_object_id);
+    EXPECT_EQ(entry.load_base, mem_info.load_base);
+    EXPECT_EQ(entry.load_size, mem_info.load_size);
+}
+
+TEST_F(test_pc_sample_record_collector_t, TranslatorGetLoadBaseThrowsForUnknownId)
+{
+    code_object_translator_impl_t real_translator;
+    EXPECT_THROW(real_translator.get_load_base(12345), std::out_of_range);
+}
+
+void test_pc_sample_record_collector_t::SetUp()
+{
+    m_translator = std::make_shared<mock_code_object_translator_t>();
+    m_collector  = pc_sample_record_collector_t::create(m_translator);
+
+    m_file_info.storage_type   = ROCPROFILER_CODE_OBJECT_STORAGE_TYPE_FILE;
+    m_file_info.uri            = "test_code_object.co";
+    m_file_info.code_object_id = k_code_object_id;
+    m_file_info.load_base      = k_load_base;
+    m_file_info.load_size      = 0x2000;
+
+    // Registers the code object id with the mock translator (via add_code_object).
+    m_collector->on_code_object_load(m_file_info);
+
+    m_translator->set_load_base(k_code_object_id, k_load_base);
+    const std::vector<symbol_t> symbols = {{"name0", k_offset_a, k_load_base + k_offset_a, 4}};
+    m_translator->add_symbols(k_code_object_id, symbols);
+    const instruction_t instruction = {"inst0", "comment0", k_load_base + k_offset_a, k_offset_a, 4};
+    m_translator->add_instruction(instruction);
+}

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_pc_sample_record_collector.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_pc_sample_record_collector.h
@@ -1,0 +1,25 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#pragma once
+#include "gtest/gtest.h"
+#include "mocks.h"
+#include "pc_sample_record_collector.h"
+#include "pc_sampling_record.h"
+
+#include <memory>
+
+class test_pc_sample_record_collector_t : public ::testing::Test
+{
+protected:
+    void SetUp() override;
+
+    static constexpr uint64_t k_code_object_id = 222;
+    static constexpr uint64_t k_load_base      = 0x1000;
+    static constexpr uint64_t k_offset_a       = 0x10;
+    static constexpr uint64_t k_offset_b       = 0x20;
+
+    std::shared_ptr<mock_code_object_translator_t>              m_translator;
+    mock_ps_file_writer_t                                       m_writer;
+    rocprofiler_compute_tool::pc_sample_record_collector_t::ptr m_collector;
+    rocprofiler_callback_tracing_code_object_load_data_t        m_file_info = {};
+};

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_ps_file_writer.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_ps_file_writer.cpp
@@ -1,0 +1,210 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#include "test_ps_file_writer.h"
+
+#include "nlohmann/json.hpp"
+
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+
+namespace
+{
+nlohmann::json tool_node(const std::string& serialized)
+{
+    const auto json = nlohmann::json::parse(serialized);
+    return json["rocprofiler-sdk-tool"][0];
+}
+}  // namespace
+
+TEST_F(test_ps_file_writer_t, PsFileWriterEmitsStochasticSamplesInOrder)
+{
+    rocprofiler_compute_tool::pc_sampling_record_t rec0{};
+    rec0.code_object_id     = 1;
+    rec0.code_object_offset = 0x10;
+    rec0.dispatch_id        = 5;
+    rec0.wave_issued        = true;
+    rec0.is_stochastic      = true;
+    rec0.stall_reason       = std::nullopt;
+
+    rocprofiler_compute_tool::pc_sampling_record_t rec1{};
+    rec1.code_object_id     = 2;
+    rec1.code_object_offset = 0x20;
+    rec1.dispatch_id        = 6;
+    rec1.wave_issued        = false;
+    rec1.is_stochastic      = true;
+    rec1.stall_reason = "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ALU_DEPENDENCY";
+
+    m_writer.add_stochastic_sample(0, rec0);
+    m_writer.add_stochastic_sample(1, rec1);
+
+    const auto  node       = tool_node(m_writer.get_result());
+    const auto& stochastic = node["buffer_records"]["pc_sample_stochastic"];
+    ASSERT_EQ(stochastic.size(), 2u);
+
+    EXPECT_EQ(stochastic[0]["inst_index"], 0);
+    EXPECT_EQ(stochastic[0]["record"]["pc"]["code_object_id"], 1);
+    EXPECT_EQ(stochastic[0]["record"]["pc"]["code_object_offset"], 0x10);
+    EXPECT_EQ(stochastic[0]["record"]["dispatch_id"], 5);
+    EXPECT_EQ(stochastic[0]["record"]["wave_issued"], true);
+    EXPECT_FALSE(stochastic[0]["record"]["snapshot"].contains("stall_reason"));
+
+    EXPECT_EQ(stochastic[1]["inst_index"], 1);
+    EXPECT_EQ(stochastic[1]["record"]["wave_issued"], false);
+    EXPECT_EQ(stochastic[1]["record"]["snapshot"]["stall_reason"],
+              "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ALU_DEPENDENCY");
+}
+
+TEST_F(test_ps_file_writer_t, PsFileWriterEmitsHostTrapSamplesSeparately)
+{
+    rocprofiler_compute_tool::pc_sampling_record_t rec{};
+    rec.code_object_id     = 3;
+    rec.code_object_offset = 0x30;
+    rec.dispatch_id        = 7;
+    rec.wave_issued        = true;
+    rec.is_stochastic      = false;
+
+    m_writer.add_host_trap_sample(0, rec);
+
+    const auto  node    = tool_node(m_writer.get_result());
+    const auto& records = node["buffer_records"];
+    ASSERT_EQ(records["pc_sample_host_trap"].size(), 1u);
+    EXPECT_EQ(records["pc_sample_stochastic"].size(), 0u);
+    EXPECT_EQ(records["pc_sample_host_trap"][0]["inst_index"], 0);
+    EXPECT_EQ(records["pc_sample_host_trap"][0]["record"]["pc"]["code_object_id"], 3);
+}
+
+TEST_F(test_ps_file_writer_t, PsFileWriterOmitsWaveIssuedForHostTrap)
+{
+    rocprofiler_compute_tool::pc_sampling_record_t rec{};
+    rec.code_object_id     = 4;
+    rec.code_object_offset = 0x40;
+    rec.dispatch_id        = 9;
+    rec.is_stochastic      = false;
+    // wave_issued left UNSET (nullopt) for host-trap records.
+
+    m_writer.add_host_trap_sample(0, rec);
+
+    const auto  node   = tool_node(m_writer.get_result());
+    const auto& record = node["buffer_records"]["pc_sample_host_trap"][0]["record"];
+    EXPECT_FALSE(record.contains("wave_issued"));
+}
+
+TEST_F(test_ps_file_writer_t, PsFileWriterEmitsWaveIssuedForStochastic)
+{
+    rocprofiler_compute_tool::pc_sampling_record_t rec{};
+    rec.code_object_id     = 5;
+    rec.code_object_offset = 0x50;
+    rec.dispatch_id        = 10;
+    rec.wave_issued        = true;
+    rec.is_stochastic      = true;
+
+    m_writer.add_stochastic_sample(0, rec);
+
+    const auto  node   = tool_node(m_writer.get_result());
+    const auto& record = node["buffer_records"]["pc_sample_stochastic"][0]["record"];
+    ASSERT_TRUE(record.contains("wave_issued"));
+    EXPECT_EQ(record["wave_issued"], true);
+}
+
+TEST_F(test_ps_file_writer_t, PsFileWriterOmitsStallReasonWhenIssued)
+{
+    rocprofiler_compute_tool::pc_sampling_record_t rec{};
+    rec.code_object_id = 1;
+    rec.dispatch_id    = 1;
+    rec.wave_issued    = true;
+    rec.is_stochastic  = true;
+    rec.stall_reason   = std::nullopt;
+
+    m_writer.add_stochastic_sample(0, rec);
+
+    const auto  node     = tool_node(m_writer.get_result());
+    const auto& snapshot = node["buffer_records"]["pc_sample_stochastic"][0]["record"]["snapshot"];
+    EXPECT_FALSE(snapshot.contains("stall_reason"));
+}
+
+TEST_F(test_ps_file_writer_t, PsFileWriterEmitsPrefixedStallReasonWhenStalled)
+{
+    rocprofiler_compute_tool::pc_sampling_record_t rec{};
+    rec.code_object_id = 1;
+    rec.dispatch_id    = 1;
+    rec.wave_issued    = false;
+    rec.is_stochastic  = true;
+    rec.stall_reason   = "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_WAITCNT";
+
+    m_writer.add_stochastic_sample(0, rec);
+
+    const auto  node     = tool_node(m_writer.get_result());
+    const auto& snapshot = node["buffer_records"]["pc_sample_stochastic"][0]["record"]["snapshot"];
+    EXPECT_EQ(snapshot["stall_reason"], "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_WAITCNT");
+}
+
+TEST_F(test_ps_file_writer_t, PsFileWriterStringsAndKernelSymbolsSerialized)
+{
+    m_writer.set_instruction_strings({"s_load", "v_add"}, {"line1", "line2"});
+    m_writer.add_kernel_symbol(7, "vcopy(int*)");
+
+    const auto  node    = tool_node(m_writer.get_result());
+    const auto& strings = node["strings"];
+    ASSERT_EQ(strings["pc_sample_instructions"].size(), 2u);
+    EXPECT_EQ(strings["pc_sample_instructions"][0], "s_load");
+    EXPECT_EQ(strings["pc_sample_instructions"][1], "v_add");
+    ASSERT_EQ(strings["pc_sample_comments"].size(), 2u);
+    EXPECT_EQ(strings["pc_sample_comments"][0], "line1");
+    EXPECT_EQ(strings["pc_sample_comments"][1], "line2");
+
+    const auto& kernel_symbols = node["kernel_symbols"];
+    ASSERT_EQ(kernel_symbols.size(), 1u);
+    EXPECT_EQ(kernel_symbols[0]["code_object_id"], 7);
+    EXPECT_EQ(kernel_symbols[0]["formatted_kernel_name"], "vcopy(int*)");
+}
+
+TEST_F(test_ps_file_writer_t, PsFileWriterEmptyHasFullTopLevelShape)
+{
+    const auto json = nlohmann::json::parse(m_writer.get_result());
+    ASSERT_TRUE(json.contains("rocprofiler-sdk-tool"));
+    ASSERT_TRUE(json["rocprofiler-sdk-tool"].is_array());
+    ASSERT_EQ(json["rocprofiler-sdk-tool"].size(), 1u);
+
+    const auto& node = json["rocprofiler-sdk-tool"][0];
+    ASSERT_TRUE(node.contains("buffer_records"));
+    EXPECT_TRUE(node["buffer_records"]["pc_sample_stochastic"].is_array());
+    EXPECT_EQ(node["buffer_records"]["pc_sample_stochastic"].size(), 0u);
+    EXPECT_TRUE(node["buffer_records"]["pc_sample_host_trap"].is_array());
+    EXPECT_EQ(node["buffer_records"]["pc_sample_host_trap"].size(), 0u);
+
+    ASSERT_TRUE(node.contains("strings"));
+    EXPECT_TRUE(node["strings"]["pc_sample_instructions"].is_array());
+    EXPECT_EQ(node["strings"]["pc_sample_instructions"].size(), 0u);
+    EXPECT_TRUE(node["strings"]["pc_sample_comments"].is_array());
+    EXPECT_EQ(node["strings"]["pc_sample_comments"].size(), 0u);
+
+    ASSERT_TRUE(node.contains("kernel_symbols"));
+    EXPECT_TRUE(node["kernel_symbols"].is_array());
+    EXPECT_EQ(node["kernel_symbols"].size(), 0u);
+}
+
+TEST_F(test_ps_file_writer_t, PsFileWriterFlushWritesFile)
+{
+    rocprofiler_compute_tool::pc_sampling_record_t rec{};
+    rec.code_object_id = 1;
+    rec.dispatch_id    = 1;
+    rec.wave_issued    = true;
+    rec.is_stochastic  = true;
+    m_writer.add_stochastic_sample(0, rec);
+
+    const auto path = std::filesystem::temp_directory_path() /
+                      "test_ps_file_writer_flush_output.json";
+    std::filesystem::remove(path);
+
+    m_writer.flush(path);
+    ASSERT_TRUE(std::filesystem::exists(path));
+
+    std::ifstream in(path);
+    const std::string contents((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    in.close();
+
+    EXPECT_EQ(nlohmann::json::parse(contents), nlohmann::json::parse(m_writer.get_result()));
+
+    std::filesystem::remove(path);
+}

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_ps_file_writer.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_ps_file_writer.h
@@ -1,0 +1,16 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#pragma once
+
+#include "gtest/gtest.h"
+#include "pc_sampling_record.h"
+#include "ps_file_writer.h"
+
+#include <filesystem>
+#include <optional>
+
+class test_ps_file_writer_t : public ::testing::Test
+{
+protected:
+    rocprofiler_compute_tool::ps_file_writer_json_t m_writer;
+};

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/pc_sampling_feature.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/pc_sampling_feature.cpp
@@ -2,9 +2,97 @@
 // SPDX-License-Identifier:  MIT
 #include "pc_sampling_feature.h"
 
+#include "code_object_translator.h"
 #include "code_object_writer.h"
+#include "ps_file_writer.h"
+
+#include <rocprofiler-sdk/agent.h>
+#include <rocprofiler-sdk/pc_sampling.h>
+
+#include <iostream>
 
 using namespace rocprofiler_compute_tool;
+
+namespace
+{
+constexpr size_t k_pc_buffer_size      = 4 * 1024 * 1024;
+constexpr size_t k_pc_buffer_watermark = k_pc_buffer_size / 2;
+
+rocprofiler_pc_sampling_method_t to_sdk_method(PcSamplingMode mode)
+{
+    switch (mode)
+    {
+    case PcSamplingMode::Stochastic:
+        return ROCPROFILER_PC_SAMPLING_METHOD_STOCHASTIC;
+    case PcSamplingMode::HostTrap:
+        return ROCPROFILER_PC_SAMPLING_METHOD_HOST_TRAP;
+    case PcSamplingMode::Disabled:
+    default:
+        return ROCPROFILER_PC_SAMPLING_METHOD_NONE;
+    }
+}
+
+// Threaded through the SDK C callbacks to capture the chosen agent + config.
+struct configure_ctx_t
+{
+    rocprofiler_pc_sampling_method_t wanted_method = ROCPROFILER_PC_SAMPLING_METHOD_NONE;
+    bool                             found         = false;
+    rocprofiler_agent_id_t           agent_id{0};
+    rocprofiler_pc_sampling_unit_t   unit{ROCPROFILER_PC_SAMPLING_UNIT_NONE};
+    uint64_t                         interval = 0;
+};
+
+rocprofiler_status_t pc_sampling_config_cb(const rocprofiler_pc_sampling_configuration_t* configs,
+                                           size_t num_config,
+                                           void*  user_data)
+{
+    auto* cctx = static_cast<configure_ctx_t*>(user_data);
+    for (size_t i = 0; i < num_config && !cctx->found; ++i)
+    {
+        if (configs[i].method == cctx->wanted_method)
+        {
+            cctx->found = true;
+            cctx->unit  = configs[i].unit;
+            // Choose a supported interval from the queried config. min_interval
+            // is the highest-frequency (smallest-period) value the agent allows.
+            cctx->interval = configs[i].min_interval;
+        }
+    }
+    return ROCPROFILER_STATUS_SUCCESS;
+}
+
+rocprofiler_status_t available_agents_cb(rocprofiler_agent_version_t version,
+                                         const void**                agents,
+                                         size_t                      num_agents,
+                                         void*                       user_data)
+{
+    if (version != ROCPROFILER_AGENT_INFO_VERSION_0)
+        return ROCPROFILER_STATUS_SUCCESS;
+
+    auto* both = static_cast<std::pair<SdkWrapper*, configure_ctx_t*>*>(user_data);
+    auto* sdk  = both->first;
+    auto* cctx = both->second;
+
+    for (size_t i = 0; i < num_agents && !cctx->found; ++i)
+    {
+        const auto* agent = static_cast<const rocprofiler_agent_v0_t*>(agents[i]);
+        if (agent == nullptr || agent->type != ROCPROFILER_AGENT_TYPE_GPU)
+            continue;
+
+        configure_ctx_t per_agent;
+        per_agent.wanted_method = cctx->wanted_method;
+        sdk->query_pc_sampling_agent_configurations(agent->id, pc_sampling_config_cb, &per_agent);
+        if (per_agent.found)
+        {
+            cctx->found    = true;
+            cctx->agent_id = agent->id;
+            cctx->unit     = per_agent.unit;
+            cctx->interval = per_agent.interval;
+        }
+    }
+    return ROCPROFILER_STATUS_SUCCESS;
+}
+}  // namespace
 
 PcSamplingMode rocprofiler_compute_tool::parse_pc_sampling_mode(const std::string& mode)
 {
@@ -16,7 +104,10 @@ PcSamplingMode rocprofiler_compute_tool::parse_pc_sampling_mode(const std::strin
 }
 
 pc_sampling_feature_t::pc_sampling_feature_t(PcSamplingMode mode, std::filesystem::path output_path)
-    : pc_sampling_feature_t(mode, std::move(output_path), pc_sampling_collector_t::create())
+    : pc_sampling_feature_t(mode,
+                            std::move(output_path),
+                            pc_sampling_collector_t::create(
+                                std::make_shared<code_object_translator_impl_t>()))
 {
 }
 
@@ -28,10 +119,15 @@ pc_sampling_feature_t::pc_sampling_feature_t(PcSamplingMode               mode,
     , m_output_path(std::move(output_path))
     , m_collector(std::move(collector))
 {
+    // Share one translator (and therefore one decode of each code object)
+    // between the code-object writer and the PC-sample collector.
+    m_record_collector = pc_sample_record_collector_t::create(m_collector->translator());
 }
 
 void pc_sampling_feature_t::on_code_object_load(const rocprofiler_callback_tracing_code_object_load_data_t& info)
 {
+    // A single shared translator backs both collectors, so one load call decodes
+    // each code object exactly once.
     m_collector->on_code_object_load(info);
 }
 
@@ -40,4 +136,143 @@ void pc_sampling_feature_t::finalize()
     code_object_writer_json_t writer;
     m_collector->write(writer);
     writer.flush(m_output_path);
+}
+
+void pc_sampling_feature_t::configure(SdkWrapper&                     sdk,
+                                      rocprofiler_buffer_tracing_cb_t buffer_cb,
+                                      void*                           buffer_cb_data)
+{
+    if (!m_enabled)
+        return;
+
+    const auto method = to_sdk_method(m_mode);
+    if (method == ROCPROFILER_PC_SAMPLING_METHOD_NONE)
+    {
+        std::clog << "[rocprofiler-compute] PC sampling mode disabled; skipping configure\n";
+        return;
+    }
+
+    configure_ctx_t cctx;
+    cctx.wanted_method = method;
+
+    std::pair<SdkWrapper*, configure_ctx_t*> agents_data{&sdk, &cctx};
+    sdk.query_available_agents(available_agents_cb, sizeof(rocprofiler_agent_v0_t), &agents_data);
+
+    if (!cctx.found)
+    {
+        std::clog << "[rocprofiler-compute] No GPU agent reported a matching PC sampling "
+                     "configuration; skipping\n";
+        return;
+    }
+
+    sdk.create_buffer(m_pc_context,
+                      k_pc_buffer_size,
+                      k_pc_buffer_watermark,
+                      ROCPROFILER_BUFFER_POLICY_LOSSLESS,
+                      buffer_cb,
+                      buffer_cb_data,
+                      &m_pc_buffer);
+
+    const auto status = sdk.configure_pc_sampling_service(m_pc_context,
+                                                          cctx.agent_id,
+                                                          method,
+                                                          cctx.unit,
+                                                          cctx.interval,
+                                                          m_pc_buffer,
+                                                          0);
+    if (status != ROCPROFILER_STATUS_SUCCESS)
+    {
+        std::clog << "[rocprofiler-compute] configure_pc_sampling_service failed (status=" << status
+                  << "); skipping\n";
+        m_pc_buffer = rocprofiler_buffer_id_t{0};
+    }
+}
+
+void pc_sampling_feature_t::start(SdkWrapper& sdk)
+{
+    if (m_pc_buffer.handle != 0)
+        sdk.start_context(m_pc_context);
+}
+
+void pc_sampling_feature_t::on_sample_records(rocprofiler_record_header_t** headers, size_t count)
+{
+    if (!m_record_collector)
+        return;
+
+    // Decode the whole batch locally, then append in one locked call to avoid
+    // taking the collector mutex once per record on this hot callback path.
+    std::vector<pc_sampling_record_t> batch;
+    batch.reserve(count);
+
+    for (size_t i = 0; i < count; ++i)
+    {
+        auto* header = headers[i];
+        if (header == nullptr || header->category != ROCPROFILER_BUFFER_CATEGORY_PC_SAMPLING)
+            continue;
+
+        switch (header->kind)
+        {
+        case ROCPROFILER_PC_SAMPLING_RECORD_HOST_TRAP_V0_SAMPLE:
+        {
+            const auto* p = static_cast<rocprofiler_pc_sampling_record_host_trap_v0_t*>(header->payload);
+            pc_sampling_record_t rec{};
+            rec.code_object_id     = p->pc.code_object_id;
+            rec.code_object_offset = p->pc.code_object_offset;
+            rec.dispatch_id        = p->dispatch_id;
+            // Host-trap records carry no wave_issued field; leave it unset.
+            rec.is_stochastic = false;
+            batch.push_back(std::move(rec));
+            break;
+        }
+        case ROCPROFILER_PC_SAMPLING_RECORD_STOCHASTIC_V0_SAMPLE:
+        {
+            const auto* p = static_cast<rocprofiler_pc_sampling_record_stochastic_v0_t*>(header->payload);
+            pc_sampling_record_t rec{};
+            rec.code_object_id     = p->pc.code_object_id;
+            rec.code_object_offset = p->pc.code_object_offset;
+            rec.dispatch_id        = p->dispatch_id;
+            const bool wave_issued = (p->wave_issued != 0);
+            rec.wave_issued        = wave_issued;
+            rec.is_stochastic      = true;
+            if (!wave_issued)
+            {
+                const char* reason = rocprofiler_get_pc_sampling_instruction_not_issued_reason_name(
+                    static_cast<rocprofiler_pc_sampling_instruction_not_issued_reason_t>(
+                        p->snapshot.reason_not_issued));
+                if (reason != nullptr)
+                    rec.stall_reason = std::string{reason};
+            }
+            batch.push_back(std::move(rec));
+            break;
+        }
+        default:
+            std::clog << "[rocprofiler-compute] Skipped unrecognized PC sampling record kind: "
+                      << header->kind << "\n";
+            break;
+        }
+    }
+
+    if (!batch.empty())
+        m_record_collector->add_records(batch);
+}
+
+void pc_sampling_feature_t::stop_and_flush(SdkWrapper& sdk)
+{
+    if (m_pc_buffer.handle == 0)
+        return;
+
+    // Stop sampling, then flush so every buffered record below the watermark is
+    // delivered to on_sample_records before finalize_samples serializes them.
+    sdk.stop_context(m_pc_context);
+    sdk.flush_buffer(m_pc_buffer);
+}
+
+void pc_sampling_feature_t::finalize_samples()
+{
+    if (!m_enabled || m_ps_output_path.empty() || !m_record_collector)
+        return;
+
+    ps_file_writer_json_t writer;
+    m_record_collector->write(writer);
+    writer.flush(m_ps_output_path);
 }

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/pc_sampling_feature.h
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/pc_sampling_feature.h
@@ -1,7 +1,12 @@
 // Copyright (c) Advanced Micro Devices, Inc.
 // SPDX-License-Identifier:  MIT
 #pragma once
+#include "pc_sample_record_collector.h"
 #include "pc_sampling_collector.h"
+#include "sdk_wrapper.h"
+
+#include <rocprofiler-sdk/buffer_tracing.h>
+#include <rocprofiler-sdk/fwd.h>
 
 #include <filesystem>
 #include <string>
@@ -25,13 +30,43 @@ public:
 
     const std::filesystem::path& output_path() const { return m_output_path; }
 
+    // Path to the SDK-equivalent ps_file_results.json. The SDK consumer reads
+    // exactly <workload>/ps_file_results.json, so this path carries NO pid prefix.
+    void set_ps_output_path(std::filesystem::path p) { m_ps_output_path = std::move(p); }
+
+    // PC sampling must use a context separate from counter collection.
+    void set_pc_context(rocprofiler_context_id_t ctx) { m_pc_context = ctx; }
+
     void on_code_object_load(const rocprofiler_callback_tracing_code_object_load_data_t& info);
     void finalize();
 
+    // Query GPU agents, pick a config matching m_mode, create a buffer on the PC
+    // context and configure the PC sampling service. Gracefully skips on failure.
+    void configure(SdkWrapper& sdk, rocprofiler_buffer_tracing_cb_t buffer_cb, void* buffer_cb_data);
+
+    // Start the PC sampling context (only if a buffer was actually created).
+    void start(SdkWrapper& sdk);
+
+    // Decode buffered PC sampling records and push them to the record collector.
+    void on_sample_records(rocprofiler_record_header_t** headers, size_t count);
+
+    // Stop the PC context and flush the PC buffer so all buffered samples are
+    // delivered to on_sample_records before finalize_samples serializes them.
+    // The SDK does not auto-flush on teardown, so without this the output file
+    // would omit any samples still sitting below the buffer watermark.
+    void stop_and_flush(SdkWrapper& sdk);
+
+    // Write ps_file_results.json via ps_file_writer_json_t.
+    void finalize_samples();
+
 private:
-    bool                         m_enabled = false;
-    PcSamplingMode               m_mode    = PcSamplingMode::Disabled;
-    std::filesystem::path        m_output_path;
-    pc_sampling_collector_t::ptr m_collector;
+    bool                              m_enabled = false;
+    PcSamplingMode                    m_mode    = PcSamplingMode::Disabled;
+    std::filesystem::path             m_output_path;
+    pc_sampling_collector_t::ptr      m_collector;
+    pc_sample_record_collector_t::ptr m_record_collector{};
+    rocprofiler_context_id_t          m_pc_context{0};
+    rocprofiler_buffer_id_t           m_pc_buffer{0};
+    std::filesystem::path             m_ps_output_path{};
 };
 }  // namespace rocprofiler_compute_tool

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/rocprofiler_compute_tool.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/rocprofiler_compute_tool.cpp
@@ -11,6 +11,7 @@
 #include <unistd.h>
 
 #include <atomic>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <sstream>
@@ -83,6 +84,18 @@ void record_callback(rocprofiler_dispatch_counting_service_data_t dispatch_data,
     g_sdk_callbacks->record_callback(dispatch_data, record_data, record_count, callback_data_args);
 }
 
+void pc_sampling_buffer_callback(rocprofiler_context_id_t /*context_id*/,
+                                 rocprofiler_buffer_id_t /*buffer_id*/,
+                                 rocprofiler_record_header_t** headers,
+                                 size_t                        num_headers,
+                                 void*                         user_data,
+                                 uint64_t /*drop_count*/)
+{
+    assert(user_data);
+    auto* tool_data = static_cast<std::unique_ptr<tool_data_t>*>(user_data)->get();
+    tool_data->pc_sampling.on_sample_records(headers, num_headers);
+}
+
 void tool_tracing_callback(rocprofiler_callback_tracing_record_t record,
                            rocprofiler_user_data_t* /*user_data*/,
                            void* callback_data)
@@ -121,12 +134,27 @@ void on_hsa_runtime_loaded(rocprofiler_intercept_table_t /*type*/,
     if (g_hsa_intercept_done.exchange(true, std::memory_order_acq_rel))
         return;
 
-    g_sdk_wrapper->configure_callback_dispatch_counting_service(get_client_ctx(),
-                                                                dispatch_callback,
-                                                                user_data,
-                                                                record_callback,
-                                                                user_data);
-    g_sdk_wrapper->start_context(get_client_ctx());
+    assert(user_data);
+    auto* tool_data = static_cast<std::unique_ptr<tool_data_t>*>(user_data)->get();
+
+    // Only set up counter dispatch-counting when counters were actually
+    // requested. PC sampling and counter collection must not share a context;
+    // gating here also avoids starting an unused counter service.
+    if (!tool_data->requested_counters.empty())
+    {
+        g_sdk_wrapper->configure_callback_dispatch_counting_service(get_client_ctx(),
+                                                                    dispatch_callback,
+                                                                    user_data,
+                                                                    record_callback,
+                                                                    user_data);
+        g_sdk_wrapper->start_context(get_client_ctx());
+    }
+
+    if (tool_data->pc_sampling.enabled())
+    {
+        tool_data->pc_sampling.configure(*g_sdk_wrapper, &pc_sampling_buffer_callback, user_data);
+        tool_data->pc_sampling.start(*g_sdk_wrapper);
+    }
 }
 
 int tool_init(rocprofiler_client_finalize_t, void* user_data)
@@ -140,6 +168,17 @@ int tool_init(rocprofiler_client_finalize_t, void* user_data)
                                                       0,
                                                       tool_tracing_callback,
                                                       user_data);
+
+    // PC sampling must live in its own context, separate from counter
+    // collection (the SDK forbids both services sharing a context).
+    assert(user_data);
+    auto* tool_data = static_cast<std::unique_ptr<tool_data_t>*>(user_data)->get();
+    if (tool_data->pc_sampling.enabled())
+    {
+        rocprofiler_context_id_t pc_ctx{};
+        g_sdk_wrapper->create_context(&pc_ctx);
+        tool_data->pc_sampling.set_pc_context(pc_ctx);
+    }
     return 0;
 }
 
@@ -166,7 +205,10 @@ void generate_output(tool_data_t* tool_data)
     }
 
     if (tool_data->pc_sampling.enabled())
+    {
         tool_data->pc_sampling.finalize();
+        tool_data->pc_sampling.finalize_samples();
+    }
 }
 
 void tool_fini(void* user_data)
@@ -177,6 +219,13 @@ void tool_fini(void* user_data)
     rocprofiler_stop_context(get_client_ctx());
 
     auto* tool_data_ptr = static_cast<std::unique_ptr<tool_data_t>*>(user_data);
+
+    // Flush PC sampling before serializing: the SDK does not auto-deliver
+    // buffered samples on teardown, so without this the JSON would drop any
+    // records still sitting below the buffer watermark.
+    if (tool_data_ptr->get()->pc_sampling.enabled())
+        tool_data_ptr->get()->pc_sampling.stop_and_flush(*g_sdk_wrapper);
+
     generate_output(tool_data_ptr->get());
 
     delete tool_data_ptr;
@@ -207,6 +256,12 @@ std::unique_ptr<tool_data_t> create_tool_data(rocprofiler_client_id_t* /*id*/)
             std::string{g_input_parameters->get_pc_sampling_method()});
         tool_data->pc_sampling =
             pc_sampling_feature_t{pc_mode, generate_output_filename(output_path, "_code_obj_info.json")};
+
+        // The SDK consumer reads exactly <workload>/ps_file_results.json, so this
+        // path carries NO pid prefix. The native tool is never co-loaded with the
+        // SDK tool in PC-sampling mode, so there is no risk of clobbering.
+        tool_data->pc_sampling.set_ps_output_path(std::filesystem::path{output_path} /
+                                                  "ps_file_results.json");
     }
 
     // ROCPROF_COUNTERS env. var. is a string like "pmc: counter1 counter2 ..."

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/sdk_wrapper.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/sdk_wrapper.cpp
@@ -64,6 +64,16 @@ void SdkWrapperImpl::start_context(rocprofiler_context_id_t context_id)
     ROCPROFILER_CALL(rocprofiler_start_context(context_id), "start context");
 }
 
+void SdkWrapperImpl::stop_context(rocprofiler_context_id_t context_id)
+{
+    ROCPROFILER_CALL(rocprofiler_stop_context(context_id), "stop context");
+}
+
+void SdkWrapperImpl::flush_buffer(rocprofiler_buffer_id_t buffer_id)
+{
+    ROCPROFILER_CALL(rocprofiler_flush_buffer(buffer_id), "flush buffer");
+}
+
 void SdkWrapperImpl::iterate_agent_supported_counters(rocprofiler_agent_id_t              agent_id,
                                                       rocprofiler_available_counters_cb_t cb,
                                                       void*                               user_data)
@@ -99,4 +109,46 @@ void SdkWrapperImpl::at_intercept_table_registration_hsa(rocprofiler_intercept_l
 {
     ROCPROFILER_CALL(rocprofiler_at_intercept_table_registration(callback, ROCPROFILER_HSA_TABLE, user_data),
                      "register HSA intercept table callback");
+}
+
+void SdkWrapperImpl::query_available_agents(rocprofiler_query_available_agents_cb_t cb,
+                                            size_t                                  agent_size,
+                                            void*                                   user_data)
+{
+    // SDK requires a version enum as the first arg; supply it here so the wrapper stays mockable.
+    ROCPROFILER_CALL(rocprofiler_query_available_agents(ROCPROFILER_AGENT_INFO_VERSION_0, cb, agent_size, user_data),
+                     "query available agents");
+}
+
+void SdkWrapperImpl::query_pc_sampling_agent_configurations(rocprofiler_agent_id_t agent_id,
+                                                            rocprofiler_available_pc_sampling_configurations_cb_t cb,
+                                                            void* user_data)
+{
+    ROCPROFILER_CALL(rocprofiler_query_pc_sampling_agent_configurations(agent_id, cb, user_data),
+                     "query pc sampling agent configurations");
+}
+
+void SdkWrapperImpl::create_buffer(rocprofiler_context_id_t        context_id,
+                                   size_t                          size,
+                                   size_t                          watermark,
+                                   rocprofiler_buffer_policy_t     policy,
+                                   rocprofiler_buffer_tracing_cb_t callback,
+                                   void*                           callback_data,
+                                   rocprofiler_buffer_id_t*        buffer_id)
+{
+    ROCPROFILER_CALL(
+        rocprofiler_create_buffer(context_id, size, watermark, policy, callback, callback_data, buffer_id),
+        "create buffer");
+}
+
+rocprofiler_status_t SdkWrapperImpl::configure_pc_sampling_service(rocprofiler_context_id_t context_id,
+                                                                   rocprofiler_agent_id_t agent_id,
+                                                                   rocprofiler_pc_sampling_method_t method,
+                                                                   rocprofiler_pc_sampling_unit_t unit,
+                                                                   uint64_t interval,
+                                                                   rocprofiler_buffer_id_t buffer_id,
+                                                                   int flags)
+{
+    // No assert: PC sampling may legitimately be unavailable; the caller inspects the status.
+    return rocprofiler_configure_pc_sampling_service(context_id, agent_id, method, unit, interval, buffer_id, flags);
 }

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/sdk_wrapper.h
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/sdk_wrapper.h
@@ -1,6 +1,9 @@
 // Copyright (c) Advanced Micro Devices, Inc.
 // SPDX-License-Identifier:  MIT
 #pragma once
+#include <rocprofiler-sdk/agent.h>
+#include <rocprofiler-sdk/buffer.h>
+#include <rocprofiler-sdk/pc_sampling.h>
 #include <rocprofiler-sdk/rocprofiler.h>
 
 namespace rocprofiler_compute_tool
@@ -26,6 +29,10 @@ public:
 
     virtual void start_context(rocprofiler_context_id_t context_id) = 0;
 
+    virtual void stop_context(rocprofiler_context_id_t context_id) = 0;
+
+    virtual void flush_buffer(rocprofiler_buffer_id_t buffer_id) = 0;
+
     virtual void iterate_agent_supported_counters(rocprofiler_agent_id_t              agent_id,
                                                   rocprofiler_available_counters_cb_t cb,
                                                   void* user_data) = 0;
@@ -44,6 +51,30 @@ public:
 
     virtual void at_intercept_table_registration_hsa(rocprofiler_intercept_library_cb_t callback,
                                                      void* user_data) = 0;
+
+    virtual void query_available_agents(rocprofiler_query_available_agents_cb_t cb,
+                                        size_t                                  agent_size,
+                                        void*                                   user_data) = 0;
+
+    virtual void query_pc_sampling_agent_configurations(rocprofiler_agent_id_t agent_id,
+                                                        rocprofiler_available_pc_sampling_configurations_cb_t cb,
+                                                        void* user_data) = 0;
+
+    virtual void create_buffer(rocprofiler_context_id_t        context_id,
+                               size_t                          size,
+                               size_t                          watermark,
+                               rocprofiler_buffer_policy_t     policy,
+                               rocprofiler_buffer_tracing_cb_t callback,
+                               void*                           callback_data,
+                               rocprofiler_buffer_id_t*        buffer_id) = 0;
+
+    virtual rocprofiler_status_t configure_pc_sampling_service(rocprofiler_context_id_t context_id,
+                                                               rocprofiler_agent_id_t   agent_id,
+                                                               rocprofiler_pc_sampling_method_t method,
+                                                               rocprofiler_pc_sampling_unit_t unit,
+                                                               uint64_t                interval,
+                                                               rocprofiler_buffer_id_t buffer_id,
+                                                               int                     flags) = 0;
 };
 
 class SdkWrapperImpl : public SdkWrapper
@@ -63,6 +94,8 @@ public:
                                             rocprofiler_callback_tracing_cb_t      callback,
                                             void* callback_args) override;
     void start_context(rocprofiler_context_id_t context_id) override;
+    void stop_context(rocprofiler_context_id_t context_id) override;
+    void flush_buffer(rocprofiler_buffer_id_t buffer_id) override;
     void iterate_agent_supported_counters(rocprofiler_agent_id_t              agent_id,
                                           rocprofiler_available_counters_cb_t cb,
                                           void*                               user_data) override;
@@ -78,5 +111,25 @@ public:
 
     void at_intercept_table_registration_hsa(rocprofiler_intercept_library_cb_t callback,
                                              void*                              user_data) override;
+    void query_available_agents(rocprofiler_query_available_agents_cb_t cb,
+                                size_t                                  agent_size,
+                                void*                                   user_data) override;
+    void query_pc_sampling_agent_configurations(rocprofiler_agent_id_t agent_id,
+                                                rocprofiler_available_pc_sampling_configurations_cb_t cb,
+                                                void* user_data) override;
+    void                 create_buffer(rocprofiler_context_id_t        context_id,
+                                       size_t                          size,
+                                       size_t                          watermark,
+                                       rocprofiler_buffer_policy_t     policy,
+                                       rocprofiler_buffer_tracing_cb_t callback,
+                                       void*                           callback_data,
+                                       rocprofiler_buffer_id_t*        buffer_id) override;
+    rocprofiler_status_t configure_pc_sampling_service(rocprofiler_context_id_t         context_id,
+                                                       rocprofiler_agent_id_t           agent_id,
+                                                       rocprofiler_pc_sampling_method_t method,
+                                                       rocprofiler_pc_sampling_unit_t   unit,
+                                                       uint64_t                         interval,
+                                                       rocprofiler_buffer_id_t          buffer_id,
+                                                       int flags) override;
 };
 }  // namespace rocprofiler_compute_tool

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.cpp
@@ -152,6 +152,45 @@ void MockSdkWrapper::start_context(rocprofiler_context_id_t context_id)
     m_started_contexts.push_back(context_id.handle);
 }
 
+void MockSdkWrapper::stop_context(rocprofiler_context_id_t /*context_id*/) {}
+
+void MockSdkWrapper::flush_buffer(rocprofiler_buffer_id_t /*buffer_id*/) {}
+
+void MockSdkWrapper::query_available_agents(rocprofiler_query_available_agents_cb_t /*cb*/,
+                                            size_t /*agent_size*/,
+                                            void* /*user_data*/)
+{
+}
+
+void MockSdkWrapper::query_pc_sampling_agent_configurations(
+    rocprofiler_agent_id_t /*agent_id*/,
+    rocprofiler_available_pc_sampling_configurations_cb_t /*cb*/,
+    void* /*user_data*/)
+{
+}
+
+void MockSdkWrapper::create_buffer(rocprofiler_context_id_t /*context_id*/,
+                                   size_t /*size*/,
+                                   size_t /*watermark*/,
+                                   rocprofiler_buffer_policy_t /*policy*/,
+                                   rocprofiler_buffer_tracing_cb_t /*callback*/,
+                                   void* /*callback_data*/,
+                                   rocprofiler_buffer_id_t* /*buffer_id*/)
+{
+}
+
+rocprofiler_status_t MockSdkWrapper::configure_pc_sampling_service(
+    rocprofiler_context_id_t /*context_id*/,
+    rocprofiler_agent_id_t /*agent_id*/,
+    rocprofiler_pc_sampling_method_t /*method*/,
+    rocprofiler_pc_sampling_unit_t /*unit*/,
+    uint64_t /*interval*/,
+    rocprofiler_buffer_id_t /*buffer_id*/,
+    int /*flags*/)
+{
+    return ROCPROFILER_STATUS_SUCCESS;
+}
+
 void MockSdkWrapper::iterate_agent_supported_counters(rocprofiler_agent_id_t              agent_id,
                                                       rocprofiler_available_counters_cb_t cb,
                                                       void*                               user_data)

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.h
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.h
@@ -91,6 +91,8 @@ public:
                                             rocprofiler_callback_tracing_cb_t      callback,
                                             void* callback_args) override;
     void start_context(rocprofiler_context_id_t context_id) override;
+    void stop_context(rocprofiler_context_id_t context_id) override;
+    void flush_buffer(rocprofiler_buffer_id_t buffer_id) override;
     void iterate_agent_supported_counters(rocprofiler_agent_id_t              agent_id,
                                           rocprofiler_available_counters_cb_t cb,
                                           void*                               user_data) override;
@@ -106,6 +108,27 @@ public:
 
     void at_intercept_table_registration_hsa(rocprofiler_intercept_library_cb_t callback,
                                              void*                              user_data) override;
+
+    void query_available_agents(rocprofiler_query_available_agents_cb_t cb,
+                                size_t                                  agent_size,
+                                void*                                   user_data) override;
+    void query_pc_sampling_agent_configurations(rocprofiler_agent_id_t agent_id,
+                                                rocprofiler_available_pc_sampling_configurations_cb_t cb,
+                                                void* user_data) override;
+    void                 create_buffer(rocprofiler_context_id_t        context_id,
+                                       size_t                          size,
+                                       size_t                          watermark,
+                                       rocprofiler_buffer_policy_t     policy,
+                                       rocprofiler_buffer_tracing_cb_t callback,
+                                       void*                           callback_data,
+                                       rocprofiler_buffer_id_t*        buffer_id) override;
+    rocprofiler_status_t configure_pc_sampling_service(rocprofiler_context_id_t         context_id,
+                                                       rocprofiler_agent_id_t           agent_id,
+                                                       rocprofiler_pc_sampling_method_t method,
+                                                       rocprofiler_pc_sampling_unit_t   unit,
+                                                       uint64_t                         interval,
+                                                       rocprofiler_buffer_id_t          buffer_id,
+                                                       int flags) override;
 
     struct hsa_intercept_registration_info
     {


### PR DESCRIPTION
## Motivation

The native tool only emitted code-object info and relied on the rocprofiler-sdk tool for PC sample records; this adds native collection of host-trap and stochastic PC samples that emits an SDK-equivalent ps_file_results.json, so PC sampling no longer depends on the separate SDK tool.

## Technical Details

- New ps_file_writer emits the rocprofiler-sdk-tool JSON schema
- New record collector: thread-safe accumulation, stable inst_index per PC
- Shared code_object_translator decodes each code object once
- SdkWrapper gains agent/config/buffer/configure/stop/flush passthroughs
- Separate PC context, gated counter setup, buffer flushed before output

## JIRA ID

N/A

## Test Plan

- [x] Build pc-sampling-collector and tool targets
- [x] Run test-pc-sampling-collector gtest suite
- [x] Run test-rocprofiler-compute-tool gtest suite
- [x] clang-format on all changed files

## Test Result

- [x] Both targets build clean
- [x] 51 collector tests pass
- [x] 57 tool tests pass
- [x] clang-format clean

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.