### PR TITLE
[rdc] CPX partition mode support + fixed-window profiler eval fields

### DIFF
--- a/projects/rdc/CMakeLists.txt
+++ b/projects/rdc/CMakeLists.txt
@@ -316,7 +316,10 @@ set(TESTS_COMPONENT "tests")
 # Standalone only folders
 if(BUILD_STANDALONE)
     # these packages are later used in server and client targets
-    find_package(protobuf HINTS ${GRPC_ROOT} CONFIG REQUIRED)
+    find_package(protobuf HINTS ${GRPC_ROOT} CONFIG QUIET)
+    if(NOT protobuf_FOUND)
+        find_package(Protobuf REQUIRED)
+    endif()
     find_package(gRPC ${GRPC_DESIRED_VERSION} HINTS ${GRPC_ROOT} CONFIG REQUIRED)
 
     # Don't print grpc install because it floods the terminal

--- a/projects/rdc/include/rdc_lib/impl/SmiUtils.h
+++ b/projects/rdc/include/rdc_lib/impl/SmiUtils.h
@@ -45,14 +45,13 @@ amdsmi_status_t get_metrics_info(amdsmi_processor_handle proc, amdsmi_gpu_metric
 amdsmi_status_t get_num_partition(uint32_t index, uint16_t* num_partition);
 
 struct GpuHandleEntry {
-    amdsmi_processor_handle handle;
-    uint32_t socket_index;
-    uint32_t proc_index;
+  amdsmi_processor_handle handle;
+  uint32_t socket_index;
+  uint32_t proc_index;
 };
 
 const std::vector<GpuHandleEntry>& get_flat_gpu_table();
 void reset_flat_gpu_table();
-
 
 }  // namespace rdc
 }  // namespace amd

--- a/projects/rdc/include/rdc_lib/impl/SmiUtils.h
+++ b/projects/rdc/include/rdc_lib/impl/SmiUtils.h
@@ -44,6 +44,16 @@ amdsmi_status_t get_kfd_partition_id(amdsmi_processor_handle proc, uint32_t* par
 amdsmi_status_t get_metrics_info(amdsmi_processor_handle proc, amdsmi_gpu_metrics_t* metrics);
 amdsmi_status_t get_num_partition(uint32_t index, uint16_t* num_partition);
 
+struct GpuHandleEntry {
+    amdsmi_processor_handle handle;
+    uint32_t socket_index;
+    uint32_t proc_index;
+};
+
+const std::vector<GpuHandleEntry>& get_flat_gpu_table();
+void reset_flat_gpu_table();
+
+
 }  // namespace rdc
 }  // namespace amd
 

