### PR TITLE
First check in: runs intra frames to completion with corrupted output

### DIFF
--- a/projects/rocdecode/CLAUDE.md
+++ b/projects/rocdecode/CLAUDE.md
@@ -159,3 +159,105 @@ When adding codec support, implement:
 
 ### Samples
 Samples are installed to `${ROCM_PATH}/share/rocdecode/samples` and can be built standalone against installed rocDecode. Each sample has its own CMakeLists.txt and can be used as external project templates.
+
+---
+
+## Windows PAL Backend
+
+The Windows backend (`src/rocdecode/pal/`) uses AMD PAL (Platform Abstraction Library) to drive the VCN hardware decode engine directly, mirroring the Linux VA-API backend in structure and semantics.
+
+### Build (Windows)
+
+PAL is pulled from the drivers tree. `UVD_INCLUDE_DIR` points to the directory containing `drv_uvd_if.h` (the UVD firmware codec structures).
+
+```cmd
+mkdir build && cd build
+cmake -DPAL_ROOT=c:\github\drivers-amd-main\drivers\build\native\Debug\x64\pal\package ^
+      -DUVD_INCLUDE_DIR=c:\github\drivers-amd-main\drivers\uvdfwlib\uvdfw_inc\ ^
+      -DCMAKE_BUILD_TYPE=Debug ..
+cmake --build . --config Debug
+cmake --install . --config Debug
+```
+
+### Run the rocdecDecode sample
+
+```cmd
+cd samples\rocdecdecode\
+mkdir build && cd build
+cmake --build . --config Debug
+.\Debug\rocdecdecode.exe -i c:\opt\rocm\share\rocdecode\frames
+```
+
+### Architecture
+
+`RocDecoder` (`src/rocdecode/roc_decoder.cpp`) is the platform switchboard — it owns either `VaapiVideoDecoder` (Linux) or `PalVideoDecoder` (Windows) and forwards all calls via `#ifdef ROCDECODE_BUILD_WINDOWS`. The shared decode pipeline is:
+
+```
+rocDecParseVideoData()
+  └─ HevcParser / AvcParser  (src/parser/)
+       └─ SendPicForDecode()
+            └─ rocDecDecodeFrame()
+                 └─ RocDecoder::DecodeFrame()
+                      └─ PalVideoDecoder::DecodeFrame()
+                               └─ DecodeHEVC() / DecodeH264()
+```
+
+**Key files:**
+- `src/rocdecode/pal/pal_videodecoder.h` — `PalObject<T>` RAII wrapper, `PalDpbSlot`, `PalDpb`, `PalVideoDecoder` class declaration
+- `src/rocdecode/pal/pal_videodecoder.cpp` — all PAL backend logic
+
+### PAL Object Lifecycle
+
+PAL uses placement-new — callers own the backing memory. `PalObject<T>` handles this with `Destroy()` + `free()` in its destructor:
+
+```cpp
+size_t sz = device->GetFenceSize(&res);
+void* mem = malloc(sz);
+Pal::IFence* f = nullptr;
+device->CreateFence(fci, mem, &f);
+// PalObject<Pal::IFence> wraps f + mem and cleans up automatically
+```
+
+**Resources owned by `PalVideoDecoder`:**
+- `video_queue_` — PAL `IQueue` targeting the VCN decode engine
+- `cmd_allocator_` / `cmd_buffer_` — shared across frames (one frame recorded at a time)
+- `video_decoder_` — PAL `IVideoDecoder` session object
+- `decoder_heap_` — VCN-internal scratch `IGpuMemory`
+- `bitstream_` — CPU-writable / GPU-readable upload buffer for compressed data
+- `dpb_` — `PalDpb` managing `max_dpb_slots_` `PalDpbSlot` entries
+
+**Per `PalDpbSlot`:**
+- `image` / `image_memory` — decoded NV12/P010 surface (`IImage` + `IGpuMemory`)
+- `fence` — per-slot `IFence`, signaled when a decode targeting this slot completes
+
+### Submission Model (mirrors VA-API)
+
+`video_queue_->Submit()` is **fire-and-forget** — the GPU queue serializes work internally, exactly like `vaEndPicture()` on Linux. The next frame is submitted without waiting for the previous one.
+
+Per-frame flow in `DecodeHEVC()`:
+1. Wait on `dpb_[last_submitted_slot_idx_].fence` **before** `cmd_buffer_->Reset()` — the shared `cmd_allocator_` cannot be recycled while the GPU is still reading its previous commands
+2. Record: `Reset` → `Begin` → `CmdBindVideoDecoder` → `CmdBeginVideoDecode` → `CmdDecodeVideoFrame` → `End`
+3. `ResetFences(output_slot->fence)` — reset this slot's fence (safe: the wait in step 1 ensures it is no longer in-flight)
+4. `Submit(output_slot->fence)` — attach this slot's fence; it signals when this decode finishes
+5. Record `last_submitted_slot_idx_ = curr_pic_idx`
+
+**Why per-slot fences, not a single global fence:** `GetDecodeStatus(pic_idx)` must report readiness for a specific picture independently — directly paralleling `vaQuerySurfaceStatus(surface)` on Linux. A single global fence reset before every submit would be reset while still in-flight from the previous frame, corrupting its state and causing `Submit` to fail.
+
+### HIP Interop (`RocDecoder::GetVideoFrame`)
+
+Decoded frames are exposed to applications as HIP device pointers. The interop is performed once per slot and cached in `hip_interop_[pic_idx]`:
+
+| Platform | Export | HIP handle type |
+|---|---|---|
+| Linux | `vaExportSurfaceHandle` → DRM prime fd | `hipExternalMemoryHandleTypeOpaqueFd` |
+| Windows | PAL `ExportExternalHandle` → KMT opaque handle | `hipExternalMemoryHandleTypeOpaqueWin32Kmt` |
+
+On Windows, `GetVideoFrame` calls `GetDecodeStatus` to confirm the frame is ready before exporting. PAL DPB surface memory must be allocated with `flags.interprocess=1` and `flags.shareable=1` to enable KMT handle export.
+
+### Adding a New Codec (Windows)
+
+1. Add `DecodeXxx(RocdecPicParams*)` to `PalVideoDecoder`
+2. Map `RocdecXxxPicParams` fields to the PAL/UVD codec struct from `drv_uvd_if.h`
+3. Set `decode_info.decodeType` to the appropriate `Pal::VideoDecodeType` enum value
+4. Wire into `PalVideoDecoder::DecodeFrame()` dispatch and `Initialize()` codec mapping
+5. Add the matching implementation to `src/rocdecode/vaapi/` for Linux parity

--- a/projects/rocdecode/CMakeLists.txt
+++ b/projects/rocdecode/CMakeLists.txt
@@ -263,17 +263,6 @@ if(DEPENDENCIES_MET)
       message(FATAL_ERROR "PAL_ROOT (${PAL_ROOT}) does not contain inc/core directory")
     endif()
 
-    if(NOT DEFINED UVD_INCLUDE_DIR)
-      set(UVD_INCLUDE_DIR "" CACHE PATH "UVD firmware include directory containing drv_uvd_if.h (required for Windows build)")
-      message(FATAL_ERROR "UVD_INCLUDE_DIR must be set for Windows builds. Use: cmake -DUVD_INCLUDE_DIR=<path> ..")
-    endif()
-
-    if(NOT EXISTS "${UVD_INCLUDE_DIR}/drv_uvd_if.h")
-      message(FATAL_ERROR "UVD_INCLUDE_DIR (${UVD_INCLUDE_DIR}) does not contain drv_uvd_if.h")
-    endif()
-
-    include_directories(${UVD_INCLUDE_DIR})
-
     # Use the PAL package CMake target to extract its INTERFACE compile definitions,
     # include directories, and link libraries.  We store them in variables and apply
     # them to rocdecode after add_library, rather than linking the 'pal' target itself.

