### PR TITLE
[rdhc] Fix security vulnerabilities in temporary directory handling

### DIFF
--- a/projects/rocm-core/rdhc/README.md
+++ b/projects/rocm-core/rdhc/README.md
@@ -64,7 +64,7 @@ sudo pip3 install -r requirements.txt
 
 ```bash
 ./rdhc.py -h
-usage: sudo -E rdhc.py [options]
+usage: ./rdhc.py [options]
 
 ROCm Deployment Health Check Tool
 
@@ -75,7 +75,8 @@ optional arguments:
   -v, --verbose         Enable verbose output
   -s, --silent          Silent mode (errors only)
   -j FILE, --json FILE  Export results to JSON file
-  -d DIR, --dir DIR     Directory path for temporary files (default: /tmp/rdhc/)
+  -d DIR, --dir DIR     Directory path for temporary files (must not exist; created with mode 0700)
+  --cleanup             Remove auto-generated temp directory after tests complete
   --rocm-install-prefix DIR  ROCm installation prefix. If set, this path is used; otherwise `ROCM_PATH` env or `/opt/rocm` is used.
   --skip-multinode-readiness   Skip multinode cluster readiness test (e.g. single-node or no RDMA stack)
   --skip-atomic-operations     Skip PCIe atomic operations test (e.g. containers or limited lspci)
@@ -87,45 +88,50 @@ optional arguments:
 
 ```bash
 # Run quick test (default tests only)
-sudo -E ./rdhc.py
+./rdhc.py
 
 # Run all tests including compile and execute the rocm-example program for each component
-sudo -E ./rdhc.py --all
+./rdhc.py --all
 
 # Run all tests with verbose output
-sudo -E ./rdhc.py --all -v
+./rdhc.py --all -v
 
 # Enable verbose output
-sudo -E ./rdhc.py -v
+./rdhc.py -v
 
 # Run in silent mode (only errors shown)
-sudo -E ./rdhc.py -s
+./rdhc.py -s
 
 # Export results to a specific JSON file
-sudo -E ./rdhc.py --all --json rdhc-results.json
+./rdhc.py --all --json rdhc-results.json
 
-# Specify a directory for temp files and logs (default: /tmp/rdhc/)
-sudo -E ./rdhc.py -d /home/user/rdhc-dir/
+# Specify a directory for temp files (directory must not exist)
+./rdhc.py --all -d /home/user/rdhc-run1/
+
+# Auto-generate temp directory and clean it up after tests
+./rdhc.py --all --cleanup
 
 # Custom install prefix
-sudo -E ./rdhc.py --rocm-install-prefix /usr/local/rocm
+./rdhc.py --rocm-install-prefix /usr/local/rocm
 
 # Custom prefix and run all tests
-sudo -E ./rdhc.py --rocm-install-prefix /usr/local/rocm --all -v
+./rdhc.py --rocm-install-prefix /usr/local/rocm --all -v
 
 # Skip multinode + atomic checks (single-node or container-friendly)
-sudo -E ./rdhc.py --skip-optional-cluster-checks
+./rdhc.py --skip-optional-cluster-checks
 
 # Or skip only one of them
-sudo -E ./rdhc.py --skip-multinode-readiness
-sudo -E ./rdhc.py --skip-atomic-operations
+./rdhc.py --skip-multinode-readiness
+./rdhc.py --skip-atomic-operations
 
 # Kernel cmdline/sysctl checks: mismatches count as warnings, not FAIL
-sudo -E ./rdhc.py --kernel-params-warnings-only
+./rdhc.py --kernel-params-warnings-only
 
 # Combine with other options
-sudo -E ./rdhc.py --all --skip-optional-cluster-checks --kernel-params-warnings-only -v
+./rdhc.py --all --skip-optional-cluster-checks --kernel-params-warnings-only -v
 ```
+
+**Note on privileges:** Most checks run without elevated privileges. Some checks (e.g., `lspci -vvv` for atomic operations) may require root access. Run as root when necessary, or use `--skip-atomic-operations` if running unprivileged.
 
 ## Optional CLI behavior
 
@@ -171,23 +177,36 @@ source ~/rdhc-venv/bin/activate
 
 # Install required packages
 pip3 install -r requirements.txt
+
+# Run the tool (virtual environment activated)
+./rdhc.py
+./rdhc.py --all
 ```
 
