### PR TITLE
Do not ring the doorbell multiple times with same write ptr

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -76,8 +76,6 @@ bool roc::Device::isHsaInitialized_ = false;
 std::vector<hsa_agent_t> roc::Device::gpu_agents_;
 std::vector<AgentInfo> roc::Device::cpu_agents_;
 
-std::atomic<bool> Device::skipHsaShutdown_{false};
-
 address Device::mg_sync_ = nullptr;
 
 bool NullDevice::create(const amd::Isa& isa) {
@@ -224,25 +222,17 @@ Device::~Device() {
   delete xferQueue_;
   xferQueue_ = nullptr;
 
-#if defined(_WIN32)
-  if (hasSchedulerQueue_.load(std::memory_order_acquire) > 0) {
-    skipHsaShutdown_.store(true, std::memory_order_release);
-    queuePool_.clear();
-  } else
-#endif  // _WIN32
-  {
-    for (auto& it : queuePool_) {
-      for (auto qIter = it.begin(); qIter != it.end();) {
-        hsa_queue_t* queue = qIter->first;
-        auto& qInfo = qIter->second;
-        ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_QUEUE, "Deleting hardware queue %p with refCount 0",
-                queue->base_address);
-        qIter = it.erase(qIter);
-        Hsa::queue_destroy(queue);
-      }
+  for (auto& it : queuePool_) {
+    for (auto qIter = it.begin(); qIter != it.end();) {
+      hsa_queue_t* queue = qIter->first;
+      auto& qInfo = qIter->second;
+      ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_QUEUE, "Deleting hardware queue %p with refCount 0",
+              queue->base_address);
+      qIter = it.erase(qIter);
+      Hsa::queue_destroy(queue);
     }
-    queuePool_.clear();
   }
+  queuePool_.clear();
 
   delete blitProgram_;
 
@@ -360,9 +350,6 @@ hsa_status_t Device::loaderQueryHostAddress(const void* device, const void** hos
 
 // ================================================================================================
 bool Device::init() {
-#if defined(_WIN32)
-  skipHsaShutdown_.store(false, std::memory_order_release);
-#endif
   if (!Hsa::LoadLib()) {
     LogPrintfWarning("Failed to load rocr library!");
     return false;
@@ -545,11 +532,6 @@ extern const char* SchedulerSourceCode;
 
 void Device::tearDown() {
   NullDevice::tearDown();
-#if defined(_WIN32)
-  if (skipHsaShutdown_.load(std::memory_order_acquire)) {
-    return;
-  }
-#endif  // _WIN32
   Hsa::shut_down();
 }
 

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -783,12 +783,6 @@ class Device : public NullDevice {
   friend void callbackQueue(hsa_status_t status, hsa_queue_t* queue, void* data);
 
  public:
-
-  //! Count of schedulerQueue_ instances per device
-  //! Windows AQL device-enqueue path.
-  std::atomic<uint32_t> hasSchedulerQueue_{0};
-  static std::atomic<bool> skipHsaShutdown_;
-
   std::atomic<uint> numOfVgpus_;  //!< Virtual gpu unique index
 
   //! Returns the valid SDMA engine bitmask for the given operation type.

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1932,33 +1932,7 @@ VirtualGPU::~VirtualGPU() {
 
   delete blitMgr_;
 
-  bool skip_fence_barrier = false;
-  if (nullptr != schedulerQueue_) {
-#if defined(_WIN32)
-    if (isSchedulerQueueThreadRunning()) {
-      schedulerQueueThreadRunning_.store(false, std::memory_order_release);
-      {
-        std::lock_guard<std::mutex> lock(scheduler_mutex_);
-        pendingSchedulerEvents_.clear();
-        scheduler_cv_.notify_one();
-      }
-      if (schedulerQueueThread_.joinable()) {
-        schedulerQueueThread_.join();
-      }
-    }
-    if (!dev().IsPm4Emulation()) {
-      roc_device_.hasSchedulerQueue_.fetch_add(1, std::memory_order_release);
-      skip_fence_barrier = true;
-    } else {
-      Hsa::queue_destroy(schedulerQueue_);
-    }
-#else
-    Hsa::queue_destroy(schedulerQueue_);
-#endif  // _WIN32
-    schedulerQueue_ = nullptr;
-  }
-
-  if (tracking_created_ && !skip_fence_barrier) {
+  if (tracking_created_) {
     std::scoped_lock l(execution());
     // Dedicated queues keep their HW queue, never acquire from pool
     if (!dedicated_queue_ && gpu_queue_ == nullptr) {
@@ -1981,6 +1955,19 @@ VirtualGPU::~VirtualGPU() {
   }
 
   delete printfdbg_;
+
+  if (nullptr != schedulerQueue_) {
+#if defined(_WIN32)
+    // Stop the monitor thread before destroying the queue
+    if (schedulerQueueThread_.joinable()) {
+      schedulerQueueThreadRunning_.store(false, std::memory_order_release);
+      scheduler_cv_.notify_one();
+      schedulerQueueThread_.join();
+    }
+#endif  // _WIN32
+    Hsa::queue_destroy(schedulerQueue_);
+    schedulerQueue_ = nullptr;
+  }
 
   if (nullptr != virtualQueue_) {
     virtualQueue_->release();
@@ -3791,6 +3778,7 @@ void VirtualGPU::startSchedulerQueueThread() {
   schedulerQueueThreadRunning_.store(true, std::memory_order_release);
 
   schedulerQueueThread_ = std::thread([this]() {
+    uint64_t updated_write_index = 0;
     while (isSchedulerQueueThreadRunning()) {
 
       // Wait until scheduler events are added or thread termination
@@ -3805,12 +3793,12 @@ void VirtualGPU::startSchedulerQueueThread() {
       // Actively monitor the scheduler queue while any sync event is pending.
       bool has_active_events = true;
       while (has_active_events && isSchedulerQueueThreadRunning()) {
-        uint64_t read_index = Hsa::queue_load_read_index_scacquire(schedulerQueue_);
         uint64_t write_index = Hsa::queue_load_write_index_scacquire(schedulerQueue_);
 
-        if (write_index > read_index) {
+        if (write_index > updated_write_index) {
           // New packets in the scheduler queue, ringing the doorbell
           Hsa::signal_store_screlease(schedulerQueue_->doorbell_signal, write_index - 1);
+          updated_write_index = write_index;
         } else {
           // Yield briefly before re-checking.
           amd::Os::yield();


### PR DESCRIPTION
## Motivation

Fix the OCL Device Enqueue tests with ROCr backend using AQL path.
Also, removes the workaround of skipping the queue destruction during device enqueue.


## Technical Details

The host side scheduler thread was ringing doorbell multiple times even though there was wptr didnt advance. This is causing fences not reported and OS doesn't release resources during the queue destroy causing hang at the end.

## JIRA ID

AIRUNTIME-277

## Test Plan

Verify with the OCL device enqueue tests

## Test Result

PASS

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
