### PR TITLE
[clr] Fix leaks related to child graphs

### DIFF
--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -219,7 +219,6 @@ void Graph::ScheduleOneNode(Node start, int stream_id) {
       hipError_t status = child->ScheduleNodes();
       (void)status;
       max_streams_ = std::max(max_streams_, child->max_streams_);
-      cgn->GraphExec::TopologicalOrder();
     }
 
     const auto& edges = cur->GetEdges();

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -1154,6 +1154,20 @@ class ChildGraphNode : public GraphNode, public GraphExec {
     graphCaptureStatus_ = false;
   }
 
+  ~ChildGraphNode() {
+    // Unlike regular nodes (whose commands_ hold non-owning references after
+    // EnqueueCommands transfers ownership to the queue), a child graph node
+    // stores an owning reference to its completion command, acquired via
+    // getLastQueuedCommand(true) in Graph::RunOneNode. Each launch releases the
+    // previous launch's stored command, but the final launch's command is only
+    // released here. Without this the command, its HwEvent ProfilingSignal and
+    // the underlying HSA signal would leak.
+    for (auto command : commands_) {
+      command->release();
+    }
+    commands_.clear();
+  }
+
   // Delete copy-assignment operator to prevent accidental copies causing unexpected behaviors.
   ChildGraphNode& operator=(const ChildGraphNode&) = delete;
 

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -961,6 +961,12 @@ class GraphExec : public amd::ReferenceCountedObject, public Graph {
   }
 
   ~GraphExec() {
+    {
+      std::scoped_lock lock(graphExecSetLock_);
+      // GraphExecSet is normally erased in hipGraphExecDestroy() before release(), but child graph
+      // nodes (which inherit GraphExec) are destroyed via delete and never go through that path.
+      graphExecSet_.erase(this);
+    }
     for (auto& streams : parallel_streams_) {
       for (auto stream : streams.second) {
         if (stream != nullptr) {

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -1155,13 +1155,8 @@ class ChildGraphNode : public GraphNode, public GraphExec {
   }
 
   ~ChildGraphNode() {
-    // Unlike regular nodes (whose commands_ hold non-owning references after
-    // EnqueueCommands transfers ownership to the queue), a child graph node
-    // stores an owning reference to its completion command, acquired via
-    // getLastQueuedCommand(true) in Graph::RunOneNode. Each launch releases the
-    // previous launch's stored command, but the final launch's command is only
-    // released here. Without this the command, its HwEvent ProfilingSignal and
-    // the underlying HSA signal would leak.
+    // A child graph node stores an owning reference to its completion command. Each launch releases
+    // the previous launch's stored command, but the final launch's command is only released here.
     for (auto command : commands_) {
       command->release();
     }


### PR DESCRIPTION
## Motivation

Asan detects leaks when running Unit_hipGraphAddChildGraphNode_CmplxGrph_SchedLogic

## Technical Details

Leak 1 - TopologicalOrder() algorithm is being called multiple times. Once in `child->ScheduleNodes()` and afterwards in `cgn->GraphExec::TopologicalOrder();` which is the same graph. Solution is to delete the second call.

Leak 2 - PR #5687 added an owning pointer to the ChildGraph. This was correctly release whenever the graph was launched. However the last run was never released. The solution was to add a destructor to the ChildGraphNode class.

## JIRA ID

Resolves AIRUNTIME-2288

## Test Plan

Unit_hipGraphAddChildGraphNode_CmplxGrph_SchedLogic passses locally when run with Asan

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
