### PR TITLE
Add missing RCCL examples

### DIFF
--- a/projects/rccl/examples/.gitignore
+++ b/projects/rccl/examples/.gitignore
@@ -1,0 +1,14 @@
+# Build artifacts
+*.o
+*.obj
+*.d
+*.prehip
+
+# Built example binaries
+01_communicators/01_multiple_devices_single_process/multiple_devices_single_process
+01_communicators/02_one_device_per_pthread/one_device_per_pthread
+01_communicators/03_one_device_per_process_mpi/one_device_per_process_mpi
+02_point_to_point/01_ring_pattern/ring_pattern
+03_collectives/01_allreduce/allreduce
+04_user_buffer_registration/01_allreduce/allreduce_ub
+05_symmetric_memory/01_allreduce/allreduce_sm

--- a/projects/rccl/examples/01_communicators/01_multiple_devices_single_process/Makefile
+++ b/projects/rccl/examples/01_communicators/01_multiple_devices_single_process/Makefile
@@ -1,0 +1,60 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# See LICENSE.txt for more license information
+#
+
+# Include common build rules
+include ../../makefiles/rccl_examples.mk
+
+# Target executable
+TARGET = multiple_devices_single_process
+
+# Source files
+SOURCES = main.cc
+OBJECTS = $(SOURCES:.cc=.o)
+
+# Default target
+all: $(TARGET)
+
+# Build executable
+$(TARGET): $(OBJECTS)
+	$(CXX) $(CXXFLAGS) $(OBJECTS) $(LIBRARIES) $(LDFLAGS) -o $@
+	@echo "Built target $@"
+
+# Compile source files
+%.o: %.cc
+	$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
+
+# Test target
+test: $(TARGET)
+	@echo "Testing $(TARGET)..."
+	@echo "Running with all available GPUs"
+	./$(TARGET)
+
+# Clean build artifacts
+clean:
+	rm -f $(OBJECTS) $(TARGET)
+
+# Install target
+install: $(TARGET)
+	@mkdir -p $(PREFIX)/bin
+	cp $(TARGET) $(PREFIX)/bin/
+
+# Help
+help:
+	@echo "NCCL Example: Multiple Devices Single Process"
+	@echo "=============================================="
+	@echo ""
+	@echo "This example shows how to use ncclCommInitAll to create"
+	@echo "communicators for multiple GPUs in a single process."
+	@echo ""
+	@echo "Targets:"
+	@echo "  all       - Build the example (default)"
+	@echo "  test      - Build and run test with all GPUs"
+	@echo "  clean     - Remove build artifacts"
+	@echo "  install   - Install to PREFIX/bin (default: /usr/local/bin)"
+	@echo "  help      - Show this help"
+
+.PHONY: all test clean install help

--- a/projects/rccl/examples/01_communicators/01_multiple_devices_single_process/README.md
+++ b/projects/rccl/examples/01_communicators/01_multiple_devices_single_process/README.md
@@ -1,0 +1,180 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+
+  See LICENSE.txt for more license information
+-->
+
+# NCCL Example: Multiple Devices Single Process
+
+This example demonstrates how to use `ncclCommInitAll` to create NCCL
+communicators for multiple GPUs within a single process, without requiring MPI
+or threading.
+
+## Overview
+
+The `ncclCommInitAll` function provides a simplified way to initialize NCCL
+communicators when:
+- All GPUs are managed by a single process
+- Running on a single node
+- No multi-process coordination is needed
+
+This approach is ideal for single-node multi-GPU applications where simplicity
+is preferred over the flexibility of multi-process setups.
+
+## What This Example Does
+
+1. **Device Detection**:
+   - Queries available HIP devices
+   - Lists device properties for each GPU
+
+2. **Communicator Creation**:
+   - Uses `ncclCommInitAll` to create all communicators in one call
+   - Automatically assigns NCCL ranks 0 through n-1
+   - No NCCL unique ID distribution needed
+
+3. **Verification**:
+   - Displays communicator information for each GPU
+   - Shows rank assignments and device mappings
+   - Confirms successful initialization
+
+4. **Cleanup**:
+   - Properly destroys communicators and streams
+   - Demonstrates correct resource management
+
+## Building and Running
+
+### Build
+```shell
+make [NCCL_HOME=<path-to-nccl>] [CUDA_HOME=<path-to-cuda>]
+```
+
+### Run with all available GPUs
+```shell
+./multiple_devices_single_process
+```
+
+### Run with specific GPUs
+```shell
+# Use only GPUs 0 and 1
+CUDA_VISIBLE_DEVICES=0,1 ./multiple_devices_single_process
+```
+
+### Run with NCCL debug output
+```shell
+NCCL_DEBUG=INFO ./multiple_devices_single_process
+```
+
+## Code Walk-through
+
+### Key Function: ncclCommInitAll
+For single-node collective examples we use `ncclCommInitAll` as it creates a clique of communicators in one call.
+```c
+int num_gpus; // num_gpus is set by querying the HIP devices
+ncclComm_t* comms;
+int* devices; // devices needs to be populated with HIP devices used
+
+// Create communicators for all devices in one call
+NCCLCHECK(ncclCommInitAll(comms, num_gpus, devices));
+```
+
+This single function call:
+- Creates `num_gpus` communicators
+- Assigns ranks 0 to (num_gpus-1)
+- Sets up internal communication paths
+- No unique ID needed
+
+### Comparison with ncclCommInitRank
+`ncclCommInitAll` is a convenience function and has the same functionality as:
+```c
+ncclUniqueId id;
+
+ncclGetUniqueId(&id);
+
+ncclGroupStart();
+for(int i = 0; i < num_gpus; i++) {
+  cudaSetDevice(i);
+  ncclCommInitRank(comms[i], num_gpus, id, devices[i]);
+}
+ncclGroupEnd();
+```
+
+## Expected Output
+
+```
+Found 4 HIP device(s) available
+
+Available GPU devices:
+  GPU 0: NVIDIA A100-SXM4-40GB (HIP Device 0)
+    Compute Capability: 8.0
+    Memory: 40.0 GB
+  GPU 1: NVIDIA A100-SXM4-40GB (HIP Device 1)
+    Compute Capability: 8.0
+    Memory: 40.0 GB
+  GPU 2: NVIDIA A100-SXM4-40GB (HIP Device 2)
+    Compute Capability: 8.0
+    Memory: 40.0 GB
+  GPU 3: NVIDIA A100-SXM4-40GB (HIP Device 3)
+    Compute Capability: 8.0
+    Memory: 40.0 GB
+Using ncclCommInitAll() to create all communicators simultaneously
+All 4 NCCL communicators initialized successfully
+
+Communicator Details:
+  Communicator 0: Rank 0/4 on HIP device 0
+  Communicator 1: Rank 1/4 on HIP device 1
+  Communicator 2: Rank 2/4 on HIP device 2
+  Communicator 3: Rank 3/4 on HIP device 3
+All communicators have the expected size of 4
+
+Synchronizing all HIP streams...
+All streams synchronized
+Destroying NCCL communicators...
+All NCCL communicators destroyed
+Destroying HIP streams...
+All HIP streams destroyed
+
+=============================================================
+SUCCESS: Multiple devices single process example completed!
+=============================================================
+```
+
+## When to Use ncclCommInitAll
+
+### Ideal Use Cases
+- **Single-node workloads**: All GPUs on one machine
+- **Simple applications**: No multi-process complexity needed
+- **Testing/Development**: Quick setup for experiments
+
+### When NOT to Use
+- **Multi-node clusters**: Need MPI for cross-node communication
+- **Process isolation**: When GPUs should be in separate processes
+
+## Performance Considerations
+
+- **Advantages**:
+  - Lower overhead (no inter process communication)
+  - Simpler memory management
+  - Direct access to all GPUs
+
+- **Disadvantages**:
+  - Limited by single process resources
+  - Cannot scale beyond one node
+
+## Common Issues and Solutions
+
+1. **Not all GPUs visible**:
+   - Check `CUDA_VISIBLE_DEVICES`
+   - Ensure user has permissions for all GPUs
+   - Verify no other process is using GPUs exclusively
+
+2. **Out of memory**:
+   - Single process must handle memory for all GPUs
+   - Consider using multiple processes if memory limited
+
+## Next Steps
+
+After understanding this example:
+1. Try the collective operation examples using `ncclCommInitAll`
+2. Compare performance with MPI-based multi-process approach
+3. Experiment with different GPU combinations

