### PR TITLE
[rocprofiler-systems] Fix pytest regex validation

### DIFF
--- a/projects/rocprofiler-systems/tests/pytest/DEVELOPMENT.md
+++ b/projects/rocprofiler-systems/tests/pytest/DEVELOPMENT.md
@@ -58,9 +58,11 @@ See the docstrings in `conftest.py` for full argument details.
 
 ### General Rules
 
+At the minimum, the following rules should always be followed. If you have a reason not to, a comment should be left explaining the reasoning behind your choice.
+
 - Test methods should always be inside a test class.
 - Every test class should inherit from `RocprofsysTest`.
-- At minimum, a test should use both `run_test` and `assert_regex`.
+- At minimum, a test should use both `run_test` and `assert_regex`. They have complementary responsibilities: `run_test` performs process-level validation (subprocess launch, exit code, signals, timeout), while `assert_regex` performs content-level validation (matching against pass/fail patterns in the captured output). A test that only calls `run_test` will detect a crash but not a silent regression where the binary runs to completion without emitting the expected instrumentation output.
 
 ### Runner Modes
 
@@ -73,6 +75,8 @@ class TestExample(RocprofsysTest):
         result = self.run_test(mode, ...)
         self.assert_regex(result)
 ```
+
+If a test is hard-coded to a single mode (no `@pytest.mark.parametrize("mode", ...)` decorator), tag it with `@pytest.mark.<mode>` (e.g. `@pytest.mark.sampling`) so `_generate_ctest_definitions` records the correct CTest mode label. When `parametrize("mode", [...])` is used — even with a single-element list — this is handled automatically.
 
 ### Test Parametrization
 
@@ -246,7 +250,6 @@ class Test<NAME>(RocprofsysTest):
 
     # Any test level markers here
     def test_<NAME>(self, <test>_env):
-        # Run the test
         result = self.run_test(
             # mode,
             # target,

--- a/projects/rocprofiler-systems/tests/pytest/conftest.py
+++ b/projects/rocprofiler-systems/tests/pytest/conftest.py
@@ -2258,8 +2258,15 @@ def assert_regex(subtests, record_subtest_failure, request):
         **kwargs,
     ) -> None:
 
-        filtered = _filter_kwargs("assert_regex", mode, **kwargs)
+        if mode is None and kwargs:
+            pytest.fail(
+                f"assert_regex received mode-specific kwargs {sorted(kwargs)} but no "
+                f"'mode' was provided. Pass mode=... so they can be resolved, or use "
+                f"pass_regex/fail_regex directly."
+            )
+
         if mode is not None:
+            filtered = _filter_kwargs("assert_regex", mode, **kwargs)
             mode_key = mode.replace("-", "_")
             mode_pass_regex = filtered.get(f"{mode_key}_pass_regex")
             if mode_pass_regex is not None:

--- a/projects/rocprofiler-systems/tests/pytest/conftest.py
+++ b/projects/rocprofiler-systems/tests/pytest/conftest.py
@@ -10,7 +10,7 @@ This module provides shared fixtures and configuration for all test modules.
 from __future__ import annotations
 from pathlib import Path
 from functools import lru_cache
-from typing import Callable, Generator, Optional
+from typing import Any, Callable, Generator, Optional
 
 import re
 import os
@@ -1947,6 +1947,69 @@ def _is_assert_disabled(request: pytest.FixtureRequest, subtest_name: str) -> bo
     return False
 
 
+# Contains a set of kwargs accepted for a given (function, mode) pair.
+_FUNCTION_ALLOWED_KWARGS: dict[str, dict[str, set[str]]] = {
+    "run_test": {
+        "baseline": {"command"},
+        "sampling": {"sampling_args"},
+        "binary_rewrite": {"binary_rewrite_args", "cleanup_on_success"},
+        "runtime_instrument": {"runtime_instrument_args"},
+        "sys_run": {"sys_run_args"},
+        "causal": {"causal_args", "causal_mode"},
+        "python": {"python_version", "profile_args", "annotated", "standalone"},
+    },
+    "assert_regex": {
+        "baseline": {"baseline_pass_regex", "baseline_fail_regex"},
+        "sampling": {"sampling_pass_regex", "sampling_fail_regex"},
+        "binary_rewrite": {"binary_rewrite_pass_regex", "binary_rewrite_fail_regex"},
+        "runtime_instrument": {
+            "runtime_instrument_pass_regex",
+            "runtime_instrument_fail_regex",
+        },
+        "sys_run": {"sys_run_pass_regex", "sys_run_fail_regex"},
+        "causal": {"causal_pass_regex", "causal_fail_regex"},
+        "python": {"python_pass_regex", "python_fail_regex"},
+    },
+}
+
+
+def _filter_kwargs(function: str, mode: str, **kwargs: Any) -> dict[str, Any]:
+    """Filter ``kwargs`` to those accepted by ``function`` for ``mode``.
+
+    This also verifies that the kwargs passed are valid for the given function.
+    If a kwarg is not valid, pytest.fail is called.
+
+    Returns:
+        A new dict containing only kwargs valid for ``(function, mode)``.
+    """
+    allowed_per_mode = _FUNCTION_ALLOWED_KWARGS.get(function)
+    if allowed_per_mode is None:
+        pytest.fail(
+            f"_filter_kwargs called with unknown function '{function}'. "
+            f"Expected one of: {sorted(_FUNCTION_ALLOWED_KWARGS.keys())}."
+        )
+
+    mode_key = mode.replace("-", "_")
+    allowed_for_mode = allowed_per_mode.get(mode_key)
+    if allowed_for_mode is None:
+        pytest.fail(
+            f"Unknown mode '{mode}' for '{function}'. "
+            f"Expected one of: {sorted(allowed_per_mode.keys())}."
+        )
+
+    # Union of every kwarg accepted by any mode of this function. Anything
+    # outside this set is considered a typo and an error is raised.
+    all_known_for_function: set[str] = set().union(*allowed_per_mode.values())
+    unknown = set(kwargs) - all_known_for_function
+    if unknown:
+        pytest.fail(
+            f"{function}: unknown kwargs {sorted(unknown)}. "
+            f"Valid kwargs across all modes: {sorted(all_known_for_function)}."
+        )
+
+    return {k: v for k, v in kwargs.items() if k in allowed_for_mode}
+
+
 # ============================================================================
 # Base Test Class
 # ============================================================================
@@ -2017,7 +2080,7 @@ def run_test(
         fail_on_not_found: If True, pytest.fail when binary not found (default: False = skip)
         fail_message: Custom failure message (default: "{runner_type} test failed: {output}")
         no_base_env: If true, don't use the base environment (default: False)
-        **kwargs: Additional runner-specific arguments (sample_args, rewrite_args, etc.)
+        **kwargs: Additional runner-specific arguments (see _FUNCTION_ALLOWED_KWARGS for valid kwargs)
 
     Returns:
         TestResult for further assertions
@@ -2040,18 +2103,13 @@ def run_test(
         no_base_env: bool = False,
         **kwargs,
     ) -> TestResult:
-        # Filter kwargs to only pass runner-specific args that each runner accepts.
-        runner_specific_args = {
-            "baseline": {"command"},
-            "sampling": {"sample_args"},
-            "binary_rewrite": {"rewrite_args", "cleanup_on_success"},
-            "runtime_instrument": {"runtime_args"},
-            "sys_run": {"sysrun_args"},
-            "causal": {"causal_args", "causal_mode"},
-            "python": {"python_version", "profile_args", "annotated", "standalone"},
-        }
-        allowed_args = runner_specific_args.get(runner_type, set())
-        filtered_kwargs = {k: v for k, v in kwargs.items() if k in allowed_args}
+        filtered_kwargs = _filter_kwargs("run_test", runner_type, **kwargs)
+
+        if num_procs > 0 and launcher is None:
+            pytest.fail(
+                f"num_procs={num_procs} was provided but no launcher was set. "
+                f"Pass launcher='<launcher_name>' alongside num_procs."
+            )
 
         if runner_type == "causal" and "causal_mode" not in filtered_kwargs:
             pytest.exit("causal_mode is required for causal tests", returncode=1)
@@ -2176,13 +2234,14 @@ def assert_regex(subtests, record_subtest_failure, request):
     Args:
         result: TestResult from run_test
         mode: Optional runner type (e.g., "binary_rewrite", "sys_run"). If provided, looks up
-              mode-specific regexes from kwargs (e.g., rewrite_pass_regex, sys_run_pass_regex)
+              mode-specific regexes from kwargs (see _FUNCTION_ALLOWED_KWARGS for valid kwargs)
         subtest_name: Name shown in subtest output (defaults to "Regex validation")
         pass_regex: Explicit list of pass regex patterns (used if mode is None or no mode-specific found)
         fail_regex: Explicit list of fail regex patterns (used if mode is None or no mode-specific found)
+        use_abort_fail_regex: Whether to validate against ROCPROFSYS_ABORT_FAIL_REGEX (default: True)
         skip_on_fail: If True, skip instead of fail when validation fails
         fail_message: Custom message for failure (defaults to validation message)
-        **kwargs: Mode-specific regexes like rewrite_pass_regex, sys_run_fail_regex, etc.
+        **kwargs: Mode-specific regexes (see _FUNCTION_ALLOWED_KWARGS for valid kwargs)
     """
     if _is_assert_disabled(request, "assert_regex"):
         return lambda *args, **kwargs: None
@@ -2198,12 +2257,16 @@ def assert_regex(subtests, record_subtest_failure, request):
         fail_message: Optional[str] = None,
         **kwargs,
     ) -> None:
-        # If mode is provided, look up mode-specific regexes from kwargs
+
+        filtered = _filter_kwargs("assert_regex", mode, **kwargs)
         if mode is not None:
-            # Normalize mode name (hyphens to underscores)
             mode_key = mode.replace("-", "_")
-            pass_regex = kwargs.get(f"{mode_key}_pass_regex") or pass_regex
-            fail_regex = kwargs.get(f"{mode_key}_fail_regex") or fail_regex
+            mode_pass_regex = filtered.get(f"{mode_key}_pass_regex")
+            if mode_pass_regex is not None:
+                pass_regex = mode_pass_regex
+            mode_fail_regex = filtered.get(f"{mode_key}_fail_regex")
+            if mode_fail_regex is not None:
+                fail_regex = mode_fail_regex
 
         with subtests.test(subtest_name):
             validation = validate_regex(

--- a/projects/rocprofiler-systems/tests/pytest/rocprofsys/runners.py
+++ b/projects/rocprofiler-systems/tests/pytest/rocprofsys/runners.py
@@ -378,7 +378,7 @@ class SamplingRunner(BaseRunner):
         config: RocprofsysConfig,
         target: str,
         output_dir: Path,
-        sample_args: Optional[list[str]] = None,
+        sampling_args: Optional[list[str]] = None,
         **kwargs,
     ):
         """Initialize sampling runner.
@@ -387,17 +387,17 @@ class SamplingRunner(BaseRunner):
             config: rocprofiler-systems configuration
             target: Name of target executable
             output_dir: Directory for output files
-            sample_args: Arguments for rocprof-sys-sample
+            sampling_args: Arguments for rocprof-sys-sample
             **kwargs: Additional arguments passed to BaseRunner
         """
         base_env = config.get_base_environment()
         super().__init__(config, base_env, target, output_dir, **kwargs)
-        self.sample_args = sample_args or []
+        self.sampling_args = sampling_args or []
 
     def build_command(self) -> list[str]:
         return (
             [str(self.config.rocprofsys_sample)]
-            + self.sample_args
+            + self.sampling_args
             + ["--"]
             + self.pre_run_args
             + [str(self.target_exe)]
@@ -413,7 +413,7 @@ class BinaryRewriteRunner(BaseRunner):
         config: RocprofsysConfig,
         target: str,
         output_dir: Path,
-        rewrite_args: Optional[list[str]] = None,
+        binary_rewrite_args: Optional[list[str]] = None,
         cleanup_on_success: bool = False,
         **kwargs,
     ):
@@ -423,7 +423,7 @@ class BinaryRewriteRunner(BaseRunner):
             config: rocprofiler-systems configuration
             target: Name of target executable
             output_dir: Directory for output files
-            rewrite_args: Arguments for rocprof-sys-instrument
+            binary_rewrite_args: Arguments for rocprof-sys-instrument
             cleanup_on_success: Whether to clean up instrumented binary immediately
                 after successful run. Default is False - let the test_output_dir
                 fixture handle cleanup after validation completes.
@@ -431,7 +431,7 @@ class BinaryRewriteRunner(BaseRunner):
         """
         base_env = config.get_base_environment()
         super().__init__(config, base_env, target, output_dir, **kwargs)
-        self.rewrite_args = rewrite_args or []
+        self.binary_rewrite_args = binary_rewrite_args or []
         self.instrumented_exe = output_dir / f"{target}.inst"
         self.cleanup_on_success = cleanup_on_success
         self._instrumented_files: list[Path] = []
@@ -449,7 +449,7 @@ class BinaryRewriteRunner(BaseRunner):
         command = (
             [str(self.config.rocprofsys_instrument)]
             + ["-o", str(self.instrumented_exe)]
-            + self.rewrite_args
+            + self.binary_rewrite_args
             + ["--print-instrumented", "functions"]
             + ["--", str(self.target_exe)]
         )
@@ -574,7 +574,7 @@ class RuntimeInstrumentRunner(BaseRunner):
         config: RocprofsysConfig,
         target: str,
         output_dir: Path,
-        runtime_args: Optional[list[str]] = None,
+        runtime_instrument_args: Optional[list[str]] = None,
         **kwargs,
     ):
         """Initialize runtime instrument runner.
@@ -583,17 +583,17 @@ class RuntimeInstrumentRunner(BaseRunner):
             config: rocprofiler-systems configuration
             target: Name of target executable
             output_dir: Directory for output files
-            runtime_args: Arguments for rocprof-sys-instrument
+            runtime_instrument_args: Arguments for rocprof-sys-instrument
             **kwargs: Additional arguments passed to BaseRunner
         """
         base_env = config.get_base_environment()
         super().__init__(config, base_env, target, output_dir, **kwargs)
-        self.runtime_args = runtime_args or []
+        self.runtime_instrument_args = runtime_instrument_args or []
 
     def build_command(self) -> list[str]:
         return (
             [str(self.config.rocprofsys_instrument)]
-            + self.runtime_args
+            + self.runtime_instrument_args
             + ["--print-instrumented", "functions"]
             + ["--"]
             + self.pre_run_args
@@ -610,7 +610,7 @@ class SysRunRunner(BaseRunner):
         config: RocprofsysConfig,
         target: str,
         output_dir: Path,
-        sysrun_args: Optional[list[str]] = None,
+        sys_run_args: Optional[list[str]] = None,
         **kwargs,
     ):
         """Initialize sys-run runner.
@@ -619,17 +619,17 @@ class SysRunRunner(BaseRunner):
             config: rocprofiler-systems configuration
             target: Name of target executable
             output_dir: Directory for output files
-            sysrun_args: Arguments for rocprof-sys-run (before --)
+            sys_run_args: Arguments for rocprof-sys-run (before --)
             **kwargs: Additional arguments passed to BaseRunner
         """
         base_env = config.get_base_environment()
         super().__init__(config, base_env, target, output_dir, **kwargs)
-        self.sysrun_args = sysrun_args or []
+        self.sys_run_args = sys_run_args or []
 
     def build_command(self) -> list[str]:
         return (
             [str(self.config.rocprofsys_run)]
-            + self.sysrun_args
+            + self.sys_run_args
             + ["--"]
             + self.pre_run_args
             + [str(self.target_exe)]

--- a/projects/rocprofiler-systems/tests/pytest/rocprofsys/validators.py
+++ b/projects/rocprofiler-systems/tests/pytest/rocprofsys/validators.py
@@ -100,50 +100,33 @@ def _validate_regex(
     if use_abort_fail_regex:
         fail_patterns.extend(ROCPROFSYS_ABORT_FAIL_REGEX)
 
-    # Build combined regex with named groups
-    all_patterns: list[str] = []
-    fail_indices: set[str] = set()
-    pass_indices: set[str] = set()
-
-    if fail_patterns:
-        for i, pattern in enumerate(fail_patterns):
-            all_patterns.append(f"(?P<f{i}>{pattern})")
-            fail_indices.add(f"f{i}")
-
-    if pass_regex:
-        for i, pattern in enumerate(pass_regex):
-            all_patterns.append(f"(?P<p{i}>{pattern})")
-            pass_indices.add(f"p{i}")
-
-    if not all_patterns:
+    if not fail_patterns and not pass_regex:
         return ValidationResult(is_valid=True, message="No patterns to validate")
 
     # Use re.DOTALL so '.' matches newlines (like CMake regex behavior)
-    combined_regex = re.compile("|".join(all_patterns), re.DOTALL)
-    found_pass: set[str] = set()
+    flags = re.DOTALL
 
-    for match in combined_regex.finditer(text):
-        matched_group = match.lastgroup
-
-        if matched_group in fail_indices:
-            original_idx = int(matched_group[1:])
+    # Fail patterns: one combined alternation, short-circuit on first hit
+    if fail_patterns:
+        fail_re = re.compile(
+            "|".join(f"(?P<f{i}>{p})" for i, p in enumerate(fail_patterns)), flags
+        )
+        m = fail_re.search(text)
+        if m is not None:
+            idx = int(m.lastgroup[1:])
             return ValidationResult(
                 is_valid=False,
-                message=f"Fail pattern matched: {fail_patterns[original_idx]}",
+                message=f"Fail pattern matched: {fail_patterns[idx]}",
             )
 
-        if matched_group in pass_indices:
-            found_pass.add(matched_group)
-
-    # Check if all pass patterns were found
+    # Pass patterns: individual re.search per pattern
     if pass_regex:
-        missing = pass_indices - found_pass
-        if missing:
-            missing_idx = int(next(iter(missing))[1:])
-            return ValidationResult(
-                is_valid=False,
-                message=f"Pass pattern not found: {pass_regex[missing_idx]}",
-            )
+        for pattern in pass_regex:
+            if re.search(pattern, text, flags) is None:
+                return ValidationResult(
+                    is_valid=False,
+                    message=f"Pass pattern not found: {pattern}",
+                )
 
     return ValidationResult(is_valid=True, message="All patterns validated successfully")
 

--- a/projects/rocprofiler-systems/tests/pytest/test_annotate.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_annotate.py
@@ -49,7 +49,7 @@ def annotate_env(annotate_papi_condition) -> dict[str, str]:
 @pytest.mark.annotate
 @pytest.mark.parametrize("mode", ["sampling", "binary_rewrite", "sys_run"])
 class TestAnnotate(RocprofsysTest):
-    REWRITE_ARGS = [
+    BINARY_REWRITE_ARGS = [
         "-e",
         "-v",
         "2",
@@ -74,7 +74,7 @@ class TestAnnotate(RocprofsysTest):
             mode,
             "parallel-overhead",
             env=annotate_env,
-            rewrite_args=self.REWRITE_ARGS,
+            binary_rewrite_args=self.BINARY_REWRITE_ARGS,
             run_args=self.RUN_ARGS,
         )
         self.assert_regex(result)

--- a/projects/rocprofiler-systems/tests/pytest/test_code_coverage.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_code_coverage.py
@@ -19,7 +19,7 @@ pytestmark = [pytest.mark.code_coverage]
 
 @pytest.mark.class_name("code-coverage")
 class TestCodeCoverage(RocprofsysTest):
-    def get_rewrite_args(self, type) -> list[str]:
+    def get_binary_rewrite_args(self, type) -> list[str]:
         ret = ["-e", "-v", "2", "--min-instructions=4", "-E", "^std::"]
         if "base" in type:
             ret.extend(["--coverage", "function"])
@@ -29,7 +29,7 @@ class TestCodeCoverage(RocprofsysTest):
             ret.extend(["-M", "coverage"])
         return ret
 
-    def get_runtime_args(self, type) -> list[str]:
+    def get_runtime_instrument_args(self, type) -> list[str]:
         ret = [
             "-e",
             "-v",
@@ -69,8 +69,8 @@ class TestCodeCoverage(RocprofsysTest):
             mode,
             "code-coverage",
             run_args=run_args,
-            rewrite_args=self.get_rewrite_args(type),
-            runtime_args=self.get_runtime_args(type),
+            binary_rewrite_args=self.get_binary_rewrite_args(type),
+            runtime_instrument_args=self.get_runtime_instrument_args(type),
         )
         self.assert_regex(
             result,

--- a/projects/rocprofiler-systems/tests/pytest/test_fork.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_fork.py
@@ -51,8 +51,8 @@ def fork_env() -> dict[str, str]:
     ],
 )
 class TestFork(RocprofsysTest):
-    REWRITE_ARGS = ["-e", "-v", "2", "--print-instrumented", "modules", "-i", "16"]
-    RUNTIME_ARGS = ["-e", "-v", "1", "--label", "file", "-i", "16"]
+    BINARY_REWRITE_ARGS = ["-e", "-v", "2", "--print-instrumented", "modules", "-i", "16"]
+    RUNTIME_INSTRUMENT_ARGS = ["-e", "-v", "1", "--label", "file", "-i", "16"]
 
     def test(self, mode, target, fork_env):
         if target == "hipMallocConcurrencyMproc":
@@ -64,8 +64,8 @@ class TestFork(RocprofsysTest):
             mode,
             target,
             env=fork_env,
-            rewrite_args=self.REWRITE_ARGS,
-            runtime_args=self.RUNTIME_ARGS,
+            binary_rewrite_args=self.BINARY_REWRITE_ARGS,
+            runtime_instrument_args=self.RUNTIME_INSTRUMENT_ARGS,
             check_target_arch=True,
         )
 

--- a/projects/rocprofiler-systems/tests/pytest/test_hpc.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_hpc.py
@@ -163,7 +163,9 @@ class TestJacobi(RocprofsysTest):
         # functions visible, changing the depth of the ROCTx markers as
         # _QMjacobi_modPinit_jacobi is captured.
         # sys_run does not go through dyninst, and hence needs a different depth check
-        expected_depths = [2, 2] if mode == "binary_rewrite" else [1, 1]
+        expected_depths = (
+            [2, 2] if mode in ["binary_rewrite", "runtime_instrument"] else [1, 1]
+        )
         self.assert_perfetto(
             result,
             subtest_name="Perfetto ROCtx marker validation",

--- a/projects/rocprofiler-systems/tests/pytest/test_hpc.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_hpc.py
@@ -159,13 +159,18 @@ class TestJacobi(RocprofsysTest):
         )
         self.assert_regex(result)
 
+        # Going through dyninst (binary_rewrite or runtime_instrument) makes the host
+        # functions visible, changing the depth of the ROCTx markers as
+        # _QMjacobi_modPinit_jacobi is captured.
+        # sys_run does not go through dyninst, and hence needs a different depth check
+        expected_depths = [2, 2] if mode == "binary_rewrite" else [1, 1]
         self.assert_perfetto(
             result,
             subtest_name="Perfetto ROCtx marker validation",
             categories=["rocm_marker_api"],
             labels=["init", "run"],
             counts=[1, 1],
-            depths=[1, 1],
+            depths=expected_depths,
         )
 
     @pytest.mark.hip

--- a/projects/rocprofiler-systems/tests/pytest/test_lulesh.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_lulesh.py
@@ -49,8 +49,17 @@ class TestLulesh(RocprofsysTest):
             "lulesh",
             env=env,
             run_args=["-i", "5", "-s", "20", "-p"],
-            rewrite_args=["-e", "-v", "2", "--label", "file", "line", "return", "args"],
-            runtime_args=[
+            binary_rewrite_args=[
+                "-e",
+                "-v",
+                "2",
+                "--label",
+                "file",
+                "line",
+                "return",
+                "args",
+            ],
+            runtime_instrument_args=[
                 "-e",
                 "-v",
                 "1",
@@ -66,8 +75,8 @@ class TestLulesh(RocprofsysTest):
         self.assert_regex(
             result,
             mode,
-            rewrite_pass_regex=[r"\|_\[kokkos\] [a-zA-Z]"],
-            runtime_pass_regex=[r"\|_\[kokkos\] [a-zA-Z]"],
+            binary_rewrite_pass_regex=[r"\|_\[kokkos\] [a-zA-Z]"],
+            runtime_instrument_pass_regex=[r"\|_\[kokkos\] [a-zA-Z]"],
         )
 
     @pytest.mark.baseline
@@ -93,8 +102,8 @@ class TestLulesh(RocprofsysTest):
             "lulesh",
             env=env,
             run_args=["-i", "10", "-s", "20", "-p"],
-            rewrite_args=["-e", "-v", "2"],
-            runtime_args=[
+            binary_rewrite_args=["-e", "-v", "2"],
+            runtime_instrument_args=[
                 "-e",
                 "-v",
                 "1",
@@ -121,8 +130,8 @@ class TestLulesh(RocprofsysTest):
             "lulesh",
             env=env,
             run_args=["-i", "10", "-s", "20", "-p"],
-            rewrite_args=["-e", "-v", "2"],
-            runtime_args=[
+            binary_rewrite_args=["-e", "-v", "2"],
+            runtime_instrument_args=[
                 "-e",
                 "-v",
                 "1",
@@ -149,7 +158,7 @@ class TestLulesh(RocprofsysTest):
             "lulesh",
             env=env,
             run_args=["-i", "2", "-s", "20", "-p"],
-            rewrite_args=[
+            binary_rewrite_args=[
                 "-e",
                 "-v",
                 "2",
@@ -158,7 +167,7 @@ class TestLulesh(RocprofsysTest):
                 "--traps",
                 "--allow-overlapping",
             ],
-            runtime_args=[
+            runtime_instrument_args=[
                 "-e",
                 "-v",
                 "1",
@@ -173,5 +182,5 @@ class TestLulesh(RocprofsysTest):
         self.assert_regex(
             result,
             mode,
-            rewrite_fail_regex=["0 instrumented loops in procedure"],
+            binary_rewrite_fail_regex=["0 instrumented loops in procedure"],
         )

--- a/projects/rocprofiler-systems/tests/pytest/test_minimal.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_minimal.py
@@ -52,8 +52,8 @@ class TestMinimal(RocprofsysTest):
             mode,
             "minimal-recursion",
             env=env,
-            rewrite_args=["--min-instructions", "0"],
-            runtime_args=["--min-instructions", "0"],
+            binary_rewrite_args=["--min-instructions", "0"],
+            runtime_instrument_args=["--min-instructions", "0"],
             run_args=[str(self.RECURSION_DEPTH)],
         )
         self.assert_regex(result)

--- a/projects/rocprofiler-systems/tests/pytest/test_mpi.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_mpi.py
@@ -75,7 +75,7 @@ class TestMPI(RocprofsysTest):
         "mode", ["baseline", "sampling", "binary_rewrite", "sys_run"]
     )
     def test(self, mode):
-        REWRITE_ARGS = [
+        BINARY_REWRITE_ARGS = [
             "-e",
             "-v",
             "2",
@@ -87,8 +87,8 @@ class TestMPI(RocprofsysTest):
             "--min-instructions",
             "0",
         ]
-        REWRITE_PASS_REGEX = [r"perfetto-trace-0\.proto", r"wall_clock-0\.txt"]
-        REWRITE_FAIL_REGEX = [
+        BINARY_REWRITE_PASS_REGEX = [r"perfetto-trace-0\.proto", r"wall_clock-0\.txt"]
+        BINARY_REWRITE_FAIL_REGEX = [
             r"Outputting.*(perfetto-trace|trip_count|sampling_percent|sampling_cpu_clock|sampling_wall_clock|wall_clock)-[0-9][0-9]+.(json|txt|proto)"
         ]
         ENV = {"ROCPROFSYS_VERBOSE": "1"}
@@ -97,20 +97,20 @@ class TestMPI(RocprofsysTest):
             mode,
             "mpi-example",
             env=ENV,
-            rewrite_args=REWRITE_ARGS,
+            binary_rewrite_args=BINARY_REWRITE_ARGS,
             launcher="mpi",
             num_procs=2,
         )
         self.assert_regex(
             result,
             mode,
-            rewrite_pass_regex=REWRITE_PASS_REGEX,
-            rewrite_fail_regex=REWRITE_FAIL_REGEX,
+            binary_rewrite_pass_regex=BINARY_REWRITE_PASS_REGEX,
+            binary_rewrite_fail_regex=BINARY_REWRITE_FAIL_REGEX,
         )
 
     @pytest.mark.parametrize("mode", ["sampling", "binary_rewrite", "sys_run"])
     def test_perfetto_merge(self, mode):
-        REWRITE_ARGS = [
+        BINARY_REWRITE_ARGS = [
             "-e",
             "-v",
             "2",
@@ -120,8 +120,10 @@ class TestMPI(RocprofsysTest):
             "--min-instructions",
             "0",
         ]
-        REWRITE_PASS_REGEX = [r"Successfully executed: .+rocprof-sys-merge-output.sh.*"]
-        REWRITE_FAIL_REGEX = ["Script not found", "Failed to execute"]
+        BINARY_REWRITE_PASS_REGEX = [
+            r"Successfully executed: .+rocprof-sys-merge-output.sh.*"
+        ]
+        BINARY_REWRITE_FAIL_REGEX = ["Script not found", "Failed to execute"]
         ENV = {
             "ROCPROFSYS_VERBOSE": "1",
             "ROCPROFSYS_MERGE_PERFETTO_FILES": "ON",
@@ -130,15 +132,15 @@ class TestMPI(RocprofsysTest):
             mode,
             "mpi-example",
             env=ENV,
-            rewrite_args=REWRITE_ARGS,
+            binary_rewrite_args=BINARY_REWRITE_ARGS,
             launcher="mpi",
             num_procs=2,
         )
         self.assert_regex(
             result,
             mode,
-            rewrite_pass_regex=REWRITE_PASS_REGEX,
-            rewrite_fail_regex=REWRITE_FAIL_REGEX,
+            binary_rewrite_pass_regex=BINARY_REWRITE_PASS_REGEX,
+            binary_rewrite_fail_regex=BINARY_REWRITE_FAIL_REGEX,
         )
 
 
@@ -157,7 +159,7 @@ class TestMPIP(RocprofsysTest):
         ],
     )
     def test(self, mode, target, mpip_env, mpip_all2all_env):
-        REWRITE_ARGS = [
+        BINARY_REWRITE_ARGS = [
             "-e",
             "-v",
             "2",
@@ -173,7 +175,7 @@ class TestMPIP(RocprofsysTest):
             mode,
             target,
             env=mpip_env if target != "mpi-all2all" else mpip_all2all_env,
-            rewrite_args=REWRITE_ARGS,
+            binary_rewrite_args=BINARY_REWRITE_ARGS,
             run_args=RUN_ARGS,
             launcher="mpi",
             num_procs=2,
@@ -182,7 +184,7 @@ class TestMPIP(RocprofsysTest):
 
     @pytest.mark.parametrize("mode", ["sampling", "binary_rewrite", "sys_run"])
     def test_flat(self, mode, mpip_flat_env):
-        REWRITE_ARGS = [
+        BINARY_REWRITE_ARGS = [
             "-e",
             "-v",
             "2",
@@ -193,7 +195,7 @@ class TestMPIP(RocprofsysTest):
             "--min-instructions",
             "0",
         ]
-        REWRITE_PASS_REGEX = [
+        BINARY_REWRITE_PASS_REGEX = [
             r">>> mpi-example.inst",
             r">>> MPI_Init_thread",
             r">>> pthread_create",
@@ -207,12 +209,12 @@ class TestMPIP(RocprofsysTest):
             mode,
             "mpi-example",
             env=mpip_flat_env,
-            rewrite_args=REWRITE_ARGS,
+            binary_rewrite_args=BINARY_REWRITE_ARGS,
             launcher="mpi",
             num_procs=2,
         )
         self.assert_regex(
             result,
             mode,
-            rewrite_pass_regex=REWRITE_PASS_REGEX,
+            binary_rewrite_pass_regex=BINARY_REWRITE_PASS_REGEX,
         )

--- a/projects/rocprofiler-systems/tests/pytest/test_openmp.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_openmp.py
@@ -10,7 +10,13 @@ import pytest
 from pathlib import Path
 from conftest import RocprofsysTest
 
-pytestmark = [pytest.mark.openmp, pytest.mark.ci_enable]
+pytestmark = [
+    pytest.mark.openmp,
+    pytest.mark.ci_enable,
+    pytest.mark.rocm_min_version(
+        "6.4"
+    ),  # Requires SDK version >= 600, 6.3 ships with 500
+]
 
 # ============================================================================
 # OpenMP Fixtures
@@ -97,7 +103,7 @@ def openmp_target_rules(validation_rules_dir: Path) -> list[Path]:
 
 
 class TestOpenMPCG(RocprofsysTest):
-    REWRITE_ARGS = ["-e", "-v", "2", "--instrument-loops"]
+    BINARY_REWRITE_ARGS = ["-e", "-v", "2", "--instrument-loops"]
     DURATION_SAMPLING_PASS_REGEX = [
         r"Sampler for thread 0 will be triggered 1000\.0x per second of CPU-time",
         r"Sampler for thread 0 will be triggered 500\.0x per second of wall-time",
@@ -124,7 +130,7 @@ class TestOpenMPCG(RocprofsysTest):
             mode,
             "openmp-cg",
             env=env,
-            rewrite_args=self.REWRITE_ARGS,
+            binary_rewrite_args=self.BINARY_REWRITE_ARGS,
         )
         self.assert_regex(result)
 
@@ -156,9 +162,9 @@ class TestOpenMPCG(RocprofsysTest):
 
 
 class TestOpenMPLU(RocprofsysTest):
-    REWRITE_ARGS = ["-e", "-v", "2", "--instrument-loops"]
-    REWRITE_PASS_REGEX = ["\\|_omp_"]
-    REWRITE_FAIL_REGEX = ["0 instrumented loops in procedure"]
+    BINARY_REWRITE_ARGS = ["-e", "-v", "2", "--instrument-loops"]
+    BINARY_REWRITE_PASS_REGEX = ["\\|_omp_"]
+    BINARY_REWRITE_FAIL_REGEX = ["0 instrumented loops in procedure"]
     DURATION_SAMPLING_PASS_REGEX = [
         r"Sampler for thread 0 will be triggered 1000\.0x per second of CPU-time",
         r"Sampler for thread 0 will be triggered 500\.0x per second of wall-time",
@@ -186,13 +192,13 @@ class TestOpenMPLU(RocprofsysTest):
             mode,
             "openmp-lu",
             env=env,
-            rewrite_args=self.REWRITE_ARGS,
+            binary_rewrite_args=self.BINARY_REWRITE_ARGS,
         )
         self.assert_regex(
             result,
             mode,
-            rewrite_pass_regex=self.REWRITE_PASS_REGEX,
-            rewrite_fail_regex=self.REWRITE_FAIL_REGEX,
+            binary_rewrite_pass_regex=self.BINARY_REWRITE_PASS_REGEX,
+            binary_rewrite_fail_regex=self.BINARY_REWRITE_FAIL_REGEX,
         )
 
     @pytest.mark.timeout(300)
@@ -252,8 +258,8 @@ class TestOpenMPTarget(RocprofsysTest):
 @pytest.mark.class_name("openmp-fortran")
 class TestOpenMPFortran(RocprofsysTest):
 
-    REWRITE_ARGS = ["-e", "-v", "2", "--instrument-loops"]
-    RUNTIME_ARGS = ["-e", "-v", "2", "--label", "return", "args"]
+    BINARY_REWRITE_ARGS = ["-e", "-v", "2", "--instrument-loops"]
+    RUNTIME_INSTRUMENT_ARGS = ["-e", "-v", "2", "--label", "return", "args"]
 
     @pytest.mark.parametrize(
         "mode",
@@ -269,14 +275,14 @@ class TestOpenMPFortran(RocprofsysTest):
             mode,
             "openmp-fortran-host",
             env=env,
-            rewrite_args=self.REWRITE_ARGS,
-            runtime_args=self.RUNTIME_ARGS,
+            binary_rewrite_args=self.BINARY_REWRITE_ARGS,
+            runtime_instrument_args=self.RUNTIME_INSTRUMENT_ARGS,
         )
         self.assert_regex(
             result,
             mode,
-            rewrite_pass_regex=["omp_parallel"],
-            runtime_pass_regex=["omp_parallel"],
+            binary_rewrite_pass_regex=["omp_parallel"],
+            runtime_instrument_pass_regex=["omp_parallel"],
             sys_run_pass_regex=["omp_parallel"],
         )
 
@@ -310,14 +316,14 @@ class TestOpenMPFortran(RocprofsysTest):
             mode,
             "openmp-fortran-offload",
             env=env,
-            rewrite_args=self.REWRITE_ARGS,
-            runtime_args=self.RUNTIME_ARGS,
+            binary_rewrite_args=self.BINARY_REWRITE_ARGS,
+            runtime_instrument_args=self.RUNTIME_INSTRUMENT_ARGS,
             check_target_arch=True,
         )
         self.assert_regex(
             result,
             mode,
-            rewrite_pass_regex=["omp_offloading"],
-            runtime_pass_regex=["omp_offloading"],
+            binary_rewrite_pass_regex=["omp_offloading"],
+            runtime_instrument_pass_regex=["omp_offloading"],
             sys_run_pass_regex=["omp_offloading"],
         )

--- a/projects/rocprofiler-systems/tests/pytest/test_overflow.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_overflow.py
@@ -48,8 +48,8 @@ class TestOverflow(RocprofsysTest):
             mode,
             "parallel-overhead",
             env=overflow_env,
-            rewrite_args=["-e", "-v", "2"],
-            runtime_args=["-e", "-v", "1"],
+            binary_rewrite_args=["-e", "-v", "2"],
+            runtime_instrument_args=["-e", "-v", "1"],
             run_args=["30", "2", "200"],
         )
         self.assert_regex(result, mode, pass_regex=self.PASS_REGEX)

--- a/projects/rocprofiler-systems/tests/pytest/test_pthread.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_pthread.py
@@ -58,8 +58,6 @@ class TestPthreads(RocprofsysTest):
         r"\|_pthread_mutex_lock .* 1000 .*"
         r"\|_pthread_mutex_unlock .* 1000 .*"
         r"\|_pthread_mutex_lock .* 1000 .*"
-        r"\|_pthread_mutex_unlock .* 1000 .*"
-        r"\|_pthread_mutex_lock .* 1000 .*"
         r"\|_pthread_mutex_unlock .* 1000"
     ]
     OVERHEAD_LOCKS_TIMEMORY_PASS_REGEX = [
@@ -68,7 +66,7 @@ class TestPthreads(RocprofsysTest):
         r"pthread_mutex_unlock (.*) 4000"
     ]
 
-    TIMEMORY_REWRITE_ARGS = [
+    TIMEMORY_BINARY_REWRITE_ARGS = [
         "-e",
         "-v",
         "2",
@@ -88,15 +86,15 @@ class TestPthreads(RocprofsysTest):
             mode,
             "parallel-overhead-locks",
             env=pthread_env,
-            rewrite_args=["-e", "-i", "256"],
-            runtime_args=["-e", "-i", "256"],
+            binary_rewrite_args=["-e", "-i", "256"],
+            runtime_instrument_args=["-e", "-i", "256"],
             run_args=["30", "4", "1000"],
         )
         self.assert_regex(
             result,
             mode,
-            rewrite_pass_regex=self.OVERHEAD_LOCKS_PASS_REGEX,
-            runtime_pass_regex=self.OVERHEAD_LOCKS_PASS_REGEX,
+            binary_rewrite_pass_regex=self.OVERHEAD_LOCKS_PASS_REGEX,
+            runtime_instrument_pass_regex=self.OVERHEAD_LOCKS_PASS_REGEX,
         )
 
     @pytest.mark.parametrize(
@@ -107,11 +105,11 @@ class TestPthreads(RocprofsysTest):
             mode,
             "parallel-overhead-locks",
             env=pthread_timemory_env,
-            rewrite_args=self.TIMEMORY_REWRITE_ARGS,
+            binary_rewrite_args=self.TIMEMORY_BINARY_REWRITE_ARGS,
             run_args=["10", "4", "1000"],
         )
         self.assert_regex(
             result,
             mode,
-            rewrite_pass_regex=self.OVERHEAD_LOCKS_TIMEMORY_PASS_REGEX,
+            binary_rewrite_pass_regex=self.OVERHEAD_LOCKS_TIMEMORY_PASS_REGEX,
         )

--- a/projects/rocprofiler-systems/tests/pytest/test_rank_filter.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_rank_filter.py
@@ -197,7 +197,7 @@ class TestRankFilter(RocprofsysTest):
             "sys_run",
             TARGET,
             env=rocpd_env,
-            sysrun_args=[
+            sys_run_args=[
                 "--rank-filter-output",
                 "garbage,10-0,-1,2,50",
                 "--rank-filter-logs",
@@ -225,7 +225,7 @@ class TestRankFilter(RocprofsysTest):
             "sys_run",
             TARGET,
             env=rocpd_env,
-            sysrun_args=["--rank-filter-output", "5,6"],
+            sys_run_args=["--rank-filter-output", "5,6"],
             launcher="mpi",
             num_procs=NUM_PROCS,
         )
@@ -280,7 +280,7 @@ class TestRankFilter(RocprofsysTest):
             "sys_run",
             TARGET,
             env=rocpd_env,
-            sysrun_args=[
+            sys_run_args=[
                 "--rank-filter-id",
                 "MY_CUSTOM_RANK",
                 "--rank-filter-output",

--- a/projects/rocprofiler-systems/tests/pytest/test_rank_filter.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_rank_filter.py
@@ -104,11 +104,11 @@ class TestRankFilter(RocprofsysTest):
         Every rank should produce both file and console output (filtering disabled).
         """
         env = rocpd_env.copy()
-        sysrun_args = []
+        sys_run_args = []
         if filter_source == "unset":
             pass
         elif filter_source == "via_cli":
-            sysrun_args = ["--rank-filter-output", "", "--rank-filter-logs", ""]
+            sys_run_args = ["--rank-filter-output", "", "--rank-filter-logs", ""]
         elif filter_source == "via_env":
             env["ROCPROFSYS_RANK_FILTER_OUTPUT"] = ""
             env["ROCPROFSYS_RANK_FILTER_LOGS"] = ""
@@ -117,7 +117,7 @@ class TestRankFilter(RocprofsysTest):
             "sys_run",
             TARGET,
             env=env,
-            sysrun_args=sysrun_args,
+            sys_run_args=sys_run_args,
             launcher="mpi",
             num_procs=NUM_PROCS,
         )
@@ -142,7 +142,7 @@ class TestRankFilter(RocprofsysTest):
             "sys_run",
             TARGET,
             env=rocpd_env,
-            sysrun_args=["--rank-filter-logs", "2"],
+            sys_run_args=["--rank-filter-logs", "2"],
             launcher="mpi",
             num_procs=NUM_PROCS,
         )
@@ -167,7 +167,7 @@ class TestRankFilter(RocprofsysTest):
             "sys_run",
             TARGET,
             env=rocpd_env,
-            sysrun_args=["--rank-filter-output", "0-1"],
+            sys_run_args=["--rank-filter-output", "0-1"],
             launcher="mpi",
             num_procs=NUM_PROCS,
         )
@@ -248,7 +248,7 @@ class TestRankFilter(RocprofsysTest):
             "sys_run",
             TARGET,
             env=rocpd_env,
-            sysrun_args=[
+            sys_run_args=[
                 "--rank-filter-id",
                 "MY_CUSTOM_RANK",
                 "--rank-filter-output",
@@ -309,7 +309,7 @@ class TestRankFilter(RocprofsysTest):
             "sys_run",
             TARGET,
             env=rocpd_env,
-            sysrun_args=["--rank-filter-id", "MY_CUSTOM_RANK"],
+            sys_run_args=["--rank-filter-id", "MY_CUSTOM_RANK"],
             launcher="mpi",
             num_procs=NUM_PROCS,
             fail_on_pass=True,

--- a/projects/rocprofiler-systems/tests/pytest/test_rccl.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_rccl.py
@@ -70,7 +70,7 @@ RCCL_TARGETS = [
 
 
 class TestRCCL(RocprofsysTest):
-    REWRITE_ARGS = [
+    BINARY_REWRITE_ARGS = [
         "-e",
         "-v",
         "2",
@@ -82,7 +82,7 @@ class TestRCCL(RocprofsysTest):
         "return",
         "args",
     ]
-    RUNTIME_ARGS = [
+    RUNTIME_INSTRUMENT_ARGS = [
         "-e",
         "-v",
         "1",
@@ -136,8 +136,8 @@ class TestRCCL(RocprofsysTest):
             mode,
             rccl_target,
             env=rccl_env,
-            rewrite_args=self.REWRITE_ARGS,
-            runtime_args=self.RUNTIME_ARGS,
+            binary_rewrite_args=self.BINARY_REWRITE_ARGS,
+            runtime_instrument_args=self.RUNTIME_INSTRUMENT_ARGS,
             run_args=self.RUN_ARGS,
             launcher="mpi",
             num_procs=1,

--- a/projects/rocprofiler-systems/tests/pytest/test_rewrite_caller.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_rewrite_caller.py
@@ -20,7 +20,7 @@ pytestmark = [pytest.mark.rewrite_caller]
 @pytest.mark.caller_include
 @pytest.mark.class_name("rewrite-caller")
 class TestRewriteCaller(RocprofsysTest):
-    REWRITE_ARGS = [
+    BINARY_REWRITE_ARGS = [
         "-e",
         "-i",
         "256",
@@ -32,7 +32,7 @@ class TestRewriteCaller(RocprofsysTest):
         "functions",
     ]
     BASELINE_PASS_REGEX = ["number of calls made = 17"]
-    REWRITE_PASS_REGEX = [
+    BINARY_REWRITE_PASS_REGEX = [
         r"\[function\]\[Forcing\] caller-include-regex :: 'outer'",
         r">>> ._outer ([ \|]+) 17",
     ]
@@ -43,12 +43,11 @@ class TestRewriteCaller(RocprofsysTest):
             mode,
             "rewrite-caller",
             env={"ROCPROFSYS_COUT_OUTPUT": "ON"},
-            rewrite_args=self.REWRITE_ARGS,
+            binary_rewrite_args=self.BINARY_REWRITE_ARGS,
             run_args=["17"],
         )
         self.assert_regex(
             result,
             mode,
-            rewrite_pass_regex=self.REWRITE_PASS_REGEX,
-            rewrite_run_pass_regex=self.REWRITE_PASS_REGEX,
+            binary_rewrite_pass_regex=self.BINARY_REWRITE_PASS_REGEX,
         )

--- a/projects/rocprofiler-systems/tests/pytest/test_roctx.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_roctx.py
@@ -98,7 +98,7 @@ class TestROCTx(RocprofsysTest):
     def roctx_cached_depth(self) -> list[int]:
         return [1, 1, 1, 0, 0, 1, 1, 1]
 
-    REWRITE_ARGS = ["-e", "-v", "2", "--instrument-loops"]
+    BINARY_REWRITE_ARGS = ["-e", "-v", "2", "--instrument-loops"]
 
     @pytest.mark.timeout(120)
     @pytest.mark.parametrize(
@@ -120,7 +120,7 @@ class TestROCTx(RocprofsysTest):
             mode,
             "roctx",
             env=roctx_env,
-            rewrite_args=self.REWRITE_ARGS,
+            binary_rewrite_args=self.BINARY_REWRITE_ARGS,
             check_target_arch=True,
         )
         self.assert_regex(result)

--- a/projects/rocprofiler-systems/tests/pytest/test_thread_limit.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_thread_limit.py
@@ -78,8 +78,8 @@ def get_thread_limit() -> int:
 )
 @pytest.mark.class_name("thread-limit")
 class TestThreadLimit(RocprofsysTest):
-    REWRITE_ARGS = ["-e", "-v", "2", "-i", "1024", "--label", "return", "args"]
-    RUNTIME_ARGS = ["-e", "-v", "1", "-i", "1024", "--label", "return", "args"]
+    BINARY_REWRITE_ARGS = ["-e", "-v", "2", "-i", "1024", "--label", "return", "args"]
+    RUNTIME_INSTRUMENT_ARGS = ["-e", "-v", "1", "-i", "1024", "--label", "return", "args"]
 
     @pytest.mark.timeout(480)
     def test(self, mode, thread_count, thread_limit_env):
@@ -88,8 +88,8 @@ class TestThreadLimit(RocprofsysTest):
             "thread-limit",
             env=thread_limit_env,
             run_args=["35", "2", str(thread_count)],
-            rewrite_args=self.REWRITE_ARGS,
-            runtime_args=self.RUNTIME_ARGS,
+            binary_rewrite_args=self.BINARY_REWRITE_ARGS,
+            runtime_instrument_args=self.RUNTIME_INSTRUMENT_ARGS,
         )
         thread_limit = get_thread_limit()
         pass_value = thread_count

--- a/projects/rocprofiler-systems/tests/pytest/test_time_window.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_time_window.py
@@ -35,8 +35,8 @@ def time_window_env() -> dict[str, str]:
 
 @pytest.mark.class_name("trace-time-window")
 class TestTraceTimeWindow(RocprofsysTest):
-    REWRITE_ARGS = ["-e", "-v", "2", "--caller-include", "inner", "-i", "4096"]
-    RUNTIME_ARGS = ["-e", "-v", "1", "--caller-include", "inner", "-i", "4096"]
+    BINARY_REWRITE_ARGS = ["-e", "-v", "2", "--caller-include", "inner", "-i", "4096"]
+    RUNTIME_INSTRUMENT_ARGS = ["-e", "-v", "1", "--caller-include", "inner", "-i", "4096"]
 
     @pytest.mark.parametrize(
         "mode",
@@ -53,8 +53,8 @@ class TestTraceTimeWindow(RocprofsysTest):
             mode,
             "trace-time-window",
             env=env,
-            rewrite_args=self.REWRITE_ARGS,
-            runtime_args=self.RUNTIME_ARGS,
+            binary_rewrite_args=self.BINARY_REWRITE_ARGS,
+            runtime_instrument_args=self.RUNTIME_INSTRUMENT_ARGS,
         )
         self.assert_regex(result)
 
@@ -96,8 +96,8 @@ class TestTraceTimeWindow(RocprofsysTest):
             mode,
             "trace-time-window",
             env=env,
-            rewrite_args=self.REWRITE_ARGS,
-            runtime_args=self.RUNTIME_ARGS,
+            binary_rewrite_args=self.BINARY_REWRITE_ARGS,
+            runtime_instrument_args=self.RUNTIME_INSTRUMENT_ARGS,
         )
         self.assert_regex(result)
         self.assert_timemory(

--- a/projects/rocprofiler-systems/tests/pytest/test_transpose.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_transpose.py
@@ -98,7 +98,7 @@ def rocprofiler_rules(validation_rules_dir: Path) -> list[Path]:
 
 @pytest.mark.mpi_optional("transpose")
 class TestTranspose(RocprofsysTest):
-    REWRITE_ARGS = [
+    BINARY_REWRITE_ARGS = [
         "-e",
         "-v",
         "2",
@@ -106,7 +106,7 @@ class TestTranspose(RocprofsysTest):
         "-E",
         "uniform_int_distribution",
     ]
-    RUNTIME_ARGS = [
+    RUNTIME_INSTRUMENT_ARGS = [
         "-e",
         "-v",
         "1",
@@ -119,7 +119,7 @@ class TestTranspose(RocprofsysTest):
         "uniform_int_distribution",
     ]
     TWO_KERNELS_RUN_ARGS = ["1", "2", "2"]
-    LOOPS_REWRITE_ARGS = [
+    LOOPS_BINARY_REWRITE_ARGS = [
         "-e",
         "-v",
         "2",
@@ -159,8 +159,8 @@ class TestTranspose(RocprofsysTest):
             mode,
             "transpose",
             env=transpose_env,
-            rewrite_args=self.REWRITE_ARGS,
-            runtime_args=self.RUNTIME_ARGS,
+            binary_rewrite_args=self.BINARY_REWRITE_ARGS,
+            runtime_instrument_args=self.RUNTIME_INSTRUMENT_ARGS,
             check_target_arch=True,
             launcher="mpi",
             num_procs=num_processes,
@@ -216,14 +216,14 @@ class TestTranspose(RocprofsysTest):
             mode,
             "transpose",
             env=transpose_env,
-            rewrite_args=self.LOOPS_REWRITE_ARGS,
+            binary_rewrite_args=self.LOOPS_BINARY_REWRITE_ARGS,
             run_args=self.LOOPS_RUN_ARGS,
             check_target_arch=True,
         )
         self.assert_regex(
             result,
             mode,
-            rewrite_fail_regex=["0 instrumented loops in procedure transpose"],
+            binary_rewrite_fail_regex=["0 instrumented loops in procedure transpose"],
         )
 
     @pytest.mark.timeout(120)
@@ -285,7 +285,7 @@ class TestTranspose(RocprofsysTest):
 @pytest.mark.parametrize("mode", ["sampling", "binary_rewrite"])
 @pytest.mark.class_name("transpose-rocprofiler")
 class TestTransposeROCProfiler(RocprofsysTest):
-    REWRITE_ARGS = ["-e", "-v", "2", "-E", "uniform_int_distribution"]
+    BINARY_REWRITE_ARGS = ["-e", "-v", "2", "-E", "uniform_int_distribution"]
 
     @pytest.mark.timeout(120)
     @pytest.mark.rocpd("rocprofiler_env")
@@ -297,7 +297,7 @@ class TestTransposeROCProfiler(RocprofsysTest):
             check_target_arch=True,
             launcher="mpi",
             num_procs=num_processes,
-            rewrite_args=self.REWRITE_ARGS,
+            binary_rewrite_args=self.BINARY_REWRITE_ARGS,
         )
         self.assert_regex(result)
         # Counter file device ID depends on GPU topology, search across IDs 0-9
@@ -332,8 +332,8 @@ class TestTransposeROCProfiler(RocprofsysTest):
 @pytest.mark.mpi_optional("transpose")
 @pytest.mark.rocprofiler
 @pytest.mark.class_name("transpose-gpu-perf-counters")
+@pytest.mark.timeout(120)
 class TestTransposeGPUPerfCounters(RocprofsysTest):
-
     @pytest.mark.rocpd("gpu_perf_counter_env")
     def test(
         self,
@@ -347,8 +347,8 @@ class TestTransposeGPUPerfCounters(RocprofsysTest):
             "transpose",
             env=gpu_perf_counter_env,
             check_target_arch=True,
-            timeout=120,
-            mpi_ranks=num_processes,
+            launcher="mpi",
+            num_procs=num_processes,
         )
         self.assert_regex(result)
         self.assert_perfetto(

--- a/projects/rocprofiler-systems/tests/pytest/test_ucx.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_ucx.py
@@ -42,6 +42,7 @@ def ucx_base_env() -> dict[str, str]:
         "OMPI_MCA_pml_ucx_devices": "any",  # Accept any device (not just InfiniBand/Mellanox)
         "OMPI_MCA_btl": "^vader,sm",  # Disable shared memory BTLs to force communication through UCX
         "UCX_TLS": "tcp,self",  # Tell UCX to use TCP for inter-process, self for intra-process
+        "FI_PROVIDER": "^psm3",  # Stop libfabric from loading the psm3 provider
         "OMPI_MCA_pml_base_verbose": "100",  # Show which PML is selected
         "UCX_LOG_LEVEL": "info",  # Enable UCX logging to show transport usage
     }
@@ -90,6 +91,11 @@ def ucx_env(ucx_base_env) -> dict[str, str]:
 
 
 class TestUCX(RocprofsysTest):
+    UCX_PASS_REGEX = [
+        "Shutting down UCX tracing",  # Emitted by rocprof-sys (requires debug logging)
+        r"pml.*ucx",  # Emitted by program when UCX logging is enabled
+    ]
+
     @pytest.mark.parametrize("mode", ["binary_rewrite", "sys_run"])
     @pytest.mark.parametrize(
         "target",
@@ -102,7 +108,7 @@ class TestUCX(RocprofsysTest):
         ],
     )
     def test(self, mode, target, ucx_env):
-        REWRITE_ARGS = [
+        BINARY_REWRITE_ARGS = [
             "-e",
             "-v",
             "2",
@@ -113,16 +119,12 @@ class TestUCX(RocprofsysTest):
             "0",
         ]
         RUN_ARGS = ["30"]
-        REWRITE_PASS_REGEX = [
-            r"ucx_gotcha|category::ucx|Successfully executed: .+rocprof-sys-merge-output\.sh.*"
-        ]
-        SYS_RUN_PASS_REGEX = [r"ucx_gotcha|category::ucx|Using UCX|pml.*ucx"]
 
         result = self.run_test(
             mode,
             target,
             env=ucx_env,
-            rewrite_args=REWRITE_ARGS,
+            binary_rewrite_args=BINARY_REWRITE_ARGS,
             run_args=RUN_ARGS,
             launcher="mpi",
             num_procs=2,
@@ -130,8 +132,7 @@ class TestUCX(RocprofsysTest):
         self.assert_regex(
             result,
             mode,
-            rewrite_pass_regex=REWRITE_PASS_REGEX,
-            sys_run_pass_regex=SYS_RUN_PASS_REGEX,
+            pass_regex=self.UCX_PASS_REGEX,
         )
         if mode == "sys_run":
             self.assert_perfetto(
@@ -143,7 +144,7 @@ class TestUCX(RocprofsysTest):
 
     @pytest.mark.parametrize("mode", ["binary_rewrite", "sys_run"])
     def test_perfetto(self, mode, ucx_env):
-        REWRITE_ARGS = [
+        BINARY_REWRITE_ARGS = [
             "-e",
             "-v",
             "2",
@@ -153,26 +154,21 @@ class TestUCX(RocprofsysTest):
             "--min-instructions",
             "0",
         ]
-        REWRITE_PASS_REGEX = [
-            r"ucx_gotcha|category::ucx|Successfully executed: .+rocprof-sys-merge-output\.sh.*"
-        ]
-        REWRITE_FAIL_REGEX = [r"Script not found|Failed to execute"]
-        SYS_RUN_PASS_REGEX = [r"ucx_gotcha|category::ucx|Using UCX|pml.*ucx"]
+        BINARY_REWRITE_FAIL_REGEX = [r"Script not found|Failed to execute"]
 
         result = self.run_test(
             mode,
             "mpi-send-recv",
             env=ucx_env,
-            rewrite_args=REWRITE_ARGS,
+            binary_rewrite_args=BINARY_REWRITE_ARGS,
             launcher="mpi",
             num_procs=2,
         )
         self.assert_regex(
             result,
             mode,
-            rewrite_pass_regex=REWRITE_PASS_REGEX,
-            rewrite_fail_regex=REWRITE_FAIL_REGEX,
-            sys_run_pass_regex=SYS_RUN_PASS_REGEX,
+            pass_regex=self.UCX_PASS_REGEX,
+            binary_rewrite_fail_regex=BINARY_REWRITE_FAIL_REGEX,
         )
         if mode == "sys_run":
             self.assert_perfetto(
@@ -184,7 +180,7 @@ class TestUCX(RocprofsysTest):
 
     @pytest.mark.parametrize("mode", ["binary_rewrite", "sys_run"])
     def test_mpip(self, mode, ucx_mpip_env):
-        REWRITE_ARGS = [
+        BINARY_REWRITE_ARGS = [
             "-e",
             "-v",
             "2",
@@ -195,14 +191,13 @@ class TestUCX(RocprofsysTest):
             "--min-instructions",
             "0",
         ]
-        REWRITE_PASS_REGEX = [r"ucx_gotcha|category::ucx"]
         RUN_ARGS = ["30"]
 
         result = self.run_test(
             mode,
             "mpi-all2all",
             env=ucx_mpip_env,
-            rewrite_args=REWRITE_ARGS,
+            binary_rewrite_args=BINARY_REWRITE_ARGS,
             run_args=RUN_ARGS,
             launcher="mpi",
             num_procs=2,
@@ -210,13 +205,13 @@ class TestUCX(RocprofsysTest):
         self.assert_regex(
             result,
             mode,
-            rewrite_pass_regex=REWRITE_PASS_REGEX,
+            pass_regex=self.UCX_PASS_REGEX,
         )
 
     @pytest.mark.parametrize("mode", ["binary_rewrite", "sys_run"])
     @pytest.mark.parametrize("msg_size", ["1024", "4096", "16384"])
     def test_bcast(self, mode, msg_size, ucx_env):
-        REWRITE_ARGS = [
+        BINARY_REWRITE_ARGS = [
             "-e",
             "-v",
             "2",
@@ -226,13 +221,12 @@ class TestUCX(RocprofsysTest):
             "--min-instructions",
             "0",
         ]
-        REWRITE_PASS_REGEX = [r"ucx_gotcha|category::ucx"]
 
         result = self.run_test(
             mode,
             "mpi-bcast",
             env=ucx_env,
-            rewrite_args=REWRITE_ARGS,
+            binary_rewrite_args=BINARY_REWRITE_ARGS,
             run_args=[msg_size],
             launcher="mpi",
             num_procs=2,
@@ -240,12 +234,12 @@ class TestUCX(RocprofsysTest):
         self.assert_regex(
             result,
             mode,
-            rewrite_pass_regex=REWRITE_PASS_REGEX,
+            pass_regex=self.UCX_PASS_REGEX,
         )
 
     @pytest.mark.parametrize("mode", ["binary_rewrite", "sys_run"])
     def test_active_message(self, mode, ucx_active_messages_env):
-        REWRITE_ARGS = [
+        BINARY_REWRITE_ARGS = [
             "-e",
             "-v",
             "2",
@@ -255,14 +249,13 @@ class TestUCX(RocprofsysTest):
             "--min-instructions",
             "0",
         ]
-        REWRITE_PASS_REGEX = [r"ucx_gotcha|category::ucx"]
         RUN_ARGS = ["64"]
 
         result = self.run_test(
             mode,
             "mpi-allreduce",
             env=ucx_active_messages_env,
-            rewrite_args=REWRITE_ARGS,
+            binary_rewrite_args=BINARY_REWRITE_ARGS,
             run_args=RUN_ARGS,
             launcher="mpi",
             num_procs=2,
@@ -270,5 +263,5 @@ class TestUCX(RocprofsysTest):
         self.assert_regex(
             result,
             mode,
-            rewrite_pass_regex=REWRITE_PASS_REGEX,
+            pass_regex=self.UCX_PASS_REGEX,
         )

--- a/projects/rocprofiler-systems/tests/pytest/test_user_api.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_user_api.py
@@ -21,7 +21,7 @@ pytestmark = [pytest.mark.user_api]
 )
 @pytest.mark.class_name("user-api")
 class TestUserAPI(RocprofsysTest):
-    REWRITE_ARGS = [
+    BINARY_REWRITE_ARGS = [
         "-e",
         "-v",
         "2",
@@ -30,7 +30,7 @@ class TestUserAPI(RocprofsysTest):
         "-E",
         "custom_push_region",
     ]
-    RUNTIME_ARGS = [
+    RUNTIME_INSTRUMENT_ARGS = [
         "-e",
         "-v",
         "1",
@@ -45,7 +45,7 @@ class TestUserAPI(RocprofsysTest):
         "args",
     ]
     BASELINE_FAIL_REGEX = ["Pushing custom region"]
-    REWRITE_FAIL_REGEX = ["0 instrumented loops in procedure"]
+    BINARY_REWRITE_FAIL_REGEX = ["0 instrumented loops in procedure"]
     CUSTOM_MARKER_PASS_REGEX = ["Pushing custom region :: run.10. x 1000"]
 
     def test(self, mode):
@@ -53,15 +53,15 @@ class TestUserAPI(RocprofsysTest):
             mode,
             "user-api",
             run_args=["10", str(self.num_threads), "1000"],
-            rewrite_args=self.REWRITE_ARGS,
-            runtime_args=self.RUNTIME_ARGS,
+            binary_rewrite_args=self.BINARY_REWRITE_ARGS,
+            runtime_instrument_args=self.RUNTIME_INSTRUMENT_ARGS,
         )
         self.assert_regex(
             result,
             mode,
             baseline_fail_regex=self.BASELINE_FAIL_REGEX,
-            rewrite_fail_regex=self.REWRITE_FAIL_REGEX,
-            rewrite_run_pass_regex=self.CUSTOM_MARKER_PASS_REGEX,
-            runtime_pass_regex=self.CUSTOM_MARKER_PASS_REGEX,
+            binary_rewrite_fail_regex=self.BINARY_REWRITE_FAIL_REGEX,
+            binary_rewrite_pass_regex=self.CUSTOM_MARKER_PASS_REGEX,
+            runtime_instrument_pass_regex=self.CUSTOM_MARKER_PASS_REGEX,
             sampling_pass_regex=self.CUSTOM_MARKER_PASS_REGEX,
         )


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

In the current pytest implementation, I only had some checks to ensure that the proper `kwargs` were set for `run_test`. But some were missing (such as `num_procs` requiring `launcher`) and there were none for `assert_regex`.

Because of the missing checks for `assert_regex`, almost all `binary_rewrite` and `runtime_instrument` pass and fail regexes were being silently skipped.

## Technical Details

 - Add `_filter_kwargs` and `_FUNCTION_ALLOWED_KWARGS` that, for now, are used in `run_test` and `assert_regex`. The function does two things:
   1. It filters the `kwargs` so that the specific `mode` gets the specific args it needs. This was already being done before this PR, I'm just centralizing it.
   2. If a `kwarg` is passed that is not in the list of allowed `kwargs` for any given mode in `_FUNCTION_ALLOWED_KWARGS` (for the given function), an error is thrown. 
 - Make the mode specific regex names match the mode name. Instead of `rewrite_pass_regex`, it is now `binary_rewrite_pass_regex`. The same holds for `runtime_instrument` pass/fail regexes.
 - Require OpenMP tests to run on `ROCm 6.4` and above. 6.3 ships with SDK version 500, and all OpenMP processing logic in `rocprofiler-sdk.cpp` is gated behind version 600 and above. 
   - Previously, on 6.3, nothing was really being "validated" and they would pass silently as the regexes were being skipped.
 - Change `_validate_regex` to scan the log independently for each pass regex as the previous combined-alternation scan could shadow one required pattern with another's match (e.g. greedy `pml.*ucx`) and report false misses. This need not be done with `fail` regex as one match forces failure.

**Local testing results**

Local tests have raised an issue with `jacobi-roctx-.*` tests. In an older PR, I added `ROCPROFSYS_DEFAULT_MIN_INSTRUCTIONS=64` (equivalent to `--min-instructions=64`) to the base environment. This had the side effect of making the perfetto validation test with `jacobi-roctx-binary-rewrite` fail as `_QMjacobi_modPinit_jacobi` appears under both `init` and `run`. The depth needed to be changed, but only for `binary-rewrite`, and not `sys-run`, as it is incapable of capturing that information (it does not go through dyninst). 

The regex for `pthreads-parallel-overhead-locks-.*` also had to be adjusted. The regex assumed 5 threads, but the test was running with 4. I changed the regex to reflect this.

`transpose-gpu-perf-counters`: Requires `launcher=mpi` as an argument.


<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

AIPROFSYST-486

## Test Plan

Local + Workflows

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

Local + Workflows

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
