### PR TITLE
[rocprofiler-systems] Change priority to current power metric. Correct track names for UMC Busy and Power Usage

### DIFF
--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.cpp
@@ -1363,8 +1363,9 @@ perfetto_processor_t::handle([[maybe_unused]] const gpu_pmc_sample& _gpu_pmc)
     // Scalar metrics
     emit_gpu_scalar<amd_smi_gfx_track>(_device_id, _ts, _em.bits.gfx_activity, "GFX Busy",
                                        "%", _m.gfx_activity);
-    emit_gpu_scalar<amd_smi_umc_track>(_device_id, _ts, _em.bits.umc_activity, "UMC Busy",
-                                       "%", _m.umc_activity);
+    emit_gpu_scalar<amd_smi_umc_track>(_device_id, _ts, _em.bits.umc_activity,
+                                       pmc::collectors::gpu::UMC_BUSY_TRACK_LABEL, "%",
+                                       _m.umc_activity);
     emit_gpu_scalar<amd_smi_mm_track>(_device_id, _ts, _em.bits.mm_activity, "MM Busy",
                                       "%", _m.mm_activity);
 
@@ -1375,9 +1376,8 @@ perfetto_processor_t::handle([[maybe_unused]] const gpu_pmc_sample& _gpu_pmc)
 
     emit_gpu_scalar<amd_smi_power_track>(
         _device_id, _ts, _em.bits.current_socket_power || _em.bits.average_socket_power,
-        "Current Power", "watts",
-        _em.bits.average_socket_power ? _m.average_socket_power
-                                      : _m.current_socket_power);
+        pmc::collectors::gpu::socket_power_track_label(_em), "watts",
+        pmc::collectors::gpu::select_socket_power(_em, _m));
 
     emit_gpu_scalar<amd_smi_mem_track>(
         _device_id, _ts, _em.bits.memory_usage, "Memory Usage", "megabytes",

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.cpp
@@ -1364,8 +1364,7 @@ perfetto_processor_t::handle([[maybe_unused]] const gpu_pmc_sample& _gpu_pmc)
     emit_gpu_scalar<amd_smi_gfx_track>(_device_id, _ts, _em.bits.gfx_activity, "GFX Busy",
                                        "%", _m.gfx_activity);
     emit_gpu_scalar<amd_smi_umc_track>(_device_id, _ts, _em.bits.umc_activity,
-                                       pmc::collectors::gpu::UMC_BUSY_TRACK_LABEL, "%",
-                                       _m.umc_activity);
+                                       "UMC Avg. Busy", "%", _m.umc_activity);
     emit_gpu_scalar<amd_smi_mm_track>(_device_id, _ts, _em.bits.mm_activity, "MM Busy",
                                       "%", _m.mm_activity);
 

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_processor.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/rocpd_processor.cpp
@@ -369,8 +369,7 @@ rocpd_processor_t::handle([[maybe_unused]] const gpu_pmc_sample& _gpu_pmc)
     insert_scalar(trait::name<category::amd_smi_power>::value,
                   info::format_track_name<category::amd_smi_power>(),
                   enabled.bits.current_socket_power || enabled.bits.average_socket_power,
-                  enabled.bits.current_socket_power ? m.current_socket_power
-                                                    : m.average_socket_power);
+                  pmc::collectors::gpu::select_socket_power(enabled, m));
     insert_scalar(trait::name<category::amd_smi_memory_usage>::value,
                   info::format_track_name<category::amd_smi_memory_usage>(),
                   enabled.bits.memory_usage, m.memory_usage / units::megabyte);

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/gpu/cache_policy.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/gpu/cache_policy.hpp
@@ -181,7 +181,7 @@ struct cache_policy
 
         trace_cache::get_metadata_registry().add_pmc_info(
             { agent_type::GPU, gpu_id, TARGET_ARCH, EVENT_CODE, INSTANCE_ID,
-              trait::name<category::amd_smi_umc_busy>::value, "UMC Busy",
+              trait::name<category::amd_smi_umc_busy>::value, UMC_BUSY_TRACK_LABEL,
               trait::name<category::amd_smi_umc_busy>::description, LONG_DESCRIPTION,
               COMPONENT, trace_cache::PERCENTAGE, rocprofsys::trace_cache::ABSOLUTE,
               BLOCK, EXPRESSION, 0, 0, "{}" });

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/gpu/cache_policy.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/gpu/cache_policy.hpp
@@ -181,7 +181,7 @@ struct cache_policy
 
         trace_cache::get_metadata_registry().add_pmc_info(
             { agent_type::GPU, gpu_id, TARGET_ARCH, EVENT_CODE, INSTANCE_ID,
-              trait::name<category::amd_smi_umc_busy>::value, UMC_BUSY_TRACK_LABEL,
+              trait::name<category::amd_smi_umc_busy>::value, "UMC Avg. Busy",
               trait::name<category::amd_smi_umc_busy>::description, LONG_DESCRIPTION,
               COMPONENT, trace_cache::PERCENTAGE, rocprofsys::trace_cache::ABSOLUTE,
               BLOCK, EXPRESSION, 0, 0, "{}" });

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/gpu/perfetto_policy.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/gpu/perfetto_policy.hpp
@@ -62,7 +62,7 @@ make_default_tracks()
 {
     return {
         { GFX_BUSY_VALUE, { "GFX Busy", "%", {} } },
-        { UMC_BUSY_VALUE, { UMC_BUSY_TRACK_LABEL, "%", {} } },
+        { UMC_BUSY_VALUE, { "UMC Avg. Busy", "%", {} } },
         { MM_BUSY_VALUE, { "MM Busy", "%", {} } },
         { TEMPERATURE_VALUE, { "Temperature", "deg C", {} } },
         { CURRENT_POWER_VALUE, { "Current Power", "watts", {} } },

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/gpu/perfetto_policy.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/gpu/perfetto_policy.hpp
@@ -62,7 +62,7 @@ make_default_tracks()
 {
     return {
         { GFX_BUSY_VALUE, { "GFX Busy", "%", {} } },
-        { UMC_BUSY_VALUE, { "UMC Busy", "%", {} } },
+        { UMC_BUSY_VALUE, { UMC_BUSY_TRACK_LABEL, "%", {} } },
         { MM_BUSY_VALUE, { "MM Busy", "%", {} } },
         { TEMPERATURE_VALUE, { "Temperature", "deg C", {} } },
         { CURRENT_POWER_VALUE, { "Current Power", "watts", {} } },
@@ -247,8 +247,18 @@ struct perfetto_policy
             }
             else
             {
+                const char* track_name = description.track_name;
+                if(num == detail::CURRENT_POWER_VALUE)
+                {
+                    // Label reflects the reading actually emitted (current vs. average),
+                    // based on what this device supports and the user enabled.
+                    enabled_metrics effective_power{};
+                    effective_power.value =
+                        enabled_metric_config.value & device_data.supported_metrics.value;
+                    track_name = socket_power_track_label(effective_power);
+                }
                 description.track_indexes.emplace_back(counter_track::emplace(
-                    device_index, addendum(description.track_name), description.units));
+                    device_index, addendum(track_name), description.units));
             }
         }
 
