### PR TITLE
[hipfile] Make sure ais-stats gets installed with hipFile.

### DIFF
--- a/projects/hipfile/cmake/AISInstall.cmake
+++ b/projects/hipfile/cmake/AISInstall.cmake
@@ -18,7 +18,12 @@ rocm_install(
 )
 
 # Install AIS tools
+if(AIS_INSTALL_TOOLS)
 install(PROGRAMS tools/ais-check/ais-check DESTINATION bin)
+    if(TARGET ais-stats)
+        install(TARGETS ais-stats DESTINATION bin)
+    endif()
+endif()
 
 # Install example code
 # Since the input DIRECTORY is `examples` don't include it in


### PR DESCRIPTION
## Motivation

ais-stats tool wasn't added to AISInstall.cmake (oops)

## Technical Details

Adds an install command for ais-stats

## JIRA ID

AIHIPFILE-203

## Test Plan

Install a hipFile package and verify ais-stats exists.

## Test Result

ais-stats is installed on the system.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
