### PR TITLE
[RCCL] Skip DDA IPC init for directMode and MNNVL

### DIFF
--- a/projects/rccl/src/ipc_init.cu
+++ b/projects/rccl/src/ipc_init.cu
@@ -33,8 +33,13 @@ ncclResult_t ncclDdaIpcCommInit(ncclComm* comm) {
   if (comm == nullptr) {
     return ncclSuccess;
   }
+  // Skip DDA if:
+  // - nranks exceeds kDdaNranks (currently hardcoded to 8)
+  // - multi-node runs
+  // - not using 1 process per GPU
+  // - MNNVL (fabric-based P2P, currently incompatible with DDA IPC)
   if (comm->nRanks != kDdaNranks || comm->nNodes != 1 ||
-      comm->bootstrap == nullptr) {
+      comm->bootstrap == nullptr || comm->directMode || comm->MNNVL) {
     return ncclSuccess;
   }
 

--- a/projects/rccl/src/ipc_init.cu
+++ b/projects/rccl/src/ipc_init.cu
@@ -34,10 +34,10 @@ ncclResult_t ncclDdaIpcCommInit(ncclComm* comm) {
     return ncclSuccess;
   }
   // Skip DDA if:
-  // - nranks exceeds kDdaNranks (currently hardcoded to 8)
+  // - nRanks is not exactly kDdaNranks (currently hardcoded to 8)
   // - multi-node runs
   // - not using 1 process per GPU
-  // - MNNVL (fabric-based P2P, currently incompatible with DDA IPC)
+  // - MNNVL (fabric-based P2P)
   if (comm->nRanks != kDdaNranks || comm->nNodes != 1 ||
       comm->bootstrap == nullptr || comm->directMode || comm->MNNVL) {
     return ncclSuccess;


### PR DESCRIPTION
## Motivation

DDA IPC is incompatible with multi-GPU-per-process (directMode). Also, DDA with MNNVL fabric-based P2P is currently untested on gfx1250.

## Technical Details

Add early-return guards for both cases to prevent incorrect initialization and spurious errors like `[FATAL ERROR]: HIP failure: 'invalid device context'` when run with 1 process for multiple GPUs on MI3XX (`-g 8` or `-t 8`) or 2x1p4g gfx1250 MNNVL.

## JIRA ID

ROCM-25527

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
