### PR TITLE
Scope the numa pinning for graphs.

### DIFF
--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -1715,6 +1715,9 @@ hipError_t hipGraphExecDestroy(hipGraphExec_t pGraphExec) {
     hip::GraphExecBase::graphExecSet_.erase(ge);
   }
   ge->release();
+  // Restore a hold-mode (AMD_GRAPH_CPU_AFFINITY_HOLD) GPU-local pin on this (the
+  // app's destroying) thread. No-op in scope mode or if this thread holds none.
+  amd::numa::RestoreHeldGraphAffinity();
   HIP_RETURN(hipSuccess);
 }
 

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -2974,12 +2974,14 @@ bool Graph::RunNodes(int32_t base_stream, const std::vector<hip::Stream*>* paral
 hipError_t GraphExecSegmented::Run(hip::Stream* launch_stream) {
   hipError_t status = hipSuccess;
 
-  // Pin the launching thread to this device's GPU-local NUMA node for the
-  // duration of the launch (opt-in via AMD_GRAPH_CPU_AFFINITY). The mask is
-  // restored on every return path by the guard's destructor, so it is never
-  // held when the application forks/spawns between launches.
+  // Pin the launching thread to the GPU-local NUMA node of the device this
+  // graph is launched on (opt-in via AMD_GRAPH_CPU_AFFINITY). Use the launch
+  // stream's device, not the instantiation device -- a graph can be launched on
+  // a different GPU than it was built on. The mask is restored on every return
+  // path by the guard's destructor, so it is never held when the application
+  // forks/spawns between launches.
   amd::ScopedGraphCpuAffinity scopedGraphAffinity(
-      Device()->devices()[0]->getPreferredNumaNode());
+      launch_stream->GetDevice()->devices()[0]->getPreferredNumaNode());
 
   // Retain under shared lock so hipDeviceGraphMemTrim's refcount check is accurate.
   // The lock blocks only while trim holds the exclusive (write) lock.

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -2974,6 +2974,13 @@ bool Graph::RunNodes(int32_t base_stream, const std::vector<hip::Stream*>* paral
 hipError_t GraphExecSegmented::Run(hip::Stream* launch_stream) {
   hipError_t status = hipSuccess;
 
+  // Pin the launching thread to this device's GPU-local NUMA node for the
+  // duration of the launch (opt-in via AMD_GRAPH_CPU_AFFINITY). The mask is
+  // restored on every return path by the guard's destructor, so it is never
+  // held when the application forks/spawns between launches.
+  amd::ScopedGraphCpuAffinity scopedGraphAffinity(
+      Device()->devices()[0]->getPreferredNumaNode());
+
   // Retain under shared lock so hipDeviceGraphMemTrim's refcount check is accurate.
   // The lock blocks only while trim holds the exclusive (write) lock.
   {

--- a/projects/clr/rocclr/os/os.hpp
+++ b/projects/clr/rocclr/os/os.hpp
@@ -375,6 +375,36 @@ inline void Os::resetPreferredNumaNode() {
   }
 }
 
+//! RAII scope guard: pin the calling thread to a GPU-local NUMA node for the
+//! duration of a hipGraph launch, then restore the original mask on exit.
+//!
+//! Unlike the process-wide AMD_CPU_AFFINITY pin (held from HIP init to
+//! teardown), this restores the caller's mask when the scope ends, so the
+//! runtime's optimization never leaks into child processes the application
+//! forks/spawns between launches. Gated by AMD_GRAPH_CPU_AFFINITY.
+class ScopedGraphCpuAffinity {
+ public:
+  explicit ScopedGraphCpuAffinity(uint32_t node) {
+    // Mutually exclusive with the process-wide pin: if AMD_CPU_AFFINITY already
+    // owns this thread's mask, do nothing -- otherwise our restore would tear
+    // down its TLS affinity state after the first launch.
+    if (AMD_GRAPH_CPU_AFFINITY && !AMD_CPU_AFFINITY) {
+      numa::NumaNode numaNode(node);
+      active_ = numaNode.SchedSetAffinityIfAllowed();
+    }
+  }
+  ~ScopedGraphCpuAffinity() {
+    if (active_) {
+      numa::resetThreadAffinity();
+    }
+  }
+  ScopedGraphCpuAffinity(const ScopedGraphCpuAffinity&) = delete;
+  ScopedGraphCpuAffinity& operator=(const ScopedGraphCpuAffinity&) = delete;
+
+ private:
+  bool active_ = false;  //!< True only if this scope actually applied a pin.
+};
+
 }  // namespace amd
 
 #endif /*OS_HPP_*/

--- a/projects/clr/rocclr/os/os.hpp
+++ b/projects/clr/rocclr/os/os.hpp
@@ -309,6 +309,25 @@ uint32_t getCurrentNumaNode();
 //! Restore the current thread affinity if it was changed by the runtime
 bool resetThreadAffinity();
 
+//! Graph-scoped (AMD_GRAPH_CPU_AFFINITY) lean pin: pin the current thread to
+//! `node` for a single graph launch. Returns true iff a pin was applied (the
+//! caller must then call RestoreGraphAffinity on scope exit). Caches the
+//! thread's original mask and the node CPU mask so the steady-state cost is one
+//! sched_setaffinity here + one in RestoreGraphAffinity.
+bool ApplyGraphAffinity(uint32_t node);
+
+//! Restore the mask saved by a prior ApplyGraphAffinity that returned true.
+void RestoreGraphAffinity();
+
+//! Hold variant (AMD_GRAPH_CPU_AFFINITY_HOLD): pin the current thread to `node`
+//! and keep it pinned across launches; re-pins only when `node` changes; no
+//! per-launch restore -- the mask is restored from hipGraphExecDestroy.
+void HoldGraphAffinity(uint32_t node);
+
+//! Restore a HoldGraphAffinity pin from the hipGraphExecDestroy path. Runs on
+//! the app's destroying thread; no-op unless that thread holds the pin.
+void RestoreHeldGraphAffinity();
+
 /*! \brief Manage Numa policy.
  *
  *  \note Works in Linux only, dummy in Windows.
@@ -384,18 +403,24 @@ inline void Os::resetPreferredNumaNode() {
 //! forks/spawns between launches. Gated by AMD_GRAPH_CPU_AFFINITY.
 class ScopedGraphCpuAffinity {
  public:
+  //! \param node GPU-local NUMA node to pin to for this launch.
   explicit ScopedGraphCpuAffinity(uint32_t node) {
     // Mutually exclusive with the process-wide pin: if AMD_CPU_AFFINITY already
     // owns this thread's mask, do nothing -- otherwise our restore would tear
     // down its TLS affinity state after the first launch.
     if (AMD_GRAPH_CPU_AFFINITY && !AMD_CPU_AFFINITY) {
-      numa::NumaNode numaNode(node);
-      active_ = numaNode.SchedSetAffinityIfAllowed();
+      if (AMD_GRAPH_CPU_AFFINITY_HOLD) {
+        // Hold mode: pin and keep it; restored at hipGraphExecDestroy, not here.
+        numa::HoldGraphAffinity(node);
+      } else {
+        // Scope mode (default): pin now, restore on scope exit.
+        active_ = numa::ApplyGraphAffinity(node);
+      }
     }
   }
   ~ScopedGraphCpuAffinity() {
     if (active_) {
-      numa::resetThreadAffinity();
+      numa::RestoreGraphAffinity();
     }
   }
   ScopedGraphCpuAffinity(const ScopedGraphCpuAffinity&) = delete;

--- a/projects/clr/rocclr/os/os_posix.cpp
+++ b/projects/clr/rocclr/os/os_posix.cpp
@@ -36,6 +36,7 @@
 #endif  // DT_GNU_HASH
 #include <atomic>
 #include <vector>
+#include <unordered_map>
 #include <string>
 #include <sstream>
 #include <cstring>  // for strncmp
@@ -56,6 +57,13 @@ struct ThreadAffinityState {
   uint32_t runtime_set_affinity_node = static_cast<uint32_t>(-1);
   std::vector<uint64_t> original_affinity_mask;
   bool original_affinity_mask_valid = false;
+  // Graph-scoped (AMD_GRAPH_CPU_AFFINITY) state:
+  bool graph_app_owned = false;  //!< app/launcher set a restricted mask -> never pin
+  // Scope mode (default): pin per launch, restore on launch exit.
+  bool graph_applied = false;    //!< this launch pinned -> restore on Run exit
+  // Hold mode (AMD_GRAPH_CPU_AFFINITY_HOLD): pin once, restore at hipGraphExecDestroy.
+  bool graph_hold_applied = false;                       //!< holding a pin -> restore at ExecDestroy
+  uint32_t graph_hold_node = static_cast<uint32_t>(-1);  //!< node currently held (skip re-pin)
 };
 
 ThreadAffinityState*& GetThreadAffinityStatePtr() {
@@ -1241,6 +1249,154 @@ bool resetThreadAffinity() {
   const bool restored = SetCurrentThreadAffinity(affinity_state->original_affinity_mask);
   ReleaseThreadAffinityState();
   return restored;
+}
+
+// ================================================================================================
+// Read a NUMA node's CPU set from sysfs into a sched_setaffinity-compatible mask
+// (same word width as GetCurrentThreadAffinity). Parses /sys/.../nodeN/cpulist
+// ("0-63" / "0-15,32-47"). Returns empty on failure.
+static std::vector<uint64_t> ReadNodeCpuMask(uint32_t node) {
+  const uint32_t bytes = CPU_ALLOC_SIZE(amd::Os::processorCount());
+  std::vector<uint64_t> mask((bytes + sizeof(uint64_t) - 1) / sizeof(uint64_t), 0);
+  std::ifstream file("/sys/devices/system/node/node" + std::to_string(node) + "/cpulist");
+  if (!file) {
+    return {};
+  }
+  std::string line;
+  std::getline(file, line);
+  size_t pos = 0;
+  while (pos < line.size()) {
+    const size_t comma = line.find(',', pos);
+    const std::string tok =
+        line.substr(pos, comma == std::string::npos ? std::string::npos : comma - pos);
+    if (!tok.empty()) {
+      const size_t dash = tok.find('-');
+      const uint32_t lo = static_cast<uint32_t>(std::stoul(tok.substr(0, dash)));
+      const uint32_t hi = (dash == std::string::npos)
+          ? lo : static_cast<uint32_t>(std::stoul(tok.substr(dash + 1)));
+      for (uint32_t cpu = lo; cpu <= hi; ++cpu) {
+        const uint32_t w = cpu / kBitsPerUInt64;
+        if (w < mask.size()) {
+          mask[w] |= (static_cast<uint64_t>(1) << (cpu % kBitsPerUInt64));
+        }
+      }
+    }
+    if (comma == std::string::npos) {
+      break;
+    }
+    pos = comma + 1;
+  }
+  return mask;
+}
+
+// Process-wide cache: node index -> CPU mask. Topology is fixed for the process,
+// so the sysfs read happens once per node, not once per graph launch.
+static const std::vector<uint64_t>& CachedNodeCpuMask(uint32_t node) {
+  static std::mutex cache_lock;
+  static std::unordered_map<uint32_t, std::vector<uint64_t>> cache;
+  std::scoped_lock lk(cache_lock);
+  auto it = cache.find(node);
+  if (it == cache.end()) {
+    it = cache.emplace(node, ReadNodeCpuMask(node)).first;
+  }
+  return it->second;  // unordered_map element refs are stable across later inserts
+}
+
+// ================================================================================================
+// Scope-mode graph pin (AMD_GRAPH_CPU_AFFINITY): pin the calling thread to `node`
+// for one graph launch.
+//   - captures the thread's original mask once (cached in TLS), then trusts it;
+//   - respects an app/launcher/cpuset-set mask (checked once, then remembered);
+//   - does nothing when the thread is already on the node (e.g. numactl-bound);
+//   - the node CPU mask is read from sysfs once per node and cached globally, so
+//     the steady-state cost is one sched_setaffinity here + one in
+//     RestoreGraphAffinity, with no per-launch reads.
+// Returns true iff a pin was applied (caller must call RestoreGraphAffinity).
+bool ApplyGraphAffinity(uint32_t node) {
+  ThreadAffinityState& st = GetThreadAffinityState();
+  if (st.graph_app_owned) {
+    return false;
+  }
+  if (!st.original_affinity_mask_valid) {
+    if (!GetCurrentThreadAffinity(&st.original_affinity_mask)) {
+      return false;
+    }
+    if (!IsUnrestrictedAffinity(st.original_affinity_mask)) {
+      st.graph_app_owned = true;  // respect app/launcher/cpuset mask; never pin
+      return false;
+    }
+    st.original_affinity_mask_valid = true;
+  }
+  const std::vector<uint64_t>& node_mask = CachedNodeCpuMask(node);
+  if (node_mask.empty() || IsSameAffinity(st.original_affinity_mask, node_mask)) {
+    return false;  // unknown node, or already on the node -> nothing to do
+  }
+  if (!SetCurrentThreadAffinity(node_mask)) {
+    return false;
+  }
+  st.graph_applied = true;
+  return true;
+}
+
+void RestoreGraphAffinity() {
+  ThreadAffinityState* st = GetThreadAffinityStatePtr();
+  if (st == nullptr || !st->graph_applied) {
+    return;
+  }
+  SetCurrentThreadAffinity(st->original_affinity_mask);
+  st->graph_applied = false;  // keep original_affinity_mask cached for next launch
+}
+
+// ================================================================================================
+// Hold-mode graph pin (AMD_GRAPH_CPU_AFFINITY_HOLD): pin the calling thread to
+// `node` and keep it pinned across launches; re-pin only when the launch node
+// changes. The mask is restored once, from the hipGraphExecDestroy path
+// (RestoreHeldGraphAffinity), which runs on the app's destroying thread -- a
+// deterministic, correct-thread boundary (unlike ~GraphExec, which may run on an
+// async completion thread when the exec is destroyed with work still in flight).
+// The pin is held from the first launch until ExecDestroy, so this mode does not
+// restore the mask between launches.
+void HoldGraphAffinity(uint32_t node) {
+  ThreadAffinityState& st = GetThreadAffinityState();
+  if (st.graph_app_owned || st.graph_hold_node == node) {
+    return;  // app owns the mask, or already held on this node -> nothing to do
+  }
+  if (!st.original_affinity_mask_valid) {
+    if (!GetCurrentThreadAffinity(&st.original_affinity_mask)) {
+      return;
+    }
+    if (!IsUnrestrictedAffinity(st.original_affinity_mask)) {
+      st.graph_app_owned = true;  // respect app/launcher/cpuset mask; never pin
+      return;
+    }
+    st.original_affinity_mask_valid = true;
+  }
+  const std::vector<uint64_t>& node_mask = CachedNodeCpuMask(node);
+  if (node_mask.empty()) {
+    return;
+  }
+  if (IsSameAffinity(st.original_affinity_mask, node_mask)) {
+    st.graph_hold_node = node;  // already on the node (e.g. numactl-bound); just remember
+    return;
+  }
+  if (!SetCurrentThreadAffinity(node_mask)) {
+    return;
+  }
+  st.graph_hold_node = node;
+  st.graph_hold_applied = true;  // restored later from hipGraphExecDestroy on this thread
+}
+
+// Restore a hold-mode pin. Called from hipGraphExecDestroy on the app's
+// destroying thread; no-op if this thread isn't holding a graph pin (e.g. a
+// different thread destroys the exec, or hold mode was not used).
+void RestoreHeldGraphAffinity() {
+  ThreadAffinityState* st = GetThreadAffinityStatePtr();
+  if (st == nullptr || !st->graph_hold_applied) {
+    return;
+  }
+  SetCurrentThreadAffinity(st->original_affinity_mask);
+  st->graph_hold_applied = false;
+  st->graph_hold_node = static_cast<uint32_t>(-1);
 }
 }  // namespace numa
 

--- a/projects/clr/rocclr/os/os_posix.cpp
+++ b/projects/clr/rocclr/os/os_posix.cpp
@@ -1305,30 +1305,32 @@ static const std::vector<uint64_t>& CachedNodeCpuMask(uint32_t node) {
 // ================================================================================================
 // Scope-mode graph pin (AMD_GRAPH_CPU_AFFINITY): pin the calling thread to `node`
 // for one graph launch.
-//   - captures the thread's original mask once (cached in TLS), then trusts it;
-//   - respects an app/launcher/cpuset-set mask (checked once, then remembered);
-//   - does nothing when the thread is already on the node (e.g. numactl-bound);
+//   - re-reads the caller's current mask each launch and captures it as the mask
+//     to restore, so an app that re-pins between launches is never clobbered;
+//   - respects an app/launcher/cpuset-set restricted mask (skips pinning);
 //   - the node CPU mask is read from sysfs once per node and cached globally, so
-//     the steady-state cost is one sched_setaffinity here + one in
-//     RestoreGraphAffinity, with no per-launch reads.
+//     the only per-launch cost is sched_getaffinity + sched_setaffinity here and
+//     one sched_setaffinity in RestoreGraphAffinity (no per-launch sysfs).
 // Returns true iff a pin was applied (caller must call RestoreGraphAffinity).
 bool ApplyGraphAffinity(uint32_t node) {
   ThreadAffinityState& st = GetThreadAffinityState();
   if (st.graph_app_owned) {
     return false;
   }
-  if (!st.original_affinity_mask_valid) {
-    if (!GetCurrentThreadAffinity(&st.original_affinity_mask)) {
-      return false;
-    }
-    if (!IsUnrestrictedAffinity(st.original_affinity_mask)) {
-      st.graph_app_owned = true;  // respect app/launcher/cpuset mask; never pin
-      return false;
-    }
-    st.original_affinity_mask_valid = true;
+  std::vector<uint64_t> current_affinity;
+  if (!GetCurrentThreadAffinity(&current_affinity)) {
+    return false;
   }
+  if (!IsUnrestrictedAffinity(current_affinity)) {
+    st.graph_app_owned = true;  // respect app/launcher/cpuset mask; never pin
+    return false;
+  }
+  // Capture the caller's current mask for this launch, so restores don't clobber
+  // affinity changes made by the application between graph launches.
+  st.original_affinity_mask = current_affinity;
+  st.original_affinity_mask_valid = true;
   const std::vector<uint64_t>& node_mask = CachedNodeCpuMask(node);
-  if (node_mask.empty() || IsSameAffinity(st.original_affinity_mask, node_mask)) {
+  if (node_mask.empty() || IsSameAffinity(current_affinity, node_mask)) {
     return false;  // unknown node, or already on the node -> nothing to do
   }
   if (!SetCurrentThreadAffinity(node_mask)) {
@@ -1344,7 +1346,7 @@ void RestoreGraphAffinity() {
     return;
   }
   SetCurrentThreadAffinity(st->original_affinity_mask);
-  st->graph_applied = false;  // keep original_affinity_mask cached for next launch
+  st->graph_applied = false;  // next launch re-reads and re-captures the original
 }
 
 // ================================================================================================
@@ -1392,6 +1394,16 @@ void HoldGraphAffinity(uint32_t node) {
 void RestoreHeldGraphAffinity() {
   ThreadAffinityState* st = GetThreadAffinityStatePtr();
   if (st == nullptr || !st->graph_hold_applied) {
+    return;
+  }
+  // If the application changed this thread's affinity after ROCclr pinned it, do
+  // not override the application's choice during restore.
+  std::vector<uint64_t> current_affinity;
+  const std::vector<uint64_t>& held_mask = CachedNodeCpuMask(st->graph_hold_node);
+  if (!held_mask.empty() && GetCurrentThreadAffinity(&current_affinity) &&
+      !IsSameAffinity(current_affinity, held_mask)) {
+    st->graph_hold_applied = false;
+    st->graph_hold_node = static_cast<uint32_t>(-1);
     return;
   }
   SetCurrentThreadAffinity(st->original_affinity_mask);

--- a/projects/clr/rocclr/os/os_win32.cpp
+++ b/projects/clr/rocclr/os/os_win32.cpp
@@ -842,6 +842,18 @@ bool resetThreadAffinity() {
   return false;
 }
 
+// ================================================================================================
+// AMD_GRAPH_CPU_AFFINITY is a no-op on Windows for now.
+bool ApplyGraphAffinity(uint32_t /*node*/) {
+  return false;
+}
+
+void RestoreGraphAffinity() {}
+
+void HoldGraphAffinity(uint32_t /*node*/) {}
+
+void RestoreHeldGraphAffinity() {}
+
 }  // namespace numa
 
 }  // namespace amd

