### PR TITLE
[rocprofiler-systems] reset fork-safe logger lock before logging in fork child

### DIFF
--- a/projects/rocprofiler-systems/source/lib/logger/logger.hpp
+++ b/projects/rocprofiler-systems/source/lib/logger/logger.hpp
@@ -155,54 +155,84 @@ class logger_t
 public:
     static spdlog::logger& instance()
     {
-        static std::shared_ptr<spdlog::logger> _instance;
-        static std::atomic<bool>               _initialized{ false };
-        static std::mutex                      _init_mutex;
-        static std::atomic<bool>               _log_lock{ false };
-
-        static std::once_flag _atfork_flag;
-        std::call_once(_atfork_flag, [] {
+        std::call_once(state().atfork_flag, [] {
             pthread_atfork(
-                // prefork: lock _init_mutex.  Safe because it is only held
+                // prefork: lock init_mutex.  Safe because it is only held
                 // briefly during one-time logger creation, never during
-                // normal log calls — so no lock-ordering inversion with
+                // normal log calls - so no lock-ordering inversion with
                 // glibc-internal locks acquired by fork().
-                [] { _init_mutex.lock(); },
+                [] { state().init_mutex.lock(); },
                 // parent postfork: unlock, resume normal operation.
-                [] { _init_mutex.unlock(); },
-                // child postfork: reset the atomic spinlock (well-defined
-                // atomic store — no UB unlike placement-new on a mutex),
-                // then safely delete the old logger (_st sinks have no
-                // internal mutex).  No leak.
+                [] { state().init_mutex.unlock(); },
+                // child postfork: defense-in-depth reset.  The authoritative
+                // reset happens earlier via reset_after_fork() called at the
+                // top of fork_gotcha::postfork_child (see note there); this
+                // handler covers fork() paths that do not route through the
+                // gotcha.
                 [] {
-                    _log_lock.store(false, std::memory_order_relaxed);
-                    _instance.reset();
-                    _initialized.store(false, std::memory_order_release);
-                    _init_mutex.unlock();
+                    reset_after_fork();
+                    state().init_mutex.unlock();
                 });
         });
 
-        if(_initialized.load(std::memory_order_acquire))
+        if(state().initialized.load(std::memory_order_acquire))
         {
-            return *_instance;
+            return *state().instance_ptr;
         }
 
-        std::lock_guard<std::mutex> lock(_init_mutex);
-        if(!_initialized.load(std::memory_order_relaxed))
+        std::lock_guard<std::mutex> lock(state().init_mutex);
+        if(!state().initialized.load(std::memory_order_relaxed))
         {
-            _instance = create_logger(_log_lock);
-            _initialized.store(true, std::memory_order_release);
+            state().instance_ptr = create_logger(state().log_lock);
+            state().initialized.store(true, std::memory_order_release);
         }
 
-        return *_instance;
+        return *state().instance_ptr;
+    }
+
+    /**
+     * Resets the logger's fork-safe lock state in a post-fork child.
+     *
+     * Clears the atomic spinlock guarding the single-threaded sinks (it may
+     * have been inherited held by a thread that does not exist in the child)
+     * and discards the inherited logger so the next instance() call rebuilds
+     * it.  After this returns the fork-safe spinlock is acquirable without
+     * spinning, making logging in the child safe.
+     *
+     * @note Must be the first thing run in the child before any log call.
+     *       Safe to call from a pthread_atfork child handler: it performs
+     *       only an atomic store and a shared_ptr reset, no blocking.
+     * @warning Call only in the child; calling it in a live multithreaded
+     *          process would race with concurrent log calls.
+     */
+    static void reset_after_fork()
+    {
+        state().log_lock.store(false, std::memory_order_relaxed);
+        state().instance_ptr.reset();
+        state().initialized.store(false, std::memory_order_release);
     }
 
     logger_t() = delete;
 
 private:
+    struct shared_state
+    {
+        std::shared_ptr<spdlog::logger> instance_ptr;
+        std::atomic<bool>               initialized{ false };
+        std::mutex                      init_mutex;
+        std::atomic<bool>               log_lock{ false };
+        std::once_flag                  atfork_flag;
+    };
+
+    static shared_state& state()
+    {
+        static shared_state _state;
+        return _state;
+    }
+
     // Serializes _st sink access through an atomic spinlock.  Unlike a
     // mutex or shared_mutex the spinlock can be safely reset in a
-    // post-fork child with a plain atomic store — no undefined behaviour,
+    // post-fork child with a plain atomic store - no undefined behaviour,
     // no TSan complaints, and the old logger can be cleanly deleted.
     class fork_safe_logger : public spdlog::logger
     {
@@ -240,7 +270,7 @@ private:
 
         std::vector<spdlog::sink_ptr> sinks;
 
-        // Use _st sinks — no internal mutex.  Thread safety is provided
+        // Use _st sinks - no internal mutex.  Thread safety is provided
         // by fork_safe_logger's atomic spinlock, which can be safely
         // reset after fork() with a plain atomic store (no UB).
         sinks.push_back(std::make_shared<spdlog::sinks::stdout_color_sink_st>());

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/fork_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/fork_gotcha.cpp
@@ -105,6 +105,17 @@ postfork_child()
 {
     if(postfork_child_lock) return;
 
+    // Reset the fork-safe logger lock FIRST, before any logging path in the
+    // child.  The console/sink spinlock may have been inherited held by a
+    // thread that did not survive fork(); any LOG_* call below (or in the
+    // postfork_child_cleanup chain) would otherwise spin forever trying to
+    // acquire it.  Doing this here, rather than relying on the logger's own
+    // atfork child handler, is order-robust: glibc runs atfork child
+    // handlers LIFO, and this gotcha registers its handler after the logger
+    // registers its, so the gotcha handler runs first - before the logger's
+    // reset would.  See logger_t::reset_after_fork.
+    logger_t::reset_after_fork();
+
     if(!is_child_process())
     {
         LOG_ERROR("Child process {} believes it is the root process {}",


### PR DESCRIPTION
## Motivation
The fork-sampling CTest intermittently hangs to its 300s timeout under load because a forked child livelocks while logging inside its pthread_atfork child handler.

## Technical Details
glibc runs pthread_atfork child handlers LIFO, so fork_gotcha's postfork_child runs before the logger's own atfork reset and logs via pmc::postfork_child_cleanup, spinning forever on the logger's atomic spinlock that was inherited held from a thread that did not survive fork; this adds logger_t::reset_after_fork() and calls it as the first statement of postfork_child so the lock is cleared before any child-side log, preserving logging at all levels.

## JIRA
N/A

## Test Plan
Build, run the logger and fork unit tests, and loop the fork-sampling workload under CPU load with trace logging enabled.

## Test Result
38/38 logger and fork unit tests pass; the fork-sampling workload ran 0/130 hangs under heavy load with trace logging versus a roughly 10% baseline hang rate.
