### PR TITLE
refactor(amdsmi): Change CLI return and exit codes

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -74,7 +74,15 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 ### Changed
 
-- **Normalized JSON/CSV key casing in `amd-smi metric` clock and temperature sections**.  
+- **Reworked `amd-smi` CLI exit codes for failed commands**.
+  - Errors now exit with distinct positive codes (192-206, 255) instead of negative
+    values or a generic `sys.exit(1)`, and error messages are written to `stderr`.
+  - Library failures surface the underlying `AMDSMI_STATUS_*` code as the exit code.
+  - `set` and `reset` operations now report a non-zero exit code when any sub-operation
+    fails, instead of printing the error and exiting `0`.
+  - Scripts that checked for the previous negative exit codes must be updated.
+
+- **Normalized JSON/CSV key casing in `amd-smi metric` clock and temperature sections**.
   - The `uclk_aid`, `socclks_mid`, and temperature `xcd` keys are now lowercase (`aid_<N>`, `mid_<N>`, `xcp_<N>`) in JSON and CSV output, matching the existing `xcp_<N>` usage keys; they were previously uppercase (`AID_<N>`, `MID_<N>`, `XCP_<N>`).
   - Human-readable output is unchanged, since it uppercases all keys.
 

--- a/projects/amdsmi/amdsmi_cli/amdsmi_cli.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_cli.py
@@ -69,19 +69,20 @@ except ImportError:
         from amdsmi_logger import AMDSMILogger
         import amdsmi_cli_exceptions
     except ImportError as e:
-        print(f"Unhandled import error: {e}")
-        print(f"Unable to import amdsmi_cli files. Check {cli_files_path} if they are present.")
-        sys.exit(1)
+        error_code = 192
+        print(f"Unable to import amdsmi_cli files. Check {cli_files_path} if they are present")
+        print(f"Unhandled import error: {e}. Error code: {error_code}", file=sys.stderr)
+        sys.exit(error_code)
 
 
 def _print_error(e, destination):
     if destination in ["stdout", "json", "csv"]:
-        print(e)
+        print(e, file=sys.stderr)
     else:
         f = open(destination, "w", encoding="utf-8")
         f.write(e)
         f.close()
-        print("Error occurred. Result written to " + str(destination) + " file")
+        print("Error occurred. Result written to " + str(destination) + " file", file=sys.stderr)
 
 
 def configure_logging_and_execute(args, amd_smi_commands):
@@ -237,9 +238,8 @@ if __name__ == "__main__":
         elif sys.argv[1] in valid_commands:
             args = amd_smi_parser.parse_args(args=None)
         else:
-            raise amdsmi_cli_exceptions.AmdSmiInvalidSubcommandException(
-                sys.argv[1], amd_smi_commands.logger.destination
-            )
+            outputformat = amd_smi_commands.logger.format
+            raise amdsmi_cli_exceptions.AmdSmiInvalidCommandException(sys.argv[1], outputformat)
 
         # Handle command modifiers before subcommand execution
         # human readable is the default output format
@@ -258,17 +258,8 @@ if __name__ == "__main__":
         sys.exit(abs(e.value))
     except amdsmi_exception.AmdSmiLibraryException as e:
         exc = amdsmi_cli_exceptions.AmdSmiLibraryErrorException(
-            amd_smi_commands.logger.format, e.get_error_code()
+            amd_smi_commands.logger.format, None, e.get_error_code()
         )
