### PR TITLE
feat(clr): add DFS stream assignment to segment scheduling path

### DIFF
--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -1597,7 +1597,9 @@ hipError_t ihipGraphInstantiate(hip::GraphExec** pGraphExec, hip::Graph* graph,
   }
 
   // PAL/Windows: classic topological path — no segment scheduling, no AQL capture.
-  if (GPU_ENABLE_PAL != 0) {
+  // DEBUG_HIP_GRAPH_CLASSIC_PATH=1 forces this path on Linux for testing without
+  // enabling the full PAL backend.
+  if (GPU_ENABLE_PAL != 0 || DEBUG_HIP_GRAPH_CLASSIC_PATH) {
     auto* classicExec = new hip::GraphExecClassic(flags);
     graph->clone(classicExec, true);
     graph->SetGraphInstantiated(true);

--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -1600,7 +1600,7 @@ hipError_t ihipGraphInstantiate(hip::GraphExec** pGraphExec, hip::Graph* graph,
   *pGraphExec = new hip::GraphExec(flags);
   graph->clone(*pGraphExec, true);
 
-  hipError_t scheduleStatus = (*pGraphExec)->ScheduleNodes();
+  hipError_t scheduleStatus = (*pGraphExec)->ScheduleNodesIntoBatches();
   if (scheduleStatus != hipSuccess) {
     delete *pGraphExec;
     *pGraphExec = nullptr;

--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -1491,7 +1491,7 @@ hipError_t hipGraphExecMemcpyNodeSetParams1D(hipGraphExec_t hGraphExec, hipGraph
     HIP_RETURN(hipErrorInvalidValue);
   }
   hip::GraphNode* clonedNode = reinterpret_cast<hip::GraphNode*>(
-      reinterpret_cast<hip::GraphExec*>(hGraphExec)->GetClonedNode(n));
+      reinterpret_cast<hip::GraphExecBase*>(hGraphExec)->GetClonedNode(n));
   if (clonedNode == nullptr) {
     HIP_RETURN(hipErrorInvalidValue);
   }
@@ -1504,7 +1504,7 @@ hipError_t hipGraphExecMemcpyNodeSetParams1D(hipGraphExec_t hGraphExec, hipGraph
   if (status != hipSuccess) {
     HIP_RETURN(status);
   }
-  auto graphExec = reinterpret_cast<hip::GraphExec*>(hGraphExec);
+  auto graphExec = reinterpret_cast<hip::GraphExecBase*>(hGraphExec);
   status = graphExec->UpdateAQLPacket(reinterpret_cast<hip::GraphKernelNode*>(clonedNode));
   HIP_RETURN(status);
 }
@@ -1582,7 +1582,7 @@ hipError_t hipGraphAddChildGraphNode(hipGraphNode_t* pGraphNode, hipGraph_t grap
   HIP_RETURN(status);
 }
 
-hipError_t ihipGraphInstantiate(hip::GraphExec** pGraphExec, hip::Graph* graph,
+hipError_t ihipGraphInstantiate(hip::GraphExecBase** pGraphExec, hip::Graph* graph,
                                 uint64_t flags = 0) {
   if (pGraphExec == nullptr || graph == nullptr) {
     return hipErrorInvalidValue;
@@ -1602,39 +1602,44 @@ hipError_t ihipGraphInstantiate(hip::GraphExec** pGraphExec, hip::Graph* graph,
   if (GPU_ENABLE_PAL != 0 || DEBUG_HIP_GRAPH_CLASSIC_PATH) {
     auto* classicExec = new hip::GraphExecClassic(flags);
     graph->clone(classicExec, true);
-    graph->SetGraphInstantiated(true);
     hipError_t initStatus = classicExec->Init();
     if (initStatus != hipSuccess) {
       delete classicExec;
       return initStatus;
     }
     *pGraphExec = classicExec;
-    return hipSuccess;
+  } else {
+    auto* segExec = new hip::GraphExecSegmented(flags);
+    graph->clone(segExec, true);
+
+    hipError_t scheduleStatus = segExec->ScheduleNodesIntoBatches();
+    if (scheduleStatus != hipSuccess) {
+      delete segExec;
+      return scheduleStatus;
+    }
+
+    segExec->SetKernelArgManager(new hip::GraphKernelArgManager());
+    hipError_t initStatus = segExec->Init();
+    if (initStatus != hipSuccess) {
+      delete segExec;
+      return initStatus;
+    }
+    *pGraphExec = segExec;
   }
 
-  auto* segExec = new hip::GraphExecSegmented(flags);
-  graph->clone(segExec, true);
+  graph->SetGraphInstantiated(true);
 
-  hipError_t scheduleStatus = segExec->ScheduleNodesIntoBatches();
-  if (scheduleStatus != hipSuccess) {
-    delete segExec;
-    return scheduleStatus;
-  }
   if (DEBUG_HIP_GRAPH_DOT_PRINT == 1) {
     static int i = 1;
     std::string filename =
         "graph_" + std::to_string(amd::Os::getProcessId()) + "_dot_print_" + std::to_string(i++);
-    hipError_t status = ihipGraphDebugDotPrint(segExec, filename.c_str(), 0);
+    hipError_t status = ihipGraphDebugDotPrint(*pGraphExec, filename.c_str(), 0);
     if (status == hipSuccess) {
       LogPrintfInfo("[hipGraph] graph dump:%s", filename.c_str());
     }
   }
 
-  graph->SetGraphInstantiated(true);
-
-  segExec->SetKernelArgManager(new hip::GraphKernelArgManager());
-  *pGraphExec = segExec;
-  return segExec->Init();
+  return hipSuccess;
 }
 
 hipError_t hipGraphInstantiate(hipGraphExec_t* pGraphExec, hipGraph_t graph,
@@ -1643,7 +1648,7 @@ hipError_t hipGraphInstantiate(hipGraphExec_t* pGraphExec, hipGraph_t graph,
   if (pGraphExec == nullptr || graph == nullptr) {
     HIP_RETURN(hipErrorInvalidValue);
   }
-  hip::GraphExec* ge;
+  hip::GraphExecBase* ge;
   hipError_t status = ihipGraphInstantiate(&ge, reinterpret_cast<hip::Graph*>(graph));
   if (status == hipSuccess) {
     *pGraphExec = reinterpret_cast<hipGraphExec_t>(ge);
@@ -1664,7 +1669,7 @@ hipError_t hipGraphInstantiateWithFlags(hipGraphExec_t* pGraphExec, hipGraph_t g
     HIP_RETURN(hipErrorInvalidValue);
   }
 
-  hip::GraphExec* ge;
+  hip::GraphExecBase* ge;
   hipError_t status = ihipGraphInstantiate(&ge, reinterpret_cast<hip::Graph*>(graph), flags);
   *pGraphExec = reinterpret_cast<hipGraphExec_t>(ge);
   HIP_RETURN(status, ReturnPtrValue(pGraphExec));
@@ -1686,7 +1691,7 @@ hipError_t hipGraphInstantiateWithParams(hipGraphExec_t* pGraphExec, hipGraph_t 
     HIP_RETURN(hipErrorInvalidValue);
   }
 
-  hip::GraphExec* ge;
+  hip::GraphExecBase* ge;
   hipError_t status = ihipGraphInstantiate(&ge, reinterpret_cast<hip::Graph*>(graph), flags);
   *pGraphExec = reinterpret_cast<hipGraphExec_t>(ge);
   if (status != hipSuccess) {
@@ -1721,14 +1726,14 @@ hipError_t hipGraphExecDestroy(hipGraphExec_t pGraphExec) {
   HIP_RETURN(hipSuccess);
 }
 
-hipError_t ihipGraphLaunch(hip::GraphExec* graphExec, hipStream_t stream) {
+hipError_t ihipGraphLaunch(hip::GraphExecBase* graphExec, hipStream_t stream) {
   getStreamPerThread(stream);
   hip::Stream* launch_stream = hip::getStream(stream);
   return graphExec->Run(launch_stream);
 }
 
-hipError_t hipGraphLaunch_common(hip::GraphExec* graphExec, hipStream_t stream) {
-  if (graphExec == nullptr || !hip::GraphExec::isGraphExecValid(graphExec)) {
+hipError_t hipGraphLaunch_common(hip::GraphExecBase* graphExec, hipStream_t stream) {
+  if (graphExec == nullptr || !hip::GraphExecBase::isGraphExecValid(graphExec)) {
     return hipErrorInvalidValue;
   }
   if (!hip::isValid(stream)) {
@@ -1743,13 +1748,13 @@ hipError_t hipGraphLaunch_common(hip::GraphExec* graphExec, hipStream_t stream) 
 
 hipError_t hipGraphLaunch(hipGraphExec_t graphExec, hipStream_t stream) {
   HIP_INIT_API(hipGraphLaunch, graphExec, stream);
-  HIP_RETURN_DURATION(hipGraphLaunch_common(reinterpret_cast<hip::GraphExec*>(graphExec), stream));
+  HIP_RETURN_DURATION(hipGraphLaunch_common(reinterpret_cast<hip::GraphExecBase*>(graphExec), stream));
 }
 
 hipError_t hipGraphLaunch_spt(hipGraphExec_t graphExec, hipStream_t stream) {
   HIP_INIT_API(hipGraphLaunch, graphExec, stream);
   PER_THREAD_DEFAULT_STREAM(stream);
-  HIP_RETURN_DURATION(hipGraphLaunch_common(reinterpret_cast<hip::GraphExec*>(graphExec), stream));
+  HIP_RETURN_DURATION(hipGraphLaunch_common(reinterpret_cast<hip::GraphExecBase*>(graphExec), stream));
 }
 
 hipError_t hipGraphGetNodes(hipGraph_t graph, hipGraphNode_t* nodes, size_t* numNodes) {
@@ -1906,7 +1911,7 @@ hipError_t hipGraphExecMemcpyNodeSetParams(hipGraphExec_t hGraphExec, hipGraphNo
       ((pNodeParams->dstArray == 0) && (pNodeParams->dstPtr.ptr == nullptr))) {
     HIP_RETURN(hipErrorInvalidValue);
   }
-  hip::GraphNode* clonedNode = reinterpret_cast<hip::GraphExec*>(hGraphExec)->GetClonedNode(n);
+  hip::GraphNode* clonedNode = reinterpret_cast<hip::GraphExecBase*>(hGraphExec)->GetClonedNode(n);
   if (clonedNode == nullptr) {
     HIP_RETURN(hipErrorInvalidValue);
   }
@@ -1920,7 +1925,7 @@ hipError_t hipGraphExecMemcpyNodeSetParams(hipGraphExec_t hGraphExec, hipGraphNo
   if (status != hipSuccess) {
     HIP_RETURN(status);
   }
-  auto graphExec = reinterpret_cast<hip::GraphExec*>(hGraphExec);
+  auto graphExec = reinterpret_cast<hip::GraphExecBase*>(hGraphExec);
   status = graphExec->UpdateAQLPacket(reinterpret_cast<hip::GraphKernelNode*>(clonedNode));
   HIP_RETURN(status);
 }
@@ -1960,7 +1965,7 @@ hipError_t hipGraphExecMemsetNodeSetParams(hipGraphExec_t hGraphExec, hipGraphNo
   if (ihipGraphMemsetParams_validate(pNodeParams) != hipSuccess) {
     HIP_RETURN(hipErrorInvalidValue);
   }
-  hip::GraphNode* clonedNode = reinterpret_cast<hip::GraphExec*>(hGraphExec)->GetClonedNode(n);
+  hip::GraphNode* clonedNode = reinterpret_cast<hip::GraphExecBase*>(hGraphExec)->GetClonedNode(n);
   if (clonedNode == nullptr) {
     HIP_RETURN(hipErrorInvalidValue);
   }
@@ -1969,7 +1974,7 @@ hipError_t hipGraphExecMemsetNodeSetParams(hipGraphExec_t hGraphExec, hipGraphNo
   if (status != hipSuccess) {
     HIP_RETURN(status);
   }
-  auto graphExec = reinterpret_cast<hip::GraphExec*>(hGraphExec);
+  auto graphExec = reinterpret_cast<hip::GraphExecBase*>(hGraphExec);
   status = graphExec->UpdateAQLPacket(reinterpret_cast<hip::GraphKernelNode*>(clonedNode));
   HIP_RETURN(status);
 }
@@ -2019,7 +2024,7 @@ hipError_t hipGraphExecKernelNodeSetParams(hipGraphExec_t hGraphExec, hipGraphNo
       pNodeParams->func == nullptr || n->GetType() != hipGraphNodeTypeKernel) {
     HIP_RETURN(hipErrorInvalidValue);
   }
-  hip::GraphNode* clonedNode = reinterpret_cast<hip::GraphExec*>(hGraphExec)->GetClonedNode(n);
+  hip::GraphNode* clonedNode = reinterpret_cast<hip::GraphExecBase*>(hGraphExec)->GetClonedNode(n);
   if (clonedNode == nullptr) {
     HIP_RETURN(hipErrorInvalidValue);
   }
@@ -2027,7 +2032,7 @@ hipError_t hipGraphExecKernelNodeSetParams(hipGraphExec_t hGraphExec, hipGraphNo
   if (status != hipSuccess) {
     HIP_RETURN(status);
   }
-  auto graphExec = reinterpret_cast<hip::GraphExec*>(hGraphExec);
+  auto graphExec = reinterpret_cast<hip::GraphExecBase*>(hGraphExec);
   status = graphExec->UpdateAQLPacket(reinterpret_cast<hip::GraphKernelNode*>(clonedNode));
   HIP_RETURN(status);
 }
@@ -2094,7 +2099,7 @@ hipError_t hipGraphExecChildGraphNodeSetParams(hipGraphExec_t hGraphExec, hipGra
     return status;
   }
 
-  hip::GraphNode* clonedNode = reinterpret_cast<hip::GraphExec*>(hGraphExec)->GetClonedNode(n);
+  hip::GraphNode* clonedNode = reinterpret_cast<hip::GraphExecBase*>(hGraphExec)->GetClonedNode(n);
   if (clonedNode == nullptr) {
     HIP_RETURN(hipErrorInvalidValue);
   }
@@ -2106,7 +2111,7 @@ hipError_t hipGraphExecChildGraphNodeSetParams(hipGraphExec_t hGraphExec, hipGra
   hip::ChildGraphNode* childNode = reinterpret_cast<hip::ChildGraphNode*>(clonedNode);
 
   // After SetParams updates node parameters in-place, we need to update the cached AQL packets
-  auto graphExec = reinterpret_cast<hip::GraphExec*>(hGraphExec);
+  auto graphExec = reinterpret_cast<hip::GraphExecBase*>(hGraphExec);
   {
     std::vector<hip::GraphNode*> childGraphNodes;
     childNode->TopologicalOrder(childGraphNodes);
@@ -2497,7 +2502,7 @@ hipError_t hipGraphExecMemcpyNodeSetParamsFromSymbol(hipGraphExec_t hGraphExec, 
     HIP_RETURN(hipErrorInvalidValue);
   }
 
-  hip::GraphNode* clonedNode = reinterpret_cast<hip::GraphExec*>(hGraphExec)->GetClonedNode(n);
+  hip::GraphNode* clonedNode = reinterpret_cast<hip::GraphExecBase*>(hGraphExec)->GetClonedNode(n);
   if (clonedNode == nullptr) {
     HIP_RETURN(hipErrorInvalidValue);
   }
@@ -2513,7 +2518,7 @@ hipError_t hipGraphExecMemcpyNodeSetParamsFromSymbol(hipGraphExec_t hGraphExec, 
   if (status != hipSuccess) {
     HIP_RETURN(status);
   }
-  auto graphExec = reinterpret_cast<hip::GraphExec*>(hGraphExec);
+  auto graphExec = reinterpret_cast<hip::GraphExecBase*>(hGraphExec);
   status = graphExec->UpdateAQLPacket(reinterpret_cast<hip::GraphKernelNode*>(clonedNode));
   HIP_RETURN(status);
 }
@@ -2576,7 +2581,7 @@ hipError_t hipGraphExecMemcpyNodeSetParamsToSymbol(hipGraphExec_t hGraphExec, hi
     HIP_RETURN(hipErrorInvalidValue);
   }
 
-  hip::GraphNode* clonedNode = reinterpret_cast<hip::GraphExec*>(hGraphExec)->GetClonedNode(n);
+  hip::GraphNode* clonedNode = reinterpret_cast<hip::GraphExecBase*>(hGraphExec)->GetClonedNode(n);
   if (clonedNode == nullptr) {
     HIP_RETURN(hipErrorInvalidValue);
   }
@@ -2591,7 +2596,7 @@ hipError_t hipGraphExecMemcpyNodeSetParamsToSymbol(hipGraphExec_t hGraphExec, hi
   if (status != hipSuccess) {
     HIP_RETURN(status);
   }
-  auto graphExec = reinterpret_cast<hip::GraphExec*>(hGraphExec);
+  auto graphExec = reinterpret_cast<hip::GraphExecBase*>(hGraphExec);
   status = graphExec->UpdateAQLPacket(reinterpret_cast<hip::GraphKernelNode*>(clonedNode));
   HIP_RETURN(status);
 }
@@ -2643,7 +2648,7 @@ hipError_t hipGraphExecEventRecordNodeSetEvent(hipGraphExec_t hGraphExec, hipGra
       n->GetType() != hipGraphNodeTypeEventRecord) {
     HIP_RETURN(hipErrorInvalidValue);
   }
-  hip::GraphNode* clonedNode = reinterpret_cast<hip::GraphExec*>(hGraphExec)->GetClonedNode(n);
+  hip::GraphNode* clonedNode = reinterpret_cast<hip::GraphExecBase*>(hGraphExec)->GetClonedNode(n);
   if (clonedNode == nullptr) {
     HIP_RETURN(hipErrorInvalidValue);
   }
@@ -2698,7 +2703,7 @@ hipError_t hipGraphExecEventWaitNodeSetEvent(hipGraphExec_t hGraphExec, hipGraph
       (n->GetType() != hipGraphNodeTypeWaitEvent)) {
     HIP_RETURN(hipErrorInvalidValue);
   }
-  hip::GraphNode* clonedNode = reinterpret_cast<hip::GraphExec*>(hGraphExec)->GetClonedNode(n);
+  hip::GraphNode* clonedNode = reinterpret_cast<hip::GraphExecBase*>(hGraphExec)->GetClonedNode(n);
   if (clonedNode == nullptr) {
     HIP_RETURN(hipErrorInvalidValue);
   }
@@ -2749,7 +2754,7 @@ hipError_t hipGraphExecHostNodeSetParams(hipGraphExec_t hGraphExec, hipGraphNode
       !hip::GraphNode::isNodeValid(n) || n->GetType() != hipGraphNodeTypeHost) {
     HIP_RETURN(hipErrorInvalidValue);
   }
-  hip::GraphNode* clonedNode = reinterpret_cast<hip::GraphExec*>(hGraphExec)->GetClonedNode(n);
+  hip::GraphNode* clonedNode = reinterpret_cast<hip::GraphExecBase*>(hGraphExec)->GetClonedNode(n);
   if (clonedNode == nullptr) {
     HIP_RETURN(hipErrorInvalidValue);
   }
@@ -2769,7 +2774,7 @@ hipError_t hipGraphExecUpdate(hipGraphExec_t hGraphExec, hipGraph_t hGraph,
   std::vector<hip::GraphNode*> newGraphNodes;
   reinterpret_cast<hip::Graph*>(hGraph)->TopologicalOrder(newGraphNodes);
   std::vector<hip::GraphNode*>& oldGraphExecNodes =
-      reinterpret_cast<hip::GraphExec*>(hGraphExec)->GetNodes();
+      reinterpret_cast<hip::GraphExecBase*>(hGraphExec)->GetNodes();
   if (newGraphNodes.size() != oldGraphExecNodes.size()) {
     *updateResult_out = hipGraphExecUpdateErrorTopologyChanged;
     *hErrorNode_out = nullptr;
@@ -2827,7 +2832,7 @@ hipError_t hipGraphExecUpdate(hipGraphExec_t hGraphExec, hipGraph_t hGraph,
         }
         HIP_RETURN(hipErrorGraphExecUpdateFailure);
       } else {
-        auto graphExec = reinterpret_cast<hip::GraphExec*>(hGraphExec);
+        auto graphExec = reinterpret_cast<hip::GraphExecBase*>(hGraphExec);
         if (newGraphNodes[i]->GraphCaptureEnabled()) {
           status = graphExec->UpdateAQLPacket(reinterpret_cast<hip::GraphKernelNode*>(oldGraphExecNodes[i]));
         }
@@ -3205,9 +3210,9 @@ hipError_t hipGraphDebugDotPrint(hipGraph_t graph, const char* path, unsigned in
 hipError_t hipGraphNodeSetEnabled(hipGraphExec_t hGraphExec, hipGraphNode_t hNode,
                                   unsigned int isEnabled) {
   HIP_INIT_API(hipGraphNodeSetEnabled, hGraphExec, hNode, isEnabled);
-  hip::GraphExec* graphExec = reinterpret_cast<hip::GraphExec*>(hGraphExec);
+  hip::GraphExecBase* graphExec = reinterpret_cast<hip::GraphExecBase*>(hGraphExec);
   hip::GraphNode* node = reinterpret_cast<hip::GraphNode*>(hNode);
-  if (hGraphExec == nullptr || hNode == nullptr || !hip::GraphExec::isGraphExecValid(graphExec) ||
+  if (hGraphExec == nullptr || hNode == nullptr || !hip::GraphExecBase::isGraphExecValid(graphExec) ||
       !hip::GraphNode::isNodeValid(node)) {
     HIP_RETURN(hipErrorInvalidValue);
   }
@@ -3228,11 +3233,11 @@ hipError_t hipGraphNodeSetEnabled(hipGraphExec_t hGraphExec, hipGraphNode_t hNod
 hipError_t hipGraphNodeGetEnabled(hipGraphExec_t hGraphExec, hipGraphNode_t hNode,
                                   unsigned int* isEnabled) {
   HIP_INIT_API(hipGraphNodeGetEnabled, hGraphExec, hNode, isEnabled);
-  hip::GraphExec* graphExec = reinterpret_cast<hip::GraphExec*>(hGraphExec);
+  hip::GraphExecBase* graphExec = reinterpret_cast<hip::GraphExecBase*>(hGraphExec);
   hip::GraphNode* node = reinterpret_cast<hip::GraphNode*>(hNode);
 
   if (hGraphExec == nullptr || hNode == nullptr || isEnabled == nullptr ||
-      !hip::GraphExec::isGraphExecValid(graphExec) || !hip::GraphNode::isNodeValid(node)) {
+      !hip::GraphExecBase::isGraphExecValid(graphExec) || !hip::GraphNode::isNodeValid(node)) {
     HIP_RETURN(hipErrorInvalidValue);
   }
   hip::GraphNode* clonedNode = graphExec->GetClonedNode(node);
@@ -3460,8 +3465,8 @@ hipError_t hipGraphExecExternalSemaphoresSignalNodeSetParams(
     const hipExternalSemaphoreSignalNodeParams* nodeParams) {
   HIP_INIT_API(hipGraphExecExternalSemaphoresSignalNodeSetParams, hGraphExec, hNode, nodeParams);
   hip::GraphNode* n = reinterpret_cast<hip::GraphNode*>(hNode);
-  hip::GraphExec* graphExec = reinterpret_cast<hip::GraphExec*>(hGraphExec);
-  if (hGraphExec == nullptr || hNode == nullptr || !hip::GraphExec::isGraphExecValid(graphExec) ||
+  hip::GraphExecBase* graphExec = reinterpret_cast<hip::GraphExecBase*>(hGraphExec);
+  if (hGraphExec == nullptr || hNode == nullptr || !hip::GraphExecBase::isGraphExecValid(graphExec) ||
       !hip::GraphNode::isNodeValid(n) || nodeParams == nullptr ||
       n->GetType() != hipGraphNodeTypeExtSemaphoreSignal) {
     HIP_RETURN(hipErrorInvalidValue);
@@ -3479,8 +3484,8 @@ hipError_t hipGraphExecExternalSemaphoresWaitNodeSetParams(
     const hipExternalSemaphoreWaitNodeParams* nodeParams) {
   HIP_INIT_API(hipGraphExecExternalSemaphoresWaitNodeSetParams, hGraphExec, hNode, nodeParams);
   hip::GraphNode* n = reinterpret_cast<hip::GraphNode*>(hNode);
-  hip::GraphExec* graphExec = reinterpret_cast<hip::GraphExec*>(hGraphExec);
-  if (hGraphExec == nullptr || hNode == nullptr || !hip::GraphExec::isGraphExecValid(graphExec) ||
+  hip::GraphExecBase* graphExec = reinterpret_cast<hip::GraphExecBase*>(hGraphExec);
+  if (hGraphExec == nullptr || hNode == nullptr || !hip::GraphExecBase::isGraphExecValid(graphExec) ||
       !hip::GraphNode::isNodeValid(n) || nodeParams == nullptr ||
       n->GetType() != hipGraphNodeTypeExtSemaphoreWait) {
     HIP_RETURN(hipErrorInvalidValue);
@@ -3540,7 +3545,7 @@ hipError_t hipDrvGraphExecMemcpyNodeSetParams(hipGraphExec_t hGraphExec, hipGrap
        (copyParams->dstDevice == nullptr))) {
     HIP_RETURN(hipErrorInvalidValue);
   }
-  hip::GraphNode* clonedNode = reinterpret_cast<hip::GraphExec*>(hGraphExec)->GetClonedNode(n);
+  hip::GraphNode* clonedNode = reinterpret_cast<hip::GraphExecBase*>(hGraphExec)->GetClonedNode(n);
   if (clonedNode == nullptr) {
     HIP_RETURN(hipErrorInvalidValue);
   }
@@ -3566,7 +3571,7 @@ hipError_t hipDrvGraphExecMemsetNodeSetParams(hipGraphExec_t hGraphExec, hipGrap
   if (ihipGraphMemsetParams_validate(&pmemsetParams) != hipSuccess) {
     HIP_RETURN(hipErrorInvalidValue);
   }
-  hip::GraphNode* clonedNode = reinterpret_cast<hip::GraphExec*>(hGraphExec)->GetClonedNode(n);
+  hip::GraphNode* clonedNode = reinterpret_cast<hip::GraphExecBase*>(hGraphExec)->GetClonedNode(n);
   if (clonedNode == nullptr) {
     HIP_RETURN(hipErrorInvalidValue);
   }
@@ -3575,7 +3580,7 @@ hipError_t hipDrvGraphExecMemsetNodeSetParams(hipGraphExec_t hGraphExec, hipGrap
   if (status != hipSuccess) {
     HIP_RETURN(status);
   }
-  auto graphExec = reinterpret_cast<hip::GraphExec*>(hGraphExec);
+  auto graphExec = reinterpret_cast<hip::GraphExecBase*>(hGraphExec);
   status = graphExec->UpdateAQLPacket(clonedNode);
   HIP_RETURN(status);
 }
@@ -3585,7 +3590,7 @@ hipError_t hipGraphExecGetFlags(hipGraphExec_t graphExec, unsigned long long* fl
   if (graphExec == nullptr || flags == nullptr) {
     HIP_RETURN(hipErrorInvalidValue);
   }
-  hip::GraphExec* pgraphExec = reinterpret_cast<hip::GraphExec*>(graphExec);
+  hip::GraphExecBase* pgraphExec = reinterpret_cast<hip::GraphExecBase*>(graphExec);
   *flags = pgraphExec->GetFlags();
   HIP_RETURN(hipSuccess);
 }
@@ -3687,7 +3692,7 @@ hipError_t hipGraphExecNodeSetParams(hipGraphExec_t graphExec, hipGraphNode_t no
     HIP_RETURN(hipErrorInvalidValue);
   }
   hip::GraphNode* clonedNode = reinterpret_cast<hip::GraphNode*>(
-      reinterpret_cast<hip::GraphExec*>(graphExec)->GetClonedNode(n));
+      reinterpret_cast<hip::GraphExecBase*>(graphExec)->GetClonedNode(n));
   if (clonedNode == nullptr) {
     HIP_RETURN(hipErrorInvalidValue);
   }
@@ -3697,7 +3702,7 @@ hipError_t hipGraphExecNodeSetParams(hipGraphExec_t graphExec, hipGraphNode_t no
     return status;
   }
 
-  auto graphExecPtr = reinterpret_cast<hip::GraphExec*>(graphExec);
+  auto graphExecPtr = reinterpret_cast<hip::GraphExecBase*>(graphExec);
   status = graphExecPtr->UpdateAQLPacket(clonedNode);
   return status;
 }
@@ -3774,8 +3779,8 @@ hipError_t hipGraphExecBatchMemOpNodeSetParams(hipGraphExec_t hGraphExec, hipGra
                                                const hipBatchMemOpNodeParams* nodeParams) {
   HIP_INIT_API(hipGraphExecBatchMemOpNodeSetParams, hGraphExec, hNode, nodeParams);
   hip::GraphNode* n = reinterpret_cast<hip::GraphNode*>(hNode);
-  hip::GraphExec* graphExec = reinterpret_cast<hip::GraphExec*>(hGraphExec);
-  if (hGraphExec == nullptr || hNode == nullptr || !hip::GraphExec::isGraphExecValid(graphExec) ||
+  hip::GraphExecBase* graphExec = reinterpret_cast<hip::GraphExecBase*>(hGraphExec);
+  if (hGraphExec == nullptr || hNode == nullptr || !hip::GraphExecBase::isGraphExecValid(graphExec) ||
       !hip::GraphNode::isNodeValid(n) || nodeParams == nullptr) {
     HIP_RETURN(hipErrorInvalidValue);
   }
@@ -3784,7 +3789,7 @@ hipError_t hipGraphExecBatchMemOpNodeSetParams(hipGraphExec_t hGraphExec, hipGra
       nodeParams->flags != 0 || nodeParams->ctx == nullptr) {
     HIP_RETURN(hipErrorInvalidValue);
   }
-  hip::GraphNode* clonedNode = reinterpret_cast<hip::GraphExec*>(graphExec)->GetClonedNode(n);
+  hip::GraphNode* clonedNode = reinterpret_cast<hip::GraphExecBase*>(graphExec)->GetClonedNode(n);
   if (clonedNode == nullptr) {
     HIP_RETURN(hipErrorInvalidValue);
   }

--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -3218,6 +3218,7 @@ hipError_t hipGraphNodeSetEnabled(hipGraphExec_t hGraphExec, hipGraphNode_t hNod
   }
   clonedNode->SetEnabled(isEnabled);
 
+  // Update packet batches when node is enabled/disabled
   hipError_t status = graphExec->UpdatePacketBatchesForNodeEnableDisable(clonedNode, isEnabled != 0);
   HIP_RETURN(status);
 }

--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -29,7 +29,7 @@ inline hipError_t ihipGraphUpload(hipGraphExec_t graphExec, hipStream_t stream) 
     return hipErrorInvalidValue;
   }
   getStreamPerThread(stream);
-  if (!hip::GraphExec::isGraphExecValid(reinterpret_cast<hip::GraphExec*>(graphExec))) {
+  if (!hip::GraphExecBase::isGraphExecValid(reinterpret_cast<hip::GraphExecBase*>(graphExec))) {
     return hipErrorInvalidValue;
   }
   return hipSuccess;
@@ -1595,7 +1595,29 @@ hipError_t ihipGraphInstantiate(hip::GraphExec** pGraphExec, hip::Graph* graph,
       }
     }
   }
-  *pGraphExec = new hip::GraphExec(flags);
+
+  // PAL/Windows uses the classic topological path; Linux/ROCm uses the segmented AQL path.
+  if (GPU_ENABLE_PAL != 0) {
+    auto* classicExec = new hip::GraphExecClassic(flags);
+    graph->clone(classicExec, true);
+    // Classic path only needs a topological ordering of nodes; no segment scheduling.
+    if (!classicExec->TopologicalOrder()) {
+      delete classicExec;
+      return hipErrorInvalidValue;
+    }
+    graph->SetGraphInstantiated(true);
+    hipError_t initStatus = classicExec->Init();
+    if (initStatus != hipSuccess) {
+      delete classicExec;
+      return initStatus;
+    }
+    // Return via the GraphExec alias (= GraphExecSegmented) — safe because hip_graph.cpp
+    // only uses the virtual Run/Init interface and the shared-base statics through this pointer.
+    *pGraphExec = reinterpret_cast<hip::GraphExec*>(classicExec);
+    return hipSuccess;
+  }
+
+  *pGraphExec = new hip::GraphExecSegmented(flags);
   graph->clone(*pGraphExec, true);
 
   hipError_t scheduleStatus = (*pGraphExec)->ScheduleNodesIntoBatches();
@@ -1693,12 +1715,12 @@ hipError_t hipGraphExecDestroy(hipGraphExec_t pGraphExec) {
   if (pGraphExec == nullptr) {
     HIP_RETURN(hipErrorInvalidValue);
   }
-  hip::GraphExec* ge = reinterpret_cast<hip::GraphExec*>(pGraphExec);
+  auto* ge = reinterpret_cast<hip::GraphExecBase*>(pGraphExec);
   {
     // Erase from the set before releasing, so that concurrent
     // hipDeviceGraphMemTrim cannot retain a dangling pointer.
-    std::scoped_lock lock(GraphExec::graphExecSetLock_);
-    GraphExec::graphExecSet_.erase(ge);
+    std::scoped_lock lock(hip::GraphExecBase::graphExecSetLock_);
+    hip::GraphExecBase::graphExecSet_.erase(ge);
   }
   ge->release();
   HIP_RETURN(hipSuccess);
@@ -3003,14 +3025,14 @@ hipError_t hipDeviceGraphMemTrim(int device) {
   }
   auto* pool = g_devices[device]->GetGraphMemoryPool();
 
-  // Acquire exclusive lock — blocks new GraphExec::Run() retain calls.
-  std::unique_lock<std::shared_mutex> trim_lock(hip::GraphExec::graphExecTrimLock_);
+  // Acquire exclusive lock — blocks new GraphExecBase::Run() retain calls.
+  std::unique_lock<std::shared_mutex> trim_lock(hip::GraphExecBase::graphExecTrimLock_);
 
-  std::vector<hip::GraphExec*> retained_graph_execs;
+  std::vector<hip::GraphExecBase*> retained_graph_execs;
   // Phase 1: Snapshot eligible graph execs under graphExecSetLock_ and retain them.
   {
-    std::scoped_lock lock(hip::GraphExec::graphExecSetLock_);
-    for (auto* ge : hip::GraphExec::graphExecSet_) {
+    std::scoped_lock lock(hip::GraphExecBase::graphExecSetLock_);
+    for (auto* ge : hip::GraphExecBase::graphExecSet_) {
       if (ge->Device() != g_devices[device]) {
         continue;
       }

--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -1608,26 +1608,23 @@ hipError_t ihipGraphInstantiate(hip::GraphExec** pGraphExec, hip::Graph* graph,
       delete classicExec;
       return initStatus;
     }
-    // Return via the GraphExec alias (= GraphExecSegmented) — safe because hip_graph.cpp
-    // only uses the virtual Run/Init interface and the shared-base statics through this pointer.
-    *pGraphExec = reinterpret_cast<hip::GraphExec*>(classicExec);
+    *pGraphExec = classicExec;
     return hipSuccess;
   }
 
-  *pGraphExec = new hip::GraphExecSegmented(flags);
-  graph->clone(*pGraphExec, true);
+  auto* segExec = new hip::GraphExecSegmented(flags);
+  graph->clone(segExec, true);
 
-  hipError_t scheduleStatus = (*pGraphExec)->ScheduleNodesIntoBatches();
+  hipError_t scheduleStatus = segExec->ScheduleNodesIntoBatches();
   if (scheduleStatus != hipSuccess) {
-    delete *pGraphExec;
-    *pGraphExec = nullptr;
+    delete segExec;
     return scheduleStatus;
   }
   if (DEBUG_HIP_GRAPH_DOT_PRINT == 1) {
     static int i = 1;
     std::string filename =
         "graph_" + std::to_string(amd::Os::getProcessId()) + "_dot_print_" + std::to_string(i++);
-    hipError_t status = ihipGraphDebugDotPrint(*pGraphExec, filename.c_str(), 0);
+    hipError_t status = ihipGraphDebugDotPrint(segExec, filename.c_str(), 0);
     if (status == hipSuccess) {
       LogPrintfInfo("[hipGraph] graph dump:%s", filename.c_str());
     }
@@ -1635,8 +1632,9 @@ hipError_t ihipGraphInstantiate(hip::GraphExec** pGraphExec, hip::Graph* graph,
 
   graph->SetGraphInstantiated(true);
 
-  (*pGraphExec)->SetKernelArgManager(new hip::GraphKernelArgManager());
-  return (*pGraphExec)->Init();
+  segExec->SetKernelArgManager(new hip::GraphKernelArgManager());
+  *pGraphExec = segExec;
+  return segExec->Init();
 }
 
 hipError_t hipGraphInstantiate(hipGraphExec_t* pGraphExec, hipGraph_t graph,

--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -1596,15 +1596,10 @@ hipError_t ihipGraphInstantiate(hip::GraphExec** pGraphExec, hip::Graph* graph,
     }
   }
 
-  // PAL/Windows uses the classic topological path; Linux/ROCm uses the segmented AQL path.
+  // PAL/Windows: classic topological path — no segment scheduling, no AQL capture.
   if (GPU_ENABLE_PAL != 0) {
     auto* classicExec = new hip::GraphExecClassic(flags);
     graph->clone(classicExec, true);
-    // Classic path only needs a topological ordering of nodes; no segment scheduling.
-    if (!classicExec->TopologicalOrder()) {
-      delete classicExec;
-      return hipErrorInvalidValue;
-    }
     graph->SetGraphInstantiated(true);
     hipError_t initStatus = classicExec->Init();
     if (initStatus != hipSuccess) {

--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -1600,7 +1600,11 @@ hipError_t ihipGraphInstantiate(hip::GraphExec** pGraphExec, hip::Graph* graph,
   *pGraphExec = new hip::GraphExec(flags);
   graph->clone(*pGraphExec, true);
 
-  hipError_t scheduleStatus = (*pGraphExec)->ScheduleNodesIntoBatches();
+  // Segment path (default): SelectStreamAssignment picks DFS or round-robin based on complexity.
+  // Classic path: use_segment_scheduling_=false (DEBUG_HIP_GRAPH_SEGMENT_SCHEDULING=0).
+  hipError_t scheduleStatus = (*pGraphExec)->IsSegmentSchedulingEnabled()
+                                  ? (*pGraphExec)->ScheduleNodesIntoBatches()
+                                  : (*pGraphExec)->ScheduleNodes();
   if (scheduleStatus != hipSuccess) {
     delete *pGraphExec;
     *pGraphExec = nullptr;

--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -1505,9 +1505,7 @@ hipError_t hipGraphExecMemcpyNodeSetParams1D(hipGraphExec_t hGraphExec, hipGraph
     HIP_RETURN(status);
   }
   auto graphExec = reinterpret_cast<hip::GraphExec*>(hGraphExec);
-  if (graphExec->IsSegmentSchedulingEnabled()) {
-    status = graphExec->UpdateAQLPacket(reinterpret_cast<hip::GraphKernelNode*>(clonedNode));
-  }
+  status = graphExec->UpdateAQLPacket(reinterpret_cast<hip::GraphKernelNode*>(clonedNode));
   HIP_RETURN(status);
 }
 
@@ -1600,11 +1598,7 @@ hipError_t ihipGraphInstantiate(hip::GraphExec** pGraphExec, hip::Graph* graph,
   *pGraphExec = new hip::GraphExec(flags);
   graph->clone(*pGraphExec, true);
 
-  // Segment path (default): SelectStreamAssignment picks DFS or round-robin based on complexity.
-  // Classic path: use_segment_scheduling_=false (DEBUG_HIP_GRAPH_SEGMENT_SCHEDULING=0).
-  hipError_t scheduleStatus = (*pGraphExec)->IsSegmentSchedulingEnabled()
-                                  ? (*pGraphExec)->ScheduleNodesIntoBatches()
-                                  : (*pGraphExec)->ScheduleNodes();
+  hipError_t scheduleStatus = (*pGraphExec)->ScheduleNodesIntoBatches();
   if (scheduleStatus != hipSuccess) {
     delete *pGraphExec;
     *pGraphExec = nullptr;
@@ -1622,9 +1616,7 @@ hipError_t ihipGraphInstantiate(hip::GraphExec** pGraphExec, hip::Graph* graph,
 
   graph->SetGraphInstantiated(true);
 
-  if ((*pGraphExec)->IsSegmentSchedulingEnabled()) {
-    (*pGraphExec)->SetKernelArgManager(new hip::GraphKernelArgManager());
-  }
+  (*pGraphExec)->SetKernelArgManager(new hip::GraphKernelArgManager());
   return (*pGraphExec)->Init();
 }
 
@@ -1912,9 +1904,7 @@ hipError_t hipGraphExecMemcpyNodeSetParams(hipGraphExec_t hGraphExec, hipGraphNo
     HIP_RETURN(status);
   }
   auto graphExec = reinterpret_cast<hip::GraphExec*>(hGraphExec);
-  if (graphExec->IsSegmentSchedulingEnabled()) {
-    status = graphExec->UpdateAQLPacket(reinterpret_cast<hip::GraphKernelNode*>(clonedNode));
-  }
+  status = graphExec->UpdateAQLPacket(reinterpret_cast<hip::GraphKernelNode*>(clonedNode));
   HIP_RETURN(status);
 }
 
@@ -1963,9 +1953,7 @@ hipError_t hipGraphExecMemsetNodeSetParams(hipGraphExec_t hGraphExec, hipGraphNo
     HIP_RETURN(status);
   }
   auto graphExec = reinterpret_cast<hip::GraphExec*>(hGraphExec);
-  if (graphExec->IsSegmentSchedulingEnabled()) {
-    status = graphExec->UpdateAQLPacket(reinterpret_cast<hip::GraphKernelNode*>(clonedNode));
-  }
+  status = graphExec->UpdateAQLPacket(reinterpret_cast<hip::GraphKernelNode*>(clonedNode));
   HIP_RETURN(status);
 }
 
@@ -2023,9 +2011,7 @@ hipError_t hipGraphExecKernelNodeSetParams(hipGraphExec_t hGraphExec, hipGraphNo
     HIP_RETURN(status);
   }
   auto graphExec = reinterpret_cast<hip::GraphExec*>(hGraphExec);
-  if (graphExec->IsSegmentSchedulingEnabled()) {
-    status = graphExec->UpdateAQLPacket(reinterpret_cast<hip::GraphKernelNode*>(clonedNode));
-  }
+  status = graphExec->UpdateAQLPacket(reinterpret_cast<hip::GraphKernelNode*>(clonedNode));
   HIP_RETURN(status);
 }
 
@@ -2104,7 +2090,7 @@ hipError_t hipGraphExecChildGraphNodeSetParams(hipGraphExec_t hGraphExec, hipGra
 
   // After SetParams updates node parameters in-place, we need to update the cached AQL packets
   auto graphExec = reinterpret_cast<hip::GraphExec*>(hGraphExec);
-  if (graphExec->IsSegmentSchedulingEnabled() || childNode->GetGraphCaptureStatus()) {
+  {
     std::vector<hip::GraphNode*> childGraphNodes;
     childNode->TopologicalOrder(childGraphNodes);
     for (std::vector<hip::GraphNode*>::size_type i = 0; i != childGraphNodes.size(); i++) {
@@ -2511,9 +2497,7 @@ hipError_t hipGraphExecMemcpyNodeSetParamsFromSymbol(hipGraphExec_t hGraphExec, 
     HIP_RETURN(status);
   }
   auto graphExec = reinterpret_cast<hip::GraphExec*>(hGraphExec);
-  if (graphExec->IsSegmentSchedulingEnabled()) {
-    status = graphExec->UpdateAQLPacket(reinterpret_cast<hip::GraphKernelNode*>(clonedNode));
-  }
+  status = graphExec->UpdateAQLPacket(reinterpret_cast<hip::GraphKernelNode*>(clonedNode));
   HIP_RETURN(status);
 }
 
@@ -2591,9 +2575,7 @@ hipError_t hipGraphExecMemcpyNodeSetParamsToSymbol(hipGraphExec_t hGraphExec, hi
     HIP_RETURN(status);
   }
   auto graphExec = reinterpret_cast<hip::GraphExec*>(hGraphExec);
-  if (graphExec->IsSegmentSchedulingEnabled()) {
-    status = graphExec->UpdateAQLPacket(reinterpret_cast<hip::GraphKernelNode*>(clonedNode));
-  }
+  status = graphExec->UpdateAQLPacket(reinterpret_cast<hip::GraphKernelNode*>(clonedNode));
   HIP_RETURN(status);
 }
 
@@ -2829,7 +2811,7 @@ hipError_t hipGraphExecUpdate(hipGraphExec_t hGraphExec, hipGraph_t hGraph,
         HIP_RETURN(hipErrorGraphExecUpdateFailure);
       } else {
         auto graphExec = reinterpret_cast<hip::GraphExec*>(hGraphExec);
-        if (graphExec->IsSegmentSchedulingEnabled() && newGraphNodes[i]->GraphCaptureEnabled()) {
+        if (newGraphNodes[i]->GraphCaptureEnabled()) {
           status = graphExec->UpdateAQLPacket(reinterpret_cast<hip::GraphKernelNode*>(oldGraphExecNodes[i]));
         }
       }
@@ -3222,14 +3204,7 @@ hipError_t hipGraphNodeSetEnabled(hipGraphExec_t hGraphExec, hipGraphNode_t hNod
   }
   clonedNode->SetEnabled(isEnabled);
 
-  hipError_t status = hipSuccess;
-  if (graphExec->IsSegmentSchedulingEnabled()) {
-    // Update packet batches when node is enabled/disabled
-    status = graphExec->UpdatePacketBatchesForNodeEnableDisable(clonedNode, isEnabled != 0);
-    if (status != hipSuccess) {
-      HIP_RETURN(status);
-    }
-  }
+  hipError_t status = graphExec->UpdatePacketBatchesForNodeEnableDisable(clonedNode, isEnabled != 0);
   HIP_RETURN(status);
 }
 
@@ -3584,9 +3559,7 @@ hipError_t hipDrvGraphExecMemsetNodeSetParams(hipGraphExec_t hGraphExec, hipGrap
     HIP_RETURN(status);
   }
   auto graphExec = reinterpret_cast<hip::GraphExec*>(hGraphExec);
-  if (graphExec->IsSegmentSchedulingEnabled()) {
-    status = graphExec->UpdateAQLPacket(clonedNode);
-  }
+  status = graphExec->UpdateAQLPacket(clonedNode);
   HIP_RETURN(status);
 }
 
@@ -3708,9 +3681,7 @@ hipError_t hipGraphExecNodeSetParams(hipGraphExec_t graphExec, hipGraphNode_t no
   }
 
   auto graphExecPtr = reinterpret_cast<hip::GraphExec*>(graphExec);
-  if (graphExecPtr->IsSegmentSchedulingEnabled()) {
-    status = graphExecPtr->UpdateAQLPacket(clonedNode);
-  }
+  status = graphExecPtr->UpdateAQLPacket(clonedNode);
   return status;
 }
 

--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -1611,14 +1611,6 @@ hipError_t ihipGraphInstantiate(hip::GraphExecBase** pGraphExec, hip::Graph* gra
   } else {
     auto* segExec = new hip::GraphExecSegmented(flags);
     graph->clone(segExec, true);
-
-    hipError_t scheduleStatus = segExec->ScheduleNodesIntoBatches();
-    if (scheduleStatus != hipSuccess) {
-      delete segExec;
-      return scheduleStatus;
-    }
-
-    segExec->SetKernelArgManager(new hip::GraphKernelArgManager());
     hipError_t initStatus = segExec->Init();
     if (initStatus != hipSuccess) {
       delete segExec;

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -251,11 +251,6 @@ void Graph::ScheduleOneNode(Node start, int stream_id) {
 
 // ================================================================================================
 hipError_t Graph::ScheduleNodes() {
-  if (use_segment_scheduling_) {
-    // Segment path: DFS or round-robin stream assignment selected in SelectStreamAssignment()
-    return ScheduleNodesIntoBatches();
-  }
-
   // Classic scheduling logic
   memset(&roots_[0], 0, sizeof(Node) * roots_.size());
   max_streams_ = 0;

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -200,6 +200,7 @@ std::vector<std::pair<Node, Node>> Graph::GetEdges() const {
 void Graph::ScheduleOneNode(Node start, int stream_id) {
   if (!start) return;
 
+  // stack of pending nodes for DFS
   std::vector<Node> pending;
   pending.push_back(start);
 
@@ -209,15 +210,18 @@ void Graph::ScheduleOneNode(Node start, int stream_id) {
     Node cur = pending.back();
     pending.pop_back();
 
+    // Skip if already scheduled
     if (cur->stream_id_ != -1) {
       continue;
     }
 
+    // Schedule current node on this branch's stream
     cur->stream_id_ = sid;
 
     max_streams_ = std::max(max_streams_, sid + 1);
     streams_dev_ids_[sid].insert(cur->dev_id_);
 
+    // Process child graph separately, since there is no connection
     if (cur->GetType() == hipGraphNodeTypeGraph) {
       auto cgn   = reinterpret_cast<hip::ChildGraphNode*>(cur);
       auto child = cgn->GetChildGraph();
@@ -229,6 +233,8 @@ void Graph::ScheduleOneNode(Node start, int stream_id) {
     const auto& edges = cur->GetEdges();
     bool end_of_branch = true;
 
+    // To preserve left-to-right behavior, push siblings in reverse so the earlier
+    // edges get processed first.
     for (int i = static_cast<int>(edges.size()) - 1; i >= 0; --i) {
       Node e = edges[static_cast<size_t>(i)];
       if (e->stream_id_ != -1) continue;
@@ -237,6 +243,7 @@ void Graph::ScheduleOneNode(Node start, int stream_id) {
     }
 
     if (end_of_branch) {
+      // Finished one depth traversal (one branch). Rotate for the next sibling/branch.
       sid = (sid + 1) % DEBUG_HIP_FORCE_GRAPH_QUEUES;
     }
   }
@@ -244,6 +251,7 @@ void Graph::ScheduleOneNode(Node start, int stream_id) {
 
 // ================================================================================================
 hipError_t Graph::ScheduleNodes() {
+  // Classic scheduling logic
   memset(&roots_[0], 0, sizeof(Node) * roots_.size());
   max_streams_ = 0;
 
@@ -251,15 +259,20 @@ hipError_t Graph::ScheduleNodes() {
   for (auto node : vertices_) {
     if (node->stream_id_ == -1) {
       ScheduleOneNode(node, stream_id);
+      // Find the root nodes
       if ((node->GetDependencies().size() == 0) && (node->stream_id_ != 0)) {
+        // Fill in only the first in the sequence
         if (roots_[node->stream_id_] == nullptr) {
           roots_[node->stream_id_] = node;
         }
       }
+      // 1. Each extra root will get a new stream from the pool
+      // 2. Streams will be recycled if the number of roots > streams
       stream_id = (stream_id + 1) % DEBUG_HIP_FORCE_GRAPH_QUEUES;
     }
   }
 
+  // Topological order is needed for classic scheduling
   GraphExecBase* graphExec = dynamic_cast<GraphExecBase*>(this);
   if (graphExec && !graphExec->TopologicalOrder()) {
     ClPrint(amd::LOG_ERROR, amd::LOG_CODE, "[hipGraph] TopologicalOrder failed - invalid graph");
@@ -981,6 +994,22 @@ void Graph::clone(Graph* newGraph, bool cloneNodes) const {
     newGraph->graphUserObj_[userObj.first] = 1;
     userObj.first->owning_graphs_.insert(newGraph);
   }
+  // Clone the root nodes to the new graph
+  // Map original root node pointers to their cloned counterparts
+  if (roots_.size() > 0) {
+    for (size_t i = 0; i < roots_.size(); ++i) {
+      if (roots_[i] != nullptr) {
+        auto it = newGraph->clonedNodes_.find(roots_[i]);
+        if (it != newGraph->clonedNodes_.end()) {
+          newGraph->roots_[i] = it->second;
+        } else {
+          newGraph->roots_[i] = nullptr;
+        }
+      } else {
+        newGraph->roots_[i] = nullptr;
+      }
+    }
+  }
   newGraph->memAllocNodePtrs_ = memAllocNodePtrs_;
 
   if (!cloneNodes) {
@@ -1074,22 +1103,30 @@ hipError_t GraphExecBase::CreateStreams(uint32_t num_streams, int devId) {
 
 // ================================================================================================
 void GraphExecBase::FindStreamsReqPerDev() {
+  // Count streams required per device based on stream-to-device mappings
   for (auto const& [stream_id, dev_ids] : streams_dev_ids_) {
     for (auto dev_id : dev_ids) {
       max_streams_dev_[dev_id]++;
     }
   }
 
+  // Recursively process child graphs to determine their stream requirements
   for (auto node : vertices_) {
     if (node->GetType() == hipGraphNodeTypeGraph) {
       auto childNode = reinterpret_cast<ChildGraphNode*>(node);
+
+      // Recursively find stream requirements for child graph
       childNode->FindStreamsReqPerDev();
 
+      // Merge child graph's stream requirements with parent graph
+      // Take the maximum streams needed per device to handle concurrent execution
       for (auto const& [dev_id, num_streams] : childNode->max_streams_dev_) {
         auto it = max_streams_dev_.find(dev_id);
         if (it != max_streams_dev_.end()) {
+          // Device already has stream requirements - take the maximum
           max_streams_dev_[dev_id] = std::max(max_streams_dev_[dev_id], num_streams);
         } else {
+          // New device - initialize with child graph's requirement
           max_streams_dev_[dev_id] = num_streams;
         }
       }
@@ -2678,27 +2715,41 @@ void GraphExecBase::UpdateStreams(hip::Stream* launch_stream) {
 
 // ================================================================================================
 bool Graph::RunOneNode(Node node) {
+  // Clear the storage of the wait nodes
   memset(&wait_order_[0], 0, sizeof(Node) * wait_order_.size());
   amd::Command::EventWaitList waitList;
+  // Walk through dependencies and find the last launches on each parallel stream
   for (auto depNode : node->GetDependencies()) {
+    // Process only the nodes that have been submitted
     if (depNode->launch_id_ != -1) {
+      // Child graph nodes may internally dispatch work on streams other
+      // than their assigned stream_id_, so the same-stream in-order
+      // assumption does not hold.  Always treat them as cross-stream deps.
       if (depNode->stream_id_ != node->stream_id_ ||
           depNode->GetType() == hipGraphNodeTypeGraph) {
+        // If there is no wait node on the stream, then assign one
         if ((wait_order_[depNode->stream_id_] == nullptr) ||
+            // If another node executed on the same stream, then use the latest launch only,
+            // since the same stream has in-order run
             (wait_order_[depNode->stream_id_]->launch_id_ < depNode->launch_id_)) {
           wait_order_[depNode->stream_id_] = depNode;
         }
       } else {
+        // Release nodes that were enqueued on the same stream, since they are not included in the
+        // wait list. Their references were retained for all outgoing edges.
         for (auto command : depNode->GetCommands()) {
           command->release();
         }
       }
     } else {
       node->SetWait(false);
+      // It should be a safe return,
+      // since the last edge to this dependency has to submit the command
       return true;
     }
   }
 
+  // Create a wait list from the last launches of all dependencies
   for (auto dep : wait_order_) {
     if (dep != nullptr) {
       for (auto command : dep->GetCommands()) {
@@ -2707,11 +2758,17 @@ bool Graph::RunOneNode(Node node) {
     }
   }
   if (node->GetType() == hipGraphNodeTypeGraph) {
+    // Process child graph separately, since there is no connection
     auto child = reinterpret_cast<hip::ChildGraphNode*>(node)->GetChildGraph();
     if (!reinterpret_cast<hip::ChildGraphNode*>(node)->GetGraphCaptureStatus()) {
       child->RunNodes(node->stream_id_, &streams_, &waitList);
+      // Store the child graph's completion command so that downstream
+      // dependency handling can use node->GetCommands() directly,
+      // instead of querying getLastQueuedCommand at dependency time
+      // (which could return unrelated later work on the same stream).
       auto completion = streams_[node->stream_id_]->getLastQueuedCommand(true);
       if (completion != nullptr) {
+        // Release any previously stored completion command (from prior launches)
         for (auto cmd : node->GetCommands()) {
           cmd->release();
         }
@@ -2720,20 +2777,25 @@ bool Graph::RunOneNode(Node node) {
       }
     }
   } else {
+    // Assign a stream to the current node
     node->SetStream(streams_);
     if (DEBUG_HIP_GRAPH_DOT_PRINT) {
       node->hw_queue_id_ = node->GetQueue()->getQueueID();
     }
+    // Create the execution commands on the assigned stream
     auto status = node->CreateCommand(node->GetQueue());
     if (status != hipSuccess) {
       LogPrintfError("Command creation for node id(%d) failed!", current_id_ + 1);
       return false;
     }
+    // If a wait was requested, then process the list
     if (node->GetWait() && !waitList.empty()) {
       node->UpdateEventWaitLists(waitList);
     }
+    // Start the execution
     node->EnqueueCommands(node->GetQueue());
   }
+  // Release commands of dependency nodes that were included in the wait list after enqueue
   for (auto dep : wait_order_) {
     if (dep != nullptr) {
       for (auto command : dep->GetCommands()) {
@@ -2741,19 +2803,32 @@ bool Graph::RunOneNode(Node node) {
       }
     }
   }
+  // Assign the launch ID of the submitted node
+  // This is also applied to childGraphs to prevent them from being reprocessed
   node->launch_id_ = current_id_++;
   uint32_t i = 0;
+  // Execute the nodes in the edges list
   for (auto edge : node->GetEdges()) {
+    // Don't wait in the nodes, executed on the same streams and if it has just one dependency
     bool wait =
         ((i < DEBUG_HIP_FORCE_GRAPH_QUEUES) || (edge->GetDependencies().size() > 1)) ? true : false;
     edge->SetWait(wait);
     i++;
+    // Retain the current node for all its outgoing edges.
+    // Each edge will include this node in its waitlist and release it after their commands are
+    // enqueued.
     for (auto command : node->GetCommands()) {
       command->retain();
     }
   }
   if (node->GetEdges().size() == 0) {
+    // Add a leaf node into the list for a wait.
+    // Always use the last node, since it's the latest for the particular queue
     leafs_[node->stream_id_] = node;
+    // An extra retain is needed for the leaves in order to be able to later enqueue a marker
+    // on the app stream that has these commands in the waitlist.
+    // Child graph nodes now have completion commands stored via GetCommands(),
+    // so they participate in the leaf retain/release cycle like regular nodes.
     for (auto command : node->GetCommands()) {
       command->retain();
     }
@@ -2770,6 +2845,7 @@ bool Graph::RunNodes(int32_t base_stream, const std::vector<hip::Stream*>* paral
     streams_ = *parallel_streams;
   }
 
+  // childgraph node has dependencies on parent graph nodes from other streams
   if (parent_waitlist != nullptr) {
     auto start_marker = new amd::Marker(*streams_[base_stream], true, *parent_waitlist);
     start_marker->enqueue();
@@ -2779,17 +2855,26 @@ bool Graph::RunNodes(int32_t base_stream, const std::vector<hip::Stream*>* paral
   current_id_ = 0;
   memset(&leafs_[0], 0, sizeof(Node) * leafs_.size());
 
+  // Add possible waits in parallel streams for the app's default launch stream
   constexpr bool kRetainCommand = true;
   auto last_command = streams_[base_stream]->getLastQueuedCommand(kRetainCommand);
   if (last_command != nullptr) {
+    // Add the last command into the waiting list
     wait_list.push_back(last_command);
+    // Check if the graph has multiple root nodes
     for (uint32_t i = 0; i < DEBUG_HIP_FORCE_GRAPH_QUEUES; ++i) {
       if ((base_stream != i) && (roots_[i] != nullptr)) {
+        // Wait for the app's queue
         auto start_marker = new amd::Marker(*streams_[i], true, wait_list);
         start_marker->enqueue();
         start_marker->release();
       }
     }
+    // For child graphs launched on a non-zero base_stream, the root nodes
+    // are on stream 0 (roots_[0] is never set because scheduling always
+    // assigns the first root to stream 0 and skips it in root recording).
+    // Sync stream 0 with base_stream so the child's work waits for the
+    // parent's dependencies.
     if (base_stream != 0) {
       auto start_marker = new amd::Marker(*streams_[0], true, wait_list);
       start_marker->enqueue();
@@ -2798,6 +2883,7 @@ bool Graph::RunNodes(int32_t base_stream, const std::vector<hip::Stream*>* paral
     last_command->release();
   }
 
+  // Run all commands in the graph
   for (auto node : GetTopoOrder()) {
     node->launch_id_ = -1;
     if (!RunOneNode(node)) {
@@ -2805,6 +2891,7 @@ bool Graph::RunNodes(int32_t base_stream, const std::vector<hip::Stream*>* paral
     }
   }
   wait_list.clear();
+  // Check if the graph has multiple leaf nodes
   for (uint32_t i = 0; i < DEBUG_HIP_FORCE_GRAPH_QUEUES; ++i) {
     if (leafs_[i] != nullptr) {
       for (auto command : leafs_[i]->GetCommands()) {
@@ -2816,6 +2903,7 @@ bool Graph::RunNodes(int32_t base_stream, const std::vector<hip::Stream*>* paral
       }
     }
   }
+  // Wait for leafs in the graph's app stream
   if (wait_list.size() > 0) {
     auto end_marker = new amd::Marker(*streams_[base_stream], true, wait_list);
     end_marker->enqueue();

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -222,8 +222,8 @@ hipError_t Graph::ScheduleNodesIntoBatches() {
   // Resolve segment dependencies and calculate dependency levels
   ResolveSegmentDependencies();
 
-  // Calculate topological order for fallback paths and compatibility
-  // (e.g., child graphs, legacy execution, GetNodes() API)
+  // Calculate topological order for compatibility
+  // (e.g., child graphs, GetNodes() API, AutoFreeOnLaunch)
   GraphExec* graphExec = dynamic_cast<GraphExec*>(this);
   if (graphExec && !graphExec->TopologicalOrder()) {
     ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
@@ -310,7 +310,7 @@ void GraphExec::BuildSyncPlan() {
   sync_plan_.seg_to_hw_event.assign(segments_.size(), -1);
   sync_plan_.num_hw_events = 0;
 
-  auto* device = g_devices[instantiateDeviceId_]->devices()[0];
+  auto* device = g_devices[captureDeviceId_]->devices()[0];
 
   // PASS 0: Barrier-ROI collapse. When multi-stream's cross-stream sync would not
   // pay for the overlap it unlocks (see ShouldCollapseToSingleStream), fold every
@@ -906,22 +906,6 @@ void Graph::clone(Graph* newGraph, bool cloneNodes) const {
     newGraph->graphUserObj_[userObj.first] = 1;
     userObj.first->owning_graphs_.insert(newGraph);
   }
-  // Clone the root nodes to the new graph
-  // Map original root node pointers to their cloned counterparts
-  if (roots_.size() > 0) {
-    for (size_t i = 0; i < roots_.size(); ++i) {
-      if (roots_[i] != nullptr) {
-        auto it = newGraph->clonedNodes_.find(roots_[i]);
-        if (it != newGraph->clonedNodes_.end()) {
-          newGraph->roots_[i] = it->second;
-        } else {
-          newGraph->roots_[i] = nullptr;
-        }
-      } else {
-        newGraph->roots_[i] = nullptr;
-      }
-    }
-  }
   newGraph->memAllocNodePtrs_ = memAllocNodePtrs_;
 
   if (!cloneNodes) {
@@ -973,7 +957,7 @@ hipError_t GraphExec::CreateStreams(uint32_t num_streams, int devId) {
   // For the instantiation device one slot is occupied by the launch stream,
   // so create one fewer extra stream. Other devices use all slots as parallel streams.
   uint32_t capped = std::min(num_streams, DEBUG_HIP_FORCE_GRAPH_QUEUES);
-  uint32_t max_streams = (devId == instantiateDeviceId_ && capped > 0) ? capped - 1 : capped;
+  uint32_t max_streams = (devId == captureDeviceId_ && capped > 0) ? capped - 1 : capped;
   if (max_streams == 0) {
     return hipSuccess;
   }
@@ -1014,40 +998,6 @@ hipError_t GraphExec::CreateStreams(uint32_t num_streams, int devId) {
 }
 
 // ================================================================================================
-void GraphExec::FindStreamsReqPerDev() {
-  // Count streams required per device based on stream-to-device mappings
-  for (auto const& [stream_id, dev_ids] : streams_dev_ids_) {
-    for (auto dev_id : dev_ids) {
-      max_streams_dev_[dev_id]++;
-    }
-  }
-
-  // Recursively process child graphs to determine their stream requirements
-  for (auto node : vertices_) {
-    if (node->GetType() == hipGraphNodeTypeGraph) {
-      auto childNode = reinterpret_cast<ChildGraphNode*>(node);
-
-      // Recursively find stream requirements for child graph
-      childNode->FindStreamsReqPerDev();
-
-      // Merge child graph's stream requirements with parent graph
-      // Take the maximum streams needed per device to handle concurrent execution
-      for (auto const& [dev_id, num_streams] : childNode->max_streams_dev_) {
-        auto it = max_streams_dev_.find(dev_id);
-        if (it != max_streams_dev_.end()) {
-          // Device already has stream requirements - take the maximum
-          max_streams_dev_[dev_id] = std::max(max_streams_dev_[dev_id], num_streams);
-        } else {
-          // New device - initialize with child graph's requirement
-          max_streams_dev_[dev_id] = num_streams;
-        }
-      }
-    }
-  }
-
-}
-
-// ================================================================================================
 void GraphExec::FindStreamsReqPerDevForSegments() {
   // For packet engine mode: analyze segments to determine stream requirements per device
   // We need to track the maximum number of concurrent segments per device at any level
@@ -1063,9 +1013,9 @@ void GraphExec::FindStreamsReqPerDevForSegments() {
       continue;
     }
 
-    if (graphExec != this && graphExec->instantiateDeviceId_ == -1) {
-      graphExec->instantiateDeviceId_ = instantiateDeviceId_;
-      static_cast<amd::ReferenceCountedObject*>(g_devices[instantiateDeviceId_])->retain();
+    if (graphExec != this && graphExec->captureDeviceId_ == -1) {
+      graphExec->captureDeviceId_ = captureDeviceId_;
+      static_cast<amd::ReferenceCountedObject*>(g_devices[captureDeviceId_])->retain();
     }
 
     for (const auto& [level, segment_ids] : graphExec->segments_per_level_) {
@@ -1092,6 +1042,19 @@ void GraphExec::FindStreamsReqPerDevForSegments() {
       }
     }
 
+    if (graphExec == this) {
+      // Single-device graph: derive captureDeviceId_ from the authoritative map key.
+      // Multi-device graphs are not supported on the segment scheduling path.
+      if (max_streams_dev_.size() == 1) {
+        captureDeviceId_ = max_streams_dev_.begin()->first;
+      } else if (max_streams_dev_.size() > 1) {
+        ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
+                "[hipGraph] Multi-device graph is not supported on the segment scheduling path");
+        captureDeviceId_ = -1;
+        return;
+      }
+    }
+
     for (const auto& segment : graphExec->segments_) {
       if (segment.child_graph_ptr != nullptr) {
         auto childGraphExec = dynamic_cast<GraphExec*>(segment.child_graph_ptr);
@@ -1106,7 +1069,7 @@ void GraphExec::FindStreamsReqPerDevForSegments() {
 // ================================================================================================
 void GraphExec::RoundRobinStreamAssignment() {
   // max_streams_dev_ holds the raw parallelism count per device as computed by
-  // FindStreamsReqPerDev[ForSegments]() and capped in Init(). CreateStreams() handles
+  // FindStreamsReqPerDevForSegments() and capped in Init(). CreateStreams() handles
   // the -1 adjustment for the instantiation device internally, so the value here
   // represents the total stream pool size for every device uniformly.
   auto getPoolSize = [&](int dev_id) -> size_t {
@@ -1162,9 +1125,8 @@ void GraphExec::ComputeCompletionSignalFlags() {
 }
 
 // ================================================================================================
-// DFS-based stream assignment for segment DAG — same algorithm as classic ScheduleOneNode
-// but operates on segments instead of individual nodes. Linear chains of segments stay
-// on the same stream; branches rotate to a new stream at each leaf.
+// DFS-based stream assignment for segment DAG.
+// Linear chains of segments stay on the same stream; branches rotate to a new stream at each leaf.
 void GraphExec::DFSStreamAssignment() {
   auto getPoolSize = [&](int dev_id) -> int {
     auto it = max_streams_dev_.find(dev_id);
@@ -1217,7 +1179,7 @@ void GraphExec::DFSStreamAssignment() {
       }
     }
 
-    // Rotate stream at leaf — same as classic ScheduleOneNode
+    // Rotate stream at branch leaf
     if (end_of_branch) {
       sid = (sid + 1) % static_cast<int>(DEBUG_HIP_FORCE_GRAPH_QUEUES);
     }
@@ -1297,12 +1259,14 @@ void GraphExec::SelectStreamAssignment() {
 // ================================================================================================
 hipError_t GraphExec::Init() {
   hipError_t status = hipSuccess;
-  // Set instantiation device ID early so Find functions can use it
-  instantiateDeviceId_ = hip::getCurrentDevice()->deviceId();
-
   // create extra stream to avoid queue collision with the default execution stream
   if (max_streams_ >= 1) {
+    // captureDeviceId_ is set inside FindStreamsReqPerDevForSegments() from
+    // max_streams_dev_ once all segments are analysed.
     FindStreamsReqPerDevForSegments();
+    if (captureDeviceId_ == -1) {
+      return hipErrorNotSupported;
+    }
 
     // Cap per-device stream counts to the hardware queue limit and compute the total.
     // This must happen before SelectStreamAssignment() reads max_streams_dev_ so
@@ -1333,7 +1297,7 @@ hipError_t GraphExec::Init() {
   // For graph nodes capture AQL packets to dispatch them directly during graph launch.
   status = CaptureAQLPackets();
 
-  static_cast<ReferenceCountedObject*>(hip::getCurrentDevice())->retain();
+  static_cast<ReferenceCountedObject*>(g_devices[captureDeviceId_])->retain();
   return status;
 }
 
@@ -1626,10 +1590,10 @@ hipError_t GraphExec::CaptureAndFormPacketsForGraph() {
         // Propagate instantiation device ID so BuildSyncPlan can
         // access the device for barrier packet creation.
         // Retain balances the release in ~Graph destructor.
-        if (childGraphExec->instantiateDeviceId_ == -1) {
-          childGraphExec->instantiateDeviceId_ = instantiateDeviceId_;
+        if (childGraphExec->captureDeviceId_ == -1) {
+          childGraphExec->captureDeviceId_ = captureDeviceId_;
           static_cast<amd::ReferenceCountedObject*>(
-              g_devices[instantiateDeviceId_])->retain();
+              g_devices[captureDeviceId_])->retain();
         }
 
         // Child graphs share the same kernel arg manager as parent
@@ -2336,210 +2300,6 @@ void GraphExec::UpdateStreams(hip::Stream* launch_stream) {
   }
 }
 
-
-// ================================================================================================
-bool Graph::RunOneNode(Node node) {
-  // Clear the storage of the wait nodes
-  memset(&wait_order_[0], 0, sizeof(Node) * wait_order_.size());
-  amd::Command::EventWaitList waitList;
-  // Walk through dependencies and find the last launches on each parallel stream
-  for (auto depNode : node->GetDependencies()) {
-    // Process only the nodes that have been submitted
-    if (depNode->launch_id_ != -1) {
-      // Child graph nodes may internally dispatch work on streams other
-      // than their assigned stream_id_, so the same-stream in-order
-      // assumption does not hold.  Always treat them as cross-stream deps.
-      if (depNode->stream_id_ != node->stream_id_ ||
-          depNode->GetType() == hipGraphNodeTypeGraph) {
-        // If there is no wait node on the stream, then assign one
-        if ((wait_order_[depNode->stream_id_] == nullptr) ||
-            // If another node executed on the same stream, then use the latest launch only,
-            // since the same stream has in-order run
-            (wait_order_[depNode->stream_id_]->launch_id_ < depNode->launch_id_)) {
-          wait_order_[depNode->stream_id_] = depNode;
-        }
-      } else {
-        // Release nodes that were enqueued on the same stream, since they are not included in the
-        // wait list. Their references were retained for all outgoing edges.
-        for (auto command : depNode->GetCommands()) {
-          command->release();
-        }
-      }
-    } else {
-      node->SetWait(false);
-      // It should be a safe return,
-      // since the last edge to this dependency has to submit the command
-      return true;
-    }
-  }
-
-  // Create a wait list from the last launches of all dependencies
-  for (auto dep : wait_order_) {
-    if (dep != nullptr) {
-      for (auto command : dep->GetCommands()) {
-        waitList.push_back(command);
-      }
-    }
-  }
-  if (node->GetType() == hipGraphNodeTypeGraph) {
-    // Process child graph separately, since, there is no connection
-    auto child = reinterpret_cast<hip::ChildGraphNode*>(node)->GetChildGraph();
-    if (!reinterpret_cast<hip::ChildGraphNode*>(node)->GetGraphCaptureStatus()) {
-      child->RunNodes(node->stream_id_, &streams_, &waitList);
-      // Store the child graph's completion command so that downstream
-      // dependency handling can use node->GetCommands() directly,
-      // instead of querying getLastQueuedCommand at dependency time
-      // (which could return unrelated later work on the same stream).
-      auto completion = streams_[node->stream_id_]->getLastQueuedCommand(true);
-      if (completion != nullptr) {
-        // Release any previously stored completion command (from prior launches)
-        for (auto cmd : node->GetCommands()) {
-          cmd->release();
-        }
-        node->GetCommands().clear();
-        node->GetCommands().push_back(completion);
-      }
-    }
-  } else {
-    // Assing a stream to the current node
-    node->SetStream(streams_);
-    if (DEBUG_HIP_GRAPH_DOT_PRINT) {
-      node->hw_queue_id_ = node->GetQueue()->getQueueID();
-    }
-    // Create the execution commands on the assigned stream
-    auto status = node->CreateCommand(node->GetQueue());
-    if (status != hipSuccess) {
-      LogPrintfError("Command creation for node id(%d) failed!", current_id_ + 1);
-      return false;
-    }
-    // If a wait was requested, then process the list
-    if (node->GetWait() && !waitList.empty()) {
-      node->UpdateEventWaitLists(waitList);
-    }
-    // Start the execution
-    node->EnqueueCommands(node->GetQueue());
-  }
-  // Release commands of dependency nodes that were included in the wait list after enqueue
-  for (auto dep : wait_order_) {
-    if (dep != nullptr) {
-      for (auto command : dep->GetCommands()) {
-        command->release();
-      }
-    }
-  }
-  // Assign the launch ID of the submmitted node
-  // This is also applied to childGraphs to prevent them from being reprocessed
-  node->launch_id_ = current_id_++;
-  uint32_t i = 0;
-  // Execute the nodes in the edges list
-  for (auto edge : node->GetEdges()) {
-    // Don't wait in the nodes, executed on the same streams and if it has just one dependency
-    bool wait =
-        ((i < DEBUG_HIP_FORCE_GRAPH_QUEUES) || (edge->GetDependencies().size() > 1)) ? true : false;
-    edge->SetWait(wait);
-    i++;
-    // Retain the current node for all its outgoing edges.
-    // Each edge will include this node in its waitlist and release it after their commands are
-    // enqueued.
-    for (auto command : node->GetCommands()) {
-      command->retain();
-    }
-  }
-  if (node->GetEdges().size() == 0) {
-    // Add a leaf node into the list for a wait.
-    // Always use the last node, since it's the latest for the particular queue
-    leafs_[node->stream_id_] = node;
-    // An extra retain is needed for the leaves in order to be able to later enqueue a marker
-    // on the app stream that has these commands in the waitlist.
-    // Child graph nodes now have completion commands stored via GetCommands(),
-    // so they participate in the leaf retain/release cycle like regular nodes.
-    for (auto command : node->GetCommands()) {
-      command->retain();
-    }
-  }
-
-  node->SetWait(false);
-  return true;
-}
-
-// ================================================================================================
-bool Graph::RunNodes(int32_t base_stream, const std::vector<hip::Stream*>* parallel_streams,
-                     const amd::Command::EventWaitList* parent_waitlist) {
-  if (parallel_streams != nullptr) {
-    streams_ = *parallel_streams;
-  }
-
-  // childgraph node has dependencies on parent graph nodes from other streams
-  if (parent_waitlist != nullptr) {
-    auto start_marker = new amd::Marker(*streams_[base_stream], true, *parent_waitlist);
-    start_marker->enqueue();
-    start_marker->release();
-  }
-  amd::Command::EventWaitList wait_list;
-  current_id_ = 0;
-  memset(&leafs_[0], 0, sizeof(Node) * leafs_.size());
-
-  // Add possible waits in parallel streams for the app's default launch stream
-  constexpr bool kRetainCommand = true;
-  auto last_command = streams_[base_stream]->getLastQueuedCommand(kRetainCommand);
-  if (last_command != nullptr) {
-    // Add the last command into the waiting list
-    wait_list.push_back(last_command);
-    // Check if the graph has multiple root nodes
-    for (uint32_t i = 0; i < DEBUG_HIP_FORCE_GRAPH_QUEUES; ++i) {
-      if ((base_stream != i) && (roots_[i] != nullptr)) {
-        // Wait for the app's queue
-        auto start_marker = new amd::Marker(*streams_[i], true, wait_list);
-        start_marker->enqueue();
-        start_marker->release();
-      }
-    }
-    // For child graphs launched on a non-zero base_stream, the root nodes
-    // are on stream 0 (roots_[0] is never set because scheduling always
-    // assigns the first root to stream 0 and skips it in root recording).
-    // Sync stream 0 with base_stream so the child's work waits for the
-    // parent's dependencies.
-    if (base_stream != 0) {
-      auto start_marker = new amd::Marker(*streams_[0], true, wait_list);
-      start_marker->enqueue();
-      start_marker->release();
-    }
-    last_command->release();
-  }
-
-  // Run all commands in the graph
-  for (auto node : GetTopoOrder()) {
-    node->launch_id_ = -1;
-    if (!RunOneNode(node)) {
-      return false;
-    }
-  }
-  wait_list.clear();
-  // Check if the graph has multiple leaf nodes
-  for (uint32_t i = 0; i < DEBUG_HIP_FORCE_GRAPH_QUEUES; ++i) {
-    if (leafs_[i] != nullptr) {
-      for (auto command : leafs_[i]->GetCommands()) {
-        if (base_stream != i) {
-          wait_list.push_back(command);
-        } else {
-          command->release();
-        }
-      }
-    }
-  }
-  // Wait for leafs in the graph's app stream
-  if (wait_list.size() > 0) {
-    auto end_marker = new amd::Marker(*streams_[base_stream], true, wait_list);
-    end_marker->enqueue();
-    end_marker->release();
-    for (auto command : wait_list) {
-      command->release();
-    }
-  }
-
-  return true;
-}
-
 hipError_t ihipGraphDebugDotPrint(hip::Graph* graph, const char* path, unsigned int flags);
 
 // ================================================================================================
@@ -2610,13 +2370,12 @@ hipError_t GraphExec::Run(hip::Stream* launch_stream) {
   // reuse the graph's own accumulate command instead of enqueuing a dedicated marker
   amd::Command* completion_cmd = nullptr;
 
-  if (instantiateDeviceId_ == launch_stream->DeviceId()) {
+  if (captureDeviceId_ == launch_stream->DeviceId()) {
     // If the graph has kernels that does device side allocation,  during packet capture, heap is
     // allocated because heap pointer has to be added to the AQL packet, and initialized during
     // graph launch.
     // Todo: Hidden heap initialization is done only for single device graph
-    if (HasHiddenHeap() &&
-        hiddenHeapInitializedDevices_.insert(launch_stream->DeviceId()).second) {
+    if (HasHiddenHeap() && hiddenHeapInitializedDevices_.insert(launch_stream->DeviceId()).second) {
       launch_stream->vdev()->HiddenHeapInit();
     }
     amd::Command* last_cmd = nullptr;
@@ -2632,19 +2391,11 @@ hipError_t GraphExec::Run(hip::Stream* launch_stream) {
     // already imply all parallel work is done). Our reference is released after
     // the callback is registered below; the queue keeps it alive until done.
     completion_cmd = last_cmd;
-  } else if (max_streams_ == 1 && instantiateDeviceId_ != launch_stream->DeviceId()) {
-    for (int i = 0; i < topoOrder_.size(); i++) {
-      topoOrder_[i]->SetStream(launch_stream);
-      status = topoOrder_[i]->CreateCommand(topoOrder_[i]->GetQueue());
-      topoOrder_[i]->EnqueueCommands(launch_stream);
-    }
-  } else {
-    // Execute all nodes in the graph
-    if (!RunNodes()) {
-      LogError("Failed to launch nodes!");
-      this->release();
-      return hipErrorOutOfMemory;
-    }
+  } else if (captureDeviceId_ != launch_stream->DeviceId()) {
+    ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
+            "[hipGraph] GraphExec::Run: launch stream device %d does not match capture device %d",
+            launch_stream->DeviceId(), captureDeviceId_);
+    status = hipErrorInvalidValue;
   }
   if (DEBUG_HIP_GRAPH_DOT_PRINT == 2 && !graph_dumped_) {
     graph_dumped_ = true;

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -260,7 +260,7 @@ hipError_t Graph::ScheduleNodes() {
     }
   }
 
-  GraphExec* graphExec = dynamic_cast<GraphExec*>(this);
+  GraphExecBase* graphExec = dynamic_cast<GraphExecBase*>(this);
   if (graphExec && !graphExec->TopologicalOrder()) {
     ClPrint(amd::LOG_ERROR, amd::LOG_CODE, "[hipGraph] TopologicalOrder failed - invalid graph");
     return hipErrorInvalidValue;
@@ -1104,10 +1104,10 @@ void GraphExecSegmented::FindStreamsReqPerDevForSegments() {
 
   max_streams_dev_.clear();
   std::unordered_map<int, int> streams_per_dev_at_level;
-  std::vector<GraphExec*> graphs_to_process{this};
+  std::vector<GraphExecBase*> graphs_to_process{this};
 
   while (!graphs_to_process.empty()) {
-    GraphExec* graphExec = graphs_to_process.back();
+    GraphExecBase* graphExec = graphs_to_process.back();
     graphs_to_process.pop_back();
     if (graphExec == nullptr) {
       continue;
@@ -1160,7 +1160,7 @@ void GraphExecSegmented::FindStreamsReqPerDevForSegments() {
 
     for (const auto& segment : graphExec->segments_) {
       if (segment.child_graph_ptr != nullptr) {
-        auto childGraphExec = dynamic_cast<GraphExec*>(segment.child_graph_ptr);
+        auto childGraphExec = dynamic_cast<GraphExecBase*>(segment.child_graph_ptr);
         if (childGraphExec != nullptr) {
           graphs_to_process.push_back(childGraphExec);
         }
@@ -2291,12 +2291,9 @@ hipError_t GraphExecSegmented::UpdatePacketBatchesForNodeEnableDisable(hip::Grap
 void GraphExecBase::OnLaunchComplete(cl_event event, cl_int command_exec_status, void* user_data) {
   auto* cleanup = reinterpret_cast<GraphLaunchCleanup*>(user_data);
   GraphExecBase* execBase = cleanup->exec;
-  // Re-arm and recycle the launch's signals while the GraphExec (and thus its
+  // Re-arm and recycle the launch's signals while the GraphExecBase (and thus its
   // signal pool) is still alive, then drop the launch's reference.
-  auto* segExec = dynamic_cast<GraphExecSegmented*>(execBase);
-  if (segExec != nullptr && segExec->signalManager_ != nullptr && !cleanup->signal_set.empty()) {
-    segExec->signalManager_->ReleaseSet(cleanup->device, cleanup->signal_set);
-  }
+  execBase->RecycleLaunchSignals(cleanup->device, cleanup->signal_set);
   delete cleanup;
   execBase->release();
 }
@@ -2351,7 +2348,7 @@ amd::Command* GraphExecSegmented::EnqueueSegmentedGraph(hip::Stream* launch_stre
   // Pass `this` as the kernel-names owner: the command borrows kernel-name
   // strings owned by this graph's nodes (via setKernelNamesRef during dispatch)
   // and reads them in ReportActivity() at completion, after OnLaunchComplete()
-  // drops the launch's reference. Tying the GraphExec's lifetime to the command
+  // drops the launch's reference. Tying the GraphExecBase's lifetime to the command
   // keeps those strings valid through the report (no copies). We already hold a
   // launch reference here, so the retain in the constructor needs no trim lock.
   auto* graph_accumulate = new amd::AccumulateCommand(*launch_stream, {}, nullptr, this);
@@ -2870,7 +2867,7 @@ hipError_t GraphExecSegmented::Run(hip::Stream* launch_stream) {
     repeatLaunch_ = true;
   }
 
-  ClPrint(amd::LOG_DEBUG, amd::LOG_CODE, "GraphExec::Run max_streams: %d, on device: %d",
+  ClPrint(amd::LOG_DEBUG, amd::LOG_CODE, "GraphExecSegmented::Run max_streams: %d, on device: %d",
           max_streams_, launch_stream->DeviceId());
 
   // If the launch stream lost its HW queue due to dynamic queue management,
@@ -2918,7 +2915,7 @@ hipError_t GraphExecSegmented::Run(hip::Stream* launch_stream) {
     }
   } else if (captureDeviceId_ != launch_stream->DeviceId()) {
     ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
-      "[hipGraph] GraphExec::Run: launch stream device %d does not match capture device %d",
+      "[hipGraph] GraphExecSegmented::Run: launch stream device %d does not match capture device %d",
       launch_stream->DeviceId(), captureDeviceId_);
     status = hipErrorInvalidValue;
   }
@@ -2970,7 +2967,7 @@ hipError_t GraphExecSegmented::Run(hip::Stream* launch_stream) {
 
 // ================================================================================================
 GraphSignalManager::~GraphSignalManager() {
-  // No launches can be in flight at this point (GraphExec refcount guarantees
+  // No launches can be in flight at this point (GraphExecBase refcount guarantees
   // it outlives all launches), so every set is back in the free pool.
   for (auto& dev_pool : free_sets_) {
     amd::Device* device = dev_pool.first;

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -252,27 +252,8 @@ void Graph::ScheduleOneNode(Node start, int stream_id) {
 // ================================================================================================
 hipError_t Graph::ScheduleNodes() {
   if (use_segment_scheduling_) {
-    // Segment packet scheduling logic
-    hipError_t result = ScheduleNodesIntoBatches();
-
-    // If ScheduleNodesIntoBatches returns hipErrorNotReady, it indicates
-    // a complex graph that would benefit from classic path, so fall back
-    if (result == hipErrorNotReady) {
-      ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_CODE,
-              "[hipGraph] Falling back to classic scheduling for complex graph");
-      // Clear any partial segment data that might have been created
-      segments_.clear();
-      node_to_segment_id_.clear();
-      segments_per_level_.clear();
-      max_dependency_level_ = -1;
-      // Disable segment scheduling for this graph permanently
-      use_segment_scheduling_ = false;
-
-      // Continue to classic scheduling logic below
-    } else {
-      // Return success or actual error (not the special fallback indicator)
-      return result;
-    }
+    // Segment path: DFS or round-robin stream assignment selected in SelectStreamAssignment()
+    return ScheduleNodesIntoBatches();
   }
 
   // Classic scheduling logic
@@ -329,27 +310,6 @@ hipError_t Graph::ScheduleNodesIntoBatches() {
     ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
             "[hipGraph] No valid segments created from execution paths");
     return hipErrorInvalidValue;
-  }
-
-  // Check if this is a complex graph that would benefit from classic path
-  // Complex graphs: 16+ segments with average segment length < 8
-  const size_t kSegmentSizeThreshold = 16;
-  const double kAvgSegmentLengthThreshold = 8.0;
-  if (segments_.size() >= kSegmentSizeThreshold && DEBUG_HIP_GRAPH_SEGMENT_SCHEDULING != 2) {
-    size_t total_nodes = 0;
-    for (const auto& segment : segments_) {
-      total_nodes += segment.nodes.size();
-    }
-    double avg_segment_length = static_cast<double>(total_nodes) / segments_.size();
-
-    if (avg_segment_length < kAvgSegmentLengthThreshold) {
-      ClPrint(amd::LOG_INFO, amd::LOG_CODE,
-              "[hipGraph] Complex graph detected: %zu segments, avg length %.2f - "
-              "falling back to classic path for better performance",
-              segments_.size(), avg_segment_length);
-      // Return special status to indicate fallback to classic path
-      return hipErrorNotReady;
-    }
   }
 
   // Resolve segment dependencies and calculate dependency levels
@@ -1237,7 +1197,7 @@ void GraphExec::FindStreamsReqPerDevForSegments() {
 }
 
 // ================================================================================================
-void GraphExec::PrecomputeStreamAssignment() {
+void GraphExec::RoundRobinStreamAssignment() {
   // max_streams_dev_ holds the raw parallelism count per device as computed by
   // FindStreamsReqPerDev[ForSegments]() and capped in Init(). CreateStreams() handles
   // the -1 adjustment for the instantiation device internally, so the value here
@@ -1295,162 +1255,136 @@ void GraphExec::ComputeCompletionSignalFlags() {
 }
 
 // ================================================================================================
-// Barrier-ROI heuristic.
-//
-// Multi-stream segment scheduling only pays off when the device-side overlap it
-// unlocks exceeds the cost of the cross-stream barriers/signals it requires. For
-// launch-overhead-bound graphs (many tiny kernels, near-serial dependencies) the
-// barriers have a high overhead: collapsing every segment onto one in-order stream
-// removes them entirely and is measurably faster on both the launch and the
-// instantiate path.
-//
-// Both sides are estimated in cheap structural units, with no device timing:
-//   * barrier_est   = number of barrier *packets* multi-stream would emit. This
-//                     mirrors BuildSyncPlan's materialization rather than the raw
-//                     dependency count: a single barrier packet resolves up to 5
-//                     dependencies ((deps + 4) / 5 packets), and a lone
-//                     dependency is folded into the segment's ext kernel-dispatch
-//                     packet with no separate barrier at all. PrecomputeStream-
-//                     Assignment() has already run by the time this is called, so
-//                     only *cross-stream/device* deps are counted (same-stream
-//                     deps are ordered by the in-order queue and emit no barrier),
-//                     matching what PASS 2/PASS 3 of BuildSyncPlan actually do.
-//   * signal_est    = number of completion *signals* multi-stream would emit.
-//                     Reuses each segment's needs_completion_signal flag (set by
-//                     PrecomputeStreamAssignment with the same cross-stream/leaf
-//                     criteria BuildSyncPlan uses), so producers whose consumers
-//                     share their stream are not over-counted. Signals are real
-//                     per-launch host cost (signal-pool acquire + packet patch)
-//                     that the barrier count alone misses, so they belong in the
-//                     ROI denominator alongside barriers.
-//   * parallel_slack = total work - critical-path work. The work that is
-//                      genuinely off the longest dependency chain and could
-//                      therefore overlap on another stream. Work is measured in
-//                      machine-occupancy passes, not node count: each kernel
-//                      weighs ceil(launch_threads / machine_threads) (>=1), so a
-//                      kernel that fills the GPU once is 1 unit and one needing N
-//                      passes is N. Non-kernel nodes and sub-machine launches are
-//                      1 unit, preserving the original node-count behaviour for
-//                      the small launch-bound kernels the gate targets. This is
-//                      what keeps two *long-running* independent kernels multi-
-//                      stream (their slack outgrows the threshold) while tiny
-//                      independent kernels (e.g. PyFR's stubs) still collapse.
-//
-// Collapse when parallel_slack < min_overlap * (barrier_est + signal_est): i.e.
-// keep multi-stream only when each unit of cross-stream sync overhead buys at
-// least min_overlap nodes of overlappable work. Folding collapse onto the launch
-// stream removes both barriers and signals (it runs inline, 0/0), so the full
-// sync cost is what multi-stream genuinely pays over collapse. Tunable via
-// DEBUG_HIP_GRAPH_MIN_OVERLAP; 0 disables the gate.
-bool GraphExec::ShouldCollapseToSingleStream() const {
-  const uint32_t min_overlap = DEBUG_HIP_GRAPH_MIN_OVERLAP;
-  if (min_overlap == 0) return false;            // gate disabled
-  if (segments_.size() < 2) return false;        // nothing to parallelize
-
-  // Collapse folds every segment onto stream 0, which EnqueueSegmentedGraph
-  // resolves to the launch stream (streams_[0]). That only works when all
-  // segments live on the same device; a multi-device graph would mis-route its
-  // off-device segments onto the launch stream, so never collapse one.
-  const int dev0 = segments_.front().dev_id;
-  for (const auto& seg : segments_) {
-    if (seg.dev_id != dev0) return false;
-  }
-
-  // Machine concurrent-thread capacity, used to convert a kernel's launch size
-  // into whole occupancy passes (the per-node work weight below). Falls back to
-  // node-count weighting (every node == 1) if the device info is unavailable.
-  size_t machine_threads = 0;
-  if (dev0 >= 0) {
-    const auto& dinfo = g_devices[dev0]->devices()[0]->info();
-    machine_threads = static_cast<size_t>(dinfo.maxComputeUnits_) * dinfo.maxThreadsPerCU_;
-  }
-  // Per-node work proxy: kernels are weighted by ceil(threads / machine_threads)
-  // — i.e. how many full-machine occupancy passes the launch needs — so a launch
-  // that fills the GPU once counts as 1, a launch needing N passes counts as N.
-  // Sub-machine launches (and all non-kernel nodes) stay at 1, which preserves
-  // the original node-count behaviour (and the min_overlap scale) for the small,
-  // launch-bound kernels the gate originally targeted. NOTE: this is occupancy-
-  // bound only; a small-grid kernel with a long internal loop is underweighted.
-  auto node_work = [machine_threads](Node n) -> size_t {
-    if (n == nullptr || n->GetType() != hipGraphNodeTypeKernel) return 1;
-    const size_t threads = static_cast<GraphKernelNode*>(n)->GetLaunchThreadCount();
-    if (threads == 0 || machine_threads == 0) return 1;
-    return std::max<size_t>(1, (threads + machine_threads - 1) / machine_threads);
+// DFS-based stream assignment for segment DAG — same algorithm as classic ScheduleOneNode
+// but operates on segments instead of individual nodes. Linear chains of segments stay
+// on the same stream; branches rotate to a new stream at each leaf.
+void GraphExec::DFSStreamAssignment() {
+  auto getPoolSize = [&](int dev_id) -> int {
+    auto it = max_streams_dev_.find(dev_id);
+    return (it != max_streams_dev_.end() && it->second > 0) ? it->second : 1;
   };
 
-  size_t barrier_est = 0;  // barrier packets multi-stream would emit (see header)
-  size_t signal_est = 0;   // completion signals multi-stream would emit (see header)
-  size_t total_work = 0;   // sum of per-node work over all segments
-  std::vector<size_t> seg_work(segments_.size(), 0);
-  for (size_t i = 0; i < segments_.size(); ++i) {
-    const auto& seg = segments_[i];
-    // Count only cross-stream/device dependencies. Same-stream deps are ordered
-    // by the in-order queue and never materialize a barrier, so including them
-    // would overstate multi-stream's cost and bias the gate toward collapse.
-    // PrecomputeStreamAssignment() has already assigned stream_id by the time
-    // this runs, so mirror the exact cross-stream filter PASS 2/PASS 3 use.
-    size_t cross_deps = 0;
-    for (int dep_id : seg.segment_ids_dependencies) {
-      if (dep_id < 0 || dep_id >= static_cast<int>(segments_.size())) continue;
-      const auto& dep_seg = segments_[dep_id];
-      if (dep_seg.dev_id != seg.dev_id || dep_seg.stream_id != seg.stream_id) {
-        ++cross_deps;
-      }
-    }
-    // cross_deps == 1 is embedded into the ext kernel-dispatch packet (no
-    // separate barrier); cross_deps >= 2 needs ceil(cross_deps / 5) barriers.
-    if (cross_deps >= 2) {
-      barrier_est += (cross_deps + 4) / 5;
-    }
-    // A segment emits a completion signal exactly when PrecomputeStreamAssignment
-    // flagged it (cross-stream/device consumer, or leaf when leaf-join back to
-    // the launch stream is required). Reuse that flag instead of counting every
-    // segment with downstream edges, which over-counts same-stream producers.
-    if (seg.needs_completion_signal) {
-      ++signal_est;
-    }
-    for (Node n : seg.nodes) seg_work[i] += node_work(n);
-    total_work += seg_work[i];
+  // Reset all stream IDs
+  for (auto& seg : segments_) {
+    seg.stream_id = -1;
   }
-  // Total per-launch cross-stream overhead multi-stream pays on the host path.
-  const size_t sync_cost = barrier_est + signal_est;
-  if (sync_cost == 0) return false;  // no barriers/signals => multi-stream is free
 
-  // Critical path (in work units) via DP over segments in dependency-level order:
-  // cp[seg] = work(seg) + max(cp[dep]); a dep always sits at a strictly lower level.
-  std::vector<size_t> cp(segments_.size(), 0);
-  size_t critical_path_work = 0;
-  for (int level = 0; level <= max_dependency_level_; ++level) {
-    auto it = segments_per_level_.find(level);
-    if (it == segments_per_level_.end()) continue;
-    for (int seg_id : it->second) {
-      if (seg_id < 0 || seg_id >= static_cast<int>(segments_.size())) continue;
-      const auto& seg = segments_[seg_id];
-      size_t best_dep = 0;
-      for (int dep_id : seg.segment_ids_dependencies) {
-        if (dep_id < 0 || dep_id >= static_cast<int>(segments_.size())) continue;
-        best_dep = std::max(best_dep, cp[dep_id]);
-      }
-      cp[seg_id] = best_dep + seg_work[seg_id];
-      critical_path_work = std::max(critical_path_work, cp[seg_id]);
+  int sid = 0;
+
+  // Find root segments (no dependencies) — these are DFS entry points
+  std::vector<int> roots;
+  for (int i = 0; i < static_cast<int>(segments_.size()); ++i) {
+    if (segments_[i].segment_ids_dependencies.empty()) {
+      roots.push_back(i);
     }
   }
 
-  // parallel_slack = overlappable work off the critical path. Weighting by work
-  // (not node count) keeps genuinely parallel long-running kernels multi-stream:
-  // their slack scales with launch size and outgrows min_overlap * sync_cost,
-  // while tiny launch-bound kernels still collapse.
-  const size_t parallel_slack =
-      (total_work > critical_path_work) ? (total_work - critical_path_work) : 0;
-  const bool collapse = parallel_slack < static_cast<size_t>(min_overlap) * sync_cost;
+  // Stack-based DFS over segment DAG — mirrors ScheduleOneNode exactly
+  std::vector<int> pending;
+  for (int i = static_cast<int>(roots.size()) - 1; i >= 0; --i) {
+    pending.push_back(roots[i]);
+  }
 
-  ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_CODE,
-          "[hipGraph] Single-stream gate: work=%zu critical_path=%zu slack=%zu "
-          "barrier_packets~=%zu signals~=%zu sync_cost=%zu min_overlap=%u -> %s",
-          total_work, critical_path_work, parallel_slack, barrier_est, signal_est,
-          sync_cost, min_overlap,
-          collapse ? "collapse to single stream" : "keep multi-stream");
-  return collapse;
+  while (!pending.empty()) {
+    int cur_id = pending.back();
+    pending.pop_back();
+
+    if (cur_id < 0 || cur_id >= static_cast<int>(segments_.size())) continue;
+    auto& cur = segments_[cur_id];
+
+    // Skip if already assigned
+    if (cur.stream_id != -1) continue;
+
+    // Assign current segment to current stream, capped per device pool
+    int pool = getPoolSize(cur.dev_id);
+    cur.stream_id = sid % pool;
+
+    // Push unassigned successors in reverse order (preserve left-to-right)
+    bool end_of_branch = true;
+    for (int i = static_cast<int>(cur.segment_ids_edges.size()) - 1; i >= 0; --i) {
+      int edge_id = cur.segment_ids_edges[i];
+      if (edge_id >= 0 && edge_id < static_cast<int>(segments_.size()) &&
+          segments_[edge_id].stream_id == -1) {
+        pending.push_back(edge_id);
+        end_of_branch = false;
+      }
+    }
+
+    // Rotate stream at leaf — same as classic ScheduleOneNode
+    if (end_of_branch) {
+      sid = (sid + 1) % static_cast<int>(DEBUG_HIP_FORCE_GRAPH_QUEUES);
+    }
+  }
+
+  // Compute needs_completion_signal — same logic as RoundRobinStreamAssignment
+  for (auto& seg : segments_) {
+    seg.needs_completion_signal = false;
+    if (seg.segment_ids_edges.empty()) {
+      seg.needs_completion_signal = true;
+      continue;
+    }
+    for (int edge_id : seg.segment_ids_edges) {
+      if (edge_id >= 0 && edge_id < static_cast<int>(segments_.size())) {
+        const auto& edge_seg = segments_[edge_id];
+        if (edge_seg.dev_id != seg.dev_id || edge_seg.stream_id != seg.stream_id) {
+          seg.needs_completion_signal = true;
+          break;
+        }
+      }
+    }
+  }
+}
+
+// ================================================================================================
+// Select stream assignment algorithm:
+//   DEBUG_HIP_GRAPH_SEGMENT_SCHEDULING == 2 → force DFS
+//   DEBUG_HIP_GRAPH_SEGMENT_SCHEDULING == 3 → force round-robin
+//   otherwise (auto): complex graphs (16+ segs, avg length < 8) → DFS
+//                     simple/parallel graphs                     → round-robin
+void GraphExec::SelectStreamAssignment() {
+  // Forced modes via env var
+  if (DEBUG_HIP_GRAPH_SEGMENT_SCHEDULING == 2) {
+    ClPrint(amd::LOG_INFO, amd::LOG_CODE,
+            "[hipGraph] SelectStreamAssignment: forced DFS (%zu segs)", segments_.size());
+    DFSStreamAssignment();
+    return;
+  }
+  if (DEBUG_HIP_GRAPH_SEGMENT_SCHEDULING == 3) {
+    ClPrint(amd::LOG_INFO, amd::LOG_CODE,
+            "[hipGraph] SelectStreamAssignment: forced round-robin (%zu segs)", segments_.size());
+    RoundRobinStreamAssignment();
+    return;
+  }
+
+  // Auto selection based on graph complexity
+  const size_t kSegmentSizeThreshold = 16;
+  const double kAvgSegmentLengthThreshold = 8.0;
+
+  bool use_dfs = false;
+  if (segments_.size() >= kSegmentSizeThreshold) {
+    size_t total_nodes = 0;
+    for (const auto& seg : segments_) {
+      total_nodes += seg.nodes.size();
+    }
+    double avg = static_cast<double>(total_nodes) / segments_.size();
+    if (avg < kAvgSegmentLengthThreshold) {
+      use_dfs = true;
+      ClPrint(amd::LOG_INFO, amd::LOG_CODE,
+              "[hipGraph] SelectStreamAssignment: complex graph (%zu segs, avg %.2f nodes) "
+              "→ DFS stream assignment",
+              segments_.size(), avg);
+    }
+  }
+
+  if (use_dfs) {
+    DFSStreamAssignment();
+  } else {
+    ClPrint(amd::LOG_INFO, amd::LOG_CODE,
+            "[hipGraph] SelectStreamAssignment: simple/parallel graph (%zu segs) "
+            "→ round-robin stream assignment",
+            segments_.size());
+    RoundRobinStreamAssignment();
+  }
 }
 
 // ================================================================================================
@@ -1489,10 +1423,10 @@ hipError_t GraphExec::Init() {
   }
 
   if (use_segment_scheduling_) {
-    // Pre-compute stream assignment before packet capture so that BuildSyncPlan
+    // Select and apply stream assignment before packet capture so that BuildSyncPlan
     // (called inside CaptureAQLPackets) can see each segment's stream_id and
     // skip same-stream dependency barriers.
-    PrecomputeStreamAssignment();
+    SelectStreamAssignment();
 
     // For graph nodes capture AQL packets to dispatch them directly during graph launch.
     // BuildSyncPlan (inside) runs the barrier-ROI collapse pass, which may fold the

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -1269,6 +1269,36 @@ struct GraphLaunchCleanup {
 // ================================================================================================
 // GraphExecClassic — PAL/Windows path: simple topological enqueue, no AQL capture.
 // ================================================================================================
+hipError_t GraphExecClassic::ScheduleOneNode(GraphNode* node, hip::Stream* stream) {
+  node->SetStream(stream);
+  return node->CreateCommand(node->GetQueue());
+}
+
+// ================================================================================================
+hipError_t GraphExecClassic::ScheduleNodes(hip::Stream* stream) {
+  hipError_t status = hipSuccess;
+  for (auto node : topoOrder_) {
+    hipError_t s = ScheduleOneNode(node, stream);
+    if (s != hipSuccess) {
+      status = s;
+    }
+  }
+  return status;
+}
+
+// ================================================================================================
+void GraphExecClassic::RunOneNode(GraphNode* node, hip::Stream* stream) {
+  node->EnqueueCommands(stream);
+}
+
+// ================================================================================================
+void GraphExecClassic::RunNodes(hip::Stream* stream) {
+  for (auto node : topoOrder_) {
+    RunOneNode(node, stream);
+  }
+}
+
+// ================================================================================================
 hipError_t GraphExecClassic::Init() {
   if (!TopologicalOrder()) {
     return hipErrorInvalidValue;
@@ -1302,15 +1332,8 @@ hipError_t GraphExecClassic::Run(hip::Stream* launch_stream) {
     }
   }
 
-  // Classic topological walk: create and enqueue each node's commands in order.
-  for (auto node : topoOrder_) {
-    node->SetStream(launch_stream);
-    hipError_t s = node->CreateCommand(node->GetQueue());
-    if (s != hipSuccess) {
-      status = s;
-    }
-    node->EnqueueCommands(launch_stream);
-  }
+  status = ScheduleNodes(launch_stream);
+  RunNodes(launch_stream);
 
   // Enqueue a lightweight marker to carry the launch-complete callback.
   auto* marker = new amd::Marker(*launch_stream, kMarkerDisableFlush, {});

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -1270,8 +1270,9 @@ struct GraphLaunchCleanup {
 // GraphExecClassic — PAL/Windows path: simple topological enqueue, no AQL capture.
 // ================================================================================================
 hipError_t GraphExecClassic::Init() {
-  // topoOrder_ is populated by TopologicalOrder() before Init() is called.
-  // Determine the capture device from the first node.
+  if (!TopologicalOrder()) {
+    return hipErrorInvalidValue;
+  }
   if (!topoOrder_.empty()) {
     auto* dev = topoOrder_[0]->GetParentGraph()->Device();
     if (dev != nullptr) {

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -1101,7 +1101,7 @@ void GraphExecSegmented::RoundRobinStreamAssignment() {
 }
 
 // ================================================================================================
-void GraphExec::ComputeCompletionSignalFlags() {
+void GraphExecSegmented::ComputeCompletionSignalFlags() {
   const bool leaf_sync_required = IsLeafNodeSyncRequired();
   for (auto& seg : segments_) {
     seg.needs_completion_signal = false;
@@ -1257,6 +1257,133 @@ void GraphExecSegmented::SelectStreamAssignment() {
   }
 }
 
+// ================================================================================================
+// Barrier-ROI heuristic.
+//
+// Multi-stream segment scheduling only pays off when the device-side overlap it
+// unlocks exceeds the cost of the cross-stream barriers/signals it requires. For
+// launch-overhead-bound graphs (many tiny kernels, near-serial dependencies) the
+// barriers have a high overhead: collapsing every segment onto one in-order stream
+// removes them entirely and is measurably faster on both the launch and the
+// instantiate path.
+//
+// Both sides are estimated in cheap structural units, with no device timing:
+//   * barrier_est   = number of barrier *packets* multi-stream would emit. This
+//                     mirrors BuildSyncPlan's materialization rather than the raw
+//                     dependency count: a single barrier packet resolves up to 5
+//                     dependencies ((deps + 4) / 5 packets), and a lone
+//                     dependency is folded into the segment's ext kernel-dispatch
+//                     packet with no separate barrier at all. SelectStream-
+//                     Assignment() has already run by the time this is called, so
+//                     only *cross-stream/device* deps are counted (same-stream
+//                     deps are ordered by the in-order queue and emit no barrier),
+//                     matching what PASS 2/PASS 3 of BuildSyncPlan actually do.
+//   * signal_est    = number of completion *signals* multi-stream would emit.
+//                     Reuses each segment's needs_completion_signal flag (set by
+//                     SelectStreamAssignment with the same cross-stream/leaf
+//                     criteria BuildSyncPlan uses), so producers whose consumers
+//                     share their stream are not over-counted. Signals are real
+//                     per-launch host cost (signal-pool acquire + packet patch)
+//                     that the barrier count alone misses, so they belong in the
+//                     ROI denominator alongside barriers.
+//   * parallel_slack = total work - critical-path work. The work that is
+//                      genuinely off the longest dependency chain and could
+//                      therefore overlap on another stream. Work is measured in
+//                      machine-occupancy passes, not node count: each kernel
+//                      weighs ceil(launch_threads / machine_threads) (>=1), so a
+//                      kernel that fills the GPU once is 1 unit and one needing N
+//                      passes is N. Non-kernel nodes and sub-machine launches are
+//                      1 unit, preserving the original node-count behaviour for
+//                      the small launch-bound kernels the gate targets. This is
+//                      what keeps two *long-running* independent kernels multi-
+//                      stream (their slack outgrows the threshold) while tiny
+//                      independent kernels (e.g. PyFR's stubs) still collapse.
+//
+// Collapse when parallel_slack < min_overlap * (barrier_est + signal_est): i.e.
+// keep multi-stream only when each unit of cross-stream sync overhead buys at
+// least min_overlap nodes of overlappable work. Folding collapse onto the launch
+// stream removes both barriers and signals (it runs inline, 0/0), so the full
+// sync cost is what multi-stream genuinely pays over collapse. Tunable via
+// DEBUG_HIP_GRAPH_MIN_OVERLAP; 0 disables the gate.
+bool GraphExecSegmented::ShouldCollapseToSingleStream() const {
+  const uint32_t min_overlap = DEBUG_HIP_GRAPH_MIN_OVERLAP;
+  if (min_overlap == 0) return false;            // gate disabled
+  if (segments_.size() < 2) return false;        // nothing to parallelize
+
+  const int dev0 = segments_.front().dev_id;
+  for (const auto& seg : segments_) {
+    if (seg.dev_id != dev0) return false;
+  }
+
+  size_t machine_threads = 0;
+  if (dev0 >= 0) {
+    const auto& dinfo = g_devices[dev0]->devices()[0]->info();
+    machine_threads = static_cast<size_t>(dinfo.maxComputeUnits_) * dinfo.maxThreadsPerCU_;
+  }
+  auto node_work = [machine_threads](Node n) -> size_t {
+    if (n == nullptr || n->GetType() != hipGraphNodeTypeKernel) return 1;
+    const size_t threads = static_cast<GraphKernelNode*>(n)->GetLaunchThreadCount();
+    if (threads == 0 || machine_threads == 0) return 1;
+    return std::max<size_t>(1, (threads + machine_threads - 1) / machine_threads);
+  };
+
+  size_t barrier_est = 0;
+  size_t signal_est = 0;
+  size_t total_work = 0;
+  std::vector<size_t> seg_work(segments_.size(), 0);
+  for (size_t i = 0; i < segments_.size(); ++i) {
+    const auto& seg = segments_[i];
+    size_t cross_deps = 0;
+    for (int dep_id : seg.segment_ids_dependencies) {
+      if (dep_id < 0 || dep_id >= static_cast<int>(segments_.size())) continue;
+      const auto& dep_seg = segments_[dep_id];
+      if (dep_seg.dev_id != seg.dev_id || dep_seg.stream_id != seg.stream_id) {
+        ++cross_deps;
+      }
+    }
+    if (cross_deps >= 2) {
+      barrier_est += (cross_deps + 4) / 5;
+    }
+    if (seg.needs_completion_signal) {
+      ++signal_est;
+    }
+    for (Node n : seg.nodes) seg_work[i] += node_work(n);
+    total_work += seg_work[i];
+  }
+  const size_t sync_cost = barrier_est + signal_est;
+  if (sync_cost == 0) return false;
+
+  std::vector<size_t> cp(segments_.size(), 0);
+  size_t critical_path_work = 0;
+  for (int level = 0; level <= max_dependency_level_; ++level) {
+    auto it = segments_per_level_.find(level);
+    if (it == segments_per_level_.end()) continue;
+    for (int seg_id : it->second) {
+      if (seg_id < 0 || seg_id >= static_cast<int>(segments_.size())) continue;
+      const auto& seg = segments_[seg_id];
+      size_t best_dep = 0;
+      for (int dep_id : seg.segment_ids_dependencies) {
+        if (dep_id < 0 || dep_id >= static_cast<int>(segments_.size())) continue;
+        best_dep = std::max(best_dep, cp[dep_id]);
+      }
+      cp[seg_id] = best_dep + seg_work[seg_id];
+      critical_path_work = std::max(critical_path_work, cp[seg_id]);
+    }
+  }
+
+  const size_t parallel_slack =
+      (total_work > critical_path_work) ? (total_work - critical_path_work) : 0;
+  const bool collapse = parallel_slack < static_cast<size_t>(min_overlap) * sync_cost;
+
+  ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_CODE,
+          "[hipGraph] Single-stream gate: work=%zu critical_path=%zu slack=%zu "
+          "barrier_packets~=%zu signals~=%zu sync_cost=%zu min_overlap=%u -> %s",
+          total_work, critical_path_work, parallel_slack, barrier_est, signal_est,
+          sync_cost, min_overlap,
+          collapse ? "collapse to single stream" : "keep multi-stream");
+  return collapse;
+}
+
 // Carries the per-launch state needed by the completion callback: the graph
 // whose refcount to drop, plus the signal set (and its device) to re-arm and
 // return to the pool now that the launch's GPU work is done.
@@ -1322,11 +1449,30 @@ hipError_t GraphExecClassic::Run(hip::Stream* launch_stream) {
     this->retain();
   }
 
+  Node firstNode = topoOrder_.empty() ? nullptr : topoOrder_[0];
+
+  if (flags_ & hipGraphInstantiateFlagAutoFreeOnLaunch) {
+    if (firstNode != nullptr) {
+      auto* parentGraph = firstNode->GetParentGraph();
+      auto* pool = parentGraph->Device()->GetGraphMemoryPool();
+      for (auto* node : topoOrder_) {
+        if (node->GetType() == hipGraphNodeTypeMemAlloc) {
+          static_cast<GraphMemAllocNode*>(node)->ReleaseCachedMapping(pool, launch_stream);
+        }
+      }
+      parentGraph->FreeAllMemory(launch_stream);
+      parentGraph->memalloc_nodes_ = 0;
+      if (!AMD_DIRECT_DISPATCH) {
+        launch_stream->finish();
+      }
+    }
+  }
+
   if (repeatLaunch_ == false) {
     repeatLaunch_ = true;
   } else {
     // Check for MemAlloc/MemFree mismatch on repeat launches.
-    if (!topoOrder_.empty() && topoOrder_[0]->GetParentGraph()->GetMemAllocNodeCount() > 0) {
+    if (firstNode != nullptr && firstNode->GetParentGraph()->GetMemAllocNodeCount() > 0) {
       this->release();
       return hipErrorInvalidValue;
     }
@@ -1375,17 +1521,6 @@ hipError_t GraphExecSegmented::Init() {
       count = std::min(count, static_cast<int>(DEBUG_HIP_FORCE_GRAPH_QUEUES));
     }
 
-    if (!use_segment_scheduling_) {
-      // Classic scheduling has no BuildSyncPlan collapse pass, so create streams now.
-      for (auto const& [dev_id, num_streams] : max_streams_dev_) {
-        if (num_streams > 0) {
-          status = CreateStreams(num_streams, dev_id);
-          if (status != hipSuccess) {
-            return status;
-          }
-        }
-      }
-    }
   }
 
   // Select and apply stream assignment before packet capture so that BuildSyncPlan

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -45,14 +45,14 @@ amd::Monitor GraphNode::nodeSetLock_{};
 std::unordered_set<Graph*> Graph::graphSet_;
 // Guards global graph set
 amd::Monitor Graph::graphSetLock_{};
-std::unordered_set<GraphExec*> GraphExec::graphExecSet_;
+std::unordered_set<GraphExecBase*> GraphExecBase::graphExecSet_;
 // Guards global exec graph set
 // we have graphExec object as part of child graph and we need recursive lock
-std::recursive_mutex GraphExec::graphExecSetLock_;
+std::recursive_mutex GraphExecBase::graphExecSetLock_;
 // Serialize the creation of internal streams from multiple threads, ensuring that each stream is
 // mapped to different HSA queues.
-std::recursive_mutex GraphExec::graphExecStreamCreateLock_;
-std::shared_mutex GraphExec::graphExecTrimLock_;
+std::recursive_mutex GraphExecBase::graphExecStreamCreateLock_;
+std::shared_mutex GraphExecBase::graphExecTrimLock_;
 std::unordered_set<UserObject*> UserObject::ObjectSet_;
 // Guards global user object
 amd::Monitor UserObject::UserObjectLock_{};
@@ -224,8 +224,8 @@ hipError_t Graph::ScheduleNodesIntoBatches() {
 
   // Calculate topological order for compatibility
   // (e.g., child graphs, GetNodes() API, AutoFreeOnLaunch)
-  GraphExec* graphExec = dynamic_cast<GraphExec*>(this);
-  if (graphExec && !graphExec->TopologicalOrder()) {
+  GraphExecBase* execBase = dynamic_cast<GraphExecBase*>(this);
+  if (execBase && !execBase->TopologicalOrder()) {
     ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
             "[hipGraph] TopologicalOrder failed - graph may contain cycles");
     return hipErrorInvalidValue;
@@ -299,7 +299,7 @@ void Graph::ResolveSegmentDependencies() {
 }
 
 // ================================================================================================
-void GraphExec::BuildSyncPlan() {
+void GraphExecSegmented::BuildSyncPlan() {
   // Clean up any prior barrier packets
   for (auto* p : sync_plan_.barrier_packets) { delete[] p; }
 
@@ -921,7 +921,7 @@ Graph* Graph::clone() const {
 }
 
 // ================================================================================================
-bool GraphExec::isGraphExecValid(GraphExec* pGraphExec) {
+bool GraphExecBase::isGraphExecValid(GraphExecBase* pGraphExec) {
   std::scoped_lock lock(graphExecSetLock_);
   if (graphExecSet_.find(pGraphExec) == graphExecSet_.end()) {
     return false;
@@ -930,7 +930,7 @@ bool GraphExec::isGraphExecValid(GraphExec* pGraphExec) {
 }
 
 // ================================================================================================
-hipError_t GraphExec::CreateStreams(uint32_t num_streams, int devId) {
+hipError_t GraphExecSegmented::CreateStreams(uint32_t num_streams, int devId) {
   std::scoped_lock lock(graphExecStreamCreateLock_);
 
   if (num_streams == 0) {
@@ -998,7 +998,7 @@ hipError_t GraphExec::CreateStreams(uint32_t num_streams, int devId) {
 }
 
 // ================================================================================================
-void GraphExec::FindStreamsReqPerDevForSegments() {
+void GraphExecSegmented::FindStreamsReqPerDevForSegments() {
   // For packet engine mode: analyze segments to determine stream requirements per device
   // We need to track the maximum number of concurrent segments per device at any level
 
@@ -1070,7 +1070,7 @@ void GraphExec::FindStreamsReqPerDevForSegments() {
 }
 
 // ================================================================================================
-void GraphExec::RoundRobinStreamAssignment() {
+void GraphExecSegmented::RoundRobinStreamAssignment() {
   // max_streams_dev_ holds the raw parallelism count per device as computed by
   // FindStreamsReqPerDevForSegments() and capped in Init(). CreateStreams() handles
   // the -1 adjustment for the instantiation device internally, so the value here
@@ -1130,7 +1130,7 @@ void GraphExec::ComputeCompletionSignalFlags() {
 // ================================================================================================
 // DFS-based stream assignment for segment DAG.
 // Linear chains of segments stay on the same stream; branches rotate to a new stream at each leaf.
-void GraphExec::DFSStreamAssignment() {
+void GraphExecSegmented::DFSStreamAssignment() {
   auto getPoolSize = [&](int dev_id) -> int {
     auto it = max_streams_dev_.find(dev_id);
     return (it != max_streams_dev_.end() && it->second > 0) ? it->second : 1;
@@ -1208,27 +1208,25 @@ void GraphExec::DFSStreamAssignment() {
 }
 
 // ================================================================================================
-// Select stream assignment algorithm:
-//   DEBUG_HIP_GRAPH_SEGMENT_SCHEDULING == 1 → force DFS
-//   DEBUG_HIP_GRAPH_SEGMENT_SCHEDULING == 2 → force round-robin
-//   otherwise (auto): complex graphs (16+ segs, avg length < 8) → DFS
-//                     simple/parallel graphs                     → round-robin
-void GraphExec::SelectStreamAssignment() {
-  // Forced modes via env var
+// Select stream assignment algorithm (DEBUG_HIP_GRAPH_SEGMENT_SCHEDULING):
+//   0 = Hybrid/auto: complex graphs (16+ segs, avg length < 8) → DFS; else round-robin
+//   1 = Force round-robin
+//   2 = Force DFS
+void GraphExecSegmented::SelectStreamAssignment() {
   if (DEBUG_HIP_GRAPH_SEGMENT_SCHEDULING == 1) {
-    ClPrint(amd::LOG_INFO, amd::LOG_CODE,
-            "[hipGraph] SelectStreamAssignment: forced DFS (%zu segs)", segments_.size());
-    DFSStreamAssignment();
-    return;
-  }
-  if (DEBUG_HIP_GRAPH_SEGMENT_SCHEDULING == 2) {
     ClPrint(amd::LOG_INFO, amd::LOG_CODE,
             "[hipGraph] SelectStreamAssignment: forced round-robin (%zu segs)", segments_.size());
     RoundRobinStreamAssignment();
     return;
   }
+  if (DEBUG_HIP_GRAPH_SEGMENT_SCHEDULING == 2) {
+    ClPrint(amd::LOG_INFO, amd::LOG_CODE,
+            "[hipGraph] SelectStreamAssignment: forced DFS (%zu segs)", segments_.size());
+    DFSStreamAssignment();
+    return;
+  }
 
-  // Auto selection based on graph complexity
+  // 0 = Hybrid: auto-select based on graph complexity
   const size_t kSegmentSizeThreshold = 16;
   const double kAvgSegmentLengthThreshold = 8.0;
 
@@ -1259,8 +1257,81 @@ void GraphExec::SelectStreamAssignment() {
   }
 }
 
+// Carries the per-launch state needed by the completion callback: the graph
+// whose refcount to drop, plus the signal set (and its device) to re-arm and
+// return to the pool now that the launch's GPU work is done.
+struct GraphLaunchCleanup {
+  GraphExecBase* exec;
+  amd::Device* device;
+  std::vector<void*> signal_set;
+};
+
 // ================================================================================================
-hipError_t GraphExec::Init() {
+// GraphExecClassic — PAL/Windows path: simple topological enqueue, no AQL capture.
+// ================================================================================================
+hipError_t GraphExecClassic::Init() {
+  // topoOrder_ is populated by TopologicalOrder() before Init() is called.
+  // Determine the capture device from the first node.
+  if (!topoOrder_.empty()) {
+    auto* dev = topoOrder_[0]->GetParentGraph()->Device();
+    if (dev != nullptr) {
+      captureDeviceId_ = dev->deviceId();
+      static_cast<amd::ReferenceCountedObject*>(g_devices[captureDeviceId_])->retain();
+    }
+  }
+  return hipSuccess;
+}
+
+// ================================================================================================
+hipError_t GraphExecClassic::Run(hip::Stream* launch_stream) {
+  hipError_t status = hipSuccess;
+
+  {
+    std::shared_lock<std::shared_mutex> trim_guard(graphExecTrimLock_);
+    this->retain();
+  }
+
+  if (repeatLaunch_ == false) {
+    repeatLaunch_ = true;
+  } else {
+    // Check for MemAlloc/MemFree mismatch on repeat launches.
+    if (!topoOrder_.empty() && topoOrder_[0]->GetParentGraph()->GetMemAllocNodeCount() > 0) {
+      this->release();
+      return hipErrorInvalidValue;
+    }
+  }
+
+  // Classic topological walk: create and enqueue each node's commands in order.
+  for (auto node : topoOrder_) {
+    node->SetStream(launch_stream);
+    hipError_t s = node->CreateCommand(node->GetQueue());
+    if (s != hipSuccess) {
+      status = s;
+    }
+    node->EnqueueCommands(launch_stream);
+  }
+
+  // Enqueue a lightweight marker to carry the launch-complete callback.
+  auto* marker = new amd::Marker(*launch_stream, kMarkerDisableFlush, {});
+  marker->setCommandEntryScope(amd::Device::kCacheStateIgnore);
+  amd::Event& event = marker->event();
+  constexpr bool kBlocking = false;
+  auto* cleanup = new GraphLaunchCleanup();
+  cleanup->exec = this;
+  cleanup->device = g_devices[launch_stream->DeviceId()]->devices()[0];
+  if (!event.setCallback(CL_COMPLETE, GraphExecBase::OnLaunchComplete, cleanup, kBlocking)) {
+    launch_stream->finish();
+    GraphExecBase::OnLaunchComplete(nullptr, CL_COMPLETE, cleanup);
+    marker->release();
+    return hipErrorInvalidHandle;
+  }
+  marker->enqueue();
+  marker->release();
+  return status;
+}
+
+// ================================================================================================
+hipError_t GraphExecSegmented::Init() {
   hipError_t status = hipSuccess;
   // captureDeviceId_ is set inside FindStreamsReqPerDevForSegments() from
   // max_streams_dev_ once all segments are analysed. Must run unconditionally
@@ -1308,7 +1379,7 @@ hipError_t GraphExec::Init() {
 //! Chunk size to add to kern arg pool
 constexpr uint32_t kKernArgChunkSize = 128 * Ki;
 // ================================================================================================
-void GraphExec::GetKernelArgSizeForGraph(std::unordered_map<int, size_t>& kernArgSizeForGraph) {
+void GraphExecSegmented::GetKernelArgSizeForGraph(std::unordered_map<int, size_t>& kernArgSizeForGraph) {
   // Calculate the kernel argument size required for all graph kernel nodes
   // when GPU packet capture is enabled
 
@@ -1344,7 +1415,7 @@ void GraphExec::GetKernelArgSizeForGraph(std::unordered_map<int, size_t>& kernAr
 // ================================================================================================
 // Enable or disable a graph node's packets in the batch
 // Simply updates the enabled state and count of disabled nodes
-void GraphExec::PacketBatch::setEnabled(GraphNode* node, bool enabled) {
+void GraphExecSegmented::PacketBatch::setEnabled(GraphNode* node, bool enabled) {
   auto it = nodeToRangeIndex.find(node);
   if (it == nodeToRangeIndex.end()) {
     return;
@@ -1375,7 +1446,7 @@ void GraphExec::PacketBatch::setEnabled(GraphNode* node, bool enabled) {
 // but are not tracked in nodeRanges.  A linear scan with a per-index enabled
 // bitmap preserves them while filtering out disabled node packets.
 // ================================================================================================
-void GraphExec::PacketBatch::rebuildFilteredLists(
+void GraphExecSegmented::PacketBatch::rebuildFilteredLists(
     std::vector<amd::Device::HwEventPatch>& patch_list) {
   if (filteredCacheValid) {
     return;
@@ -1445,7 +1516,7 @@ void GraphExec::PacketBatch::rebuildFilteredLists(
 // Called when all nodes are re-enabled (disabledNodeCount == 0) so that
 // ApplyHwEventPatches writes into the buffer the dispatch path will use.
 // ================================================================================================
-void GraphExec::PacketBatch::restorePatchListPointers(
+void GraphExecSegmented::PacketBatch::restorePatchListPointers(
     std::vector<amd::Device::HwEventPatch>& patch_list) {
   for (auto& patch : patch_list) {
     for (size_t i = 0; i < dispatchPackets.size(); ++i) {
@@ -1458,7 +1529,7 @@ void GraphExec::PacketBatch::restorePatchListPointers(
 }
 
 // ================================================================================================
-hipError_t GraphExec::CaptureAndFormPacketsForGraph() {
+hipError_t GraphExecSegmented::CaptureAndFormPacketsForGraph() {
   // Fixme: Only single stream child graph nodes are supported.
   hipError_t status = hipSuccess;
 
@@ -1655,7 +1726,7 @@ hipError_t GraphExec::CaptureAndFormPacketsForGraph() {
 }
 
 // ================================================================================================
-hipError_t GraphExec::CaptureAQLPackets() {
+hipError_t GraphExecSegmented::CaptureAQLPackets() {
   hipError_t status = hipSuccess;
 
   // Create a map to track kernel argument sizes for each device
@@ -1695,7 +1766,7 @@ hipError_t GraphExec::CaptureAQLPackets() {
 }
 
 // ================================================================================================
-hipError_t GraphExec::UpdateAQLPacket(hip::GraphNode* node) {
+hipError_t GraphExecSegmented::UpdateAQLPacket(hip::GraphNode* node) {
   if (!node->GraphCaptureEnabled()) {
     return hipSuccess;
   }
@@ -1825,7 +1896,7 @@ hipError_t GraphExec::UpdateAQLPacket(hip::GraphNode* node) {
 // ================================================================================================
 // Append one 64-byte AQL packet to a flat buffer: copies the body, saves the original full_header
 // and invalidates the header.
-void GraphExec::PacketBatch::appendPacketToFlatBuffer(const uint8_t* pkt_raw,
+void GraphExecSegmented::PacketBatch::appendPacketToFlatBuffer(const uint8_t* pkt_raw,
                                                       std::vector<uint8_t>& flatData,
                                                       std::vector<uint32_t>& fullHeaders) {
   static constexpr size_t kSigOff = 56;
@@ -1848,7 +1919,7 @@ void GraphExec::PacketBatch::appendPacketToFlatBuffer(const uint8_t* pkt_raw,
 
 // ================================================================================================
 // Rebuild the flat packet buffer from the current dispatchPackets contents.
-void GraphExec::PacketBatch::rebuildFlatBuffer() {
+void GraphExecSegmented::PacketBatch::rebuildFlatBuffer() {
   const size_t n = dispatchPackets.size();
   flatPacketData.clear();
   validPacketFullHeaders.clear();
@@ -1873,7 +1944,7 @@ void GraphExec::PacketBatch::rebuildFlatBuffer() {
 }
 
 // ================================================================================================
-hipError_t GraphExec::UpdatePacketBatchesForNodeEnableDisable(hip::GraphNode* node,
+hipError_t GraphExecSegmented::UpdatePacketBatchesForNodeEnableDisable(hip::GraphNode* node,
                                                               bool isEnabled) {
   if (!node->GraphCaptureEnabled()) {
     // Only handle single stream case with captured nodes
@@ -1917,29 +1988,21 @@ hipError_t GraphExec::UpdatePacketBatchesForNodeEnableDisable(hip::GraphNode* no
   return hipSuccess;
 }
 
-// Carries the per-launch state needed by the completion callback: the graph
-// whose refcount to drop, plus the signal set (and its device) to re-arm and
-// return to the pool now that the launch's GPU work is done.
-struct GraphLaunchCleanup {
-  GraphExec* exec;
-  amd::Device* device;
-  std::vector<void*> signal_set;
-};
-
-void GraphExec::OnLaunchComplete(cl_event event, cl_int command_exec_status, void* user_data) {
+void GraphExecBase::OnLaunchComplete(cl_event event, cl_int command_exec_status, void* user_data) {
   auto* cleanup = reinterpret_cast<GraphLaunchCleanup*>(user_data);
-  GraphExec* graphExec = cleanup->exec;
+  GraphExecBase* execBase = cleanup->exec;
   // Re-arm and recycle the launch's signals while the GraphExec (and thus its
   // signal pool) is still alive, then drop the launch's reference.
-  if (graphExec->signalManager_ != nullptr && !cleanup->signal_set.empty()) {
-    graphExec->signalManager_->ReleaseSet(cleanup->device, cleanup->signal_set);
+  auto* segExec = dynamic_cast<GraphExecSegmented*>(execBase);
+  if (segExec != nullptr && segExec->signalManager_ != nullptr && !cleanup->signal_set.empty()) {
+    segExec->signalManager_->ReleaseSet(cleanup->device, cleanup->signal_set);
   }
   delete cleanup;
-  graphExec->release();
+  execBase->release();
 }
 
 // ================================================================================================
-amd::Command* GraphExec::EnqueueSegmentedGraph(hip::Stream* launch_stream,
+amd::Command* GraphExecSegmented::EnqueueSegmentedGraph(hip::Stream* launch_stream,
                                                const std::vector<hip::Stream*>& streams,
                                                hipError_t* out_status,
                                                std::vector<void*>* out_signal_set) {
@@ -2081,7 +2144,7 @@ amd::Command* GraphExec::EnqueueSegmentedGraph(hip::Stream* launch_stream,
 
 // ================================================================================================
 // Graph segment to queue dispatch matching
-hipError_t GraphExec::EnqueueSegment(const Segment& segment, hip::Stream* stream,
+hipError_t GraphExecSegmented::EnqueueSegment(const Segment& segment, hip::Stream* stream,
                                      amd::AccumulateCommand* accumulate) {
   hipError_t status = hipSuccess;
 
@@ -2271,7 +2334,7 @@ hipError_t GraphExec::EnqueueSegment(const Segment& segment, hip::Stream* stream
 }
 
 // ================================================================================================
-void GraphExec::UpdateStreams(hip::Stream* launch_stream) {
+void GraphExecSegmented::UpdateStreams(hip::Stream* launch_stream) {
   int devId = launch_stream->vdev()->device().index();
   streams_.clear();
   streams_.push_back(launch_stream);
@@ -2307,7 +2370,7 @@ void GraphExec::UpdateStreams(hip::Stream* launch_stream) {
 hipError_t ihipGraphDebugDotPrint(hip::Graph* graph, const char* path, unsigned int flags);
 
 // ================================================================================================
-hipError_t GraphExec::Run(hip::Stream* launch_stream) {
+hipError_t GraphExecSegmented::Run(hip::Stream* launch_stream) {
   hipError_t status = hipSuccess;
 
   // Retain under shared lock so hipDeviceGraphMemTrim's refcount check is accurate.
@@ -2426,7 +2489,7 @@ hipError_t GraphExec::Run(hip::Stream* launch_stream) {
   cleanup->exec = this;
   cleanup->device = g_devices[launch_stream->DeviceId()]->devices()[0];
   cleanup->signal_set = std::move(launch_signal_set);
-  if (!event.setCallback(CL_COMPLETE, GraphExec::OnLaunchComplete, cleanup, kBlocking)) {
+  if (!event.setCallback(CL_COMPLETE, GraphExecBase::OnLaunchComplete, cleanup, kBlocking)) {
     // setCallback essentially never fails, but if it does the launch's GPU work
     // is already queued (the accumulate is enqueued and was told not to destroy
     // its signals). Drain that work, then run the same completion handling the

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -1687,7 +1687,7 @@ void GraphExecSegmented::GetKernelArgSizeForGraph(std::unordered_map<int, size_t
     for (const auto& segment : segments_) {
       // Handle child graph segments - skip node iteration, process recursively
       if (segment.child_graph_ptr != nullptr) {
-        auto childGraphExec = dynamic_cast<GraphExec*>(segment.child_graph_ptr);
+        auto childGraphExec = dynamic_cast<GraphExecSegmented*>(segment.child_graph_ptr);
         if (childGraphExec != nullptr) {
           // Child graphs share the same kernel arg manager as parent
           if (childGraphExec->GetKernelArgManager() == nullptr) {
@@ -1960,7 +1960,7 @@ hipError_t GraphExecSegmented::CaptureAndFormPacketsForGraph() {
   // Recursively process child graphs to capture their packets
   for (const auto& segment : segments_) {
     if (segment.child_graph_ptr != nullptr) {
-      auto childGraphExec = dynamic_cast<GraphExec*>(segment.child_graph_ptr);
+      auto childGraphExec = dynamic_cast<GraphExecSegmented*>(segment.child_graph_ptr);
       if (childGraphExec != nullptr) {
         // Propagate instantiation device ID so BuildSyncPlan can
         // access the device for barrier packet creation.
@@ -2515,7 +2515,7 @@ hipError_t GraphExecSegmented::EnqueueSegment(const Segment& segment, hip::Strea
     status = dispatchCurrentBatch();
     if (status != hipSuccess) return status;
 
-    auto childGraphExec = dynamic_cast<GraphExec*>(segment.child_graph_ptr);
+    auto childGraphExec = dynamic_cast<GraphExecSegmented*>(segment.child_graph_ptr);
     if (childGraphExec != nullptr) {
       // Child graphs share the same kernel arg manager as parent (for packet capture)
       if (childGraphExec->GetKernelArgManager() == nullptr) {

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -195,94 +195,6 @@ std::vector<std::pair<Node, Node>> Graph::GetEdges() const {
 }
 
 // ================================================================================================
-void Graph::ScheduleOneNode(Node start, int stream_id) {
-  if (!start) return;
-
-  // stack of pending nodes for DFS
-  std::vector<Node> pending;
-  pending.push_back(start);
-
-  int sid = stream_id;
-
-  while (!pending.empty()) {
-    Node cur = pending.back();
-    pending.pop_back();
-
-    // Skip if already scheduled
-    if (cur->stream_id_ != -1) {
-      continue;
-    }
-
-    // Schedule current node on this branch's stream
-    cur->stream_id_ = sid;
-
-    max_streams_ = std::max(max_streams_, sid + 1);
-    streams_dev_ids_[sid].insert(cur->dev_id_);
-
-    // Process child graph separately, since, there is no connection
-    if (cur->GetType() == hipGraphNodeTypeGraph) {
-      auto cgn   = reinterpret_cast<hip::ChildGraphNode*>(cur);
-      auto child = cgn->GetChildGraph();
-      // Use same scheduling logic(classic or segment) as parent graph for child graph
-      child->SetSegmentScheduling(use_segment_scheduling_);
-      hipError_t status = child->ScheduleNodes();
-      (void)status;
-      max_streams_ = std::max(max_streams_, child->max_streams_);
-    }
-
-    const auto& edges = cur->GetEdges();
-    bool end_of_branch = true;
-
-    // To preserve left-to-right behavior, push siblings in reverse so the earlier
-    // edges get processed first.
-    for (int i = static_cast<int>(edges.size()) - 1; i >= 0; --i) {
-      Node e = edges[static_cast<size_t>(i)];
-      if (e->stream_id_ != -1) continue;
-      pending.push_back(e);
-      end_of_branch = false;
-    }
-
-    if (end_of_branch) {
-      // Finished one depth traversal (one branch). Rotate for the next sibling/branch.
-      sid = (sid + 1) % DEBUG_HIP_FORCE_GRAPH_QUEUES;
-    }
-  }
-}
-
-// ================================================================================================
-hipError_t Graph::ScheduleNodes() {
-  // Classic scheduling logic
-  memset(&roots_[0], 0, sizeof(Node) * roots_.size());
-  max_streams_ = 0;
-
-  int stream_id = 0;
-  for (auto node : vertices_) {
-    if (node->stream_id_ == -1) {
-      ScheduleOneNode(node, stream_id);
-      // Find the root nodes
-      if ((node->GetDependencies().size() == 0) && (node->stream_id_ != 0)) {
-        // Fill in only the first in the sequence
-        if (roots_[node->stream_id_] == nullptr) {
-          roots_[node->stream_id_] = node;
-        }
-      }
-      // 1. Each extra root will get a new stream from the pool
-      // 2. Streams will be recycled if the number of roots > streams
-      stream_id = (stream_id + 1) % DEBUG_HIP_FORCE_GRAPH_QUEUES;
-    }
-  }
-
-  // Topological order is only needed for original scheduling
-  GraphExec* graphExec = dynamic_cast<GraphExec*>(this);
-  if (graphExec && !graphExec->TopologicalOrder()) {
-    ClPrint(amd::LOG_ERROR, amd::LOG_CODE, "[hipGraph] TopologicalOrder failed - invalid graph");
-    return hipErrorInvalidValue;
-  }
-
-  return hipSuccess;
-}
-
-// ================================================================================================
 hipError_t Graph::ScheduleNodesIntoBatches() {
   // Handle empty graph case - valid, nothing to schedule
   if (GetNodeCount() == 0) {
@@ -1390,16 +1302,12 @@ hipError_t GraphExec::Init() {
 
   // create extra stream to avoid queue collision with the default execution stream
   if (max_streams_ >= 1) {
-    if (use_segment_scheduling_) {
-      // For packet engine: analyze segments to determine per-device stream requirements
-      FindStreamsReqPerDevForSegments();
-    } else {
-      // For classic scheduling: use stream-to-device mappings
-      FindStreamsReqPerDev();
-    }
+    FindStreamsReqPerDevForSegments();
 
-    // Cap per-device stream counts to the hardware queue limit. PrecomputeStreamAssignment()
-    // reads max_streams_dev_ to assign segment stream ids, so both must see the capped values.
+    // Cap per-device stream counts to the hardware queue limit and compute the total.
+    // This must happen before SelectStreamAssignment() reads max_streams_dev_ so
+    // both stream creation and stream-id assignment see the same capped values.
+    uint32_t total_streams = 0;
     for (auto& [dev_id, count] : max_streams_dev_) {
       count = std::min(count, static_cast<int>(DEBUG_HIP_FORCE_GRAPH_QUEUES));
     }
@@ -1417,44 +1325,13 @@ hipError_t GraphExec::Init() {
     }
   }
 
-  if (use_segment_scheduling_) {
-    // Select and apply stream assignment before packet capture so that BuildSyncPlan
-    // (called inside CaptureAQLPackets) can see each segment's stream_id and
-    // skip same-stream dependency barriers.
-    SelectStreamAssignment();
+  // Select and apply stream assignment before packet capture so that BuildSyncPlan
+  // (called inside CaptureAQLPackets) can see each segment's stream_id and
+  // skip same-stream dependency barriers.
+  SelectStreamAssignment();
 
-    // For graph nodes capture AQL packets to dispatch them directly during graph launch.
-    // BuildSyncPlan (inside) runs the barrier-ROI collapse pass, which may fold the
-    // graph onto a single stream per device.
-    status = CaptureAQLPackets();
-    if (status != hipSuccess) {
-      return status;
-    }
-
-    // Create parallel streams now (still at instantiate time, never lazily at launch),
-    // sized to the final post-collapse assignment: one stream per device when the
-    // collapse pass fired, otherwise the capped multi-stream counts.
-    if (collapsed_to_single_stream_) {
-      for (auto& [dev_id, count] : max_streams_dev_) {
-        count = 1;
-      }
-    }
-    uint32_t total_streams = 0;
-    for (auto const& [dev_id, count] : max_streams_dev_) {
-      total_streams += static_cast<uint32_t>(std::max(count, 0));
-    }
-    ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_CODE,
-            "[hipGraph] Init: %zu device(s), %u total stream(s) (per-device cap: %u)",
-            max_streams_dev_.size(), total_streams, DEBUG_HIP_FORCE_GRAPH_QUEUES);
-    for (auto const& [dev_id, num_streams] : max_streams_dev_) {
-      if (num_streams > 0) {
-        status = CreateStreams(num_streams, dev_id);
-        if (status != hipSuccess) {
-          return status;
-        }
-      }
-    }
-  }
+  // For graph nodes capture AQL packets to dispatch them directly during graph launch.
+  status = CaptureAQLPackets();
 
   static_cast<ReferenceCountedObject*>(hip::getCurrentDevice())->retain();
   return status;
@@ -1467,7 +1344,7 @@ void GraphExec::GetKernelArgSizeForGraph(std::unordered_map<int, size_t>& kernAr
   // Calculate the kernel argument size required for all graph kernel nodes
   // when GPU packet capture is enabled
 
-  if (use_segment_scheduling_ && !segments_.empty()) {
+  if (!segments_.empty()) {
     for (const auto& segment : segments_) {
       // Handle child graph segments - skip node iteration, process recursively
       if (segment.child_graph_ptr != nullptr) {
@@ -2676,9 +2553,9 @@ hipError_t GraphExec::Run(hip::Stream* launch_stream) {
     this->retain();
   }
 
-  // Get the first node based on scheduling mode
+  // Get the first node
   Node firstNode = nullptr;
-  if (use_segment_scheduling_ && !segments_.empty() && !segments_[0].nodes.empty()) {
+  if (!segments_.empty() && !segments_[0].nodes.empty()) {
     firstNode = segments_[0].nodes[0];
   } else if (!topoOrder_.empty()) {
     firstNode = topoOrder_[0];
@@ -2733,7 +2610,7 @@ hipError_t GraphExec::Run(hip::Stream* launch_stream) {
   // reuse the graph's own accumulate command instead of enqueuing a dedicated marker
   amd::Command* completion_cmd = nullptr;
 
-  if (use_segment_scheduling_ && instantiateDeviceId_ == launch_stream->DeviceId()) {
+  if (instantiateDeviceId_ == launch_stream->DeviceId()) {
     // If the graph has kernels that does device side allocation,  during packet capture, heap is
     // allocated because heap pointer has to be added to the AQL packet, and initialized during
     // graph launch.

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -1535,7 +1535,6 @@ struct GraphLaunchCleanup {
 // ================================================================================================
 hipError_t GraphExecClassic::Init() {
   hipError_t status = hipSuccess;
-  captureDeviceId_ = hip::getCurrentDevice()->deviceId();
 
   // ScheduleNodes does DFS stream assignment + TopologicalOrder
   status = ScheduleNodes();
@@ -1546,6 +1545,15 @@ hipError_t GraphExecClassic::Init() {
   if (max_streams_ >= 1) {
     FindStreamsReqPerDev();
 
+    if (max_streams_dev_.size() == 1) {
+      captureDeviceId_ = max_streams_dev_.begin()->first;
+      static_cast<amd::ReferenceCountedObject*>(g_devices[captureDeviceId_])->retain();
+    } else if (max_streams_dev_.size() > 1) {
+      ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
+              "[hipGraph] Multi-device graph is not supported for classic scheduling path");
+      captureDeviceId_ = -1;
+      return hipErrorNotSupported;
+    }
     for (auto& [dev_id, count] : max_streams_dev_) {
       count = std::min(count, static_cast<int>(DEBUG_HIP_FORCE_GRAPH_QUEUES));
     }
@@ -1560,7 +1568,6 @@ hipError_t GraphExecClassic::Init() {
     }
   }
 
-  static_cast<ReferenceCountedObject*>(hip::getCurrentDevice())->retain();
   return status;
 }
 

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -1617,6 +1617,18 @@ hipError_t GraphExecClassic::Run(hip::Stream* launch_stream) {
 // ================================================================================================
 hipError_t GraphExecSegmented::Init() {
   hipError_t status = hipSuccess;
+
+  // Schedule nodes into segments for batch execution
+  status = ScheduleNodesIntoBatches();
+  if (status != hipSuccess) {
+    return status;
+  }
+
+  // Allocate kernel argument manager for packet capture
+  if (kernArgManager_ == nullptr) {
+    SetKernelArgManager(new GraphKernelArgManager());
+  }
+
   // captureDeviceId_ is set inside FindStreamsReqPerDevForSegments() from
   // max_streams_dev_ once all segments are analysed. Must run unconditionally
   // so that captureDeviceId_ is valid before CaptureAQLPackets/BuildSyncPlan.

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -1045,6 +1045,7 @@ void GraphExec::FindStreamsReqPerDevForSegments() {
     if (graphExec == this) {
       // Single-device graph: derive captureDeviceId_ from the authoritative map key.
       // Multi-device graphs are not supported on the segment scheduling path.
+      // Empty graphs have no segments, so fall back to the current device.
       if (max_streams_dev_.size() == 1) {
         captureDeviceId_ = max_streams_dev_.begin()->first;
       } else if (max_streams_dev_.size() > 1) {
@@ -1052,6 +1053,8 @@ void GraphExec::FindStreamsReqPerDevForSegments() {
                 "[hipGraph] Multi-device graph is not supported on the segment scheduling path");
         captureDeviceId_ = -1;
         return;
+      } else {
+        captureDeviceId_ = hip::getCurrentDevice()->deviceId();
       }
     }
 
@@ -1206,19 +1209,19 @@ void GraphExec::DFSStreamAssignment() {
 
 // ================================================================================================
 // Select stream assignment algorithm:
-//   DEBUG_HIP_GRAPH_SEGMENT_SCHEDULING == 2 → force DFS
-//   DEBUG_HIP_GRAPH_SEGMENT_SCHEDULING == 3 → force round-robin
+//   DEBUG_HIP_GRAPH_SEGMENT_SCHEDULING == 1 → force DFS
+//   DEBUG_HIP_GRAPH_SEGMENT_SCHEDULING == 2 → force round-robin
 //   otherwise (auto): complex graphs (16+ segs, avg length < 8) → DFS
 //                     simple/parallel graphs                     → round-robin
 void GraphExec::SelectStreamAssignment() {
   // Forced modes via env var
-  if (DEBUG_HIP_GRAPH_SEGMENT_SCHEDULING == 2) {
+  if (DEBUG_HIP_GRAPH_SEGMENT_SCHEDULING == 1) {
     ClPrint(amd::LOG_INFO, amd::LOG_CODE,
             "[hipGraph] SelectStreamAssignment: forced DFS (%zu segs)", segments_.size());
     DFSStreamAssignment();
     return;
   }
-  if (DEBUG_HIP_GRAPH_SEGMENT_SCHEDULING == 3) {
+  if (DEBUG_HIP_GRAPH_SEGMENT_SCHEDULING == 2) {
     ClPrint(amd::LOG_INFO, amd::LOG_CODE,
             "[hipGraph] SelectStreamAssignment: forced round-robin (%zu segs)", segments_.size());
     RoundRobinStreamAssignment();
@@ -1259,15 +1262,16 @@ void GraphExec::SelectStreamAssignment() {
 // ================================================================================================
 hipError_t GraphExec::Init() {
   hipError_t status = hipSuccess;
+  // captureDeviceId_ is set inside FindStreamsReqPerDevForSegments() from
+  // max_streams_dev_ once all segments are analysed. Must run unconditionally
+  // so that captureDeviceId_ is valid before CaptureAQLPackets/BuildSyncPlan.
+  FindStreamsReqPerDevForSegments();
+  if (captureDeviceId_ == -1) {
+    return hipErrorNotSupported;
+  }
+
   // create extra stream to avoid queue collision with the default execution stream
   if (max_streams_ >= 1) {
-    // captureDeviceId_ is set inside FindStreamsReqPerDevForSegments() from
-    // max_streams_dev_ once all segments are analysed.
-    FindStreamsReqPerDevForSegments();
-    if (captureDeviceId_ == -1) {
-      return hipErrorNotSupported;
-    }
-
     // Cap per-device stream counts to the hardware queue limit and compute the total.
     // This must happen before SelectStreamAssignment() reads max_streams_dev_ so
     // both stream creation and stream-id assignment see the same capped values.

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -6,8 +6,6 @@
 
 #include "hip_graph_internal.hpp"
 
-hipError_t ihipGraphDebugDotPrint(hip::Graph* graph, const char* path, unsigned int flags);
-
 #define CASE_STRING(X, C)                                                                          \
   case X:                                                                                          \
     case_string = #C;                                                                              \
@@ -38,6 +36,8 @@ const char* GetGraphNodeTypeString(uint32_t op) {
 }  // namespace
 
 namespace hip {
+
+hipError_t ihipGraphDebugDotPrint(hip::Graph* graph, const char* path, unsigned int flags);
 
 std::atomic<int> GraphNode::nextID{0};
 std::atomic<int> Graph::nextID{0};
@@ -2915,8 +2915,6 @@ bool Graph::RunNodes(int32_t base_stream, const std::vector<hip::Stream*>* paral
 
   return true;
 }
-
-hipError_t ihipGraphDebugDotPrint(hip::Graph* graph, const char* path, unsigned int flags);
 
 // ================================================================================================
 hipError_t GraphExecSegmented::Run(hip::Stream* launch_stream) {

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -6,6 +6,8 @@
 
 #include "hip_graph_internal.hpp"
 
+hipError_t ihipGraphDebugDotPrint(hip::Graph* graph, const char* path, unsigned int flags);
+
 #define CASE_STRING(X, C)                                                                          \
   case X:                                                                                          \
     case_string = #C;                                                                              \
@@ -192,6 +194,79 @@ std::vector<std::pair<Node, Node>> Graph::GetEdges() const {
     }
   }
   return edges;
+}
+
+// ================================================================================================
+void Graph::ScheduleOneNode(Node start, int stream_id) {
+  if (!start) return;
+
+  std::vector<Node> pending;
+  pending.push_back(start);
+
+  int sid = stream_id;
+
+  while (!pending.empty()) {
+    Node cur = pending.back();
+    pending.pop_back();
+
+    if (cur->stream_id_ != -1) {
+      continue;
+    }
+
+    cur->stream_id_ = sid;
+
+    max_streams_ = std::max(max_streams_, sid + 1);
+    streams_dev_ids_[sid].insert(cur->dev_id_);
+
+    if (cur->GetType() == hipGraphNodeTypeGraph) {
+      auto cgn   = reinterpret_cast<hip::ChildGraphNode*>(cur);
+      auto child = cgn->GetChildGraph();
+      hipError_t status = child->ScheduleNodes();
+      (void)status;
+      max_streams_ = std::max(max_streams_, child->max_streams_);
+    }
+
+    const auto& edges = cur->GetEdges();
+    bool end_of_branch = true;
+
+    for (int i = static_cast<int>(edges.size()) - 1; i >= 0; --i) {
+      Node e = edges[static_cast<size_t>(i)];
+      if (e->stream_id_ != -1) continue;
+      pending.push_back(e);
+      end_of_branch = false;
+    }
+
+    if (end_of_branch) {
+      sid = (sid + 1) % DEBUG_HIP_FORCE_GRAPH_QUEUES;
+    }
+  }
+}
+
+// ================================================================================================
+hipError_t Graph::ScheduleNodes() {
+  memset(&roots_[0], 0, sizeof(Node) * roots_.size());
+  max_streams_ = 0;
+
+  int stream_id = 0;
+  for (auto node : vertices_) {
+    if (node->stream_id_ == -1) {
+      ScheduleOneNode(node, stream_id);
+      if ((node->GetDependencies().size() == 0) && (node->stream_id_ != 0)) {
+        if (roots_[node->stream_id_] == nullptr) {
+          roots_[node->stream_id_] = node;
+        }
+      }
+      stream_id = (stream_id + 1) % DEBUG_HIP_FORCE_GRAPH_QUEUES;
+    }
+  }
+
+  GraphExec* graphExec = dynamic_cast<GraphExec*>(this);
+  if (graphExec && !graphExec->TopologicalOrder()) {
+    ClPrint(amd::LOG_ERROR, amd::LOG_CODE, "[hipGraph] TopologicalOrder failed - invalid graph");
+    return hipErrorInvalidValue;
+  }
+
+  return hipSuccess;
 }
 
 // ================================================================================================
@@ -930,7 +1005,7 @@ bool GraphExecBase::isGraphExecValid(GraphExecBase* pGraphExec) {
 }
 
 // ================================================================================================
-hipError_t GraphExecSegmented::CreateStreams(uint32_t num_streams, int devId) {
+hipError_t GraphExecBase::CreateStreams(uint32_t num_streams, int devId) {
   std::scoped_lock lock(graphExecStreamCreateLock_);
 
   if (num_streams == 0) {
@@ -995,6 +1070,31 @@ hipError_t GraphExecSegmented::CreateStreams(uint32_t num_streams, int devId) {
     parallel_streams_[devId].push_back(stream);
   }
   return hipSuccess;
+}
+
+// ================================================================================================
+void GraphExecBase::FindStreamsReqPerDev() {
+  for (auto const& [stream_id, dev_ids] : streams_dev_ids_) {
+    for (auto dev_id : dev_ids) {
+      max_streams_dev_[dev_id]++;
+    }
+  }
+
+  for (auto node : vertices_) {
+    if (node->GetType() == hipGraphNodeTypeGraph) {
+      auto childNode = reinterpret_cast<ChildGraphNode*>(node);
+      childNode->FindStreamsReqPerDev();
+
+      for (auto const& [dev_id, num_streams] : childNode->max_streams_dev_) {
+        auto it = max_streams_dev_.find(dev_id);
+        if (it != max_streams_dev_.end()) {
+          max_streams_dev_[dev_id] = std::max(max_streams_dev_[dev_id], num_streams);
+        } else {
+          max_streams_dev_[dev_id] = num_streams;
+        }
+      }
+    }
+  }
 }
 
 // ================================================================================================
@@ -1394,50 +1494,37 @@ struct GraphLaunchCleanup {
 };
 
 // ================================================================================================
-// GraphExecClassic — PAL/Windows path: simple topological enqueue, no AQL capture.
-// ================================================================================================
-hipError_t GraphExecClassic::ScheduleOneNode(GraphNode* node, hip::Stream* stream) {
-  node->SetStream(stream);
-  return node->CreateCommand(node->GetQueue());
-}
-
-// ================================================================================================
-hipError_t GraphExecClassic::ScheduleNodes(hip::Stream* stream) {
-  hipError_t status = hipSuccess;
-  for (auto node : topoOrder_) {
-    hipError_t s = ScheduleOneNode(node, stream);
-    if (s != hipSuccess) {
-      status = s;
-    }
-  }
-  return status;
-}
-
-// ================================================================================================
-void GraphExecClassic::RunOneNode(GraphNode* node, hip::Stream* stream) {
-  node->EnqueueCommands(stream);
-}
-
-// ================================================================================================
-void GraphExecClassic::RunNodes(hip::Stream* stream) {
-  for (auto node : topoOrder_) {
-    RunOneNode(node, stream);
-  }
-}
-
+// GraphExecClassic — PAL/Windows path: classic topological enqueue, no AQL capture.
 // ================================================================================================
 hipError_t GraphExecClassic::Init() {
-  if (!TopologicalOrder()) {
-    return hipErrorInvalidValue;
+  hipError_t status = hipSuccess;
+  captureDeviceId_ = hip::getCurrentDevice()->deviceId();
+
+  // ScheduleNodes does DFS stream assignment + TopologicalOrder
+  status = ScheduleNodes();
+  if (status != hipSuccess) {
+    return status;
   }
-  if (!topoOrder_.empty()) {
-    auto* dev = topoOrder_[0]->GetParentGraph()->Device();
-    if (dev != nullptr) {
-      captureDeviceId_ = dev->deviceId();
-      static_cast<amd::ReferenceCountedObject*>(g_devices[captureDeviceId_])->retain();
+
+  if (max_streams_ >= 1) {
+    FindStreamsReqPerDev();
+
+    for (auto& [dev_id, count] : max_streams_dev_) {
+      count = std::min(count, static_cast<int>(DEBUG_HIP_FORCE_GRAPH_QUEUES));
+    }
+
+    for (auto const& [dev_id, num_streams] : max_streams_dev_) {
+      if (num_streams > 0) {
+        status = CreateStreams(num_streams, dev_id);
+        if (status != hipSuccess) {
+          return status;
+        }
+      }
     }
   }
-  return hipSuccess;
+
+  static_cast<ReferenceCountedObject*>(hip::getCurrentDevice())->retain();
+  return status;
 }
 
 // ================================================================================================
@@ -1468,18 +1555,45 @@ hipError_t GraphExecClassic::Run(hip::Stream* launch_stream) {
     }
   }
 
-  if (repeatLaunch_ == false) {
-    repeatLaunch_ = true;
-  } else {
-    // Check for MemAlloc/MemFree mismatch on repeat launches.
+  if (repeatLaunch_ == true) {
     if (firstNode != nullptr && firstNode->GetParentGraph()->GetMemAllocNodeCount() > 0) {
       this->release();
       return hipErrorInvalidValue;
     }
+  } else {
+    repeatLaunch_ = true;
   }
 
-  status = ScheduleNodes(launch_stream);
-  RunNodes(launch_stream);
+  ClPrint(amd::LOG_DEBUG, amd::LOG_CODE, "GraphExecClassic::Run max_streams: %d, on device: %d",
+          max_streams_, launch_stream->DeviceId());
+
+  launch_stream->vdev()->SetPreferredQueue();
+  launch_stream->vdev()->AcquireQueueWithPreference();
+  UpdateStreams(launch_stream);
+
+  if (max_streams_ == 1 && captureDeviceId_ != launch_stream->DeviceId()) {
+    for (int i = 0; i < topoOrder_.size(); i++) {
+      topoOrder_[i]->SetStream(launch_stream);
+      status = topoOrder_[i]->CreateCommand(topoOrder_[i]->GetQueue());
+      topoOrder_[i]->EnqueueCommands(launch_stream);
+    }
+  } else {
+    if (!RunNodes()) {
+      LogError("Failed to launch nodes!");
+      this->release();
+      return hipErrorOutOfMemory;
+    }
+  }
+
+  if (DEBUG_HIP_GRAPH_DOT_PRINT == 2 && !graph_dumped_) {
+    graph_dumped_ = true;
+    std::string filename =
+        "graph_" + std::to_string(amd::Os::getProcessId()) + "_dot_print_launch_1";
+    hipError_t dot_status = ihipGraphDebugDotPrint(this, filename.c_str(), 0);
+    if (dot_status == hipSuccess) {
+      ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_CODE, "[hipGraph] graph dump:%s", filename.c_str());
+    }
+  }
 
   // Enqueue a lightweight marker to carry the launch-complete callback.
   auto* marker = new amd::Marker(*launch_stream, kMarkerDisableFlush, {});
@@ -1513,14 +1627,12 @@ hipError_t GraphExecSegmented::Init() {
 
   // create extra stream to avoid queue collision with the default execution stream
   if (max_streams_ >= 1) {
-    // Cap per-device stream counts to the hardware queue limit and compute the total.
-    // This must happen before SelectStreamAssignment() reads max_streams_dev_ so
-    // both stream creation and stream-id assignment see the same capped values.
-    uint32_t total_streams = 0;
+    // Cap per-device stream counts to the hardware queue limit.
+    // SelectStreamAssignment() reads max_streams_dev_ to assign segment stream ids,
+    // so both must see the capped values.
     for (auto& [dev_id, count] : max_streams_dev_) {
       count = std::min(count, static_cast<int>(DEBUG_HIP_FORCE_GRAPH_QUEUES));
     }
-
   }
 
   // Select and apply stream assignment before packet capture so that BuildSyncPlan
@@ -1529,7 +1641,36 @@ hipError_t GraphExecSegmented::Init() {
   SelectStreamAssignment();
 
   // For graph nodes capture AQL packets to dispatch them directly during graph launch.
+  // BuildSyncPlan (inside CaptureAndFormPacketsForGraph) runs the barrier-ROI collapse
+  // pass, which may fold the graph onto a single stream per device.
   status = CaptureAQLPackets();
+  if (status != hipSuccess) {
+    return status;
+  }
+
+  // Create parallel streams now (still at instantiate time, never lazily at launch),
+  // sized to the final post-collapse assignment: one stream per device when the
+  // collapse pass fired, otherwise the capped multi-stream counts.
+  if (collapsed_to_single_stream_) {
+    for (auto& [dev_id, count] : max_streams_dev_) {
+      count = 1;
+    }
+  }
+  uint32_t total_streams = 0;
+  for (auto const& [dev_id, count] : max_streams_dev_) {
+    total_streams += static_cast<uint32_t>(std::max(count, 0));
+  }
+  ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_CODE,
+          "[hipGraph] Init: %zu device(s), %u total stream(s) (per-device cap: %u)",
+          max_streams_dev_.size(), total_streams, DEBUG_HIP_FORCE_GRAPH_QUEUES);
+  for (auto const& [dev_id, num_streams] : max_streams_dev_) {
+    if (num_streams > 0) {
+      status = CreateStreams(num_streams, dev_id);
+      if (status != hipSuccess) {
+        return status;
+      }
+    }
+  }
 
   static_cast<ReferenceCountedObject*>(g_devices[captureDeviceId_])->retain();
   return status;
@@ -2493,7 +2634,7 @@ hipError_t GraphExecSegmented::EnqueueSegment(const Segment& segment, hip::Strea
 }
 
 // ================================================================================================
-void GraphExecSegmented::UpdateStreams(hip::Stream* launch_stream) {
+void GraphExecBase::UpdateStreams(hip::Stream* launch_stream) {
   int devId = launch_stream->vdev()->device().index();
   streams_.clear();
   streams_.push_back(launch_stream);
@@ -2524,6 +2665,158 @@ void GraphExecSegmented::UpdateStreams(hip::Stream* launch_stream) {
     used_qids.insert(qid);
     streams_.push_back(stream);
   }
+}
+
+// ================================================================================================
+bool Graph::RunOneNode(Node node) {
+  memset(&wait_order_[0], 0, sizeof(Node) * wait_order_.size());
+  amd::Command::EventWaitList waitList;
+  for (auto depNode : node->GetDependencies()) {
+    if (depNode->launch_id_ != -1) {
+      if (depNode->stream_id_ != node->stream_id_ ||
+          depNode->GetType() == hipGraphNodeTypeGraph) {
+        if ((wait_order_[depNode->stream_id_] == nullptr) ||
+            (wait_order_[depNode->stream_id_]->launch_id_ < depNode->launch_id_)) {
+          wait_order_[depNode->stream_id_] = depNode;
+        }
+      } else {
+        for (auto command : depNode->GetCommands()) {
+          command->release();
+        }
+      }
+    } else {
+      node->SetWait(false);
+      return true;
+    }
+  }
+
+  for (auto dep : wait_order_) {
+    if (dep != nullptr) {
+      for (auto command : dep->GetCommands()) {
+        waitList.push_back(command);
+      }
+    }
+  }
+  if (node->GetType() == hipGraphNodeTypeGraph) {
+    auto child = reinterpret_cast<hip::ChildGraphNode*>(node)->GetChildGraph();
+    if (!reinterpret_cast<hip::ChildGraphNode*>(node)->GetGraphCaptureStatus()) {
+      child->RunNodes(node->stream_id_, &streams_, &waitList);
+      auto completion = streams_[node->stream_id_]->getLastQueuedCommand(true);
+      if (completion != nullptr) {
+        for (auto cmd : node->GetCommands()) {
+          cmd->release();
+        }
+        node->GetCommands().clear();
+        node->GetCommands().push_back(completion);
+      }
+    }
+  } else {
+    node->SetStream(streams_);
+    if (DEBUG_HIP_GRAPH_DOT_PRINT) {
+      node->hw_queue_id_ = node->GetQueue()->getQueueID();
+    }
+    auto status = node->CreateCommand(node->GetQueue());
+    if (status != hipSuccess) {
+      LogPrintfError("Command creation for node id(%d) failed!", current_id_ + 1);
+      return false;
+    }
+    if (node->GetWait() && !waitList.empty()) {
+      node->UpdateEventWaitLists(waitList);
+    }
+    node->EnqueueCommands(node->GetQueue());
+  }
+  for (auto dep : wait_order_) {
+    if (dep != nullptr) {
+      for (auto command : dep->GetCommands()) {
+        command->release();
+      }
+    }
+  }
+  node->launch_id_ = current_id_++;
+  uint32_t i = 0;
+  for (auto edge : node->GetEdges()) {
+    bool wait =
+        ((i < DEBUG_HIP_FORCE_GRAPH_QUEUES) || (edge->GetDependencies().size() > 1)) ? true : false;
+    edge->SetWait(wait);
+    i++;
+    for (auto command : node->GetCommands()) {
+      command->retain();
+    }
+  }
+  if (node->GetEdges().size() == 0) {
+    leafs_[node->stream_id_] = node;
+    for (auto command : node->GetCommands()) {
+      command->retain();
+    }
+  }
+
+  node->SetWait(false);
+  return true;
+}
+
+// ================================================================================================
+bool Graph::RunNodes(int32_t base_stream, const std::vector<hip::Stream*>* parallel_streams,
+                     const amd::Command::EventWaitList* parent_waitlist) {
+  if (parallel_streams != nullptr) {
+    streams_ = *parallel_streams;
+  }
+
+  if (parent_waitlist != nullptr) {
+    auto start_marker = new amd::Marker(*streams_[base_stream], true, *parent_waitlist);
+    start_marker->enqueue();
+    start_marker->release();
+  }
+  amd::Command::EventWaitList wait_list;
+  current_id_ = 0;
+  memset(&leafs_[0], 0, sizeof(Node) * leafs_.size());
+
+  constexpr bool kRetainCommand = true;
+  auto last_command = streams_[base_stream]->getLastQueuedCommand(kRetainCommand);
+  if (last_command != nullptr) {
+    wait_list.push_back(last_command);
+    for (uint32_t i = 0; i < DEBUG_HIP_FORCE_GRAPH_QUEUES; ++i) {
+      if ((base_stream != i) && (roots_[i] != nullptr)) {
+        auto start_marker = new amd::Marker(*streams_[i], true, wait_list);
+        start_marker->enqueue();
+        start_marker->release();
+      }
+    }
+    if (base_stream != 0) {
+      auto start_marker = new amd::Marker(*streams_[0], true, wait_list);
+      start_marker->enqueue();
+      start_marker->release();
+    }
+    last_command->release();
+  }
+
+  for (auto node : GetTopoOrder()) {
+    node->launch_id_ = -1;
+    if (!RunOneNode(node)) {
+      return false;
+    }
+  }
+  wait_list.clear();
+  for (uint32_t i = 0; i < DEBUG_HIP_FORCE_GRAPH_QUEUES; ++i) {
+    if (leafs_[i] != nullptr) {
+      for (auto command : leafs_[i]->GetCommands()) {
+        if (base_stream != i) {
+          wait_list.push_back(command);
+        } else {
+          command->release();
+        }
+      }
+    }
+  }
+  if (wait_list.size() > 0) {
+    auto end_marker = new amd::Marker(*streams_[base_stream], true, wait_list);
+    end_marker->enqueue();
+    end_marker->release();
+    for (auto command : wait_list) {
+      command->release();
+    }
+  }
+
+  return true;
 }
 
 hipError_t ihipGraphDebugDotPrint(hip::Graph* graph, const char* path, unsigned int flags);
@@ -2617,10 +2910,16 @@ hipError_t GraphExecSegmented::Run(hip::Stream* launch_stream) {
     // already imply all parallel work is done). Our reference is released after
     // the callback is registered below; the queue keeps it alive until done.
     completion_cmd = last_cmd;
+  } else if (max_streams_ == 1 && captureDeviceId_ != launch_stream->DeviceId()) {
+    for (int i = 0; i < topoOrder_.size(); i++) {
+      topoOrder_[i]->SetStream(launch_stream);
+      status = topoOrder_[i]->CreateCommand(topoOrder_[i]->GetQueue());
+      topoOrder_[i]->EnqueueCommands(launch_stream);
+    }
   } else if (captureDeviceId_ != launch_stream->DeviceId()) {
     ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
-            "[hipGraph] GraphExec::Run: launch stream device %d does not match capture device %d",
-            launch_stream->DeviceId(), captureDeviceId_);
+      "[hipGraph] GraphExec::Run: launch stream device %d does not match capture device %d",
+      launch_stream->DeviceId(), captureDeviceId_);
     status = hipErrorInvalidValue;
   }
   if (DEBUG_HIP_GRAPH_DOT_PRINT == 2 && !graph_dumped_) {

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -279,6 +279,7 @@ class GraphNode : public hipGraphNodeDOTAttribute {
     std::for_each(gpuPackets_.begin(), gpuPackets_.end(), [](auto p) { delete[] p; });
     std::for_each(gpuMetadataPackets_.begin(), gpuMetadataPackets_.end(),
                   [](auto p) { delete[] p; });
+    // Clear the pointer array
     gpuPackets_.clear();
     gpuMetadataPackets_.clear();
 
@@ -317,6 +318,7 @@ class GraphNode : public hipGraphNodeDOTAttribute {
   ) {
     assert(stream_id_ != -1 && "Stream ID wasn't initialized");
     stream_ = streams[stream_id_];
+    // Reset the launch ID after the stream assignment
     launch_id_ = -1;
   }
   /// Create amd::command for the graph node
@@ -743,22 +745,23 @@ class Graph {
     std::vector<GraphExecutionPaths> child_graph_paths;  //!< Child graph execution paths
   };
 
-  //! DFS-based stream assignment for a single node and its subtree
+  //! Schedules one node on a virtual stream.
+  //! It will also process the nodes in edges, using DFS
   void ScheduleOneNode(Node node,     //!< Node for scheduling on a virtual stream
-                       int stream_id  //!< A virtual stream for scheduling
+                       int stream_id  //!< Current active virtual stream to use for scheduling
   );
 
-  //! Schedule all nodes in the graph (classic or segment path)
+  //! Schedules all nodes in the graph into different streams
   hipError_t ScheduleNodes();
 
   //! Runs one node on the assigned stream
-  bool RunOneNode(Node node);
+  bool RunOneNode(Node node);  //!< Node for the execution on GPU
 
   //! Runs all nodes from the execution graph on the assigned streams
   bool RunNodes(
-      int32_t base_stream = 0,
-      const std::vector<hip::Stream*>* streams = nullptr,
-      const amd::Command::EventWaitList* parent_waitlist = nullptr
+      int32_t base_stream = 0,                             //!< The base stream to run the graph on
+      const std::vector<hip::Stream*>* streams = nullptr,  //!< Streams to run the graph
+      const amd::Command::EventWaitList* parent_waitlist = nullptr  //!< Parent Graph waitlist
   );
 
   //! Schedules nodes into batches for optimized execution
@@ -921,6 +924,8 @@ class Graph {
  protected:
   int max_streams_ = 0;  //!< Maximum number of streams used in the graph launch
   //!< Maps stream ID to the set of device IDs that use that stream.
+  //!< Used to track which devices are accessed by each parallel stream
+  //!< during multi-device graph execution scheduling.
   std::unordered_map<int, std::set<int>> streams_dev_ids_;
   int captureDeviceId_ = -1;
     //! Topological order of the graph doesn't include nodes embedded as part of the child graph
@@ -968,7 +973,9 @@ class Graph {
   uint32_t memalloc_nodes_ = 0;  //!< Count of unreleased Memalloc nodes
   std::vector<Node> roots_;      //!< Root nodes, used in parallel launches
   std::vector<Node> leafs_;      //!< The list of leaf nodes on every parallel stream
-  std::vector<Node> wait_order_; //!< Temporary storage for waiting nodes
+  //!< Used as a temporary storage for the waiting nodes
+  //!< to reduce the stack pressure in recursion
+  std::vector<Node> wait_order_;
   std::vector<hip::Stream*> streams_;  //!< The list of streams, used in the execution
   int32_t current_id_ = 0;             //!< The current node ID in the graph execution sequence
   hip::Device* device_;                //!< HIP device object
@@ -1017,8 +1024,10 @@ class GraphExecBase : public amd::ReferenceCountedObject, public Graph {
     graphExecSet_.erase(this);
   }
 
+  //! Check executable graphs validity
   static bool isGraphExecValid(GraphExecBase* pGraphExec);
-  // Completion callback shared by both paths: releases the launch reference.
+  // Completion callback for a graph launch: re-arms and returns the launch's
+  // pooled signals, then drops the launch's reference on the GraphExecBase.
   static void OnLaunchComplete(cl_event event, cl_int command_exec_status, void* user_data);
 
   Node GetClonedNode(Node node) {

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -31,7 +31,9 @@ typedef struct ihipExtKernelEvents {
 namespace hip {
 class Graph;
 class GraphNode;
-class GraphExec;
+class GraphExecBase;
+class GraphExecClassic;
+class GraphExecSegmented;
 class UserObject;
 class GraphKernelNode;
 typedef GraphNode* Node;
@@ -488,7 +490,8 @@ class GraphNode : public hipGraphNodeDOTAttribute {
  protected:
   // Declare Graph and GraphExec as friends of node for simpler access to GraphNode fields
   friend class Graph;
-  friend class GraphExec;
+  friend class GraphExecBase;
+  friend class GraphExecSegmented;
   hip::Stream* stream_ = nullptr;
   unsigned int id_;
   hipGraphNodeType type_;
@@ -927,7 +930,8 @@ class Graph {
   std::unordered_map<Node, Node> clonedNodes_;
 
  private:
-  friend class GraphExec;
+  friend class GraphExecBase;
+  friend class GraphExecSegmented;
   std::vector<Node> vertices_;
   const Graph* pOriginalGraph_ = nullptr;
   //!< graphUserObj_.second stores refcount owned by this graph for user object,
@@ -960,26 +964,72 @@ class Graph {
   std::vector<Batch> batches_;
 };
 
-class GraphExec : public amd::ReferenceCountedObject, public Graph {
+// ================================================================================================
+// GraphExecBase — shared statics and interface for all graph-exec variants.
+// GraphExecClassic (PAL/Windows) and GraphExecSegmented (Linux/ROCm) inherit from this.
+class GraphExecBase : public amd::ReferenceCountedObject, public Graph {
  public:
-  static std::unordered_set<GraphExec*> graphExecSet_;
+  static std::unordered_set<GraphExecBase*> graphExecSet_;
   static std::recursive_mutex graphExecSetLock_;
   static std::recursive_mutex graphExecStreamCreateLock_;
   static std::shared_mutex graphExecTrimLock_;
-  bool graph_dumped_ = false;
-  GraphExec(uint64_t flags = 0)
+
+  GraphExecBase(uint64_t flags = 0)
       : ReferenceCountedObject(), Graph(hip::getCurrentDevice()), flags_(flags) {
     std::scoped_lock lock(graphExecSetLock_);
     graphExecSet_.insert(this);
   }
 
-  ~GraphExec() {
-    {
-      std::scoped_lock lock(graphExecSetLock_);
-      // GraphExecSet is normally erased in hipGraphExecDestroy() before release(), but child graph
-      // nodes (which inherit GraphExec) are destroyed via delete and never go through that path.
-      graphExecSet_.erase(this);
-    }
+  ~GraphExecBase() {
+    std::scoped_lock lock(graphExecSetLock_);
+    // Normally erased in hipGraphExecDestroy(), but child graph nodes use delete directly.
+    graphExecSet_.erase(this);
+  }
+
+  static bool isGraphExecValid(GraphExecBase* pGraphExec);
+  // Completion callback shared by both paths: releases the launch reference.
+  static void OnLaunchComplete(cl_event event, cl_int command_exec_status, void* user_data);
+
+  Node GetClonedNode(Node node) {
+    auto it = clonedNodes_.find(node);
+    return (it != clonedNodes_.end()) ? it->second : nullptr;
+  }
+
+  std::vector<Node>& GetNodes() { return topoOrder_; }
+  uint64_t GetFlags() const { return flags_; }
+  bool TopologicalOrder() { return Graph::TopologicalOrder(topoOrder_); }
+
+  virtual hipError_t Init() = 0;
+  virtual hipError_t Run(hip::Stream* stream) = 0;
+
+ protected:
+  uint64_t flags_ = 0;
+};
+
+// ================================================================================================
+// GraphExecClassic — PAL/Windows path. No segment scheduling, no AQL packet capture.
+// Uses a simple topological-order walk over nodes for both instantiation and launch.
+class GraphExecClassic : public GraphExecBase {
+ public:
+  GraphExecClassic(uint64_t flags = 0) : GraphExecBase(flags) {}
+  ~GraphExecClassic() = default;
+
+  hipError_t Init() override;
+  hipError_t Run(hip::Stream* launch_stream) override;
+
+ protected:
+  bool repeatLaunch_ = false;
+};
+
+// ================================================================================================
+// GraphExecSegmented — Linux/ROCm path. Segment scheduling, AQL packet capture, multi-stream.
+class GraphExecSegmented : public GraphExecBase {
+  friend class GraphExecBase;  // allows OnLaunchComplete to access signalManager_
+ public:
+  bool graph_dumped_ = false;
+  GraphExecSegmented(uint64_t flags = 0) : GraphExecBase(flags) {}
+
+  ~GraphExecSegmented() {
     for (auto& streams : parallel_streams_) {
       for (auto stream : streams.second) {
         if (stream != nullptr) {
@@ -1002,43 +1052,26 @@ class GraphExec : public amd::ReferenceCountedObject, public Graph {
     segmentBatches_.clear();
   }
 
-  Node GetClonedNode(Node node) {
-    Node clonedNode;
-    if (clonedNodes_.find(node) == clonedNodes_.end()) {
-      return nullptr;
-    } else {
-      clonedNode = clonedNodes_[node];
-    }
-    return clonedNode;
-  }
-
   //! Check if kernel node has hidden heap
   bool HasHiddenHeap() const { return hasHiddenHeap_; }
   //! Graph has nodes that require hidden heap.
   void SetHiddenHeap() { hasHiddenHeap_ = true; }
 
-  //! Check executable graphs validity
-  static bool isGraphExecValid(GraphExec* pGraphExec);
-  std::vector<Node>& GetNodes() { return topoOrder_; }
-  uint64_t GetFlags() const { return flags_; }
-  hipError_t Init();
+  hipError_t Init() override;
   hipError_t CreateStreams(uint32_t num_streams, int devId = 0);
-  hipError_t Run(hip::Stream* stream);
+  hipError_t Run(hip::Stream* stream) override;
   // Capture GPU Packets from graph commands
   hipError_t CaptureAQLPackets();
   hipError_t UpdateAQLPacket(hip::GraphNode* node);
   // Handle packetBatches_ updates when nodes are enabled/disabled
   hipError_t UpdatePacketBatchesForNodeEnableDisable(hip::GraphNode* node, bool isEnabled);
-  // Kenrel arg manger is for the entire graph.
+  // Kernel arg manager is for the entire graph.
   // Child graph also shares the same kernel arg manager object. some apps have 100's of
   // child graph nodes and each child graph has only one node.
   void SetKernelArgManager(GraphKernelArgManager* kernArgManager) {
     kernArgManager_ = kernArgManager;
   }
   GraphKernelArgManager* GetKernelArgManager() { return kernArgManager_; }
-  // Completion callback for a graph launch: re-arms and returns the launch's
-  // pooled signals, then drops the launch's reference on the GraphExec.
-  static void OnLaunchComplete(cl_event event, cl_int command_exec_status, void* user_data);
   hipError_t CaptureAndFormPacketsForGraph();
   void GetKernelArgSizeForGraph(std::unordered_map<int, size_t>& kernArgSizeForGraph);
 
@@ -1054,7 +1087,6 @@ class GraphExec : public amd::ReferenceCountedObject, public Graph {
   hipError_t EnqueueSegment(const Segment& segment, hip::Stream* stream,
                             amd::AccumulateCommand* accumulate);
 
-  bool TopologicalOrder() { return Graph::TopologicalOrder(topoOrder_); }
   //! Update streams for the graph execution with launch stream from application
   void UpdateStreams(hip::Stream* launch_stream);
   //! Find the number of streams required per device for packet engine mode
@@ -1064,7 +1096,7 @@ class GraphExec : public amd::ReferenceCountedObject, public Graph {
   void RoundRobinStreamAssignment();
   //! DFS stream assignment: preserves chain continuity for linear chains of segments
   void DFSStreamAssignment();
-  //! Select stream assignment algorithm based on graph complexity
+  //! Select stream assignment algorithm based on graph complexity (0=Hybrid, 1=RR, 2=DFS)
   void SelectStreamAssignment();
   //! Get the parallel streams map for synchronization before destruction
   const std::unordered_map<int, std::vector<hip::Stream*>>& GetParallelStreams() const {
@@ -1074,7 +1106,6 @@ class GraphExec : public amd::ReferenceCountedObject, public Graph {
  protected:
   //! parallel streams per device
   std::unordered_map<int, std::vector<hip::Stream*>> parallel_streams_;
-  uint64_t flags_ = 0;
   GraphKernelArgManager* kernArgManager_ = nullptr;  //!< Kernel Arg manager for graph.
   GraphSignalManager* signalManager_ = nullptr;      //!< HW event signal pool for graph launches.
   bool hasHiddenHeap_ = false;  //!< Hidden heap indicator for Kernel node
@@ -1181,16 +1212,19 @@ class GraphExec : public amd::ReferenceCountedObject, public Graph {
   void BuildSyncPlan();
 };
 
-class ChildGraphNode : public GraphNode, public GraphExec {
+// Backward-compatible alias: code that refers to GraphExec gets GraphExecSegmented.
+using GraphExec = GraphExecSegmented;
+
+class ChildGraphNode : public GraphNode, public GraphExecSegmented {
  protected:
   // Copy Constructor. This is protected to prevent accidental copies causing unexpected behaviors.
-  ChildGraphNode(const ChildGraphNode& rhs) : GraphNode(rhs), GraphExec() {
+  ChildGraphNode(const ChildGraphNode& rhs) : GraphNode(rhs), GraphExecSegmented() {
     rhs.Graph::clone(this);
     graphCaptureStatus_ = rhs.graphCaptureStatus_;
   }
 
  public:
-  ChildGraphNode(Graph* g) : GraphNode(hipGraphNodeTypeGraph, "solid", "rectangle"), GraphExec() {
+  ChildGraphNode(Graph* g) : GraphNode(hipGraphNodeTypeGraph, "solid", "rectangle"), GraphExecSegmented() {
     g->clone(this);
     graphCaptureStatus_ = false;
   }

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -1001,6 +1001,11 @@ class GraphExecBase : public amd::ReferenceCountedObject, public Graph {
 
   virtual hipError_t Init() = 0;
   virtual hipError_t Run(hip::Stream* stream) = 0;
+  // AQL packet update — no-op on the classic path (PAL has no AQL capture).
+  virtual hipError_t UpdateAQLPacket(hip::GraphNode* node) { return hipSuccess; }
+  virtual hipError_t UpdatePacketBatchesForNodeEnableDisable(hip::GraphNode* node, bool isEnabled) {
+    return hipSuccess;
+  }
 
  protected:
   uint64_t flags_ = 0;
@@ -1062,9 +1067,9 @@ class GraphExecSegmented : public GraphExecBase {
   hipError_t Run(hip::Stream* stream) override;
   // Capture GPU Packets from graph commands
   hipError_t CaptureAQLPackets();
-  hipError_t UpdateAQLPacket(hip::GraphNode* node);
+  hipError_t UpdateAQLPacket(hip::GraphNode* node) override;
   // Handle packetBatches_ updates when nodes are enabled/disabled
-  hipError_t UpdatePacketBatchesForNodeEnableDisable(hip::GraphNode* node, bool isEnabled);
+  hipError_t UpdatePacketBatchesForNodeEnableDisable(hip::GraphNode* node, bool isEnabled) override;
   // Kernel arg manager is for the entire graph.
   // Child graph also shares the same kernel arg manager object. some apps have 100's of
   // child graph nodes and each child graph has only one node.

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -610,8 +610,6 @@ class Graph {
     graphSet_.insert(this);
     mem_pool_ = device->GetGraphMemoryPool();
     graphInstantiated_ = false;
-    // Initialize per-graph segment scheduling flag from global env var
-    use_segment_scheduling_ = DEBUG_HIP_GRAPH_SEGMENT_SCHEDULING;
     roots_.resize(DEBUG_HIP_FORCE_GRAPH_QUEUES);
     leafs_.resize(DEBUG_HIP_FORCE_GRAPH_QUEUES);
     wait_order_.resize(DEBUG_HIP_FORCE_GRAPH_QUEUES);
@@ -695,10 +693,6 @@ class Graph {
   const std::vector<Node>& GetTopoOrder() const { return topoOrder_; }
   /// returns all the edges in the graph
   std::vector<std::pair<Node, Node>> GetEdges() const;
-  /// Returns whether segment scheduling is enabled for this graph
-  bool IsSegmentSchedulingEnabled() const { return use_segment_scheduling_; }
-  // Enable or disable segment scheduling for this graph
-  void SetSegmentScheduling(bool segmentScheduling) {use_segment_scheduling_ = segmentScheduling;}
   // returns the original graph ptr if cloned
   const Graph* getOriginalGraph() const { return pOriginalGraph_; }
   // Add user obj resource to graph
@@ -731,15 +725,6 @@ class Graph {
   }
   // Delete user obj resource from graph
   void RemoveUserObjGraph(UserObject* pUserObj) { graphUserObj_.erase(pUserObj); }
-
-  //! Schedules one node on a vitual stream.
-  //! It will also process the nodes in edges, using DFS
-  void ScheduleOneNode(Node node,     //!< Node for scheduling on a virtual stream
-                       int stream_id  //!< Current active virtual stream to use for scheduling
-  );
-
-  //! Schedules all nodes in the graph into different streams
-  hipError_t ScheduleNodes();
 
   // Hierarchical path structure for child graph support
   struct HierarchicalPath {
@@ -982,10 +967,6 @@ class Graph {
   hip::MemoryPool* mem_pool_;          //!< Memory pool, associated with this graph
   std::unordered_set<GraphNode*> capturedNodes_;
   bool graphInstantiated_;
-  //!< Per-graph flag to control segment scheduling
-  //!< Can be disabled per-graph for complex graphs that benefit from classic path
-  bool use_segment_scheduling_;
-
   //! Map of device ID to vector of streams allocated for that device during graph execution.
   //! Each device may require multiple streams to handle parallel execution of graph nodes.
   std::unordered_map<int, std::vector<hip::Stream*>> streams_dev_;
@@ -1037,10 +1018,8 @@ class GraphExec : public amd::ReferenceCountedObject, public Graph {
       }
     }
     parallel_streams_.clear();
-    if (IsSegmentSchedulingEnabled()) {
-      if (kernArgManager_ != nullptr) {
-        kernArgManager_->release();
-      }
+    if (kernArgManager_ != nullptr) {
+      kernArgManager_->release();
     }
     if (signalManager_ != nullptr) {
       signalManager_->release();
@@ -1267,12 +1246,7 @@ class ChildGraphNode : public GraphNode, public GraphExec {
 
   bool GetGraphCaptureStatus() { return graphCaptureStatus_; }
 
-  bool GraphCaptureEnabled() override {
-    if (IsSegmentSchedulingEnabled()) {
-      return graphCaptureStatus_;
-    }
-    return false;
-  }
+  bool GraphCaptureEnabled() override { return graphCaptureStatus_; }
 
   std::vector<Node>& GetChildGraphNodeOrder() { return topoOrder_; }
 
@@ -1504,7 +1478,7 @@ class GraphKernelNode : public GraphNode {
     }
     resolvedFunc_ = func;
     amd::Kernel* kernel = hip::asKernel(func);
-    if (parentGraph_ != nullptr && parentGraph_->IsSegmentSchedulingEnabled()) {
+    if (parentGraph_ != nullptr) {
       auto device = g_devices[dev_id_]->devices()[0];
       device::Kernel* devKernel = const_cast<device::Kernel*>(kernel->getDeviceKernel(*device));
       kernargSegmentByteSize_ = devKernel->KernargSegmentByteSize();
@@ -1870,13 +1844,8 @@ class GraphKernelNode : public GraphNode {
   }
 
   virtual bool GraphCaptureEnabled() override {
-    if (parentGraph_ != nullptr && parentGraph_->IsSegmentSchedulingEnabled()) {
-      // Disable capture for cooperative kernels
-      if (!coopKernel_) {
-        return true;
-      }
-    }
-    return false;
+    // Disable capture for cooperative kernels
+    return !coopKernel_;
   }
 };
 
@@ -2035,16 +2004,7 @@ class GraphMemcpyNode : public GraphNode {
     }
   }
   virtual bool GraphCaptureEnabled() override {
-    if (parentGraph_ != nullptr && parentGraph_->IsSegmentSchedulingEnabled()) {
-      switch (copyParams_.kind) {
-        case hipMemcpyDeviceToDevice:
-          return true;
-          break;
-        default:
-          break;
-      }
-    }
-    return false;
+    return copyParams_.kind == hipMemcpyDeviceToDevice;
   }
 
   // Returns true when this memcpy will NOT use the SDMA engine, so no
@@ -2316,19 +2276,15 @@ class GraphMemcpyNode1D : public GraphMemcpyNode {
     }
   }
   virtual bool GraphCaptureEnabled() override {
-    if (parentGraph_ != nullptr && parentGraph_->IsSegmentSchedulingEnabled()) {
-      hip::MemcpyType type = hipHostToHost;
+    hip::MemcpyType type = hipHostToHost;
 
-      size_t dOffset, sOffset;
-      amd::Memory* dstMemory = getMemoryObjectForCurrentDevice(dst_, dOffset);
-      amd::Memory* srcMemory = getMemoryObjectForCurrentDevice(src_, sOffset);
+    size_t dOffset, sOffset;
+    amd::Memory* dstMemory = getMemoryObject(dst_, dOffset);
+    amd::Memory* srcMemory = getMemoryObject(src_, sOffset);
 
-      // The case below is only interested in hipCopyBuffer,
-      // which is only valid for device to device copies.
-      if (dstMemory != nullptr && srcMemory != nullptr) {
-        return (hipCopyBuffer == ihipGetMemcpyType(srcMemory, dstMemory, kind_));
-      }
-      return false;
+    // hipCopyBuffer is only valid for device to device copies.
+    if (dstMemory != nullptr && srcMemory != nullptr) {
+      return (hipCopyBuffer == ihipGetMemcpyType(srcMemory, dstMemory, kind_));
     }
     return false;
   }
@@ -2677,12 +2633,7 @@ class GraphMemsetNode : public GraphNode {
     }
   }
 
-  virtual bool GraphCaptureEnabled() override {
-    if (parentGraph_ != nullptr && parentGraph_->IsSegmentSchedulingEnabled()) {
-      return true;
-    }
-    return false;
-  }
+  virtual bool GraphCaptureEnabled() override { return true; }
 
   hipError_t CreateCommand(hip::Stream* stream) override {
     hipError_t status = GraphNode::CreateCommand(stream);

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -315,8 +315,6 @@ class GraphNode : public hipGraphNodeDOTAttribute {
   ) {
     assert(stream_id_ != -1 && "Stream ID wasn't initialized");
     stream_ = streams[stream_id_];
-    // Reset the launch ID after the stream assignment
-    launch_id_ = -1;
   }
   /// Create amd::command for the graph node
   virtual hipError_t CreateCommand(hip::Stream* stream) {
@@ -501,7 +499,6 @@ class GraphNode : public hipGraphNodeDOTAttribute {
   int32_t stream_id_ = -1;  //! Stream ID on which this node will be executed
   int hw_queue_id_ = -1; //! Hardware queue ID on which this node will be executed
   int32_t segment_id_ = -1;  //! Segment ID on which this node will be executed
-  int32_t launch_id_ = -1;  //! Launch ID of this node in the entire graph execution sequence
   static std::atomic<int> nextID;
   Graph* parentGraph_;
   static std::unordered_set<GraphNode*> nodeSet_;
@@ -610,9 +607,6 @@ class Graph {
     graphSet_.insert(this);
     mem_pool_ = device->GetGraphMemoryPool();
     graphInstantiated_ = false;
-    roots_.resize(DEBUG_HIP_FORCE_GRAPH_QUEUES);
-    leafs_.resize(DEBUG_HIP_FORCE_GRAPH_QUEUES);
-    wait_order_.resize(DEBUG_HIP_FORCE_GRAPH_QUEUES);
     streams_dev_.reserve(g_devices.size());
   }
   void RemoveUserObjectFromOwingGraphs(UserObject* uObj) {
@@ -648,8 +642,8 @@ class Graph {
     }
     graphUserObj_.clear();
     memAllocNodePtrs_.clear();
-    if (instantiateDeviceId_ != -1) {
-      static_cast<amd::ReferenceCountedObject*>(g_devices[instantiateDeviceId_])->release();
+    if (captureDeviceId_ != -1) {
+      static_cast<amd::ReferenceCountedObject*>(g_devices[captureDeviceId_])->release();
     }
   }
 
@@ -690,7 +684,6 @@ class Graph {
   size_t GetNodeCount() const { return vertices_.size(); }
   /// returns all the nodes in the graph
   const std::vector<Node>& GetNodes() const { return vertices_; }
-  const std::vector<Node>& GetTopoOrder() const { return topoOrder_; }
   /// returns all the edges in the graph
   std::vector<std::pair<Node, Node>> GetEdges() const;
   // returns the original graph ptr if cloned
@@ -760,16 +753,6 @@ class Graph {
 
   //! Calculate dependency levels for segments using topological sort
   void CalculateSegmentTopoDependencyLevels();
-
-  //! Runs one node on the assigned stream
-  bool RunOneNode(Node node);  //!< Node for the execution on GPU
-
-  //! Runs all nodes from the execution graph on the assigned streams
-  bool RunNodes(
-      int32_t base_stream = 0,                             //!< The base stream to run the graph on
-      const std::vector<hip::Stream*>* streams = nullptr,  //!< Streams to run the graph
-      const amd::Command::EventWaitList* parent_waitlist = nullptr  //!< Parent Graph waitlist
-  );
 
   bool TopologicalOrder(std::vector<Node>& TopoOrder);
 
@@ -910,11 +893,7 @@ class Graph {
 
  protected:
   int max_streams_ = 0;  //!< Maximum number of streams used in the graph launch
-  //!< Maps stream ID to the set of device IDs that use that stream.
-  //!< Used to track which devices are accessed by each parallel stream
-  //!< during multi-device graph execution scheduling.
-  std::unordered_map<int, std::set<int>> streams_dev_ids_;
-  int instantiateDeviceId_ = -1;
+  int captureDeviceId_ = -1;
     //! Topological order of the graph doesn't include nodes embedded as part of the child graph
   std::vector<Node> topoOrder_;
 
@@ -956,13 +935,7 @@ class Graph {
   unsigned int id_;
   static std::atomic<int> nextID;
   uint32_t memalloc_nodes_ = 0;  //!< Count of unreleased Memalloc nodes
-  std::vector<Node> roots_;      //!< Root nodes, used in parallel launches
-  std::vector<Node> leafs_;      //!< The list of leaf nodes on every parallel stream
-  //!< Used as a temporary storage for the waiting nodes
-  //!< to reduce the stack pressure in recursion
-  std::vector<Node> wait_order_;
   std::vector<hip::Stream*> streams_;  //!< The list of streams, used in the execution
-  int32_t current_id_ = 0;             //!< The current node ID in the graph execution sequence
   hip::Device* device_;                //!< HIP device object
   hip::MemoryPool* mem_pool_;          //!< Memory pool, associated with this graph
   std::unordered_set<GraphNode*> capturedNodes_;
@@ -1084,16 +1057,12 @@ class GraphExec : public amd::ReferenceCountedObject, public Graph {
   bool TopologicalOrder() { return Graph::TopologicalOrder(topoOrder_); }
   //! Update streams for the graph execution with launch stream from application
   void UpdateStreams(hip::Stream* launch_stream);
-  //! Find the number of streams required per device for multi-device graph execution
-  //! This method analyzes the stream-to-device mappings and recursively processes
-  //! child graphs to determine the maximum concurrent streams needed per device
-  void FindStreamsReqPerDev();
   //! Find the number of streams required per device for packet engine mode
   //! This method analyzes segments to determine per-device stream requirements
   void FindStreamsReqPerDevForSegments();
   //! Round-robin stream assignment: spreads parallel segments evenly per dependency level
   void RoundRobinStreamAssignment();
-  //! DFS stream assignment: preserves chain continuity, same algorithm as classic ScheduleOneNode
+  //! DFS stream assignment: preserves chain continuity for linear chains of segments
   void DFSStreamAssignment();
   //! Select stream assignment algorithm based on graph complexity
   void SelectStreamAssignment();
@@ -2279,8 +2248,8 @@ class GraphMemcpyNode1D : public GraphMemcpyNode {
     hip::MemcpyType type = hipHostToHost;
 
     size_t dOffset, sOffset;
-    amd::Memory* dstMemory = getMemoryObject(dst_, dOffset);
-    amd::Memory* srcMemory = getMemoryObject(src_, sOffset);
+    amd::Memory* dstMemory = getMemoryObjectForCurrentDevice(dst_, dOffset);
+    amd::Memory* srcMemory = getMemoryObjectForCurrentDevice(src_, sOffset);
 
     // hipCopyBuffer is only valid for device to device copies.
     if (dstMemory != nullptr && srcMemory != nullptr) {
@@ -2917,12 +2886,7 @@ class GraphEmptyNode : public GraphNode {
   // Empty nodes participate in AQL capture as zero-packet dependency points.
   // The capture loop registers them as zero-packet nodeRanges so dependency
   // tracking works without emitting any GPU commands.
-  bool GraphCaptureEnabled() override {
-    if (parentGraph_ != nullptr && parentGraph_->IsSegmentSchedulingEnabled()) {
-      return true;
-    }
-    return false;
-  }
+  bool GraphCaptureEnabled() override { return true; }
 
   hipError_t CreateCommand(hip::Stream* stream) override {
     hipError_t status = GraphNode::CreateCommand(stream);

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -176,7 +176,7 @@ class GraphKernelArgManager : public amd::ReferenceCountedObject,
   using KernelArgImpl = device::Settings::KernelArgImpl;
 };
 
-//! Per-GraphExec pool of HW event sets.
+//! Per-GraphExecBase pool of HW event sets.
 class GraphSignalManager : public amd::ReferenceCountedObject {
  public:
   GraphSignalManager() : amd::ReferenceCountedObject() {}
@@ -489,7 +489,7 @@ class GraphNode : public hipGraphNodeDOTAttribute {
   void SetWait(bool wait) { wait_ = wait; }
 
  protected:
-  // Declare Graph and GraphExec as friends of node for simpler access to GraphNode fields
+  // Declare Graph and GraphExecBase as friends of node for simpler access to GraphNode fields
   friend class Graph;
   friend class GraphExecBase;
   friend class GraphExecSegmented;
@@ -1037,6 +1037,8 @@ class GraphExecBase : public amd::ReferenceCountedObject, public Graph {
   virtual hipError_t UpdatePacketBatchesForNodeEnableDisable(hip::GraphNode* node, bool isEnabled) {
     return hipSuccess;
   }
+  //! Recycle HW event signals borrowed for a launch. No-op on classic path.
+  virtual void RecycleLaunchSignals(amd::Device* device, std::vector<void*>& signal_set) {}
 
  protected:
   uint64_t flags_ = 0;
@@ -1080,7 +1082,6 @@ class GraphExecClassic : public GraphExecBase {
 // ================================================================================================
 // GraphExecSegmented — Linux/ROCm path. Segment scheduling, AQL packet capture, multi-stream.
 class GraphExecSegmented : public GraphExecBase {
-  friend class GraphExecBase;  // allows OnLaunchComplete to access signalManager_
  public:
   bool graph_dumped_ = false;
   GraphExecSegmented(uint64_t flags = 0) : GraphExecBase(flags) {}
@@ -1109,6 +1110,12 @@ class GraphExecSegmented : public GraphExecBase {
   hipError_t UpdateAQLPacket(hip::GraphNode* node) override;
   // Handle packetBatches_ updates when nodes are enabled/disabled
   hipError_t UpdatePacketBatchesForNodeEnableDisable(hip::GraphNode* node, bool isEnabled) override;
+  //! Recycle HW event signals borrowed for a launch back to the signal pool.
+  void RecycleLaunchSignals(amd::Device* device, std::vector<void*>& signal_set) override {
+    if (signalManager_ != nullptr && !signal_set.empty()) {
+      signalManager_->ReleaseSet(device, signal_set);
+    }
+  }
   // Kernel arg manager is for the entire graph.
   // Child graph also shares the same kernel arg manager object. some apps have 100's of
   // child graph nodes and each child graph has only one node.
@@ -1259,8 +1266,6 @@ class GraphExecSegmented : public GraphExecBase {
   void BuildSyncPlan();
 };
 
-// Backward-compatible alias: path-agnostic code uses GraphExecBase through this alias.
-using GraphExec = GraphExecBase;
 
 class ChildGraphNode : public GraphNode, public GraphExecSegmented {
  protected:

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -932,6 +932,7 @@ class Graph {
  private:
   friend class GraphExecBase;
   friend class GraphExecSegmented;
+  friend class GraphExecClassic;
   std::vector<Node> vertices_;
   const Graph* pOriginalGraph_ = nullptr;
   //!< graphUserObj_.second stores refcount owned by this graph for user object,
@@ -1108,10 +1109,18 @@ class GraphExecSegmented : public GraphExecBase {
   void FindStreamsReqPerDevForSegments();
   //! Round-robin stream assignment: spreads parallel segments evenly per dependency level
   void RoundRobinStreamAssignment();
-  //! DFS stream assignment: preserves chain continuity for linear chains of segments
+  //! DFS stream assignment: preserves chain continuity across segment DAG branches
   void DFSStreamAssignment();
-  //! Select stream assignment algorithm based on graph complexity (0=Hybrid, 1=RR, 2=DFS)
+  //! Select stream assignment algorithm based on graph complexity
   void SelectStreamAssignment();
+  //! Recompute each segment's needs_completion_signal flag from its current
+  //! stream assignment. Called after the initial assignment and again if
+  //! BuildSyncPlan's collapse pass reassigns segments to a single stream.
+  void ComputeCompletionSignalFlags();
+  //! Barrier-ROI heuristic: decide whether the segment graph should be collapsed
+  //! onto a single stream because the cross-stream barriers multi-stream would
+  //! cost outweigh the work that could actually overlap. Returns true to collapse.
+  bool ShouldCollapseToSingleStream() const;
   //! Get the parallel streams map for synchronization before destruction
   const std::unordered_map<int, std::vector<hip::Stream*>>& GetParallelStreams() const {
     return parallel_streams_;

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -1259,8 +1259,8 @@ class GraphExecSegmented : public GraphExecBase {
   void BuildSyncPlan();
 };
 
-// Backward-compatible alias: code that refers to GraphExec gets GraphExecSegmented.
-using GraphExec = GraphExecSegmented;
+// Backward-compatible alias: path-agnostic code uses GraphExecBase through this alias.
+using GraphExec = GraphExecBase;
 
 class ChildGraphNode : public GraphNode, public GraphExecSegmented {
  protected:

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -1112,16 +1112,12 @@ class GraphExec : public amd::ReferenceCountedObject, public Graph {
   //! Find the number of streams required per device for packet engine mode
   //! This method analyzes segments to determine per-device stream requirements
   void FindStreamsReqPerDevForSegments();
-  //! Pre-compute segment-to-stream-index mapping and same-stream dep flags at instantiate
-  void PrecomputeStreamAssignment();
-  //! Recompute each segment's needs_completion_signal flag from its current
-  //! stream assignment. Called after the initial assignment and again if
-  //! BuildSyncPlan's collapse pass reassigns segments to a single stream.
-  void ComputeCompletionSignalFlags();
-  //! Barrier-ROI heuristic: decide whether the segment graph should be collapsed
-  //! onto a single stream because the cross-stream barriers multi-stream would
-  //! cost outweigh the work that could actually overlap. Returns true to collapse.
-  bool ShouldCollapseToSingleStream() const;
+  //! Round-robin stream assignment: spreads parallel segments evenly per dependency level
+  void RoundRobinStreamAssignment();
+  //! DFS stream assignment: preserves chain continuity, same algorithm as classic ScheduleOneNode
+  void DFSStreamAssignment();
+  //! Select stream assignment algorithm based on graph complexity
+  void SelectStreamAssignment();
   //! Get the parallel streams map for synchronization before destruction
   const std::unordered_map<int, std::vector<hip::Stream*>>& GetParallelStreams() const {
     return parallel_streams_;

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -317,6 +317,7 @@ class GraphNode : public hipGraphNodeDOTAttribute {
   ) {
     assert(stream_id_ != -1 && "Stream ID wasn't initialized");
     stream_ = streams[stream_id_];
+    launch_id_ = -1;
   }
   /// Create amd::command for the graph node
   virtual hipError_t CreateCommand(hip::Stream* stream) {
@@ -502,6 +503,7 @@ class GraphNode : public hipGraphNodeDOTAttribute {
   int32_t stream_id_ = -1;  //! Stream ID on which this node will be executed
   int hw_queue_id_ = -1; //! Hardware queue ID on which this node will be executed
   int32_t segment_id_ = -1;  //! Segment ID on which this node will be executed
+  int32_t launch_id_ = -1;  //! Launch ID of this node in the entire graph execution sequence
   static std::atomic<int> nextID;
   Graph* parentGraph_;
   static std::unordered_set<GraphNode*> nodeSet_;
@@ -610,6 +612,9 @@ class Graph {
     graphSet_.insert(this);
     mem_pool_ = device->GetGraphMemoryPool();
     graphInstantiated_ = false;
+    roots_.resize(DEBUG_HIP_FORCE_GRAPH_QUEUES);
+    leafs_.resize(DEBUG_HIP_FORCE_GRAPH_QUEUES);
+    wait_order_.resize(DEBUG_HIP_FORCE_GRAPH_QUEUES);
     streams_dev_.reserve(g_devices.size());
   }
   void RemoveUserObjectFromOwingGraphs(UserObject* uObj) {
@@ -687,6 +692,7 @@ class Graph {
   size_t GetNodeCount() const { return vertices_.size(); }
   /// returns all the nodes in the graph
   const std::vector<Node>& GetNodes() const { return vertices_; }
+  const std::vector<Node>& GetTopoOrder() const { return topoOrder_; }
   /// returns all the edges in the graph
   std::vector<std::pair<Node, Node>> GetEdges() const;
   // returns the original graph ptr if cloned
@@ -736,6 +742,24 @@ class Graph {
     std::vector<HierarchicalPath> paths;  //!< All execution paths at this level only
     std::vector<GraphExecutionPaths> child_graph_paths;  //!< Child graph execution paths
   };
+
+  //! DFS-based stream assignment for a single node and its subtree
+  void ScheduleOneNode(Node node,     //!< Node for scheduling on a virtual stream
+                       int stream_id  //!< A virtual stream for scheduling
+  );
+
+  //! Schedule all nodes in the graph (classic or segment path)
+  hipError_t ScheduleNodes();
+
+  //! Runs one node on the assigned stream
+  bool RunOneNode(Node node);
+
+  //! Runs all nodes from the execution graph on the assigned streams
+  bool RunNodes(
+      int32_t base_stream = 0,
+      const std::vector<hip::Stream*>* streams = nullptr,
+      const amd::Command::EventWaitList* parent_waitlist = nullptr
+  );
 
   //! Schedules nodes into batches for optimized execution
   hipError_t ScheduleNodesIntoBatches();
@@ -896,6 +920,8 @@ class Graph {
 
  protected:
   int max_streams_ = 0;  //!< Maximum number of streams used in the graph launch
+  //!< Maps stream ID to the set of device IDs that use that stream.
+  std::unordered_map<int, std::set<int>> streams_dev_ids_;
   int captureDeviceId_ = -1;
     //! Topological order of the graph doesn't include nodes embedded as part of the child graph
   std::vector<Node> topoOrder_;
@@ -940,7 +966,11 @@ class Graph {
   unsigned int id_;
   static std::atomic<int> nextID;
   uint32_t memalloc_nodes_ = 0;  //!< Count of unreleased Memalloc nodes
+  std::vector<Node> roots_;      //!< Root nodes, used in parallel launches
+  std::vector<Node> leafs_;      //!< The list of leaf nodes on every parallel stream
+  std::vector<Node> wait_order_; //!< Temporary storage for waiting nodes
   std::vector<hip::Stream*> streams_;  //!< The list of streams, used in the execution
+  int32_t current_id_ = 0;             //!< The current node ID in the graph execution sequence
   hip::Device* device_;                //!< HIP device object
   hip::MemoryPool* mem_pool_;          //!< Memory pool, associated with this graph
   std::unordered_set<GraphNode*> capturedNodes_;
@@ -1010,41 +1040,26 @@ class GraphExecBase : public amd::ReferenceCountedObject, public Graph {
 
  protected:
   uint64_t flags_ = 0;
+  bool repeatLaunch_ = false;
+  //! parallel streams per device
+  std::unordered_map<int, std::vector<hip::Stream*>> parallel_streams_;
+
+  //! Create parallel streams for a device
+  hipError_t CreateStreams(uint32_t num_streams, int devId);
+  //! Compute per-device stream requirements from streams_dev_ids_ mappings
+  void FindStreamsReqPerDev();
+  //! Update streams_[0] to the launch stream and resolve HW queue collisions
+  void UpdateStreams(hip::Stream* launch_stream);
 };
 
 // ================================================================================================
 // GraphExecClassic — PAL/Windows path. No segment scheduling, no AQL packet capture.
-// Uses a simple topological-order walk over nodes for both instantiation and launch.
+// Uses classic DFS scheduling + RunNodes for multi-stream execution.
 class GraphExecClassic : public GraphExecBase {
  public:
-  GraphExecClassic(uint64_t flags = 0) : GraphExecBase(flags) {}
-  ~GraphExecClassic() = default;
-
-  hipError_t Init() override;
-  hipError_t Run(hip::Stream* launch_stream) override;
-
-  //! Schedule a single node: assign stream and create its commands.
-  hipError_t ScheduleOneNode(GraphNode* node, hip::Stream* stream);
-  //! Schedule all nodes in topological order.
-  hipError_t ScheduleNodes(hip::Stream* stream);
-  //! Enqueue a single node's already-created commands onto the stream.
-  void RunOneNode(GraphNode* node, hip::Stream* stream);
-  //! Enqueue all nodes in topological order.
-  void RunNodes(hip::Stream* stream);
-
- protected:
-  bool repeatLaunch_ = false;
-};
-
-// ================================================================================================
-// GraphExecSegmented — Linux/ROCm path. Segment scheduling, AQL packet capture, multi-stream.
-class GraphExecSegmented : public GraphExecBase {
-  friend class GraphExecBase;  // allows OnLaunchComplete to access signalManager_
- public:
   bool graph_dumped_ = false;
-  GraphExecSegmented(uint64_t flags = 0) : GraphExecBase(flags) {}
-
-  ~GraphExecSegmented() {
+  GraphExecClassic(uint64_t flags = 0) : GraphExecBase(flags) {}
+  ~GraphExecClassic() {
     for (auto& streams : parallel_streams_) {
       for (auto stream : streams.second) {
         if (stream != nullptr) {
@@ -1056,6 +1071,21 @@ class GraphExecSegmented : public GraphExecBase {
       }
     }
     parallel_streams_.clear();
+  }
+
+  hipError_t Init() override;
+  hipError_t Run(hip::Stream* launch_stream) override;
+};
+
+// ================================================================================================
+// GraphExecSegmented — Linux/ROCm path. Segment scheduling, AQL packet capture, multi-stream.
+class GraphExecSegmented : public GraphExecBase {
+  friend class GraphExecBase;  // allows OnLaunchComplete to access signalManager_
+ public:
+  bool graph_dumped_ = false;
+  GraphExecSegmented(uint64_t flags = 0) : GraphExecBase(flags) {}
+
+  ~GraphExecSegmented() {
     if (kernArgManager_ != nullptr) {
       kernArgManager_->release();
     }
@@ -1073,7 +1103,6 @@ class GraphExecSegmented : public GraphExecBase {
   void SetHiddenHeap() { hasHiddenHeap_ = true; }
 
   hipError_t Init() override;
-  hipError_t CreateStreams(uint32_t num_streams, int devId = 0);
   hipError_t Run(hip::Stream* stream) override;
   // Capture GPU Packets from graph commands
   hipError_t CaptureAQLPackets();
@@ -1102,8 +1131,6 @@ class GraphExecSegmented : public GraphExecBase {
   hipError_t EnqueueSegment(const Segment& segment, hip::Stream* stream,
                             amd::AccumulateCommand* accumulate);
 
-  //! Update streams for the graph execution with launch stream from application
-  void UpdateStreams(hip::Stream* launch_stream);
   //! Find the number of streams required per device for packet engine mode
   //! This method analyzes segments to determine per-device stream requirements
   void FindStreamsReqPerDevForSegments();
@@ -1127,13 +1154,10 @@ class GraphExecSegmented : public GraphExecBase {
   }
 
  protected:
-  //! parallel streams per device
-  std::unordered_map<int, std::vector<hip::Stream*>> parallel_streams_;
   GraphKernelArgManager* kernArgManager_ = nullptr;  //!< Kernel Arg manager for graph.
   GraphSignalManager* signalManager_ = nullptr;      //!< HW event signal pool for graph launches.
   bool hasHiddenHeap_ = false;  //!< Hidden heap indicator for Kernel node
   std::unordered_set<int> hiddenHeapInitializedDevices_;
-  bool repeatLaunch_ = false;
 
   // PacketBatch structure
   struct PacketBatch {

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -1292,12 +1292,16 @@ class ChildGraphNode : public GraphNode, public GraphExecSegmented {
         ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
                 "[hipGraph] ChildGraphNode::EnqueueCommands failed with status=%d", status);
       }
-    } else if (max_streams_ == 1) {
-      // Legacy topological order execution for non-segmented graphs
-      for (int i = 0; i < topoOrder_.size(); i++) {
-        topoOrder_[i]->SetStream(stream_);
-        hipError_t status = topoOrder_[i]->CreateCommand(topoOrder_[i]->GetQueue());
-        topoOrder_[i]->EnqueueCommands(stream_);
+    } else {
+      // Classic path: no segments, no AQL capture — walk topoOrder_ directly.
+      // Populate topoOrder_ on first launch if not yet done.
+      if (topoOrder_.empty()) {
+        Graph::TopologicalOrder(topoOrder_);
+      }
+      for (auto* node : topoOrder_) {
+        node->SetStream(stream);
+        [[maybe_unused]] hipError_t s = node->CreateCommand(node->GetQueue());
+        node->EnqueueCommands(stream);
       }
     }
   }

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -1022,6 +1022,15 @@ class GraphExecClassic : public GraphExecBase {
   hipError_t Init() override;
   hipError_t Run(hip::Stream* launch_stream) override;
 
+  //! Schedule a single node: assign stream and create its commands.
+  hipError_t ScheduleOneNode(GraphNode* node, hip::Stream* stream);
+  //! Schedule all nodes in topological order.
+  hipError_t ScheduleNodes(hip::Stream* stream);
+  //! Enqueue a single node's already-created commands onto the stream.
+  void RunOneNode(GraphNode* node, hip::Stream* stream);
+  //! Enqueue all nodes in topological order.
+  void RunNodes(hip::Stream* stream);
+
  protected:
   bool repeatLaunch_ = false;
 };

--- a/projects/clr/hipamd/src/hip_internal.hpp
+++ b/projects/clr/hipamd/src/hip_internal.hpp
@@ -75,7 +75,8 @@ enum MemcpyType {
 
 struct Graph;
 struct GraphNode;
-struct GraphExec;
+class GraphExecBase;
+class GraphExecSegmented;
 struct UserObject;
 class Stream;
 

--- a/projects/clr/rocclr/device/pal/palsettings.cpp
+++ b/projects/clr/rocclr/device/pal/palsettings.cpp
@@ -117,7 +117,7 @@ Settings::Settings() {
                                                           : HIP_FORCE_DEV_KERNARG;
 
   limit_blit_wg_ = 16;
-  DEBUG_HIP_GRAPH_SEGMENT_SCHEDULING = 0;  // disable graph performance optimizations for PAL
+  // PAL now uses GraphExecClassic which has no segment scheduling — flag is irrelevant.
 }
 
 bool Settings::create(const Pal::DeviceProperties& palProp,

--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -248,6 +248,9 @@ release(uint, DEBUG_HIP_GRAPH_BATCH_SIZE, 256,                                \
 release(uint, DEBUG_HIP_GRAPH_SEGMENT_SCHEDULING, 0,                          \
         "Segment scheduling mode (segmented path only): "                      \
         "0=Hybrid/auto, 1=Round-robin, 2=DFS")                                \
+release(bool, DEBUG_HIP_GRAPH_CLASSIC_PATH, false,                            \
+        "Force GraphExecClassic (classic topological path) regardless of "    \
+        "GPU_ENABLE_PAL, for testing on Linux")                                \
 release(uint, DEBUG_HIP_BLOCK_SYNC, 50,                                       \
         "Blocks synchronization on CPU until the callback processing is done")\
 release(uint, DEBUG_CLR_MAX_BATCH_SIZE, 1000,                                 \

--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -246,12 +246,8 @@ release(uint, DEBUG_HIP_FORCE_GRAPH_QUEUES, 4,                                \
 release(uint, DEBUG_HIP_GRAPH_BATCH_SIZE, 256,                                \
         "Number of graph nodes to batch at a time")                           \
 release(uint, DEBUG_HIP_GRAPH_SEGMENT_SCHEDULING, 1,                          \
-        "0 = Disable, 1 = Enable, 2 = Force")                                 \
-release(uint, DEBUG_HIP_GRAPH_MIN_OVERLAP, 2,                                 \
-        "Min overlappable work (in occupancy passes) per unit of cross-stream "\
-        "sync (barrier packets + completion signals) to keep a graph "         \
-        "multi-stream; below this ratio it collapses to a single stream. "     \
-        "0 = off.")                                                            \
+        "0 = Disable (classic path), 1 = Enable (auto DFS/round-robin), "    \
+        "2 = Force DFS, 3 = Force round-robin")                               \
 release(uint, DEBUG_HIP_BLOCK_SYNC, 50,                                       \
         "Blocks synchronization on CPU until the callback processing is done")\
 release(uint, DEBUG_CLR_MAX_BATCH_SIZE, 1000,                                 \

--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -246,7 +246,8 @@ release(uint, DEBUG_HIP_FORCE_GRAPH_QUEUES, 4,                                \
 release(uint, DEBUG_HIP_GRAPH_BATCH_SIZE, 256,                                \
         "Number of graph nodes to batch at a time")                           \
 release(uint, DEBUG_HIP_GRAPH_SEGMENT_SCHEDULING, 0,                          \
-        "0 = Auto (DFS or round-robin), 1 = Force DFS, 2 = Force round-robin")\
+        "Segment scheduling mode (segmented path only): "                      \
+        "0=Hybrid/auto, 1=Round-robin, 2=DFS")                                \
 release(uint, DEBUG_HIP_BLOCK_SYNC, 50,                                       \
         "Blocks synchronization on CPU until the callback processing is done")\
 release(uint, DEBUG_CLR_MAX_BATCH_SIZE, 1000,                                 \

--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -248,6 +248,11 @@ release(uint, DEBUG_HIP_GRAPH_BATCH_SIZE, 256,                                \
 release(uint, DEBUG_HIP_GRAPH_SEGMENT_SCHEDULING, 0,                          \
         "Segment scheduling mode (segmented path only): "                      \
         "0=Hybrid/auto, 1=Round-robin, 2=DFS")                                \
+release(uint, DEBUG_HIP_GRAPH_MIN_OVERLAP, 2,                                 \
+        "Min overlappable work (in occupancy passes) per unit of cross-stream "\
+        "sync (barrier packets + completion signals) to keep a graph "         \
+        "multi-stream; below this ratio it collapses to a single stream. "     \
+        "0 = off.")                                                            \
 release(bool, DEBUG_HIP_GRAPH_CLASSIC_PATH, false,                            \
         "Force GraphExecClassic (classic topological path) regardless of "    \
         "GPU_ENABLE_PAL, for testing on Linux")                                \

--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -246,8 +246,7 @@ release(uint, DEBUG_HIP_FORCE_GRAPH_QUEUES, 4,                                \
 release(uint, DEBUG_HIP_GRAPH_BATCH_SIZE, 256,                                \
         "Number of graph nodes to batch at a time")                           \
 release(uint, DEBUG_HIP_GRAPH_SEGMENT_SCHEDULING, 1,                          \
-        "0 = Disable (classic path), 1 = Enable (auto DFS/round-robin), "    \
-        "2 = Force DFS, 3 = Force round-robin")                               \
+        "1 = Auto (DFS or round-robin), 2 = Force DFS, 3 = Force round-robin")\
 release(uint, DEBUG_HIP_BLOCK_SYNC, 50,                                       \
         "Blocks synchronization on CPU until the callback processing is done")\
 release(uint, DEBUG_CLR_MAX_BATCH_SIZE, 1000,                                 \

--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -245,8 +245,8 @@ release(uint, DEBUG_HIP_FORCE_GRAPH_QUEUES, 4,                                \
         "Forces the number of streams for the graph parallel execution")      \
 release(uint, DEBUG_HIP_GRAPH_BATCH_SIZE, 256,                                \
         "Number of graph nodes to batch at a time")                           \
-release(uint, DEBUG_HIP_GRAPH_SEGMENT_SCHEDULING, 1,                          \
-        "1 = Auto (DFS or round-robin), 2 = Force DFS, 3 = Force round-robin")\
+release(uint, DEBUG_HIP_GRAPH_SEGMENT_SCHEDULING, 0,                          \
+        "0 = Auto (DFS or round-robin), 1 = Force DFS, 2 = Force round-robin")\
 release(uint, DEBUG_HIP_BLOCK_SYNC, 50,                                       \
         "Blocks synchronization on CPU until the callback processing is done")\
 release(uint, DEBUG_CLR_MAX_BATCH_SIZE, 1000,                                 \


### PR DESCRIPTION
## Summary
JIRA ID: AIRUNTIME-2294

This PR modernizes HIP graph stream assignment by bringing DFS-based scheduling into the segment path, making segment scheduling the default on Linux/ROCm, and splitting graph execution into classic (PAL/Windows) and segmented (Linux/ROCm) implementations.

## Segment scheduling improvements (Linux/ROCm)

- Add DFSStreamAssignment() — iterative DFS over the segment DAG (same algorithm as the former classic ScheduleOneNode, but at segment granularity). Linear segment chains stay on one stream; branches rotate to a new stream at each leaf to minimize cross-stream barriers. 
- Add SelectStreamAssignment() — chooses DFS vs round-robin at instantiation based on graph complexity (≥16 segments with average length <8 nodes → DFS; otherwise round-robin).
- Rename PrecomputeStreamAssignment() → RoundRobinStreamAssignment() for clarity.
- Remove hipErrorNotReady fallback from ScheduleNodesIntoBatches(); complexity handling is now inside SelectStreamAssignment().
- Consolidate initialization — ScheduleNodesIntoBatches() and SetKernelArgManager() moved into GraphExecSegmented::Init() so ihipGraphInstantiate only does clone() + Init() for both paths.
- Fix captureDeviceId_ — derive from segment metadata in FindStreamsReqPerDevForSegments() (with empty-graph fallback); call unconditionally in Init() to avoid SIGSEGV in BuildSyncPlan().

## GraphExec architecture split
Introduce a clean class hierarchy to support PAL (no AQL) and ROCm (segment + AQL) without unsafe casts:

- GraphExecBase — shared state, virtual Init()/Run(), RecycleLaunchSignals(), no-op virtuals for AQL update methods.
- GraphExecClassic — PAL/Windows path: topological order, per-node ScheduleOneNode/RunOneNode loop, no segments or AQL capture.
- GraphExecSegmented — Linux/ROCm path: existing segment scheduling, AQL packet capture, and multi-stream machinery.
- ihipGraphInstantiate selects classic vs segmented via GPU_ENABLE_PAL || DEBUG_HIP_GRAPH_CLASSIC_PATH. Remove the palsettings.cpp hack that zeroed segment scheduling; PAL uses GraphExecClassic directly.

## Debug flags
- DEBUG_HIP_GRAPH_SEGMENT_SCHEDULING (segmented path only):
0 = Auto/hybrid (default; heuristic selects DFS or round-robin)
1 = Force round-robin
2 = Force DFS
- DEBUG_HIP_GRAPH_CLASSIC_PATH — force classic execution on Linux for testing without enabling PAL.
## Other fixes
- Fix child graph execution on the classic path when segments_ is empty.
- Fix device retain/release imbalance in GraphExecClassic::Init() (cycle detection / early-return paths).
- Fix ihipGraphDebugDotPrint namespace mismatch causing link errors in CI.
- Restore root node cloning and inline comments lost during refactor.
- Move shared members (parallel_streams_, CreateStreams, etc.) to GraphExecBase.

## Test plan
## Run graph tests with all scheduling modes on gfx942:
DEBUG_HIP_GRAPH_SEGMENT_SCHEDULING=0 (auto/hybrid, default)
DEBUG_HIP_GRAPH_SEGMENT_SCHEDULING=1 (force round-robin)
DEBUG_HIP_GRAPH_SEGMENT_SCHEDULING=2 (force DFS)
Verify classic path with DEBUG_HIP_GRAPH_CLASSIC_PATH=1 on Linux — no regressions vs segmented path (GraphsTest1)

 ## Verify PAL/classic path (cycle detection, device retain balance)
Test results
All scheduling modes pass 382/382 graph tests locally on gfx942. Classic path on Linux shows identical failure set to segmented path (no new regressions).

