### PR TITLE
[RCCL-tests] [SYNC] NCCL-tests v2.18.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ All tests support the same set of arguments :
   * `-S,--report_timestamps <0/1>` Add timestamp (`"%Y-%m-%d %H:%M:%S"`) to each performance report line. Default : 0.
   * `-J,--output_file <file>` Write [JSON] output to filepath. Infer type from suffix (only `json` supported presently).
   * `-T,--timeout <time in seconds>` timeout each test after specified number of seconds. Default : disabled.
-  * `-M,--memory_report <0/1>` enable memory usage report. Default : 0
+  * `-M,--memory_report <0/1>` enable memory usage report. Default : 0.
+  * `-u,--unalign <index of first element>` Misalign source and destination buffers. Default : 0.
 
 ### Running multiple operations in parallel
 
@@ -107,4 +108,4 @@ Note that the reported bandwidth is per group, hence to get the total bandwidth 
 
 ## Copyright
 
-NCCL tests are provided under the BSD license. All source code and accompanying documentation is copyright (c) 2016-2025, NVIDIA CORPORATION. All rights reserved.
+NCCL tests are provided under the BSD license. All source code and accompanying documentation is copyright (c) 2016-2026, NVIDIA CORPORATION. All rights reserved.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ All tests support the same set of arguments :
 * Test operation
   * `-p,--parallel_init <0/1>` use threads to initialize NCCL in parallel. Default : 0.
   * `-c,--check <check iteration count>` perform count iterations, checking correctness of results on each iteration. This can be quite slow on large numbers of GPUs. Default : 1.
-  * `-z,--blocking <0/1>` Make NCCL collective blocking, i.e. have CPUs wait and sync after each collective. Default : 0.
+  * `-z,--blocking <0/1/2>` collective blocking: 1=wait for completion and barrier, 2=wait without barrier. Default : 0.
   * `-G,--cudagraph <num graph launches>` Capture iterations as a CUDA graph and then replay specified number of times. Default : 0.
   * `-C,--report_cputime <0/1>` Report CPU time instead of latency. Default : 0.
   * `-R,--local_register <0/1/2>` enable local (1) or symmetric (2) buffer registration on send/recv buffers. Default : 0.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ ./build/all_reduce_perf -b 8 -e 128M -f 2 -g 8
 ```
 
 Run 64 MPI processes on nodes with 8 GPUs each, for a total of 64 GPUs spread across 8 nodes.
-Scanning from 8 Bytes to 32GiB (Gibibytes), doubling between each test (`-f 2`).
+Scanning from 8 Bytes to 8GiB (Gibibytes), doubling between each test (`-f 2`).
 (NB: The nccl-tests binaries must be compiled with `MPI=1` for this case)
 
 ```shell

--- a/src/alltoall.cu
+++ b/src/alltoall.cu
@@ -69,6 +69,11 @@ testResult_t AlltoAllGetDevCommRequirements(int deviceImpl, ncclDevCommRequireme
       }
       reqs->barrierCount = deviceCtaCount;
       reqs->ginSignalCount = deviceCtaCount;
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 7)
+      reqs->ginConnectionType = NCCL_GIN_CONNECTION_FULL;
+#else
+      reqs->ginForceEnable = true;
+#endif
       return testSuccess;
     default:
       return testNotImplemented;

--- a/src/common.cu
+++ b/src/common.cu
@@ -1344,8 +1344,10 @@ testResult_t run() {
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2,28,0)
   ncclDevComm devComms[nThreads*nGpus];
 #endif
-  int64_t initGpuMem[nThreads] = {0};
-  int64_t bufferMemory[nThreads] = {0};
+  int64_t initGpuMem[nThreads];
+  int64_t bufferMemory[nThreads];
+  memset(initGpuMem, 0, sizeof(initGpuMem));
+  memset(bufferMemory, 0, sizeof(bufferMemory));
   if (!parallel_init) {
     // Capture the memory used by the GPUs before initializing the NCCL communicators
     int64_t* initFreeGpuMem = (int64_t*)calloc(nGpus*3, sizeof(int64_t));

--- a/src/common.cu
+++ b/src/common.cu
@@ -540,7 +540,7 @@ testResult_t startColl(struct threadArgs* args, ncclDataType_t type, ncclRedOp_t
     // Complete op before returning
     TESTCHECK(testStreamSynchronize(args->nGpus, args->streams, args->comms));
   }
-  if (blocking_coll) Barrier(args);
+  if (blocking_coll == 1) Barrier(args);
   return testSuccess;
 }
 
