### PR TITLE
[rocshmem] Add stream-ordered team barrier/sync host APIs, bindings and tests

### DIFF
--- a/projects/rocshmem/include/rocshmem/rocshmem.hpp
+++ b/projects/rocshmem/include/rocshmem/rocshmem.hpp
@@ -549,9 +549,7 @@ __host__ void rocshmem_barrier_all_on_stream(hipStream_t stream);
  * @brief enqueues a collective barrier across all PEs in \p team on given
  * stream.
  *
- * The barrier is stream-ordered: it executes after previously enqueued work on
- * \p stream and before subsequently enqueued work. Passing
- * ROCSHMEM_TEAM_INVALID is a no-op (nothing is enqueued).
+ * Passing ROCSHMEM_TEAM_INVALID is a no-op.
  *
  * @param[in] team    Team participating in the barrier.
  * @param[in] stream  HIP stream on which to enqueue the operation.

--- a/projects/rocshmem/include/rocshmem/rocshmem.hpp
+++ b/projects/rocshmem/include/rocshmem/rocshmem.hpp
@@ -527,11 +527,39 @@ __host__ void rocshmem_quiet_on_stream(hipStream_t stream);
 __host__ void rocshmem_barrier_all();
 
 /**
+ * @brief perform a collective barrier across all PEs in \p team.
+ * The caller is blocked until the barrier is resolved.
+ *
+ * Passing ROCSHMEM_TEAM_INVALID is a no-op.
+ *
+ * @param[in] team Team participating in the barrier.
+ *
+ * @return void
+ */
+__host__ void rocshmem_barrier(rocshmem_team_t team);
+
+/**
  * @brief enqueues a collective barrier on given stream.
  *
  * @return void
  */
 __host__ void rocshmem_barrier_all_on_stream(hipStream_t stream);
+
+/**
+ * @brief enqueues a collective barrier across all PEs in \p team on given
+ * stream.
+ *
+ * The barrier is stream-ordered: it executes after previously enqueued work on
+ * \p stream and before subsequently enqueued work. Passing
+ * ROCSHMEM_TEAM_INVALID is a no-op (nothing is enqueued).
+ *
+ * @param[in] team    Team participating in the barrier.
+ * @param[in] stream  HIP stream on which to enqueue the operation.
+ *
+ * @return void
+ */
+__host__ void rocshmem_barrier_on_stream(rocshmem_team_t team,
+                                         hipStream_t stream);
 
 /**
  * @brief enqueues a sync_all operation on given stream.
@@ -541,6 +569,23 @@ __host__ void rocshmem_barrier_all_on_stream(hipStream_t stream);
  * @return void
  */
 __host__ void rocshmem_sync_all_on_stream(hipStream_t stream);
+
+/**
+ * @brief enqueues a team-scoped sync across all PEs in \p team on given stream.
+ *
+ * In contrast with rocshmem_barrier_on_stream, rocshmem_team_sync_on_stream
+ * only ensures completion and visibility of previously issued memory stores and
+ * does not ensure completion of remote memory updates issued via OpenSHMEM
+ * routines. The sync is stream-ordered. Passing ROCSHMEM_TEAM_INVALID is a
+ * no-op (nothing is enqueued).
+ *
+ * @param[in] team    Team participating in the sync.
+ * @param[in] stream  HIP stream on which to enqueue the operation.
+ *
+ * @return void
+ */
+__host__ void rocshmem_team_sync_on_stream(rocshmem_team_t team,
+                                           hipStream_t stream);
 
 /**
  * @brief enqueues an alltoall collective operation on given stream.
@@ -665,6 +710,22 @@ __host__ void rocshmem_signal_wait_until_on_stream(uint64_t *sig_addr, int cmp,
  * @return void
  */
 __host__ void rocshmem_sync_all();
+
+/**
+ * @brief registers the arrival of a PE at a team-scoped sync.
+ * The caller is blocked until synchronization is resolved across \p team.
+ *
+ * In contrast with rocshmem_barrier, rocshmem_team_sync only ensures
+ * completion and visibility of previously issued memory stores and does not
+ * ensure completion of remote memory updates issued via OpenSHMEM routines.
+ *
+ * Passing ROCSHMEM_TEAM_INVALID is a no-op.
+ *
+ * @param[in] team Team participating in the sync.
+ *
+ * @return void
+ */
+__host__ void rocshmem_team_sync(rocshmem_team_t team);
 
 /**
  * @brief allows any PE to force the termination of an entire program.

--- a/projects/rocshmem/include/rocshmem/rocshmem_COLL.hpp
+++ b/projects/rocshmem/include/rocshmem/rocshmem_COLL.hpp
@@ -742,12 +742,32 @@ __host__ int rocshmem_ctx_double_prod_reduce(
 __global__ ATTR_NO_INLINE void rocshmem_barrier_all_kernel();
 
 /**
+ * @brief kernel for performing a team-scoped barrier synchronization.
+ * Caller enqueues the kernel on given stream.
+ *
+ * @param[in] team  The team participating in the barrier.
+ *
+ * @return void
+ */
+__global__ ATTR_NO_INLINE void rocshmem_barrier_kernel(rocshmem_team_t team);
+
+/**
  * @brief kernel for performing a sync_all operation.
  * Caller enqueues the kernel on given stream
  *
  * @return void
  */
 __global__ ATTR_NO_INLINE void rocshmem_sync_all_kernel();
