### PR TITLE
clr: fix deadlock in GraphMemAllocNode::ReleaseCachedMapping

### DIFF
--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -2788,6 +2788,8 @@ hipError_t hipGraphAddMemAllocNode(hipGraphNode_t* pGraphNode, hipGraph_t graph,
   pNodeParams->dptr =
       (HIP_MEM_POOL_USE_VM) ? mem_alloc_node->ReserveAddress() : mem_alloc_node->Execute();
   if (pNodeParams->dptr == nullptr) {
+    amd::ScopedLock lock(hip::Graph::graphSetLock_);
+    hgraph->RemoveNode(node);
     HIP_RETURN(hipErrorOutOfMemory);
   }
   *pGraphNode = reinterpret_cast<hipGraphNode_t>(node);

--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -2787,6 +2787,9 @@ hipError_t hipGraphAddMemAllocNode(hipGraphNode_t* pGraphNode, hipGraph_t graph,
   // The address must be provided during the node creation time
   pNodeParams->dptr =
       (HIP_MEM_POOL_USE_VM) ? mem_alloc_node->ReserveAddress() : mem_alloc_node->Execute();
+  if (pNodeParams->dptr == nullptr) {
+    HIP_RETURN(hipErrorOutOfMemory);
+  }
   *pGraphNode = reinterpret_cast<hipGraphNode_t>(node);
   amd::ScopedLock lock(hip::Graph::graphSetLock_);
   hgraph->memAllocNodePtrs_.insert(pNodeParams->dptr);

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -2951,6 +2951,9 @@ class GraphMemAllocNode final : public GraphNode {
           *stream, amd::Command::EventWaitList{},
           node_params_.dptr, sub_obj->getSize(), nullptr);
       cmd->enqueue();
+      if (!AMD_DIRECT_DISPATCH) {
+        cmd->awaitCompletion();
+      }
       cmd->release();
       if (phys != nullptr && pool != nullptr) {
         pool->DecrementRefCount(phys);

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -802,6 +802,7 @@ class Graph {
                                                    dev_info.virtualMemAllocGranularityRecommended_);
     if (ptr == nullptr) {
       LogError("Failed to reserve Virtual Address");
+      return nullptr;
     }
 
     // Set Access to read write for all devices.
@@ -2941,15 +2942,15 @@ class GraphMemAllocNode final : public GraphNode {
       hip::Stream* stream = launch_stream;
       if (stream == nullptr) {
         auto device_id = phys ? phys->getUserData().deviceId : 0;
-        stream = g_devices[device_id]->NullStream();
+        // wait=false: skip WaitActiveStreams — not needed since GPU is already done
+        // when called from the async events loop callback (DecrementRefCount), and
+        // waiting deadlocks if called from the async events loop thread.
+        stream = g_devices[device_id]->NullStream(false);
       }
       auto cmd = new amd::VirtualMapCommand(
           *stream, amd::Command::EventWaitList{},
           node_params_.dptr, sub_obj->getSize(), nullptr);
       cmd->enqueue();
-      if (launch_stream == nullptr) {
-        cmd->awaitCompletion();
-      }
       cmd->release();
       if (phys != nullptr && pool != nullptr) {
         pool->DecrementRefCount(phys);

--- a/projects/clr/hipamd/src/hip_mempool_impl.cpp
+++ b/projects/clr/hipamd/src/hip_mempool_impl.cpp
@@ -501,8 +501,13 @@ void MemoryPool::GetAccess(hip::Device* device, hipMemAccessFlags* flags) {
 
 // ================================================================================================
 void MemoryPool::FreeAllMemory(Stream* stream) {
+  // skip_event=true: ordering is guaranteed by the caller (AutoFreeOnLaunch path
+  // finishes the stream before next dispatch). Creating a marker event here would
+  // allocate an HSA signal that leaks under ASAN if the free_heap_ entry is never
+  // reused before the pool is destroyed.
+  constexpr bool kSkipEvent = true;
   while (!busy_heap_.Allocations().empty()) {
-    FreeMemory(busy_heap_.Allocations().begin()->first.second, stream);
+    FreeMemory(busy_heap_.Allocations().begin()->first.second, stream, nullptr, kSkipEvent);
   }
 }
 


### PR DESCRIPTION
## Motivation
When GraphExec::DecrementRefCount fires as a GPU completion callback, the destructor runs on the async events loop thread. Calling NullStream(wait=true) from this context triggers WaitActiveStreams which spins in awaitCompletion waiting for stream completions — but those completions are delivered by the same async events loop thread, causing a deadlock.

## Technical Details
Fix:
- Pass wait=false to NullStream() in ReleaseCachedMapping to skip WaitActiveStreams on the destructor/trim path. The GPU is already done when DecrementRefCount fires, so waiting on active streams is unnecessary.
- Remove cmd->awaitCompletion() on the destructor path. With AMD_DIRECT_DISPATCH, enqueue() calls submitVirtualMap synchronously so the unmap is complete before enqueue() returns.
- Add null check on dptr after ReserveAddress()/Execute() in hipGraphAddMemAllocNode and return hipErrorOutOfMemory.
- Pass skip_event=true in FreeAllMemory to avoid HSA signal allocation that leaks under ASAN on the AutoFreeOnLaunch path.

The deadlock caused the hung process to hold graph pool memory (512MB per device), resulting in OOM failures in 26 other tests on memory-constrained PSDBs.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
AIRUNTIME-2286
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
