### PR TITLE
[rocprofiler-systems] Exclude rocprofiler-sdk shutdown upon fork impacted by sampler

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/sampler.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/sampler.cpp
@@ -152,7 +152,7 @@ shutdown_amd_smi_collectors()
         return;
     }
 
-    LOG_DEBUG("Shutting down PMC sampler.");
+    LOG_DEBUG("Shutting down AMD-SMI PMC sampler.");
 
     try
     {
@@ -162,7 +162,8 @@ shutdown_amd_smi_collectors()
         }
     } catch(const std::runtime_error& _e)
     {
-        LOG_ERROR("Exception thrown when shutting down PMC sampler: {}", _e.what());
+        LOG_ERROR("Exception thrown when shutting down AMD-SMI PMC sampler: {}",
+                  _e.what());
     }
 
     is_initialized() = false;
@@ -178,6 +179,8 @@ shutdown_gpu_hw_collector()
 {
 #if ROCPROFILER_VERSION >= 600
     auto_lock_t _lk{ type_mutex<category::amd_smi>() };
+
+    LOG_DEBUG("Shutting down rocprofiler-sdk GPU hardware counter collector.");
 
     if(g_gpu_perf_counter_collector) g_gpu_perf_counter_collector->shutdown();
     g_gpu_perf_counter_collector.reset();

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/sampler.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/sampler.cpp
@@ -139,6 +139,46 @@ std::vector<collectors::collector_slice> g_collector_slices;
 
 std::atomic<bool> g_reinit_pending{ false };
 
+// Shared implementation behind the public shutdown(). reset_gpu_perf_counter must be
+// false on the post-fork reinit path: that reinit only exists to refresh AMD SMI device
+// handles, but the rocprofiler-sdk GPU perf-counter collector is registered once (from
+// sdk_tool_configure) and is never recreated by setup(). Its SDK contexts are owned by
+// the parent and survive fork(), so tearing it down here would permanently disable GPU
+// hardware-counter sampling. Only the real finalize (public shutdown()) resets it.
+void
+shutdown_impl(bool reset_gpu_perf_counter)
+{
+    auto_lock_t _lk{ type_mutex<category::amd_smi>() };
+
+    if(!is_initialized())
+    {
+        return;
+    }
+
+    LOG_DEBUG("Shutting down PMC sampler.");
+
+    try
+    {
+        for(auto& slice : g_collector_slices)
+        {
+            slice.shutdown();
+        }
+    } catch(const std::runtime_error& _e)
+    {
+        LOG_ERROR("Exception thrown when shutting down PMC sampler: {}", _e.what());
+    }
+
+    is_initialized() = false;
+#if ROCPROFILER_VERSION >= 600
+    if(reset_gpu_perf_counter)
+    {
+        if(g_gpu_perf_counter_collector) g_gpu_perf_counter_collector->shutdown();
+        g_gpu_perf_counter_collector.reset();
+        g_gpu_perf_counter_provider.reset();
+    }
+#endif
+}
+
 void
 reinit_if_pending()
 {
@@ -146,7 +186,7 @@ reinit_if_pending()
     if(!g_reinit_pending.compare_exchange_strong(_expected, false)) return;
 
     LOG_DEBUG("Performing deferred PMC reinit after fork.");
-    shutdown();
+    shutdown_impl(/*reset_gpu_perf_counter=*/false);
     setup();
 }
 
@@ -244,32 +284,7 @@ setup()
 void
 shutdown()
 {
-    auto_lock_t _lk{ type_mutex<category::amd_smi>() };
-
-    if(!is_initialized())
-    {
-        return;
-    }
-
-    LOG_DEBUG("Shutting down PMC sampler.");
-
-    try
-    {
-        for(auto& slice : g_collector_slices)
-        {
-            slice.shutdown();
-        }
-    } catch(const std::runtime_error& _e)
-    {
-        LOG_ERROR("Exception thrown when shutting down PMC sampler: {}", _e.what());
-    }
-
-    is_initialized() = false;
-#if ROCPROFILER_VERSION >= 600
-    if(g_gpu_perf_counter_collector) g_gpu_perf_counter_collector->shutdown();
-    g_gpu_perf_counter_collector.reset();
-    g_gpu_perf_counter_provider.reset();
-#endif
+    shutdown_impl(/*reset_gpu_perf_counter=*/true);
 }
 
 void

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/sampler.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/sampler.cpp
@@ -139,14 +139,11 @@ std::vector<collectors::collector_slice> g_collector_slices;
 
 std::atomic<bool> g_reinit_pending{ false };
 
-// Shared implementation behind the public shutdown(). reset_gpu_perf_counter must be
-// false on the post-fork reinit path: that reinit only exists to refresh AMD SMI device
-// handles, but the rocprofiler-sdk GPU perf-counter collector is registered once (from
-// sdk_tool_configure) and is never recreated by setup(). Its SDK contexts are owned by
-// the parent and survive fork(), so tearing it down here would permanently disable GPU
-// hardware-counter sampling. Only the real finalize (public shutdown()) resets it.
+// Tears down the AMD SMI collector slices and marks the sampler uninitialized.
+// This is the only teardown performed on the post-fork reinit path: that reinit
+// exists solely to refresh AMD SMI device handles in the child.
 void
-shutdown_impl(bool reset_gpu_perf_counter)
+shutdown_amd_smi_collectors()
 {
     auto_lock_t _lk{ type_mutex<category::amd_smi>() };
 
@@ -169,13 +166,22 @@ shutdown_impl(bool reset_gpu_perf_counter)
     }
 
     is_initialized() = false;
+}
+
+// Tears down the rocprofiler-sdk GPU hardware perf-counter collector. This must
+// NOT run on the post-fork reinit path: the collector is registered once (from
+// sdk_tool_configure) and is never recreated by setup(); its SDK contexts are
+// owned by the parent and survive fork(), so tearing it down would permanently
+// disable GPU hardware-counter sampling. Only the real finalize resets it.
+void
+shutdown_gpu_hw_collector()
+{
 #if ROCPROFILER_VERSION >= 600
-    if(reset_gpu_perf_counter)
-    {
-        if(g_gpu_perf_counter_collector) g_gpu_perf_counter_collector->shutdown();
-        g_gpu_perf_counter_collector.reset();
-        g_gpu_perf_counter_provider.reset();
-    }
+    auto_lock_t _lk{ type_mutex<category::amd_smi>() };
+
+    if(g_gpu_perf_counter_collector) g_gpu_perf_counter_collector->shutdown();
+    g_gpu_perf_counter_collector.reset();
+    g_gpu_perf_counter_provider.reset();
 #endif
 }
 
