### PR TITLE
rccl: net-ib resiliency refactoring for AINIC with review feedback fixes

### DIFF
--- a/projects/rccl/src/transport/net_ib_cast/CMakeLists.txt
+++ b/projects/rccl/src/transport/net_ib_cast/CMakeLists.txt
@@ -8,6 +8,8 @@ set(NET_IB_CAST_SOURCES
     src/transport/net_ib_cast/p2p_cast.h
     src/transport/net_ib_cast/p2p_resiliency_cast.h
     src/transport/net_ib_cast/p2p_resiliency_recovery_cast.h
+    src/transport/net_ib_cast/p2p_resiliency_recovery_internal.h
+    src/transport/net_ib_cast/p2p_resiliency_recovery_ainic.h
     src/transport/net_ib_cast/common.cc
     src/transport/net_ib_cast/connect.cc
     src/transport/net_ib_cast/gdr.cc
@@ -15,6 +17,7 @@ set(NET_IB_CAST_SOURCES
     src/transport/net_ib_cast/p2p.cc
     src/transport/net_ib_cast/p2p_resiliency.cc
     src/transport/net_ib_cast/p2p_resiliency_recovery.cc
+    src/transport/net_ib_cast/p2p_resiliency_recovery_ainic.cc
     src/transport/net_ib_cast/reg.cc
     src/transport/net_ib_cast/scheduler.cc
     # gin.cc and gin_host_gdaki.cc require gin/gin_host.h (CUDA/NCCL-only) — exclude from ROCm build.

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_cast.h
@@ -11,7 +11,7 @@
 #include "common_cast.h"
 #include "connect_cast.h"
 
-#define NCCL_IB_UD_GRH_SIZE 40
+#define NCCL_IB_UD_GRH_SIZE (40)
 
 struct RecoveryQpnEntry {
   uint32_t qpIndex;

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery.cc
@@ -4,7 +4,8 @@
  * See LICENSE.txt for license information
  ************************************************************************/
 
-#include "p2p_resiliency_recovery_cast.h"
+#include "p2p_resiliency_recovery_internal.h"
+#include "p2p_resiliency_recovery_ainic.h"
 #include <list>
 
 NCCL_PARAM(IbCastResiliencyPortRecovery, "IB_RESILIENCY_PORT_RECOVERY", 0);
@@ -30,14 +31,6 @@ extern int64_t ncclParamIbCastPkey();
 // no more than two batches of "alive" messsages should be pending in the CQ at
 // any time.
 #define NCCL_IB_RESILIENCY_PORT_RECOVERY_CQ_SIZE (NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX*2)
-#define NCCL_IB_RESILIENCY_PORT_RECOVERY_ACK_MSG_ID (0x1234)
-
-#define NCCL_IB_RECOVERY_QKEY 0x1234ABCD
-
-// Max QPN entries for recovery exchange. Both send and recv buffers are
-// sized to NCCL_IB_MAX_QPS entries, accommodating the worst case where
-// all QPs belong to the failed device.
-#define NCCL_IB_MAX_RECOVERY_QPN_ENTRIES NCCL_IB_MAX_QPS
 
 static ncclResult_t IbCastPortRecoveryQpInitUd(struct ncclIbQp* qp, int pkeyIndex, int portNum) {
   struct ibv_qp_attr attr;
@@ -111,85 +104,6 @@ static std::vector<ncclIbPortRecoveryCloseRequest*> recoveryCloseRequests;
 // Condition variable to signal completion of close requests
 static std::condition_variable IbCastPortRecoveryCloseCond;
 
-enum ncclIbPortRecoveryState {
-  // Recovery protocol has not started yet. Before moving to the next state,
-  // the "data CQs" and "data QPs" of the failed device should be drained.
-  ncclIbPortRecoveryStateInit,
-  // On the requestor's side: The requestor posts "alive" messages and
-  // responder receives them. After posting a batch of "alive" messages, and
-  // waiting for their local completion, the requestor transitions to the "peer
-  // ack" state waiting for an "ack" from the responder. If after a while no
-  // "ack" is received, the requestor replays this state and retransmits more
-  // "alive" messages.
-  // On the responder's side: The responder, waits until all expected "alive"
-  // messages are received and then sends an "ack" to the requestor and waits
-  // for the "ack" to complete locally. If the responder does not receive a
-  // consecutive sequence of "alive" messages, it replays this state and waits
-  // for more "alive" messages.
-  ncclIbPortRecoveryStateAliveMessages,
-  // On the requestor's side: The requestor is waiting to receive an "ack" from
-  // the responder. After receiving the "ack" message from the responder, the
-  // requestor posts the "final ack" message to the responder and waits for its
-  // local completion. After this local completion, the requestor concludes this
-  // phase and determines the port has recovered.
-  // On the responder's side: The responder waits for the "final ack" message
-  // from the requestor. After receiving the "final ack" message, the responder
-  // concludes the recovery protocol and determines the port has recovered.
-  // If a "final ack" is not received within some time window, the responder
-  // goes back to the "alive messages" state.
-  ncclIbPortRecoveryStateAck,
-  // This state represents a state where the failed device has completed the
-  // recovery protocol successfully, "data QPs" were restored and and sender
-  // and receiver can now resume posting new work requests using on the device.
-  ncclIbPortRecoveryStateSuccess,
-  // This state represents a state where the failed device could not be
-  // recovered.
-  ncclIbPortRecoveryStateFailed,
-};
-
-struct ncclIbPortRecoveryContext {
-  struct ncclIbResiliency* resCtx;
-  // The index of the device that is recovered.
-  int devIndex;
-  enum ncclIbPortRecoveryState state;
-
-  struct ibv_cq* recoveryCq;
-
-  // The time when the recovery context was initialized
-  uint64_t timeInit;
-
-  int nFailedAttempts;
-
-  // Timestamp of last issued message.
-  uint64_t timeLastMsg;
-
-  uint32_t aliveMsgNextId;
-
-  // Indicates whether an "ack" message was recived from the peer.
-  bool ackReceived;
-
-  // Indicates whether an "ack" message was posted to the peer.
-  bool ackPosted;
-  // Indicates whether an "ack" message posted to the peer was completed locally.
-  bool ackCompleted;
-
-  union {
-    struct {
-      bool aliveMsgPosted;
-      bool aliveMsgCompleted;
-    } send;
-    struct {
-      uint32_t windowBase;
-      uint32_t receivedBits;
-    } recv;
-  };
-
-  // AINIC destroy+recreate: local and remote QPN exchange buffers.
-  struct RecoveryQpnEntry localQpns[NCCL_IB_MAX_QPS];
-  int nLocalQpns;
-  struct RecoveryQpnEntry remoteQpns[NCCL_IB_MAX_QPS];
-  int nRemoteQpns;
-};
 
 // Shared inbox for new recovery contexts - protected by IbCastPortRecoveryMutex.
 // Producer threads add items here; the async thread drains it under lock.
@@ -507,6 +421,23 @@ ncclResult_t IbCastPortRecoveryQpsDestroy(struct ncclIbResiliency* resCtx, int n
 }
 
 static inline ncclResult_t IbCastPortRecoveryQpsRestore(ncclIbPortRecoveryContext* recoveryContext, bool* success) {
+  if (IbCastAinicRoce) {
+    // AINIC: ibv_modify_qp(RESET) is broken — destroy+recreate (Phase A).
+    // Sender also runs Phase B (RTR+RTS) here since it already has the remote
+    // QPNs from the ACK received before this call. Receiver runs Phase B later
+    // in ProgressAckReceiver after receiving the sender's final ACK with QPNs.
+    if (IbCastPortRecoveryQpsRestoreAinic(recoveryContext) != ncclSuccess) {
+      *success = false;
+      return ncclSuccess;
+    }
+    if (recoveryContext->resCtx->baseComm->isSend &&
+        IbCastPortRecoveryQpsToRtsAinic(recoveryContext) != ncclSuccess) {
+      *success = false;
+      return ncclSuccess;
+    }
+    *success = true;
+    return ncclSuccess;
+  }
   ncclResult_t res = ncclSuccess;
   uint nqps = recoveryContext->resCtx->baseComm->nqps;
   for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
@@ -605,228 +536,6 @@ static inline ncclResult_t IbCastPortRecoveryQpsRestore(ncclIbPortRecoveryContex
   return ncclSuccess;
 }
 
-// AINIC workaround: Destroy old QPs and create new ones (Phase A).
-// ibv_modify_qp(RESET) does not work on AINIC, so we must destroy and
-// recreate the QP to get a fresh one. This produces a new QPN which must
-// be exchanged with the remote side before RTR/RTS (Phase B).
-static inline ncclResult_t IbCastPortRecoveryQpsDestroyAndCreate(ncclIbPortRecoveryContext* recoveryContext) {
-  uint nqps = recoveryContext->resCtx->baseComm->nqps;
-  recoveryContext->nLocalQpns = 0;
-
-  for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
-    ncclIbQp* localQp = &recoveryContext->resCtx->baseComm->qps[qpIndex];
-    if (localQp->devIndex != recoveryContext->devIndex) {
-      continue;
-    }
-
-    uint32_t oldQpn = localQp->qp->qp_num;
-    INFO(NCCL_NET, "NET/IB: %s: Destroying QP %d on device %d (comm=%p, old_qp_num=%u)",
-         __func__, qpIndex, recoveryContext->devIndex,
-         recoveryContext->resCtx->baseComm, oldQpn);
-
-    NCCLCHECK(wrap_ibv_destroy_qp(localQp->qp));
-    localQp->qp = NULL;
-
-    struct ncclIbQpCreateAttr createAttr;
-    IbCastBuildDataQpCreateAttr(recoveryContext->resCtx->baseComm, recoveryContext->devIndex, &createAttr);
-    createAttr.channelId = localQp->channelId;
-    createAttr.isDataQp = localQp->isDataQp;
-    // isCtsEnabled and ctsQpSlot are left at 0 (from memset in IbCastBuildDataQpCreateAttr).
-    // CTS offload is disabled when resiliency features are enabled (init.cc).
-    NCCLCHECK(IbCastQpCreate(localQp, &createAttr));
-
-    INFO(NCCL_NET, "NET/IB: %s: Recreated QP %d on device %d (comm=%p, old_qp_num=%u, new_qp_num=%u)",
-         __func__, qpIndex, recoveryContext->devIndex,
-         recoveryContext->resCtx->baseComm, oldQpn, localQp->qp->qp_num);
-
-    // Transition to INIT
-    NCCLCHECK(IbCastQpInit(localQp));
-
-    // Record the new QPN for exchange with remote
-    int idx = recoveryContext->nLocalQpns;
-    recoveryContext->localQpns[idx].qpIndex = qpIndex;
-    recoveryContext->localQpns[idx].newQpn = localQp->qp->qp_num;
-    recoveryContext->nLocalQpns++;
-  }
-
-  // Also destroy+recreate flush QP on receiver side (it connects to itself)
-  if (!recoveryContext->resCtx->baseComm->isSend) {
-    ncclIbRecvComm* recvComm = (ncclIbRecvComm*)recoveryContext->resCtx->baseComm;
-    if (recvComm->flushEnabled) {
-      for (int i = 0; i < recvComm->base.vProps.ndevs; i++) {
-        if (i != recoveryContext->devIndex) continue;
-        struct ncclIbRecvCommDev* rCommDev = &recvComm->devs[i];
-        ncclIbQp* flushQp = &rCommDev->gpuFlush.qp;
-        INFO(NCCL_NET, "NET/IB: %s: Destroying Flush QP on device %d (comm=%p, old_qp_num=%u)",
-             __func__, i, recoveryContext->resCtx->baseComm, flushQp->qp->qp_num);
-        NCCLCHECK(wrap_ibv_destroy_qp(flushQp->qp));
-        flushQp->qp = NULL;
-        struct ncclIbQpCreateAttr flushCreateAttr;
-        IbCastBuildDataQpCreateAttr(recoveryContext->resCtx->baseComm, recoveryContext->devIndex, &flushCreateAttr);
-        flushCreateAttr.maxRecvWorkRequest = 0;
-        flushCreateAttr.maxSendWorkRequest = NET_IB_MAX_REQUESTS;
-        flushCreateAttr.channelId = flushQp->channelId;
-        flushCreateAttr.isDataQp = flushQp->isDataQp;
-        NCCLCHECK(IbCastQpCreate(flushQp, &flushCreateAttr));
-        INFO(NCCL_NET, "NET/IB: %s: Recreated Flush QP on device %d (comm=%p, new_qp_num=%u)",
-             __func__, i, recoveryContext->resCtx->baseComm, flushQp->qp->qp_num);
-        NCCLCHECK(IbCastQpInit(flushQp));
-      }
-    }
-  }
-
-  INFO(NCCL_NET, "NET/IB: %s: Phase A complete: %d QPs destroyed+recreated on device %d (comm=%p)",
-       __func__, recoveryContext->nLocalQpns, recoveryContext->devIndex,
-       recoveryContext->resCtx->baseComm);
-  return ncclSuccess;
-}
-
-// AINIC workaround: Transition recreated QPs to RTR+RTS (Phase B).
-// Uses remote QPNs received via ACK payload to set remoteQpNum before RTR.
-static inline ncclResult_t IbCastPortRecoveryQpsToRts(ncclIbPortRecoveryContext* recoveryContext) {
-  uint nqps = recoveryContext->resCtx->baseComm->nqps;
-
-  for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
-    ncclIbQp* localQp = &recoveryContext->resCtx->baseComm->qps[qpIndex];
-    if (localQp->devIndex != recoveryContext->devIndex) {
-      continue;
-    }
-
-    // Find the matching remote QPN for this QP
-    uint32_t remoteQpn = 0;
-    bool found = false;
-    for (int r = 0; r < recoveryContext->nRemoteQpns; r++) {
-      if (recoveryContext->remoteQpns[r].qpIndex == qpIndex) {
-        remoteQpn = recoveryContext->remoteQpns[r].newQpn;
-        found = true;
-        break;
-      }
-    }
-    if (!found) {
-      WARN("NET/IB: %s: No remote QPN found for QP index %d on device %d (comm=%p)",
-           __func__, qpIndex, recoveryContext->devIndex,
-           recoveryContext->resCtx->baseComm);
-      return ncclInternalError;
-    }
-
-    // Update the remote QPN and transition to RTR+RTS
-    localQp->rtrAttr.remoteQpNum = remoteQpn;
-    INFO(NCCL_NET, "NET/IB: %s: QP %d RTR with remoteQpn=%u (comm=%p, qp_num=%u)",
-         __func__, qpIndex, remoteQpn, recoveryContext->resCtx->baseComm,
-         localQp->qp->qp_num);
-
-    if (localQp->eceSupported) {
-      NCCLCHECK(wrap_ibv_set_ece(localQp->qp, &localQp->ece, &localQp->eceSupported));
-    }
-    NCCLCHECK(IbCastQpRtr(localQp));
-    NCCLCHECK(IbCastQpRts(localQp));
-
-    INFO(NCCL_NET, "NET/IB: %s: Restored QP %d on device %d (comm=%p, qp_num=%u)",
-         __func__, qpIndex, recoveryContext->devIndex,
-         recoveryContext->resCtx->baseComm, localQp->qp->qp_num);
-
-    // Pre-post receive work requests on receiver QPs
-    if (!recoveryContext->resCtx->baseComm->isSend) {
-      struct ncclIbRecvComm* recvComm = (struct ncclIbRecvComm*)recoveryContext->resCtx->baseComm;
-      NCCLCHECK(IbCastPostReceiveWorkRequestsOnQp(recvComm, localQp));
-    }
-  }
-
-  // Restore Flush QP on receiver (self-loopback — remote QPN is own new QPN)
-  if (!recoveryContext->resCtx->baseComm->isSend) {
-    ncclIbRecvComm* recvComm = (ncclIbRecvComm*)recoveryContext->resCtx->baseComm;
-    if (recvComm->flushEnabled) {
-      for (int i = 0; i < recvComm->base.vProps.ndevs; i++) {
-        if (i != recoveryContext->devIndex) continue;
-        struct ncclIbRecvCommDev* rCommDev = &recvComm->devs[i];
-        ncclIbQp* flushQp = &rCommDev->gpuFlush.qp;
-        // Self-loopback: remote QPN = own new QPN
-        flushQp->rtrAttr.remoteQpNum = flushQp->qp->qp_num;
-        NCCLCHECK(IbCastQpRtr(flushQp));
-        NCCLCHECK(IbCastQpRts(flushQp));
-        INFO(NCCL_NET, "NET/IB: %s: Restored Flush QP on device %d (comm=%p, qp_num=%u)",
-             __func__, i, recoveryContext->resCtx->baseComm, flushQp->qp->qp_num);
-      }
-    }
-  }
-
-  return ncclSuccess;
-}
-
-// Post an ACK message with QPN payload for AINIC destroy+recreate recovery.
-static inline ncclResult_t IbCastPortRecoveryPostAckWithQpns(ncclIbPortRecoveryContext* recoveryContext, bool* success) {
-  int devIdx = recoveryContext->devIndex;
-  struct ncclIbResiliency* resCtx = recoveryContext->resCtx;
-
-  // Populate the QPN send buffer with local QPN entries.
-  // Payload must fit in both the send buffer and the remote recv buffer (after GRH).
-  if (recoveryContext->nLocalQpns > NCCL_IB_MAX_RECOVERY_QPN_ENTRIES) {
-    WARN("NET/IB: %s: Too many QPN entries (%d) for recovery ACK payload (max %d)",
-         __func__, recoveryContext->nLocalQpns, NCCL_IB_MAX_RECOVERY_QPN_ENTRIES);
-    return ncclInternalError;
-  }
-  int payloadSize = recoveryContext->nLocalQpns * sizeof(struct RecoveryQpnEntry);
-  memcpy(resCtx->portRecoveryQpnBuf, recoveryContext->localQpns, payloadSize);
-
-  struct ibv_sge qpnSge;
-  qpnSge.addr = (uintptr_t)resCtx->portRecoveryQpnBuf;
-  qpnSge.length = payloadSize;
-  qpnSge.lkey = resCtx->devs[devIdx].portRecoveryQpnMr->lkey;
-
-  struct ibv_send_wr wr;
-  memset(&wr, 0, sizeof(wr));
-  wr.wr_id = recoveryContext->aliveMsgNextId;
-  wr.opcode = IBV_WR_SEND_WITH_IMM;
-  wr.imm_data = NCCL_IB_RESILIENCY_PORT_RECOVERY_ACK_MSG_ID;
-  wr.send_flags = IBV_SEND_SIGNALED;
-  wr.sg_list = &qpnSge;
-  wr.num_sge = 1;
-  wr.wr.ud.ah = resCtx->portRecoveryAh[devIdx];
-  wr.wr.ud.remote_qpn = resCtx->portRecoveryRemoteQpn[devIdx];
-  wr.wr.ud.remote_qkey = NCCL_IB_RECOVERY_QKEY;
-
-  INFO(NCCL_NET, "NET/IB: %s: %s posting ACK with %d QPN entries for device %d (comm=%p)",
-       __func__, resCtx->baseComm->isSend ? "Sender" : "Receiver",
-       recoveryContext->nLocalQpns, devIdx, resCtx->baseComm);
-
-  struct ibv_send_wr* bad_wr = NULL;
-  struct ncclIbQp* recoveryQp = &resCtx->portRecoveryQps[devIdx];
-  if (wrap_ibv_post_send(recoveryQp->qp, &wr, &bad_wr) != ncclSuccess) {
-    INFO(NCCL_NET, "NET/IB: %s: Failed to post ACK with QPNs on device %d (comm=%p, qp_num=%u)",
-         __func__, devIdx, resCtx->baseComm, recoveryQp->qp->qp_num);
-    *success = false;
-    return ncclSuccess;
-  }
-  recoveryContext->ackPosted = true;
-  *success = true;
-  return ncclSuccess;
-}
-
-// Extract QPNs from a received ACK message buffer (after GRH offset in UD recv).
-static inline void IbCastPortRecoveryExtractQpns(ncclIbPortRecoveryContext* recoveryContext, struct ibv_wc* wc) {
-  struct ncclIbResiliencyDev* resDev = &recoveryContext->resCtx->devs[recoveryContext->devIndex];
-  // UD receives prepend GRH; QPN payload starts at offset NCCL_IB_UD_GRH_SIZE
-  int totalLen = wc->byte_len;
-  int payloadLen = totalLen - NCCL_IB_UD_GRH_SIZE;
-  if (payloadLen <= 0) {
-    // No QPN payload (shouldn't happen on AINIC path, but be safe)
-    recoveryContext->nRemoteQpns = 0;
-    return;
-  }
-  int nEntries = payloadLen / sizeof(struct RecoveryQpnEntry);
-  if (nEntries > NCCL_IB_MAX_QPS) nEntries = NCCL_IB_MAX_QPS;
-
-  uint8_t* payload = resDev->portRecoveryGrhBuf + NCCL_IB_UD_GRH_SIZE;
-  memcpy(recoveryContext->remoteQpns, payload, nEntries * sizeof(struct RecoveryQpnEntry));
-  recoveryContext->nRemoteQpns = nEntries;
-
-  for (int i = 0; i < nEntries; i++) {
-    INFO(NCCL_NET, "NET/IB: %s: Extracted remote QPN: qpIndex=%u newQpn=%u (comm=%p)",
-         __func__, recoveryContext->remoteQpns[i].qpIndex,
-         recoveryContext->remoteQpns[i].newQpn,
-         recoveryContext->resCtx->baseComm);
-  }
-}
 
 static inline ncclResult_t IbCastPortRecoveryHandleCompletionReceiver(struct ncclIbPortRecoveryContext* recoveryContext, struct ibv_wc completion, bool* success) {
   ncclResult_t res = ncclSuccess;
@@ -880,10 +589,7 @@ static inline ncclResult_t IbCastPortRecoveryHandleCompletionReceiver(struct ncc
     assert(completion.opcode == IBV_WC_RECV);
     assert(completion.imm_data == NCCL_IB_RESILIENCY_PORT_RECOVERY_ACK_MSG_ID);
     INFO(NCCL_NET, "NET/IB: %s: Receiver received final ACK message for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
-    // On AINIC, extract sender's new QPNs from the final ACK payload
-    if (IbCastAinicRoce) {
-      IbCastPortRecoveryExtractQpns(recoveryContext, &completion);
-    }
+    IbCastPortRecoveryExtractQpnsAinic(recoveryContext, &completion);
     recoveryContext->ackReceived = true;
   }
   *success = true;
@@ -909,10 +615,7 @@ static inline ncclResult_t IbCastPortRecoveryHandleCompletionSender(struct ncclI
       assert(completion.opcode == IBV_WC_RECV);
       assert(completion.imm_data == NCCL_IB_RESILIENCY_PORT_RECOVERY_ACK_MSG_ID);
       INFO(NCCL_NET, "NET/IB: %s: Sender received an ACK message from the receiver for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
-      // On AINIC, extract receiver's new QPNs from the ACK payload
-      if (IbCastAinicRoce) {
-        IbCastPortRecoveryExtractQpns(recoveryContext, &completion);
-      }
+      IbCastPortRecoveryExtractQpnsAinic(recoveryContext, &completion);
       recoveryContext->ackReceived = true;
       *success = true;
       return ncclSuccess;
@@ -1013,6 +716,9 @@ static inline ncclResult_t IbCastPortRecoveryPostAliveMessages(struct ncclIbPort
 }
 
 static inline ncclResult_t IbCastPortRecoveryPostAck(ncclIbPortRecoveryContext* recoveryContext, bool* success) {
+  if (IbCastAinicRoce) {
+    return IbCastPortRecoveryPostAckWithQpnsAinic(recoveryContext, success);
+  }
   struct ibv_send_wr *bad_wr = NULL;
   struct ibv_send_wr wr;
   memset(&wr, 0, sizeof(wr));
@@ -1103,20 +809,13 @@ static inline ncclResult_t IbCastPortRecoveryProgressAliveMessagesReceiver(ncclI
         return ncclSuccess;
       }
       INFO(NCCL_NET, "NET/IB: %s: Receiver received enough in-order alive messages for device %d (comm=%p). Restoring QPs and posting ACK message.", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
-      if (IbCastAinicRoce) {
-        // AINIC workaround: destroy+recreate QPs (Phase A), send ACK with QPNs
-        NCCLCHECK(IbCastPortRecoveryQpsDestroyAndCreate(recoveryContext));
-        NCCLCHECK(IbCastPortRecoveryPostAckWithQpns(recoveryContext, &success));
-      } else {
-        // bnxt_re: standard RESET path, send zero-byte ACK
-        NCCLCHECK(IbCastPortRecoveryQpsRestore(recoveryContext, &success));
-        if (!success) {
-          INFO(NCCL_NET, "NET/IB: %s: Receiver failed to restore QPs on device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
-          *outResult = ncclIbPortRecoveryStateProgressResultFailed;
-          return ncclSuccess;
-        }
-        NCCLCHECK(IbCastPortRecoveryPostAck(recoveryContext, &success));
+      NCCLCHECK(IbCastPortRecoveryQpsRestore(recoveryContext, &success));
+      if (!success) {
+        INFO(NCCL_NET, "NET/IB: %s: Receiver failed to restore QPs on device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+        *outResult = ncclIbPortRecoveryStateProgressResultFailed;
+        return ncclSuccess;
       }
+      NCCLCHECK(IbCastPortRecoveryPostAck(recoveryContext, &success));
       if (!success) {
         INFO(NCCL_NET, "NET/IB: %s: Failed to post ACK message for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
         *outResult = ncclIbPortRecoveryStateProgressResultFailed;
@@ -1244,22 +943,13 @@ static inline ncclResult_t IbCastPortRecoveryProgressAckSender(ncclIbPortRecover
   }
 
   if (recoveryContext->ackPosted == false) {
-    if (IbCastAinicRoce) {
-      // AINIC workaround: Phase A (destroy+create) + Phase B (RTR+RTS with
-      // receiver's QPNs), then send final ACK with our new QPNs
-      NCCLCHECK(IbCastPortRecoveryQpsDestroyAndCreate(recoveryContext));
-      NCCLCHECK(IbCastPortRecoveryQpsToRts(recoveryContext));
-      NCCLCHECK(IbCastPortRecoveryPostAckWithQpns(recoveryContext, &success));
-    } else {
-      // bnxt_re: standard RESET path, send zero-byte final ACK
-      NCCLCHECK(IbCastPortRecoveryQpsRestore(recoveryContext, &success));
-      if (!success) {
-        INFO(NCCL_NET, "NET/IB: %s: Sender failed to restore QPs on device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
-        *outResult = ncclIbPortRecoveryStateProgressResultFailed;
-        return ncclSuccess;
-      }
-      NCCLCHECK(IbCastPortRecoveryPostAck(recoveryContext, &success));
+    NCCLCHECK(IbCastPortRecoveryQpsRestore(recoveryContext, &success));
+    if (!success) {
+      INFO(NCCL_NET, "NET/IB: %s: Sender failed to restore QPs on device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+      *outResult = ncclIbPortRecoveryStateProgressResultFailed;
+      return ncclSuccess;
     }
+    NCCLCHECK(IbCastPortRecoveryPostAck(recoveryContext, &success));
     if (!success) {
       INFO(NCCL_NET, "NET/IB: %s: Failed to post ack for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
       *outResult = ncclIbPortRecoveryStateProgressResultFailed;
@@ -1320,11 +1010,8 @@ static inline ncclResult_t IbCastPortRecoveryProgressAckReceiver(ncclIbPortRecov
       *outResult = ncclIbPortRecoveryStateProgressResultInProgress;
     }
   } else {
-    // Final ACK received. On AINIC, complete Phase B (RTR+RTS with sender's QPNs).
-    // On bnxt_re, QPs were already restored before the ACK was posted.
-    if (IbCastAinicRoce && recoveryContext->nRemoteQpns > 0) {
-      NCCLCHECK(IbCastPortRecoveryQpsToRts(recoveryContext));
-    }
+    // Complete Phase B (RTR+RTS with sender's QPNs). No-op on bnxt_re.
+    NCCLCHECK(IbCastPortRecoveryQpsToRtsAinic(recoveryContext));
     *outResult = ncclIbPortRecoveryStateProgressResultGoToNextState;
   }
   return ncclSuccess;

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery_ainic.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery_ainic.cc
@@ -211,7 +211,7 @@ ncclResult_t IbCastPortRecoveryPostAckWithQpnsAinic(struct ncclIbPortRecoveryCon
 void IbCastPortRecoveryExtractQpnsAinic(struct ncclIbPortRecoveryContext* recoveryContext, struct ibv_wc* wc) {
   if (!IbCastAinicRoce) return;
   struct ncclIbResiliencyDev* resDev = &recoveryContext->resCtx->devs[recoveryContext->devIndex];
-  int payloadLen = wc->byte_len - NCCL_IB_UD_GRH_SIZE;
+  int payloadLen = (int)(wc->byte_len - NCCL_IB_UD_GRH_SIZE);
   if (payloadLen <= 0) {
     recoveryContext->nRemoteQpns = 0;
     return;

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery_ainic.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery_ainic.cc
@@ -10,9 +10,8 @@
  * recreated to obtain a fresh QPN. The new QPNs are exchanged with the
  * remote peer via the ACK payload before RTR/RTS (two-phase handshake).
  *
- * Entry points called from p2p_resiliency_recovery.cc via the unified
- * wrappers IbCastPortRecoveryReceiverRestoreAndAck /
- * IbCastPortRecoverySenderRestoreAndAck.
+ * Entry points are invoked by p2p_resiliency_recovery.cc from the
+ * IbCastPortRecoveryQpsRestore / IbCastPortRecoveryPostAck flows.
  */
 
 #include "p2p_resiliency_recovery_internal.h"

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery_ainic.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery_ainic.cc
@@ -1,0 +1,232 @@
+/*************************************************************************
+ * Copyright (c) 2016-2026, NVIDIA CORPORATION. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+/* AINIC-specific QP recovery operations.
+ *
+ * On AINIC, ibv_modify_qp(RESET) is broken — QPs must be destroyed and
+ * recreated to obtain a fresh QPN. The new QPNs are exchanged with the
+ * remote peer via the ACK payload before RTR/RTS (two-phase handshake).
+ *
+ * Entry points called from p2p_resiliency_recovery.cc via the unified
+ * wrappers IbCastPortRecoveryReceiverRestoreAndAck /
+ * IbCastPortRecoverySenderRestoreAndAck.
+ */
+
+#include "p2p_resiliency_recovery_internal.h"
+#include "p2p_resiliency_recovery_ainic.h"
+#include "connect_cast.h"
+
+/* Phase A: destroy+recreate QPs, recording new QPNs for exchange. */
+ncclResult_t IbCastPortRecoveryQpsRestoreAinic(struct ncclIbPortRecoveryContext* recoveryContext) {
+  uint nqps = recoveryContext->resCtx->baseComm->nqps;
+  recoveryContext->nLocalQpns = 0;
+
+  for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
+    ncclIbQp* localQp = &recoveryContext->resCtx->baseComm->qps[qpIndex];
+    if (localQp->devIndex != recoveryContext->devIndex) {
+      continue;
+    }
+
+    uint32_t oldQpn = localQp->qp->qp_num;
+    INFO(NCCL_NET, "NET/IB: %s: Destroying QP %d on device %d (comm=%p, old_qp_num=%u)",
+         __func__, qpIndex, recoveryContext->devIndex,
+         recoveryContext->resCtx->baseComm, oldQpn);
+
+    NCCLCHECK(wrap_ibv_destroy_qp(localQp->qp));
+    localQp->qp = NULL;
+
+    struct ncclIbQpCreateAttr createAttr;
+    IbCastBuildDataQpCreateAttr(recoveryContext->resCtx->baseComm, recoveryContext->devIndex, &createAttr);
+    createAttr.channelId = localQp->channelId;
+    createAttr.isDataQp = localQp->isDataQp;
+    // isCtsEnabled and ctsQpSlot are left at 0 (from memset in IbCastBuildDataQpCreateAttr).
+    // CTS offload is disabled when resiliency features are enabled (init.cc).
+    NCCLCHECK(IbCastQpCreate(localQp, &createAttr));
+
+    INFO(NCCL_NET, "NET/IB: %s: Recreated QP %d on device %d (comm=%p, old_qp_num=%u, new_qp_num=%u)",
+         __func__, qpIndex, recoveryContext->devIndex,
+         recoveryContext->resCtx->baseComm, oldQpn, localQp->qp->qp_num);
+
+    NCCLCHECK(IbCastQpInit(localQp));
+
+    int idx = recoveryContext->nLocalQpns;
+    recoveryContext->localQpns[idx].qpIndex = qpIndex;
+    recoveryContext->localQpns[idx].newQpn = localQp->qp->qp_num;
+    recoveryContext->nLocalQpns++;
+  }
+
+  // Also destroy+recreate flush QP on receiver side (it connects to itself)
+  if (!recoveryContext->resCtx->baseComm->isSend) {
+    ncclIbRecvComm* recvComm = (ncclIbRecvComm*)recoveryContext->resCtx->baseComm;
+    if (recvComm->flushEnabled) {
+      for (int i = 0; i < recvComm->base.vProps.ndevs; i++) {
+        if (i != recoveryContext->devIndex) continue;
+        struct ncclIbRecvCommDev* rCommDev = &recvComm->devs[i];
+        ncclIbQp* flushQp = &rCommDev->gpuFlush.qp;
+        INFO(NCCL_NET, "NET/IB: %s: Destroying Flush QP on device %d (comm=%p, old_qp_num=%u)",
+             __func__, i, recoveryContext->resCtx->baseComm, flushQp->qp->qp_num);
+        NCCLCHECK(wrap_ibv_destroy_qp(flushQp->qp));
+        flushQp->qp = NULL;
+        struct ncclIbQpCreateAttr flushCreateAttr;
+        IbCastBuildDataQpCreateAttr(recoveryContext->resCtx->baseComm, recoveryContext->devIndex, &flushCreateAttr);
+        flushCreateAttr.maxRecvWorkRequest = 0;
+        flushCreateAttr.maxSendWorkRequest = NET_IB_MAX_REQUESTS;
+        flushCreateAttr.channelId = flushQp->channelId;
+        flushCreateAttr.isDataQp = flushQp->isDataQp;
+        NCCLCHECK(IbCastQpCreate(flushQp, &flushCreateAttr));
+        INFO(NCCL_NET, "NET/IB: %s: Recreated Flush QP on device %d (comm=%p, new_qp_num=%u)",
+             __func__, i, recoveryContext->resCtx->baseComm, flushQp->qp->qp_num);
+        NCCLCHECK(IbCastQpInit(flushQp));
+      }
+    }
+  }
+
+  INFO(NCCL_NET, "NET/IB: %s: Phase A complete: %d QPs destroyed+recreated on device %d (comm=%p)",
+       __func__, recoveryContext->nLocalQpns, recoveryContext->devIndex,
+       recoveryContext->resCtx->baseComm);
+  return ncclSuccess;
+}
+
+/* Phase B: transition recreated QPs to RTR+RTS using remote QPNs from ACK.
+ * No-op on non-AINIC paths. */
+ncclResult_t IbCastPortRecoveryQpsToRtsAinic(struct ncclIbPortRecoveryContext* recoveryContext) {
+  if (!IbCastAinicRoce) return ncclSuccess;
+  uint nqps = recoveryContext->resCtx->baseComm->nqps;
+
+  for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
+    ncclIbQp* localQp = &recoveryContext->resCtx->baseComm->qps[qpIndex];
+    if (localQp->devIndex != recoveryContext->devIndex) {
+      continue;
+    }
+
+    uint32_t remoteQpn = 0;
+    bool found = false;
+    for (int r = 0; r < recoveryContext->nRemoteQpns; r++) {
+      if (recoveryContext->remoteQpns[r].qpIndex == qpIndex) {
+        remoteQpn = recoveryContext->remoteQpns[r].newQpn;
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      WARN("NET/IB: %s: No remote QPN found for QP index %d on device %d (comm=%p)",
+           __func__, qpIndex, recoveryContext->devIndex,
+           recoveryContext->resCtx->baseComm);
+      return ncclInternalError;
+    }
+
+    localQp->rtrAttr.remoteQpNum = remoteQpn;
+    INFO(NCCL_NET, "NET/IB: %s: QP %d RTR with remoteQpn=%u (comm=%p, qp_num=%u)",
+         __func__, qpIndex, remoteQpn, recoveryContext->resCtx->baseComm,
+         localQp->qp->qp_num);
+
+    if (localQp->eceSupported) {
+      NCCLCHECK(wrap_ibv_set_ece(localQp->qp, &localQp->ece, &localQp->eceSupported));
+    }
+    NCCLCHECK(IbCastQpRtr(localQp));
+    NCCLCHECK(IbCastQpRts(localQp));
+
+    INFO(NCCL_NET, "NET/IB: %s: Restored QP %d on device %d (comm=%p, qp_num=%u)",
+         __func__, qpIndex, recoveryContext->devIndex,
+         recoveryContext->resCtx->baseComm, localQp->qp->qp_num);
+
+    if (!recoveryContext->resCtx->baseComm->isSend) {
+      struct ncclIbRecvComm* recvComm = (struct ncclIbRecvComm*)recoveryContext->resCtx->baseComm;
+      NCCLCHECK(IbCastPostReceiveWorkRequestsOnQp(recvComm, localQp));
+    }
+  }
+
+  // Restore Flush QP on receiver (self-loopback — remote QPN is own new QPN)
+  if (!recoveryContext->resCtx->baseComm->isSend) {
+    ncclIbRecvComm* recvComm = (ncclIbRecvComm*)recoveryContext->resCtx->baseComm;
+    if (recvComm->flushEnabled) {
+      for (int i = 0; i < recvComm->base.vProps.ndevs; i++) {
+        if (i != recoveryContext->devIndex) continue;
+        struct ncclIbRecvCommDev* rCommDev = &recvComm->devs[i];
+        ncclIbQp* flushQp = &rCommDev->gpuFlush.qp;
+        flushQp->rtrAttr.remoteQpNum = flushQp->qp->qp_num;
+        NCCLCHECK(IbCastQpRtr(flushQp));
+        NCCLCHECK(IbCastQpRts(flushQp));
+        INFO(NCCL_NET, "NET/IB: %s: Restored Flush QP on device %d (comm=%p, qp_num=%u)",
+             __func__, i, recoveryContext->resCtx->baseComm, flushQp->qp->qp_num);
+      }
+    }
+  }
+
+  return ncclSuccess;
+}
+
+/* Post a UD ACK carrying local QPN entries as payload. */
+ncclResult_t IbCastPortRecoveryPostAckWithQpnsAinic(struct ncclIbPortRecoveryContext* recoveryContext, bool* success) {
+  int devIdx = recoveryContext->devIndex;
+  struct ncclIbResiliency* resCtx = recoveryContext->resCtx;
+
+  if (recoveryContext->nLocalQpns > NCCL_IB_MAX_RECOVERY_QPN_ENTRIES) {
+    WARN("NET/IB: %s: Too many QPN entries (%d) for recovery ACK payload (max %d)",
+         __func__, recoveryContext->nLocalQpns, NCCL_IB_MAX_RECOVERY_QPN_ENTRIES);
+    return ncclInternalError;
+  }
+  int payloadSize = recoveryContext->nLocalQpns * sizeof(struct RecoveryQpnEntry);
+  memcpy(resCtx->portRecoveryQpnBuf, recoveryContext->localQpns, payloadSize);
+
+  struct ibv_sge qpnSge;
+  qpnSge.addr = (uintptr_t)resCtx->portRecoveryQpnBuf;
+  qpnSge.length = payloadSize;
+  qpnSge.lkey = resCtx->devs[devIdx].portRecoveryQpnMr->lkey;
+
+  struct ibv_send_wr wr;
+  memset(&wr, 0, sizeof(wr));
+  wr.wr_id = recoveryContext->aliveMsgNextId;
+  wr.opcode = IBV_WR_SEND_WITH_IMM;
+  wr.imm_data = NCCL_IB_RESILIENCY_PORT_RECOVERY_ACK_MSG_ID;
+  wr.send_flags = IBV_SEND_SIGNALED;
+  wr.sg_list = &qpnSge;
+  wr.num_sge = 1;
+  wr.wr.ud.ah = resCtx->portRecoveryAh[devIdx];
+  wr.wr.ud.remote_qpn = resCtx->portRecoveryRemoteQpn[devIdx];
+  wr.wr.ud.remote_qkey = NCCL_IB_RECOVERY_QKEY;
+
+  INFO(NCCL_NET, "NET/IB: %s: %s posting ACK with %d QPN entries for device %d (comm=%p)",
+       __func__, resCtx->baseComm->isSend ? "Sender" : "Receiver",
+       recoveryContext->nLocalQpns, devIdx, resCtx->baseComm);
+
+  struct ibv_send_wr* bad_wr = NULL;
+  struct ncclIbQp* recoveryQp = &resCtx->portRecoveryQps[devIdx];
+  if (wrap_ibv_post_send(recoveryQp->qp, &wr, &bad_wr) != ncclSuccess) {
+    INFO(NCCL_NET, "NET/IB: %s: Failed to post ACK with QPNs on device %d (comm=%p, qp_num=%u)",
+         __func__, devIdx, resCtx->baseComm, recoveryQp->qp->qp_num);
+    *success = false;
+    return ncclSuccess;
+  }
+  recoveryContext->ackPosted = true;
+  *success = true;
+  return ncclSuccess;
+}
+
+/* Extract remote QPNs from a received ACK completion buffer (after GRH).
+ * No-op on non-AINIC paths. */
+void IbCastPortRecoveryExtractQpnsAinic(struct ncclIbPortRecoveryContext* recoveryContext, struct ibv_wc* wc) {
+  if (!IbCastAinicRoce) return;
+  struct ncclIbResiliencyDev* resDev = &recoveryContext->resCtx->devs[recoveryContext->devIndex];
+  int payloadLen = wc->byte_len - NCCL_IB_UD_GRH_SIZE;
+  if (payloadLen <= 0) {
+    recoveryContext->nRemoteQpns = 0;
+    return;
+  }
+  int nEntries = payloadLen / sizeof(struct RecoveryQpnEntry);
+  if (nEntries > NCCL_IB_MAX_QPS) nEntries = NCCL_IB_MAX_QPS;
+
+  uint8_t* payload = resDev->portRecoveryGrhBuf + NCCL_IB_UD_GRH_SIZE;
+  memcpy(recoveryContext->remoteQpns, payload, nEntries * sizeof(struct RecoveryQpnEntry));
+  recoveryContext->nRemoteQpns = nEntries;
+
+  for (int i = 0; i < nEntries; i++) {
+    INFO(NCCL_NET, "NET/IB: %s: Extracted remote QPN: qpIndex=%u newQpn=%u (comm=%p)",
+         __func__, recoveryContext->remoteQpns[i].qpIndex,
+         recoveryContext->remoteQpns[i].newQpn,
+         recoveryContext->resCtx->baseComm);
+  }
+}

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery_ainic.h
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery_ainic.h
@@ -10,7 +10,7 @@
 #include "nccl.h"
 #include "p2p_resiliency_cast.h"
 
-/* Forward declaration — ncclIbPortRecoveryContext is defined in recovery.cc */
+/* Forward declaration — ncclIbPortRecoveryContext is defined in p2p_resiliency_recovery_internal.h */
 struct ncclIbPortRecoveryContext;
 struct ibv_wc;
 

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery_ainic.h
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery_ainic.h
@@ -1,0 +1,32 @@
+/*************************************************************************
+ * Copyright (c) 2016-2026, NVIDIA CORPORATION. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#ifndef NET_IB_P2P_RESILIENCY_RECOVERY_AINIC_H_
+#define NET_IB_P2P_RESILIENCY_RECOVERY_AINIC_H_
+
+#include "nccl.h"
+#include "p2p_resiliency_cast.h"
+
+/* Forward declaration — ncclIbPortRecoveryContext is defined in recovery.cc */
+struct ncclIbPortRecoveryContext;
+struct ibv_wc;
+
+/* Phase A: destroy+recreate QPs on AINIC (ibv_modify_qp RESET is broken).
+ * Records new QPNs in recoveryContext->localQpns for exchange with remote. */
+ncclResult_t IbCastPortRecoveryQpsRestoreAinic(struct ncclIbPortRecoveryContext* recoveryContext);
+
+/* Phase B: transition recreated QPs to RTR+RTS using remote QPNs from ACK.
+ * No-op on non-AINIC paths. */
+ncclResult_t IbCastPortRecoveryQpsToRtsAinic(struct ncclIbPortRecoveryContext* recoveryContext);
+
+/* Post a UD ACK message carrying local QPN entries as payload. */
+ncclResult_t IbCastPortRecoveryPostAckWithQpnsAinic(struct ncclIbPortRecoveryContext* recoveryContext, bool* success);
+
+/* Extract remote QPNs from a received ACK completion buffer (after GRH).
+ * No-op on non-AINIC paths where ACK messages carry no QPN payload. */
+void IbCastPortRecoveryExtractQpnsAinic(struct ncclIbPortRecoveryContext* recoveryContext, struct ibv_wc* wc);
+
+#endif /* NET_IB_P2P_RESILIENCY_RECOVERY_AINIC_H_ */

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery_internal.h
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery_internal.h
@@ -1,0 +1,61 @@
+/*************************************************************************
+ * Copyright (c) 2016-2026, NVIDIA CORPORATION. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+/* Internal types and constants shared between p2p_resiliency_recovery.cc
+ * and p2p_resiliency_recovery_ainic.cc. Not part of the public plugin API. */
+
+#ifndef NET_IB_P2P_RESILIENCY_RECOVERY_INTERNAL_H_
+#define NET_IB_P2P_RESILIENCY_RECOVERY_INTERNAL_H_
+
+#include "p2p_resiliency_recovery_cast.h"
+
+#define NCCL_IB_RESILIENCY_PORT_RECOVERY_ACK_MSG_ID (0x1234)
+#define NCCL_IB_RECOVERY_QKEY                        0x1234ABCD
+#define NCCL_IB_MAX_RECOVERY_QPN_ENTRIES             NCCL_IB_MAX_QPS
+
+enum ncclIbPortRecoveryState {
+  ncclIbPortRecoveryStateInit,
+  ncclIbPortRecoveryStateAliveMessages,
+  ncclIbPortRecoveryStateAck,
+  ncclIbPortRecoveryStateSuccess,
+  ncclIbPortRecoveryStateFailed,
+};
+
+struct ncclIbPortRecoveryContext {
+  struct ncclIbResiliency* resCtx;
+  int devIndex;
+  enum ncclIbPortRecoveryState state;
+
+  struct ibv_cq* recoveryCq;
+
+  uint64_t timeInit;
+  int nFailedAttempts;
+  uint64_t timeLastMsg;
+  uint32_t aliveMsgNextId;
+
+  bool ackReceived;
+  bool ackPosted;
+  bool ackCompleted;
+
+  union {
+    struct {
+      bool aliveMsgPosted;
+      bool aliveMsgCompleted;
+    } send;
+    struct {
+      uint32_t windowBase;
+      uint32_t receivedBits;
+    } recv;
+  };
+
+  /* AINIC destroy+recreate: local and remote QPN exchange buffers. */
+  struct RecoveryQpnEntry localQpns[NCCL_IB_MAX_QPS];
+  int nLocalQpns;
+  struct RecoveryQpnEntry remoteQpns[NCCL_IB_MAX_QPS];
+  int nRemoteQpns;
+};
+
+#endif /* NET_IB_P2P_RESILIENCY_RECOVERY_INTERNAL_H_ */

--- a/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
@@ -36,7 +36,11 @@ static int CreateMergedDeviceForFailover(ncclNet_t* net, int totalDevs) {
         vProps.devs[1] = 1;
         net->makeVDevice(&mergedDev, &vProps);
     }
-    MPI_Bcast(&mergedDev, 1, MPI_INT, /*root=*/0, MPI_COMM_WORLD);
+    // Each rank creates its own merged device from its local physical devices.
+    // Reduce to the minimum: if any rank lacks >=2 devices, all ranks skip.
+    int minDev = 0;
+    MPI_Allreduce(&mergedDev, &minDev, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD);
+    if (minDev < 0) return -1;
     return mergedDev;
 }
 


### PR DESCRIPTION
## Motivation

Refactor AINIC-specific net-ib resiliency code to keep the recovery path clear, and incorporate review feedback fixes needed for correctness and maintainability.

## Technical Details

- Split AINIC-specific resiliency recovery logic into dedicated files (`p2p_resiliency_recovery_ainic.{h,cc}`) and shared internal definitions (`p2p_resiliency_recovery_internal.h`).
- Updated the MPI fault-injection merged-device helper to avoid cross-rank misuse of per-rank virtual device indices.
- Fixed a potential unsigned underflow when computing recovery ACK payload length from `wc->byte_len` in AINIC recovery ACK parsing.
- Corrected resiliency comments in AINIC recovery source/header to match the actual call flow and current type-definition location.

## JIRA ID

AICOMNET-246

## Test Plan

AINIC/Thor2/MLX unit tests validation

## Test Result

All tests passed for all 3 configurations.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.