### PR TITLE
Disable RCCL multi-node CI tests on Ruby MI350 cluster

### DIFF
--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -127,8 +127,8 @@ jobs:
 
   therock-test-linux-multi-node:
     name: "Test multi-node"
-    # TODO: Re-enable gfx94X-dcgpu multi-node tests once the cluster is stable again.
-    if: ${{ inputs.amdgpu_families == 'gfx950-dcgpu' }}
+    # TODO: Re-enable gfx94X-dcgpu and gfx950-dcgpu multi-node tests once the clusters are stable again.
+    if: false
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary

Temporarily disables RCCL multi-node CI tests for `gfx950-dcgpu`.

These tests are currently failing intermittently on the Ruby MI350 cluster due to MPI initialization/startup issues seen only on a subset of nodes. Until the cluster is stable enough for CI usage, or a smaller known-good node partition is identified, the multi-node test job is disabled to avoid blocking CI.

## Details

* Disables the `therock-test-linux-multi-node` job by setting `if: false`
* Keeps the multi-node workflow block in place so it can be re-enabled easily later
* Updates the TODO comment to track that multi-node testing should be restored once the cluster/MPI setup is stable

## Reason

Recent multi-node RCCL CI runs have shown intermittent MPI startup failures on Ruby MI350 nodes. The failures appear to be node-specific rather than a consistent RCCL test failure.

## Follow-up

Re-enable the multi-node tests once one of the following is available:

* The Ruby MI350 cluster is stable for CI runs
* A dedicated stable partition/subset of nodes is identified for RCCL multi-node CI

Issue opened in TheRock to Re-enable these tests once runner is stable:

https://github.com/ROCm/TheRock/issues/5583