@@ -425,9 +435,7 @@ private:
             effective_metrics.bits.current_socket_power) &&
            power_it != tracks.end() && !power_it->second.track_indexes.empty())
         {
-            const double power = effective_metrics.bits.average_socket_power
-                                     ? metric_values.average_socket_power
-                                     : metric_values.current_socket_power;
+            const double power = select_socket_power(effective_metrics, metric_values);
             TRACE_COUNTER(
                 "device_power",
                 counter_track::at(device_index, power_it->second.track_indexes[0]), ts,

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/gpu/tests/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/gpu/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-add_library(pmc-gpu-collector-tests OBJECT test_device.cpp)
+add_library(pmc-gpu-collector-tests OBJECT test_device.cpp test_power_metrics.cpp)
 
 target_link_libraries(
     pmc-gpu-collector-tests

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/gpu/tests/test_power_metrics.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/gpu/tests/test_power_metrics.cpp
@@ -1,0 +1,79 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+//
+// Unit tests for the shared socket-power selection / labeling helpers and the
+// UMC busy track label declared in library/pmc/collectors/gpu/types.hpp.
+//
+// These helpers are the single source of truth used by the live Perfetto path
+// (perfetto_policy.hpp) and the replay paths (perfetto_processor.cpp /
+// rocpd_processor.cpp), so exercising them here covers all output formats.
+//
+
+#include "library/pmc/collectors/gpu/types.hpp"
+#include <cstdint>
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+using namespace rocprofsys::pmc::collectors::gpu;
+
+namespace
+{
+
+enabled_metrics
+make_enabled(bool current, bool average)
+{
+    enabled_metrics em{};
+    em.bits.current_socket_power = current ? 1u : 0u;
+    em.bits.average_socket_power = average ? 1u : 0u;
+    return em;
+}
+
+metrics
+make_power_metrics(std::uint32_t current, std::uint32_t average)
+{
+    metrics m{};
+    m.current_socket_power = current;
+    m.average_socket_power = average;
+    return m;
+}
+
+}  // namespace
+
+// Current available (with or without average) -> current value is used.
+TEST(socket_power, PrefersCurrentWhenAvailable)
+{
+    const auto m = make_power_metrics(150, 140);
+
+    EXPECT_DOUBLE_EQ(select_socket_power(make_enabled(true, false), m), 150.0);
+    EXPECT_DOUBLE_EQ(select_socket_power(make_enabled(true, true), m), 150.0);
+}
+
+// Only average available -> falls back to the averaged reading.
+TEST(socket_power, FallsBackToAverageWhenCurrentUnavailable)
+{
+    const auto m = make_power_metrics(150, 140);
+
+    EXPECT_DOUBLE_EQ(select_socket_power(make_enabled(false, true), m), 140.0);
+}
+
+TEST(socket_power, HasCurrentReflectsBit)
+{
+    EXPECT_TRUE(has_current_socket_power(make_enabled(true, false)));
+    EXPECT_TRUE(has_current_socket_power(make_enabled(true, true)));
+    EXPECT_FALSE(has_current_socket_power(make_enabled(false, true)));
+    EXPECT_FALSE(has_current_socket_power(make_enabled(false, false)));
+}
+
+// Track label matches the reading select_socket_power() emits.
+TEST(socket_power, TrackLabelMatchesSelectedReading)
+{
+    EXPECT_STREQ(socket_power_track_label(make_enabled(true, false)), "Current Power");
+    EXPECT_STREQ(socket_power_track_label(make_enabled(true, true)), "Current Power");
+    EXPECT_STREQ(socket_power_track_label(make_enabled(false, true)), "Avg. Power");
+}
+
+// UMC busy is always an averaged reading; the label states so explicitly.
+TEST(umc_busy, LabelIsAverage) { EXPECT_STREQ(UMC_BUSY_TRACK_LABEL, "UMC Avg. Busy"); }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/gpu/tests/test_power_metrics.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/gpu/tests/test_power_metrics.cpp
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 //
-// Unit tests for the shared socket-power selection / labeling helpers and the
-// UMC busy track label declared in library/pmc/collectors/gpu/types.hpp.
+// Unit tests for the shared socket-power selection / labeling helpers declared in
+// library/pmc/collectors/gpu/types.hpp.
 //
 // These helpers are the single source of truth used by the live Perfetto path
 // (perfetto_policy.hpp) and the replay paths (perfetto_processor.cpp /
@@ -14,8 +14,6 @@
 #include <cstdint>
 
 #include <gtest/gtest.h>
-
-#include <string>
 
 using namespace rocprofsys::pmc::collectors::gpu;
 
@@ -74,6 +72,3 @@ TEST(socket_power, TrackLabelMatchesSelectedReading)
     EXPECT_STREQ(socket_power_track_label(make_enabled(true, true)), "Current Power");
     EXPECT_STREQ(socket_power_track_label(make_enabled(false, true)), "Avg. Power");
 }
-
-// UMC busy is always an averaged reading; the label states so explicitly.
-TEST(umc_busy, LabelIsAverage) { EXPECT_STREQ(UMC_BUSY_TRACK_LABEL, "UMC Avg. Busy"); }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/gpu/types.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/gpu/types.hpp
@@ -145,10 +145,6 @@ struct metrics
     std::uint32_t mem_clock_mhz = 0;  // current_uclk (MHz)
 };
 
-// AMD SMI reports UMC busy as a time-averaged value (average_umc_activity), so the
-// track is labeled to make the averaging explicit.
-inline constexpr const char* UMC_BUSY_TRACK_LABEL = "UMC Avg. Busy";
-
 // Socket power: prefer the instantaneous "current" reading, falling back to the
 // time-averaged reading only when current is unavailable.
 [[nodiscard]] inline bool

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/gpu/types.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/gpu/types.hpp
@@ -145,6 +145,33 @@ struct metrics
     std::uint32_t mem_clock_mhz = 0;  // current_uclk (MHz)
 };
 
