### PR TITLE
[rocshmem4py] cmake changes for TheRock packaging

### DIFF
--- a/projects/rocshmem/CMakeLists.txt
+++ b/projects/rocshmem/CMakeLists.txt
@@ -65,6 +65,7 @@ option(BUILD_FUNCTIONAL_TESTS "Build the functional tests (uses MPI if available
 option(BUILD_EXAMPLES "Build the examples" OFF)
 option(BUILD_UNIT_TESTS "Build the unit tests (Requires MPI)" OFF)
 option(BUILD_PYTHON_TESTS "Install rocshmem4py test assets (RO execution requires MPI launcher, Python, pip)" OFF)
+option(BUILD_PYTHON_BINDING "Build and install the rocshmem4py Python binding" OFF)
 option(BUILD_TESTS_ONLY "Build only tests. Used to link against rocSHMEM in a ROCm Release" OFF)
 option(BUILD_TOOLS "Build binary tools (e.g., rocshmem_info)" ON)
 option(BUILD_CTESTS "Register tests with CTest for tier-based execution" ON)
@@ -553,5 +554,17 @@ add_subdirectory(tests)
 
 if (BUILD_EXAMPLES)
   add_subdirectory(examples)
+endif()
+
+###############################################################################
+# PYTHON BINDING (rocshmem4py)
+#
+# Opt-in build of the rocshmem4py Python extension as a sub-project. Decoupled
+# from BUILD_PYTHON_TESTS so packagers (e.g. TheRock) can ship the binding
+# without test assets, and vice versa. python/CMakeLists.txt detects sub-
+# project mode and links against the in-tree `rocshmem` target directly.
+###############################################################################
+if (BUILD_PYTHON_BINDING AND NOT BUILD_TESTS_ONLY)
+  add_subdirectory(python)
 endif()
 

--- a/projects/rocshmem/python/CMakeLists.txt
+++ b/projects/rocshmem/python/CMakeLists.txt
@@ -45,10 +45,26 @@ if(ROCSHMEM4PY_IS_TOP_LEVEL)
   project(rocshmem4py LANGUAGES CXX)
 endif()
 
-find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
-find_program(PYTHON_EXECUTABLE NAMES python3 python REQUIRED)
+# Single Python discovery for the whole file.  nanobind's CMake config
+# requires the modern FindPython module with the Development.Module component
+# (Development.Module is sufficient for building extension modules and avoids
+# pulling in the embed/libpython requirement of the full Development component).
+#
+# Honor an explicitly provided interpreter so downstream builds pin the right
+# Python: setuptools passes -DPYTHON_EXECUTABLE, and the TheRock super-build
+# passes -DPython3_EXECUTABLE.  FindPython only consults Python_EXECUTABLE, so
+# seed it from whichever hint was given.
+if(NOT DEFINED Python_EXECUTABLE)
+  if(DEFINED PYTHON_EXECUTABLE)
+    set(Python_EXECUTABLE "${PYTHON_EXECUTABLE}")
+  elseif(DEFINED Python3_EXECUTABLE)
+    set(Python_EXECUTABLE "${Python3_EXECUTABLE}")
+  endif()
+endif()
+find_package(Python 3.8 COMPONENTS Interpreter Development.Module REQUIRED)
+set(PYTHON_EXECUTABLE "${Python_EXECUTABLE}" CACHE FILEPATH "Python interpreter" FORCE)
 
-message(STATUS "Python3_VERSION: ${Python3_VERSION}")
+message(STATUS "Python_VERSION: ${Python_VERSION}")
 message(STATUS "CMAKE_CXX_COMPILER: ${CMAKE_CXX_COMPILER}")
 
 set(CMAKE_CXX_STANDARD 17)
@@ -94,21 +110,32 @@ else()
   link_directories(${HIP_ROOT_DIR}/lib)
 endif()
 
-# Find pybind11
+# Binding backend: nanobind.  It builds the `_rocshmem4py` module whose module
+# name, function names, argument behavior, and return types are the stable
+# public API contract.  (Python was already located above with the
+# Development.Module component nanobind needs.)
+#
+# nanobind discovery is two-tiered:
+#   1. Standalone (pip) builds: nanobind is pip-installed, so ask the Python
+#      module for its CMake config directory and add it to the prefix path.
+#   2. TheRock super-build: nanobind is provided as a CMake subproject
+#      (therock-nanobind), so `python -m nanobind` is unavailable -- the
+#      execute_process fails harmlessly and find_package resolves the
+#      subproject-provided package config instead.
 execute_process(
-  COMMAND ${PYTHON_EXECUTABLE} -c 
-          "from __future__ import print_function; import os; import pybind11; print(os.path.dirname(pybind11.__file__), end='')"
-  RESULT_VARIABLE _PYTHON_SUCCESS
-  OUTPUT_VARIABLE PYBIND11_DIR
+  COMMAND ${Python_EXECUTABLE} -m nanobind --cmake_dir
+  RESULT_VARIABLE _NB_CMAKE_DIR_OK
+  OUTPUT_VARIABLE _NB_CMAKE_DIR
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  ERROR_QUIET
 )
-
-if(NOT _PYTHON_SUCCESS MATCHES 0)
-  message(FATAL_ERROR "pybind11 not found. Install with: pip install pybind11")
+if(_NB_CMAKE_DIR_OK EQUAL 0 AND _NB_CMAKE_DIR)
+  message(STATUS "nanobind CMake dir (pip): ${_NB_CMAKE_DIR}")
+  list(APPEND CMAKE_PREFIX_PATH ${_NB_CMAKE_DIR})
 endif()
 
-message(STATUS "pybind11 directory: ${PYBIND11_DIR}")
-list(APPEND CMAKE_PREFIX_PATH ${PYBIND11_DIR})
-find_package(pybind11 REQUIRED)
+find_package(nanobind CONFIG REQUIRED)
+message(STATUS "nanobind found: ${nanobind_DIR}")
 
 # Sub-project: the parent CMake exposes the in-tree rocshmem target.
 # Standalone: locate an installed rocSHMEM via ROCSHMEM_HOME.
@@ -168,7 +195,21 @@ endif()
 # Build Extension Module
 ###############################################################################
 
-pybind11_add_module(_rocshmem4py src/rocshmem4py.cc)
+nanobind_add_module(_rocshmem4py NB_STATIC src/rocshmem4py.cc)
+# rocSHMEM bindings throw std::runtime_error (translated to RuntimeError)
+# and the team-config caster relies on RTTI.  nanobind defaults to
+# -fno-rtti/-fno-exceptions, so re-enable them here and undo any global
+# compile options that would otherwise disable exceptions on the static
+# nanobind helper library.
+target_compile_options(_rocshmem4py PRIVATE -frtti -fexceptions)
+if(TARGET nanobind-static)
+  get_target_property(_NB_OPTS nanobind-static COMPILE_OPTIONS)
+  if(_NB_OPTS)
+    list(REMOVE_ITEM _NB_OPTS "-fno-rtti" "-fno-exceptions")
+    set_target_properties(nanobind-static PROPERTIES COMPILE_OPTIONS "${_NB_OPTS}")
+  endif()
+  target_compile_options(nanobind-static PRIVATE -frtti -fexceptions)
+endif()
 
 set_target_properties(_rocshmem4py PROPERTIES
   POSITION_INDEPENDENT_CODE ON
@@ -176,7 +217,7 @@ set_target_properties(_rocshmem4py PROPERTIES
 
 target_include_directories(_rocshmem4py PRIVATE
   ${ROCSHMEM_INCLUDE_DIRS}
-  ${Python3_INCLUDE_DIRS}
+  ${Python_INCLUDE_DIRS}
   ${ROCM_PATH}/include
 )
 if(THEROCK_TOOLCHAIN_ROOT)

--- a/projects/rocshmem/python/CMakeLists.txt
+++ b/projects/rocshmem/python/CMakeLists.txt
@@ -1,15 +1,21 @@
 cmake_minimum_required(VERSION 3.16)
 
 ###############################################################################
-# ROCM/HIP Configuration
+# Build mode: Standalone vs Sub-project
 #
-# Two supported layouts:
-#   1. Standard ROCm install:  hipcc at ${ROCM_PATH}/bin/hipcc
-#                              HIP at  ${ROCM_PATH}/{include,lib,lib/cmake/hip}
-#   2. TheRock toolchain:      hipcc at ${THEROCK_TOOLCHAIN_ROOT}/lib/llvm/bin/hipcc
-#                              HIP at  ${THEROCK_TOOLCHAIN_ROOT}/{include,lib,lib/cmake/hip}
+# Standalone:  pip install / direct cmake on python/. This CMakeLists is the
+#              top-level project; we must locate hipcc and pin
+#              CMAKE_CXX_COMPILER ourselves before calling project().
+# Sub-project: added via add_subdirectory() from the parent rocSHMEM CMake
+#              (TheRock super-build). The parent has already run project()
+#              with the right toolchain, so we skip compiler selection.
 #
 ###############################################################################
+set(ROCSHMEM4PY_IS_TOP_LEVEL FALSE)
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  set(ROCSHMEM4PY_IS_TOP_LEVEL TRUE)
+endif()
+
 if(DEFINED ENV{THEROCK_TOOLCHAIN_ROOT} AND NOT THEROCK_TOOLCHAIN_ROOT)
   set(THEROCK_TOOLCHAIN_ROOT "$ENV{THEROCK_TOOLCHAIN_ROOT}" CACHE PATH "TheRock toolchain root")
 endif()
@@ -22,22 +28,22 @@ else()
   set(ROCM_PATH "/opt/rocm" CACHE STRING "ROCm install directory")
 endif()
 
-# Locate hipcc; prefer ROCM_PATH/bin then TheRock's lib/llvm/bin layout.
-find_program(HIPCC_EXECUTABLE hipcc
-             PATHS
-               ${ROCM_PATH}/bin
-               ${THEROCK_TOOLCHAIN_ROOT}/lib/llvm/bin
-             NO_DEFAULT_PATH)
+if(ROCSHMEM4PY_IS_TOP_LEVEL)
+  find_program(HIPCC_EXECUTABLE hipcc
+               PATHS
+                 ${ROCM_PATH}/bin
+                 ${THEROCK_TOOLCHAIN_ROOT}/lib/llvm/bin
+               NO_DEFAULT_PATH)
 
-if(NOT HIPCC_EXECUTABLE)
-  message(FATAL_ERROR "hipcc not found under ${ROCM_PATH}/bin or "
-                      "${THEROCK_TOOLCHAIN_ROOT}/lib/llvm/bin. "
-                      "Set ROCM_PATH or THEROCK_TOOLCHAIN_ROOT.")
+  if(NOT HIPCC_EXECUTABLE)
+    message(FATAL_ERROR "hipcc not found under ${ROCM_PATH}/bin or "
+                        "${THEROCK_TOOLCHAIN_ROOT}/lib/llvm/bin. "
+                        "Set ROCM_PATH or THEROCK_TOOLCHAIN_ROOT.")
+  endif()
+
+  set(CMAKE_CXX_COMPILER "${HIPCC_EXECUTABLE}" CACHE FILEPATH "C++ compiler")
+  project(rocshmem4py LANGUAGES CXX)
 endif()
-
-# CMake chooses the compiler during project(), so set it first.
-set(CMAKE_CXX_COMPILER "${HIPCC_EXECUTABLE}" CACHE FILEPATH "C++ compiler")
-project(rocshmem4py LANGUAGES CXX)
 
 find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
 find_program(PYTHON_EXECUTABLE NAMES python3 python REQUIRED)
@@ -61,7 +67,6 @@ set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 # Find Dependencies
 ###############################################################################
 
-# Find HIP. Probe both ROCM_PATH and THEROCK_TOOLCHAIN_ROOT layouts.
 list(APPEND CMAKE_PREFIX_PATH
      ${ROCM_PATH} ${ROCM_PATH}/hip ${ROCM_PATH}/lib/cmake/hip)
 if(THEROCK_TOOLCHAIN_ROOT)
@@ -105,47 +110,58 @@ message(STATUS "pybind11 directory: ${PYBIND11_DIR}")
 list(APPEND CMAKE_PREFIX_PATH ${PYBIND11_DIR})
 find_package(pybind11 REQUIRED)
 
-# Find ROCSHMEM
-if(DEFINED ENV{ROCSHMEM_HOME})
-  set(ROCSHMEM_HOME "$ENV{ROCSHMEM_HOME}" CACHE STRING "ROCSHMEM install directory")
-  list(APPEND CMAKE_PREFIX_PATH ${ROCSHMEM_HOME})
-endif()
-
-find_path(ROCSHMEM_INCLUDE_DIR 
-  NAMES rocshmem/rocshmem.hpp
-  PATHS 
-    ${ROCSHMEM_HOME}
-    ${ROCSHMEM_HOME}/../include
-    /opt/rocm
-  PATH_SUFFIXES include
-  NO_DEFAULT_PATH
-)
-
-find_library(ROCSHMEM_LIBRARY
-  NAMES rocshmem
-  PATHS 
-    ${ROCSHMEM_HOME}
-    ${ROCSHMEM_HOME}/lib
-    /opt/rocm
-  PATH_SUFFIXES lib lib64
-  NO_DEFAULT_PATH
-)
-
-if(ROCSHMEM_INCLUDE_DIR AND ROCSHMEM_LIBRARY)
+# Sub-project: the parent CMake exposes the in-tree rocshmem target.
+# Standalone: locate an installed rocSHMEM via ROCSHMEM_HOME.
+if(TARGET rocshmem)
   set(ROCSHMEM_FOUND TRUE)
-  set(ROCSHMEM_INCLUDE_DIRS ${ROCSHMEM_INCLUDE_DIR})
-  if(EXISTS "${ROCSHMEM_HOME}/include/rocshmem")
-    list(APPEND ROCSHMEM_INCLUDE_DIRS "${ROCSHMEM_HOME}/include/rocshmem")
-  endif()
-  if(EXISTS "${ROCSHMEM_HOME}/include")
-    list(APPEND ROCSHMEM_INCLUDE_DIRS "${ROCSHMEM_HOME}/include")
-  endif()
-  set(ROCSHMEM_LIBRARIES ${ROCSHMEM_LIBRARY})
-  message(STATUS "ROCSHMEM found!")
-  message(STATUS "  ROCSHMEM_INCLUDE_DIRS: ${ROCSHMEM_INCLUDE_DIRS}")
-  message(STATUS "  ROCSHMEM_LIBRARIES: ${ROCSHMEM_LIBRARIES}")
+  set(ROCSHMEM_LINK_TARGET roc::rocshmem)
+  set(ROCSHMEM_INCLUDE_DIRS
+      ${CMAKE_SOURCE_DIR}/include
+      ${CMAKE_BINARY_DIR}/include)
+  message(STATUS "ROCSHMEM target found in parent project: ${ROCSHMEM_LINK_TARGET}")
 else()
-  message(FATAL_ERROR "ROCSHMEM not found. Set ROCSHMEM_HOME environment variable.")
+  if(DEFINED ENV{ROCSHMEM_HOME})
+    set(ROCSHMEM_HOME "$ENV{ROCSHMEM_HOME}" CACHE STRING "ROCSHMEM install directory")
+    list(APPEND CMAKE_PREFIX_PATH ${ROCSHMEM_HOME})
+  endif()
+
+  find_path(ROCSHMEM_INCLUDE_DIR
+    NAMES rocshmem/rocshmem.hpp
+    PATHS
+      ${ROCSHMEM_HOME}
+      ${ROCSHMEM_HOME}/../include
+      /opt/rocm
+    PATH_SUFFIXES include
+    NO_DEFAULT_PATH
+  )
+
+  find_library(ROCSHMEM_LIBRARY
+    NAMES rocshmem
+    PATHS
+      ${ROCSHMEM_HOME}
+      ${ROCSHMEM_HOME}/lib
+      /opt/rocm
+    PATH_SUFFIXES lib lib64
+    NO_DEFAULT_PATH
+  )
+
+  if(ROCSHMEM_INCLUDE_DIR AND ROCSHMEM_LIBRARY)
+    set(ROCSHMEM_FOUND TRUE)
+    set(ROCSHMEM_INCLUDE_DIRS ${ROCSHMEM_INCLUDE_DIR})
+    if(EXISTS "${ROCSHMEM_HOME}/include/rocshmem")
+      list(APPEND ROCSHMEM_INCLUDE_DIRS "${ROCSHMEM_HOME}/include/rocshmem")
+    endif()
+    if(EXISTS "${ROCSHMEM_HOME}/include")
+      list(APPEND ROCSHMEM_INCLUDE_DIRS "${ROCSHMEM_HOME}/include")
+    endif()
+    set(ROCSHMEM_LIBRARIES ${ROCSHMEM_LIBRARY})
+    set(ROCSHMEM_LINK_TARGET ${ROCSHMEM_LIBRARIES})
+    message(STATUS "ROCSHMEM found!")
+    message(STATUS "  ROCSHMEM_INCLUDE_DIRS: ${ROCSHMEM_INCLUDE_DIRS}")
+    message(STATUS "  ROCSHMEM_LIBRARIES: ${ROCSHMEM_LIBRARIES}")
+  else()
+    message(FATAL_ERROR "ROCSHMEM not found. Set ROCSHMEM_HOME environment variable.")
+  endif()
 endif()
 
 ###############################################################################
@@ -173,13 +189,13 @@ find_package(MPI QUIET)
 
 if(hip_FOUND)
   target_link_libraries(_rocshmem4py PRIVATE
-    ${ROCSHMEM_LIBRARIES}
+    ${ROCSHMEM_LINK_TARGET}
     hip::device
     hip::host
   )
 else()
   target_link_libraries(_rocshmem4py PRIVATE
-    ${ROCSHMEM_LIBRARIES}
+    ${ROCSHMEM_LINK_TARGET}
     amdhip64
     hsa-runtime64
   )
@@ -208,6 +224,19 @@ target_link_options(_rocshmem4py PRIVATE
   -lhsa-runtime64
 )
 
-install(TARGETS _rocshmem4py
-  LIBRARY DESTINATION .
-)
+if(ROCSHMEM4PY_IS_TOP_LEVEL)
+  # Standalone: setuptools positions the .so via CMAKE_LIBRARY_OUTPUT_DIRECTORY;
+  # install(.) lands the extension at the wheel root for built distributions.
+  install(TARGETS _rocshmem4py LIBRARY DESTINATION .)
+else()
+  # Sub-project (TheRock super-build): ship the binding under the rocSHMEM
+  # subtree alongside lib/*.bc, lib/cmake/rocshmem, share/rocshmem.
+  # Consumers add <prefix>/lib/rocshmem/python to PYTHONPATH.
+  include(GNUInstallDirs)
+  set(_ROCSHMEM4PY_DEST "${CMAKE_INSTALL_LIBDIR}/rocshmem/python/rocshmem4py")
+  install(TARGETS _rocshmem4py LIBRARY DESTINATION ${_ROCSHMEM4PY_DEST})
+  install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/rocshmem4py/
+    DESTINATION ${_ROCSHMEM4PY_DEST}
+    FILES_MATCHING PATTERN "*.py"
+  )
+endif()

--- a/projects/rocshmem/python/README.md
+++ b/projects/rocshmem/python/README.md
@@ -35,7 +35,7 @@ Host-facing symbols are exported directly from the compiled extension module
 - rocSHMEM library (built with RO, IPC, or GDA backend)
 - Python 3.8+
 - CMake 3.20+
-- pybind11 2.13.1+
+- nanobind 2.12.0+ (binding backend)
 - Distributed launcher: `torchrun` (for `init_with_torch()`, IPC/GDA
   backends) **or** `mpirun` (for `init_with_mpi()`, and required by the RO
   backend regardless of init path &mdash; see [*RO backend requires `mpirun`*](#ro-backend-requires-mpirun) below).
@@ -50,11 +50,25 @@ export ROCM_PATH=/opt/rocm
 export ROCSHMEM_HOME=/path/to/rocshmem/build
 export LD_LIBRARY_PATH=$ROCSHMEM_HOME/lib:$ROCM_PATH/lib:$LD_LIBRARY_PATH
 
-pip install pybind11 cmake
 pip install -e .
 ```
 
+The build requirements (`nanobind`, `cmake`) are declared in
+`pyproject.toml`, so a standard `pip install -e .` pulls them into the build
+isolation environment automatically. If you build with
+`--no-build-isolation`, install them into your environment first:
+`pip install nanobind cmake`.
+
 > Note: this package is not published to PyPI yet; install from source only.
+
+### Binding backend
+
+`rocshmem4py` uses **nanobind** to build the compiled extension module
+(`_rocshmem4py`). The public Python contract &mdash; module name, function
+names, argument behavior, and return types &mdash; is stable and independent
+of the binding framework. Framework-independent rocSHMEM glue lives in
+`src/rocshmem4py_common.hpp`; the thin `m.def(...)` registration layer lives in
+`src/rocshmem4py.cc`.
 
 ## Quick Start
 

--- a/projects/rocshmem/python/README.md
+++ b/projects/rocshmem/python/README.md
@@ -36,8 +36,12 @@ Host-facing symbols are exported directly from the compiled extension module
 - Python 3.8+
 - CMake 3.20+
 - pybind11 2.13.1+
-- OpenMPI with UCX support (required for the RO backend)
-- `mpi4py` (only required when using `init_with_mpi()`)
+- Distributed launcher: `torchrun` (for `init_with_torch()`, IPC/GDA
+  backends) **or** `mpirun` (for `init_with_mpi()`, and required by the RO
+  backend regardless of init path &mdash; see [*RO backend requires `mpirun`*](#ro-backend-requires-mpirun) below).
+- ROCm-aware Open MPI 5.0.x + UCX 1.17+ &mdash; **RO backend only**; any
+  distro Open MPI works for IPC/GDA bootstrap. See [*ROCm-aware Open MPI required for RO*](#rocm-aware-open-mpi-required-for-ro) below.
+- `mpi4py` (only when using `init_with_mpi()`).
 
 ## Installation
 
@@ -289,7 +293,7 @@ suite's own README:
 | `ImportError: _rocshmem4py` | rocSHMEM not on the loader path | `export LD_LIBRARY_PATH=$ROCSHMEM_HOME/lib:$ROCM_PATH/lib:$LD_LIBRARY_PATH` |
 | CMake cannot find rocSHMEM at build time | `ROCSHMEM_HOME` unset | `export ROCSHMEM_HOME=/path/to/rocshmem/build` before `pip install -e .` |
 | Link error: `recompile with -fPIC` | `librocshmem.a` built without PIC | Rebuild rocSHMEM with `-DCMAKE_POSITION_INDEPENDENT_CODE=ON` |
-| MPI / UCX import or runtime errors | OpenMPI not built with UCX | Use an OpenMPI install with UCX and point `OMPI_DIR` at it |
+| RO backend hangs in `mca_btl_vader.so` (`Wrote -1, errno = 14`), aborts with `MPI_ERR_WIN: invalid window`, or hangs at exit in `__run_exit_handlers` &rarr; `libamdhip64` | Non-ROCm-aware Open MPI / UCX cannot handle GPU buffers in the data plane | Use ROCm-aware Open MPI 5.0.x + UCX 1.17+ &mdash; see [below](#rocm-aware-open-mpi-required-for-ro) |
 | `Unsupported configuration to initialize rocSHMEM. Please initialize the MPI library using MPI_Init first` | RO backend launched under `torchrun` &mdash; see *"RO backend requires `mpirun`"* below | Launch with `mpirun` (you can keep `init_with_torch()`), or build an IPC/GDA-only rocSHMEM if you don't need inter-node RDMA |
 | Rendezvous / port conflict under `torchrun` | Default `MASTER_PORT=29500` already taken | Set `MASTER_PORT` (or `ROCSHMEM_MASTER_PORT`) to a free port |
 
@@ -307,6 +311,24 @@ in disjoint singleton MPI universes, and that crashes inside OMPI's PMIx
 wireup. Use `mpirun` for RO; `init_with_torch()` itself still works
 under `mpirun`, so you keep the `torch.distributed` unique-id exchange
 and only the launcher changes.
+
+### ROCm-aware Open MPI required for RO
+
+Only RO backend builds need ROCm-aware **Open MPI 5.0.x + UCX 1.17+ built
+with `--with-rocm`** for data-plane RMA. IPC and GDA backends use MPI
+only for bootstrap and work with any distro Open MPI (see prereqs and
+troubleshooting above).
+
+Verify on the launch host:
+
+```bash
+mpirun --version           # must say "Open MPI v5.0.x"
+ucx_info -d | grep rocm    # must list rocm_copy and rocm_ipc transports
+```
+
+See the rocSHMEM
+[install docs](https://github.com/ROCm/rocm-systems/blob/develop/projects/rocshmem/docs/install.rst#install-dependencies)
+for build instructions.
 
 ### Diagnosing which rocSHMEM backend you actually linked
 

--- a/projects/rocshmem/python/pyproject.toml
+++ b/projects/rocshmem/python/pyproject.toml
@@ -1,9 +1,10 @@
 [build-system]
+# nanobind is the binding backend (used by TheRock).
 requires = [
     "setuptools>=40.8.0",
     "wheel",
     "cmake>=3.20,<4.0",
-    "pybind11>=2.13.1",
+    "nanobind>=2.12.0",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/projects/rocshmem/python/rocshmem4py/__init__.py
+++ b/projects/rocshmem/python/rocshmem4py/__init__.py
@@ -119,7 +119,7 @@ def _team_split_strided_tracked(parent, start, stride, size,
     Records every successfully created team handle in ``_live_teams`` so
     finalize_with_torch can destroy any leaked teams before
     rocshmem_finalize.  Returns ``(status, team_handle)`` matching the
-    raw pybind signature.  Callers that intentionally bypass this wrapper
+    raw extension signature.  Callers that intentionally bypass this wrapper
     via ``_rocshmem4py.rocshmem_team_split_strided`` own the returned team
     handle and must destroy it themselves.
 
@@ -167,7 +167,7 @@ from _rocshmem4py import rocshmem_team_translate_pe  # noqa: E402
 # Full host AMO matrix (re-export by symbol-name discovery)
 # ---------------------------------------------------------------------------
 #
-# The pybind layer generates host AMO bindings via macros.  Hand-listing
+# The binding layer generates host AMO bindings via macros.  Hand-listing
 # them in the import block is fragile — instead, walk the extension module
 # and re-export every name matching the AMO naming convention.  These are
 # runtime-backed host APIs; IPC no-MPI support for host AMOs needs to be 

--- a/projects/rocshmem/python/src/rocshmem4py.cc
+++ b/projects/rocshmem/python/src/rocshmem4py.cc
@@ -1,10 +1,12 @@
 /*
  * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
- * Python bindings for rocSHMEM via pybind11.
+ *
+ * Python bindings for rocSHMEM via nanobind.  Framework-independent rocSHMEM
+ * glue lives in rocshmem4py_common.hpp; this file is the thin nanobind
+ * registration layer.  The compiled module name (_rocshmem4py), function
+ * names, argument behavior, and return types are the stable public contract.
  */
-
-#include <pybind11/pybind11.h>
-#include <pybind11/pytypes.h>
+#include <nanobind/nanobind.h>
 #include <rocshmem/rocshmem.hpp>
 #include <hip/hip_runtime.h>
 #include <cstdint>
@@ -12,33 +14,15 @@
 #include <sstream>
 #include <stdexcept>
 
-namespace py = pybind11;
+#include "rocshmem4py_common.hpp"
+
+// Single binding framework: import nanobind's names directly.  A namespace
+// prefix only earns its keep when a second framework shares the file.
+using namespace nanobind;
 using namespace rocshmem;
+using rocshmem4py::resolve_team_handle;
 
-namespace {
-rocshmem_team_t resolve_team_handle(intptr_t team) {
-  // Python sentinels are translated to rocSHMEM ABI handles:
-  //   0   -> host::ROCSHMEM_TEAM_WORLD (runtime pointer set at init)
-  //  -1   -> ROCSHMEM_TEAM_INVALID    (rocSHMEM ABI nullptr)
-  // Anything else is a raw rocshmem_team_t (intptr_t-cast pointer)
-  // returned by a previous successful split and passed back through.
-  if (team == 0)  return ROCSHMEM_TEAM_WORLD;
-  if (team == -1) return ROCSHMEM_TEAM_INVALID;
-  return reinterpret_cast<rocshmem_team_t>(team);
-}
-}  // namespace
-
-#define CHECK_ROCSHMEM(expr)                                                   \
-  do {                                                                         \
-    int status = expr;                                                         \
-    if (status != ROCSHMEM_SUCCESS) {                                          \
-      std::ostringstream err_msg;                                              \
-      err_msg << "ROCSHMEM error in " << __FILE__ << ":" << __LINE__;        \
-      throw std::runtime_error(err_msg.str());                                 \
-    }                                                                          \
-  } while (0)
-
-PYBIND11_MODULE(_rocshmem4py, m) {
+NB_MODULE(_rocshmem4py, m) {
   m.doc() = "Python bindings for ROCSHMEM library";
   // Keep host-facing symbol coverage aligned with
   // python/rocshmem4py/__init__.py:_HOST_API_BINDINGS.
@@ -52,7 +36,7 @@ PYBIND11_MODULE(_rocshmem4py, m) {
     hipStream_t hip_stream = reinterpret_cast<hipStream_t>(stream);
     return rocshmem_hipmodule_init(hip_module, hip_stream);
   }, "Initialize rocSHMEM for HIP module (CUDA graph compatible)",
-     py::arg("module"), py::arg("stream") = 0);
+     arg("module"), arg("stream") = 0);
 
   // PE queries
   m.def("rocshmem_my_pe", []() -> int { return rocshmem_my_pe(); });
@@ -70,11 +54,11 @@ PYBIND11_MODULE(_rocshmem4py, m) {
   // Team queries
   m.def("rocshmem_team_my_pe", [](intptr_t team) -> int {
     return rocshmem_team_my_pe(resolve_team_handle(team));
-  }, "Get PE number within a team", py::arg("team"));
+  }, "Get PE number within a team", arg("team"));
 
   m.def("rocshmem_team_n_pes", [](intptr_t team) -> int {
     return rocshmem_team_n_pes(resolve_team_handle(team));
-  }, "Get number of PEs in a team", py::arg("team"));
+  }, "Get number of PEs in a team", arg("team"));
 
   // Memory management
   m.def("rocshmem_malloc", [](size_t size) -> intptr_t {
@@ -93,7 +77,7 @@ PYBIND11_MODULE(_rocshmem4py, m) {
     }
     return (intptr_t)ptr;
   }, "Collective: allocate count*size zero-initialized bytes on the symmetric heap.",
-     py::arg("count"), py::arg("size"));
+     arg("count"), arg("size"));
 
   m.def("rocshmem_align", [](size_t alignment, size_t size) -> intptr_t {
     void *ptr = rocshmem_align(alignment, size);
@@ -104,19 +88,19 @@ PYBIND11_MODULE(_rocshmem4py, m) {
     return (intptr_t)ptr;
   }, "Collective: allocate size bytes aligned to alignment on the symmetric "
      "heap. alignment must be a power of two and a multiple of sizeof(void*).",
-     py::arg("alignment"), py::arg("size"));
+     arg("alignment"), arg("size"));
 
   m.def("rocshmem_buffer_register", [](intptr_t addr, size_t length) -> int {
     return rocshmem_buffer_register((void *)addr, length);
   }, "Register a non-symmetric user buffer with the active backend. "
      "Returns ROCSHMEM_SUCCESS (0) on success.",
-     py::arg("addr"), py::arg("length"));
+     arg("addr"), arg("length"));
 
   m.def("rocshmem_buffer_unregister", [](intptr_t addr) -> int {
     return rocshmem_buffer_unregister((void *)addr);
   }, "Deregister a previously registered non-symmetric buffer. "
      "Returns ROCSHMEM_SUCCESS (0) on success.",
-     py::arg("addr"));
+     arg("addr"));
 
   m.def("rocshmem_buffer_unregister_all", []() {
     rocshmem_buffer_unregister_all();
@@ -128,43 +112,43 @@ PYBIND11_MODULE(_rocshmem4py, m) {
       return 0;
     }
     return (intptr_t)remote_ptr;
-  }, "Get pointer to remote symmetric memory", 
-     py::arg("dest"), py::arg("pe"));
+  }, "Get pointer to remote symmetric memory",
+     arg("dest"), arg("pe"));
 
   // Synchronization
   m.def("rocshmem_barrier_all", []() { rocshmem_barrier_all(); });
   m.def("rocshmem_barrier", [](intptr_t team) {
     rocshmem_barrier(resolve_team_handle(team));
-  }, "Barrier across all PEs in team.", py::arg("team"));
+  }, "Barrier across all PEs in team.", arg("team"));
 
   m.def("rocshmem_barrier_all_on_stream", [](intptr_t stream) {
     rocshmem_barrier_all_on_stream((hipStream_t)stream);
-  }, "Stream-ordered barrier across all PEs", py::arg("stream"));
+  }, "Stream-ordered barrier across all PEs", arg("stream"));
 
   m.def("rocshmem_barrier_on_stream", [](intptr_t team, intptr_t stream) {
     rocshmem_barrier_on_stream(resolve_team_handle(team), (hipStream_t)stream);
   }, "Stream-ordered barrier across all PEs in team (ROCSHMEM_TEAM_INVALID is a no-op).",
-     py::arg("team"), py::arg("stream"));
+     arg("team"), arg("stream"));
 
   m.def("rocshmem_fence", []() { rocshmem_fence(); });
   m.def("rocshmem_quiet", []() { rocshmem_quiet(); });
 
   // Unique ID
-  m.def("rocshmem_get_uniqueid", []() -> py::bytes {
+  m.def("rocshmem_get_uniqueid", []() -> bytes {
     rocshmem_uniqueid_t uid;
     CHECK_ROCSHMEM(rocshmem_get_uniqueid(&uid));
-    std::string bytes((char *)&uid, sizeof(uid));
-    return py::bytes(bytes);
+    // Construct from (buffer, size) to preserve the exact byte length and any
+    // embedded NUL bytes in the binary unique-id blob.
+    return bytes(reinterpret_cast<const char *>(&uid), sizeof(uid));
   });
 
-  m.def("rocshmem_init_attr", [](int rank, int nranks, py::bytes bytes) {
+  m.def("rocshmem_init_attr", [](int rank, int nranks, bytes uid_bytes) {
     rocshmem_uniqueid_t uid;
-    std::string uid_str = bytes;
-    if (uid_str.size() != sizeof(uid)) {
+    if (uid_bytes.size() != sizeof(uid)) {
       throw std::runtime_error("rocshmem_init_attr: invalid unique ID size");
     }
     rocshmem_init_attr_t init_attr{};
-    memcpy(&uid, uid_str.data(), uid_str.size());
+    memcpy(&uid, uid_bytes.c_str(), uid_bytes.size());
     CHECK_ROCSHMEM(rocshmem_set_attr_uniqueid_args(rank, nranks, &uid, &init_attr));
     CHECK_ROCSHMEM(rocshmem_init_attr(ROCSHMEM_INIT_WITH_UNIQUEID, &init_attr));
   });
@@ -187,12 +171,12 @@ PYBIND11_MODULE(_rocshmem4py, m) {
   m.def("rocshmem_putmem_on_stream", [](intptr_t dest, intptr_t source, size_t nelems, int pe, intptr_t stream) {
     rocshmem_putmem_on_stream((void *)dest, (const void *)source, nelems, pe, (hipStream_t)stream);
   }, "Stream-ordered put operation",
-     py::arg("dest"), py::arg("source"), py::arg("nelems"), py::arg("pe"), py::arg("stream"));
+     arg("dest"), arg("source"), arg("nelems"), arg("pe"), arg("stream"));
 
   m.def("rocshmem_getmem_on_stream", [](intptr_t dest, intptr_t source, size_t nelems, int pe, intptr_t stream) {
     rocshmem_getmem_on_stream((void *)dest, (const void *)source, nelems, pe, (hipStream_t)stream);
   }, "Stream-ordered get operation",
-     py::arg("dest"), py::arg("source"), py::arg("nelems"), py::arg("pe"), py::arg("stream"));
+     arg("dest"), arg("source"), arg("nelems"), arg("pe"), arg("stream"));
 
   m.def("rocshmem_putmem_signal_on_stream",
     [](intptr_t dest, intptr_t source, size_t nelems, intptr_t sig_addr, uint64_t signal, int sig_op, int pe, intptr_t stream) {
@@ -200,42 +184,42 @@ PYBIND11_MODULE(_rocshmem4py, m) {
         (void *)dest, (const void *)source, nelems,
         (uint64_t *)sig_addr, signal, sig_op, pe, (hipStream_t)stream);
     }, "Stream-ordered put with remote signaling",
-    py::arg("dest"), py::arg("source"), py::arg("nelems"),
-    py::arg("sig_addr"), py::arg("signal"), py::arg("sig_op"), py::arg("pe"), py::arg("stream"));
+    arg("dest"), arg("source"), arg("nelems"),
+    arg("sig_addr"), arg("signal"), arg("sig_op"), arg("pe"), arg("stream"));
 
   m.def("rocshmem_signal_wait_until_on_stream",
     [](intptr_t sig_addr, int cmp, uint64_t cmp_value, intptr_t stream) {
       rocshmem_signal_wait_until_on_stream((uint64_t *)sig_addr, cmp, cmp_value, (hipStream_t)stream);
     }, "Stream-ordered wait on signal",
-    py::arg("sig_addr"), py::arg("cmp"), py::arg("cmp_value"), py::arg("stream"));
+    arg("sig_addr"), arg("cmp"), arg("cmp_value"), arg("stream"));
 
   // -------------------------------------------------------------------------
   // Team APIs
   // -------------------------------------------------------------------------
 
-  py::class_<rocshmem_team_config_t>(m, "TeamConfig",
+  class_<rocshmem_team_config_t>(m, "TeamConfig",
       "Configuration record for rocshmem_team_split_strided.")
-    .def(py::init<>())
-    .def_readwrite("num_contexts", &rocshmem_team_config_t::num_contexts);
+    .def(init<>())
+    .def_rw("num_contexts", &rocshmem_team_config_t::num_contexts);
 
   m.def("rocshmem_team_split_strided",
     [](intptr_t parent, int start, int stride, int size,
-       py::object config_obj, long mask) -> py::tuple {
+       object config_obj, long mask) -> tuple {
       rocshmem_team_t new_team = ROCSHMEM_TEAM_INVALID;
       rocshmem_team_config_t cfg{};
       const rocshmem_team_config_t* cfg_ptr = nullptr;
       if (!config_obj.is_none()) {
-        cfg = config_obj.cast<rocshmem_team_config_t>();
+        cfg = cast<rocshmem_team_config_t>(config_obj);
         cfg_ptr = &cfg;
       }
       int status = rocshmem_team_split_strided(
           resolve_team_handle(parent), start, stride, size, cfg_ptr, mask,
           &new_team);
-      return py::make_tuple(status, (intptr_t)new_team);
+      return make_tuple(status, (intptr_t)new_team);
     },
     "Split parent team into a strided sub-team. Returns (status, new_team_handle).",
-    py::arg("parent"), py::arg("start"), py::arg("stride"), py::arg("size"),
-    py::arg("config") = py::none(), py::arg("mask") = 0L);
+    arg("parent"), arg("start"), arg("stride"), arg("size"),
+    arg("config") = none(), arg("mask") = 0L);
 
   m.def("rocshmem_team_destroy", [](intptr_t team) {
     // Both Python sentinels (WORLD=0, INVALID=-1) are no-ops, matching
@@ -245,7 +229,7 @@ PYBIND11_MODULE(_rocshmem4py, m) {
     if (team == 0 || team == -1) return;
     rocshmem_team_destroy(reinterpret_cast<rocshmem_team_t>(team));
   }, "Destroy a team. Silently ignored for INVALID/WORLD/SHARED.",
-     py::arg("team"));
+     arg("team"));
 
   m.def("rocshmem_team_translate_pe",
     [](intptr_t src, int pe, intptr_t dst) -> int {
@@ -253,29 +237,29 @@ PYBIND11_MODULE(_rocshmem4py, m) {
           resolve_team_handle(src), pe, resolve_team_handle(dst));
     },
     "Translate a PE index from src_team to dst_team. Returns -1 if unmappable.",
-    py::arg("src_team"), py::arg("src_pe"), py::arg("dest_team"));
+    arg("src_team"), arg("src_pe"), arg("dest_team"));
 
   // -------------------------------------------------------------------------
   // sync_all (host-side ordering)
   // -------------------------------------------------------------------------
   //
   // TODO: ctx-scoped APIs (rocshmem_ctx_create / _destroy / _fence / _quiet)
-  
+
   m.def("rocshmem_sync_all", []() { rocshmem_sync_all(); },
     "Lighter-weight partner to barrier_all (local-store visibility).");
 
   m.def("rocshmem_team_sync", [](intptr_t team) {
     rocshmem_team_sync(resolve_team_handle(team));
-  }, "Lighter-weight sync across all PEs in team.", py::arg("team"));
+  }, "Lighter-weight sync across all PEs in team.", arg("team"));
 
   m.def("rocshmem_sync_all_on_stream", [](intptr_t stream) {
     rocshmem_sync_all_on_stream((hipStream_t)stream);
-  }, "Stream-ordered sync_all.", py::arg("stream"));
+  }, "Stream-ordered sync_all.", arg("stream"));
 
   m.def("rocshmem_team_sync_on_stream", [](intptr_t team, intptr_t stream) {
     rocshmem_team_sync_on_stream(resolve_team_handle(team), (hipStream_t)stream);
   }, "Stream-ordered lighter-weight sync across all PEs in team (ROCSHMEM_TEAM_INVALID is a no-op).",
-     py::arg("team"), py::arg("stream"));
+     arg("team"), arg("stream"));
 
   // -------------------------------------------------------------------------
   // Full host AMO matrix
@@ -297,62 +281,62 @@ PYBIND11_MODULE(_rocshmem4py, m) {
   m.def("rocshmem_" #Tname "_atomic_fetch",                                    \
     [](intptr_t dest, int pe) -> T {                                           \
       return rocshmem_##Tname##_atomic_fetch((T *)dest, pe);                   \
-    }, py::arg("dest"), py::arg("pe"))
+    }, arg("dest"), arg("pe"))
 
 #define AMO_SET_T(T, Tname)                                                    \
   m.def("rocshmem_" #Tname "_atomic_set",                                      \
     [](intptr_t dest, T value, int pe) {                                       \
       rocshmem_##Tname##_atomic_set((T *)dest, value, pe);                     \
-    }, py::arg("dest"), py::arg("value"), py::arg("pe"))
+    }, arg("dest"), arg("value"), arg("pe"))
 
 #define AMO_CAS_T(T, Tname)                                                    \
   m.def("rocshmem_" #Tname "_atomic_compare_swap",                             \
     [](intptr_t dest, T cond, T value, int pe) -> T {                          \
       return rocshmem_##Tname##_atomic_compare_swap(                           \
           (T *)dest, cond, value, pe);                                         \
-    }, py::arg("dest"), py::arg("cond"), py::arg("value"), py::arg("pe"))
+    }, arg("dest"), arg("cond"), arg("value"), arg("pe"))
 
 #define AMO_SWAP_T(T, Tname)                                                   \
   m.def("rocshmem_" #Tname "_atomic_swap",                                     \
     [](intptr_t dest, T value, int pe) -> T {                                  \
       return rocshmem_##Tname##_atomic_swap((T *)dest, value, pe);             \
-    }, py::arg("dest"), py::arg("value"), py::arg("pe"))
+    }, arg("dest"), arg("value"), arg("pe"))
 
 #define AMO_FETCH_ADD_T(T, Tname)                                              \
   m.def("rocshmem_" #Tname "_atomic_fetch_add",                                \
     [](intptr_t dest, T value, int pe) -> T {                                  \
       return rocshmem_##Tname##_atomic_fetch_add((T *)dest, value, pe);        \
-    }, py::arg("dest"), py::arg("value"), py::arg("pe"))
+    }, arg("dest"), arg("value"), arg("pe"))
 
 #define AMO_FETCH_INC_T(T, Tname)                                              \
   m.def("rocshmem_" #Tname "_atomic_fetch_inc",                                \
     [](intptr_t dest, int pe) -> T {                                           \
       return rocshmem_##Tname##_atomic_fetch_inc((T *)dest, pe);               \
-    }, py::arg("dest"), py::arg("pe"))
+    }, arg("dest"), arg("pe"))
 
 #define AMO_ADD_T(T, Tname)                                                    \
   m.def("rocshmem_" #Tname "_atomic_add",                                      \
     [](intptr_t dest, T value, int pe) {                                       \
       rocshmem_##Tname##_atomic_add((T *)dest, value, pe);                     \
-    }, py::arg("dest"), py::arg("value"), py::arg("pe"))
+    }, arg("dest"), arg("value"), arg("pe"))
 
 #define AMO_INC_T(T, Tname)                                                    \
   m.def("rocshmem_" #Tname "_atomic_inc",                                      \
     [](intptr_t dest, int pe) {                                                \
       rocshmem_##Tname##_atomic_inc((T *)dest, pe);                            \
-    }, py::arg("dest"), py::arg("pe"))
+    }, arg("dest"), arg("pe"))
 
 #define AMO_FETCH_BITWISE_T(T, Tname, Op)                                      \
   m.def("rocshmem_" #Tname "_atomic_fetch_" #Op,                               \
     [](intptr_t dest, T value, int pe) -> T {                                  \
       return rocshmem_##Tname##_atomic_fetch_##Op((T *)dest, value, pe);       \
-    }, py::arg("dest"), py::arg("value"), py::arg("pe"))
+    }, arg("dest"), arg("value"), arg("pe"))
 
 #define AMO_BITWISE_T(T, Tname, Op)                                            \
   m.def("rocshmem_" #Tname "_atomic_" #Op,                                     \
     [](intptr_t dest, T value, int pe) {                                       \
       rocshmem_##Tname##_atomic_##Op((T *)dest, value, pe);                    \
-    }, py::arg("dest"), py::arg("value"), py::arg("pe"))
+    }, arg("dest"), arg("value"), arg("pe"))
 
   // ------ fetch / set / cas / swap (full type set) ------
   // Note: numeric types only. CAS is missing on float/double per header.
@@ -463,8 +447,8 @@ PYBIND11_MODULE(_rocshmem4py, m) {
     },
     "Stream-ordered all-to-all over a team. bytes_per_pe is the number of "
     "bytes transferred to each PE in the team.",
-    py::arg("team"), py::arg("dest"), py::arg("source"),
-    py::arg("bytes_per_pe"), py::arg("stream"));
+    arg("team"), arg("dest"), arg("source"),
+    arg("bytes_per_pe"), arg("stream"));
 
   m.def("rocshmem_broadcastmem_on_stream",
     [](intptr_t team, intptr_t dest, intptr_t source, size_t nbytes,
@@ -475,8 +459,8 @@ PYBIND11_MODULE(_rocshmem4py, m) {
     },
     "Stream-ordered broadcast over a team. nbytes is the number of bytes "
     "broadcast. pe_root is in the team's PE space.",
-    py::arg("team"), py::arg("dest"), py::arg("source"), py::arg("nbytes"),
-    py::arg("pe_root"), py::arg("stream"));
+    arg("team"), arg("dest"), arg("source"), arg("nbytes"),
+    arg("pe_root"), arg("stream"));
 
   m.def("rocshmem_query_thread", []() -> int {
     int provided = 0;
@@ -486,7 +470,7 @@ PYBIND11_MODULE(_rocshmem4py, m) {
 
   m.def("rocshmem_global_exit", [](int status) {
     rocshmem_global_exit(status);
-  }, "Emergency abort hook (collective).", py::arg("status"));
+  }, "Emergency abort hook (collective).", arg("status"));
 
   m.def("rocshmem_dump_stats", []() { rocshmem_dump_stats(); },
     "Dump runtime telemetry to stdout.");
@@ -499,15 +483,15 @@ PYBIND11_MODULE(_rocshmem4py, m) {
   }, "Return the default device context as an intptr_t.");
 
   // Constants
-  m.attr("ROCSHMEM_SUCCESS") = py::int_(0);
+  m.attr("ROCSHMEM_SUCCESS") = int_(0);
 
-  m.attr("ROCSHMEM_SIGNAL_SET") = py::int_(static_cast<int>(ROCSHMEM_SIGNAL_SET));
-  m.attr("ROCSHMEM_SIGNAL_ADD") = py::int_(static_cast<int>(ROCSHMEM_SIGNAL_ADD));
+  m.attr("ROCSHMEM_SIGNAL_SET") = int_(static_cast<int>(ROCSHMEM_SIGNAL_SET));
+  m.attr("ROCSHMEM_SIGNAL_ADD") = int_(static_cast<int>(ROCSHMEM_SIGNAL_ADD));
 
-  m.attr("ROCSHMEM_CMP_EQ") = py::int_(static_cast<int>(ROCSHMEM_CMP_EQ));
-  m.attr("ROCSHMEM_CMP_NE") = py::int_(static_cast<int>(ROCSHMEM_CMP_NE));
-  m.attr("ROCSHMEM_CMP_GT") = py::int_(static_cast<int>(ROCSHMEM_CMP_GT));
-  m.attr("ROCSHMEM_CMP_GE") = py::int_(static_cast<int>(ROCSHMEM_CMP_GE));
-  m.attr("ROCSHMEM_CMP_LT") = py::int_(static_cast<int>(ROCSHMEM_CMP_LT));
-  m.attr("ROCSHMEM_CMP_LE") = py::int_(static_cast<int>(ROCSHMEM_CMP_LE));
+  m.attr("ROCSHMEM_CMP_EQ") = int_(static_cast<int>(ROCSHMEM_CMP_EQ));
+  m.attr("ROCSHMEM_CMP_NE") = int_(static_cast<int>(ROCSHMEM_CMP_NE));
+  m.attr("ROCSHMEM_CMP_GT") = int_(static_cast<int>(ROCSHMEM_CMP_GT));
+  m.attr("ROCSHMEM_CMP_GE") = int_(static_cast<int>(ROCSHMEM_CMP_GE));
+  m.attr("ROCSHMEM_CMP_LT") = int_(static_cast<int>(ROCSHMEM_CMP_LT));
+  m.attr("ROCSHMEM_CMP_LE") = int_(static_cast<int>(ROCSHMEM_CMP_LE));
 }

--- a/projects/rocshmem/python/src/rocshmem4py_common.hpp
+++ b/projects/rocshmem/python/src/rocshmem4py_common.hpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Framework-independent helpers for the rocshmem4py binding.  This header
+ * MUST NOT include or depend on any binding framework: it only wraps rocSHMEM
+ * ABI behavior, keeping the nanobind registration layer (rocshmem4py.cc) thin.
+ */
+
+#ifndef ROCSHMEM4PY_COMMON_HPP
+#define ROCSHMEM4PY_COMMON_HPP
+
+#include <rocshmem/rocshmem.hpp>
+#include <cstdint>
+#include <sstream>
+#include <stdexcept>
+
+namespace rocshmem4py {
+
+// Translate the Python team sentinels to rocSHMEM ABI handles:
+//   0   -> rocshmem::ROCSHMEM_TEAM_WORLD (runtime pointer set at init)
+//  -1   -> rocshmem::ROCSHMEM_TEAM_INVALID    (rocSHMEM ABI nullptr)
+// Anything else is a raw rocshmem_team_t (intptr_t-cast pointer) returned by
+// a previous successful split and passed back through.
+inline rocshmem::rocshmem_team_t resolve_team_handle(intptr_t team) {
+  if (team == 0) return rocshmem::ROCSHMEM_TEAM_WORLD;
+  if (team == -1) return rocshmem::ROCSHMEM_TEAM_INVALID;
+  return reinterpret_cast<rocshmem::rocshmem_team_t>(team);
+}
+
+}  // namespace rocshmem4py
+
+// Throw std::runtime_error on a non-success rocSHMEM status.  nanobind
+// auto-translates std::runtime_error to a Python RuntimeError.
+#define CHECK_ROCSHMEM(expr)                                            \
+  do {                                                                  \
+    int status = expr;                                                  \
+    if (status != ROCSHMEM_SUCCESS) {                                   \
+      std::ostringstream err_msg;                                       \
+      err_msg << "ROCSHMEM error in " << __FILE__ << ":" << __LINE__;   \
+      throw std::runtime_error(err_msg.str());                         \
+    }                                                                   \
+  } while (0)
+
+#endif  // ROCSHMEM4PY_COMMON_HPP

--- a/projects/rocshmem/python/tests/test_api_compat.py
+++ b/projects/rocshmem/python/tests/test_api_compat.py
@@ -1,0 +1,164 @@
+"""Public-API surface tests for rocshmem4py.
+
+These tests assert that the *public Python API* of ``rocshmem4py`` (built with
+the nanobind backend) is complete and stable: the module name, function names,
+argument behavior, and return types must not change.  This is the contract
+consumers depend on, independent of the C++ binding framework.
+
+They are torch-free and single-PE safe, so they run in any CI environment.
+"""
+
+import pytest
+
+import rocshmem4py
+import _rocshmem4py
+
+
+# Host-facing symbols that must be importable and callable from the compiled
+# extension.  Mirrors __init__.py:_HOST_API_BINDINGS.
+_REQUIRED_EXT_CALLABLES = (
+    "rocshmem_init",
+    "rocshmem_finalize",
+    "rocshmem_hipmodule_init",
+    "rocshmem_my_pe",
+    "rocshmem_n_pes",
+    "rocshmem_team_my_pe",
+    "rocshmem_team_n_pes",
+    "rocshmem_malloc",
+    "rocshmem_free",
+    "rocshmem_calloc",
+    "rocshmem_align",
+    "rocshmem_buffer_register",
+    "rocshmem_buffer_unregister",
+    "rocshmem_buffer_unregister_all",
+    "rocshmem_ptr",
+    "rocshmem_barrier_all",
+    "rocshmem_barrier",
+    "rocshmem_barrier_all_on_stream",
+    "rocshmem_barrier_on_stream",
+    "rocshmem_fence",
+    "rocshmem_quiet",
+    "rocshmem_get_uniqueid",
+    "rocshmem_init_attr",
+    "rocshmem_putmem",
+    "rocshmem_getmem",
+    "rocshmem_putmem_nbi",
+    "rocshmem_getmem_nbi",
+    "rocshmem_putmem_on_stream",
+    "rocshmem_getmem_on_stream",
+    "rocshmem_putmem_signal_on_stream",
+    "rocshmem_signal_wait_until_on_stream",
+    "rocshmem_team_split_strided",
+    "rocshmem_team_destroy",
+    "rocshmem_team_translate_pe",
+    "rocshmem_sync_all",
+    "rocshmem_team_sync",
+    "rocshmem_sync_all_on_stream",
+    "rocshmem_team_sync_on_stream",
+    "rocshmem_alltoallmem_on_stream",
+    "rocshmem_broadcastmem_on_stream",
+    "rocshmem_query_thread",
+    "rocshmem_global_exit",
+    "rocshmem_dump_stats",
+    "rocshmem_reset_stats",
+    "rocshmem_get_device_ctx",
+    "hip_device_synchronize",
+)
+
+_REQUIRED_CONSTANTS = (
+    "ROCSHMEM_SUCCESS",
+    "ROCSHMEM_SIGNAL_SET",
+    "ROCSHMEM_SIGNAL_ADD",
+    "ROCSHMEM_CMP_EQ",
+    "ROCSHMEM_CMP_NE",
+    "ROCSHMEM_CMP_GT",
+    "ROCSHMEM_CMP_GE",
+    "ROCSHMEM_CMP_LT",
+    "ROCSHMEM_CMP_LE",
+)
+
+
+def test_module_name_is_stable():
+    # The compiled extension must keep the same import name so the wheel
+    # import path is unchanged.
+    assert _rocshmem4py.__name__ == "_rocshmem4py"
+    assert rocshmem4py.__version__ is not None
+
+
+def test_required_callables_present():
+    for name in _REQUIRED_EXT_CALLABLES:
+        assert hasattr(_rocshmem4py, name), f"_rocshmem4py missing {name}"
+        assert callable(getattr(_rocshmem4py, name)), f"{name} not callable"
+
+
+def test_required_constants_are_ints():
+    for name in _REQUIRED_CONSTANTS:
+        val = getattr(_rocshmem4py, name)
+        assert isinstance(val, int), f"{name} must be int, got {type(val)}"
+
+
+def test_constant_values():
+    assert rocshmem4py.ROCSHMEM_SUCCESS == 0
+    assert rocshmem4py.ROCSHMEM_TEAM_WORLD == 0
+    assert rocshmem4py.ROCSHMEM_TEAM_INVALID == -1
+    assert rocshmem4py.ROCSHMEM_SIGNAL_SET == 0
+    assert rocshmem4py.ROCSHMEM_SIGNAL_ADD == 1
+
+
+def test_pe_queries_return_ints():
+    my_pe = rocshmem4py.rocshmem_my_pe()
+    n_pes = rocshmem4py.rocshmem_n_pes()
+    assert isinstance(my_pe, int) and isinstance(n_pes, int)
+    assert 0 <= my_pe < n_pes
+
+
+def test_pointer_apis_return_ints():
+    ptr = rocshmem4py.rocshmem_malloc(1024)
+    try:
+        assert isinstance(ptr, int) and ptr > 0
+        remote = rocshmem4py.rocshmem_ptr(ptr, rocshmem4py.rocshmem_my_pe())
+        assert isinstance(remote, int)
+    finally:
+        rocshmem4py.rocshmem_free(ptr)
+
+
+def test_uniqueid_returns_bytes():
+    # get_uniqueid round-trips a fixed-size binary blob through nb::bytes;
+    # the exact length must be preserved.
+    uid = rocshmem4py.rocshmem_get_uniqueid()
+    assert isinstance(uid, bytes)
+    assert len(uid) > 0
+    # Stable length across calls (the blob is a fixed-size struct).
+    assert len(rocshmem4py.rocshmem_get_uniqueid()) == len(uid)
+
+
+def test_team_config_attribute_roundtrip():
+    cfg = rocshmem4py.TeamConfig()
+    cfg.num_contexts = 4
+    assert cfg.num_contexts == 4
+    cfg.num_contexts = 0
+    assert cfg.num_contexts == 0
+
+
+def test_capsule_buffer_api():
+    # SymmetricBuffer exposes the raw device pointer and the
+    # __cuda_array_interface__ protocol.
+    buf = rocshmem4py.SymmetricBuffer(512)
+    try:
+        assert isinstance(buf.ptr, int) and buf.ptr > 0
+        cai = buf.__cuda_array_interface__
+        assert cai["data"] == (buf.ptr, False)
+        assert cai["version"] == 3
+    finally:
+        buf.free()
+
+
+def test_public_surface_matches_init_all():
+    # The high-level package surface (__all__) is independent of the binding
+    # framework; verify the documented names are all resolvable.
+    for name in rocshmem4py.__all__:
+        assert hasattr(rocshmem4py, name), f"rocshmem4py.__all__ lists missing {name}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/projects/rocshmem/python/tests/test_atomics.py
+++ b/projects/rocshmem/python/tests/test_atomics.py
@@ -41,7 +41,7 @@ requires_host_amo_runtime = pytest.mark.skipif(
 
 
 # ---------------------------------------------------------------------------
-# Coverage matrix — every (type, op) we expect the pybind layer to expose.
+# Coverage matrix — every (type, op) we expect the binding layer to expose.
 # ---------------------------------------------------------------------------
 
 INTEGER_TYPES = ["int", "long", "uint32", "uint64", "size", "ptrdiff"]


### PR DESCRIPTION
## Motivation
Move from pybind11 to nanobind for thin build-time dependency.

Add parent CMake hook to  invoke python build with BUILD_PYTHON_BINDING=ON; installs bindings under <prefix>/lib/rocshmem/python/rocshmem4py/. Enables ROCm/TheRock to package rocshmem4py alongside the C library.

## Technical Details
All pybind11 usage is moved to nanobind. no functional change is intended in the python binding testing due to that.
New parent option BUILD_PYTHON_BINDING (default OFF); when set, add_subdirectory(python) runs inside the existing NOT BUILD_TESTS_ONLY gate. Standalone C++ builds and packager CI are unaffected.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