@@ -1167,7 +1167,7 @@ int main(int argc, char* argv[], char **envp) {
 #endif
             "[-d,--datatype <nccltype/all>] \n\t"
             "[-r,--root <root>] \n\t"
-            "[-z,--blocking <0/1>] \n\t"
+            "[-z,--blocking <0/1/2> 1=wait for completion and barrier (default behavior), 2=wait without barrier] \n\t"
             "[-y,--stream_null <0/1>] \n\t"
             "[-T,--timeout <time in seconds>] \n\t"
             "[-G,--cudagraph <num graph launches>] \n\t"

--- a/src/common.cu
+++ b/src/common.cu
@@ -1170,7 +1170,7 @@ int main(int argc, char* argv[], char **envp) {
             "[-D,--device_implementation <implementation number> enable device implementation (default: 0, use NCCL implementation; requires -R 2 if > 0)] \n\t"
             "[-V,--device_cta_count <number> set number of CTAs for device implementation (default: 16)] \n\t"
             "[-M,--memory_report <0/1> enable memory usage report (default: 0)] \n\t"
-            "[-u,--unalign <index of first element>] \n\t"
+            "[-u,--unalign <index of first element> Misalign source and destination buffers (default: 0)] \n\t"
             "[-h,--help]\n",
           basename(argv[0]));
         return 0;

--- a/src/common.cu
+++ b/src/common.cu
@@ -801,6 +801,16 @@ testResult_t threadInit(struct threadArgs* args) {
   int firstRank = args->proc*args->nThreads*args->nGpus + args->thread*args->nGpus;
   TESTCHECK(initComms(args->comms, args->nGpus, firstRank, nranks, args->gpus, args->ncclId));
 
+  /* Allocate buffers for each GPU (parallel_init: each thread allocates its own) */
+  size_t sendBytes, recvBytes;
+  ncclTestEngine.getBuffSize(&sendBytes, &recvBytes, (size_t)args->maxbytes, (size_t)nranks);
+  NCCLCHECK(ncclGroupStart());
+  for (int i = 0; i < args->nGpus; i++) {
+    CUDACHECK(cudaSetDevice(args->gpus[i]));
+    TESTCHECK(AllocateBuffs(args->sendbuffs + i, sendBytes, args->recvbuffs + i, recvBytes, args->expected + i, (size_t)args->maxbytes));
+  }
+  NCCLCHECK(ncclGroupEnd());
+
   // Capture the memory used by the GPUs after initializing the NCCL communicators
   for (int g = 0; g < args->nGpus; ++g) {
     CUDACHECK(cudaSetDevice(args->gpus[g]));

--- a/src/common.cu
+++ b/src/common.cu
@@ -101,7 +101,7 @@ int cudaGraphLaunches = 0;
 static int report_cputime = 0;
 static int report_timestamps = 0;
 static int deviceImpl = 0;
-static int unalign = 0;
+int unalign = 0;
 int memory_report = 0;
 
 int deviceCtaCount = 16; // Default number of CTAs for device implementation

--- a/src/common.cu
+++ b/src/common.cu
@@ -195,6 +195,8 @@ testResult_t initComms(ncclComm_t* comms, int nComms, int firstRank, int nRanks,
   config.nvlinkCentricSched = 1;
 #endif
 #endif
+  if (ncclTestEngine.initCommConfig)
+    ncclTestEngine.initCommConfig(&config);
 #endif
 
   NCCLCHECK(ncclGroupStart());

--- a/src/common.cu
+++ b/src/common.cu
@@ -101,6 +101,7 @@ int cudaGraphLaunches = 0;
 static int report_cputime = 0;
 static int report_timestamps = 0;
 static int deviceImpl = 0;
+static int unalign = 0;
 int memory_report = 0;
 
 int deviceCtaCount = 16; // Default number of CTAs for device implementation
@@ -716,6 +717,12 @@ testResult_t TimeTest(struct threadArgs* args, ncclDataType_t type, const char* 
   // Sync to avoid first-call timeout
   Barrier(args);
 
+  // Add forced misalignment
+  for (int i = 0; i < args->nGpus; i++) {
+    args->sendbuffs[i] = (char*)args->sendbuffs[i] + unalign * wordSize(type);
+    args->recvbuffs[i] = (char*)args->recvbuffs[i] + unalign * wordSize(type);
+  }
+
   // Warm-up for all sizes (using a stepfactor of 2)
   for (size_t size = args->minbytes; size <= args->maxbytes; size = size * 2) {
     setupArgs(size, type, args);
@@ -737,6 +744,11 @@ testResult_t TimeTest(struct threadArgs* args, ncclDataType_t type, const char* 
     }
   } while (--repeat);
 
+  // Revert forced misalignment
+  for (int i = 0; i < args->nGpus; i++) {
+    args->sendbuffs[i] = (char*)args->sendbuffs[i] - unalign * wordSize(type);
+    args->recvbuffs[i] = (char*)args->recvbuffs[i] - unalign * wordSize(type);
+  }
   return testSuccess;
 }
 
@@ -886,6 +898,7 @@ testResult_t threadLaunch(struct testThread* thread) {
 }
 
 testResult_t AllocateBuffs(void **sendbuff, size_t sendBytes, void **recvbuff, size_t recvBytes, void **expected, size_t nbytes) {
+    nbytes += 8*unalign; // pad with size of max datatype in case all datatypes selected
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2,19,0)
     NCCLCHECK(ncclMemAlloc(sendbuff, nbytes));
     NCCLCHECK(ncclMemAlloc(recvbuff, nbytes));
@@ -965,14 +978,14 @@ int main(int argc, char* argv[], char **envp) {
     {"device_implementation", required_argument, 0, 'D'},
     {"device_cta_count", required_argument, 0, 'V'},
     {"memory", required_argument, 0, 'M'},
-
+    {"unalign", required_argument, 0, 'u'},
     {"help", no_argument, 0, 'h'},
     {}
   };
 
   while(1) {
     int c;
-    c = getopt_long(argc, argv, "t:g:b:e:i:f:n:m:w:N:p:c:o:d:r:z:y:T:hG:C:a:R:x:D:V:J:S:M:", longopts, &longindex);
+    c = getopt_long(argc, argv, "t:g:b:e:i:f:n:m:w:N:p:c:o:d:r:z:y:T:hG:C:a:R:x:D:V:J:S:M:u:", longopts, &longindex);
 
     if (c == -1)
       break;
@@ -1116,6 +1129,9 @@ int main(int argc, char* argv[], char **envp) {
           return -1;
 	}
         break;
+      case 'u':
+        unalign = (int)strtol(optarg, NULL, 0);
+        break;
       case 'h':
       default:
         if (c != 'h') printf("invalid option '%c'\n", c);
@@ -1154,6 +1170,7 @@ int main(int argc, char* argv[], char **envp) {
             "[-D,--device_implementation <implementation number> enable device implementation (default: 0, use NCCL implementation; requires -R 2 if > 0)] \n\t"
             "[-V,--device_cta_count <number> set number of CTAs for device implementation (default: 16)] \n\t"
             "[-M,--memory_report <0/1> enable memory usage report (default: 0)] \n\t"
+            "[-u,--unalign <index of first element>] \n\t"
             "[-h,--help]\n",
           basename(argv[0]));
         return 0;

--- a/src/common.h
+++ b/src/common.h
@@ -6,7 +6,7 @@
 #ifndef __COMMON_H__
 #define __COMMON_H__
 
-#define NCCL_TESTS_VERSION "2.17.10"
+#define NCCL_TESTS_VERSION "2.18.0"
 
 #include "nccl.h"
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2,28,0)

--- a/src/common.h
+++ b/src/common.h
@@ -182,7 +182,7 @@ extern void Barrier(struct threadArgs* args);
 extern testResult_t TimeTest(struct threadArgs* args, ncclDataType_t type, const char* typeName, ncclRedOp_t op,  const char* opName, int root);
 extern testResult_t InitDataReduce(void* data, const size_t count, const size_t offset, ncclDataType_t type, ncclRedOp_t op, const uint64_t seed, const int nranks);
 extern testResult_t InitData(void* data, const size_t count, size_t offset, ncclDataType_t type, ncclRedOp_t op, const uint64_t seed, const int nranks, const int rank);
-extern void AllocateBuffs(void **sendbuff, void **recvbuff, void **expected, void **expectedHost, size_t nbytes, int nranks);
+extern testResult_t AllocateBuffs(void **sendbuff, size_t sendBytes, void **recvbuff, size_t recvBytes, void **expected, size_t nbytes);
 
 #include <unistd.h>
 

--- a/src/common.h
+++ b/src/common.h
@@ -6,7 +6,7 @@
 #ifndef __COMMON_H__
 #define __COMMON_H__
 
-#define NCCL_TESTS_VERSION "2.18.2"
+#define NCCL_TESTS_VERSION "2.18.3"
 
 #include "nccl.h"
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2,28,0)

--- a/src/common.h
+++ b/src/common.h
@@ -6,7 +6,7 @@
 #ifndef __COMMON_H__
 #define __COMMON_H__
 
-#define NCCL_TESTS_VERSION "2.18.1"
+#define NCCL_TESTS_VERSION "2.18.2"
 
 #include "nccl.h"
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2,28,0)

--- a/src/common.h
+++ b/src/common.h
@@ -6,7 +6,7 @@
 #ifndef __COMMON_H__
 #define __COMMON_H__
 
-#define NCCL_TESTS_VERSION "2.17.9"
+#define NCCL_TESTS_VERSION "2.17.10"
 
 #include "nccl.h"
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2,28,0)

--- a/src/common.h
+++ b/src/common.h
@@ -6,7 +6,7 @@
 #ifndef __COMMON_H__
 #define __COMMON_H__
 
-#define NCCL_TESTS_VERSION "2.18.0"
+#define NCCL_TESTS_VERSION "2.18.1"
 
 #include "nccl.h"
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2,28,0)

