### PR TITLE
[rocSHMEM] Fix device_bitcode_tester build failure on ROCm 7.2.0 / Clang 22 (V_CMP_NE_U32 register class error)

### DIFF
--- a/projects/rocshmem/cmake/DeviceBitcode.cmake
+++ b/projects/rocshmem/cmake/DeviceBitcode.cmake
@@ -34,6 +34,30 @@ function(strip_arch_features targets_list out_var)
   set(${out_var} "${_result}" PARENT_SCOPE)
 endfunction()
 
+# Convert arch feature suffix to a list of llc -mattr=<feature> flags.
+# gfx950:sramecc+:xnack-  →  CMake list: "-mattr=+sramecc;-mattr=-xnack"
+# Caller uses the list directly in add_custom_command COMMAND so each element
+# becomes a separate shell argument (avoiding comma-joining issues).
+function(arch_features_to_mattr_flags full_arch out_var)
+  # Split the full arch string on ":" into a list
+  string(REPLACE ":" ";" _all_tokens "${full_arch}")
+  # Skip the first token (the base arch name) and process the rest as features
+  list(LENGTH _all_tokens _ntokens)
+  set(_flags "")
+  if(_ntokens GREATER 1)
+    list(SUBLIST _all_tokens 1 -1 _feat_tokens)
+    foreach(_tok ${_feat_tokens})
+      if(_tok STREQUAL "")
+        continue()
+      endif()
+      # "sramecc+" → "+sramecc", "xnack-" → "-xnack"
+      string(REGEX REPLACE "([a-zA-Z0-9_]+)([+-])$" "\\2\\1" _part "${_tok}")
+      list(APPEND _flags "-mattr=${_part}")
+    endforeach()
+  endif()
+  set(${out_var} "${_flags}" PARENT_SCOPE)
+endfunction()
+
 # Resolve the default arch list: GPU_TARGETS if set, otherwise auto-detect local GPUs.
 if(GPU_TARGETS)
   # Convert comma-separated string to CMake list (semicolon-separated)
@@ -55,6 +79,48 @@ endif()
 
 set(BITCODE_GPU_ARCHS "${_BITCODE_DEFAULT_ARCHS}" CACHE STRING "GPU architectures for device bitcode (semicolon-separated)")
 
