### PR TITLE
[AMD-SMI] Make CPU/ESMI init non-fatal in amdsmi_init

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -31,6 +31,11 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 ### Resolved Issues
 
+- **Fixed `amdsmi_init()` aborting entirely when CPU/ESMI initialization fails**.  
+  - `populate_amd_cpus()` treated an `esmi_init()` failure (non-AMD CPU, missing/unsupported energy or HSMP driver, or a CPU/SMU in a bad state) as fatal, causing all of `amdsmi_init()` to fail so GPU and NIC functionality became unusable. ESMI/CPU discovery is now non-fatal and is skipped on failure, mirroring the NIC discovery paths.
+  - Removed an incorrect `static_cast<amdsmi_status_t>(esmi_init())` that conflated the unrelated `esmi_status_t` and `amdsmi_status_t` enums.
+  - Added checks for the previously ignored return values of `get_nr_cpu_sockets()`, `get_nr_cpu_cores()`, and `get_nr_threads_per_core()`, plus a guard against a divide-by-zero when a misbehaving driver reports zero sockets or threads.
+
 - **Fixed `amd-smi static` hanging indefinitely on gfx1153 and gfx950**.  
   - Added a 60-second timeout to `amdsmi_init()` in the CLI so the process exits with a clear error message instead of hanging when the GPU driver is unresponsive.
   - Added `O_NONBLOCK` to DRM device open during initialization so `open()` returns immediately if the device is wedged.

--- a/projects/amdsmi/src/amd_smi/amd_smi_system.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_system.cc
@@ -299,15 +299,30 @@ amdsmi_status_t AMDSmiSystem::populate_amd_cpus() {
   amdsmi_status_t amd_smi_status;
 
   /* esmi is for AMD cpus, if its not AMD CPU, we are not going to initialise esmi */
-  amd_smi_status = static_cast<amdsmi_status_t>(esmi_init());
-  if (amd_smi_status != AMDSMI_STATUS_SUCCESS) {
+  esmi_status_t esmi_status = esmi_init();
+  if (esmi_status != ESMI_SUCCESS) {
+    // CPU monitoring via ESMI is unavailable: non-AMD CPU, missing/unsupported
+    // energy or HSMP driver, or the CPU/SMU is in a bad state (busy, timeout,
+    // prerequisite not satisfied, etc.). This must NOT be fatal to amdsmi_init()
+    // - GPU and NIC functionality must remain usable. Skip CPU population and
+    // continue, mirroring the non-fatal BRCM/AI NIC discovery paths.
     std::cout << "\tESMI Not initialized, drivers not found " << std::endl;
-    return amd_smi_status;
+    return AMDSMI_STATUS_SUCCESS;
   }
 
   amd_smi_status = get_nr_cpu_sockets(&sockets);
+  if (amd_smi_status != AMDSMI_STATUS_SUCCESS) return AMDSMI_STATUS_SUCCESS;
   amd_smi_status = get_nr_cpu_cores(&cpus);
+  if (amd_smi_status != AMDSMI_STATUS_SUCCESS) return AMDSMI_STATUS_SUCCESS;
   amd_smi_status = get_nr_threads_per_core(&threads);
+  if (amd_smi_status != AMDSMI_STATUS_SUCCESS) return AMDSMI_STATUS_SUCCESS;
+
+  // Guard against a misbehaving driver reporting zero topology counts, which
+  // would otherwise cause a divide-by-zero below. CPU monitoring is simply
+  // skipped (non-fatal) rather than crashing amdsmi_init().
+  if (sockets == 0 || threads == 0) {
+    return AMDSMI_STATUS_SUCCESS;
+  }
 
   for (uint32_t i = 0; i < sockets; i++) {
     std::string cpu_socket_id = std::to_string(i);


### PR DESCRIPTION
## Motivation

On a system with a misbehaving CPU/HSMP driver, every `amd-smi` invocation failed while `rocm-smi` worked. A `pdb` trace showed execution never got past `amdsmi_init`. The root cause is that AMD-SMI's CPU discovery path treated an ESMI initialization failure as fatal to the *entire* `amdsmi_init()`, so a bad CPU/SMU state (or simply a non-AMD CPU / missing HSMP driver) took down GPU and NIC functionality along with it.

## Technical Details

In `AMDSmiSystem::populate_amd_cpus()`:

- **ESMI/CPU discovery is now non-fatal.** An `esmi_init()` failure (non-AMD CPU, missing/unsupported energy or HSMP driver, or a CPU/SMU in a bad state) is logged and skipped, returning `AMDSMI_STATUS_SUCCESS` so GPU and NIC discovery continue. This mirrors the existing non-fatal BRCM/AI-NIC discovery convention.
- **Removed a type-confusion cast.** `static_cast<amdsmi_status_t>(esmi_init())` conflated the unrelated `esmi_status_t` and `amdsmi_status_t` enums (only `0` coincides). The result is now compared against `ESMI_SUCCESS` directly.
- **Hardened topology reads.** The previously ignored return values of `get_nr_cpu_sockets()`, `get_nr_cpu_cores()`, and `get_nr_threads_per_core()` are now checked, and a guard was added against a divide-by-zero in `(cpus / threads) / sockets` when a half-broken driver reports zero sockets or threads.

## JIRA ID

<!-- N/A -->

## Test Plan

- Built `libamd_smi.so` against `develop` with `-DENABLE_ESMI_LIB=ON`.
- Confirmed the edited translation unit compiles warning- and error-free.
- `pre-commit` (codespell, clang-format, whitespace/EOF checks) passes.

## Test Result

- Build succeeds (`[100%] Built target amd_smi`), clean link, no new compiler diagnostics in `amd_smi_system.cc`.
- `pre-commit run` on the staged files: all hooks Passed/Skipped.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