--- a/src/common.h
+++ b/src/common.h
@@ -112,6 +112,10 @@ struct testEngine {
   void (*getBuffSize)(size_t *sendcount, size_t *recvcount, size_t count, int nranks);
   testResult_t (*runTest)(struct threadArgs* args, int root, ncclDataType_t type,
       const char* typeName, ncclRedOp_t op, const char* opName);
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2,14,0)
+  /* Optional; called from initComms after common fields are set on ncclConfig_t. */
+  void (*initCommConfig)(ncclConfig_t* config);
+#endif
 
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2,29,0)
   testResult_t (*getDevCommRequirements)(int deviceImpl, ncclDevCommRequirements* reqs, ncclCommProperties_t* commProperties);

--- a/src/common.mk
+++ b/src/common.mk
@@ -66,7 +66,7 @@ NVCC_GENCODE ?= -gencode=arch=compute_35,code=sm_35 \
                 -gencode=arch=compute_70,code=compute_70
 endif
 
-NVCUFLAGS  := -ccbin $(CXX) $(NVCC_GENCODE) $(CXXSTD)
+NVCUFLAGS  := -ccbin $(CXX) $(NVCC_GENCODE) $(CXXSTD) --extended-lambda
 CXXFLAGS   := $(CXXSTD)
 
 LDFLAGS    := -L${CUDA_LIB} -lcudart -lrt

