### PR TITLE
[hipFile/CI] Run hipFile CI off of nightly ROCm builds

### DIFF
--- a/.github/workflows/hipfile-ci-toplevel.yml
+++ b/.github/workflows/hipfile-ci-toplevel.yml
@@ -133,8 +133,10 @@ jobs:
           REGISTRY_URL: ghcr.io/${{ github.repository_owner }}
           CHANGED_DOCKERFILE: ${{ steps.ci-flags.outputs.changed_dockerfile }}
           FULL_CI_IMAGES_MATRIX: ${{ steps.matrices.outputs.full_CI_images_matrix }}
+          NIGHTLY_BUILD: ${{ steps.nightly.outputs.nightly_build }}
         # ci_images is computed by util/ci-images.sh. Sourcing it sets ci_images
-        # from REGISTRY_URL, tag, and FULL_CI_IMAGES_MATRIX in the environment.
+        # from REGISTRY_URL, tag, FULL_CI_IMAGES_MATRIX, and NIGHTLY_BUILD in
+        # the environment.
         run: |
           if [ "${CHANGED_DOCKERFILE}" = "1" ]; then
             # sanitize ref for tag

--- a/.github/workflows/hipfile-ci-toplevel.yml
+++ b/.github/workflows/hipfile-ci-toplevel.yml
@@ -67,12 +67,13 @@ jobs:
         id: ci-flags
         run: |
           echo "changed_dockerfile=$(./util/files-changed.sh "origin/${GITHUB_BASE_REF}" HEAD 'projects/hipfile/util/docker/DOCKERFILE.*')" >> "${GITHUB_OUTPUT}"
-      - name: Sanity-check jq commands
-        # Ensure that the jq commands work as expected before using them.
+      - name: Sanity-check util script test suites
+        # Ensure the util scripts work as expected before using them.
         working-directory: rocm-systems/projects/hipfile
         run: |
           util/ci-matrices.sh --test
           util/ci-images.sh --test
+          util/resolve-rocm-nightly.sh --test
       - name: Compute matrix configurations
         id: matrices
         working-directory: rocm-systems/projects/hipfile
@@ -88,6 +89,21 @@ jobs:
           echo "${full_CI_images_matrix}" | jq .
           echo "ci_matrix=${ci_matrix}" >> "${GITHUB_OUTPUT}"
           echo "full_CI_images_matrix=${full_CI_images_matrix}" >> "${GITHUB_OUTPUT}"
+      - name: Resolve ROCm nightly metadata
+        id: nightly
+        working-directory: rocm-systems/projects/hipfile
+        env:
+          FULL_CI_IMAGES_MATRIX: ${{ steps.matrices.outputs.full_CI_images_matrix }}
+        # Only resolves when a nightly row is present; otherwise emit empty values
+        # so the downstream image-name step stays wired up unconditionally.
+        run: |
+          if printf '%s' "${FULL_CI_IMAGES_MATRIX}" \
+              | jq -e '.include[]? | select(.rocm_versions == "nightly")' >/dev/null; then
+            ./util/resolve-rocm-nightly.sh | tee -a "${GITHUB_OUTPUT}"
+          else
+            echo "nightly_build=" >> "${GITHUB_OUTPUT}"
+            echo "nightly_rocm_version=" >> "${GITHUB_OUTPUT}"
+          fi
       - name: Compute CI image names
         id: ci-images
         working-directory: rocm-systems/projects/hipfile

--- a/.github/workflows/hipfile-ci-toplevel.yml
+++ b/.github/workflows/hipfile-ci-toplevel.yml
@@ -24,7 +24,7 @@ jobs:
     outputs:
       changed_dockerfile: ${{ steps.ci-flags.outputs.changed_dockerfile }}
       ci_matrix: ${{ steps.matrices.outputs.ci_matrix }}
-      build_CI_images_matrix: ${{ steps.matrices.outputs.build_CI_images_matrix }}
+      build_CI_images_matrix: ${{ steps.build-ci-images-matrix.outputs.build_CI_images_matrix }}
       ci_images: ${{ steps.ci-images.outputs.ci_images }}
       nightly_build: ${{ steps.nightly.outputs.nightly_build }}
       nightly_rocm_version: ${{ steps.nightly.outputs.nightly_rocm_version }}
@@ -62,6 +62,12 @@ jobs:
           sparse-checkout: |
             projects/hipfile
             .github/workflows
+      - name: Authenticating to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Git fetch base ref
         working-directory: rocm-systems
         run: git fetch origin "${GITHUB_BASE_REF}"
@@ -77,18 +83,15 @@ jobs:
           util/ci-matrices.sh --test
           util/ci-images.sh --test
           util/resolve-rocm-nightly.sh --test
+          util/build-ci-images-matrix.sh --test
       - name: Compute matrix configurations
         id: matrices
         working-directory: rocm-systems/projects/hipfile
-        env:
-          CHANGED_DOCKERFILE: ${{ steps.ci-flags.outputs.changed_dockerfile }}
         # ci_matrix (the full strategy.matrix handed to the Linux test job) and
         # full_CI_images_matrix (the deduped catalog of every CI image this run
         # references) are both computed by util/ci-matrices.sh. Sourcing it sets
-        # both shell vars from the job-level matrix env vars.
-        #
-        # build_CI_images_matrix is the subset we actually (re)build this run
-        # (see below).
+        # both shell vars from the job-level matrix env vars. The
+        # build-ci-images-matrix step below derives what to actually build.
         run: |
           source ./util/ci-matrices.sh
           echo "hipFile CI Matrix: "
@@ -97,23 +100,6 @@ jobs:
           echo "${full_CI_images_matrix}" | jq .
           echo "ci_matrix=${ci_matrix}" >> "${GITHUB_OUTPUT}"
           echo "full_CI_images_matrix=${full_CI_images_matrix}" >> "${GITHUB_OUTPUT}"
-
-          # build_CI_images_matrix drives which images are actually (re)built this
-          # run. When a Dockerfile changed we rebuild everything; otherwise only
-          # the nightly rows, whose target moves daily and so cannot be served
-          # from a pre-existing latest tag. (Other versions reuse their
-          # latest-rocm<ver> image.)
-          if [ "${CHANGED_DOCKERFILE}" = "1" ]; then
-            build_CI_images_matrix="${full_CI_images_matrix}"
-          else
-            build_CI_images_matrix=$(
-              printf '%s' "${full_CI_images_matrix}" \
-                | jq -c '{include: [.include[] | select(.rocm_versions == "nightly")]}'
-            )
-          fi
-          echo "hipFile Build CI Images Matrix: "
-          echo "${build_CI_images_matrix}" | jq .
-          echo "build_CI_images_matrix=${build_CI_images_matrix}" >> "${GITHUB_OUTPUT}"
       - name: Resolve ROCm nightly metadata
         id: nightly
         working-directory: rocm-systems/projects/hipfile
@@ -152,10 +138,29 @@ jobs:
           echo "List of CI Images: "
           echo "${ci_images}" | jq .
           echo "ci_images=${ci_images}" >> "${GITHUB_OUTPUT}"
+      - name: Compute images to build
+        id: build-ci-images-matrix
+        working-directory: rocm-systems/projects/hipfile
+        env:
+          CHANGED_DOCKERFILE: ${{ steps.ci-flags.outputs.changed_dockerfile }}
+          FULL_CI_IMAGES_MATRIX: ${{ steps.matrices.outputs.full_CI_images_matrix }}
+          CI_IMAGES: ${{ steps.ci-images.outputs.ci_images }}
+        # build_CI_images_matrix is computed by util/build-ci-images-matrix.sh.
+        # Sourcing it sets the shell var from CHANGED_DOCKERFILE,
+        # FULL_CI_IMAGES_MATRIX and CI_IMAGES: a Dockerfile change rebuilds the
+        # whole catalog, otherwise only nightly rows whose base/nvidia images
+        # aren't already published in GHCR (querying the registry) are kept -- so
+        # in the common case the set is empty and build_CI_image is skipped.
+        run: |
+          source ./util/build-ci-images-matrix.sh
+          echo "hipFile Build CI Images Matrix: "
+          echo "${build_CI_images_matrix}" | jq .
+          echo "build_CI_images_matrix=${build_CI_images_matrix}" >> "${GITHUB_OUTPUT}"
 
   build_CI_image:
-    # build_CI_images_matrix is non-empty when a Dockerfile changed or a nightly
-    # row exists; otherwise it has no include rows and this job produces no jobs.
+    # build_CI_images_matrix is empty when there's nothing to (re)build (no
+    # Dockerfile change and every nightly image already published). An empty
+    # include yields zero matrix jobs, so this job is skipped.
     if: ${{ fromJSON(needs.Precheck.outputs.build_CI_images_matrix).include[0] != null }}
     needs: Precheck
     permissions:

--- a/.github/workflows/hipfile-ci-toplevel.yml
+++ b/.github/workflows/hipfile-ci-toplevel.yml
@@ -24,8 +24,10 @@ jobs:
     outputs:
       changed_dockerfile: ${{ steps.ci-flags.outputs.changed_dockerfile }}
       ci_matrix: ${{ steps.matrices.outputs.ci_matrix }}
-      full_CI_images_matrix: ${{ steps.matrices.outputs.full_CI_images_matrix }}
+      build_CI_images_matrix: ${{ steps.matrices.outputs.build_CI_images_matrix }}
       ci_images: ${{ steps.ci-images.outputs.ci_images }}
+      nightly_build: ${{ steps.nightly.outputs.nightly_build }}
+      nightly_rocm_version: ${{ steps.nightly.outputs.nightly_rocm_version }}
     env:
       # Matrix variables go here in JSON notation.
       # '>-' strips newlines
@@ -46,7 +48,8 @@ jobs:
       # be expressed without abandoning the base cross-product.
       MATRIX_INCLUDE: >-
         [
-          {"supported_platforms": "ubuntu", "rocm_versions": "7.13.0"}
+          {"supported_platforms": "ubuntu", "rocm_versions": "7.13.0"},
+          {"supported_platforms": "ubuntu", "rocm_versions": "nightly"}
         ]
       MATRIX_EXCLUDE: >-
         []
@@ -79,10 +82,10 @@ jobs:
         working-directory: rocm-systems/projects/hipfile
         env:
           CHANGED_DOCKERFILE: ${{ steps.ci-flags.outputs.changed_dockerfile }}
-        # ci_matrix (the full strategy.matrix handed to the Linux test job)
-        # and full_CI_images_matrix (which drives the image-build job) are both
-        # computed by util/ci-matrices.sh. Sourcing it sets both shell vars from
-        # the job-level matrix env vars.
+        # ci_matrix (the full strategy.matrix handed to the Linux test job) and
+        # full_CI_images_matrix (the deduped catalog of every CI image this run
+        # references) are both computed by util/ci-matrices.sh. Sourcing it sets
+        # both shell vars from the job-level matrix env vars.
         #
         # build_CI_images_matrix is the subset we actually (re)build this run
         # (see below).
@@ -151,14 +154,16 @@ jobs:
           echo "ci_images=${ci_images}" >> "${GITHUB_OUTPUT}"
 
   build_CI_image:
-    if: ${{ needs.Precheck.outputs.changed_dockerfile == '1' }}
+    # build_CI_images_matrix is non-empty when a Dockerfile changed or a nightly
+    # row exists; otherwise it has no include rows and this job produces no jobs.
+    if: ${{ fromJSON(needs.Precheck.outputs.build_CI_images_matrix).include[0] != null }}
     needs: Precheck
     permissions:
       contents: read
       packages: write
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.Precheck.outputs.full_CI_images_matrix) }}
+      matrix: ${{ fromJSON(needs.Precheck.outputs.build_CI_images_matrix) }}
     uses: ./.github/workflows/hipfile-image-build.yml
     with:
       ci_image_name: ${{ fromJSON(needs.Precheck.outputs.ci_images)[format('{0}-{1}', matrix.supported_platforms, matrix.rocm_versions)].ci_image }}
@@ -166,7 +171,10 @@ jobs:
       ci_image_name_nvidia: ${{ fromJSON(needs.Precheck.outputs.ci_images)[format('{0}-{1}', matrix.supported_platforms, matrix.rocm_versions)].ci_image_nvidia }}
       ci_image_cache_nvidia: ${{ fromJSON(needs.Precheck.outputs.ci_images)[format('{0}-{1}', matrix.supported_platforms, matrix.rocm_versions)].ci_image_nvidia_cache }}
       platform: ${{ matrix.supported_platforms }}
