### PR TITLE
[RCCL] bootstrap: fix Debug unit-test link for bootstrapBidirEnabled

### DIFF
--- a/projects/rccl/src/bootstrap.cc
+++ b/projects/rccl/src/bootstrap.cc
@@ -148,11 +148,13 @@ static inline bool bootstrapNetEnabledEffective(int nranks) {
 // overhead must be amortised over enough ranks. Defaults are documented above.
 //
 // Exposed (non-static) so test/BootstrapBidirTests.cpp can verify the env-var contract.
-// The visibility("hidden") attribute keeps the symbol off librccl.so's exported
-// dynsym table even in BUILD_TESTS=ON Debug builds (which globally relax visibility
-// to let tests link against internal helpers). Defense-in-depth on top of the
-// production -fvisibility=hidden flag — see src/CMakeLists.txt visibility block.
-__attribute__((visibility("hidden")))
+// Visibility follows the global -fvisibility flag (see src/CMakeLists.txt): production
+// and Release/non-Debug test builds compile with -fvisibility=hidden, so the symbol
+// stays off librccl.so's exported dynsym table. The BUILD_TESTS + Debug configuration
+// switches to -fvisibility=default precisely so rccl-UnitTestsFixturesDebug can link
+// against internal helpers like this one — do NOT pin an explicit visibility("hidden")
+// here, as the attribute overrides the command-line flag and breaks that link step
+// (ld.lld: undefined hidden symbol: bootstrapBidirEnabled).
 bool bootstrapBidirEnabled(int nranks, int kind) {
   if (nranks < 3) return false;
   bool netOn = bootstrapNetEnabledEffective(nranks);

--- a/projects/rccl/src/include/bootstrap.h
+++ b/projects/rccl/src/include/bootstrap.h
@@ -43,10 +43,11 @@ ncclResult_t bootstrapAbort(void* commState);
 // the exact contract production uses.
 //   nranks: total ranks in the comm (returns false unconditionally for < 3).
 //   kind:   0 = socket OOB path, 1 = net (IB/OFI) OOB path.
-// Marked visibility("hidden") so the symbol is linkable inside librccl.so for
-// the test TU but never exported in the final shared library; see the matching
-// attribute on the definition in src/bootstrap.cc.
-__attribute__((visibility("hidden")))
+// Visibility is left to the global -fvisibility flag: hidden (not exported) in
+// production and Release builds, default (exported, so rccl-UnitTestsFixturesDebug
+// can link it) in BUILD_TESTS + Debug builds. See the note on the definition in
+// src/bootstrap.cc — an explicit visibility("hidden") attribute here would override
+// that flag and break the Debug test link.
 bool bootstrapBidirEnabled(int nranks, int kind);
 
 #endif


### PR DESCRIPTION
## Problem

A Debug build of the unit tests fails to link:

```
[100%] Linking CXX executable rccl-UnitTestsFixturesDebug
ld.lld: error: undefined hidden symbol: bootstrapBidirEnabled(int, int)
>>> referenced by BootstrapBidirTests.cpp:40
clang++: error: linker command failed with exit code 1
```

```cmake
elseif(BUILD_TESTS)
  if (ROCM_VERSION VERSION_GREATER_EQUAL "60400" AND CMAKE_BUILD_TYPE MATCHES "Debug")
    target_compile_options(rccl PRIVATE -fvisibility=default)
  else()
    target_compile_options(rccl PRIVATE -fvisibility=hidden)
  endif()
```

The pinned `visibility("hidden")` attribute defeats that `-fvisibility=default` for this one symbol, keeping it hidden in the Debug `librccl.so`, so the test can't resolve it -> `undefined hidden symbol`.

## Fix

Drop the explicit attribute from both the definition (`src/bootstrap.cc`) and declaration (`src/include/bootstrap.h`) and let visibility follow the global `-fvisibility` flag, exactly like every other internal symbol the Debug fixtures consume:

- **Debug + BUILD_TESTS** -> `-fvisibility=default` -> symbol exported -> `rccl-UnitTestsFixturesDebug` links (OK)
- **Release / production** -> global `-fvisibility=hidden` -> symbol stays off `librccl.so`'s exported dynsym table (production guarantee unchanged; `BootstrapBidirTests.cpp` is excluded from Release builds anyway)

## Verification

Minimal reproduction mirroring the build model (shared lib built with `-fvisibility=default`, consumer linking against it):

- **With** `visibility("hidden")` on top of `-fvisibility=default` -> linker error `undefined hidden symbol` / `undefined reference to bootstrapBidirEnabled` (reproduces the failure).
- **Without** the attribute -> links and runs cleanly.

The change is comment + attribute removal only; no behavioural change.
