### PR TITLE
[rocshmem] functional_tests fix for hdp_flush

### DIFF
--- a/projects/rocshmem/tests/functional_tests/tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/tester.cpp
@@ -937,12 +937,16 @@ void flush_hdp() {
   CHECK_HIP(hipGetDevice(&hip_dev_id));
   CHECK_HIP(hipDeviceGetAttribute(reinterpret_cast<int*>(&hdp_flush_ptr_),
                         hipDeviceAttributeHdpMemFlushCntl, hip_dev_id));
-  __atomic_store_n(hdp_flush_ptr_, 0x1, __ATOMIC_SEQ_CST);
+  if (hdp_flush_ptr_ != nullptr) {
+    __atomic_store_n(hdp_flush_ptr_, 0x1, __ATOMIC_SEQ_CST);
+  }
 }
 
 void Tester::barrier() {
   rocshmem_barrier_all();
+#if defined USE_HDP_FLUSH
   flush_hdp();
+#endif
 }
 
 double Tester::gpuCyclesToMicroseconds(long long int cycles) {


### PR DESCRIPTION
## Motivation

the functional tests executed an hdp_flush as part of its barrier operation. That is not required and not necessarily correct. Use the high level macro that controls if hdp flush was requested.

In addition, check the pointer returned by hipDeviceGetAttribute to ensure that we write to a valid memory location.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
