### PR TITLE
[rocprofiler-sdk] Enable scratch memory tracing tests

### DIFF
--- a/projects/rocprofiler-sdk/tests/rocprofv3/scratch-memory/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/scratch-memory/CMakeLists.txt
@@ -26,8 +26,7 @@ foreach(_OUTPUT_FORMAT csv json)
         TIMEOUT 45
         LABELS "integration-tests"
         PRELOAD "${PRELOAD_ENV}"
-        FIXTURES_SETUP rocprofv3-test-scratch-memory-tracing-${_OUTPUT_FORMAT}
-        DISABLED "${ROCPROFILER_DISABLE_UNSTABLE_CTESTS}")
+        FIXTURES_SETUP rocprofv3-test-scratch-memory-tracing-${_OUTPUT_FORMAT})
 endforeach()
 
 rocprofiler_add_integration_validate_test(
@@ -41,5 +40,4 @@ rocprofiler_add_integration_validate_test(
     TIMEOUT 45
     LABELS "integration-tests"
     FIXTURES_REQUIRED rocprofv3-test-scratch-memory-tracing-csv
-                      rocprofv3-test-scratch-memory-tracing-json
-    DISABLED "${ROCPROFILER_DISABLE_UNSTABLE_CTESTS}")
+                      rocprofv3-test-scratch-memory-tracing-json)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/scratch-memory/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/scratch-memory/validate.py
@@ -159,32 +159,39 @@ def test_scratch_memory(json_input_data, csv_input_data):
 
 def verify_scratch_memory_alternating_pattern(scratch_memory_data, bf_op_names):
     """
-    Verify that operations follow ALLOC→FREE→ALLOC→FREE pattern per (thread, flags) combination.
+    Verify that operations follow ALLOC→FREE→ALLOC→FREE pattern per
+    (agent, thread, flags) combination.
+
+    Scratch memory is managed independently per agent (each device maintains its
+    own scratch pool), so the alternating sequence must be validated per agent.
+    Otherwise, a single host thread that allocates scratch on multiple agents
+    produces consecutive ALLOC events that are not actually out of order.
     """
-    # Track operations by thread and flags
-    thread_flag_operations = {}
+    # Track operations by agent, thread and flags
+    agent_thread_flag_operations = {}
 
     for node in scratch_memory_data:
+        agent_id = node["agent_id"]["handle"]
         thread_id = node["thread_id"]
         operation = node["operation"]  # Numeric (1=ALLOC, 2=FREE)
         flags = node["flags"]
         timestamp = node["start_timestamp"]
 
-        key = (thread_id, flags)
-        if key not in thread_flag_operations:
-            thread_flag_operations[key] = []
+        key = (agent_id, thread_id, flags)
+        if key not in agent_thread_flag_operations:
+            agent_thread_flag_operations[key] = []
 
-        thread_flag_operations[key].append((timestamp, operation))
+        agent_thread_flag_operations[key].append((timestamp, operation))
 
-    # Verify proper alternating sequence for each thread+flags combination
-    for (thread_id, flags), operations in thread_flag_operations.items():
+    # Verify proper alternating sequence for each agent+thread+flags combination
+    for (agent_id, thread_id, flags), operations in agent_thread_flag_operations.items():
         # Sort by timestamp to ensure chronological order
         sorted_ops = [op for _, op in sorted(operations)]
 
         # Must start with ALLOC (operation code 1)
         if sorted_ops and sorted_ops[0] != 1:
             raise AssertionError(
-                f"Thread {thread_id}, Flags {flags}: Must start with ALLOC, found operation code {sorted_ops[0]}"
+                f"Agent {agent_id}, Thread {thread_id}, Flags {flags}: Must start with ALLOC, found operation code {sorted_ops[0]}"
             )
 
         # Check for alternating pattern - expected pattern is ALLOC→FREE→ALLOC→FREE
@@ -203,7 +210,7 @@ def verify_scratch_memory_alternating_pattern(scratch_memory_data, bf_op_names):
                 )
 
                 raise AssertionError(
-                    f"Thread {thread_id}, Flags {flags}: Operation #{i+1} should be {expected_name} (code {expected}), found {op_name} (code {sorted_ops[i]})"
+                    f"Agent {agent_id}, Thread {thread_id}, Flags {flags}: Operation #{i+1} should be {expected_name} (code {expected}), found {op_name} (code {sorted_ops[i]})"
                 )
 
 

--- a/projects/rocprofiler-sdk/tests/rocprofv3/scratch-memory/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/scratch-memory/validate.py
@@ -115,7 +115,10 @@ def test_scratch_memory(json_input_data, csv_input_data):
 
     verify_scratch_memory_alternating_pattern(scratch_memory_data, bf_op_names)
     assert 2**64 - 1 not in scratch_reported_agent_ids
-    assert scratch_reported_agent_ids == detected_agents_ids
+    assert scratch_reported_agent_ids, "no scratch memory was reported on any agent"
+    assert scratch_reported_agent_ids.issubset(
+        detected_agents_ids
+    ), f"scratch reported on unknown agents: {scratch_reported_agent_ids - detected_agents_ids}"
 
     assert len(csv_input_data) > 0
 

