### PR TITLE
rocjitsu: Use local code caves instead of global code caves

### DIFF
--- a/emulation/rocjitsu/docs/dbt-design.md
+++ b/emulation/rocjitsu/docs/dbt-design.md
@@ -48,9 +48,9 @@ The binary translator is the top-level orchestrator. It operates on binary and s
 - Load code objects via the `AmdGpuCodeObject` API
 - Decode guest instructions into basic blocks via `Decoder::create(guest_arch)`
 - Traverse each basic block and apply semantic rules first, then per-instruction encoding translation
-- Manage code caves for expanded instructions (branch stubs in .text, bodies in `.rj_translations`)
+- Relocate each kernel into a new `.text` layout with kernel-local code caves
 - Delegate descriptor ABI/resource policy to `KernelDescriptorTranslator`
-- Delegate byte-level ELF mutation and entry prologue redirects to `CodeObjectPatcher`
+- Delegate byte-level ELF mutation to `CodeObjectPatcher`
 
 ### Key design constraint
 
@@ -58,7 +58,14 @@ The binary translator's per-instruction loop is ISA-agnostic. It contains no con
 
 ### Code cave mechanism
 
-When a translated instruction sequence is larger than the source instruction, the binary translator creates a code cave: a branch stub replaces the original instruction slot, and the expanded sequence is placed in the executable `.rj_translations` section immediately after `.text`. A return branch at the end of the cave jumps back to the next instruction. The `s_branch` target is computed as `(cave_offset - (branch_pc + 4)) / 4` per the AMDGPU branch encoding, where `cave_offset` is the `.text`-relative offset into the combined `.text` + `.rj_translations` code range. The patcher may add file padding after `.rj_translations` so later `PT_LOAD` segments keep their required `p_offset`/`p_vaddr` alignment.
+When a translated instruction sequence is larger than the source instruction,
+the binary translator creates a kernel-local code cave in the rewritten `.text`:
+a branch stub replaces the relocated instruction slot, the expanded sequence is
+appended after that kernel's emitted body, and a return branch jumps back to the
+relocated fallthrough instruction. The `s_branch` target is computed as
+`(target - (branch_pc + 4)) / 4` per the AMDGPU branch encoding. Because each
+cave sits next to its kernel body, branch reach is bounded by one kernel instead
+of the entire original `.text`.
 
 ---
 
@@ -131,7 +138,7 @@ struct TranslationRule {
 
 The `try_lower_expand()` method performs binary search over the sorted rule table. For matrix instructions, the `guest_layout` and `host_layout` pointers are passed to the expansion function, which uses `compute_lane_permutation()` to derive the cross-lane shuffle rather than hardcoding it.
 
-Context-dependent descriptor ABI translations are handled by `KernelDescriptorTranslator` and handed to `CodeObjectPatcher` as prebuilt kernel-entry prologue words. The original kernel entry stays untouched; when a prologue is actually required, the kernel descriptor is redirected to a prologue cave that branches into the original entry. For CDNA-to-RDNA4 translation today, CDNA workgroup-id SGPRs are materialized from RDNA4's `TTMP9` and packed `TTMP7` launch payload.
+Context-dependent descriptor ABI translations are handled by `KernelDescriptorTranslator` and handed to `BinaryTranslator` as prebuilt kernel-entry prologue words. The original kernel entry stays untouched; when a prologue is required, the descriptor is redirected to a kernel-local `.text` cave prologue that branches into the relocated original body entry. For CDNA-to-RDNA4 translation today, CDNA workgroup-id SGPRs are materialized from RDNA4's `TTMP9` and packed `TTMP7` launch payload.
 
 ### Supporting infrastructure
 
@@ -155,11 +162,11 @@ Kernel-scoped backward liveness analysis over the CFG embedded in `BasicBlock`. 
 
 ### Code Object Patcher (`code/patch/code_object_patcher.h`)
 
-Handles ELF-level mutations: descriptor byte overwrite, entry prologue cave placement, kernel-entry descriptor redirects, ELF flag updates, `.text` overwrite, code cave storage, and load-segment alignment preservation. It does not decide descriptor translation policy.
+Handles ELF-level mutations: descriptor byte overwrite, kernel-entry descriptor redirects, ELF flag updates, `.text` replacement, and load-segment alignment preservation. It does not decide descriptor translation policy or own DBT cave layout.
 
 ### Kernel Descriptor Translator (`code/dbt/kernel_descriptor_translator.h`)
 
-Handles descriptor-level ABI and resource policy: `compute_pgm_rsrc1/2/3`, `kernel_code_properties`, AccVGPR placement metadata, and kernel-entry prologue words for descriptor ABI shuffles when the target launch state cannot preserve the guest-visible register layout directly. It produces descriptor bytes and prologue words; `CodeObjectPatcher` places those words in the ELF and redirects the descriptor entry point when needed.
+Handles descriptor-level ABI and resource policy: `compute_pgm_rsrc1/2/3`, `kernel_code_properties`, AccVGPR placement metadata, and kernel-entry prologue words for descriptor ABI shuffles when the target launch state cannot preserve the guest-visible register layout directly. It produces descriptor patches and prologue words; `BinaryTranslator` places those words in the kernel-local `.text` cave and `CodeObjectPatcher` redirects the descriptor entry to the recorded target offset.
 
 ### Instruction Builder (`code/patch/instruction_builder.h`)
 
@@ -177,12 +184,16 @@ For each code object:
 4. **Per-instruction pass:** For each instruction in each basic block:
    - Call `try_lower_expand(inst, offset, liveness)` — binary search the expand rules table by `(encoding_id, opcode)`. If a rule matches, the `ExpandFn` generates replacement instruction words using the `HazardTracker` for automatic `s_delay_alu` insertion and liveness-based register allocation for temp VGPRs/SGPRs.
    - If no expand rule matched, look up the legalization table. If Identity or Substitute, call the encoding translator. If Expand with no handler, NOP-fill and emit a warning.
-   - If the replacement is larger than the source instruction, create a code cave (branch to `.rj_translations`, return branch at end of cave).
-5. **Entry prologues:** `CodeObjectPatcher` places descriptor-provided prologue words in a cave and redirects the kernel descriptor entry point to that cave.
-6. **Patch:** Update ELF flags, write descriptor byte patches, and materialize cave body bytes in `.rj_translations`.
+   - If the replacement is larger than the source instruction, create a kernel-local code cave in `.text` with a branch stub and return branch.
+5. **Entry prologues:** `BinaryTranslator` places descriptor-provided prologue words in the kernel-local cave and records the redirected descriptor entry.
+6. **Patch:** Replace `.text`, update ELF flags, and write descriptor byte patches.
 7. **Emit:** Return the modified ELF bytes.
 
-**Code cave sizing:** The cave body is placed in `.rj_translations`, so translation no longer depends on compiler-emitted NOP padding after `s_endpgm`. Direct `s_branch` cave stubs still require the cave entry to be within the SOPP signed-16-bit branch range; trampoline islands remain future work for unusually large kernels.
+**Code cave sizing:** Cave bodies are placed in each kernel's local `.text`
+cave, so branch reach no longer depends on the size of the whole original
+`.text`. Direct `s_branch` cave stubs still require the local cave entry to be
+within the SOPP signed-16-bit branch range; trampoline islands remain future
+work for unusually large kernels.
 
 ---
 

--- a/emulation/rocjitsu/docs/dbt-design.md
+++ b/emulation/rocjitsu/docs/dbt-design.md
@@ -183,7 +183,7 @@ For each code object:
 3. **Analyze:** Build per-kernel CFG scopes from kernel descriptor entry offsets and compute `LivenessAnalysis` for each scope.
 4. **Per-instruction pass:** For each instruction in each basic block:
    - Call `try_lower_expand(inst, offset, liveness)` — binary search the expand rules table by `(encoding_id, opcode)`. If a rule matches, the `ExpandFn` generates replacement instruction words using the `HazardTracker` for automatic `s_delay_alu` insertion and liveness-based register allocation for temp VGPRs/SGPRs.
-   - If no expand rule matched, look up the legalization table. If Identity or Substitute, call the encoding translator. If Expand with no handler, NOP-fill and emit a warning.
+   - If no expand rule matched, look up the legalization table. If Identity or Substitute, call the encoding translator. If Expand with no handler, report `ExpandMissing` and leave translation unchanged.
    - If the replacement is larger than the source instruction, create a kernel-local code cave in `.text` with a branch stub and return branch.
 5. **Entry prologues:** `BinaryTranslator` places descriptor-provided prologue words in the kernel-local cave and records the redirected descriptor entry.
 6. **Patch:** Replace `.text`, update ELF flags, and write descriptor byte patches.

--- a/emulation/rocjitsu/docs/rj_dbt_translate.md
+++ b/emulation/rocjitsu/docs/rj_dbt_translate.md
@@ -62,7 +62,7 @@ report with enough context to answer the usual DBT questions:
 - Did the instruction change, lower, expand, or get copied unchanged?
 - Which source words produced the change?
 - Which target words did the translator emit?
-- Did expanded code stay in `.text`, or move into `.rj_translations`?
+- Did expanded code emit in-place, or into a kernel-local `.text` cave?
 - Did source or translated decode validation fail?
 
 Run it with:

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/CMakeLists.txt
@@ -20,6 +20,7 @@ rj_add_object_library(rocjitsu_code
     dbt/semantic_translator.cpp
     dbt/waitcnt_translator.cpp
     patch/code_object_patcher.cpp
+    patch/kernel_text_layout.cpp
     patch/instruction_builder.cpp
     patch/spill_manager.cpp
 )

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/CMakeLists.txt
@@ -20,5 +20,6 @@ rj_add_object_library(rocjitsu_code
     dbt/semantic_translator.cpp
     dbt/waitcnt_translator.cpp
     patch/code_object_patcher.cpp
+    patch/instruction_builder.cpp
     patch/spill_manager.cpp
 )

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_code_object.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_code_object.cpp
@@ -45,10 +45,6 @@ private:
 
 bool is_elf(const Elf64_Ehdr &ehdr) { return !std::memcmp(ehdr.e_ident, EI_MAGIC, EI_MAGIC_SIZE); }
 
-bool is_executable_section(const Elf64_Shdr &shdr) {
-  return shdr.sh_type == SHT_PROGBITS && (shdr.sh_flags & SHF_EXECINSTR) != 0;
-}
-
 using detail::fits_in_bounds;
 
 rj_code_target_id_t target_from_machine_flags(uint32_t flags) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_code_object.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_code_object.cpp
@@ -90,7 +90,6 @@ AmdGpuCodeObject::AmdGpuCodeObject(AmdGpuCodeObject &&other) noexcept
   header_ = std::move(other.header_);
   sections_ = std::move(other.sections_);
   text_sections_ = std::move(other.text_sections_);
-  code_sections_ = std::move(other.code_sections_);
   rodata_sections_ = std::move(other.rodata_sections_);
 }
 
@@ -224,9 +223,6 @@ void AmdGpuCodeObject::load_sections() {
       text_sections_.push_back(sections_.back().get());
     else if (sec_name == ".rodata")
       rodata_sections_.push_back(sections_.back().get());
-
-    if (is_executable_section(shdr))
-      code_sections_.push_back(sections_.back().get());
   }
 
   // Parse symbol table for kernel descriptor offsets.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_elf.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_elf.h
@@ -168,6 +168,7 @@ inline constexpr uint32_t SHT_DYNSYM = 11;
 
 inline constexpr uint8_t kElfSymbolBindGlobal = 1;
 inline constexpr uint8_t kElfSymbolTypeObject = 1;
+inline constexpr uint8_t kElfSymbolTypeFunc = 2;
 
 inline constexpr uint8_t elf_symbol_bind(uint8_t info) { return info >> 4; }
 inline constexpr uint8_t elf_symbol_type(uint8_t info) { return info & 0xf; }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/code_object.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/code_object.h
@@ -106,16 +106,6 @@ public:
   /// @returns Vector of pointers to .text sections.
   const std::vector<const Section *> &text_sections() const { return text_sections_; }
 
-  /// @brief Executable code sections in parsed section-header order.
-  ///
-  /// @details ELF does not require section headers to be sorted by load address.
-  /// For DBT-emitted objects, `.rj_translations` is inserted immediately after
-  /// `.text` in the file/image and its section header is appended after the
-  /// existing headers, so the parser observes original `.text` before the DBT
-  /// cave. Use `text_sections()` when offsets must remain relative to the
-  /// original `.text` section.
-  const std::vector<const Section *> &code_sections() const { return code_sections_; }
-
   /// @brief .rodata sections containing read-only data.
   /// @returns Vector of pointers to .rodata sections.
   const std::vector<const Section *> &rodata_sections() const { return rodata_sections_; }
@@ -199,7 +189,6 @@ protected:
   std::unique_ptr<Header> header_;
   std::vector<std::unique_ptr<Section>> sections_;
   std::vector<const Section *> text_sections_;
