### PR TITLE
[RCCL] Gate DDA AllReduce fast path on NCCL_LAUNCH_ORDER_IMPLICIT

### DIFF
--- a/projects/rccl/src/collectives.cc
+++ b/projects/rccl/src/collectives.cc
@@ -123,10 +123,6 @@ static ncclResult_t rcclDirectAllGather(const void* sendbuff, void* recvbuff, si
 RCCL_PARAM(HierarchicalAllGather, "HIERARCHICAL_ALLGATHER", 0);
 RCCL_PARAM(DdaEnable, "DDA_ENABLE", 1);
 
-// Defined via NCCL_PARAM in enqueue.cc; declared extern here so the DDA fast
-// path can fall back to ncclEnqueueCheck when implicit launch ordering is on.
-extern int64_t ncclParamLaunchOrderImplicit();
-
 static bool rcclUseHierarchicalAllGather(struct ncclComm* comm, size_t msgSize) {
   if (comm->nNodes < 8) return false;
   if (rcclParamHierarchicalAllGather() != 1) return false;

--- a/projects/rccl/src/collectives.cc
+++ b/projects/rccl/src/collectives.cc
@@ -123,6 +123,10 @@ static ncclResult_t rcclDirectAllGather(const void* sendbuff, void* recvbuff, si
 RCCL_PARAM(HierarchicalAllGather, "HIERARCHICAL_ALLGATHER", 0);
 RCCL_PARAM(DdaEnable, "DDA_ENABLE", 1);
 
+// Defined via NCCL_PARAM in enqueue.cc; declared extern here so the DDA fast
+// path can fall back to ncclEnqueueCheck when implicit launch ordering is on.
+extern int64_t ncclParamLaunchOrderImplicit();
+
 static bool rcclUseHierarchicalAllGather(struct ncclComm* comm, size_t msgSize) {
   if (comm->nNodes < 8) return false;
   if (rcclParamHierarchicalAllGather() != 1) return false;
@@ -393,7 +397,7 @@ ncclResult_t ncclAllReduce_impl(const void* sendbuff, void* recvbuff, size_t cou
      ddaThreshold = 0;	
   }
 
-  if (rcclParamDdaEnable() && (count * ncclTypeSize(datatype) <= ddaThreshold) && (ddaThreshold > 0) && ncclAllReduceDdaIpcEligible(comm, sendbuff, recvbuff, count, datatype, op) && ncclGroupDepth == 0) {
+  if (!ncclParamLaunchOrderImplicit() && rcclParamDdaEnable() && (count * ncclTypeSize(datatype) <= ddaThreshold) && (ddaThreshold > 0) && ncclAllReduceDdaIpcEligible(comm, sendbuff, recvbuff, count, datatype, op) && ncclGroupDepth == 0) {
     NCCLCHECK(ncclAllReduceDdaIpc(
         sendbuff,
         recvbuff,

--- a/projects/rccl/src/include/enqueue.h
+++ b/projects/rccl/src/include/enqueue.h
@@ -30,6 +30,9 @@ ncclResult_t ncclLaunchFinish(struct ncclComm* comm);
 ncclResult_t ncclPrepareTasks(struct ncclComm* comm, bool* algoNeedConnect, bool* needConnect, ncclSimInfo_t* simInfo);
 ncclResult_t ncclTasksRegAndEnqueue(struct ncclComm* comm);
 
+// Defined via NCCL_PARAM in enqueue.cc.
+int64_t ncclParamLaunchOrderImplicit();
+
 static inline size_t ncclFuncSendCount(ncclFunc_t func, int nRanks, size_t count) {
   return func == ncclFuncReduceScatter ? nRanks*count : count;
 }


### PR DESCRIPTION
## Motivation
The DDA-IPC AllReduce fast path silently skips the user-set `NCCL_LAUNCH_ORDER_IMPLICIT` environment variable.

## Technical Details
`ncclAllReduce_impl` in `projects/rccl/src/collectives.cc` early-returns into `ncclAllReduceDdaIpc` before reaching `ncclEnqueueCheck`, which is the only place `NCCL_LAUNCH_ORDER_IMPLICIT` is honored (via `ncclLaunchPrepare` / `ncclLaunchFinish` in `src/enqueue.cc`). Gate the DDA branch on `!ncclParamLaunchOrderImplicit()` so users who opt into implicit launch ordering fall through to the normal path. Default users (param unset) keep the DDA fast path unchanged.

## JIRA ID
AICOMRCCL-1096

## Test Plan
Build with `--debug --enable-mpi-tests` and run `rccl-UnitTestsMPI --gtest_filter=ImplicitLaunchOrderMPITest.*` with `NCCL_LAUNCH_ORDER_IMPLICIT=1` on 8x MI300X.

## Test Result
- develop baseline: ImplicitLaunchOrderMPITest.MultiCommunicatorChain fails 0/20 (reproduces AICOMRCCL-1096).
- this branch: passes.

## Submission Checklist
- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.