-      rocm_version: ${{ matrix.rocm_versions }}
+      # Nightly passes the resolved clean version (e.g. 7.14.0) as ROCM_VERSION
+      # and the build id separately; other versions pass the matrix value.
+      rocm_version: ${{ matrix.rocm_versions == 'nightly' && needs.Precheck.outputs.nightly_rocm_version || matrix.rocm_versions }}
+      rocm_nightly_build: ${{ matrix.rocm_versions == 'nightly' && needs.Precheck.outputs.nightly_build || '' }}
 
   # Due to GHA matrix limitations, we cannot inspect the result of individual jobs
   # in the matrix. To avoid confusing errors, our only option is that if a single

--- a/.github/workflows/hipfile-ci-toplevel.yml
+++ b/.github/workflows/hipfile-ci-toplevel.yml
@@ -77,10 +77,15 @@ jobs:
       - name: Compute matrix configurations
         id: matrices
         working-directory: rocm-systems/projects/hipfile
+        env:
+          CHANGED_DOCKERFILE: ${{ steps.ci-flags.outputs.changed_dockerfile }}
         # ci_matrix (the full strategy.matrix handed to the Linux test job)
         # and full_CI_images_matrix (which drives the image-build job) are both
         # computed by util/ci-matrices.sh. Sourcing it sets both shell vars from
         # the job-level matrix env vars.
+        #
+        # build_CI_images_matrix is the subset we actually (re)build this run
+        # (see below).
         run: |
           source ./util/ci-matrices.sh
           echo "hipFile CI Matrix: "
@@ -89,6 +94,23 @@ jobs:
           echo "${full_CI_images_matrix}" | jq .
           echo "ci_matrix=${ci_matrix}" >> "${GITHUB_OUTPUT}"
           echo "full_CI_images_matrix=${full_CI_images_matrix}" >> "${GITHUB_OUTPUT}"
+
+          # build_CI_images_matrix drives which images are actually (re)built this
+          # run. When a Dockerfile changed we rebuild everything; otherwise only
+          # the nightly rows, whose target moves daily and so cannot be served
+          # from a pre-existing latest tag. (Other versions reuse their
+          # latest-rocm<ver> image.)
+          if [ "${CHANGED_DOCKERFILE}" = "1" ]; then
+            build_CI_images_matrix="${full_CI_images_matrix}"
+          else
+            build_CI_images_matrix=$(
+              printf '%s' "${full_CI_images_matrix}" \
+                | jq -c '{include: [.include[] | select(.rocm_versions == "nightly")]}'
+            )
+          fi
+          echo "hipFile Build CI Images Matrix: "
+          echo "${build_CI_images_matrix}" | jq .
+          echo "build_CI_images_matrix=${build_CI_images_matrix}" >> "${GITHUB_OUTPUT}"
       - name: Resolve ROCm nightly metadata
         id: nightly
         working-directory: rocm-systems/projects/hipfile

--- a/.github/workflows/hipfile-ci-toplevel.yml
+++ b/.github/workflows/hipfile-ci-toplevel.yml
@@ -180,6 +180,9 @@ jobs:
       # and the build id separately; other versions pass the matrix value.
       rocm_version: ${{ matrix.rocm_versions == 'nightly' && needs.Precheck.outputs.nightly_rocm_version || matrix.rocm_versions }}
       rocm_nightly_build: ${{ matrix.rocm_versions == 'nightly' && needs.Precheck.outputs.nightly_build || '' }}
+      # Only a steady-state nightly fallback build refreshes the shared floating
+      # cache; a Dockerfile-change PR builds a PR-namespaced image and must not.
+      publish_cache: ${{ matrix.rocm_versions == 'nightly' && needs.Precheck.outputs.changed_dockerfile != '1' }}
 
   # Due to GHA matrix limitations, we cannot inspect the result of individual jobs
   # in the matrix. To avoid confusing errors, our only option is that if a single

--- a/.github/workflows/hipfile-ci-toplevel.yml
+++ b/.github/workflows/hipfile-ci-toplevel.yml
@@ -24,7 +24,7 @@ jobs:
     outputs:
       changed_dockerfile: ${{ steps.ci-flags.outputs.changed_dockerfile }}
       ci_matrix: ${{ steps.matrices.outputs.ci_matrix }}
-      build_ci_image_matrix: ${{ steps.matrices.outputs.build_ci_image_matrix }}
+      full_CI_images_matrix: ${{ steps.matrices.outputs.full_CI_images_matrix }}
       ci_images: ${{ steps.ci-images.outputs.ci_images }}
     env:
       # Matrix variables go here in JSON notation.
@@ -77,26 +77,26 @@ jobs:
         id: matrices
         working-directory: rocm-systems/projects/hipfile
         # ci_matrix (the full strategy.matrix handed to the Linux test job)
-        # and build_ci_image_matrix (which drives the image-build job) are both
+        # and full_CI_images_matrix (which drives the image-build job) are both
         # computed by util/ci-matrices.sh. Sourcing it sets both shell vars from
         # the job-level matrix env vars.
         run: |
           source ./util/ci-matrices.sh
           echo "hipFile CI Matrix: "
           echo "${ci_matrix}" | jq .
-          echo "hipFile Build CI Image Matrix: "
-          echo "${build_ci_image_matrix}" | jq .
+          echo "hipFile Full CI Image Matrix: "
+          echo "${full_CI_images_matrix}" | jq .
           echo "ci_matrix=${ci_matrix}" >> "${GITHUB_OUTPUT}"
-          echo "build_ci_image_matrix=${build_ci_image_matrix}" >> "${GITHUB_OUTPUT}"
+          echo "full_CI_images_matrix=${full_CI_images_matrix}" >> "${GITHUB_OUTPUT}"
       - name: Compute CI image names
         id: ci-images
         working-directory: rocm-systems/projects/hipfile
         env:
           REGISTRY_URL: ghcr.io/${{ github.repository_owner }}
           CHANGED_DOCKERFILE: ${{ steps.ci-flags.outputs.changed_dockerfile }}
-          BUILD_CI_IMAGE_MATRIX: ${{ steps.matrices.outputs.build_ci_image_matrix }}
+          FULL_CI_IMAGES_MATRIX: ${{ steps.matrices.outputs.full_CI_images_matrix }}
         # ci_images is computed by util/ci-images.sh. Sourcing it sets ci_images
-        # from REGISTRY_URL, tag, and BUILD_CI_IMAGE_MATRIX in the environment.
+        # from REGISTRY_URL, tag, and FULL_CI_IMAGES_MATRIX in the environment.
         run: |
           if [ "${CHANGED_DOCKERFILE}" = "1" ]; then
             # sanitize ref for tag
@@ -118,7 +118,7 @@ jobs:
       packages: write
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.Precheck.outputs.build_ci_image_matrix) }}
+      matrix: ${{ fromJSON(needs.Precheck.outputs.full_CI_images_matrix) }}
     uses: ./.github/workflows/hipfile-image-build.yml
     with:
       ci_image_name: ${{ fromJSON(needs.Precheck.outputs.ci_images)[format('{0}-{1}', matrix.supported_platforms, matrix.rocm_versions)].ci_image }}

--- a/.github/workflows/hipfile-ci.yml
+++ b/.github/workflows/hipfile-ci.yml
@@ -84,7 +84,7 @@ jobs:
       rocm_version: ${{ inputs.rocm_version }}
 
   build_and_test_NVIDIA:
-    if: ${{ !startsWith(inputs.rocm_version, '7.13.') }}
+    if: ${{ !startsWith(inputs.rocm_version, '7.13.') && inputs.rocm_version != 'nightly' }}
     uses: ./.github/workflows/hipfile-build-nvidia.yml
     with:
       ci_image: ${{ inputs.ci_image_nvidia }}

--- a/.github/workflows/hipfile-image-build.yml
+++ b/.github/workflows/hipfile-image-build.yml
@@ -9,6 +9,9 @@ env:
   AIS_INPUT_ROCM_VERSION: ${{ inputs.rocm_version }}
   AIS_INPUT_ROCM_NIGHTLY_BUILD: ${{ inputs.rocm_nightly_build }}
   AIS_INPUT_PLATFORM: ${{ inputs.platform }}
+  # When publish_cache is set, also produce the floating registry cache.
+  AIS_BASE_CACHE_TO: ${{ case(inputs.publish_cache, format('--cache-to=type=registry,ref={0}', inputs.ci_image_cache), '') }}
+  AIS_NVIDIA_CACHE_TO: ${{ case(inputs.publish_cache, format('--cache-to=type=registry,ref={0}', inputs.ci_image_cache_nvidia), '') }}
 
 on:
   workflow_call:
@@ -41,6 +44,11 @@ on:
         required: false
         default: ""
         type: string
+      publish_cache:
+        description: "Also push the floating registry cache (--cache-to); for nightly fallback builds only."
+        required: false
+        default: false
+        type: boolean
     outputs:
       ci_image:
         description: "The full name & tag of the CI image to use."
@@ -81,7 +89,9 @@ jobs:
           cache-binary: false # True uses the GHA Cache Backend
 
       - name: Build base image for AIS CI
-        # Current caveat: At this time we don't have nightlies being cleanly cached
+        # The floating nightly cache is normally produced by
+        # hipfile-image-update-nightly.yml; publish_cache lets a per-PR nightly
+        # fallback build refresh it too (no other version should set publish_cache).
         run: |
           docker buildx build \
             -f "${GITHUB_WORKSPACE}/projects/hipfile/util/docker/DOCKERFILE.ais_ci_${AIS_INPUT_PLATFORM}" \
@@ -91,6 +101,7 @@ jobs:
             --build-arg ROCM_NIGHTLY_BUILD=${AIS_INPUT_ROCM_NIGHTLY_BUILD} \
             --cache-from=type=registry,ref="${AIS_INPUT_CI_IMAGE_NAME}" \
             --cache-from=type=registry,ref="${AIS_INPUT_CI_IMAGE_CACHE}" \
+            ${AIS_BASE_CACHE_TO} \
             --push \
             -t "${AIS_INPUT_CI_IMAGE_NAME}" \
             "${GITHUB_WORKSPACE}/projects/hipfile/util/docker"
@@ -106,6 +117,7 @@ jobs:
             --cache-from=type=registry,ref="${AIS_INPUT_CI_IMAGE_NAME}" \
             --cache-from=type=registry,ref="${AIS_INPUT_CI_IMAGE_NAME_NVIDIA}" \
             --cache-from=type=registry,ref="${AIS_INPUT_CI_IMAGE_CACHE_NVIDIA}" \
+            ${AIS_NVIDIA_CACHE_TO} \
             --push \
             -t "${AIS_INPUT_CI_IMAGE_NAME_NVIDIA}" \
             "${GITHUB_WORKSPACE}/projects/hipfile/util/docker"

--- a/.github/workflows/hipfile-image-build.yml
+++ b/.github/workflows/hipfile-image-build.yml
@@ -7,6 +7,7 @@ env:
   AIS_INPUT_CI_IMAGE_NAME_NVIDIA: ${{ inputs.ci_image_name_nvidia }}
   AIS_INPUT_CI_IMAGE_CACHE_NVIDIA: ${{ inputs.ci_image_cache_nvidia }}
   AIS_INPUT_ROCM_VERSION: ${{ inputs.rocm_version }}
+  AIS_INPUT_ROCM_NIGHTLY_BUILD: ${{ inputs.rocm_nightly_build }}
   AIS_INPUT_PLATFORM: ${{ inputs.platform }}
 
 on:
@@ -34,6 +35,11 @@ on:
       rocm_version:
         description: "Target ROCm MAJOR.MINOR.PATCH Version"
         required: true
+        type: string
+      rocm_nightly_build:
+        description: "Nightly build id (YYYYMMDD-<gha_run_id>); empty for non-nightly"
+        required: false
+        default: ""
         type: string
     outputs:
       ci_image:
@@ -75,12 +81,14 @@ jobs:
           cache-binary: false # True uses the GHA Cache Backend
 
       - name: Build base image for AIS CI
+        # Current caveat: At this time we don't have nightlies being cleanly cached
         run: |
           docker buildx build \
             -f "${GITHUB_WORKSPACE}/projects/hipfile/util/docker/DOCKERFILE.ais_ci_${AIS_INPUT_PLATFORM}" \
             --target base \
             --build-arg BUILDKIT_INLINE_CACHE=1 \
             --build-arg ROCM_VERSION=${AIS_INPUT_ROCM_VERSION} \