-**Note for Ubuntu 24.04 users:** Due to enhanced security policies, `sudo -E` does not preserve the virtual environment PATH. Replace all `sudo -E` commands with `sudo --preserve-env=PATH` in the usage examples above.
+### Temporary Directory Behavior
 
-For example:
+When using `--all` mode, RDHC clones and builds rocm-examples:
+
+- **Without `-d` flag**: A secure temporary directory is auto-generated in `/tmp` (e.g., `/tmp/rdhc-abc123/`) with mode `0700`. By default, this directory persists after the run. Use `--cleanup` to remove it automatically.
+- **With `-d` flag**: The specified directory is created with mode `0700`. The directory **must not already exist** (for security reasons). If you need to reuse a directory, remove it first: `rm -rf /path/to/dir`
+
+Example workflow for repeated runs:
 
 ```bash
-# Instead of: sudo -E ./rdhc.py
-# Use:
-source ~/rdhc-venv/bin/activate
-sudo --preserve-env=PATH ./rdhc.py
+# Auto-generated temp dir (persists)
+./rdhc.py --all
+# Creates /tmp/rdhc-abc123/ (check logs or report for actual path)
 
-# Run all tests
-sudo --preserve-env=PATH ./rdhc.py --all
+# Auto-generated temp dir with automatic cleanup
+./rdhc.py --all --cleanup
+# Creates and removes temp dir after tests complete
 
-# Run with verbose output
-sudo --preserve-env=PATH ./rdhc.py -v
+# Custom directory (must not exist)
+./rdhc.py --all -d /tmp/my-rdhc-run1/   # First run with this path
+rm -rf /tmp/my-rdhc-run1/                # Clean up before next run
+./rdhc.py --all -d /tmp/my-rdhc-run1/   # Can reuse after cleanup
+
+# Note: --cleanup has no effect when -d is specified
 ```
 
 ---

--- a/projects/rocm-core/rdhc/rdhc.py
+++ b/projects/rocm-core/rdhc/rdhc.py
@@ -2100,6 +2100,7 @@ class ROCMHealthCheck:
         if run_all:
             # Store original directory
             original_dir = os.getcwd()
+            setup_failed = False
 
             try:
                 # Create or validate temp directory
@@ -2202,7 +2203,12 @@ class ROCMHealthCheck:
 
             except Exception as e:
                 self.logger.error(f"Error during rocm-examples setup: \n{str(e)}")
+                setup_failed = True
             finally:
+                if setup_failed:
+                    os.chdir(original_dir)
+                    return self.results, actual_temp_dir
+
                 # Run component tests
                 component_results = self.run_component_tests()
                 self.results.update(component_results)

--- a/projects/rocm-core/rdhc/rdhc.py
+++ b/projects/rocm-core/rdhc/rdhc.py
@@ -9,6 +9,8 @@ import glob
 import re
 import sys
 import textwrap
+import tempfile
+import stat
 from enum import Enum
 from pathlib import Path
 
@@ -1619,7 +1621,10 @@ class ROCMHealthCheck:
                 self.logger.warning(
                     f"!!! Failed to get atomic operations info for device {pci_address}"
                 )
-                self.logger.warning(f"!!! Try running the test with 'sudo -E' ")
+                if os.geteuid() != 0:
+                    self.logger.warning(
+                        f"!!! Try running as root or use --skip-atomic-operations"
+                    )
                 return pci_address, "check_failed", f"{pci_address}: Check failed"
 
             # Parse AtomicOpsCap and AtomicOpsCtl
@@ -2073,7 +2078,7 @@ class ROCMHealthCheck:
 
         return results
 
-    def run_tests(self, run_all=False, temp_dir="/tmp/rdhc/"):
+    def run_tests(self, run_all=False, temp_dir=None):
         """Run tests based on the run_all flag"""
         # Always run default tests
         self.results = self.run_default_tests()
@@ -2087,20 +2092,41 @@ class ROCMHealthCheck:
             original_dir = os.getcwd()
 
             try:
