### PR TITLE
[rocprofiler-compute] Disable test_L1_cache_counters in CI

### DIFF
--- a/projects/rocprofiler-compute/tests/test_categories.yaml
+++ b/projects/rocprofiler-compute/tests/test_categories.yaml
@@ -15,7 +15,6 @@ test_categories:
       - test_analysis_db
       - test_torch_trace_analysis
       - test_torch_trace_coverage
-      - test_L1_cache_counters
       - test_data_imputation
       - test_roofline_calc_ai_analyze
       - test_num_xcds_spec_class
@@ -31,6 +30,7 @@ test_categories:
     exclude:
       - test_profile_live_attach_detach
       - test_metric_validation
+      - test_L1_cache_counters
     labels:
       - "quick"
       - "pre-commit"
@@ -62,7 +62,6 @@ test_categories:
       - test_num_xcds_spec_class
       - test_mi_gpu_spec
       - test_utils
-      - test_L1_cache_counters
       - test_roofline_calc_ai_analyze
       - test_torch_trace_analysis
       - test_torch_trace_coverage
@@ -79,6 +78,7 @@ test_categories:
     exclude:
       - test_profile_live_attach_detach
       - test_metric_validation
+      - test_L1_cache_counters
     labels:
       - "standard"
       - "pr"
@@ -109,7 +109,6 @@ test_categories:
       - test_num_xcds_spec_class
       - test_mi_gpu_spec
       - test_utils
-      - test_L1_cache_counters
       - test_roofline_calc_ai_analyze
       - test_torch_trace_analysis
       - test_torch_trace_coverage
@@ -126,6 +125,7 @@ test_categories:
     exclude:
       - test_profile_live_attach_detach
       - test_metric_validation
+      - test_L1_cache_counters
     labels:
       - "comprehensive"
       - "nightly"
@@ -156,7 +156,6 @@ test_categories:
       - test_num_xcds_spec_class
       - test_mi_gpu_spec
       - test_utils
-      - test_L1_cache_counters
       - test_roofline_calc_ai_analyze
       - test_torch_trace_analysis
       - test_torch_trace_coverage
@@ -173,6 +172,7 @@ test_categories:
     exclude:
       - test_profile_live_attach_detach
       - test_metric_validation
+      - test_L1_cache_counters
     labels:
       - "full"
       - "weekly"


### PR DESCRIPTION
## Motivation

`test_L1_cache_counters` is failing intermittently on the CI machine used by TheRock. The failures come from heavy profiling load during parallel testing on that machine, which perturbs the cache hit rate and request-count counters the test asserts on, so the comparison between sequential and random access no longer holds reliably.

This is a band-aid fix to unblock CI by disabling the test across all category sets while we identify and solve the root cause.

## Technical Details

- `tests/test_categories.yaml`: move `test_L1_cache_counters` out of `test_patterns` and into the `exclude` list for all sets (quick / standard / comprehensive / full), mirroring how `test_metric_validation` is handled.

## JIRA ID

## Test Plan

- Confirm CI category runs no longer schedule `test_L1_cache_counters`.

## Test Result

Pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.