### PR TITLE
[rocjitsu] RocFuzz proof of concept

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -127,3 +127,7 @@
 [submodule "projects/rocprofiler-compute/src/lib/external/fmt"]
 	path = projects/rocprofiler-compute/src/lib/external/fmt
 	url = https://github.com/fmtlib/fmt.git
+[submodule "emulation/rocjitsu/third_party/AFLplusplus"]
+	path = emulation/rocjitsu/third_party/AFLplusplus
+	url = https://github.com/AFLplusplus/AFLplusplus.git
+	branch = stable

--- a/emulation/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/CMakeLists.txt
@@ -231,6 +231,7 @@ endif()
 # Tests and scaling tools.
 if(BUILD_TESTING)
     add_subdirectory(tests)
+    add_subdirectory(fuzzer)
 endif()
 
 # ---------------------------------------------------------------------------

--- a/emulation/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/CMakeLists.txt
@@ -231,8 +231,13 @@ endif()
 # Tests and scaling tools.
 if(BUILD_TESTING)
     add_subdirectory(tests)
-    add_subdirectory(fuzzer)
+    add_subdirectory(fuzzer/tests)
 endif()
+
+# Optional RocFuzz AFL++ integration. The fuzzer subdirectory is a separate
+# DBI client that shares rocjitsu code-object, decoder, CFG, and instrumentation
+# substrate without coupling it to the KMD simulator path.
+add_subdirectory(fuzzer)
 
 # ---------------------------------------------------------------------------
 # Install rules.

--- a/emulation/rocjitsu/cmake/rj_add_object_library.cmake
+++ b/emulation/rocjitsu/cmake/rj_add_object_library.cmake
@@ -11,8 +11,9 @@ function(rj_add_object_library name)
     set_target_properties(${name} PROPERTIES POSITION_INDEPENDENT_CODE ON)
     target_include_directories(
         ${name}
-        PRIVATE ${ROCJITSU_INCLUDE_DIR} ${ROCJITSU_SRC_DIR} ${HSA_INCLUDE_DIR}
+        PRIVATE ${ROCJITSU_INCLUDE_DIR} ${ROCJITSU_SRC_DIR}
     )
+    target_include_directories(${name} SYSTEM PRIVATE ${HSA_INCLUDE_DIR})
     target_link_libraries(${name} PRIVATE util simdojo)
     if(MSVC)
         target_compile_options(${name} PRIVATE /W4 /WX)

--- a/emulation/rocjitsu/cmake/rj_configure_target.cmake
+++ b/emulation/rocjitsu/cmake/rj_configure_target.cmake
@@ -66,8 +66,8 @@ function(rj_configure_target target)
             PRIVATE
                 ${PROJECT_SOURCE_DIR}/lib/rocjitsu/include
                 ${PROJECT_SOURCE_DIR}/lib/rocjitsu/src
-                ${HSA_INCLUDE_DIR}
         )
+        target_include_directories(${target} SYSTEM PRIVATE ${HSA_INCLUDE_DIR})
     endif()
     if(ARG_GENERATED)
         target_include_directories(${target} PRIVATE ${GENERATED_DIR})

--- a/emulation/rocjitsu/fuzzer/CMakeLists.txt
+++ b/emulation/rocjitsu/fuzzer/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(tests)

--- a/emulation/rocjitsu/fuzzer/CMakeLists.txt
+++ b/emulation/rocjitsu/fuzzer/CMakeLists.txt
@@ -1,1 +1,4 @@
-add_subdirectory(tests)
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+add_subdirectory(afl-dbi)

--- a/emulation/rocjitsu/fuzzer/README.md
+++ b/emulation/rocjitsu/fuzzer/README.md
@@ -1,0 +1,8 @@
+# RocFuzz AFL++ Integration
+
+RocFuzz is the planned AFL++ integration for rocjitsu device-code
+instrumentation. This first slice only wires the fuzzer directory and a small
+host-side AFL++ smoke test so reviewers can validate the AFL toolchain before
+any ROCm runtime or DBI pieces are introduced.
+
+The later preload and device-coverage pieces build on this scaffold.

--- a/emulation/rocjitsu/fuzzer/README.md
+++ b/emulation/rocjitsu/fuzzer/README.md
@@ -1,8 +1,31 @@
 # RocFuzz AFL++ Integration
 
 RocFuzz is the planned AFL++ integration for rocjitsu device-code
-instrumentation. This first slice only wires the fuzzer directory and a small
-host-side AFL++ smoke test so reviewers can validate the AFL toolchain before
-any ROCm runtime or DBI pieces are introduced.
+instrumentation. The first upstream slice is intentionally host-side only: it
+provides a small `librocjitsu_afl_preload.so` with persistent-iteration hooks
+that synchronize ROCm work before AFL++ advances to the next input.
 
-The later preload and device-coverage pieces build on this scaffold.
+The fuzzer preload is separate from the KMD simulator preload. RocFuzz is meant
+to instrument HIP/HSA loader and launch paths for AFL++ coverage feedback, while
+the KMD preload emulates the kernel-driver interface for simulated execution.
+They should remain independently usable and share common rocjitsu DBI/DBT
+building blocks such as code-object parsing, decoding, CFG analysis, relocation,
+and probe insertion. Future work may validate composing both preloads, but that
+is not the default workflow described here.
+
+Targets can call `rocjitsu_afl_persistent_begin()` at the start of each
+persistent iteration and `rocjitsu_afl_persistent_end()` before returning to
+AFL++. The current implementation makes the begin hook a no-op boundary and uses
+`hipDeviceSynchronize()` in the end hook.
+
+## Validation Layers
+
+The checked-in tests are intentionally layered:
+
+- `RocFuzz.HelloWorldAFL` checks the AFL++ compiler wrapper and fuzzer driver.
+- `RocFuzz.TwoVectorAddAFL` and `RocFuzz.HipblasLtTransformAFL` exercise
+  bounded ROCm fuzz targets.
+- `RocjitsuAflDbi.*` tests cover preload symbol resolution, persistent runtime
+  hooks, raw AMDGPU ELF rewriting, and HSA reader lifetime handling.
+- `RocFuzz.TwoVectorAddAFL.Preload` is the end-to-end proof that a rewritten
+  kernel entry can update device-side coverage and merge it into AFL's map.

