### PR TITLE
fix(rccl-tests): restore gated ginConnectionType alltoall GIN kernel

### DIFF
--- a/projects/rccl-tests/src/alltoall.cu
+++ b/projects/rccl-tests/src/alltoall.cu
@@ -68,6 +68,11 @@ testResult_t AlltoAllGetDevCommRequirements(int deviceImpl, ncclDevCommRequireme
       }
       reqs->barrierCount = deviceCtaCount;
       reqs->ginSignalCount = deviceCtaCount;
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2,29,7)
+      reqs->ginConnectionType = NCCL_GIN_CONNECTION_FULL;
+#else
+      reqs->ginForceEnable = true;
+#endif
       return testSuccess;
     default:
       return testNotImplemented;


### PR DESCRIPTION
## Motivation

The clean re-sync of the NCCL 2.29.x work into develop (PR [#6674](https://github.com/ROCm/rocm-systems/pull/6674)) dropped the ginConnectionType request for the alltoall GIN device kernels. The line was originally added in PR [#6562](https://github.com/ROCm/rocm-systems/pull/6562) (and version-gated in commit 353bae4), but because the sync was re-squashed into a single port commit (557141e), this change was lost and never reached develop.

As a result, alltoall_perf -R 2 -D 3 (GinAlltoAllKernel) and -D 4 (HybridAlltoAllKernel) fail at init with:

`User requested GIN resources but did not request GIN to be enabled!`

## Technical Details

AlltoAllGetDevCommRequirements (the -D 3/-D 4 path) set barrierCount and ginSignalCount but left ginConnectionType at its zero-init default (NCCL_GIN_CONNECTION_NONE). Both kernels need every GIN rank reachable from every other (full mesh of QPs), so we request NCCL_GIN_CONNECTION_FULL.

The assignment is version-gated because the surrounding function compiles at NCCL_VERSION_CODE >= 2.29.0, but the ginConnectionType field only exists at >= 2.29.7; older versions use ginForceEnable:

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
