### PR TITLE
Revert "Add __hipOnError debugger hook for HIP API failures"

### DIFF
--- a/projects/clr/hipamd/src/amdhip.def.in
+++ b/projects/clr/hipamd/src/amdhip.def.in
@@ -207,7 +207,6 @@ hipStreamGetFlags
 hipStreamQuery
 hipStreamSynchronize
 hipStreamWaitEvent
-__hipOnError
 __hipPopCallConfiguration
 __hipPushCallConfiguration
 __hipRegisterFatBinary

--- a/projects/clr/hipamd/src/hip_error.cpp
+++ b/projects/clr/hipamd/src/hip_error.cpp
@@ -8,8 +8,6 @@
 
 #include "hip_internal.hpp"
 
-extern "C" void __hipOnError(const void *err_info) { (void)err_info; }
-
 namespace hip {
 hipError_t hipExtGetLastError() {
   HIP_INIT_API(hipExtGetLastError);

--- a/projects/clr/hipamd/src/hip_event.cpp
+++ b/projects/clr/hipamd/src/hip_event.cpp
@@ -339,7 +339,7 @@ hipError_t hipEventCreateWithFlags(hipEvent_t* event, unsigned flags) {
   HIP_INIT_API(hipEventCreateWithFlags, event, flags);
 
   if (event == nullptr) {
-    HIP_RETURN(hipErrorInvalidValue);
+    return hipErrorInvalidValue;
   }
 
   HIP_RETURN(ihipEventCreateWithFlags(event, flags), *event);
@@ -350,7 +350,7 @@ hipError_t hipEventCreate(hipEvent_t* event) {
   HIP_INIT_API(hipEventCreate, event);
 
   if (event == nullptr) {
-    HIP_RETURN(hipErrorInvalidValue);
+    return hipErrorInvalidValue;
   }
 
   HIP_RETURN(ihipEventCreateWithFlags(event, 0), *event);
@@ -366,7 +366,7 @@ hipError_t hipEventDestroy(hipEvent_t event) {
 
   std::unique_lock lock(hip::eventSetLock);
   if (hip::eventSet.erase(event) == 0) {
-    HIP_RETURN(hipErrorContextIsDestroyed);
+    return hipErrorContextIsDestroyed;
   }
 
   auto* e = reinterpret_cast<hip::Event*>(event);

--- a/projects/clr/hipamd/src/hip_gl.cpp
+++ b/projects/clr/hipamd/src/hip_gl.cpp
@@ -699,7 +699,7 @@ hipError_t hipGraphicsGLRegisterImage(hipGraphicsResource** resource, GLuint ima
 
   hip::Device* device = hip::getCurrentDevice();
   if (device == nullptr) {
-    HIP_RETURN(hipErrorNoDevice);
+    return hipErrorNoDevice;
   }
 
   if (!device->registeredGraphics().add(*resource)) {
@@ -809,7 +809,7 @@ hipError_t hipGraphicsGLRegisterBuffer(hipGraphicsResource** resource, GLuint bu
 
   hip::Device* device = hip::getCurrentDevice();
   if (device == nullptr) {
-    HIP_RETURN(hipErrorNoDevice);
+    return hipErrorNoDevice;
   }
 
   if (!device->registeredGraphics().add(*resource)) {
@@ -889,7 +889,7 @@ hipError_t hipGraphicsMapResources(int count, hipGraphicsResource_t* resources,
   // Track mapping status
   hip::Device* device = hip::getCurrentDevice();
   if (device == nullptr) {
-    HIP_RETURN(hipErrorNoDevice);
+    return hipErrorNoDevice;
   }
   for (int i = 0; i < count; i++) {
     if (!device->mappedGraphics().add(resources[i])) {

--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -1150,13 +1150,13 @@ hipError_t hipStreamBeginCaptureToGraph(hipStream_t stream, hipGraph_t graph,
   HIP_INIT_API(hipStreamBeginCapture, stream, graph, dependencies, dependencyData, numDependencies,
                mode);
   if (dependencyData != nullptr) {
-    HIP_RETURN(hipErrorNotSupported);
+    return hipErrorNotSupported;
   } else if (graph == nullptr) {
-    HIP_RETURN(hipErrorInvalidValue);
+    return hipErrorInvalidValue;
   } else if (dependencies == nullptr && numDependencies != 0) {
-    HIP_RETURN(hipErrorInvalidValue);
+    return hipErrorInvalidValue;
   } else if (dependencies != nullptr && numDependencies == 0) {
-    HIP_RETURN(hipErrorInvalidValue);
+    return hipErrorInvalidValue;
   }
   hip::Graph* g = reinterpret_cast<hip::Graph*>(graph);
   const std::vector<Node> nodes = g->GetNodes();
@@ -1547,7 +1547,7 @@ hipError_t hipGraphInstantiate(hipGraphExec_t* pGraphExec, hipGraph_t graph,
                                hipGraphNode_t* pErrorNode, char* pLogBuffer, size_t bufferSize) {
   HIP_INIT_API(hipGraphInstantiate, pGraphExec, graph);
   if (pGraphExec == nullptr || graph == nullptr) {
-    HIP_RETURN(hipErrorInvalidValue);
+    return hipErrorInvalidValue;
   }
   hip::GraphExec* ge;
   hipError_t status = ihipGraphInstantiate(&ge, reinterpret_cast<hip::Graph*>(graph));
@@ -1848,7 +1848,7 @@ hipError_t hipGraphMemsetNodeSetParams(hipGraphNode_t node, const hipMemsetParam
   }
   if (pNodeParams->height > 1 &&
       pNodeParams->pitch < (pNodeParams->width * pNodeParams->elementSize)) {
-    HIP_RETURN(hipErrorInvalidValue);
+    return hipErrorInvalidValue;
   }
   HIP_RETURN(reinterpret_cast<hip::GraphMemsetNode*>(node)->SetParams(pNodeParams));
 }
@@ -2698,7 +2698,7 @@ hipError_t hipGraphExecUpdate(hipGraphExec_t hGraphExec, hipGraph_t hGraph,
             oldGraphExecNodes[i]->GetParentGraph()->Device()) {
           *updateResult_out = hipGraphExecUpdateErrorUnsupportedFunctionChange;
           *hErrorNode_out = reinterpret_cast<hipGraphNode_t>(newGraphNodes[i]);
-          HIP_RETURN(hipErrorGraphExecUpdateFailure);
+          return hipErrorGraphExecUpdateFailure;
         }
       }
 
@@ -3119,7 +3119,7 @@ hipError_t ihipGraphDebugDotPrint(hip::Graph* graph, const char* path, unsigned 
 hipError_t hipGraphDebugDotPrint(hipGraph_t graph, const char* path, unsigned int flags) {
   HIP_INIT_API(hipGraphDebugDotPrint, graph, path, flags);
   if (graph == nullptr || path == nullptr) {
-    HIP_RETURN(hipErrorInvalidValue);
+    return hipErrorInvalidValue;
   }
   hip::Graph* hip_graph = reinterpret_cast<hip::Graph*>(graph);
   HIP_RETURN(ihipGraphDebugDotPrint(hip_graph, path, flags));
@@ -3667,7 +3667,7 @@ hipError_t hipGraphAddBatchMemOpNode(hipGraphNode_t* phGraphNode, hipGraph_t hGr
   // Check nodeParams fields
   if (nodeParams->count <= 0 || nodeParams->count > 256 || nodeParams->paramArray == nullptr ||
       nodeParams->flags != 0 || nodeParams->ctx == nullptr) {
-    HIP_RETURN(hipErrorInvalidValue);
+    return hipErrorInvalidValue;
   }
 
   hip::GraphNode* node = new hip::hipGraphBatchMemOpNode(nodeParams);
@@ -3699,7 +3699,7 @@ hipError_t hipGraphBatchMemOpNodeSetParams(hipGraphNode_t hNode,
   // Check nodeParams fields
   if (nodeParams->count <= 0 || nodeParams->count > 256 || nodeParams->paramArray == nullptr ||
       nodeParams->flags != 0 || nodeParams->ctx == nullptr) {
-    HIP_RETURN(hipErrorInvalidValue);
+    return hipErrorInvalidValue;
   }
   HIP_RETURN(reinterpret_cast<hip::hipGraphBatchMemOpNode*>(n)->SetParams(nodeParams));
 }
@@ -3716,7 +3716,7 @@ hipError_t hipGraphExecBatchMemOpNodeSetParams(hipGraphExec_t hGraphExec, hipGra
   // Check nodeParams fields
   if (nodeParams->count <= 0 || nodeParams->count > 256 || nodeParams->paramArray == nullptr ||
       nodeParams->flags != 0 || nodeParams->ctx == nullptr) {
-    HIP_RETURN(hipErrorInvalidValue);
+    return hipErrorInvalidValue;
   }
   hip::GraphNode* clonedNode = reinterpret_cast<hip::GraphExec*>(graphExec)->GetClonedNode(n);
   if (clonedNode == nullptr) {

--- a/projects/clr/hipamd/src/hip_hcc.map.in
+++ b/projects/clr/hipamd/src/hip_hcc.map.in
@@ -176,7 +176,6 @@ global:
     hipStreamQuery;
     hipStreamSynchronize;
     hipStreamWaitEvent;
-    __hipOnError;
     __hipPopCallConfiguration;
     __hipPushCallConfiguration;
     __hipRegisterFatBinary;

--- a/projects/clr/hipamd/src/hip_internal.hpp
+++ b/projects/clr/hipamd/src/hip_internal.hpp
@@ -97,12 +97,6 @@ const char* ihipGetErrorName(hipError_t hip_error);
 
 } // namespace hip
 
-#if defined(__GNUC__) || defined(__clang__)
-extern "C" __attribute__((visibility("default"))) void __hipOnError(const void *err_info);
-#else
-extern "C" void __hipOnError(const void *err_info);
-#endif
-
 // Helper: set up TLS device pointer on first use.
 #define HIP_INIT_TLS_DEVICE()                                                                      \
   if (hip::tls.device_ == nullptr && !hip::g_devices.empty()) {                                    \
@@ -178,22 +172,6 @@ extern "C" void __hipOnError(const void *err_info);
   } else if (hip::tls.last_command_error_ != hipSuccess &&                                         \
              hip::tls.last_command_error_ != hipErrorNotReady) {                                   \
     hip::tls.last_error_ = hip::tls.last_command_error_;                                           \
-  }                                                                                                \
-  if (hip::tls.last_command_error_ != hipSuccess &&                                                \
-      hip::tls.last_command_error_ != hipErrorNotReady) {                                          \
-    /* The debugger may place a breakpoint at __hipOnError to catch failed API calls */            \
-    struct {                                                                                       \
-      uint32_t version;                                                                            \
-      uint32_t code;                                                                               \
-      const char *name;                                                                            \
-      const char *desc;                                                                            \
-    } err_info = {                                                                                 \
-      1,                                                                                           \
-      hip::tls.last_command_error_,                                                                \
-      hipGetErrorName(hip::tls.last_command_error_),                                               \
-      hipGetErrorString(hip::tls.last_command_error_)                                              \
-    };                                                                                             \
-    __hipOnError((void *) &err_info);                                                              \
   }
 
 #define HIP_RETURN_DURATION(ret, ...)                                                              \

--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -1299,7 +1299,7 @@ hipError_t ihipArrayCreate(hipArray_t* array, const HIP_ARRAY3D_DESCRIPTOR* pAll
 hipError_t hipArrayCreate(hipArray_t* array, const HIP_ARRAY_DESCRIPTOR* pAllocateArray) {
   HIP_INIT_API(hipArrayCreate, array, pAllocateArray);
   if (pAllocateArray == nullptr) {
-    HIP_RETURN(hipErrorInvalidValue);
+    return hipErrorInvalidValue;
   }
   CHECK_STREAM_CAPTURE_SUPPORTED();
   HIP_ARRAY3D_DESCRIPTOR desc = {
@@ -1314,7 +1314,7 @@ hipError_t hipMallocArray(hipArray_t* array, const hipChannelFormatDesc* desc, s
                           size_t height, unsigned int flags) {
   HIP_INIT_API(hipMallocArray, array, desc, width, height, flags);
   if (array == nullptr || desc == nullptr) {
-    HIP_RETURN(hipErrorInvalidValue);
+    return hipErrorInvalidValue;
   }
   CHECK_STREAM_CAPTURE_SUPPORTED();
   HIP_ARRAY3D_DESCRIPTOR allocateArray = {width,
@@ -1324,7 +1324,7 @@ hipError_t hipMallocArray(hipArray_t* array, const hipChannelFormatDesc* desc, s
                                           hip::getNumChannels(*desc),
                                           flags};
   if (!hip::CheckArrayFormat(*desc)) {
-    HIP_RETURN(hipErrorInvalidValue);
+    return hipErrorInvalidValue;
   }
   HIP_RETURN(ihipArrayCreate(array, &allocateArray, 0 /* numMipLevels */));
 }
@@ -1342,7 +1342,7 @@ hipError_t hipMalloc3DArray(hipArray_t* array, const hipChannelFormatDesc* desc,
                             unsigned int flags) {
   HIP_INIT_API(hipMalloc3DArray, array, desc, extent, flags);
   if (array == nullptr || desc == nullptr) {
-    HIP_RETURN(hipErrorInvalidValue);
+    return hipErrorInvalidValue;
   }
   CHECK_STREAM_CAPTURE_SUPPORTED();
   HIP_ARRAY3D_DESCRIPTOR allocateArray = {extent.width,
@@ -1352,7 +1352,7 @@ hipError_t hipMalloc3DArray(hipArray_t* array, const hipChannelFormatDesc* desc,
                                           hip::getNumChannels(*desc),
                                           flags};
   if (!hip::CheckArrayFormat(*desc)) {
-    HIP_RETURN(hipErrorInvalidValue);
+    return hipErrorInvalidValue;
   }
 
   HIP_RETURN(ihipArrayCreate(array, &allocateArray, 0));
@@ -1730,10 +1730,10 @@ hipError_t hipMemcpyHtoDAsync(hipDeviceptr_t dstDevice, const void* srcHost, siz
   hipMemcpyKind kind = hipMemcpyHostToDevice;
   STREAM_CAPTURE(hipMemcpyHtoDAsync, stream, dstDevice, srcHost, ByteCount, kind);
   if (static_cast<uint32_t>(kind) > hipMemcpyDefault && kind != hipMemcpyDeviceToDeviceNoCU) {
-    HIP_RETURN(hipErrorInvalidMemcpyDirection);
+    return hipErrorInvalidMemcpyDirection;
   }
   if (!hip::isValid(stream)) {
-    HIP_RETURN(hipErrorContextIsDestroyed);
+    return hipErrorContextIsDestroyed;
   }
   hip::Stream* hip_stream = hip::getStream(stream);
   if (hip_stream == nullptr) {
@@ -1748,10 +1748,10 @@ hipError_t hipMemcpyDtoDAsync(hipDeviceptr_t dstDevice, hipDeviceptr_t srcDevice
   hipMemcpyKind kind = hipMemcpyDeviceToDevice;
   STREAM_CAPTURE(hipMemcpyDtoDAsync, stream, dstDevice, srcDevice, ByteCount, kind);
   if (static_cast<uint32_t>(kind) > hipMemcpyDefault && kind != hipMemcpyDeviceToDeviceNoCU) {
-    HIP_RETURN(hipErrorInvalidMemcpyDirection);
+    return hipErrorInvalidMemcpyDirection;
   }
   if (!hip::isValid(stream)) {
-    HIP_RETURN(hipErrorContextIsDestroyed);
+    return hipErrorContextIsDestroyed;
   }
   hip::Stream* hip_stream = hip::getStream(stream);
   if (hip_stream == nullptr) {
@@ -1766,10 +1766,10 @@ hipError_t hipMemcpyDtoHAsync(void* dstHost, hipDeviceptr_t srcDevice, size_t By
   hipMemcpyKind kind = hipMemcpyDeviceToHost;
   STREAM_CAPTURE(hipMemcpyDtoHAsync, stream, dstHost, srcDevice, ByteCount, kind);
   if (static_cast<uint32_t>(kind) > hipMemcpyDefault && kind != hipMemcpyDeviceToDeviceNoCU) {
-    HIP_RETURN(hipErrorInvalidMemcpyDirection);
+    return hipErrorInvalidMemcpyDirection;
   }
   if (!hip::isValid(stream)) {
-    HIP_RETURN(hipErrorContextIsDestroyed);
+    return hipErrorContextIsDestroyed;
   }
   hip::Stream* hip_stream = hip::getStream(stream);
   if (hip_stream == nullptr) {
@@ -4756,7 +4756,7 @@ hipError_t hipMallocMipmappedArray(hipMipmappedArray_t* mipmappedArray,
                                    unsigned int numLevels, unsigned int flags) {
   HIP_INIT_API(hipMallocMipmappedArray, mipmappedArray, desc, extent, numLevels, flags);
   if (mipmappedArray == nullptr || desc == nullptr) {
-    HIP_RETURN(hipErrorInvalidValue);
+    return hipErrorInvalidValue;
   }
   CHECK_STREAM_CAPTURE_SUPPORTED();
   HIP_ARRAY3D_DESCRIPTOR allocateArray = {extent.width,
@@ -4766,7 +4766,7 @@ hipError_t hipMallocMipmappedArray(hipMipmappedArray_t* mipmappedArray,
                                           hip::getNumChannels(*desc),
                                           flags};
   if (!hip::CheckArrayFormat(*desc)) {
-    HIP_RETURN(hipErrorInvalidValue);
+    return hipErrorInvalidValue;
   }
   HIP_RETURN(ihipMipmapArrayCreate(mipmappedArray, &allocateArray, numLevels));
 }
@@ -4818,12 +4818,12 @@ hipError_t hipMemGetHandleForAddressRange(void* handle, hipDeviceptr_t dptr, siz
 
   // We do not support any flags at this time.
   if (dptr == nullptr || size == 0 || handleType != hipMemRangeHandleTypeDmaBufFd || flags != 0) {
-    HIP_RETURN(hipErrorInvalidValue);
+    HIP_RETURN(hipErrorInvalidValue;)
   }
 
   amd::Device* device = hip::getCurrentDevice()->devices()[0];
   if (!device->GetHandleForAddressRange(dptr, size, handle)) {
-    HIP_RETURN(hipErrorInvalidValue);
+    HIP_RETURN(hipErrorInvalidValue;)
   }
 
   HIP_RETURN(hipSuccess);

--- a/projects/clr/hipamd/src/hip_mempool.cpp
+++ b/projects/clr/hipamd/src/hip_mempool.cpp
@@ -88,7 +88,7 @@ hipError_t hipMallocAsync(void** dev_ptr, size_t size, hipStream_t stream) {
   // Return error if any stream other than the current stream is in capture mode
   if (device->StreamCaptureBlocking()) {
     if (s->GetCaptureStatus() != hipStreamCaptureStatusActive) {
-      HIP_RETURN(hipErrorStreamCaptureUnsupported);
+      return hipErrorStreamCaptureUnsupported;
     }
   }
 
@@ -144,7 +144,7 @@ hipError_t hipFreeAsync(void* dev_ptr, hipStream_t stream) {
   // Return error if any stream other than the current stream is in capture mode
   if (device->StreamCaptureBlocking()) {
     if (s->GetCaptureStatus() != hipStreamCaptureStatusActive) {
-      HIP_RETURN(hipErrorStreamCaptureUnsupported);
+      return hipErrorStreamCaptureUnsupported;
     }
   }
 

--- a/projects/clr/hipamd/src/hip_module.cpp
+++ b/projects/clr/hipamd/src/hip_module.cpp
@@ -173,10 +173,10 @@ hipError_t hipFuncGetAttributes(hipFuncAttributes* attr, const void* func) {
   HIP_INIT_API(hipFuncGetAttributes, attr, func);
 
   if (attr == nullptr) {
-    HIP_RETURN(hipErrorInvalidValue);
+    return hipErrorInvalidValue;
   }
   if (func == nullptr) {
-    HIP_RETURN(hipErrorInvalidDeviceFunction);
+    return hipErrorInvalidDeviceFunction;
   }
 
   HIP_RETURN_ONFAIL(PlatformState::Instance().StatCO().GetFuncAttr(attr, func, ihipGetDevice()));

--- a/projects/clr/hipamd/src/hip_peer.cpp
+++ b/projects/clr/hipamd/src/hip_peer.cpp
@@ -197,7 +197,7 @@ hipError_t hipMemcpyPeerAsync(void* dst, int dstDevice, const void* src, int src
   getStreamPerThread(stream);
   hip::Stream* hip_stream = hip::getStream(stream);
   if (hip_stream == nullptr) {
-    HIP_RETURN(hipErrorInvalidValue);
+    return hipErrorInvalidValue;
   }
   HIP_RETURN(ihipMemcpy(dst, src, sizeBytes, hipMemcpyDeviceToDevice, *hip_stream, true, true));
 }
@@ -228,11 +228,11 @@ hipError_t hipMemcpy3DPeerAsync(hipMemcpy3DPeerParms* p, hipStream_t stream) {
   getStreamPerThread(stream);
   hip::Stream* hip_stream = hip::getStream(stream);
   if (hip_stream == nullptr) {
-    HIP_RETURN(hipErrorInvalidValue);
+    return hipErrorInvalidValue;
   }
 
   hipMemcpy3DParms copyParms = getMemcpy3DParms(*p);
-  HIP_RETURN(ihipMemcpy3D(&copyParms, stream, true));
+  HIP_RETURN(ihipMemcpy3D(&copyParms), stream, true);
 }
 
 hipError_t hipCtxEnablePeerAccess(hipCtx_t peerCtx, unsigned int flags) {

--- a/projects/clr/hipamd/src/hip_table_interface.cpp
+++ b/projects/clr/hipamd/src/hip_table_interface.cpp
@@ -50,7 +50,7 @@ template <> hipError_t HandleException<hipError_t>() {
 }  // namespace hip
 
 #define TRY try {
-#define CATCH } catch(...) { HIP_RETURN(hip::HandleException<hipError_t>()); }
+#define CATCH } catch(...) { return hip::HandleException<hipError_t>(); }
 #define CATCHRET(RETURN_TYPE) } catch(...) { return hip::HandleException<RETURN_TYPE>(); }
 
 extern "C" hipError_t __hipPopCallConfiguration(dim3* gridDim, dim3* blockDim, size_t* sharedMem,

--- a/projects/clr/hipamd/src/hip_table_interface_c.cpp
+++ b/projects/clr/hipamd/src/hip_table_interface_c.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <hip/amd_detail/hip_api_trace.hpp>
-#include "hip_internal.hpp"
 namespace hip {
 const HipDispatchTable* GetHipDispatchTable();
 const HipCompilerDispatchTable* GetHipCompilerDispatchTable();
@@ -21,7 +20,7 @@ template <> hipError_t HandleException<hipError_t>();
 #endif  // !_WIN32
 
 #define TRY try {
-#define CATCH } catch(...) { HIP_RETURN(hip::HandleException<hipError_t>()); }
+#define CATCH } catch(...) { return hip::HandleException<hipError_t>(); }
 
 DllExport hipError_t hipExtModuleLaunchKernel(hipFunction_t f, uint32_t globalWorkSizeX,
                                               uint32_t globalWorkSizeY, uint32_t globalWorkSizeZ,


### PR DESCRIPTION
Reverts ROCm/rocm-systems#4755

fixes: https://github.com/ROCm/rocm-libraries/issues/8065 
https://github.com/ROCm/rocm-libraries/issues/8060

Tested the revert here: https://github.com/ROCm/TheRock/actions/runs/27006056559