--- a/projects/rccl/examples/01_communicators/01_multiple_devices_single_process/main.cc
+++ b/projects/rccl/examples/01_communicators/01_multiple_devices_single_process/main.cc
@@ -1,0 +1,258 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See LICENSE.txt for more license information
+ *************************************************************************/
+
+#include "hip/hip_runtime.h"
+#include <rccl/rccl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+/*
+ * NCCL Example: Multiple Devices Single Process
+ * =============================================
+ *
+ * PURPOSE:
+ * This example demonstrates how to initialize NCCL communicators for multiple
+ * GPUs within a single process. This is the simplest NCCL setup and is ideal
+ * for learning NCCL basics or for applications that want to use multiple GPUs
+ * without the complexity of multi-process coordination.
+ *
+ * LEARNING OBJECTIVES:
+ * - Learn how to use ncclCommInitAll() for simple multi-GPU setups
+ * - See proper NCCL communicator lifecycle management
+ * - Understand GPU device management in NCCL applications
+ * - Learn proper resource cleanup patterns
+ *
+ * HOW IT WORKS:
+ * 1. Detect all available CUDA devices
+ * 2. Create communicators for all devices using ncclCommInitAll()
+ * 3. Verify communicator properties (rank, size, device assignment)
+ * 4. Clean up all resources properly
+ *
+ * KEY CONCEPTS:
+ * - ncclCommInitAll(): Creates multiple communicators in a single call
+ * - Single-process topology: All GPUs managed by one process
+ * - Device management: Setting active CUDA device for operations
+ * - Stream management: Each GPU gets its own CUDA stream
+ *
+ * WHEN TO USE THIS PATTERN:
+ * - Learning NCCL fundamentals
+ * - Single-node, multi-GPU applications
+ * - Applications that don't need multi-node scaling
+ * - Prototyping and testing NCCL functionality
+ *
+ * USAGE EXAMPLES:
+ * ./multiple_devices_single_process               # Use all available GPUs
+ *
+ * EXPECTED OUTPUT:
+ * - Detection of all available GPUs
+ * - Successful communicator initialization
+ * - Display of rank/size information for each GPU
+ * - Clean resource cleanup confirmation
+ */
+
+// Enhanced error checking macro for NCCL operations
+// Provides detailed error information including the failed operation
+
+#define NCCLCHECK(cmd)                                                         \
+  do {                                                                         \
+    ncclResult_t res = cmd;                                                    \
+    if (res != ncclSuccess) {                                                  \
+      fprintf(stderr, "Failed, NCCL error %s:%d '%s'\n", __FILE__, __LINE__,   \
+              ncclGetErrorString(res));                                        \
+      fprintf(stderr, "Failed NCCL operation: %s\n", #cmd);                    \
+      exit(EXIT_FAILURE);                                                      \
+    }                                                                          \
+  } while (0)
+
+#define CUDACHECK(cmd)                                                         \
+  do {                                                                         \
+    hipError_t err = cmd;                                                     \
+    if (err != hipSuccess) {                                                  \
+      fprintf(stderr, "Failed: Cuda error %s:%d '%s'\n", __FILE__, __LINE__,   \
+              hipGetErrorString(err));                                        \
+      fprintf(stderr, "Failed CUDA operation: %s\n", #cmd);                    \
+      exit(EXIT_FAILURE);                                                      \
+    }                                                                          \
+  } while (0)
+
+// =============================================================================
+// MAIN FUNCTION - NCCL Communicator Lifecycle Example
+// =============================================================================
+
+int main(int argc, char *argv[]) {
+  // Variables for managing multiple GPU communicators
+  int num_gpus;                 // Number of available CUDA devices
+  ncclComm_t *comms = NULL;     // Array of NCCL communicators (one per GPU)
+  hipStream_t *streams = NULL; // Array of CUDA streams (one per GPU)
+  int *devices = NULL;          // Array of device IDs to use
+
+  // Discover how many CUDA devices are available
+  // This determines how many NCCL communicators we'll create
+  CUDACHECK(hipGetDeviceCount(&num_gpus));
+
+  if (num_gpus == 0) {
+    fprintf(stderr, "ERROR: No CUDA devices found on this system\n");
+    fprintf(
+        stderr,
+        "Please ensure CUDA is properly installed and GPUs are available\n");
+    return 1;
+  }
+
+  printf("Found %d CUDA device(s) available\n\n", num_gpus);
+
+  // =========================================================================
+  // STEP 1: Prepare Device Information and Memory Allocation
+  // =========================================================================
+
+  // Allocate arrays to hold our per-device resources
+  // We need one communicator, stream, and device ID per GPU
+  devices = (int *)malloc(num_gpus * sizeof(int));
+  comms = (ncclComm_t *)malloc(num_gpus * sizeof(ncclComm_t));
+  streams = (hipStream_t *)malloc(num_gpus * sizeof(hipStream_t));
+
+  if (!devices || !comms || !streams) {
+    fprintf(stderr, "ERROR: Failed to allocate memory for device arrays\n");
+    return 1;
+  }
+
+  // Create device list and display device information
+  // By default, we use all available devices (0, 1, 2, ...)
+  printf("Available GPU devices:\n");
+  for (int i = 0; i < num_gpus; i++) {
+    devices[i] = i; // Use device i for communicator i
+
+    // Query device properties for informational display
+    hipDeviceProp_t prop;
+    CUDACHECK(hipGetDeviceProperties(&prop, devices[i]));
+    printf("  GPU %d: %s (CUDA Device %d)\n", i, prop.name, devices[i]);
+    printf("    Compute Capability: %d.%d\n", prop.major, prop.minor);
+    printf("    Memory: %.1f GB\n",
+           prop.totalGlobalMem / (1024.0 * 1024.0 * 1024.0));
+  }
+
+  // Create a CUDA stream for each GPU
+  // Each GPU needs its own stream for optimal performance
+  for (int i = 0; i < num_gpus; i++) {
+    // Set the active CUDA device before creating resources on it
+    // This ensures the stream is created on the correct GPU
+    CUDACHECK(hipSetDevice(devices[i]));
+    CUDACHECK(hipStreamCreate(&streams[i]));
+  }
+
+  // =========================================================================
+  // STEP 2 : Initialize NCCL Communicators
+  // =========================================================================
+
+  printf("Using ncclCommInitAll() to create all communicators "
+         "simultaneously\n");
+
+  // ncclCommInitAll() creates all communicators at once and handles the
+  // coordination internally
+  //
+  // Parameters:
+  // - comms: Array to store the created communicators
+  // - num_gpus: Number of communicators to create
+  // - devices: Array of CUDA device IDs to use
+  //
+  // After this call:
+  // - comms[0] will be the communicator for devices[0] with rank 0
+  // - comms[1] will be the communicator for devices[1] with rank 1
+  // - ... and so on
+  //
+  // All communicators will have the same 'size' (total number of
+  // participants)
+  NCCLCHECK(ncclCommInitAll(comms, num_gpus, devices));
+  printf("All %d NCCL communicators initialized successfully\n\n", num_gpus);
+
+  // =========================================================================
+  // STEP 3: Create CUDA Streams and Verify Communicator Properties
+  // =========================================================================
+
+  printf("Communicator Details:\n");
+
+  bool sizes_match = true;
+  for (int i = 0; i < num_gpus; i++) {
+
+    // Query the communicator to verify it was set up correctly
+    // These calls validate that NCCL properly assigned ranks and devices
+    int rank, size, device;
+    // Get this communicator's rank
+    NCCLCHECK(ncclCommUserRank(comms[i], &rank));
+    // Get total number of participants
+    NCCLCHECK(ncclCommCount(comms[i], &size));
+    // Get assigned CUDA device
+    NCCLCHECK(ncclCommCuDevice(comms[i], &device));
+
+    printf("  Communicator %d: Rank %d/%d on CUDA device %d", i, rank, size,
+           device);
+
+    // Verify the assignment is correct
+    if (rank != i) {
+      printf(" [WARNING: Expected rank %d]", i);
+    }
+    if (device != devices[i]) {
+      printf(" [WARNING: Expected device %d]", devices[i]);
+    }
+    printf("\n");
+
+    // Verify that all communicators have the expected size
+    if (size != num_gpus) {
+      printf("WARNING: Communicator %d has size %d, expected %d\n", i, size, num_gpus);
+      sizes_match = false;
+    }
+  }
+  if (sizes_match)
+    printf("All communicators have the expected size of %d\n", num_gpus);
+
+  printf("\n");
+
+  // =========================================================================
+  // STEP 4: Cleanup and Resource Management
+  // =========================================================================
+
+  // IMPORTANT: Proper cleanup is critical for NCCL applications
+  // Resources must be cleaned up in the correct order to avoid issues
+
+  // First, synchronize all streams to ensure no operations are in flight
+  // This prevents destroying resources while they're still being used
+  printf("Synchronizing all CUDA streams...\n");
+  for (int i = 0; i < num_gpus; i++) {
+    CUDACHECK(hipSetDevice(devices[i]));
+    CUDACHECK(hipStreamSynchronize(streams[i]));
+  }
+  printf("All streams synchronized\n");
+
+  // Next, destroy NCCL communicators first
+  // This must be done before destroying CUDA resources they depend on
+  printf("Destroying NCCL communicators...\n");
+  for (int i = 0; i < num_gpus; i++) {
+    NCCLCHECK(ncclCommFinalize(comms[i]));
+    NCCLCHECK(ncclCommDestroy(comms[i]));
+  }
+  printf("All NCCL communicators destroyed\n");
+
+  // Finally, destroy CUDA streams
+  // This is safe now that the communicators are gone
+  printf("Destroying CUDA streams...\n");
+  for (int i = 0; i < num_gpus; i++) {
+    CUDACHECK(hipSetDevice(devices[i]));
+    CUDACHECK(hipStreamDestroy(streams[i]));
+  }
+  printf("All CUDA streams destroyed\n");
+
+  // Free host memory allocations
+  free(devices);
+  free(comms);
+  free(streams);
+
+  printf("\n=============================================================\n");
+  printf("SUCCESS: Multiple devices single process example completed!\n");
+  printf("=============================================================\n\n");
+
+  return 0;
+}

--- a/projects/rccl/examples/01_communicators/02_one_device_per_pthread/Makefile
+++ b/projects/rccl/examples/01_communicators/02_one_device_per_pthread/Makefile
@@ -1,0 +1,68 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# See LICENSE.txt for more license information
+#
+
+# Include common build rules
+include ../../makefiles/rccl_examples.mk
+
+# Target executable
+TARGET = one_device_per_pthread
+
+# Add pthread support
+LDFLAGS += -lpthread
+
+# Source files
+SOURCES = main.cc
+OBJECTS = $(SOURCES:.cc=.o)
+
+# Default target
+all: $(TARGET)
+
+# Build executable
+$(TARGET): $(OBJECTS)
+	$(CXX) $(CXXFLAGS) $(OBJECTS) $(LIBRARIES) $(LDFLAGS) -o $@
+	@echo "Built target $@"
+
+# Compile source files
+%.o: %.cc
+	$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
+
+# Test target
+test: $(TARGET)
+	@echo "Testing $(TARGET)..."
+	@echo "Running with default thread count (number of GPUs)"
+	./$(TARGET)
+	@echo ""
+	@if [ "$$(nvidia-smi -L | wc -l)" -ge 2 ]; then \
+		echo "Running with 2 threads"; \
+		NTHREADS=2 ./$(TARGET); \
+	fi
+
+# Clean build artifacts
+clean:
+	rm -f $(OBJECTS) $(TARGET)
+
+# Install target
+install: $(TARGET)
+	@mkdir -p $(PREFIX)/bin
+	cp $(TARGET) $(PREFIX)/bin/
+
+# Help
+help:
+	@echo "NCCL Example: One Device per Thread (pthread)"
+	@echo "============================================"
+	@echo ""
+	@echo "This example shows how to use ncclCommInitRank to create"
+	@echo "communicators for multiple GPUs using pthreads."
+	@echo ""
+	@echo "Targets:"
+	@echo "  all     - Build the example (default)"
+	@echo "  test    - Build and run basic tests"
+	@echo "  clean   - Remove build artifacts"
+	@echo "  install - Install to PREFIX/bin (default: /usr/local/bin)"
+	@echo "  help    - Show this help"
+
+.PHONY: all test clean install help

--- a/projects/rccl/examples/01_communicators/02_one_device_per_pthread/Makefile
+++ b/projects/rccl/examples/01_communicators/02_one_device_per_pthread/Makefile
@@ -36,7 +36,7 @@ test: $(TARGET)
 	@echo "Running with default thread count (number of GPUs)"
 	./$(TARGET)
 	@echo ""
-	@if [ "$$(nvidia-smi -L | wc -l)" -ge 2 ]; then \
+	@if [ "$$(rocm-smi --showid 2>/dev/null | grep -oE '^GPU\[[0-9]+\]' | sort -u | wc -l)" -ge 2 ]; then \
 		echo "Running with 2 threads"; \
 		NTHREADS=2 ./$(TARGET); \
 	fi

--- a/projects/rccl/examples/01_communicators/02_one_device_per_pthread/README.md
+++ b/projects/rccl/examples/01_communicators/02_one_device_per_pthread/README.md
@@ -1,0 +1,161 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+
+  See LICENSE.txt for more license information
+-->
+
+# NCCL Example: One Device per Thread (pthread)
+
+This example demonstrates NCCL communicator lifecycle management using pthreads, with one GPU per
+thread.
+
+## Overview
+
+This example shows how to use NCCL in a multi-threaded environment where each pthread manages one
+GPU device. It demonstrates the proper initialization and cleanup sequence for NCCL communicators
+within threads.
+
+## What This Example Does
+
+1. **Thread Creation**:
+   - Creates one pthread per available GPU or `NTHREADS` if set
+   - Each thread manages its own HIP device context
+
+2. **Communicator Creation**:
+   - Uses `ncclCommInitRank` with unique ID across threads
+   - Each thread initializes its own communicator
+   - Demonstrates thread-safe NCCL initialization
+
+3. **Verification**:
+   - Queries communicator properties (rank, size, device)
+   - Confirms successful initialization across all threads
+
+4. **Cleanup**:
+   - Proper resource cleanup order within each thread
+   - Demonstrates correct NCCL and HIP resource management
+
+## Building and Running
+
+### Build
+```shell
+make  [NCCL_HOME=<path-to-nccl>] [CUDA_HOME=<path-to-cuda>]
+```
+
+### Run with specific thread count (number of GPUs)
+```shell
+[NTHREADS=n] ./one_device_per_pthread
+```
+
+### Run with NCCL debug output
+```shell
+NCCL_DEBUG=INFO ./one_device_per_pthread
+```
+
+## Code Walk-through
+
+### Key Function: ncclCommInitRank in threads
+```c
+// Each thread creates it's own copy of struct `threadData_t`.
+typedef struct {
+  int thread_id; // thread_id is set when thread is created
+  int num_gpus; // num_gpus is set by querying the HIP devices
+  ncclUniqueId commId; // commId is set by ncclGetUniqueId
+  ncclComm_t* comms;
+} threadData_t;
+threadData_t* data;
+
+// Each thread initializes its own communicator
+NCCLCHECK(ncclCommInitRank(&data->comms[thread_id], data->num_gpus, data->commId, data->thread_id));
+```
+
+In this approach:
+- Each thread gets its own NCCL rank (0, 1, 2...)
+- Does not need explicit distribution of `uniqueId` since it uses a global variable.
+
+## Expected Output
+
+```
+Using 4 devices with pthreads
+Creating 4 threads for NCCL communicators
+  Thread 0: Set device 0 and created stream
+  Thread 1: Set device 1 and created stream
+  Thread 2: Set device 2 and created stream
+  Thread 3: Set device 3 and created stream
+  Thread 0: NCCL communicator initialized
+  Thread 1: NCCL communicator initialized
+  Thread 2: NCCL communicator initialized
+  Thread 3: NCCL communicator initialized
+All threads synchronized - communicators ready
+  Thread 0: Communicator rank 0 of 4
+  Thread 1: Communicator rank 1 of 4
+  Thread 2: Communicator rank 2 of 4
+  Thread 3: Communicator rank 3 of 4
+  Thread 0: Destroyed NCCL communicator
+  Thread 1: Destroyed NCCL communicator
+  Thread 2: Destroyed NCCL communicator
+  Thread 3: Destroyed NCCL communicator
+  Thread 0: Resources cleaned up
+  Thread 1: Resources cleaned up
+  Thread 2: Resources cleaned up
+  Thread 3: Resources cleaned up
+All threads completed
+Success
+```
+
+## When to Use pthread Approach
+
+### Ideal Use Cases
+- **Thread-based applications**: When your application is already threaded
+- **Single-node workloads**: All GPUs on one machine
+- **Shared memory**: Need to share data structures between GPU contexts
+
+### When NOT to Use
+- **Multi-node clusters**: Cannot scale beyond one node
+- **Process isolation**: When GPU contexts should be isolated
+- **Complex applications**: Multi-process approach may be cleaner
+
+## Performance Considerations
+
+- **Advantages**:
+  - Shared address space between threads
+  - Easier data sharing between GPU contexts
+  - No MPI overhead
+
+- **Disadvantages**:
+  - Thread synchronization complexity
+  - Limited to single node
+
+## Common Issues and Solutions
+
+1. **Thread synchronization errors**:
+   - Ensure all threads use the same NCCL unique ID
+   - Proper pthread synchronization (barriers, joins)
+
+2. **HIP context conflicts**:
+   - Each thread must call `cudaSetDevice()` before HIP operations
+   - Don't share HIP streams between threads
+
+3. **Resource cleanup order**:
+   - Always destroy NCCL communicators before HIP resources
+   - Synchronize streams before destroying communicators
+
+## Error Handling
+
+The example uses simplified error handling with CHECK macros:
+- **CUDACHECK**: Exits immediately on HIP errors
+- **NCCLCHECK**: Exits immediately on NCCL errors
+- **No async error checking**: Simplified for clarity
+- **Thread safety**: Each thread handles its own errors
+
+## Highlighted Environment Variables
+
+- `NTHREADS`: Number of threads to create (defaults to number of GPUs)
+
+See examples/README.md for the full list.
+
+## Next Steps
+
+After understanding this example:
+1. Try using the collective examples and add the pthread approach
+2. Compare with MPI-based multi-process approach

--- a/projects/rccl/examples/01_communicators/02_one_device_per_pthread/main.cc
+++ b/projects/rccl/examples/01_communicators/02_one_device_per_pthread/main.cc
@@ -1,0 +1,198 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See LICENSE.txt for more license information
+ *************************************************************************/
+
+#include "hip/hip_runtime.h"
+#include <rccl/rccl.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/**
+ * NCCL Pthread Example - One Device Per Thread (Simple Version)
+ *
+ * This example demonstrates the basic lifecycle of NCCL communicators in a
+ * multi-threaded environment. Each pthread manages one GPU device and shows
+ * how to properly create and destroy NCCL communicators.
+ *
+ * Key Learning Points:
+ * - NCCL communicator creation and destruction within threads
+ * - CUDA stream management per thread
+ * - Proper resource cleanup order
+ *
+ * This is a minimal example focusing purely on communicator lifecycle
+ * management without performing actual collective operations.
+ */
+
+// Enhanced error checking macro for NCCL operations
+// Provides detailed error information including the failed operation
+
+#define NCCLCHECK(cmd)                                                         \
+  do {                                                                         \
+    ncclResult_t res = cmd;                                                    \
+    if (res != ncclSuccess) {                                                  \
+      fprintf(stderr, "Failed, NCCL error %s:%d '%s'\n", __FILE__, __LINE__,   \
+              ncclGetErrorString(res));                                        \
+      fprintf(stderr, "Failed NCCL operation: %s\n", #cmd);                    \
+      exit(EXIT_FAILURE);                                                      \
+    }                                                                          \
+  } while (0)
+
+#define CUDACHECK(cmd)                                                         \
+  do {                                                                         \
+    hipError_t err = cmd;                                                     \
+    if (err != hipSuccess) {                                                  \
+      fprintf(stderr, "Failed: Cuda error %s:%d '%s'\n", __FILE__, __LINE__,   \
+              hipGetErrorString(err));                                        \
+      fprintf(stderr, "Failed CUDA operation: %s\n", #cmd);                    \
+      exit(EXIT_FAILURE);                                                      \
+    }                                                                          \
+  } while (0)
+
+// Thread data structure to pass parameters
+typedef struct {
+  int thread_id;
+  int num_gpus;
+  ncclUniqueId commId;
+  ncclComm_t *comms;
+} threadData_t;
+
+void *thread_worker(void *arg) {
+  threadData_t *data = (threadData_t *)arg;
+  int thread_id = data->thread_id;
+  hipStream_t stream;
+
+  // =========================================================================
+  // Set Device Context and Create Stream
+  // =========================================================================
+  // Each thread must set its device context before any CUDA operations
+  CUDACHECK(hipSetDevice(thread_id));
+  CUDACHECK(hipStreamCreate(&stream));
+
+  printf("  Thread %d: Set device %d and created stream\n", thread_id,
+         thread_id);
+
+  // =========================================================================
+  // Initialize NCCL Communicator
+  // =========================================================================
+  // Each thread creates its own communicator using the shared unique ID
+  NCCLCHECK(ncclCommInitRank(&data->comms[thread_id], data->num_gpus, data->commId,
+                             thread_id));
+
+  printf("  Thread %d: NCCL communicator initialized\n", thread_id);
+
+  if (thread_id == 0) {
+    printf("All threads initialized - communicators ready\n");
+  }
+
+  // =========================================================================
+  // Query Communicator Properties
+  // =========================================================================
+  // Verify the communicator was created correctly
+  int comm_thread_id, comm_size;
+  NCCLCHECK(ncclCommUserRank(data->comms[thread_id], &comm_thread_id));
+  NCCLCHECK(ncclCommCount(data->comms[thread_id], &comm_size));
+
+  printf("  Thread %d: Communicator thread_id %d of %d\n", thread_id,
+         comm_thread_id, comm_size);
+
+  // Synchronize CUDA stream to ensure all GPU work is complete
+  if (stream != NULL) {
+    CUDACHECK(hipStreamSynchronize(stream));
+  }
+
+  // =========================================================================
+  // Cleanup Resources (Proper Order)
+  // =========================================================================
+  // Destroy NCCL communicator FIRST (before CUDA resources)
+  // This is important - NCCL cleanup should happen before CUDA cleanup
+  if (data->comms[thread_id] != NULL) {
+    NCCLCHECK(ncclCommFinalize(data->comms[thread_id]));
+    NCCLCHECK(ncclCommDestroy(data->comms[thread_id]));
+    printf("  Thread %d: Destroyed NCCL communicator\n", comm_thread_id);
+  }
+
+  // Now destroy CUDA stream
+  if (stream != NULL) {
+    CUDACHECK(hipStreamDestroy(stream));
+  }
+
+  printf("  Thread %d: Resources cleaned up\n", thread_id);
+
+  return NULL;
+}
+
+int main(int argc, char *argv[]) {
+  int num_gpus;
+  pthread_t *threads;
+  threadData_t *threadData;
+  ncclComm_t *comms;
+  ncclUniqueId commId;
+
+  // =========================================================================
+  // STEP 1: Initialize Variables and Check GPU Availability
+  // =========================================================================
+
+  CUDACHECK(hipGetDeviceCount(&num_gpus));
+  const char *nThreadsEnv = getenv("NTHREADS");
+  if (nThreadsEnv) {
+    num_gpus = atoi(nThreadsEnv);
+  }
+
+  if (num_gpus < 1) {
+    printf("No CUDA devices found\n");
+    return EXIT_FAILURE;
+  }
+
+  printf("Using %d devices with pthreads\n", num_gpus);
+
+  // =========================================================================
+  // STEP 2: Allocate Memory and Prepare Data Structures
+  // =========================================================================
+
+  threads = (pthread_t *)malloc(num_gpus * sizeof(pthread_t));
+  threadData = (threadData_t *)malloc(num_gpus * sizeof(threadData_t));
+  comms = (ncclComm_t *)malloc(num_gpus * sizeof(ncclComm_t));
+
+  // Generate unique ID for NCCL communicator initialization
+  NCCLCHECK(ncclGetUniqueId(&commId));
+
+  // =========================================================================
+  // STEP 3: Create and Launch Pthread Threads
+  // =========================================================================
+
+  printf("Creating %d threads for NCCL communicators\n", num_gpus);
+
+  for (int i = 0; i < num_gpus; i++) {
+    threadData[i].thread_id = i;
+    threadData[i].num_gpus = num_gpus;
+    threadData[i].commId = commId;
+    threadData[i].comms = comms;
+
+    pthread_create(&threads[i], NULL, thread_worker, &threadData[i]);
+  }
+
+  // =========================================================================
+  // STEP 4: Wait for Thread Completion
+  // =========================================================================
+
+  for (int i = 0; i < num_gpus; i++) {
+    pthread_join(threads[i], NULL);
+  }
+
+  printf("All threads completed\n");
+
+  // =========================================================================
+  // STEP 5: Cleanup Resources
+  // =========================================================================
+
+  free(threads);
+  free(threadData);
+  free(comms);
+
+  printf("Success\n");
+  return 0;
+}

--- a/projects/rccl/examples/01_communicators/03_one_device_per_process_mpi/Makefile
+++ b/projects/rccl/examples/01_communicators/03_one_device_per_process_mpi/Makefile
@@ -1,0 +1,66 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# See LICENSE.txt for more license information
+#
+
+# This examples needs to be built with MPI support
+MPI = 1
+
+# Include common build rules
+include ../../makefiles/rccl_examples.mk
+
+# Target executable
+TARGET = one_device_per_process_mpi
+
+# Source files
+SOURCES = main.cc
+OBJECTS = $(SOURCES:.cc=.o)
+
+# Default target
+all: $(TARGET)
+
+# Build executable
+$(TARGET): $(OBJECTS)
+	$(MPICXX) $(CXXFLAGS) $(OBJECTS) $(LIBRARIES) $(LDFLAGS) -o $@
+	@echo "Built target $@"
+
+# Compile source files
+%.o: %.cc
+	$(MPICXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
+
+# Test target
+test: $(TARGET)
+	@echo "Testing $(TARGET)..."
+	@echo "Running with 1 process"
+	$(MPIRUN) -np 1 ./$(TARGET)
+	@echo ""
+	@echo "Running with 2 processes"
+	$(MPIRUN) -np 2 ./$(TARGET)
+
+# Clean build artifacts
+clean:
+	rm -f $(OBJECTS) $(TARGET)
+
+# Install target
+install: $(TARGET)
+	@mkdir -p $(PREFIX)/bin
+	cp $(TARGET) $(PREFIX)/bin/
+
+# Help
+help:
+	@echo "NCCL Example: One Device per Process (MPI)"
+	@echo "=========================================="
+	@echo ""
+	@echo "This example shows how to use ncclCommInitRank to create"
+	@echo "communicators for multiple GPUs using pthreads."
+	@echo ""
+	@echo "Targets:"
+	@echo "  all           - Build the example (default)"
+	@echo "  test          - Build and run tests with different process counts"
+	@echo "  clean         - Remove build artifacts"
+	@echo "  install       - Install to PREFIX/bin (default: /usr/local/bin)"
+	@echo "  help          - Show this help"
+
+.PHONY: all test clean install help

--- a/projects/rccl/examples/01_communicators/03_one_device_per_process_mpi/Makefile
+++ b/projects/rccl/examples/01_communicators/03_one_device_per_process_mpi/Makefile
@@ -54,7 +54,7 @@ help:
 	@echo "=========================================="
 	@echo ""
 	@echo "This example shows how to use ncclCommInitRank to create"
-	@echo "communicators for multiple GPUs using pthreads."
+	@echo "communicators for multiple GPUs using MPI."
 	@echo ""
 	@echo "Targets:"
 	@echo "  all           - Build the example (default)"

--- a/projects/rccl/examples/01_communicators/03_one_device_per_process_mpi/README.md
+++ b/projects/rccl/examples/01_communicators/03_one_device_per_process_mpi/README.md
@@ -1,0 +1,199 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+
+  See LICENSE.txt for more license information
+-->
+
+# NCCL Example: One Device per Process (MPI)
+
+This example demonstrates NCCL communicator lifecycle management using MPI, with
+one GPU per MPI process.
+
+## Overview
+
+This example shows one of the most common NCCL deployment pattern: one GPU
+device per process. This approach is ideal for distributed training across
+multiple nodes and provides the foundation for scalable multi-GPU applications.
+MPI is used as it provides a parallel launcher and broadcast functions. It is,
+however, not a requirement for multi-node NCCL applications.
+
+Other approaches use server-client models or spawn parallel processes using
+sockets. NCCL only requires that the unique ID is distributed among each
+thread/process taking part in collective communication and all threads/processes
+call some NCCL initialization function.
+
+## What This Example Does
+
+1. **Multi-node Support**:
+   - Determines local rank on each node automatically
+   - Maps MPI processes to GPUs on each node
+   - Uses `MPI_Comm_split_type` with `MPI_COMM_TYPE_SHARED` to assign each local
+     rank a GPU.
+
+2. **Communicator Creation**:
+   - Uses `ncclCommInitRank` with MPI-coordinated unique ID
+   - Rank `0` generates and broadcasts NCCL unique ID
+   - Each process joins the distributed communicator
+
+3. **Verification**:
+   - Displays MPI rank → NCCL rank → GPU device mapping
+   - Confirms successful initialization across all processes
+
+4. **Cleanup**:
+   - Proper resource cleanup order
+   - MPI synchronization for clean shutdown
+
+## Building and Running
+
+### Build
+```shell
+make MPI=1 [MPI_HOME=<path-to-mpi>] [NCCL_HOME=<path-to-nccl>] [CUDA_HOME=<path-to-cuda>]
+```
+
+### Run example
+```shell
+mpirun -np <num_processes> ./one_device_per_process_mpi
+```
+
+### Run with NCCL debug output
+```shell
+NCCL_DEBUG=INFO mpirun -np <num_processes> ./one_device_per_process_mpi
+```
+
+## Code Walk-through
+
+This approach:
+- Automatically handles multi-node GPU assignment
+- Uses MPI for coordination and NCCL for GPU communication
+- Supports both single-node and multi-node deployments
+
+### Unique ID Distribution
+The NCCL unique ID must be shared with all process which call `ncclCommInitRank`. We use MPI for that:
+```c
+// Rank 0 generates unique ID
+if (mpi_rank == 0) {
+    NCCLCHECK(ncclGetUniqueId(&nccl_id));
+}
+
+// Broadcast to all processes
+MPI_Bcast(&nccl_id, sizeof(ncclUniqueId), MPI_BYTE, 0, MPI_COMM_WORLD);
+```
+
+### Key Function: Multi-node GPU assignment
+```c
+// Separate function to determine the node local rank via `MPI_Comm_split_type`
+int local_rank = getLocalRank(MPI_COMM_WORLD);
+
+// Use the local rank as the GPU device number. This assumes you only start as many processes as available GPUs
+CUDACHECK(cudaSetDevice(local_rank));
+
+ncclComm_t comm;
+int mpi_rank, mpi_size; // mpi_rank & mpi_size are set during MPI initialization
+ncclUniqueId nccl_id; // nccl_id is generated and broadcasted as above
+
+// Initialize NCCL communicator across all processes
+NCCLCHECK(ncclCommInitRank(&comm, mpi_size, nccl_id, mpi_rank));
+```
+
+## Expected Output
+
+### Single Node (4 processes)
+```
+Starting NCCL communicator lifecycle example with 4 processes
+  MPI initialized - Process 0 of 4 total processes
+  Found 4 HIP devices on this node
+  MPI rank 0 assigned to HIP device 0
+Rank 0 generated NCCL unique ID for all processes
+  Rank 0 received NCCL unique ID
+  Rank 0 created NCCL communicator
+  MPI rank 0 → NCCL rank 0/4 on GPU device 0
+
+[Similar output for ranks 1-3]
+
+All communicators initialized successfully! Beginning cleanup...
+  Rank 0 destroyed NCCL communicator
+
+All NCCL communicators created and cleaned up properly!
+This example demonstrated the complete NCCL communicator lifecycle.
+Next steps: Try running NCCL collective operations (AllReduce, etc.)
+```
+
+### Multi-node (8 processes, 2 nodes)
+```
+Starting NCCL communicator lifecycle example with 8 processes
+  MPI initialized - Process 0 of 8 total processes
+  MPI initialized - Process 1 of 8 total processes
+  MPI initialized - Process 2 of 8 total processes
+  MPI initialized - Process 3 of 8 total processes
+  MPI initialized - Process 4 of 8 total processes
+  MPI initialized - Process 5 of 8 total processes
+  MPI initialized - Process 6 of 8 total processes
+  MPI initialized - Process 7 of 8 total processes
+...
+
+  MPI rank 0 → NCCL rank 0/8 on GPU device 0
+  MPI rank 1 → NCCL rank 1/8 on GPU device 1
+  MPI rank 2 → NCCL rank 2/8 on GPU device 2
+  MPI rank 3 → NCCL rank 3/8 on GPU device 3
+  MPI rank 4 → NCCL rank 4/8 on GPU device 0
+  MPI rank 5 → NCCL rank 5/8 on GPU device 1
+  MPI rank 6 → NCCL rank 6/8 on GPU device 2
+  MPI rank 7 → NCCL rank 7/8 on GPU device 3
+
+All NCCL communicators created and cleaned up properly!
+```
+
+## When to Use MPI Approach
+
+### Ideal Use Cases
+- **Multi-node clusters**: Scales across multiple machines
+- **Production deployments**: Industry standard for distributed training,
+  inference, and most HPC codes
+- **Process isolation**: Each GPU in separate process for robustness
+- **Large scale**: Supports thousands of GPUs
+
+### When NOT to Use
+- **Single-node testing**: Simpler approaches available
+- **No MPI available**: Some environments don't support MPI
+- **Shared memory needs**: Single-process approaches may be simpler
+
+## Performance Considerations
+
+- **Advantages**:
+  - MPI has been optimized for large parallel startup.
+  - Industry standard deployment pattern
+  - Optimal for large-scale training
+
+- **Disadvantages**:
+  - MPI setup complexity
+  - Inter-process communication overhead
+  - Requires MPI runtime environment
+
+## Common Issues and Solutions
+
+1. **More MPI processes than GPUs on a node**:
+   - The example reports an error if local rank exceeds available devices
+   - Use fewer processes per node or more GPUs
+
+2. **MPI broadcast hangs**:
+   - Ensure all ranks participate in collective operations
+   - Check MPI installation and network connectivity
+
+3. **Multi-node communication fails**:
+   - Check firewall settings and network configuration
+   - Set `NCCL_SOCKET_IFNAME` to specify network interface
+
+## Error Handling
+
+The example uses simplified error handling with CHECK macros:
+- **CUDACHECK**: Exits immediately on HIP errors
+- **NCCLCHECK**: Exits immediately on NCCL errors
+- **No async error checking**: Simplified for clarity
+- **No global error coordination**: Each process exits on its own errors
+
+## Next Steps
+
+After understanding this example:
+1. Try running collective operations (AllReduce, AllGather, etc.)
+2. Experiment with multi-node deployments

--- a/projects/rccl/examples/01_communicators/03_one_device_per_process_mpi/main.cc
+++ b/projects/rccl/examples/01_communicators/03_one_device_per_process_mpi/main.cc
@@ -1,0 +1,251 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See LICENSE.txt for more license information
+ *************************************************************************/
+
+#include "hip/hip_runtime.h"
+#include "mpi.h"
+#include <rccl/rccl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+/**
+ * NCCL Example: One Device per Process with MPI
+ * =============================================
+ *
+ * LEARNING OBJECTIVE:
+ * This example teaches the fundamental NCCL pattern: one GPU device per MPI
+ * process. This is the most common deployment pattern for multi-GPU distributed
+ * training.
+ *
+ * WHAT THIS CODE DEMONSTRATES:
+ * - How to initialize NCCL communicators across multiple processes
+ * - Proper GPU assignment in both single-node and multi-node environments
+ * - Complete NCCL communicator lifecycle management
+ * - Error handling best practices for production code
+ *
+ * STEP-BY-STEP PROCESS:
+ * 1. MPI Setup: Initialize MPI and determine process layout
+ * 2. GPU Assignment: Map each process to a local GPU device
+ * 3. NCCL ID Sharing: Rank 0 creates unique ID, broadcasts to all processes
+ * 4. Communicator Creation: Each process joins the NCCL communicator
+ * 5. Verification: Query and verify communicator properties
+ * 6. Clean Shutdown: Properly destroy all resources in correct order
+ *
+ * MULTI-NODE INTELLIGENCE:
+ * - Automatically detects which processes are on the same physical node
+ * - Assigns local GPU indices (0, 1, 2, 3...) to processes on each node
+ * - Uses MPI_Comm_split_type with MPI_COMM_TYPE_SHARED for robust node
+ * identification
+ * - Leverages MPI's native shared memory detection for optimal performance
+ *
+ * USAGE EXAMPLES:
+ *   Single node (4 GPUs): mpirun -np 4 ./one_device_per_process_mpi
+ *
+ * EXPECTED OUTPUT:
+ *   Each process will report: MPI rank → NCCL rank → GPU device assignment
+ *   Success message confirms all communicators were created properly
+ */
+
+// Enhanced error checking macro for NCCL operations
+// Provides detailed error information including the failed operation
+
+#define NCCLCHECK(cmd)                                                         \
+  do {                                                                         \
+    ncclResult_t res = cmd;                                                    \
+    if (res != ncclSuccess) {                                                  \
+      fprintf(stderr, "Failed, NCCL error %s:%d '%s'\n", __FILE__, __LINE__,   \
+              ncclGetErrorString(res));                                        \
+      fprintf(stderr, "Failed NCCL operation: %s\n", #cmd);                    \
+      exit(EXIT_FAILURE);                                                      \
+    }                                                                          \
+  } while (0)
+
+#define CUDACHECK(cmd)                                                         \
+  do {                                                                         \
+    hipError_t err = cmd;                                                     \
+    if (err != hipSuccess) {                                                  \
+      fprintf(stderr, "Failed: Cuda error %s:%d '%s'\n", __FILE__, __LINE__,   \
+              hipGetErrorString(err));                                        \
+      fprintf(stderr, "Failed CUDA operation: %s\n", #cmd);                    \
+      exit(EXIT_FAILURE);                                                      \
+    }                                                                          \
+  } while (0)
+
+// =============================================================================
+// LOCAL RANK UTILITY FUNCTION - For Multi-Node GPU Assignment
+// =============================================================================
+
+/**
+ * Determine the local rank of this process on its physical node
+ *
+ * Algorithm:
+ * 1. Split the communicator based on shared memory (i.e., nodes)
+ * 2. Get the rank within the node communicator
+ * 3. This rank becomes the local rank for GPU assignment
+ *
+ * @param comm The MPI communicator to use for determining local rank
+ * @return Local rank (0, 1, 2...) for GPU assignment, or -1 on error
+ */
+int getLocalRank(MPI_Comm comm) {
+
+  int world_size;
+  MPI_Comm_size(comm, &world_size);
+
+  int world_rank;
+  MPI_Comm_rank(comm, &world_rank);
+
+  // Split the communicator based on shared memory (i.e., nodes)
+  MPI_Comm node_comm;
+  MPI_Comm_split_type(comm, MPI_COMM_TYPE_SHARED, world_rank, MPI_INFO_NULL,
+                      &node_comm);
+
+  // Get the rank and size within the node communicator
+  int node_rank, node_size;
+  MPI_Comm_rank(node_comm, &node_rank);
+  MPI_Comm_size(node_comm, &node_size);
+
+  // Clean up the node communicator
+  MPI_Comm_free(&node_comm);
+
+  return node_rank;
+}
+
+// =============================================================================
+// MAIN FUNCTION - NCCL Communicator Lifecycle Example
+// =============================================================================
+
+int main(int argc, char *argv[]) {
+  // Variables for MPI, CUDA, and NCCL components
+  int mpi_rank, mpi_size, local_rank;
+  int num_gpus = 0;
+  ncclComm_t comm = NULL;
+  hipStream_t stream = NULL;
+  ncclUniqueId nccl_id;
+
+  // =========================================================================
+  // STEP 1: Initialize MPI and determine process layout
+  // =========================================================================
+
+  MPI_Init(&argc, &argv);
+  MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
+
+
+  if (mpi_rank == 0) {
+    printf("Starting NCCL communicator lifecycle example with %d processes\n",
+           mpi_size);
+  }
+  // Determine which local GPU this process should use
+  local_rank = getLocalRank(MPI_COMM_WORLD);
+
+  printf("  MPI initialized - Process %d of %d total processes\n", mpi_rank,
+         mpi_size);
+
+  // =========================================================================
+  // STEP 2: Setup CUDA device for this process
+  // =========================================================================
+
+  // Check how many CUDA devices are available on this node
+  CUDACHECK(hipGetDeviceCount(&num_gpus));
+  printf("  Found %d CUDA devices on this node\n", num_gpus);
+
+  if (num_gpus == 0) {
+    fprintf(stderr, "ERROR: No CUDA devices found on this node!\n");
+    exit(EXIT_FAILURE);
+  }
+
+  if (local_rank >= num_gpus) {
+    fprintf(stderr,
+            "ERROR: Process %d needs GPU %d but only %d devices available\n",
+            mpi_rank, local_rank, num_gpus);
+    exit(EXIT_FAILURE);
+  }
+
+  // Assign this process to its designated GPU device
+  CUDACHECK(hipSetDevice(local_rank));
+
+  // Create CUDA stream for GPU operations
+  CUDACHECK(hipStreamCreate(&stream));
+
+  printf("  MPI rank %d assigned to CUDA device %d\n", mpi_rank,
+         local_rank);
+
+  // =========================================================================
+  // STEP 3: Initialize NCCL communicator
+  // =========================================================================
+
+  // Generate NCCL unique ID (only rank 0 needs to do this)
+  if (mpi_rank == 0) {
+    NCCLCHECK(ncclGetUniqueId(&nccl_id));
+    printf("Rank 0 generated NCCL unique ID for all processes\n");
+  }
+
+  // Share the unique ID with all processes using MPI broadcast
+  MPI_Bcast(&nccl_id, NCCL_UNIQUE_ID_BYTES, MPI_CHAR, 0, MPI_COMM_WORLD);
+  printf("INFO: Rank %d received NCCL unique ID\n", mpi_rank);
+
+  // Create NCCL communicator for this process
+  // This is where each process joins the distributed NCCL communicator
+  NCCLCHECK(ncclCommInitRank(&comm, mpi_size, nccl_id, mpi_rank));
+  printf("  Rank %d created NCCL communicator\n", mpi_rank);
+
+  // =========================================================================
+  // STEP 4: Verify communicator setup
+  // =========================================================================
+
+  // Query communicator properties to verify everything is set up correctly
+  int comm_rank, comm_size, comm_device;
+  NCCLCHECK(ncclCommUserRank(comm, &comm_rank));
+  NCCLCHECK(ncclCommCount(comm, &comm_size));
+  NCCLCHECK(ncclCommCuDevice(comm, &comm_device));
+
+  printf("  MPI rank %d → NCCL rank %d/%d on GPU device %d\n", mpi_rank,
+         comm_rank, comm_size, comm_device);
+
+  // Give all processes a chance to finish their printf
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  // =========================================================================
+  // STEP 5: Clean shutdown and resource cleanup
+  // =========================================================================
+
+  if (mpi_rank == 0) {
+    printf(
+        "\nAll communicators initialized successfully! Beginning cleanup...\n");
+  }
+
+  // Synchronize CUDA stream to ensure all GPU work is complete
+  if (stream != NULL) {
+    CUDACHECK(hipStreamSynchronize(stream));
+  }
+
+  // Destroy NCCL communicator FIRST (before CUDA resources)
+  // This is important - NCCL cleanup should happen before CUDA cleanup
+  if (comm != NULL) {
+    NCCLCHECK(ncclCommFinalize(comm));
+    NCCLCHECK(ncclCommDestroy(comm));
+    printf("  Rank %d destroyed NCCL communicator\n", mpi_rank);
+  }
+
+  // Now destroy CUDA stream
+  if (stream != NULL) {
+    CUDACHECK(hipStreamDestroy(stream));
+  }
+
+  if (mpi_rank == 0) {
+    printf(
+        "\nAll NCCL communicators created and cleaned up properly!\n");
+    printf("This example demonstrated the complete NCCL communicator "
+           "lifecycle.\n");
+    printf("Next steps: Try running NCCL collective operations (AllReduce, "
+           "etc.)\n");
+  }
+
+  MPI_Finalize();
+  return 0;
+}

--- a/projects/rccl/examples/01_communicators/Makefile
+++ b/projects/rccl/examples/01_communicators/Makefile
@@ -1,0 +1,60 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# See LICENSE.txt for more license information
+#
+
+# Include common build rules
+include ../makefiles/rccl_examples.mk
+
+# NCCL Fundamental Examples
+EXAMPLES = 01_multiple_devices_single_process 02_one_device_per_pthread
+
+ifeq ($(MPI), 1)
+EXAMPLES += 03_one_device_per_process_mpi
+endif
+
+# Default target
+all: $(EXAMPLES)
+
+# Build individual examples
+$(EXAMPLES):
+	$(MAKE) -C $@
+
+# Clean all build artifacts
+clean:
+	for example in $(EXAMPLES); do \
+		$(MAKE) -C $$example clean; \
+	done
+ifneq ($(MPI),1)
+		$(MAKE) -C 03_one_device_per_process_mpi clean
+endif
+
+# Test all examples
+test: all
+	for example in $(EXAMPLES); do \
+		echo "Testing $$example..."; \
+		$(MAKE) -C $$example test || exit 1; \
+	done
+
+# Help
+help:
+	@echo "NCCL Communicator Init Examples"
+	@echo "==============================="
+	@echo ""
+	@echo "Targets:"
+	@echo "  all     - Build all examples"
+	@echo "  clean   - Clean all build artifacts"
+	@echo "  test    - Test all examples"
+	@echo "  help    - Show this help"
+	@echo ""
+	@echo "Examples:"
+	@echo "  01_multiple_devices_single_process - Create communicators using multiple GPUs in a single thread"
+	@echo "  02_one_device_per_pthread - Create communicators using one GPU per thread"
+	@echo "  03_one_device_per_process_mpi - Create communicators using one GPU per MPI process"
+	@echo ""
+	@echo "To build/run individual examples:"
+	@echo "  make -C 01_multiple_devices_single_process"
+
+.PHONY: all clean test help $(EXAMPLES)

--- a/projects/rccl/examples/01_communicators/README.md
+++ b/projects/rccl/examples/01_communicators/README.md
@@ -1,0 +1,110 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+
+  See LICENSE.txt for more license information
+-->
+
+# NCCL Communicator Examples
+
+## Overview
+This directory contains minimal examples that demonstrate NCCL communicator
+lifecycle management (creation, query, and destruction) using different
+initialization patterns.
+
+## Examples
+
+### [01_multiple_devices_single_process](01_multiple_devices_single_process/)
+**Multiple Devices Single Process**
+- **Pattern**: Single process manages all GPUs
+- **API**: `ncclCommInitAll` (no external coordination)
+- **Use case**: Simple single-node applications
+- **Key features**:
+  - Simplest initialization method
+  - No MPI or threading required
+  - Automatic rank assignment (0 to n-1)
+  - Cannot span multiple nodes
+
+**Run command:**
+```shell
+./01_multiple_devices_single_process/multiple_devices_single_process
+```
+
+### [02_one_device_per_pthread](02_one_device_per_pthread/)
+**One Device per Thread with pthreads**
+- **Pattern**: One thread per GPU within single process
+- **API**: `ncclCommInitRank` with pthread coordination
+- **Use case**: Single-node multi-GPU, thread-based parallelism
+- **Key features**:
+  - pthread barriers for synchronization
+  - Shared memory for unique ID
+  - Lower overhead than multi-process
+  - Cannot span multiple nodes
+
+**Run command:**
+```shell
+[NTHREADS=n] ./02_one_device_per_pthread/one_device_per_pthread
+```
+
+### [03_one_device_per_process_mpi](03_one_device_per_process_mpi/)
+**One Device per Process with MPI**
+- **Pattern**: One MPI process per GPU
+- **API**: `ncclCommInitRank` with MPI coordination
+- **Use case**: Multi-node clusters, distributed training
+- **Key features**:
+  - MPI broadcast for unique ID distribution
+  - Process-to-GPU mapping by local MPI ranks
+  - Scalable to multiple nodes
+
+**Run command:**
+```shell
+mpirun -np <num_processes> ./03_one_device_per_process_mpi/one_device_per_process_mpi
+```
+
+## Choosing the Right Approach
+
+| Feature                | ncclCommInitAll | pthread          | MPI      |
+|------------------------|-----------------|------------------|----------|
+| **Multi-node support** | ✗               | ✗                | ✓        |
+| **Process isolation**  | ✗               | ✗                | ✓        |
+| **Setup complexity**   | Low             | Medium           | High     |
+| **Memory overhead**    | Low             | Medium           | High     |
+| **Best for**           | Simple test     | Single-node apps | Clusters |
+
+### When to use each:
+- **ncclCommInitAll**: Development, testing, simple single-node apps
+- **pthread**: Single-node with thread-based parallelism needs
+- **MPI**: Production distributed training, multi-node setups
+
+## Building
+
+### **Quick Start**
+```shell
+# Build all examples [or single directory]
+make [directory]
+
+# Test all examples
+make test
+```
+
+### **Individual Examples**
+```shell
+# Build specific example
+make 01_multiple_devices_single_process
+make 02_one_device_per_pthread
+make 03_one_device_per_process_mpi
+
+# Test individual example
+cd 01_multiple_devices_single_process && make test
+cd 02_one_device_per_pthread && make test
+cd 03_one_device_per_process_mpi && make test
+```
+
+## References
+- [NVIDIA NCCL User Guide
+  Examples](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/examples.html)
+- [NCCL API
+  Reference](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api.html)
+- [HIP Programming
+  Guide](https://docs.nvidia.com/cuda/cuda-c-programming-guide/)
+- [MPI Standard](https://www.mpi-forum.org/docs/)

--- a/projects/rccl/examples/02_point_to_point/01_ring_pattern/Makefile
+++ b/projects/rccl/examples/02_point_to_point/01_ring_pattern/Makefile
@@ -1,0 +1,61 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# See LICENSE.txt for more license information
+#
+
+# Include common build rules
+include ../../makefiles/rccl_examples.mk
+
+# Target executable
+TARGET = ring_pattern
+
+# Common utilities (for utils.h, nccl_utils.h, etc.)
+COMMON_INC = ../../common/include
+INCLUDES += -I$(COMMON_INC)
+
+# Source files
+SOURCES = main.cc
+OBJECTS = $(SOURCES:.cc=.o)
+
+# Default target
+all: $(TARGET)
+
+# Build executable
+$(TARGET): $(OBJECTS)
+	$(CXX) $(CXXFLAGS) $(OBJECTS) $(LIBRARIES) $(LDFLAGS) -o $@
+	@echo "Built target $@"
+
+# Compile source files
+%.o: %.cc
+	$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
+
+# Test target
+test: $(TARGET)
+	@echo "Testing $(TARGET)..."
+	@echo "Running with all available GPUs"
+	./$(TARGET)
+
+# Clean build artifacts
+clean:
+	rm -f $(OBJECTS) $(TARGET)
+
+# Install target
+install: $(TARGET)
+	@mkdir -p $(PREFIX)/bin
+	cp $(TARGET) $(PREFIX)/bin/
+
+# Help
+help:
+	@echo "NCCL Example: P2P Ring Pattern"
+	@echo "=============================================="
+	@echo ""
+	@echo "Targets:"
+	@echo "  all       - Build the example (default)"
+	@echo "  test      - Build and run test with all GPUs"
+	@echo "  clean     - Remove build artifacts"
+	@echo "  install   - Install to PREFIX/bin (default: /usr/local/bin)"
+	@echo "  help      - Show this help"
+
+.PHONY: all test clean install help

--- a/projects/rccl/examples/02_point_to_point/01_ring_pattern/README.md
+++ b/projects/rccl/examples/02_point_to_point/01_ring_pattern/README.md
@@ -1,0 +1,152 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+
+  See LICENSE.txt for more license information
+-->
+
+# NCCL Ring Communication Pattern Example
+
+This example demonstrates a ring communication pattern using NCCL P2P
+operations. It runs on a single node where a single process manages all GPUs and
+data flows in a circular pattern.
+
+## Overview
+
+The ring communication pattern creates a circular data flow where each GPU sends
+data to its "next" neighbor and receives from its "previous" neighbor in the
+ring. This example uses `ncclCommInitAll` for simplified single-threaded,
+single-process multi-GPU setup.
+
+## What This Example Does
+
+1. **Detects and initializes all available GPUs** using `ncclCommInitAll` for
+   simplified single-process setup
+2. **Creates ring topology** where each GPU calculates its next and previous
+   neighbors using modulo
+3. **Executes simultaneous point-to-point communication** with each GPU sending
+   to next and receiving from previous
+4. **Verifies data correctness** by checking that each GPU received the expected
+   data from its predecessor
+
+## Building and Running
+
+### Build the Example
+```bash
+cd examples/02_point_to_point/01_ring_pattern
+make [NCCL_HOME=<path-to-nccl>] [CUDA_HOME=<path-to-cuda>]
+```
+
+### Run with All Available GPUs
+```bash
+./ring_pattern
+```
+
+## Code Walk-through
+
+### Ring Topology Setup
+
+The example calculates ring neighbors using modulo arithmetic:
+
+```cpp
+for (int i = 0; i < num_gpus; i++) {
+    int next = (i + 1) % num_gpus;        // Next neighbor in ring
+    int prev = (i - 1 + num_gpus) % num_gpus;  // Previous neighbor in ring
+}
+```
+
+### Simultaneous Communication
+
+Uses `ncclGroupStart/End` to prevent deadlocks when scheduling all send and
+receive operations:
+
+```cpp
+float **d_sendbuff; // device side send and receive buffer are allocated through cudaMalloc
+float **d_recvbuff;
+size_t count;       // count is set to the number of floats to be sent (usually the size of the buffers)
+ncclComm_t *comms;  // comms are set during ncclCommInitAll
+cudaStream_t *streams; // streams are set in cudaStreamCreate
+
+// Each GPU simultaneously sends to next and receives from previous
+NCCLCHECK(ncclGroupStart());
+for (int i = 0; i < num_gpus; i++) {
+    int next = (i + 1) % num_gpus;
+    int prev = (i - 1 + num_gpus) % num_gpus;
+
+    NCCLCHECK(ncclSend(d_sendbuff[i], count, ncclFloat, next, comms[i], streams[i]));
+    NCCLCHECK(ncclRecv(d_recvbuff[i], count, ncclFloat, prev, comms[i], streams[i]));
+}
+NCCLCHECK(ncclGroupEnd());
+```
+
+## Expected Output
+
+```
+Starting NCCL ring communication example
+Using 4 GPUs for ring communication
+Preparing data structures
+Initializing NCCL communicators
+All communicators initialized successfully
+Creating HIP streams and verifying setup
+  GPU 0 -> NCCL rank 0/4 on HIP device 0
+  GPU 1 -> NCCL rank 1/4 on HIP device 1
+  GPU 2 -> NCCL rank 2/4 on HIP device 2
+  GPU 3 -> NCCL rank 3/4 on HIP device 3
+Setting up ring topology
+Data flow -> GPU 0 -> GPU 1 -> ... -> GPU 3 -> GPU 0
+Ring transfer with 268435456 elements (1.00 GB per GPU)
+Allocating and initializing buffers
+Executing ring communication
+  GPU 0 sends to GPU 1, receives from GPU 3
+  GPU 1 sends to GPU 2, receives from GPU 0
+  GPU 2 sends to GPU 3, receives from GPU 1
+  GPU 3 sends to GPU 0, receives from GPU 2
+Ring communication completed successfully
+Verifying data correctness
+  GPU 0 received data from GPU 3: CORRECT
+  GPU 1 received data from GPU 0: CORRECT
+  GPU 2 received data from GPU 1: CORRECT
+  GPU 3 received data from GPU 2: CORRECT
+SUCCESS - All GPUs received correct data
+Cleaning up resources
+Example completed successfully!
+```
+
+## When to Use
+
+- **Learning NCCL fundamentals**: Understanding point-to-point communication
+  patterns
+- **Algorithm development**: Building custom collective operations based on
+  point to point communications
+- **Single-node applications**: Pipeline parallelism or custom data distribution
+  patterns
+
+## Key Insights
+- `ncclCommInitAll` simplifies single-node multi-GPU setup
+- No MPI or pthreads needed for single-node patterns
+- Ring pattern enables circular data flow among all GPUs
+- `ncclGroupStart/End` prevents deadlock in simultaneous operations
+- Each GPU both sends and receives in parallel
+
+## Common Issues and Solutions
+
+### Issue: Deadlock without group operations
+**Solution:** Always use `ncclGroupStart()` and `ncclGroupEnd()` when performing
+simultaneous send/recv operations.
+
+### Issue: Verification failures
+**Solution:** Check ring topology calculations and data initialization patterns.
+Ensure correct neighbor calculations.
+
+## Error Handling
+
+This example uses comprehensive error checking with `NCCLCHECK` and `CUDACHECK`
+macros that immediately exit on any failure. In production code, consider more
+graceful error handling and recovery mechanisms.
+
+## Next Steps
+
+After this example, try:
+- **Collective operations**: Examples in `03_collectives/`
+- **Multi-node approach**: Use the MPI implementation from `01_communicators` to
+  send data across nodes.

--- a/projects/rccl/examples/02_point_to_point/01_ring_pattern/main.cc
+++ b/projects/rccl/examples/02_point_to_point/01_ring_pattern/main.cc
@@ -1,0 +1,275 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See LICENSE.txt for more license information
+ *************************************************************************/
+
+#include "hip/hip_runtime.h"
+#include <rccl/rccl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+/*
+ * NCCL Ring Pattern Example - Educational Version
+ *
+ * This example demonstrates the fundamental ring communication pattern using
+ * NCCL's point-to-point operations. Understanding ring patterns is essential
+ * for NCCL programming as they form the basis of many collective algorithms.
+ *
+ * Learning Objectives:
+ * - Understand ring topology and neighbor communication
+ * - Learn NCCL point-to-point send/recv operations
+ * - See how data flows in a ring pattern
+ * - Practice deadlock avoidance with ncclGroup operations
+ * - Understand single-process multi-GPU patterns
+ *
+ */
+
+// Enhanced error checking macro for NCCL operations
+// Provides detailed error information including the failed operation
+#define NCCLCHECK(cmd)                                                         \
+  do {                                                                         \
+    ncclResult_t res = cmd;                                                    \
+    if (res != ncclSuccess) {                                                  \
+      fprintf(stderr, "Failed, NCCL error %s:%d '%s'\n", __FILE__, __LINE__,   \
+              ncclGetErrorString(res));                                        \
+      fprintf(stderr, "Failed NCCL operation: %s\n", #cmd);                    \
+      exit(EXIT_FAILURE);                                                      \
+    }                                                                          \
+  } while (0)
+
+#define CUDACHECK(cmd)                                                         \
+  do {                                                                         \
+    hipError_t err = cmd;                                                     \
+    if (err != hipSuccess) {                                                  \
+      fprintf(stderr, "Failed: Cuda error %s:%d '%s'\n", __FILE__, __LINE__,   \
+              hipGetErrorString(err));                                        \
+      fprintf(stderr, "Failed CUDA operation: %s\n", #cmd);                    \
+      exit(EXIT_FAILURE);                                                      \
+    }                                                                          \
+  } while (0)
+
+int main(int argc, char *argv[]) {
+  // ========================================================================
+  // STEP 1: Initialize Environment and Detect GPUs
+  // ========================================================================
+
+  int num_gpus = 0;
+  ncclComm_t *comms = NULL;
+  hipStream_t *streams = NULL;
+  float **h_sendbuff = NULL;
+  float **h_recvbuff = NULL;
+  float **d_sendbuff = NULL;
+  float **d_recvbuff = NULL;
+
+  printf("Starting NCCL ring communication example\n");
+
+  // Get number of available CUDA devices
+  CUDACHECK(hipGetDeviceCount(&num_gpus));
+
+  if (num_gpus == 0) {
+    fprintf(stderr, "No CUDA devices found\n");
+    return 1;
+  }
+
+  if (num_gpus < 2) {
+    printf("At least 2 GPU are necessary to create inter-GPU traffic\n");
+    printf("Found only %d GPU(s) - pattern will be limited\n", num_gpus);
+  }
+
+  printf("Using %d GPUs for ring communication\n", num_gpus);
+
+  // ========================================================================
+  // STEP 2: Prepare Data Structures and Device List
+  // ========================================================================
+
+  printf("Preparing data structures\n");
+
+  // Create device list (use all available devices)
+  int *devices = (int *)malloc(num_gpus * sizeof(int));
+  for (int i = 0; i < num_gpus; i++) {
+    devices[i] = i;
+  }
+
+  // Allocate communicators, streams, and buffer pointers
+  comms = (ncclComm_t *)malloc(num_gpus * sizeof(ncclComm_t));
+  streams = (hipStream_t *)malloc(num_gpus * sizeof(hipStream_t));
+  h_sendbuff = (float **)malloc(num_gpus * sizeof(float *));
+  h_recvbuff = (float **)malloc(num_gpus * sizeof(float *));
+  d_sendbuff = (float **)malloc(num_gpus * sizeof(float *));
+  d_recvbuff = (float **)malloc(num_gpus * sizeof(float *));
+
+  // ========================================================================
+  // STEP 3: Initialize NCCL Communicators
+  // ========================================================================
+
+  /*
+   * ncclCommInitAll is the simplest way to initialize NCCL communicators
+   * for single-process, multi-GPU scenarios. It automatically:
+   * - Creates one communicator per GPU
+   * - Assigns ranks sequentially (GPU 0 = rank 0, GPU 1 = rank 1, etc.)
+   */
+  printf("Initializing NCCL communicators\n");
+  NCCLCHECK(ncclCommInitAll(comms, num_gpus, devices));
+  printf("All communicators initialized successfully\n");
+
+  // ========================================================================
+  // STEP 4: Create Streams and Verify Communicator Setup
+  // ========================================================================
+
+  printf("Creating CUDA streams and verifying setup\n");
+
+  // Create streams and verify communicator info
+  for (int i = 0; i < num_gpus; i++) {
+    CUDACHECK(hipSetDevice(devices[i]));
+    CUDACHECK(hipStreamCreate(&streams[i]));
+
+    // Query communicator information for verification
+    int rank, size, device;
+    NCCLCHECK(ncclCommUserRank(comms[i], &rank));
+    NCCLCHECK(ncclCommCount(comms[i], &size));
+    NCCLCHECK(ncclCommCuDevice(comms[i], &device));
+
+    printf("  GPU %d -> NCCL rank %d/%d on CUDA device %d\n", i, rank, size,
+           device);
+  }
+
+  // ========================================================================
+  // STEP 5: Set Up Ring Topology and Allocate Buffers
+  // ========================================================================
+
+  printf("Setting up ring topology\n");
+  printf("Data flow -> GPU 0 -> ... -> GPU %d -> GPU 0\n", num_gpus - 1);
+
+  // Test with 1GB of data
+  const size_t count = 256 * 1024 * 1024; // 256M floats = 1GB
+  const size_t size_bytes = count * sizeof(float);
+
+  printf("Ring transfer with %zu elements (%.2f GB per GPU)\n", count,
+         size_bytes / (1024.0 * 1024.0 * 1024.0));
+
+  // Allocate buffers for each GPU
+  printf("Allocating and initializing buffers\n");
+  for (int i = 0; i < num_gpus; i++) {
+    CUDACHECK(hipSetDevice(devices[i]));
+
+    h_sendbuff[i] = (float *)malloc(size_bytes);
+    h_recvbuff[i] = (float *)malloc(size_bytes);
+    CUDACHECK(hipMalloc((void **)&d_sendbuff[i], size_bytes));
+    CUDACHECK(hipMalloc((void **)&d_recvbuff[i], size_bytes));
+
+    // Initialize data with GPU-specific pattern for verification
+    for (size_t j = 0; j < count; j++) {
+      h_sendbuff[i][j] = (float)(i * 1000 + j % 1000);
+    }
+    CUDACHECK(hipMemcpy(d_sendbuff[i], h_sendbuff[i], size_bytes,
+                         hipMemcpyHostToDevice));
+  }
+
+  // ========================================================================
+  // STEP 6: Execute Ring Communication Pattern
+  // ========================================================================
+
+  /*
+   * The ring communication uses ncclGroup operations to avoid deadlock.
+   * Without grouping, if all GPUs tried to send first, they would deadlock
+   * waiting for receivers. Grouping allows NCCL to execute operations
+   * in the optimal order.
+   */
+  printf("Executing ring communication\n");
+
+  // NOTE: ncclGroupStart and ncclGroupEnd are essential to avoid deadlock
+  // when using ncclCommInitAll!
+  NCCLCHECK(ncclGroupStart());
+  for (int i = 0; i < num_gpus; i++) {
+    int next = (i + 1) % num_gpus;
+    int prev = (i - 1 + num_gpus) % num_gpus;
+    printf("  GPU %d sends to GPU %d, receives from GPU %d\n", i, next, prev);
+
+    // Each GPU simultaneously sends to next and receives from previous
+    NCCLCHECK(
+        ncclSend(d_sendbuff[i], count, ncclFloat, next, comms[i], streams[i]));
+    NCCLCHECK(
+        ncclRecv(d_recvbuff[i], count, ncclFloat, prev, comms[i], streams[i]));
+  }
+  NCCLCHECK(ncclGroupEnd());
+
+  // Synchronize all streams to ensure communication completes
+  for (int i = 0; i < num_gpus; i++) {
+    CUDACHECK(hipSetDevice(devices[i]));
+    CUDACHECK(hipStreamSynchronize(streams[i]));
+  }
+
+  printf("Ring communication completed successfully\n");
+
+  // ========================================================================
+  // STEP 7: Verify Data Correctness and Report Results
+  // ========================================================================
+
+  printf("Verifying data correctness\n");
+  bool all_correct = true;
+
+  for (int i = 0; i < num_gpus; i++) {
+    CUDACHECK(hipSetDevice(devices[i]));
+    CUDACHECK(hipMemcpy(h_recvbuff[i], d_recvbuff[i], size_bytes,
+                         hipMemcpyDeviceToHost));
+
+    int prev = (i - 1 + num_gpus) % num_gpus;
+    // Verify that GPU i received data from GPU prev
+    float expected = (float)(prev * 1000);
+    bool correct = (h_recvbuff[i][0] == expected);
+
+    printf("  GPU %d received data from GPU %d: %s\n", i, prev,
+           correct ? "CORRECT" : "ERROR");
+
+    if (!correct) {
+      all_correct = false;
+      printf("  Expected %.0f, got %.0f\n", expected, h_recvbuff[i][0]);
+    }
+  }
+
+  if (all_correct) {
+    printf("SUCCESS - All GPUs received correct data\n");
+  } else {
+    printf("FAILURE - Data verification failed\n");
+  }
+
+  // ========================================================================
+  // STEP 8: Cleanup Resources
+  // ========================================================================
+
+  printf("Cleaning up resources\n");
+
+  // Free buffers
+  for (int i = 0; i < num_gpus; i++) {
+    CUDACHECK(hipSetDevice(devices[i]));
+    free(h_sendbuff[i]);
+    free(h_recvbuff[i]);
+    CUDACHECK(hipFree(d_sendbuff[i]));
+    CUDACHECK(hipFree(d_recvbuff[i]));
+  }
+
+  // Destroy communicators and streams
+  for (int i = 0; i < num_gpus; i++) {
+    NCCLCHECK(ncclCommFinalize(comms[i]));
+    NCCLCHECK(ncclCommDestroy(comms[i]));
+    CUDACHECK(hipSetDevice(devices[i]));
+    CUDACHECK(hipStreamDestroy(streams[i]));
+  }
+
+  // Free allocated memory
+  free(devices);
+  free(comms);
+  free(streams);
+  free(h_sendbuff);
+  free(h_recvbuff);
+  free(d_sendbuff);
+  free(d_recvbuff);
+
+  printf("Example completed successfully!\n");
+
+  return 0;
+}

--- a/projects/rccl/examples/02_point_to_point/Makefile
+++ b/projects/rccl/examples/02_point_to_point/Makefile
@@ -1,0 +1,48 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# See LICENSE.txt for more license information
+#
+
+# NCCL Fundamental Examples
+EXAMPLES = 01_ring_pattern
+
+# Default target
+all: $(EXAMPLES)
+
+# Build individual examples
+$(EXAMPLES):
+	$(MAKE) -C $@
+
+# Clean all build artifacts
+clean:
+	for example in $(EXAMPLES); do \
+		$(MAKE) -C $$example clean; \
+	done
+
+# Test all examples
+test: all
+	for example in $(EXAMPLES); do \
+		echo "Testing $$example..."; \
+		$(MAKE) -C $$example test || exit 1; \
+	done
+
+# Help
+help:
+	@echo "NCCL Point to Point Examples"
+	@echo "============================"
+	@echo ""
+	@echo "Targets:"
+	@echo "  all     - Build all examples"
+	@echo "  clean   - Clean all build artifacts"
+	@echo "  test    - Test all examples"
+	@echo "  help    - Show this help"
+	@echo ""
+	@echo "Examples:"
+	@echo "  01_ring_pattern - Use send and receive operations to form a ring pattern"
+	@echo ""
+	@echo "To build/run individual examples:"
+	@echo "  make -C 01_ring_pattern"
+
+.PHONY: all clean test $(EXAMPLES)

--- a/projects/rccl/examples/02_point_to_point/README.md
+++ b/projects/rccl/examples/02_point_to_point/README.md
@@ -1,0 +1,68 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+
+  See LICENSE.txt for more license information
+-->
+
+# NCCL Point-to-Point Communication Examples
+
+## Overview
+This directory contains minimal examples that demonstrate NCCL point-to-point
+(P2P) communication patterns on a single node. These examples focus on clarity
+and correct communicator usage, resource management, and verification.
+
+## Examples
+
+### [01_ring_pattern](01_ring_pattern/)
+**Ring Communication Pattern**
+- **Pattern**: Circular data flow among all GPUs
+- **API**: `ncclCommInitAll` with P2P operations (`ncclSend`/`ncclRecv`)
+- **Use case**: Learning P2P communication; pipeline/data movement patterns on a
+  single node
+- **Key features**:
+  - Initializes all GPUs in a single process
+  - Computes ring neighbors with modulo arithmetic
+  - Uses `ncclGroupStart/End` to prevent deadlocks
+  - Verifies data correctness after transfers
+
+## Choosing the Right Pattern
+
+*Scenario* : Pipeline parallel training needs to send data from one GPU to
+another
+*Addresses* : Individual transfers between two ranks
+*Dependencies* : A functional NCCL library and its dependencies
+
+### Why `ncclCommInitAll` here?
+For single-node collective examples we use `ncclCommInitAll` as it creates a
+clique of communicators in one call.
+
+```c
+// Initialize all GPUs in one call
+ncclComm_t* comms;
+int num_gpus;
+NCCLCHECK(ncclCommInitAll(comms, num_gpus, NULL));
+```
+
+## Building
+
+### **Quick Start**
+```shell
+# Build example by directory name
+make 01_ring_pattern
+```
+
+### **Individual Examples**
+```shell
+# Build and run the ring pattern
+cd 01_ring_pattern && make
+./ring_pattern
+```
+
+## References
+- [NCCL User Guide:
+  Examples](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/examples.html)
+- [NCCL API
+  Reference](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api.html)
+- [HIP Programming
+  Guide](https://docs.nvidia.com/cuda/cuda-c-programming-guide/)

--- a/projects/rccl/examples/03_collectives/01_allreduce/Makefile
+++ b/projects/rccl/examples/03_collectives/01_allreduce/Makefile
@@ -1,0 +1,57 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# See LICENSE.txt for more license information
+#
+
+# Include common build rules
+include ../../makefiles/rccl_examples.mk
+
+# Target executable
+TARGET = allreduce
+
+# Source files
+SOURCES = main.cc
+OBJECTS = $(SOURCES:.cc=.o)
+
+# Default target
+all: $(TARGET)
+
+# Build executable
+$(TARGET): $(OBJECTS)
+	$(CXX) $(CXXFLAGS) $(OBJECTS) $(LIBRARIES) $(LDFLAGS) -o $@
+	@echo "Built target $@"
+
+# Compile source files
+%.o: %.cc
+	$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
+
+# Test target
+test: $(TARGET)
+	@echo "Testing $(TARGET)..."
+	@echo "Running with all available GPUs"
+	./$(TARGET)
+
+# Clean build artifacts
+clean:
+	rm -f $(OBJECTS) $(TARGET)
+
+# Install target
+install: $(TARGET)
+	@mkdir -p $(PREFIX)/bin
+	cp $(TARGET) $(PREFIX)/bin/
+
+# Help
+help:
+	@echo "NCCL Example: Allreduce"
+	@echo "=============================================="
+	@echo ""
+	@echo "Targets:"
+	@echo "  all       - Build the example (default)"
+	@echo "  test      - Build and run test with all GPUs"
+	@echo "  clean     - Remove build artifacts"
+	@echo "  install   - Install to PREFIX/bin (default: /usr/local/bin)"
+	@echo "  help      - Show this help"
+
+.PHONY: all test clean install help

--- a/projects/rccl/examples/03_collectives/01_allreduce/README.md
+++ b/projects/rccl/examples/03_collectives/01_allreduce/README.md
@@ -1,0 +1,144 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+
+  See LICENSE.txt for more license information
+-->
+
+# NCCL AllReduce Collective Operation Example
+
+This example demonstrates the fundamental AllReduce collective operation using
+NCCL's single-process, multi-GPU approach in which a single process manages all
+GPUs to perform a sum reduction.
+
+## Overview
+
+AllReduce combines data from all participants using a reduction operation (sum,
+max, min, etc.) and distributes the result to all participants. This example
+shows how each GPU contributes its rank value and all GPUs receive the combined
+sum using `ncclCommInitAll` for simplified setup.
+
+## What This Example Does
+
+1. **Detects available GPUs** and initializes NCCL communicators for all devices
+   using `ncclCommInitAll`
+2. **Initializes data** with each GPU contributing its rank value (GPU 0→0, GPU
+   1→1, etc.)
+3. **Performs AllReduce sum operation** where all GPU values are summed and
+   distributed to all participants
+4. **Verifies correctness** by checking that all GPUs received the expected sum:
+   0+1+2+...+(n-1)
+
+## Building and Running
+
+### Build the Example
+```bash
+cd examples/03_collectives/01_allreduce
+make [NCCL_HOME=<path-to-nccl>] [CUDA_HOME=<path-to-cuda>]
+```
+
+### Run with All Available GPUs
+```bash
+./allreduce
+```
+
+### Run with Specific GPUs
+```bash
+CUDA_VISIBLE_DEVICES=0,1,2,3 ./allreduce
+```
+
+## Code Walk-through
+
+### Data Initialization
+Each GPU sets a send buffer allocated on the GPU to its rank value:
+```cpp
+float** sendbuff;
+float rank_value = (float)i;
+size_t size; // size is the number of float to be sent
+
+// Allocate device memory for send buffers
+CUDACHECK(cudaMalloc((void **)&sendbuff[i], size * sizeof(float)));
+
+// Each GPU contributes its rank (GPU i contributes value i)
+// Zero the entire buffer, then set first element to rank
+CUDACHECK(cudaMemset(sendbuff[i], 0, size * sizeof(float)));
+CUDACHECK(cudaMemcpy(sendbuff[i], &rank_value, sizeof(float), cudaMemcpyHostToDevice));
+```
+
+### AllReduce Operation
+All GPUs participate in the sum reduction. The operations are evaluated in parallel within a NCCL group to avoid any deadlocks.
+```cpp
+float** recvbuff;
+ncclComm_t *comms;  // comms are set during ncclCommInitAll
+cudaStream_t *streams; // streams are set in cudaStreamCreate
+
+// Allocate device memory for receive buffers
+CUDACHECK(cudaMalloc((void **)&recvbuff[i], size * sizeof(float)));
+
+NCCLCHECK(ncclGroupStart());
+for (int i = 0; i < num_gpus; i++) {
+    NCCLCHECK(ncclAllReduce(sendbuff[i], recvbuff[i], size, ncclFloat,
+                            ncclSum, comms[i], streams[i]));
+}
+NCCLCHECK(ncclGroupEnd());
+```
+
+## Expected Output
+
+```
+Using 4 devices for collective communication
+Memory allocated for 4 communicators and streams
+NCCL communicators initialized for all devices
+  Device 0 initialized with data value 0
+  Device 1 initialized with data value 1
+  Device 2 initialized with data value 2
+  Device 3 initialized with data value 3
+Starting collective sum operation across all devices
+Collective operation completed
+Verifying results (expected sum: 6)
+  Device 0 correctly received sum: 6
+  Device 1 correctly received sum: 6
+  Device 2 correctly received sum: 6
+  Device 3 correctly received sum: 6
+Example completed successfully!
+```
+
+## When to Use
+
+- **Deep learning**: Gradient averaging in data-parallel training
+- **Scientific computing**: Global reductions in parallel algorithms
+- **Statistics**: Computing global sums, averages, or other reductions
+- **Distributed algorithms**: Any scenario requiring collective reduction
+  operations
+
+## Key Insights
+- `ncclCommInitAll` simplifies single-node multi-GPU setup
+- No MPI or pthreads needed for single-node patterns
+- Allocate device buffer via ``cudaMalloc` and initialize via `cudaMemset`.
+- Best practices to wrap all collective calls in ncclGroupStart/End
+- All communication happens in parallel
+
+## Common Issues and Solutions
+
+### Issue: Verification failures
+**Solution:** Ensure each GPU initializes its buffer correctly with its rank
+value.
+
+### Issue: Out of memory errors
+**Solution:** Reduce the buffer size in the code or use fewer GPUs.
+
+## Error Handling
+
+This example uses comprehensive error checking with `NCCLCHECK` and `CUDACHECK`
+macros that immediately exit on any failure. In production code, consider more
+graceful error handling and recovery mechanisms.
+
+## Next Steps
+
+After understanding AllReduce, explore:
+- **Point-to-point communication**: Examples in `02_point_to_point/`
+- **Other collectives**: Implement Broadcast, Reduce, AllGather operations using
+  this example
+- **Multi-node approach**: Use the MPI implementation from `01_communicators` to
+  send data across nodes.
+

--- a/projects/rccl/examples/03_collectives/01_allreduce/README.md
+++ b/projects/rccl/examples/03_collectives/01_allreduce/README.md
@@ -34,7 +34,7 @@ sum using `ncclCommInitAll` for simplified setup.
 ### Build the Example
 ```bash
 cd examples/03_collectives/01_allreduce
-make [NCCL_HOME=<path-to-nccl>] [CUDA_HOME=<path-to-cuda>]
+make [ROCM_PATH=<path-to-rocm>] [RCCL_HOME=<path-to-rccl>]
 ```
 
 ### Run with All Available GPUs
@@ -44,7 +44,7 @@ make [NCCL_HOME=<path-to-nccl>] [CUDA_HOME=<path-to-cuda>]
 
 ### Run with Specific GPUs
 ```bash
-CUDA_VISIBLE_DEVICES=0,1,2,3 ./allreduce
+HIP_VISIBLE_DEVICES=0,1,2,3 ./allreduce
 ```
 
 ## Code Walk-through
@@ -57,12 +57,12 @@ float rank_value = (float)i;
 size_t size; // size is the number of float to be sent
 
 // Allocate device memory for send buffers
-CUDACHECK(cudaMalloc((void **)&sendbuff[i], size * sizeof(float)));
+CUDACHECK(hipMalloc((void **)&sendbuff[i], size * sizeof(float)));
 
 // Each GPU contributes its rank (GPU i contributes value i)
 // Zero the entire buffer, then set first element to rank
-CUDACHECK(cudaMemset(sendbuff[i], 0, size * sizeof(float)));
-CUDACHECK(cudaMemcpy(sendbuff[i], &rank_value, sizeof(float), cudaMemcpyHostToDevice));
+CUDACHECK(hipMemset(sendbuff[i], 0, size * sizeof(float)));
+CUDACHECK(hipMemcpy(sendbuff[i], &rank_value, sizeof(float), hipMemcpyHostToDevice));
 ```
 
 ### AllReduce Operation
@@ -70,10 +70,10 @@ All GPUs participate in the sum reduction. The operations are evaluated in paral
 ```cpp
 float** recvbuff;
 ncclComm_t *comms;  // comms are set during ncclCommInitAll
-cudaStream_t *streams; // streams are set in cudaStreamCreate
+hipStream_t *streams; // streams are set in hipStreamCreate
 
 // Allocate device memory for receive buffers
-CUDACHECK(cudaMalloc((void **)&recvbuff[i], size * sizeof(float)));
+CUDACHECK(hipMalloc((void **)&recvbuff[i], size * sizeof(float)));
 
 NCCLCHECK(ncclGroupStart());
 for (int i = 0; i < num_gpus; i++) {
@@ -114,7 +114,7 @@ Example completed successfully!
 ## Key Insights
 - `ncclCommInitAll` simplifies single-node multi-GPU setup
 - No MPI or pthreads needed for single-node patterns
-- Allocate device buffer via ``cudaMalloc` and initialize via `cudaMemset`.
+- Allocate device buffer via `hipMalloc` and initialize via `hipMemset`.
 - Best practices to wrap all collective calls in ncclGroupStart/End
 - All communication happens in parallel
 

--- a/projects/rccl/examples/03_collectives/01_allreduce/main.cc
+++ b/projects/rccl/examples/03_collectives/01_allreduce/main.cc
@@ -1,0 +1,203 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See LICENSE.txt for more license information
+ *************************************************************************/
+
+#include "hip/hip_runtime.h"
+#include <rccl/rccl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+/*
+ * NCCL AllReduce Example - Collective Communication
+ *
+ * This example demonstrates the fundamental AllReduce collective operation
+ * using NCCL's single-process, multi-GPU approach. AllReduce is one of the most
+ * important collective operations in distributed and parallel computing.
+ *
+ * Learning Objectives:
+ * - Understand AllReduce collective communication pattern
+ * - Learn NCCL single-process multi-GPU programming model
+ * - See how data reduction works across multiple devices
+ * - Practice verification and validation of collective results
+ *
+ */
+
+// Enhanced error checking macro for NCCL operations
+// Provides detailed error information including the failed operation
+#define NCCLCHECK(cmd)                                                         \
+  do {                                                                         \
+    ncclResult_t res = cmd;                                                    \
+    if (res != ncclSuccess) {                                                  \
+      fprintf(stderr, "Failed, NCCL error %s:%d '%s'\n", __FILE__, __LINE__,   \
+              ncclGetErrorString(res));                                        \
+      fprintf(stderr, "Failed NCCL operation: %s\n", #cmd);                    \
+      exit(EXIT_FAILURE);                                                      \
+    }                                                                          \
+  } while (0)
+
+#define CUDACHECK(cmd)                                                         \
+  do {                                                                         \
+    hipError_t err = cmd;                                                     \
+    if (err != hipSuccess) {                                                  \
+      fprintf(stderr, "Failed: Cuda error %s:%d '%s'\n", __FILE__, __LINE__,   \
+              hipGetErrorString(err));                                        \
+      fprintf(stderr, "Failed CUDA operation: %s\n", #cmd);                    \
+      exit(EXIT_FAILURE);                                                      \
+    }                                                                          \
+  } while (0)
+
+int main(int argc, char *argv[]) {
+  // ========================================================================
+  // STEP 1: Initialize Variables and Detect Available GPUs
+  // ========================================================================
+
+  int num_gpus = 0;
+  ncclComm_t *comms;
+  hipStream_t *streams;
+  float **sendbuff;
+  float **recvbuff;
+
+  // Get number of CUDA devices
+  CUDACHECK(hipGetDeviceCount(&num_gpus));
+  if (num_gpus < 1) {
+    printf("No CUDA devices found\n");
+    return EXIT_FAILURE;
+  }
+
+  printf("Using %d devices for collective communication\n", num_gpus);
+
+  // ========================================================================
+  // STEP 2: Allocate Memory for Communicators, Streams, and Data Buffers
+  // ========================================================================
+
+  // Allocate arrays for per-device resources, and array of pointers for buffers
+  comms = (ncclComm_t *)malloc(num_gpus * sizeof(ncclComm_t));
+  streams = (hipStream_t *)malloc(num_gpus * sizeof(hipStream_t));
+  sendbuff = (float **)malloc(num_gpus * sizeof(float *));
+  recvbuff = (float **)malloc(num_gpus * sizeof(float *));
+
+  printf("Memory allocated for %d communicators and streams\n", num_gpus);
+
+  // ========================================================================
+  // STEP 3: Initialize NCCL Communicators for All Devices
+  // ========================================================================
+
+  // ncclCommInitAll creates communicators for all devices in one call
+  // This is the simplest way to set up NCCL for single-process applications
+  NCCLCHECK(ncclCommInitAll(comms, num_gpus, NULL));
+  printf("NCCL communicators initialized for all devices\n");
+
+  // ========================================================================
+  // STEP 4: Create CUDA Streams and Allocate Device Memory
+  // ========================================================================
+
+  const size_t size = 32 * 1024 * 1024; // 32M floats for demonstration
+
+  for (int i = 0; i < num_gpus; i++) {
+    // Set device context for each GPU
+    CUDACHECK(hipSetDevice(i));
+
+    // Create stream for asynchronous operations
+    CUDACHECK(hipStreamCreate(&streams[i]));
+
+    // Allocate device memory for send and receive buffers
+    CUDACHECK(hipMalloc((void **)&sendbuff[i], size * sizeof(float)));
+    CUDACHECK(hipMalloc((void **)&recvbuff[i], size * sizeof(float)));
+
+    // Initialize send buffer: zero the entire buffer, then set first element to
+    // rank
+    CUDACHECK(hipMemset(sendbuff[i], 0, size * sizeof(float)));
+    float rank_value = (float)i;
+    CUDACHECK(hipMemcpy(sendbuff[i], &rank_value, sizeof(float),
+                         hipMemcpyHostToDevice));
+
+    printf("  Device %d initialized with data value %d\n", i, i);
+  }
+
+  // ========================================================================
+  // STEP 5: Perform AllReduce Sum Operation
+  // ========================================================================
+
+  printf("Starting collective sum operation across all devices\n");
+
+  // NOTE: ncclGroupStart and ncclGroupEnd are essential to avoid
+  // deadlock when using ncclCommInitAll and multiple communication calls.
+  NCCLCHECK(ncclGroupStart());
+  for (int i = 0; i < num_gpus; i++) {
+    // Each device performs combines all contributions and distributes result
+    NCCLCHECK(ncclAllReduce(sendbuff[i], recvbuff[i], size, ncclFloat, ncclSum,
+                            comms[i], streams[i]));
+  }
+  NCCLCHECK(ncclGroupEnd());
+
+  // Synchronize all streams to ensure completion
+  for (int i = 0; i < num_gpus; i++) {
+    CUDACHECK(hipSetDevice(i));
+    CUDACHECK(hipStreamSynchronize(streams[i]));
+  }
+
+  printf("Collective operation completed\n");
+
+  // ========================================================================
+  // STEP 6: Verify Results and Validate Correctness
+  // ========================================================================
+
+  // Expected result: sum of all ranks = 0 + 1 + 2 + ... + (num_gpus-1)
+  // Note: We only check the first element since that's all we initialized
+  float expected = (float)(num_gpus * (num_gpus - 1) / 2);
+  printf("Verifying results (expected sum: %.0f)\n", expected);
+
+  bool success = true;
+  for (int i = 0; i < num_gpus; i++) {
+    float result;
+    CUDACHECK(hipSetDevice(i));
+    CUDACHECK(hipMemcpy(&result, recvbuff[i], sizeof(float),
+                         hipMemcpyDeviceToHost));
+
+    if (result != expected) {
+      printf("  Device %d received incorrect result: %.0f (expected %.0f)\n", i,
+             result, expected);
+      success = false;
+    } else {
+      printf("  Device %d correctly received sum: %.0f\n", i, result);
+    }
+  }
+
+  // ========================================================================
+  // STEP 7: Cleanup Resources and Report Results
+  // ========================================================================
+
+  // Destroy NCCL communicators
+  for (int i = 0; i < num_gpus; i++) {
+    NCCLCHECK(ncclCommFinalize(comms[i]));
+    NCCLCHECK(ncclCommDestroy(comms[i]));
+  }
+
+  // Free device memory and destroy streams
+  for (int i = 0; i < num_gpus; i++) {
+    CUDACHECK(hipSetDevice(i));
+    CUDACHECK(hipFree(sendbuff[i]));
+    CUDACHECK(hipFree(recvbuff[i]));
+    CUDACHECK(hipStreamDestroy(streams[i]));
+  }
+
+  // Free host memory
+  free(comms);
+  free(streams);
+  free(sendbuff);
+  free(recvbuff);
+
+  if (success) {
+    printf("Example completed successfully!\n");
+  } else {
+    printf("Example failed - incorrect results detected\n");
+    return EXIT_FAILURE;
+  }
+
+  return 0;
+}

--- a/projects/rccl/examples/03_collectives/Makefile
+++ b/projects/rccl/examples/03_collectives/Makefile
@@ -1,0 +1,48 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# See LICENSE.txt for more license information
+#
+
+# NCCL Collective Examples
+EXAMPLES = 01_allreduce
+
+# Default target
+all: $(EXAMPLES)
+
+# Build individual examples
+$(EXAMPLES):
+	$(MAKE) -C $@
+
+# Clean all build artifacts
+clean:
+	for example in $(EXAMPLES); do \
+		$(MAKE) -C $$example clean; \
+	done
+
+# Test all examples
+test: all
+	for example in $(EXAMPLES); do \
+		echo "Testing $$example..."; \
+		$(MAKE) -C $$example test; \
+	done
+
+# Help
+help:
+	@echo "NCCL Collective Communication Examples"
+	@echo "====================================="
+	@echo ""
+	@echo "Targets:"
+	@echo "  all     - Build all examples"
+	@echo "  clean   - Clean all build artifacts"
+	@echo "  test    - Test all examples"
+	@echo "  help    - Show this help"
+	@echo ""
+	@echo "Examples:"
+	@echo "  01_allreduce - AllReduce collective operation"
+	@echo ""
+	@echo "To build/run individual examples:"
+	@echo "  make -C 01_allreduce"
+
+.PHONY: all clean test help $(EXAMPLES)

--- a/projects/rccl/examples/03_collectives/README.md
+++ b/projects/rccl/examples/03_collectives/README.md
@@ -1,0 +1,71 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+
+  See LICENSE.txt for more license information
+-->
+
+# NCCL Collective Communication Examples
+
+## Overview
+This directory contains minimal examples that demonstrate NCCL collective
+communication operations on a single node using a single process managing all
+GPUs. The focus is clarity, correct resource management, and result
+verification.
+
+## Examples
+
+### [01_allreduce](01_allreduce/)
+**AllReduce Collective Operation**
+- **Pattern**: All participants reduce and distribute the result
+- **API**: `ncclCommInitAll`, `ncclAllReduce`
+- **Use case**: Global reductions in ML and HPC (e.g., gradient averaging)
+- **Key features**:
+  - Initializes all GPUs in a single process
+  - Each GPU contributes its rank value
+  - Executes AllReduce sum across all GPUs
+  - Verifies the expected global sum
+
+## Choosing the Right Pattern
+
+*Scenario* : Parallel training needs efficient global communication
+*Addresses* : Most commonly used collective algorithms
+*Dependencies* : A functional NCCL library and its dependencies
+
+### Why `ncclCommInitAll` here?
+For single-node collective examples we use `ncclCommInitAll` as it creates a
+clique of communicators in one call.
+
+```c
+// Initialize all GPUs in one call
+ncclComm_t* comms;
+int num_gpus;
+NCCLCHECK(ncclCommInitAll(comms, num_gpus, NULL));
+```
+
+A more advanced setup using MPI to initialize communicators across multiple
+nodes is shown in
+[01_communicators/03_one_device_per_process_mpi](../01_communicators/03_one_device_per_process_mpi)
+
+## Building
+
+### **Quick Start**
+```shell
+# Build example by directory name
+make 01_allreduce
+```
+
+### **Individual Examples**
+```shell
+# Build and run AllReduce
+cd 01_allreduce && make
+./allreduce
+```
+
+## References
+- [NCCL User Guide:
+  Examples](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/examples.html)
+- [NCCL API
+  Reference](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api.html)
+- [HIP Programming
+  Guide](https://docs.nvidia.com/cuda/cuda-c-programming-guide/)

--- a/projects/rccl/examples/04_user_buffer_registration/01_allreduce/Makefile
+++ b/projects/rccl/examples/04_user_buffer_registration/01_allreduce/Makefile
@@ -1,0 +1,77 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# See LICENSE.txt for more license information
+#
+
+# Include common build rules
+include ../../makefiles/rccl_examples.mk
+
+# Target executable
+TARGET = allreduce_ub
+
+# Common utilities
+COMMON_INC = ../../common/include
+COMMON_SRC = ../../common/src
+
+# Build configuration
+INCLUDES += -I$(COMMON_INC)
+
+# Source files
+SOURCES = main.cc $(COMMON_SRC)/utils.cc
+OBJECTS = $(SOURCES:.cc=.o)
+
+# Default target
+all: $(TARGET)
+
+# Build executable
+$(TARGET): $(OBJECTS)
+ifeq ($(MPI),1)
+	$(MPICXX) $(CXXFLAGS) $(OBJECTS) $(LIBRARIES) $(LDFLAGS) -o $@
+else
+	$(CXX) $(CXXFLAGS) $(OBJECTS) $(LIBRARIES) $(LDFLAGS) -lpthread -o $@
+endif
+	@echo "Built target $@"
+
+# Compile source files
+%.o: %.cc
+ifeq ($(MPI),1)
+	$(MPICXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
+else
+	$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
+endif
+
+# Test target
+test: $(TARGET)
+	@echo "Testing $(TARGET)..."
+ifeq ($(MPI),1)
+	@echo "Running with 2 processes"
+	$(MPIRUN) -np 2 ./$(TARGET)
+else
+	@echo "Running with all available GPUs"
+	./$(TARGET)
+endif
+
+# Clean build artifacts
+clean:
+	rm -f $(OBJECTS) $(TARGET)
+
+# Install target
+install: $(TARGET)
+	@mkdir -p $(PREFIX)/bin
+	cp $(TARGET) $(PREFIX)/bin/
+
+# Help
+help:
+	@echo "NCCL Example: User Buffer Registration Allreduce"
+	@echo "=============================================="
+	@echo ""
+	@echo "Targets:"
+	@echo "  all       - Build the example (default)"
+	@echo "  test      - Build and run test with all GPUs"
+	@echo "  clean     - Remove build artifacts"
+	@echo "  install   - Install to PREFIX/bin (default: /usr/local/bin)"
+	@echo "  help      - Show this help"
+
+.PHONY: all test clean install help

--- a/projects/rccl/examples/04_user_buffer_registration/01_allreduce/README.md
+++ b/projects/rccl/examples/04_user_buffer_registration/01_allreduce/README.md
@@ -1,0 +1,166 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+
+  See LICENSE.txt for more license information
+-->
+
+# NCCL User Buffer Registration AllReduce Example
+
+This example demonstrates how to use NCCL's user buffer registration feature to
+optimize performance for repeated collective operations on the same buffers.
+User Buffer Registration is a feature that allows NCCL to directly
+send/receive/operate data through the user buffer without extra internal copy
+(zero-copy).
+
+## Overview
+
+User buffer registration allows NCCL to pre-register memory buffers with
+communicators, eliminating registration overhead on each operation. This is
+particularly beneficial for applications that repeatedly perform collective
+operations on the same memory regions, such as iterative training loops.
+
+## What This Example Does
+
+1. **Allocates memory using NCCL allocator** (`ncclMemAlloc`) which is provided
+   by NCCL as convenience function
+2. **Registers buffers with communicator** using `ncclCommRegister` for
+   optimized performance
+3. **Performs AllReduce sum operation** using the registered buffers for
+   efficient communication
+
+## Building and Running
+
+The advanced examples can be built using either pthread or MPI for
+parallelization. pthread is the default choice. To use MPI the user needs to
+provide a valid MPI installation under `MPI_HOME`.
+
+### Build
+```shell
+make [MPI=1] [MPI_HOME=<path-to-mpi>] [NCCL_HOME=<path-to-nccl>] [CUDA_HOME=<path-to-cuda>]
+```
+
+### Run when compiled for pthreads (default)
+```shell
+[NTHREADS=N] ./allreduce_ub
+```
+
+### Run when compiled for MPI
+```shell
+mpirun -np <num_processes> ./allreduce_ub
+```
+
+## Code Structure
+
+### Key Components
+
+1. **Buffer Allocation and Registration**:
+```c
+size_t size_bytes; // Is set to the size of the send/receive buffers
+void *d_sendbuff;
+void *d_recvbuff;
+
+// Allocate buffers using ncclMemAlloc (or another qualified allocator) on the device
+NCCLCHECK(ncclMemAlloc(&d_sendbuff, size_bytes));
+NCCLCHECK(ncclMemAlloc(&d_recvbuff, size_bytes));
+
+ncclComm_t comm;   // comms is set during ncclCommInitRank
+void *send_handle;
+void *recv_handle;
+
+// Register buffers with NCCL, handle is returned for De-registration
+NCCLCHECK(ncclCommRegister(comm, d_sendbuff, size_bytes, &send_handle));
+NCCLCHECK(ncclCommRegister(comm, d_recvbuff, size_bytes, &recv_handle));
+```
+
+2. **AllReduce with Group Operations**:
+```c
+size_t count;  // set to number of floats to exchange
+cudaStream_t stream; // stream is set in cudaStreamCreate
+
+NCCLCHECK(ncclAllReduce(d_sendbuff, d_recvbuff, count, ncclFloat, ncclSum,
+                        comm, stream));
+```
+
+3. **Buffer Deregistration and Cleanup**:
+```c
+// Deregister buffers using handle from ncclCommRegister
+NCCLCHECK(ncclCommDeregister(comm, send_handle));
+NCCLCHECK(ncclCommDeregister(comm, recv_handle));
+
+// Free buffers allocated with ncclMemAlloc
+NCCLCHECK(ncclMemFree(d_sendbuff));
+NCCLCHECK(ncclMemFree(d_recvbuff));
+
+```
+
+## Expected Output
+
+### With 4 GPUs (using pthreads/MPI)
+```
+Starting AllReduce example with 4 ranks
+  Rank 0 communicator initialized using device 0
+  Rank 1 communicator initialized using device 1
+  Rank 2 communicator initialized using device 2
+  Rank 3 communicator initialized using device 3
+User Buffer allocation:
+  Rank 0 allocating 4.00 MB per buffer
+  Rank 1 allocating 4.00 MB per buffer
+  Rank 2 allocating 4.00 MB per buffer
+  Rank 3 allocating 4.00 MB per buffer
+  Rank 0 data initialized (value: 0)
+  Rank 1 data initialized (value: 1)
+  Rank 2 data initialized (value: 2)
+  Rank 3 data initialized (value: 3)
+Starting AllReduce with 1048576 elements (4 MB)
+AllReduce completed successfully
+Verification - Expected: 6.0, Got: 6.0
+Results verified correctly
+  Rank 0 buffers deregistered
+  Rank 1 buffers deregistered
+  Rank 2 buffers deregistered
+  Rank 3 buffers deregistered
+All resources cleaned up successfully
+```
+
+## Performance Benefits of User Buffer Registration
+
+User buffer registration provides several performance advantages:
+
+1. **Reduced Overhead**: Pre-registration eliminates the need to
+   register/deregister buffers for each operation
+2. **Better Memory Pinning**: Registered buffers are pinned in memory,
+   preventing page faults
+3. **Lower Latency**: Especially beneficial for repeated operations on the same
+   buffers
+
+**Important**: Buffers must be allocated with `ncclMemAlloc` or a compatible
+allocator for registration to work. See The [General Buffer Registration
+](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/bufferreg.html#general-buffer-registration)
+section of the user guide.
+
+**Important**: If any rank in a communicator passes registered buffers to a NCCL
+communication function, all other ranks in the same communicator must pass their
+registered buffers; otherwise, mixing registered and non-registered buffers can
+result in undefined behavior.
+
+## Key Insights
+
+- **User Buffer Registration** is most beneficial for:
+  - Large data transfers
+  - Repeated operations on the same buffers
+  - Performance-critical applications
+- **Memory management** is critical - always deregister buffers before freeing
+
+## Common Issues and Solutions
+
+1. **Registration Failure**: Buffers MUST be allocated with `ncclMemAlloc` or
+   another qualified allocator (not `cudaMalloc`) for registration. See [Buffer
+   Registration](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/bufferreg.html)
+   section for details.
+2. **Allocation Error**: If `ncclMemAlloc` fails, check NCCL version (requires
+   2.19.x+) and available memory
+3. **Deregistration Order**: Always deregister before freeing memory
+4. **Handle Management**: Keep track of registration handles for proper cleanup
+5. **Memory Leaks**: Always use `ncclMemFree` for buffers allocated with
+   `ncclMemAlloc`

--- a/projects/rccl/examples/04_user_buffer_registration/01_allreduce/main.cc
+++ b/projects/rccl/examples/04_user_buffer_registration/01_allreduce/main.cc
@@ -1,0 +1,215 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See LICENSE.txt for more license information
+ *************************************************************************/
+
+#include "hip/hip_runtime.h"
+#include <rccl/rccl.h>
+#include "utils.h"
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+/*
+ * NCCL User Buffer Registration AllReduce Example
+ *
+ * This example demonstrates how to use NCCL's user buffer registration feature
+ * to optimize performance for repeated collective operations on the same
+ * buffers.
+ *
+ * Learning Objectives:
+ * - Learn how to register and deregister buffers with NCCL communicators
+ * - See the proper lifecycle management of registered buffers
+ *
+ */
+
+/*
+ * This function can be called inside an MPI rank or pthread thread. The
+ * initialization and broadcast are implemented in common/src/utils.cc for
+ * easier readability. For fully integrated examples using pthreads or MPI see
+ * examples in 01_communicators.
+ */
+void *allReduce(int my_rank, int total_ranks, int local_device,
+                int devices_per_rank) {
+
+  // ========================================================================
+  // STEP 1: Initialize NCCL Communicator and Setup
+  // ========================================================================
+
+  ncclUniqueId nccl_unique_id;
+  if (my_rank == 0) {
+    printf("Starting AllReduce example with %d ranks\n", total_ranks);
+    NCCLCHECK(ncclGetUniqueId(&nccl_unique_id));
+  }
+
+  // Distribute unique ID.
+  // This step ensures all ranks have the same unique ID for communicator
+  // creation
+  util_broadcast(0, my_rank, &nccl_unique_id);
+
+  // Set device context for this rank
+  // Each rank manages its assigned GPU device
+  CUDACHECK(hipSetDevice(local_device));
+
+  // Initialize NCCL communicator
+  // This creates the communication context for collective operations
+  ncclComm_t comm;
+  NCCLCHECK(ncclCommInitRank(&comm, total_ranks, nccl_unique_id, my_rank));
+  printf("  Rank %d communicator initialized using device %d\n", my_rank,
+         local_device);
+
+  // ========================================================================
+  // STEP 2: Allocate Memory Using NCCL Allocator
+  // ========================================================================
+
+  if (my_rank == 0) {
+    printf("User Buffer allocation:\n");
+  }
+  // Allocate memory - using larger buffers to demonstrate registration
+  // benefits
+  size_t count = 1024 * 1024; // 1M elements
+  size_t size_bytes = count * sizeof(float);
+
+  printf("  Rank %d allocating %.2f MB per buffer\n", my_rank,
+         (float)size_bytes / (1024 * 1024));
+
+  // Allocate buffers using NCCL allocator
+  // NCCL's allocator can provide optimized memory for communication
+  void *d_sendbuff;
+  void *d_recvbuff;
+  NCCLCHECK(ncclMemAlloc(&d_sendbuff, size_bytes));
+  NCCLCHECK(ncclMemAlloc(&d_recvbuff, size_bytes));
+
+  // ========================================================================
+  // STEP 3: Register Buffers with NCCL Communicator
+  // ========================================================================
+
+  // Register the buffers with NCCL
+  // This is the key optimization - buffers are pre-registered for efficiency
+  // The handles returned can be used to identify registered buffers
+  void *send_handle;
+  void *recv_handle;
+  NCCLCHECK(ncclCommRegister(comm, d_sendbuff, size_bytes, &send_handle));
+  NCCLCHECK(ncclCommRegister(comm, d_recvbuff, size_bytes, &recv_handle));
+
+  // ========================================================================
+  // STEP 4: Initialize Data and Prepare for Communication
+  // ========================================================================
+
+  // Initialize data - each rank contributes its rank value
+  // This creates a simple test pattern for verification
+  float *h_data = (float *)malloc(size_bytes);
+  for (size_t i = 0; i < count; i++) {
+    h_data[i] = (float)my_rank;
+  }
+  CUDACHECK(hipMemcpy(d_sendbuff, h_data, size_bytes, hipMemcpyHostToDevice));
+  printf("  Rank %d data initialized (value: %d)\n", my_rank, my_rank);
+
+  // Create stream for asynchronous operations
+  // Streams allow overlapping computation and communication
+  hipStream_t stream;
+  CUDACHECK(hipStreamCreate(&stream));
+
+  // ========================================================================
+  // STEP 5: Perform AllReduce Operation
+  // ========================================================================
+
+  if (my_rank == 0) {
+    printf("Starting AllReduce with %zu elements (%zu MB)\n", count,
+           size_bytes / (1024 * 1024));
+  }
+
+  // Perform AllReduce operation
+  // Since buffers are registered, this should have optimized performance
+  NCCLCHECK(ncclAllReduce(d_sendbuff, d_recvbuff, count, ncclFloat, ncclSum,
+                          comm, stream));
+
+  if (my_rank == 0) {
+    printf("AllReduce completed successfully\n");
+  }
+
+  // ========================================================================
+  // STEP 6: Verify Results and Validate Correctness
+  // ========================================================================
+
+  // Synchronize to ensure completion
+  CUDACHECK(hipStreamSynchronize(stream));
+
+  // Verify results (optional - copy back and check a few elements)
+  float *h_result = (float *)malloc(sizeof(float) * count);
+  CUDACHECK(hipMemcpy(h_result, d_recvbuff, sizeof(float) * count,
+                       hipMemcpyDeviceToHost));
+
+  // Each element should be the sum of all ranks
+  float expected_sum = (float)(total_ranks * (total_ranks - 1)) / 2;
+  bool all_ok = true;
+  if (my_rank == 0) {
+    printf("Verification - Expected: %.1f, Got: %.1f\n", expected_sum,
+           h_result[0]);
+
+    for (size_t i = 1; i < count; i++) {
+      if (fabsf(h_result[i] - expected_sum) > 0.001) {
+        printf(" Results verification failed at index %zu: Expected %.1f, Got "
+               "%.1f\n",
+               i, expected_sum, h_result[i]);
+        all_ok = false;
+        break;
+      }
+    }
+
+    if (all_ok) {
+      printf("Results verified correctly\n");
+    } else {
+      printf("Results verification failed\n");
+    }
+  }
+
+  // ========================================================================
+  // STEP 7: Cleanup and Resource Management
+  // ========================================================================
+
+  // Important: Cleanup must happen in the correct order
+  // 1. Free host memory
+  // 2. Deregister buffers from communicator
+  // 3. Free device memory
+  // 4. Destroy CUDA resources
+  // 5. Finalize and destroy NCCL communicator
+
+  free(h_data);
+  free(h_result);
+
+  // Deregister buffers from communicator
+  // This must happen before freeing the buffers or destroying the
+  // communicator
+  NCCLCHECK(ncclCommDeregister(comm, send_handle));
+  NCCLCHECK(ncclCommDeregister(comm, recv_handle));
+  printf("  Rank %d buffers deregistered\n", my_rank);
+
+  // Free device memory allocated by NCCL
+  NCCLCHECK(ncclMemFree(d_sendbuff));
+  NCCLCHECK(ncclMemFree(d_recvbuff));
+
+  // Finalize and destroy NCCL communicator
+  NCCLCHECK(ncclCommFinalize(comm));
+  NCCLCHECK(ncclCommDestroy(comm));
+
+  // Destroy CUDA stream
+  CUDACHECK(hipStreamDestroy(stream));
+
+  if (my_rank == 0) {
+    printf("All resources cleaned up successfully\n");
+  }
+
+  return NULL;
+}
+
+int main(int argc, char *argv[]) {
+  // Run example using the standard test framework
+  // This handles MPI/pthread initialization, device assignment, and cleanup
+  return run_example(argc, argv, allReduce);
+}

--- a/projects/rccl/examples/04_user_buffer_registration/Makefile
+++ b/projects/rccl/examples/04_user_buffer_registration/Makefile
@@ -1,0 +1,48 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# See LICENSE.txt for more license information
+#
+
+# NCCL User Buffer Examples
+EXAMPLES = 01_allreduce
+
+# Default target
+all: $(EXAMPLES)
+
+# Build individual examples
+$(EXAMPLES):
+	$(MAKE) -C $@
+
+# Clean all build artifacts
+clean:
+	for example in $(EXAMPLES); do \
+		$(MAKE) -C $$example clean; \
+	done
+
+# Test all examples
+test: all
+	for example in $(EXAMPLES); do \
+		echo "Testing $$example..."; \
+		$(MAKE) -C $$example test; \
+	done
+
+# Help
+help:
+	@echo "NCCL User Buffer Registration Examples"
+	@echo "======================================"
+	@echo ""
+	@echo "Targets:"
+	@echo "  all     - Build all examples"
+	@echo "  clean   - Clean all build artifacts"
+	@echo "  test    - Test all examples"
+	@echo "  help    - Show this help"
+	@echo ""
+	@echo "Examples:"
+	@echo "  01_allreduce - AllReduce collective operation"
+	@echo ""
+	@echo "To build/run individual examples:"
+	@echo "  make -C 01_allreduce"
+
+.PHONY: all clean test help $(EXAMPLES)

--- a/projects/rccl/examples/04_user_buffer_registration/README.md
+++ b/projects/rccl/examples/04_user_buffer_registration/README.md
@@ -1,0 +1,76 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+
+  See LICENSE.txt for more license information
+-->
+
+# NCCL User Buffer Registration Examples
+
+## Overview
+This directory contains minimal examples that demonstrate NCCL user buffer
+registration for improving performance by allowing NCCL to operate directly on
+user-allocated buffers.
+
+## Examples
+
+### [01_allreduce](01_allreduce/)
+**AllReduce with User Buffer Registration**
+- **Pattern**: Register communication buffers once and reuse across operations
+- **API**: `ncclCommRegister`, `ncclCommDeregister`, `ncclMemAlloc`,
+  `ncclAllReduce`
+- **Use case**: Repeated collectives on the same buffers; performance-critical
+  workloads
+- **Key features**:
+  - Buffers allocated via `ncclMemAlloc` for registration compatibility
+  - Registration handles managed explicitly (register → use → deregister)
+  - Collective operations executed on registered buffers
+  - Correct cleanup and verification
+
+## Choosing the Right Pattern
+
+*Scenario* : Optimize performance for repeated collectives on same buffers
+*Addresses* : Throughput-sensitive training loops
+*Dependencies* : pthread or MPI
+
+### Why Buffer Registration?
+Pre-registering buffers eliminates per-call registration overhead and enables
+direct access. It can accelerate collectives and greatly reduce the resource
+usage (e.g. #channel usage). Also, this is a prerequisite for advanced features
+such as symmetric memory or device API calls.
+
+```c
+// Allocate using NCCL convenience function and register buffers
+NCCLCHECK(ncclMemAlloc((void**)&d_send, size_bytes));
+NCCLCHECK(ncclCommRegister(comm, d_send, size_bytes, &send_handle));
+
+// Use in collectives
+NCCLCHECK(ncclAllReduce(d_send, d_recv, count, ncclFloat, ncclSum, comm, stream));
+
+// Deregister and free
+NCCLCHECK(ncclCommDeregister(comm, send_handle));
+NCCLCHECK(ncclMemFree(d_send));
+```
+
+## Building
+
+### **Quick Start**
+```shell
+# Build example by directory name
+make 01_allreduce
+```
+
+### **Individual Examples**
+```shell
+# Build and run AllReduce with user buffer registration
+cd 01_allreduce && make
+./allreduce_ub
+```
+
+## References
+- [NCCL User Guide:
+  Examples](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/examples.html)
+- [NCCL API
+  Reference](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api.html)
+- [HIP Programming
+  Guide](https://docs.nvidia.com/cuda/cuda-c-programming-guide/)

--- a/projects/rccl/examples/05_symmetric_memory/01_allreduce/Makefile
+++ b/projects/rccl/examples/05_symmetric_memory/01_allreduce/Makefile
@@ -1,0 +1,77 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# See LICENSE.txt for more license information
+#
+
+# Include common build rules
+include ../../makefiles/rccl_examples.mk
+
+# Target executable
+TARGET = allreduce_sm
+
+# Common utilities
+COMMON_INC = ../../common/include
+COMMON_SRC = ../../common/src
+
+# Build configuration
+INCLUDES += -I$(COMMON_INC)
+
+# Source files
+SOURCES = main.cc $(COMMON_SRC)/utils.cc
+OBJECTS = $(SOURCES:.cc=.o)
+
+# Default target
+all: $(TARGET)
+
+# Build executable
+$(TARGET): $(OBJECTS)
+ifeq ($(MPI),1)
+	$(MPICXX) $(CXXFLAGS) $(OBJECTS) $(LIBRARIES) $(LDFLAGS) -o $@
+else
+	$(CXX) $(CXXFLAGS) $(OBJECTS) $(LIBRARIES) $(LDFLAGS) -lpthread -o $@
+endif
+	@echo "Built target $@"
+
+# Compile source files
+%.o: %.cc
+ifeq ($(MPI),1)
+	$(MPICXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
+else
+	$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
+endif
+
+# Test target
+test: $(TARGET)
+	@echo "Testing $(TARGET)..."
+ifeq ($(MPI),1)
+	@echo "Running with 2 processes"
+	$(MPIRUN) -np 2 ./$(TARGET)
+else
+	@echo "Running with all available GPUs"
+	./$(TARGET)
+endif
+
+# Clean build artifacts
+clean:
+	rm -f $(OBJECTS) $(TARGET)
+
+# Install target
+install: $(TARGET)
+	@mkdir -p $(PREFIX)/bin
+	cp $(TARGET) $(PREFIX)/bin/
+
+# Help
+help:
+	@echo "NCCL Example: Symmetric Memeory Allreduce"
+	@echo "=============================================="
+	@echo ""
+	@echo "Targets:"
+	@echo "  all       - Build the example (default)"
+	@echo "  test      - Build and run test with all GPUs"
+	@echo "  clean     - Remove build artifacts"
+	@echo "  install   - Install to PREFIX/bin (default: /usr/local/bin)"
+	@echo "  help      - Show this help"
+
+.PHONY: all test clean install help

--- a/projects/rccl/examples/05_symmetric_memory/01_allreduce/Makefile
+++ b/projects/rccl/examples/05_symmetric_memory/01_allreduce/Makefile
@@ -64,7 +64,7 @@ install: $(TARGET)
 
 # Help
 help:
-	@echo "NCCL Example: Symmetric Memeory Allreduce"
+	@echo "NCCL Example: Symmetric Memory Allreduce"
 	@echo "=============================================="
 	@echo ""
 	@echo "Targets:"

--- a/projects/rccl/examples/05_symmetric_memory/01_allreduce/README.md
+++ b/projects/rccl/examples/05_symmetric_memory/01_allreduce/README.md
@@ -135,7 +135,7 @@ Symmetric memory registration provides several performance advantages:
 
 For more information on the performance benefits see the [Enabling Fast
 Inference and Resilient Training with NCCL
-2.27]()https://developer.nvidia.com/blog/enabling-fast-inference-and-resilient-training-with-nccl-2-27/)
+2.27](https://developer.nvidia.com/blog/enabling-fast-inference-and-resilient-training-with-nccl-2-27/)
 blog.
 
 **Important**: Buffers must be allocated using the HIP Virtual Memory

--- a/projects/rccl/examples/05_symmetric_memory/01_allreduce/README.md
+++ b/projects/rccl/examples/05_symmetric_memory/01_allreduce/README.md
@@ -1,0 +1,168 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+
+  See LICENSE.txt for more license information
+-->
+
+# NCCL Symmetric Memory AllReduce Example
+
+This example demonstrates how to use NCCL's symmetric memory feature for
+optimized collective operations. Symmetric memory provides optimized performance
+by leveraging consistent memory layouts across all participating ranks, enabling
+advanced communication algorithms.
+
+## Overview
+
+Symmetric memory windows provide a way to register memory buffers that benefit
+from optimized collective operations. When using `NCCL_WIN_COLL_SYMMETRIC`, all
+ranks must provide symmetric buffers, enabling optimized communication patterns
+and better performance for large-scale multi-GPU operations.
+
+## What This Example Does
+
+1. **Allocates memory using NCCL allocator** (`ncclMemAlloc`) which provides
+   memory compatible with symmetric windows
+2. **Registers buffers as symmetric windows** using `ncclCommWindowRegister`
+   with `NCCL_WIN_COLL_SYMMETRIC` flag
+3. **Performs AllReduce sum operation** using the symmetric memory for optimized
+   communication performance
+
+## Building and Running
+
+The advanced examples can be built using either pthread or MPI for
+parallelization. pthread is the default choice. To use MPI the user needs to set
+`MPI=1` at build time and can optionally provide a valid MPI installation under
+`MPI_HOME`.
+
+### Build
+```shell
+make [MPI=1] [MPI_HOME=<path-to-mpi>] [NCCL_HOME=<path-to-nccl>] [CUDA_HOME=<path-to-cuda>]
+```
+
+### Run when compiled for pthreads (default)
+```shell
+[NTHREADS=N] ./allreduce_sm
+```
+
+### Run when compiled for MPI
+```shell
+mpirun -np <num_processes> ./allreduce_sm
+```
+
+## Code Structure
+
+### Key Components
+
+1. **Buffer Allocation and Window Registration**:
+```c
+size_t size_bytes; // Is set to the size of the send/receive buffers
+void *d_sendbuff;
+void *d_recvbuff;
+
+// Allocate buffers using ncclMemAlloc (compatible with symmetric memory)
+NCCLCHECK(ncclMemAlloc(&d_sendbuff, size_bytes));
+NCCLCHECK(ncclMemAlloc(&d_recvbuff, size_bytes));
+
+ncclComm_t comm;
+ncclWindow_t send_win;
+ncclWindow_t recv_win;
+
+// Register buffers as symmetric windows
+NCCLCHECK(ncclCommWindowRegister(comm, d_sendbuff, size_bytes, &send_win, NCCL_WIN_COLL_SYMMETRIC));
+NCCLCHECK(ncclCommWindowRegister(comm, d_recvbuff, size_bytes, &recv_win, NCCL_WIN_COLL_SYMMETRIC));
+```
+
+2. **AllReduce Operation**:
+```c
+size_t count;  // set to number of floats to exchange
+cudaStream_t stream; // stream is set in cudaStreamCreate
+
+// Perform AllReduce with symmetric memory optimization
+NCCLCHECK(ncclAllReduce(d_sendbuff, d_recvbuff, count, ncclFloat, ncclSum,
+                        comm, stream));
+```
+
+3. **Window Deregistration and Cleanup**:
+```c
+// Deregister symmetric memory windows
+NCCLCHECK(ncclCommWindowDeregister(comm, send_win));
+NCCLCHECK(ncclCommWindowDeregister(comm, recv_win));
+
+// Free buffers allocated with ncclMemAlloc
+NCCLCHECK(ncclMemFree(d_sendbuff));
+NCCLCHECK(ncclMemFree(d_recvbuff));
+```
+
+## Expected Output
+
+### With 4 GPUs (using pthreads/MPI)
+```
+Starting AllReduce example with 4 ranks
+  Rank 0 communicator initialized using device 0
+  Rank 1 communicator initialized using device 1
+  Rank 2 communicator initialized using device 2
+  Rank 3 communicator initialized using device 3
+Symmetric Memory allocation
+  Rank 0 allocating 4.00 MB per buffer
+  Rank 1 allocating 4.00 MB per buffer
+  Rank 2 allocating 4.00 MB per buffer
+  Rank 3 allocating 4.00 MB per buffer
+  Rank 0 data initialized (value: 0)
+  Rank 1 data initialized (value: 1)
+  Rank 2 data initialized (value: 2)
+  Rank 3 data initialized (value: 3)
+Starting AllReduce with 1048576 elements (4 MB)
+AllReduce completed successfully
+Verification - Expected: 6.0, Got: 6.0
+Results verified correctly
+  Rank 0 symmetric memory windows deregistered
+  Rank 1 symmetric memory windows deregistered
+  Rank 2 symmetric memory windows deregistered
+  Rank 3 symmetric memory windows deregistered
+All resources cleaned up successfully
+Example completed - demonstrated symmetric memory lifecycle
+```
+
+## Performance Benefits of Symmetric Memory
+
+Symmetric memory registration provides several performance advantages:
+
+- **Optimized Communication Algorithms**: NCCL can apply advanced optimizations
+  when all ranks have symmetric layouts
+- **Better Memory Access Patterns**: Consistent layouts enable better caching
+  and memory access optimization
+
+For more information on the performance benefits see the [Enabling Fast
+Inference and Resilient Training with NCCL
+2.27]()https://developer.nvidia.com/blog/enabling-fast-inference-and-resilient-training-with-nccl-2-27/)
+blog.
+
+**Important**: Buffers must be allocated using the HIP Virtual Memory
+Management (VMM) API. NCCL provides the `ncclMemAlloc` convenience function for
+symmetric memory registration. The `NCCL_WIN_COLL_SYMMETRIC` flag requires all
+ranks to provide symmetric buffers consistently.
+
+## Key Insights
+
+- **Symmetric Memory Windows** are most beneficial for:
+  - Large-scale collective operations with consistent memory patterns
+  - Latency-sensitive kernels
+  - Applications with predictable allocation patterns
+- **ncclCommInitRank** can be used for pthread or MPI parallel case
+- **Window registration** must happen on all ranks for collective operations
+- **Memory management** is critical - always deregister windows before freeing
+  memory
+
+## Common Issues and Solutions
+
+1. **Window Registration Failure**: Buffers MUST be allocated with (VMM) API,
+   e.g. `ncclMemAlloc` (not `cudaMalloc`) for symmetric memory.
+2. **Allocation Error**: If `ncclMemAlloc` fails, check NCCL version (requires
+   at least v2.27) and available memory
+3. **Deregistration Order**: Always deregister windows before freeing memory or
+   destroying communicators
+4. **Symmetric Requirement**: All ranks must use `NCCL_WIN_COLL_SYMMETRIC`
+   consistently in collective operations
+5. **Memory Leaks**: Always use `ncclMemFree` for buffers allocated with
+   `ncclMemAlloc`

--- a/projects/rccl/examples/05_symmetric_memory/01_allreduce/main.cc
+++ b/projects/rccl/examples/05_symmetric_memory/01_allreduce/main.cc
@@ -1,0 +1,221 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See LICENSE.txt for more license information
+ *************************************************************************/
+
+#include "hip/hip_runtime.h"
+#include <rccl/rccl.h>
+#include "utils.h"
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+/*
+ * NCCL Symmetric Memory AllReduce Example
+ *
+ * This example demonstrates how to use NCCL's symmetric memory feature
+ * for collective operations. Symmetric memory provides optimized performance
+ * by leveraging consistent memory layouts across all participating ranks.
+ *
+ * Learning Objectives:
+ * - Learn how to register symmetric memory windows with NCCL communicators
+ * - See the proper lifecycle management of symmetric memory
+ *
+ */
+
+/*
+ * This function can be called inside an MPI rank or pthread thread. The
+ * initialization and broadcast are implemented in common/src/utils.cc for
+ * easier readability. For fully integrated examples using pthreads or MPI see
+ * examples in 01_communicators.
+ */
+void *allReduce(int my_rank, int total_ranks, int local_device,
+                int devices_per_rank) {
+
+  // ========================================================================
+  // STEP 1: Initialize NCCL Communicator and Setup
+  // ========================================================================
+
+  ncclUniqueId nccl_unique_id;
+  if (my_rank == 0) {
+    printf("Starting AllReduce example with %d ranks\n", total_ranks);
+    NCCLCHECK(ncclGetUniqueId(&nccl_unique_id));
+  }
+
+  // Distribute unique ID.
+  // This step ensures all ranks have the same unique ID for communicator
+  // creation
+  util_broadcast(0, my_rank, &nccl_unique_id);
+
+  // Set device context for this rank
+  // Each rank manages its assigned GPU device
+  CUDACHECK(hipSetDevice(local_device));
+
+  // Initialize NCCL communicator
+  // This creates the communication context for collective operations
+  ncclComm_t comm;
+  NCCLCHECK(ncclCommInitRank(&comm, total_ranks, nccl_unique_id, my_rank));
+  printf("  Rank %d communicator initialized using device %d\n", my_rank,
+         local_device);
+
+  // ========================================================================
+  // STEP 2: Allocate Memory Using NCCL Allocator
+  // ========================================================================
+
+  if (my_rank == 0) {
+    printf("Symmetric Memory allocation\n");
+  }
+  // Allocate memory - using larger buffers to demonstrate symmetric memory
+  // benefits
+  size_t count = 1024 * 1024; // 1M elements
+  size_t size_bytes = count * sizeof(float);
+
+  printf("  Rank %d allocating %.2f MB per buffer\n", my_rank,
+         (float)size_bytes / (1024 * 1024));
+
+  float *h_data = (float *)malloc(size_bytes);
+
+  // Allocate buffers using NCCL allocator
+  // NCCL's allocator is compatible with symmetric memory layouts
+  void *d_sendbuff;
+  void *d_recvbuff;
+  NCCLCHECK(ncclMemAlloc(&d_sendbuff, size_bytes));
+  NCCLCHECK(ncclMemAlloc(&d_recvbuff, size_bytes));
+
+  // ========================================================================
+  // STEP 3: Register Symmetric Memory Windows
+  // ========================================================================
+
+  /* Passing NCCL_WIN_COLL_SYMMETRIC requires users to provide the symmetric
+   * buffers among all ranks in collectives.
+   * Every rank needs to call ncclCommWindowRegister to register its buffers.
+   */
+
+  // Register symmetric memory windows with NCCL
+  ncclWindow_t send_win;
+  ncclWindow_t recv_win;
+  NCCLCHECK(ncclCommWindowRegister(comm, d_sendbuff, size_bytes, &send_win,
+                                   NCCL_WIN_COLL_SYMMETRIC));
+  NCCLCHECK(ncclCommWindowRegister(comm, d_recvbuff, size_bytes, &recv_win,
+                                   NCCL_WIN_COLL_SYMMETRIC));
+
+  // ========================================================================
+  // STEP 4: Initialize Data and Prepare for Communication
+  // ========================================================================
+
+  // Initialize data - each rank contributes its rank value
+  // This creates a simple test pattern for verification
+  for (size_t i = 0; i < count; i++) {
+    h_data[i] = (float)my_rank;
+  }
+  CUDACHECK(hipMemcpy(d_sendbuff, h_data, size_bytes, hipMemcpyHostToDevice));
+  printf("  Rank %d data initialized (value: %d)\n", my_rank, my_rank);
+
+  // Create stream for asynchronous operations
+  // Streams allow overlapping computation and communication
+  hipStream_t stream;
+  CUDACHECK(hipStreamCreate(&stream));
+
+  // ========================================================================
+  // STEP 5: Perform AllReduce Operation
+  // ========================================================================
+
+  if (my_rank == 0) {
+    printf("Starting AllReduce with %zu elements (%zu MB)\n", count,
+           size_bytes / (1024 * 1024));
+  }
+
+  // Perform AllReduce operation
+  // Since symmetric memory is registered, NCCL can apply optimized algorithms
+  NCCLCHECK(ncclAllReduce(d_sendbuff, d_recvbuff, count, ncclFloat, ncclSum,
+                          comm, stream));
+
+  if (my_rank == 0) {
+    printf("AllReduce completed successfully\n");
+  }
+
+  // ========================================================================
+  // STEP 6: Verify Results and Validate Correctness
+  // ========================================================================
+
+  // Synchronize to ensure completion
+  CUDACHECK(hipStreamSynchronize(stream));
+
+  // Verify results (optional - copy back and check)
+  float *h_result = (float *)malloc(size_bytes);
+  CUDACHECK(hipMemcpy(h_result, d_recvbuff, size_bytes,
+                       hipMemcpyDeviceToHost));
+
+  // Each element should be the sum of all ranks
+  float expected_sum = (float)(total_ranks * (total_ranks - 1)) / 2;
+  bool all_ok = true;
+  if (my_rank == 0) {
+    printf("Verification - Expected: %.1f, Got: %.1f\n", expected_sum,
+           h_result[0]);
+
+    for (size_t i = 1; i < count; i++) {
+      if (fabsf(h_result[i] - expected_sum) > 0.001) {
+        printf(" Results verification failed at index %zu: Expected %.1f, Got "
+               "%.1f\n", i, expected_sum, h_result[i]);
+        all_ok = false;
+        break;
+      }
+    }
+
+    if (all_ok) {
+      printf("Results verified correctly\n");
+    } else {
+      printf("Results verification failed\n");
+    }
+  }
+
+  // ========================================================================
+  // STEP 7: Cleanup and Resource Management
+  // ========================================================================
+
+  // Important: Cleanup must happen in the correct order
+  // 1. Free host memory
+  // 2. Deregister symmetric memory windows
+  // 3. Free device memory
+  // 4. Destroy CUDA resources
+  // 5. Finalize and destroy NCCL communicator
+
+  free(h_data);
+  free(h_result);
+
+  // Deregister symmetric memory windows from communicator
+  // This must happen before freeing the buffers or destroying the
+  // communicator
+  NCCLCHECK(ncclCommWindowDeregister(comm, send_win));
+  NCCLCHECK(ncclCommWindowDeregister(comm, recv_win));
+  printf("  Rank %d symmetric memory windows deregistered\n", my_rank);
+
+  // Free device memory allocated by NCCL
+  NCCLCHECK(ncclMemFree(d_sendbuff));
+  NCCLCHECK(ncclMemFree(d_recvbuff));
+
+  // Finalize and destroy NCCL communicator
+  NCCLCHECK(ncclCommFinalize(comm));
+  NCCLCHECK(ncclCommDestroy(comm));
+
+  // Destroy CUDA stream
+  CUDACHECK(hipStreamDestroy(stream));
+
+  if (my_rank == 0) {
+    printf("All resources cleaned up successfully\n");
+    printf("Example completed - demonstrated symmetric memory lifecycle\n");
+  }
+
+  return NULL;
+}
+
+int main(int argc, char *argv[]) {
+  // Run example using the standard test framework
+  // This handles MPI/pthread initialization, device assignment, and cleanup
+  return run_example(argc, argv, allReduce);
+}

--- a/projects/rccl/examples/05_symmetric_memory/Makefile
+++ b/projects/rccl/examples/05_symmetric_memory/Makefile
@@ -1,0 +1,48 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# See LICENSE.txt for more license information
+#
+
+# NCCL Shared Memory Examples
+EXAMPLES = 01_allreduce
+
+# Default target
+all: $(EXAMPLES)
+
+# Build individual examples
+$(EXAMPLES):
+	$(MAKE) -C $@
+
+# Clean all build artifacts
+clean:
+	for example in $(EXAMPLES); do \
+		$(MAKE) -C $$example clean; \
+	done
+
+# Test all examples
+test: all
+	for example in $(EXAMPLES); do \
+		echo "Testing $$example..."; \
+		$(MAKE) -C $$example test; \
+	done
+
+# Help
+help:
+	@echo "NCCL Symmetric Memeory Examples"
+	@echo "==============================="
+	@echo ""
+	@echo "Targets:"
+	@echo "  all     - Build all examples"
+	@echo "  clean   - Clean all build artifacts"
+	@echo "  test    - Test all examples"
+	@echo "  help    - Show this help"
+	@echo ""
+	@echo "Examples:"
+	@echo "  01_allreduce - AllReduce collective operation"
+	@echo ""
+	@echo "To build/run individual examples:"
+	@echo "  make -C 01_allreduce"
+
+.PHONY: all clean test help $(EXAMPLES)

--- a/projects/rccl/examples/05_symmetric_memory/Makefile
+++ b/projects/rccl/examples/05_symmetric_memory/Makefile
@@ -30,7 +30,7 @@ test: all
 
 # Help
 help:
-	@echo "NCCL Symmetric Memeory Examples"
+	@echo "NCCL Symmetric Memory Examples"
 	@echo "==============================="
 	@echo ""
 	@echo "Targets:"

--- a/projects/rccl/examples/05_symmetric_memory/README.md
+++ b/projects/rccl/examples/05_symmetric_memory/README.md
@@ -72,4 +72,4 @@ cd 01_allreduce && make
 - [NCCL API
   Reference](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api.html)
 - [HIP Programming
-  Guide](https://docs.nvidia.com/cuda/cuda-c-programming-guide/)
+  Guide](https://rocm.docs.amd.com/projects/HIP/en/latest/programming_guide.html)

--- a/projects/rccl/examples/05_symmetric_memory/README.md
+++ b/projects/rccl/examples/05_symmetric_memory/README.md
@@ -1,0 +1,75 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+
+  See LICENSE.txt for more license information
+-->
+
+# NCCL Symmetric Memory Examples
+
+## Overview
+This directory contains minimal examples that demonstrate NCCL symmetric memory
+windows for improving performance of collective operations when all ranks use
+consistent memory layouts.
+
+## Examples
+
+### [01_allreduce](01_allreduce/)
+**AllReduce with Symmetric Memory Windows**
+- **Pattern**: Register symmetric windows per rank and use them for collectives
+- **API**: `ncclCommWindowRegister`, `ncclCommWindowDeregister`, `ncclMemAlloc`,
+  `ncclAllReduce`
+- **Use case**: Large-scale collectives with consistent buffer layouts across
+  ranks
+- **Key features**:
+  - Buffers allocated via `ncclMemAlloc` for symmetric compatibility
+  - Windows registered as `NCCL_WIN_COLL_SYMMETRIC`
+  - Collective operations executed on symmetric windows
+  - Correct deregistration and cleanup
+
+## Choosing the Right Pattern
+
+*Scenario* : Large-scale training with consistent memory patterns
+*Addresses* : Low-latency, high-bandwidth collectives on supported systems
+*Dependencies* : pthread or MPI
+
+### Why Symmetric Windows?
+Symmetric windows enable NCCL to apply optimized collective protocols when all
+ranks use consistent layouts. The memory needs to be allocated through the HIP
+Virtual Memory Management (VMM) API and registered with NCCL.
+
+```c
+// Allocate using NCCL provided convenience function and register symmetric windows
+NCCLCHECK(ncclMemAlloc(&buffer, size_bytes));
+NCCLCHECK(ncclCommWindowRegister(comm, buffer, size_bytes, &win, NCCL_WIN_COLL_SYMMETRIC));
+
+// Collective using symmetric windows
+NCCLCHECK(ncclAllReduce(buffer, buffer, count, ncclFloat, ncclSum, comm, stream));
+
+// Deregister and free
+NCCLCHECK(ncclCommWindowDeregister(comm, win));
+NCCLCHECK(ncclMemFree(buffer));
+```
+
+## Building
+
+### **Quick Start**
+```shell
+# Build example by directory name
+make 01_allreduce
+```
+
+### **Individual Examples**
+```shell
+# Build and run AllReduce with symmetric windows
+cd 01_allreduce && make
+./allreduce_sm
+```
+
+## References
+- [NCCL User Guide:
+  Examples](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/examples.html)
+- [NCCL API
+  Reference](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/api.html)
+- [HIP Programming
+  Guide](https://docs.nvidia.com/cuda/cuda-c-programming-guide/)

--- a/projects/rccl/examples/Makefile
+++ b/projects/rccl/examples/Makefile
@@ -1,0 +1,56 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# See LICENSE.txt for more license information
+#
+
+# RCCL Examples Main Makefile (ported from NCCL examples)
+
+# Define all category directories. 06_device_api is RCCL-specific and lives
+# alongside but uses its own build system, so it's intentionally omitted here.
+CATEGORIES := 01_communicators 02_point_to_point 03_collectives 04_user_buffer_registration 05_symmetric_memory
+
+# Default target
+all: $(CATEGORIES)
+
+# Build all categories
+$(CATEGORIES):
+	@echo "Building $@..."
+	@$(MAKE) -C $@
+
+# Clean all categories
+clean:
+	@echo "Cleaning all examples..."
+	@for category in $(CATEGORIES); do \
+		$(MAKE) -C $$category clean; \
+	done
+
+# Test all examples
+test: all
+	@echo "Testing all examples..."
+	@for category in $(CATEGORIES); do \
+		$(MAKE) -C $$category test; \
+	done
+
+# Install all examples
+install: all
+	@echo "Installing all examples..."
+	@for category in $(CATEGORIES); do \
+		$(MAKE) -C $$category install; \
+	done
+
+# Help target
+help:
+	@echo "RCCL Examples Main Makefile"
+	@echo "==========================="
+	@echo ""
+	@echo "Available targets:"
+	@echo "  all      - Build all examples"
+	@echo "  clean    - Clean all build artifacts"
+	@echo "  test     - Build and test all examples"
+	@echo "  install  - Install all examples"
+	@echo "  help     - Show this help message"
+	@echo ""
+
+.PHONY: all clean test install help $(CATEGORIES)

--- a/projects/rccl/examples/README.md
+++ b/projects/rccl/examples/README.md
@@ -1,0 +1,80 @@
+<!--
+  SPDX-License-Identifier: Apache-2.0
+  Ported from the NVIDIA NCCL examples (https://github.com/NVIDIA/nccl/tree/master/docs/examples).
+-->
+
+# RCCL Library Examples
+
+This directory contains RCCL (ROCm Communication Collectives Library) examples,
+ported from the upstream
+[NCCL examples](https://github.com/NVIDIA/nccl/tree/master/docs/examples).
+Because RCCL exposes the same `ncclXxx` API surface as NCCL, the application
+code is largely identical — only the underlying GPU runtime calls have been
+translated from CUDA to HIP, and the build system retargeted to `hipcc` and
+`librccl`.
+
+The examples progress from basic concepts to advanced usage patterns, each with
+its own README. See the
+[RCCL documentation](https://rocm.docs.amd.com/projects/rccl/en/latest/) for a
+full reference.
+
+## Categories
+
+| Folder | What it shows |
+| --- | --- |
+| `01_communicators` | Communicator creation: single-process multi-GPU, one device per pthread, one device per MPI process |
+| `02_point_to_point` | Send/Recv in a simple ring pattern |
+| `03_collectives` | Basic AllReduce |
+| `04_user_buffer_registration` | `ncclCommRegister` to pre-register user buffers for faster collectives |
+| `05_symmetric_memory` | `ncclCommWindowRegister` symmetric memory windows |
+| `06_device_api` | Device-side API (kept as the RCCL-specific examples already present in the project) |
+
+## Prerequisites
+
+- ROCm (default: `/opt/rocm`). Override with `ROCM_PATH=...`.
+- RCCL headers and library (shipped with ROCm; override location with `RCCL_HOME=...`).
+- `hipcc` in `$ROCM_PATH/bin`.
+- Optional: an MPI implementation for the MPI example.
+
+## Build
+
+From this directory:
+
+```bash
+make GPU_TARGETS="gfx942"            # build all 01..05 categories
+make -C 03_collectives/01_allreduce  # build one example
+make MPI=1 -C 01_communicators/03_one_device_per_process_mpi
+```
+
+Useful variables:
+
+- `GPU_TARGETS` — space-separated AMD GPU archs, e.g. `"gfx90a gfx942 gfx1100"`. Defaults to those three.
+- `ROCM_PATH` — ROCm install root (default `/opt/rocm`).
+- `RCCL_HOME` — RCCL install root (default `$(ROCM_PATH)`).
+- `MPI=1` — build with MPI support. Optionally set `MPI_HOME`.
+- `PREFIX` — install prefix for `make install` (default `/usr/local`).
+
+The build uses `hipcc` for both compilation and linking. For the MPI example,
+`OMPI_CXX`/`MPICH_CXX` are exported so the MPI wrapper invokes `hipcc`.
+
+## Run
+
+```bash
+./03_collectives/01_allreduce/allreduce
+mpirun -np 2 ./01_communicators/03_one_device_per_process_mpi/one_device_per_process_mpi
+```
+
+By default the threaded/single-process examples use every visible GPU; restrict
+with `HIP_VISIBLE_DEVICES=0,1,2,3`.
+
+## Environment Variables (runtime)
+
+- `HIP_VISIBLE_DEVICES` — comma-separated list of GPUs visible to the application.
+- `NCCL_DEBUG=INFO` — verbose RCCL logging (RCCL honors the `NCCL_*` env vars).
+- All other RCCL environment variables apply.
+
+## Troubleshooting
+
+- Use `NCCL_DEBUG=INFO` for detailed RCCL logging.
+- Ensure your GPU's `gfx` arch is included in `GPU_TARGETS` (check with `rocminfo`).
+- For MPI builds, confirm `mpicxx`/`mpirun` are on `PATH` or set `MPI_HOME`.

--- a/projects/rccl/examples/common/README.md
+++ b/projects/rccl/examples/common/README.md
@@ -1,0 +1,36 @@
+# NCCL Common Utilities
+
+## Description
+This directory contains shared utilities and helper functions used across all NCCL examples. These utilities provide common functionality for error handling, device management, and MPI integration.
+
+## Components
+
+### Headers (`include/`)
+- **utils.h**: General utility functions
+- **nccl_utils.h**: NCCL error checking macros
+- **mpi_utils.h**: MPI error checking macros
+
+### Source Files (`src/`)
+- **utils.cc**: General utility functions
+
+## Key Features
+
+### Error Checking Macros
+```c
+#define NCCLCHECK(cmd)  // NCCL error checking
+#define CUDACHECK(cmd)  // HIP error checking
+#define MPICHECK(cmd)   // MPI error checking
+```
+
+## Usage in Examples
+Include the headers in your example source files:
+```c
+#include "utils.h"
+#include "mpi_utils.h"
+```
+
+## Notes
+- All utilities include comprehensive error checking
+- Functions are designed to be thread-safe
+- Memory management functions handle null pointers safely
+- MPI utilities are only needed for multi-process examples

--- a/projects/rccl/examples/common/include/mpi_utils.h
+++ b/projects/rccl/examples/common/include/mpi_utils.h
@@ -1,0 +1,30 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See LICENSE.txt for more license information
+ *************************************************************************/
+
+#ifndef MPI_UTILS_H_
+#define MPI_UTILS_H_
+
+#include "mpi.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+// MPI error checking macro
+#define MPICHECK(cmd)                                                          \
+  do {                                                                         \
+    int err = cmd;                                                             \
+    if (err != MPI_SUCCESS) {                                                  \
+      char error_string[MPI_MAX_ERROR_STRING];                                 \
+      int length;                                                              \
+      MPI_Error_string(err, error_string, &length);                            \
+      fprintf(stderr, "MPI error at %s:%d - %s\n", __FILE__, __LINE__,         \
+              error_string);                                                   \
+      fprintf(stderr, "Failed MPI operation: %s\n", #cmd);                     \
+      MPI_Abort(MPI_COMM_WORLD, err);                                          \
+    }                                                                          \
+  } while (0)
+
+#endif

--- a/projects/rccl/examples/common/include/nccl_utils.h
+++ b/projects/rccl/examples/common/include/nccl_utils.h
@@ -1,0 +1,41 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See LICENSE.txt for more license information
+ *************************************************************************/
+
+#ifndef NCCL_UTILS_H_
+#define NCCL_UTILS_H_
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#include "hip/hip_runtime.h"
+
+// Error checking
+#define NCCLCHECK(cmd)                                                         \
+  do {                                                                         \
+    ncclResult_t res = cmd;                                                    \
+    if (res != ncclSuccess) {                                                  \
+      fprintf(stderr, "Failed, NCCL error %s:%d '%s'\n", __FILE__, __LINE__,   \
+              ncclGetErrorString(res));                                        \
+      fprintf(stderr, "Failed NCCL operation: %s\n", #cmd);                    \
+      exit(EXIT_FAILURE);                                                      \
+    }                                                                          \
+  } while (0)
+
+#define CUDACHECK(cmd)                                                         \
+  do {                                                                         \
+    hipError_t err = cmd;                                                     \
+    if (err != hipSuccess) {                                                  \
+      fprintf(stderr, "Failed: Cuda error %s:%d '%s'\n", __FILE__, __LINE__,   \
+              hipGetErrorString(err));                                        \
+      fprintf(stderr, "Failed CUDA operation: %s\n", #cmd);                    \
+      exit(EXIT_FAILURE);                                                      \
+    }                                                                          \
+  } while (0)
+
+#endif

--- a/projects/rccl/examples/common/include/nccl_utils.h
+++ b/projects/rccl/examples/common/include/nccl_utils.h
@@ -14,6 +14,7 @@
 #include <unistd.h>
 
 #include "hip/hip_runtime.h"
+#include <rccl/rccl.h>
 
 // Error checking
 #define NCCLCHECK(cmd)                                                         \
@@ -31,9 +32,9 @@
   do {                                                                         \
     hipError_t err = cmd;                                                     \
     if (err != hipSuccess) {                                                  \
-      fprintf(stderr, "Failed: Cuda error %s:%d '%s'\n", __FILE__, __LINE__,   \
+      fprintf(stderr, "Failed: HIP error %s:%d '%s'\n", __FILE__, __LINE__,   \
               hipGetErrorString(err));                                        \
-      fprintf(stderr, "Failed CUDA operation: %s\n", #cmd);                    \
+      fprintf(stderr, "Failed HIP operation: %s\n", #cmd);                    \
       exit(EXIT_FAILURE);                                                      \
     }                                                                          \
   } while (0)

--- a/projects/rccl/examples/common/include/utils.h
+++ b/projects/rccl/examples/common/include/utils.h
@@ -1,0 +1,56 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See LICENSE.txt for more license information
+ *************************************************************************/
+
+#ifndef UTILS_H_
+#define UTILS_H_
+
+#include "hip/hip_runtime.h"
+#include <rccl/rccl.h>
+#include "nccl_utils.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifdef MPI_SUPPORT
+#include "mpi.h"
+#include "mpi_utils.h"
+#else
+#include <pthread.h>
+#include <unistd.h>
+#endif
+
+/**
+ * Broadcast NCCL unique ID
+ *
+ * Broadcasts the NCCL unique ID from the root rank to all other ranks.
+ * Uses MPI_Bcast in MPI mode and pthread barrier in pthread mode.
+ *
+ * @param root      Root rank that holds the NCCL unique ID
+ * @param my_rank   Current rank or thread id
+ * @param arg       Pointer to NCCL unique ID to broadcast
+ *
+ * @return 0 on success, non-zero on error
+ */
+int util_broadcast(int root, int my_rank, ncclUniqueId *arg);
+
+/**
+ * Run the given NCCL example in parallel
+ *
+ * This function performs the complete NCCL example lifecycle:
+ * 1. Initialize backend (MPI or pthread)
+ * 2. Execute NCCL communicator setup function
+ * 3. Cleanup of all resources
+ *
+ * @param argc              Command line argument count
+ * @param argv              Command line arguments
+ * @param ncclExample       Function pointer to example-specific NCCL setup
+ *
+ * @return 0 on success, non-zero on error
+ */
+int run_example(int argc, char *argv[],
+                void *(*ncclExample)(int, int, int, int));
+
+#endif // UTILS_H_

--- a/projects/rccl/examples/common/src/utils.cc
+++ b/projects/rccl/examples/common/src/utils.cc
@@ -1,0 +1,322 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See LICENSE.txt for more license information
+ *************************************************************************/
+
+#include "utils.h"
+#include <cstring>
+#include <unistd.h>
+
+#ifndef MPI_SUPPORT
+pthread_barrier_t barrier;
+ncclUniqueId nccl_unique_id;
+#endif
+
+/**
+ * Common context structure for both MPI and pthread examples
+ *
+ * This structure provides a unified interface for NCCL examples that can
+ * run in either MPI mode (one process per device) or pthread mode
+ * (one thread per device).
+ */
+typedef struct {
+  // Common variables
+  int total_ranks;      // Total number of MPI ranks or pthreads
+  int devices_per_rank; // Number of devices per rank or thread
+  int local_device;     // Node local rank or thread id (0 to total_ranks-1)
+  int my_rank;          // Rank or thread id for NCCL
+  void *func;
+
+  // pthread-specific variables
+#ifndef MPI_SUPPORT
+  pthread_t *threads; // Thread array
+#endif
+} context_t;
+
+/**
+ * Initialize MPI or pthread backend
+ *
+ * Sets up the backend and populates common context variables.
+ *
+ * MPI Mode (compiled with MPI=1):
+ *   - Initializes MPI (rank, size)
+ *   - Calculates local rank based on splitting communicator by node multi-node
+ * support
+ *   - Generates and broadcasts NCCL unique ID
+ *   - Sets device assignment based on local rank
+ *
+ * pthread Mode (default):
+ *   - Gets thread count from NTHREADS environment or GPU count
+ *   - Validates thread count against available GPUs
+ *   - Generates NCCL unique ID for sharing across threads
+ *   - Allocates thread management resources
+ *
+ * @param argc      Command line argument count
+ * @param argv      Command line arguments
+ * @param ctx       Output: Populated example context
+ *
+ * @return 0 on success, non-zero on error
+ */
+int initialize(int argc, char *argv[], context_t *ctx);
+
+/**
+ * Wrap function to call the example function in a thread
+ *
+ * Note: This function is needed since pthread only allows a single void*
+ * argument.
+ */
+void *thread_wrapper(void *arg);
+
+/**
+ * Run ncclExample in parallel using MPI or pthreads
+ *
+ * Starts the execution of the given NCCL example function in parallel
+ *
+ * MPI Mode:
+ *   - Starts the function on each rank
+ *   - Checks the output and calls MPI_Barrier to synchronize
+ *
+ * pthread Mode:
+ *   - Creates threads (one per device)
+ *   - Each thread runs the given example function
+ *   - Waits for all threads to complete
+ *
+ * @param ctx               Context with backend setup completed
+ * @param ncclExample       Function pointer to example-specific NCCL setup
+ *
+ * @return 0 on success, non-zero on error
+ *
+ * Note: This function expects ncclExample() to be defined by the example.
+ * The ncclExample function should have signature:
+ * void* ncclExample(int, int, int, int)
+ */
+int run_parallel(context_t *ctx, void *(*ncclExample)(int, int, int, int));
+
+/**
+ * Clean up resources
+ *
+ * Properly cleans up all resources allocated during initialization.
+ * Note: NCCL communicators are destroyed by ncclCommSetup function.
+ *
+ * MPI Mode:
+ *   - Finalizes MPI
+ *
+ * pthread Mode:
+ *   - Frees thread arrays
+ *
+ * @param ctx       Context to clean up
+ */
+void cleanup(context_t *ctx);
+
+/**
+ * Broadcast NCCL unique ID
+ */
+int util_broadcast(int root, int my_rank, ncclUniqueId *arg) {
+#ifdef MPI_SUPPORT
+  MPICHECK(
+      MPI_Bcast(arg, sizeof(ncclUniqueId), MPI_BYTE, root, MPI_COMM_WORLD));
+#else
+  if (my_rank == root) {
+    nccl_unique_id = *arg;
+  }
+  int barrier_err = pthread_barrier_wait(&barrier);
+  if (barrier_err != 0 && barrier_err != PTHREAD_BARRIER_SERIAL_THREAD) {
+    fprintf(stderr, "pthread_barrier_wait failed at %s:%d with error code %d\n",
+            __FILE__, __LINE__, barrier_err);
+    abort();
+  }
+  if (my_rank != root) {
+    *arg = nccl_unique_id;
+  }
+#endif
+  return 0;
+}
+
+/**
+ * Initialize MPI or pthread backend
+ */
+int initialize(int argc, char *argv[], context_t *ctx) {
+#ifdef MPI_SUPPORT
+  // Initialize MPI
+  MPICHECK(MPI_Init(&argc, &argv));
+  MPICHECK(MPI_Comm_rank(MPI_COMM_WORLD, &ctx->my_rank));
+  MPICHECK(MPI_Comm_size(MPI_COMM_WORLD, &ctx->total_ranks));
+
+  if (ctx->my_rank == 0) {
+    printf("Number of processes: %d\n", ctx->total_ranks);
+  }
+  // Only for printing the output in order
+  MPI_Barrier(MPI_COMM_WORLD);
+  printf("MPI initialized: rank %d of %d\n", ctx->my_rank, ctx->total_ranks);
+
+  // Split the communicator based on shared memory (i.e., nodes)
+  MPI_Comm node_comm;
+  MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, ctx->my_rank,
+                      MPI_INFO_NULL, &node_comm);
+
+  // Get the rank within the node communicator
+  MPI_Comm_rank(node_comm, &ctx->local_device);
+
+  // Clean up the node communicator
+  MPI_Comm_free(&node_comm);
+
+#else
+
+  // Get number of devices (threads) from environment or default to available
+  // GPUs
+  int num_gpus = 0;
+  CUDACHECK(hipGetDeviceCount(&num_gpus));
+  ctx->total_ranks = num_gpus; // Default to all available GPUs
+  const char *nThreadsEnv = getenv("NTHREADS");
+  if (nThreadsEnv) {
+    ctx->total_ranks = atoi(nThreadsEnv);
+  }
+
+  printf("Creating %d threads for %d devices\n", ctx->total_ranks, num_gpus);
+
+  if (ctx->total_ranks < 1) {
+    printf("Invalid number of threads: %d\n", ctx->total_ranks);
+    return 1;
+  }
+
+  // Check if we have enough GPUs
+  if (ctx->total_ranks > num_gpus) {
+    printf("Error: Requested %d threads but only %d GPUs available\n",
+           ctx->total_ranks, num_gpus);
+    printf("Please reduce NTHREADS to %d or fewer\n", num_gpus);
+    return 1;
+  }
+
+  // Thread synchronization needed for unique ID sharing later on
+  pthread_barrier_init(&barrier, NULL, ctx->total_ranks);
+
+  // Allocate thread resources
+  ctx->threads = (pthread_t *)malloc(ctx->total_ranks * sizeof(pthread_t));
+  if (ctx->threads == NULL) {
+    printf("Failed to allocate memory for threads\n");
+    return 1;
+  }
+#endif
+
+  return 0;
+}
+
+/**
+ * Wrap function to call the example function in a thread
+ *
+ * Note: This function is needed since pthread only allows a single void*
+ * argument.
+ */
+void *thread_wrapper(void *arg) {
+  context_t *ctx = (context_t *)arg;
+  void *(*example_func)(int, int, int, int) =
+      (void *(*)(int, int, int, int))ctx->func;
+  return example_func(ctx->my_rank, ctx->total_ranks, ctx->local_device,
+                      ctx->devices_per_rank);
+}
+
+/**
+ * Run ncclExample in parallel using MPI or pthreads
+ */
+int run_parallel(context_t *ctx, void *(*ncclExample)(int, int, int, int)) {
+#ifdef MPI_SUPPORT
+  if (ctx->my_rank == 0) {
+    printf("NCCL Example: One Device per Process\n");
+    printf("====================================\n");
+  }
+
+  if (ncclExample(ctx->my_rank, ctx->total_ranks, ctx->local_device,
+                  ctx->devices_per_rank) != NULL)
+    return 1;
+  // Synchronize to ensure ordered output
+  MPICHECK(MPI_Barrier(MPI_COMM_WORLD));
+#else
+  printf("NCCL Example: One Device per Thread\n");
+  printf("===================================\n");
+
+  // Create separate context for each thread
+  context_t *thread_contexts =
+      (context_t *)malloc(ctx->total_ranks * sizeof(context_t));
+  if (thread_contexts == NULL) {
+    printf("Failed to allocate thread contexts\n");
+    return 1;
+  }
+
+  for (int i = 0; i < ctx->total_ranks; i++) {
+    // Copy main context to thread context
+    memcpy(&thread_contexts[i], ctx, sizeof(context_t));
+    thread_contexts[i].threads = NULL;
+    thread_contexts[i].my_rank = i; // Set NCCL rank to thread id
+    thread_contexts[i].local_device = i;
+    thread_contexts[i].total_ranks = ctx->total_ranks;
+    thread_contexts[i].devices_per_rank = 1;
+    thread_contexts[i].func = (void *)ncclExample;
+    pthread_create(&ctx->threads[i], NULL, thread_wrapper, &thread_contexts[i]);
+  }
+
+  // Wait for all threads to complete
+  for (int i = 0; i < ctx->total_ranks; i++) {
+    pthread_join(ctx->threads[i], NULL);
+  }
+
+  free(thread_contexts);
+#endif
+
+  return 0;
+}
+
+/**
+ * Run the given NCCL example in parallel
+ */
+int run_example(int argc, char *argv[],
+                void *(*ncclExample)(int, int, int, int)) {
+
+  // 1. Allocate context
+  context_t *ctx = (context_t *)calloc(1, sizeof(context_t));
+  if (ctx == NULL) {
+    printf("Failed to allocate memory for context\n");
+    return 1;
+  }
+
+  // 2. Initialize backend (MPI or pthread)
+  if (initialize(argc, argv, ctx) != 0) {
+    printf("Failed to initialize backend\n");
+    return 1;
+  }
+
+  // 3. Start the given example code in parallel
+  if (run_parallel(ctx, ncclExample) != 0) {
+    printf("Failed to execute NCCL operations\n");
+    cleanup(ctx); // Cleanup on failure
+    return 1;
+  }
+
+  // 3. Cleanup
+  cleanup(ctx);
+
+  // 4. Print common success message
+#ifdef MPI_SUPPORT
+  if (ctx->my_rank == 0) {
+#endif
+    printf("\nAll NCCL communicators finalized successfully!\n");
+#ifdef MPI_SUPPORT
+  }
+#endif
+
+  return 0;
+}
+
+/**
+ * Clean up resources
+ */
+void cleanup(context_t *ctx) {
+#ifdef MPI_SUPPORT
+  // Free MPI resources
+  MPICHECK(MPI_Finalize());
+#else
+  free(ctx->threads);
+  pthread_barrier_destroy(&barrier);
+#endif
+}

--- a/projects/rccl/examples/makefiles/rccl_examples.mk
+++ b/projects/rccl/examples/makefiles/rccl_examples.mk
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Common build rules for the RCCL examples.
+# Ported from the NVIDIA NCCL examples (docs/examples) to use HIP/RCCL.
+
+ROCM_PATH ?= /opt/rocm
+RCCL_HOME ?= $(ROCM_PATH)
+PREFIX    ?= /usr/local
+
+HIPCC ?= $(ROCM_PATH)/bin/hipcc
+# Force CXX to hipcc (Make sets CXX=g++ by default, so we override).
+CXX := $(HIPCC)
+
+# Default GPU architectures - override with `make GPU_TARGETS="gfx942"` etc.
+GPU_TARGETS ?= gfx90a gfx942 gfx1100
+OFFLOAD_ARCH_FLAGS := $(foreach a,$(GPU_TARGETS),--offload-arch=$(a))
+
+CXXFLAGS  ?= -O2 -g -std=c++17 -Wall
+CXXFLAGS  += -D__HIP_PLATFORM_AMD__ $(OFFLOAD_ARCH_FLAGS)
+
+INCLUDES  := -I$(ROCM_PATH)/include -I$(RCCL_HOME)/include
+LIBRARIES := -L$(ROCM_PATH)/lib -L$(RCCL_HOME)/lib
+LDFLAGS   := -lrccl -lamdhip64 -Wl,-rpath,$(RCCL_HOME)/lib -Wl,-rpath,$(ROCM_PATH)/lib
+
+# MPI configuration
+ifeq ($(MPI), 1)
+ifdef MPI_HOME
+MPICXX ?= $(MPI_HOME)/bin/mpicxx
+MPIRUN ?= $(MPI_HOME)/bin/mpirun
+INCLUDES  += -I$(MPI_HOME)/include
+LIBRARIES += -L$(MPI_HOME)/lib
+else
+MPICXX ?= mpicxx
+MPIRUN ?= mpirun
+endif
+# Force the MPI compiler wrapper to use hipcc instead of g++ so HIP flags work.
+export OMPI_CXX := $(HIPCC)
+export MPICH_CXX := $(HIPCC)
+CXXFLAGS += -DMPI_SUPPORT
+LDFLAGS  += -lmpi
+endif


### PR DESCRIPTION
## Motivation

Adding the missing examples directory to RCCL.

## Technical Details


## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan


Adds a new `projects/rccl/examples/` tree (40 files, ~4.6k LOC) ported from the
upstream [NCCL examples](https://github.com/NVIDIA/nccl/tree/master/docs/examples):
- `01_communicators/` — multi-GPU single-process, one-device-per-pthread, and
  one-device-per-process MPI communicator setups.
- `02_point_to_point/01_ring_pattern` — `ncclSend`/`ncclRecv` ring.
- `03_collectives/01_allreduce` — basic AllReduce.
- `04_user_buffer_registration/01_allreduce` — `ncclCommRegister` usage.
- `05_symmetric_memory/01_allreduce` — `ncclCommWindowRegister` symmetric
  memory windows.
- `common/` — shared utility headers (`utils.h`, `nccl_utils.h`, `mpi_utils.h`)
  and `utils.cc`.
- `makefiles/rccl_examples.mk` plus per-example `Makefile`s and a top-level
  `Makefile` driving all categories.


## Test Result
- `make GPU_TARGETS="gfx942"` from `projects/rccl/examples/` to build all
  01–05 categories.
- `make -C 03_collectives/01_allreduce` to build a single example.
- `make MPI=1 -C 01_communicators/03_one_device_per_process_mpi` to verify the
  MPI build path.
- Run each example binary on a multi-GPU node, optionally with
  `HIP_VISIBLE_DEVICES` and `NCCL_DEBUG=INFO`.
- `mpirun -np 2 ./01_communicators/03_one_device_per_process_mpi/one_device_per_process_mpi`
  for the MPI example.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
