### PR TITLE
rocr: svm_profiler: surface rescheduled queue restore events

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/svm_profiler.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/svm_profiler.cpp
@@ -226,6 +226,7 @@ void SvmProfileControl::PollSmi() {
             assert(args == 3 && "Parsing error!");
 
             std::string detail;
+            bool restore_rescheduled = false;
             cursor += offset + 1;
             switch (event_id) {
               //@addr(size) from->to prefetch_location:preferred_location
@@ -311,11 +312,22 @@ void SvmProfileControl::PollSmi() {
                 detail = cause + " " + agent;
                 break;
               }
-              // gpu_id
+              // gpu_id [rescheduled]
+              // The kernel emits both real queue restores and
+              // svm_range_restore_work reschedule retries under this same
+              // event ID, distinguished only by a trailing discriminator
+              // byte: '0' for an actual resume, 'R' when the restore work
+              // failed validation and was requeued. Decode that byte so a
+              // high QUEUE_RESTORE count caused by MMU-notifier eviction
+              // churn (reschedule retries) can be told apart from genuine
+              // queue resumes. The trailing byte is optional: kernels that
+              // do not emit it simply parse as a non-rescheduled restore.
               case HSA_SMI_EVENT_QUEUE_RESTORE: {
                 uint32_t gpuid;
-                args = sscanf(cursor, "%x", &gpuid);
-                assert(args == 1 && "Parsing error!");
+                char tag = '0';
+                args = sscanf(cursor, "%x %c", &gpuid, &tag);
+                assert(args >= 1 && "Parsing error!");
+                restore_rescheduled = (args == 2 && tag == 'R');
                 std::string agent = format_agent(gpuid);
                 detail = agent;
                 break;
@@ -341,8 +353,10 @@ void SvmProfileControl::PollSmi() {
               default:;
             }
 
+            const char* event_name = restore_rescheduled ? "QUEUE_RESTORE_RESCHEDULED"
+                                                          : smi_event_string(event_id);
             std::string record = std::string("ROCr HMM event: ") + std::to_string(time) + " " +
-                smi_event_string(event_id) + " " + detail;
+                event_name + " " + detail;
             // printf("%s\n", record.c_str());
             fprintf(logFile, "%s\n", record.c_str());
           }


### PR DESCRIPTION
## Motivation

The KFD SMI event interface emits both `kfd_smi_event_queue_restore()` (queues were actually resumed) and `kfd_smi_event_queue_restore_rescheduled()` (`svm_range_restore_work` cmpxchg failed and the work was requeued) under the same event ID `KFD_SMI_EVENT_QUEUE_RESTORE = 10`, distinguished only by a trailing `'0'` or `'R'` character in the payload string. `svm_profiler.cpp` parses only `%x` for the gpuid in its `QUEUE_RESTORE` case and discards the trailing byte, so `HSA_SVM_PROFILE` logs show both kinds of events as identical `QUEUE_RESTORE` lines. This hides the difference between actual queue resumes and reschedule retries, inflating `QUEUE_RESTORE` counts under workloads with high MMU-notifier churn (e.g. jemalloc/tcmalloc page-decay `madvise(MADV_DONTNEED)` storms) and making the logs unusable for diagnosing whether a high restore count reflects real work or workqueue retry pressure.

## Technical Details

This change decodes the trailing discriminator byte the existing kernel already emits — **no kernel change is required**. It reads information the running KFD already provides.

- **`runtime/hsa-runtime/core/runtime/svm_profiler.cpp`**:
  - In the `HSA_SMI_EVENT_QUEUE_RESTORE` parser, read the optional trailing byte with `"%x %c"` and set a `restore_rescheduled` flag when it is `'R'`. The byte is optional, so the parse accepts `args >= 1`: kernels that do not emit it simply parse as a non-rescheduled restore.
  - When `restore_rescheduled` is set, log the record as `QUEUE_RESTORE_RESCHEDULED` instead of `QUEUE_RESTORE`.

No `libhsakmt` uAPI header change and no new SMI event subscription are needed; the distinction is derived entirely from the existing `QUEUE_RESTORE` event payload.

### Backwards / forwards compatibility

The trailing byte is optional. On kernels that emit the `'0'`/`'R'` discriminator the two cases are now distinguished; on kernels that emit no trailing byte the `QUEUE_RESTORE` line is unchanged. No other SMI event parsing is affected.

## JIRA ID

N/A

## Test Plan

1. Build `libhsa-runtime64.so` with this change.
2. Run an SVM-heavy workload with `HSA_SVM_PROFILE=/tmp/svm.log` set.
3. Trigger MMU-notifier churn (e.g. an allocator page-decay against ranges with active GPU residence) so that `svm_range_restore_work` is forced to reschedule.
4. Inspect `/tmp/svm.log` and confirm real queue restores appear as `QUEUE_RESTORE` while reschedule retries appear as `QUEUE_RESTORE_RESCHEDULED`, and the two are no longer conflated.

## Test Result

- Applies cleanly on `develop`; `libhsa-runtime64.so` compiles and links with no new warnings.
- Decode logic unit-validated against the exact payloads the kernel produces: `"<gpuid> 0"` → `QUEUE_RESTORE`, `"<gpuid> R"` → `QUEUE_RESTORE_RESCHEDULED`, and `"<gpuid>"` (no trailing byte) → `QUEUE_RESTORE`.
- No new asserts and no parser regressions on the other SMI event types in the same code path.

## Submission Checklist

- [x] Looked over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