+
+/**
+ * @brief kernel for performing a team-scoped sync operation.
+ * Caller enqueues the kernel on given stream.
+ *
+ * @param[in] team  The team participating in the sync.
+ *
+ * @return void
+ */
+__global__ ATTR_NO_INLINE void rocshmem_team_sync_kernel(rocshmem_team_t team);
 
 /**
  * @brief kernel for performing an alltoall collective operation.

--- a/projects/rocshmem/python/README.md
+++ b/projects/rocshmem/python/README.md
@@ -218,10 +218,23 @@ Pass `ROCSHMEM_TEAM_WORLD` (`0`) as the team handle for world-scope collectives.
 | Function | Description |
 |---|---|
 | `rocshmem_barrier_all()` | Barrier across all PEs |
-| `rocshmem_barrier_all_on_stream(stream)` | Stream-ordered barrier |
+| `rocshmem_barrier_all_on_stream(stream)` | Stream-ordered barrier across all PEs |
+| `rocshmem_barrier(team)` | Blocking barrier across all PEs in `team` |
+| `rocshmem_barrier_on_stream(team, stream)` | Stream-ordered team barrier; `ROCSHMEM_TEAM_INVALID` is a no-op |
+| `rocshmem_team_sync(team)` | Team member rendezvous plus local-store visibility (lighter than barrier) |
+| `rocshmem_team_sync_on_stream(team, stream)` | Stream-ordered team sync; `ROCSHMEM_TEAM_INVALID` is a no-op |
+| `rocshmem_sync_all()` | World-scope sync (local-store visibility) |
+| `rocshmem_sync_all_on_stream(stream)` | Stream-ordered world sync |
 | `rocshmem_fence()` | Ordering fence |
 | `rocshmem_quiet()` | Wait for all outstanding operations |
 | `hip_device_synchronize()` | Synchronize the current HIP device |
+
+Team-scoped calls use the same `team` handle conventions as collectives
+(`ROCSHMEM_TEAM_WORLD` or a handle from `rocshmem_team_split_strided`).
+Non-members of a child team should pass `ROCSHMEM_TEAM_INVALID` (`-1`); the
+runtime returns without enqueueing work. If RMA was issued on a HIP stream,
+synchronize that stream before a *blocking* `rocshmem_barrier(team)`; use
+`rocshmem_barrier_on_stream` on the same stream as the RMA for overlap.
 
 ### Atomic Operations
 

--- a/projects/rocshmem/python/rocshmem4py/__init__.py
+++ b/projects/rocshmem/python/rocshmem4py/__init__.py
@@ -42,7 +42,9 @@ try:
         rocshmem_buffer_unregister_all,
         rocshmem_ptr,
         rocshmem_barrier_all,
+        rocshmem_barrier,
         rocshmem_barrier_all_on_stream,
+        rocshmem_barrier_on_stream,
         rocshmem_fence,
         rocshmem_quiet,
         rocshmem_get_uniqueid,
@@ -57,7 +59,9 @@ try:
         rocshmem_signal_wait_until_on_stream,
         TeamConfig,
         rocshmem_sync_all,
+        rocshmem_team_sync,
         rocshmem_sync_all_on_stream,
+        rocshmem_team_sync_on_stream,
         # TODO: rocshmem_ctx_{create,destroy,fence,quiet} to be added later
         # due to IPC no-MPI HostInterface aborting on non-MPI WindowInfo
         # rocshmem_ctx_create,

--- a/projects/rocshmem/python/src/rocshmem4py.cc
+++ b/projects/rocshmem/python/src/rocshmem4py.cc
@@ -133,10 +133,18 @@ PYBIND11_MODULE(_rocshmem4py, m) {
 
   // Synchronization
   m.def("rocshmem_barrier_all", []() { rocshmem_barrier_all(); });
+  m.def("rocshmem_barrier", [](intptr_t team) {
+    rocshmem_barrier(resolve_team_handle(team));
+  }, "Barrier across all PEs in team.", py::arg("team"));
 
   m.def("rocshmem_barrier_all_on_stream", [](intptr_t stream) {
     rocshmem_barrier_all_on_stream((hipStream_t)stream);
   }, "Stream-ordered barrier across all PEs", py::arg("stream"));
+
+  m.def("rocshmem_barrier_on_stream", [](intptr_t team, intptr_t stream) {
+    rocshmem_barrier_on_stream(resolve_team_handle(team), (hipStream_t)stream);
+  }, "Stream-ordered barrier across all PEs in team (ROCSHMEM_TEAM_INVALID is a no-op).",
+     py::arg("team"), py::arg("stream"));
 
   m.def("rocshmem_fence", []() { rocshmem_fence(); });
   m.def("rocshmem_quiet", []() { rocshmem_quiet(); });
@@ -256,9 +264,18 @@ PYBIND11_MODULE(_rocshmem4py, m) {
   m.def("rocshmem_sync_all", []() { rocshmem_sync_all(); },
     "Lighter-weight partner to barrier_all (local-store visibility).");
 
+  m.def("rocshmem_team_sync", [](intptr_t team) {
+    rocshmem_team_sync(resolve_team_handle(team));
+  }, "Lighter-weight sync across all PEs in team.", py::arg("team"));
+
   m.def("rocshmem_sync_all_on_stream", [](intptr_t stream) {
     rocshmem_sync_all_on_stream((hipStream_t)stream);
   }, "Stream-ordered sync_all.", py::arg("stream"));
+
+  m.def("rocshmem_team_sync_on_stream", [](intptr_t team, intptr_t stream) {
+    rocshmem_team_sync_on_stream(resolve_team_handle(team), (hipStream_t)stream);
+  }, "Stream-ordered lighter-weight sync across all PEs in team (ROCSHMEM_TEAM_INVALID is a no-op).",
+     py::arg("team"), py::arg("stream"));
 
   // -------------------------------------------------------------------------
   // Full host AMO matrix

--- a/projects/rocshmem/python/tests/hip_test_utils.py
+++ b/projects/rocshmem/python/tests/hip_test_utils.py
@@ -1,0 +1,105 @@
+"""Shared HIP ctypes helpers for torch-free Python tests."""
+
+from __future__ import annotations
+
+import ctypes
+
+import pytest
+
+try:
+    _hip = ctypes.CDLL("libamdhip64.so")
+except OSError as e:
+    pytest.skip(f"libamdhip64.so not loadable: {e}", allow_module_level=True)
+
+
+HIP_MEMCPY_HOST_TO_DEVICE = 1
+HIP_MEMCPY_DEVICE_TO_HOST = 2
+
+_hip.hipDeviceSynchronize.restype = ctypes.c_int
+_hip.hipMemcpy.restype = ctypes.c_int
+_hip.hipMemcpy.argtypes = [
+    ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int,
+]
+_hip.hipStreamCreate.restype = ctypes.c_int
+_hip.hipStreamCreate.argtypes = [ctypes.POINTER(ctypes.c_void_p)]
+_hip.hipStreamDestroy.restype = ctypes.c_int
+_hip.hipStreamDestroy.argtypes = [ctypes.c_void_p]
+_hip.hipStreamSynchronize.restype = ctypes.c_int
+_hip.hipStreamSynchronize.argtypes = [ctypes.c_void_p]
+
+
+def hip_check(rc: int, fn: str) -> None:
+    if rc != 0:
+        raise RuntimeError(f"{fn} failed with HIP error {rc}")
+
+
+def _as_void_p(buf: object) -> ctypes.c_void_p:
+    try:
+        return ctypes.cast(buf, ctypes.c_void_p)
+    except (TypeError, ctypes.ArgumentError):
+        return ctypes.cast(ctypes.byref(buf), ctypes.c_void_p)
+
+
+def h2d(device_ptr: int, host_buf: object) -> None:
+    hip_check(
+        _hip.hipMemcpy(
+            ctypes.c_void_p(device_ptr),
+            _as_void_p(host_buf),
+            ctypes.sizeof(host_buf),
+            HIP_MEMCPY_HOST_TO_DEVICE,
+        ),
+        "hipMemcpy H2D",
+    )
+
+
+def d2h(host_buf: object, device_ptr: int) -> None:
+    hip_check(
+        _hip.hipMemcpy(
+            _as_void_p(host_buf),
+            ctypes.c_void_p(device_ptr),
+            ctypes.sizeof(host_buf),
+            HIP_MEMCPY_DEVICE_TO_HOST,
+        ),
+        "hipMemcpy D2H",
+    )
+
+
+def hip_sync() -> None:
+    hip_check(_hip.hipDeviceSynchronize(), "hipDeviceSynchronize")
+
+
+def store_u64(device_ptr: int, value: int) -> None:
+    host_value = ctypes.c_uint64(value)
+    h2d(device_ptr, host_value)
+
+
+def load_u64(device_ptr: int) -> int:
+    host_value = ctypes.c_uint64()
+    d2h(host_value, device_ptr)
+    return int(host_value.value)
+
+
+class HipStream:
+    """Context-manager wrapping a raw hipStream_t."""
+
+    def __init__(self) -> None:
+        s = ctypes.c_void_p()
+        hip_check(_hip.hipStreamCreate(ctypes.byref(s)), "hipStreamCreate")
+        self._handle = s
+
+    @property
+    def handle(self) -> int:
+        return self._handle.value or 0
+
+    def synchronize(self) -> None:
+        hip_check(
+            _hip.hipStreamSynchronize(self._handle), "hipStreamSynchronize"
+        )
+
+    def __enter__(self) -> "HipStream":
+        return self
+
+    def __exit__(self, *exc) -> None:
+        if self._handle:
+            _hip.hipStreamDestroy(self._handle)
+            self._handle = ctypes.c_void_p()

--- a/projects/rocshmem/python/tests/test_smoke.py
+++ b/projects/rocshmem/python/tests/test_smoke.py
@@ -23,97 +23,9 @@ import ctypes
 import pytest
 
 from conftest import requires_multi_pe  # noqa: E402
+from hip_test_utils import HipStream, d2h, h2d, hip_sync  # noqa: E402
 
 import rocshmem4py  # noqa: E402
-
-
-# ---------------------------------------------------------------------------
-# Minimal HIP ctypes shim (just enough to move bytes and drive a stream)
-# ---------------------------------------------------------------------------
-
-try:
-    _hip = ctypes.CDLL("libamdhip64.so")
-except OSError as e:
-    pytest.skip(f"libamdhip64.so not loadable: {e}", allow_module_level=True)
-
-HIP_MEMCPY_HOST_TO_DEVICE = 1
-HIP_MEMCPY_DEVICE_TO_HOST = 2
-
-_hip.hipDeviceSynchronize.restype = ctypes.c_int
-_hip.hipMemcpy.restype = ctypes.c_int
-_hip.hipMemcpy.argtypes = [
-    ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int,
-]
-_hip.hipStreamCreate.restype = ctypes.c_int
-_hip.hipStreamCreate.argtypes = [ctypes.POINTER(ctypes.c_void_p)]
-_hip.hipStreamDestroy.restype = ctypes.c_int
-_hip.hipStreamDestroy.argtypes = [ctypes.c_void_p]
-_hip.hipStreamSynchronize.restype = ctypes.c_int
-_hip.hipStreamSynchronize.argtypes = [ctypes.c_void_p]
-
-
-def _hip_check(rc: int, fn: str) -> None:
-    if rc != 0:
-        raise RuntimeError(f"{fn} failed with HIP error {rc}")
-
-
-def h2d(device_ptr: int, host_buf) -> None:
-    _hip_check(
-        _hip.hipMemcpy(
-            ctypes.c_void_p(device_ptr),
-            ctypes.cast(host_buf, ctypes.c_void_p),
-            ctypes.sizeof(host_buf),
-            HIP_MEMCPY_HOST_TO_DEVICE,
-        ),
-        "hipMemcpy H2D",
-    )
-
-
-def d2h(host_buf, device_ptr: int) -> None:
-    _hip_check(
-        _hip.hipMemcpy(
-            ctypes.cast(host_buf, ctypes.c_void_p),
-            ctypes.c_void_p(device_ptr),
-            ctypes.sizeof(host_buf),
-            HIP_MEMCPY_DEVICE_TO_HOST,
-        ),
-        "hipMemcpy D2H",
-    )
-
-
-def hip_sync() -> None:
-    _hip_check(_hip.hipDeviceSynchronize(), "hipDeviceSynchronize")
-
-
-class HipStream:
-    """Context-manager wrapping a raw hipStream_t.
-
-    The integer handle matches the type expected by ``rocshmem_*_on_stream``
-    bindings.  In torch environments the equivalent is
-    ``torch.cuda.current_stream().cuda_stream``.
-    """
-
-    def __init__(self) -> None:
-        s = ctypes.c_void_p()
-        _hip_check(_hip.hipStreamCreate(ctypes.byref(s)), "hipStreamCreate")
-        self._handle = s
-
-    @property
-    def handle(self) -> int:
-        return self._handle.value or 0
-
-    def synchronize(self) -> None:
-        _hip_check(
-            _hip.hipStreamSynchronize(self._handle), "hipStreamSynchronize"
-        )
-
-    def __enter__(self) -> "HipStream":
-        return self
-
-    def __exit__(self, *exc) -> None:
-        if self._handle:
-            _hip.hipStreamDestroy(self._handle)
-            self._handle = ctypes.c_void_p()
 
 
 # ---------------------------------------------------------------------------

--- a/projects/rocshmem/python/tests/test_smoke.py
+++ b/projects/rocshmem/python/tests/test_smoke.py
@@ -23,7 +23,7 @@ import ctypes
 import pytest
 
 from conftest import requires_multi_pe  # noqa: E402
-from tests.hip_test_utils import HipStream, d2h, h2d, hip_sync  # noqa: E402
+from hip_test_utils import HipStream, d2h, h2d, hip_sync  # noqa: E402
 
 import rocshmem4py  # noqa: E402
 

--- a/projects/rocshmem/python/tests/test_smoke.py
+++ b/projects/rocshmem/python/tests/test_smoke.py
@@ -23,7 +23,7 @@ import ctypes
 import pytest
 
 from conftest import requires_multi_pe  # noqa: E402
-from hip_test_utils import HipStream, d2h, h2d, hip_sync  # noqa: E402
+from tests.hip_test_utils import HipStream, d2h, h2d, hip_sync  # noqa: E402
 
 import rocshmem4py  # noqa: E402
 

--- a/projects/rocshmem/python/tests/test_team_collectives.py
+++ b/projects/rocshmem/python/tests/test_team_collectives.py
@@ -67,6 +67,10 @@ def test_team_collective_symbols_are_exported():
     for name in (
         "rocshmem_alltoallmem_on_stream",
         "rocshmem_broadcastmem_on_stream",
+        "rocshmem_barrier",
+        "rocshmem_team_sync",
+        "rocshmem_barrier_on_stream",
+        "rocshmem_team_sync_on_stream",
         "rocshmem_global_exit",
         "rocshmem_dump_stats",
         "rocshmem_reset_stats",

--- a/projects/rocshmem/python/tests/test_teams.py
+++ b/projects/rocshmem/python/tests/test_teams.py
@@ -32,7 +32,7 @@ from rocshmem4py import (
     rocshmem_getmem_on_stream,
 )
 from conftest import requires_multi_pe
-from tests.hip_test_utils import HipStream, load_u64, store_u64
+from hip_test_utils import HipStream, load_u64, store_u64
 
 # Wall-clock delay before the delayed team member enters a collective.
 # Override on slow CI hosts: ROCSHMEM_TEST_TEAM_DELAY_S=2.5 pytest ...

--- a/projects/rocshmem/python/tests/test_teams.py
+++ b/projects/rocshmem/python/tests/test_teams.py
@@ -2,9 +2,10 @@
 Multi-PE tests; require at least 2 PEs.
 """
 
+import time
+
 import pytest
 
-import rocshmem4py
 from rocshmem4py import (
     ROCSHMEM_SUCCESS,
     ROCSHMEM_TEAM_INVALID,
@@ -23,8 +24,13 @@ from rocshmem4py import (
     rocshmem_barrier_on_stream,
     rocshmem_team_sync_on_stream,
     hip_device_synchronize,
+    rocshmem_malloc,
+    rocshmem_free,
+    rocshmem_putmem_on_stream,
+    rocshmem_getmem_on_stream,
 )
 from conftest import requires_multi_pe
+from hip_test_utils import HipStream, load_u64, store_u64
 
 
 def test_team_config_struct():
@@ -69,10 +75,10 @@ def test_split_strided_even_subteam():
     )
     assert status == ROCSHMEM_SUCCESS
 
-    me = rocshmem_my_pe()
-    if me % 2 == 0:
+    my_pe = rocshmem_my_pe()
+    if my_pe % 2 == 0:
         assert team != ROCSHMEM_TEAM_INVALID
-        assert rocshmem_team_my_pe(team) == me // 2
+        assert rocshmem_team_my_pe(team) == my_pe // 2
         assert rocshmem_team_n_pes(team) == even_size
     else:
         # Odd PEs are non-members of the even-subteam; the binding's
@@ -111,12 +117,12 @@ def test_split_strided_subset_parent_then_split():
     if n < 4:
         pytest.skip("requires >= 4 PEs to form non-trivial subset parents")
 
-    me = rocshmem_my_pe()
+    my_pe = rocshmem_my_pe()
     cfg = TeamConfig()
     cfg.num_contexts = 1
 
     # ---------- Step 1: subset parent via parity split ----------
-    parity = me % 2
+    parity = my_pe % 2
     start_pe = parity  # 0 for even, 1 for odd
     subset_size = n // 2
     if (n % 2) != 0 and parity == 0:
@@ -127,11 +133,11 @@ def test_split_strided_subset_parent_then_split():
     )
     assert status == ROCSHMEM_SUCCESS
     assert subset_parent != ROCSHMEM_TEAM_INVALID, (
-        f"PE {me}: subset parent (parity={parity}, size={subset_size}) "
+        f"PE {my_pe}: subset parent (parity={parity}, size={subset_size}) "
         "must be valid; every PE is a member of exactly one parity subset"
     )
     assert rocshmem_team_n_pes(subset_parent) == subset_size
-    assert rocshmem_team_my_pe(subset_parent) == me // 2
+    assert rocshmem_team_my_pe(subset_parent) == my_pe // 2
 
     # ---------- Step 2: split the subset parent (non-WORLD) into halves ----------
     subset_n = rocshmem_team_n_pes(subset_parent)
@@ -152,7 +158,7 @@ def test_split_strided_subset_parent_then_split():
     )
     assert status == ROCSHMEM_SUCCESS
     assert child != ROCSHMEM_TEAM_INVALID, (
-        f"PE {me}: child team (subset_parent parity={parity}, "
+        f"PE {my_pe}: child team (subset_parent parity={parity}, "
         f"start={child_start}, size={child_size}) must be valid; every PE in "
         "the subset parent participates in exactly one half"
     )
@@ -179,18 +185,18 @@ def test_split_strided_recursive_split_world():
     if n < 4:
         pytest.skip("requires >= 4 PEs so each half can be split again")
 
-    me = rocshmem_my_pe()
+    my_pe = rocshmem_my_pe()
     cfg = TeamConfig()
     cfg.num_contexts = 1
 
     # First-level split: lower half {0..mid-1}, upper half {mid..n-1}.
     mid = n // 2
-    if me < mid:
+    if my_pe < mid:
         half_start, half_size = 0, mid
-        my_half_pe = me
+        my_half_pe = my_pe
     else:
         half_start, half_size = mid, n - mid
-        my_half_pe = me - mid
+        my_half_pe = my_pe - mid
 
     status, half = rocshmem_team_split_strided(
         ROCSHMEM_TEAM_WORLD, half_start, 1, half_size, cfg, 0,
@@ -261,16 +267,72 @@ def test_team_translate_pe_round_trip():
 
 
 @requires_multi_pe
-def test_team_destroy_idempotent_on_special_handles():
-    """Destroying ROCSHMEM_TEAM_{INVALID,WORLD} is a documented no-op."""
-    rocshmem_team_destroy(ROCSHMEM_TEAM_INVALID)
-    rocshmem_team_destroy(ROCSHMEM_TEAM_WORLD)
-    # Just survives without segfault.
+def test_team_sync_barrier_member_scoped():
+    """Non-members should not block on team collectives.
+
+    Construct an even-rank subteam. Delay one team member before entering
+    team sync / barrier, then assert:
+      - other members block waiting for the delayed member
+      - non-members (TEAM_INVALID path) return quickly
+    """
+    n = rocshmem_n_pes()
+    if n < 4:
+        pytest.skip("requires >= 4 PEs to exercise member/non-member timing")
+
+    cfg = TeamConfig()
+    cfg.num_contexts = 1
+    even_size = (n + 1) // 2
+    status, even_team = rocshmem_team_split_strided(
+        ROCSHMEM_TEAM_WORLD, 0, 2, even_size, cfg, 0,
+    )
+    assert status == ROCSHMEM_SUCCESS
+
+    my_pe = rocshmem_my_pe()
+    is_member = (my_pe % 2) == 0
+    if is_member:
+        assert even_team != ROCSHMEM_TEAM_INVALID
+        team_rank = rocshmem_team_my_pe(even_team)
+    else:
+        assert even_team == ROCSHMEM_TEAM_INVALID
+        team_rank = -1
+
+    delay_s = 0.8
+
+    # Phase 1: sync timing
+    rocshmem_barrier_all()
+    if is_member and team_rank == 0:
+        time.sleep(delay_s)
+    t0 = time.perf_counter()
+    rocshmem_team_sync(even_team)
+    sync_dt = time.perf_counter() - t0
+
+    # Phase 2: barrier timing
+    rocshmem_barrier_all()
+    if is_member and team_rank == 0:
+        time.sleep(delay_s)
+    t0 = time.perf_counter()
+    rocshmem_barrier(even_team)
+    barrier_dt = time.perf_counter() - t0
+
+    rocshmem_barrier_all()
+    rocshmem_team_destroy(even_team)
+    rocshmem_barrier_all()
+
+    if is_member and team_rank != 0:
+        # Other team members must wait for delayed member.
+        # higher time on the non-delayed member is the expected 
+        # behavior for a collective barrier/sync.
+        assert sync_dt > delay_s * 0.6
+        assert barrier_dt > delay_s * 0.6
+    if not is_member:
+        # Non-members pass TEAM_INVALID and should not wait for team progress.
+        assert sync_dt < delay_s * 0.5
+        assert barrier_dt < delay_s * 0.5
 
 
 @requires_multi_pe
-def test_team_barrier_and_sync_on_split_team():
-    """Members participate in team sync/barrier; non-members can no-op safely."""
+def test_team_sync_store_visibility():
+    """`team_sync` gates team-local store visibility for member communication."""
     n = rocshmem_n_pes()
     if n < 4:
         pytest.skip("requires >= 4 PEs to exercise member/non-member behavior")
@@ -283,28 +345,59 @@ def test_team_barrier_and_sync_on_split_team():
     )
     assert status == ROCSHMEM_SUCCESS
 
-    # Members call into the team-scoped primitives; non-members pass INVALID
-    # and rely on no-op semantics.
-    rocshmem_team_sync(even_team)
-    rocshmem_barrier(even_team)
+    my_pe = rocshmem_my_pe()
+    is_member = (my_pe % 2) == 0
+    if is_member:
+        assert even_team != ROCSHMEM_TEAM_INVALID
+        team_rank = rocshmem_team_my_pe(even_team)
+        team_n = rocshmem_team_n_pes(even_team)
+    else:
+        assert even_team == ROCSHMEM_TEAM_INVALID
+        team_rank = -1
+        team_n = 0
 
-    rocshmem_barrier_all()
-    rocshmem_team_destroy(even_team)
-    rocshmem_barrier_all()
+    local_val = rocshmem_malloc(8)
+    pull_buf = rocshmem_malloc(8)
+    try:
+        store_u64(local_val, my_pe + 5000)
+        store_u64(pull_buf, 0xFFFFFFFFFFFFFFFF)
 
+        # team_sync is the ONLY synchronization gating the cross-member read
+        # below.  Per rocSHMEM semantics it must guarantee every member's
+        # local store (above) is complete and visible to the other members
+        # before any of them returns. 
+        rocshmem_team_sync(even_team)
 
-def test_team_barrier_sync_on_stream_symbols_exported():
-    """The stream-ordered team barrier/sync bindings are exported."""
-    assert hasattr(rocshmem4py, "rocshmem_barrier_on_stream")
-    assert hasattr(rocshmem4py, "rocshmem_team_sync_on_stream")
+        if is_member and team_n > 1:
+            prev_rank = (team_rank - 1 + team_n) % team_n
+            prev_world = rocshmem_team_translate_pe(
+                even_team, prev_rank, ROCSHMEM_TEAM_WORLD
+            )
+            rocshmem_getmem_on_stream(pull_buf, local_val, 8, prev_world, 0)
+            hip_device_synchronize()
+            assert load_u64(pull_buf) == prev_world + 5000
+
+        rocshmem_barrier_all()
+    finally:
+        rocshmem_free(local_val)
+        rocshmem_free(pull_buf)
+        rocshmem_barrier_all()
+        rocshmem_team_destroy(even_team)
+        rocshmem_barrier_all()
 
 
 @requires_multi_pe
-def test_team_barrier_and_sync_on_stream_on_split_team():
-    """Stream-ordered team sync/barrier; members enqueue, non-members no-op.
+def test_team_barrier_rma_ordering():
+    """Team `barrier` synchronizes members after remote RMA so each member
+    can safely read data a peer wrote into its inbox.
 
-    Uses the default stream (handle 0) so this exercises the real binding
-    path on both the torch and the mpi4py bootstraps (no torch dependency).
+    Production gotcha exercised here: the put is issued via the stream-ordered
+    API and flushed with ``hip_device_synchronize()`` *before* the blocking
+    host barrier.  A blocking host barrier does NOT flush stream-enqueued RMA,
+    so omitting that device sync would race.  The team barrier's load-bearing
+    role is the cross-PE arrival ordering -- a member cannot read its inbox
+    until the writing peer has reached the barrier, i.e. issued and locally
+    completed its put.
     """
     n = rocshmem_n_pes()
     if n < 4:
@@ -318,22 +411,214 @@ def test_team_barrier_and_sync_on_stream_on_split_team():
     )
     assert status == ROCSHMEM_SUCCESS
 
-    # Members enqueue the team collective on the default stream; non-members
-    # pass ROCSHMEM_TEAM_INVALID and rely on the documented no-op (nothing
-    # enqueued).  Synchronizing the device then re-joining barrier_all confirms
-    # the enqueued kernels completed without a hang.
-    rocshmem_team_sync_on_stream(even_team, 0)
-    rocshmem_barrier_on_stream(even_team, 0)
-    hip_device_synchronize()
+    my_pe = rocshmem_my_pe()
+    is_member = (my_pe % 2) == 0
+    if is_member:
+        assert even_team != ROCSHMEM_TEAM_INVALID
+        team_rank = rocshmem_team_my_pe(even_team)
+        team_n = rocshmem_team_n_pes(even_team)
+    else:
+        assert even_team == ROCSHMEM_TEAM_INVALID
+        team_rank = -1
+        team_n = 0
 
-    # Passing the INVALID sentinel explicitly must be a no-op for every rank.
-    rocshmem_barrier_on_stream(ROCSHMEM_TEAM_INVALID, 0)
-    rocshmem_team_sync_on_stream(ROCSHMEM_TEAM_INVALID, 0)
-    hip_device_synchronize()
+    inbox = rocshmem_malloc(8)
+    send_val_ptr = rocshmem_malloc(8)
+    try:
+        store_u64(inbox, 0xABCDEF00 + my_pe)
+        store_u64(send_val_ptr, my_pe + 7000)
+
+        rocshmem_barrier_all()
+
+        if is_member and team_n > 1:
+            next_rank = (team_rank + 1) % team_n
+            next_world = rocshmem_team_translate_pe(
+                even_team, next_rank, ROCSHMEM_TEAM_WORLD
+            )
+            rocshmem_putmem_on_stream(inbox, send_val_ptr, 8, next_world, 0)
+            # Required: flush the stream-enqueued put before the blocking host
+            # barrier, which has no visibility into stream-ordered RMA.
+            hip_device_synchronize()
+
+        # Cross-PE arrival ordering: no member proceeds past here until every
+        # member has reached the barrier, i.e. completed its put above.
+        rocshmem_barrier(even_team)
+
+        if is_member and team_n > 1:
+            prev_rank = (team_rank - 1 + team_n) % team_n
+            prev_world = rocshmem_team_translate_pe(
+                even_team, prev_rank, ROCSHMEM_TEAM_WORLD
+            )
+            assert load_u64(inbox) == prev_world + 7000
+
+        rocshmem_barrier_all()
+    finally:
+        rocshmem_free(inbox)
+        rocshmem_free(send_val_ptr)
+        rocshmem_barrier_all()
+        rocshmem_team_destroy(even_team)
+        rocshmem_barrier_all()
+
+
+@requires_multi_pe
+def test_team_barrier_on_stream_rma_ordering():
+    """Stream-ordered team barrier orders an enqueued put against a later read.
+
+    This is the realistic overlap pattern: the put, the team barrier, and the
+    dependent consumption are all driven from a single dedicated ``hipStream_t``
+    with NO host-side device sync in between.  Correctness relies on two
+    properties together:
+      1. in-order stream execution -- the put copy completes before the
+         barrier kernel on the same stream begins; and
+      2. the collective team barrier -- a member's barrier completes only
+         after every member (including the peer writing into its inbox) has
+         reached the barrier, so the peer's put has landed and is visible.
+
+    Non-members pass ROCSHMEM_TEAM_INVALID and must no-op while members make
+    real RMA progress -- exercising the INVALID path interleaved with live
+    team traffic, not in isolation.
+    """
+    n = rocshmem_n_pes()
+    if n < 4:
+        pytest.skip("requires >= 4 PEs to exercise member/non-member behavior")
+
+    cfg = TeamConfig()
+    cfg.num_contexts = 1
+    even_size = (n + 1) // 2
+    status, even_team = rocshmem_team_split_strided(
+        ROCSHMEM_TEAM_WORLD, 0, 2, even_size, cfg, 0,
+    )
+    assert status == ROCSHMEM_SUCCESS
+
+    my_pe = rocshmem_my_pe()
+    is_member = (my_pe % 2) == 0
+    if is_member:
+        assert even_team != ROCSHMEM_TEAM_INVALID
+        team_rank = rocshmem_team_my_pe(even_team)
+        team_n = rocshmem_team_n_pes(even_team)
+    else:
+        assert even_team == ROCSHMEM_TEAM_INVALID
+        team_rank = -1
+        team_n = 0
+
+    inbox = rocshmem_malloc(8)
+    send_val_ptr = rocshmem_malloc(8)
+    try:
+        store_u64(inbox, 0xABCDEF00 + my_pe)
+        store_u64(send_val_ptr, my_pe + 9000)
+
+        # Every inbox must be initialized before any peer writes into it,
+        # otherwise a late init store could clobber a received value.
+        rocshmem_barrier_all()
+
+        with HipStream() as s:
+            if is_member and team_n > 1:
+                next_rank = (team_rank + 1) % team_n
+                next_world = rocshmem_team_translate_pe(
+                    even_team, next_rank, ROCSHMEM_TEAM_WORLD
+                )
+                rocshmem_putmem_on_stream(
+                    inbox, send_val_ptr, 8, next_world, s.handle
+                )
+            # Stream-ordered team barrier: orders the put enqueued above and
+            # synchronizes members.  Non-members enqueue the INVALID no-op.
+            rocshmem_barrier_on_stream(even_team, s.handle)
+            s.synchronize()
+
+        if is_member and team_n > 1:
+            prev_rank = (team_rank - 1 + team_n) % team_n
+            prev_world = rocshmem_team_translate_pe(
+                even_team, prev_rank, ROCSHMEM_TEAM_WORLD
+            )
+            assert load_u64(inbox) == prev_world + 9000
+
+        # Explicit INVALID sentinel on a dedicated stream must no-op for every
+        # rank (members and non-members alike) without hanging.
+        with HipStream() as s2:
+            rocshmem_barrier_on_stream(ROCSHMEM_TEAM_INVALID, s2.handle)
+            rocshmem_team_sync_on_stream(ROCSHMEM_TEAM_INVALID, s2.handle)
+            s2.synchronize()
+
+        rocshmem_barrier_all()
+    finally:
+        rocshmem_free(inbox)
+        rocshmem_free(send_val_ptr)
+        rocshmem_barrier_all()
+        rocshmem_team_destroy(even_team)
+        rocshmem_barrier_all()
+
+
+@requires_multi_pe
+def test_team_sync_barrier_on_stream_member_scoped():
+    """Stream-ordered team sync/barrier are team-scoped: non-members no-op.
+
+    Stream analogue of ``test_team_sync_barrier_member_scoped``.  One team
+    member delays *before* it enqueues + drives its stream-ordered collective,
+    so its barrier kernel rendezvouses late.  Then:
+      - other members block in ``stream.synchronize()`` waiting for the
+        delayed member's barrier kernel to arrive on the device, and
+      - non-members (TEAM_INVALID) enqueue nothing, so their
+        ``stream.synchronize()`` on an empty stream returns promptly.
+
+    This is the property the explicit-INVALID block in the data test cannot
+    show: a non-member must not stall on team progress driven by the stream.
+    """
+    n = rocshmem_n_pes()
+    if n < 4:
+        pytest.skip("requires >= 4 PEs to exercise member/non-member timing")
+
+    cfg = TeamConfig()
+    cfg.num_contexts = 1
+    even_size = (n + 1) // 2
+    status, even_team = rocshmem_team_split_strided(
+        ROCSHMEM_TEAM_WORLD, 0, 2, even_size, cfg, 0,
+    )
+    assert status == ROCSHMEM_SUCCESS
+
+    my_pe = rocshmem_my_pe()
+    is_member = (my_pe % 2) == 0
+    if is_member:
+        assert even_team != ROCSHMEM_TEAM_INVALID
+        team_rank = rocshmem_team_my_pe(even_team)
+    else:
+        assert even_team == ROCSHMEM_TEAM_INVALID
+        team_rank = -1
+
+    delay_s = 0.8
+
+    # Phase 1: sync_on_stream timing
+    rocshmem_barrier_all()
+    if is_member and team_rank == 0:
+        time.sleep(delay_s)
+    t0 = time.perf_counter()
+    with HipStream() as s:
+        rocshmem_team_sync_on_stream(even_team, s.handle)
+        s.synchronize()
+    sync_dt = time.perf_counter() - t0
+
+    # Phase 2: barrier_on_stream timing
+    rocshmem_barrier_all()
+    if is_member and team_rank == 0:
+        time.sleep(delay_s)
+    t0 = time.perf_counter()
+    with HipStream() as s:
+        rocshmem_barrier_on_stream(even_team, s.handle)
+        s.synchronize()
+    barrier_dt = time.perf_counter() - t0
 
     rocshmem_barrier_all()
     rocshmem_team_destroy(even_team)
     rocshmem_barrier_all()
+
+    if is_member and team_rank != 0:
+        # Members must wait on the device rendezvous for the delayed member.
+        assert sync_dt > delay_s * 0.6
+        assert barrier_dt > delay_s * 0.6
+    if not is_member:
+        # Non-members enqueue nothing for INVALID; the empty stream drains
+        # immediately and must not wait for the team's progress.
+        assert sync_dt < delay_s * 0.5
+        assert barrier_dt < delay_s * 0.5
 
 
 @requires_multi_pe

--- a/projects/rocshmem/python/tests/test_teams.py
+++ b/projects/rocshmem/python/tests/test_teams.py
@@ -2,7 +2,9 @@
 Multi-PE tests; require at least 2 PEs.
 """
 
+import os
 import time
+from collections.abc import Callable
 
 import pytest
 
@@ -30,7 +32,81 @@ from rocshmem4py import (
     rocshmem_getmem_on_stream,
 )
 from conftest import requires_multi_pe
-from hip_test_utils import HipStream, load_u64, store_u64
+from tests.hip_test_utils import HipStream, load_u64, store_u64
+
+# Wall-clock delay before the delayed team member enters a collective.
+# Override on slow CI hosts: ROCSHMEM_TEST_TEAM_DELAY_S=2.5 pytest ...
+_TEAM_DELAY_S = float(os.environ.get("ROCSHMEM_TEST_TEAM_DELAY_S", "1.5"))
+# Waiting members (team rank != 0) must observe at least this fraction of
+# ``_TEAM_DELAY_S``; non-members must finish faster than
+# ``_NONMEMBER_TO_MEMBER_RATIO * min(member elapsed)``.  The ratio check
+# is tolerant of uniform host slowdown (both sides scale) but still fails
+# if non-members block on the team's delayed rendezvous.
+_MEMBER_MIN_FRACTION = 0.5
+_NONMEMBER_TO_MEMBER_RATIO = 0.35
+
+
+def _read_elapsed_us(table: int, pe: int, scratch: int) -> int:
+    rocshmem_getmem_on_stream(scratch, table + pe * 8, 8, pe, 0)
+    hip_device_synchronize()
+    return load_u64(scratch)
+
+
+def _assert_team_collective_member_scoping(
+    even_team: int,
+    delay_s: float,
+    invoke: Callable[[], None],
+) -> None:
+    """Members wait on a delayed peer; non-members (INVALID) do not.
+
+    Each PE records wall time for ``invoke()`` in symmetric memory, then
+    gathers all entries and checks cross-rank ordering instead of absolute
+    per-rank ceilings.  That avoids flakes when CI is loaded (members and
+    non-members slow down together) while still catching a broken INVALID
+    path that joins the team rendezvous.
+    """
+    n = rocshmem_n_pes()
+    my_pe = rocshmem_my_pe()
+    is_member = (my_pe % 2) == 0
+    team_rank = rocshmem_team_my_pe(even_team) if is_member else -1
+
+    table = rocshmem_malloc(n * 8)
+    scratch = rocshmem_malloc(8)
+    try:
+        rocshmem_barrier_all()
+        if is_member and team_rank == 0:
+            time.sleep(delay_s)
+
+        t0 = time.perf_counter()
+        invoke()
+        elapsed_us = int((time.perf_counter() - t0) * 1_000_000)
+        store_u64(table + my_pe * 8, elapsed_us)
+
+        rocshmem_barrier_all()
+
+        # Even world PEs are team members; PE 0 is the intentional delayer.
+        member_us = [_read_elapsed_us(table, pe, scratch) for pe in range(2, n, 2)]
+        non_member_us = [_read_elapsed_us(table, pe, scratch) for pe in range(1, n, 2)]
+        if not member_us or not non_member_us:
+            pytest.skip("need >= 2 even team members and >= 1 non-member")
+
+        min_member_us = min(member_us)
+        max_non_member_us = max(non_member_us)
+        delay_us = int(delay_s * 1_000_000)
+
+        assert min_member_us >= delay_us * _MEMBER_MIN_FRACTION, (
+            f"waiting member elapsed too short: min_member={min_member_us}us, "
+            f"expected >= {_MEMBER_MIN_FRACTION * 100:.0f}% of delay={delay_us}us; "
+            f"all_member={member_us}"
+        )
+        assert max_non_member_us < min_member_us * _NONMEMBER_TO_MEMBER_RATIO, (
+            f"non-member blocked on team collective: max_non_member="
+            f"{max_non_member_us}us, min_member={min_member_us}us, "
+            f"all_non_member={non_member_us}"
+        )
+    finally:
+        rocshmem_free(scratch)
+        rocshmem_free(table)
 
 
 def test_team_config_struct():
@@ -270,10 +346,16 @@ def test_team_translate_pe_round_trip():
 def test_team_sync_barrier_member_scoped():
     """Non-members should not block on team collectives.
 
-    Construct an even-rank subteam. Delay one team member before entering
-    team sync / barrier, then assert:
-      - other members block waiting for the delayed member
-      - non-members (TEAM_INVALID path) return quickly
+    Construct an even-rank subteam. Delay team rank 0 before entering
+    team sync / barrier, then compare elapsed times across ranks via
+    symmetric memory:
+
+      - waiting members (team rank != 0) must observe most of the delay;
+      - non-members (TEAM_INVALID) must finish much faster than members.
+
+    Uses a cross-rank ratio (not absolute per-rank ceilings) so the check
+    survives uniform CI host slowdown.  Tune delay with
+    ``ROCSHMEM_TEST_TEAM_DELAY_S`` (default 1.5s).
     """
     n = rocshmem_n_pes()
     if n < 4:
@@ -288,46 +370,22 @@ def test_team_sync_barrier_member_scoped():
     assert status == ROCSHMEM_SUCCESS
 
     my_pe = rocshmem_my_pe()
-    is_member = (my_pe % 2) == 0
-    if is_member:
+    if my_pe % 2 == 0:
         assert even_team != ROCSHMEM_TEAM_INVALID
-        team_rank = rocshmem_team_my_pe(even_team)
     else:
         assert even_team == ROCSHMEM_TEAM_INVALID
-        team_rank = -1
 
-    delay_s = 0.8
-
-    # Phase 1: sync timing
-    rocshmem_barrier_all()
-    if is_member and team_rank == 0:
-        time.sleep(delay_s)
-    t0 = time.perf_counter()
-    rocshmem_team_sync(even_team)
-    sync_dt = time.perf_counter() - t0
-
-    # Phase 2: barrier timing
-    rocshmem_barrier_all()
-    if is_member and team_rank == 0:
-        time.sleep(delay_s)
-    t0 = time.perf_counter()
-    rocshmem_barrier(even_team)
-    barrier_dt = time.perf_counter() - t0
-
-    rocshmem_barrier_all()
-    rocshmem_team_destroy(even_team)
-    rocshmem_barrier_all()
-
-    if is_member and team_rank != 0:
-        # Other team members must wait for delayed member.
-        # higher time on the non-delayed member is the expected 
-        # behavior for a collective barrier/sync.
-        assert sync_dt > delay_s * 0.6
-        assert barrier_dt > delay_s * 0.6
-    if not is_member:
-        # Non-members pass TEAM_INVALID and should not wait for team progress.
-        assert sync_dt < delay_s * 0.5
-        assert barrier_dt < delay_s * 0.5
+    try:
+        _assert_team_collective_member_scoping(
+            even_team, _TEAM_DELAY_S, lambda: rocshmem_team_sync(even_team),
+        )
+        _assert_team_collective_member_scoping(
+            even_team, _TEAM_DELAY_S, lambda: rocshmem_barrier(even_team),
+        )
+    finally:
+        rocshmem_barrier_all()
+        rocshmem_team_destroy(even_team)
+        rocshmem_barrier_all()
 
 
 @requires_multi_pe
@@ -552,16 +610,9 @@ def test_team_barrier_on_stream_rma_ordering():
 def test_team_sync_barrier_on_stream_member_scoped():
     """Stream-ordered team sync/barrier are team-scoped: non-members no-op.
 
-    Stream analogue of ``test_team_sync_barrier_member_scoped``.  One team
-    member delays *before* it enqueues + drives its stream-ordered collective,
-    so its barrier kernel rendezvouses late.  Then:
-      - other members block in ``stream.synchronize()`` waiting for the
-        delayed member's barrier kernel to arrive on the device, and
-      - non-members (TEAM_INVALID) enqueue nothing, so their
-        ``stream.synchronize()`` on an empty stream returns promptly.
-
-    This is the property the explicit-INVALID block in the data test cannot
-    show: a non-member must not stall on team progress driven by the stream.
+    Stream analogue of ``test_team_sync_barrier_member_scoped``.  Uses the
+    same cross-rank elapsed-time ratio as the blocking test (see
+    ``_assert_team_collective_member_scoping``).
     """
     n = rocshmem_n_pes()
     if n < 4:
@@ -576,49 +627,30 @@ def test_team_sync_barrier_on_stream_member_scoped():
     assert status == ROCSHMEM_SUCCESS
 
     my_pe = rocshmem_my_pe()
-    is_member = (my_pe % 2) == 0
-    if is_member:
+    if my_pe % 2 == 0:
         assert even_team != ROCSHMEM_TEAM_INVALID
-        team_rank = rocshmem_team_my_pe(even_team)
     else:
         assert even_team == ROCSHMEM_TEAM_INVALID
-        team_rank = -1
 
-    delay_s = 0.8
+    def _sync_on_stream() -> None:
+        with HipStream() as s:
+            rocshmem_team_sync_on_stream(even_team, s.handle)
+            s.synchronize()
 
-    # Phase 1: sync_on_stream timing
-    rocshmem_barrier_all()
-    if is_member and team_rank == 0:
-        time.sleep(delay_s)
-    t0 = time.perf_counter()
-    with HipStream() as s:
-        rocshmem_team_sync_on_stream(even_team, s.handle)
-        s.synchronize()
-    sync_dt = time.perf_counter() - t0
+    def _barrier_on_stream() -> None:
+        with HipStream() as s:
+            rocshmem_barrier_on_stream(even_team, s.handle)
+            s.synchronize()
 
-    # Phase 2: barrier_on_stream timing
-    rocshmem_barrier_all()
-    if is_member and team_rank == 0:
-        time.sleep(delay_s)
-    t0 = time.perf_counter()
-    with HipStream() as s:
-        rocshmem_barrier_on_stream(even_team, s.handle)
-        s.synchronize()
-    barrier_dt = time.perf_counter() - t0
-
-    rocshmem_barrier_all()
-    rocshmem_team_destroy(even_team)
-    rocshmem_barrier_all()
-
-    if is_member and team_rank != 0:
-        # Members must wait on the device rendezvous for the delayed member.
-        assert sync_dt > delay_s * 0.6
-        assert barrier_dt > delay_s * 0.6
-    if not is_member:
-        # Non-members enqueue nothing for INVALID; the empty stream drains
-        # immediately and must not wait for the team's progress.
-        assert sync_dt < delay_s * 0.5
-        assert barrier_dt < delay_s * 0.5
+    try:
+        _assert_team_collective_member_scoping(even_team, _TEAM_DELAY_S, _sync_on_stream)
+        _assert_team_collective_member_scoping(
+            even_team, _TEAM_DELAY_S, _barrier_on_stream,
+        )
+    finally:
+        rocshmem_barrier_all()
+        rocshmem_team_destroy(even_team)
+        rocshmem_barrier_all()
 
 
 @requires_multi_pe

--- a/projects/rocshmem/python/tests/test_teams.py
+++ b/projects/rocshmem/python/tests/test_teams.py
@@ -18,6 +18,11 @@ from rocshmem4py import (
     rocshmem_team_destroy,
     rocshmem_team_translate_pe,
     rocshmem_barrier_all,
+    rocshmem_barrier,
+    rocshmem_team_sync,
+    rocshmem_barrier_on_stream,
+    rocshmem_team_sync_on_stream,
+    hip_device_synchronize,
 )
 from conftest import requires_multi_pe
 
@@ -261,6 +266,74 @@ def test_team_destroy_idempotent_on_special_handles():
     rocshmem_team_destroy(ROCSHMEM_TEAM_INVALID)
     rocshmem_team_destroy(ROCSHMEM_TEAM_WORLD)
     # Just survives without segfault.
+
+
+@requires_multi_pe
+def test_team_barrier_and_sync_on_split_team():
+    """Members participate in team sync/barrier; non-members can no-op safely."""
+    n = rocshmem_n_pes()
+    if n < 4:
+        pytest.skip("requires >= 4 PEs to exercise member/non-member behavior")
+
+    cfg = TeamConfig()
+    cfg.num_contexts = 1
+    even_size = (n + 1) // 2
+    status, even_team = rocshmem_team_split_strided(
+        ROCSHMEM_TEAM_WORLD, 0, 2, even_size, cfg, 0,
+    )
+    assert status == ROCSHMEM_SUCCESS
+
+    # Members call into the team-scoped primitives; non-members pass INVALID
+    # and rely on no-op semantics.
+    rocshmem_team_sync(even_team)
+    rocshmem_barrier(even_team)
+
+    rocshmem_barrier_all()
+    rocshmem_team_destroy(even_team)
+    rocshmem_barrier_all()
+
+
+def test_team_barrier_sync_on_stream_symbols_exported():
+    """The stream-ordered team barrier/sync bindings are exported."""
+    assert hasattr(rocshmem4py, "rocshmem_barrier_on_stream")
+    assert hasattr(rocshmem4py, "rocshmem_team_sync_on_stream")
+
+
+@requires_multi_pe
+def test_team_barrier_and_sync_on_stream_on_split_team():
+    """Stream-ordered team sync/barrier; members enqueue, non-members no-op.
+
+    Uses the default stream (handle 0) so this exercises the real binding
+    path on both the torch and the mpi4py bootstraps (no torch dependency).
+    """
+    n = rocshmem_n_pes()
+    if n < 4:
+        pytest.skip("requires >= 4 PEs to exercise member/non-member behavior")
+
+    cfg = TeamConfig()
+    cfg.num_contexts = 1
+    even_size = (n + 1) // 2
+    status, even_team = rocshmem_team_split_strided(
+        ROCSHMEM_TEAM_WORLD, 0, 2, even_size, cfg, 0,
+    )
+    assert status == ROCSHMEM_SUCCESS
+
+    # Members enqueue the team collective on the default stream; non-members
+    # pass ROCSHMEM_TEAM_INVALID and rely on the documented no-op (nothing
+    # enqueued).  Synchronizing the device then re-joining barrier_all confirms
+    # the enqueued kernels completed without a hang.
+    rocshmem_team_sync_on_stream(even_team, 0)
+    rocshmem_barrier_on_stream(even_team, 0)
+    hip_device_synchronize()
+
+    # Passing the INVALID sentinel explicitly must be a no-op for every rank.
+    rocshmem_barrier_on_stream(ROCSHMEM_TEAM_INVALID, 0)
+    rocshmem_team_sync_on_stream(ROCSHMEM_TEAM_INVALID, 0)
+    hip_device_synchronize()
+
+    rocshmem_barrier_all()
+    rocshmem_team_destroy(even_team)
+    rocshmem_barrier_all()
 
 
 @requires_multi_pe

--- a/projects/rocshmem/scripts/functional_tests/driver.sh
+++ b/projects/rocshmem/scripts/functional_tests/driver.sh
@@ -641,9 +641,11 @@ TestOther() {
   ExecTest  "teamctxsubsetparentinfra" 5  1            1
   export ROCSHMEM_MAX_NUM_HOST_CONTEXTS=1024
   ExecTest  "host_ctx_create"          2       1            1
+  if [[ $TEST != ro* ]]; then # host team sync/barrier hangs on RO
   ExecTest  "hostteamsyncbarrier"      2  1            1
   ExecTest  "hostteamsyncbarrier"      4  1            1
   ExecTest  "hostteamsyncbarrier"      8  1            1
+  else echo "Skip:   hostteamsyncbarrier (host team sync/barrier hangs on RO)"; fi
   unset ROCSHMEM_MAX_NUM_CONTEXTS
   unset ROCSHMEM_MAX_NUM_HOST_CONTEXTS
   

--- a/projects/rocshmem/scripts/functional_tests/driver.sh
+++ b/projects/rocshmem/scripts/functional_tests/driver.sh
@@ -152,6 +152,7 @@ declare -A TEST_NUMBERS=(
   ["reduce_on_stream"]="117"
   ["host_ctx_create"]="118"
   ["teamsplit2d"]="119"
+  ["hostteamsyncbarrier"]="120"
 )
 
 ExecTest() {
@@ -640,6 +641,9 @@ TestOther() {
   ExecTest  "teamctxsubsetparentinfra" 5  1            1
   export ROCSHMEM_MAX_NUM_HOST_CONTEXTS=1024
   ExecTest  "host_ctx_create"          2       1            1
+  ExecTest  "hostteamsyncbarrier"      2  1            1
+  ExecTest  "hostteamsyncbarrier"      4  1            1
+  ExecTest  "hostteamsyncbarrier"      8  1            1
   unset ROCSHMEM_MAX_NUM_CONTEXTS
   unset ROCSHMEM_MAX_NUM_HOST_CONTEXTS
   

--- a/projects/rocshmem/src/context.hpp
+++ b/projects/rocshmem/src/context.hpp
@@ -517,11 +517,17 @@ class Context {
 
   __host__ void barrier_all();
 
+  __host__ void barrier(rocshmem_team_t team);
+
   __host__ void barrier_all_on_stream(hipStream_t stream);
+
+  __host__ void barrier_on_stream(rocshmem_team_t team, hipStream_t stream);
 
   __host__ void quiet_on_stream(hipStream_t stream);
 
   __host__ void sync_all_on_stream(hipStream_t stream);
+
+  __host__ void sync_on_stream(rocshmem_team_t team, hipStream_t stream);
 
   __host__ void alltoallmem_on_stream(rocshmem_team_t team, void *dest,
                                       const void *source, size_t size,
@@ -547,6 +553,8 @@ class Context {
                                             hipStream_t stream);
 
   __host__ void sync_all();
+
+  __host__ void sync(rocshmem_team_t team);
 
   template <typename T>
   __host__ void broadcast(T* dest, const T* source, int nelems, int pe_root,

--- a/projects/rocshmem/src/context_host.cpp
+++ b/projects/rocshmem/src/context_host.cpp
@@ -109,16 +109,35 @@ __host__ void Context::sync_all() {
   HOST_DISPATCH(sync_all());
 }
 
+__host__ void Context::sync(rocshmem_team_t team) {
+  ctxHostStats.incStat(NUM_HOST_SYNC_ALL);
+
+  HOST_DISPATCH(sync(team));
+}
+
 __host__ void Context::barrier_all() {
   ctxHostStats.incStat(NUM_HOST_BARRIER_ALL);
 
   HOST_DISPATCH(barrier_all());
 }
 
+__host__ void Context::barrier(rocshmem_team_t team) {
+  ctxHostStats.incStat(NUM_HOST_BARRIER_ALL);
+
+  HOST_DISPATCH(barrier(team));
+}
+
 __host__ void Context::barrier_all_on_stream(hipStream_t stream) {
   ctxHostStats.incStat(NUM_HOST_BARRIER_ALL);
 
   HOST_DISPATCH(barrier_all_on_stream(stream));
+}
+
+__host__ void Context::barrier_on_stream(rocshmem_team_t team,
+                                         hipStream_t stream) {
+  ctxHostStats.incStat(NUM_HOST_BARRIER_ALL);
+
+  HOST_DISPATCH(barrier_on_stream(team, stream));
 }
 
 __host__ void Context::quiet_on_stream(hipStream_t stream) {
@@ -131,6 +150,13 @@ __host__ void Context::sync_all_on_stream(hipStream_t stream) {
   ctxHostStats.incStat(NUM_HOST_SYNC_ALL);
 
   HOST_DISPATCH(sync_all_on_stream(stream));
+}
+
+__host__ void Context::sync_on_stream(rocshmem_team_t team,
+                                      hipStream_t stream) {
+  ctxHostStats.incStat(NUM_HOST_SYNC_ALL);
+
+  HOST_DISPATCH(sync_on_stream(team, stream));
 }
 
 __host__ void Context::alltoallmem_on_stream(rocshmem_team_t team, void *dest,

--- a/projects/rocshmem/src/gda/context_gda_host.cpp
+++ b/projects/rocshmem/src/gda/context_gda_host.cpp
@@ -112,12 +112,25 @@ __host__ void GDAHostContext::sync_all() {
   host_interface->sync_all(context_window_info);
 }
 
+__host__ void GDAHostContext::sync(rocshmem_team_t team) {
+  host_interface->sync(team, context_window_info);
+}
+
 __host__ void GDAHostContext::barrier_all() {
   host_interface->barrier_all(context_window_info);
 }
 
+__host__ void GDAHostContext::barrier(rocshmem_team_t team) {
+  host_interface->barrier(team, context_window_info);
+}
+
 __host__ void GDAHostContext::barrier_all_on_stream(hipStream_t stream) {
   host_interface->barrier_all_on_stream(stream);
+}
+
+__host__ void GDAHostContext::barrier_on_stream(rocshmem_team_t team,
+                                                hipStream_t stream) {
+  host_interface->barrier_on_stream(team, stream);
 }
 
 __host__ void GDAHostContext::quiet_on_stream(hipStream_t stream) {
@@ -127,6 +140,11 @@ __host__ void GDAHostContext::quiet_on_stream(hipStream_t stream) {
 
 __host__ void GDAHostContext::sync_all_on_stream(hipStream_t stream) {
   host_interface->sync_all_on_stream(stream);
+}
+
+__host__ void GDAHostContext::sync_on_stream(rocshmem_team_t team,
+                                             hipStream_t stream) {
+  host_interface->sync_on_stream(team, stream);
 }
 
 __host__ void GDAHostContext::alltoallmem_on_stream(rocshmem_team_t team,

--- a/projects/rocshmem/src/gda/context_gda_host.hpp
+++ b/projects/rocshmem/src/gda/context_gda_host.hpp
@@ -84,9 +84,13 @@ class GDAHostContext : public Context {
 
   __host__ void barrier_all_on_stream(hipStream_t stream);
 
+  __host__ void barrier_on_stream(rocshmem_team_t team, hipStream_t stream);
+
   __host__ void quiet_on_stream(hipStream_t stream);
 
   __host__ void sync_all_on_stream(hipStream_t stream);
+
+  __host__ void sync_on_stream(rocshmem_team_t team, hipStream_t stream);
 
   __host__ void alltoallmem_on_stream(rocshmem_team_t team, void *dest,
                                       const void *source, size_t size,
@@ -112,6 +116,10 @@ class GDAHostContext : public Context {
                                             hipStream_t stream);
 
   __host__ void sync_all();
+
+  __host__ void sync(rocshmem_team_t team);
+
+  __host__ void barrier(rocshmem_team_t team);
 
   template <typename T>
   __host__ void broadcast(T *dest, const T *source, int nelems, int pe_root,

--- a/projects/rocshmem/src/host/host.cpp
+++ b/projects/rocshmem/src/host/host.cpp
@@ -31,10 +31,23 @@
 #include "memory/window_info.hpp"
 #include "util.hpp"
 #include "log.hpp"
+#include "team.hpp"
 
 #include <cassert>
 
 namespace rocshmem {
+
+namespace {
+std::vector<int> team_world_ranks(const Team* team_obj) {
+  std::vector<int> world_ranks;
+  world_ranks.reserve(team_obj->num_pes);
+  const TeamInfo* info = team_obj->tinfo_wrt_world;
+  for (int i = 0; i < team_obj->num_pes; i++) {
+    world_ranks.push_back(info->pe_start + i * info->stride);
+  }
+  return world_ranks;
+}
+}  // namespace
 
 __host__ HostContextWindowInfo::HostContextWindowInfo(MPI_Comm comm_world,
                                                       SymmetricHeap* heap) {
@@ -304,6 +317,25 @@ __host__ void HostInterface::sync_all(WindowInfo* window_info) {
   return;
 }
 
+__host__ void HostInterface::sync(rocshmem_team_t team, WindowInfo* window_info) {
+  if (team == ROCSHMEM_TEAM_INVALID) {
+    return;
+  }
+
+  Team* team_obj{get_internal_team(team)};
+  WindowInfoMPI* window_info_mpi = dynamic_cast<WindowInfoMPI*>(window_info);
+  if (window_info_mpi && team_obj->mpi_comm != MPI_COMM_NULL) {
+    mpilib_ftable_.Win_sync(window_info_mpi->get_win());
+    hdp_policy_->hdp_flush();
+    mpilib_ftable_.Barrier(team_obj->mpi_comm);
+  } else {
+    hdp_policy_->hdp_flush();
+    host_bootstrap_->groupBarrier(team_world_ranks(team_obj));
+  }
+
+  return;
+}
+
 __host__ void HostInterface::barrier_all(WindowInfo* window_info) {
   WindowInfoMPI* window_info_mpi = dynamic_cast<WindowInfoMPI*>(window_info);
   if (window_info_mpi) {
@@ -325,9 +357,40 @@ __host__ void HostInterface::barrier_all(WindowInfo* window_info) {
   return;
 }
 
+__host__ void HostInterface::barrier(rocshmem_team_t team,
+                                     WindowInfo* window_info) {
+  if (team == ROCSHMEM_TEAM_INVALID) {
+    return;
+  }
+
+  Team* team_obj{get_internal_team(team)};
+  WindowInfoMPI* window_info_mpi = dynamic_cast<WindowInfoMPI*>(window_info);
+  if (window_info_mpi && team_obj->mpi_comm != MPI_COMM_NULL) {
+    complete_all(window_info_mpi->get_win());
+    hdp_policy_->hdp_flush();
+    mpilib_ftable_.Barrier(team_obj->mpi_comm);
+  } else {
+    hdp_policy_->hdp_flush();
+    host_bootstrap_->groupBarrier(team_world_ranks(team_obj));
+  }
+
+  return;
+}
+
 __host__ void HostInterface::barrier_all_on_stream(hipStream_t stream) {
   // Launch kernel to do barrier with given stream
   rocshmem_barrier_all_kernel<<<1, 1, 0, stream>>>();
+}
+
+__host__ void HostInterface::barrier_on_stream(rocshmem_team_t team,
+                                               hipStream_t stream) {
+  // Non-members hold ROCSHMEM_TEAM_INVALID; matching the blocking
+  // rocshmem_barrier(team), this is a no-op: nothing is enqueued.
+  if (team == ROCSHMEM_TEAM_INVALID) {
+    return;
+  }
+  // Launch kernel to do the team-scoped barrier on the given stream.
+  rocshmem_barrier_kernel<<<1, 1, 0, stream>>>(team);
 }
 
 __host__ void HostInterface::quiet_on_stream(hipStream_t stream) {
@@ -338,6 +401,17 @@ __host__ void HostInterface::quiet_on_stream(hipStream_t stream) {
 __host__ void HostInterface::sync_all_on_stream(hipStream_t stream) {
   // Launch kernel to do sync_all with given stream
   rocshmem_sync_all_kernel<<<1, 1, 0, stream>>>();
+}
+
+__host__ void HostInterface::sync_on_stream(rocshmem_team_t team,
+                                            hipStream_t stream) {
+  // Non-members hold ROCSHMEM_TEAM_INVALID; matching the blocking
+  // rocshmem_team_sync(team), this is a no-op: nothing is enqueued.
+  if (team == ROCSHMEM_TEAM_INVALID) {
+    return;
+  }
+  // Launch kernel to do the team-scoped sync on the given stream.
+  rocshmem_team_sync_kernel<<<1, 1, 0, stream>>>(team);
 }
 
 __host__ void HostInterface::alltoallmem_on_stream(rocshmem_team_t team,

--- a/projects/rocshmem/src/host/host.hpp
+++ b/projects/rocshmem/src/host/host.hpp
@@ -194,11 +194,17 @@ class HostInterface {
 
   __host__ void barrier_all(WindowInfo* window_info);
 
+  __host__ void barrier(rocshmem_team_t team, WindowInfo* window_info);
+
   __host__ void barrier_all_on_stream(hipStream_t stream);
+
+  __host__ void barrier_on_stream(rocshmem_team_t team, hipStream_t stream);
 
   __host__ void quiet_on_stream(hipStream_t stream);
 
   __host__ void sync_all_on_stream(hipStream_t stream);
+
+  __host__ void sync_on_stream(rocshmem_team_t team, hipStream_t stream);
 
   __host__ void alltoallmem_on_stream(rocshmem_team_t team, void *dest,
                                       const void *source, size_t size,
@@ -226,6 +232,8 @@ class HostInterface {
   __host__ void barrier_for_sync();
 
   __host__ void sync_all(WindowInfo* window_info);
+
+  __host__ void sync(rocshmem_team_t team, WindowInfo* window_info);
 
   template <typename T>
   __host__ void broadcast(T* dest, const T* source, int nelems, int pe_root,

--- a/projects/rocshmem/src/ipc/context_ipc_host.cpp
+++ b/projects/rocshmem/src/ipc/context_ipc_host.cpp
@@ -97,12 +97,25 @@ __host__ void IPCHostContext::sync_all() {
   host_interface->sync_all(context_window_info);
 }
 
+__host__ void IPCHostContext::sync(rocshmem_team_t team) {
+  host_interface->sync(team, context_window_info);
+}
+
 __host__ void IPCHostContext::barrier_all() {
   host_interface->barrier_all(context_window_info);
 }
 
+__host__ void IPCHostContext::barrier(rocshmem_team_t team) {
+  host_interface->barrier(team, context_window_info);
+}
+
 __host__ void IPCHostContext::barrier_all_on_stream(hipStream_t stream) {
   host_interface->barrier_all_on_stream(stream);
+}
+
+__host__ void IPCHostContext::barrier_on_stream(rocshmem_team_t team,
+                                                hipStream_t stream) {
+  host_interface->barrier_on_stream(team, stream);
 }
 
 __host__ void IPCHostContext::quiet_on_stream(hipStream_t stream) {
@@ -112,6 +125,11 @@ __host__ void IPCHostContext::quiet_on_stream(hipStream_t stream) {
 
 __host__ void IPCHostContext::sync_all_on_stream(hipStream_t stream) {
   host_interface->sync_all_on_stream(stream);
+}
+
+__host__ void IPCHostContext::sync_on_stream(rocshmem_team_t team,
+                                             hipStream_t stream) {
+  host_interface->sync_on_stream(team, stream);
 }
 
 __host__ void IPCHostContext::alltoallmem_on_stream(rocshmem_team_t team,

--- a/projects/rocshmem/src/ipc/context_ipc_host.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_host.hpp
@@ -84,9 +84,13 @@ class IPCHostContext : public Context {
 
   __host__ void barrier_all_on_stream(hipStream_t stream);
 
+  __host__ void barrier_on_stream(rocshmem_team_t team, hipStream_t stream);
+
   __host__ void quiet_on_stream(hipStream_t stream);
 
   __host__ void sync_all_on_stream(hipStream_t stream);
+
+  __host__ void sync_on_stream(rocshmem_team_t team, hipStream_t stream);
 
   __host__ void alltoallmem_on_stream(rocshmem_team_t team, void *dest,
                                       const void *source, size_t size,
@@ -112,6 +116,10 @@ class IPCHostContext : public Context {
                                             hipStream_t stream);
 
   __host__ void sync_all();
+
+  __host__ void sync(rocshmem_team_t team);
+
+  __host__ void barrier(rocshmem_team_t team);
 
   template <typename T>
   __host__ void broadcast(T *dest, const T *source, int nelems, int pe_root,

--- a/projects/rocshmem/src/reverse_offload/context_ro_host.cpp
+++ b/projects/rocshmem/src/reverse_offload/context_ro_host.cpp
@@ -120,6 +120,10 @@ __host__ void ROHostContext::sync_all() {
   host_interface->sync_all(context_window_info);
 }
 
+__host__ void ROHostContext::sync(rocshmem_team_t team) {
+  host_interface->sync(team, context_window_info);
+}
+
 __host__ void ROHostContext::barrier_all() {
 
   host_interface->fence(context_window_info);
@@ -127,9 +131,18 @@ __host__ void ROHostContext::barrier_all() {
   host_interface->barrier_for_sync();
 }
 
+__host__ void ROHostContext::barrier(rocshmem_team_t team) {
+  host_interface->barrier(team, context_window_info);
+}
+
 __host__ void ROHostContext::barrier_all_on_stream(hipStream_t stream) {
 
   host_interface->barrier_all_on_stream(stream);
+}
+
+__host__ void ROHostContext::barrier_on_stream(rocshmem_team_t team,
+                                               hipStream_t stream) {
+  host_interface->barrier_on_stream(team, stream);
 }
 
 __host__ void ROHostContext::quiet_on_stream(hipStream_t stream) {
@@ -142,6 +155,13 @@ __host__ void ROHostContext::sync_all_on_stream(hipStream_t stream) {
   LOG_TRACE("ro_net_host_sync_all_on_stream");
 
   host_interface->sync_all_on_stream(stream);
+}
+
+__host__ void ROHostContext::sync_on_stream(rocshmem_team_t team,
+                                            hipStream_t stream) {
+  LOG_TRACE("ro_net_host_sync_on_stream");
+
+  host_interface->sync_on_stream(team, stream);
 }
 
 __host__ void ROHostContext::alltoallmem_on_stream(rocshmem_team_t team,

--- a/projects/rocshmem/src/reverse_offload/context_ro_host.hpp
+++ b/projects/rocshmem/src/reverse_offload/context_ro_host.hpp
@@ -133,9 +133,13 @@ class ROHostContext : public Context {
 
   __host__ void barrier_all_on_stream(hipStream_t stream);
 
+  __host__ void barrier_on_stream(rocshmem_team_t team, hipStream_t stream);
+
   __host__ void quiet_on_stream(hipStream_t stream);
 
   __host__ void sync_all_on_stream(hipStream_t stream);
+
+  __host__ void sync_on_stream(rocshmem_team_t team, hipStream_t stream);
 
   __host__ void alltoallmem_on_stream(rocshmem_team_t team, void *dest,
                                       const void *source, size_t size,
@@ -165,6 +169,10 @@ class ROHostContext : public Context {
   template <typename T, ROCSHMEM_OP Op>
   __host__ int reduce_on_stream(rocshmem_team_t team, T *dest, const T *source, 
                                 int nreduce, hipStream_t stream);
+
+  __host__ void sync(rocshmem_team_t team);
+
+  __host__ void barrier(rocshmem_team_t team);
 
   template <typename T>
   __host__ void broadcast(T *dest, const T *source, int nelems, int pe_root,

--- a/projects/rocshmem/src/rocshmem.cpp
+++ b/projects/rocshmem/src/rocshmem.cpp
@@ -1262,11 +1262,24 @@ __host__ void rocshmem_barrier_all() {
   get_internal_ctx(ROCSHMEM_HOST_CTX_DEFAULT)->barrier_all();
 }
 
+__host__ void rocshmem_barrier(rocshmem_team_t team) {
+  LOG_API("host::barrier (team=%p)", team);
+
+  get_internal_ctx(ROCSHMEM_HOST_CTX_DEFAULT)->barrier(team);
+}
+
 
 __host__ void rocshmem_barrier_all_on_stream(hipStream_t stream) {
   LOG_API("host::barrier_all_on_stream ()");
 
   get_internal_ctx(ROCSHMEM_HOST_CTX_DEFAULT)->barrier_all_on_stream(stream);
+}
+
+__host__ void rocshmem_barrier_on_stream(rocshmem_team_t team,
+                                         hipStream_t stream) {
+  LOG_API("host::barrier_on_stream (team=%p)", team);
+
+  get_internal_ctx(ROCSHMEM_HOST_CTX_DEFAULT)->barrier_on_stream(team, stream);
 }
 
 __host__ void rocshmem_quiet_on_stream(hipStream_t stream) {
@@ -1279,6 +1292,13 @@ __host__ void rocshmem_sync_all_on_stream(hipStream_t stream) {
   LOG_API("rocshmem_sync_all_on_stream");
 
   get_internal_ctx(ROCSHMEM_HOST_CTX_DEFAULT)->sync_all_on_stream(stream);
+}
+
+__host__ void rocshmem_team_sync_on_stream(rocshmem_team_t team,
+                                           hipStream_t stream) {
+  LOG_API("host::team_sync_on_stream (team=%p)", team);
+
+  get_internal_ctx(ROCSHMEM_HOST_CTX_DEFAULT)->sync_on_stream(team, stream);
 }
 
 __host__ void rocshmem_alltoallmem_on_stream(rocshmem_team_t team, void *dest,
@@ -1342,6 +1362,12 @@ __host__ void rocshmem_sync_all() {
   LOG_API("host::sync_all");
 
   get_internal_ctx(ROCSHMEM_HOST_CTX_DEFAULT)->sync_all();
+}
+
+__host__ void rocshmem_team_sync(rocshmem_team_t team) {
+  LOG_API("host::team_sync (team=%p)", team);
+
+  get_internal_ctx(ROCSHMEM_HOST_CTX_DEFAULT)->sync(team);
 }
 
 template <typename T>

--- a/projects/rocshmem/src/rocshmem_gpu.cpp
+++ b/projects/rocshmem/src/rocshmem_gpu.cpp
@@ -778,12 +778,20 @@ __global__ ATTR_NO_INLINE void rocshmem_barrier_all_kernel(){
   rocshmem_barrier_all();
 }
 
+__global__ ATTR_NO_INLINE void rocshmem_barrier_kernel(rocshmem_team_t team){
+  rocshmem_ctx_barrier(ROCSHMEM_CTX_DEFAULT, team);
+}
+
 __global__ ATTR_NO_INLINE void rocshmem_quiet_kernel(){
   rocshmem_quiet();
 }
 
 __global__ ATTR_NO_INLINE void rocshmem_sync_all_kernel(){
   rocshmem_sync_all();
+}
+
+__global__ ATTR_NO_INLINE void rocshmem_team_sync_kernel(rocshmem_team_t team){
+  rocshmem_ctx_sync(ROCSHMEM_CTX_DEFAULT, team);
 }
 
 __global__ ATTR_NO_INLINE void rocshmem_alltoallmem_kernel(rocshmem_team_t team,

--- a/projects/rocshmem/tests/functional_tests/CMakeLists.txt
+++ b/projects/rocshmem/tests/functional_tests/CMakeLists.txt
@@ -74,6 +74,7 @@ target_sources(
     library_info_tester.cpp
     fence_ordering_tester.cpp
     tile_rma_tester.cpp
+    host_team_sync_barrier_tester.cpp
 )
 
 ###############################################################################

--- a/projects/rocshmem/tests/functional_tests/host_team_sync_barrier_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/host_team_sync_barrier_tester.cpp
@@ -1,0 +1,122 @@
+/******************************************************************************
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *****************************************************************************/
+
+#include "host_team_sync_barrier_tester.hpp"
+
+#include <cstdlib>
+#include <iostream>
+
+using namespace rocshmem;
+
+HostTeamSyncBarrierTester::HostTeamSyncBarrierTester(TesterArguments args)
+    : Tester(args) {
+  _type = HostTeamSyncBarrierTestType;
+  _print_results = false;
+}
+
+HostTeamSyncBarrierTester::~HostTeamSyncBarrierTester() {}
+
+void HostTeamSyncBarrierTester::resetBuffers([[maybe_unused]] size_t size) {}
+
+void HostTeamSyncBarrierTester::launchKernel([[maybe_unused]] dim3 gridSize,
+                                             [[maybe_unused]] dim3 blockSize,
+                                             [[maybe_unused]] int loop,
+                                             [[maybe_unused]] size_t size) {}
+
+void HostTeamSyncBarrierTester::verifyResults([[maybe_unused]] size_t size) {
+  int me = rocshmem_my_pe();
+  int n = rocshmem_n_pes();
+  if (n < 2) {
+    if (me == 0) {
+      std::cerr << "host team sync/barrier test requires >= 2 PEs\n";
+    }
+    abort();
+  }
+
+  // Split WORLD into even ranks, so odd ranks exercise INVALID no-op behavior.
+  int even_size = (n + 1) / 2;
+  rocshmem_team_t even_team = ROCSHMEM_TEAM_INVALID;
+  int rc = rocshmem_team_split_strided(ROCSHMEM_TEAM_WORLD, 0, 2, even_size,
+                                       nullptr, 0, &even_team);
+  if (rc != ROCSHMEM_SUCCESS) {
+    std::cerr << "rocshmem_team_split_strided(even) failed rc=" << rc << "\n";
+    abort();
+  }
+
+  if ((me % 2) == 0) {
+    if (even_team == ROCSHMEM_TEAM_INVALID) {
+      std::cerr << "even rank received TEAM_INVALID for even_team\n";
+      abort();
+    }
+  } else if (even_team != ROCSHMEM_TEAM_INVALID) {
+    std::cerr << "odd rank unexpectedly received valid even_team\n";
+    abort();
+  }
+
+  // All ranks call with their local handle (valid or INVALID).
+  rocshmem_team_sync(even_team);
+  rocshmem_barrier(even_team);
+
+  // Stream-ordered variants: even ranks enqueue a real team collective on the
+  // stream; odd ranks pass ROCSHMEM_TEAM_INVALID and must no-op (nothing is
+  // enqueued).  Synchronizing the stream then re-joining barrier_all confirms
+  // the enqueued kernels completed without a hang.
+  rocshmem_team_sync_on_stream(even_team, stream);
+  rocshmem_barrier_on_stream(even_team, stream);
+  CHECK_HIP(hipStreamSynchronize(stream));
+  rocshmem_barrier_all();
+
+  // Nested split inside the even team: team of size 1 containing even-team PE 0.
+  rocshmem_team_t leader_team = ROCSHMEM_TEAM_INVALID;
+  if ((me % 2) == 0) {
+    rc = rocshmem_team_split_strided(even_team, 0, 1, 1, nullptr, 0,
+                                     &leader_team);
+    if (rc != ROCSHMEM_SUCCESS) {
+      std::cerr << "rocshmem_team_split_strided(leader) failed rc=" << rc
+                << "\n";
+      abort();
+    }
+  }
+
+  rocshmem_team_sync(leader_team);
+  rocshmem_barrier(leader_team);
+
+  // Stream-ordered on the single-PE leader team (and INVALID no-op for
+  // non-leaders).
+  rocshmem_team_sync_on_stream(leader_team, stream);
+  rocshmem_barrier_on_stream(leader_team, stream);
+  CHECK_HIP(hipStreamSynchronize(stream));
+
+  if ((me % 2) == 0) {
+    rocshmem_team_destroy(leader_team);
+  }
+  rocshmem_team_destroy(even_team);
+
+  rocshmem_barrier_all();
+
+  if (me == 0) {
+    std::cout << "PASS: host team sync/barrier (blocking + on_stream) "
+                 "runtime behavior validated\n";
+  }
+}

