### PR TITLE
[RCCL] Use atomic load/store with correct orderings in op128.h scalar

### DIFF
--- a/projects/rccl/src/device/op128.h
+++ b/projects/rccl/src/device/op128.h
@@ -408,20 +408,12 @@ DEFINE_ld_st_16__space(global, uintptr_t, l)
 
 __device__ __forceinline__ uint64_t ld_volatile_global(uint64_t *ptr) {
   uint64_t ans;
-  #if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
   ans = __hip_atomic_load((__attribute__((address_space(1)))uint64_t *)ptr, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
-  #else
-  ans = __builtin_nontemporal_load(ptr);
-  #endif
   return ans;
 }
 __device__ __forceinline__ uint64_t ld_relaxed_sys_global(uint64_t *ptr) {
   uint64_t ans;
-  #if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
   ans = __hip_atomic_load((__attribute__((address_space(1)))uint64_t *)ptr, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
-  #else
-  ans = __builtin_nontemporal_load(ptr);
-  #endif
   return ans;
 }
 
@@ -437,34 +429,18 @@ __device__ __forceinline__ uint64_t ld_relaxed_sys_global(uint64_t *ptr) {
 
 __device__ __forceinline__ uint64_t ld_acquire_sys_global(uint64_t *ptr) {
   uint64_t ans;
-  #if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
   ans = __hip_atomic_load((__attribute__((address_space(1)))uint64_t *)ptr, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_SYSTEM);
-  #else
-  ans = __atomic_load_n(ptr ,__ATOMIC_SEQ_CST);
-  #endif
   return ans;
 }
 
 __device__ __forceinline__ void st_volatile_global(uint64_t *ptr, uint64_t val) {
-  #if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
   __hip_atomic_store((__attribute__((address_space(1)))uint64_t *)ptr, val, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
-  #else
-  __builtin_nontemporal_store(val, ptr);
-  #endif
 }
 __device__ __forceinline__ void st_relaxed_sys_global(uint64_t *ptr, uint64_t val) {
-  #if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
   __hip_atomic_store((__attribute__((address_space(1)))uint64_t *)ptr, val, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
-  #else
-  __builtin_nontemporal_store(val, ptr);
-  #endif
 }
 __device__ __forceinline__ void st_release_sys_global(uint64_t *ptr, uint64_t val) {
-  #if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
   __hip_atomic_store((__attribute__((address_space(1)))uint64_t *)ptr, val, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_SYSTEM);
-  #else
-  __atomic_store_n(ptr, val, __ATOMIC_SEQ_CST);
-  #endif
 }
 
 __device__ __forceinline__ void fence_acq_rel_sys() {


### PR DESCRIPTION
## Motivation

Port of upstream rccl commit bd21fd7 ("Corrections on some load store functions") onto the monorepo's op128.h.

## Technical Details

The scalar uint64_t load/store helpers had been split into two paths guarded by RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS: a __hip_atomic_load/store path and a non-atomic fallback (__builtin_nontemporal_load/store and over-strong SEQ_CST atomics). The fallback path provided no atomicity and the wrong memory orderings, so both paths are collapsed into a single __hip_atomic_load/store implementation with the correct ordering:

- ld_volatile_global / ld_relaxed_sys_global: __ATOMIC_RELAXED
- ld_acquire_sys_global:                       __ATOMIC_ACQUIRE
- st_volatile_global / st_relaxed_sys_global:  __ATOMIC_RELAXED
- st_release_sys_global:                       __ATOMIC_RELEASE

all at __HIP_MEMORY_SCOPE_SYSTEM. This removes the need for the RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS branch in these helpers.

The upstream commit's fence_acq_rel_sys change is not ported: the monorepo's fence_acq_rel_sys has already diverged and contains no __threadfence_system / RCCL_IB_CHECKSUM_DEVICE_ENABLED gating to adjust.

## JIRA ID

## Test Plan

## Test Result

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
