### PR TITLE
[rocprofiler-compute] Consolidate code-object tracing into SdkCallbacks

### DIFF
--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/rocprofiler_compute_tool.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/rocprofiler_compute_tool.cpp
@@ -87,20 +87,6 @@ void tool_tracing_callback(rocprofiler_callback_tracing_record_t record,
                            rocprofiler_user_data_t* /*user_data*/,
                            void* callback_data)
 {
-    if (record.kind == ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT &&
-        record.phase == ROCPROFILER_CALLBACK_PHASE_LOAD && record.operation == ROCPROFILER_CODE_OBJECT_LOAD)
-    {
-        assert(callback_data);
-        auto* tool_data = static_cast<std::unique_ptr<tool_data_t>*>(callback_data)->get();
-        if (tool_data->pc_sampling.enabled())
-        {
-            assert(record.payload);
-            const auto* obj_data = static_cast<rocprofiler_callback_tracing_code_object_load_data_t*>(
-                record.payload);
-            tool_data->pc_sampling.on_code_object_load(*obj_data);
-        }
-        return;
-    }
     g_sdk_callbacks->tool_tracing_callback(record, callback_data);
 }
 

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/sdk_callbacks.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/sdk_callbacks.cpp
@@ -14,6 +14,7 @@
 
 using namespace rocprofiler_compute_tool;
 using kernel_symbol_data_t = rocprofiler_callback_tracing_code_object_kernel_symbol_register_data_t;
+using code_object_load_data_t = rocprofiler_callback_tracing_code_object_load_data_t;
 
 SdkCallbacksImpl::SdkCallbacksImpl(const std::shared_ptr<SdkWrapper>& sdk_wrapper)
     : m_sdk_wrapper(sdk_wrapper)
