### PR TITLE
[AMD-SMI] Add debug AMDSMI_DISABLE_CPU_INIT env var

### DIFF
--- a/projects/amdsmi/amdsmi_cli/amdsmi_init.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_init.py
@@ -106,10 +106,18 @@ def amdsmi_cli_init():
         err: AmdSmiLibraryException if not successful in initializing any drivers
     """
     init_flag = 0
+    cpu_init_disabled = os.environ.get("AMDSMI_DISABLE_CPU_INIT", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
     if check_amdgpu_driver():
         init_flag |= amdsmi_interface.AmdSmiInitFlags.INIT_AMD_GPUS
         logging.debug("amdgpu driver's initstate is live")
-    if check_amd_hsmp_driver() and hasattr(
+    if cpu_init_disabled:
+        logging.debug("CPU/ESMI init disabled via AMDSMI_DISABLE_CPU_INIT")
+    elif check_amd_hsmp_driver() and hasattr(
         amdsmi_interface.amdsmi_wrapper, "amdsmi_get_cpu_handles"
     ):
         init_flag |= amdsmi_interface.AmdSmiInitFlags.INIT_AMD_CPUS


### PR DESCRIPTION
## Motivation

On systems where the HSMP/ESMI (CPU) driver is present but unhealthy or slow to respond, AMD-SMI CLI initialization can hang or fail while bringing up CPU/ESMI support. There was no way to skip CPU initialization without unloading the driver. This PR adds a debug escape hatch so users can disable CPU init and continue using the GPU functionality.

## Technical Details

Adds support for an `AMDSMI_DISABLE_CPU_INIT` environment variable in the CLI's `amdsmi_cli_init()` (`amdsmi_cli/amdsmi_init.py`):

- When the variable is set to a truthy value (`1`, `true`, `yes`, or `on`, case-insensitive, whitespace-trimmed), the CLI skips the `INIT_AMD_CPUS` initialization path entirely.
- When disabled, a debug log line (`CPU/ESMI init disabled via AMDSMI_DISABLE_CPU_INIT`) is emitted to make the behavior observable.
- GPU initialization is unaffected; only the CPU/ESMI branch is gated.

## Test Plan

- Run the CLI normally (without the env var) on a system with the HSMP driver and confirm CPU init still occurs.
- Set `AMDSMI_DISABLE_CPU_INIT=1` and confirm CPU init is skipped while GPU commands continue to function.
- Verify truthy variants (`true`, `yes`, `on`) and falsy/empty values behave as expected.

Signed-off-by: Maisam Arif <Maisam.Arif@amd.com>

