### PR TITLE
[rocprofiler-systems] Force OpenMP examples to use LLVM based AMD compiler

### DIFF
--- a/projects/rocprofiler-systems/examples/hpc/jacobi-fortran-usm/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/hpc/jacobi-fortran-usm/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier:  MIT
 
-check_rocprofsys_disable_examples("jacobi-fortran-usm" _JACOBI_FORTAN_USM_DISABLED)
+check_rocprofsys_disable_examples("jacobi-fortran-usm" _JACOBI_FORTRAN_USM_DISABLED)
 check_rocprofsys_disable_examples("openmp" _OPENMP_DISABLED)
-if(_JACOBI_FORTAN_USM_DISABLED OR _OPENMP_DISABLED)
+if(_JACOBI_FORTRAN_USM_DISABLED OR _OPENMP_DISABLED)
     return()
 endif()
 

--- a/projects/rocprofiler-systems/examples/openmp/CG/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/CG/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
+if(ROCPROFSYS_DISABLE_EXAMPLES)
+    if("openmp-cg" IN_LIST ROCPROFSYS_DISABLE_EXAMPLES)
+        return()
+    endif()
+endif()
+
+include(${CMAKE_CURRENT_LIST_DIR}/../openmp-helper.cmake)
+
+add_executable(openmp-cg cg.cpp)
+target_link_libraries(openmp-cg PRIVATE openmp-common)
+
+rocprofiler_systems_custom_compilation(
+    COMPILER ${amdclangpp_EXECUTABLE}
+    TARGET openmp-cg
+)
+
+if(ROCPROFSYS_INSTALL_EXAMPLES AND TARGET openmp-cg)
+    install(
+        TARGETS openmp-cg
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples
+        COMPONENT rocprofiler-systems-examples
+    )
+endif()

--- a/projects/rocprofiler-systems/examples/openmp/CG/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/CG/CMakeLists.txt
@@ -1,10 +1,9 @@
 # Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier:  MIT
 
-if(ROCPROFSYS_DISABLE_EXAMPLES)
-    if("openmp-cg" IN_LIST ROCPROFSYS_DISABLE_EXAMPLES)
-        return()
-    endif()
+check_rocprofsys_disable_examples("openmp-cg" _OPENMP_CG_DISABLED)
+if(_OPENMP_CG_DISABLED)
+    return()
 endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/../openmp-helper.cmake)

--- a/projects/rocprofiler-systems/examples/openmp/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/CMakeLists.txt
@@ -1,6 +1,12 @@
 # Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier:  MIT
 
+if(ROCPROFSYS_DISABLE_EXAMPLES)
+    if("openmp" IN_LIST ROCPROFSYS_DISABLE_EXAMPLES)
+        return()
+    endif()
+endif()
+
 cmake_minimum_required(VERSION 3.25 FATAL_ERROR)
 
 project(rocprofiler-systems-openmp LANGUAGES CXX)

