### PR TITLE
rocprofiler-sdk: fix test/codeobj build reliability with TheRock

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/tests/codeobj/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/tests/codeobj/CMakeLists.txt
@@ -22,12 +22,14 @@ configure_file(hipcc_output.s hipcc_output.s COPYONLY)
 
 # Compile a HIP kernel with debug info to test DWARF inline annotation. Two-step: compile
 # to offload bundle, then unbundle to get the GPU ELF.
-find_program(
-    CODEOBJ_AMDCLANGPP REQUIRED
-    NAMES amdclang++
-    HINTS ${ROCM_PATH} ENV ROCM_PATH /opt/rocm
-    PATHS ${ROCM_PATH} ENV ROCM_PATH /opt/rocm
-    PATH_SUFFIXES bin llvm/bin NO_CACHE)
+if(NOT ROCPROFILER_SDK_TEST_AMDCLANGPP)
+    find_program(
+        ROCPROFILER_SDK_TEST_AMDCLANGPP REQUIRED
+        NAMES amdclang++
+        HINTS ${ROCM_PATH} ENV ROCM_PATH /opt/rocm
+        PATHS ${ROCM_PATH} ENV ROCM_PATH /opt/rocm
+        PATH_SUFFIXES bin llvm/bin NO_CACHE)
+endif()
 
 find_program(
     CODEOBJ_OFFLOAD_BUNDLER REQUIRED
@@ -46,9 +48,9 @@ set(_SYNCKERNEL_BIN "${CMAKE_CURRENT_BINARY_DIR}/syncthreads_kernel.bin")
 add_custom_command(
     OUTPUT "${_SYNCKERNEL_BIN}"
     COMMAND
-        ${CODEOBJ_AMDCLANGPP} -x hip -ggdb --offload-arch=${_SYNCKERNEL_ARCH}
-        --offload-device-only -c -fno-gpu-rdc --no-offload-new-driver -o
-        "${_SYNCKERNEL_BUNDLE}" "${_SYNCKERNEL_SRC}"
+        ${ROCPROFILER_SDK_TEST_AMDCLANGPP} ${ROCPROFILER_SDK_TEST_AMDCLANGPP_FLAGS} -x hip
+        -ggdb --offload-arch=${_SYNCKERNEL_ARCH} --offload-device-only -c -fno-gpu-rdc
+        --no-offload-new-driver -o "${_SYNCKERNEL_BUNDLE}" "${_SYNCKERNEL_SRC}"
     COMMAND
         ${CODEOBJ_OFFLOAD_BUNDLER} --type=o --input=${_SYNCKERNEL_BUNDLE}
         --output=${_SYNCKERNEL_BIN} --unbundle


### PR DESCRIPTION
# Motivation

rocprofiler-sdk has a test case where it builds a piece of HIP code, syncthreads_kernel.hip, then extracts the DWARF from the resulting binary to test debug info parsing.

When building with TheRock, the current cmake code looks for the the amdclang++ compiler in a way that could either find:

`build/compiler/amd-llvm/dist/lib/llvm/bin/amdclang++`

or

`build/dist/rocm/bin/amdclang++`

depending on a race condition between the `rocprofiler-sdk+configure` step and the ROCm artifact installation under `build/dist/rocm`.

Relevant code is in `projects/rocmprofiler-sdk/source/lib/tests/codeobj/CMakeLists.txt`:

```
find_program(
    CODEOBJ_AMDCLANGPP REQUIRED
    NAMES amdclang++
    HINTS ${ROCM_PATH} ENV ROCM_PATH /opt/rocm
    PATHS ${ROCM_PATH} ENV ROCM_PATH /opt/rocm
    PATH_SUFFIXES bin llvm/bin NO_CACHE)

(...)

add_custom_command(
    OUTPUT "${_SYNCKERNEL_BIN}"
    COMMAND
        ${CODEOBJ_AMDCLANGPP} -x hip -ggdb --offload-arch=${_SYNCKERNEL_ARCH}
        --offload-device-only -c -fno-gpu-rdc --no-offload-new-driver -o
        "${_SYNCKERNEL_BUNDLE}" "${_SYNCKERNEL_SRC}"
    COMMAND
        ${CODEOBJ_OFFLOAD_BUNDLER} --type=o --input=${_SYNCKERNEL_BUNDLE}
        --output=${_SYNCKERNEL_BIN} --unbundle
        --targets=hipv4-amdgcn-amd-amdhsa--${_SYNCKERNEL_ARCH}
    DEPENDS "${_SYNCKERNEL_SRC}"
    COMMENT
        "Compiling syncthreads_kernel.hip -> syncthreads_kernel.bin (${_SYNCKERNEL_ARCH})"
    VERBATIM)
```

If rocprofiler-sdk+configure finds the amdclang++ under `build/compiler/amd-llvm/dist/...` the build fails since the HIP source uses <hip/hip_runtime.h> and the location of the HIP runtime header can't be inferred from that directory layout.

Log snippet:

```
FAILED: source/lib/tests/codeobj/syncthreads_kernel.bin /home/scottt/o/r-gfx1151/build/profiler/rocprofiler-sdk/build/source/lib/tests/codeobj/syncthreads_kernel.bin
cd /home/scottt/o/r-gfx1151/build/profiler/rocprofiler-sdk/build/source/lib/tests/codeobj && /home/scottt/o/r-gfx1151/build/compiler/amd-llvm/dist/lib/llvm/bin/amdclang++ -x hip -ggdb --offload-arch=gfx90a --offload-device-only -c -fno-gpu-rdc --no-offload-new-driver -o /home/scottt/o/r-gfx1151/build/profiler/rocprofiler-sdk/build/source/lib/tests/codeobj/syncthreads_kernel_bundle.o /home/scottt/w/r/rocm-systems/projects/rocprofiler-sdk/source/lib/tests/codeobj/syncthreads_kernel.hip && /home/scottt/o/r-gfx1151/build/compiler/amd-llvm/dist/lib/llvm/bin/clang-offload-bundler --type=o --input=/home/scottt/o/r-gfx1151/build/profiler/rocprofiler-sdk/build/source/lib/tests/codeobj/syncthreads_kernel_bundle.o --output=/home/scottt/o/r-gfx1151/build/profiler/rocprofiler-sdk/build/source/lib/tests/codeobj/syncthreads_kernel.bin --unbundle --targets=hipv4-amdgcn-amd-amdhsa--gfx90a
clang++: error: cannot find HIP runtime; provide its path via '--rocm-path', or pass '-nogpuinc' to build without HIP runtime
```

where syncthreads_kernel.hip contains:

```
__device__ void
barrier_wrapper(int* data)
{
        __syncthreads();
        data[threadIdx.x] += data[threadIdx.x ^ 1];
}

__global__ void
syncthreads_kernel(int* data)
{
        data[threadIdx.x] = threadIdx.x;

}
```
# Technical Details

The patch creates two variables, `ROCPROFILER_SDK_TEST_AMDCLANGPP` and `ROCPROFILER_SDK_TEST_AMDCLANGPP_FLAGS` and allows TheRock to pass the values required by its split directory layout explicitly.

Building with a standard ROCm install would not need to set the variables as the location of `amdclang++` and the value of `--hip-path` would be auto-discovered from the standard directory layout.

# Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