-  std::vector<const Section *> code_sections_;
   std::vector<const Section *> rodata_sections_;
 };
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -35,7 +35,53 @@
 
 namespace rocjitsu {
 
+/// @brief Relocated placement of one source CFG block in one emitted kernel.
+///
+/// @details A source block can be emitted more than once when multiple kernel
+/// entries reach shared code. The first relocation implementation rejects shared
+/// blocks, but this struct is still kernel-local so later duplication can reuse
+/// the same fixup model.
+struct BlockPlacement {
+  BasicBlock *block = nullptr; ///< Source CFG block.
+  uint64_t source_start = 0;   ///< Original .text-relative block start.
+  uint64_t source_end = 0;     ///< Original .text-relative block end.
+  uint64_t target_start = 0;   ///< New .text-relative block start.
+  uint64_t target_end = 0;     ///< New .text-relative block end.
+};
+
+/// @brief Pending direct PC-relative branch fixup in one relocated kernel.
+///
+/// @details Source offsets are resolved through the kernel-local placement map
+/// after all reachable blocks and local cave bytes have final target offsets.
+struct BranchFixup {
+  const Instruction *inst = nullptr; ///< Decoded source branch instruction.
+  uint64_t source_inst_offset = 0;   ///< Original .text offset of the branch.
+  uint64_t source_target_offset = 0; ///< Original .text offset of the branch target.
+  uint64_t target_inst_offset = 0;   ///< New .text offset of the branch instruction.
+};
+
+/// @brief Physical output layout for one translated kernel.
+///
+/// @details Blocks are emitted in original .text order. This is intentional: it
+/// preserves every CFG fallthrough edge as physical adjacency, so DBT only
+/// patches explicit PC-relative branch immediates. Expansion bodies are appended
+/// after the emitted body as a local cave.
+struct KernelTextLayout {
+  KdTranslation *translation = nullptr;   ///< Descriptor plan for this kernel.
+  uint64_t source_entry = 0;              ///< Original descriptor entry offset.
+  uint64_t target_entry = 0;              ///< Final descriptor entry offset.
+  uint64_t target_body_entry = 0;         ///< Relocated original entry offset.
+  uint64_t body_begin = 0;                ///< First emitted body byte.
+  uint64_t body_end = 0;                  ///< One-past-end of emitted body.
+  uint64_t cave_begin = 0;                ///< First local cave byte.
+  uint64_t cave_end = 0;                  ///< One-past-end of local cave.
+  std::vector<BlockPlacement> blocks;     ///< Kernel-local block placements.
+  std::vector<BranchFixup> branch_fixups; ///< Explicit branch patches.
+};
+
 namespace {
+
+inline constexpr uint64_t kKernargPreloadSkipBytes = 256;
 
 EncodingTranslateFn select_encoding_translator(rj_code_arch_t guest, rj_code_arch_t host) {
   if (guest == ROCJITSU_CODE_ARCH_CDNA4 && host == ROCJITSU_CODE_ARCH_RDNA4)
@@ -107,6 +153,96 @@ LegalizationLookupFn select_legalization(rj_code_arch_t guest, rj_code_arch_t ho
   if (!raw)
     return {};
   return {raw, raw + inst.size() / sizeof(uint32_t)};
+}
+
+void append_words(std::vector<uint8_t> &text, std::span<const uint32_t> words) {
+  const auto *bytes = reinterpret_cast<const uint8_t *>(words.data());
+  text.insert(text.end(), bytes, bytes + words.size() * sizeof(uint32_t));
+}
+
+void append_nop_padding(std::vector<uint8_t> &text, uint64_t byte_count, rj_code_arch_t arch) {
+  assert(byte_count % sizeof(uint32_t) == 0 && "padding must be word-aligned");
+  for (uint64_t off = 0; off < byte_count; off += sizeof(uint32_t)) {
+    const uint32_t nop = build_s_nop(0, arch);
+    append_words(text, std::span<const uint32_t>(&nop, 1));
+  }
+}
+
+[[nodiscard]] uint64_t padding_for_residue(uint64_t current_offset, uint64_t target_residue,
+                                           uint64_t alignment) {
+  const uint64_t current_residue = current_offset % alignment;
+  return (target_residue + alignment - current_residue) % alignment;
+}
+
+[[nodiscard]] uint64_t preserve_entry_skip_window_offset(const KernelTextLayout &layout,
+                                                         const BasicBlock &block, uint64_t cursor) {
+  if (block.start_offset() < layout.source_entry)
+    return cursor;
+
+  // Kernels with kernarg preloading have two valid hardware entry paths:
+  // incompatible firmware executes the descriptor entry and branches around the
+  // preload compatibility prologue, while compatible firmware adds 256 bytes to
+  // KERNEL_CODE_ENTRY_BYTE_OFFSET and starts at the real body directly. Local
+  // body compaction must therefore keep the first 256 bytes after the descriptor
+  // entry stable. Otherwise compatible firmware lands in the middle of compacted
+  // translated code with the preloaded SGPR ABI assumed but not honored.
+  const uint64_t source_delta = block.start_offset() - layout.source_entry;
+  if (source_delta > kKernargPreloadSkipBytes)
+    return cursor;
+
+  return std::max(cursor, layout.body_begin + source_delta);
+}
+
+[[nodiscard]] std::optional<uint64_t> target_for_source_offset(const KernelTextLayout &layout,
+                                                               uint64_t source_offset) {
+  for (const BlockPlacement &placement : layout.blocks) {
+    if (source_offset >= placement.source_start && source_offset < placement.source_end)
+      return placement.target_start + (source_offset - placement.source_start);
+  }
+  return std::nullopt;
+}
+
+[[nodiscard]] uint32_t text_word_at(std::span<const uint8_t> text, uint64_t offset) {
+  uint32_t word = 0;
+  if (offset + sizeof(word) <= text.size())
+    std::memcpy(&word, text.data() + offset, sizeof(word));
+  return word;
+}
+
+[[nodiscard]] bool is_nop_padding_gap(std::span<const uint8_t> text, uint64_t begin, uint64_t end,
+                                      rj_code_arch_t arch) {
+  if (begin > end || end > text.size() || (begin % sizeof(uint32_t)) != 0 ||
+      (end % sizeof(uint32_t)) != 0)
+    return false;
+
+  const uint32_t nop = build_s_nop(0, arch);
+  for (uint64_t off = begin; off < end; off += sizeof(uint32_t)) {
+    if (text_word_at(text, off) != nop)
+      return false;
+  }
+  return true;
+}
+
+[[nodiscard]] std::optional<uint64_t> target_for_source_fallthrough(const KernelTextLayout &layout,
+                                                                    std::span<const uint8_t> text,
+                                                                    uint64_t source_offset,
+                                                                    rj_code_arch_t arch) {
+  if (auto target = target_for_source_offset(layout, source_offset))
+    return target;
+
+  // Local cave expansions return to the source instruction's next PC. When the
+  // compiler placed only s_nop padding between two reachable blocks, that next
+  // PC is not present in the compact relocated body. Skipping that source-only
+  // padding here keeps the body layout compact while preserving the observable
+  // fallthrough target: executing zero or more nops reaches the next block.
+  for (const BlockPlacement &placement : layout.blocks) {
+    if (source_offset >= placement.source_start)
+      continue;
+    if (is_nop_padding_gap(text, source_offset, placement.source_start, arch))
+      return placement.target_start;
+    break;
+  }
+  return std::nullopt;
 }
 
 [[nodiscard]] bool words_changed(std::span<const uint32_t> before,
@@ -253,12 +389,25 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     return leave_unchanged();
   }
 
+  // Per-kernel text relocation strategy:
+  // 1. Decode kernel descriptors and use their entry offsets as translation roots.
+  // 2. Decode .text into basic blocks and compute the blocks reachable from each root.
+  // 3. Reject shared reachable blocks for this first implementation instead of
+  //    guessing how to preserve public kernel references.
+  // 4. Emit each kernel's reachable blocks into a compact, source-ordered body.
+  // 5. Translate instructions in that relocated body and append oversized
+  //    expansions or descriptor ABI prologues into the kernel-local cave.
+  // 6. Patch direct PC-relative branches through the kernel-local placement map.
+  // 7. Replace the ELF .text payload and redirect descriptors to their new entries.
   auto decoder = Decoder::create(guest_arch_);
   if (!decoder) {
     append_error(result.diagnostics, DiagnosticKind::UnsupportedGuestArch,
                  "unsupported guest_arch: no decoder available");
     return leave_unchanged();
   }
+
+  // Phase 1: descriptor translation gives DBT the source kernel roots and any
+  // target descriptor/prologue bytes that must be materialized with the body.
   KernelDescriptorTranslator descriptor_translator(guest_arch_, host_arch_);
   auto descriptor_translations = descriptor_translator.translate_image(
       patcher.image_bytes(), patcher.text_offset(), patcher.text_size(),
@@ -282,6 +431,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   }
 
   const auto entry_offsets = kernel_entry_offsets(descriptor_translations);
+  // Phase 2: build a CFG over .text and reduce each descriptor root to the
+  // source blocks that this kernel owns in the initial relocation strategy.
   auto blocks = BasicBlock::build(obj, *decoder, entry_offsets);
   auto scopes = kernel_translation_scopes(blocks, descriptor_translations);
 
@@ -291,12 +442,13 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     return leave_unchanged();
   }
 
-  std::vector<uint8_t> translated_text(text.begin(), text.end());
+  std::vector<uint8_t> translated_text;
   const bool continue_after_failure = options_.debug_continue_after_failure;
 
-  auto copy_original_instruction = [&](const Instruction &inst, uint64_t offset) {
+  auto copy_original_instruction = [&](const Instruction &inst, uint64_t offset,
+                                       uint64_t target_offset) {
     const uint32_t inst_size = inst.size();
-    std::memcpy(translated_text.data() + offset, text.data() + offset, inst_size);
+    std::memcpy(translated_text.data() + target_offset, text.data() + offset, inst_size);
     if (!trace_callback_)
       return;
 
@@ -311,27 +463,129 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
                      .semantic_lowering = false,
                      .changed = false,
                      .emitted_in_cave = false,
-                     .target_offset = offset,
+                     .target_offset = target_offset,
                      .target_words = source_words});
   };
 
-  auto continue_after_instruction_error = [&](const Instruction &inst, uint64_t offset) {
+  auto continue_after_instruction_error = [&](const Instruction &inst, uint64_t offset,
+                                              uint64_t target_offset) {
     if (!continue_after_failure)
       return false;
-    copy_original_instruction(inst, offset);
+    copy_original_instruction(inst, offset, target_offset);
     return true;
   };
 
-  // Code caves live in a separate executable section that is placed immediately
-  // after the original .text bytes. Treating that section as a .text-relative
-  // continuation keeps existing instruction addresses stable while avoiding any
-  // dependency on compiler-emitted NOP padding after s_endpgm.
-  patcher.set_cave_start(text.size());
-
+  // Phase 3: fail shared reachable text up front. The plan deliberately keeps
+  // duplication/removal of public references out of this first implementation.
   std::unordered_set<const BasicBlock *> translated_blocks;
   for (const KernelTranslationScope &scope : scopes) {
     if (scope.blocks.empty())
       continue;
+    for (BasicBlock *block : scope.blocks) {
+      if (block == nullptr)
+        continue;
+      if (!translated_blocks.insert(block).second) {
+        append_error(result.diagnostics, DiagnosticKind::Legalization,
+                     "basic block is reachable from multiple kernel entries; shared kernel text "
+                     "translation is not implemented");
+        return leave_unchanged();
+      }
+    }
+  }
+
+  for (const KernelTranslationScope &scope : scopes) {
+    if (scope.blocks.empty())
+      continue;
+
+    // Phase 4: assign compact target offsets for this kernel before translating
+    // instructions. Local cave writes may append bytes, so body placement must be
+    // fixed first.
+    KernelTextLayout layout;
+    layout.translation = scope.translation;
+    layout.source_entry = scope.translation->entry_text_offset;
+
+    // The entry block is not necessarily the first reachable source block. The
+    // relocated body is compact, so compute the entry delta from emitted block
+    // sizes rather than from original .text spacing. This keeps the launch
+    // address aligned without preserving unrelated padding or helper gaps.
+    uint64_t entry_delta = 0;
+    bool found_entry_delta = false;
+    for (BasicBlock *block : scope.blocks) {
+      if (layout.source_entry >= block->start_offset() &&
+          layout.source_entry < block->end_offset()) {
+        entry_delta += layout.source_entry - block->start_offset();
+        found_entry_delta = true;
+        break;
+      }
+      entry_delta += block->size();
+    }
+    if (!found_entry_delta) {
+      append_error(result.diagnostics, DiagnosticKind::KernelDescriptor,
+                   "kernel descriptor entry offset is not present in the reachable body",
+                   layout.source_entry);
+      return leave_unchanged();
+    }
+
+    const uint64_t body_padding =
+        padding_for_residue(translated_text.size() + entry_delta, layout.source_entry % 256, 256);
+    append_nop_padding(translated_text, body_padding, host_arch_);
+
+    layout.body_begin = translated_text.size();
+    uint64_t cursor = layout.body_begin;
+    layout.blocks.reserve(scope.blocks.size());
+    for (BasicBlock *block : scope.blocks) {
+      cursor = preserve_entry_skip_window_offset(layout, *block, cursor);
+      layout.blocks.push_back({.block = block,
+                               .source_start = block->start_offset(),
+                               .source_end = block->end_offset(),
+                               .target_start = cursor,
+                               .target_end = cursor + block->size()});
+      cursor += block->size();
+    }
+    layout.body_end = cursor;
+    layout.cave_begin = layout.body_end;
+    layout.cave_end = layout.body_end;
+
+    // Reserve the compact source-ordered body before instruction translation.
+    // Expansion helpers can then append local cave bytes without invalidating
+    // any precomputed body placements.
+    append_nop_padding(translated_text, layout.body_end - translated_text.size(), host_arch_);
+    auto body_entry = target_for_source_offset(layout, layout.source_entry);
+    if (!body_entry) {
+      append_error(result.diagnostics, DiagnosticKind::KernelDescriptor,
+                   "kernel descriptor entry offset is not present in the relocated body",
+                   layout.source_entry);
+      return leave_unchanged();
+    }
+    layout.target_body_entry = *body_entry;
+
+    if (!scope.translation->prologue_words.empty()) {
+      // Descriptor prologues are hardware entry points. Align the cave prologue
+      // to the original entry residue, then branch into the relocated body.
+      const uint64_t prologue_padding =
+          padding_for_residue(translated_text.size(), layout.source_entry % 256, 256);
+      append_nop_padding(translated_text, prologue_padding, host_arch_);
+      layout.target_entry = translated_text.size();
+      append_words(translated_text, scope.translation->prologue_words);
+
+      int16_t branch_dwords = 0;
+      const uint64_t branch_pc = translated_text.size();
+      if (!compute_sopp_branch_offset(branch_pc, layout.target_body_entry, branch_dwords)) {
+        append_error(result.diagnostics, DiagnosticKind::ResourceLimit,
+                     "kernel descriptor prologue branch range exceeds s_branch simm16; leaving "
+                     "code object unchanged",
+                     layout.source_entry);
+        return leave_unchanged();
+      }
+      const uint32_t branch = build_s_branch(branch_dwords, host_arch_);
+      append_words(translated_text, std::span<const uint32_t>(&branch, 1));
+      layout.cave_end = translated_text.size();
+    } else {
+      layout.target_entry = layout.target_body_entry;
+    }
+
+    scope.translation->target_entry_text_offset = layout.target_entry;
+    scope.translation->target_body_entry_text_offset = layout.target_body_entry;
 
     TranslationContext kernel_context(
         scope.translation->target_vgpr_count, scope.translation->target_agpr_count,
@@ -341,26 +595,56 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       liveness_options.min_free_vgpr = *options_.debug_min_free_vgpr;
     LivenessAnalysis liveness(KernelBlockScope(scope.blocks), liveness_options);
 
-    for (BasicBlock *block : scope.blocks) {
-      if (block == nullptr)
-        continue;
-      if (!translated_blocks.insert(block).second) {
-        append_error(result.diagnostics, DiagnosticKind::Legalization,
-                     "basic block is reachable from multiple kernel entries; shared kernel text "
-                     "translation is not implemented");
-        if (continue_after_failure)
-          continue;
-        return leave_unchanged();
-      }
-
+    // Phase 5: translate each relocated body instruction. Oversized semantic
+    // expansions branch into this kernel's private cave immediately after the body.
+    for (const BlockPlacement &placement : layout.blocks) {
+      BasicBlock *block = placement.block;
       uint64_t offset = block->start_offset();
+      uint64_t target_offset = placement.target_start;
       for (auto it = block->instructions().begin(); it != block->instructions().end(); ++it) {
         const auto &inst = *it;
         const uint32_t inst_size = inst.size();
 
+        if ((inst.flags() & (INDIRECT_BRANCH | INDIRECT_CALL)) != 0) {
+          append_error(result.diagnostics, DiagnosticKind::Legalization,
+                       "indirect branch or call target recovery is not implemented for relocated "
+                       "kernel text",
+                       offset, std::string(inst.mnemonic()));
+          if (continue_after_instruction_error(inst, offset, target_offset)) {
+            offset += inst_size;
+            target_offset += inst_size;
+            continue;
+          }
+          return leave_unchanged();
+        }
+
+        if (auto branch_delta = inst.branch_offset_bytes()) {
+          // Record direct branches while emitting the body, but patch only after
+          // every block has a final target placement. This keeps fallthrough
+          // implicit and limits fixups to explicit PC-relative edges.
+          const int64_t source_target =
+              static_cast<int64_t>(offset + inst_size) + static_cast<int64_t>(*branch_delta);
+          if (source_target < 0) {
+            append_error(result.diagnostics, DiagnosticKind::Legalization,
+                         "direct branch target is outside the source .text range", offset,
+                         std::string(inst.mnemonic()));
+            if (continue_after_instruction_error(inst, offset, target_offset)) {
+              offset += inst_size;
+              target_offset += inst_size;
+              continue;
+            }
+            return leave_unchanged();
+          }
+          layout.branch_fixups.push_back(
+              {.inst = &inst,
+               .source_inst_offset = offset,
+               .source_target_offset = static_cast<uint64_t>(source_target),
+               .target_inst_offset = target_offset});
+        }
+
         const uint32_t *raw = inst.raw_encoding();
         if (!raw) {
-          std::memcpy(translated_text.data() + offset, text.data() + offset, inst_size);
+          std::memcpy(translated_text.data() + target_offset, text.data() + offset, inst_size);
           if (trace_callback_) {
             trace_callback_({.source_offset = offset,
                              .source_size = inst_size,
@@ -370,10 +654,11 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
                              .semantic_lowering = false,
                              .changed = false,
                              .emitted_in_cave = false,
-                             .target_offset = offset,
+                             .target_offset = target_offset,
                              .target_words = {}});
           }
           offset += inst_size;
+          target_offset += inst_size;
           continue;
         }
 
@@ -396,8 +681,9 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
                              ? "semantic EXPAND rule matched, but could not safely lower"
                              : expansion.message,
                          offset, std::string(inst.mnemonic()), std::move(expansion.required_work));
-            if (continue_after_instruction_error(inst, offset)) {
+            if (continue_after_instruction_error(inst, offset, target_offset)) {
               offset += inst_size;
+              target_offset += inst_size;
               continue;
             }
             return leave_unchanged();
@@ -405,12 +691,13 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
 
           if (expansion.status == ExpandStatus::Success) {
             const bool emitted_in_cave = expansion.words.size() * sizeof(uint32_t) > inst_size;
-            const uint64_t target_offset =
-                emitted_in_cave ? patcher.cave_start() + patcher.cave_body_size() : offset;
-            SemanticReplacement repl{offset, offset + inst_size, std::move(expansion.words)};
-            if (!apply_semantic(repl, translated_text, patcher)) {
-              if (continue_after_instruction_error(inst, offset)) {
+            const uint64_t event_target_offset = emitted_in_cave ? layout.cave_end : target_offset;
+            SemanticReplacement repl{target_offset, target_offset + inst_size,
+                                     std::move(expansion.words)};
+            if (!apply_semantic(repl, translated_text, layout, text, offset + inst_size)) {
+              if (continue_after_instruction_error(inst, offset, target_offset)) {
                 offset += inst_size;
+                target_offset += inst_size;
                 continue;
               }
               return leave_unchanged();
@@ -425,10 +712,11 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
                                .semantic_lowering = true,
                                .changed = true,
                                .emitted_in_cave = emitted_in_cave,
-                               .target_offset = target_offset,
+                               .target_offset = event_target_offset,
                                .target_words = repl.target_words});
             }
             offset += inst_size;
+            target_offset += inst_size;
             continue;
           }
         }
@@ -438,26 +726,60 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
                        "legalization requires EXPAND, but no expansion rule is implemented", offset,
                        std::string(inst.mnemonic()),
                        {"Add a semantic expansion rule for this mnemonic."});
-          if (continue_after_instruction_error(inst, offset)) {
+          if (continue_after_instruction_error(inst, offset, target_offset)) {
             offset += inst_size;
+            target_offset += inst_size;
             continue;
           }
           return leave_unchanged();
         }
 
-        if (!handle_encoding(inst, offset, translated_text, dst_opcode, patcher, text, leg)) {
-          if (continue_after_instruction_error(inst, offset)) {
+        if (!handle_encoding(inst, offset, target_offset, translated_text, dst_opcode, layout, text,
+                             leg)) {
+          if (continue_after_instruction_error(inst, offset, target_offset)) {
             offset += inst_size;
+            target_offset += inst_size;
             continue;
           }
           return leave_unchanged();
         }
         offset += inst_size;
+        target_offset += inst_size;
       }
     }
 
     if (continue_after_failure && has_error_diagnostic(result.diagnostics))
       continue;
+
+    // Phase 6: now that the local body and cave have final offsets, rewrite only
+    // the direct branch immediate bits using the kernel-local source placement.
+    for (const BranchFixup &fixup : layout.branch_fixups) {
+      auto target_target = target_for_source_offset(layout, fixup.source_target_offset);
+      if (!target_target) {
+        append_error(result.diagnostics, DiagnosticKind::Legalization,
+                     "direct branch target is not present in the kernel-local relocated body",
+                     fixup.source_inst_offset,
+                     fixup.inst ? std::string(fixup.inst->mnemonic()) : std::string{});
+        return leave_unchanged();
+      }
+
+      // The source decoder reports branch deltas from the source instruction's
+      // next PC. Recompute that same next-PC-relative delta in relocated .text
+      // coordinates and patch only the immediate bits of the translated branch.
+      const int64_t new_delta = static_cast<int64_t>(*target_target) -
+                                static_cast<int64_t>(fixup.target_inst_offset + fixup.inst->size());
+      std::vector<uint32_t> words(fixup.inst->size() / sizeof(uint32_t));
+      std::memcpy(words.data(), translated_text.data() + fixup.target_inst_offset,
+                  fixup.inst->size());
+      if (!patch_pcrel_branch_offset(*fixup.inst, words, new_delta, host_arch_)) {
+        append_error(result.diagnostics, DiagnosticKind::ResourceLimit,
+                     "direct branch relocation exceeds encoded branch range",
+                     fixup.source_inst_offset, std::string(fixup.inst->mnemonic()));
+        return leave_unchanged();
+      }
+      std::memcpy(translated_text.data() + fixup.target_inst_offset, words.data(),
+                  fixup.inst->size());
+    }
 
     if (kernel_context.required_vgpr_count > kernel_context.num_vgprs)
       scope.translation->target_vgpr_count = kernel_context.required_vgpr_count;
@@ -500,6 +822,15 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
           return leave_unchanged();
         }
 
+        if (updated->prologue_words != translation.prologue_words) {
+          append_error(result.diagnostics, DiagnosticKind::KernelDescriptor,
+                       "kernel descriptor prologue changed after relocated text was emitted; "
+                       "leaving code object unchanged");
+          return leave_unchanged();
+        }
+
+        updated->target_entry_text_offset = layout.target_entry;
+        updated->target_body_entry_text_offset = layout.target_body_entry;
         translation = std::move(*updated);
         recomputed_descriptor = true;
       }
@@ -511,10 +842,26 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
         return leave_unchanged();
       }
     }
+
+    for (KdTranslation &translation : descriptor_translations) {
+      if (translation.entry_text_offset != layout.source_entry)
+        continue;
+      translation.target_entry_text_offset = layout.target_entry;
+      translation.target_body_entry_text_offset = layout.target_body_entry;
+    }
   }
 
   if (continue_after_failure && has_error_diagnostic(result.diagnostics))
     return leave_unchanged();
+
+  // Phase 7: write the relocated .text and descriptor entry offsets into the ELF.
+  // Reachability-driven emission intentionally drops source padding and other
+  // unreachable bytes. Keep the first implementation's ELF mutation one-sided
+  // by padding the relocated .text back to at least the original size; local
+  // caves have already been placed next to their kernels, so this tail padding
+  // does not reintroduce the old global-cave branch-distance problem.
+  if (translated_text.size() < text.size())
+    append_nop_padding(translated_text, text.size() - translated_text.size(), host_arch_);
 
   std::unordered_set<uint64_t> applied_descriptors;
   for (const KdTranslation &translation : descriptor_translations) {
@@ -528,11 +875,9 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     }
   }
 
-  patcher.overwrite_text(translated_text);
-  if (!patcher.append_cave_section()) {
+  if (!patcher.replace_text(translated_text)) {
     append_error(result.diagnostics, DiagnosticKind::ResourceLimit,
-                 "code cave section could not be materialized safely; leaving code object "
-                 "unchanged");
+                 "relocated .text could not be materialized safely; leaving code object unchanged");
     return leave_unchanged();
   }
 