--- a/projects/rocprofiler-systems/examples/openmp/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/CMakeLists.txt
@@ -14,93 +14,16 @@ file(GLOB common_source ${CMAKE_CURRENT_SOURCE_DIR}/common/*.cpp)
 add_library(openmp-common OBJECT ${common_source})
 target_include_directories(openmp-common PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/common)
 
-add_executable(
-    openmp-cg
-    ${CMAKE_CURRENT_SOURCE_DIR}/CG/cg.cpp
-    $<TARGET_OBJECTS:openmp-common>
-)
-add_executable(
-    openmp-lu
-    ${CMAKE_CURRENT_SOURCE_DIR}/LU/lu.cpp
-    $<TARGET_OBJECTS:openmp-common>
+include(${CMAKE_CURRENT_LIST_DIR}/openmp-helper.cmake)
+
+target_compile_options(openmp-common PUBLIC -fopenmp)
+target_link_options(openmp-common PUBLIC -fopenmp)
+rocprofiler_systems_custom_compilation(
+    COMPILER ${amdclangpp_EXECUTABLE}
+    TARGET openmp-common
 )
 
-option(USE_CLANG_OMP "Use the clang OpenMP if available" ON)
-
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    set(OpenMP_C_FLAGS "-fopenmp=libomp")
-    set(OpenMP_CXX_FLAGS "-fopenmp=libomp")
-
-    find_package(OpenMP REQUIRED)
-    target_link_libraries(openmp-common PUBLIC OpenMP::OpenMP_CXX)
-    set(ROCPROFSYS_OPENMP_USING_LIBOMP_LIBRARY
-        ON
-        CACHE INTERNAL
-        "Used by rocprofiler-systems testing"
-        FORCE
-    )
-else()
-    find_program(CLANGXX_EXECUTABLE NAMES clang++)
-    find_library(
-        LIBOMP_LIBRARY
-        NAMES omp omp5 ${CMAKE_SHARED_LIBRARY_PREFIX}omp${CMAKE_SHARED_LIBRARY_SUFFIX}.5
-    )
-    if(
-        CLANGXX_EXECUTABLE
-        AND LIBOMP_LIBRARY
-        AND COMMAND rocprofiler_systems_custom_compilation
-        AND USE_CLANG_OMP
-    )
-        target_compile_options(openmp-common PUBLIC -W -Wall -fopenmp=libomp)
-        target_link_libraries(openmp-common PUBLIC ${LIBOMP_LIBRARY})
-        rocprofiler_systems_custom_compilation(COMPILER ${CLANGXX_EXECUTABLE}
-            TARGET openmp-common
-        )
-        rocprofiler_systems_custom_compilation(COMPILER ${CLANGXX_EXECUTABLE}
-            TARGET openmp-cg
-        )
-        rocprofiler_systems_custom_compilation(COMPILER ${CLANGXX_EXECUTABLE}
-            TARGET openmp-lu
-        )
-        set(ROCPROFSYS_OPENMP_USING_LIBOMP_LIBRARY
-            ON
-            CACHE INTERNAL
-            "Used by rocprofiler-systems testing"
-            FORCE
-        )
-    else()
-        find_package(OpenMP REQUIRED)
-        target_link_libraries(openmp-common PUBLIC OpenMP::OpenMP_CXX)
-        set(ROCPROFSYS_OPENMP_USING_LIBOMP_LIBRARY
-            OFF
-            CACHE INTERNAL
-            "Used by rocprofiler-systems testing"
-            FORCE
-        )
-    endif()
-endif()
-
-target_link_libraries(openmp-cg PRIVATE openmp-common)
-target_link_libraries(openmp-lu PRIVATE openmp-common)
-
-set(OPENMP_EXAMPLES openmp-cg openmp-lu)
-
-foreach(OPENMP_EXAMPLE IN LISTS OPENMP_EXAMPLES)
-    if(ROCPROFSYS_INSTALL_EXAMPLES AND TARGET ${OPENMP_EXAMPLE})
-        install(
-            TARGETS ${OPENMP_EXAMPLE}
-            DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples
-            COMPONENT rocprofiler-systems-examples
-        )
-    endif()
-endforeach()
-
+add_subdirectory(CG)
+add_subdirectory(LU)
 add_subdirectory(fortran)
-
-if(ROCPROFSYS_DISABLE_EXAMPLES)
-    if(NOT "openmp-target" IN_LIST ROCPROFSYS_DISABLE_EXAMPLES)
-        add_subdirectory(target)
-    endif()
-else()
-    add_subdirectory(target)
-endif()
+add_subdirectory(target)

--- a/projects/rocprofiler-systems/examples/openmp/LU/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/LU/CMakeLists.txt
@@ -1,10 +1,9 @@
 # Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier:  MIT
 
-if(ROCPROFSYS_DISABLE_EXAMPLES)
-    if("openmp-lu" IN_LIST ROCPROFSYS_DISABLE_EXAMPLES)
-        return()
-    endif()
+check_rocprofsys_disable_examples("openmp-lu" _OPENMP_LU_DISABLED)
+if(_OPENMP_LU_DISABLED)
+    return()
 endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/../openmp-helper.cmake)

--- a/projects/rocprofiler-systems/examples/openmp/LU/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/LU/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
+if(ROCPROFSYS_DISABLE_EXAMPLES)
+    if("openmp-lu" IN_LIST ROCPROFSYS_DISABLE_EXAMPLES)
+        return()
+    endif()
+endif()
+
+include(${CMAKE_CURRENT_LIST_DIR}/../openmp-helper.cmake)
+
+add_executable(openmp-lu lu.cpp)
+target_link_libraries(openmp-lu PRIVATE openmp-common)
+
+rocprofiler_systems_custom_compilation(
+    COMPILER ${amdclangpp_EXECUTABLE}
+    TARGET openmp-lu
+)
+
+if(ROCPROFSYS_INSTALL_EXAMPLES AND TARGET openmp-lu)
+    install(
+        TARGETS openmp-lu
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples
+        COMPONENT rocprofiler-systems-examples
+    )
+endif()

--- a/projects/rocprofiler-systems/examples/openmp/README.md
+++ b/projects/rocprofiler-systems/examples/openmp/README.md
@@ -27,7 +27,7 @@ This directory contains NAS Parallel Benchmarks (NPB) implemented with OpenMP th
   - `amdclang++` is **required** for the C++ examples (`openmp-cg`, `openmp-lu`, and the `openmp-common` shared utility objects).
   - `amdflang` (version 20 or newer) is **required** for the Fortran examples (`fortran/host.f90`, `fortran/offload.f90`).
 
-If either compiler is missing, CMake configuration fails with a `FATAL_ERROR`.
+If a required compiler for an **enabled** target is missing, CMake configuration fails with a `FATAL_ERROR` (append `openmp` to `ROCPROFSYS_DISABLE_EXAMPLES` to skip building these examples).
 
 ## Building
 

--- a/projects/rocprofiler-systems/examples/openmp/README.md
+++ b/projects/rocprofiler-systems/examples/openmp/README.md
@@ -20,12 +20,14 @@ This directory contains NAS Parallel Benchmarks (NPB) implemented with OpenMP th
 - `fortran/host.f90` - OpenMP host example that uses two CPU threads to update an integer array in round-robin order.
 - `fortran/offload.f90` - OpenMP target offload example that launches a GPU target region to transpose a matrix.
 
-These Fortran examples require `amdflang` version 20 or newer.
-
 ## Prerequisites
 
 - CMake 3.25+
-- C++ compiler with OpenMP support (Clang with libomp or GCC)
+- ROCm install providing `amdclang++` and `amdflang` (resolved from `ROCM_PATH` or `/opt/rocm`)
+  - `amdclang++` is **required** for the C++ examples (`openmp-cg`, `openmp-lu`, and the `openmp-common` shared utility objects).
+  - `amdflang` (version 20 or newer) is **required** for the Fortran examples (`fortran/host.f90`, `fortran/offload.f90`).
+
+If either compiler is missing, CMake configuration fails with a `FATAL_ERROR`.
 
 ## Building
 
@@ -49,6 +51,9 @@ cmake --build <build_dir> --target openmp-cg openmp-lu
 | -------- | ------------- |
 | `openmp-cg` | NAS Conjugate Gradient benchmark |
 | `openmp-lu` | NAS LU Gauss-Seidel benchmark |
+| `openmp-target` | OpenMP GPU target offloading example |
+| `openmp-fortran-host` | Fortran OpenMP host example |
+| `openmp-fortran-offload` | Fortran OpenMP target offload example |
 
 ## Running
 

--- a/projects/rocprofiler-systems/examples/openmp/fortran/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/fortran/CMakeLists.txt
@@ -3,9 +3,9 @@
 
 set(OPENMP_DIRECTIVE_USE_OFFLOAD TRUE)
 
-check_rocprofsys_disable_examples("fortran" _FORTAN_DISABLED)
-check_rocprofsys_disable_examples("openmp-fortran" _OPENMP_FORTAN_DISABLED)
-if(_FORTAN_DISABLED OR _OPENMP_FORTAN_DISABLED)
+check_rocprofsys_disable_examples("fortran" _FORTRAN_DISABLED)
+check_rocprofsys_disable_examples("openmp-fortran" _OPENMP_FORTRAN_DISABLED)
+if(_FORTRAN_DISABLED OR _OPENMP_FORTRAN_DISABLED)
     return()
 endif()
 

--- a/projects/rocprofiler-systems/examples/openmp/fortran/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/fortran/CMakeLists.txt
@@ -3,13 +3,10 @@
 
 set(OPENMP_DIRECTIVE_USE_OFFLOAD TRUE)
 
-if(ROCPROFSYS_DISABLE_EXAMPLES)
-    if("fortran" IN_LIST ROCPROFSYS_DISABLE_EXAMPLES)
-        return()
-    endif()
-    if("offload" IN_LIST ROCPROFSYS_DISABLE_EXAMPLES)
-        set(OPENMP_DIRECTIVE_USE_OFFLOAD FALSE)
-    endif()
+check_rocprofsys_disable_examples("fortran" _FORTAN_DISABLED)
+check_rocprofsys_disable_examples("openmp-fortran" _OPENMP_FORTAN_DISABLED)
+if(_FORTAN_DISABLED OR _OPENMP_FORTAN_DISABLED)
+    return()
 endif()
 
 rocprofiler_systems_message(STATUS "Configure OpenMP Fortran examples...")
@@ -38,8 +35,9 @@ mark_as_advanced(amdflang_EXECUTABLE)
 
 if(NOT amdflang_EXECUTABLE)
     rocprofiler_systems_message(
-      FATAL_ERROR
-      "Could not find amdflang. This is required for the OpenMP Fortran examples."
+        FATAL_ERROR
+        "Could not find amdflang. This is required for the OpenMP Fortran examples. "
+        "Append fortran to ROCPROFSYS_DISABLE_EXAMPLES to prevent these examples from being built."
     )
 endif()
 

--- a/projects/rocprofiler-systems/examples/openmp/openmp-helper.cmake
+++ b/projects/rocprofiler-systems/examples/openmp/openmp-helper.cmake
@@ -1,0 +1,33 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
+include_guard(DIRECTORY)
+
+find_program(
+    amdclangpp_EXECUTABLE
+    NAMES amdclang++
+    HINTS ${ROCM_PATH}
+    ENV ROCM_PATH
+    /opt/rocm
+    PATHS ${ROCM_PATH}
+    ENV ROCM_PATH
+    /opt/rocm
+    PATH_SUFFIXES bin llvm/bin
+)
+mark_as_advanced(amdclangpp_EXECUTABLE)
+
+if(NOT amdclangpp_EXECUTABLE)
+    rocprofiler_systems_message(
+        FATAL_ERROR
+        "Could not find amdclang++. This is required for the OpenMP examples. "
+        "Append openmp to ROCPROFSYS_DISABLE_EXAMPLES to prevent these examples from being built."
+    )
+endif()
+
+if(NOT COMMAND rocprofiler_systems_custom_compilation)
+    rocprofiler_systems_message(
+        FATAL_ERROR
+        "rocprofiler_systems_custom_compilation() is not available. "
+        "The OpenMP examples require the rocprofiler-systems CMake helpers."
+    )
+endif()

--- a/projects/rocprofiler-systems/examples/openmp/openmp-helper.cmake
+++ b/projects/rocprofiler-systems/examples/openmp/openmp-helper.cmake
@@ -28,6 +28,19 @@ if(NOT COMMAND rocprofiler_systems_custom_compilation)
     rocprofiler_systems_message(
         FATAL_ERROR
         "rocprofiler_systems_custom_compilation() is not available. "
-        "The OpenMP examples require the rocprofiler-systems CMake helpers."
+        "The OpenMP examples require the rocprofiler-systems CMake helpers. "
+        "Append openmp to ROCPROFSYS_DISABLE_EXAMPLES to prevent these examples from being built."
     )
 endif()
+
+# TODO: Move this to a top level helper in examples and reuse across all examples
+# Outputs a bool if the _EXAMPLE_NAME is in ROCPROFSYS_DISABLE_EXAMPLES
+function(CHECK_ROCPROFSYS_DISABLE_EXAMPLES _EXAMPLE_NAME _OUTPUT)
+    if(ROCPROFSYS_DISABLE_EXAMPLES)
+        if("${_EXAMPLE_NAME}" IN_LIST ROCPROFSYS_DISABLE_EXAMPLES)
+            set(${_OUTPUT} TRUE PARENT_SCOPE)
+            return()
+        endif()
+    endif()
+    set(${_OUTPUT} FALSE PARENT_SCOPE)
+endfunction()

--- a/projects/rocprofiler-systems/examples/openmp/target/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/target/CMakeLists.txt
@@ -1,10 +1,9 @@
 # Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier:  MIT
 
-if(ROCPROFSYS_DISABLE_EXAMPLES)
-    if("openmp-target" IN_LIST ROCPROFSYS_DISABLE_EXAMPLES)
-        return()
-    endif()
+check_rocprofsys_disable_examples("openmp-target" _OPENMP_TARGET_DISABLED)
+if(_OPENMP_TARGET_DISABLED)
+    return()
 endif()
 
 cmake_minimum_required(VERSION 3.25 FATAL_ERROR)
@@ -30,26 +29,12 @@ if(NOT OMP_TARGET_COMPILER)
             "OpenMP target compiler"
         )
     else()
-        find_program(
-            amdclangpp_EXECUTABLE
-            NAMES amdclang++
-            PATHS "${ROCM_PATH}"
-            ENV ROCM_PATH
-            /opt/rocm
-            PATH_SUFFIXES bin llvm/bin
+        # Fall back to the amdclang++ discovered by openmp-helper.cmake
+        set(OMP_TARGET_COMPILER
+            "${amdclangpp_EXECUTABLE}"
+            CACHE FILEPATH
+            "OpenMP target compiler"
         )
-        mark_as_advanced(amdclangpp_EXECUTABLE)
-
-        if(amdclangpp_EXECUTABLE)
-            set(OMP_TARGET_COMPILER
-                "${amdclangpp_EXECUTABLE}"
-                CACHE FILEPATH
-                "OpenMP target compiler"
-            )
-        else()
-            message(WARNING "OpenMP target compiler not found. Skipping this example.")
-            return()
-        endif()
     endif()
 endif()
 

--- a/projects/rocprofiler-systems/examples/openmp/target/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/openmp/target/CMakeLists.txt
@@ -1,6 +1,12 @@
 # Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier:  MIT
 
+if(ROCPROFSYS_DISABLE_EXAMPLES)
+    if("openmp-target" IN_LIST ROCPROFSYS_DISABLE_EXAMPLES)
+        return()
+    endif()
+endif()
+
 cmake_minimum_required(VERSION 3.25 FATAL_ERROR)
 
 if(NOT ROCPROFSYS_GFX_TARGETS)


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Force the OpenMP examples to be compiled with `amdclang`/`amdflang`. That way we can guarantee that OMPT is implemented and the OpenMP tests that check for these callbacks pass. 

Specifically, this will allow `openmplu-binary-rewrite` test to pass once regexes are fixed.

This is part of https://github.com/ROCm/rocm-systems/pull/6355 and is considered Part 1.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

LU and CG now have their own CMakeLists.txt to build.
OpenMP examples now all require `amdclang/amdflang`.
Typo fix: FORTAN -> FORTRAN

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

N/A

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Workflows

## Test Result

<!-- Briefly summarize test outcomes. -->

See workflows

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
