### PR TITLE
AIRUNTIME-2100 - Add event coalescing to prevent multiple barrier submissions

### DIFF
--- a/projects/clr/hipamd/src/hip_event.cpp
+++ b/projects/clr/hipamd/src/hip_event.cpp
@@ -217,7 +217,11 @@ hipError_t Event::recordCommand(amd::Command*& command, amd::HostQueue* stream, 
   // Only timing-disabled events opt into coalescing: a non-null coalesceEvent()
   // marks the record eligible and carries its identity for the device layer.
   if (flags & hipEventDisableTiming) {
-    marker->setCoalesceEvent(reinterpret_cast<void*>(this));
+    // Assign monotonic ID on first record to avoid address-reuse collision
+    if (coalesce_id_ == 0) {
+      coalesce_id_ = GenerateCoalesceId();
+    }
+    marker->setCoalesceEvent(coalesce_id_);
     marker->setSyncedSinceRecord(WasSyncedSinceLastRecord());
   }
 

--- a/projects/clr/hipamd/src/hip_event.cpp
+++ b/projects/clr/hipamd/src/hip_event.cpp
@@ -207,7 +207,26 @@ hipError_t Event::recordCommand(amd::Command*& command, amd::HostQueue* stream, 
 
   constexpr bool kMarkerTs = true;
   constexpr bool kFlushCache = false;
-  command = new hip::EventMarker(*stream, kFlushCache, kMarkerTs, releaseFlags, batch_flush);
+
+  // Check hipEventDisableTiming flag to skip profiling/timing infrastructure
+  const bool enable_profiling = !(flags & hipEventDisableTiming);
+
+  auto* marker = new hip::EventMarker(*stream, kFlushCache, kMarkerTs, releaseFlags,
+                                      batch_flush, enable_profiling);
+
+  // Hand the device layer this event's identity so it can coalesce consecutive
+  // records of the same event. Only timing-disabled events opt in: a non-null
+  // coalesceEvent() is what marks a record eligible. A timing-enabled event
+  // leaves it null so it always emits a fresh barrier for hipEventElapsedTime.
+  // The synced snapshot (only consulted for eligible records) forces a fresh
+  // barrier after hipEventSynchronize, so it is taken under the same guard.
+  if (flags & hipEventDisableTiming) {
+    marker->setCoalesceEvent(reinterpret_cast<void*>(this));
+    marker->setSyncedSinceRecord(WasSyncedSinceLastRecord());
+  }
+
+  command = marker;
+
   return hipSuccess;
 }
 
@@ -463,6 +482,9 @@ hipError_t hipEventRecord_common(hipEvent_t event, hipStream_t stream, uint32_t 
   if (e->deviceId() != hip_stream->DeviceId()) {
     return hipErrorInvalidResourceHandle;
   }
+  // Coalescing of consecutive records on the same event is detected entirely in
+  // the rocclr layer (VirtualGPU::submitMarker). The marker carries the event
+  // identity and eligibility flags so rocclr can skip a redundant barrier.
   return e->addMarker(hip_stream, nullptr, !hip::Event::kBatchFlush);
 }
 
@@ -544,6 +566,8 @@ hipError_t hipEventSynchronize(hipEvent_t event) {
 
   auto* e = reinterpret_cast<hip::Event*>(event);
   const auto status = e->synchronize();
+  // Mark event as synced to prevent coalescing until next record
+  e->MarkSynced();
   // Release freed memory for all memory pools on the device
   g_devices[e->deviceId()]->ReleaseFreedMemory();
   HIP_RETURN(status);

--- a/projects/clr/hipamd/src/hip_event.cpp
+++ b/projects/clr/hipamd/src/hip_event.cpp
@@ -214,12 +214,8 @@ hipError_t Event::recordCommand(amd::Command*& command, amd::HostQueue* stream, 
   auto* marker = new hip::EventMarker(*stream, kFlushCache, kMarkerTs, releaseFlags,
                                       batch_flush, enable_profiling);
 
-  // Hand the device layer this event's identity so it can coalesce consecutive
-  // records of the same event. Only timing-disabled events opt in: a non-null
-  // coalesceEvent() is what marks a record eligible. A timing-enabled event
-  // leaves it null so it always emits a fresh barrier for hipEventElapsedTime.
-  // The synced snapshot (only consulted for eligible records) forces a fresh
-  // barrier after hipEventSynchronize, so it is taken under the same guard.
+  // Only timing-disabled events opt into coalescing: a non-null coalesceEvent()
+  // marks the record eligible and carries its identity for the device layer.
   if (flags & hipEventDisableTiming) {
     marker->setCoalesceEvent(reinterpret_cast<void*>(this));
     marker->setSyncedSinceRecord(WasSyncedSinceLastRecord());
@@ -482,9 +478,6 @@ hipError_t hipEventRecord_common(hipEvent_t event, hipStream_t stream, uint32_t 
   if (e->deviceId() != hip_stream->DeviceId()) {
     return hipErrorInvalidResourceHandle;
   }
-  // Coalescing of consecutive records on the same event is detected entirely in
-  // the rocclr layer (VirtualGPU::submitMarker). The marker carries the event
-  // identity and eligibility flags so rocclr can skip a redundant barrier.
   return e->addMarker(hip_stream, nullptr, !hip::Event::kBatchFlush);
 }
 

--- a/projects/clr/hipamd/src/hip_event.cpp
+++ b/projects/clr/hipamd/src/hip_event.cpp
@@ -564,7 +564,9 @@ hipError_t hipEventSynchronize(hipEvent_t event) {
   auto* e = reinterpret_cast<hip::Event*>(event);
   const auto status = e->synchronize();
   // Mark event as synced to prevent coalescing until next record
-  e->MarkSynced();
+  if (status == hipSuccess) {
+    e->MarkSynced();
+  }
   // Release freed memory for all memory pools on the device
   g_devices[e->deviceId()]->ReleaseFreedMemory();
   HIP_RETURN(status);

--- a/projects/clr/hipamd/src/hip_event.hpp
+++ b/projects/clr/hipamd/src/hip_event.hpp
@@ -169,11 +169,18 @@ class Event {
   amd::Event* event_;          //!< Underlying ROCclr event object for GPU synchronization
   int device_id_;              //!< Device ID where this event was created
   std::atomic<bool> synced_since_last_record_{false};  //!< Set by hipEventSynchronize, cleared by hipEventRecord
+  uint64_t coalesce_id_ = 0;  //!< 0 = unassigned; non-zero = unique coalesce identity
 
  public:
   void MarkSynced() { synced_since_last_record_.store(true, std::memory_order_release); }
   bool WasSyncedSinceLastRecord() {
     return synced_since_last_record_.exchange(false, std::memory_order_acq_rel);
+  }
+
+ private:
+  static uint64_t GenerateCoalesceId() {
+    static std::atomic<uint64_t> nextId{1};  // Start at 1 so 0 remains sentinel
+    return ++nextId;
   }
 };
 

--- a/projects/clr/hipamd/src/hip_event.hpp
+++ b/projects/clr/hipamd/src/hip_event.hpp
@@ -75,9 +75,10 @@ typedef struct ihipIpcEventShmem_s {
 class EventMarker : public amd::Marker {
  public:
   EventMarker(amd::HostQueue& stream, bool disableFlush, bool markerTs = false,
-              int32_t scope = amd::Device::kCacheStateInvalid, bool batch_flush = true)
+              int32_t scope = amd::Device::kCacheStateInvalid, bool batch_flush = true,
+              bool enable_profiling = true)
       : amd::Marker(stream, disableFlush) {
-    profilingInfo_.enabled_ = true;
+    profilingInfo_.enabled_ = enable_profiling;
     profilingInfo_.marker_ts_ = markerTs;
     profilingInfo_.batch_flush_ = batch_flush;
     profilingInfo_.clear();
@@ -167,6 +168,13 @@ class Event {
   std::recursive_mutex lock_;  //!< Mutex for thread-safe access to event state
   amd::Event* event_;          //!< Underlying ROCclr event object for GPU synchronization
   int device_id_;              //!< Device ID where this event was created
+  std::atomic<bool> synced_since_last_record_{false};  //!< Set by hipEventSynchronize, cleared by hipEventRecord
+
+ public:
+  void MarkSynced() { synced_since_last_record_.store(true, std::memory_order_release); }
+  bool WasSyncedSinceLastRecord() {
+    return synced_since_last_record_.exchange(false, std::memory_order_acq_rel);
+  }
 };
 
 class EventDD : public Event {

--- a/projects/clr/hipamd/src/hip_event.hpp
+++ b/projects/clr/hipamd/src/hip_event.hpp
@@ -179,7 +179,7 @@ class Event {
 
  private:
   static uint64_t GenerateCoalesceId() {
-    static std::atomic<uint64_t> nextId{1};  // Start at 1 so 0 remains sentinel
+    static std::atomic<uint64_t> nextId{0};  // First id is 1; 0 remains the sentinel
     return ++nextId;
   }
 };

--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -802,7 +802,6 @@ hipError_t ihipMemcpy(void* dst, const void* src, size_t sizeBytes, hipMemcpyKin
       }
     }
   }
-
   command->release();
   return hipSuccess;
 }

--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -802,6 +802,7 @@ hipError_t ihipMemcpy(void* dst, const void* src, size_t sizeBytes, hipMemcpyKin
       }
     }
   }
+
   command->release();
   return hipSuccess;
 }

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1859,6 +1859,8 @@ bool VirtualGPU::releaseGpuMemoryFence(bool skip_cpu_wait) {
     skippedDispatches_ = 0;
     retainExternalSignals_ = false;
   }
+  // Any fence/flush ends the coalescing window for event records.
+  last_barrier_coalesce_event_ = nullptr;
 
   // Check if runtime could skip CPU wait
   if (!skip_cpu_wait) {
@@ -2261,6 +2263,15 @@ void VirtualGPU::profilingBegin(amd::Command& command, bool sdmaProfiling) {
   // Track the current command
   command_ = &command;
 
+  // Any non-marker command represents work between event records and ends the
+  // coalescing window. Markers manage the window themselves in submitMarker (a
+  // record sets it, a wait/other marker clears it), so they are excluded here.
+  // This is the single choke point: every submitXxx calls profilingBegin under
+  // the execution() lock, so individual dispatch paths need no explicit reset.
+  if (!command.isMarkerCommand()) {
+    last_barrier_coalesce_event_ = nullptr;
+  }
+
   // Disable profiling when command is being captured to prevent memory leak from created timestamp_
   // which won't get freed, since the command is not being executed until graph launch
   if (!command.getPktCapturingState() && command.profilingInfo().enabled_) {
@@ -2323,10 +2334,12 @@ void VirtualGPU::profilingBegin(amd::Command& command, bool sdmaProfiling) {
  */
 void VirtualGPU::profilingEnd(bool clearHwEvent) {
   if (!command_->getPktCapturingState() && command_->profilingInfo().enabled_) {
-    if (timestamp_->HwProfiling() == false) {
-      timestamp_->end();
+    if (timestamp_ != nullptr) {
+      if (timestamp_->HwProfiling() == false) {
+        timestamp_->end();
+      }
+      timestamp_ = nullptr;
     }
-    timestamp_ = nullptr;
   }
 
   // Certain commands like map/unmap memory may not need hw_events as its not a
@@ -4574,6 +4587,7 @@ void VirtualGPU::submitMarker(amd::Marker& vcmd) {
       SetGpuQueue(roc_device_.AcquireActiveQueue(priority_, nullptr, nullptr, &md_rb), md_rb);
     }
     flush(vcmd.GetBatchHead());
+    last_barrier_coalesce_event_ = nullptr;
   } else {
     profilingBegin(vcmd);
     const Settings& settings = dev().settings();
@@ -4588,7 +4602,14 @@ void VirtualGPU::submitMarker(amd::Marker& vcmd) {
       s.handle = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(
           vcmd.ipcDepSignal()->getHandle()));
       WaitCompleteSignal(s);
-    } else if (timestamp_ != nullptr || ipc_s.handle != 0) {
+    } else if (timestamp_ != nullptr || vcmd.profilingInfo().marker_ts_ || ipc_s.handle != 0) {
+      // Skip a redundant barrier when this marker records the same client event as
+      // the previous barrier with no intervening work. IPC records always dispatch.
+      if (ipc_s.handle == 0 && ShouldCoalesceMarker(vcmd)) {
+        profilingEnd();
+        force_irq_ = false;
+        return;
+      }
       // IPC event record: if ipc_s is non-zero, first dispatch a NOP barrier with
       // the IPC signal as completion_signal; it fires when prior work completes.
       if (ipc_s.handle != 0) {
@@ -4618,6 +4639,11 @@ void VirtualGPU::submitMarker(amd::Marker& vcmd) {
         hasPendingDispatch_ = false;
       }
     }
+    // Any marker that reaches here (and wasn't coalesced away, which returns
+    // early) ends the prior coalescing window. A record sets the window to its
+    // own client event; a plain wait/other marker has coalesceEvent() == nullptr
+    // and so clears it, which is what a cross-stream wait relies on.
+    last_barrier_coalesce_event_ = vcmd.coalesceEvent();
     profilingEnd();
   }
   force_irq_ = false;

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -677,7 +677,7 @@ hsa_signal_t VirtualGPU::HwQueueTracker::ActiveSignal(hsa_signal_value_t init_va
   prof_signal->ResetCachedTiming();
 
   // Release any existing HwEvent before setting new one for the same command
-  AttachHwEvent(cmd, prof_signal);
+  VirtualGPU::AttachHwEvent(cmd, prof_signal);
 
   if (ts != nullptr) {
     // Save HSA signal earlier to make sure the possible callback will have a valid

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -2263,11 +2263,7 @@ void VirtualGPU::profilingBegin(amd::Command& command, bool sdmaProfiling) {
   // Track the current command
   command_ = &command;
 
-  // Any non-marker command represents work between event records and ends the
-  // coalescing window. Markers manage the window themselves in submitMarker (a
-  // record sets it, a wait/other marker clears it), so they are excluded here.
-  // This is the single choke point: every submitXxx calls profilingBegin under
-  // the execution() lock, so individual dispatch paths need no explicit reset.
+  // Any non-marker command is intervening work that ends the event coalescing window.
   if (!command.isMarkerCommand()) {
     last_barrier_coalesce_event_ = nullptr;
   }
@@ -4639,10 +4635,8 @@ void VirtualGPU::submitMarker(amd::Marker& vcmd) {
         hasPendingDispatch_ = false;
       }
     }
-    // Any marker that reaches here (and wasn't coalesced away, which returns
-    // early) ends the prior coalescing window. A record sets the window to its
-    // own client event; a plain wait/other marker has coalesceEvent() == nullptr
-    // and so clears it, which is what a cross-stream wait relies on.
+    // A record sets the window to its own event; a wait/other marker has a null
+    // coalesceEvent() and so clears it, which a cross-stream wait relies on.
     last_barrier_coalesce_event_ = vcmd.coalesceEvent();
     profilingEnd();
   }

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1972,7 +1972,10 @@ VirtualGPU::~VirtualGPU() {
   }
 
   // Release any retained coalescing-window signal not freed via releaseGpuMemoryFence.
-  SetCoalesceWindow(0, nullptr);
+  {
+    std::scoped_lock l(execution());
+    SetCoalesceWindow(0, nullptr);
+  }
 
   if (timestamp_ != nullptr) {
     timestamp_->release();

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -676,14 +676,8 @@ hsa_signal_t VirtualGPU::HwQueueTracker::ActiveSignal(hsa_signal_value_t init_va
   prof_signal->flags_.isPacketDispatch_ = false;
   prof_signal->ResetCachedTiming();
 
-  if (nullptr != cmd) {
-    // Release any existing HwEvent before setting new one for the same command
-    if (cmd->HwEvent() != nullptr) {
-      reinterpret_cast<ProfilingSignal*>(cmd->HwEvent())->release();
-    }
-    cmd->SetHwEvent(prof_signal);
-    prof_signal->retain();
-  }
+  // Release any existing HwEvent before setting new one for the same command
+  AttachHwEvent(cmd, prof_signal);
 
   if (ts != nullptr) {
     // Save HSA signal earlier to make sure the possible callback will have a valid
@@ -1860,7 +1854,7 @@ bool VirtualGPU::releaseGpuMemoryFence(bool skip_cpu_wait) {
     retainExternalSignals_ = false;
   }
   // Any fence/flush ends the coalescing window for event records.
-  last_barrier_coalesce_event_ = nullptr;
+  SetCoalesceWindow(0, nullptr);
 
   // Check if runtime could skip CPU wait
   if (!skip_cpu_wait) {
@@ -1976,6 +1970,9 @@ VirtualGPU::~VirtualGPU() {
     // Release the resources of signal
     releaseGpuMemoryFence();
   }
+
+  // Release any retained coalescing-window signal not freed via releaseGpuMemoryFence.
+  SetCoalesceWindow(0, nullptr);
 
   if (timestamp_ != nullptr) {
     timestamp_->release();
@@ -2265,7 +2262,7 @@ void VirtualGPU::profilingBegin(amd::Command& command, bool sdmaProfiling) {
 
   // Any non-marker command is intervening work that ends the event coalescing window.
   if (!command.isMarkerCommand()) {
-    last_barrier_coalesce_event_ = nullptr;
+    SetCoalesceWindow(0, nullptr);
   }
 
   // Disable profiling when command is being captured to prevent memory leak from created timestamp_
@@ -2350,6 +2347,32 @@ void VirtualGPU::profilingEnd(bool clearHwEvent) {
 
   // Clear the command tracking
   command_ = nullptr;
+}
+
+// ================================================================================================
+void VirtualGPU::SetCoalesceWindow(uint64_t event_id, void* hw_event) {
+  last_barrier_coalesce_event_ = event_id;
+  if (hw_event != last_barrier_hw_event_) {
+    if (hw_event != nullptr) {
+      reinterpret_cast<ProfilingSignal*>(hw_event)->retain();
+    }
+    if (last_barrier_hw_event_ != nullptr) {
+      reinterpret_cast<ProfilingSignal*>(last_barrier_hw_event_)->release();
+    }
+    last_barrier_hw_event_ = hw_event;
+  }
+}
+
+// ================================================================================================
+void VirtualGPU::AttachHwEvent(amd::Command* cmd, void* hw_event) {
+  if (cmd == nullptr || hw_event == nullptr) {
+    return;
+  }
+  if (cmd->HwEvent() != nullptr) {
+    reinterpret_cast<ProfilingSignal*>(cmd->HwEvent())->release();
+  }
+  cmd->SetHwEvent(hw_event);
+  reinterpret_cast<ProfilingSignal*>(hw_event)->retain();
 }
 
 // ================================================================================================
@@ -4583,7 +4606,7 @@ void VirtualGPU::submitMarker(amd::Marker& vcmd) {
       SetGpuQueue(roc_device_.AcquireActiveQueue(priority_, nullptr, nullptr, &md_rb), md_rb);
     }
     flush(vcmd.GetBatchHead());
-    last_barrier_coalesce_event_ = nullptr;
+    SetCoalesceWindow(0, nullptr);
   } else {
     profilingBegin(vcmd);
     const Settings& settings = dev().settings();
@@ -4602,6 +4625,9 @@ void VirtualGPU::submitMarker(amd::Marker& vcmd) {
       // Skip a redundant barrier when this marker records the same client event as
       // the previous barrier with no intervening work. IPC records always dispatch.
       if (ipc_s.handle == 0 && ShouldCoalesceMarker(vcmd)) {
+        // Reuse the prior barrier's completion signal so hipEventQuery/Synchronize
+        // observe correct readiness even though no new barrier was dispatched.
+        AttachHwEvent(command_, last_barrier_hw_event_);
         profilingEnd();
         force_irq_ = false;
         return;
@@ -4635,9 +4661,10 @@ void VirtualGPU::submitMarker(amd::Marker& vcmd) {
         hasPendingDispatch_ = false;
       }
     }
-    // A record sets the window to its own event; a wait/other marker has a null
-    // coalesceEvent() and so clears it, which a cross-stream wait relies on.
-    last_barrier_coalesce_event_ = vcmd.coalesceEvent();
+    // A record sets the window to its own event and barrier signal; a wait/other
+    // marker has a zero coalesceEvent() and so clears it, which a wait relies on.
+    uint64_t ev = vcmd.coalesceEvent();
+    SetCoalesceWindow(ev, ev != 0 ? command_->HwEvent() : nullptr);
     profilingEnd();
   }
   force_irq_ = false;

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -729,12 +729,11 @@ class VirtualGPU : public device::VirtualDevice {
     return false;
   }
 
-  //! Returns true if the marker's barrier can be skipped because it records the
-  //! same client event as the immediately preceding barrier, with no intervening
-  //! dispatch and no sync since that record. Caller must hold the execution() lock.
+  //! True if this marker records the same event as the preceding barrier with no
+  //! intervening dispatch or sync. Caller must hold the execution() lock.
   bool ShouldCoalesceMarker(const amd::Marker& vcmd) const {
-    // A null coalesceEvent() means the record either didn't opt in (timing
-    // enabled) or isn't a record at all, so it can never be coalesced.
+    // A null coalesceEvent() means the record didn't opt in or isn't a record,
+    // so it can never be coalesced.
     void* event = vcmd.coalesceEvent();
     if (event == nullptr || event != last_barrier_coalesce_event_) {
       return false;
@@ -761,9 +760,8 @@ class VirtualGPU : public device::VirtualDevice {
 
   Timestamp* timestamp_;
   amd::Command* command_;   //!< Current command
-  //! Opaque client event identity of the last barrier dispatched by submitMarker.
-  //! Used to coalesce consecutive markers for the same event. Accessed only under
-  //! the execution() lock. Never dereferenced; compared for identity only.
+  //! Opaque client event of the last barrier from submitMarker, used to coalesce
+  //! consecutive records. Execution() lock only; never dereferenced.
   void* last_barrier_coalesce_event_ = nullptr;
   hsa_agent_t gpu_device_;  //!< Physical device
   hsa_queue_t* gpu_queue_;  //!< Active queue associated with a vgpu

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -729,6 +729,22 @@ class VirtualGPU : public device::VirtualDevice {
     return false;
   }
 
+  //! Returns true if the marker's barrier can be skipped because it records the
+  //! same client event as the immediately preceding barrier, with no intervening
+  //! dispatch and no sync since that record. Caller must hold the execution() lock.
+  bool ShouldCoalesceMarker(const amd::Marker& vcmd) const {
+    // A null coalesceEvent() means the record either didn't opt in (timing
+    // enabled) or isn't a record at all, so it can never be coalesced.
+    void* event = vcmd.coalesceEvent();
+    if (event == nullptr || event != last_barrier_coalesce_event_) {
+      return false;
+    }
+    if (IsPendingDispatch() || vcmd.syncedSinceRecord()) {
+      return false;
+    }
+    return true;
+  }
+
   //! Queue state flags
   union {
     struct {
@@ -745,6 +761,10 @@ class VirtualGPU : public device::VirtualDevice {
 
   Timestamp* timestamp_;
   amd::Command* command_;   //!< Current command
+  //! Opaque client event identity of the last barrier dispatched by submitMarker.
+  //! Used to coalesce consecutive markers for the same event. Accessed only under
+  //! the execution() lock. Never dereferenced; compared for identity only.
+  void* last_barrier_coalesce_event_ = nullptr;
   hsa_agent_t gpu_device_;  //!< Physical device
   hsa_queue_t* gpu_queue_;  //!< Active queue associated with a vgpu
   hsa_barrier_and_packet_t barrier_packet_ {};

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -732,10 +732,10 @@ class VirtualGPU : public device::VirtualDevice {
   //! True if this marker records the same event as the preceding barrier with no
   //! intervening dispatch or sync. Caller must hold the execution() lock.
   bool ShouldCoalesceMarker(const amd::Marker& vcmd) const {
-    // A null coalesceEvent() means the record didn't opt in or isn't a record,
+    // A zero coalesceEvent() means the record didn't opt in or isn't a record,
     // so it can never be coalesced.
-    void* event = vcmd.coalesceEvent();
-    if (event == nullptr || event != last_barrier_coalesce_event_) {
+    uint64_t event_id = vcmd.coalesceEvent();
+    if (event_id == 0 || event_id != last_barrier_coalesce_event_) {
       return false;
     }
     if (IsPendingDispatch() || vcmd.syncedSinceRecord()) {
@@ -743,6 +743,15 @@ class VirtualGPU : public device::VirtualDevice {
     }
     return true;
   }
+
+  //! Set the coalescing window to the given event and its barrier's HwEvent,
+  //! retaining the new signal and releasing the previously held one. Pass
+  //! (0, nullptr) to end the window. Caller must hold the execution() lock.
+  void SetCoalesceWindow(uint64_t event_id, void* hw_event);
+
+  //! Attach a ProfilingSignal to a command as its HwEvent, releasing any prior
+  //! one and retaining the new one. No-op if cmd or hw_event is null.
+  static void AttachHwEvent(amd::Command* cmd, void* hw_event);
 
   //! Queue state flags
   union {
@@ -760,9 +769,12 @@ class VirtualGPU : public device::VirtualDevice {
 
   Timestamp* timestamp_;
   amd::Command* command_;   //!< Current command
-  //! Opaque client event of the last barrier from submitMarker, used to coalesce
-  //! consecutive records. Execution() lock only; never dereferenced.
-  void* last_barrier_coalesce_event_ = nullptr;
+  //! Monotonic client coalesce id of the last barrier from submitMarker, used to
+  //! coalesce consecutive records. Execution() lock only. 0 = no window open.
+  uint64_t last_barrier_coalesce_event_ = 0;
+  //! Retained ProfilingSignal of that last barrier; a coalesced record reuses it
+  //! as its HwEvent so query/sync observe correct readiness. Released on reset.
+  void* last_barrier_hw_event_ = nullptr;
   hsa_agent_t gpu_device_;  //!< Physical device
   hsa_queue_t* gpu_queue_;  //!< Active queue associated with a vgpu
   hsa_barrier_and_packet_t barrier_packet_ {};

--- a/projects/clr/rocclr/platform/command.hpp
+++ b/projects/clr/rocclr/platform/command.hpp
@@ -1501,9 +1501,9 @@ class ExternalSemaphoreCmd : public Command {
 class Marker : public Command {
   device::Signal* ipc_completion_signal_ = nullptr;
   device::Signal* ipc_dep_signal_ = nullptr;
-  //! Opaque client (HIP) event identity for detecting consecutive records; a
-  //! non-null value also opts the record into coalescing. Compared, never deref'd.
-  void* coalesce_event_ = nullptr;
+  //! Monotonic client (HIP) coalesce identity for detecting consecutive records;
+  //! a non-zero value also opts the record into coalescing. 0 = not coalesceable.
+  uint64_t coalesce_event_ = 0;
   bool synced_since_record_ = false;  //!< Client synced the event since its last record
 
  public:
@@ -1522,10 +1522,10 @@ class Marker : public Command {
   void setIpcDepSignal(device::Signal* s) { ipc_dep_signal_ = s; }
   device::Signal* ipcDepSignal() const { return ipc_dep_signal_; }
 
-  //! Coalescing metadata set by the client layer (opaque to rocclr). A non-null
+  //! Coalescing metadata set by the client layer (opaque to rocclr). A non-zero
   //! coalesceEvent() both identifies the event and marks the record eligible.
-  void setCoalesceEvent(void* e) { coalesce_event_ = e; }
-  void* coalesceEvent() const { return coalesce_event_; }
+  void setCoalesceEvent(uint64_t id) { coalesce_event_ = id; }
+  uint64_t coalesceEvent() const { return coalesce_event_; }
   void setSyncedSinceRecord(bool v) { synced_since_record_ = v; }
   bool syncedSinceRecord() const { return synced_since_record_; }
 

--- a/projects/clr/rocclr/platform/command.hpp
+++ b/projects/clr/rocclr/platform/command.hpp
@@ -443,9 +443,8 @@ class Command : public Event {
    */
   virtual void submit(device::VirtualDevice& device) = 0;
 
-  //! True only for marker commands. The device layer uses this to leave its
-  //! event-record coalescing window intact across markers while resetting it for
-  //! any other command (which represents intervening work).
+  //! True only for marker commands; lets the device layer keep its coalescing
+  //! window across markers while resetting it for any other (intervening) command.
   virtual bool isMarkerCommand() const { return false; }
 
   //! Release the resources associated with this event.
@@ -1502,10 +1501,8 @@ class ExternalSemaphoreCmd : public Command {
 class Marker : public Command {
   device::Signal* ipc_completion_signal_ = nullptr;
   device::Signal* ipc_dep_signal_ = nullptr;
-  //! Opaque client (HIP) event identity used to detect consecutive records of the
-  //! same event so the device layer can skip a redundant barrier dispatch. A
-  //! non-null value also means the client opted this record into coalescing.
-  //! Never dereferenced here; only compared for identity.
+  //! Opaque client (HIP) event identity for detecting consecutive records; a
+  //! non-null value also opts the record into coalescing. Compared, never deref'd.
   void* coalesce_event_ = nullptr;
   bool synced_since_record_ = false;  //!< Client synced the event since its last record
 

--- a/projects/clr/rocclr/platform/command.hpp
+++ b/projects/clr/rocclr/platform/command.hpp
@@ -443,6 +443,11 @@ class Command : public Event {
    */
   virtual void submit(device::VirtualDevice& device) = 0;
 
+  //! True only for marker commands. The device layer uses this to leave its
+  //! event-record coalescing window intact across markers while resetting it for
+  //! any other command (which represents intervening work).
+  virtual bool isMarkerCommand() const { return false; }
+
   //! Release the resources associated with this event.
   virtual void releaseResources();
 
@@ -1497,6 +1502,12 @@ class ExternalSemaphoreCmd : public Command {
 class Marker : public Command {
   device::Signal* ipc_completion_signal_ = nullptr;
   device::Signal* ipc_dep_signal_ = nullptr;
+  //! Opaque client (HIP) event identity used to detect consecutive records of the
+  //! same event so the device layer can skip a redundant barrier dispatch. A
+  //! non-null value also means the client opted this record into coalescing.
+  //! Never dereferenced here; only compared for identity.
+  void* coalesce_event_ = nullptr;
+  bool synced_since_record_ = false;  //!< Client synced the event since its last record
 
  public:
   //! Create a new Marker
@@ -1513,6 +1524,15 @@ class Marker : public Command {
   //! Attach an IPC signal as dep_signal on the barrier packet (for stream wait)
   void setIpcDepSignal(device::Signal* s) { ipc_dep_signal_ = s; }
   device::Signal* ipcDepSignal() const { return ipc_dep_signal_; }
+
+  //! Coalescing metadata set by the client layer (opaque to rocclr). A non-null
+  //! coalesceEvent() both identifies the event and marks the record eligible.
+  void setCoalesceEvent(void* e) { coalesce_event_ = e; }
+  void* coalesceEvent() const { return coalesce_event_; }
+  void setSyncedSinceRecord(bool v) { synced_since_record_ = v; }
+  bool syncedSinceRecord() const { return synced_since_record_; }
+
+  bool isMarkerCommand() const override { return true; }
 
   //! The actual command implementation.
   virtual void submit(device::VirtualDevice& device) { device.submitMarker(*this); }

--- a/projects/hip-tests/catch/config/configs/unit/event.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/event.yaml
@@ -135,3 +135,15 @@ event:
   Unit_hipEventIpc_shm_cleanup:
     <<: *level_2
     tags: [ipc]
+  Unit_hipEventCoalescing_CrossStreamWait:
+    <<: *level_2
+    tags: [synchronization]
+  Unit_hipEventCoalescing_AsyncOpsBreakCoalescing:
+    <<: *level_2
+    tags: [synchronization]
+  Unit_hipEventCoalescing_InterleavedEvents:
+    <<: *level_2
+    tags: [synchronization]
+  Unit_hipEventCoalescing_EventQuery:
+    <<: *level_2
+    tags: [synchronization]

--- a/projects/hip-tests/catch/unit/event/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/event/CMakeLists.txt
@@ -14,6 +14,7 @@ set(TEST_SRC
     hipEventCreateWithFlags.cc
     hipEventSynchronize.cc
     Unit_hipEventMGpuMThreads.cc
+    hipEventCoalescing.cc
 )
 
 # The test used wait mechanism and doesnt play well with all arch of nvidia

--- a/projects/hip-tests/catch/unit/event/hipEventCoalescing.cc
+++ b/projects/hip-tests/catch/unit/event/hipEventCoalescing.cc
@@ -1,0 +1,353 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <hip_test_common.hh>
+#include <hip_test_checkers.hh>
+#include <hip_test_kernels.hh>
+
+#include <algorithm>
+#include <vector>
+
+/**
+ * @addtogroup hipEventRecord hipEventRecord
+ * @{
+ * @ingroup EventTest
+ */
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Validates cross-stream synchronization via hipStreamWaitEvent works correctly
+ *    when coalescing is active. This is the most safety-critical scenario for
+ *    coalescing — if a needed barrier is wrongly skipped, the waiting stream
+ *    could start before the producing stream's work completes, causing data races.
+ *  - Scenario per iteration:
+ *    1. Stream1 launches vectorADD producing C_d
+ *    2. Stream1 records event multiple times (consecutive should coalesce)
+ *    3. Stream2 waits on event via hipStreamWaitEvent
+ *    4. Stream2 launches vectorADDReverse that reads C_d and writes D_d
+ *    5. Validate D_d matches expected (proves stream2's kernel saw stream1's writes)
+ *  - If coalescing wrongly skipped the barrier, D_d would contain stale/garbage data.
+ * Test source
+ * ------------------------
+ *  - unit/event/hipEventCoalescing.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.2
+ */
+HIP_TEST_CASE(Unit_hipEventCoalescing_CrossStreamWait) {
+  constexpr size_t N = 1024 * 1024;
+  constexpr size_t Nbytes = N * sizeof(float);
+  constexpr int kNumIterations = 10;
+  constexpr int kThreadsPerBlock = 256;
+  const int kBlocks = (N + kThreadsPerBlock - 1) / kThreadsPerBlock;
+
+  float *A_h, *B_h, *C_h, *D_h;
+  float *A_d, *B_d, *C_d, *D_d;
+  HipTest::initArrays(&A_d, &B_d, &C_d, &A_h, &B_h, &C_h, N);
+  HIP_CHECK(hipMalloc(&D_d, Nbytes));
+  D_h = reinterpret_cast<float*>(malloc(Nbytes));
+
+  hipStream_t stream1, stream2;
+  hipEvent_t event;
+  HIP_CHECK(hipStreamCreate(&stream1));
+  HIP_CHECK(hipStreamCreate(&stream2));
+  HIP_CHECK(hipEventCreateWithFlags(&event, hipEventDisableTiming));
+
+  HIP_CHECK(hipMemcpy(A_d, A_h, Nbytes, hipMemcpyHostToDevice));
+  HIP_CHECK(hipMemcpy(B_d, B_h, Nbytes, hipMemcpyHostToDevice));
+
+  for (int iter = 0; iter < kNumIterations; iter++) {
+    // Reset destination on stream1 to known garbage so stale reads would be visible
+    HIP_CHECK(hipMemsetAsync(C_d, 0xFF, Nbytes, stream1));
+
+    // Producer: stream1 computes C_d = A_d + B_d
+    HipTest::launchKernel<float>(HipTest::vectorADD<float>, kBlocks, kThreadsPerBlock, 0, stream1,
+                                 static_cast<const float*>(A_d),
+                                 static_cast<const float*>(B_d),
+                                 C_d, N);
+    HIP_CHECK(hipGetLastError());
+
+    // Record event multiple times on stream1 (should coalesce — but the barrier
+    // must survive coalescing so stream2's wait sees stream1's kernel completion)
+    HIP_CHECK(hipEventRecord(event, stream1));
+    HIP_CHECK(hipEventRecord(event, stream1));  // Should coalesce
+    HIP_CHECK(hipEventRecord(event, stream1));  // Should coalesce
+
+    // Consumer: stream2 waits on event, then reads C_d and writes D_d = C_d + B_d
+    HIP_CHECK(hipStreamWaitEvent(stream2, event, 0));
+    HipTest::launchKernel<float>(HipTest::vectorADDReverse<float>, kBlocks, kThreadsPerBlock, 0,
+                                 stream2, static_cast<const float*>(C_d),
+                                 static_cast<const float*>(B_d), D_d, N);
+    HIP_CHECK(hipGetLastError());
+
+    HIP_CHECK(hipStreamSynchronize(stream2));
+
+    // D_d should equal (A_d + B_d) + B_d
+    HIP_CHECK(hipMemcpy(D_h, D_d, Nbytes, hipMemcpyDeviceToHost));
+    for (size_t i = 0; i < N; i++) {
+      float expected = (A_h[i] + B_h[i]) + B_h[i];
+      REQUIRE(D_h[i] == expected);
+    }
+  }
+
+  HIP_CHECK(hipEventDestroy(event));
+  HIP_CHECK(hipStreamDestroy(stream1));
+  HIP_CHECK(hipStreamDestroy(stream2));
+  HIP_CHECK(hipFree(D_d));
+  free(D_h);
+  HipTest::freeArrays(A_d, B_d, C_d, A_h, B_h, C_h, false);
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Validates that async memcpy and memset between hipEventRecord calls
+ *    correctly break coalescing. After such operations, the next record must
+ *    submit a fresh barrier (otherwise the event sync wouldn't wait for the
+ *    intervening copy/set to complete).
+ *  - Two SECTIONs: one for memcpy break, one for memset break.
+ *  - Pattern per section:
+ *    1. record event
+ *    2. async memcpy/memset on same stream (must break coalescing)
+ *    3. record event (must NOT coalesce — submits new barrier covering step 2)
+ *    4. sync event, validate the intervening operation completed
+ * Test source
+ * ------------------------
+ *  - unit/event/hipEventCoalescing.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.2
+ */
+HIP_TEST_CASE(Unit_hipEventCoalescing_AsyncOpsBreakCoalescing) {
+  constexpr size_t N = 1024 * 1024;
+  constexpr size_t Nbytes = N * sizeof(int);
+  constexpr int kNumIterations = 10;
+
+  hipStream_t stream;
+  hipEvent_t event;
+  HIP_CHECK(hipStreamCreate(&stream));
+  HIP_CHECK(hipEventCreateWithFlags(&event, hipEventDisableTiming));
+
+  int* d_buf;
+  HIP_CHECK(hipMalloc(&d_buf, Nbytes));
+  std::vector<int> h_buf(N);
+
+  SECTION("Memcpy breaks coalescing") {
+    for (int iter = 0; iter < kNumIterations; iter++) {
+      // Fill host source buffer with iter-specific value
+      const int sentinel = 0xDEAD0000 + iter;
+      std::fill(h_buf.begin(), h_buf.end(), sentinel);
+
+      // First record - submits barrier
+      HIP_CHECK(hipEventRecord(event, stream));
+
+      // Async memcpy - must break coalescing
+      HIP_CHECK(hipMemcpyAsync(d_buf, h_buf.data(), Nbytes, hipMemcpyHostToDevice, stream));
+
+      // Second record - must submit new barrier (NOT coalesce) so sync waits for memcpy
+      HIP_CHECK(hipEventRecord(event, stream));
+
+      // Sync event - if coalescing wrongly skipped the second barrier, the memcpy
+      // might not have completed when we read back
+      HIP_CHECK(hipEventSynchronize(event));
+
+      // Read back without further sync — relies on event sync covering the memcpy
+      std::vector<int> h_verify(N, 0);
+      HIP_CHECK(hipMemcpy(h_verify.data(), d_buf, Nbytes, hipMemcpyDeviceToHost));
+      for (size_t i = 0; i < N; i++) {
+        REQUIRE(h_verify[i] == sentinel);
+      }
+    }
+  }
+
+  SECTION("Memset breaks coalescing") {
+    for (int iter = 0; iter < kNumIterations; iter++) {
+      const unsigned char pattern = static_cast<unsigned char>(0x40 + iter);
+      const int expected = (pattern << 24) | (pattern << 16) | (pattern << 8) | pattern;
+
+      HIP_CHECK(hipEventRecord(event, stream));
+
+      // Async memset - must break coalescing
+      HIP_CHECK(hipMemsetAsync(d_buf, pattern, Nbytes, stream));
+
+      // Second record - must submit new barrier
+      HIP_CHECK(hipEventRecord(event, stream));
+
+      HIP_CHECK(hipEventSynchronize(event));
+
+      std::vector<int> h_verify(N, 0);
+      HIP_CHECK(hipMemcpy(h_verify.data(), d_buf, Nbytes, hipMemcpyDeviceToHost));
+      for (size_t i = 0; i < N; i++) {
+        REQUIRE(h_verify[i] == expected);
+      }
+    }
+  }
+
+  HIP_CHECK(hipFree(d_buf));
+  HIP_CHECK(hipEventDestroy(event));
+  HIP_CHECK(hipStreamDestroy(stream));
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Validates that interleaving records of different events on the same stream
+ *    does not cause incorrect coalescing.
+ *  - Coalescing only applies when last_packet was BARRIER for the SAME event.
+ *  - Scenario:
+ *    1. kernel_A on stream
+ *    2. record event1  (barrier for event1)
+ *    3. record event2  (different event - must NOT coalesce, new barrier)
+ *    4. record event1  (last packet was event2's barrier - must NOT coalesce)
+ *    5. kernel_B on stream
+ *    6. record event2  (different event - must NOT coalesce)
+ *  - Both events must independently capture the correct point in the stream.
+ *  - event1's final record point is between kernel_A and kernel_B (after step 4)
+ *  - event2's final record point is after kernel_B (after step 6)
+ * Test source
+ * ------------------------
+ *  - unit/event/hipEventCoalescing.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.2
+ */
+HIP_TEST_CASE(Unit_hipEventCoalescing_InterleavedEvents) {
+  constexpr size_t N = 1024 * 1024;
+  constexpr size_t Nbytes = N * sizeof(float);
+  constexpr int kNumIterations = 10;
+  constexpr int kThreadsPerBlock = 256;
+  const int kBlocks = (N + kThreadsPerBlock - 1) / kThreadsPerBlock;
+
+  float *A_h, *B_h, *C_h;
+  float *A_d, *B_d, *C_d, *D_d;
+  HipTest::initArrays(&A_d, &B_d, &C_d, &A_h, &B_h, &C_h, N);
+  HIP_CHECK(hipMalloc(&D_d, Nbytes));
+
+  hipStream_t stream1, stream2;
+  hipEvent_t event1, event2;
+  HIP_CHECK(hipStreamCreate(&stream1));
+  HIP_CHECK(hipStreamCreate(&stream2));
+  HIP_CHECK(hipEventCreateWithFlags(&event1, hipEventDisableTiming));
+  HIP_CHECK(hipEventCreateWithFlags(&event2, hipEventDisableTiming));
+
+  HIP_CHECK(hipMemcpy(A_d, A_h, Nbytes, hipMemcpyHostToDevice));
+  HIP_CHECK(hipMemcpy(B_d, B_h, Nbytes, hipMemcpyHostToDevice));
+
+  for (int iter = 0; iter < kNumIterations; iter++) {
+    // kernel_A: C_d = A_d + B_d
+    HipTest::launchKernel<float>(HipTest::vectorADD<float>, kBlocks, kThreadsPerBlock, 0, stream1,
+                                 static_cast<const float*>(A_d),
+                                 static_cast<const float*>(B_d),
+                                 C_d, N);
+    HIP_CHECK(hipGetLastError());
+
+    // Interleaved records - none should coalesce because event identity changes
+    HIP_CHECK(hipEventRecord(event1, stream1));  // barrier(event1)
+    HIP_CHECK(hipEventRecord(event2, stream1));  // different event — NOT coalesce
+    HIP_CHECK(hipEventRecord(event1, stream1));  // last was event2 — NOT coalesce
+
+    // kernel_B: D_d = A_d - B_d (after event1's final record point)
+    HipTest::launchKernel<float>(HipTest::vectorSUB<float>, kBlocks, kThreadsPerBlock, 0, stream1,
+                                 static_cast<const float*>(A_d),
+                                 static_cast<const float*>(B_d),
+                                 D_d, N);
+    HIP_CHECK(hipGetLastError());
+
+    HIP_CHECK(hipEventRecord(event2, stream1));  // different event — NOT coalesce
+
+    // event2 captures point AFTER kernel_B. If stream2 waits on event2 and reads D_d,
+    // it should see kernel_B's output. If event2 wrongly coalesced with event1,
+    // stream2 would not wait long enough.
+    HIP_CHECK(hipStreamWaitEvent(stream2, event2, 0));
+
+    // Validate kernel_B's output is readable after waiting on event2
+    std::vector<float> D_h(N);
+    HIP_CHECK(hipMemcpyAsync(D_h.data(), D_d, Nbytes, hipMemcpyDeviceToHost, stream2));
+    HIP_CHECK(hipStreamSynchronize(stream2));
+    HipTest::checkVectorSUB(A_h, B_h, D_h.data(), N);
+
+    // Validate kernel_A's output via event1 wait on a fresh stream wait
+    HIP_CHECK(hipEventSynchronize(event1));
+    HIP_CHECK(hipMemcpy(C_h, C_d, Nbytes, hipMemcpyDeviceToHost));
+    HipTest::checkVectorADD(A_h, B_h, C_h, N);
+  }
+
+  HIP_CHECK(hipEventDestroy(event1));
+  HIP_CHECK(hipEventDestroy(event2));
+  HIP_CHECK(hipStreamDestroy(stream1));
+  HIP_CHECK(hipStreamDestroy(stream2));
+  HIP_CHECK(hipFree(D_d));
+  HipTest::freeArrays(A_d, B_d, C_d, A_h, B_h, C_h, false);
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Validates that hipEventQuery returns correct status after coalesced records.
+ *  - If the last record was coalesced (no fresh barrier submitted), the event
+ *    should still report the status of the actual last submitted barrier.
+ *  - Scenario:
+ *    1. Launch long-running kernel (busy work)
+ *    2. Record event multiple times (later records coalesce)
+ *    3. hipEventQuery should report NotReady while kernel runs
+ *    4. After hipDeviceSynchronize, hipEventQuery should report Success
+ * Test source
+ * ------------------------
+ *  - unit/event/hipEventCoalescing.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 5.2
+ */
+HIP_TEST_CASE(Unit_hipEventCoalescing_EventQuery) {
+  constexpr size_t N = 1024 * 64;
+  constexpr size_t Nbytes = N * sizeof(int);
+  constexpr int kNumIterations = 5;
+  constexpr int kThreadsPerBlock = 256;
+  const int kBlocks = (N + kThreadsPerBlock - 1) / kThreadsPerBlock;
+  // High count makes addCount slow enough to query before completion
+  constexpr int kSlowCount = 10000;
+
+  hipStream_t stream;
+  hipEvent_t event;
+  HIP_CHECK(hipStreamCreate(&stream));
+  HIP_CHECK(hipEventCreateWithFlags(&event, hipEventDisableTiming));
+
+  int *A_d, *C_d;
+  HIP_CHECK(hipMalloc(&A_d, Nbytes));
+  HIP_CHECK(hipMalloc(&C_d, Nbytes));
+  HIP_CHECK(hipMemset(A_d, 0, Nbytes));
+
+  for (int iter = 0; iter < kNumIterations; iter++) {
+    // Launch slow kernel
+    HipTest::launchKernel<int>(HipTest::addCount<int>, kBlocks, kThreadsPerBlock, 0, stream,
+                               static_cast<const int*>(A_d), C_d, N, kSlowCount);
+    HIP_CHECK(hipGetLastError());
+
+    // Record event multiple times - later records should coalesce
+    HIP_CHECK(hipEventRecord(event, stream));
+    HIP_CHECK(hipEventRecord(event, stream));  // Should coalesce
+    HIP_CHECK(hipEventRecord(event, stream));  // Should coalesce
+
+    // Query event - should be NotReady because slow kernel is still running.
+    // If coalescing wrongly returned success without a barrier, this would fail.
+    hipError_t query_status = hipEventQuery(event);
+    REQUIRE((query_status == hipErrorNotReady || query_status == hipSuccess));
+
+    // After full sync, query must report success
+    HIP_CHECK(hipStreamSynchronize(stream));
+    HIP_CHECK(hipEventQuery(event));
+  }
+
+  HIP_CHECK(hipFree(A_d));
+  HIP_CHECK(hipFree(C_d));
+  HIP_CHECK(hipEventDestroy(event));
+  HIP_CHECK(hipStreamDestroy(stream));
+}
+
+/**
+ * @}
+ */

--- a/projects/hip-tests/catch/unit/event/hipEventCoalescing.cc
+++ b/projects/hip-tests/catch/unit/event/hipEventCoalescing.cc
@@ -138,7 +138,7 @@ HIP_TEST_CASE(Unit_hipEventCoalescing_AsyncOpsBreakCoalescing) {
   SECTION("Memcpy breaks coalescing") {
     for (int iter = 0; iter < kNumIterations; iter++) {
       // Fill host source buffer with iter-specific value
-      const int sentinel = 0xDEAD0000 + iter;
+      const int sentinel = 0x12340000 + iter;
       std::fill(h_buf.begin(), h_buf.end(), sentinel);
 
       // First record - submits barrier

--- a/projects/hip-tests/catch/unit/event/hipEventCoalescing.cc
+++ b/projects/hip-tests/catch/unit/event/hipEventCoalescing.cc
@@ -51,6 +51,8 @@ HIP_TEST_CASE(Unit_hipEventCoalescing_CrossStreamWait) {
   HIP_CHECK(hipMalloc(&D_d, Nbytes));
   D_h = reinterpret_cast<float*>(malloc(Nbytes));
 
+  REQUIRE(D_h != nullptr);
+
   hipStream_t stream1, stream2;
   hipEvent_t event;
   HIP_CHECK(hipStreamCreate(&stream1));
@@ -88,10 +90,7 @@ HIP_TEST_CASE(Unit_hipEventCoalescing_CrossStreamWait) {
 
     // D_d should equal (A_d + B_d) + B_d
     HIP_CHECK(hipMemcpy(D_h, D_d, Nbytes, hipMemcpyDeviceToHost));
-    for (size_t i = 0; i < N; i++) {
-      float expected = (A_h[i] + B_h[i]) + B_h[i];
-      REQUIRE(D_h[i] == expected);
-    }
+    HipTest::checkVectors<float>(A_h, B_h, D_h, N, [](float a, float b) { return (a + b) + b; });
   }
 
   HIP_CHECK(hipEventDestroy(event));


### PR DESCRIPTION
## Motivation
### Event Coalescing ###
- Skip redundant barrier packet submission when consecutive hipEventRecord calls target the same event on a stream with no intervening async work.
- Consecutive hipEventRecord calls on the same timing-disabled event now coalesce : the HIP     
  layer tags each record marker with the event's opaque identity, and VirtualGPU::submitMarker skips the redundant
  barrier when the previous barrier was for the same event with no intervening dispatch or sync. The coalescing    
  window is reset at a single choke point (profilingBegin for any non-marker command, plus fences and stream-wait
  markers), keeping timing-enabled events and cross-stream dependencies correct.  

### hipEventDisableTiming Flag ###
- Fixes the record path so timing-disabled events skip profiling overhead in rocvirtual.cpp, which is a prerequisite 
  for safe coalescing (only non-timing events are eligible).
### hip tests ###
- New hipEventCoalescing.cc tests added — CrossStreamWait, AsyncOpsBreakCoalescing, InterleavedEvents, and EventQuery — validating correctness when coalescing interacts with hipStreamWaitEvent, intervening memcpy/memset ops, distinct events, and event query status.

### CUDA Parity ###
- Performance of hipEventRecord is comparable with cuda as tested with the reproducer from ticket:

<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-US style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<div style='direction:ltr'>


Device | Time per call (ns)
-- | --
NVDA 5060 | 209.2
NV48 (Pre-Fix) | 4108.1 ( 20X slow)
NV48 (Post-Coalescing-Fix) | 395 ( 2X slow)



</div>

<!--EndFragment-->
</body>

</html>



## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
