### PR TITLE
rocdbgapi: Fix potential segfault during teardown

### DIFF
--- a/projects/rocdbgapi/src/process.cpp
+++ b/projects/rocdbgapi/src/process.cpp
@@ -109,6 +109,12 @@ process_t::process_t (amd_dbgapi_process_id_t process_id,
 
 process_t::~process_t ()
 {
+  /* Make sure to discard any cache before closing the driver.  The agent dtor
+     might otherwise try to write_back / discard the cache, but without a
+     process or a driver connection, this cannot work and would fail.  */
+  for (auto &&agent : range<agent_t> ())
+    agent.memory_cache ().discard (0, amd_dbgapi_size_t (-1), true);
+
   /* Destruct the os_driver before closing the notifier.  */
   m_os_driver.reset ();
   client_notifier ().close ();


### PR DESCRIPTION
## Motivation

Fix segfault observed during process tear down.

## Technical Details

During tear down of a process using rocdbgapi, the program will eventually call the destructor of any global object.  This include the amd::dbgapi::process_t::s_process_map static member, which will delete all of the remaining process_t instances.  This will invoke the destructor for the process object, which closes the associated driver_t connection, and then calls the destructor of all the members of the process_t.  This includes all the agents, which will try to flush / discard any dirty cache lines they still hold.

Because at this point the driver connection has been closed and the process_t::m_os_driver has been reset, any call to process_t::os_driver is invalid and will lead to a segfault.

If for some reason, the client of the library fails to call amd_dbgapi_process_detach before calling exit(3), it is possible that some cache remain unflushed before the call to exit.  This case was exposed by a patch in upstream GDB 3780b9993c9 "gdb: refactor core_target ::close and ::detach functions".  Since this patch, when ROCgdb opens a core file, if the user enters "exit" it will cause GDB to terminate without calling amd_dbgapi_process_detach, triggering the issue.

This patch make sure that early in the process_t::~process_t destructor we explicitly discard any remaining cache line in any agent.  This way when agent_t::~agent_t is called, we do not have any remaining dirty cache line we try to commit.


## JIRA ID

AIROCGDB-602

## Test Plan

Tested using ROCgdb's testsuite.

## Test Result

Before patch:

```
$ make check-gdb TESTS=gdb.rocm/corefile.exp
[…]
                === gdb Summary ===

# of unexpected core files      2
# of expected passes            14
```

with the patch:

```
$ make check-gdb TESTS=gdb.rocm/corefile.exp
[…]
                === gdb Summary ===

# of expected passes            14
```

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
