### PR TITLE
clr: always sort hsa queues by id

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -138,9 +138,8 @@ Device::Device(hsa_agent_t bkendDevice)
       sdma_engine_allocator_(*this),
       cpu_agent_info_(nullptr),
       numHwPipes_(4) {
-  // Initialize queue pools with proper comparators (requires 'this' pointer)
   for (uint i = 0; i < QueuePriority::Total; ++i) {
-    queuePool_.emplace_back(QueueCompare(this));
+    queuePool_.emplace_back();
   }
 
   group_segment_.handle = 0;

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -737,18 +737,8 @@ class Device : public NullDevice {
   };
 
   struct QueueCompare {
-    const Device* device_;
-
-    QueueCompare(const Device* dev = nullptr) : device_(dev) {}
-
     // Customized queue compare operator to make sure the queues are sorted in the creation order
-    bool operator()(hsa_queue_t* lhs, hsa_queue_t* rhs) const {
-      if (device_ != nullptr && device_->settings().dynamic_queues_ > 0) {
-        return (lhs->id < rhs->id) ? true : false;
-      } else {
-        return (lhs < rhs) ? true : false;
-      }
-    }
+    bool operator()(hsa_queue_t* lhs, hsa_queue_t* rhs) const { return lhs->id < rhs->id; }
   };
   //! a vector for keeping Pool of HSA queues with low, normal and high priorities for recycling
   std::vector<std::map<hsa_queue_t*, QueueInfo, QueueCompare>> queuePool_;


### PR DESCRIPTION
## Motivation

Need to have deterministic queue assignment when dynamic queue is enabled, use queue id instead of queue ptr when there's a tie breaker in queue assignment.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Always sort by queue id when dynamic queue is disabled.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
AIRUNTIME-2263

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
hip-tests with `DEBUG_HIP_DYNAMIC_QUEUES=0`

## Test Result

<!-- Briefly summarize test outcomes. -->
Passed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
