### PR TITLE
clr: Pool and recycle HW signals across graph launches

### DIFF
--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -544,6 +544,19 @@ void GraphExec::BuildSyncPlan() {
       sync_plan_.leaf_segment_ids.push_back(segment.id);
     }
   }
+
+  // Create the per-graph HW event signal pool once at instantiate time
+  // (single-threaded here) and pre-create the signals, so the launch hot path
+  // only pops a ready set and patches it — never creating signals.
+  if (signalManager_ == nullptr) {
+    signalManager_ = new GraphSignalManager();
+  }
+  if (sync_plan_.num_segments > 0) {
+    // Pre-create a few sets to cover a small amount of launch overlap; the pool
+    // grows on demand if more launches are concurrently in flight.
+    constexpr int kPrecreatedSets = 16;
+    signalManager_->Prepopulate(device, sync_plan_.num_segments, kPrecreatedSets);
+  }
 }
 
 // ================================================================================================
@@ -1779,15 +1792,32 @@ hipError_t GraphExec::UpdatePacketBatchesForNodeEnableDisable(hip::GraphNode* no
   return hipSuccess;
 }
 
-void GraphExec::DecrementRefCount(cl_event event, cl_int command_exec_status, void* user_data) {
-  GraphExec* graphExec = reinterpret_cast<GraphExec*>(user_data);
+// Carries the per-launch state needed by the completion callback: the graph
+// whose refcount to drop, plus the signal set (and its device) to re-arm and
+// return to the pool now that the launch's GPU work is done.
+struct GraphLaunchCleanup {
+  GraphExec* exec;
+  amd::Device* device;
+  std::vector<void*> signal_set;
+};
+
+void GraphExec::OnLaunchComplete(cl_event event, cl_int command_exec_status, void* user_data) {
+  auto* cleanup = reinterpret_cast<GraphLaunchCleanup*>(user_data);
+  GraphExec* graphExec = cleanup->exec;
+  // Re-arm and recycle the launch's signals while the GraphExec (and thus its
+  // signal pool) is still alive, then drop the launch's reference.
+  if (graphExec->signalManager_ != nullptr && !cleanup->signal_set.empty()) {
+    graphExec->signalManager_->ReleaseSet(cleanup->device, cleanup->signal_set);
+  }
+  delete cleanup;
   graphExec->release();
 }
 
 // ================================================================================================
 amd::Command* GraphExec::EnqueueSegmentedGraph(hip::Stream* launch_stream,
                                                const std::vector<hip::Stream*>& streams,
-                                               hipError_t* out_status) {
+                                               hipError_t* out_status,
+                                               std::vector<void*>* out_signal_set) {
   hipError_t status = hipSuccess;
   if (out_status != nullptr) {
     *out_status = hipSuccess;
@@ -1795,10 +1825,17 @@ amd::Command* GraphExec::EnqueueSegmentedGraph(hip::Stream* launch_stream,
 
   auto* device = g_devices[launch_stream->DeviceId()]->devices()[0];
 
-  // Allocate HW events for all segments
+  // Top-level launches recycle signals through the per-graph pool; the legacy
+  // recursive child-graph path (out_signal_set == nullptr) creates them locally
+  // and lets the AccumulateCommand destructor destroy them.
+  const bool recycle = (out_signal_set != nullptr);
+
   std::vector<void*> segment_hw_events;
   if (sync_plan_.num_segments > 0) {
-    if (!device->CreateHwEvents(sync_plan_.num_segments, segment_hw_events)) {
+    const bool ok = recycle
+        ? signalManager_->AcquireSet(device, sync_plan_.num_segments, segment_hw_events)
+        : device->CreateHwEvents(sync_plan_.num_segments, segment_hw_events);
+    if (!ok) {
       if (out_status != nullptr) {
         *out_status = hipErrorOutOfMemory;
       }
@@ -1825,13 +1862,21 @@ amd::Command* GraphExec::EnqueueSegmentedGraph(hip::Stream* launch_stream,
   // and serves as the dispatch anchor for all segments across all streams.
   auto* graph_accumulate = new amd::AccumulateCommand(*launch_stream, {}, nullptr);
 
-  // Register HW events with graph_accumulate for lifetime tracking.
-  // addHwEvent does not retain — ownership transfers from CreateHwEvents
-  // to graph_accumulate. ~AccumulateCommand releases them after graph completion.
+  // Register HW events with graph_accumulate so profiling can read them.
   for (auto& hw_event : segment_hw_events) {
     if (hw_event != nullptr) {
       graph_accumulate->addHwEvent(hw_event, device);
     }
+  }
+
+  // For the recycling (top-level) path, the pool owns the signals: hand the set
+  // back to the caller, which forwards it to the completion callback
+  // (OnLaunchComplete) that re-arms and returns it to the pool. Tell the
+  // AccumulateCommand destructor not to destroy them. The legacy path keeps the
+  // default (destructor destroys the locally created signals).
+  if (recycle && !segment_hw_events.empty()) {
+    graph_accumulate->setOwnsHwEvents(false);
+    *out_signal_set = segment_hw_events;
   }
 
   // Process segments level by level
@@ -1977,7 +2022,14 @@ hipError_t GraphExec::EnqueueSegment(const Segment& segment, hip::Stream* stream
         }
       }
 
-      // Recursively enqueue the child graph with its own dependency tracking
+      // Recursively enqueue the child graph with its own dependency tracking.
+      // TODO: child graphs currently take the legacy create/destroy signal path
+      // (out_signal_set == nullptr -> recycle == false), so their pre-created
+      // signal pool (from the child's BuildSyncPlan/Prepopulate) sits unused and
+      // they pay signal_create/destroy every launch. To pool child signals too,
+      // pass an out_signal_set here and recycle it from the parent's
+      // OnLaunchComplete (the parent's accumulate completion encloses the
+      // child's work); the cleanup would carry per-pool (manager, set) pairs.
       hipError_t child_status = hipSuccess;
       amd::Command* child_last_cmd =
           childGraphExec->EnqueueSegmentedGraph(stream, {}, &child_status);
@@ -2366,6 +2418,14 @@ hipError_t GraphExec::Run(hip::Stream* launch_stream) {
   launch_stream->vdev()->AcquireQueueWithPreference();
   UpdateStreams(launch_stream);
 
+  // Signals borrowed from the per-graph pool for this launch (segmented path
+  // only); handed to the completion callback to re-arm and return to the pool.
+  std::vector<void*> launch_signal_set;
+
+  // Command whose completion drives OnLaunchComplete. On the segmented path we
+  // reuse the graph's own accumulate command instead of enqueuing a dedicated marker
+  amd::Command* completion_cmd = nullptr;
+
   if (use_segment_scheduling_ && instantiateDeviceId_ == launch_stream->DeviceId()) {
     // If the graph has kernels that does device side allocation,  during packet capture, heap is
     // allocated because heap pointer has to be added to the AQL packet, and initialized during
@@ -2378,16 +2438,16 @@ hipError_t GraphExec::Run(hip::Stream* launch_stream) {
     amd::Command* last_cmd = nullptr;
     if (max_streams_dev_.size() == 1) {
       // Single-device: pass collision-handled streams_ to EnqueueSegmentedGraph
-      last_cmd = EnqueueSegmentedGraph(launch_stream, streams_, &status);
+      last_cmd = EnqueueSegmentedGraph(launch_stream, streams_, &status, &launch_signal_set);
     } else {
       // Multi-device: pass empty vector, will use parallel_streams_ internally
-      last_cmd = EnqueueSegmentedGraph(launch_stream, {}, &status);
+      last_cmd = EnqueueSegmentedGraph(launch_stream, {}, &status, &launch_signal_set);
     }
 
-    // Release the last command as we don't need to track it for top-level graph execution
-    if (last_cmd != nullptr) {
-      last_cmd->release();
-    }
+    // Drive OnLaunchComplete off this command's completion (its leaf-sync deps
+    // already imply all parallel work is done). Our reference is released after
+    // the callback is registered below; the queue keeps it alive until done.
+    completion_cmd = last_cmd;
   } else if (max_streams_ == 1 && instantiateDeviceId_ != launch_stream->DeviceId()) {
     for (int i = 0; i < topoOrder_.size(); i++) {
       topoOrder_[i]->SetStream(launch_stream);
@@ -2411,19 +2471,131 @@ hipError_t GraphExec::Run(hip::Stream* launch_stream) {
       ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_CODE, "[hipGraph] graph dump:%s", filename.c_str());
     }
   }
-  amd::Command* CallbackCommand = new amd::Marker(*launch_stream, kMarkerDisableFlush, {});
-  // we may not need to flush any caches.
-  CallbackCommand->setCommandEntryScope(amd::Device::kCacheStateIgnore);
+  // Register the refcount/recycle callback. Prefer the graph's own accumulate
+  // command (segmented path); otherwise enqueue a lightweight marker just to
+  // carry the callback.
+  amd::Command* CallbackCommand = completion_cmd;
+  const bool own_callback_cmd = (CallbackCommand == nullptr);
+  if (own_callback_cmd) {
+    CallbackCommand = new amd::Marker(*launch_stream, kMarkerDisableFlush, {});
+    // we may not need to flush any caches.
+    CallbackCommand->setCommandEntryScope(amd::Device::kCacheStateIgnore);
+  }
   amd::Event& event = CallbackCommand->event();
   constexpr bool kBlocking = false;
-  if (!event.setCallback(CL_COMPLETE, GraphExec::DecrementRefCount, this, kBlocking)) {
-    this->release();
+  auto* cleanup = new GraphLaunchCleanup();
+  cleanup->exec = this;
+  cleanup->device = g_devices[launch_stream->DeviceId()]->devices()[0];
+  cleanup->signal_set = std::move(launch_signal_set);
+  if (!event.setCallback(CL_COMPLETE, GraphExec::OnLaunchComplete, cleanup, kBlocking)) {
+    // setCallback essentially never fails, but if it does the launch's GPU work
+    // is already queued (the accumulate is enqueued and was told not to destroy
+    // its signals). Drain that work, then run the same completion handling the
+    // callback would have (recycle the borrowed pooled signals + drop our
+    // reference) so they are not leaked and the pool does not shrink.
+    launch_stream->finish();
+    OnLaunchComplete(nullptr, CL_COMPLETE, cleanup);
     CallbackCommand->release();
     return hipErrorInvalidHandle;
   }
-  CallbackCommand->enqueue();
+  // The marker must be enqueued to run; the accumulate command is already
+  // enqueued by EnqueueSegmentedGraph. Either way, release our reference: the
+  // queue keeps the command alive until completion, when the callback fires.
+  if (own_callback_cmd) {
+    CallbackCommand->enqueue();
+  }
   CallbackCommand->release();
   return status;
+}
+
+// ================================================================================================
+GraphSignalManager::~GraphSignalManager() {
+  // No launches can be in flight at this point (GraphExec refcount guarantees
+  // it outlives all launches), so every set is back in the free pool.
+  for (auto& dev_pool : free_sets_) {
+    amd::Device* device = dev_pool.first;
+    for (auto& set : dev_pool.second) {
+      // Pooled signals rest armed (value 1); mark them idle before destroy so
+      // ~ProfilingSignal does not block waiting on an armed-but-idle signal.
+      device->QuiesceHwEvents(set);
+      for (void* sig : set) {
+        if (sig != nullptr) {
+          // Pair with CreateHwEvents() so non-ROCm devices can hook teardown.
+          device->DestroyHwEvent(sig);
+        }
+      }
+    }
+  }
+  free_sets_.clear();
+}
+
+bool GraphSignalManager::Prepopulate(amd::Device* device, int count, int num_sets) {
+  if (count <= 0 || num_sets <= 0) {
+    return true;
+  }
+  std::lock_guard<std::mutex> lock(lock_);
+  auto& pool = free_sets_[device];
+
+  // BuildSyncPlan is re-runnable, so Prepopulate may be called more than once.
+  // If a prior run sized the sets for a different segment count, those sets are
+  // unusable -- destroy and rebuild. No launches are in flight at (re)instantiate
+  // time, so every set for this device is present in the free pool here.
+  if (!pool.empty() && static_cast<int>(pool.back().size()) != count) {
+    for (auto& set : pool) {
+      device->QuiesceHwEvents(set);
+      for (void* sig : set) {
+        if (sig != nullptr) {
+          device->DestroyHwEvent(sig);
+        }
+      }
+    }
+    pool.clear();
+  }
+
+  // Top up to num_sets only; do not unconditionally append on every call, which
+  // would grow the pool without bound across re-instantiations.
+  for (int i = static_cast<int>(pool.size()); i < num_sets; ++i) {
+    std::vector<void*> set;
+    if (!device->CreateHwEvents(count, set)) {
+      return false;
+    }
+    pool.push_back(std::move(set));
+  }
+  return true;
+}
+
+bool GraphSignalManager::AcquireSet(amd::Device* device, int count,
+                                    std::vector<void*>& out_set) {
+  if (count <= 0) {
+    out_set.clear();
+    return true;
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(lock_);
+    auto& pool = free_sets_[device];
+    if (!pool.empty()) {
+      // Hot path: just hand out a ready (already-armed) set, then patch it.
+      out_set = std::move(pool.back());
+      pool.pop_back();
+      return true;
+    }
+  }
+
+  // Fallback only: more launches in flight than pre-created sets. Create one
+  // (armed to 1 by CreateHwEvents); it joins the pool when released.
+  return device->CreateHwEvents(count, out_set);
+}
+
+void GraphSignalManager::ReleaseSet(amd::Device* device, std::vector<void*>& set) {
+  if (set.empty()) {
+    return;
+  }
+  // Re-arm the signals for the next launch. Safe here because this runs from
+  // the launch completion callback, so the GPU work that used them is done.
+  device->ResetHwEvents(set);
+  std::lock_guard<std::mutex> lock(lock_);
+  free_sets_[device].push_back(std::move(set));
 }
 
 // ================================================================================================

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -174,6 +174,30 @@ class GraphKernelArgManager : public amd::ReferenceCountedObject,
   using KernelArgImpl = device::Settings::KernelArgImpl;
 };
 
+//! Per-GraphExec pool of HW event sets.
+class GraphSignalManager : public amd::ReferenceCountedObject {
+ public:
+  GraphSignalManager() : amd::ReferenceCountedObject() {}
+  ~GraphSignalManager();
+
+  //! Pre-create `num_sets` signal sets of `count` signals each at instantiate
+  //! time, so launches never pay signal creation on the hot path.
+  bool Prepopulate(amd::Device* device, int count, int num_sets);
+
+  //! Acquire a ready signal set for a single launch. Pops from the free pool;
+  //! only creates a new set as a fallback if the pool is unexpectedly empty.
+  bool AcquireSet(amd::Device* device, int count, std::vector<void*>& out_set);
+
+  //! Re-arm a used set and return it to the free pool. Called from the launch
+  //! completion callback, which guarantees the launch's GPU work has finished.
+  void ReleaseSet(amd::Device* device, std::vector<void*>& set);
+
+ private:
+  std::mutex lock_;
+  //! Per-device stack of free signal sets available for reuse.
+  std::unordered_map<amd::Device*, std::vector<std::vector<void*>>> free_sets_;
+};
+
 class GraphNode : public hipGraphNodeDOTAttribute {
  protected:
   /// Copy Constructor. This is protected to prevent accidental copies causing unexpected behaviors.
@@ -977,6 +1001,10 @@ class GraphExec : public amd::ReferenceCountedObject, public Graph {
         kernArgManager_->release();
       }
     }
+    if (signalManager_ != nullptr) {
+      signalManager_->release();
+      signalManager_ = nullptr;
+    }
 
     segmentBatches_.clear();
   }
@@ -1015,13 +1043,21 @@ class GraphExec : public amd::ReferenceCountedObject, public Graph {
     kernArgManager_ = kernArgManager;
   }
   GraphKernelArgManager* GetKernelArgManager() { return kernArgManager_; }
-  static void DecrementRefCount(cl_event event, cl_int command_exec_status, void* user_data);
+  // Completion callback for a graph launch: re-arms and returns the launch's
+  // pooled signals, then drops the launch's reference on the GraphExec.
+  static void OnLaunchComplete(cl_event event, cl_int command_exec_status, void* user_data);
   hipError_t CaptureAndFormPacketsForGraph();
   void GetKernelArgSizeForGraph(std::unordered_map<int, size_t>& kernArgSizeForGraph);
 
+  //! out_signal_set, when non-null, marks the top-level launch path: signals
+  //! are taken from the per-graph pool and returned via this out-parameter so
+  //! the completion callback can re-arm and recycle them. When null (legacy /
+  //! recursive child-graph path), signals are created locally and destroyed by
+  //! the AccumulateCommand destructor.
   amd::Command* EnqueueSegmentedGraph(hip::Stream* launch_stream,
                                       const std::vector<hip::Stream*>& streams,
-                                      hipError_t* out_status = nullptr);
+                                      hipError_t* out_status = nullptr,
+                                      std::vector<void*>* out_signal_set = nullptr);
   hipError_t EnqueueSegment(const Segment& segment, hip::Stream* stream,
                             amd::AccumulateCommand* accumulate);
 
@@ -1047,6 +1083,7 @@ class GraphExec : public amd::ReferenceCountedObject, public Graph {
   std::unordered_map<int, std::vector<hip::Stream*>> parallel_streams_;
   uint64_t flags_ = 0;
   GraphKernelArgManager* kernArgManager_ = nullptr;  //!< Kernel Arg manager for graph.
+  GraphSignalManager* signalManager_ = nullptr;      //!< HW event signal pool for graph launches.
   bool hasHiddenHeap_ = false;  //!< Hidden heap indicator for Kernel node
   std::unordered_set<int> hiddenHeapInitializedDevices_;
   bool repeatLaunch_ = false;

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -2120,6 +2120,16 @@ class Device : public RuntimeObject {
   virtual bool CreateHwEvents(int count, std::vector<void*>& hw_events) const { return false; }
   virtual void DestroyHwEvent(void* hw_event) const {}
 
+  //! Re-arm already-allocated HW event signals so they can be reused by a new
+  //! graph launch (resets the signal value and cached timing). Used by the
+  //! graph signal pool to avoid create/destroy on every launch.
+  virtual void ResetHwEvents(const std::vector<void*>& hw_events) const {}
+
+  //! Mark pooled HW event signals as idle/completed (store the done value)
+  //! before they are destroyed. Pooled signals rest in the armed state, so this
+  //! prevents signal destruction from blocking on an armed-but-idle signal.
+  virtual void QuiesceHwEvents(const std::vector<void*>& hw_events) const {}
+
   struct HwEventPatch {
     static constexpr int kCompletionSignal = -1;
     static constexpr int kExtDispatchDepSignal = -2;

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -3717,6 +3717,35 @@ void Device::DestroyHwEvent(void* hw_event) const {
 }
 
 // ================================================================================================
+void Device::ResetHwEvents(const std::vector<void*>& hw_events) const {
+  // Re-arm pooled signals for reuse by a new graph launch. The caller
+  // guarantees these signals belong to a completed (drained) launch, so this
+  // cannot corrupt an in-flight launch. Avoids signal_create/destroy on the
+  // hot launch path.
+  for (void* hw_event : hw_events) {
+    if (hw_event != nullptr) {
+      auto* ps = reinterpret_cast<ProfilingSignal*>(hw_event);
+      Hsa::signal_silent_store_relaxed(ps->signal_, 1);
+      ps->flags_.done_ = true;
+      ps->ResetCachedTiming();
+    }
+  }
+}
+
+// ================================================================================================
+void Device::QuiesceHwEvents(const std::vector<void*>& hw_events) const {
+  // Pooled signals rest in the armed state (value 1). Before destruction, store
+  // the completed value (0) so ~ProfilingSignal does not block waiting on a
+  // signal that is armed but idle (no GPU work will ever drain it).
+  for (void* hw_event : hw_events) {
+    if (hw_event != nullptr) {
+      auto* ps = reinterpret_cast<ProfilingSignal*>(hw_event);
+      Hsa::signal_silent_store_relaxed(ps->signal_, 0);
+    }
+  }
+}
+
+// ================================================================================================
 uint8_t* Device::CreateBarrierPacket() const {
   static constexpr uint16_t kBarrierNopHeader =
       (HSA_PACKET_TYPE_BARRIER_AND << HSA_PACKET_HEADER_TYPE) |

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -490,6 +490,8 @@ class Device : public NullDevice {
   virtual void RetainGlobalSignal(void* signal) const override;
   virtual bool CreateHwEvents(int count, std::vector<void*>& hw_events) const override;
   virtual void DestroyHwEvent(void* hw_event) const override;
+  virtual void ResetHwEvents(const std::vector<void*>& hw_events) const override;
+  virtual void QuiesceHwEvents(const std::vector<void*>& hw_events) const override;
   virtual uint8_t* CreateBarrierPacket() const override;
   virtual void ApplyHwEventPatches(const std::vector<HwEventPatch>& patches,
                                    const std::vector<void*>& hw_events) const override;

--- a/projects/clr/rocclr/platform/command.cpp
+++ b/projects/clr/rocclr/platform/command.cpp
@@ -63,6 +63,11 @@ Event::~Event() {
 
 // ================================================================================================
 AccumulateCommand::~AccumulateCommand() {
+  // When an external owner (e.g. the graph signal pool) reclaims the signals,
+  // do not destroy them here.
+  if (!owns_hw_events_) {
+    return;
+  }
   // Release all retained HW events per device
   for (auto& device_events_pair : hw_events_) {
     Device* dev = device_events_pair.first;

--- a/projects/clr/rocclr/platform/command.hpp
+++ b/projects/clr/rocclr/platform/command.hpp
@@ -1526,6 +1526,9 @@ class AccumulateCommand : public Command {
   std::vector<std::pair<uint64_t, uint64_t>> tsList_;
   //! HW events that need to be released when this command is destroyed
   std::unordered_map<Device*, std::vector<void*>> hw_events_;
+  //! When false, the destructor does not destroy hw_events_ (an external owner,
+  //! e.g. the graph signal pool, reclaims them instead).
+  bool owns_hw_events_ = true;
 
  public:
   //! Create a new Marker
@@ -1537,9 +1540,11 @@ class AccumulateCommand : public Command {
   virtual ~AccumulateCommand();
 
   //! Add HW event to the list for later cleanup.
-  //! Does not retain — caller owns the reference. Attached events are
-  //! released via ReleaseGlobalSignal in ~AccumulateCommand when the
-  //! profiling signals are destroyed after graph completion.
+  //! Does not retain — caller owns the reference. By default (owns_hw_events_ ==
+  //! true) attached events are released via ReleaseGlobalSignal in
+  //! ~AccumulateCommand after graph completion. If an external owner recycles
+  //! them (see setOwnsHwEvents(false), e.g. the graph signal pool), the
+  //! destructor leaves them untouched.
   void addHwEvent(void* hw_event, Device* device = nullptr) {
     if (hw_event != nullptr) {
       Device* dev = (device != nullptr) ? device : const_cast<Device*>(device_);
@@ -1551,6 +1556,11 @@ class AccumulateCommand : public Command {
 
   //! Get HW events map (for profiling pre-patched graph signals)
   const std::unordered_map<Device*, std::vector<void*>>& getHwEvents() const { return hw_events_; }
+
+  //! Control whether the destructor destroys the attached HW event signals.
+  //! Set to false when an external owner (e.g. the graph signal pool) recycles
+  //! them across launches instead.
+  void setOwnsHwEvents(bool owns) { owns_hw_events_ = owns; }
 
   //! Add kernel name to the list if available
   void addKernelName(const std::string* kernelName) { kernelNames_.push_back(kernelName); }


### PR DESCRIPTION
Pre-create per-graph HW signals at instantiate time via GraphSignalManager and reuse them on each launch (packet patching only) instead of creating/destroying signals per launch. A launch-completion callback (OnLaunchComplete) re-arms and returns the signals to the pool after the launch's GPU work drains, and also drops the launch's GraphExec reference.

Signals are quiesced (set to 0) before graph destruction to avoid blocking on armed-but-idle pooled signals.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
