### PR TITLE
fix(rccl): enqueue imported proxy mem handle in p2pProxyRegister

### DIFF
--- a/projects/rccl/src/transport/p2p.cc
+++ b/projects/rccl/src/transport/p2p.cc
@@ -1357,6 +1357,20 @@ static ncclResult_t p2pProxyRegister(struct ncclProxyConnection* connection, str
   INFO(NCCL_REG, "Proxy rank %d register success regAddr %p size %ld offset %ld legacyIpcCap %d sameProcess %d", proxyState->tpRank, regAddr, ipcExpInfo->size, ipcExpInfo->offset, ipcExpInfo->legacyIpcCap, connection->sameProcess);
 
 exit:
+  // Enqueue the imported handle (single segment) so p2pProxyDeregister()
+  // can release it; the 2.29.x sync dropped this, segfaulting on teardown.
+  if (regAddr) {
+    struct proxyMemHandle* memHandle;
+    struct ncclIpcImpInfo* ipcInfo;
+    NCCLCHECK(ncclCalloc(&memHandle, 1));
+    NCCLCHECK(ncclCalloc(&ipcInfo, 1));
+    ipcInfo->rmtRegAddr = regAddr;
+    ipcInfo->offset = ipcExpInfo->offset;
+    ipcInfo->legacyIpcCap = ipcExpInfo->legacyIpcCap;
+    ipcInfo->numSegments = 1;
+    memHandle->handle = (void*)ipcInfo;
+    ncclIntruQueueEnqueue(&connection->proxyMemHandleQueue, memHandle);
+  }
   memcpy(respBuff, (void*)&regAddr, sizeof(void*));
   *done = 1;
   return ret;


### PR DESCRIPTION
The NCCL 2.29.x sync dropped the ncclIntruQueueEnqueue onto connection->proxyMemHandleQueue in p2pProxyRegister(). With nothing enqueued, p2pProxyDeregister() (and the p2pSend/RecvProxyFree drain) called ncclIntruQueueDelete() on an empty queue and dereferenced a NULL handle, segfaulting (rc=139) at communicator teardown for every symmetric-memory (-R 2) collective, and leaking the imported VA mapping.

Re-add the enqueue (matching upstream NCCL) so deregister can find and release the imported handle. Fixes the teardown crash and the leak.

## Motivation

On the NCCL 2.29.x sync branch, every symmetric-memory collective (rccl-tests `-R 2`) crashes with a SIGSEGV (rc=139) at communicator teardown on MI350X/gfx950. The collective itself produces correct results, but the process dies on cleanup, so the runs look like hard failures and CI/perf sweeps using `-R 2` cannot complete. The same path also leaks the imported peer VA mapping on every teardown. This PR restores clean teardown for symmetric-memory collectives.

## Technical Details

When a peer buffer is registered through the proxy, `p2pProxyRegister()` imports the handle and maps it (producing `regAddr`). It is supposed to record that imported handle on the connection by enqueuing it onto `connection->proxyMemHandleQueue`. The 2.29.x sync dropped that enqueue.

As a result the queue stays empty. At teardown, `p2pProxyDeregister()` — and the proxy-free drain in `p2pSendProxyFree` / `p2pRecvProxyFree` — pop handles off `proxyMemHandleQueue` via `ncclIntruQueueDelete()` to release each mapping. With nothing ever enqueued, the dequeue path walks a `NULL` handle and dereferences it, segfaulting. Because the handle is never tracked, the imported VA mapping is also never released (leak).

The fix re-adds the enqueue in the `exit:` path of `p2pProxyRegister()` (matching upstream NCCL): when `regAddr` is valid, it allocates a `proxyMemHandle` + `ncclIpcImpInfo`, populates the imported address/offset/legacyIpcCap (single segment, as RCCL imports one segment), and `ncclIntruQueueEnqueue`s it onto `connection->proxyMemHandleQueue`. Deregister now finds and releases the handle cleanly.

- File changed: `projects/rccl/src/transport/p2p.cc` (`p2pProxyRegister`)

## JIRA ID

Relates to AICOMRCCL-952

## Test Plan

Environment: 4× nodes of 8× MI350X (gfx950), Broadcom bnxt_re RoCEv2, ROCm 7.13, NCCL 2.29.7, RCCL built with `--generate-sym-kernels` and rccl-tests with `ENABLE_DEVICE_API=1`.

Ran the symmetric-memory sweep over all 9 collectives at 1 and 2 nodes, before and after the change:
 