### PR TITLE
[HIP][DOC]-Change the doxygen config for typedef fields showing inlin…

### DIFF
--- a/projects/hip/docs/doxygen-input/doxy.cfg
+++ b/projects/hip/docs/doxygen-input/doxy.cfg
@@ -431,7 +431,7 @@ INLINE_GROUPED_CLASSES = NO
 # Man pages) or section (for LaTeX and RTF).
 # The default value is: NO.
 
-INLINE_SIMPLE_STRUCTS  = NO
+INLINE_SIMPLE_STRUCTS  = YES
 
 # When TYPEDEF_HIDES_STRUCT tag is enabled, a typedef of a struct, union, or
 # enum is documented as struct, union, or enum with the name of the typedef. So

--- a/projects/hip/docs/doxygen/Doxyfile
+++ b/projects/hip/docs/doxygen/Doxyfile
@@ -430,7 +430,7 @@ INLINE_GROUPED_CLASSES = NO
 # Man pages) or section (for LaTeX and RTF).
 # The default value is: NO.
 
-INLINE_SIMPLE_STRUCTS  = NO
+INLINE_SIMPLE_STRUCTS  = YES
 
 # When TYPEDEF_HIDES_STRUCT tag is enabled, a typedef of a struct, union, or
 # enum is documented as struct, union, or enum with the name of the typedef. So


### PR DESCRIPTION
…e with descriptions

## Motivation

Update the Doxygen configuration so that typedef fields are displayed inline with their associated descriptions.

## Technical Details

Changed the INLINE_SIMPLE_STRUCTS configuration flag so that typedef fields are now displayed inline with their descriptions.

## JIRA ID

https://amd-hub.atlassian.net/browse/ROCM-24656

## Test Plan

Build the HIP documentation and verify the resulting output format, including how enum and struct definitions are generated.

## Test Result

Enum names within a typedef struct should appear inline with their descriptions.

## Submission Checklist

- Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
