### PR TITLE
[rocshmem] Implement rocshmem_team_split_2d

### DIFF
--- a/projects/rocshmem/include/rocshmem/rocshmem.hpp
+++ b/projects/rocshmem/include/rocshmem/rocshmem.hpp
@@ -420,16 +420,16 @@ __host__ int rocshmem_team_my_pe(rocshmem_team_t team);
  *        y-coordinate, and each yteam will contain all the PEs with
  *        the same x-coordinate.
  *
- * @param parent_team   The team to be split.
- * @param xrange        Number of PEs per row (x-axis stride). 
- * @param xaxis_config  Pointer to a team configuration struct for the x-axis.
- * @param xaxis_mask    Bitmask of representing the set of configuration parameters 
- *                      to use from @p xconfig. A zero mask indicates all fields use defaults.
- * @param xaxis_team    Output handle for the calling PE's x-axis team.
- * @param yaxis_config  Pointer to a team configuration struct for the y-axis.
- * @param yaxis_mask    Bitmask of representing the set of configuration parameters 
- *                      to use from @p yconfig. A zero mask indicates all fields use defaults.
- * @param yaxis_team    Output handle for the calling PE's y-axis team.
+ * @param[in] parent_team    The team to be split.
+ * @param[in] xrange         Number of PEs per row (x-axis stride). 
+ * @param[in] xaxis_config   Pointer to a team configuration struct for the x-axis.
+ * @param[in] xaxis_mask     Bitmask of representing the set of configuration parameters 
+ *                           to use from @p xconfig. A zero mask indicates all fields use defaults.
+ * @param[out] xaxis_team    Output handle for the calling PE's x-axis team.
+ * @param[in] yaxis_config   Pointer to a team configuration struct for the y-axis.
+ * @param[in] yaxis_mask     Bitmask of representing the set of configuration parameters 
+ *                           to use from @p yconfig. A zero mask indicates all fields use defaults.
+ * @param[out] yaxis_team    Output handle for the calling PE's y-axis team.
  *
  * @return Zero on sucess; non-zero on failure.
  */

--- a/projects/rocshmem/include/rocshmem/rocshmem.hpp
+++ b/projects/rocshmem/include/rocshmem/rocshmem.hpp
@@ -414,6 +414,40 @@ __host__ int rocshmem_team_n_pes(rocshmem_team_t team);
 __host__ int rocshmem_team_my_pe(rocshmem_team_t team);
 
 /**
+ * @brief Splits a parent team into two sets of non-overlapping teams based on a
+ *        2D Cartesian decomposition. Must be called by all PEs in the parent team.
+ *        After the split each of the xteams will contain all the PEs with the same
+ *        y-coordinate, and each yteam will contain all the PEs with
+ *        the same x-coordinate.
+ *
+ * @param parent_team   The team to be split.
+ * 
+ * @param xrange        Number of PEs per row (x-axis stride). 
+ * 
+ * @param xaxis_config  Pointer to a team configuration struct for the x-axis.
+ * 
+ * @param xaxis_mask    Bitmask of representing the set of configuration parameters to use from @p xconfig. 
+ *                      A zero mask indicates all fields use defaults.
+ * 
+ * @param xaxis_team    Output handle for the calling PE's x-axis team.
+ * 
+ * @param yaxis_config  Pointer to a team configuration struct for the y-axis.
+ * 
+ * @param yaxis_mask    Bitmask of representing the set of configuration parameters to use from @p yconfig. 
+ *                      A zero mask indicates all fields use defaults.
+ * @param yaxis_team    Output handle for the calling PE's y-axis team.
+ *
+ *
+ * @return Zero on sucess; non-zero on failure.
+ */
+__host__ int rocshmem_team_split_2d(rocshmem_team_t parent_team, int xrange, const 
+                                    rocshmem_team_config_t *xaxis_config, long xaxis_mask, 
+                                    rocshmem_team_t *xaxis_team, 
+                                    const rocshmem_team_config_t *yaxis_config, long yaxis_mask, 
+                                    rocshmem_team_t *yaxis_team);
+
+
+/**
  * @brief Create a new a team of PEs. Must be called by all PEs
  * in the parent team.
  *

--- a/projects/rocshmem/include/rocshmem/rocshmem.hpp
+++ b/projects/rocshmem/include/rocshmem/rocshmem.hpp
@@ -421,22 +421,15 @@ __host__ int rocshmem_team_my_pe(rocshmem_team_t team);
  *        the same x-coordinate.
  *
  * @param parent_team   The team to be split.
- * 
  * @param xrange        Number of PEs per row (x-axis stride). 
- * 
  * @param xaxis_config  Pointer to a team configuration struct for the x-axis.
- * 
- * @param xaxis_mask    Bitmask of representing the set of configuration parameters to use from @p xconfig. 
- *                      A zero mask indicates all fields use defaults.
- * 
+ * @param xaxis_mask    Bitmask of representing the set of configuration parameters 
+ *                      to use from @p xconfig. A zero mask indicates all fields use defaults.
  * @param xaxis_team    Output handle for the calling PE's x-axis team.
- * 
  * @param yaxis_config  Pointer to a team configuration struct for the y-axis.
- * 
- * @param yaxis_mask    Bitmask of representing the set of configuration parameters to use from @p yconfig. 
- *                      A zero mask indicates all fields use defaults.
+ * @param yaxis_mask    Bitmask of representing the set of configuration parameters 
+ *                      to use from @p yconfig. A zero mask indicates all fields use defaults.
  * @param yaxis_team    Output handle for the calling PE's y-axis team.
- *
  *
  * @return Zero on sucess; non-zero on failure.
  */

