### PR TITLE
[rocSHMEM] Enable GPUDirect RDMA for VMM allocations

### DIFF
--- a/projects/rocshmem/src/memory/hip_allocator_vmm_common.hpp
+++ b/projects/rocshmem/src/memory/hip_allocator_vmm_common.hpp
@@ -71,6 +71,9 @@ inline hipError_t VMMAllocCommon(void** ptr, size_t size, hipMemAllocationHandle
   prop.location.id = device_id;
   prop.requestedHandleTypes = handle_type;
 
+  // Required so VMM allocations are accessible by GPUDirect RDMA-capable NICs
+  prop.allocFlags.gpuDirectRDMACapable = 1;
+
   // Get allocation granularity
   size_t granularity;
   err = hipMemGetAllocationGranularity(&granularity, &prop, hipMemAllocationGranularityMinimum);


### PR DESCRIPTION
## Motivation

- VMM-backed allocations in rocSHMEM were not marked as GPUDirect RDMA-capable, This PR sets the required allocation flag so VMM-backed memory can be used in GPUDirect RDMA paths.

## Technical Details

- Set `prop.allocFlags.gpuDirectRDMACapable = 1` in `VMMAllocCommon` (`projects/rocshmem/src/memory/hip_allocator_vmm_common.hpp`) so VMM allocations are accessible by GPUDirect RDMA-capable NICs.