### PR TITLE
[ROCM-25398] Fix CPER invalid-free crash on zero-byte debugfs nodes

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -34,6 +34,10 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 ### Resolved Issues
 
+- **Fixed `amdsmi_get_gpu_cper_entries()` crash (`free(): invalid pointer` / `SIGABRT`) when the CPER node reports zero bytes**.  
+  - debugfs CPER nodes (`/sys/kernel/debug/dri/<N>/amdgpu_ring_cper`) report `st_size == 0` because their content is generated on read. The previous `std::ifstream`-based read allocated a zero-byte buffer and left an STL `basic_filebuf` whose destructor could perform an invalid free across the library boundary when `libamd_smi.so` is `LD_PRELOAD`-ed alongside a different host libstdc++ (the device-metrics-exporter / `gpuagent` scenario), aborting the process and zeroing all GPU metrics.
+  - Reverted the CPER file read to POSIX `open`/`read`/`close`, which performs no STL allocation across the library boundary and returns `AMDSMI_STATUS_FILE_ERROR` cleanly on zero-byte or short reads. The file descriptor is now closed on every exit path, also fixing a latent fd leak on the short-read branch.
+
 - **Fixed `amdsmi_init()` aborting entirely when CPU/ESMI initialization fails**.  
   - `populate_amd_cpus()` treated an `esmi_init()` failure (non-AMD CPU, missing/unsupported energy or HSMP driver, or a CPU/SMU in a bad state) as fatal, causing all of `amdsmi_init()` to fail so GPU and NIC functionality became unusable. ESMI/CPU discovery is now non-fatal and is skipped on failure, mirroring the NIC discovery paths.
   - Removed an incorrect `static_cast<amdsmi_status_t>(esmi_init())` that conflated the unrelated `esmi_status_t` and `amdsmi_status_t` enums.

--- a/projects/amdsmi/src/amd_smi/amd_smi_cper.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_cper.cc
@@ -24,6 +24,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include <cerrno>
 #include <cstring>
 #include <memory>
 #include <sstream>
