### PR TITLE
[rocshmem] Add tile-based broadcast and allgather for IPC backend

### DIFF
--- a/projects/rocshmem/scripts/functional_tests/driver.sh
+++ b/projects/rocshmem/scripts/functional_tests/driver.sh
@@ -145,6 +145,12 @@ declare -A TEST_NUMBERS=(
   ["host_int_amo_fcswap"]="128"
   ["host_amo_all_pes"]="129"
   ["host_amo_self"]="130"
+  ["tile_broadcast"]="131"
+  ["tile_broadcast_wave"]="132"
+  ["tile_broadcast_wg"]="133"
+  ["tile_allgather"]="134"
+  ["tile_allgather_wave"]="135"
+  ["tile_allgather_wg"]="136"
 )
 
 # Detect which runtime to use
@@ -877,6 +883,18 @@ TestTiles() {
   ExecTest  "tile_put_1d"               2       1            1
   ExecTest  "tile_get_1d"               2       1            1
   ExecTest  "tile_get_wave_contiguous"  2       1            $WAVE_SIZE
+  ExecTest  "tile_broadcast"            2       1            1
+  ExecTest  "tile_broadcast"            4       1            1
+  ExecTest  "tile_broadcast_wave"       2       1            $WAVE_SIZE
+  ExecTest  "tile_broadcast_wave"       4       1            $WAVE_SIZE
+  ExecTest  "tile_broadcast_wg"         2       4            $WAVE_SIZE
+  ExecTest  "tile_broadcast_wg"         4       4            $WAVE_SIZE
+  ExecTest  "tile_allgather"            2       1            1
+  ExecTest  "tile_allgather"            4       1            1
+  ExecTest  "tile_allgather_wave"       2       1            $WAVE_SIZE
+  ExecTest  "tile_allgather_wave"       4       1            $WAVE_SIZE
+  ExecTest  "tile_allgather_wg"         2       4            $WAVE_SIZE
+  ExecTest  "tile_allgather_wg"         4       4            $WAVE_SIZE
 }
 
 TestHeatMapRMA() {

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -1180,92 +1180,217 @@ __device__ inline int IPCContext::tile_get_wg(void* dst_data, const void* src_da
 }
 
 // Collective Allgather - Type-erased implementations
-__device__ inline int IPCContext::tile_allgather([[maybe_unused]] rocshmem_team_t team,
-                                                 [[maybe_unused]] void* dst_data,
-                                                 [[maybe_unused]] const void* src_data,
-                                                 [[maybe_unused]] const size_t* dst_strides,
-                                                 [[maybe_unused]] const size_t* src_strides,
-                                                 [[maybe_unused]] const size_t* start_coord,
-                                                 [[maybe_unused]] const size_t* boundary,
-                                                 [[maybe_unused]] int ndim,
-                                                 [[maybe_unused]] size_t element_size,
-                                                 [[maybe_unused]] uint64_t flags) {
-  LOGD_WARN("Tile API not implemented for IPC backend");
-  return ROCSHMEM_ERROR;
+__device__ inline int IPCContext::tile_allgather(rocshmem_team_t team,
+                                                 void* dst_data,
+                                                 const void* src_data,
+                                                 const size_t* dst_strides,
+                                                 const size_t* src_strides,
+                                                 const size_t* start_coord,
+                                                 const size_t* boundary,
+                                                 int ndim,
+                                                 size_t element_size,
+                                                 uint64_t flags) {
+  IPCTeam *team_obj = reinterpret_cast<IPCTeam *>(team);
+  int team_size = team_obj->num_pes;
+
+  // Calculate tile size for computing destination offsets
+  size_t tile_size = 1;
+  for (int dim = 0; dim < ndim; dim++) {
+    tile_size *= (boundary[dim] - start_coord[dim]);
+  }
+
+  // Each PE gathers tiles from all PEs in the team
+  for (int src_pe_in_team = 0; src_pe_in_team < team_size; src_pe_in_team++) {
+    int src_pe_world = team_obj->get_pe_in_world(src_pe_in_team);
+
+    // Compute destination offset for this PE's tile
+    // Destination layout: [PE0's tile][PE1's tile]...[PEn's tile]
+    char* dst_offset = static_cast<char*>(dst_data) + src_pe_in_team * tile_size * element_size;
+
+    // Use tile_get to fetch this PE's tile into the appropriate destination slot
+    int result = tile_get(dst_offset, src_data, dst_strides, src_strides, start_coord,
+                          boundary, ndim, element_size, src_pe_world, flags);
+    if (result != ROCSHMEM_SUCCESS) {
+      return result;
+    }
+  }
+
+  // Synchronize to ensure all PEs complete before any can modify buffers
+  sync(team);
+
+  return ROCSHMEM_SUCCESS;
 }
 
-__device__ inline int IPCContext::tile_allgather_wave([[maybe_unused]] rocshmem_team_t team,
-                                                      [[maybe_unused]] void* dst_data,
-                                                      [[maybe_unused]] const void* src_data,
-                                                      [[maybe_unused]] const size_t* dst_strides,
-                                                      [[maybe_unused]] const size_t* src_strides,
-                                                      [[maybe_unused]] const size_t* start_coord,
-                                                      [[maybe_unused]] const size_t* boundary,
-                                                      [[maybe_unused]] int ndim,
-                                                      [[maybe_unused]] size_t element_size,
-                                                      [[maybe_unused]] uint64_t flags) {
-  LOGD_WARN("Tile API not implemented for IPC backend");
-  return ROCSHMEM_ERROR;
+__device__ inline int IPCContext::tile_allgather_wave(rocshmem_team_t team,
+                                                      void* dst_data,
+                                                      const void* src_data,
+                                                      const size_t* dst_strides,
+                                                      const size_t* src_strides,
+                                                      const size_t* start_coord,
+                                                      const size_t* boundary,
+                                                      int ndim,
+                                                      size_t element_size,
+                                                      uint64_t flags) {
+  IPCTeam *team_obj = reinterpret_cast<IPCTeam *>(team);
+  int team_size = team_obj->num_pes;
+
+  // Calculate tile size for computing destination offsets
+  size_t tile_size = 1;
+  for (int dim = 0; dim < ndim; dim++) {
+    tile_size *= (boundary[dim] - start_coord[dim]);
+  }
+
+  // Each PE gathers tiles from all PEs in the team (wave-collective)
+  for (int src_pe_in_team = 0; src_pe_in_team < team_size; src_pe_in_team++) {
+    int src_pe_world = team_obj->get_pe_in_world(src_pe_in_team);
+
+    // Compute destination offset for this PE's tile
+    char* dst_offset = static_cast<char*>(dst_data) + src_pe_in_team * tile_size * element_size;
+
+    // Use tile_get_wave to fetch this PE's tile
+    int result = tile_get_wave(dst_offset, src_data, dst_strides, src_strides, start_coord,
+                                boundary, ndim, element_size, src_pe_world, flags);
+    if (result != ROCSHMEM_SUCCESS) {
+      return result;
+    }
+  }
+
+  // Synchronize to ensure all PEs complete
+  sync_wave(team);
+
+  return ROCSHMEM_SUCCESS;
 }
 
-__device__ inline int IPCContext::tile_allgather_wg([[maybe_unused]] rocshmem_team_t team,
-                                                    [[maybe_unused]] void* dst_data,
-                                                    [[maybe_unused]] const void* src_data,
-                                                    [[maybe_unused]] const size_t* dst_strides,
-                                                    [[maybe_unused]] const size_t* src_strides,
-                                                    [[maybe_unused]] const size_t* start_coord,
-                                                    [[maybe_unused]] const size_t* boundary,
-                                                    [[maybe_unused]] int ndim,
-                                                    [[maybe_unused]] size_t element_size,
-                                                    [[maybe_unused]] uint64_t flags) {
-  LOGD_WARN("Tile API not implemented for IPC backend");
-  return ROCSHMEM_ERROR;
+__device__ inline int IPCContext::tile_allgather_wg(rocshmem_team_t team,
+                                                    void* dst_data,
+                                                    const void* src_data,
+                                                    const size_t* dst_strides,
+                                                    const size_t* src_strides,
+                                                    const size_t* start_coord,
+                                                    const size_t* boundary,
+                                                    int ndim,
+                                                    size_t element_size,
+                                                    uint64_t flags) {
+  IPCTeam *team_obj = reinterpret_cast<IPCTeam *>(team);
+  int team_size = team_obj->num_pes;
+
+  // Calculate tile size for computing destination offsets
+  size_t tile_size = 1;
+  for (int dim = 0; dim < ndim; dim++) {
+    tile_size *= (boundary[dim] - start_coord[dim]);
+  }
+
+  // Each PE gathers tiles from all PEs in the team (workgroup-collective)
+  for (int src_pe_in_team = 0; src_pe_in_team < team_size; src_pe_in_team++) {
+    int src_pe_world = team_obj->get_pe_in_world(src_pe_in_team);
+
+    // Compute destination offset for this PE's tile
+    char* dst_offset = static_cast<char*>(dst_data) + src_pe_in_team * tile_size * element_size;
+
+    // Use tile_get_wg to fetch this PE's tile
+    int result = tile_get_wg(dst_offset, src_data, dst_strides, src_strides, start_coord,
+                              boundary, ndim, element_size, src_pe_world, flags);
+    if (result != ROCSHMEM_SUCCESS) {
+      return result;
+    }
+  }
+
+  // Synchronize to ensure all PEs complete
+  sync_wg(team);
+
+  return ROCSHMEM_SUCCESS;
 }
 
 // Collective Broadcast - Type-erased implementations
-__device__ inline int IPCContext::tile_broadcast([[maybe_unused]] rocshmem_team_t team,
-                                                 [[maybe_unused]] void* dst_data,
-                                                 [[maybe_unused]] const void* src_data,
-                                                 [[maybe_unused]] const size_t* dst_strides,
-                                                 [[maybe_unused]] const size_t* src_strides,
-                                                 [[maybe_unused]] const size_t* start_coord,
-                                                 [[maybe_unused]] const size_t* boundary,
-                                                 [[maybe_unused]] int ndim,
-                                                 [[maybe_unused]] size_t element_size,
-                                                 [[maybe_unused]] int pe_root,
-                                                 [[maybe_unused]] uint64_t flags) {
-  LOGD_WARN("Tile API not implemented for IPC backend");
-  return ROCSHMEM_ERROR;
+__device__ inline int IPCContext::tile_broadcast(rocshmem_team_t team,
+                                                 void* dst_data,
+                                                 const void* src_data,
+                                                 const size_t* dst_strides,
+                                                 const size_t* src_strides,
+                                                 const size_t* start_coord,
+                                                 const size_t* boundary,
+                                                 int ndim,
+                                                 size_t element_size,
+                                                 int pe_root,
+                                                 uint64_t flags) {
+  IPCTeam *team_obj = reinterpret_cast<IPCTeam *>(team);
+  int my_pe_in_team = team_obj->my_pe;
+  int root_pe_world = team_obj->get_pe_in_world(pe_root);
+
+  // Non-root PEs fetch tile from root using GET
+  if (my_pe_in_team != pe_root) {
+    int result = tile_get(dst_data, src_data, dst_strides, src_strides, start_coord,
+                          boundary, ndim, element_size, root_pe_world, flags);
+    if (result != ROCSHMEM_SUCCESS) {
+      return result;
+    }
+  }
+  // Note: Root PE's data is already in src, no need to copy to dst unless src != dst
+
+  // Synchronize to ensure all PEs complete before root can modify buffer
+  sync(team);
+
+  return ROCSHMEM_SUCCESS;
 }
 
-__device__ inline int IPCContext::tile_broadcast_wave([[maybe_unused]] rocshmem_team_t team,
-                                                      [[maybe_unused]] void* dst_data,
-                                                      [[maybe_unused]] const void* src_data,
-                                                      [[maybe_unused]] const size_t* dst_strides,
-                                                      [[maybe_unused]] const size_t* src_strides,
-                                                      [[maybe_unused]] const size_t* start_coord,
-                                                      [[maybe_unused]] const size_t* boundary,
-                                                      [[maybe_unused]] int ndim,
-                                                      [[maybe_unused]] size_t element_size,
-                                                      [[maybe_unused]] int pe_root,
-                                                      [[maybe_unused]] uint64_t flags) {
-  LOGD_WARN("Tile API not implemented for IPC backend");
-  return ROCSHMEM_ERROR;
+__device__ inline int IPCContext::tile_broadcast_wave(rocshmem_team_t team,
+                                                      void* dst_data,
+                                                      const void* src_data,
+                                                      const size_t* dst_strides,
+                                                      const size_t* src_strides,
+                                                      const size_t* start_coord,
+                                                      const size_t* boundary,
+                                                      int ndim,
+                                                      size_t element_size,
+                                                      int pe_root,
+                                                      uint64_t flags) {
+  IPCTeam *team_obj = reinterpret_cast<IPCTeam *>(team);
+  int my_pe_in_team = team_obj->my_pe;
+  int root_pe_world = team_obj->get_pe_in_world(pe_root);
+
+  // Non-root PEs fetch tile from root using GET (wave-collective)
+  if (my_pe_in_team != pe_root) {
+    int result = tile_get_wave(dst_data, src_data, dst_strides, src_strides, start_coord,
+                                boundary, ndim, element_size, root_pe_world, flags);
+    if (result != ROCSHMEM_SUCCESS) {
+      return result;
+    }
+  }
+
+  // Synchronize to ensure all PEs complete before root can modify buffer
+  sync_wave(team);
+
+  return ROCSHMEM_SUCCESS;
 }
 
-__device__ inline int IPCContext::tile_broadcast_wg([[maybe_unused]] rocshmem_team_t team,
-                                                    [[maybe_unused]] void* dst_data,
-                                                    [[maybe_unused]] const void* src_data,
-                                                    [[maybe_unused]] const size_t* dst_strides,
-                                                    [[maybe_unused]] const size_t* src_strides,
-                                                    [[maybe_unused]] const size_t* start_coord,
-                                                    [[maybe_unused]] const size_t* boundary,
-                                                    [[maybe_unused]] int ndim,
-                                                    [[maybe_unused]] size_t element_size,
-                                                    [[maybe_unused]] int pe_root,
-                                                    [[maybe_unused]] uint64_t flags) {
-  LOGD_WARN("Tile API not implemented for IPC backend");
-  return ROCSHMEM_ERROR;
+__device__ inline int IPCContext::tile_broadcast_wg(rocshmem_team_t team,
+                                                    void* dst_data,
+                                                    const void* src_data,
+                                                    const size_t* dst_strides,
+                                                    const size_t* src_strides,
+                                                    const size_t* start_coord,
+                                                    const size_t* boundary,
+                                                    int ndim,
+                                                    size_t element_size,
+                                                    int pe_root,
+                                                    uint64_t flags) {
+  IPCTeam *team_obj = reinterpret_cast<IPCTeam *>(team);
+  int my_pe_in_team = team_obj->my_pe;
+  int root_pe_world = team_obj->get_pe_in_world(pe_root);
+
+  // Non-root PEs fetch tile from root using GET (workgroup-collective)
+  if (my_pe_in_team != pe_root) {
+    int result = tile_get_wg(dst_data, src_data, dst_strides, src_strides, start_coord,
+                              boundary, ndim, element_size, root_pe_world, flags);
+    if (result != ROCSHMEM_SUCCESS) {
+      return result;
+    }
+  }
+
+  // Synchronize to ensure all PEs complete before root can modify buffer
+  sync_wg(team);
+
+  return ROCSHMEM_SUCCESS;
 }
 
 // SUM Reductions - Type-erased implementations

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -1193,19 +1193,18 @@ __device__ inline int IPCContext::tile_allgather(rocshmem_team_t team,
   IPCTeam *team_obj = reinterpret_cast<IPCTeam *>(team);
   int team_size = team_obj->num_pes;
 
-  // Calculate tile size for computing destination offsets
-  size_t tile_size = 1;
-  for (int dim = 0; dim < ndim; dim++) {
-    tile_size *= (boundary[dim] - start_coord[dim]);
-  }
+  // Calculate tile extent along dimension 0
+  size_t tile_extent_dim0 = boundary[0] - start_coord[0];
 
   // Each PE gathers tiles from all PEs in the team
   for (int src_pe_in_team = 0; src_pe_in_team < team_size; src_pe_in_team++) {
     int src_pe_world = team_obj->get_pe_in_world(src_pe_in_team);
 
-    // Compute destination offset for this PE's tile
+    // Compute destination offset for this PE's tile using dst_strides[0]
+    // Stack tiles along dimension 0: each PE's tile is offset by tile_extent_dim0 * dst_strides[0]
     // Destination layout: [PE0's tile][PE1's tile]...[PEn's tile]
-    char* dst_offset = static_cast<char*>(dst_data) + src_pe_in_team * tile_size * element_size;
+    char* dst_offset = static_cast<char*>(dst_data) +
+                       src_pe_in_team * tile_extent_dim0 * dst_strides[0] * element_size;
 
     // Use tile_get to fetch this PE's tile into the appropriate destination slot
     int result = tile_get(dst_offset, src_data, dst_strides, src_strides, start_coord,
@@ -1234,18 +1233,17 @@ __device__ inline int IPCContext::tile_allgather_wave(rocshmem_team_t team,
   IPCTeam *team_obj = reinterpret_cast<IPCTeam *>(team);
   int team_size = team_obj->num_pes;
 
-  // Calculate tile size for computing destination offsets
-  size_t tile_size = 1;
-  for (int dim = 0; dim < ndim; dim++) {
-    tile_size *= (boundary[dim] - start_coord[dim]);
-  }
+  // Calculate tile extent along dimension 0
+  size_t tile_extent_dim0 = boundary[0] - start_coord[0];
 
   // Each PE gathers tiles from all PEs in the team (wave-collective)
   for (int src_pe_in_team = 0; src_pe_in_team < team_size; src_pe_in_team++) {
     int src_pe_world = team_obj->get_pe_in_world(src_pe_in_team);
 
-    // Compute destination offset for this PE's tile
-    char* dst_offset = static_cast<char*>(dst_data) + src_pe_in_team * tile_size * element_size;
+    // Compute destination offset for this PE's tile using dst_strides[0]
+    // Stack tiles along dimension 0: each PE's tile is offset by tile_extent_dim0 * dst_strides[0]
+    char* dst_offset = static_cast<char*>(dst_data) +
+                       src_pe_in_team * tile_extent_dim0 * dst_strides[0] * element_size;
 
     // Use tile_get_wave to fetch this PE's tile
     int result = tile_get_wave(dst_offset, src_data, dst_strides, src_strides, start_coord,
@@ -1274,18 +1272,17 @@ __device__ inline int IPCContext::tile_allgather_wg(rocshmem_team_t team,
   IPCTeam *team_obj = reinterpret_cast<IPCTeam *>(team);
   int team_size = team_obj->num_pes;
 
-  // Calculate tile size for computing destination offsets
-  size_t tile_size = 1;
-  for (int dim = 0; dim < ndim; dim++) {
-    tile_size *= (boundary[dim] - start_coord[dim]);
-  }
+  // Calculate tile extent along dimension 0
+  size_t tile_extent_dim0 = boundary[0] - start_coord[0];
 
   // Each PE gathers tiles from all PEs in the team (workgroup-collective)
   for (int src_pe_in_team = 0; src_pe_in_team < team_size; src_pe_in_team++) {
     int src_pe_world = team_obj->get_pe_in_world(src_pe_in_team);
 
-    // Compute destination offset for this PE's tile
-    char* dst_offset = static_cast<char*>(dst_data) + src_pe_in_team * tile_size * element_size;
+    // Compute destination offset for this PE's tile using dst_strides[0]
+    // Stack tiles along dimension 0: each PE's tile is offset by tile_extent_dim0 * dst_strides[0]
+    char* dst_offset = static_cast<char*>(dst_data) +
+                       src_pe_in_team * tile_extent_dim0 * dst_strides[0] * element_size;
 
     // Use tile_get_wg to fetch this PE's tile
     int result = tile_get_wg(dst_offset, src_data, dst_strides, src_strides, start_coord,

--- a/projects/rocshmem/tests/functional_tests/CMakeLists.txt
+++ b/projects/rocshmem/tests/functional_tests/CMakeLists.txt
@@ -76,6 +76,8 @@ target_sources(
     tile_rma_tester.cpp
     host_team_sync_barrier_tester.cpp
     host_rma_tester.cpp
+    tile_broadcast_tester.cpp
+    tile_allgather_tester.cpp
 )
 
 ###############################################################################

--- a/projects/rocshmem/tests/functional_tests/CTestFunctionalTests.cmake
+++ b/projects/rocshmem/tests/functional_tests/CTestFunctionalTests.cmake
@@ -135,16 +135,23 @@ set(TEST_tile_get_arbitrary 116)
 set(TEST_reduce_on_stream 117)
 set(TEST_host_ctx_create 118)
 set(TEST_teamsplit2d 119)
-set(TEST_host_putmem 120)
-set(TEST_host_getmem 121)
-set(TEST_host_amo_fadd 122)
-set(TEST_host_amo_fcswap 123)
-set(TEST_host_ctx_putmem 124)
-set(TEST_host_ctx_getmem 125)
-set(TEST_host_int_amo_fadd 126)
-set(TEST_host_int_amo_fcswap 127)
-set(TEST_host_amo_all_pes 128)
-set(TEST_host_amo_self 129)
+set(TEST_hostteamsyncbarrier 120)
+set(TEST_host_putmem 121)
+set(TEST_host_getmem 122)
+set(TEST_host_amo_fadd 123)
+set(TEST_host_amo_fcswap 124)
+set(TEST_host_ctx_putmem 125)
+set(TEST_host_ctx_getmem 126)
+set(TEST_host_int_amo_fadd 127)
+set(TEST_host_int_amo_fcswap 128)
+set(TEST_host_amo_all_pes 129)
+set(TEST_host_amo_self 130)
+set(TEST_tile_broadcast 131)
+set(TEST_tile_broadcast_wave 132)
+set(TEST_tile_broadcast_wg 133)
+set(TEST_tile_allgather 134)
+set(TEST_tile_allgather_wave 135)
+set(TEST_tile_allgather_wg 136)
 
 # MPI should already be found by the parent CMakeLists.txt
 # Use standard CMake MPI variables set by find_package(MPI)
@@ -1017,6 +1024,11 @@ function(add_coll_tests)
         add_rocshmem_functional_test(NAME fcollect RANKS 2 WORKGROUPS 1 THREADS 64 MAX_MSG_SIZE 32768)
         add_rocshmem_functional_test(NAME teamreduction RANKS 2 WORKGROUPS 1 THREADS 64 MAX_MSG_SIZE 32768)
     end_test_group()
+
+    # Team split 2D test - requires exactly 4 PEs
+    begin_test_group(CATEGORY "COLLECTIVE;TEAM" TIER comprehensive BACKENDS "all" GPUS "all")
+        add_rocshmem_functional_test(NAME teamsplit2d RANKS 4 WORKGROUPS 1 THREADS 1)
+    end_test_group()
 endfunction()
 
 # Stream Tests
@@ -1228,6 +1240,31 @@ function(add_tile_tests)
         add_rocshmem_functional_test(NAME tile_get_wave_contiguous RANKS 2 WORKGROUPS 1 THREADS 64)
         add_rocshmem_functional_test(NAME tile_get_wg_contiguous RANKS 2 WORKGROUPS 1 THREADS 1024)
         add_rocshmem_functional_test(NAME tile_get_wg_contiguous RANKS 2 WORKGROUPS 4 THREADS 1024)
+    end_test_group()
+
+    # Tile collective tests (broadcast and allgather)
+    begin_test_group(CATEGORY "TILE;COLLECTIVE;BROADCAST" TIER comprehensive BACKENDS "ipc" GPUS "all")
+        # Thread-level broadcast - test with 2 and 4 PEs
+        add_rocshmem_functional_test(NAME tile_broadcast RANKS 2 WORKGROUPS 1 THREADS 1)
+        add_rocshmem_functional_test(NAME tile_broadcast RANKS 4 WORKGROUPS 1 THREADS 1)
+        # Wave-level broadcast
+        add_rocshmem_functional_test(NAME tile_broadcast_wave RANKS 2 WORKGROUPS 1 THREADS 64)
+        add_rocshmem_functional_test(NAME tile_broadcast_wave RANKS 4 WORKGROUPS 1 THREADS 64)
+        # Workgroup-level broadcast
+        add_rocshmem_functional_test(NAME tile_broadcast_wg RANKS 2 WORKGROUPS 1 THREADS 1024)
+        add_rocshmem_functional_test(NAME tile_broadcast_wg RANKS 4 WORKGROUPS 1 THREADS 1024)
+    end_test_group()
+
+    begin_test_group(CATEGORY "TILE;COLLECTIVE;ALLGATHER" TIER comprehensive BACKENDS "ipc" GPUS "all")
+        # Thread-level allgather - test with 2 and 4 PEs
+        add_rocshmem_functional_test(NAME tile_allgather RANKS 2 WORKGROUPS 1 THREADS 1)
+        add_rocshmem_functional_test(NAME tile_allgather RANKS 4 WORKGROUPS 1 THREADS 1)
+        # Wave-level allgather
+        add_rocshmem_functional_test(NAME tile_allgather_wave RANKS 2 WORKGROUPS 1 THREADS 64)
+        add_rocshmem_functional_test(NAME tile_allgather_wave RANKS 4 WORKGROUPS 1 THREADS 64)
+        # Workgroup-level allgather
+        add_rocshmem_functional_test(NAME tile_allgather_wg RANKS 2 WORKGROUPS 1 THREADS 1024)
+        add_rocshmem_functional_test(NAME tile_allgather_wg RANKS 4 WORKGROUPS 1 THREADS 1024)
     end_test_group()
 endfunction()
 

--- a/projects/rocshmem/tests/functional_tests/tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/tester.cpp
@@ -72,6 +72,8 @@
 #include "library_info_tester.hpp"
 #include "fence_ordering_tester.hpp"
 #include "tile_rma_tester.hpp"
+#include "tile_broadcast_tester.hpp"
+#include "tile_allgather_tester.hpp"
 #include "reduce_on_stream_tester.hpp"
 #include "host_ctx_create_tester.hpp"
 #include "team_split_2d_tester.hpp"
@@ -774,6 +776,30 @@ std::vector<Tester*> Tester::create(TesterArguments args) {
       test_name = "Team Split 2D";
       testers.push_back(new TeamSplit2DTester(args));
       break;
+    case TileBroadcastTestType:
+      test_name = "Tile Broadcast";
+      testers.push_back(new TileBroadcastTester(args));
+      break;
+    case TileBroadcastWaveTestType:
+      test_name = "Tile Broadcast Wave-Collective";
+      testers.push_back(new TileBroadcastTester(args));
+      break;
+    case TileBroadcastWGTestType:
+      test_name = "Tile Broadcast Workgroup-Collective";
+      testers.push_back(new TileBroadcastTester(args));
+      break;
+    case TileAllgatherTestType:
+      test_name = "Tile Allgather";
+      testers.push_back(new TileAllgatherTester(args));
+      break;
+    case TileAllgatherWaveTestType:
+      test_name = "Tile Allgather Wave-Collective";
+      testers.push_back(new TileAllgatherTester(args));
+      break;
+    case TileAllgatherWGTestType:
+      test_name = "Tile Allgather Workgroup-Collective";
+      testers.push_back(new TileAllgatherTester(args));
+      break;
     default:
       test_name = "Empty";
       break;
@@ -929,6 +955,12 @@ bool Tester::peLaunchesKernel() {
     case FenceOrderPutLargeSmallTestType:
     case FenceOrderFanoutTestType:
     case FenceOrderPutWaveNbiChunksTestType:
+    case TileBroadcastTestType:
+    case TileBroadcastWaveTestType:
+    case TileBroadcastWGTestType:
+    case TileAllgatherTestType:
+    case TileAllgatherWaveTestType:
+    case TileAllgatherWGTestType:
       is_launcher = true;
       break;
     case HostPutmemTestType:

--- a/projects/rocshmem/tests/functional_tests/tester.hpp
+++ b/projects/rocshmem/tests/functional_tests/tester.hpp
@@ -172,8 +172,13 @@
   X(HostIntAmoFAdd,            127)  \
   X(HostIntAmoFCswap,          128)  \
   X(HostAmoAllPes,             129)  \
-  X(HostAmoSelf,               130)
-
+  X(HostAmoSelf,               130)  \
+  X(TileBroadcast,             131)  \
+  X(TileBroadcastWave,         132)  \
+  X(TileBroadcastWG,           133)  \
+  X(TileAllgather,             134)  \
+  X(TileAllgatherWave,         135)  \
+  X(TileAllgatherWG,           136)
 #define _ROCSHMEM_ENUM_ENTRY(name, val) name##TestType = val,
 enum TestType {
   ROCSHMEM_FOREACH_TEST_TYPE(_ROCSHMEM_ENUM_ENTRY)

--- a/projects/rocshmem/tests/functional_tests/tester_arguments.cpp
+++ b/projects/rocshmem/tests/functional_tests/tester_arguments.cpp
@@ -319,6 +319,13 @@ void TesterArguments::get_arguments() {
     case HostTeamSyncBarrierTestType:
     case HostAmoAllPesTestType:
     case HostAmoSelfTestType:
+    // Tile collective tests - support any number of PEs
+    case TileBroadcastTestType:
+    case TileBroadcastWaveTestType:
+    case TileBroadcastWGTestType:
+    case TileAllgatherTestType:
+    case TileAllgatherWaveTestType:
+    case TileAllgatherWGTestType:
       requires_two_pes = false;
       break;
     default:

--- a/projects/rocshmem/tests/functional_tests/tile_allgather_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/tile_allgather_tester.cpp
@@ -1,0 +1,375 @@
+/******************************************************************************
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#include "tile_allgather_tester.hpp"
+
+#include <rocshmem/rocshmem.hpp>
+
+// Include internal context types before the tile API implementations
+#include "../../src/context_incl.hpp"
+
+// Include tile API template implementations
+#include <rocshmem/rocshmem_TILE_impl.hpp>
+
+using namespace rocshmem;
+
+/******************************************************************************
+ * TENSOR HELPERS
+ *****************************************************************************/
+
+// Simple 2D tensor implementation for testing
+template <typename T>
+struct Tensor2D {
+  using element_type = T;
+  static constexpr int ndim = 2;
+
+  T* data;
+  int rows;
+  int cols;
+  int row_stride;
+  int col_stride;
+
+  __device__ Tensor2D(T* data_, int rows_, int cols_,
+                      int row_stride_ = -1, int col_stride_ = 1)
+      : data(data_), rows(rows_), cols(cols_), col_stride(col_stride_) {
+    // Default row_stride is cols (contiguous row-major layout)
+    row_stride = (row_stride_ == -1) ? cols : row_stride_;
+  }
+
+  __device__ T* data_handle() const { return data; }
+  __device__ int stride(int dim) const {
+    return (dim == 0) ? row_stride : col_stride;
+  }
+};
+
+// Simple tuple for coordinates
+struct Tuple2D {
+  int x, y;
+  __device__ Tuple2D(int x_, int y_) : x(x_), y(y_) {}
+  __device__ int get(int dim) const { return (dim == 0) ? x : y; }
+};
+
+/******************************************************************************
+ * DEVICE TEST KERNELS
+ *****************************************************************************/
+
+// Thread-level allgather test - single WG, single wave
+__global__ void TileAllgatherThreadTest(rocshmem_team_t team,
+                                        float *source, float *dest,
+                                        int tile_extent_0, int tile_extent_1,
+                                        int my_world_pe, int n_pes,
+                                        ShmemContextType ctx_type,
+                                        int *error_flag) {
+  __shared__ rocshmem_ctx_t ctx;
+
+  // Create context from team (single WG)
+  rocshmem_wg_team_create_ctx(team, ctx_type, &ctx);
+
+  // Each PE has one source tile, and receives n_pes tiles in dest
+  int tile_size = tile_extent_0 * tile_extent_1;
+
+  Tensor2D<float> src_tensor(source, tile_extent_0, tile_extent_1);
+  Tensor2D<float> dst_tensor(dest, tile_extent_0 * n_pes, tile_extent_1);
+  Tuple2D start(0, 0);
+  Tuple2D boundary(tile_extent_0, tile_extent_1);
+
+  // Only thread 0 performs allgather
+  if (threadIdx.x == 0) {
+    rocshmem_ctx_tile_allgather(ctx, team, dst_tensor, src_tensor,
+                                start, boundary, 0);
+  }
+  __syncthreads();
+
+  // Verify results: each PE should have all tiles from all PEs
+  if (threadIdx.x == 0) {
+    for (int pe = 0; pe < n_pes; pe++) {
+      int offset = pe * tile_size;
+      for (int idx = 0; idx < tile_size; idx++) {
+        float expected = pe * 100.0f + idx;
+        float actual = dest[offset + idx];
+        if (actual != expected) {
+          printf("Thread-level: PE %d verification failed for PE %d's data at [%d]: got %f, expected %f\n",
+                 my_world_pe, pe, idx, actual, expected);
+          *error_flag = 1;
+        }
+      }
+    }
+  }
+
+  __syncthreads();
+  rocshmem_wg_ctx_destroy(&ctx);
+}
+
+// Wave-level allgather test - single WG, single wave
+__global__ void TileAllgatherWaveTest(rocshmem_team_t team,
+                                      float *source, float *dest,
+                                      int tile_extent_0, int tile_extent_1,
+                                      int my_world_pe, int n_pes,
+                                      ShmemContextType ctx_type,
+                                      int wf_size,
+                                      int *error_flag) {
+  __shared__ rocshmem_ctx_t ctx;
+
+  // Create context from team
+  rocshmem_wg_team_create_ctx(team, ctx_type, &ctx);
+
+  int tile_size = tile_extent_0 * tile_extent_1;
+
+  Tensor2D<float> src_tensor(source, tile_extent_0, tile_extent_1);
+  Tensor2D<float> dst_tensor(dest, tile_extent_0 * n_pes, tile_extent_1);
+  Tuple2D start(0, 0);
+  Tuple2D boundary(tile_extent_0, tile_extent_1);
+
+  // Only first wave performs allgather
+  if (threadIdx.x < wf_size) {
+    rocshmem_ctx_tile_allgather_wave(ctx, team, dst_tensor, src_tensor,
+                                     start, boundary, 0);
+  }
+  __syncthreads();
+
+  // Verify on thread 0
+  if (threadIdx.x == 0) {
+    for (int pe = 0; pe < n_pes; pe++) {
+      int offset = pe * tile_size;
+      for (int idx = 0; idx < tile_size; idx++) {
+        float expected = pe * 100.0f + idx;
+        float actual = dest[offset + idx];
+        if (actual != expected) {
+          printf("Wave-level: PE %d verification failed for PE %d's data at [%d]: got %f, expected %f\n",
+                 my_world_pe, pe, idx, actual, expected);
+          *error_flag = 1;
+        }
+      }
+    }
+  }
+
+  __syncthreads();
+  rocshmem_wg_ctx_destroy(&ctx);
+}
+
+// Workgroup-level allgather test - multiple WGs with different teams
+__global__ void TileAllgatherTest(rocshmem_team_t *teams, int num_teams,
+                                   float *source, float *dest,
+                                   int tile_extent_0, int tile_extent_1,
+                                   int my_world_pe, int n_pes,
+                                   ShmemContextType ctx_type,
+                                   int *error_flag) {
+  __shared__ rocshmem_ctx_t ctx;
+  int wg_id = get_flat_grid_id();
+
+  // Each workgroup uses a DIFFERENT team
+  rocshmem_team_t my_team = teams[wg_id % num_teams];
+
+  // Create context from this workgroup's specific team
+  rocshmem_wg_team_create_ctx(my_team, ctx_type, &ctx);
+
+  // Calculate offset for this workgroup's tiles
+  int tile_size = tile_extent_0 * tile_extent_1;
+  int src_offset = tile_size * wg_id;
+  int dst_offset = tile_size * n_pes * wg_id;
+
+  // Create tensors for source (one tile) and destination (n_pes tiles)
+  Tensor2D<float> src_tensor(source + src_offset, tile_extent_0, tile_extent_1);
+  Tensor2D<float> dst_tensor(dest + dst_offset, tile_extent_0 * n_pes, tile_extent_1);
+  Tuple2D start(0, 0);
+  Tuple2D boundary(tile_extent_0, tile_extent_1);
+
+  // Perform tile allgather - each PE contributes its tile, all PEs receive all tiles
+  rocshmem_ctx_tile_allgather_wg(ctx, my_team, dst_tensor, src_tensor,
+                                  start, boundary, 0);
+
+  __syncthreads();
+
+  // Verify results: each PE should have received all tiles from all PEs
+  if (threadIdx.x == 0) {
+    for (int pe = 0; pe < n_pes; pe++) {
+      // Each PE's data is: pe * 100 + wg_id * 1000 + element_index
+      int pe_offset = pe * tile_size;
+      for (int i = 0; i < tile_extent_0; i++) {
+        for (int j = 0; j < tile_extent_1; j++) {
+          int idx = i * tile_extent_1 + j;
+          float expected = pe * 100.0f + wg_id * 1000.0f + idx;
+          float actual = dest[dst_offset + pe_offset + idx];
+          if (actual != expected) {
+            printf("WG %d: PE %d verification failed for PE %d's data at [%d,%d]: got %f, expected %f\n",
+                   wg_id, my_world_pe, pe, i, j, actual, expected);
+            *error_flag = 1;
+          }
+        }
+      }
+    }
+  }
+
+  __syncthreads();
+
+  // Team barrier - each workgroup synchronizes on its own team
+  rocshmem_ctx_sync_wg(ctx, my_team);
+
+  rocshmem_wg_ctx_destroy(&ctx);
+}
+
+/******************************************************************************
+ * HOST TESTER CLASS METHODS
+ *****************************************************************************/
+TileAllgatherTester::TileAllgatherTester(TesterArguments args)
+    : Tester(args) {
+  num_teams = 4;  // Default to 4 teams
+
+  // Allocate teams using hipHostMalloc
+  CHECK_HIP(hipHostMalloc(&teams, num_teams * sizeof(rocshmem_team_t)));
+
+  // Allocate tile data
+  tile_extent_0 = 8;  // Default tile size
+  tile_extent_1 = 8;
+  int tile_size = tile_extent_0 * tile_extent_1;
+  int n_pes = rocshmem_n_pes();
+
+  // Each workgroup needs: 1 source tile + n_pes destination tiles
+  int total_src_size = tile_size * num_teams;
+  int total_dst_size = tile_size * n_pes * num_teams;
+
+  source = (float *)rocshmem_malloc(total_src_size * sizeof(float));
+  dest = (float *)rocshmem_malloc(total_dst_size * sizeof(float));
+
+  if (!source || !dest) {
+    fprintf(stderr, "Failed to allocate symmetric memory for tiles\n");
+    exit(EXIT_FAILURE);
+  }
+
+  // Allocate error flag
+  CHECK_HIP(hipMalloc(&error_flag, sizeof(int)));
+}
+
+TileAllgatherTester::~TileAllgatherTester() {
+  rocshmem_free(source);
+  rocshmem_free(dest);
+  CHECK_HIP(hipFree(error_flag));
+
+  // Destroy teams
+  for (int i = 0; i < num_teams; i++) {
+    if (teams[i] != ROCSHMEM_TEAM_INVALID) {
+      rocshmem_team_destroy(teams[i]);
+    }
+  }
+  CHECK_HIP(hipHostFree(teams));
+}
+
+void TileAllgatherTester::resetBuffers([[maybe_unused]] size_t size) {
+  int tile_size = tile_extent_0 * tile_extent_1;
+  int n_pes = rocshmem_n_pes();
+  int total_src_size = tile_size * num_teams;
+  int total_dst_size = tile_size * n_pes * num_teams;
+
+  // Initialize source data: each PE's data is pe * 100 + wg_id * 1000 + element_index
+  for (int wg = 0; wg < num_teams; wg++) {
+    int offset = wg * tile_size;
+    for (int i = 0; i < tile_size; i++) {
+      source[offset + i] = args.myid * 100.0f + wg * 1000.0f + i;
+    }
+  }
+
+  // Initialize dest to invalid value
+  for (int i = 0; i < total_dst_size; i++) {
+    dest[i] = -1.0f;
+  }
+
+  // Reset error flag
+  int zero = 0;
+  CHECK_HIP(hipMemcpy(error_flag, &zero, sizeof(int), hipMemcpyHostToDevice));
+}
+
+void TileAllgatherTester::preLaunchKernel() {
+  int n_pes = rocshmem_n_pes();
+
+  if (_type == TileAllgatherWGTestType) {
+    // Multi-team case: Create multiple duplicate teams (all PEs are members of all teams)
+    for (int i = 0; i < num_teams; i++) {
+      teams[i] = ROCSHMEM_TEAM_INVALID;
+      rocshmem_team_split_strided(ROCSHMEM_TEAM_WORLD, 0, 1, n_pes, nullptr, 0, &teams[i]);
+
+      if (teams[i] == ROCSHMEM_TEAM_INVALID) {
+        printf("PE %d: Failed to create team %d\n", args.myid, i);
+        rocshmem_global_exit(1);
+      }
+    }
+  } else {
+    // Single-team case: Create just one team for thread/wave level tests
+    teams[0] = ROCSHMEM_TEAM_INVALID;
+    rocshmem_team_split_strided(ROCSHMEM_TEAM_WORLD, 0, 1, n_pes, nullptr, 0, &teams[0]);
+
+    if (teams[0] == ROCSHMEM_TEAM_INVALID) {
+      printf("PE %d: Failed to create team\n", args.myid);
+      rocshmem_global_exit(1);
+    }
+  }
+}
+
+void TileAllgatherTester::launchKernel(dim3 gridSize, dim3 blockSize,
+                                       [[maybe_unused]] int loop,
+                                       [[maybe_unused]] size_t size) {
+  int n_pes = rocshmem_n_pes();
+
+  switch (_type) {
+    case TileAllgatherTestType:
+      // Thread-level test: single WG, single wave
+      hipLaunchKernelGGL(TileAllgatherThreadTest, dim3(1), blockSize, 0, stream,
+                         teams[0], source, dest, tile_extent_0, tile_extent_1,
+                         args.myid, n_pes, _shmem_context, error_flag);
+      break;
+
+    case TileAllgatherWaveTestType:
+      // Wave-level test: single WG, single wave
+      hipLaunchKernelGGL(TileAllgatherWaveTest, dim3(1), blockSize, 0, stream,
+                         teams[0], source, dest, tile_extent_0, tile_extent_1,
+                         args.myid, n_pes, _shmem_context, wf_size, error_flag);
+      break;
+
+    case TileAllgatherWGTestType:
+      // Workgroup-level test: multiple WGs with different teams
+      hipLaunchKernelGGL(TileAllgatherTest, dim3(num_teams), blockSize, 0, stream,
+                         teams, num_teams, source, dest, tile_extent_0, tile_extent_1,
+                         args.myid, n_pes, _shmem_context, error_flag);
+      break;
+
+    default:
+      fprintf(stderr, "Unknown TileAllgather test type\n");
+      exit(EXIT_FAILURE);
+  }
+}
+
+void TileAllgatherTester::postLaunchKernel() {
+  // Destroy teams after each iteration to prevent resource exhaustion
+  if (_type == TileAllgatherWGTestType) {
+    // Multi-team case: destroy all teams
+    for (int i = 0; i < num_teams; i++) {
+      if (teams[i] != ROCSHMEM_TEAM_INVALID) {
+        rocshmem_team_destroy(teams[i]);
+        teams[i] = ROCSHMEM_TEAM_INVALID;
+      }
+    }
+  } else {
+    // Single-team case: destroy the one team
+    if (teams[0] != ROCSHMEM_TEAM_INVALID) {
+      rocshmem_team_destroy(teams[0]);
+      teams[0] = ROCSHMEM_TEAM_INVALID;
+    }
+  }
+}
+
+void TileAllgatherTester::verifyResults([[maybe_unused]] size_t size) {
+  // Check error flag
+  int h_error_flag;
+  CHECK_HIP(hipMemcpy(&h_error_flag, error_flag, sizeof(int), hipMemcpyDeviceToHost));
+
+  if (h_error_flag) {
+    fprintf(stderr, "PE %d: Tile allgather verification FAILED\n", args.myid);
+    exit(EXIT_FAILURE);
+  }
+
+  if (args.myid == 0) {
+    printf("PE %d: Tile allgather verification PASSED\n", args.myid);
+  }
+}

--- a/projects/rocshmem/tests/functional_tests/tile_allgather_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/tile_allgather_tester.cpp
@@ -221,6 +221,11 @@ TileAllgatherTester::TileAllgatherTester(TesterArguments args)
   // Allocate teams using hipHostMalloc
   CHECK_HIP(hipHostMalloc(&teams, num_teams * sizeof(rocshmem_team_t)));
 
+  // Initialize all team handles to ROCSHMEM_TEAM_INVALID
+  for (int i = 0; i < num_teams; i++) {
+    teams[i] = ROCSHMEM_TEAM_INVALID;
+  }
+
   // Allocate tile data
   tile_extent_0 = 8;  // Default tile size
   tile_extent_1 = 8;

--- a/projects/rocshmem/tests/functional_tests/tile_allgather_tester.hpp
+++ b/projects/rocshmem/tests/functional_tests/tile_allgather_tester.hpp
@@ -1,0 +1,74 @@
+/******************************************************************************
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef TILE_ALLGATHER_TESTER_HPP
+#define TILE_ALLGATHER_TESTER_HPP
+
+#include "tester.hpp"
+
+using namespace rocshmem;
+
+/******************************************************************************
+ * DEVICE TEST KERNELS
+ *****************************************************************************/
+// Thread-level allgather test - single WG, single wave
+__global__ void TileAllgatherThreadTest(rocshmem_team_t team,
+                                        float *source, float *dest,
+                                        int tile_extent_0, int tile_extent_1,
+                                        int my_world_pe, int n_pes,
+                                        ShmemContextType ctx_type,
+                                        int *error_flag);
+
+// Wave-level allgather test - single WG, single wave
+__global__ void TileAllgatherWaveTest(rocshmem_team_t team,
+                                      float *source, float *dest,
+                                      int tile_extent_0, int tile_extent_1,
+                                      int my_world_pe, int n_pes,
+                                      ShmemContextType ctx_type,
+                                      int wf_size,
+                                      int *error_flag);
+
+// Workgroup-level allgather test - multiple WGs with different teams
+__global__ void TileAllgatherTest(rocshmem_team_t *teams, int num_teams,
+                                   float *source, float *dest,
+                                   int tile_extent_0, int tile_extent_1,
+                                   int my_world_pe, int n_pes,
+                                   ShmemContextType ctx_type,
+                                   int *error_flag);
+
+/******************************************************************************
+ * HOST TESTER CLASS
+ *****************************************************************************/
+class TileAllgatherTester : public Tester {
+ public:
+  explicit TileAllgatherTester(TesterArguments args);
+
+  virtual ~TileAllgatherTester();
+
+  virtual void resetBuffers(size_t size) override;
+
+  virtual void preLaunchKernel() override;
+
+  virtual void launchKernel(dim3 gridSize, dim3 blockSize, int loop,
+                            size_t size) override;
+
+  virtual void postLaunchKernel() override;
+
+  virtual void verifyResults(size_t size) override;
+
+ protected:
+  rocshmem_team_t *teams;  // Array of teams
+  int num_teams;           // Number of teams to create
+
+  float *source;           // Source tile data (one tile per PE)
+  float *dest;             // Destination tile data (n_pes tiles per PE)
+  int tile_extent_0;       // Tile dimension 0
+  int tile_extent_1;       // Tile dimension 1
+
+  int *error_flag;         // Device error flag for verification
+};
+
+#endif  // TILE_ALLGATHER_TESTER_HPP

--- a/projects/rocshmem/tests/functional_tests/tile_broadcast_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/tile_broadcast_tester.cpp
@@ -1,0 +1,353 @@
+/******************************************************************************
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#include "tile_broadcast_tester.hpp"
+
+#include <rocshmem/rocshmem.hpp>
+
+// Include internal context types before the tile API implementations
+#include "../../src/context_incl.hpp"
+
+// Include tile API template implementations
+#include <rocshmem/rocshmem_TILE_impl.hpp>
+
+using namespace rocshmem;
+
+/******************************************************************************
+ * TENSOR HELPERS (from tile_rma_tester.cpp)
+ *****************************************************************************/
+
+// Simple 2D tensor implementation for testing
+template <typename T>
+struct Tensor2D {
+  using element_type = T;
+  static constexpr int ndim = 2;
+
+  T* data;
+  int rows;
+  int cols;
+  int row_stride;
+  int col_stride;
+
+  __device__ Tensor2D(T* data_, int rows_, int cols_,
+                      int row_stride_ = -1, int col_stride_ = 1)
+      : data(data_), rows(rows_), cols(cols_), col_stride(col_stride_) {
+    // Default row_stride is cols (contiguous row-major layout)
+    row_stride = (row_stride_ == -1) ? cols : row_stride_;
+  }
+
+  __device__ T* data_handle() const { return data; }
+  __device__ int stride(int dim) const {
+    return (dim == 0) ? row_stride : col_stride;
+  }
+};
+
+// Simple tuple for coordinates
+struct Tuple2D {
+  int x, y;
+  __device__ Tuple2D(int x_, int y_) : x(x_), y(y_) {}
+  __device__ int get(int dim) const { return (dim == 0) ? x : y; }
+};
+
+/******************************************************************************
+ * DEVICE TEST KERNELS
+ *****************************************************************************/
+
+// Thread-level broadcast test - single WG, single wave
+__global__ void TileBroadcastThreadTest(rocshmem_team_t team,
+                                        float *source, float *dest,
+                                        int tile_extent_0, int tile_extent_1,
+                                        int my_world_pe, int pe_root,
+                                        ShmemContextType ctx_type,
+                                        int *error_flag) {
+  __shared__ rocshmem_ctx_t ctx;
+
+  // Create context from team (single WG)
+  rocshmem_wg_team_create_ctx(team, ctx_type, &ctx);
+
+  // Single tile, no offset needed
+  Tensor2D<float> src_tensor(source, tile_extent_0, tile_extent_1);
+  Tensor2D<float> dst_tensor(dest, tile_extent_0, tile_extent_1);
+  Tuple2D start(0, 0);
+  Tuple2D boundary(tile_extent_0, tile_extent_1);
+
+  // Only thread 0 performs broadcast
+  if (threadIdx.x == 0) {
+    rocshmem_ctx_tile_broadcast(ctx, team, dst_tensor, src_tensor,
+                                 start, boundary, pe_root, 0);
+  }
+  __syncthreads();
+
+  // Verify results on non-root PEs
+  if (my_world_pe != pe_root && threadIdx.x == 0) {
+    int matrix_size = tile_extent_0 * tile_extent_1;
+    for (int idx = 0; idx < matrix_size; idx++) {
+      float expected = pe_root * 100.0f + idx;
+      float actual = dest[idx];
+      if (actual != expected) {
+        printf("Thread-level: PE %d verification failed at [%d]: got %f, expected %f\n",
+               my_world_pe, idx, actual, expected);
+        *error_flag = 1;
+      }
+    }
+  }
+
+  __syncthreads();
+  rocshmem_wg_ctx_destroy(&ctx);
+}
+
+// Wave-level broadcast test - single WG, single wave
+__global__ void TileBroadcastWaveTest(rocshmem_team_t team,
+                                      float *source, float *dest,
+                                      int tile_extent_0, int tile_extent_1,
+                                      int my_world_pe, int pe_root,
+                                      ShmemContextType ctx_type,
+                                      int wf_size,
+                                      int *error_flag) {
+  __shared__ rocshmem_ctx_t ctx;
+
+  // Create context from team
+  rocshmem_wg_team_create_ctx(team, ctx_type, &ctx);
+
+  Tensor2D<float> src_tensor(source, tile_extent_0, tile_extent_1);
+  Tensor2D<float> dst_tensor(dest, tile_extent_0, tile_extent_1);
+  Tuple2D start(0, 0);
+  Tuple2D boundary(tile_extent_0, tile_extent_1);
+
+  // Only first wave performs broadcast
+  if (threadIdx.x < wf_size) {
+    rocshmem_ctx_tile_broadcast_wave(ctx, team, dst_tensor, src_tensor,
+                                      start, boundary, pe_root, 0);
+  }
+  __syncthreads();
+
+  // Verify on non-root PEs
+  if (my_world_pe != pe_root && threadIdx.x == 0) {
+    int matrix_size = tile_extent_0 * tile_extent_1;
+    for (int idx = 0; idx < matrix_size; idx++) {
+      float expected = pe_root * 100.0f + idx;
+      float actual = dest[idx];
+      if (actual != expected) {
+        printf("Wave-level: PE %d verification failed at [%d]: got %f, expected %f\n",
+               my_world_pe, idx, actual, expected);
+        *error_flag = 1;
+      }
+    }
+  }
+
+  __syncthreads();
+  rocshmem_wg_ctx_destroy(&ctx);
+}
+
+// Workgroup-level broadcast test - multiple WGs with different teams
+__global__ void TileBroadcastTest(rocshmem_team_t *teams, int num_teams,
+                                  float *source, float *dest,
+                                  int tile_extent_0, int tile_extent_1,
+                                  int my_world_pe, int pe_root,
+                                  ShmemContextType ctx_type,
+                                  int *error_flag) {
+  __shared__ rocshmem_ctx_t ctx;
+  int wg_id = get_flat_grid_id();
+
+  // Each workgroup uses a DIFFERENT team
+  rocshmem_team_t my_team = teams[wg_id % num_teams];
+
+  // Create context from this workgroup's specific team
+  rocshmem_wg_team_create_ctx(my_team, ctx_type, &ctx);
+
+  // Calculate offset for this workgroup's tile
+  int matrix_size = tile_extent_0 * tile_extent_1;
+  int offset = matrix_size * wg_id;
+
+  // Create tensors for source and destination
+  Tensor2D<float> src_tensor(source + offset, tile_extent_0, tile_extent_1);
+  Tensor2D<float> dst_tensor(dest + offset, tile_extent_0, tile_extent_1);
+  Tuple2D start(0, 0);
+  Tuple2D boundary(tile_extent_0, tile_extent_1);
+
+  // Perform tile broadcast - root PE broadcasts its tile to all other PEs on the team
+  rocshmem_ctx_tile_broadcast_wg(ctx, my_team, dst_tensor, src_tensor,
+                                  start, boundary, pe_root, 0);
+
+  __syncthreads();
+
+  // Verify results on non-root PEs
+  if (my_world_pe != pe_root) {
+    if (threadIdx.x == 0) {
+      // Check that we received the root PE's data
+      // Root PE's data is pe_root * 100 + element index
+      for (int i = 0; i < tile_extent_0; i++) {
+        for (int j = 0; j < tile_extent_1; j++) {
+          int idx = i * tile_extent_1 + j;
+          float expected = pe_root * 100.0f + idx;
+          float actual = dest[offset + idx];
+          if (actual != expected) {
+            printf("WG %d: PE %d verification failed at [%d,%d]: got %f, expected %f\n",
+                   wg_id, my_world_pe, i, j, actual, expected);
+            *error_flag = 1;
+          }
+        }
+      }
+    }
+  }
+
+  __syncthreads();
+
+  // Team barrier - each workgroup synchronizes on its own team
+  rocshmem_ctx_sync_wg(ctx, my_team);
+
+  rocshmem_wg_ctx_destroy(&ctx);
+}
+
+/******************************************************************************
+ * HOST TESTER CLASS METHODS
+ *****************************************************************************/
+TileBroadcastTester::TileBroadcastTester(TesterArguments args)
+    : Tester(args) {
+  num_teams = 4;  // Default to 4 teams
+
+  // Allocate teams using hipHostMalloc
+  CHECK_HIP(hipHostMalloc(&teams, num_teams * sizeof(rocshmem_team_t)));
+
+  // Allocate tile data
+  tile_extent_0 = 8;  // Default tile size
+  tile_extent_1 = 8;
+  int tile_size = tile_extent_0 * tile_extent_1;
+  int total_size = tile_size * num_teams;  // One tile per workgroup
+
+  source = (float *)rocshmem_malloc(total_size * sizeof(float));
+  dest = (float *)rocshmem_malloc(total_size * sizeof(float));
+
+  if (!source || !dest) {
+    fprintf(stderr, "Failed to allocate symmetric memory for tiles\n");
+    exit(EXIT_FAILURE);
+  }
+
+  // Allocate error flag
+  CHECK_HIP(hipMalloc(&error_flag, sizeof(int)));
+}
+
+TileBroadcastTester::~TileBroadcastTester() {
+  rocshmem_free(source);
+  rocshmem_free(dest);
+  CHECK_HIP(hipFree(error_flag));
+
+  // Destroy teams
+  for (int i = 0; i < num_teams; i++) {
+    if (teams[i] != ROCSHMEM_TEAM_INVALID) {
+      rocshmem_team_destroy(teams[i]);
+    }
+  }
+  CHECK_HIP(hipHostFree(teams));
+}
+
+void TileBroadcastTester::resetBuffers([[maybe_unused]] size_t size) {
+  int tile_size = tile_extent_0 * tile_extent_1;
+  int total_size = tile_size * num_teams;
+
+  // Initialize source data: each PE's data is pe * 100 + element index
+  for (int i = 0; i < total_size; i++) {
+    source[i] = args.myid * 100.0f + (i % tile_size);
+    dest[i] = -1.0f;  // Initialize dest to invalid value
+  }
+
+  // Reset error flag
+  int zero = 0;
+  CHECK_HIP(hipMemcpy(error_flag, &zero, sizeof(int), hipMemcpyHostToDevice));
+}
+
+void TileBroadcastTester::preLaunchKernel() {
+  int n_pes = rocshmem_n_pes();
+
+  if (_type == TileBroadcastWGTestType) {
+    // Multi-team case: Create multiple duplicate teams (all PEs are members of all teams)
+    for (int i = 0; i < num_teams; i++) {
+      teams[i] = ROCSHMEM_TEAM_INVALID;
+      rocshmem_team_split_strided(ROCSHMEM_TEAM_WORLD, 0, 1, n_pes, nullptr, 0, &teams[i]);
+
+      if (teams[i] == ROCSHMEM_TEAM_INVALID) {
+        printf("PE %d: Failed to create team %d\n", args.myid, i);
+        rocshmem_global_exit(1);
+      }
+    }
+  } else {
+    // Single-team case: Create just one team for thread/wave level tests
+    teams[0] = ROCSHMEM_TEAM_INVALID;
+    rocshmem_team_split_strided(ROCSHMEM_TEAM_WORLD, 0, 1, n_pes, nullptr, 0, &teams[0]);
+
+    if (teams[0] == ROCSHMEM_TEAM_INVALID) {
+      printf("PE %d: Failed to create team\n", args.myid);
+      rocshmem_global_exit(1);
+    }
+  }
+}
+
+void TileBroadcastTester::launchKernel(dim3 gridSize, dim3 blockSize,
+                                       [[maybe_unused]] int loop,
+                                       [[maybe_unused]] size_t size) {
+  int pe_root = 0;  // Root PE for broadcast
+
+  switch (_type) {
+    case TileBroadcastTestType:
+      // Thread-level test: single WG, single wave
+      hipLaunchKernelGGL(TileBroadcastThreadTest, dim3(1), blockSize, 0, stream,
+                         teams[0], source, dest, tile_extent_0, tile_extent_1,
+                         args.myid, pe_root, _shmem_context, error_flag);
+      break;
+
+    case TileBroadcastWaveTestType:
+      // Wave-level test: single WG, single wave
+      hipLaunchKernelGGL(TileBroadcastWaveTest, dim3(1), blockSize, 0, stream,
+                         teams[0], source, dest, tile_extent_0, tile_extent_1,
+                         args.myid, pe_root, _shmem_context, wf_size, error_flag);
+      break;
+
+    case TileBroadcastWGTestType:
+      // Workgroup-level test: multiple WGs with different teams
+      hipLaunchKernelGGL(TileBroadcastTest, dim3(num_teams), blockSize, 0, stream,
+                         teams, num_teams, source, dest, tile_extent_0, tile_extent_1,
+                         args.myid, pe_root, _shmem_context, error_flag);
+      break;
+
+    default:
+      fprintf(stderr, "Unknown TileBroadcast test type\n");
+      exit(EXIT_FAILURE);
+  }
+}
+
+void TileBroadcastTester::postLaunchKernel() {
+  // Destroy teams after each iteration to prevent resource exhaustion
+  if (_type == TileBroadcastWGTestType) {
+    // Multi-team case: destroy all teams
+    for (int i = 0; i < num_teams; i++) {
+      if (teams[i] != ROCSHMEM_TEAM_INVALID) {
+        rocshmem_team_destroy(teams[i]);
+        teams[i] = ROCSHMEM_TEAM_INVALID;
+      }
+    }
+  } else {
+    // Single-team case: destroy the one team
+    if (teams[0] != ROCSHMEM_TEAM_INVALID) {
+      rocshmem_team_destroy(teams[0]);
+      teams[0] = ROCSHMEM_TEAM_INVALID;
+    }
+  }
+}
+
+void TileBroadcastTester::verifyResults([[maybe_unused]] size_t size) {
+  // Check error flag
+  int h_error_flag;
+  CHECK_HIP(hipMemcpy(&h_error_flag, error_flag, sizeof(int), hipMemcpyDeviceToHost));
+
+  if (h_error_flag) {
+    fprintf(stderr, "PE %d: Tile broadcast verification FAILED\n", args.myid);
+    exit(EXIT_FAILURE);
+  }
+
+  if (args.myid == 0) {
+    printf("PE %d: Tile broadcast verification PASSED\n", args.myid);
+  }
+}

--- a/projects/rocshmem/tests/functional_tests/tile_broadcast_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/tile_broadcast_tester.cpp
@@ -212,6 +212,11 @@ TileBroadcastTester::TileBroadcastTester(TesterArguments args)
   // Allocate teams using hipHostMalloc
   CHECK_HIP(hipHostMalloc(&teams, num_teams * sizeof(rocshmem_team_t)));
 
+  // Initialize all team handles to ROCSHMEM_TEAM_INVALID
+  for (int i = 0; i < num_teams; i++) {
+    teams[i] = ROCSHMEM_TEAM_INVALID;
+  }
+
   // Allocate tile data
   tile_extent_0 = 8;  // Default tile size
   tile_extent_1 = 8;

--- a/projects/rocshmem/tests/functional_tests/tile_broadcast_tester.hpp
+++ b/projects/rocshmem/tests/functional_tests/tile_broadcast_tester.hpp
@@ -1,0 +1,74 @@
+/******************************************************************************
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef TILE_BROADCAST_TESTER_HPP
+#define TILE_BROADCAST_TESTER_HPP
+
+#include "tester.hpp"
+
+using namespace rocshmem;
+
+/******************************************************************************
+ * DEVICE TEST KERNELS
+ *****************************************************************************/
+// Thread-level broadcast test - single WG, single wave
+__global__ void TileBroadcastThreadTest(rocshmem_team_t team,
+                                        float *source, float *dest,
+                                        int tile_extent_0, int tile_extent_1,
+                                        int my_world_pe, int pe_root,
+                                        ShmemContextType ctx_type,
+                                        int *error_flag);
+
+// Wave-level broadcast test - single WG, single wave
+__global__ void TileBroadcastWaveTest(rocshmem_team_t team,
+                                      float *source, float *dest,
+                                      int tile_extent_0, int tile_extent_1,
+                                      int my_world_pe, int pe_root,
+                                      ShmemContextType ctx_type,
+                                      int wf_size,
+                                      int *error_flag);
+
+// Workgroup-level broadcast test - multiple WGs with different teams
+__global__ void TileBroadcastTest(rocshmem_team_t *teams, int num_teams,
+                                  float *source, float *dest,
+                                  int tile_extent_0, int tile_extent_1,
+                                  int my_world_pe, int pe_root,
+                                  ShmemContextType ctx_type,
+                                  int *error_flag);
+
+/******************************************************************************
+ * HOST TESTER CLASS
+ *****************************************************************************/
+class TileBroadcastTester : public Tester {
+ public:
+  explicit TileBroadcastTester(TesterArguments args);
+
+  virtual ~TileBroadcastTester();
+
+  virtual void resetBuffers(size_t size) override;
+
+  virtual void preLaunchKernel() override;
+
+  virtual void launchKernel(dim3 gridSize, dim3 blockSize, int loop,
+                            size_t size) override;
+
+  virtual void postLaunchKernel() override;
+
+  virtual void verifyResults(size_t size) override;
+
+ protected:
+  rocshmem_team_t *teams;  // Array of teams
+  int num_teams;           // Number of teams to create
+
+  float *source;           // Source tile data
+  float *dest;             // Destination tile data
+  int tile_extent_0;       // Tile dimension 0
+  int tile_extent_1;       // Tile dimension 1
+
+  int *error_flag;         // Device error flag for verification
+};
+
+#endif  // TILE_BROADCAST_TESTER_HPP

--- a/projects/rocshmem/tests/test_categories.yaml
+++ b/projects/rocshmem/tests/test_categories.yaml
@@ -145,6 +145,7 @@ test_categories:
       - "teamwgbarrier_.*"
       - "teamwavesync_.*"
       - "teamwgsync_.*"
+      - "teamsplit2d_.*"
 
       # Extended signal operations
       - "wgputsignal_.*"
@@ -196,6 +197,10 @@ test_categories:
       - "host_int_amo_fcswap_.*"
       - "host_amo_all_pes_.*"
       - "host_amo_self_.*"
+
+      # Tile collective tests (IPC-only)
+      - "tile_broadcast_.*"
+      - "tile_allgather_.*"
 
     labels:
       - "nightly"


### PR DESCRIPTION
Implement tile_broadcast and tile_allgather collective operations with three granularity levels (thread, wave, workgroup) for the IPC backend.

Implementation Details:
- tile_broadcast: Non-root PEs fetch tile from root using tile_get, followed by team-wide synchronization
- tile_allgather: Each PE gathers tiles from all team members into sequential destination slots using tile_get operations

Changes:
- IPC backend: Replace stub implementations with full tile collective operations (6 functions: broadcast/allgather × 3 granularities)
- Add functional tests for tile_broadcast and tile_allgather operations
- Register new test types (118-124) in test infrastructure
- Add multi-PE support for tile collective tests in tester_arguments.cpp
- Update driver.sh with test configurations for 2 and 4 PEs

Tile based reductions will come in a separate PR

## JIRA ID

AIROCSHMEM-390


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
