### PR TITLE
[AMD-SMI] Fix TestAmdSmiCli.test_help using lastest amd-smi --help

### DIFF
--- a/projects/amdsmi/tests/python_unittest/cli_unit_test.py
+++ b/projects/amdsmi/tests/python_unittest/cli_unit_test.py
@@ -753,10 +753,20 @@ class TestAmdSmiCli(unittest.TestCase):
         # Find all available command line args
         cmd_args = []
         found = False
+        cmd_indent = None
         for line in lines:
             if found:
                 if not line:
                     break
+                indent = len(line) - len(line.lstrip())
+                # The first command establishes the command column. Lines that
+                # are indented further are wrapped description continuations
+                # (e.g. the "devices" tail of the long fabric help text) and
+                # must be skipped so they aren't parsed as subcommands.
+                if cmd_indent is None:
+                    cmd_indent = indent
+                elif indent > cmd_indent:
+                    continue
                 items = line.split()
                 cmd_args.append(items[0])
                 continue


### PR DESCRIPTION
## Motivation

Fix `TestAmdSmiCli.test_help` so it correctly validates `amd-smi --help` output when a command description wraps onto a continuation line. The previous parser treated wrapped description text as another subcommand, which could cause the test to run invalid help commands.

Test failure on older Navi/Driver Install:
```bash
> sudo /opt/rocm/share/amd_smi/tests/python_unittest/cli_unit_test.py -k test_help -v
AMD SMI CLI Tests
In class Common, Cannot get virtualization mode information for gpu c_void_p(1021056848), Error code:
        2 | AMDSMI_STATUS_NOT_SUPPORTED - Feature not supported
In class Common, Cannot get virtualization mode information for gpu c_void_p(1022112592), Error code:
        2 | AMDSMI_STATUS_NOT_SUPPORTED - Feature not supported

## test_help()
### amd-smi help
    amd-smi --help            : Success: Received and Expected PASS (0)
    amd-smi version --help    : Success: Received and Expected PASS (0)
    amd-smi list --help       : Success: Received and Expected PASS (0)
    amd-smi static --help     : Success: Received and Expected PASS (0)
    amd-smi firmware --help   : Success: Received and Expected PASS (0)
    amd-smi bad-pages --help  : Success: Received and Expected PASS (0)
    amd-smi metric --help     : Success: Received and Expected PASS (0)
    amd-smi process --help    : Success: Received and Expected PASS (0)
    amd-smi event --help      : Success: Received and Expected PASS (0)
    amd-smi topology --help   : Success: Received and Expected PASS (0)
    amd-smi set --help        : Success: Received and Expected PASS (0)
    amd-smi reset --help      : Success: Received and Expected PASS (0)
    amd-smi monitor --help    : Success: Received and Expected PASS (0)
    amd-smi xgmi --help       : Success: Received and Expected PASS (0)
    amd-smi partition --help  : Success: Received and Expected PASS (0)
    amd-smi ras --help        : Success: Received and Expected PASS (0)
    amd-smi node --help       : Success: Received and Expected PASS (0)
    amd-smi fabric --help     : Success: Received and Expected PASS (0)
    amd-smi devices --help    : Failure: Received FAIL (10), expected PASS (0)
======================================================================
FAIL: test_help (__main__.TestAmdSmiCli)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/rocm/share/amd_smi/tests/python_unittest/cli_unit_test.py", line 770, in test_help
    self.RunCmds(cmds)
  File "/opt/rocm/share/amd_smi/tests/python_unittest/cli_unit_test.py", line 742, in RunCmds
    self.fail(f"Fail:\n{self.tab}{msg}")
AssertionError: Fail:
    amd-smi devices --help    : Failure: Received FAIL (10), expected PASS (0)

----------------------------------------------------------------------
Ran 1 test in 4.667s

FAILED (failures=1)

[----------] 1 test ran. (4668 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] TestAmdSmiCli.test_help
```


## Technical Details

Updated the `test_help` parser to track the indentation of the command column after the `Descriptions` section is found. Lines indented farther than the first command entry are now treated as wrapped description continuations and skipped instead of being added to the list of subcommands.

This prevents long help text, such as wrapped fabric command descriptions, from being parsed as fake CLI commands.

## JIRA ID

N/A

## Test Plan

Built and packaged `amd-smi-lib` locally, then installed the generated packages.

Recommended focused validation:
```bash
sudo /opt/rocm/share/amd_smi/tests/python_unittest/cli_unit_test.py -k "test_help" -v
```

## Test Result
amd-smi-lib build, packaging, and local install completed successfully. The change is limited to the CLI help unit test parser and is intended to prevent wrapped help-description lines from being interpreted as subcommands.

```bash
> sudo /opt/rocm/share/amd_smi/tests/python_unittest/cli_unit_test.py -k test_help -v
AMD SMI CLI Tests
In class Common, Cannot get virtualization mode information for gpu c_void_p(216610160), Error code:
        2 | AMDSMI_STATUS_NOT_SUPPORTED - Feature not supported
In class Common, Cannot get virtualization mode information for gpu c_void_p(215609664), Error code:
        2 | AMDSMI_STATUS_NOT_SUPPORTED - Feature not supported

## test_help()
### amd-smi help
    amd-smi --help            : Success: Received and Expected PASS (0)
    amd-smi version --help    : Success: Received and Expected PASS (0)
    amd-smi list --help       : Success: Received and Expected PASS (0)
    amd-smi static --help     : Success: Received and Expected PASS (0)
    amd-smi firmware --help   : Success: Received and Expected PASS (0)
    amd-smi bad-pages --help  : Success: Received and Expected PASS (0)
    amd-smi metric --help     : Success: Received and Expected PASS (0)
    amd-smi process --help    : Success: Received and Expected PASS (0)
    amd-smi event --help      : Success: Received and Expected PASS (0)
    amd-smi topology --help   : Success: Received and Expected PASS (0)
    amd-smi set --help        : Success: Received and Expected PASS (0)
    amd-smi reset --help      : Success: Received and Expected PASS (0)
    amd-smi monitor --help    : Success: Received and Expected PASS (0)
    amd-smi xgmi --help       : Success: Received and Expected PASS (0)
    amd-smi partition --help  : Success: Received and Expected PASS (0)
    amd-smi ras --help        : Success: Received and Expected PASS (0)
    amd-smi node --help       : Success: Received and Expected PASS (0)
    amd-smi fabric --help     : Success: Received and Expected PASS (0)
----------------------------------------------------------------------
Ran 1 test in 4.460s

OK

[----------] 1 test ran. (4461 ms total)
[  PASSED  ] 1 test.
```
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