--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -211,9 +211,9 @@ release(bool, AMD_GRAPH_CPU_AFFINITY, false,                                  \
         "Scope GPU-local NUMA CPU affinity to each hipGraph launch (set on "  \
         "entry, restored on return) instead of the process-wide AMD_CPU_AFFINITY pin") \
 release(bool, AMD_GRAPH_CPU_AFFINITY_HOLD, false,                             \
-        "AMD_GRAPH_CPU_AFFINITY mode: 0 = scope per launch (pin on entry, "   \
-        "restore on exit); 1 = hold (pin once, re-pin on node change, restore " \
-        "at hipGraphExecDestroy)")                                            \
+        "AMD_GRAPH_CPU_AFFINITY_HOLD: 0 = scope affinity per graph launch "   \
+        "(pin on entry, restore on exit); 1 = hold the pin across launches "  \
+        "(re-pin on node change, restore at hipGraphExecDestroy)")            \
 release(bool, ROC_USE_FGS_KERNARG, true,                                      \
         "Use fine grain kernel args segment for supported asics")             \
 release(uint, ROC_P2P_SDMA_SIZE, 1024,                                        \

--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -210,6 +210,10 @@ release(bool, AMD_CPU_AFFINITY, false,                                         \
 release(bool, AMD_GRAPH_CPU_AFFINITY, false,                                  \
         "Scope GPU-local NUMA CPU affinity to each hipGraph launch (set on "  \
         "entry, restored on return) instead of the process-wide AMD_CPU_AFFINITY pin") \
+release(bool, AMD_GRAPH_CPU_AFFINITY_HOLD, false,                             \
+        "AMD_GRAPH_CPU_AFFINITY mode: 0 = scope per launch (pin on entry, "   \
+        "restore on exit); 1 = hold (pin once, re-pin on node change, restore " \
+        "at hipGraphExecDestroy)")                                            \
 release(bool, ROC_USE_FGS_KERNARG, true,                                      \
         "Use fine grain kernel args segment for supported asics")             \
 release(uint, ROC_P2P_SDMA_SIZE, 1024,                                        \

--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -207,6 +207,9 @@ release(size_t, PAL_PREPINNED_MEMORY_SIZE, 64,                                \
         "Size in KBytes of prepinned memory")                                 \
 release(bool, AMD_CPU_AFFINITY, false,                                         \
         "Prefer GPU-local NUMA CPU affinity when the application has not set a CPU mask") \
+release(bool, AMD_GRAPH_CPU_AFFINITY, false,                                  \
+        "Scope GPU-local NUMA CPU affinity to each hipGraph launch (set on "  \
+        "entry, restored on return) instead of the process-wide AMD_CPU_AFFINITY pin") \
 release(bool, ROC_USE_FGS_KERNARG, true,                                      \
         "Use fine grain kernel args segment for supported asics")             \
 release(uint, ROC_P2P_SDMA_SIZE, 1024,                                        \


### PR DESCRIPTION
## Motivation
The GPU-local CPU-affinity pin (AMD_CPU_AFFINITY) is applied on first HIP use and held from init until teardown. Since CPU affinity is inherited across fork() and survives execve(), that process-wide pin leaks into child processes: a launcher that pins its main thread near GPU0 and then spawns per-rank workers via numactl leaves every child confined to that NUMA node, so a rank targeting a different node fails to bind and aborts (e.g. DeepSpeed --bind_cores_to_rank).
This adds an opt-in way to confine the GPU-local pin to hipGraph launches instead of holding it process-wide — keeping the dispatch-locality benefit without a pin that escapes into forked children.

## Technical Details
New flags (rocclr/utils/flags.hpp):
  - AMD_GRAPH_CPU_AFFINITY (default off): pin the launching thread to the launch device's GPU-local NUMA node around hipGraph launches, instead of the process-wide AMD_CPU_AFFINITY pin. Engages only when AMD_CPU_AFFINITY is off (mutually exclusive).
  - AMD_GRAPH_CPU_AFFINITY_HOLD (default off): selects the restore boundary:
    - 0 (scope, default): pin on each GraphExec::Run, restore the original mask on return (RAII). The mask is original between launches, so it never leaks into a fork that happens between launches.
    - 1 (hold): pin once, re-pin only when the launch device's node changes, restore once from hipGraphExecDestroy (on the app's destroying thread). Lower per-launch cost; the pin is held between launches.

  Implementation:
  - Pins to the launch stream's device node (correct for graphs launched on a different GPU than instantiated).
  - Respects an application/launcher/cpuset-set mask — never overrides it.
  - Caches the thread's original mask (TLS) and the node→CPU mask (global, one sysfs read per node), so steady-state cost is one sched_setaffinity to pin + one to restore, no per-launch reads. Already-on-node (e.g. numactl-bound) is a no-op.
  - Reuses the existing numa affinity machinery; Windows is a no-op.

## JIRA ID
ROCM-25138

## Test Plan

DeepSpeed test
GraphBench

## Test Result

DeepSpeed test pass
GraphBench shows perf gain for --sync --sweep.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
