### PR TITLE
[hipFile] Untested use tempfiles for async/basic tests

### DIFF
--- a/.github/workflows/hipfile-ci-system.yml
+++ b/.github/workflows/hipfile-ci-system.yml
@@ -147,7 +147,19 @@ jobs:
             ${GITHUB_WORKSPACE}/hipfile-build-dir/test/hipfile_system_tests \
             ${GITHUB_WORKSPACE}/hipfile-build-dir/test/amd_detail/batch_mt \
             ${GITHUB_WORKSPACE}/hipfile-build-dir/test/amd_detail/state_mt \
-            ${GITHUB_WORKSPACE}/hipfile-build-dir/examples/aiscp/aiscp
+            ${GITHUB_WORKSPACE}/hipfile-build-dir/examples/aiscp/aiscp \
+            ${GITHUB_WORKSPACE}/hipfile-build-dir/examples/basics/bufregister-write \
+            ${GITHUB_WORKSPACE}/hipfile-build-dir/examples/basics/no-bufregister-write \
+            ${GITHUB_WORKSPACE}/hipfile-build-dir/examples/basics/no-odirect-write \
+            ${GITHUB_WORKSPACE}/hipfile-build-dir/examples/basics/iterative-read \
+            ${GITHUB_WORKSPACE}/hipfile-build-dir/examples/basics/iterative-devmem-offset-read \
+            ${GITHUB_WORKSPACE}/hipfile-build-dir/examples/basics/various-mem-rw \
+            ${GITHUB_WORKSPACE}/hipfile-build-dir/examples/basics/subregion-write \
+            ${GITHUB_WORKSPACE}/hipfile-build-dir/examples/basics/roundtrip-verify \
+            ${GITHUB_WORKSPACE}/hipfile-build-dir/examples/async/roundtrip-async \
+            ${GITHUB_WORKSPACE}/hipfile-build-dir/examples/async/roundtrip-async-nonblocking-stream \
+            ${GITHUB_WORKSPACE}/hipfile-build-dir/examples/async/roundtrip-async-multi-stream \
+            ${GITHUB_WORKSPACE}/hipfile-build-dir/examples/async/roundtrip-async-multi-stream-registered
       - name: Copy the hipFile build directory into the container
         run: |
           docker cp \

--- a/projects/hipfile/examples/async/CMakeLists.txt
+++ b/projects/hipfile/examples/async/CMakeLists.txt
@@ -44,15 +44,10 @@ endforeach()
 # parent CMakeLists which only adds this subdirectory when examples are built.
 if(BUILD_TESTING)
     set(ASYNC_TEST_DIR "${AIS_CAPABLE_DIR}/hipfile_async_tests")