--- a/emulation/rocjitsu/fuzzer/afl-dbi/CMakeLists.txt
+++ b/emulation/rocjitsu/fuzzer/afl-dbi/CMakeLists.txt
@@ -43,8 +43,10 @@ target_link_libraries(
         rocjitsu_isa_rdna3
         rocjitsu_isa_rdna3_5
         rocjitsu_isa_rdna4
+        rocjitsu_isa_gfx1250
         rocjitsu_isa_risc_v
         simdojo
+        rocjitsu_kmd
         rocjitsu_vm
         rocjitsu_vm_amdgpu
         rocjitsu_vm_risc_v
@@ -86,8 +88,10 @@ if(ROCFUZZ_HIP_RUNTIME AND ROCFUZZ_HIP_INCLUDE_DIR)
             rocjitsu_isa_rdna3
             rocjitsu_isa_rdna3_5
             rocjitsu_isa_rdna4
+            rocjitsu_isa_gfx1250
             rocjitsu_isa_risc_v
             simdojo
+            rocjitsu_kmd
             rocjitsu_vm
             rocjitsu_vm_amdgpu
             rocjitsu_vm_risc_v
@@ -201,8 +205,10 @@ if(ROCFUZZ_HIP_RUNTIME AND ROCFUZZ_HIP_INCLUDE_DIR)
             rocjitsu_isa_rdna3
             rocjitsu_isa_rdna3_5
             rocjitsu_isa_rdna4
+            rocjitsu_isa_gfx1250
             rocjitsu_isa_risc_v
             simdojo
+            rocjitsu_kmd
             rocjitsu_vm
             rocjitsu_vm_amdgpu
             rocjitsu_vm_risc_v

--- a/emulation/rocjitsu/fuzzer/afl-dbi/CMakeLists.txt
+++ b/emulation/rocjitsu/fuzzer/afl-dbi/CMakeLists.txt
@@ -3,6 +3,27 @@
 
 include(rj_configure_target)
 
+set(ROCFUZZ_ROCM_PATH
+    "/opt/rocm"
+    CACHE PATH
+    "ROCm installation used by RocFuzz"
+)
+
+find_library(
+    ROCFUZZ_HIP_RUNTIME
+    amdhip64
+    HINTS "${ROCFUZZ_ROCM_PATH}"
+    ENV ROCM_PATH
+    PATH_SUFFIXES lib lib64
+)
+find_path(
+    ROCFUZZ_HIP_INCLUDE_DIR
+    hip/hip_runtime_api.h
+    HINTS "${ROCFUZZ_ROCM_PATH}"
+    ENV ROCM_PATH
+    PATH_SUFFIXES include
+)
+
 add_executable(
     rocjitsu_afl_amdgpu_elf_reader_test
     tests/amdgpu_elf_reader_test.cpp
@@ -38,3 +59,174 @@ add_test(
     NAME RocjitsuAflDbi.AmdGpuElfReader
     COMMAND rocjitsu_afl_amdgpu_elf_reader_test
 )
+
+if(ROCFUZZ_HIP_RUNTIME AND ROCFUZZ_HIP_INCLUDE_DIR)
+    add_library(rocjitsu_afl_preload SHARED runtime/afl_preload.cpp)
+    target_include_directories(
+        rocjitsu_afl_preload
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+    target_include_directories(
+        rocjitsu_afl_preload
+        SYSTEM
+        PRIVATE ${ROCFUZZ_HIP_INCLUDE_DIR}
+    )
+    target_link_libraries(
+        rocjitsu_afl_preload
+        PRIVATE
+            rocjitsu_analysis
+            rocjitsu_code
+            rocjitsu_isa
+            rocjitsu_isa_cdna1
+            rocjitsu_isa_cdna2
+            rocjitsu_isa_cdna3
+            rocjitsu_isa_cdna4
+            rocjitsu_isa_rdna1
+            rocjitsu_isa_rdna2
+            rocjitsu_isa_rdna3
+            rocjitsu_isa_rdna3_5
+            rocjitsu_isa_rdna4
+            rocjitsu_isa_risc_v
+            simdojo
+            rocjitsu_vm
+            rocjitsu_vm_amdgpu
+            rocjitsu_vm_risc_v
+            rocjitsu_config
+            util
+            flatbuffers
+            Threads::Threads
+            ${ROCFUZZ_HIP_RUNTIME}
+            ${CMAKE_DL_LIBS}
+    )
+    target_compile_definitions(
+        rocjitsu_afl_preload
+        PRIVATE __HIP_PLATFORM_AMD__
+    )
+    rj_configure_target(rocjitsu_afl_preload PRIVATE_INCLUDES)
+    set_target_properties(
+        rocjitsu_afl_preload
+        PROPERTIES OUTPUT_NAME rocjitsu_afl_preload
+    )
+    add_executable(
+        rocjitsu_afl_preload_symbols_test
+        tests/afl_preload_symbols_test.cpp
+    )
+    target_compile_definitions(
+        rocjitsu_afl_preload_symbols_test
+        PRIVATE ROCJITSU_AFL_PRELOAD_PATH="$<TARGET_FILE:rocjitsu_afl_preload>"
+    )
+    target_link_libraries(
+        rocjitsu_afl_preload_symbols_test
+        PRIVATE GTest::gtest_main ${CMAKE_DL_LIBS}
+    )
+    rj_configure_target(rocjitsu_afl_preload_symbols_test TEST)
+    add_dependencies(rocjitsu_afl_preload_symbols_test rocjitsu_afl_preload)
+    add_test(
+        NAME RocjitsuAflDbi.PreloadSymbols
+        COMMAND rocjitsu_afl_preload_symbols_test
+    )
+
+    add_library(rocjitsu_afl_fake_hip_runtime SHARED tests/fake_hip_runtime.cpp)
+    rj_configure_target(rocjitsu_afl_fake_hip_runtime PRIVATE_INCLUDES)
+
+    add_library(rocjitsu_afl_fake_hsa_runtime SHARED tests/fake_hsa_runtime.cpp)
+    target_include_directories(
+        rocjitsu_afl_fake_hsa_runtime
+        SYSTEM
+        PRIVATE ${ROCFUZZ_HIP_INCLUDE_DIR}
+    )
+    rj_configure_target(rocjitsu_afl_fake_hsa_runtime PRIVATE_INCLUDES)
+
+    add_executable(
+        rocjitsu_afl_preload_runtime_test
+        tests/afl_preload_runtime_test.cpp
+    )
+    target_include_directories(
+        rocjitsu_afl_preload_runtime_test
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+    target_compile_definitions(
+        rocjitsu_afl_preload_runtime_test
+        PRIVATE
+            ROCJITSU_AFL_PRELOAD_PATH="$<TARGET_FILE:rocjitsu_afl_preload>"
+            ROCJITSU_AFL_FAKE_HIP_RUNTIME_PATH="$<TARGET_FILE:rocjitsu_afl_fake_hip_runtime>"
+    )
+    target_link_libraries(
+        rocjitsu_afl_preload_runtime_test
+        PRIVATE GTest::gtest_main ${CMAKE_DL_LIBS}
+    )
+    rj_configure_target(rocjitsu_afl_preload_runtime_test TEST)
+    add_dependencies(
+        rocjitsu_afl_preload_runtime_test
+        rocjitsu_afl_preload
+        rocjitsu_afl_fake_hip_runtime
+    )
+    add_test(
+        NAME RocjitsuAflDbi.PreloadRuntime
+        COMMAND rocjitsu_afl_preload_runtime_test
+    )
+
+    add_executable(
+        rocjitsu_afl_preload_hsa_reader_test
+        tests/afl_preload_hsa_reader_test.cpp
+    )
+    target_include_directories(
+        rocjitsu_afl_preload_hsa_reader_test
+        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+    target_include_directories(
+        rocjitsu_afl_preload_hsa_reader_test
+        SYSTEM
+        PRIVATE ${ROCFUZZ_HIP_INCLUDE_DIR}
+    )
+    target_compile_definitions(
+        rocjitsu_afl_preload_hsa_reader_test
+        PRIVATE
+            ROCJITSU_AFL_PRELOAD_PATH="$<TARGET_FILE:rocjitsu_afl_preload>"
+            ROCJITSU_AFL_FAKE_HIP_RUNTIME_PATH="$<TARGET_FILE:rocjitsu_afl_fake_hip_runtime>"
+            ROCJITSU_AFL_FAKE_HSA_RUNTIME_PATH="$<TARGET_FILE:rocjitsu_afl_fake_hsa_runtime>"
+    )
+    target_link_libraries(
+        rocjitsu_afl_preload_hsa_reader_test
+        PRIVATE
+            rocjitsu_analysis
+            rocjitsu_code
+            rocjitsu_isa
+            rocjitsu_isa_cdna1
+            rocjitsu_isa_cdna2
+            rocjitsu_isa_cdna3
+            rocjitsu_isa_cdna4
+            rocjitsu_isa_rdna1
+            rocjitsu_isa_rdna2
+            rocjitsu_isa_rdna3
+            rocjitsu_isa_rdna3_5
+            rocjitsu_isa_rdna4
+            rocjitsu_isa_risc_v
+            simdojo
+            rocjitsu_vm
+            rocjitsu_vm_amdgpu
+            rocjitsu_vm_risc_v
+            rocjitsu_config
+            util
+            flatbuffers
+            Threads::Threads
+            GTest::gtest_main
+            ${CMAKE_DL_LIBS}
+    )
+    rj_configure_target(rocjitsu_afl_preload_hsa_reader_test TEST)
+    add_dependencies(
+        rocjitsu_afl_preload_hsa_reader_test
+        rocjitsu_afl_preload
+        rocjitsu_afl_fake_hip_runtime
+        rocjitsu_afl_fake_hsa_runtime
+    )
+    add_test(
+        NAME RocjitsuAflDbi.PreloadHsaReader
+        COMMAND rocjitsu_afl_preload_hsa_reader_test
+    )
+else()
+    message(
+        STATUS
+        "RocFuzz AFL preload disabled (amdhip64 or HIP headers not found)"
+    )
+endif()

--- a/emulation/rocjitsu/fuzzer/afl-dbi/CMakeLists.txt
+++ b/emulation/rocjitsu/fuzzer/afl-dbi/CMakeLists.txt
@@ -1,0 +1,40 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+include(rj_configure_target)
+
+add_executable(
+    rocjitsu_afl_amdgpu_elf_reader_test
+    tests/amdgpu_elf_reader_test.cpp
+)
+target_link_libraries(
+    rocjitsu_afl_amdgpu_elf_reader_test
+    PRIVATE
+        rocjitsu_analysis
+        rocjitsu_code
+        rocjitsu_isa
+        rocjitsu_isa_cdna1
+        rocjitsu_isa_cdna2
+        rocjitsu_isa_cdna3
+        rocjitsu_isa_cdna4
+        rocjitsu_isa_rdna1
+        rocjitsu_isa_rdna2
+        rocjitsu_isa_rdna3
+        rocjitsu_isa_rdna3_5
+        rocjitsu_isa_rdna4
+        rocjitsu_isa_risc_v
+        simdojo
+        rocjitsu_vm
+        rocjitsu_vm_amdgpu
+        rocjitsu_vm_risc_v
+        rocjitsu_config
+        util
+        flatbuffers
+        Threads::Threads
+        GTest::gtest_main
+)
+rj_configure_target(rocjitsu_afl_amdgpu_elf_reader_test TEST)
+add_test(
+    NAME RocjitsuAflDbi.AmdGpuElfReader
+    COMMAND rocjitsu_afl_amdgpu_elf_reader_test
+)

--- a/emulation/rocjitsu/fuzzer/afl-dbi/include/rocjitsu_fuzzer/afl_runtime.h
+++ b/emulation/rocjitsu/fuzzer/afl-dbi/include/rocjitsu_fuzzer/afl_runtime.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <stdint.h>
+
+namespace rocjitsu::fuzzer::afl {
+
+inline constexpr uint32_t kMapSize = 65536;
+inline constexpr uint32_t kDeviceStart = kMapSize / 2;
+inline constexpr uint32_t kCoverageSlots = kMapSize / 2;
+inline constexpr uint32_t kEntryCounterSlot = 0;
+
+} // namespace rocjitsu::fuzzer::afl
+
+extern "C" {
+
+int rocjitsu_afl_persistent_begin();
+int rocjitsu_afl_persistent_end();
+}

--- a/emulation/rocjitsu/fuzzer/afl-dbi/runtime/afl_preload.cpp
+++ b/emulation/rocjitsu/fuzzer/afl-dbi/runtime/afl_preload.cpp
@@ -1,0 +1,558 @@
+#include "rocjitsu_fuzzer/afl_runtime.h"
+
+#include "rocjitsu/code/amdgpu_elf.h"
+#include "rocjitsu/code/amdgpu_elf_reader.h"
+#include "rocjitsu/code/hsa_code_object_reader_rewriter.h"
+
+#include <hip/hip_runtime_api.h>
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu-anonymous-struct"
+#pragma clang diagnostic ignored "-Wnested-anon-types"
+#endif
+#include <hsa/hsa.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+
+#include <dlfcn.h>
+#include <errno.h>
+#include <string.h>
+#include <sys/shm.h>
+
+#include <algorithm>
+#include <cstring>
+#include <limits>
+#include <mutex>
+#include <new>
+#include <optional>
+#include <span>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unordered_map>
+#include <vector>
+
+namespace {
+
+using rocjitsu::EI_CLASS;
+using rocjitsu::EI_MAGIC;
+using rocjitsu::EI_MAGIC_SIZE;
+using rocjitsu::Elf64_Ehdr;
+using rocjitsu::Elf64_Phdr;
+using rocjitsu::Elf64_Shdr;
+using rocjitsu::ELFCLASS64;
+using rocjitsu::fuzzer::afl::kCoverageSlots;
+using rocjitsu::fuzzer::afl::kDeviceStart;
+
+constexpr hipError_t kHipErrorRuntimeUnavailable = static_cast<hipError_t>(999);
+constexpr size_t kDeviceCounterBytes = sizeof(uint32_t) * kCoverageSlots;
+
+using hipModuleLoadData_t = hipError_t (*)(hipModule_t *, const void *);
+using hipModuleUnload_t = hipError_t (*)(hipModule_t);
+using hipModuleGetFunction_t = hipError_t (*)(hipFunction_t *, hipModule_t, const char *);
+using hipModuleLaunchKernel_t = hipError_t (*)(hipFunction_t, unsigned int, unsigned int,
+                                               unsigned int, unsigned int, unsigned int,
+                                               unsigned int, unsigned int, hipStream_t, void **,
+                                               void **);
+using hipDeviceSynchronize_t = hipError_t (*)();
+using hipMemcpy_t = hipError_t (*)(void *, const void *, size_t, hipMemcpyKind);
+using hipMalloc_t = hipError_t (*)(void **, size_t);
+using hipMemset_t = hipError_t (*)(void *, int, size_t);
+using hipFree_t = hipError_t (*)(void *);
+using hipGetErrorString_t = const char *(*)(hipError_t);
+using hsa_code_object_reader_create_from_memory_t = hsa_status_t (*)(const void *, size_t,
+                                                                     hsa_code_object_reader_t *);
+using hsa_code_object_reader_create_from_file_t = hsa_status_t (*)(hsa_file_t,
+                                                                   hsa_code_object_reader_t *);
+using hsa_code_object_reader_destroy_t = hsa_status_t (*)(hsa_code_object_reader_t);
+using hsa_ven_amd_loader_code_object_reader_create_from_file_with_offset_size_t =
+    hsa_status_t (*)(hsa_file_t, size_t, size_t, hsa_code_object_reader_t *);
+
+hipModuleLoadData_t real_hipModuleLoadData = nullptr;
+hipModuleUnload_t real_hipModuleUnload = nullptr;
+hipModuleGetFunction_t real_hipModuleGetFunction = nullptr;
+hipModuleLaunchKernel_t real_hipModuleLaunchKernel = nullptr;
+hipDeviceSynchronize_t real_hipDeviceSynchronize = nullptr;
+hipMemcpy_t real_hipMemcpy = nullptr;
+hipMalloc_t real_hipMalloc = nullptr;
+hipMemset_t real_hipMemset = nullptr;
+hipFree_t real_hipFree = nullptr;
+hipGetErrorString_t real_hipGetErrorString = nullptr;
+hsa_code_object_reader_create_from_memory_t real_hsa_code_object_reader_create_from_memory =
+    nullptr;
+hsa_code_object_reader_create_from_file_t real_hsa_code_object_reader_create_from_file = nullptr;
+hsa_code_object_reader_destroy_t real_hsa_code_object_reader_destroy = nullptr;
+hsa_ven_amd_loader_code_object_reader_create_from_file_with_offset_size_t
+    real_hsa_ven_amd_loader_code_object_reader_create_from_file_with_offset_size = nullptr;
+
+std::once_flag g_symbol_once;
+void *g_explicit_hip_runtime = nullptr;
+void *g_explicit_hsa_runtime = nullptr;
+thread_local uint32_t g_intercept_depth = 0;
+
+std::mutex g_runtime_mutex;
+uint8_t *g_afl_area = nullptr;
+int g_afl_shm_id = -1;
+void *g_device_counters = nullptr;
+std::vector<uint32_t> g_host_counters;
+rocjitsu::HsaCodeObjectReaderRewriter g_hsa_reader_rewriter;
+std::unordered_map<hipModule_t, std::vector<uint8_t>> g_rewritten_hip_modules;
+
+bool env_flag(const char *name) {
+  const char *value = getenv(name);
+  return value != nullptr && value[0] != '\0' && value[0] != '0';
+}
+
+template <typename T> T load_symbol(const char *name) {
+  return reinterpret_cast<T>(dlsym(RTLD_NEXT, name));
+}
+
+bool verbose_enabled();
+
+template <typename T> T load_hip_symbol(const char *name) {
+  if (g_explicit_hip_runtime != nullptr)
+    return reinterpret_cast<T>(dlsym(g_explicit_hip_runtime, name));
+  return load_symbol<T>(name);
+}
+
+template <typename T> T load_hsa_symbol(const char *name) {
+  if (g_explicit_hsa_runtime != nullptr)
+    return reinterpret_cast<T>(dlsym(g_explicit_hsa_runtime, name));
+  return load_symbol<T>(name);
+}
+
+void resolve_symbols() {
+  std::call_once(g_symbol_once, [] {
+    const char *runtime_path = getenv("ROCJITSU_AFL_HIP_RUNTIME_PATH");
+    if (runtime_path != nullptr && runtime_path[0] != '\0') {
+      g_explicit_hip_runtime = dlopen(runtime_path, RTLD_LAZY | RTLD_LOCAL);
+      if (g_explicit_hip_runtime == nullptr && verbose_enabled())
+        fprintf(stderr, "rocjitsu-afl: failed to load HIP runtime '%s': %s\n", runtime_path,
+                dlerror());
+    }
+
+    const char *hsa_runtime_path = getenv("ROCJITSU_AFL_HSA_RUNTIME_PATH");
+    if (hsa_runtime_path != nullptr && hsa_runtime_path[0] != '\0') {
+      g_explicit_hsa_runtime = dlopen(hsa_runtime_path, RTLD_LAZY | RTLD_LOCAL);
+      if (g_explicit_hsa_runtime == nullptr && verbose_enabled())
+        fprintf(stderr, "rocjitsu-afl: failed to load HSA runtime '%s': %s\n", hsa_runtime_path,
+                dlerror());
+    }
+
+    real_hipModuleLoadData = load_hip_symbol<hipModuleLoadData_t>("hipModuleLoadData");
+    real_hipModuleUnload = load_hip_symbol<hipModuleUnload_t>("hipModuleUnload");
+    real_hipModuleGetFunction = load_hip_symbol<hipModuleGetFunction_t>("hipModuleGetFunction");
+    real_hipModuleLaunchKernel = load_hip_symbol<hipModuleLaunchKernel_t>("hipModuleLaunchKernel");
+    real_hipDeviceSynchronize = load_hip_symbol<hipDeviceSynchronize_t>("hipDeviceSynchronize");
+    real_hipMemcpy = load_hip_symbol<hipMemcpy_t>("hipMemcpy");
+    real_hipMalloc = load_hip_symbol<hipMalloc_t>("hipMalloc");
+    real_hipMemset = load_hip_symbol<hipMemset_t>("hipMemset");
+    real_hipFree = load_hip_symbol<hipFree_t>("hipFree");
+    real_hipGetErrorString = load_hip_symbol<hipGetErrorString_t>("hipGetErrorString");
+    real_hsa_code_object_reader_create_from_memory =
+        load_hsa_symbol<hsa_code_object_reader_create_from_memory_t>(
+            "hsa_code_object_reader_create_from_memory");
+    real_hsa_code_object_reader_create_from_file =
+        load_hsa_symbol<hsa_code_object_reader_create_from_file_t>(
+            "hsa_code_object_reader_create_from_file");
+    real_hsa_code_object_reader_destroy =
+        load_hsa_symbol<hsa_code_object_reader_destroy_t>("hsa_code_object_reader_destroy");
+    real_hsa_ven_amd_loader_code_object_reader_create_from_file_with_offset_size =
+        load_hsa_symbol<hsa_ven_amd_loader_code_object_reader_create_from_file_with_offset_size_t>(
+            "hsa_ven_amd_loader_code_object_reader_create_from_file_with_offset_size");
+    g_hsa_reader_rewriter.set_api(real_hsa_code_object_reader_create_from_memory,
+                                  real_hsa_code_object_reader_destroy);
+  });
+}
+
+bool interception_bypassed() { return g_intercept_depth != 0; }
+
+struct ScopedInterceptionBypass {
+  ScopedInterceptionBypass() { ++g_intercept_depth; }
+  ScopedInterceptionBypass(const ScopedInterceptionBypass &) = delete;
+  ScopedInterceptionBypass &operator=(const ScopedInterceptionBypass &) = delete;
+  ~ScopedInterceptionBypass() { --g_intercept_depth; }
+};
+
+bool verbose_enabled() { return env_flag("ROCJITSU_AFL_VERBOSE"); }
+
+const char *hip_error_string(hipError_t status) {
+  if (real_hipGetErrorString != nullptr)
+    return real_hipGetErrorString(status);
+  return "HIP runtime unavailable";
+}
+
+bool parse_shm_id(int *id) {
+  const char *value = getenv("__AFL_SHM_ID");
+  if (value == nullptr || value[0] == '\0')
+    return false;
+
+  errno = 0;
+  char *end = nullptr;
+  const long parsed = strtol(value, &end, 10);
+  if (errno != 0 || end == value || *end != '\0' || parsed < 0)
+    return false;
+
+  *id = static_cast<int>(parsed);
+  return true;
+}
+
+bool ensure_afl_map_locked() {
+  int shm_id = -1;
+  if (!parse_shm_id(&shm_id))
+    return false;
+
+  if (g_afl_area != nullptr && g_afl_shm_id == shm_id)
+    return true;
+
+  if (g_afl_area != nullptr)
+    shmdt(g_afl_area);
+
+  g_afl_area = static_cast<uint8_t *>(shmat(shm_id, nullptr, 0));
+  if (g_afl_area == reinterpret_cast<uint8_t *>(-1)) {
+    g_afl_area = nullptr;
+    g_afl_shm_id = -1;
+    if (verbose_enabled())
+      fprintf(stderr, "rocjitsu-afl: failed to attach AFL shared memory id %d\n", shm_id);
+    return false;
+  }
+
+  g_afl_shm_id = shm_id;
+  return true;
+}
+
+hipError_t ensure_device_counters_locked() {
+  if (g_device_counters != nullptr)
+    return hipSuccess;
+  if (real_hipMalloc == nullptr || real_hipMemset == nullptr)
+    return kHipErrorRuntimeUnavailable;
+
+  hipError_t status = real_hipMalloc(&g_device_counters, kDeviceCounterBytes);
+  if (status != hipSuccess)
+    return status;
+
+  status = real_hipMemset(g_device_counters, 0, kDeviceCounterBytes);
+  if (status != hipSuccess) {
+    if (real_hipFree != nullptr)
+      static_cast<void>(real_hipFree(g_device_counters));
+    g_device_counters = nullptr;
+    return status;
+  }
+
+  g_host_counters.assign(kCoverageSlots, 0);
+  return hipSuccess;
+}
+
+uint8_t saturating_add(uint8_t value, uint32_t delta) {
+  const uint32_t sum = static_cast<uint32_t>(value) + delta;
+  return static_cast<uint8_t>(std::min<uint32_t>(sum, 255));
+}
+
+bool checked_add(uint64_t lhs, uint64_t rhs, uint64_t *out) {
+  if (out == nullptr || lhs > std::numeric_limits<uint64_t>::max() - rhs)
+    return false;
+  *out = lhs + rhs;
+  return true;
+}
+
+bool checked_multiply(uint64_t lhs, uint64_t rhs, uint64_t *out) {
+  if (out == nullptr || (lhs != 0 && rhs > std::numeric_limits<uint64_t>::max() / lhs))
+    return false;
+  *out = lhs * rhs;
+  return true;
+}
+
+std::optional<size_t> infer_raw_elf_image_size(const void *image) {
+  if (image == nullptr)
+    return std::nullopt;
+
+  Elf64_Ehdr ehdr{};
+  std::memcpy(&ehdr, image, sizeof(ehdr));
+  if (std::memcmp(ehdr.e_ident, EI_MAGIC, EI_MAGIC_SIZE) != 0 ||
+      ehdr.e_ident[EI_CLASS] != ELFCLASS64 || ehdr.e_shentsize != sizeof(Elf64_Shdr) ||
+      ehdr.e_shnum == 0)
+    return std::nullopt;
+
+  uint64_t section_headers_bytes = 0;
+  uint64_t section_headers_end = 0;
+  if (!checked_multiply(ehdr.e_shnum, sizeof(Elf64_Shdr), &section_headers_bytes) ||
+      !checked_add(ehdr.e_shoff, section_headers_bytes, &section_headers_end))
+    return std::nullopt;
+
+  uint64_t program_headers_end = 0;
+  if (ehdr.e_phnum != 0) {
+    if (ehdr.e_phentsize != sizeof(Elf64_Phdr))
+      return std::nullopt;
+
+    uint64_t program_headers_bytes = 0;
+    if (!checked_multiply(ehdr.e_phnum, sizeof(Elf64_Phdr), &program_headers_bytes) ||
+        !checked_add(ehdr.e_phoff, program_headers_bytes, &program_headers_end))
+      return std::nullopt;
+  }
+
+  const uint64_t inferred_size = std::max(section_headers_end, program_headers_end);
+  constexpr uint64_t kMaxModuleImageBytes = 256ull * 1024ull * 1024ull;
+  if (inferred_size == 0 || inferred_size > kMaxModuleImageBytes ||
+      inferred_size > std::numeric_limits<size_t>::max())
+    return std::nullopt;
+
+  return static_cast<size_t>(inferred_size);
+}
+
+std::optional<uint64_t> ensure_device_counter_pointer() {
+  std::lock_guard<std::mutex> lock(g_runtime_mutex);
+  const hipError_t status = ensure_device_counters_locked();
+  if (status != hipSuccess) {
+    if (verbose_enabled())
+      fprintf(stderr, "rocjitsu-afl: HSA reader rewrite disabled: %s\n", hip_error_string(status));
+    return std::nullopt;
+  }
+  return reinterpret_cast<uint64_t>(g_device_counters);
+}
+
+std::optional<std::vector<uint8_t>> try_rewrite_hsa_image(std::span<const uint8_t> image, void *) {
+  if (!rocjitsu::is_supported_amdgpu_elf(image))
+    return std::nullopt;
+
+  const auto state_pointer = ensure_device_counter_pointer();
+  if (!state_pointer.has_value())
+    return std::nullopt;
+
+  std::vector<uint8_t> rewritten = rocjitsu::patch_amdgpu_elf_kernel_entries(image, *state_pointer);
+  if (rewritten.size() == image.size() &&
+      std::equal(rewritten.begin(), rewritten.end(), image.begin(), image.end()))
+    return std::nullopt;
+  return rewritten;
+}
+
+std::optional<std::vector<uint8_t>> try_rewrite_hip_module_image(const void *image) {
+  const auto image_size = infer_raw_elf_image_size(image);
+  if (!image_size.has_value())
+    return std::nullopt;
+  return try_rewrite_hsa_image(
+      std::span<const uint8_t>(static_cast<const uint8_t *>(image), *image_size), nullptr);
+}
+
+} // namespace
+
+extern "C" {
+
+hipError_t hipModuleLoadData(hipModule_t *module, const void *image) {
+  resolve_symbols();
+  if (real_hipModuleLoadData == nullptr)
+    return kHipErrorRuntimeUnavailable;
+  if (interception_bypassed())
+    return real_hipModuleLoadData(module, image);
+  if (module == nullptr)
+    return real_hipModuleLoadData(module, image);
+  ScopedInterceptionBypass bypass;
+  try {
+    auto rewritten = try_rewrite_hip_module_image(image);
+    if (!rewritten.has_value())
+      return real_hipModuleLoadData(module, image);
+
+    hipModule_t loaded_module = nullptr;
+    hipError_t status = real_hipModuleLoadData(&loaded_module, rewritten->data());
+    if (status != hipSuccess)
+      return status;
+
+    if (module != nullptr)
+      *module = loaded_module;
+
+    std::lock_guard<std::mutex> lock(g_runtime_mutex);
+    g_rewritten_hip_modules[loaded_module] = std::move(*rewritten);
+    return hipSuccess;
+  } catch (const std::bad_alloc &) {
+    return kHipErrorRuntimeUnavailable;
+  }
+}
+
+hipError_t hipModuleUnload(hipModule_t module) {
+  resolve_symbols();
+  if (real_hipModuleUnload == nullptr)
+    return kHipErrorRuntimeUnavailable;
+  if (interception_bypassed())
+    return real_hipModuleUnload(module);
+  ScopedInterceptionBypass bypass;
+  const hipError_t status = real_hipModuleUnload(module);
+  if (status == hipSuccess) {
+    std::lock_guard<std::mutex> lock(g_runtime_mutex);
+    g_rewritten_hip_modules.erase(module);
+  }
+  return status;
+}
+
+hipError_t hipModuleGetFunction(hipFunction_t *function, hipModule_t module, const char *kname) {
+  resolve_symbols();
+  if (real_hipModuleGetFunction == nullptr)
+    return kHipErrorRuntimeUnavailable;
+  if (interception_bypassed())
+    return real_hipModuleGetFunction(function, module, kname);
+  ScopedInterceptionBypass bypass;
+  return real_hipModuleGetFunction(function, module, kname);
+}
+
+hipError_t hipModuleLaunchKernel(hipFunction_t f, unsigned int grid_dim_x, unsigned int grid_dim_y,
+                                 unsigned int grid_dim_z, unsigned int block_dim_x,
+                                 unsigned int block_dim_y, unsigned int block_dim_z,
+                                 unsigned int shared_mem_bytes, hipStream_t stream,
+                                 void **kernel_params, void **extra) {
+  resolve_symbols();
+  if (real_hipModuleLaunchKernel == nullptr)
+    return kHipErrorRuntimeUnavailable;
+  if (interception_bypassed()) {
+    return real_hipModuleLaunchKernel(f, grid_dim_x, grid_dim_y, grid_dim_z, block_dim_x,
+                                      block_dim_y, block_dim_z, shared_mem_bytes, stream,
+                                      kernel_params, extra);
+  }
+  ScopedInterceptionBypass bypass;
+  return real_hipModuleLaunchKernel(f, grid_dim_x, grid_dim_y, grid_dim_z, block_dim_x, block_dim_y,
+                                    block_dim_z, shared_mem_bytes, stream, kernel_params, extra);
+}
+
+hipError_t hipDeviceSynchronize() {
+  resolve_symbols();
+  if (real_hipDeviceSynchronize == nullptr)
+    return kHipErrorRuntimeUnavailable;
+  if (interception_bypassed())
+    return real_hipDeviceSynchronize();
+  ScopedInterceptionBypass bypass;
+  return real_hipDeviceSynchronize();
+}
+
+hipError_t hipMemcpy(void *dst, const void *src, size_t size_bytes, hipMemcpyKind kind) {
+  resolve_symbols();
+  if (real_hipMemcpy == nullptr)
+    return kHipErrorRuntimeUnavailable;
+  if (interception_bypassed())
+    return real_hipMemcpy(dst, src, size_bytes, kind);
+  ScopedInterceptionBypass bypass;
+  return real_hipMemcpy(dst, src, size_bytes, kind);
+}
+
+hsa_status_t
+hsa_code_object_reader_create_from_memory(const void *code_object, size_t size,
+                                          hsa_code_object_reader_t *code_object_reader) {
+  resolve_symbols();
+  if (real_hsa_code_object_reader_create_from_memory == nullptr)
+    return HSA_STATUS_ERROR_NOT_INITIALIZED;
+  if (interception_bypassed() || code_object == nullptr || size == 0 ||
+      code_object_reader == nullptr)
+    return real_hsa_code_object_reader_create_from_memory(code_object, size, code_object_reader);
+
+  ScopedInterceptionBypass bypass;
+  return g_hsa_reader_rewriter.create_from_memory(code_object, size, code_object_reader,
+                                                  try_rewrite_hsa_image, nullptr);
+}
+
+hsa_status_t hsa_code_object_reader_create_from_file(hsa_file_t file,
+                                                     hsa_code_object_reader_t *code_object_reader) {
+  resolve_symbols();
+  if (real_hsa_code_object_reader_create_from_file == nullptr)
+    return HSA_STATUS_ERROR_NOT_INITIALIZED;
+  if (interception_bypassed() || code_object_reader == nullptr)
+    return real_hsa_code_object_reader_create_from_file(file, code_object_reader);
+
+  ScopedInterceptionBypass bypass;
+  return g_hsa_reader_rewriter.create_from_file(file, code_object_reader,
+                                                real_hsa_code_object_reader_create_from_file,
+                                                try_rewrite_hsa_image, nullptr);
+}
+
+hsa_status_t hsa_ven_amd_loader_code_object_reader_create_from_file_with_offset_size(
+    hsa_file_t file, size_t offset, size_t size, hsa_code_object_reader_t *code_object_reader) {
+  resolve_symbols();
+  if (real_hsa_ven_amd_loader_code_object_reader_create_from_file_with_offset_size == nullptr)
+    return HSA_STATUS_ERROR_NOT_INITIALIZED;
+  if (interception_bypassed() || code_object_reader == nullptr) {
+    return real_hsa_ven_amd_loader_code_object_reader_create_from_file_with_offset_size(
+        file, offset, size, code_object_reader);
+  }
+
+  ScopedInterceptionBypass bypass;
+  return g_hsa_reader_rewriter.create_from_file_with_offset_size(
+      file, offset, size, code_object_reader,
+      real_hsa_ven_amd_loader_code_object_reader_create_from_file_with_offset_size,
+      try_rewrite_hsa_image, nullptr);
+}
+
+hsa_status_t hsa_code_object_reader_destroy(hsa_code_object_reader_t code_object_reader) {
+  resolve_symbols();
+  if (real_hsa_code_object_reader_destroy == nullptr)
+    return HSA_STATUS_ERROR_NOT_INITIALIZED;
+  if (interception_bypassed())
+    return g_hsa_reader_rewriter.destroy(code_object_reader);
+  ScopedInterceptionBypass bypass;
+  return g_hsa_reader_rewriter.destroy(code_object_reader);
+}
+
+int rocjitsu_afl_persistent_begin() {
+  resolve_symbols();
+  std::lock_guard<std::mutex> lock(g_runtime_mutex);
+
+  if (!ensure_afl_map_locked())
+    return 0;
+
+  const hipError_t status = ensure_device_counters_locked();
+  if (status != hipSuccess) {
+    fprintf(stderr, "rocjitsu-afl: failed to allocate device counters: %s\n",
+            hip_error_string(status));
+    return static_cast<int>(status);
+  }
+
+  if (real_hipMemset == nullptr)
+    return static_cast<int>(kHipErrorRuntimeUnavailable);
+
+  const hipError_t memset_status = real_hipMemset(g_device_counters, 0, kDeviceCounterBytes);
+  if (memset_status != hipSuccess) {
+    fprintf(stderr, "rocjitsu-afl: failed to reset device counters: %s\n",
+            hip_error_string(memset_status));
+    return static_cast<int>(memset_status);
+  }
+
+  if (verbose_enabled())
+    fprintf(stderr, "rocjitsu-afl: persistent iteration begin\n");
+  return 0;
+}
+
+int rocjitsu_afl_persistent_end() {
+  resolve_symbols();
+  if (real_hipDeviceSynchronize == nullptr)
+    return static_cast<int>(kHipErrorRuntimeUnavailable);
+
+  ScopedInterceptionBypass bypass;
+  const hipError_t status = real_hipDeviceSynchronize();
+  if (status != hipSuccess) {
+    fprintf(stderr, "rocjitsu-afl: hipDeviceSynchronize failed: %s\n", hip_error_string(status));
+    return static_cast<int>(status);
+  }
+
+  std::lock_guard<std::mutex> lock(g_runtime_mutex);
+  if (ensure_afl_map_locked() && g_device_counters != nullptr) {
+    if (real_hipMemcpy == nullptr)
+      return static_cast<int>(kHipErrorRuntimeUnavailable);
+
+    if (g_host_counters.size() != kCoverageSlots)
+      g_host_counters.assign(kCoverageSlots, 0);
+
+    const hipError_t copy_status = real_hipMemcpy(g_host_counters.data(), g_device_counters,
+                                                  kDeviceCounterBytes, hipMemcpyDeviceToHost);
+    if (copy_status != hipSuccess) {
+      fprintf(stderr, "rocjitsu-afl: failed to copy device counters: %s\n",
+              hip_error_string(copy_status));
+      return static_cast<int>(copy_status);
+    }
+
+    for (uint32_t slot = 0; slot < kCoverageSlots; ++slot) {
+      const uint32_t delta = g_host_counters[slot];
+      if (delta != 0)
+        g_afl_area[kDeviceStart + slot] = saturating_add(g_afl_area[kDeviceStart + slot], delta);
+    }
+  }
+
+  if (verbose_enabled())
+    fprintf(stderr, "rocjitsu-afl: persistent iteration end\n");
+  return 0;
+}
+
+} // extern "C"

--- a/emulation/rocjitsu/fuzzer/afl-dbi/tests/afl_preload_hsa_reader_test.cpp
+++ b/emulation/rocjitsu/fuzzer/afl-dbi/tests/afl_preload_hsa_reader_test.cpp
@@ -1,0 +1,351 @@
+#include "rocjitsu/code/amdgpu_elf_reader.h"
+#include "rocjitsu_fuzzer/afl_runtime.h"
+
+#include "minimal_amdgpu_elf.h"
+
+#include <gtest/gtest.h>
+
+#include <dlfcn.h>
+#include <fcntl.h>
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu-anonymous-struct"
+#pragma clang diagnostic ignored "-Wnested-anon-types"
+#endif
+#include <hsa/hsa.h>
+#include <hsa/hsa_ven_amd_loader.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+#include <sys/shm.h>
+#include <unistd.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#ifndef ROCJITSU_AFL_PRELOAD_PATH
+#error "ROCJITSU_AFL_PRELOAD_PATH must point to librocjitsu_afl_preload.so"
+#endif
+
+#ifndef ROCJITSU_AFL_FAKE_HIP_RUNTIME_PATH
+#error "ROCJITSU_AFL_FAKE_HIP_RUNTIME_PATH must point to the fake HIP runtime"
+#endif
+
+#ifndef ROCJITSU_AFL_FAKE_HSA_RUNTIME_PATH
+#error "ROCJITSU_AFL_FAKE_HSA_RUNTIME_PATH must point to the fake HSA runtime"
+#endif
+
+namespace {
+
+using PersistentFn = int (*)();
+using HipModuleLoadDataFn = int (*)(void **, const void *);
+using HipModuleUnloadFn = int (*)(void *);
+using CreateFromMemoryFn = hsa_status_t (*)(const void *, size_t, hsa_code_object_reader_t *);
+using CreateFromFileFn = hsa_status_t (*)(hsa_file_t, hsa_code_object_reader_t *);
+using CreateFromFileWithOffsetFn = hsa_status_t (*)(hsa_file_t, size_t, size_t,
+                                                    hsa_code_object_reader_t *);
+using DestroyFn = hsa_status_t (*)(hsa_code_object_reader_t);
+using ResetFakeHipFn = void (*)();
+using ResetFakeHsaFn = void (*)();
+using LastCreateKindFn = int (*)();
+using DestroyCallsFn = int (*)();
+using ReaderDataFn = const uint8_t *(*)(uint64_t);
+using ReaderSizeFn = size_t (*)(uint64_t);
+using ModuleCallsFn = int (*)();
+using ModuleImageFn = const uint8_t *(*)();
+using ModuleImageSizeFn = size_t (*)();
+
+constexpr int kCreateKindMemory = 1;
+constexpr int kCreateKindFile = 2;
+
+class DlHandle {
+public:
+  DlHandle() = default;
+  explicit DlHandle(const char *path, int flags) : handle_(dlopen(path, flags)) {}
+  DlHandle(const DlHandle &) = delete;
+  DlHandle &operator=(const DlHandle &) = delete;
+  ~DlHandle() {
+    if (handle_ != nullptr)
+      dlclose(handle_);
+  }
+
+  void open(const char *path, int flags) { handle_ = dlopen(path, flags); }
+  void *symbol(const char *name) const { return dlsym(handle_, name); }
+  void *get() const { return handle_; }
+
+private:
+  void *handle_ = nullptr;
+};
+
+class SharedMemory {
+public:
+  SharedMemory() : id_(shmget(IPC_PRIVATE, rocjitsu::fuzzer::afl::kMapSize, IPC_CREAT | 0600)) {
+    EXPECT_GE(id_, 0);
+    if (id_ >= 0) {
+      data_ = static_cast<uint8_t *>(shmat(id_, nullptr, 0));
+      EXPECT_NE(data_, reinterpret_cast<uint8_t *>(-1));
+      if (data_ != reinterpret_cast<uint8_t *>(-1))
+        std::memset(data_, 0, rocjitsu::fuzzer::afl::kMapSize);
+    }
+  }
+
+  SharedMemory(const SharedMemory &) = delete;
+  SharedMemory &operator=(const SharedMemory &) = delete;
+
+  ~SharedMemory() {
+    if (data_ != nullptr && data_ != reinterpret_cast<uint8_t *>(-1))
+      shmdt(data_);
+    if (id_ >= 0)
+      shmctl(id_, IPC_RMID, nullptr);
+  }
+
+  int id() const { return id_; }
+
+private:
+  int id_ = -1;
+  uint8_t *data_ = nullptr;
+};
+
+class TempFile {
+public:
+  explicit TempFile(const std::vector<uint8_t> &bytes) {
+    char path[] = "/tmp/rocjitsu-afl-hsa-reader-XXXXXX";
+    fd_ = mkstemp(path);
+    EXPECT_GE(fd_, 0);
+    if (fd_ >= 0) {
+      path_ = path;
+      EXPECT_EQ(write(fd_, bytes.data(), bytes.size()), static_cast<ssize_t>(bytes.size()));
+      EXPECT_EQ(lseek(fd_, 0, SEEK_SET), 0);
+    }
+  }
+
+  TempFile(const TempFile &) = delete;
+  TempFile &operator=(const TempFile &) = delete;
+
+  ~TempFile() {
+    if (fd_ >= 0)
+      close(fd_);
+    if (!path_.empty())
+      unlink(path_.c_str());
+  }
+
+  int fd() const { return fd_; }
+
+private:
+  int fd_ = -1;
+  std::string path_;
+};
+
+struct PreloadHarness {
+  SharedMemory shm;
+  DlHandle preload;
+  DlHandle fake_hip;
+  DlHandle fake_hsa;
+
+  PersistentFn persistent_begin = nullptr;
+  HipModuleLoadDataFn hip_module_load_data = nullptr;
+  HipModuleUnloadFn hip_module_unload = nullptr;
+  CreateFromMemoryFn create_from_memory = nullptr;
+  CreateFromFileFn create_from_file = nullptr;
+  CreateFromFileWithOffsetFn create_from_file_with_offset = nullptr;
+  DestroyFn destroy = nullptr;
+  ResetFakeHipFn reset_fake_hip = nullptr;
+  ResetFakeHsaFn reset_fake_hsa = nullptr;
+  ModuleCallsFn module_load_data_calls = nullptr;
+  ModuleCallsFn module_unload_calls = nullptr;
+  ModuleImageFn last_module_image = nullptr;
+  ModuleImageSizeFn last_module_image_size = nullptr;
+  LastCreateKindFn last_create_kind = nullptr;
+  DestroyCallsFn destroy_calls = nullptr;
+  ReaderDataFn reader_data = nullptr;
+  ReaderSizeFn reader_size = nullptr;
+
+  PreloadHarness() {
+    setenv("__AFL_SHM_ID", std::to_string(shm.id()).c_str(), 1);
+    setenv("ROCJITSU_AFL_HIP_RUNTIME_PATH", ROCJITSU_AFL_FAKE_HIP_RUNTIME_PATH, 1);
+    setenv("ROCJITSU_AFL_HSA_RUNTIME_PATH", ROCJITSU_AFL_FAKE_HSA_RUNTIME_PATH, 1);
+
+    preload.open(ROCJITSU_AFL_PRELOAD_PATH, RTLD_LAZY | RTLD_LOCAL);
+    fake_hip.open(ROCJITSU_AFL_FAKE_HIP_RUNTIME_PATH, RTLD_LAZY | RTLD_LOCAL);
+    fake_hsa.open(ROCJITSU_AFL_FAKE_HSA_RUNTIME_PATH, RTLD_LAZY | RTLD_LOCAL);
+    EXPECT_NE(preload.get(), nullptr) << dlerror();
+    EXPECT_NE(fake_hip.get(), nullptr) << dlerror();
+    EXPECT_NE(fake_hsa.get(), nullptr) << dlerror();
+
+    persistent_begin =
+        reinterpret_cast<PersistentFn>(preload.symbol("rocjitsu_afl_persistent_begin"));
+    hip_module_load_data =
+        reinterpret_cast<HipModuleLoadDataFn>(preload.symbol("hipModuleLoadData"));
+    hip_module_unload = reinterpret_cast<HipModuleUnloadFn>(preload.symbol("hipModuleUnload"));
+    create_from_memory = reinterpret_cast<CreateFromMemoryFn>(
+        preload.symbol("hsa_code_object_reader_create_from_memory"));
+    create_from_file = reinterpret_cast<CreateFromFileFn>(
+        preload.symbol("hsa_code_object_reader_create_from_file"));
+    create_from_file_with_offset = reinterpret_cast<CreateFromFileWithOffsetFn>(
+        preload.symbol("hsa_ven_amd_loader_code_object_reader_create_from_file_with_offset_size"));
+    destroy = reinterpret_cast<DestroyFn>(preload.symbol("hsa_code_object_reader_destroy"));
+
+    reset_fake_hip = reinterpret_cast<ResetFakeHipFn>(fake_hip.symbol("rocfuzz_fake_hip_reset"));
+    module_load_data_calls =
+        reinterpret_cast<ModuleCallsFn>(fake_hip.symbol("rocfuzz_fake_hip_module_load_data_calls"));
+    module_unload_calls =
+        reinterpret_cast<ModuleCallsFn>(fake_hip.symbol("rocfuzz_fake_hip_module_unload_calls"));
+    last_module_image =
+        reinterpret_cast<ModuleImageFn>(fake_hip.symbol("rocfuzz_fake_hip_last_module_image"));
+    last_module_image_size = reinterpret_cast<ModuleImageSizeFn>(
+        fake_hip.symbol("rocfuzz_fake_hip_last_module_image_size"));
+    reset_fake_hsa = reinterpret_cast<ResetFakeHsaFn>(fake_hsa.symbol("rocfuzz_fake_hsa_reset"));
+    last_create_kind =
+        reinterpret_cast<LastCreateKindFn>(fake_hsa.symbol("rocfuzz_fake_hsa_last_create_kind"));
+    destroy_calls =
+        reinterpret_cast<DestroyCallsFn>(fake_hsa.symbol("rocfuzz_fake_hsa_destroy_calls"));
+    reader_data = reinterpret_cast<ReaderDataFn>(fake_hsa.symbol("rocfuzz_fake_hsa_reader_data"));
+    reader_size = reinterpret_cast<ReaderSizeFn>(fake_hsa.symbol("rocfuzz_fake_hsa_reader_size"));
+  }
+
+  ~PreloadHarness() {
+    unsetenv("ROCJITSU_AFL_HSA_RUNTIME_PATH");
+    unsetenv("ROCJITSU_AFL_HIP_RUNTIME_PATH");
+    unsetenv("__AFL_SHM_ID");
+  }
+
+  void assert_ready() const {
+    ASSERT_NE(persistent_begin, nullptr);
+    ASSERT_NE(hip_module_load_data, nullptr);
+    ASSERT_NE(hip_module_unload, nullptr);
+    ASSERT_NE(create_from_memory, nullptr);
+    ASSERT_NE(create_from_file, nullptr);
+    ASSERT_NE(create_from_file_with_offset, nullptr);
+    ASSERT_NE(destroy, nullptr);
+    ASSERT_NE(reset_fake_hip, nullptr);
+    ASSERT_NE(reset_fake_hsa, nullptr);
+    ASSERT_NE(module_load_data_calls, nullptr);
+    ASSERT_NE(module_unload_calls, nullptr);
+    ASSERT_NE(last_module_image, nullptr);
+    ASSERT_NE(last_module_image_size, nullptr);
+    ASSERT_NE(last_create_kind, nullptr);
+    ASSERT_NE(destroy_calls, nullptr);
+    ASSERT_NE(reader_data, nullptr);
+    ASSERT_NE(reader_size, nullptr);
+  }
+};
+
+std::vector<uint8_t> reader_bytes(const PreloadHarness &harness, hsa_code_object_reader_t reader) {
+  const uint8_t *data = harness.reader_data(reader.handle);
+  const size_t size = harness.reader_size(reader.handle);
+  EXPECT_NE(data, nullptr);
+  EXPECT_GT(size, 0u);
+  if (data == nullptr || size == 0)
+    return {};
+  return std::vector<uint8_t>(data, data + size);
+}
+
+} // namespace
+
+TEST(RocjitsuAflPreloadHsaReaderTest, RewritesRawMemoryReaderAndOwnsBytesUntilDestroy) {
+  PreloadHarness harness;
+  harness.assert_ready();
+  harness.reset_fake_hsa();
+  ASSERT_EQ(harness.persistent_begin(), 0);
+
+  const auto image = rocjitsu::fuzzer::afl::test::make_minimal_amdgpu_elf();
+  hsa_code_object_reader_t reader{};
+  ASSERT_EQ(harness.create_from_memory(image.data(), image.size(), &reader), HSA_STATUS_SUCCESS);
+
+  EXPECT_EQ(harness.last_create_kind(), kCreateKindMemory);
+  EXPECT_NE(harness.reader_data(reader.handle), image.data());
+  const auto rewritten = reader_bytes(harness, reader);
+  EXPECT_TRUE(rocjitsu::is_supported_amdgpu_elf(rewritten));
+  EXPECT_GT(rewritten.size(), image.size());
+  EXPECT_NE(rewritten, image);
+
+  EXPECT_EQ(harness.destroy(reader), HSA_STATUS_SUCCESS);
+  EXPECT_EQ(harness.destroy_calls(), 1);
+  EXPECT_EQ(harness.reader_data(reader.handle), nullptr);
+}
+
+TEST(RocjitsuAflPreloadHsaReaderTest, RewritesRawHipModuleLoadData) {
+  PreloadHarness harness;
+  harness.assert_ready();
+  harness.reset_fake_hip();
+
+  const auto image = rocjitsu::fuzzer::afl::test::make_minimal_amdgpu_elf();
+  void *module = nullptr;
+  ASSERT_EQ(harness.hip_module_load_data(&module, image.data()), 0);
+
+  EXPECT_EQ(harness.module_load_data_calls(), 1);
+  ASSERT_NE(module, nullptr);
+  const uint8_t *loaded_image = harness.last_module_image();
+  ASSERT_NE(loaded_image, nullptr);
+  EXPECT_NE(loaded_image, image.data());
+
+  const size_t loaded_image_size = harness.last_module_image_size();
+  ASSERT_GT(loaded_image_size, image.size());
+  const std::vector<uint8_t> loaded(loaded_image, loaded_image + loaded_image_size);
+  EXPECT_TRUE(rocjitsu::is_supported_amdgpu_elf(loaded));
+  EXPECT_NE(loaded, image);
+
+  ASSERT_EQ(harness.hip_module_unload(module), 0);
+  EXPECT_EQ(harness.module_unload_calls(), 1);
+}
+
+TEST(RocjitsuAflPreloadHsaReaderTest, ForwardsNonRawMemoryReader) {
+  PreloadHarness harness;
+  harness.assert_ready();
+  harness.reset_fake_hsa();
+
+  const std::vector<uint8_t> not_elf = {'n', 'o', 't', '-', 'e', 'l', 'f'};
+  hsa_code_object_reader_t reader{};
+  ASSERT_EQ(harness.create_from_memory(not_elf.data(), not_elf.size(), &reader),
+            HSA_STATUS_SUCCESS);
+
+  EXPECT_EQ(harness.last_create_kind(), kCreateKindMemory);
+  EXPECT_EQ(harness.reader_data(reader.handle), not_elf.data());
+  EXPECT_EQ(harness.reader_size(reader.handle), not_elf.size());
+  EXPECT_EQ(harness.destroy(reader), HSA_STATUS_SUCCESS);
+}
+
+TEST(RocjitsuAflPreloadHsaReaderTest, RewritesRawFileWithOffsetReader) {
+  PreloadHarness harness;
+  harness.assert_ready();
+  harness.reset_fake_hsa();
+  ASSERT_EQ(harness.persistent_begin(), 0);
+
+  const std::vector<uint8_t> prefix = {'p', 'a', 'd'};
+  const auto image = rocjitsu::fuzzer::afl::test::make_minimal_amdgpu_elf();
+  std::vector<uint8_t> file_bytes(prefix);
+  file_bytes.insert(file_bytes.end(), image.begin(), image.end());
+  TempFile file(file_bytes);
+  ASSERT_GE(file.fd(), 0);
+
+  hsa_code_object_reader_t reader{};
+  ASSERT_EQ(harness.create_from_file_with_offset(file.fd(), prefix.size(), image.size(), &reader),
+            HSA_STATUS_SUCCESS);
+
+  EXPECT_EQ(harness.last_create_kind(), kCreateKindMemory);
+  const auto rewritten = reader_bytes(harness, reader);
+  EXPECT_TRUE(rocjitsu::is_supported_amdgpu_elf(rewritten));
+  EXPECT_GT(rewritten.size(), image.size());
+  EXPECT_NE(rewritten, image);
+  EXPECT_EQ(harness.destroy(reader), HSA_STATUS_SUCCESS);
+}
+
+TEST(RocjitsuAflPreloadHsaReaderTest, ForwardsNonRawFileReader) {
+  PreloadHarness harness;
+  harness.assert_ready();
+  harness.reset_fake_hsa();
+
+  const std::vector<uint8_t> not_elf = {'n', 'o', 't', '-', 'e', 'l', 'f'};
+  TempFile file(not_elf);
+  ASSERT_GE(file.fd(), 0);
+
+  hsa_code_object_reader_t reader{};
+  ASSERT_EQ(harness.create_from_file(file.fd(), &reader), HSA_STATUS_SUCCESS);
+
+  EXPECT_EQ(harness.last_create_kind(), kCreateKindFile);
+  EXPECT_EQ(harness.destroy(reader), HSA_STATUS_SUCCESS);
+}

--- a/emulation/rocjitsu/fuzzer/afl-dbi/tests/afl_preload_runtime_test.cpp
+++ b/emulation/rocjitsu/fuzzer/afl-dbi/tests/afl_preload_runtime_test.cpp
@@ -1,0 +1,134 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu_fuzzer/afl_runtime.h"
+
+#include <gtest/gtest.h>
+
+#include <dlfcn.h>
+#include <sys/shm.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+#ifndef ROCJITSU_AFL_PRELOAD_PATH
+#error "ROCJITSU_AFL_PRELOAD_PATH must point to librocjitsu_afl_preload.so"
+#endif
+
+#ifndef ROCJITSU_AFL_FAKE_HIP_RUNTIME_PATH
+#error "ROCJITSU_AFL_FAKE_HIP_RUNTIME_PATH must point to the fake HIP runtime"
+#endif
+
+namespace {
+
+using rocjitsu::fuzzer::afl::kCoverageSlots;
+using rocjitsu::fuzzer::afl::kDeviceStart;
+using rocjitsu::fuzzer::afl::kMapSize;
+
+using PersistentFn = int (*)();
+using DeviceCountersFn = uint32_t *(*)();
+using DeviceCounterBytesFn = size_t (*)();
+using DeviceSynchronizeCallsFn = int (*)();
+
+class DlHandle {
+public:
+  explicit DlHandle(const char *path, int flags) : handle_(dlopen(path, flags)) {}
+  DlHandle(const DlHandle &) = delete;
+  DlHandle &operator=(const DlHandle &) = delete;
+  ~DlHandle() {
+    if (handle_ != nullptr)
+      dlclose(handle_);
+  }
+
+  void *symbol(const char *name) const { return dlsym(handle_, name); }
+  void *get() const { return handle_; }
+
+private:
+  void *handle_ = nullptr;
+};
+
+class SharedMemory {
+public:
+  SharedMemory() : id_(shmget(IPC_PRIVATE, kMapSize, IPC_CREAT | 0600)) {
+    EXPECT_GE(id_, 0);
+    if (id_ >= 0) {
+      data_ = static_cast<uint8_t *>(shmat(id_, nullptr, 0));
+      EXPECT_NE(data_, reinterpret_cast<uint8_t *>(-1));
+      if (data_ != reinterpret_cast<uint8_t *>(-1))
+        std::memset(data_, 0, kMapSize);
+    }
+  }
+
+  SharedMemory(const SharedMemory &) = delete;
+  SharedMemory &operator=(const SharedMemory &) = delete;
+
+  ~SharedMemory() {
+    if (data_ != nullptr && data_ != reinterpret_cast<uint8_t *>(-1))
+      shmdt(data_);
+    if (id_ >= 0)
+      shmctl(id_, IPC_RMID, nullptr);
+  }
+
+  int id() const { return id_; }
+  uint8_t *data() const { return data_; }
+
+private:
+  int id_ = -1;
+  uint8_t *data_ = nullptr;
+};
+
+} // namespace
+
+TEST(RocjitsuAflPreloadRuntimeTest, PersistentBeginEndMergesBasicBlockCounters) {
+  SharedMemory shm;
+  ASSERT_GE(shm.id(), 0);
+  ASSERT_NE(shm.data(), nullptr);
+  setenv("__AFL_SHM_ID", std::to_string(shm.id()).c_str(), 1);
+  setenv("ROCJITSU_AFL_HIP_RUNTIME_PATH", ROCJITSU_AFL_FAKE_HIP_RUNTIME_PATH, 1);
+
+  DlHandle preload(ROCJITSU_AFL_PRELOAD_PATH, RTLD_LAZY | RTLD_LOCAL);
+  ASSERT_NE(preload.get(), nullptr) << dlerror();
+
+  auto persistent_begin =
+      reinterpret_cast<PersistentFn>(preload.symbol("rocjitsu_afl_persistent_begin"));
+  auto persistent_end =
+      reinterpret_cast<PersistentFn>(preload.symbol("rocjitsu_afl_persistent_end"));
+  ASSERT_NE(persistent_begin, nullptr);
+  ASSERT_NE(persistent_end, nullptr);
+
+  ASSERT_EQ(persistent_begin(), 0);
+
+  DlHandle fake_hip(ROCJITSU_AFL_FAKE_HIP_RUNTIME_PATH, RTLD_LAZY | RTLD_LOCAL);
+  ASSERT_NE(fake_hip.get(), nullptr) << dlerror();
+  auto fake_device_counters =
+      reinterpret_cast<DeviceCountersFn>(fake_hip.symbol("rocfuzz_fake_device_counters"));
+  auto fake_device_counter_bytes =
+      reinterpret_cast<DeviceCounterBytesFn>(fake_hip.symbol("rocfuzz_fake_device_counter_bytes"));
+  auto fake_device_synchronize_calls = reinterpret_cast<DeviceSynchronizeCallsFn>(
+      fake_hip.symbol("rocfuzz_fake_device_synchronize_calls"));
+  ASSERT_NE(fake_device_counters, nullptr);
+  ASSERT_NE(fake_device_counter_bytes, nullptr);
+  ASSERT_NE(fake_device_synchronize_calls, nullptr);
+
+  uint32_t *device_counters = fake_device_counters();
+  ASSERT_NE(device_counters, nullptr);
+  EXPECT_EQ(fake_device_counter_bytes(), sizeof(uint32_t) * kCoverageSlots);
+  for (uint32_t i = 0; i < kCoverageSlots; ++i)
+    ASSERT_EQ(device_counters[i], 0u);
+
+  device_counters[0] = 1;
+  device_counters[1] = 3;
+  device_counters[2] = 512;
+  ASSERT_EQ(persistent_end(), 0);
+
+  EXPECT_EQ(shm.data()[kDeviceStart], 1u);
+  EXPECT_EQ(shm.data()[kDeviceStart + 1], 3u);
+  EXPECT_EQ(shm.data()[kDeviceStart + 2], 255u);
+  EXPECT_GE(fake_device_synchronize_calls(), 1);
+
+  unsetenv("ROCJITSU_AFL_HIP_RUNTIME_PATH");
+  unsetenv("__AFL_SHM_ID");
+}

--- a/emulation/rocjitsu/fuzzer/afl-dbi/tests/afl_preload_symbols_test.cpp
+++ b/emulation/rocjitsu/fuzzer/afl-dbi/tests/afl_preload_symbols_test.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <gtest/gtest.h>
+
+#include <dlfcn.h>
+
+#ifndef ROCJITSU_AFL_PRELOAD_PATH
+#error "ROCJITSU_AFL_PRELOAD_PATH must point to librocjitsu_afl_preload.so"
+#endif
+
+namespace {
+
+class DlHandle {
+public:
+  explicit DlHandle(const char *path) : handle_(dlopen(path, RTLD_LAZY | RTLD_LOCAL)) {}
+  DlHandle(const DlHandle &) = delete;
+  DlHandle &operator=(const DlHandle &) = delete;
+  ~DlHandle() {
+    if (handle_ != nullptr)
+      dlclose(handle_);
+  }
+
+  void *get() const { return handle_; }
+
+private:
+  void *handle_ = nullptr;
+};
+
+} // namespace
+
+TEST(RocjitsuAflPreloadSymbolsTest, ExportsVectorAddInterceptSurface) {
+  DlHandle preload(ROCJITSU_AFL_PRELOAD_PATH);
+  ASSERT_NE(preload.get(), nullptr) << dlerror();
+
+  const char *symbols[] = {
+      "hipModuleLoadData",
+      "hipModuleUnload",
+      "hipModuleGetFunction",
+      "hipModuleLaunchKernel",
+      "hipDeviceSynchronize",
+      "hipMemcpy",
+      "hsa_code_object_reader_create_from_memory",
+      "hsa_code_object_reader_create_from_file",
+      "hsa_ven_amd_loader_code_object_reader_create_from_file_with_offset_size",
+      "hsa_code_object_reader_destroy",
+      "rocjitsu_afl_persistent_begin",
+      "rocjitsu_afl_persistent_end",
+  };
+
+  for (const char *symbol : symbols) {
+    dlerror();
+    void *address = dlsym(preload.get(), symbol);
+    EXPECT_NE(address, nullptr) << symbol << ": " << dlerror();
+  }
+}

--- a/emulation/rocjitsu/fuzzer/afl-dbi/tests/amdgpu_elf_reader_test.cpp
+++ b/emulation/rocjitsu/fuzzer/afl-dbi/tests/amdgpu_elf_reader_test.cpp
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/code/amdgpu_elf_reader.h"
+
+#include "minimal_amdgpu_elf.h"
+#include "rocjitsu/code/amdgpu_elf.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstring>
+#include <vector>
+
+namespace {
+
+template <typename T> void write_at(std::vector<uint8_t> &image, uint64_t offset, const T &value) {
+  ASSERT_LE(offset + sizeof(T), image.size());
+  std::memcpy(image.data() + offset, &value, sizeof(T));
+}
+
+} // namespace
+
+TEST(AmdGpuElfReaderTest, DetectsSupportedAmdGpuElf) {
+  auto image = rocjitsu::fuzzer::afl::test::make_minimal_amdgpu_elf();
+  EXPECT_TRUE(rocjitsu::is_supported_amdgpu_elf(image));
+
+  auto wrong_machine = image;
+  auto ehdr = *reinterpret_cast<const rocjitsu::Elf64_Ehdr *>(wrong_machine.data());
+  ehdr.e_machine = rocjitsu::EM_X86_64;
+  write_at(wrong_machine, 0, ehdr);
+  EXPECT_FALSE(rocjitsu::is_supported_amdgpu_elf(wrong_machine));
+
+  auto unsupported_target = image;
+  ehdr = *reinterpret_cast<const rocjitsu::Elf64_Ehdr *>(unsupported_target.data());
+  ehdr.e_flags = rocjitsu::EF_AMDGPU_MACH_AMDGCN_GFX90A;
+  write_at(unsupported_target, 0, ehdr);
+  EXPECT_FALSE(rocjitsu::is_supported_amdgpu_elf(unsupported_target));
+}
+
+TEST(AmdGpuElfReaderTest, DiscoversKernelDescriptorSite) {
+  const auto image = rocjitsu::fuzzer::afl::test::make_minimal_amdgpu_elf();
+
+  const auto sites = rocjitsu::discover_amdgpu_kernel_sites(image);
+
+  ASSERT_EQ(sites.size(), 1u);
+  EXPECT_EQ(sites[0].kernel_name, "kernel");
+  EXPECT_EQ(sites[0].descriptor_file_offset,
+            rocjitsu::fuzzer::afl::test::kMinimalAmdGpuElfKernelDescriptorOffset);
+  EXPECT_EQ(sites[0].entry_file_offset,
+            rocjitsu::fuzzer::afl::test::kMinimalAmdGpuElfKernelEntryOffset);
+}
+
+TEST(AmdGpuElfReaderTest, IgnoresMalformedInput) {
+  constexpr uint8_t not_elf[] = {'n', 'o', 't', 'e', 'l', 'f'};
+  EXPECT_FALSE(rocjitsu::is_supported_amdgpu_elf(not_elf));
+  EXPECT_TRUE(rocjitsu::discover_amdgpu_kernel_sites(not_elf).empty());
+
+  auto truncated = rocjitsu::fuzzer::afl::test::make_minimal_amdgpu_elf();
+  truncated.resize(sizeof(rocjitsu::Elf64_Ehdr));
+  EXPECT_FALSE(rocjitsu::is_supported_amdgpu_elf(truncated));
+  EXPECT_TRUE(rocjitsu::discover_amdgpu_kernel_sites(truncated).empty());
+}
+
+TEST(AmdGpuElfReaderTest, BuildsEntryCounterProbeFromStatePointer) {
+  constexpr uint64_t state_pointer = 0x0123456789abcdefULL;
+
+  const auto words =
+      rocjitsu::build_amdgpu_entry_counter_probe_words(state_pointer, ROCJITSU_CODE_ARCH_RDNA4);
+
+  ASSERT_FALSE(words.empty());
+  // The runtime patches raw ELF bytes after allocating the device counters, so
+  // the probe must carry that device pointer as immediate words. This is the
+  // GPU-visible staging buffer, not AFL's host shared-memory bitmap.
+  const auto low = std::find(words.begin(), words.end(), static_cast<uint32_t>(state_pointer));
+  ASSERT_NE(low, words.end());
+  const auto high = std::find(low + 1, words.end(), static_cast<uint32_t>(state_pointer >> 32));
+  EXPECT_NE(high, words.end());
+}
+
+TEST(AmdGpuElfReaderTest, RewritesKernelEntriesWithEntryProbe) {
+  constexpr uint64_t state_pointer = 0x1020304050607080ULL;
+  const auto image = rocjitsu::fuzzer::afl::test::make_minimal_amdgpu_elf();
+  const auto original_sites = rocjitsu::discover_amdgpu_kernel_sites(image);
+  ASSERT_EQ(original_sites.size(), 1u);
+
+  const auto patched = rocjitsu::patch_amdgpu_elf_kernel_entries(image, state_pointer);
+  const auto patched_sites = rocjitsu::discover_amdgpu_kernel_sites(patched);
+
+  ASSERT_EQ(patched_sites.size(), 1u);
+  EXPECT_GT(patched.size(), image.size());
+  EXPECT_NE(patched, image);
+  EXPECT_TRUE(rocjitsu::is_supported_amdgpu_elf(patched));
+  EXPECT_EQ(patched_sites[0].kernel_name, original_sites[0].kernel_name);
+  EXPECT_NE(patched_sites[0].entry_file_offset, original_sites[0].entry_file_offset);
+}
+
+TEST(AmdGpuElfReaderTest, KernelEntryRewriteFailsOpenForUnsupportedInput) {
+  auto unsupported = rocjitsu::fuzzer::afl::test::make_minimal_amdgpu_elf();
+  auto ehdr = *reinterpret_cast<const rocjitsu::Elf64_Ehdr *>(unsupported.data());
+  ehdr.e_flags = rocjitsu::EF_AMDGPU_MACH_AMDGCN_GFX90A;
+  write_at(unsupported, 0, ehdr);
+
+  const auto patched = rocjitsu::patch_amdgpu_elf_kernel_entries(unsupported, 0x99);
+  EXPECT_EQ(patched, unsupported);
+}

--- a/emulation/rocjitsu/fuzzer/afl-dbi/tests/fake_hip_runtime.cpp
+++ b/emulation/rocjitsu/fuzzer/afl-dbi/tests/fake_hip_runtime.cpp
@@ -1,0 +1,134 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <elf.h>
+#include <limits>
+
+namespace {
+
+constexpr int kHipSuccess = 0;
+constexpr int kHipMemcpyDeviceToHost = 2;
+
+uint32_t *g_fake_device_counters = nullptr;
+size_t g_fake_device_counter_bytes = 0;
+int g_device_synchronize_calls = 0;
+uintptr_t g_next_module = 1;
+int g_module_load_data_calls = 0;
+int g_module_unload_calls = 0;
+void *g_last_module = nullptr;
+const uint8_t *g_last_module_image = nullptr;
+size_t g_last_module_image_size = 0;
+
+size_t infer_elf_image_size(const void *image) {
+  if (image == nullptr)
+    return 0;
+
+  Elf64_Ehdr ehdr{};
+  std::memcpy(&ehdr, image, sizeof(ehdr));
+  if (std::memcmp(ehdr.e_ident, ELFMAG, SELFMAG) != 0 || ehdr.e_ident[EI_CLASS] != ELFCLASS64 ||
+      ehdr.e_shentsize != sizeof(Elf64_Shdr) || ehdr.e_shnum == 0)
+    return 0;
+
+  const uint64_t section_headers_bytes = ehdr.e_shnum * sizeof(Elf64_Shdr);
+  if (ehdr.e_shoff > std::numeric_limits<uint64_t>::max() - section_headers_bytes)
+    return 0;
+  uint64_t image_size = ehdr.e_shoff + section_headers_bytes;
+
+  if (ehdr.e_phnum != 0) {
+    if (ehdr.e_phentsize != sizeof(Elf64_Phdr))
+      return 0;
+    const uint64_t program_headers_bytes = ehdr.e_phnum * sizeof(Elf64_Phdr);
+    if (ehdr.e_phoff > std::numeric_limits<uint64_t>::max() - program_headers_bytes)
+      return 0;
+    image_size = std::max(image_size, ehdr.e_phoff + program_headers_bytes);
+  }
+
+  return image_size <= std::numeric_limits<size_t>::max() ? static_cast<size_t>(image_size) : 0;
+}
+
+} // namespace
+
+extern "C" {
+
+int hipModuleLoadData(void **module, const void *image) {
+  if (module == nullptr)
+    return 999;
+
+  ++g_module_load_data_calls;
+  g_last_module = reinterpret_cast<void *>(g_next_module++);
+  g_last_module_image = static_cast<const uint8_t *>(image);
+  g_last_module_image_size = infer_elf_image_size(image);
+  *module = g_last_module;
+  return kHipSuccess;
+}
+
+int hipModuleUnload(void *module) {
+  ++g_module_unload_calls;
+  if (module == g_last_module)
+    g_last_module = nullptr;
+  return kHipSuccess;
+}
+
+int hipMalloc(void **ptr, size_t size) {
+  g_fake_device_counter_bytes = size;
+  g_fake_device_counters = static_cast<uint32_t *>(std::calloc(1, size));
+  *ptr = g_fake_device_counters;
+  return g_fake_device_counters == nullptr ? 999 : kHipSuccess;
+}
+
+int hipFree(void *ptr) {
+  std::free(ptr);
+  if (ptr == g_fake_device_counters) {
+    g_fake_device_counters = nullptr;
+    g_fake_device_counter_bytes = 0;
+  }
+  return kHipSuccess;
+}
+
+int hipMemset(void *dst, int value, size_t size) {
+  std::memset(dst, value, size);
+  return kHipSuccess;
+}
+
+int hipMemcpy(void *dst, const void *src, size_t size, int kind) {
+  if (kind != kHipMemcpyDeviceToHost)
+    return 999;
+  std::memcpy(dst, src, size);
+  return kHipSuccess;
+}
+
+int hipDeviceSynchronize() {
+  ++g_device_synchronize_calls;
+  return kHipSuccess;
+}
+
+const char *hipGetErrorString(int) { return "fake hip error"; }
+
+uint32_t *rocfuzz_fake_device_counters() { return g_fake_device_counters; }
+
+size_t rocfuzz_fake_device_counter_bytes() { return g_fake_device_counter_bytes; }
+
+int rocfuzz_fake_device_synchronize_calls() { return g_device_synchronize_calls; }
+
+void rocfuzz_fake_hip_reset() {
+  g_module_load_data_calls = 0;
+  g_module_unload_calls = 0;
+  g_last_module = nullptr;
+  g_last_module_image = nullptr;
+  g_last_module_image_size = 0;
+}
+
+int rocfuzz_fake_hip_module_load_data_calls() { return g_module_load_data_calls; }
+
+int rocfuzz_fake_hip_module_unload_calls() { return g_module_unload_calls; }
+
+const uint8_t *rocfuzz_fake_hip_last_module_image() { return g_last_module_image; }
+
+size_t rocfuzz_fake_hip_last_module_image_size() { return g_last_module_image_size; }
+
+} // extern "C"

--- a/emulation/rocjitsu/fuzzer/afl-dbi/tests/fake_hsa_runtime.cpp
+++ b/emulation/rocjitsu/fuzzer/afl-dbi/tests/fake_hsa_runtime.cpp
@@ -1,0 +1,96 @@
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu-anonymous-struct"
+#pragma clang diagnostic ignored "-Wnested-anon-types"
+#endif
+#include <hsa/hsa.h>
+#include <hsa/hsa_ven_amd_loader.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+
+#include <cstddef>
+#include <cstdint>
+#include <unordered_map>
+
+namespace {
+
+enum CreateKind {
+  kCreateKindNone = 0,
+  kCreateKindMemory = 1,
+  kCreateKindFile = 2,
+  kCreateKindFileWithOffset = 3,
+};
+
+struct ReaderRecord {
+  const uint8_t *data = nullptr;
+  size_t size = 0;
+  CreateKind kind = kCreateKindNone;
+};
+
+uint64_t g_next_handle = 1;
+CreateKind g_last_create_kind = kCreateKindNone;
+int g_destroy_calls = 0;
+std::unordered_map<uint64_t, ReaderRecord> g_readers;
+
+hsa_status_t create_reader(CreateKind kind, const void *data, size_t size,
+                           hsa_code_object_reader_t *reader) {
+  if (reader == nullptr)
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+
+  reader->handle = g_next_handle++;
+  g_last_create_kind = kind;
+  g_readers[reader->handle] = ReaderRecord{static_cast<const uint8_t *>(data), size, kind};
+  return HSA_STATUS_SUCCESS;
+}
+
+} // namespace
+
+extern "C" {
+
+hsa_status_t
+hsa_code_object_reader_create_from_memory(const void *code_object, size_t size,
+                                          hsa_code_object_reader_t *code_object_reader) {
+  if (code_object == nullptr || size == 0)
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  return create_reader(kCreateKindMemory, code_object, size, code_object_reader);
+}
+
+hsa_status_t hsa_code_object_reader_create_from_file(hsa_file_t,
+                                                     hsa_code_object_reader_t *code_object_reader) {
+  return create_reader(kCreateKindFile, nullptr, 0, code_object_reader);
+}
+
+hsa_status_t hsa_ven_amd_loader_code_object_reader_create_from_file_with_offset_size(
+    hsa_file_t, size_t, size_t, hsa_code_object_reader_t *code_object_reader) {
+  return create_reader(kCreateKindFileWithOffset, nullptr, 0, code_object_reader);
+}
+
+hsa_status_t hsa_code_object_reader_destroy(hsa_code_object_reader_t code_object_reader) {
+  ++g_destroy_calls;
+  g_readers.erase(code_object_reader.handle);
+  return HSA_STATUS_SUCCESS;
+}
+
+void rocfuzz_fake_hsa_reset() {
+  g_next_handle = 1;
+  g_last_create_kind = kCreateKindNone;
+  g_destroy_calls = 0;
+  g_readers.clear();
+}
+
+int rocfuzz_fake_hsa_last_create_kind() { return static_cast<int>(g_last_create_kind); }
+
+int rocfuzz_fake_hsa_destroy_calls() { return g_destroy_calls; }
+
+const uint8_t *rocfuzz_fake_hsa_reader_data(uint64_t handle) {
+  const auto it = g_readers.find(handle);
+  return it == g_readers.end() ? nullptr : it->second.data;
+}
+
+size_t rocfuzz_fake_hsa_reader_size(uint64_t handle) {
+  const auto it = g_readers.find(handle);
+  return it == g_readers.end() ? 0 : it->second.size;
+}
+
+} // extern "C"

--- a/emulation/rocjitsu/fuzzer/afl-dbi/tests/minimal_amdgpu_elf.h
+++ b/emulation/rocjitsu/fuzzer/afl-dbi/tests/minimal_amdgpu_elf.h
@@ -1,0 +1,172 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "rocjitsu/code/amdgpu_elf.h"
+
+#include "hsa/AMDHSAKernelDescriptor.h"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+namespace rocjitsu::fuzzer::afl::test {
+
+inline constexpr uint64_t kMinimalAmdGpuElfTextOffset = 0x100;
+inline constexpr uint64_t kMinimalAmdGpuElfTextVaddr = 0x1100;
+inline constexpr uint64_t kMinimalAmdGpuElfRodataOffset = 0x110;
+inline constexpr uint64_t kMinimalAmdGpuElfRodataVaddr = 0x2000;
+inline constexpr uint64_t kMinimalAmdGpuElfKernelDescriptorOffset = kMinimalAmdGpuElfRodataOffset;
+inline constexpr uint64_t kMinimalAmdGpuElfKernelEntryOffset = kMinimalAmdGpuElfTextOffset;
+
+namespace detail {
+
+inline uint32_t add_elf_name(std::vector<uint8_t> &table, const char *name) {
+  const uint32_t offset = static_cast<uint32_t>(table.size());
+  const auto *bytes = reinterpret_cast<const uint8_t *>(name);
+  table.insert(table.end(), bytes, bytes + std::strlen(name) + 1);
+  return offset;
+}
+
+inline uint64_t align_up(uint64_t value, uint64_t alignment) {
+  return (value + alignment - 1) & ~(alignment - 1);
+}
+
+} // namespace detail
+
+inline std::vector<uint8_t> make_minimal_amdgpu_elf() {
+  using KernelDescriptor = rocr::llvm::amdhsa::kernel_descriptor_t;
+
+  constexpr std::array<uint32_t, 4> text_words = {
+      0xbf800000u, // s_nop 0
+      0xbf810000u, // s_endpgm
+      0xbf800000u, // s_nop 0
+      0xbf800000u, // s_nop 0
+  };
+  constexpr uint64_t text_size = text_words.size() * sizeof(uint32_t);
+  constexpr uint64_t rodata_size = sizeof(KernelDescriptor);
+  constexpr uint64_t load_align = 0x1000;
+
+  std::vector<uint8_t> shstrtab{'\0'};
+  const uint32_t text_name = detail::add_elf_name(shstrtab, ".text");
+  const uint32_t rodata_name = detail::add_elf_name(shstrtab, ".rodata");
+  const uint32_t symtab_name = detail::add_elf_name(shstrtab, ".symtab");
+  const uint32_t strtab_name = detail::add_elf_name(shstrtab, ".strtab");
+  const uint32_t shstrtab_name = detail::add_elf_name(shstrtab, ".shstrtab");
+
+  std::vector<uint8_t> strtab{'\0'};
+  const uint32_t kd_symbol_name = detail::add_elf_name(strtab, "kernel.kd");
+
+  const uint64_t strtab_offset = kMinimalAmdGpuElfRodataOffset + rodata_size;
+  const uint64_t symtab_offset = detail::align_up(strtab_offset + strtab.size(), 8);
+  constexpr size_t symbol_count = 2;
+  const uint64_t shstrtab_offset = symtab_offset + symbol_count * sizeof(Elf64_Sym);
+  const uint64_t shoff = detail::align_up(shstrtab_offset + shstrtab.size(), 8);
+  constexpr uint16_t section_count = 6;
+  constexpr uint16_t program_header_count = 2;
+
+  std::vector<uint8_t> image(shoff + section_count * sizeof(Elf64_Shdr), 0);
+
+  Elf64_Ehdr ehdr{};
+  std::memcpy(ehdr.e_ident, EI_MAGIC, EI_MAGIC_SIZE);
+  ehdr.e_ident[EI_CLASS] = ELFCLASS64;
+  ehdr.e_ident[EI_OSABI] = ELFOSABI_AMDGPU_HSA;
+  ehdr.e_type = ET_DYN;
+  ehdr.e_machine = EM_AMDGPU;
+  ehdr.e_version = 1;
+  ehdr.e_phoff = sizeof(Elf64_Ehdr);
+  ehdr.e_shoff = shoff;
+  ehdr.e_flags = EF_AMDGPU_MACH_AMDGCN_GFX950;
+  ehdr.e_ehsize = sizeof(Elf64_Ehdr);
+  ehdr.e_phentsize = sizeof(Elf64_Phdr);
+  ehdr.e_phnum = program_header_count;
+  ehdr.e_shentsize = sizeof(Elf64_Shdr);
+  ehdr.e_shnum = section_count;
+  ehdr.e_shstrndx = 5;
+  std::memcpy(image.data(), &ehdr, sizeof(ehdr));
+
+  std::array<Elf64_Phdr, program_header_count> phdrs{};
+  phdrs[0].p_type = PT_LOAD;
+  phdrs[0].p_flags = 0x5; // PF_R | PF_X
+  phdrs[0].p_offset = kMinimalAmdGpuElfTextOffset;
+  phdrs[0].p_vaddr = kMinimalAmdGpuElfTextVaddr;
+  phdrs[0].p_paddr = kMinimalAmdGpuElfTextVaddr;
+  phdrs[0].p_filesz = text_size;
+  phdrs[0].p_memsz = text_size;
+  phdrs[0].p_align = load_align;
+
+  phdrs[1].p_type = PT_LOAD;
+  phdrs[1].p_flags = 0x4; // PF_R
+  phdrs[1].p_offset = kMinimalAmdGpuElfRodataOffset;
+  phdrs[1].p_vaddr = kMinimalAmdGpuElfRodataVaddr;
+  phdrs[1].p_paddr = kMinimalAmdGpuElfRodataVaddr;
+  phdrs[1].p_filesz = rodata_size;
+  phdrs[1].p_memsz = rodata_size;
+  phdrs[1].p_align = load_align;
+  std::memcpy(image.data() + ehdr.e_phoff, phdrs.data(), phdrs.size() * sizeof(Elf64_Phdr));
+
+  std::memcpy(image.data() + kMinimalAmdGpuElfTextOffset, text_words.data(), text_size);
+
+  KernelDescriptor kd{};
+  kd.kernel_code_entry_byte_offset = static_cast<int64_t>(kMinimalAmdGpuElfTextVaddr) -
+                                     static_cast<int64_t>(kMinimalAmdGpuElfRodataVaddr);
+  std::memcpy(image.data() + kMinimalAmdGpuElfRodataOffset, &kd, sizeof(kd));
+
+  std::memcpy(image.data() + strtab_offset, strtab.data(), strtab.size());
+
+  std::array<Elf64_Sym, symbol_count> syms{};
+  syms[1].st_name = kd_symbol_name;
+  syms[1].st_info = elf_symbol_info(kElfSymbolBindGlobal, kElfSymbolTypeObject);
+  syms[1].st_shndx = 2;
+  syms[1].st_value = kMinimalAmdGpuElfRodataVaddr;
+  syms[1].st_size = sizeof(KernelDescriptor);
+  std::memcpy(image.data() + symtab_offset, syms.data(), syms.size() * sizeof(Elf64_Sym));
+
+  std::memcpy(image.data() + shstrtab_offset, shstrtab.data(), shstrtab.size());
+
+  std::array<Elf64_Shdr, section_count> shdrs{};
+  shdrs[1].sh_name = text_name;
+  shdrs[1].sh_type = SHT_PROGBITS;
+  shdrs[1].sh_flags = SHF_ALLOC | SHF_EXECINSTR;
+  shdrs[1].sh_addr = kMinimalAmdGpuElfTextVaddr;
+  shdrs[1].sh_offset = kMinimalAmdGpuElfTextOffset;
+  shdrs[1].sh_size = text_size;
+  shdrs[1].sh_addralign = sizeof(uint32_t);
+
+  shdrs[2].sh_name = rodata_name;
+  shdrs[2].sh_type = SHT_PROGBITS;
+  shdrs[2].sh_flags = SHF_ALLOC;
+  shdrs[2].sh_addr = kMinimalAmdGpuElfRodataVaddr;
+  shdrs[2].sh_offset = kMinimalAmdGpuElfRodataOffset;
+  shdrs[2].sh_size = rodata_size;
+  shdrs[2].sh_addralign = 64;
+
+  shdrs[3].sh_name = symtab_name;
+  shdrs[3].sh_type = SHT_SYMTAB;
+  shdrs[3].sh_offset = symtab_offset;
+  shdrs[3].sh_size = syms.size() * sizeof(Elf64_Sym);
+  shdrs[3].sh_link = 4;
+  shdrs[3].sh_info = 1;
+  shdrs[3].sh_addralign = 8;
+  shdrs[3].sh_entsize = sizeof(Elf64_Sym);
+
+  shdrs[4].sh_name = strtab_name;
+  shdrs[4].sh_type = SHT_STRTAB;
+  shdrs[4].sh_offset = strtab_offset;
+  shdrs[4].sh_size = strtab.size();
+  shdrs[4].sh_addralign = 1;
+
+  shdrs[5].sh_name = shstrtab_name;
+  shdrs[5].sh_type = SHT_STRTAB;
+  shdrs[5].sh_offset = shstrtab_offset;
+  shdrs[5].sh_size = shstrtab.size();
+  shdrs[5].sh_addralign = 1;
+
+  std::memcpy(image.data() + shoff, shdrs.data(), shdrs.size() * sizeof(Elf64_Shdr));
+  return image;
+}
+
+} // namespace rocjitsu::fuzzer::afl::test

--- a/emulation/rocjitsu/fuzzer/afl-dbi/tests/minimal_amdgpu_elf.h
+++ b/emulation/rocjitsu/fuzzer/afl-dbi/tests/minimal_amdgpu_elf.h
@@ -11,6 +11,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <string_view>
 #include <vector>
 
 namespace rocjitsu::fuzzer::afl::test {
@@ -24,10 +25,10 @@ inline constexpr uint64_t kMinimalAmdGpuElfKernelEntryOffset = kMinimalAmdGpuElf
 
 namespace detail {
 
-inline uint32_t add_elf_name(std::vector<uint8_t> &table, const char *name) {
+inline uint32_t add_elf_name(std::vector<uint8_t> &table, std::string_view name) {
   const uint32_t offset = static_cast<uint32_t>(table.size());
-  const auto *bytes = reinterpret_cast<const uint8_t *>(name);
-  table.insert(table.end(), bytes, bytes + std::strlen(name) + 1);
+  table.insert(table.end(), name.begin(), name.end());
+  table.push_back('\0');
   return offset;
 }
 

--- a/emulation/rocjitsu/fuzzer/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/fuzzer/tests/CMakeLists.txt
@@ -187,6 +187,9 @@ else()
     set(RJ_FUZZ_TWO_VECTOR_ADD_PERSISTENT_OUTPUT_DIR
         "${CMAKE_CURRENT_BINARY_DIR}/two_vector_add_persistent_findings"
     )
+    set(RJ_FUZZ_TWO_VECTOR_ADD_PRELOAD_SMOKE_BIN
+        "${CMAKE_CURRENT_BINARY_DIR}/bin/two_vector_add_preload_smoke"
+    )
     set(RJ_FUZZ_TWO_VECTOR_ADD_LIBRARY_PATH
         "${RJ_HIPRTC_LIBRARY_DIR}:${RJ_HIP_RUNTIME_LIBRARY_DIR}:$ENV{LD_LIBRARY_PATH}"
     )
@@ -224,6 +227,29 @@ else()
         DEPENDS "${RJ_FUZZ_TWO_VECTOR_ADD_BIN}"
     )
 
+    add_executable(
+        two_vector_add_preload_smoke
+        two_vector_add_preload_smoke.cpp
+    )
+    target_include_directories(
+        two_vector_add_preload_smoke
+        PRIVATE
+            "${CMAKE_SOURCE_DIR}/fuzzer/afl-dbi/include"
+            "${RJ_HIP_INCLUDE_DIR}"
+    )
+    target_compile_definitions(
+        two_vector_add_preload_smoke
+        PRIVATE __HIP_PLATFORM_AMD__
+    )
+    target_link_libraries(
+        two_vector_add_preload_smoke
+        PRIVATE ${RJ_HIP_RUNTIME_LIBRARY}
+    )
+    set_target_properties(
+        two_vector_add_preload_smoke
+        PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bin"
+    )
+
     add_custom_command(
         OUTPUT "${RJ_FUZZ_TWO_VECTOR_ADD_PERSISTENT_BIN}"
         COMMAND
@@ -252,6 +278,11 @@ else()
         "${CMAKE_CURRENT_BINARY_DIR}/run_two_vector_add_afl_persistent.cmake"
         @ONLY
     )
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/run_two_vector_add_preload_smoke.cmake.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/run_two_vector_add_preload_smoke.cmake"
+        @ONLY
+    )
 
     add_test(
         NAME "RocFuzz.TwoVectorAddAFL"
@@ -268,6 +299,16 @@ else()
     )
     set_tests_properties(
         "RocFuzz.TwoVectorAddAFL.Persistent"
+        PROPERTIES TIMEOUT 60
+    )
+    add_test(
+        NAME "RocFuzz.TwoVectorAddAFL.Preload"
+        COMMAND
+            ${CMAKE_COMMAND} -P
+            "${CMAKE_CURRENT_BINARY_DIR}/run_two_vector_add_preload_smoke.cmake"
+    )
+    set_tests_properties(
+        "RocFuzz.TwoVectorAddAFL.Preload"
         PROPERTIES TIMEOUT 60
     )
 endif()

--- a/emulation/rocjitsu/fuzzer/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/fuzzer/tests/CMakeLists.txt
@@ -23,7 +23,6 @@ find_program(
     HINTS "${RJ_AFL_ROOT}"
     PATH_SUFFIXES . bin
 )
-
 if(NOT RJ_AFL_CXX_EXECUTABLE OR NOT RJ_AFL_FUZZ_EXECUTABLE)
     message(
         STATUS
@@ -31,6 +30,10 @@ if(NOT RJ_AFL_CXX_EXECUTABLE OR NOT RJ_AFL_FUZZ_EXECUTABLE)
     )
     return()
 endif()
+
+set(RJ_AFL_PRELOAD_LIBRARY
+    "${CMAKE_BINARY_DIR}/fuzzer/afl-dbi/librocjitsu_afl_preload.so"
+)
 
 set(RJ_FUZZ_HELLO_WORLD_BIN "${CMAKE_CURRENT_BINARY_DIR}/bin/hello_world_afl")
 set(RJ_FUZZ_HELLO_WORLD_PERSISTENT_BIN
@@ -184,8 +187,11 @@ else()
     set(RJ_FUZZ_TWO_VECTOR_ADD_PERSISTENT_OUTPUT_DIR
         "${CMAKE_CURRENT_BINARY_DIR}/two_vector_add_persistent_findings"
     )
+    set(RJ_FUZZ_TWO_VECTOR_ADD_LIBRARY_PATH
+        "${RJ_HIPRTC_LIBRARY_DIR}:${RJ_HIP_RUNTIME_LIBRARY_DIR}:$ENV{LD_LIBRARY_PATH}"
+    )
     set(RJ_FUZZ_TWO_VECTOR_ADD_ENV
-        "LD_LIBRARY_PATH=${RJ_HIPRTC_LIBRARY_DIR}:${RJ_HIP_RUNTIME_LIBRARY_DIR}:$ENV{LD_LIBRARY_PATH}"
+        "LD_LIBRARY_PATH=${RJ_FUZZ_TWO_VECTOR_ADD_LIBRARY_PATH}"
     )
     set(RJ_FUZZ_TWO_VECTOR_ADD_COMPILE_FLAGS
         -std=c++20
@@ -197,6 +203,7 @@ else()
         "${RJ_HIP_RUNTIME_LIBRARY}"
         -Wl,-rpath,${RJ_HIPRTC_LIBRARY_DIR}
         -Wl,-rpath,${RJ_HIP_RUNTIME_LIBRARY_DIR}
+        -l${CMAKE_DL_LIBS}
     )
 
     add_custom_command(

--- a/emulation/rocjitsu/fuzzer/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/fuzzer/tests/CMakeLists.txt
@@ -46,6 +46,47 @@ set(RJ_FUZZ_HELLO_WORLD_PERSISTENT_OUTPUT_DIR
     "${CMAKE_CURRENT_BINARY_DIR}/hello_world_persistent_findings"
 )
 
+find_path(
+    RJ_HIP_INCLUDE_DIR
+    NAMES hip/hip_runtime_api.h
+    HINTS
+    ENV ROCM_PATH
+    /opt/rocm
+    PATH_SUFFIXES include
+)
+find_path(
+    RJ_HIPBLASLT_INCLUDE_DIR
+    NAMES hipblaslt/hipblaslt.h
+    HINTS
+    ENV ROCM_PATH
+    /opt/rocm
+    PATH_SUFFIXES include
+)
+find_library(
+    RJ_HIP_RUNTIME_LIBRARY
+    NAMES amdhip64
+    HINTS
+    ENV ROCM_PATH
+    /opt/rocm
+    PATH_SUFFIXES lib lib64
+)
+find_library(
+    RJ_HIPRTC_LIBRARY
+    NAMES hiprtc
+    HINTS
+    ENV ROCM_PATH
+    /opt/rocm
+    PATH_SUFFIXES lib lib64
+)
+find_library(
+    RJ_HIPBLASLT_LIBRARY
+    NAMES hipblaslt
+    HINTS
+    ENV ROCM_PATH
+    /opt/rocm
+    PATH_SUFFIXES lib lib64
+)
+
 file(MAKE_DIRECTORY "${RJ_FUZZ_HELLO_WORLD_INPUT_DIR}")
 file(WRITE "${RJ_FUZZ_HELLO_WORLD_INPUT_DIR}/seed.txt" "hello\n")
 
@@ -106,3 +147,241 @@ add_test(
         "${CMAKE_CURRENT_BINARY_DIR}/run_hello_world_afl_persistent.cmake"
 )
 set_tests_properties("RocFuzz.HelloWorldAFL.Persistent" PROPERTIES TIMEOUT 30)
+
+if(
+    NOT RJ_HIP_INCLUDE_DIR
+    OR NOT RJ_HIP_RUNTIME_LIBRARY
+    OR NOT RJ_HIPRTC_LIBRARY
+)
+    message(
+        STATUS
+        "two-vector-add AFL smoke test disabled (HIP headers/runtime or hiprtc not found)"
+    )
+else()
+    get_filename_component(
+        RJ_HIP_RUNTIME_LIBRARY_DIR
+        "${RJ_HIP_RUNTIME_LIBRARY}"
+        DIRECTORY
+    )
+    get_filename_component(
+        RJ_HIPRTC_LIBRARY_DIR
+        "${RJ_HIPRTC_LIBRARY}"
+        DIRECTORY
+    )
+
+    set(RJ_FUZZ_TWO_VECTOR_ADD_BIN
+        "${CMAKE_CURRENT_BINARY_DIR}/bin/two_vector_add_afl"
+    )
+    set(RJ_FUZZ_TWO_VECTOR_ADD_PERSISTENT_BIN
+        "${CMAKE_CURRENT_BINARY_DIR}/bin/two_vector_add_afl_persistent"
+    )
+    set(RJ_FUZZ_TWO_VECTOR_ADD_INPUT_DIR
+        "${CMAKE_CURRENT_SOURCE_DIR}/seeds/two_vector_add"
+    )
+    set(RJ_FUZZ_TWO_VECTOR_ADD_OUTPUT_DIR
+        "${CMAKE_CURRENT_BINARY_DIR}/two_vector_add_findings"
+    )
+    set(RJ_FUZZ_TWO_VECTOR_ADD_PERSISTENT_OUTPUT_DIR
+        "${CMAKE_CURRENT_BINARY_DIR}/two_vector_add_persistent_findings"
+    )
+    set(RJ_FUZZ_TWO_VECTOR_ADD_ENV
+        "LD_LIBRARY_PATH=${RJ_HIPRTC_LIBRARY_DIR}:${RJ_HIP_RUNTIME_LIBRARY_DIR}:$ENV{LD_LIBRARY_PATH}"
+    )
+    set(RJ_FUZZ_TWO_VECTOR_ADD_COMPILE_FLAGS
+        -std=c++20
+        -D__HIP_PLATFORM_AMD__
+        "-I${CMAKE_CURRENT_SOURCE_DIR}"
+        "-I${RJ_HIP_INCLUDE_DIR}"
+        "${CMAKE_CURRENT_SOURCE_DIR}/two_vector_add_fuzz.cpp"
+        "${RJ_HIPRTC_LIBRARY}"
+        "${RJ_HIP_RUNTIME_LIBRARY}"
+        -Wl,-rpath,${RJ_HIPRTC_LIBRARY_DIR}
+        -Wl,-rpath,${RJ_HIP_RUNTIME_LIBRARY_DIR}
+    )
+
+    add_custom_command(
+        OUTPUT "${RJ_FUZZ_TWO_VECTOR_ADD_BIN}"
+        COMMAND
+            ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/bin"
+        COMMAND
+            ${CMAKE_COMMAND} -E env --unset=AFL_CXX --unset=MAKEFLAGS
+            --unset=MFLAGS "${RJ_AFL_CXX_EXECUTABLE}"
+            ${RJ_FUZZ_TWO_VECTOR_ADD_COMPILE_FLAGS} -o
+            "${RJ_FUZZ_TWO_VECTOR_ADD_BIN}"
+        DEPENDS two_vector_add_fuzz.cpp rj_fuzz_input.h
+        COMMENT "Building AFL-instrumented two-vector-add smoke test"
+        VERBATIM
+    )
+    add_custom_target(
+        two_vector_add_afl
+        DEPENDS "${RJ_FUZZ_TWO_VECTOR_ADD_BIN}"
+    )
+
+    add_custom_command(
+        OUTPUT "${RJ_FUZZ_TWO_VECTOR_ADD_PERSISTENT_BIN}"
+        COMMAND
+            ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/bin"
+        COMMAND
+            ${CMAKE_COMMAND} -E env --unset=AFL_CXX --unset=MAKEFLAGS
+            --unset=MFLAGS "${RJ_AFL_CXX_EXECUTABLE}" -DRJ_AFL_PERSISTENT_MODE
+            ${RJ_FUZZ_TWO_VECTOR_ADD_COMPILE_FLAGS} -o
+            "${RJ_FUZZ_TWO_VECTOR_ADD_PERSISTENT_BIN}"
+        DEPENDS two_vector_add_fuzz.cpp rj_fuzz_input.h
+        COMMENT "Building AFL persistent-mode two-vector-add smoke test"
+        VERBATIM
+    )
+    add_custom_target(
+        two_vector_add_afl_persistent
+        DEPENDS "${RJ_FUZZ_TWO_VECTOR_ADD_PERSISTENT_BIN}"
+    )
+
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/run_two_vector_add_afl.cmake.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/run_two_vector_add_afl.cmake"
+        @ONLY
+    )
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/run_two_vector_add_afl_persistent.cmake.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/run_two_vector_add_afl_persistent.cmake"
+        @ONLY
+    )
+
+    add_test(
+        NAME "RocFuzz.TwoVectorAddAFL"
+        COMMAND
+            ${CMAKE_COMMAND} -P
+            "${CMAKE_CURRENT_BINARY_DIR}/run_two_vector_add_afl.cmake"
+    )
+    set_tests_properties("RocFuzz.TwoVectorAddAFL" PROPERTIES TIMEOUT 60)
+    add_test(
+        NAME "RocFuzz.TwoVectorAddAFL.Persistent"
+        COMMAND
+            ${CMAKE_COMMAND} -P
+            "${CMAKE_CURRENT_BINARY_DIR}/run_two_vector_add_afl_persistent.cmake"
+    )
+    set_tests_properties(
+        "RocFuzz.TwoVectorAddAFL.Persistent"
+        PROPERTIES TIMEOUT 60
+    )
+endif()
+
+if(
+    NOT RJ_HIP_INCLUDE_DIR
+    OR NOT RJ_HIPBLASLT_INCLUDE_DIR
+    OR NOT RJ_HIP_RUNTIME_LIBRARY
+    OR NOT RJ_HIPBLASLT_LIBRARY
+)
+    message(
+        STATUS
+        "hipBLASLt AFL smoke test disabled (HIP or hipBLASLt headers/libraries not found)"
+    )
+    return()
+endif()
+
+get_filename_component(
+    RJ_HIP_RUNTIME_LIBRARY_DIR
+    "${RJ_HIP_RUNTIME_LIBRARY}"
+    DIRECTORY
+)
+get_filename_component(
+    RJ_HIPBLASLT_LIBRARY_DIR
+    "${RJ_HIPBLASLT_LIBRARY}"
+    DIRECTORY
+)
+
+set(RJ_FUZZ_HIPBLASLT_TRANSFORM_BIN
+    "${CMAKE_CURRENT_BINARY_DIR}/bin/hipblaslt_transform_afl"
+)
+set(RJ_FUZZ_HIPBLASLT_TRANSFORM_PERSISTENT_BIN
+    "${CMAKE_CURRENT_BINARY_DIR}/bin/hipblaslt_transform_afl_persistent"
+)
+set(RJ_FUZZ_HIPBLASLT_TRANSFORM_INPUT_DIR
+    "${CMAKE_CURRENT_SOURCE_DIR}/seeds/hipblaslt_transform"
+)
+set(RJ_FUZZ_HIPBLASLT_TRANSFORM_OUTPUT_DIR
+    "${CMAKE_CURRENT_BINARY_DIR}/hipblaslt_transform_findings"
+)
+set(RJ_FUZZ_HIPBLASLT_TRANSFORM_PERSISTENT_OUTPUT_DIR
+    "${CMAKE_CURRENT_BINARY_DIR}/hipblaslt_transform_persistent_findings"
+)
+
+set(RJ_FUZZ_HIPBLASLT_TRANSFORM_ENV
+    "LD_LIBRARY_PATH=${RJ_HIPBLASLT_LIBRARY_DIR}:${RJ_HIP_RUNTIME_LIBRARY_DIR}:$ENV{LD_LIBRARY_PATH}"
+)
+
+set(RJ_FUZZ_HIPBLASLT_TRANSFORM_COMPILE_FLAGS
+    -std=c++20
+    -D__HIP_PLATFORM_AMD__
+    "-I${CMAKE_CURRENT_SOURCE_DIR}"
+    "-I${RJ_HIP_INCLUDE_DIR}"
+    "-I${RJ_HIPBLASLT_INCLUDE_DIR}"
+    "${CMAKE_CURRENT_SOURCE_DIR}/hipblaslt_transform_fuzz.cpp"
+    "${RJ_HIPBLASLT_LIBRARY}"
+    "${RJ_HIP_RUNTIME_LIBRARY}"
+    -Wl,-rpath,${RJ_HIPBLASLT_LIBRARY_DIR}
+    -Wl,-rpath,${RJ_HIP_RUNTIME_LIBRARY_DIR}
+)
+
+add_custom_command(
+    OUTPUT "${RJ_FUZZ_HIPBLASLT_TRANSFORM_BIN}"
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/bin"
+    COMMAND
+        ${CMAKE_COMMAND} -E env --unset=AFL_CXX --unset=MAKEFLAGS --unset=MFLAGS
+        "${RJ_AFL_CXX_EXECUTABLE}" ${RJ_FUZZ_HIPBLASLT_TRANSFORM_COMPILE_FLAGS}
+        -o "${RJ_FUZZ_HIPBLASLT_TRANSFORM_BIN}"
+    DEPENDS hipblaslt_transform_fuzz.cpp rj_fuzz_input.h
+    COMMENT "Building AFL-instrumented hipBLASLt transform smoke test"
+    VERBATIM
+)
+
+add_custom_target(
+    hipblaslt_transform_afl
+    DEPENDS "${RJ_FUZZ_HIPBLASLT_TRANSFORM_BIN}"
+)
+
+add_custom_command(
+    OUTPUT "${RJ_FUZZ_HIPBLASLT_TRANSFORM_PERSISTENT_BIN}"
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/bin"
+    COMMAND
+        ${CMAKE_COMMAND} -E env --unset=AFL_CXX --unset=MAKEFLAGS --unset=MFLAGS
+        "${RJ_AFL_CXX_EXECUTABLE}" -DRJ_AFL_PERSISTENT_MODE
+        ${RJ_FUZZ_HIPBLASLT_TRANSFORM_COMPILE_FLAGS} -o
+        "${RJ_FUZZ_HIPBLASLT_TRANSFORM_PERSISTENT_BIN}"
+    DEPENDS hipblaslt_transform_fuzz.cpp rj_fuzz_input.h
+    COMMENT "Building AFL persistent-mode hipBLASLt transform smoke test"
+    VERBATIM
+)
+
+add_custom_target(
+    hipblaslt_transform_afl_persistent
+    DEPENDS "${RJ_FUZZ_HIPBLASLT_TRANSFORM_PERSISTENT_BIN}"
+)
+
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/run_hipblaslt_transform_afl.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/run_hipblaslt_transform_afl.cmake"
+    @ONLY
+)
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/run_hipblaslt_transform_afl_persistent.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/run_hipblaslt_transform_afl_persistent.cmake"
+    @ONLY
+)
+
+add_test(
+    NAME "RocFuzz.HipblasLtTransformAFL"
+    COMMAND
+        ${CMAKE_COMMAND} -P
+        "${CMAKE_CURRENT_BINARY_DIR}/run_hipblaslt_transform_afl.cmake"
+)
+set_tests_properties("RocFuzz.HipblasLtTransformAFL" PROPERTIES TIMEOUT 60)
+add_test(
+    NAME "RocFuzz.HipblasLtTransformAFL.Persistent"
+    COMMAND
+        ${CMAKE_COMMAND} -P
+        "${CMAKE_CURRENT_BINARY_DIR}/run_hipblaslt_transform_afl_persistent.cmake"
+)
+set_tests_properties(
+    "RocFuzz.HipblasLtTransformAFL.Persistent"
+    PROPERTIES TIMEOUT 60
+)

--- a/emulation/rocjitsu/fuzzer/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/fuzzer/tests/CMakeLists.txt
@@ -1,0 +1,65 @@
+set(RJ_AFL_ROOT
+    "${PROJECT_SOURCE_DIR}/third_party/AFLplusplus"
+    CACHE PATH
+    "Optional AFL++ checkout used by rocjitsu fuzz tests"
+)
+
+find_program(
+    RJ_AFL_CXX_EXECUTABLE
+    NAMES afl-clang-fast++
+    HINTS "${RJ_AFL_ROOT}"
+    PATH_SUFFIXES . bin
+)
+find_program(
+    RJ_AFL_FUZZ_EXECUTABLE
+    NAMES afl-fuzz
+    HINTS "${RJ_AFL_ROOT}"
+    PATH_SUFFIXES . bin
+)
+
+if(NOT RJ_AFL_CXX_EXECUTABLE OR NOT RJ_AFL_FUZZ_EXECUTABLE)
+    message(
+        STATUS
+        "AFL hello_world smoke test disabled (afl-clang-fast++ or afl-fuzz not found)"
+    )
+    return()
+endif()
+
+set(RJ_FUZZ_HELLO_WORLD_BIN "${CMAKE_CURRENT_BINARY_DIR}/bin/hello_world_afl")
+set(RJ_FUZZ_HELLO_WORLD_INPUT_DIR
+    "${CMAKE_CURRENT_BINARY_DIR}/hello_world_inputs"
+)
+set(RJ_FUZZ_HELLO_WORLD_OUTPUT_DIR
+    "${CMAKE_CURRENT_BINARY_DIR}/hello_world_findings"
+)
+
+file(MAKE_DIRECTORY "${RJ_FUZZ_HELLO_WORLD_INPUT_DIR}")
+file(WRITE "${RJ_FUZZ_HELLO_WORLD_INPUT_DIR}/seed.txt" "hello\n")
+
+add_custom_command(
+    OUTPUT "${RJ_FUZZ_HELLO_WORLD_BIN}"
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/bin"
+    COMMAND
+        ${CMAKE_COMMAND} -E env --unset=AFL_CXX --unset=MAKEFLAGS --unset=MFLAGS
+        "${RJ_AFL_CXX_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/hello_world.cpp"
+        -o "${RJ_FUZZ_HELLO_WORLD_BIN}"
+    DEPENDS hello_world.cpp
+    COMMENT "Building AFL-instrumented hello_world smoke test"
+    VERBATIM
+)
+
+add_custom_target(hello_world_afl DEPENDS "${RJ_FUZZ_HELLO_WORLD_BIN}")
+
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/run_hello_world_afl.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/run_hello_world_afl.cmake"
+    @ONLY
+)
+
+add_test(
+    NAME "RocFuzz.HelloWorldAFL"
+    COMMAND
+        ${CMAKE_COMMAND} -P
+        "${CMAKE_CURRENT_BINARY_DIR}/run_hello_world_afl.cmake"
+)
+set_tests_properties("RocFuzz.HelloWorldAFL" PROPERTIES TIMEOUT 30)

--- a/emulation/rocjitsu/fuzzer/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/fuzzer/tests/CMakeLists.txt
@@ -4,6 +4,13 @@ set(RJ_AFL_ROOT
     "Optional AFL++ checkout used by rocjitsu fuzz tests"
 )
 
+if(RJ_AFL_CXX_EXECUTABLE AND NOT EXISTS "${RJ_AFL_CXX_EXECUTABLE}")
+    unset(RJ_AFL_CXX_EXECUTABLE CACHE)
+endif()
+if(RJ_AFL_FUZZ_EXECUTABLE AND NOT EXISTS "${RJ_AFL_FUZZ_EXECUTABLE}")
+    unset(RJ_AFL_FUZZ_EXECUTABLE CACHE)
+endif()
+
 find_program(
     RJ_AFL_CXX_EXECUTABLE
     NAMES afl-clang-fast++
@@ -26,11 +33,17 @@ if(NOT RJ_AFL_CXX_EXECUTABLE OR NOT RJ_AFL_FUZZ_EXECUTABLE)
 endif()
 
 set(RJ_FUZZ_HELLO_WORLD_BIN "${CMAKE_CURRENT_BINARY_DIR}/bin/hello_world_afl")
+set(RJ_FUZZ_HELLO_WORLD_PERSISTENT_BIN
+    "${CMAKE_CURRENT_BINARY_DIR}/bin/hello_world_afl_persistent"
+)
 set(RJ_FUZZ_HELLO_WORLD_INPUT_DIR
     "${CMAKE_CURRENT_BINARY_DIR}/hello_world_inputs"
 )
 set(RJ_FUZZ_HELLO_WORLD_OUTPUT_DIR
     "${CMAKE_CURRENT_BINARY_DIR}/hello_world_findings"
+)
+set(RJ_FUZZ_HELLO_WORLD_PERSISTENT_OUTPUT_DIR
+    "${CMAKE_CURRENT_BINARY_DIR}/hello_world_persistent_findings"
 )
 
 file(MAKE_DIRECTORY "${RJ_FUZZ_HELLO_WORLD_INPUT_DIR}")
@@ -42,7 +55,7 @@ add_custom_command(
     COMMAND
         ${CMAKE_COMMAND} -E env --unset=AFL_CXX --unset=MAKEFLAGS --unset=MFLAGS
         "${RJ_AFL_CXX_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/hello_world.cpp"
-        -o "${RJ_FUZZ_HELLO_WORLD_BIN}"
+        -std=c++20 -o "${RJ_FUZZ_HELLO_WORLD_BIN}"
     DEPENDS hello_world.cpp
     COMMENT "Building AFL-instrumented hello_world smoke test"
     VERBATIM
@@ -50,9 +63,32 @@ add_custom_command(
 
 add_custom_target(hello_world_afl DEPENDS "${RJ_FUZZ_HELLO_WORLD_BIN}")
 
+add_custom_command(
+    OUTPUT "${RJ_FUZZ_HELLO_WORLD_PERSISTENT_BIN}"
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/bin"
+    COMMAND
+        ${CMAKE_COMMAND} -E env --unset=AFL_CXX --unset=MAKEFLAGS --unset=MFLAGS
+        "${RJ_AFL_CXX_EXECUTABLE}" -DRJ_AFL_PERSISTENT_MODE
+        "${CMAKE_CURRENT_SOURCE_DIR}/hello_world.cpp" -std=c++20 -o
+        "${RJ_FUZZ_HELLO_WORLD_PERSISTENT_BIN}"
+    DEPENDS hello_world.cpp
+    COMMENT "Building AFL persistent-mode hello_world smoke test"
+    VERBATIM
+)
+
+add_custom_target(
+    hello_world_afl_persistent
+    DEPENDS "${RJ_FUZZ_HELLO_WORLD_PERSISTENT_BIN}"
+)
+
 configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/run_hello_world_afl.cmake.in"
     "${CMAKE_CURRENT_BINARY_DIR}/run_hello_world_afl.cmake"
+    @ONLY
+)
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/run_hello_world_afl_persistent.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/run_hello_world_afl_persistent.cmake"
     @ONLY
 )
 
@@ -63,3 +99,10 @@ add_test(
         "${CMAKE_CURRENT_BINARY_DIR}/run_hello_world_afl.cmake"
 )
 set_tests_properties("RocFuzz.HelloWorldAFL" PROPERTIES TIMEOUT 30)
+add_test(
+    NAME "RocFuzz.HelloWorldAFL.Persistent"
+    COMMAND
+        ${CMAKE_COMMAND} -P
+        "${CMAKE_CURRENT_BINARY_DIR}/run_hello_world_afl_persistent.cmake"
+)
+set_tests_properties("RocFuzz.HelloWorldAFL.Persistent" PROPERTIES TIMEOUT 30)

--- a/emulation/rocjitsu/fuzzer/tests/README.md
+++ b/emulation/rocjitsu/fuzzer/tests/README.md
@@ -1,8 +1,9 @@
-# AFL hello_world smoke test
+# AFL smoke tests
 
-This directory contains a small AFL++ smoke test that verifies the AFL compiler
-wrapper and `afl-fuzz` are available. The target is intentionally simple and
-non-crashing so it can run as a short CTest check.
+This directory contains small AFL++ smoke tests that verify the AFL compiler
+wrapper and `afl-fuzz` are available. The hello-world target is intentionally
+simple and non-crashing, while the hipBLASLt transform target exercises a real
+ROCm library entrypoint with bounded inputs.
 
 ## Build AFL++
 
@@ -22,6 +23,10 @@ targets:
 cmake -S emulation/rocjitsu -B build/rocjitsu -G Ninja -DBUILD_TESTING=ON
 cmake --build build/rocjitsu --target hello_world_afl
 cmake --build build/rocjitsu --target hello_world_afl_persistent
+cmake --build build/rocjitsu --target two_vector_add_afl
+cmake --build build/rocjitsu --target two_vector_add_afl_persistent
+cmake --build build/rocjitsu --target hipblaslt_transform_afl
+cmake --build build/rocjitsu --target hipblaslt_transform_afl_persistent
 ```
 
 If AFL++ is built outside the rocjitsu tree, pass its checkout path:
@@ -37,6 +42,10 @@ The compiled binaries are written to:
 ```text
 build/rocjitsu/fuzzer/tests/bin/hello_world_afl
 build/rocjitsu/fuzzer/tests/bin/hello_world_afl_persistent
+build/rocjitsu/fuzzer/tests/bin/two_vector_add_afl
+build/rocjitsu/fuzzer/tests/bin/two_vector_add_afl_persistent
+build/rocjitsu/fuzzer/tests/bin/hipblaslt_transform_afl
+build/rocjitsu/fuzzer/tests/bin/hipblaslt_transform_afl_persistent
 ```
 
 ## Fuzz the test
@@ -76,10 +85,85 @@ afl-fuzz \
   build/rocjitsu/fuzzer/tests/bin/hello_world_afl_persistent
 ```
 
+The two-vector-add target compiles its GPU kernel at runtime with HIPRTC, then
+loads the resulting code object with the HIP module API. This is intentional:
+the host fuzzer must be compiled with AFL++'s compiler wrapper so AFL can
+instrument the fuzz target, which means we cannot build this example as a
+normal `hipcc` translation unit. HIPRTC keeps device compilation separate from
+the AFL-instrumented host binary. This mirrors the direction of future
+rocjitsu dynamic binary translation and instrumentation work, where generated
+or loaded device code can be observed and instrumented after the host harness is
+already under AFL control.
+
+```bash
+rm -rf build/rocjitsu/fuzzer/tests/two_vector_add_findings
+
+AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1 \
+AFL_NO_UI=1 \
+AFL_SKIP_CPUFREQ=1 \
+afl-fuzz \
+  -i emulation/rocjitsu/fuzzer/tests/seeds/two_vector_add \
+  -o build/rocjitsu/fuzzer/tests/two_vector_add_findings \
+  -V 1 -- \
+  build/rocjitsu/fuzzer/tests/bin/two_vector_add_afl
+```
+
+The persistent two-vector-add target uses the same HIPRTC harness with
+`RJ_AFL_PERSISTENT_MODE` defined:
+
+```bash
+rm -rf build/rocjitsu/fuzzer/tests/two_vector_add_persistent_findings
+
+AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1 \
+AFL_NO_UI=1 \
+AFL_SKIP_CPUFREQ=1 \
+afl-fuzz \
+  -i emulation/rocjitsu/fuzzer/tests/seeds/two_vector_add \
+  -o build/rocjitsu/fuzzer/tests/two_vector_add_persistent_findings \
+  -V 1 -- \
+  build/rocjitsu/fuzzer/tests/bin/two_vector_add_afl_persistent
+```
+
+The hipBLASLt transform target interprets AFL input bytes as bounded matrix
+dimensions, transposition flags, leading dimensions, scalar values, and input
+matrix values before calling `hipblasLtMatrixTransform`. It uses the checked-in
+seed corpus:
+
+```bash
+rm -rf build/rocjitsu/fuzzer/tests/hipblaslt_transform_findings
+
+AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1 \
+AFL_NO_UI=1 \
+AFL_SKIP_CPUFREQ=1 \
+afl-fuzz \
+  -i emulation/rocjitsu/fuzzer/tests/seeds/hipblaslt_transform \
+  -o build/rocjitsu/fuzzer/tests/hipblaslt_transform_findings \
+  -V 1 -- \
+  build/rocjitsu/fuzzer/tests/bin/hipblaslt_transform_afl
+```
+
+The persistent hipBLASLt target uses the same harness with
+`RJ_AFL_PERSISTENT_MODE` defined:
+
+```bash
+rm -rf build/rocjitsu/fuzzer/tests/hipblaslt_transform_persistent_findings
+
+AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1 \
+AFL_NO_UI=1 \
+AFL_SKIP_CPUFREQ=1 \
+afl-fuzz \
+  -i emulation/rocjitsu/fuzzer/tests/seeds/hipblaslt_transform \
+  -o build/rocjitsu/fuzzer/tests/hipblaslt_transform_persistent_findings \
+  -V 1 -- \
+  build/rocjitsu/fuzzer/tests/bin/hipblaslt_transform_afl_persistent
+```
+
 CTest runs the same flow with:
 
 ```bash
 ctest --test-dir build/rocjitsu -R RocFuzz.HelloWorldAFL -V
+ctest --test-dir build/rocjitsu -R RocFuzz.TwoVectorAddAFL -V
+ctest --test-dir build/rocjitsu -R RocFuzz.HipblasLtTransformAFL -V
 ```
 
 ## Read AFL output
@@ -89,6 +173,10 @@ AFL++ writes findings under the output directory:
 ```text
 build/rocjitsu/fuzzer/tests/hello_world_findings/default/
 build/rocjitsu/fuzzer/tests/hello_world_persistent_findings/default/
+build/rocjitsu/fuzzer/tests/two_vector_add_findings/default/
+build/rocjitsu/fuzzer/tests/two_vector_add_persistent_findings/default/
+build/rocjitsu/fuzzer/tests/hipblaslt_transform_findings/default/
+build/rocjitsu/fuzzer/tests/hipblaslt_transform_persistent_findings/default/
 ```
 
 Useful files and directories:

--- a/emulation/rocjitsu/fuzzer/tests/README.md
+++ b/emulation/rocjitsu/fuzzer/tests/README.md
@@ -15,22 +15,34 @@ make -C emulation/rocjitsu/third_party/AFLplusplus source-only
 
 ## Compile the test
 
-Configure rocjitsu with tests enabled, then build the instrumented target:
+Configure rocjitsu with tests enabled, then build one of the instrumented
+targets:
 
 ```bash
 cmake -S emulation/rocjitsu -B build/rocjitsu -G Ninja -DBUILD_TESTING=ON
 cmake --build build/rocjitsu --target hello_world_afl
+cmake --build build/rocjitsu --target hello_world_afl_persistent
 ```
 
-The compiled binary is written to:
+If AFL++ is built outside the rocjitsu tree, pass its checkout path:
+
+```bash
+cmake -S emulation/rocjitsu -B build/rocjitsu -G Ninja \
+  -DBUILD_TESTING=ON \
+  -DRJ_AFL_ROOT=$HOME/code/AFLplusplus
+```
+
+The compiled binaries are written to:
 
 ```text
 build/rocjitsu/fuzzer/tests/bin/hello_world_afl
+build/rocjitsu/fuzzer/tests/bin/hello_world_afl_persistent
 ```
 
 ## Fuzz the test
 
-Create a seed corpus and run AFL++ for a bounded smoke run:
+Create a seed corpus and run AFL++ for a bounded smoke run. The regular target
+reads one input from `stdin` and exits:
 
 ```bash
 mkdir -p build/rocjitsu/fuzzer/tests/hello_world_inputs
@@ -47,6 +59,23 @@ afl-fuzz \
   build/rocjitsu/fuzzer/tests/bin/hello_world_afl
 ```
 
+The persistent target is built from the same source with
+`RJ_AFL_PERSISTENT_MODE` defined. It calls `__AFL_INIT()` once, then processes
+inputs inside `__AFL_LOOP()` using AFL++'s shared testcase buffer:
+
+```bash
+rm -rf build/rocjitsu/fuzzer/tests/hello_world_persistent_findings
+
+AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1 \
+AFL_NO_UI=1 \
+AFL_SKIP_CPUFREQ=1 \
+afl-fuzz \
+  -i build/rocjitsu/fuzzer/tests/hello_world_inputs \
+  -o build/rocjitsu/fuzzer/tests/hello_world_persistent_findings \
+  -V 1 -- \
+  build/rocjitsu/fuzzer/tests/bin/hello_world_afl_persistent
+```
+
 CTest runs the same flow with:
 
 ```bash
@@ -59,6 +88,7 @@ AFL++ writes findings under the output directory:
 
 ```text
 build/rocjitsu/fuzzer/tests/hello_world_findings/default/
+build/rocjitsu/fuzzer/tests/hello_world_persistent_findings/default/
 ```
 
 Useful files and directories:

--- a/emulation/rocjitsu/fuzzer/tests/README.md
+++ b/emulation/rocjitsu/fuzzer/tests/README.md
@@ -166,6 +166,11 @@ ctest --test-dir build/rocjitsu -R RocFuzz.TwoVectorAddAFL -V
 ctest --test-dir build/rocjitsu -R RocFuzz.HipblasLtTransformAFL -V
 ```
 
+The persistent two-vector-add and hipBLASLt CTest runners also build and
+preload `librocjitsu_afl_preload.so`, so those runs exercise
+`rocjitsu_afl_persistent_begin()` and `rocjitsu_afl_persistent_end()`. Manual
+runs can do the same by adding that library to `LD_PRELOAD`.
+
 ## Read AFL output
 
 AFL++ writes findings under the output directory:

--- a/emulation/rocjitsu/fuzzer/tests/README.md
+++ b/emulation/rocjitsu/fuzzer/tests/README.md
@@ -1,0 +1,78 @@
+# AFL hello_world smoke test
+
+This directory contains a small AFL++ smoke test that verifies the AFL compiler
+wrapper and `afl-fuzz` are available. The target is intentionally simple and
+non-crashing so it can run as a short CTest check.
+
+## Build AFL++
+
+If AFL++ is not already installed on `PATH`, build the bundled submodule:
+
+```bash
+git submodule update --init emulation/rocjitsu/third_party/AFLplusplus
+make -C emulation/rocjitsu/third_party/AFLplusplus source-only
+```
+
+## Compile the test
+
+Configure rocjitsu with tests enabled, then build the instrumented target:
+
+```bash
+cmake -S emulation/rocjitsu -B build/rocjitsu -G Ninja -DBUILD_TESTING=ON
+cmake --build build/rocjitsu --target hello_world_afl
+```
+
+The compiled binary is written to:
+
+```text
+build/rocjitsu/fuzzer/tests/bin/hello_world_afl
+```
+
+## Fuzz the test
+
+Create a seed corpus and run AFL++ for a bounded smoke run:
+
+```bash
+mkdir -p build/rocjitsu/fuzzer/tests/hello_world_inputs
+printf 'hello\n' > build/rocjitsu/fuzzer/tests/hello_world_inputs/seed.txt
+rm -rf build/rocjitsu/fuzzer/tests/hello_world_findings
+
+AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1 \
+AFL_NO_UI=1 \
+AFL_SKIP_CPUFREQ=1 \
+afl-fuzz \
+  -i build/rocjitsu/fuzzer/tests/hello_world_inputs \
+  -o build/rocjitsu/fuzzer/tests/hello_world_findings \
+  -V 1 -- \
+  build/rocjitsu/fuzzer/tests/bin/hello_world_afl
+```
+
+CTest runs the same flow with:
+
+```bash
+ctest --test-dir build/rocjitsu -R RocFuzz.HelloWorldAFL -V
+```
+
+## Read AFL output
+
+AFL++ writes findings under the output directory:
+
+```text
+build/rocjitsu/fuzzer/tests/hello_world_findings/default/
+```
+
+Useful files and directories:
+
+- `queue/` contains inputs that reached new coverage. Replay one with
+  `build/rocjitsu/fuzzer/tests/bin/hello_world_afl < path/to/queue/id:...`.
+- `crashes/` contains crashing inputs if the target ever crashes.
+- `hangs/` contains inputs that exceeded AFL's timeout.
+- `fuzzer_stats` contains summary counters such as executions, paths found, and
+  crashes.
+
+For example:
+
+```bash
+sed -n '1,40p' build/rocjitsu/fuzzer/tests/hello_world_findings/default/fuzzer_stats
+ls build/rocjitsu/fuzzer/tests/hello_world_findings/default/queue
+```

--- a/emulation/rocjitsu/fuzzer/tests/hello_world.cpp
+++ b/emulation/rocjitsu/fuzzer/tests/hello_world.cpp
@@ -1,0 +1,18 @@
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+int main() {
+  std::string s;
+  std::getline(std::cin, s);
+
+  if (s == "hello") {
+    std::cout << "Hello, AFL!\n";
+  } else if (s.rfind("rocm", 0) == 0) {
+    std::cout << "Hello, ROCm!\n";
+  } else if (!s.empty()) {
+    std::cout << "Hello, fuzzed input!\n";
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/emulation/rocjitsu/fuzzer/tests/hello_world.cpp
+++ b/emulation/rocjitsu/fuzzer/tests/hello_world.cpp
@@ -1,18 +1,46 @@
 #include <cstdlib>
 #include <iostream>
 #include <string>
+#include <string_view>
 
-int main() {
-  std::string s;
-  std::getline(std::cin, s);
+#ifdef RJ_AFL_PERSISTENT_MODE
+#include <unistd.h>
 
-  if (s == "hello") {
+__AFL_FUZZ_INIT();
+#endif
+
+namespace {
+
+void say_hello(std::string_view input) {
+  while (!input.empty() && (input.back() == '\n' || input.back() == '\r')) {
+    input.remove_suffix(1);
+  }
+
+  if (input == "hello") {
     std::cout << "Hello, AFL!\n";
-  } else if (s.rfind("rocm", 0) == 0) {
+  } else if (input.substr(0, 4) == "rocm") {
     std::cout << "Hello, ROCm!\n";
-  } else if (!s.empty()) {
+  } else if (!input.empty()) {
     std::cout << "Hello, fuzzed input!\n";
   }
+}
+
+} // namespace
+
+int main() {
+#ifdef RJ_AFL_PERSISTENT_MODE
+  __AFL_INIT();
+
+  unsigned char *buffer = __AFL_FUZZ_TESTCASE_BUF;
+  while (__AFL_LOOP(10000)) {
+    const int length = __AFL_FUZZ_TESTCASE_LEN;
+    say_hello(std::string_view(reinterpret_cast<const char *>(buffer), length));
+  }
+#else
+  std::string input;
+  std::getline(std::cin, input);
+  say_hello(input);
+#endif
 
   return EXIT_SUCCESS;
 }

--- a/emulation/rocjitsu/fuzzer/tests/hipblaslt_transform_fuzz.cpp
+++ b/emulation/rocjitsu/fuzzer/tests/hipblaslt_transform_fuzz.cpp
@@ -120,13 +120,17 @@ int run_case(hipblasLtHandle_t handle, const std::vector<uint8_t> &input) {
   const float alpha = stream.next_float();
   const float beta = stream.next_float();
 
+  if (const int rc = rj_fuzz::persistent_iteration_begin(); rc != 0)
+    return rc;
+
   const hipblasStatus_t status = hipblasLtMatrixTransform(
       handle, transform.desc, &alpha, device_a.get(), layout_a.layout, &beta, device_b.get(),
       layout_b.layout, device_c.get(), layout_c.layout, nullptr);
   if (!ok(status))
     return 0;
 
-  rj_fuzz::crash_on_hip_error("hipDeviceSynchronize", hipDeviceSynchronize());
+  if (const int rc = rj_fuzz::persistent_iteration_end(); rc != 0)
+    return rc;
 
   std::vector<float> out(host_c.size());
   rj_fuzz::crash_on_hip_error("hipMemcpy D2H",

--- a/emulation/rocjitsu/fuzzer/tests/hipblaslt_transform_fuzz.cpp
+++ b/emulation/rocjitsu/fuzzer/tests/hipblaslt_transform_fuzz.cpp
@@ -1,0 +1,179 @@
+#include "rj_fuzz_input.h"
+
+#include <hipblaslt/hipblaslt.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+__AFL_FUZZ_INIT();
+
+namespace {
+
+bool ok(hipblasStatus_t status) { return status == HIPBLAS_STATUS_SUCCESS; }
+
+struct HipblasLtHandle {
+  hipblasLtHandle_t handle = nullptr;
+
+  ~HipblasLtHandle() {
+    if (handle != nullptr)
+      (void)hipblasLtDestroy(handle);
+  }
+};
+
+struct TransformDesc {
+  hipblasLtMatrixTransformDesc_t desc = nullptr;
+
+  ~TransformDesc() {
+    if (desc != nullptr)
+      (void)hipblasLtMatrixTransformDescDestroy(desc);
+  }
+};
+
+struct MatrixLayout {
+  hipblasLtMatrixLayout_t layout = nullptr;
+
+  ~MatrixLayout() {
+    if (layout != nullptr)
+      (void)hipblasLtMatrixLayoutDestroy(layout);
+  }
+};
+
+size_t matrix_elements(int leading_dim, int columns) {
+  return static_cast<size_t>(leading_dim) * static_cast<size_t>(columns);
+}
+
+bool create_layout(MatrixLayout &layout, uint64_t rows, uint64_t cols, int64_t ld) {
+  return ok(hipblasLtMatrixLayoutCreate(&layout.layout, HIP_R_32F, rows, cols, ld));
+}
+
+bool configure_transform(TransformDesc &desc, hipblasOperation_t op_a, hipblasOperation_t op_b) {
+  if (!ok(hipblasLtMatrixTransformDescCreate(&desc.desc, HIP_R_32F)))
+    return false;
+
+  const hipblasLtPointerMode_t pointer_mode = HIPBLASLT_POINTER_MODE_HOST;
+  if (!ok(hipblasLtMatrixTransformDescSetAttribute(desc.desc,
+                                                   HIPBLASLT_MATRIX_TRANSFORM_DESC_POINTER_MODE,
+                                                   &pointer_mode, sizeof(pointer_mode))))
+    return false;
+
+  if (!ok(hipblasLtMatrixTransformDescSetAttribute(
+          desc.desc, HIPBLASLT_MATRIX_TRANSFORM_DESC_TRANSA, &op_a, sizeof(op_a))))
+    return false;
+
+  return ok(hipblasLtMatrixTransformDescSetAttribute(
+      desc.desc, HIPBLASLT_MATRIX_TRANSFORM_DESC_TRANSB, &op_b, sizeof(op_b)));
+}
+
+int run_case(hipblasLtHandle_t handle, const std::vector<uint8_t> &input) {
+  using namespace rj_fuzz;
+
+  ByteStream stream(input);
+
+  const int rows = interesting_dim(stream);
+  const int cols = interesting_dim(stream);
+  const bool transpose_a = (stream.next() & 1) != 0;
+  const bool transpose_b = (stream.next() & 1) != 0;
+
+  const int a_rows = transpose_a ? cols : rows;
+  const int a_cols = transpose_a ? rows : cols;
+  const int b_rows = transpose_b ? cols : rows;
+  const int b_cols = transpose_b ? rows : cols;
+  const int lda = a_rows + static_cast<int>(stream.next() & 3);
+  const int ldb = b_rows + static_cast<int>(stream.next() & 3);
+  const int ldc = rows + static_cast<int>(stream.next() & 3);
+
+  std::vector<float> host_a(matrix_elements(lda, a_cols));
+  std::vector<float> host_b(matrix_elements(ldb, b_cols));
+  std::vector<float> host_c(matrix_elements(ldc, cols));
+  fill_floats(host_a, stream);
+  fill_floats(host_b, stream);
+  fill_floats(host_c, stream);
+
+  DeviceBuffer<float> device_a;
+  DeviceBuffer<float> device_b;
+  DeviceBuffer<float> device_c;
+  if (!device_a.allocate(host_a.size()) || !device_b.allocate(host_b.size()) ||
+      !device_c.allocate(host_c.size()))
+    return 0;
+
+  if (!device_a.copy_from_host(host_a) || !device_b.copy_from_host(host_b) ||
+      !device_c.copy_from_host(host_c))
+    return 0;
+
+  MatrixLayout layout_a;
+  MatrixLayout layout_b;
+  MatrixLayout layout_c;
+  if (!create_layout(layout_a, a_rows, a_cols, lda) ||
+      !create_layout(layout_b, b_rows, b_cols, ldb) || !create_layout(layout_c, rows, cols, ldc))
+    return 0;
+
+  const hipblasOperation_t op_a = transpose_a ? HIPBLAS_OP_T : HIPBLAS_OP_N;
+  const hipblasOperation_t op_b = transpose_b ? HIPBLAS_OP_T : HIPBLAS_OP_N;
+  TransformDesc transform;
+  if (!configure_transform(transform, op_a, op_b))
+    return 0;
+
+  const float alpha = stream.next_float();
+  const float beta = stream.next_float();
+
+  const hipblasStatus_t status = hipblasLtMatrixTransform(
+      handle, transform.desc, &alpha, device_a.get(), layout_a.layout, &beta, device_b.get(),
+      layout_b.layout, device_c.get(), layout_c.layout, nullptr);
+  if (!ok(status))
+    return 0;
+
+  rj_fuzz::crash_on_hip_error("hipDeviceSynchronize", hipDeviceSynchronize());
+
+  std::vector<float> out(host_c.size());
+  rj_fuzz::crash_on_hip_error("hipMemcpy D2H",
+                              device_c.copy_to_host(out) ? hipSuccess : hipErrorUnknown);
+
+  volatile float sink = 0.0f;
+  for (size_t i = 0; i < std::min<size_t>(out.size(), 16); ++i)
+    sink += out[i];
+  (void)sink;
+
+  return 0;
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+  if (!rj_fuzz::have_hip_device())
+    return 0;
+
+  HipblasLtHandle handle;
+  if (!ok(hipblasLtCreate(&handle.handle)))
+    return 0;
+
+#ifdef RJ_AFL_PERSISTENT_MODE
+  __AFL_INIT();
+
+#ifdef __AFL_FUZZ_TESTCASE_BUF
+  unsigned char *afl_buf = __AFL_FUZZ_TESTCASE_BUF;
+  while (__AFL_LOOP(1000)) {
+    const size_t len = __AFL_FUZZ_TESTCASE_LEN;
+    std::vector<uint8_t> input(afl_buf, afl_buf + len);
+    const int rc = run_case(handle.handle, input);
+    if (rc != 0)
+      return rc;
+  }
+#else
+  while (__AFL_LOOP(1)) {
+    const int rc = run_case(handle.handle, rj_fuzz::read_input(argc, argv));
+    if (rc != 0)
+      return rc;
+  }
+#endif
+#else
+  const int rc = run_case(handle.handle, rj_fuzz::read_input(argc, argv));
+  if (rc != 0)
+    return rc;
+#endif
+
+  return 0;
+}

--- a/emulation/rocjitsu/fuzzer/tests/rj_fuzz_input.h
+++ b/emulation/rocjitsu/fuzzer/tests/rj_fuzz_input.h
@@ -2,6 +2,8 @@
 
 #include <hip/hip_runtime_api.h>
 
+#include <dlfcn.h>
+
 #include <array>
 #include <cstdint>
 #include <cstdio>
@@ -24,6 +26,11 @@
 #ifndef __AFL_LOOP
 #define __AFL_LOOP(_count) rj_fuzz::fallback_afl_loop_once()
 #endif
+
+extern "C" {
+int rocjitsu_afl_persistent_begin() __attribute__((weak));
+int rocjitsu_afl_persistent_end() __attribute__((weak));
+}
 
 namespace rj_fuzz {
 
@@ -96,6 +103,24 @@ inline void crash_on_hip_error(const char *what, hipError_t status) {
   std::abort();
 }
 
+inline int persistent_iteration_begin() {
+  if (rocjitsu_afl_persistent_begin != nullptr)
+    return rocjitsu_afl_persistent_begin();
+  return 0;
+}
+
+inline int persistent_iteration_end() {
+  if (rocjitsu_afl_persistent_end != nullptr)
+    return rocjitsu_afl_persistent_end();
+
+  const hipError_t status = hipDeviceSynchronize();
+  if (status == hipSuccess)
+    return 0;
+
+  std::fprintf(stderr, "hipDeviceSynchronize failed: %s\n", hipGetErrorString(status));
+  return static_cast<int>(status);
+}
+
 template <typename T> class DeviceBuffer {
 public:
   DeviceBuffer() = default;
@@ -133,6 +158,25 @@ private:
 inline bool have_hip_device() {
   int device_count = 0;
   return hipGetDeviceCount(&device_count) == hipSuccess && device_count > 0;
+}
+
+using PersistentHook = int (*)();
+
+inline PersistentHook load_persistent_hook(const char *name) {
+  return reinterpret_cast<PersistentHook>(dlsym(RTLD_DEFAULT, name));
+}
+
+inline bool persistent_hooks_required() {
+  return std::getenv("ROCJITSU_AFL_REQUIRE_PERSISTENT_HOOKS") != nullptr;
+}
+
+inline int call_persistent_hook(PersistentHook hook, const char *name) {
+  if (hook == nullptr)
+    return 0;
+  const int rc = hook();
+  if (rc != 0)
+    std::fprintf(stderr, "%s failed with rc=%d\n", name, rc);
+  return rc;
 }
 
 } // namespace rj_fuzz

--- a/emulation/rocjitsu/fuzzer/tests/rj_fuzz_input.h
+++ b/emulation/rocjitsu/fuzzer/tests/rj_fuzz_input.h
@@ -1,0 +1,138 @@
+#pragma once
+
+#include <hip/hip_runtime_api.h>
+
+#include <array>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <string>
+#include <utility>
+#include <vector>
+
+#ifndef __AFL_FUZZ_INIT
+#define __AFL_FUZZ_INIT()
+#endif
+
+#ifndef __AFL_INIT
+#define __AFL_INIT() ((void)0)
+#endif
+
+#ifndef __AFL_LOOP
+#define __AFL_LOOP(_count) rj_fuzz::fallback_afl_loop_once()
+#endif
+
+namespace rj_fuzz {
+
+inline bool fallback_afl_loop_once() {
+  static bool done = false;
+  if (done)
+    return false;
+  done = true;
+  return true;
+}
+
+inline std::vector<uint8_t> read_input(int argc, char **argv) {
+  std::vector<uint8_t> bytes;
+  if (argc > 1) {
+    std::ifstream file(argv[1], std::ios::binary);
+    bytes.assign(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>());
+  } else {
+    bytes.assign(std::istreambuf_iterator<char>(std::cin), std::istreambuf_iterator<char>());
+  }
+
+  if (bytes.empty())
+    bytes = {0, 1, 2, 3, 5, 8, 13, 21};
+  return bytes;
+}
+
+class ByteStream {
+public:
+  explicit ByteStream(std::vector<uint8_t> bytes) : bytes_(std::move(bytes)) {
+    if (bytes_.empty())
+      bytes_ = {0, 1, 2, 3, 5, 8, 13, 21};
+  }
+
+  uint8_t next() {
+    const uint8_t value = bytes_[offset_ % bytes_.size()];
+    ++offset_;
+    return value;
+  }
+
+  template <typename T, size_t N> T pick(const std::array<T, N> &values) {
+    return values[next() % values.size()];
+  }
+
+  float next_float() {
+    static constexpr std::array<float, 16> kInterestingValues = {
+        -4.0f, -2.0f, -1.0f, -0.5f, -0.0f, 0.0f,   0.125f, 0.5f,
+        1.0f,  2.0f,  4.0f,  8.0f,  16.0f, -16.0f, 0.25f,  -0.25f};
+    return pick(kInterestingValues);
+  }
+
+private:
+  std::vector<uint8_t> bytes_;
+  size_t offset_ = 0;
+};
+
+inline int interesting_dim(ByteStream &stream) {
+  static constexpr std::array<int, 20> kDims = {1,  2,  3,  4,  5,  7,  8,  15, 16,  17,
+                                                31, 32, 33, 48, 63, 64, 65, 96, 127, 128};
+  return stream.pick(kDims);
+}
+
+inline void fill_floats(std::vector<float> &values, ByteStream &stream) {
+  for (float &value : values)
+    value = stream.next_float();
+}
+
+inline void crash_on_hip_error(const char *what, hipError_t status) {
+  if (status == hipSuccess)
+    return;
+  std::fprintf(stderr, "%s failed: %s\n", what, hipGetErrorString(status));
+  std::abort();
+}
+
+template <typename T> class DeviceBuffer {
+public:
+  DeviceBuffer() = default;
+  DeviceBuffer(const DeviceBuffer &) = delete;
+  DeviceBuffer &operator=(const DeviceBuffer &) = delete;
+
+  ~DeviceBuffer() {
+    if (data_ != nullptr)
+      (void)hipFree(data_);
+  }
+
+  bool allocate(size_t count) {
+    count_ = count;
+    return hipMalloc(reinterpret_cast<void **>(&data_), sizeof(T) * count_) == hipSuccess;
+  }
+
+  bool copy_from_host(const std::vector<T> &host) {
+    return hipMemcpy(data_, host.data(), sizeof(T) * host.size(), hipMemcpyHostToDevice) ==
+           hipSuccess;
+  }
+
+  bool copy_to_host(std::vector<T> &host) const {
+    return hipMemcpy(host.data(), data_, sizeof(T) * host.size(), hipMemcpyDeviceToHost) ==
+           hipSuccess;
+  }
+
+  T *get() const { return data_; }
+  size_t count() const { return count_; }
+
+private:
+  T *data_ = nullptr;
+  size_t count_ = 0;
+};
+
+inline bool have_hip_device() {
+  int device_count = 0;
+  return hipGetDeviceCount(&device_count) == hipSuccess && device_count > 0;
+}
+
+} // namespace rj_fuzz

--- a/emulation/rocjitsu/fuzzer/tests/run_hello_world_afl.cmake.in
+++ b/emulation/rocjitsu/fuzzer/tests/run_hello_world_afl.cmake.in
@@ -1,0 +1,27 @@
+execute_process(
+    COMMAND "@CMAKE_COMMAND@" --build "@CMAKE_BINARY_DIR@" --target hello_world_afl
+    RESULT_VARIABLE _rj_afl_build_result
+)
+
+if(NOT _rj_afl_build_result EQUAL 0)
+    message(
+        FATAL_ERROR
+        "hello_world AFL build failed: ${_rj_afl_build_result}"
+    )
+endif()
+
+file(REMOVE_RECURSE "@RJ_FUZZ_HELLO_WORLD_OUTPUT_DIR@")
+
+execute_process(
+    COMMAND
+        "@CMAKE_COMMAND@" -E env AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1
+        AFL_NO_UI=1 AFL_SKIP_CPUFREQ=1 "@RJ_AFL_FUZZ_EXECUTABLE@" -i
+        "@RJ_FUZZ_HELLO_WORLD_INPUT_DIR@" -o
+        "@RJ_FUZZ_HELLO_WORLD_OUTPUT_DIR@" -V 1 --
+        "@RJ_FUZZ_HELLO_WORLD_BIN@"
+    RESULT_VARIABLE _rj_afl_result
+)
+
+if(NOT _rj_afl_result EQUAL 0)
+    message(FATAL_ERROR "hello_world AFL smoke test failed: ${_rj_afl_result}")
+endif()

--- a/emulation/rocjitsu/fuzzer/tests/run_hello_world_afl_persistent.cmake.in
+++ b/emulation/rocjitsu/fuzzer/tests/run_hello_world_afl_persistent.cmake.in
@@ -1,0 +1,32 @@
+execute_process(
+    COMMAND
+        "@CMAKE_COMMAND@" --build "@CMAKE_BINARY_DIR@" --target
+        hello_world_afl_persistent
+    RESULT_VARIABLE _rj_afl_build_result
+)
+
+if(NOT _rj_afl_build_result EQUAL 0)
+    message(
+        FATAL_ERROR
+        "hello_world persistent AFL build failed: ${_rj_afl_build_result}"
+    )
+endif()
+
+file(REMOVE_RECURSE "@RJ_FUZZ_HELLO_WORLD_PERSISTENT_OUTPUT_DIR@")
+
+execute_process(
+    COMMAND
+        "@CMAKE_COMMAND@" -E env AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1
+        AFL_NO_UI=1 AFL_SKIP_CPUFREQ=1 "@RJ_AFL_FUZZ_EXECUTABLE@" -i
+        "@RJ_FUZZ_HELLO_WORLD_INPUT_DIR@" -o
+        "@RJ_FUZZ_HELLO_WORLD_PERSISTENT_OUTPUT_DIR@" -V 1 --
+        "@RJ_FUZZ_HELLO_WORLD_PERSISTENT_BIN@"
+    RESULT_VARIABLE _rj_afl_result
+)
+
+if(NOT _rj_afl_result EQUAL 0)
+    message(
+        FATAL_ERROR
+        "hello_world persistent AFL smoke test failed: ${_rj_afl_result}"
+    )
+endif()

--- a/emulation/rocjitsu/fuzzer/tests/run_hipblaslt_transform_afl.cmake.in
+++ b/emulation/rocjitsu/fuzzer/tests/run_hipblaslt_transform_afl.cmake.in
@@ -1,0 +1,33 @@
+execute_process(
+    COMMAND
+        "@CMAKE_COMMAND@" --build "@CMAKE_BINARY_DIR@" --target
+        hipblaslt_transform_afl
+    RESULT_VARIABLE _rj_afl_build_result
+)
+
+if(NOT _rj_afl_build_result EQUAL 0)
+    message(
+        FATAL_ERROR
+        "hipBLASLt transform AFL build failed: ${_rj_afl_build_result}"
+    )
+endif()
+
+file(REMOVE_RECURSE "@RJ_FUZZ_HIPBLASLT_TRANSFORM_OUTPUT_DIR@")
+
+execute_process(
+    COMMAND
+        "@CMAKE_COMMAND@" -E env @RJ_FUZZ_HIPBLASLT_TRANSFORM_ENV@
+        AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1 AFL_NO_UI=1
+        AFL_SKIP_CPUFREQ=1 "@RJ_AFL_FUZZ_EXECUTABLE@" -i
+        "@RJ_FUZZ_HIPBLASLT_TRANSFORM_INPUT_DIR@" -o
+        "@RJ_FUZZ_HIPBLASLT_TRANSFORM_OUTPUT_DIR@" -V 1 --
+        "@RJ_FUZZ_HIPBLASLT_TRANSFORM_BIN@"
+    RESULT_VARIABLE _rj_afl_result
+)
+
+if(NOT _rj_afl_result EQUAL 0)
+    message(
+        FATAL_ERROR
+        "hipBLASLt transform AFL smoke test failed: ${_rj_afl_result}"
+    )
+endif()

--- a/emulation/rocjitsu/fuzzer/tests/run_hipblaslt_transform_afl_persistent.cmake.in
+++ b/emulation/rocjitsu/fuzzer/tests/run_hipblaslt_transform_afl_persistent.cmake.in
@@ -12,11 +12,25 @@ if(NOT _rj_afl_build_result EQUAL 0)
     )
 endif()
 
+execute_process(
+    COMMAND "@CMAKE_COMMAND@" --build "@CMAKE_BINARY_DIR@" --target
+            rocjitsu_afl_preload
+    RESULT_VARIABLE _rj_afl_preload_build_result
+)
+
+if(NOT _rj_afl_preload_build_result EQUAL 0)
+    message(
+        FATAL_ERROR
+        "rocjitsu AFL preload build failed: ${_rj_afl_preload_build_result}"
+    )
+endif()
+
 file(REMOVE_RECURSE "@RJ_FUZZ_HIPBLASLT_TRANSFORM_PERSISTENT_OUTPUT_DIR@")
 
 execute_process(
     COMMAND
         "@CMAKE_COMMAND@" -E env @RJ_FUZZ_HIPBLASLT_TRANSFORM_ENV@
+        LD_PRELOAD="@RJ_AFL_PRELOAD_LIBRARY@:$ENV{LD_PRELOAD}"
         AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1 AFL_NO_UI=1
         AFL_SKIP_CPUFREQ=1 "@RJ_AFL_FUZZ_EXECUTABLE@" -i
         "@RJ_FUZZ_HIPBLASLT_TRANSFORM_INPUT_DIR@" -o

--- a/emulation/rocjitsu/fuzzer/tests/run_hipblaslt_transform_afl_persistent.cmake.in
+++ b/emulation/rocjitsu/fuzzer/tests/run_hipblaslt_transform_afl_persistent.cmake.in
@@ -1,0 +1,33 @@
+execute_process(
+    COMMAND
+        "@CMAKE_COMMAND@" --build "@CMAKE_BINARY_DIR@" --target
+        hipblaslt_transform_afl_persistent
+    RESULT_VARIABLE _rj_afl_build_result
+)
+
+if(NOT _rj_afl_build_result EQUAL 0)
+    message(
+        FATAL_ERROR
+        "hipBLASLt transform persistent AFL build failed: ${_rj_afl_build_result}"
+    )
+endif()
+
+file(REMOVE_RECURSE "@RJ_FUZZ_HIPBLASLT_TRANSFORM_PERSISTENT_OUTPUT_DIR@")
+
+execute_process(
+    COMMAND
+        "@CMAKE_COMMAND@" -E env @RJ_FUZZ_HIPBLASLT_TRANSFORM_ENV@
+        AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1 AFL_NO_UI=1
+        AFL_SKIP_CPUFREQ=1 "@RJ_AFL_FUZZ_EXECUTABLE@" -i
+        "@RJ_FUZZ_HIPBLASLT_TRANSFORM_INPUT_DIR@" -o
+        "@RJ_FUZZ_HIPBLASLT_TRANSFORM_PERSISTENT_OUTPUT_DIR@" -V 1 --
+        "@RJ_FUZZ_HIPBLASLT_TRANSFORM_PERSISTENT_BIN@"
+    RESULT_VARIABLE _rj_afl_result
+)
+
+if(NOT _rj_afl_result EQUAL 0)
+    message(
+        FATAL_ERROR
+        "hipBLASLt transform persistent AFL smoke test failed: ${_rj_afl_result}"
+    )
+endif()

--- a/emulation/rocjitsu/fuzzer/tests/run_two_vector_add_afl.cmake.in
+++ b/emulation/rocjitsu/fuzzer/tests/run_two_vector_add_afl.cmake.in
@@ -1,0 +1,26 @@
+execute_process(
+    COMMAND "@CMAKE_COMMAND@" --build "@CMAKE_BINARY_DIR@" --target
+            two_vector_add_afl
+    RESULT_VARIABLE _rj_afl_build_result
+)
+
+if(NOT _rj_afl_build_result EQUAL 0)
+    message(FATAL_ERROR "two-vector-add AFL build failed: ${_rj_afl_build_result}")
+endif()
+
+file(REMOVE_RECURSE "@RJ_FUZZ_TWO_VECTOR_ADD_OUTPUT_DIR@")
+
+execute_process(
+    COMMAND
+        "@CMAKE_COMMAND@" -E env @RJ_FUZZ_TWO_VECTOR_ADD_ENV@
+        AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1 AFL_NO_UI=1
+        AFL_SKIP_CPUFREQ=1 "@RJ_AFL_FUZZ_EXECUTABLE@" -i
+        "@RJ_FUZZ_TWO_VECTOR_ADD_INPUT_DIR@" -o
+        "@RJ_FUZZ_TWO_VECTOR_ADD_OUTPUT_DIR@" -V 1 --
+        "@RJ_FUZZ_TWO_VECTOR_ADD_BIN@"
+    RESULT_VARIABLE _rj_afl_result
+)
+
+if(NOT _rj_afl_result EQUAL 0)
+    message(FATAL_ERROR "two-vector-add AFL smoke test failed: ${_rj_afl_result}")
+endif()

--- a/emulation/rocjitsu/fuzzer/tests/run_two_vector_add_afl_persistent.cmake.in
+++ b/emulation/rocjitsu/fuzzer/tests/run_two_vector_add_afl_persistent.cmake.in
@@ -11,11 +11,25 @@ if(NOT _rj_afl_build_result EQUAL 0)
     )
 endif()
 
+execute_process(
+    COMMAND "@CMAKE_COMMAND@" --build "@CMAKE_BINARY_DIR@" --target
+            rocjitsu_afl_preload
+    RESULT_VARIABLE _rj_afl_preload_build_result
+)
+
+if(NOT _rj_afl_preload_build_result EQUAL 0)
+    message(
+        FATAL_ERROR
+        "rocjitsu AFL preload build failed: ${_rj_afl_preload_build_result}"
+    )
+endif()
+
 file(REMOVE_RECURSE "@RJ_FUZZ_TWO_VECTOR_ADD_PERSISTENT_OUTPUT_DIR@")
 
 execute_process(
     COMMAND
         "@CMAKE_COMMAND@" -E env @RJ_FUZZ_TWO_VECTOR_ADD_ENV@
+        LD_PRELOAD="@RJ_AFL_PRELOAD_LIBRARY@:$ENV{LD_PRELOAD}"
         AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1 AFL_NO_UI=1
         AFL_SKIP_CPUFREQ=1 "@RJ_AFL_FUZZ_EXECUTABLE@" -i
         "@RJ_FUZZ_TWO_VECTOR_ADD_INPUT_DIR@" -o

--- a/emulation/rocjitsu/fuzzer/tests/run_two_vector_add_afl_persistent.cmake.in
+++ b/emulation/rocjitsu/fuzzer/tests/run_two_vector_add_afl_persistent.cmake.in
@@ -1,0 +1,32 @@
+execute_process(
+    COMMAND "@CMAKE_COMMAND@" --build "@CMAKE_BINARY_DIR@" --target
+            two_vector_add_afl_persistent
+    RESULT_VARIABLE _rj_afl_build_result
+)
+
+if(NOT _rj_afl_build_result EQUAL 0)
+    message(
+        FATAL_ERROR
+        "two-vector-add persistent AFL build failed: ${_rj_afl_build_result}"
+    )
+endif()
+
+file(REMOVE_RECURSE "@RJ_FUZZ_TWO_VECTOR_ADD_PERSISTENT_OUTPUT_DIR@")
+
+execute_process(
+    COMMAND
+        "@CMAKE_COMMAND@" -E env @RJ_FUZZ_TWO_VECTOR_ADD_ENV@
+        AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1 AFL_NO_UI=1
+        AFL_SKIP_CPUFREQ=1 "@RJ_AFL_FUZZ_EXECUTABLE@" -i
+        "@RJ_FUZZ_TWO_VECTOR_ADD_INPUT_DIR@" -o
+        "@RJ_FUZZ_TWO_VECTOR_ADD_PERSISTENT_OUTPUT_DIR@" -V 1 --
+        "@RJ_FUZZ_TWO_VECTOR_ADD_PERSISTENT_BIN@"
+    RESULT_VARIABLE _rj_afl_result
+)
+
+if(NOT _rj_afl_result EQUAL 0)
+    message(
+        FATAL_ERROR
+        "two-vector-add persistent AFL smoke test failed: ${_rj_afl_result}"
+    )
+endif()

--- a/emulation/rocjitsu/fuzzer/tests/run_two_vector_add_preload_smoke.cmake.in
+++ b/emulation/rocjitsu/fuzzer/tests/run_two_vector_add_preload_smoke.cmake.in
@@ -1,0 +1,28 @@
+execute_process(
+    COMMAND "@CMAKE_COMMAND@" --build "@CMAKE_BINARY_DIR@" --target
+            two_vector_add_afl
+            rocjitsu_afl_preload
+            two_vector_add_preload_smoke
+    RESULT_VARIABLE _rj_build_result
+)
+
+if(NOT _rj_build_result EQUAL 0)
+    message(FATAL_ERROR "two-vector-add preload smoke build failed: ${_rj_build_result}")
+endif()
+
+execute_process(
+    COMMAND
+        "@RJ_FUZZ_TWO_VECTOR_ADD_PRELOAD_SMOKE_BIN@"
+        "@RJ_FUZZ_TWO_VECTOR_ADD_BIN@"
+        "@RJ_AFL_PRELOAD_LIBRARY@"
+        "@RJ_FUZZ_TWO_VECTOR_ADD_INPUT_DIR@/seed0"
+        "@RJ_FUZZ_TWO_VECTOR_ADD_LIBRARY_PATH@"
+    RESULT_VARIABLE _rj_preload_smoke_result
+)
+
+if(NOT _rj_preload_smoke_result EQUAL 0)
+    message(
+        FATAL_ERROR
+        "two-vector-add preload smoke failed: ${_rj_preload_smoke_result}"
+    )
+endif()

--- a/emulation/rocjitsu/fuzzer/tests/seeds/hipblaslt_transform/seed0
+++ b/emulation/rocjitsu/fuzzer/tests/seeds/hipblaslt_transform/seed0
@@ -1,0 +1,1 @@
+hipblaslt-transform-seed-0001

--- a/emulation/rocjitsu/fuzzer/tests/seeds/two_vector_add/seed0
+++ b/emulation/rocjitsu/fuzzer/tests/seeds/two_vector_add/seed0
@@ -1,0 +1,1 @@
+two-vector-add-seed-0001

--- a/emulation/rocjitsu/fuzzer/tests/two_vector_add_fuzz.cpp
+++ b/emulation/rocjitsu/fuzzer/tests/two_vector_add_fuzz.cpp
@@ -120,7 +120,8 @@ unsigned interesting_vector_length(rj_fuzz::ByteStream &stream) {
   return stream.pick(kLengths);
 }
 
-int run_case(HipModule &module, const std::vector<uint8_t> &input) {
+int run_case(HipModule &module, const std::vector<uint8_t> &input, rj_fuzz::PersistentHook begin,
+             rj_fuzz::PersistentHook end) {
   using namespace rj_fuzz;
 
   ByteStream stream(input);
@@ -149,6 +150,9 @@ int run_case(HipModule &module, const std::vector<uint8_t> &input) {
       !device_d.copy_from_host(host_d) || !device_e.copy_from_host(host_e))
     return 0;
 
+  if (call_persistent_hook(begin, "rocjitsu_afl_persistent_begin") != 0)
+    return 3;
+
   constexpr unsigned block_size = 128;
   const unsigned grid_size = (n + block_size - 1) / block_size;
   float *a = device_a.get();
@@ -162,7 +166,12 @@ int run_case(HipModule &module, const std::vector<uint8_t> &input) {
                      hipModuleLaunchKernel(module.function, grid_size, 1, 1, block_size, 1, 1, 0,
                                            nullptr, args, nullptr));
 
-  crash_on_hip_error("hipDeviceSynchronize", hipDeviceSynchronize());
+  if (end != nullptr) {
+    if (call_persistent_hook(end, "rocjitsu_afl_persistent_end") != 0)
+      return 3;
+  } else {
+    crash_on_hip_error("hipDeviceSynchronize", hipDeviceSynchronize());
+  }
 
   std::vector<float> host_c(n);
   std::vector<float> host_f(n);
@@ -196,6 +205,13 @@ int main(int argc, char **argv) {
   const std::vector<char> code = compile_kernel();
   HipModule module(code);
 
+  rj_fuzz::PersistentHook begin = rj_fuzz::load_persistent_hook("rocjitsu_afl_persistent_begin");
+  rj_fuzz::PersistentHook end = rj_fuzz::load_persistent_hook("rocjitsu_afl_persistent_end");
+  if (rj_fuzz::persistent_hooks_required() && (begin == nullptr || end == nullptr)) {
+    std::fprintf(stderr, "rocjitsu AFL persistent hooks are not available\n");
+    return 4;
+  }
+
 #ifdef RJ_AFL_PERSISTENT_MODE
   __AFL_INIT();
 
@@ -204,19 +220,19 @@ int main(int argc, char **argv) {
   while (__AFL_LOOP(1000)) {
     const size_t len = __AFL_FUZZ_TESTCASE_LEN;
     std::vector<uint8_t> input(afl_buf, afl_buf + len);
-    const int rc = run_case(module, input);
+    const int rc = run_case(module, input, begin, end);
     if (rc != 0)
       return rc;
   }
 #else
   while (__AFL_LOOP(1)) {
-    const int rc = run_case(module, rj_fuzz::read_input(argc, argv));
+    const int rc = run_case(module, rj_fuzz::read_input(argc, argv), begin, end);
     if (rc != 0)
       return rc;
   }
 #endif
 #else
-  const int rc = run_case(module, rj_fuzz::read_input(argc, argv));
+  const int rc = run_case(module, rj_fuzz::read_input(argc, argv), begin, end);
   if (rc != 0)
     return rc;
 #endif

--- a/emulation/rocjitsu/fuzzer/tests/two_vector_add_fuzz.cpp
+++ b/emulation/rocjitsu/fuzzer/tests/two_vector_add_fuzz.cpp
@@ -1,0 +1,225 @@
+#include "rj_fuzz_input.h"
+
+#include <hip/hip_runtime_api.h>
+#include <hip/hiprtc.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+__AFL_FUZZ_INIT();
+
+namespace {
+
+constexpr const char *kKernelSource = R"(
+extern "C" __global__ void two_vector_add(const float *A,
+                                          const float *B,
+                                          const float *D,
+                                          const float *E,
+                                          float *C,
+                                          float *F,
+                                          unsigned N) {
+  unsigned i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < N) {
+    C[i] = A[i] + B[i];
+    F[i] = D[i] + E[i];
+  }
+}
+)";
+
+bool ok(hiprtcResult status) { return status == HIPRTC_SUCCESS; }
+
+std::string current_device_arch() {
+  int device = 0;
+  rj_fuzz::crash_on_hip_error("hipGetDevice", hipGetDevice(&device));
+
+  hipDeviceProp_t props{};
+  rj_fuzz::crash_on_hip_error("hipGetDeviceProperties", hipGetDeviceProperties(&props, device));
+
+  std::string arch = props.gcnArchName;
+  const size_t feature_delimiter = arch.find(':');
+  if (feature_delimiter != std::string::npos)
+    arch.resize(feature_delimiter);
+  if (arch.empty()) {
+    std::fprintf(stderr, "hipGetDeviceProperties returned an empty gcnArchName\n");
+    std::abort();
+  }
+  return arch;
+}
+
+std::vector<char> compile_kernel() {
+  hiprtcProgram program = nullptr;
+  if (!ok(hiprtcCreateProgram(&program, kKernelSource, "two_vector_add.hip", 0, nullptr,
+                              nullptr))) {
+    std::fprintf(stderr, "hiprtcCreateProgram failed\n");
+    std::abort();
+  }
+
+  const std::string arch_option = "--gpu-architecture=" + current_device_arch();
+  const char *options[] = {arch_option.c_str(), "-O2"};
+  const hiprtcResult compile_status = hiprtcCompileProgram(program, 2, options);
+
+  size_t log_size = 0;
+  (void)hiprtcGetProgramLogSize(program, &log_size);
+  if (log_size > 1) {
+    std::string log(log_size, '\0');
+    (void)hiprtcGetProgramLog(program, log.data());
+    std::fprintf(stderr, "%s\n", log.c_str());
+  }
+
+  if (!ok(compile_status)) {
+    std::fprintf(stderr, "hiprtcCompileProgram failed: %s\n", hiprtcGetErrorString(compile_status));
+    (void)hiprtcDestroyProgram(&program);
+    std::abort();
+  }
+
+  size_t code_size = 0;
+  if (!ok(hiprtcGetCodeSize(program, &code_size)) || code_size == 0) {
+    std::fprintf(stderr, "hiprtcGetCodeSize failed\n");
+    (void)hiprtcDestroyProgram(&program);
+    std::abort();
+  }
+
+  std::vector<char> code(code_size);
+  if (!ok(hiprtcGetCode(program, code.data()))) {
+    std::fprintf(stderr, "hiprtcGetCode failed\n");
+    (void)hiprtcDestroyProgram(&program);
+    std::abort();
+  }
+
+  (void)hiprtcDestroyProgram(&program);
+  return code;
+}
+
+struct HipModule {
+  hipModule_t module = nullptr;
+  hipFunction_t function = nullptr;
+
+  explicit HipModule(const std::vector<char> &code) {
+    rj_fuzz::crash_on_hip_error("hipModuleLoadData", hipModuleLoadData(&module, code.data()));
+    rj_fuzz::crash_on_hip_error("hipModuleGetFunction",
+                                hipModuleGetFunction(&function, module, "two_vector_add"));
+  }
+
+  ~HipModule() {
+    if (module != nullptr)
+      (void)hipModuleUnload(module);
+  }
+};
+
+unsigned interesting_vector_length(rj_fuzz::ByteStream &stream) {
+  static constexpr std::array<unsigned, 14> kLengths = {1,   7,   16,  31,  64,   127,  128,
+                                                        255, 256, 511, 512, 1024, 2048, 4096};
+  return stream.pick(kLengths);
+}
+
+int run_case(HipModule &module, const std::vector<uint8_t> &input) {
+  using namespace rj_fuzz;
+
+  ByteStream stream(input);
+  unsigned n = interesting_vector_length(stream);
+
+  std::vector<float> host_a(n);
+  std::vector<float> host_b(n);
+  std::vector<float> host_d(n);
+  std::vector<float> host_e(n);
+  fill_floats(host_a, stream);
+  fill_floats(host_b, stream);
+  fill_floats(host_d, stream);
+  fill_floats(host_e, stream);
+
+  DeviceBuffer<float> device_a;
+  DeviceBuffer<float> device_b;
+  DeviceBuffer<float> device_c;
+  DeviceBuffer<float> device_d;
+  DeviceBuffer<float> device_e;
+  DeviceBuffer<float> device_f;
+  if (!device_a.allocate(n) || !device_b.allocate(n) || !device_c.allocate(n) ||
+      !device_d.allocate(n) || !device_e.allocate(n) || !device_f.allocate(n))
+    return 0;
+
+  if (!device_a.copy_from_host(host_a) || !device_b.copy_from_host(host_b) ||
+      !device_d.copy_from_host(host_d) || !device_e.copy_from_host(host_e))
+    return 0;
+
+  constexpr unsigned block_size = 128;
+  const unsigned grid_size = (n + block_size - 1) / block_size;
+  float *a = device_a.get();
+  float *b = device_b.get();
+  float *c = device_c.get();
+  float *d = device_d.get();
+  float *e = device_e.get();
+  float *f = device_f.get();
+  void *args[] = {&a, &b, &d, &e, &c, &f, &n};
+  crash_on_hip_error("hipModuleLaunchKernel",
+                     hipModuleLaunchKernel(module.function, grid_size, 1, 1, block_size, 1, 1, 0,
+                                           nullptr, args, nullptr));
+
+  crash_on_hip_error("hipDeviceSynchronize", hipDeviceSynchronize());
+
+  std::vector<float> host_c(n);
+  std::vector<float> host_f(n);
+  crash_on_hip_error("hipMemcpy C D2H",
+                     device_c.copy_to_host(host_c) ? hipSuccess : hipErrorUnknown);
+  crash_on_hip_error("hipMemcpy F D2H",
+                     device_f.copy_to_host(host_f) ? hipSuccess : hipErrorUnknown);
+
+  for (unsigned i = 0; i < n; ++i) {
+    if (std::fabs(host_c[i] - (host_a[i] + host_b[i])) > 1.0e-5f ||
+        std::fabs(host_f[i] - (host_d[i] + host_e[i])) > 1.0e-5f) {
+      std::fprintf(stderr, "two_vector_add mismatch at %u\n", i);
+      std::abort();
+    }
+  }
+
+  volatile float sink = 0.0f;
+  for (size_t i = 0; i < std::min<size_t>(host_c.size(), 16); ++i)
+    sink += host_c[i] + host_f[i];
+  (void)sink;
+
+  return 0;
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+  if (!rj_fuzz::have_hip_device())
+    return 0;
+
+  const std::vector<char> code = compile_kernel();
+  HipModule module(code);
+
+#ifdef RJ_AFL_PERSISTENT_MODE
+  __AFL_INIT();
+
+#ifdef __AFL_FUZZ_TESTCASE_BUF
+  unsigned char *afl_buf = __AFL_FUZZ_TESTCASE_BUF;
+  while (__AFL_LOOP(1000)) {
+    const size_t len = __AFL_FUZZ_TESTCASE_LEN;
+    std::vector<uint8_t> input(afl_buf, afl_buf + len);
+    const int rc = run_case(module, input);
+    if (rc != 0)
+      return rc;
+  }
+#else
+  while (__AFL_LOOP(1)) {
+    const int rc = run_case(module, rj_fuzz::read_input(argc, argv));
+    if (rc != 0)
+      return rc;
+  }
+#endif
+#else
+  const int rc = run_case(module, rj_fuzz::read_input(argc, argv));
+  if (rc != 0)
+    return rc;
+#endif
+
+  return 0;
+}

--- a/emulation/rocjitsu/fuzzer/tests/two_vector_add_preload_smoke.cpp
+++ b/emulation/rocjitsu/fuzzer/tests/two_vector_add_preload_smoke.cpp
@@ -1,0 +1,150 @@
+#include "rocjitsu_fuzzer/afl_runtime.h"
+
+#include <hip/hip_runtime_api.h>
+#include <sys/shm.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+namespace {
+
+using rocjitsu::fuzzer::afl::kDeviceStart;
+using rocjitsu::fuzzer::afl::kEntryCounterSlot;
+using rocjitsu::fuzzer::afl::kMapSize;
+
+bool have_hip_device() {
+  int device_count = 0;
+  return hipGetDeviceCount(&device_count) == hipSuccess && device_count > 0;
+}
+
+void set_env_or_die(const char *name, const std::string &value) {
+  if (setenv(name, value.c_str(), 1) != 0) {
+    std::fprintf(stderr, "setenv(%s) failed: %s\n", name, std::strerror(errno));
+    std::_Exit(127);
+  }
+}
+
+void prepend_env_or_die(const char *name, const std::string &prefix) {
+  const char *existing = std::getenv(name);
+  if (existing == nullptr || existing[0] == '\0') {
+    set_env_or_die(name, prefix);
+    return;
+  }
+  set_env_or_die(name, prefix + ":" + existing);
+}
+
+class SharedAflMap {
+public:
+  SharedAflMap() {
+    id_ = shmget(IPC_PRIVATE, kMapSize, IPC_CREAT | 0600);
+    if (id_ < 0) {
+      std::fprintf(stderr, "shmget failed: %s\n", std::strerror(errno));
+      return;
+    }
+
+    void *attached = shmat(id_, nullptr, 0);
+    if (attached == reinterpret_cast<void *>(-1)) {
+      std::fprintf(stderr, "shmat failed: %s\n", std::strerror(errno));
+      shmctl(id_, IPC_RMID, nullptr);
+      id_ = -1;
+      return;
+    }
+
+    data_ = static_cast<uint8_t *>(attached);
+    std::memset(data_, 0, kMapSize);
+  }
+
+  SharedAflMap(const SharedAflMap &) = delete;
+  SharedAflMap &operator=(const SharedAflMap &) = delete;
+
+  ~SharedAflMap() {
+    if (data_ != nullptr)
+      shmdt(data_);
+    if (id_ >= 0)
+      shmctl(id_, IPC_RMID, nullptr);
+  }
+
+  bool valid() const { return id_ >= 0 && data_ != nullptr; }
+  int id() const { return id_; }
+  const uint8_t *data() const { return data_; }
+
+private:
+  int id_ = -1;
+  uint8_t *data_ = nullptr;
+};
+
+[[noreturn]] void exec_target(const char *target, const char *seed, const char *preload,
+                              const char *library_path, int shm_id) {
+  set_env_or_die("__AFL_SHM_ID", std::to_string(shm_id));
+  set_env_or_die("AFL_MAP_SIZE", std::to_string(kMapSize));
+  set_env_or_die("AFL_QUIET", "1");
+  set_env_or_die("ROCJITSU_AFL_REQUIRE_PERSISTENT_HOOKS", "1");
+  prepend_env_or_die("LD_PRELOAD", preload);
+  prepend_env_or_die("LD_LIBRARY_PATH", library_path);
+
+  char *const argv[] = {const_cast<char *>(target), const_cast<char *>(seed), nullptr};
+  execv(target, argv);
+  std::fprintf(stderr, "execv(%s) failed: %s\n", target, std::strerror(errno));
+  std::_Exit(127);
+}
+
+bool child_succeeded(int status) {
+  if (WIFEXITED(status) && WEXITSTATUS(status) == 0)
+    return true;
+
+  if (WIFEXITED(status)) {
+    std::fprintf(stderr, "two-vector-add preload smoke exited with %d\n", WEXITSTATUS(status));
+  } else if (WIFSIGNALED(status)) {
+    std::fprintf(stderr, "two-vector-add preload smoke died on signal %d\n", WTERMSIG(status));
+  } else {
+    std::fprintf(stderr, "two-vector-add preload smoke ended unexpectedly\n");
+  }
+  return false;
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+  if (argc != 5) {
+    std::fprintf(stderr, "usage: %s <target> <preload> <seed> <ld-library-path>\n", argv[0]);
+    return 2;
+  }
+
+  if (!have_hip_device())
+    return 0;
+
+  SharedAflMap shm;
+  if (!shm.valid())
+    return 1;
+
+  const pid_t pid = fork();
+  if (pid < 0) {
+    std::fprintf(stderr, "fork failed: %s\n", std::strerror(errno));
+    return 1;
+  }
+
+  if (pid == 0)
+    exec_target(argv[1], argv[3], argv[2], argv[4], shm.id());
+
+  int status = 0;
+  if (waitpid(pid, &status, 0) < 0) {
+    std::fprintf(stderr, "waitpid failed: %s\n", std::strerror(errno));
+    return 1;
+  }
+  if (!child_succeeded(status))
+    return 1;
+
+  const uint8_t entry_counter = shm.data()[kDeviceStart + kEntryCounterSlot];
+  if (entry_counter == 0) {
+    std::fprintf(stderr, "preload smoke did not observe device-half AFL feedback\n");
+    return 1;
+  }
+
+  return 0;
+}

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 rj_add_object_library(rocjitsu_code
     amdgpu_code_object.cpp
+    amdgpu_elf_reader.cpp
     basic_block.cpp
     executable.cpp
     file_io.cpp

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/CMakeLists.txt
@@ -7,6 +7,7 @@ rj_add_object_library(rocjitsu_code
     basic_block.cpp
     executable.cpp
     file_io.cpp
+    hsa_code_object_reader_rewriter.cpp
     kernel_symbol.cpp
     rj_code.cpp
     dbt/binary_translator.cpp

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_elf.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_elf.h
@@ -91,6 +91,34 @@ inline constexpr uint32_t elf_mach_for_arch(rj_code_arch_t arch) {
   }
 }
 
+inline constexpr rj_code_arch_t arch_from_elf_flags(uint32_t flags) {
+  switch (flags & EF_AMDGPU_MACH) {
+  case EF_AMDGPU_MACH_AMDGCN_GFX908:
+    return ROCJITSU_CODE_ARCH_CDNA1;
+  case EF_AMDGPU_MACH_AMDGCN_GFX90A:
+  case EF_AMDGPU_MACH_AMDGCN_GFX940:
+  case EF_AMDGPU_MACH_AMDGCN_GFX941:
+    return ROCJITSU_CODE_ARCH_CDNA2;
+  case EF_AMDGPU_MACH_AMDGCN_GFX942:
+    return ROCJITSU_CODE_ARCH_CDNA3;
+  case EF_AMDGPU_MACH_AMDGCN_GFX950:
+    return ROCJITSU_CODE_ARCH_CDNA4;
+  case EF_AMDGPU_MACH_AMDGCN_GFX1010:
+    return ROCJITSU_CODE_ARCH_RDNA1;
+  case EF_AMDGPU_MACH_AMDGCN_GFX1030:
+    return ROCJITSU_CODE_ARCH_RDNA2;
+  case EF_AMDGPU_MACH_AMDGCN_GFX1100:
+    return ROCJITSU_CODE_ARCH_RDNA3;
+  case EF_AMDGPU_MACH_AMDGCN_GFX1150:
+    return ROCJITSU_CODE_ARCH_RDNA3_5;
+  case EF_AMDGPU_MACH_AMDGCN_GFX1200:
+  case EF_AMDGPU_MACH_AMDGCN_GFX1201:
+    return ROCJITSU_CODE_ARCH_RDNA4;
+  default:
+    return ROCJITSU_CODE_ARCH_INVALID;
+  }
+}
+
 inline constexpr uint32_t SHT_NULL = 0;
 inline constexpr uint32_t SHT_PROGBITS = 1;
 inline constexpr uint32_t SHT_SYMTAB = 2;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_elf_reader.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_elf_reader.cpp
@@ -1,0 +1,504 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/code/amdgpu_elf_reader.h"
+
+#include "rocjitsu/code/amdgpu_code_object.h"
+#include "rocjitsu/code/amdgpu_elf.h"
+#include "rocjitsu/code/patch/code_object_patcher.h"
+#include "rocjitsu/code/patch/instruction_builder.h"
+
+#include "hsa/AMDHSAKernelDescriptor.h"
+
+#include <algorithm>
+#include <cstring>
+#include <limits>
+#include <optional>
+#include <string_view>
+
+namespace rocjitsu {
+
+namespace {
+
+using KernelDescriptor = rocr::llvm::amdhsa::kernel_descriptor_t;
+namespace kd = rocr::llvm::amdhsa;
+
+inline constexpr uint16_t kScalarLiteral = 255;
+inline constexpr uint32_t kMaxInlinePositiveImm = 64;
+
+struct EntryCounterProbeRegisters {
+  uint8_t state_sgpr = 20;
+  uint8_t workitem_vgpr = 20;
+  uint8_t tmp0_vgpr = 21;
+};
+
+uint32_t build_v_mov_b32(uint8_t vdst, uint16_t src0) {
+  return (0x3Fu << 25) | (static_cast<uint32_t>(vdst) << 17) | (1u << 9) | (src0 & 0x1FFu);
+}
+
+uint16_t amdgpu_positive_inline_const(uint32_t value) {
+  return static_cast<uint16_t>(rocjitsu::kScalarPositiveInlineBase + value);
+}
+
+bool uses_gfx9_flat_global_encoding(rj_code_arch_t arch) {
+  return arch == ROCJITSU_CODE_ARCH_CDNA2 || arch == ROCJITSU_CODE_ARCH_CDNA3 ||
+         arch == ROCJITSU_CODE_ARCH_CDNA4;
+}
+
+bool uses_gfx10_flat_global_encoding(rj_code_arch_t arch) {
+  return arch == ROCJITSU_CODE_ARCH_RDNA1 || arch == ROCJITSU_CODE_ARCH_RDNA2;
+}
+
+bool uses_gfx11_global_encoding(rj_code_arch_t arch) {
+  return arch == ROCJITSU_CODE_ARCH_RDNA3 || arch == ROCJITSU_CODE_ARCH_RDNA3_5;
+}
+
+bool is_cdna_arch(rj_code_arch_t arch) {
+  return arch == ROCJITSU_CODE_ARCH_CDNA1 || arch == ROCJITSU_CODE_ARCH_CDNA2 ||
+         arch == ROCJITSU_CODE_ARCH_CDNA3 || arch == ROCJITSU_CODE_ARCH_CDNA4;
+}
+
+bool is_rdna_arch(rj_code_arch_t arch) {
+  return arch == ROCJITSU_CODE_ARCH_RDNA1 || arch == ROCJITSU_CODE_ARCH_RDNA2 ||
+         arch == ROCJITSU_CODE_ARCH_RDNA3 || arch == ROCJITSU_CODE_ARCH_RDNA3_5 ||
+         arch == ROCJITSU_CODE_ARCH_RDNA4;
+}
+
+bool uses_gfx9_or_gfx10_waitcnt(rj_code_arch_t arch) {
+  return uses_gfx9_flat_global_encoding(arch) || uses_gfx10_flat_global_encoding(arch);
+}
+
+uint32_t descriptor_vgpr_granularity_for_wavefront(rj_code_arch_t arch, uint32_t wavefront_size) {
+  if (arch == ROCJITSU_CODE_ARCH_CDNA1)
+    return 4;
+  if (is_cdna_arch(arch))
+    return 8;
+  if (is_rdna_arch(arch))
+    return wavefront_size == 32 ? 8 : 4;
+  return 1;
+}
+
+uint32_t granulated_count_to_registers(uint32_t granulated, uint32_t granularity) {
+  return (granulated + 1) * std::max(granularity, 1u);
+}
+
+uint32_t register_count_to_granulated(uint32_t registers, uint32_t granularity) {
+  granularity = std::max(granularity, 1u);
+  if (registers == 0)
+    return 0;
+  return (registers + granularity - 1) / granularity - 1;
+}
+
+void append_s_mov_b64_literal(std::vector<uint32_t> &words, uint8_t sdst_lo, uint64_t value,
+                              rj_code_arch_t arch) {
+  words.push_back(build_s_mov_b32(sdst_lo, kScalarLiteral, arch));
+  words.push_back(static_cast<uint32_t>(value));
+  words.push_back(build_s_mov_b32(static_cast<uint16_t>(sdst_lo + 1), kScalarLiteral, arch));
+  words.push_back(static_cast<uint32_t>(value >> 32));
+}
+
+void append_s_wait_kmcnt(std::vector<uint32_t> &words, rj_code_arch_t arch) {
+  if (uses_gfx9_or_gfx10_waitcnt(arch)) {
+    words.push_back(pack_sopp(/*s_waitcnt=*/12, /*all counters complete=*/0));
+    return;
+  }
+  if (uses_gfx11_global_encoding(arch)) {
+    words.push_back(pack_sopp(/*s_waitcnt=*/9, /*all counters complete=*/0));
+    return;
+  }
+  words.push_back(pack_sopp(/*s_wait_kmcnt=*/0x47, /*imm=*/0));
+}
+
+/// @brief Preserve the mbcnt dependency ordering across supported targets.
+///
+/// Newer targets have s_delay_alu for a precise VALU dependency barrier. Older
+/// flat/global encodings used by the minimal probe do not, so a one-cycle NOP is
+/// enough for this fixed sequence.
+void append_valu_dep_2_barrier(std::vector<uint32_t> &words, rj_code_arch_t arch) {
+  if (uses_gfx9_or_gfx10_waitcnt(arch)) {
+    words.push_back(build_s_nop());
+    return;
+  }
+  words.push_back(build_s_delay_alu(/*VALU_DEP_2=*/2, arch));
+}
+
+/// @brief Emit the counter update for the selected ISA memory encoding.
+///
+/// The entry probe always addresses counter slot 0, so the vector address
+/// register is zero and @p saddr_lo/@p saddr_lo+1 hold the device counter base.
+void append_global_store_u32(std::vector<uint32_t> &words, uint8_t vaddr, uint8_t vdata,
+                             uint8_t saddr_lo, rj_code_arch_t arch) {
+  if (uses_gfx9_flat_global_encoding(arch)) {
+    words.push_back(0xDC708000u);
+    words.push_back((static_cast<uint32_t>(saddr_lo) << 16) | (static_cast<uint32_t>(vdata) << 8) |
+                    vaddr);
+    return;
+  }
+  if (uses_gfx10_flat_global_encoding(arch)) {
+    words.push_back(0xDC708000u);
+    words.push_back((static_cast<uint32_t>(saddr_lo) << 16) | (static_cast<uint32_t>(vdata) << 8) |
+                    vaddr);
+    return;
+  }
+  if (uses_gfx11_global_encoding(arch)) {
+    words.push_back(0xDC6A0000u);
+    words.push_back((static_cast<uint32_t>(saddr_lo) << 16) | (static_cast<uint32_t>(vdata) << 8) |
+                    vaddr);
+    words.push_back(build_s_nop());
+    return;
+  }
+  words.push_back(0xEE068000u | saddr_lo);
+  words.push_back(static_cast<uint32_t>(vdata) << 23);
+  words.push_back(vaddr);
+}
+
+std::optional<EntryCounterProbeRegisters>
+allocate_entry_probe_registers(const KernelDescriptor &desc, rj_code_arch_t arch) {
+  const bool wave32 =
+      is_rdna_arch(arch) && AMDHSA_BITS_GET(desc.kernel_code_properties,
+                                            kd::KERNEL_CODE_PROPERTY_ENABLE_WAVEFRONT_SIZE32) != 0;
+  const uint32_t wavefront_size = wave32 ? 32 : 64;
+  const uint32_t vgpr_granularity = descriptor_vgpr_granularity_for_wavefront(arch, wavefront_size);
+  const uint32_t vgpr_granulated =
+      AMDHSA_BITS_GET(desc.compute_pgm_rsrc1, kd::COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT);
+  const uint32_t vgprs = granulated_count_to_registers(vgpr_granulated, vgpr_granularity);
+
+  constexpr uint32_t sgpr_granularity = 8;
+  const uint32_t sgpr_granulated = AMDHSA_BITS_GET(
+      desc.compute_pgm_rsrc1, kd::COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT);
+  const uint32_t sgprs = granulated_count_to_registers(sgpr_granulated, sgpr_granularity);
+  if (sgprs > std::numeric_limits<uint8_t>::max() - 1 ||
+      vgprs > std::numeric_limits<uint8_t>::max() - 1)
+    return std::nullopt;
+
+  // Place the fixed entry probe above the kernel's current allocation so the
+  // prologue cannot clobber values that the original entry expects to consume.
+  EntryCounterProbeRegisters regs;
+  regs.state_sgpr = static_cast<uint8_t>(sgprs);
+  regs.workitem_vgpr = static_cast<uint8_t>(vgprs);
+  regs.tmp0_vgpr = static_cast<uint8_t>(vgprs + 1);
+  return regs;
+}
+
+void reserve_entry_probe_registers(KernelDescriptor &desc, rj_code_arch_t arch,
+                                   const EntryCounterProbeRegisters &regs) {
+  const bool wave32 =
+      is_rdna_arch(arch) && AMDHSA_BITS_GET(desc.kernel_code_properties,
+                                            kd::KERNEL_CODE_PROPERTY_ENABLE_WAVEFRONT_SIZE32) != 0;
+  const uint32_t wavefront_size = wave32 ? 32 : 64;
+  const uint32_t vgpr_granularity = descriptor_vgpr_granularity_for_wavefront(arch, wavefront_size);
+  const uint32_t required_vgprs = std::max(static_cast<uint32_t>(regs.workitem_vgpr) + 1,
+                                           static_cast<uint32_t>(regs.tmp0_vgpr) + 1);
+  const uint32_t vgpr_granulated =
+      AMDHSA_BITS_GET(desc.compute_pgm_rsrc1, kd::COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT);
+  const uint32_t vgprs = granulated_count_to_registers(vgpr_granulated, vgpr_granularity);
+  if (vgprs < required_vgprs) {
+    AMDHSA_BITS_SET(desc.compute_pgm_rsrc1, kd::COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT,
+                    register_count_to_granulated(required_vgprs, vgpr_granularity));
+  }
+
+  constexpr uint32_t sgpr_granularity = 8;
+  const uint32_t required_sgprs = static_cast<uint32_t>(regs.state_sgpr) + 2;
+  const uint32_t sgpr_granulated = AMDHSA_BITS_GET(
+      desc.compute_pgm_rsrc1, kd::COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT);
+  const uint32_t sgprs = granulated_count_to_registers(sgpr_granulated, sgpr_granularity);
+  if (sgprs < required_sgprs) {
+    AMDHSA_BITS_SET(desc.compute_pgm_rsrc1, kd::COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT,
+                    register_count_to_granulated(required_sgprs, sgpr_granularity));
+  }
+}
+
+bool image_contains_range(size_t image_size, uint64_t offset, uint64_t size) {
+  return offset <= image_size && size <= image_size - offset;
+}
+
+template <typename T> std::optional<T> read_at(std::span<const uint8_t> image, uint64_t offset) {
+  if (!image_contains_range(image.size(), offset, sizeof(T)))
+    return std::nullopt;
+
+  T value{};
+  std::memcpy(&value, image.data() + offset, sizeof(T));
+  return value;
+}
+
+bool is_elf_header(const Elf64_Ehdr &ehdr) {
+  return std::memcmp(ehdr.e_ident, EI_MAGIC, EI_MAGIC_SIZE) == 0;
+}
+
+bool supported_machine_flags(uint32_t flags) {
+  switch (flags & EF_AMDGPU_MACH) {
+  case EF_AMDGPU_MACH_AMDGCN_GFX942:
+  case EF_AMDGPU_MACH_AMDGCN_GFX950:
+  case EF_AMDGPU_MACH_AMDGCN_GFX1200:
+  case EF_AMDGPU_MACH_AMDGCN_GFX1201:
+    return true;
+  default:
+    return false;
+  }
+}
+
+std::optional<Elf64_Ehdr> parse_supported_header(std::span<const uint8_t> image) {
+  auto ehdr = read_at<Elf64_Ehdr>(image, 0);
+  if (!ehdr.has_value())
+    return std::nullopt;
+  if (!is_elf_header(*ehdr) || ehdr->e_ident[EI_CLASS] != ELFCLASS64 ||
+      ehdr->e_ident[EI_OSABI] != ELFOSABI_AMDGPU_HSA || ehdr->e_machine != EM_AMDGPU)
+    return std::nullopt;
+  if (ehdr->e_type != ET_DYN && ehdr->e_type != ET_REL)
+    return std::nullopt;
+  if (ehdr->e_shentsize != sizeof(Elf64_Shdr) || ehdr->e_shnum == 0)
+    return std::nullopt;
+  if (!image_contains_range(image.size(), ehdr->e_shoff,
+                            static_cast<uint64_t>(ehdr->e_shnum) * sizeof(Elf64_Shdr)))
+    return std::nullopt;
+  if (!supported_machine_flags(ehdr->e_flags))
+    return std::nullopt;
+  return ehdr;
+}
+
+std::optional<std::vector<Elf64_Shdr>> parse_section_headers(std::span<const uint8_t> image,
+                                                             const Elf64_Ehdr &ehdr) {
+  std::vector<Elf64_Shdr> shdrs(ehdr.e_shnum);
+  std::memcpy(shdrs.data(), image.data() + ehdr.e_shoff, shdrs.size() * sizeof(Elf64_Shdr));
+  return shdrs;
+}
+
+bool kernel_descriptor_symbol(const Elf64_Sym &symbol, const char *strtab, size_t strtab_size) {
+  if (symbol.st_size != sizeof(KernelDescriptor))
+    return false;
+  if (elf_symbol_type(symbol.st_info) != kElfSymbolTypeObject ||
+      elf_symbol_bind(symbol.st_info) != kElfSymbolBindGlobal)
+    return false;
+  if (strtab == nullptr || strtab_size == 0 || symbol.st_name == 0 || symbol.st_name >= strtab_size)
+    return false;
+
+  const char *name = strtab + symbol.st_name;
+  const size_t len = strnlen(name, strtab_size - symbol.st_name);
+  return len > 3 && std::string_view(name, len).ends_with(".kd");
+}
+
+std::string kernel_name_from_symbol(const Elf64_Sym &symbol, const char *strtab,
+                                    size_t strtab_size) {
+  const char *name = strtab + symbol.st_name;
+  const size_t len = strnlen(name, strtab_size - symbol.st_name);
+  return std::string(name, len - 3);
+}
+
+std::optional<uint64_t> symbol_file_offset(const Elf64_Sym &symbol,
+                                           std::span<const Elf64_Shdr> shdrs, size_t image_size) {
+  if (symbol.st_shndx == SHN_UNDEF || symbol.st_shndx == SHN_ABS || symbol.st_shndx >= shdrs.size())
+    return std::nullopt;
+
+  const Elf64_Shdr &section = shdrs[symbol.st_shndx];
+  if (symbol.st_value < section.sh_addr)
+    return std::nullopt;
+
+  const uint64_t section_offset = symbol.st_value - section.sh_addr;
+  if (section_offset > section.sh_size)
+    return std::nullopt;
+
+  const uint64_t file_offset = section.sh_offset + section_offset;
+  if (!image_contains_range(image_size, file_offset, sizeof(KernelDescriptor)))
+    return std::nullopt;
+
+  return file_offset;
+}
+
+std::optional<uint64_t> add_signed_offset(uint64_t base, int64_t offset) {
+  if (offset >= 0) {
+    const uint64_t unsigned_offset = static_cast<uint64_t>(offset);
+    if (base > UINT64_MAX - unsigned_offset)
+      return std::nullopt;
+    return base + unsigned_offset;
+  }
+
+  const uint64_t magnitude = static_cast<uint64_t>(-(offset + 1)) + 1;
+  if (base < magnitude)
+    return std::nullopt;
+  return base - magnitude;
+}
+
+std::optional<uint64_t> executable_vaddr_to_file_offset(uint64_t vaddr,
+                                                        std::span<const Elf64_Shdr> shdrs,
+                                                        size_t image_size) {
+  for (const Elf64_Shdr &section : shdrs) {
+    if ((section.sh_flags & SHF_EXECINSTR) == 0)
+      continue;
+    if (vaddr < section.sh_addr || vaddr >= section.sh_addr + section.sh_size)
+      continue;
+
+    const uint64_t file_offset = section.sh_offset + (vaddr - section.sh_addr);
+    if (!image_contains_range(image_size, file_offset, 1))
+      return std::nullopt;
+    return file_offset;
+  }
+  return std::nullopt;
+}
+
+std::vector<uint32_t>
+build_amdgpu_entry_counter_probe_words(uint64_t state_pointer, rj_code_arch_t arch,
+                                       const EntryCounterProbeRegisters &regs) {
+  std::vector<uint32_t> words;
+  append_s_mov_b64_literal(words, regs.state_sgpr, state_pointer, arch);
+  constexpr uint32_t slot_byte_offset = 0;
+  static_assert(slot_byte_offset <= kMaxInlinePositiveImm);
+  words.push_back(
+      build_v_mov_b32(regs.workitem_vgpr, amdgpu_positive_inline_const(slot_byte_offset)));
+  words.push_back(build_v_mov_b32(regs.tmp0_vgpr, amdgpu_positive_inline_const(1)));
+  append_valu_dep_2_barrier(words, arch);
+  append_s_wait_kmcnt(words, arch);
+  append_global_store_u32(words, regs.workitem_vgpr, regs.tmp0_vgpr, regs.state_sgpr, arch);
+  append_s_wait_kmcnt(words, arch);
+  return words;
+}
+
+} // namespace
+
+bool is_supported_amdgpu_elf(std::span<const uint8_t> image) {
+  return parse_supported_header(image).has_value();
+}
+
+std::vector<AmdGpuKernelSite> discover_amdgpu_kernel_sites(std::span<const uint8_t> image) {
+  const auto ehdr = parse_supported_header(image);
+  if (!ehdr.has_value())
+    return {};
+
+  const auto shdrs = parse_section_headers(image, *ehdr);
+  if (!shdrs.has_value())
+    return {};
+
+  std::vector<AmdGpuKernelSite> sites;
+  for (const Elf64_Shdr &symtab : *shdrs) {
+    if (symtab.sh_type != SHT_SYMTAB && symtab.sh_type != SHT_DYNSYM)
+      continue;
+    if (symtab.sh_entsize != sizeof(Elf64_Sym) || symtab.sh_link >= shdrs->size())
+      continue;
+    if (!image_contains_range(image.size(), symtab.sh_offset, symtab.sh_size))
+      continue;
+
+    const Elf64_Shdr &strtab_section = (*shdrs)[symtab.sh_link];
+    if (!image_contains_range(image.size(), strtab_section.sh_offset, strtab_section.sh_size))
+      continue;
+
+    const char *strtab = reinterpret_cast<const char *>(image.data() + strtab_section.sh_offset);
+    const size_t strtab_size = static_cast<size_t>(strtab_section.sh_size);
+    const size_t symbol_count = symtab.sh_size / sizeof(Elf64_Sym);
+    for (size_t i = 0; i < symbol_count; ++i) {
+      const auto symbol = read_at<Elf64_Sym>(image, symtab.sh_offset + i * sizeof(Elf64_Sym));
+      if (!symbol.has_value() || !kernel_descriptor_symbol(*symbol, strtab, strtab_size))
+        continue;
+
+      const auto descriptor_offset = symbol_file_offset(*symbol, *shdrs, image.size());
+      if (!descriptor_offset.has_value())
+        continue;
+
+      const auto descriptor = read_at<KernelDescriptor>(image, *descriptor_offset);
+      if (!descriptor.has_value())
+        continue;
+
+      const auto entry_vaddr =
+          add_signed_offset(symbol->st_value, descriptor->kernel_code_entry_byte_offset);
+      if (!entry_vaddr.has_value())
+        continue;
+
+      const auto entry_offset = executable_vaddr_to_file_offset(*entry_vaddr, *shdrs, image.size());
+      if (!entry_offset.has_value())
+        continue;
+
+      sites.push_back(AmdGpuKernelSite{
+          .kernel_name = kernel_name_from_symbol(*symbol, strtab, strtab_size),
+          .descriptor_file_offset = *descriptor_offset,
+          .entry_file_offset = *entry_offset,
+      });
+    }
+  }
+
+  std::sort(sites.begin(), sites.end(), [](const auto &lhs, const auto &rhs) {
+    return lhs.descriptor_file_offset < rhs.descriptor_file_offset;
+  });
+  // HIPRTC code objects may publish the same `.kd` symbol through both
+  // `.dynsym` and `.symtab`; treat those aliases as one kernel descriptor.
+  sites.erase(std::unique(sites.begin(), sites.end(),
+                          [](const auto &lhs, const auto &rhs) {
+                            return lhs.descriptor_file_offset == rhs.descriptor_file_offset;
+                          }),
+              sites.end());
+  return sites;
+}
+
+/// @brief Return entry-probe words for a patched raw AMDGPU ELF kernel.
+///
+/// Example use: the HSA reader rewrite path can call this with the runtime's
+/// device counter buffer address, append the returned words to an executable
+/// cave, and redirect each discovered kernel descriptor entry to that cave. A
+/// vector-add AFL smoke then observes device coverage whenever the HIPRTC kernel
+/// launches, even before general basic-block edge instrumentation exists.
+std::vector<uint32_t> build_amdgpu_entry_counter_probe_words(uint64_t state_pointer,
+                                                             rj_code_arch_t arch) {
+  return build_amdgpu_entry_counter_probe_words(state_pointer, arch, EntryCounterProbeRegisters{});
+}
+
+std::vector<uint8_t> patch_amdgpu_elf_kernel_entries(std::span<const uint8_t> image,
+                                                     uint64_t state_pointer) {
+  std::vector<uint8_t> fail_open(image.begin(), image.end());
+  const auto header = parse_supported_header(image);
+  if (!header.has_value())
+    return fail_open;
+
+  const auto arch = arch_from_elf_flags(header->e_flags);
+  if (arch == ROCJITSU_CODE_ARCH_INVALID)
+    return fail_open;
+
+  const auto sites = discover_amdgpu_kernel_sites(image);
+  if (sites.empty())
+    return fail_open;
+
+  AmdGpuCodeObject code_object(image.data(), image.size());
+  if (!code_object.is_valid())
+    return fail_open;
+  if (code_object.text_sections().empty())
+    return fail_open;
+
+  CodeObjectPatcher patcher(code_object);
+  const uint64_t text_offset = patcher.text_offset();
+  patcher.set_cave_start(patcher.text_size());
+
+  for (const auto &site : sites) {
+    if (site.entry_file_offset < text_offset)
+      return fail_open;
+    const uint64_t entry_text_offset = site.entry_file_offset - text_offset;
+
+    auto descriptor = read_at<KernelDescriptor>(patcher.image_bytes(), site.descriptor_file_offset);
+    if (!descriptor.has_value())
+      return fail_open;
+
+    const auto regs = allocate_entry_probe_registers(*descriptor, arch);
+    if (!regs.has_value())
+      return fail_open;
+    const auto probe_words = build_amdgpu_entry_counter_probe_words(state_pointer, arch, *regs);
+    if (probe_words.empty())
+      return fail_open;
+
+    const auto new_entry =
+        patcher.append_kernel_entry_prologue(entry_text_offset, probe_words, arch);
+    if (!new_entry.has_value())
+      return fail_open;
+    if (!patcher.redirect_kernel_entry(site.descriptor_file_offset, entry_text_offset, *new_entry))
+      return fail_open;
+    descriptor = read_at<KernelDescriptor>(patcher.image_bytes(), site.descriptor_file_offset);
+    if (!descriptor.has_value())
+      return fail_open;
+    reserve_entry_probe_registers(*descriptor, arch, *regs);
+    if (!patcher.patch_kernel_descriptor(
+            site.descriptor_file_offset,
+            std::span<const uint8_t>(reinterpret_cast<const uint8_t *>(&*descriptor),
+                                     sizeof(*descriptor))))
+      return fail_open;
+  }
+
+  if (!patcher.append_cave_section(".rj_translations"))
+    return fail_open;
+  return patcher.emit();
+}
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_elf_reader.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_elf_reader.h
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#ifndef ROCJITSU_CODE_AMDGPU_ELF_READER_H_
+#define ROCJITSU_CODE_AMDGPU_ELF_READER_H_
+
+#include <cstdint>
+#include <span>
+#include <string>
+#include <vector>
+
+#include "rocjitsu/code/rj_code.h"
+
+namespace rocjitsu {
+
+struct AmdGpuKernelSite {
+  std::string kernel_name;
+  uint64_t descriptor_file_offset = 0;
+  uint64_t entry_file_offset = 0;
+};
+
+bool is_supported_amdgpu_elf(std::span<const uint8_t> image);
+
+std::vector<AmdGpuKernelSite> discover_amdgpu_kernel_sites(std::span<const uint8_t> image);
+
+/// @brief Build a kernel-entry AFL device-counter probe.
+///
+/// The probe treats @p state_pointer as the base address of the device counter
+/// array allocated by the RocFuzz AFL runtime. It writes a nonzero value to
+/// counter slot 0 when a patched kernel entry executes before branching back to
+/// the original kernel entry.
+/// @p state_pointer is not AFL's host shared-memory bitmap; it is the
+/// GPU-visible staging buffer that persistent_end later merges into AFL's map.
+///
+/// This is intentionally a fixed entry-only probe: for the minimal vector-add
+/// smoke, one inserted prologue proves that raw AMDGPU ELF patching can feed
+/// device-side coverage back into AFL without pulling in the full edge planner.
+///
+/// @param state_pointer Device virtual address of the AFL device-counter state.
+/// @param arch Target ISA used for wait and memory instruction variants.
+/// @returns Encoded 32-bit AMDGPU instruction words for the entry probe.
+std::vector<uint32_t>
+build_amdgpu_entry_counter_probe_words(uint64_t state_pointer,
+                                       rj_code_arch_t arch = ROCJITSU_CODE_ARCH_RDNA4);
+
+/// @brief Rewrite raw AMDGPU ELF kernel descriptors to run an entry probe.
+///
+/// For each discovered `.kd` symbol in a supported raw AMDGPU ELF image, this
+/// appends an entry-counter prologue into a code cave and redirects the kernel
+/// descriptor entry to that prologue. Unsupported or malformed input fails open
+/// by returning the original bytes unchanged.
+///
+/// @param image Raw AMDGPU ELF bytes.
+/// @param state_pointer Device pointer to the AFL counter buffer.
+/// @returns Rewritten ELF bytes when patching succeeds, or a copy of @p image.
+std::vector<uint8_t> patch_amdgpu_elf_kernel_entries(std::span<const uint8_t> image,
+                                                     uint64_t state_pointer);
+
+} // namespace rocjitsu
+
+#endif // ROCJITSU_CODE_AMDGPU_ELF_READER_H_

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/hsa_code_object_reader_rewriter.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/hsa_code_object_reader_rewriter.cpp
@@ -1,0 +1,164 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/code/hsa_code_object_reader_rewriter.h"
+
+#include <unistd.h>
+
+#include <limits>
+#include <new>
+
+namespace rocjitsu {
+
+namespace {
+
+uint64_t reader_handle(hsa_code_object_reader_t reader) { return reader.handle; }
+
+} // namespace
+
+void HsaCodeObjectReaderRewriter::set_api(CreateFromMemoryFn create_from_memory,
+                                          DestroyFn destroy) {
+  create_from_memory_ = create_from_memory;
+  destroy_ = destroy;
+}
+
+hsa_status_t
+HsaCodeObjectReaderRewriter::create_from_memory(const void *code_object, size_t size,
+                                                hsa_code_object_reader_t *code_object_reader,
+                                                RewriteFn rewrite, void *rewrite_data) {
+  if (create_from_memory_ == nullptr)
+    return HSA_STATUS_ERROR_NOT_INITIALIZED;
+  if (code_object == nullptr || size == 0 || code_object_reader == nullptr || rewrite == nullptr)
+    return create_from_memory_(code_object, size, code_object_reader);
+
+  try {
+    const std::span<const uint8_t> image(static_cast<const uint8_t *>(code_object), size);
+    auto rewritten = rewrite(image, rewrite_data);
+    if (rewritten.has_value()) {
+      const hsa_status_t status =
+          create_reader_from_rewritten_memory(std::move(*rewritten), code_object_reader);
+      if (status == HSA_STATUS_SUCCESS)
+        return status;
+    }
+  } catch (const std::bad_alloc &) {
+    return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+  }
+
+  return create_from_memory_(code_object, size, code_object_reader);
+}
+
+hsa_status_t HsaCodeObjectReaderRewriter::create_from_file(
+    hsa_file_t file, hsa_code_object_reader_t *code_object_reader,
+    CreateFromFileFn original_create_from_file, RewriteFn rewrite, void *rewrite_data) {
+  if (original_create_from_file == nullptr)
+    return HSA_STATUS_ERROR_NOT_INITIALIZED;
+  if (code_object_reader == nullptr || create_from_memory_ == nullptr || rewrite == nullptr)
+    return original_create_from_file(file, code_object_reader);
+
+  try {
+    std::vector<uint8_t> image;
+    if (read_hsa_file(file, &image)) {
+      auto rewritten = rewrite(image, rewrite_data);
+      if (rewritten.has_value()) {
+        const hsa_status_t status =
+            create_reader_from_rewritten_memory(std::move(*rewritten), code_object_reader);
+        if (status == HSA_STATUS_SUCCESS)
+          return status;
+      }
+    }
+  } catch (const std::bad_alloc &) {
+    return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+  }
+
+  return original_create_from_file(file, code_object_reader);
+}
+
+hsa_status_t HsaCodeObjectReaderRewriter::create_from_file_with_offset_size(
+    hsa_file_t file, size_t offset, size_t size, hsa_code_object_reader_t *code_object_reader,
+    CreateFromFileWithOffsetSizeFn original_create_from_file_with_offset_size, RewriteFn rewrite,
+    void *rewrite_data) {
+  if (original_create_from_file_with_offset_size == nullptr)
+    return HSA_STATUS_ERROR_NOT_INITIALIZED;
+  if (code_object_reader == nullptr || create_from_memory_ == nullptr || rewrite == nullptr) {
+    return original_create_from_file_with_offset_size(file, offset, size, code_object_reader);
+  }
+
+  try {
+    std::vector<uint8_t> image;
+    if (read_hsa_file_region(file, offset, size, &image)) {
+      auto rewritten = rewrite(image, rewrite_data);
+      if (rewritten.has_value()) {
+        const hsa_status_t status =
+            create_reader_from_rewritten_memory(std::move(*rewritten), code_object_reader);
+        if (status == HSA_STATUS_SUCCESS)
+          return status;
+      }
+    }
+  } catch (const std::bad_alloc &) {
+    return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+  }
+
+  return original_create_from_file_with_offset_size(file, offset, size, code_object_reader);
+}
+
+hsa_status_t HsaCodeObjectReaderRewriter::destroy(hsa_code_object_reader_t code_object_reader) {
+  if (destroy_ == nullptr)
+    return HSA_STATUS_ERROR_NOT_INITIALIZED;
+
+  const hsa_status_t status = destroy_(code_object_reader);
+  if (status == HSA_STATUS_SUCCESS) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    rewritten_readers_.erase(reader_handle(code_object_reader));
+  }
+  return status;
+}
+
+hsa_status_t HsaCodeObjectReaderRewriter::create_reader_from_rewritten_memory(
+    std::vector<uint8_t> rewritten, hsa_code_object_reader_t *code_object_reader) {
+  hsa_code_object_reader_t reader{};
+  const hsa_status_t status = create_from_memory_(rewritten.data(), rewritten.size(), &reader);
+  if (status != HSA_STATUS_SUCCESS)
+    return status;
+
+  try {
+    std::lock_guard<std::mutex> lock(mutex_);
+    rewritten_readers_[reader_handle(reader)] = std::move(rewritten);
+  } catch (const std::bad_alloc &) {
+    (void)destroy_(reader);
+    return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+  }
+
+  *code_object_reader = reader;
+  return HSA_STATUS_SUCCESS;
+}
+
+bool read_hsa_file_region(hsa_file_t file, size_t offset, size_t size,
+                          std::vector<uint8_t> *bytes) {
+  if (bytes == nullptr || size == 0)
+    return false;
+
+  bytes->assign(size, 0);
+  size_t done = 0;
+  while (done < size) {
+    if (offset > static_cast<size_t>(std::numeric_limits<off_t>::max()) - done)
+      return false;
+    const ssize_t nread =
+        pread(file, bytes->data() + done, size - done, static_cast<off_t>(offset + done));
+    if (nread <= 0)
+      return false;
+    done += static_cast<size_t>(nread);
+  }
+  return true;
+}
+
+bool read_hsa_file(hsa_file_t file, std::vector<uint8_t> *bytes) {
+  const off_t saved = lseek(file, 0, SEEK_CUR);
+  const off_t end = lseek(file, 0, SEEK_END);
+  if (saved >= 0)
+    (void)lseek(file, saved, SEEK_SET);
+  if (end <= 0)
+    return false;
+  return read_hsa_file_region(file, 0, static_cast<size_t>(end), bytes);
+}
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/hsa_code_object_reader_rewriter.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/hsa_code_object_reader_rewriter.h
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#ifndef ROCJITSU_CODE_HSA_CODE_OBJECT_READER_REWRITER_H_
+#define ROCJITSU_CODE_HSA_CODE_OBJECT_READER_REWRITER_H_
+
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu-anonymous-struct"
+#pragma clang diagnostic ignored "-Wnested-anon-types"
+#endif
+#include <hsa/hsa.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <optional>
+#include <span>
+#include <unordered_map>
+#include <vector>
+
+namespace rocjitsu {
+
+/// @brief Owns replacement HSA code-object reader memory while readers exist.
+///
+/// HSA reader APIs do not take ownership of memory passed to
+/// hsa_code_object_reader_create_from_memory(). This helper centralizes the
+/// common interposer pattern: read code-object bytes, optionally rewrite them,
+/// create a replacement memory reader, and retain those replacement bytes until
+/// the real reader destroy succeeds.
+class HsaCodeObjectReaderRewriter {
+public:
+  using CreateFromMemoryFn = hsa_status_t (*)(const void *, size_t, hsa_code_object_reader_t *);
+  using CreateFromFileFn = hsa_status_t (*)(hsa_file_t, hsa_code_object_reader_t *);
+  using CreateFromFileWithOffsetSizeFn = hsa_status_t (*)(hsa_file_t, size_t, size_t,
+                                                          hsa_code_object_reader_t *);
+  using DestroyFn = hsa_status_t (*)(hsa_code_object_reader_t);
+  using RewriteFn = std::optional<std::vector<uint8_t>> (*)(std::span<const uint8_t>, void *);
+
+  HsaCodeObjectReaderRewriter() = default;
+  HsaCodeObjectReaderRewriter(const HsaCodeObjectReaderRewriter &) = delete;
+  HsaCodeObjectReaderRewriter &operator=(const HsaCodeObjectReaderRewriter &) = delete;
+
+  void set_api(CreateFromMemoryFn create_from_memory, DestroyFn destroy);
+
+  hsa_status_t create_from_memory(const void *code_object, size_t size,
+                                  hsa_code_object_reader_t *code_object_reader, RewriteFn rewrite,
+                                  void *rewrite_data);
+
+  hsa_status_t create_from_file(hsa_file_t file, hsa_code_object_reader_t *code_object_reader,
+                                CreateFromFileFn original_create_from_file, RewriteFn rewrite,
+                                void *rewrite_data);
+
+  hsa_status_t create_from_file_with_offset_size(
+      hsa_file_t file, size_t offset, size_t size, hsa_code_object_reader_t *code_object_reader,
+      CreateFromFileWithOffsetSizeFn original_create_from_file_with_offset_size, RewriteFn rewrite,
+      void *rewrite_data);
+
+  hsa_status_t destroy(hsa_code_object_reader_t code_object_reader);
+
+private:
+  hsa_status_t create_reader_from_rewritten_memory(std::vector<uint8_t> rewritten,
+                                                   hsa_code_object_reader_t *code_object_reader);
+
+  CreateFromMemoryFn create_from_memory_ = nullptr;
+  DestroyFn destroy_ = nullptr;
+  std::mutex mutex_;
+  std::unordered_map<uint64_t, std::vector<uint8_t>> rewritten_readers_;
+};
+
+bool read_hsa_file_region(hsa_file_t file, size_t offset, size_t size, std::vector<uint8_t> *bytes);
+bool read_hsa_file(hsa_file_t file, std::vector<uint8_t> *bytes);
+
+} // namespace rocjitsu
+
+#endif // ROCJITSU_CODE_HSA_CODE_OBJECT_READER_REWRITER_H_

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
@@ -421,10 +421,8 @@ CodeObjectPatcher::CodeObjectPatcher(const AmdGpuCodeObject &obj)
 }
 
 std::optional<KernelEntryProloguePlan>
-plan_kernel_entry_prologue(uint64_t cave_start, uint64_t cave_body_size,
-                           uint64_t entry_text_offset,
-                           std::span<const uint32_t> prologue_words,
-                           rj_code_arch_t arch) {
+plan_kernel_entry_prologue(uint64_t cave_start, uint64_t cave_body_size, uint64_t entry_text_offset,
+                           std::span<const uint32_t> prologue_words, rj_code_arch_t arch) {
   assert(!prologue_words.empty() && "empty kernel entry prologue");
 
   // A kernel descriptor entry point is a hardware launch address, not an
@@ -507,8 +505,7 @@ bool CodeObjectPatcher::replace_note_section(uint64_t section_file_offset,
   Elf64_Ehdr header{};
   std::memcpy(&header, image_.data(), sizeof(header));
   if (header.e_shentsize != sizeof(Elf64_Shdr) || header.e_shoff > image_.size() ||
-      static_cast<uint64_t>(header.e_shnum) * sizeof(Elf64_Shdr) >
-          image_.size() - header.e_shoff) {
+      static_cast<uint64_t>(header.e_shnum) * sizeof(Elf64_Shdr) > image_.size() - header.e_shoff) {
     return false;
   }
   if (header.e_phnum != 0 &&
@@ -572,14 +569,13 @@ bool CodeObjectPatcher::replace_note_section(uint64_t section_file_offset,
     return false;
   std::vector<uint8_t> replacement_region;
   replacement_region.reserve(static_cast<size_t>(old_region_size + delta));
-  replacement_region.insert(
-      replacement_region.end(), image_.begin() + static_cast<std::ptrdiff_t>(old_region_offset),
-      image_.begin() + static_cast<std::ptrdiff_t>(old_section.sh_offset));
-  replacement_region.insert(replacement_region.end(), section_bytes.begin(),
-                            section_bytes.end());
-  replacement_region.insert(
-      replacement_region.end(), image_.begin() + static_cast<std::ptrdiff_t>(old_section_end),
-      image_.begin() + static_cast<std::ptrdiff_t>(old_region_end));
+  replacement_region.insert(replacement_region.end(),
+                            image_.begin() + static_cast<std::ptrdiff_t>(old_region_offset),
+                            image_.begin() + static_cast<std::ptrdiff_t>(old_section.sh_offset));
+  replacement_region.insert(replacement_region.end(), section_bytes.begin(), section_bytes.end());
+  replacement_region.insert(replacement_region.end(),
+                            image_.begin() + static_cast<std::ptrdiff_t>(old_section_end),
+                            image_.begin() + static_cast<std::ptrdiff_t>(old_region_end));
 
   const uint64_t new_region_offset = align_up(image_.size(), alignment);
   if (new_region_offset < image_.size())
@@ -709,9 +705,8 @@ bool CodeObjectPatcher::apply_kernel_descriptor_translation(const KdTranslation 
 
 std::optional<uint64_t> CodeObjectPatcher::append_kernel_entry_prologue(
     uint64_t entry_text_offset, std::span<const uint32_t> prologue_words, rj_code_arch_t arch) {
-  std::optional<KernelEntryProloguePlan> plan =
-      plan_kernel_entry_prologue(cave_start_, cave_body_size(), entry_text_offset,
-                                 prologue_words, arch);
+  std::optional<KernelEntryProloguePlan> plan = plan_kernel_entry_prologue(
+      cave_start_, cave_body_size(), entry_text_offset, prologue_words, arch);
   if (!plan)
     return std::nullopt;
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
@@ -420,6 +420,51 @@ CodeObjectPatcher::CodeObjectPatcher(const AmdGpuCodeObject &obj)
   }
 }
 
+std::optional<KernelEntryProloguePlan>
+plan_kernel_entry_prologue(uint64_t cave_start, uint64_t cave_body_size,
+                           uint64_t entry_text_offset,
+                           std::span<const uint32_t> prologue_words,
+                           rj_code_arch_t arch) {
+  assert(!prologue_words.empty() && "empty kernel entry prologue");
+
+  // A kernel descriptor entry point is a hardware launch address, not an
+  // ordinary branch target. CP expects that instruction address to be
+  // 256-byte-aligned. The patcher works in .text-relative offsets, so preserve
+  // the original entry's 256-byte residue; if the original virtual address was
+  // aligned, the redirected virtual address stays aligned too.
+  const uint64_t current_offset = cave_start + cave_body_size;
+  const uint64_t required_residue = entry_text_offset % 256;
+  const uint64_t alignment_padding = (required_residue + 256 - (current_offset % 256)) % 256;
+  assert(alignment_padding % sizeof(uint32_t) == 0 && "unaligned cave padding");
+
+  const uint64_t cave_byte_offset = current_offset + alignment_padding;
+  assert(cave_byte_offset % 256 == required_residue &&
+         "kernel descriptor entry lost its 256-byte alignment");
+
+  // The descriptor enters the cave directly. The only control-flow fixup is a
+  // final branch from the prologue body to the original, untouched entry.
+  const int64_t branch_pc =
+      static_cast<int64_t>(cave_byte_offset + prologue_words.size() * sizeof(uint32_t));
+  const int64_t target = static_cast<int64_t>(entry_text_offset);
+  const int64_t target_delta_bytes = target - (branch_pc + 4);
+  if (target_delta_bytes % static_cast<int64_t>(sizeof(uint32_t)) != 0)
+    return std::nullopt;
+
+  const int64_t target_dwords = target_delta_bytes / static_cast<int64_t>(sizeof(uint32_t));
+  if (target_dwords < std::numeric_limits<int16_t>::min() ||
+      target_dwords > std::numeric_limits<int16_t>::max())
+    return std::nullopt;
+
+  KernelEntryProloguePlan plan;
+  plan.new_entry_text_offset = cave_byte_offset;
+  plan.cave_words.reserve(alignment_padding / sizeof(uint32_t) + prologue_words.size() + 1);
+  for (uint64_t i = 0; i < alignment_padding; i += sizeof(uint32_t))
+    plan.cave_words.push_back(build_s_nop(0, arch));
+  plan.cave_words.insert(plan.cave_words.end(), prologue_words.begin(), prologue_words.end());
+  plan.cave_words.push_back(build_s_branch(static_cast<int16_t>(target_dwords), arch));
+  return plan;
+}
+
 std::span<uint8_t> CodeObjectPatcher::text_bytes() {
   return {image_.data() + text_offset_, text_size_};
 }
@@ -441,10 +486,141 @@ void CodeObjectPatcher::update_elf_flags(uint32_t new_mach) {
 
 bool CodeObjectPatcher::patch_kernel_descriptor(uint64_t file_offset,
                                                 std::span<const uint8_t> descriptor) {
-  if (!image_contains_range(image_.size(), file_offset, descriptor.size()))
+  return patch_bytes(file_offset, descriptor);
+}
+
+bool CodeObjectPatcher::patch_bytes(uint64_t file_offset, std::span<const uint8_t> bytes) {
+  if (!image_contains_range(image_.size(), file_offset, bytes.size()))
     return false;
 
-  std::memcpy(image_.data() + file_offset, descriptor.data(), descriptor.size());
+  std::memcpy(image_.data() + file_offset, bytes.data(), bytes.size());
+  return true;
+}
+
+bool CodeObjectPatcher::replace_note_section(uint64_t section_file_offset,
+                                             std::span<const uint8_t> section_bytes) {
+  if (section_bytes.empty())
+    return false;
+  if (image_.size() < sizeof(Elf64_Ehdr))
+    return false;
+
+  Elf64_Ehdr header{};
+  std::memcpy(&header, image_.data(), sizeof(header));
+  if (header.e_shentsize != sizeof(Elf64_Shdr) || header.e_shoff > image_.size() ||
+      static_cast<uint64_t>(header.e_shnum) * sizeof(Elf64_Shdr) >
+          image_.size() - header.e_shoff) {
+    return false;
+  }
+  if (header.e_phnum != 0 &&
+      (header.e_phentsize != sizeof(Elf64_Phdr) || header.e_phoff > image_.size() ||
+       static_cast<uint64_t>(header.e_phnum) * sizeof(Elf64_Phdr) >
+           image_.size() - header.e_phoff)) {
+    return false;
+  }
+
+  std::vector<Elf64_Shdr> shdrs = read_section_headers(image_, header);
+  std::vector<Elf64_Phdr> phdrs = read_program_headers(image_, header);
+
+  std::optional<size_t> target_section_index;
+  for (size_t i = 0; i < shdrs.size(); ++i) {
+    if (shdrs[i].sh_type == SHT_NOTE && shdrs[i].sh_offset == section_file_offset) {
+      target_section_index = i;
+      break;
+    }
+  }
+  if (!target_section_index)
+    return false;
+
+  const Elf64_Shdr old_section = shdrs[*target_section_index];
+  if (!image_contains_range(image_.size(), old_section.sh_offset, old_section.sh_size))
+    return false;
+  if (section_bytes.size() < old_section.sh_size)
+    return false;
+
+  std::optional<size_t> note_segment_index;
+  for (size_t i = 0; i < phdrs.size(); ++i) {
+    const Elf64_Phdr &phdr = phdrs[i];
+    const uint64_t segment_end = phdr.p_offset + phdr.p_filesz;
+    const uint64_t section_end = old_section.sh_offset + old_section.sh_size;
+    if (phdr.p_type == PT_NOTE && phdr.p_offset <= old_section.sh_offset &&
+        section_end <= segment_end) {
+      note_segment_index = i;
+      break;
+    }
+  }
+
+  uint64_t old_region_offset = old_section.sh_offset;
+  uint64_t old_region_size = old_section.sh_size;
+  uint64_t section_relative_offset = 0;
+  uint64_t alignment = std::max<uint64_t>(4, old_section.sh_addralign);
+  if (note_segment_index) {
+    const Elf64_Phdr &phdr = phdrs[*note_segment_index];
+    if (!image_contains_range(image_.size(), phdr.p_offset, phdr.p_filesz))
+      return false;
+    old_region_offset = phdr.p_offset;
+    old_region_size = phdr.p_filesz;
+    section_relative_offset = old_section.sh_offset - phdr.p_offset;
+    alignment = checked_lcm_u64(alignment, phdr.p_align == 0 ? 1 : phdr.p_align);
+    if (alignment == 0)
+      return false;
+  }
+
+  const uint64_t old_section_end = old_section.sh_offset + old_section.sh_size;
+  const uint64_t old_region_end = old_region_offset + old_region_size;
+  const uint64_t delta = section_bytes.size() - old_section.sh_size;
+  if (delta > std::numeric_limits<uint64_t>::max() - old_region_size)
+    return false;
+  std::vector<uint8_t> replacement_region;
+  replacement_region.reserve(static_cast<size_t>(old_region_size + delta));
+  replacement_region.insert(
+      replacement_region.end(), image_.begin() + static_cast<std::ptrdiff_t>(old_region_offset),
+      image_.begin() + static_cast<std::ptrdiff_t>(old_section.sh_offset));
+  replacement_region.insert(replacement_region.end(), section_bytes.begin(),
+                            section_bytes.end());
+  replacement_region.insert(
+      replacement_region.end(), image_.begin() + static_cast<std::ptrdiff_t>(old_section_end),
+      image_.begin() + static_cast<std::ptrdiff_t>(old_region_end));
+
+  const uint64_t new_region_offset = align_up(image_.size(), alignment);
+  if (new_region_offset < image_.size())
+    return false;
+
+  const uint64_t new_section_offset = new_region_offset + section_relative_offset;
+  for (size_t i = 0; i < shdrs.size(); ++i) {
+    Elf64_Shdr &section = shdrs[i];
+    if (section.sh_type != SHT_NOTE)
+      continue;
+    const uint64_t section_end = section.sh_offset + section.sh_size;
+    if (section.sh_offset < old_region_offset || section_end > old_region_end)
+      continue;
+    const uint64_t old_relative = section.sh_offset - old_region_offset;
+    uint64_t new_relative = old_relative;
+    if (i == *target_section_index) {
+      section.sh_size = section_bytes.size();
+    } else if (section.sh_offset >= old_section_end) {
+      new_relative += delta;
+    } else if (section_end > old_section.sh_offset) {
+      return false;
+    }
+    section.sh_offset = new_region_offset + new_relative;
+    if (note_segment_index && (section.sh_flags & SHF_ALLOC) != 0)
+      section.sh_addr = phdrs[*note_segment_index].p_vaddr + new_relative;
+  }
+  shdrs[*target_section_index].sh_offset = new_section_offset;
+  shdrs[*target_section_index].sh_size = section_bytes.size();
+
+  if (note_segment_index) {
+    Elf64_Phdr &phdr = phdrs[*note_segment_index];
+    if (delta > std::numeric_limits<uint64_t>::max() - phdr.p_memsz)
+      return false;
+    phdr.p_offset = new_region_offset;
+    phdr.p_filesz = replacement_region.size();
+    phdr.p_memsz += delta;
+  }
+
+  image_.resize(static_cast<size_t>(new_region_offset), 0);
+  image_.insert(image_.end(), replacement_region.begin(), replacement_region.end());
+  write_elf_tables(image_, header, shdrs, phdrs);
   return true;
 }
 
@@ -533,44 +709,14 @@ bool CodeObjectPatcher::apply_kernel_descriptor_translation(const KdTranslation 
 
 std::optional<uint64_t> CodeObjectPatcher::append_kernel_entry_prologue(
     uint64_t entry_text_offset, std::span<const uint32_t> prologue_words, rj_code_arch_t arch) {
-  assert(!prologue_words.empty() && "empty kernel entry prologue");
-
-  // A kernel descriptor entry point is a hardware launch address, not an
-  // ordinary branch target. CP expects that instruction address to be 256-byte
-  // aligned. The patcher works in .text-relative offsets, so preserve the
-  // original entry's 256-byte residue; if the original virtual address was
-  // aligned, the redirected virtual address stays aligned too.
-  const uint64_t current_offset = cave_start_ + cave_body_size();
-  const uint64_t required_residue = entry_text_offset % 256;
-  const uint64_t alignment_padding = (required_residue + 256 - (current_offset % 256)) % 256;
-  assert(alignment_padding % sizeof(uint32_t) == 0 && "unaligned cave padding");
-
-  std::vector<uint32_t> cave_words(prologue_words.begin(), prologue_words.end());
-  const uint64_t cave_byte_offset = current_offset + alignment_padding;
-  assert(cave_byte_offset % 256 == required_residue &&
-         "kernel descriptor entry lost its 256-byte alignment");
-
-  // The descriptor now enters the cave directly. The only control-flow fixup is
-  // a final branch from the prologue body to the original, untouched entry.
-  const int64_t branch_pc = static_cast<int64_t>(cave_byte_offset + cave_words.size() * 4);
-  const int64_t target = static_cast<int64_t>(entry_text_offset);
-  const int64_t target_delta_bytes = target - (branch_pc + 4);
-  if (target_delta_bytes % static_cast<int64_t>(sizeof(uint32_t)) != 0)
+  std::optional<KernelEntryProloguePlan> plan =
+      plan_kernel_entry_prologue(cave_start_, cave_body_size(), entry_text_offset,
+                                 prologue_words, arch);
+  if (!plan)
     return std::nullopt;
 
-  const int64_t target_dwords = target_delta_bytes / static_cast<int64_t>(sizeof(uint32_t));
-  if (target_dwords < std::numeric_limits<int16_t>::min() ||
-      target_dwords > std::numeric_limits<int16_t>::max())
-    return std::nullopt;
-
-  if (alignment_padding != 0) {
-    std::vector<uint32_t> padding(alignment_padding / sizeof(uint32_t), build_s_nop(0, arch));
-    append_cave_body(padding);
-  }
-  cave_words.push_back(build_s_branch(static_cast<int16_t>(target_dwords), arch));
-
-  append_cave_body(cave_words);
-  return cave_byte_offset;
+  append_cave_body(plan->cave_words);
+  return plan->new_entry_text_offset;
 }
 
 bool CodeObjectPatcher::redirect_kernel_entry(uint64_t descriptor_file_offset,
@@ -624,10 +770,12 @@ bool CodeObjectPatcher::append_cave_section(std::string_view section_name) {
   // Insert the executable bytes at the exact address assumed by branch stub
   // construction: .text-relative offset text_size_. Any later PT_LOAD segment
   // must keep p_offset congruent with p_vaddr modulo p_align, so the total file
-  // delta is padded up to the required load alignment. Later allocated sections
-  // also move forward in virtual address space; otherwise a large cave can
-  // overlap the following LOAD segment in memory. The padding is part of the RX
-  // LOAD segment but not part of the .rj_translations section.
+  // delta is padded up to the required load alignment. If the padded cave still
+  // fits in the virtual gap after .text, preserve later virtual addresses. This
+  // keeps ET_DYN metadata such as .dynamic entries valid for code objects with
+  // writable LOAD segments after .text. If the cave would overlap the next
+  // allocated address, fall back to moving later allocated sections in virtual
+  // address space.
   const uint64_t file_delta_alignment = shifted_load_delta_alignment(phdrs, cave_file_offset);
   const uint64_t padded_file_delta = align_up(cave_body_.size(), file_delta_alignment);
   assert(padded_file_delta >= cave_body_.size() && "aligned cave delta underflowed");
@@ -637,19 +785,35 @@ bool CodeObjectPatcher::append_cave_section(std::string_view section_name) {
   std::vector<uint8_t> cave_file_bytes(cave_body_.begin(), cave_body_.end());
   cave_file_bytes.resize(padded_file_delta, 0);
 
+  uint64_t next_alloc_vaddr = std::numeric_limits<uint64_t>::max();
+  for (size_t i = 0; i < shdrs.size(); ++i) {
+    if (i == *text_index || shdrs[i].sh_type == SHT_NULL)
+      continue;
+    if ((shdrs[i].sh_flags & SHF_ALLOC) != 0 && shdrs[i].sh_addr >= cave_vaddr)
+      next_alloc_vaddr = std::min(next_alloc_vaddr, shdrs[i].sh_addr);
+  }
+  for (const Elf64_Phdr &phdr : phdrs) {
+    if (phdr.p_type == PT_LOAD && phdr.p_offset >= cave_file_offset && phdr.p_vaddr >= cave_vaddr)
+      next_alloc_vaddr = std::min(next_alloc_vaddr, phdr.p_vaddr);
+  }
+  const bool preserve_later_vaddrs = next_alloc_vaddr == std::numeric_limits<uint64_t>::max() ||
+                                     padded_file_delta <= next_alloc_vaddr - cave_vaddr;
+
   // insert_file_bytes handles file offsets. These side maps record which
   // already-existing allocated objects also need virtual-address adjustments.
   std::vector<bool> shift_section_vaddr(shdrs.size(), false);
   for (size_t i = 0; i < shdrs.size(); ++i) {
     if (i == *text_index || shdrs[i].sh_type == SHT_NULL)
       continue;
-    if ((shdrs[i].sh_flags & SHF_ALLOC) != 0 && shdrs[i].sh_addr >= cave_vaddr)
+    if (!preserve_later_vaddrs && (shdrs[i].sh_flags & SHF_ALLOC) != 0 &&
+        shdrs[i].sh_addr >= cave_vaddr)
       shift_section_vaddr[i] = true;
   }
 
   std::vector<bool> shift_segment_vaddr(phdrs.size(), false);
   for (size_t i = 0; i < phdrs.size(); ++i) {
-    if (phdrs[i].p_vaddr >= cave_vaddr && phdrs[i].p_offset >= cave_file_offset)
+    if (!preserve_later_vaddrs && phdrs[i].p_vaddr >= cave_vaddr &&
+        phdrs[i].p_offset >= cave_file_offset)
       shift_segment_vaddr[i] = true;
   }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.h
@@ -17,6 +17,17 @@ namespace rocjitsu {
 class AmdGpuCodeObject;
 struct KdTranslation;
 
+struct KernelEntryProloguePlan {
+  uint64_t new_entry_text_offset = 0;
+  std::vector<uint32_t> cave_words;
+};
+
+[[nodiscard]] std::optional<KernelEntryProloguePlan>
+plan_kernel_entry_prologue(uint64_t cave_start, uint64_t cave_body_size,
+                           uint64_t entry_text_offset,
+                           std::span<const uint32_t> prologue_words,
+                           rj_code_arch_t arch);
+
 class CodeObjectPatcher {
 public:
   explicit CodeObjectPatcher(const AmdGpuCodeObject &obj);
@@ -33,7 +44,17 @@ public:
   void update_elf_flags(uint32_t new_flags);
 
   [[nodiscard]] bool patch_kernel_descriptor(uint64_t file_offset,
-                                             std::span<const uint8_t> descriptor);
+                                              std::span<const uint8_t> descriptor);
+  [[nodiscard]] bool patch_bytes(uint64_t file_offset, std::span<const uint8_t> bytes);
+
+  /// @brief Replace an SHT_NOTE section with a larger payload.
+  ///
+  /// The replacement bytes are appended to the image and the SHT_NOTE/PT_NOTE
+  /// records are retargeted there. This avoids inserting bytes into existing
+  /// LOAD segments, where shifting file offsets can break ELF loader
+  /// invariants for dynamic code objects.
+  [[nodiscard]] bool replace_note_section(uint64_t section_file_offset,
+                                           std::span<const uint8_t> section_bytes);
 
   /// @brief Apply a descriptor translation plan to the in-memory ELF image.
   ///

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.h
@@ -23,10 +23,8 @@ struct KernelEntryProloguePlan {
 };
 
 [[nodiscard]] std::optional<KernelEntryProloguePlan>
-plan_kernel_entry_prologue(uint64_t cave_start, uint64_t cave_body_size,
-                           uint64_t entry_text_offset,
-                           std::span<const uint32_t> prologue_words,
-                           rj_code_arch_t arch);
+plan_kernel_entry_prologue(uint64_t cave_start, uint64_t cave_body_size, uint64_t entry_text_offset,
+                           std::span<const uint32_t> prologue_words, rj_code_arch_t arch);
 
 class CodeObjectPatcher {
 public:
@@ -44,7 +42,7 @@ public:
   void update_elf_flags(uint32_t new_flags);
 
   [[nodiscard]] bool patch_kernel_descriptor(uint64_t file_offset,
-                                              std::span<const uint8_t> descriptor);
+                                             std::span<const uint8_t> descriptor);
   [[nodiscard]] bool patch_bytes(uint64_t file_offset, std::span<const uint8_t> bytes);
 
   /// @brief Replace an SHT_NOTE section with a larger payload.
@@ -54,7 +52,7 @@ public:
   /// LOAD segments, where shifting file offsets can break ELF loader
   /// invariants for dynamic code objects.
   [[nodiscard]] bool replace_note_section(uint64_t section_file_offset,
-                                           std::span<const uint8_t> section_bytes);
+                                          std::span<const uint8_t> section_bytes);
 
   /// @brief Apply a descriptor translation plan to the in-memory ELF image.
   ///

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/CMakeLists.txt
@@ -13,12 +13,9 @@ target_include_directories(rocjitsu_kmd PRIVATE ${GENERATED_DIR})
 add_library(rocjitsu_kmd_shim SHARED interposer.cpp)
 target_include_directories(
     rocjitsu_kmd_shim
-    PRIVATE
-        ${ROCJITSU_INCLUDE_DIR}
-        ${ROCJITSU_SRC_DIR}
-        ${HSA_INCLUDE_DIR}
-        ${GENERATED_DIR}
+    PRIVATE ${ROCJITSU_INCLUDE_DIR} ${ROCJITSU_SRC_DIR} ${GENERATED_DIR}
 )
+target_include_directories(rocjitsu_kmd_shim SYSTEM PRIVATE ${HSA_INCLUDE_DIR})
 target_link_libraries(
     rocjitsu_kmd_shim
     PRIVATE

--- a/emulation/rocjitsu/tests/dbt/device_kernels_translate_tests.cpp
+++ b/emulation/rocjitsu/tests/dbt/device_kernels_translate_tests.cpp
@@ -577,6 +577,8 @@ TEST(CodeObjectPatcher, KernelEntryPrologueRejectsOutOfRangeBranch) {
                              rocjitsu::KernelDescriptorTranslationOptions{});
   ASSERT_FALSE(infos.empty());
 
+  const std::vector<uint8_t> original_image(patcher.image_bytes().begin(),
+                                            patcher.image_bytes().end());
   patcher.set_cave_start(infos[0].entry_text_offset + 200000);
   const std::array<uint32_t, 1> prologue = {rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_RDNA4)};
   const auto prologue_entry = patcher.append_kernel_entry_prologue(
@@ -584,6 +586,8 @@ TEST(CodeObjectPatcher, KernelEntryPrologueRejectsOutOfRangeBranch) {
 
   EXPECT_FALSE(prologue_entry.has_value());
   EXPECT_EQ(patcher.cave_body_size(), 0u);
+  EXPECT_EQ(std::vector<uint8_t>(patcher.image_bytes().begin(), patcher.image_bytes().end()),
+            original_image);
 }
 
 TEST(CodeObjectPatcher, RejectsOutOfRangeKernelDescriptorUpdates) {

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -1162,6 +1162,48 @@ TEST(CodeObjectPatcher, CaveInsertionPreservesLoadSegmentAlignment) {
       << "symbols in unmoved .text must keep their original virtual address";
 }
 
+TEST(CodeObjectPatcher, CaveInsertionPreservesLaterVirtualAddressesWhenGapAllows) {
+  constexpr uint64_t load_align = 0x1000;
+  constexpr uint64_t padded_file_delta = load_align;
+
+  auto image = make_minimal_amdgpu_elf_with_load_segments();
+  AmdGpuCodeObject co(image.data(), image.size());
+  ASSERT_TRUE(co.is_valid());
+  ASSERT_FALSE(co.text_sections().empty());
+  const Section *original_rodata = find_section(co, ".rodata");
+  ASSERT_NE(original_rodata, nullptr);
+
+  CodeObjectPatcher patcher(co);
+  patcher.set_cave_start(co.text_sections()[0]->size());
+  const std::array<uint32_t, 2> cave_words = {0xDEADBEEFu, 0xCAFEBABEu};
+  patcher.append_cave_body(cave_words);
+  ASSERT_TRUE(patcher.append_cave_section());
+
+  auto patched_bytes = patcher.emit();
+  AmdGpuCodeObject patched(patched_bytes.data(), patched_bytes.size());
+  ASSERT_TRUE(patched.is_valid());
+
+  const Section *text = patched.text_sections()[0];
+  const Section *translations = find_section(patched, ".rj_translations");
+  const Section *rodata = find_section(patched, ".rodata");
+  ASSERT_NE(text, nullptr);
+  ASSERT_NE(translations, nullptr);
+  ASSERT_NE(rodata, nullptr);
+  EXPECT_EQ(translations->vaddr(), text->vaddr() + text->size());
+  EXPECT_EQ(rodata->sectionOffset(), original_rodata->sectionOffset() + padded_file_delta);
+  EXPECT_EQ(rodata->vaddr(), original_rodata->vaddr())
+      << "later ET_DYN virtual addresses should stay stable when the cave fits in the gap";
+
+  const auto *ehdr = reinterpret_cast<const Elf64_Ehdr *>(patched_bytes.data());
+  ASSERT_EQ(ehdr->e_phnum, 2u);
+  const auto *phdrs = reinterpret_cast<const Elf64_Phdr *>(patched_bytes.data() + ehdr->e_phoff);
+  EXPECT_EQ(phdrs[0].p_filesz, text->size() + padded_file_delta);
+  EXPECT_EQ(phdrs[0].p_memsz, text->size() + padded_file_delta);
+  EXPECT_EQ(phdrs[1].p_offset, rodata->sectionOffset());
+  EXPECT_EQ(phdrs[1].p_vaddr, rodata->vaddr());
+  EXPECT_LE(phdrs[0].p_vaddr + phdrs[0].p_memsz, phdrs[1].p_vaddr);
+}
+
 TEST(CodeObjectPatcher, CaveInsertionPreservesMovedKernelDescriptorEntryAddress) {
   using KD = rocr::llvm::amdhsa::kernel_descriptor_t;
   constexpr uint64_t load_align = 0x1000;

--- a/emulation/rocjitsu/tests/kernels/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/kernels/CMakeLists.txt
@@ -21,7 +21,7 @@ find_program(
     HINTS
     ENV ROCM_PATH
     /opt/rocm
-    PATH_SUFFIXES bin
+    PATH_SUFFIXES lib/llvm/bin bin
     DOC "Path to the ROCm amdclang++ compiler"
 )
 
@@ -46,9 +46,18 @@ message(STATUS "Found amdclang++: ${AMDCLANG}")
 set(KERNEL_OUTPUT_DIR ${CMAKE_BINARY_DIR}/kernels)
 file(MAKE_DIRECTORY ${KERNEL_OUTPUT_DIR})
 
-# Locate the ROCm installation root for --rocm-path.
-get_filename_component(ROCM_PATH "${AMDCLANG}" DIRECTORY)
-get_filename_component(ROCM_PATH "${ROCM_PATH}" DIRECTORY)
+# Locate the ROCm installation root for --rocm-path. Python rocm-sdk-devel
+# packages install the real compiler in lib/llvm/bin, while system installs
+# commonly expose it directly under bin.
+get_filename_component(AMDCLANG_DIR "${AMDCLANG}" DIRECTORY)
+if(AMDCLANG_DIR MATCHES "/lib/llvm/bin$")
+    get_filename_component(ROCM_PATH "${AMDCLANG_DIR}" DIRECTORY)
+    get_filename_component(ROCM_PATH "${ROCM_PATH}" DIRECTORY)
+    get_filename_component(ROCM_PATH "${ROCM_PATH}" DIRECTORY)
+else()
+    get_filename_component(ROCM_PATH "${AMDCLANG_DIR}" DIRECTORY)
+endif()
+message(STATUS "Using ROCm path for device kernels: ${ROCM_PATH}")
 
 include(rj_add_device_kernel)
 


### PR DESCRIPTION
## Motivation

This PR adds a small proof of concept for integrating AFL++ with rocjitsu.

## Technical Details

This PR is based on Jakub's original prototype but with the following differences:

* Focuses on keeping the PR reviewable.
* Focuses on a minimal working example for HIP kernels.
* Adds several examples (that can be deleted) to serve as guide for reviewers.
* Does not add support for CCOB, KPACK, or other kernel formats beyond ELF.
* Lack the infrastructure for error reporting and logging.
* Focuses on just a proof of concept showing that device coverage is possible by flipping a bit upon reaching the kernel's entry point.

And has the following similarities
* Captures HIP and HSA runtimes.
* Allows for AFL++'s persistent mode to be used.
* Runs using AFL_PRELOAD environment variable.
* Modifies kernels at runtime.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Besides unit tests, integration tests for the fuzzer exist. The last test added proves that the bitmap is updated by the device indirectly via a buffer.

## Test Result

All test pass.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
