### PR TITLE
[rocprofiler-sdk-rocpd] Fix mixed-lib symbol collisions for SQLite3

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/output/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/output/CMakeLists.txt
@@ -58,6 +58,10 @@ add_library(rocprofiler-sdk::rocprofiler-sdk-output-library ALIAS
             rocprofiler-sdk-output-library)
 target_sources(rocprofiler-sdk-output-library PRIVATE ${TOOL_OUTPUT_SOURCES}
                                                       ${TOOL_OUTPUT_HEADERS})
+# targets linking to this library should also link to the
+# rocprofiler-sdk::rocprofiler-sdk-sqlite3 target if the target is a shared library. Do
+# not link to the sqlite3 library here because the Python bindings target should not
+# directly link to the sqlite3 library.
 target_link_libraries(
     rocprofiler-sdk-output-library
     PUBLIC rocprofiler-sdk::rocprofiler-sdk-rocpd-library
@@ -71,8 +75,7 @@ target_link_libraries(
             rocprofiler-sdk::rocprofiler-sdk-otf2
             rocprofiler-sdk::rocprofiler-sdk-amd-comgr
             rocprofiler-sdk::rocprofiler-sdk-dw
-            rocprofiler-sdk::rocprofiler-sdk-elf
-            rocprofiler-sdk::rocprofiler-sdk-sqlite3)
+            rocprofiler-sdk::rocprofiler-sdk-elf)
 
 target_compile_definitions(rocprofiler-sdk-output-library
                            PRIVATE PROJECT_BINARY_DIR="${PROJECT_BINARY_DIR}")

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/__init__.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/__init__.py
@@ -27,16 +27,17 @@ import os
 
 try:
     import ctypes
-
-    # RTLD_GLOBAL so Python + librocpd bind the same SQLite, avoiding mixed-lib symbol collisions
-    sqlite3lib = ctypes.CDLL("libsqlite3.so", mode=ctypes.RTLD_GLOBAL)
-except Exception:
-    pass
-
-try:
     import sqlite3
 
-    sqlite3.connect(":memory:")  # Test if sqlite3 is available
+    # import the _sqlite3 C extension to ensure it's loaded before librocpd's
+    # sqlite3 symbols are loaded, avoiding mixed-lib symbol collisions
+    import _sqlite3
+
+    sqlite3.connect(":memory:")  # Test that sqlite3 works after these imports
+    # promote the SQLite3 symbols introduced by _sqlite3 to global scope so that
+    # librocpd and Python use the same SQLite library, avoiding mixed-lib symbol
+    # collisions
+    _sqlite3lib = ctypes.CDLL(_sqlite3.__file__, mode=ctypes.RTLD_GLOBAL)
 except Exception:
     pass
 

--- a/projects/rocprofiler-sdk/source/lib/python/utilities.cmake
+++ b/projects/rocprofiler-sdk/source/lib/python/utilities.cmake
@@ -196,6 +196,10 @@ function(rocprofiler_rocpd_python_bindings _VERSION)
                 $<TARGET_OBJECTS:rocprofiler-sdk::rocprofiler-sdk-object-library>)
     target_include_directories(rocprofiler-sdk-rocpd-python-bindings-${_VERSION} SYSTEM
                                PRIVATE ${Python3_INCLUDE_DIRS})
+
+    # do not link to sqlite3 library here. Python will import the _sqlite3 extension
+    # module which links to sqlite3, and we want to avoid mixed-lib symbol collisions by
+    # ensuring Python and librocpd use the same sqlite3 library.
     target_link_libraries(
         rocprofiler-sdk-rocpd-python-bindings-${_VERSION}
         PRIVATE rocprofiler-sdk::rocprofiler-sdk-headers
@@ -206,7 +210,6 @@ function(rocprofiler_rocpd_python_bindings _VERSION)
                 rocprofiler-sdk::rocprofiler-sdk-cereal
                 rocprofiler-sdk::rocprofiler-sdk-perfetto
                 rocprofiler-sdk::rocprofiler-sdk-otf2
-                rocprofiler-sdk::rocprofiler-sdk-sqlite3
                 rocprofiler-sdk::rocprofiler-sdk-pybind11
                 rocprofiler-sdk::rocprofiler-sdk-gotcha
                 rocprofiler-sdk::rocprofiler-sdk-dw

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/CMakeLists.txt
@@ -24,7 +24,8 @@ target_link_libraries(
             rocprofiler-sdk::rocprofiler-sdk-otf2
             rocprofiler-sdk::rocprofiler-sdk-dw
             rocprofiler-sdk::rocprofiler-sdk-amd-comgr
-            rocprofiler-sdk::rocprofiler-sdk-att-parser)
+            rocprofiler-sdk::rocprofiler-sdk-att-parser
+            rocprofiler-sdk::rocprofiler-sdk-sqlite3)
 
 set_target_properties(
     rocprofiler-sdk-tool


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Avoid linking to `libsqlite3.so` in rocpd python extension library.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Python provides sqlite3 in the standard library and thus requires a `libsqlite3.so` library to be installed.
The `sqlite3` python module imports a `_sqlite3` python module which links to `libsqlite3.so`. By
importing `_sqlite3` directly and executing `ctypes.CDLL(_sqlite3.__file__, mode=ctypes.RTLD_GLOBAL)`,
we promote the `libsqlite3.so` symbols loaded by `_sqlite3` to global visibility and, thus, when we import
`libpyrocpd` within `rocpd`, the necessary sqlite3 symbols are resolved.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
ROCM-21400

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
