### PR TITLE
[RCCL] - Update Changelog to incorporate 2.28.x and 2.29.x info

### DIFF
--- a/projects/rccl/CHANGELOG.md
+++ b/projects/rccl/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Full documentation for RCCL is available at [https://rccl.readthedocs.io](https://rccl.readthedocs.io)
 
-## Unreleased - RCCL 2.28.3 for ROCm 7.11
+## Unreleased - RCCL 2.29.7 for ROCm 7.14
 
 ### Known issues
 * AllGather regression for small message sizes (less than 1 MB) due to the Direct algorithm.
@@ -16,6 +16,11 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 
 ### Changed
 * Compatibility with NCCL 2.28.3.
+* Compatibility with NCCL 2.28.7.
+* Compatibility with NCCL 2.28.9.
+* Compatibility with NCCL 2.29.2.
+* Compatibility with NCCL 2.29.3.
+* Compatibility with NCCL 2.29.7.
 * The MSCCL feature is now disabled by default. The `--disable-msccl-kernel` build flag is replaced with `--enable-msccl-kernel` in the `rccl/install.sh` script.
 * MSCCL and NPKIT are deprecated and will be removed in a future release of RCCL.
 * Changed GPU Direct RDMA mode selection logic to prefer peermem over DMAbuf by default. `NCCL_DMABUF_ENABLE` now defaults to 1 (previously 0). When both peermem and DMAbuf are available, RCCL will use peermem. If peermem is unavailable, RCCL will automatically fall back to DMAbuf (if available and enabled). Setting `RCCL_FORCE_ENABLE_DMABUF=1` forces DMAbuf usage exclusively, skipping peermem even if available, and disables GPU Direct RDMA if DMAbuf is unavailable.


### PR DESCRIPTION
## Motivation

RCCL recently brought in NCCL's 2.28.x and 2.29x updates. Let's update the changelog accordingly.

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