@@ -316,15 +317,25 @@ void SdkCallbacksImpl::record_callback(rocprofiler_dispatch_counting_service_dat
 void SdkCallbacksImpl::tool_tracing_callback(rocprofiler_callback_tracing_record_t record,
                                              void*                                 callback_data)
 {
-    if (record.phase == ROCPROFILER_CALLBACK_PHASE_LOAD &&
-        record.kind == ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT &&
-        record.operation == ROCPROFILER_CODE_OBJECT_DEVICE_KERNEL_SYMBOL_REGISTER)
+    if (record.phase != ROCPROFILER_CALLBACK_PHASE_LOAD ||
+        record.kind != ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT)
+        return;
+
+    auto* tool = static_cast<std::unique_ptr<tool_data_t>*>(callback_data)->get();
+
+    if (record.operation == ROCPROFILER_CODE_OBJECT_LOAD)
+    {
+        if (tool->pc_sampling.enabled())
+        {
+            const auto* obj_data = static_cast<code_object_load_data_t*>(record.payload);
+            tool->pc_sampling.on_code_object_load(*obj_data);
+        }
+    }
+    else if (record.operation == ROCPROFILER_CODE_OBJECT_DEVICE_KERNEL_SYMBOL_REGISTER)
     {
         auto* data = static_cast<kernel_symbol_data_t*>(record.payload);
         // check if regex can be found in kernel name matches regex from tool data,
         // if matches store kernel id
-        auto* tool_data_ptr = static_cast<std::unique_ptr<tool_data_t>*>(callback_data);
-        auto* tool          = tool_data_ptr->get();
         // Lock before modifying target_kernel_ids
         std::lock_guard<std::mutex> lock(tool->mut);
         if (!tool->kernel_filter_include_regex.empty())

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/sdk_callbacks.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/sdk_callbacks.cpp
@@ -7,6 +7,7 @@
 #include <cxxabi.h>
 
 #include <algorithm>
+#include <cassert>
 #include <iostream>
 #include <map>
 #include <regex>
@@ -321,12 +322,14 @@ void SdkCallbacksImpl::tool_tracing_callback(rocprofiler_callback_tracing_record
         record.kind != ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT)
         return;
 
+    assert(callback_data);
     auto* tool = static_cast<std::unique_ptr<tool_data_t>*>(callback_data)->get();
 
     if (record.operation == ROCPROFILER_CODE_OBJECT_LOAD)
     {
         if (tool->pc_sampling.enabled())
         {
+            assert(record.payload);
             const auto* obj_data = static_cast<code_object_load_data_t*>(record.payload);
             tool->pc_sampling.on_code_object_load(*obj_data);
         }

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.cpp
@@ -266,3 +266,11 @@ const std::vector<MockCountersWriter::write_counters_info>& MockCountersWriter::
 {
     return m_write_counters_args;
 }
+
+void MockPcSamplingCollector::on_code_object_load(
+    const rocprofiler_callback_tracing_code_object_load_data_t& /*info*/)
+{
+    ++load_count;
+}
+
+void MockPcSamplingCollector::write(rocprofiler_compute_tool::code_object_writer_t& /*writer*/) {}

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.h
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.h
@@ -149,3 +149,12 @@ public:
 private:
     std::vector<write_counters_info> m_write_counters_args;
 };
+
+class MockPcSamplingCollector : public rocprofiler_compute_tool::pc_sampling_collector_t
+{
+public:
+    void on_code_object_load(const rocprofiler_callback_tracing_code_object_load_data_t& info) override;
+    void write(rocprofiler_compute_tool::code_object_writer_t& writer) override;
+
+    int load_count = 0;
+};

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_sdk_callbacks.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_sdk_callbacks.cpp
@@ -165,22 +165,6 @@ TEST_F(TestSdkCallbacks, ProvidedTracingRecord_ToolTracingCbReturnsKernelIdsFrom
     EXPECT_EQ(*(++m_tool_data->target_kernel_ids.cbegin()), kernel_id_1);
 }
 
-namespace
-{
-class MockPcSamplingCollector : public pc_sampling_collector_t
-{
-public:
-    void on_code_object_load(const rocprofiler_callback_tracing_code_object_load_data_t& /*info*/) override
-    {
-        ++load_count;
-    }
-
-    void write(code_object_writer_t& /*writer*/) override {}
-
-    int load_count = 0;
-};
-}  // namespace
-
 TEST_F(TestSdkCallbacks, ProvidedCodeObjectLoadWithPcSamplingEnabled_ForwardsToCollector)
 {
     auto collector = std::make_shared<MockPcSamplingCollector>();

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_sdk_callbacks.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_sdk_callbacks.cpp
@@ -165,6 +165,39 @@ TEST_F(TestSdkCallbacks, ProvidedTracingRecord_ToolTracingCbReturnsKernelIdsFrom
     EXPECT_EQ(*(++m_tool_data->target_kernel_ids.cbegin()), kernel_id_1);
 }
 
+namespace
+{
+class MockPcSamplingCollector : public pc_sampling_collector_t
+{
+public:
+    void on_code_object_load(const rocprofiler_callback_tracing_code_object_load_data_t& /*info*/) override
+    {
+        ++load_count;
+    }
+
+    void write(code_object_writer_t& /*writer*/) override {}
+
+    int load_count = 0;
+};
+}  // namespace
+
+TEST_F(TestSdkCallbacks, ProvidedCodeObjectLoadWithPcSamplingEnabled_ForwardsToCollector)
+{
+    auto collector = std::make_shared<MockPcSamplingCollector>();
+    m_tool_data->pc_sampling = pc_sampling_feature_t{PcSamplingMode::HostTrap, "unused.json", collector};
+
+    rocprofiler_callback_tracing_record_t                record  = {};
+    rocprofiler_callback_tracing_code_object_load_data_t payload = {};
+    record.phase                                                 = ROCPROFILER_CALLBACK_PHASE_LOAD;
+    record.kind      = ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT;
+    record.operation = ROCPROFILER_CODE_OBJECT_LOAD;
+    record.payload   = &payload;
+
+    m_sdk_callbacks->tool_tracing_callback(record, &m_tool_data);
+
+    EXPECT_EQ(collector->load_count, 1);
+}
+
 TEST_P(TestSdkCallbacksKernelFiltering, ProvidedKernelFilteringEnabled_ReturnsKernelIdsOnlyForMathing)
 {
     constexpr uint64_t kernel_id_0           = 10;


### PR DESCRIPTION
## Motivation

Code-object LOAD / pc_sampling handling lived in the free-function callback shim, bypassing the mockable `SdkCallbacks` layer the unit tests exercise, so it shipped untested. Move it into `SdkCallbacksImpl` so all code-object tracing logic lives in one tested place.

## Technical Details

- `sdk_callbacks.cpp`: `SdkCallbacksImpl::tool_tracing_callback` now handles both code-object operations behind a shared phase/kind guard, then `if/else if` on operation (LOAD -> pc_sampling, DEVICE_KERNEL_SYMBOL_REGISTER -> kernel filtering).
- `rocprofiler_compute_tool.cpp`: `tool_tracing_callback` restored to a one-line forwarder, matching `dispatch_callback`/`record_callback`.
- `test_sdk_callbacks.cpp`: add `ProvidedCodeObjectLoadWithPcSamplingEnabled_ForwardsToCollector` covering the previously untested LOAD path.

## JIRA ID

## Test Plan

- Build with `-DENABLE_TESTS=ON` and run `test-rocprofiler-compute-tool`.

## Test Result

All 58 gtests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.