+// AMD SMI reports UMC busy as a time-averaged value (average_umc_activity), so the
+// track is labeled to make the averaging explicit.
+inline constexpr const char* UMC_BUSY_TRACK_LABEL = "UMC Avg. Busy";
+
+// Socket power: prefer the instantaneous "current" reading, falling back to the
+// time-averaged reading only when current is unavailable.
+[[nodiscard]] inline bool
+has_current_socket_power(const enabled_metrics& enabled)
+{
+    return enabled.bits.current_socket_power != 0;
+}
+
+[[nodiscard]] inline double
+select_socket_power(const enabled_metrics& enabled, const metrics& values)
+{
+    return has_current_socket_power(enabled)
+               ? static_cast<double>(values.current_socket_power)
+               : static_cast<double>(values.average_socket_power);
+}
+
+// Display label for the socket-power track, matching select_socket_power().
+[[nodiscard]] inline const char*
+socket_power_track_label(const enabled_metrics& enabled)
+{
+    return has_current_socket_power(enabled) ? "Current Power" : "Avg. Power";
+}
+
 template <typename T>
 [[nodiscard]] constexpr bool
 is_metric_supported(T value, T invalid_sentinel = std::numeric_limits<T>::max())


### PR DESCRIPTION
## Motivation

GPU socket-power readings were not consistently prioritized across output paths. The live Perfetto path and the Perfetto replay path preferred the time-averaged socket power (`average_socket_power`) when both were available, while the RocPD replay path preferred the instantaneous `current_socket_power`. This inconsistency meant the same run could report different power values depending on the output format. The instantaneous "current" reading is the more meaningful metric, so all paths should prefer it and only fall back to the averaged reading when current is unavailable.

