### PR TITLE
[rocprofiler-register] Use sandbox runner for sanitizer CI jobs

### DIFF
--- a/.github/workflows/rocprofiler-register-continuous-integration.yml
+++ b/.github/workflows/rocprofiler-register-continuous-integration.yml
@@ -56,17 +56,17 @@ jobs:
             ci-args: '--memcheck ThreadSanitizer'
             ci-tag: '-thread-sanitizer'
             # DO NOT UPDATE: sanitizer builds and tests cause issue on prod machines
-            runner: 'linux-mi325-8gpu-ossci-rocm-sandbox'
+            runner: 'linux-mi325-gpu-rocm-cpu-sandbox'
           - compiler: 'gcc-12'
             ci-args: '--memcheck AddressSanitizer'
             ci-tag: '-address-sanitizer'
             # DO NOT UPDATE: sanitizer builds and tests cause issue on prod machines
-            runner: 'linux-mi325-8gpu-ossci-rocm-sandbox'
+            runner: 'linux-mi325-gpu-rocm-cpu-sandbox'
           - compiler: 'gcc-12'
             ci-args: '--memcheck LeakSanitizer'
             ci-tag: '-leak-sanitizer'
             # DO NOT UPDATE: sanitizer builds and tests cause issue on prod machines
-            runner: 'linux-mi325-8gpu-ossci-rocm-sandbox'
+            runner: 'linux-mi325-gpu-rocm-cpu-sandbox'
         #   - compiler: 'gcc-12'
         #     ci-args: '--memcheck UndefinedBehaviorSanitizer'
         #     ci-tag: '-undefined-behavior-sanitizer'

--- a/.github/workflows/rocprofiler-register-continuous-integration.yml
+++ b/.github/workflows/rocprofiler-register-continuous-integration.yml
@@ -38,30 +38,41 @@ jobs:
         compiler: ['clang-14', 'clang-15', 'gcc-11', 'gcc-12']
         ci-args: ['']
         ci-tag: ['']
+        runner: ['linux-gfx942-1gpu-core42-ossci-rocm']
         include:
           - compiler: 'gcc-12'
             ci-args: '--coverage'
             ci-tag: '-codecov'
+            runner: 'linux-gfx942-1gpu-core42-ossci-rocm'
           - compiler: 'clang-15'
             ci-args: '--linter clang-tidy'
             ci-tag: '-clang-tidy'
+            runner: 'linux-gfx942-1gpu-core42-ossci-rocm'
           - compiler: 'clang-13'
             ci-args: ''
             ci-tag: ''
+            runner: 'linux-gfx942-1gpu-core42-ossci-rocm'
           - compiler: 'gcc-12'
             ci-args: '--memcheck ThreadSanitizer'
             ci-tag: '-thread-sanitizer'
+            # DO NOT UPDATE: sanitizer builds and tests cause issue on prod machines
+            runner: 'linux-mi325-8gpu-ossci-rocm-sandbox'
           - compiler: 'gcc-12'
             ci-args: '--memcheck AddressSanitizer'
             ci-tag: '-address-sanitizer'
+            # DO NOT UPDATE: sanitizer builds and tests cause issue on prod machines
+            runner: 'linux-mi325-8gpu-ossci-rocm-sandbox'
           - compiler: 'gcc-12'
             ci-args: '--memcheck LeakSanitizer'
             ci-tag: '-leak-sanitizer'
+            # DO NOT UPDATE: sanitizer builds and tests cause issue on prod machines
+            runner: 'linux-mi325-8gpu-ossci-rocm-sandbox'
         #   - compiler: 'gcc-12'
         #     ci-args: '--memcheck UndefinedBehaviorSanitizer'
         #     ci-tag: '-undefined-behavior-sanitizer'
+        #     runner: 'linux-mi325-8gpu-ossci-rocm-sandbox'
 
-    runs-on: linux-gfx942-1gpu-core42-ossci-rocm
+    runs-on: ${{ matrix.runner }}
     container:
       image: docker.io/rocm/rocprofiler-private:ubuntu-22.04-gfx94X-latest
       credentials:

--- a/.github/workflows/rocprofiler-sdk-continuous_integration.yml
+++ b/.github/workflows/rocprofiler-sdk-continuous_integration.yml
@@ -453,10 +453,10 @@ jobs:
       fail-fast: false
       matrix:
         system:
-          - { sanitizer: 'AddressSanitizer', os: 'ubuntu-22.04', runner: 'linux-mi325-8gpu-ossci-rocm-sandbox', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo' }
-          - { sanitizer: 'ThreadSanitizer', os: 'ubuntu-22.04', runner: 'linux-mi325-8gpu-ossci-rocm-sandbox', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo' }
-          - { sanitizer: 'LeakSanitizer', os: 'ubuntu-22.04', runner: 'linux-mi325-8gpu-ossci-rocm-sandbox', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo' }
-          - { sanitizer: 'UndefinedBehaviorSanitizer', os: 'ubuntu-22.04', runner: 'linux-mi325-8gpu-ossci-rocm-sandbox', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo' }
+          - { sanitizer: 'AddressSanitizer', os: 'ubuntu-22.04', runner: 'linux-mi325-gpu-rocm-cpu-sandbox', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo' }
+          - { sanitizer: 'ThreadSanitizer', os: 'ubuntu-22.04', runner: 'linux-mi325-gpu-rocm-cpu-sandbox', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo' }
+          - { sanitizer: 'LeakSanitizer', os: 'ubuntu-22.04', runner: 'linux-mi325-gpu-rocm-cpu-sandbox', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo' }
+          - { sanitizer: 'UndefinedBehaviorSanitizer', os: 'ubuntu-22.04', runner: 'linux-mi325-gpu-rocm-cpu-sandbox', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo' }
 
     # Disabled until a dedicated sanitizer runner pool is available.
     if: ${{ false }}


### PR DESCRIPTION
Due to sanitizer jobs causing crashes on production CI machines, we are setting sanitizer jobs for sandbox runners