### PR TITLE
Revert "rocr: report SDMA 1 as preferred for H2D on gfx942 (#4105)"

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -1391,8 +1391,8 @@ hsa_status_t GpuAgent::DmaPreferredEngine(core::Agent& dst_agent, core::Agent& s
         dst_agent.device_type() == core::Agent::kAmdCpuDevice))) {
 
     if (src_agent.device_type() == core::Agent::kAmdCpuDevice) {
-      // Host to Device: Use SDMA engine 1 if available
-      *recommended_ids_mask = HSA_AMD_SDMA_ENGINE_1;
+      // Host to Device: Use SDMA engine 0 if available
+      *recommended_ids_mask = HSA_AMD_SDMA_ENGINE_0;
     } else {
       // Device to Host: Use SDMA engines 1 and 2 if available
       *recommended_ids_mask = HSA_AMD_SDMA_ENGINE_1;


### PR DESCRIPTION
## Motivation

  Revert PR #4105 (commit `a8be668`), which caused a ~13% regression in AGFHC `dma_bidi_peak` per-GPU bandwidth on MI350X (gfx950) — from ~100 GB/s to ~87 GB/s (sum metric).

  ## Technical Details

  PR #4105 changed rocr's H2D preferred SDMA engine from `HSA_AMD_SDMA_ENGINE_0` to `HSA_AMD_SDMA_ENGINE_1` for gfx94x in `GpuAgent::DmaPreferredEngine` to mask MI300's SDMA0-D2H perf hit. The `isGfx94x` check matches both gfx942 and gfx950, so MI350X is
  affected as collateral. AGFHC's bidi test calls `hsa_amd_memory_async_copy` (no engine pin), which routes to rocr's `DmaCopy` → `PickSdmaEngine` round-robin. With H2D pinned to SDMA1 and D2H round-robining over SDMA1|SDMA2, ~50% of D2H copies collide with H2D
  on SDMA1. Reverting puts H2D back on SDMA0 (not in D2H's preferred mask), eliminating the collision.

  ## JIRA ID

ROCM-25268

  ## Test Plan

  - Run `./agfhc -t dma_bidi_peak` on MI350X with and without the revert.
  - Spot-check `dma_h2d_peak` and `dma_d2h_peak` to confirm no single-direction regression.
  - Re-verify MI300/gfx942 to confirm the original SWDEV-550186 fix scope is preserved (or address gfx942-conditionally in a follow-up).

  ## Test Result

  - MI350X AGFHC `dma_bidi_peak` (8 GPUs, sum metric, avg): **~87.6 GB/s → ~100.5 GB/s** with revert.
  - rocr-level test confirms SDMA0 and SDMA1 are symmetric on MI350X (~57 GB/s per direction solo), so no per-engine perf cost.

  ## Submission Checklist

  - [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