--- a/projects/rocshmem/tests/functional_tests/host_team_sync_barrier_tester.hpp
+++ b/projects/rocshmem/tests/functional_tests/host_team_sync_barrier_tester.hpp
@@ -1,0 +1,47 @@
+/******************************************************************************
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *****************************************************************************/
+
+#ifndef _HOST_TEAM_SYNC_BARRIER_TESTER_HPP
+#define _HOST_TEAM_SYNC_BARRIER_TESTER_HPP
+
+#include "tester.hpp"
+
+/**
+ * Host-side functional validation for the team-scoped barrier/sync APIs:
+ *   - blocking:       rocshmem_barrier(team), rocshmem_team_sync(team)
+ *   - stream-ordered: rocshmem_barrier_on_stream(team, stream),
+ *                     rocshmem_team_sync_on_stream(team, stream)
+ */
+class HostTeamSyncBarrierTester : public Tester {
+ public:
+  explicit HostTeamSyncBarrierTester(TesterArguments args);
+  ~HostTeamSyncBarrierTester() override;
+
+ protected:
+  void resetBuffers(size_t size) override;
+  void launchKernel(dim3 gridSize, dim3 blockSize, int loop, size_t size) override;
+  void verifyResults(size_t size) override;
+};
+
+#endif  // _HOST_TEAM_SYNC_BARRIER_TESTER_HPP