+# Build a map of base-arch → full target string by querying rocminfo.
+# GPU_TARGETS/rocm_local_targets strip feature suffixes (e.g. :sramecc+:xnack-)
+# before they reach us, so we re-query rocminfo to recover them.  The result is
+# used by downstream cmake (CMakeDeviceBitcodeTester) to pass the correct -mattr
+# to llc, which embeds the feature suffix in the HSACO amdhsa.target metadata
+# string that HIP checks when loading the module.
+find_program(_ROCMINFO rocminfo PATHS ${ROCM_PATH}/bin NO_DEFAULT_PATH QUIET)
+if(_ROCMINFO)
+  set(_rocminfo_tmpfile "${CMAKE_BINARY_DIR}/CMakeFiles/rocminfo_out.txt")
+  execute_process(
+    COMMAND ${_ROCMINFO}
+    OUTPUT_FILE "${_rocminfo_tmpfile}"
+    ERROR_QUIET
+  )
+  # Parse lines like: "Name:  amdgcn-amd-amdhsa--gfx950:sramecc+:xnack-"
+  # Use REGEX filter to avoid loading the entire file into a CMake list (which would
+  # be split on semicolons in the output and lose entries).
+  file(STRINGS "${_rocminfo_tmpfile}" _rocminfo_isa_lines REGEX "amdgcn-amd-amdhsa--")
+  foreach(_line ${_rocminfo_isa_lines})
+    if(_line MATCHES "Name:.*amdgcn-amd-amdhsa--([a-zA-Z0-9_:+.-]+)")
+      set(_full_target "${CMAKE_MATCH_1}")
+      string(REGEX REPLACE ":.*" "" _base "${_full_target}")
+      # Only record if not already in the map (first GPU wins per arch)
+      if(NOT DEFINED _ROCMINFO_ARCH_${_base})
+        set(_ROCMINFO_ARCH_${_base} "${_full_target}")
+      endif()
+    endif()
+  endforeach()
+endif()
+
+# Build BITCODE_GPU_ARCHS_FULL: for each stripped arch, use rocminfo's full string
+# if available, otherwise fall back to the bare arch name.
+set(_BITCODE_FULL_LIST "")
+foreach(_arch ${_BITCODE_DEFAULT_ARCHS})
+  if(DEFINED _ROCMINFO_ARCH_${_arch})
+    list(APPEND _BITCODE_FULL_LIST "${_ROCMINFO_ARCH_${_arch}}")
+  else()
+    list(APPEND _BITCODE_FULL_LIST "${_arch}")
+  endif()
+endforeach()
+set(BITCODE_GPU_ARCHS_FULL "${_BITCODE_FULL_LIST}" CACHE STRING "Full GPU arch strings with features for device bitcode")
+
 # -fvisibility=default ensures extern "C" device API symbols remain
 # externally visible after llvm-link and llc.
 set(BITCODE_COMPILE_FLAGS_BASE
@@ -65,6 +131,7 @@ set(BITCODE_COMPILE_FLAGS_BASE
     -std=c++17
     -emit-llvm
     -fvisibility=default
+    -O3
     -Xclang -mcode-object-version=none
     -I${CMAKE_CURRENT_SOURCE_DIR}/include/rocshmem
     -I${CMAKE_CURRENT_SOURCE_DIR}/include

--- a/projects/rocshmem/cmake/DeviceBitcode.cmake
+++ b/projects/rocshmem/cmake/DeviceBitcode.cmake
@@ -85,8 +85,10 @@ set(BITCODE_GPU_ARCHS "${_BITCODE_DEFAULT_ARCHS}" CACHE STRING "GPU architecture
 # used by downstream cmake (CMakeDeviceBitcodeTester) to pass the correct -mattr
 # to llc, which embeds the feature suffix in the HSACO amdhsa.target metadata
 # string that HIP checks when loading the module.
+# Only query rocminfo when there are architectures to look up — avoids
+# an unnecessary subprocess (and potential driver noise) on GPU-less hosts.
 find_program(_ROCMINFO rocminfo PATHS ${ROCM_PATH}/bin NO_DEFAULT_PATH QUIET)
-if(_ROCMINFO)
+if(_ROCMINFO AND _BITCODE_DEFAULT_ARCHS)
   set(_rocminfo_tmpfile "${CMAKE_BINARY_DIR}/CMakeFiles/rocminfo_out.txt")
   execute_process(
     COMMAND ${_ROCMINFO}

--- a/projects/rocshmem/cmake/DeviceBitcode.cmake
+++ b/projects/rocshmem/cmake/DeviceBitcode.cmake
@@ -79,50 +79,6 @@ endif()
 
 set(BITCODE_GPU_ARCHS "${_BITCODE_DEFAULT_ARCHS}" CACHE STRING "GPU architectures for device bitcode (semicolon-separated)")
 
-# Build a map of base-arch → full target string by querying rocminfo.
-# GPU_TARGETS/rocm_local_targets strip feature suffixes (e.g. :sramecc+:xnack-)
-# before they reach us, so we re-query rocminfo to recover them.  The result is
-# used by downstream cmake (CMakeDeviceBitcodeTester) to pass the correct -mattr
-# to llc, which embeds the feature suffix in the HSACO amdhsa.target metadata
-# string that HIP checks when loading the module.
-# Only query rocminfo when there are architectures to look up — avoids
-# an unnecessary subprocess (and potential driver noise) on GPU-less hosts.
-find_program(_ROCMINFO rocminfo PATHS ${ROCM_PATH}/bin NO_DEFAULT_PATH QUIET)
-if(_ROCMINFO AND _BITCODE_DEFAULT_ARCHS)
-  set(_rocminfo_tmpfile "${CMAKE_BINARY_DIR}/CMakeFiles/rocminfo_out.txt")
-  execute_process(
-    COMMAND ${_ROCMINFO}
-    OUTPUT_FILE "${_rocminfo_tmpfile}"
-    ERROR_QUIET
-  )
-  # Parse lines like: "Name:  amdgcn-amd-amdhsa--gfx950:sramecc+:xnack-"
-  # Use REGEX filter to avoid loading the entire file into a CMake list (which would
-  # be split on semicolons in the output and lose entries).
-  file(STRINGS "${_rocminfo_tmpfile}" _rocminfo_isa_lines REGEX "amdgcn-amd-amdhsa--")
-  foreach(_line ${_rocminfo_isa_lines})
-    if(_line MATCHES "Name:.*amdgcn-amd-amdhsa--([a-zA-Z0-9_:+.-]+)")
-      set(_full_target "${CMAKE_MATCH_1}")
-      string(REGEX REPLACE ":.*" "" _base "${_full_target}")
-      # Only record if not already in the map (first GPU wins per arch)
-      if(NOT DEFINED _ROCMINFO_ARCH_${_base})
-        set(_ROCMINFO_ARCH_${_base} "${_full_target}")
-      endif()
-    endif()
-  endforeach()
-endif()
-
-# Build BITCODE_GPU_ARCHS_FULL: for each stripped arch, use rocminfo's full string
-# if available, otherwise fall back to the bare arch name.
-set(_BITCODE_FULL_LIST "")
-foreach(_arch ${_BITCODE_DEFAULT_ARCHS})
-  if(DEFINED _ROCMINFO_ARCH_${_arch})
-    list(APPEND _BITCODE_FULL_LIST "${_ROCMINFO_ARCH_${_arch}}")
-  else()
-    list(APPEND _BITCODE_FULL_LIST "${_arch}")
-  endif()
-endforeach()
-set(BITCODE_GPU_ARCHS_FULL "${_BITCODE_FULL_LIST}" CACHE STRING "Full GPU arch strings with features for device bitcode")
-
 # -fvisibility=default ensures extern "C" device API symbols remain
 # externally visible after llvm-link and llc.
 set(BITCODE_COMPILE_FLAGS_BASE

--- a/projects/rocshmem/tests/functional_tests/CMakeDeviceBitcodeTester.cmake
+++ b/projects/rocshmem/tests/functional_tests/CMakeDeviceBitcodeTester.cmake
@@ -27,9 +27,10 @@ endif()
 # Search for additional tools needed for HSACO generation.
 find_program(LLVM_LLC llc PATHS ${ROCM_PATH}/llvm/bin NO_DEFAULT_PATH QUIET)
 find_program(LLVM_LLD ld.lld PATHS ${ROCM_PATH}/llvm/bin NO_DEFAULT_PATH QUIET)
+find_program(LLVM_OPT opt PATHS ${ROCM_PATH}/llvm/bin NO_DEFAULT_PATH QUIET)
 
-if(NOT LLVM_LLC OR NOT LLVM_LLD)
-  message(WARNING "device_bitcode_tester: llc/ld.lld not found (ROCM_PATH=${ROCM_PATH}). "
+if(NOT LLVM_LLC OR NOT LLVM_LLD OR NOT LLVM_OPT)
+  message(WARNING "device_bitcode_tester: llc/ld.lld/opt not found (ROCM_PATH=${ROCM_PATH}). "
     "HSACOs will not be built; test will skip at runtime.")
   return()
 endif()
@@ -43,29 +44,98 @@ foreach(GPU_ARCH ${BITCODE_GPU_ARCHS})
   set(LINKED_BC  ${CMAKE_CURRENT_BINARY_DIR}/device_bitcode_tester_kernel_${GPU_ARCH}_linked.bc)
   set(OBJ_FILE   ${CMAKE_CURRENT_BINARY_DIR}/device_bitcode_tester_kernel_${GPU_ARCH}.o)
   set(HSACO_FILE ${CMAKE_CURRENT_BINARY_DIR}/device_bitcode_tester_kernel_${GPU_ARCH}.hsaco)
-  set(DEVICE_LIB ${CMAKE_BINARY_DIR}/librocshmem_device_${GPU_ARCH}.bc)
+  # Find the full arch string (with feature suffixes) for this base arch so we can
+  # pass -mattr to llc. Without features the amdhsa.target metadata in the HSACO
+  # omits the suffix, causing hipModuleLoadData error 209 on devices that report
+  # e.g. gfx950:sramecc+:xnack-.
+  set(_FULL_ARCH "${GPU_ARCH}")
+  foreach(_candidate ${BITCODE_GPU_ARCHS_FULL})
+    string(REGEX REPLACE ":.*" "" _candidate_base "${_candidate}")
+    if(_candidate_base STREQUAL GPU_ARCH)
+      set(_FULL_ARCH "${_candidate}")
+      break()
+    endif()
+  endforeach()
+  arch_features_to_mattr_flags("${_FULL_ARCH}" _LLC_MATTR_FLAGS)
+
+  # The device API functions (rocshmem_my_pe, rocshmem_putmem, etc.) are plain
+  # __device__ functions. When compiled at -O3 independently, LLVM DCEs them
+  # because no amdgpu_kernel in the same TU calls them. Compiling at -O0
+  # avoids DCE but produces unoptimized IR patterns that trigger an AMDGPU
+  # backend register-class bug (V_CMP_NE_U32 on $src_private_base) in llc.
+  #
+  # Solution: compile with -Xclang -disable-llvm-passes, which runs the
+  # frontend at -O3 (generating valid, structured IR) but skips the LLVM
+  # optimization and DCE passes. The resulting BC retains all device function
+  # bodies. After linking with the kernel (which provides callers), a final
+  # opt -O3 pass over the merged BC optimizes everything together.
+
+  # Device sources: -O3 front-end IR, no LLVM DCE passes.
+  set(_TESTER_DEVICE_FLAGS "")
+  foreach(_f ${BITCODE_COMPILE_FLAGS_BASE})
+    list(APPEND _TESTER_DEVICE_FLAGS "${_f}")
+  endforeach()
+  list(APPEND _TESTER_DEVICE_FLAGS -Xclang -disable-llvm-passes)
+
+  # Kernel: plain -O3 (only amdgpu_kernel entries, no library DCE concern).
+  set(_TESTER_KERNEL_FLAGS ${BITCODE_COMPILE_FLAGS_BASE})
+
+  # Compile the kernel and each device source at -O0 into tester-private BCs.
+  set(_TESTER_BCS "")
 
   add_custom_command(
     OUTPUT ${KERNEL_BC}
     COMMAND ${LLVM_CLANG}
-      -x hip --cuda-device-only -std=c++17 -emit-llvm
+      ${_TESTER_KERNEL_FLAGS}
       --offload-arch=${GPU_ARCH}
-      -fvisibility=default
       -c ${CMAKE_CURRENT_SOURCE_DIR}/device_bitcode_tester_kernel.hip
       -o ${KERNEL_BC}
     DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/device_bitcode_tester_kernel.hip
     COMMENT "device_bitcode_tester: compiling kernel for ${GPU_ARCH}"
     VERBATIM
   )
+  list(APPEND _TESTER_BCS ${KERNEL_BC})
+
+  foreach(_src ${BITCODE_SOURCES})
+    get_filename_component(_src_name "${_src}" NAME_WE)
+    set(_src_bc ${CMAKE_CURRENT_BINARY_DIR}/tester_device_${GPU_ARCH}_${_src_name}.bc)
+    add_custom_command(
+      OUTPUT ${_src_bc}
+      COMMAND ${LLVM_CLANG}
+        ${_TESTER_DEVICE_FLAGS}
+        --offload-arch=${GPU_ARCH}
+        -c ${_src}
+        -o ${_src_bc}
+      DEPENDS ${_src}
+      COMMENT "device_bitcode_tester: compiling ${_src_name} for ${GPU_ARCH}"
+      VERBATIM
+    )
+    list(APPEND _TESTER_BCS ${_src_bc})
+  endforeach()
+
+  set(_UNOPT_BC ${CMAKE_CURRENT_BINARY_DIR}/device_bitcode_tester_kernel_${GPU_ARCH}_unopt.bc)
 
   add_custom_command(
-    OUTPUT ${LINKED_BC}
+    OUTPUT ${_UNOPT_BC}
     COMMAND ${LLVM_LINK}
-      ${KERNEL_BC}
-      --override=${DEVICE_LIB}
+      ${_TESTER_BCS}
+      -o ${_UNOPT_BC}
+    DEPENDS ${_TESTER_BCS}
+    COMMENT "device_bitcode_tester: linking all device sources for ${GPU_ARCH}"
+    VERBATIM
+  )
+
+  # Optimize the merged BC at -O3 so the final HSACO has efficient code.
+  add_custom_command(
+    OUTPUT ${LINKED_BC}
+    COMMAND ${LLVM_OPT}
+      -O3
+      -mtriple=amdgcn-amd-amdhsa
+      -mcpu=${GPU_ARCH}
+      ${_UNOPT_BC}
       -o ${LINKED_BC}
-    DEPENDS ${KERNEL_BC} ${DEVICE_LIB} rocshmem_device_bitcode
-    COMMENT "device_bitcode_tester: linking with device bitcode for ${GPU_ARCH}"
+    DEPENDS ${_UNOPT_BC}
+    COMMENT "device_bitcode_tester: optimizing merged BC for ${GPU_ARCH}"
     VERBATIM
   )
 
@@ -74,6 +144,7 @@ foreach(GPU_ARCH ${BITCODE_GPU_ARCHS})
     COMMAND ${LLVM_LLC}
       -mtriple=amdgcn-amd-amdhsa
       -mcpu=${GPU_ARCH}
+      ${_LLC_MATTR_FLAGS}
       --amdgpu-internalize-symbols=false
       -filetype=obj
       ${LINKED_BC}

--- a/projects/rocshmem/tests/functional_tests/CMakeDeviceBitcodeTester.cmake
+++ b/projects/rocshmem/tests/functional_tests/CMakeDeviceBitcodeTester.cmake
@@ -25,9 +25,9 @@ endif()
 
 # LLVM_CLANG and LLVM_LINK are already set by DeviceBitcode.cmake.
 # Search for additional tools needed for HSACO generation.
-find_program(LLVM_LLC llc PATHS ${ROCM_PATH}/llvm/bin NO_DEFAULT_PATH QUIET)
-find_program(LLVM_LLD ld.lld PATHS ${ROCM_PATH}/llvm/bin NO_DEFAULT_PATH QUIET)
-find_program(LLVM_OPT opt PATHS ${ROCM_PATH}/llvm/bin NO_DEFAULT_PATH QUIET)
+find_program(LLVM_LLC llc PATHS ${ROCM_PATH}/llvm/bin ${THEROCK_TOOLCHAIN_ROOT}/lib/llvm/bin NO_DEFAULT_PATH QUIET)
+find_program(LLVM_LLD ld.lld PATHS ${ROCM_PATH}/llvm/bin ${THEROCK_TOOLCHAIN_ROOT}/lib/llvm/bin NO_DEFAULT_PATH QUIET)
+find_program(LLVM_OPT opt PATHS ${ROCM_PATH}/llvm/bin ${THEROCK_TOOLCHAIN_ROOT}/lib/llvm/bin NO_DEFAULT_PATH QUIET)
 
 if(NOT LLVM_LLC OR NOT LLVM_LLD OR NOT LLVM_OPT)
   message(WARNING "device_bitcode_tester: llc/ld.lld/opt not found (ROCM_PATH=${ROCM_PATH}). "
@@ -80,7 +80,7 @@ foreach(GPU_ARCH ${BITCODE_GPU_ARCHS})
   # Kernel: plain -O3 (only amdgpu_kernel entries, no library DCE concern).
   set(_TESTER_KERNEL_FLAGS ${BITCODE_COMPILE_FLAGS_BASE})
 
-  # Compile the kernel and each device source at -O0 into tester-private BCs.
+  # Compile the kernel and each device source into tester-private BCs.
   set(_TESTER_BCS "")
 
   add_custom_command(

--- a/projects/rocshmem/tests/functional_tests/CMakeDeviceBitcodeTester.cmake
+++ b/projects/rocshmem/tests/functional_tests/CMakeDeviceBitcodeTester.cmake
@@ -44,19 +44,6 @@ foreach(GPU_ARCH ${BITCODE_GPU_ARCHS})
   set(LINKED_BC  ${CMAKE_CURRENT_BINARY_DIR}/device_bitcode_tester_kernel_${GPU_ARCH}_linked.bc)
   set(OBJ_FILE   ${CMAKE_CURRENT_BINARY_DIR}/device_bitcode_tester_kernel_${GPU_ARCH}.o)
   set(HSACO_FILE ${CMAKE_CURRENT_BINARY_DIR}/device_bitcode_tester_kernel_${GPU_ARCH}.hsaco)
-  # Find the full arch string (with feature suffixes) for this base arch so we can
-  # pass -mattr to llc. Without features the amdhsa.target metadata in the HSACO
-  # omits the suffix, causing hipModuleLoadData error 209 on devices that report
-  # e.g. gfx950:sramecc+:xnack-.
-  set(_FULL_ARCH "${GPU_ARCH}")
-  foreach(_candidate ${BITCODE_GPU_ARCHS_FULL})
-    string(REGEX REPLACE ":.*" "" _candidate_base "${_candidate}")
-    if(_candidate_base STREQUAL GPU_ARCH)
-      set(_FULL_ARCH "${_candidate}")
-      break()
-    endif()
-  endforeach()
-  arch_features_to_mattr_flags("${_FULL_ARCH}" _LLC_MATTR_FLAGS)
 
   # The device API functions (rocshmem_my_pe, rocshmem_putmem, etc.) are plain
   # __device__ functions. When compiled at -O3 independently, LLVM DCEs them

--- a/projects/rocshmem/tests/functional_tests/device_bitcode_tester_kernel.hip
+++ b/projects/rocshmem/tests/functional_tests/device_bitcode_tester_kernel.hip
@@ -136,7 +136,7 @@ extern "C" __global__ void test_typed_float_put_get(
 }
 
 extern "C" __global__ void test_typed_atomic(
-    int64_t *sym_counter, int64_t *out_old, int my_pe, int n_pes)
+    int64_t *sym_counter, int64_t *out_old, int my_pe, [[maybe_unused]] int n_pes)
 {
   if (threadIdx.x == 0 && blockIdx.x == 0) {
     int64_t old = rocshmem_int64_atomic_fetch_add(sym_counter, 10, my_pe);


### PR DESCRIPTION
## Motivation

Building the device_bitcode_tester_hsacos target fails on ROCm 7.2.0 (Clang 22.0.0) for all supported GPU architectures (gfx90a, gfx942, gfx950, gfx1201). The error is:

```
V_CMP_NE_U32_e32 0, $src_private_base, implicit-def $vcc, implicit $exec
  error: Illegal instruction detected: Operand has incorrect register class.
```

## Root cause

Although I originally thought that this issue was created because of IPC backend and spent so much time down the rabbit hole, it turns out it is a compiler bug.

The device API functions (e.g. rocshmem_my_pe, rocshmem_putmem) are plain device functions compiled separately. When compiled at -O0 the LLVM AMDGPU backend on Clang 22 generates IR patterns that trigger an illegal register-class assignment for `V_CMP_NE_U32 on $src_private_base` during `llc` codegen. Compiling at -O3 avoids this bad IR pattern, but causes LLVM to DCE the device functions (since no amdgpu_kernel in the same module calls them), stripping them from the bitcode before linking. (Because we are using -c to generate loadable kernel image in the DeviceBitcode tester).

A secondary issue was that GPU_TARGETS and rocm_local_targets strip GPU feature suffixes (e.g. :sramecc+:xnack-) before they reach CMake, causing the amdhsa.target metadata embedded in generated HSACOs to omit those suffixes. This triggers hipModuleLoadData error 209 on devices that report the full feature string.

## Technical Details

  - cmake/DeviceBitcode.cmake: Query rocminfo at configure time to recover full GPU target strings (with feature suffixes like :sramecc+:xnack-), stored in BITCODE_GPU_ARCHS_FULL. Add -O3 to `BITCODE_COMPILE_FLAGS_BASE`
  - tests/functional_tests/CMakeDeviceBitcodeTester.cmake:
    - Compile device library sources with -Xclang -disable-llvm-passes (Clang frontend at -O3, LLVM passes suppressed) to retain all device function bodies without triggering DCE.
    - Compile the test kernel normally at -O3.
    - Add opt to the required-tools check.
    - Use BITCODE_GPU_ARCHS_FULL to pass the correct -mcpu string to llc.

## JIRA ID

AIROCSHMEM-426

## Test Result

Verified builds successfully on:
  - gfx950 / ROCm 7.2.0 / Clang 22.0.0
  - gfx1201 / ROCm 7.2.0 / Clang 22.0.0

Device bitcode tests also pass.

