### PR TITLE
clr: revert AMD_CPU_AFFINITY default to false

### DIFF
--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -203,7 +203,7 @@ release(cstring, ROC_GLOBAL_CU_MASK, "",                                      \
         "Each active bit represents using one CU (e.g., 0xf enables only 4 CUs)") \
 release(size_t, PAL_PREPINNED_MEMORY_SIZE, 64,                                \
         "Size in KBytes of prepinned memory")                                 \
-release(bool, AMD_CPU_AFFINITY, true,                                         \
+release(bool, AMD_CPU_AFFINITY, false,                                         \
         "Prefer GPU-local NUMA CPU affinity when the application has not set a CPU mask") \
 release(bool, ROC_USE_FGS_KERNARG, true,                                      \
         "Use fine grain kernel args segment for supported asics")             \


### PR DESCRIPTION
## Motivation

  ROCM-25138: `pyt_deepspeed_moe_cifar` fails on MI355X-8 starting
  TheRock 1413. The DeepSpeed launcher spawns per-rank workers via
  `numactl -C <range> python …`; ranks 4–7 die with
  `libnuma: cpu argument 64-79 is out of range` and the launcher exits 1.

  Bisected to commit
  [d6bd7cb7](https://github.com/ROCm/rocm-systems/commit/d6bd7cb7a0711de173cf7cca6481df4c607013ef)
  (PR #6134, *"clr/rocr: Respect app affinity for NUMA placement"*), via
  the swap-test: 1394-docker + 1413-hip-runtime ⇒ fail;
  1413-docker + 1394-hip-runtime ⇒ pass.
  
  The PR bundled two changes:

  1. Flipped `AMD_CPU_AFFINITY` default `false` → `true`.
  2. Added `SchedSetAffinityIfAllowed()` on the **caller's thread** inside
     `Runtime::init()` whenever `AMD_CPU_AFFINITY` is on.
  
  With (1) on, every process that loads `libamdhip64.so` and calls into
  HIP - including launchers that only invoke `hipGetDeviceCount()` to
  enumerate devices - has its main-thread CPU mask silently narrowed to
  the CPUs of GPU 0's nearest NUMA node. `fork()`/`clone()` inherits
  this mask into every per-rank child. `numactl -C` for ranks whose
  slice lives on the other socket then fails with `EINVAL` because the
  requested CPUs are disjoint from the inherited mask.

## Technical Details

 ```cpp
  // projects/clr/rocclr/os/os_posix.cpp - SchedSetAffinityIfAllowed
  if (!current_mask_is_runtime_set && !IsUnrestrictedAffinity(current_affinity)) {
    // Respect application, launcher, or cpuset affinity masks.
    return false;
  } 

  The intent of !IsUnrestrictedAffinity(...) was to bail when the user
  or launcher had already pinned the process. But "all CPU bits set" is
  the kernel default state of every process that hasn't explicitly
  called sched_setaffinity - i.e., basically every Python interpreter,
  every container entrypoint, every CI runner, every launcher before
  it forks workers. The guard fires for ~100% of real launcher
  invocations. 

## JIRA ID

ROCM-25138

## Test Plan

DeepSpeed test

## Test Result

DeepSpeed test

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
