### PR TITLE
[hipfile] Add include dir to format script

### DIFF
--- a/projects/hipfile/util/format-source.sh
+++ b/projects/hipfile/util/format-source.sh
@@ -9,6 +9,7 @@ COMMAND="clang-format"
 
 DIRS=(
     "examples"
+    "include"
     "src"
     "test"
     "tools"


### PR DESCRIPTION
## Motivation

The util/format-source.sh script does not cover the include directory

## Technical Details

Adds the include directory to the list of directories that are formatted

## JIRA ID

N/A

## Test Plan

Check that the formatter fixes include dir issues

## Test Result

Success

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
