### PR TITLE
[rocprofiler-systems] extend C++20 concept conversions (SFINAE/traits sweep)

### DIFF
--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.hpp
@@ -278,7 +278,8 @@ TIMEMORY_CEREAL_SAVE_FUNCTION_NAME(SettingsTextArchive&, const std::nullptr_t&)
 {}
 
 //! Saving for arithmetic
-template <typename T, traits::EnableIf<std::is_arithmetic<T>::value> = traits::sfinae>
+template <typename T>
+    requires std::is_arithmetic_v<T>
 inline void
 TIMEMORY_CEREAL_SAVE_FUNCTION_NAME(SettingsTextArchive& ar, const T& t)
 {

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/get_availability.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/get_availability.hpp
@@ -22,38 +22,23 @@
 struct unknown
 {};
 
-template <typename T, typename U = typename T::value_type>
-constexpr bool
-available_value_type_alias(int)
-{
-    return true;
-}
-
-template <typename T, typename U = unknown>
-constexpr bool
-available_value_type_alias(long)
-{
-    return false;
-}
-
-template <typename Type, bool>
-struct component_value_type;
+template <typename T>
+concept has_value_type = requires { typename T::value_type; };
 
 template <typename Type>
-struct component_value_type<Type, true>
+struct component_value_type
+{
+    using type = unknown;
+};
+
+template <has_value_type Type>
+struct component_value_type<Type>
 {
     using type = typename Type::value_type;
 };
 
 template <typename Type>
-struct component_value_type<Type, false>
-{
-    using type = unknown;
-};
-
-template <typename Type>
-using component_value_type_t =
-    typename component_value_type<Type, available_value_type_alias<Type>(0)>::type;
+using component_value_type_t = typename component_value_type<Type>::type;
 
 //--------------------------------------------------------------------------------------//
 

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/info.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/info.hpp
@@ -28,8 +28,8 @@ dump_info(std::ostream& _os, const fmodset_t& _data)
     module_function::reset_width();
 }
 //
