### PR TITLE
[rocprofiler-systems] Fix: skip GPU KFD dropped-events PMC when no GPU agents

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk/kfd_events.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk/kfd_events.cpp
@@ -267,16 +267,21 @@ kfd_event_metadata_initialize(const client_data* tool_data)
     constexpr auto*  BLOCK       = "KFD";
     constexpr auto*  EXPRESSION  = "";
 
-    constexpr std::uint32_t DEVICE_ID = 0;
-
-    // Dropped events have no associated agent; pin to GPU 0 as a placeholder.
-    trace_cache::get_metadata_registry().add_pmc_info(
-        { agent_type::GPU, DEVICE_ID, "GPU", EVENT_CODE, INSTANCE_ID,
-          trait::name<category::rocm_kfd_event_dropped_events>::value,
-          "KFD Dropped Events",
-          trait::name<category::rocm_kfd_event_dropped_events>::description,
-          "KFD dropped_events events", COMPONENT, "count", trace_cache::ABSOLUTE, BLOCK,
-          EXPRESSION, 0, 0, "{}" });
+    // Dropped events have no associated agent; pin them to the first GPU as a
+    // placeholder. Skip when no GPU agents are present - otherwise the metadata
+    // post-processor cannot resolve the GPU agent and aborts post-processing.
+    if(!tool_data->gpu_agents.empty())
+    {
+        const auto dropped_dev_id =
+            static_cast<std::uint32_t>(tool_data->gpu_agents.front().device_id);
+        trace_cache::get_metadata_registry().add_pmc_info(
+            { agent_type::GPU, dropped_dev_id, "GPU", EVENT_CODE, INSTANCE_ID,
+              trait::name<category::rocm_kfd_event_dropped_events>::value,
+              "KFD Dropped Events",
+              trait::name<category::rocm_kfd_event_dropped_events>::description,
+              "KFD dropped_events events", COMPONENT, "count", trace_cache::ABSOLUTE,
+              BLOCK, EXPRESSION, 0, 0, "{}" });
+    }
 
     // All KFD event types carry an agent; register one PMC info entry per GPU
     // (and per CPU for page migrate) so events are correctly attributed.


### PR DESCRIPTION
## Motivation
With `ROCPROFSYS_USE_ROCPD=ON` and `kfd_events` in `ROCPROFSYS_ROCM_DOMAINS` on a host that enumerates no GPU agents, `rocprof-sys` aborts with SIGABRT during rocpd post-processing.

## Technical Details
`kfd_event_metadata_initialize` unconditionally registered the `rocm_kfd_event_dropped_events `PMC as a GPU-typed entry pinned to GPU 0, so with no GPU agent `get_agent_by_type_index(0, GPU)` later threw `std::out_of_range` on a worker thread and terminated the process; the placeholder is now registered only when a GPU agent exists and is pinned to a real device id. Complements #6528, which skips missing-agent records defensively during post-processing.

## JIRA ID
TBA

## Test Plan
`rocprof-sys-run` with `ROCPROFSYS_USE_ROCPD=ON` and `ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,kernel_dispatch,kfd_events` on a host where `rocminfo` enumerates only CPU agents.

## Test Result
Before: SIGABRT (exit 134), `std::out_of_range "Agent not found for type index: 0, type: GPU"`. After: clean run, both perfetto trace and rocpd database emitted. Verified in container on ROCm 7.14.0, develop at 8ec64cdb70.

## Submission Checklist
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
