### PR TITLE
[rocprofiler-systems] Remove Timemory demangler dependency

### DIFF
--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.hpp
@@ -10,7 +10,6 @@
 #include <timemory/settings/macros.hpp>
 #include <timemory/tpls/cereal/archives.hpp>
 #include <timemory/tpls/cereal/cereal/external/base64.hpp>
-#include <timemory/utility/demangle.hpp>
 
 #include <algorithm>
 #include <array>

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.hpp
@@ -10,7 +10,6 @@
 #include <timemory/mpl/concepts.hpp>
 #include <timemory/settings/types.hpp>
 #include <timemory/utility/argparse.hpp>
-#include <timemory/utility/demangle.hpp>
 #include <timemory/utility/type_list.hpp>
 
 #include <array>

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/get_availability.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/get_availability.hpp
@@ -13,7 +13,6 @@
 #include <timemory/defines.h>
 #include <timemory/enum.h>
 #include <timemory/mpl/type_traits.hpp>
-#include <timemory/utility/demangle.hpp>
 #include <timemory/utility/type_list.hpp>
 #include <timemory/variadic/macros.hpp>
 
@@ -133,7 +132,7 @@ get_availability<Type>::get_info()
                               : std::string("");
     auto description =
         (has_metadata) ? metadata_t::description() : Type::get_description();
-    auto     data_type = demangle<value_type>();
+    auto     data_type = rocprofsys::utility::demangle<value_type>();
     string_t enum_type = property_t::enum_string();
     string_t id_type   = property_t::id();
     auto     ids_set   = property_t::ids();

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/get_categories.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/get_categories.hpp
@@ -6,7 +6,6 @@
 #include "common.hpp"
 #include "core/demangler.hpp"
 
-#include <timemory/utility/demangle.hpp>
 #include <timemory/utility/type_list.hpp>
 
 #include <algorithm>

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/fwd.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/fwd.hpp
@@ -13,7 +13,6 @@
 #include <timemory/tpls/cereal/archives.hpp>
 #include <timemory/tpls/cereal/cereal.hpp>
 #include <timemory/utility/argparse.hpp>
-#include <timemory/utility/demangle.hpp>
 #include <timemory/utility/popen.hpp>
 #include <timemory/variadic/macros.hpp>
 

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/internal_libs.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/internal_libs.cpp
@@ -17,7 +17,6 @@
 #include <timemory/components/timing/wall_clock.hpp>
 #include <timemory/environment/types.hpp>
 #include <timemory/log/macros.hpp>
-#include <timemory/utility/demangle.hpp>
 #include <timemory/utility/filepath.hpp>
 #include <timemory/utility/join.hpp>
 #include <timemory/utility/types.hpp>

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/rocprof-sys-instrument.cpp
@@ -21,7 +21,6 @@
 #include <timemory/signals/signal_mask.hpp>
 #include <timemory/utility/console.hpp>
 #include <timemory/utility/delimit.hpp>
-#include <timemory/utility/demangle.hpp>
 #include <timemory/utility/filepath.hpp>
 #include <timemory/utility/signals.hpp>
 

--- a/projects/rocprofiler-systems/source/lib/core/common.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/common.hpp
@@ -13,7 +13,6 @@
 #include <timemory/backends/threading.hpp>
 #include <timemory/environment/types.hpp>
 #include <timemory/mpl/types.hpp>
-#include <timemory/utility/demangle.hpp>
 #include <timemory/utility/filepath.hpp>
 #include <timemory/utility/locking.hpp>
 

--- a/projects/rocprofiler-systems/source/lib/core/containers/static_vector.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/containers/static_vector.hpp
@@ -7,8 +7,6 @@
 #include "core/containers/c_array.hpp"
 #include "core/exception.hpp"
 
-#include <timemory/utility/demangle.hpp>
-
 #include <array>
 #include <atomic>
 #include <cstdlib>

--- a/projects/rocprofiler-systems/source/lib/core/rocprofiler-sdk.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/rocprofiler-sdk.cpp
@@ -11,7 +11,6 @@
 #include <spdlog/fmt/ranges.h>
 
 #include <timemory/defines.h>
-#include <timemory/utility/demangle.hpp>
 
 #include <rocprofiler-sdk/agent.h>
 #include <rocprofiler-sdk/cxx/name_info.hpp>

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/backtrace.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/backtrace.cpp
@@ -31,7 +31,6 @@
 #include <timemory/storage.hpp>
 #include <timemory/units.hpp>
 #include <timemory/utility/backtrace.hpp>
-#include <timemory/utility/demangle.hpp>
 #include <timemory/utility/types.hpp>
 #include <timemory/variadic.hpp>
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/backtrace_metrics.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/backtrace_metrics.cpp
@@ -37,7 +37,6 @@
 #include <timemory/storage.hpp>
 #include <timemory/units.hpp>
 #include <timemory/utility/backtrace.hpp>
-#include <timemory/utility/demangle.hpp>
 #include <timemory/utility/types.hpp>
 #include <timemory/variadic.hpp>
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/callchain.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/callchain.cpp
@@ -34,7 +34,6 @@
 #include <timemory/storage.hpp>
 #include <timemory/units.hpp>
 #include <timemory/unwind/entry.hpp>
-#include <timemory/utility/demangle.hpp>
 #include <timemory/utility/types.hpp>
 #include <timemory/variadic.hpp>
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpip.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/mpip.hpp
@@ -14,7 +14,6 @@
 #include <timemory/mpl/apply.hpp>
 #include <timemory/mpl/types.hpp>
 #include <timemory/units.hpp>
-#include <timemory/utility/demangle.hpp>
 #include <timemory/variadic/types.hpp>
 
 #include "logger/debug.hpp"

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/sampling.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/sampling.cpp
@@ -50,7 +50,6 @@
 #include <timemory/units.hpp>
 #include <timemory/unwind/processed_entry.hpp>
 #include <timemory/utility/backtrace.hpp>
-#include <timemory/utility/demangle.hpp>
 #include <timemory/utility/procfs/maps.hpp>
 #include <timemory/utility/types.hpp>
 #include <timemory/variadic.hpp>


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Dependency on Timemory demangler functionality has been mostly replaced earlier with rocprofsys::utility::demangle(), but there was some remaining includes and one unqualified call to demangle() that resolved to Timemory. This PR completely removes all remaining includes of `timemory/utility/demangle.hpp`.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

AIPROFSYST-531

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

Tests from existing ctest suite should pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