@@ -545,7 +890,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
 }
 
 bool BinaryTranslator::apply_semantic(const SemanticReplacement &repl, std::vector<uint8_t> &text,
-                                      CodeObjectPatcher &patcher) {
+                                      KernelTextLayout &layout, std::span<const uint8_t> orig_text,
+                                      uint64_t source_return_offset) {
   assert(repl.matched() && "apply_semantic called with unmatched replacement");
   assert(repl.start_offset < repl.end_offset && "invalid replacement range");
   assert(repl.end_offset <= text.size() && "replacement exceeds text bounds");
@@ -560,8 +906,10 @@ bool BinaryTranslator::apply_semantic(const SemanticReplacement &repl, std::vect
     return true;
   }
 
-  const uint64_t cave_byte_offset = patcher.cave_start() + patcher.cave_body_size();
-  const uint64_t stub_next = repl.start_offset + source_size;
+  const uint64_t cave_byte_offset = layout.cave_end;
+  const uint64_t stub_next =
+      target_for_source_fallthrough(layout, orig_text, source_return_offset, guest_arch_)
+          .value_or(repl.start_offset + source_size);
   const uint64_t branch_pc = repl.start_offset;
 
   // s_branch simm16 targets (PC + 4 + simm16*4).
@@ -594,13 +942,14 @@ bool BinaryTranslator::apply_semantic(const SemanticReplacement &repl, std::vect
   }
   cave_words.push_back(build_s_branch(ret_dwords, host_arch_));
 
-  patcher.append_cave_body(cave_words);
+  append_words(text, cave_words);
+  layout.cave_end = text.size();
   return true;
 }
 
 bool BinaryTranslator::handle_encoding(const Instruction &inst, uint64_t offset,
-                                       std::vector<uint8_t> &text, uint16_t dst_opcode,
-                                       CodeObjectPatcher &patcher,
+                                       uint64_t target_offset, std::vector<uint8_t> &text,
+                                       uint16_t dst_opcode, KernelTextLayout &layout,
                                        std::span<const uint8_t> orig_text,
                                        const InstructionLegalization *leg) {
   const uint32_t *raw = inst.raw_encoding();
@@ -625,8 +974,8 @@ bool BinaryTranslator::handle_encoding(const Instruction &inst, uint64_t offset,
   };
 
   if (!encoding_translate_) {
-    std::memcpy(text.data() + offset, raw, inst.size());
-    emit_trace(true, false, false, offset, source_words);
+    std::memcpy(text.data() + target_offset, raw, inst.size());
+    emit_trace(true, false, false, target_offset, source_words);
     return true;
   }
 
@@ -637,8 +986,8 @@ bool BinaryTranslator::handle_encoding(const Instruction &inst, uint64_t offset,
   auto tr = encoding_translate_(inst.encoding_id(), w0, w1, w2, dst_opcode);
 
   if (tr.word_count == 0) {
-    std::memcpy(text.data() + offset, raw, inst.size());
-    emit_trace(true, false, false, offset, source_words);
+    std::memcpy(text.data() + target_offset, raw, inst.size());
+    emit_trace(true, false, false, target_offset, source_words);
     return true;
   }
 
@@ -660,18 +1009,18 @@ bool BinaryTranslator::handle_encoding(const Instruction &inst, uint64_t offset,
   const uint32_t target_size = tr.word_count * 4u;
   const auto target_words = std::span<const uint32_t>(tr.words, tr.word_count);
   const bool emitted_in_cave = target_size > orig_bytes;
-  const uint64_t target_offset =
-      emitted_in_cave ? patcher.cave_start() + patcher.cave_body_size() : offset;
+  const uint64_t event_target_offset = emitted_in_cave ? layout.cave_end : target_offset;
   const bool changed = tracing && words_changed(source_words, target_words);
 
   if (target_size <= orig_bytes) {
-    std::memcpy(text.data() + offset, tr.words, target_size);
+    std::memcpy(text.data() + target_offset, tr.words, target_size);
   } else {
-    SemanticReplacement repl{offset, offset + inst.size(), {tr.words, tr.words + tr.word_count}};
-    if (!apply_semantic(repl, text, patcher))
+    SemanticReplacement repl{
+        target_offset, target_offset + inst.size(), {tr.words, tr.words + tr.word_count}};
+    if (!apply_semantic(repl, text, layout, orig_text, offset + orig_bytes))
       return false;
   }
-  emit_trace(false, changed, emitted_in_cave, target_offset, target_words);
+  emit_trace(false, changed, emitted_in_cave, event_target_offset, target_words);
   return true;
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -18,6 +18,7 @@
 #include "rocjitsu/code/dbt/semantic_translator.h"
 #include "rocjitsu/code/patch/code_object_patcher.h"
 #include "rocjitsu/code/patch/instruction_builder.h"
+#include "rocjitsu/code/patch/kernel_text_layout.h"
 #include "rocjitsu/isa/decoder.h"
 #include "rocjitsu/isa/instruction.h"
 
@@ -35,53 +36,7 @@
 
 namespace rocjitsu {
 
-/// @brief Relocated placement of one source CFG block in one emitted kernel.
-///
-/// @details A source block can be emitted more than once when multiple kernel
-/// entries reach shared code. The first relocation implementation rejects shared
-/// blocks, but this struct is still kernel-local so later duplication can reuse
-/// the same fixup model.
-struct BlockPlacement {
-  BasicBlock *block = nullptr; ///< Source CFG block.
-  uint64_t source_start = 0;   ///< Original .text-relative block start.
-  uint64_t source_end = 0;     ///< Original .text-relative block end.
-  uint64_t target_start = 0;   ///< New .text-relative block start.
-  uint64_t target_end = 0;     ///< New .text-relative block end.
-};
-
-/// @brief Pending direct PC-relative branch fixup in one relocated kernel.
-///
-/// @details Source offsets are resolved through the kernel-local placement map
-/// after all reachable blocks and local cave bytes have final target offsets.
-struct BranchFixup {
-  const Instruction *inst = nullptr; ///< Decoded source branch instruction.
-  uint64_t source_inst_offset = 0;   ///< Original .text offset of the branch.
-  uint64_t source_target_offset = 0; ///< Original .text offset of the branch target.
-  uint64_t target_inst_offset = 0;   ///< New .text offset of the branch instruction.
-};
-
-/// @brief Physical output layout for one translated kernel.
-///
-/// @details Blocks are emitted in original .text order. This is intentional: it
-/// preserves every CFG fallthrough edge as physical adjacency, so DBT only
-/// patches explicit PC-relative branch immediates. Expansion bodies are appended
-/// after the emitted body as a local cave.
-struct KernelTextLayout {
-  KdTranslation *translation = nullptr;   ///< Descriptor plan for this kernel.
-  uint64_t source_entry = 0;              ///< Original descriptor entry offset.
-  uint64_t target_entry = 0;              ///< Final descriptor entry offset.
-  uint64_t target_body_entry = 0;         ///< Relocated original entry offset.
-  uint64_t body_begin = 0;                ///< First emitted body byte.
-  uint64_t body_end = 0;                  ///< One-past-end of emitted body.
-  uint64_t cave_begin = 0;                ///< First local cave byte.
-  uint64_t cave_end = 0;                  ///< One-past-end of local cave.
-  std::vector<BlockPlacement> blocks;     ///< Kernel-local block placements.
-  std::vector<BranchFixup> branch_fixups; ///< Explicit branch patches.
-};
-
 namespace {
-
-inline constexpr uint64_t kKernargPreloadSkipBytes = 256;
 
 EncodingTranslateFn select_encoding_translator(rj_code_arch_t guest, rj_code_arch_t host) {
   if (guest == ROCJITSU_CODE_ARCH_CDNA4 && host == ROCJITSU_CODE_ARCH_RDNA4)
@@ -153,96 +108,6 @@ LegalizationLookupFn select_legalization(rj_code_arch_t guest, rj_code_arch_t ho
   if (!raw)
     return {};
   return {raw, raw + inst.size() / sizeof(uint32_t)};
-}
-
-void append_words(std::vector<uint8_t> &text, std::span<const uint32_t> words) {
-  const auto *bytes = reinterpret_cast<const uint8_t *>(words.data());
-  text.insert(text.end(), bytes, bytes + words.size() * sizeof(uint32_t));
-}
-
-void append_nop_padding(std::vector<uint8_t> &text, uint64_t byte_count, rj_code_arch_t arch) {
-  assert(byte_count % sizeof(uint32_t) == 0 && "padding must be word-aligned");
-  for (uint64_t off = 0; off < byte_count; off += sizeof(uint32_t)) {
-    const uint32_t nop = build_s_nop(0, arch);
-    append_words(text, std::span<const uint32_t>(&nop, 1));
-  }
-}
-
-[[nodiscard]] uint64_t padding_for_residue(uint64_t current_offset, uint64_t target_residue,
-                                           uint64_t alignment) {
-  const uint64_t current_residue = current_offset % alignment;
-  return (target_residue + alignment - current_residue) % alignment;
-}
-
-[[nodiscard]] uint64_t preserve_entry_skip_window_offset(const KernelTextLayout &layout,
-                                                         const BasicBlock &block, uint64_t cursor) {
-  if (block.start_offset() < layout.source_entry)
-    return cursor;
-
-  // Kernels with kernarg preloading have two valid hardware entry paths:
-  // incompatible firmware executes the descriptor entry and branches around the
-  // preload compatibility prologue, while compatible firmware adds 256 bytes to
-  // KERNEL_CODE_ENTRY_BYTE_OFFSET and starts at the real body directly. Local
-  // body compaction must therefore keep the first 256 bytes after the descriptor
-  // entry stable. Otherwise compatible firmware lands in the middle of compacted
-  // translated code with the preloaded SGPR ABI assumed but not honored.
-  const uint64_t source_delta = block.start_offset() - layout.source_entry;
-  if (source_delta > kKernargPreloadSkipBytes)
-    return cursor;
-
-  return std::max(cursor, layout.body_begin + source_delta);
-}
-
-[[nodiscard]] std::optional<uint64_t> target_for_source_offset(const KernelTextLayout &layout,
-                                                               uint64_t source_offset) {
-  for (const BlockPlacement &placement : layout.blocks) {
-    if (source_offset >= placement.source_start && source_offset < placement.source_end)
-      return placement.target_start + (source_offset - placement.source_start);
-  }
-  return std::nullopt;
-}
-
-[[nodiscard]] uint32_t text_word_at(std::span<const uint8_t> text, uint64_t offset) {
-  uint32_t word = 0;
-  if (offset + sizeof(word) <= text.size())
-    std::memcpy(&word, text.data() + offset, sizeof(word));
-  return word;
-}
-
-[[nodiscard]] bool is_nop_padding_gap(std::span<const uint8_t> text, uint64_t begin, uint64_t end,
-                                      rj_code_arch_t arch) {
-  if (begin > end || end > text.size() || (begin % sizeof(uint32_t)) != 0 ||
-      (end % sizeof(uint32_t)) != 0)
-    return false;
-
-  const uint32_t nop = build_s_nop(0, arch);
-  for (uint64_t off = begin; off < end; off += sizeof(uint32_t)) {
-    if (text_word_at(text, off) != nop)
-      return false;
-  }
-  return true;
-}
-
-[[nodiscard]] std::optional<uint64_t> target_for_source_fallthrough(const KernelTextLayout &layout,
-                                                                    std::span<const uint8_t> text,
-                                                                    uint64_t source_offset,
-                                                                    rj_code_arch_t arch) {
-  if (auto target = target_for_source_offset(layout, source_offset))
-    return target;
-
-  // Local cave expansions return to the source instruction's next PC. When the
-  // compiler placed only s_nop padding between two reachable blocks, that next
-  // PC is not present in the compact relocated body. Skipping that source-only
-  // padding here keeps the body layout compact while preserving the observable
-  // fallthrough target: executing zero or more nops reaches the next block.
-  for (const BlockPlacement &placement : layout.blocks) {
-    if (source_offset >= placement.source_start)
-      continue;
-    if (is_nop_padding_gap(text, source_offset, placement.source_start, arch))
-      return placement.target_start;
-    break;
-  }
-  return std::nullopt;
 }
 
 [[nodiscard]] bool words_changed(std::span<const uint32_t> before,
@@ -485,6 +350,8 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       if (block == nullptr)
         continue;
       if (!translated_blocks.insert(block).second) {
+        // Reject shared source blocks to avoid generating an invalid layout when
+        // one block is used by multiple kernel entry points.
         append_error(result.diagnostics, DiagnosticKind::Legalization,
                      "basic block is reachable from multiple kernel entries; shared kernel text "
                      "translation is not implemented");

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.h
@@ -37,10 +37,10 @@
 namespace rocjitsu {
 
 class AmdGpuCodeObject;
-class CodeObjectPatcher;
 class SemanticTranslator;
 class Instruction;
 struct InstructionLegalization;
+struct KernelTextLayout;
 
 /// @brief Encoding translation function type.
 ///
@@ -72,12 +72,11 @@ using LegalizationLookupFn = const InstructionLegalization *(*)(uint16_t encodin
 
 /// @brief One source instruction trace event emitted by BinaryTranslator.
 ///
-/// @details Offsets are .text-relative. When emitted_in_cave is true,
-/// target_offset points into the logical .text continuation that later becomes
-/// `.rj_translations`; subtracting the original .text size gives the offset in
-/// that cave section. source_words and target_words are only valid for the
-/// duration of the callback; callers that need to retain them must copy the
-/// spans.
+/// @details Offsets are .text-relative in the relocated output. When
+/// emitted_in_cave is true, target_offset points into the current kernel's
+/// private local cave inside the rewritten .text. source_words and target_words
+/// are only valid for the duration of the callback; callers that need to retain
+/// them must copy the spans.
 struct TranslationTraceEvent {
   uint64_t source_offset = 0;
   uint32_t source_size = 0;
@@ -130,10 +129,13 @@ struct TranslatedCodeObject {
 ///   3. Translating remaining instructions via legalization + encoding translate.
 ///   4. Re-emitting a valid ELF for host_arch via CodeObjectPatcher.
 ///
-/// Because every in-place replacement preserves the original instruction's size
-/// (same-size for Identity/Substitute/Lower; branch stub for code caves),
-/// no instruction in .text ever shifts. Branch offsets remain valid — no global
-/// branch fixup pass is required.
+/// DBT relocates each kernel into a fresh .text layout instead of appending a
+/// global `.rj_translations` cave. Each descriptor entry gets a private emitted
+/// body plus a local cave immediately after that body. Since explicit branches
+/// may move by a different delta than their targets, direct PC-relative branch
+/// immediates are patched through the kernel-local source-to-target block
+/// placement map. Fallthrough is preserved by emitting reachable blocks in
+/// original .text order.
 class BinaryTranslator {
 public:
   /// @brief Construct a translator for the given (guest, host) ISA pair.
@@ -159,15 +161,19 @@ private:
   /// @details If the replacement fits within the source byte range, writes
   /// in-place and pads any leftover source words. If it expands, writes a
   /// branch stub in-place and appends the replacement body + return branch to
-  /// the .rj_translations code cave via the patcher.
+  /// the current kernel's local cave.
   ///
-  /// @param repl    The semantic replacement to apply.
-  /// @param text    The translated text buffer (same size as original .text).
-  /// @param patcher The code object patcher for cave body accumulation.
+  /// @param repl                 The semantic replacement to apply.
+  /// @param text                 The relocated .text buffer under construction.
+  /// @param layout               Current kernel layout for local cave accounting.
+  /// @param orig_text            Original guest .text used to classify fallthrough padding.
+  /// @param source_return_offset Original .text offset reached after the replaced instruction.
   /// @returns true if the replacement was applied safely; false if an expanding
   ///          replacement could not be branched to/from the code cave.
   [[nodiscard]] bool apply_semantic(const struct SemanticReplacement &repl,
-                                    std::vector<uint8_t> &text, CodeObjectPatcher &patcher);
+                                    std::vector<uint8_t> &text, KernelTextLayout &layout,
+                                    std::span<const uint8_t> orig_text,
+                                    uint64_t source_return_offset);
 
   /// @brief Translate a single instruction via the encoding translation pipeline.
   ///
@@ -176,17 +182,19 @@ private:
   /// Falls back to copying the original encoding if translation produces no output.
   ///
   /// @param inst       The decoded guest instruction.
-  /// @param offset     Byte offset of the instruction within .text.
+  /// @param offset     Source byte offset of the instruction within original .text.
+  /// @param target_offset Relocated byte offset of the instruction in output .text.
   /// @param text       The translated text buffer.
   /// @param dst_opcode Target opcode from the legalization table.
-  /// @param patcher    The code object patcher for expanded instruction bodies.
+  /// @param layout     Current kernel layout for local cave accounting.
   /// @param orig_text   The original .text bytes used to preserve trailing literals.
   /// @returns true if the instruction was translated or copied safely; false if
   ///          the translated encoding expanded and could not be branched through
   ///          the code cave.
   [[nodiscard]] bool handle_encoding(const Instruction &inst, uint64_t offset,
-                                     std::vector<uint8_t> &text, uint16_t dst_opcode,
-                                     CodeObjectPatcher &patcher, std::span<const uint8_t> orig_text,
+                                     uint64_t target_offset, std::vector<uint8_t> &text,
+                                     uint16_t dst_opcode, KernelTextLayout &layout,
+                                     std::span<const uint8_t> orig_text,
                                      const InstructionLegalization *leg);
 
   rj_code_arch_t guest_arch_;                               ///< Source ISA.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.cpp
@@ -237,31 +237,6 @@ constexpr uint16_t kTtmpRdna4GridX = 9;
   return std::nullopt;
 }
 
-[[nodiscard]] uint64_t executable_code_range_size(uint64_t text_vaddr, uint64_t text_size,
-                                                  const Elf64_Ehdr &ehdr, const Elf64_Shdr *shdr) {
-  constexpr uint64_t max_u64 = std::numeric_limits<uint64_t>::max();
-  if (text_vaddr > max_u64 - text_size)
-    return 0;
-
-  uint64_t code_end = text_vaddr + text_size;
-
-  // DBT places expansion bodies in .rj_translations and addresses them as a
-  // .text-relative continuation. Include executable sections at or after .text
-  // so a redirected kernel descriptor entry can still be parsed.
-  for (int i = 0; i < ehdr.e_shnum; ++i) {
-    constexpr uint64_t executable_load_flags = SHF_ALLOC | SHF_EXECINSTR;
-    if ((shdr[i].sh_flags & executable_load_flags) != executable_load_flags)
-      continue;
-    if (shdr[i].sh_addr < text_vaddr)
-      continue;
-    if (shdr[i].sh_addr > max_u64 - shdr[i].sh_size)
-      continue;
-    code_end = std::max(code_end, shdr[i].sh_addr + shdr[i].sh_size);
-  }
-
-  return code_end - text_vaddr;
-}
-
 using KernelDescriptorVisitor = std::function<void(uint64_t descriptor_file_offset,
                                                    uint64_t entry_text_offset, const KD &desc)>;
 
@@ -278,7 +253,10 @@ void visit_kernel_descriptors(std::span<const uint8_t> image, uint64_t text_offs
   auto text_vaddr = text_vaddr_for_section(text_offset, text_size, *ehdr, shdr);
   if (!text_vaddr)
     return;
-  const uint64_t code_range_size = executable_code_range_size(*text_vaddr, text_size, *ehdr, shdr);
+  constexpr uint64_t max_u64 = std::numeric_limits<uint64_t>::max();
+  if (*text_vaddr > max_u64 - text_size)
+    return;
+  const uint64_t text_end = *text_vaddr + text_size;
 
   // .symtab and .dynsym may both describe the same descriptor. Translation is
   // keyed by descriptor bytes, so visit each file offset once.
@@ -324,7 +302,7 @@ void visit_kernel_descriptors(std::span<const uint8_t> image, uint64_t text_offs
       if (entry_vaddr_signed < 0)
         continue;
       const uint64_t entry_vaddr = static_cast<uint64_t>(entry_vaddr_signed);
-      if (entry_vaddr < *text_vaddr || entry_vaddr >= *text_vaddr + code_range_size)
+      if (entry_vaddr < *text_vaddr || entry_vaddr >= text_end)
         continue;
 
       const uint64_t entry_text_offset = entry_vaddr - *text_vaddr;
@@ -540,6 +518,8 @@ translate_one_descriptor(rj_code_arch_t guest_arch, rj_code_arch_t host_arch,
   KdTranslation result;
   result.descriptor_file_offset = descriptor_file_offset;
   result.entry_text_offset = entry_text_offset;
+  result.target_entry_text_offset = entry_text_offset;
+  result.target_body_entry_text_offset = entry_text_offset;
 
   // The source descriptor encodes the guest launch wave size. The target
   // descriptor must request a wave size the host can actually launch. We do not
@@ -565,8 +545,8 @@ translate_one_descriptor(rj_code_arch_t guest_arch, rj_code_arch_t host_arch,
   result.target_accvgpr_base = result.accvgpr_base;
 
   // Descriptor ABI fixes that require instructions, not bitfield changes, are
-  // emitted as prologue words. CodeObjectPatcher decides where to place them and
-  // redirects the kernel descriptor entry point if this vector is non-empty.
+  // emitted as prologue words. BinaryTranslator places those words in the
+  // kernel-local .text cave and records the final redirected entry offset.
   result.prologue_words = build_kernel_entry_prologue(src, guest_arch, host_arch);
 
   // VGPR descriptor fields do not store raw register counts. They store
@@ -585,14 +565,22 @@ translate_one_descriptor(rj_code_arch_t guest_arch, rj_code_arch_t host_arch,
       granulated_count_to_registers(guest_vgpr_granulated, guest_vgpr_granularity);
   if (arch_has_accvgpr(guest_arch) && result.accvgpr_base != 0 &&
       result.guest_vgpr_allocation_count > result.accvgpr_base) {
+    // CDNA encodes a unified VGPR allocation endpoint while ACCUM_OFFSET
+    // carves the trailing AccVGPR window out of that allocation. Liveness and
+    // semantic scratch allocation need the ordinary VGPR floor, not the unified
+    // endpoint, or they will unnecessarily force new scratch above the
+    // accumulator window and move ACCUM_OFFSET. That descriptor growth changed
+    // dynamic Triton matmul results on gfx942 because the translated MFMA/DS
+    // transpose sequence depends on the original ordinary/accumulator split.
     result.guest_agpr_count = result.guest_vgpr_allocation_count - result.accvgpr_base;
   }
   result.guest_vgpr_count = result.guest_vgpr_allocation_count - result.guest_agpr_count;
 
   // Start from the guest's ordinary VGPR count. Keep the descriptor allocation
-  // count separate: CDNA kernels with AccVGPRs encode a unified allocation end
-  // in COMPUTE_PGM_RSRC1, but liveness and scratch allocation need the ordinary
-  // VGPR count only.
+  // count separate for target reporting and descriptor encoding. CDNA
+  // descriptors encode the ordinary VGPRs and AccVGPRs as one allocation range,
+  // but scratch allocation must reason about only the ordinary part so it can
+  // reuse registers that are dead at a given expansion site.
   //
   // - CDNA-to-RDNA unifies AccVGPRs into the ordinary VGPR namespace, so the
   //   target needs enough VGPRs to cover the remapped accumulator window.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.h
@@ -32,7 +32,22 @@ struct KernelDescriptorTranslationOptions {
 /// ELF/kernel descriptor bytes.
 struct KdTranslation {
   uint64_t descriptor_file_offset = 0;
+  /// @brief Original .text-relative kernel entry decoded from the source descriptor.
   uint64_t entry_text_offset = 0;
+
+  /// @brief New .text-relative kernel entry after DBT rewrites .text.
+  ///
+  /// @details This is the final launch address written into
+  /// KERNEL_CODE_ENTRY_BYTE_OFFSET. It may point at descriptor ABI prologue code
+  /// emitted before the relocated original kernel body.
+  uint64_t target_entry_text_offset = 0;
+
+  /// @brief New .text-relative offset of the original kernel entry block.
+  ///
+  /// @details Descriptor ABI prologues may make @c target_entry_text_offset
+  /// point before this address. Branches and diagnostics that refer to the
+  /// relocated original guest entry should use this field.
+  uint64_t target_body_entry_text_offset = 0;
 
   /// @brief Ordinary architectural VGPRs required by translated code.
   ///
@@ -90,27 +105,30 @@ struct KdTranslation {
   std::vector<uint32_t> user_sgpr_shuffle;
 
   /// All kernel-entry instructions required by descriptor ABI translation.
-  /// CodeObjectPatcher places these words in a cave and redirects the KD entry.
+  /// BinaryTranslator places these words in the kernel-local .text cave and
+  /// records the final descriptor entry offset.
   std::vector<uint32_t> prologue_words;
 
   uint8_t guest_wavefront_size = 64;
   uint8_t host_wavefront_size = 64;
 
-  /// @brief Ordinary guest VGPR count decoded from the source descriptor.
+  /// @brief Ordinary guest VGPR floor decoded from the source descriptor.
   ///
-  /// @details This excludes any source AccVGPR window. It is the right source
-  /// floor for ordinary VGPR liveness and scratch reasoning.
+  /// @details On CDNA, COMPUTE_PGM_RSRC1 describes the unified VGPR allocation
+  /// endpoint and ACCUM_OFFSET carves the trailing AccVGPR window out of that
+  /// allocation. Liveness and semantic scratch allocation need only the
+  /// ordinary portion so they can reuse registers that are dead at a lowering
+  /// site without forcing unnecessary descriptor growth.
   uint32_t guest_vgpr_count = 0;
 
-  /// @brief Source descriptor's unified VGPR allocation count.
+  /// @brief Source descriptor unified VGPR allocation after rounding.
   ///
   /// @details This is decoded from COMPUTE_PGM_RSRC1 and may include the
-  /// AccVGPR window on CDNA descriptors. Use it when preserving or re-encoding
-  /// descriptor allocation size, not when asking how many ordinary VGPRs the
-  /// guest program used.
+  /// AccVGPR window on CDNA. Use it for descriptor encoding/reporting; use
+  /// @c guest_vgpr_count when asking how many ordinary VGPRs the guest used.
   uint32_t guest_vgpr_allocation_count = 0;
 
-  /// @brief Source AccVGPR count derived from allocation count and ACCUM_OFFSET.
+  /// @brief Conservative source AccVGPR window size derived from rounded count and ACCUM_OFFSET.
   uint32_t guest_agpr_count = 0;
 
   /// @brief Ordinary host VGPR count after translation requirements are applied.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
@@ -462,6 +462,12 @@ std::span<const uint8_t> CodeObjectPatcher::text_bytes() const {
 }
 
 bool CodeObjectPatcher::replace_text(std::span<const uint8_t> new_text) {
+  // Keep fail-closed behavior for callers that assume word-aligned executable
+  // sections; accepting a non-word-aligned replacement can break downstream
+  // PC-relative patching and branch-distance checks.
+  if ((new_text.size() % sizeof(uint32_t)) != 0)
+    return false;
+
   if (text_size_ == 0)
     return false;
   if (new_text.size() < text_size_)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
@@ -6,7 +6,6 @@
 #include "rocjitsu/code/amdgpu_code_object.h"
 #include "rocjitsu/code/amdgpu_elf.h"
 #include "rocjitsu/code/dbt/kernel_descriptor_translator.h"
-#include "rocjitsu/code/patch/instruction_builder.h"
 
 #include "rocjitsu/base/rj_compiler.h"
 RJ_DIAGNOSTIC_PUSH
@@ -15,7 +14,6 @@ RJ_DIAGNOSTIC_IGNORE_PEDANTIC
 RJ_DIAGNOSTIC_POP
 
 #include <algorithm>
-#include <array>
 #include <cassert>
 #include <cstddef>
 #include <cstring>
@@ -24,7 +22,6 @@ RJ_DIAGNOSTIC_POP
 #include <optional>
 // Standard library
 #include <span>
-#include <string_view>
 #include <unordered_set>
 #include <vector>
 
@@ -152,25 +149,6 @@ void insert_file_bytes(std::vector<uint8_t> &image, Elf64_Ehdr &ehdr,
   return alignment;
 }
 
-[[nodiscard]] uint32_t append_section_name(std::vector<uint8_t> &image, Elf64_Ehdr &ehdr,
-                                           std::vector<Elf64_Shdr> &shdrs,
-                                           std::vector<Elf64_Phdr> &phdrs,
-                                           std::string_view section_name) {
-  assert(ehdr.e_shstrndx < shdrs.size() && "invalid section-name string table index");
-
-  auto &shstrtab = shdrs[ehdr.e_shstrndx];
-  // sh_name values are offsets into .shstrtab before appending the new bytes.
-  const uint32_t name_offset = static_cast<uint32_t>(shstrtab.sh_size);
-
-  std::vector<uint8_t> name_bytes(section_name.begin(), section_name.end());
-  name_bytes.push_back('\0');
-
-  insert_file_bytes(image, ehdr, shdrs, phdrs, shstrtab.sh_offset + shstrtab.sh_size, name_bytes,
-                    static_cast<size_t>(ehdr.e_shstrndx), false);
-  shstrtab.sh_size += name_bytes.size();
-  return name_offset;
-}
-
 [[nodiscard]] std::optional<size_t> find_text_section(std::span<const Elf64_Shdr> shdrs,
                                                       uint64_t text_offset, uint64_t text_size) {
   for (size_t i = 0; i < shdrs.size(); ++i) {
@@ -245,6 +223,61 @@ void shift_symbols_in_moved_sections(std::vector<uint8_t> &image, const Elf64_Eh
       assert(symbol.st_value <= std::numeric_limits<uint64_t>::max() - delta &&
              "ELF symbol value overflow");
       symbol.st_value += delta;
+      std::memcpy(image.data() + symbol_offset, &symbol, sizeof(symbol));
+    }
+  }
+}
+
+void grow_text_function_symbols(std::vector<uint8_t> &image, const Elf64_Ehdr &ehdr,
+                                std::span<const Elf64_Shdr> shdrs, size_t text_index,
+                                uint64_t old_text_size, uint64_t new_text_size) {
+  if (new_text_size <= old_text_size)
+    return;
+
+  const Elf64_Shdr &text = shdrs[text_index];
+  for (const Elf64_Shdr &symtab : shdrs) {
+    if (symtab.sh_type != SHT_SYMTAB && symtab.sh_type != SHT_DYNSYM)
+      continue;
+    if (symtab.sh_entsize != sizeof(Elf64_Sym))
+      continue;
+    if (!image_contains_range(image.size(), symtab.sh_offset, symtab.sh_size))
+      continue;
+
+    const size_t count = symtab.sh_size / sizeof(Elf64_Sym);
+    for (size_t i = 0; i < count; ++i) {
+      const uint64_t symbol_offset = symtab.sh_offset + i * sizeof(Elf64_Sym);
+      Elf64_Sym symbol{};
+      std::memcpy(&symbol, image.data() + symbol_offset, sizeof(symbol));
+
+      if (symbol.st_shndx != text_index || elf_symbol_type(symbol.st_info) != kElfSymbolTypeFunc)
+        continue;
+
+      // ET_DYN symbols use virtual addresses; ET_REL symbols use section
+      // offsets.  Normalize both forms so the range test below is independent
+      // of the input code-object kind.
+      uint64_t symbol_text_offset = symbol.st_value;
+      if (ehdr.e_type != ET_REL) {
+        if (symbol.st_value < text.sh_addr)
+          continue;
+        symbol_text_offset = symbol.st_value - text.sh_addr;
+      }
+      if (symbol_text_offset > old_text_size)
+        continue;
+
+      // The translator appends executable cave code after the original .text
+      // contents and branches into it from relocated instructions.  AMDGPU code
+      // objects often leave padding after the kernel function, so a valid input
+      // function symbol may not reach the old section end.  Any non-empty
+      // function body that starts in the translated .text can now reach appended
+      // cave code, so keep its extent covering those bytes for loaders and
+      // runtime tooling that consult FUNC ranges.
+      if (symbol.st_size == 0)
+        continue;
+
+      const uint64_t grown_size = new_text_size - symbol_text_offset;
+      if (symbol.st_size >= grown_size)
+        continue;
+      symbol.st_size = grown_size;
       std::memcpy(image.data() + symbol_offset, &symbol, sizeof(symbol));
     }
   }
@@ -428,9 +461,98 @@ std::span<const uint8_t> CodeObjectPatcher::text_bytes() const {
   return {image_.data() + text_offset_, text_size_};
 }
 
-void CodeObjectPatcher::overwrite_text(std::span<const uint8_t> new_text) {
-  assert(new_text.size() == text_size_ && "text size mismatch");
+bool CodeObjectPatcher::replace_text(std::span<const uint8_t> new_text) {
+  if (text_size_ == 0)
+    return false;
+  if (new_text.size() < text_size_)
+    return false;
+  if (!image_contains_range(image_.size(), text_offset_, text_size_))
+    return false;
+
+  auto *ehdr = reinterpret_cast<Elf64_Ehdr *>(image_.data());
+  auto header = *ehdr;
+  auto shdrs = read_section_headers(image_, header);
+  auto phdrs = read_program_headers(image_, header);
+
+  const auto text_index = find_text_section(shdrs, text_offset_, text_size_);
+  if (!text_index) {
+    assert(false && "text section header not found");
+    return false;
+  }
+
+  const auto text_header = shdrs[*text_index];
+  const uint64_t old_text_end_file = text_offset_ + text_size_;
+  const uint64_t old_text_end_vaddr = text_header.sh_addr + text_size_;
+  const uint64_t growth = new_text.size() - text_size_;
+
+  if (growth != 0) {
+    // Growing .text can shift later LOAD segments. Pad the inserted file range
+    // so every shifted LOAD keeps p_offset % p_align congruent with p_vaddr %
+    // p_align. The padding is executable segment filler, not part of .text.
+    const uint64_t file_delta_alignment = shifted_load_delta_alignment(phdrs, old_text_end_file);
+    const uint64_t padded_file_delta = align_up(growth, file_delta_alignment);
+    assert(padded_file_delta >= growth && "aligned text growth underflowed");
+    assert(padded_file_delta % sizeof(uint32_t) == 0 && "text growth must stay word-aligned");
+
+    std::vector<uint8_t> inserted(padded_file_delta, 0);
+    std::vector<bool> shift_section_vaddr(shdrs.size(), false);
+    for (size_t i = 0; i < shdrs.size(); ++i) {
+      if (i == *text_index || shdrs[i].sh_type == SHT_NULL)
+        continue;
+      if ((shdrs[i].sh_flags & SHF_ALLOC) != 0 && shdrs[i].sh_addr >= old_text_end_vaddr)
+        shift_section_vaddr[i] = true;
+    }
+
+    std::vector<bool> shift_segment_vaddr(phdrs.size(), false);
+    for (size_t i = 0; i < phdrs.size(); ++i) {
+      if (phdrs[i].p_vaddr >= old_text_end_vaddr && phdrs[i].p_offset >= old_text_end_file)
+        shift_segment_vaddr[i] = true;
+    }
+
+    insert_file_bytes(image_, header, shdrs, phdrs, old_text_end_file, inserted, *text_index, true);
+
+    for (size_t i = 0; i < shdrs.size(); ++i) {
+      if (!shift_section_vaddr[i])
+        continue;
+      [[maybe_unused]] const uint64_t old_addr = shdrs[i].sh_addr;
+      shdrs[i].sh_addr += padded_file_delta;
+      assert((shdrs[i].sh_addralign <= 1 ||
+              shdrs[i].sh_addr % shdrs[i].sh_addralign == old_addr % shdrs[i].sh_addralign) &&
+             "shifted allocated section lost its address alignment residue");
+    }
+
+    shift_symbols_in_moved_sections(image_, header, shdrs, shift_section_vaddr, padded_file_delta);
+    shift_relocation_offsets_in_moved_sections(image_, header, shdrs, shift_section_vaddr,
+                                               padded_file_delta);
+    adjust_kernel_descriptor_entry_offsets_in_moved_sections(image_, shdrs, shift_section_vaddr,
+                                                             padded_file_delta);
+
+    for (size_t i = 0; i < phdrs.size(); ++i) {
+      if (!shift_segment_vaddr[i])
+        continue;
+      assert((phdrs[i].p_align <= 1 || padded_file_delta % phdrs[i].p_align == 0) &&
+             "text padding does not preserve shifted LOAD alignment");
+      phdrs[i].p_vaddr += padded_file_delta;
+      phdrs[i].p_paddr += padded_file_delta;
+      assert((phdrs[i].p_align <= 1 ||
+              phdrs[i].p_offset % phdrs[i].p_align == phdrs[i].p_vaddr % phdrs[i].p_align) &&
+             "shifted LOAD lost file/virtual address congruence");
+    }
+  }
+
   std::memcpy(image_.data() + text_offset_, new_text.data(), new_text.size());
+  shdrs[*text_index].sh_size = new_text.size();
+  grow_text_function_symbols(image_, header, shdrs, *text_index, text_size_, new_text.size());
+  text_size_ = new_text.size();
+
+  for (const Elf64_Phdr &phdr : phdrs) {
+    if (phdr.p_type != PT_LOAD || phdr.p_align <= 1)
+      continue;
+    assert(phdr.p_offset % phdr.p_align == phdr.p_vaddr % phdr.p_align &&
+           "patched LOAD lost file/virtual address congruence");
+  }
+  write_elf_tables(image_, header, shdrs, phdrs);
+  return true;
 }
 
 void CodeObjectPatcher::update_elf_flags(uint32_t new_mach) {
@@ -452,14 +574,6 @@ bool CodeObjectPatcher::apply_kernel_descriptor_translation(const KdTranslation 
                                                             rj_code_arch_t target_arch) {
   if (!image_contains_range(image_.size(), translation.descriptor_file_offset, sizeof(KD)))
     return false;
-
-  std::optional<uint64_t> prologue_entry;
-  if (!translation.prologue_words.empty()) {
-    prologue_entry = append_kernel_entry_prologue(translation.entry_text_offset,
-                                                  translation.prologue_words, target_arch);
-    if (!prologue_entry)
-      return false;
-  }
 
   auto *desc = reinterpret_cast<KD *>(image_.data() + translation.descriptor_file_offset);
 
@@ -523,54 +637,10 @@ bool CodeObjectPatcher::apply_kernel_descriptor_translation(const KdTranslation 
   AMDHSA_BITS_SET(desc->compute_pgm_rsrc2, kd::COMPUTE_PGM_RSRC2_ENABLE_PRIVATE_SEGMENT,
                   enable_private_segment);
 
-  if (prologue_entry) {
-    if (!redirect_kernel_entry(translation.descriptor_file_offset, translation.entry_text_offset,
-                               *prologue_entry))
-      return false;
-  }
+  if (!redirect_kernel_entry(translation.descriptor_file_offset, translation.entry_text_offset,
+                             translation.target_entry_text_offset))
+    return false;
   return true;
-}
-
-std::optional<uint64_t> CodeObjectPatcher::append_kernel_entry_prologue(
-    uint64_t entry_text_offset, std::span<const uint32_t> prologue_words, rj_code_arch_t arch) {
-  assert(!prologue_words.empty() && "empty kernel entry prologue");
-
-  // A kernel descriptor entry point is a hardware launch address, not an
-  // ordinary branch target. CP expects that instruction address to be 256-byte
-  // aligned. The patcher works in .text-relative offsets, so preserve the
-  // original entry's 256-byte residue; if the original virtual address was
-  // aligned, the redirected virtual address stays aligned too.
-  const uint64_t current_offset = cave_start_ + cave_body_size();
-  const uint64_t required_residue = entry_text_offset % 256;
-  const uint64_t alignment_padding = (required_residue + 256 - (current_offset % 256)) % 256;
-  assert(alignment_padding % sizeof(uint32_t) == 0 && "unaligned cave padding");
-
-  std::vector<uint32_t> cave_words(prologue_words.begin(), prologue_words.end());
-  const uint64_t cave_byte_offset = current_offset + alignment_padding;
-  assert(cave_byte_offset % 256 == required_residue &&
-         "kernel descriptor entry lost its 256-byte alignment");
-
-  // The descriptor now enters the cave directly. The only control-flow fixup is
-  // a final branch from the prologue body to the original, untouched entry.
-  const int64_t branch_pc = static_cast<int64_t>(cave_byte_offset + cave_words.size() * 4);
-  const int64_t target = static_cast<int64_t>(entry_text_offset);
-  const int64_t target_delta_bytes = target - (branch_pc + 4);
-  if (target_delta_bytes % static_cast<int64_t>(sizeof(uint32_t)) != 0)
-    return std::nullopt;
-
-  const int64_t target_dwords = target_delta_bytes / static_cast<int64_t>(sizeof(uint32_t));
-  if (target_dwords < std::numeric_limits<int16_t>::min() ||
-      target_dwords > std::numeric_limits<int16_t>::max())
-    return std::nullopt;
-
-  if (alignment_padding != 0) {
-    std::vector<uint32_t> padding(alignment_padding / sizeof(uint32_t), build_s_nop(0, arch));
-    append_cave_body(padding);
-  }
-  cave_words.push_back(build_s_branch(static_cast<int16_t>(target_dwords), arch));
-
-  append_cave_body(cave_words);
-  return cave_byte_offset;
 }
 
 bool CodeObjectPatcher::redirect_kernel_entry(uint64_t descriptor_file_offset,
@@ -587,149 +657,6 @@ bool CodeObjectPatcher::redirect_kernel_entry(uint64_t descriptor_file_offset,
   // after the descriptor in virtual address order. Preserve that signed value
   // when applying the text-relative delta.
   desc->kernel_code_entry_byte_offset = redirected;
-  return true;
-}
-
-void CodeObjectPatcher::append_cave_body(std::span<const uint32_t> words) {
-  auto *bytes = reinterpret_cast<const uint8_t *>(words.data());
-  cave_body_.insert(cave_body_.end(), bytes, bytes + words.size() * 4);
-}
-
-bool CodeObjectPatcher::append_cave_section(std::string_view section_name) {
-  if (cave_body_.empty())
-    return true;
-  if (text_size_ == 0)
-    return false;
-
-  assert(cave_start_ == text_size_ &&
-         "separate cave sections must start immediately after original .text");
-  assert(text_offset_ + text_size_ <= image_.size() && "text section out of bounds");
-  assert(cave_body_.size() % sizeof(uint32_t) == 0 && "cave body must be word-aligned");
-
-  auto *ehdr = reinterpret_cast<Elf64_Ehdr *>(image_.data());
-  auto header = *ehdr;
-  auto shdrs = read_section_headers(image_, header);
-  auto phdrs = read_program_headers(image_, header);
-
-  const auto text_index = find_text_section(shdrs, text_offset_, text_size_);
-  if (!text_index) {
-    assert(false && "text section header not found");
-    return false;
-  }
-
-  const auto text_header = shdrs[*text_index];
-  const uint64_t cave_file_offset = text_offset_ + text_size_;
-  const uint64_t cave_vaddr = text_header.sh_addr + text_size_;
-
-  // Insert the executable bytes at the exact address assumed by branch stub
-  // construction: .text-relative offset text_size_. Any later PT_LOAD segment
-  // must keep p_offset congruent with p_vaddr modulo p_align, so the total file
-  // delta is padded up to the required load alignment. Later allocated sections
-  // also move forward in virtual address space; otherwise a large cave can
-  // overlap the following LOAD segment in memory. The padding is part of the RX
-  // LOAD segment but not part of the .rj_translations section.
-  const uint64_t file_delta_alignment = shifted_load_delta_alignment(phdrs, cave_file_offset);
-  const uint64_t padded_file_delta = align_up(cave_body_.size(), file_delta_alignment);
-  assert(padded_file_delta >= cave_body_.size() && "aligned cave delta underflowed");
-  assert((file_delta_alignment <= 1 || padded_file_delta % file_delta_alignment == 0) &&
-         "padded cave delta is not load-aligned");
-  assert(padded_file_delta % sizeof(uint32_t) == 0 && "padded cave delta must stay word-aligned");
-  std::vector<uint8_t> cave_file_bytes(cave_body_.begin(), cave_body_.end());
-  cave_file_bytes.resize(padded_file_delta, 0);
-
-  // insert_file_bytes handles file offsets. These side maps record which
-  // already-existing allocated objects also need virtual-address adjustments.
-  std::vector<bool> shift_section_vaddr(shdrs.size(), false);
-  for (size_t i = 0; i < shdrs.size(); ++i) {
-    if (i == *text_index || shdrs[i].sh_type == SHT_NULL)
-      continue;
-    if ((shdrs[i].sh_flags & SHF_ALLOC) != 0 && shdrs[i].sh_addr >= cave_vaddr)
-      shift_section_vaddr[i] = true;
-  }
-
-  std::vector<bool> shift_segment_vaddr(phdrs.size(), false);
-  for (size_t i = 0; i < phdrs.size(); ++i) {
-    if (phdrs[i].p_vaddr >= cave_vaddr && phdrs[i].p_offset >= cave_file_offset)
-      shift_segment_vaddr[i] = true;
-  }
-
-  insert_file_bytes(image_, header, shdrs, phdrs, cave_file_offset, cave_file_bytes, std::nullopt,
-                    true);
-
-  for (size_t i = 0; i < shdrs.size(); ++i) {
-    if (shift_section_vaddr[i]) {
-      [[maybe_unused]] const uint64_t old_addr = shdrs[i].sh_addr;
-      shdrs[i].sh_addr += padded_file_delta;
-      assert((shdrs[i].sh_addralign <= 1 ||
-              shdrs[i].sh_addr % shdrs[i].sh_addralign == old_addr % shdrs[i].sh_addralign) &&
-             "shifted allocated section lost its address alignment residue");
-    }
-  }
-  shift_symbols_in_moved_sections(image_, header, shdrs, shift_section_vaddr, padded_file_delta);
-  shift_relocation_offsets_in_moved_sections(image_, header, shdrs, shift_section_vaddr,
-                                             padded_file_delta);
-  adjust_kernel_descriptor_entry_offsets_in_moved_sections(image_, shdrs, shift_section_vaddr,
-                                                           padded_file_delta);
-
-  // The text LOAD grows over the inserted cave bytes; later LOADs move forward
-  // in both file offset and virtual address.
-  for (size_t i = 0; i < phdrs.size(); ++i) {
-    if (!shift_segment_vaddr[i])
-      continue;
-    assert((phdrs[i].p_align <= 1 || padded_file_delta % phdrs[i].p_align == 0) &&
-           "cave padding does not preserve shifted LOAD alignment");
-    phdrs[i].p_vaddr += padded_file_delta;
-    phdrs[i].p_paddr += padded_file_delta;
-    assert((phdrs[i].p_align <= 1 ||
-            phdrs[i].p_offset % phdrs[i].p_align == phdrs[i].p_vaddr % phdrs[i].p_align) &&
-           "shifted LOAD lost file/virtual address congruence");
-  }
-
-  const uint32_t name_offset = append_section_name(image_, header, shdrs, phdrs, section_name);
-
-  Elf64_Shdr cave_header{};
-  cave_header.sh_name = name_offset;
-  cave_header.sh_type = SHT_PROGBITS;
-  cave_header.sh_flags = text_header.sh_flags;
-  cave_header.sh_addr = cave_vaddr;
-  cave_header.sh_offset = cave_file_offset;
-  cave_header.sh_size = cave_body_.size();
-  cave_header.sh_addralign = sizeof(uint32_t);
-  assert(cave_header.sh_offset % cave_header.sh_addralign == 0 &&
-         "cave section file offset is not word-aligned");
-  assert(cave_header.sh_addr % cave_header.sh_addralign == 0 &&
-         "cave section virtual address is not word-aligned");
-
-  const uint64_t section_header_table_end =
-      header.e_shoff + static_cast<uint64_t>(shdrs.size()) * sizeof(Elf64_Shdr);
-  assert(section_header_table_end <= image_.size() && "section header table end out of bounds");
-
-  // Reserve the next contiguous section-header slot, not necessarily EOF:
-  //
-  //   old table: [e_shoff, e_shoff + N * sizeof(Elf64_Shdr))
-  //   new slot:                         ^ here
-  //
-  // insert_file_bytes shifts any later file contents to make room; then
-  // write_elf_tables rewrites the expanded N + 1 section-header table at
-  // e_shoff.
-  const uint64_t new_shdr_offset = section_header_table_end;
-  const std::array<uint8_t, sizeof(Elf64_Shdr)> blank_header{};
-  insert_file_bytes(image_, header, shdrs, phdrs, new_shdr_offset, blank_header, std::nullopt,
-                    false);
-  assert(header.e_shoff + (static_cast<uint64_t>(shdrs.size()) + 1) * sizeof(Elf64_Shdr) <=
-             image_.size() &&
-         "expanded section header table out of bounds");
-
-  shdrs.push_back(cave_header);
-  assert(shdrs.size() <= std::numeric_limits<uint16_t>::max() && "ELF section count overflow");
-  for (const Elf64_Phdr &phdr : phdrs) {
-    if (phdr.p_type != PT_LOAD || phdr.p_align <= 1)
-      continue;
-    assert(phdr.p_offset % phdr.p_align == phdr.p_vaddr % phdr.p_align &&
-           "patched LOAD lost file/virtual address congruence");
-  }
-  header.e_shnum = static_cast<uint16_t>(shdrs.size());
-  write_elf_tables(image_, header, shdrs, phdrs);
   return true;
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.h
@@ -28,7 +28,13 @@ public:
   uint64_t text_offset() const { return text_offset_; }
   uint64_t text_size() const { return text_size_; }
 
-  void overwrite_text(std::span<const uint8_t> new_text);
+  /// @brief Replace the original .text payload with DBT-relocated code.
+  ///
+  /// @details Updates the .text section size, shifts later file contents, grows
+  /// the executable LOAD segment that contains .text, preserves LOAD alignment,
+  /// updates moved symbols and relocation places, and keeps descriptor-relative
+  /// entries coherent with explicit descriptor patches applied by DBT.
+  [[nodiscard]] bool replace_text(std::span<const uint8_t> new_text);
 
   void update_elf_flags(uint32_t new_flags);
 
@@ -37,21 +43,12 @@ public:
 
   /// @brief Apply a descriptor translation plan to the in-memory ELF image.
   ///
-  /// KernelDescriptorTranslator owns the resource/ABI decision. The patcher
-  /// owns the byte-level descriptor update, cave placement, and entry redirect.
+  /// KernelDescriptorTranslator owns the resource/ABI decision. BinaryTranslator
+  /// owns text relocation and any local prologue layout. The patcher only
+  /// mutates descriptor bytes and redirects the descriptor to the already-known
+  /// relocated entry offset.
   [[nodiscard]] bool apply_kernel_descriptor_translation(const KdTranslation &translation,
                                                          rj_code_arch_t target_arch);
-
-  /// @brief Append descriptor-derived instructions and return their .text offset.
-  ///
-  /// The descriptor translator owns the ABI policy and emits @p prologue_words.
-  /// The patcher owns the byte-level placement: it puts those words in the code
-  /// cave at a 256-byte-aligned launch address and appends a branch into the
-  /// original kernel entry. The caller then redirects the kernel descriptor to
-  /// the returned offset.
-  [[nodiscard]] std::optional<uint64_t>
-  append_kernel_entry_prologue(uint64_t entry_text_offset, std::span<const uint32_t> prologue_words,
-                               rj_code_arch_t arch);
 
   /// @brief Redirect one kernel descriptor from @p old_entry_text_offset to @p
   /// new_entry_text_offset.
@@ -63,41 +60,12 @@ public:
                                            uint64_t old_entry_text_offset,
                                            uint64_t new_entry_text_offset);
 
-  void append_cave_body(std::span<const uint32_t> words);
-
-  uint64_t cave_body_size() const { return cave_body_.size(); }
-
-  /// @brief Materialize the accumulated cave body as an executable ELF section.
-  ///
-  /// The section data is inserted immediately after the original .text bytes so
-  /// all cave offsets are still expressible as .text-relative byte offsets:
-  /// original .text occupies [0, text_size_) and this section starts at
-  /// text_size_. The caller must therefore set cave_start() to text_size()
-  /// before emitting branch stubs.
-  ///
-  /// @returns true if there was no cave body to emit or the section was
-  ///          materialized successfully; false if the original .text section
-  ///          header could not be found.
-  [[nodiscard]] bool append_cave_section(std::string_view section_name = ".rj_translations");
-
-  /// @brief Set the .text-relative byte offset where the cave body will be placed.
-  /// This must be called before any apply_semantic() calls so branch offsets
-  /// are computed correctly.
-  void set_cave_start(uint64_t offset) { cave_start_ = offset; }
-
-  /// @brief Get the .text-relative cave start offset.
-  uint64_t cave_start() const { return cave_start_; }
-
-  std::span<const uint8_t> cave_body() const { return cave_body_; }
-
   std::vector<uint8_t> emit() const;
 
 private:
   std::vector<uint8_t> image_;
   uint64_t text_offset_;
   uint64_t text_size_;
-  std::vector<uint8_t> cave_body_;
-  uint64_t cave_start_ = 0;
 };
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instruction_builder.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instruction_builder.cpp
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/code/patch/instruction_builder.h"
+
+#include "rocjitsu/isa/instruction.h"
+
+#include <limits>
+
+namespace rocjitsu {
+
+bool patch_pcrel_branch_offset(const Instruction &inst, std::span<uint32_t> words,
+                               int64_t delta_bytes, [[maybe_unused]] rj_code_arch_t arch) {
+  if ((inst.flags() & (BRANCH | COND_BRANCH)) == 0)
+    return false;
+  if (!inst.branch_offset_bytes())
+    return false;
+  if (words.empty())
+    return false;
+  if (delta_bytes % static_cast<int64_t>(sizeof(uint32_t)) != 0)
+    return false;
+
+  const int64_t delta_dwords = delta_bytes / static_cast<int64_t>(sizeof(uint32_t));
+  if (delta_dwords < std::numeric_limits<int16_t>::min() ||
+      delta_dwords > std::numeric_limits<int16_t>::max())
+    return false;
+
+  // Generated AMDGPU direct branches expose only SOPP branch immediates through
+  // branch_offset_bytes() today. Preserve the already-translated opcode bits and
+  // replace just the signed simm16 field so this utility covers s_branch and the
+  // s_cbranch_* family without depending on per-ISA opcode numbers.
+  words[0] = (words[0] & 0xFFFF0000u) | static_cast<uint16_t>(static_cast<int16_t>(delta_dwords));
+  return true;
+}
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instruction_builder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instruction_builder.h
@@ -20,10 +20,13 @@
 #pragma once
 
 #include <cstdint>
+#include <span>
 
 #include "rocjitsu/code/rj_code.h"
 
 namespace rocjitsu {
+
+class Instruction;
 
 /// @brief SOPP encoding prefix, consistent across all AMDGPU ISA generations.
 inline constexpr uint32_t kSoppEncodingPrefix = 0x17F;
@@ -118,6 +121,18 @@ inline constexpr uint16_t kDelayAluSaluDep1 = 9;
 [[nodiscard]] inline constexpr uint32_t build_s_branch(int16_t offset_dwords, rj_code_arch_t arch) {
   return pack_sopp(sopp_op_branch(arch), static_cast<uint16_t>(offset_dwords));
 }
+
+/// @brief Patch an emitted direct PC-relative branch instruction in-place.
+///
+/// @details @p words points into the translated output buffer. @p delta_bytes is
+/// relative to the instruction's branch base. For AMDGPU SOPP direct branches,
+/// the base is the next instruction and the immediate is a signed dword offset.
+/// The function handles unconditional and conditional SOPP direct branches by
+/// replacing bits [15:0] of word 0. It returns false when @p inst is not a
+/// decoded direct branch, the buffer is empty, or the delta is not representable
+/// by SOPP's signed 16-bit dword immediate.
+[[nodiscard]] bool patch_pcrel_branch_offset(const Instruction &inst, std::span<uint32_t> words,
+                                             int64_t delta_bytes, rj_code_arch_t arch);
 
 /// @brief Encode an s_nop instruction for the given target ISA.
 ///

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/kernel_text_layout.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/kernel_text_layout.cpp
@@ -1,0 +1,129 @@
+// Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/code/patch/kernel_text_layout.h"
+
+#include "rocjitsu/code/basic_block.h"
+#include "rocjitsu/code/patch/instruction_builder.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstring>
+
+namespace rocjitsu {
+
+namespace {
+
+inline constexpr uint64_t kKernargPreloadSkipBytes = 256;
+
+[[nodiscard]] uint32_t text_word_at(std::span<const uint8_t> text, uint64_t offset) {
+  uint32_t word = 0;
+  if (offset + sizeof(word) <= text.size())
+    std::memcpy(&word, text.data() + offset, sizeof(word));
+  return word;
+}
+
+[[nodiscard]] bool is_nop_padding_gap(std::span<const uint8_t> text, uint64_t begin, uint64_t end,
+                                      rj_code_arch_t arch) {
+  if (begin > end || end > text.size() || (begin % sizeof(uint32_t)) != 0 ||
+      (end % sizeof(uint32_t)) != 0)
+    return false;
+
+  const uint32_t nop = build_s_nop(0, arch);
+  for (uint64_t off = begin; off < end; off += sizeof(uint32_t)) {
+    if (text_word_at(text, off) != nop)
+      return false;
+  }
+  return true;
+}
+
+} // namespace
+
+void append_words(std::vector<uint8_t> &text, std::span<const uint32_t> words) {
+  if (words.empty())
+    return;
+
+  const size_t old_size = text.size();
+  const size_t extra_bytes = words.size() * sizeof(uint32_t);
+  text.resize(old_size + extra_bytes);
+  std::memcpy(text.data() + old_size, words.data(), extra_bytes);
+}
+
+void append_nop_padding(std::vector<uint8_t> &text, uint64_t byte_count, rj_code_arch_t arch) {
+  assert(byte_count % sizeof(uint32_t) == 0 && "padding must be word-aligned");
+  for (uint64_t off = 0; off < byte_count; off += sizeof(uint32_t)) {
+    const uint32_t nop = build_s_nop(0, arch);
+    append_words(text, std::span<const uint32_t>(&nop, 1));
+  }
+}
+
+[[nodiscard]] uint64_t padding_for_residue(uint64_t current_offset, uint64_t target_residue,
+                                           uint64_t alignment) {
+  const uint64_t current_residue = current_offset % alignment;
+  return (target_residue + alignment - current_residue) % alignment;
+}
+
+[[nodiscard]] uint64_t preserve_entry_skip_window_offset(const KernelTextLayout &layout,
+                                                         const BasicBlock &block, uint64_t cursor) {
+  if (block.start_offset() < layout.source_entry)
+    return cursor;
+
+  // Kernels with kernarg preloading have two valid hardware entry paths:
+  // incompatible firmware executes the descriptor entry and branches around the
+  // preload compatibility prologue, while compatible firmware adds 256 bytes to
+  // KERNEL_CODE_ENTRY_BYTE_OFFSET and starts at the real body directly. Local
+  // body compaction must therefore keep the first 256 bytes after the descriptor
+  // entry stable. Otherwise compatible firmware lands in the middle of compacted
+  // translated code with the preloaded SGPR ABI assumed but not honored.
+  const uint64_t source_delta = block.start_offset() - layout.source_entry;
+  if (source_delta > kKernargPreloadSkipBytes)
+    return cursor;
+
+  return std::max(cursor, layout.body_begin + source_delta);
+}
+
+[[nodiscard]] std::optional<uint64_t> target_for_source_offset(const KernelTextLayout &layout,
+                                                               uint64_t source_offset) {
+  if (layout.blocks.empty())
+    return std::nullopt;
+
+  // Blocks are emitted in source order and are non-overlapping in source space
+  // for the current scope; binary search preserves the prior semantics of the
+  // linear scan while reducing lookup complexity to O(log N).
+  const auto it = std::upper_bound(layout.blocks.begin(), layout.blocks.end(), source_offset,
+                                   [](uint64_t source, const BlockPlacement &placement) {
+                                     return source < placement.source_start;
+                                   });
+  if (it == layout.blocks.begin())
+    return std::nullopt;
+
+  const BlockPlacement &placement = *(it - 1);
+  if (source_offset < placement.source_start || source_offset >= placement.source_end)
+    return std::nullopt;
+
+  return placement.target_start + (source_offset - placement.source_start);
+}
+
+[[nodiscard]] std::optional<uint64_t> target_for_source_fallthrough(const KernelTextLayout &layout,
+                                                                    std::span<const uint8_t> text,
+                                                                    uint64_t source_offset,
+                                                                    rj_code_arch_t arch) {
+  if (auto target = target_for_source_offset(layout, source_offset))
+    return target;
+
+  // Local cave expansions return to the source instruction's next PC. When the
+  // compiler placed only s_nop padding between two reachable blocks, that next
+  // PC is not present in the compact relocated body. Skipping that source-only
+  // padding here keeps the body layout compact while preserving the observable
+  // fallthrough target: executing zero or more nops reaches the next block.
+  for (const BlockPlacement &placement : layout.blocks) {
+    if (source_offset >= placement.source_start)
+      continue;
+    if (is_nop_padding_gap(text, source_offset, placement.source_start, arch))
+      return placement.target_start;
+    break;
+  }
+  return std::nullopt;
+}
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/kernel_text_layout.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/kernel_text_layout.h
@@ -1,0 +1,81 @@
+// Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <vector>
+
+#include "rocjitsu/code/rj_code.h"
+
+namespace rocjitsu {
+
+class BasicBlock;
+class Instruction;
+struct KdTranslation;
+
+/// @brief Relocated placement of one source CFG block in one emitted kernel.
+///
+/// @details A source block can be emitted more than once when multiple kernel
+/// entries reach shared code. The first relocation implementation rejects shared
+/// blocks, but this struct is still kernel-local so later duplication can reuse
+/// the same fixup model.
+struct BlockPlacement {
+  BasicBlock *block = nullptr; ///< Source CFG block.
+  uint64_t source_start = 0;   ///< Original .text-relative block start.
+  uint64_t source_end = 0;     ///< Original .text-relative block end.
+  uint64_t target_start = 0;   ///< New .text-relative block start.
+  uint64_t target_end = 0;     ///< New .text-relative block end.
+};
+
+/// @brief Pending direct PC-relative branch fixup in one relocated kernel.
+///
+/// @details Source offsets are resolved through the kernel-local placement map
+/// after all reachable blocks and local cave bytes have final target offsets.
+struct BranchFixup {
+  const Instruction *inst = nullptr; ///< Decoded source branch instruction.
+  uint64_t source_inst_offset = 0;   ///< Original .text offset of the branch.
+  uint64_t source_target_offset = 0; ///< Original .text offset of the branch target.
+  uint64_t target_inst_offset = 0;   ///< New .text offset of the branch instruction.
+};
+
+/// @brief Physical output layout for one translated kernel.
+///
+/// @details Blocks are emitted in original .text order. This is intentional: it
+/// preserves every CFG fallthrough edge as physical adjacency, so DBT only
+/// patches explicit PC-relative branch immediates. Expansion bodies are appended
+/// after the emitted body as a local cave.
+struct KernelTextLayout {
+  KdTranslation *translation = nullptr;   ///< Descriptor plan for this kernel.
+  uint64_t source_entry = 0;              ///< Original descriptor entry offset.
+  uint64_t target_entry = 0;              ///< Final descriptor entry offset.
+  uint64_t target_body_entry = 0;         ///< Relocated original entry offset.
+  uint64_t body_begin = 0;                ///< First emitted body byte.
+  uint64_t body_end = 0;                  ///< One-past-end of emitted body.
+  uint64_t cave_begin = 0;                ///< First local cave byte.
+  uint64_t cave_end = 0;                  ///< One-past-end of local cave.
+  std::vector<BlockPlacement> blocks;     ///< Kernel-local block placements.
+  std::vector<BranchFixup> branch_fixups; ///< Explicit branch patches.
+};
+
+void append_words(std::vector<uint8_t> &text, std::span<const uint32_t> words);
+
+void append_nop_padding(std::vector<uint8_t> &text, uint64_t byte_count, rj_code_arch_t arch);
+
+[[nodiscard]] uint64_t padding_for_residue(uint64_t current_offset, uint64_t target_residue,
+                                           uint64_t alignment);
+
+[[nodiscard]] uint64_t preserve_entry_skip_window_offset(const KernelTextLayout &layout,
+                                                         const BasicBlock &block, uint64_t cursor);
+
+[[nodiscard]] std::optional<uint64_t> target_for_source_offset(const KernelTextLayout &layout,
+                                                               uint64_t source_offset);
+
+[[nodiscard]] std::optional<uint64_t> target_for_source_fallthrough(const KernelTextLayout &layout,
+                                                                    std::span<const uint8_t> text,
+                                                                    uint64_t source_offset,
+                                                                    rj_code_arch_t arch);
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/rj_code.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/rj_code.cpp
@@ -127,9 +127,9 @@ rj_status_t rj_code_inst_list_create(rj_code_object_t *obj, rj_code_target_id_t 
 
   auto owned = std::make_unique<rj_code_inst_list_t>();
 
-  // DBT-generated cave bodies live outside .text, but they still need normal
-  // disassembly/validation alongside original text bytes.
-  for (const auto *sec : obj->co->code_sections()) {
+  // DBT local caves are emitted into .text, so instruction-list callers only
+  // need the text sections to see translated code.
+  for (const auto *sec : obj->co->text_sections()) {
     const auto *inst_data = reinterpret_cast<const uint32_t *>(sec->data());
     std::size_t inst_data_size = sec->size() / sizeof(uint32_t);
     // Each executable section owns a separate data buffer, so decoding starts

--- a/emulation/rocjitsu/tests/dbt/device_kernels_translate_tests.cpp
+++ b/emulation/rocjitsu/tests/dbt/device_kernels_translate_tests.cpp
@@ -42,6 +42,14 @@ namespace {
 
 std::string kernel_path(const char *name) { return std::string(KERNEL_DIR) + "/" + name + ".o"; }
 
+const rocjitsu::Section *find_section(const rocjitsu::CodeObject &co, std::string_view name) {
+  for (const auto &section : co.all_sections()) {
+    if (section->name() == name)
+      return section.get();
+  }
+  return nullptr;
+}
+
 struct MutableKernelDescriptorImage {
   std::vector<uint8_t> image;
   uint64_t text_offset = 0;
@@ -316,8 +324,10 @@ TEST(KernelDescriptorTranslator, Cdna4ToRdna4SkipsPrologueWhenNoWorkgroupIdsAreE
   rocjitsu::AmdGpuCodeObject mutated(fixture.image.data(), fixture.image.size());
   ASSERT_TRUE(mutated.is_valid());
   rocjitsu::CodeObjectPatcher patcher(mutated);
-  EXPECT_TRUE(patcher.apply_kernel_descriptor_translation(*translated, ROCJITSU_CODE_ARCH_RDNA4));
-  EXPECT_TRUE(patcher.cave_body().empty());
+  auto patch_plan = *translated;
+  patch_plan.target_entry_text_offset = patch_plan.entry_text_offset;
+  patch_plan.target_body_entry_text_offset = patch_plan.entry_text_offset;
+  EXPECT_TRUE(patcher.apply_kernel_descriptor_translation(patch_plan, ROCJITSU_CODE_ARCH_RDNA4));
 
   const auto patched_image = patcher.emit();
   const auto *patched_kd =
@@ -347,7 +357,10 @@ TEST(KernelDescriptorTranslator, CdnaAccVgprExpansionGrowsUnifiedVgprAllocationF
         });
     ASSERT_NE(translated, translations.end());
     EXPECT_EQ(translated->accvgpr_base, 64u);
-    EXPECT_EQ(translated->guest_vgpr_count, 64u);
+    // CDNA COMPUTE_PGM_RSRC1 is the ordinary VGPR floor used for scratch
+    // safety. The AccVGPR window starts at ACCUM_OFFSET, but it is not
+    // subtracted from the ordinary guest count.
+    EXPECT_EQ(translated->guest_vgpr_count, 128u);
     EXPECT_EQ(translated->guest_agpr_count, 64u);
     EXPECT_EQ(translated->target_vgpr_count, 128u);
     EXPECT_EQ(translated->target_vgpr_allocation_count, 128u);
@@ -386,7 +399,10 @@ TEST(KernelDescriptorTranslator, CdnaToCdnaMovesAccVgprBaseAboveSemanticScratch)
   rocjitsu::AmdGpuCodeObject mutated(fixture.image.data(), fixture.image.size());
   ASSERT_TRUE(mutated.is_valid());
   rocjitsu::CodeObjectPatcher patcher(mutated);
-  ASSERT_TRUE(patcher.apply_kernel_descriptor_translation(*translated, ROCJITSU_CODE_ARCH_CDNA3));
+  auto patch_plan = *translated;
+  patch_plan.target_entry_text_offset = patch_plan.entry_text_offset;
+  patch_plan.target_body_entry_text_offset = patch_plan.entry_text_offset;
+  ASSERT_TRUE(patcher.apply_kernel_descriptor_translation(patch_plan, ROCJITSU_CODE_ARCH_CDNA3));
 
   const auto patched_image = patcher.emit();
   const auto *patched_kd =
@@ -486,6 +502,9 @@ TEST(BinaryTranslatorE2E, DescriptorPrologueRedirectsEntryWithoutOverwritingOrig
 
   EXPECT_GT(translated_info->entry_text_offset, original_info->entry_text_offset)
       << "CDNA4 workgroup-id SGPRs must be materialized from RDNA4's TTMP launch payload";
+  EXPECT_EQ(translated_info->entry_text_offset % 256, original_info->entry_text_offset % 256)
+      << "The redirected descriptor entry remains a hardware launch address and must preserve the "
+         "source entry alignment residue";
   EXPECT_GE(translated_info->guest_vgpr_count, original_info->guest_vgpr_count)
       << "Descriptor translation should not fabricate conservative VGPR headroom; semantic "
          "lowerings grow the descriptor through explicit resource feedback when needed";
@@ -506,84 +525,17 @@ TEST(BinaryTranslatorE2E, DescriptorPrologueRedirectsEntryWithoutOverwritingOrig
   EXPECT_NE(std::string_view(original_entry->mnemonic()), "s_branch")
       << "Original kernel entry should not be replaced by a prologue branch stub";
 
-  const rocjitsu::Section *redirected_section = text;
   uint64_t redirected_section_offset = translated_info->entry_text_offset;
-  if (redirected_section_offset >= text->size()) {
-    redirected_section = nullptr;
-    for (const auto &section : translated_co.all_sections()) {
-      if (section->name() == ".rj_translations") {
-        redirected_section = section.get();
-        break;
-      }
-    }
-    ASSERT_NE(redirected_section, nullptr)
-        << "Descriptor ABI prologues should be materialized in .rj_translations";
-    redirected_section_offset -= text->size();
-  }
-  ASSERT_LT(redirected_section_offset, redirected_section->size());
+  ASSERT_LT(redirected_section_offset, text->size());
+  EXPECT_EQ(find_section(translated_co, ".rj_translations"), nullptr)
+      << "Descriptor ABI prologues should be materialized in the relocated .text";
 
-  const auto *redirected_words = reinterpret_cast<const uint32_t *>(redirected_section->data());
+  const auto *redirected_words = reinterpret_cast<const uint32_t *>(text->data());
   std::unique_ptr<rocjitsu::Instruction> redirected_entry(
       decoder->decode(&redirected_words[redirected_section_offset / sizeof(uint32_t)]));
   ASSERT_NE(redirected_entry, nullptr);
   EXPECT_EQ(std::string_view(redirected_entry->mnemonic()), "s_mov_b32")
       << "Redirected kernel entry should begin with the descriptor ABI prologue";
-}
-
-TEST(CodeObjectPatcher, KernelEntryPrologueIs256ByteAligned) {
-  Executable exec(kernel_path("vector_add"));
-  ASSERT_TRUE(exec.is_valid());
-  ASSERT_GT(exec.num_code_objects(ROCJITSU_CODE_TARGET_GFX950), 0u);
-
-  const auto *co = exec.code_object(ROCJITSU_CODE_TARGET_GFX950, 0);
-  ASSERT_NE(co, nullptr);
-
-  rocjitsu::CodeObjectPatcher patcher(*co);
-  ASSERT_FALSE(co->text_sections().empty());
-  const auto *image = reinterpret_cast<const uint8_t *>(co->image_data());
-  const auto *text = co->text_sections()[0];
-  rocjitsu::KernelDescriptorTranslator parser(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_RDNA4);
-  const auto infos =
-      parser.translate_image({image, co->image_size()}, text->sectionOffset(), text->size(),
-                             rocjitsu::KernelDescriptorTranslationOptions{});
-  ASSERT_FALSE(infos.empty());
-
-  patcher.set_cave_start(infos[0].entry_text_offset + sizeof(uint32_t));
-  const std::array<uint32_t, 1> prologue = {rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_RDNA4)};
-  const auto prologue_entry = patcher.append_kernel_entry_prologue(
-      infos[0].entry_text_offset, prologue, ROCJITSU_CODE_ARCH_RDNA4);
-  ASSERT_TRUE(prologue_entry.has_value());
-
-  EXPECT_EQ(*prologue_entry % 256, infos[0].entry_text_offset % 256)
-      << "Kernel descriptor entry points are hardware launch addresses; the cave prologue must "
-         "preserve the original entry's .text-relative alignment residue";
-}
-
-TEST(CodeObjectPatcher, KernelEntryPrologueRejectsOutOfRangeBranch) {
-  Executable exec(kernel_path("vector_add"));
-  ASSERT_TRUE(exec.is_valid());
-  ASSERT_GT(exec.num_code_objects(ROCJITSU_CODE_TARGET_GFX950), 0u);
-
-  const auto *co = exec.code_object(ROCJITSU_CODE_TARGET_GFX950, 0);
-  ASSERT_NE(co, nullptr);
-
-  rocjitsu::CodeObjectPatcher patcher(*co);
-  ASSERT_FALSE(co->text_sections().empty());
-  const auto *image = reinterpret_cast<const uint8_t *>(co->image_data());
-  const auto *text = co->text_sections()[0];
-  rocjitsu::KernelDescriptorTranslator parser(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_RDNA4);
-  const auto infos =
-      parser.translate_image({image, co->image_size()}, text->sectionOffset(), text->size(),
-                             rocjitsu::KernelDescriptorTranslationOptions{});
-  ASSERT_FALSE(infos.empty());
-
-  patcher.set_cave_start(infos[0].entry_text_offset + 200000);
-  const std::array<uint32_t, 1> prologue = {rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_RDNA4)};
-  const auto prologue_entry = patcher.append_kernel_entry_prologue(
-      infos[0].entry_text_offset, prologue, ROCJITSU_CODE_ARCH_RDNA4);
-
-  EXPECT_FALSE(prologue_entry.has_value());
-  EXPECT_EQ(patcher.cave_body_size(), 0u);
 }
 
 TEST(CodeObjectPatcher, RejectsOutOfRangeKernelDescriptorUpdates) {
@@ -604,10 +556,9 @@ TEST(CodeObjectPatcher, RejectsOutOfRangeKernelDescriptorUpdates) {
   rocjitsu::KdTranslation invalid;
   invalid.descriptor_file_offset = image_size;
   EXPECT_FALSE(patcher.apply_kernel_descriptor_translation(invalid, ROCJITSU_CODE_ARCH_RDNA4));
-  EXPECT_TRUE(patcher.cave_body().empty());
 }
 
-TEST(BinaryTranslatorE2E, NoTextPaddingStillMaterializesCodeCaveSection) {
+TEST(BinaryTranslatorE2E, NoTextPaddingStillMaterializesLocalCaveInText) {
   Executable exec(kernel_path("vector_add"));
   ASSERT_TRUE(exec.is_valid());
   ASSERT_GT(exec.num_code_objects(ROCJITSU_CODE_TARGET_GFX950), 0u);
@@ -626,7 +577,7 @@ TEST(BinaryTranslatorE2E, NoTextPaddingStillMaterializesCodeCaveSection) {
   const uint32_t filler = rocjitsu::build_s_branch(0, ROCJITSU_CODE_ARCH_CDNA4);
 
   // Force away the old trailing-NOP escape hatch so this test only passes if
-  // caves are materialized in the new executable section.
+  // expansion bodies are materialized in the relocated .text.
   size_t overwritten_padding_words = 0;
   for (size_t i = word_count; i > 0; --i) {
     uint32_t word = 0;
@@ -650,17 +601,8 @@ TEST(BinaryTranslatorE2E, NoTextPaddingStillMaterializesCodeCaveSection) {
   rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
   ASSERT_TRUE(translated.is_valid());
   ASSERT_FALSE(translated.text_sections().empty());
-  EXPECT_EQ(translated.text_sections()[0]->size(), text->size());
-
-  const rocjitsu::Section *translations = nullptr;
-  for (const auto &section : translated.all_sections()) {
-    if (section->name() == ".rj_translations") {
-      translations = section.get();
-      break;
-    }
-  }
-  ASSERT_NE(translations, nullptr);
-  EXPECT_GT(translations->size(), 0u);
+  EXPECT_GE(translated.text_sections()[0]->size(), text->size());
+  EXPECT_EQ(find_section(translated, ".rj_translations"), nullptr);
 }
 
 TEST(BinaryTranslatorE2E, OutputDecodesAsValidRdna4) {
@@ -684,7 +626,7 @@ TEST(BinaryTranslatorE2E, OutputDecodesAsValidRdna4) {
 
   int decode_failures = 0;
   int inst_count = 0;
-  for (const auto *sec : translated_co.code_sections()) {
+  for (const auto *sec : translated_co.text_sections()) {
     const auto *data = reinterpret_cast<const uint32_t *>(sec->data());
     const size_t words = sec->size() / sizeof(uint32_t);
     size_t pc = 0;
@@ -726,7 +668,7 @@ TEST(BinaryTranslatorE2E, NoGfx9WaitcntInOutput) {
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA4);
   ASSERT_NE(decoder, nullptr);
 
-  for (const auto *sec : translated_co.code_sections()) {
+  for (const auto *sec : translated_co.text_sections()) {
     const auto *data = reinterpret_cast<const uint32_t *>(sec->data());
     const size_t words = sec->size() / sizeof(uint32_t);
     size_t pc = 0;
@@ -747,7 +689,7 @@ TEST(BinaryTranslatorE2E, NoGfx9WaitcntInOutput) {
   }
 }
 
-TEST(BinaryTranslatorE2E, TextSizesMatch) {
+TEST(BinaryTranslatorE2E, RelocatedTextIsAtLeastOriginalSize) {
   Executable exec(kernel_path("vector_add"));
   ASSERT_TRUE(exec.is_valid());
   ASSERT_GT(exec.num_code_objects(ROCJITSU_CODE_TARGET_GFX950), 0u);
@@ -766,9 +708,9 @@ TEST(BinaryTranslatorE2E, TextSizesMatch) {
   const size_t translated_text_size =
       translated_co.text_sections().empty() ? 0 : translated_co.text_sections()[0]->size();
 
-  // Code caves are separate from .text; the original instruction layout must
-  // remain byte-for-byte sized so existing branches keep their offsets.
-  EXPECT_EQ(translated_text_size, original_text_size);
+  // Expansion bodies and descriptor ABI prologues now live in local caves inside
+  // .text. Explicit branches are patched after relocation, so .text may grow.
+  EXPECT_GE(translated_text_size, original_text_size);
 }
 
 TEST(BinaryTranslatorE2E, WriteTranslatedElfToFile) {
@@ -843,7 +785,7 @@ TEST(BinaryTranslatorE2E, DumpTranslation) {
   ASSERT_FALSE(result.elf_bytes.empty());
 
   rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
-  for (const auto *sec : translated.code_sections())
+  for (const auto *sec : translated.text_sections())
     dump("RDNA4 translated", reinterpret_cast<const uint8_t *>(sec->data()), sec->size(),
          ROCJITSU_CODE_ARCH_RDNA4);
 

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -242,6 +242,7 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_load_segments() {
   syms[1].st_value = rodata_vaddr;
   syms[1].st_size = rodata_size;
   syms[2].st_name = text_symbol_name;
+  syms[2].st_info = elf_symbol_info(kElfSymbolBindGlobal, kElfSymbolTypeFunc);
   syms[2].st_shndx = 1;
   syms[2].st_value = text_vaddr;
   syms[2].st_size = text_size;
@@ -1057,17 +1058,16 @@ CHECK_NO_ILLEGAL(rdna4_to_cdna4)
 
 #undef CHECK_NO_ILLEGAL
 
-TEST(CodeObjectPatcher, CaveBodyMaterializesInRjTranslationsAfterText) {
+TEST(CodeObjectPatcher, ReplaceTextGrowsTextAndShiftsFollowingSections) {
   auto image = make_minimal_amdgpu_elf_with_text_and_rodata();
   AmdGpuCodeObject co(image.data(), image.size());
   ASSERT_TRUE(co.is_valid());
   ASSERT_FALSE(co.text_sections().empty());
 
   CodeObjectPatcher patcher(co);
-  patcher.set_cave_start(co.text_sections()[0]->size());
-  const std::array<uint32_t, 2> cave_words = {0xDEADBEEFu, 0xCAFEBABEu};
-  patcher.append_cave_body(cave_words);
-  ASSERT_TRUE(patcher.append_cave_section());
+  const std::array<uint32_t, 4> text_words = {0xBF800000u, 0xBF800000u, 0xDEADBEEFu, 0xCAFEBABEu};
+  const auto *text_bytes = reinterpret_cast<const uint8_t *>(text_words.data());
+  ASSERT_TRUE(patcher.replace_text({text_bytes, text_words.size() * sizeof(uint32_t)}));
 
   auto patched_bytes = patcher.emit();
   AmdGpuCodeObject patched(patched_bytes.data(), patched_bytes.size());
@@ -1076,28 +1076,22 @@ TEST(CodeObjectPatcher, CaveBodyMaterializesInRjTranslationsAfterText) {
 
   const Section *text = patched.text_sections()[0];
   ASSERT_NE(text, nullptr);
-  EXPECT_EQ(text->size(), 8u) << ".text must keep its original size";
-
-  const Section *translations = find_section(patched, ".rj_translations");
-  ASSERT_NE(translations, nullptr);
-  ASSERT_EQ(patched.code_sections().size(), 2u);
-  EXPECT_EQ(patched.code_sections()[0]->name(), ".text");
-  EXPECT_EQ(patched.code_sections()[1]->name(), ".rj_translations");
-  EXPECT_EQ(translations->sectionOffset(), text->sectionOffset() + text->size())
-      << ".rj_translations must be physically placed immediately after .text";
-  ASSERT_EQ(translations->size(), cave_words.size() * sizeof(uint32_t));
-  EXPECT_EQ(std::memcmp(translations->data(), cave_words.data(), translations->size()), 0);
+  EXPECT_EQ(text->size(), text_words.size() * sizeof(uint32_t));
+  ASSERT_EQ(patched.text_sections().size(), 1u);
+  EXPECT_EQ(patched.text_sections()[0]->name(), ".text");
+  EXPECT_EQ(find_section(patched, ".rj_translations"), nullptr);
+  EXPECT_EQ(std::memcmp(text->data(), text_words.data(), text->size()), 0);
 
   const Section *rodata = find_section(patched, ".rodata");
   ASSERT_NE(rodata, nullptr);
-  EXPECT_EQ(rodata->sectionOffset(), translations->sectionOffset() + translations->size())
-      << "sections following .text must be shifted after the cave section";
+  EXPECT_EQ(rodata->sectionOffset(), text->sectionOffset() + text->size())
+      << "sections following .text must be shifted after the grown text";
   uint32_t rodata_word = 0;
   std::memcpy(&rodata_word, rodata->data(), sizeof(rodata_word));
   EXPECT_EQ(rodata_word, 0xA5A55A5Au);
 }
 
-TEST(CodeObjectPatcher, CaveInsertionPreservesLoadSegmentAlignment) {
+TEST(CodeObjectPatcher, ReplaceTextPreservesLoadSegmentAlignment) {
   constexpr uint64_t load_align = 0x1000;
   constexpr uint64_t padded_file_delta = 2 * load_align;
 
@@ -1107,10 +1101,9 @@ TEST(CodeObjectPatcher, CaveInsertionPreservesLoadSegmentAlignment) {
   ASSERT_FALSE(co.text_sections().empty());
 
   CodeObjectPatcher patcher(co);
-  patcher.set_cave_start(co.text_sections()[0]->size());
-  const std::vector<uint32_t> cave_words(load_align / sizeof(uint32_t) + 1, 0xDEADBEEFu);
-  patcher.append_cave_body(cave_words);
-  ASSERT_TRUE(patcher.append_cave_section());
+  const std::vector<uint32_t> text_words(load_align / sizeof(uint32_t) + 3, 0xDEADBEEFu);
+  const auto *text_bytes = reinterpret_cast<const uint8_t *>(text_words.data());
+  ASSERT_TRUE(patcher.replace_text({text_bytes, text_words.size() * sizeof(uint32_t)}));
 
   auto patched_bytes = patcher.emit();
   AmdGpuCodeObject patched(patched_bytes.data(), patched_bytes.size());
@@ -1118,17 +1111,14 @@ TEST(CodeObjectPatcher, CaveInsertionPreservesLoadSegmentAlignment) {
   ASSERT_FALSE(patched.text_sections().empty());
 
   const Section *text = patched.text_sections()[0];
-  const Section *translations = find_section(patched, ".rj_translations");
   const Section *rodata = find_section(patched, ".rodata");
-  ASSERT_NE(translations, nullptr);
   ASSERT_NE(rodata, nullptr);
-  EXPECT_EQ(translations->sectionOffset(), text->sectionOffset() + text->size());
-  EXPECT_EQ(translations->size(), cave_words.size() * sizeof(uint32_t));
-  EXPECT_EQ(translations->vaddr(), text->vaddr() + text->size());
+  EXPECT_EQ(find_section(patched, ".rj_translations"), nullptr);
+  EXPECT_EQ(text->size(), text_words.size() * sizeof(uint32_t));
 
-  EXPECT_EQ(rodata->sectionOffset(), text->sectionOffset() + text->size() + padded_file_delta)
+  EXPECT_EQ(rodata->sectionOffset(), text->sectionOffset() + 8u + padded_file_delta)
       << "file padding should preserve later PT_LOAD p_offset/p_vaddr congruence";
-  EXPECT_EQ(rodata->vaddr(), text->vaddr() + text->size() + load_align + padded_file_delta)
+  EXPECT_EQ(rodata->vaddr(), text->vaddr() + 8 + load_align + padded_file_delta)
       << "later allocated sections must move after the expanded RX LOAD segment";
 
   const auto *ehdr = reinterpret_cast<const Elf64_Ehdr *>(patched_bytes.data());
@@ -1140,8 +1130,8 @@ TEST(CodeObjectPatcher, CaveInsertionPreservesLoadSegmentAlignment) {
     EXPECT_EQ(phdrs[i].p_offset % phdrs[i].p_align, phdrs[i].p_vaddr % phdrs[i].p_align)
         << "PT_LOAD " << i << " must remain loader-congruent";
   }
-  EXPECT_EQ(phdrs[0].p_filesz, text->size() + padded_file_delta);
-  EXPECT_EQ(phdrs[0].p_memsz, text->size() + padded_file_delta);
+  EXPECT_EQ(phdrs[0].p_filesz, 8u + padded_file_delta);
+  EXPECT_EQ(phdrs[0].p_memsz, 8u + padded_file_delta);
   EXPECT_EQ(phdrs[1].p_offset, rodata->sectionOffset());
   EXPECT_EQ(phdrs[1].p_vaddr, rodata->vaddr());
   EXPECT_EQ(phdrs[1].p_paddr, rodata->vaddr());
@@ -1160,9 +1150,11 @@ TEST(CodeObjectPatcher, CaveInsertionPreservesLoadSegmentAlignment) {
       << "defined symbols in moved sections must track the section virtual address";
   EXPECT_EQ(symbols[2].st_value, text->vaddr())
       << "symbols in unmoved .text must keep their original virtual address";
+  EXPECT_EQ(symbols[2].st_size, text->size())
+      << "function symbols spanning old .text must cover appended translated cave code";
 }
 
-TEST(CodeObjectPatcher, CaveInsertionPreservesMovedKernelDescriptorEntryAddress) {
+TEST(CodeObjectPatcher, ReplaceTextPreservesMovedKernelDescriptorEntryAddress) {
   using KD = rocr::llvm::amdhsa::kernel_descriptor_t;
   constexpr uint64_t load_align = 0x1000;
   constexpr uint64_t padded_file_delta = 2 * load_align;
@@ -1177,10 +1169,9 @@ TEST(CodeObjectPatcher, CaveInsertionPreservesMovedKernelDescriptorEntryAddress)
   std::memcpy(&original_kd, original_rodata->data(), sizeof(original_kd));
 
   CodeObjectPatcher patcher(co);
-  patcher.set_cave_start(co.text_sections()[0]->size());
-  const std::vector<uint32_t> cave_words(load_align / sizeof(uint32_t) + 1, 0xDEADBEEFu);
-  patcher.append_cave_body(cave_words);
-  ASSERT_TRUE(patcher.append_cave_section());
+  const std::vector<uint32_t> text_words(load_align / sizeof(uint32_t) + 3, 0xDEADBEEFu);
+  const auto *text_bytes = reinterpret_cast<const uint8_t *>(text_words.data());
+  ASSERT_TRUE(patcher.replace_text({text_bytes, text_words.size() * sizeof(uint32_t)}));
 
   auto patched_bytes = patcher.emit();
   AmdGpuCodeObject patched(patched_bytes.data(), patched_bytes.size());
@@ -1200,7 +1191,7 @@ TEST(CodeObjectPatcher, CaveInsertionPreservesMovedKernelDescriptorEntryAddress)
             original_kd.kernel_code_entry_byte_offset - static_cast<int64_t>(padded_file_delta));
 }
 
-TEST(CodeObjectPatcher, CaveInsertionUpdatesRelocationOffsetsIntoMovedSections) {
+TEST(CodeObjectPatcher, ReplaceTextUpdatesRelocationOffsetsIntoMovedSections) {
   constexpr uint64_t load_align = 0x1000;
 
   auto image = make_minimal_amdgpu_elf_with_relocation_after_text();
@@ -1209,10 +1200,9 @@ TEST(CodeObjectPatcher, CaveInsertionUpdatesRelocationOffsetsIntoMovedSections) 
   ASSERT_FALSE(co.text_sections().empty());
 
   CodeObjectPatcher patcher(co);
-  patcher.set_cave_start(co.text_sections()[0]->size());
-  const std::vector<uint32_t> cave_words(load_align / sizeof(uint32_t) + 1, 0xDEADBEEFu);
-  patcher.append_cave_body(cave_words);
-  ASSERT_TRUE(patcher.append_cave_section());
+  const std::vector<uint32_t> text_words(load_align / sizeof(uint32_t) + 3, 0xDEADBEEFu);
+  const auto *text_bytes = reinterpret_cast<const uint8_t *>(text_words.data());
+  ASSERT_TRUE(patcher.replace_text({text_bytes, text_words.size() * sizeof(uint32_t)}));
 
   auto patched_bytes = patcher.emit();
   AmdGpuCodeObject patched(patched_bytes.data(), patched_bytes.size());
@@ -1249,6 +1239,71 @@ TEST(BinaryTranslator, CaveBranchOverflowLeavesCodeObjectUnchanged) {
                diagnostic.message.find("leaving code object unchanged") != std::string::npos;
       });
   EXPECT_TRUE(diagnosed);
+}
+
+TEST(BinaryTranslator, LocalCaveIgnoresUnreachableTextTail) {
+  auto image = make_large_amdgpu_elf_with_waitcnt_entry();
+  AmdGpuCodeObject source_layout(image.data(), image.size());
+  ASSERT_TRUE(source_layout.is_valid());
+  ASSERT_FALSE(source_layout.text_sections().empty());
+
+  const auto *source_text = source_layout.text_sections()[0];
+  auto *source_words = reinterpret_cast<uint32_t *>(image.data() + source_text->sectionOffset());
+  source_words[1] = 0xBF810000u; // CDNA4 s_endpgm; the remaining large tail is unreachable.
+
+  AmdGpuCodeObject co(image.data(), image.size());
+  ASSERT_TRUE(co.is_valid());
+
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_RDNA4);
+  auto result = translator.translate(co);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_TRUE(translated.is_valid());
+  ASSERT_FALSE(translated.text_sections().empty());
+  EXPECT_EQ(find_section(translated, ".rj_translations"), nullptr);
+
+  const auto *target_words =
+      reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+  EXPECT_EQ(target_words[0], build_s_branch(1, ROCJITSU_CODE_ARCH_RDNA4))
+      << "The expansion cave should be placed immediately after the reachable entry block, not "
+         "after the large unreachable .text tail";
+}
+
+TEST(BinaryTranslator, PreservesKernargPreloadEntrySkipWindow) {
+  auto image = make_large_amdgpu_elf_with_waitcnt_entry();
+  AmdGpuCodeObject source_layout(image.data(), image.size());
+  ASSERT_TRUE(source_layout.is_valid());
+  ASSERT_FALSE(source_layout.text_sections().empty());
+
+  const auto *source_text = source_layout.text_sections()[0];
+  auto *source_words = reinterpret_cast<uint32_t *>(image.data() + source_text->sectionOffset());
+  source_words[0] = build_s_branch(63, ROCJITSU_CODE_ARCH_CDNA4);
+  source_words[64] = 0xBF810000u; // CDNA4 s_endpgm at the post-preload body entry.
+
+  AmdGpuCodeObject co(image.data(), image.size());
+  ASSERT_TRUE(co.is_valid());
+
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_CDNA3);
+  auto result = translator.translate(co);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_TRUE(translated.is_valid());
+  ASSERT_FALSE(translated.text_sections().empty());
+
+  const auto *text = translated.text_sections()[0];
+  ASSERT_GT(text->size(), 256u);
+  const auto *target_words = reinterpret_cast<const uint32_t *>(text->data());
+  EXPECT_EQ(target_words[0], build_s_branch(63, ROCJITSU_CODE_ARCH_CDNA3))
+      << "the compatibility prologue must still branch over the 256-byte preload skip window";
+  for (size_t i = 1; i < 64; ++i)
+    EXPECT_EQ(target_words[i], build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA3))
+        << "preload skip window padding word " << i << " must remain executable padding";
+  EXPECT_EQ(target_words[64], 0xBF810000u)
+      << "compatible firmware starts at descriptor entry + 256 when kernargs are preloaded";
 }
 
 } // namespace
@@ -1777,16 +1832,17 @@ void expect_cdna3_instruction_matches(const rocjitsu::Instruction &inst,
   }
 }
 
-void expect_cdna3_code_cave_matches(const rocjitsu::Section &translations,
-                                    const std::vector<ExpectedCdna3Inst> &expected) {
-  ASSERT_EQ(translations.size() % sizeof(uint32_t), 0u);
-  ASSERT_GT(translations.size(), 0u);
+void expect_cdna3_local_cave_matches(const rocjitsu::Section &text, uint64_t cave_offset,
+                                     const std::vector<ExpectedCdna3Inst> &expected) {
+  ASSERT_EQ(text.size() % sizeof(uint32_t), 0u);
+  ASSERT_GT(text.size(), cave_offset);
+  ASSERT_EQ(cave_offset % sizeof(uint32_t), 0u);
 
   auto decoder = rocjitsu::Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);
   ASSERT_NE(decoder, nullptr);
 
-  const auto *words = reinterpret_cast<const uint32_t *>(translations.data());
-  const size_t word_count = translations.size() / sizeof(uint32_t);
+  const auto *words = reinterpret_cast<const uint32_t *>(text.data() + cave_offset);
+  const size_t word_count = (text.size() - cave_offset) / sizeof(uint32_t);
   std::vector<std::unique_ptr<rocjitsu::Instruction>> actual;
   for (size_t pc = 0; pc < word_count;) {
     SCOPED_TRACE(pc);
@@ -1928,9 +1984,10 @@ TEST_P(Cdna4ToCdna3SemanticRuleTranslationTest, TranslatesSingleInstruction) {
 
   rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
   ASSERT_TRUE(translated.is_valid());
-  const rocjitsu::Section *translations = rocjitsu::find_section(translated, ".rj_translations");
-  ASSERT_NE(translations, nullptr);
-  expect_cdna3_code_cave_matches(*translations, test_case.expected);
+  ASSERT_FALSE(translated.text_sections().empty());
+  EXPECT_EQ(rocjitsu::find_section(translated, ".rj_translations"), nullptr);
+  expect_cdna3_local_cave_matches(*translated.text_sections()[0], source_text->size(),
+                                  test_case.expected);
 }
 
 INSTANTIATE_TEST_SUITE_P(ImplementedRules, Cdna4ToCdna3SemanticRuleTranslationTest,
@@ -1978,6 +2035,49 @@ TEST(BinaryTranslatorE2E, Cdna4ToCdna3MfmaPartialScratchGrowsDescriptor) {
   // The 16x16x32 F16 lowering uses a four-VGPR partial accumulator when an
   // ordinary destination overlaps the still-needed wide A/B source window.
   expect_cdna3_translated_descriptor_vgprs_at_least(result.elf_bytes, kScratchFloor + 4);
+}
+
+TEST(BinaryTranslatorE2E, RelocatedKernelCompactsSourceGapsAndPatchesBranches) {
+  constexpr uint32_t kCdna4SEndpgm = 0xBF810000u;
+  constexpr uint32_t kCdna4SCbranchScc1ToSourceTarget = rocjitsu::pack_sopp(5, 4);
+  const std::vector<uint32_t> words = {
+      rocjitsu::build_s_branch(2, ROCJITSU_CODE_ARCH_CDNA4), // 0x00 -> source 0x0c.
+      rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4),    // 0x04 unreachable.
+      rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4),    // 0x08 unreachable.
+      kCdna4SCbranchScc1ToSourceTarget,                      // 0x0c -> 0x20, else 0x10.
+      rocjitsu::build_s_branch(4, ROCJITSU_CODE_ARCH_CDNA4), // 0x10 -> source 0x24.
+      rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4),    // 0x14 unreachable.
+      rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4),    // 0x18 unreachable.
+      rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4),    // 0x1c unreachable.
+      rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4),    // 0x20 conditional target.
+      kCdna4SEndpgm,                                         // 0x24 fallthrough-branch target.
+  };
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_CDNA3);
+  auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << result.diagnostics.front().message;
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_TRUE(translated.is_valid());
+  ASSERT_FALSE(translated.text_sections().empty());
+
+  const auto *target_words =
+      reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
+  // Relocation emits only reachable blocks, compacted in source order. Explicit
+  // branch immediates are then patched into the compact layout; the old source
+  // gaps are not preserved for compatibility.
+  EXPECT_EQ(target_words[0], rocjitsu::build_s_branch(0, ROCJITSU_CODE_ARCH_CDNA3));
+  EXPECT_EQ(target_words[1], rocjitsu::pack_sopp(5, 1));
+  EXPECT_EQ(target_words[2], rocjitsu::build_s_branch(1, ROCJITSU_CODE_ARCH_CDNA3));
+  EXPECT_EQ(target_words[3], rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA3));
+  EXPECT_EQ(target_words[4], kCdna4SEndpgm);
+  for (size_t i = 5; i < words.size(); ++i) {
+    SCOPED_TRACE(i);
+    EXPECT_EQ(target_words[i], rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA3));
+  }
 }
 
 TEST(BinaryTranslatorE2E, ExpandLegalizationWithoutSemanticRuleFails) {
@@ -2065,7 +2165,7 @@ TEST(BinaryTranslatorE2E, MatchedSemanticExpandRuleFailureIsDiagnostic) {
   EXPECT_FALSE(diagnostic->message.empty());
 }
 
-TEST(KernelDescriptorTranslator, IgnoresNonAllocExecutableSectionsForEntryRange) {
+TEST(KernelDescriptorTranslator, IgnoresExecutableSectionsOutsideTextForEntryRange) {
   using KD = rocr::llvm::amdhsa::kernel_descriptor_t;
 
   auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text();
@@ -2073,7 +2173,7 @@ TEST(KernelDescriptorTranslator, IgnoresNonAllocExecutableSectionsForEntryRange)
   auto *shdrs = reinterpret_cast<rocjitsu::Elf64_Shdr *>(image.data() + ehdr->e_shoff);
 
   constexpr uint64_t fake_exec_vaddr = 0x9000;
-  shdrs[5].sh_flags = rocjitsu::SHF_EXECINSTR;
+  shdrs[5].sh_flags = rocjitsu::SHF_ALLOC | rocjitsu::SHF_EXECINSTR;
   shdrs[5].sh_addr = fake_exec_vaddr;
   shdrs[5].sh_size = sizeof(uint32_t);
 
@@ -2086,5 +2186,5 @@ TEST(KernelDescriptorTranslator, IgnoresNonAllocExecutableSectionsForEntryRange)
   const auto translations = translator.translate_image(
       image, shdrs[1].sh_offset, shdrs[1].sh_size, rocjitsu::KernelDescriptorTranslationOptions{});
   EXPECT_TRUE(translations.empty())
-      << "non-loadable executable sections must not extend valid kernel entry range";
+      << "descriptor entries must point into the .text section being translated";
 }

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -425,6 +425,23 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_descriptor_after_text() {
   return make_minimal_amdgpu_elf_with_descriptor_after_text({0xBF800000u, 0xBF800000u});
 }
 
+std::unique_ptr<Instruction> decode_one(uint32_t word, rj_code_arch_t arch) {
+  auto decoder = Decoder::create(arch);
+  if (!decoder)
+    return nullptr;
+  return std::unique_ptr<Instruction>(decoder->decode(&word));
+}
+
+bool has_error_containing(const TranslatedCodeObject &result, DiagnosticKind kind,
+                          std::string_view message) {
+  return std::any_of(result.diagnostics.begin(), result.diagnostics.end(),
+                     [&](const TranslationDiagnostic &diagnostic) {
+                       return diagnostic.severity == DiagnosticSeverity::Error &&
+                              diagnostic.kind == kind &&
+                              diagnostic.message.find(message) != std::string::npos;
+                     });
+}
+
 std::vector<uint8_t> make_minimal_amdgpu_elf_with_two_kernel_descriptors() {
   using KD = rocr::llvm::amdhsa::kernel_descriptor_t;
   constexpr uint64_t text_offset = 0x100;
@@ -808,6 +825,21 @@ const Section *find_section(const CodeObject &co, std::string_view name) {
       return section.get();
   }
   return nullptr;
+}
+
+void enable_workgroup_id_x_sgpr(std::vector<uint8_t> &image) {
+  using KD = rocr::llvm::amdhsa::kernel_descriptor_t;
+
+  AmdGpuCodeObject layout(image.data(), image.size());
+  ASSERT_TRUE(layout.is_valid());
+  const auto *rodata = find_section(layout, ".rodata");
+  ASSERT_NE(rodata, nullptr);
+  ASSERT_GE(rodata->size(), sizeof(KD));
+
+  KD kd{};
+  std::memcpy(&kd, image.data() + rodata->sectionOffset(), sizeof(kd));
+  kd.compute_pgm_rsrc2 |= rocr::llvm::amdhsa::COMPUTE_PGM_RSRC2_ENABLE_SGPR_WORKGROUP_ID_X;
+  std::memcpy(image.data() + rodata->sectionOffset(), &kd, sizeof(kd));
 }
 
 TEST(CoherencyRemap, Gfx940ToGfx12AgentScope) {
@@ -1304,6 +1336,49 @@ TEST(BinaryTranslator, PreservesKernargPreloadEntrySkipWindow) {
         << "preload skip window padding word " << i << " must remain executable padding";
   EXPECT_EQ(target_words[64], 0xBF810000u)
       << "compatible firmware starts at descriptor entry + 256 when kernargs are preloaded";
+}
+
+TEST(InstructionBuilder, PatchPcrelBranchOffsetInRange) {
+  const uint32_t source_word = build_s_branch(0, ROCJITSU_CODE_ARCH_CDNA4);
+  auto inst = decode_one(source_word, ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(inst, nullptr);
+
+  std::array<uint32_t, 1> words = {build_s_branch(0, ROCJITSU_CODE_ARCH_CDNA3)};
+  EXPECT_TRUE(patch_pcrel_branch_offset(*inst, words, -8, ROCJITSU_CODE_ARCH_CDNA3));
+  EXPECT_EQ(words[0], build_s_branch(-2, ROCJITSU_CODE_ARCH_CDNA3));
+}
+
+TEST(InstructionBuilder, PatchPcrelBranchOffsetRejectsOutOfRange) {
+  const uint32_t source_word = build_s_branch(0, ROCJITSU_CODE_ARCH_CDNA4);
+  auto inst = decode_one(source_word, ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(inst, nullptr);
+
+  std::array<uint32_t, 1> words = {build_s_branch(0, ROCJITSU_CODE_ARCH_CDNA3)};
+  EXPECT_FALSE(patch_pcrel_branch_offset(*inst, words, 32768LL * 4, ROCJITSU_CODE_ARCH_CDNA3));
+  EXPECT_EQ(words[0], build_s_branch(0, ROCJITSU_CODE_ARCH_CDNA3));
+
+  EXPECT_FALSE(patch_pcrel_branch_offset(*inst, words, -32769LL * 4, ROCJITSU_CODE_ARCH_CDNA3));
+  EXPECT_EQ(words[0], build_s_branch(0, ROCJITSU_CODE_ARCH_CDNA3));
+}
+
+TEST(InstructionBuilder, PatchPcrelBranchOffsetRejectsNonBranch) {
+  const uint32_t source_word = build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4);
+  auto inst = decode_one(source_word, ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(inst, nullptr);
+
+  std::array<uint32_t, 1> words = {build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA3)};
+  EXPECT_FALSE(patch_pcrel_branch_offset(*inst, words, 4, ROCJITSU_CODE_ARCH_CDNA3));
+  EXPECT_EQ(words[0], build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA3));
+}
+
+TEST(InstructionBuilder, PatchPcrelBranchOffsetRejectsMisalignedDelta) {
+  const uint32_t source_word = build_s_branch(0, ROCJITSU_CODE_ARCH_CDNA4);
+  auto inst = decode_one(source_word, ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(inst, nullptr);
+
+  std::array<uint32_t, 1> words = {build_s_branch(0, ROCJITSU_CODE_ARCH_CDNA3)};
+  EXPECT_FALSE(patch_pcrel_branch_offset(*inst, words, 2, ROCJITSU_CODE_ARCH_CDNA3));
+  EXPECT_EQ(words[0], build_s_branch(0, ROCJITSU_CODE_ARCH_CDNA3));
 }
 
 } // namespace
@@ -2078,6 +2153,94 @@ TEST(BinaryTranslatorE2E, RelocatedKernelCompactsSourceGapsAndPatchesBranches) {
     SCOPED_TRACE(i);
     EXPECT_EQ(target_words[i], rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA3));
   }
+}
+
+TEST(BinaryTranslatorE2E, RejectsIndirectBranchAndCallInstructions) {
+  struct Case {
+    const char *name;
+    std::vector<uint32_t> words;
+    const char *mnemonic;
+  };
+
+  const std::array<Case, 3> cases = {{
+      {"Setpc", {0xBE801D00u, 0x00000000u}, "s_setpc_b64"},
+      {"Swappc", {0xBE801E00u, 0x00000000u}, "s_swappc_b64"},
+      {"Call", {0xBA800000u, 0x00000000u}, "s_call_b64"},
+  }};
+
+  for (const auto &test_case : cases) {
+    SCOPED_TRACE(test_case.name);
+    auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(test_case.words);
+    rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+    ASSERT_TRUE(source.is_valid());
+
+    rocjitsu::BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_CDNA3);
+    auto result = translator.translate(source);
+
+    EXPECT_EQ(result.elf_bytes, image);
+    EXPECT_TRUE(rocjitsu::has_error_containing(
+        result, rocjitsu::DiagnosticKind::Legalization,
+        "indirect branch or call target recovery is not implemented"));
+    const auto diagnostic =
+        std::find_if(result.diagnostics.begin(), result.diagnostics.end(),
+                     [&](const auto &d) { return d.mnemonic == test_case.mnemonic; });
+    EXPECT_NE(diagnostic, result.diagnostics.end());
+  }
+}
+
+TEST(BinaryTranslatorE2E, RejectsDirectBranchTargetBeforeText) {
+  const std::vector<uint32_t> words = {
+      rocjitsu::build_s_branch(-2, ROCJITSU_CODE_ARCH_CDNA4), // 0x00 -> -0x04.
+      rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4),
+  };
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_CDNA3);
+  auto result = translator.translate(source);
+
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(
+      rocjitsu::has_error_containing(result, rocjitsu::DiagnosticKind::Legalization,
+                                     "direct branch target is outside the source .text range"));
+}
+
+TEST(BinaryTranslatorE2E, RejectsDirectBranchTargetAbsentFromRelocatedBody) {
+  const std::vector<uint32_t> words = {
+      rocjitsu::build_s_branch(1, ROCJITSU_CODE_ARCH_CDNA4), // 0x00 -> .text end.
+      rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4),
+  };
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_CDNA3);
+  auto result = translator.translate(source);
+
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(rocjitsu::has_error_containing(
+      result, rocjitsu::DiagnosticKind::Legalization,
+      "direct branch target is not present in the kernel-local relocated body"));
+}
+
+TEST(BinaryTranslatorE2E, RejectsDescriptorPrologueBranchRangeOverflow) {
+  constexpr size_t kBodyWordsPastBranchRange = 32769;
+  std::vector<uint32_t> words(kBodyWordsPastBranchRange, 0xBF800000u);
+  words.push_back(0xBF810000u);
+
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
+  rocjitsu::enable_workgroup_id_x_sgpr(image);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_RDNA4);
+  auto result = translator.translate(source);
+
+  EXPECT_EQ(result.elf_bytes, image);
+  EXPECT_TRUE(rocjitsu::has_error_containing(
+      result, rocjitsu::DiagnosticKind::ResourceLimit,
+      "kernel descriptor prologue branch range exceeds s_branch simm16"));
 }
 
 TEST(BinaryTranslatorE2E, ExpandLegalizationWithoutSemanticRuleFails) {

--- a/emulation/rocjitsu/tools/dbt_translate.cpp
+++ b/emulation/rocjitsu/tools/dbt_translate.cpp
@@ -60,7 +60,7 @@ void record_decode_failure(CodeSectionReport &section_report, size_t byte_offset
   if (!decoder) {
     if (include_disassembly)
       os << "decoder unavailable\n";
-    for (const auto *section : obj.code_sections()) {
+    for (const auto *section : obj.text_sections()) {
       CodeSectionReport section_report;
       section_report.name = section->name();
       section_report.size_bytes = section->size();
@@ -70,7 +70,7 @@ void record_decode_failure(CodeSectionReport &section_report, size_t byte_offset
     return inspection;
   }
 
-  for (const auto *section : obj.code_sections()) {
+  for (const auto *section : obj.text_sections()) {
     CodeSectionReport section_report;
     section_report.name = section->name();
     section_report.size_bytes = section->size();
@@ -180,9 +180,9 @@ void record_decode_failure(CodeSectionReport &section_report, size_t byte_offset
   if (text_sections.empty())
     return "<source section unavailable>";
 
-  // BinaryTranslator trace offsets are relative to the original .text section.
-  // Use text_sections() instead of code_sections() so the DBT cave never shifts
-  // source locations when a translated object is inspected again.
+  // BinaryTranslator source offsets are relative to the original .text section.
+  // Use the primary .text section so relocated local-cave bytes are not treated
+  // as source instructions when a translated object is inspected again.
   const auto *text = text_sections.front();
   if (offset % sizeof(uint32_t) != 0)
     return "<source offset unaligned>";

--- a/emulation/rocjitsu/tools/dbt_translate_main.cpp
+++ b/emulation/rocjitsu/tools/dbt_translate_main.cpp
@@ -372,7 +372,7 @@ count_semantic_lowerings(const std::vector<InstructionTranslationReport> &transl
 [[nodiscard]] std::string target_location(const InstructionTranslationReport &translation,
                                           size_t text_size) {
   if (translation.emitted_in_cave && translation.target_offset >= text_size)
-    return ".rj_translations+" + hex_offset(translation.target_offset - text_size);
+    return ".text(local-cave)+" + hex_offset(translation.target_offset);
   return ".text+" + hex_offset(translation.target_offset);
 }
 

--- a/emulation/rocjitsu/tools/dbt_translate_main.cpp
+++ b/emulation/rocjitsu/tools/dbt_translate_main.cpp
@@ -229,14 +229,6 @@ struct ReportTotals {
   return totals;
 }
 
-[[nodiscard]] size_t text_section_size(const CodeObjectReport &report) {
-  for (const auto &section : report.sections) {
-    if (section.name == ".text")
-      return section.size_bytes;
-  }
-  return 0;
-}
-
 [[nodiscard]] std::string hex_offset(uint64_t value) {
   std::ostringstream os;
   os << "0x" << std::hex << std::setw(4) << std::setfill('0') << value;
@@ -369,9 +361,8 @@ count_semantic_lowerings(const std::vector<InstructionTranslationReport> &transl
   return count;
 }
 
-[[nodiscard]] std::string target_location(const InstructionTranslationReport &translation,
-                                          size_t text_size) {
-  if (translation.emitted_in_cave && translation.target_offset >= text_size)
+[[nodiscard]] std::string target_location(const InstructionTranslationReport &translation) {
+  if (translation.emitted_in_cave)
     return ".text(local-cave)+" + hex_offset(translation.target_offset);
   return ".text+" + hex_offset(translation.target_offset);
 }
@@ -424,14 +415,13 @@ void print_instruction_translation_report(std::ostream &os, const TranslateOutpu
      << " illegal=" << count_action(translations, Action::Illegal)
      << " semantic=" << count_semantic_lowerings(translations) << "\n";
 
-  const size_t text_size = text_section_size(output.source_report);
   for (const auto &translation : translations) {
     if (!should_show_translation(translation))
       continue;
 
     os << "  " << hex_offset(translation.source_offset) << " "
        << translation_action_text(translation) << " .text+" << hex_offset(translation.source_offset)
-       << " -> " << target_location(translation, text_size) << "\n";
+       << " -> " << target_location(translation) << "\n";
     if (!translation.source_words.empty())
       os << "    source_words: " << words_text(translation.source_words) << "\n";
     os << "    source: " << translation.source_instruction << "\n";


### PR DESCRIPTION
This patch changes DBT to use local code caves instead of global code caves. Before this patch, the final output layout was:

```
.text
  [original kernel text]
.rj_translations
  [code caves]
```

There are two problems with this layout: 

1. If the original kernel text has multiple kernels, the code cave offset can exceed 16bits.
2. Some loaders only recognize .text as as the executable code section

The new local code cave layout changes this to:

```
.text
  [kernel 1 text]
  [kernel 1 code cave]
  [kernel 2 text]
  [kernel 2 code cave]
   ...  
```

Note that the new format does require relocating branch offsets. The reason we still use code caves is that before emission of the kernel to it's new offset, we exactly know the new relocation offset and can assign new branch offsets greedily instead of resolving them later. 

We currently handle pc-relative direct branches only (s_branch/s_cbranch), but no indirect branches (s_setpc, s_swappc). In a future patch we will handle indirect branches which can be statically resolved (usually device library calls that were linked in but not optimized), but we will not be able to handle arbitary indirect branches with the new way. This is a trade-off we have to make, because otherwise we have to use long jumps for code caves.