+            --build-arg ROCM_NIGHTLY_BUILD=${AIS_INPUT_ROCM_NIGHTLY_BUILD} \
             --cache-from=type=registry,ref="${AIS_INPUT_CI_IMAGE_NAME}" \
             --cache-from=type=registry,ref="${AIS_INPUT_CI_IMAGE_CACHE}" \
             --push \
@@ -94,6 +102,8 @@ jobs:
             --target nvidia \
             --build-arg BUILDKIT_INLINE_CACHE=1 \
             --build-arg ROCM_VERSION=${AIS_INPUT_ROCM_VERSION} \
+            --build-arg ROCM_NIGHTLY_BUILD=${AIS_INPUT_ROCM_NIGHTLY_BUILD} \
+            --cache-from=type=registry,ref="${AIS_INPUT_CI_IMAGE_NAME}" \
             --cache-from=type=registry,ref="${AIS_INPUT_CI_IMAGE_NAME_NVIDIA}" \
             --cache-from=type=registry,ref="${AIS_INPUT_CI_IMAGE_CACHE_NVIDIA}" \
             --push \

--- a/.github/workflows/hipfile-image-update-nightly.yml
+++ b/.github/workflows/hipfile-image-update-nightly.yml
@@ -12,6 +12,18 @@ on:
     # image on demand.
     - cron: "0 10 * * *"
   workflow_dispatch:
