### PR TITLE
ROCr: Add a runtime interface to configure RAS poison-consumption SIGBUS

### DIFF
--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/drm/amdgpu_drm.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/drm/amdgpu_drm.h
@@ -54,6 +54,7 @@ extern "C" {
 #define DRM_AMDGPU_VM			0x13
 #define DRM_AMDGPU_FENCE_TO_HANDLE	0x14
 #define DRM_AMDGPU_SCHED		0x15
+#define DRM_AMDGPU_PROC_OPTIONS	0x1A
 
 /* hybrid specific ioctls */
 #define DRM_AMDGPU_SEM			0x5b
@@ -75,6 +76,7 @@ extern "C" {
 #define DRM_IOCTL_AMDGPU_VM		DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_VM, union drm_amdgpu_vm)
 #define DRM_IOCTL_AMDGPU_FENCE_TO_HANDLE DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_FENCE_TO_HANDLE, union drm_amdgpu_fence_to_handle)
 #define DRM_IOCTL_AMDGPU_SCHED		DRM_IOW(DRM_COMMAND_BASE + DRM_AMDGPU_SCHED, union drm_amdgpu_sched)
+#define DRM_IOCTL_AMDGPU_PROC_OPTIONS	DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_PROC_OPTIONS, struct drm_amdgpu_proc_options)
 /* hybrid specific ioctls */
 #define DRM_IOCTL_AMDGPU_SEM		DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_SEM, union drm_amdgpu_sem)
 #define DRM_IOCTL_AMDGPU_GEM_DGMA	DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_GEM_DGMA, struct drm_amdgpu_gem_dgma)
@@ -397,6 +399,18 @@ struct drm_amdgpu_sched_in {
 union drm_amdgpu_sched {
 	struct drm_amdgpu_sched_in in;
 };
+
+struct drm_amdgpu_proc_options {
+  __u32 op;
+  union {
+    struct {
+      __u32 value;
+    } kfd_sigbus_delay;
+  };
+};
+
+#define AMDGPU_PROC_OPTIONS_OP_KFD_SIGBUS_DELAY 0
+#define AMDGPU_PROC_OPTIONS_KFD_SIGBUS_DELAY_DISABLED UINT32_MAX
 
 /*
  * This is not a reliable API and you should expect it to fail for any

--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt.h
@@ -1342,6 +1342,17 @@ hsaKmtModelEnabled(
 
 
 /**
+ * Forwards the SIGBUS delay
+ */
+HSAKMT_STATUS
+HSAKMTAPI
+hsaKmtSetSigbusDelay(
+    HSAuint32 NodeId,    //IN
+    HSAuint32 DelayMs    //IN
+);
+
+
+/**
  *  Experimental APIs to abstract DRM calls to thunk
 */
 HSAKMT_STATUS

--- a/projects/rocr-runtime/libhsakmt/src/dxg/librocdxg.ver
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/librocdxg.ver
@@ -65,6 +65,7 @@ hsaKmtPmcStopTrace;
 hsaKmtMapGraphicHandle;
 hsaKmtUnmapGraphicHandle;
 hsaKmtSetTrapHandler;
+hsaKmtSetSigbusDelay;
 hsaKmtGetTileConfig;
 hsaKmtQueryPointerInfo;
 hsaKmtSetMemoryUserData;

--- a/projects/rocr-runtime/libhsakmt/src/dxg/queues.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/queues.cpp
@@ -244,3 +244,8 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtQueueRingDoorbell(HSA_QUEUEID QueueId, uint64_t va
   queue_->RingDoorbell(value);
   return HSAKMT_STATUS_SUCCESS;
 }
+
+HSAKMT_STATUS HSAKMTAPI hsaKmtSetSigbusDelay(HSAuint32 /*NodeId*/,
+                                             HSAuint32 /*DelayMs*/) {
+  return HSAKMT_STATUS_NOT_SUPPORTED;
+}

--- a/projects/rocr-runtime/libhsakmt/src/libhsakmt.ver
+++ b/projects/rocr-runtime/libhsakmt/src/libhsakmt.ver
@@ -102,6 +102,7 @@ hsaKmtMemoryVaUnmap;
 hsaKmtMemHandleFree;
 hsaKmtMemoryGetCpuAddr;
 hsaKmtMemoryCpuMap;
+hsaKmtSetSigbusDelay;
 local: *;
 };
 

--- a/projects/rocr-runtime/libhsakmt/src/memory.c
+++ b/projects/rocr-runtime/libhsakmt/src/memory.c
@@ -31,9 +31,10 @@
 #include <sys/types.h>
 #include <sys/mman.h>
 #include <fcntl.h>
+#include <sys/ioctl.h>
 
 #include <amdgpu.h>
-#include <amdgpu_drm.h>
+#include "hsakmt/drm/amdgpu_drm.h"
 #include <xf86drm.h>
 
 #include "fmm.h"
@@ -1098,4 +1099,31 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtMemoryGetCpuAddr(HsaAMDGPUDeviceHandle DeviceHandl
   	*fd = (HSAint32)renderFd;
   	*cpu_addr = (HSAuint64)args.out.addr_ptr;
   	return HSAKMT_STATUS_SUCCESS;
+}
+
+HSAKMT_STATUS HSAKMTAPI hsaKmtSetSigbusDelay(HSAuint32 NodeId, HSAuint32 DelayMs)
+{
+	CHECK_KFD_OPEN();
+
+	if (!hsakmt_fn_amdgpu_device_get_fd)
+		return HSAKMT_STATUS_NOT_SUPPORTED;
+
+	HsaAMDGPUDeviceHandle dev = NULL;
+	HSAKMT_STATUS s = hsakmt_fmm_get_amdgpu_device_handle(&hsakmt_primary_kfd_ctx,
+						      NodeId, &dev);
+	if (s != HSAKMT_STATUS_SUCCESS || dev == NULL)
+		return HSAKMT_STATUS_NOT_SUPPORTED;
+
+	int fd = hsakmt_fn_amdgpu_device_get_fd(dev);
+	if (fd < 0)
+		return HSAKMT_STATUS_NOT_SUPPORTED;
+
+	struct drm_amdgpu_proc_options args;
+	memset(&args, 0, sizeof(args));
+	args.op = AMDGPU_PROC_OPTIONS_OP_KFD_SIGBUS_DELAY;
+	args.kfd_sigbus_delay.value = DelayMs;
+	if (ioctl(fd, DRM_IOCTL_AMDGPU_PROC_OPTIONS, &args) != 0)
+		return HSAKMT_STATUS_NOT_SUPPORTED;
+
+	return HSAKMT_STATUS_SUCCESS;
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -694,6 +694,13 @@ hsa_status_t KfdDriver::SetTrapHandler(uint32_t node_id, const void* base, uint6
   return HSA_STATUS_SUCCESS;
 }
 
+hsa_status_t KfdDriver::SetSigbusDelay(uint32_t node_id, uint32_t delay_ms) const {
+  if (HSAKMT_CALL(hsaKmtSetSigbusDelay(node_id, delay_ms)) != HSAKMT_STATUS_SUCCESS)
+    return HSA_STATUS_ERROR;
+
+  return HSA_STATUS_SUCCESS;
+}
+
 hsa_status_t KfdDriver::AllocateScratchMemory(uint32_t node_id, uint64_t size, void** mem) const {
   assert(mem);
   assert(size > 0);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
@@ -127,6 +127,7 @@ public:
                                 bool* is_spm_data_loss) const override;
   hsa_status_t SetTrapHandler(uint32_t node_id, const void* base, uint64_t base_size,
                               const void* buffer_base, uint64_t buffer_base_size) const override;
+  hsa_status_t SetSigbusDelay(uint32_t node_id, uint32_t delay_ms) const override;
   hsa_status_t GetDeviceHandle(uint32_t node_id, void** device_handle) const override;
   hsa_status_t GetClockCounters(uint32_t node_id, HsaClockCounters* clock_counter) const override;
   hsa_status_t GetTileConfig(uint32_t node_id, HsaGpuTileConfig* config) const override;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
@@ -335,7 +335,7 @@ public:
   /// @return HSA_STATUS_SUCCESS, or HSA_STATUS_ERROR if the kernel/driver does
   ///         not support the opt-in (callers may treat as non-fatal).
   virtual hsa_status_t SetSigbusDelay(uint32_t /*node_id*/, uint32_t /*delay_ms*/) const {
-    return HSA_STATUS_SUCCESS;
+    return HSA_STATUS_ERROR;
   }
 
   /// @brief Gets the device handle for a specific node.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
@@ -329,6 +329,15 @@ public:
   virtual hsa_status_t SetTrapHandler(uint32_t node_id, const void* base, uint64_t base_size,
                                       const void* buffer_base, uint64_t buffer_base_size) const = 0;
 
+  /// @brief Forward the RAS-poison SIGBUS delay to the kernel driver for a node.
+  /// @param[in] node_id  Node ID of the agent.
+  /// @param[in] delay_ms Delay in ms (UINT32_MAX disables the opt-in).
+  /// @return HSA_STATUS_SUCCESS, or HSA_STATUS_ERROR if the kernel/driver does
+  ///         not support the opt-in (callers may treat as non-fatal).
+  virtual hsa_status_t SetSigbusDelay(uint32_t /*node_id*/, uint32_t /*delay_ms*/) const {
+    return HSA_STATUS_SUCCESS;
+  }
+
   /// @brief Gets the device handle for a specific node.
   /// @param node_id Node ID of the agent
   /// @param device_handle Device handle

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/thunk_loader.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/thunk_loader.h
@@ -265,6 +265,8 @@ class ThunkLoader {
                                       HSAuint64 TrapHandlerSizeInBytes, \
                                       void* TrapBufferBaseAddress, \
                                       HSAuint64 TrapBufferSizeInBytes);
+    typedef HSAKMT_STATUS (HSAKMT_DEF(hsaKmtSetSigbusDelay))(HSAuint32 NodeId, \
+                                      HSAuint32 DelayMs);
     typedef HSAKMT_STATUS (HSAKMT_DEF(hsaKmtGetTileConfig))(HSAuint32 NodeId, \
                                       HsaGpuTileConfig* config);
     typedef HSAKMT_STATUS (HSAKMT_DEF(hsaKmtQueryPointerInfo))(const void* Pointer, \
@@ -492,6 +494,7 @@ class ThunkLoader {
     HSAKMT_DEF(hsaKmtMapGraphicHandle)* HSAKMT_PFN(hsaKmtMapGraphicHandle);
     HSAKMT_DEF(hsaKmtUnmapGraphicHandle)* HSAKMT_PFN(hsaKmtUnmapGraphicHandle);
     HSAKMT_DEF(hsaKmtSetTrapHandler)* HSAKMT_PFN(hsaKmtSetTrapHandler);
+    HSAKMT_DEF(hsaKmtSetSigbusDelay)* HSAKMT_PFN(hsaKmtSetSigbusDelay);
     HSAKMT_DEF(hsaKmtGetTileConfig)* HSAKMT_PFN(hsaKmtGetTileConfig);
     HSAKMT_DEF(hsaKmtQueryPointerInfo)* HSAKMT_PFN(hsaKmtQueryPointerInfo);
     HSAKMT_DEF(hsaKmtSetMemoryUserData)* HSAKMT_PFN(hsaKmtSetMemoryUserData);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -1049,6 +1049,10 @@ hsa_status_t GpuAgent::PostToolsInit() {
   BindTrapHandler();
   InitDma();
 
+  const auto& flag = core::Runtime::runtime_singleton_->flag();
+  if (flag.poison_sigbus_delay_set())
+    driver().SetSigbusDelay(node_id(), flag.poison_sigbus_delay_ms());
+
   return HSA_STATUS_SUCCESS;
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/thunk_loader.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/thunk_loader.cpp
@@ -294,6 +294,9 @@ namespace core {
       HSAKMT_PFN(hsaKmtSetTrapHandler) = (HSAKMT_DEF(hsaKmtSetTrapHandler)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtSetTrapHandler");
       if (HSAKMT_PFN(hsaKmtSetTrapHandler) == nullptr) goto LOAD_ERROR;
 
+      // only resolved when libhsakmt exposes the RAS-poison opt-in.
+      HSAKMT_PFN(hsaKmtSetSigbusDelay) = (HSAKMT_DEF(hsaKmtSetSigbusDelay)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtSetSigbusDelay");
+
       HSAKMT_PFN(hsaKmtGetTileConfig) = (HSAKMT_DEF(hsaKmtGetTileConfig)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtGetTileConfig");
       if (HSAKMT_PFN(hsaKmtGetTileConfig) == nullptr) goto LOAD_ERROR;
 
@@ -524,6 +527,7 @@ LOAD_ERROR:
       HSAKMT_PFN(hsaKmtMapGraphicHandle) = (HSAKMT_DEF(hsaKmtMapGraphicHandle)*)(&hsaKmtMapGraphicHandle);
       HSAKMT_PFN(hsaKmtUnmapGraphicHandle) = (HSAKMT_DEF(hsaKmtUnmapGraphicHandle)*)(&hsaKmtUnmapGraphicHandle);
       HSAKMT_PFN(hsaKmtSetTrapHandler) = (HSAKMT_DEF(hsaKmtSetTrapHandler)*)(&hsaKmtSetTrapHandler);
+      HSAKMT_PFN(hsaKmtSetSigbusDelay) = (HSAKMT_DEF(hsaKmtSetSigbusDelay)*)(&hsaKmtSetSigbusDelay);
       HSAKMT_PFN(hsaKmtGetTileConfig) = (HSAKMT_DEF(hsaKmtGetTileConfig)*)(&hsaKmtGetTileConfig);
       HSAKMT_PFN(hsaKmtQueryPointerInfo) = (HSAKMT_DEF(hsaKmtQueryPointerInfo)*)(&hsaKmtQueryPointerInfo);
       HSAKMT_PFN(hsaKmtSetMemoryUserData) = (HSAKMT_DEF(hsaKmtSetMemoryUserData)*)(&hsaKmtSetMemoryUserData);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
@@ -87,6 +87,24 @@ class Flag {
     var = os::GetEnvVar("HSA_ENABLE_QUEUE_FAULT_MESSAGE");
     enable_queue_fault_message_ = (var == "0") ? false : true;
 
+    // RAS poison-consumption SIGBUS opt-in (forwarded to the amdgpu KFD driver
+    // via DRM_IOCTL_AMDGPU_PROC_OPTIONS).  Lets the registered system-event
+    // handler observe the poison-consumed event before (or instead of) the
+    // process being killed by SIGBUS.
+    //   unset / empty       - do not call ioctl, kernel default (immediate SIGBUS)
+    //   "off" / "disable"   - suppress SIGBUS entirely (UINT32_MAX)
+    //   numeric value (ms)  - safety timeout: deliver SIGBUS after N ms if the
+    //                         app does not handle the error in time
+    var = os::GetEnvVar("HSA_SIGBUS_DELAY_MS");
+    poison_sigbus_delay_set_ = !var.empty();
+    if (!poison_sigbus_delay_set_) {
+      poison_sigbus_delay_ms_ = 0;
+    } else if (var == "off" || var == "disable" || var == "disabled") {
+      poison_sigbus_delay_ms_ = UINT32_MAX;
+    } else {
+      poison_sigbus_delay_ms_ = static_cast<uint32_t>(strtoul(var.c_str(), nullptr, 0));
+    }
+
     var = os::GetEnvVar("HSA_ENABLE_INTERRUPT");
     enable_interrupt_ = (var == "0") ? false : true;
 
@@ -343,6 +361,10 @@ class Flag {
 
   bool enable_queue_fault_message() const { return enable_queue_fault_message_; }
 
+  bool poison_sigbus_delay_set() const { return poison_sigbus_delay_set_; }
+
+  uint32_t poison_sigbus_delay_ms() const { return poison_sigbus_delay_ms_; }
+
   bool enable_interrupt() const { return enable_interrupt_; }
 
   bool enable_sdma_hdp_flush() const { return enable_sdma_hdp_flush_; }
@@ -516,6 +538,8 @@ class Flag {
   bool running_valgrind_;
   bool sdma_wait_idle_;
   bool enable_queue_fault_message_;
+  bool poison_sigbus_delay_set_ = false;
+  uint32_t poison_sigbus_delay_ms_ = 0;
   bool report_tool_load_failures_;
   bool report_tool_register_failures_ = false;
   bool disable_tool_register_ = false;


### PR DESCRIPTION
This change introduces parsing of the
HSA_SIGBUS_DELAY_MS environment variable and forwards the configured value to the kernel through DRM_IOCTL_AMDGPU_PROC_OPTIONS for each GPU agent during runtime initialization.

Supported modes:
- unset/empty: leave kernel default behavior unchanged
- off/disable/disabled: suppress SIGBUS delivery
- numeric value: delay SIGBUS delivery by the specified timeout in ms

This enables applications to observe poison-consumed events via the registered system-event handler before an immediate SIGBUS terminates the process, or to apply a safety timeout before SIGBUS is delivered