### PR TITLE
CLR: Add Clang flag to convert compiler error into warning for certain apps

### DIFF
--- a/projects/clr/rocclr/device/devprogram.cpp
+++ b/projects/clr/rocclr/device/devprogram.cpp
@@ -1412,6 +1412,19 @@ std::vector<std::string> Program::ProcessOptions(amd::option::Options* options) 
       optionsVec.push_back("-Xclang");
       optionsVec.push_back(clext.str());
     }
+
+    // ROCM-24914 - Convert incompatible pointer types error to warning for some Adobe apps.
+    // This change was made upstream but the kernels used by these apps are still affected.
+    // Refer: https://github.com/llvm/llvm-project/pull/157364
+    std::string appName = {};
+    std::string appPathAndName = {};
+    amd::Os::getAppPathAndFileName(appName, appPathAndName);
+    if ((appName == "Indigo Benchmark.exe") ||
+        (appName == "Adobe Premiere Pro.exe") ||
+        (appName == "AfterFX.exe")) {
+      optionsVec.push_back("-Xclang");
+      optionsVec.push_back("-Wno-error=incompatible-pointer-types");
+    }
   }
 
   return optionsVec;


### PR DESCRIPTION
## Motivation

When using top-of-the-tip compiler, we are seeing crashes for apps such as IndigoBench.exe, Premiere Pro.exe and AfterFx.exe. This change aims to fix them.

## Technical Details

This issue arises because of a change that was made to upstream LLVM by https://github.com/llvm/llvm-project/pull/157364. This change converts the warning `-Wincompatible-pointer-types` into an error. It so happens that the kernels dispatched by these apps have these warnings within them.

The correct way to fix the underlying issue is to reach out to the ISVs to fix the kernels sources. However, this is a slow process. Until then, we'd like to remain successfully test and run these benchmarks and applications.

To achieve that, we add the flag `-Wno-error=incompatible-pointer-types` to the compilation action dispatched by the runtime. We only do this for the specified apps so as to not impact other apps/dispatches.

## JIRA ID

ROCM-24914

## Test Plan

Tested locally and can confirm that IndigoBench and the Adobe apps launched via PugetBench run successfully.

## Test Result

Mentioned apps run successfully.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