@@ -186,7 +192,7 @@ reinit_if_pending()
     if(!g_reinit_pending.compare_exchange_strong(_expected, false)) return;
 
     LOG_DEBUG("Performing deferred PMC reinit after fork.");
-    shutdown_impl(/*reset_gpu_perf_counter=*/false);
+    shutdown_amd_smi_collectors();
     setup();
 }
 
@@ -284,7 +290,8 @@ setup()
 void
 shutdown()
 {
-    shutdown_impl(/*reset_gpu_perf_counter=*/true);
+    shutdown_amd_smi_collectors();
+    shutdown_gpu_hw_collector();
 }
 
 void


### PR DESCRIPTION
## Motivation

GPU hardware-counter sampling stopped working after a profiled application called `fork()`. The PMC sampler performs a deferred reinitialization after fork (`reinit_if_pending`) so it can refresh AMD SMI device handles in the child. That reinit path reused the public `shutdown()`, which also tears down the rocprofiler-sdk GPU perf-counter collector. Because that collector is registered exactly once from `sdk_tool_configure` and is never recreated by `setup()`, tearing it down on the post-fork path permanently disabled GPU hardware-counter sampling for the rest of the run.

## Technical Details

Extracted a shared `shutdown_impl(bool reset_gpu_perf_counter)` from the public `shutdown()` in `source/lib/rocprof-sys/library/pmc/sampler.cpp`. The flag controls whether the rocprofiler-sdk GPU perf-counter collector (`g_gpu_perf_counter_collector` / `g_gpu_perf_counter_provider`) is shut down and reset:

- Public `shutdown()` calls `shutdown_impl(reset_gpu_perf_counter=true)` — the real finalize fully tears everything down.
- `reinit_if_pending()` (post-fork reinit) calls `shutdown_impl(reset_gpu_perf_counter=false)` — it only shuts down the AMD SMI collector slices and refreshes device handles via `setup()`, leaving the SDK GPU perf-counter collector intact. The SDK contexts are owned by the parent and survive `fork()`.

The AMD SMI teardown (collector slices, `is_initialized` reset, locking under `type_mutex<category::amd_smi>()`) is unchanged and shared by both paths. The SDK reset remains guarded by `#if ROCPROFILER_VERSION >= 600`.
## JIRA ID

ROCM-25421

## Test Plan

- [x] Run a GPU workload under rocprof-sys with PMC/GPU hardware counters enabled and confirm counters are collected.
- [x] Run a workload that calls `fork()` and confirm GPU hardware-counter sampling continues in both parent and child after the fork.
- [x] Confirm normal finalize still cleanly tears down the SDK GPU perf-counter collector (no leak / no double-shutdown).

## Test Results

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.