--- a/src/sendrecv.cu
+++ b/src/sendrecv.cu
@@ -64,6 +64,17 @@ testResult_t SendRecvRunColl(void* sendbuff, size_t sendoffset, void* recvbuff, 
   return testSuccess;
 }
 
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2,14,0)
+static void SendRecvInitCommConfig(ncclConfig_t* config) {
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2,30,0)
+  // Ring sendrecv uses two distinct peers per rank (send to rank+1, recv from rank-1).
+  config->maxP2pPeers = 2;
+#else
+  (void)config;
+#endif
+}
+#endif
+
 struct testColl sendRecvTest = {
   "SendRecv",
   SendRecvGetCollByteCount,
@@ -114,7 +125,10 @@ testResult_t SendRecvRunTest(struct threadArgs* args, int root, ncclDataType_t t
 
 struct testEngine sendRecvEngine = {
   .getBuffSize = SendRecvGetBuffSize,
-  .runTest = SendRecvRunTest
+  .runTest = SendRecvRunTest,
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2,14,0)
+  .initCommConfig = SendRecvInitCommConfig,
+#endif
 };
 
 #pragma weak ncclTestEngine=sendRecvEngine

--- a/src/util.cu
+++ b/src/util.cu
@@ -518,7 +518,8 @@ testResult_t writeDeviceReport(size_t *maxMem, int localRank, int proc, int tota
         nThreads, nGpus, minBytes, maxBytes,
         (stepFactor > 1)?stepFactor:stepBytes, (stepFactor > 1)?"factor":"bytes",
         warmup_iters, iters, agg_iters, datacheck, cudaGraphLaunches);
-  if (blocking_coll) PRINT("# Blocking Enabled: wait for completion and barrier after each collective \n");
+  if (blocking_coll == 1) PRINT("# Blocking Enabled: wait for completion and barrier after each collective \n");
+  if (blocking_coll > 1)  PRINT("# Blocking Enabled: wait for completion after each collective (no barrier) \n");
   if (parallel_init) PRINT("# Parallel Init Enabled: threads call into NcclInitRank concurrently \n");
   PRINT("#\n");
 

--- a/src/util.cu
+++ b/src/util.cu
@@ -37,6 +37,7 @@ extern int agg_iters;
 extern int parallel_init;
 extern int blocking_coll;
 extern int cudaGraphLaunches;
+extern int unalign;
 
 static FILE *json_report_fp;
 static thread_local bool write_json;
@@ -514,10 +515,10 @@ void writeBenchmarkLineBody(double timeUsec, double algBw, double busBw, bool re
 testResult_t writeDeviceReport(size_t *maxMem, int localRank, int proc, int totalProcs, int color, const char hostname[], const char *program_name) {
   PRINT("# nccl-tests version %s nccl-headers=%d nccl-library=%d\n", NCCL_TESTS_VERSION, NCCL_VERSION_CODE, test_ncclVersion);
   PRINT("# Collective test starting: %s\n", program_name);
-  PRINT("# nThread %d nGpus %d minBytes %ld maxBytes %ld step: %ld(%s) warmup iters: %d iters: %d agg iters: %d validation: %d graph: %d\n",
+  PRINT("# nThread %d nGpus %d minBytes %ld maxBytes %ld step: %ld(%s) warmup iters: %d iters: %d agg iters: %d validation: %d graph: %d unalign: %d\n",
         nThreads, nGpus, minBytes, maxBytes,
         (stepFactor > 1)?stepFactor:stepBytes, (stepFactor > 1)?"factor":"bytes",
-        warmup_iters, iters, agg_iters, datacheck, cudaGraphLaunches);
+        warmup_iters, iters, agg_iters, datacheck, cudaGraphLaunches, unalign);
   if (blocking_coll == 1) PRINT("# Blocking Enabled: wait for completion and barrier after each collective \n");
   if (blocking_coll > 1)  PRINT("# Blocking Enabled: wait for completion after each collective (no barrier) \n");
   if (parallel_init) PRINT("# Parallel Init Enabled: threads call into NcclInitRank concurrently \n");


### PR DESCRIPTION
## Motivation

Sync rccl-tests with NCCL-tests v2.18.3 (upstream master `632ad398`).

## Technical Details

Incoming upstream commits (`2535da80..632ad398`):

- New `-u,--unalign <index>` flag to force unaligned buffer addresses (+ README, help text, banner display)
- `maxP2pPeers` comm config for sendrecv (NCCL 2.30+)
- `-z,--blocking <0/1/2>`: 1=wait+barrier, 2=wait without barrier
- Allocate buffers during thread initialization (parallel-init path)
- Allow blocking collectives without `MPI_Barrier` in timing loop
- Request GIN to be explicitly enabled in alltoall (with NCCL 2.29.7 connection-type guard)
- Fix Clang VLA-initialization compile errors
- Fix compilation against latest NCCL release headers
- README: correct MPI example scanning range 32GiB → 8GiB; `-z` option clarification; 2026 copyright bump
- Version bumps 2.17.10 → 2.18.3

RCCL-specific resolutions:

- `-u` reassigned: upstream now uses `-u` for `--unalign`. The RCCL-only `--cumask` option moved from `-u` to `-U` (README + help text + getopt updated).
- `AllocateBuffs` signature combined: upstream's `testResult_t` return + per-buffer sizes + RCCL's trailing `void **bias` arg.
- Upstream's new `AllocateBuffs` call in `threadInit` (parallel-init path) plumbs `args->bias` when `test_bias` is set, matching the existing run() pattern.
- Kept RCCL `Reporter`, `enable_rotating_tensor`, `cumask`, RCCL output options, ROCM-2696 HIP_VERSION guard, AMD copyright line.

## JIRA ID

AICOMRCCL-1193

## Test Plan

- [x] Build and Run all collectives single and multi-node
- [x] Verify `-U,--cumask` still functions (flag rename)
- [x] Verify parallel-init (`-p 1`) allocation path

## Test Result

Pending.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.