@@ -102,12 +103,17 @@ static auto amdsmi_read_cper_file(const std::string& filepath) -> CperFileCtx {
   ctx.file_size = file_stats.st_size;
   ctx.buffer = std::make_unique<char[]>(ctx.file_size);
 
-  // Use POSIX open/read/close rather than std::ifstream. debugfs CPER nodes
+  // Read with POSIX open/read/close rather than std::ifstream. The hazard is
+  // not open() vs ifstream itself, but where the memory is allocated and freed:
+  // std::ifstream owns a std::basic_filebuf whose internal buffer is allocated
+  // and later torn down (in its destructor) by the libstdc++ bound to this
+  // library. When libamd_smi.so is LD_PRELOAD-ed alongside a different host
+  // libstdc++, that destructor can free a pointer the host allocator never
+  // owned, producing "free(): invalid pointer". debugfs CPER nodes
   // (e.g. /sys/kernel/debug/dri/<N>/amdgpu_ring_cper) report st_size == 0
-  // because their content is generated on read. An ifstream over such a node
-  // allocates an internal filebuf whose destructor can crash (invalid free)
-  // when the library is LD_PRELOAD-ed alongside the host libstdc++. The POSIX
-  // path performs no STL allocation across the library boundary (ROCM-25398).
+  // because their content is generated on read, which is the case that
+  // triggered the abort. POSIX I/O performs no STL allocation across the
+  // library boundary, avoiding the issue entirely (ROCM-25398).
   int fd = open(filepath.c_str(), O_RDONLY);
   if (fd == -1) {
     ss << __PRETTY_FUNCTION__ << "\n:" << __LINE__ << "[CPER] failed to open file: " << filepath
@@ -115,7 +121,7 @@ static auto amdsmi_read_cper_file(const std::string& filepath) -> CperFileCtx {
     LOG_ERROR(ss);
     return ctx;
   }
-  long bytes_read = read(fd, ctx.buffer.get(), ctx.file_size);
+  auto bytes_read = read(fd, ctx.buffer.get(), ctx.file_size);
   if (bytes_read <= 0) {
     ss << __PRETTY_FUNCTION__ << "\n:" << __LINE__
        << "[CPER] failed to read complete file, read only  " << bytes_read << " of "

--- a/projects/amdsmi/src/amd_smi/amd_smi_cper.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_cper.cc
@@ -20,10 +20,11 @@
  * THE SOFTWARE.
  */
 
+#include <fcntl.h>
 #include <sys/stat.h>
+#include <unistd.h>
 
 #include <cstring>
-#include <fstream>
 #include <memory>
 #include <sstream>
 
@@ -101,21 +102,29 @@ static auto amdsmi_read_cper_file(const std::string& filepath) -> CperFileCtx {
   ctx.file_size = file_stats.st_size;
   ctx.buffer = std::make_unique<char[]>(ctx.file_size);
 
-  std::ifstream file(filepath, std::ios::binary);
-  if (!file) {
-    ss << __PRETTY_FUNCTION__ << "\n:" << __LINE__ << "[CPER] failed to open file: " << filepath;
+  // Use POSIX open/read/close rather than std::ifstream. debugfs CPER nodes
+  // (e.g. /sys/kernel/debug/dri/<N>/amdgpu_ring_cper) report st_size == 0
+  // because their content is generated on read. An ifstream over such a node
+  // allocates an internal filebuf whose destructor can crash (invalid free)
+  // when the library is LD_PRELOAD-ed alongside the host libstdc++. The POSIX
+  // path performs no STL allocation across the library boundary (ROCM-25398).
+  int fd = open(filepath.c_str(), O_RDONLY);
+  if (fd == -1) {
+    ss << __PRETTY_FUNCTION__ << "\n:" << __LINE__ << "[CPER] failed to open file: " << filepath
+       << ", errno:(" << errno << "): " << strerror(errno);
     LOG_ERROR(ss);
     return ctx;
   }
-  file.read(ctx.buffer.get(), ctx.file_size);
-  long bytes_read = file.gcount();
+  long bytes_read = read(fd, ctx.buffer.get(), ctx.file_size);
   if (bytes_read <= 0) {
     ss << __PRETTY_FUNCTION__ << "\n:" << __LINE__
        << "[CPER] failed to read complete file, read only  " << bytes_read << " of "
        << ctx.file_size << " bytes";
     LOG_ERROR(ss);
+    close(fd);
     return ctx;
   }
+  close(fd);
 
   ctx.status = AMDSMI_STATUS_SUCCESS;
   ctx.file_size = bytes_read;

--- a/projects/amdsmi/tests/amd_smi_test/functional/cper_read.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/cper_read.cc
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+// Regression tests for ROCM-25398: amdsmi_get_gpu_cper_entries crashed with
+// "free(): invalid pointer" / SIGABRT when the CPER node reported a zero byte
+// size (the case for debugfs amdgpu_ring_cper nodes, whose content is generated
+// on read). These tests exercise the read error path directly via
+// amdsmi_get_gpu_cper_entries_by_path() and require no GPU. They must return a
+// clean error status without aborting the process.
+
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+#include <cstdint>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+#include "amd_smi/impl/amd_smi_cper.h"
+
+namespace {
+
+// Drives the CPER read path against a caller supplied file and returns the
+// status. All output parameters are valid so that validation succeeds and the
+// file read is actually attempted.
+static amdsmi_status_t CallCperByPath(const char* path) {
+  std::vector<char> cper_data(4096, 0);
+  std::vector<amdsmi_cper_hdr_t*> cper_hdrs(8, nullptr);
+  uint64_t buf_size = cper_data.size();
+  uint64_t entry_count = cper_hdrs.size();
+  uint64_t cursor = 0;
+
+  return amdsmi_get_gpu_cper_entries_by_path(path, 0xFFFFFFFF, cper_data.data(), &buf_size,
+                                             cper_hdrs.data(), &entry_count, &cursor,
+                                             /*product_serial=*/0);
+}
+
+}  // namespace
+
+// A zero-size regular file reproduces the debugfs amdgpu_ring_cper case exactly:
+// stat() reports S_ISREG with st_size == 0. Before the fix this aborted the
+// process inside the std::ifstream filebuf destructor.
+TEST(amdsmitstReadOnly, CperReadZeroSizeFile) {
+  char tmpl[] = "/tmp/amdsmi_cper_zero_XXXXXX";
+  int fd = mkstemp(tmpl);
+  ASSERT_NE(fd, -1) << "failed to create temp file";
+  close(fd);  // leave it empty -> st_size == 0
+
+  amdsmi_status_t status = CallCperByPath(tmpl);
+  unlink(tmpl);
+
+  EXPECT_EQ(status, AMDSMI_STATUS_FILE_ERROR);
+}
+
+// A non-existent path must report a clean status, never crash.
+TEST(amdsmitstReadOnly, CperReadMissingFile) {
+  amdsmi_status_t status = CallCperByPath("/tmp/amdsmi_cper_does_not_exist_12345");
+  EXPECT_NE(status, AMDSMI_STATUS_SUCCESS);
+}

--- a/projects/amdsmi/tests/amd_smi_test/functional/cper_read.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/cper_read.cc
@@ -60,19 +60,20 @@ static amdsmi_status_t CallCperByPath(const char* path) {
 // stat() reports S_ISREG with st_size == 0. Before the fix this aborted the
 // process inside the std::ifstream filebuf destructor.
 TEST(amdsmitstReadOnly, CperReadZeroSizeFile) {
-  char tmpl[] = "/tmp/amdsmi_cper_zero_XXXXXX";
-  int fd = mkstemp(tmpl);
+  std::string tmpl = "/tmp/amdsmi_cper_zero_XXXXXX";
+  int fd = mkstemp(tmpl.data());
   ASSERT_NE(fd, -1) << "failed to create temp file";
   close(fd);  // leave it empty -> st_size == 0
 
-  amdsmi_status_t status = CallCperByPath(tmpl);
-  unlink(tmpl);
+  amdsmi_status_t status = CallCperByPath(tmpl.c_str());
+  unlink(tmpl.c_str());
 
   EXPECT_EQ(status, AMDSMI_STATUS_FILE_ERROR);
 }
 
-// A non-existent path must report a clean status, never crash.
+// A non-existent path must report a clean status, never crash. stat() fails for
+// a missing path, so the read helper reports AMDSMI_STATUS_NOT_SUPPORTED.
 TEST(amdsmitstReadOnly, CperReadMissingFile) {
   amdsmi_status_t status = CallCperByPath("/tmp/amdsmi_cper_does_not_exist_12345");
-  EXPECT_NE(status, AMDSMI_STATUS_SUCCESS);
+  EXPECT_EQ(status, AMDSMI_STATUS_NOT_SUPPORTED);
 }


### PR DESCRIPTION
## Motivation

`amdsmi_get_gpu_cper_entries()` aborted with `free(): invalid pointer` / `SIGABRT`
when the CPER node reported `st_size == 0`. This is the case for debugfs
`amdgpu_ring_cper` nodes, whose content is generated on read. In the
device-metrics-exporter / gpuagent scenario (where `libamd_smi.so` is
`LD_PRELOAD`-ed alongside a different host libstdc++), this aborted the process
and zeroed all GPU metrics. Reproduced on MI300X (gfx942) and R9700S (gfx1201).

## Technical Details

The `std::ifstream`-based CPER read allocated a zero-byte buffer and left an STL
`basic_filebuf` whose destructor could perform an invalid free across the library
boundary when the library's allocator disagreed with the host deallocator.

This change reverts the CPER file read to POSIX `open`/`read`/`close`, which
performs no STL allocation across the library boundary and returns
`AMDSMI_STATUS_FILE_ERROR` cleanly on zero-byte or short reads. The file
descriptor is now closed on every exit path, also fixing a latent fd leak on the
short-read branch. No public-API change.

## JIRA ID

Resolves ROCM-25398.

## Test Plan

Added `tests/amd_smi_test/functional/cper_read.cc`: self-registering GTests that
drive `amdsmi_get_gpu_cper_entries_by_path()` against a zero-size temp file (the
debugfs repro) and a missing path, asserting a clean error status
(`AMDSMI_STATUS_FILE_ERROR`) with no abort. No GPU required.

## Test Result

- `make amd_smi amdsmitst` — exit 0, no errors/warnings on changed files.
- `amdsmitst` with `*Cper*` filter — 2/2 passed, no abort.
- `pre-commit run --all-files` — all hooks passed.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
