### PR TITLE
Media - Fix latest

### DIFF
--- a/.github/workflows/media-libs-ci.yml
+++ b/.github/workflows/media-libs-ci.yml
@@ -35,14 +35,51 @@ permissions:
   contents: read
 
 jobs:
+  setup:
+    name: "Setup"
+    runs-on: ubuntu-24.04
+    outputs:
+      package_version: ${{ steps.rocm_package_version.outputs.rocm_package_version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          sparse-checkout: .github
+          sparse-checkout-cone-mode: true
+          fetch-depth: 2
+
+      - name: Checkout TheRock repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: "ROCm/TheRock"
+          path: TheRock
+          ref: 685f8c3b89006309b34a7c16de17e841400f0d76 # 2025-05-29 commit
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Install python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pydantic requests
+
+      - name: Compute package version
+        id: rocm_package_version
+        run: |
+          python TheRock/build_tools/compute_rocm_package_version.py --release-type=dev
+
   therock-ci-linux:
     name: Build Media Libs
+    needs: setup
     permissions:
       contents: read
       id-token: write
     uses: ./.github/workflows/therock-ci-linux.yml
     secrets: inherit
     with:
+      package_version: ${{ needs.setup.outputs.package_version }}
       cmake_options: >
         -DTHEROCK_ENABLE_CORE=ON
         -DTHEROCK_ENABLE_COMM_LIBS=OFF


### PR DESCRIPTION
## Motivation

Update Media pipeline

## Technical Details

* Added a setup job that checks out TheRock and computes the version via compute_rocm_package_version.py --release-type=dev, exposing it as a job output — exactly the pattern used in the main therock-ci.yml.
* Made therock-ci-linux depend on it (needs: setup) and pass package_version: ${{ needs.setup.outputs.package_version }}.

This resolves the "Input package_version is required, but not provided" validation error while keeping versioning consistent with the rest of the CI.

## JIRA ID

NA

## Test Plan

Current media pipeline

## Test Result

Pass media pipeline

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