-    set(ASYNC_INPUT "${ASYNC_TEST_DIR}/input.bin")
 
     add_test(
         NAME async_setup_dir
         COMMAND ${CMAKE_COMMAND} -E make_directory ${ASYNC_TEST_DIR}
-    )
-    add_test(
-        NAME async_setup_input
-        COMMAND sh -c "dd if=/dev/urandom of='${ASYNC_INPUT}' bs=4096 count=64 status=none"
     )
     add_test(
         NAME async_cleanup
@@ -61,18 +56,17 @@ if(BUILD_TESTING)
     set_tests_properties(async_setup_dir PROPERTIES
         FIXTURES_SETUP async_scratch
     )
-    set_tests_properties(async_setup_input PROPERTIES
-        FIXTURES_SETUP async_scratch
-        DEPENDS async_setup_dir
-    )
     set_tests_properties(async_cleanup PROPERTIES
         FIXTURES_CLEANUP async_scratch
     )
 
+    # Each async example calls seed_read_file() to truncate+seed its READ_FILE,
+    # so we give every test its own input path. This avoids parallel-run races
+    # on a shared input file and removes the need for an upfront dd seeding.
     foreach(example ${ASYNC_EXAMPLES})
         add_test(
             NAME async_${example}
-            COMMAND $<TARGET_FILE:${example}> ${ASYNC_INPUT} out_${example}.bin
+            COMMAND $<TARGET_FILE:${example}> in_${example}.bin out_${example}.bin
             WORKING_DIRECTORY ${ASYNC_TEST_DIR}
         )
         set_tests_properties(async_${example} PROPERTIES

--- a/projects/hipfile/examples/async/CMakeLists.txt
+++ b/projects/hipfile/examples/async/CMakeLists.txt
@@ -43,34 +43,21 @@ endforeach()
 # Gated on BUILD_TESTING; AIS_INSTALL_EXAMPLES is already enforced by the
 # parent CMakeLists which only adds this subdirectory when examples are built.
 if(BUILD_TESTING)
-    set(ASYNC_TEST_DIR "${AIS_CAPABLE_DIR}/hipfile_async_tests")
-
-    add_test(
-        NAME async_setup_dir
-        COMMAND ${CMAKE_COMMAND} -E make_directory ${ASYNC_TEST_DIR}
-    )
-    add_test(
-        NAME async_cleanup
-        COMMAND ${CMAKE_COMMAND} -E rm -rf ${ASYNC_TEST_DIR}
-    )
-    set_tests_properties(async_setup_dir PROPERTIES
-        FIXTURES_SETUP async_scratch
-    )
-    set_tests_properties(async_cleanup PROPERTIES
-        FIXTURES_CLEANUP async_scratch
-    )
-
+    # Each test runs in its own mktemp directory so that parallel ctest
+    # invocations and concurrent CI runners cannot interfere with one another.
+    # The binary is passed as $0 so "$0" "$@" runs it with the file args;
+    # trap ensures the directory is removed even on failure.
+    #
     # Each async example calls seed_read_file() to truncate+seed its READ_FILE,
-    # so we give every test its own input path. This avoids parallel-run races
-    # on a shared input file and removes the need for an upfront dd seeding.
+    # so no upfront dd seeding is needed.
     foreach(example ${ASYNC_EXAMPLES})
         add_test(
             NAME async_${example}
-            COMMAND $<TARGET_FILE:${example}> in_${example}.bin out_${example}.bin
-            WORKING_DIRECTORY ${ASYNC_TEST_DIR}
+            COMMAND sh -c
+                "dir=$(mktemp -d '${AIS_CAPABLE_DIR}/hipfile_async_XXXXXX') && trap 'rm -rf \"$dir\"' EXIT && \"$0\" \"$dir/in_${example}.bin\" \"$dir/out_${example}.bin\""
+                $<TARGET_FILE:${example}>
         )
         set_tests_properties(async_${example} PROPERTIES
-            FIXTURES_REQUIRED async_scratch
             LABELS "system;hipfile;async"
         )
     endforeach()

--- a/projects/hipfile/examples/async/CMakeLists.txt
+++ b/projects/hipfile/examples/async/CMakeLists.txt
@@ -38,3 +38,46 @@ foreach(example ${ASYNC_EXAMPLES})
     target_include_directories(${example} SYSTEM PRIVATE ${HIPFILE_INCLUDE_PATH})
     target_link_libraries(${example} PRIVATE examples_common)
 endforeach()
+
+# CTest wrappers: run each async example as a hipFile system test.
+# Gated on BUILD_TESTING; AIS_INSTALL_EXAMPLES is already enforced by the
+# parent CMakeLists which only adds this subdirectory when examples are built.
+if(BUILD_TESTING)
+    set(ASYNC_TEST_DIR "${AIS_CAPABLE_DIR}/hipfile_async_tests")
+    set(ASYNC_INPUT "${ASYNC_TEST_DIR}/input.bin")
+
+    add_test(
+        NAME async_setup_dir
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${ASYNC_TEST_DIR}
+    )
+    add_test(
+        NAME async_setup_input
+        COMMAND sh -c "dd if=/dev/urandom of='${ASYNC_INPUT}' bs=4096 count=64 status=none"
+    )
+    add_test(
+        NAME async_cleanup
+        COMMAND ${CMAKE_COMMAND} -E rm -rf ${ASYNC_TEST_DIR}
+    )
+    set_tests_properties(async_setup_dir PROPERTIES
+        FIXTURES_SETUP async_scratch
+    )
+    set_tests_properties(async_setup_input PROPERTIES
+        FIXTURES_SETUP async_scratch
+        DEPENDS async_setup_dir
+    )
+    set_tests_properties(async_cleanup PROPERTIES
+        FIXTURES_CLEANUP async_scratch
+    )
+
+    foreach(example ${ASYNC_EXAMPLES})
+        add_test(
+            NAME async_${example}
+            COMMAND $<TARGET_FILE:${example}> ${ASYNC_INPUT} out_${example}.bin
+            WORKING_DIRECTORY ${ASYNC_TEST_DIR}
+        )
+        set_tests_properties(async_${example} PROPERTIES
+            FIXTURES_REQUIRED async_scratch
+            LABELS "system;hipfile;async"
+        )
+    endforeach()
+endif()

--- a/projects/hipfile/examples/basics/CMakeLists.txt
+++ b/projects/hipfile/examples/basics/CMakeLists.txt
@@ -47,10 +47,15 @@ endforeach()
 # parent CMakeLists which only adds this subdirectory when examples are built.
 if(BUILD_TESTING)
     set(BASICS_TEST_DIR "${AIS_CAPABLE_DIR}/hipfile_basics_tests")
+    set(BASICS_INPUT "${BASICS_TEST_DIR}/input.bin")
 
     add_test(
         NAME basics_setup_dir
         COMMAND ${CMAKE_COMMAND} -E make_directory ${BASICS_TEST_DIR}
+    )
+    add_test(
+        NAME basics_setup_input
+        COMMAND dd if=/dev/urandom of=${BASICS_INPUT} bs=4096 count=64 status=none
     )
     add_test(
         NAME basics_cleanup
@@ -59,14 +64,19 @@ if(BUILD_TESTING)
     set_tests_properties(basics_setup_dir PROPERTIES
         FIXTURES_SETUP basics_scratch
     )
+    set_tests_properties(basics_setup_input PROPERTIES
+        FIXTURES_SETUP basics_scratch
+        DEPENDS basics_setup_dir
+    )
     set_tests_properties(basics_cleanup PROPERTIES
         FIXTURES_CLEANUP basics_scratch
     )
 
-    # Every basics example calls seed_read_file() (or O_TRUNC's its input),
-    # so each test gets its own READ_FILE path to avoid races under
-    # `ctest --parallel`. The binaries create/truncate/seed the file
-    # themselves; no upfront dd seed is needed.
+    # The read-style basics tests (iterative-read, iterative-devmem-offset-read,
+    # subregion-write, various-mem-rw) consume BASICS_INPUT read-only, so they
+    # can safely share the dd-seeded fixture file under `ctest --parallel`.
+    # The write-style tests (bufregister-write, no-bufregister-write,
+    # no-odirect-write, roundtrip-verify) create their own output files.
     function(_basics_add_test name)
         add_test(
             NAME basics_${name}
@@ -82,9 +92,9 @@ if(BUILD_TESTING)
     _basics_add_test(bufregister-write            out_bufregister.bin)
     _basics_add_test(no-bufregister-write         out_no_bufregister.bin)
     _basics_add_test(no-odirect-write             out_no_odirect.bin)
-    _basics_add_test(iterative-read               in_iter.bin out_iter.bin)
-    _basics_add_test(iterative-devmem-offset-read in_iter_off.bin out_iter_off.bin)
-    _basics_add_test(subregion-write              in_subregion.bin out_subregion.bin)
+    _basics_add_test(iterative-read               ${BASICS_INPUT} out_iter.bin)
+    _basics_add_test(iterative-devmem-offset-read ${BASICS_INPUT} out_iter_off.bin)
+    _basics_add_test(subregion-write              ${BASICS_INPUT} out_subregion.bin)
     _basics_add_test(roundtrip-verify             rtv_created.bin rtv_copied.bin)
 
     # various-mem-rw exercises MODE = 1 (device), 2 (managed), 3 (pinned-host).
@@ -94,7 +104,7 @@ if(BUILD_TESTING)
         add_test(
             NAME basics_various-mem-rw_${mode_name}
             COMMAND
-                $<TARGET_FILE:various-mem-rw> in_vmrw_${mode_name}.bin
+                $<TARGET_FILE:various-mem-rw> ${BASICS_INPUT}
                 out_vmrw_${mode_name}.bin ${mode_num}
             WORKING_DIRECTORY ${BASICS_TEST_DIR}
         )

--- a/projects/hipfile/examples/basics/CMakeLists.txt
+++ b/projects/hipfile/examples/basics/CMakeLists.txt
@@ -41,3 +41,76 @@ foreach(example ${BASICS_EXAMPLES})
     target_include_directories(${example} SYSTEM PRIVATE ${HIPFILE_INCLUDE_PATH})
     target_link_libraries(${example} PRIVATE examples_common)
 endforeach()
+
+# CTest wrappers: run each example as a hipFile system test.
+# Gated on BUILD_TESTING; AIS_INSTALL_EXAMPLES is already enforced by the
+# parent CMakeLists which only adds this subdirectory when examples are built.
+if(BUILD_TESTING)
+    set(BASICS_TEST_DIR "${AIS_CAPABLE_DIR}/hipfile_basics_tests")
+    set(BASICS_INPUT "${BASICS_TEST_DIR}/input.bin")
+
+    add_test(
+        NAME basics_setup_dir
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${BASICS_TEST_DIR}
+    )
+    add_test(
+        NAME basics_setup_input
+        COMMAND sh -c "dd if=/dev/urandom of='${BASICS_INPUT}' bs=4096 count=64 status=none"
+    )
+    add_test(
+        NAME basics_cleanup
+        COMMAND ${CMAKE_COMMAND} -E rm -rf ${BASICS_TEST_DIR}
+    )
+    set_tests_properties(basics_setup_dir PROPERTIES
+        FIXTURES_SETUP basics_scratch
+    )
+    set_tests_properties(basics_setup_input PROPERTIES
+        FIXTURES_SETUP basics_scratch
+        DEPENDS basics_setup_dir
+    )
+    set_tests_properties(basics_cleanup PROPERTIES
+        FIXTURES_CLEANUP basics_scratch
+    )
+
+    function(_basics_add_test name)
+        add_test(
+            NAME basics_${name}
+            COMMAND $<TARGET_FILE:${name}> ${ARGN}
+            WORKING_DIRECTORY ${BASICS_TEST_DIR}
+        )
+        set_tests_properties(basics_${name} PROPERTIES
+            FIXTURES_REQUIRED basics_scratch
+            LABELS "system;hipfile;basics"
+        )
+    endfunction()
+
+    _basics_add_test(bufregister-write            out_bufregister.bin)
+    _basics_add_test(no-bufregister-write         out_no_bufregister.bin)
+    _basics_add_test(no-odirect-write             out_no_odirect.bin)
+    _basics_add_test(iterative-read               ${BASICS_INPUT} out_iter.bin)
+    _basics_add_test(iterative-devmem-offset-read ${BASICS_INPUT} out_iter_off.bin)
+    _basics_add_test(subregion-write              ${BASICS_INPUT} out_subregion.bin)
+    _basics_add_test(roundtrip-verify             rtv_created.bin rtv_copied.bin)
+
+    # various-mem-rw exercises MODE = 1 (device), 2 (managed), 3 (pinned-host).
+    foreach(mode_pair "1;device" "2;managed" "3;pinned")
+        list(GET mode_pair 0 mode_num)
+        list(GET mode_pair 1 mode_name)
+        add_test(
+            NAME basics_various-mem-rw_${mode_name}
+            COMMAND
+                $<TARGET_FILE:various-mem-rw> ${BASICS_INPUT}
+                out_vmrw_${mode_name}.bin ${mode_num}
+            WORKING_DIRECTORY ${BASICS_TEST_DIR}
+        )
+        set_tests_properties(basics_various-mem-rw_${mode_name} PROPERTIES
+            FIXTURES_REQUIRED basics_scratch
+            LABELS "system;hipfile;basics"
+        )
+        if(mode_name STREQUAL "managed" OR mode_name STREQUAL "pinned")
+            set_tests_properties(basics_various-mem-rw_${mode_name} PROPERTIES
+                DISABLED TRUE
+            )
+        endif()
+    endforeach()
+endif()

--- a/projects/hipfile/examples/basics/CMakeLists.txt
+++ b/projects/hipfile/examples/basics/CMakeLists.txt
@@ -47,15 +47,10 @@ endforeach()
 # parent CMakeLists which only adds this subdirectory when examples are built.
 if(BUILD_TESTING)
     set(BASICS_TEST_DIR "${AIS_CAPABLE_DIR}/hipfile_basics_tests")
-    set(BASICS_INPUT "${BASICS_TEST_DIR}/input.bin")
 
     add_test(
         NAME basics_setup_dir
         COMMAND ${CMAKE_COMMAND} -E make_directory ${BASICS_TEST_DIR}
-    )
-    add_test(
-        NAME basics_setup_input
-        COMMAND sh -c "dd if=/dev/urandom of='${BASICS_INPUT}' bs=4096 count=64 status=none"
     )
     add_test(
         NAME basics_cleanup
@@ -64,14 +59,14 @@ if(BUILD_TESTING)
     set_tests_properties(basics_setup_dir PROPERTIES
         FIXTURES_SETUP basics_scratch
     )
-    set_tests_properties(basics_setup_input PROPERTIES
-        FIXTURES_SETUP basics_scratch
-        DEPENDS basics_setup_dir
-    )
     set_tests_properties(basics_cleanup PROPERTIES
         FIXTURES_CLEANUP basics_scratch
     )
 
+    # Every basics example calls seed_read_file() (or O_TRUNC's its input),
+    # so each test gets its own READ_FILE path to avoid races under
+    # `ctest --parallel`. The binaries create/truncate/seed the file
+    # themselves; no upfront dd seed is needed.
     function(_basics_add_test name)
         add_test(
             NAME basics_${name}
@@ -87,9 +82,9 @@ if(BUILD_TESTING)
     _basics_add_test(bufregister-write            out_bufregister.bin)
     _basics_add_test(no-bufregister-write         out_no_bufregister.bin)
     _basics_add_test(no-odirect-write             out_no_odirect.bin)
-    _basics_add_test(iterative-read               ${BASICS_INPUT} out_iter.bin)
-    _basics_add_test(iterative-devmem-offset-read ${BASICS_INPUT} out_iter_off.bin)
-    _basics_add_test(subregion-write              ${BASICS_INPUT} out_subregion.bin)
+    _basics_add_test(iterative-read               in_iter.bin out_iter.bin)
+    _basics_add_test(iterative-devmem-offset-read in_iter_off.bin out_iter_off.bin)
+    _basics_add_test(subregion-write              in_subregion.bin out_subregion.bin)
     _basics_add_test(roundtrip-verify             rtv_created.bin rtv_copied.bin)
 
     # various-mem-rw exercises MODE = 1 (device), 2 (managed), 3 (pinned-host).
@@ -99,7 +94,7 @@ if(BUILD_TESTING)
         add_test(
             NAME basics_various-mem-rw_${mode_name}
             COMMAND
-                $<TARGET_FILE:various-mem-rw> ${BASICS_INPUT}
+                $<TARGET_FILE:various-mem-rw> in_vmrw_${mode_name}.bin
                 out_vmrw_${mode_name}.bin ${mode_num}
             WORKING_DIRECTORY ${BASICS_TEST_DIR}
         )

--- a/projects/hipfile/examples/basics/CMakeLists.txt
+++ b/projects/hipfile/examples/basics/CMakeLists.txt
@@ -46,56 +46,46 @@ endforeach()
 # Gated on BUILD_TESTING; AIS_INSTALL_EXAMPLES is already enforced by the
 # parent CMakeLists which only adds this subdirectory when examples are built.
 if(BUILD_TESTING)
-    set(BASICS_TEST_DIR "${AIS_CAPABLE_DIR}/hipfile_basics_tests")
-    set(BASICS_INPUT "${BASICS_TEST_DIR}/input.bin")
+    # Each test runs in its own mktemp directory so that parallel ctest
+    # invocations and concurrent CI runners cannot interfere with one another.
+    # The binary is passed as $0 so "$0" "$@" runs it with the file args;
+    # trap ensures the directory is removed even on failure.
 
-    add_test(
-        NAME basics_setup_dir
-        COMMAND ${CMAKE_COMMAND} -E make_directory ${BASICS_TEST_DIR}
-    )
-    add_test(
-        NAME basics_setup_input
-        COMMAND dd if=/dev/urandom of=${BASICS_INPUT} bs=4096 count=64 status=none
-    )
-    add_test(
-        NAME basics_cleanup
-        COMMAND ${CMAKE_COMMAND} -E rm -rf ${BASICS_TEST_DIR}
-    )
-    set_tests_properties(basics_setup_dir PROPERTIES
-        FIXTURES_SETUP basics_scratch
-    )
-    set_tests_properties(basics_setup_input PROPERTIES
-        FIXTURES_SETUP basics_scratch
-        DEPENDS basics_setup_dir
-    )
-    set_tests_properties(basics_cleanup PROPERTIES
-        FIXTURES_CLEANUP basics_scratch
-    )
-
-    # The read-style basics tests (iterative-read, iterative-devmem-offset-read,
-    # subregion-write, various-mem-rw) consume BASICS_INPUT read-only, so they
-    # can safely share the dd-seeded fixture file under `ctest --parallel`.
-    # The write-style tests (bufregister-write, no-bufregister-write,
-    # no-odirect-write, roundtrip-verify) create their own output files.
-    function(_basics_add_test name)
+    # Write-only tests: no input file needed, just a fresh working directory.
+    function(_basics_add_write_test name)
         add_test(
             NAME basics_${name}
-            COMMAND $<TARGET_FILE:${name}> ${ARGN}
-            WORKING_DIRECTORY ${BASICS_TEST_DIR}
+            COMMAND sh -c
+                "dir=$(mktemp -d '${AIS_CAPABLE_DIR}/hipfile_basics_XXXXXX') && trap 'rm -rf \"$dir\"' EXIT && cd \"$dir\" && \"$0\" \"$@\""
+                $<TARGET_FILE:${name}> ${ARGN}
         )
         set_tests_properties(basics_${name} PROPERTIES
-            FIXTURES_REQUIRED basics_scratch
             LABELS "system;hipfile;basics"
         )
     endfunction()
 
-    _basics_add_test(bufregister-write            out_bufregister.bin)
-    _basics_add_test(no-bufregister-write         out_no_bufregister.bin)
-    _basics_add_test(no-odirect-write             out_no_odirect.bin)
-    _basics_add_test(iterative-read               ${BASICS_INPUT} out_iter.bin)
-    _basics_add_test(iterative-devmem-offset-read ${BASICS_INPUT} out_iter_off.bin)
-    _basics_add_test(subregion-write              ${BASICS_INPUT} out_subregion.bin)
-    _basics_add_test(roundtrip-verify             rtv_created.bin rtv_copied.bin)
+    # Read tests: seed a fresh input.bin in the temp dir, then run.
+    # Callers pass 'input.bin' as the input argument; it resolves relative to
+    # the cd'd temp dir.
+    function(_basics_add_read_test name)
+        add_test(
+            NAME basics_${name}
+            COMMAND sh -c
+                "dir=$(mktemp -d '${AIS_CAPABLE_DIR}/hipfile_basics_XXXXXX') && trap 'rm -rf \"$dir\"' EXIT && dd if=/dev/urandom of=\"$dir/input.bin\" bs=4096 count=64 status=none && cd \"$dir\" && \"$0\" \"$@\""
+                $<TARGET_FILE:${name}> ${ARGN}
+        )
+        set_tests_properties(basics_${name} PROPERTIES
+            LABELS "system;hipfile;basics"
+        )
+    endfunction()
+
+    _basics_add_write_test(bufregister-write            out_bufregister.bin)
+    _basics_add_write_test(no-bufregister-write         out_no_bufregister.bin)
+    _basics_add_write_test(no-odirect-write             out_no_odirect.bin)
+    _basics_add_read_test(iterative-read               input.bin out_iter.bin)
+    _basics_add_read_test(iterative-devmem-offset-read input.bin out_iter_off.bin)
+    _basics_add_read_test(subregion-write              input.bin out_subregion.bin)
+    _basics_add_write_test(roundtrip-verify            rtv_created.bin rtv_copied.bin)
 
     # various-mem-rw exercises MODE = 1 (device), 2 (managed), 3 (pinned-host).
     foreach(mode_pair "1;device" "2;managed" "3;pinned")
@@ -103,13 +93,11 @@ if(BUILD_TESTING)
         list(GET mode_pair 1 mode_name)
         add_test(
             NAME basics_various-mem-rw_${mode_name}
-            COMMAND
-                $<TARGET_FILE:various-mem-rw> ${BASICS_INPUT}
-                out_vmrw_${mode_name}.bin ${mode_num}
-            WORKING_DIRECTORY ${BASICS_TEST_DIR}
+            COMMAND sh -c
+                "dir=$(mktemp -d '${AIS_CAPABLE_DIR}/hipfile_basics_XXXXXX') && trap 'rm -rf \"$dir\"' EXIT && dd if=/dev/urandom of=\"$dir/input.bin\" bs=4096 count=64 status=none && cd \"$dir\" && \"$0\" \"$@\""
+                $<TARGET_FILE:various-mem-rw> input.bin out_vmrw_${mode_name}.bin ${mode_num}
         )
         set_tests_properties(basics_various-mem-rw_${mode_name} PROPERTIES
-            FIXTURES_REQUIRED basics_scratch
             LABELS "system;hipfile;basics"
         )
         if(mode_name STREQUAL "managed" OR mode_name STREQUAL "pinned")


### PR DESCRIPTION
## Motivation

Ensure hipfile CI runners don't conflict when running file tests.

Fix for issues seen in https://github.com/ROCm/rocm-systems/pull/6534

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

AIHIPFILE-200

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