--- a/projects/rocdecode/CMakeLists.txt
+++ b/projects/rocdecode/CMakeLists.txt
@@ -23,6 +23,14 @@
 
 cmake_minimum_required(VERSION 3.10)
 
+# CMP0091: MSVC_RUNTIME_LIBRARY target property is honoured only when NEW.
+# Must be set before the first project() call.
+cmake_policy(SET CMP0091 NEW)
+# Force all targets to use the static Release CRT so they match the PAL
+# pre-built libs (compiled with /MT). This must be set before any add_library
+# or add_executable, which is why it is placed at the top of the file.
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+
 # Platform detection
 if(WIN32)
   set(IS_WINDOWS TRUE)
@@ -255,46 +263,34 @@ if(DEPENDENCIES_MET)
       message(FATAL_ERROR "PAL_ROOT (${PAL_ROOT}) does not contain inc/core directory")
     endif()
 
-    include_directories(${PAL_ROOT}/inc/core ${PAL_ROOT}/inc/util ${PAL_ROOT}/inc/gpuUtil ${PAL_ROOT}/shared/inc)
+    if(NOT DEFINED UVD_INCLUDE_DIR)
+      set(UVD_INCLUDE_DIR "" CACHE PATH "UVD firmware include directory containing drv_uvd_if.h (required for Windows build)")
+      message(FATAL_ERROR "UVD_INCLUDE_DIR must be set for Windows builds. Use: cmake -DUVD_INCLUDE_DIR=<path> ..")
+    endif()
 
-    # PAL static libraries with all dependencies (matching vulkan-video-driver)
-    set(PAL_LIB_DIR "${PAL_ROOT}/lib/Release/x64")
+    if(NOT EXISTS "${UVD_INCLUDE_DIR}/drv_uvd_if.h")
+      message(FATAL_ERROR "UVD_INCLUDE_DIR (${UVD_INCLUDE_DIR}) does not contain drv_uvd_if.h")
+    endif()
+
+    include_directories(${UVD_INCLUDE_DIR})
+
+    # Use the PAL package CMake target to extract its INTERFACE compile definitions,
+    # include directories, and link libraries.  We store them in variables and apply
+    # them to rocdecode after add_library, rather than linking the 'pal' target itself.
+    # This avoids install(EXPORT) errors from 'pal' not being in the rocdecode export set.
+    if(NOT TARGET pal)
+      # Set the version before add_subdirectory so the PAL CMakeLists version check passes.
+      set(PAL_CLIENT_INTERFACE_MAJOR_VERSION 954)
+      add_subdirectory(${PAL_ROOT} ${CMAKE_BINARY_DIR}/pal_package EXCLUDE_FROM_ALL)
+    endif()
+    get_target_property(_pal_defs pal INTERFACE_COMPILE_DEFINITIONS)
+    get_target_property(_pal_incs pal INTERFACE_INCLUDE_DIRECTORIES)
+    get_target_property(_pal_libs pal INTERFACE_LINK_LIBRARIES)
     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST}
-        ${PAL_LIB_DIR}/pal.lib
-        ${PAL_LIB_DIR}/palUtil.lib
-        ${PAL_LIB_DIR}/palCompilerDeps.lib
-        ${PAL_LIB_DIR}/addrlib.lib
-        ${PAL_LIB_DIR}/vam.lib
-        ${PAL_LIB_DIR}/amdrdf.lib
-        ${PAL_LIB_DIR}/zstd.lib
-        ${PAL_LIB_DIR}/pal_lz4.lib
-        ${PAL_LIB_DIR}/pal_uuid.lib
-        ${PAL_LIB_DIR}/metrohash.lib
-        ${PAL_LIB_DIR}/mpack.lib
-        ${PAL_LIB_DIR}/cwpack.lib
-        ${PAL_LIB_DIR}/stb_sprintf.lib
-        ${PAL_LIB_DIR}/DriverUtilsService.lib
-        ${PAL_LIB_DIR}/UberTraceService.lib
-        ${PAL_LIB_DIR}/SettingsRpcService2.lib
-        ${PAL_LIB_DIR}/dd_settings.lib
-        ${PAL_LIB_DIR}/devdriver.lib
-        ${PAL_LIB_DIR}/ddRpcServer.lib
-        ${PAL_LIB_DIR}/ddRpcClient.lib
-        ${PAL_LIB_DIR}/ddRpcShared.lib
-        ${PAL_LIB_DIR}/ddEventServer.lib
-        ${PAL_LIB_DIR}/ddEventClient.lib
-        ${PAL_LIB_DIR}/ddEventParser.lib
-        ${PAL_LIB_DIR}/ddEventStreamer.lib
-        ${PAL_LIB_DIR}/ddNet.lib
-        ${PAL_LIB_DIR}/ddSocket.lib
-        ${PAL_LIB_DIR}/ddYaml.lib
-        ${PAL_LIB_DIR}/dd_common.lib
-        ${PAL_LIB_DIR}/ddCore.lib
-        ${PAL_LIB_DIR}/ddCommon.lib
-        Setupapi.lib
+        ${_pal_libs}
         ws2_32.lib
     )
-    message("-- ${Green}${PROJECT_NAME} -- PAL libraries linked from ${PAL_LIB_DIR}${ColourReset}")
+    message("-- ${Green}${PROJECT_NAME} -- PAL linked via CMake target from ${PAL_ROOT}${ColourReset}")
   endif()
 
   # rocprofiler
