### PR TITLE
[debug] Enable AMD_LOG_LEVEL=7 to diagnose hipGraphAddMemAllocNode dptr==nullptr

### DIFF
--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -111,6 +111,8 @@ jobs:
           # Windows hip-tests (PAL=1, ROCR=0) set this via matrix; other
           # components leave it empty. See: https://github.com/ROCm/TheRock/issues/3587
           GPU_ENABLE_PAL: ${{ fromJSON(inputs.component).gpu_enable_pal }}
+          # Temporary: enable verbose HIP logging to debug hipGraphAddMemAllocNode dptr==nullptr
+          AMD_LOG_LEVEL: 7
         run: |
           ${{ fromJSON(inputs.component).test_script }}
 


### PR DESCRIPTION
## Summary
- Adds `AMD_LOG_LEVEL=7` to the CI test environment to capture verbose HIP runtime logs
- This is a **temporary debug PR** to diagnose why `hipGraphAddMemAllocNode` returns `dptr==nullptr` on gfx942 CI runners, causing cascading graph memory test failures (tests #527, #535, #539, #543, #547, #551, #555)
- To be reverted after the root cause is identified

## Test plan
- [ ] Trigger CI and check log output from `Unit_hipGraphMem_Alloc_Free_NodeGetParams_Functional` (test #527) for HIP pool/VM allocation errors
- [ ] Look for `HIP_MEM_POOL_USE_VM`, `ReserveAddress`, or memory pool exhaustion messages around the `dptr==nullptr` failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)