### PR TITLE
[ROCM-23433] Correct rocm-smi-lib command for GPU reset warning

### DIFF
--- a/projects/rocm-smi-lib/docs/how-to/use-python.rst
+++ b/projects/rocm-smi-lib/docs/how-to/use-python.rst
@@ -436,7 +436,7 @@ Clock type descriptions
   .. warning::
 
    * On systems with XGMI/Infinity Fabric (for example, AMD Instinct MI Series), resetting one
-     GPU resets all GPUs in the same XGMI hive. Use ``amd-smi xgmi`` or ``amd-smi topology`` to find the XGMI link connected GPUs or check ``/sys/class/drm/card*/device/xgmi_info/xgmi_hive_id`` to identify GPUs having the same hive id, before issuing a reset.
+     GPU resets all GPUs in the same XGMI hive. Use ``rocm-smi --showtopo`` to find the XGMI link connected GPUs or check ``/sys/class/drm/card*/device/xgmi_info/xgmi_hive_id`` to identify GPUs having the same hive id, before issuing a reset.
 
    * Any process with an open ``/dev/kfd`` handle will be terminated when a GPU reset occurs,
      even if that process is not using the GPU being reset. GPU isolation techniques using the


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
This PR is related to https://github.com/ROCm/rocm-systems/pull/6688. The AMD SMI command included in the GPU reset warning needed to be changed to one used for ROCm SMI.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
``amd-smi xgmi`` or ``amd-smi topology`` replaced with ``rocm-smi --showtopo``. for ROCm SMI documentation.



## JIRA ID
ROCM-23433

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