-template <typename ArchiveT,
-          std::enable_if_t<tim::concepts::is_archive<ArchiveT>::value, int> = 0>
+template <typename ArchiveT>
+    requires tim::concepts::is_archive<ArchiveT>::value
 static inline void
 dump_info(ArchiveT& _ar, const fmodset_t& _data)
 {

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.hpp
@@ -34,7 +34,8 @@ to_lower(string_t s)
 //
 //======================================================================================//
 //
-template <typename Tp, std::enable_if_t<!std::is_same<Tp, std::string>::value, int> = 0>
+template <typename Tp>
+    requires(!std::is_same_v<Tp, std::string>)
 snippet_pointer_t
 get_snippet(Tp arg)
 {
@@ -43,7 +44,8 @@ get_snippet(Tp arg)
 //
 //======================================================================================//
 //
-template <typename Tp, std::enable_if_t<std::is_same<Tp, std::string>::value, int> = 0>
+template <typename Tp>
+    requires std::is_same_v<Tp, std::string>
 snippet_pointer_t
 get_snippet(const Tp& arg)
 {

--- a/projects/rocprofiler-systems/source/lib/binary/address_multirange.hpp
+++ b/projects/rocprofiler-systems/source/lib/binary/address_multirange.hpp
@@ -26,6 +26,8 @@ struct address_multirange
     address_multirange& operator+=(address_range _v);
 
     template <typename Tp>
+        requires(std::is_integral_v<concepts::unqualified_type_t<Tp>> ||
+                 std::is_same_v<concepts::unqualified_type_t<Tp>, address_range>)
     bool contains(Tp&& _v) const;
 
     auto size() const { return m_fine_ranges.size(); }
@@ -40,14 +42,11 @@ private:
 };
 
 template <typename Tp>
+    requires(std::is_integral_v<concepts::unqualified_type_t<Tp>> ||
+             std::is_same_v<concepts::unqualified_type_t<Tp>, address_range>)
 ROCPROFSYS_INLINE bool
 address_multirange::contains(Tp&& _v) const
 {
-    using type = concepts::unqualified_type_t<Tp>;
-    static_assert(std::is_integral<type>::value ||
-                      std::is_same<type, address_range>::value,
-                  "Error! operator+= supports only integrals or address_ranges");
-
     if(!m_coarse_range.contains(_v)) return false;
     return std::any_of(m_fine_ranges.begin(), m_fine_ranges.end(),
                        [_v](auto&& itr) { return itr.contains(_v); });

--- a/projects/rocprofiler-systems/source/lib/common/delimit.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/delimit.hpp
@@ -14,48 +14,44 @@ inline namespace common
 namespace
 {
 template <typename ContainerT, typename... Args>
+concept has_emplace_back = requires(ContainerT& _c, Args&&... _args) {
+    _c.emplace_back(std::forward<Args>(_args)...);
+};
+
+template <typename ContainerT, typename... Args>
+    requires has_emplace_back<ContainerT, Args...>
 inline auto
-emplace_impl(ContainerT& _c, int,
-             Args&&... _args) -> decltype(_c.emplace_back(std::forward<Args>(_args)...))
+emplace(ContainerT& _c, Args&&... _args)
 {
     return _c.emplace_back(std::forward<Args>(_args)...);
 }
 
 template <typename ContainerT, typename... Args>
+    requires(!has_emplace_back<ContainerT, Args...>)
 inline auto
-emplace_impl(ContainerT& _c, long,
-             Args&&... _args) -> decltype(_c.emplace(std::forward<Args>(_args)...))
+emplace(ContainerT& _c, Args&&... _args)
 {
     return _c.emplace(std::forward<Args>(_args)...);
 }
 
-template <typename ContainerT, typename... Args>
-inline auto
-emplace(ContainerT& _c, Args&&... _args)
-{
-    return emplace_impl(_c, 0, std::forward<Args>(_args)...);
-}
+template <typename ContainerT, typename ArgT>
+concept has_reserve = requires(ContainerT& _c, ArgT _arg) { _c.reserve(_arg); };
 
 template <typename ContainerT, typename ArgT>
-inline auto
-reserve_impl(ContainerT& _c, int, ArgT _arg) -> decltype(_c.reserve(_arg), bool())
+    requires has_reserve<ContainerT, ArgT>
+inline bool
+reserve(ContainerT& _c, ArgT _arg)
 {
     _c.reserve(_arg);
     return true;
 }
 
 template <typename ContainerT, typename ArgT>
-inline auto
-reserve_impl(ContainerT&, long, ArgT)
+    requires(!has_reserve<ContainerT, ArgT>)
+inline bool
+reserve(ContainerT&, ArgT)
 {
     return false;
-}
-
-template <typename ContainerT, typename ArgT>
-inline auto
-reserve(ContainerT& _c, ArgT _arg)
-{
-    return reserve_impl(_c, 0, _arg);
 }
 
 template <typename ContainerT = std::vector<std::string>>

--- a/projects/rocprofiler-systems/source/lib/common/environment.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/environment.hpp
@@ -654,13 +654,14 @@ enum class update_mode : std::uint8_t
 ///        strings pass through.
 /// @return The string representation of @p val.
 template <typename Tp>
+    requires(std::is_same_v<std::decay_t<Tp>, std::string> ||
+             std::is_same_v<std::decay_t<Tp>, const char*> ||
+             std::is_same_v<std::decay_t<Tp>, bool> ||
+             std::is_arithmetic_v<std::decay_t<Tp>>)
 inline std::string
 to_env_string(Tp&& val)
 {
     using T = std::decay_t<Tp>;
-    static_assert(std::is_same_v<T, std::string> || std::is_same_v<T, const char*> ||
-                      std::is_same_v<T, bool> || std::is_arithmetic_v<T>,
-                  "to_env_string: unsupported type. Use string, bool, or numeric types.");
 
     if constexpr(std::is_same_v<T, std::string> || std::is_same_v<T, const char*>)
         return std::string{ val };

--- a/projects/rocprofiler-systems/source/lib/common/join.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/join.hpp
@@ -12,6 +12,8 @@
 #include <tuple>
 #include <type_traits>
 
+#include "traits.hpp"
+
 #if !defined(ROCPROFSYS_FOLD_EXPRESSION)
 #    define ROCPROFSYS_FOLD_EXPRESSION(...) ((__VA_ARGS__), ...)
 #endif
@@ -22,32 +24,8 @@ inline namespace common
 {
 namespace
 {
-template <typename Tp>
-struct is_string_impl : std::false_type
-{};
-
-template <>
-struct is_string_impl<std::string> : std::true_type
-{};
-
-template <>
-struct is_string_impl<std::string_view> : std::true_type
-{};
-
-template <>
-struct is_string_impl<const char*> : std::true_type
-{};
-
-template <>
-struct is_string_impl<char*> : std::true_type
-{};
-
-template <typename Tp>
-struct is_string : is_string_impl<std::remove_cv_t<std::decay_t<Tp>>>
-{};
-
 template <typename ArgT>
-    requires(is_string<ArgT>::value)
+    requires traits::string_literal<ArgT>
 auto
 as_string(const ArgT& _v)
 {
@@ -63,7 +41,7 @@ as_string(const ArgT& _v)
 }
 
 template <typename ArgT>
-    requires(!is_string<ArgT>::value)
+    requires(!traits::string_literal<ArgT>)
 auto
 as_string(const ArgT& _v)
 {

--- a/projects/rocprofiler-systems/source/lib/common/synchronized.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/synchronized.hpp
@@ -55,9 +55,11 @@ public:
     synchronized(const synchronized&) = delete;
 
     template <typename FuncT, typename... Args>
+        requires std::is_invocable_v<FuncT, const LockedType&, Args...>
     decltype(auto) rlock(FuncT&& lambda, Args&&... args) const;
 
     template <typename FuncT, typename... Args>
+        requires std::is_invocable_v<FuncT, LockedType&, Args...>
     decltype(auto) wlock(FuncT&& lambda, Args&&... args);
 
     // This overload to wlock allows a synchronized map whose keys map to synchronized
@@ -69,6 +71,8 @@ public:
     // Upgradable lock. If read returns false, write will be called with a unique_lock.
     // Essentially a helper function that does .rlock() followed by .wlock().
     template <typename ReadFuncT, typename WriteFuncT, typename... Args>
+        requires(std::is_invocable_v<ReadFuncT, const LockedType&, Args...> &&
+                 std::is_invocable_v<WriteFuncT, LockedType&, Args...>)
     bool ulock(ReadFuncT&& read, WriteFuncT&& write, Args&&... args);
 
 private:
@@ -81,24 +85,20 @@ private:
 //
 template <typename LockedType, bool IsMappedTypeV>
 template <typename FuncT, typename... Args>
+    requires std::is_invocable_v<FuncT, const LockedType&, Args...>
 decltype(auto)
 synchronized<LockedType, IsMappedTypeV>::rlock(FuncT&& lambda, Args&&... args) const
 {
-    static_assert(std::is_invocable<FuncT, const value_type&, Args...>::value,
-                  "function must accept const reference to locked type");
-
     auto lock = std::shared_lock{ m_mutex };
     return std::forward<FuncT>(lambda)(m_data, std::forward<Args>(args)...);
 }
 
 template <typename LockedType, bool IsMappedTypeV>
 template <typename FuncT, typename... Args>
+    requires std::is_invocable_v<FuncT, LockedType&, Args...>
 decltype(auto)
 synchronized<LockedType, IsMappedTypeV>::wlock(FuncT&& lambda, Args&&... args)
 {
-    static_assert(std::is_invocable<FuncT, value_type&, Args...>::value,
-                  "function must accept reference to locked type");
-
     auto lock = std::unique_lock{ m_mutex };
     return std::forward<FuncT>(lambda)(m_data, std::forward<Args>(args)...);
 }
@@ -119,15 +119,12 @@ synchronized<LockedType, IsMappedTypeV>::wlock(FuncT&& lambda, Args&&... args) c
 // Essentially a helper function that does .rlock() followed by .wlock().
 template <typename LockedType, bool IsMappedTypeV>
 template <typename ReadFuncT, typename WriteFuncT, typename... Args>
+    requires(std::is_invocable_v<ReadFuncT, const LockedType&, Args...> &&
+             std::is_invocable_v<WriteFuncT, LockedType&, Args...>)
 bool
 synchronized<LockedType, IsMappedTypeV>::ulock(ReadFuncT&& read, WriteFuncT&& write,
                                                Args&&... args)
 {
-    static_assert(std::is_invocable<ReadFuncT, const value_type&, Args...>::value,
-                  "read function must accept const reference to locked type");
-    static_assert(std::is_invocable<WriteFuncT, value_type&, Args...>::value,
-                  "write function must accept reference to locked type");
-
     using read_return_type  = std::invoke_result_t<ReadFuncT, const value_type&, Args...>;
     using write_return_type = std::invoke_result_t<WriteFuncT, value_type&, Args...>;
 

--- a/projects/rocprofiler-systems/source/lib/common/traits.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/traits.hpp
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: MIT
 
 #pragma once
+#include <concepts>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <type_traits>
 
 namespace rocprofsys
@@ -12,40 +14,17 @@ inline namespace common
 {
 namespace traits
 {
-
-namespace
-{
 template <typename T>
-struct is_string_literal_impl : std::false_type
-{};
-
-template <>
-struct is_string_literal_impl<std::string_view> : std::true_type
-{};
-
-template <>
-struct is_string_literal_impl<const char*> : std::true_type
-{};
-
-template <>
-struct is_string_literal_impl<char*> : std::true_type
-{};
-
-template <>
-struct is_string_literal_impl<std::string> : std::true_type
-{};
-
-template <typename T>
-inline constexpr bool is_string_literal_impl_v = is_string_literal_impl<T>::value;
-
-}  // namespace
+concept string_literal =
+    std::same_as<std::decay_t<T>, std::string> ||
+    std::same_as<std::decay_t<T>, std::string_view> ||
+    std::same_as<std::decay_t<T>, const char*> || std::same_as<std::decay_t<T>, char*>;
 
 template <typename T>
 constexpr bool
 is_string_literal()
 {
-    using Tp = std::decay_t<T>;
-    return is_string_literal_impl_v<Tp>;
+    return string_literal<T>;
 }
 
 template <typename T>
@@ -58,7 +37,6 @@ struct is_optional<std::optional<T>> : std::true_type
 
 template <typename T>
 inline constexpr bool is_optional_v = is_optional<T>::value;
-
 }  // namespace traits
 }  // namespace common
 }  // namespace rocprofsys

--- a/projects/rocprofiler-systems/source/lib/core/concepts.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/concepts.hpp
@@ -59,30 +59,7 @@ struct is_unique_pointer<std::unique_ptr<Tp>> : std::true_type
 {};
 
 template <typename Tp>
-struct is_optional : std::false_type
-{};
-
-template <typename Tp>
-struct is_optional<std::optional<Tp>> : std::true_type
-{};
-
-template <typename Tp>
-struct can_stringify
-{
-private:
-    static constexpr auto sfinae(int) -> decltype(std::declval<std::ostream&>()
-                                                      << std::declval<Tp>(),
-                                                  bool())
-    {
-        return true;
-    }
-
-    static constexpr auto sfinae(long) { return false; }
-
-public:
-    static constexpr bool value = sfinae(0);
-    constexpr auto        operator()() const { return sfinae(0); }
-};
+concept can_stringify = requires(std::ostream& _os, const Tp& _v) { _os << _v; };
 
 template <size_t N, typename Tp, bool>
 struct tuple_element_impl;

--- a/projects/rocprofiler-systems/source/lib/core/concepts.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/concepts.hpp
@@ -59,7 +59,7 @@ struct is_unique_pointer<std::unique_ptr<Tp>> : std::true_type
 {};
 
 template <typename Tp>
-concept can_stringify = requires(std::ostream& _os, const Tp& _v) { _os << _v; };
+concept string_like = requires(std::ostream& _os, const Tp& _v) { _os << _v; };
 
 template <size_t N, typename Tp, bool>
 struct tuple_element_impl;

--- a/projects/rocprofiler-systems/source/lib/core/demangler.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/demangler.hpp
@@ -27,7 +27,12 @@ struct cxa_demangle_wrapper_impl
     }
 };
 
-template <typename DemanglerTp = cxa_demangle_wrapper_impl>
+template <typename T>
+concept demangle_backend = requires(const char* _m, char* _o, size_t* _l, int* _s) {
+    T::demangle(_m, _o, _l, _s);
+};
+
+template <demangle_backend DemanglerTp = cxa_demangle_wrapper_impl>
 struct demangler
 {
     template <typename Tp>

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/cache_type_traits.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/cache_type_traits.hpp
@@ -117,6 +117,9 @@ inline constexpr bool is_supported_type_v =
     is_string_view_v<T> || is_vector_v<T> || is_optional_v<T> || is_array_v<T>;
 
 template <typename T>
+concept supported_cache_type = is_supported_type_v<std::decay_t<T>>;
+
+template <typename T>
 struct is_enum_class
 : std::bool_constant<std::is_enum_v<T> &&
                      !std::is_convertible_v<T, std::underlying_type_t<T>>>

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/cacheable.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/cacheable.hpp
@@ -55,12 +55,11 @@ const auto get_metadata_filepath = [](const int& ppid, const int& pid) {
 };
 
 template <typename Type>
+    requires type_traits::supported_cache_type<Type>
 __attribute__((always_inline)) inline constexpr size_t
 get_size(Type&& val)
 {
     using DecayedType = std::decay_t<Type>;
-    static_assert(type_traits::is_supported_type_v<DecayedType>,
-                  "Unsupported type in get_size");
 
     if constexpr(type_traits::is_string_view_v<DecayedType> ||
                  type_traits::is_vector_v<DecayedType> ||
@@ -93,12 +92,11 @@ get_size(Type&& val, Types&&... vals)
 }
 
 template <typename Type>
+    requires type_traits::supported_cache_type<Type>
 __attribute__((always_inline)) inline void
 store_value(const Type& value, std::uint8_t* buffer, size_t& position)
 {
     using DecayedType = std::decay_t<Type>;
-    static_assert(type_traits::is_supported_type_v<DecayedType>,
-                  "Unsupported type in store_value");
 
     auto* dest = buffer + position;
 
@@ -140,12 +138,11 @@ store_value(std::uint8_t* buffer, const Types&... values)
 }
 
 template <typename Type>
+    requires type_traits::supported_cache_type<Type>
 __attribute__((always_inline)) inline static void
 parse_value(std::uint8_t*& data_pos, Type& arg)
 {
     using DecayedType = std::decay_t<Type>;
-    static_assert(type_traits::is_supported_type_v<DecayedType>,
-                  "Unsupported type in parse_value");
 
     if constexpr(type_traits::is_string_view_v<DecayedType>)
     {

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/sample_processor.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/sample_processor.hpp
@@ -124,13 +124,11 @@ struct processor_view_t
     };
 
     template <typename T>
+        requires std::is_base_of_v<processor_t<T>, T>
     explicit processor_view_t(T& t) noexcept
     : m_object{ std::addressof(t) }
     , m_vtable{ std::addressof(get_vtable_for_type<T>()) }
-    {
-        static_assert(std::is_base_of<processor_t<T>, T>::value,
-                      "Type must be derived from processor_t<T>");
-    }
+    {}
 
     processor_view_t(const processor_view_t&) noexcept            = default;
     processor_view_t(processor_view_t&&) noexcept                 = default;

--- a/projects/rocprofiler-systems/source/lib/core/utility.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/utility.cpp
@@ -13,26 +13,23 @@ namespace utility
 namespace
 {
 template <typename ContainerT, typename Arg>
-auto
-emplace_impl(ContainerT& _targ, Arg&& _v,
-             int) -> decltype(_targ.emplace(std::forward<Arg>(_v)))
+concept has_emplace =
+    requires(ContainerT& _targ, Arg&& _v) { _targ.emplace(std::forward<Arg>(_v)); };
+
+template <typename ContainerT, typename Arg>
+    requires has_emplace<ContainerT, Arg>
+decltype(auto)
+emplace(ContainerT& _targ, Arg&& _v)
 {
     return _targ.emplace(std::forward<Arg>(_v));
 }
 
 template <typename ContainerT, typename Arg>
-auto
-emplace_impl(ContainerT& _targ, Arg&& _v,
-             long) -> decltype(_targ.emplace_back(std::forward<Arg>(_v)))
-{
-    return _targ.emplace_back(std::forward<Arg>(_v));
-}
-
-template <typename ContainerT, typename Arg>
+    requires(!has_emplace<ContainerT, Arg>)
 decltype(auto)
 emplace(ContainerT& _targ, Arg&& _v)
 {
-    return emplace_impl(_targ, std::forward<Arg>(_v), 0);
+    return _targ.emplace_back(std::forward<Arg>(_v));
 }
 }  // namespace
 

--- a/projects/rocprofiler-systems/source/lib/core/utility.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/utility.hpp
@@ -188,12 +188,10 @@ combine(LhsT& _lhs, RhsT&& _rhs)
 
 template <template <typename, typename...> class ContainerT, typename Tp,
           typename... TailT>
+    requires tim::concepts::is_string_type<Tp>::value
 std::string
 get_regex_or(const ContainerT<Tp, TailT...>& _container, const std::string& _fallback)
 {
-    static_assert(tim::concepts::is_string_type<Tp>::value,
-                  "get_regex_or requires a container of string types");
-
     if(_container.empty()) return _fallback;
 
     auto _ss  = std::stringstream{};
@@ -207,13 +205,11 @@ get_regex_or(const ContainerT<Tp, TailT...>& _container, const std::string& _fal
 
 template <template <typename, typename...> class ContainerT, typename Tp,
           typename... TailT, typename PredicateT>
+    requires tim::concepts::is_string_type<Tp>::value
 std::string
 get_regex_or(const ContainerT<Tp, TailT...>& _container, PredicateT&& _predicate,
              const std::string& _fallback)
 {
-    static_assert(tim::concepts::is_string_type<Tp>::value,
-                  "get_regex_or requires a container of string types");
-
     if(_container.empty()) return _fallback;
 
     auto _dest = std::vector<std::string>{};

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/sampling.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/sampling.cpp
@@ -459,14 +459,10 @@ sampling_signals()
 }  // namespace
 
 template <typename ScopeT>
+    requires sampling_scope<ScopeT>
 void
 pause(ScopeT)
 {
-    static_assert(
-        tim::is_one_of<ScopeT,
-                       type_list<scope::thread_scope, scope::process_scope>>::value,
-        "Unsupported scope");
-
     if constexpr(std::is_same<ScopeT, scope::thread_scope>::value)
     {
         if(!_thread_paused) _thread_paused = false;
@@ -499,14 +495,10 @@ pause(ScopeT)
 }
 
 template <typename ScopeT>
+    requires sampling_scope<ScopeT>
 void
 resume(ScopeT)
 {
-    static_assert(
-        tim::is_one_of<ScopeT,
-                       type_list<scope::thread_scope, scope::process_scope>>::value,
-        "Unsupported scope");
-
     if constexpr(std::is_same<ScopeT, scope::thread_scope>::value)
     {
         if(!_thread_paused) _thread_paused = true;

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/sampling.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/causal/sampling.hpp
@@ -32,10 +32,16 @@ block_backtrace_samples();
 void
 unblock_backtrace_samples();
 
+template <typename Tp>
+concept sampling_scope = std::is_same_v<Tp, tim::scope::thread_scope> ||
+                         std::is_same_v<Tp, tim::scope::process_scope>;
+
 template <typename Tp = tim::scope::thread_scope>
+    requires sampling_scope<Tp>
 void pause(Tp = {});
 
 template <typename Tp = tim::scope::thread_scope>
+    requires sampling_scope<Tp>
 void resume(Tp = {});
 
 void block_signals(std::set<int> = {});

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/backtrace_metrics.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/backtrace_metrics.hpp
@@ -85,6 +85,7 @@ struct backtrace_metrics : comp::empty_base
     bool operator()(Tp) const;
 
     template <typename Tp>
+        requires(!concepts::is_type_listing<Tp>::value)
     bool operator()(type_list<Tp>) const;
 
     auto        get_valid() const { return m_valid; }
@@ -123,12 +124,10 @@ backtrace_metrics::get_valid(type_list<Tp>, valid_array_t _valid)
 }
 
 template <typename Tp>
+    requires(!concepts::is_type_listing<Tp>::value)
 bool
 backtrace_metrics::operator()(type_list<Tp>) const
 {
-    static_assert(!concepts::is_type_listing<Tp>::value,
-                  "Error! invalid call with tuple");
-
     constexpr auto idx = tim::index_of<Tp, categories_t>::value;
     return m_valid.test(idx);
 }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_mutex_gotcha.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_mutex_gotcha.hpp
@@ -21,6 +21,11 @@
 namespace rocprofsys::component
 {
 
+template <typename Lock>
+concept pthread_lock_type =
+    std::is_same_v<Lock, pthread_mutex_t> || std::is_same_v<Lock, pthread_spinlock_t> ||
+    std::is_same_v<Lock, pthread_rwlock_t> || std::is_same_v<Lock, pthread_barrier_t>;
+
 template <typename Policy>
 struct pthread_mutex_gotcha : tim::component::base<pthread_mutex_gotcha<Policy>, void>
 {
@@ -93,12 +98,7 @@ struct pthread_mutex_gotcha : tim::component::base<pthread_mutex_gotcha<Policy>,
 
     static void resume() { s_is_paused.store(false, std::memory_order_relaxed); }
 
-    template <typename Lock,
-              std::enable_if_t<std::disjunction_v<std::is_same<Lock, pthread_mutex_t>,
-                                                  std::is_same<Lock, pthread_spinlock_t>,
-                                                  std::is_same<Lock, pthread_rwlock_t>,
-                                                  std::is_same<Lock, pthread_barrier_t>>,
-                               int> = 0>
+    template <pthread_lock_type Lock>
     [[nodiscard]] int operator()(int (*_callee)(Lock*), Lock* _lock) const
     {
         return (Policy::inactive_state() || m_protect)

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/common/collector_slice.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/common/collector_slice.hpp
@@ -8,6 +8,16 @@
 namespace rocprofsys::pmc::collectors
 {
 
+template <typename T>
+concept collector_type = requires(T& _c, std::int64_t _ts) {
+    _c.setup();
+    _c.config();
+    _c.sample(_ts);
+    _c.post_process();
+    _c.shutdown();
+    _c.pause(_ts);
+};
+
 /**
  * @brief Type-erased collector slice - non-owning view of any collector type.
  *
@@ -48,7 +58,7 @@ public:
      * methods)
      * @param obj Reference to the collector object (must outlive the slice)
      */
-    template <typename T>
+    template <collector_type T>
     explicit collector_slice(T& obj)
     : m_object{ &obj }
     , m_setup_impl{ [](void* ptr) { static_cast<T*>(ptr)->setup(); } }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/device_providers/amd_smi/provider.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/device_providers/amd_smi/provider.hpp
@@ -29,7 +29,13 @@ namespace rocprofsys::pmc::device_providers::amd_smi
  *
  * @tparam DriverFactory Factory for creating AMD SMI driver instances.
  */
-template <typename DriverFactory>
+template <typename T>
+concept driver_factory = requires {
+    typename T::driver_t;
+    T::create_driver();
+};
+
+template <driver_factory DriverFactory>
 class provider
 {
 private:

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/device_providers/procfs/provider.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/device_providers/procfs/provider.hpp
@@ -26,7 +26,13 @@ namespace rocprofsys::pmc::device_providers::procfs
  *
  * @tparam DriverFactory Factory for creating procfs driver instances.
  */
-template <typename DriverFactory>
+template <typename T>
+concept driver_factory = requires(size_t _n) {
+    typename T::driver_t;
+    T::create_driver(_n);
+};
+
+template <driver_factory DriverFactory>
 class provider
 {
 public:

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/device_providers/rocprofiler_sdk/provider.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/device_providers/rocprofiler_sdk/provider.hpp
@@ -21,7 +21,13 @@
 namespace rocprofsys::pmc::device_providers::rocprofiler_sdk
 {
 
-template <typename DriverFactory>
+template <typename T>
+concept driver_factory = requires {
+    typename T::driver_t;
+    T::create_driver();
+};
+
+template <driver_factory DriverFactory>
 class provider
 {
 public:

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk/rccl_internal.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk/rccl_internal.hpp
@@ -84,7 +84,11 @@ struct rccl_event_info
  *   Testing:    rccl_gpu_tracking_state_t<mock_pmc_registrar> state(mock);
  *               rccl_gpu_tracking_state_t<mock_pmc_registrar> state(nullptr);
  */
-template <typename PmcRegistrar>
+template <typename T>
+concept pmc_registrar =
+    requires(T& _r, std::uint32_t _idx) { _r.register_gpu_pmc(_idx); };
+
+template <pmc_registrar PmcRegistrar>
 class rccl_gpu_tracking_state_t
 {
 public:

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/thread_data.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/thread_data.hpp
@@ -125,10 +125,9 @@ struct thread_data : base_thread_data<thread_data<Tp, Tag, MaxThreads>>
     void resize(size_t _n) { container::resize(m_data, _n, m_init()); }
 
     template <typename Up>
+        requires std::is_assignable_v<value_type, Up>
     void resize(size_t _n, Up&& _v)
     {
-        static_assert(std::is_assignable<value_type, Up>::value,
-                      "value is not assignable to optional<Tp>");
         container::resize(m_data, _n, std::forward<Up>(_v));
     }
 
@@ -277,10 +276,9 @@ struct thread_data<std::optional<Tp>, Tag, MaxThreads>
     void resize(size_t _n) { container::resize(m_data, _n, m_init()); }
 
     template <typename Up>
+        requires std::is_assignable_v<value_type, Up>
     void resize(size_t _n, Up&& _v)
     {
-        static_assert(std::is_assignable<value_type, Up>::value,
-                      "value is not assignable to optional<Tp>");
         container::resize(m_data, _n, std::forward<Up>(_v));
     }
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/tracing.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/tracing.hpp
@@ -89,17 +89,19 @@ auto&
 get_category_stack();
 
 template <typename T>
+    requires std::is_const_v<T>
 auto
 get_perfetto_string(T& name)
 {
-    if constexpr(std::is_const_v<T>)
-    {
-        return ::perfetto::StaticString{ name };
-    }
-    else
-    {
-        return ::perfetto::DynamicString{ name };
-    }
+    return ::perfetto::StaticString{ name };
+}
+
+template <typename T>
+    requires(!std::is_const_v<T>)
+auto
+get_perfetto_string(T& name)
+{
+    return ::perfetto::DynamicString{ name };
 }
 
 template <typename CategoryT, typename... Args>

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/tracing/annotation.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/tracing/annotation.hpp
@@ -114,7 +114,7 @@ add_perfetto_annotation(perfetto_event_context_t& ctx, Np&& _name, Tp&& _val,
     {
         _get_dbg()->set_pointer_value(reinterpret_cast<std::uint64_t>(_val));
     }
-    else if constexpr(concepts::can_stringify<value_type>::value)
+    else if constexpr(concepts::can_stringify<value_type>)
     {
         _get_dbg()->set_string_value(fmt::format("{}", std::forward<Tp>(_val)));
     }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/tracing/annotation.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/tracing/annotation.hpp
@@ -203,38 +203,28 @@ struct annotate<perfetto_event_context_t, Tp>
 {
     auto operator()(Tp& obj, perfetto_event_context_t& _ctx) const
     {
-        return sfinae(obj, 0, _ctx);
+        if constexpr(requires { obj.annotate(_ctx); })
+        {
+            return obj.annotate(_ctx);
+        }
+        else
+        {
+            using value_type = typename Tp::value_type;
+            if constexpr(!std::is_void_v<value_type>)
+            {
+                auto _obj_data = sfinae_data<Tp, decltype(obj.get())>(obj, 0);
+                for(size_t i = 0; i < std::get<0>(_obj_data); ++i)
+                {
+                    auto&& _label = std::get<1>(_obj_data).at(i);
+                    auto&& _value = std::get<2>(_obj_data).at(i);
+                    ::rocprofsys::tracing::add_perfetto_annotation(_ctx, _label, _value);
+                }
+            }
+            (void) _ctx;
+        }
     }
 
 private:
-    //  If the component has a annotate(...) member function
-    template <typename T>
-    static auto sfinae(T&                        obj, int,
-                       perfetto_event_context_t& _ctx) -> decltype(obj.annotate(_ctx))
-    {
-        static_assert(std::is_same<T, Tp>::value, "Error T != Tp");
-        return obj.annotate(_ctx);
-    }
-
-    //  If the component does not have a annotate(...) member function
-    template <typename T>
-    static void sfinae(T& obj, long, perfetto_event_context_t& _ctx)
-    {
-        static_assert(std::is_same<T, Tp>::value, "Error T != Tp");
-        using value_type = typename T::value_type;
-        if constexpr(!std::is_void<value_type>::value)
-        {
-            auto _obj_data = sfinae_data<Tp, decltype(obj.get())>(obj, 0);
-            for(size_t i = 0; i < std::get<0>(_obj_data); ++i)
-            {
-                auto&& _label = std::get<1>(_obj_data).at(i);
-                auto&& _value = std::get<2>(_obj_data).at(i);
-                ::rocprofsys::tracing::add_perfetto_annotation(_ctx, _label, _value);
-            }
-        }
-        (void) _ctx;
-    }
-
     template <typename T, typename DataT>
     static auto sfinae_data(T& obj, int)
         -> decltype(std::tuple<size_t, std::vector<std::string>, DataT>(obj.get().size(),

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/tracing/annotation.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/tracing/annotation.hpp
@@ -114,7 +114,7 @@ add_perfetto_annotation(perfetto_event_context_t& ctx, Np&& _name, Tp&& _val,
     {
         _get_dbg()->set_pointer_value(reinterpret_cast<std::uint64_t>(_val));
     }
-    else if constexpr(concepts::can_stringify<value_type>)
+    else if constexpr(concepts::string_like<value_type>)
     {
         _get_dbg()->set_string_value(fmt::format("{}", std::forward<Tp>(_val)));
     }


### PR DESCRIPTION
## Motivation

Stacked on #5992. Continues replacing the remaining pre-C++20 SFINAE / trait-struct / static_assert idioms across rocprofiler-systems with C++20 concepts and requires-clauses, for clearer constraints and call-site diagnostics. No behavior change - this is a constraint/expression refactor only.

## Technical Details

Shared concepts and dedup: introduced `string_literal` and `can_stringify` concepts and removed the duplicated `is_string_literal`/`is_string` trait structs. static_assert template guards converted to requires-clauses across trace_cache (`supported_cache_type`), environment, utility, synchronized (rlock/wlock/ulock), thread_data, backtrace_metrics, address_multirange, and causal/sampling (new `sampling_scope` concept). enable_if and detection idioms converted to concepts: instrument get_snippet/dump_info, avail and a `has_value_type` concept in get_availability, the pthread lock-type, annotation has-annotate (now `if constexpr(requires{...})`), and the delimit/utility int/long emplace/reserve tag-dispatch. Policy/CRTP duck-typed contracts are now named concepts: `collector_type`, `pmc_registrar`, `driver_factory` (shared shape across the amd_smi/procfs/rocprofiler_sdk providers), `demangle_backend`, and the processor CRTP check. Every out-of-line constrained member spells its requires-clause with identical tokens on declaration and definition, since GCC 10 (the RHEL 8.10 toolchain) does not normalize aliases in constraint-equivalence.

Deliberately not converted, as poor-ROI or behavior-changing: class-level constraints on classes with many out-of-line members (trace_cache buffer_storage/type_registry/storage_parser, stable_vector, marker_writer/roctx_client) keep their static_asserts; the `always_false` serialize/deserialize/get_size primary templates are kept (removing them would flip `serializable<T>` from always-true to conditional). One remaining item for a focused follow-up: converting the push/pop/mark_perfetto if-constexpr ladders in tracing.hpp to constrained overloads.

## JIRA

N/A

## Test Plan

Full build plus unit tests under the RHEL 8.10 toolchain (GCC 10.3) in the CI container, since GCC 10 is the strictest on C++20 constraint-equivalence and is where #5992's CI originally failed.

## Test Result

Full GCC-10 build clean (0 errors); unit-tests, annotate, causal-e2e, and sampling tests pass. The single failing ctest (annotate-parallel-overhead-binary-rewrite) is a pre-existing environmental flake (it fails identically on the base branch) unrelated to these changes.

## Checklist

- [x] Builds clean on GCC 10 / C++20
- [x] Unit tests pass
- [x] No behavior change (constraint refactor only)
