### PR TITLE
Change HSA access to RW for VaMap in IPCAttach

### DIFF
--- a/projects/clr/hipamd/src/hip_event_ipc.cpp
+++ b/projects/clr/hipamd/src/hip_event_ipc.cpp
@@ -264,7 +264,7 @@ hipError_t IPCEvent::OpenHandle(ihipIpcEventHandle_t* handle) {
     return hipErrorInvalidValue;
   }
 
-  if (!ipc_signal_->IpcImport(handle->ipc_signal_handle, IHIP_IPC_EVENT_HANDLE_SIZE, dev)) {
+  if (!ipc_signal_->IpcImport(handle->ipc_signal_handle, IHIP_IPC_EVENT_HANDLE_SIZE)) {
     delete ipc_signal_;
     ipc_signal_ = nullptr;
     return hipErrorInvalidValue;

--- a/projects/clr/rocclr/device/devsignal.hpp
+++ b/projects/clr/rocclr/device/devsignal.hpp
@@ -51,14 +51,10 @@ class Signal {
   virtual bool IpcExport(void* handle, size_t handle_size) { return false; }
 
   // Initializes this signal from an IPC handle (alternative to Init for imported signals)
-  virtual bool IpcImport(const void* handle, size_t handle_size,
-                         const amd::Device* dev = nullptr) { return false; }
+  virtual bool IpcImport(const void* handle, size_t handle_size) { return false; }
 
   // Return the handle to the underlying amd_signal_t object
   virtual void* getHandle() { return nullptr; }
-
-  // Return a GPU-accessible handle (may differ from getHandle for IPC signals)
-  virtual void* getGpuHandle() { return getHandle(); }
 };
 
 };  // namespace amd::device

--- a/projects/clr/rocclr/device/rocm/rocsignal.cpp
+++ b/projects/clr/rocclr/device/rocm/rocsignal.cpp
@@ -78,7 +78,7 @@ bool IpcSignal::IpcExport(void* handle, size_t handle_size) {
   return true;
 }
 
-bool IpcSignal::IpcImport(const void* handle, size_t handle_size, const amd::Device* dev) {
+bool IpcSignal::IpcImport(const void* handle, size_t handle_size) {
   if (handle_size < sizeof(hsa_amd_ipc_signal_t)) {
     return false;
   }
@@ -88,15 +88,6 @@ bool IpcSignal::IpcImport(const void* handle, size_t handle_size, const amd::Dev
   hsa_status_t status = Hsa::ipc_signal_attach(&ipc_handle, &signal_);
   if (status != HSA_STATUS_SUCCESS) {
     return false;
-  }
-
-  // Lock the imported signal memory for GPU access.
-  // The IPC signal is CPU-only after dma-buf import.
-  if (dev != nullptr) {
-    auto* rocDev = static_cast<const roc::Device*>(dev);
-    constexpr size_t kSignalAbiSize = 4096;
-    gpu_ptr_ = rocDev->hostLock(reinterpret_cast<void*>(signal_.handle),
-                                kSignalAbiSize, amd::Device::kNoAtomics);
   }
 
   ws_ = WaitState::Active;

--- a/projects/clr/rocclr/device/rocm/rocsignal.cpp
+++ b/projects/clr/rocclr/device/rocm/rocsignal.cpp
@@ -37,9 +37,6 @@ void Signal::Reset(uint64_t value) { Hsa::signal_store_screlease(signal_, value)
 // ================================================================================================
 
 IpcSignal::~IpcSignal() {
-  if (gpu_ptr_ != nullptr) {
-    Hsa::memory_unlock(reinterpret_cast<void*>(signal_.handle));
-  }
   if (signal_.handle != 0) {
     Hsa::signal_destroy(signal_);
   }

--- a/projects/clr/rocclr/device/rocm/rocsignal.hpp
+++ b/projects/clr/rocclr/device/rocm/rocsignal.hpp
@@ -44,12 +44,8 @@ class IpcSignal : public device::Signal {
   void Reset(uint64_t value) override;
   uint64_t Load() override;
   bool IpcExport(void* handle, size_t handle_size) override;
-  bool IpcImport(const void* handle, size_t handle_size,
-                 const amd::Device* dev = nullptr) override;
+  bool IpcImport(const void* handle, size_t handle_size) override;
   void* getHandle() override { return reinterpret_cast<void*>(signal_.handle); }
-  void* getGpuHandle() override {
-    return gpu_ptr_ ? gpu_ptr_ : reinterpret_cast<void*>(signal_.handle);
-  }
 };
 
 };  // namespace amd::roc

--- a/projects/clr/rocclr/device/rocm/rocsignal.hpp
+++ b/projects/clr/rocclr/device/rocm/rocsignal.hpp
@@ -32,7 +32,6 @@ class Signal : public device::Signal {
 class IpcSignal : public device::Signal {
  private:
   hsa_signal_t signal_;
-  void* gpu_ptr_ = nullptr;  // GPU-accessible pointer from memory_lock (if needed)
 
  public:
   IpcSignal() { signal_.handle = 0; }

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -4560,13 +4560,13 @@ void VirtualGPU::submitMarker(amd::Marker& vcmd) {
     hsa_signal_t ipc_s{0};
     if (vcmd.ipcCompletionSignal() != nullptr) {
       ipc_s.handle = static_cast<uint64_t>(
-          reinterpret_cast<uintptr_t>(vcmd.ipcCompletionSignal()->getGpuHandle()));
+          reinterpret_cast<uintptr_t>(vcmd.ipcCompletionSignal()->getHandle()));
     }
 
     if (vcmd.ipcDepSignal() != nullptr) {
       hsa_signal_t s;
       s.handle = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(
-          vcmd.ipcDepSignal()->getGpuHandle()));
+          vcmd.ipcDepSignal()->getHandle()));
       WaitCompleteSignal(s);
     } else if (timestamp_ != nullptr || ipc_s.handle != 0) {
       // IPC event record: if ipc_s is non-zero, first dispatch a NOP barrier with

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -1632,7 +1632,7 @@ hsa_status_t Runtime::IPCAttach(const hsa_amd_ipc_memory_t* handle, size_t len, 
       return errCleanup(bo);
     }
     status = HSAKMT_CALL(hsaKmtMemoryVaMap(bo, 0, static_cast<HSAuint64>(importSize),
-                                           reinterpret_cast<HSAuint64>(cpuPtr), HSA_MEMORY_ACCESS_NONE));
+                                           reinterpret_cast<HSAuint64>(cpuPtr), HSA_MEMORY_ACCESS_RW));
     if (status != HSAKMT_STATUS_SUCCESS) {
       return errCleanup(bo);
     }


### PR DESCRIPTION
## Motivation

Fixes the catch test Unit_hipGetProcAddress_IPC_Event on MI308X

## Technical Details

Change HSA access to RW instead of None so that the device can have read/write permissions to the imported pointer in another process. 

## JIRA ID

ROCM-24784

## Test Plan

Unit_hipGetProcAddress_IPC_Event should pass on all configs

## Test Result

PASS

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
