### PR TITLE
Fix Build Issue with --no-device-linker on ROCm 7.13

### DIFF
--- a/projects/rccl/src/include/nccl_device/gin/proxy/gin_proxy.h
+++ b/projects/rccl/src/include/nccl_device/gin/proxy/gin_proxy.h
@@ -12,7 +12,9 @@
 
 #include <cstdint>
 #include <cuda_runtime.h>
+#if defined(RCCL_DEVICE_LINKER) // Without this, we get a duplicate symbol error when building with the --no-device-linker flag on ROCm 7.13.
 #include <cooperative_groups.h>
+#endif
 #if defined(__HIP_PLATFORM_AMD__)
 // HIP analog of CUDA __stwt: dwordx4 builtins, v4u typedefs, system sync scope.
 #include "nccl_device/rccl_ptr.h"


### PR DESCRIPTION
## Motivation

We need to be able to turn the parallel device linker off and still build RCCL.

## Technical Details

The duplicate symbol occurs when we import the cooperative_groups header on ROCm 7.13.

## JIRA ID
ROCM-25471

## Test Plan

Tested on ROCm 7.13, was able to reproduce the duplicate symbol error on the develop branch without this when running install.sh -l --no-device-linker

## Test Result
With this, the build succeeds with and without the --no-device-linker flag.


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
