### PR TITLE
[rocjitsu] Added First DBI Instance -- Adding an Inlined nop

### DIFF
--- a/emulation/rocjitsu/cmake/rj_add_device_kernel.cmake
+++ b/emulation/rocjitsu/cmake/rj_add_device_kernel.cmake
@@ -8,12 +8,27 @@
 # the specified GPU target. AMDCXX, ROCM_PATH, and KERNEL_OUTPUT_DIR
 # must be set before including this module.
 #
-# Usage: rj_add_device_kernel(<name> <offload_arch>)
+# Usage: rj_add_device_kernel(<name> <offload_arch> [OUTPUT_NAME <output_name>])
 #   name         - base name of the .hip source (without extension)
 #   offload_arch - GPU target (e.g. gfx942, gfx950)
+#   OUTPUT_NAME  - optional; basename of the output .o (default: ${name}).
+#                  Use when the same source is compiled for multiple targets
+#                  so each build lands in a distinct .o file. (Multi-target
+#                  fat binaries via repeated --offload-arch flags would be
+#                  more elegant but the Executable fat-binary loader has a
+#                  pre-existing single-bundle assumption — see
+#                  executable.cpp::load_hip_fatbin.)
 function(rj_add_device_kernel name offload_arch)
+    set(oneValueArgs OUTPUT_NAME)
+    cmake_parse_arguments(RJ_KERNEL "" "${oneValueArgs}" "" ${ARGN})
+
+    set(output_name "${name}")
+    if(RJ_KERNEL_OUTPUT_NAME)
+        set(output_name "${RJ_KERNEL_OUTPUT_NAME}")
+    endif()
+
     set(src ${CMAKE_CURRENT_SOURCE_DIR}/${name}.hip)
-    set(out ${KERNEL_OUTPUT_DIR}/${name}.o)
+    set(out ${KERNEL_OUTPUT_DIR}/${output_name}.o)
 
     add_custom_command(
         OUTPUT ${out}
@@ -21,9 +36,9 @@ function(rj_add_device_kernel name offload_arch)
             ${AMDCXX} -x hip --offload-arch=${offload_arch}
             --rocm-path=${ROCM_PATH} -fPIC -c -O2 -o ${out} ${src}
         DEPENDS ${src}
-        COMMENT "Compiling device kernel: ${name} (${offload_arch})"
+        COMMENT "Compiling device kernel: ${output_name} (${offload_arch})"
     )
 
     # Per-kernel target so dependents can reference it.
-    add_custom_target(kernel_${name} DEPENDS ${out})
+    add_custom_target(kernel_${output_name} DEPENDS ${out})
 endfunction()

--- a/emulation/rocjitsu/docs/dbi-design.md
+++ b/emulation/rocjitsu/docs/dbi-design.md
@@ -2,57 +2,201 @@
 
 ## Overview
 
-The Dynamic Binary Instrumentation (DBI) system patches AMDGPU HSA code objects in-place, before they are loaded into device memory, to inject calls into user-supplied instrumentation functions. Patched code objects can (will) then be loaded by either the simulated KMD (`SimulatedDriver`) or by real ROCR via the HSA tools layer (`HSA_TOOLS_LIB=librocjitsu_hooks.so`). DBI itself is (will be) target-agnostic.
+The Dynamic Binary Instrumentation (DBI) system patches AMDGPU HSA code objects in-place, before they are loaded into device memory, to inject code at chosen anchor instructions. Patched code objects can be loaded by either the simulated KMD (`SimulatedDriver`) or — eventually — by real ROCR via the HSA tools layer (`HSA_TOOLS_LIB=librocjitsu_hooks.so`). DBI itself is target-agnostic at the layer boundary; per-ISA differences are confined to the instruction builder and decoder.
 
-This document describes the DBI subsystem as currently implemented. Most of the planned DBI machinery (trampoline builder, probe registry, instrumentation pass, public C API) does not exist yet. The pieces in tree today are the foundational analyses and resource managers that future instrumentation passes will consume.
+This document describes the DBI subsystem as currently implemented. The first end-to-end slice — an *inline-nop* trampoline at a single anchor — is in tree. The broader instrumentation framework (probe-call bodies, multi-site instrumentation with per-site failure tolerance, predicate-based anchor selection, EXEC-policy management, `AfterInst` / `BlockEntry` / `BlockExit` kinds, layout/negotiation between the builder and the orchestrator) is still future work and is tracked in `dbt_dbi_plan.md`.
 
 ---
 
 ## Architecture
 
-TODO. The shipped DBI surface is a set of foundational building blocks (liveness, register set, spill manager) rather than an end-to-end pipeline. A meaningful block diagram will land once the trampoline builder and instrumentation pass exist and there is a real flow to draw.
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  Instrumentor                                                    │
+│  Orchestration: collect points, validate, plan, build, splice    │
+│                                                                  │
+│  ┌────────────────────────┐  ┌─────────────────────────────────┐ │
+│  │  Validators            │  │  Trampoline planning            │ │
+│  │  - is_relocatable_     │  │  - make_trampoline_plan()       │ │
+│  │    anchor() (structural│  │  - validate_inline_nop_plan()   │ │
+│  │  - validate_anchor()   │  │    (milestone guardrail)        │ │
+│  │    (+ milestone rules) │  │                                 │ │
+│  └────────────────────────┘  └─────────────────────────────────┘ │
+│                                                                  │
+│  ┌──────────────────────────────────────────────────────────────┐│
+│  │  TrampolineBuilder                                           ││
+│  │  Plan → bytes: patched anchor word + trampoline body words   ││
+│  └──────────────────────────────────────────────────────────────┘│
+│                                                                  │
+│  ┌──────────────────────────────────────────────────────────────┐│
+│  │  CodeObjectPatcher                                           ││
+│  │  ELF mutation: splice .text, append .rj_trampolines, emit    ││
+│  └──────────────────────────────────────────────────────────────┘│
+└──────────────────────────────────────────────────────────────────┘
+```
+
+The orchestrator owns the multi-stage pipeline. All per-site validation and builder output is *preflighted* before the patcher mutates anything — a late failure (e.g. branch-range overflow) cannot leak a half-built ELF.
 
 ---
 
-## Register Liveness Analysis [shared with DBT]
+## Instrumentor
+
+**Files:** `code/patch/instrumentor.h`, `code/patch/instrumentor.cpp`
+
+The Instrumentor is the top-level orchestrator. Callers queue `InstrumentationPoint`s (requests) and then invoke `patch()`. The orchestrator runs the pipeline: validate each anchor, plan a trampoline per site, build it, then mutate the ELF.
+
+### Pipeline stages
+
+```
+InstrumentationPoint        -- request: "instrument here, with this body"
+      |  validate_points()
+      v
+ResolvedInstrumentationSite -- one validated anchor + snapshot of the
+      |                        original bytes (captured before mutation)
+      |  make_trampoline_plan() + TrampolineBuilder::build()
+      v
+(preflight: per-site plan + built bytes, accumulated locally)
+      |  splice anchors + append .rj_trampolines + emit()
+      v
+InstrumentedCodeObject      -- patched ELF + diagnostics
+```
+
+### Responsibilities
+
+- Lazy CFG construction: blocks are decoded on the first call that needs them via `Decoder::create(arch)` + `BasicBlock::build(obj, *decoder)`. Decoder creation failure (RV32I/RV64I/INVALID) surfaces as a structured `ValidationResult` / `InstrumentedCodeObject` error, not a crash.
+- `validate_points()` looks up the decoded `Instruction` at each requested `anchor_offset` and runs `validate_anchor()`. All-or-nothing today: any per-site failure empties `sites` and reports diagnostics in `errors`.
+- `patch()` runs validation, then per-site `make_trampoline_plan()` + `TrampolineBuilder::build()` as preflight. Only after every site succeeds does it splice patched anchor bytes into a local `.text` copy, `overwrite_text()`, accumulate trampoline words via `append_cave_body()`, and materialize the section with `append_cave_section(".rj_trampolines")`. Returns `InstrumentedCodeObject{elf_bytes, errors, warnings}`.
+- `patch_with_debug_summaries()` is a test/debug entry point returning `InstrumentedCodeObjectDebug` (extends `InstrumentedCodeObject` with per-site `InstrumentationPatch` summaries — schema unstable; production callers should prefer `patch()` and recover per-site info from a fresh disassembly).
+- Single-attempt: both entry points share one budget. After `patched_ = true`, subsequent calls return a fatal error. Recoverable errors require constructing a new Instrumentor.
+
+### Current scope (inline-nop milestone)
+
+- Exactly one queued `InstrumentationPoint` per `patch()` call (multi-site is fatal).
+- Single `.text` section (multi-text is fatal).
+- `BeforeInst` kind only (other kinds are fatal).
+- Reserved `InstrumentationPoint` fields (`filter_flags`, `probe_obj`, `probe_symbol`, `force_full_exec`) must be default; non-default is fatal. These rejections are the milestone guardrail and disappear as each field gains a real consumer.
+
+### Key design constraint
+
+The Instrumentor knows about milestones; the TrampolineBuilder and CodeObjectPatcher do not. Milestone-scoped restrictions live in three places at the orchestrator boundary: reserved-field rejections in `validate_anchor()`, plan-shape checks in `validate_inline_nop_plan()`, and multi-text/multi-point rejections at the top of `patch()`. The builder accepts any well-formed plan and the patcher accepts any well-formed mutation request.
+
+---
+
+## TrampolineBuilder
+
+**Files:** `code/patch/trampoline_builder.h`, `code/patch/trampoline_builder.cpp`
+
+Generic byte emitter. Takes a `TrampolinePlan` and returns `TrampolineBytes{patched_anchor_bytes, trampoline_words}`. Knows nothing about `InstrumentationPoint`s, milestones, or probe bodies — ready to absorb richer plans (probe calls, clobber-bearing inline asm) without rewrites.
+
+### What it handles
+
+- Encoding the forward `s_branch` that goes into the anchor slot, pointing at the trampoline's first word.
+- Emitting the trampoline body in order: `before_items` (each an `InlineAsmItem` containing one or more pre-encoded words), then the relocated original instruction words (when `emit_original`), then `after_items`, then the return `s_branch` back to `anchor_offset + original_size`.
+- Plan well-formedness: `original_size` ∈ {4, 8}, `original_words.size() * sizeof(uint32_t) == original_size`, branch reach fits in SOPP `simm16`.
+- Architecture awareness — SOPP encoding format is uniform across AMDGPU but opcodes differ (e.g. `s_branch` is opcode 2 on GFX9/CDNA, opcode 32 on GFX12/RDNA4). All opcode selection goes through `instruction_builder.h` helpers.
+
+### What it does NOT handle
+
+- Validating the *intent* of the plan (e.g. that it's a canonical inline-nop body). That's the orchestrator's `validate_inline_nop_plan()` job.
+- Choosing the trampoline offset — the caller picks `trampoline_offset` in the plan.
+- Mutating any ELF state — output is just bytes.
+
+### Shared SOPP branch math
+
+`compute_sopp_branch_simm16(branch_pc, target)` in `instruction_builder.h` is the single source of truth for the AMDGPU branch encoding `(target - (branch_pc + 4)) / 4`. Used by both the trampoline builder and the DBT code-cave path.
+
+---
+
+## Validators
+
+Three validators sit at the orchestrator boundary, separated so each can evolve independently.
+
+### `is_relocatable_anchor(anchor, anchor_offset, text_bytes, arch, error_out)`
+
+Pure predicate over the anchor instruction and its position. Permanent structural checks only — no `InstrumentationPoint` involvement. Reusable by future predicate-based anchor selection (Instrumentor walks blocks and filters candidates) without inheriting milestone noise.
+
+Rules enforced:
+- `anchor_offset` is dword aligned.
+- `anchor.size()` is 4 or 8 and fits inside `text_bytes` (subtraction-based bounds check; resists overflow when `anchor_offset` is huge).
+- `anchor.raw_encoding()` is non-null.
+- `anchor` is not a branch / cond branch / indirect branch / indirect call / program terminator, and `branch_offset_bytes()` is `nullopt`.
+- `anchor.mnemonic()` is not on the small PC-relative denylist (`s_getpc_b64`, `s_call_b64`, `s_setpc_b64`, `s_swappc_b64`, `s_rfe_*`) — these may not surface as flag bits on every ISA.
+
+`arch` is accepted now so a future ISA-specific denylist can grow without an API change.
+
+### `validate_anchor(anchor, anchor_offset, text_bytes, pt, arch, error_out)`
+
+Combines `is_relocatable_anchor()` with milestone-scoped policy checks against `pt`: `filter_flags` is zero, `kind` is `BeforeInst`, `probe_obj` is null, `probe_symbol` is empty, `force_full_exec` is false. On success returns a `ResolvedInstrumentationSite` with the captured anchor snapshot (offset, size, original bytes, mnemonic, kind).
+
+### `validate_inline_nop_plan(plan, error_out)`
+
+Defense-in-depth check that the orchestrator-produced `TrampolinePlan` matches the canonical inline-nop shape: exactly one `before_items` entry containing `s_nop 0`, empty `after_items`, `emit_original == true`. Lives at the orchestrator boundary rather than inside the builder so the builder stays generic. Deleted once arbitrary inline-asm bodies are supported.
+
+---
+
+## Data Types
+
+| Type | Stage | Carries |
+| --- | --- | --- |
+| `InstrumentationPoint` | request | `anchor_offset`, `kind`, reserved fields |
+| `ResolvedInstrumentationSite` | post-validation | `anchor_offset`, `original_size`, `original_bytes`, `mnemonic`, `kind` |
+| `TrampolinePlan` | builder input | `arch`, `anchor_offset`, `original_size`, `original_words`, `trampoline_offset`, `return_target`, `before_items`, `after_items`, `emit_original` |
+| `TrampolineBytes` | builder output | `patched_anchor_bytes`, `trampoline_words` |
+| `InstrumentationPatch` | per-site summary (test/debug) | `anchor_offset`, `original_size`, `trampoline_offset`, `return_target`, `original_bytes`, `patched_anchor_bytes` |
+| `InstrumentedCodeObject` | `patch()` output | `elf_bytes`, `errors`, `warnings` |
+| `InstrumentedCodeObjectDebug` | `patch_with_debug_summaries()` output | `InstrumentedCodeObject` + `patches` |
+
+The intermediate site/plan types are expected to thicken as the framework grows (e.g. `ResolvedInstrumentationSite` likely gains an ordered list of bodies once multi-point coalescing lands; a layout/negotiation stage will appear between planning and splicing).
+
+---
+
+## Supporting Modules
+
+### Code Object Patcher (`code/patch/code_object_patcher.h`) [shared with DBT]
+
+Owns ELF-level mutations. The DBI orchestrator uses: `text_bytes()` / `overwrite_text()` for the anchor splice, `set_cave_start()` + `append_cave_body()` + `append_cave_section()` for the appended trampolines, and `emit()` for the final patched ELF buffer. The patcher accepts any well-formed mutation request; layout decisions stay in the orchestrator. The orchestrator establishes the cave coordinate once (`set_cave_start(text_size())`) and reads it back via `cave_start()` rather than recomputing.
+
+### Instruction Builder (`code/patch/instruction_builder.h`) [shared with DBT]
+
+ISA-parameterized helpers for encoding common instructions (`s_branch`, `s_nop`, etc.) and the SOPP branch math (`compute_sopp_branch_simm16`). Used by both the trampoline builder and the DBT code-cave path. SOPP format is identical across AMDGPU generations but opcodes differ; always go through these helpers, never hardcode opcodes.
+
+### Register Liveness Analysis [shared with DBT]
 
 **Files:** `analysis/liveness.h`, `analysis/liveness.cpp`, `analysis/def_use_chain.h`, `analysis/def_use_chain.cpp`
-**Used by:** DBT semantic translator (today); DBI passes (planned)
+**Used by:** DBT semantic translator (today); DBI probe-call passes (planned)
 
 Kernel-scoped backward register liveness over the CFG embedded in `BasicBlock`. Callers construct a `LivenessAnalysis` from one `KernelBlockScope` (the blocks reachable from one kernel descriptor entry). Successor/predecessor edges that leave the scope are ignored, so one decoded code object containing N kernels yields N independent analyses.
 
-### What it tracks
+#### What it tracks
 
 Ordinary SGPRs, VGPRs, and AccVGPRs via `RegisterSet`. `InstDefUse` records explicit operand defs and uses plus instruction-level implicit hooks; the only implicit hook today is the FLAT `saddr` SGPR-pair use that does not appear as an explicit operand.
 
-### What it does NOT track
+#### What it does NOT track
 
 - EXEC, VCC, SCC, M0, FLAT_SCRATCH, TTMP — special architectural state. The `RegClass` enum names these for future use, but they are not in the dataflow set.
 - Cross-kernel CFG. Edges that leave the kernel scope are silently dropped.
 - Memory dependencies. Liveness is purely register-based.
 
----
-
-## SpillManager
+### SpillManager
 
 **Files:** `code/patch/spill_manager.h`, `code/patch/spill_manager.cpp`
 
-Per-kernel scratch-layout planner for DBI spill/fill slots. Future instrumentation passes will use it to reserve byte offsets within per-lane scratch where saved SGPRs / VGPRs / AccVGPRs go before a probe runs and from which they are restored after.
+Per-kernel scratch-layout planner for DBI spill/fill slots. Probe-call trampolines will use it to reserve byte offsets within per-lane scratch where saved SGPRs / VGPRs / AccVGPRs go before a probe runs and from which they are restored after. Not consumed by the inline-nop pipeline.
 
-### Responsibilities
+#### Responsibilities
 
 - Reserve a "DBI spill zone" appended above the kernel's existing `private_segment_fixed_size`, aligned to 16 bytes.
 - Hand out stable per-register byte offsets within that zone. Registers cannot get more than one offset.
 - Enforce a hard per-lane scratch cap. Allocations that would push the bumped total past the cap fail; on failure the manager state is unchanged.
 - Compute the bumped `private_segment_fixed_size` that the kernel descriptor patcher will write back.
 
-### What it is not
+#### What it is not
 
 - Not a memory allocator. SpillManager only computes layout.
 - Not the code generator. SpillManager hands out offsets; emitting the actual `scratch_store` / `scratch_load` (or equivalents) will be the trampoline builder's job.
-- Not an MFMA-clobber tracker. AccVGPR clobbering by long-latency MFMA is deferred
+- Not an MFMA-clobber tracker. AccVGPR clobbering by long-latency MFMA is deferred.
 
-### Public API
+#### Public API
 
 ```cpp
 class SpillManager final {
@@ -72,10 +216,6 @@ public:
 
 `allocate_slots` is the common multi-lane case (SGPR pair, 64-bit VGPR pair). `reserve` performs an upfront capacity check across the whole set so a partial allocation can never become visible. `offset_for` is the lookup used by code generators when emitting the matching `scratch_load` after a probe.
 
----
-
-## Supporting Types
-
 ### RegisterRef / RegisterSet [shared with DBT]
 
 **Files:** `isa/register_set.h`, `isa/register_set.cpp`
@@ -84,3 +224,41 @@ public:
 ISA-independent register-file model. `RegisterRef` is `(RegClass, uint16_t index, uint8_t width)` measured in 32-bit lanes. `RegisterSet` is three disjoint bitsets (SGPR / VGPR / ACC_VGPR) sized to the union of CDNA and RDNA hardware bounds (`REGISTER_SET_MAX_*`). For scratch selection across both families, `REGISTER_SET_ALLOCATABLE_SGPRS` gives the conservative `min(CDNA, RDNA)` bound.
 
 `RegisterSet` exposes `expand` / `erase` / `contains` / `none` / `size` / `intersects`, the standard set operators (`|=`, `&=`, `-=`), and a `for_each` visitor that yields tracked single-lane `RegisterRef`s in (SGPR, VGPR, AccVGPR) ascending-index order.
+
+---
+
+## Instrumentation Flow (inline-nop)
+
+For a code object with one queued `InstrumentationPoint` at `anchor_offset`:
+
+1. **Lazy block decode:** On the first stage that needs the CFG, `Decoder::create(arch)` + `BasicBlock::build(obj, *decoder)` populates `blocks_`. Unsupported arch surfaces as a fatal error here.
+2. **Validate:** `validate_points()` walks `points_`; for each, `find_instruction_at_offset()` locates the decoded `Instruction`, then `validate_anchor()` runs milestone-scoped + structural checks and produces a `ResolvedInstrumentationSite` capturing the original bytes.
+3. **Plan + build (preflight):** For each site, `make_trampoline_plan(site, arch, trampoline_offset)` produces a canonical inline-nop plan (`before_items = {{ s_nop 0 }}`, `emit_original = true`); `validate_inline_nop_plan()` rechecks shape; `TrampolineBuilder::build(plan)` lowers it to `TrampolineBytes`. Trampoline cursor is derived from `patcher.cave_start()`. Nothing is written to the patcher yet.
+4. **Splice:** Once every site preflighted, copy `.text` into a local buffer, `memcpy` each `patched_anchor_bytes` into its `anchor_offset`, then `patcher.overwrite_text()`.
+5. **Append:** For each site, `patcher.append_cave_body(trampoline_words)`; then `patcher.append_cave_section(".rj_trampolines")` materializes the new executable section immediately after `.text`.
+6. **Emit:** `patcher.emit()` returns the patched ELF.
+
+The trampoline body for one site lays out as:
+
+```
+.rj_trampolines:
+  s_nop 0                     <-- inline-nop placeholder (becomes probe call later)
+  <relocated original word(s)> <-- 4 or 8 bytes, same encoding as the anchor
+  s_branch <return>           <-- back to anchor_offset + original_size
+
+.text @ anchor_offset:
+  s_branch <trampoline>       <-- forward branch into .rj_trampolines
+```
+
+Branch offsets are computed in SOPP `simm16` units; the trampoline must lie within `±32768 * 4` bytes of the anchor. For unusually large kernels this would require trampoline islands, which remain future work (same constraint as DBT code caves).
+
+---
+
+## Testing
+
+- **Unit (`tests/patch/instrumentor_test.cpp`):** Validator coverage (each rejection path on synthetic anchors, including the bounds-overflow regression for `is_relocatable_anchor`), inline-nop plan guardrail, `make_trampoline_plan`, end-to-end `patch()` on a synthetic ELF (expected anchor splice + trampoline layout + reparse), and a decoded round-trip of every word in the emitted trampoline.
+- **Unit (`tests/patch/trampoline_builder_test.cpp`):** Builder byte-layout contract, branch math, arch-honoring opcode selection, INT16 limit boundary cases.
+- **Unit (`tests/patch/instruction_builder_test.cpp`):** `compute_sopp_branch_simm16` boundary / alignment / overflow / negative-unaligned-delta.
+- **Static DBI smoke (`tests/dbi/hsa_dbi_smoke_test.cpp`, `HsaDbiSmokeStatic`):** Loads a real compiled gfx90a `vector_add` ELF, runs `Instrumentor::patch()`, asserts the patched ELF differs from the original, decodes the anchor as `s_branch`, and confirms `.rj_trampolines` exists. No GPU required.
+- **Hardware DBI smoke (`HsaDbiSmokeHardware`, gated on `HAS_CDNA2_GPU`):** Three tests on a real gfx90a GPU — patched ELF loads + validates via HSA; dispatched kernel produces bit-identical output to the original (the inline-nop placeholder is a no-op); a *sabotage* test overwrites the trampoline's `s_nop 0` with `s_endpgm 0` and asserts the kernel actually fails, proving the GPU genuinely executes the trampoline path rather than silently bypassing the splice. `hsa_init` / `hsa_shut_down` and gfx90a agent enumeration run once per suite via `SetUpTestSuite` / `TearDownTestSuite`.
+- Run with `build/tests/rocjitsu_tests` and `build/tests/hsa_dbi_smoke_test`.

--- a/emulation/rocjitsu/docs/dbi-design.md
+++ b/emulation/rocjitsu/docs/dbi-design.md
@@ -30,7 +30,7 @@ This document describes the DBI subsystem as currently implemented. The first en
 │                                                                  │
 │  ┌──────────────────────────────────────────────────────────────┐│
 │  │  CodeObjectPatcher                                           ││
-│  │  ELF mutation: splice .text, append .rj_trampolines, emit    ││
+│  │  ELF mutation: splice + grow .text with trampoline cave, emit││
 │  └──────────────────────────────────────────────────────────────┘│
 └──────────────────────────────────────────────────────────────────┘
 ```
@@ -56,7 +56,7 @@ ResolvedInstrumentationSite -- one validated anchor + snapshot of the
       |  make_trampoline_plan() + TrampolineBuilder::build()
       v
 (preflight: per-site plan + built bytes, accumulated locally)
-      |  splice anchors + append .rj_trampolines + emit()
+      |  splice anchors + append trampoline caves into .text + emit()
       v
 InstrumentedCodeObject      -- patched ELF + diagnostics
 ```
@@ -65,7 +65,7 @@ InstrumentedCodeObject      -- patched ELF + diagnostics
 
 - Lazy CFG construction: blocks are decoded on the first call that needs them via `Decoder::create(arch)` + `BasicBlock::build(obj, *decoder)`. Decoder creation failure (RV32I/RV64I/INVALID) surfaces as a structured `ValidationResult` / `InstrumentedCodeObject` error, not a crash.
 - `validate_points()` looks up the decoded `Instruction` at each requested `anchor_offset` and runs `validate_anchor()`. All-or-nothing today: any per-site failure empties `sites` and reports diagnostics in `errors`.
-- `patch()` runs validation, then per-site `make_trampoline_plan()` + `TrampolineBuilder::build()` as preflight. Only after every site succeeds does it splice patched anchor bytes into a local `.text` copy, `overwrite_text()`, accumulate trampoline words via `append_cave_body()`, and materialize the section with `append_cave_section(".rj_trampolines")`. Returns `InstrumentedCodeObject{elf_bytes, errors, warnings}`.
+- `patch()` runs validation, then per-site `make_trampoline_plan()` + `TrampolineBuilder::build()` as preflight. Only after every site succeeds does it splice patched anchor bytes into a local `.text` copy, `append_words()` each trampoline after the original bytes as a local code cave, and grow the section in one `replace_text()` call. Returns `InstrumentedCodeObject{elf_bytes, errors, warnings}`.
 - `patch_with_debug_summaries()` is a test/debug entry point returning `InstrumentedCodeObjectDebug` (extends `InstrumentedCodeObject` with per-site `InstrumentationPatch` summaries — schema unstable; production callers should prefer `patch()` and recover per-site info from a fresh disassembly).
 - Single-attempt: both entry points share one budget. After `patched_ = true`, subsequent calls return a fatal error. Recoverable errors require constructing a new Instrumentor.
 
@@ -233,21 +233,24 @@ For a code object with one queued `InstrumentationPoint` at `anchor_offset`:
 
 1. **Lazy block decode:** On the first stage that needs the CFG, `Decoder::create(arch)` + `BasicBlock::build(obj, *decoder)` populates `blocks_`. Unsupported arch surfaces as a fatal error here.
 2. **Validate:** `validate_points()` walks `points_`; for each, `find_instruction_at_offset()` locates the decoded `Instruction`, then `validate_anchor()` runs milestone-scoped + structural checks and produces a `ResolvedInstrumentationSite` capturing the original bytes.
-3. **Plan + build (preflight):** For each site, `make_trampoline_plan(site, arch, trampoline_offset)` produces a canonical inline-nop plan (`before_items = {{ s_nop 0 }}`, `emit_original = true`); `validate_inline_nop_plan()` rechecks shape; `TrampolineBuilder::build(plan)` lowers it to `TrampolineBytes`. Trampoline cursor is derived from `patcher.cave_start()`. Nothing is written to the patcher yet.
-4. **Splice:** Once every site preflighted, copy `.text` into a local buffer, `memcpy` each `patched_anchor_bytes` into its `anchor_offset`, then `patcher.overwrite_text()`.
-5. **Append:** For each site, `patcher.append_cave_body(trampoline_words)`; then `patcher.append_cave_section(".rj_trampolines")` materializes the new executable section immediately after `.text`.
-6. **Emit:** `patcher.emit()` returns the patched ELF.
+3. **Plan + build (preflight):** For each site, `make_trampoline_plan(site, arch, trampoline_offset)` produces a canonical inline-nop plan (`before_items = {{ s_nop 0 }}`, `emit_original = true`); `validate_inline_nop_plan()` rechecks shape; `TrampolineBuilder::build(plan)` lowers it to `TrampolineBytes`. The trampoline cursor begins at `patcher.text_size()` (the first byte of the local cave) and advances by each built trampoline's size. Nothing is written to the patcher yet.
+4. **Assemble + replace:** Once every site preflighted, copy `.text` into a local buffer, `memcpy` each `patched_anchor_bytes` into its `anchor_offset`, then `append_words()` every trampoline after the original bytes as a local code cave. A single `patcher.replace_text()` grows `.text` in place and fixes up the surrounding ELF (section/segment sizes, moved symbols, descriptor entries).
+5. **Emit:** `patcher.emit()` returns the patched ELF.
 
-The trampoline body for one site lays out as:
+The trampolines live inside `.text`, immediately after the original kernel bytes (like what DBT currently does). Keeping a single executable `.text` section avoids loaders that only treat `.text` as executable, and keeps cave offsets expressible as `.text`-relative bytes. Because the original bytes do not move, no branch offsets in the original code are relocated — only the in-place `s_branch` at each anchor is rewritten. One site lays out as:
 
 ```
-.rj_trampolines:
-  s_nop 0                     <-- inline-nop placeholder (becomes probe call later)
-  <relocated original word(s)> <-- 4 or 8 bytes, same encoding as the anchor
-  s_branch <return>           <-- back to anchor_offset + original_size
-
-.text @ anchor_offset:
-  s_branch <trampoline>       <-- forward branch into .rj_trampolines
+.text:
+  [original kernel bytes]
+  ...
+  @ anchor_offset:
+    s_branch <trampoline>       <-- forward branch into the local cave
+  ...
+  [local cave, after the original bytes]
+  @ trampoline_offset:
+    s_nop 0                     <-- inline-nop placeholder (becomes probe call later)
+    <relocated original word(s)> <-- 4 or 8 bytes, same encoding as the anchor
+    s_branch <return>           <-- back to anchor_offset + original_size
 ```
 
 Branch offsets are computed in SOPP `simm16` units; the trampoline must lie within `±32768 * 4` bytes of the anchor. For unusually large kernels this would require trampoline islands, which remain future work (same constraint as DBT code caves).
@@ -259,6 +262,6 @@ Branch offsets are computed in SOPP `simm16` units; the trampoline must lie with
 - **Unit (`tests/patch/instrumentor_test.cpp`):** Validator coverage (each rejection path on synthetic anchors, including the bounds-overflow regression for `is_relocatable_anchor`), inline-nop plan guardrail, `make_trampoline_plan`, end-to-end `patch()` on a synthetic ELF (expected anchor splice + trampoline layout + reparse), and a decoded round-trip of every word in the emitted trampoline.
 - **Unit (`tests/patch/trampoline_builder_test.cpp`):** Builder byte-layout contract, branch math, arch-honoring opcode selection, INT16 limit boundary cases.
 - **Unit (`tests/patch/instruction_builder_test.cpp`):** `compute_sopp_branch_simm16` boundary / alignment / overflow / negative-unaligned-delta.
-- **Static DBI smoke (`tests/dbi/hsa_dbi_smoke_test.cpp`, `HsaDbiSmokeStatic`):** Loads a real compiled gfx90a `vector_add` ELF, runs `Instrumentor::patch()`, asserts the patched ELF differs from the original, decodes the anchor as `s_branch`, and confirms `.rj_trampolines` exists. No GPU required.
+- **Static DBI smoke (`tests/dbi/hsa_dbi_smoke_test.cpp`, `HsaDbiSmokeStatic`):** Loads a real compiled gfx90a `vector_add` ELF, runs `Instrumentor::patch()`, asserts the patched ELF differs from the original, decodes the anchor as `s_branch`, and confirms `.text` grew to hold the appended trampoline cave. No GPU required.
 - **Hardware DBI smoke (`HsaDbiSmokeHardware`, gated on `HAS_CDNA2_GPU`):** Three tests on a real gfx90a GPU — patched ELF loads + validates via HSA; dispatched kernel produces bit-identical output to the original (the inline-nop placeholder is a no-op); a *sabotage* test overwrites the trampoline's `s_nop 0` with `s_endpgm 0` and asserts the kernel actually fails, proving the GPU genuinely executes the trampoline path rather than silently bypassing the splice. `hsa_init` / `hsa_shut_down` and gfx90a agent enumeration run once per suite via `SetUpTestSuite` / `TearDownTestSuite`.
 - Run with `build/tests/rocjitsu_tests` and `build/tests/hsa_dbi_smoke_test`.

--- a/emulation/rocjitsu/docs/dbi-design.md
+++ b/emulation/rocjitsu/docs/dbi-design.md
@@ -154,7 +154,7 @@ The intermediate site/plan types are expected to thicken as the framework grows 
 
 ### Code Object Patcher (`code/patch/code_object_patcher.h`) [shared with DBT]
 
-Owns ELF-level mutations. The DBI orchestrator uses: `text_bytes()` / `overwrite_text()` for the anchor splice, `set_cave_start()` + `append_cave_body()` + `append_cave_section()` for the appended trampolines, and `emit()` for the final patched ELF buffer. The patcher accepts any well-formed mutation request; layout decisions stay in the orchestrator. The orchestrator establishes the cave coordinate once (`set_cave_start(text_size())`) and reads it back via `cave_start()` rather than recomputing.
+Owns ELF-level mutations. The DBI orchestrator reads the original payload via `text_bytes()`, assembles the new `.text` locally (each anchor spliced in place, then every trampoline appended after the original bytes with `append_words()`), and applies it with a single `replace_text()` before `emit()` returns the patched ELF buffer. The patcher accepts any well-formed mutation request; layout decisions stay in the orchestrator. Trampolines live inside `.text` as a local code cave (the same layout DBT uses) rather than a separate section, so cave offsets are plain `.text`-relative bytes in `[text_size, text_size + cave_bytes)`.
 
 ### Instruction Builder (`code/patch/instruction_builder.h`) [shared with DBT]
 

--- a/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/code/rj_code.h
+++ b/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/code/rj_code.h
@@ -98,6 +98,8 @@ RJ_API_EXPORT rj_status_t rj_code_decoder_decode(rj_code_decoder_t *decoder,
 
 /// @brief GPU target identifiers.
 typedef enum rj_code_target_id_t {
+  /// @brief gfx90a target ID (CDNA2).
+  ROCJITSU_CODE_TARGET_GFX90A = 2,
   /// @brief gfx942 target ID (CDNA3).
   ROCJITSU_CODE_TARGET_GFX942,
   /// @brief gfx950 target ID (CDNA4).

--- a/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/code/rj_code.h
+++ b/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/code/rj_code.h
@@ -98,8 +98,6 @@ RJ_API_EXPORT rj_status_t rj_code_decoder_decode(rj_code_decoder_t *decoder,
 
 /// @brief GPU target identifiers.
 typedef enum rj_code_target_id_t {
-  /// @brief gfx90a target ID (CDNA2).
-  ROCJITSU_CODE_TARGET_GFX90A = 2,
   /// @brief gfx942 target ID (CDNA3).
   ROCJITSU_CODE_TARGET_GFX942,
   /// @brief gfx950 target ID (CDNA4).
@@ -110,6 +108,8 @@ typedef enum rj_code_target_id_t {
   ROCJITSU_CODE_TARGET_GFX1201,
   /// @brief gfx1250 target ID.
   ROCJITSU_CODE_TARGET_GFX1250,
+  /// @brief gfx90a target ID (CDNA2).
+  ROCJITSU_CODE_TARGET_GFX90A,
   /// @brief Sentinel value representing an invalid target.
   ROCJITSU_CODE_TARGET_INVALID
 } rj_code_target_id_t;

--- a/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/code/rj_code.h
+++ b/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/code/rj_code.h
@@ -98,6 +98,8 @@ RJ_API_EXPORT rj_status_t rj_code_decoder_decode(rj_code_decoder_t *decoder,
 
 /// @brief GPU target identifiers.
 typedef enum rj_code_target_id_t {
+  /// @brief gfx90a target ID (CDNA2).
+  ROCJITSU_CODE_TARGET_GFX90A,
   /// @brief gfx942 target ID (CDNA3).
   ROCJITSU_CODE_TARGET_GFX942,
   /// @brief gfx950 target ID (CDNA4).
@@ -108,8 +110,6 @@ typedef enum rj_code_target_id_t {
   ROCJITSU_CODE_TARGET_GFX1201,
   /// @brief gfx1250 target ID.
   ROCJITSU_CODE_TARGET_GFX1250,
-  /// @brief gfx90a target ID (CDNA2).
-  ROCJITSU_CODE_TARGET_GFX90A,
   /// @brief Sentinel value representing an invalid target.
   ROCJITSU_CODE_TARGET_INVALID
 } rj_code_target_id_t;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/CMakeLists.txt
@@ -23,4 +23,5 @@ rj_add_object_library(rocjitsu_code
     patch/kernel_text_layout.cpp
     patch/instruction_builder.cpp
     patch/spill_manager.cpp
+    patch/trampoline_builder.cpp
 )

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/CMakeLists.txt
@@ -22,6 +22,7 @@ rj_add_object_library(rocjitsu_code
     patch/code_object_patcher.cpp
     patch/kernel_text_layout.cpp
     patch/instruction_builder.cpp
+    patch/instrumentor.cpp
     patch/spill_manager.cpp
     patch/trampoline_builder.cpp
 )

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_code_object.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_code_object.cpp
@@ -49,6 +49,8 @@ using detail::fits_in_bounds;
 
 rj_code_target_id_t target_from_machine_flags(uint32_t flags) {
   uint32_t mach = flags & EF_AMDGPU_MACH;
+  if (mach == EF_AMDGPU_MACH_AMDGCN_GFX90A)
+    return ROCJITSU_CODE_TARGET_GFX90A;
   if (mach == EF_AMDGPU_MACH_AMDGCN_GFX942)
     return ROCJITSU_CODE_TARGET_GFX942;
   if (mach == EF_AMDGPU_MACH_AMDGCN_GFX950)
@@ -63,6 +65,8 @@ rj_code_target_id_t target_from_machine_flags(uint32_t flags) {
 }
 
 rj_code_target_id_t target_from_triple(const std::string &triple) {
+  if (triple == "gfx90a")
+    return ROCJITSU_CODE_TARGET_GFX90A;
   if (triple == "gfx942")
     return ROCJITSU_CODE_TARGET_GFX942;
   if (triple == "gfx950")

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -76,33 +76,6 @@ LegalizationLookupFn select_legalization(rj_code_arch_t guest, rj_code_arch_t ho
   return nullptr;
 }
 
-[[nodiscard]] bool compute_sopp_branch_offset(uint64_t branch_pc, uint64_t target,
-                                              int16_t &offset_dwords) {
-  // SOPP branches encode a signed dword offset from the next instruction. Keep
-  // the range check shared so both cave entry and return branches fail closed.
-  constexpr int64_t kBranchPcBiasBytes = static_cast<int64_t>(sizeof(uint32_t));
-  constexpr uint64_t kMaxSignedTarget = static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
-  constexpr uint64_t kMaxSignedBranchPc =
-      static_cast<uint64_t>(std::numeric_limits<int64_t>::max() - kBranchPcBiasBytes);
-  // The PCs are unsigned until this check passes. Compare against the casted
-  // signed int64_t limits so the later signed conversion, and branch_pc + 4,
-  // cannot overflow.
-  if (branch_pc > kMaxSignedBranchPc || target > kMaxSignedTarget)
-    return false;
-
-  const int64_t delta_bytes = static_cast<int64_t>(target) - (static_cast<int64_t>(branch_pc) + 4);
-  if (delta_bytes % static_cast<int64_t>(sizeof(uint32_t)) != 0)
-    return false;
-
-  const int64_t delta_dwords = delta_bytes / static_cast<int64_t>(sizeof(uint32_t));
-  if (delta_dwords < std::numeric_limits<int16_t>::min() ||
-      delta_dwords > std::numeric_limits<int16_t>::max())
-    return false;
-
-  offset_dwords = static_cast<int16_t>(delta_dwords);
-  return true;
-}
-
 [[nodiscard]] std::vector<uint32_t> raw_words_for_inst(const Instruction &inst) {
   const uint32_t *raw = inst.raw_encoding();
   if (!raw)
@@ -435,16 +408,16 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       layout.target_entry = translated_text.size();
       append_words(translated_text, scope.translation->prologue_words);
 
-      int16_t branch_dwords = 0;
       const uint64_t branch_pc = translated_text.size();
-      if (!compute_sopp_branch_offset(branch_pc, layout.target_body_entry, branch_dwords)) {
+      const auto branch_dwords = compute_sopp_branch_simm16(branch_pc, layout.target_body_entry);
+      if (!branch_dwords) {
         append_error(result.diagnostics, DiagnosticKind::ResourceLimit,
                      "kernel descriptor prologue branch range exceeds s_branch simm16; leaving "
                      "code object unchanged",
                      layout.source_entry);
         return leave_unchanged();
       }
-      const uint32_t branch = build_s_branch(branch_dwords, host_arch_);
+      const uint32_t branch = build_s_branch(*branch_dwords, host_arch_);
       append_words(translated_text, std::span<const uint32_t>(&branch, 1));
       layout.cave_end = translated_text.size();
     } else {
@@ -780,8 +753,8 @@ bool BinaryTranslator::apply_semantic(const SemanticReplacement &repl, std::vect
   const uint64_t branch_pc = repl.start_offset;
 
   // s_branch simm16 targets (PC + 4 + simm16*4).
-  int16_t fwd_dwords = 0;
-  if (!compute_sopp_branch_offset(branch_pc, cave_byte_offset, fwd_dwords)) {
+  const auto fwd_dwords = compute_sopp_branch_simm16(branch_pc, cave_byte_offset);
+  if (!fwd_dwords) {
     if (diagnostics_)
       append_error(*diagnostics_, DiagnosticKind::ResourceLimit,
                    "code cave branch range exceeds s_branch simm16; leaving code object unchanged",
@@ -789,7 +762,7 @@ bool BinaryTranslator::apply_semantic(const SemanticReplacement &repl, std::vect
     return false;
   }
 
-  const uint32_t stub = build_s_branch(fwd_dwords, host_arch_);
+  const uint32_t stub = build_s_branch(*fwd_dwords, host_arch_);
   std::memcpy(text.data() + repl.start_offset, &stub, 4);
   for (uint64_t off = repl.start_offset + 4; off < repl.end_offset; off += 4) {
     const uint32_t nop = build_s_nop(0, host_arch_);
@@ -797,9 +770,9 @@ bool BinaryTranslator::apply_semantic(const SemanticReplacement &repl, std::vect
   }
 
   auto cave_words = repl.target_words;
-  int16_t ret_dwords = 0;
   const uint64_t return_branch_pc = cave_byte_offset + cave_words.size() * sizeof(uint32_t);
-  if (!compute_sopp_branch_offset(return_branch_pc, stub_next, ret_dwords)) {
+  const auto ret_dwords = compute_sopp_branch_simm16(return_branch_pc, stub_next);
+  if (!ret_dwords) {
     if (diagnostics_)
       append_error(*diagnostics_, DiagnosticKind::ResourceLimit,
                    "code cave return branch range exceeds s_branch simm16; leaving code object "
@@ -807,7 +780,7 @@ bool BinaryTranslator::apply_semantic(const SemanticReplacement &repl, std::vect
                    repl.start_offset);
     return false;
   }
-  cave_words.push_back(build_s_branch(ret_dwords, host_arch_));
+  cave_words.push_back(build_s_branch(*ret_dwords, host_arch_));
 
   append_words(text, cave_words);
   layout.cave_end = text.size();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/error_report.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/error_report.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file error_report.h
+/// @brief Shared helper for the patch layer's optional-error-string convention:
+///        functions that may fail take a `std::string *error_out` (often null)
+///        and assign a diagnostic when it is non-null.
+
+#pragma once
+
+#include <string>
+
+namespace rocjitsu {
+
+/// @brief Write @p msg into @p out when @p out is non-null; no-op otherwise.
+///
+/// Replaces (does not append). Each function that takes a `std::string *`
+/// out-param is contracted to report at most one failure per call. This is
+/// so that the string holds "this call's single failure reason", as opposed to
+/// a running log. The caller is in charge of Cross-call accumulation (e.g.
+/// `std::vector<std::string>`).
+inline void report(std::string *out, const char *msg) {
+  if (out)
+    *out = msg;
+}
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instruction_builder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instruction_builder.h
@@ -109,6 +109,18 @@ inline constexpr uint16_t kDelayAluSaluDep1 = 9;
   }
 }
 
+/// @brief Get the s_endpgm opcode for a target ISA.
+[[nodiscard]] inline constexpr uint32_t sopp_op_endpgm(rj_code_arch_t arch) {
+  // GFX9 (CDNA1-4): opcode 1; GFX12 (RDNA3/3.5/4): opcode 48
+  switch (arch) {
+  case ROCJITSU_CODE_ARCH_RDNA3:
+  case ROCJITSU_CODE_ARCH_RDNA3_5:
+  case ROCJITSU_CODE_ARCH_RDNA4:
+    return 48;
+  default:
+    return 1;
+  }
+}
 /// @brief Get the s_nop opcode for a target ISA.
 [[nodiscard]] inline constexpr uint32_t sopp_op_nop([[maybe_unused]] rj_code_arch_t arch) {
   return 0; // s_nop is opcode 0 on all ISAs
@@ -177,10 +189,13 @@ build_s_nop(uint16_t cycles = 0, rj_code_arch_t arch = ROCJITSU_CODE_ARCH_RDNA4)
   return pack_sopp(sopp_op_nop(arch), cycles);
 }
 
-// TODO: add build_s_endpgm(uint16_t simm16, rj_code_arch_t arch). s_endpgm is
-// opcode 1 on GFX9 (CDNA1-4) and opcode 48 (0x30) on GFX12 (RDNA4); the
-// sabotage path in tests/dbi/hsa_dbi_smoke_test.cpp currently hardcodes the
-// CDNA encoding 0xBF810000.
+/// @brief Encode an s_endpgm instruction for the given target ISA.
+///
+/// @param arch    Target ISA architecture.
+/// @returns The encoded 32-bit instruction word.
+[[nodiscard]] inline constexpr uint32_t build_s_endpgm(rj_code_arch_t arch) {
+  return pack_sopp(sopp_op_endpgm(arch), 0);
+}
 
 /// @brief Encode s_delay_alu for the given target ISA.
 [[nodiscard]] inline constexpr uint32_t build_s_delay_alu(uint16_t simm16, rj_code_arch_t) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instruction_builder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instruction_builder.h
@@ -20,6 +20,8 @@
 #pragma once
 
 #include <cstdint>
+#include <limits>
+#include <optional>
 #include <span>
 
 #include "rocjitsu/code/rj_code.h"
@@ -60,6 +62,38 @@ inline constexpr uint16_t kDelayAluSaluDep1 = 9;
 /// @brief Scalar source operand encoding for a non-negative inline integer.
 [[nodiscard]] inline constexpr uint16_t scalar_positive_inline_u32(uint16_t value) {
   return static_cast<uint16_t>(kScalarPositiveInlineBase + value);
+}
+
+/// @brief Compute the SOPP simm16 dword field for a branch from @p branch_pc
+///        to @p target under SOPP semantics: target = branch_pc + 4 + simm16*4.
+///
+/// Returns std::nullopt if the delta is not dword-aligned, if it does not fit
+/// in a signed 16-bit dword field, or if @p branch_pc / @p target are large
+/// enough that the signed int64 intermediate would overflow.
+///
+/// Shared by DBT cave-entry/return branches and the DBI relocation trampoline
+/// so both paths fail closed on the same range.
+[[nodiscard]] inline constexpr std::optional<int16_t>
+compute_sopp_branch_simm16(uint64_t branch_pc, uint64_t target) {
+  constexpr int64_t kBranchPcBiasBytes = static_cast<int64_t>(sizeof(uint32_t));
+  constexpr uint64_t kMaxSignedTarget =
+      static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
+  constexpr uint64_t kMaxSignedBranchPc =
+      static_cast<uint64_t>(std::numeric_limits<int64_t>::max() - kBranchPcBiasBytes);
+  if (branch_pc > kMaxSignedBranchPc || target > kMaxSignedTarget)
+    return std::nullopt;
+
+  const int64_t delta_bytes =
+      static_cast<int64_t>(target) - (static_cast<int64_t>(branch_pc) + kBranchPcBiasBytes);
+  if (delta_bytes % static_cast<int64_t>(sizeof(uint32_t)) != 0)
+    return std::nullopt;
+
+  const int64_t delta_dwords = delta_bytes / static_cast<int64_t>(sizeof(uint32_t));
+  if (delta_dwords < std::numeric_limits<int16_t>::min() ||
+      delta_dwords > std::numeric_limits<int16_t>::max())
+    return std::nullopt;
+
+  return static_cast<int16_t>(delta_dwords);
 }
 
 /// @brief Get the s_branch opcode for a target ISA.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instruction_builder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instruction_builder.h
@@ -73,11 +73,10 @@ inline constexpr uint16_t kDelayAluSaluDep1 = 9;
 ///
 /// Shared by DBT cave-entry/return branches and the DBI relocation trampoline
 /// so both paths fail closed on the same range.
-[[nodiscard]] inline constexpr std::optional<int16_t>
-compute_sopp_branch_simm16(uint64_t branch_pc, uint64_t target) {
+[[nodiscard]] inline constexpr std::optional<int16_t> compute_sopp_branch_simm16(uint64_t branch_pc,
+                                                                                 uint64_t target) {
   constexpr int64_t kBranchPcBiasBytes = static_cast<int64_t>(sizeof(uint32_t));
-  constexpr uint64_t kMaxSignedTarget =
-      static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
+  constexpr uint64_t kMaxSignedTarget = static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
   constexpr uint64_t kMaxSignedBranchPc =
       static_cast<uint64_t>(std::numeric_limits<int64_t>::max() - kBranchPcBiasBytes);
   if (branch_pc > kMaxSignedBranchPc || target > kMaxSignedTarget)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instruction_builder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instruction_builder.h
@@ -67,9 +67,10 @@ inline constexpr uint16_t kDelayAluSaluDep1 = 9;
 /// @brief Compute the SOPP simm16 dword field for a branch from @p branch_pc
 ///        to @p target under SOPP semantics: target = branch_pc + 4 + simm16*4.
 ///
-/// Returns std::nullopt if the delta is not dword-aligned, if it does not fit
-/// in a signed 16-bit dword field, or if @p branch_pc / @p target are large
-/// enough that the signed int64 intermediate would overflow.
+/// Returns std::nullopt if @p branch_pc or @p target is not dword-aligned, if
+/// the resulting delta does not fit in a signed 16-bit dword field, or if
+/// @p branch_pc / @p target are large enough that the signed int64 intermediate
+/// would overflow.
 ///
 /// Shared by DBT cave-entry/return branches and the DBI relocation trampoline
 /// so both paths fail closed on the same range.
@@ -82,11 +83,13 @@ inline constexpr uint16_t kDelayAluSaluDep1 = 9;
   if (branch_pc > kMaxSignedBranchPc || target > kMaxSignedTarget)
     return std::nullopt;
 
-  const int64_t delta_bytes =
-      static_cast<int64_t>(target) - (static_cast<int64_t>(branch_pc) + kBranchPcBiasBytes);
-  if (delta_bytes % static_cast<int64_t>(sizeof(uint32_t)) != 0)
+  // The SOPP immediate is a signed *dword* offset, so both the branch base
+  // (branch_pc + 4) and the target must be dword-aligned.
+  if (branch_pc % sizeof(uint32_t) != 0 || target % sizeof(uint32_t) != 0)
     return std::nullopt;
 
+  const int64_t delta_bytes =
+      static_cast<int64_t>(target) - (static_cast<int64_t>(branch_pc) + kBranchPcBiasBytes);
   const int64_t delta_dwords = delta_bytes / static_cast<int64_t>(sizeof(uint32_t));
   if (delta_dwords < std::numeric_limits<int16_t>::min() ||
       delta_dwords > std::numeric_limits<int16_t>::max())
@@ -111,11 +114,12 @@ inline constexpr uint16_t kDelayAluSaluDep1 = 9;
 
 /// @brief Get the s_endpgm opcode for a target ISA.
 [[nodiscard]] inline constexpr uint32_t sopp_op_endpgm(rj_code_arch_t arch) {
-  // GFX9 (CDNA1-4): opcode 1; GFX12 (RDNA3/3.5/4): opcode 48
+  // GFX9 (CDNA1-4): opcode 1; GFX12 (RDNA3/3.5/4, gfx1250): opcode 48
   switch (arch) {
   case ROCJITSU_CODE_ARCH_RDNA3:
   case ROCJITSU_CODE_ARCH_RDNA3_5:
   case ROCJITSU_CODE_ARCH_RDNA4:
+  case ROCJITSU_CODE_ARCH_GFX1250:
     return 48;
   default:
     return 1;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instruction_builder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instruction_builder.h
@@ -177,6 +177,11 @@ build_s_nop(uint16_t cycles = 0, rj_code_arch_t arch = ROCJITSU_CODE_ARCH_RDNA4)
   return pack_sopp(sopp_op_nop(arch), cycles);
 }
 
+// TODO: add build_s_endpgm(uint16_t simm16, rj_code_arch_t arch). s_endpgm is
+// opcode 1 on GFX9 (CDNA1-4) and opcode 48 (0x30) on GFX12 (RDNA4); the
+// sabotage path in tests/dbi/hsa_dbi_smoke_test.cpp currently hardcodes the
+// CDNA encoding 0xBF810000.
+
 /// @brief Encode s_delay_alu for the given target ISA.
 [[nodiscard]] inline constexpr uint32_t build_s_delay_alu(uint16_t simm16, rj_code_arch_t) {
   constexpr uint8_t kSoppDelayAlu = 7;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
@@ -58,10 +58,49 @@ struct AppliedSite {
 
 } // namespace
 
+bool is_relocatable_anchor(const Instruction &anchor, uint64_t anchor_offset,
+                           std::span<const uint8_t> text_bytes,
+                           [[maybe_unused]] rj_code_arch_t arch, std::string *error_out) {
+  if (anchor_offset % sizeof(uint32_t) != 0) {
+    report(error_out, "anchor_offset must be dword aligned");
+    return false;
+  }
+  // Instruction::size() returns int by convention; the `!= 4 && != 8` check
+  // also rejects negative values (which decoders never produce in practice).
+  const int size = anchor.size();
+  if (size != 4 && size != 8) {
+    report(error_out, "anchor instruction size must be 4 or 8 bytes");
+    return false;
+  }
+  if (anchor_offset + static_cast<uint64_t>(size) > text_bytes.size()) {
+    report(error_out, "anchor extends past end of .text");
+    return false;
+  }
+  if (anchor.raw_encoding() == nullptr) {
+    report(error_out, "anchor instruction has no raw encoding bytes");
+    return false;
+  }
+  constexpr uint64_t kControlFlowFlags =
+      BRANCH | COND_BRANCH | INDIRECT_BRANCH | INDIRECT_CALL | PROGRAM_TERMINATOR;
+  if (anchor.flags() & kControlFlowFlags) {
+    report(error_out, "anchor instruction is a branch / indirect / program terminator");
+    return false;
+  }
+  if (anchor.branch_offset_bytes().has_value()) {
+    report(error_out, "anchor instruction has a PC-relative branch offset");
+    return false;
+  }
+  if (is_denylisted_mnemonic(anchor.mnemonic())) {
+    report(error_out, "anchor mnemonic is in the PC-relative denylist");
+    return false;
+  }
+  return true;
+}
+
 std::optional<ResolvedInstrumentationSite>
 validate_anchor(const Instruction &anchor, uint64_t anchor_offset,
                 std::span<const uint8_t> text_bytes, const InstrumentationPoint &pt,
-                [[maybe_unused]] rj_code_arch_t arch, std::string *error_out) {
+                rj_code_arch_t arch, std::string *error_out) {
   if (pt.filter_flags != 0) {
     report(error_out, "InstrumentationPoint::filter_flags must be 0 in the inline-nop milestone");
     return std::nullopt;
@@ -88,45 +127,15 @@ validate_anchor(const Instruction &anchor, uint64_t anchor_offset,
            "InstrumentationPoint::force_full_exec must be false in the inline-nop milestone");
     return std::nullopt;
   }
-  if (anchor_offset % sizeof(uint32_t) != 0) {
-    report(error_out, "anchor_offset must be dword aligned");
-    return std::nullopt;
-  }
-  // Instruction::size() returns int by convention; the `!= 4 && != 8` check
-  // also rejects negative values (which decoders never produce in practice).
-  const int size = anchor.size();
-  if (size != 4 && size != 8) {
-    report(error_out, "anchor instruction size must be 4 or 8 bytes");
-    return std::nullopt;
-  }
-  if (anchor_offset + static_cast<uint64_t>(size) > text_bytes.size()) {
-    report(error_out, "anchor extends past end of .text");
-    return std::nullopt;
-  }
-  if (anchor.raw_encoding() == nullptr) {
-    report(error_out, "anchor instruction has no raw encoding bytes");
-    return std::nullopt;
-  }
-  constexpr uint64_t kControlFlowFlags =
-      BRANCH | COND_BRANCH | INDIRECT_BRANCH | INDIRECT_CALL | PROGRAM_TERMINATOR;
-  if (anchor.flags() & kControlFlowFlags) {
-    report(error_out, "anchor instruction is a branch / indirect / program terminator");
-    return std::nullopt;
-  }
-  if (anchor.branch_offset_bytes().has_value()) {
-    report(error_out, "anchor instruction has a PC-relative branch offset");
-    return std::nullopt;
-  }
-  if (is_denylisted_mnemonic(anchor.mnemonic())) {
-    report(error_out, "anchor mnemonic is in the PC-relative denylist");
-    return std::nullopt;
-  }
 
+  if (!is_relocatable_anchor(anchor, anchor_offset, text_bytes, arch, error_out))
+    return std::nullopt;
+
+  const auto size = static_cast<uint32_t>(anchor.size());
   ResolvedInstrumentationSite site;
-  site.anchor_inst = &anchor;
   site.kind = pt.kind;
   site.anchor_offset = anchor_offset;
-  site.original_size = static_cast<uint32_t>(size);
+  site.original_size = size;
   site.original_bytes.assign(text_bytes.begin() + anchor_offset,
                              text_bytes.begin() + anchor_offset + size);
   site.mnemonic = std::string(anchor.mnemonic());
@@ -187,11 +196,6 @@ void Instrumentor::add_point_by_offset(uint64_t anchor_offset, InstrumentationKi
   points_.push_back(std::move(pt));
 }
 
-std::span<const std::unique_ptr<BasicBlock>> Instrumentor::owned_blocks() {
-  ensure_blocks_built();
-  return blocks_;
-}
-
 void Instrumentor::ensure_blocks_built() {
   if (blocks_built_)
     return;
@@ -215,22 +219,8 @@ const Instruction *Instrumentor::find_instruction_at_offset(uint64_t anchor_offs
   return nullptr;
 }
 
-std::optional<uint64_t> Instrumentor::resolve_anchor_inst_to_offset(const Instruction *target,
-                                                                    std::string *err) {
-  for (const auto &block : blocks_) {
-    uint64_t cur = block->start_offset();
-    for (const Instruction &inst : block->instructions()) {
-      if (&inst == target)
-        return cur;
-      cur += static_cast<uint64_t>(inst.size());
-    }
-  }
-  report(err, "anchor_inst does not belong to any Instrumentor-owned block");
-  return std::nullopt;
-}
-
-Instrumentor::ResolveResult Instrumentor::resolve_and_validate() {
-  ResolveResult result;
+Instrumentor::ValidationResult Instrumentor::validate_points() {
+  ValidationResult result;
   ensure_blocks_built();
 
   if (obj_.text_sections().empty()) {
@@ -257,37 +247,14 @@ Instrumentor::ResolveResult Instrumentor::resolve_and_validate() {
   std::vector<ResolvedInstrumentationSite> sites;
   sites.reserve(points_.size());
   for (const auto &pt : points_) {
-    const bool has_inst = pt.anchor_inst != nullptr;
-    const bool has_off = pt.anchor_offset.has_value();
-    if (has_inst == has_off) {
-      result.errors.emplace_back(
-          has_inst ? "InstrumentationPoint sets both anchor_inst and anchor_offset"
-                   : "InstrumentationPoint sets neither anchor_inst nor anchor_offset");
+    const Instruction *anchor = find_instruction_at_offset(pt.anchor_offset);
+    if (anchor == nullptr) {
+      result.errors.emplace_back("no decoded instruction starts at the requested anchor_offset");
       continue;
     }
 
-    uint64_t offset = 0;
-    const Instruction *anchor = nullptr;
-    if (has_inst) {
-      std::string err;
-      auto off = resolve_anchor_inst_to_offset(pt.anchor_inst, &err);
-      if (!off) {
-        result.errors.push_back(std::move(err));
-        continue;
-      }
-      offset = *off;
-      anchor = pt.anchor_inst;
-    } else {
-      offset = *pt.anchor_offset;
-      anchor = find_instruction_at_offset(offset);
-      if (anchor == nullptr) {
-        result.errors.emplace_back("no decoded instruction starts at the requested anchor_offset");
-        continue;
-      }
-    }
-
     std::string err;
-    auto site = validate_anchor(*anchor, offset, text_bytes, pt, arch_, &err);
+    auto site = validate_anchor(*anchor, pt.anchor_offset, text_bytes, pt, arch_, &err);
     if (!site) {
       result.errors.push_back(std::move(err));
       continue;
@@ -320,12 +287,12 @@ InstrumentedCodeObject Instrumentor::patch() {
     return result;
   }
 
-  auto resolved = resolve_and_validate();
-  if (!resolved.errors.empty()) {
-    result.errors = std::move(resolved.errors);
+  auto validation = validate_points();
+  if (!validation.errors.empty()) {
+    result.errors = std::move(validation.errors);
     return result;
   }
-  const auto &sites = resolved.sites;
+  const auto &sites = validation.sites;
 
   // Construct the patcher and preflight builder output before mutating it.
   // TODO: The "cave" terminology is inherited from the patcher API (originally

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
@@ -72,7 +72,10 @@ bool is_relocatable_anchor(const Instruction &anchor, uint64_t anchor_offset,
     report(error_out, "anchor instruction size must be 4 or 8 bytes");
     return false;
   }
-  if (anchor_offset + static_cast<uint64_t>(size) > text_bytes.size()) {
+  // Subtraction-based bounds check: a huge anchor_offset would otherwise wrap
+  // the addition and silently pass.
+  const uint64_t size_u = static_cast<uint64_t>(size);
+  if (anchor_offset > text_bytes.size() || size_u > text_bytes.size() - anchor_offset) {
     report(error_out, "anchor extends past end of .text");
     return false;
   }
@@ -101,30 +104,29 @@ std::optional<ResolvedInstrumentationSite>
 validate_anchor(const Instruction &anchor, uint64_t anchor_offset,
                 std::span<const uint8_t> text_bytes, const InstrumentationPoint &pt,
                 rj_code_arch_t arch, std::string *error_out) {
+  // TODO: consume filter_flags to filter anchors based on InstFlags.
   if (pt.filter_flags != 0) {
-    report(error_out, "InstrumentationPoint::filter_flags must be 0 in the inline-nop milestone");
+    report(error_out, "InstrumentationPoint::filter_flags must be 0 temporarily");
     return std::nullopt;
   }
   // TODO: support AfterInst / BlockEntry / BlockExit.
   if (pt.kind != InstrumentationKind::BeforeInst) {
-    report(error_out, "InstrumentationPoint::kind must be BeforeInst in the inline-nop milestone");
+    report(error_out, "InstrumentationPoint::kind must be BeforeInst temporarily");
     return std::nullopt;
   }
   // TODO: consume probe_obj / probe_symbol when probe-call trampolines are
   // supported.
   if (pt.probe_obj != nullptr) {
-    report(error_out, "InstrumentationPoint::probe_obj must be null in the inline-nop milestone");
+    report(error_out, "InstrumentationPoint::probe_obj must be null temporarily");
     return std::nullopt;
   }
   if (!pt.probe_symbol.empty()) {
-    report(error_out,
-           "InstrumentationPoint::probe_symbol must be empty in the inline-nop milestone");
+    report(error_out, "InstrumentationPoint::probe_symbol must be empty temporarily");
     return std::nullopt;
   }
   // TODO: consume force_full_exec when EXEC policy management is implemented
   if (pt.force_full_exec) {
-    report(error_out,
-           "InstrumentationPoint::force_full_exec must be false in the inline-nop milestone");
+    report(error_out, "InstrumentationPoint::force_full_exec must be false temporarily");
     return std::nullopt;
   }
 
@@ -144,17 +146,17 @@ validate_anchor(const Instruction &anchor, uint64_t anchor_offset,
 
 bool validate_inline_nop_plan(const TrampolinePlan &plan, std::string *error_out) {
   if (!plan.emit_original) {
-    report(error_out, "trampoline plan: emit_original must be true for the inline-nop milestone");
+    report(error_out, "trampoline plan: emit_original must be true for the inlined nop");
     return false;
   }
   if (!plan.after_items.empty()) {
-    report(error_out, "trampoline plan: after_items must be empty for the inline-nop milestone");
+    report(error_out, "trampoline plan: after_items must be empty for the inline nop");
     return false;
   }
   if (plan.before_items.size() != 1 || plan.before_items[0].words.size() != 1 ||
       plan.before_items[0].words[0] != build_s_nop(0, plan.arch)) {
     report(error_out, "trampoline plan: before_items must be exactly { { s_nop 0 } } "
-                      "for the inline-nop milestone");
+                      "for the inlined nop");
     return false;
   }
   return true;
@@ -196,12 +198,18 @@ void Instrumentor::add_point_by_offset(uint64_t anchor_offset, InstrumentationKi
   points_.push_back(std::move(pt));
 }
 
-void Instrumentor::ensure_blocks_built() {
+bool Instrumentor::ensure_blocks_built(std::string *error_out) {
   if (blocks_built_)
-    return;
-  decoder_ = Decoder::create(arch_);
+    return true;
+  auto decoder = Decoder::create(arch_);
+  if (!decoder) {
+    report(error_out, "no decoder available for the requested architecture");
+    return false;
+  }
+  decoder_ = std::move(decoder);
   blocks_ = BasicBlock::build(obj_, *decoder_);
   blocks_built_ = true;
+  return true;
 }
 
 const Instruction *Instrumentor::find_instruction_at_offset(uint64_t anchor_offset) {
@@ -221,17 +229,21 @@ const Instruction *Instrumentor::find_instruction_at_offset(uint64_t anchor_offs
 
 Instrumentor::ValidationResult Instrumentor::validate_points() {
   ValidationResult result;
-  ensure_blocks_built();
+  std::string err;
+  if (!ensure_blocks_built(&err)) {
+    result.errors.push_back(std::move(err));
+    return result;
+  }
 
   if (obj_.text_sections().empty()) {
     result.errors.emplace_back("code object has no .text section");
     return result;
   }
-  // TODO(future milestone): support multi-text code objects. Anchor offsets
+  // TODO: support multi-text code objects. Anchor offsets
   // would need to identify which .text section they belong to.
   if (obj_.text_sections().size() > 1) {
     result.errors.emplace_back(
-        "code object has multiple .text sections; the inline-nop milestone supports only one");
+        "code object has multiple .text sections; currently supports only one");
     return result;
   }
   const Section *text = obj_.text_sections().front();
@@ -268,22 +280,28 @@ Instrumentor::ValidationResult Instrumentor::validate_points() {
 }
 
 InstrumentedCodeObject Instrumentor::patch() {
-  InstrumentedCodeObject result;
+  // Slice off the debug summaries; move the base subobject into the return.
+  auto debug = patch_with_debug_summaries();
+  return std::move(static_cast<InstrumentedCodeObject &>(debug));
+}
+
+InstrumentedCodeObjectDebug Instrumentor::patch_with_debug_summaries() {
+  InstrumentedCodeObjectDebug result;
 
   if (patched_) {
-    result.errors.emplace_back("Instrumentor::patch has already been called on this Instrumentor");
+    result.errors.emplace_back(
+        "Instrumentor::patch / patch_with_debug_summaries has already been called");
     return result;
   }
   patched_ = true;
 
-  // Inline-nop milestone restriction: exactly one queued point.
+  // Temporary restriction: exactly one queued point.
   if (points_.empty()) {
     result.errors.emplace_back("Instrumentor::patch requires exactly one queued point; got zero");
     return result;
   }
   if (points_.size() > 1) {
-    result.errors.emplace_back(
-        "Instrumentor::patch accepts only one queued point in the inline-nop milestone");
+    result.errors.emplace_back("Instrumentor::patch temporarily accepts only one queued point");
     return result;
   }
 
@@ -304,7 +322,9 @@ InstrumentedCodeObject Instrumentor::patch() {
 
   std::vector<AppliedSite> applied;
   applied.reserve(sites.size());
-  uint64_t cave_cursor = patcher.text_size();
+  // Derive the trampoline cursor from the patcher's recorded cave_start so
+  // the cave coordinate is established in exactly one place.
+  uint64_t cave_cursor = patcher.cave_start();
   for (const auto &site : sites) {
     const uint64_t trampoline_offset = cave_cursor;
     TrampolinePlan plan = make_trampoline_plan(site, arch_, trampoline_offset);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
@@ -7,6 +7,7 @@
 #include "rocjitsu/code/basic_block.h"
 #include "rocjitsu/code/code_object.h"
 #include "rocjitsu/code/patch/code_object_patcher.h"
+#include "rocjitsu/code/patch/error_report.h"
 #include "rocjitsu/code/patch/instruction_builder.h"
 #include "rocjitsu/code/patch/trampoline_builder.h"
 #include "rocjitsu/isa/decoder.h"
@@ -21,11 +22,6 @@
 namespace rocjitsu {
 
 namespace {
-
-void report(std::string *out, const char *msg) {
-  if (out)
-    *out = msg;
-}
 
 // PC-relative instructions that may not surface in flags() or
 // branch_offset_bytes() on every ISA. Exact-match list plus a prefix match
@@ -208,23 +204,20 @@ bool Instrumentor::ensure_blocks_built(std::string *error_out) {
   }
   decoder_ = std::move(decoder);
   blocks_ = BasicBlock::build(obj_, *decoder_);
+  for (const auto &block : blocks_) {
+    uint64_t cur = block->start_offset();
+    for (const Instruction &inst : block->instructions()) {
+      offset_to_inst_.emplace(cur, &inst);
+      cur += static_cast<uint64_t>(inst.size());
+    }
+  }
   blocks_built_ = true;
   return true;
 }
 
-const Instruction *Instrumentor::find_instruction_at_offset(uint64_t anchor_offset) {
-  for (const auto &block : blocks_) {
-    if (anchor_offset < block->start_offset() || anchor_offset >= block->end_offset())
-      continue;
-    uint64_t cur = block->start_offset();
-    for (const Instruction &inst : block->instructions()) {
-      if (cur == anchor_offset)
-        return &inst;
-      cur += static_cast<uint64_t>(inst.size());
-    }
-    return nullptr;
-  }
-  return nullptr;
+const Instruction *Instrumentor::find_instruction_at_offset(uint64_t anchor_offset) const {
+  auto it = offset_to_inst_.find(anchor_offset);
+  return it == offset_to_inst_.end() ? nullptr : it->second;
 }
 
 Instrumentor::ValidationResult Instrumentor::validate_points() {
@@ -335,16 +328,20 @@ InstrumentedCodeObjectDebug Instrumentor::patch_with_debug_summaries() {
     std::string err;
     if (!validate_inline_nop_plan(plan, &err)) {
       result.errors.push_back(std::move(err));
-      return result;
+      continue;
     }
     auto bytes = TrampolineBuilder::build(plan, &err);
     if (!bytes) {
       result.errors.push_back(std::move(err));
-      return result;
+      continue;
     }
     cave_cursor += bytes->trampoline_words.size() * sizeof(uint32_t);
     applied.push_back({&site, trampoline_offset, std::move(*bytes)});
   }
+
+  // All-or-nothing: bail before mutating the patcher if any site failed.
+  if (!result.errors.empty())
+    return result;
 
   // Every per-site validation, branch-range check, and trampoline-byte
   // construction has succeeded up to this point. Now time to patch.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
@@ -60,16 +60,15 @@ struct AppliedSite {
 
 std::optional<ResolvedInstrumentationSite>
 validate_anchor(const Instruction &anchor, uint64_t anchor_offset,
-                           std::span<const uint8_t> text_bytes, const InstrumentationPoint &pt,
-                           [[maybe_unused]] rj_code_arch_t arch, std::string *error_out) {
+                std::span<const uint8_t> text_bytes, const InstrumentationPoint &pt,
+                [[maybe_unused]] rj_code_arch_t arch, std::string *error_out) {
   if (pt.filter_flags != 0) {
     report(error_out, "InstrumentationPoint::filter_flags must be 0 in the inline-nop milestone");
     return std::nullopt;
   }
   // TODO: support AfterInst / BlockEntry / BlockExit.
   if (pt.kind != InstrumentationKind::BeforeInst) {
-    report(error_out,
-           "InstrumentationPoint::kind must be BeforeInst in the inline-nop milestone");
+    report(error_out, "InstrumentationPoint::kind must be BeforeInst in the inline-nop milestone");
     return std::nullopt;
   }
   // TODO: consume probe_obj / probe_symbol when probe-call trampolines are
@@ -152,8 +151,8 @@ bool validate_inline_nop_plan(const TrampolinePlan &plan, std::string *error_out
   return true;
 }
 
-TrampolinePlan make_trampoline_plan(const ResolvedInstrumentationSite &site,
-                                         rj_code_arch_t arch, uint64_t trampoline_offset) {
+TrampolinePlan make_trampoline_plan(const ResolvedInstrumentationSite &site, rj_code_arch_t arch,
+                                    uint64_t trampoline_offset) {
   TrampolinePlan plan;
   plan.arch = arch;
   plan.anchor_offset = site.anchor_offset;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
@@ -1,0 +1,400 @@
+// Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/code/patch/instrumentor.h"
+
+#include "rocjitsu/code/amdgpu_code_object.h"
+#include "rocjitsu/code/basic_block.h"
+#include "rocjitsu/code/code_object.h"
+#include "rocjitsu/code/patch/code_object_patcher.h"
+#include "rocjitsu/code/patch/instruction_builder.h"
+#include "rocjitsu/code/patch/trampoline_builder.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+
+#include <array>
+#include <cstring>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace rocjitsu {
+
+namespace {
+
+void report(std::string *out, const char *msg) {
+  if (out) *out = msg;
+}
+
+// PC-relative instructions that may not surface in flags() or
+// branch_offset_bytes() on every ISA. Exact-match list plus a prefix match
+// for the s_rfe_* family (variants differ across ISAs).
+constexpr std::array<std::string_view, 4> kPcRelativeDenylist = {
+    "s_getpc_b64",
+    "s_call_b64",
+    "s_setpc_b64",
+    "s_swappc_b64",
+};
+
+constexpr std::string_view kRfePrefix = "s_rfe_";
+
+[[nodiscard]] bool is_denylisted_mnemonic(std::string_view mnemonic) {
+  for (auto m : kPcRelativeDenylist)
+    if (mnemonic == m) return true;
+  if (mnemonic.size() >= kRfePrefix.size() &&
+      mnemonic.substr(0, kRfePrefix.size()) == kRfePrefix)
+    return true;
+  return false;
+}
+
+// Per-site result of patch_relocation_only's preflight: the chosen trampoline
+// offset and the concrete bytes we'll splice in once all preflights succeed.
+struct AppliedSite {
+  const ResolvedInstrumentationSite *site;
+  uint64_t trampoline_offset;
+  TrampolineBytes bytes;
+};
+
+} // namespace
+
+std::optional<ResolvedInstrumentationSite>
+validate_relocation_anchor(const Instruction &anchor, uint64_t anchor_offset,
+                           std::span<const uint8_t> text_bytes,
+                           const InstrumentationPoint &pt,
+                           [[maybe_unused]] rj_code_arch_t arch, std::string *error_out) {
+  if (pt.filter_flags != 0) {
+    report(error_out, "InstrumentationPoint::filter_flags must be 0 in the inline-nop smoke build");
+    return std::nullopt;
+  }
+  // TODO(future milestone): support AfterInst / BlockEntry / BlockExit.
+  if (pt.kind != InstrumentationKind::BeforeInst) {
+    report(error_out,
+           "InstrumentationPoint::kind must be BeforeInst in the inline-nop smoke build");
+    return std::nullopt;
+  }
+  // TODO(future milestone): consume probe_obj / probe_symbol when probe-call
+  // trampolines are supported.
+  if (pt.probe_obj != nullptr) {
+    report(error_out, "InstrumentationPoint::probe_obj must be null in the inline-nop smoke build");
+    return std::nullopt;
+  }
+  if (!pt.probe_symbol.empty()) {
+    report(error_out,
+           "InstrumentationPoint::probe_symbol must be empty in the inline-nop smoke build");
+    return std::nullopt;
+  }
+  // TODO(future milestone): consume force_full_exec when EXEC policy
+  // management lands.
+  if (pt.force_full_exec) {
+    report(error_out,
+           "InstrumentationPoint::force_full_exec must be false in the inline-nop smoke build");
+    return std::nullopt;
+  }
+  if (anchor_offset % sizeof(uint32_t) != 0) {
+    report(error_out, "anchor_offset must be dword aligned");
+    return std::nullopt;
+  }
+  // Instruction::size() returns int by convention; the `!= 4 && != 8` check
+  // also rejects negative values (which decoders never produce in practice).
+  const int size = anchor.size();
+  if (size != 4 && size != 8) {
+    report(error_out, "anchor instruction size must be 4 or 8 bytes");
+    return std::nullopt;
+  }
+  if (anchor_offset + static_cast<uint64_t>(size) > text_bytes.size()) {
+    report(error_out, "anchor extends past end of .text");
+    return std::nullopt;
+  }
+  if (anchor.raw_encoding() == nullptr) {
+    report(error_out, "anchor instruction has no raw encoding bytes");
+    return std::nullopt;
+  }
+  constexpr uint64_t kControlFlowFlags =
+      BRANCH | COND_BRANCH | INDIRECT_BRANCH | INDIRECT_CALL | PROGRAM_TERMINATOR;
+  if (anchor.flags() & kControlFlowFlags) {
+    report(error_out, "anchor instruction is a branch / indirect / program terminator");
+    return std::nullopt;
+  }
+  if (anchor.branch_offset_bytes().has_value()) {
+    report(error_out, "anchor instruction has a PC-relative branch offset");
+    return std::nullopt;
+  }
+  if (is_denylisted_mnemonic(anchor.mnemonic())) {
+    report(error_out, "anchor mnemonic is in the PC-relative denylist");
+    return std::nullopt;
+  }
+
+  ResolvedInstrumentationSite site;
+  site.anchor_inst = &anchor;
+  site.kind = pt.kind;
+  site.anchor_offset = anchor_offset;
+  site.original_size = static_cast<uint32_t>(size);
+  site.original_bytes.assign(text_bytes.begin() + anchor_offset,
+                             text_bytes.begin() + anchor_offset + size);
+  site.mnemonic = std::string(anchor.mnemonic());
+  return site;
+}
+
+bool validate_inline_nop_smoke_plan(const TrampolinePlan &plan, std::string *error_out) {
+  if (!plan.emit_original) {
+    report(error_out,
+           "trampoline plan: emit_original must be true for the inline-nop smoke build");
+    return false;
+  }
+  if (!plan.after_items.empty()) {
+    report(error_out, "trampoline plan: after_items must be empty for the inline-nop smoke build");
+    return false;
+  }
+  if (plan.before_items.size() != 1 || plan.before_items[0].words.size() != 1 ||
+      plan.before_items[0].words[0] != build_s_nop(0, plan.arch)) {
+    report(error_out,
+           "trampoline plan: before_items must be exactly { { s_nop 0 } } "
+           "for the inline-nop smoke build");
+    return false;
+  }
+  return true;
+}
+
+TrampolinePlan make_relocation_only_plan(const ResolvedInstrumentationSite &site,
+                                         rj_code_arch_t arch, uint64_t trampoline_offset) {
+  TrampolinePlan plan;
+  plan.arch = arch;
+  plan.anchor_offset = site.anchor_offset;
+  plan.original_size = site.original_size;
+  plan.trampoline_offset = trampoline_offset;
+  plan.return_target = site.anchor_offset + site.original_size;
+
+  // Little-endian host assumption (consistent with DBT and the rest of the
+  // codebase): host byte order matches AMDGPU's little-endian encoding, so
+  // memcpy of the raw bytes into uint32_t words preserves semantics.
+  const size_t num_words = site.original_size / sizeof(uint32_t);
+  plan.original_words.resize(num_words);
+  std::memcpy(plan.original_words.data(), site.original_bytes.data(), site.original_size);
+
+  plan.before_items = {InlineAsmItem{{build_s_nop(0, arch)}}};
+  plan.after_items = {};
+  plan.emit_original = true;
+  return plan;
+}
+
+Instrumentor::Instrumentor(const AmdGpuCodeObject &obj, rj_code_arch_t arch)
+    : obj_(obj), arch_(arch) {}
+
+Instrumentor::~Instrumentor() = default;
+
+void Instrumentor::add_point(InstrumentationPoint pt) { points_.push_back(std::move(pt)); }
+
+void Instrumentor::add_point_by_offset(uint64_t anchor_offset, InstrumentationKind kind) {
+  InstrumentationPoint pt;
+  pt.anchor_offset = anchor_offset;
+  pt.kind = kind;
+  points_.push_back(std::move(pt));
+}
+
+std::span<const std::unique_ptr<BasicBlock>> Instrumentor::owned_blocks() {
+  ensure_blocks_built();
+  return blocks_;
+}
+
+void Instrumentor::ensure_blocks_built() {
+  if (blocks_built_) return;
+  decoder_ = Decoder::create(arch_);
+  blocks_ = BasicBlock::build(obj_, *decoder_);
+  blocks_built_ = true;
+}
+
+const Instruction *Instrumentor::find_instruction_at_offset(uint64_t anchor_offset) {
+  for (const auto &block : blocks_) {
+    if (anchor_offset < block->start_offset() || anchor_offset >= block->end_offset())
+      continue;
+    uint64_t cur = block->start_offset();
+    for (const Instruction &inst : block->instructions()) {
+      if (cur == anchor_offset) return &inst;
+      cur += static_cast<uint64_t>(inst.size());
+    }
+    return nullptr;
+  }
+  return nullptr;
+}
+
+std::optional<uint64_t>
+Instrumentor::resolve_anchor_inst_to_offset(const Instruction *target, std::string *err) {
+  for (const auto &block : blocks_) {
+    uint64_t cur = block->start_offset();
+    for (const Instruction &inst : block->instructions()) {
+      if (&inst == target) return cur;
+      cur += static_cast<uint64_t>(inst.size());
+    }
+  }
+  report(err, "anchor_inst does not belong to any Instrumentor-owned block");
+  return std::nullopt;
+}
+
+Instrumentor::ResolveResult Instrumentor::resolve_and_validate() {
+  ResolveResult result;
+  ensure_blocks_built();
+
+  if (obj_.text_sections().empty()) {
+    result.errors.emplace_back("code object has no .text section");
+    return result;
+  }
+  // TODO(future milestone): support multi-text code objects. Anchor offsets
+  // would need to identify which .text section they belong to.
+  if (obj_.text_sections().size() > 1) {
+    result.errors.emplace_back(
+        "code object has multiple .text sections; the inline-nop smoke build supports only one");
+    return result;
+  }
+  const Section *text = obj_.text_sections().front();
+  const std::span<const uint8_t> text_bytes(
+      reinterpret_cast<const uint8_t *>(text->data()), text->size());
+
+  // All-or-nothing: per-point errors accumulate in `result.errors`; per-point
+  // successes accumulate in `sites` but are only published to `result.sites`
+  // if `errors` ends up empty. Multi-site callers therefore can't tell
+  // *which* points succeeded when any fail — only the failures are itemized.
+  // Acceptable for PC01-A (single-site only); revisit if a future milestone
+  // exposes multi-site to callers.
+  std::vector<ResolvedInstrumentationSite> sites;
+  sites.reserve(points_.size());
+  for (const auto &pt : points_) {
+    const bool has_inst = pt.anchor_inst != nullptr;
+    const bool has_off = pt.anchor_offset.has_value();
+    if (has_inst == has_off) {
+      result.errors.emplace_back(
+          has_inst ? "InstrumentationPoint sets both anchor_inst and anchor_offset"
+                   : "InstrumentationPoint sets neither anchor_inst nor anchor_offset");
+      continue;
+    }
+
+    uint64_t offset = 0;
+    const Instruction *anchor = nullptr;
+    if (has_inst) {
+      std::string err;
+      auto off = resolve_anchor_inst_to_offset(pt.anchor_inst, &err);
+      if (!off) {
+        result.errors.push_back(std::move(err));
+        continue;
+      }
+      offset = *off;
+      anchor = pt.anchor_inst;
+    } else {
+      offset = *pt.anchor_offset;
+      anchor = find_instruction_at_offset(offset);
+      if (anchor == nullptr) {
+        result.errors.emplace_back("no decoded instruction starts at the requested anchor_offset");
+        continue;
+      }
+    }
+
+    std::string err;
+    auto site = validate_relocation_anchor(*anchor, offset, text_bytes, pt, arch_, &err);
+    if (!site) {
+      result.errors.push_back(std::move(err));
+      continue;
+    }
+    sites.push_back(std::move(*site));
+  }
+
+  if (result.errors.empty()) result.sites = std::move(sites);
+  return result;
+}
+
+InstrumentedCodeObject Instrumentor::patch_relocation_only() {
+  InstrumentedCodeObject result;
+
+  if (patched_) {
+    result.errors.emplace_back(
+        "patch_relocation_only has already been called on this Instrumentor");
+    return result;
+  }
+  patched_ = true;
+
+  // Inline-nop smoke restriction: exactly one queued point.
+  if (points_.empty()) {
+    result.errors.emplace_back("patch_relocation_only requires exactly one queued point; got zero");
+    return result;
+  }
+  if (points_.size() > 1) {
+    result.errors.emplace_back(
+        "patch_relocation_only accepts only one queued point in the inline-nop smoke build");
+    return result;
+  }
+
+  auto resolved = resolve_and_validate();
+  if (!resolved.errors.empty()) {
+    result.errors = std::move(resolved.errors);
+    return result;
+  }
+  const auto &sites = resolved.sites;
+
+  // Construct the patcher and preflight builder output before mutating it.
+  // TODO(future cleanup): the "cave" terminology is inherited from the
+  // patcher API (originally added for DBT). For DBI the appended section is
+  // not really "unused space" — rename the patcher API to something like
+  // `appended_section_*` so DBI reads naturally too.
+  CodeObjectPatcher patcher(obj_);
+  patcher.set_cave_start(patcher.text_size());
+
+  std::vector<AppliedSite> applied;
+  applied.reserve(sites.size());
+  uint64_t cave_cursor = patcher.text_size();
+  for (const auto &site : sites) {
+    const uint64_t trampoline_offset = cave_cursor;
+    TrampolinePlan plan = make_relocation_only_plan(site, arch_, trampoline_offset);
+    // Defense-in-depth: make_relocation_only_plan always produces a
+    // canonical inline-nop smoke plan today, so this never fires in
+    // practice. If it does, that's a bug in plan construction.
+    std::string err;
+    if (!validate_inline_nop_smoke_plan(plan, &err)) {
+      result.errors.push_back(std::move(err));
+      return result;
+    }
+    auto bytes = TrampolineBuilder::build(plan, &err);
+    if (!bytes) {
+      result.errors.push_back(std::move(err));
+      return result;
+    }
+    cave_cursor += bytes->trampoline_words.size() * sizeof(uint32_t);
+    applied.push_back({&site, trampoline_offset, std::move(*bytes)});
+  }
+
+  // Preflight invariant: every per-site validation, branch-range check, and
+  // trampoline-byte construction has succeeded before this point. The patcher
+  // is now mutated. `append_cave_section` below is the one operation that
+  // *can* still fail after mutation; in practice it only fails when the
+  // `.text` section header is missing, which was caught earlier by the
+  // `text_sections().empty()` check.
+  // Splice patched anchors into a local copy of .text, then overwrite once.
+  const auto text_span = patcher.text_bytes();
+  std::vector<uint8_t> local_text(text_span.begin(), text_span.end());
+  for (const auto &a : applied) {
+    std::memcpy(local_text.data() + a.site->anchor_offset,
+                a.bytes.patched_anchor_bytes.data(), a.site->original_size);
+  }
+  patcher.overwrite_text(local_text);
+
+  // Append trampoline words and materialize the section.
+  for (const auto &a : applied)
+    patcher.append_cave_body(a.bytes.trampoline_words);
+  if (!patcher.append_cave_section(".rj_trampolines")) {
+    result.errors.emplace_back("failed to append .rj_trampolines section");
+    return result;
+  }
+
+  // Emit and build patch summaries.
+  result.elf_bytes = patcher.emit();
+  for (const auto &a : applied) {
+    InstrumentationPatch patch;
+    patch.anchor_offset = a.site->anchor_offset;
+    patch.original_size = a.site->original_size;
+    patch.trampoline_offset = a.trampoline_offset;
+    patch.return_target = a.site->anchor_offset + a.site->original_size;
+    patch.original_bytes = a.site->original_bytes;
+    patch.patched_anchor_bytes = a.bytes.patched_anchor_bytes;
+    result.patches.push_back(std::move(patch));
+  }
+  return result;
+}
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
@@ -23,7 +23,8 @@ namespace rocjitsu {
 namespace {
 
 void report(std::string *out, const char *msg) {
-  if (out) *out = msg;
+  if (out)
+    *out = msg;
 }
 
 // PC-relative instructions that may not surface in flags() or
@@ -40,14 +41,14 @@ constexpr std::string_view kRfePrefix = "s_rfe_";
 
 [[nodiscard]] bool is_denylisted_mnemonic(std::string_view mnemonic) {
   for (auto m : kPcRelativeDenylist)
-    if (mnemonic == m) return true;
-  if (mnemonic.size() >= kRfePrefix.size() &&
-      mnemonic.substr(0, kRfePrefix.size()) == kRfePrefix)
+    if (mnemonic == m)
+      return true;
+  if (mnemonic.size() >= kRfePrefix.size() && mnemonic.substr(0, kRfePrefix.size()) == kRfePrefix)
     return true;
   return false;
 }
 
-// Per-site result of patch_relocation_only's preflight: the chosen trampoline
+// Per-site result of Instrumentor::patch's preflight: the chosen trampoline
 // offset and the concrete bytes we'll splice in once all preflights succeed.
 struct AppliedSite {
   const ResolvedInstrumentationSite *site;
@@ -58,36 +59,34 @@ struct AppliedSite {
 } // namespace
 
 std::optional<ResolvedInstrumentationSite>
-validate_relocation_anchor(const Instruction &anchor, uint64_t anchor_offset,
-                           std::span<const uint8_t> text_bytes,
-                           const InstrumentationPoint &pt,
+validate_anchor(const Instruction &anchor, uint64_t anchor_offset,
+                           std::span<const uint8_t> text_bytes, const InstrumentationPoint &pt,
                            [[maybe_unused]] rj_code_arch_t arch, std::string *error_out) {
   if (pt.filter_flags != 0) {
-    report(error_out, "InstrumentationPoint::filter_flags must be 0 in the inline-nop smoke build");
+    report(error_out, "InstrumentationPoint::filter_flags must be 0 in the inline-nop milestone");
     return std::nullopt;
   }
-  // TODO(future milestone): support AfterInst / BlockEntry / BlockExit.
+  // TODO: support AfterInst / BlockEntry / BlockExit.
   if (pt.kind != InstrumentationKind::BeforeInst) {
     report(error_out,
-           "InstrumentationPoint::kind must be BeforeInst in the inline-nop smoke build");
+           "InstrumentationPoint::kind must be BeforeInst in the inline-nop milestone");
     return std::nullopt;
   }
-  // TODO(future milestone): consume probe_obj / probe_symbol when probe-call
-  // trampolines are supported.
+  // TODO: consume probe_obj / probe_symbol when probe-call trampolines are
+  // supported.
   if (pt.probe_obj != nullptr) {
-    report(error_out, "InstrumentationPoint::probe_obj must be null in the inline-nop smoke build");
+    report(error_out, "InstrumentationPoint::probe_obj must be null in the inline-nop milestone");
     return std::nullopt;
   }
   if (!pt.probe_symbol.empty()) {
     report(error_out,
-           "InstrumentationPoint::probe_symbol must be empty in the inline-nop smoke build");
+           "InstrumentationPoint::probe_symbol must be empty in the inline-nop milestone");
     return std::nullopt;
   }
-  // TODO(future milestone): consume force_full_exec when EXEC policy
-  // management lands.
+  // TODO: consume force_full_exec when EXEC policy management is implemented
   if (pt.force_full_exec) {
     report(error_out,
-           "InstrumentationPoint::force_full_exec must be false in the inline-nop smoke build");
+           "InstrumentationPoint::force_full_exec must be false in the inline-nop milestone");
     return std::nullopt;
   }
   if (anchor_offset % sizeof(uint32_t) != 0) {
@@ -135,27 +134,25 @@ validate_relocation_anchor(const Instruction &anchor, uint64_t anchor_offset,
   return site;
 }
 
-bool validate_inline_nop_smoke_plan(const TrampolinePlan &plan, std::string *error_out) {
+bool validate_inline_nop_plan(const TrampolinePlan &plan, std::string *error_out) {
   if (!plan.emit_original) {
-    report(error_out,
-           "trampoline plan: emit_original must be true for the inline-nop smoke build");
+    report(error_out, "trampoline plan: emit_original must be true for the inline-nop milestone");
     return false;
   }
   if (!plan.after_items.empty()) {
-    report(error_out, "trampoline plan: after_items must be empty for the inline-nop smoke build");
+    report(error_out, "trampoline plan: after_items must be empty for the inline-nop milestone");
     return false;
   }
   if (plan.before_items.size() != 1 || plan.before_items[0].words.size() != 1 ||
       plan.before_items[0].words[0] != build_s_nop(0, plan.arch)) {
-    report(error_out,
-           "trampoline plan: before_items must be exactly { { s_nop 0 } } "
-           "for the inline-nop smoke build");
+    report(error_out, "trampoline plan: before_items must be exactly { { s_nop 0 } } "
+                      "for the inline-nop milestone");
     return false;
   }
   return true;
 }
 
-TrampolinePlan make_relocation_only_plan(const ResolvedInstrumentationSite &site,
+TrampolinePlan make_trampoline_plan(const ResolvedInstrumentationSite &site,
                                          rj_code_arch_t arch, uint64_t trampoline_offset) {
   TrampolinePlan plan;
   plan.arch = arch;
@@ -197,7 +194,8 @@ std::span<const std::unique_ptr<BasicBlock>> Instrumentor::owned_blocks() {
 }
 
 void Instrumentor::ensure_blocks_built() {
-  if (blocks_built_) return;
+  if (blocks_built_)
+    return;
   decoder_ = Decoder::create(arch_);
   blocks_ = BasicBlock::build(obj_, *decoder_);
   blocks_built_ = true;
@@ -209,7 +207,8 @@ const Instruction *Instrumentor::find_instruction_at_offset(uint64_t anchor_offs
       continue;
     uint64_t cur = block->start_offset();
     for (const Instruction &inst : block->instructions()) {
-      if (cur == anchor_offset) return &inst;
+      if (cur == anchor_offset)
+        return &inst;
       cur += static_cast<uint64_t>(inst.size());
     }
     return nullptr;
@@ -217,12 +216,13 @@ const Instruction *Instrumentor::find_instruction_at_offset(uint64_t anchor_offs
   return nullptr;
 }
 
-std::optional<uint64_t>
-Instrumentor::resolve_anchor_inst_to_offset(const Instruction *target, std::string *err) {
+std::optional<uint64_t> Instrumentor::resolve_anchor_inst_to_offset(const Instruction *target,
+                                                                    std::string *err) {
   for (const auto &block : blocks_) {
     uint64_t cur = block->start_offset();
     for (const Instruction &inst : block->instructions()) {
-      if (&inst == target) return cur;
+      if (&inst == target)
+        return cur;
       cur += static_cast<uint64_t>(inst.size());
     }
   }
@@ -242,19 +242,19 @@ Instrumentor::ResolveResult Instrumentor::resolve_and_validate() {
   // would need to identify which .text section they belong to.
   if (obj_.text_sections().size() > 1) {
     result.errors.emplace_back(
-        "code object has multiple .text sections; the inline-nop smoke build supports only one");
+        "code object has multiple .text sections; the inline-nop milestone supports only one");
     return result;
   }
   const Section *text = obj_.text_sections().front();
-  const std::span<const uint8_t> text_bytes(
-      reinterpret_cast<const uint8_t *>(text->data()), text->size());
+  const std::span<const uint8_t> text_bytes(reinterpret_cast<const uint8_t *>(text->data()),
+                                            text->size());
 
   // All-or-nothing: per-point errors accumulate in `result.errors`; per-point
   // successes accumulate in `sites` but are only published to `result.sites`
   // if `errors` ends up empty. Multi-site callers therefore can't tell
   // *which* points succeeded when any fail — only the failures are itemized.
-  // Acceptable for PC01-A (single-site only); revisit if a future milestone
-  // exposes multi-site to callers.
+  // TODO: Currently only supporting single site so this is fine for now but
+  // revisit when exposing multi-site to callers.
   std::vector<ResolvedInstrumentationSite> sites;
   sites.reserve(points_.size());
   for (const auto &pt : points_) {
@@ -288,7 +288,7 @@ Instrumentor::ResolveResult Instrumentor::resolve_and_validate() {
     }
 
     std::string err;
-    auto site = validate_relocation_anchor(*anchor, offset, text_bytes, pt, arch_, &err);
+    auto site = validate_anchor(*anchor, offset, text_bytes, pt, arch_, &err);
     if (!site) {
       result.errors.push_back(std::move(err));
       continue;
@@ -296,28 +296,28 @@ Instrumentor::ResolveResult Instrumentor::resolve_and_validate() {
     sites.push_back(std::move(*site));
   }
 
-  if (result.errors.empty()) result.sites = std::move(sites);
+  if (result.errors.empty())
+    result.sites = std::move(sites);
   return result;
 }
 
-InstrumentedCodeObject Instrumentor::patch_relocation_only() {
+InstrumentedCodeObject Instrumentor::patch() {
   InstrumentedCodeObject result;
 
   if (patched_) {
-    result.errors.emplace_back(
-        "patch_relocation_only has already been called on this Instrumentor");
+    result.errors.emplace_back("Instrumentor::patch has already been called on this Instrumentor");
     return result;
   }
   patched_ = true;
 
-  // Inline-nop smoke restriction: exactly one queued point.
+  // Inline-nop milestone restriction: exactly one queued point.
   if (points_.empty()) {
-    result.errors.emplace_back("patch_relocation_only requires exactly one queued point; got zero");
+    result.errors.emplace_back("Instrumentor::patch requires exactly one queued point; got zero");
     return result;
   }
   if (points_.size() > 1) {
     result.errors.emplace_back(
-        "patch_relocation_only accepts only one queued point in the inline-nop smoke build");
+        "Instrumentor::patch accepts only one queued point in the inline-nop milestone");
     return result;
   }
 
@@ -329,10 +329,10 @@ InstrumentedCodeObject Instrumentor::patch_relocation_only() {
   const auto &sites = resolved.sites;
 
   // Construct the patcher and preflight builder output before mutating it.
-  // TODO(future cleanup): the "cave" terminology is inherited from the
-  // patcher API (originally added for DBT). For DBI the appended section is
-  // not really "unused space" — rename the patcher API to something like
-  // `appended_section_*` so DBI reads naturally too.
+  // TODO: The "cave" terminology is inherited from the patcher API (originally
+  // added for DBT). For DBI the appended section is not really "unused space".
+  // Rename the patcher API to something like `appended_section_*` so DBI
+  // reads naturally too.
   CodeObjectPatcher patcher(obj_);
   patcher.set_cave_start(patcher.text_size());
 
@@ -341,12 +341,13 @@ InstrumentedCodeObject Instrumentor::patch_relocation_only() {
   uint64_t cave_cursor = patcher.text_size();
   for (const auto &site : sites) {
     const uint64_t trampoline_offset = cave_cursor;
-    TrampolinePlan plan = make_relocation_only_plan(site, arch_, trampoline_offset);
-    // Defense-in-depth: make_relocation_only_plan always produces a
-    // canonical inline-nop smoke plan today, so this never fires in
-    // practice. If it does, that's a bug in plan construction.
+    TrampolinePlan plan = make_trampoline_plan(site, arch_, trampoline_offset);
+    // make_trampoline_plan always produces a canonical inline-nop plan today,
+    // but TrampolinePlan is a generic shape. Defense-in-depth check that we
+    // didn't accidentally feed a richer plan into a builder path that the
+    // milestone hasn't validated yet.
     std::string err;
-    if (!validate_inline_nop_smoke_plan(plan, &err)) {
+    if (!validate_inline_nop_plan(plan, &err)) {
       result.errors.push_back(std::move(err));
       return result;
     }
@@ -359,18 +360,16 @@ InstrumentedCodeObject Instrumentor::patch_relocation_only() {
     applied.push_back({&site, trampoline_offset, std::move(*bytes)});
   }
 
-  // Preflight invariant: every per-site validation, branch-range check, and
-  // trampoline-byte construction has succeeded before this point. The patcher
-  // is now mutated. `append_cave_section` below is the one operation that
-  // *can* still fail after mutation; in practice it only fails when the
-  // `.text` section header is missing, which was caught earlier by the
-  // `text_sections().empty()` check.
+  // Every per-site validation, branch-range check, and trampoline-byte
+  // construction has succeeded up to this point. Now time to patch.
+  // `append_cave_section` below could theoretically fail if the `.text`
+  // section is missing, but that should have been caught earlier.
   // Splice patched anchors into a local copy of .text, then overwrite once.
   const auto text_span = patcher.text_bytes();
   std::vector<uint8_t> local_text(text_span.begin(), text_span.end());
   for (const auto &a : applied) {
-    std::memcpy(local_text.data() + a.site->anchor_offset,
-                a.bytes.patched_anchor_bytes.data(), a.site->original_size);
+    std::memcpy(local_text.data() + a.site->anchor_offset, a.bytes.patched_anchor_bytes.data(),
+                a.site->original_size);
   }
   patcher.overwrite_text(local_text);
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
@@ -25,14 +25,19 @@ namespace rocjitsu {
 
 namespace {
 
-// PC-relative instructions that may not surface in flags() or
-// branch_offset_bytes() on every ISA. Exact-match list plus a prefix match
-// for the s_rfe_* family (variants differ across ISAs).
-constexpr std::array<std::string_view, 4> kPcRelativeDenylist = {
-    "s_getpc_b64",
-    "s_call_b64",
-    "s_setpc_b64",
-    "s_swappc_b64",
+// PC-reading / PC-relative instructions to reject as anchors: relocating any of
+// them into a trampoline changes the PC value they read (s_getpc) or the target
+// they branch to. s_getpc and the s_rfe_ family carry no control-flow flag or
+// branch_offset_bytes, so validate_anchor's flag/offset checks miss them and the
+// denylist is the only thing that catches them. The s_call / s_setpc / s_swappc
+// entries are already rejected upstream by their INDIRECT_BRANCH / INDIRECT_CALL
+// flags and are listed only as defense-in-depth. gfx1250 renames the whole
+// family from *_b64 to *_i64 (e.g. s_getpc_b64 -> s_get_pc_i64), so both
+// spellings are listed; the s_rfe_ prefix match below covers s_rfe_b64,
+// s_rfe_i64, and s_rfe_restore_b64.
+constexpr std::array<std::string_view, 8> kPcRelativeDenylist = {
+    "s_getpc_b64",  "s_call_b64", "s_setpc_b64",  "s_swappc_b64",
+    "s_get_pc_i64", "s_call_i64", "s_set_pc_i64", "s_swap_pc_i64",
 };
 
 constexpr std::string_view kRfePrefix = "s_rfe_";

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
@@ -16,6 +16,7 @@
 #include <array>
 #include <cstring>
 #include <string_view>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -100,29 +101,32 @@ std::optional<ResolvedInstrumentationSite>
 validate_anchor(const Instruction &anchor, uint64_t anchor_offset,
                 std::span<const uint8_t> text_bytes, const InstrumentationPoint &pt,
                 rj_code_arch_t arch, std::string *error_out) {
+  auto fail = [&](const char *msg) {
+    report(error_out, (msg + (", anchor_offset = " + std::to_string(anchor_offset))).c_str());
+  };
   // TODO: consume filter_flags to filter anchors based on InstFlags.
   if (pt.filter_flags != 0) {
-    report(error_out, "InstrumentationPoint::filter_flags must be 0 temporarily");
+    fail("InstrumentationPoint::filter_flags must be 0 temporarily");
     return std::nullopt;
   }
   // TODO: support AfterInst / BlockEntry / BlockExit.
   if (pt.kind != InstrumentationKind::BeforeInst) {
-    report(error_out, "InstrumentationPoint::kind must be BeforeInst temporarily");
+    fail("InstrumentationPoint::kind must be BeforeInst temporarily");
     return std::nullopt;
   }
   // TODO: consume probe_obj / probe_symbol when probe-call trampolines are
   // supported.
   if (pt.probe_obj != nullptr) {
-    report(error_out, "InstrumentationPoint::probe_obj must be null temporarily");
+    fail("InstrumentationPoint::probe_obj must be null temporarily");
     return std::nullopt;
   }
   if (!pt.probe_symbol.empty()) {
-    report(error_out, "InstrumentationPoint::probe_symbol must be empty temporarily");
+    fail("InstrumentationPoint::probe_symbol must be empty temporarily");
     return std::nullopt;
   }
   // TODO: consume force_full_exec when EXEC policy management is implemented
   if (pt.force_full_exec) {
-    report(error_out, "InstrumentationPoint::force_full_exec must be false temporarily");
+    fail("InstrumentationPoint::force_full_exec must be false temporarily");
     return std::nullopt;
   }
 
@@ -245,16 +249,21 @@ Instrumentor::ValidationResult Instrumentor::validate_points() {
 
   // All-or-nothing: per-point errors accumulate in `result.errors`; per-point
   // successes accumulate in `sites` but are only published to `result.sites`
-  // if `errors` ends up empty. Multi-site callers therefore can't tell
-  // *which* points succeeded when any fail — only the failures are itemized.
-  // TODO: Currently only supporting single site so this is fine for now but
-  // revisit when exposing multi-site to callers.
+  // if `errors` ends up empty.
   std::vector<ResolvedInstrumentationSite> sites;
+  std::unordered_set<uint64_t> site_offsets;
   sites.reserve(points_.size());
   for (const auto &pt : points_) {
     const Instruction *anchor = find_instruction_at_offset(pt.anchor_offset);
     if (anchor == nullptr) {
-      result.errors.emplace_back("no decoded instruction starts at the requested anchor_offset");
+      result.errors.emplace_back("no decoded instruction starts at the requested anchor_offset = " +
+                                 std::to_string(pt.anchor_offset));
+      continue;
+    }
+
+    if (site_offsets.find(pt.anchor_offset) != site_offsets.end()) {
+      result.errors.emplace_back("multiple points requested the same anchor_offset = " +
+                                 std::to_string(pt.anchor_offset));
       continue;
     }
 
@@ -265,6 +274,7 @@ Instrumentor::ValidationResult Instrumentor::validate_points() {
       continue;
     }
     sites.push_back(std::move(*site));
+    site_offsets.insert(site->anchor_offset);
   }
 
   if (result.errors.empty())
@@ -288,13 +298,8 @@ InstrumentedCodeObjectDebug Instrumentor::patch_with_debug_summaries() {
   }
   patched_ = true;
 
-  // Temporary restriction: exactly one queued point.
   if (points_.empty()) {
-    result.errors.emplace_back("Instrumentor::patch requires exactly one queued point; got zero");
-    return result;
-  }
-  if (points_.size() > 1) {
-    result.errors.emplace_back("Instrumentor::patch temporarily accepts only one queued point");
+    result.errors.emplace_back("Instrumentor::patch requires at least one queued point; got zero");
     return result;
   }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
@@ -9,6 +9,7 @@
 #include "rocjitsu/code/patch/code_object_patcher.h"
 #include "rocjitsu/code/patch/error_report.h"
 #include "rocjitsu/code/patch/instruction_builder.h"
+#include "rocjitsu/code/patch/kernel_text_layout.h"
 #include "rocjitsu/code/patch/trampoline_builder.h"
 #include "rocjitsu/isa/decoder.h"
 #include "rocjitsu/isa/instruction.h"
@@ -311,18 +312,16 @@ InstrumentedCodeObjectDebug Instrumentor::patch_with_debug_summaries() {
   const auto &sites = validation.sites;
 
   // Construct the patcher and preflight builder output before mutating it.
-  // TODO: The "cave" terminology is inherited from the patcher API (originally
-  // added for DBT). For DBI the appended section is not really "unused space".
-  // Rename the patcher API to something like `appended_section_*` so DBI
-  // reads naturally too.
+  // Each trampoline is appended directly after the original .text bytes as a
+  // local code cave (as in the current DBT design).
   CodeObjectPatcher patcher(obj_);
-  patcher.set_cave_start(patcher.text_size());
+  const uint64_t cave_start = patcher.text_size();
 
   std::vector<AppliedSite> applied;
   applied.reserve(sites.size());
-  // Derive the trampoline cursor from the patcher's recorded cave_start so
-  // the cave coordinate is established in exactly one place.
-  uint64_t cave_cursor = patcher.cave_start();
+  // The trampoline cursor advances through the local cave that begins at the
+  // first byte after the original .text.
+  uint64_t cave_cursor = cave_start;
   for (const auto &site : sites) {
     const uint64_t trampoline_offset = cave_cursor;
     TrampolinePlan plan = make_trampoline_plan(site, arch_, trampoline_offset);
@@ -349,23 +348,21 @@ InstrumentedCodeObjectDebug Instrumentor::patch_with_debug_summaries() {
     return result;
 
   // Every per-site validation, branch-range check, and trampoline-byte
-  // construction has succeeded up to this point. Now time to patch.
-  // `append_cave_section` below could theoretically fail if the `.text`
-  // section is missing, but that should have been caught earlier.
-  // Splice patched anchors into a local copy of .text, then overwrite once.
+  // construction has succeeded up to this point. Assemble the new .text in one
+  // buffer: the original bytes with each anchor spliced to its forward branch,
+  // followed by every trampoline appended as the local cave. replace_text()
+  // grows .text in place and fixes up the surrounding ELF (section/segment
+  // sizes, moved symbols, descriptor entries).
   const auto text_span = patcher.text_bytes();
-  std::vector<uint8_t> local_text(text_span.begin(), text_span.end());
+  std::vector<uint8_t> new_text(text_span.begin(), text_span.end());
   for (const auto &a : applied) {
-    std::memcpy(local_text.data() + a.site->anchor_offset, a.bytes.patched_anchor_bytes.data(),
+    std::memcpy(new_text.data() + a.site->anchor_offset, a.bytes.patched_anchor_bytes.data(),
                 a.site->original_size);
   }
-  patcher.overwrite_text(local_text);
-
-  // Append trampoline words and materialize the section.
   for (const auto &a : applied)
-    patcher.append_cave_body(a.bytes.trampoline_words);
-  if (!patcher.append_cave_section(".rj_trampolines")) {
-    result.errors.emplace_back("failed to append .rj_trampolines section");
+    append_words(new_text, a.bytes.trampoline_words);
+  if (!patcher.replace_text(new_text)) {
+    result.errors.emplace_back("failed to replace .text with the instrumented code");
     return result;
   }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.h
@@ -63,7 +63,7 @@ class Instruction;
 /// placeholders so the descriptor evolves into the Section 2 probe shape
 /// without renaming.
 ///
-/// TODO(future milestone): implement AfterInst, BlockEntry, and BlockExit.
+/// TODO: implement AfterInst, BlockEntry, and BlockExit.
 /// Today the validator rejects any kind other than BeforeInst.
 enum class InstrumentationKind {
   BeforeInst,
@@ -81,14 +81,13 @@ struct InstrumentationPoint {
   uint64_t anchor_offset = 0;
 
   InstrumentationKind kind = InstrumentationKind::BeforeInst;
-  uint32_t filter_flags = 0; // Must be 0 in the inline-nop build.
 
-  // Reserved for later milestones — must remain default in the inline-nop
-  // build. The validator rejects any non-default value to keep the
+  // Not used yet. The validator rejects any non-default value to keep the
   // contract honest until each field is actually implemented.
   // TODO: consume probe_obj / probe_symbol when probe-call
   // trampolines are supported; consume force_full_exec when EXEC policy
-  // management lands.
+  // management lands; consume filter_flags to filter based on InstFlags
+  uint32_t filter_flags = 0;
   const AmdGpuCodeObject *probe_obj = nullptr;
   std::string probe_symbol;
   bool force_full_exec = false;
@@ -98,16 +97,17 @@ struct InstrumentationPoint {
 struct ResolvedInstrumentationSite {
   InstrumentationKind kind = InstrumentationKind::BeforeInst;
   uint64_t anchor_offset = 0;
-  uint32_t original_size = 0; // 4 or 8 in the inline-nop smoke build.
+  uint32_t original_size = 0;
   std::vector<uint8_t> original_bytes;
   std::string mnemonic; // Diagnostic/debug only.
 };
 
-/// @brief Per-site patch record returned by Instrumentor::patch().
+/// @brief Per-site patch record, for testing and debugging.
 ///
-/// Intended for test assertions and debugging only — a fresh disassembly of
-/// the emitted ELF would expose the same information. Not a proposed public
-/// metadata surface.
+/// Returned from Instrumentor::patch_with_debug_summaries(), not from the
+/// regular patch() entry point. The schema is not yet stable; the same
+/// information is also recoverable from a fresh disassembly of the emitted
+/// ELF.
 struct InstrumentationPatch {
   uint64_t anchor_offset;
   uint32_t original_size;
@@ -119,26 +119,31 @@ struct InstrumentationPatch {
 
 /// @brief Result of Instrumentor::patch().
 ///
-/// All-or-nothing: when any fatal error occurs, `elf_bytes` and `patches`
-/// are empty and `errors` is non-empty. On success, `errors` is empty,
-/// `elf_bytes` contains a re-parseable patched ELF, and `patches` contains
-/// one record per applied site.
+/// All-or-nothing: when any fatal error occurs, `elf_bytes` is empty and
+/// `errors` is non-empty. On success, `errors` is empty and `elf_bytes`
+/// contains a re-parseable patched ELF.
 struct InstrumentedCodeObject {
   std::vector<uint8_t> elf_bytes;
-  std::vector<InstrumentationPatch> patches;
   std::vector<std::string> errors;
   std::vector<std::string> warnings;
 };
 
+/// @brief Result of Instrumentor::patch_with_debug_summaries().
+///
+/// Extends InstrumentedCodeObject with one InstrumentationPatch per applied
+/// site. Test / debug surface only; the per-site schema is unstable.
+struct InstrumentedCodeObjectDebug : InstrumentedCodeObject {
+  std::vector<InstrumentationPatch> patches;
+};
+
 /// @brief Permanent structural checks: would @p anchor work as a trampoline
-///        anchor at @p anchor_offset, ignoring any milestone-scoped policy?
+///        anchor at @p anchor_offset?
 ///
-/// Pure predicate. Does not look at any InstrumentationPoint — it answers
+/// Pure predicate. Does not look at any InstrumentationPoint. Answers only
 /// "can the trampoline machinery splice an `s_branch` here and relocate the
-/// original safely?" only. Reusable by future predicate-based anchor
-/// selection (the orchestrator walks blocks itself and filters candidates).
+/// original safely?"
 ///
-/// Rules enforced (all permanent; none are milestone-scoped):
+/// Rules enforced (last two will eventually be relaxed):
 ///   - @p anchor_offset is dword aligned.
 ///   - anchor.size() is 4 or 8 and fits inside @p text_bytes.
 ///   - anchor.raw_encoding() is non-null.
@@ -159,13 +164,9 @@ struct InstrumentedCodeObject {
 /// (the free-function form lets test fixtures use synthetic TestInstruction
 /// objects without standing up an AmdGpuCodeObject). The anchor identity is
 /// already resolved by the caller; @p pt is read for `filter_flags`, `kind`,
-/// and reserved fields.
+/// and reserved fields. See is_relocatable_anchor for rules.
 ///
-/// Layering: this function combines milestone-scoped policy (reserved-field
-/// rejections — temporary) with permanent structural relocatability
-/// (delegated to is_relocatable_anchor — see there for the structural rules).
-///
-/// Milestone-scoped rules enforced here:
+/// Temporary rules enforced here:
 ///   - @p pt.filter_flags is zero.
 ///   - @p pt.kind is BeforeInst (other kinds are unsupported in this milestone).
 ///   - @p pt.probe_obj is null, @p pt.probe_symbol is empty, and
@@ -175,39 +176,51 @@ validate_anchor(const Instruction &anchor, uint64_t anchor_offset,
                 std::span<const uint8_t> text_bytes, const InstrumentationPoint &pt,
                 rj_code_arch_t arch, std::string *error_out = nullptr);
 
-/// @brief Build the inline-nop TrampolinePlan from a validated site.
+/// @brief Build a TrampolinePlan from a validated site.
 ///
+/// Temporarily fills it ONLY with a plan to instrument with a nop.
 /// Fills before_items = {{ s_nop 0 }}, after_items = {}, emit_original = true.
 /// The caller chooses @p trampoline_offset (typically `patcher.text_size()`).
 [[nodiscard]] TrampolinePlan make_trampoline_plan(const ResolvedInstrumentationSite &site,
                                                   rj_code_arch_t arch, uint64_t trampoline_offset);
 
-/// @brief Verify @p plan matches the inline-nop canonical body shape: exactly
-///        one `before_items` entry containing `s_nop 0`, empty `after_items`,
-///        and `emit_original == true`.
+/// @brief Verify @p plan matches the (temporary) inlined nop body shape:
+///        exactly one `before_items` entry containing `s_nop 0`, empty
+///        `after_items`, and `emit_original == true`.
 ///
-/// One of several places where inline-nop milestone constraints are enforced.
+/// One of several places where temporary inlined nop constraints are enforced.
 /// The others: validate_anchor() rejects reserved InstrumentationPoint fields,
 /// and Instrumentor::patch() rejects multi-text code objects and the multi-
 /// point case. This one lives at the orchestrator boundary rather than inside
-/// TrampolineBuilder so the builder stays generic and ready for future probe-
-/// call / clobber-bearing inline-asm bodies. Called by Instrumentor::patch()
-/// as a defense-in-depth check (make_trampoline_plan always produces canonical
-/// plans today) and also directly by tests so the guardrail logic is
-/// exercised at the layer where it lives.
+/// TrampolineBuilder so the builder stays generic.
+/// Called by Instrumentor::patch() as a defense-check (make sure users/agents
+/// do not misinterpret current DBI support) and also directly by tests
 ///
-/// TODO(future milestone): delete this once arbitrary inline-asm bodies with
-/// declared clobbers are supported.
+/// TODO: delete this when DBI supports more plans
 [[nodiscard]] bool validate_inline_nop_plan(const TrampolinePlan &plan,
                                             std::string *error_out = nullptr);
 
-/// @brief DBI orchestrator owning point collection and resolution.
+/// @brief DBI orchestrator. Collects InstrumentationPoints, validates each
+///        anchor, plans + builds per-site trampolines, and drives the
+///        CodeObjectPatcher to splice the patches into a new ELF. See the
+///        mental-model diagram at the top of this file for the full pipeline.
 ///
-/// PC01-A scope: resolve points to .text-relative offsets, validate, capture
-/// original bytes. Patching (TrampolineBuilder lowering + CodeObjectPatcher
-/// mutation) arrives in the next slice.
+/// Single-attempt: each Instrumentor instance owns one call to patch() or
+/// patch_with_debug_summaries(), success or failure. Could expand to allow
+/// calls again upon failure. Re-instrumenting and already instrumented code
+/// is a much more difficult task.
+///
+/// Block decoding is lazy so the CFG is built on the first call that needs
+/// it (validate_points / find_instruction_at_offset). An Instrumentor that
+/// never gets patched also never decodes.
 class Instrumentor {
 public:
+  /// @param obj  The code object to instrument. Borrowed; must outlive the
+  ///             Instrumentor.
+  /// @param arch The ISA used to decode @p obj. An arch that has no
+  ///             registered Decoder (RV32I/RV64I/INVALID/etc.) surfaces as
+  ///             a ValidationResult / InstrumentedCodeObject error at
+  ///             validate_points() / patch() time rather than at construction.
   Instrumentor(const AmdGpuCodeObject &obj, rj_code_arch_t arch);
   ~Instrumentor();
 
@@ -217,9 +230,10 @@ public:
   /// @brief Queue a point. The point is not validated until validate_points().
   void add_point(InstrumentationPoint pt);
 
-  /// @brief Convenience: queue a point identified only by .text-relative offset.
-  ///        Equivalent to constructing an InstrumentationPoint with
-  ///        anchor_offset set.
+  /// @brief Convenience: queue a point identified by its .text-relative byte
+  ///        offset. Equivalent to constructing an InstrumentationPoint with
+  ///        anchor_offset set. Handy when callers walk basic blocks themselves
+  ///        and already have the offset of each candidate instruction.
   void add_point_by_offset(uint64_t anchor_offset,
                            InstrumentationKind kind = InstrumentationKind::BeforeInst);
 
@@ -230,23 +244,31 @@ public:
 
   /// @brief Look up each queued point's anchor and validate it.
   ///
-  /// All-or-nothing: on any failure, `sites` is empty and `errors` lists every
-  /// fatal diagnostic encountered. On success, `sites` contains one record per
-  /// queued point in insertion order and `errors` is empty.
+  /// Currently all-or-nothing: on any failure, `sites` is empty and `errors`
+  /// lists every fatal diagnostic encountered. On success, `sites` contains
+  /// one record per queued point in insertion order and `errors` is empty.
   [[nodiscard]] ValidationResult validate_points();
 
-  /// @brief Resolve, validate, plan, build, and patch the queued points.
+  /// @brief Validate, plan, build, and apply the queued points; emit a
+  ///        patched ELF.
   ///
-  /// Inline-nop milestone accepts exactly one queued point; queuing zero or
-  /// more than one is a fatal error. The orchestrator preflights all builder
-  /// output before mutating the patcher, so a branch-range failure can't leak
-  /// a half-built ELF.
+  /// All per-site validation and builder output is preflighted before any
+  /// patcher mutation, so a late failure (e.g. branch-range overflow) can't
+  /// leak a half-built ELF. Thus `elf_bytes` is either fully populated or empty
+  /// with diagnostics in `errors`.
   ///
-  /// Single-attempt: any call (success or failure) consumes the Instrumentor's
-  /// budget. A second call returns an empty result with a fatal error, even
-  /// if the first call failed for argument reasons (e.g., zero queued points).
-  /// Callers that hit a recoverable error must construct a new Instrumentor.
+  /// Current support is single-point: queuing zero or more than one
+  /// InstrumentationPoint is a fatal error. Shares the single-attempt budget
+  /// with patch_with_debug_summaries(); see the class-level note.
   [[nodiscard]] InstrumentedCodeObject patch();
+
+  /// @brief Same as patch(), plus per-site InstrumentationPatch summaries.
+  ///
+  /// Currently intended for tests and debugging, although could eventually
+  /// be used to communicate important information for the host (an ordering
+  /// of which instructions were instrumented and should be analyzed further
+  /// for post-processing. Per-site info not yet stable.
+  [[nodiscard]] InstrumentedCodeObjectDebug patch_with_debug_summaries();
 
 private:
   const AmdGpuCodeObject &obj_;
@@ -259,7 +281,10 @@ private:
   std::vector<std::unique_ptr<BasicBlock>> blocks_;
   bool blocks_built_ = false;
 
-  void ensure_blocks_built();
+  // Returns false if no decoder exists for arch_ (RV32I/RV64I/INVALID/etc.);
+  // in that case *error_out is set and blocks_built_ stays false so the failure
+  // is reported instead of crashing in BasicBlock::build.
+  [[nodiscard]] bool ensure_blocks_built(std::string *error_out = nullptr);
   [[nodiscard]] const Instruction *find_instruction_at_offset(uint64_t anchor_offset);
 };
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.h
@@ -3,8 +3,39 @@
 
 /// @file instrumentor.h
 /// @brief DBI orchestrator: resolves InstrumentationPoints to .text-relative
-///        anchors, validates them, and (in a later slice) drives byte-level
-///        patching via TrampolineBuilder and CodeObjectPatcher.
+///        anchors, validates them, and drives byte-level patching via
+///        TrampolineBuilder and CodeObjectPatcher.
+///
+/// Mental model
+/// ------------
+/// The Instrumentor is the central hub. Callers queue InstrumentationPoints
+/// (the requests). On patch(), the orchestrator runs a multi-stage pipeline:
+///
+///   InstrumentationPoint        -- request: "instrument here, with this body"
+///         |  validate_points()
+///         v
+///   ResolvedInstrumentationSite -- one validated anchor + snapshot of the
+///         |                        original bytes (captured before mutation)
+///         |  make_trampoline_plan() + TrampolineBuilder::build()
+///         v
+///   (preflight: per-site plan + built bytes, accumulated locally)
+///         |  splice anchors + append .rj_trampolines + emit()
+///         v
+///   InstrumentedCodeObject      -- patched ELF + per-site InstrumentationPatch
+///
+/// Current pipeline is single-point and all-or-nothing: any per-site failure
+/// aborts the whole patch.
+/// TODOs:: predicate-based anchor selection (Instrumentor walks blocks itself),
+/// multi-site with per-site failure tolerance, probe-call bodies,
+/// AfterInst / BlockEntry / BlockExit kinds, EXEC policy management.
+/// As that lands the per-stage types will thicken
+/// (e.g. ResolvedInstrumentationSite probably gains an ordered list of bodies)
+/// and a layout/negotiation stage will appear between planning and splicing.
+///
+/// Layer split: this file is the orchestrator. TrampolineBuilder
+/// (trampoline_builder.h) is the generic byte emitter — it knows nothing
+/// about points or milestones. CodeObjectPatcher (code_object_patcher.h)
+/// owns ELF mutation.
 
 #pragma once
 
@@ -43,21 +74,19 @@ enum class InstrumentationKind {
 
 /// @brief A request to instrument one site.
 ///
-/// The anchor is identified by either @ref anchor_inst (when the caller
-/// already has a decoded Instruction pointer from an Instrumentor-owned
-/// block) or @ref anchor_offset (test/internal shortcut). Exactly one must
-/// be set; setting both or neither is a fatal error during resolution.
+/// The anchor is identified by @ref anchor_offset (a .text-relative byte
+/// offset). The orchestrator looks up the decoded Instruction at that offset
+/// during validation.
 struct InstrumentationPoint {
-  const Instruction *anchor_inst = nullptr;
-  std::optional<uint64_t> anchor_offset;
+  uint64_t anchor_offset = 0;
 
   InstrumentationKind kind = InstrumentationKind::BeforeInst;
-  uint32_t filter_flags = 0; // Must be 0 in the inline-nop smoke build.
+  uint32_t filter_flags = 0; // Must be 0 in the inline-nop build.
 
   // Reserved for later milestones — must remain default in the inline-nop
-  // smoke build. The validator rejects any non-default value to keep the
+  // build. The validator rejects any non-default value to keep the
   // contract honest until each field is actually implemented.
-  // TODO(future milestone): consume probe_obj / probe_symbol when probe-call
+  // TODO: consume probe_obj / probe_symbol when probe-call
   // trampolines are supported; consume force_full_exec when EXEC policy
   // management lands.
   const AmdGpuCodeObject *probe_obj = nullptr;
@@ -66,12 +95,7 @@ struct InstrumentationPoint {
 };
 
 /// @brief Per-site record produced after validation and byte capture.
-///
-/// @note `anchor_inst` points into BasicBlock storage owned by the
-///       Instrumentor that produced the site. Consumers must not retain
-///       sites past the Instrumentor's lifetime.
 struct ResolvedInstrumentationSite {
-  const Instruction *anchor_inst = nullptr;
   InstrumentationKind kind = InstrumentationKind::BeforeInst;
   uint64_t anchor_offset = 0;
   uint32_t original_size = 0; // 4 or 8 in the inline-nop smoke build.
@@ -106,21 +130,15 @@ struct InstrumentedCodeObject {
   std::vector<std::string> warnings;
 };
 
-/// @brief Validate that @p anchor is a legal trampoline anchor.
+/// @brief Permanent structural checks: would @p anchor work as a trampoline
+///        anchor at @p anchor_offset, ignoring any milestone-scoped policy?
 ///
-/// Called by Instrumentor::resolve_and_validate() and also directly by tests
-/// (the free-function form lets test fixtures use synthetic TestInstruction
-/// objects without standing up an AmdGpuCodeObject). The anchor identity is
-/// already resolved by the caller; @p pt is read for `filter_flags`, `kind`,
-/// and reserved fields. @p arch is accepted now so a future denylist can
-/// grow ISA-specific entries without an API change; today's checks are
-/// uniform across all AMDGPU ISAs.
+/// Pure predicate. Does not look at any InstrumentationPoint — it answers
+/// "can the trampoline machinery splice an `s_branch` here and relocate the
+/// original safely?" only. Reusable by future predicate-based anchor
+/// selection (the orchestrator walks blocks itself and filters candidates).
 ///
-/// Rules enforced:
-///   - @p pt.filter_flags is zero.
-///   - @p pt.kind is BeforeInst (other kinds are unsupported in this milestone).
-///   - @p pt.probe_obj is null, @p pt.probe_symbol is empty, and
-///     @p pt.force_full_exec is false.
+/// Rules enforced (all permanent; none are milestone-scoped):
 ///   - @p anchor_offset is dword aligned.
 ///   - anchor.size() is 4 or 8 and fits inside @p text_bytes.
 ///   - anchor.raw_encoding() is non-null.
@@ -128,6 +146,30 @@ struct InstrumentedCodeObject {
 ///     program terminator, and branch_offset_bytes() is nullopt.
 ///   - anchor.mnemonic() is not in the small PC-relative denylist
 ///     (s_getpc_b64, s_call_b64, s_setpc_b64, s_swappc_b64, s_rfe_*).
+///
+/// @p arch is accepted now so a future denylist can grow ISA-specific entries
+/// without an API change; today's checks are uniform across all AMDGPU ISAs.
+[[nodiscard]] bool is_relocatable_anchor(const Instruction &anchor, uint64_t anchor_offset,
+                                         std::span<const uint8_t> text_bytes, rj_code_arch_t arch,
+                                         std::string *error_out = nullptr);
+
+/// @brief Validate that @p anchor is a legal trampoline anchor for @p pt.
+///
+/// Called by Instrumentor::validate_points() and also directly by tests
+/// (the free-function form lets test fixtures use synthetic TestInstruction
+/// objects without standing up an AmdGpuCodeObject). The anchor identity is
+/// already resolved by the caller; @p pt is read for `filter_flags`, `kind`,
+/// and reserved fields.
+///
+/// Layering: this function combines milestone-scoped policy (reserved-field
+/// rejections — temporary) with permanent structural relocatability
+/// (delegated to is_relocatable_anchor — see there for the structural rules).
+///
+/// Milestone-scoped rules enforced here:
+///   - @p pt.filter_flags is zero.
+///   - @p pt.kind is BeforeInst (other kinds are unsupported in this milestone).
+///   - @p pt.probe_obj is null, @p pt.probe_symbol is empty, and
+///     @p pt.force_full_exec is false.
 [[nodiscard]] std::optional<ResolvedInstrumentationSite>
 validate_anchor(const Instruction &anchor, uint64_t anchor_offset,
                 std::span<const uint8_t> text_bytes, const InstrumentationPoint &pt,
@@ -172,7 +214,7 @@ public:
   Instrumentor(const Instrumentor &) = delete;
   Instrumentor &operator=(const Instrumentor &) = delete;
 
-  /// @brief Queue a point. The point is not validated until resolve_and_validate().
+  /// @brief Queue a point. The point is not validated until validate_points().
   void add_point(InstrumentationPoint pt);
 
   /// @brief Convenience: queue a point identified only by .text-relative offset.
@@ -181,28 +223,17 @@ public:
   void add_point_by_offset(uint64_t anchor_offset,
                            InstrumentationKind kind = InstrumentationKind::BeforeInst);
 
-  /// @brief Force the lazy block build and return the owned blocks.
-  ///
-  /// Callers walk these to choose anchor candidates, then queue the chosen
-  /// Instruction* via add_point(). Pointers obtained any other way fail
-  /// resolution.
-  [[nodiscard]] std::span<const std::unique_ptr<BasicBlock>> owned_blocks();
-
-  struct ResolveResult {
+  struct ValidationResult {
     std::vector<ResolvedInstrumentationSite> sites;
     std::vector<std::string> errors; // Fatal; sites is empty when non-empty.
   };
 
-  /// @brief Resolve and validate all queued points.
+  /// @brief Look up each queued point's anchor and validate it.
   ///
   /// All-or-nothing: on any failure, `sites` is empty and `errors` lists every
   /// fatal diagnostic encountered. On success, `sites` contains one record per
   /// queued point in insertion order and `errors` is empty.
-  ///
-  /// @note `sites[i].anchor_inst` points into BasicBlock storage owned by
-  ///       this Instrumentor. Consumers must not retain sites past this
-  ///       Instrumentor's lifetime.
-  [[nodiscard]] ResolveResult resolve_and_validate();
+  [[nodiscard]] ValidationResult validate_points();
 
   /// @brief Resolve, validate, plan, build, and patch the queued points.
   ///
@@ -230,8 +261,6 @@ private:
 
   void ensure_blocks_built();
   [[nodiscard]] const Instruction *find_instruction_at_offset(uint64_t anchor_offset);
-  [[nodiscard]] std::optional<uint64_t> resolve_anchor_inst_to_offset(const Instruction *target,
-                                                                      std::string *error_out);
 };
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.h
@@ -47,6 +47,7 @@
 #include <optional>
 #include <span>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace rocjitsu {
@@ -279,13 +280,17 @@ private:
   // Lazily populated.
   std::unique_ptr<Decoder> decoder_;
   std::vector<std::unique_ptr<BasicBlock>> blocks_;
+  // .text-relative byte offset -> decoded Instruction. Populated alongside
+  // blocks_ so find_instruction_at_offset is O(1). Pointers are stable for
+  // the lifetime of blocks_ (BasicBlock owns the Instructions via unique_ptr).
+  std::unordered_map<uint64_t, const Instruction *> offset_to_inst_;
   bool blocks_built_ = false;
 
   // Returns false if no decoder exists for arch_ (RV32I/RV64I/INVALID/etc.);
   // in that case *error_out is set and blocks_built_ stays false so the failure
   // is reported instead of crashing in BasicBlock::build.
   [[nodiscard]] bool ensure_blocks_built(std::string *error_out = nullptr);
-  [[nodiscard]] const Instruction *find_instruction_at_offset(uint64_t anchor_offset);
+  [[nodiscard]] const Instruction *find_instruction_at_offset(uint64_t anchor_offset) const;
 };
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.h
@@ -1,0 +1,237 @@
+// Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file instrumentor.h
+/// @brief DBI orchestrator: resolves InstrumentationPoints to .text-relative
+///        anchors, validates them, and (in a later slice) drives byte-level
+///        patching via TrampolineBuilder and CodeObjectPatcher.
+
+#pragma once
+
+#include "rocjitsu/code/patch/trampoline_builder.h"
+#include "rocjitsu/code/rj_code.h"
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace rocjitsu {
+
+class AmdGpuCodeObject;
+class BasicBlock;
+class Decoder;
+class Instruction;
+
+/// @brief Where the instrumentation should attach relative to the anchor.
+///
+/// Internal enum mirroring the future public `rj_code_instrument_kind_t`.
+/// The inline-nop smoke build only supports BeforeInst; the other values are
+/// placeholders so the descriptor evolves into the Section 2 probe shape
+/// without renaming.
+///
+/// TODO(future milestone): implement AfterInst, BlockEntry, and BlockExit.
+/// Today the validator rejects any kind other than BeforeInst.
+enum class InstrumentationKind {
+  BeforeInst,
+  AfterInst,
+  BlockEntry,
+  BlockExit,
+};
+
+/// @brief A request to instrument one site.
+///
+/// The anchor is identified by either @ref anchor_inst (when the caller
+/// already has a decoded Instruction pointer from an Instrumentor-owned
+/// block) or @ref anchor_offset (test/internal shortcut). Exactly one must
+/// be set; setting both or neither is a fatal error during resolution.
+struct InstrumentationPoint {
+  const Instruction *anchor_inst = nullptr;
+  std::optional<uint64_t> anchor_offset;
+
+  InstrumentationKind kind = InstrumentationKind::BeforeInst;
+  uint32_t filter_flags = 0; // Must be 0 in the inline-nop smoke build.
+
+  // Reserved for later milestones — must remain default in the inline-nop
+  // smoke build. The validator rejects any non-default value to keep the
+  // contract honest until each field is actually implemented.
+  // TODO(future milestone): consume probe_obj / probe_symbol when probe-call
+  // trampolines are supported; consume force_full_exec when EXEC policy
+  // management lands.
+  const AmdGpuCodeObject *probe_obj = nullptr;
+  std::string probe_symbol;
+  bool force_full_exec = false;
+};
+
+/// @brief Per-site record produced after validation and byte capture.
+///
+/// @note `anchor_inst` points into BasicBlock storage owned by the
+///       Instrumentor that produced the site. Consumers must not retain
+///       sites past the Instrumentor's lifetime.
+struct ResolvedInstrumentationSite {
+  const Instruction *anchor_inst = nullptr;
+  InstrumentationKind kind = InstrumentationKind::BeforeInst;
+  uint64_t anchor_offset = 0;
+  uint32_t original_size = 0; // 4 or 8 in the inline-nop smoke build.
+  std::vector<uint8_t> original_bytes;
+  std::string mnemonic; // Diagnostic/debug only.
+};
+
+/// @brief Per-site patch record returned by patch_relocation_only().
+///
+/// Intended for test assertions and debugging only — a fresh disassembly of
+/// the emitted ELF would expose the same information. Not a proposed public
+/// metadata surface.
+struct InstrumentationPatch {
+  uint64_t anchor_offset;
+  uint32_t original_size;
+  uint64_t trampoline_offset; // .text-relative.
+  uint64_t return_target;
+  std::vector<uint8_t> original_bytes;
+  std::vector<uint8_t> patched_anchor_bytes;
+};
+
+/// @brief Result of patch_relocation_only().
+///
+/// All-or-nothing: when any fatal error occurs, `elf_bytes` and `patches`
+/// are empty and `errors` is non-empty. On success, `errors` is empty,
+/// `elf_bytes` contains a re-parseable patched ELF, and `patches` contains
+/// one record per applied site.
+struct InstrumentedCodeObject {
+  std::vector<uint8_t> elf_bytes;
+  std::vector<InstrumentationPatch> patches;
+  std::vector<std::string> errors;
+  std::vector<std::string> warnings;
+};
+
+/// @brief Validate that @p anchor is a legal relocation target.
+///
+/// Called by Instrumentor::resolve_and_validate() and also directly by tests
+/// (the free-function form lets test fixtures use synthetic TestInstruction
+/// objects without standing up an AmdGpuCodeObject). The anchor identity is
+/// already resolved by the caller; @p pt is read for `filter_flags`, `kind`,
+/// and reserved fields. @p arch is accepted now so a future denylist can
+/// grow ISA-specific entries without an API change; today's checks are
+/// uniform across all AMDGPU ISAs.
+///
+/// Rules enforced:
+///   - @p pt.filter_flags is zero.
+///   - @p pt.kind is BeforeInst (other kinds are unsupported in this milestone).
+///   - @p pt.probe_obj is null, @p pt.probe_symbol is empty, and
+///     @p pt.force_full_exec is false.
+///   - @p anchor_offset is dword aligned.
+///   - anchor.size() is 4 or 8 and fits inside @p text_bytes.
+///   - anchor.raw_encoding() is non-null.
+///   - anchor is not a branch/cond branch/indirect branch/indirect call/
+///     program terminator, and branch_offset_bytes() is nullopt.
+///   - anchor.mnemonic() is not in the small PC-relative denylist
+///     (s_getpc_b64, s_call_b64, s_setpc_b64, s_swappc_b64, s_rfe_*).
+[[nodiscard]] std::optional<ResolvedInstrumentationSite>
+validate_relocation_anchor(const Instruction &anchor, uint64_t anchor_offset,
+                           std::span<const uint8_t> text_bytes,
+                           const InstrumentationPoint &pt, rj_code_arch_t arch,
+                           std::string *error_out = nullptr);
+
+/// @brief Build the inline-nop smoke TrampolinePlan from a validated site.
+///
+/// Fills before_items = {{ s_nop 0 }}, after_items = {}, emit_original = true.
+/// The caller chooses @p trampoline_offset (typically `patcher.text_size()`).
+[[nodiscard]] TrampolinePlan
+make_relocation_only_plan(const ResolvedInstrumentationSite &site, rj_code_arch_t arch,
+                          uint64_t trampoline_offset);
+
+/// @brief Verify @p plan matches the inline-nop smoke build's canonical body
+///        shape: exactly one `before_items` entry containing `s_nop 0`, empty
+///        `after_items`, and `emit_original == true`.
+///
+/// Lives at the orchestrator boundary rather than inside TrampolineBuilder so
+/// the builder stays generic and ready for future probe-call / clobber-bearing
+/// inline-asm bodies. Called by Instrumentor::patch_relocation_only as a
+/// defense-in-depth check (make_relocation_only_plan always produces canonical
+/// plans today) and also directly by tests so the guardrail logic is
+/// exercised at the layer where it lives.
+///
+/// TODO(future milestone): delete this once arbitrary inline-asm bodies with
+/// declared clobbers are supported.
+[[nodiscard]] bool
+validate_inline_nop_smoke_plan(const TrampolinePlan &plan,
+                               std::string *error_out = nullptr);
+
+/// @brief DBI orchestrator owning point collection and resolution.
+///
+/// PC01-A scope: resolve points to .text-relative offsets, validate, capture
+/// original bytes. Patching (TrampolineBuilder lowering + CodeObjectPatcher
+/// mutation) arrives in the next slice.
+class Instrumentor {
+public:
+  Instrumentor(const AmdGpuCodeObject &obj, rj_code_arch_t arch);
+  ~Instrumentor();
+
+  Instrumentor(const Instrumentor &) = delete;
+  Instrumentor &operator=(const Instrumentor &) = delete;
+
+  /// @brief Queue a point. The point is not validated until resolve_and_validate().
+  void add_point(InstrumentationPoint pt);
+
+  /// @brief Convenience: queue a point identified only by .text-relative offset.
+  ///        Equivalent to constructing an InstrumentationPoint with
+  ///        anchor_offset set.
+  void add_point_by_offset(uint64_t anchor_offset,
+                           InstrumentationKind kind = InstrumentationKind::BeforeInst);
+
+  /// @brief Force the lazy block build and return the owned blocks.
+  ///
+  /// Callers walk these to choose anchor candidates, then queue the chosen
+  /// Instruction* via add_point(). Pointers obtained any other way fail
+  /// resolution.
+  [[nodiscard]] std::span<const std::unique_ptr<BasicBlock>> owned_blocks();
+
+  struct ResolveResult {
+    std::vector<ResolvedInstrumentationSite> sites;
+    std::vector<std::string> errors; // Fatal; sites is empty when non-empty.
+  };
+
+  /// @brief Resolve and validate all queued points.
+  ///
+  /// All-or-nothing: on any failure, `sites` is empty and `errors` lists every
+  /// fatal diagnostic encountered. On success, `sites` contains one record per
+  /// queued point in insertion order and `errors` is empty.
+  ///
+  /// @note `sites[i].anchor_inst` points into BasicBlock storage owned by
+  ///       this Instrumentor. Consumers must not retain sites past this
+  ///       Instrumentor's lifetime.
+  [[nodiscard]] ResolveResult resolve_and_validate();
+
+  /// @brief Resolve, validate, plan, build, and patch the queued points.
+  ///
+  /// Inline-nop smoke build accepts exactly one queued point; queuing zero
+  /// or more than one is a fatal error. The orchestrator preflights all
+  /// builder output before mutating the patcher, so a branch-range failure
+  /// can't leak a half-built ELF.
+  ///
+  /// Single-attempt: any call (success or failure) consumes the Instrumentor's
+  /// budget. A second call returns an empty result with a fatal error, even
+  /// if the first call failed for argument reasons (e.g., zero queued points).
+  /// Callers that hit a recoverable error must construct a new Instrumentor.
+  [[nodiscard]] InstrumentedCodeObject patch_relocation_only();
+
+private:
+  const AmdGpuCodeObject &obj_;
+  rj_code_arch_t arch_;
+  std::vector<InstrumentationPoint> points_;
+  bool patched_ = false;
+
+  // Lazily populated.
+  std::unique_ptr<Decoder> decoder_;
+  std::vector<std::unique_ptr<BasicBlock>> blocks_;
+  bool blocks_built_ = false;
+
+  void ensure_blocks_built();
+  [[nodiscard]] const Instruction *find_instruction_at_offset(uint64_t anchor_offset);
+  [[nodiscard]] std::optional<uint64_t>
+  resolve_anchor_inst_to_offset(const Instruction *target, std::string *error_out);
+};
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.h
@@ -79,7 +79,7 @@ struct ResolvedInstrumentationSite {
   std::string mnemonic; // Diagnostic/debug only.
 };
 
-/// @brief Per-site patch record returned by patch_relocation_only().
+/// @brief Per-site patch record returned by Instrumentor::patch().
 ///
 /// Intended for test assertions and debugging only — a fresh disassembly of
 /// the emitted ELF would expose the same information. Not a proposed public
@@ -93,7 +93,7 @@ struct InstrumentationPatch {
   std::vector<uint8_t> patched_anchor_bytes;
 };
 
-/// @brief Result of patch_relocation_only().
+/// @brief Result of Instrumentor::patch().
 ///
 /// All-or-nothing: when any fatal error occurs, `elf_bytes` and `patches`
 /// are empty and `errors` is non-empty. On success, `errors` is empty,
@@ -106,7 +106,7 @@ struct InstrumentedCodeObject {
   std::vector<std::string> warnings;
 };
 
-/// @brief Validate that @p anchor is a legal relocation target.
+/// @brief Validate that @p anchor is a legal trampoline anchor.
 ///
 /// Called by Instrumentor::resolve_and_validate() and also directly by tests
 /// (the free-function form lets test fixtures use synthetic TestInstruction
@@ -129,35 +129,36 @@ struct InstrumentedCodeObject {
 ///   - anchor.mnemonic() is not in the small PC-relative denylist
 ///     (s_getpc_b64, s_call_b64, s_setpc_b64, s_swappc_b64, s_rfe_*).
 [[nodiscard]] std::optional<ResolvedInstrumentationSite>
-validate_relocation_anchor(const Instruction &anchor, uint64_t anchor_offset,
-                           std::span<const uint8_t> text_bytes,
-                           const InstrumentationPoint &pt, rj_code_arch_t arch,
-                           std::string *error_out = nullptr);
+validate_anchor(const Instruction &anchor, uint64_t anchor_offset,
+                std::span<const uint8_t> text_bytes, const InstrumentationPoint &pt,
+                rj_code_arch_t arch, std::string *error_out = nullptr);
 
-/// @brief Build the inline-nop smoke TrampolinePlan from a validated site.
+/// @brief Build the inline-nop TrampolinePlan from a validated site.
 ///
 /// Fills before_items = {{ s_nop 0 }}, after_items = {}, emit_original = true.
 /// The caller chooses @p trampoline_offset (typically `patcher.text_size()`).
-[[nodiscard]] TrampolinePlan
-make_relocation_only_plan(const ResolvedInstrumentationSite &site, rj_code_arch_t arch,
-                          uint64_t trampoline_offset);
+[[nodiscard]] TrampolinePlan make_trampoline_plan(const ResolvedInstrumentationSite &site,
+                                                  rj_code_arch_t arch,
+                                                  uint64_t trampoline_offset);
 
-/// @brief Verify @p plan matches the inline-nop smoke build's canonical body
-///        shape: exactly one `before_items` entry containing `s_nop 0`, empty
-///        `after_items`, and `emit_original == true`.
+/// @brief Verify @p plan matches the inline-nop canonical body shape: exactly
+///        one `before_items` entry containing `s_nop 0`, empty `after_items`,
+///        and `emit_original == true`.
 ///
-/// Lives at the orchestrator boundary rather than inside TrampolineBuilder so
-/// the builder stays generic and ready for future probe-call / clobber-bearing
-/// inline-asm bodies. Called by Instrumentor::patch_relocation_only as a
-/// defense-in-depth check (make_relocation_only_plan always produces canonical
+/// One of several places where inline-nop milestone constraints are enforced.
+/// The others: validate_anchor() rejects reserved InstrumentationPoint fields,
+/// and Instrumentor::patch() rejects multi-text code objects and the multi-
+/// point case. This one lives at the orchestrator boundary rather than inside
+/// TrampolineBuilder so the builder stays generic and ready for future probe-
+/// call / clobber-bearing inline-asm bodies. Called by Instrumentor::patch()
+/// as a defense-in-depth check (make_trampoline_plan always produces canonical
 /// plans today) and also directly by tests so the guardrail logic is
 /// exercised at the layer where it lives.
 ///
 /// TODO(future milestone): delete this once arbitrary inline-asm bodies with
 /// declared clobbers are supported.
-[[nodiscard]] bool
-validate_inline_nop_smoke_plan(const TrampolinePlan &plan,
-                               std::string *error_out = nullptr);
+[[nodiscard]] bool validate_inline_nop_plan(const TrampolinePlan &plan,
+                                            std::string *error_out = nullptr);
 
 /// @brief DBI orchestrator owning point collection and resolution.
 ///
@@ -206,16 +207,16 @@ public:
 
   /// @brief Resolve, validate, plan, build, and patch the queued points.
   ///
-  /// Inline-nop smoke build accepts exactly one queued point; queuing zero
-  /// or more than one is a fatal error. The orchestrator preflights all
-  /// builder output before mutating the patcher, so a branch-range failure
-  /// can't leak a half-built ELF.
+  /// Inline-nop milestone accepts exactly one queued point; queuing zero or
+  /// more than one is a fatal error. The orchestrator preflights all builder
+  /// output before mutating the patcher, so a branch-range failure can't leak
+  /// a half-built ELF.
   ///
   /// Single-attempt: any call (success or failure) consumes the Instrumentor's
   /// budget. A second call returns an empty result with a fatal error, even
   /// if the first call failed for argument reasons (e.g., zero queued points).
   /// Callers that hit a recoverable error must construct a new Instrumentor.
-  [[nodiscard]] InstrumentedCodeObject patch_relocation_only();
+  [[nodiscard]] InstrumentedCodeObject patch();
 
 private:
   const AmdGpuCodeObject &obj_;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.h
@@ -138,8 +138,7 @@ validate_anchor(const Instruction &anchor, uint64_t anchor_offset,
 /// Fills before_items = {{ s_nop 0 }}, after_items = {}, emit_original = true.
 /// The caller chooses @p trampoline_offset (typically `patcher.text_size()`).
 [[nodiscard]] TrampolinePlan make_trampoline_plan(const ResolvedInstrumentationSite &site,
-                                                  rj_code_arch_t arch,
-                                                  uint64_t trampoline_offset);
+                                                  rj_code_arch_t arch, uint64_t trampoline_offset);
 
 /// @brief Verify @p plan matches the inline-nop canonical body shape: exactly
 ///        one `before_items` entry containing `s_nop 0`, empty `after_items`,
@@ -231,8 +230,8 @@ private:
 
   void ensure_blocks_built();
   [[nodiscard]] const Instruction *find_instruction_at_offset(uint64_t anchor_offset);
-  [[nodiscard]] std::optional<uint64_t>
-  resolve_anchor_inst_to_offset(const Instruction *target, std::string *error_out);
+  [[nodiscard]] std::optional<uint64_t> resolve_anchor_inst_to_offset(const Instruction *target,
+                                                                      std::string *error_out);
 };
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.h
@@ -23,10 +23,10 @@
 ///         v
 ///   InstrumentedCodeObject      -- patched ELF + per-site InstrumentationPatch
 ///
-/// Current pipeline is single-point and all-or-nothing: any per-site failure
-/// aborts the whole patch.
-/// TODOs:: predicate-based anchor selection (Instrumentor walks blocks itself),
-/// multi-site with per-site failure tolerance, probe-call bodies,
+/// Current pipeline is all-or-nothing across all queued points: any per-site
+/// failure aborts the whole patch.
+/// Future work: predicate-based anchor selection (Instrumentor walks blocks
+/// itself), per-site failure tolerance, probe-call bodies,
 /// AfterInst / BlockEntry / BlockExit kinds, EXEC policy management.
 /// As that lands the per-stage types will thicken
 /// (e.g. ResolvedInstrumentationSite probably gains an ordered list of bodies)
@@ -258,9 +258,9 @@ public:
   /// leak a half-built ELF. Thus `elf_bytes` is either fully populated or empty
   /// with diagnostics in `errors`.
   ///
-  /// Current support is single-point: queuing zero or more than one
-  /// InstrumentationPoint is a fatal error. Shares the single-attempt budget
-  /// with patch_with_debug_summaries(); see the class-level note.
+  /// Requires at least one queued InstrumentationPoint; queuing zero is a fatal
+  /// error. Shares the single-attempt budget with patch_with_debug_summaries();
+  /// see the class-level note.
   [[nodiscard]] InstrumentedCodeObject patch();
 
   /// @brief Same as patch(), plus per-site InstrumentationPatch summaries.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.h
@@ -19,7 +19,7 @@
 ///         |  make_trampoline_plan() + TrampolineBuilder::build()
 ///         v
 ///   (preflight: per-site plan + built bytes, accumulated locally)
-///         |  splice anchors + append .rj_trampolines + emit()
+///         |  splice anchors + append trampoline caves into .text + emit()
 ///         v
 ///   InstrumentedCodeObject      -- patched ELF + per-site InstrumentationPatch
 ///

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/trampoline_builder.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/trampoline_builder.cpp
@@ -1,0 +1,110 @@
+// Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/code/patch/trampoline_builder.h"
+
+#include "rocjitsu/code/patch/instruction_builder.h"
+
+#include <cstring>
+
+namespace rocjitsu {
+
+namespace {
+
+void report(std::string *out, const char *msg) {
+  if (out)
+    *out = msg;
+}
+
+// DBI currently only supports inlined nops as the instrumentation body. Any
+// other inline-asm shape needs clobber declarations and liveness handling,
+// which arrive in a later milestone — this guardrail keeps the first DBI
+// build from silently emitting bytes whose register footprint hasn't been
+// accounted for.
+[[nodiscard]] bool check_inline_nop_smoke_guardrail(const TrampolinePlan &plan,
+                                                    std::string *err) {
+  if (!plan.emit_original) {
+    report(err, "trampoline plan: emit_original must be true for the inline-nop smoke build");
+    return false;
+  }
+  if (!plan.after_items.empty()) {
+    report(err, "trampoline plan: after_items must be empty for the inline-nop smoke build");
+    return false;
+  }
+  if (plan.before_items.size() != 1 || plan.before_items[0].words.size() != 1 ||
+      plan.before_items[0].words[0] != build_s_nop(0, plan.arch)) {
+    report(err,
+           "trampoline plan: before_items must be exactly { { s_nop 0 } } "
+           "for the inline-nop smoke build");
+    return false;
+  }
+  return true;
+}
+
+[[nodiscard]] bool check_size_and_words(const TrampolinePlan &plan, std::string *err) {
+  if (plan.original_size != 4 && plan.original_size != 8) {
+    report(err, "trampoline plan: original_size must be 4 or 8");
+    return false;
+  }
+  const size_t expected_words = plan.original_size / sizeof(uint32_t);
+  if (plan.original_words.size() != expected_words) {
+    report(err, "trampoline plan: original_words count does not match original_size");
+    return false;
+  }
+  return true;
+}
+
+void append_word(std::vector<uint8_t> &dst, uint32_t w) {
+  uint8_t buf[sizeof(w)];
+  std::memcpy(buf, &w, sizeof(w));
+  dst.insert(dst.end(), buf, buf + sizeof(w));
+}
+
+} // namespace
+
+std::optional<TrampolineBytes> TrampolineBuilder::build(const TrampolinePlan &plan,
+                                                        std::string *error_out) {
+  if (!check_inline_nop_smoke_guardrail(plan, error_out))
+    return std::nullopt;
+  if (!check_size_and_words(plan, error_out))
+    return std::nullopt;
+
+  // Forward branch: from the anchor to the trampoline.
+  const auto fwd = compute_sopp_branch_simm16(plan.anchor_offset, plan.trampoline_offset);
+  if (!fwd) {
+    report(error_out, "relocation trampoline forward branch exceeds s_branch simm16");
+    return std::nullopt;
+  }
+
+  // Lay out trampoline body so we can compute the return branch offset. For
+  // the inline-nop smoke build the body is exactly [s_nop 0, original*]; the
+  // generic loops below also handle the eventual multi-item inline-asm shape.
+  std::vector<uint32_t> body;
+  body.reserve(1 + plan.original_words.size() + 1);
+  for (const InlineAsmItem &item : plan.before_items)
+    body.insert(body.end(), item.words.begin(), item.words.end());
+  if (plan.emit_original)
+    body.insert(body.end(), plan.original_words.begin(), plan.original_words.end());
+  for (const InlineAsmItem &item : plan.after_items)
+    body.insert(body.end(), item.words.begin(), item.words.end());
+
+  const uint64_t return_branch_pc =
+      plan.trampoline_offset + body.size() * sizeof(uint32_t);
+  const auto ret = compute_sopp_branch_simm16(return_branch_pc, plan.return_target);
+  if (!ret) {
+    report(error_out, "relocation trampoline return branch exceeds s_branch simm16");
+    return std::nullopt;
+  }
+
+  TrampolineBytes out;
+  out.patched_anchor_bytes.reserve(plan.original_size);
+  append_word(out.patched_anchor_bytes, build_s_branch(*fwd, plan.arch));
+  if (plan.original_size == 8)
+    append_word(out.patched_anchor_bytes, build_s_nop(0, plan.arch));
+
+  out.trampoline_words = std::move(body);
+  out.trampoline_words.push_back(build_s_branch(*ret, plan.arch));
+  return out;
+}
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/trampoline_builder.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/trampoline_builder.cpp
@@ -65,8 +65,7 @@ std::optional<TrampolineBytes> TrampolineBuilder::build(const TrampolinePlan &pl
   for (const InlineAsmItem &item : plan.after_items)
     body.insert(body.end(), item.words.begin(), item.words.end());
 
-  const uint64_t return_branch_pc =
-      plan.trampoline_offset + body.size() * sizeof(uint32_t);
+  const uint64_t return_branch_pc = plan.trampoline_offset + body.size() * sizeof(uint32_t);
   const auto ret = compute_sopp_branch_simm16(return_branch_pc, plan.return_target);
   if (!ret) {
     report(error_out, "relocation trampoline return branch exceeds s_branch simm16");

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/trampoline_builder.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/trampoline_builder.cpp
@@ -16,31 +16,6 @@ void report(std::string *out, const char *msg) {
     *out = msg;
 }
 
-// DBI currently only supports inlined nops as the instrumentation body. Any
-// other inline-asm shape needs clobber declarations and liveness handling,
-// which arrive in a later milestone — this guardrail keeps the first DBI
-// build from silently emitting bytes whose register footprint hasn't been
-// accounted for.
-[[nodiscard]] bool check_inline_nop_smoke_guardrail(const TrampolinePlan &plan,
-                                                    std::string *err) {
-  if (!plan.emit_original) {
-    report(err, "trampoline plan: emit_original must be true for the inline-nop smoke build");
-    return false;
-  }
-  if (!plan.after_items.empty()) {
-    report(err, "trampoline plan: after_items must be empty for the inline-nop smoke build");
-    return false;
-  }
-  if (plan.before_items.size() != 1 || plan.before_items[0].words.size() != 1 ||
-      plan.before_items[0].words[0] != build_s_nop(0, plan.arch)) {
-    report(err,
-           "trampoline plan: before_items must be exactly { { s_nop 0 } } "
-           "for the inline-nop smoke build");
-    return false;
-  }
-  return true;
-}
-
 [[nodiscard]] bool check_size_and_words(const TrampolinePlan &plan, std::string *err) {
   if (plan.original_size != 4 && plan.original_size != 8) {
     report(err, "trampoline plan: original_size must be 4 or 8");
@@ -54,6 +29,10 @@ void report(std::string *out, const char *msg) {
   return true;
 }
 
+// Appends @p w to @p dst in host byte order. AMDGPU code objects are little-
+// endian and rocjitsu only supports little-endian hosts (matches DBT's
+// memcpy convention in binary_translator.cpp); if either invariant ever
+// changes, this helper needs an explicit byte-swap.
 void append_word(std::vector<uint8_t> &dst, uint32_t w) {
   uint8_t buf[sizeof(w)];
   std::memcpy(buf, &w, sizeof(w));
@@ -64,8 +43,6 @@ void append_word(std::vector<uint8_t> &dst, uint32_t w) {
 
 std::optional<TrampolineBytes> TrampolineBuilder::build(const TrampolinePlan &plan,
                                                         std::string *error_out) {
-  if (!check_inline_nop_smoke_guardrail(plan, error_out))
-    return std::nullopt;
   if (!check_size_and_words(plan, error_out))
     return std::nullopt;
 
@@ -76,11 +53,11 @@ std::optional<TrampolineBytes> TrampolineBuilder::build(const TrampolinePlan &pl
     return std::nullopt;
   }
 
-  // Lay out trampoline body so we can compute the return branch offset. For
-  // the inline-nop smoke build the body is exactly [s_nop 0, original*]; the
-  // generic loops below also handle the eventual multi-item inline-asm shape.
+  // Lay out trampoline body so we can compute the return branch offset. The
+  // generic loops below handle any multi-item inline-asm shape; no reserve
+  // hint because the per-item word counts aren't known up front and
+  // vector::insert handles growth.
   std::vector<uint32_t> body;
-  body.reserve(1 + plan.original_words.size() + 1);
   for (const InlineAsmItem &item : plan.before_items)
     body.insert(body.end(), item.words.begin(), item.words.end());
   if (plan.emit_original)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/trampoline_builder.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/trampoline_builder.cpp
@@ -3,6 +3,7 @@
 
 #include "rocjitsu/code/patch/trampoline_builder.h"
 
+#include "rocjitsu/code/patch/error_report.h"
 #include "rocjitsu/code/patch/instruction_builder.h"
 
 #include <cstring>
@@ -10,11 +11,6 @@
 namespace rocjitsu {
 
 namespace {
-
-void report(std::string *out, const char *msg) {
-  if (out)
-    *out = msg;
-}
 
 [[nodiscard]] bool check_size_and_words(const TrampolinePlan &plan, std::string *err) {
   if (plan.original_size != 4 && plan.original_size != 8) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/trampoline_builder.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/trampoline_builder.cpp
@@ -13,6 +13,10 @@ namespace rocjitsu {
 namespace {
 
 [[nodiscard]] bool check_size_and_words(const TrampolinePlan &plan, std::string *err) {
+  if (plan.arch == ROCJITSU_CODE_ARCH_INVALID) {
+    report(err, "trampoline plan: arch was not set");
+    return false;
+  }
   if (plan.original_size != 4 && plan.original_size != 8) {
     report(err, "trampoline plan: original_size must be 4 or 8");
     return false;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/trampoline_builder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/trampoline_builder.h
@@ -69,8 +69,8 @@ public:
   /// The builder does not enforce milestone-scoped restrictions on body
   /// shape; the orchestrator decides what kind of plan to emit and calls
   /// validate_inline_nop_plan (in instrumentor.h) when appropriate.
-  [[nodiscard]] static std::optional<TrampolineBytes>
-  build(const TrampolinePlan &plan, std::string *error_out = nullptr);
+  [[nodiscard]] static std::optional<TrampolineBytes> build(const TrampolinePlan &plan,
+                                                            std::string *error_out = nullptr);
 };
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/trampoline_builder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/trampoline_builder.h
@@ -5,10 +5,13 @@
 /// @brief Lowers a TrampolinePlan into patched-anchor bytes and trampoline
 ///        words for the DBI relocation-only path.
 ///
-/// This is the byte emitter; it owns SOPP branch math and the inline-nop smoke
-/// guardrail. It does not touch the ELF or own layout assignment — see
-/// instrumentor.h for the orchestrator and code_object_patcher.h for the ELF
-/// mutation layer.
+/// This is the byte emitter; it owns SOPP branch math and basic plan
+/// well-formedness checks (original_size 4 or 8, original_words count
+/// matches, branch ranges fit). It does not touch the ELF, does not own
+/// layout assignment, and does not enforce milestone-scoped restrictions
+/// (e.g. "only emit s_nop placeholder bodies" — that lives in the
+/// orchestrator as `validate_inline_nop_smoke_plan` in instrumentor.h).
+/// See code_object_patcher.h for the ELF mutation layer.
 
 #pragma once
 
@@ -59,10 +62,13 @@ public:
   ///
   /// Returns std::nullopt and writes a human-readable explanation to
   /// @p error_out (if non-null) on:
-  ///   - Inline-nop smoke guardrail violation (before/after/emit_original)
   ///   - original_size other than 4 or 8
   ///   - original_words size mismatch with original_size
   ///   - Forward or return branch outside s_branch simm16 range
+  ///
+  /// The builder does not enforce milestone-scoped restrictions on body
+  /// shape; the orchestrator decides what kind of plan to emit and calls
+  /// validate_inline_nop_smoke_plan (in instrumentor.h) when appropriate.
   [[nodiscard]] static std::optional<TrampolineBytes>
   build(const TrampolinePlan &plan, std::string *error_out = nullptr);
 };

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/trampoline_builder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/trampoline_builder.h
@@ -1,0 +1,70 @@
+// Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file trampoline_builder.h
+/// @brief Lowers a TrampolinePlan into patched-anchor bytes and trampoline
+///        words for the DBI relocation-only path.
+///
+/// This is the byte emitter; it owns SOPP branch math and the inline-nop smoke
+/// guardrail. It does not touch the ELF or own layout assignment — see
+/// instrumentor.h for the orchestrator and code_object_patcher.h for the ELF
+/// mutation layer.
+
+#pragma once
+
+#include "rocjitsu/code/rj_code.h"
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace rocjitsu {
+
+/// @brief Concrete instruction words placed before or after the relocated
+///        original in the trampoline. Declared clobbers are intentionally
+///        deferred to a later milestone.
+struct InlineAsmItem {
+  std::vector<uint32_t> words;
+};
+
+/// @brief Builder-facing description of one trampoline.
+///
+/// Coordinates are .text-relative byte offsets. The orchestrator fills this
+/// after validation and layout, then hands it to TrampolineBuilder.
+struct TrampolinePlan {
+  rj_code_arch_t arch = ROCJITSU_CODE_ARCH_CDNA4;
+
+  uint64_t anchor_offset = 0;
+  uint32_t original_size = 0; // 4 or 8 for the inline-nop smoke build.
+  uint64_t trampoline_offset = 0;
+  uint64_t return_target = 0; // Typically anchor_offset + original_size.
+
+  std::vector<uint32_t> original_words; // Exact bytes pulled from .text.
+
+  std::vector<InlineAsmItem> before_items;
+  std::vector<InlineAsmItem> after_items;
+  bool emit_original = true;
+};
+
+/// @brief Output bytes for one trampoline.
+struct TrampolineBytes {
+  std::vector<uint8_t> patched_anchor_bytes; // original_size bytes.
+  std::vector<uint32_t> trampoline_words;
+};
+
+class TrampolineBuilder {
+public:
+  /// @brief Lower @p plan to patched-anchor bytes and trampoline words.
+  ///
+  /// Returns std::nullopt and writes a human-readable explanation to
+  /// @p error_out (if non-null) on:
+  ///   - Inline-nop smoke guardrail violation (before/after/emit_original)
+  ///   - original_size other than 4 or 8
+  ///   - original_words size mismatch with original_size
+  ///   - Forward or return branch outside s_branch simm16 range
+  [[nodiscard]] static std::optional<TrampolineBytes>
+  build(const TrampolinePlan &plan, std::string *error_out = nullptr);
+};
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/trampoline_builder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/trampoline_builder.h
@@ -10,7 +10,7 @@
 /// matches, branch ranges fit). It does not touch the ELF, does not own
 /// layout assignment, and does not enforce milestone-scoped restrictions
 /// (e.g. "only emit s_nop placeholder bodies" — that lives in the
-/// orchestrator as `validate_inline_nop_smoke_plan` in instrumentor.h).
+/// orchestrator as `validate_inline_nop_plan` in instrumentor.h).
 /// See code_object_patcher.h for the ELF mutation layer.
 
 #pragma once
@@ -68,7 +68,7 @@ public:
   ///
   /// The builder does not enforce milestone-scoped restrictions on body
   /// shape; the orchestrator decides what kind of plan to emit and calls
-  /// validate_inline_nop_smoke_plan (in instrumentor.h) when appropriate.
+  /// validate_inline_nop_plan (in instrumentor.h) when appropriate.
   [[nodiscard]] static std::optional<TrampolineBytes>
   build(const TrampolinePlan &plan, std::string *error_out = nullptr);
 };

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/trampoline_builder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/trampoline_builder.h
@@ -36,7 +36,7 @@ struct InlineAsmItem {
 /// Coordinates are .text-relative byte offsets. The orchestrator fills this
 /// after validation and layout, then hands it to TrampolineBuilder.
 struct TrampolinePlan {
-  rj_code_arch_t arch = ROCJITSU_CODE_ARCH_CDNA4;
+  rj_code_arch_t arch = ROCJITSU_CODE_ARCH_INVALID;
 
   uint64_t anchor_offset = 0;
   uint32_t original_size = 0; // 4 or 8 for the inline-nop smoke build.
@@ -62,6 +62,7 @@ public:
   ///
   /// Returns std::nullopt and writes a human-readable explanation to
   /// @p error_out (if non-null) on:
+  ///   - arch left at ROCJITSU_CODE_ARCH_INVALID (caller forgot to set it)
   ///   - original_size other than 4 or 8
   ///   - original_words size mismatch with original_size
   ///   - Forward or return branch outside s_branch simm16 range

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/rj_code.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/rj_code.cpp
@@ -12,12 +12,17 @@ using namespace rocjitsu;
 namespace {
 
 Decoder *create_decoder_for_target(rj_code_target_id_t target) {
+  static thread_local std::unique_ptr<Decoder> cdna2_decoder;
   static thread_local std::unique_ptr<Decoder> cdna3_decoder;
   static thread_local std::unique_ptr<Decoder> cdna4_decoder;
   static thread_local std::unique_ptr<Decoder> rdna4_decoder;
   static thread_local std::unique_ptr<Decoder> gfx1250_decoder;
 
   switch (target) {
+  case ROCJITSU_CODE_TARGET_GFX90A:
+    if (!cdna2_decoder)
+      cdna2_decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA2);
+    return cdna2_decoder.get();
   case ROCJITSU_CODE_TARGET_GFX942:
     if (!cdna3_decoder)
       cdna3_decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA3);

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -49,6 +49,7 @@ add_executable(
     transcendental_test.cpp
     analysis/liveness_test.cpp
     patch/spill_manager_test.cpp
+    patch/instruction_builder_test.cpp
     dbt/translate_test.cpp
     mtype_flags_test.cpp
     kfd_ioctl_test.cpp

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -581,7 +581,10 @@ if(HSA_RUNTIME64)
                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
             )
             if(RJ_DBI_TIMEOUT)
-                set_tests_properties("${name}" PROPERTIES TIMEOUT ${RJ_DBI_TIMEOUT})
+                set_tests_properties(
+                    "${name}"
+                    PROPERTIES TIMEOUT ${RJ_DBI_TIMEOUT}
+                )
             endif()
         endfunction()
 
@@ -595,10 +598,7 @@ if(HSA_RUNTIME64)
             register_hsa_dbi_smoke_case(Hardware PatchedElfLoadsAndValidatesInHsaExecutable)
             register_hsa_dbi_smoke_case(Hardware PatchedKernelDispatchMatchesOriginal TIMEOUT 30)
             register_hsa_dbi_smoke_case(Hardware TrampolineIsActuallyExecutedByGpu TIMEOUT 30)
-            message(
-                STATUS
-                "HSA DBI smoke test enabled (gfx90a detected)"
-            )
+            message(STATUS "HSA DBI smoke test enabled (gfx90a detected)")
         else()
             message(
                 STATUS

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -51,6 +51,7 @@ add_executable(
     patch/spill_manager_test.cpp
     patch/instruction_builder_test.cpp
     patch/trampoline_builder_test.cpp
+    patch/instrumentor_test.cpp
     dbt/translate_test.cpp
     mtype_flags_test.cpp
     kfd_ioctl_test.cpp

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -50,6 +50,7 @@ add_executable(
     analysis/liveness_test.cpp
     patch/spill_manager_test.cpp
     patch/instruction_builder_test.cpp
+    patch/trampoline_builder_test.cpp
     dbt/translate_test.cpp
     mtype_flags_test.cpp
     kfd_ioctl_test.cpp

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -52,6 +52,7 @@ add_executable(
     patch/instruction_builder_test.cpp
     patch/trampoline_builder_test.cpp
     patch/instrumentor_test.cpp
+    patch/error_report_test.cpp
     code/code_object_target_id_test.cpp
     dbt/translate_test.cpp
     mtype_flags_test.cpp

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -52,6 +52,7 @@ add_executable(
     patch/instruction_builder_test.cpp
     patch/trampoline_builder_test.cpp
     patch/instrumentor_test.cpp
+    code/code_object_target_id_test.cpp
     dbt/translate_test.cpp
     mtype_flags_test.cpp
     kfd_ioctl_test.cpp
@@ -298,6 +299,7 @@ if(HSA_RUNTIME64)
         set(HAS_CDNA3_GPU FALSE)
         set(HAS_RDNA4_GPU FALSE)
         set(HAS_GFX1201_GPU FALSE)
+        set(HAS_CDNA2_GPU FALSE)
         if(ROCM_AGENT_ENUM)
             execute_process(
                 COMMAND ${ROCM_AGENT_ENUM}
@@ -320,6 +322,9 @@ if(HSA_RUNTIME64)
             endif()
             if(_agent_rc EQUAL 0 AND _agents MATCHES "gfx1201")
                 set(HAS_GFX1201_GPU TRUE)
+            endif()
+            if(_agent_rc EQUAL 0 AND _agents MATCHES "gfx90a")
+                set(HAS_CDNA2_GPU TRUE)
             endif()
         endif()
 
@@ -529,6 +534,76 @@ if(HSA_RUNTIME64)
                 STATUS
                 "CDNA4->CDNA3 dispatch tests built but NOT registered with CTest "
                 "(no CDNA3 GPU)"
+            )
+        endif()
+
+        # --- HSA DBI smoke test: gfx90a kernel patched with inlined nop ---
+        # Build always; register with CTest only when a gfx90a GPU is present.
+        add_executable(hsa_dbi_smoke_test dbi/hsa_dbi_smoke_test.cpp)
+        target_include_directories(
+            hsa_dbi_smoke_test
+            PRIVATE
+                ${CMAKE_SOURCE_DIR}/lib/rocjitsu/include
+                ${CMAKE_SOURCE_DIR}/lib/rocjitsu/src
+                ${CMAKE_SOURCE_DIR}/lib/util/include
+                ${RJ_HSA_INCLUDE_DIR}
+        )
+        target_link_libraries(
+            hsa_dbi_smoke_test
+            PRIVATE
+                ${RJ_OBJECT_LIBS}
+                ${HSA_RUNTIME64}
+                GTest::gtest
+                GTest::gtest_main
+        )
+        target_link_options(
+            hsa_dbi_smoke_test
+            PRIVATE -Wl,-rpath,${RJ_HSA_LIBRARY_DIR}
+        )
+        target_compile_definitions(
+            hsa_dbi_smoke_test
+            PRIVATE HAS_HOST_AMDGPU=1 KERNEL_DIR="${KERNEL_OUTPUT_DIR}"
+        )
+        add_dependencies(hsa_dbi_smoke_test device_kernels)
+        rj_configure_target(hsa_dbi_smoke_test TEST)
+
+        # Local helper: register one TEST_F case from hsa_dbi_smoke_test as a
+        # CTest entry. <group> is the part of the fixture name after
+        # "HsaDbiSmoke" (Static or Hardware). Scoped here because it's only
+        # used by the calls immediately below.
+        function(register_hsa_dbi_smoke_case group case)
+            set(oneValueArgs TIMEOUT)
+            cmake_parse_arguments(RJ_DBI "" "${oneValueArgs}" "" ${ARGN})
+            set(name "HsaDbiSmoke${group}.${case}")
+            add_test(
+                NAME "${name}"
+                COMMAND hsa_dbi_smoke_test --gtest_filter=${name}
+                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            )
+            if(RJ_DBI_TIMEOUT)
+                set_tests_properties("${name}" PROPERTIES TIMEOUT ${RJ_DBI_TIMEOUT})
+            endif()
+        endfunction()
+
+        # Static-only test: no GPU needed, runs anywhere the binary is built.
+        register_hsa_dbi_smoke_case(Static PatchedElfActuallyContainsInstrumentation)
+
+        if(HAS_CDNA2_GPU)
+            # Hardware-gated tests. The two that dispatch get an explicit
+            # timeout; the load+validate one runs quickly enough for the
+            # default.
+            register_hsa_dbi_smoke_case(Hardware PatchedElfLoadsAndValidatesInHsaExecutable)
+            register_hsa_dbi_smoke_case(Hardware PatchedKernelDispatchMatchesOriginal TIMEOUT 30)
+            register_hsa_dbi_smoke_case(Hardware TrampolineIsActuallyExecutedByGpu TIMEOUT 30)
+            message(
+                STATUS
+                "HSA DBI smoke test enabled (gfx90a detected)"
+            )
+        else()
+            message(
+                STATUS
+                "HSA DBI smoke test built but NOT registered with CTest "
+                "(no gfx90a)"
             )
         endif()
     endif()

--- a/emulation/rocjitsu/tests/code/code_object_target_id_test.cpp
+++ b/emulation/rocjitsu/tests/code/code_object_target_id_test.cpp
@@ -163,7 +163,8 @@ void expect_c_api_accepts_target(uint32_t mach_flag, rj_code_target_id_t target)
   //   - blocks came from _create()   -> refcount 0 -> destroy only.
   //   - obj    came from _get_code_object() -> refcount 1 -> destroy + release.
   //   - exec   came from _create()   -> refcount 0 -> destroy only.
-  if (blocks) rj_code_basic_block_list_destroy(blocks);
+  if (blocks)
+    rj_code_basic_block_list_destroy(blocks);
   rj_code_object_destroy(obj);
   rj_code_object_release(obj);
   rj_code_executable_destroy(exec);

--- a/emulation/rocjitsu/tests/code/code_object_target_id_test.cpp
+++ b/emulation/rocjitsu/tests/code/code_object_target_id_test.cpp
@@ -1,0 +1,221 @@
+// Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file code_object_target_id_test.cpp
+/// @brief Tests for AMDGPU code-object target identification: that the ELF
+///        machine-flag field (e_flags & EF_AMDGPU_MACH) maps to the right
+///        rj_code_target_id_t value, and that the corresponding C API path
+///        (rj_code_executable_create -> get_code_object ->
+///        basic_block_list_create) accepts each target by exercising the
+///        create_decoder_for_target switch in rj_code.cpp.
+///
+/// Covers all supported targets (gfx90a, gfx942, gfx950) plus an unknown-
+/// machine-flag case to guard the INVALID sentinel and prevent a future
+/// edit from silently aliasing one target onto another.
+
+#include "rocjitsu/code/amdgpu_code_object.h"
+#include "rocjitsu/code/amdgpu_elf.h"
+#include "rocjitsu/code/rj_code.h"
+
+#include <gtest/gtest.h>
+
+#include <unistd.h>
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace rocjitsu {
+namespace {
+
+// Helpers duplicated from tests/dbt/translate_test.cpp /
+// tests/patch/instrumentor_test.cpp.
+// TODO: extract into a shared fixture header
+
+uint32_t add_elf_name(std::vector<uint8_t> &names, std::string_view name) {
+  const uint32_t offset = static_cast<uint32_t>(names.size());
+  names.insert(names.end(), name.begin(), name.end());
+  names.push_back('\0');
+  return offset;
+}
+
+uint64_t align_up(uint64_t value, uint64_t alignment) {
+  const uint64_t remainder = value % alignment;
+  return remainder == 0 ? value : value + alignment - remainder;
+}
+
+// Minimal AMDGPU ELF tagged with @p mach_flag. .text contains two `s_nop 0`
+// words so it can be decoded by any AMDGPU ISA (SOPP encoding is shared).
+std::vector<uint8_t> make_minimal_amdgpu_elf(uint32_t mach_flag) {
+  constexpr uint64_t text_offset = 0x100;
+  constexpr uint64_t text_size = 8;
+  constexpr uint64_t rodata_size = 4;
+
+  std::vector<uint8_t> shstrtab{'\0'};
+  const uint32_t text_name = add_elf_name(shstrtab, ".text");
+  const uint32_t rodata_name = add_elf_name(shstrtab, ".rodata");
+  const uint32_t shstrtab_name = add_elf_name(shstrtab, ".shstrtab");
+
+  const uint64_t rodata_offset = text_offset + text_size;
+  const uint64_t shstrtab_offset = rodata_offset + rodata_size;
+  const uint64_t shoff = align_up(shstrtab_offset + shstrtab.size(), 8);
+  constexpr uint16_t section_count = 4;
+
+  std::vector<uint8_t> image(shoff + section_count * sizeof(Elf64_Shdr), 0);
+
+  Elf64_Ehdr ehdr{};
+  std::memcpy(ehdr.e_ident, EI_MAGIC, EI_MAGIC_SIZE);
+  ehdr.e_ident[EI_CLASS] = ELFCLASS64;
+  ehdr.e_ident[EI_OSABI] = ELFOSABI_AMDGPU_HSA;
+  ehdr.e_type = ET_REL;
+  ehdr.e_machine = EM_AMDGPU;
+  ehdr.e_version = 1;
+  ehdr.e_shoff = shoff;
+  ehdr.e_flags = mach_flag;
+  ehdr.e_ehsize = sizeof(Elf64_Ehdr);
+  ehdr.e_shentsize = sizeof(Elf64_Shdr);
+  ehdr.e_shnum = section_count;
+  ehdr.e_shstrndx = 3;
+  std::memcpy(image.data(), &ehdr, sizeof(ehdr));
+
+  const std::array<uint32_t, 2> text_words = {0xBF800000u, 0xBF800000u};
+  std::memcpy(image.data() + text_offset, text_words.data(), text_size);
+
+  const uint32_t rodata_word = 0xA5A55A5Au;
+  std::memcpy(image.data() + rodata_offset, &rodata_word, sizeof(rodata_word));
+  std::memcpy(image.data() + shstrtab_offset, shstrtab.data(), shstrtab.size());
+
+  std::array<Elf64_Shdr, section_count> shdrs{};
+  shdrs[1].sh_name = text_name;
+  shdrs[1].sh_type = SHT_PROGBITS;
+  shdrs[1].sh_flags = SHF_ALLOC | SHF_EXECINSTR;
+  shdrs[1].sh_offset = text_offset;
+  shdrs[1].sh_size = text_size;
+  shdrs[1].sh_addralign = sizeof(uint32_t);
+
+  shdrs[2].sh_name = rodata_name;
+  shdrs[2].sh_type = SHT_PROGBITS;
+  shdrs[2].sh_flags = SHF_ALLOC;
+  shdrs[2].sh_offset = rodata_offset;
+  shdrs[2].sh_size = rodata_size;
+  shdrs[2].sh_addralign = sizeof(uint32_t);
+
+  shdrs[3].sh_name = shstrtab_name;
+  shdrs[3].sh_type = SHT_STRTAB;
+  shdrs[3].sh_offset = shstrtab_offset;
+  shdrs[3].sh_size = shstrtab.size();
+  shdrs[3].sh_addralign = 1;
+
+  std::memcpy(image.data() + shoff, shdrs.data(), shdrs.size() * sizeof(Elf64_Shdr));
+  return image;
+}
+
+// Build a minimal ELF tagged with @p mach_flag, load it as an
+// AmdGpuCodeObject, and assert target_id() resolves to @p expected.
+void expect_machine_flag_maps_to_target(uint32_t mach_flag, rj_code_target_id_t expected) {
+  auto image = make_minimal_amdgpu_elf(mach_flag);
+  AmdGpuCodeObject obj(image.data(), image.size());
+  ASSERT_TRUE(obj.is_valid());
+  EXPECT_EQ(obj.target_id(), expected);
+}
+
+// Drive the C API path that internally calls create_decoder_for_target:
+// write a minimal ELF for @p mach_flag to a temp file, open it as an
+// executable, fetch the code object for @p target, and build a basic-block
+// list. Cleans up after.
+void expect_c_api_accepts_target(uint32_t mach_flag, rj_code_target_id_t target) {
+  auto image = make_minimal_amdgpu_elf(mach_flag);
+
+  // PID-suffix the tmp filename so concurrent ctest runs and stale leftovers
+  // from prior crashed runs don't collide.
+  const std::filesystem::path tmp =
+      std::filesystem::temp_directory_path() /
+      ("rj_code_object_target_id_test_" + std::to_string(getpid()) + ".co");
+  {
+    std::ofstream out(tmp, std::ios::binary | std::ios::trunc);
+    ASSERT_TRUE(out.is_open()) << "could not open " << tmp;
+    out.write(reinterpret_cast<const char *>(image.data()),
+              static_cast<std::streamsize>(image.size()));
+  }
+
+  rj_code_executable_t *exec = nullptr;
+  ASSERT_EQ(rj_code_executable_create(tmp.c_str(), &exec), ROCJITSU_STATUS_SUCCESS);
+  ASSERT_NE(exec, nullptr);
+
+  ASSERT_GT(rj_code_executable_num_code_objects(exec, target), 0u)
+      << "executable must expose at least one code object for the requested target";
+
+  rj_code_object_t *obj = nullptr;
+  ASSERT_EQ(rj_code_executable_get_code_object(exec, target, 0, &obj), ROCJITSU_STATUS_SUCCESS);
+  ASSERT_NE(obj, nullptr);
+
+  rj_code_basic_block_list_t *blocks = nullptr;
+  EXPECT_EQ(rj_code_basic_block_list_create(obj, target, &blocks), ROCJITSU_STATUS_SUCCESS)
+      << "rj_code_basic_block_list_create must succeed for a target whose decoder is wired in";
+  EXPECT_NE(blocks, nullptr);
+
+  // Cleanup follows the refcount discipline in refcount.h:
+  //   - blocks came from _create()   -> refcount 0 -> destroy only.
+  //   - obj    came from _get_code_object() -> refcount 1 -> destroy + release.
+  //   - exec   came from _create()   -> refcount 0 -> destroy only.
+  if (blocks) rj_code_basic_block_list_destroy(blocks);
+  rj_code_object_destroy(obj);
+  rj_code_object_release(obj);
+  rj_code_executable_destroy(exec);
+
+  std::error_code ec;
+  std::filesystem::remove(tmp, ec); // best-effort
+}
+
+//==============================================================================
+// Machine flag -> target_id (one test per supported target)
+//==============================================================================
+
+TEST(GfxCodeObjectTargets, LoadsGfx90aFromMachineFlags) {
+  expect_machine_flag_maps_to_target(EF_AMDGPU_MACH_AMDGCN_GFX90A, ROCJITSU_CODE_TARGET_GFX90A);
+}
+
+TEST(GfxCodeObjectTargets, LoadsGfx942FromMachineFlags) {
+  expect_machine_flag_maps_to_target(EF_AMDGPU_MACH_AMDGCN_GFX942, ROCJITSU_CODE_TARGET_GFX942);
+}
+
+TEST(GfxCodeObjectTargets, LoadsGfx950FromMachineFlags) {
+  expect_machine_flag_maps_to_target(EF_AMDGPU_MACH_AMDGCN_GFX950, ROCJITSU_CODE_TARGET_GFX950);
+}
+
+// Machine flags outside the supported set must surface as
+// ROCJITSU_CODE_TARGET_INVALID rather than silently aliasing onto a real
+// target (which would happen if someone accidentally made a real target the
+// default arm of the switch).
+TEST(GfxCodeObjectTargets, UnknownMachineFlagMapsToInvalid) {
+  // 0x1234 is not any defined EF_AMDGPU_MACH_AMDGCN_* value.
+  auto image = make_minimal_amdgpu_elf(/*mach_flag=*/0x1234);
+  AmdGpuCodeObject obj(image.data(), image.size());
+  ASSERT_TRUE(obj.is_valid()) << "ELF should still parse; only target_id is unknown";
+  EXPECT_EQ(obj.target_id(), ROCJITSU_CODE_TARGET_INVALID);
+}
+
+//==============================================================================
+// C API path (rj_code_executable_create + ... + basic_block_list_create)
+// exercises create_decoder_for_target for each supported target.
+//==============================================================================
+
+TEST(GfxCodeObjectTargets, CApiAcceptsGfx90aForBasicBlockList) {
+  expect_c_api_accepts_target(EF_AMDGPU_MACH_AMDGCN_GFX90A, ROCJITSU_CODE_TARGET_GFX90A);
+}
+
+TEST(GfxCodeObjectTargets, CApiAcceptsGfx942ForBasicBlockList) {
+  expect_c_api_accepts_target(EF_AMDGPU_MACH_AMDGCN_GFX942, ROCJITSU_CODE_TARGET_GFX942);
+}
+
+TEST(GfxCodeObjectTargets, CApiAcceptsGfx950ForBasicBlockList) {
+  expect_c_api_accepts_target(EF_AMDGPU_MACH_AMDGCN_GFX950, ROCJITSU_CODE_TARGET_GFX950);
+}
+
+} // namespace
+} // namespace rocjitsu

--- a/emulation/rocjitsu/tests/code/code_object_target_id_test.cpp
+++ b/emulation/rocjitsu/tests/code/code_object_target_id_test.cpp
@@ -9,9 +9,10 @@
 ///        basic_block_list_create) accepts each target by exercising the
 ///        create_decoder_for_target switch in rj_code.cpp.
 ///
-/// Covers all supported targets (gfx90a, gfx942, gfx950) plus an unknown-
-/// machine-flag case to guard the INVALID sentinel and prevent a future
-/// edit from silently aliasing one target onto another.
+/// Covers the only currently supported targets (gfx90a, gfx942, gfx950,
+/// gfx1200, gfx1201, gfx1250) plus an unknown-machine-flag case to guard the
+/// INVALID sentinel and prevent a future edit from silently aliasing one target
+/// onto another.
 
 #include "rocjitsu/code/amdgpu_code_object.h"
 #include "rocjitsu/code/amdgpu_elf.h"
@@ -189,6 +190,18 @@ TEST(GfxCodeObjectTargets, LoadsGfx950FromMachineFlags) {
   expect_machine_flag_maps_to_target(EF_AMDGPU_MACH_AMDGCN_GFX950, ROCJITSU_CODE_TARGET_GFX950);
 }
 
+TEST(GfxCodeObjectTargets, LoadsGfx1200FromMachineFlags) {
+  expect_machine_flag_maps_to_target(EF_AMDGPU_MACH_AMDGCN_GFX1200, ROCJITSU_CODE_TARGET_GFX1200);
+}
+
+TEST(GfxCodeObjectTargets, LoadsGfx1201FromMachineFlags) {
+  expect_machine_flag_maps_to_target(EF_AMDGPU_MACH_AMDGCN_GFX1201, ROCJITSU_CODE_TARGET_GFX1201);
+}
+
+TEST(GfxCodeObjectTargets, LoadsGfx1250FromMachineFlags) {
+  expect_machine_flag_maps_to_target(EF_AMDGPU_MACH_AMDGCN_GFX1250, ROCJITSU_CODE_TARGET_GFX1250);
+}
+
 // Machine flags outside the supported set must surface as
 // ROCJITSU_CODE_TARGET_INVALID rather than silently aliasing onto a real
 // target (which would happen if someone accidentally made a real target the
@@ -216,6 +229,18 @@ TEST(GfxCodeObjectTargets, CApiAcceptsGfx942ForBasicBlockList) {
 
 TEST(GfxCodeObjectTargets, CApiAcceptsGfx950ForBasicBlockList) {
   expect_c_api_accepts_target(EF_AMDGPU_MACH_AMDGCN_GFX950, ROCJITSU_CODE_TARGET_GFX950);
+}
+
+TEST(GfxCodeObjectTargets, CApiAcceptsGfx1200ForBasicBlockList) {
+  expect_c_api_accepts_target(EF_AMDGPU_MACH_AMDGCN_GFX1200, ROCJITSU_CODE_TARGET_GFX1200);
+}
+
+TEST(GfxCodeObjectTargets, CApiAcceptsGfx1201ForBasicBlockList) {
+  expect_c_api_accepts_target(EF_AMDGPU_MACH_AMDGCN_GFX1201, ROCJITSU_CODE_TARGET_GFX1201);
+}
+
+TEST(GfxCodeObjectTargets, CApiAcceptsGfx1250ForBasicBlockList) {
+  expect_c_api_accepts_target(EF_AMDGPU_MACH_AMDGCN_GFX1250, ROCJITSU_CODE_TARGET_GFX1250);
 }
 
 } // namespace

--- a/emulation/rocjitsu/tests/dbi/hsa_dbi_smoke_test.cpp
+++ b/emulation/rocjitsu/tests/dbi/hsa_dbi_smoke_test.cpp
@@ -1,0 +1,602 @@
+// Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file hsa_dbi_smoke_test.cpp
+/// @brief End-to-end DBI smoke: patch a real compiled gfx90a kernel with
+///        Instrumentor::patch_relocation_only, then load and
+///        eventually dispatch the patched ELF via HSA.
+
+#include "rocjitsu/base/rj_compiler.h"
+RJ_DIAGNOSTIC_PUSH
+RJ_DIAGNOSTIC_IGNORE_PEDANTIC
+#include <hsa/hsa.h>
+#include <hsa/hsa_ext_amd.h>
+RJ_DIAGNOSTIC_POP
+
+#include "rocjitsu/code/amdgpu_code_object.h"
+#include "rocjitsu/code/basic_block.h"
+#include "rocjitsu/code/executable.h"
+#include "rocjitsu/code/patch/instrumentor.h"
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <random>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#ifdef HAS_HOST_AMDGPU
+using namespace rocjitsu;
+
+namespace {
+
+std::string kernel_path(const char *name) {
+  return std::string(KERNEL_DIR) + "/" + name + ".o";
+}
+
+// Find a GPU agent whose ISA name contains "gfx90a". Returns {handle=0} if
+// no such agent is present.
+hsa_agent_t find_gfx90a_agent() {
+  hsa_agent_t result{};
+  hsa_iterate_agents(
+      [](hsa_agent_t agent, void *data) -> hsa_status_t {
+        hsa_device_type_t type;
+        hsa_agent_get_info(agent, HSA_AGENT_INFO_DEVICE, &type);
+        if (type != HSA_DEVICE_TYPE_GPU)
+          return HSA_STATUS_SUCCESS;
+        hsa_isa_t isa{};
+        hsa_agent_get_info(agent, HSA_AGENT_INFO_ISA, &isa);
+        char isa_name[128]{};
+        hsa_isa_get_info_alt(isa, HSA_ISA_INFO_NAME, isa_name);
+        if (std::strstr(isa_name, "gfx90a")) {
+          *static_cast<hsa_agent_t *>(data) = agent;
+          return HSA_STATUS_INFO_BREAK;
+        }
+        return HSA_STATUS_SUCCESS;
+      },
+      &result);
+  return result;
+}
+
+hsa_agent_t find_cpu_agent() {
+  hsa_agent_t result{};
+  hsa_iterate_agents(
+      [](hsa_agent_t agent, void *data) -> hsa_status_t {
+        hsa_device_type_t type;
+        hsa_agent_get_info(agent, HSA_AGENT_INFO_DEVICE, &type);
+        if (type == HSA_DEVICE_TYPE_CPU) {
+          *static_cast<hsa_agent_t *>(data) = agent;
+          return HSA_STATUS_INFO_BREAK;
+        }
+        return HSA_STATUS_SUCCESS;
+      },
+      &result);
+  return result;
+}
+
+hsa_amd_memory_pool_t find_pool(hsa_agent_t agent, hsa_amd_segment_t segment,
+                                bool host_accessible = false) {
+  struct Ctx {
+    hsa_amd_segment_t seg;
+    bool host_acc;
+    hsa_amd_memory_pool_t pool;
+  } ctx{segment, host_accessible, {}};
+  hsa_amd_agent_iterate_memory_pools(
+      agent,
+      [](hsa_amd_memory_pool_t pool, void *data) -> hsa_status_t {
+        auto *c = static_cast<Ctx *>(data);
+        hsa_amd_segment_t seg;
+        hsa_amd_memory_pool_get_info(pool, HSA_AMD_MEMORY_POOL_INFO_SEGMENT, &seg);
+        if (seg != c->seg)
+          return HSA_STATUS_SUCCESS;
+        if (c->host_acc) {
+          bool acc = false;
+          hsa_amd_memory_pool_get_info(pool, HSA_AMD_MEMORY_POOL_INFO_ACCESSIBLE_BY_ALL, &acc);
+          if (!acc)
+            return HSA_STATUS_SUCCESS;
+        }
+        c->pool = pool;
+        return HSA_STATUS_INFO_BREAK;
+      },
+      &ctx);
+  return ctx.pool;
+}
+
+// Dispatch the vector_add kernel from @p elf_bytes and return the output
+// buffer. Returns an empty vector on any HSA failure (test will fail with an
+// assertion in the caller). Mirrors the dispatch scaffold in
+// tests/dbt/hsa_translate_test.cpp:186-298.
+std::vector<float> dispatch_vector_add(std::span<const uint8_t> elf_bytes, hsa_agent_t gpu,
+                                       hsa_agent_t cpu, const std::vector<float> &a_in,
+                                       const std::vector<float> &b_in, uint32_t n) {
+  constexpr size_t kKernArgsBytes = 256;
+  const size_t buf_size = n * sizeof(float);
+
+  hsa_code_object_reader_t reader{};
+  if (hsa_code_object_reader_create_from_memory(elf_bytes.data(), elf_bytes.size(), &reader) !=
+      HSA_STATUS_SUCCESS)
+    return {};
+
+  hsa_executable_t executable{};
+  if (hsa_executable_create_alt(HSA_PROFILE_FULL, HSA_DEFAULT_FLOAT_ROUNDING_MODE_DEFAULT, nullptr,
+                                &executable) != HSA_STATUS_SUCCESS) {
+    hsa_code_object_reader_destroy(reader);
+    return {};
+  }
+  if (hsa_executable_load_agent_code_object(executable, gpu, reader, nullptr, nullptr) !=
+          HSA_STATUS_SUCCESS ||
+      hsa_executable_freeze(executable, nullptr) != HSA_STATUS_SUCCESS) {
+    hsa_executable_destroy(executable);
+    hsa_code_object_reader_destroy(reader);
+    return {};
+  }
+
+  hsa_executable_symbol_t symbol{};
+  uint64_t kernel_object = 0;
+  if (hsa_executable_get_symbol_by_name(executable, "vector_add.kd", &gpu, &symbol) !=
+          HSA_STATUS_SUCCESS ||
+      hsa_executable_symbol_get_info(symbol, HSA_EXECUTABLE_SYMBOL_INFO_KERNEL_OBJECT,
+                                     &kernel_object) != HSA_STATUS_SUCCESS ||
+      kernel_object == 0) {
+    hsa_executable_destroy(executable);
+    hsa_code_object_reader_destroy(reader);
+    return {};
+  }
+
+  // Pool + buffer + queue setup. Each step is checked so a failure on a
+  // flaky system returns an empty result cleanly rather than crashing on a
+  // null pointer or zero handle later. A single cleanup epilogue runs
+  // regardless of success.
+  auto gpu_pool = find_pool(gpu, HSA_AMD_SEGMENT_GLOBAL);
+  auto kernarg_pool = find_pool(cpu, HSA_AMD_SEGMENT_GLOBAL, /*host_accessible=*/true);
+  float *A_dev = nullptr, *B_dev = nullptr, *C_dev = nullptr;
+  void *kernarg = nullptr;
+  hsa_queue_t *queue = nullptr;
+  hsa_signal_t signal{};
+  std::vector<float> out;
+
+  bool ok = (gpu_pool.handle != 0) && (kernarg_pool.handle != 0);
+  if (ok)
+    ok = hsa_amd_memory_pool_allocate(gpu_pool, buf_size, 0,
+                                      reinterpret_cast<void **>(&A_dev)) == HSA_STATUS_SUCCESS;
+  if (ok)
+    ok = hsa_amd_memory_pool_allocate(gpu_pool, buf_size, 0,
+                                      reinterpret_cast<void **>(&B_dev)) == HSA_STATUS_SUCCESS;
+  if (ok)
+    ok = hsa_amd_memory_pool_allocate(gpu_pool, buf_size, 0,
+                                      reinterpret_cast<void **>(&C_dev)) == HSA_STATUS_SUCCESS;
+  if (ok)
+    ok = hsa_amd_memory_pool_allocate(kernarg_pool, kKernArgsBytes, 0, &kernarg) ==
+         HSA_STATUS_SUCCESS;
+
+  if (ok) {
+    hsa_agent_t both[] = {cpu, gpu};
+    hsa_amd_agents_allow_access(2, both, nullptr, A_dev);
+    hsa_amd_agents_allow_access(2, both, nullptr, B_dev);
+    hsa_amd_agents_allow_access(2, both, nullptr, C_dev);
+    hsa_amd_agents_allow_access(2, both, nullptr, kernarg);
+
+    hsa_memory_copy(A_dev, a_in.data(), buf_size);
+    hsa_memory_copy(B_dev, b_in.data(), buf_size);
+    const std::vector<uint8_t> zero_bytes(buf_size, 0);
+    hsa_memory_copy(C_dev, zero_bytes.data(), buf_size);
+
+    std::memset(kernarg, 0, kKernArgsBytes);
+    struct __attribute__((packed)) KernArgs {
+      const float *A;
+      const float *B;
+      float *C;
+      uint32_t N;
+    };
+    auto *args = static_cast<KernArgs *>(kernarg);
+    args->A = A_dev;
+    args->B = B_dev;
+    args->C = C_dev;
+    args->N = n;
+
+    uint32_t queue_size = 0;
+    hsa_agent_get_info(gpu, HSA_AGENT_INFO_QUEUE_MAX_SIZE, &queue_size);
+    ok = hsa_queue_create(gpu, queue_size, HSA_QUEUE_TYPE_SINGLE, nullptr, nullptr, UINT32_MAX,
+                          UINT32_MAX, &queue) == HSA_STATUS_SUCCESS &&
+         queue != nullptr;
+  }
+
+  if (ok)
+    ok = hsa_signal_create(1, 0, nullptr, &signal) == HSA_STATUS_SUCCESS;
+
+  if (ok) {
+    uint64_t write_idx = hsa_queue_add_write_index_relaxed(queue, 1);
+    auto *aql = static_cast<hsa_kernel_dispatch_packet_t *>(queue->base_address) +
+                (write_idx & (queue->size - 1));
+    std::memset(aql, 0, sizeof(*aql));
+    aql->setup = 1;
+    aql->workgroup_size_x = 64;
+    aql->workgroup_size_y = 1;
+    aql->workgroup_size_z = 1;
+    aql->grid_size_x = n;
+    aql->grid_size_y = 1;
+    aql->grid_size_z = 1;
+    aql->kernel_object = kernel_object;
+    aql->kernarg_address = kernarg;
+    aql->completion_signal = signal;
+
+    uint16_t header = HSA_PACKET_TYPE_KERNEL_DISPATCH << HSA_PACKET_HEADER_TYPE;
+    header |= 1 << HSA_PACKET_HEADER_BARRIER;
+    header |= HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_ACQUIRE_FENCE_SCOPE;
+    header |= HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_RELEASE_FENCE_SCOPE;
+    __atomic_store_n(reinterpret_cast<uint16_t *>(aql), header, __ATOMIC_RELEASE);
+
+    hsa_signal_store_relaxed(queue->doorbell_signal, write_idx);
+
+    hsa_signal_value_t val = hsa_signal_wait_scacquire(signal, HSA_SIGNAL_CONDITION_LT, 1,
+                                                       5'000'000'000ULL, HSA_WAIT_STATE_BLOCKED);
+    if (val == 0) {
+      out.resize(n);
+      hsa_memory_copy(out.data(), C_dev, buf_size);
+    }
+  }
+
+  // Cleanup epilogue: each call is guarded so partial-initialization paths
+  // don't dereference null handles.
+  if (signal.handle != 0)
+    hsa_signal_destroy(signal);
+  if (queue != nullptr)
+    hsa_queue_destroy(queue);
+  if (kernarg != nullptr)
+    hsa_amd_memory_pool_free(kernarg);
+  if (A_dev != nullptr)
+    hsa_amd_memory_pool_free(A_dev);
+  if (B_dev != nullptr)
+    hsa_amd_memory_pool_free(B_dev);
+  if (C_dev != nullptr)
+    hsa_amd_memory_pool_free(C_dev);
+  hsa_executable_destroy(executable);
+  hsa_code_object_reader_destroy(reader);
+  return out;
+}
+
+} // namespace
+
+// Shared fixture: loads vector_add_gfx90a.o, decodes .text, finds the first
+// relocatable v_add_f32 anchor, and patches it via Instrumentor. Two empty
+// derived classes (HsaDbiSmokeStatic / HsaDbiSmokeHardware) inherit this so
+// CMake can register one CTest entry per gating policy:
+//   - HsaDbiSmokeStatic.*   - no GPU needed, registered unconditionally
+//   - HsaDbiSmokeHardware.* - registered only when HAS_CDNA2_GPU is set
+class HsaDbiSmokeFixture : public ::testing::Test {
+protected:
+
+  // Load a vector_add_gfx90a.o device ELF and instrument a single instruction
+  // with the inlined nop functionality currently available in Instrumentor
+  void SetUp() override {
+    // Get gfx90a build of vector_add.
+    Executable exec(kernel_path("vector_add_gfx90a"));
+    ASSERT_TRUE(exec.is_valid()) << "Failed to load vector_add_gfx90a.o";
+    ASSERT_GT(exec.num_code_objects(ROCJITSU_CODE_TARGET_GFX90A), 0u);
+    const auto *co = exec.code_object(ROCJITSU_CODE_TARGET_GFX90A, 0);
+    ASSERT_NE(co, nullptr);
+
+    // Snapshot the original device ELF so we can dispatch it too
+    original_elf_bytes_.assign(
+        reinterpret_cast<const uint8_t *>(co->image_data()),
+        reinterpret_cast<const uint8_t *>(co->image_data()) + co->image_size());
+
+    // Decode .text and find the first v_add_f32-mnemonic anchor that
+    // satisfies the validator's relocatability rules. Decode-and-search so
+    // the test is stable across compiler revisions.
+    // TODO: instrument multiple instructions
+    auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA2);
+    ASSERT_NE(decoder, nullptr);
+    auto blocks = BasicBlock::build(*co, *decoder);
+
+    bool found = false;
+    for (const auto &block : blocks) {
+      uint64_t cur = block->start_offset();
+      for (const Instruction &inst : block->instructions()) {
+        const bool is_vadd =
+            inst.mnemonic().find("v_add_f32") != std::string_view::npos;
+        // TODO: Okay for now but Instrumentor should do this check
+        const bool relocatable = inst.size() == 4 && inst.raw_encoding() != nullptr &&
+                                 !inst.is_branch() &&
+                                 !inst.branch_offset_bytes().has_value();
+        if (is_vadd && relocatable) {
+          anchor_offset_ = cur;   // Instrumentor will need offset
+          anchor_mnemonic_ = std::string(inst.mnemonic());
+          found = true;
+          break;
+        }
+        cur += static_cast<uint64_t>(inst.size());
+      }
+      if (found)
+        break;
+    }
+    ASSERT_TRUE(found) << "No relocatable v_add_f32 anchor in vector_add_gfx90a.o; "
+                          "did the compiler change the lowering?";
+
+    // Patch via with the inlined nop (patch_relocation_only)
+    Instrumentor instrumentor(*co, ROCJITSU_CODE_ARCH_CDNA2);
+    instrumentor.add_point_by_offset(anchor_offset_);
+    auto result = instrumentor.patch_relocation_only();
+    ASSERT_TRUE(result.errors.empty())
+        << "patch_relocation_only failed: "
+        << (result.errors.empty() ? std::string{} : result.errors.front());
+    patched_elf_bytes_ = std::move(result.elf_bytes);
+    ASSERT_FALSE(patched_elf_bytes_.empty());
+  }
+
+  std::vector<uint8_t> original_elf_bytes_;
+  std::vector<uint8_t> patched_elf_bytes_;
+  uint64_t anchor_offset_ = 0;
+  std::string anchor_mnemonic_;
+};
+
+// Tests that need only HSA libs (parsing + decoding the patched ELF). Run
+// anywhere the binary is built.
+class HsaDbiSmokeStatic : public HsaDbiSmokeFixture {};
+
+// Tests that need to load + dispatch on a real gfx90a GPU. Gated at CMake
+// time by HAS_CDNA2_GPU; bodies also GTEST_SKIP at runtime if no agent.
+class HsaDbiSmokeHardware : public HsaDbiSmokeFixture {};
+
+// Static verification: prove the patcher actually changed the kernel before
+// any HSA / dispatch tests run. No GPU or HSA runtime required. Catches
+// failure modes that the byte-equality dispatch check cannot:
+//   - patcher silently produced the original bytes (e.g. patch_relocation_only
+//     short-circuited without applying the patch)
+//   - patch landed at a different offset than anchor_offset_ records
+//   - .rj_trampolines section is missing from the patched ELF
+TEST_F(HsaDbiSmokeStatic, PatchedElfActuallyContainsInstrumentation) {
+  // (a) Patcher produced different bytes from the original.
+  ASSERT_NE(patched_elf_bytes_, original_elf_bytes_)
+      << "Patched ELF is byte-identical to original - patcher silently no-oped?";
+
+  // (b) The patched .text at anchor_offset_ now decodes as s_branch, not the
+  //     original v_add_f32 we recorded as anchor_mnemonic_.
+  AmdGpuCodeObject patched(patched_elf_bytes_.data(), patched_elf_bytes_.size());
+  ASSERT_TRUE(patched.is_valid());
+  ASSERT_FALSE(patched.text_sections().empty());
+  const Section *text = patched.text_sections().front();
+  ASSERT_GT(text->size(), anchor_offset_ + 4);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA2);
+  ASSERT_NE(decoder, nullptr);
+  rj_code_binary_inst_t anchor_word = 0;
+  std::memcpy(&anchor_word, text->data() + anchor_offset_, sizeof(anchor_word));
+  std::unique_ptr<Instruction> decoded(decoder->decode(&anchor_word));
+  ASSERT_NE(decoded, nullptr);
+  EXPECT_NE(decoded->mnemonic().find("s_branch"), std::string_view::npos)
+      << "Anchor at offset " << anchor_offset_ << " should now decode as s_branch; got: "
+      << decoded->mnemonic();
+  EXPECT_NE(decoded->mnemonic(), anchor_mnemonic_)
+      << "Anchor mnemonic unchanged (" << anchor_mnemonic_ << ") - was the patch applied?";
+
+  // (c) Patched ELF has a .rj_trampolines section.
+  bool found_tramp = false;
+  for (const Section *s : patched.code_sections()) {
+    if (s->name() == ".rj_trampolines") {
+      found_tramp = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(found_tramp) << ".rj_trampolines section missing from patched ELF";
+}
+
+// Load patched ELF into an HSA executable and validate. No dispatch.
+// Gates on a real gfx90a agent because hsa_executable_load_agent_code_object
+// requires an agent whose ISA matches the code object.
+TEST_F(HsaDbiSmokeHardware, PatchedElfLoadsAndValidatesInHsaExecutable) {
+  if (hsa_init() != HSA_STATUS_SUCCESS)
+    GTEST_SKIP() << "hsa_init failed (no HSA runtime at runtime)";
+
+  hsa_agent_t gpu = find_gfx90a_agent();
+  if (gpu.handle == 0) {
+    hsa_shut_down();
+    GTEST_SKIP() << "No gfx90a agent present";
+  }
+
+  hsa_code_object_reader_t reader{};
+  ASSERT_EQ(hsa_code_object_reader_create_from_memory(
+                patched_elf_bytes_.data(), patched_elf_bytes_.size(), &reader),
+            HSA_STATUS_SUCCESS)
+      << "Patched ELF rejected by hsa_code_object_reader_create_from_memory";
+
+  hsa_executable_t executable{};
+  ASSERT_EQ(hsa_executable_create_alt(HSA_PROFILE_FULL,
+                                       HSA_DEFAULT_FLOAT_ROUNDING_MODE_DEFAULT,
+                                       nullptr, &executable),
+            HSA_STATUS_SUCCESS);
+
+  ASSERT_EQ(hsa_executable_load_agent_code_object(executable, gpu, reader, nullptr, nullptr),
+            HSA_STATUS_SUCCESS)
+      << "hsa_executable_load_agent_code_object rejected the patched ELF";
+
+  ASSERT_EQ(hsa_executable_freeze(executable, nullptr), HSA_STATUS_SUCCESS);
+
+  uint32_t validate_result = 0;
+  ASSERT_EQ(hsa_executable_validate(executable, &validate_result), HSA_STATUS_SUCCESS);
+  EXPECT_EQ(validate_result, 0u)
+      << "hsa_executable_validate reported error: " << validate_result;
+
+  // Sanity: the kernel symbol is still findable post-patch.
+  hsa_executable_symbol_t symbol{};
+  EXPECT_EQ(hsa_executable_get_symbol_by_name(executable, "vector_add.kd", &gpu, &symbol),
+            HSA_STATUS_SUCCESS)
+      << "kernel symbol vector_add.kd missing after patching";
+
+  hsa_executable_destroy(executable);
+  hsa_code_object_reader_destroy(reader);
+  hsa_shut_down();
+}
+
+// Dispatch both the original and patched kernels with identical
+// inputs and confirm bit-identical outputs. The inline-nop placeholder is
+// semantically a no-op, so the patched kernel must produce the same buffer
+// as the original — anything else means the patch path corrupted execution.
+TEST_F(HsaDbiSmokeHardware, PatchedKernelDispatchMatchesOriginal) {
+  if (hsa_init() != HSA_STATUS_SUCCESS)
+    GTEST_SKIP() << "hsa_init failed";
+  hsa_agent_t gpu = find_gfx90a_agent();
+  if (gpu.handle == 0) {
+    hsa_shut_down();
+    GTEST_SKIP() << "No gfx90a agent present";
+  }
+  hsa_agent_t cpu = find_cpu_agent();
+  ASSERT_NE(cpu.handle, 0u) << "No CPU agent found";
+
+  constexpr uint32_t N = 1024;
+  std::mt19937 rng(42);
+  std::uniform_real_distribution<float> dist(-100.0f, 100.0f);
+  std::vector<float> a(N), b(N), golden(N);
+  for (uint32_t i = 0; i < N; ++i) {
+    a[i] = dist(rng);
+    b[i] = dist(rng);
+    golden[i] = a[i] + b[i];
+  }
+
+  // Helper: assert the output buffer is non-zero somewhere. The C buffer is
+  // zeroed before each dispatch (see dispatch_vector_add), so a non-zero
+  // result proves the kernel actually executed and wrote into it \xE2\x80\x94 not just
+  // that the surrounding plumbing succeeded.
+  auto assert_kernel_wrote_output = [](const std::vector<float> &out, const char *label) {
+    bool wrote = false;
+    for (float v : out) {
+      if (v != 0.0f) {
+        wrote = true;
+        break;
+      }
+    }
+    ASSERT_TRUE(wrote) << label << " dispatch left output buffer all zeros (kernel didn't run?)";
+  };
+
+  // Sanity: original (unpatched) dispatch matches the CPU golden. If this
+  // fails the test fixture is bad, not the instrumentation.
+  auto orig_out = dispatch_vector_add(original_elf_bytes_, gpu, cpu, a, b, N);
+  ASSERT_EQ(orig_out.size(), N) << "original dispatch failed (empty result)";
+  assert_kernel_wrote_output(orig_out, "original");
+  int orig_mismatches = 0;
+  for (uint32_t i = 0; i < N; ++i) {
+    if (std::abs(orig_out[i] - golden[i]) > 1e-5f)
+      ++orig_mismatches;
+  }
+  ASSERT_EQ(orig_mismatches, 0)
+      << "original vector_add dispatch produced " << orig_mismatches << "/" << N
+      << " mismatches against CPU golden (test fixture problem)";
+
+  // The real check: patched dispatch must produce the same buffer as the
+  // original. Bit-identical because the trampoline body is just s_nop 0
+  // around the relocated v_add_f32.
+  auto patched_out = dispatch_vector_add(patched_elf_bytes_, gpu, cpu, a, b, N);
+  ASSERT_EQ(patched_out.size(), N) << "patched dispatch failed (empty result)";
+  assert_kernel_wrote_output(patched_out, "patched");
+  EXPECT_EQ(patched_out, orig_out)
+      << "patched kernel output differs from original — the inline-nop placeholder "
+         "should be semantically a no-op";
+
+  hsa_shut_down();
+}
+
+// "Sabotage" verification: overwrite the s_nop 0 placeholder in the patched
+// trampoline with s_endpgm 0. If the GPU genuinely takes the trampoline
+// path, every wave terminates before reaching the relocated v_add_f32 and
+// the output stays at the pre-dispatch zero pattern. If the trampoline is
+// somehow bypassed (e.g., the forward s_branch didn't take effect), the
+// kernel would still produce the golden output.
+//
+// This is the only test that proves "the trampoline executes on the GPU" -
+// the other tests are statically verifiable (correct bytes, correct ELF
+// structure, semantically-equivalent dispatch output).
+TEST_F(HsaDbiSmokeHardware, TrampolineIsActuallyExecutedByGpu) {
+  if (hsa_init() != HSA_STATUS_SUCCESS)
+    GTEST_SKIP() << "hsa_init failed";
+  hsa_agent_t gpu = find_gfx90a_agent();
+  if (gpu.handle == 0) {
+    hsa_shut_down();
+    GTEST_SKIP() << "No gfx90a agent present";
+  }
+  hsa_agent_t cpu = find_cpu_agent();
+  ASSERT_NE(cpu.handle, 0u);
+
+  // Find .rj_trampolines in the patched ELF and overwrite its first 4 bytes
+  // (the s_nop 0 placeholder) with s_endpgm 0.
+  std::vector<uint8_t> sabotaged = patched_elf_bytes_;
+  AmdGpuCodeObject parsed(sabotaged.data(), sabotaged.size());
+  ASSERT_TRUE(parsed.is_valid());
+  const Section *tramp = nullptr;
+  for (const Section *s : parsed.code_sections()) {
+    if (s->name() == ".rj_trampolines") {
+      tramp = s;
+      break;
+    }
+  }
+  ASSERT_NE(tramp, nullptr);
+  ASSERT_GE(tramp->size(), 4u);
+
+  // Before sabotaging: verify the bytes we're about to overwrite are indeed
+  // s_nop 0. If this assertion fails, the orchestrator's trampoline layout
+  // no longer starts with the placeholder we think it does, and the
+  // sabotage premise ("we replaced the no-op with s_endpgm") would be a lie.
+  // TODO: With multiple instrumentation points, this will no longer be a good 
+  // assumption. Will likely need to sabotage the whole section.
+  constexpr uint32_t kSNop0 = 0xBF800000u;
+  uint32_t pre_overwrite = 0;
+  std::memcpy(&pre_overwrite, sabotaged.data() + tramp->sectionOffset(),
+              sizeof(pre_overwrite));
+  ASSERT_EQ(pre_overwrite, kSNop0)
+      << "Expected s_nop 0 (0x" << std::hex << kSNop0
+      << ") at start of .rj_trampolines but found 0x" << pre_overwrite
+      << " - trampoline body layout changed?";
+
+  // s_endpgm 0 on CDNA: SOPP prefix (0x17F) << 23 | opcode 1 << 16 | simm16 0.
+  constexpr uint32_t kSEndpgm0 = 0xBF810000u;
+  std::memcpy(sabotaged.data() + tramp->sectionOffset(), &kSEndpgm0, sizeof(kSEndpgm0));
+
+  // Same inputs as the dispatch test so we can compare against its golden.
+  constexpr uint32_t N = 1024;
+  std::mt19937 rng(42);
+  std::uniform_real_distribution<float> dist(-100.0f, 100.0f);
+  std::vector<float> a(N), b(N), golden(N);
+  for (uint32_t i = 0; i < N; ++i) {
+    a[i] = dist(rng);
+    b[i] = dist(rng);
+    golden[i] = a[i] + b[i];
+  }
+
+  auto sabotaged_out = dispatch_vector_add(sabotaged, gpu, cpu, a, b, N);
+  ASSERT_EQ(sabotaged_out.size(), N)
+      << "Sabotaged dispatch failed (HSA error before s_endpgm could run)";
+
+  // Trampoline-executed path: every thread that enters the trampoline hits
+  // s_endpgm and terminates before reaching the relocated v_add_f32 or its
+  // store-to-C. So C stays at the pre-dispatch zero pattern.
+  bool any_nonzero = false;
+  for (float v : sabotaged_out) {
+    if (v != 0.0f) {
+      any_nonzero = true;
+      break;
+    }
+  }
+  EXPECT_FALSE(any_nonzero)
+      << "Sabotaged dispatch produced non-zero output - did the GPU bypass the trampoline?";
+
+  // And the output must NOT match the golden (would mean the trampoline
+  // wasn't hit and the kernel ran end-to-end normally).
+  int matches_golden = 0;
+  for (uint32_t i = 0; i < N; ++i) {
+    if (std::abs(sabotaged_out[i] - golden[i]) < 1e-5f)
+      ++matches_golden;
+  }
+  EXPECT_LT(matches_golden, N) << "Sabotaged dispatch matched the golden in " << matches_golden
+                               << "/" << N << " elements - trampoline appears bypassed";
+
+  hsa_shut_down();
+}
+
+#endif // HAS_HOST_AMDGPU

--- a/emulation/rocjitsu/tests/dbi/hsa_dbi_smoke_test.cpp
+++ b/emulation/rocjitsu/tests/dbi/hsa_dbi_smoke_test.cpp
@@ -286,23 +286,25 @@ protected:
                                reinterpret_cast<const uint8_t *>(co->image_data()) +
                                    co->image_size());
 
-    // Decode .text and find the first v_add_f32-mnemonic anchor that
-    // satisfies the validator's relocatability rules. Decode-and-search so
-    // the test is stable across compiler revisions.
+    // Decode .text and find the first v_add_f32-mnemonic anchor that the
+    // trampoline machinery considers relocatable. Decode-and-search so the
+    // test is stable across compiler revisions.
     // TODO: instrument multiple instructions
     auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA2);
     ASSERT_NE(decoder, nullptr);
     auto blocks = BasicBlock::build(*co, *decoder);
+
+    ASSERT_FALSE(co->text_sections().empty());
+    const auto *text = co->text_sections().front();
+    const std::span<const uint8_t> text_bytes(reinterpret_cast<const uint8_t *>(text->data()),
+                                              text->size());
 
     bool found = false;
     for (const auto &block : blocks) {
       uint64_t cur = block->start_offset();
       for (const Instruction &inst : block->instructions()) {
         const bool is_vadd = inst.mnemonic().find("v_add_f32") != std::string_view::npos;
-        // TODO: Okay for now but Instrumentor should do this check
-        const bool relocatable = inst.size() == 4 && inst.raw_encoding() != nullptr &&
-                                 !inst.is_branch() && !inst.branch_offset_bytes().has_value();
-        if (is_vadd && relocatable) {
+        if (is_vadd && is_relocatable_anchor(inst, cur, text_bytes, ROCJITSU_CODE_ARCH_CDNA2)) {
           anchor_offset_ = cur; // Instrumentor will need offset
           anchor_mnemonic_ = std::string(inst.mnemonic());
           found = true;
@@ -339,7 +341,28 @@ class HsaDbiSmokeStatic : public HsaDbiSmokeFixture {};
 
 // Tests that need to load + dispatch on a real gfx90a GPU. Gated at CMake
 // time by HAS_CDNA2_GPU; bodies also GTEST_SKIP at runtime if no agent.
-class HsaDbiSmokeHardware : public HsaDbiSmokeFixture {};
+//
+// hsa_init / hsa_shut_down run once per suite (HSA tolerates per-test
+// init/shutdown but it isn't free). The gfx90a agent is enumerated once
+// in SetUpTestSuite and cached. Bodies pull the cached agent and skip if
+// initialization or enumeration didn't succeed.
+class HsaDbiSmokeHardware : public HsaDbiSmokeFixture {
+protected:
+  static void SetUpTestSuite() {
+    s_init_ok_ = (hsa_init() == HSA_STATUS_SUCCESS);
+    if (s_init_ok_)
+      s_gpu_ = find_gfx90a_agent();
+  }
+  static void TearDownTestSuite() {
+    if (s_init_ok_)
+      hsa_shut_down();
+    s_init_ok_ = false;
+    s_gpu_ = {};
+  }
+
+  static inline bool s_init_ok_ = false;
+  static inline hsa_agent_t s_gpu_{};
+};
 
 // Static verification: prove the patcher actually changed the kernel before
 // any HSA / dispatch tests run. No GPU or HSA runtime required. Catches
@@ -388,14 +411,11 @@ TEST_F(HsaDbiSmokeStatic, PatchedElfActuallyContainsInstrumentation) {
 // Gates on a real gfx90a agent because hsa_executable_load_agent_code_object
 // requires an agent whose ISA matches the code object.
 TEST_F(HsaDbiSmokeHardware, PatchedElfLoadsAndValidatesInHsaExecutable) {
-  if (hsa_init() != HSA_STATUS_SUCCESS)
+  if (!s_init_ok_)
     GTEST_SKIP() << "hsa_init failed (no HSA runtime at runtime)";
-
-  hsa_agent_t gpu = find_gfx90a_agent();
-  if (gpu.handle == 0) {
-    hsa_shut_down();
+  if (s_gpu_.handle == 0)
     GTEST_SKIP() << "No gfx90a agent present";
-  }
+  hsa_agent_t gpu = s_gpu_;
 
   hsa_code_object_reader_t reader{};
   ASSERT_EQ(hsa_code_object_reader_create_from_memory(patched_elf_bytes_.data(),
@@ -426,7 +446,6 @@ TEST_F(HsaDbiSmokeHardware, PatchedElfLoadsAndValidatesInHsaExecutable) {
 
   hsa_executable_destroy(executable);
   hsa_code_object_reader_destroy(reader);
-  hsa_shut_down();
 }
 
 // Dispatch both the original and patched kernels with identical
@@ -434,13 +453,11 @@ TEST_F(HsaDbiSmokeHardware, PatchedElfLoadsAndValidatesInHsaExecutable) {
 // semantically a no-op, so the patched kernel must produce the same buffer
 // as the original — anything else means the patch path corrupted execution.
 TEST_F(HsaDbiSmokeHardware, PatchedKernelDispatchMatchesOriginal) {
-  if (hsa_init() != HSA_STATUS_SUCCESS)
+  if (!s_init_ok_)
     GTEST_SKIP() << "hsa_init failed";
-  hsa_agent_t gpu = find_gfx90a_agent();
-  if (gpu.handle == 0) {
-    hsa_shut_down();
+  if (s_gpu_.handle == 0)
     GTEST_SKIP() << "No gfx90a agent present";
-  }
+  hsa_agent_t gpu = s_gpu_;
   hsa_agent_t cpu = find_cpu_agent();
   ASSERT_NE(cpu.handle, 0u) << "No CPU agent found";
 
@@ -492,8 +509,6 @@ TEST_F(HsaDbiSmokeHardware, PatchedKernelDispatchMatchesOriginal) {
   EXPECT_EQ(patched_out, orig_out)
       << "patched kernel output differs from original — the inline-nop placeholder "
          "should be semantically a no-op";
-
-  hsa_shut_down();
 }
 
 // "Sabotage" verification: overwrite the s_nop 0 placeholder in the patched
@@ -507,13 +522,11 @@ TEST_F(HsaDbiSmokeHardware, PatchedKernelDispatchMatchesOriginal) {
 // the other tests are statically verifiable (correct bytes, correct ELF
 // structure, semantically-equivalent dispatch output).
 TEST_F(HsaDbiSmokeHardware, TrampolineIsActuallyExecutedByGpu) {
-  if (hsa_init() != HSA_STATUS_SUCCESS)
+  if (!s_init_ok_)
     GTEST_SKIP() << "hsa_init failed";
-  hsa_agent_t gpu = find_gfx90a_agent();
-  if (gpu.handle == 0) {
-    hsa_shut_down();
+  if (s_gpu_.handle == 0)
     GTEST_SKIP() << "No gfx90a agent present";
-  }
+  hsa_agent_t gpu = s_gpu_;
   hsa_agent_t cpu = find_cpu_agent();
   ASSERT_NE(cpu.handle, 0u);
 
@@ -546,6 +559,8 @@ TEST_F(HsaDbiSmokeHardware, TrampolineIsActuallyExecutedByGpu) {
                                    << " - trampoline body layout changed?";
 
   // s_endpgm 0 on CDNA: SOPP prefix (0x17F) << 23 | opcode 1 << 16 | simm16 0.
+  // TODO: replace with build_s_endpgm(0, arch) once an arch-aware helper exists
+  // in instruction_builder.h (opcode differs across CDNA/RDNA generations).
   constexpr uint32_t kSEndpgm0 = 0xBF810000u;
   std::memcpy(sabotaged.data() + tramp->sectionOffset(), &kSEndpgm0, sizeof(kSEndpgm0));
 
@@ -586,8 +601,6 @@ TEST_F(HsaDbiSmokeHardware, TrampolineIsActuallyExecutedByGpu) {
   }
   EXPECT_LT(matches_golden, N) << "Sabotaged dispatch matched the golden in " << matches_golden
                                << "/" << N << " elements - trampoline appears bypassed";
-
-  hsa_shut_down();
 }
 
 #endif // HAS_HOST_AMDGPU

--- a/emulation/rocjitsu/tests/dbi/hsa_dbi_smoke_test.cpp
+++ b/emulation/rocjitsu/tests/dbi/hsa_dbi_smoke_test.cpp
@@ -16,6 +16,7 @@ RJ_DIAGNOSTIC_POP
 #include "rocjitsu/code/amdgpu_code_object.h"
 #include "rocjitsu/code/basic_block.h"
 #include "rocjitsu/code/executable.h"
+#include "rocjitsu/code/patch/instruction_builder.h"
 #include "rocjitsu/code/patch/instrumentor.h"
 #include "rocjitsu/code/rj_code.h"
 #include "rocjitsu/isa/decoder.h"
@@ -559,9 +560,7 @@ TEST_F(HsaDbiSmokeHardware, TrampolineIsActuallyExecutedByGpu) {
                                    << " - trampoline body layout changed?";
 
   // s_endpgm 0 on CDNA: SOPP prefix (0x17F) << 23 | opcode 1 << 16 | simm16 0.
-  // TODO: replace with build_s_endpgm(0, arch) once an arch-aware helper exists
-  // in instruction_builder.h (opcode differs across CDNA/RDNA generations).
-  constexpr uint32_t kSEndpgm0 = 0xBF810000u;
+  constexpr uint32_t kSEndpgm0 = build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4);
   std::memcpy(sabotaged.data() + tramp->sectionOffset(), &kSEndpgm0, sizeof(kSEndpgm0));
 
   // Same inputs as the dispatch test so we can compare against its golden.

--- a/emulation/rocjitsu/tests/dbi/hsa_dbi_smoke_test.cpp
+++ b/emulation/rocjitsu/tests/dbi/hsa_dbi_smoke_test.cpp
@@ -38,9 +38,7 @@ using namespace rocjitsu;
 
 namespace {
 
-std::string kernel_path(const char *name) {
-  return std::string(KERNEL_DIR) + "/" + name + ".o";
-}
+std::string kernel_path(const char *name) { return std::string(KERNEL_DIR) + "/" + name + ".o"; }
 
 // Find a GPU agent whose ISA name contains "gfx90a". Returns {handle=0} if
 // no such agent is present.
@@ -165,14 +163,14 @@ std::vector<float> dispatch_vector_add(std::span<const uint8_t> elf_bytes, hsa_a
 
   bool ok = (gpu_pool.handle != 0) && (kernarg_pool.handle != 0);
   if (ok)
-    ok = hsa_amd_memory_pool_allocate(gpu_pool, buf_size, 0,
-                                      reinterpret_cast<void **>(&A_dev)) == HSA_STATUS_SUCCESS;
+    ok = hsa_amd_memory_pool_allocate(gpu_pool, buf_size, 0, reinterpret_cast<void **>(&A_dev)) ==
+         HSA_STATUS_SUCCESS;
   if (ok)
-    ok = hsa_amd_memory_pool_allocate(gpu_pool, buf_size, 0,
-                                      reinterpret_cast<void **>(&B_dev)) == HSA_STATUS_SUCCESS;
+    ok = hsa_amd_memory_pool_allocate(gpu_pool, buf_size, 0, reinterpret_cast<void **>(&B_dev)) ==
+         HSA_STATUS_SUCCESS;
   if (ok)
-    ok = hsa_amd_memory_pool_allocate(gpu_pool, buf_size, 0,
-                                      reinterpret_cast<void **>(&C_dev)) == HSA_STATUS_SUCCESS;
+    ok = hsa_amd_memory_pool_allocate(gpu_pool, buf_size, 0, reinterpret_cast<void **>(&C_dev)) ==
+         HSA_STATUS_SUCCESS;
   if (ok)
     ok = hsa_amd_memory_pool_allocate(kernarg_pool, kKernArgsBytes, 0, &kernarg) ==
          HSA_STATUS_SUCCESS;
@@ -273,7 +271,6 @@ std::vector<float> dispatch_vector_add(std::span<const uint8_t> elf_bytes, hsa_a
 //   - HsaDbiSmokeHardware.* - registered only when HAS_CDNA2_GPU is set
 class HsaDbiSmokeFixture : public ::testing::Test {
 protected:
-
   // Load a vector_add_gfx90a.o device ELF and instrument a single instruction
   // with the inlined nop functionality currently available in Instrumentor
   void SetUp() override {
@@ -285,9 +282,9 @@ protected:
     ASSERT_NE(co, nullptr);
 
     // Snapshot the original device ELF so we can dispatch it too
-    original_elf_bytes_.assign(
-        reinterpret_cast<const uint8_t *>(co->image_data()),
-        reinterpret_cast<const uint8_t *>(co->image_data()) + co->image_size());
+    original_elf_bytes_.assign(reinterpret_cast<const uint8_t *>(co->image_data()),
+                               reinterpret_cast<const uint8_t *>(co->image_data()) +
+                                   co->image_size());
 
     // Decode .text and find the first v_add_f32-mnemonic anchor that
     // satisfies the validator's relocatability rules. Decode-and-search so
@@ -301,14 +298,12 @@ protected:
     for (const auto &block : blocks) {
       uint64_t cur = block->start_offset();
       for (const Instruction &inst : block->instructions()) {
-        const bool is_vadd =
-            inst.mnemonic().find("v_add_f32") != std::string_view::npos;
+        const bool is_vadd = inst.mnemonic().find("v_add_f32") != std::string_view::npos;
         // TODO: Okay for now but Instrumentor should do this check
         const bool relocatable = inst.size() == 4 && inst.raw_encoding() != nullptr &&
-                                 !inst.is_branch() &&
-                                 !inst.branch_offset_bytes().has_value();
+                                 !inst.is_branch() && !inst.branch_offset_bytes().has_value();
         if (is_vadd && relocatable) {
-          anchor_offset_ = cur;   // Instrumentor will need offset
+          anchor_offset_ = cur; // Instrumentor will need offset
           anchor_mnemonic_ = std::string(inst.mnemonic());
           found = true;
           break;
@@ -373,8 +368,8 @@ TEST_F(HsaDbiSmokeStatic, PatchedElfActuallyContainsInstrumentation) {
   std::unique_ptr<Instruction> decoded(decoder->decode(&anchor_word));
   ASSERT_NE(decoded, nullptr);
   EXPECT_NE(decoded->mnemonic().find("s_branch"), std::string_view::npos)
-      << "Anchor at offset " << anchor_offset_ << " should now decode as s_branch; got: "
-      << decoded->mnemonic();
+      << "Anchor at offset " << anchor_offset_
+      << " should now decode as s_branch; got: " << decoded->mnemonic();
   EXPECT_NE(decoded->mnemonic(), anchor_mnemonic_)
       << "Anchor mnemonic unchanged (" << anchor_mnemonic_ << ") - was the patch applied?";
 
@@ -403,15 +398,14 @@ TEST_F(HsaDbiSmokeHardware, PatchedElfLoadsAndValidatesInHsaExecutable) {
   }
 
   hsa_code_object_reader_t reader{};
-  ASSERT_EQ(hsa_code_object_reader_create_from_memory(
-                patched_elf_bytes_.data(), patched_elf_bytes_.size(), &reader),
+  ASSERT_EQ(hsa_code_object_reader_create_from_memory(patched_elf_bytes_.data(),
+                                                      patched_elf_bytes_.size(), &reader),
             HSA_STATUS_SUCCESS)
       << "Patched ELF rejected by hsa_code_object_reader_create_from_memory";
 
   hsa_executable_t executable{};
-  ASSERT_EQ(hsa_executable_create_alt(HSA_PROFILE_FULL,
-                                       HSA_DEFAULT_FLOAT_ROUNDING_MODE_DEFAULT,
-                                       nullptr, &executable),
+  ASSERT_EQ(hsa_executable_create_alt(HSA_PROFILE_FULL, HSA_DEFAULT_FLOAT_ROUNDING_MODE_DEFAULT,
+                                      nullptr, &executable),
             HSA_STATUS_SUCCESS);
 
   ASSERT_EQ(hsa_executable_load_agent_code_object(executable, gpu, reader, nullptr, nullptr),
@@ -422,8 +416,7 @@ TEST_F(HsaDbiSmokeHardware, PatchedElfLoadsAndValidatesInHsaExecutable) {
 
   uint32_t validate_result = 0;
   ASSERT_EQ(hsa_executable_validate(executable, &validate_result), HSA_STATUS_SUCCESS);
-  EXPECT_EQ(validate_result, 0u)
-      << "hsa_executable_validate reported error: " << validate_result;
+  EXPECT_EQ(validate_result, 0u) << "hsa_executable_validate reported error: " << validate_result;
 
   // Sanity: the kernel symbol is still findable post-patch.
   hsa_executable_symbol_t symbol{};
@@ -486,9 +479,9 @@ TEST_F(HsaDbiSmokeHardware, PatchedKernelDispatchMatchesOriginal) {
     if (std::abs(orig_out[i] - golden[i]) > 1e-5f)
       ++orig_mismatches;
   }
-  ASSERT_EQ(orig_mismatches, 0)
-      << "original vector_add dispatch produced " << orig_mismatches << "/" << N
-      << " mismatches against CPU golden (test fixture problem)";
+  ASSERT_EQ(orig_mismatches, 0) << "original vector_add dispatch produced " << orig_mismatches
+                                << "/" << N
+                                << " mismatches against CPU golden (test fixture problem)";
 
   // The real check: patched dispatch must produce the same buffer as the
   // original. Bit-identical because the trampoline body is just s_nop 0
@@ -543,16 +536,14 @@ TEST_F(HsaDbiSmokeHardware, TrampolineIsActuallyExecutedByGpu) {
   // s_nop 0. If this assertion fails, the orchestrator's trampoline layout
   // no longer starts with the placeholder we think it does, and the
   // sabotage premise ("we replaced the no-op with s_endpgm") would be a lie.
-  // TODO: With multiple instrumentation points, this will no longer be a good 
+  // TODO: With multiple instrumentation points, this will no longer be a good
   // assumption. Will likely need to sabotage the whole section.
   constexpr uint32_t kSNop0 = 0xBF800000u;
   uint32_t pre_overwrite = 0;
-  std::memcpy(&pre_overwrite, sabotaged.data() + tramp->sectionOffset(),
-              sizeof(pre_overwrite));
-  ASSERT_EQ(pre_overwrite, kSNop0)
-      << "Expected s_nop 0 (0x" << std::hex << kSNop0
-      << ") at start of .rj_trampolines but found 0x" << pre_overwrite
-      << " - trampoline body layout changed?";
+  std::memcpy(&pre_overwrite, sabotaged.data() + tramp->sectionOffset(), sizeof(pre_overwrite));
+  ASSERT_EQ(pre_overwrite, kSNop0) << "Expected s_nop 0 (0x" << std::hex << kSNop0
+                                   << ") at start of .rj_trampolines but found 0x" << pre_overwrite
+                                   << " - trampoline body layout changed?";
 
   // s_endpgm 0 on CDNA: SOPP prefix (0x17F) << 23 | opcode 1 << 16 | simm16 0.
   constexpr uint32_t kSEndpgm0 = 0xBF810000u;

--- a/emulation/rocjitsu/tests/dbi/hsa_dbi_smoke_test.cpp
+++ b/emulation/rocjitsu/tests/dbi/hsa_dbi_smoke_test.cpp
@@ -3,8 +3,8 @@
 
 /// @file hsa_dbi_smoke_test.cpp
 /// @brief End-to-end DBI smoke: patch a real compiled gfx90a kernel with
-///        Instrumentor::patch_relocation_only, then load and
-///        eventually dispatch the patched ELF via HSA.
+///        Instrumentor::patch, then load and eventually dispatch the patched
+///        ELF via HSA.
 
 #include "rocjitsu/base/rj_compiler.h"
 RJ_DIAGNOSTIC_PUSH
@@ -321,12 +321,12 @@ protected:
     ASSERT_TRUE(found) << "No relocatable v_add_f32 anchor in vector_add_gfx90a.o; "
                           "did the compiler change the lowering?";
 
-    // Patch via with the inlined nop (patch_relocation_only)
+    // Apply the inline-nop trampoline.
     Instrumentor instrumentor(*co, ROCJITSU_CODE_ARCH_CDNA2);
     instrumentor.add_point_by_offset(anchor_offset_);
-    auto result = instrumentor.patch_relocation_only();
+    auto result = instrumentor.patch();
     ASSERT_TRUE(result.errors.empty())
-        << "patch_relocation_only failed: "
+        << "Instrumentor::patch failed: "
         << (result.errors.empty() ? std::string{} : result.errors.front());
     patched_elf_bytes_ = std::move(result.elf_bytes);
     ASSERT_FALSE(patched_elf_bytes_.empty());
@@ -349,7 +349,7 @@ class HsaDbiSmokeHardware : public HsaDbiSmokeFixture {};
 // Static verification: prove the patcher actually changed the kernel before
 // any HSA / dispatch tests run. No GPU or HSA runtime required. Catches
 // failure modes that the byte-equality dispatch check cannot:
-//   - patcher silently produced the original bytes (e.g. patch_relocation_only
+//   - patcher silently produced the original bytes (e.g. Instrumentor::patch
 //     short-circuited without applying the patch)
 //   - patch landed at a different offset than anchor_offset_ records
 //   - .rj_trampolines section is missing from the patched ELF

--- a/emulation/rocjitsu/tests/dbi/hsa_dbi_smoke_test.cpp
+++ b/emulation/rocjitsu/tests/dbi/hsa_dbi_smoke_test.cpp
@@ -377,7 +377,7 @@ protected:
 //   - patcher silently produced the original bytes (e.g. Instrumentor::patch
 //     short-circuited without applying the patch)
 //   - patch landed at a different offset than anchor_offset_ records
-//   - .rj_trampolines section is missing from the patched ELF
+//   - the trampoline cave was not appended to .text
 TEST_F(HsaDbiSmokeStatic, PatchedElfActuallyContainsInstrumentation) {
   // (a) Patcher produced different bytes from the original.
   ASSERT_NE(patched_elf_bytes_, original_elf_bytes_)
@@ -406,15 +406,12 @@ TEST_F(HsaDbiSmokeStatic, PatchedElfActuallyContainsInstrumentation) {
         << ") - was the patch applied?";
   }
 
-  // (c) Patched ELF has a .rj_trampolines section.
-  bool found_tramp = false;
-  for (const Section *s : patched.code_sections()) {
-    if (s->name() == ".rj_trampolines") {
-      found_tramp = true;
-      break;
-    }
-  }
-  EXPECT_TRUE(found_tramp) << ".rj_trampolines section missing from patched ELF";
+  // (c) The trampoline cave was appended to .text
+  AmdGpuCodeObject original(original_elf_bytes_.data(), original_elf_bytes_.size());
+  ASSERT_TRUE(original.is_valid());
+  ASSERT_FALSE(original.text_sections().empty());
+  EXPECT_GT(text->size(), original.text_sections().front()->size())
+      << ".text must grow to hold the appended trampoline cave";
 }
 
 // Load patched ELF into an HSA executable and validate. No dispatch.
@@ -522,7 +519,7 @@ TEST_F(HsaDbiSmokeHardware, PatchedKernelDispatchMatchesOriginal) {
 }
 
 // "Sabotage" verification: overwrite the s_nop 0 placeholders in the patched
-// trampolines with s_endpgm 0 one at a time. If the GPU genuinely takes the trampoline
+// trampolines with s_endpgm one at a time. If the GPU genuinely takes the trampoline
 // path, every wave terminates before reaching the relocated instruction and
 // the output stays at the pre-dispatch zero pattern. If that trampoline is
 // somehow bypassed (e.g., the forward s_branch didn't take effect), the
@@ -540,37 +537,33 @@ TEST_F(HsaDbiSmokeHardware, TrampolineIsActuallyExecutedByGpu) {
   hsa_agent_t cpu = find_cpu_agent();
   ASSERT_NE(cpu.handle, 0u);
 
-  // Find .rj_trampolines in the patched ELF and overwrite its first 4 bytes
-  // (the s_nop 0 placeholder) with s_endpgm 0.
+  // The trampolines live inside .text at .text-relative offset
+  // patches_[i].trampoline_offset. Overwrite the first 4 bytes of each
+  // trampoline (the s_nop 0 placeholder) with s_endpgm.
   std::vector<uint8_t> sabotaged = patched_elf_bytes_;
   AmdGpuCodeObject parsed(sabotaged.data(), sabotaged.size());
   ASSERT_TRUE(parsed.is_valid());
-  const Section *tramp = nullptr;
-  for (const Section *s : parsed.code_sections()) {
-    if (s->name() == ".rj_trampolines") {
-      tramp = s;
-      break;
-    }
-  }
-  ASSERT_NE(tramp, nullptr);
-  ASSERT_GE(tramp->size(), 4u);
+  ASSERT_FALSE(parsed.text_sections().empty());
+  const Section *text = parsed.text_sections().front();
 
   ASSERT_EQ(anchor_count_, 2u);
   ASSERT_EQ(patches_.size(), 2u);
+  ASSERT_GE(text->size(), patches_[1].trampoline_offset + 4);
+  // File offset of the first trampoline's placeholder word.
+  const uint64_t tramp0_file_off = text->sectionOffset() + patches_[0].trampoline_offset;
   // Before sabotaging: verify the bytes we're about to overwrite are indeed
   // s_nop 0. If this assertion fails, the orchestrator's trampoline layout
   // no longer starts with the placeholder we think it does, and the
   // sabotage premise ("we replaced the no-op with s_endpgm") would be a lie.
   constexpr uint32_t kSNop0 = 0xBF800000u;
   uint32_t pre_overwrite = 0;
-  std::memcpy(&pre_overwrite, sabotaged.data() + tramp->sectionOffset(), sizeof(pre_overwrite));
+  std::memcpy(&pre_overwrite, sabotaged.data() + tramp0_file_off, sizeof(pre_overwrite));
   ASSERT_EQ(pre_overwrite, kSNop0) << "Expected s_nop 0 (0x" << std::hex << kSNop0
-                                   << ") at start of .rj_trampolines but found 0x" << pre_overwrite
-                                   << " - trampoline body layout changed?";
+                                   << ") at start of the trampoline cave but found 0x"
+                                   << pre_overwrite << " - trampoline body layout changed?";
 
-  // s_endpgm 0 on CDNA: SOPP prefix (0x17F) << 23 | opcode 1 << 16 | simm16 0.
   constexpr uint32_t kSEndpgm0 = build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4);
-  std::memcpy(sabotaged.data() + tramp->sectionOffset(), &kSEndpgm0, sizeof(kSEndpgm0));
+  std::memcpy(sabotaged.data() + tramp0_file_off, &kSEndpgm0, sizeof(kSEndpgm0));
 
   // Same inputs as the dispatch test so we can compare against its golden.
   constexpr uint32_t N = 1024;
@@ -611,7 +604,7 @@ TEST_F(HsaDbiSmokeHardware, TrampolineIsActuallyExecutedByGpu) {
                                  << "/" << N << " elements - trampoline appears bypassed";
 
   // Revert first trampoline in sabotaged
-  std::memcpy(sabotaged.data() + tramp->sectionOffset(), &kSNop0, sizeof(kSNop0));
+  std::memcpy(sabotaged.data() + tramp0_file_off, &kSNop0, sizeof(kSNop0));
   auto unsabotaged_out = dispatch_vector_add(sabotaged, gpu, cpu, a, b, N);
   ASSERT_EQ(unsabotaged_out.size(), N) << "HSA error before unsabotaged run could finish";
 
@@ -624,14 +617,13 @@ TEST_F(HsaDbiSmokeHardware, TrampolineIsActuallyExecutedByGpu) {
   int64_t offset_between_anchors = patches_[1].trampoline_offset - patches_[0].trampoline_offset;
   EXPECT_TRUE(offset_between_anchors)
       << "Both selected trampolines have the same trampoline offset";
-  std::memcpy(&pre_overwrite, sabotaged.data() + tramp->sectionOffset() + offset_between_anchors,
+  std::memcpy(&pre_overwrite, sabotaged.data() + tramp0_file_off + offset_between_anchors,
               sizeof(pre_overwrite));
   ASSERT_EQ(pre_overwrite, kSNop0) << "Expected s_nop 0 (0x" << std::hex << kSNop0
-                                   << ") at start of .rj_trampolines but found 0x" << pre_overwrite
-                                   << " - trampoline body layout changed?";
+                                   << ") at start of the trampoline cave but found 0x"
+                                   << pre_overwrite << " - trampoline body layout changed?";
 
-  // s_endpgm 0 on CDNA: SOPP prefix (0x17F) << 23 | opcode 1 << 16 | simm16 0.
-  std::memcpy(sabotaged.data() + tramp->sectionOffset() + offset_between_anchors, &kSEndpgm0,
+  std::memcpy(sabotaged.data() + tramp0_file_off + offset_between_anchors, &kSEndpgm0,
               sizeof(kSEndpgm0));
 
   auto sabotaged_out_2 = dispatch_vector_add(sabotaged, gpu, cpu, a, b, N);

--- a/emulation/rocjitsu/tests/dbi/hsa_dbi_smoke_test.cpp
+++ b/emulation/rocjitsu/tests/dbi/hsa_dbi_smoke_test.cpp
@@ -300,40 +300,46 @@ protected:
     const std::span<const uint8_t> text_bytes(reinterpret_cast<const uint8_t *>(text->data()),
                                               text->size());
 
-    bool found = false;
     for (const auto &block : blocks) {
       uint64_t cur = block->start_offset();
       for (const Instruction &inst : block->instructions()) {
-        const bool is_vadd = inst.mnemonic().find("v_add_f32") != std::string_view::npos;
-        if (is_vadd && is_relocatable_anchor(inst, cur, text_bytes, ROCJITSU_CODE_ARCH_CDNA2)) {
-          anchor_offset_ = cur; // Instrumentor will need offset
-          anchor_mnemonic_ = std::string(inst.mnemonic());
-          found = true;
-          break;
+        if (is_relocatable_anchor(inst, cur, text_bytes, ROCJITSU_CODE_ARCH_CDNA2)) {
+          anchor_offsets_.push_back(cur); // Instrumentor will need offset
+          anchor_mnemonics_.push_back(std::string(inst.mnemonic()));
+          ++anchor_count_;
         }
         cur += static_cast<uint64_t>(inst.size());
+        if (anchor_count_ == 2)
+          break;
       }
-      if (found)
+      if (anchor_count_ == 2)
         break;
     }
-    ASSERT_TRUE(found) << "No relocatable v_add_f32 anchor in vector_add_gfx90a.o; "
-                          "did the compiler change the lowering?";
+    ASSERT_NE(anchor_count_, 0u) << "No relocatable anchor in vector_add_gfx90a.o; "
+                                    "did the compiler change the lowering?";
 
     // Apply the inline-nop trampoline.
     Instrumentor instrumentor(*co, ROCJITSU_CODE_ARCH_CDNA2);
-    instrumentor.add_point_by_offset(anchor_offset_);
-    auto result = instrumentor.patch();
+    for (uint64_t anchor_idx = 0; anchor_idx < anchor_count_; ++anchor_idx) {
+      instrumentor.add_point_by_offset(anchor_offsets_[anchor_idx]);
+    }
+    auto result = instrumentor.patch_with_debug_summaries();
     ASSERT_TRUE(result.errors.empty())
         << "Instrumentor::patch failed: "
         << (result.errors.empty() ? std::string{} : result.errors.front());
     patched_elf_bytes_ = std::move(result.elf_bytes);
     ASSERT_FALSE(patched_elf_bytes_.empty());
+    // Keep the per-site summaries so tests can locate each trampoline by its
+    // real cave offset rather than guessing the in-section stride.
+    patches_ = std::move(result.patches);
   }
 
   std::vector<uint8_t> original_elf_bytes_;
   std::vector<uint8_t> patched_elf_bytes_;
-  uint64_t anchor_offset_ = 0;
-  std::string anchor_mnemonic_;
+  std::vector<uint64_t> anchor_offsets_;
+  std::vector<std::string> anchor_mnemonics_;
+  std::vector<InstrumentationPatch> patches_;
+  uint64_t anchor_count_ = 0;
 };
 
 // Tests that need only HSA libs (parsing + decoding the patched ELF). Run
@@ -377,25 +383,28 @@ TEST_F(HsaDbiSmokeStatic, PatchedElfActuallyContainsInstrumentation) {
   ASSERT_NE(patched_elf_bytes_, original_elf_bytes_)
       << "Patched ELF is byte-identical to original - patcher silently no-oped?";
 
-  // (b) The patched .text at anchor_offset_ now decodes as s_branch, not the
-  //     original v_add_f32 we recorded as anchor_mnemonic_.
+  // (b) The patched .text at anchor_offsets_[idx] now decodes as s_branch, not the
+  //     original instructions we recorded as anchor_mnemonics_[idx].
   AmdGpuCodeObject patched(patched_elf_bytes_.data(), patched_elf_bytes_.size());
   ASSERT_TRUE(patched.is_valid());
   ASSERT_FALSE(patched.text_sections().empty());
   const Section *text = patched.text_sections().front();
-  ASSERT_GT(text->size(), anchor_offset_ + 4);
+  ASSERT_GT(text->size(), anchor_offsets_[0] + 4);
 
   auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA2);
   ASSERT_NE(decoder, nullptr);
-  rj_code_binary_inst_t anchor_word = 0;
-  std::memcpy(&anchor_word, text->data() + anchor_offset_, sizeof(anchor_word));
-  std::unique_ptr<Instruction> decoded(decoder->decode(&anchor_word));
-  ASSERT_NE(decoded, nullptr);
-  EXPECT_NE(decoded->mnemonic().find("s_branch"), std::string_view::npos)
-      << "Anchor at offset " << anchor_offset_
-      << " should now decode as s_branch; got: " << decoded->mnemonic();
-  EXPECT_NE(decoded->mnemonic(), anchor_mnemonic_)
-      << "Anchor mnemonic unchanged (" << anchor_mnemonic_ << ") - was the patch applied?";
+  for (uint64_t anchor_idx = 0; anchor_idx < anchor_count_; ++anchor_idx) {
+    rj_code_binary_inst_t anchor_word = 0;
+    std::memcpy(&anchor_word, text->data() + anchor_offsets_[anchor_idx], sizeof(anchor_word));
+    std::unique_ptr<Instruction> decoded(decoder->decode(&anchor_word));
+    ASSERT_NE(decoded, nullptr);
+    EXPECT_NE(decoded->mnemonic().find("s_branch"), std::string_view::npos)
+        << "Anchor at offset " << anchor_offsets_[anchor_idx]
+        << " should now decode as s_branch; got: " << decoded->mnemonic();
+    EXPECT_NE(decoded->mnemonic(), anchor_mnemonics_[anchor_idx])
+        << "Anchor mnemonic unchanged (" << anchor_mnemonics_[anchor_idx]
+        << ") - was the patch applied?";
+  }
 
   // (c) Patched ELF has a .rj_trampolines section.
   bool found_tramp = false;
@@ -503,7 +512,7 @@ TEST_F(HsaDbiSmokeHardware, PatchedKernelDispatchMatchesOriginal) {
 
   // The real check: patched dispatch must produce the same buffer as the
   // original. Bit-identical because the trampoline body is just s_nop 0
-  // around the relocated v_add_f32.
+  // around the relocated instruction.
   auto patched_out = dispatch_vector_add(patched_elf_bytes_, gpu, cpu, a, b, N);
   ASSERT_EQ(patched_out.size(), N) << "patched dispatch failed (empty result)";
   assert_kernel_wrote_output(patched_out, "patched");
@@ -512,10 +521,10 @@ TEST_F(HsaDbiSmokeHardware, PatchedKernelDispatchMatchesOriginal) {
          "should be semantically a no-op";
 }
 
-// "Sabotage" verification: overwrite the s_nop 0 placeholder in the patched
-// trampoline with s_endpgm 0. If the GPU genuinely takes the trampoline
-// path, every wave terminates before reaching the relocated v_add_f32 and
-// the output stays at the pre-dispatch zero pattern. If the trampoline is
+// "Sabotage" verification: overwrite the s_nop 0 placeholders in the patched
+// trampolines with s_endpgm 0 one at a time. If the GPU genuinely takes the trampoline
+// path, every wave terminates before reaching the relocated instruction and
+// the output stays at the pre-dispatch zero pattern. If that trampoline is
 // somehow bypassed (e.g., the forward s_branch didn't take effect), the
 // kernel would still produce the golden output.
 //
@@ -546,12 +555,12 @@ TEST_F(HsaDbiSmokeHardware, TrampolineIsActuallyExecutedByGpu) {
   ASSERT_NE(tramp, nullptr);
   ASSERT_GE(tramp->size(), 4u);
 
+  ASSERT_EQ(anchor_count_, 2u);
+  ASSERT_EQ(patches_.size(), 2u);
   // Before sabotaging: verify the bytes we're about to overwrite are indeed
   // s_nop 0. If this assertion fails, the orchestrator's trampoline layout
   // no longer starts with the placeholder we think it does, and the
   // sabotage premise ("we replaced the no-op with s_endpgm") would be a lie.
-  // TODO: With multiple instrumentation points, this will no longer be a good
-  // assumption. Will likely need to sabotage the whole section.
   constexpr uint32_t kSNop0 = 0xBF800000u;
   uint32_t pre_overwrite = 0;
   std::memcpy(&pre_overwrite, sabotaged.data() + tramp->sectionOffset(), sizeof(pre_overwrite));
@@ -574,32 +583,83 @@ TEST_F(HsaDbiSmokeHardware, TrampolineIsActuallyExecutedByGpu) {
     golden[i] = a[i] + b[i];
   }
 
-  auto sabotaged_out = dispatch_vector_add(sabotaged, gpu, cpu, a, b, N);
-  ASSERT_EQ(sabotaged_out.size(), N)
+  auto sabotaged_out_1 = dispatch_vector_add(sabotaged, gpu, cpu, a, b, N);
+  ASSERT_EQ(sabotaged_out_1.size(), N)
+      << "Sabotaged dispatch failed (HSA error before s_endpgm could run)";
+
+  // Trampoline-executed path: every thread that enters the trampoline hits
+  // s_endpgm and terminates before reaching the relocated instruction or its
+  // store-to-C. So C stays at the pre-dispatch zero pattern.
+  bool any_nonzero_1 = false;
+  for (float v : sabotaged_out_1) {
+    if (v != 0.0f) {
+      any_nonzero_1 = true;
+      break;
+    }
+  }
+  EXPECT_FALSE(any_nonzero_1)
+      << "Sabotaged dispatch produced non-zero output - did the GPU bypass the trampoline?";
+
+  // And the output must NOT match the golden (would mean the trampoline
+  // wasn't hit and the kernel ran end-to-end normally).
+  int matches_golden_1 = 0;
+  for (uint32_t i = 0; i < N; ++i) {
+    if (std::abs(sabotaged_out_1[i] - golden[i]) < 1e-5f)
+      ++matches_golden_1;
+  }
+  EXPECT_LT(matches_golden_1, N) << "Sabotaged dispatch matched the golden in " << matches_golden_1
+                                 << "/" << N << " elements - trampoline appears bypassed";
+
+  // Revert first trampoline in sabotaged
+  std::memcpy(sabotaged.data() + tramp->sectionOffset(), &kSNop0, sizeof(kSNop0));
+  auto unsabotaged_out = dispatch_vector_add(sabotaged, gpu, cpu, a, b, N);
+  ASSERT_EQ(unsabotaged_out.size(), N) << "HSA error before unsabotaged run could finish";
+
+  for (uint32_t i = 0; i < N; ++i) {
+    ASSERT_LT(std::abs(unsabotaged_out[i] - golden[i]), 1e-5f)
+        << "Unsabotaged code differs from golden";
+  }
+
+  // Perform same change and test for second trampoline
+  int64_t offset_between_anchors = patches_[1].trampoline_offset - patches_[0].trampoline_offset;
+  EXPECT_TRUE(offset_between_anchors)
+      << "Both selected trampolines have the same trampoline offset";
+  std::memcpy(&pre_overwrite, sabotaged.data() + tramp->sectionOffset() + offset_between_anchors,
+              sizeof(pre_overwrite));
+  ASSERT_EQ(pre_overwrite, kSNop0) << "Expected s_nop 0 (0x" << std::hex << kSNop0
+                                   << ") at start of .rj_trampolines but found 0x" << pre_overwrite
+                                   << " - trampoline body layout changed?";
+
+  // s_endpgm 0 on CDNA: SOPP prefix (0x17F) << 23 | opcode 1 << 16 | simm16 0.
+  std::memcpy(sabotaged.data() + tramp->sectionOffset() + offset_between_anchors, &kSEndpgm0,
+              sizeof(kSEndpgm0));
+
+  auto sabotaged_out_2 = dispatch_vector_add(sabotaged, gpu, cpu, a, b, N);
+  ASSERT_EQ(sabotaged_out_2.size(), N)
       << "Sabotaged dispatch failed (HSA error before s_endpgm could run)";
 
   // Trampoline-executed path: every thread that enters the trampoline hits
   // s_endpgm and terminates before reaching the relocated v_add_f32 or its
   // store-to-C. So C stays at the pre-dispatch zero pattern.
-  bool any_nonzero = false;
-  for (float v : sabotaged_out) {
+  bool any_nonzero_2 = false;
+  for (float v : sabotaged_out_2) {
     if (v != 0.0f) {
-      any_nonzero = true;
+      any_nonzero_2 = true;
       break;
     }
   }
-  EXPECT_FALSE(any_nonzero)
+  EXPECT_FALSE(any_nonzero_2)
       << "Sabotaged dispatch produced non-zero output - did the GPU bypass the trampoline?";
 
   // And the output must NOT match the golden (would mean the trampoline
   // wasn't hit and the kernel ran end-to-end normally).
-  int matches_golden = 0;
+  int matches_golden_2 = 0;
   for (uint32_t i = 0; i < N; ++i) {
-    if (std::abs(sabotaged_out[i] - golden[i]) < 1e-5f)
-      ++matches_golden;
+    if (std::abs(sabotaged_out_2[i] - golden[i]) < 1e-5f)
+      ++matches_golden_2;
   }
-  EXPECT_LT(matches_golden, N) << "Sabotaged dispatch matched the golden in " << matches_golden
-                               << "/" << N << " elements - trampoline appears bypassed";
+  EXPECT_LT(matches_golden_2, N) << "Sabotaged dispatch matched the golden in " << matches_golden_2
+                                 << "/" << N << " elements - trampoline appears bypassed";
 }
 
 #endif // HAS_HOST_AMDGPU

--- a/emulation/rocjitsu/tests/dbi/hsa_dbi_smoke_test.cpp
+++ b/emulation/rocjitsu/tests/dbi/hsa_dbi_smoke_test.cpp
@@ -555,14 +555,14 @@ TEST_F(HsaDbiSmokeHardware, TrampolineIsActuallyExecutedByGpu) {
   // s_nop 0. If this assertion fails, the orchestrator's trampoline layout
   // no longer starts with the placeholder we think it does, and the
   // sabotage premise ("we replaced the no-op with s_endpgm") would be a lie.
-  constexpr uint32_t kSNop0 = 0xBF800000u;
+  constexpr uint32_t kSNop0 = build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA2);
   uint32_t pre_overwrite = 0;
   std::memcpy(&pre_overwrite, sabotaged.data() + tramp0_file_off, sizeof(pre_overwrite));
   ASSERT_EQ(pre_overwrite, kSNop0) << "Expected s_nop 0 (0x" << std::hex << kSNop0
                                    << ") at start of the trampoline cave but found 0x"
                                    << pre_overwrite << " - trampoline body layout changed?";
 
-  constexpr uint32_t kSEndpgm0 = build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4);
+  constexpr uint32_t kSEndpgm0 = build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA2);
   std::memcpy(sabotaged.data() + tramp0_file_off, &kSEndpgm0, sizeof(kSEndpgm0));
 
   // Same inputs as the dispatch test so we can compare against its golden.
@@ -615,7 +615,7 @@ TEST_F(HsaDbiSmokeHardware, TrampolineIsActuallyExecutedByGpu) {
 
   // Perform same change and test for second trampoline
   int64_t offset_between_anchors = patches_[1].trampoline_offset - patches_[0].trampoline_offset;
-  EXPECT_TRUE(offset_between_anchors)
+  EXPECT_NE(offset_between_anchors, 0)
       << "Both selected trampolines have the same trampoline offset";
   std::memcpy(&pre_overwrite, sabotaged.data() + tramp0_file_off + offset_between_anchors,
               sizeof(pre_overwrite));

--- a/emulation/rocjitsu/tests/kernels/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/kernels/CMakeLists.txt
@@ -89,6 +89,13 @@ rj_add_triton_asm_fixture(triton_cdna3_matmul_buffer_async_1024 gfx942)
 rj_add_triton_asm_fixture(triton_cdna3_flash_attention_no_async_1024 gfx942)
 rj_add_triton_asm_fixture(triton_cdna3_flash_attention_buffer_async_1024 gfx942)
 
+# Second build of vector_add for gfx90a, used by the DBI hardware-gated
+# smoke test (tests/dbi/hsa_dbi_smoke_test.cpp). Outputs vector_add_gfx90a.o
+# so it coexists with the gfx950 build above. (A single multi-target fat
+# binary would be cleaner but the Executable loader has a pre-existing
+# single-bundle assumption — see executable.cpp::load_hip_fatbin.)
+rj_add_device_kernel(vector_add gfx90a OUTPUT_NAME vector_add_gfx90a)
+
 # Umbrella target for all device kernels.
 add_custom_target(
     device_kernels
@@ -98,6 +105,7 @@ add_custom_target(
         kernel_matmul_mfma_16x16
         kernel_matmul_tiled
         kernel_vector_add
+        kernel_vector_add_gfx90a
         kernel_dynamic_copy_loop
         kernel_triton_cdna4_matmul_dynamic_32x32x64
         kernel_triton_cdna4_matmul_buffer_async_1024

--- a/emulation/rocjitsu/tests/matmul_test.cpp
+++ b/emulation/rocjitsu/tests/matmul_test.cpp
@@ -5,6 +5,7 @@
 
 #include "embedded_schema.h"
 #include "rocjitsu/code/executable.h"
+#include "rocjitsu/code/patch/instruction_builder.h"
 #include "rocjitsu/config/config_loader.h"
 #include "rocjitsu/isa/decoder.h"
 #include "rocjitsu/isa/instruction.h"
@@ -383,7 +384,7 @@ TEST(MatmulStressTest, MfmaAllCUs_MultiThreaded) {
 
 TEST(MatmulStressTest, Cdna4TopologyDispatchAndHalt) {
   constexpr uint32_t total_wgs = TOTAL_CUS;
-  constexpr uint32_t SOPP_S_ENDPGM = 0xBF810000;
+  constexpr uint32_t SOPP_S_ENDPGM = build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4);
 
   auto loaded = config::load_config(CONFIG_PATH, rocjitsu::kEmbeddedSchema);
   auto *soc = loaded.soc();
@@ -434,7 +435,7 @@ TEST(MatmulStressTest, Cdna4TopologyDispatchAndHalt) {
 // Multi-threaded topology-only: 1 thread per XCD, dispatch s_endpgm to all CUs.
 TEST(MatmulStressTest, Cdna4TopologyDispatchAndHalt_MultiThreaded) {
   constexpr uint32_t total_wgs = TOTAL_CUS;
-  constexpr uint32_t SOPP_S_ENDPGM = 0xBF810000;
+  constexpr uint32_t SOPP_S_ENDPGM = build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4);
 
   auto loaded = config::load_config(CONFIG_PATH, rocjitsu::kEmbeddedSchema);
   auto *soc = loaded.soc();

--- a/emulation/rocjitsu/tests/patch/error_report_test.cpp
+++ b/emulation/rocjitsu/tests/patch/error_report_test.cpp
@@ -1,0 +1,35 @@
+// Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/code/patch/error_report.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+namespace rocjitsu {
+namespace {
+
+TEST(ErrorReport, NullPointerIsNoOp) {
+  // Patch-layer convention: callers pass nullptr when they don't care about
+  // the diagnostic. report() must tolerate that without crashing.
+  report(nullptr, "ignored");
+}
+
+TEST(ErrorReport, AssignsMessageWhenPointerIsNonNull) {
+  std::string err = "previous";
+  report(&err, "hello");
+  EXPECT_EQ(err, "hello");
+}
+
+TEST(ErrorReport, OverwritesPriorContents) {
+  // Successive reports replace, not append. Pins the assignment semantics so
+  // a future refactor doesn't silently turn this into a += or a no-op-if-set.
+  std::string err;
+  report(&err, "first");
+  report(&err, "second");
+  EXPECT_EQ(err, "second");
+}
+
+} // namespace
+} // namespace rocjitsu

--- a/emulation/rocjitsu/tests/patch/instruction_builder_test.cpp
+++ b/emulation/rocjitsu/tests/patch/instruction_builder_test.cpp
@@ -87,6 +87,15 @@ TEST(ComputeSoppBranchSimm16, NonDwordAlignedBranchPcFails) {
   EXPECT_FALSE(compute_sopp_branch_simm16(0x1002, 0x1100).has_value());
 }
 
+// C++20 specifies truncated-toward-zero integer division/modulo, so
+// `(-258) % 4 == -2 != 0`. This pins that semantic: a negative delta that
+// is not a multiple of 4 must be rejected (not silently rounded).
+TEST(ComputeSoppBranchSimm16, NegativeUnalignedDeltaFails) {
+  // branch_pc = 0x1100, target = 0x1002 →
+  //   delta = 0x1002 - 0x1100 - 4 = -0x102 = -258 bytes (not /4).
+  EXPECT_FALSE(compute_sopp_branch_simm16(0x1100, 0x1002).has_value());
+}
+
 TEST(ComputeSoppBranchSimm16, BranchPcNearInt64MaxFails) {
   constexpr uint64_t kHugePc = static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
   EXPECT_FALSE(compute_sopp_branch_simm16(kHugePc, kHugePc).has_value());

--- a/emulation/rocjitsu/tests/patch/instruction_builder_test.cpp
+++ b/emulation/rocjitsu/tests/patch/instruction_builder_test.cpp
@@ -64,8 +64,7 @@ TEST(ComputeSoppBranchSimm16, MaxNegativeSimm16) {
 
 TEST(ComputeSoppBranchSimm16, PositiveOverflowFails) {
   constexpr uint64_t pc = 0x10000;
-  constexpr int64_t kJustOver =
-      (static_cast<int64_t>(std::numeric_limits<int16_t>::max()) + 1) * 4;
+  constexpr int64_t kJustOver = (static_cast<int64_t>(std::numeric_limits<int16_t>::max()) + 1) * 4;
   EXPECT_FALSE(compute_sopp_branch_simm16(pc, pc + 4 + kJustOver).has_value());
 }
 
@@ -73,10 +72,9 @@ TEST(ComputeSoppBranchSimm16, NegativeOverflowFails) {
   constexpr uint64_t pc = 0x10'0000;
   constexpr int64_t kJustUnder =
       (static_cast<int64_t>(std::numeric_limits<int16_t>::min()) - 1) * 4;
-  EXPECT_FALSE(
-      compute_sopp_branch_simm16(
-          pc, static_cast<uint64_t>(static_cast<int64_t>(pc) + 4 + kJustUnder))
-          .has_value());
+  EXPECT_FALSE(compute_sopp_branch_simm16(
+                   pc, static_cast<uint64_t>(static_cast<int64_t>(pc) + 4 + kJustUnder))
+                   .has_value());
 }
 
 TEST(ComputeSoppBranchSimm16, NonDwordAlignedTargetFails) {
@@ -102,8 +100,7 @@ TEST(ComputeSoppBranchSimm16, BranchPcNearInt64MaxFails) {
 }
 
 TEST(ComputeSoppBranchSimm16, TargetNearUint64MaxFails) {
-  constexpr uint64_t kHugeTarget =
-      static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) + 1;
+  constexpr uint64_t kHugeTarget = static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) + 1;
   EXPECT_FALSE(compute_sopp_branch_simm16(0x1000, kHugeTarget).has_value());
 }
 

--- a/emulation/rocjitsu/tests/patch/instruction_builder_test.cpp
+++ b/emulation/rocjitsu/tests/patch/instruction_builder_test.cpp
@@ -104,5 +104,14 @@ TEST(ComputeSoppBranchSimm16, TargetNearUint64MaxFails) {
   EXPECT_FALSE(compute_sopp_branch_simm16(0x1000, kHugeTarget).has_value());
 }
 
+TEST(InstructionBuilder, BuildSEndpgm) {
+  // calculate with SOPP prefix (0x17F) << 23 | opcode 0x1 << 16
+  constexpr uint32_t SOPP_S_ENDPGM_CDNA4 = 0xBF810000u;
+  EXPECT_EQ(build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4), SOPP_S_ENDPGM_CDNA4);
+  // calculate with SOPP prefix (0x17F) << 23 | opcode 0x30 << 16
+  constexpr uint32_t SOPP_S_ENDPGM_RDNA4 = 0xBFB00000u;
+  EXPECT_EQ(build_s_endpgm(ROCJITSU_CODE_ARCH_RDNA4), SOPP_S_ENDPGM_RDNA4);
+}
+
 } // namespace
 } // namespace rocjitsu

--- a/emulation/rocjitsu/tests/patch/instruction_builder_test.cpp
+++ b/emulation/rocjitsu/tests/patch/instruction_builder_test.cpp
@@ -1,0 +1,102 @@
+// Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/code/patch/instruction_builder.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <limits>
+#include <optional>
+
+namespace rocjitsu {
+namespace {
+
+// SOPP semantics under test:
+//   target = branch_pc + 4 + simm16 * 4
+// Inverted:
+//   simm16 = (target - (branch_pc + 4)) / 4
+//
+// The helper must return nullopt when the delta is not dword-aligned, when it
+// would not fit in a signed 16-bit dword field, or when branch_pc/target are so
+// large that the signed int64 intermediate (branch_pc + 4) would overflow.
+
+TEST(ComputeSoppBranchSimm16, SelfBranchIsMinusOne) {
+  auto simm = compute_sopp_branch_simm16(/*branch_pc=*/0x100, /*target=*/0x100);
+  ASSERT_TRUE(simm.has_value());
+  EXPECT_EQ(*simm, -1);
+}
+
+TEST(ComputeSoppBranchSimm16, FallThroughIsZero) {
+  auto simm = compute_sopp_branch_simm16(/*branch_pc=*/0x100, /*target=*/0x104);
+  ASSERT_TRUE(simm.has_value());
+  EXPECT_EQ(*simm, 0);
+}
+
+TEST(ComputeSoppBranchSimm16, SmallForwardBranch) {
+  auto simm = compute_sopp_branch_simm16(0x1000, 0x1100);
+  ASSERT_TRUE(simm.has_value());
+  EXPECT_EQ(*simm, 63);
+}
+
+TEST(ComputeSoppBranchSimm16, SmallBackwardBranch) {
+  auto simm = compute_sopp_branch_simm16(0x1100, 0x1000);
+  ASSERT_TRUE(simm.has_value());
+  EXPECT_EQ(*simm, -65);
+}
+
+TEST(ComputeSoppBranchSimm16, MaxPositiveSimm16) {
+  constexpr uint64_t pc = 0x10000;
+  constexpr int64_t kMaxDelta = static_cast<int64_t>(std::numeric_limits<int16_t>::max()) * 4;
+  auto simm = compute_sopp_branch_simm16(pc, pc + 4 + kMaxDelta);
+  ASSERT_TRUE(simm.has_value());
+  EXPECT_EQ(*simm, std::numeric_limits<int16_t>::max());
+}
+
+TEST(ComputeSoppBranchSimm16, MaxNegativeSimm16) {
+  constexpr uint64_t pc = 0x10'0000;
+  constexpr int64_t kMinDelta = static_cast<int64_t>(std::numeric_limits<int16_t>::min()) * 4;
+  auto simm = compute_sopp_branch_simm16(
+      pc, static_cast<uint64_t>(static_cast<int64_t>(pc) + 4 + kMinDelta));
+  ASSERT_TRUE(simm.has_value());
+  EXPECT_EQ(*simm, std::numeric_limits<int16_t>::min());
+}
+
+TEST(ComputeSoppBranchSimm16, PositiveOverflowFails) {
+  constexpr uint64_t pc = 0x10000;
+  constexpr int64_t kJustOver =
+      (static_cast<int64_t>(std::numeric_limits<int16_t>::max()) + 1) * 4;
+  EXPECT_FALSE(compute_sopp_branch_simm16(pc, pc + 4 + kJustOver).has_value());
+}
+
+TEST(ComputeSoppBranchSimm16, NegativeOverflowFails) {
+  constexpr uint64_t pc = 0x10'0000;
+  constexpr int64_t kJustUnder =
+      (static_cast<int64_t>(std::numeric_limits<int16_t>::min()) - 1) * 4;
+  EXPECT_FALSE(
+      compute_sopp_branch_simm16(
+          pc, static_cast<uint64_t>(static_cast<int64_t>(pc) + 4 + kJustUnder))
+          .has_value());
+}
+
+TEST(ComputeSoppBranchSimm16, NonDwordAlignedTargetFails) {
+  EXPECT_FALSE(compute_sopp_branch_simm16(0x1000, 0x1002).has_value());
+}
+
+TEST(ComputeSoppBranchSimm16, NonDwordAlignedBranchPcFails) {
+  EXPECT_FALSE(compute_sopp_branch_simm16(0x1002, 0x1100).has_value());
+}
+
+TEST(ComputeSoppBranchSimm16, BranchPcNearInt64MaxFails) {
+  constexpr uint64_t kHugePc = static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
+  EXPECT_FALSE(compute_sopp_branch_simm16(kHugePc, kHugePc).has_value());
+}
+
+TEST(ComputeSoppBranchSimm16, TargetNearUint64MaxFails) {
+  constexpr uint64_t kHugeTarget =
+      static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) + 1;
+  EXPECT_FALSE(compute_sopp_branch_simm16(0x1000, kHugeTarget).has_value());
+}
+
+} // namespace
+} // namespace rocjitsu

--- a/emulation/rocjitsu/tests/patch/instruction_builder_test.cpp
+++ b/emulation/rocjitsu/tests/patch/instruction_builder_test.cpp
@@ -85,6 +85,14 @@ TEST(ComputeSoppBranchSimm16, NonDwordAlignedBranchPcFails) {
   EXPECT_FALSE(compute_sopp_branch_simm16(0x1002, 0x1100).has_value());
 }
 
+// branch_pc and target are misaligned by the same amount, so the delta is
+// dword-aligned (0 and 4 here). A delta-only check would accept these; the
+// branch_pc/target alignment checks must still reject them.
+TEST(ComputeSoppBranchSimm16, EquallyMisalignedPcsFailEvenWhenDeltaAligned) {
+  EXPECT_FALSE(compute_sopp_branch_simm16(0x1002, 0x1006).has_value()); // delta 0
+  EXPECT_FALSE(compute_sopp_branch_simm16(0x1002, 0x100a).has_value()); // delta 4
+}
+
 // C++20 specifies truncated-toward-zero integer division/modulo, so
 // `(-258) % 4 == -2 != 0`. This pins that semantic: a negative delta that
 // is not a multiple of 4 must be rejected (not silently rounded).

--- a/emulation/rocjitsu/tests/patch/instrumentor_test.cpp
+++ b/emulation/rocjitsu/tests/patch/instrumentor_test.cpp
@@ -47,9 +47,7 @@ private:
   std::optional<int64_t> branch_delta_;
 };
 
-std::vector<uint8_t> dummy_text(size_t size = 16) {
-  return std::vector<uint8_t>(size, 0xCC);
-}
+std::vector<uint8_t> dummy_text(size_t size = 16) { return std::vector<uint8_t>(size, 0xCC); }
 
 //==============================================================================
 // Section 1: validate_anchor (synthetic)
@@ -62,7 +60,8 @@ TEST(Validator, AcceptsFourByteRelocatable) {
   InstrumentationPoint pt;
 
   std::string err;
-  auto site = validate_anchor(anchor, /*anchor_offset=*/0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err);
+  auto site =
+      validate_anchor(anchor, /*anchor_offset=*/0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err);
   ASSERT_TRUE(site.has_value()) << err;
   EXPECT_EQ(site->original_size, 4u);
   EXPECT_EQ(site->original_bytes.size(), 4u);
@@ -151,7 +150,8 @@ TEST(Validator, RejectsUnalignedOffset) {
   InstrumentationPoint pt;
   std::string err;
   EXPECT_FALSE(
-      validate_anchor(anchor, /*anchor_offset=*/2, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value());
+      validate_anchor(anchor, /*anchor_offset=*/2, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err)
+          .has_value());
   EXPECT_FALSE(err.empty());
 }
 
@@ -162,7 +162,8 @@ TEST(Validator, RejectsOutOfBoundsOffset) {
   InstrumentationPoint pt;
   std::string err;
   EXPECT_FALSE(
-      validate_anchor(anchor, /*anchor_offset=*/4, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value());
+      validate_anchor(anchor, /*anchor_offset=*/4, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err)
+          .has_value());
   EXPECT_FALSE(err.empty());
 }
 
@@ -227,8 +228,7 @@ TEST(Validator, RejectsDenylistedMnemonic) {
   InstrumentationPoint pt;
 
   // PC-relative semantics that may not surface in flags / branch_offset_bytes.
-  for (const char *m : {"s_getpc_b64", "s_call_b64", "s_setpc_b64", "s_swappc_b64",
-                        "s_rfe_b64"}) {
+  for (const char *m : {"s_getpc_b64", "s_call_b64", "s_setpc_b64", "s_swappc_b64", "s_rfe_b64"}) {
     TestInstruction anchor(m, 4, /*flags=*/0, std::nullopt, &kRaw);
     std::string err;
     EXPECT_FALSE(validate_anchor(anchor, 0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value())
@@ -269,8 +269,7 @@ TEST(InlineNopGuardrail, RejectsNonCanonicalBody) {
     auto plan = valid_plan();
     plan.before_items.push_back(InlineAsmItem{{build_s_nop(0, kArch)}});
     std::string err;
-    EXPECT_FALSE(validate_inline_nop_plan(plan, &err))
-        << "extra before-item must be rejected";
+    EXPECT_FALSE(validate_inline_nop_plan(plan, &err)) << "extra before-item must be rejected";
     EXPECT_FALSE(err.empty());
   }
 
@@ -289,8 +288,7 @@ TEST(InlineNopGuardrail, RejectsNonCanonicalBody) {
     auto plan = valid_plan();
     plan.after_items.push_back(InlineAsmItem{{build_s_nop(0, kArch)}});
     std::string err;
-    EXPECT_FALSE(validate_inline_nop_plan(plan, &err))
-        << "non-empty after_items must be rejected";
+    EXPECT_FALSE(validate_inline_nop_plan(plan, &err)) << "non-empty after_items must be rejected";
     EXPECT_FALSE(err.empty());
   }
 
@@ -299,8 +297,7 @@ TEST(InlineNopGuardrail, RejectsNonCanonicalBody) {
     auto plan = valid_plan();
     plan.emit_original = false;
     std::string err;
-    EXPECT_FALSE(validate_inline_nop_plan(plan, &err))
-        << "emit_original = false must be rejected";
+    EXPECT_FALSE(validate_inline_nop_plan(plan, &err)) << "emit_original = false must be rejected";
     EXPECT_FALSE(err.empty());
   }
 }
@@ -853,14 +850,15 @@ protected:
         << (result_.errors.empty() ? std::string{} : result_.errors.front());
     ASSERT_FALSE(result_.elf_bytes.empty());
 
-    patched_ = std::make_unique<AmdGpuCodeObject>(result_.elf_bytes.data(),
-                                                  result_.elf_bytes.size());
+    patched_ =
+        std::make_unique<AmdGpuCodeObject>(result_.elf_bytes.data(), result_.elf_bytes.size());
     ASSERT_TRUE(patched_->is_valid());
   }
 
   const Section *find_section(std::string_view name) const {
     for (const Section *s : patched_->code_sections())
-      if (s->name() == name) return s;
+      if (s->name() == name)
+        return s;
     return nullptr;
   }
 
@@ -877,8 +875,7 @@ TEST_F(InstrumentorPatchElfShape, RjTrampolinesSectionExists) {
 TEST_F(InstrumentorPatchElfShape, RjTrampolinesIsExecutable) {
   const Section *tramp = find_section(".rj_trampolines");
   ASSERT_NE(tramp, nullptr);
-  EXPECT_NE(tramp->flags() & SHF_EXECINSTR, 0u)
-      << ".rj_trampolines must have SHF_EXECINSTR";
+  EXPECT_NE(tramp->flags() & SHF_EXECINSTR, 0u) << ".rj_trampolines must have SHF_EXECINSTR";
 }
 
 TEST_F(InstrumentorPatchElfShape, RjTrampolinesPlacedImmediatelyAfterText) {
@@ -913,8 +910,10 @@ TEST_F(InstrumentorPatchElfShape, CodeSectionsIncludesTextAndTrampoline) {
   bool saw_text = false;
   bool saw_tramp = false;
   for (const Section *s : patched_->code_sections()) {
-    if (s->name() == ".text") saw_text = true;
-    if (s->name() == ".rj_trampolines") saw_tramp = true;
+    if (s->name() == ".text")
+      saw_text = true;
+    if (s->name() == ".rj_trampolines")
+      saw_tramp = true;
   }
   EXPECT_TRUE(saw_text) << "code_sections() must include .text";
   EXPECT_TRUE(saw_tramp) << "code_sections() must include .rj_trampolines";
@@ -943,8 +942,8 @@ protected:
         << (result_.errors.empty() ? std::string{} : result_.errors.front());
     ASSERT_FALSE(result_.elf_bytes.empty());
 
-    patched_ = std::make_unique<AmdGpuCodeObject>(result_.elf_bytes.data(),
-                                                  result_.elf_bytes.size());
+    patched_ =
+        std::make_unique<AmdGpuCodeObject>(result_.elf_bytes.data(), result_.elf_bytes.size());
     ASSERT_TRUE(patched_->is_valid());
 
     decoder_ = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
@@ -953,7 +952,8 @@ protected:
 
   const Section *find_section(std::string_view name) const {
     for (const Section *s : patched_->code_sections())
-      if (s->name() == name) return s;
+      if (s->name() == name)
+        return s;
     return nullptr;
   }
 
@@ -981,8 +981,7 @@ TEST_F(InstrumentorPatchDecoded, PatchedAnchorDecodesAsForwardSBranch) {
   ASSERT_TRUE(inst->branch_offset_bytes().has_value())
       << "patched anchor must report a PC-relative branch offset";
   EXPECT_GE(*inst->branch_offset_bytes(), 0)
-      << "forward branch offset must be non-negative; got "
-      << *inst->branch_offset_bytes();
+      << "forward branch offset must be non-negative; got " << *inst->branch_offset_bytes();
 }
 
 TEST_F(InstrumentorPatchDecoded, UnpatchedTextInstructionIsUnchanged) {
@@ -1035,8 +1034,7 @@ TEST_F(InstrumentorPatchDecoded, TrampolineReturnDecodesAsBackwardSBranch) {
   ASSERT_TRUE(inst->branch_offset_bytes().has_value())
       << "return must report a PC-relative branch offset";
   EXPECT_LT(*inst->branch_offset_bytes(), 0)
-      << "return branch offset must be negative; got "
-      << *inst->branch_offset_bytes();
+      << "return branch offset must be negative; got " << *inst->branch_offset_bytes();
 }
 
 // End-to-end behavioral check: decode the patched s_branch and the return

--- a/emulation/rocjitsu/tests/patch/instrumentor_test.cpp
+++ b/emulation/rocjitsu/tests/patch/instrumentor_test.cpp
@@ -52,7 +52,7 @@ std::vector<uint8_t> dummy_text(size_t size = 16) {
 }
 
 //==============================================================================
-// Section 1: validate_relocation_anchor (synthetic)
+// Section 1: validate_anchor (synthetic)
 //==============================================================================
 
 TEST(Validator, AcceptsFourByteRelocatable) {
@@ -62,7 +62,7 @@ TEST(Validator, AcceptsFourByteRelocatable) {
   InstrumentationPoint pt;
 
   std::string err;
-  auto site = validate_relocation_anchor(anchor, /*anchor_offset=*/0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err);
+  auto site = validate_anchor(anchor, /*anchor_offset=*/0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err);
   ASSERT_TRUE(site.has_value()) << err;
   EXPECT_EQ(site->original_size, 4u);
   EXPECT_EQ(site->original_bytes.size(), 4u);
@@ -77,7 +77,7 @@ TEST(Validator, AcceptsEightByteRelocatable) {
   InstrumentationPoint pt;
 
   std::string err;
-  auto site = validate_relocation_anchor(anchor, 0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err);
+  auto site = validate_anchor(anchor, 0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err);
   ASSERT_TRUE(site.has_value()) << err;
   EXPECT_EQ(site->original_size, 8u);
   EXPECT_EQ(site->original_bytes.size(), 8u);
@@ -90,7 +90,7 @@ TEST(Validator, RejectsNonZeroFilterFlags) {
   InstrumentationPoint pt;
   pt.filter_flags = 1;
   std::string err;
-  EXPECT_FALSE(validate_relocation_anchor(anchor, 0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value());
+  EXPECT_FALSE(validate_anchor(anchor, 0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value());
   EXPECT_FALSE(err.empty());
 }
 
@@ -109,7 +109,7 @@ TEST(Validator, RejectsControlFlowFlags) {
   for (auto [name, flag] : cases) {
     TestInstruction anchor("test_inst", 4, flag, std::nullopt, &kRaw);
     std::string err;
-    EXPECT_FALSE(validate_relocation_anchor(anchor, 0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value())
+    EXPECT_FALSE(validate_anchor(anchor, 0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value())
         << "flag " << name << " should be rejected";
     EXPECT_FALSE(err.empty());
   }
@@ -121,7 +121,7 @@ TEST(Validator, RejectsNonNullBranchOffsetBytes) {
   auto text = dummy_text();
   InstrumentationPoint pt;
   std::string err;
-  EXPECT_FALSE(validate_relocation_anchor(anchor, 0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value());
+  EXPECT_FALSE(validate_anchor(anchor, 0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value());
   EXPECT_FALSE(err.empty());
 }
 
@@ -130,7 +130,7 @@ TEST(Validator, RejectsNullRawEncoding) {
   auto text = dummy_text();
   InstrumentationPoint pt;
   std::string err;
-  EXPECT_FALSE(validate_relocation_anchor(anchor, 0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value());
+  EXPECT_FALSE(validate_anchor(anchor, 0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value());
   EXPECT_FALSE(err.empty());
 }
 
@@ -140,7 +140,7 @@ TEST(Validator, RejectsUnsupportedSize) {
   auto text = dummy_text();
   InstrumentationPoint pt;
   std::string err;
-  EXPECT_FALSE(validate_relocation_anchor(anchor, 0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value());
+  EXPECT_FALSE(validate_anchor(anchor, 0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value());
   EXPECT_FALSE(err.empty());
 }
 
@@ -151,7 +151,7 @@ TEST(Validator, RejectsUnalignedOffset) {
   InstrumentationPoint pt;
   std::string err;
   EXPECT_FALSE(
-      validate_relocation_anchor(anchor, /*anchor_offset=*/2, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value());
+      validate_anchor(anchor, /*anchor_offset=*/2, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value());
   EXPECT_FALSE(err.empty());
 }
 
@@ -162,7 +162,7 @@ TEST(Validator, RejectsOutOfBoundsOffset) {
   InstrumentationPoint pt;
   std::string err;
   EXPECT_FALSE(
-      validate_relocation_anchor(anchor, /*anchor_offset=*/4, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value());
+      validate_anchor(anchor, /*anchor_offset=*/4, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value());
   EXPECT_FALSE(err.empty());
 }
 
@@ -176,7 +176,7 @@ TEST(Validator, RejectsNonBeforeInstKind) {
     InstrumentationPoint pt;
     pt.kind = kind;
     std::string err;
-    EXPECT_FALSE(validate_relocation_anchor(anchor, 0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value())
+    EXPECT_FALSE(validate_anchor(anchor, 0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value())
         << "kind != BeforeInst must be rejected";
     EXPECT_FALSE(err.empty());
   }
@@ -193,7 +193,7 @@ TEST(Validator, RejectsNonNullProbeObj) {
   pt.probe_obj = kSentinel;
 
   std::string err;
-  EXPECT_FALSE(validate_relocation_anchor(anchor, 0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value());
+  EXPECT_FALSE(validate_anchor(anchor, 0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value());
   EXPECT_FALSE(err.empty());
 }
 
@@ -205,7 +205,7 @@ TEST(Validator, RejectsNonEmptyProbeSymbol) {
   pt.probe_symbol = "my_probe";
 
   std::string err;
-  EXPECT_FALSE(validate_relocation_anchor(anchor, 0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value());
+  EXPECT_FALSE(validate_anchor(anchor, 0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value());
   EXPECT_FALSE(err.empty());
 }
 
@@ -217,7 +217,7 @@ TEST(Validator, RejectsForceFullExec) {
   pt.force_full_exec = true;
 
   std::string err;
-  EXPECT_FALSE(validate_relocation_anchor(anchor, 0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value());
+  EXPECT_FALSE(validate_anchor(anchor, 0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value());
   EXPECT_FALSE(err.empty());
 }
 
@@ -231,20 +231,20 @@ TEST(Validator, RejectsDenylistedMnemonic) {
                         "s_rfe_b64"}) {
     TestInstruction anchor(m, 4, /*flags=*/0, std::nullopt, &kRaw);
     std::string err;
-    EXPECT_FALSE(validate_relocation_anchor(anchor, 0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value())
+    EXPECT_FALSE(validate_anchor(anchor, 0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value())
         << "mnemonic " << m << " should be rejected";
     EXPECT_FALSE(err.empty());
   }
 }
 
 //==============================================================================
-// Section 1b: validate_inline_nop_smoke_plan
+// Section 1b: validate_inline_nop_plan
 //
 // This guardrail used to live in TrampolineBuilder. It now lives at the
 // orchestrator boundary so the builder stays generic. Tests moved with it.
 //==============================================================================
 
-TEST(InlineNopSmokeGuardrail, RejectsNonCanonicalBody) {
+TEST(InlineNopGuardrail, RejectsNonCanonicalBody) {
   constexpr rj_code_arch_t kArch = ROCJITSU_CODE_ARCH_CDNA4;
 
   auto valid_plan = [&] {
@@ -262,14 +262,14 @@ TEST(InlineNopSmokeGuardrail, RejectsNonCanonicalBody) {
 
   // Sanity: the unmutated plan is accepted, so each sub-case below is
   // exercising exactly one guardrail dimension.
-  ASSERT_TRUE(validate_inline_nop_smoke_plan(valid_plan()));
+  ASSERT_TRUE(validate_inline_nop_plan(valid_plan()));
 
   // Extra before-item.
   {
     auto plan = valid_plan();
     plan.before_items.push_back(InlineAsmItem{{build_s_nop(0, kArch)}});
     std::string err;
-    EXPECT_FALSE(validate_inline_nop_smoke_plan(plan, &err))
+    EXPECT_FALSE(validate_inline_nop_plan(plan, &err))
         << "extra before-item must be rejected";
     EXPECT_FALSE(err.empty());
   }
@@ -279,7 +279,7 @@ TEST(InlineNopSmokeGuardrail, RejectsNonCanonicalBody) {
     auto plan = valid_plan();
     plan.before_items = {InlineAsmItem{{build_s_branch(0, kArch)}}};
     std::string err;
-    EXPECT_FALSE(validate_inline_nop_smoke_plan(plan, &err))
+    EXPECT_FALSE(validate_inline_nop_plan(plan, &err))
         << "non-placeholder before-item must be rejected";
     EXPECT_FALSE(err.empty());
   }
@@ -289,7 +289,7 @@ TEST(InlineNopSmokeGuardrail, RejectsNonCanonicalBody) {
     auto plan = valid_plan();
     plan.after_items.push_back(InlineAsmItem{{build_s_nop(0, kArch)}});
     std::string err;
-    EXPECT_FALSE(validate_inline_nop_smoke_plan(plan, &err))
+    EXPECT_FALSE(validate_inline_nop_plan(plan, &err))
         << "non-empty after_items must be rejected";
     EXPECT_FALSE(err.empty());
   }
@@ -299,14 +299,14 @@ TEST(InlineNopSmokeGuardrail, RejectsNonCanonicalBody) {
     auto plan = valid_plan();
     plan.emit_original = false;
     std::string err;
-    EXPECT_FALSE(validate_inline_nop_smoke_plan(plan, &err))
+    EXPECT_FALSE(validate_inline_nop_plan(plan, &err))
         << "emit_original = false must be rejected";
     EXPECT_FALSE(err.empty());
   }
 }
 
 //==============================================================================
-// Section 2: make_relocation_only_plan
+// Section 2: make_trampoline_plan
 //==============================================================================
 
 TEST(MakeRelocationOnlyPlan, FillsCanonicalBodyAndCopiesSiteFields) {
@@ -318,7 +318,7 @@ TEST(MakeRelocationOnlyPlan, FillsCanonicalBodyAndCopiesSiteFields) {
   site.mnemonic = "buffer_load_dword";
 
   const uint64_t kTrampolineOffset = 0x400;
-  TrampolinePlan plan = make_relocation_only_plan(site, kArch, kTrampolineOffset);
+  TrampolinePlan plan = make_trampoline_plan(site, kArch, kTrampolineOffset);
 
   EXPECT_EQ(plan.arch, kArch);
   EXPECT_EQ(plan.anchor_offset, 0x100u);
@@ -671,7 +671,7 @@ TEST(Instrumentor, MutuallyExclusiveAnchorFieldsFails) {
 }
 
 //==============================================================================
-// Section 4: Instrumentor::patch_relocation_only end-to-end
+// Section 4: Instrumentor::patch end-to-end
 //
 // The synthetic ELF places .text at file offset 0x100 with two s_nop 0
 // instructions (size = 8 bytes total). Patching the second instruction at
@@ -691,7 +691,7 @@ TEST(InstrumentorPatch, EmitsValidElfWithExpectedPatchSummary) {
   Instrumentor instrumentor(obj, ROCJITSU_CODE_ARCH_CDNA4);
   instrumentor.add_point_by_offset(/*anchor_offset=*/4);
 
-  auto result = instrumentor.patch_relocation_only();
+  auto result = instrumentor.patch();
   ASSERT_TRUE(result.errors.empty())
       << (result.errors.empty() ? std::string{} : result.errors.front());
   EXPECT_FALSE(result.elf_bytes.empty());
@@ -725,7 +725,7 @@ TEST(InstrumentorPatch, RejectsZeroQueuedPoints) {
   Instrumentor instrumentor(obj, ROCJITSU_CODE_ARCH_CDNA4);
   // No points queued.
 
-  auto result = instrumentor.patch_relocation_only();
+  auto result = instrumentor.patch();
   EXPECT_TRUE(result.elf_bytes.empty());
   EXPECT_TRUE(result.patches.empty());
   EXPECT_FALSE(result.errors.empty());
@@ -738,7 +738,7 @@ TEST(InstrumentorPatch, RejectsMoreThanOneQueuedPoint) {
   instrumentor.add_point_by_offset(0);
   instrumentor.add_point_by_offset(4);
 
-  auto result = instrumentor.patch_relocation_only();
+  auto result = instrumentor.patch();
   EXPECT_TRUE(result.elf_bytes.empty());
   EXPECT_TRUE(result.patches.empty());
   EXPECT_FALSE(result.errors.empty());
@@ -751,7 +751,7 @@ TEST(InstrumentorPatch, ValidationFailurePropagates) {
   // Unaligned offset — validator rejects.
   instrumentor.add_point_by_offset(/*anchor_offset=*/2);
 
-  auto result = instrumentor.patch_relocation_only();
+  auto result = instrumentor.patch();
   EXPECT_TRUE(result.elf_bytes.empty());
   EXPECT_TRUE(result.patches.empty());
   EXPECT_FALSE(result.errors.empty());
@@ -763,11 +763,11 @@ TEST(InstrumentorPatch, IsSingleCall) {
   Instrumentor instrumentor(obj, ROCJITSU_CODE_ARCH_CDNA4);
   instrumentor.add_point_by_offset(4);
 
-  auto first = instrumentor.patch_relocation_only();
+  auto first = instrumentor.patch();
   ASSERT_TRUE(first.errors.empty()) << first.errors.front();
   EXPECT_FALSE(first.elf_bytes.empty());
 
-  auto second = instrumentor.patch_relocation_only();
+  auto second = instrumentor.patch();
   EXPECT_TRUE(second.elf_bytes.empty());
   EXPECT_TRUE(second.patches.empty());
   EXPECT_FALSE(second.errors.empty());
@@ -781,12 +781,12 @@ TEST(InstrumentorPatch, FailedFirstCallStillBurnsSingleAttemptBudget) {
   AmdGpuCodeObject obj(image.data(), image.size());
   Instrumentor instrumentor(obj, ROCJITSU_CODE_ARCH_CDNA4);
   // First call: no queued points — fatal error.
-  auto first = instrumentor.patch_relocation_only();
+  auto first = instrumentor.patch();
   ASSERT_FALSE(first.errors.empty()) << "first call must fail with zero points";
 
   // Try to recover by queueing a valid point and calling again.
   instrumentor.add_point_by_offset(4);
-  auto second = instrumentor.patch_relocation_only();
+  auto second = instrumentor.patch();
   EXPECT_TRUE(second.elf_bytes.empty()) << "single-attempt budget must already be spent";
   EXPECT_TRUE(second.patches.empty());
   EXPECT_FALSE(second.errors.empty());
@@ -803,7 +803,7 @@ TEST(InstrumentorPatch, RejectsMultiTextCodeObject) {
 
   Instrumentor instrumentor(obj, ROCJITSU_CODE_ARCH_CDNA4);
   instrumentor.add_point_by_offset(0);
-  auto result = instrumentor.patch_relocation_only();
+  auto result = instrumentor.patch();
   EXPECT_TRUE(result.elf_bytes.empty());
   EXPECT_TRUE(result.patches.empty());
   EXPECT_FALSE(result.errors.empty());
@@ -812,7 +812,7 @@ TEST(InstrumentorPatch, RejectsMultiTextCodeObject) {
 // Branch-range overflow at the orchestrator level. The trampoline is placed
 // at .text_size; with anchor at offset 0 we need .text_size > 131072 to push
 // forward_simm16 past INT16_MAX. .text_size = 131076 gives forward_simm16 =
-// 32768 → overflow. The builder returns an error; patch_relocation_only must
+// 32768 → overflow. The builder returns an error; Instrumentor::patch must
 // surface it and emit no ELF.
 TEST(InstrumentorPatch, BranchRangeOverflowPropagatesAsFatalError) {
   // 32769 × 4 = 131076 bytes of s_nop in .text.
@@ -822,7 +822,7 @@ TEST(InstrumentorPatch, BranchRangeOverflowPropagatesAsFatalError) {
 
   Instrumentor instrumentor(obj, ROCJITSU_CODE_ARCH_CDNA4);
   instrumentor.add_point_by_offset(/*anchor_offset=*/0);
-  auto result = instrumentor.patch_relocation_only();
+  auto result = instrumentor.patch();
 
   EXPECT_TRUE(result.elf_bytes.empty()) << "overflow must not leak a half-built ELF";
   EXPECT_TRUE(result.patches.empty());
@@ -848,7 +848,7 @@ protected:
 
     Instrumentor instrumentor(obj, ROCJITSU_CODE_ARCH_CDNA4);
     instrumentor.add_point_by_offset(/*anchor_offset=*/4);
-    result_ = instrumentor.patch_relocation_only();
+    result_ = instrumentor.patch();
     ASSERT_TRUE(result_.errors.empty())
         << (result_.errors.empty() ? std::string{} : result_.errors.front());
     ASSERT_FALSE(result_.elf_bytes.empty());
@@ -938,7 +938,7 @@ protected:
 
     Instrumentor instrumentor(obj, ROCJITSU_CODE_ARCH_CDNA4);
     instrumentor.add_point_by_offset(/*anchor_offset=*/4);
-    result_ = instrumentor.patch_relocation_only();
+    result_ = instrumentor.patch();
     ASSERT_TRUE(result_.errors.empty())
         << (result_.errors.empty() ? std::string{} : result_.errors.front());
     ASSERT_FALSE(result_.elf_bytes.empty());

--- a/emulation/rocjitsu/tests/patch/instrumentor_test.cpp
+++ b/emulation/rocjitsu/tests/patch/instrumentor_test.cpp
@@ -1,0 +1,1081 @@
+// Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/code/patch/instrumentor.h"
+
+#include "rocjitsu/code/amdgpu_code_object.h"
+#include "rocjitsu/code/amdgpu_elf.h"
+#include "rocjitsu/code/basic_block.h"
+#include "rocjitsu/code/patch/instruction_builder.h"
+#include "rocjitsu/code/patch/trampoline_builder.h"
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace rocjitsu {
+namespace {
+
+//==============================================================================
+// Synthetic Instruction subclass for fast validator unit tests.
+//==============================================================================
+
+class TestInstruction : public Instruction {
+public:
+  TestInstruction(std::string_view mnemonic, int size, uint64_t flags,
+                  std::optional<int64_t> branch_delta, const uint32_t *raw_enc)
+      : Instruction(mnemonic, nullptr), branch_delta_(branch_delta) {
+    size_ = size;
+    flags_ = flags;
+    raw_encoding_ = raw_enc;
+  }
+  std::optional<int64_t> branch_offset_bytes() const override { return branch_delta_; }
+
+private:
+  std::optional<int64_t> branch_delta_;
+};
+
+std::vector<uint8_t> dummy_text(size_t size = 16) {
+  return std::vector<uint8_t>(size, 0xCC);
+}
+
+//==============================================================================
+// Section 1: validate_relocation_anchor (synthetic)
+//==============================================================================
+
+TEST(Validator, AcceptsFourByteRelocatable) {
+  static constexpr uint32_t kRaw = 0xDEADBEEFu;
+  TestInstruction anchor("v_add_f32_e32", 4, /*flags=*/0, std::nullopt, &kRaw);
+  auto text = dummy_text();
+  InstrumentationPoint pt;
+
+  std::string err;
+  auto site = validate_relocation_anchor(anchor, /*anchor_offset=*/0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err);
+  ASSERT_TRUE(site.has_value()) << err;
+  EXPECT_EQ(site->original_size, 4u);
+  EXPECT_EQ(site->original_bytes.size(), 4u);
+  EXPECT_EQ(site->mnemonic, "v_add_f32_e32");
+  EXPECT_EQ(site->anchor_offset, 0u);
+}
+
+TEST(Validator, AcceptsEightByteRelocatable) {
+  static constexpr uint32_t kRaw[2] = {0xDEADBEEFu, 0xCAFEF00Du};
+  TestInstruction anchor("buffer_load_dword", 8, /*flags=*/0, std::nullopt, kRaw);
+  auto text = dummy_text();
+  InstrumentationPoint pt;
+
+  std::string err;
+  auto site = validate_relocation_anchor(anchor, 0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err);
+  ASSERT_TRUE(site.has_value()) << err;
+  EXPECT_EQ(site->original_size, 8u);
+  EXPECT_EQ(site->original_bytes.size(), 8u);
+}
+
+TEST(Validator, RejectsNonZeroFilterFlags) {
+  static constexpr uint32_t kRaw = 0xDEADBEEFu;
+  TestInstruction anchor("v_add_f32_e32", 4, 0, std::nullopt, &kRaw);
+  auto text = dummy_text();
+  InstrumentationPoint pt;
+  pt.filter_flags = 1;
+  std::string err;
+  EXPECT_FALSE(validate_relocation_anchor(anchor, 0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value());
+  EXPECT_FALSE(err.empty());
+}
+
+TEST(Validator, RejectsControlFlowFlags) {
+  static constexpr uint32_t kRaw = 0xCAFEBABEu;
+  auto text = dummy_text();
+  InstrumentationPoint pt;
+
+  const std::array<std::pair<const char *, uint64_t>, 5> cases = {{
+      {"BRANCH", BRANCH},
+      {"COND_BRANCH", COND_BRANCH},
+      {"INDIRECT_BRANCH", INDIRECT_BRANCH},
+      {"INDIRECT_CALL", INDIRECT_CALL},
+      {"PROGRAM_TERMINATOR", PROGRAM_TERMINATOR},
+  }};
+  for (auto [name, flag] : cases) {
+    TestInstruction anchor("test_inst", 4, flag, std::nullopt, &kRaw);
+    std::string err;
+    EXPECT_FALSE(validate_relocation_anchor(anchor, 0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value())
+        << "flag " << name << " should be rejected";
+    EXPECT_FALSE(err.empty());
+  }
+}
+
+TEST(Validator, RejectsNonNullBranchOffsetBytes) {
+  static constexpr uint32_t kRaw = 0xCAFEBABEu;
+  TestInstruction anchor("s_cbranch_scc0", 4, /*flags=*/0, /*branch_delta=*/42, &kRaw);
+  auto text = dummy_text();
+  InstrumentationPoint pt;
+  std::string err;
+  EXPECT_FALSE(validate_relocation_anchor(anchor, 0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value());
+  EXPECT_FALSE(err.empty());
+}
+
+TEST(Validator, RejectsNullRawEncoding) {
+  TestInstruction anchor("opaque", 4, /*flags=*/0, std::nullopt, /*raw_enc=*/nullptr);
+  auto text = dummy_text();
+  InstrumentationPoint pt;
+  std::string err;
+  EXPECT_FALSE(validate_relocation_anchor(anchor, 0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value());
+  EXPECT_FALSE(err.empty());
+}
+
+TEST(Validator, RejectsUnsupportedSize) {
+  static constexpr uint32_t kRaw[3] = {0, 0, 0};
+  TestInstruction anchor("hypothetical_12byte", 12, 0, std::nullopt, kRaw);
+  auto text = dummy_text();
+  InstrumentationPoint pt;
+  std::string err;
+  EXPECT_FALSE(validate_relocation_anchor(anchor, 0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value());
+  EXPECT_FALSE(err.empty());
+}
+
+TEST(Validator, RejectsUnalignedOffset) {
+  static constexpr uint32_t kRaw = 0xDEADBEEFu;
+  TestInstruction anchor("v_add_f32_e32", 4, 0, std::nullopt, &kRaw);
+  auto text = dummy_text();
+  InstrumentationPoint pt;
+  std::string err;
+  EXPECT_FALSE(
+      validate_relocation_anchor(anchor, /*anchor_offset=*/2, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value());
+  EXPECT_FALSE(err.empty());
+}
+
+TEST(Validator, RejectsOutOfBoundsOffset) {
+  static constexpr uint32_t kRaw[2] = {0, 0};
+  TestInstruction anchor("buffer_load_dword", 8, 0, std::nullopt, kRaw);
+  auto text = dummy_text(/*size=*/8);
+  InstrumentationPoint pt;
+  std::string err;
+  EXPECT_FALSE(
+      validate_relocation_anchor(anchor, /*anchor_offset=*/4, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value());
+  EXPECT_FALSE(err.empty());
+}
+
+TEST(Validator, RejectsNonBeforeInstKind) {
+  static constexpr uint32_t kRaw = 0xDEADBEEFu;
+  TestInstruction anchor("v_add_f32_e32", 4, 0, std::nullopt, &kRaw);
+  auto text = dummy_text();
+
+  for (auto kind : {InstrumentationKind::AfterInst, InstrumentationKind::BlockEntry,
+                    InstrumentationKind::BlockExit}) {
+    InstrumentationPoint pt;
+    pt.kind = kind;
+    std::string err;
+    EXPECT_FALSE(validate_relocation_anchor(anchor, 0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value())
+        << "kind != BeforeInst must be rejected";
+    EXPECT_FALSE(err.empty());
+  }
+}
+
+TEST(Validator, RejectsNonNullProbeObj) {
+  static constexpr uint32_t kRaw = 0xDEADBEEFu;
+  TestInstruction anchor("v_add_f32_e32", 4, 0, std::nullopt, &kRaw);
+  auto text = dummy_text();
+  InstrumentationPoint pt;
+  // The struct stores a const AmdGpuCodeObject*. Any non-null value triggers
+  // the guardrail; we never dereference it.
+  static const AmdGpuCodeObject *kSentinel = reinterpret_cast<const AmdGpuCodeObject *>(0x1);
+  pt.probe_obj = kSentinel;
+
+  std::string err;
+  EXPECT_FALSE(validate_relocation_anchor(anchor, 0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value());
+  EXPECT_FALSE(err.empty());
+}
+
+TEST(Validator, RejectsNonEmptyProbeSymbol) {
+  static constexpr uint32_t kRaw = 0xDEADBEEFu;
+  TestInstruction anchor("v_add_f32_e32", 4, 0, std::nullopt, &kRaw);
+  auto text = dummy_text();
+  InstrumentationPoint pt;
+  pt.probe_symbol = "my_probe";
+
+  std::string err;
+  EXPECT_FALSE(validate_relocation_anchor(anchor, 0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value());
+  EXPECT_FALSE(err.empty());
+}
+
+TEST(Validator, RejectsForceFullExec) {
+  static constexpr uint32_t kRaw = 0xDEADBEEFu;
+  TestInstruction anchor("v_add_f32_e32", 4, 0, std::nullopt, &kRaw);
+  auto text = dummy_text();
+  InstrumentationPoint pt;
+  pt.force_full_exec = true;
+
+  std::string err;
+  EXPECT_FALSE(validate_relocation_anchor(anchor, 0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value());
+  EXPECT_FALSE(err.empty());
+}
+
+TEST(Validator, RejectsDenylistedMnemonic) {
+  static constexpr uint32_t kRaw = 0xCAFEBABEu;
+  auto text = dummy_text();
+  InstrumentationPoint pt;
+
+  // PC-relative semantics that may not surface in flags / branch_offset_bytes.
+  for (const char *m : {"s_getpc_b64", "s_call_b64", "s_setpc_b64", "s_swappc_b64",
+                        "s_rfe_b64"}) {
+    TestInstruction anchor(m, 4, /*flags=*/0, std::nullopt, &kRaw);
+    std::string err;
+    EXPECT_FALSE(validate_relocation_anchor(anchor, 0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value())
+        << "mnemonic " << m << " should be rejected";
+    EXPECT_FALSE(err.empty());
+  }
+}
+
+//==============================================================================
+// Section 1b: validate_inline_nop_smoke_plan
+//
+// This guardrail used to live in TrampolineBuilder. It now lives at the
+// orchestrator boundary so the builder stays generic. Tests moved with it.
+//==============================================================================
+
+TEST(InlineNopSmokeGuardrail, RejectsNonCanonicalBody) {
+  constexpr rj_code_arch_t kArch = ROCJITSU_CODE_ARCH_CDNA4;
+
+  auto valid_plan = [&] {
+    TrampolinePlan p;
+    p.arch = kArch;
+    p.anchor_offset = 0x100;
+    p.original_size = 4;
+    p.trampoline_offset = 0x200;
+    p.return_target = 0x104;
+    p.original_words = {0xDEADBEEFu};
+    p.before_items = {InlineAsmItem{{build_s_nop(0, kArch)}}};
+    p.emit_original = true;
+    return p;
+  };
+
+  // Sanity: the unmutated plan is accepted, so each sub-case below is
+  // exercising exactly one guardrail dimension.
+  ASSERT_TRUE(validate_inline_nop_smoke_plan(valid_plan()));
+
+  // Extra before-item.
+  {
+    auto plan = valid_plan();
+    plan.before_items.push_back(InlineAsmItem{{build_s_nop(0, kArch)}});
+    std::string err;
+    EXPECT_FALSE(validate_inline_nop_smoke_plan(plan, &err))
+        << "extra before-item must be rejected";
+    EXPECT_FALSE(err.empty());
+  }
+
+  // Before-item that isn't s_nop 0.
+  {
+    auto plan = valid_plan();
+    plan.before_items = {InlineAsmItem{{build_s_branch(0, kArch)}}};
+    std::string err;
+    EXPECT_FALSE(validate_inline_nop_smoke_plan(plan, &err))
+        << "non-placeholder before-item must be rejected";
+    EXPECT_FALSE(err.empty());
+  }
+
+  // Any after-item at all.
+  {
+    auto plan = valid_plan();
+    plan.after_items.push_back(InlineAsmItem{{build_s_nop(0, kArch)}});
+    std::string err;
+    EXPECT_FALSE(validate_inline_nop_smoke_plan(plan, &err))
+        << "non-empty after_items must be rejected";
+    EXPECT_FALSE(err.empty());
+  }
+
+  // emit_original = false.
+  {
+    auto plan = valid_plan();
+    plan.emit_original = false;
+    std::string err;
+    EXPECT_FALSE(validate_inline_nop_smoke_plan(plan, &err))
+        << "emit_original = false must be rejected";
+    EXPECT_FALSE(err.empty());
+  }
+}
+
+//==============================================================================
+// Section 2: make_relocation_only_plan
+//==============================================================================
+
+TEST(MakeRelocationOnlyPlan, FillsCanonicalBodyAndCopiesSiteFields) {
+  constexpr rj_code_arch_t kArch = ROCJITSU_CODE_ARCH_CDNA4;
+  ResolvedInstrumentationSite site;
+  site.anchor_offset = 0x100;
+  site.original_size = 8;
+  site.original_bytes = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88};
+  site.mnemonic = "buffer_load_dword";
+
+  const uint64_t kTrampolineOffset = 0x400;
+  TrampolinePlan plan = make_relocation_only_plan(site, kArch, kTrampolineOffset);
+
+  EXPECT_EQ(plan.arch, kArch);
+  EXPECT_EQ(plan.anchor_offset, 0x100u);
+  EXPECT_EQ(plan.original_size, 8u);
+  EXPECT_EQ(plan.trampoline_offset, kTrampolineOffset);
+  EXPECT_EQ(plan.return_target, 0x108u);
+  ASSERT_EQ(plan.original_words.size(), 2u);
+  EXPECT_EQ(plan.original_words[0], 0x44332211u); // little-endian
+  EXPECT_EQ(plan.original_words[1], 0x88776655u);
+  ASSERT_EQ(plan.before_items.size(), 1u);
+  ASSERT_EQ(plan.before_items[0].words.size(), 1u);
+  EXPECT_EQ(plan.before_items[0].words[0], build_s_nop(0, kArch));
+  EXPECT_TRUE(plan.after_items.empty());
+  EXPECT_TRUE(plan.emit_original);
+}
+
+//==============================================================================
+// Section 3: Instrumentor integration tests (minimal in-memory gfx950 ELF)
+//==============================================================================
+
+// NOTE: helpers below are intentionally duplicated from
+//   tests/dbt/translate_test.cpp::add_elf_name
+//   tests/dbt/translate_test.cpp::align_up_for_test
+//   tests/dbt/translate_test.cpp::make_minimal_amdgpu_elf_with_text_and_rodata
+// to keep this slice self-contained. If/when a third test file needs the same
+// helpers, extract them into a shared test-fixture header (the project lead
+// may also have a different preference for where this should live).
+
+uint32_t add_elf_name(std::vector<uint8_t> &names, std::string_view name) {
+  const uint32_t offset = static_cast<uint32_t>(names.size());
+  names.insert(names.end(), name.begin(), name.end());
+  names.push_back('\0');
+  return offset;
+}
+
+uint64_t align_up_for_test(uint64_t value, uint64_t alignment) {
+  const uint64_t remainder = value % alignment;
+  return remainder == 0 ? value : value + alignment - remainder;
+}
+
+// gfx950 ELF with a single .text of `text_size` bytes filled with `s_nop 0`
+// words (so every dword-aligned offset is a valid anchor). Used for the
+// forward-branch overflow test, which needs .text large enough that the
+// trampoline (placed at text_size) is more than INT16_MAX dwords past offset
+// 0.
+std::vector<uint8_t> make_gfx950_elf_with_nop_text(uint64_t text_size) {
+  // Must be a multiple of 4 so the entire section is decodable as s_nop words.
+  const uint64_t text_offset = 0x100;
+  const uint64_t rodata_size = 4;
+
+  std::vector<uint8_t> shstrtab{'\0'};
+  const uint32_t text_name = add_elf_name(shstrtab, ".text");
+  const uint32_t rodata_name = add_elf_name(shstrtab, ".rodata");
+  const uint32_t shstrtab_name = add_elf_name(shstrtab, ".shstrtab");
+
+  const uint64_t rodata_offset = text_offset + text_size;
+  const uint64_t shstrtab_offset = rodata_offset + rodata_size;
+  const uint64_t shoff = align_up_for_test(shstrtab_offset + shstrtab.size(), 8);
+  constexpr uint16_t section_count = 4;
+
+  std::vector<uint8_t> image(shoff + section_count * sizeof(Elf64_Shdr), 0);
+
+  Elf64_Ehdr ehdr{};
+  std::memcpy(ehdr.e_ident, EI_MAGIC, EI_MAGIC_SIZE);
+  ehdr.e_ident[EI_CLASS] = ELFCLASS64;
+  ehdr.e_ident[EI_OSABI] = ELFOSABI_AMDGPU_HSA;
+  ehdr.e_type = ET_REL;
+  ehdr.e_machine = EM_AMDGPU;
+  ehdr.e_version = 1;
+  ehdr.e_shoff = shoff;
+  ehdr.e_flags = EF_AMDGPU_MACH_AMDGCN_GFX950;
+  ehdr.e_ehsize = sizeof(Elf64_Ehdr);
+  ehdr.e_shentsize = sizeof(Elf64_Shdr);
+  ehdr.e_shnum = section_count;
+  ehdr.e_shstrndx = 3;
+  std::memcpy(image.data(), &ehdr, sizeof(ehdr));
+
+  for (uint64_t off = 0; off < text_size; off += sizeof(uint32_t)) {
+    const uint32_t nop = 0xBF800000u;
+    std::memcpy(image.data() + text_offset + off, &nop, sizeof(nop));
+  }
+
+  const uint32_t rodata_word = 0xA5A55A5Au;
+  std::memcpy(image.data() + rodata_offset, &rodata_word, sizeof(rodata_word));
+  std::memcpy(image.data() + shstrtab_offset, shstrtab.data(), shstrtab.size());
+
+  std::array<Elf64_Shdr, section_count> shdrs{};
+  shdrs[1].sh_name = text_name;
+  shdrs[1].sh_type = SHT_PROGBITS;
+  shdrs[1].sh_flags = SHF_ALLOC | SHF_EXECINSTR;
+  shdrs[1].sh_offset = text_offset;
+  shdrs[1].sh_size = text_size;
+  shdrs[1].sh_addralign = sizeof(uint32_t);
+
+  shdrs[2].sh_name = rodata_name;
+  shdrs[2].sh_type = SHT_PROGBITS;
+  shdrs[2].sh_flags = SHF_ALLOC;
+  shdrs[2].sh_offset = rodata_offset;
+  shdrs[2].sh_size = rodata_size;
+  shdrs[2].sh_addralign = sizeof(uint32_t);
+
+  shdrs[3].sh_name = shstrtab_name;
+  shdrs[3].sh_type = SHT_STRTAB;
+  shdrs[3].sh_offset = shstrtab_offset;
+  shdrs[3].sh_size = shstrtab.size();
+  shdrs[3].sh_addralign = 1;
+
+  std::memcpy(image.data() + shoff, shdrs.data(), shdrs.size() * sizeof(Elf64_Shdr));
+  return image;
+}
+
+// gfx950 ELF with TWO `.text` sections (both SHF_ALLOC | SHF_EXECINSTR, both
+// named ".text"). Used to verify the multi-text rejection path.
+std::vector<uint8_t> make_gfx950_elf_with_two_text_sections() {
+  constexpr uint64_t text1_offset = 0x100;
+  constexpr uint64_t text1_size = 4;
+  constexpr uint64_t text2_offset = text1_offset + text1_size;
+  constexpr uint64_t text2_size = 4;
+  constexpr uint64_t rodata_size = 4;
+
+  std::vector<uint8_t> shstrtab{'\0'};
+  const uint32_t text_name = add_elf_name(shstrtab, ".text");
+  const uint32_t rodata_name = add_elf_name(shstrtab, ".rodata");
+  const uint32_t shstrtab_name = add_elf_name(shstrtab, ".shstrtab");
+
+  const uint64_t rodata_offset = text2_offset + text2_size;
+  const uint64_t shstrtab_offset = rodata_offset + rodata_size;
+  const uint64_t shoff = align_up_for_test(shstrtab_offset + shstrtab.size(), 8);
+  constexpr uint16_t section_count = 5;
+
+  std::vector<uint8_t> image(shoff + section_count * sizeof(Elf64_Shdr), 0);
+
+  Elf64_Ehdr ehdr{};
+  std::memcpy(ehdr.e_ident, EI_MAGIC, EI_MAGIC_SIZE);
+  ehdr.e_ident[EI_CLASS] = ELFCLASS64;
+  ehdr.e_ident[EI_OSABI] = ELFOSABI_AMDGPU_HSA;
+  ehdr.e_type = ET_REL;
+  ehdr.e_machine = EM_AMDGPU;
+  ehdr.e_version = 1;
+  ehdr.e_shoff = shoff;
+  ehdr.e_flags = EF_AMDGPU_MACH_AMDGCN_GFX950;
+  ehdr.e_ehsize = sizeof(Elf64_Ehdr);
+  ehdr.e_shentsize = sizeof(Elf64_Shdr);
+  ehdr.e_shnum = section_count;
+  ehdr.e_shstrndx = 4;
+  std::memcpy(image.data(), &ehdr, sizeof(ehdr));
+
+  const uint32_t nop = 0xBF800000u;
+  std::memcpy(image.data() + text1_offset, &nop, sizeof(nop));
+  std::memcpy(image.data() + text2_offset, &nop, sizeof(nop));
+  const uint32_t rodata_word = 0xA5A55A5Au;
+  std::memcpy(image.data() + rodata_offset, &rodata_word, sizeof(rodata_word));
+  std::memcpy(image.data() + shstrtab_offset, shstrtab.data(), shstrtab.size());
+
+  std::array<Elf64_Shdr, section_count> shdrs{};
+  shdrs[1].sh_name = text_name;
+  shdrs[1].sh_type = SHT_PROGBITS;
+  shdrs[1].sh_flags = SHF_ALLOC | SHF_EXECINSTR;
+  shdrs[1].sh_offset = text1_offset;
+  shdrs[1].sh_size = text1_size;
+  shdrs[1].sh_addralign = sizeof(uint32_t);
+
+  shdrs[2].sh_name = text_name; // also named ".text"
+  shdrs[2].sh_type = SHT_PROGBITS;
+  shdrs[2].sh_flags = SHF_ALLOC | SHF_EXECINSTR;
+  shdrs[2].sh_offset = text2_offset;
+  shdrs[2].sh_size = text2_size;
+  shdrs[2].sh_addralign = sizeof(uint32_t);
+
+  shdrs[3].sh_name = rodata_name;
+  shdrs[3].sh_type = SHT_PROGBITS;
+  shdrs[3].sh_flags = SHF_ALLOC;
+  shdrs[3].sh_offset = rodata_offset;
+  shdrs[3].sh_size = rodata_size;
+  shdrs[3].sh_addralign = sizeof(uint32_t);
+
+  shdrs[4].sh_name = shstrtab_name;
+  shdrs[4].sh_type = SHT_STRTAB;
+  shdrs[4].sh_offset = shstrtab_offset;
+  shdrs[4].sh_size = shstrtab.size();
+  shdrs[4].sh_addralign = 1;
+
+  std::memcpy(image.data() + shoff, shdrs.data(), shdrs.size() * sizeof(Elf64_Shdr));
+  return image;
+}
+
+// gfx950 ELF with .text containing two `s_nop 0` words (8 bytes total).
+// The two-instruction layout lets tests verify that anchor resolution finds
+// the second instruction at offset 4, not just the first at offset 0.
+std::vector<uint8_t> make_gfx950_elf_with_two_nops() {
+  constexpr uint64_t text_offset = 0x100;
+  constexpr uint64_t text_size = 8;
+  constexpr uint64_t rodata_size = 4;
+
+  std::vector<uint8_t> shstrtab{'\0'};
+  const uint32_t text_name = add_elf_name(shstrtab, ".text");
+  const uint32_t rodata_name = add_elf_name(shstrtab, ".rodata");
+  const uint32_t shstrtab_name = add_elf_name(shstrtab, ".shstrtab");
+
+  const uint64_t rodata_offset = text_offset + text_size;
+  const uint64_t shstrtab_offset = rodata_offset + rodata_size;
+  const uint64_t shoff = align_up_for_test(shstrtab_offset + shstrtab.size(), 8);
+  constexpr uint16_t section_count = 4;
+
+  std::vector<uint8_t> image(shoff + section_count * sizeof(Elf64_Shdr), 0);
+
+  Elf64_Ehdr ehdr{};
+  std::memcpy(ehdr.e_ident, EI_MAGIC, EI_MAGIC_SIZE);
+  ehdr.e_ident[EI_CLASS] = ELFCLASS64;
+  ehdr.e_ident[EI_OSABI] = ELFOSABI_AMDGPU_HSA;
+  ehdr.e_type = ET_REL;
+  ehdr.e_machine = EM_AMDGPU;
+  ehdr.e_version = 1;
+  ehdr.e_shoff = shoff;
+  ehdr.e_flags = EF_AMDGPU_MACH_AMDGCN_GFX950;
+  ehdr.e_ehsize = sizeof(Elf64_Ehdr);
+  ehdr.e_shentsize = sizeof(Elf64_Shdr);
+  ehdr.e_shnum = section_count;
+  ehdr.e_shstrndx = 3;
+  std::memcpy(image.data(), &ehdr, sizeof(ehdr));
+
+  // Two s_nop 0 words: SOPP encoding prefix 0x17F << 23, opcode 0, simm16 0.
+  const std::array<uint32_t, 2> text_words = {0xBF800000u, 0xBF800000u};
+  std::memcpy(image.data() + text_offset, text_words.data(), text_size);
+
+  const uint32_t rodata_word = 0xA5A55A5Au;
+  std::memcpy(image.data() + rodata_offset, &rodata_word, sizeof(rodata_word));
+  std::memcpy(image.data() + shstrtab_offset, shstrtab.data(), shstrtab.size());
+
+  std::array<Elf64_Shdr, section_count> shdrs{};
+  shdrs[1].sh_name = text_name;
+  shdrs[1].sh_type = SHT_PROGBITS;
+  shdrs[1].sh_flags = SHF_ALLOC | SHF_EXECINSTR;
+  shdrs[1].sh_offset = text_offset;
+  shdrs[1].sh_size = text_size;
+  shdrs[1].sh_addralign = sizeof(uint32_t);
+
+  shdrs[2].sh_name = rodata_name;
+  shdrs[2].sh_type = SHT_PROGBITS;
+  shdrs[2].sh_flags = SHF_ALLOC;
+  shdrs[2].sh_offset = rodata_offset;
+  shdrs[2].sh_size = rodata_size;
+  shdrs[2].sh_addralign = sizeof(uint32_t);
+
+  shdrs[3].sh_name = shstrtab_name;
+  shdrs[3].sh_type = SHT_STRTAB;
+  shdrs[3].sh_offset = shstrtab_offset;
+  shdrs[3].sh_size = shstrtab.size();
+  shdrs[3].sh_addralign = 1;
+
+  std::memcpy(image.data() + shoff, shdrs.data(), shdrs.size() * sizeof(Elf64_Shdr));
+  return image;
+}
+
+TEST(Instrumentor, AddPointByOffsetResolvesValidatedSite) {
+  auto image = make_gfx950_elf_with_two_nops();
+  AmdGpuCodeObject obj(image.data(), image.size());
+  ASSERT_TRUE(obj.is_valid());
+
+  Instrumentor instrumentor(obj, ROCJITSU_CODE_ARCH_CDNA4);
+  instrumentor.add_point_by_offset(/*anchor_offset=*/4);
+
+  auto result = instrumentor.resolve_and_validate();
+  ASSERT_TRUE(result.errors.empty())
+      << (result.errors.empty() ? std::string{} : result.errors.front());
+  ASSERT_EQ(result.sites.size(), 1u);
+  EXPECT_EQ(result.sites[0].anchor_offset, 4u);
+  EXPECT_EQ(result.sites[0].original_size, 4u);
+  EXPECT_EQ(result.sites[0].original_bytes.size(), 4u);
+  EXPECT_NE(result.sites[0].mnemonic.find("s_nop"), std::string::npos)
+      << "mnemonic was: " << result.sites[0].mnemonic;
+}
+
+TEST(Instrumentor, AnchorInstFromOwnedBlockResolves) {
+  auto image = make_gfx950_elf_with_two_nops();
+  AmdGpuCodeObject obj(image.data(), image.size());
+  ASSERT_TRUE(obj.is_valid());
+
+  Instrumentor instrumentor(obj, ROCJITSU_CODE_ARCH_CDNA4);
+  auto blocks = instrumentor.owned_blocks();
+  ASSERT_FALSE(blocks.empty());
+
+  // Pick the second instruction in the first block.
+  const Instruction *second = nullptr;
+  size_t i = 0;
+  for (const Instruction &inst : blocks.front()->instructions()) {
+    if (i++ == 1) {
+      second = &inst;
+      break;
+    }
+  }
+  ASSERT_NE(second, nullptr);
+
+  InstrumentationPoint pt;
+  pt.anchor_inst = second;
+  instrumentor.add_point(pt);
+
+  auto result = instrumentor.resolve_and_validate();
+  ASSERT_TRUE(result.errors.empty())
+      << (result.errors.empty() ? std::string{} : result.errors.front());
+  ASSERT_EQ(result.sites.size(), 1u);
+  EXPECT_EQ(result.sites[0].anchor_offset, 4u);
+  EXPECT_EQ(result.sites[0].anchor_inst, second);
+}
+
+TEST(Instrumentor, AnchorInstNotInOwnedBlocksFails) {
+  auto image = make_gfx950_elf_with_two_nops();
+  AmdGpuCodeObject obj(image.data(), image.size());
+
+  Instrumentor instrumentor(obj, ROCJITSU_CODE_ARCH_CDNA4);
+
+  // External Instruction not from instrumentor's owned blocks.
+  static constexpr uint32_t kRaw = 0xBF800000u;
+  TestInstruction external("s_nop", 4, 0, std::nullopt, &kRaw);
+
+  InstrumentationPoint pt;
+  pt.anchor_inst = &external;
+  instrumentor.add_point(pt);
+
+  auto result = instrumentor.resolve_and_validate();
+  EXPECT_TRUE(result.sites.empty());
+  EXPECT_FALSE(result.errors.empty());
+}
+
+TEST(Instrumentor, MutuallyExclusiveAnchorFieldsFails) {
+  auto image = make_gfx950_elf_with_two_nops();
+  AmdGpuCodeObject obj(image.data(), image.size());
+
+  // Both set.
+  {
+    static constexpr uint32_t kRaw = 0xBF800000u;
+    TestInstruction inst("s_nop", 4, 0, std::nullopt, &kRaw);
+    InstrumentationPoint pt;
+    pt.anchor_inst = &inst;
+    pt.anchor_offset = 0;
+    Instrumentor i2(obj, ROCJITSU_CODE_ARCH_CDNA4);
+    i2.add_point(pt);
+    auto result = i2.resolve_and_validate();
+    EXPECT_FALSE(result.errors.empty()) << "both anchor_inst and anchor_offset set";
+  }
+
+  // Neither set.
+  {
+    InstrumentationPoint pt;
+    Instrumentor i3(obj, ROCJITSU_CODE_ARCH_CDNA4);
+    i3.add_point(pt);
+    auto result = i3.resolve_and_validate();
+    EXPECT_FALSE(result.errors.empty()) << "neither anchor_inst nor anchor_offset set";
+  }
+}
+
+//==============================================================================
+// Section 4: Instrumentor::patch_relocation_only end-to-end
+//
+// The synthetic ELF places .text at file offset 0x100 with two s_nop 0
+// instructions (size = 8 bytes total). Patching the second instruction at
+// .text-relative offset 4 yields these expected layout values:
+//   trampoline_offset  = patcher.text_size() = 8
+//   return_target      = 4 + 4 = 8
+//   forward_simm16     = (8 - (4 + 4)) / 4 = 0
+//   return_branch_pc   = 8 + 4 + 4 = 16
+//   return_simm16      = (8 - (16 + 4)) / 4 = -3
+//==============================================================================
+
+TEST(InstrumentorPatch, EmitsValidElfWithExpectedPatchSummary) {
+  auto image = make_gfx950_elf_with_two_nops();
+  AmdGpuCodeObject obj(image.data(), image.size());
+  ASSERT_TRUE(obj.is_valid());
+
+  Instrumentor instrumentor(obj, ROCJITSU_CODE_ARCH_CDNA4);
+  instrumentor.add_point_by_offset(/*anchor_offset=*/4);
+
+  auto result = instrumentor.patch_relocation_only();
+  ASSERT_TRUE(result.errors.empty())
+      << (result.errors.empty() ? std::string{} : result.errors.front());
+  EXPECT_FALSE(result.elf_bytes.empty());
+  ASSERT_EQ(result.patches.size(), 1u);
+
+  const auto &p = result.patches[0];
+  EXPECT_EQ(p.anchor_offset, 4u);
+  EXPECT_EQ(p.original_size, 4u);
+  EXPECT_EQ(p.trampoline_offset, 8u);
+  EXPECT_EQ(p.return_target, 8u);
+
+  // Original bytes are s_nop 0 = 0xBF800000 little-endian.
+  const std::vector<uint8_t> expected_original = {0x00, 0x00, 0x80, 0xBF};
+  EXPECT_EQ(p.original_bytes, expected_original);
+
+  // Patched anchor is build_s_branch(0, CDNA4): branch from anchor to the
+  // trampoline that starts immediately after .text.
+  ASSERT_EQ(p.patched_anchor_bytes.size(), 4u);
+  uint32_t patched_word = 0;
+  std::memcpy(&patched_word, p.patched_anchor_bytes.data(), sizeof(patched_word));
+  EXPECT_EQ(patched_word, build_s_branch(0, ROCJITSU_CODE_ARCH_CDNA4));
+
+  // Emitted ELF reparses cleanly.
+  AmdGpuCodeObject patched(result.elf_bytes.data(), result.elf_bytes.size());
+  EXPECT_TRUE(patched.is_valid());
+}
+
+TEST(InstrumentorPatch, RejectsZeroQueuedPoints) {
+  auto image = make_gfx950_elf_with_two_nops();
+  AmdGpuCodeObject obj(image.data(), image.size());
+  Instrumentor instrumentor(obj, ROCJITSU_CODE_ARCH_CDNA4);
+  // No points queued.
+
+  auto result = instrumentor.patch_relocation_only();
+  EXPECT_TRUE(result.elf_bytes.empty());
+  EXPECT_TRUE(result.patches.empty());
+  EXPECT_FALSE(result.errors.empty());
+}
+
+TEST(InstrumentorPatch, RejectsMoreThanOneQueuedPoint) {
+  auto image = make_gfx950_elf_with_two_nops();
+  AmdGpuCodeObject obj(image.data(), image.size());
+  Instrumentor instrumentor(obj, ROCJITSU_CODE_ARCH_CDNA4);
+  instrumentor.add_point_by_offset(0);
+  instrumentor.add_point_by_offset(4);
+
+  auto result = instrumentor.patch_relocation_only();
+  EXPECT_TRUE(result.elf_bytes.empty());
+  EXPECT_TRUE(result.patches.empty());
+  EXPECT_FALSE(result.errors.empty());
+}
+
+TEST(InstrumentorPatch, ValidationFailurePropagates) {
+  auto image = make_gfx950_elf_with_two_nops();
+  AmdGpuCodeObject obj(image.data(), image.size());
+  Instrumentor instrumentor(obj, ROCJITSU_CODE_ARCH_CDNA4);
+  // Unaligned offset — validator rejects.
+  instrumentor.add_point_by_offset(/*anchor_offset=*/2);
+
+  auto result = instrumentor.patch_relocation_only();
+  EXPECT_TRUE(result.elf_bytes.empty());
+  EXPECT_TRUE(result.patches.empty());
+  EXPECT_FALSE(result.errors.empty());
+}
+
+TEST(InstrumentorPatch, IsSingleCall) {
+  auto image = make_gfx950_elf_with_two_nops();
+  AmdGpuCodeObject obj(image.data(), image.size());
+  Instrumentor instrumentor(obj, ROCJITSU_CODE_ARCH_CDNA4);
+  instrumentor.add_point_by_offset(4);
+
+  auto first = instrumentor.patch_relocation_only();
+  ASSERT_TRUE(first.errors.empty()) << first.errors.front();
+  EXPECT_FALSE(first.elf_bytes.empty());
+
+  auto second = instrumentor.patch_relocation_only();
+  EXPECT_TRUE(second.elf_bytes.empty());
+  EXPECT_TRUE(second.patches.empty());
+  EXPECT_FALSE(second.errors.empty());
+}
+
+// Pins the documented single-attempt semantics: any call (success or failure)
+// burns the budget. A caller that hits a recoverable argument error must
+// construct a new Instrumentor.
+TEST(InstrumentorPatch, FailedFirstCallStillBurnsSingleAttemptBudget) {
+  auto image = make_gfx950_elf_with_two_nops();
+  AmdGpuCodeObject obj(image.data(), image.size());
+  Instrumentor instrumentor(obj, ROCJITSU_CODE_ARCH_CDNA4);
+  // First call: no queued points — fatal error.
+  auto first = instrumentor.patch_relocation_only();
+  ASSERT_FALSE(first.errors.empty()) << "first call must fail with zero points";
+
+  // Try to recover by queueing a valid point and calling again.
+  instrumentor.add_point_by_offset(4);
+  auto second = instrumentor.patch_relocation_only();
+  EXPECT_TRUE(second.elf_bytes.empty()) << "single-attempt budget must already be spent";
+  EXPECT_TRUE(second.patches.empty());
+  EXPECT_FALSE(second.errors.empty());
+}
+
+TEST(InstrumentorPatch, RejectsMultiTextCodeObject) {
+  auto image = make_gfx950_elf_with_two_text_sections();
+  AmdGpuCodeObject obj(image.data(), image.size());
+  ASSERT_TRUE(obj.is_valid());
+  // Precondition for the test to be meaningful: the loader actually produced
+  // two .text sections.
+  ASSERT_EQ(obj.text_sections().size(), 2u)
+      << "fixture must yield multi-text; got " << obj.text_sections().size();
+
+  Instrumentor instrumentor(obj, ROCJITSU_CODE_ARCH_CDNA4);
+  instrumentor.add_point_by_offset(0);
+  auto result = instrumentor.patch_relocation_only();
+  EXPECT_TRUE(result.elf_bytes.empty());
+  EXPECT_TRUE(result.patches.empty());
+  EXPECT_FALSE(result.errors.empty());
+}
+
+// Branch-range overflow at the orchestrator level. The trampoline is placed
+// at .text_size; with anchor at offset 0 we need .text_size > 131072 to push
+// forward_simm16 past INT16_MAX. .text_size = 131076 gives forward_simm16 =
+// 32768 → overflow. The builder returns an error; patch_relocation_only must
+// surface it and emit no ELF.
+TEST(InstrumentorPatch, BranchRangeOverflowPropagatesAsFatalError) {
+  // 32769 × 4 = 131076 bytes of s_nop in .text.
+  auto image = make_gfx950_elf_with_nop_text(/*text_size=*/131076);
+  AmdGpuCodeObject obj(image.data(), image.size());
+  ASSERT_TRUE(obj.is_valid());
+
+  Instrumentor instrumentor(obj, ROCJITSU_CODE_ARCH_CDNA4);
+  instrumentor.add_point_by_offset(/*anchor_offset=*/0);
+  auto result = instrumentor.patch_relocation_only();
+
+  EXPECT_TRUE(result.elf_bytes.empty()) << "overflow must not leak a half-built ELF";
+  EXPECT_TRUE(result.patches.empty());
+  ASSERT_FALSE(result.errors.empty());
+  // The builder's diagnostic mentions "forward branch ... exceeds s_branch simm16".
+  EXPECT_NE(result.errors.front().find("forward"), std::string::npos)
+      << "diagnostic must identify the forward branch; got: " << result.errors.front();
+}
+
+//==============================================================================
+// Section 5: Patched ELF shape (reparse)
+//
+// Builds, instruments, and reparses once via TEST_F SetUp. Each test then
+// asserts one structural property of the emitted ELF.
+//==============================================================================
+
+class InstrumentorPatchElfShape : public ::testing::Test {
+protected:
+  void SetUp() override {
+    image_ = make_gfx950_elf_with_two_nops();
+    AmdGpuCodeObject obj(image_.data(), image_.size());
+    ASSERT_TRUE(obj.is_valid());
+
+    Instrumentor instrumentor(obj, ROCJITSU_CODE_ARCH_CDNA4);
+    instrumentor.add_point_by_offset(/*anchor_offset=*/4);
+    result_ = instrumentor.patch_relocation_only();
+    ASSERT_TRUE(result_.errors.empty())
+        << (result_.errors.empty() ? std::string{} : result_.errors.front());
+    ASSERT_FALSE(result_.elf_bytes.empty());
+
+    patched_ = std::make_unique<AmdGpuCodeObject>(result_.elf_bytes.data(),
+                                                  result_.elf_bytes.size());
+    ASSERT_TRUE(patched_->is_valid());
+  }
+
+  const Section *find_section(std::string_view name) const {
+    for (const Section *s : patched_->code_sections())
+      if (s->name() == name) return s;
+    return nullptr;
+  }
+
+  std::vector<uint8_t> image_;
+  InstrumentedCodeObject result_;
+  std::unique_ptr<AmdGpuCodeObject> patched_;
+};
+
+TEST_F(InstrumentorPatchElfShape, RjTrampolinesSectionExists) {
+  ASSERT_NE(find_section(".rj_trampolines"), nullptr)
+      << ".rj_trampolines must appear in code_sections()";
+}
+
+TEST_F(InstrumentorPatchElfShape, RjTrampolinesIsExecutable) {
+  const Section *tramp = find_section(".rj_trampolines");
+  ASSERT_NE(tramp, nullptr);
+  EXPECT_NE(tramp->flags() & SHF_EXECINSTR, 0u)
+      << ".rj_trampolines must have SHF_EXECINSTR";
+}
+
+TEST_F(InstrumentorPatchElfShape, RjTrampolinesPlacedImmediatelyAfterText) {
+  const Section *text = find_section(".text");
+  const Section *tramp = find_section(".rj_trampolines");
+  ASSERT_NE(text, nullptr);
+  ASSERT_NE(tramp, nullptr);
+  EXPECT_EQ(tramp->sectionOffset(), text->sectionOffset() + text->size())
+      << ".rj_trampolines must start at the byte immediately after .text";
+}
+
+TEST_F(InstrumentorPatchElfShape, RjTrampolinesContentsMatchExpectedWords) {
+  const Section *tramp = find_section(".rj_trampolines");
+  ASSERT_NE(tramp, nullptr);
+
+  // Body for the inline-nop smoke build with a 4-byte anchor:
+  //   [placeholder s_nop 0, relocated original s_nop 0, return s_branch(-3)].
+  ASSERT_EQ(tramp->size(), 12u);
+  std::array<uint32_t, 3> words{};
+  std::memcpy(words.data(), tramp->data(), tramp->size());
+
+  constexpr rj_code_arch_t kArch = ROCJITSU_CODE_ARCH_CDNA4;
+  EXPECT_EQ(words[0], build_s_nop(0, kArch))
+      << "trampoline body must start with the placeholder s_nop 0";
+  EXPECT_EQ(words[1], 0xBF800000u) // original s_nop 0 from .text[4..8)
+      << "trampoline body must contain the relocated original instruction unchanged";
+  EXPECT_EQ(words[2], build_s_branch(-3, kArch))
+      << "trampoline must end with s_branch back to anchor + original_size";
+}
+
+TEST_F(InstrumentorPatchElfShape, CodeSectionsIncludesTextAndTrampoline) {
+  bool saw_text = false;
+  bool saw_tramp = false;
+  for (const Section *s : patched_->code_sections()) {
+    if (s->name() == ".text") saw_text = true;
+    if (s->name() == ".rj_trampolines") saw_tramp = true;
+  }
+  EXPECT_TRUE(saw_text) << "code_sections() must include .text";
+  EXPECT_TRUE(saw_tramp) << "code_sections() must include .rj_trampolines";
+}
+
+//==============================================================================
+// Section 6: Patched code decoded back through the real Decoder
+//
+// Verifies that the bytes the orchestrator emits are recognized by the
+// decoder as the instructions we intended, with the expected flags and
+// branch-offset signs. Complements Section 5, which only checks
+// byte-equality against the builder's output.
+//==============================================================================
+
+class InstrumentorPatchDecoded : public ::testing::Test {
+protected:
+  void SetUp() override {
+    image_ = make_gfx950_elf_with_two_nops();
+    AmdGpuCodeObject obj(image_.data(), image_.size());
+    ASSERT_TRUE(obj.is_valid());
+
+    Instrumentor instrumentor(obj, ROCJITSU_CODE_ARCH_CDNA4);
+    instrumentor.add_point_by_offset(/*anchor_offset=*/4);
+    result_ = instrumentor.patch_relocation_only();
+    ASSERT_TRUE(result_.errors.empty())
+        << (result_.errors.empty() ? std::string{} : result_.errors.front());
+    ASSERT_FALSE(result_.elf_bytes.empty());
+
+    patched_ = std::make_unique<AmdGpuCodeObject>(result_.elf_bytes.data(),
+                                                  result_.elf_bytes.size());
+    ASSERT_TRUE(patched_->is_valid());
+
+    decoder_ = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    ASSERT_NE(decoder_, nullptr);
+  }
+
+  const Section *find_section(std::string_view name) const {
+    for (const Section *s : patched_->code_sections())
+      if (s->name() == name) return s;
+    return nullptr;
+  }
+
+  std::unique_ptr<Instruction> decode_word(const Section *section, size_t byte_offset) {
+    rj_code_binary_inst_t word = 0;
+    std::memcpy(&word, section->data() + byte_offset, sizeof(word));
+    return std::unique_ptr<Instruction>(decoder_->decode(&word));
+  }
+
+  std::vector<uint8_t> image_;
+  InstrumentedCodeObject result_;
+  std::unique_ptr<AmdGpuCodeObject> patched_;
+  std::unique_ptr<Decoder> decoder_;
+};
+
+TEST_F(InstrumentorPatchDecoded, PatchedAnchorDecodesAsForwardSBranch) {
+  const Section *text = find_section(".text");
+  ASSERT_NE(text, nullptr);
+  auto inst = decode_word(text, /*byte_offset=*/4);
+  ASSERT_NE(inst, nullptr);
+
+  EXPECT_NE(inst->mnemonic().find("s_branch"), std::string_view::npos)
+      << "mnemonic was: " << inst->mnemonic();
+  EXPECT_NE(inst->flags() & BRANCH, 0u) << "patched anchor must carry BRANCH flag";
+  ASSERT_TRUE(inst->branch_offset_bytes().has_value())
+      << "patched anchor must report a PC-relative branch offset";
+  EXPECT_GE(*inst->branch_offset_bytes(), 0)
+      << "forward branch offset must be non-negative; got "
+      << *inst->branch_offset_bytes();
+}
+
+TEST_F(InstrumentorPatchDecoded, UnpatchedTextInstructionIsUnchanged) {
+  // The first s_nop at .text[0..4] was not the anchor. Decoder must still see
+  // it as s_nop — proves the patcher did not accidentally touch it.
+  const Section *text = find_section(".text");
+  ASSERT_NE(text, nullptr);
+  auto inst = decode_word(text, /*byte_offset=*/0);
+  ASSERT_NE(inst, nullptr);
+  EXPECT_NE(inst->mnemonic().find("s_nop"), std::string_view::npos)
+      << "unpatched .text instruction must remain s_nop; got " << inst->mnemonic();
+  EXPECT_EQ(inst->flags() & BRANCH, 0u);
+  EXPECT_FALSE(inst->branch_offset_bytes().has_value());
+}
+
+TEST_F(InstrumentorPatchDecoded, TrampolinePlaceholderDecodesAsSNop) {
+  const Section *tramp = find_section(".rj_trampolines");
+  ASSERT_NE(tramp, nullptr);
+  auto inst = decode_word(tramp, /*byte_offset=*/0);
+  ASSERT_NE(inst, nullptr);
+
+  EXPECT_NE(inst->mnemonic().find("s_nop"), std::string_view::npos)
+      << "mnemonic was: " << inst->mnemonic();
+  EXPECT_EQ(inst->flags() & BRANCH, 0u) << "placeholder must not be marked as a branch";
+  EXPECT_FALSE(inst->branch_offset_bytes().has_value())
+      << "placeholder must not carry a branch offset";
+}
+
+TEST_F(InstrumentorPatchDecoded, RelocatedOriginalPreservesMnemonic) {
+  // The original instruction at .text[4..8] was s_nop 0. After relocation it
+  // lives in the trampoline body at offset 4. Decoded bytes must agree.
+  const Section *tramp = find_section(".rj_trampolines");
+  ASSERT_NE(tramp, nullptr);
+  auto relocated = decode_word(tramp, /*byte_offset=*/4);
+  ASSERT_NE(relocated, nullptr);
+  EXPECT_NE(relocated->mnemonic().find("s_nop"), std::string_view::npos)
+      << "relocated original must decode to the same mnemonic as the source; got "
+      << relocated->mnemonic();
+}
+
+TEST_F(InstrumentorPatchDecoded, TrampolineReturnDecodesAsBackwardSBranch) {
+  const Section *tramp = find_section(".rj_trampolines");
+  ASSERT_NE(tramp, nullptr);
+  auto inst = decode_word(tramp, /*byte_offset=*/8);
+  ASSERT_NE(inst, nullptr);
+
+  EXPECT_NE(inst->mnemonic().find("s_branch"), std::string_view::npos)
+      << "mnemonic was: " << inst->mnemonic();
+  EXPECT_NE(inst->flags() & BRANCH, 0u) << "return must carry BRANCH flag";
+  ASSERT_TRUE(inst->branch_offset_bytes().has_value())
+      << "return must report a PC-relative branch offset";
+  EXPECT_LT(*inst->branch_offset_bytes(), 0)
+      << "return branch offset must be negative; got "
+      << *inst->branch_offset_bytes();
+}
+
+// End-to-end behavioral check: decode the patched s_branch and the return
+// s_branch, compute their actual landing addresses from the raw SOPP simm16,
+// and assert they hit the expected .text-relative offsets. This pins the one
+// promise PC01-A is fundamentally about — the round trip through the
+// trampoline lands the program right back at anchor + original_size.
+//
+// SOPP semantics: target = branch_pc + 4 + simm16 * 4.
+TEST_F(InstrumentorPatchDecoded, BranchesLandAtTheirIntendedTargets) {
+  const Section *text = find_section(".text");
+  const Section *tramp = find_section(".rj_trampolines");
+  ASSERT_NE(text, nullptr);
+  ASSERT_NE(tramp, nullptr);
+
+  auto sopp_target = [](uint64_t branch_pc, const uint32_t *word) -> uint64_t {
+    const int16_t simm16 = static_cast<int16_t>(*word & 0xFFFFu);
+    return branch_pc + 4 + static_cast<int64_t>(simm16) * 4;
+  };
+
+  // Forward branch lives at .text-relative offset 4 (the patched anchor).
+  // It should land at trampoline_offset == text->size() (== 8 in this fixture).
+  auto fwd = decode_word(text, /*byte_offset=*/4);
+  ASSERT_NE(fwd, nullptr);
+  ASSERT_NE(fwd->raw_encoding(), nullptr);
+  const uint64_t fwd_target = sopp_target(/*branch_pc=*/4, fwd->raw_encoding());
+  EXPECT_EQ(fwd_target, text->size())
+      << "forward branch must land at trampoline_offset (= text->size())";
+
+  // Return branch lives at trampoline-section-relative offset 8. In
+  // .text-relative coordinates that is text->size() + 8 (= 16 in this fixture).
+  // It should land at anchor_offset + original_size = 4 + 4 = 8.
+  auto ret = decode_word(tramp, /*byte_offset=*/8);
+  ASSERT_NE(ret, nullptr);
+  ASSERT_NE(ret->raw_encoding(), nullptr);
+  const uint64_t ret_pc = text->size() + 8;
+  const uint64_t ret_target = sopp_target(ret_pc, ret->raw_encoding());
+  EXPECT_EQ(ret_target, 8u) << "return branch must land at anchor + original_size";
+}
+
+} // namespace
+} // namespace rocjitsu

--- a/emulation/rocjitsu/tests/patch/instrumentor_test.cpp
+++ b/emulation/rocjitsu/tests/patch/instrumentor_test.cpp
@@ -17,6 +17,7 @@
 #include <array>
 #include <cstdint>
 #include <cstring>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <span>
@@ -164,6 +165,19 @@ TEST(Validator, RejectsOutOfBoundsOffset) {
   EXPECT_FALSE(
       validate_anchor(anchor, /*anchor_offset=*/4, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err)
           .has_value());
+  EXPECT_FALSE(err.empty());
+}
+
+TEST(Validator, RejectsOffsetThatWouldOverflow) {
+  // Pure predicate: huge offset must fail closed, not wrap the bounds check.
+  static constexpr uint32_t kRaw = 0xDEADBEEFu;
+  TestInstruction anchor("v_add_f32_e32", 4, 0, std::nullopt, &kRaw);
+  auto text = dummy_text();
+  // UINT64_MAX - 3 is dword aligned (UINT64_MAX = 2^64 - 1 ≡ 3 mod 4) and
+  // anchor_offset + 4 would wrap to 0 with the old additive check.
+  const uint64_t huge_offset = std::numeric_limits<uint64_t>::max() - 3;
+  std::string err;
+  EXPECT_FALSE(is_relocatable_anchor(anchor, huge_offset, text, ROCJITSU_CODE_ARCH_CDNA4, &err));
   EXPECT_FALSE(err.empty());
 }
 
@@ -589,6 +603,29 @@ TEST(Instrumentor, AddPointByOffsetResolvesValidatedSite) {
       << "mnemonic was: " << result.sites[0].mnemonic;
 }
 
+TEST(Instrumentor, UnsupportedArchReportsErrorInsteadOfCrashing) {
+  // Decoder::create returns nullptr for RV32I/RV64I/INVALID. The Instrumentor
+  // must surface that as a structured ValidationResult error rather than
+  // dereferencing a null decoder during block construction.
+  auto image = make_gfx950_elf_with_two_nops();
+  AmdGpuCodeObject obj(image.data(), image.size());
+  ASSERT_TRUE(obj.is_valid());
+
+  Instrumentor instrumentor(obj, ROCJITSU_CODE_ARCH_RV32I);
+  instrumentor.add_point_by_offset(/*anchor_offset=*/4);
+
+  auto result = instrumentor.validate_points();
+  EXPECT_TRUE(result.sites.empty());
+  ASSERT_FALSE(result.errors.empty());
+
+  // patch() must surface the same error rather than crashing.
+  Instrumentor instrumentor2(obj, ROCJITSU_CODE_ARCH_RV32I);
+  instrumentor2.add_point_by_offset(/*anchor_offset=*/4);
+  auto patched = instrumentor2.patch();
+  EXPECT_TRUE(patched.elf_bytes.empty());
+  ASSERT_FALSE(patched.errors.empty());
+}
+
 //==============================================================================
 // Section 4: Instrumentor::patch end-to-end
 //
@@ -610,7 +647,7 @@ TEST(InstrumentorPatch, EmitsValidElfWithExpectedPatchSummary) {
   Instrumentor instrumentor(obj, ROCJITSU_CODE_ARCH_CDNA4);
   instrumentor.add_point_by_offset(/*anchor_offset=*/4);
 
-  auto result = instrumentor.patch();
+  auto result = instrumentor.patch_with_debug_summaries();
   ASSERT_TRUE(result.errors.empty())
       << (result.errors.empty() ? std::string{} : result.errors.front());
   EXPECT_FALSE(result.elf_bytes.empty());
@@ -646,7 +683,6 @@ TEST(InstrumentorPatch, RejectsZeroQueuedPoints) {
 
   auto result = instrumentor.patch();
   EXPECT_TRUE(result.elf_bytes.empty());
-  EXPECT_TRUE(result.patches.empty());
   EXPECT_FALSE(result.errors.empty());
 }
 
@@ -659,7 +695,6 @@ TEST(InstrumentorPatch, RejectsMoreThanOneQueuedPoint) {
 
   auto result = instrumentor.patch();
   EXPECT_TRUE(result.elf_bytes.empty());
-  EXPECT_TRUE(result.patches.empty());
   EXPECT_FALSE(result.errors.empty());
 }
 
@@ -672,7 +707,6 @@ TEST(InstrumentorPatch, ValidationFailurePropagates) {
 
   auto result = instrumentor.patch();
   EXPECT_TRUE(result.elf_bytes.empty());
-  EXPECT_TRUE(result.patches.empty());
   EXPECT_FALSE(result.errors.empty());
 }
 
@@ -688,7 +722,6 @@ TEST(InstrumentorPatch, IsSingleCall) {
 
   auto second = instrumentor.patch();
   EXPECT_TRUE(second.elf_bytes.empty());
-  EXPECT_TRUE(second.patches.empty());
   EXPECT_FALSE(second.errors.empty());
 }
 
@@ -707,7 +740,6 @@ TEST(InstrumentorPatch, FailedFirstCallStillBurnsSingleAttemptBudget) {
   instrumentor.add_point_by_offset(4);
   auto second = instrumentor.patch();
   EXPECT_TRUE(second.elf_bytes.empty()) << "single-attempt budget must already be spent";
-  EXPECT_TRUE(second.patches.empty());
   EXPECT_FALSE(second.errors.empty());
 }
 
@@ -724,7 +756,6 @@ TEST(InstrumentorPatch, RejectsMultiTextCodeObject) {
   instrumentor.add_point_by_offset(0);
   auto result = instrumentor.patch();
   EXPECT_TRUE(result.elf_bytes.empty());
-  EXPECT_TRUE(result.patches.empty());
   EXPECT_FALSE(result.errors.empty());
 }
 
@@ -744,7 +775,6 @@ TEST(InstrumentorPatch, BranchRangeOverflowPropagatesAsFatalError) {
   auto result = instrumentor.patch();
 
   EXPECT_TRUE(result.elf_bytes.empty()) << "overflow must not leak a half-built ELF";
-  EXPECT_TRUE(result.patches.empty());
   ASSERT_FALSE(result.errors.empty());
   // The builder's diagnostic mentions "forward branch ... exceeds s_branch simm16".
   EXPECT_NE(result.errors.front().find("forward"), std::string::npos)

--- a/emulation/rocjitsu/tests/patch/instrumentor_test.cpp
+++ b/emulation/rocjitsu/tests/patch/instrumentor_test.cpp
@@ -306,7 +306,7 @@ TEST(InlineNopGuardrail, RejectsNonCanonicalBody) {
 // Section 2: make_trampoline_plan
 //==============================================================================
 
-TEST(MakeRelocationOnlyPlan, FillsCanonicalBodyAndCopiesSiteFields) {
+TEST(MakeTrampolinePlan, FillsCanonicalBodyAndCopiesSiteFields) {
   constexpr rj_code_arch_t kArch = ROCJITSU_CODE_ARCH_CDNA4;
   ResolvedInstrumentationSite site;
   site.anchor_offset = 0x100;
@@ -578,7 +578,7 @@ TEST(Instrumentor, AddPointByOffsetResolvesValidatedSite) {
   Instrumentor instrumentor(obj, ROCJITSU_CODE_ARCH_CDNA4);
   instrumentor.add_point_by_offset(/*anchor_offset=*/4);
 
-  auto result = instrumentor.resolve_and_validate();
+  auto result = instrumentor.validate_points();
   ASSERT_TRUE(result.errors.empty())
       << (result.errors.empty() ? std::string{} : result.errors.front());
   ASSERT_EQ(result.sites.size(), 1u);
@@ -587,84 +587,6 @@ TEST(Instrumentor, AddPointByOffsetResolvesValidatedSite) {
   EXPECT_EQ(result.sites[0].original_bytes.size(), 4u);
   EXPECT_NE(result.sites[0].mnemonic.find("s_nop"), std::string::npos)
       << "mnemonic was: " << result.sites[0].mnemonic;
-}
-
-TEST(Instrumentor, AnchorInstFromOwnedBlockResolves) {
-  auto image = make_gfx950_elf_with_two_nops();
-  AmdGpuCodeObject obj(image.data(), image.size());
-  ASSERT_TRUE(obj.is_valid());
-
-  Instrumentor instrumentor(obj, ROCJITSU_CODE_ARCH_CDNA4);
-  auto blocks = instrumentor.owned_blocks();
-  ASSERT_FALSE(blocks.empty());
-
-  // Pick the second instruction in the first block.
-  const Instruction *second = nullptr;
-  size_t i = 0;
-  for (const Instruction &inst : blocks.front()->instructions()) {
-    if (i++ == 1) {
-      second = &inst;
-      break;
-    }
-  }
-  ASSERT_NE(second, nullptr);
-
-  InstrumentationPoint pt;
-  pt.anchor_inst = second;
-  instrumentor.add_point(pt);
-
-  auto result = instrumentor.resolve_and_validate();
-  ASSERT_TRUE(result.errors.empty())
-      << (result.errors.empty() ? std::string{} : result.errors.front());
-  ASSERT_EQ(result.sites.size(), 1u);
-  EXPECT_EQ(result.sites[0].anchor_offset, 4u);
-  EXPECT_EQ(result.sites[0].anchor_inst, second);
-}
-
-TEST(Instrumentor, AnchorInstNotInOwnedBlocksFails) {
-  auto image = make_gfx950_elf_with_two_nops();
-  AmdGpuCodeObject obj(image.data(), image.size());
-
-  Instrumentor instrumentor(obj, ROCJITSU_CODE_ARCH_CDNA4);
-
-  // External Instruction not from instrumentor's owned blocks.
-  static constexpr uint32_t kRaw = 0xBF800000u;
-  TestInstruction external("s_nop", 4, 0, std::nullopt, &kRaw);
-
-  InstrumentationPoint pt;
-  pt.anchor_inst = &external;
-  instrumentor.add_point(pt);
-
-  auto result = instrumentor.resolve_and_validate();
-  EXPECT_TRUE(result.sites.empty());
-  EXPECT_FALSE(result.errors.empty());
-}
-
-TEST(Instrumentor, MutuallyExclusiveAnchorFieldsFails) {
-  auto image = make_gfx950_elf_with_two_nops();
-  AmdGpuCodeObject obj(image.data(), image.size());
-
-  // Both set.
-  {
-    static constexpr uint32_t kRaw = 0xBF800000u;
-    TestInstruction inst("s_nop", 4, 0, std::nullopt, &kRaw);
-    InstrumentationPoint pt;
-    pt.anchor_inst = &inst;
-    pt.anchor_offset = 0;
-    Instrumentor i2(obj, ROCJITSU_CODE_ARCH_CDNA4);
-    i2.add_point(pt);
-    auto result = i2.resolve_and_validate();
-    EXPECT_FALSE(result.errors.empty()) << "both anchor_inst and anchor_offset set";
-  }
-
-  // Neither set.
-  {
-    InstrumentationPoint pt;
-    Instrumentor i3(obj, ROCJITSU_CODE_ARCH_CDNA4);
-    i3.add_point(pt);
-    auto result = i3.resolve_and_validate();
-    EXPECT_FALSE(result.errors.empty()) << "neither anchor_inst nor anchor_offset set";
-  }
 }
 
 //==============================================================================

--- a/emulation/rocjitsu/tests/patch/instrumentor_test.cpp
+++ b/emulation/rocjitsu/tests/patch/instrumentor_test.cpp
@@ -603,6 +603,41 @@ TEST(Instrumentor, AddPointByOffsetResolvesValidatedSite) {
       << "mnemonic was: " << result.sites[0].mnemonic;
 }
 
+TEST(Instrumentor, ResolvesAnchorAtOffsetZero) {
+  // Boundary: the first instruction starts at .text offset 0. Exercises the
+  // offset→Instruction map's zero key alongside the offset-4 case above.
+  auto image = make_gfx950_elf_with_two_nops();
+  AmdGpuCodeObject obj(image.data(), image.size());
+  ASSERT_TRUE(obj.is_valid());
+
+  Instrumentor instrumentor(obj, ROCJITSU_CODE_ARCH_CDNA4);
+  instrumentor.add_point_by_offset(/*anchor_offset=*/0);
+
+  auto result = instrumentor.validate_points();
+  ASSERT_TRUE(result.errors.empty())
+      << (result.errors.empty() ? std::string{} : result.errors.front());
+  ASSERT_EQ(result.sites.size(), 1u);
+  EXPECT_EQ(result.sites[0].anchor_offset, 0u);
+}
+
+TEST(Instrumentor, RejectsAlignedOffsetPastLastInstruction) {
+  // Aligned and looks plausible, but no instruction starts at offset 8 in a
+  // 2-nop (8-byte) .text. The offset→Instruction map must miss rather than
+  // extrapolate past its populated keys.
+  auto image = make_gfx950_elf_with_two_nops();
+  AmdGpuCodeObject obj(image.data(), image.size());
+  ASSERT_TRUE(obj.is_valid());
+
+  Instrumentor instrumentor(obj, ROCJITSU_CODE_ARCH_CDNA4);
+  instrumentor.add_point_by_offset(/*anchor_offset=*/8);
+
+  auto result = instrumentor.validate_points();
+  EXPECT_TRUE(result.sites.empty());
+  ASSERT_FALSE(result.errors.empty());
+  EXPECT_NE(result.errors.front().find("no decoded instruction"), std::string::npos)
+      << "error was: " << result.errors.front();
+}
+
 TEST(Instrumentor, UnsupportedArchReportsErrorInsteadOfCrashing) {
   // Decoder::create returns nullptr for RV32I/RV64I/INVALID. The Instrumentor
   // must surface that as a structured ValidationResult error rather than

--- a/emulation/rocjitsu/tests/patch/instrumentor_test.cpp
+++ b/emulation/rocjitsu/tests/patch/instrumentor_test.cpp
@@ -242,13 +242,31 @@ TEST(Validator, RejectsDenylistedMnemonic) {
   InstrumentationPoint pt;
 
   // PC-relative semantics that may not surface in flags / branch_offset_bytes.
-  for (const char *m : {"s_getpc_b64", "s_call_b64", "s_setpc_b64", "s_swappc_b64", "s_rfe_b64"}) {
+  // Includes gfx1250's renamed _i64 family (s_getpc_b64 -> s_get_pc_i64, etc.);
+  // s_rfe_b64 / s_rfe_i64 exercise the s_rfe_ prefix match.
+  for (const char *m :
+       {"s_getpc_b64", "s_call_b64", "s_setpc_b64", "s_swappc_b64", "s_rfe_b64", "s_get_pc_i64",
+        "s_call_i64", "s_set_pc_i64", "s_swap_pc_i64", "s_rfe_i64"}) {
     TestInstruction anchor(m, 4, /*flags=*/0, std::nullopt, &kRaw);
     std::string err;
     EXPECT_FALSE(validate_anchor(anchor, 0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value())
         << "mnemonic " << m << " should be rejected";
     EXPECT_FALSE(err.empty());
   }
+}
+
+// Instruction::size() is a signed int; the `size != 4 && size != 8` check must
+// reject negative sizes (which decoders never emit in practice) rather than let
+// them through to the later cast to unsigned, where they would wrap.
+TEST(Validator, RejectsNegativeInstructionSize) {
+  static constexpr uint32_t kRaw = 0xDEADBEEFu;
+  TestInstruction anchor("v_add_f32_e32", /*size=*/-4, /*flags=*/0, std::nullopt, &kRaw);
+  auto text = dummy_text();
+
+  std::string err;
+  EXPECT_FALSE(
+      is_relocatable_anchor(anchor, /*anchor_offset=*/0, text, ROCJITSU_CODE_ARCH_CDNA4, &err));
+  EXPECT_NE(err.find("size must be 4 or 8"), std::string::npos) << "error was: " << err;
 }
 
 //==============================================================================
@@ -375,9 +393,12 @@ uint64_t align_up_for_test(uint64_t value, uint64_t alignment) {
 // forward-branch overflow test, which needs .text large enough that the
 // trampoline (placed at text_size) is more than INT16_MAX dwords past offset
 // 0.
-std::vector<uint8_t> make_gfx950_elf_with_nop_text(uint64_t text_size) {
-  // Must be a multiple of 4 so the entire section is decodable as s_nop words.
+// Build a minimal gfx950 ELF whose .text holds @p words verbatim. Lets a test
+// embed a real multi-word instruction (e.g. an 8-byte SOP1 + literal) rather
+// than only s_nop fillers.
+std::vector<uint8_t> make_gfx950_elf_with_text_words(const std::vector<uint32_t> &words) {
   const uint64_t text_offset = 0x100;
+  const uint64_t text_size = words.size() * sizeof(uint32_t);
   const uint64_t rodata_size = 4;
 
   std::vector<uint8_t> shstrtab{'\0'};
@@ -407,10 +428,7 @@ std::vector<uint8_t> make_gfx950_elf_with_nop_text(uint64_t text_size) {
   ehdr.e_shstrndx = 3;
   std::memcpy(image.data(), &ehdr, sizeof(ehdr));
 
-  for (uint64_t off = 0; off < text_size; off += sizeof(uint32_t)) {
-    const uint32_t nop = 0xBF800000u;
-    std::memcpy(image.data() + text_offset + off, &nop, sizeof(nop));
-  }
+  std::memcpy(image.data() + text_offset, words.data(), text_size);
 
   const uint32_t rodata_word = 0xA5A55A5Au;
   std::memcpy(image.data() + rodata_offset, &rodata_word, sizeof(rodata_word));
@@ -439,6 +457,12 @@ std::vector<uint8_t> make_gfx950_elf_with_nop_text(uint64_t text_size) {
 
   std::memcpy(image.data() + shoff, shdrs.data(), shdrs.size() * sizeof(Elf64_Shdr));
   return image;
+}
+
+std::vector<uint8_t> make_gfx950_elf_with_nop_text(uint64_t text_size) {
+  // Must be a multiple of 4 so the entire section is decodable as s_nop words.
+  return make_gfx950_elf_with_text_words(
+      std::vector<uint32_t>(text_size / sizeof(uint32_t), 0xBF800000u));
 }
 
 // gfx950 ELF with TWO `.text` sections (both SHF_ALLOC | SHF_EXECINSTR, both
@@ -638,6 +662,26 @@ TEST(Instrumentor, RejectsAlignedOffsetPastLastInstruction) {
       << "error was: " << result.errors.front();
 }
 
+TEST(Instrumentor, RejectsOffsetInteriorToMultiWordInstruction) {
+  // .text: [s_mov_b32 s0, 0xDEADBEEF (8 bytes)][s_nop 0]. Offset 4 lands in the
+  // *interior* of the 8-byte instruction at offset 0, so no decoded instruction
+  // starts there -- a distinct miss from the past-the-end case above. The
+  // offset->Instruction map has keys 0 and 8 only.
+  const std::vector<uint32_t> words = {0xBE8000FFu, 0xDEADBEEFu, 0xBF800000u};
+  auto image = make_gfx950_elf_with_text_words(words);
+  AmdGpuCodeObject obj(image.data(), image.size());
+  ASSERT_TRUE(obj.is_valid());
+
+  Instrumentor instrumentor(obj, ROCJITSU_CODE_ARCH_CDNA4);
+  instrumentor.add_point_by_offset(/*anchor_offset=*/4);
+
+  auto result = instrumentor.validate_points();
+  EXPECT_TRUE(result.sites.empty());
+  ASSERT_FALSE(result.errors.empty());
+  EXPECT_NE(result.errors.front().find("no decoded instruction"), std::string::npos)
+      << "error was: " << result.errors.front();
+}
+
 TEST(Instrumentor, UnsupportedArchReportsErrorInsteadOfCrashing) {
   // Decoder::create returns nullptr for RV32I/RV64I/INVALID. The Instrumentor
   // must surface that as a structured ValidationResult error rather than
@@ -708,6 +752,90 @@ TEST(InstrumentorPatch, EmitsValidElfWithExpectedPatchSummary) {
   // Emitted ELF reparses cleanly.
   AmdGpuCodeObject patched(result.elf_bytes.data(), result.elf_bytes.size());
   EXPECT_TRUE(patched.is_valid());
+}
+
+// 8-byte anchor end-to-end. .text is [s_nop 0][s_mov_b32 s0, 0xDEADBEEF]; the
+// s_mov_b32 + literal at offset 4 is a real 8-byte instruction. This exercises
+// the orchestrator paths the 4-byte nop fixtures never reach: offset_to_inst_
+// advancing by 8, the 8-byte splice, the s_branch + s_nop 0 tail, and a
+// reparse/decode of the relocated 8-byte original from the trampoline cave.
+TEST(InstrumentorPatch, PatchesEightByteAnchorEndToEnd) {
+  constexpr uint32_t kSMovLitWord0 = 0xBE8000FFu; // s_mov_b32 s0, <literal>
+  constexpr uint32_t kSMovLitWord1 = 0xDEADBEEFu; // the 32-bit literal
+  const std::vector<uint32_t> words = {0xBF800000u, kSMovLitWord0, kSMovLitWord1};
+  auto image = make_gfx950_elf_with_text_words(words);
+  AmdGpuCodeObject obj(image.data(), image.size());
+  ASSERT_TRUE(obj.is_valid());
+
+  Instrumentor instrumentor(obj, ROCJITSU_CODE_ARCH_CDNA4);
+  instrumentor.add_point_by_offset(/*anchor_offset=*/4);
+
+  auto result = instrumentor.patch_with_debug_summaries();
+  ASSERT_TRUE(result.errors.empty())
+      << (result.errors.empty() ? std::string{} : result.errors.front());
+  ASSERT_EQ(result.patches.size(), 1u);
+
+  const auto &p = result.patches[0];
+  // The decoder saw an 8-byte instruction and the orchestrator carried that
+  // width through. Original .text is 3 words (12 bytes), so the trampoline cave
+  // begins at offset 12.
+  EXPECT_EQ(p.original_size, 8u);
+  EXPECT_EQ(p.anchor_offset, 4u);
+  EXPECT_EQ(p.trampoline_offset, 12u);
+  EXPECT_EQ(p.return_target, 12u); // anchor_offset + original_size
+
+  // Original 8 bytes captured verbatim.
+  ASSERT_EQ(p.original_bytes.size(), 8u);
+  std::array<uint32_t, 2> orig_words{};
+  std::memcpy(orig_words.data(), p.original_bytes.data(), orig_words.size() * sizeof(uint32_t));
+  EXPECT_EQ(orig_words[0], kSMovLitWord0);
+  EXPECT_EQ(orig_words[1], kSMovLitWord1);
+
+  // Patched anchor fills the full 8-byte slot: forward s_branch + s_nop 0 tail.
+  // Forward simm16 = (trampoline_offset - (anchor_offset + 4)) / 4 = (12 - 8)/4 = 1.
+  ASSERT_EQ(p.patched_anchor_bytes.size(), 8u);
+  std::array<uint32_t, 2> patched_words{};
+  std::memcpy(patched_words.data(), p.patched_anchor_bytes.data(),
+              patched_words.size() * sizeof(uint32_t));
+  EXPECT_EQ(patched_words[0], build_s_branch(1, ROCJITSU_CODE_ARCH_CDNA4));
+  EXPECT_EQ(patched_words[1], build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4));
+
+  // Reparse and decode out of the grown .text. The cave (tail of .text) for an
+  // 8-byte anchor is [s_nop 0][orig word0][orig word1][s_branch return] = 16
+  // bytes, so .text grows from 12 to 28 bytes.
+  AmdGpuCodeObject patched(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_TRUE(patched.is_valid());
+  ASSERT_FALSE(patched.text_sections().empty());
+  const Section *text = patched.text_sections().front();
+  ASSERT_EQ(text->size(), 28u);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+  ASSERT_NE(decoder, nullptr);
+  // Copy two words (8 bytes) so an 8-byte instruction has its literal available.
+  auto decode_at = [&](uint64_t off) {
+    std::array<rj_code_binary_inst_t, 2> w{};
+    std::memcpy(w.data(), text->data() + off, w.size() * sizeof(rj_code_binary_inst_t));
+    return std::unique_ptr<Instruction>(decoder->decode(w.data()));
+  };
+
+  // Patched anchor decodes as a forward s_branch.
+  auto anchor = decode_at(4);
+  ASSERT_NE(anchor, nullptr);
+  EXPECT_NE(anchor->mnemonic().find("s_branch"), std::string_view::npos)
+      << "mnemonic was: " << anchor->mnemonic();
+
+  // Cave placeholder decodes as s_nop; the relocated original (cave offset 4 ->
+  // .text offset 16) decodes back to the same 8-byte s_mov_b32.
+  auto placeholder = decode_at(12);
+  ASSERT_NE(placeholder, nullptr);
+  EXPECT_NE(placeholder->mnemonic().find("s_nop"), std::string_view::npos)
+      << "mnemonic was: " << placeholder->mnemonic();
+
+  auto relocated = decode_at(16);
+  ASSERT_NE(relocated, nullptr);
+  EXPECT_EQ(relocated->size(), 8) << "relocated original must decode as an 8-byte instruction";
+  EXPECT_NE(relocated->mnemonic().find("s_mov_b32"), std::string_view::npos)
+      << "mnemonic was: " << relocated->mnemonic();
 }
 
 TEST(InstrumentorPatch, RejectsZeroQueuedPoints) {

--- a/emulation/rocjitsu/tests/patch/instrumentor_test.cpp
+++ b/emulation/rocjitsu/tests/patch/instrumentor_test.cpp
@@ -817,6 +817,8 @@ protected:
   void Init(uint64_t num_elf_nops, uint64_t num_instrumentation_points) {
     // leaving anchor_offset = 0 empty, so will fail on num_elf_nops == num_instrumentation_points
     ASSERT_TRUE(num_elf_nops > num_instrumentation_points);
+    num_elf_nops_ = num_elf_nops;
+    num_points_ = num_instrumentation_points;
 
     image_ = make_gfx950_elf_with_nop_text(num_elf_nops * 4);
     AmdGpuCodeObject obj(image_.data(), image_.size());
@@ -837,73 +839,74 @@ protected:
   }
 
   const Section *find_section(std::string_view name) const {
-    for (const Section *s : patched_->code_sections())
+    for (const auto &s : patched_->all_sections())
       if (s->name() == name)
-        return s;
+        return s.get();
     return nullptr;
   }
 
+  // Byte size of the original .text before instrumentation.
+  uint64_t original_text_size() const { return num_elf_nops_ * sizeof(uint32_t); }
+  // Byte size of the appended trampoline cave: 3 words per inline-nop site.
+  uint64_t cave_size() const { return num_points_ * 3 * sizeof(uint32_t); }
+
+  // The trampoline cave lives at the tail of .text, immediately after the
+  // original bytes. Reads it back as decoded words.
+  std::vector<uint32_t> cave_words() const {
+    const Section *text = find_section(".text");
+    EXPECT_NE(text, nullptr);
+    std::vector<uint32_t> words(cave_size() / sizeof(uint32_t));
+    if (text != nullptr)
+      std::memcpy(words.data(), text->data() + original_text_size(), cave_size());
+    return words;
+  }
+
+  uint64_t num_elf_nops_ = 0;
+  uint64_t num_points_ = 0;
   std::vector<uint8_t> image_;
   InstrumentedCodeObject result_;
   std::unique_ptr<AmdGpuCodeObject> patched_;
 };
 
-TEST_F(InstrumentorPatchElfShape, RjTrampolinesSectionExists) {
-  Init(2, 1);
-  ASSERT_NE(find_section(".rj_trampolines"), nullptr)
-      << ".rj_trampolines must appear in code_sections()";
-}
-
-TEST_F(InstrumentorPatchElfShape, RjTrampolinesMultipleSectionExists) {
-  Init(100, 50);
-  ASSERT_NE(find_section(".rj_trampolines"), nullptr)
-      << ".rj_trampolines must appear in code_sections()";
-}
-
-TEST_F(InstrumentorPatchElfShape, RjTrampolinesIsExecutable) {
-  Init(2, 1);
-  const Section *tramp = find_section(".rj_trampolines");
-  ASSERT_NE(tramp, nullptr);
-  EXPECT_NE(tramp->flags() & SHF_EXECINSTR, 0u) << ".rj_trampolines must have SHF_EXECINSTR";
-}
-
-TEST_F(InstrumentorPatchElfShape, RjTrampolinesMultipleIsExecutable) {
-  Init(100, 50);
-  const Section *tramp = find_section(".rj_trampolines");
-  ASSERT_NE(tramp, nullptr);
-  EXPECT_NE(tramp->flags() & SHF_EXECINSTR, 0u) << ".rj_trampolines must have SHF_EXECINSTR";
-}
-
-TEST_F(InstrumentorPatchElfShape, RjTrampolinesPlacedImmediatelyAfterText) {
+TEST_F(InstrumentorPatchElfShape, TrampolineCaveAppendedToText) {
   Init(2, 1);
   const Section *text = find_section(".text");
-  const Section *tramp = find_section(".rj_trampolines");
   ASSERT_NE(text, nullptr);
-  ASSERT_NE(tramp, nullptr);
-  EXPECT_EQ(tramp->sectionOffset(), text->sectionOffset() + text->size())
-      << ".rj_trampolines must start at the byte immediately after .text";
+  EXPECT_EQ(text->size(), original_text_size() + cave_size())
+      << ".text must grow by exactly the appended trampoline cave";
 }
 
-TEST_F(InstrumentorPatchElfShape, RjTrampolinesMultiplePlacedImmediatelyAfterText) {
+TEST_F(InstrumentorPatchElfShape, TrampolineCaveAppendedToTextMultiple) {
   Init(100, 50);
   const Section *text = find_section(".text");
-  const Section *tramp = find_section(".rj_trampolines");
   ASSERT_NE(text, nullptr);
-  ASSERT_NE(tramp, nullptr);
-  EXPECT_EQ(tramp->sectionOffset(), text->sectionOffset() + text->size())
-      << ".rj_trampolines must start at the byte immediately after .text";
+  EXPECT_EQ(text->size(), original_text_size() + cave_size())
+      << ".text must grow by exactly the appended trampoline cave";
 }
 
-TEST_F(InstrumentorPatchElfShape, RjTrampolinesContentsMatchExpectedWords) {
+TEST_F(InstrumentorPatchElfShape, TextRemainsExecutable) {
   Init(2, 1);
-  const Section *tramp = find_section(".rj_trampolines");
-  ASSERT_NE(tramp, nullptr);
+  // The cave is part of .text, so it inherits .text's executable flag
+  const Section *text = find_section(".text");
+  ASSERT_NE(text, nullptr);
+  EXPECT_NE(text->flags() & SHF_EXECINSTR, 0u) << ".text must have SHF_EXECINSTR";
+}
 
+TEST_F(InstrumentorPatchElfShape, TextRemainsExecutableMultiple) {
+  Init(100, 50);
+  const Section *text = find_section(".text");
+  ASSERT_NE(text, nullptr);
+  EXPECT_NE(text->flags() & SHF_EXECINSTR, 0u) << ".text must have SHF_EXECINSTR";
+}
+
+TEST_F(InstrumentorPatchElfShape, TrampolineCaveContentsMatchExpectedWords) {
+  Init(2, 1);
   // Body for the inline-nop smoke build with a 4-byte anchor:
   //   [placeholder s_nop 0, relocated original s_nop 0, return s_branch(-3)].
-  ASSERT_EQ(tramp->size(), 12u);
-  std::array<uint32_t, 3> words{};
-  std::memcpy(words.data(), tramp->data(), tramp->size());
+  // The cave's absolute offset is unchanged from the old separate-section
+  // layout (still text_size()), so the branch math is identical.
+  const std::vector<uint32_t> words = cave_words();
+  ASSERT_EQ(words.size(), 3u);
 
   constexpr rj_code_arch_t kArch = ROCJITSU_CODE_ARCH_CDNA4;
   EXPECT_EQ(words[0], build_s_nop(0, kArch))
@@ -914,16 +917,10 @@ TEST_F(InstrumentorPatchElfShape, RjTrampolinesContentsMatchExpectedWords) {
       << "trampoline must end with s_branch back to anchor + original_size";
 }
 
-TEST_F(InstrumentorPatchElfShape, RjTrampolinesMultipleContentsMatchExpectedWords) {
+TEST_F(InstrumentorPatchElfShape, TrampolineCaveContentsMatchExpectedWordsMultiple) {
   Init(100, 50);
-  const Section *tramp = find_section(".rj_trampolines");
-  ASSERT_NE(tramp, nullptr);
-
-  // Body for the inline-nop smoke build with a 4-byte anchor:
-  //   [placeholder s_nop 0, relocated original s_nop 0, return s_branch(-3)].
-  ASSERT_EQ(tramp->size(), 600u);
-  std::array<uint32_t, 150> words{};
-  std::memcpy(words.data(), tramp->data(), tramp->size());
+  const std::vector<uint32_t> words = cave_words();
+  ASSERT_EQ(words.size(), 150u);
 
   constexpr rj_code_arch_t kArch = ROCJITSU_CODE_ARCH_CDNA4;
   for (uint64_t point = 0; point < 50; ++point) {
@@ -934,20 +931,6 @@ TEST_F(InstrumentorPatchElfShape, RjTrampolinesMultipleContentsMatchExpectedWord
     EXPECT_EQ(words[point * 3 + 2], build_s_branch(-101 - 2 * point, kArch))
         << "trampoline must end with s_branch back to anchor + original_size";
   }
-}
-
-TEST_F(InstrumentorPatchElfShape, CodeSectionsIncludesTextAndTrampoline) {
-  Init(2, 1);
-  bool saw_text = false;
-  bool saw_tramp = false;
-  for (const Section *s : patched_->code_sections()) {
-    if (s->name() == ".text")
-      saw_text = true;
-    if (s->name() == ".rj_trampolines")
-      saw_tramp = true;
-  }
-  EXPECT_TRUE(saw_text) << "code_sections() must include .text";
-  EXPECT_TRUE(saw_tramp) << "code_sections() must include .rj_trampolines";
 }
 
 //==============================================================================
@@ -965,6 +948,8 @@ protected:
   void Init(uint64_t num_elf_nops, uint64_t num_instrumentation_points) {
     // leaving anchor_offset = 0 empty, so will fail on num_elf_nops == num_instrumentation_points
     ASSERT_TRUE(num_elf_nops > num_instrumentation_points);
+    num_elf_nops_ = num_elf_nops;
+    num_points_ = num_instrumentation_points;
 
     image_ = make_gfx950_elf_with_nop_text(num_elf_nops * 4);
     AmdGpuCodeObject obj(image_.data(), image_.size());
@@ -987,9 +972,9 @@ protected:
   }
 
   const Section *find_section(std::string_view name) const {
-    for (const Section *s : patched_->code_sections())
+    for (const auto &s : patched_->all_sections())
       if (s->name() == name)
-        return s;
+        return s.get();
     return nullptr;
   }
 
@@ -999,6 +984,20 @@ protected:
     return std::unique_ptr<Instruction>(decoder_->decode(&word));
   }
 
+  // Byte size of the original .text before instrumentation. The trampoline cave
+  // begins here, at the tail of the grown .text
+  uint64_t original_text_size() const { return num_elf_nops_ * sizeof(uint32_t); }
+
+  // Decode a word from the trampoline cave. @p cave_byte_offset is relative to
+  // the start of the cave (== the old .rj_trampolines-relative offset).
+  std::unique_ptr<Instruction> decode_cave_word(size_t cave_byte_offset) {
+    const Section *text = find_section(".text");
+    EXPECT_NE(text, nullptr);
+    return decode_word(text, original_text_size() + cave_byte_offset);
+  }
+
+  uint64_t num_elf_nops_ = 0;
+  uint64_t num_points_ = 0;
   std::vector<uint8_t> image_;
   InstrumentedCodeObject result_;
   std::unique_ptr<AmdGpuCodeObject> patched_;
@@ -1077,9 +1076,7 @@ TEST_F(InstrumentorPatchDecoded, UnpatchedMultipleTextInstructionIsUnchanged) {
 
 TEST_F(InstrumentorPatchDecoded, TrampolinePlaceholderDecodesAsSNop) {
   Init(2, 1);
-  const Section *tramp = find_section(".rj_trampolines");
-  ASSERT_NE(tramp, nullptr);
-  auto inst = decode_word(tramp, /*byte_offset=*/0);
+  auto inst = decode_cave_word(/*cave_byte_offset=*/0);
   ASSERT_NE(inst, nullptr);
 
   EXPECT_NE(inst->mnemonic().find("s_nop"), std::string_view::npos)
@@ -1091,10 +1088,8 @@ TEST_F(InstrumentorPatchDecoded, TrampolinePlaceholderDecodesAsSNop) {
 
 TEST_F(InstrumentorPatchDecoded, TrampolinePlaceholderMultipleDecodesAsSNop) {
   Init(100, 50);
-  const Section *tramp = find_section(".rj_trampolines");
-  ASSERT_NE(tramp, nullptr);
   for (uint64_t trampoline_count = 0; trampoline_count < 50; ++trampoline_count) {
-    auto inst = decode_word(tramp, /*byte_offset=*/trampoline_count * 12);
+    auto inst = decode_cave_word(/*cave_byte_offset=*/trampoline_count * 12);
     ASSERT_NE(inst, nullptr);
 
     EXPECT_NE(inst->mnemonic().find("s_nop"), std::string_view::npos)
@@ -1108,10 +1103,8 @@ TEST_F(InstrumentorPatchDecoded, TrampolinePlaceholderMultipleDecodesAsSNop) {
 TEST_F(InstrumentorPatchDecoded, RelocatedOriginalPreservesMnemonic) {
   Init(2, 1);
   // The original instruction at .text[4..8] was s_nop 0. After relocation it
-  // lives in the trampoline body at offset 4. Decoded bytes must agree.
-  const Section *tramp = find_section(".rj_trampolines");
-  ASSERT_NE(tramp, nullptr);
-  auto relocated = decode_word(tramp, /*byte_offset=*/4);
+  // lives in the trampoline body at cave offset 4. Decoded bytes must agree.
+  auto relocated = decode_cave_word(/*cave_byte_offset=*/4);
   ASSERT_NE(relocated, nullptr);
   EXPECT_NE(relocated->mnemonic().find("s_nop"), std::string_view::npos)
       << "relocated original must decode to the same mnemonic as the source; got "
@@ -1121,12 +1114,9 @@ TEST_F(InstrumentorPatchDecoded, RelocatedOriginalPreservesMnemonic) {
 TEST_F(InstrumentorPatchDecoded, RelocatedMultipleOriginalPreservesMnemonic) {
   Init(100, 50);
   // The original instruction at .text[4..8] was s_nop 0. After relocation it
-  // lives in the trampoline body at offset 4. Decoded bytes must agree.
-  const Section *tramp = find_section(".rj_trampolines");
-  ASSERT_NE(tramp, nullptr);
-
+  // lives in the trampoline body at cave offset 4. Decoded bytes must agree.
   for (uint64_t trampoline_count = 0; trampoline_count < 50; ++trampoline_count) {
-    auto relocated = decode_word(tramp, /*byte_offset=*/trampoline_count * 12 + 4);
+    auto relocated = decode_cave_word(/*cave_byte_offset=*/trampoline_count * 12 + 4);
     ASSERT_NE(relocated, nullptr);
     EXPECT_NE(relocated->mnemonic().find("s_nop"), std::string_view::npos)
         << "relocated original must decode to the same mnemonic as the source; got "
@@ -1136,9 +1126,7 @@ TEST_F(InstrumentorPatchDecoded, RelocatedMultipleOriginalPreservesMnemonic) {
 
 TEST_F(InstrumentorPatchDecoded, TrampolineReturnDecodesAsBackwardSBranch) {
   Init(2, 1);
-  const Section *tramp = find_section(".rj_trampolines");
-  ASSERT_NE(tramp, nullptr);
-  auto inst = decode_word(tramp, /*byte_offset=*/8);
+  auto inst = decode_cave_word(/*cave_byte_offset=*/8);
   ASSERT_NE(inst, nullptr);
 
   EXPECT_NE(inst->mnemonic().find("s_branch"), std::string_view::npos)
@@ -1152,10 +1140,8 @@ TEST_F(InstrumentorPatchDecoded, TrampolineReturnDecodesAsBackwardSBranch) {
 
 TEST_F(InstrumentorPatchDecoded, TrampolineMultipleReturnDecodesAsBackwardSBranch) {
   Init(100, 50);
-  const Section *tramp = find_section(".rj_trampolines");
-  ASSERT_NE(tramp, nullptr);
   for (uint64_t trampoline_count = 0; trampoline_count < 50; ++trampoline_count) {
-    auto inst = decode_word(tramp, /*byte_offset=*/trampoline_count * 12 + 8);
+    auto inst = decode_cave_word(/*cave_byte_offset=*/trampoline_count * 12 + 8);
     ASSERT_NE(inst, nullptr);
 
     EXPECT_NE(inst->mnemonic().find("s_branch"), std::string_view::npos)
@@ -1178,31 +1164,29 @@ TEST_F(InstrumentorPatchDecoded, TrampolineMultipleReturnDecodesAsBackwardSBranc
 TEST_F(InstrumentorPatchDecoded, BranchesLandAtTheirIntendedTargets) {
   Init(2, 1);
   const Section *text = find_section(".text");
-  const Section *tramp = find_section(".rj_trampolines");
   ASSERT_NE(text, nullptr);
-  ASSERT_NE(tramp, nullptr);
 
   auto sopp_target = [](uint64_t branch_pc, const uint32_t *word) -> uint64_t {
     const int16_t simm16 = static_cast<int16_t>(*word & 0xFFFFu);
     return branch_pc + 4 + static_cast<int64_t>(simm16) * 4;
   };
 
-  // Forward branch lives at .text-relative offset 4 (the patched anchor).
-  // It should land at trampoline_offset == text->size() (== 8 in this fixture).
+  // Forward branch lives at .text-relative offset 4 (the patched anchor). It
+  // should land at the cave start == original_text_size() (== 8 in this fixture).
   auto fwd = decode_word(text, /*byte_offset=*/4);
   ASSERT_NE(fwd, nullptr);
   ASSERT_NE(fwd->raw_encoding(), nullptr);
   const uint64_t fwd_target = sopp_target(/*branch_pc=*/4, fwd->raw_encoding());
-  EXPECT_EQ(fwd_target, text->size())
-      << "forward branch must land at trampoline_offset (= text->size())";
+  EXPECT_EQ(fwd_target, original_text_size())
+      << "forward branch must land at the trampoline cave start (= original_text_size())";
 
-  // Return branch lives at trampoline-section-relative offset 8. In
-  // .text-relative coordinates that is text->size() + 8 (= 16 in this fixture).
-  // It should land at anchor_offset + original_size = 4 + 4 = 8.
-  auto ret = decode_word(tramp, /*byte_offset=*/8);
+  // Return branch lives at cave-relative offset 8. In .text-relative coordinates
+  // that is original_text_size() + 8 (= 16 in this fixture). It should land at
+  // anchor_offset + original_size = 4 + 4 = 8.
+  auto ret = decode_cave_word(/*cave_byte_offset=*/8);
   ASSERT_NE(ret, nullptr);
   ASSERT_NE(ret->raw_encoding(), nullptr);
-  const uint64_t ret_pc = text->size() + 8;
+  const uint64_t ret_pc = original_text_size() + 8;
   const uint64_t ret_target = sopp_target(ret_pc, ret->raw_encoding());
   EXPECT_EQ(ret_target, 8u) << "return branch must land at anchor + original_size";
 }
@@ -1210,9 +1194,7 @@ TEST_F(InstrumentorPatchDecoded, BranchesLandAtTheirIntendedTargets) {
 TEST_F(InstrumentorPatchDecoded, BranchesMultipleLandAtTheirIntendedTargets) {
   Init(100, 50);
   const Section *text = find_section(".text");
-  const Section *tramp = find_section(".rj_trampolines");
   ASSERT_NE(text, nullptr);
-  ASSERT_NE(tramp, nullptr);
 
   auto sopp_target = [](uint64_t branch_pc, const uint32_t *word) -> uint64_t {
     const int16_t simm16 = static_cast<int16_t>(*word & 0xFFFFu);
@@ -1224,15 +1206,15 @@ TEST_F(InstrumentorPatchDecoded, BranchesMultipleLandAtTheirIntendedTargets) {
     ASSERT_NE(fwd, nullptr);
     ASSERT_NE(fwd->raw_encoding(), nullptr);
     const uint64_t fwd_target = sopp_target(/*branch_pc=*/(point + 1) * 4, fwd->raw_encoding());
-    EXPECT_EQ(fwd_target, text->size() + point * 12)
-        << "forward branch must land at trampoline_offset (= text->size())";
+    EXPECT_EQ(fwd_target, original_text_size() + point * 12)
+        << "forward branch must land at its trampoline cave offset";
   }
 
   for (uint64_t point = 0; point < 50; ++point) {
-    auto ret = decode_word(tramp, /*byte_offset=*/point * 12 + 8);
+    auto ret = decode_cave_word(/*cave_byte_offset=*/point * 12 + 8);
     ASSERT_NE(ret, nullptr);
     ASSERT_NE(ret->raw_encoding(), nullptr);
-    const uint64_t ret_pc = text->size() + point * 12 + 8;
+    const uint64_t ret_pc = original_text_size() + point * 12 + 8;
     const uint64_t ret_target = sopp_target(ret_pc, ret->raw_encoding());
     EXPECT_EQ(ret_target, (point + 2) * 4) << "return branch must land at anchor + original_size";
   }

--- a/emulation/rocjitsu/tests/patch/instrumentor_test.cpp
+++ b/emulation/rocjitsu/tests/patch/instrumentor_test.cpp
@@ -721,18 +721,6 @@ TEST(InstrumentorPatch, RejectsZeroQueuedPoints) {
   EXPECT_FALSE(result.errors.empty());
 }
 
-TEST(InstrumentorPatch, RejectsMoreThanOneQueuedPoint) {
-  auto image = make_gfx950_elf_with_two_nops();
-  AmdGpuCodeObject obj(image.data(), image.size());
-  Instrumentor instrumentor(obj, ROCJITSU_CODE_ARCH_CDNA4);
-  instrumentor.add_point_by_offset(0);
-  instrumentor.add_point_by_offset(4);
-
-  auto result = instrumentor.patch();
-  EXPECT_TRUE(result.elf_bytes.empty());
-  EXPECT_FALSE(result.errors.empty());
-}
-
 TEST(InstrumentorPatch, ValidationFailurePropagates) {
   auto image = make_gfx950_elf_with_two_nops();
   AmdGpuCodeObject obj(image.data(), image.size());
@@ -825,13 +813,19 @@ TEST(InstrumentorPatch, BranchRangeOverflowPropagatesAsFatalError) {
 
 class InstrumentorPatchElfShape : public ::testing::Test {
 protected:
-  void SetUp() override {
-    image_ = make_gfx950_elf_with_two_nops();
+  // places instrumentation points starting at anchor_offset = 4
+  void Init(uint64_t num_elf_nops, uint64_t num_instrumentation_points) {
+    // leaving anchor_offset = 0 empty, so will fail on num_elf_nops == num_instrumentation_points
+    ASSERT_TRUE(num_elf_nops > num_instrumentation_points);
+
+    image_ = make_gfx950_elf_with_nop_text(num_elf_nops * 4);
     AmdGpuCodeObject obj(image_.data(), image_.size());
     ASSERT_TRUE(obj.is_valid());
 
     Instrumentor instrumentor(obj, ROCJITSU_CODE_ARCH_CDNA4);
-    instrumentor.add_point_by_offset(/*anchor_offset=*/4);
+    for (uint64_t point = 0; point < num_instrumentation_points; ++point)
+      instrumentor.add_point_by_offset(/*anchor_offset=*/(point + 1) * 4);
+
     result_ = instrumentor.patch();
     ASSERT_TRUE(result_.errors.empty())
         << (result_.errors.empty() ? std::string{} : result_.errors.front());
@@ -855,17 +849,43 @@ protected:
 };
 
 TEST_F(InstrumentorPatchElfShape, RjTrampolinesSectionExists) {
+  Init(2, 1);
+  ASSERT_NE(find_section(".rj_trampolines"), nullptr)
+      << ".rj_trampolines must appear in code_sections()";
+}
+
+TEST_F(InstrumentorPatchElfShape, RjTrampolinesMultipleSectionExists) {
+  Init(100, 50);
   ASSERT_NE(find_section(".rj_trampolines"), nullptr)
       << ".rj_trampolines must appear in code_sections()";
 }
 
 TEST_F(InstrumentorPatchElfShape, RjTrampolinesIsExecutable) {
+  Init(2, 1);
+  const Section *tramp = find_section(".rj_trampolines");
+  ASSERT_NE(tramp, nullptr);
+  EXPECT_NE(tramp->flags() & SHF_EXECINSTR, 0u) << ".rj_trampolines must have SHF_EXECINSTR";
+}
+
+TEST_F(InstrumentorPatchElfShape, RjTrampolinesMultipleIsExecutable) {
+  Init(100, 50);
   const Section *tramp = find_section(".rj_trampolines");
   ASSERT_NE(tramp, nullptr);
   EXPECT_NE(tramp->flags() & SHF_EXECINSTR, 0u) << ".rj_trampolines must have SHF_EXECINSTR";
 }
 
 TEST_F(InstrumentorPatchElfShape, RjTrampolinesPlacedImmediatelyAfterText) {
+  Init(2, 1);
+  const Section *text = find_section(".text");
+  const Section *tramp = find_section(".rj_trampolines");
+  ASSERT_NE(text, nullptr);
+  ASSERT_NE(tramp, nullptr);
+  EXPECT_EQ(tramp->sectionOffset(), text->sectionOffset() + text->size())
+      << ".rj_trampolines must start at the byte immediately after .text";
+}
+
+TEST_F(InstrumentorPatchElfShape, RjTrampolinesMultiplePlacedImmediatelyAfterText) {
+  Init(100, 50);
   const Section *text = find_section(".text");
   const Section *tramp = find_section(".rj_trampolines");
   ASSERT_NE(text, nullptr);
@@ -875,6 +895,7 @@ TEST_F(InstrumentorPatchElfShape, RjTrampolinesPlacedImmediatelyAfterText) {
 }
 
 TEST_F(InstrumentorPatchElfShape, RjTrampolinesContentsMatchExpectedWords) {
+  Init(2, 1);
   const Section *tramp = find_section(".rj_trampolines");
   ASSERT_NE(tramp, nullptr);
 
@@ -893,7 +914,30 @@ TEST_F(InstrumentorPatchElfShape, RjTrampolinesContentsMatchExpectedWords) {
       << "trampoline must end with s_branch back to anchor + original_size";
 }
 
+TEST_F(InstrumentorPatchElfShape, RjTrampolinesMultipleContentsMatchExpectedWords) {
+  Init(100, 50);
+  const Section *tramp = find_section(".rj_trampolines");
+  ASSERT_NE(tramp, nullptr);
+
+  // Body for the inline-nop smoke build with a 4-byte anchor:
+  //   [placeholder s_nop 0, relocated original s_nop 0, return s_branch(-3)].
+  ASSERT_EQ(tramp->size(), 600u);
+  std::array<uint32_t, 150> words{};
+  std::memcpy(words.data(), tramp->data(), tramp->size());
+
+  constexpr rj_code_arch_t kArch = ROCJITSU_CODE_ARCH_CDNA4;
+  for (uint64_t point = 0; point < 50; ++point) {
+    EXPECT_EQ(words[point * 3], build_s_nop(0, kArch))
+        << "trampoline body must start with the placeholder s_nop 0";
+    EXPECT_EQ(words[point * 3 + 1], 0xBF800000u) // original s_nop 0 from .text)
+        << "trampoline body must contain the relocated original instruction unchanged";
+    EXPECT_EQ(words[point * 3 + 2], build_s_branch(-101 - 2 * point, kArch))
+        << "trampoline must end with s_branch back to anchor + original_size";
+  }
+}
+
 TEST_F(InstrumentorPatchElfShape, CodeSectionsIncludesTextAndTrampoline) {
+  Init(2, 1);
   bool saw_text = false;
   bool saw_tramp = false;
   for (const Section *s : patched_->code_sections()) {
@@ -917,13 +961,18 @@ TEST_F(InstrumentorPatchElfShape, CodeSectionsIncludesTextAndTrampoline) {
 
 class InstrumentorPatchDecoded : public ::testing::Test {
 protected:
-  void SetUp() override {
-    image_ = make_gfx950_elf_with_two_nops();
+  // places instrumentation points starting at anchor_offset = 4
+  void Init(uint64_t num_elf_nops, uint64_t num_instrumentation_points) {
+    // leaving anchor_offset = 0 empty, so will fail on num_elf_nops == num_instrumentation_points
+    ASSERT_TRUE(num_elf_nops > num_instrumentation_points);
+
+    image_ = make_gfx950_elf_with_nop_text(num_elf_nops * 4);
     AmdGpuCodeObject obj(image_.data(), image_.size());
     ASSERT_TRUE(obj.is_valid());
 
     Instrumentor instrumentor(obj, ROCJITSU_CODE_ARCH_CDNA4);
-    instrumentor.add_point_by_offset(/*anchor_offset=*/4);
+    for (uint64_t point = 0; point < num_instrumentation_points; ++point)
+      instrumentor.add_point_by_offset(/*anchor_offset=*/(point + 1) * 4);
     result_ = instrumentor.patch();
     ASSERT_TRUE(result_.errors.empty())
         << (result_.errors.empty() ? std::string{} : result_.errors.front());
@@ -957,6 +1006,7 @@ protected:
 };
 
 TEST_F(InstrumentorPatchDecoded, PatchedAnchorDecodesAsForwardSBranch) {
+  Init(2, 1);
   const Section *text = find_section(".text");
   ASSERT_NE(text, nullptr);
   auto inst = decode_word(text, /*byte_offset=*/4);
@@ -971,7 +1021,26 @@ TEST_F(InstrumentorPatchDecoded, PatchedAnchorDecodesAsForwardSBranch) {
       << "forward branch offset must be non-negative; got " << *inst->branch_offset_bytes();
 }
 
+TEST_F(InstrumentorPatchDecoded, PatchedMultipleAnchorDecodesAsForwardSBranch) {
+  Init(100, 50);
+  const Section *text = find_section(".text");
+  ASSERT_NE(text, nullptr);
+  for (uint64_t point = 0; point < 50; ++point) {
+    auto inst = decode_word(text, /*byte_offset=*/(point + 1) * 4);
+    ASSERT_NE(inst, nullptr);
+
+    EXPECT_NE(inst->mnemonic().find("s_branch"), std::string_view::npos)
+        << "mnemonic was: " << inst->mnemonic();
+    EXPECT_NE(inst->flags() & BRANCH, 0u) << "patched anchor must carry BRANCH flag";
+    ASSERT_TRUE(inst->branch_offset_bytes().has_value())
+        << "patched anchor must report a PC-relative branch offset";
+    EXPECT_GE(*inst->branch_offset_bytes(), 0)
+        << "forward branch offset must be non-negative; got " << *inst->branch_offset_bytes();
+  }
+}
+
 TEST_F(InstrumentorPatchDecoded, UnpatchedTextInstructionIsUnchanged) {
+  Init(2, 1);
   // The first s_nop at .text[0..4] was not the anchor. Decoder must still see
   // it as s_nop — proves the patcher did not accidentally touch it.
   const Section *text = find_section(".text");
@@ -984,7 +1053,30 @@ TEST_F(InstrumentorPatchDecoded, UnpatchedTextInstructionIsUnchanged) {
   EXPECT_FALSE(inst->branch_offset_bytes().has_value());
 }
 
+TEST_F(InstrumentorPatchDecoded, UnpatchedMultipleTextInstructionIsUnchanged) {
+  Init(100, 50);
+  // The first s_nop at .text[0..4] was not the anchor. Decoder must still see
+  // it as s_nop — proves the patcher did not accidentally touch it.
+  const Section *text = find_section(".text");
+  ASSERT_NE(text, nullptr);
+  auto inst = decode_word(text, /*byte_offset=*/0);
+  ASSERT_NE(inst, nullptr);
+  EXPECT_NE(inst->mnemonic().find("s_nop"), std::string_view::npos)
+      << "unpatched .text instruction must remain s_nop; got " << inst->mnemonic();
+  EXPECT_EQ(inst->flags() & BRANCH, 0u);
+  EXPECT_FALSE(inst->branch_offset_bytes().has_value());
+  for (uint64_t point = 51; point < 100; ++point) {
+    inst = decode_word(text, point * 4);
+    ASSERT_NE(inst, nullptr);
+    EXPECT_NE(inst->mnemonic().find("s_nop"), std::string_view::npos)
+        << "unpatched .text instruction must remain s_nop; got " << inst->mnemonic();
+    EXPECT_EQ(inst->flags() & BRANCH, 0u);
+    EXPECT_FALSE(inst->branch_offset_bytes().has_value());
+  }
+}
+
 TEST_F(InstrumentorPatchDecoded, TrampolinePlaceholderDecodesAsSNop) {
+  Init(2, 1);
   const Section *tramp = find_section(".rj_trampolines");
   ASSERT_NE(tramp, nullptr);
   auto inst = decode_word(tramp, /*byte_offset=*/0);
@@ -997,7 +1089,24 @@ TEST_F(InstrumentorPatchDecoded, TrampolinePlaceholderDecodesAsSNop) {
       << "placeholder must not carry a branch offset";
 }
 
+TEST_F(InstrumentorPatchDecoded, TrampolinePlaceholderMultipleDecodesAsSNop) {
+  Init(100, 50);
+  const Section *tramp = find_section(".rj_trampolines");
+  ASSERT_NE(tramp, nullptr);
+  for (uint64_t trampoline_count = 0; trampoline_count < 50; ++trampoline_count) {
+    auto inst = decode_word(tramp, /*byte_offset=*/trampoline_count * 12);
+    ASSERT_NE(inst, nullptr);
+
+    EXPECT_NE(inst->mnemonic().find("s_nop"), std::string_view::npos)
+        << "mnemonic was: " << inst->mnemonic();
+    EXPECT_EQ(inst->flags() & BRANCH, 0u) << "placeholder must not be marked as a branch";
+    EXPECT_FALSE(inst->branch_offset_bytes().has_value())
+        << "placeholder must not carry a branch offset";
+  }
+}
+
 TEST_F(InstrumentorPatchDecoded, RelocatedOriginalPreservesMnemonic) {
+  Init(2, 1);
   // The original instruction at .text[4..8] was s_nop 0. After relocation it
   // lives in the trampoline body at offset 4. Decoded bytes must agree.
   const Section *tramp = find_section(".rj_trampolines");
@@ -1009,7 +1118,24 @@ TEST_F(InstrumentorPatchDecoded, RelocatedOriginalPreservesMnemonic) {
       << relocated->mnemonic();
 }
 
+TEST_F(InstrumentorPatchDecoded, RelocatedMultipleOriginalPreservesMnemonic) {
+  Init(100, 50);
+  // The original instruction at .text[4..8] was s_nop 0. After relocation it
+  // lives in the trampoline body at offset 4. Decoded bytes must agree.
+  const Section *tramp = find_section(".rj_trampolines");
+  ASSERT_NE(tramp, nullptr);
+
+  for (uint64_t trampoline_count = 0; trampoline_count < 50; ++trampoline_count) {
+    auto relocated = decode_word(tramp, /*byte_offset=*/trampoline_count * 12 + 4);
+    ASSERT_NE(relocated, nullptr);
+    EXPECT_NE(relocated->mnemonic().find("s_nop"), std::string_view::npos)
+        << "relocated original must decode to the same mnemonic as the source; got "
+        << relocated->mnemonic();
+  }
+}
+
 TEST_F(InstrumentorPatchDecoded, TrampolineReturnDecodesAsBackwardSBranch) {
+  Init(2, 1);
   const Section *tramp = find_section(".rj_trampolines");
   ASSERT_NE(tramp, nullptr);
   auto inst = decode_word(tramp, /*byte_offset=*/8);
@@ -1024,6 +1150,24 @@ TEST_F(InstrumentorPatchDecoded, TrampolineReturnDecodesAsBackwardSBranch) {
       << "return branch offset must be negative; got " << *inst->branch_offset_bytes();
 }
 
+TEST_F(InstrumentorPatchDecoded, TrampolineMultipleReturnDecodesAsBackwardSBranch) {
+  Init(100, 50);
+  const Section *tramp = find_section(".rj_trampolines");
+  ASSERT_NE(tramp, nullptr);
+  for (uint64_t trampoline_count = 0; trampoline_count < 50; ++trampoline_count) {
+    auto inst = decode_word(tramp, /*byte_offset=*/trampoline_count * 12 + 8);
+    ASSERT_NE(inst, nullptr);
+
+    EXPECT_NE(inst->mnemonic().find("s_branch"), std::string_view::npos)
+        << "mnemonic was: " << inst->mnemonic();
+    EXPECT_NE(inst->flags() & BRANCH, 0u) << "return must carry BRANCH flag";
+    ASSERT_TRUE(inst->branch_offset_bytes().has_value())
+        << "return must report a PC-relative branch offset";
+    EXPECT_LT(*inst->branch_offset_bytes(), 0)
+        << "return branch offset must be negative; got " << *inst->branch_offset_bytes();
+  }
+}
+
 // End-to-end behavioral check: decode the patched s_branch and the return
 // s_branch, compute their actual landing addresses from the raw SOPP simm16,
 // and assert they hit the expected .text-relative offsets. This pins the one
@@ -1032,6 +1176,7 @@ TEST_F(InstrumentorPatchDecoded, TrampolineReturnDecodesAsBackwardSBranch) {
 //
 // SOPP semantics: target = branch_pc + 4 + simm16 * 4.
 TEST_F(InstrumentorPatchDecoded, BranchesLandAtTheirIntendedTargets) {
+  Init(2, 1);
   const Section *text = find_section(".text");
   const Section *tramp = find_section(".rj_trampolines");
   ASSERT_NE(text, nullptr);
@@ -1060,6 +1205,37 @@ TEST_F(InstrumentorPatchDecoded, BranchesLandAtTheirIntendedTargets) {
   const uint64_t ret_pc = text->size() + 8;
   const uint64_t ret_target = sopp_target(ret_pc, ret->raw_encoding());
   EXPECT_EQ(ret_target, 8u) << "return branch must land at anchor + original_size";
+}
+
+TEST_F(InstrumentorPatchDecoded, BranchesMultipleLandAtTheirIntendedTargets) {
+  Init(100, 50);
+  const Section *text = find_section(".text");
+  const Section *tramp = find_section(".rj_trampolines");
+  ASSERT_NE(text, nullptr);
+  ASSERT_NE(tramp, nullptr);
+
+  auto sopp_target = [](uint64_t branch_pc, const uint32_t *word) -> uint64_t {
+    const int16_t simm16 = static_cast<int16_t>(*word & 0xFFFFu);
+    return branch_pc + 4 + static_cast<int64_t>(simm16) * 4;
+  };
+
+  for (uint64_t point = 0; point < 50; ++point) {
+    auto fwd = decode_word(text, /*byte_offset=*/(point + 1) * 4);
+    ASSERT_NE(fwd, nullptr);
+    ASSERT_NE(fwd->raw_encoding(), nullptr);
+    const uint64_t fwd_target = sopp_target(/*branch_pc=*/(point + 1) * 4, fwd->raw_encoding());
+    EXPECT_EQ(fwd_target, text->size() + point * 12)
+        << "forward branch must land at trampoline_offset (= text->size())";
+  }
+
+  for (uint64_t point = 0; point < 50; ++point) {
+    auto ret = decode_word(tramp, /*byte_offset=*/point * 12 + 8);
+    ASSERT_NE(ret, nullptr);
+    ASSERT_NE(ret->raw_encoding(), nullptr);
+    const uint64_t ret_pc = text->size() + point * 12 + 8;
+    const uint64_t ret_target = sopp_target(ret_pc, ret->raw_encoding());
+    EXPECT_EQ(ret_target, (point + 2) * 4) << "return branch must land at anchor + original_size";
+  }
 }
 
 } // namespace

--- a/emulation/rocjitsu/tests/patch/trampoline_builder_test.cpp
+++ b/emulation/rocjitsu/tests/patch/trampoline_builder_test.cpp
@@ -157,6 +157,25 @@ TEST(TrampolineBuilder, ForwardBranchOverflowFails) {
       << "Diagnostic must identify the forward branch, got: " << err;
 }
 
+// original_size and original_words.size()*4 must agree. The builder rejects
+// inconsistent plans rather than silently using one or the other.
+TEST(TrampolineBuilder, RejectsOriginalWordsSizeMismatch) {
+  constexpr rj_code_arch_t kArch = ROCJITSU_CODE_ARCH_CDNA4;
+  TrampolinePlan plan;
+  plan.arch = kArch;
+  plan.anchor_offset = 0x100;
+  plan.original_size = 8; // expects 2 words ...
+  plan.trampoline_offset = 0x200;
+  plan.return_target = 0x108;
+  plan.original_words = {0xDEADBEEFu}; // ... but only one provided.
+  plan.before_items = {InlineAsmItem{{build_s_nop(0, kArch)}}};
+  plan.emit_original = true;
+
+  std::string err;
+  EXPECT_FALSE(TrampolineBuilder::build(plan, &err).has_value());
+  EXPECT_FALSE(err.empty()) << "Builder must explain the mismatch";
+}
+
 TEST(TrampolineBuilder, ReturnBranchOverflowFails) {
   // With forward_simm16 = INT16_MAX = 32767 (just in range) and
   // original_size = 4, the return branch needs simm16 = -32770 (one past
@@ -280,75 +299,12 @@ TEST(TrampolineBuilder, ReturnSimm16AtNegativeLimitSucceeds) {
             build_s_branch(std::numeric_limits<int16_t>::min(), kArch));
 }
 
-//==============================================================================
-// Inline-nop smoke guardrail
-//
-// The first DBI milestone (inline-nop smoke) only emits the no-clobber
-// `s_nop 0` placeholder body so we never produce instrumentation bytes that
-// need clobber handling or liveness. This is scaffolding — delete this block
-// when arbitrary inline-asm becomes legal.
-//==============================================================================
-
-TEST(TrampolineBuilderInlineNopSmokeGuardrail, RejectsNonCanonicalBody) {
-  constexpr rj_code_arch_t kArch = ROCJITSU_CODE_ARCH_CDNA4;
-
-  auto valid_plan = [&] {
-    TrampolinePlan p;
-    p.arch = kArch;
-    p.anchor_offset = 0x100;
-    p.original_size = 4;
-    p.trampoline_offset = 0x200;
-    p.return_target = 0x104;
-    p.original_words = {0xDEADBEEFu};
-    p.before_items = {InlineAsmItem{{build_s_nop(0, kArch)}}};
-    p.emit_original = true;
-    return p;
-  };
-
-  // Sanity: the unmutated plan is accepted, so each sub-case below is
-  // exercising exactly one guardrail dimension.
-  ASSERT_TRUE(TrampolineBuilder::build(valid_plan()).has_value());
-
-  // Extra before-item.
-  {
-    auto plan = valid_plan();
-    plan.before_items.push_back(InlineAsmItem{{build_s_nop(0, kArch)}});
-    std::string err;
-    EXPECT_FALSE(TrampolineBuilder::build(plan, &err).has_value())
-        << "extra before-item must be rejected";
-    EXPECT_FALSE(err.empty());
-  }
-
-  // Before-item that isn't s_nop 0.
-  {
-    auto plan = valid_plan();
-    plan.before_items = {InlineAsmItem{{build_s_branch(0, kArch)}}};
-    std::string err;
-    EXPECT_FALSE(TrampolineBuilder::build(plan, &err).has_value())
-        << "non-placeholder before-item must be rejected";
-    EXPECT_FALSE(err.empty());
-  }
-
-  // Any after-item at all.
-  {
-    auto plan = valid_plan();
-    plan.after_items.push_back(InlineAsmItem{{build_s_nop(0, kArch)}});
-    std::string err;
-    EXPECT_FALSE(TrampolineBuilder::build(plan, &err).has_value())
-        << "non-empty after_items must be rejected";
-    EXPECT_FALSE(err.empty());
-  }
-
-  // emit_original = false.
-  {
-    auto plan = valid_plan();
-    plan.emit_original = false;
-    std::string err;
-    EXPECT_FALSE(TrampolineBuilder::build(plan, &err).has_value())
-        << "emit_original = false must be rejected";
-    EXPECT_FALSE(err.empty());
-  }
-}
+// NOTE: the inline-nop smoke guardrail used to live in TrampolineBuilder and
+// was tested here. It has been moved to the orchestrator boundary as
+// validate_inline_nop_smoke_plan() in instrumentor.h, and the test moved with
+// it (see InlineNopSmokeGuardrail.* in instrumentor_test.cpp). The builder is
+// now generic and accepts any well-formed plan; milestone-scoped restrictions
+// are the orchestrator's responsibility.
 
 } // namespace
 } // namespace rocjitsu

--- a/emulation/rocjitsu/tests/patch/trampoline_builder_test.cpp
+++ b/emulation/rocjitsu/tests/patch/trampoline_builder_test.cpp
@@ -24,9 +24,7 @@ uint32_t word_at(const std::vector<uint8_t> &bytes, size_t byte_off) {
   return w;
 }
 
-int16_t decode_sopp_simm16(uint32_t word) {
-  return static_cast<int16_t>(word & 0xFFFFu);
-}
+int16_t decode_sopp_simm16(uint32_t word) { return static_cast<int16_t>(word & 0xFFFFu); }
 
 uint64_t resolve_sopp_target(uint64_t branch_pc, uint32_t branch_word) {
   return branch_pc + 4 + static_cast<int64_t>(decode_sopp_simm16(branch_word)) * 4;
@@ -135,8 +133,7 @@ TEST(TrampolineBuilder, ForwardBranchOverflowFails) {
   // forward_simm16 = (trampoline - (anchor + 4)) / 4. Place trampoline one
   // dword past the positive INT16 limit so the forward branch cannot fit.
   constexpr rj_code_arch_t kArch = ROCJITSU_CODE_ARCH_CDNA4;
-  constexpr int64_t kJustOver =
-      (static_cast<int64_t>(std::numeric_limits<int16_t>::max()) + 1) * 4;
+  constexpr int64_t kJustOver = (static_cast<int64_t>(std::numeric_limits<int16_t>::max()) + 1) * 4;
   constexpr uint64_t kAnchor = 0x100;
   const uint64_t kTrampoline = kAnchor + 4 + static_cast<uint64_t>(kJustOver);
 
@@ -233,10 +230,8 @@ TEST(TrampolineBuilder, EncodedBranchesRoundTripToPlanCoordinates) {
   // return_target. This is the only assertion in the file that exercises the
   // negative-immediate sign-extension path semantically rather than by byte
   // equality against build_s_branch(-66, ...).
-  const uint64_t ret_pc =
-      kTrampoline + (bytes->trampoline_words.size() - 1) * sizeof(uint32_t);
-  EXPECT_EQ(resolve_sopp_target(ret_pc, bytes->trampoline_words.back()),
-            plan.return_target);
+  const uint64_t ret_pc = kTrampoline + (bytes->trampoline_words.size() - 1) * sizeof(uint32_t);
+  EXPECT_EQ(resolve_sopp_target(ret_pc, bytes->trampoline_words.back()), plan.return_target);
 }
 
 // Under the inline-nop smoke body (1 nop + 1-2 original words = 8-12 bytes

--- a/emulation/rocjitsu/tests/patch/trampoline_builder_test.cpp
+++ b/emulation/rocjitsu/tests/patch/trampoline_builder_test.cpp
@@ -1,0 +1,354 @@
+// Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/code/patch/trampoline_builder.h"
+
+#include "rocjitsu/code/patch/instruction_builder.h"
+#include "rocjitsu/code/rj_code.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace rocjitsu {
+namespace {
+
+uint32_t word_at(const std::vector<uint8_t> &bytes, size_t byte_off) {
+  uint32_t w = 0;
+  std::memcpy(&w, bytes.data() + byte_off, sizeof(w));
+  return w;
+}
+
+int16_t decode_sopp_simm16(uint32_t word) {
+  return static_cast<int16_t>(word & 0xFFFFu);
+}
+
+uint64_t resolve_sopp_target(uint64_t branch_pc, uint32_t branch_word) {
+  return branch_pc + 4 + static_cast<int64_t>(decode_sopp_simm16(branch_word)) * 4;
+}
+
+//==============================================================================
+// Permanent contract: byte layout, branch math, arch honoring
+//
+// These tests describe what TrampolineBuilder::build() must always produce
+// from a valid plan.
+//==============================================================================
+
+TEST(TrampolineBuilder, Emits4ByteRelocationAnchorPatch) {
+  constexpr rj_code_arch_t kArch = ROCJITSU_CODE_ARCH_CDNA4;
+  constexpr uint64_t kAnchor = 0x100;
+  constexpr uint64_t kTrampoline = 0x200;
+  constexpr uint32_t kOriginalWord = 0xDEADBEEFu;
+
+  TrampolinePlan plan;
+  plan.arch = kArch;
+  plan.anchor_offset = kAnchor;
+  plan.original_size = 4;
+  plan.trampoline_offset = kTrampoline;
+  plan.return_target = kAnchor + 4;
+  plan.original_words = {kOriginalWord};
+  plan.before_items = {InlineAsmItem{{build_s_nop(0, kArch)}}};
+  plan.emit_original = true;
+
+  auto bytes = TrampolineBuilder::build(plan);
+  ASSERT_TRUE(bytes.has_value());
+
+  // Patched anchor is one s_branch covering the forward delta.
+  // forward_simm16 = (0x200 - (0x100 + 4)) / 4 = 63.
+  ASSERT_EQ(bytes->patched_anchor_bytes.size(), 4u);
+  EXPECT_EQ(word_at(bytes->patched_anchor_bytes, 0), build_s_branch(63, kArch));
+
+  // Trampoline: [before s_nop, original word, return s_branch].
+  // return_branch_offset = 0x200 + 4 + 4 = 0x208.
+  // return_simm16 = (0x104 - (0x208 + 4)) / 4 = -66.
+  ASSERT_EQ(bytes->trampoline_words.size(), 3u);
+  EXPECT_EQ(bytes->trampoline_words[0], build_s_nop(0, kArch));
+  EXPECT_EQ(bytes->trampoline_words[1], kOriginalWord);
+  EXPECT_EQ(bytes->trampoline_words[2], build_s_branch(-66, kArch));
+}
+
+TEST(TrampolineBuilder, Emits8ByteRelocationAnchorPatchWithNopTail) {
+  constexpr rj_code_arch_t kArch = ROCJITSU_CODE_ARCH_CDNA4;
+  constexpr uint64_t kAnchor = 0x100;
+  constexpr uint64_t kTrampoline = 0x200;
+  constexpr uint32_t kW0 = 0xAAAA1111u;
+  constexpr uint32_t kW1 = 0xBBBB2222u;
+
+  TrampolinePlan plan;
+  plan.arch = kArch;
+  plan.anchor_offset = kAnchor;
+  plan.original_size = 8;
+  plan.trampoline_offset = kTrampoline;
+  plan.return_target = kAnchor + 8;
+  plan.original_words = {kW0, kW1};
+  plan.before_items = {InlineAsmItem{{build_s_nop(0, kArch)}}};
+  plan.emit_original = true;
+
+  auto bytes = TrampolineBuilder::build(plan);
+  ASSERT_TRUE(bytes.has_value());
+
+  // Patched anchor is s_branch + s_nop 0 tail (preserves the 8-byte slot).
+  ASSERT_EQ(bytes->patched_anchor_bytes.size(), 8u);
+  EXPECT_EQ(word_at(bytes->patched_anchor_bytes, 0), build_s_branch(63, kArch));
+  EXPECT_EQ(word_at(bytes->patched_anchor_bytes, 4), build_s_nop(0, kArch));
+
+  // Trampoline: [before s_nop, w0, w1, return s_branch].
+  // return_branch_offset = 0x200 + 4 + 8 = 0x20C.
+  // return_simm16 = (0x108 - (0x20C + 4)) / 4 = -66.
+  ASSERT_EQ(bytes->trampoline_words.size(), 4u);
+  EXPECT_EQ(bytes->trampoline_words[0], build_s_nop(0, kArch));
+  EXPECT_EQ(bytes->trampoline_words[1], kW0);
+  EXPECT_EQ(bytes->trampoline_words[2], kW1);
+  EXPECT_EQ(bytes->trampoline_words[3], build_s_branch(-66, kArch));
+}
+
+// build_s_branch uses opcode 32 on RDNA3/3.5/4 and opcode 2 on CDNA1-4. If the
+// builder hard-coded one of those, this test would catch it.
+TEST(TrampolineBuilder, RespectsTargetArchForBranchEncoding) {
+  constexpr rj_code_arch_t kRdna = ROCJITSU_CODE_ARCH_RDNA4;
+  constexpr rj_code_arch_t kCdna = ROCJITSU_CODE_ARCH_CDNA4;
+
+  TrampolinePlan plan;
+  plan.arch = kRdna;
+  plan.anchor_offset = 0x100;
+  plan.original_size = 4;
+  plan.trampoline_offset = 0x200;
+  plan.return_target = 0x104;
+  plan.original_words = {0xCAFEF00Du};
+  plan.before_items = {InlineAsmItem{{build_s_nop(0, kRdna)}}};
+  plan.emit_original = true;
+
+  auto bytes = TrampolineBuilder::build(plan);
+  ASSERT_TRUE(bytes.has_value());
+  EXPECT_EQ(word_at(bytes->patched_anchor_bytes, 0), build_s_branch(63, kRdna));
+  EXPECT_NE(word_at(bytes->patched_anchor_bytes, 0), build_s_branch(63, kCdna))
+      << "Builder must use plan.arch, not a hard-coded opcode";
+  EXPECT_EQ(bytes->trampoline_words.back(), build_s_branch(-66, kRdna));
+}
+
+TEST(TrampolineBuilder, ForwardBranchOverflowFails) {
+  // forward_simm16 = (trampoline - (anchor + 4)) / 4. Place trampoline one
+  // dword past the positive INT16 limit so the forward branch cannot fit.
+  constexpr rj_code_arch_t kArch = ROCJITSU_CODE_ARCH_CDNA4;
+  constexpr int64_t kJustOver =
+      (static_cast<int64_t>(std::numeric_limits<int16_t>::max()) + 1) * 4;
+  constexpr uint64_t kAnchor = 0x100;
+  const uint64_t kTrampoline = kAnchor + 4 + static_cast<uint64_t>(kJustOver);
+
+  TrampolinePlan plan;
+  plan.arch = kArch;
+  plan.anchor_offset = kAnchor;
+  plan.original_size = 4;
+  plan.trampoline_offset = kTrampoline;
+  plan.return_target = kAnchor + 4;
+  plan.original_words = {0xDEADBEEFu};
+  plan.before_items = {InlineAsmItem{{build_s_nop(0, kArch)}}};
+  plan.emit_original = true;
+
+  std::string err;
+  EXPECT_FALSE(TrampolineBuilder::build(plan, &err).has_value());
+  EXPECT_FALSE(err.empty()) << "Builder must explain the rejection";
+  EXPECT_NE(err.find("forward"), std::string::npos)
+      << "Diagnostic must identify the forward branch, got: " << err;
+}
+
+TEST(TrampolineBuilder, ReturnBranchOverflowFails) {
+  // With forward_simm16 = INT16_MAX = 32767 (just in range) and
+  // original_size = 4, the return branch needs simm16 = -32770 (one past
+  // INT16_MIN). Asymmetric layout — trampoline placed exactly at the forward
+  // limit forces the return out of range.
+  constexpr rj_code_arch_t kArch = ROCJITSU_CODE_ARCH_CDNA4;
+  constexpr uint64_t kAnchor = 0;
+  constexpr uint64_t kTrampoline = 4 + 32767ull * 4;
+
+  TrampolinePlan plan;
+  plan.arch = kArch;
+  plan.anchor_offset = kAnchor;
+  plan.original_size = 4;
+  plan.trampoline_offset = kTrampoline;
+  plan.return_target = kAnchor + 4;
+  plan.original_words = {0xDEADBEEFu};
+  plan.before_items = {InlineAsmItem{{build_s_nop(0, kArch)}}};
+  plan.emit_original = true;
+
+  std::string err;
+  EXPECT_FALSE(TrampolineBuilder::build(plan, &err).has_value());
+  EXPECT_FALSE(err.empty());
+  EXPECT_NE(err.find("return"), std::string::npos)
+      << "Diagnostic must identify the return branch, got: " << err;
+}
+
+// Decode each emitted s_branch back through SOPP semantics and confirm it
+// lands at the plan-specified target. Pins the negative-immediate path:
+// build_s_branch packs a signed int16 into a uint16 field, and a wrong
+// sign-extension on decode would not be caught by the byte-equality
+// assertions in the earlier tests.
+TEST(TrampolineBuilder, EncodedBranchesRoundTripToPlanCoordinates) {
+  constexpr rj_code_arch_t kArch = ROCJITSU_CODE_ARCH_CDNA4;
+  constexpr uint64_t kAnchor = 0x100;
+  constexpr uint64_t kTrampoline = 0x200;
+
+  TrampolinePlan plan;
+  plan.arch = kArch;
+  plan.anchor_offset = kAnchor;
+  plan.original_size = 4;
+  plan.trampoline_offset = kTrampoline;
+  plan.return_target = kAnchor + 4;
+  plan.original_words = {0xDEADBEEFu};
+  plan.before_items = {InlineAsmItem{{build_s_nop(0, kArch)}}};
+  plan.emit_original = true;
+
+  auto bytes = TrampolineBuilder::build(plan);
+  ASSERT_TRUE(bytes.has_value());
+
+  // Forward: the anchor word decodes to the trampoline offset.
+  const uint32_t fwd_word = word_at(bytes->patched_anchor_bytes, 0);
+  EXPECT_EQ(resolve_sopp_target(kAnchor, fwd_word), kTrampoline);
+
+  // Return: the last trampoline word (negative immediate) decodes back to
+  // return_target. This is the only assertion in the file that exercises the
+  // negative-immediate sign-extension path semantically rather than by byte
+  // equality against build_s_branch(-66, ...).
+  const uint64_t ret_pc =
+      kTrampoline + (bytes->trampoline_words.size() - 1) * sizeof(uint32_t);
+  EXPECT_EQ(resolve_sopp_target(ret_pc, bytes->trampoline_words.back()),
+            plan.return_target);
+}
+
+// Under the inline-nop smoke body (1 nop + 1-2 original words = 8-12 bytes
+// between forward and return branches), the asymmetry forces a layout where
+// forward = INT16_MAX implies return = -32770 and vice versa. Positive-limit
+// success cases at the builder level are therefore not constructible without
+// pathological return_target divergence; the math-level positive-limit cases
+// are covered by ComputeSoppBranchSimm16.MaxPositiveSimm16 in
+// instruction_builder_test.cpp.
+
+TEST(TrampolineBuilder, ForwardSimm16AtNegativeLimitSucceeds) {
+  // Trampoline placed before the anchor so the forward branch goes backward.
+  // forward_simm16 = (trampoline - (anchor + 4)) / 4 = INT16_MIN = -32768
+  //   → trampoline = anchor + 4 + (-32768)*4
+  //   With anchor = 131068, trampoline = 0.
+  constexpr rj_code_arch_t kArch = ROCJITSU_CODE_ARCH_CDNA4;
+  constexpr uint64_t kTrampoline = 0;
+  constexpr uint64_t kAnchor = 131068;
+
+  TrampolinePlan plan;
+  plan.arch = kArch;
+  plan.anchor_offset = kAnchor;
+  plan.original_size = 4;
+  plan.trampoline_offset = kTrampoline;
+  plan.return_target = kAnchor + 4;
+  plan.original_words = {0xDEADBEEFu};
+  plan.before_items = {InlineAsmItem{{build_s_nop(0, kArch)}}};
+  plan.emit_original = true;
+
+  auto bytes = TrampolineBuilder::build(plan);
+  ASSERT_TRUE(bytes.has_value());
+  EXPECT_EQ(word_at(bytes->patched_anchor_bytes, 0),
+            build_s_branch(std::numeric_limits<int16_t>::min(), kArch));
+}
+
+TEST(TrampolineBuilder, ReturnSimm16AtNegativeLimitSucceeds) {
+  // Trampoline placed far ahead of the anchor so the return branch goes
+  // backward at exactly INT16_MIN.
+  //   return_branch_pc = trampoline + 4 + original_size
+  //   return_simm16    = (return_target - return_branch_pc - 4) / 4 = -32768
+  //   With anchor = 0, original_size = 4, return_target = 4:
+  //     trampoline + 8 + 4 = 4 + 131072  →  trampoline = 131064
+  constexpr rj_code_arch_t kArch = ROCJITSU_CODE_ARCH_CDNA4;
+  constexpr uint64_t kAnchor = 0;
+  constexpr uint64_t kTrampoline = 131064;
+
+  TrampolinePlan plan;
+  plan.arch = kArch;
+  plan.anchor_offset = kAnchor;
+  plan.original_size = 4;
+  plan.trampoline_offset = kTrampoline;
+  plan.return_target = kAnchor + 4;
+  plan.original_words = {0xDEADBEEFu};
+  plan.before_items = {InlineAsmItem{{build_s_nop(0, kArch)}}};
+  plan.emit_original = true;
+
+  auto bytes = TrampolineBuilder::build(plan);
+  ASSERT_TRUE(bytes.has_value());
+  EXPECT_EQ(bytes->trampoline_words.back(),
+            build_s_branch(std::numeric_limits<int16_t>::min(), kArch));
+}
+
+//==============================================================================
+// Inline-nop smoke guardrail
+//
+// The first DBI milestone (inline-nop smoke) only emits the no-clobber
+// `s_nop 0` placeholder body so we never produce instrumentation bytes that
+// need clobber handling or liveness. This is scaffolding — delete this block
+// when arbitrary inline-asm becomes legal.
+//==============================================================================
+
+TEST(TrampolineBuilderInlineNopSmokeGuardrail, RejectsNonCanonicalBody) {
+  constexpr rj_code_arch_t kArch = ROCJITSU_CODE_ARCH_CDNA4;
+
+  auto valid_plan = [&] {
+    TrampolinePlan p;
+    p.arch = kArch;
+    p.anchor_offset = 0x100;
+    p.original_size = 4;
+    p.trampoline_offset = 0x200;
+    p.return_target = 0x104;
+    p.original_words = {0xDEADBEEFu};
+    p.before_items = {InlineAsmItem{{build_s_nop(0, kArch)}}};
+    p.emit_original = true;
+    return p;
+  };
+
+  // Sanity: the unmutated plan is accepted, so each sub-case below is
+  // exercising exactly one guardrail dimension.
+  ASSERT_TRUE(TrampolineBuilder::build(valid_plan()).has_value());
+
+  // Extra before-item.
+  {
+    auto plan = valid_plan();
+    plan.before_items.push_back(InlineAsmItem{{build_s_nop(0, kArch)}});
+    std::string err;
+    EXPECT_FALSE(TrampolineBuilder::build(plan, &err).has_value())
+        << "extra before-item must be rejected";
+    EXPECT_FALSE(err.empty());
+  }
+
+  // Before-item that isn't s_nop 0.
+  {
+    auto plan = valid_plan();
+    plan.before_items = {InlineAsmItem{{build_s_branch(0, kArch)}}};
+    std::string err;
+    EXPECT_FALSE(TrampolineBuilder::build(plan, &err).has_value())
+        << "non-placeholder before-item must be rejected";
+    EXPECT_FALSE(err.empty());
+  }
+
+  // Any after-item at all.
+  {
+    auto plan = valid_plan();
+    plan.after_items.push_back(InlineAsmItem{{build_s_nop(0, kArch)}});
+    std::string err;
+    EXPECT_FALSE(TrampolineBuilder::build(plan, &err).has_value())
+        << "non-empty after_items must be rejected";
+    EXPECT_FALSE(err.empty());
+  }
+
+  // emit_original = false.
+  {
+    auto plan = valid_plan();
+    plan.emit_original = false;
+    std::string err;
+    EXPECT_FALSE(TrampolineBuilder::build(plan, &err).has_value())
+        << "emit_original = false must be rejected";
+    EXPECT_FALSE(err.empty());
+  }
+}
+
+} // namespace
+} // namespace rocjitsu

--- a/emulation/rocjitsu/tests/patch/trampoline_builder_test.cpp
+++ b/emulation/rocjitsu/tests/patch/trampoline_builder_test.cpp
@@ -299,11 +299,11 @@ TEST(TrampolineBuilder, ReturnSimm16AtNegativeLimitSucceeds) {
             build_s_branch(std::numeric_limits<int16_t>::min(), kArch));
 }
 
-// NOTE: the inline-nop smoke guardrail used to live in TrampolineBuilder and
-// was tested here. It has been moved to the orchestrator boundary as
-// validate_inline_nop_smoke_plan() in instrumentor.h, and the test moved with
-// it (see InlineNopSmokeGuardrail.* in instrumentor_test.cpp). The builder is
-// now generic and accepts any well-formed plan; milestone-scoped restrictions
+// NOTE: the inline-nop guardrail used to live in TrampolineBuilder and was
+// tested here. It has been moved to the orchestrator boundary as
+// validate_inline_nop_plan() in instrumentor.h, and the test moved with it
+// (see InlineNopGuardrail.* in instrumentor_test.cpp). The builder is now
+// generic and accepts any well-formed plan; milestone-scoped restrictions
 // are the orchestrator's responsibility.
 
 } // namespace

--- a/emulation/rocjitsu/tests/patch/trampoline_builder_test.cpp
+++ b/emulation/rocjitsu/tests/patch/trampoline_builder_test.cpp
@@ -173,6 +173,23 @@ TEST(TrampolineBuilder, RejectsOriginalWordsSizeMismatch) {
   EXPECT_FALSE(err.empty()) << "Builder must explain the mismatch";
 }
 
+// arch defaults to ROCJITSU_CODE_ARCH_INVALID; a caller who forgets to set it
+// must be rejected loudly rather than silently emitting a wrong-ISA encoding.
+TEST(TrampolineBuilder, RejectsUnsetArch) {
+  TrampolinePlan plan; // arch left at its ROCJITSU_CODE_ARCH_INVALID default.
+  plan.anchor_offset = 0x100;
+  plan.original_size = 4;
+  plan.trampoline_offset = 0x200;
+  plan.return_target = 0x104;
+  plan.original_words = {0xDEADBEEFu};
+  plan.emit_original = true;
+
+  std::string err;
+  EXPECT_FALSE(TrampolineBuilder::build(plan, &err).has_value());
+  EXPECT_NE(err.find("arch"), std::string::npos)
+      << "Diagnostic must identify the unset arch, got: " << err;
+}
+
 TEST(TrampolineBuilder, ReturnBranchOverflowFails) {
   // With forward_simm16 = INT16_MAX = 32767 (just in range) and
   // original_size = 4, the return branch needs simm16 = -32770 (one past


### PR DESCRIPTION
## Motivation

The goal of this PR was to put together the pieces necessary to instrument an instruction in a kernel with a simple `nop` on a gfx90a. The next milestone will be to instrument with a probe. The idea behind this PR is to just get things started and give us something to build off of. The new classes only do what is necessary to instrument with the `nop`, so they will look incomplete. 


## Technical Details

This PR includes

- The first version of a TrampolinePlan (not in the original dbi plan): 
  - This is to describe what the TrampolineBuilder will need to do, where to do it, and what the constraints are (e.g. what architecture to assume). 
  - Currently, the Instrumentor creates it and passes it to the TrampolineBuilder one time. It is possible that this will be passed back and forth in the future (e.g. the Instrumentor creates the TrampolinePlan, asks the TrampolineBuilder how much space will be required for it, allocate the space and update the Plan, and then pass the final version back to the TrampolineBuilder. It feels easier to keep this information together, rather than passing arguments back and forth but I am open to other suggestions.
- The first version of the TrampolineBuilder:
  -  Accepts a "TrampolinePlan"  and returns the trampoline and the branch to the trampoline.
  - For this case, the trampoline is just a nop, the original instruction, and a branch back to the `.text` section.
- The first version of the Instrumentor:
  - This is the BI conductor, putting all the pieces together. Current workflow (until we have an API) is to create the Instrumentor, add instrumentation points, and then `patch`.
  - To make this PR as easy as possible, it only supports instrumenting a single instruction, although generalizing really shouldn't be hard.
  - There are currently two `patch` functions. They all return an InstrumentedCodeObject (provides the patched elf), warnings and errors. One includes instrumentation site information. It is currently only used for testing purposes, but it is possible we will want to pass some form of the instrumentation site info for more complex tooling. For example, if a tool wants to pair static information from parsing the code object with dynamic information collected by the probe, it will need to know which sites actually get instrumented. This could be a way to do that.
  - The patching workflow is:
    - `validate_points`: Get the decoded `Instruction` at the given anchors and make sure the point is good with `validate_anchor` (e.g. is instrumentable, has correct metadata). At this time, PC-relative instructions are not allowed because moving those requires more information. 
    - Creates the `.rj_trampolines` section (via CodeObjectPatcher)
    - Creates the TrampolinePlan at each instrumentation site and has TrampolineBuilder build them
    - Currently makes sure the instrumentation settings match the inlined nop settings (so that no one makes the mistake of thinking that more is supported than really is)
    - Updates the `.text.` and `.rj_trampolines` sections with the bytes that TrampolineBuilder provided

EDIT - 06/17/2026:
- Includes code from PR #6929 (added the endpgm builder) and PR #7213 (instrument multiple instructions).
- Instead of creating an `.rj_trampolines` section, we use local code caves like DBT in PR #6733.

## JIRA ID

N/A

## Test Plan

* All previous tests still need to work
* Added unit tests for the new classes
* gfx90a only (for now): Added an end-to-end test using the included vector_add. Instruments a single instruction with the inlined nop. Tests that this actually happens by:
  - Saving the original kernel so that both original and instrumented can be executed
  - Making sure that the original kernel has output and then making sure that the instrumented kernel produces the same output
  - Statically checking that the instrumented instruction is now a branch
  - Placing garbage in the `rj_trampolines` section and making sure the instrumented kernel breaks

## Test Result

* All previous tests still pass
* Added unit tests pass
* gfx90a-specific tests pass on a supported system and does not run on an unsupported system

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
