### PR TITLE
Fix SPM packet memory leak causing intermittent spm_core test failures

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/core/spm_v2.cpp
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/core/spm_v2.cpp
@@ -486,8 +486,7 @@ aqlprofile_spm_stop(aqlprofile_handle_t handle)
 PUBLIC_API void
 aqlprofile_spm_delete_packets(aqlprofile_handle_t handle)
 {
-    if(auto* map = rocprofiler::common::static_object<SpmStateMap>::get())
-        map->remove(handle);
+    if(auto* map = rocprofiler::common::static_object<SpmStateMap>::get()) map->remove(handle);
 }
 
 struct consumer_thread_handle_t

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/core/spm_v2.cpp
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/core/spm_v2.cpp
@@ -486,7 +486,8 @@ aqlprofile_spm_stop(aqlprofile_handle_t handle)
 PUBLIC_API void
 aqlprofile_spm_delete_packets(aqlprofile_handle_t handle)
 {
-    if(auto* map = rocprofiler::common::static_object<SpmStateMap>::get()) map->remove(handle);
+    if(auto* map = rocprofiler::common::static_object<aqlprofile::spm::SpmStateMap>::get())
+        map->remove(handle);
 }
 
 struct consumer_thread_handle_t

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/core/spm_v2.cpp
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/core/spm_v2.cpp
@@ -486,7 +486,8 @@ aqlprofile_spm_stop(aqlprofile_handle_t handle)
 PUBLIC_API void
 aqlprofile_spm_delete_packets(aqlprofile_handle_t handle)
 {
-    aqlprofile::spm::spm_state_map()->remove(handle);
+    if(auto* map = rocprofiler::common::static_object<SpmStateMap>::get())
+        map->remove(handle);
 }
 
 struct consumer_thread_handle_t

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/aql_packet.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/aql_packet.cpp
@@ -487,7 +487,7 @@ SPMPacket::~SPMPacket()
     if(!sym) return;
 
     running.wlock([&](auto& _running) {
-        if(!_running) return;
+        if(_running == false) return;
         auto status = sym->spm_stop(this->handle);
         ROCP_WARNING_IF(status != HSA_STATUS_SUCCESS)
             << "spm_stop failed with HSA status: " << status;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/aql_packet.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/aql_packet.cpp
@@ -484,13 +484,21 @@ SPMPacket::kfd_stop()
 
 SPMPacket::~SPMPacket()
 {
+    if(!sym) return;
+
     running.wlock([&](auto& _running) {
-        if(_running == false) return;
+        if(!_running) return;
         auto status = sym->spm_stop(this->handle);
         ROCP_WARNING_IF(status != HSA_STATUS_SUCCESS)
             << "spm_stop failed with HSA status: " << status;
         _running = false;
     });
+
+    if(handle.handle != 0 && sym->spm_delete_packets)
+    {
+        sym->spm_delete_packets(this->handle);
+        handle.handle = 0;
+    }
 }
 }  // namespace hsa
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/interface.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/interface.cpp
@@ -38,6 +38,7 @@ construct_spm_interface()
 
 #if defined(ROCPROFILER_BUILD_AQLPROFILE) && ROCPROFILER_BUILD_AQLPROFILE
     cached->spm_create_packets             = &aqlprofile_spm_create_packets;
+    cached->spm_delete_packets             = &aqlprofile_spm_delete_packets;
     cached->spm_start                      = &aqlprofile_spm_start;
     cached->spm_stop                       = &aqlprofile_spm_stop;
     cached->spm_decode_stream_v1           = &aqlprofile_spm_decode_stream_v1;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/interface.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/interface.hpp
@@ -33,6 +33,7 @@ namespace spm
 struct spm_interface
 {
     using spm_create_packets_fn_t             = decltype(aqlprofile_spm_create_packets);
+    using spm_delete_packets_fn_t             = decltype(aqlprofile_spm_delete_packets);
     using spm_start_fn_t                      = decltype(aqlprofile_spm_start);
     using spm_stop_fn_t                       = decltype(aqlprofile_spm_stop);
     using spm_decode_stream_v1_fn_t           = decltype(aqlprofile_spm_decode_stream_v1);
@@ -41,6 +42,7 @@ struct spm_interface
     using spm_query_agent_configurations_fn_t = decltype(aqlprofile_spm_query_agent_configurations);
 
     spm_create_packets_fn_t*             spm_create_packets             = nullptr;
+    spm_delete_packets_fn_t*             spm_delete_packets             = nullptr;
     spm_start_fn_t*                      spm_start                      = nullptr;
     spm_stop_fn_t*                       spm_stop                       = nullptr;
     spm_decode_stream_v1_fn_t*           spm_decode_stream_v1           = nullptr;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/core.cpp
@@ -255,6 +255,9 @@ TEST(spm_core, check_packet_generation)
                 EXPECT_EQ(get_spm_packet(pkt, profile), ROCPROFILER_STATUS_SUCCESS)
                     << "Unable to generate packet";
                 EXPECT_TRUE(pkt) << "Expected a packet to be generated";
+                pkt.reset();
+                ROCPROFILER_CALL(rocprofiler_spm_destroy_counter_config(cfg_id),
+                                 "Could not delete profile id");
             }
         }
     }
@@ -458,6 +461,8 @@ TEST(spm_core, check_callbacks)
                 pkts.emplace_back(
                     std::make_pair(std::move(ret_pkt.packet), static_cast<spm::ClientID>(0)));
                 post_kernel_call(&ctx, cb_info, sess, pkts, kernel_dispatch::profiling_time{});
+                ROCPROFILER_CALL(rocprofiler_spm_destroy_counter_config(expected.id),
+                                 "Could not delete profile id");
             }
         }
     }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/tests/core.cpp
@@ -255,7 +255,6 @@ TEST(spm_core, check_packet_generation)
                 EXPECT_EQ(get_spm_packet(pkt, profile), ROCPROFILER_STATUS_SUCCESS)
                     << "Unable to generate packet";
                 EXPECT_TRUE(pkt) << "Expected a packet to be generated";
-                pkt.reset();
                 ROCPROFILER_CALL(rocprofiler_spm_destroy_counter_config(cfg_id),
                                  "Could not delete profile id");
             }


### PR DESCRIPTION


## Motivation

unit.spm_core.check_packet_generation and unit.spm_core.check_callbacks were failing intermittently on CI with:

aql_packet.cpp:360] Could not allocate memory
Both tests iterate over all SPM metrics and create a new SPM packet for each one. Each packet allocates substantial memory through the HSA CPU memory pool (via aqlprofile). Those resources were not being released, so repeated runs could exhaust the pool and cause allocation failures. Failures were intermittent because they depended on how many metrics were exercised and how much memory was already in use on the CI runner.

## Technical Details

~SPMPacket: Call aqlprofile_spm_delete_packets after spm_stop, matching the cleanup pattern used by CounterAQLPacket (aqlprofile_pmc_delete_packets).

spm_interface: Wire up aqlprofile_spm_delete_packets so the SDK can release aqlprofile SPM state.

spm/tests/core.cpp: In check_packet_generation and check_callbacks, destroy each per-metric counter config after the test body so cached packets and configs do not accumulate across the full metric loop.


## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
