### PR TITLE
[rocprofiler-sdk] add output file suffixing when attaching to same the process multiple times

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -2275,6 +2275,37 @@ reset_output_thread(std::optional<std::thread>& thread_ptr)
     }
 }
 
+// Checks for a file in /tmp to see if this is a re-attach to a process that was already profiled,
+// and if so suffixes the output file name with the session number so that previous output files are
+// not overwritten.
+void
+assign_attach_output_session_suffix()
+{
+    const auto target_pid =
+        static_cast<pid_t>(common::get_env("ROCPROF_ATTACH_PID", static_cast<long>(getpid())));
+    const auto session_path = fmt::format("/tmp/rocprofv3_attach_{}.session", target_pid);
+
+    auto session = uint64_t{0};
+    if(fs::exists(session_path))
+    {
+        std::ifstream ifs{session_path};
+        if(ifs >> session) ++session;
+    }
+
+    {
+        std::ofstream ofs{session_path, std::ios::trunc};
+        ofs << session;
+    }
+
+    if(session > 0)
+    {
+        auto& cfg       = tool::get_config();
+        cfg.output_file = fmt::format("{}_{}", cfg.output_file, session);
+        ROCP_INFO << "Reattach #" << session << " for PID " << target_pid << ". Base file name is "
+                  << cfg.output_file;
+    }
+}
+
 int
 tool_attach(rocprofiler_client_detach_t /*detach_func*/,
             rocprofiler_context_id_t* context_ids,
@@ -2304,6 +2335,8 @@ tool_attach(rocprofiler_client_detach_t /*detach_func*/,
            "support changing the set of enabled tracing services between initial load and attach. "
            "After the initial attachment, it is recommended to just use `rocprofv3 --pid=<pid> [-o "
            "<output_file> -d <output_directory> ...]` to attach to a new process.";
+
+    assign_attach_output_session_suffix();
 
     pid_t target_pid = getppid();  // The target process we're attaching to
     pid_t tool_pid   = getpid();   // The rocprofv3 tool process

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -2301,8 +2301,7 @@ attach_session_file_path(pid_t target_pid)
     return fmt::format("/tmp/rocprofv3_attach_{}.session", target_pid);
 }
 
-// Reject symlinks and non-regular files before fstream open (best-effort; fstream has no
-// O_NOFOLLOW).
+// Reject symlinks and non-regular files before fstream open
 bool
 is_attach_session_path_safe(const fs::path& path)
 {
@@ -2333,8 +2332,8 @@ set_attach_session_file_permissions(const fs::path& path)
     fs::permissions(path, attach_session_file_perms, fs::perm_options::replace, ec);
     if(ec)
     {
-        ROCP_WARNING << "Failed to set attach session file permissions on " << path << " :: "
-                     << ec.message();
+        ROCP_WARNING << "Failed to set attach session file permissions on " << path
+                     << " :: " << ec.message();
     }
 }
 
@@ -2454,8 +2453,8 @@ tool_attach(rocprofiler_client_detach_t /*detach_func*/,
 
     assign_attach_output_session_suffix();
 
-    pid_t target_pid = get_attach_target_pid(); //The target process we're attaching to
-    pid_t tool_pid   = getpid(); //The rocprofv3 tool process
+    pid_t target_pid = get_attach_target_pid();  // The target process we're attaching to
+    pid_t tool_pid   = getpid();                 // The rocprofv3 tool process
     ROCP_INFO << "Attach mode: Setting process_id to target PID " << target_pid
               << " (tool PID: " << tool_pid << ")";
     tool_metadata->set_process_id(target_pid, 0);  // Set target as main process

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -108,9 +108,7 @@
 #include <vector>
 
 #include <dlfcn.h>
-#include <fcntl.h>
 #include <sys/mman.h>
-#include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 
@@ -2280,13 +2278,14 @@ reset_output_thread(std::optional<std::thread>& thread_ptr)
 
 namespace
 {
-// Session counter file permissions (0644).
-constexpr mode_t attach_session_file_mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
+constexpr auto attach_session_file_perms =
+    fs::perms::owner_read | fs::perms::owner_write | fs::perms::group_read | fs::perms::others_read;
 
-// Same PID as /tmp/rocprofv3_attach_<pid>.pkl: ROCPROF_ATTACH_PID when set by rocprofv3 /
-// rocprof-attach, otherwise the attach target PID used for metadata in tool_attach (ppid).
+// Attach target PID shared by session bookkeeping and tool_attach metadata.
+// Matches /tmp/rocprofv3_attach_<pid>.pkl: ROCPROF_ATTACH_PID when set by rocprofv3 /
+// rocprof-attach, otherwise getppid().
 pid_t
-get_attach_session_target_pid()
+get_attach_target_pid()
 {
     if(const auto env_pid = common::get_env("ROCPROF_ATTACH_PID", static_cast<long>(-1));
        env_pid > 0)
@@ -2296,59 +2295,107 @@ get_attach_session_target_pid()
     return getppid();
 }
 
-std::string
+fs::path
 attach_session_file_path(pid_t target_pid)
 {
     return fmt::format("/tmp/rocprofv3_attach_{}.session", target_pid);
 }
 
-int
-open_attach_session_file(const std::string& path, int flags)
+// Reject symlinks and non-regular files before fstream open (best-effort; fstream has no
+// O_NOFOLLOW).
+bool
+is_attach_session_path_safe(const fs::path& path)
 {
-    return ::open(path.c_str(), flags | O_NOFOLLOW | O_CLOEXEC, attach_session_file_mode);
+    std::error_code ec;
+    if(!fs::exists(path, ec)) return true;
+    if(ec)
+    {
+        ROCP_WARNING << "Failed to stat attach session file " << path << " :: " << ec.message();
+        return false;
+    }
+    if(fs::is_symlink(path, ec))
+    {
+        ROCP_WARNING << "Refusing attach session path (symlink): " << path;
+        return false;
+    }
+    if(!fs::is_regular_file(path, ec))
+    {
+        ROCP_WARNING << "Refusing attach session path (not a regular file): " << path;
+        return false;
+    }
+    return true;
+}
+
+void
+set_attach_session_file_permissions(const fs::path& path)
+{
+    std::error_code ec;
+    fs::permissions(path, attach_session_file_perms, fs::perm_options::replace, ec);
+    if(ec)
+    {
+        ROCP_WARNING << "Failed to set attach session file permissions on " << path << " :: "
+                     << ec.message();
+    }
 }
 
 bool
-read_attach_session(const std::string& path, uint64_t& session_out)
+read_attach_session(const fs::path& path, uint64_t& session_out)
 {
-    const int fd = open_attach_session_file(path, O_RDONLY);
-    if(fd < 0) return false;
+    constexpr auto reattach_overwrite_warning =
+        "If this is a re-attach, output may overwrite a previous session";
 
-    char       buf[32] = {};
-    const auto nread   = ::read(fd, buf, sizeof(buf) - 1);
-    ::close(fd);
-    if(nread <= 0) return false;
-
-    try
+    if(!is_attach_session_path_safe(path))
     {
-        session_out = std::stoull(std::string{buf, static_cast<size_t>(nread)});
-        return true;
-    } catch(...)
-    {
+        ROCP_WARNING << reattach_overwrite_warning;
         return false;
     }
+    if(!fs::exists(path)) return false;
+
+    std::ifstream ifs{path};
+    if(!ifs)
+    {
+        ROCP_WARNING << "Failed to open attach session file for read: " << path << ". "
+                     << reattach_overwrite_warning;
+        return false;
+    }
+
+    uint64_t session = 0;
+    if(!(ifs >> session))
+    {
+        ROCP_WARNING << "Failed to parse attach session file: " << path << ". "
+                     << reattach_overwrite_warning;
+        return false;
+    }
+
+    session_out = session;
+    return true;
 }
 
 bool
-write_attach_session(const std::string& path, uint64_t session)
+write_attach_session(const fs::path& path, uint64_t session)
 {
-    const int fd = open_attach_session_file(path, O_WRONLY | O_CREAT | O_TRUNC);
-    if(fd < 0)
+    if(!is_attach_session_path_safe(path)) return false;
+
+    std::ofstream ofs{path, std::ios::trunc};
+    if(!ofs)
     {
-        ROCP_WARNING << "Failed to open attach session file (will not suffix output): " << path
-                     << " :: " << strerror(errno);
+        ROCP_WARNING << "Failed to open attach session file for write (reattaches may "
+                        "overwrite previous rocprof output): "
+                     << path;
         return false;
     }
 
-    const auto data     = fmt::format("{}", session);
-    const auto nwritten = ::write(fd, data.data(), data.size());
-    const auto ok       = (::close(fd) == 0) && (nwritten == static_cast<ssize_t>(data.size()));
-    if(!ok)
+    ofs << session;
+    if(!ofs.good())
     {
-        ROCP_WARNING << "Failed to write attach session file (will not suffix output): " << path
-                     << " :: " << strerror(errno);
+        ROCP_WARNING << "Failed to write attach session file (reattaches may "
+                        "overwrite previous rocprof output): "
+                     << path;
+        return false;
     }
-    return ok;
+
+    set_attach_session_file_permissions(path);
+    return true;
 }
 }  // namespace
 
@@ -2358,7 +2405,7 @@ write_attach_session(const std::string& path, uint64_t session)
 void
 assign_attach_output_session_suffix()
 {
-    const auto target_pid   = get_attach_session_target_pid();
+    const auto target_pid   = get_attach_target_pid();
     const auto session_path = attach_session_file_path(target_pid);
 
     auto session = uint64_t{0};
@@ -2407,8 +2454,8 @@ tool_attach(rocprofiler_client_detach_t /*detach_func*/,
 
     assign_attach_output_session_suffix();
 
-    pid_t target_pid = getppid();  // The target process we're attaching to
-    pid_t tool_pid   = getpid();   // The rocprofv3 tool process
+    pid_t target_pid = get_attach_target_pid(); //The target process we're attaching to
+    pid_t tool_pid   = getpid(); //The rocprofv3 tool process
     ROCP_INFO << "Attach mode: Setting process_id to target PID " << target_pid
               << " (tool PID: " << tool_pid << ")";
     tool_metadata->set_process_id(target_pid, 0);  // Set target as main process

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -2439,11 +2439,12 @@ tool_attach(rocprofiler_client_detach_t /*detach_func*/,
 
     assign_attach_output_session_suffix();
 
-    pid_t instrumented_pid = getpid();   // The target process we're attaching to
-    pid_t parent_pid       = getppid();  // The rocprofv3 tool process
-    ROCP_INFO << "Attach mode: Setting process_id to target PID " << instrumented_pid
-              << " (tool PID: " << parent_pid << ")";
-    tool_metadata->set_process_id(instrumented_pid, parent_pid);  // Set target as main process
+    pid_t instrumented_pid = getpid();   // The process being profiled
+    pid_t parent_pid       = getppid();  // Its parent process
+    ROCP_INFO << "Attach mode: Setting process_id to instrumented PID " << instrumented_pid
+              << " (parent PID: " << parent_pid << ")";
+    // NOLINTNEXTLINE(readability-suspicious-call-argument): parent_pid is correctly the _ppid arg
+    tool_metadata->set_process_id(instrumented_pid, parent_pid);
 
     for(uint64_t i = 0; i < context_ids_length; ++i)
     {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -2281,20 +2281,6 @@ namespace
 constexpr auto attach_session_file_perms =
     fs::perms::owner_read | fs::perms::owner_write | fs::perms::group_read | fs::perms::others_read;
 
-// Attach target PID shared by session bookkeeping and tool_attach metadata.
-// Matches /tmp/rocprofv3_attach_<pid>.pkl: ROCPROF_ATTACH_PID when set by rocprofv3 /
-// rocprof-attach, otherwise getppid().
-pid_t
-get_attach_target_pid()
-{
-    if(const auto env_pid = common::get_env("ROCPROF_ATTACH_PID", static_cast<long>(-1));
-       env_pid > 0)
-    {
-        return static_cast<pid_t>(env_pid);
-    }
-    return getppid();
-}
-
 fs::path
 attach_session_file_path(pid_t target_pid)
 {
@@ -2404,8 +2390,8 @@ write_attach_session(const fs::path& path, uint64_t session)
 void
 assign_attach_output_session_suffix()
 {
-    const auto instrumented_pid    = getpid();
-    const auto session_path = attach_session_file_path(instrumented_pid);
+    const auto instrumented_pid = getpid();
+    const auto session_path     = attach_session_file_path(instrumented_pid);
 
     auto session = uint64_t{0};
     if(read_attach_session(session_path, session)) ++session;
@@ -2416,8 +2402,8 @@ assign_attach_output_session_suffix()
     {
         auto& cfg       = tool::get_config();
         cfg.output_file = fmt::format("{}_{}", cfg.output_file, session);
-        ROCP_INFO << "Reattach #" << session << " for PID " << instrumented_pid << ". Base file name is "
-                  << cfg.output_file;
+        ROCP_INFO << "Reattach #" << session << " for PID " << instrumented_pid
+                  << ". Base file name is " << cfg.output_file;
     }
 }
 
@@ -2453,8 +2439,8 @@ tool_attach(rocprofiler_client_detach_t /*detach_func*/,
 
     assign_attach_output_session_suffix();
 
-    pid_t instrumented_pid  = getpid();  // The target process we're attaching to
-    pid_t parent_pid   = getppid();                 // The rocprofv3 tool process
+    pid_t instrumented_pid = getpid();   // The target process we're attaching to
+    pid_t parent_pid       = getppid();  // The rocprofv3 tool process
     ROCP_INFO << "Attach mode: Setting process_id to target PID " << instrumented_pid
               << " (tool PID: " << parent_pid << ")";
     tool_metadata->set_process_id(instrumented_pid, parent_pid);  // Set target as main process

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -87,6 +87,7 @@
 #include <unistd.h>
 #include <algorithm>
 #include <cassert>
+#include <cerrno>
 #include <chrono>
 #include <csignal>
 #include <cstdint>
@@ -107,7 +108,9 @@
 #include <vector>
 
 #include <dlfcn.h>
+#include <fcntl.h>
 #include <sys/mman.h>
+#include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 
@@ -2275,27 +2278,93 @@ reset_output_thread(std::optional<std::thread>& thread_ptr)
     }
 }
 
+namespace
+{
+// Session counter file permissions (0644).
+constexpr mode_t attach_session_file_mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
+
+// Same PID as /tmp/rocprofv3_attach_<pid>.pkl: ROCPROF_ATTACH_PID when set by rocprofv3 /
+// rocprof-attach, otherwise the attach target PID used for metadata in tool_attach (ppid).
+pid_t
+get_attach_session_target_pid()
+{
+    if(const auto env_pid = common::get_env("ROCPROF_ATTACH_PID", static_cast<long>(-1));
+       env_pid > 0)
+    {
+        return static_cast<pid_t>(env_pid);
+    }
+    return getppid();
+}
+
+std::string
+attach_session_file_path(pid_t target_pid)
+{
+    return fmt::format("/tmp/rocprofv3_attach_{}.session", target_pid);
+}
+
+int
+open_attach_session_file(const std::string& path, int flags)
+{
+    return ::open(path.c_str(), flags | O_NOFOLLOW | O_CLOEXEC, attach_session_file_mode);
+}
+
+bool
+read_attach_session(const std::string& path, uint64_t& session_out)
+{
+    const int fd = open_attach_session_file(path, O_RDONLY);
+    if(fd < 0) return false;
+
+    char       buf[32] = {};
+    const auto nread   = ::read(fd, buf, sizeof(buf) - 1);
+    ::close(fd);
+    if(nread <= 0) return false;
+
+    try
+    {
+        session_out = std::stoull(std::string{buf, static_cast<size_t>(nread)});
+        return true;
+    } catch(...)
+    {
+        return false;
+    }
+}
+
+bool
+write_attach_session(const std::string& path, uint64_t session)
+{
+    const int fd = open_attach_session_file(path, O_WRONLY | O_CREAT | O_TRUNC);
+    if(fd < 0)
+    {
+        ROCP_WARNING << "Failed to open attach session file (will not suffix output): " << path
+                     << " :: " << strerror(errno);
+        return false;
+    }
+
+    const auto data     = fmt::format("{}", session);
+    const auto nwritten = ::write(fd, data.data(), data.size());
+    const auto ok       = (::close(fd) == 0) && (nwritten == static_cast<ssize_t>(data.size()));
+    if(!ok)
+    {
+        ROCP_WARNING << "Failed to write attach session file (will not suffix output): " << path
+                     << " :: " << strerror(errno);
+    }
+    return ok;
+}
+}  // namespace
+
 // Checks for a file in /tmp to see if this is a re-attach to a process that was already profiled,
 // and if so suffixes the output file name with the session number so that previous output files are
 // not overwritten.
 void
 assign_attach_output_session_suffix()
 {
-    const auto target_pid =
-        static_cast<pid_t>(common::get_env("ROCPROF_ATTACH_PID", static_cast<long>(getpid())));
-    const auto session_path = fmt::format("/tmp/rocprofv3_attach_{}.session", target_pid);
+    const auto target_pid   = get_attach_session_target_pid();
+    const auto session_path = attach_session_file_path(target_pid);
 
     auto session = uint64_t{0};
-    if(fs::exists(session_path))
-    {
-        std::ifstream ifs{session_path};
-        if(ifs >> session) ++session;
-    }
+    if(read_attach_session(session_path, session)) ++session;
 
-    {
-        std::ofstream ofs{session_path, std::ios::trunc};
-        ofs << session;
-    }
+    if(!write_attach_session(session_path, session)) return;
 
     if(session > 0)
     {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -2404,7 +2404,7 @@ write_attach_session(const fs::path& path, uint64_t session)
 void
 assign_attach_output_session_suffix()
 {
-    const auto target_pid   = get_attach_target_pid();
+    const auto target_pid   = getppid();
     const auto session_path = attach_session_file_path(target_pid);
 
     auto session = uint64_t{0};

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -2404,8 +2404,8 @@ write_attach_session(const fs::path& path, uint64_t session)
 void
 assign_attach_output_session_suffix()
 {
-    const auto target_pid   = getppid();
-    const auto session_path = attach_session_file_path(target_pid);
+    const auto instrumented_pid    = getpid();
+    const auto session_path = attach_session_file_path(instrumented_pid);
 
     auto session = uint64_t{0};
     if(read_attach_session(session_path, session)) ++session;
@@ -2416,7 +2416,7 @@ assign_attach_output_session_suffix()
     {
         auto& cfg       = tool::get_config();
         cfg.output_file = fmt::format("{}_{}", cfg.output_file, session);
-        ROCP_INFO << "Reattach #" << session << " for PID " << target_pid << ". Base file name is "
+        ROCP_INFO << "Reattach #" << session << " for PID " << instrumented_pid << ". Base file name is "
                   << cfg.output_file;
     }
 }
@@ -2453,11 +2453,11 @@ tool_attach(rocprofiler_client_detach_t /*detach_func*/,
 
     assign_attach_output_session_suffix();
 
-    pid_t target_pid = get_attach_target_pid();  // The target process we're attaching to
-    pid_t tool_pid   = getpid();                 // The rocprofv3 tool process
-    ROCP_INFO << "Attach mode: Setting process_id to target PID " << target_pid
-              << " (tool PID: " << tool_pid << ")";
-    tool_metadata->set_process_id(target_pid, 0);  // Set target as main process
+    pid_t instrumented_pid  = getpid();  // The target process we're attaching to
+    pid_t parent_pid   = getppid();                 // The rocprofv3 tool process
+    ROCP_INFO << "Attach mode: Setting process_id to target PID " << instrumented_pid
+              << " (tool PID: " << parent_pid << ")";
+    tool_metadata->set_process_id(instrumented_pid, parent_pid);  // Set target as main process
 
     for(uint64_t i = 0; i < context_ids_length; ++i)
     {

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/run_attachment_tree_test.sh
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/run_attachment_tree_test.sh
@@ -164,9 +164,7 @@ fi
 # Locate the child process's output files. With default naming the files are
 # under a subdirectory named after the hostname and contain the PID in the
 # filename, e.g. attachment-output/<hostname>/<child_pid>_results.json
-# Reattach session appears after the PID in the basename, e.g. <pid>_1_results.json,
-# when another process in the same attach wave already advanced the session counter.
-CHILD_JSON=$(find ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/ \( -name "${CHILD_PID}_results.json" -o -name "${CHILD_PID}_*_results.json" \) | head -1)
+CHILD_JSON=$(find ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/ -name "${CHILD_PID}_results.json" | head -1)
 if [ -z "$CHILD_JSON" ]; then
     echo "Error: Could not find child (PID ${CHILD_PID}) JSON output in ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/"
     exit 1
@@ -179,8 +177,7 @@ CHILD_DIR=$(dirname "$CHILD_JSON")
 # reference them without knowing the hostname or PID at configure time.
 for src in "${CHILD_DIR}/${CHILD_PID}"_*.json "${CHILD_DIR}/${CHILD_PID}"_*.db; do
     [ -f "$src" ] || continue
-    dst_name=$(basename "$src" | sed "s/^${CHILD_PID}_/${OUTPUT_FILENAME}_/" |
-        sed -E "s/^${OUTPUT_FILENAME}_[0-9]+_/${OUTPUT_FILENAME}_/")
+    dst_name=$(basename "$src" | sed "s/^${CHILD_PID}_/${OUTPUT_FILENAME}_/")
     cp "$src" "${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${dst_name}"
     echo "Copied $(basename $src) -> ${dst_name}"
 done

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/run_attachment_tree_test.sh
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/run_attachment_tree_test.sh
@@ -164,7 +164,9 @@ fi
 # Locate the child process's output files. With default naming the files are
 # under a subdirectory named after the hostname and contain the PID in the
 # filename, e.g. attachment-output/<hostname>/<child_pid>_results.json
-CHILD_JSON=$(find ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/ -name "${CHILD_PID}_results.json" | head -1)
+# Reattach session suffixes (_1, _2, ...) also apply when another process in the
+# same attach wave (e.g. parent) already advanced the shared session counter.
+CHILD_JSON=$(find ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/ \( -name "${CHILD_PID}_results.json" -o -name "${CHILD_PID}_results_*.json" \) | head -1)
 if [ -z "$CHILD_JSON" ]; then
     echo "Error: Could not find child (PID ${CHILD_PID}) JSON output in ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/"
     exit 1
@@ -177,7 +179,7 @@ CHILD_DIR=$(dirname "$CHILD_JSON")
 # reference them without knowing the hostname or PID at configure time.
 for src in "${CHILD_DIR}/${CHILD_PID}"_*.json "${CHILD_DIR}/${CHILD_PID}"_*.db; do
     [ -f "$src" ] || continue
-    dst_name=$(basename "$src" | sed "s/^${CHILD_PID}_/out_/")
+    dst_name=$(basename "$src" | sed "s/^${CHILD_PID}_/out_/" | sed -E 's/_[0-9]+\.(json|db)$/\.\1/')
     cp "$src" "${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${dst_name}"
     echo "Copied $(basename $src) -> ${dst_name}"
 done

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/run_attachment_tree_test.sh
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-tree/run_attachment_tree_test.sh
@@ -164,9 +164,9 @@ fi
 # Locate the child process's output files. With default naming the files are
 # under a subdirectory named after the hostname and contain the PID in the
 # filename, e.g. attachment-output/<hostname>/<child_pid>_results.json
-# Reattach session suffixes (_1, _2, ...) also apply when another process in the
-# same attach wave (e.g. parent) already advanced the shared session counter.
-CHILD_JSON=$(find ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/ \( -name "${CHILD_PID}_results.json" -o -name "${CHILD_PID}_results_*.json" \) | head -1)
+# Reattach session appears after the PID in the basename, e.g. <pid>_1_results.json,
+# when another process in the same attach wave already advanced the session counter.
+CHILD_JSON=$(find ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/ \( -name "${CHILD_PID}_results.json" -o -name "${CHILD_PID}_*_results.json" \) | head -1)
 if [ -z "$CHILD_JSON" ]; then
     echo "Error: Could not find child (PID ${CHILD_PID}) JSON output in ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/"
     exit 1
@@ -179,13 +179,14 @@ CHILD_DIR=$(dirname "$CHILD_JSON")
 # reference them without knowing the hostname or PID at configure time.
 for src in "${CHILD_DIR}/${CHILD_PID}"_*.json "${CHILD_DIR}/${CHILD_PID}"_*.db; do
     [ -f "$src" ] || continue
-    dst_name=$(basename "$src" | sed "s/^${CHILD_PID}_/out_/" | sed -E 's/_[0-9]+\.(json|db)$/\.\1/')
+    dst_name=$(basename "$src" | sed "s/^${CHILD_PID}_/${OUTPUT_FILENAME}_/" |
+        sed -E "s/^${OUTPUT_FILENAME}_[0-9]+_/${OUTPUT_FILENAME}_/")
     cp "$src" "${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${dst_name}"
     echo "Copied $(basename $src) -> ${dst_name}"
 done
 
 # Verify the well-known files exist
-for expected_file in "out_results.json" "out_results.db"; do
+for expected_file in "${OUTPUT_FILENAME}_results.json" "${OUTPUT_FILENAME}_results.db"; do
     if [ ! -f "${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${expected_file}" ]; then
         echo "Error: Expected output file ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${expected_file} not found"
         exit 1

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/run_attachment_test_unified.sh
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/run_attachment_test_unified.sh
@@ -199,8 +199,8 @@ fi
 
 # Locate the process's output files. With default naming the files are under a
 # subdirectory named after the hostname and contain the PID in the filename,
-# e.g. attachment-output/<hostname>/<pid>_results.json
-APP_JSON=$(find ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/ -name "${APP_PID}_results.json" | head -1)
+# e.g. attachment-output/<hostname>/<pid>_results_1.json (session suffix on reattach).
+APP_JSON=$(find ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/ \( -name "${APP_PID}_results.json" -o -name "${APP_PID}_results_*.json" \) | head -1)
 if [ -z "$APP_JSON" ]; then
     echo "Error: Could not find app (PID ${APP_PID}) JSON output after second attachment"
     exit 1
@@ -213,7 +213,7 @@ APP_OUTPUT_DIR=$(dirname "$APP_JSON")
 # without knowing the hostname or PID at configure time.
 for src in "${APP_OUTPUT_DIR}/${APP_PID}"_*.json "${APP_OUTPUT_DIR}/${APP_PID}"_*.db; do
     [ -f "$src" ] || continue
-    dst_name=$(basename "$src" | sed "s/^${APP_PID}_/${OUTPUT_FILENAME}_/")
+    dst_name=$(basename "$src" | sed "s/^${APP_PID}_/${OUTPUT_FILENAME}_/" | sed -E 's/_[0-9]+\.(json|db)$/\.\1/')
     cp "$src" "${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${dst_name}"
     echo "Copied $(basename $src) -> ${dst_name}"
 done

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/run_attachment_test_unified.sh
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/run_attachment_test_unified.sh
@@ -198,9 +198,10 @@ else
 fi
 
 # Locate the process's output files. With default naming the files are under a
-# subdirectory named after the hostname and contain the PID in the filename,
-# e.g. attachment-output/<hostname>/<pid>_results_1.json (session suffix on reattach).
-APP_JSON=$(find ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/ \( -name "${APP_PID}_results.json" -o -name "${APP_PID}_results_*.json" \) | head -1)
+# subdirectory named after the hostname. Reattach adds a session segment after the
+# PID in the basename, e.g. <pid>_results.json vs <pid>_1_results.json (not
+# <pid>_results_1.json).
+APP_JSON=$(find ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/ \( -name "${APP_PID}_results.json" -o -name "${APP_PID}_*_results.json" \) | head -1)
 if [ -z "$APP_JSON" ]; then
     echo "Error: Could not find app (PID ${APP_PID}) JSON output after second attachment"
     exit 1
@@ -213,7 +214,8 @@ APP_OUTPUT_DIR=$(dirname "$APP_JSON")
 # without knowing the hostname or PID at configure time.
 for src in "${APP_OUTPUT_DIR}/${APP_PID}"_*.json "${APP_OUTPUT_DIR}/${APP_PID}"_*.db; do
     [ -f "$src" ] || continue
-    dst_name=$(basename "$src" | sed "s/^${APP_PID}_/${OUTPUT_FILENAME}_/" | sed -E 's/_[0-9]+\.(json|db)$/\.\1/')
+    dst_name=$(basename "$src" | sed "s/^${APP_PID}_/${OUTPUT_FILENAME}_/" |
+        sed -E "s/^${OUTPUT_FILENAME}_[0-9]+_/${OUTPUT_FILENAME}_/")
     cp "$src" "${OUTPUT_DIR}/${OUTPUT_SUBDIR}/${dst_name}"
     echo "Copied $(basename $src) -> ${dst_name}"
 done

--- a/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/run_attachment_test_unified.sh
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/attachment/attach-twice/run_attachment_test_unified.sh
@@ -198,9 +198,8 @@ else
 fi
 
 # Locate the process's output files. With default naming the files are under a
-# subdirectory named after the hostname. Reattach adds a session segment after the
-# PID in the basename, e.g. <pid>_results.json vs <pid>_1_results.json (not
-# <pid>_results_1.json).
+# subdirectory named after the hostname. Reattach adds a session ID after the
+# PID in the basename, e.g. <pid>_1_results.json
 APP_JSON=$(find ${OUTPUT_DIR}/${OUTPUT_SUBDIR}/ \( -name "${APP_PID}_results.json" -o -name "${APP_PID}_*_results.json" \) | head -1)
 if [ -z "$APP_JSON" ]; then
     echo "Error: Could not find app (PID ${APP_PID}) JSON output after second attachment"


### PR DESCRIPTION
## Motivation

Multiple attaches to the same pid will output to the same file, overwriting previous attach outputs. This PR adds suffixes to the output file name when reattaching to a pid that has previously been attached to.

## Technical Details

When attaching to a process, a session file in /tmp is checked/written to in order to establish any necessary file name suffix.

## JIRA ID

Addresses AIPROFSDK-848.

## Test Plan

Created a test script that spins up a dummy HIP program and attaches and detaches the profiler twice.

## Test Result

Two log files were created, the first having the original name, and the second suffixed with a session number.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