+  # Refresh on merge of a Dockerfile/resolver change so the published nightly
+  # image + floating cache track develop. Without this, the per-PR registry
+  # skip could serve an image built from an out-of-date Dockerfile.
+  pull_request_target:
+    types:
+      - closed
+    branches:
+      - develop
+    paths:
+      - projects/hipfile/util/docker/**
+      - projects/hipfile/util/resolve-rocm-nightly.sh
+      - .github/workflows/hipfile-image-update-nightly.yml
 
 concurrency:
   group: ${{ github.workflow }}
@@ -25,6 +37,9 @@ jobs:
   # Resolve runs on the runner (not the docker:28.5 container) because the
   # resolver needs curl/bash, which the Alpine-based docker image lacks.
   resolve_nightly:
+    # pull_request_target/closed fires for un-merged PRs too; only act on merges.
+    # (The downstream build job needs this one, so skipping here skips both.)
+    if: ${{ github.event_name != 'pull_request_target' || github.event.pull_request.merged == true }}
     runs-on: [ubuntu-24.04]
     outputs:
       nightly_build: ${{ steps.nightly.outputs.nightly_build }}

--- a/.github/workflows/hipfile-image-update-nightly.yml
+++ b/.github/workflows/hipfile-image-update-nightly.yml
@@ -1,0 +1,115 @@
+name: update_nightly_CI_image
+run-name: Refresh the latest nightly hipFile CI image
+
+env:
+  AIS_DOCKER_REGISTRY: ghcr.io/${{ github.repository_owner }}/hipfile
+
+on:
+  schedule:
+    # ~10:00 UTC daily. The ROCm nightly publish runs ~02:00 UTC, leaving ~8h of
+    # buffer. This job is purely an optimization: if it is late/failed/builds
+    # against an incomplete nightly, per-PR runs fall back to building the nightly
+    # image on demand.
+    - cron: "0 10 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  # Resolve runs on the runner (not the docker:28.5 container) because the
+  # resolver needs curl/bash, which the Alpine-based docker image lacks.
+  resolve_nightly:
+    runs-on: [ubuntu-24.04]
+    outputs:
+      nightly_build: ${{ steps.nightly.outputs.nightly_build }}
+      nightly_rocm_version: ${{ steps.nightly.outputs.nightly_rocm_version }}
+    steps:
+      - name: Fetching code repository...
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: |
+            projects/hipfile
+            .github/workflows
+      - name: Resolve ROCm nightly metadata
+        id: nightly
+        working-directory: projects/hipfile
+        run: ./util/resolve-rocm-nightly.sh | tee -a "${GITHUB_OUTPUT}"
+
+  update_nightly_AIS_CI_image:
+    needs: resolve_nightly
+    env:
+      AIS_CI_IMAGE_NAME: ais_ci_ubuntu
+      AIS_INPUT_PLATFORM: ubuntu
+      AIS_NIGHTLY_BUILD: ${{ needs.resolve_nightly.outputs.nightly_build }}
+      AIS_NIGHTLY_ROCM_VERSION: ${{ needs.resolve_nightly.outputs.nightly_rocm_version }}
+    runs-on: [ubuntu-24.04]
+    container: docker:28.5
+    steps:
+      - name: Fetching code repository...
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: |
+            projects/hipfile
+            .github/workflows
+
+      - name: Authenticating to GitHub Container Registry.
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set target nightly AIS CI image
+        id: ci-image
+        # The image tag carries the resolved build id for reproducibility; the
+        # cache refs stay floating (no build id) so each day's build reuses the
+        # previous day's layers.
+        run: |
+          AIS_CI_IMAGE="${AIS_DOCKER_REGISTRY}/${AIS_CI_IMAGE_NAME}:latest-rocm-nightly-${AIS_NIGHTLY_BUILD}"
+          echo "AIS_CI_IMAGE=$(printf '%s' "${AIS_CI_IMAGE}" | tr '[:upper:]' '[:lower:]')" >> "${GITHUB_OUTPUT}"
+          AIS_CI_IMAGE_NVIDIA="${AIS_CI_IMAGE}-nvidia"
+          echo "AIS_CI_IMAGE_NVIDIA=$(printf '%s' "${AIS_CI_IMAGE_NVIDIA}" | tr '[:upper:]' '[:lower:]')" >> "${GITHUB_OUTPUT}"
+          AIS_CI_CACHE="${AIS_DOCKER_REGISTRY}/${AIS_CI_IMAGE_NAME}:latest-rocm-nightly-cache"
+          echo "AIS_CI_CACHE=$(printf '%s' "${AIS_CI_CACHE}" | tr '[:upper:]' '[:lower:]')" >> "${GITHUB_OUTPUT}"
+          AIS_CI_CACHE_NVIDIA="${AIS_DOCKER_REGISTRY}/${AIS_CI_IMAGE_NAME}:latest-rocm-nightly-nvidia-cache"
+          echo "AIS_CI_CACHE_NVIDIA=$(printf '%s' "${AIS_CI_CACHE_NVIDIA}" | tr '[:upper:]' '[:lower:]')" >> "${GITHUB_OUTPUT}"
+
+      - name: Setup Docker Builder
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        with:
+          name: ais-builder
+          driver: docker-container
+          cache-binary: false # True uses the GHA Cache Backend
+
+      - name: Build & Push latest nightly base image for AIS CI
+        run: |
+          docker buildx build \
+            -f "${GITHUB_WORKSPACE}/projects/hipfile/util/docker/DOCKERFILE.${AIS_CI_IMAGE_NAME}" \
+            --target base \
+            --build-arg ROCM_VERSION=${AIS_NIGHTLY_ROCM_VERSION} \
+            --build-arg ROCM_NIGHTLY_BUILD=${AIS_NIGHTLY_BUILD} \
+            --cache-to=type=registry,ref="${{ steps.ci-image.outputs.AIS_CI_CACHE }}" \
+            --cache-from=type=registry,ref="${{ steps.ci-image.outputs.AIS_CI_CACHE }}" \
+            --push \
+            -t "${{ steps.ci-image.outputs.AIS_CI_IMAGE }}" \
+            "${GITHUB_WORKSPACE}/projects/hipfile/util/docker"
+
+      - name: Build & Push latest nightly NVIDIA image for AIS CI
+        run: |
+          docker buildx build \
+            -f "${GITHUB_WORKSPACE}/projects/hipfile/util/docker/DOCKERFILE.${AIS_CI_IMAGE_NAME}" \
+            --target nvidia \
+            --build-arg ROCM_VERSION=${AIS_NIGHTLY_ROCM_VERSION} \
+            --build-arg ROCM_NIGHTLY_BUILD=${AIS_NIGHTLY_BUILD} \
+            --cache-to=type=registry,ref="${{ steps.ci-image.outputs.AIS_CI_CACHE_NVIDIA }}" \
+            --cache-from=type=registry,ref="${{ steps.ci-image.outputs.AIS_CI_CACHE }}" \
+            --cache-from=type=registry,ref="${{ steps.ci-image.outputs.AIS_CI_CACHE_NVIDIA }}" \
+            --push \
+            -t "${{ steps.ci-image.outputs.AIS_CI_IMAGE_NVIDIA }}" \
+            "${GITHUB_WORKSPACE}/projects/hipfile/util/docker"

--- a/.github/workflows/hipfile-image-update.yml
+++ b/.github/workflows/hipfile-image-update.yml
@@ -41,6 +41,12 @@ jobs:
     if: ${{ github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch' }}
     runs-on: [ubuntu-24.04]
     container: docker:28.5
+    # NOTE: nightly is intentionally absent here. This job refreshes the static
+    # latest-rocm<ver> images post-merge, but the nightly target moves daily, so
+    # nightly images are refreshed by hipfile-image-update-nightly.yml (daily and
+    # on Dockerfile-change merge) instead. Keep this matrix in sync with
+    # hipfile-ci-toplevel.yml's SUPPORTED_PLATFORMS/ROCM_VERSIONS/MATRIX_INCLUDE
+    # for the non-nightly rows.
     strategy:
       matrix:
         supported_platforms:

--- a/projects/hipfile/util/build-ci-images-matrix.sh
+++ b/projects/hipfile/util/build-ci-images-matrix.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Single source of truth for the "which images do we build" logic used by the
+# Precheck job in .github/workflows/hipfile-ci-toplevel.yml ("Compute images to
+# build" step). compute_build_set decides the matrix of images to (re)build:
+#   - a Dockerfile change rebuilds the whole catalog;
+#   - otherwise only nightly rows may need building (other versions reuse their
+#     latest-rocm<ver> images from hipfile-image-update.yml), and a nightly row
+#     is built only when its base or nvidia image isn't already published.
+#
+# Two ways to use it:
+#   Sourced (CI):  source build-ci-images-matrix.sh
+#                  -> sets shell var build_CI_images_matrix from the env vars
+#                     CHANGED_DOCKERFILE, FULL_CI_IMAGES_MATRIX, CI_IMAGES
+#                     (querying GHCR for nightly rows)
+#   Tests:         bash build-ci-images-matrix.sh --test
+#
+# The only impurity is the registry-existence check, isolated behind
+# _image_published so --test can override it and run offline. Everything else is
+# pure; because the same code is shipped to CI and exercised by --test, the two
+# can never drift.
+
+# --- pure helpers: the jq, one copy each ----------------------------------
+
+# Keep only the nightly rows of a matrix (rocm_versions == "nightly") -- the
+# only rows whose target moves daily and so may need (re)building this run.
+# Args: matrix (JSON {include:[...]})
+filter_nightly_rows() {
+  local matrix="$1"
+  printf '%s' "${matrix}" \
+    | jq -c '{include: [.include[] | select(.rocm_versions == "nightly")]}'
+}
+
+# Keep only candidate rows whose "<supported_platforms>-<rocm_versions>" key is
+# present in to_build.
+# Args: candidate (JSON {include:[...]}) to_build (space-separated keys)
+select_to_build() {
+  local candidate="$1" to_build="$2"
+  printf '%s' "${candidate}" | jq -c --arg tb "${to_build}" \
+    '($tb | split(" ") | map(select(length > 0))) as $b
+     | {include: [.include[]
+         | select((.supported_platforms + "-" + .rocm_versions) as $k | $b | index($k))]}'
+}
+
+# --- impurity seam --------------------------------------------------------
+
+# Returns 0 if the image ref already exists in the registry. This is the one
+# I/O point; --test overrides it to keep the suite offline.
+# Args: image_ref
+_image_published() {
+  docker buildx imagetools inspect "$1" >/dev/null 2>&1
+}
+
+# --- orchestration --------------------------------------------------------
+
+# Emit the matrix of images to (re)build on stdout. Progress notes go to stderr
+# so stdout carries only the JSON result.
+# Args: changed_dockerfile ("1" or other) full_ci_images_matrix (JSON)
+#       ci_images (JSON map: "<sp>-<rv>" -> {ci_image, ci_image_nvidia, ...})
+compute_build_set() {
+  local changed_dockerfile="$1" full_ci_images_matrix="$2" ci_images="$3"
+
+  if [ "${changed_dockerfile}" = "1" ]; then
+    printf '%s' "${full_ci_images_matrix}"
+    return
+  fi
+
+  local nightly_matrix to_build="" key img img_nvidia
+  nightly_matrix=$(filter_nightly_rows "${full_ci_images_matrix}")
+
+  # A nightly row is (re)built when its base OR nvidia image is missing.
+  for key in $(printf '%s' "${nightly_matrix}" \
+      | jq -r '.include[] | "\(.supported_platforms)-\(.rocm_versions)"'); do
+    img=$(printf '%s' "${ci_images}" | jq -r --arg k "${key}" '.[$k].ci_image')
+    img_nvidia=$(printf '%s' "${ci_images}" | jq -r --arg k "${key}" '.[$k].ci_image_nvidia')
+    if ! _image_published "${img}" || ! _image_published "${img_nvidia}"; then
+      echo "Nightly image not yet published, will build: ${key}" >&2
+      to_build="${to_build}${key} "
+    fi
+  done
+
+  select_to_build "${nightly_matrix}" "${to_build}"
+}
+
+# --- test suite -----------------------------------------------------------
+
+_assert_eq() {
+  local label="$1" actual="$2" expected="$3"
+  local a_norm e_norm
+  a_norm=$(printf '%s' "${actual}"   | jq -cS '.include |= sort')
+  e_norm=$(printf '%s' "${expected}" | jq -cS '.include |= sort')
+  if [ "${a_norm}" = "${e_norm}" ]; then
+    printf '  PASS  %s\n        -> %s\n' "${label}" "${a_norm}"
+  else
+    printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' \
+      "${label}" "${e_norm}" "${a_norm}"
+    return 1
+  fi
+}
+
+_run_tests() {
+  set -uo pipefail
+  local failures=0
+
+  # Offline seam: treat refs listed in _PUBLISHED as already published, so the
+  # compute_build_set tests need no registry. Visible to _image_published via
+  # bash dynamic scoping.
+  local _PUBLISHED=""
+  _image_published() {
+    case " ${_PUBLISHED} " in
+      *" $1 "*) return 0 ;;
+      *)        return 1 ;;
+    esac
+  }
+
+  local CI_IMAGES_FIX='{
+    "ubuntu-nightly":{"ci_image":"reg/ubuntu:nightly","ci_image_nvidia":"reg/ubuntu:nightly-nvidia"},
+    "rocky-nightly":{"ci_image":"reg/rocky:nightly","ci_image_nvidia":"reg/rocky:nightly-nvidia"}
+  }'
+  local FULL='{"include":[{"supported_platforms":"ubuntu","rocm_versions":"7.2.2"},{"supported_platforms":"ubuntu","rocm_versions":"nightly"}]}'
+  local TWO_NIGHTLY='{"include":[{"supported_platforms":"ubuntu","rocm_versions":"nightly"},{"supported_platforms":"rocky","rocm_versions":"nightly"}]}'
+
+  echo "Test 1: filter_nightly_rows keeps only nightly rows"
+  _assert_eq "  output" \
+    "$(filter_nightly_rows "${FULL}")" \
+    '{"include":[{"supported_platforms":"ubuntu","rocm_versions":"nightly"}]}' || failures=$((failures+1))
+
+  echo
+  echo "Test 2: filter_nightly_rows with no nightly row -> empty"
+  _assert_eq "  output" \
+    "$(filter_nightly_rows '{"include":[{"supported_platforms":"ubuntu","rocm_versions":"7.2.2"}]}')" \
+    '{"include":[]}' || failures=$((failures+1))
+
+  echo
+  echo "Test 3: select_to_build keeps only rows whose key is in to_build"
+  _assert_eq "  output" \
+    "$(select_to_build "${TWO_NIGHTLY}" 'rocky-nightly')" \
+    '{"include":[{"supported_platforms":"rocky","rocm_versions":"nightly"}]}' || failures=$((failures+1))
+
+  echo
+  echo "Test 4: select_to_build with empty to_build -> empty"
+  _assert_eq "  output" \
+    "$(select_to_build "${TWO_NIGHTLY}" '')" \
+    '{"include":[]}' || failures=$((failures+1))
+
+  echo
+  echo "Test 5: select_to_build ignores keys not in the candidate set"
+  _assert_eq "  output" \
+    "$(select_to_build '{"include":[{"supported_platforms":"ubuntu","rocm_versions":"nightly"}]}' 'rocky-nightly')" \
+    '{"include":[]}' || failures=$((failures+1))
+
+  echo
+  echo "Test 6: compute_build_set with Dockerfile change -> full catalog"
+  _PUBLISHED="reg/ubuntu:nightly reg/ubuntu:nightly-nvidia"
+  _assert_eq "  output" \
+    "$(compute_build_set "1" "${FULL}" "${CI_IMAGES_FIX}")" \
+    "${FULL}" || failures=$((failures+1))
+
+  echo
+  echo "Test 7: compute_build_set, nightly fully published -> empty (skip)"
+  _PUBLISHED="reg/ubuntu:nightly reg/ubuntu:nightly-nvidia"
+  _assert_eq "  output" \
+    "$(compute_build_set "0" "${FULL}" "${CI_IMAGES_FIX}")" \
+    '{"include":[]}' || failures=$((failures+1))
+
+  echo
+  echo "Test 8: compute_build_set, nightly base missing -> build it"
+  _PUBLISHED="reg/ubuntu:nightly-nvidia"
+  _assert_eq "  output" \
+    "$(compute_build_set "0" "${FULL}" "${CI_IMAGES_FIX}")" \
+    '{"include":[{"supported_platforms":"ubuntu","rocm_versions":"nightly"}]}' || failures=$((failures+1))
+
+  echo
+  echo "Test 9: compute_build_set, nightly nvidia missing -> build it"
+  _PUBLISHED="reg/ubuntu:nightly"
+  _assert_eq "  output" \
+    "$(compute_build_set "0" "${FULL}" "${CI_IMAGES_FIX}")" \
+    '{"include":[{"supported_platforms":"ubuntu","rocm_versions":"nightly"}]}' || failures=$((failures+1))
+
+  echo
+  echo "Test 10: compute_build_set, two nightly rows, only the unpublished one is built"
+  _PUBLISHED="reg/rocky:nightly reg/rocky:nightly-nvidia"
+  _assert_eq "  output" \
+    "$(compute_build_set "0" "${TWO_NIGHTLY}" "${CI_IMAGES_FIX}")" \
+    '{"include":[{"supported_platforms":"ubuntu","rocm_versions":"nightly"}]}' || failures=$((failures+1))
+
+  echo
+  if [ "${failures}" -eq 0 ]; then
+    echo "All tests passed."
+  else
+    echo "${failures} test(s) FAILED."
+    return 1
+  fi
+}
+
+# --- dispatch -------------------------------------------------------------
+# When sourced, ${BASH_SOURCE[0]} (this file) differs from ${0} (the caller's
+# shell); when executed they are equal. So "!=" means "we are being sourced".
+# Do NOT set shell options at top level: sourcing must not mutate the caller.
+if [ "${BASH_SOURCE[0]}" != "${0}" ]; then
+  # SC2034: build_CI_images_matrix is consumed by the sourcing CI step.
+  # SC2153: the UPPER_CASE names are CI env vars, not typos of the lowercase args.
+  # shellcheck disable=SC2034,SC2153
+  build_CI_images_matrix=$(compute_build_set "${CHANGED_DOCKERFILE}" "${FULL_CI_IMAGES_MATRIX}" "${CI_IMAGES}")
+else
+  case "${1:-}" in
+    --test) _run_tests ;;
+    *) echo "usage: source build-ci-images-matrix.sh | bash build-ci-images-matrix.sh --test" >&2; exit 2 ;;
+  esac
+fi

--- a/projects/hipfile/util/ci-images.sh
+++ b/projects/hipfile/util/ci-images.sh
@@ -11,7 +11,7 @@
 # Two ways to use it:
 #   Sourced (CI):  source ci-images.sh
 #                  -> sets shell var ci_images from the env vars REGISTRY_URL,
-#                     tag, FULL_CI_IMAGES_MATRIX
+#                     tag, NIGHTLY_BUILD, FULL_CI_IMAGES_MATRIX
 #   Tests:         bash ci-images.sh --test
 #
 # Because the same jq is both shipped to CI and exercised by --test, the two
@@ -27,12 +27,19 @@
 # (missing rocm_versions) produces a malformed image URL (e.g. "...:latest-rocm"
 # with no version); the resulting docker-pull failure surfaces the malformed
 # include to the maintainer.
-# Args: registry tag full_CI_images_matrix (JSON)
+#
+# Nightly: the version axis is the literal "nightly". The image tag carries the
+# resolved YYYYMMDD-XXX build id for diagnosability
+# (e.g. :latest-rocm-nightly-20260602-26796279962), while the cache ref stays
+# floating (:latest-rocm-nightly-cache) so successive nightly builds share cache
+# layers.
+# Args: registry tag nightly_build full_CI_images_matrix (JSON)
 compute_ci_images() {
-  local registry="$1" tag="$2" full_CI_images_matrix="$3"
+  local registry="$1" tag="$2" nightly_build="$3" full_CI_images_matrix="$4"
   jq -c -n \
     --arg registry "${registry}" \
     --arg tag "${tag}" \
+    --arg nightly_build "${nightly_build}" \
     --argjson build_matrix "${full_CI_images_matrix}" \
     '
       $build_matrix.include
@@ -42,11 +49,19 @@ compute_ci_images() {
           {}; . + {
             ($combo.platform + "-" + $combo.version): (
               ( $combo
+                # Versions concatenate after the "rocm" prefix without a
+                # separator ("latest-rocm7.2.2"). For nightly, insert a hyphen
+                # so the tag reads "latest-rocm-nightly[-BUILD]" rather than
+                # "latest-rocmnightly".
+                | .version_for_tag = (if .version == "nightly" then "-nightly" else .version end)
+                | .build_suffix    = (if .version == "nightly" and ($nightly_build | length) > 0
+                                      then "-" + $nightly_build
+                                      else "" end)
                 | .image_name    = ($registry + "/hipfile/ais_ci_" + .platform)
-                | .image         = (.image_name + ":" + $tag + .version)
-                | .cache         = (.image_name + ":latest-rocm" + .version + "-cache")
-                | .image_nvidia  = (.image_name + ":" + $tag + .version + "-nvidia")
-                | .cache_nvidia  = (.image_name + ":latest-rocm" + .version + "-nvidia-cache")
+                | .image         = (.image_name + ":" + $tag + .version_for_tag + .build_suffix)
+                | .cache         = (.image_name + ":latest-rocm" + .version_for_tag + "-cache")
+                | .image_nvidia  = (.image_name + ":" + $tag + .version_for_tag + .build_suffix + "-nvidia")
+                | .cache_nvidia  = (.image_name + ":latest-rocm" + .version_for_tag + "-nvidia-cache")
               ) | {
                 ci_image:              (.image        | ascii_downcase),
                 ci_image_cache:        (.cache        | ascii_downcase),
@@ -82,14 +97,14 @@ _run_tests() {
 
   echo "Test 1: single (ubuntu, 7.2.2) row -> one keyed entry, all 4 URL fields"
   bm='{"include":[{"supported_platforms":"ubuntu","rocm_versions":"7.2.2"}]}'
-  out=$(compute_ci_images "ghcr.io/testorg" "latest-rocm" "$bm")
+  out=$(compute_ci_images "ghcr.io/testorg" "latest-rocm" "" "$bm")
   _assert_eq "  output" "$out" \
     '{"ubuntu-7.2.2":{"ci_image":"ghcr.io/testorg/hipfile/ais_ci_ubuntu:latest-rocm7.2.2","ci_image_cache":"ghcr.io/testorg/hipfile/ais_ci_ubuntu:latest-rocm7.2.2-cache","ci_image_nvidia":"ghcr.io/testorg/hipfile/ais_ci_ubuntu:latest-rocm7.2.2-nvidia","ci_image_nvidia_cache":"ghcr.io/testorg/hipfile/ais_ci_ubuntu:latest-rocm7.2.2-nvidia-cache"}}' || failures=$((failures+1))
 
   echo
   echo "Test 2: multiple rows -> one entry per (platform, version)"
   bm='{"include":[{"supported_platforms":"rocky","rocm_versions":"7.2.2"},{"supported_platforms":"ubuntu","rocm_versions":"7.13.0"}]}'
-  out=$(compute_ci_images "ghcr.io/testorg" "latest-rocm" "$bm")
+  out=$(compute_ci_images "ghcr.io/testorg" "latest-rocm" "" "$bm")
   _assert_eq "  output" "$out" \
     '{"rocky-7.2.2":{"ci_image":"ghcr.io/testorg/hipfile/ais_ci_rocky:latest-rocm7.2.2","ci_image_cache":"ghcr.io/testorg/hipfile/ais_ci_rocky:latest-rocm7.2.2-cache","ci_image_nvidia":"ghcr.io/testorg/hipfile/ais_ci_rocky:latest-rocm7.2.2-nvidia","ci_image_nvidia_cache":"ghcr.io/testorg/hipfile/ais_ci_rocky:latest-rocm7.2.2-nvidia-cache"},"ubuntu-7.13.0":{"ci_image":"ghcr.io/testorg/hipfile/ais_ci_ubuntu:latest-rocm7.13.0","ci_image_cache":"ghcr.io/testorg/hipfile/ais_ci_ubuntu:latest-rocm7.13.0-cache","ci_image_nvidia":"ghcr.io/testorg/hipfile/ais_ci_ubuntu:latest-rocm7.13.0-nvidia","ci_image_nvidia_cache":"ghcr.io/testorg/hipfile/ais_ci_ubuntu:latest-rocm7.13.0-nvidia-cache"}}' || failures=$((failures+1))
 
@@ -98,7 +113,7 @@ _run_tests() {
   # When a DOCKERFILE changes, CI passes a per-ref tag instead of latest-rocm.
   # The cache fields are pinned to latest-rocm regardless (warm-cache reuse).
   bm='{"include":[{"supported_platforms":"ubuntu","rocm_versions":"7.2.2"}]}'
-  out=$(compute_ci_images "ghcr.io/testorg" "refs-pull-42-merge-rocm" "$bm")
+  out=$(compute_ci_images "ghcr.io/testorg" "refs-pull-42-merge-rocm" "" "$bm")
   _assert_eq "  output" "$out" \
     '{"ubuntu-7.2.2":{"ci_image":"ghcr.io/testorg/hipfile/ais_ci_ubuntu:refs-pull-42-merge-rocm7.2.2","ci_image_cache":"ghcr.io/testorg/hipfile/ais_ci_ubuntu:latest-rocm7.2.2-cache","ci_image_nvidia":"ghcr.io/testorg/hipfile/ais_ci_ubuntu:refs-pull-42-merge-rocm7.2.2-nvidia","ci_image_nvidia_cache":"ghcr.io/testorg/hipfile/ais_ci_ubuntu:latest-rocm7.2.2-nvidia-cache"}}' || failures=$((failures+1))
 
@@ -108,14 +123,14 @@ _run_tests() {
   # key is built from the raw matrix values so it round-trips with the GHA
   # format('{0}-{1}', ...) lookup, which also uses raw matrix values.
   bm='{"include":[{"supported_platforms":"Ubuntu","rocm_versions":"7.2.2"}]}'
-  out=$(compute_ci_images "ghcr.io/TestOrg" "latest-rocm" "$bm")
+  out=$(compute_ci_images "ghcr.io/TestOrg" "latest-rocm" "" "$bm")
   _assert_eq "  output" "$out" \
     '{"Ubuntu-7.2.2":{"ci_image":"ghcr.io/testorg/hipfile/ais_ci_ubuntu:latest-rocm7.2.2","ci_image_cache":"ghcr.io/testorg/hipfile/ais_ci_ubuntu:latest-rocm7.2.2-cache","ci_image_nvidia":"ghcr.io/testorg/hipfile/ais_ci_ubuntu:latest-rocm7.2.2-nvidia","ci_image_nvidia_cache":"ghcr.io/testorg/hipfile/ais_ci_ubuntu:latest-rocm7.2.2-nvidia-cache"}}' || failures=$((failures+1))
 
   echo
   echo "Test 5: empty include -> empty map"
   bm='{"include":[]}'
-  out=$(compute_ci_images "ghcr.io/testorg" "latest-rocm" "$bm")
+  out=$(compute_ci_images "ghcr.io/testorg" "latest-rocm" "" "$bm")
   _assert_eq "  output" "$out" '{}' || failures=$((failures+1))
 
   echo
@@ -124,9 +139,27 @@ _run_tests() {
   # image ref. The pull fails downstream, surfacing the bad include rather
   # than silently dropping it.
   bm='{"include":[{"supported_platforms":"rocky"}]}'
-  out=$(compute_ci_images "ghcr.io/testorg" "latest-rocm" "$bm")
+  out=$(compute_ci_images "ghcr.io/testorg" "latest-rocm" "" "$bm")
   _assert_eq "  output" "$out" \
     '{"rocky-":{"ci_image":"ghcr.io/testorg/hipfile/ais_ci_rocky:latest-rocm","ci_image_cache":"ghcr.io/testorg/hipfile/ais_ci_rocky:latest-rocm-cache","ci_image_nvidia":"ghcr.io/testorg/hipfile/ais_ci_rocky:latest-rocm-nvidia","ci_image_nvidia_cache":"ghcr.io/testorg/hipfile/ais_ci_rocky:latest-rocm-nvidia-cache"}}' || failures=$((failures+1))
+
+  echo
+  echo "Test 7: nightly version -> hyphenated tag + build-id suffix; cache stays floating"
+  # The image tag carries the resolved build id; the cache ref drops it so
+  # successive nightly builds share cache layers.
+  bm='{"include":[{"supported_platforms":"ubuntu","rocm_versions":"nightly"}]}'
+  out=$(compute_ci_images "ghcr.io/testorg" "latest-rocm" "20260602-26796279962" "$bm")
+  _assert_eq "  output" "$out" \
+    '{"ubuntu-nightly":{"ci_image":"ghcr.io/testorg/hipfile/ais_ci_ubuntu:latest-rocm-nightly-20260602-26796279962","ci_image_cache":"ghcr.io/testorg/hipfile/ais_ci_ubuntu:latest-rocm-nightly-cache","ci_image_nvidia":"ghcr.io/testorg/hipfile/ais_ci_ubuntu:latest-rocm-nightly-20260602-26796279962-nvidia","ci_image_nvidia_cache":"ghcr.io/testorg/hipfile/ais_ci_ubuntu:latest-rocm-nightly-nvidia-cache"}}' || failures=$((failures+1))
+
+  echo
+  echo "Test 8: nightly version, empty build id -> bare -nightly tag (suffix omitted)"
+  # When the resolver yields no build id, build_suffix is empty so the tag is
+  # the floating ":latest-rocm-nightly" rather than a malformed trailing dash.
+  bm='{"include":[{"supported_platforms":"ubuntu","rocm_versions":"nightly"}]}'
+  out=$(compute_ci_images "ghcr.io/testorg" "latest-rocm" "" "$bm")
+  _assert_eq "  output" "$out" \
+    '{"ubuntu-nightly":{"ci_image":"ghcr.io/testorg/hipfile/ais_ci_ubuntu:latest-rocm-nightly","ci_image_cache":"ghcr.io/testorg/hipfile/ais_ci_ubuntu:latest-rocm-nightly-cache","ci_image_nvidia":"ghcr.io/testorg/hipfile/ais_ci_ubuntu:latest-rocm-nightly-nvidia","ci_image_nvidia_cache":"ghcr.io/testorg/hipfile/ais_ci_ubuntu:latest-rocm-nightly-nvidia-cache"}}' || failures=$((failures+1))
 
   echo
   if [ "${failures}" -eq 0 ]; then
@@ -143,9 +176,10 @@ _run_tests() {
 # Do NOT set shell options here: sourcing must not mutate the caller's shell.
 if [ "${BASH_SOURCE[0]}" != "${0}" ]; then
   # SC2034: ci_images is consumed by the sourcing CI step.
-  # SC2153: FULL_CI_IMAGES_MATRIX is a CI env var, not a typo of full_CI_images_matrix.
+  # SC2153: NIGHTLY_BUILD / FULL_CI_IMAGES_MATRIX are CI env vars, not typos of
+  # the lowercase args.
   # shellcheck disable=SC2034,SC2153
-  ci_images=$(compute_ci_images "${REGISTRY_URL}" "${tag}" "${FULL_CI_IMAGES_MATRIX}")
+  ci_images=$(compute_ci_images "${REGISTRY_URL}" "${tag}" "${NIGHTLY_BUILD}" "${FULL_CI_IMAGES_MATRIX}")
 else
   set -euo pipefail
   case "${1:-}" in

--- a/projects/hipfile/util/ci-images.sh
+++ b/projects/hipfile/util/ci-images.sh
@@ -5,35 +5,35 @@
 #
 # Single source of truth for the ci_images jq used by the Precheck job in
 # .github/workflows/hipfile-ci-toplevel.yml ("Compute CI image names" step).
-# ci_images consumes build_ci_image_matrix.include and emits the keyed map of
+# ci_images consumes full_CI_images_matrix.include and emits the keyed map of
 # image names (and caches) used by the downstream build/test jobs.
 #
 # Two ways to use it:
 #   Sourced (CI):  source ci-images.sh
 #                  -> sets shell var ci_images from the env vars REGISTRY_URL,
-#                     tag, BUILD_CI_IMAGE_MATRIX
+#                     tag, FULL_CI_IMAGES_MATRIX
 #   Tests:         bash ci-images.sh --test
 #
 # Because the same jq is both shipped to CI and exercised by --test, the two
 # can never drift. The tests are self-contained: they feed literal
-# build_ci_image_matrix fixtures into compute_ci_images and assert the map, so
+# full_CI_images_matrix fixtures into compute_ci_images and assert the map, so
 # they do not depend on ci-matrices.sh or on any env vars.
 
 # --- pure functions: the jq, one copy -------------------------------------
 
-# Consume build_ci_image_matrix.include directly: it is already the
+# Consume full_CI_images_matrix.include directly: it is already the
 # deduplicated set of (platform, version) pairs to build. Single source of
 # truth -- no parallel exclude/include logic here. A partial-axis include row
 # (missing rocm_versions) produces a malformed image URL (e.g. "...:latest-rocm"
 # with no version); the resulting docker-pull failure surfaces the malformed
 # include to the maintainer.
-# Args: registry tag build_ci_image_matrix (JSON)
+# Args: registry tag full_CI_images_matrix (JSON)
 compute_ci_images() {
-  local registry="$1" tag="$2" build_ci_image_matrix="$3"
+  local registry="$1" tag="$2" full_CI_images_matrix="$3"
   jq -c -n \
     --arg registry "${registry}" \
     --arg tag "${tag}" \
-    --argjson build_matrix "${build_ci_image_matrix}" \
+    --argjson build_matrix "${full_CI_images_matrix}" \
     '
       $build_matrix.include
       | map({ platform: .supported_platforms,
@@ -143,9 +143,9 @@ _run_tests() {
 # Do NOT set shell options here: sourcing must not mutate the caller's shell.
 if [ "${BASH_SOURCE[0]}" != "${0}" ]; then
   # SC2034: ci_images is consumed by the sourcing CI step.
-  # SC2153: BUILD_CI_IMAGE_MATRIX is a CI env var, not a typo of build_ci_image_matrix.
+  # SC2153: FULL_CI_IMAGES_MATRIX is a CI env var, not a typo of full_CI_images_matrix.
   # shellcheck disable=SC2034,SC2153
-  ci_images=$(compute_ci_images "${REGISTRY_URL}" "${tag}" "${BUILD_CI_IMAGE_MATRIX}")
+  ci_images=$(compute_ci_images "${REGISTRY_URL}" "${tag}" "${FULL_CI_IMAGES_MATRIX}")
 else
   set -euo pipefail
   case "${1:-}" in

--- a/projects/hipfile/util/ci-matrices.sh
+++ b/projects/hipfile/util/ci-matrices.sh
@@ -3,13 +3,13 @@
 #
 # SPDX-License-Identifier: MIT
 #
-# Single source of truth for the ci_matrix + build_ci_image_matrix jq used by
+# Single source of truth for the ci_matrix + full_CI_images_matrix jq used by
 # the Precheck job in .github/workflows/hipfile-ci-toplevel.yml ("Compute
 # matrix configurations" step).
 #
 # Two ways to use it:
 #   Sourced (CI):  source ci-matrices.sh
-#                  -> sets shell vars ci_matrix and build_ci_image_matrix from
+#                  -> sets shell vars ci_matrix and full_CI_images_matrix from
 #                     the env vars SUPPORTED_PLATFORMS, ROCM_VERSIONS,
 #                     MATRIX_INCLUDE, MATRIX_EXCLUDE
 #   Tests:         bash ci-matrices.sh --test
@@ -37,15 +37,16 @@ compute_ci_matrix() {
     }'
 }
 
-# Derive the image-build matrix from ci_matrix. Simulates GHA's matrix
-# expansion (cross-product -> exclude -> include with merge semantics),
-# projects each resulting combo down to (supported_platforms, rocm_versions),
-# and dedupes. This way future test-only axes on ci_matrix (CXX, compiler,
-# ...) do not multiply images, and an exclude that removes all test legs for a
+# Calculate the catalog of every CI image this run references. It is
+# derived by simulating GHA's matrix expansion (cross-product -> exclude
+# -> include with merge semantics) on ci_matrix, projecting each resulting 
+# combo down to (supported_platforms, rocm_versions), and deduping.
+# This way future test-only axes on ci_matrix (CXX, compiler, ...)
+# do not multiply images, and an exclude that removes all test legs for a
 # given (platform, version) correctly removes that image. Emitted in
 # include-only form so GHA spawns exactly one image-build job per row.
 # Arg: ci_matrix (JSON)
-compute_build_ci_image_matrix() {
+compute_full_CI_images_matrix() {
   local ci_matrix="$1"
   printf '%s' "${ci_matrix}" | jq -c '
     . as $ci
@@ -118,14 +119,14 @@ _run_tests() {
 
   echo "Test 1: today's ci_matrix (no extra axes) -> all cross-product pairs"
   ci='{"supported_platforms":["rocky","ubuntu"],"rocm_versions":["7.2.2"],"include":[],"exclude":[]}'
-  out=$(compute_build_ci_image_matrix "$ci")
+  out=$(compute_full_CI_images_matrix "$ci")
   _assert_eq "  output" "$out" \
     '{"include":[{"supported_platforms":"rocky","rocm_versions":"7.2.2"},{"supported_platforms":"ubuntu","rocm_versions":"7.2.2"}]}' || failures=$((failures+1))
 
   echo
   echo "Test 2: real-world today (rocky,rocky8,suse,ubuntu) x (7.2.2), include ubuntu/7.13.0"
   ci='{"supported_platforms":["rocky","rocky8","suse","ubuntu"],"rocm_versions":["7.2.2"],"include":[{"supported_platforms":"ubuntu","rocm_versions":"7.13.0"}],"exclude":[]}'
-  out=$(compute_build_ci_image_matrix "$ci")
+  out=$(compute_full_CI_images_matrix "$ci")
   _assert_eq "  output" "$out" \
     '{"include":[{"supported_platforms":"rocky","rocm_versions":"7.2.2"},{"supported_platforms":"rocky8","rocm_versions":"7.2.2"},{"supported_platforms":"suse","rocm_versions":"7.2.2"},{"supported_platforms":"ubuntu","rocm_versions":"7.13.0"},{"supported_platforms":"ubuntu","rocm_versions":"7.2.2"}]}' || failures=$((failures+1))
 
@@ -134,7 +135,7 @@ _run_tests() {
   # rocky8 has only one test leg in ci_matrix and it's excluded. Therefore no
   # rocky8 image is needed.
   ci='{"supported_platforms":["rocky8","ubuntu"],"rocm_versions":["7.2.2"],"cxx_standard":[17],"exclude":[{"supported_platforms":"rocky8","cxx_standard":17}],"include":[]}'
-  out=$(compute_build_ci_image_matrix "$ci")
+  out=$(compute_full_CI_images_matrix "$ci")
   _assert_eq "  output" "$out" \
     '{"include":[{"supported_platforms":"ubuntu","rocm_versions":"7.2.2"}]}' || failures=$((failures+1))
 
@@ -143,7 +144,7 @@ _run_tests() {
   # rocky8 has two test legs; only one is excluded. Image still required for
   # the cxx=20 leg.
   ci='{"supported_platforms":["rocky8","ubuntu"],"rocm_versions":["7.2.2"],"cxx_standard":[17,20],"exclude":[{"supported_platforms":"rocky8","cxx_standard":17}],"include":[]}'
-  out=$(compute_build_ci_image_matrix "$ci")
+  out=$(compute_full_CI_images_matrix "$ci")
   _assert_eq "  output" "$out" \
     '{"include":[{"supported_platforms":"rocky8","rocm_versions":"7.2.2"},{"supported_platforms":"ubuntu","rocm_versions":"7.2.2"}]}' || failures=$((failures+1))
 
@@ -152,7 +153,7 @@ _run_tests() {
   # include {ubuntu, 7.13.0, cxx:17} can't merge (rv=7.13.0 not in base), so
   # new combo; projection adds the pair.
   ci='{"supported_platforms":["ubuntu"],"rocm_versions":["7.2.2"],"cxx_standard":[17],"include":[{"supported_platforms":"ubuntu","rocm_versions":"7.13.0","cxx_standard":17}],"exclude":[]}'
-  out=$(compute_build_ci_image_matrix "$ci")
+  out=$(compute_full_CI_images_matrix "$ci")
   _assert_eq "  output" "$out" \
     '{"include":[{"supported_platforms":"ubuntu","rocm_versions":"7.13.0"},{"supported_platforms":"ubuntu","rocm_versions":"7.2.2"}]}' || failures=$((failures+1))
 
@@ -160,21 +161,21 @@ _run_tests() {
   echo "Test 6: augmenting include {cxx:20} -> no new (sp, rv) pairs"
   # {cxx:20} merges into every combo (no overwrite), creates no new combos.
   ci='{"supported_platforms":["ubuntu"],"rocm_versions":["7.2.2"],"cxx_standard":[17],"include":[{"cxx_standard":20}],"exclude":[]}'
-  out=$(compute_build_ci_image_matrix "$ci")
+  out=$(compute_full_CI_images_matrix "$ci")
   _assert_eq "  output" "$out" \
     '{"include":[{"supported_platforms":"ubuntu","rocm_versions":"7.2.2"}]}' || failures=$((failures+1))
 
   echo
   echo "Test 7: include duplicating an existing combo -> dedup, no spurious entry"
   ci='{"supported_platforms":["ubuntu"],"rocm_versions":["7.2.2"],"include":[{"supported_platforms":"ubuntu","rocm_versions":"7.2.2"}],"exclude":[]}'
-  out=$(compute_build_ci_image_matrix "$ci")
+  out=$(compute_full_CI_images_matrix "$ci")
   _assert_eq "  output" "$out" \
     '{"include":[{"supported_platforms":"ubuntu","rocm_versions":"7.2.2"}]}' || failures=$((failures+1))
 
   echo
   echo "Test 8: partial-axis include {sp:rocky} when rocky in base -> merges, no new"
   ci='{"supported_platforms":["rocky","ubuntu"],"rocm_versions":["7.2.2"],"include":[{"supported_platforms":"rocky"}],"exclude":[]}'
-  out=$(compute_build_ci_image_matrix "$ci")
+  out=$(compute_full_CI_images_matrix "$ci")
   _assert_eq "  output" "$out" \
     '{"include":[{"supported_platforms":"rocky","rocm_versions":"7.2.2"},{"supported_platforms":"ubuntu","rocm_versions":"7.2.2"}]}' || failures=$((failures+1))
 
@@ -182,28 +183,28 @@ _run_tests() {
   echo "Test 9: partial-axis include {sp:rocky} when rocky NOT in base -> creates partial entry"
   # The phantom case the maintainer accepted. We don't paper over it.
   ci='{"supported_platforms":["ubuntu"],"rocm_versions":["7.2.2"],"include":[{"supported_platforms":"rocky"}],"exclude":[]}'
-  out=$(compute_build_ci_image_matrix "$ci")
+  out=$(compute_full_CI_images_matrix "$ci")
   _assert_eq "  output" "$out" \
     '{"include":[{"supported_platforms":"rocky"},{"supported_platforms":"ubuntu","rocm_versions":"7.2.2"}]}' || failures=$((failures+1))
 
   echo
   echo "Test 10: exclude (rocky, 7.2.2) -> removes that pair"
   ci='{"supported_platforms":["rocky","ubuntu"],"rocm_versions":["7.2.2","7.3.0"],"exclude":[{"supported_platforms":"rocky","rocm_versions":"7.2.2"}],"include":[]}'
-  out=$(compute_build_ci_image_matrix "$ci")
+  out=$(compute_full_CI_images_matrix "$ci")
   _assert_eq "  output" "$out" \
     '{"include":[{"supported_platforms":"rocky","rocm_versions":"7.3.0"},{"supported_platforms":"ubuntu","rocm_versions":"7.2.2"},{"supported_platforms":"ubuntu","rocm_versions":"7.3.0"}]}' || failures=$((failures+1))
 
   echo
   echo "Test 11: exclude then re-include same pair"
   ci='{"supported_platforms":["rocky","ubuntu"],"rocm_versions":["7.2.2"],"exclude":[{"supported_platforms":"rocky","rocm_versions":"7.2.2"}],"include":[{"supported_platforms":"rocky","rocm_versions":"7.2.2"}]}'
-  out=$(compute_build_ci_image_matrix "$ci")
+  out=$(compute_full_CI_images_matrix "$ci")
   _assert_eq "  output" "$out" \
     '{"include":[{"supported_platforms":"rocky","rocm_versions":"7.2.2"},{"supported_platforms":"ubuntu","rocm_versions":"7.2.2"}]}' || failures=$((failures+1))
 
   echo
   echo "Test 12: future axes, no excludes/includes -> dedup down to (sp,rv) projection"
   ci='{"supported_platforms":["ubuntu"],"rocm_versions":["7.2.2"],"cxx_standard":[17,20],"compiler":["clang","gcc"],"include":[],"exclude":[]}'
-  out=$(compute_build_ci_image_matrix "$ci")
+  out=$(compute_full_CI_images_matrix "$ci")
   _assert_eq "  output" "$out" \
     '{"include":[{"supported_platforms":"ubuntu","rocm_versions":"7.2.2"}]}' || failures=$((failures+1))
 
@@ -221,12 +222,12 @@ _run_tests() {
 # shell); when executed they are equal. So "!=" means "we are being sourced".
 # Do NOT set shell options here: sourcing must not mutate the caller's shell.
 if [ "${BASH_SOURCE[0]}" != "${0}" ]; then
-  # SC2034: ci_matrix/build_ci_image_matrix are consumed by the sourcing CI step.
+  # SC2034: ci_matrix/full_CI_images_matrix are consumed by the sourcing CI step.
   # SC2153: the UPPER_CASE names are CI env vars, not typos of the lowercase args.
   # shellcheck disable=SC2034,SC2153
   ci_matrix=$(compute_ci_matrix "${SUPPORTED_PLATFORMS}" "${ROCM_VERSIONS}" "${MATRIX_INCLUDE}" "${MATRIX_EXCLUDE}")
   # shellcheck disable=SC2034
-  build_ci_image_matrix=$(compute_build_ci_image_matrix "${ci_matrix}")
+  full_CI_images_matrix=$(compute_full_CI_images_matrix "${ci_matrix}")
 else
   set -euo pipefail
   case "${1:-}" in

--- a/projects/hipfile/util/docker/DOCKERFILE.ais_ci_ubuntu
+++ b/projects/hipfile/util/docker/DOCKERFILE.ais_ci_ubuntu
@@ -15,6 +15,11 @@ ARG ROCM_VERSION=7.2.2
 # Ex. Package 7.0_alpha installs 7.0.0
 ARG ROCM_PKG_REPO_OVERRIDE
 
+# Nightly ROCm build id (YYYYMMDD-<gha_run_id>). When set, ROCm is installed from
+# the unsigned nightly repo at rocm.nightlies.amd.com/deb/<ROCM_NIGHTLY_BUILD>
+# and ROCM_VERSION is expected to be the clean MAJOR.MINOR.PATCH that build pins.
+ARG ROCM_NIGHTLY_BUILD
+
 RUN apt update && \
     apt install -y \
         curl \
@@ -23,25 +28,31 @@ RUN apt update && \
 # Cache MAJOR/MINOR and the ROCm build type for use by later RUN steps.
 # Threshold: ROCm 7.11+ ships from repo.amd.com to /opt/rocm/core-<MAJOR>.<MINOR>;
 # earlier releases ship from repo.radeon.com to /opt/rocm (legacy symlink).
+# A non-empty ROCM_NIGHTLY_BUILD selects the nightly repo and shares the 7.11+
+# install layout (ROCM_VERSION must be the clean version that build pins).
 RUN ROCM_MAJOR=$(echo "${ROCM_VERSION}" | cut -d. -f1); \
     ROCM_MINOR=$(echo "${ROCM_VERSION}" | cut -d. -f2); \
-    if [ "${ROCM_MAJOR}" -gt 7 ] || { [ "${ROCM_MAJOR}" -eq 7 ] && [ "${ROCM_MINOR}" -ge 11 ]; }; then \
+    if [ -n "${ROCM_NIGHTLY_BUILD}" ]; then \
+        ROCM_BUILD_TYPE=nightly; \
+        ROCM_INSTALL_PATH="/opt/rocm/core-${ROCM_MAJOR}.${ROCM_MINOR}"; \
+    elif [ "${ROCM_MAJOR}" -gt 7 ] || { [ "${ROCM_MAJOR}" -eq 7 ] && [ "${ROCM_MINOR}" -ge 11 ]; }; then \
         ROCM_BUILD_TYPE=new; \
         ROCM_INSTALL_PATH="/opt/rocm/core-${ROCM_MAJOR}.${ROCM_MINOR}"; \
     else \
         ROCM_BUILD_TYPE=legacy; \
         ROCM_INSTALL_PATH="/opt/rocm"; \
     fi; \
-    printf 'ROCM_MAJOR=%s\nROCM_MINOR=%s\nROCM_BUILD_TYPE=%s\nROCM_INSTALL_PATH=%s\n' \
-        "${ROCM_MAJOR}" "${ROCM_MINOR}" "${ROCM_BUILD_TYPE}" "${ROCM_INSTALL_PATH}" \
+    printf 'ROCM_MAJOR=%s\nROCM_MINOR=%s\nROCM_BUILD_TYPE=%s\nROCM_INSTALL_PATH=%s\nROCM_NIGHTLY_BUILD=%s\n' \
+        "${ROCM_MAJOR}" "${ROCM_MINOR}" "${ROCM_BUILD_TYPE}" "${ROCM_INSTALL_PATH}" "${ROCM_NIGHTLY_BUILD}" \
         > /etc/rocm-build.env
 
-# Retrieve ROCm GPG key
+# Retrieve ROCm GPG key. The nightly repo is unsigned, so no key is fetched
+# (the nightly sources.list entry uses [trusted=yes]).
 RUN . /etc/rocm-build.env && \
     if [ "${ROCM_BUILD_TYPE}" = "new" ]; then \
         curl https://repo.amd.com/rocm/packages/gpg/rocm.gpg | \
             gpg --dearmor >> /etc/apt/keyrings/amdrocm.gpg; \
-    else \
+    elif [ "${ROCM_BUILD_TYPE}" = "legacy" ]; then \
         curl https://repo.radeon.com/rocm/rocm.gpg.key | \
             gpg --dearmor >> /etc/apt/keyrings/rocm.gpg; \
     fi
@@ -54,6 +65,9 @@ RUN . /etc/rocm-build.env && \
     if [ "${ROCM_BUILD_TYPE}" = "new" ]; then \
         echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/amdrocm.gpg] https://repo.amd.com/rocm/packages/ubuntu${UBUNTU_MAJOR_VERSION}${UBUNTU_MINOR_VERSION} stable main" \
             > /etc/apt/sources.list.d/amdrocm.list; \
+    elif [ "${ROCM_BUILD_TYPE}" = "nightly" ]; then \
+        echo "deb [arch=amd64 trusted=yes] https://rocm.nightlies.amd.com/deb/${ROCM_NIGHTLY_BUILD} stable main" \
+            > /etc/apt/sources.list.d/amdrocm-nightly.list; \
     else \
         ROCM_PKG_REPO_VERSION="$(echo ${ROCM_PKG_REPO_OVERRIDE:-$ROCM_VERSION} | sed -E 's|([^.]+\.[^.]+)\.0$|\1|')"; \
         echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/${ROCM_PKG_REPO_VERSION} ${UBUNTU_CODENAME} main" \
@@ -86,9 +100,10 @@ RUN apt update && \
         python3.12-dev \
         python3.12-venv
 
-# ROCm dev packages
+# ROCm dev packages. The new and nightly repos both ship the runtime + dev as a
+# single amdrocm-runtime-dev<MAJOR>.<MINOR> meta-package.
 RUN . /etc/rocm-build.env && \
-    if [ "${ROCM_BUILD_TYPE}" = "new" ]; then \
+    if [ "${ROCM_BUILD_TYPE}" = "new" ] || [ "${ROCM_BUILD_TYPE}" = "nightly" ]; then \
         apt install -y \
             amdrocm-runtime-dev${ROCM_MAJOR}.${ROCM_MINOR}; \
     else \

--- a/projects/hipfile/util/docker/DOCKERFILE.ais_ci_ubuntu
+++ b/projects/hipfile/util/docker/DOCKERFILE.ais_ci_ubuntu
@@ -16,7 +16,7 @@ ARG ROCM_VERSION=7.2.2
 ARG ROCM_PKG_REPO_OVERRIDE
 
 # Nightly ROCm build id (YYYYMMDD-<gha_run_id>). When set, ROCm is installed from
-# the unsigned nightly repo at rocm.nightlies.amd.com/deb/<ROCM_NIGHTLY_BUILD>
+# the unsigned nightly repo at rocm.nightlies.amd.com/packages-multi-arch/deb/<ROCM_NIGHTLY_BUILD>
 # and ROCM_VERSION is expected to be the clean MAJOR.MINOR.PATCH that build pins.
 ARG ROCM_NIGHTLY_BUILD
 
@@ -66,7 +66,7 @@ RUN . /etc/rocm-build.env && \
         echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/amdrocm.gpg] https://repo.amd.com/rocm/packages/ubuntu${UBUNTU_MAJOR_VERSION}${UBUNTU_MINOR_VERSION} stable main" \
             > /etc/apt/sources.list.d/amdrocm.list; \
     elif [ "${ROCM_BUILD_TYPE}" = "nightly" ]; then \
-        echo "deb [arch=amd64 trusted=yes] https://rocm.nightlies.amd.com/deb/${ROCM_NIGHTLY_BUILD} stable main" \
+        echo "deb [arch=amd64 trusted=yes] https://rocm.nightlies.amd.com/packages-multi-arch/deb/${ROCM_NIGHTLY_BUILD} stable main" \
             > /etc/apt/sources.list.d/amdrocm-nightly.list; \
     else \
         ROCM_PKG_REPO_VERSION="$(echo ${ROCM_PKG_REPO_OVERRIDE:-$ROCM_VERSION} | sed -E 's|([^.]+\.[^.]+)\.0$|\1|')"; \

--- a/projects/hipfile/util/docker/DOCKERFILE.ais_ci_ubuntu
+++ b/projects/hipfile/util/docker/DOCKERFILE.ais_ci_ubuntu
@@ -20,25 +20,25 @@ RUN apt update && \
         curl \
         gpg
 
-# Cache MAJOR/MINOR and a 'use new repo' flag for use by later RUN steps.
+# Cache MAJOR/MINOR and the ROCm build type for use by later RUN steps.
 # Threshold: ROCm 7.11+ ships from repo.amd.com to /opt/rocm/core-<MAJOR>.<MINOR>;
 # earlier releases ship from repo.radeon.com to /opt/rocm (legacy symlink).
 RUN ROCM_MAJOR=$(echo "${ROCM_VERSION}" | cut -d. -f1); \
     ROCM_MINOR=$(echo "${ROCM_VERSION}" | cut -d. -f2); \
     if [ "${ROCM_MAJOR}" -gt 7 ] || { [ "${ROCM_MAJOR}" -eq 7 ] && [ "${ROCM_MINOR}" -ge 11 ]; }; then \
-        ROCM_USE_NEW_REPO=1; \
+        ROCM_BUILD_TYPE=new; \
         ROCM_INSTALL_PATH="/opt/rocm/core-${ROCM_MAJOR}.${ROCM_MINOR}"; \
     else \
-        ROCM_USE_NEW_REPO=0; \
+        ROCM_BUILD_TYPE=legacy; \
         ROCM_INSTALL_PATH="/opt/rocm"; \
     fi; \
-    printf 'ROCM_MAJOR=%s\nROCM_MINOR=%s\nROCM_USE_NEW_REPO=%s\nROCM_INSTALL_PATH=%s\n' \
-        "${ROCM_MAJOR}" "${ROCM_MINOR}" "${ROCM_USE_NEW_REPO}" "${ROCM_INSTALL_PATH}" \
+    printf 'ROCM_MAJOR=%s\nROCM_MINOR=%s\nROCM_BUILD_TYPE=%s\nROCM_INSTALL_PATH=%s\n' \
+        "${ROCM_MAJOR}" "${ROCM_MINOR}" "${ROCM_BUILD_TYPE}" "${ROCM_INSTALL_PATH}" \
         > /etc/rocm-build.env
 
 # Retrieve ROCm GPG key
 RUN . /etc/rocm-build.env && \
-    if [ "${ROCM_USE_NEW_REPO}" = "1" ]; then \
+    if [ "${ROCM_BUILD_TYPE}" = "new" ]; then \
         curl https://repo.amd.com/rocm/packages/gpg/rocm.gpg | \
             gpg --dearmor >> /etc/apt/keyrings/amdrocm.gpg; \
     else \
@@ -51,7 +51,7 @@ RUN . /etc/rocm-build.env && \
 # If the PATCH component is 0, the PATCH of the version is dropped. Otherwise no
 # modification is made.
 RUN . /etc/rocm-build.env && \
-    if [ "${ROCM_USE_NEW_REPO}" = "1" ]; then \
+    if [ "${ROCM_BUILD_TYPE}" = "new" ]; then \
         echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/amdrocm.gpg] https://repo.amd.com/rocm/packages/ubuntu${UBUNTU_MAJOR_VERSION}${UBUNTU_MINOR_VERSION} stable main" \
             > /etc/apt/sources.list.d/amdrocm.list; \
     else \
@@ -64,7 +64,7 @@ RUN . /etc/rocm-build.env && \
 # Outer EOT is a Dockerfile-level heredoc delimiter, kept distinct from the inner shell EOF.
 RUN <<"EOT"
 . /etc/rocm-build.env
-if [ "${ROCM_USE_NEW_REPO}" = "0" ]; then
+if [ "${ROCM_BUILD_TYPE}" = "legacy" ]; then
     cat <<EOF > /etc/apt/preferences.d/rocm-pin-600
 Package: *
 Pin: release o=repo.radeon.com
@@ -88,7 +88,7 @@ RUN apt update && \
 
 # ROCm dev packages
 RUN . /etc/rocm-build.env && \
-    if [ "${ROCM_USE_NEW_REPO}" = "1" ]; then \
+    if [ "${ROCM_BUILD_TYPE}" = "new" ]; then \
         apt install -y \
             amdrocm-runtime-dev${ROCM_MAJOR}.${ROCM_MINOR}; \
     else \

--- a/projects/hipfile/util/resolve-rocm-nightly.sh
+++ b/projects/hipfile/util/resolve-rocm-nightly.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Resolves the latest ROCm nightly build and the clean ROCm version it pins.
+# Used in CI to target a reproducible nightly when building the hipFile CI image.
+#
+# Two ways to use it:
+#   Executed (CI):  ./resolve-rocm-nightly.sh
+#                   -> emits (GITHUB_OUTPUT form) on stdout:
+#                        nightly_build=<YYYYMMDD-gha_run_id>
+#                        nightly_rocm_version=<MAJOR.MINOR.PATCH>
+#   Tests:          bash resolve-rocm-nightly.sh --test
+#
+# The parsing/selection helpers are pure (stdin -> stdout), so --test validates
+# them against fixtures offline -- without the network round-trips main() makes.
+# Because the same helpers are both shipped to CI and exercised by --test, the
+# two can never drift.
+
+NIGHTLY_DEB_BASE="https://rocm.nightlies.amd.com/deb"
+
+# --- pure helpers ---------------------------------------------------------
+
+# Reads a /deb/ directory index on stdin and prints the latest build id.
+# Build ids are YYYYMMDD-<gha_run_id>; the date dominates, the numeric run id
+# breaks ties so same-day builds resolve to a single deterministic match.
+select_latest_build() {
+    # awk 'NR==1' (rather than head) consumes the whole stream so sort does not
+    # receive SIGPIPE under pipefail.
+    grep -oE '[0-9]{8}-[0-9]+' \
+        | sort -u -t- -k1,1nr -k2,2nr \
+        | awk 'NR==1 { print }'
+}
+
+# Reads a binary-amd64/Packages file on stdin and prints the clean
+# MAJOR.MINOR.PATCH version of the amdrocm-runtime-dev meta-package (the nightly
+# Debian version is e.g. 7.14.0~20260602-26796279962; everything from '~' on is
+# stripped).
+extract_clean_version() {
+    # Read the whole file (no early exit) so the upstream feeder does not get
+    # SIGPIPE under pipefail; keep the first matching version.
+    awk '
+        /^Package:/ { in_pkg = ($0 == "Package: amdrocm-runtime-dev") }
+        in_pkg && /^Version:/ && ver == "" { ver = $2; sub(/~.*/, "", ver) }
+        END { if (ver != "") print ver }
+    '
+}
+
+# --- main -----------------------------------------------------------------
+
+main() {
+    set -euo pipefail
+    local index build packages version
+
+    index="$(curl -fsSL "${NIGHTLY_DEB_BASE}/")"
+    build="$(printf '%s' "${index}" | select_latest_build)"
+    if [ -z "${build}" ]; then
+        echo "resolve-rocm-nightly: no nightly build found at ${NIGHTLY_DEB_BASE}/" >&2
+        exit 1
+    fi
+
+    packages="$(curl -fsSL "${NIGHTLY_DEB_BASE}/${build}/dists/stable/main/binary-amd64/Packages")"
+    version="$(printf '%s' "${packages}" | extract_clean_version)"
+    if [ -z "${version}" ]; then
+        echo "resolve-rocm-nightly: could not determine ROCm version for build ${build}" >&2
+        exit 1
+    fi
+
+    printf 'nightly_build=%s\n' "${build}"
+    printf 'nightly_rocm_version=%s\n' "${version}"
+}
+
+# --- test suite -----------------------------------------------------------
+
+_assert_eq() {
+    local label="$1" actual="$2" expected="$3"
+    if [ "${actual}" = "${expected}" ]; then
+        printf '  PASS  %s\n        -> %s\n' "${label}" "${actual}"
+    else
+        printf '  FAIL  %s\n        expected: %s\n        got:      %s\n' \
+            "${label}" "${expected}" "${actual}"
+        return 1
+    fi
+}
+
+_run_tests() {
+    # not -e: the `read -r -d ''` fixtures below return non-zero at EOF, and we
+    # want to keep going and tally failures rather than abort on the first one.
+    set -uo pipefail
+    local failures=0
+
+    # Sample /deb/ index, mixing dates and same-date run ids, with href + text
+    # duplicates as the real S3 listing produces.
+    local INDEX_FIXTURE
+    read -r -d '' INDEX_FIXTURE <<'EOF'
+<a href="20260530-26673017729/">20260530-26673017729/</a>
+<a href="20260602-26796000000/">20260602-26796000000/</a>
+<a href="20260601-26733368587/">20260601-26733368587/</a>
+<a href="20260602-26796279962/">20260602-26796279962/</a>
+EOF
+
+    # Sample Packages: the versioned -dev7.14 stanza must NOT be matched; only the
+    # bare amdrocm-runtime-dev meta-package supplies the version.
+    local PACKAGES_FIXTURE
+    read -r -d '' PACKAGES_FIXTURE <<'EOF'
+Package: amdrocm-runtime-dev7.14
+Version: 7.14.0~20260602-26796279962
+Architecture: amd64
+Filename: pool/main/amdrocm-runtime-dev7.14_7.14.0~20260602-26796279962_amd64.deb
+
+Package: amdrocm-runtime-dev
+Version: 7.14.0~20260602-26796279962
+Architecture: amd64
+Filename: pool/main/amdrocm-runtime-dev_7.14.0~20260602-26796279962_amd64.deb
+EOF
+
+    # A different pinned version, meta stanza appearing first.
+    local PACKAGES_FIXTURE_ALT
+    read -r -d '' PACKAGES_FIXTURE_ALT <<'EOF'
+Package: amdrocm-runtime-dev
+Version: 7.15.1~20260701-30000000001
+Architecture: amd64
+
+Package: amdrocm-runtime-dev7.15
+Version: 7.15.1~20260701-30000000001
+Architecture: amd64
+EOF
+
+    echo "Test 1: latest build picks the highest date"
+    _assert_eq "  select_latest_build" \
+        "$(printf '%s' "${INDEX_FIXTURE}" | select_latest_build)" \
+        "20260602-26796279962" || failures=$((failures+1))
+
+    echo
+    echo "Test 2: same-date tie-break picks the larger numeric run id"
+    local INDEX_TIE
+    read -r -d '' INDEX_TIE <<'EOF'
+<a href="20260602-26796000000/">20260602-26796000000/</a>
+<a href="20260602-9999999999/">20260602-9999999999/</a>
+<a href="20260602-26796279962/">20260602-26796279962/</a>
+EOF
+    _assert_eq "  select_latest_build" \
+        "$(printf '%s' "${INDEX_TIE}" | select_latest_build)" \
+        "20260602-26796279962" || failures=$((failures+1))
+
+    echo
+    echo "Test 3: clean version from meta-package (strips ~build, ignores -dev7.14)"
+    _assert_eq "  extract_clean_version" \
+        "$(printf '%s' "${PACKAGES_FIXTURE}" | extract_clean_version)" \
+        "7.14.0" || failures=$((failures+1))
+
+    echo
+    echo "Test 4: clean version when meta stanza is first"
+    _assert_eq "  extract_clean_version" \
+        "$(printf '%s' "${PACKAGES_FIXTURE_ALT}" | extract_clean_version)" \
+        "7.15.1" || failures=$((failures+1))
+
+    echo
+    if [ "${failures}" -eq 0 ]; then
+        echo "All tests passed."
+    else
+        echo "${failures} test(s) FAILED."
+        return 1
+    fi
+}
+
+# --- dispatch -------------------------------------------------------------
+# When sourced, ${BASH_SOURCE[0]} (this file) differs from ${0} (the caller's
+# shell); when executed they are equal. So "!=" means "we are being sourced".
+# Do NOT set shell options at top level: sourcing must not mutate the caller's
+# shell. main and _run_tests each set the options they want.
+if [ "${BASH_SOURCE[0]}" != "${0}" ]; then
+    : # sourced: helper functions are now available; do nothing else
+else
+    case "${1:-}" in
+        --test) _run_tests ;;
+        "")     main ;;
+        *)      echo "usage: ./resolve-rocm-nightly.sh [--test]" >&2; exit 2 ;;
+    esac
+fi

