### PR TITLE
[rocshmem] Skip ParseNicMergeLevel test when warnings are disabled

### DIFF
--- a/projects/rocshmem/scripts/unit_tests/driver.sh
+++ b/projects/rocshmem/scripts/unit_tests/driver.sh
@@ -69,7 +69,7 @@ mpi_timeout=$((20 * 60)) # 20 minutes in seconds
 function run_mpirun {
     local np=$1
     local gtest_filter=$2
-    cmd_str="mpirun -np $np --timeout $mpi_timeout $binary_name --gtest_filter=$gtest_filter >> $log_file 2>&1"
+    cmd_str="ROCSHMEM_DEBUG_LEVEL=WARN mpirun -np $np --timeout $mpi_timeout $binary_name --gtest_filter=$gtest_filter >> $log_file 2>&1"
     echo $cmd_str
     eval $cmd_str
 

--- a/projects/rocshmem/tests/unit_tests/topology_gtest.cpp
+++ b/projects/rocshmem/tests/unit_tests/topology_gtest.cpp
@@ -586,9 +586,9 @@ TEST_F(DeviceTypeTestFixture, ParseNicMergeLevelKnown) {
 }
 
 TEST_F(DeviceTypeTestFixture, ParseNicMergeLevelUnknown) {
-  // Skip this test if warnings are not enabled
+  // Skip this test if warning logging is disabled (e.g., ROCSHMEM_DEBUG_LEVEL < WARN or includes :nowarn)
   if (!rocshmem::envvar::log_flags.show_warn) {
-    GTEST_SKIP() << "Skipping test because ROCSHMEM_DEBUG_LEVEL is not set to WARN or higher";
+    GTEST_SKIP() << "Skipping test because warning logging is disabled (ROCSHMEM_DEBUG_LEVEL < WARN or contains :nowarn)";
   }
 
   testing::internal::CaptureStderr();

--- a/projects/rocshmem/tests/unit_tests/topology_gtest.cpp
+++ b/projects/rocshmem/tests/unit_tests/topology_gtest.cpp
@@ -586,9 +586,15 @@ TEST_F(DeviceTypeTestFixture, ParseNicMergeLevelKnown) {
 }
 
 TEST_F(DeviceTypeTestFixture, ParseNicMergeLevelUnknown) {
+  // Skip this test if warnings are not enabled
+  if (!rocshmem::envvar::log_flags.show_warn) {
+    GTEST_SKIP() << "Skipping test because ROCSHMEM_DEBUG_LEVEL is not set to WARN or higher";
+  }
+
   testing::internal::CaptureStderr();
   auto result = ParseNicMergeLevel("INVALID");
   std::string err = testing::internal::GetCapturedStderr();
+
   EXPECT_EQ(result, NIC_PATH_SYS);
   EXPECT_TRUE(err.find("unknown") != std::string::npos ||
               err.find("defaulting") != std::string::npos);


### PR DESCRIPTION
The ParseNicMergeLevelUnknown unit test was failing because LOG_WARN no longer outputs to stderr by default after recent logging changes. The test expects to capture warning output, but this only works when ROCSHMEM_DEBUG_LEVEL is set to WARN or higher.

Update the test to check if warnings are enabled and skip gracefully with a clear message if they are not, allowing the test to pass in both scenarios.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
