### PR TITLE
Support for TDM

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_gfx1250_TDM.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_gfx1250_TDM.h
@@ -1,0 +1,354 @@
+/*
+Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#ifndef HIP_INCLUDE_HIP_AMD_GFX1250_TDM_H
+#define HIP_INCLUDE_HIP_AMD_GFX1250_TDM_H
+
+#if !defined(__HIPCC_RTC__)
+#include <hip/hip_common.h>
+#include <hip/driver_types.h>
+#include <hip/amd_detail/amd_hip_vector_types.h>
+#if __cplusplus
+#include <cstdint>
+#else
+#include <stdint.h>
+#endif
+#endif
+
+using __hip_uint32x4 = __NATIVE_VECTOR__(4, uint32_t);
+using __hip_uint32x8 = __NATIVE_VECTOR__(8, uint32_t);
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshift-count-overflow" // we're going to be using overflow on purpose
+
+union gfx1250_TDM_GROUP0
+{
+    __device__ constexpr gfx1250_TDM_GROUP0() : m_bitfield{0x1, 0, 0, 0x80000000}
+    {}
+
+    __device__ gfx1250_TDM_GROUP0( uintptr_t lds_addr_in,
+                           uintptr_t global_addr_in,
+                           uint32_t  gather_idx_size_in = 0,
+                           uint32_t  gather_mode_in = 0 )
+    {
+        globalAddr(global_addr_in);
+        m_count             = 1;
+        m_lds_addr          = lds_addr_in;
+        m_type              = 2;
+        m_gather_index_size = gather_idx_size_in;
+        m_gather_mode       = gather_mode_in;
+    }
+
+
+    struct
+    {
+        //reserve the first 32 bits
+        union
+        {
+            struct
+            {
+                uint32_t m_count : 2;
+                uint32_t m_is_restore : 1;
+                uint32_t m_is_store : 1;
+                uint32_t m_nv : 1;
+                uint32_t m_scope_trait : 2;
+                uint32_t m_th :3;
+                uint32_t m_reserved_space : 20;
+                uint32_t m_gather_index_size : 1;
+                uint32_t m_gather_mode : 1;
+            };
+
+            uint32_t m_reserved0;
+        };
+
+        uint32_t m_lds_addr;
+        uint32_t m_global_addr_lo;
+        union
+        {
+            struct
+            {
+                uint32_t m_global_addr_hi : 25;
+                uint32_t m_reserved2  : 5;
+                uint32_t m_type       : 2;
+            };
+            uint32_t m_sgpr3;
+        };
+    };
+    __hip_uint32x4 m_bitfield;
+
+    // setters for all user configurable fields
+    __device__ void count(bool value)
+    {
+        m_count = (int)value;
+    }
+
+    __device__ void ldsAddr(uint32_t value)
+    {
+        m_lds_addr = value;
+    }
+
+    __device__ void gatherMode(int enable, int value)
+    {
+        m_gather_mode = enable;
+        m_gather_index_size = value;
+    }
+
+    __device__ void globalAddr(uintptr_t value)
+    {
+        m_global_addr_lo = value & 0xFFFFFFFF;
+        m_global_addr_hi = (value >> 32);
+    }
+};
+
+union gfx1250_TDM_GROUP1
+{
+    __device__ constexpr gfx1250_TDM_GROUP1() : m_bitfield{0,0,0,0,0,0,0,0} {}
+
+    struct
+    {
+        union
+        {
+            struct
+            {
+                uint32_t m_workgroup_mask         : 16;
+                uint32_t m_data_size              : 2;
+                uint32_t m_atomic_barrier_enable  : 1;
+                uint32_t m_iterate_enable         : 1;
+                uint32_t m_pad_enable             : 1;
+                uint32_t m_early_timeout          : 1;
+                uint32_t m_pad_interval           : 3;
+                uint32_t m_pad_amount             : 7;
+            };
+            uint32_t m_sgpr0;
+        };
+        union
+        {
+            struct
+            {
+                uint32_t m_atomic_barrier_address  : 16;
+                uint32_t m_tensor_dim0_lo          : 16;
+            };
+            uint32_t m_sgpr1;
+        };
+        union
+        {
+            struct
+            {
+                uint32_t m_tensor_dim0_hi : 16;
+                uint32_t m_tensor_dim1_lo : 16;
+            };
+            uint32_t m_sgpr2;
+        };
+        union
+        {
+            struct
+            {
+                uint32_t m_tensor_dim1_hi : 16;
+                uint32_t m_tile_dim0      : 16;
+            };
+            uint32_t m_sgpr3;
+        };
+        union
+        {
+            struct
+            {
+                uint32_t m_tile_dim1 : 16;
+                uint32_t m_tile_dim2 : 16;
+            };
+            uint32_t m_sgpr4;
+        };
+        union
+        {
+            uint32_t m_tensor_dim0_stride_lo;
+            uint32_t m_sgpr5;
+        };
+        union
+        {
+            struct
+            {
+                uint32_t m_tensor_dim0_stride_hi : 16;
+                uint32_t m_tensor_dim1_stride_lo : 16;
+            };
+            uint32_t m_sgpr6;
+        };
+        union
+        {
+            uint32_t m_tensor_dim1_stride_hi;
+            uint32_t m_sgpr7;
+        };
+    };
+    __hip_uint32x8 m_bitfield;
+
+    // setters for all fields
+    void __device__ inline workgroupMask(uint32_t value)
+    {
+        m_workgroup_mask = value;
+    }
+
+    void __device__ inline dataSize(uint32_t value)
+    {
+        m_data_size = value;
+    }
+
+    void __device__ inline atomicBarrierEnable(bool value)
+    {
+        m_atomic_barrier_enable = value;
+    }
+
+    void __device__ inline iterateEnable(bool value)
+    {
+        m_iterate_enable = value;
+    }
+
+    void __device__ inline padEnable(bool value)
+    {
+        m_pad_enable = value;
+    }
+
+    void __device__ inline earlyTimeout(bool value)
+    {
+        m_early_timeout = value;
+    }
+
+    void __device__ inline padInterval(uint32_t value)
+    {
+        m_pad_interval = value;
+    }
+
+    void __device__ inline padAmount(uint32_t value)
+    {
+        m_pad_amount = value;
+    }
+
+    void __device__ inline atomicBarrierAddress(uint32_t value)
+    {
+        m_atomic_barrier_address = value;
+    }
+
+    void __device__ inline tileDim0(uint32_t value)
+    {
+        m_tile_dim0 = value;
+    }
+
+    void __device__ inline tileDim1(uint32_t value)
+    {
+        m_tile_dim1 = value;
+    }
+    void __device__ inline tileDim2(uint32_t value)
+    {
+        m_tile_dim2 = value;
+    }
+
+    void __device__ inline tensorDim0(uint32_t value)
+    {
+        m_tensor_dim0_lo = value & 0xFFFF;
+        m_tensor_dim0_hi = (value >> 16);
+    }
+    void __device__ inline tensorDim1(uint32_t value)
+    {
+        m_tensor_dim1_lo = value & 0xFFFF;
+        m_tensor_dim1_hi = (value >> 16);
+    }
+    void __device__ inline tensorDim0Stride(uint32_t value)
+    {
+        m_tensor_dim0_stride_lo = value & 0xFFFFFFFF;
+        m_tensor_dim0_stride_hi = (value >> 32);
+    }
+
+    void __device__ inline tensorDim1Stride(uint32_t value)
+    {
+        m_tensor_dim1_stride_lo = value & 0xFFFFFFFF;
+        m_tensor_dim1_stride_hi = (value >> 32);
+    }
+};
+
+union gfx1250_TDM_GROUP2
+{
+    __device__ gfx1250_TDM_GROUP2() : m_bitfield{0,0,0,0} {}
+
+    struct
+    {
+        uint32_t m_tensor_dim2; //sgpr0
+        uint32_t m_tensor_dim3; //sgpr1
+        uint32_t m_tensor_dim2_stride_lo; //sgpr2
+        union
+        {
+            struct
+            {
+                uint32_t m_tensor_dim2_stride_hi : 16;
+                uint32_t m_tile_dim3             : 16;
+            };
+            uint32_t m_sgpr3;
+        };
+    };
+    __hip_uint32x4 m_bitfield;
+
+    void __device__ inline tensorDim2Stride(uint64_t value)
+    {
+        m_tensor_dim2_stride_lo = value & 0xFFFFFFFF;
+        m_tensor_dim2_stride_hi = value >> 32;
+    }
+};
+
+union gfx1250_TDM_GROUP3
+{
+    __device__ gfx1250_TDM_GROUP3() : m_bitfield{0,0,0,0} {}
+
+    struct
+    {
+        uint32_t m_tensor_dim3_stride_lo; //sgpr0
+        union
+        {
+            struct
+            {
+                uint32_t m_tensor_dim3_stride_hi : 16;
+                uint32_t m_tensor_dim_4_lo : 16;
+            };
+            uint32_t m_sgpr1;
+        };
+        union
+        {
+            struct
+            {
+                uint32_t m_tensor_dim_4_hi : 16;
+                uint32_t m_tile_dim4       : 16;
+            };
+            uint32_t m_sgpr2;
+        };
+        uint32_t m_sgpr3_reserved;
+    };
+    __hip_uint32x4 m_bitfield;
+
+    void __device__ inline tensorDim3Stride(uint64_t value)
+    {
+        m_tensor_dim3_stride_lo =  value & 0xFFFFFFFF;
+        m_tensor_dim3_stride_hi = value >> 32;
+    }
+
+    void __device__ inline tensorDim4(uint32_t value)
+    {
+        m_tensor_dim_4_lo = value & 0xFFFF;
+        m_tensor_dim_4_hi = value >> 16;
+    }
+};
+#pragma clang diagnostic pop
+#endif // HIP_INCLUDE_HIP_AMD_GFX1250_TDM_H

--- a/projects/hip-tests/catch/unit/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/CMakeLists.txt
@@ -49,6 +49,7 @@ if(HIP_PLATFORM STREQUAL "amd")
   # Vulkan interop APIs currently undefined for Nvidia
   add_subdirectory(vulkan_interop)
   add_subdirectory(gl_interop) # Disabled on NVIDIA due to defect - EXSWHTEC-246
+  add_subdirectory(TDM)
 endif()
 add_subdirectory(synchronization)
 add_subdirectory(launchBounds)

--- a/projects/hip-tests/catch/unit/TDM/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/TDM/CMakeLists.txt
@@ -1,0 +1,51 @@
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+# Accepted archs
+set(ACCEPTED_GFX1250_ARCH gfx1250)
+
+function(CheckAcceptedArchs OFFLOAD_ARCH_STR_LOCAL)
+  set(ARCH_GFX1250 -1 PARENT_SCOPE)
+  string(REGEX MATCHALL "--offload-arch=gfx[0-9a-z]+" OFFLOAD_ARCH_LIST ${OFFLOAD_ARCH_STR_LOCAL})
+  foreach(OFFLOAD_ARCH IN LISTS OFFLOAD_ARCH_LIST)
+    string(REGEX MATCHALL "--offload-arch=(gfx[0-9a-z]+)" matches ${OFFLOAD_ARCH})
+    if (CMAKE_MATCH_COUNT EQUAL 1)
+      # CMAKE_MATCH_1
+    if (CMAKE_MATCH_1 IN_LIST ACCEPTED_GFX1250_ARCH)
+        set(ARCH_GFX1250 1 PARENT_SCOPE)
+      endif()
+    endif()        # CMAKE_MATCH_COUNT
+  endforeach()   # OFFLOAD_ARCH_LIST
+endfunction()  # CheckAcceptedArchs
+
+if (DEFINED OFFLOAD_ARCH_STR)
+  CheckAcceptedArchs(${OFFLOAD_ARCH_STR})
+elseif(DEFINED $ENV{HCC_AMDGPU_TARGET})
+  CheckAcceptedArchs($ENV{HCC_AMDGPU_TARGET})
+endif()
+
+if(${ARCH_GFX1250} GREATER_EQUAL 0)
+    set(TEST_SRC
+        tdm_basic_load_store.cc
+    )
+    hip_add_exe_to_target(NAME tdm_basic_load_store
+                        TEST_SRC ${TEST_SRC}
+                        TEST_TARGET_NAME build_tests)
+endif()

--- a/projects/hip-tests/catch/unit/TDM/tdm_basic_load_store.cc
+++ b/projects/hip-tests/catch/unit/TDM/tdm_basic_load_store.cc
@@ -2,7 +2,7 @@
 #include <resource_guards.hh>
 #include <hip/amd_detail/amd_gfx1250_TDM.h>
 
-#if defined(__clang__) && defined(__HIP__) && defined(__gfx1250__)
+#if defined(__clang__) && defined(__HIP__)
 __global__ void  TDM_load_store_tester(const int* data,  int* result, int sizex, int sizey)
 {
     __shared__ int shmem[10 * 10];
@@ -59,4 +59,4 @@ TEST_CASE("TDM_Basic_load_2d")
         REQUIRE(result.ptr()[i] == input.ptr()[i]);
     }
 }
-#endif // #if defined(__clang__) && defined(__HIP__) && defined(__gfx1250__)
+#endif // #if defined(__clang__) && defined(__HIP__)

--- a/projects/hip-tests/catch/unit/TDM/tdm_basic_load_store.cc
+++ b/projects/hip-tests/catch/unit/TDM/tdm_basic_load_store.cc
@@ -5,9 +5,12 @@
 #include <string>
 
 #if defined(__clang__) && defined(__HIP__)
-#if defined(__gfx1250__) || defined(__gfx1251__)
-__global__ void  TDM_load_store_tester(const int* data,  int* result, int sizex, int sizey)
+__global__ void  TDM_load_store_tester([[maybe_unused]] const int* data,
+                                       [[maybe_unused]] int* result,
+                                       [[maybe_unused]] int sizex,
+                                       [[maybe_unused]] int sizey)
 {
+    #if defined(__gfx1250__) || defined(__gfx1251__)
     __shared__ int shmem[10 * 10];
     auto* pShmem = static_cast<int*>(shmem);
     gfx1250_TDM_GROUP0 group0;
@@ -33,8 +36,8 @@ __global__ void  TDM_load_store_tester(const int* data,  int* result, int sizex,
     __builtin_amdgcn_tensor_store_from_lds_d2(group0.m_bitfield, group1.m_bitfield, 0);
     __builtin_amdgcn_s_wait_tensorcnt(0);
 
+    #endif // #if defined(__gfx1250__) || defined(__gfx1251__)
 }
-#endif // #if defined(__gfx1250__) || defined(__gfx1251__)
 
 TEST_CASE("TDM_Basic_load_2d")
 {
@@ -65,9 +68,7 @@ TEST_CASE("TDM_Basic_load_2d")
     }
 
     HIP_CHECK(hipMemcpy(input_dev.ptr(), input.ptr(), alloc_size, hipMemcpyHostToDevice));
-#if defined(__gfx1250__) || defined(__gfx1251__)
-TDM_load_store_tester<<<1, 32>>>(input_dev.ptr(), result_dev.ptr(), 10, 10);
-#endif
+    TDM_load_store_tester<<<1, 32>>>(input_dev.ptr(), result_dev.ptr(), 10, 10);
     HIP_CHECK(hipDeviceSynchronize());
     HIP_CHECK(hipMemcpy(result.ptr(), result_dev.ptr(), alloc_size, hipMemcpyDeviceToHost));
 

--- a/projects/hip-tests/catch/unit/TDM/tdm_basic_load_store.cc
+++ b/projects/hip-tests/catch/unit/TDM/tdm_basic_load_store.cc
@@ -1,0 +1,62 @@
+#include <hip_test_common.hh>
+#include <resource_guards.hh>
+#include <hip/amd_detail/amd_gfx1250_TDM.h>
+
+#if defined(__clang__) && defined(__HIP__) && defined(__gfx1250__)
+__global__ void  TDM_load_store_tester(const int* data,  int* result, int sizex, int sizey)
+{
+    __shared__ int shmem[10 * 10];
+    auto* pShmem = static_cast<int*>(shmem);
+    gfx1250_TDM_GROUP0 group0;
+    group0.globalAddr((uintptr_t)data);
+    group0.ldsAddr((uintptr_t)pShmem);
+
+    gfx1250_TDM_GROUP1 group1;
+    group1.dataSize(2);
+    group1.tensorDim0(sizex);
+    group1.tensorDim1(sizey);
+    group1.tensorDim0Stride(sizex);
+    group1.tensorDim1Stride(sizey);
+    group1.tileDim0(sizex);
+    group1.tileDim1(sizey);
+
+    __builtin_amdgcn_tensor_load_to_lds_d2(group0.m_bitfield, group1.m_bitfield, 0);
+    __builtin_amdgcn_s_wait_tensorcnt(0);
+    __syncthreads();
+
+    // write back to global
+
+    group0.globalAddr((uintptr_t)result);
+    __builtin_amdgcn_tensor_store_from_lds_d2(group0.m_bitfield, group1.m_bitfield, 0);
+    __builtin_amdgcn_s_wait_tensorcnt(0);
+
+}
+
+TEST_CASE("TDM_Basic_load_2d")
+{
+    constexpr int kAllocSize = 10 * 10;
+    const auto alloc_size = kAllocSize * sizeof(int);
+
+    LinearAllocGuard<int> input_dev(LinearAllocs::hipMalloc, alloc_size);
+    LinearAllocGuard<int> input(LinearAllocs::hipHostMalloc, alloc_size);
+
+    LinearAllocGuard<int> result_dev(LinearAllocs::hipMalloc, alloc_size);
+    LinearAllocGuard<int> result(LinearAllocs::hipHostMalloc, alloc_size);
+    HIP_CHECK(hipMemset(result_dev.ptr(), 0, alloc_size));
+
+    for(int i = 0; i < kAllocSize; ++i)
+    {
+        input.ptr()[i] = i;
+    }
+
+    HIP_CHECK(hipMemcpy(input_dev.ptr(), input.ptr(), alloc_size, hipMemcpyHostToDevice));
+    TDM_load_store_tester<<<1, 32>>>(input_dev.ptr(), result_dev.ptr(), 10, 10);
+    HIP_CHECK(hipDeviceSynchronize());
+    HIP_CHECK(hipMemcpy(result.ptr(), result_dev.ptr(), alloc_size, hipMemcpyDeviceToHost));
+
+    for(int i =0; i < alloc_size;++i)
+    {
+        REQUIRE(result.ptr()[i] == input.ptr()[i]);
+    }
+}
+#endif // #if defined(__clang__) && defined(__HIP__) && defined(__gfx1250__)

--- a/projects/hip-tests/catch/unit/TDM/tdm_basic_load_store.cc
+++ b/projects/hip-tests/catch/unit/TDM/tdm_basic_load_store.cc
@@ -2,7 +2,10 @@
 #include <resource_guards.hh>
 #include <hip/amd_detail/amd_gfx1250_TDM.h>
 
+#include <string>
+
 #if defined(__clang__) && defined(__HIP__)
+#if defined(__gfx1250__) || defined(__gfx1251__)
 __global__ void  TDM_load_store_tester(const int* data,  int* result, int sizex, int sizey)
 {
     __shared__ int shmem[10 * 10];
@@ -31,9 +34,21 @@ __global__ void  TDM_load_store_tester(const int* data,  int* result, int sizex,
     __builtin_amdgcn_s_wait_tensorcnt(0);
 
 }
+#endif // #if defined(__gfx1250__) || defined(__gfx1251__)
 
 TEST_CASE("TDM_Basic_load_2d")
 {
+#if HT_AMD
+    int device = 0;
+    HIP_CHECK(hipGetDevice(&device));
+    hipDeviceProp_t props{};
+    HIP_CHECK(hipGetDeviceProperties(&props, device));
+    const std::string arch(props.gcnArchName);
+    if (arch.find("gfx1250") == std::string::npos && arch.find("gfx1251") == std::string::npos) {
+        HipTest::HIP_SKIP_TEST("TDM_Basic_load_2d requires gfx1250 or gfx1251");
+        return;
+    }
+#endif
     constexpr int kAllocSize = 10 * 10;
     const auto alloc_size = kAllocSize * sizeof(int);
 
@@ -50,7 +65,9 @@ TEST_CASE("TDM_Basic_load_2d")
     }
 
     HIP_CHECK(hipMemcpy(input_dev.ptr(), input.ptr(), alloc_size, hipMemcpyHostToDevice));
-    TDM_load_store_tester<<<1, 32>>>(input_dev.ptr(), result_dev.ptr(), 10, 10);
+#if defined(__gfx1250__) || defined(__gfx1251__)
+TDM_load_store_tester<<<1, 32>>>(input_dev.ptr(), result_dev.ptr(), 10, 10);
+#endif
     HIP_CHECK(hipDeviceSynchronize());
     HIP_CHECK(hipMemcpy(result.ptr(), result_dev.ptr(), alloc_size, hipMemcpyDeviceToHost));
 


### PR DESCRIPTION
## Motivation

Add TDM (Tensor Data Movement) programming support for gfx1250 and fix compilation issues preventing TDM tests from running.

## Technical Details

- Added amd_gfx1250_TDM.h header with device-specific TDM structures
- Implemented basic TDM load/store unit test for 2D data movement
- Fixed preprocessor directive in test - removed __gfx1250__ check that was causing tests to be excluded during host compilation

## JIRA ID

SWDEV-575524

## Test Plan

Basic TDM load/store test validates 2D data movement between global memory and shared memory.

## Test Result

Basic TDM load/store test validates 2D data movement between global memory and shared memory on gfx1250.

## Submission Checklist

- [ X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