--- a/projects/rdc/include/rdc_lib/impl/SmiUtils.h
+++ b/projects/rdc/include/rdc_lib/impl/SmiUtils.h
@@ -32,6 +32,9 @@ namespace amd {
 namespace rdc {
 
 rdc_status_t Smi2RdcError(amdsmi_status_t rsmi);
+
+// Physical/instance-0: gpu_id is a flat GPU index. Partition-instance: device_index is
+// a socket index, instance_index the per-socket proc. These diverge in CPX. See SmiUtils.cc.
 amdsmi_status_t get_processor_handle_from_id(uint32_t gpu_id,
                                              amdsmi_processor_handle* processor_handle);
 amdsmi_status_t get_gpu_id_from_processor_handle(amdsmi_processor_handle processor_handle,
@@ -50,7 +53,10 @@ struct GpuHandleEntry {
   uint32_t proc_index;
 };
 
+// Flat table of all AMD GPU handles, built on first use and cached. Thread-safe.
 const std::vector<GpuHandleEntry>& get_flat_gpu_table();
+
+// Invalidates the cache (thread-safe). Prefer a daemon restart after a partition-mode change.
 void reset_flat_gpu_table();
 
 }  // namespace rdc

--- a/projects/rdc/include/rdc_modules/rdc_rocp/RdcRocpBase.h
+++ b/projects/rdc/include/rdc_modules/rdc_rocp/RdcRocpBase.h
@@ -83,7 +83,7 @@ class RdcRocpBase {
   /**
    * @brief Tweak this to change for how long each metric is collected
    */
-  static const uint32_t collection_duration_us_k = 10000;
+  static const uint32_t collection_duration_us_k = 100000;
 
   /**
    * @brief SIMD_UTILIZATION is a derived metric (SQ_BUSY_CU_CYCLES/GRBM_COUNT/CU_NUM).
@@ -114,7 +114,8 @@ class RdcRocpBase {
 
   bool m_is_initialized = false;
 
-  // these fields must be divided by time passed
+  // These fields are rates derived from counters sampled over the fixed
+  // collection window, so they are divided by the sample time (not wall clock).
   std::unordered_set<rdc_field_t> eval_fields = {
       RDC_FI_PROF_EVAL_MEM_R_BW,         RDC_FI_PROF_EVAL_MEM_W_BW,
       RDC_FI_PROF_EVAL_FLOPS_16,         RDC_FI_PROF_EVAL_FLOPS_32,
@@ -128,7 +129,7 @@ class RdcRocpBase {
    * @param[in] field Field ID to transform
    * @param[in] agent_index Index of the agent/GPU
    * @param[in] raw_value Raw value from profiler
-   * @param[in] elapsed_time_ms Elapsed time in milliseconds (for eval fields)
+   * @param[in] sample_time_ms Counter collection duration in milliseconds (for eval fields)
    * @param[in] sampled_values Map of all sampled values (for fields needing multiple metrics)
    * @param[out] output Transformed output value
    * @param[out] type Output type
@@ -136,7 +137,7 @@ class RdcRocpBase {
    * @retval ::RDC_ST_OK Transformation successful
    */
   rdc_status_t apply_field_transformation(rdc_field_t field, uint32_t agent_index, double raw_value,
-                                          double elapsed_time_ms,
+                                          double sample_time_ms,
                                           const std::map<std::string, double>& sampled_values,
                                           rdc_field_value_data* output, rdc_field_type_t* type);
 

--- a/projects/rdc/include/rdc_modules/rdc_rocp/RdcRocpBase.h
+++ b/projects/rdc/include/rdc_modules/rdc_rocp/RdcRocpBase.h
@@ -114,8 +114,7 @@ class RdcRocpBase {
 
   bool m_is_initialized = false;
 
-  // These fields are rates derived from counters sampled over the fixed
-  // collection window, so they are divided by the sample time (not wall clock).
+  // Rate fields: divided by the sample time (the fixed collection window, not wall clock).
   std::unordered_set<rdc_field_t> eval_fields = {
       RDC_FI_PROF_EVAL_MEM_R_BW,         RDC_FI_PROF_EVAL_MEM_W_BW,
       RDC_FI_PROF_EVAL_FLOPS_16,         RDC_FI_PROF_EVAL_FLOPS_32,

--- a/projects/rdc/rdc_libs/rdc/src/RdcGroupSettingsImpl.cc
+++ b/projects/rdc/rdc_libs/rdc/src/RdcGroupSettingsImpl.cc
@@ -90,8 +90,17 @@ rdc_status_t RdcGroupSettingsImpl::rdc_group_gpu_add(rdc_gpu_group_t groupId, ui
   rdc_status_t status =
       partition_->rdc_get_num_partition_impl(entity_info.device_index, &num_partitions);
   if (status != RDC_ST_OK) {
+    RDC_LOG(RDC_ERROR, "rdc_group_gpu_add: get_num_partition failed for gpu_index=" << gpu_index
+                       << " device_index=" << entity_info.device_index
+                       << " instance_index=" << entity_info.instance_index
+                       << " role=" << entity_info.entity_role
+                       << " status=" << status);
     return status;
   }
+  RDC_LOG(RDC_DEBUG, "rdc_group_gpu_add: gpu_index=" << gpu_index
+                     << " device_index=" << entity_info.device_index
+                     << " num_partitions=" << num_partitions
+                     << " role=" << entity_info.entity_role);
 
   if (num_partitions != UINT16_MAX && num_partitions > 1) {
     if (entity_info.entity_role == RDC_DEVICE_ROLE_PARTITION_INSTANCE) {

--- a/projects/rdc/rdc_libs/rdc/src/RdcGroupSettingsImpl.cc
+++ b/projects/rdc/rdc_libs/rdc/src/RdcGroupSettingsImpl.cc
@@ -90,17 +90,16 @@ rdc_status_t RdcGroupSettingsImpl::rdc_group_gpu_add(rdc_gpu_group_t groupId, ui
   rdc_status_t status =
       partition_->rdc_get_num_partition_impl(entity_info.device_index, &num_partitions);
   if (status != RDC_ST_OK) {
-    RDC_LOG(RDC_ERROR, "rdc_group_gpu_add: get_num_partition failed for gpu_index=" << gpu_index
-                       << " device_index=" << entity_info.device_index
-                       << " instance_index=" << entity_info.instance_index
-                       << " role=" << entity_info.entity_role
-                       << " status=" << status);
+    RDC_LOG(RDC_ERROR, "rdc_group_gpu_add: get_num_partition failed for gpu_index="
+                           << gpu_index << " device_index=" << entity_info.device_index
+                           << " instance_index=" << entity_info.instance_index
+                           << " role=" << entity_info.entity_role << " status=" << status);
     return status;
   }
   RDC_LOG(RDC_DEBUG, "rdc_group_gpu_add: gpu_index=" << gpu_index
-                     << " device_index=" << entity_info.device_index
-                     << " num_partitions=" << num_partitions
-                     << " role=" << entity_info.entity_role);
+                                                     << " device_index=" << entity_info.device_index
+                                                     << " num_partitions=" << num_partitions
+                                                     << " role=" << entity_info.entity_role);
 
   if (num_partitions != UINT16_MAX && num_partitions > 1) {
     if (entity_info.entity_role == RDC_DEVICE_ROLE_PARTITION_INSTANCE) {

--- a/projects/rdc/rdc_libs/rdc/src/RdcMetricFetcherImpl.cc
+++ b/projects/rdc/rdc_libs/rdc/src/RdcMetricFetcherImpl.cc
@@ -1343,11 +1343,15 @@ rdc_status_t RdcMetricFetcherImpl::fetch_gpu_partition_field_(uint32_t gpu_index
     return RDC_ST_UNKNOWN_ERROR;
   }
 
-  // Always use the physical device handle (raw device index) for gpu_metrics,
-  // since xcp_stats[] is indexed by partition from the whole-GPU metrics table.
-  // Partition handles may not support amdsmi_get_gpu_metrics_info.
+  // gpu_metrics needs the socket-primary (whole-GPU) handle; xcp_stats[] is indexed by
+  // partition via info.instance_index below. Encode an instance-0 socket-path entity so the
+  // socket dispatch picks procs[0] (passing info.device_index raw would hit the wrong CPX GPU).
+  rdc_entity_info_t socket_primary_info = info;
+  socket_primary_info.entity_role = RDC_DEVICE_ROLE_PARTITION_INSTANCE;
+  socket_primary_info.instance_index = 0;
+  uint32_t socket_primary_index = rdc_get_entity_index_from_info(socket_primary_info);
   amdsmi_processor_handle processor_handle = {};
-  amdsmi_status_t ret = get_processor_handle_from_id(info.device_index, &processor_handle);
+  amdsmi_status_t ret = get_processor_handle_from_id(socket_primary_index, &processor_handle);
   if (ret != AMDSMI_STATUS_SUCCESS) {
     RDC_LOG(RDC_ERROR, "Cannot get processor handle for device " << info.device_index);
     return Smi2RdcError(ret);
@@ -1710,7 +1714,9 @@ rdc_status_t RdcMetricFetcherImpl::fetch_smi_field(uint32_t gpu_index, rdc_field
   rdc_status_t status = RDC_ST_UNKNOWN_ERROR;
   rdc_entity_info_t info = rdc_get_info_from_entity_index(gpu_index);
 
-  amdsmi_status_t ret = get_processor_handle_from_id(info.device_index, &processor_handle);
+  // Pass the full entity index, not info.device_index, so the flat/socket dispatch stays
+  // correct for CPU, physical-GPU, and partition entities (matters in CPX).
+  amdsmi_status_t ret = get_processor_handle_from_id(gpu_index, &processor_handle);
   if (ret != AMDSMI_STATUS_SUCCESS) {
     std::string info_str;
     if (info.entity_role == RDC_DEVICE_ROLE_PARTITION_INSTANCE) {

--- a/projects/rdc/rdc_libs/rdc/src/RdcMetricFetcherImpl.cc
+++ b/projects/rdc/rdc_libs/rdc/src/RdcMetricFetcherImpl.cc
@@ -784,46 +784,10 @@ rdc_status_t RdcMetricFetcherImpl::fetch_gpu_field_(uint32_t gpu_index, rdc_fiel
       break;
     }
     case RDC_FI_GPU_COUNT: {
-      uint32_t gpu_count = 0;
-      uint32_t socket_count = 0;
-      std::vector<amdsmi_socket_handle> socket_handles;
-      value->status = amdsmi_get_socket_handles(&socket_count, nullptr);
+      const auto& table = get_flat_gpu_table();
       value->type = INTEGER;
-      if (value->status != AMDSMI_STATUS_SUCCESS) {
-        break;
-      }
-      socket_handles.resize(socket_count);
-      value->status = amdsmi_get_socket_handles(&socket_count, socket_handles.data());
-      if (value->status != AMDSMI_STATUS_SUCCESS) {
-        break;
-      }
-      for (uint32_t i = 0; i < socket_count; i++) {
-        uint32_t proc_count = 0;
-        amdsmi_status_t status = AMDSMI_STATUS_UNKNOWN_ERROR;
-        status = amdsmi_get_processor_handles(socket_handles[i], &proc_count, nullptr);
-        if ((status != AMDSMI_STATUS_SUCCESS) || (proc_count < 1)) {
-          continue;
-        }
-        // only need to check the first processor in socket.
-        // sockets don't mix CPUs and GPUs.. I hope.
-        proc_count = 1;
-        amdsmi_processor_handle proc = nullptr;
-        status = amdsmi_get_processor_handles(socket_handles[i], &proc_count, &proc);
-        if ((status != AMDSMI_STATUS_SUCCESS) || (proc_count < 1)) {
-          continue;
-        }
-        processor_type_t proc_type = AMDSMI_PROCESSOR_TYPE_UNKNOWN;
-        status = amdsmi_get_processor_type(proc, &proc_type);
-        if (status != AMDSMI_STATUS_SUCCESS) {
-          continue;
-        }
-        // only count AMD GPUs
-        // only count 1 GPU per socket
-        if (proc_type == AMDSMI_PROCESSOR_TYPE_AMD_GPU) {
-          gpu_count++;
-        }
-      }
-      value->value.l_int = static_cast<int64_t>(gpu_count);
+      value->status = AMDSMI_STATUS_SUCCESS;
+      value->value.l_int = static_cast<int64_t>(table.size());
     } break;
     case RDC_FI_GPU_PARTITION_COUNT: {
       uint32_t partition_count = 0;

--- a/projects/rdc/rdc_libs/rdc/src/RdcPartitionImpl.cc
+++ b/projects/rdc/rdc_libs/rdc/src/RdcPartitionImpl.cc
@@ -45,8 +45,9 @@ rdc_status_t RdcPartitionImpl::rdc_instance_profile_get_impl(
   rdc_entity_info_t info = rdc_get_info_from_entity_index(entity_index);
 
   amdsmi_processor_handle proc_handle;
-  // Get processor handle of socket
-  amdsmi_status_t ret = get_processor_handle_from_id(info.device_index, &proc_handle);
+  // Pass the full entity index (not info.device_index) to keep the flat/socket dispatch
+  // correct for partition instances in CPX.
+  amdsmi_status_t ret = get_processor_handle_from_id(entity_index, &proc_handle);
   if (ret != AMDSMI_STATUS_SUCCESS) {
     return RDC_ST_UNKNOWN_ERROR;
   }

--- a/projects/rdc/rdc_libs/rdc/src/SmiUtils.cc
+++ b/projects/rdc/rdc_libs/rdc/src/SmiUtils.cc
@@ -271,7 +271,6 @@ amdsmi_status_t get_num_partition(uint32_t index, uint16_t* num_partition) {
   return ret;
 }
 
-
 static std::vector<GpuHandleEntry> s_flat_gpu_table;
 static bool s_flat_gpu_table_initialized = false;
 
@@ -293,7 +292,8 @@ static void build_flat_gpu_table() {
       continue;
     }
     std::vector<amdsmi_processor_handle> procs(proc_count);
-    if (amdsmi_get_processor_handles(sockets[s], &proc_count, procs.data()) != AMDSMI_STATUS_SUCCESS) {
+    if (amdsmi_get_processor_handles(sockets[s], &proc_count, procs.data()) !=
+        AMDSMI_STATUS_SUCCESS) {
       continue;
     }
     for (uint32_t p = 0; p < proc_count; p++) {

--- a/projects/rdc/rdc_libs/rdc/src/SmiUtils.cc
+++ b/projects/rdc/rdc_libs/rdc/src/SmiUtils.cc
@@ -24,6 +24,7 @@ THE SOFTWARE.
 
 #include <cstdint>
 #include <cstring>
+#include <mutex>
 #include <vector>
 
 #include "amd_smi/amdsmi.h"
@@ -77,6 +78,11 @@ rdc_status_t Smi2RdcError(amdsmi_status_t rsmi) {
   }
 }
 
+// Dual index semantics for gpu_id:
+//   Physical/instance-0: device_index is a flat index into s_flat_gpu_table.
+//   Partition-instance:  device_index is a socket index, instance_index the per-socket proc.
+// These coincide in SPX but diverge in CPX (multiple procs per socket), so don't pass a
+// flat index where a socket index is expected.
 amdsmi_status_t get_processor_handle_from_id(uint32_t gpu_id,
                                              amdsmi_processor_handle* processor_handle) {
   const auto& table = get_flat_gpu_table();
@@ -271,10 +277,14 @@ amdsmi_status_t get_num_partition(uint32_t index, uint16_t* num_partition) {
   return ret;
 }
 
+// Flat (0-based) index -> AMD GPU handle, built lazily and cached for the process lifetime.
+// Goes stale if the partition mode changes at runtime; a daemon restart is the supported fix.
+static std::mutex s_flat_gpu_table_mutex;
 static std::vector<GpuHandleEntry> s_flat_gpu_table;
 static bool s_flat_gpu_table_initialized = false;
 
-static void build_flat_gpu_table() {
+// Caller must hold s_flat_gpu_table_mutex.
+static void build_flat_gpu_table_locked() {
   s_flat_gpu_table.clear();
 
   uint32_t socket_count = 0;
@@ -314,13 +324,16 @@ static void build_flat_gpu_table() {
 }
 
 const std::vector<GpuHandleEntry>& get_flat_gpu_table() {
+  std::lock_guard<std::mutex> lock(s_flat_gpu_table_mutex);
   if (!s_flat_gpu_table_initialized) {
-    build_flat_gpu_table();
+    build_flat_gpu_table_locked();
   }
   return s_flat_gpu_table;
 }
 
+// Invalidates the cache; previously returned references are dangling afterward.
 void reset_flat_gpu_table() {
+  std::lock_guard<std::mutex> lock(s_flat_gpu_table_mutex);
   s_flat_gpu_table.clear();
   s_flat_gpu_table_initialized = false;
 }

--- a/projects/rdc/rdc_libs/rdc/src/SmiUtils.cc
+++ b/projects/rdc/rdc_libs/rdc/src/SmiUtils.cc
@@ -79,6 +79,19 @@ rdc_status_t Smi2RdcError(amdsmi_status_t rsmi) {
 
 amdsmi_status_t get_processor_handle_from_id(uint32_t gpu_id,
                                              amdsmi_processor_handle* processor_handle) {
+  const auto& table = get_flat_gpu_table();
+  rdc_entity_info_t info = rdc_get_info_from_entity_index(gpu_id);
+
+  if (info.instance_index == 0 && info.entity_role == RDC_DEVICE_ROLE_PHYSICAL) {
+    uint32_t flat_idx = info.device_index;
+    if (flat_idx >= table.size()) {
+      return AMDSMI_STATUS_INPUT_OUT_OF_BOUNDS;
+    }
+    *processor_handle = table[flat_idx].handle;
+    return AMDSMI_STATUS_SUCCESS;
+  }
+
+  // Entity-encoded index (partition instances): use socket/proc mapping
   uint32_t socket_count = 0;
   amdsmi_status_t ret = amdsmi_get_socket_handles(&socket_count, nullptr);
   if (ret != AMDSMI_STATUS_SUCCESS) {
@@ -91,39 +104,30 @@ amdsmi_status_t get_processor_handle_from_id(uint32_t gpu_id,
     return ret;
   }
 
-  std::vector<std::vector<amdsmi_processor_handle>> procs_by_socket;
-  procs_by_socket.resize(socket_count);
-
-  for (size_t s = 0; s < sockets.size(); s++) {
-    uint32_t proc_count = 0;
-    ret = amdsmi_get_processor_handles(sockets[s], &proc_count, nullptr);
-    if (ret != AMDSMI_STATUS_SUCCESS) {
-      return ret;
-    }
-
-    std::vector<amdsmi_processor_handle> procs(proc_count);
-    ret = amdsmi_get_processor_handles(sockets[s], &proc_count, procs.data());
-    if (ret != AMDSMI_STATUS_SUCCESS) {
-      return ret;
-    }
-
-    procs_by_socket[s] = procs;
-  }
-
-  rdc_entity_info_t info = rdc_get_info_from_entity_index(gpu_id);
   uint32_t socket_index = info.device_index;
   uint32_t instance_index = info.instance_index;
 
-  if (socket_index >= procs_by_socket.size()) {
+  if (socket_index >= socket_count) {
     return AMDSMI_STATUS_INPUT_OUT_OF_BOUNDS;
   }
 
-  const auto& handles = procs_by_socket[socket_index];
-  if (instance_index >= handles.size()) {
+  uint32_t proc_count = 0;
+  ret = amdsmi_get_processor_handles(sockets[socket_index], &proc_count, nullptr);
+  if (ret != AMDSMI_STATUS_SUCCESS) {
+    return ret;
+  }
+
+  if (instance_index >= proc_count) {
     return AMDSMI_STATUS_INPUT_OUT_OF_BOUNDS;
   }
 
-  *processor_handle = handles[instance_index];
+  std::vector<amdsmi_processor_handle> procs(proc_count);
+  ret = amdsmi_get_processor_handles(sockets[socket_index], &proc_count, procs.data());
+  if (ret != AMDSMI_STATUS_SUCCESS) {
+    return ret;
+  }
+
+  *processor_handle = procs[instance_index];
   return AMDSMI_STATUS_SUCCESS;
 }
 
@@ -224,22 +228,36 @@ amdsmi_status_t get_metrics_info(amdsmi_processor_handle proc, amdsmi_gpu_metric
 }
 
 amdsmi_status_t get_num_partition(uint32_t index, uint16_t* num_partition) {
-  // Get the processor handle for the physical device.
-  amdsmi_processor_handle proc_handle = nullptr;
-  amdsmi_status_t ret = get_processor_handle_from_id(index, &proc_handle);
-  if (ret != AMDSMI_STATUS_SUCCESS) {
-    return ret;
-  }
-
   if (num_partition == nullptr) {
     return AMDSMI_STATUS_INVAL;
+  }
+
+  // Use flat table to find the physical GPU (first processor in the socket)
+  const auto& table = get_flat_gpu_table();
+  if (index >= table.size()) {
+    return AMDSMI_STATUS_INPUT_OUT_OF_BOUNDS;
+  }
+
+  // Find the first processor in the same socket to query the physical GPU profile.
+  uint32_t target_socket = table[index].socket_index;
+  amdsmi_processor_handle phys_handle = nullptr;
+  for (const auto& entry : table) {
+    if (entry.socket_index == target_socket) {
+      phys_handle = entry.handle;
+      break;
+    }
+  }
+
+  if (phys_handle == nullptr) {
+    return AMDSMI_STATUS_NOT_FOUND;
   }
 
   amdsmi_accelerator_partition_profile_t profile;
   memset(&profile, 0, sizeof(profile));
   uint32_t partition_id{};
 
-  ret = amdsmi_get_gpu_accelerator_partition_profile(proc_handle, &profile, &partition_id);
+  amdsmi_status_t ret =
+      amdsmi_get_gpu_accelerator_partition_profile(phys_handle, &profile, &partition_id);
   if (ret != AMDSMI_STATUS_SUCCESS) {
     return ret;
   }
@@ -251,6 +269,60 @@ amdsmi_status_t get_num_partition(uint32_t index, uint16_t* num_partition) {
   *num_partition = profile.num_partitions;
 
   return ret;
+}
+
+
+static std::vector<GpuHandleEntry> s_flat_gpu_table;
+static bool s_flat_gpu_table_initialized = false;
+
+static void build_flat_gpu_table() {
+  s_flat_gpu_table.clear();
+
+  uint32_t socket_count = 0;
+  if (amdsmi_get_socket_handles(&socket_count, nullptr) != AMDSMI_STATUS_SUCCESS) {
+    return;
+  }
+  std::vector<amdsmi_socket_handle> sockets(socket_count);
+  if (amdsmi_get_socket_handles(&socket_count, sockets.data()) != AMDSMI_STATUS_SUCCESS) {
+    return;
+  }
+
+  for (uint32_t s = 0; s < socket_count; s++) {
+    uint32_t proc_count = 0;
+    if (amdsmi_get_processor_handles(sockets[s], &proc_count, nullptr) != AMDSMI_STATUS_SUCCESS) {
+      continue;
+    }
+    std::vector<amdsmi_processor_handle> procs(proc_count);
+    if (amdsmi_get_processor_handles(sockets[s], &proc_count, procs.data()) != AMDSMI_STATUS_SUCCESS) {
+      continue;
+    }
+    for (uint32_t p = 0; p < proc_count; p++) {
+      processor_type_t proc_type = AMDSMI_PROCESSOR_TYPE_UNKNOWN;
+      if (amdsmi_get_processor_type(procs[p], &proc_type) != AMDSMI_STATUS_SUCCESS) {
+        continue;
+      }
+      if (proc_type == AMDSMI_PROCESSOR_TYPE_AMD_GPU) {
+        GpuHandleEntry entry;
+        entry.handle = procs[p];
+        entry.socket_index = s;
+        entry.proc_index = p;
+        s_flat_gpu_table.push_back(entry);
+      }
+    }
+  }
+  s_flat_gpu_table_initialized = true;
+}
+
+const std::vector<GpuHandleEntry>& get_flat_gpu_table() {
+  if (!s_flat_gpu_table_initialized) {
+    build_flat_gpu_table();
+  }
+  return s_flat_gpu_table;
+}
+
+void reset_flat_gpu_table() {
+  s_flat_gpu_table.clear();
+  s_flat_gpu_table_initialized = false;
 }
 
 }  // namespace rdc

--- a/projects/rdc/rdc_libs/rdc_modules/rdc_rocp/RdcRocpBase.cc
+++ b/projects/rdc/rdc_libs/rdc_modules/rdc_rocp/RdcRocpBase.cc
@@ -296,7 +296,6 @@ rdc_status_t RdcRocpBase::rocp_lookup(rdc_gpu_field_t gpu_field, rdc_field_value
 
   init_rocp_if_not();
 
-  const auto start_time = std::chrono::high_resolution_clock::now();
   // direct read from rocprofiler
   double read_dbl = 0.0;
   const auto status = run_profiler(agent_index, field, &read_dbl);
@@ -306,8 +305,11 @@ rdc_status_t RdcRocpBase::rocp_lookup(rdc_gpu_field_t gpu_field, rdc_field_value
     return status;
   }
 
-  const auto stop_time = std::chrono::high_resolution_clock::now();
-  const double elapsed = std::chrono::duration<double, std::milli>(stop_time - start_time).count();
+  // Eval fields are rates over the fixed collection window. Use the configured
+  // sample time instead of wall-clock elapsed so the value is deterministic and
+  // free of sampling overhead. run_profiler() samples eval fields for
+  // collection_duration_us_k.
+  const double sample_time_ms = static_cast<double>(collection_duration_us_k) / 1000.0;
 
   // For OCC_ELAPSED, we need to read the occupancy metric as well
   std::map<std::string, double> sampled_values;
@@ -325,8 +327,8 @@ rdc_status_t RdcRocpBase::rocp_lookup(rdc_gpu_field_t gpu_field, rdc_field_value
   }
 
   // Apply field transformations using the helper function
-  return apply_field_transformation(field, agent_index, read_dbl, elapsed, sampled_values, data,
-                                    type);
+  return apply_field_transformation(field, agent_index, read_dbl, sample_time_ms, sampled_values,
+                                    data, type);
 }
 
 rdc_status_t RdcRocpBase::rocp_lookup_bulk(const std::vector<rdc_gpu_field_t>& fields,
@@ -406,7 +408,6 @@ rdc_status_t RdcRocpBase::rocp_lookup_bulk(const std::vector<rdc_gpu_field_t>& f
   const uint32_t duration_us =
       needs_simd_window ? simd_utilization_duration_us_k : collection_duration_us_k;
 
-  const auto start_time = std::chrono::high_resolution_clock::now();
   if (!metrics_to_sample.empty()) {
     try {
       counter_sampler->sample_counters_with_packing(metrics_to_sample, sampled_values, duration_us);
@@ -418,8 +419,12 @@ rdc_status_t RdcRocpBase::rocp_lookup_bulk(const std::vector<rdc_gpu_field_t>& f
       return RDC_ST_BAD_PARAMETER;
     }
   }
-  const auto stop_time = std::chrono::high_resolution_clock::now();
-  const double elapsed = std::chrono::duration<double, std::milli>(stop_time - start_time).count();
+
+  // Eval fields are rates over the fixed collection window. Divide by the actual
+  // sample window used for this batch (duration_us) instead of wall-clock
+  // elapsed, so the reported value is deterministic and free of sampling
+  // overhead.
+  const double sample_time_ms = static_cast<double>(duration_us) / 1000.0;
 
   // Process results for each field
   for (size_t i = 0; i < fields.size(); i++) {
@@ -447,15 +452,15 @@ rdc_status_t RdcRocpBase::rocp_lookup_bulk(const std::vector<rdc_gpu_field_t>& f
     double read_dbl = sampled_it->second;
 
     // Apply field transformation using the helper function
-    statuses[i] = apply_field_transformation(field, agent_index, read_dbl, elapsed, sampled_values,
-                                             &values[i], &types[i]);
+    statuses[i] = apply_field_transformation(field, agent_index, read_dbl, sample_time_ms,
+                                             sampled_values, &values[i], &types[i]);
   }
 
   return RDC_ST_OK;
 }
 
 rdc_status_t RdcRocpBase::apply_field_transformation(
-    rdc_field_t field, uint32_t agent_index, double raw_value, double elapsed_time_ms,
+    rdc_field_t field, uint32_t agent_index, double raw_value, double sample_time_ms,
     const std::map<std::string, double>& sampled_values, rdc_field_value_data* output,
     rdc_field_type_t* type) {
   // Default type is DOUBLE
@@ -466,10 +471,10 @@ rdc_status_t RdcRocpBase::apply_field_transformation(
   // Calculate divided value for eval fields
   double divided_dbl = NAN;
   if (is_eval_field) {
-    if (elapsed_time_ms != 0.0) {
-      divided_dbl = raw_value / elapsed_time_ms;
+    if (sample_time_ms != 0.0) {
+      divided_dbl = raw_value / sample_time_ms;
     } else {
-      RDC_LOG(RDC_ERROR, "Error: Elapsed time is zero. Cannot divide by zero.");
+      RDC_LOG(RDC_ERROR, "Error: Sample time is zero. Cannot divide by zero.");
       return RDC_ST_BAD_PARAMETER;
     }
   }

--- a/projects/rdc/rdc_libs/rdc_modules/rdc_rocp/RdcRocpBase.cc
+++ b/projects/rdc/rdc_libs/rdc_modules/rdc_rocp/RdcRocpBase.cc
@@ -181,17 +181,17 @@ rdc_status_t RdcRocpBase::map_entity_to_profiler() {
     amdsmi_kfd_info_t kfd_info;
     auto amdsmi_status = amdsmi_get_gpu_kfd_info(processor, &kfd_info);
     if (amdsmi_status != AMDSMI_STATUS_SUCCESS) {
-      RDC_LOG(RDC_ERROR, "Failed to get KFD info for flat GPU " << flat_idx
-                             << " (socket " << flat_table[flat_idx].socket_index
-                             << ", proc " << flat_table[flat_idx].proc_index << "): "
-                             << amdsmi_status);
+      RDC_LOG(RDC_ERROR, "Failed to get KFD info for flat GPU "
+                             << flat_idx << " (socket " << flat_table[flat_idx].socket_index
+                             << ", proc " << flat_table[flat_idx].proc_index
+                             << "): " << amdsmi_status);
       continue;
     }
 
     for (const auto& [prof_index, prof_id] : prof_kfd_map) {
       if (std::memcmp(&kfd_info.kfd_id, &prof_id, sizeof(kfd_id_t)) == 0) {
-        RDC_LOG(RDC_DEBUG, "Flat[" << flat_idx << "] <-> Profiler[" << prof_index
-                                   << "] = KFD_ID[" << prof_id << "]");
+        RDC_LOG(RDC_DEBUG, "Flat[" << flat_idx << "] <-> Profiler[" << prof_index << "] = KFD_ID["
+                                   << prof_id << "]");
         entity_to_prof_map.insert({flat_idx, prof_index});
         break;
       }

--- a/projects/rdc/rdc_libs/rdc_modules/rdc_rocp/RdcRocpBase.cc
+++ b/projects/rdc/rdc_libs/rdc_modules/rdc_rocp/RdcRocpBase.cc
@@ -166,83 +166,34 @@ const std::vector<rdc_field_t> RdcRocpBase::get_field_ids() {
 }
 
 rdc_status_t RdcRocpBase::map_entity_to_profiler() {
-  // std::map<uint32_t, uint32_t> entity_to_index_map;
-  // kfd_id_t is only used inside this function
   typedef uint64_t kfd_id_t;
   std::map<uint32_t, kfd_id_t> prof_kfd_map;
 
-  // populate profiler map
   for (uint32_t prof_gpu_index = 0; prof_gpu_index < agents.size(); prof_gpu_index++) {
     prof_kfd_map.insert({prof_gpu_index, agents[prof_gpu_index].gpu_id});
   }
 
-  std::vector<amdsmi_socket_handle> sockets;
-  auto amdsmi_status = get_socket_handles(sockets);
-  if (amdsmi_status != AMDSMI_STATUS_SUCCESS) {
-    RDC_LOG(RDC_ERROR, "Failed to get socket handles: " << amdsmi_status);
-    return Smi2RdcError(amdsmi_status);
-  }
+  const auto& flat_table = get_flat_gpu_table();
 
-  for (int socket_index = 0; socket_index < sockets.size(); socket_index++) {
-    auto* socket = sockets[socket_index];
-    std::vector<amdsmi_processor_handle> processors;
-    amdsmi_status = get_processor_handles(socket, processors);
+  for (uint32_t flat_idx = 0; flat_idx < flat_table.size(); flat_idx++) {
+    auto* processor = flat_table[flat_idx].handle;
+
+    amdsmi_kfd_info_t kfd_info;
+    auto amdsmi_status = amdsmi_get_gpu_kfd_info(processor, &kfd_info);
     if (amdsmi_status != AMDSMI_STATUS_SUCCESS) {
-      RDC_LOG(RDC_ERROR, "Failed to get processor handles for socket " << socket_index << ": "
-                                                                       << amdsmi_status);
-      return Smi2RdcError(amdsmi_status);
+      RDC_LOG(RDC_ERROR, "Failed to get KFD info for flat GPU " << flat_idx
+                             << " (socket " << flat_table[flat_idx].socket_index
+                             << ", proc " << flat_table[flat_idx].proc_index << "): "
+                             << amdsmi_status);
+      continue;
     }
 
-    for (int processor_index = 0; processor_index < processors.size(); processor_index++) {
-      auto* processor = processors[processor_index];
-      processor_type_t processor_type = AMDSMI_PROCESSOR_TYPE_UNKNOWN;
-      amdsmi_status = amdsmi_get_processor_type(processor, &processor_type);
-      if (amdsmi_status != AMDSMI_STATUS_SUCCESS) {
-        RDC_LOG(RDC_ERROR, "Failed to get processor type for processor "
-                               << processor_index << " on socket " << socket_index << ": "
-                               << amdsmi_status);
-        return Smi2RdcError(amdsmi_status);
-      }
-      if (processor_type != AMDSMI_PROCESSOR_TYPE_AMD_GPU) {
-        continue;
-      }
-
-      amdsmi_kfd_info_t kfd_info;
-      amdsmi_status = amdsmi_get_gpu_kfd_info(processor, &kfd_info);
-      if (amdsmi_status != AMDSMI_STATUS_SUCCESS) {
-        RDC_LOG(RDC_ERROR, "Failed to get KFD info for processor "
-                               << processor_index << " on socket " << socket_index << ": "
-                               << amdsmi_status);
-        return Smi2RdcError(amdsmi_status);
-      }
-
-      rdc_entity_info_t entity_info = {
-          .device_index = static_cast<uint32_t>(socket_index),
-          .instance_index = static_cast<uint32_t>(processor_index),
-          .entity_role = RDC_DEVICE_ROLE_PHYSICAL,
-          .device_type = RDC_DEVICE_TYPE_GPU,
-      };
-
-      uint32_t entity_index = rdc_get_entity_index_from_info(entity_info);
-
-      for (const auto& [prof_index, prof_id] : prof_kfd_map) {
-        if (std::memcmp(&kfd_info.kfd_id, &prof_id, sizeof(kfd_id_t)) == 0) {
-          // match found
-          // clang-format off
-          RDC_LOG(RDC_DEBUG, "SMI[" << entity_index << "] <-> Profiler[" << prof_index << "] = KFD_ID[" << prof_id << "]");
-          // clang-format on
-          if (entity_info.entity_role == RDC_DEVICE_ROLE_PHYSICAL) {
-            entity_index = rdc_get_entity_index_from_info(entity_info);
-            entity_to_prof_map.insert({entity_index, prof_index});
-          }
-          if (processors.size() > 1) {
-            // if there are multiple processors, also add entity with partition instance type
-            entity_info.entity_role = RDC_DEVICE_ROLE_PARTITION_INSTANCE;
-            entity_index = rdc_get_entity_index_from_info(entity_info);
-            entity_to_prof_map.insert({entity_index, prof_index});
-          }
-          break;
-        }
+    for (const auto& [prof_index, prof_id] : prof_kfd_map) {
+      if (std::memcmp(&kfd_info.kfd_id, &prof_id, sizeof(kfd_id_t)) == 0) {
+        RDC_LOG(RDC_DEBUG, "Flat[" << flat_idx << "] <-> Profiler[" << prof_index
+                                   << "] = KFD_ID[" << prof_id << "]");
+        entity_to_prof_map.insert({flat_idx, prof_index});
+        break;
       }
     }
   }

--- a/projects/rdc/rdc_libs/rdc_modules/rdc_rocp/RdcRocpBase.cc
+++ b/projects/rdc/rdc_libs/rdc_modules/rdc_rocp/RdcRocpBase.cc
@@ -286,8 +286,13 @@ rdc_status_t RdcRocpBase::rocp_lookup(rdc_gpu_field_t gpu_field, rdc_field_value
   // default type
   *type = DOUBLE;
 
-  // convert from entity to flat index
-  uint32_t agent_index = entity_to_prof_map[gpu_field.gpu_index];
+  // look up the profiler agent index for the given flat GPU index
+  auto entity_it = entity_to_prof_map.find(gpu_field.gpu_index);
+  if (entity_it == entity_to_prof_map.end()) {
+    RDC_LOG(RDC_ERROR, "gpu_index=" << gpu_field.gpu_index << " not found in entity_to_prof_map");
+    return RDC_ST_BAD_PARAMETER;
+  }
+  uint32_t agent_index = entity_it->second;
   const auto& field = gpu_field.field_id;
 
   if (data == nullptr) {
@@ -305,10 +310,7 @@ rdc_status_t RdcRocpBase::rocp_lookup(rdc_gpu_field_t gpu_field, rdc_field_value
     return status;
   }
 
-  // Eval fields are rates over the fixed collection window. Use the configured
-  // sample time instead of wall-clock elapsed so the value is deterministic and
-  // free of sampling overhead. run_profiler() samples eval fields for
-  // collection_duration_us_k.
+  // Divide eval-field rates by the fixed collection window, not wall-clock, for stable values.
   const double sample_time_ms = static_cast<double>(collection_duration_us_k) / 1000.0;
 
   // For OCC_ELAPSED, we need to read the occupancy metric as well
@@ -346,8 +348,14 @@ rdc_status_t RdcRocpBase::rocp_lookup_bulk(const std::vector<rdc_gpu_field_t>& f
   types.resize(fields.size());
   statuses.resize(fields.size());
 
-  // All fields should be for the same GPU
-  uint32_t agent_index = entity_to_prof_map[fields[0].gpu_index];
+  // All fields share one GPU; look up its profiler agent index (keyed by flat GPU index)
+  auto entity_it = entity_to_prof_map.find(fields[0].gpu_index);
+  if (entity_it == entity_to_prof_map.end()) {
+    RDC_LOG(RDC_ERROR, "gpu_index=" << fields[0].gpu_index << " not found in entity_to_prof_map");
+    statuses.assign(fields.size(), RDC_ST_BAD_PARAMETER);
+    return RDC_ST_BAD_PARAMETER;
+  }
+  uint32_t agent_index = entity_it->second;
 
   // Collect all unique metric names needed for sampling
   std::vector<std::string> metrics_to_sample;
@@ -420,10 +428,7 @@ rdc_status_t RdcRocpBase::rocp_lookup_bulk(const std::vector<rdc_gpu_field_t>& f
     }
   }
 
-  // Eval fields are rates over the fixed collection window. Divide by the actual
-  // sample window used for this batch (duration_us) instead of wall-clock
-  // elapsed, so the reported value is deterministic and free of sampling
-  // overhead.
+  // Divide eval-field rates by this batch's actual window (duration_us), not wall-clock.
   const double sample_time_ms = static_cast<double>(duration_us) / 1000.0;
 
   // Process results for each field


### PR DESCRIPTION
## Summary

Two related RDC improvements for AMD Instinct (gfx942 / MI300 / MI308X):

1. **CPX partition mode support** (`[rdc] Support CPX partition mode via flat GPU handle table`)
   - In CPX compute-partition mode each socket exposes multiple GPU processors (partitions), but RDC enumerated only the first processor per socket, so it reported 8 GPUs instead of 32 and profiler metrics landed on the wrong GPU.
   - Adds a flat GPU handle table (`get_flat_gpu_table()`) in `SmiUtils`; `RDC_FI_GPU_COUNT`, handle resolution, partition-count lookup, and profiler entity mapping all go through it. SPX behaviour is unchanged (one processor per socket).
   - `get_num_partition()` keeps develop's `amdsmi_get_gpu_accelerator_partition_profile` path but resolves the physical GPU via the flat table.
   - Protobuf discovery falls back to `find_package(Protobuf)` when the CONFIG package is absent.

2. **Fixed-window profiler eval fields** (`[rdc] Use fixed counter-collection window for profiler eval fields`)
   - Eval fields (`FLOPS_*`, `MEM_*_BW`) were divided by a wall-clock timer around the sample call, so sampling overhead/jitter leaked in and the reported value was unstable sample-to-sample.
   - Divide by the fixed counter-collection window actually passed to the sampler instead (deterministic). Preserves the documented "OPS / ms" units (does not revert 87664cdf9a).
   - Widen the default `collection_duration_us_k` 10 ms -> 100 ms: a 10 ms window is too short to average hipBLAS's per-XCC dispatch and makes large-GEMM FLOPS swing wildly / read 0; 100 ms is stable.

## Test plan / results

Built with `BUILD_PROFILER=ON` on ROCm 7.2.1 (MI308X) and validated via the embedded RDC API:

- SPX: 8 GPUs; FP32 GEMM attributes to the correct GPU with stable FLOPS_32.
- CPX: 32 GPUs; GEMM attributes to the correct partition (busy partition stable ~7.0e9 OPS/ms, idle siblings read 0).
- Profiler A/B on the same GEMM load: 100 ms window gives a tight cluster (~2.45e10 OPS/ms, no zeros) vs the old 10 ms window which swings `0 ... 6.8e9` with frequent zeros.
- SPX restored after testing.

Signed-off-by: Brian Chang <brichang@amd.com>