@@ -330,37 +326,19 @@ if(DEPENDENCIES_MET)
   if(IS_WINDOWS)
     set_target_properties(${PROJECT_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
     target_compile_definitions(${PROJECT_NAME} PRIVATE
-      ROCDECODE_BUILD_WINDOWS=1
-      PAL_KMT_BUILD=1
-      PAL_CLOSED_SOURCE=1
-    )
-# -----------------------------------------------------------------------
-# Platform-specific settings
-# -----------------------------------------------------------------------
-    target_compile_definitions(${PROJECT_NAME} PRIVATE
+        ROCDECODE_BUILD_WINDOWS=1
         WINVER=0x0A00
         _WIN32_WINNT=0x0A00
         WIN32_LEAN_AND_MEAN
         NOMINMAX
-        # Match PAL library build settings
-        PAL_CLIENT_INTERFACE_MAJOR_VERSION=954
-        GPUOPEN_CLIENT_INTERFACE_MAJOR_VERSION=42
-        PAL_BUILD_RDF=1
-        PAL_DEVELOPER_BUILD=0
-        PAL_KMT_BUILD=1
-        PAL_CLIENT_OCL=1
-        PAL_CLOSED_SOURCE=1
-        PAL_BUILD_GFX9=1
-        PAL_BUILD_LIGHT_SHAFT_OPT=1
-        PAL_BUILD_OSS=1
-        PAL_BUILD_VIDEO=1
-        PAL_BUILD_VIDEO_DECODER=1
-        PAL_BUILD_VCN3=1
-        PAL_BUILD_VCN4=1
-        PAL_BUILD_VCN5=1
-        )
+    )
+    # Apply PAL INTERFACE compile definitions and include directories extracted above.
+    # These must match what the PAL library was compiled with to avoid ABI mismatches.
+    target_compile_definitions(${PROJECT_NAME} PRIVATE ${_pal_defs})
+    target_include_directories(${PROJECT_NAME} PRIVATE ${_pal_incs})
 
     # Set static runtime library to match PAL (works for both MSVC and Clang)
+    # PAL static libs are built with /MT (Release CRT only); always match that regardless of build config.
     set_property(TARGET ${PROJECT_NAME} PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
   else()
     target_compile_definitions(${PROJECT_NAME} PRIVATE ROCDECODE_BUILD_LINUX=1)
@@ -385,7 +363,7 @@ if(DEPENDENCIES_MET)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
   endif()
 
-  target_link_libraries(${PROJECT_NAME} ${LINK_LIBRARY_LIST})
+  target_link_libraries(${PROJECT_NAME} PRIVATE ${LINK_LIBRARY_LIST})
 
   set_target_properties(${PROJECT_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
   set_target_properties(${PROJECT_NAME} PROPERTIES LINKER_LANGUAGE CXX)

--- a/projects/rocdecode/samples/rocdecDecode/rocdecdecode.cpp
+++ b/projects/rocdecode/samples/rocdecDecode/rocdecdecode.cpp
@@ -595,6 +595,7 @@ int ROCDECAPI handle_picture_display(void* user_data, RocdecParserDispInfo* disp
     params.progressive_frame = disp_info->progressive_frame;
     params.top_field_first = disp_info->top_field_first;
     // get device memory pointer for decoded output surface
+    // GetVideoFrame (KMT export) temporarily disabled while debugging decode-only path
     void* dev_mem_ptr[3] = { 0 };
     uint32_t pitch[3] = { 0 };
     CHECK(rocDecGetVideoFrame(p_dec_info->decoder, disp_info->picture_index, dev_mem_ptr, pitch, &params));

--- a/projects/rocdecode/src/rocdecode/pal/pal_videodecoder.cpp
+++ b/projects/rocdecode/src/rocdecode/pal/pal_videodecoder.cpp
@@ -83,6 +83,7 @@ void PalDpb::Clear() {
     for (uint32_t i = 0; i < slot_count_; ++i) {
         slots_[i].image.Reset();
         slots_[i].image_memory.Reset();
+        slots_[i].fence.Reset();
         slots_[i].occupied = false;
         slots_[i].poc = -1;
         slots_[i].frame_idx = -1;
@@ -1341,7 +1342,7 @@ void PalVideoDecoder::Destroy() {
 
     // Release resources (PalObject destructors handle this)
     bitstream_.gpu_memory.Reset();
-    dpb_.Clear();  // PalDpbSlot::fence PalObjects destroyed here
+    dpb_.Clear();  // Resets image, image_memory, and fence PalObjects for all slots
     decoder_heap_.Reset();
     cmd_buffer_.Reset();
     cmd_allocator_.Reset();

--- a/projects/rocdecode/src/rocdecode/pal/pal_videodecoder.cpp
+++ b/projects/rocdecode/src/rocdecode/pal/pal_videodecoder.cpp
@@ -219,6 +219,7 @@ Pal::IDevice* PalVideoDecoder::GetPalDevice() {
 
         // Check for VCN hardware
         Pal::DeviceProperties dev_props = {};
+        InfoLog(g_rocdec_logger, "PAL: Getting properties for device " + ROCDEC_TOSTR(i));
         dev->GetProperties(&dev_props);
 
         InfoLog(g_rocdec_logger, ROCDEC_STR("PAL: Device ") + ROCDEC_TOSTR(i) +
@@ -289,7 +290,8 @@ PalVideoDecoder::PalVideoDecoder()
     , bit_depth_(0)
     , max_dpb_slots_(0)
     , initialized_(false)
-    , session_begun_(false) {
+    , session_begun_(false)
+    , last_submitted_slot_idx_(-1) {
 }
 
 PalVideoDecoder::~PalVideoDecoder() {
@@ -378,6 +380,13 @@ rocDecStatus PalVideoDecoder::Initialize(rocDecVideoCodec codec_type,
         const auto& eng_props = dev_props_for_alloc.engineProperties[eng];
 
         Pal::CmdAllocatorCreateInfo aci = {};
+        InfoLog(g_rocdec_logger, ROCDEC_STR("PAL: CmdAllocator create - engineType=") + ROCDEC_TOSTR((int)eng) +
+                " queueType=" + ROCDEC_TOSTR((int)Pal::QueueTypeVideoDecode) +
+                " preferred heaps: " +
+                ROCDEC_TOSTR(eng_props.preferredCmdAllocHeaps[0]) + ", " +
+                ROCDEC_TOSTR(eng_props.preferredCmdAllocHeaps[1]) + ", " +
+                ROCDEC_TOSTR(eng_props.preferredCmdAllocHeaps[2]) + ", " +
+                ROCDEC_TOSTR(eng_props.preferredCmdAllocHeaps[3]));
         aci.flags.threadSafe = 1;
 
         // Initialize all allocator types from the device's preferred heaps for this engine
@@ -415,9 +424,10 @@ rocDecStatus PalVideoDecoder::Initialize(rocDecVideoCodec codec_type,
         Pal::CmdBufferCreateInfo cbci = {};
         cbci.engineType = eng;
         cbci.queueType = Pal::QueueTypeVideoDecode;
-        cbci.pCmdAllocator = nullptr;
+        //cbci.pCmdAllocator = nullptr;
+        cbci.pCmdAllocator = static_cast<Pal::ICmdAllocator*>(*cmd_allocator_.PtrAddr());
 
-        InfoLog(g_rocdec_logger, ROCDEC_STR("PAL: CmdBuffer create - engineType=") + ROCDEC_TOSTR((int)cbci.engineType) +
+        InfoLog(g_rocdec_logger, ROCDEC_STR("PAL: CmdBufferCreateInfo - engineType=") + ROCDEC_TOSTR((int)cbci.engineType) +
                 " queueType=" + ROCDEC_TOSTR((int)cbci.queueType) +
                 " (EngineTypeVcnDecode=" + ROCDEC_TOSTR((int)Pal::EngineTypeVcnDecode) +
                 " EngineTypeVcnUnified=" + ROCDEC_TOSTR((int)Pal::EngineTypeVcnUnified) +
@@ -446,30 +456,6 @@ rocDecStatus PalVideoDecoder::Initialize(rocDecVideoCodec codec_type,
         *cmd_buffer_.PtrAddr() = cb;
         *cmd_buffer_.MemAddr() = mem;
         InfoLog(g_rocdec_logger, "PAL: Command buffer created successfully");
-    }
-
-    // Create fence
-    {
-        Pal::FenceCreateInfo fci = {};
-        fci.flags.signaled = 0;
-
-        size_t sz = device_->GetFenceSize(&res);
-        if (Util::IsErrorResult(res)) {
-            CriticalLog(g_rocdec_logger, "PAL: GetFenceSize failed");
-            return ROCDEC_RUNTIME_ERROR;
-        }
-
-        void* mem = malloc(sz);
-        Pal::IFence* f = nullptr;
-        res = device_->CreateFence(fci, mem, &f);
-        if (Util::IsErrorResult(res) || !f) {
-            free(mem);
-            CriticalLog(g_rocdec_logger, "PAL: CreateFence failed");
-            return ROCDEC_RUNTIME_ERROR;
-        }
-
-        *fence_.PtrAddr() = f;
-        *fence_.MemAddr() = mem;
     }
 
     // Allocate DPB slots
@@ -556,6 +542,15 @@ rocDecStatus PalVideoDecoder::Initialize(rocDecVideoCodec codec_type,
 
         *decoder_heap_.PtrAddr() = heap_mem;
         *decoder_heap_.MemAddr() = heap_obj_mem;
+
+        Pal::GpuMemoryRef mem_ref = {};
+        mem_ref.pGpuMemory = heap_mem;
+        Pal::Result add_res = device_->AddGpuMemoryReferences(1, &mem_ref, nullptr, 0);
+        if (Util::IsErrorResult(add_res)) {
+            CriticalLog(g_rocdec_logger, ROCDEC_STR("PAL: AddGpuMemoryReferences (decoder heap) failed with result ") +
+                        ROCDEC_TOSTR((int)add_res));
+            return ROCDEC_RUNTIME_ERROR;
+        }
         InfoLog(g_rocdec_logger, "PAL: Decoder heap allocated successfully");
     }
 
@@ -588,7 +583,9 @@ rocDecStatus PalVideoDecoder::AllocateDecodedFrame(uint32_t width, uint32_t heig
     ici.mipLevels = 1;
     ici.arraySize = 1;
     ici.samples = 1;
+#if PAL_CLIENT_INTERFACE_MAJOR_VERSION < 961
     ici.fragments = 1;
+#endif
     ici.tiling = Pal::ImageTiling::Optimal;
     // TODO: PAL version mismatch - videoDecodeTarget not found
     // ici.usageFlags.videoDecodeTarget = 1;
@@ -615,19 +612,30 @@ rocDecStatus PalVideoDecoder::AllocateDecodedFrame(uint32_t width, uint32_t heig
     Pal::GpuMemoryRequirements mem_reqs = {};
     img->GetGpuMemoryRequirements(&mem_reqs);
 
+    /*static const char* kHeapNames[] = { "Local(0)", "Invisible(1)", "GartUswc(2)", "GartCacheable(3)" };
+    std::string heap_list;
+    for (uint32_t i = 0; i < mem_reqs.heapCount; ++i) {
+        uint32_t h = static_cast<uint32_t>(mem_reqs.heaps[i]);
+        heap_list += (h < 4 ? kHeapNames[h] : ROCDEC_STR("Unknown(") + ROCDEC_TOSTR(h) + ")");
+        if (i + 1 < mem_reqs.heapCount) heap_list += ", ";
+    }
+    InfoLog(g_rocdec_logger, ROCDEC_STR("PAL: DPB mem_reqs size=") + ROCDEC_TOSTR(mem_reqs.size) +
+            " alignment=" + ROCDEC_TOSTR(mem_reqs.alignment) +
+            " heapCount=" + ROCDEC_TOSTR(mem_reqs.heapCount) +
+            " heaps=[" + heap_list + "]");*/
+
+
     Pal::GpuMemoryCreateInfo mem_ci = {};
     mem_ci.size = mem_reqs.size;
     mem_ci.alignment = mem_reqs.alignment;
-    mem_ci.vaRange = Pal::VaRange::Default;
-    mem_ci.priority = Pal::GpuMemPriority::Normal;
-    mem_ci.heapCount = mem_reqs.heapCount;
-    for (uint32_t i = 0; i < mem_reqs.heapCount; ++i) {
-        mem_ci.heaps[i] = mem_reqs.heaps[i];
-    }
+    mem_ci.flags.interprocess = 1;
+    mem_ci.flags.shareable = 1;
+    mem_ci.heapCount = 1;
+    mem_ci.heaps[0] = Pal::GpuHeapGartCacheable;
 
     size_t gpu_mem_size = device_->GetGpuMemorySize(mem_ci, &res);
     if (Util::IsErrorResult(res)) {
-        CriticalLog(g_rocdec_logger, "PAL: GetGpuMemorySize failed");
+        CriticalLog(g_rocdec_logger, ROCDEC_STR("PAL: GetGpuMemorySize (decode surface) failed result=") + ROCDEC_TOSTR((int)res));
         return ROCDEC_RUNTIME_ERROR;
     }
 
@@ -636,7 +644,7 @@ rocDecStatus PalVideoDecoder::AllocateDecodedFrame(uint32_t width, uint32_t heig
     res = device_->CreateGpuMemory(mem_ci, gpu_mem_obj, &gpu_mem);
     if (Util::IsErrorResult(res) || !gpu_mem) {
         free(gpu_mem_obj);
-        CriticalLog(g_rocdec_logger, "PAL: CreateGpuMemory failed");
+        CriticalLog(g_rocdec_logger, ROCDEC_STR("PAL: CreateGpuMemory failed result=") + ROCDEC_TOSTR((int)res));
         return ROCDEC_RUNTIME_ERROR;
     }
 
@@ -650,7 +658,46 @@ rocDecStatus PalVideoDecoder::AllocateDecodedFrame(uint32_t width, uint32_t heig
         return ROCDEC_RUNTIME_ERROR;
     }
 
+    // Register with WDDM VidMm so the KMD keeps it resident for GPU access.
+    // On WDDM, per-submit gpuMemRefs are not supported; residency is managed device-wide.
+    {
+        Pal::GpuMemoryRef mem_ref = {};
+        mem_ref.pGpuMemory = gpu_mem;
+        Pal::Result add_res = device_->AddGpuMemoryReferences(1, &mem_ref, nullptr, 0);
+        if (Util::IsErrorResult(add_res)) {
+            CriticalLog(g_rocdec_logger, ROCDEC_STR("PAL: AddGpuMemoryReferences (DPB slot) failed with result ") +
+                        ROCDEC_TOSTR((int)add_res));
+            return ROCDEC_RUNTIME_ERROR;
+        }
+    }
+
     slot.image_index = 0;
+
+    // Create a fence for this slot so GetDecodeStatus/SyncSurface can track
+    // when a decode targeting this slot has completed, independently of other slots.
+    {
+        Pal::FenceCreateInfo fci = {};
+        fci.flags.signaled = 1; // Start signaled — no pending work yet
+
+        size_t fence_sz = device_->GetFenceSize(&res);
+        if (Util::IsErrorResult(res)) {
+            CriticalLog(g_rocdec_logger, "PAL: GetFenceSize failed for DPB slot fence");
+            return ROCDEC_RUNTIME_ERROR;
+        }
+
+        void* fence_mem = malloc(fence_sz);
+        Pal::IFence* f = nullptr;
+        res = device_->CreateFence(fci, fence_mem, &f);
+        if (Util::IsErrorResult(res) || !f) {
+            free(fence_mem);
+            CriticalLog(g_rocdec_logger, "PAL: CreateFence failed for DPB slot");
+            return ROCDEC_RUNTIME_ERROR;
+        }
+
+        *slot.fence.PtrAddr() = f;
+        *slot.fence.MemAddr() = fence_mem;
+    }
+
     return ROCDEC_SUCCESS;
 }
 
@@ -701,6 +748,19 @@ rocDecStatus PalVideoDecoder::AllocateBitstreamBuffer(size_t capacity) {
     if (Util::IsErrorResult(res)) {
         CriticalLog(g_rocdec_logger, "PAL: Map (bitstream) failed");
         return ROCDEC_RUNTIME_ERROR;
+    }
+
+    // Register with WDDM VidMm for GPU residency
+    if (device_) {
+        Pal::GpuMemoryRef mem_ref = {};
+        mem_ref.pGpuMemory = gpu_mem;
+        mem_ref.flags.readOnly = 1;  // GPU only reads the bitstream
+        Pal::Result add_res = device_->AddGpuMemoryReferences(1, &mem_ref, nullptr, 0);
+        if (Util::IsErrorResult(add_res)) {
+            CriticalLog(g_rocdec_logger, ROCDEC_STR("PAL: AddGpuMemoryReferences (bitstream) failed with result ") +
+                        ROCDEC_TOSTR((int)add_res));
+            return ROCDEC_RUNTIME_ERROR;
+        }
     }
 
     return ROCDEC_SUCCESS;
@@ -758,23 +818,6 @@ rocDecStatus PalVideoDecoder::DecodeHEVC(RocdecPicParams* params) {
     }
 
     const RocdecHevcPicParams* hevc = &params->pic_params.hevc;
-
-    // Upload bitstream to GPU
-    size_t bitstream_size = params->bitstream_data_len;
-    if (bitstream_size > bitstream_.capacity) {
-        rocDecStatus status = AllocateBitstreamBuffer(bitstream_size * 2);
-        if (status != ROCDEC_SUCCESS) {
-            return status;
-        }
-    }
-
-    rocDecStatus status = UploadBitstream(
-        static_cast<const uint8_t*>(params->bitstream_data),
-        bitstream_size
-    );
-    if (status != ROCDEC_SUCCESS) {
-        return status;
-    }
 
     // Map rocDecode HEVC parameters to PAL/UVD format
     hevc_t pal_hevc = {};
@@ -886,9 +929,9 @@ rocDecStatus PalVideoDecoder::DecodeHEVC(RocdecPicParams* params) {
     pal_hevc.curr_poc = hevc->curr_pic.poc;
     pal_hevc.curr_idx = static_cast<unsigned char>(params->curr_pic_idx);
 
-    // Reference picture list
+    // Reference picture list — hevc_t.ref_pic_list[16], rocDecode provides 15 ref slots.
+    // Fill all 16 entries; the 16th (index 15) has no rocDecode counterpart so mark invalid.
     for (size_t i = 0; i < 15; i++) {
-        // Check if reference is valid (not using is_invalid flag directly, check pic_idx)
         if (hevc->ref_frames[i].pic_idx != 0xFF && hevc->ref_frames[i].pic_idx >= 0) {
             pal_hevc.ref_pic_list[i] = static_cast<unsigned char>(hevc->ref_frames[i].pic_idx);
             pal_hevc.poc_list[i] = hevc->ref_frames[i].poc;
@@ -897,6 +940,7 @@ rocDecStatus PalVideoDecoder::DecodeHEVC(RocdecPicParams* params) {
             pal_hevc.poc_list[i] = 0;
         }
     }
+    pal_hevc.ref_pic_list[15] = 0xFF;  // No rocDecode counterpart — must be explicitly invalid
 
     // 10-bit mode
     if (hevc->bit_depth_luma_minus8 == 2) {
@@ -914,11 +958,13 @@ rocDecStatus PalVideoDecoder::DecodeHEVC(RocdecPicParams* params) {
             ROCDEC_TOSTR(hevc->picture_height_in_luma_samples));
 
     // Get current DPB slot for output
+    InfoLog(g_rocdec_logger, ROCDEC_STR("PAL: Getting DPB slot for curr_pic_idx=") + ROCDEC_TOSTR(params->curr_pic_idx));
     PalDpbSlot* output_slot = dpb_.GetSlot(params->curr_pic_idx);
     if (!output_slot || !output_slot->image.Get()) {
         CriticalLog(g_rocdec_logger, "PAL: Invalid output slot");
         return ROCDEC_INVALID_PARAMETER;
     }
+    InfoLog(g_rocdec_logger, "PAL: DPB slot acquired");
 
     // Build PAL decode frame info
     Pal::VideoCodecInfo codec_info = {};
@@ -935,7 +981,7 @@ rocDecStatus PalVideoDecoder::DecodeHEVC(RocdecPicParams* params) {
 
     // Bitstream buffer
     decode_info.pBitstreamBuffer = bitstream_.gpu_memory.Get();
-    decode_info.bitstreamBufferSize = bitstream_size;
+    decode_info.bitstreamBufferSize = params->bitstream_data_len;
     decode_info.bitstreamBufferOffset = 0;
 
     // Decode target (output image)
@@ -953,8 +999,12 @@ rocDecStatus PalVideoDecoder::DecodeHEVC(RocdecPicParams* params) {
     decode_info.dpbArraySize = max_dpb_slots_;
 
     // Query device properties to determine DPB tier
+    InfoLog(g_rocdec_logger, "PAL: Calling device_->GetProperties ...");
     Pal::DeviceProperties dev_props = {};
     device_->GetProperties(&dev_props);
+    InfoLog(g_rocdec_logger, ROCDEC_STR("PAL: GetProperties done - supportUnifiedDecodeTarget=") +
+            ROCDEC_TOSTR(dev_props.vcnipProperties.flags.supportUnifiedDecodeTarget) +
+            " supportArrayOfTextures=" + ROCDEC_TOSTR(dev_props.vcnipProperties.flags.supportArrayOfTextures));
 
     if (dev_props.vcnipProperties.flags.supportUnifiedDecodeTarget) {
         // Tier 2: Array of textures (preferred)
@@ -1016,31 +1066,128 @@ rocDecStatus PalVideoDecoder::DecodeHEVC(RocdecPicParams* params) {
         }
     }
 
+    // Wait for the previous frame's slot fence before recycling the shared cmd_allocator.
+    // The GPU queue serializes execution, but cmd_allocator_->Reset frees CPU-side memory
+    // that the GPU may still be reading for the previous submission.
+    if (last_submitted_slot_idx_ >= 0) {
+        PalDpbSlot* prev_slot = dpb_.GetSlot(last_submitted_slot_idx_);
+        if (prev_slot && prev_slot->fence.Get()) {
+            Pal::Result fence_status = prev_slot->fence->GetStatus();
+            if (fence_status == Pal::Result::NotReady) {
+                InfoLog(g_rocdec_logger, ROCDEC_STR("PAL: Waiting for slot ") +
+                        ROCDEC_TOSTR(last_submitted_slot_idx_) + " fence before cmd_buffer Reset ...");
+                const Pal::IFence* wait_fences[] = { prev_slot->fence.Get() };
+                Pal::Result wait_res = device_->WaitForFences(1, wait_fences, true,
+                                                              std::chrono::nanoseconds(5000000000LL));
+                if (Util::IsErrorResult(wait_res)) {
+                    CriticalLog(g_rocdec_logger, ROCDEC_STR("PAL: WaitForFences failed with result ") +
+                                ROCDEC_TOSTR((int)wait_res));
+                    return ROCDEC_RUNTIME_ERROR;
+                }
+            }
+        }
+    }
+
+    // Upload bitstream after the fence wait so Frame N-1's GPU read of the shared
+    // bitstream buffer has completed before Frame N overwrites it.
+    {
+        size_t bitstream_size = params->bitstream_data_len;
+        if (bitstream_size > bitstream_.capacity) {
+            rocDecStatus alloc_status = AllocateBitstreamBuffer(bitstream_size * 2);
+            if (alloc_status != ROCDEC_SUCCESS) {
+                return alloc_status;
+            }
+        }
+        rocDecStatus upload_status = UploadBitstream(
+            static_cast<const uint8_t*>(params->bitstream_data),
+            bitstream_size
+        );
+        if (upload_status != ROCDEC_SUCCESS) {
+            return upload_status;
+        }
+    }
+
     // Reset and begin command buffer
+    InfoLog(g_rocdec_logger, "PAL: Calling cmd_buffer_->Reset ...");
     Pal::Result res = cmd_buffer_->Reset(cmd_allocator_.Get(), true);
+    InfoLog(g_rocdec_logger, ROCDEC_STR("PAL: cmd_buffer_->Reset returned ") + ROCDEC_TOSTR((int)res));
     if (Util::IsErrorResult(res)) {
         CriticalLog(g_rocdec_logger, ROCDEC_STR("PAL: CmdBuffer Reset failed with result ") + ROCDEC_TOSTR((int)res));
         return ROCDEC_RUNTIME_ERROR;
     }
 
     Pal::CmdBufferBuildInfo build_info = {};
+    InfoLog(g_rocdec_logger, "PAL: Calling cmd_buffer_->Begin ...");
     res = cmd_buffer_->Begin(build_info);
+    InfoLog(g_rocdec_logger, ROCDEC_STR("PAL: cmd_buffer_->Begin returned ") + ROCDEC_TOSTR((int)res));
     if (Util::IsErrorResult(res)) {
         CriticalLog(g_rocdec_logger, ROCDEC_STR("PAL: CmdBuffer Begin failed with result ") + ROCDEC_TOSTR((int)res));
         return ROCDEC_RUNTIME_ERROR;
     }
 
-    // Begin video decode session (if first frame)
-    if (!session_begun_) {
-        Pal::VideoDecodeBeginInfo begin_info = {};
-        begin_info.srcExtent.width = hevc->picture_width_in_luma_samples;
-        begin_info.srcExtent.height = hevc->picture_height_in_luma_samples;
-        cmd_buffer_->CmdBeginVideoDecode(begin_info);
-        session_begun_ = true;
-        InfoLog(g_rocdec_logger, "PAL: Video decode session begun");
-    }
+    InfoLog(g_rocdec_logger, "PAL: Calling CmdBindVideoDecoder ...");
+    cmd_buffer_->CmdBindVideoDecoder(*video_decoder_.Get());
+
+    InfoLog(g_rocdec_logger, "PAL: Calling CmdBeginVideoDecode ...");
+    Pal::VideoDecodeBeginInfo begin_info = {};
+    begin_info.srcExtent.width = hevc->picture_width_in_luma_samples;
+    begin_info.srcExtent.height = hevc->picture_height_in_luma_samples;
+    cmd_buffer_->CmdBeginVideoDecode(begin_info);
+    InfoLog(g_rocdec_logger, "PAL: CmdBeginVideoDecode done");
 
     // Submit decode frame command
+    // --- Frame parameter dump for submission debugging ---
+    {
+        static int s_frame_idx = 0;
+        InfoLog(g_rocdec_logger, ROCDEC_STR("PAL: === FRAME ") + ROCDEC_TOSTR(s_frame_idx) + " DECODE_INFO DUMP ===");
+        InfoLog(g_rocdec_logger, ROCDEC_STR("PAL:   curr_pic_idx=") + ROCDEC_TOSTR(params->curr_pic_idx) +
+                " last_submitted_slot_idx=" + ROCDEC_TOSTR(last_submitted_slot_idx_));
+        InfoLog(g_rocdec_logger, ROCDEC_STR("PAL:   decodeType=") + ROCDEC_TOSTR((int)decode_info.decodeType) +
+                " srcExtent=" + ROCDEC_TOSTR(decode_info.srcExtent.width) + "x" + ROCDEC_TOSTR(decode_info.srcExtent.height));
+        InfoLog(g_rocdec_logger, ROCDEC_STR("PAL:   bitstreamBufferSize=") + ROCDEC_TOSTR(decode_info.bitstreamBufferSize) +
+                " bitstreamBufferOffset=" + ROCDEC_TOSTR(decode_info.bitstreamBufferOffset) +
+                " pBitstreamBuffer=" + ROCDEC_TOSTR((uintptr_t)decode_info.pBitstreamBuffer));
+        InfoLog(g_rocdec_logger, ROCDEC_STR("PAL:   pDecodeTargetBuffer=") + ROCDEC_TOSTR((uintptr_t)decode_info.pDecodeTargetBuffer) +
+                " decodeTargetArraySlice=" + ROCDEC_TOSTR(decode_info.decodeTargetArraySlice));
+        InfoLog(g_rocdec_logger, ROCDEC_STR("PAL:   pDpbCurrBuffer=") + ROCDEC_TOSTR((uintptr_t)decode_info.pDpbCurrBuffer) +
+                " dpbCurArraySlice=" + ROCDEC_TOSTR(decode_info.dpbCurArraySlice) +
+                " dpbArraySize=" + ROCDEC_TOSTR(decode_info.dpbArraySize));
+        InfoLog(g_rocdec_logger, ROCDEC_STR("PAL:   dpbTier1=") + ROCDEC_TOSTR(decode_info.dpbConfig.dynamicDpbTier1) +
+                " tier2=" + ROCDEC_TOSTR(decode_info.dpbConfig.dynamicDpbTier2) +
+                " tier3=" + ROCDEC_TOSTR(decode_info.dpbConfig.dynamicDpbTier3));
+        InfoLog(g_rocdec_logger, ROCDEC_STR("PAL:   pDecoderHeapBuffer=") + ROCDEC_TOSTR((uintptr_t)decode_info.pDecoderHeapBuffer) +
+                " decoderHeapOffset=" + ROCDEC_TOSTR(decode_info.decoderHeapOffset));
+        InfoLog(g_rocdec_logger, ROCDEC_STR("PAL:   pCodecInfoBuffer=") + ROCDEC_TOSTR((uintptr_t)decode_info.pCodecInfoBuffer));
+        InfoLog(g_rocdec_logger, ROCDEC_STR("PAL:   output_slot->fence=") + ROCDEC_TOSTR((uintptr_t)output_slot->fence.Get()) +
+                " fence_status=" + ROCDEC_TOSTR((int)output_slot->fence->GetStatus()));
+
+        // Dump reference buffer pointers to catch null/invalid refs
+        for (uint32_t i = 0; i < Pal::MaxDpbSliceCount; i++) {
+            if (decode_info.pDpbRefBuffers[i] != nullptr || decode_info.dpbRefArraySlices[i] != 0xFF) {
+                InfoLog(g_rocdec_logger, ROCDEC_STR("PAL:   ref[") + ROCDEC_TOSTR(i) + "]=" +
+                        ROCDEC_TOSTR((uintptr_t)decode_info.pDpbRefBuffers[i]) +
+                        " slice=" + ROCDEC_TOSTR((int)decode_info.dpbRefArraySlices[i]));
+            }
+        }
+
+        // Dump HEVC codec params that differ most between frames
+        InfoLog(g_rocdec_logger, ROCDEC_STR("PAL:   hevc.curr_poc=") + ROCDEC_TOSTR(pal_hevc.curr_poc) +
+                " curr_idx=" + ROCDEC_TOSTR((int)pal_hevc.curr_idx) +
+                " sps_info_flags=" + ROCDEC_TOSTR(pal_hevc.sps_info_flags) +
+                " pps_info_flags=" + ROCDEC_TOSTR(pal_hevc.pps_info_flags));
+        InfoLog(g_rocdec_logger, ROCDEC_STR("PAL:   ref_pic_list[0..3]=") +
+                ROCDEC_TOSTR((int)pal_hevc.ref_pic_list[0]) + "," +
+                ROCDEC_TOSTR((int)pal_hevc.ref_pic_list[1]) + "," +
+                ROCDEC_TOSTR((int)pal_hevc.ref_pic_list[2]) + "," +
+                ROCDEC_TOSTR((int)pal_hevc.ref_pic_list[3]));
+        InfoLog(g_rocdec_logger, ROCDEC_STR("PAL:   poc_list[0..3]=") +
+                ROCDEC_TOSTR(pal_hevc.poc_list[0]) + "," +
+                ROCDEC_TOSTR(pal_hevc.poc_list[1]) + "," +
+                ROCDEC_TOSTR(pal_hevc.poc_list[2]) + "," +
+                ROCDEC_TOSTR(pal_hevc.poc_list[3]));
+        InfoLog(g_rocdec_logger, ROCDEC_STR("PAL: === END FRAME ") + ROCDEC_TOSTR(s_frame_idx) + " DUMP ===");
+        s_frame_idx++;
+    }
     cmd_buffer_->CmdDecodeVideoFrame(decode_info);
 
     // End command buffer
@@ -1050,9 +1197,11 @@ rocDecStatus PalVideoDecoder::DecodeHEVC(RocdecPicParams* params) {
         return ROCDEC_RUNTIME_ERROR;
     }
 
-    // Reset fence before submission so it can be signaled on completion
+    // Reset this slot's fence so it can be signaled when this decode completes.
+    // The queue serializes GPU work, so resetting after the previous submit for a
+    // different slot is safe — each slot has its own independent fence.
     {
-        Pal::IFence* fences_to_reset[] = { fence_.Get() };
+        Pal::IFence* fences_to_reset[] = { output_slot->fence.Get() };
         res = device_->ResetFences(1, fences_to_reset);
         if (Util::IsErrorResult(res)) {
             CriticalLog(g_rocdec_logger, ROCDEC_STR("PAL: ResetFences failed with result ") + ROCDEC_TOSTR((int)res));
@@ -1060,25 +1209,33 @@ rocDecStatus PalVideoDecoder::DecodeHEVC(RocdecPicParams* params) {
         }
     }
 
-    // Submit to queue, attaching fence via MultiSubmitInfo
+    // Submit to queue, attaching this slot's fence
     Pal::ICmdBuffer* cmd_bufs[] = { cmd_buffer_.Get() };
     Pal::PerSubQueueSubmitInfo per_queue_info = {};
     per_queue_info.cmdBufferCount = 1;
     per_queue_info.ppCmdBuffers = cmd_bufs;
 
-    Pal::IFence* submit_fence = fence_.Get();
+    Pal::IFence* submit_fence = output_slot->fence.Get();
     Pal::MultiSubmitInfo submit_info = {};
     submit_info.perSubQueueInfoCount = 1;
     submit_info.pPerSubQueueInfo = &per_queue_info;
     submit_info.ppFences = &submit_fence;
     submit_info.fenceCount = 1;
 
+    InfoLog(g_rocdec_logger, ROCDEC_STR("PAL: Calling video_queue_->Submit - cmdBufCount=") +
+            ROCDEC_TOSTR(per_queue_info.cmdBufferCount) +
+            " fenceCount=" + ROCDEC_TOSTR(submit_info.fenceCount) +
+            " fence=" + ROCDEC_TOSTR((uintptr_t)submit_fence));
     res = video_queue_->Submit(submit_info);
+    InfoLog(g_rocdec_logger, ROCDEC_STR("PAL: video_queue_->Submit returned ") + ROCDEC_TOSTR((int)res));
     if (Util::IsErrorResult(res)) {
-        CriticalLog(g_rocdec_logger, ROCDEC_STR("PAL: Queue Submit failed with result ") + ROCDEC_TOSTR((int)res));
+        CriticalLog(g_rocdec_logger, ROCDEC_STR("PAL: Queue Submit failed with result ") + ROCDEC_TOSTR((int)res) +
+                    " curr_pic_idx=" + ROCDEC_TOSTR(params->curr_pic_idx) +
+                    " last_submitted_slot_idx=" + ROCDEC_TOSTR(last_submitted_slot_idx_));
         return ROCDEC_RUNTIME_ERROR;
     }
 
+    last_submitted_slot_idx_ = params->curr_pic_idx;
     InfoLog(g_rocdec_logger, "PAL: HEVC frame decode submitted successfully");
     return ROCDEC_SUCCESS;
 }
@@ -1104,22 +1261,22 @@ rocDecStatus PalVideoDecoder::GetDecodeStatus(int pic_idx, RocdecDecodeStatus* d
 
     std::lock_guard<std::mutex> lock(mutex_);
 
-    if (!initialized_ || !fence_.Get()) {
-        dec_pic->decode_status = static_cast<rocDecDecodeStatus>(0);  // Invalid/not ready
+    if (!initialized_) {
+        dec_pic->decode_status = static_cast<rocDecDecodeStatus>(0);
         dec_pic->reserved[0] = 0;
         return ROCDEC_NOT_INITIALIZED;
     }
 
     // Check if picture index is valid
     PalDpbSlot* slot = dpb_.GetSlot(pic_idx);
-    if (!slot || !slot->occupied) {
+    if (!slot || !slot->occupied || !slot->fence.Get()) {
         dec_pic->decode_status = static_cast<rocDecDecodeStatus>(0);  // Invalid
         dec_pic->reserved[0] = 0;
         return ROCDEC_INVALID_PARAMETER;
     }
 
-    // Query fence status (non-blocking)
-    Pal::Result res = fence_->GetStatus();
+    // Non-blocking poll on this slot's fence — mirrors vaQuerySurfaceStatus
+    Pal::Result res = slot->fence->GetStatus();
 
     if (res == Pal::Result::Success) {
         // Fence is signaled - decode complete
@@ -1159,10 +1316,34 @@ void PalVideoDecoder::Destroy() {
         return;
     }
 
-    // Wait for pending operations
-    if (device_ && fence_.Get()) {
-        const Pal::IFence* fences[] = { fence_.Get() };
-        device_->WaitForFences(1, fences, true, std::chrono::nanoseconds::max());
+    // Wait for any in-flight decode to finish before tearing down resources.
+    // Only the last submitted slot can have a pending fence; waiting on it is sufficient.
+    if (device_ && last_submitted_slot_idx_ >= 0) {
+        PalDpbSlot* slot = dpb_.GetSlot(last_submitted_slot_idx_);
+        if (slot && slot->fence.Get()) {
+            const Pal::IFence* fences[] = { slot->fence.Get() };
+            device_->WaitForFences(1, fences, true, std::chrono::nanoseconds::max());
+        }
+    }
+
+    // Unregister GPU memory from WDDM VidMm residency tracking before releasing
+    {
+        // Collect all registered allocations
+        Pal::IGpuMemory* to_remove[2 + PalDpb::kMaxSlots] = {};
+        uint32_t remove_count = 0;
+
+        if (bitstream_.gpu_memory.Get())
+            to_remove[remove_count++] = bitstream_.gpu_memory.Get();
+        if (decoder_heap_.Get())
+            to_remove[remove_count++] = decoder_heap_.Get();
+        for (uint32_t i = 0; i < dpb_.GetSlotCount(); i++) {
+            PalDpbSlot* slot = dpb_.GetSlot(static_cast<int32_t>(i));
+            if (slot && slot->image_memory.Get())
+                to_remove[remove_count++] = slot->image_memory.Get();
+        }
+
+        if (remove_count > 0)
+            device_->RemoveGpuMemoryReferences(remove_count, to_remove, nullptr);
     }
 
     // Unmap bitstream
@@ -1173,9 +1354,8 @@ void PalVideoDecoder::Destroy() {
 
     // Release resources (PalObject destructors handle this)
     bitstream_.gpu_memory.Reset();
-    dpb_.Clear();
+    dpb_.Clear();  // PalDpbSlot::fence PalObjects destroyed here
     decoder_heap_.Reset();
-    fence_.Reset();
     cmd_buffer_.Reset();
     cmd_allocator_.Reset();
     video_queue_.Reset();
@@ -1183,6 +1363,7 @@ void PalVideoDecoder::Destroy() {
 
     initialized_ = false;
     session_begun_ = false;
+    last_submitted_slot_idx_ = -1;
     device_ = nullptr;
 
     ReleasePalPlatform();
@@ -1251,21 +1432,23 @@ rocDecStatus PalVideoDecoder::ExportSurface(int pic_idx,
     const Pal::GpuMemoryDesc& mem_desc = gpu_mem->Desc();
     mem_size = mem_desc.size;
 
-    // Export GPU memory as Windows KMT handle
+    // Export GPU memory as KMT opaque handle (sharedViaNtHandle=0 path, uses m_hGlobalShare).
+    // The caller must import with hipExternalMemoryHandleTypeOpaqueWin32Kmt (not the NT variant).
 #if defined(PAL_KMT_BUILD)
     Pal::GpuMemoryExportInfo export_info = {};
-    export_info.exportType = Pal::ExportHandleType::Default;
+    export_info.exportType        = Pal::ExportHandleType::Default;
     export_info.pSecurityAttributes = nullptr;
-    export_info.pNtObjectName = nullptr;
-    export_info.accessFlags = 0;  // Use default access
+    export_info.pNtObjectName     = nullptr;
+    export_info.accessFlags       = 0; // Unused for KMT (non-NT) path
 
     Pal::OsExternalHandle external_handle = gpu_mem->ExportExternalHandle(export_info);
     if (external_handle == nullptr) {
-        CriticalLog(g_rocdec_logger, "PAL: ExportExternalHandle failed");
+        CriticalLog(g_rocdec_logger, "PAL: ExportExternalHandle failed (is memory allocated with interprocess=1?)");
         return ROCDEC_RUNTIME_ERROR;
     }
 
     kmt_handle = external_handle;
+    InfoLog(g_rocdec_logger, "PAL: Exported KMT opaque handle — import with hipExternalMemoryHandleTypeOpaqueWin32Kmt");
 #else
     // PAL_KMT_BUILD not defined - export not available
     CriticalLog(g_rocdec_logger, "PAL: ExportExternalHandle not available (PAL_KMT_BUILD not defined)");

--- a/projects/rocdecode/src/rocdecode/pal/pal_videodecoder.cpp
+++ b/projects/rocdecode/src/rocdecode/pal/pal_videodecoder.cpp
@@ -612,19 +612,6 @@ rocDecStatus PalVideoDecoder::AllocateDecodedFrame(uint32_t width, uint32_t heig
     Pal::GpuMemoryRequirements mem_reqs = {};
     img->GetGpuMemoryRequirements(&mem_reqs);
 
-    /*static const char* kHeapNames[] = { "Local(0)", "Invisible(1)", "GartUswc(2)", "GartCacheable(3)" };
-    std::string heap_list;
-    for (uint32_t i = 0; i < mem_reqs.heapCount; ++i) {
-        uint32_t h = static_cast<uint32_t>(mem_reqs.heaps[i]);
-        heap_list += (h < 4 ? kHeapNames[h] : ROCDEC_STR("Unknown(") + ROCDEC_TOSTR(h) + ")");
-        if (i + 1 < mem_reqs.heapCount) heap_list += ", ";
-    }
-    InfoLog(g_rocdec_logger, ROCDEC_STR("PAL: DPB mem_reqs size=") + ROCDEC_TOSTR(mem_reqs.size) +
-            " alignment=" + ROCDEC_TOSTR(mem_reqs.alignment) +
-            " heapCount=" + ROCDEC_TOSTR(mem_reqs.heapCount) +
-            " heaps=[" + heap_list + "]");*/
-
-
     Pal::GpuMemoryCreateInfo mem_ci = {};
     mem_ci.size = mem_reqs.size;
     mem_ci.alignment = mem_reqs.alignment;

--- a/projects/rocdecode/src/rocdecode/pal/pal_videodecoder.h
+++ b/projects/rocdecode/src/rocdecode/pal/pal_videodecoder.h
@@ -119,8 +119,9 @@ private:
  * @brief DPB (Decoded Picture Buffer) slot for reference frames
  */
 struct PalDpbSlot {
-    PalObject<Pal::IImage> image;           // Decoded frame surface (NV12/P010)
+    PalObject<Pal::IImage> image;            // Decoded frame surface (NV12/P010)
     PalObject<Pal::IGpuMemory> image_memory; // Backing GPU memory
+    PalObject<Pal::IFence> fence;            // Signaled when this slot's decode completes
     uint32_t image_index;                    // Array layer (usually 0)
 
     bool occupied;
@@ -289,7 +290,6 @@ private:
     PalObject<Pal::IQueue> video_queue_;
     PalObject<Pal::ICmdAllocator> cmd_allocator_;
     PalObject<Pal::ICmdBuffer> cmd_buffer_;
-    PalObject<Pal::IFence> fence_;
     PalObject<Pal::IVideoDecoder> video_decoder_;
 
     rocDecVideoCodec codec_;
@@ -305,6 +305,7 @@ private:
 
     bool initialized_;
     bool session_begun_;
+    int32_t last_submitted_slot_idx_; // DPB slot index of the most recently submitted frame
     std::mutex mutex_;
 
     // Platform singleton state (recursive mutex because GetPalDevice calls GetPalPlatform)

--- a/projects/rocdecode/src/rocdecode/roc_decoder.cpp
+++ b/projects/rocdecode/src/rocdecode/roc_decoder.cpp
@@ -238,9 +238,14 @@ rocDecStatus RocDecoder::GetVideoFrame(int pic_idx, void *dev_mem_ptr[3], uint32
         external_mem_handle_desc.size = va_drm_prime_surface_desc.objects[0].size;
 
         CHECK_HIP(hipImportExternalMemory(&hip_interop_[pic_idx].hip_ext_mem, &external_mem_handle_desc));
+        InfoLog(g_rocdec_logger, "HIP INTEROP DEBUG ----- Imported external memory for picture idx = " + ROCDEC_TOSTR(pic_idx) +
+                " size = " + ROCDEC_TOSTR(external_mem_handle_desc.size));
 
         external_mem_buffer_desc.size = va_drm_prime_surface_desc.objects[0].size;
         CHECK_HIP(hipExternalMemoryGetMappedBuffer((void**)&hip_interop_[pic_idx].hip_mapped_device_mem, hip_interop_[pic_idx].hip_ext_mem, &external_mem_buffer_desc));
+        InfoLog(g_rocdec_logger, "HIP INTEROP DEBUG ----- Got mapped buffer for picture idx = " + ROCDEC_TOSTR(pic_idx) +
+                " size = " + ROCDEC_TOSTR(external_mem_buffer_desc.size) +
+                " device pointer = " + ROCDEC_TOSTR((uintptr_t)hip_interop_[pic_idx].hip_mapped_device_mem));
 
         hip_interop_[pic_idx].width = va_drm_prime_surface_desc.width;
         hip_interop_[pic_idx].height = va_drm_prime_surface_desc.height;


### PR DESCRIPTION
## Motivation

To get an entire video to decode on windows using PAL

## Technical Details

Changes in pal_videodecoder.cpp

1. `ref_pic_list[15]` fix — The hevc_t struct has 16 ref entries but rocDecode only provides 15. Index 15 was zero-initialized = slot 0, making slot 0 appear as a spurious reference on every P-frame. Fixed by

explicitly marking it invalid:
`pal_hevc.ref_pic_list[15] = 0xFF;` // No rocDecode counterpart — must be explicitly invalid

2. WDDM GPU memory residency via AddGpuMemoryReferences — On WDDM, MultiSubmitInfo::gpuMemRefCount is asserted to be 0 (not supported). Residency must be declared device-wide at allocation time via

`IDevice::AddGpuMemoryReferences`. Added after creating:

- Each DPB slot's image_memory (in AllocateDecodedFrame)
- The decoder heap (in Initialize)
- The bitstream buffer (in AllocateBitstreamBuffer)

3. RemoveGpuMemoryReferences in Destroy — Paired cleanup collecting all registered allocations before releasing them.

4. Fence wait before `cmd_buffer_->Reset` — The shared cmd_allocator_ cannot be recycled while the GPU is still reading its previous commands. Wait on `dpb_[last_submitted_slot_idx_].fence` first:
```
if (last_submitted_slot_idx_ >= 0) {
// WaitForFences on prev slot before Reset/Begin
}
```

5. Bitstream upload moved after fence wait — Frame N overwrites the shared bitstream buffer only after Frame N-1's GPU read of it has completed.

6. Per-slot fences starting signaled — Each `PalDpbSlot::fence` is created with `fci.flags.signaled = 1` so `GetDecodeStatus` returns ready before any decode has been submitted to that slot.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