--- a/projects/rocshmem/include/rocshmem/rocshmem.hpp
+++ b/projects/rocshmem/include/rocshmem/rocshmem.hpp
@@ -416,22 +416,22 @@ __host__ int rocshmem_team_my_pe(rocshmem_team_t team);
 /**
  * @brief Splits a parent team into two sets of non-overlapping teams based on a
  *        2D Cartesian decomposition. Must be called by all PEs in the parent team.
- *        After the split each of the xteams will contain all the PEs with the same
- *        y-coordinate, and each yteam will contain all the PEs with
+ *        After the split, each of the x-axis teams will contain all the PEs with the same
+ *        y-coordinate, and each of the y-axis teams will contain all the PEs with
  *        the same x-coordinate.
  *
  * @param[in] parent_team    The team to be split.
- * @param[in] xrange         Number of PEs per row (x-axis stride). 
+ * @param[in] xrange         Number of PEs per row.
  * @param[in] xaxis_config   Pointer to a team configuration struct for the x-axis.
- * @param[in] xaxis_mask     Bitmask of representing the set of configuration parameters 
- *                           to use from @p xconfig. A zero mask indicates all fields use defaults.
+ * @param[in] xaxis_mask     Bitmask representing the set of configuration parameters
+ *                           to use from @p xaxis_config. A zero mask indicates all fields use defaults.
  * @param[out] xaxis_team    Output handle for the calling PE's x-axis team.
  * @param[in] yaxis_config   Pointer to a team configuration struct for the y-axis.
- * @param[in] yaxis_mask     Bitmask of representing the set of configuration parameters 
- *                           to use from @p yconfig. A zero mask indicates all fields use defaults.
+ * @param[in] yaxis_mask     Bitmask representing the set of configuration parameters
+ *                           to use from @p yaxis_config. A zero mask indicates all fields use defaults.
  * @param[out] yaxis_team    Output handle for the calling PE's y-axis team.
  *
- * @return Zero on sucess; non-zero on failure.
+ * @return Zero on success; non-zero on failure.
  */
 __host__ int rocshmem_team_split_2d(rocshmem_team_t parent_team, int xrange, const 
                                     rocshmem_team_config_t *xaxis_config, long xaxis_mask, 

--- a/projects/rocshmem/scripts/functional_tests/driver.sh
+++ b/projects/rocshmem/scripts/functional_tests/driver.sh
@@ -151,6 +151,7 @@ declare -A TEST_NUMBERS=(
   ["tile_get_arbitrary"]="116"
   ["reduce_on_stream"]="117"
   ["host_ctx_create"]="118"
+  ["teamsplit2d"]="119"
 )
 
 ExecTest() {
@@ -641,7 +642,9 @@ TestOther() {
   ExecTest  "host_ctx_create"          2       1            1
   unset ROCSHMEM_MAX_NUM_CONTEXTS
   unset ROCSHMEM_MAX_NUM_HOST_CONTEXTS
-
+  
+  ExecTest  "teamsplit2d"              4  1            1
+  
   ExecTest  "shmemptr"         2       1            1         8
   ExecTest  "shmemptr"         2       1            1024      8
   ExecTest  "shmemptr"         2       8            1         8

--- a/projects/rocshmem/src/rocshmem.cpp
+++ b/projects/rocshmem/src/rocshmem.cpp
@@ -802,13 +802,18 @@ __host__ int rocshmem_team_split_2d(rocshmem_team_t parent_team, int xrange, con
                                     const rocshmem_team_config_t *yaxis_config, long yaxis_mask, 
                                     rocshmem_team_t *yaxis_team)
 {
+  VERIFY_BACKEND();
   *yaxis_team = ROCSHMEM_TEAM_INVALID;
   *xaxis_team = ROCSHMEM_TEAM_INVALID;
 
   if (parent_team == ROCSHMEM_TEAM_INVALID) {
-      LOG_ERROR("Parent team is invaid");
-      return ROCSHMEM_ERROR;
-    }
+    LOG_ERROR("Parent team is invaid");
+    return ROCSHMEM_ERROR;
+  }
+  if (xrange < 1) {
+    LOG_ERROR("xrange must be >= 1 (got %d)", xrange);
+    return ROCSHMEM_ERROR;
+  }
 
   Team *parent_team_obj = get_internal_team(parent_team);
   const int parent_size = parent_team_obj->num_pes;
@@ -816,7 +821,7 @@ __host__ int rocshmem_team_split_2d(rocshmem_team_t parent_team, int xrange, con
   const int _xrange = (xrange > parent_size) ? parent_size : xrange;
   const int yrange = parent_size / _xrange;
 
-  const int num_xteams = ceil(parent_size / static_cast<float>(_xrange));
+  const int num_xteams = (parent_size + _xrange - 1) / _xrange;
   const int num_yteams = _xrange;
   const int remainder = parent_size % _xrange;
 
@@ -831,7 +836,7 @@ __host__ int rocshmem_team_split_2d(rocshmem_team_t parent_team, int xrange, con
                                       &my_xteam);
 
     if (ret) {
-      LOG_ERROR("Unable to make xteam %d/%d", i + 1, num_xteams);
+      LOG_ERROR("Unable to make xteam %d out of %d", i + 1, num_xteams);
       return ROCSHMEM_ERROR;
     }
     
@@ -852,7 +857,7 @@ __host__ int rocshmem_team_split_2d(rocshmem_team_t parent_team, int xrange, con
                                       yaxis_mask, &my_yteam);
 
     if (ret) {
-      LOG_ERROR("Unable to make yteam %d/%d", i + 1, num_yteams);
+      LOG_ERROR("Unable to make yteam %d out of %d", i + 1, num_yteams);
       return ROCSHMEM_ERROR;
     }
 

--- a/projects/rocshmem/src/rocshmem.cpp
+++ b/projects/rocshmem/src/rocshmem.cpp
@@ -804,7 +804,12 @@ __host__ int rocshmem_team_split_2d(rocshmem_team_t parent_team, int xrange, con
 {
   *yaxis_team = ROCSHMEM_TEAM_INVALID;
   *xaxis_team = ROCSHMEM_TEAM_INVALID;
-  
+
+  if (parent_team == ROCSHMEM_TEAM_INVALID) {
+      LOG_ERROR("Parent team is invaid");
+      return ROCSHMEM_ERROR;
+    }
+
   Team *parent_team_obj = get_internal_team(parent_team);
   const int parent_size = parent_team_obj->num_pes;
 

--- a/projects/rocshmem/src/rocshmem.cpp
+++ b/projects/rocshmem/src/rocshmem.cpp
@@ -796,6 +796,69 @@ __host__ int rocshmem_team_split_strided(
   return 0;
 }
 
+__host__ int rocshmem_team_split_2d(rocshmem_team_t parent_team, int xrange, const 
+                                    rocshmem_team_config_t *xaxis_config, long xaxis_mask, 
+                                    rocshmem_team_t *xaxis_team, 
+                                    const rocshmem_team_config_t *yaxis_config, long yaxis_mask, 
+                                    rocshmem_team_t *yaxis_team)
+{
+  *yaxis_team = ROCSHMEM_TEAM_INVALID;
+  *xaxis_team = ROCSHMEM_TEAM_INVALID;
+  
+  Team *parent_team_obj = get_internal_team(parent_team);
+  const int parent_size = parent_team_obj->num_pes;
+
+  const int _xrange = (xrange > parent_size) ? parent_size : xrange;
+  const int yrange = parent_size / _xrange;
+
+  const int num_xteams = ceil(parent_size / static_cast<float>(_xrange));
+  const int num_yteams = _xrange;
+  const int remainder = parent_size % _xrange;
+
+  int start = 0;
+  int ret = 0;
+
+  for (int i = 0; i < num_xteams; ++i) {
+    rocshmem_team_t my_xteam;
+    int xsize = (i == num_xteams - 1 && remainder) ? remainder : _xrange;
+
+    ret = rocshmem_team_split_strided(parent_team, start, 1, xsize, xaxis_config, xaxis_mask,
+                                      &my_xteam);
+
+    if (ret) {
+      LOG_ERROR("Unable to make xteam %d/%d", i + 1, num_xteams);
+      return ROCSHMEM_ERROR;
+    }
+    
+    start += _xrange;
+
+    if (my_xteam != ROCSHMEM_TEAM_INVALID) 
+      *xaxis_team = my_xteam;
+  }
+
+  start = 0;
+
+  for (int i = 0; i < num_yteams; ++i) {
+    rocshmem_team_t my_yteam;
+    int ysize = yrange;
+    if (remainder && i < remainder) ysize += 1;
+    
+    ret = rocshmem_team_split_strided(parent_team, start, _xrange, ysize, yaxis_config,
+                                      yaxis_mask, &my_yteam);
+
+    if (ret) {
+      LOG_ERROR("Unable to make yteam %d/%d", i + 1, num_yteams);
+      return ROCSHMEM_ERROR;
+    }
+
+    start += 1;
+
+    if (my_yteam != ROCSHMEM_TEAM_INVALID) 
+      *yaxis_team = my_yteam;
+  }
+  return ROCSHMEM_SUCCESS;
+}
+
 __host__ void rocshmem_team_destroy(rocshmem_team_t team) {
   if (team == ROCSHMEM_TEAM_INVALID || team == ROCSHMEM_TEAM_WORLD ||
       team == ROCSHMEM_TEAM_SHARED) {

--- a/projects/rocshmem/tests/functional_tests/team_split_2d_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_split_2d_tester.cpp
@@ -55,7 +55,9 @@ TeamSplit2DTester::TeamSplit2DTester(TesterArguments args) : Tester(args)
   }
 }
 
-TeamSplit2DTester::~TeamSplit2DTester() {}
+TeamSplit2DTester::~TeamSplit2DTester() {
+  rocshmem_team_destroy(team_world_dup);
+}
 
 void TeamSplit2DTester::resetBuffers([[maybe_unused]] size_t size) {}
 
@@ -69,6 +71,7 @@ void TeamSplit2DTester::verifyResults([[maybe_unused]] size_t size) {
     }
     else {
       printf("FAIL: rocshmem_team_split_2d failed %d times\n", test_failed);
+      exit(-1);
     }
   }
 }
@@ -108,7 +111,7 @@ void TeamSplit2DTester::postLaunchKernel() {
   int y_size = rocshmem_team_n_pes(y_team);
   if (y_size != n_pes / xrange){
     fprintf(stderr,
-            "PE %d FAIL: xaxis_team size = %d, expected %d\n",
+            "PE %d FAIL: yaxis_team size = %d, expected %d\n",
             my_pe, y_size, n_pes / xrange);
     test_failed++;
   }

--- a/projects/rocshmem/tests/functional_tests/team_split_2d_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_split_2d_tester.cpp
@@ -1,0 +1,114 @@
+/******************************************************************************
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *****************************************************************************/
+
+#include "team_split_2d_tester.hpp"
+
+#include <rocshmem/rocshmem.hpp>
+
+using namespace rocshmem;
+
+/******************************************************************************
+ * HOST TESTER CLASS METHODS
+ *****************************************************************************/
+TeamSplit2DTester::TeamSplit2DTester(TesterArguments args) : Tester(args) 
+{
+  my_pe = rocshmem_team_my_pe(ROCSHMEM_TEAM_WORLD);
+  n_pes = rocshmem_team_n_pes(ROCSHMEM_TEAM_WORLD);
+
+  if (n_pes % xrange) {
+    fprintf(stderr, 
+      "Test needs world size divisible by %d, cannot continue test \n",
+      xrange);
+    exit(-1);
+  }
+
+  team_world_dup = ROCSHMEM_TEAM_INVALID;
+  x_team = ROCSHMEM_TEAM_INVALID;
+  y_team = ROCSHMEM_TEAM_INVALID;
+}
+
+TeamSplit2DTester::~TeamSplit2DTester() {}
+
+void TeamSplit2DTester::resetBuffers([[maybe_unused]] size_t size) {}
+
+void TeamSplit2DTester::launchKernel(dim3 gridSize, dim3 blockSize, int loop,
+                                     size_t size) {}
+
+void TeamSplit2DTester::verifyResults([[maybe_unused]] size_t size) {
+  if (my_pe == 0){
+    if (!test_failed){
+      printf("PASS: rocshmem_team_split_2d succeeded with %d PEs\n", n_pes);
+    }
+    else {
+      printf("FAIL: rocshmem_team_split_2d failed %d times\n", test_failed);
+    }
+  }
+}
+
+void TeamSplit2DTester::preLaunchKernel() {
+  int ret = 0;
+  ret = rocshmem_team_split_strided(ROCSHMEM_TEAM_WORLD, 0, 1, n_pes, nullptr, 0, 
+                                    &team_world_dup);
+  if (ret != ROCSHMEM_SUCCESS){
+    fprintf(stderr, 
+            "ERROR: Unable to start test. Error in rocshmem_team_split_strided\n");
+    exit(-1);
+  }
+  ret = rocshmem_team_split_2d(team_world_dup, xrange, nullptr, 0, &x_team, 
+                               nullptr, 0, &y_team);
+  if (ret != 0){
+    fprintf(stderr,
+            "PE %d FAIL: rocshmem_team_split_2d returned %d (expected 0)\n",
+            my_pe, ret);
+    test_failed++;
+  }
+}
+
+void TeamSplit2DTester::postLaunchKernel() {
+  if (x_team == ROCSHMEM_TEAM_INVALID){
+    fprintf(stderr, "PE %d FAIL: x_team is invalid\n", my_pe);
+    test_failed++;
+  }
+  if (y_team == ROCSHMEM_TEAM_INVALID){
+    fprintf(stderr, "PE %d FAIL: y_team is invalid\n", my_pe);
+    test_failed++;
+  }
+  
+  int x_size = rocshmem_team_n_pes(x_team);
+  if (x_size != xrange){
+    fprintf(stderr,
+            "PE %d FAIL: xaxis_team size = %d, expected %d\n",
+            my_pe, x_size, xrange);
+    test_failed++;
+  }
+
+  int y_size = rocshmem_team_n_pes(y_team);
+  if (y_size != n_pes / xrange){
+    fprintf(stderr,
+            "PE %d FAIL: xaxis_team size = %d, expected %d\n",
+            my_pe, y_size, n_pes / xrange);
+    test_failed++;
+  }
+  
+}

--- a/projects/rocshmem/tests/functional_tests/team_split_2d_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_split_2d_tester.cpp
@@ -65,15 +65,15 @@ void TeamSplit2DTester::launchKernel(dim3 gridSize, dim3 blockSize, int loop,
                                      size_t size) {}
 
 void TeamSplit2DTester::verifyResults([[maybe_unused]] size_t size) {
-  if (my_pe == 0){
-    if (!test_failed){
-      printf("PASS: rocshmem_team_split_2d succeeded with %d PEs\n", n_pes);
-    }
-    else {
-      printf("FAIL: rocshmem_team_split_2d failed %d times\n", test_failed);
-      exit(-1);
-    }
-  }
+  if (test_failed) {
+     fprintf(stderr,
+             "PE %d FAIL: rocshmem_team_split_2d failed %d checks\n",
+             my_pe, test_failed);
+     exit(-1);
+   }
+   if (my_pe == 0) {
+     printf("PASS: rocshmem_team_split_2d succeeded with %d PEs\n", n_pes);
+   }
 }
 
 void TeamSplit2DTester::preLaunchKernel() {

--- a/projects/rocshmem/tests/functional_tests/team_split_2d_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_split_2d_tester.cpp
@@ -46,6 +46,13 @@ TeamSplit2DTester::TeamSplit2DTester(TesterArguments args) : Tester(args)
   team_world_dup = ROCSHMEM_TEAM_INVALID;
   x_team = ROCSHMEM_TEAM_INVALID;
   y_team = ROCSHMEM_TEAM_INVALID;
+
+  if (rocshmem_team_split_strided(ROCSHMEM_TEAM_WORLD, 0, 1, n_pes, nullptr, 0, 
+                                    &team_world_dup) != ROCSHMEM_SUCCESS){
+    fprintf(stderr, 
+            "ERROR: Unable to start test. Error in rocshmem_team_split_strided\n");
+    exit(-1);
+  }
 }
 
 TeamSplit2DTester::~TeamSplit2DTester() {}
@@ -68,13 +75,8 @@ void TeamSplit2DTester::verifyResults([[maybe_unused]] size_t size) {
 
 void TeamSplit2DTester::preLaunchKernel() {
   int ret = 0;
-  ret = rocshmem_team_split_strided(ROCSHMEM_TEAM_WORLD, 0, 1, n_pes, nullptr, 0, 
-                                    &team_world_dup);
-  if (ret != ROCSHMEM_SUCCESS){
-    fprintf(stderr, 
-            "ERROR: Unable to start test. Error in rocshmem_team_split_strided\n");
-    exit(-1);
-  }
+  x_team = ROCSHMEM_TEAM_INVALID;
+  y_team = ROCSHMEM_TEAM_INVALID;
   ret = rocshmem_team_split_2d(team_world_dup, xrange, nullptr, 0, &x_team, 
                                nullptr, 0, &y_team);
   if (ret != 0){
@@ -110,5 +112,6 @@ void TeamSplit2DTester::postLaunchKernel() {
             my_pe, y_size, n_pes / xrange);
     test_failed++;
   }
-  
+  rocshmem_team_destroy(x_team);
+  rocshmem_team_destroy(y_team);
 }

--- a/projects/rocshmem/tests/functional_tests/team_split_2d_tester.hpp
+++ b/projects/rocshmem/tests/functional_tests/team_split_2d_tester.hpp
@@ -1,0 +1,56 @@
+/******************************************************************************
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *****************************************************************************/
+
+#ifndef ROCSHMEM_TEAM_SPLIT_2D_TESTER_HPP
+#define ROCSHMEM_TEAM_SPLIT_2D_TESTER_HPP
+
+#include "tester.hpp"
+
+/******************************************************************************
+ * HOST TESTER CLASS
+ *****************************************************************************/
+class TeamSplit2DTester : public Tester {
+ public:
+  explicit TeamSplit2DTester(TesterArguments args);
+  virtual ~TeamSplit2DTester();
+
+ protected:
+  virtual void resetBuffers(size_t size) override;
+
+  virtual void launchKernel(dim3 gridSize, dim3 blockSize, int loop,
+                            size_t size) override;
+
+  virtual void verifyResults(size_t size) override;
+  virtual void preLaunchKernel() override;
+  virtual void postLaunchKernel() override;
+
+  rocshmem_team_t team_world_dup, x_team, y_team;
+  int my_pe, n_pes;
+  const int xrange = 2;
+  int test_failed = 0;
+};
+
+#include "team_split_2d_tester.cpp"
+
+#endif  // ROCSHMEM_TEAM_SPLIT_2D_TESTER_HPP

--- a/projects/rocshmem/tests/functional_tests/tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/tester.cpp
@@ -73,6 +73,7 @@
 #include "tile_rma_tester.hpp"
 #include "reduce_on_stream_tester.hpp"
 #include "host_ctx_create_tester.hpp"
+#include "team_split_2d_tester.hpp"
 
 #include "backend_bc.hpp"
 extern Backend* backend;
@@ -713,6 +714,9 @@ std::vector<Tester*> Tester::create(TesterArguments args) {
     case HostCtxCreateTestType:
       test_name = "Host CTX Create";
       testers.push_back(new HostCtxCreateTester(args));
+    case TeamSplit2DTestType:
+      test_name = "Team Split 2D";
+      testers.push_back(new TeamSplit2DTester(args));
       break;
     default:
       test_name = "Empty";
@@ -801,7 +805,8 @@ void Tester::execute() {
         _type != TeamCtxInfraOddEvenTestType &&
         _type != TeamCtxSharedInfraTestType &&
         _type != TeamCtxSubsetParentInfraTestType &&
-        _type != HostCtxCreateTestType) {
+        _type != HostCtxCreateTestType &&
+        _type != TeamSplit2DTestType  ) {
       print(size);
     }
   }

--- a/projects/rocshmem/tests/functional_tests/tester.hpp
+++ b/projects/rocshmem/tests/functional_tests/tester.hpp
@@ -160,7 +160,9 @@
   X(TileGetColumnMajor,        115)  \
   X(TileGetArbitrary,          116)  \
   X(ReduceOnStream,            117)  \
-  X(HostCtxCreate,             118) 
+  X(HostCtxCreate,             118)  \
+  X(TeamSplit2D,               119)
+
 #define _ROCSHMEM_ENUM_ENTRY(name, val) name##TestType = val,
 enum TestType {
   ROCSHMEM_FOREACH_TEST_TYPE(_ROCSHMEM_ENUM_ENTRY)

--- a/projects/rocshmem/tests/functional_tests/tester_arguments.cpp
+++ b/projects/rocshmem/tests/functional_tests/tester_arguments.cpp
@@ -314,6 +314,7 @@ void TesterArguments::get_arguments() {
     case DeviceBitcodeTestType:
     case TeamCtxSharedInfraTestType:
     case FenceOrderFanoutTestType:
+    case TeamSplit2DTestType:
       requires_two_pes = false;
       break;
     default:


### PR DESCRIPTION
## Motivation

Add `rocshmem_team_split_2d()` for parity with nvshmem 3.6.5 `nvshmem_team_split_2d()`.

## Technical Details

- Added `__host__ int rocshmem_team_split_2d(rocshmem_team_t parent_team, int xrange, const rocshmem_team_config_t *xaxis_config, long xaxis_mask, rocshmem_team_t *xaxis_team, const rocshmem_team_config_t *yaxis_config, long yaxis_mask, rocshmem_team_t *yaxis_team)`
- Added `rocshmem_team_split_2d()` functional test

## JIRA ID

AIROCSHMEM-410

## Test Plan

- Use functional test to verify correctness

## Test Result

- [x] Passed functional test

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
