### PR TITLE
[rocprofiler-sdk] Remove counter callbacks when stopping counter collection

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/core.cpp
@@ -32,6 +32,7 @@
 #include "lib/rocprofiler-sdk/hsa/queue.hpp"
 #include "lib/rocprofiler-sdk/hsa/queue_controller.hpp"
 #include "lib/rocprofiler-sdk/kernel_dispatch/profiling_time.hpp"
+#include "lib/rocprofiler-sdk/registration.hpp"
 
 #include <rocprofiler-sdk/fwd.h>
 
@@ -221,12 +222,19 @@ stop_context(const context::context* ctx)
     {
         controller->disable_serialization();
 
-        for(auto& cb : ctx->dispatch_counter_collection->callbacks)
+        // In attach mode, remove counter callbacks when stopping the context so
+        // new dispatches during detach drain can pass through without incrementing
+        // _active_kernels. In normal profiling, keep callbacks registered to avoid
+        // dropping counter data for in-flight dispatches.
+        if(registration::is_attached())
         {
-            if(cb->queue_id != rocprofiler::hsa::ClientID{-1})
+            for(auto& cb : ctx->dispatch_counter_collection->callbacks)
             {
-                controller->remove_callback(cb->queue_id);
-                cb->queue_id = rocprofiler::hsa::ClientID{-1};
+                if(cb->queue_id != rocprofiler::hsa::ClientID{-1})
+                {
+                    controller->remove_callback(cb->queue_id);
+                    cb->queue_id = rocprofiler::hsa::ClientID{-1};
+                }
             }
         }
     }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/core.cpp
@@ -217,7 +217,19 @@ stop_context(const context::context* ctx)
         enabled = false;
     });
 
-    if(controller) controller->disable_serialization();
+    if(controller)
+    {
+        controller->disable_serialization();
+
+        for(auto& cb : ctx->dispatch_counter_collection->callbacks)
+        {
+            if(cb->queue_id != rocprofiler::hsa::ClientID{-1})
+            {
+                controller->remove_callback(cb->queue_id);
+                cb->queue_id = rocprofiler::hsa::ClientID{-1};
+            }
+        }
+    }
 
     callback_thread_stop();
 }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
@@ -263,8 +263,8 @@ get_status()
 
 struct attach_status
 {
-    bool has_attach_table = false;
-    bool is_attached      = false;
+    std::atomic<bool> has_attach_table{false};
+    std::atomic<bool> is_attached{false};
 };
 
 auto*
@@ -761,6 +761,9 @@ invoke_client_attaches()
         }
     }
 
+    if(ret == ROCPROFILER_STATUS_SUCCESS && get_attach_status())
+        get_attach_status()->is_attached.store(true, std::memory_order_release);
+
     return ret;
 }
 
@@ -800,6 +803,9 @@ invoke_client_detaches()
             ROCP_INFO << "Client " << itr->name << " does not have tool_detach function";
         }
     }
+
+    if(get_attach_status())
+        get_attach_status()->is_attached.store(false, std::memory_order_release);
 
     return ret;
 }
@@ -842,9 +848,18 @@ invoke_client_finalizer(rocprofiler_client_id_t client_id)
 }  // namespace
 
 bool
+is_attached()
+{
+    return (get_attach_status()) ? get_attach_status()->is_attached.load(std::memory_order_acquire)
+                                 : false;
+}
+
+bool
 supports_attachment()
 {
-    return (get_attach_status()) ? get_attach_status()->has_attach_table : false;
+    return (get_attach_status())
+               ? get_attach_status()->has_attach_table.load(std::memory_order_acquire)
+               : false;
 }
 
 void

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.hpp
@@ -74,6 +74,9 @@ void
 set_fini_status(int);
 
 bool
+is_attached();
+
+bool
 supports_attachment();
 
 // call tool_attach function for all registered clients


### PR DESCRIPTION
## Motivation

Fix intermittent attach-once timeouts observed when running rocprofv3 attach with PMC enabled.

During detach, `queue_controller_sync()` may wait for active kernels to drain while counter collection has already been stopped. However, counter collection queue callbacks can remain registered, causing new dispatches to still be tracked by the queue interceptor and keep `_active_kernels` nonzero.

## Technical Details

Unregister counter collection queue callbacks during `stop_context()` by calling `remove_callback()`, consistent with the SPM and thread trace stop paths. e.g. https://github.com/ROCm/rocm-systems/blob/fbd715e567dcd964024f23daa3d55b913e20f732/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/core.cpp#L341
https://github.com/ROCm/rocm-systems/blob/fbd715e567dcd964024f23daa3d55b913e20f732/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp#L521

This allows new dispatches after counter collection is stopped to pass through without being tracked as active profiler work during detach.

## JIRA ID

part of ROCM-23882

## Test Plan

Ran the attach-once test with PMC enabled using `--pmc SQ_WAVES`.

Also verified the timeout path with debug logging before the fix, confirming that counter collection was disabled while queue callbacks remained registered.

## Test Result

With this change applied on top of the test branch, the attach-once PMC test completed successfully for 20 consecutive runs without observing the queue-sync timeout.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
