### PR TITLE
[clr] Windows: fix MSVC warning C4838

### DIFF
--- a/projects/clr/hipamd/src/hip_internal.hpp
+++ b/projects/clr/hipamd/src/hip_internal.hpp
@@ -189,7 +189,7 @@ extern "C" void __hipOnError(const void *err_info);
       const char *desc;                                                                            \
     } err_info = {                                                                                 \
       1,                                                                                           \
-      hip::tls.last_command_error_,                                                                \
+      (uint32_t)hip::tls.last_command_error_,                                                      \
       hipGetErrorName(hip::tls.last_command_error_),                                               \
       hipGetErrorString(hip::tls.last_command_error_)                                              \
     };                                                                                             \


### PR DESCRIPTION
## Motivation

While building CLR on Windows I got 2568 warnings:
```
H:\ROCm\rocm-systems\projects\clr\hipamd\src\hip_error.cpp(15): warning C4838: conversion from 'hipError_t' to 'uint32_t' requires a narrowing conversion
H:\ROCm\rocm-systems\projects\clr\hipamd\src\hip_error.cpp(22): warning C4838: conversion from 'hipError_t' to 'uint32_t' requires a narrowing conversion
H:\ROCm\rocm-systems\projects\clr\hipamd\src\hip_error.cpp(29): warning C4838: conversion from 'hipError_t' to 'uint32_t' requires a narrowing conversion
H:\ROCm\rocm-systems\projects\clr\hipamd\src\hip_error.cpp(31): warning C4838: conversion from 'hipError_t' to 'uint32_t' requires a narrowing conversion
...
```

## Technical Details

MSVC will warn this with https://github.com/ROCm/rocm-systems/commit/5e9f3b642538bb381324fcbfede1f025988f80ca introduced `__hipOnError debugger hook`.

Fix: keep `err_info`'s structure and convert the signed int (hipError_t)last_command_error_ into uint32_t.

## Test Plan

No functional changes.

## Test Result

No warning C4838 while building.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
