### PR TITLE
[rocprofiler-sdk] fix(tests/thread_trace): skip producer/consumer unit suite on unsupported architecture

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/tests/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/tests/CMakeLists.txt
@@ -51,12 +51,20 @@ target_link_libraries(
             GTest::gtest_main
             rocprofiler-sdk::counter-test-constants)
 
+# The producer/consumer harness exercises the AQL profile thread-trace path with triple
+# buffering enabled, which is not supported by aqlprofile on GFX11
+# (aqlprofile_att_create_packets() throws "Not supported"). Reuse the shared SQTT
+# triple-buffer architecture gate to skip this suite on unsupported GPUs.
+include(rocprofiler-sdk-utilities)
+rocprofiler_sdk_sqtt_triple_buffer_disabled(THREAD_TRACE_PC_TEST_DISABLED)
+
 rocprofiler_add_unit_test(
     TARGET thread-trace-producer-consumer-test
     SOURCES ${ROCPROFILER_THREAD_TRACE_PRODUCER_CONSUMER_TEST_SOURCES}
     TEST_LIST thread-trace-test_TESTS
     TIMEOUT 100
     LABELS "unittests"
+    DISABLED ${THREAD_TRACE_PC_TEST_DISABLED}
     ENVIRONMENT
         "ROCPROFILER_METRICS_PATH=${_ROCPROFILER_SHARE_DIR}"
         "LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/llvm/lib:/opt/rocm/lib:/opt/rocm/llvm/lib:$ENV{LD_LIBRARY_PATH}"


### PR DESCRIPTION
The thread-trace-producer-consumer-test harness drives the AQL profile thread-trace path with triple buffering enabled. aqlprofile rejects this on GFX11 (and other non-MI300/non-GFX12 targets) with aqlprofile_att_create_packets(): "Not supported", causing every test in the suite (init_shutdown, status_query, multiple_calls, data_integrity, slow_cpu, slow_gpu, restart_after_overflow, buffer_alternation) to abort during test_init.

Gate the unit suite using the existing
rocprofiler_sdk_sqtt_triple_buffer_disabled() helper so it follows the same arch policy already applied to tests/thread-trace integration tests.

## Motivation


<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
ROCM-25091
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
