### PR TITLE
fix(rocjitsu): link rocjitsu_analysis into rocjitsu_shared

### DIFF
--- a/emulation/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/CMakeLists.txt
@@ -186,6 +186,7 @@ set_target_properties(rocjitsu_shared PROPERTIES OUTPUT_NAME rocjitsu)
 target_link_libraries(
     rocjitsu_shared
     PRIVATE
+        rocjitsu_analysis
         rocjitsu_code
         rocjitsu_isa
         rocjitsu_isa_cdna1


### PR DESCRIPTION
## Motivation

CI shared-library validation for `librocjitsu.so` failed with an undefined symbol error (`rocjitsu::LivenessAnalysis::find_free_sgpr`). The `rocjitsu_shared` library did not link the object library providing the liveness-analysis symbols, even though they are referenced by `rocjitsu_code`.

## Technical Details

Added the `rocjitsu_analysis` object library to the `target_link_libraries` list for `rocjitsu_shared` in CMakeLists.txt. This resolves the `find_free_sgpr` and `find_free_sgpr_pair` symbols (referenced from cdna4_to_rdna4.cpp) that were previously missing from the linked shared library.

Also, I am pretty sure this is like the 3rd time I have made this fix.

## JIRA ID

<!-- N/A -->

## Test Plan

Rebuild `librocjitsu.so` and run the shared-library validation step (`validate_shared_library.py`) that previously failed in CI.

## Test Result

`librocjitsu.so` loads successfully with no undefined symbols; shared-library validation passes.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.