### PR TITLE
Add gfx9 read offset, workaround for async copy, fix wait on status.busy

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/aql_profile_v2.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/aql_profile_v2.h
@@ -539,6 +539,7 @@ typedef struct aqlprofile_att_buffer_status_t
     bool     needs_swap;  // If buffer requires swap
     bool     is_too_late;
     bool     error;
+    uint64_t read_offset;
 } aqlprofile_att_buffer_status_t;
 
 /**

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/core/threadtrace.cpp
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/core/threadtrace.cpp
@@ -439,6 +439,8 @@ aqlprofile_att_update_buffer_status(aqlprofile_att_buffer_status_t* out,
         out->read_size    = manager->config.capacity_per_se;
         out->num_swaps    = manager->buffer_swaps.fetch_add(1);
         out->data = buffer_data.at((out->num_swaps + buffer_data.size() - 1) % buffer_data.size());
+
+        out->read_offset = sizeof(uint16_t) * (control.wptr_doublebuffer >> 30);
     }
 
     return HSA_STATUS_SUCCESS;

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/sqtt_builder.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/sqtt_builder.h
@@ -98,6 +98,7 @@ struct TraceControl
     uint64_t gpu_clock_cnt_start{0};
     uint64_t gpu_clock_cnt_end{0};
     uint32_t status_double_buffer{0};
+    uint32_t wptr_doublebuffer{0};
 };
 
 // Encapsulates the various Api and structures that are used to enable
@@ -771,6 +772,13 @@ public:
         XCC_Packet_Lock<Builder> lock(builder, cmd_buffer, GetXCCNumber(), se_id / se_per_xcc);
         Select_GRBM_SE_SH0(cmd_buffer, se_id % se_per_xcc);
 
+        if(Primitives::GFXIP_LEVEL == 9)
+        {
+            const uint32_t mask_val      = Primitives::sqtt_busy_mask();
+            auto           status_offset = Primitives::SQ_THREAD_TRACE_STATUS_OFFSET;
+            builder.BuildWaitRegMemCommand(cmd_buffer, false, status_offset, false, mask_val, 1);
+        }
+
         auto status_addr = (Primitives::GFXIP_LEVEL >= 12)
                                ? Primitives::SQ_THREAD_TRACE_STATUS2_ADDR
                                : Primitives::SQ_THREAD_TRACE_STATUS_ADDR;
@@ -779,8 +787,13 @@ public:
                                        &control.status_double_buffer,
                                        Primitives::COPY_DATA_SEL_COUNT_1DW_PRM,
                                        false);
+        if(Primitives::GFXIP_LEVEL == 9)
+            builder.BuildCopyRegDataPacket(cmd_buffer,
+                                           Primitives::SQ_THREAD_TRACE_WPTR_ADDR,
+                                           &control.wptr_doublebuffer,
+                                           Primitives::COPY_DATA_SEL_COUNT_1DW_PRM,
+                                           false);
 
-        builder.BuildWriteWaitIdlePacket(cmd_buffer);
         builder.BuildCacheFlushPacket(cmd_buffer, size_t(&control), sizeof(TraceControl));
         SetGRBMToBroadcast(cmd_buffer);
     }
@@ -800,6 +813,10 @@ public:
 
         if(Primitives::GFXIP_LEVEL == 9)
         {
+            const uint32_t mask_val      = Primitives::sqtt_busy_mask();
+            auto           status_offset = Primitives::SQ_THREAD_TRACE_STATUS_OFFSET;
+            builder.BuildWaitRegMemCommand(cmd_buffer, false, status_offset, false, mask_val, 1);
+
             builder.BuildWriteUConfigRegPacket(cmd_buffer,
                                                Primitives::SQ_THREAD_TRACE_BASE_ADDR,
                                                Primitives::sqtt_base_value_lo(base_addr));
@@ -818,7 +835,6 @@ public:
                                : Primitives::SQ_THREAD_TRACE_BUF0_BASE_HI_ADDR;
 
             WriteConfigPacket(cmd_buffer, reg_lo, buff1_lo);
-            builder.BuildWriteWaitIdlePacket(cmd_buffer);
             WriteConfigPacket(cmd_buffer, reg_hi, buff1_hi);
         }
         builder.BuildCacheFlushPacket(cmd_buffer, size_t(prev), config->data_buffer_size);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
@@ -262,15 +262,12 @@ ThreadTracerAgent::start_thread_trace(std::shared_ptr<std::atomic<int>> _flag)
     if(params.triple_buffering)
     {
         auto& buffer = queue->triple_buffer_memory;
-        auto  signal = signal_create();
         copy_data_sync(buffer.at(0),
                        buffer.at(1),
                        queue->near_cpu,
                        queue->hsa_agent,
                        MIN_BUFFER_SIZE,
-                       &signal);
-        signal_wait(signal);
-        signal_destroy(signal);
+                       nullptr);
     }
 
     // Submit the start packets without waiting: the producer thread (triple-buffer

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/threading.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/threading.cpp
@@ -87,15 +87,17 @@ copy_data_sync(void*         dst,
                size_t        size,
                hsa_signal_t* dependency)
 {
-    ROCP_FATAL_IF(dependency == nullptr) << "Dependency must not be null";
     ROCP_TRACE << fmt::format("Executing async copy from {} to {}", src, dst);
 
     thread_local auto signal = scoped_signal_t{};
 
     auto copy_fn = CHECK_NOTNULL(hsa::get_amd_ext_table())->hsa_amd_memory_async_copy_fn;
 
+    // Workaround for ROCM-25606
+    if(dependency) signal_wait(*dependency);
+
     signal_reset(signal.sig);
-    auto status = copy_fn(dst, dst_agent, src, src_agent, size, 1, dependency, signal.sig);
+    auto status = copy_fn(dst, dst_agent, src, src_agent, size, 0, nullptr, signal.sig);
     ROCP_FATAL_IF(status != HSA_STATUS_SUCCESS) << "Failed to copy: " << status;
     signal_wait(signal.sig);
 }


### PR DESCRIPTION
## Motivation

* Read offset was not properly handled for gfx9, which means users cant parse buffers independently. This is AQLprofile side: AIPROFSDK-871
* Async copy is now explicitly waited on, as a workaround for ROCM-25606
* Remove cs flushes on double buffer packets are they are not necessary and sometimes counter productive.
* These combined changes will help with stability of double buffer tests.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

AIPROFSDK-871, ROCM-25606

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