--- a/projects/rocprofiler-sdk/tests/scratch-memory-tracing/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/scratch-memory-tracing/CMakeLists.txt
@@ -28,8 +28,7 @@ rocprofiler_add_integration_execute_test(
     ENVIRONMENT
         "ROCPROFILER_TOOL_OUTPUT_FILE=scratch-memory-tracing-test.json"
         "LD_LIBRARY_PATH=$<TARGET_FILE_DIR:rocprofiler-sdk::rocprofiler-sdk-shared-library>:$ENV{LD_LIBRARY_PATH}"
-    FIXTURES_SETUP test-scratch-memory-tracing
-    UNSTABLE)
+    FIXTURES_SETUP test-scratch-memory-tracing)
 
 # copy to binary directory
 rocprofiler_add_integration_validate_test(
@@ -40,5 +39,4 @@ rocprofiler_add_integration_validate_test(
     ARGS --input ${CMAKE_CURRENT_BINARY_DIR}/scratch-memory-tracing-test.json
     TIMEOUT 45
     LABELS "integration-tests"
-    FIXTURES_REQUIRED test-scratch-memory-tracing
-    UNSTABLE)
+    FIXTURES_REQUIRED test-scratch-memory-tracing)

--- a/projects/rocprofiler-sdk/tests/scratch-memory-tracing/validate.py
+++ b/projects/rocprofiler-sdk/tests/scratch-memory-tracing/validate.py
@@ -237,9 +237,6 @@ def test_scratch_memory_tracking(input_data):
         scratch_reported_agent_ids.add(node["agent_id"]["handle"])
 
     assert 2**64 - 1 not in scratch_reported_agent_ids
-    # A runner may expose only a subset of the node's GPUs to the workload while
-    # rocprofiler-sdk still enumerates every agent in the topology. Require scratch
-    # to be reported on at least one agent, all of which must be detected GPU agents.
     assert scratch_reported_agent_ids, "no scratch memory was reported on any agent"
     assert scratch_reported_agent_ids.issubset(
         detected_agents_ids

--- a/projects/rocprofiler-sdk/tests/scratch-memory-tracing/validate.py
+++ b/projects/rocprofiler-sdk/tests/scratch-memory-tracing/validate.py
@@ -46,8 +46,6 @@ def test_data_structure(input_data):
 
     sdk_data = data["rocprofiler-sdk-json-tool"]
 
-    num_agents = len([agent for agent in sdk_data["agents"] if agent["type"] == 2])
-
     node_exists("metadata", sdk_data)
     node_exists("pid", sdk_data["metadata"])
     node_exists("main_tid", sdk_data["metadata"])
@@ -65,9 +63,10 @@ def test_data_structure(input_data):
     node_exists("host_functions", sdk_data["callback_records"])
     node_exists("hsa_api_traces", sdk_data["callback_records"])
     node_exists("hip_api_traces", sdk_data["callback_records"], 0)
-    node_exists(
-        "scratch_memory_traces", sdk_data["callback_records"], min_len=(2 * num_agents)
-    )
+    # Each scratch allocation produces a phase-enter and phase-exit callback record.
+    # The workload only exercises the GPUs visible to it (which may be a subset of
+    # all detected agents), so require at least one complete allocation (2 records).
+    node_exists("scratch_memory_traces", sdk_data["callback_records"], min_len=2)
 
     node_exists("names", sdk_data["buffer_records"])
     node_exists("kernel_dispatch", sdk_data["buffer_records"])
@@ -75,9 +74,7 @@ def test_data_structure(input_data):
     node_exists("hsa_api_traces", sdk_data["buffer_records"])
     node_exists("hip_api_traces", sdk_data["buffer_records"], 0)
     node_exists("retired_correlation_ids", sdk_data["buffer_records"])
-    node_exists(
-        "scratch_memory_traces", sdk_data["buffer_records"], min_len=(1 * num_agents)
-    )
+    node_exists("scratch_memory_traces", sdk_data["buffer_records"], min_len=1)
 
 
 def test_timestamps(input_data):
@@ -240,7 +237,13 @@ def test_scratch_memory_tracking(input_data):
         scratch_reported_agent_ids.add(node["agent_id"]["handle"])
 
     assert 2**64 - 1 not in scratch_reported_agent_ids
-    assert scratch_reported_agent_ids == detected_agents_ids
+    # A runner may expose only a subset of the node's GPUs to the workload while
+    # rocprofiler-sdk still enumerates every agent in the topology. Require scratch
+    # to be reported on at least one agent, all of which must be detected GPU agents.
+    assert scratch_reported_agent_ids, "no scratch memory was reported on any agent"
+    assert scratch_reported_agent_ids.issubset(
+        detected_agents_ids
+    ), f"scratch reported on unknown agents: {scratch_reported_agent_ids - detected_agents_ids}"
 
     # { thread-id -> [ events ],  ... }
     cb_threads = defaultdict(list)


### PR DESCRIPTION
## Motivation

Enable scratch memory tracing tests

## Technical Details
Two correctness fixes that were the reason the tests were flaky/unstable in the first place:

- Per-agent alternating-pattern check. The ALLOC→FREE→ALLOC→FREE ordering is now validated per (agent, thread, flags) instead of per (thread, flags). Scratch is managed independently per GPU, so a single host thread allocating on multiple GPUs produces interleaved ALLOC events that aren't actually out of order — the old check falsely flagged those.

- Subset instead of equality for reported agents. Changed `scratch_reported_agent_ids == detected_agents_ids`
to "non-empty and a subset of detected GPU agents." rocprofiler-sdk enumerates every GPU in the node's topology, but a runner only exposes a subset of those GPUs to the workload. Requiring all detected GPUs to report scratch was an environment assumption, not a property of the feature — that's what caused {3900} != {3899..3906}

## JIRA ID

AIROCVAL-39

## Test Plan

Run tests on TheRock CI and ensure they all pass

## Test Result

All tests are passing under TheRock CI

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
