### PR TITLE
[rocprofiler-compute] Add debug logging to test_L1_cache_counters

### DIFF
--- a/projects/rocprofiler-compute/CMakeLists.txt
+++ b/projects/rocprofiler-compute/CMakeLists.txt
@@ -477,7 +477,7 @@ add_test(
 add_test(
     NAME test_L1_cache_counters
     COMMAND
-        ${PYTHON_TEST_COMMAND} -m pytest ${STANDALONEBINARY_TEST_OPTION} -m L1_cache
+        ${PYTHON_TEST_COMMAND} -m pytest ${STANDALONEBINARY_TEST_OPTION} -s -m L1_cache
         --junitxml=tests/test_L1_cache_counters.xml ${COV_OPTION}
         tests/test_TCP_counters.py ${WORKING_DIR_OPTION}
 )

--- a/projects/rocprofiler-compute/tests/test_TCP_counters.py
+++ b/projects/rocprofiler-compute/tests/test_TCP_counters.py
@@ -73,8 +73,26 @@ def test_L1_cache_counters(
         ])
         assert return_code == 0
 
+        # DEBUG: dump merged pmc_perf.csv (created by the analyze phase)
+        pmc_perf_path = Path(workload_dir) / "pmc_perf.csv"
+        print(f"\n===== DEBUG pmc_perf.csv [{app_name}] {pmc_perf_path} =====")
+        with pd.option_context(
+            "display.max_rows", None, "display.max_columns", None, "display.width", None
+        ):
+            print(pd.read_csv(pmc_perf_path))
+        print(f"===== END pmc_perf.csv [{app_name}] =====\n")
+
         # 3. save results in local
         csv_path = workload_dir_output + "/workload_metric.csv"
+
+        # DEBUG: dump workload_metric.csv from the analysis phase
+        print(f"\n===== DEBUG workload_metric.csv [{app_name}] {csv_path} =====")
+        with pd.option_context(
+            "display.max_rows", None, "display.max_columns", None, "display.width", None
+        ):
+            print(pd.read_csv(csv_path))
+        print(f"===== END workload_metric.csv [{app_name}] =====\n")
+
         data = load_metrics(csv_path)
 
         for metric in metrics:


### PR DESCRIPTION
## Motivation

The L1 cache counter assertions in `test_L1_cache_counters` are failing. Add debug dumps of the intermediate CSVs so the actual values are visible in CI logs and we can diagnose the failure.

## Technical Details

- `tests/test_TCP_counters.py`: dump the full merged `pmc_perf.csv` (analyze output) and `workload_metric.csv` per app (`vseq`/`vrand`), with pandas truncation disabled.
- `CMakeLists.txt`: run the `L1_cache` ctest with `pytest -s` so the dumps reach the CI logs.

## JIRA ID

AIPROFCOMP-641

## Test Plan

- Run the `test_L1_cache_counters` CI job on an MI300 machine and inspect the dumped `pmc_perf.csv` and `workload_metric.csv`.

## Test Result

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.