--- a/projects/hipfile/util/resolve-rocm-nightly.sh
+++ b/projects/hipfile/util/resolve-rocm-nightly.sh
@@ -27,8 +27,10 @@ NIGHTLY_DEB_BASE="https://rocm.nightlies.amd.com/deb"
 # breaks ties so same-day builds resolve to a single deterministic match.
 select_latest_build() {
     # awk 'NR==1' (rather than head) consumes the whole stream so sort does not
-    # receive SIGPIPE under pipefail.
-    grep -oE '[0-9]{8}-[0-9]+' \
+    # receive SIGPIPE under pipefail. The `|| true` keeps a no-match grep (exit 1)
+    # from aborting the caller under `set -e`/pipefail: we emit nothing and exit 0
+    # so the caller's own empty-result check can report a clean error.
+    { grep -oE '[0-9]{8}-[0-9]+' || true; } \
         | sort -u -t- -k1,1nr -k2,2nr \
         | awk 'NR==1 { print }'
 }
@@ -155,6 +157,17 @@ EOF
     _assert_eq "  extract_clean_version" \
         "$(printf '%s' "${PACKAGES_FIXTURE_ALT}" | extract_clean_version)" \
         "7.15.1" || failures=$((failures+1))
+
+    echo
+    echo "Test 5: index with no build ids -> empty output and exit 0 (no-match grep"
+    echo "        must not abort the caller under set -e/pipefail)"
+    local nomatch_out nomatch_rc
+    nomatch_out="$(printf '%s' '<a href="stable/">stable/</a>' | select_latest_build)"
+    nomatch_rc=$?
+    _assert_eq "  select_latest_build (output)" "${nomatch_out}" "" \
+        || failures=$((failures+1))
+    _assert_eq "  select_latest_build (exit)" "${nomatch_rc}" "0" \
+        || failures=$((failures+1))
 
     echo
     if [ "${failures}" -eq 0 ]; then