-                # Ensure temp directory exists
-                os.makedirs(temp_dir, exist_ok=True)
+                # Create or validate temp directory
+                if temp_dir is None:
+                    temp_dir = tempfile.mkdtemp(prefix="rdhc-")
+                    self.logger.info(f"Created temporary directory: {temp_dir}")
+                else:
+                    # User-specified directory - create safely
+                    os.makedirs(temp_dir, mode=0o700, exist_ok=False)
+                    self.logger.info(f"Created user-specified directory: {temp_dir}")
+
+                # Validate directory ownership and permissions
+                st = os.lstat(temp_dir)
+                if st.st_uid != os.geteuid():
+                    raise PermissionError(
+                        f"{temp_dir} is not owned by the current user (UID mismatch)"
+                    )
+                if stat.S_ISLNK(st.st_mode):
+                    raise PermissionError(f"{temp_dir} is a symbolic link")
+                if st.st_mode & 0o022:
+                    raise PermissionError(
+                        f"{temp_dir} has insecure permissions (world/group writable)"
+                    )
 
                 # Check if rocm-examples already exists
                 examples_dir = os.path.join(temp_dir, "rocm-examples")
                 if not os.path.exists(examples_dir):
-                    # Navigate to temp directory
-                    os.chdir(temp_dir)
-
-                    # Clone repository
+                    # Clone repository with safe command arguments
                     self.logger.info("Cloning rocm-examples repository...")
                     stdout, stderr, ret_code = run_command(
-                        "git clone https://github.com/ROCm/rocm-examples.git",
-                        shell=True,
+                        [
+                            "git",
+                            "clone",
+                            "--depth=1",
+                            "https://github.com/ROCm/rocm-examples.git",
+                            examples_dir,
+                        ]
                     )
                     if ret_code != 0:
                         self.logger.error(f"Failed to clone rocm-examples: \n{stderr}")
@@ -2120,7 +2146,9 @@ class ROCMHealthCheck:
                 if not os.path.exists(os.path.join(examples_dir, "build")):
                     # Configure with cmake
                     self.logger.info("Configuring rocm-examples with cmake...")
