### PR TITLE
ENABLE_ESMI_LIB = OFF on non-x86 systems

### DIFF
--- a/projects/amdsmi/CMakeLists.txt
+++ b/projects/amdsmi/CMakeLists.txt
@@ -111,7 +111,13 @@ include(GNUInstallDirs)
 
 option(BUILD_TESTS "Build test suite" OFF)
 option(ENABLE_ASAN_PACKAGING "" OFF)
-option(ENABLE_ESMI_LIB "Build ESMI Library" ON)
+
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
+    option(ENABLE_ESMI_LIB "Build ESMI Library" ON)
+else()
+    option(ENABLE_ESMI_LIB "Build ESMI Library" OFF)
+endif()
+
 option(BUILD_EXAMPLES "Build examples" OFF)
 
 # If amdsmi is built as a static library, it should support being embedded in other programs. The setting below essentially enables the -fPIC flag.


### PR DESCRIPTION
## Motivation

Part of https://github.com/ROCm/TheRock/issues/5518

ESMI has EPYC-specific features, so should only build on X86 by default.

## Technical Details

In CMakeLists.txt, check system processor and determine if ESMI should be enabled or not.


## Test Plan

Build on X86 machine. Verify build includes ESMI:
-Library includes ESMI symbols like `esmi_init`

## Test Result

X86 build includes ESMI

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