--- a/projects/hipfile/util/resolve-rocm-nightly.sh
+++ b/projects/hipfile/util/resolve-rocm-nightly.sh
@@ -18,7 +18,7 @@
 # Because the same helpers are both shipped to CI and exercised by --test, the
 # two can never drift.
 
-NIGHTLY_DEB_BASE="https://rocm.nightlies.amd.com/deb"
+NIGHTLY_DEB_BASE="https://rocm.nightlies.amd.com/packages-multi-arch/deb"
 
 # --- pure helpers ---------------------------------------------------------
 


### PR DESCRIPTION
## Motivation

hipFile CI only tested released ROCm. This adds a ROCm **nightly** leg (Ubuntu) so regressions against in-development ROCm are caught early — without paying to rebuild the nightly image on every PR.

## Technical Details

- **Dockerfile**: replaces the boolean `ROCM_USE_NEW_REPO` with a `ROCM_BUILD_TYPE` enum (`legacy`/`new`/`nightly`); the nightly type installs from the unsigned `rocm.nightlies.amd.com` repo using a resolved build id.
- **`resolve-rocm-nightly.sh`**: resolves the latest nightly build id and the clean `MAJOR.MINOR.PATCH` version it pins, so builds target a reproducible nightly.
- **Image naming**: nightly images carry the build id in the tag (`latest-rocm-nightly-<build>`) while the cache ref stays floating.
- **Per-PR efficiency**: a new `build-ci-images-matrix.sh` computes the set of images to actually build — on a no-Dockerfile-change PR it queries GHCR and builds a nightly row only if its base/nvidia image isn't already published, so the build is normally skipped (and a newly-published nightly is picked up on demand).
- **`hipfile-image-update-nightly.yml`**: a daily job that pre-builds/pushes the nightly image and warms the floating cache, plus a merge-refresh on Dockerfile/resolver changes; per-PR fallback builds also refresh the cache.
- The CI jq/orchestration lives in sourced `util/*.sh` scripts, each exercised by a `--test` suite. (Nightly nvidia images are built but not yet tested.)

