### PR TITLE
[codespell] Fix spelling errors in rocjitsu

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/external_headers/hsa_headers/hsa/hsa.h
+++ b/emulation/rocjitsu/lib/rocjitsu/external_headers/hsa_headers/hsa/hsa.h
@@ -848,7 +848,7 @@ typedef enum {
    */
   HSA_AGENT_INFO_FEATURE = 2,
   /**
-   * @deprecated Query ::HSA_ISA_INFO_MACHINE_MODELS for a given intruction set
+   * @deprecated Query ::HSA_ISA_INFO_MACHINE_MODELS for a given instruction set
    * architecture supported by the agent instead.  If more than one ISA is
    * supported by the agent, the returned value corresponds to the first ISA
    * enumerated by ::hsa_agent_iterate_isas.
@@ -858,7 +858,7 @@ typedef enum {
    */
   HSA_AGENT_INFO_MACHINE_MODEL = 3,
   /**
-   * @deprecated Query ::HSA_ISA_INFO_PROFILES for a given intruction set
+   * @deprecated Query ::HSA_ISA_INFO_PROFILES for a given instruction set
    * architecture supported by the agent instead.  If more than one ISA is
    * supported by the agent, the returned value corresponds to the first ISA
    * enumerated by ::hsa_agent_iterate_isas.
@@ -869,7 +869,7 @@ typedef enum {
   HSA_AGENT_INFO_PROFILE = 4,
   /**
    * @deprecated Query ::HSA_ISA_INFO_DEFAULT_FLOAT_ROUNDING_MODES for a given
-   * intruction set architecture supported by the agent instead.  If more than
+   * instruction set architecture supported by the agent instead.  If more than
    * one ISA is supported by the agent, the returned value corresponds to the
    * first ISA enumerated by ::hsa_agent_iterate_isas.
    *
@@ -880,7 +880,7 @@ typedef enum {
   HSA_AGENT_INFO_DEFAULT_FLOAT_ROUNDING_MODE = 5,
   /**
    * @deprecated Query ::HSA_ISA_INFO_BASE_PROFILE_DEFAULT_FLOAT_ROUNDING_MODES
-   * for a given intruction set architecture supported by the agent instead.  If
+   * for a given instruction set architecture supported by the agent instead.  If
    * more than one ISA is supported by the agent, the returned value corresponds
    * to the first ISA enumerated by ::hsa_agent_iterate_isas.
    *
@@ -892,7 +892,7 @@ typedef enum {
    */
   HSA_AGENT_INFO_BASE_PROFILE_DEFAULT_FLOAT_ROUNDING_MODES = 23,
   /**
-   * @deprecated Query ::HSA_ISA_INFO_FAST_F16_OPERATION for a given intruction
+   * @deprecated Query ::HSA_ISA_INFO_FAST_F16_OPERATION for a given instruction
    * set architecture supported by the agent instead.  If more than one ISA is
    * supported by the agent, the returned value corresponds to the first ISA
    * enumerated by ::hsa_agent_iterate_isas.
@@ -905,7 +905,7 @@ typedef enum {
   HSA_AGENT_INFO_FAST_F16_OPERATION = 24,
   /**
    * @deprecated Query ::HSA_WAVEFRONT_INFO_SIZE for a given wavefront and
-   * intruction set architecture supported by the agent instead.  If more than
+   * instruction set architecture supported by the agent instead.  If more than
    * one ISA is supported by the agent, the returned value corresponds to the
    * first ISA enumerated by ::hsa_agent_iterate_isas and the first wavefront
    * enumerated by ::hsa_isa_iterate_wavefronts for that ISA.
@@ -916,7 +916,7 @@ typedef enum {
    */
   HSA_AGENT_INFO_WAVEFRONT_SIZE = 6,
   /**
-   * @deprecated Query ::HSA_ISA_INFO_WORKGROUP_MAX_DIM for a given intruction
+   * @deprecated Query ::HSA_ISA_INFO_WORKGROUP_MAX_DIM for a given instruction
    * set architecture supported by the agent instead.  If more than one ISA is
    * supported by the agent, the returned value corresponds to the first ISA
    * enumerated by ::hsa_agent_iterate_isas.
@@ -929,7 +929,7 @@ typedef enum {
    */
   HSA_AGENT_INFO_WORKGROUP_MAX_DIM = 7,
   /**
-   * @deprecated Query ::HSA_ISA_INFO_WORKGROUP_MAX_SIZE for a given intruction
+   * @deprecated Query ::HSA_ISA_INFO_WORKGROUP_MAX_SIZE for a given instruction
    * set architecture supported by the agent instead.  If more than one ISA is
    * supported by the agent, the returned value corresponds to the first ISA
    * enumerated by ::hsa_agent_iterate_isas.
@@ -940,7 +940,7 @@ typedef enum {
    */
   HSA_AGENT_INFO_WORKGROUP_MAX_SIZE = 8,
   /**
-   * @deprecated Query ::HSA_ISA_INFO_GRID_MAX_DIM for a given intruction set
+   * @deprecated Query ::HSA_ISA_INFO_GRID_MAX_DIM for a given instruction set
    * architecture supported by the agent instead.
    *
    * Maximum number of work-items of each dimension of a grid. Each maximum must
@@ -952,7 +952,7 @@ typedef enum {
    */
   HSA_AGENT_INFO_GRID_MAX_DIM = 9,
   /**
-   * @deprecated Query ::HSA_ISA_INFO_GRID_MAX_SIZE for a given intruction set
+   * @deprecated Query ::HSA_ISA_INFO_GRID_MAX_SIZE for a given instruction set
    * architecture supported by the agent instead.  If more than one ISA is
    * supported by the agent, the returned value corresponds to the first ISA
    * enumerated by ::hsa_agent_iterate_isas.
@@ -963,7 +963,7 @@ typedef enum {
    */
   HSA_AGENT_INFO_GRID_MAX_SIZE = 10,
   /**
-   * @deprecated Query ::HSA_ISA_INFO_FBARRIER_MAX_SIZE for a given intruction
+   * @deprecated Query ::HSA_ISA_INFO_FBARRIER_MAX_SIZE for a given instruction
    * set architecture supported by the agent instead.  If more than one ISA is
    * supported by the agent, the returned value corresponds to the first ISA
    * enumerated by ::hsa_agent_iterate_isas.
@@ -1135,7 +1135,7 @@ typedef enum {
 } hsa_exception_policy_t;
 
 /**
- * @deprecated Use ::hsa_isa_get_exception_policies for a given intruction set
+ * @deprecated Use ::hsa_isa_get_exception_policies for a given instruction set
  * architecture supported by the agent instead. If more than one ISA is
  * supported by the agent, this function uses the first value returned by
  * ::hsa_agent_iterate_isas.
@@ -3060,7 +3060,7 @@ typedef enum {
   /**
    * Updates to memory in this region can be performed by a single agent at
    * a time. If a different agent in the system is allowed to access the
-   * region, the application must explicitely invoke ::hsa_memory_assign_agent
+   * region, the application must explicitly invoke ::hsa_memory_assign_agent
    * in order to transfer ownership to that agent for a particular buffer.
    */
   HSA_REGION_GLOBAL_FLAG_COARSE_GRAINED = 4,
@@ -3276,8 +3276,8 @@ hsa_status_t HSA_API hsa_memory_copy(void *dst, const void *src, size_t size);
  * @brief Change the ownership of a global, coarse-grained buffer.
  *
  * @details The contents of a coarse-grained buffer are visible to an agent
- * only after ownership has been explicitely transferred to that agent. Once the
- * operation completes, the previous owner cannot longer access the data in the
+ * only after ownership has been explicitly transferred to that agent. Once the
+ * operation completes, the previous owner can no longer access the data in the
  * buffer.
  *
  * An implementation of the HSA runtime is allowed, but not required, to change

--- a/emulation/rocjitsu/lib/rocjitsu/external_headers/hsa_headers/linux/uapi/kfd_ioctl.h
+++ b/emulation/rocjitsu/lib/rocjitsu/external_headers/hsa_headers/linux/uapi/kfd_ioctl.h
@@ -378,7 +378,7 @@ struct kfd_runtime_info {
  *
  * Coordinates debug exception signalling and debug device enablement with runtime.
  *
- * @r_debug - pointer to user struct for sharing information between ROCr and the debuggger
+ * @r_debug - pointer to user struct for sharing information between ROCr and the debugger
  * @mode_mask - mask to set mode
  *	KFD_RUNTIME_ENABLE_MODE_ENABLE_MASK - enable runtime for debugging, otherwise disable
  *	KFD_RUNTIME_ENABLE_MODE_TTMP_SAVE_MASK - enable trap temporary setup (ignore on disable)
@@ -465,7 +465,7 @@ enum kfd_dbg_trap_operations {
  *     @exception_mask (IN)	- exceptions to raise to the debugger
  *     @rinfo_ptr      (IN)	- pointer to runtime info buffer (see kfd_runtime_info)
  *     @rinfo_size     (IN/OUT)	- size of runtime info buffer in bytes
- *     @dbg_fd	       (IN)	- fd the KFD will nofify the debugger with of raised
+ *     @dbg_fd	       (IN)	- fd the KFD will notify the debugger with of raised
  *				  exceptions set in exception_mask.
  *
  *     Generic errors apply (see kfd_dbg_trap_operations).
@@ -1234,7 +1234,7 @@ struct kfd_ioctl_spm_args {
 /**
  * kfd_ioctl_spm_buffer_header - SPM Buffer header for kfd_ioctl_spm_args->dest_buf
  *
- * @version        [out]: spm versiom
+ * @version        [out]: spm version
  * @bytes_copied   [out]: amount of data for each sub-block
  * @has_data_loss: [out]: boolean indicating whether data was lost for each sub-block
  *                        (e.g. due to a ring-buffer overflow)

--- a/emulation/rocjitsu/lib/util/include/util/bit.h
+++ b/emulation/rocjitsu/lib/util/include/util/bit.h
@@ -119,8 +119,8 @@ inline T clear_bit(T val, int position) {
 
 /// @brief Extract bits from first to last inclusive from val and justify to the LSB.
 /// @param val The value to extract bits from.
-/// @param first The first bit (LSB) to extact.
-/// @param last The last bit (MSB) to extact.
+/// @param first The first bit (LSB) to extract.
+/// @param last The last bit (MSB) to extract.
 /// @returns The extracted bits.
 template <typename T>
   requires metaprogramming::IsUnsignedInt<T>
@@ -134,7 +134,7 @@ inline T bits(T val, int first, int last) {
 
 /// @brief Extract bit specified by position from val and justify to the LSB.
 /// @param val The value to extract the bit from.
-/// @param position The bit to extact.
+/// @param position The bit to extract.
 /// @returns The extracted bit.
 template <typename T>
   requires metaprogramming::IsUnsignedInt<T>
@@ -146,10 +146,10 @@ inline T bit(T val, int position) {
 }
 
 /// @brief Extend bits of val starting from the LSB up to num_bits - 1.
-/// @details The bits are replicated as many times as possibe based on
+/// @details The bits are replicated as many times as possible based on
 /// the size of T. The number of bits should be a power of two.
 /// @param[in] val Value to be extended.
-/// @param[in] num_bits The number of of bits in val to extend.
+/// @param[in] num_bits The number of bits in val to extend.
 /// @returns Value containing the replicated bits.
 template <typename T>
   requires metaprogramming::IsUnsignedInt<T>

--- a/emulation/rocjitsu/lib/util/include/util/intrusive_list.h
+++ b/emulation/rocjitsu/lib/util/include/util/intrusive_list.h
@@ -164,7 +164,7 @@ public:
     node.next_ = nullptr;
     return Iterator(next);
   }
-  /// @brief Return an iterator to the begining of the list.
+  /// @brief Return an iterator to the beginning of the list.
   /// @returns Iterator pointing to the first element in the list.
   Iterator begin() { return ++Iterator(sentinel_); }
   /// @brief Return an iterator past the end of the list.


### PR DESCRIPTION
## Motivation

We should fix spelling errors in ROCm

## Technical Details

Clean with `codespell -L=HSA,hsa,nd,offen,VALU,hart,FPR,VAs,FLE,fle,te,TRU,renderD,Misue,Mattern,Condtion,Identifer,Inactivate`

## JIRA ID

N/A

## Test Plan

CI passes (no functional changes)

## Test Result

Passes

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