-        _print_error(
-            f"{type(exc).__module__}.{type(exc).__name__}: {str(exc)}",
-            amd_smi_commands.logger.destination,
-        )
-        sys.exit(abs(exc.value))
-    except PermissionError as e:
-        command = sys.argv[1] if len(sys.argv) > 1 else ""
-        outputformat = amd_smi_commands.logger.format
-        exc = amdsmi_cli_exceptions.AmdSmiPermissionDeniedException(command, outputformat)
         _print_error(
             f"{type(exc).__module__}.{type(exc).__name__}: {str(exc)}",
             amd_smi_commands.logger.destination,

--- a/projects/amdsmi/amdsmi_cli/amdsmi_cli_exceptions.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_cli_exceptions.py
@@ -20,6 +20,7 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import json
+import sys
 
 
 AMDSMI_ERROR_MESSAGES = {
@@ -52,6 +53,8 @@ AMDSMI_ERROR_MESSAGES = {
     33: "No more free slot",
     34: "Driver not loaded",
     # Reserved for future error messages
+    # Data and size errors
+    39: "There is more data than the buffer size the user passed",
     40: "No data was found for given input",
     41: "Insufficient size for operation",
     42: "Unexpected size of data was read",
@@ -68,6 +71,8 @@ AMDSMI_ERROR_MESSAGES = {
     53: "Parsed argument is invalid",
     54: "AMDGPU restart error",
     55: "Setting is not available",
+    56: "EEPROM is corrupted",
+    # General errors
     0xFFFFFFFE: "AMD-SMI Library error did not map to a status code",
     0xFFFFFFFF: "Unknown error",
 }
@@ -77,6 +82,10 @@ def _get_error_message(error_code):
     if abs(error_code) in AMDSMI_ERROR_MESSAGES:
         return AMDSMI_ERROR_MESSAGES[abs(error_code)]
     return "Generic error"
+
+
+# All exception values are derived from accepted values in Confluence
+# "AMD SMI Error Codes"
 
 
 class AmdSmiException(Exception):
@@ -101,15 +110,27 @@ class AmdSmiException(Exception):
         return self.message
 
 
+class AmdSmiImportException(AmdSmiException):
+    def __init__(self, message=None):
+        super().__init__()
+
+        self.value = 192
+        common_message = "AMD-SMI Unhandled import error."
+        if message:
+            common_message = message
+
+        self.stdout_message = f"{common_message} Error code: {self.value}"
+
+
 class AmdSmiInvalidCommandException(AmdSmiException):
     def __init__(self, command, outputformat: str, message=None):
         super().__init__()
-        self.value = -1
+
+        self.value = 193
         self.command = command
         self.output_format = outputformat
 
-        common_message = f"Command '{self.command}' is invalid. Run 'amd-smi -h' for more info."
-
+        common_message = f"AMD-SMI Command '{self.command}' is invalid."
         if message:
             common_message = message
 
@@ -120,16 +141,21 @@ class AmdSmiInvalidCommandException(AmdSmiException):
 
 
 class AmdSmiInvalidParameterException(AmdSmiException):
-    def __init__(self, command, arg, outputformat: str):
+    def __init__(self, command, arg, outputformat: str, hint: str = None):
         super().__init__()
-        self.value = -2
+        self.value = 194
         self.command = command
         self.arg = arg
         self.output_format = outputformat
 
-        common_message = (
-            f"Parameter '{self.arg}' is invalid. Run 'amd-smi {self.command} -h' for more info."
-        )
+        if not arg:
+            common_message = ""
+        else:
+            common_message = f"AMD-SMI Parameter '{self.arg}' is invalid."
+        if hint:
+            if hint[-1] == ".":
+                hint = hint[:-1]
+            common_message = f"{common_message} {hint}.".strip()
 
         self.json_message["error"] = common_message
         self.json_message["code"] = self.value
@@ -140,7 +166,7 @@ class AmdSmiInvalidParameterException(AmdSmiException):
 class AmdSmiDeviceNotFoundException(AmdSmiException):
     def __init__(self, command, outputformat: str, gpu: bool, cpu: bool, core: bool):
         super().__init__()
-        self.value = -3
+        self.value = 195
         self.command = command
         self.output_format = outputformat
 
@@ -153,7 +179,7 @@ class AmdSmiDeviceNotFoundException(AmdSmiException):
         elif core:
             self.device_type = "CPU CORE"
 
-        common_message = f"Can not find a device: {self.device_type} '{self.command}'"
+        common_message = f"AMD-SMI Can not find a device: {self.device_type} '{self.command}'."
 
         self.json_message["error"] = common_message
         self.json_message["code"] = self.value
@@ -164,11 +190,11 @@ class AmdSmiDeviceNotFoundException(AmdSmiException):
 class AmdSmiInvalidFilePathException(AmdSmiException):
     def __init__(self, command, outputformat: str, message=None):
         super().__init__()
-        self.value = -4
+        self.value = 196
         self.command = command
         self.output_format = outputformat
 
-        common_message = f"Path '{self.command}' cannot be found."
+        common_message = f"AMD-SMI Path '{self.command}' cannot be found."
 
         if message:
             common_message = message
@@ -182,14 +208,21 @@ class AmdSmiInvalidFilePathException(AmdSmiException):
 class AmdSmiInvalidParameterValueException(AmdSmiException):
     def __init__(self, command, arg, outputformat: str, hint: str = None):
         super().__init__()
-        self.value = -5
+        self.value = 197
         self.command = command
         self.arg = arg
         self.output_format = outputformat
+        if arg is not None:
+            common_message = f"AMD-SMI Value '{self.arg}' is not of valid type or format."
+        elif hint is None:
+            common_message = "AMD-SMI Value is not of valid type or format."
+        else:
+            common_message = ""
 
-        common_message = f"Value '{self.arg}' is not of valid type or format. Run 'amd-smi {self.command} -h' for more info."
         if hint:
-            common_message += f" {hint}"
+            if hint[-1] == ".":
+                hint = hint[:-1]
+            common_message = f"{common_message} {hint}."
 
         self.json_message["error"] = common_message
         self.json_message["code"] = self.value
@@ -200,11 +233,11 @@ class AmdSmiInvalidParameterValueException(AmdSmiException):
 class AmdSmiMissingParameterValueException(AmdSmiException):
     def __init__(self, command, outputformat: str):
         super().__init__()
-        self.value = -6
+        self.value = 198
         self.command = command
         self.output_format = outputformat
 
-        common_message = f"Parameter '{self.command}' requires a value. Run '--help' for more info."
+        common_message = f"AMD-SMI Parameter '{self.command}' requires a value."
 
         self.json_message["error"] = common_message
         self.json_message["code"] = self.value
@@ -215,13 +248,11 @@ class AmdSmiMissingParameterValueException(AmdSmiException):
 class AmdSmiCommandNotSupportedException(AmdSmiException):
     def __init__(self, command, outputformat: str):
         super().__init__()
-        self.value = -7
+        self.value = 199
         self.command = command
         self.output_format = outputformat
 
-        common_message = (
-            f"Command '{self.command}' is not supported on the system. Run '--help' for more info."
-        )
+        common_message = f"AMD-SMI Command '{self.command}' is not supported on the system."
 
         self.json_message["error"] = common_message
         self.json_message["code"] = self.value
@@ -232,11 +263,11 @@ class AmdSmiCommandNotSupportedException(AmdSmiException):
 class AmdSmiParameterNotSupportedException(AmdSmiException):
     def __init__(self, command, outputformat: str):
         super().__init__()
-        self.value = -8
+        self.value = 200
         self.command = command
         self.output_format = outputformat
 
-        common_message = f"Parameter '{self.command}' is not supported on the system. Run '--help' for more info."
+        common_message = f"AMD-SMI Parameter '{self.command}' is not supported on the system."
 
         self.json_message["error"] = common_message
         self.json_message["code"] = self.value
@@ -245,13 +276,15 @@ class AmdSmiParameterNotSupportedException(AmdSmiException):
 
 
 class AmdSmiRequiredCommandException(AmdSmiException):
-    def __init__(self, command, outputformat: str):
+    def __init__(self, command, outputformat: str, hint: str = None):
         super().__init__()
-        self.value = -9
+        self.value = 201
         self.command = command
         self.output_format = outputformat
 
-        common_message = f"Command '{self.command}' requires a target argument. Run 'amd-smi {self.command} -h' for more info."
+        common_message = f"AMD-SMI Command '{self.command}' requires a target argument."
+        if hint:
+            common_message = f"{common_message} {hint}.".strip()
 
         self.json_message["error"] = common_message
         self.json_message["code"] = self.value
@@ -262,11 +295,11 @@ class AmdSmiRequiredCommandException(AmdSmiException):
 class AmdSmiInvalidSubcommandException(AmdSmiException):
     def __init__(self, command, outputformat: str):
         super().__init__()
-        self.value = -10
+        self.value = 202
         self.command = command
         self.output_format = outputformat
 
-        common_message = f"AMD-SMI Command '{self.command}' is invalid. Must receive valid AMD-SMI Command first. Run 'amd-smi -h' for more info."
+        common_message = f"AMD-SMI Command '{self.command}' is invalid. Must receive valid AMD-SMI Command first."
 
         self.json_message["error"] = common_message
         self.json_message["code"] = self.value
@@ -275,15 +308,17 @@ class AmdSmiInvalidSubcommandException(AmdSmiException):
 
 
 class AmdSmiPermissionDeniedException(AmdSmiException):
-    def __init__(self, command, outputformat: str):
+    def __init__(self, command, outputformat: str, hint: str = None):
         super().__init__()
-        self.value = -11
+        self.value = 203
         self.command = command
         self.output_format = outputformat
 
-        common_message = (
-            f"AMD-SMI Command '{self.command}' requires elevation (sudo privileges required)"
-        )
+        common_message = f"AMD-SMI Command '{self.command}'"
+        if hint is not None:
+            common_message += f" {hint}."
+        else:
+            common_message += " requires elevation (sudo privileges required)."
 
         self.json_message["error"] = common_message
         self.json_message["code"] = self.value
@@ -294,11 +329,11 @@ class AmdSmiPermissionDeniedException(AmdSmiException):
 class AmdSmiUnknownErrorException(AmdSmiException):
     def __init__(self, command, outputformat: str):
         super().__init__()
-        self.value = -100
+        self.value = 255
         self.command = command
         self.output_format = outputformat
 
-        common_message = "An unknown error has occurred. Run 'help' for more info."
+        common_message = "AMD-SMI An unknown error has occurred."
 
         self.json_message["error"] = common_message
         self.json_message["code"] = self.value
@@ -307,14 +342,19 @@ class AmdSmiUnknownErrorException(AmdSmiException):
 
 
 class AmdSmiLibraryErrorException(AmdSmiException):
-    def __init__(self, outputformat: str, error_code):
+    def __init__(self, outputformat: str, msg: str, error_code: int):
         super().__init__()
-        self.value = -1000 - abs(error_code)
+        if error_code == 0xFFFFFFFF:
+            error_code = 206
+        elif error_code == 0xFFFFFFFE:
+            error_code = 205
+        self.value = abs(error_code)
         self.smilibcode = error_code
         self.output_format = outputformat
-
-        common_message = f"AMDSMI has returned error '{self.value}' - '{AMDSMI_ERROR_MESSAGES[abs(self.smilibcode)]}'"
-
+        if msg:
+            common_message = msg
+        else:
+            common_message = f"AMDSMI has returned error '{self.value}' - '{_get_error_message(abs(self.smilibcode))}'."
         self.json_message["error"] = common_message
         self.json_message["code"] = self.value
         self.csv_message = f"error,code\n{common_message}, {self.value}"

--- a/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_commands.py
@@ -26,6 +26,7 @@ import sys
 from amdsmi_helpers import AMDSMIHelpers
 from amdsmi_logger import AMDSMILogger
 from amdsmi import amdsmi_exception, amdsmi_interface
+from amdsmi_cli_exceptions import AmdSmiDeviceNotFoundException
 
 from subcommands import (
     BadPagesCommands,
@@ -199,7 +200,16 @@ class AMDSMICommands(
             version_args.cpu_version = False
             version_args.nic_version = False
             self.version(version_args)
-            sys.exit(-1)
+            output_format = self.helpers.get_output_format()
+            command = sys.argv[1] if len(sys.argv) > 1 else "unknown"
+            gpu = cpu = core = False
+            if len(self.device_handles) == 0:
+                gpu = True
+            if len(self.cpu_handles) == 0:
+                cpu = True
+            if len(self.core_handles) == 0:
+                core = True
+            raise AmdSmiDeviceNotFoundException(command, output_format, gpu, cpu, core)
 
     def profile(self, args):
         """Not applicable to linux baremetal"""
@@ -260,9 +270,14 @@ class AMDSMICommands(
                     pass
 
         except ImportError as e:
+            error_code = 192
             logging.error(f"Could not import ROCm-SMI compatibility module: {e}")
             logging.error("Make sure amdsmi_rocm_smi_compat.py is in the amdsmi_cli directory")
-            print("ERROR: ROCm-SMI compatibility mode not available")
+            print(
+                f"ERROR: ROCm-SMI compatibility mode not available. Error code: {error_code}",
+                file=sys.stderr,
+            )
+            sys.exit(error_code)
         except Exception as e:
             logging.error(f"Error in ROCm-SMI compatibility mode: {e}")
-            print(f"ERROR: {e}")
+            print(f"ERROR: {e}", file=sys.stderr)

--- a/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_helpers.py
@@ -1793,6 +1793,20 @@ class AMDSMIHelpers:
                 continue
         return None
 
+    def raise_permission_exception(self, msg=None):
+        if len(sys.argv) > 2:
+            cmd = " ".join(sys.argv[1:3])
+        elif len(sys.argv) == 2:
+            cmd = sys.argv[1]
+        else:
+            cmd = "unknown"
+
+        if msg is None:
+            msg = "Confirmation not given. Exiting without setting value"
+        raise amdsmi_cli_exceptions.AmdSmiPermissionDeniedException(
+            cmd, self.get_output_format(), msg
+        )
+
     def confirm_out_of_spec_warning(self, auto_respond=False):
         """Print the warning for running outside of specification and prompt user to accept the terms.
 
@@ -1818,7 +1832,7 @@ class AMDSMIHelpers:
         if user_input in ["y", "Y", "yes", "Yes", "YES"]:
             return
         else:
-            sys.exit("Confirmation not given. Exiting without setting value")
+            self.raise_permission_exception()
 
     def confirm_changing_memory_partition_gpu_reload_warning(self, auto_respond=False):
         """Print the warning for running outside of specification and prompt user to accept the terms.
@@ -1857,8 +1871,8 @@ class AMDSMIHelpers:
             print("")
             return
         else:
-            print("Confirmation not given. Exiting without setting value")
-            sys.exit(1)
+            msg = "Confirmation not given. Exiting without setting value"
+            self.raise_permission_exception(msg)
 
     def is_valid_profile(self, profile):
         profile_presets = (
@@ -2723,23 +2737,29 @@ class AMDSMIHelpers:
                 num_entries = num_entries + len(entries)
             except amdsmi_exception.AmdSmiLibraryException as e:
                 if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
-                    raise PermissionError(
-                        "Error opening CPER file. This command requires elevation"
-                    ) from e
+                    msg = "Error opening CPER file. This command requires elevation"
+                    self.raise_permission_exception(msg)
                 if (
                     e.get_error_code()
                     == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NOT_SUPPORTED
                     or e.get_error_code()
                     == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_FILE_NOT_FOUND
                 ):
-                    raise FileNotFoundError(
-                        "Error accessing CPER files. This command requires CPER to be enabled."
-                    ) from e
+                    output_format = self.get_output_format()
+                    command = sys.argv[1] if len(sys.argv) > 1 else "unknown"
+                    msg = "Error accessing CPER files. This command requires CPER to be enabled."
+                    raise amdsmi_cli_exceptions.AmdSmiInvalidFilePathException(
+                        command, output_format, msg
+                    )
+                output_format = self.get_output_format()
                 if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_FILE_ERROR:
-                    raise OSError("Error opening CPER file. Unable to read CPER File") from e
+                    msg = "Error opening CPER file. Unable to read CPER File."
                 else:
-                    logging.debug(f"Cannot retrieve CPER entries: {e}")
-                    break
+                    msg = f"Cannot retrieve CPER entries: {e}."
+                    logging.debug(msg)
+                raise amdsmi_cli_exceptions.AmdSmiLibraryErrorException(
+                    output_format, msg, e.get_error_code()
+                )
 
             args.cursor[gpu_idx] = new_cursor
             if len(entries) == 0:
@@ -3163,9 +3183,9 @@ class AMDSMIHelpers:
                         "sensor": power_type_key,
                         "requested_power_cap": self.unit_format(logger, requested_power_cap, "W"),
                         "current_power_cap": self.unit_format(logger, current_power_cap, "W"),
-                        "message": f"{power_type_key} power cap is already set to {requested_power_cap}W",
+                        "message": f"{power_type_key} power cap is already set to {requested_power_cap} W",
                     }
-                return f"{power_type_key} power cap is already set to {requested_power_cap}W"
+                return f"{power_type_key} power cap is already set to {requested_power_cap} W"
             elif current_power_cap == 0:
                 if logger.is_json_format() or logger.is_csv_format():
                     return {
@@ -3180,7 +3200,7 @@ class AMDSMIHelpers:
                 # Raise so the caller exits with a non-zero return code
                 raise amdsmi_cli_exceptions.AmdSmiInvalidParameterValueException(
                     sys.argv[1] if len(sys.argv) > 1 else "unknown",
-                    f"{requested_power_cap}W",
+                    f"{requested_power_cap} W",
                     self.get_output_format(),
                     hint=f"Power cap must be between {min_power_cap}W and {max_power_cap}W",
                 )
@@ -3189,27 +3209,23 @@ class AMDSMIHelpers:
                 requested_power_cap, AMDSMIHelpers.SI_Unit.BASE, AMDSMIHelpers.SI_Unit.MICRO
             )
             amdsmi_interface.amdsmi_set_power_cap(device_handle, power_type, new_power_cap)
+            msg = f"Successfully set {power_type_key} power cap to {requested_power_cap} W"
             if logger.is_json_format() or logger.is_csv_format():
                 return {
                     "status": "success",
                     "sensor": power_type_key,
                     "power_cap": self.unit_format(logger, requested_power_cap, "W"),
-                    "message": f"Successfully set {power_type_key} power cap to {requested_power_cap}W",
+                    "message": msg,
                 }
-            return f"Successfully set {power_type_key} power cap to {requested_power_cap}W"
+            return msg
         except amdsmi_exception.AmdSmiLibraryException as e:
             if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
-                raise PermissionError("Command requires elevation") from e
-            error_msg = f"[{e.get_error_info(detailed=False)}] Unable to set {power_type_key} power cap to {requested_power_cap}W"
-            if logger.is_json_format() or logger.is_csv_format():
-                return {
-                    "status": "error",
-                    "sensor": power_type_key,
-                    "requested_power_cap": self.unit_format(logger, requested_power_cap, "W"),
-                    "error": e.get_error_info(detailed=False),
-                    "message": error_msg,
-                }
-            return error_msg
+                self.raise_permission_exception("Command requires elevation")
+            error_msg = f"[{e.get_error_info(detailed=False)}] Unable to set {power_type_key} power cap to {requested_power_cap} W"
+            output_format = self.get_output_format()
+            raise amdsmi_cli_exceptions.AmdSmiInvalidParameterValueException(
+                sys.argv[1] if len(sys.argv) > 1 else "unknown", None, output_format, error_msg
+            )
 
     def prompt_reboot(self):
         """Prompt user to reboot and execute if confirmed

--- a/projects/amdsmi/amdsmi_cli/amdsmi_init.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_init.py
@@ -38,10 +38,17 @@ sys.path.insert(0, python_lib_path)
 try:
     from amdsmi import amdsmi_interface, amdsmi_exception
 except ImportError as e:
-    print(f"Unhandled import error: {e}")
-    print("Failed to import the amdsmi Python library. Ensure it is installed in Python.")
-    print(f"Alternatively, verify that the library is in the path:\n{python_lib_path}")
-    sys.exit(1)
+    error_code = 192
+    print(
+        "Failed to import the amdsmi Python library. Ensure it is installed in Python.",
+        file=sys.stderr,
+    )
+    print(
+        f"Alternatively, verify that the library is in the path:\n{python_lib_path}",
+        file=sys.stderr,
+    )
+    print(f"Unhandled import error: {e}. Error code: {error_code}", file=sys.stderr)
+    sys.exit(error_code)
 
 # Using basic python logging for user errors and development
 logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.ERROR)  # User level logging
@@ -155,11 +162,11 @@ def amdsmi_cli_init():
     init_thread.join(timeout=_INIT_TIMEOUT_SEC)
 
     if init_thread.is_alive():
-        logging.error(
-            "amdsmi_init() timed out after %ds. The GPU driver may be unresponsive.",
-            _INIT_TIMEOUT_SEC,
-        )
-        sys.exit(2)
+        error_code = amdsmi_interface.AmdSmiStatus.TIMEOUT
+        msg = f"amdsmi_init() timed out after {_INIT_TIMEOUT_SEC}s. The GPU driver may be unresponsive."
+        logging.error(msg)
+        print(f"{msg} Error code: {int(error_code)}", file=sys.stderr)
+        sys.exit(error_code)
 
     if isinstance(
         init_result["exception"],
@@ -170,15 +177,16 @@ def amdsmi_cli_init():
         if (
             e.err_code
             in (
-                amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NOT_INIT,
-                amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_DRIVER_NOT_LOADED,
+                amdsmi_interface.AmdSmiStatus.NOT_INIT,
+                amdsmi_interface.AmdSmiStatus.DRIVER_NOT_LOADED,
             )
             or init_flag == 0
         ):
-            logging.error(
-                "Drivers not loaded (amdgpu, amd_hsmp, ionic, bnxt_en drivers not found in modules)"
-            )
-            sys.exit(-1)
+            msg = "Drivers not loaded (amdgpu, amd_hsmp, ionic, rdma drivers not found in modules)"
+            logging.error(msg)
+            error_code = amdsmi_interface.AmdSmiStatus.DRIVER_NOT_LOADED
+            print(f"{msg}. Error code: {int(error_code)}", file=sys.stderr)
+            sys.exit(error_code)
         else:
             raise e
     elif init_result["exception"] is not None:

--- a/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
@@ -74,7 +74,7 @@ class AMDSMISubParser(argparse.ArgumentParser):
     """Subcommand parser with custom error handling for AMDSMI CLI.
     Used as parser_class for subcommands so that argparse errors on
     subcommand arguments (e.g., --loglevel INVALID) are routed through
-    the same AmdSmiException framework instead of calling sys.exit(2).
+    the same AmdSmiException framework instead of calling sys.exit() directly.
     """
 
     def error(self, message):
@@ -369,7 +369,9 @@ class AMDSMIParser(argparse.ArgumentParser):
     def _is_command_supported(self, user_input, acceptable_values, command_name):
         if acceptable_values == "N/A":
             outputformat = self.helpers.get_output_format()
-            raise amdsmi_cli_exceptions.AmdSmiPermissionDeniedException(command_name, outputformat)
+            raise amdsmi_cli_exceptions.AmdSmiCommandNotSupportedException(
+                command_name, outputformat
+            )
         elif str(user_input).upper() not in acceptable_values:
             print(f"Valid inputs are {acceptable_values}")
             raise amdsmi_cli_exceptions.AmdSmiInvalidParameterValueException(
@@ -706,7 +708,8 @@ class AMDSMIParser(argparse.ArgumentParser):
                             .lower()
                         )
                     except Exception:
-                        sys.exit("Confirmation not given. Exiting without setting value")
+                        msg = "Confirmation not given. Exiting without setting value"
+                        self.helpers.raise_permission_exception(msg)
                     if resp in ("a", "append"):
                         setattr(args, self.dest, path)
                         return
@@ -774,8 +777,7 @@ class AMDSMIParser(argparse.ArgumentParser):
             def __call__(self, parser, args, values, option_string=None):
                 if args.watch is None:
                     raise argparse.ArgumentError(
-                        self,
-                        f"invalid argument: '{self.dest}' needs to be paired with -w/--watch. Error code: -2",
+                        self, f"invalid argument: '{self.dest}' needs to be paired with -w/--watch."
                     )
                 else:
                     setattr(args, self.dest, values)
@@ -1229,7 +1231,7 @@ class AMDSMIParser(argparse.ArgumentParser):
                     raise argparse.ArgumentError(
                         self,
                         f"Invalid argument for {option_string}: '{values}' "
-                        f"(expected string like I8,F32)",
+                        "(expected string like I8,F32)",
                     )
 
                 parts = values.split(",")
@@ -1256,7 +1258,7 @@ class AMDSMIParser(argparse.ArgumentParser):
                             + ", ".join(valid_names),
                         )
                     if enum_val == amdsmi_interface.AmdSmiPtlData.INVALID:
-                        raise argparse.ArgumentError(self, f"INVALID is not a usable PTL format.")
+                        raise argparse.ArgumentError(self, "INVALID is not a usable PTL format.")
                     enums.append(enum_val)
 
                 if enums[0] == enums[1]:
@@ -2407,7 +2409,10 @@ class AMDSMIParser(argparse.ArgumentParser):
                 )
                 (accelerator_set_choices, _) = self.helpers.get_accelerator_choices_types_indices()
                 memory_partition_choices_str = ", ".join(self.helpers.get_memory_partition_types())
-                accelerator_set_choices_str = ", ".join(accelerator_set_choices)
+                if isinstance(accelerator_set_choices, str) and accelerator_set_choices == "N/A":
+                    accelerator_set_choices_str = "N/A"
+                else:
+                    accelerator_set_choices_str = ", ".join(accelerator_set_choices)
                 set_compute_partition_help = f"Set one of the following accelerator TYPE or profile INDEX:\n\t{accelerator_set_choices_str}.\n\tUse `sudo amd-smi partition --accelerator` to find acceptable values."
                 set_memory_partition_help = f"Set one of the following the memory partition modes:\n\t{memory_partition_choices_str}"
                 soc_pstate_help_info = ", ".join(self.helpers.get_soc_pstates())

--- a/projects/amdsmi/amdsmi_cli/amdsmi_rocm_smi_compat.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_rocm_smi_compat.py
@@ -21,7 +21,7 @@ SMI_PAT = 0
 SMI_HASH = "amdsmi"
 __version__ = "%s.%s.%s+%s" % (SMI_MAJ, SMI_MIN, SMI_PAT, SMI_HASH)
 
-# Set to 1 if an error occurs
+# Set to error_code if an error occurs
 RETCODE = 0
 
 # If we want JSON format output instead
@@ -821,10 +821,10 @@ def showAllConcise(deviceList):
     import amdsmi
 
     if PRINT_JSON:
-        print("NOT_SUPPORTED: Cannot print JSON/CSV output for concise output")
-        sys.exit(1)
-
-    silent = True
+        error_code = 199
+        msg = f"NOT_SUPPORTED: Cannot print JSON/CSV output for concise output. Error code: {error_code}"
+        print(msg, file=sys.stderr)
+        sys.exit(error_code)
 
     # CRITICAL: Cache BDF first to minimize GPU wake-up
     bdf_cache = {}
@@ -997,28 +997,40 @@ def main():
     # Import amdsmi
     try:
         import amdsmi
-    except ImportError:
-        print("ERROR: Could not import amdsmi module")
-        print("Install with: pip install amdsmi")
-        return 1
+        from amdsmi import amdsmi_interface
+    except ImportError as e:
+        error_code = 192
+        print("Could not import amdsmi module", file=sys.stderr)
+        print("Install with: pip install amdsmi", file=sys.stderr)
+        print(f"Error: {e}. Error code: {error_code}", file=sys.stderr)
+        return error_code
 
     # Check if driver is initialized
     if not driverInitialized():
-        logging.error("Unable to detect amdgpu driver. Exiting...")
-        return 1
+        error_code = 195
+        msg = "Unable to detect amdgpu driver. Exiting..."
+        logging.error(msg)
+        print(f"Error: {msg} Error code: {error_code}", file=sys.stderr)
+        return error_code
 
     # Initialize AMD SMI (equivalent to rocm_smi.initializeRsmi())
     if not initializeRsmi():
-        logging.error("Failed to initialize AMD SMI")
-        return 1
+        error_code = amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NOT_INIT
+        msg = "Failed to initialize AMD SMI"
+        logging.error(msg)
+        print(f"Error: {msg} Error code: {error_code}", file=sys.stderr)
+        return error_code
 
     try:
         # Get processor handles (equivalent to rocm_smi.listDevices())
         deviceList = listDevices()
 
         if not deviceList:
-            logging.error("No AMD GPU devices found")
-            return 1
+            error_code = amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_DRIVER_NOT_LOADED
+            msg = "No AMD GPU devices found"
+            logging.error(msg)
+            print(f"Error: {msg}. Error code: {error_code}", file=sys.stderr)
+            return error_code
 
         # Check AMD GPUs (equivalent to rocm_smi.checkAmdGpus())
         if not checkAmdGpus(deviceList):

--- a/projects/amdsmi/amdsmi_cli/subcommands/monitor.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/monitor.py
@@ -85,7 +85,7 @@ class MonitorCommands:
             brcm_switch (bool, optional): Value override for args.brcm_switch. Defaults to None.
 
         Raises:
-            ValueError: Value error if no gpu value is provided
+            AmdSmiLibraryException: if there is an AMDSMI library error
             IndexError: Index error if gpu list is empty
 
         Return:
@@ -849,7 +849,7 @@ class MonitorCommands:
                 process_list = amdsmi_interface.amdsmi_get_gpu_process_list(args.gpu)
             except amdsmi_exception.AmdSmiLibraryException as e:
                 if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
-                    raise PermissionError("Command requires elevation") from e
+                    self.helpers.raise_permission_exception("Command requires elevation")
                 logging.debug(
                     "Failed to get process list for gpu %s | %s", gpu_id, e.get_error_info()
                 )

--- a/projects/amdsmi/amdsmi_cli/subcommands/reset.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/reset.py
@@ -23,6 +23,9 @@ import logging
 import sys
 
 from amdsmi_cli_exceptions import AmdSmiRequiredCommandException
+from amdsmi_cli_exceptions import AmdSmiLibraryErrorException
+from amdsmi_cli_exceptions import AmdSmiDeviceNotFoundException
+from amdsmi_cli_exceptions import AmdSmiInvalidParameterException
 from amdsmi_helpers import AMDSMIHelpers
 
 from amdsmi import amdsmi_exception, amdsmi_interface
@@ -61,8 +64,10 @@ class ResetCommands:
             clean_local_data (bool, optional): Value override for args.run_cleaner_shader. Defaults to None.
 
         Raises:
-            ValueError: Value error if no gpu value is provided
-            IndexError: Index error if gpu list is empty
+            AmdSmiLibraryErrorException
+            AmdSmiDeviceNotFoundException
+            AmdSmiRequiredCommandException
+            AmdSmiInvalidParameterException
 
         Return:
             Nothing
@@ -93,12 +98,12 @@ class ResetCommands:
         # Special GTT handling (system-wide, not per-GPU) — handle before device dispatch
         if hasattr(args, "gtt") and args.gtt:
             if hasattr(args, "gpu") and args.gpu is not None:
-                print(
+                msg = (
                     "amd-smi reset: error: argument --gtt: not allowed with argument --gpu/-g "
-                    "(--gtt is a system-wide setting, not per-GPU)",
-                    file=sys.stderr,
+                    "(--gtt is a system-wide setting, not per-GPU)."
                 )
-                sys.exit(2)
+                output_format = self.helpers.get_output_format()
+                raise AmdSmiInvalidParameterException("reset", None, output_format, msg)
             try:
                 amdsmi_interface.amdsmi_reset_ttm_pages_limit()
                 self.logger.output["reset_gtt"] = (
@@ -111,12 +116,12 @@ class ResetCommands:
                 return
             except amdsmi_exception.AmdSmiLibraryException as e:
                 if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
-                    raise PermissionError("Command requires elevation") from e
-                self.logger.output["reset_gtt"] = (
-                    f"[{e.get_error_info(detailed=False)}] Unable to reset GTT"
-                )
+                    self.helpers.raise_permission_exception("Command requires elevation")
+                error_msg = f"[{e.get_error_info(detailed=False)}] Unable to reset GTT"
+                self.logger.output["reset_gtt"] = error_msg
                 self.logger.print_output()
-                return
+                output_format = self.helpers.get_output_format()
+                raise AmdSmiLibraryErrorException(output_format, error_msg, e.get_error_code())
 
         # Handle No GPU passed
         if args.gpu == None:
@@ -202,6 +207,7 @@ class ResetCommands:
 
         if self.helpers.is_baremetal():
             if args.gpureset:
+                found_error = False
                 if self.helpers.is_amd_device(args.gpu):
                     try:
                         amdsmi_interface.amdsmi_reset_gpu(args.gpu)
@@ -211,43 +217,58 @@ class ResetCommands:
                             e.get_error_code()
                             == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM
                         ):
-                            raise PermissionError("Command requires elevation") from e
-                        result = f"[{e.get_error_info(detailed=False)}] Unable to reset GPU"
-                        self.logger.store_output(args.gpu, "gpu_reset", result)
+                            self.helpers.raise_permission_exception("Command requires elevation")
+                        error_msg = f"[{e.get_error_info(detailed=False)}] Unable to reset GPU"
+                        self.logger.store_output(args.gpu, "gpu_reset", error_msg)
                         self.logger.print_output()
                         self.logger.clear_multiple_devices_output()
-                        return
+                        output_format = self.helpers.get_output_format()
+                        raise AmdSmiLibraryErrorException(
+                            output_format, error_msg, e.get_error_code()
+                        )
                 else:
-                    result = "Unable to reset non-amd GPU"
+                    found_error = True
+                    result = "Unable to reset non-amd GPU."
+
                 self.logger.store_output(args.gpu, "gpu_reset", result)
                 self.logger.print_output()
                 self.logger.clear_multiple_devices_output()
+                if found_error:
+                    output_format = self.helpers.get_output_format()
+                    raise AmdSmiDeviceNotFoundException("reset", output_format, True, False, False)
                 return
             if args.clocks:
                 reset_clocks_results = {"overdrive": "", "clocks": "", "performance": ""}
+                msgs = []
+                detected_exception = None
                 try:
                     amdsmi_interface.amdsmi_set_gpu_overdrive_level(args.gpu, 0)
                     reset_clocks_results["overdrive"] = "Overdrive set to 0"
                 except amdsmi_exception.AmdSmiLibraryException as e:
+                    detected_exception = e
                     if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
-                        raise PermissionError("Command requires elevation") from e
+                        self.helpers.raise_permission_exception("Command requires elevation")
                     logging.debug(
                         "Failed to reset overdrive on gpu %s | %s", gpu_id, e.get_error_info()
                     )
-                    reset_clocks_results["overdrive"] = (
+                    msgs.append(
                         f"[{e.get_error_info(detailed=False)}] Unable to reset overdrive to 0"
                     )
+                    reset_clocks_results["overdrive"] = msgs[-1]
                     # continue to reset clocks and performance level
                 try:
                     level_auto = amdsmi_interface.AmdSmiDevPerfLevel.AUTO
                     amdsmi_interface.amdsmi_set_gpu_perf_level(args.gpu, level_auto)
                     reset_clocks_results["clocks"] = "Successfully reset performance level to auto"
                 except amdsmi_exception.AmdSmiLibraryException as e:
+                    if detected_exception is None:
+                        detected_exception = e
                     if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
-                        raise PermissionError("Command requires elevation") from e
-                    reset_clocks_results["clocks"] = (
+                        self.helpers.raise_permission_exception("Command requires elevation")
+                    msgs.append(
                         f"[{e.get_error_info(detailed=False)}] Unable to reset performance level to auto"
                     )
+                    reset_clocks_results["clocks"] = msgs[-1]
                     logging.debug(
                         "Failed to reset perf level on gpu %s | %s", gpu_id, e.get_error_info()
                     )
@@ -260,11 +281,14 @@ class ResetCommands:
                         "Successfully reset performance level to auto"
                     )
                 except amdsmi_exception.AmdSmiLibraryException as e:
+                    if detected_exception is None:
+                        detected_exception = e
                     if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
-                        raise PermissionError("Command requires elevation") from e
-                    reset_clocks_results["performance"] = (
+                        self.helpers.raise_permission_exception("Command requires elevation")
+                    msgs.append(
                         f"[{e.get_error_info(detailed=False)}] Unable to reset performance level to auto"
                     )
+                    reset_clocks_results["performance"] = msgs[-1]
                     logging.debug(
                         "Failed to reset perf level on gpu %s | %s", gpu_id, e.get_error_info()
                     )
@@ -272,6 +296,12 @@ class ResetCommands:
                 self.logger.store_output(args.gpu, "reset_clocks", reset_clocks_results)
                 self.logger.print_output()
                 self.logger.clear_multiple_devices_output()
+                if detected_exception is not None:
+                    output_format = self.helpers.get_output_format()
+                    msg = "\n".join(msgs)
+                    raise AmdSmiLibraryErrorException(
+                        output_format, msg, detected_exception.get_error_code()
+                    )
                 return
             if args.fans:
                 try:
@@ -279,18 +309,20 @@ class ResetCommands:
                     result = "Successfully reset fan speed to driver control"
                 except amdsmi_exception.AmdSmiLibraryException as e:
                     if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
-                        raise PermissionError("Command requires elevation") from e
+                        self.helpers.raise_permission_exception("Command requires elevation")
                     result = f"[{e.get_error_info(detailed=False)}] Unable to reset fan speed to driver control"
                     logging.debug("Failed to reset fans on gpu %s | %s", gpu_id, e.get_error_info())
                     self.logger.store_output(args.gpu, "reset_fans", result)
                     self.logger.print_output()
                     self.logger.clear_multiple_devices_output()
-                    return
+                    output_format = self.helpers.get_output_format()
+                    raise AmdSmiLibraryErrorException(output_format, result, e.get_error_code())
                 self.logger.store_output(args.gpu, "reset_fans", result)
                 self.logger.print_output()
                 self.logger.clear_multiple_devices_output()
                 return
             if args.profile:
+                detected_exception = None
                 reset_profile_results = {"power_profile": "N/A"}
                 try:
                     power_profile_mask = (
@@ -301,11 +333,11 @@ class ResetCommands:
                         "Successfully reset Power Profile to default (bootup default)"
                     )
                 except amdsmi_exception.AmdSmiLibraryException as e:
+                    detected_exception = e
                     if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
-                        raise PermissionError("Command requires elevation") from e
-                    reset_profile_results["power_profile"] = (
-                        f"[{e.get_error_info(detailed=False)}] Unable to reset Power Profile to default (bootup default)"
-                    )
+                        self.helpers.raise_permission_exception("Command requires elevation")
+                    error_msg = f"[{e.get_error_info(detailed=False)}] Unable to reset Power Profile to default (bootup default)"
+                    reset_profile_results["power_profile"] = error_msg
                     logging.debug(
                         "Failed to reset power profile on gpu %s | %s", gpu_id, e.get_error_info()
                     )
@@ -313,14 +345,21 @@ class ResetCommands:
                 self.logger.store_output(args.gpu, "reset_profile", reset_profile_results)
                 self.logger.print_output()
                 self.logger.clear_multiple_devices_output()
+                if detected_exception is not None:
+                    output_format = self.helpers.get_output_format()
+                    raise AmdSmiLibraryErrorException(
+                        output_format, error_msg, detected_exception.get_error_code()
+                    )
                 return
             if args.xgmierr:
+                detected_exception = None
                 try:
                     amdsmi_interface.amdsmi_reset_gpu_xgmi_error(args.gpu)
                     result = "Successfully reset XGMI Error count"
                 except amdsmi_exception.AmdSmiLibraryException as e:
+                    detected_exception = e
                     if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
-                        raise PermissionError("Command requires elevation") from e
+                        self.helpers.raise_permission_exception("Command requires elevation")
                     logging.debug(
                         "Failed to reset xgmi error count on gpu %s | %s",
                         gpu_id,
@@ -329,13 +368,15 @@ class ResetCommands:
                     result = (
                         f"[{e.get_error_info(detailed=False)}] Unable to reset XGMI Error count"
                     )
-                    self.logger.store_output(args.gpu, "reset_xgmi_err", result)
-                    self.logger.print_output()
                     self.logger.clear_multiple_devices_output()
-                    return
                 self.logger.store_output(args.gpu, "reset_xgmi_err", result)
                 self.logger.print_output()
                 self.logger.clear_multiple_devices_output()
+                if detected_exception is not None:
+                    output_format = self.helpers.get_output_format()
+                    raise AmdSmiLibraryErrorException(
+                        output_format, result, detected_exception.get_error_code()
+                    )
                 return
             if args.perf_determinism:
                 try:
@@ -344,7 +385,7 @@ class ResetCommands:
                     result = "Successfully reset Performance Level to default (auto)"
                 except amdsmi_exception.AmdSmiLibraryException as e:
                     if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
-                        raise PermissionError("Command requires elevation") from e
+                        self.helpers.raise_permission_exception("Command requires elevation")
                     logging.debug(
                         "Failed to set perf level on gpu %s | %s", gpu_id, e.get_error_info()
                     )
@@ -366,6 +407,8 @@ class ResetCommands:
                     power_limit_types[key] = "N/A"
                 current_sensor_num = 0
 
+                msgs = []
+                detected_exception = None
                 try:
                     power_cap_types = amdsmi_interface.amdsmi_get_supported_power_cap(args.gpu)
                     for sensor in power_cap_types["sensor_inds"]:
@@ -398,35 +441,46 @@ class ResetCommands:
                             f"Successfully reset power cap to {default_power_cap_in_w}W"
                         )
                 except amdsmi_exception.AmdSmiLibraryException as e:
+                    detected_exception = e
                     if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
-                        raise PermissionError("Command requires elevation") from e
-                    final_output[f"ppt{current_sensor_num}"] = (
-                        f"[{e.get_error_info(detailed=False)}] Unable to reset cap to default power cap"
+                        self.helpers.raise_permission_exception("Command requires elevation")
+                    msgs.append(
+                        f"[{e.get_error_info(detailed=False)}] Unable to reset cap to default power cap."
                     )
+                    final_output[f"ppt{current_sensor_num}"] = msgs[-1]
                 self.logger.store_output(args.gpu, "powercap", final_output)
                 if multiple_devices:
                     self.logger.store_multiple_device_output()
                     return
                 self.logger.print_output()
                 self.logger.clear_multiple_devices_output()
+                if detected_exception is not None:
+                    output_format = self.helpers.get_output_format()
+                    msg = "\n".join(msgs)
+                    raise AmdSmiLibraryErrorException(
+                        output_format, msg, detected_exception.get_error_code()
+                    )
 
         #######################
         # BM commands - END   #
         #######################
 
         if args.clean_local_data:
+            detected_exception = None
             try:
                 amdsmi_interface.amdsmi_clean_gpu_local_data(args.gpu)
                 result = "Successfully clean GPU local data"
             except amdsmi_exception.AmdSmiLibraryException as e:
                 if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
-                    raise PermissionError("Command requires elevation") from e
-                result = f"[{e.get_error_info(detailed=False)}] Unable to clean local data"
-                self.logger.store_output(args.gpu, "clean_local_data", result)
-                self.logger.print_output()
-                self.logger.clear_multiple_devices_output()
-                return
+                    self.helpers.raise_permission_exception("Command requires elevation")
+                detected_exception = e
+                result = f"[{e.get_error_info(detailed=False)}] Unable to clean local data."
             self.logger.store_output(args.gpu, "clean_local_data", result)
             self.logger.print_output()
             self.logger.clear_multiple_devices_output()
+            if detected_exception is not None:
+                output_format = self.helpers.get_output_format()
+                raise AmdSmiLibraryErrorException(
+                    output_format, result, detected_exception.get_error_code()
+                )
             return

--- a/projects/amdsmi/amdsmi_cli/subcommands/set_value.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/set_value.py
@@ -24,8 +24,11 @@ import logging
 import math
 import sys
 
+from amdsmi_cli_exceptions import AmdSmiLibraryErrorException
 from amdsmi_cli_exceptions import AmdSmiRequiredCommandException
-
+from amdsmi_cli_exceptions import AmdSmiInvalidFilePathException
+from amdsmi_cli_exceptions import AmdSmiInvalidParameterException
+from amdsmi_cli_exceptions import AmdSmiInvalidParameterValueException
 from amdsmi import amdsmi_exception, amdsmi_interface
 from amdsmi.amdsmi_interface import AMDSMI_MAX_PPT_LIMIT, AMDSMI_MAX_UTIL
 
@@ -51,7 +54,7 @@ class SetValueCommands:
             core_msr_floor_limit (list, optional): Value override for args.core_msr_floor_limit. Defaults to None.
 
         Raises:
-            ValueError: Value error if no core value is provided
+            AmdSmiRequiredCommandException: if no core value is provided
             IndexError: Index error if core list is empty
 
         Return:
@@ -67,7 +70,8 @@ class SetValueCommands:
             args.core_msr_floor_limit = core_msr_floor_limit
 
         if args.core == None:
-            raise ValueError("No Core provided, specific Core targets(S) are needed")
+            command = " ".join(sys.argv[1:])
+            raise AmdSmiRequiredCommandException(command, self.logger.format)
 
         # Handle multiple cores
         handled_multiple_cores, device_handle = self.helpers.handle_cores(
@@ -88,6 +92,8 @@ class SetValueCommands:
         except IndexError:
             core_id = f"ID Unavailable for {args.core}"
 
+        detected_exception = None
+        msgs = []
         static_dict = {}
         if args.core_boost_limit:
             static_dict["set_core_boost_limit"] = {}
@@ -115,12 +121,14 @@ class SetValueCommands:
                 else:
                     static_dict["set_core_boost_limit"]["Response"] = f"{boost_limit} MHz"
             except amdsmi_exception.AmdSmiLibraryException as e:
+                detected_exception = e
                 static_dict["set_core_boost_limit"]["Response"] = (
                     f"Error occurred for Core {core_id} - {e.get_error_info()}"
                 )
-                logging.debug(
-                    "Failed to set core boost limit for core %s | %s", core_id, e.get_error_info()
+                msgs.append(
+                    f"Failed to set core boost limit for core {core_id} | {e.get_error_info()}"
                 )
+                logging.debug(msgs[-1])
 
         # Set core floor limit
         if args.core_floor_limit:
@@ -156,12 +164,15 @@ class SetValueCommands:
                 else:
                     static_dict["floor_limit"]["Response"] = f"Set, VALUE: {flimit} MHz, successful"
             except amdsmi_exception.AmdSmiLibraryException as e:
+                if detected_exception is None:
+                    detected_exception = e
                 static_dict["floor_limit"]["Response"] = (
                     f"Error occurred for Core {core_id} - {e.get_error_info()}"
                 )
-                logging.debug(
-                    "Failed to set core floor limit for core %s | %s", core_id, e.get_error_info()
+                msgs.append(
+                    f"Failed to set core floor limit for core {core_id} | {e.get_error_info()}"
                 )
+                logging.debug(msgs[-1])
 
         # Set core MSR floor limit
         if args.core_msr_floor_limit:
@@ -202,21 +213,28 @@ class SetValueCommands:
                         f"Set, VALUE: {effflimit} MHz, successful"
                     )
             except amdsmi_exception.AmdSmiLibraryException as e:
+                if detected_exception is None:
+                    detected_exception = e
                 static_dict["msr_floor_limit"]["Response"] = (
                     f"Error occurred for Core {core_id} - {e.get_error_info()}"
                 )
-                logging.debug(
-                    "Failed to set core MSR floor limit for core %s | %s",
-                    core_id,
-                    e.get_error_info(),
+                msgs.append(
+                    f"Failed to set core MSR floor limit for core {core_id} | {e.get_error_info()}"
                 )
+                logging.debug(msgs[-1])
 
         multiple_devices_csv_override = False
         self.logger.store_core_output(args.core, "values", static_dict)
         if multiple_devices:
             self.logger.store_multiple_device_output()
-            return  # Skip printing when there are multiple devices
-        self.logger.print_output(multiple_device_enabled=multiple_devices_csv_override)
+            # Skip printing when there are multiple devices
+        else:
+            self.logger.print_output(multiple_device_enabled=multiple_devices_csv_override)
+        if detected_exception is not None:
+            msg = "\n".join(msgs)
+            error_code = detected_exception.get_error_code()
+            output_format = self.helpers.get_output_format()
+            raise AmdSmiLibraryErrorException(output_format, msg, error_code)
 
     def set_cpu(
         self,
@@ -270,7 +288,7 @@ class SetValueCommands:
             cpu_sdps_limit (int, optional): Value override for args.cpu_sdps_limit. Defaults to None.
 
         Raises:
-            ValueError: Value error if no cpu value is provided
+            AmdSmiRequiredCommandException: if no core value is provided
             IndexError: Index error if cpu list is empty
 
         Return:
@@ -318,7 +336,8 @@ class SetValueCommands:
             args.cpu_sdps_limit = cpu_sdps_limit
 
         if args.cpu == None:
-            raise ValueError("No CPU provided, specific CPU targets(S) are needed")
+            command = " ".join(sys.argv[1:])
+            raise AmdSmiRequiredCommandException(command, self.logger.format)
 
         # Handle multiple CPU's
         handled_multiple_cpus, device_handle = self.helpers.handle_cpus(
@@ -363,6 +382,8 @@ class SetValueCommands:
 
         static_dict = {}
 
+        detected_exception = None
+        msgs = []
         if args.cpu_pwr_limit:
             static_dict["set_pwr_limit"] = {}
             try:
@@ -379,12 +400,12 @@ class SetValueCommands:
                     f"{args.cpu_pwr_limit[0][0] / 1000:.3f} W"
                 )
             except amdsmi_exception.AmdSmiLibraryException as e:
+                detected_exception = e
                 static_dict["set_pwr_limit"]["Response"] = (
                     f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
                 )
-                logging.debug(
-                    "Failed to set power limit for cpu %s | %s", cpu_id, e.get_error_info()
-                )
+                msgs.append(f"Failed to set power limit for cpu {cpu_id} | {e.get_error_info()}")
+                logging.debug(msgs[-1])
 
         if args.cpu_xgmi_link_width:
             static_dict["set_xgmi_link_width"] = {}
@@ -396,12 +417,15 @@ class SetValueCommands:
                     f"{args.cpu_xgmi_link_width[0][0]} - {args.cpu_xgmi_link_width[0][1]}"
                 )
             except amdsmi_exception.AmdSmiLibraryException as e:
+                if detected_exception is None:
+                    detected_exception = e
                 static_dict["set_xgmi_link_width"]["Response"] = (
                     f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
                 )
-                logging.debug(
-                    "Failed to set xgmi link width for cpu %s | %s", cpu_id, e.get_error_info()
+                msgs.append(
+                    f"Failed to set xgmi link width for cpu {cpu_id} | {e.get_error_info()}"
                 )
+                logging.debug(msgs[-1])
 
         if args.cpu_lclk_dpm_level:
             static_dict["set_lclk_dpm_level"] = {}
@@ -416,12 +440,13 @@ class SetValueCommands:
                     f"NBIO[{args.cpu_lclk_dpm_level[0][0]}]"
                 )
             except amdsmi_exception.AmdSmiLibraryException as e:
+                if detected_exception is None:
+                    detected_exception = e
                 static_dict["set_lclk_dpm_level"]["Response"] = (
                     f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
                 )
-                logging.debug(
-                    "Failed to set lclk dpm level for cpu %s | %s", cpu_id, e.get_error_info()
-                )
+                msgs.append(f"Failed to set lclk dpm level for cpu {cpu_id} | {e.get_error_info()}")
+                logging.debug(msgs[-1])
 
         if args.cpu_pwr_eff_mode:
             static_dict["pwr_eff_mode"] = {}
@@ -458,14 +483,15 @@ class SetValueCommands:
                     "Set power efficiency mode operation successful"
                 )
             except amdsmi_exception.AmdSmiLibraryException as e:
+                if detected_exception is None:
+                    detected_exception = e
                 static_dict["pwr_eff_mode"]["response"] = (
                     f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
                 )
-                logging.debug(
-                    "Failed to set power efficiency mode for cpu %s | %s",
-                    cpu_id,
-                    e.get_error_info(),
+                msgs.append(
+                    f"Failed to set power efficiency mode for cpu {cpu_id} | {e.get_error_info()}"
                 )
+                logging.debug(msgs[-1])
 
         if args.cpu_gmi3_link_width:
             static_dict["set_gmi3_link_width"] = {}
@@ -477,12 +503,15 @@ class SetValueCommands:
                     f"{args.cpu_gmi3_link_width[0][0]} - {args.cpu_gmi3_link_width[0][1]}"
                 )
             except amdsmi_exception.AmdSmiLibraryException as e:
+                if detected_exception is None:
+                    detected_exception = e
                 static_dict["set_gmi3_link_width"]["response"] = (
                     f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
                 )
-                logging.debug(
-                    "Failed to set gmi3 link width for cpu %s | %s", cpu_id, e.get_error_info()
+                msgs.append(
+                    f"Failed to set gmi3 link width for cpu {cpu_id} | {e.get_error_info()}"
                 )
+                logging.debug(msgs[-1])
 
         if args.cpu_pcie_link_rate:
             static_dict["set_pcie_link_rate"] = {}
@@ -492,12 +521,13 @@ class SetValueCommands:
                 )
                 static_dict["set_pcie_link_rate"]["prev_mode"] = resp
             except amdsmi_exception.AmdSmiLibraryException as e:
+                if detected_exception is None:
+                    detected_exception = e
                 static_dict["set_pcie_link_rate"]["prev_mode"] = (
                     f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
                 )
-                logging.debug(
-                    "Failed to set pcie link rate for cpu %s | %s", cpu_id, e.get_error_info()
-                )
+                msgs.append(f"Failed to set pcie link rate for cpu {cpu_id} | {e.get_error_info()}")
+                logging.debug(msgs[-1])
 
         if args.cpu_df_pstate_range:
             static_dict["set_df_pstate_range"] = {}
@@ -507,12 +537,15 @@ class SetValueCommands:
                 )
                 static_dict["set_df_pstate_range"]["response"] = "Set Operation successful"
             except amdsmi_exception.AmdSmiLibraryException as e:
+                if detected_exception is None:
+                    detected_exception = e
                 static_dict["set_df_pstate_range"]["response"] = (
                     f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
                 )
-                logging.debug(
-                    "Failed to set df pstate range for cpu %s | %s", cpu_id, e.get_error_info()
+                msgs.append(
+                    f"Failed to set df pstate range for cpu {cpu_id} | {e.get_error_info()}"
                 )
+                logging.debug(msgs[-1])
 
         if args.cpu_enable_apb:
             static_dict["apbenable"] = {}
@@ -522,10 +555,13 @@ class SetValueCommands:
                     "Enabled DF - Pstate performance boost algorithm"
                 )
             except amdsmi_exception.AmdSmiLibraryException as e:
+                if detected_exception is None:
+                    detected_exception = e
                 static_dict["apbenable"]["state"] = (
                     f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
                 )
-                logging.debug("Failed to enable APB for cpu %s | %s", cpu_id, e.get_error_info())
+                msgs.append(f"Failed to enable APB for cpu {cpu_id} | {e.get_error_info()}")
+                logging.debug(msgs[-1])
 
         if args.cpu_disable_apb:
             static_dict["apbdisable"] = {}
@@ -535,10 +571,13 @@ class SetValueCommands:
                     "Disabled DF - Pstate performance boost algorithm"
                 )
             except amdsmi_exception.AmdSmiLibraryException as e:
+                if detected_exception is None:
+                    detected_exception = e
                 static_dict["apbdisable"]["state"] = (
                     f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
                 )
-                logging.debug("Failed to enable APB for cpu %s | %s", cpu_id, e.get_error_info())
+                msgs.append(f"Failed to enable APB for cpu {cpu_id} | {e.get_error_info()}")
+                logging.debug(msgs[-1])
 
         if args.soc_boost_limit:
             static_dict["set_soc_boost_limit"] = {}
@@ -548,13 +587,16 @@ class SetValueCommands:
                 )
                 static_dict["set_soc_boost_limit"]["Response"] = "Set Operation successful"
             except amdsmi_exception.AmdSmiLibraryException as e:
+                if detected_exception is None:
+                    detected_exception = e
                 # static_dict["set_soc_boost_limit"]["Response"] = "N/A"
                 static_dict["set_soc_boost_limit"]["Response"] = (
                     f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
                 )
-                logging.debug(
-                    "Failed to set socket boost limit for cpu %s | %s", cpu_id, e.get_error_info()
+                msgs.append(
+                    f"Failed to set socket boost limit for cpu {cpu_id} | {e.get_error_info()}"
                 )
+                logging.debug(msgs[-1])
 
         if args.cpu_xgmi_pstate_range:
             static_dict["xgmi_pstate_range"] = {}
@@ -566,12 +608,15 @@ class SetValueCommands:
                     f"Set, MIN_PSTATE: {args.cpu_xgmi_pstate_range[0][0]}, MAX_PSTATE: {args.cpu_xgmi_pstate_range[0][1]}, successful"
                 )
             except amdsmi_exception.AmdSmiLibraryException as e:
+                if detected_exception is None:
+                    detected_exception = e
                 static_dict["xgmi_pstate_range"]["response"] = (
                     f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
                 )
-                logging.debug(
-                    "Failed to set xgmi pstate range for cpu %s | %s", cpu_id, e.get_error_info()
+                msgs.append(
+                    f"Failed to set xgmi pstate range for cpu {cpu_id} | {e.get_error_info()}"
                 )
+                logging.debug(msgs[-1])
 
         if args.cpu_railisofreq_policy:
             static_dict["railisofreq_policy"] = {}
@@ -581,12 +626,15 @@ class SetValueCommands:
                 )
                 static_dict["railisofreq_policy"]["response"] = f"Set, VALUE: {resp}, successful"
             except amdsmi_exception.AmdSmiLibraryException as e:
+                if detected_exception is None:
+                    detected_exception = e
                 static_dict["railisofreq_policy"]["response"] = (
                     f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
                 )
-                logging.debug(
-                    "Failed to set ISO frequency policy for cpu %s | %s", cpu_id, e.get_error_info()
+                msgs.append(
+                    f"Failed to set ISO frequency policy for cpu {cpu_id} | {e.get_error_info()}"
                 )
+                logging.debug(msgs[-1])
 
         if args.cpu_dfcstate_ctrl:
             static_dict["dfcstate_ctrl"] = {}
@@ -596,12 +644,15 @@ class SetValueCommands:
                 )
                 static_dict["dfcstate_ctrl"]["response"] = f"Set, VALUE: {resp}, successful"
             except amdsmi_exception.AmdSmiLibraryException as e:
+                if detected_exception is None:
+                    detected_exception = e
                 static_dict["dfcstate_ctrl"]["response"] = (
                     f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
                 )
-                logging.debug(
-                    "Failed to set dfcstate control for cpu %s | %s", cpu_id, e.get_error_info()
+                msgs.append(
+                    f"Failed to set dfcstate control for cpu {cpu_id} | {e.get_error_info()}"
                 )
+                logging.debug(msgs[-1])
 
         if args.cpu_pc6_enable:
             static_dict["pc6_enable"] = {}
@@ -611,12 +662,13 @@ class SetValueCommands:
                     f"Set, VALUE: {args.cpu_pc6_enable[0][0]}, successful"
                 )
             except amdsmi_exception.AmdSmiLibraryException as e:
+                if detected_exception is None:
+                    detected_exception = e
                 static_dict["pc6_enable"]["response"] = (
                     f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
                 )
-                logging.debug(
-                    "Failed to set PC6 enable for cpu %s | %s", cpu_id, e.get_error_info()
-                )
+                msgs.append(f"Failed to set PC6 enable for cpu {cpu_id} | {e.get_error_info()}")
+                logging.debug(msgs[-1])
 
         if args.cpu_cc6_enable:
             static_dict["cc6_enable"] = {}
@@ -626,12 +678,13 @@ class SetValueCommands:
                     f"Set, VALUE: {args.cpu_cc6_enable[0][0]}, successful"
                 )
             except amdsmi_exception.AmdSmiLibraryException as e:
+                if detected_exception is None:
+                    detected_exception = e
                 static_dict["cc6_enable"]["response"] = (
                     f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
                 )
-                logging.debug(
-                    "Failed to set CC6 enable for cpu %s | %s", cpu_id, e.get_error_info()
-                )
+                msgs.append(f"Failed to set CC6 enable for cpu {cpu_id} | {e.get_error_info()}")
+                logging.debug(msgs[-1])
 
         if args.cpu_floor_limit:
             static_dict["floor_limit"] = {}
@@ -666,12 +719,15 @@ class SetValueCommands:
                 else:
                     static_dict["floor_limit"]["Response"] = f"Set, VALUE: {flimit} MHz, successful"
             except amdsmi_exception.AmdSmiLibraryException as e:
+                if detected_exception is None:
+                    detected_exception = e
                 static_dict["floor_limit"]["Response"] = (
                     f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
                 )
-                logging.debug(
-                    "Failed to set socket floor limit for cpu %s | %s", cpu_id, e.get_error_info()
+                msgs.append(
+                    f"Failed to set socket floor limit for cpu {cpu_id} | {e.get_error_info()}"
                 )
+                logging.debug(msgs[-1])
 
         if args.cpu_msr_floor_limit:
             static_dict["msr_floor_limit"] = {}
@@ -710,12 +766,15 @@ class SetValueCommands:
                         f"Set, VALUE: {effflimit} MHz, successful"
                     )
             except amdsmi_exception.AmdSmiLibraryException as e:
+                if detected_exception is None:
+                    detected_exception = e
                 static_dict["msr_floor_limit"]["Response"] = (
                     f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
                 )
-                logging.debug(
-                    "Failed to set CPU MSR floor limit for cpu %s | %s", cpu_id, e.get_error_info()
+                msgs.append(
+                    f"Failed to set CPU MSR floor limit for cpu {cpu_id} | {e.get_error_info()}"
                 )
+                logging.debug(msgs[-1])
 
         if args.cpu_dimm_sb_reg:
             static_dict["dimm_sb_reg"] = {}
@@ -737,14 +796,15 @@ class SetValueCommands:
                     "Set DIMM sideband register write operation successful"
                 )
             except amdsmi_exception.AmdSmiLibraryException as e:
+                if detected_exception is None:
+                    detected_exception = e
                 static_dict["dimm_sb_reg"]["Response"] = (
                     f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
                 )
-                logging.debug(
-                    "Failed to write DIMM sideband register for cpu %s | %s",
-                    cpu_id,
-                    e.get_error_info(),
+                msgs.append(
+                    f"Failed to write DIMM sideband register for cpu {cpu_id} | {e.get_error_info()}"
                 )
+                logging.debug(msgs[-1])
 
         if args.cpu_sdps_limit:
             static_dict["sdps_limit"] = {}
@@ -755,19 +815,28 @@ class SetValueCommands:
                     f"Set, VALUE: {sdps_limit_watts:.3f} W, successful"
                 )
             except amdsmi_exception.AmdSmiLibraryException as e:
+                if detected_exception is None:
+                    detected_exception = e
                 static_dict["sdps_limit"]["Response"] = (
                     f"Error occurred for CPU {cpu_id} - {e.get_error_info()}"
                 )
-                logging.debug(
-                    "Failed to set socket SDPS limit for cpu %s | %s", cpu_id, e.get_error_info()
+                msgs.append(
+                    f"Failed to set socket SDPS limit for cpu {cpu_id} | {e.get_error_info()}"
                 )
+                logging.debug(msgs[-1])
 
         multiple_devices_csv_override = False
         self.logger.store_cpu_output(args.cpu, "values", static_dict)
         if multiple_devices:
             self.logger.store_multiple_device_output()
-            return  # Skip printing when there are multiple devices
-        self.logger.print_output(multiple_device_enabled=multiple_devices_csv_override)
+            # Skip printing when there are multiple devices
+        else:
+            self.logger.print_output(multiple_device_enabled=multiple_devices_csv_override)
+        if detected_exception is not None:
+            msg = "\n".join(msgs)
+            error_code = detected_exception.get_error_code()
+            output_format = self.helpers.get_output_format()
+            raise AmdSmiLibraryErrorException(output_format, msg, error_code)
 
     def set_gpu(
         self,
@@ -811,7 +880,7 @@ class SetValueCommands:
             ptl_format(string, optional): Value override for args.ptl_format. Defaults to None.
             compute_partition_mem_alloc_mode (str, optional): Value override for args.compute_partition_mem_alloc_mode. Defaults to None.
         Raises:
-            ValueError: Value error if no gpu value is provided
+            AmdSmiRequiredCommandException: if no core value is provided
             IndexError: Index error if gpu list is empty
 
         Return:
@@ -918,6 +987,7 @@ class SetValueCommands:
 
         # Handle args
         if self.helpers.is_baremetal():
+            msgs = []
             if isinstance(args.fan, tuple):
                 # Parse input: args.fan is now (value, is_percentage) tuple from parser
                 input_value, is_percentage = args.fan
@@ -944,14 +1014,14 @@ class SetValueCommands:
                     od_min, od_max = self.helpers.parse_gpu_od_fan_range(gpu_od_path)
                     if od_min is None:
                         # Parsing failed - cannot proceed without valid range
-                        result = format_fan_error(
-                            f"Unable to read gpu_od OD_RANGE from {gpu_od_path}. Cannot set fan speed.",
-                            include_driver_note=True,
-                        )
+                        msg = f"Unable to read gpu_od OD_RANGE from {gpu_od_path}. Cannot set fan speed."
+                        result = format_fan_error(msg, include_driver_note=True)
                         self.logger.store_output(args.gpu, "fan", result)
                         self.logger.print_output()
                         self.logger.clear_multiple_devices_output()
-                        return
+                        output_format = self.helpers.get_output_format()
+                        command = sys.argv[1] if len(sys.argv) > 1 else "unknown"
+                        raise AmdSmiInvalidFilePathException(command, output_format, msg)
 
                     od_range = od_max - od_min
                     if is_percentage:
@@ -968,14 +1038,16 @@ class SetValueCommands:
                                 else 0
                             )
                         else:
-                            result = format_fan_error(
-                                f"Invalid fan speed value {input_value} for gpu_od interface. Valid range: {od_min}-{od_max} or use percentage (0-100%)",
-                                include_driver_note=True,
-                            )
+                            msg = f"Invalid fan speed value {input_value} for gpu_od interface. Valid range: {od_min}-{od_max} or use percentage (0-100%)"
+                            result = format_fan_error(msg, include_driver_note=True)
                             self.logger.store_output(args.gpu, "fan", result)
                             self.logger.print_output()
                             self.logger.clear_multiple_devices_output()
-                            return
+                            output_format = self.helpers.get_output_format()
+                            command = sys.argv[1] if len(sys.argv) > 1 else "unknown"
+                            raise AmdSmiInvalidParameterValueException(
+                                command, input_value, output_format, msg
+                            )
                 else:
                     # For legacy hwmon: range 0-255
                     if is_percentage:
@@ -994,42 +1066,46 @@ class SetValueCommands:
                             self.logger.store_output(args.gpu, "fan", result)
                             self.logger.print_output()
                             self.logger.clear_multiple_devices_output()
-                            return
+                            output_format = self.helpers.get_output_format()
+                            command = sys.argv[1] if len(sys.argv) > 1 else "unknown"
+                            raise AmdSmiInvalidParameterValueException(
+                                command, input_value, output_format, result
+                            )
 
+                detected_exception = None
                 try:
                     amdsmi_interface.amdsmi_set_gpu_fan_speed(args.gpu, 0, hw_value)
+                    result = f"Successfully set fan speed to {hw_value} RPM/PWM ({fan_percentage}%)"
                 except amdsmi_exception.AmdSmiLibraryException as e:
                     if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
-                        raise PermissionError("Command requires elevation") from e
+                        self.helpers.raise_permission_exception("Command requires elevation")
+                    detected_exception = e
                     result = format_fan_error(
                         f"[{e.get_error_info(detailed=False)}] Unable to set fan speed to {hw_value} RPM/PWM ({fan_percentage}%)",
                         include_driver_note=has_gpu_od,
                     )
-                    self.logger.store_output(args.gpu, "fan", result)
-                    self.logger.print_output()
-                    self.logger.clear_multiple_devices_output()
-                    return
 
-                self.logger.store_output(
-                    args.gpu,
-                    "fan",
-                    f"Successfully set fan speed to {hw_value} RPM/PWM ({fan_percentage}%)",
-                )
+                self.logger.store_output(args.gpu, "fan", result)
                 self.logger.print_output()
                 self.logger.clear_multiple_devices_output()
+                if detected_exception is not None:
+                    output_format = self.helpers.get_output_format()
+                    raise AmdSmiLibraryErrorException(
+                        output_format, result, detected_exception.get_error_code()
+                    )
                 return
+
             if args.perf_level:
                 perf_level = amdsmi_interface.AmdSmiDevPerfLevel[args.perf_level]
+                detected_exception = None
                 try:
                     amdsmi_interface.amdsmi_set_gpu_perf_level(args.gpu, perf_level)
+                    result = f"Successfully set performance level {args.perf_level}"
                 except amdsmi_exception.AmdSmiLibraryException as e:
                     if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
-                        raise PermissionError("Command requires elevation") from e
-                    self.logger.store_output(
-                        args.gpu,
-                        "perflevel",
-                        f"[{e.get_error_info(detailed=False)}] Unable to set performance level to {args.perf_level}",
-                    )
+                        self.helpers.raise_permission_exception("Command requires elevation")
+                    detected_exception = e
+                    result = f"[{e.get_error_info(detailed=False)}] Unable to set performance level to {args.perf_level}."
                     perf_options = (
                         str(self.helpers.get_perf_levels()[0][0:-1])
                         .replace("[", "")
@@ -1038,16 +1114,17 @@ class SetValueCommands:
                         .replace(" ", "")
                     )
                     print(f"\nPerformance Level Options:\n\t{perf_options}\n")
-                    self.logger.print_output()
-                    self.logger.clear_multiple_devices_output()
-                    return
 
-                self.logger.store_output(
-                    args.gpu, "perflevel", f"Successfully set performance level {args.perf_level}"
-                )
+                self.logger.store_output(args.gpu, "perflevel", result)
                 self.logger.print_output()
                 self.logger.clear_multiple_devices_output()
+                if detected_exception is not None:
+                    output_format = self.helpers.get_output_format()
+                    raise AmdSmiLibraryErrorException(
+                        output_format, result, detected_exception.get_error_code()
+                    )
                 return
+
             if args.profile:
                 try:
                     # Parse profile input (name or number)
@@ -1058,6 +1135,7 @@ class SetValueCommands:
                         profile_mask = name_mapping[profile_input]
                     else:
                         # Invalid profile - show available ones
+                        detected_exception = None
                         try:
                             profile_status = amdsmi_interface.amdsmi_get_gpu_power_profile_presets(
                                 args.gpu, 0
@@ -1067,19 +1145,28 @@ class SetValueCommands:
                             )
                             available_str = ", ".join(available)
                         except amdsmi_exception.AmdSmiLibraryException as e:
+                            detected_exception = e
                             available_str = "Unable to fetch available profiles"
                             logging.debug(
                                 f"Failed to fetch available profiles: {e.get_error_info()}"
                             )
 
-                        self.logger.store_output(
-                            args.gpu,
-                            "profile",
-                            f"Invalid profile: {args.profile}\n\nAvailable profiles: {available_str}",
-                        )
+                        error_msg = f"Invalid profile: {args.profile}\n\nAvailable profiles: {available_str}."
+                        self.logger.store_output(args.gpu, "profile", error_msg)
                         self.logger.print_output()
                         self.logger.clear_multiple_devices_output()
-                        return
+                        output_format = self.helpers.get_output_format()
+                        if detected_exception is not None:
+                            raise AmdSmiLibraryErrorException(
+                                output_format, error_msg, detected_exception.get_error_code()
+                            )
+                        else:
+                            raise AmdSmiInvalidParameterValueException(
+                                sys.argv[1] if len(sys.argv) > 1 else "unknown",
+                                args.profile,
+                                output_format,
+                                hint=error_msg,
+                            )
 
                     # Set the profile
                     amdsmi_interface.amdsmi_set_gpu_power_profile(args.gpu, 0, profile_mask)
@@ -1087,9 +1174,13 @@ class SetValueCommands:
                     self.logger.store_output(
                         args.gpu, "profile", f"Successfully set power profile to {profile_input}"
                     )
+                except AmdSmiInvalidParameterValueException as e:
+                    self.logger.print_output()
+                    self.logger.clear_multiple_devices_output()
+                    raise e
                 except amdsmi_exception.AmdSmiLibraryException as e:
                     if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
-                        raise PermissionError("Command requires elevation") from e
+                        self.helpers.raise_permission_exception("Command requires elevation")
 
                     # Get available profiles for error message
                     try:
@@ -1111,36 +1202,35 @@ class SetValueCommands:
                     print(f"\nAvailable Power Profiles:\n\t{available_str}\n")
                     self.logger.print_output()
                     self.logger.clear_multiple_devices_output()
-                    return
-
+                    output_format = self.helpers.get_output_format()
+                    raise AmdSmiLibraryErrorException(output_format, error_msg, e.get_error_code())
                 self.logger.print_output()
                 self.logger.clear_multiple_devices_output()
                 return
+
             if isinstance(args.perf_determinism, int):
+                detected_exception = None
                 try:
                     amdsmi_interface.amdsmi_set_gpu_perf_determinism_mode(
                         args.gpu, args.perf_determinism
                     )
+                    result = f"Successfully enabled performance determinism and set GFX clock frequency to {args.perf_determinism} MHz"
                 except amdsmi_exception.AmdSmiLibraryException as e:
                     if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
-                        raise PermissionError("Command requires elevation") from e
-                    self.logger.store_output(
-                        args.gpu,
-                        "perfdeterminism",
-                        f"[{e.get_error_info(detailed=False)}] Unable to enable performance determinism and set GFX clock frequency to {args.perf_determinism} MHz",
-                    )
-                    self.logger.print_output()
-                    self.logger.clear_multiple_devices_output()
-                    return
+                        self.helpers.raise_permission_exception("Command requires elevation")
+                    detected_exception = e
+                    result = f"[{e.get_error_info(detailed=False)}] Unable to enable performance determinism and set GFX clock frequency to {args.perf_determinism} MHz"
 
-                self.logger.store_output(
-                    args.gpu,
-                    "perfdeterminism",
-                    f"Successfully enabled performance determinism and set GFX clock frequency to {args.perf_determinism} MHz",
-                )
+                self.logger.store_output(args.gpu, "perfdeterminism", result)
                 self.logger.print_output()
                 self.logger.clear_multiple_devices_output()
+                if detected_exception is not None:
+                    output_format = self.helpers.get_output_format()
+                    raise AmdSmiLibraryErrorException(
+                        output_format, result, detected_exception.get_error_code()
+                    )
                 return
+
             if args.compute_partition:
                 current_set_count = self.helpers.get_set_count()
                 future_set_count = 0
@@ -1176,8 +1266,11 @@ class SetValueCommands:
                             args.gpu, compute_partition
                         )
                     else:
-                        raise ValueError(
-                            f"Invalid accelerator configuration {args.compute_partition} on {gpu_string}"
+                        raise AmdSmiInvalidParameterValueException(
+                            sys.argv[1] if len(sys.argv) > 1 else "unknown",
+                            args.compute_partition,
+                            self.helpers.get_output_format(),
+                            hint="Invalid accelerator configuration",
                         )
                     self.helpers.increment_set_count()
                     future_set_count = self.helpers.get_set_count()
@@ -1189,11 +1282,9 @@ class SetValueCommands:
                         )
                     self.logger.print_output()
                     self.logger.clear_multiple_devices_output()
-                    return
-
                 except amdsmi_exception.AmdSmiLibraryException as e:
                     if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
-                        raise PermissionError("Command requires elevation") from e
+                        self.helpers.raise_permission_exception("Command requires elevation")
                     elif (
                         e.get_error_code()
                         == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NOT_SUPPORTED
@@ -1201,27 +1292,29 @@ class SetValueCommands:
                         self.helpers.increment_set_count()
                         future_set_count = self.helpers.get_set_count()
                         if current_set_count == future_set_count - 1:
-                            out = f"[AMDSMI_STATUS_NOT_SUPPORTED] Unable to set compute partition to {user_requested_partition_args}"
-                            self.logger.store_output(args.gpu, "accelerator_partition", out)
+                            error_msg = f"[AMDSMI_STATUS_NOT_SUPPORTED] Unable to set compute partition, {current_set_count}, to {user_requested_partition_args}."
+                        else:
+                            error_msg = f"[AMDSMI_STATUS_NOT_SUPPORTED] Unable to set compute partition to {user_requested_partition_args}."
                     elif (
                         e.get_error_code()
                         == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_SETTING_UNAVAILABLE
                     ):
                         print(
                             f"\n{attempted_to_set}\n"
-                            f"\n[AMDSMI_STATUS_SETTING_UNAVAILABLE] Please check amd-smi partition --memory --accelerator for available profiles.\n"
+                            "\n[AMDSMI_STATUS_SETTING_UNAVAILABLE] Please check amd-smi partition --memory --accelerator for available profiles.\n"
                             "Users may need to switch memory partition to another mode in order to enable the desired accelerator partition.\n"
                         )
-                        raise ValueError(
-                            f"[AMDSMI_STATUS_SETTING_UNAVAILABLE] Unable to set accelerator partition to {args.compute_partition} on {gpu_string}"
-                        ) from e
+                        error_msg = f"[AMDSMI_STATUS_SETTING_UNAVAILABLE] Unable to set accelerator partition to {args.compute_partition} on {gpu_string}"
                     else:
-                        raise ValueError(
-                            f"Unable to set accelerator partition to {args.compute_partition} on {gpu_string}"
-                        ) from e
+                        error_msg = f"Unable to set accelerator partition to {args.compute_partition} on {gpu_string}"
+
+                    self.logger.store_output(args.gpu, "accelerator_partition", error_msg)
                     self.logger.print_output()
                     self.logger.clear_multiple_devices_output()
-                    return
+                    output_format = self.helpers.get_output_format()
+                    raise AmdSmiLibraryErrorException(output_format, error_msg, e.get_error_code())
+                return
+
             if args.memory_partition:
                 ####################################################################
                 # Get current and available memory partition modes                 #
@@ -1231,6 +1324,8 @@ class SetValueCommands:
                 set_count = self.helpers.get_set_count()
                 if set_count == 1:  # only show reload warning on 1st set
                     self.helpers.confirm_changing_memory_partition_gpu_reload_warning()
+                detected_exception = None
+                msgs = []
                 try:
                     memory_dict = {"caps": "N/A", "current": "N/A"}
                     memory_partition_config = (
@@ -1245,46 +1340,56 @@ class SetValueCommands:
                     )
                     memory_dict["current"] = memory_partition_config["mp_mode"]
                 except amdsmi_exception.AmdSmiLibraryException as e:
-                    logging.debug(
-                        "Failed to get current memory partition for GPU %s | %s",
-                        gpu_id,
-                        e.get_error_info(),
+                    detected_exception = e
+                    msgs.append(
+                        f"Failed to get current memory partition for GPU {gpu_id} | {e.get_error_info()}"
                     )
+                    logging.debug(msgs[-1])
+
                 try:
                     memory_partition = amdsmi_interface.AmdSmiMemoryPartitionType[
                         args.memory_partition
                     ]
                     amdsmi_interface.amdsmi_set_gpu_memory_partition(args.gpu, memory_partition)
-                    out = f"Successfully set memory partition to {args.memory_partition}, use `sudo modprobe -r amdgpu && sudo modprobe amdgpu` to reload driver"
+                    result = f"Successfully set memory partition to {args.memory_partition}, use `sudo modprobe -r amdgpu && sudo modprobe amdgpu` to reload driver"
                 except amdsmi_exception.AmdSmiLibraryException as e:
-                    out = f"[{e.get_error_info(detailed=False)}] Unable to set memory partition to {args.memory_partition}"
+                    if detected_exception is None:
+                        detected_exception = e
+                    msgs.append(
+                        f"[{e.get_error_info(detailed=False)}] Unable to set memory partition to {args.memory_partition}"
+                    )
                     if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
-                        out = "[AMDSMI_STATUS_NO_PERM] Command requires elevation"
-                        self.logger.store_output(args.gpu, "memory_partition", out)
+                        result = "[AMDSMI_STATUS_NO_PERM] Command requires elevation"
+                        self.logger.store_output(args.gpu, "memory_partition", result)
                         self.logger.print_output()
                         self.logger.clear_multiple_devices_output()
-                        raise PermissionError("Command requires elevation") from e
+                        self.helpers.raise_permission_exception("Command requires elevation")
                     elif e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_INVAL:
+                        detected_exception = e
                         print(f"Valid Memory partition Modes: {memory_dict['caps']}\n")
-                        self.logger.store_output(args.gpu, "memory_partition", out)
-                        self.logger.print_output()
-                        self.logger.clear_multiple_devices_output()
-                        return
+                        result = "[AMDSMI_STATUS_INVAL] Invalid parameter"
                     else:
-                        self.logger.store_output(args.gpu, "memory_partition", out)
-                        self.logger.print_output()
-                        self.logger.clear_multiple_devices_output()
-                        return
-                self.logger.store_output(args.gpu, "memory_partition", out)
+                        detected_exception = e
+                        result = msgs[-1]
+                self.logger.store_output(args.gpu, "memory_partition", result)
                 self.logger.print_output()
                 self.logger.clear_multiple_devices_output()
+                if detected_exception is not None:
+                    msg = "\n".join(msgs)
+                    error_code = detected_exception.get_error_code()
+                    output_format = self.helpers.get_output_format()
+                    raise AmdSmiLibraryErrorException(output_format, msg, error_code)
                 return
+
             if isinstance(args.soc_pstate, int):
+                detected_exception = None
                 try:
                     amdsmi_interface.amdsmi_set_soc_pstate(args.gpu, args.soc_pstate)
+                    result = f"Successfully set soc pstate dpm policy to {args.soc_pstate}"
                 except amdsmi_exception.AmdSmiLibraryException as e:
                     if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
-                        raise PermissionError("Command requires elevation") from e
+                        self.helpers.raise_permission_exception("Command requires elevation")
+                    detected_exception = e
                     if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_INVAL:
                         soc_pstate_info = amdsmi_interface.amdsmi_get_soc_pstate(args.gpu)
                         policy_string = "N/A"
@@ -1299,28 +1404,27 @@ class SetValueCommands:
                                 ", "
                             )  # Remove trailing comma and space
                         print(f"Valid SOC P-State Policies: [{policy_string}]\n")
-                    self.logger.store_output(
-                        args.gpu,
-                        "socpstate",
-                        f"[{e.get_error_info(detailed=False)}] Unable to set soc pstate dpm policy to {args.soc_pstate}",
-                    )
-                    self.logger.print_output()
-                    self.logger.clear_multiple_devices_output()
-                    return
-                self.logger.store_output(
-                    args.gpu,
-                    "socpstate",
-                    f"Successfully set soc pstate dpm policy to {args.soc_pstate}",
-                )
+
+                    result = f"[{e.get_error_info(detailed=False)}] Unable to set soc pstate dpm policy to {args.soc_pstate}"
+                self.logger.store_output(args.gpu, "socpstate", result)
                 self.logger.print_output()
                 self.logger.clear_multiple_devices_output()
+                if detected_exception is not None:
+                    output_format = self.helpers.get_output_format()
+                    raise AmdSmiLibraryErrorException(
+                        output_format, result, detected_exception.get_error_code()
+                    )
                 return
+
             if isinstance(args.xgmi_plpd, int):
+                detected_exception = None
                 try:
                     amdsmi_interface.amdsmi_set_xgmi_plpd(args.gpu, args.xgmi_plpd)
+                    result = f"Successfully set XGMI per-link power down policy to {args.xgmi_plpd}"
                 except amdsmi_exception.AmdSmiLibraryException as e:
                     if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
-                        raise PermissionError("Command requires elevation") from e
+                        self.helpers.raise_permission_exception("Command requires elevation")
+                    detected_exception = e
                     if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_INVAL:
                         xgmi_plpd_info = amdsmi_interface.amdsmi_get_xgmi_plpd(args.gpu)
                         policy_string = "N/A"
@@ -1335,22 +1439,17 @@ class SetValueCommands:
                                 ", "
                             )  # Remove trailing comma and space
                         print(f"Valid XGMI PLPD Policies: [{policy_string}]\n")
-                    self.logger.store_output(
-                        args.gpu,
-                        "xgmiplpd",
-                        f"[{e.get_error_info(detailed=False)}] Unable to set XGMI per-link power down policy to {args.xgmi_plpd}",
-                    )
-                    self.logger.print_output()
-                    self.logger.clear_multiple_devices_output()
-                    return
-                self.logger.store_output(
-                    args.gpu,
-                    "xgmiplpd",
-                    f"Successfully set XGMI per-link power down policy to {args.xgmi_plpd}",
-                )
+                    result = f"[{e.get_error_info(detailed=False)}] Unable to set XGMI per-link power down policy to {args.xgmi_plpd}"
+                self.logger.store_output(args.gpu, "xgmiplpd", result)
                 self.logger.print_output()
                 self.logger.clear_multiple_devices_output()
+                if detected_exception is not None:
+                    output_format = self.helpers.get_output_format()
+                    raise AmdSmiLibraryErrorException(
+                        output_format, result, detected_exception.get_error_code()
+                    )
                 return
+
             if isinstance(args.clk_level, tuple):
                 clk_type = args.clk_level.clk_type
                 perf_levels = args.clk_level.perf_levels
@@ -1368,11 +1467,14 @@ class SetValueCommands:
                     "set_clock": f"Unable to set {clk_type} perf level(s) to {perf_levels_str}",
                 }
                 if clk_type not in smi_clk_type_mapping:
-                    raise ValueError(
-                        f"Invalid clock type {clk_type}. Valid options are: {', '.join(smi_clk_type_mapping.keys())}"
-                    )
+                    error_msg = f"Invalid clock type {clk_type}. Valid options are: {', '.join(smi_clk_type_mapping.keys())}."
+                    output_format = self.helpers.get_output_format()
+                    raise AmdSmiInvalidParameterException(
+                        "set", None, output_format, error_msg
+                    )  # clk type given is bad
 
                 # Set perf level to manual if not already set
+                detected_exception = None
                 try:
                     amdsmi_interface.amdsmi_set_gpu_perf_level(
                         args.gpu, amdsmi_interface.AmdSmiDevPerfLevel.MANUAL
@@ -1380,17 +1482,25 @@ class SetValueCommands:
                     results_clk_lvl["perf_level"] = "Successfully set performance level to MANUAL"
                 except amdsmi_exception.AmdSmiLibraryException as e:
                     if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
-                        raise PermissionError("Command requires elevation") from e
+                        self.helpers.raise_permission_exception("Command requires elevation")
+                    detected_exception = e
                     results_clk_lvl["perf_level"] = (
                         f"[{e.get_error_info(detailed=False)}] Unable to set performance level to MANUAL"
                     )
-                    self.logger.store_output(args.gpu, "clk_level", results_clk_lvl)
-                    self.logger.print_output()
-                    self.logger.clear_multiple_devices_output()
-                    return
+                self.logger.store_output(args.gpu, "clk_level", results_clk_lvl)
+                self.logger.print_output()
+                self.logger.clear_multiple_devices_output()
+                if detected_exception is not None:
+                    output_format = self.helpers.get_output_format()
+                    raise AmdSmiLibraryErrorException(
+                        output_format,
+                        results_clk_lvl["perf_level"],
+                        detected_exception.get_error_code(),
+                    )
 
                 if clk_type.lower() == "pcie":
                     # Get PCIe bandwidth levels
+                    detected_exception = None
                     try:
                         pcie_bandwidth_levels = amdsmi_interface.amdsmi_get_gpu_pci_bandwidth(
                             args.gpu
@@ -1400,15 +1510,23 @@ class SetValueCommands:
                             f"Successfully retrieved {clk_type} frequency levels"
                         )
                     except amdsmi_exception.AmdSmiLibraryException as e:
+                        detected_exception = e
                         results_clk_lvl["get_clock_freq"] = (
                             f"[{e.get_error_info(detailed=False)}] Unable to retrieve {clk_type} frequency levels"
                         )
-                        self.logger.store_output(args.gpu, "clk_level", results_clk_lvl)
-                        self.logger.print_output()
-                        self.logger.clear_multiple_devices_output()
-                        return
+                    self.logger.store_output(args.gpu, "clk_level", results_clk_lvl)
+                    self.logger.print_output()
+                    self.logger.clear_multiple_devices_output()
+                    if detected_exception is not None:
+                        output_format = self.helpers.get_output_format()
+                        raise AmdSmiLibraryErrorException(
+                            output_format,
+                            results_clk_lvl["get_clock_freq"],
+                            detected_exception.get_error_code(),
+                        )
                 else:
                     # Get clock frequency levels
+                    detected_exception = None
                     try:
                         frequencies = amdsmi_interface.amdsmi_get_clk_freq(
                             args.gpu, smi_clk_type_mapping[clk_type]
@@ -1418,13 +1536,20 @@ class SetValueCommands:
                             f"Successfully retrieved {clk_type} frequency levels"
                         )
                     except amdsmi_exception.AmdSmiLibraryException as e:
+                        detected_exception = e
                         results_clk_lvl["get_clock_freq"] = (
                             f"[{e.get_error_info(detailed=False)}] Unable to retrieve {clk_type} frequency levels"
                         )
-                        self.logger.store_output(args.gpu, "clk_level", results_clk_lvl)
-                        self.logger.print_output()
-                        self.logger.clear_multiple_devices_output()
-                        return
+                    self.logger.store_output(args.gpu, "clk_level", results_clk_lvl)
+                    self.logger.print_output()
+                    self.logger.clear_multiple_devices_output()
+                    if detected_exception is not None:
+                        output_format = self.helpers.get_output_format()
+                        raise AmdSmiLibraryErrorException(
+                            output_format,
+                            results_clk_lvl["get_clock_freq"],
+                            detected_exception.get_error_code(),
+                        )
 
                 # Validate bandwidth bitmask
                 freq_bitmask = 0
@@ -1448,12 +1573,18 @@ class SetValueCommands:
                     self.logger.store_output(args.gpu, "clk_level", results_clk_lvl)
                     self.logger.print_output()
                     self.logger.clear_multiple_devices_output()
-                    return
+                    raise AmdSmiInvalidParameterValueException(
+                        sys.argv[1] if len(sys.argv) > 1 else "unknown",
+                        None,
+                        self.helpers.get_output_format(),
+                        hint=results_clk_lvl["set_clock"],
+                    )
                 else:
                     # Proceed with freq_bitmask
                     pass
 
                 if clk_type.lower() == "pcie":
+                    detected_exception = None
                     try:
                         amdsmi_interface.amdsmi_set_gpu_pci_bandwidth(args.gpu, freq_bitmask)
                         results_clk_lvl["set_clock"] = (
@@ -1464,15 +1595,22 @@ class SetValueCommands:
                             e.get_error_code()
                             == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM
                         ):
-                            raise PermissionError("Command requires elevation") from e
+                            self.helpers.raise_permission_exception("Command requires elevation")
+                        detected_exception = e
 
                         results_clk_lvl["set_clock"] = (
                             f"[{e.get_error_info(detailed=False)}] Unable to set {clk_type} perf level(s) to {perf_levels_str}"
                         )
-                        self.logger.store_output(args.gpu, "clk_level", results_clk_lvl)
-                        self.logger.print_output()
-                        self.logger.clear_multiple_devices_output()
-                        return
+                    self.logger.store_output(args.gpu, "clk_level", results_clk_lvl)
+                    self.logger.print_output()
+                    self.logger.clear_multiple_devices_output()
+                    if detected_exception is not None:
+                        output_format = self.helpers.get_output_format()
+                        raise AmdSmiLibraryErrorException(
+                            output_format,
+                            results_clk_lvl["set_clock"],
+                            detected_exception.get_error_code(),
+                        )
                 else:
                     # For non-pcie clocks
                     if clk_type in self.helpers.convert_clock_type:
@@ -1480,6 +1618,7 @@ class SetValueCommands:
                     else:
                         clk_type_conversion = "N/A"
 
+                    detected_exception = None
                     try:
                         amdsmi_interface.amdsmi_set_clk_freq(args.gpu, clk_type, freq_bitmask)
                         results_clk_lvl["set_clock"] = (
@@ -1490,44 +1629,51 @@ class SetValueCommands:
                             e.get_error_code()
                             == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM
                         ):
-                            raise PermissionError("Command requires elevation") from e
+                            self.helpers.raise_permission_exception("Command requires elevation")
+                        detected_exception = e
                         results_clk_lvl["set_clock"] = (
                             f"[{e.get_error_info(detailed=False)}] Unable to set {clk_type} perf level(s) to {perf_levels_str}"
                         )
-                        self.logger.store_output(args.gpu, "clk_level", results_clk_lvl)
-                        self.logger.print_output()
-                        self.logger.clear_multiple_devices_output()
-                        return
-                self.logger.store_output(args.gpu, "clk_level", results_clk_lvl)
-                self.logger.print_output()
-                self.logger.clear_multiple_devices_output()
+                    self.logger.store_output(args.gpu, "clk_level", results_clk_lvl)
+                    self.logger.print_output()
+                    self.logger.clear_multiple_devices_output()
+                    if detected_exception is not None:
+                        output_format = self.helpers.get_output_format()
+                        raise AmdSmiLibraryErrorException(
+                            output_format,
+                            results_clk_lvl["set_clock"],
+                            detected_exception.get_error_code(),
+                        )
                 return
+
             if isinstance(args.ptl_status, int):
                 status_string = "Enabled" if args.ptl_status else "Disabled"
                 result = f"Requested PTL status to {status_string}"  # This should not print out
+                detected_exception = None
                 try:  # Due to driver requirements, do NOT check current state. Set state regardless of current state.
                     amdsmi_interface.amdsmi_set_gpu_ptl_state(args.gpu, args.ptl_status)
                     result = f"Successfully set PTL state to {status_string}"
                 except amdsmi_exception.AmdSmiLibraryException as e:
                     if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
-                        raise PermissionError("Command requires elevation") from e
-                    self.logger.store_output(
-                        args.gpu,
-                        "ptlstatus",
-                        f"[{e.get_error_info(detailed=False)}] Unable to set ptl status to {args.ptl_status}",
-                    )
-                    self.logger.print_output()
-                    self.logger.clear_multiple_devices_output()
-                    return
+                        self.helpers.raise_permission_exception("Command requires elevation")
+                    detected_exception = e
+                    result = f"[{e.get_error_info(detailed=False)}] Unable to set ptl status to {args.ptl_status}"
                 self.logger.store_output(args.gpu, "ptlstatus", result)
                 self.logger.print_output()
                 self.logger.clear_multiple_devices_output()
+                if detected_exception is not None:
+                    output_format = self.helpers.get_output_format()
+                    raise AmdSmiLibraryErrorException(
+                        output_format, result, detected_exception.get_error_code()
+                    )
                 return
+
             if isinstance(args.ptl_format, tuple):
                 requested_fmt1_enum, requested_fmt2_enum = args.ptl_format
                 requested_str = f"{requested_fmt1_enum.name},{requested_fmt2_enum.name}"
 
                 result = f"Requested PTL status to {requested_str}"  # This should not print out
+                detected_exception = None
                 try:
                     # Get current formats as ints
                     cur1_code, cur2_code = amdsmi_interface.amdsmi_get_gpu_ptl_formats(args.gpu)
@@ -1543,18 +1689,17 @@ class SetValueCommands:
                         result = f"Successfully set PTL format to {requested_str}"
                 except amdsmi_exception.AmdSmiLibraryException as e:
                     if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
-                        raise PermissionError("Command requires elevation") from e
-                    self.logger.store_output(
-                        args.gpu,
-                        "ptlformat",
-                        f"[{e.get_error_info(detailed=False)}] Unable to set PTL format to {requested_str}",
-                    )
-                    self.logger.print_output()
-                    self.logger.clear_multiple_devices_output()
-                    return
+                        self.helpers.raise_permission_exception("Command requires elevation")
+                    detected_exception = e
+                    result = f"[{e.get_error_info(detailed=False)}] Unable to set PTL format to {requested_str}"
                 self.logger.store_output(args.gpu, "ptlformat", result)
                 self.logger.print_output()
                 self.logger.clear_multiple_devices_output()
+                if detected_exception is not None:
+                    output_format = self.helpers.get_output_format()
+                    raise AmdSmiLibraryErrorException(
+                        output_format, result, detected_exception.get_error_code()
+                    )
                 return
 
         # Universal args
@@ -1581,6 +1726,7 @@ class SetValueCommands:
             self.logger.print_output()
             self.logger.clear_multiple_devices_output()
             return
+
         if isinstance(args.clk_limit, tuple):
             clk_type = args.clk_limit.clk_type
             lim_type = args.clk_limit.lim_type
@@ -1598,66 +1744,62 @@ class SetValueCommands:
                     amdsmi_clk_type = amdsmi_interface.AmdSmiClkType.DF
                 else:
                     print("Valid clock types are: sclk, mclk, fclk\n")
-                    self.logger.store_output(
-                        args.gpu, "clk_limit", f"Invalid clock type {args.clk_limit.clk_type}"
-                    )
+                    error_msg = f"Invalid clock type {args.clk_limit.clk_type}."
+                    self.logger.store_output(args.gpu, "clk_limit", error_msg)
                     self.logger.print_output()
                     self.logger.clear_multiple_devices_output()
-                    return
+                    output_format = self.helpers.get_output_format()
+                    raise AmdSmiInvalidParameterException(
+                        "set", None, output_format, error_msg
+                    )  # clk type given is bad
                 clk_tuple = amdsmi_interface.amdsmi_get_clock_info(args.gpu, amdsmi_clk_type)
 
                 if lim_type == "min":
                     amdsmi_lim_type = amdsmi_interface.AmdSmiClkLimitType.MIN
                     if isinstance(clk_tuple["max_clk"], int) and val > clk_tuple["max_clk"]:
-                        self.logger.store_output(
-                            args.gpu,
-                            "clk_limit",
-                            f"Cannot set {args.clk_limit.clk_type} min value greater than max ({clk_tuple['max_clk']}MHz)",
-                        )
+                        error_msg = f"Cannot set {args.clk_limit.clk_type} min value greater than max ({clk_tuple['max_clk']}MHz)"
+                        self.logger.store_output(args.gpu, "clk_limit", error_msg)
                         self.logger.print_output()
                         self.logger.clear_multiple_devices_output()
-                        return
+                        output_format = self.helpers.get_output_format()
+                        raise AmdSmiInvalidParameterException(
+                            "set", None, output_format, error_msg
+                        )  # clk limit given is bad
 
                     if val == clk_tuple["min_clk"]:
                         val_changed = False  # Clock limit value did not changed
                 elif lim_type == "max":
                     amdsmi_lim_type = amdsmi_interface.AmdSmiClkLimitType.MAX
                     if isinstance(clk_tuple["min_clk"], int) and val < clk_tuple["min_clk"]:
-                        self.logger.store_output(
-                            args.gpu,
-                            "clk_limit",
-                            f"Cannot set {args.clk_limit.clk_type} max value less than min ({clk_tuple['min_clk']}MHz)",
-                        )
+                        error_msg = f"Cannot set {args.clk_limit.clk_type} max value less than min ({clk_tuple['min_clk']}MHz)"
+                        self.logger.store_output(args.gpu, "clk_limit", error_msg)
                         self.logger.print_output()
                         self.logger.clear_multiple_devices_output()
-                        return
+                        output_format = self.helpers.get_output_format()
+                        raise AmdSmiInvalidParameterException(
+                            "set", None, output_format, error_msg
+                        )  # clk limit given is bad
                     if val == clk_tuple["max_clk"]:
                         val_changed = False  # Clock limit value did not changed
             except amdsmi_exception.AmdSmiLibraryException as e:
+                output_format = self.helpers.get_output_format()
                 if (
                     e.get_error_code()
                     == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NOT_SUPPORTED
                     and lim_type == "min"
                     and clk_type == "mclk"
                 ):
-                    logging.debug("Setting mclk min is not supported")
-                    self.logger.store_output(
-                        args.gpu, "clk_limit", "Setting mclk min is not supported"
-                    )
+                    error_msg = "Setting mclk min is not supported."
+                    logging.debug(error_msg)
                 else:
                     logging.debug(
-                        "Failed to get clock extremum info for gpu %s | %s",
-                        gpu_id,
-                        e.get_error_info(),
+                        f"Failed to get clock extremum info for gpu {gpu_id} | {e.get_error_info()}"
                     )
-                    self.logger.store_output(
-                        args.gpu,
-                        "clk_limit",
-                        f"[{e.get_error_info(detailed=False)}] Unable to change {args.clk_limit.lim_type} of {args.clk_limit.clk_type} to {args.clk_limit.val}MHz",
-                    )
+                    error_msg = f"[{e.get_error_info(detailed=False)}] Unable to change {args.clk_limit.lim_type} of {args.clk_limit.clk_type} to {args.clk_limit.val} MHz"
+                self.logger.store_output(args.gpu, "clk_limit", error_msg)
                 self.logger.print_output()
                 self.logger.clear_multiple_devices_output()
-                return
+                raise AmdSmiLibraryErrorException(output_format, error_msg, e.get_error_code())
 
             # Set the value
             try:
@@ -1665,43 +1807,42 @@ class SetValueCommands:
                     amdsmi_interface.amdsmi_set_gpu_clk_limit(args.gpu, clk_type, lim_type, val)
             except amdsmi_exception.AmdSmiLibraryException as e:
                 if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
-                    raise PermissionError("Command requires elevation") from e
+                    self.helpers.raise_permission_exception("Command requires elevation")
                 elif (
                     e.get_error_code()
                     == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NOT_SUPPORTED
                     and lim_type == "min"
                     and clk_type == "mclk"
                 ):
-                    logging.debug("Setting mclk min is not supported")
-                    self.logger.store_output(
-                        args.gpu, "clk_limit", "Setting mclk min is not supported"
-                    )
+                    error_msg = "Setting mclk min is not supported."
+                    logging.debug(error_msg)
+                    self.logger.store_output(args.gpu, "clk_limit", error_msg)
                 else:
-                    self.logger.store_output(
-                        args.gpu,
-                        "clk_limit",
-                        f"[{e.get_error_info(detailed=False)}] Unable to set {args.clk_limit.lim_type} of {args.clk_limit.clk_type} to {args.clk_limit.val}MHz",
-                    )
+                    error_msg = f"[{e.get_error_info(detailed=False)}] Unable to set {args.clk_limit.lim_type} of {args.clk_limit.clk_type} to {args.clk_limit.val} MHz"
+                    self.logger.store_output(args.gpu, "clk_limit", error_msg)
                 self.logger.print_output()
                 self.logger.clear_multiple_devices_output()
-                return
+                output_format = self.helpers.get_output_format()
+                raise AmdSmiLibraryErrorException(output_format, error_msg, e.get_error_code())
 
             if val_changed:
                 self.logger.store_output(
                     args.gpu,
                     "clk_limit",
-                    f"Successfully changed {args.clk_limit.lim_type} of {args.clk_limit.clk_type} to {args.clk_limit.val}MHz",
+                    f"Successfully changed {args.clk_limit.lim_type} of {args.clk_limit.clk_type} to {args.clk_limit.val} MHz",
                 )
             else:
                 self.logger.store_output(
-                    args.gpu, "clk_limit", f"Clock limit is already set to {args.clk_limit.val}MHz"
+                    args.gpu, "clk_limit", f"Clock limit is already set to {args.clk_limit.val} MHz"
                 )
             self.logger.print_output()
             self.logger.clear_multiple_devices_output()
             return
+
         if isinstance(args.process_isolation, int):
             status_string = "Enabled" if args.process_isolation else "Disabled"
             result = f"Requested process isolation to {status_string}"  # This should not print out
+            detected_exception = None
             try:
                 current_status = amdsmi_interface.amdsmi_get_gpu_process_isolation(args.gpu)
                 if current_status == args.process_isolation:
@@ -1713,27 +1854,26 @@ class SetValueCommands:
                     result = f"Successfully set process isolation to {status_string}"
             except amdsmi_exception.AmdSmiLibraryException as e:
                 if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
-                    raise PermissionError("Command requires elevation") from e
-                self.logger.store_output(
-                    args.gpu,
-                    "process_isolation",
-                    f"[{e.get_error_info(detailed=False)}] Unable to set process isolation to {status_string}",
-                )
-                self.logger.print_output()
-                self.logger.clear_multiple_devices_output()
-                return
+                    self.helpers.raise_permission_exception("Command requires elevation")
+                detected_exception = e
+                result = f"[{e.get_error_info(detailed=False)}] Unable to set process isolation to {status_string}"
 
             self.logger.store_output(args.gpu, "process_isolation", result)
             self.logger.print_output()
             self.logger.clear_multiple_devices_output()
+            if detected_exception is not None:
+                output_format = self.helpers.get_output_format()
+                raise AmdSmiLibraryErrorException(
+                    output_format, result, detected_exception.get_error_code()
+                )
             return
 
         if args.mem_carveout is not None:
             # Validate single GPU (VRAM is per-GPU)
             if isinstance(args.gpu, list) and len(args.gpu) > 1:
-                raise ValueError(
-                    "VRAM carveout can only be set for a single GPU. Please specify --gpu <id>"
-                )
+                msg = "VRAM carveout can only be set for a single GPU. Please specify --gpu <id>"
+                output_format = self.helpers.get_output_format()
+                raise AmdSmiInvalidParameterException("set", None, output_format, msg)
 
             try:
                 uma_info = amdsmi_interface.amdsmi_get_gpu_uma_carveout_info(args.gpu)
@@ -1742,14 +1882,18 @@ class SetValueCommands:
 
                 # Validate index
                 if args.mem_carveout >= len(options):
-                    self.logger.store_output(
-                        args.gpu,
-                        "mem_carveout",
-                        f"Invalid index {args.mem_carveout}. Valid range: 0-{len(options) - 1}",
+                    error_msg = (
+                        f"Invalid index {args.mem_carveout}. Valid range: 0-{len(options) - 1}."
                     )
+                    self.logger.store_output(args.gpu, "mem_carveout", error_msg)
                     self.logger.print_output()
                     self.logger.clear_multiple_devices_output()
-                    return
+                    raise AmdSmiInvalidParameterValueException(
+                        sys.argv[1] if len(sys.argv) > 1 else "unknown",
+                        None,
+                        self.helpers.get_output_format(),
+                        hint=error_msg,
+                    )
 
                 # Check if already set
                 if args.mem_carveout == current_index:
@@ -1778,7 +1922,7 @@ class SetValueCommands:
 
             except amdsmi_exception.AmdSmiLibraryException as e:
                 if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
-                    raise PermissionError("Command requires elevation") from e
+                    self.helpers.raise_permission_exception("Command requires elevation")
                 if (
                     e.get_error_code()
                     == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NOT_SUPPORTED
@@ -1786,19 +1930,14 @@ class SetValueCommands:
                     # Surface an actionable message instead of a raw error code.
                     # Avoid naming specific products here so the message does not
                     # age as new ASICs add or drop UMA carveout support.
-                    self.logger.store_output(
-                        args.gpu,
-                        "mem_carveout",
-                        "Not supported: UMA carveout is only available on APUs whose"
-                        ' VBIOS exposes the ATCS "Set UMA Allocation Size" function.',
-                    )
+                    error_msg = 'Not supported: UMA carveout is only available on APUs whose VBIOS exposes the ATCS "Set UMA Allocation Size" function.'
                 else:
-                    self.logger.store_output(
-                        args.gpu,
-                        "mem_carveout",
-                        f"[{e.get_error_info(detailed=False)}] Unable to set VRAM carveout to index {args.mem_carveout}",
-                    )
+                    error_msg = f"[{e.get_error_info(detailed=False)}] Unable to set VRAM carveout to index {args.mem_carveout}"
+                self.logger.store_output(args.gpu, "mem_carveout", error_msg)
                 self.logger.print_output()
+                self.logger.clear_multiple_devices_output()
+                output_format = self.helpers.get_output_format()
+                raise AmdSmiLibraryErrorException(output_format, error_msg, e.get_error_code())
 
             self.logger.clear_multiple_devices_output()
             return
@@ -1826,7 +1965,7 @@ class SetValueCommands:
                     self.logger.store_output(args.gpu, "compute_partition_mem_alloc_mode", out)
                     self.logger.print_output()
                     self.logger.clear_multiple_devices_output()
-                    raise PermissionError("Command requires elevation") from e
+                    self.helpers.raise_permission_exception("Command requires elevation")
                 else:
                     self.logger.store_output(args.gpu, "compute_partition_mem_alloc_mode", out)
                     self.logger.print_output()
@@ -1926,14 +2065,14 @@ class SetValueCommands:
             xgmi_plpd (int, optional): Value override for args.xgmi_plpd. Defaults to None.
             process_isolation (int, optional): Value override for args.process_isolation. Defaults to None.
         Raises:
-            ValueError: Value error if no gpu value is provided
+            AmdSmiInvalidParameterValueException: if no value is provided
             IndexError: Index error if gpu list is empty
 
         Return:
             Nothing
         """
         # These are the only args checked at this point, the other args will be passed
-        #   in through the applicable function set_gpu, set_cpu, or set_core function
+        # in through the applicable function set_gpu, set_cpu, or set_core function
         if gpu:
             args.gpu = gpu
         if cpu:
@@ -1944,12 +2083,12 @@ class SetValueCommands:
         # Special GTT handling (system-wide, not per-GPU) — handle before device dispatch
         if hasattr(args, "gtt") and args.gtt is not None:
             if hasattr(args, "gpu") and args.gpu is not None:
-                print(
+                msg = (
                     "amd-smi set: error: argument --gtt/-G: not allowed with argument --gpu/-g "
-                    "(--gtt is a system-wide setting, not per-GPU)",
-                    file=sys.stderr,
+                    "(--gtt is a system-wide setting, not per-GPU)"
                 )
-                sys.exit(2)
+                output_format = self.helpers.get_output_format()
+                raise AmdSmiInvalidParameterException("set", None, output_format, msg)
             gb_value = args.gtt
             pages = self.helpers.gb_to_pages(gb_value)
             try:
@@ -1964,12 +2103,14 @@ class SetValueCommands:
                 return
             except amdsmi_exception.AmdSmiLibraryException as e:
                 if e.get_error_code() == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NO_PERM:
-                    raise PermissionError("Command requires elevation") from e
-                self.logger.output["set_gtt"] = (
+                    self.helpers.raise_permission_exception("Command requires elevation")
+                error_msg = (
                     f"[{e.get_error_info(detailed=False)}] Unable to set GTT to {gb_value:.2f} GB"
                 )
+                self.logger.output["set_gtt"] = error_msg
                 self.logger.print_output()
-                return
+                output_format = self.helpers.get_output_format()
+                raise AmdSmiLibraryErrorException(output_format, error_msg, e.get_error_code())
 
         # Check if a GPU argument has been set
         gpu_args_enabled = False
@@ -2121,13 +2262,17 @@ class SetValueCommands:
 
         # Only allow one device's arguments to be set at a time
         if not any([gpu_args_enabled, cpu_args_enabled, core_args_enabled]):
-            raise ValueError(
-                "No GPU, CPU, or CORE arguments provided, specific arguments are needed"
-            )
+            msg = "No GPU, CPU, or CORE arguments provided, specific arguments are needed"
+            command = " ".join(sys.argv[1:])
+            raise AmdSmiRequiredCommandException(command, self.logger.format, msg)
         elif all([gpu_args_enabled, cpu_args_enabled, core_args_enabled]):
-            raise ValueError("Cannot set GPU, CPU, and CORE arguments at the same time")
+            msg = "Cannot set GPU, CPU, and CORE arguments at the same time"
+            command = " ".join(sys.argv[1:])
+            raise AmdSmiRequiredCommandException(command, self.logger.format, msg)
         elif not (gpu_args_enabled ^ cpu_args_enabled ^ core_args_enabled):
-            raise ValueError("Cannot set GPU, CPU, or CORE arguments at the same time")
+            msg = "Cannot set GPU, CPU, or CORE arguments at the same time"
+            command = " ".join(sys.argv[1:])
+            raise AmdSmiRequiredCommandException(command, self.logger.format, msg)
 
         if self.helpers.is_amdgpu_initialized() and gpu_args_enabled:
             if args.gpu == None:
@@ -2146,7 +2291,9 @@ class SetValueCommands:
             # Print out all CPU and all GPU static info only if no device was specified.
             # If a GPU or CPU argument is provided only print out the specified device.
             if args.cpu == None and args.gpu == None and args.core == None:
-                raise ValueError("No GPU, CPU, or CORE provided, specific target(s) are needed")
+                msg = "No GPU, CPU, or CORE provided, specific target(s) are needed"
+                command = " ".join(sys.argv[1:])
+                raise AmdSmiRequiredCommandException(command, self.logger.format)
 
             if args.cpu:
                 self.set_cpu(
@@ -2209,7 +2356,9 @@ class SetValueCommands:
                 )
         elif self.helpers.is_amd_hsmp_initialized():  # Only CPU is initialized
             if args.cpu == None and args.core == None:
-                raise ValueError("No CPU or CORE provided, specific target(s) are needed")
+                msg = "No CPU or CORE provided, specific target(s) are needed"
+                command = " ".join(sys.argv[1:])
+                raise AmdSmiRequiredCommandException(command, self.logger.format)
             if args.cpu:
                 self.set_cpu(
                     args,

--- a/projects/amdsmi/tests/python/cli/base.py
+++ b/projects/amdsmi/tests/python/cli/base.py
@@ -48,6 +48,28 @@ class TestCliBase(unittest.TestCase):
     TMP_FILENAME = "_tmp.log"
     TMP_FOLDER = "_tmp"
 
+    # CLI exit codes for the structured AmdSmi*Exception types (192-255 range).
+    # A test may pass one of these as the expected ``cond`` to assert the exact
+    # exit code, instead of the generic ``FAIL`` ("any non-zero").
+    InvalidCommand = 193
+    InvalidParameter = 194
+    DeviceNotFound = 195
+    InvalidFilePath = 196
+    InvalidParameterValue = 197
+    MissingParameterValue = 198
+    CommandNotSupported = 199
+    ParameterNotSupported = 200
+    RequiredCommand = 201
+    InvalidSubcommand = 202
+    PermissionDenied = 203
+    UnknownError = 255
+
+    # Codes that count as a pass for a command expected to succeed: a device may
+    # legitimately not support a feature.
+    #      2: from amdsmi.h, AMDSMI_STATUS_NOT_SUPPORTED
+    #    199: from amd-smi,  AmdSmiCommandNotSupportedException
+    not_supported_error_codes = [2, 199]
+
     # Scaffolding shared across every CLI test class.  setUpClass populates
     # these once, directly on ``TestCliBase``; subclasses then resolve them
     # natively through normal attribute inheritance -- no dynamic ``setattr``
@@ -160,7 +182,9 @@ class TestCliBase(unittest.TestCase):
         self.AddLogLevel = "--loglevel DEBUG"
 
         self.PASS = 0
-        self.FAIL = 1
+        # FAIL is negative so RunCmds can treat it as "expect any non-zero exit"
+        # while a positive ``cond`` asserts that exact exit code.
+        self.FAIL = -1
         self.tab = "    "
         self.tmp_filename = self.TMP_FILENAME
         self.tmp_folder = self.TMP_FOLDER
@@ -722,6 +746,81 @@ class TestCliBase(unittest.TestCase):
             print(json.dumps(cmds, sort_keys=False, indent=4), flush=True)
         return cmds
 
+    @staticmethod
+    def _str_to_number(num_str):
+        rc = 0
+        num_str = num_str.strip()
+        try:
+            value = int(num_str)
+        except ValueError:
+            try:
+                value = float(num_str)
+                if value.is_integer():
+                    value = int(value)
+            except ValueError:
+                rc = 1
+                value = num_str
+        return (rc, value)
+
+    def _get_error_code(self, std_out, std_err, cond):
+        """Extract the trailing exit code the CLI prints ("... Error code: N")."""
+        error_code = 0
+        items = []
+        output_stream = None
+        if std_out and "Error code" in std_out:
+            output_stream = "std_out"
+            items = std_out.strip().split()
+        elif std_err and "Error code" in std_err:
+            output_stream = "std_err"
+            items = std_err.strip().split()
+        elif cond != self.PASS:
+            if std_out:
+                output_stream = "std_out"
+                items = std_out.strip().split()
+            elif std_err:
+                output_stream = "std_err"
+                items = std_err.strip().split()
+        if items:
+            _rc, error_code = self._str_to_number(items[-1])
+        return (error_code, output_stream)
+
+    def _get_command_return_msg(self, rc_num, ec_num, cond):
+        """Classify a run against ``cond``.
+
+        ``cond == PASS`` expects exit 0 (or a not-supported code); ``cond < 0``
+        (``FAIL``) expects any non-zero exit; ``cond > 0`` expects that exact
+        exit code.
+        """
+        msg = ""
+        if cond == self.PASS:
+            if rc_num in self.not_supported_error_codes:
+                msg = "Success: PASS Not Supported   "
+            elif rc_num == 0 and ec_num == 0:
+                msg = "Success: Expected PASS (0)"
+            elif rc_num != 0:
+                msg = "Failure: Expected PASS (0)"
+            elif ec_num != 0:
+                msg = "Failure: Expected PASS (0)"
+            msg = f"{msg}; Received rc={rc_num:3d}, ec={str(ec_num):3s}"
+        else:
+            if cond < 0:
+                if rc_num > 0:
+                    msg = "Success: Expected FAIL (> 0)"
+                else:
+                    msg = "Failure: Expected FAIL (> 0)"
+            else:
+                if rc_num > 0 and (rc_num == ec_num):
+                    if rc_num == cond:
+                        msg = "Success: Expected FAIL (> 0)"
+                    else:
+                        msg = f"Failure: Expected FAIL ({cond})"
+                else:
+                    msg = "Failure: Expected FAIL (> 0)"
+            msg = f"{msg}; Received rc={rc_num:3d}, ec={str(ec_num):3s}"
+
+        passed = "Success" in msg
+        return (msg, passed)
+
     def RunCmds(self, cmds):
         errors = []
         msg_len = 0
@@ -736,49 +835,30 @@ class TestCliBase(unittest.TestCase):
             if self.PrintCmdsOnly:
                 continue
             (rc, std_out, std_err) = self.util.RunCmdSync(cmd)
-            error_code = rc
-            if rc and std_err:
-                items = std_err.split()
-                if "amdsmi_exception" in std_err:
-                    # error code from amdsmi library exception
-                    for index, item in enumerate(items):
-                        if item == "Error":
-                            error_code_str = items[index + 4]
-                            error_code = error_code_str
-                            # break
-                else:
-                    # error code from amd-smi CLI
-                    error_code = items[-1]
-                    # Check for parse error 'choice'
-                    if "CRITICAL" in error_code:
-                        error_code = "Bad loglevel"
+            if rc:
+                error_code, output_stream = self._get_error_code(std_out, std_err, cond)
+            else:
+                error_code = 0
+                output_stream = None
+            _msg, passed = self._get_command_return_msg(rc, error_code, cond)
 
             msg = f"{cmd:{msg_len}s}:"
             if "--file" in cmd:
                 if not os.path.exists(self.tmp_filename):
-                    _msg = f"{msg} Failure: File {self.tmp_filename} does not exist"
-                    errors.append(_msg)
+                    _fmsg = f"{msg} Failure: File {self.tmp_filename} does not exist"
+                    errors.append(_fmsg)
                 else:
                     with open(self.tmp_filename, "r") as fin:
                         std_out = fin.read()
                     if not len(std_out):
-                        _msg = f"{msg} Failure: File {self.tmp_filename} was empty"
-                        errors.append(_msg)
+                        _fmsg = f"{msg} Failure: File {self.tmp_filename} was empty"
+                        errors.append(_fmsg)
                     os.chmod(self.tmp_filename, stat.S_IWRITE)
                     os.remove(self.tmp_filename)
 
-            if rc and cond == self.PASS:
-                msg += f" Failure: Received FAIL ({error_code}), expected PASS (0)"
+            msg += f" {_msg}"
+            if not passed:
                 errors.append(msg)
-            elif not rc and cond != self.PASS:
-                msg += " Failure: Received PASS (0), expected FAIL (!0)"
-                errors.append(msg)
-            else:
-                if not rc:
-                    expected = "PASS"
-                else:
-                    expected = "FAIL"
-                msg += f" Success: Received and Expected {expected} ({error_code})"
 
             self.common.print(f"{self.tab}{msg}")
             if self.Debug:

--- a/projects/amdsmi/tests/python/cli/test_general.py
+++ b/projects/amdsmi/tests/python/cli/test_general.py
@@ -80,26 +80,27 @@ class TestGeneral(TestCliBase):
             bad_uuid = self.list_data[0]["uuid"][:-1] + "0"
 
         cmds = [
-            # Test invalid command
-            ("amd-smi invalid_cmd", self.FAIL),
-            # Test invalid sub command
-            ("amd-smi version --invalid", self.FAIL),
-            ("amd-smi list --invalid", self.FAIL),
-            ("amd-smi static --invalid", self.FAIL),
-            ("amd-smi firmware --invalid", self.FAIL),
-            ("amd-smi bad_pages --invalid", self.FAIL),
-            ("amd-smi metric --invalid", self.FAIL),
-            ("amd-smi process --invalid", self.FAIL),
-            ("amd-smi event --invalid", self.FAIL),
-            ("amd-smi topology --invalid", self.FAIL),
-            ("amd-smi set --invalid", self.FAIL),
-            ("amd-smi reset", self.FAIL),
-            ("amd-smi reset --invalid", self.FAIL),
-            ("amd-smi monitor --invalid", self.FAIL),
-            ("amd-smi xgmi --invalid", self.FAIL),
-            ("amd-smi partition --invalid", self.FAIL),
-            ("amd-smi ras --invalid", self.FAIL),
-            ("amd-smi node --invalid", self.FAIL),
+            # Test invalid command (unknown top-level command)
+            ("amd-smi invalid_cmd", self.InvalidCommand),
+            # Test invalid sub command (unrecognized flag on a valid command)
+            ("amd-smi version --invalid", self.InvalidParameter),
+            ("amd-smi list --invalid", self.InvalidParameter),
+            ("amd-smi static --invalid", self.InvalidParameter),
+            ("amd-smi firmware --invalid", self.InvalidParameter),
+            ("amd-smi bad-pages --invalid", self.InvalidParameter),
+            ("amd-smi metric --invalid", self.InvalidParameter),
+            ("amd-smi process --invalid", self.InvalidParameter),
+            ("amd-smi event --invalid", self.InvalidParameter),
+            ("amd-smi topology --invalid", self.InvalidParameter),
+            ("amd-smi set --invalid", self.InvalidParameter),
+            # reset with no target argument reports a missing required command
+            ("amd-smi reset", self.RequiredCommand),
+            ("amd-smi reset --invalid", self.InvalidParameter),
+            ("amd-smi monitor --invalid", self.InvalidParameter),
+            ("amd-smi xgmi --invalid", self.InvalidParameter),
+            ("amd-smi partition --invalid", self.InvalidParameter),
+            ("amd-smi ras --invalid", self.InvalidParameter),
+            ("amd-smi node --invalid", self.InvalidParameter),
             # Test invalid gpu value
             ("amd-smi version --gpu 0", self.FAIL),
             ("amd-smi version --gpu -1", self.FAIL),

--- a/projects/amdsmi/tests/python/unit/system/test_cli_exceptions.py
+++ b/projects/amdsmi/tests/python/unit/system/test_cli_exceptions.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) Advanced Micro Devices. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""Hardware-independent checks for the CLI exception framework."""
+
+import ast
+import glob
+import os
+import re
+import shutil
+import sys
+import unittest
+
+
+class TestAmdSmiCliExceptions(unittest.TestCase):
+    """Hardware-independent checks for the CLI exception framework.
+
+    Guards two classes of regression:
+      1. A CLI module raising an ``AmdSmi*Exception`` it never imported, which
+         only surfaces as a ``NameError`` on an error path (e.g. the missing
+         imports in ``subcommands/reset.py`` and ``subcommands/set_value.py``).
+      2. The empty-string ``hint`` ``IndexError`` in
+         ``AmdSmiInvalidParameterValueException``.
+    """
+
+    EXCEPTION_NAME = re.compile(r"^AmdSmi.*Exception$")
+
+    @staticmethod
+    def _cli_dir():
+        # Prefer the in-repo CLI source tree by walking up from this test file
+        # looking for amdsmi_cli/amdsmi_cli_exceptions.py; fall back to the
+        # installed CLI the `amd-smi` launcher points at.
+        here = os.path.dirname(os.path.abspath(__file__))
+        cur = here
+        for _ in range(8):
+            candidate = os.path.join(cur, "amdsmi_cli")
+            if os.path.isfile(os.path.join(candidate, "amdsmi_cli_exceptions.py")):
+                return candidate
+            parent = os.path.dirname(cur)
+            if parent == cur:
+                break
+            cur = parent
+        amd_smi = shutil.which("amd-smi")
+        if amd_smi:
+            cli_dir = os.path.dirname(os.path.realpath(amd_smi))
+            if os.path.isfile(os.path.join(cli_dir, "amdsmi_cli_exceptions.py")):
+                return cli_dir
+        return None
+
+    @staticmethod
+    def _resolvable_names(tree):
+        names = set(dir(__builtins__))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                for alias in node.names:
+                    names.add(alias.asname or alias.name)
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    names.add((alias.asname or alias.name).split(".")[0])
+            elif isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+                names.add(node.name)
+            elif isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if isinstance(target, ast.Name):
+                        names.add(target.id)
+        return names
+
+    def test_cli_modules_import_every_exception_they_raise(self):
+        cli_dir = self._cli_dir()
+        if cli_dir is None:
+            self.skipTest("Could not locate amdsmi_cli source directory")
+
+        py_files = glob.glob(os.path.join(cli_dir, "*.py"))
+        py_files += glob.glob(os.path.join(cli_dir, "subcommands", "*.py"))
+        self.assertTrue(py_files, f"No CLI source files found under {cli_dir}")
+
+        offenders = {}
+        for path in py_files:
+            with open(path, "r", encoding="utf-8") as fin:
+                tree = ast.parse(fin.read(), filename=path)
+            resolvable = self._resolvable_names(tree)
+            used = {
+                node.id
+                for node in ast.walk(tree)
+                if isinstance(node, ast.Name)
+                and isinstance(node.ctx, ast.Load)
+                and self.EXCEPTION_NAME.match(node.id)
+            }
+            missing = sorted(name for name in used if name not in resolvable)
+            if missing:
+                offenders[os.path.relpath(path, cli_dir)] = missing
+
+        self.assertEqual(
+            offenders,
+            {},
+            "CLI modules reference exception classes they never import "
+            f"(NameError on the error path): {offenders}",
+        )
+
+    def test_invalid_parameter_value_exception_accepts_empty_hint(self):
+        cli_dir = self._cli_dir()
+        if cli_dir is None:
+            self.skipTest("Could not locate amdsmi_cli source directory")
+        if cli_dir not in sys.path:
+            sys.path.insert(0, cli_dir)
+        import amdsmi_cli_exceptions
+
+        try:
+            exc = amdsmi_cli_exceptions.AmdSmiInvalidParameterValueException(
+                "set", None, "json", hint=""
+            )
+        except IndexError as e:
+            self.fail(f"Empty hint raised IndexError: {e}")
+
+        # The guard is that an empty hint does not raise IndexError; the
+        # specific code number is intentionally not asserted here.
+        self.assertIsInstance(exc.value, int)
+        self.assertIsInstance(str(exc), str)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation
The amd-smi CLI previously exited with code 0 on library errors (swallowing failures silently) and used negative exit codes (-1 to -100) for CLI exceptions — which are not valid Unix exit codes (they wrap to 255 or get truncated). This made the tool unusable in scripted environments where $? is checked for success/failure.

## Technical Details
Normalize all CLI exit codes to the positive 192–255 range (above the POSIX signal range), propagate library errors via exceptions instead of returning error strings, and add a new AmdSmiImportException for import failures. The pattern changes from sys.exit(N) / return error_dict to structured exception raising with a top-level handler.

## JIRA ID
JIRA ID : ROCM-25289

## Test Plan
cli_unit_test.py
amd-smi with ticket scenarios

## Test Results
Ran all ticket scenarios
All tests passed as expected