--- a/projects/rocshmem/tests/functional_tests/tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/tester.cpp
@@ -74,6 +74,7 @@
 #include "reduce_on_stream_tester.hpp"
 #include "host_ctx_create_tester.hpp"
 #include "team_split_2d_tester.hpp"
+#include "host_team_sync_barrier_tester.hpp"
 
 #include "backend_bc.hpp"
 extern Backend* backend;
@@ -706,6 +707,9 @@ std::vector<Tester*> Tester::create(TesterArguments args) {
     case TileGetArbitraryTestType:
       test_name = "Tile Get Arbitrary Strides";
       testers.push_back(new TileRMATester(args));
+    case HostTeamSyncBarrierTestType:
+      test_name = "Host Team Sync/Barrier";
+      testers.push_back(new HostTeamSyncBarrierTester(args));
       break;
     case ReduceOnStreamTestType:
       test_name = "Reduce On Stream";

--- a/projects/rocshmem/tests/functional_tests/tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/tester.cpp
@@ -707,6 +707,7 @@ std::vector<Tester*> Tester::create(TesterArguments args) {
     case TileGetArbitraryTestType:
       test_name = "Tile Get Arbitrary Strides";
       testers.push_back(new TileRMATester(args));
+      break;
     case HostTeamSyncBarrierTestType:
       test_name = "Host Team Sync/Barrier";
       testers.push_back(new HostTeamSyncBarrierTester(args));

--- a/projects/rocshmem/tests/functional_tests/tester.hpp
+++ b/projects/rocshmem/tests/functional_tests/tester.hpp
@@ -161,7 +161,8 @@
   X(TileGetArbitrary,          116)  \
   X(ReduceOnStream,            117)  \
   X(HostCtxCreate,             118)  \
-  X(TeamSplit2D,               119)
+  X(TeamSplit2D,               119)  \
+  X(HostTeamSyncBarrier,       120)
 
 #define _ROCSHMEM_ENUM_ENTRY(name, val) name##TestType = val,
 enum TestType {

--- a/projects/rocshmem/tests/functional_tests/tester_arguments.cpp
+++ b/projects/rocshmem/tests/functional_tests/tester_arguments.cpp
@@ -214,6 +214,7 @@ TesterArguments::TesterArguments(int argc, char *argv[]) {
     case TeamCtxInfraBlockTestType:
     case TeamCtxInfraOddEvenTestType:
     case TeamCtxSubsetParentInfraTestType:
+    case HostTeamSyncBarrierTestType:
       max_msg_size = min_msg_size;
       break;
     case FenceOrderPutWaveNbiChunksTestType:
@@ -315,6 +316,7 @@ void TesterArguments::get_arguments() {
     case TeamCtxSharedInfraTestType:
     case FenceOrderFanoutTestType:
     case TeamSplit2DTestType:
+    case HostTeamSyncBarrierTestType:
       requires_two_pes = false;
       break;
     default:


### PR DESCRIPTION
## Motivation

Follow-up to #6368. Adds team-scoped and stream-ordered host synchronization for team `barrier` / `sync`, teams can synchronize and order RMA on a HIP stream (compute/comm overlap) rather than only via blocking host calls.

## Technical Details

Host APIs

- `rocshmem_barrier_on_stream(rocshmem_team_t team, hipStream_t stream)`
- `rocshmem_team_sync_on_stream(rocshmem_team_t team, hipStream_t stream)`

Python bindings: `rocshmem_barrier_on_stream` / `rocshmem_team_sync_on_stream`

## JIRA ID

AIROCSHMEM-420

## Test Plan

- C functional tester `host_team_sync_barrier_tester` (blocking + stream variants over 2/4/8-PE teams), wired into the driver.
- Python `test_teams.py`: team-scoped timing (members block, non-members return promptly), `team_sync` local-store visibility, `barrier` RMA ordering, and stream-ordered put -> `barrier_on_stream` -> read on a dedicated `hipStream_t`, for both blocking and stream variants.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