-                    stdout, stderr, ret_code = run_command("cmake -S . -B build")
+                    stdout, stderr, ret_code = run_command(
+                        ["cmake", "-S", ".", "-B", "build"]
+                    )
                     if ret_code != 0:
                         self.logger.error(
                             f"Failed to configure rocm-examples: \n{stderr}"
@@ -2135,7 +2163,7 @@ class ROCMHealthCheck:
                 # Get the avilabale build targets dynamically.
                 self.logger.info("Retrieving available build targets...")
                 stdout, stderr, ret_code = run_command(
-                    "cmake --build build --target help", shell=True
+                    ["cmake", "--build", "build", "--target", "help"]
                 )
                 if ret_code != 0:
                     self.logger.error(f"Failed to retrieve build targets: \n{stderr}")
@@ -2244,39 +2272,42 @@ def main():
     parser = argparse.ArgumentParser(
         description="ROCm Deployment Health Check Tool",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        usage="sudo -E ./rdhc.py [options]",
+        usage="./rdhc.py [options]",
         epilog="Refer the README @<ROCM_INSTALL_PATH>/share/rdhc/README.md \n"
         + "Usage examples:\n"
         + "# Run quick test (default tests only)\n"
-        + "sudo -E ./rdhc.py\n"
+        + "./rdhc.py\n"
         + "\n"
         + "# Run all tests including compile and execute the rocm-example program for each component\n"
-        + "sudo -E ./rdhc.py --all\n"
+        + "./rdhc.py --all\n"
         + "\n"
         + "# Run all tests with verbose output\n"
-        + "sudo -E ./rdhc.py --all -v\n"
+        + "./rdhc.py --all -v\n"
         + "\n"
         + "# Enable verbose output\n"
-        + "sudo -E ./rdhc.py -v\n"
+        + "./rdhc.py -v\n"
         + "\n"
         + "# Run in silent mode (only errors shown)\n"
-        + "sudo -E ./rdhc.py -s\n"
+        + "./rdhc.py -s\n"
         + "\n"
         + "# Export results to a specific JSON file\n"
-        + "sudo -E ./rdhc.py --all --json rdhc-results.json\n"
+        + "./rdhc.py --all --json rdhc-results.json\n"
         + "\n"
-        + "# Specify a directory for temp files and logs (default: /tmp/rdhc/)\n"
-        + "sudo -E ./rdhc.py -d /home/user/rdhc-dir/\n"
+        + "# Specify a directory for temp files and logs\n"
+        + "./rdhc.py -d /home/user/rdhc-dir/\n"
         + "\n"
         + "# Use a custom ROCm install prefix\n"
-        + "sudo -E ./rdhc.py --rocm-install-prefix /usr/local/rocm\n"
+        + "./rdhc.py --rocm-install-prefix /usr/local/rocm\n"
         + "\n"
         + "# Skip optional checks (e.g. single-node, containers without full PCI/RDMA)\n"
-        + "sudo -E ./rdhc.py --skip-optional-cluster-checks\n"
+        + "./rdhc.py --skip-optional-cluster-checks\n"
         + "# (or: --skip-multinode-readiness --skip-atomic-operations)\n"
         + "\n"
         + "# Kernel cmdline/sysctl checks: failures as warnings only (no FAIL on mismatch)\n"
-        + "sudo -E ./rdhc.py --kernel-params-warnings-only\n"
+        + "./rdhc.py --kernel-params-warnings-only\n"
+        + "\n"
+        + "NOTE: Some checks require root privileges (e.g., lspci -vvv for atomic operations).\n"
+        + "Run as root when necessary, or use --skip-atomic-operations if running unprivileged.\n"
         + "\n"
         + "NOTE for Ubuntu 24.04 (Python 3.12) users:\n"
         + "Due to enhanced security policies, you must use a virtual environment:\n"
@@ -2285,9 +2316,9 @@ def main():
         + "  source ~/rdhc-venv/bin/activate\n"
         + "  pip3 install -r requirements.txt\n"
         + "\n"
-        + "  # Run the tool (use --preserve-env=PATH instead of -E)\n"
-        + "  sudo --preserve-env=PATH ./rdhc.py\n"
-        + "  sudo --preserve-env=PATH ./rdhc.py --all\n"
+        + "  # Run the tool\n"
+        + "  ./rdhc.py\n"
+        + "  ./rdhc.py --all\n"
         + " ",
     )
 
@@ -2316,8 +2347,8 @@ def main():
         "-d",
         "--dir",
         metavar="DIR",
-        help="Directory path for temporary files (default: /tmp/rdhc/)",
-        default="/tmp/rdhc/",
+        help="Directory path for temporary files (default: auto-generated secure temp directory)",
+        default=None,
     )
     parser.add_argument(
         "--rocm-install-prefix",
@@ -2354,15 +2385,23 @@ def main():
     # Setup logger
     logger = setup_logger(args.verbose, args.silent)
 
-    # Ensure temp directory exists
+    # Handle temp directory (None means auto-generate in run_tests)
     temp_dir = args.dir
-    try:
-        os.makedirs(temp_dir, exist_ok=True)
-        logger.debug(f"Using temporary directory: {temp_dir}")
-    except Exception as e:
-        logger.error(f"Failed to create temporary directory {temp_dir}: {e}")
-        logger.info("Falling back to current directory")
-        temp_dir = "./"
+    if temp_dir is not None:
+        # Validate user-specified directory
+        try:
+            # Check if it's a valid path
+            if not os.path.isabs(temp_dir):
+                logger.warning(f"Relative path provided for temp directory: {temp_dir}")
+                temp_dir = os.path.abspath(temp_dir)
+                logger.info(f"Using absolute path: {temp_dir}")
+            logger.debug(f"Will use user-specified directory: {temp_dir}")
+        except Exception as e:
+            logger.error(f"Invalid temporary directory path {temp_dir}: {e}")
+            logger.info("Falling back to auto-generated temp directory")
+            temp_dir = None
+    else:
+        logger.debug("Will use auto-generated secure temporary directory")
 
     # If --rocm-install-prefix was passed and is non-empty; else keep current logic
     rocm_path = None
@@ -2395,7 +2434,9 @@ def main():
 
     # Generate and print report
     print("\nROCm Deployment Health Check Results:")
-    health_check.system_info["RDHC directory"] = temp_dir
+    health_check.system_info["RDHC directory"] = (
+        temp_dir if temp_dir is not None else "auto-generated"
+    )
     health_check.system_info["Json output file"] = args.json
 
     table = generate_table_system_info(health_check.system_info)
@@ -2412,10 +2453,14 @@ def main():
 
     # Export results to JSON if requested
     if args.json:
-        # If json path is not absolute, place it in the specified temp directory
+        # If json path is not absolute, use current directory or temp directory
         json_path = args.json
         if not os.path.isabs(json_path):
-            json_path = os.path.join(temp_dir, json_path)
+            if temp_dir is not None:
+                json_path = os.path.join(temp_dir, json_path)
+            else:
+                # Use current directory if no temp_dir specified
+                json_path = os.path.join(os.getcwd(), json_path)
 
         logger.info(f"Exporting results to JSON file: {json_path}")
         # Create a combined data dictionary with all information

--- a/projects/rocm-core/rdhc/rdhc.py
+++ b/projects/rocm-core/rdhc/rdhc.py
@@ -11,6 +11,7 @@ import sys
 import textwrap
 import tempfile
 import stat
+import shutil
 from enum import Enum
 from pathlib import Path
 
@@ -2078,28 +2079,51 @@ class ROCMHealthCheck:
 
         return results
 
-    def run_tests(self, run_all=False, temp_dir=None):
-        """Run tests based on the run_all flag"""
+    def run_tests(self, run_all=False, temp_dir=None, cleanup=False):
+        """Run tests based on the run_all flag
+
+        Args:
+            run_all: If True, run component tests by building rocm-examples
+            temp_dir: Directory for temporary files. None = auto-generate
+            cleanup: If True and temp_dir was auto-generated, remove it after tests
+
+        Returns:
+            tuple: (results, actual_temp_dir) where actual_temp_dir is None if not created,
+                   or the path to the temporary directory if run_all=True
+        """
         # Always run default tests
         self.results = self.run_default_tests()
+        actual_temp_dir = None
+        temp_dir_was_auto_generated = False
 
         # Run component tests if run_all is True
         if run_all:
-            # Clone and configure rocm-examples repository if its not already done.
-            # self.logger.info("Cloning rocm-examples repository...")
-
             # Store original directory
             original_dir = os.getcwd()
 
             try:
                 # Create or validate temp directory
                 if temp_dir is None:
-                    temp_dir = tempfile.mkdtemp(prefix="rdhc-")
+                    actual_temp_dir = tempfile.mkdtemp(prefix="rdhc-")
+                    temp_dir = actual_temp_dir
+                    temp_dir_was_auto_generated = True
                     self.logger.info(f"Created temporary directory: {temp_dir}")
                 else:
                     # User-specified directory - create safely
-                    os.makedirs(temp_dir, mode=0o700, exist_ok=False)
-                    self.logger.info(f"Created user-specified directory: {temp_dir}")
+                    try:
+                        os.makedirs(temp_dir, mode=0o700, exist_ok=False)
+                        actual_temp_dir = temp_dir
+                        self.logger.info(
+                            f"Created user-specified directory: {temp_dir}"
+                        )
+                    except FileExistsError:
+                        self.logger.error(
+                            f"Directory already exists: {temp_dir}\n"
+                            f"For security reasons, --dir requires a non-existent directory.\n"
+                            f"Please remove the directory first: rm -rf {temp_dir}\n"
+                            f"Or omit -d to use an auto-generated temp directory."
+                        )
+                        raise
 
                 # Validate directory ownership and permissions
                 st = os.lstat(temp_dir)
@@ -2190,7 +2214,21 @@ class ROCMHealthCheck:
                 # Return to original directory
                 os.chdir(original_dir)
 
-        return self.results
+                # Clean up auto-generated temp directory if requested
+                if cleanup and temp_dir_was_auto_generated and actual_temp_dir:
+                    try:
+                        self.logger.info(
+                            f"Cleaning up auto-generated temp directory: {actual_temp_dir}"
+                        )
+                        shutil.rmtree(actual_temp_dir)
+                        self.logger.info("Cleanup completed successfully")
+                        actual_temp_dir = None
+                    except Exception as e:
+                        self.logger.warning(
+                            f"Failed to clean up temp directory {actual_temp_dir}: {e}"
+                        )
+
+        return self.results, actual_temp_dir
 
     def _parse_rocm_example_targets(self, cmake_target_help_output):
         """Parse cmake target help output and categorize targets by component.
@@ -2293,8 +2331,11 @@ def main():
         + "# Export results to a specific JSON file\n"
         + "./rdhc.py --all --json rdhc-results.json\n"
         + "\n"
-        + "# Specify a directory for temp files and logs\n"
-        + "./rdhc.py -d /home/user/rdhc-dir/\n"
+        + "# Specify a directory for temp files (directory must not exist)\n"
+        + "./rdhc.py --all -d /home/user/rdhc-dir/\n"
+        + "\n"
+        + "# Auto-generate temp directory and clean it up after tests\n"
+        + "./rdhc.py --all --cleanup\n"
         + "\n"
         + "# Use a custom ROCm install prefix\n"
         + "./rdhc.py --rocm-install-prefix /usr/local/rocm\n"
@@ -2347,8 +2388,15 @@ def main():
         "-d",
         "--dir",
         metavar="DIR",
-        help="Directory path for temporary files (default: auto-generated secure temp directory)",
+        help="Directory path for temporary files. Must not already exist; will be created with mode 0700. "
+        "Default: auto-generated secure temp directory in /tmp (not auto-cleaned). "
+        "To reuse a directory, remove it first: rm -rf <dir>",
         default=None,
+    )
+    parser.add_argument(
+        "--cleanup",
+        action="store_true",
+        help="Remove auto-generated temp directory after tests complete (only applies when -d is not specified)",
     )
     parser.add_argument(
         "--rocm-install-prefix",
@@ -2430,13 +2478,20 @@ def main():
     )
 
     # Run tests with the temp_dir
-    health_check.run_tests(run_all=args.all, temp_dir=temp_dir)
+    results, actual_temp_dir = health_check.run_tests(
+        run_all=args.all, temp_dir=temp_dir, cleanup=args.cleanup
+    )
 
     # Generate and print report
     print("\nROCm Deployment Health Check Results:")
-    health_check.system_info["RDHC directory"] = (
-        temp_dir if temp_dir is not None else "auto-generated"
-    )
+    if actual_temp_dir is not None:
+        health_check.system_info["RDHC directory"] = actual_temp_dir
+    elif args.all and args.cleanup:
+        health_check.system_info["RDHC directory"] = "auto-generated (cleaned up)"
+    elif args.all:
+        health_check.system_info["RDHC directory"] = "N/A (creation failed)"
+    else:
+        health_check.system_info["RDHC directory"] = "N/A (quick mode)"
     health_check.system_info["Json output file"] = args.json
 
     table = generate_table_system_info(health_check.system_info)

--- a/projects/rocm-core/rdhc/rdhc.py
+++ b/projects/rocm-core/rdhc/rdhc.py
@@ -2205,17 +2205,14 @@ class ROCMHealthCheck:
                 self.logger.error(f"Error during rocm-examples setup: \n{str(e)}")
                 setup_failed = True
             finally:
-                if setup_failed:
-                    os.chdir(original_dir)
-                    return self.results, actual_temp_dir
+                if not setup_failed:
+                    # Run component tests
+                    component_results = self.run_component_tests()
+                    self.results.update(component_results)
 
-                # Run component tests
-                component_results = self.run_component_tests()
-                self.results.update(component_results)
-
-                # Run Simple Application tests
-                app_results = self.run_applications_tests()
-                self.results.update(app_results)
+                    # Run Simple Application tests
+                    app_results = self.run_applications_tests()
+                    self.results.update(app_results)
 
                 # Return to original directory
                 os.chdir(original_dir)


### PR DESCRIPTION
Create working directory with tempfile.mkdtemp() (mode 0700, unpredictable name, owned by caller) and refuse to reuse pre-existing directories. Additionally drop the sudo -E recommendation from help text and use os.geteuid() to gate privileged checks explicitly.

Security improvements:
- Use tempfile.mkdtemp(prefix="rdhc-") for auto-generated temp directories
- Validate directory ownership, permissions, and reject symlinks
- Create user-specified directories with mode 0o700 and exist_ok=False
- Replace shell=True command execution with safe array-based arguments
- Remove all sudo -E references from help text and examples
- Use os.geteuid() for explicit privilege checks

Changes:
- Import tempfile and stat modules for secure directory operations
- Update run_tests() to default temp_dir=None (auto-generate secure path)
- Add comprehensive directory validation (ownership, permissions, symlinks)
- Convert git clone and cmake commands to array form (no shell injection)
- Update all help text to remove sudo -E recommendations
- Change --dir default from "/tmp/rdhc/" to None (auto-generated)
- Update privilege check warnings to use os.geteuid() instead of sudo -E

Fixes TOCTOU vulnerabilities and eliminates need for elevated privileges in normal operation.

## JIRA ID

SWSPLAT-24264

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
