### PR TITLE
clr: add ROC_FORCE_STAGED_D2H env flag

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -52,7 +52,9 @@ bool DmaBlitManager::readBuffer(device::Memory& srcMemory, void* dstHost,
     const_address addrSrc = gpuMem(srcMemory).getDeviceMemory() + origin[0];
     address addrDst = reinterpret_cast<address>(dstHost);
     constexpr bool kHostToDev = false;
-    constexpr bool kEnablePin = true;
+    // ROC_FORCE_STAGED_D2H forces the staging-buffer path: no user-pointer
+    // pin and no svm_range install on the host destination.
+    const bool kEnablePin = !ROC_FORCE_STAGED_D2H;
     if (!hsaCopyStagedOrPinned(addrSrc, addrDst, copySize, kHostToDev, copyMetadata, kEnablePin)) {
       LogError("DmaBlitManager:: readBuffer copy failure!");
       return false;
@@ -136,7 +138,10 @@ bool DmaBlitManager::writeBuffer(const void* srcHost, device::Memory& dstMemory,
     address dstAddr = gpuMem(dstMemory).getDeviceMemory() + origin[0];
     const_address srcAddr = reinterpret_cast<const_address>(srcHost);
     constexpr bool kHostToDev = true;
-    constexpr bool enablePin = true;
+    // ROC_FORCE_STAGED_D2H is direction-symmetric: applying it to H2D as
+    // well ensures host source pointers also avoid persistent svm_range
+    // install.
+    const bool enablePin = !ROC_FORCE_STAGED_D2H;
     if (!hsaCopyStagedOrPinned(srcAddr, dstAddr, copySize, kHostToDev, copyMetadata, enablePin)) {
       LogError("DmaBlitManager:: writeBuffer copy failure!");
       return false;

--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -209,6 +209,14 @@ release(bool, ROC_USE_FGS_KERNARG, true,                                      \
         "Use fine grain kernel args segment for supported asics")             \
 release(uint, ROC_P2P_SDMA_SIZE, 1024,                                        \
         "The minimum size in KB for P2P transfer with SDMA")                  \
+release(bool, ROC_FORCE_STAGED_D2H, false,                                    \
+        "Force linear D2H/H2D hipMemcpy through ROCm-internal staging "       \
+        "buffers instead of pinning the user host pointer. Avoids "           \
+        "installing persistent svm_ranges that can be subsequently evicted "  \
+        "by userspace allocator page-decay "                                  \
+        "(jemalloc/tcmalloc/glibc madvise(MADV_DONTNEED)). Trade-off: "       \
+        "per-chunk CPU memcpy through staging buffer; may regress "           \
+        "bandwidth for large unpinned host dst.")                             \
 release(uint, ROC_AQL_QUEUE_SIZE, 16384,                                      \
         "AQL queue size in AQL packets")                                      \
 release(uint, ROC_SIGNAL_POOL_SIZE, 64,                                       \


### PR DESCRIPTION
## Motivation

Add an opt-in env flag that forces `DmaBlitManager` D2H/H2D linear transfers through ROCm-internal staging buffers instead of pinning the user host pointer via `MemoryRegion::Lock` → `KfdDriver::RegisterMemory` → `hsakmt_fmm_register_memory`.

When a user host pointer (e.g. `malloc` / `jemalloc` / `tcmalloc` memory) is passed as a `hipMemcpy` destination, the current path takes the pin branch in `DmaBlitManager::getBuffer` and allocates an `amd::Buffer(CL_MEM_USE_HOST_PTR)`. Constructing that buffer's device view calls `MemoryRegion::Lock`, which on dGPU with `HSA_USE_SVM=1` routes through `fmm_register_mem_svm_api` and issues an `AMDKFD_IOC_SVM(OP_SET_ATTR)` ioctl. That installs a persistent `svm_range` in the kernel with an `mmu_interval_notifier` attached to the user VA range.

The `amd::Buffer` is added to the issuing command's `pinned_memory_` list and only released when the HostQueue processes the command's `releaseResources()`. Under sustained `hipMemcpyAsync` traffic (e.g. checkpoint flushes that issue many async D2H copies in a tight burst) these buffers — and their underlying `svm_range`s with `mmu_interval_notifier`s — accumulate before the queue drains.

Subsequent `madvise(MADV_DONTNEED)` on the same VAs (the standard behavior of every modern userspace allocator's page-decay path: jemalloc, tcmalloc, glibc) fires `MMU_NOTIFY_CLEAR` on each still-live `svm_range`, which `kfd_svm.c` handles as an eviction: `svm_range_cpu_invalidate_pagetables` → `svm_range_evict` → `kgd2kfd_quiesce_mm`. All KFD queues belonging to the process are quiesced, then `svm_range_restore_work` re-faults the pages onto fresh scattered backing via `amdgpu_hmm_range_get_pages`. The resulting fragmented physical mapping increases GPU TLB pressure on any workload that subsequently streams through those VAs, e.g. collective communication kernels.

With `ROC_FORCE_STAGED_D2H=1` the linear D2H/H2D paths drop into the existing staging-buffer branch of `DmaBlitManager::getBuffer`, which uses `gpu().Staging().Acquire()` to get a chunk of ROCm-internal pre-pinned memory. The user host pointer is never registered with the GPU; no `svm_range` is installed; the subsequent `madvise` on the allocator's decay timer has nothing to invalidate.

## Technical Details

- **`rocclr/utils/flags.hpp`**: add a new `release(bool, ...)` entry `ROC_FORCE_STAGED_D2H` defaulting to `false`. 
- **`rocclr/device/rocm/rocblit.cpp`**:in `DmaBlitManager::readBuffer` and `DmaBlitManager::writeBuffer`, replace the hard-coded `constexpr bool kEnablePin = true` with `const bool kEnablePin = !ROC_FORCE_STAGED_D2H`. The 6th argument to `hsaCopyStagedOrPinned` controls whether `getBuffer` takes the pin branch (calling `pinHostMemory` → `MemoryRegion::Lock`) or the staging branch (using `gpu().Staging().Acquire(...)`). When the flag is set, the call site forces the staging branch.

`DmaBlitManager::readBufferRect` / `writeBufferRect` call `hsaCopyStagedOrPinned` without the `enablePin` argument, which defaults to `false` in `rocblit.hpp`. They therefore already use the staging branch unconditionally; no change is required for them.

Trade-off: the staging path adds one CPU `memcpy` per chunk between the user buffer and the ROCm-internal staging buffer. For GPU-compute-bound workloads (where collective communication / TLB pressure dominates), this overhead is below the noise floor of what the flag avoids. For CPU-bandwidth-bound workloads (very large host destinations, no downstream GPU traffic), the staging copy may regress bandwidth. The flag is opt-in for exactly this reason.

Backwards compatibility: default value is `false`. With the flag unset, all existing behavior is unchanged. There are no public API changes; the flag is internal to clr. `hipMallocManaged` / `hipHostRegister` / explicit pin APIs are unaffected, only the auto-Lock path triggered by `hipMemcpy*` is gated by this flag.

## Test Plan

1. Build `libamdhip64.so` with this patch on a system with an MI300-class or newer dGPU and `HSA_USE_SVM=1` (the default).
2. Run a synthetic D2H-heavy workload (e.g. repeated `tensor.cpu()` from a deep-learning framework) on `jemalloc`-managed memory with aggressive decay tuning to amplify `madvise(MADV_DONTNEED)` frequency.
3. Capture kernel-side SVM event counts via `HSA_SVM_PROFILE` pointed at a per-rank log directory, and capture a subsequent collective communication latency (e.g. AllGather 128 MB).
4. Repeat with `ROC_FORCE_STAGED_D2H=0` (baseline) and `ROC_FORCE_STAGED_D2H=1` (patched path).
5. Verify:
   - The `ROC_FORCE_STAGED_D2H=1` run produces a dramatically lower SVM event count (no svm_range install on user dst).
   - The `ROC_FORCE_STAGED_D2H=1` run does not regress the collective communication latency.
   - The `ROC_FORCE_STAGED_D2H=0` run reproduces the prior behavior bit-for-bit (no regression from this PR for the default code path).
6. Run the existing clr unit test suite to confirm no breakage in either configuration.

## Test Result

On AMD MI355X (`gfx950`) with the same `libamdhip64.so` (only the env var differs):

| Configuration | AllGather slowdown after D2H burst | Kernel SVM events (8 ranks total) |
|---|---|---|
| `ROC_FORCE_STAGED_D2H=0` (default) | 2.16× | 38,303 |
| `ROC_FORCE_STAGED_D2H=1`           | 1.07× | 148 |

The remaining 1.07× ratio reflects the per-chunk CPU memcpy overhead of the staging path which is far below the original 2.16× slowdown caused by svm_range eviction churn. Same SVM API enabled in both runs; `hipMallocManaged` users are unaffected. No regressions observed in the existing clr unit test suite for either flag setting.

## Submission Checklist

- [x] Looked over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