## JIRA ID

AIHIPFILE-197

## Test Plan

- Added offline unit suites for every util script, run in the Precheck "Sanity-check" step.
- Running CI a few times under different conditions.

## Test Result

Workflow runs from a personal fork - don't expect system tests to run.
Workflow tests where the PR does not change a Dockerfile are run in a separate PR.

### PR changes a Dockerfile
- All images are built, cache misses expected as this is done in a personal fork.
- https://github.com/riley-dixon/rocm-systems/actions/runs/27044717591?pr=7
- [Images that are pushed](https://github.com/riley-dixon/rocm-systems/actions/runs/27044717591/job/79828200755?pr=7#step:6:1954)

### Merged PR changing Dockerfile updates the nightly image
- Reminder that the existing update image workflow does not update nightly images.
- https://github.com/riley-dixon/rocm-systems/actions/runs/27045316010
- [Images that are pushed](https://github.com/riley-dixon/rocm-systems/actions/runs/27045316010/job/79829975887#step:7:1977)
- [Cached pushed](https://github.com/riley-dixon/rocm-systems/actions/runs/27044717591/job/79828200755?pr=7#step:6:1954)
- Independently confirmed that published cache SHA after workflow completed matches `fc973e81839ca1e62e55c8099d3fd0e305543d293ad9b356079ec40773b0c23c`

### Scheduled Job Updates the Nightly Image 
- Expect a new ROCm nightly build to be available at this time.
- https://github.com/riley-dixon/rocm-systems/actions/runs/27143613929
- [Images that are pushed](https://github.com/riley-dixon/rocm-systems/actions/runs/27143613929/job/80115238452#step:7:1985)
- [Cache pushed](https://github.com/riley-dixon/rocm-systems/actions/runs/27143613929/job/80115238452#step:7:1985)
- Independently confirmed that published cache SHA after workflow completed matches `709223f58087a689f6969316d37c441cb49c011cc1c0d160c0c3934274693a46`

### PR does not change a Dockerfile
- Nightly image cache miss, builds only nightly image and updates it.
- https://github.com/riley-dixon/rocm-systems/actions/runs/27046094941?pr=8
- [Cached pushed](https://github.com/riley-dixon/rocm-systems/actions/runs/27046094941/job/79832249186?pr=8#step:6:1992)
- Independently confirmed that published cache SHA after workflow completed matches `6bf5d02b9b2c749aabbe8eda4414a3591050e5791e140099b34defe9d1527ed7`

### PR does not change a Dockerfile
- Nightly image cache hit, build_CI_image skipped.
- https://github.com/riley-dixon/rocm-systems/actions/runs/27045663770?pr=8

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