Additionally, two track labels did not reflect the nature of the underlying reading. AMD SMI reports UMC busy as a time-averaged value, and the socket-power track was always labeled "Current Power" even when the emitted value was actually the averaged reading. The labels are now corrected so the displayed name matches the data being shown.

## Technical Details

Introduced shared helpers in `library/pmc/collectors/gpu/types.hpp` as the single source of truth for socket-power selection and labeling:
- `has_current_socket_power(enabled)` — whether the instantaneous reading is enabled.
- `select_socket_power(enabled, values)` — returns the current reading, falling back to the average only when current is unavailable.
- `socket_power_track_label(enabled)` — returns `"Current Power"` or `"Avg. Power"` to match the selected reading.
- `UMC_BUSY_TRACK_LABEL` constant set to `"UMC Avg. Busy"` to make the averaging explicit.

These helpers are now used uniformly across all three output paths:
- `perfetto_processor.cpp` (Perfetto replay) — uses `select_socket_power` / `socket_power_track_label` and the UMC label constant.
- `rocpd_processor.cpp` (RocPD replay) — uses `select_socket_power`.
- `perfetto_policy.hpp` (live Perfetto capture) — uses `select_socket_power`, and now derives the power track label at emit time from the device's supported metrics intersected with the user-enabled metrics, so the live track name reflects the reading actually emitted.
- `cache_policy.hpp` — uses `UMC_BUSY_TRACK_LABEL` for the PMC metadata registry entry.

## JIRA ID

<!-- If applicable. -->
AIPROFSYST-468

## Test Plan

- [x] New unit test suite `tests/test_power_metrics.cpp` (registered in `tests/CMakeLists.txt`) exercising the shared helpers, which back every output format:
  - prefers current power when available (with and without average present)
  - falls back to average when current is unavailable
  - `has_current_socket_power` reflects the enabled bit
  - `socket_power_track_label` matches the selected reading
  - `UMC_BUSY_TRACK_LABEL` equals `"UMC Avg. Busy"`
- [x] Verify Perfetto and RocPD outputs show consistent power values and corrected track names ("Current Power"/"Avg. Power", "UMC Avg. Busy").

## Test Result
Tests passing.
<!-- Summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.