### PR TITLE
[rocjitsu] Add v_cvt_scalef32 and non-scaled FP8/BF8 cvt insts

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -1929,6 +1929,24 @@ class CodeGenerator:
         if cls == 'true_nop':
             return '  (void)wf;'
 
+        if cls == 'gpr_idx':
+            if op == 'on':
+                return (
+                    '  uint32_t idx = ssrc0.read_scalar(wf) & 0xFF;\n'
+                    '  uint32_t mode = ssrc1.read_scalar(wf) & 0xF;\n'
+                    '  wf.set_m0((wf.m0() & 0xFFFFF000u) | (mode << 8) | idx);\n'
+                    '  wf.set_mode_raw(wf.mode_raw() | Wavefront::GPR_IDX_EN_BIT);'
+                )
+            if op == 'off':
+                return '  wf.set_mode_raw(wf.mode_raw() & ~Wavefront::GPR_IDX_EN_BIT);'
+            if op == 'idx':
+                return '  wf.set_m0((wf.m0() & 0xFFFFFF00u) | (ssrc0.read_scalar(wf) & 0xFF));'
+            if op == 'mode':
+                return (
+                    f'  wf.set_m0((wf.m0() & 0xFFFFF0FFu) '
+                    f'| (({src_ops[0]}.read_scalar(wf) & 0xF) << 8));'
+                )
+
         if cls == 'set_vgpr_msb':
             L.append(
                 f'  wf.set_vgpr_msb_mode(static_cast<uint8_t>({src_ops[0]}.encoding_value_ & 0xffu));'
@@ -4084,6 +4102,11 @@ class CodeGenerator:
             # V_CMPX writes VCC+EXEC on CDNA but only EXEC on RDNA:
             'vector_cmpx',
             'vector_cmpx_class',
+            # FP8/BF8 conversions access inst_.op_sel (VOP3-only field):
+            'cvt_fp8',
+            'cvt_scalef32',
+            # vector_cvt_pk FP8 pack/unpack uses inst_.op_sel for word sel:
+            'vector_cvt_pk',
         }
     )
     _NON_SHAREABLE_MNEMONICS = frozenset(
@@ -5547,6 +5570,386 @@ class CodeGenerator:
             file=sys.stderr,
         )
 
+    @staticmethod
+    def _gen_narrow_cvt_header_REMOVED_PLACEHOLDER(out_path: str) -> None:
+        pass
+        content_UNUSED = f"""\
+// REMOVED — narrow FP conversions now live in util/data_types.h
+
+#ifndef {guard}
+#define {guard}
+
+#include <bit>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+
+namespace util {{
+
+// LFSR for stochastic rounding seed advancement
+inline uint32_t prng_advance(uint32_t seed) {{
+  return (seed << 1) ^ ((seed >> 31) ? 197u : 0u);
+}}
+
+// --- FP8 E4M3 (OCP E4M3FN) with RNE rounding ---
+
+inline uint8_t f32_to_fp8_e4m3_rne(float val) {{
+  uint32_t f = std::bit_cast<uint32_t>(val);
+  uint32_t sign = (f >> 24) & 0x80;
+  if (std::isnan(val)) return static_cast<uint8_t>(sign | 0x7F);
+  int32_t f_exp = static_cast<int32_t>((f >> 23) & 0xFF);
+  uint32_t f_mant = f & 0x7FFFFF;
+  if (f_exp == 0xFF) return static_cast<uint8_t>(sign | 0x7E);
+  int32_t exp = f_exp - 127 + 7;
+  if (exp <= 0) {{
+    if (exp < -3) return static_cast<uint8_t>(sign);
+    uint32_t mant = f_mant | 0x800000;
+    int shift = 21 - exp;
+    if (shift > 23) return static_cast<uint8_t>(sign);
+    uint32_t round_bit = (mant >> (shift - 1)) & 1;
+    uint32_t sticky = (mant & ((1u << (shift - 1)) - 1)) ? 1 : 0;
+    uint32_t result = mant >> shift;
+    result += round_bit & (sticky | (result & 1));
+    if (result >= 8) {{ result = 4; exp = 1; return static_cast<uint8_t>(sign | (1 << 3) | (result & 0x7)); }}
+    return static_cast<uint8_t>(sign | (result & 0x7));
+  }}
+  if (exp >= 15) {{
+    uint32_t mant = (f_mant >> 20) & 0x7;
+    if (exp > 15 || (exp == 15 && mant >= 7))
+      return static_cast<uint8_t>(sign | 0x7E);
+    return static_cast<uint8_t>(sign | (static_cast<uint32_t>(exp) << 3) | mant);
+  }}
+  uint32_t round_bit = (f_mant >> 19) & 1;
+  uint32_t sticky = (f_mant & 0x7FFFF) ? 1 : 0;
+  uint32_t mant = (f_mant >> 20) & 0x7;
+  mant += round_bit & (sticky | (mant & 1));
+  if (mant > 0x7) {{
+    mant = 0;
+    exp += 1;
+    if (exp >= 15) {{
+      if (exp > 15) return static_cast<uint8_t>(sign | 0x7E);
+      return static_cast<uint8_t>(sign | (static_cast<uint32_t>(exp) << 3));
+    }}
+  }}
+  return static_cast<uint8_t>(sign | (static_cast<uint32_t>(exp) << 3) | mant);
+}}
+
+inline uint8_t f32_to_fp8_e4m3_sr(float val, uint32_t seed) {{
+  if (std::isnan(val)) return static_cast<uint8_t>((std::bit_cast<uint32_t>(val) >> 24) & 0x80) | 0x7F;
+  uint32_t f = std::bit_cast<uint32_t>(val);
+  uint32_t sign = (f >> 24) & 0x80;
+  int32_t f_exp = static_cast<int32_t>((f >> 23) & 0xFF);
+  uint32_t f_mant = f & 0x7FFFFF;
+  if (f_exp == 0xFF) return static_cast<uint8_t>(sign | 0x7E);
+  int32_t exp = f_exp - 127 + 7;
+  if (exp <= 0) return static_cast<uint8_t>(sign);
+  if (exp >= 15) return static_cast<uint8_t>(sign | 0x7E);
+  uint32_t trunc_bits = f_mant & 0xFFFFF;
+  uint32_t random_add = seed >> 12;
+  uint32_t mant = (f_mant >> 20) & 0x7;
+  if ((trunc_bits + random_add) > 0xFFFFF) {{
+    mant += 1;
+    if (mant > 0x7) {{ mant = 0; exp += 1; if (exp >= 15) return static_cast<uint8_t>(sign | 0x7E); }}
+  }}
+  return static_cast<uint8_t>(sign | (static_cast<uint32_t>(exp) << 3) | mant);
+}}
+
+// --- BF8 E5M2 with RNE rounding ---
+
+inline uint8_t f32_to_bf8_e5m2_rne(float val) {{
+  uint32_t f = std::bit_cast<uint32_t>(val);
+  uint32_t sign = (f >> 24) & 0x80;
+  if (std::isnan(val)) return static_cast<uint8_t>(sign | 0x7F);
+  int32_t f_exp = static_cast<int32_t>((f >> 23) & 0xFF);
+  uint32_t f_mant = f & 0x7FFFFF;
+  if (f_exp == 0xFF) return static_cast<uint8_t>(sign | 0x7C);
+  int32_t exp = f_exp - 127 + 15;
+  if (exp <= 0) {{
+    if (exp < -1) return static_cast<uint8_t>(sign);
+    uint32_t mant = f_mant | 0x800000;
+    int shift = 22 - exp;
+    if (shift > 23) return static_cast<uint8_t>(sign);
+    uint32_t round_bit = (mant >> (shift - 1)) & 1;
+    uint32_t sticky = (mant & ((1u << (shift - 1)) - 1)) ? 1 : 0;
+    uint32_t result = mant >> shift;
+    result += round_bit & (sticky | (result & 1));
+    if (result >= 4) {{ return static_cast<uint8_t>(sign | (1 << 2) | 0); }}
+    return static_cast<uint8_t>(sign | (result & 0x3));
+  }}
+  if (exp >= 31) return static_cast<uint8_t>(sign | 0x7C);
+  uint32_t round_bit = (f_mant >> 20) & 1;
+  uint32_t sticky = (f_mant & 0xFFFFF) ? 1 : 0;
+  uint32_t mant = (f_mant >> 21) & 0x3;
+  mant += round_bit & (sticky | (mant & 1));
+  if (mant > 0x3) {{
+    mant = 0; exp += 1;
+    if (exp >= 31) return static_cast<uint8_t>(sign | 0x7C);
+  }}
+  return static_cast<uint8_t>(sign | (static_cast<uint32_t>(exp) << 2) | mant);
+}}
+
+inline uint8_t f32_to_bf8_e5m2_sr(float val, uint32_t seed) {{
+  if (std::isnan(val)) return static_cast<uint8_t>((std::bit_cast<uint32_t>(val) >> 24) & 0x80) | 0x7F;
+  uint32_t f = std::bit_cast<uint32_t>(val);
+  uint32_t sign = (f >> 24) & 0x80;
+  int32_t f_exp = static_cast<int32_t>((f >> 23) & 0xFF);
+  uint32_t f_mant = f & 0x7FFFFF;
+  if (f_exp == 0xFF) return static_cast<uint8_t>(sign | 0x7C);
+  int32_t exp = f_exp - 127 + 15;
+  if (exp <= 0) return static_cast<uint8_t>(sign);
+  if (exp >= 31) return static_cast<uint8_t>(sign | 0x7C);
+  uint32_t trunc_bits = f_mant & 0x1FFFFF;
+  uint32_t random_add = seed >> 11;
+  uint32_t mant = (f_mant >> 21) & 0x3;
+  if ((trunc_bits + random_add) > 0x1FFFFF) {{
+    mant += 1;
+    if (mant > 0x3) {{ mant = 0; exp += 1; if (exp >= 31) return static_cast<uint8_t>(sign | 0x7C); }}
+  }}
+  return static_cast<uint8_t>(sign | (static_cast<uint32_t>(exp) << 2) | mant);
+}}
+
+// --- FP4 E2M1 (bias=1, no NaN/Inf, max=6.0) ---
+
+inline float fp4_e2m1_to_f32(uint8_t v) {{
+  uint32_t sign = (v >> 3) & 1;
+  uint32_t exp = (v >> 1) & 0x3;
+  uint32_t mant = v & 0x1;
+  if (exp == 0 && mant == 0) return std::bit_cast<float>(sign << 31);
+  if (exp == 0) {{
+    float result = 0.5f;
+    return sign ? -result : result;
+  }}
+  uint32_t f = (sign << 31) | ((exp + 127 - 1) << 23) | (mant << 22);
+  return std::bit_cast<float>(f);
+}}
+
+inline uint8_t f32_to_fp4_e2m1_rne(float val) {{
+  if (std::isnan(val)) return 0;
+  uint32_t f = std::bit_cast<uint32_t>(val);
+  uint32_t sign = (f >> 28) & 0x8;
+  if (std::isinf(val)) return static_cast<uint8_t>(sign | 0x7);
+  float absval = std::fabs(val);
+  if (absval > 6.0f) return static_cast<uint8_t>(sign | 0x7);
+  if (absval < 0.25f) return static_cast<uint8_t>(sign);
+  int32_t f_exp = static_cast<int32_t>((f >> 23) & 0xFF);
+  uint32_t f_mant = f & 0x7FFFFF;
+  int32_t exp = f_exp - 127 + 1;
+  if (exp <= 0) {{
+    uint32_t round_bit = (f_mant >> 22) & 1;
+    uint32_t sticky = (f_mant & 0x3FFFFF) ? 1 : 0;
+    uint32_t result = round_bit & (sticky | 0);
+    return static_cast<uint8_t>(sign | result);
+  }}
+  if (exp > 3) return static_cast<uint8_t>(sign | 0x7);
+  uint32_t round_bit = (f_mant >> 21) & 1;
+  uint32_t sticky = (f_mant & 0x1FFFFF) ? 1 : 0;
+  uint32_t mant = (f_mant >> 22) & 0x1;
+  mant += round_bit & (sticky | (mant & 1));
+  if (mant > 1) {{
+    mant = 0; exp += 1;
+    if (exp > 3) return static_cast<uint8_t>(sign | 0x7);
+  }}
+  return static_cast<uint8_t>(sign | (static_cast<uint32_t>(exp) << 1) | mant);
+}}
+
+inline uint8_t f32_to_fp4_e2m1_sr(float val, uint32_t seed) {{
+  if (std::isnan(val)) return 0;
+  uint32_t f = std::bit_cast<uint32_t>(val);
+  uint32_t sign = (f >> 28) & 0x8;
+  if (std::isinf(val) || std::fabs(val) > 6.0f) return static_cast<uint8_t>(sign | 0x7);
+  if (std::fabs(val) < 0.25f) return static_cast<uint8_t>(sign);
+  int32_t f_exp = static_cast<int32_t>((f >> 23) & 0xFF);
+  uint32_t f_mant = f & 0x7FFFFF;
+  int32_t exp = f_exp - 127 + 1;
+  if (exp <= 0) return static_cast<uint8_t>(sign);
+  if (exp > 3) return static_cast<uint8_t>(sign | 0x7);
+  uint32_t trunc_bits = f_mant & 0x3FFFFF;
+  uint32_t random_add = seed >> 10;
+  uint32_t mant = (f_mant >> 22) & 0x1;
+  if ((trunc_bits + random_add) > 0x3FFFFF) {{
+    mant += 1;
+    if (mant > 1) {{ mant = 0; exp += 1; if (exp > 3) return static_cast<uint8_t>(sign | 0x7); }}
+  }}
+  return static_cast<uint8_t>(sign | (static_cast<uint32_t>(exp) << 1) | mant);
+}}
+
+// --- FP6 E2M3 (bias=1, no NaN/Inf, max=7.5) ---
+
+inline float fp6_e2m3_to_f32(uint8_t v) {{
+  uint32_t sign = (v >> 5) & 1;
+  uint32_t exp = (v >> 3) & 0x3;
+  uint32_t mant = v & 0x7;
+  if (exp == 0 && mant == 0) return std::bit_cast<float>(sign << 31);
+  if (exp == 0) {{
+    float result = std::ldexp(static_cast<float>(mant), -3);
+    return sign ? -result : result;
+  }}
+  uint32_t f = (sign << 31) | ((exp + 127 - 1) << 23) | (mant << 20);
+  return std::bit_cast<float>(f);
+}}
+
+inline uint8_t f32_to_fp6_e2m3_rne(float val) {{
+  if (std::isnan(val)) return 0;
+  uint32_t f = std::bit_cast<uint32_t>(val);
+  uint32_t sign = (f >> 26) & 0x20;
+  if (std::isinf(val) || std::fabs(val) > 7.5f) return static_cast<uint8_t>(sign | 0x1F);
+  float absval = std::fabs(val);
+  if (absval < std::ldexp(1.0f, -4)) return static_cast<uint8_t>(sign);
+  int32_t f_exp = static_cast<int32_t>((f >> 23) & 0xFF);
+  uint32_t f_mant = f & 0x7FFFFF;
+  int32_t exp = f_exp - 127 + 1;
+  if (exp <= 0) {{
+    uint32_t full_mant = f_mant | 0x800000;
+    int shift = 21 - exp;
+    if (shift > 23) return static_cast<uint8_t>(sign);
+    uint32_t round_bit = (full_mant >> (shift - 1)) & 1;
+    uint32_t sticky = (full_mant & ((1u << (shift - 1)) - 1)) ? 1 : 0;
+    uint32_t result = full_mant >> shift;
+    result += round_bit & (sticky | (result & 1));
+    if (result >= 8) return static_cast<uint8_t>(sign | (1 << 3));
+    return static_cast<uint8_t>(sign | (result & 0x7));
+  }}
+  if (exp > 3) return static_cast<uint8_t>(sign | 0x1F);
+  uint32_t round_bit = (f_mant >> 19) & 1;
+  uint32_t sticky = (f_mant & 0x7FFFF) ? 1 : 0;
+  uint32_t mant = (f_mant >> 20) & 0x7;
+  mant += round_bit & (sticky | (mant & 1));
+  if (mant > 0x7) {{
+    mant = 0; exp += 1;
+    if (exp > 3) return static_cast<uint8_t>(sign | 0x1F);
+  }}
+  return static_cast<uint8_t>(sign | (static_cast<uint32_t>(exp) << 3) | mant);
+}}
+
+inline uint8_t f32_to_fp6_e2m3_sr(float val, uint32_t seed) {{
+  if (std::isnan(val)) return 0;
+  uint32_t f = std::bit_cast<uint32_t>(val);
+  uint32_t sign = (f >> 26) & 0x20;
+  if (std::isinf(val) || std::fabs(val) > 7.5f) return static_cast<uint8_t>(sign | 0x1F);
+  if (std::fabs(val) < std::ldexp(1.0f, -4)) return static_cast<uint8_t>(sign);
+  int32_t f_exp = static_cast<int32_t>((f >> 23) & 0xFF);
+  uint32_t f_mant = f & 0x7FFFFF;
+  int32_t exp = f_exp - 127 + 1;
+  if (exp <= 0) return static_cast<uint8_t>(sign);
+  if (exp > 3) return static_cast<uint8_t>(sign | 0x1F);
+  uint32_t trunc_bits = f_mant & 0xFFFFF;
+  uint32_t random_add = seed >> 12;
+  uint32_t mant = (f_mant >> 20) & 0x7;
+  if ((trunc_bits + random_add) > 0xFFFFF) {{
+    mant += 1;
+    if (mant > 0x7) {{ mant = 0; exp += 1; if (exp > 3) return static_cast<uint8_t>(sign | 0x1F); }}
+  }}
+  return static_cast<uint8_t>(sign | (static_cast<uint32_t>(exp) << 3) | mant);
+}}
+
+// --- BF6 E3M2 (bias=3, no NaN/Inf, max=28.0) ---
+
+inline float bf6_e3m2_to_f32(uint8_t v) {{
+  uint32_t sign = (v >> 5) & 1;
+  uint32_t exp = (v >> 2) & 0x7;
+  uint32_t mant = v & 0x3;
+  if (exp == 0 && mant == 0) return std::bit_cast<float>(sign << 31);
+  if (exp == 0) {{
+    float result = std::ldexp(static_cast<float>(mant), -4);
+    return sign ? -result : result;
+  }}
+  uint32_t f = (sign << 31) | ((exp + 127 - 3) << 23) | (mant << 21);
+  return std::bit_cast<float>(f);
+}}
+
+inline uint8_t f32_to_bf6_e3m2_rne(float val) {{
+  if (std::isnan(val)) return 0;
+  uint32_t f = std::bit_cast<uint32_t>(val);
+  uint32_t sign = (f >> 26) & 0x20;
+  if (std::isinf(val) || std::fabs(val) > 28.0f) return static_cast<uint8_t>(sign | 0x1F);
+  float absval = std::fabs(val);
+  if (absval < std::ldexp(1.0f, -5)) return static_cast<uint8_t>(sign);
+  int32_t f_exp = static_cast<int32_t>((f >> 23) & 0xFF);
+  uint32_t f_mant = f & 0x7FFFFF;
+  int32_t exp = f_exp - 127 + 3;
+  if (exp <= 0) {{
+    uint32_t full_mant = f_mant | 0x800000;
+    int shift = 22 - exp;
+    if (shift > 23) return static_cast<uint8_t>(sign);
+    uint32_t round_bit = (full_mant >> (shift - 1)) & 1;
+    uint32_t sticky = (full_mant & ((1u << (shift - 1)) - 1)) ? 1 : 0;
+    uint32_t result = full_mant >> shift;
+    result += round_bit & (sticky | (result & 1));
+    if (result >= 4) return static_cast<uint8_t>(sign | (1 << 2));
+    return static_cast<uint8_t>(sign | (result & 0x3));
+  }}
+  if (exp > 7) return static_cast<uint8_t>(sign | 0x1F);
+  uint32_t round_bit = (f_mant >> 20) & 1;
+  uint32_t sticky = (f_mant & 0xFFFFF) ? 1 : 0;
+  uint32_t mant = (f_mant >> 21) & 0x3;
+  mant += round_bit & (sticky | (mant & 1));
+  if (mant > 0x3) {{
+    mant = 0; exp += 1;
+    if (exp > 7) return static_cast<uint8_t>(sign | 0x1F);
+  }}
+  return static_cast<uint8_t>(sign | (static_cast<uint32_t>(exp) << 2) | mant);
+}}
+
+inline uint8_t f32_to_bf6_e3m2_sr(float val, uint32_t seed) {{
+  if (std::isnan(val)) return 0;
+  uint32_t f = std::bit_cast<uint32_t>(val);
+  uint32_t sign = (f >> 26) & 0x20;
+  if (std::isinf(val) || std::fabs(val) > 28.0f) return static_cast<uint8_t>(sign | 0x1F);
+  if (std::fabs(val) < std::ldexp(1.0f, -5)) return static_cast<uint8_t>(sign);
+  int32_t f_exp = static_cast<int32_t>((f >> 23) & 0xFF);
+  uint32_t f_mant = f & 0x7FFFFF;
+  int32_t exp = f_exp - 127 + 3;
+  if (exp <= 0) return static_cast<uint8_t>(sign);
+  if (exp > 7) return static_cast<uint8_t>(sign | 0x1F);
+  uint32_t trunc_bits = f_mant & 0x1FFFFF;
+  uint32_t random_add = seed >> 11;
+  uint32_t mant = (f_mant >> 21) & 0x3;
+  if ((trunc_bits + random_add) > 0x1FFFFF) {{
+    mant += 1;
+    if (mant > 0x3) {{ mant = 0; exp += 1; if (exp > 7) return static_cast<uint8_t>(sign | 0x1F); }}
+  }}
+  return static_cast<uint8_t>(sign | (static_cast<uint32_t>(exp) << 2) | mant);
+}}
+
+// --- 6-bit packing/unpacking (32×6-bit values ↔ 6 DWORDs, little-endian) ---
+
+inline void pack_6bit(const uint8_t vals[32], uint32_t dwords[6]) {{
+  for (int d = 0; d < 6; ++d) dwords[d] = 0;
+  for (int i = 0; i < 32; ++i) {{
+    uint64_t bit_offset = static_cast<uint64_t>(i) * 6;
+    uint32_t dw_idx = static_cast<uint32_t>(bit_offset / 32);
+    uint32_t bit_pos = static_cast<uint32_t>(bit_offset % 32);
+    uint32_t val6 = vals[i] & 0x3F;
+    dwords[dw_idx] |= val6 << bit_pos;
+    if (bit_pos > 26)
+      dwords[dw_idx + 1] |= val6 >> (32 - bit_pos);
+  }}
+}}
+
+inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
+  for (int i = 0; i < 32; ++i) {{
+    uint64_t bit_offset = static_cast<uint64_t>(i) * 6;
+    uint32_t dw_idx = static_cast<uint32_t>(bit_offset / 32);
+    uint32_t bit_pos = static_cast<uint32_t>(bit_offset % 32);
+    uint32_t val = (dwords[dw_idx] >> bit_pos) & 0x3F;
+    if (bit_pos > 26)
+      val |= (dwords[dw_idx + 1] << (32 - bit_pos)) & 0x3F;
+    vals[i] = static_cast<uint8_t>(val);
+  }}
+}}
+
+}} // namespace util
+
+#endif // {guard}
+"""
+        filepath = os.path.join(shared_dir, 'narrow_cvt.h')
+        with open(filepath, 'w') as f:
+            f.write(content)
+
+        import sys
+
+        print(f'Generated shared/narrow_cvt.h', file=sys.stderr)
+
     def gen_operand_types(self) -> None:
         """Generate operand type and OpSel enums."""
         code_lines = []
@@ -6031,8 +6434,10 @@ class CodeGenerator:
             )
         read_lane_lines.extend(
             [
-                f'  if (auto off = {_resolved_vgpr_read_call})',
-                '    return wf.cu().read_vgpr(wf.vgpr_alloc().base + *off, lane);',
+                f'  if (auto off = {_resolved_vgpr_read_call}) {{',
+                '    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, false) : *off;',
+                '    return wf.cu().read_vgpr(wf.vgpr_alloc().base + voff, lane);',
+                '  }',
                 '  if (is_immediate_type(opr_type_))',
                 '    return static_cast<uint32_t>(ev);',
                 '  return resolve_src_scalar(wf, ev);',
@@ -6046,7 +6451,8 @@ class CodeGenerator:
             '  if (delegate()) return delegate()->read_lane64(wf, lane);\n'
             '  int ev = encoding_value_;\n'
             f'  if (auto off = {_resolved_vgpr_read_call}) {{\n'
-            '    uint32_t idx = wf.vgpr_alloc().base + *off;\n'
+            '    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, false) : *off;\n'
+            '    uint32_t idx = wf.vgpr_alloc().base + voff;\n'
             '    uint32_t lo = wf.cu().read_vgpr(idx, lane);\n'
             '    uint32_t hi = wf.cu().read_vgpr(idx + 1, lane);\n'
             '    return static_cast<uint64_t>(hi) << 32 | lo;\n'
@@ -6359,7 +6765,8 @@ class CodeGenerator:
             '\n'
             'void Operand::write_lane(amdgpu::Wavefront &wf, uint32_t lane, uint32_t val) const {\n'
             f'  if (auto off = {_resolved_vgpr_encoded_call}) {{\n'
-            '    wf.cu().write_vgpr(wf.vgpr_alloc().base + *off, lane, val);\n'
+            '    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, true) : *off;\n'
+            '    wf.cu().write_vgpr(wf.vgpr_alloc().base + voff, lane, val);\n'
             '    return;\n'
             '  }\n'
             '  throw std::logic_error("write_lane called on non-VGPR operand type");\n'
@@ -6367,7 +6774,8 @@ class CodeGenerator:
             '\n' + _read_lane64_body + '\n\n'
             'void Operand::write_lane64(amdgpu::Wavefront &wf, uint32_t lane, uint64_t val) const {\n'
             f'  if (auto off = {_resolved_vgpr_encoded_call}) {{\n'
-            '    uint32_t idx = wf.vgpr_alloc().base + *off;\n'
+            '    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, true) : *off;\n'
+            '    uint32_t idx = wf.vgpr_alloc().base + voff;\n'
             '    wf.cu().write_vgpr(idx, lane, static_cast<uint32_t>(val));\n'
             '    wf.cu().write_vgpr(idx + 1, lane, static_cast<uint32_t>(val >> 32));\n'
             '    return;\n'

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/__init__.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/__init__.py
@@ -96,6 +96,8 @@ def _register_handlers() -> None:
         gen_vector_permlane64,
         gen_vector_cvt_pk,
         gen_vector_cvt_scale,
+        gen_cvt_fp8,
+        gen_cvt_scalef32,
     )
     from amdisa.codegen.execute.packed import (
         gen_pk_binop,
@@ -185,11 +187,17 @@ def _register_handlers() -> None:
         c.dst_ops, c.src_ops
     )
     DISPATCH['vector_cvt_pk'] = lambda c: gen_vector_cvt_pk(
-        c.dst_ops, c.src_ops, c.cls, c.op
+        c.dst_ops,
+        c.src_ops,
+        c.cls,
+        c.op,
+        opsel='inst_.op_sel' if c.is_vop3 and 'op_sel' in c.enc_field_names else '0u',
     )
     DISPATCH['vector_cvt_scale'] = lambda c: gen_vector_cvt_scale(
         c.dst_ops, c.src_ops, c.cls, c.op
     )
+    DISPATCH['cvt_fp8'] = lambda c: gen_cvt_fp8(c)
+    DISPATCH['cvt_scalef32'] = lambda c: gen_cvt_scalef32(c)
 
     # Packed
     DISPATCH['pk_binop'] = lambda c: gen_pk_binop(

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/vector_special.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/vector_special.py
@@ -632,7 +632,9 @@ def gen_vector_permlane64(dst: list[str], src: list[str]) -> str:
     return '\n'.join(L)
 
 
-def gen_vector_cvt_pk(dst: list[str], src: list[str], cls: str, op: str | None) -> str:
+def gen_vector_cvt_pk(
+    dst: list[str], src: list[str], cls: str, op: str | None, *, opsel: str = '0u'
+) -> str:
     """Generate pack/convert instructions."""
     L = []
     L.append('  uint64_t exec = wf.exec();')
@@ -705,17 +707,33 @@ def gen_vector_cvt_pk(dst: list[str], src: list[str], cls: str, op: str | None) 
                 )
             L.append(f'    uint32_t lo = {conv}(s0);')
             L.append(f'    uint32_t hi = {conv}(s1);')
-            L.append(f'    {dst[0]}.write_lane(wf, lane, lo | (hi << 8));')
+            L.append(
+                '    uint32_t packed = static_cast<uint32_t>(lo) | (static_cast<uint32_t>(hi) << 8);'
+            )
+            L.append(f'    bool word_hi = ({opsel} >> 3) & 1;')
+            L.append(f'    uint32_t old = {dst[0]}.read_lane(wf, lane);')
+            L.append('    if (word_hi)')
+            L.append(
+                f'      {dst[0]}.write_lane(wf, lane, (old & 0xFFFFu) | (packed << 16));'
+            )
+            L.append('    else')
+            L.append(
+                f'      {dst[0]}.write_lane(wf, lane, (old & 0xFFFF0000u) | (packed & 0xFFFFu));'
+            )
         elif op in ('f32_fp8', 'f32_bf8', 'f16_fp8', 'f16_bf8'):
             conv = (
                 'util::fp8_e4m3_to_f32'
                 if op.endswith('_fp8')
                 else 'util::bf8_e5m2_to_f32'
             )
-            L.append(f'    uint32_t raw = {src[0]}.read_lane(wf, lane);')
-            L.append(f'    float lo = {conv}(static_cast<uint8_t>(raw & 0xFFu));')
+            L.append(f'    uint32_t packed = {src[0]}.read_lane(wf, lane);')
+            L.append(f'    bool src_hi = {opsel} & 1;')
             L.append(
-                f'    float hi = {conv}(static_cast<uint8_t>((raw >> 8) & 0xFFu));'
+                '    uint32_t half = src_hi ? (packed >> 16) : (packed & 0xFFFFu);'
+            )
+            L.append(f'    float lo = {conv}(static_cast<uint8_t>(half & 0xFFu));')
+            L.append(
+                f'    float hi = {conv}(static_cast<uint8_t>((half >> 8) & 0xFFu));'
             )
             if op.startswith('f32_'):
                 L.append('    uint32_t lo_bits = std::bit_cast<uint32_t>(lo);')
@@ -808,6 +826,20 @@ def _scale_encode_call(fmt: str, value_expr: str) -> str:
     raise ValueError(f'unsupported scaled conversion output format: {fmt}')
 
 
+def _scale_sr_encode_call(fmt: str, value_expr: str, seed_expr: str) -> str:
+    if fmt == 'fp4':
+        return f'util::f32_to_fp4_e2m1_sr({value_expr}, {seed_expr})'
+    if fmt == 'fp6':
+        return f'util::f32_to_fp6_e2m3_sr({value_expr}, {seed_expr})'
+    if fmt == 'bf6':
+        return f'util::f32_to_bf6_e3m2_sr({value_expr}, {seed_expr})'
+    if fmt == 'fp8':
+        return f'util::f32_to_fp8_e4m3_sr({value_expr}, {seed_expr})'
+    if fmt == 'bf8':
+        return f'util::f32_to_bf8_e5m2_sr({value_expr}, {seed_expr})'
+    raise ValueError(f'unsupported scaled SR conversion output format: {fmt}')
+
+
 def _scale_lowp_bits(fmt: str) -> int:
     if fmt == 'fp4':
         return 4
@@ -888,7 +920,13 @@ def gen_vector_cvt_scale(
     if cls != 'vector_cvt_scale' or op is None:
         raise ValueError('vector_cvt_scale requires an operation')
 
-    parts = op.split('_')
+    stochastic = False
+    parsed_op = op
+    if parsed_op.startswith('sr_'):
+        stochastic = True
+        parsed_op = parsed_op[3:]
+
+    parts = parsed_op.split('_')
     if len(parts) != 4 or parts[1] not in ('pk8', 'pk16'):
         raise ValueError(f'unsupported vector_cvt_scale operation: {op}')
 
@@ -899,7 +937,14 @@ def gen_vector_cvt_scale(
     L.append('  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {')
     L.append('    if (!(exec & (1ULL << lane))) continue;')
     _scale_read_vgpr_base(L, 'dst_base', dst[0])
-    L.append(f'    float scale = std::bit_cast<float>({src[1]}.read_lane(wf, lane));')
+    scale_src = src[2] if stochastic else src[1]
+    L.append(
+        f'    float scale = std::bit_cast<float>({scale_src}.read_lane(wf, lane));'
+    )
+    if stochastic:
+        L.append(
+            f'    uint32_t seed = static_cast<uint32_t>({src[1]}.read_lane(wf, lane));'
+        )
 
     if direction == 'unpack':
         bits = _scale_lowp_bits(in_fmt)
@@ -959,15 +1004,797 @@ def gen_vector_cvt_scale(
         L.append('        dst_words[word + 1u] |= code >> (32u - shift);')
         L.append('    };')
         L.append(f'    for (uint32_t index = 0; index < {count}u; ++index) {{')
-        L.append('      float value = read_scaled_input(index) * scale;')
-        L.append(
-            f"      pack_scaled_dst(index, {_scale_encode_call(out_fmt, 'value')});"
-        )
+        L.append('      float value = read_scaled_input(index) / scale;')
+        if stochastic:
+            L.append(
+                f"      pack_scaled_dst(index, {_scale_sr_encode_call(out_fmt, 'value', 'seed')});"
+            )
+            L.append('      seed = util::prng_advance(seed);')
+        else:
+            L.append(
+                f"      pack_scaled_dst(index, {_scale_encode_call(out_fmt, 'value')});"
+            )
         L.append('    }')
         L.append(f'    for (uint32_t word = 0; word < {out_words}u; ++word)')
         L.append('      wf.cu().write_vgpr(dst_base + word, lane, dst_words[word]);')
     else:
         raise ValueError(f'unsupported vector_cvt_scale direction: {direction}')
+
+    L.append('  }')
+    return '\n'.join(L)
+
+
+# ---------------------------------------------------------------------------
+# Non-scaled FP8/BF8 pack/convert instructions (CDNA3/4, RDNA4)
+# ---------------------------------------------------------------------------
+
+
+def _opsel_field(ctx) -> str:
+    """Return the correct opsel field name for the current ISA encoding."""
+    if 'op_sel' in ctx.enc_field_names:
+        return 'inst_.op_sel'
+    if 'opsel' in ctx.enc_field_names:
+        return 'inst_.opsel'
+    return '0u'
+
+
+def gen_cvt_fp8(ctx) -> str:
+    """Generate execute body for non-scaled V_CVT_{PK,SR}_{FP8,BF8}_F32
+    and V_CVT_PK_F32_{FP8,BF8} instructions."""
+    from amdisa.codegen.execute import ExecuteContext
+
+    op = ctx.op
+    dst = ctx.dst_ops
+    src = ctx.src_ops
+    is_vop3 = ctx.is_vop3
+    opsel = _opsel_field(ctx) if is_vop3 else '0u'
+
+    L = []
+    L.append('  uint64_t exec = wf.exec();')
+    L.append('  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {')
+    L.append('    if (!(exec & (1ULL << lane))) continue;')
+
+    if op == 'pk_fp8_f32':
+        _gen_pk_narrow_fp8(L, dst, src, 'util::f32_to_fp8_e4m3_rne', opsel)
+    elif op == 'pk_bf8_f32':
+        _gen_pk_narrow_fp8(L, dst, src, 'util::f32_to_bf8_e5m2_rne', opsel)
+    elif op == 'sr_fp8_f32':
+        _gen_sr_narrow_fp8(L, dst, src, 'util::f32_to_fp8_e4m3_sr', opsel)
+    elif op == 'sr_bf8_f32':
+        _gen_sr_narrow_fp8(L, dst, src, 'util::f32_to_bf8_e5m2_sr', opsel)
+    elif op == 'pk_f32_fp8':
+        _gen_pk_widen_fp8(L, dst, src, 'util::fp8_e4m3_to_f32', opsel)
+    elif op == 'pk_f32_bf8':
+        _gen_pk_widen_fp8(L, dst, src, 'util::bf8_e5m2_to_f32', opsel)
+
+    L.append('  }')
+    return '\n'.join(L)
+
+
+def _gen_pk_narrow_fp8(
+    L: list[str], dst: list[str], src: list[str], cvt_fn: str, opsel: str = '0u'
+) -> None:
+    """Pack 2×F32 → 2×FP8/BF8 with OPSEL[3] half selection, R-M-W."""
+    L.append(
+        f'    float s0 = std::bit_cast<float>(static_cast<uint32_t>({src[0]}.read_lane(wf, lane)));'
+    )
+    L.append(
+        f'    float s1 = std::bit_cast<float>(static_cast<uint32_t>({src[1]}.read_lane(wf, lane)));'
+    )
+    L.append(f'    uint8_t r0 = {cvt_fn}(s0);')
+    L.append(f'    uint8_t r1 = {cvt_fn}(s1);')
+    L.append(
+        '    uint32_t packed = static_cast<uint32_t>(r0) | (static_cast<uint32_t>(r1) << 8);'
+    )
+    L.append(f'    bool hi = ({opsel} >> 3) & 1;')
+    L.append(f'    uint32_t old = {dst[0]}.read_lane(wf, lane);')
+    L.append('    if (hi)')
+    L.append(f'      {dst[0]}.write_lane(wf, lane, (old & 0xFFFFu) | (packed << 16));')
+    L.append('    else')
+    L.append(
+        f'      {dst[0]}.write_lane(wf, lane, (old & 0xFFFF0000u) | (packed & 0xFFFFu));'
+    )
+
+
+def _gen_sr_narrow_fp8(
+    L: list[str], dst: list[str], src: list[str], cvt_fn: str, opsel: str = '0u'
+) -> None:
+    """Single F32 → FP8/BF8 with stochastic rounding, OPSEL[3:2] byte sel, R-M-W."""
+    L.append(
+        f'    float s0 = std::bit_cast<float>(static_cast<uint32_t>({src[0]}.read_lane(wf, lane)));'
+    )
+    L.append(f'    uint32_t seed = {src[1]}.read_lane(wf, lane);')
+    L.append(f'    uint8_t result = {cvt_fn}(s0, seed);')
+    L.append(f'    uint32_t dst_byte = ({opsel} >> 2) & 0x3;')
+    L.append(f'    uint32_t old = {dst[0]}.read_lane(wf, lane);')
+    L.append('    uint32_t mask = ~(0xFFu << (dst_byte * 8));')
+    L.append(
+        f'    {dst[0]}.write_lane(wf, lane, (old & mask) | (static_cast<uint32_t>(result) << (dst_byte * 8)));'
+    )
+
+
+def _gen_pk_widen_fp8(
+    L: list[str], dst: list[str], src: list[str], cvt_fn: str, opsel: str = '0u'
+) -> None:
+    """Unpack 2×FP8/BF8 → 2×F32 with OPSEL[0] half selection."""
+    L.append(f'    uint32_t packed = {src[0]}.read_lane(wf, lane);')
+    L.append(f'    bool hi = {opsel} & 1;')
+    L.append('    uint32_t half = hi ? (packed >> 16) : (packed & 0xFFFFu);')
+    L.append(f'    float f0 = {cvt_fn}(static_cast<uint8_t>(half & 0xFF));')
+    L.append(f'    float f1 = {cvt_fn}(static_cast<uint8_t>((half >> 8) & 0xFF));')
+    L.append('    uint64_t result = static_cast<uint64_t>(std::bit_cast<uint32_t>(f0))')
+    L.append('        | (static_cast<uint64_t>(std::bit_cast<uint32_t>(f1)) << 32);')
+    L.append(f'    {dst[0]}.write_lane64(wf, lane, result);')
+
+
+# ---------------------------------------------------------------------------
+# Scaled FP8/BF8/FP4/FP6/BF6 format conversion instructions (CDNA4)
+# ---------------------------------------------------------------------------
+
+_NARROW_FMTS = frozenset({'fp8', 'bf8', 'fp4', 'fp6', 'bf6'})
+_WIDE_FMTS = frozenset({'f32', 'f16', 'bf16'})
+
+# Mapping from narrow format name → util:: conversion functions
+_NARROW_TO_F32 = {
+    'fp8': 'util::fp8_e4m3_to_f32',
+    'bf8': 'util::bf8_e5m2_to_f32',
+    'fp4': 'util::fp4_e2m1_to_f32',
+    'fp6': 'util::fp6_e2m3_to_f32',
+    'bf6': 'util::bf6_e3m2_to_f32',
+}
+_F32_TO_NARROW_RNE = {
+    'fp8': 'util::f32_to_fp8_e4m3_rne',
+    'bf8': 'util::f32_to_bf8_e5m2_rne',
+    'fp4': 'util::f32_to_fp4_e2m1_rne',
+    'fp6': 'util::f32_to_fp6_e2m3_rne',
+    'bf6': 'util::f32_to_bf6_e3m2_rne',
+}
+_F32_TO_NARROW_SR = {
+    'fp8': 'util::f32_to_fp8_e4m3_sr',
+    'bf8': 'util::f32_to_bf8_e5m2_sr',
+    'fp4': 'util::f32_to_fp4_e2m1_sr',
+    'fp6': 'util::f32_to_fp6_e2m3_sr',
+    'bf6': 'util::f32_to_bf6_e3m2_sr',
+}
+
+
+def _parse_scalef32_op(op: str):
+    """Parse a CVT_SCALEF32 operation suffix into components.
+
+    Returns (stochastic, mode, dst_fmt, src_fmt, direction).
+    """
+    s = op
+    stochastic = False
+    if s.startswith('sr_'):
+        stochastic = True
+        s = s[3:]
+
+    if s.startswith('2xpk16_'):
+        mode = '2xpk16'
+        s = s[7:]
+    elif s.startswith('pk32_'):
+        mode = 'pk32'
+        s = s[5:]
+    elif s.startswith('pk_'):
+        mode = 'pk'
+        s = s[3:]
+    else:
+        mode = 'single'
+
+    parts = s.split('_')
+    assert len(parts) == 2, f'unexpected scalef32 suffix: {op}'
+    dst_fmt, src_fmt = parts
+
+    if dst_fmt in _NARROW_FMTS and src_fmt in _WIDE_FMTS:
+        direction = 'narrow'
+    elif dst_fmt in _WIDE_FMTS and src_fmt in _NARROW_FMTS:
+        direction = 'widen'
+    else:
+        raise ValueError(f'cannot determine direction for {op}: {dst_fmt} vs {src_fmt}')
+
+    return stochastic, mode, dst_fmt, src_fmt, direction
+
+
+def _read_as_f32(src_name: str, src_fmt: str) -> str:
+    """Return C++ expression to read a source value as float."""
+    if src_fmt == 'f32':
+        return f'std::bit_cast<float>(static_cast<uint32_t>({src_name}.read_lane(wf, lane)))'
+    elif src_fmt == 'f16':
+        return f'util::f16_to_f32(static_cast<uint16_t>({src_name}.read_lane(wf, lane) & 0xFFFF))'
+    elif src_fmt == 'bf16':
+        return f'util::bf16_to_f32(static_cast<uint16_t>({src_name}.read_lane(wf, lane) & 0xFFFF))'
+    raise ValueError(f'unsupported source format: {src_fmt}')
+
+
+def _write_as_fmt(dst_name: str, dst_fmt: str, val_expr: str) -> str:
+    """Return C++ statement to write a float result in the target format."""
+    if dst_fmt == 'f32':
+        return f'{dst_name}.write_lane(wf, lane, std::bit_cast<uint32_t>({val_expr}));'
+    elif dst_fmt == 'f16':
+        return f'{dst_name}.write_lane(wf, lane, static_cast<uint32_t>(util::f32_to_f16({val_expr})));'
+    elif dst_fmt == 'bf16':
+        return f'{dst_name}.write_lane(wf, lane, static_cast<uint32_t>(util::f32_to_bf16({val_expr})));'
+    raise ValueError(f'unsupported dst format: {dst_fmt}')
+
+
+def _nan_for_fmt(dst_fmt: str) -> str:
+    """Return the quiet-NaN bit pattern for a wide format, or 0 for narrow."""
+    if dst_fmt in _NARROW_FMTS:
+        return '0u'
+    if dst_fmt == 'f32':
+        return '0x7FC00000u'
+    if dst_fmt == 'f16':
+        return 'static_cast<uint32_t>(0x7E00u)'
+    if dst_fmt == 'bf16':
+        return 'static_cast<uint32_t>(0x7FC0u)'
+    return '0x7FC00000u'
+
+
+def gen_cvt_scalef32(ctx) -> str:
+    """Generate execute body for V_CVT_SCALEF32_* instructions."""
+    from amdisa.codegen.execute import ExecuteContext
+
+    op = ctx.op
+    dst = ctx.dst_ops
+    src = ctx.src_ops
+    stochastic, mode, dst_fmt, src_fmt, direction = _parse_scalef32_op(op)
+
+    if mode in ('pk32', '2xpk16', 'sr_pk32'):
+        return _gen_wide_scalef32(ctx, stochastic, mode, dst_fmt, src_fmt, direction)
+
+    if direction == 'narrow':
+        if stochastic:
+            return _gen_sr_scalef32(ctx, mode, dst_fmt, src_fmt)
+        return _gen_narrow_scalef32(ctx, mode, dst_fmt, src_fmt)
+    else:
+        return _gen_widen_scalef32(ctx, mode, dst_fmt, src_fmt)
+
+
+def _scale_preamble(L: list[str], scale_src: str) -> None:
+    """Emit per-lane scale factor extraction with E8M0 NaN check."""
+    L.append(f'    uint32_t scale_bits = {scale_src}.read_lane(wf, lane);')
+    L.append('    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;')
+
+
+def _gen_narrow_scalef32(ctx, mode: str, dst_fmt: str, src_fmt: str) -> str:
+    """Narrowing: F32/F16/BF16 → FP8/BF8/FP4, with scale, RNE."""
+    dst = ctx.dst_ops
+    src = ctx.src_ops
+    cvt_fn = _F32_TO_NARROW_RNE[dst_fmt]
+    nan_val = _nan_for_fmt(dst_fmt)
+
+    L = []
+    L.append('  uint64_t exec = wf.exec();')
+    L.append('  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {')
+    L.append('    if (!(exec & (1ULL << lane))) continue;')
+
+    if mode == 'pk' and src_fmt == 'f32' and dst_fmt != 'fp4':
+        # 3-src: src0=F32[0], src1=F32[1], src2=scale
+        scale_src = src[2]
+        _scale_preamble(L, scale_src)
+        L.append(
+            f'    if (biased_exp == 0xFFu) {{ {dst[0]}.write_lane(wf, lane, {dst[0]}.read_lane(wf, lane)); continue; }}'
+        )
+        L.append(
+            '    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);'
+        )
+        L.append(
+            f'    float s0 = static_cast<float>(static_cast<double>(std::bit_cast<float>(static_cast<uint32_t>({src[0]}.read_lane(wf, lane)))) / scale);'
+        )
+        L.append(
+            f'    float s1 = static_cast<float>(static_cast<double>(std::bit_cast<float>(static_cast<uint32_t>({src[1]}.read_lane(wf, lane)))) / scale);'
+        )
+        L.append(f'    uint8_t r0 = {cvt_fn}(s0);')
+        L.append(f'    uint8_t r1 = {cvt_fn}(s1);')
+        L.append(
+            '    uint32_t packed = static_cast<uint32_t>(r0) | (static_cast<uint32_t>(r1) << 8);'
+        )
+        L.append('    bool hi = (inst_.op_sel >> 3) & 1;')
+        L.append(f'    uint32_t old = {dst[0]}.read_lane(wf, lane);')
+        L.append('    if (hi)')
+        L.append(
+            f'      {dst[0]}.write_lane(wf, lane, (old & 0xFFFFu) | (packed << 16));'
+        )
+        L.append('    else')
+        L.append(
+            f'      {dst[0]}.write_lane(wf, lane, (old & 0xFFFF0000u) | (packed & 0xFFFFu));'
+        )
+    elif mode == 'pk' and src_fmt in ('f16', 'bf16'):
+        # 2-src: src0=packed 2xF16/BF16, src1=scale
+        scale_src = src[1]
+        _scale_preamble(L, scale_src)
+        L.append(
+            f'    if (biased_exp == 0xFFu) {{ {dst[0]}.write_lane(wf, lane, {dst[0]}.read_lane(wf, lane)); continue; }}'
+        )
+        L.append(
+            '    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);'
+        )
+        L.append(f'    uint32_t packed_src = {src[0]}.read_lane(wf, lane);')
+        if src_fmt == 'f16':
+            L.append(
+                '    float s0 = static_cast<float>(static_cast<double>(util::f16_to_f32(static_cast<uint16_t>(packed_src & 0xFFFF))) / scale);'
+            )
+            L.append(
+                '    float s1 = static_cast<float>(static_cast<double>(util::f16_to_f32(static_cast<uint16_t>((packed_src >> 16) & 0xFFFF))) / scale);'
+            )
+        else:
+            L.append(
+                '    float s0 = static_cast<float>(static_cast<double>(util::bf16_to_f32(static_cast<uint16_t>(packed_src & 0xFFFF))) / scale);'
+            )
+            L.append(
+                '    float s1 = static_cast<float>(static_cast<double>(util::bf16_to_f32(static_cast<uint16_t>((packed_src >> 16) & 0xFFFF))) / scale);'
+            )
+        L.append(f'    uint8_t r0 = {cvt_fn}(s0);')
+        L.append(f'    uint8_t r1 = {cvt_fn}(s1);')
+        if dst_fmt == 'fp4':
+            L.append(
+                '    uint32_t packed = static_cast<uint32_t>(r0 & 0xF) | (static_cast<uint32_t>(r1 & 0xF) << 4);'
+            )
+            L.append('    uint32_t dst_byte = (inst_.op_sel >> 2) & 0x3;')
+            L.append(f'    uint32_t old = {dst[0]}.read_lane(wf, lane);')
+            L.append('    uint32_t mask = ~(0xFFu << (dst_byte * 8));')
+            L.append(
+                f'    {dst[0]}.write_lane(wf, lane, (old & mask) | (packed << (dst_byte * 8)));'
+            )
+        else:
+            L.append(
+                '    uint32_t packed = static_cast<uint32_t>(r0) | (static_cast<uint32_t>(r1) << 8);'
+            )
+            L.append('    bool hi = (inst_.op_sel >> 3) & 1;')
+            L.append(f'    uint32_t old = {dst[0]}.read_lane(wf, lane);')
+            L.append('    if (hi)')
+            L.append(
+                f'      {dst[0]}.write_lane(wf, lane, (old & 0xFFFFu) | (packed << 16));'
+            )
+            L.append('    else')
+            L.append(
+                f'      {dst[0]}.write_lane(wf, lane, (old & 0xFFFF0000u) | (packed & 0xFFFFu));'
+            )
+    elif mode == 'pk' and dst_fmt == 'fp4' and src_fmt == 'f32':
+        # 3-src: src0=F32[0], src1=F32[1], src2=scale → packed 2×FP4 (8-bit)
+        scale_src = src[2]
+        _scale_preamble(L, scale_src)
+        L.append(
+            f'    if (biased_exp == 0xFFu) {{ {dst[0]}.write_lane(wf, lane, {dst[0]}.read_lane(wf, lane)); continue; }}'
+        )
+        L.append(
+            '    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);'
+        )
+        L.append(
+            f'    float s0 = static_cast<float>(static_cast<double>(std::bit_cast<float>(static_cast<uint32_t>({src[0]}.read_lane(wf, lane)))) / scale);'
+        )
+        L.append(
+            f'    float s1 = static_cast<float>(static_cast<double>(std::bit_cast<float>(static_cast<uint32_t>({src[1]}.read_lane(wf, lane)))) / scale);'
+        )
+        L.append(f'    uint8_t r0 = {cvt_fn}(s0);')
+        L.append(f'    uint8_t r1 = {cvt_fn}(s1);')
+        L.append(
+            '    uint32_t packed = static_cast<uint32_t>(r0 & 0xF) | (static_cast<uint32_t>(r1 & 0xF) << 4);'
+        )
+        L.append('    uint32_t dst_byte = (inst_.op_sel >> 2) & 0x3;')
+        L.append(f'    uint32_t old = {dst[0]}.read_lane(wf, lane);')
+        L.append('    uint32_t mask = ~(0xFFu << (dst_byte * 8));')
+        L.append(
+            f'    {dst[0]}.write_lane(wf, lane, (old & mask) | (packed << (dst_byte * 8)));'
+        )
+
+    L.append('  }')
+    return '\n'.join(L)
+
+
+def _gen_sr_scalef32(ctx, mode: str, dst_fmt: str, src_fmt: str) -> str:
+    """Narrowing with stochastic rounding: scale + SR."""
+    dst = ctx.dst_ops
+    src = ctx.src_ops
+    cvt_fn = _F32_TO_NARROW_SR[dst_fmt]
+    op = ctx.op
+
+    L = []
+    is_sr_pk_fp4_f32 = op == 'sr_pk_fp4_f32'
+    if is_sr_pk_fp4_f32:
+        L.append('  auto &cu = wf.cu();')
+        L.append('  uint32_t vb = wf.vgpr_alloc().base;')
+    L.append('  uint64_t exec = wf.exec();')
+    L.append('  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {')
+    L.append('    if (!(exec & (1ULL << lane))) continue;')
+
+    if mode == 'pk' and dst_fmt == 'fp4':
+        data_src, random_src, scale_src = src[0], src[1], src[2]
+        _scale_preamble(L, scale_src)
+        L.append(
+            f'    if (biased_exp == 0xFFu) {{ {dst[0]}.write_lane(wf, lane, {dst[0]}.read_lane(wf, lane)); continue; }}'
+        )
+        L.append(
+            '    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);'
+        )
+        if is_sr_pk_fp4_f32:
+            L.append(
+                f'    uint32_t seed_lo = static_cast<uint32_t>({random_src}.read_lane(wf, lane));'
+            )
+            L.append(
+                f'    float val0 = std::bit_cast<float>(static_cast<uint32_t>({data_src}.read_lane(wf, lane)));'
+            )
+            L.append(
+                f'    float val1 = std::bit_cast<float>(cu.read_vgpr(vb + {data_src}.unified_vgpr_index() + 1, lane));'
+            )
+        else:
+            L.append(f'    uint32_t packed_src = {data_src}.read_lane(wf, lane);')
+            L.append(f'    uint32_t seed_lo = {random_src}.read_lane(wf, lane);')
+        if is_sr_pk_fp4_f32:
+            L.append(
+                '    float s0 = static_cast<float>(static_cast<double>(val0) / scale);'
+            )
+            L.append(
+                '    float s1 = static_cast<float>(static_cast<double>(val1) / scale);'
+            )
+            L.append(f'    uint8_t r0 = {cvt_fn}(s0, seed_lo);')
+            L.append('    uint32_t seed_hi = util::prng_advance(seed_lo);')
+            L.append(f'    uint8_t r1 = {cvt_fn}(s1, seed_hi);')
+        elif src_fmt == 'f16':
+            L.append(
+                '    float s0 = static_cast<float>(static_cast<double>(util::f16_to_f32(static_cast<uint16_t>(packed_src & 0xFFFF))) / scale);'
+            )
+            L.append(
+                '    float s1 = static_cast<float>(static_cast<double>(util::f16_to_f32(static_cast<uint16_t>((packed_src >> 16) & 0xFFFF))) / scale);'
+            )
+            L.append(f'    uint8_t r0 = {cvt_fn}(s0, seed_lo);')
+            L.append('    uint32_t seed_hi = util::prng_advance(seed_lo);')
+            L.append(f'    uint8_t r1 = {cvt_fn}(s1, seed_hi);')
+        elif src_fmt == 'bf16':
+            L.append(
+                '    float s0 = static_cast<float>(static_cast<double>(util::bf16_to_f32(static_cast<uint16_t>(packed_src & 0xFFFF))) / scale);'
+            )
+            L.append(
+                '    float s1 = static_cast<float>(static_cast<double>(util::bf16_to_f32(static_cast<uint16_t>((packed_src >> 16) & 0xFFFF))) / scale);'
+            )
+            L.append(f'    uint8_t r0 = {cvt_fn}(s0, seed_lo);')
+            L.append('    uint32_t seed_hi = util::prng_advance(seed_lo);')
+            L.append(f'    uint8_t r1 = {cvt_fn}(s1, seed_hi);')
+        L.append(
+            '    uint32_t packed = static_cast<uint32_t>(r0 & 0xF) | (static_cast<uint32_t>(r1 & 0xF) << 4);'
+        )
+        L.append('    uint32_t dst_byte = (inst_.op_sel >> 2) & 0x3;')
+        L.append(f'    uint32_t old = {dst[0]}.read_lane(wf, lane);')
+        L.append('    uint32_t mask = ~(0xFFu << (dst_byte * 8));')
+        L.append(
+            f'    {dst[0]}.write_lane(wf, lane, (old & mask) | (packed << (dst_byte * 8)));'
+        )
+    else:
+        # SR single FP8/BF8: src0=data, src1=random, src2=scale
+        data_src, random_src, scale_src = src[0], src[1], src[2]
+        _scale_preamble(L, scale_src)
+        L.append(
+            f'    if (biased_exp == 0xFFu) {{ {dst[0]}.write_lane(wf, lane, {dst[0]}.read_lane(wf, lane)); continue; }}'
+        )
+        L.append(
+            '    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);'
+        )
+        if src_fmt == 'f32':
+            L.append(
+                f'    float val = std::bit_cast<float>(static_cast<uint32_t>({data_src}.read_lane(wf, lane)));'
+            )
+        elif src_fmt == 'f16':
+            L.append(f'    uint32_t src_packed = {data_src}.read_lane(wf, lane);')
+            L.append(
+                '    float val = util::f16_to_f32(static_cast<uint16_t>(src_packed & 0xFFFF));'
+            )
+        else:
+            L.append(f'    uint32_t src_packed = {data_src}.read_lane(wf, lane);')
+            L.append(
+                '    float val = util::bf16_to_f32(static_cast<uint16_t>(src_packed & 0xFFFF));'
+            )
+        L.append(
+            '    float scaled = static_cast<float>(static_cast<double>(val) / scale);'
+        )
+        L.append(f'    uint32_t seed = {random_src}.read_lane(wf, lane);')
+        L.append(f'    uint8_t result = {cvt_fn}(scaled, seed);')
+        L.append('    uint32_t dst_byte = (inst_.op_sel >> 2) & 0x3;')
+        L.append(f'    uint32_t old = {dst[0]}.read_lane(wf, lane);')
+        L.append('    uint32_t mask = ~(0xFFu << (dst_byte * 8));')
+        L.append(
+            f'    {dst[0]}.write_lane(wf, lane, (old & mask) | (static_cast<uint32_t>(result) << (dst_byte * 8)));'
+        )
+
+    L.append('  }')
+    return '\n'.join(L)
+
+
+def _gen_widen_scalef32(ctx, mode: str, dst_fmt: str, src_fmt: str) -> str:
+    """Widening: FP8/BF8/FP4 → F32/F16/BF16, with scale."""
+    dst = ctx.dst_ops
+    src = ctx.src_ops
+    cvt_fn = _NARROW_TO_F32[src_fmt]
+    nan_val = _nan_for_fmt(dst_fmt)
+
+    L = []
+    L.append('  uint64_t exec = wf.exec();')
+    L.append('  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {')
+    L.append('    if (!(exec & (1ULL << lane))) continue;')
+
+    scale_src = src[1]
+    _scale_preamble(L, scale_src)
+
+    if mode == 'single':
+        # Single widening: src0 = narrow value (byte selected by OPSEL[1:0])
+        if dst_fmt in ('f16', 'bf16'):
+            conv = 'util::f32_to_f16' if dst_fmt == 'f16' else 'util::f32_to_bf16'
+            L.append('    bool hi = (inst_.op_sel >> 3) & 1;')
+            L.append(f'    uint32_t old = {dst[0]}.read_lane(wf, lane);')
+            L.append('    if (biased_exp == 0xFFu) {')
+            L.append(f'      uint32_t nv = {nan_val};')
+            L.append(
+                f'      {dst[0]}.write_lane(wf, lane, hi ? ((old & 0xFFFFu) | (nv << 16)) : ((old & 0xFFFF0000u) | nv));'
+            )
+            L.append('      continue;')
+            L.append('    }')
+        else:
+            L.append(
+                f'    if (biased_exp == 0xFFu) {{ {dst[0]}.write_lane(wf, lane, {nan_val}); continue; }}'
+            )
+        L.append(
+            '    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);'
+        )
+        L.append(f'    uint32_t src_raw = {src[0]}.read_lane(wf, lane);')
+        L.append('    uint32_t src_byte = inst_.op_sel & 0x3;')
+        if src_fmt == 'fp4':
+            L.append(
+                '    uint8_t narrow_val = static_cast<uint8_t>((src_raw >> (src_byte * 8)) & 0xF);'
+            )
+        else:
+            L.append(
+                '    uint8_t narrow_val = static_cast<uint8_t>((src_raw >> (src_byte * 8)) & 0xFF);'
+            )
+        L.append(
+            f'    float f = static_cast<float>(static_cast<double>({cvt_fn}(narrow_val)) * scale);'
+        )
+        if dst_fmt in ('f16', 'bf16'):
+            L.append(f'    uint32_t bits = static_cast<uint32_t>({conv}(f));')
+            L.append(
+                f'    {dst[0]}.write_lane(wf, lane, hi ? ((old & 0xFFFFu) | (bits << 16)) : ((old & 0xFFFF0000u) | (bits & 0xFFFFu)));'
+            )
+        else:
+            L.append(f'    {_write_as_fmt(dst[0], dst_fmt, "f")}')
+    elif mode == 'pk':
+        # Packed widening: 2 narrow values → 2 wide values
+        if src_fmt == 'fp4':
+            # OPSEL[1:0] selects source byte
+            L.append(f'    if (biased_exp == 0xFFu) {{')
+            if dst_fmt == 'f32':
+                L.append(
+                    f'      {dst[0]}.write_lane64(wf, lane, 0x7FC000007FC00000ULL); continue;'
+                )
+            else:
+                L.append(
+                    f'      {dst[0]}.write_lane(wf, lane, {nan_val} | ({nan_val} << 16)); continue;'
+                )
+            L.append('    }')
+            L.append(
+                '    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);'
+            )
+            L.append(f'    uint32_t src_raw = {src[0]}.read_lane(wf, lane);')
+            L.append('    uint32_t src_byte = inst_.op_sel & 0x3;')
+            L.append(
+                '    uint8_t byte_val = static_cast<uint8_t>((src_raw >> (src_byte * 8)) & 0xFF);'
+            )
+            L.append(
+                f'    float f0 = static_cast<float>(static_cast<double>({cvt_fn}(static_cast<uint8_t>(byte_val & 0xF))) * scale);'
+            )
+            L.append(
+                f'    float f1 = static_cast<float>(static_cast<double>({cvt_fn}(static_cast<uint8_t>((byte_val >> 4) & 0xF))) * scale);'
+            )
+        else:
+            # FP8/BF8: OPSEL[0] selects half
+            L.append(f'    if (biased_exp == 0xFFu) {{')
+            if dst_fmt == 'f32':
+                L.append(
+                    f'      {dst[0]}.write_lane64(wf, lane, 0x7FC000007FC00000ULL); continue;'
+                )
+            else:
+                L.append(
+                    f'      {dst[0]}.write_lane(wf, lane, {nan_val} | ({nan_val} << 16)); continue;'
+                )
+            L.append('    }')
+            L.append(
+                '    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);'
+            )
+            L.append(f'    uint32_t src_raw = {src[0]}.read_lane(wf, lane);')
+            L.append('    bool src_hi = inst_.op_sel & 1;')
+            L.append(
+                '    uint32_t half = src_hi ? (src_raw >> 16) : (src_raw & 0xFFFFu);'
+            )
+            L.append(
+                f'    float f0 = static_cast<float>(static_cast<double>({cvt_fn}(static_cast<uint8_t>(half & 0xFF))) * scale);'
+            )
+            L.append(
+                f'    float f1 = static_cast<float>(static_cast<double>({cvt_fn}(static_cast<uint8_t>((half >> 8) & 0xFF))) * scale);'
+            )
+
+        if dst_fmt == 'f32':
+            L.append(
+                '    uint64_t result = static_cast<uint64_t>(std::bit_cast<uint32_t>(f0))'
+            )
+            L.append(
+                '        | (static_cast<uint64_t>(std::bit_cast<uint32_t>(f1)) << 32);'
+            )
+            L.append(f'    {dst[0]}.write_lane64(wf, lane, result);')
+        elif dst_fmt == 'f16':
+            L.append(
+                '    uint32_t result = static_cast<uint32_t>(util::f32_to_f16(f0))'
+            )
+            L.append('        | (static_cast<uint32_t>(util::f32_to_f16(f1)) << 16);')
+            L.append(f'    {dst[0]}.write_lane(wf, lane, result);')
+        else:
+            L.append(
+                '    uint32_t result = static_cast<uint32_t>(util::f32_to_bf16(f0))'
+            )
+            L.append('        | (static_cast<uint32_t>(util::f32_to_bf16(f1)) << 16);')
+            L.append(f'    {dst[0]}.write_lane(wf, lane, result);')
+
+    L.append('  }')
+    return '\n'.join(L)
+
+
+def _gen_wide_scalef32(
+    ctx, stochastic: bool, mode: str, dst_fmt: str, src_fmt: str, direction: str
+) -> str:
+    """Wide (pk32/2xpk16) FP6/BF6 instructions — 32 elements across multi-VGPRs."""
+    dst = ctx.dst_ops
+    src = ctx.src_ops
+
+    L = []
+    L.append('  auto &cu = wf.cu();')
+    L.append('  uint32_t vb = wf.vgpr_alloc().base;')
+    L.append(
+        '  auto rd = [&](const auto &op, uint32_t lane, uint32_t dw) -> uint32_t {'
+    )
+    L.append('    return cu.read_vgpr(vb + op.unified_vgpr_index() + dw, lane);')
+    L.append('  };')
+    L.append(
+        '  auto wr = [&](const auto &op, uint32_t lane, uint32_t dw, uint32_t val) {'
+    )
+    L.append('    cu.write_vgpr(vb + op.unified_vgpr_index() + dw, lane, val);')
+    L.append('  };')
+
+    L.append('  uint64_t exec = wf.exec();')
+    L.append('  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {')
+    L.append('    if (!(exec & (1ULL << lane))) continue;')
+
+    scale_src = src[-1]
+    if stochastic and len(src) >= 3:
+        scale_src = src[2]
+        random_src = src[1]
+    elif len(src) >= 2:
+        scale_src = src[-1]
+
+    _scale_preamble(L, scale_src)
+    L.append('    if (biased_exp == 0xFFu) continue;')
+    L.append('    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);')
+
+    if direction == 'narrow':
+        cvt_fn = (
+            _F32_TO_NARROW_SR[dst_fmt] if stochastic else _F32_TO_NARROW_RNE[dst_fmt]
+        )
+        n_elems = 32
+        bits_per_elem = 6
+
+        if stochastic:
+            L.append(f'    uint32_t seed = {random_src}.read_lane(wf, lane);')
+
+        L.append(f'    uint8_t vals[{n_elems}];')
+
+        if mode == '2xpk16':
+            # src0 = 16×F32 (lo), src1 = 16×F32 (hi), interleaved in output:
+            # field[2k] = lo[k], field[2k+1] = hi[k]
+            for half in range(2):
+                s = src[half]
+                for j in range(16):
+                    idx = j * 2 + half
+                    L.append(f'    {{')
+                    L.append(
+                        f'      float v = std::bit_cast<float>(rd({s}, lane, {j}));'
+                    )
+                    L.append(
+                        f'      float sv = static_cast<float>(static_cast<double>(v) / scale);'
+                    )
+                    if stochastic:
+                        L.append(f'      vals[{idx}] = {cvt_fn}(sv, seed);')
+                        L.append(f'      seed = util::prng_advance(seed);')
+                    else:
+                        L.append(f'      vals[{idx}] = {cvt_fn}(sv);')
+                    L.append(f'    }}')
+        elif src_fmt == 'f32':
+            # sr_pk32: src0 = 32×F32 (32 DWORDs)
+            for j in range(32):
+                L.append(f'    {{')
+                L.append(
+                    f'      float v = std::bit_cast<float>(rd({src[0]}, lane, {j}));'
+                )
+                L.append(
+                    f'      float sv = static_cast<float>(static_cast<double>(v) / scale);'
+                )
+                if stochastic:
+                    L.append(f'      vals[{j}] = {cvt_fn}(sv, seed);')
+                    L.append(f'      seed = util::prng_advance(seed);')
+                else:
+                    L.append(f'      vals[{j}] = {cvt_fn}(sv);')
+                L.append(f'    }}')
+        else:
+            # pk32 from F16/BF16: src0 = 32×F16/BF16 (16 DWORDs, 2 per DWORD)
+            to_f32 = 'util::f16_to_f32' if src_fmt == 'f16' else 'util::bf16_to_f32'
+            for j in range(16):
+                L.append(f'    {{')
+                L.append(f'      uint32_t dw = rd({src[0]}, lane, {j});')
+                L.append(
+                    f'      float v0 = {to_f32}(static_cast<uint16_t>(dw & 0xFFFF));'
+                )
+                L.append(
+                    f'      float v1 = {to_f32}(static_cast<uint16_t>((dw >> 16) & 0xFFFF));'
+                )
+                L.append(
+                    f'      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);'
+                )
+                L.append(
+                    f'      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);'
+                )
+                if stochastic:
+                    L.append(f'      vals[{j*2}] = {cvt_fn}(sv0, seed);')
+                    L.append(f'      seed = util::prng_advance(seed);')
+                    L.append(f'      vals[{j*2+1}] = {cvt_fn}(sv1, seed);')
+                    L.append(f'      seed = util::prng_advance(seed);')
+                else:
+                    L.append(f'      vals[{j*2}] = {cvt_fn}(sv0);')
+                    L.append(f'      vals[{j*2+1}] = {cvt_fn}(sv1);')
+                L.append(f'    }}')
+
+        L.append('    uint32_t dwords[6];')
+        L.append('    util::pack_6bit(vals, dwords);')
+        for d in range(6):
+            L.append(f'    wr({dst[0]}, lane, {d}, dwords[{d}]);')
+
+    else:
+        # Widening: FP6/BF6 → F32/F16/BF16
+        cvt_fn = _NARROW_TO_F32[src_fmt]
+        n_elems = 32
+
+        L.append('    uint32_t src_dwords[6];')
+        for d in range(6):
+            L.append(f'    src_dwords[{d}] = rd({src[0]}, lane, {d});')
+        L.append('    uint8_t vals[32];')
+        L.append('    util::unpack_6bit(src_dwords, vals);')
+
+        if dst_fmt == 'f32':
+            for j in range(32):
+                L.append(
+                    f'    wr({dst[0]}, lane, {j}, std::bit_cast<uint32_t>(static_cast<float>(static_cast<double>({cvt_fn}(vals[{j}])) * scale)));'
+                )
+        elif dst_fmt == 'f16':
+            to_narrow = 'util::f32_to_f16'
+            for j in range(16):
+                L.append(f'    {{')
+                L.append(
+                    f'      float f0 = static_cast<float>(static_cast<double>({cvt_fn}(vals[{j*2}])) * scale);'
+                )
+                L.append(
+                    f'      float f1 = static_cast<float>(static_cast<double>({cvt_fn}(vals[{j*2+1}])) * scale);'
+                )
+                L.append(
+                    f'      wr({dst[0]}, lane, {j}, static_cast<uint32_t>({to_narrow}(f0)) | (static_cast<uint32_t>({to_narrow}(f1)) << 16));'
+                )
+                L.append(f'    }}')
+        else:
+            to_narrow = 'util::f32_to_bf16'
+            for j in range(16):
+                L.append(f'    {{')
+                L.append(
+                    f'      float f0 = static_cast<float>(static_cast<double>({cvt_fn}(vals[{j*2}])) * scale);'
+                )
+                L.append(
+                    f'      float f1 = static_cast<float>(static_cast<double>({cvt_fn}(vals[{j*2+1}])) * scale);'
+                )
+                L.append(
+                    f'      wr({dst[0]}, lane, {j}, static_cast<uint32_t>({to_narrow}(f0)) | (static_cast<uint32_t>({to_narrow}(f1)) << 16));'
+                )
+                L.append(f'    }}')
 
     L.append('  }')
     return '\n'.join(L)

--- a/emulation/rocjitsu/lib/python/amdisa/semantics.py
+++ b/emulation/rocjitsu/lib/python/amdisa/semantics.py
@@ -324,6 +324,10 @@ def _derive_sopp(name: str) -> InstructionSemantics | None:
     if name == 'S_BARRIER':
         return InstructionSemantics(name, 'barrier')
 
+    if name == 'S_SET_GPR_IDX_OFF':
+        return InstructionSemantics(name, 'gpr_idx', operation='off')
+    if name == 'S_SET_GPR_IDX_MODE':
+        return InstructionSemantics(name, 'gpr_idx', operation='mode')
     # S_NOP, S_SLEEP, S_SETHALT, S_SETPRIO, S_SENDMSG, S_ICACHE_INV,
     # S_INCPERFLEVEL, S_DECPERFLEVEL — all are either no-ops or system/debug
     # instructions that don't affect compute simulation correctness.
@@ -363,8 +367,8 @@ _SOP1_SPECIAL = {
     'S_SEXT_I32_I8': None,  # handled specially below
     'S_SEXT_I32_I16': None,
     'S_QUADMASK': ('scalar_unary', 'quadmask'),
-    'S_SET_GPR_IDX_ON': ('true_nop', None),
-    'S_SET_GPR_IDX_IDX': ('true_nop', None),
+    'S_SET_GPR_IDX_ON': ('gpr_idx', 'on'),
+    'S_SET_GPR_IDX_IDX': ('gpr_idx', 'idx'),
     'S_BITREPLICATE': ('scalar_bitreplicate', None),
     'S_CBRANCH_JOIN': ('true_nop', None),
     'S_BITREPL_B64_B32': ('scalar_bitreplicate', None),
@@ -612,7 +616,9 @@ def _derive_sopc(name: str) -> InstructionSemantics | None:
             return InstructionSemantics(
                 name, 'scalar_cmp', operation=op, data_type=_DTYPE_MAP[dt_raw]
             )
-    # Unrecognized SOPC instructions (S_SETVSKIP, S_SET_GPR_IDX_ON, …) → nop
+    if name == 'S_SET_GPR_IDX_ON':
+        return InstructionSemantics(name, 'gpr_idx', operation='on')
+    # Unrecognized SOPC instructions (S_SETVSKIP, …) → nop
     return InstructionSemantics(name, 'nop')
 
 
@@ -666,8 +672,9 @@ _VOP1_OP_MAP = {
     'V_CVT_F32_FP8': ('vector_unary', 'cvt_f32_fp8'),
     'V_CVT_F32_BF8': ('vector_unary', 'cvt_f32_bf8'),
     'V_CVT_F32_BF16': ('vector_unary', 'cvt_f32_bf16'),
-    'V_CVT_PK_F32_FP8': ('nop', None),  # TODO: needs dual-VGPR write
-    'V_CVT_PK_F32_BF8': ('nop', None),  # TODO: needs dual-VGPR write
+    'V_CVT_PK_F32_FP8': ('cvt_fp8', 'pk_f32_fp8'),
+    'V_CVT_PK_F32_BF8': ('cvt_fp8', 'pk_f32_bf8'),
+    'V_CVT_OFF_F32_I4': ('nop', None),
     'V_CVT_NORM_I16': ('vector_unary', 'cvt_norm_i16_f16'),
     'V_CVT_NORM_U16': ('vector_unary', 'cvt_norm_u16_f16'),
     'V_SWAP': ('vector_swap', None),
@@ -1298,22 +1305,49 @@ def _derive_vop3(name: str) -> InstructionSemantics | None:
             name, 'vector_cvt_scale', operation=scaled_pack_conversions[name]
         )
 
-    # FP8/BF8 stochastic-round pack/convert (non-scaled, CDNA3/4)
-    _FP8_PATTERNS = (
-        'V_CVT_SR_FP8_F32',
-        'V_CVT_SR_BF8_F32',
-        'V_CVT_PKNORM_I16_F16',
-        'V_CVT_PKNORM_U16_F16',
-    )
-    if name in _FP8_PATTERNS:
+    scaled_sr_pack_conversions = {
+        'V_CVT_SCALEF32_SR_PK8_FP4_F32': 'sr_pack_pk8_fp4_f32',
+        'V_CVT_SCALEF32_SR_PK8_FP4_F16': 'sr_pack_pk8_fp4_f16',
+        'V_CVT_SCALEF32_SR_PK8_FP4_BF16': 'sr_pack_pk8_fp4_bf16',
+        'V_CVT_SCALEF32_SR_PK8_FP8_F32': 'sr_pack_pk8_fp8_f32',
+        'V_CVT_SCALEF32_SR_PK8_FP8_F16': 'sr_pack_pk8_fp8_f16',
+        'V_CVT_SCALEF32_SR_PK8_FP8_BF16': 'sr_pack_pk8_fp8_bf16',
+        'V_CVT_SCALEF32_SR_PK8_BF8_F32': 'sr_pack_pk8_bf8_f32',
+        'V_CVT_SCALEF32_SR_PK8_BF8_F16': 'sr_pack_pk8_bf8_f16',
+        'V_CVT_SCALEF32_SR_PK8_BF8_BF16': 'sr_pack_pk8_bf8_bf16',
+        'V_CVT_SCALEF32_SR_PK16_FP6_F32': 'sr_pack_pk16_fp6_f32',
+        'V_CVT_SCALEF32_SR_PK16_FP6_F16': 'sr_pack_pk16_fp6_f16',
+        'V_CVT_SCALEF32_SR_PK16_FP6_BF16': 'sr_pack_pk16_fp6_bf16',
+        'V_CVT_SCALEF32_SR_PK16_BF6_F32': 'sr_pack_pk16_bf6_f32',
+        'V_CVT_SCALEF32_SR_PK16_BF6_F16': 'sr_pack_pk16_bf6_f16',
+        'V_CVT_SCALEF32_SR_PK16_BF6_BF16': 'sr_pack_pk16_bf6_bf16',
+    }
+    if name in scaled_sr_pack_conversions:
+        return InstructionSemantics(
+            name, 'vector_cvt_scale', operation=scaled_sr_pack_conversions[name]
+        )
+
+    # FP8/BF8 pack/convert (non-scaled, CDNA3/4/RDNA4)
+    _CVT_FP8_MAP = {
+        'V_CVT_SR_FP8_F32': 'sr_fp8_f32',
+        'V_CVT_SR_BF8_F32': 'sr_bf8_f32',
+    }
+    if name in _CVT_FP8_MAP:
+        return InstructionSemantics(name, 'cvt_fp8', operation=_CVT_FP8_MAP[name])
+
+    if name in ('V_CVT_PKNORM_I16_F16', 'V_CVT_PKNORM_U16_F16'):
         return InstructionSemantics(name, 'nop')
 
     # Scaled FP8/BF8/FP6/FP4 conversions not covered by the exact gfx1250
     # mappings above still need per-encoding validation.
     if 'CVT_SCALEF32' in name.upper():
-        return InstructionSemantics(
-            name, 'nop'
-        )  # scaled conversions not yet implemented
+        suffix = name.upper()
+        prefix = 'V_CVT_SCALEF32_'
+        if suffix.startswith(prefix):
+            op = suffix[len(prefix) :].lower()
+        else:
+            op = suffix.split('CVT_SCALEF32_', 1)[1].lower()
+        return InstructionSemantics(name, 'cvt_scalef32', operation=op)
 
     # V_PK_FMAC_F16 VOP2 form — the VOP3P form is handled via _VOP3P_PK16_MAP.
     if name == 'V_PK_FMAC_F16':

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna1/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna1/operand.cpp
@@ -1410,8 +1410,10 @@ uint32_t Operand::read_lane(const amdgpu::Wavefront &wf, uint32_t lane) const {
   if (delegate())
     return delegate()->read_lane(wf, lane);
   int ev = encoding_value_;
-  if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev))
-    return wf.cu().read_vgpr(wf.vgpr_alloc().base + *off, lane);
+  if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev)) {
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, false) : *off;
+    return wf.cu().read_vgpr(wf.vgpr_alloc().base + voff, lane);
+  }
   if (is_immediate_type(opr_type_))
     return static_cast<uint32_t>(ev);
   return resolve_src_scalar(wf, ev);
@@ -1423,7 +1425,8 @@ void Operand::write_scalar(amdgpu::Wavefront &wf, uint32_t val) const {
 
 void Operand::write_lane(amdgpu::Wavefront &wf, uint32_t lane, uint32_t val) const {
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, encoding_value_)) {
-    wf.cu().write_vgpr(wf.vgpr_alloc().base + *off, lane, val);
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, true) : *off;
+    wf.cu().write_vgpr(wf.vgpr_alloc().base + voff, lane, val);
     return;
   }
   throw std::logic_error("write_lane called on non-VGPR operand type");
@@ -1434,7 +1437,8 @@ uint64_t Operand::read_lane64(const amdgpu::Wavefront &wf, uint32_t lane) const 
     return delegate()->read_lane64(wf, lane);
   int ev = encoding_value_;
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev)) {
-    uint32_t idx = wf.vgpr_alloc().base + *off;
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, false) : *off;
+    uint32_t idx = wf.vgpr_alloc().base + voff;
     uint32_t lo = wf.cu().read_vgpr(idx, lane);
     uint32_t hi = wf.cu().read_vgpr(idx + 1, lane);
     return static_cast<uint64_t>(hi) << 32 | lo;
@@ -1448,7 +1452,8 @@ uint64_t Operand::read_lane64(const amdgpu::Wavefront &wf, uint32_t lane) const 
 
 void Operand::write_lane64(amdgpu::Wavefront &wf, uint32_t lane, uint64_t val) const {
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, encoding_value_)) {
-    uint32_t idx = wf.vgpr_alloc().base + *off;
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, true) : *off;
+    uint32_t idx = wf.vgpr_alloc().base + voff;
     wf.cu().write_vgpr(idx, lane, static_cast<uint32_t>(val));
     wf.cu().write_vgpr(idx + 1, lane, static_cast<uint32_t>(val >> 32));
     return;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna1/sopc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna1/sopc.cpp
@@ -428,8 +428,7 @@ SSetGprIdxOnSopc::SSetGprIdxOnSopc(const MachineInst *inst)
 }
 
 void SSetGprIdxOnSopc::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  amdgpu::execute_s_set_gpr_idx_on_sopc(*this, wf);
 }
 
 SCmpEqU64Sopc::SCmpEqU64Sopc(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna2/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna2/operand.cpp
@@ -1289,8 +1289,10 @@ uint32_t Operand::read_lane(const amdgpu::Wavefront &wf, uint32_t lane) const {
   if (delegate())
     return delegate()->read_lane(wf, lane);
   int ev = encoding_value_;
-  if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev))
-    return wf.cu().read_vgpr(wf.vgpr_alloc().base + *off, lane);
+  if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev)) {
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, false) : *off;
+    return wf.cu().read_vgpr(wf.vgpr_alloc().base + voff, lane);
+  }
   if (is_immediate_type(opr_type_))
     return static_cast<uint32_t>(ev);
   return resolve_src_scalar(wf, ev);
@@ -1302,7 +1304,8 @@ void Operand::write_scalar(amdgpu::Wavefront &wf, uint32_t val) const {
 
 void Operand::write_lane(amdgpu::Wavefront &wf, uint32_t lane, uint32_t val) const {
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, encoding_value_)) {
-    wf.cu().write_vgpr(wf.vgpr_alloc().base + *off, lane, val);
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, true) : *off;
+    wf.cu().write_vgpr(wf.vgpr_alloc().base + voff, lane, val);
     return;
   }
   throw std::logic_error("write_lane called on non-VGPR operand type");
@@ -1313,7 +1316,8 @@ uint64_t Operand::read_lane64(const amdgpu::Wavefront &wf, uint32_t lane) const 
     return delegate()->read_lane64(wf, lane);
   int ev = encoding_value_;
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev)) {
-    uint32_t idx = wf.vgpr_alloc().base + *off;
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, false) : *off;
+    uint32_t idx = wf.vgpr_alloc().base + voff;
     uint32_t lo = wf.cu().read_vgpr(idx, lane);
     uint32_t hi = wf.cu().read_vgpr(idx + 1, lane);
     return static_cast<uint64_t>(hi) << 32 | lo;
@@ -1327,7 +1331,8 @@ uint64_t Operand::read_lane64(const amdgpu::Wavefront &wf, uint32_t lane) const 
 
 void Operand::write_lane64(amdgpu::Wavefront &wf, uint32_t lane, uint64_t val) const {
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, encoding_value_)) {
-    uint32_t idx = wf.vgpr_alloc().base + *off;
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, true) : *off;
+    uint32_t idx = wf.vgpr_alloc().base + voff;
     wf.cu().write_vgpr(idx, lane, static_cast<uint32_t>(val));
     wf.cu().write_vgpr(idx + 1, lane, static_cast<uint32_t>(val >> 32));
     return;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna2/sopc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna2/sopc.cpp
@@ -428,8 +428,7 @@ SSetGprIdxOnSopc::SSetGprIdxOnSopc(const MachineInst *inst)
 }
 
 void SSetGprIdxOnSopc::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  amdgpu::execute_s_set_gpr_idx_on_sopc(*this, wf);
 }
 
 SCmpEqU64Sopc::SCmpEqU64Sopc(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/operand.cpp
@@ -1289,8 +1289,10 @@ uint32_t Operand::read_lane(const amdgpu::Wavefront &wf, uint32_t lane) const {
   if (delegate())
     return delegate()->read_lane(wf, lane);
   int ev = encoding_value_;
-  if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev))
-    return wf.cu().read_vgpr(wf.vgpr_alloc().base + *off, lane);
+  if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev)) {
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, false) : *off;
+    return wf.cu().read_vgpr(wf.vgpr_alloc().base + voff, lane);
+  }
   if (is_immediate_type(opr_type_))
     return static_cast<uint32_t>(ev);
   return resolve_src_scalar(wf, ev);
@@ -1302,7 +1304,8 @@ void Operand::write_scalar(amdgpu::Wavefront &wf, uint32_t val) const {
 
 void Operand::write_lane(amdgpu::Wavefront &wf, uint32_t lane, uint32_t val) const {
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, encoding_value_)) {
-    wf.cu().write_vgpr(wf.vgpr_alloc().base + *off, lane, val);
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, true) : *off;
+    wf.cu().write_vgpr(wf.vgpr_alloc().base + voff, lane, val);
     return;
   }
   throw std::logic_error("write_lane called on non-VGPR operand type");
@@ -1313,7 +1316,8 @@ uint64_t Operand::read_lane64(const amdgpu::Wavefront &wf, uint32_t lane) const 
     return delegate()->read_lane64(wf, lane);
   int ev = encoding_value_;
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev)) {
-    uint32_t idx = wf.vgpr_alloc().base + *off;
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, false) : *off;
+    uint32_t idx = wf.vgpr_alloc().base + voff;
     uint32_t lo = wf.cu().read_vgpr(idx, lane);
     uint32_t hi = wf.cu().read_vgpr(idx + 1, lane);
     return static_cast<uint64_t>(hi) << 32 | lo;
@@ -1327,7 +1331,8 @@ uint64_t Operand::read_lane64(const amdgpu::Wavefront &wf, uint32_t lane) const 
 
 void Operand::write_lane64(amdgpu::Wavefront &wf, uint32_t lane, uint64_t val) const {
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, encoding_value_)) {
-    uint32_t idx = wf.vgpr_alloc().base + *off;
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, true) : *off;
+    uint32_t idx = wf.vgpr_alloc().base + voff;
     wf.cu().write_vgpr(idx, lane, static_cast<uint32_t>(val));
     wf.cu().write_vgpr(idx + 1, lane, static_cast<uint32_t>(val >> 32));
     return;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/sopc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/sopc.cpp
@@ -428,8 +428,7 @@ SSetGprIdxOnSopc::SSetGprIdxOnSopc(const MachineInst *inst)
 }
 
 void SSetGprIdxOnSopc::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  amdgpu::execute_s_set_gpr_idx_on_sopc(*this, wf);
 }
 
 SCmpEqU64Sopc::SCmpEqU64Sopc(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/vop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/vop1.cpp
@@ -10483,7 +10483,20 @@ void VCvtPkF32Fp8Vop1::execute_impl(amdgpu::Wavefront &wf) {
   }
   if (dpp_src0_)
     src0.set_delegate(dpp_src0_.get());
-  amdgpu::execute_v_cvt_pk_f32_fp8_vop1(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t packed = src0.read_lane(wf, lane);
+    bool src_hi = 0u & 1;
+    uint32_t half = src_hi ? (packed >> 16) : (packed & 0xFFFFu);
+    float lo = util::fp8_e4m3_to_f32(static_cast<uint8_t>(half & 0xFFu));
+    float hi = util::fp8_e4m3_to_f32(static_cast<uint8_t>((half >> 8) & 0xFFu));
+    uint32_t lo_bits = std::bit_cast<uint32_t>(lo);
+    uint32_t hi_bits = std::bit_cast<uint32_t>(hi);
+    vdst.write_lane64(wf, lane,
+                      static_cast<uint64_t>(lo_bits) | (static_cast<uint64_t>(hi_bits) << 32));
+  }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
@@ -10609,7 +10622,20 @@ void VCvtPkF32Bf8Vop1::execute_impl(amdgpu::Wavefront &wf) {
   }
   if (dpp_src0_)
     src0.set_delegate(dpp_src0_.get());
-  amdgpu::execute_v_cvt_pk_f32_bf8_vop1(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t packed = src0.read_lane(wf, lane);
+    bool src_hi = 0u & 1;
+    uint32_t half = src_hi ? (packed >> 16) : (packed & 0xFFFFu);
+    float lo = util::bf8_e5m2_to_f32(static_cast<uint8_t>(half & 0xFFu));
+    float hi = util::bf8_e5m2_to_f32(static_cast<uint8_t>((half >> 8) & 0xFFu));
+    uint32_t lo_bits = std::bit_cast<uint32_t>(lo);
+    uint32_t hi_bits = std::bit_cast<uint32_t>(hi);
+    vdst.write_lane64(wf, lane,
+                      static_cast<uint64_t>(lo_bits) | (static_cast<uint64_t>(hi_bits) << 32));
+  }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/vop3.cpp
@@ -1177,7 +1177,20 @@ VCvtPkF32Fp8Vop3::VCvtPkF32Fp8Vop3(const MachineInst *inst)
 }
 
 void VCvtPkF32Fp8Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cvt_pk_f32_fp8_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t packed = src0.read_lane(wf, lane);
+    bool src_hi = inst_.op_sel & 1;
+    uint32_t half = src_hi ? (packed >> 16) : (packed & 0xFFFFu);
+    float lo = util::fp8_e4m3_to_f32(static_cast<uint8_t>(half & 0xFFu));
+    float hi = util::fp8_e4m3_to_f32(static_cast<uint8_t>((half >> 8) & 0xFFu));
+    uint32_t lo_bits = std::bit_cast<uint32_t>(lo);
+    uint32_t hi_bits = std::bit_cast<uint32_t>(hi);
+    vdst.write_lane64(wf, lane,
+                      static_cast<uint64_t>(lo_bits) | (static_cast<uint64_t>(hi_bits) << 32));
+  }
 }
 
 VCvtPkF32Bf8Vop3::VCvtPkF32Bf8Vop3(const MachineInst *inst)
@@ -1192,7 +1205,20 @@ VCvtPkF32Bf8Vop3::VCvtPkF32Bf8Vop3(const MachineInst *inst)
 }
 
 void VCvtPkF32Bf8Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cvt_pk_f32_bf8_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t packed = src0.read_lane(wf, lane);
+    bool src_hi = inst_.op_sel & 1;
+    uint32_t half = src_hi ? (packed >> 16) : (packed & 0xFFFFu);
+    float lo = util::bf8_e5m2_to_f32(static_cast<uint8_t>(half & 0xFFu));
+    float hi = util::bf8_e5m2_to_f32(static_cast<uint8_t>((half >> 8) & 0xFFu));
+    uint32_t lo_bits = std::bit_cast<uint32_t>(lo);
+    uint32_t hi_bits = std::bit_cast<uint32_t>(hi);
+    vdst.write_lane64(wf, lane,
+                      static_cast<uint64_t>(lo_bits) | (static_cast<uint64_t>(hi_bits) << 32));
+  }
 }
 
 VCndmaskB32Vop3::VCndmaskB32Vop3(const MachineInst *inst)
@@ -3745,7 +3771,13 @@ void VCvtPkFp8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
     float s1 = std::bit_cast<float>(src1.read_lane(wf, lane));
     uint32_t lo = util::f32_to_fp8_e4m3_rne(s0);
     uint32_t hi = util::f32_to_fp8_e4m3_rne(s1);
-    vdst.write_lane(wf, lane, lo | (hi << 8));
+    uint32_t packed = static_cast<uint32_t>(lo) | (static_cast<uint32_t>(hi) << 8);
+    bool word_hi = (inst_.op_sel >> 3) & 1;
+    uint32_t old = vdst.read_lane(wf, lane);
+    if (word_hi)
+      vdst.write_lane(wf, lane, (old & 0xFFFFu) | (packed << 16));
+    else
+      vdst.write_lane(wf, lane, (old & 0xFFFF0000u) | (packed & 0xFFFFu));
   }
 }
 
@@ -3772,7 +3804,13 @@ void VCvtPkBf8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
     float s1 = std::bit_cast<float>(src1.read_lane(wf, lane));
     uint32_t lo = util::f32_to_bf8_e5m2_rne(s0);
     uint32_t hi = util::f32_to_bf8_e5m2_rne(s1);
-    vdst.write_lane(wf, lane, lo | (hi << 8));
+    uint32_t packed = static_cast<uint32_t>(lo) | (static_cast<uint32_t>(hi) << 8);
+    bool word_hi = (inst_.op_sel >> 3) & 1;
+    uint32_t old = vdst.read_lane(wf, lane);
+    if (word_hi)
+      vdst.write_lane(wf, lane, (old & 0xFFFFu) | (packed << 16));
+    else
+      vdst.write_lane(wf, lane, (old & 0xFFFF0000u) | (packed & 0xFFFFu));
   }
 }
 
@@ -3791,8 +3829,18 @@ VCvtSrFp8F32Vop3::VCvtSrFp8F32Vop3(const MachineInst *inst)
 }
 
 void VCvtSrFp8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    float s0 = std::bit_cast<float>(static_cast<uint32_t>(src0.read_lane(wf, lane)));
+    uint32_t seed = src1.read_lane(wf, lane);
+    uint8_t result = util::f32_to_fp8_e4m3_sr(s0, seed);
+    uint32_t dst_byte = (inst_.op_sel >> 2) & 0x3;
+    uint32_t old = vdst.read_lane(wf, lane);
+    uint32_t mask = ~(0xFFu << (dst_byte * 8));
+    vdst.write_lane(wf, lane, (old & mask) | (static_cast<uint32_t>(result) << (dst_byte * 8)));
+  }
 }
 
 VCvtSrBf8F32Vop3::VCvtSrBf8F32Vop3(const MachineInst *inst)
@@ -3810,8 +3858,18 @@ VCvtSrBf8F32Vop3::VCvtSrBf8F32Vop3(const MachineInst *inst)
 }
 
 void VCvtSrBf8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    float s0 = std::bit_cast<float>(static_cast<uint32_t>(src0.read_lane(wf, lane)));
+    uint32_t seed = src1.read_lane(wf, lane);
+    uint8_t result = util::f32_to_bf8_e5m2_sr(s0, seed);
+    uint32_t dst_byte = (inst_.op_sel >> 2) & 0x3;
+    uint32_t old = vdst.read_lane(wf, lane);
+    uint32_t mask = ~(0xFFu << (dst_byte * 8));
+    vdst.write_lane(wf, lane, (old & mask) | (static_cast<uint32_t>(result) << (dst_byte * 8)));
+  }
 }
 
 VCmpClassF32Vop3::VCmpClassF32Vop3(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/operand.cpp
@@ -1611,8 +1611,10 @@ uint32_t Operand::read_lane(const amdgpu::Wavefront &wf, uint32_t lane) const {
   if (delegate())
     return delegate()->read_lane(wf, lane);
   int ev = encoding_value_;
-  if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev))
-    return wf.cu().read_vgpr(wf.vgpr_alloc().base + *off, lane);
+  if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev)) {
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, false) : *off;
+    return wf.cu().read_vgpr(wf.vgpr_alloc().base + voff, lane);
+  }
   if (is_immediate_type(opr_type_))
     return static_cast<uint32_t>(ev);
   return resolve_src_scalar(wf, ev);
@@ -1624,7 +1626,8 @@ void Operand::write_scalar(amdgpu::Wavefront &wf, uint32_t val) const {
 
 void Operand::write_lane(amdgpu::Wavefront &wf, uint32_t lane, uint32_t val) const {
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, encoding_value_)) {
-    wf.cu().write_vgpr(wf.vgpr_alloc().base + *off, lane, val);
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, true) : *off;
+    wf.cu().write_vgpr(wf.vgpr_alloc().base + voff, lane, val);
     return;
   }
   throw std::logic_error("write_lane called on non-VGPR operand type");
@@ -1635,7 +1638,8 @@ uint64_t Operand::read_lane64(const amdgpu::Wavefront &wf, uint32_t lane) const 
     return delegate()->read_lane64(wf, lane);
   int ev = encoding_value_;
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev)) {
-    uint32_t idx = wf.vgpr_alloc().base + *off;
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, false) : *off;
+    uint32_t idx = wf.vgpr_alloc().base + voff;
     uint32_t lo = wf.cu().read_vgpr(idx, lane);
     uint32_t hi = wf.cu().read_vgpr(idx + 1, lane);
     return static_cast<uint64_t>(hi) << 32 | lo;
@@ -1649,7 +1653,8 @@ uint64_t Operand::read_lane64(const amdgpu::Wavefront &wf, uint32_t lane) const 
 
 void Operand::write_lane64(amdgpu::Wavefront &wf, uint32_t lane, uint64_t val) const {
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, encoding_value_)) {
-    uint32_t idx = wf.vgpr_alloc().base + *off;
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, true) : *off;
+    uint32_t idx = wf.vgpr_alloc().base + voff;
     wf.cu().write_vgpr(idx, lane, static_cast<uint32_t>(val));
     wf.cu().write_vgpr(idx + 1, lane, static_cast<uint32_t>(val >> 32));
     return;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/sopc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/sopc.cpp
@@ -428,8 +428,7 @@ SSetGprIdxOnSopc::SSetGprIdxOnSopc(const MachineInst *inst)
 }
 
 void SSetGprIdxOnSopc::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  amdgpu::execute_s_set_gpr_idx_on_sopc(*this, wf);
 }
 
 SCmpEqU64Sopc::SCmpEqU64Sopc(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/sopp.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/sopp.cpp
@@ -434,7 +434,9 @@ SSetGprIdxModeSopp::SSetGprIdxModeSopp(const MachineInst *inst)
   num_dst_ = 0;
 }
 
-void SSetGprIdxModeSopp::execute_impl(amdgpu::Wavefront &wf) { (void)wf; }
+void SSetGprIdxModeSopp::execute_impl(amdgpu::Wavefront &wf) {
+  wf.set_m0((wf.m0() & 0xFFFFF0FFu) | ((simm16.read_scalar(wf) & 0xF) << 8));
+}
 
 SEndpgmOrderedPsDoneSopp::SEndpgmOrderedPsDoneSopp(const MachineInst *inst)
     : Sopp("s_endpgm_ordered_ps_done", reinterpret_cast<const OpEncoding *>(inst),

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop1.cpp
@@ -10766,7 +10766,20 @@ void VCvtPkF32Fp8Vop1::execute_impl(amdgpu::Wavefront &wf) {
   }
   if (dpp_src0_)
     src0.set_delegate(dpp_src0_.get());
-  amdgpu::execute_v_cvt_pk_f32_fp8_vop1(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t packed = src0.read_lane(wf, lane);
+    bool src_hi = 0u & 1;
+    uint32_t half = src_hi ? (packed >> 16) : (packed & 0xFFFFu);
+    float lo = util::fp8_e4m3_to_f32(static_cast<uint8_t>(half & 0xFFu));
+    float hi = util::fp8_e4m3_to_f32(static_cast<uint8_t>((half >> 8) & 0xFFu));
+    uint32_t lo_bits = std::bit_cast<uint32_t>(lo);
+    uint32_t hi_bits = std::bit_cast<uint32_t>(hi);
+    vdst.write_lane64(wf, lane,
+                      static_cast<uint64_t>(lo_bits) | (static_cast<uint64_t>(hi_bits) << 32));
+  }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
@@ -10892,7 +10905,20 @@ void VCvtPkF32Bf8Vop1::execute_impl(amdgpu::Wavefront &wf) {
   }
   if (dpp_src0_)
     src0.set_delegate(dpp_src0_.get());
-  amdgpu::execute_v_cvt_pk_f32_bf8_vop1(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t packed = src0.read_lane(wf, lane);
+    bool src_hi = 0u & 1;
+    uint32_t half = src_hi ? (packed >> 16) : (packed & 0xFFFFu);
+    float lo = util::bf8_e5m2_to_f32(static_cast<uint8_t>(half & 0xFFu));
+    float hi = util::bf8_e5m2_to_f32(static_cast<uint8_t>((half >> 8) & 0xFFu));
+    uint32_t lo_bits = std::bit_cast<uint32_t>(lo);
+    uint32_t hi_bits = std::bit_cast<uint32_t>(hi);
+    vdst.write_lane64(wf, lane,
+                      static_cast<uint64_t>(lo_bits) | (static_cast<uint64_t>(hi_bits) << 32));
+  }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3.cpp
@@ -1258,7 +1258,20 @@ VCvtPkF32Fp8Vop3::VCvtPkF32Fp8Vop3(const MachineInst *inst)
 }
 
 void VCvtPkF32Fp8Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cvt_pk_f32_fp8_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t packed = src0.read_lane(wf, lane);
+    bool src_hi = inst_.op_sel & 1;
+    uint32_t half = src_hi ? (packed >> 16) : (packed & 0xFFFFu);
+    float lo = util::fp8_e4m3_to_f32(static_cast<uint8_t>(half & 0xFFu));
+    float hi = util::fp8_e4m3_to_f32(static_cast<uint8_t>((half >> 8) & 0xFFu));
+    uint32_t lo_bits = std::bit_cast<uint32_t>(lo);
+    uint32_t hi_bits = std::bit_cast<uint32_t>(hi);
+    vdst.write_lane64(wf, lane,
+                      static_cast<uint64_t>(lo_bits) | (static_cast<uint64_t>(hi_bits) << 32));
+  }
 }
 
 VCvtPkF32Bf8Vop3::VCvtPkF32Bf8Vop3(const MachineInst *inst)
@@ -1273,7 +1286,20 @@ VCvtPkF32Bf8Vop3::VCvtPkF32Bf8Vop3(const MachineInst *inst)
 }
 
 void VCvtPkF32Bf8Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cvt_pk_f32_bf8_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t packed = src0.read_lane(wf, lane);
+    bool src_hi = inst_.op_sel & 1;
+    uint32_t half = src_hi ? (packed >> 16) : (packed & 0xFFFFu);
+    float lo = util::bf8_e5m2_to_f32(static_cast<uint8_t>(half & 0xFFu));
+    float hi = util::bf8_e5m2_to_f32(static_cast<uint8_t>((half >> 8) & 0xFFu));
+    uint32_t lo_bits = std::bit_cast<uint32_t>(lo);
+    uint32_t hi_bits = std::bit_cast<uint32_t>(hi);
+    vdst.write_lane64(wf, lane,
+                      static_cast<uint64_t>(lo_bits) | (static_cast<uint64_t>(hi_bits) << 32));
+  }
 }
 
 VPrngB32Vop3::VPrngB32Vop3(const MachineInst *inst)
@@ -3541,8 +3567,33 @@ VCvtScalef32PkFp8F32Vop3::VCvtScalef32PkFp8F32Vop3(const MachineInst *inst)
 }
 
 void VCvtScalef32PkFp8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src2.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu) {
+      vdst.write_lane(wf, lane, vdst.read_lane(wf, lane));
+      continue;
+    }
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    float s0 = static_cast<float>(
+        static_cast<double>(std::bit_cast<float>(static_cast<uint32_t>(src0.read_lane(wf, lane)))) /
+        scale);
+    float s1 = static_cast<float>(
+        static_cast<double>(std::bit_cast<float>(static_cast<uint32_t>(src1.read_lane(wf, lane)))) /
+        scale);
+    uint8_t r0 = util::f32_to_fp8_e4m3_rne(s0);
+    uint8_t r1 = util::f32_to_fp8_e4m3_rne(s1);
+    uint32_t packed = static_cast<uint32_t>(r0) | (static_cast<uint32_t>(r1) << 8);
+    bool hi = (inst_.op_sel >> 3) & 1;
+    uint32_t old = vdst.read_lane(wf, lane);
+    if (hi)
+      vdst.write_lane(wf, lane, (old & 0xFFFFu) | (packed << 16));
+    else
+      vdst.write_lane(wf, lane, (old & 0xFFFF0000u) | (packed & 0xFFFFu));
+  }
 }
 
 VCvtScalef32PkBf8F32Vop3::VCvtScalef32PkBf8F32Vop3(const MachineInst *inst)
@@ -3561,8 +3612,33 @@ VCvtScalef32PkBf8F32Vop3::VCvtScalef32PkBf8F32Vop3(const MachineInst *inst)
 }
 
 void VCvtScalef32PkBf8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src2.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu) {
+      vdst.write_lane(wf, lane, vdst.read_lane(wf, lane));
+      continue;
+    }
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    float s0 = static_cast<float>(
+        static_cast<double>(std::bit_cast<float>(static_cast<uint32_t>(src0.read_lane(wf, lane)))) /
+        scale);
+    float s1 = static_cast<float>(
+        static_cast<double>(std::bit_cast<float>(static_cast<uint32_t>(src1.read_lane(wf, lane)))) /
+        scale);
+    uint8_t r0 = util::f32_to_bf8_e5m2_rne(s0);
+    uint8_t r1 = util::f32_to_bf8_e5m2_rne(s1);
+    uint32_t packed = static_cast<uint32_t>(r0) | (static_cast<uint32_t>(r1) << 8);
+    bool hi = (inst_.op_sel >> 3) & 1;
+    uint32_t old = vdst.read_lane(wf, lane);
+    if (hi)
+      vdst.write_lane(wf, lane, (old & 0xFFFFu) | (packed << 16));
+    else
+      vdst.write_lane(wf, lane, (old & 0xFFFF0000u) | (packed & 0xFFFFu));
+  }
 }
 
 VCvtScalef32SrFp8F32Vop3::VCvtScalef32SrFp8F32Vop3(const MachineInst *inst)
@@ -3581,8 +3657,26 @@ VCvtScalef32SrFp8F32Vop3::VCvtScalef32SrFp8F32Vop3(const MachineInst *inst)
 }
 
 void VCvtScalef32SrFp8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src2.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu) {
+      vdst.write_lane(wf, lane, vdst.read_lane(wf, lane));
+      continue;
+    }
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    float val = std::bit_cast<float>(static_cast<uint32_t>(src0.read_lane(wf, lane)));
+    float scaled = static_cast<float>(static_cast<double>(val) / scale);
+    uint32_t seed = src1.read_lane(wf, lane);
+    uint8_t result = util::f32_to_fp8_e4m3_sr(scaled, seed);
+    uint32_t dst_byte = (inst_.op_sel >> 2) & 0x3;
+    uint32_t old = vdst.read_lane(wf, lane);
+    uint32_t mask = ~(0xFFu << (dst_byte * 8));
+    vdst.write_lane(wf, lane, (old & mask) | (static_cast<uint32_t>(result) << (dst_byte * 8)));
+  }
 }
 
 VCvtScalef32SrBf8F32Vop3::VCvtScalef32SrBf8F32Vop3(const MachineInst *inst)
@@ -3601,8 +3695,26 @@ VCvtScalef32SrBf8F32Vop3::VCvtScalef32SrBf8F32Vop3(const MachineInst *inst)
 }
 
 void VCvtScalef32SrBf8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src2.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu) {
+      vdst.write_lane(wf, lane, vdst.read_lane(wf, lane));
+      continue;
+    }
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    float val = std::bit_cast<float>(static_cast<uint32_t>(src0.read_lane(wf, lane)));
+    float scaled = static_cast<float>(static_cast<double>(val) / scale);
+    uint32_t seed = src1.read_lane(wf, lane);
+    uint8_t result = util::f32_to_bf8_e5m2_sr(scaled, seed);
+    uint32_t dst_byte = (inst_.op_sel >> 2) & 0x3;
+    uint32_t old = vdst.read_lane(wf, lane);
+    uint32_t mask = ~(0xFFu << (dst_byte * 8));
+    vdst.write_lane(wf, lane, (old & mask) | (static_cast<uint32_t>(result) << (dst_byte * 8)));
+  }
 }
 
 VCvtScalef32PkF32Fp8Vop3::VCvtScalef32PkF32Fp8Vop3(const MachineInst *inst)
@@ -3619,8 +3731,29 @@ VCvtScalef32PkF32Fp8Vop3::VCvtScalef32PkF32Fp8Vop3(const MachineInst *inst)
 }
 
 void VCvtScalef32PkF32Fp8Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src1.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu) {
+      vdst.write_lane64(wf, lane, 0x7FC000007FC00000ULL);
+      continue;
+    }
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint32_t src_raw = src0.read_lane(wf, lane);
+    bool src_hi = inst_.op_sel & 1;
+    uint32_t half = src_hi ? (src_raw >> 16) : (src_raw & 0xFFFFu);
+    float f0 = static_cast<float>(
+        static_cast<double>(util::fp8_e4m3_to_f32(static_cast<uint8_t>(half & 0xFF))) * scale);
+    float f1 = static_cast<float>(
+        static_cast<double>(util::fp8_e4m3_to_f32(static_cast<uint8_t>((half >> 8) & 0xFF))) *
+        scale);
+    uint64_t result = static_cast<uint64_t>(std::bit_cast<uint32_t>(f0)) |
+                      (static_cast<uint64_t>(std::bit_cast<uint32_t>(f1)) << 32);
+    vdst.write_lane64(wf, lane, result);
+  }
 }
 
 VCvtScalef32PkF32Bf8Vop3::VCvtScalef32PkF32Bf8Vop3(const MachineInst *inst)
@@ -3637,8 +3770,29 @@ VCvtScalef32PkF32Bf8Vop3::VCvtScalef32PkF32Bf8Vop3(const MachineInst *inst)
 }
 
 void VCvtScalef32PkF32Bf8Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src1.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu) {
+      vdst.write_lane64(wf, lane, 0x7FC000007FC00000ULL);
+      continue;
+    }
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint32_t src_raw = src0.read_lane(wf, lane);
+    bool src_hi = inst_.op_sel & 1;
+    uint32_t half = src_hi ? (src_raw >> 16) : (src_raw & 0xFFFFu);
+    float f0 = static_cast<float>(
+        static_cast<double>(util::bf8_e5m2_to_f32(static_cast<uint8_t>(half & 0xFF))) * scale);
+    float f1 = static_cast<float>(
+        static_cast<double>(util::bf8_e5m2_to_f32(static_cast<uint8_t>((half >> 8) & 0xFF))) *
+        scale);
+    uint64_t result = static_cast<uint64_t>(std::bit_cast<uint32_t>(f0)) |
+                      (static_cast<uint64_t>(std::bit_cast<uint32_t>(f1)) << 32);
+    vdst.write_lane64(wf, lane, result);
+  }
 }
 
 VCvtScalef32F32Fp8Vop3::VCvtScalef32F32Fp8Vop3(const MachineInst *inst)
@@ -3655,8 +3809,23 @@ VCvtScalef32F32Fp8Vop3::VCvtScalef32F32Fp8Vop3(const MachineInst *inst)
 }
 
 void VCvtScalef32F32Fp8Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src1.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu) {
+      vdst.write_lane(wf, lane, 0x7FC00000u);
+      continue;
+    }
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint32_t src_raw = src0.read_lane(wf, lane);
+    uint32_t src_byte = inst_.op_sel & 0x3;
+    uint8_t narrow_val = static_cast<uint8_t>((src_raw >> (src_byte * 8)) & 0xFF);
+    float f = static_cast<float>(static_cast<double>(util::fp8_e4m3_to_f32(narrow_val)) * scale);
+    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(f));
+  }
 }
 
 VCvtScalef32F32Bf8Vop3::VCvtScalef32F32Bf8Vop3(const MachineInst *inst)
@@ -3673,8 +3842,23 @@ VCvtScalef32F32Bf8Vop3::VCvtScalef32F32Bf8Vop3(const MachineInst *inst)
 }
 
 void VCvtScalef32F32Bf8Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src1.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu) {
+      vdst.write_lane(wf, lane, 0x7FC00000u);
+      continue;
+    }
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint32_t src_raw = src0.read_lane(wf, lane);
+    uint32_t src_byte = inst_.op_sel & 0x3;
+    uint8_t narrow_val = static_cast<uint8_t>((src_raw >> (src_byte * 8)) & 0xFF);
+    float f = static_cast<float>(static_cast<double>(util::bf8_e5m2_to_f32(narrow_val)) * scale);
+    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(f));
+  }
 }
 
 VCvtScalef32PkFp4F32Vop3::VCvtScalef32PkFp4F32Vop3(const MachineInst *inst)
@@ -3693,8 +3877,31 @@ VCvtScalef32PkFp4F32Vop3::VCvtScalef32PkFp4F32Vop3(const MachineInst *inst)
 }
 
 void VCvtScalef32PkFp4F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src2.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu) {
+      vdst.write_lane(wf, lane, vdst.read_lane(wf, lane));
+      continue;
+    }
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    float s0 = static_cast<float>(
+        static_cast<double>(std::bit_cast<float>(static_cast<uint32_t>(src0.read_lane(wf, lane)))) /
+        scale);
+    float s1 = static_cast<float>(
+        static_cast<double>(std::bit_cast<float>(static_cast<uint32_t>(src1.read_lane(wf, lane)))) /
+        scale);
+    uint8_t r0 = util::f32_to_fp4_e2m1_rne(s0);
+    uint8_t r1 = util::f32_to_fp4_e2m1_rne(s1);
+    uint32_t packed = static_cast<uint32_t>(r0 & 0xF) | (static_cast<uint32_t>(r1 & 0xF) << 4);
+    uint32_t dst_byte = (inst_.op_sel >> 2) & 0x3;
+    uint32_t old = vdst.read_lane(wf, lane);
+    uint32_t mask = ~(0xFFu << (dst_byte * 8));
+    vdst.write_lane(wf, lane, (old & mask) | (packed << (dst_byte * 8)));
+  }
 }
 
 VCvtScalef32SrPkFp4F32Vop3::VCvtScalef32SrPkFp4F32Vop3(const MachineInst *inst)
@@ -3713,8 +3920,33 @@ VCvtScalef32SrPkFp4F32Vop3::VCvtScalef32SrPkFp4F32Vop3(const MachineInst *inst)
 }
 
 void VCvtScalef32SrPkFp4F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src2.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu) {
+      vdst.write_lane(wf, lane, vdst.read_lane(wf, lane));
+      continue;
+    }
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint32_t seed_lo = static_cast<uint32_t>(src1.read_lane(wf, lane));
+    float val0 = std::bit_cast<float>(static_cast<uint32_t>(src0.read_lane(wf, lane)));
+    float val1 = std::bit_cast<float>(cu.read_vgpr(vb + src0.unified_vgpr_index() + 1, lane));
+    float s0 = static_cast<float>(static_cast<double>(val0) / scale);
+    float s1 = static_cast<float>(static_cast<double>(val1) / scale);
+    uint8_t r0 = util::f32_to_fp4_e2m1_sr(s0, seed_lo);
+    uint32_t seed_hi = util::prng_advance(seed_lo);
+    uint8_t r1 = util::f32_to_fp4_e2m1_sr(s1, seed_hi);
+    uint32_t packed = static_cast<uint32_t>(r0 & 0xF) | (static_cast<uint32_t>(r1 & 0xF) << 4);
+    uint32_t dst_byte = (inst_.op_sel >> 2) & 0x3;
+    uint32_t old = vdst.read_lane(wf, lane);
+    uint32_t mask = ~(0xFFu << (dst_byte * 8));
+    vdst.write_lane(wf, lane, (old & mask) | (packed << (dst_byte * 8)));
+  }
 }
 
 VCvtScalef32PkF32Fp4Vop3::VCvtScalef32PkF32Fp4Vop3(const MachineInst *inst)
@@ -3731,8 +3963,29 @@ VCvtScalef32PkF32Fp4Vop3::VCvtScalef32PkF32Fp4Vop3(const MachineInst *inst)
 }
 
 void VCvtScalef32PkF32Fp4Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src1.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu) {
+      vdst.write_lane64(wf, lane, 0x7FC000007FC00000ULL);
+      continue;
+    }
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint32_t src_raw = src0.read_lane(wf, lane);
+    uint32_t src_byte = inst_.op_sel & 0x3;
+    uint8_t byte_val = static_cast<uint8_t>((src_raw >> (src_byte * 8)) & 0xFF);
+    float f0 = static_cast<float>(
+        static_cast<double>(util::fp4_e2m1_to_f32(static_cast<uint8_t>(byte_val & 0xF))) * scale);
+    float f1 = static_cast<float>(
+        static_cast<double>(util::fp4_e2m1_to_f32(static_cast<uint8_t>((byte_val >> 4) & 0xF))) *
+        scale);
+    uint64_t result = static_cast<uint64_t>(std::bit_cast<uint32_t>(f0)) |
+                      (static_cast<uint64_t>(std::bit_cast<uint32_t>(f1)) << 32);
+    vdst.write_lane64(wf, lane, result);
+  }
 }
 
 VCvtScalef32PkFp8F16Vop3::VCvtScalef32PkFp8F16Vop3(const MachineInst *inst)
@@ -3749,8 +4002,33 @@ VCvtScalef32PkFp8F16Vop3::VCvtScalef32PkFp8F16Vop3(const MachineInst *inst)
 }
 
 void VCvtScalef32PkFp8F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src1.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu) {
+      vdst.write_lane(wf, lane, vdst.read_lane(wf, lane));
+      continue;
+    }
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint32_t packed_src = src0.read_lane(wf, lane);
+    float s0 = static_cast<float>(
+        static_cast<double>(util::f16_to_f32(static_cast<uint16_t>(packed_src & 0xFFFF))) / scale);
+    float s1 = static_cast<float>(
+        static_cast<double>(util::f16_to_f32(static_cast<uint16_t>((packed_src >> 16) & 0xFFFF))) /
+        scale);
+    uint8_t r0 = util::f32_to_fp8_e4m3_rne(s0);
+    uint8_t r1 = util::f32_to_fp8_e4m3_rne(s1);
+    uint32_t packed = static_cast<uint32_t>(r0) | (static_cast<uint32_t>(r1) << 8);
+    bool hi = (inst_.op_sel >> 3) & 1;
+    uint32_t old = vdst.read_lane(wf, lane);
+    if (hi)
+      vdst.write_lane(wf, lane, (old & 0xFFFFu) | (packed << 16));
+    else
+      vdst.write_lane(wf, lane, (old & 0xFFFF0000u) | (packed & 0xFFFFu));
+  }
 }
 
 VCvtScalef32PkBf8F16Vop3::VCvtScalef32PkBf8F16Vop3(const MachineInst *inst)
@@ -3767,8 +4045,33 @@ VCvtScalef32PkBf8F16Vop3::VCvtScalef32PkBf8F16Vop3(const MachineInst *inst)
 }
 
 void VCvtScalef32PkBf8F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src1.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu) {
+      vdst.write_lane(wf, lane, vdst.read_lane(wf, lane));
+      continue;
+    }
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint32_t packed_src = src0.read_lane(wf, lane);
+    float s0 = static_cast<float>(
+        static_cast<double>(util::f16_to_f32(static_cast<uint16_t>(packed_src & 0xFFFF))) / scale);
+    float s1 = static_cast<float>(
+        static_cast<double>(util::f16_to_f32(static_cast<uint16_t>((packed_src >> 16) & 0xFFFF))) /
+        scale);
+    uint8_t r0 = util::f32_to_bf8_e5m2_rne(s0);
+    uint8_t r1 = util::f32_to_bf8_e5m2_rne(s1);
+    uint32_t packed = static_cast<uint32_t>(r0) | (static_cast<uint32_t>(r1) << 8);
+    bool hi = (inst_.op_sel >> 3) & 1;
+    uint32_t old = vdst.read_lane(wf, lane);
+    if (hi)
+      vdst.write_lane(wf, lane, (old & 0xFFFFu) | (packed << 16));
+    else
+      vdst.write_lane(wf, lane, (old & 0xFFFF0000u) | (packed & 0xFFFFu));
+  }
 }
 
 VCvtScalef32SrFp8F16Vop3::VCvtScalef32SrFp8F16Vop3(const MachineInst *inst)
@@ -3787,8 +4090,27 @@ VCvtScalef32SrFp8F16Vop3::VCvtScalef32SrFp8F16Vop3(const MachineInst *inst)
 }
 
 void VCvtScalef32SrFp8F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src2.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu) {
+      vdst.write_lane(wf, lane, vdst.read_lane(wf, lane));
+      continue;
+    }
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint32_t src_packed = src0.read_lane(wf, lane);
+    float val = util::f16_to_f32(static_cast<uint16_t>(src_packed & 0xFFFF));
+    float scaled = static_cast<float>(static_cast<double>(val) / scale);
+    uint32_t seed = src1.read_lane(wf, lane);
+    uint8_t result = util::f32_to_fp8_e4m3_sr(scaled, seed);
+    uint32_t dst_byte = (inst_.op_sel >> 2) & 0x3;
+    uint32_t old = vdst.read_lane(wf, lane);
+    uint32_t mask = ~(0xFFu << (dst_byte * 8));
+    vdst.write_lane(wf, lane, (old & mask) | (static_cast<uint32_t>(result) << (dst_byte * 8)));
+  }
 }
 
 VCvtScalef32SrBf8F16Vop3::VCvtScalef32SrBf8F16Vop3(const MachineInst *inst)
@@ -3807,8 +4129,27 @@ VCvtScalef32SrBf8F16Vop3::VCvtScalef32SrBf8F16Vop3(const MachineInst *inst)
 }
 
 void VCvtScalef32SrBf8F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src2.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu) {
+      vdst.write_lane(wf, lane, vdst.read_lane(wf, lane));
+      continue;
+    }
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint32_t src_packed = src0.read_lane(wf, lane);
+    float val = util::f16_to_f32(static_cast<uint16_t>(src_packed & 0xFFFF));
+    float scaled = static_cast<float>(static_cast<double>(val) / scale);
+    uint32_t seed = src1.read_lane(wf, lane);
+    uint8_t result = util::f32_to_bf8_e5m2_sr(scaled, seed);
+    uint32_t dst_byte = (inst_.op_sel >> 2) & 0x3;
+    uint32_t old = vdst.read_lane(wf, lane);
+    uint32_t mask = ~(0xFFu << (dst_byte * 8));
+    vdst.write_lane(wf, lane, (old & mask) | (static_cast<uint32_t>(result) << (dst_byte * 8)));
+  }
 }
 
 VCvtScalef32PkFp8Bf16Vop3::VCvtScalef32PkFp8Bf16Vop3(const MachineInst *inst)
@@ -3825,8 +4166,33 @@ VCvtScalef32PkFp8Bf16Vop3::VCvtScalef32PkFp8Bf16Vop3(const MachineInst *inst)
 }
 
 void VCvtScalef32PkFp8Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src1.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu) {
+      vdst.write_lane(wf, lane, vdst.read_lane(wf, lane));
+      continue;
+    }
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint32_t packed_src = src0.read_lane(wf, lane);
+    float s0 = static_cast<float>(
+        static_cast<double>(util::bf16_to_f32(static_cast<uint16_t>(packed_src & 0xFFFF))) / scale);
+    float s1 = static_cast<float>(
+        static_cast<double>(util::bf16_to_f32(static_cast<uint16_t>((packed_src >> 16) & 0xFFFF))) /
+        scale);
+    uint8_t r0 = util::f32_to_fp8_e4m3_rne(s0);
+    uint8_t r1 = util::f32_to_fp8_e4m3_rne(s1);
+    uint32_t packed = static_cast<uint32_t>(r0) | (static_cast<uint32_t>(r1) << 8);
+    bool hi = (inst_.op_sel >> 3) & 1;
+    uint32_t old = vdst.read_lane(wf, lane);
+    if (hi)
+      vdst.write_lane(wf, lane, (old & 0xFFFFu) | (packed << 16));
+    else
+      vdst.write_lane(wf, lane, (old & 0xFFFF0000u) | (packed & 0xFFFFu));
+  }
 }
 
 VCvtScalef32PkBf8Bf16Vop3::VCvtScalef32PkBf8Bf16Vop3(const MachineInst *inst)
@@ -3843,8 +4209,33 @@ VCvtScalef32PkBf8Bf16Vop3::VCvtScalef32PkBf8Bf16Vop3(const MachineInst *inst)
 }
 
 void VCvtScalef32PkBf8Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src1.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu) {
+      vdst.write_lane(wf, lane, vdst.read_lane(wf, lane));
+      continue;
+    }
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint32_t packed_src = src0.read_lane(wf, lane);
+    float s0 = static_cast<float>(
+        static_cast<double>(util::bf16_to_f32(static_cast<uint16_t>(packed_src & 0xFFFF))) / scale);
+    float s1 = static_cast<float>(
+        static_cast<double>(util::bf16_to_f32(static_cast<uint16_t>((packed_src >> 16) & 0xFFFF))) /
+        scale);
+    uint8_t r0 = util::f32_to_bf8_e5m2_rne(s0);
+    uint8_t r1 = util::f32_to_bf8_e5m2_rne(s1);
+    uint32_t packed = static_cast<uint32_t>(r0) | (static_cast<uint32_t>(r1) << 8);
+    bool hi = (inst_.op_sel >> 3) & 1;
+    uint32_t old = vdst.read_lane(wf, lane);
+    if (hi)
+      vdst.write_lane(wf, lane, (old & 0xFFFFu) | (packed << 16));
+    else
+      vdst.write_lane(wf, lane, (old & 0xFFFF0000u) | (packed & 0xFFFFu));
+  }
 }
 
 VCvtScalef32SrFp8Bf16Vop3::VCvtScalef32SrFp8Bf16Vop3(const MachineInst *inst)
@@ -3863,8 +4254,27 @@ VCvtScalef32SrFp8Bf16Vop3::VCvtScalef32SrFp8Bf16Vop3(const MachineInst *inst)
 }
 
 void VCvtScalef32SrFp8Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src2.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu) {
+      vdst.write_lane(wf, lane, vdst.read_lane(wf, lane));
+      continue;
+    }
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint32_t src_packed = src0.read_lane(wf, lane);
+    float val = util::bf16_to_f32(static_cast<uint16_t>(src_packed & 0xFFFF));
+    float scaled = static_cast<float>(static_cast<double>(val) / scale);
+    uint32_t seed = src1.read_lane(wf, lane);
+    uint8_t result = util::f32_to_fp8_e4m3_sr(scaled, seed);
+    uint32_t dst_byte = (inst_.op_sel >> 2) & 0x3;
+    uint32_t old = vdst.read_lane(wf, lane);
+    uint32_t mask = ~(0xFFu << (dst_byte * 8));
+    vdst.write_lane(wf, lane, (old & mask) | (static_cast<uint32_t>(result) << (dst_byte * 8)));
+  }
 }
 
 VCvtScalef32SrBf8Bf16Vop3::VCvtScalef32SrBf8Bf16Vop3(const MachineInst *inst)
@@ -3883,8 +4293,27 @@ VCvtScalef32SrBf8Bf16Vop3::VCvtScalef32SrBf8Bf16Vop3(const MachineInst *inst)
 }
 
 void VCvtScalef32SrBf8Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src2.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu) {
+      vdst.write_lane(wf, lane, vdst.read_lane(wf, lane));
+      continue;
+    }
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint32_t src_packed = src0.read_lane(wf, lane);
+    float val = util::bf16_to_f32(static_cast<uint16_t>(src_packed & 0xFFFF));
+    float scaled = static_cast<float>(static_cast<double>(val) / scale);
+    uint32_t seed = src1.read_lane(wf, lane);
+    uint8_t result = util::f32_to_bf8_e5m2_sr(scaled, seed);
+    uint32_t dst_byte = (inst_.op_sel >> 2) & 0x3;
+    uint32_t old = vdst.read_lane(wf, lane);
+    uint32_t mask = ~(0xFFu << (dst_byte * 8));
+    vdst.write_lane(wf, lane, (old & mask) | (static_cast<uint32_t>(result) << (dst_byte * 8)));
+  }
 }
 
 VCvtScalef32PkF16Fp8Vop3::VCvtScalef32PkF16Fp8Vop3(const MachineInst *inst)
@@ -3901,8 +4330,30 @@ VCvtScalef32PkF16Fp8Vop3::VCvtScalef32PkF16Fp8Vop3(const MachineInst *inst)
 }
 
 void VCvtScalef32PkF16Fp8Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src1.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu) {
+      vdst.write_lane(wf, lane,
+                      static_cast<uint32_t>(0x7E00u) | (static_cast<uint32_t>(0x7E00u) << 16));
+      continue;
+    }
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint32_t src_raw = src0.read_lane(wf, lane);
+    bool src_hi = inst_.op_sel & 1;
+    uint32_t half = src_hi ? (src_raw >> 16) : (src_raw & 0xFFFFu);
+    float f0 = static_cast<float>(
+        static_cast<double>(util::fp8_e4m3_to_f32(static_cast<uint8_t>(half & 0xFF))) * scale);
+    float f1 = static_cast<float>(
+        static_cast<double>(util::fp8_e4m3_to_f32(static_cast<uint8_t>((half >> 8) & 0xFF))) *
+        scale);
+    uint32_t result = static_cast<uint32_t>(util::f32_to_f16(f0)) |
+                      (static_cast<uint32_t>(util::f32_to_f16(f1)) << 16);
+    vdst.write_lane(wf, lane, result);
+  }
 }
 
 VCvtScalef32PkF16Bf8Vop3::VCvtScalef32PkF16Bf8Vop3(const MachineInst *inst)
@@ -3919,8 +4370,30 @@ VCvtScalef32PkF16Bf8Vop3::VCvtScalef32PkF16Bf8Vop3(const MachineInst *inst)
 }
 
 void VCvtScalef32PkF16Bf8Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src1.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu) {
+      vdst.write_lane(wf, lane,
+                      static_cast<uint32_t>(0x7E00u) | (static_cast<uint32_t>(0x7E00u) << 16));
+      continue;
+    }
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint32_t src_raw = src0.read_lane(wf, lane);
+    bool src_hi = inst_.op_sel & 1;
+    uint32_t half = src_hi ? (src_raw >> 16) : (src_raw & 0xFFFFu);
+    float f0 = static_cast<float>(
+        static_cast<double>(util::bf8_e5m2_to_f32(static_cast<uint8_t>(half & 0xFF))) * scale);
+    float f1 = static_cast<float>(
+        static_cast<double>(util::bf8_e5m2_to_f32(static_cast<uint8_t>((half >> 8) & 0xFF))) *
+        scale);
+    uint32_t result = static_cast<uint32_t>(util::f32_to_f16(f0)) |
+                      (static_cast<uint32_t>(util::f32_to_f16(f1)) << 16);
+    vdst.write_lane(wf, lane, result);
+  }
 }
 
 VCvtScalef32F16Fp8Vop3::VCvtScalef32F16Fp8Vop3(const MachineInst *inst)
@@ -3937,8 +4410,28 @@ VCvtScalef32F16Fp8Vop3::VCvtScalef32F16Fp8Vop3(const MachineInst *inst)
 }
 
 void VCvtScalef32F16Fp8Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src1.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    bool hi = (inst_.op_sel >> 3) & 1;
+    uint32_t old = vdst.read_lane(wf, lane);
+    if (biased_exp == 0xFFu) {
+      uint32_t nv = static_cast<uint32_t>(0x7E00u);
+      vdst.write_lane(wf, lane, hi ? ((old & 0xFFFFu) | (nv << 16)) : ((old & 0xFFFF0000u) | nv));
+      continue;
+    }
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint32_t src_raw = src0.read_lane(wf, lane);
+    uint32_t src_byte = inst_.op_sel & 0x3;
+    uint8_t narrow_val = static_cast<uint8_t>((src_raw >> (src_byte * 8)) & 0xFF);
+    float f = static_cast<float>(static_cast<double>(util::fp8_e4m3_to_f32(narrow_val)) * scale);
+    uint32_t bits = static_cast<uint32_t>(util::f32_to_f16(f));
+    vdst.write_lane(
+        wf, lane, hi ? ((old & 0xFFFFu) | (bits << 16)) : ((old & 0xFFFF0000u) | (bits & 0xFFFFu)));
+  }
 }
 
 VCvtScalef32F16Bf8Vop3::VCvtScalef32F16Bf8Vop3(const MachineInst *inst)
@@ -3955,8 +4448,28 @@ VCvtScalef32F16Bf8Vop3::VCvtScalef32F16Bf8Vop3(const MachineInst *inst)
 }
 
 void VCvtScalef32F16Bf8Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src1.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    bool hi = (inst_.op_sel >> 3) & 1;
+    uint32_t old = vdst.read_lane(wf, lane);
+    if (biased_exp == 0xFFu) {
+      uint32_t nv = static_cast<uint32_t>(0x7E00u);
+      vdst.write_lane(wf, lane, hi ? ((old & 0xFFFFu) | (nv << 16)) : ((old & 0xFFFF0000u) | nv));
+      continue;
+    }
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint32_t src_raw = src0.read_lane(wf, lane);
+    uint32_t src_byte = inst_.op_sel & 0x3;
+    uint8_t narrow_val = static_cast<uint8_t>((src_raw >> (src_byte * 8)) & 0xFF);
+    float f = static_cast<float>(static_cast<double>(util::bf8_e5m2_to_f32(narrow_val)) * scale);
+    uint32_t bits = static_cast<uint32_t>(util::f32_to_f16(f));
+    vdst.write_lane(
+        wf, lane, hi ? ((old & 0xFFFFu) | (bits << 16)) : ((old & 0xFFFF0000u) | (bits & 0xFFFFu)));
+  }
 }
 
 VCvtScalef32PkFp4F16Vop3::VCvtScalef32PkFp4F16Vop3(const MachineInst *inst)
@@ -3973,8 +4486,31 @@ VCvtScalef32PkFp4F16Vop3::VCvtScalef32PkFp4F16Vop3(const MachineInst *inst)
 }
 
 void VCvtScalef32PkFp4F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src1.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu) {
+      vdst.write_lane(wf, lane, vdst.read_lane(wf, lane));
+      continue;
+    }
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint32_t packed_src = src0.read_lane(wf, lane);
+    float s0 = static_cast<float>(
+        static_cast<double>(util::f16_to_f32(static_cast<uint16_t>(packed_src & 0xFFFF))) / scale);
+    float s1 = static_cast<float>(
+        static_cast<double>(util::f16_to_f32(static_cast<uint16_t>((packed_src >> 16) & 0xFFFF))) /
+        scale);
+    uint8_t r0 = util::f32_to_fp4_e2m1_rne(s0);
+    uint8_t r1 = util::f32_to_fp4_e2m1_rne(s1);
+    uint32_t packed = static_cast<uint32_t>(r0 & 0xF) | (static_cast<uint32_t>(r1 & 0xF) << 4);
+    uint32_t dst_byte = (inst_.op_sel >> 2) & 0x3;
+    uint32_t old = vdst.read_lane(wf, lane);
+    uint32_t mask = ~(0xFFu << (dst_byte * 8));
+    vdst.write_lane(wf, lane, (old & mask) | (packed << (dst_byte * 8)));
+  }
 }
 
 VCvtScalef32PkFp4Bf16Vop3::VCvtScalef32PkFp4Bf16Vop3(const MachineInst *inst)
@@ -3991,8 +4527,31 @@ VCvtScalef32PkFp4Bf16Vop3::VCvtScalef32PkFp4Bf16Vop3(const MachineInst *inst)
 }
 
 void VCvtScalef32PkFp4Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src1.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu) {
+      vdst.write_lane(wf, lane, vdst.read_lane(wf, lane));
+      continue;
+    }
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint32_t packed_src = src0.read_lane(wf, lane);
+    float s0 = static_cast<float>(
+        static_cast<double>(util::bf16_to_f32(static_cast<uint16_t>(packed_src & 0xFFFF))) / scale);
+    float s1 = static_cast<float>(
+        static_cast<double>(util::bf16_to_f32(static_cast<uint16_t>((packed_src >> 16) & 0xFFFF))) /
+        scale);
+    uint8_t r0 = util::f32_to_fp4_e2m1_rne(s0);
+    uint8_t r1 = util::f32_to_fp4_e2m1_rne(s1);
+    uint32_t packed = static_cast<uint32_t>(r0 & 0xF) | (static_cast<uint32_t>(r1 & 0xF) << 4);
+    uint32_t dst_byte = (inst_.op_sel >> 2) & 0x3;
+    uint32_t old = vdst.read_lane(wf, lane);
+    uint32_t mask = ~(0xFFu << (dst_byte * 8));
+    vdst.write_lane(wf, lane, (old & mask) | (packed << (dst_byte * 8)));
+  }
 }
 
 VCvtScalef32SrPkFp4F16Vop3::VCvtScalef32SrPkFp4F16Vop3(const MachineInst *inst)
@@ -4011,8 +4570,33 @@ VCvtScalef32SrPkFp4F16Vop3::VCvtScalef32SrPkFp4F16Vop3(const MachineInst *inst)
 }
 
 void VCvtScalef32SrPkFp4F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src2.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu) {
+      vdst.write_lane(wf, lane, vdst.read_lane(wf, lane));
+      continue;
+    }
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint32_t packed_src = src0.read_lane(wf, lane);
+    uint32_t seed_lo = src1.read_lane(wf, lane);
+    float s0 = static_cast<float>(
+        static_cast<double>(util::f16_to_f32(static_cast<uint16_t>(packed_src & 0xFFFF))) / scale);
+    float s1 = static_cast<float>(
+        static_cast<double>(util::f16_to_f32(static_cast<uint16_t>((packed_src >> 16) & 0xFFFF))) /
+        scale);
+    uint8_t r0 = util::f32_to_fp4_e2m1_sr(s0, seed_lo);
+    uint32_t seed_hi = util::prng_advance(seed_lo);
+    uint8_t r1 = util::f32_to_fp4_e2m1_sr(s1, seed_hi);
+    uint32_t packed = static_cast<uint32_t>(r0 & 0xF) | (static_cast<uint32_t>(r1 & 0xF) << 4);
+    uint32_t dst_byte = (inst_.op_sel >> 2) & 0x3;
+    uint32_t old = vdst.read_lane(wf, lane);
+    uint32_t mask = ~(0xFFu << (dst_byte * 8));
+    vdst.write_lane(wf, lane, (old & mask) | (packed << (dst_byte * 8)));
+  }
 }
 
 VCvtScalef32SrPkFp4Bf16Vop3::VCvtScalef32SrPkFp4Bf16Vop3(const MachineInst *inst)
@@ -4031,8 +4615,33 @@ VCvtScalef32SrPkFp4Bf16Vop3::VCvtScalef32SrPkFp4Bf16Vop3(const MachineInst *inst
 }
 
 void VCvtScalef32SrPkFp4Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src2.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu) {
+      vdst.write_lane(wf, lane, vdst.read_lane(wf, lane));
+      continue;
+    }
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint32_t packed_src = src0.read_lane(wf, lane);
+    uint32_t seed_lo = src1.read_lane(wf, lane);
+    float s0 = static_cast<float>(
+        static_cast<double>(util::bf16_to_f32(static_cast<uint16_t>(packed_src & 0xFFFF))) / scale);
+    float s1 = static_cast<float>(
+        static_cast<double>(util::bf16_to_f32(static_cast<uint16_t>((packed_src >> 16) & 0xFFFF))) /
+        scale);
+    uint8_t r0 = util::f32_to_fp4_e2m1_sr(s0, seed_lo);
+    uint32_t seed_hi = util::prng_advance(seed_lo);
+    uint8_t r1 = util::f32_to_fp4_e2m1_sr(s1, seed_hi);
+    uint32_t packed = static_cast<uint32_t>(r0 & 0xF) | (static_cast<uint32_t>(r1 & 0xF) << 4);
+    uint32_t dst_byte = (inst_.op_sel >> 2) & 0x3;
+    uint32_t old = vdst.read_lane(wf, lane);
+    uint32_t mask = ~(0xFFu << (dst_byte * 8));
+    vdst.write_lane(wf, lane, (old & mask) | (packed << (dst_byte * 8)));
+  }
 }
 
 VCvtScalef32PkF16Fp4Vop3::VCvtScalef32PkF16Fp4Vop3(const MachineInst *inst)
@@ -4049,8 +4658,30 @@ VCvtScalef32PkF16Fp4Vop3::VCvtScalef32PkF16Fp4Vop3(const MachineInst *inst)
 }
 
 void VCvtScalef32PkF16Fp4Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src1.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu) {
+      vdst.write_lane(wf, lane,
+                      static_cast<uint32_t>(0x7E00u) | (static_cast<uint32_t>(0x7E00u) << 16));
+      continue;
+    }
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint32_t src_raw = src0.read_lane(wf, lane);
+    uint32_t src_byte = inst_.op_sel & 0x3;
+    uint8_t byte_val = static_cast<uint8_t>((src_raw >> (src_byte * 8)) & 0xFF);
+    float f0 = static_cast<float>(
+        static_cast<double>(util::fp4_e2m1_to_f32(static_cast<uint8_t>(byte_val & 0xF))) * scale);
+    float f1 = static_cast<float>(
+        static_cast<double>(util::fp4_e2m1_to_f32(static_cast<uint8_t>((byte_val >> 4) & 0xF))) *
+        scale);
+    uint32_t result = static_cast<uint32_t>(util::f32_to_f16(f0)) |
+                      (static_cast<uint32_t>(util::f32_to_f16(f1)) << 16);
+    vdst.write_lane(wf, lane, result);
+  }
 }
 
 VCvtScalef32PkBf16Fp4Vop3::VCvtScalef32PkBf16Fp4Vop3(const MachineInst *inst)
@@ -4067,8 +4698,30 @@ VCvtScalef32PkBf16Fp4Vop3::VCvtScalef32PkBf16Fp4Vop3(const MachineInst *inst)
 }
 
 void VCvtScalef32PkBf16Fp4Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src1.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu) {
+      vdst.write_lane(wf, lane,
+                      static_cast<uint32_t>(0x7FC0u) | (static_cast<uint32_t>(0x7FC0u) << 16));
+      continue;
+    }
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint32_t src_raw = src0.read_lane(wf, lane);
+    uint32_t src_byte = inst_.op_sel & 0x3;
+    uint8_t byte_val = static_cast<uint8_t>((src_raw >> (src_byte * 8)) & 0xFF);
+    float f0 = static_cast<float>(
+        static_cast<double>(util::fp4_e2m1_to_f32(static_cast<uint8_t>(byte_val & 0xF))) * scale);
+    float f1 = static_cast<float>(
+        static_cast<double>(util::fp4_e2m1_to_f32(static_cast<uint8_t>((byte_val >> 4) & 0xF))) *
+        scale);
+    uint32_t result = static_cast<uint32_t>(util::f32_to_bf16(f0)) |
+                      (static_cast<uint32_t>(util::f32_to_bf16(f1)) << 16);
+    vdst.write_lane(wf, lane, result);
+  }
 }
 
 VCvtScalef322xpk16Fp6F32Vop3::VCvtScalef322xpk16Fp6F32Vop3(const MachineInst *inst)
@@ -4087,8 +4740,193 @@ VCvtScalef322xpk16Fp6F32Vop3::VCvtScalef322xpk16Fp6F32Vop3(const MachineInst *in
 }
 
 void VCvtScalef322xpk16Fp6F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  auto rd = [&](const auto &op, uint32_t lane, uint32_t dw) -> uint32_t {
+    return cu.read_vgpr(vb + op.unified_vgpr_index() + dw, lane);
+  };
+  auto wr = [&](const auto &op, uint32_t lane, uint32_t dw, uint32_t val) {
+    cu.write_vgpr(vb + op.unified_vgpr_index() + dw, lane, val);
+  };
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src2.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu)
+      continue;
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint8_t vals[32];
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 0));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[0] = util::f32_to_fp6_e2m3_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 1));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[2] = util::f32_to_fp6_e2m3_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 2));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[4] = util::f32_to_fp6_e2m3_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 3));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[6] = util::f32_to_fp6_e2m3_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 4));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[8] = util::f32_to_fp6_e2m3_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 5));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[10] = util::f32_to_fp6_e2m3_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 6));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[12] = util::f32_to_fp6_e2m3_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 7));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[14] = util::f32_to_fp6_e2m3_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 8));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[16] = util::f32_to_fp6_e2m3_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 9));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[18] = util::f32_to_fp6_e2m3_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 10));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[20] = util::f32_to_fp6_e2m3_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 11));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[22] = util::f32_to_fp6_e2m3_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 12));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[24] = util::f32_to_fp6_e2m3_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 13));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[26] = util::f32_to_fp6_e2m3_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 14));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[28] = util::f32_to_fp6_e2m3_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 15));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[30] = util::f32_to_fp6_e2m3_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src1, lane, 0));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[1] = util::f32_to_fp6_e2m3_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src1, lane, 1));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[3] = util::f32_to_fp6_e2m3_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src1, lane, 2));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[5] = util::f32_to_fp6_e2m3_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src1, lane, 3));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[7] = util::f32_to_fp6_e2m3_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src1, lane, 4));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[9] = util::f32_to_fp6_e2m3_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src1, lane, 5));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[11] = util::f32_to_fp6_e2m3_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src1, lane, 6));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[13] = util::f32_to_fp6_e2m3_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src1, lane, 7));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[15] = util::f32_to_fp6_e2m3_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src1, lane, 8));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[17] = util::f32_to_fp6_e2m3_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src1, lane, 9));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[19] = util::f32_to_fp6_e2m3_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src1, lane, 10));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[21] = util::f32_to_fp6_e2m3_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src1, lane, 11));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[23] = util::f32_to_fp6_e2m3_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src1, lane, 12));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[25] = util::f32_to_fp6_e2m3_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src1, lane, 13));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[27] = util::f32_to_fp6_e2m3_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src1, lane, 14));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[29] = util::f32_to_fp6_e2m3_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src1, lane, 15));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[31] = util::f32_to_fp6_e2m3_rne(sv);
+    }
+    uint32_t dwords[6];
+    util::pack_6bit(vals, dwords);
+    wr(vdst, lane, 0, dwords[0]);
+    wr(vdst, lane, 1, dwords[1]);
+    wr(vdst, lane, 2, dwords[2]);
+    wr(vdst, lane, 3, dwords[3]);
+    wr(vdst, lane, 4, dwords[4]);
+    wr(vdst, lane, 5, dwords[5]);
+  }
 }
 
 VCvtScalef322xpk16Bf6F32Vop3::VCvtScalef322xpk16Bf6F32Vop3(const MachineInst *inst)
@@ -4107,8 +4945,193 @@ VCvtScalef322xpk16Bf6F32Vop3::VCvtScalef322xpk16Bf6F32Vop3(const MachineInst *in
 }
 
 void VCvtScalef322xpk16Bf6F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  auto rd = [&](const auto &op, uint32_t lane, uint32_t dw) -> uint32_t {
+    return cu.read_vgpr(vb + op.unified_vgpr_index() + dw, lane);
+  };
+  auto wr = [&](const auto &op, uint32_t lane, uint32_t dw, uint32_t val) {
+    cu.write_vgpr(vb + op.unified_vgpr_index() + dw, lane, val);
+  };
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src2.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu)
+      continue;
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint8_t vals[32];
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 0));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[0] = util::f32_to_bf6_e3m2_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 1));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[2] = util::f32_to_bf6_e3m2_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 2));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[4] = util::f32_to_bf6_e3m2_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 3));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[6] = util::f32_to_bf6_e3m2_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 4));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[8] = util::f32_to_bf6_e3m2_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 5));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[10] = util::f32_to_bf6_e3m2_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 6));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[12] = util::f32_to_bf6_e3m2_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 7));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[14] = util::f32_to_bf6_e3m2_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 8));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[16] = util::f32_to_bf6_e3m2_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 9));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[18] = util::f32_to_bf6_e3m2_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 10));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[20] = util::f32_to_bf6_e3m2_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 11));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[22] = util::f32_to_bf6_e3m2_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 12));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[24] = util::f32_to_bf6_e3m2_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 13));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[26] = util::f32_to_bf6_e3m2_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 14));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[28] = util::f32_to_bf6_e3m2_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 15));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[30] = util::f32_to_bf6_e3m2_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src1, lane, 0));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[1] = util::f32_to_bf6_e3m2_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src1, lane, 1));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[3] = util::f32_to_bf6_e3m2_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src1, lane, 2));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[5] = util::f32_to_bf6_e3m2_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src1, lane, 3));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[7] = util::f32_to_bf6_e3m2_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src1, lane, 4));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[9] = util::f32_to_bf6_e3m2_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src1, lane, 5));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[11] = util::f32_to_bf6_e3m2_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src1, lane, 6));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[13] = util::f32_to_bf6_e3m2_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src1, lane, 7));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[15] = util::f32_to_bf6_e3m2_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src1, lane, 8));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[17] = util::f32_to_bf6_e3m2_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src1, lane, 9));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[19] = util::f32_to_bf6_e3m2_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src1, lane, 10));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[21] = util::f32_to_bf6_e3m2_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src1, lane, 11));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[23] = util::f32_to_bf6_e3m2_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src1, lane, 12));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[25] = util::f32_to_bf6_e3m2_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src1, lane, 13));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[27] = util::f32_to_bf6_e3m2_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src1, lane, 14));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[29] = util::f32_to_bf6_e3m2_rne(sv);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src1, lane, 15));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[31] = util::f32_to_bf6_e3m2_rne(sv);
+    }
+    uint32_t dwords[6];
+    util::pack_6bit(vals, dwords);
+    wr(vdst, lane, 0, dwords[0]);
+    wr(vdst, lane, 1, dwords[1]);
+    wr(vdst, lane, 2, dwords[2]);
+    wr(vdst, lane, 3, dwords[3]);
+    wr(vdst, lane, 4, dwords[4]);
+    wr(vdst, lane, 5, dwords[5]);
+  }
 }
 
 VCvtScalef32SrPk32Fp6F32Vop3::VCvtScalef32SrPk32Fp6F32Vop3(const MachineInst *inst)
@@ -4127,8 +5150,226 @@ VCvtScalef32SrPk32Fp6F32Vop3::VCvtScalef32SrPk32Fp6F32Vop3(const MachineInst *in
 }
 
 void VCvtScalef32SrPk32Fp6F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  auto rd = [&](const auto &op, uint32_t lane, uint32_t dw) -> uint32_t {
+    return cu.read_vgpr(vb + op.unified_vgpr_index() + dw, lane);
+  };
+  auto wr = [&](const auto &op, uint32_t lane, uint32_t dw, uint32_t val) {
+    cu.write_vgpr(vb + op.unified_vgpr_index() + dw, lane, val);
+  };
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src2.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu)
+      continue;
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint32_t seed = src1.read_lane(wf, lane);
+    uint8_t vals[32];
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 0));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[0] = util::f32_to_fp6_e2m3_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 1));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[1] = util::f32_to_fp6_e2m3_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 2));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[2] = util::f32_to_fp6_e2m3_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 3));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[3] = util::f32_to_fp6_e2m3_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 4));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[4] = util::f32_to_fp6_e2m3_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 5));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[5] = util::f32_to_fp6_e2m3_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 6));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[6] = util::f32_to_fp6_e2m3_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 7));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[7] = util::f32_to_fp6_e2m3_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 8));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[8] = util::f32_to_fp6_e2m3_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 9));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[9] = util::f32_to_fp6_e2m3_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 10));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[10] = util::f32_to_fp6_e2m3_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 11));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[11] = util::f32_to_fp6_e2m3_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 12));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[12] = util::f32_to_fp6_e2m3_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 13));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[13] = util::f32_to_fp6_e2m3_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 14));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[14] = util::f32_to_fp6_e2m3_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 15));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[15] = util::f32_to_fp6_e2m3_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 16));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[16] = util::f32_to_fp6_e2m3_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 17));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[17] = util::f32_to_fp6_e2m3_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 18));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[18] = util::f32_to_fp6_e2m3_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 19));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[19] = util::f32_to_fp6_e2m3_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 20));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[20] = util::f32_to_fp6_e2m3_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 21));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[21] = util::f32_to_fp6_e2m3_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 22));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[22] = util::f32_to_fp6_e2m3_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 23));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[23] = util::f32_to_fp6_e2m3_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 24));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[24] = util::f32_to_fp6_e2m3_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 25));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[25] = util::f32_to_fp6_e2m3_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 26));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[26] = util::f32_to_fp6_e2m3_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 27));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[27] = util::f32_to_fp6_e2m3_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 28));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[28] = util::f32_to_fp6_e2m3_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 29));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[29] = util::f32_to_fp6_e2m3_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 30));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[30] = util::f32_to_fp6_e2m3_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 31));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[31] = util::f32_to_fp6_e2m3_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    uint32_t dwords[6];
+    util::pack_6bit(vals, dwords);
+    wr(vdst, lane, 0, dwords[0]);
+    wr(vdst, lane, 1, dwords[1]);
+    wr(vdst, lane, 2, dwords[2]);
+    wr(vdst, lane, 3, dwords[3]);
+    wr(vdst, lane, 4, dwords[4]);
+    wr(vdst, lane, 5, dwords[5]);
+  }
 }
 
 VCvtScalef32SrPk32Bf6F32Vop3::VCvtScalef32SrPk32Bf6F32Vop3(const MachineInst *inst)
@@ -4147,8 +5388,226 @@ VCvtScalef32SrPk32Bf6F32Vop3::VCvtScalef32SrPk32Bf6F32Vop3(const MachineInst *in
 }
 
 void VCvtScalef32SrPk32Bf6F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  auto rd = [&](const auto &op, uint32_t lane, uint32_t dw) -> uint32_t {
+    return cu.read_vgpr(vb + op.unified_vgpr_index() + dw, lane);
+  };
+  auto wr = [&](const auto &op, uint32_t lane, uint32_t dw, uint32_t val) {
+    cu.write_vgpr(vb + op.unified_vgpr_index() + dw, lane, val);
+  };
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src2.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu)
+      continue;
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint32_t seed = src1.read_lane(wf, lane);
+    uint8_t vals[32];
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 0));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[0] = util::f32_to_bf6_e3m2_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 1));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[1] = util::f32_to_bf6_e3m2_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 2));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[2] = util::f32_to_bf6_e3m2_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 3));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[3] = util::f32_to_bf6_e3m2_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 4));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[4] = util::f32_to_bf6_e3m2_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 5));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[5] = util::f32_to_bf6_e3m2_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 6));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[6] = util::f32_to_bf6_e3m2_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 7));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[7] = util::f32_to_bf6_e3m2_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 8));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[8] = util::f32_to_bf6_e3m2_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 9));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[9] = util::f32_to_bf6_e3m2_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 10));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[10] = util::f32_to_bf6_e3m2_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 11));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[11] = util::f32_to_bf6_e3m2_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 12));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[12] = util::f32_to_bf6_e3m2_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 13));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[13] = util::f32_to_bf6_e3m2_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 14));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[14] = util::f32_to_bf6_e3m2_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 15));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[15] = util::f32_to_bf6_e3m2_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 16));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[16] = util::f32_to_bf6_e3m2_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 17));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[17] = util::f32_to_bf6_e3m2_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 18));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[18] = util::f32_to_bf6_e3m2_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 19));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[19] = util::f32_to_bf6_e3m2_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 20));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[20] = util::f32_to_bf6_e3m2_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 21));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[21] = util::f32_to_bf6_e3m2_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 22));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[22] = util::f32_to_bf6_e3m2_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 23));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[23] = util::f32_to_bf6_e3m2_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 24));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[24] = util::f32_to_bf6_e3m2_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 25));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[25] = util::f32_to_bf6_e3m2_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 26));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[26] = util::f32_to_bf6_e3m2_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 27));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[27] = util::f32_to_bf6_e3m2_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 28));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[28] = util::f32_to_bf6_e3m2_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 29));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[29] = util::f32_to_bf6_e3m2_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 30));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[30] = util::f32_to_bf6_e3m2_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      float v = std::bit_cast<float>(rd(src0, lane, 31));
+      float sv = static_cast<float>(static_cast<double>(v) / scale);
+      vals[31] = util::f32_to_bf6_e3m2_sr(sv, seed);
+      seed = util::prng_advance(seed);
+    }
+    uint32_t dwords[6];
+    util::pack_6bit(vals, dwords);
+    wr(vdst, lane, 0, dwords[0]);
+    wr(vdst, lane, 1, dwords[1]);
+    wr(vdst, lane, 2, dwords[2]);
+    wr(vdst, lane, 3, dwords[3]);
+    wr(vdst, lane, 4, dwords[4]);
+    wr(vdst, lane, 5, dwords[5]);
+  }
 }
 
 VCvtScalef32Pk32F32Fp6Vop3::VCvtScalef32Pk32F32Fp6Vop3(const MachineInst *inst)
@@ -4165,8 +5624,129 @@ VCvtScalef32Pk32F32Fp6Vop3::VCvtScalef32Pk32F32Fp6Vop3(const MachineInst *inst)
 }
 
 void VCvtScalef32Pk32F32Fp6Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  auto rd = [&](const auto &op, uint32_t lane, uint32_t dw) -> uint32_t {
+    return cu.read_vgpr(vb + op.unified_vgpr_index() + dw, lane);
+  };
+  auto wr = [&](const auto &op, uint32_t lane, uint32_t dw, uint32_t val) {
+    cu.write_vgpr(vb + op.unified_vgpr_index() + dw, lane, val);
+  };
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src1.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu)
+      continue;
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint32_t src_dwords[6];
+    src_dwords[0] = rd(src0, lane, 0);
+    src_dwords[1] = rd(src0, lane, 1);
+    src_dwords[2] = rd(src0, lane, 2);
+    src_dwords[3] = rd(src0, lane, 3);
+    src_dwords[4] = rd(src0, lane, 4);
+    src_dwords[5] = rd(src0, lane, 5);
+    uint8_t vals[32];
+    util::unpack_6bit(src_dwords, vals);
+    wr(vdst, lane, 0,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[0])) * scale)));
+    wr(vdst, lane, 1,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[1])) * scale)));
+    wr(vdst, lane, 2,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[2])) * scale)));
+    wr(vdst, lane, 3,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[3])) * scale)));
+    wr(vdst, lane, 4,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[4])) * scale)));
+    wr(vdst, lane, 5,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[5])) * scale)));
+    wr(vdst, lane, 6,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[6])) * scale)));
+    wr(vdst, lane, 7,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[7])) * scale)));
+    wr(vdst, lane, 8,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[8])) * scale)));
+    wr(vdst, lane, 9,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[9])) * scale)));
+    wr(vdst, lane, 10,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[10])) * scale)));
+    wr(vdst, lane, 11,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[11])) * scale)));
+    wr(vdst, lane, 12,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[12])) * scale)));
+    wr(vdst, lane, 13,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[13])) * scale)));
+    wr(vdst, lane, 14,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[14])) * scale)));
+    wr(vdst, lane, 15,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[15])) * scale)));
+    wr(vdst, lane, 16,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[16])) * scale)));
+    wr(vdst, lane, 17,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[17])) * scale)));
+    wr(vdst, lane, 18,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[18])) * scale)));
+    wr(vdst, lane, 19,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[19])) * scale)));
+    wr(vdst, lane, 20,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[20])) * scale)));
+    wr(vdst, lane, 21,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[21])) * scale)));
+    wr(vdst, lane, 22,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[22])) * scale)));
+    wr(vdst, lane, 23,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[23])) * scale)));
+    wr(vdst, lane, 24,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[24])) * scale)));
+    wr(vdst, lane, 25,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[25])) * scale)));
+    wr(vdst, lane, 26,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[26])) * scale)));
+    wr(vdst, lane, 27,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[27])) * scale)));
+    wr(vdst, lane, 28,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[28])) * scale)));
+    wr(vdst, lane, 29,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[29])) * scale)));
+    wr(vdst, lane, 30,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[30])) * scale)));
+    wr(vdst, lane, 31,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[31])) * scale)));
+  }
 }
 
 VCvtScalef32Pk32F32Bf6Vop3::VCvtScalef32Pk32F32Bf6Vop3(const MachineInst *inst)
@@ -4183,8 +5763,129 @@ VCvtScalef32Pk32F32Bf6Vop3::VCvtScalef32Pk32F32Bf6Vop3(const MachineInst *inst)
 }
 
 void VCvtScalef32Pk32F32Bf6Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  auto rd = [&](const auto &op, uint32_t lane, uint32_t dw) -> uint32_t {
+    return cu.read_vgpr(vb + op.unified_vgpr_index() + dw, lane);
+  };
+  auto wr = [&](const auto &op, uint32_t lane, uint32_t dw, uint32_t val) {
+    cu.write_vgpr(vb + op.unified_vgpr_index() + dw, lane, val);
+  };
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src1.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu)
+      continue;
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint32_t src_dwords[6];
+    src_dwords[0] = rd(src0, lane, 0);
+    src_dwords[1] = rd(src0, lane, 1);
+    src_dwords[2] = rd(src0, lane, 2);
+    src_dwords[3] = rd(src0, lane, 3);
+    src_dwords[4] = rd(src0, lane, 4);
+    src_dwords[5] = rd(src0, lane, 5);
+    uint8_t vals[32];
+    util::unpack_6bit(src_dwords, vals);
+    wr(vdst, lane, 0,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[0])) * scale)));
+    wr(vdst, lane, 1,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[1])) * scale)));
+    wr(vdst, lane, 2,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[2])) * scale)));
+    wr(vdst, lane, 3,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[3])) * scale)));
+    wr(vdst, lane, 4,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[4])) * scale)));
+    wr(vdst, lane, 5,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[5])) * scale)));
+    wr(vdst, lane, 6,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[6])) * scale)));
+    wr(vdst, lane, 7,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[7])) * scale)));
+    wr(vdst, lane, 8,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[8])) * scale)));
+    wr(vdst, lane, 9,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[9])) * scale)));
+    wr(vdst, lane, 10,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[10])) * scale)));
+    wr(vdst, lane, 11,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[11])) * scale)));
+    wr(vdst, lane, 12,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[12])) * scale)));
+    wr(vdst, lane, 13,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[13])) * scale)));
+    wr(vdst, lane, 14,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[14])) * scale)));
+    wr(vdst, lane, 15,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[15])) * scale)));
+    wr(vdst, lane, 16,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[16])) * scale)));
+    wr(vdst, lane, 17,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[17])) * scale)));
+    wr(vdst, lane, 18,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[18])) * scale)));
+    wr(vdst, lane, 19,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[19])) * scale)));
+    wr(vdst, lane, 20,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[20])) * scale)));
+    wr(vdst, lane, 21,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[21])) * scale)));
+    wr(vdst, lane, 22,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[22])) * scale)));
+    wr(vdst, lane, 23,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[23])) * scale)));
+    wr(vdst, lane, 24,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[24])) * scale)));
+    wr(vdst, lane, 25,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[25])) * scale)));
+    wr(vdst, lane, 26,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[26])) * scale)));
+    wr(vdst, lane, 27,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[27])) * scale)));
+    wr(vdst, lane, 28,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[28])) * scale)));
+    wr(vdst, lane, 29,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[29])) * scale)));
+    wr(vdst, lane, 30,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[30])) * scale)));
+    wr(vdst, lane, 31,
+       std::bit_cast<uint32_t>(
+           static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[31])) * scale)));
+  }
 }
 
 VCvtScalef32Pk32Fp6F16Vop3::VCvtScalef32Pk32Fp6F16Vop3(const MachineInst *inst)
@@ -4201,8 +5902,177 @@ VCvtScalef32Pk32Fp6F16Vop3::VCvtScalef32Pk32Fp6F16Vop3(const MachineInst *inst)
 }
 
 void VCvtScalef32Pk32Fp6F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  auto rd = [&](const auto &op, uint32_t lane, uint32_t dw) -> uint32_t {
+    return cu.read_vgpr(vb + op.unified_vgpr_index() + dw, lane);
+  };
+  auto wr = [&](const auto &op, uint32_t lane, uint32_t dw, uint32_t val) {
+    cu.write_vgpr(vb + op.unified_vgpr_index() + dw, lane, val);
+  };
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src1.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu)
+      continue;
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint8_t vals[32];
+    {
+      uint32_t dw = rd(src0, lane, 0);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[0] = util::f32_to_fp6_e2m3_rne(sv0);
+      vals[1] = util::f32_to_fp6_e2m3_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 1);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[2] = util::f32_to_fp6_e2m3_rne(sv0);
+      vals[3] = util::f32_to_fp6_e2m3_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 2);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[4] = util::f32_to_fp6_e2m3_rne(sv0);
+      vals[5] = util::f32_to_fp6_e2m3_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 3);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[6] = util::f32_to_fp6_e2m3_rne(sv0);
+      vals[7] = util::f32_to_fp6_e2m3_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 4);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[8] = util::f32_to_fp6_e2m3_rne(sv0);
+      vals[9] = util::f32_to_fp6_e2m3_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 5);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[10] = util::f32_to_fp6_e2m3_rne(sv0);
+      vals[11] = util::f32_to_fp6_e2m3_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 6);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[12] = util::f32_to_fp6_e2m3_rne(sv0);
+      vals[13] = util::f32_to_fp6_e2m3_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 7);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[14] = util::f32_to_fp6_e2m3_rne(sv0);
+      vals[15] = util::f32_to_fp6_e2m3_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 8);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[16] = util::f32_to_fp6_e2m3_rne(sv0);
+      vals[17] = util::f32_to_fp6_e2m3_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 9);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[18] = util::f32_to_fp6_e2m3_rne(sv0);
+      vals[19] = util::f32_to_fp6_e2m3_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 10);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[20] = util::f32_to_fp6_e2m3_rne(sv0);
+      vals[21] = util::f32_to_fp6_e2m3_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 11);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[22] = util::f32_to_fp6_e2m3_rne(sv0);
+      vals[23] = util::f32_to_fp6_e2m3_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 12);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[24] = util::f32_to_fp6_e2m3_rne(sv0);
+      vals[25] = util::f32_to_fp6_e2m3_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 13);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[26] = util::f32_to_fp6_e2m3_rne(sv0);
+      vals[27] = util::f32_to_fp6_e2m3_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 14);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[28] = util::f32_to_fp6_e2m3_rne(sv0);
+      vals[29] = util::f32_to_fp6_e2m3_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 15);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[30] = util::f32_to_fp6_e2m3_rne(sv0);
+      vals[31] = util::f32_to_fp6_e2m3_rne(sv1);
+    }
+    uint32_t dwords[6];
+    util::pack_6bit(vals, dwords);
+    wr(vdst, lane, 0, dwords[0]);
+    wr(vdst, lane, 1, dwords[1]);
+    wr(vdst, lane, 2, dwords[2]);
+    wr(vdst, lane, 3, dwords[3]);
+    wr(vdst, lane, 4, dwords[4]);
+    wr(vdst, lane, 5, dwords[5]);
+  }
 }
 
 VCvtScalef32Pk32Fp6Bf16Vop3::VCvtScalef32Pk32Fp6Bf16Vop3(const MachineInst *inst)
@@ -4219,8 +6089,177 @@ VCvtScalef32Pk32Fp6Bf16Vop3::VCvtScalef32Pk32Fp6Bf16Vop3(const MachineInst *inst
 }
 
 void VCvtScalef32Pk32Fp6Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  auto rd = [&](const auto &op, uint32_t lane, uint32_t dw) -> uint32_t {
+    return cu.read_vgpr(vb + op.unified_vgpr_index() + dw, lane);
+  };
+  auto wr = [&](const auto &op, uint32_t lane, uint32_t dw, uint32_t val) {
+    cu.write_vgpr(vb + op.unified_vgpr_index() + dw, lane, val);
+  };
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src1.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu)
+      continue;
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint8_t vals[32];
+    {
+      uint32_t dw = rd(src0, lane, 0);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[0] = util::f32_to_fp6_e2m3_rne(sv0);
+      vals[1] = util::f32_to_fp6_e2m3_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 1);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[2] = util::f32_to_fp6_e2m3_rne(sv0);
+      vals[3] = util::f32_to_fp6_e2m3_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 2);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[4] = util::f32_to_fp6_e2m3_rne(sv0);
+      vals[5] = util::f32_to_fp6_e2m3_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 3);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[6] = util::f32_to_fp6_e2m3_rne(sv0);
+      vals[7] = util::f32_to_fp6_e2m3_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 4);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[8] = util::f32_to_fp6_e2m3_rne(sv0);
+      vals[9] = util::f32_to_fp6_e2m3_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 5);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[10] = util::f32_to_fp6_e2m3_rne(sv0);
+      vals[11] = util::f32_to_fp6_e2m3_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 6);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[12] = util::f32_to_fp6_e2m3_rne(sv0);
+      vals[13] = util::f32_to_fp6_e2m3_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 7);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[14] = util::f32_to_fp6_e2m3_rne(sv0);
+      vals[15] = util::f32_to_fp6_e2m3_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 8);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[16] = util::f32_to_fp6_e2m3_rne(sv0);
+      vals[17] = util::f32_to_fp6_e2m3_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 9);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[18] = util::f32_to_fp6_e2m3_rne(sv0);
+      vals[19] = util::f32_to_fp6_e2m3_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 10);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[20] = util::f32_to_fp6_e2m3_rne(sv0);
+      vals[21] = util::f32_to_fp6_e2m3_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 11);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[22] = util::f32_to_fp6_e2m3_rne(sv0);
+      vals[23] = util::f32_to_fp6_e2m3_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 12);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[24] = util::f32_to_fp6_e2m3_rne(sv0);
+      vals[25] = util::f32_to_fp6_e2m3_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 13);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[26] = util::f32_to_fp6_e2m3_rne(sv0);
+      vals[27] = util::f32_to_fp6_e2m3_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 14);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[28] = util::f32_to_fp6_e2m3_rne(sv0);
+      vals[29] = util::f32_to_fp6_e2m3_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 15);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[30] = util::f32_to_fp6_e2m3_rne(sv0);
+      vals[31] = util::f32_to_fp6_e2m3_rne(sv1);
+    }
+    uint32_t dwords[6];
+    util::pack_6bit(vals, dwords);
+    wr(vdst, lane, 0, dwords[0]);
+    wr(vdst, lane, 1, dwords[1]);
+    wr(vdst, lane, 2, dwords[2]);
+    wr(vdst, lane, 3, dwords[3]);
+    wr(vdst, lane, 4, dwords[4]);
+    wr(vdst, lane, 5, dwords[5]);
+  }
 }
 
 VCvtScalef32Pk32Bf6F16Vop3::VCvtScalef32Pk32Bf6F16Vop3(const MachineInst *inst)
@@ -4237,8 +6276,177 @@ VCvtScalef32Pk32Bf6F16Vop3::VCvtScalef32Pk32Bf6F16Vop3(const MachineInst *inst)
 }
 
 void VCvtScalef32Pk32Bf6F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  auto rd = [&](const auto &op, uint32_t lane, uint32_t dw) -> uint32_t {
+    return cu.read_vgpr(vb + op.unified_vgpr_index() + dw, lane);
+  };
+  auto wr = [&](const auto &op, uint32_t lane, uint32_t dw, uint32_t val) {
+    cu.write_vgpr(vb + op.unified_vgpr_index() + dw, lane, val);
+  };
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src1.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu)
+      continue;
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint8_t vals[32];
+    {
+      uint32_t dw = rd(src0, lane, 0);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[0] = util::f32_to_bf6_e3m2_rne(sv0);
+      vals[1] = util::f32_to_bf6_e3m2_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 1);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[2] = util::f32_to_bf6_e3m2_rne(sv0);
+      vals[3] = util::f32_to_bf6_e3m2_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 2);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[4] = util::f32_to_bf6_e3m2_rne(sv0);
+      vals[5] = util::f32_to_bf6_e3m2_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 3);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[6] = util::f32_to_bf6_e3m2_rne(sv0);
+      vals[7] = util::f32_to_bf6_e3m2_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 4);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[8] = util::f32_to_bf6_e3m2_rne(sv0);
+      vals[9] = util::f32_to_bf6_e3m2_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 5);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[10] = util::f32_to_bf6_e3m2_rne(sv0);
+      vals[11] = util::f32_to_bf6_e3m2_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 6);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[12] = util::f32_to_bf6_e3m2_rne(sv0);
+      vals[13] = util::f32_to_bf6_e3m2_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 7);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[14] = util::f32_to_bf6_e3m2_rne(sv0);
+      vals[15] = util::f32_to_bf6_e3m2_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 8);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[16] = util::f32_to_bf6_e3m2_rne(sv0);
+      vals[17] = util::f32_to_bf6_e3m2_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 9);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[18] = util::f32_to_bf6_e3m2_rne(sv0);
+      vals[19] = util::f32_to_bf6_e3m2_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 10);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[20] = util::f32_to_bf6_e3m2_rne(sv0);
+      vals[21] = util::f32_to_bf6_e3m2_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 11);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[22] = util::f32_to_bf6_e3m2_rne(sv0);
+      vals[23] = util::f32_to_bf6_e3m2_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 12);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[24] = util::f32_to_bf6_e3m2_rne(sv0);
+      vals[25] = util::f32_to_bf6_e3m2_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 13);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[26] = util::f32_to_bf6_e3m2_rne(sv0);
+      vals[27] = util::f32_to_bf6_e3m2_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 14);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[28] = util::f32_to_bf6_e3m2_rne(sv0);
+      vals[29] = util::f32_to_bf6_e3m2_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 15);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[30] = util::f32_to_bf6_e3m2_rne(sv0);
+      vals[31] = util::f32_to_bf6_e3m2_rne(sv1);
+    }
+    uint32_t dwords[6];
+    util::pack_6bit(vals, dwords);
+    wr(vdst, lane, 0, dwords[0]);
+    wr(vdst, lane, 1, dwords[1]);
+    wr(vdst, lane, 2, dwords[2]);
+    wr(vdst, lane, 3, dwords[3]);
+    wr(vdst, lane, 4, dwords[4]);
+    wr(vdst, lane, 5, dwords[5]);
+  }
 }
 
 VCvtScalef32Pk32Bf6Bf16Vop3::VCvtScalef32Pk32Bf6Bf16Vop3(const MachineInst *inst)
@@ -4255,8 +6463,177 @@ VCvtScalef32Pk32Bf6Bf16Vop3::VCvtScalef32Pk32Bf6Bf16Vop3(const MachineInst *inst
 }
 
 void VCvtScalef32Pk32Bf6Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  auto rd = [&](const auto &op, uint32_t lane, uint32_t dw) -> uint32_t {
+    return cu.read_vgpr(vb + op.unified_vgpr_index() + dw, lane);
+  };
+  auto wr = [&](const auto &op, uint32_t lane, uint32_t dw, uint32_t val) {
+    cu.write_vgpr(vb + op.unified_vgpr_index() + dw, lane, val);
+  };
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src1.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu)
+      continue;
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint8_t vals[32];
+    {
+      uint32_t dw = rd(src0, lane, 0);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[0] = util::f32_to_bf6_e3m2_rne(sv0);
+      vals[1] = util::f32_to_bf6_e3m2_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 1);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[2] = util::f32_to_bf6_e3m2_rne(sv0);
+      vals[3] = util::f32_to_bf6_e3m2_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 2);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[4] = util::f32_to_bf6_e3m2_rne(sv0);
+      vals[5] = util::f32_to_bf6_e3m2_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 3);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[6] = util::f32_to_bf6_e3m2_rne(sv0);
+      vals[7] = util::f32_to_bf6_e3m2_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 4);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[8] = util::f32_to_bf6_e3m2_rne(sv0);
+      vals[9] = util::f32_to_bf6_e3m2_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 5);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[10] = util::f32_to_bf6_e3m2_rne(sv0);
+      vals[11] = util::f32_to_bf6_e3m2_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 6);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[12] = util::f32_to_bf6_e3m2_rne(sv0);
+      vals[13] = util::f32_to_bf6_e3m2_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 7);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[14] = util::f32_to_bf6_e3m2_rne(sv0);
+      vals[15] = util::f32_to_bf6_e3m2_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 8);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[16] = util::f32_to_bf6_e3m2_rne(sv0);
+      vals[17] = util::f32_to_bf6_e3m2_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 9);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[18] = util::f32_to_bf6_e3m2_rne(sv0);
+      vals[19] = util::f32_to_bf6_e3m2_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 10);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[20] = util::f32_to_bf6_e3m2_rne(sv0);
+      vals[21] = util::f32_to_bf6_e3m2_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 11);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[22] = util::f32_to_bf6_e3m2_rne(sv0);
+      vals[23] = util::f32_to_bf6_e3m2_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 12);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[24] = util::f32_to_bf6_e3m2_rne(sv0);
+      vals[25] = util::f32_to_bf6_e3m2_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 13);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[26] = util::f32_to_bf6_e3m2_rne(sv0);
+      vals[27] = util::f32_to_bf6_e3m2_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 14);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[28] = util::f32_to_bf6_e3m2_rne(sv0);
+      vals[29] = util::f32_to_bf6_e3m2_rne(sv1);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 15);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[30] = util::f32_to_bf6_e3m2_rne(sv0);
+      vals[31] = util::f32_to_bf6_e3m2_rne(sv1);
+    }
+    uint32_t dwords[6];
+    util::pack_6bit(vals, dwords);
+    wr(vdst, lane, 0, dwords[0]);
+    wr(vdst, lane, 1, dwords[1]);
+    wr(vdst, lane, 2, dwords[2]);
+    wr(vdst, lane, 3, dwords[3]);
+    wr(vdst, lane, 4, dwords[4]);
+    wr(vdst, lane, 5, dwords[5]);
+  }
 }
 
 VCvtScalef32SrPk32Fp6F16Vop3::VCvtScalef32SrPk32Fp6F16Vop3(const MachineInst *inst)
@@ -4275,8 +6652,210 @@ VCvtScalef32SrPk32Fp6F16Vop3::VCvtScalef32SrPk32Fp6F16Vop3(const MachineInst *in
 }
 
 void VCvtScalef32SrPk32Fp6F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  auto rd = [&](const auto &op, uint32_t lane, uint32_t dw) -> uint32_t {
+    return cu.read_vgpr(vb + op.unified_vgpr_index() + dw, lane);
+  };
+  auto wr = [&](const auto &op, uint32_t lane, uint32_t dw, uint32_t val) {
+    cu.write_vgpr(vb + op.unified_vgpr_index() + dw, lane, val);
+  };
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src2.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu)
+      continue;
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint32_t seed = src1.read_lane(wf, lane);
+    uint8_t vals[32];
+    {
+      uint32_t dw = rd(src0, lane, 0);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[0] = util::f32_to_fp6_e2m3_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[1] = util::f32_to_fp6_e2m3_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 1);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[2] = util::f32_to_fp6_e2m3_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[3] = util::f32_to_fp6_e2m3_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 2);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[4] = util::f32_to_fp6_e2m3_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[5] = util::f32_to_fp6_e2m3_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 3);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[6] = util::f32_to_fp6_e2m3_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[7] = util::f32_to_fp6_e2m3_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 4);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[8] = util::f32_to_fp6_e2m3_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[9] = util::f32_to_fp6_e2m3_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 5);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[10] = util::f32_to_fp6_e2m3_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[11] = util::f32_to_fp6_e2m3_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 6);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[12] = util::f32_to_fp6_e2m3_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[13] = util::f32_to_fp6_e2m3_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 7);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[14] = util::f32_to_fp6_e2m3_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[15] = util::f32_to_fp6_e2m3_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 8);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[16] = util::f32_to_fp6_e2m3_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[17] = util::f32_to_fp6_e2m3_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 9);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[18] = util::f32_to_fp6_e2m3_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[19] = util::f32_to_fp6_e2m3_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 10);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[20] = util::f32_to_fp6_e2m3_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[21] = util::f32_to_fp6_e2m3_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 11);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[22] = util::f32_to_fp6_e2m3_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[23] = util::f32_to_fp6_e2m3_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 12);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[24] = util::f32_to_fp6_e2m3_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[25] = util::f32_to_fp6_e2m3_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 13);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[26] = util::f32_to_fp6_e2m3_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[27] = util::f32_to_fp6_e2m3_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 14);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[28] = util::f32_to_fp6_e2m3_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[29] = util::f32_to_fp6_e2m3_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 15);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[30] = util::f32_to_fp6_e2m3_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[31] = util::f32_to_fp6_e2m3_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    uint32_t dwords[6];
+    util::pack_6bit(vals, dwords);
+    wr(vdst, lane, 0, dwords[0]);
+    wr(vdst, lane, 1, dwords[1]);
+    wr(vdst, lane, 2, dwords[2]);
+    wr(vdst, lane, 3, dwords[3]);
+    wr(vdst, lane, 4, dwords[4]);
+    wr(vdst, lane, 5, dwords[5]);
+  }
 }
 
 VCvtScalef32SrPk32Fp6Bf16Vop3::VCvtScalef32SrPk32Fp6Bf16Vop3(const MachineInst *inst)
@@ -4295,8 +6874,210 @@ VCvtScalef32SrPk32Fp6Bf16Vop3::VCvtScalef32SrPk32Fp6Bf16Vop3(const MachineInst *
 }
 
 void VCvtScalef32SrPk32Fp6Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  auto rd = [&](const auto &op, uint32_t lane, uint32_t dw) -> uint32_t {
+    return cu.read_vgpr(vb + op.unified_vgpr_index() + dw, lane);
+  };
+  auto wr = [&](const auto &op, uint32_t lane, uint32_t dw, uint32_t val) {
+    cu.write_vgpr(vb + op.unified_vgpr_index() + dw, lane, val);
+  };
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src2.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu)
+      continue;
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint32_t seed = src1.read_lane(wf, lane);
+    uint8_t vals[32];
+    {
+      uint32_t dw = rd(src0, lane, 0);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[0] = util::f32_to_fp6_e2m3_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[1] = util::f32_to_fp6_e2m3_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 1);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[2] = util::f32_to_fp6_e2m3_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[3] = util::f32_to_fp6_e2m3_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 2);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[4] = util::f32_to_fp6_e2m3_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[5] = util::f32_to_fp6_e2m3_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 3);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[6] = util::f32_to_fp6_e2m3_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[7] = util::f32_to_fp6_e2m3_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 4);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[8] = util::f32_to_fp6_e2m3_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[9] = util::f32_to_fp6_e2m3_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 5);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[10] = util::f32_to_fp6_e2m3_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[11] = util::f32_to_fp6_e2m3_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 6);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[12] = util::f32_to_fp6_e2m3_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[13] = util::f32_to_fp6_e2m3_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 7);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[14] = util::f32_to_fp6_e2m3_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[15] = util::f32_to_fp6_e2m3_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 8);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[16] = util::f32_to_fp6_e2m3_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[17] = util::f32_to_fp6_e2m3_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 9);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[18] = util::f32_to_fp6_e2m3_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[19] = util::f32_to_fp6_e2m3_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 10);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[20] = util::f32_to_fp6_e2m3_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[21] = util::f32_to_fp6_e2m3_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 11);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[22] = util::f32_to_fp6_e2m3_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[23] = util::f32_to_fp6_e2m3_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 12);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[24] = util::f32_to_fp6_e2m3_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[25] = util::f32_to_fp6_e2m3_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 13);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[26] = util::f32_to_fp6_e2m3_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[27] = util::f32_to_fp6_e2m3_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 14);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[28] = util::f32_to_fp6_e2m3_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[29] = util::f32_to_fp6_e2m3_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 15);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[30] = util::f32_to_fp6_e2m3_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[31] = util::f32_to_fp6_e2m3_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    uint32_t dwords[6];
+    util::pack_6bit(vals, dwords);
+    wr(vdst, lane, 0, dwords[0]);
+    wr(vdst, lane, 1, dwords[1]);
+    wr(vdst, lane, 2, dwords[2]);
+    wr(vdst, lane, 3, dwords[3]);
+    wr(vdst, lane, 4, dwords[4]);
+    wr(vdst, lane, 5, dwords[5]);
+  }
 }
 
 VCvtScalef32SrPk32Bf6F16Vop3::VCvtScalef32SrPk32Bf6F16Vop3(const MachineInst *inst)
@@ -4315,8 +7096,210 @@ VCvtScalef32SrPk32Bf6F16Vop3::VCvtScalef32SrPk32Bf6F16Vop3(const MachineInst *in
 }
 
 void VCvtScalef32SrPk32Bf6F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  auto rd = [&](const auto &op, uint32_t lane, uint32_t dw) -> uint32_t {
+    return cu.read_vgpr(vb + op.unified_vgpr_index() + dw, lane);
+  };
+  auto wr = [&](const auto &op, uint32_t lane, uint32_t dw, uint32_t val) {
+    cu.write_vgpr(vb + op.unified_vgpr_index() + dw, lane, val);
+  };
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src2.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu)
+      continue;
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint32_t seed = src1.read_lane(wf, lane);
+    uint8_t vals[32];
+    {
+      uint32_t dw = rd(src0, lane, 0);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[0] = util::f32_to_bf6_e3m2_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[1] = util::f32_to_bf6_e3m2_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 1);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[2] = util::f32_to_bf6_e3m2_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[3] = util::f32_to_bf6_e3m2_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 2);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[4] = util::f32_to_bf6_e3m2_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[5] = util::f32_to_bf6_e3m2_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 3);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[6] = util::f32_to_bf6_e3m2_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[7] = util::f32_to_bf6_e3m2_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 4);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[8] = util::f32_to_bf6_e3m2_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[9] = util::f32_to_bf6_e3m2_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 5);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[10] = util::f32_to_bf6_e3m2_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[11] = util::f32_to_bf6_e3m2_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 6);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[12] = util::f32_to_bf6_e3m2_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[13] = util::f32_to_bf6_e3m2_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 7);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[14] = util::f32_to_bf6_e3m2_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[15] = util::f32_to_bf6_e3m2_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 8);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[16] = util::f32_to_bf6_e3m2_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[17] = util::f32_to_bf6_e3m2_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 9);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[18] = util::f32_to_bf6_e3m2_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[19] = util::f32_to_bf6_e3m2_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 10);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[20] = util::f32_to_bf6_e3m2_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[21] = util::f32_to_bf6_e3m2_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 11);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[22] = util::f32_to_bf6_e3m2_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[23] = util::f32_to_bf6_e3m2_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 12);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[24] = util::f32_to_bf6_e3m2_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[25] = util::f32_to_bf6_e3m2_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 13);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[26] = util::f32_to_bf6_e3m2_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[27] = util::f32_to_bf6_e3m2_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 14);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[28] = util::f32_to_bf6_e3m2_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[29] = util::f32_to_bf6_e3m2_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 15);
+      float v0 = util::f16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::f16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[30] = util::f32_to_bf6_e3m2_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[31] = util::f32_to_bf6_e3m2_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    uint32_t dwords[6];
+    util::pack_6bit(vals, dwords);
+    wr(vdst, lane, 0, dwords[0]);
+    wr(vdst, lane, 1, dwords[1]);
+    wr(vdst, lane, 2, dwords[2]);
+    wr(vdst, lane, 3, dwords[3]);
+    wr(vdst, lane, 4, dwords[4]);
+    wr(vdst, lane, 5, dwords[5]);
+  }
 }
 
 VCvtScalef32SrPk32Bf6Bf16Vop3::VCvtScalef32SrPk32Bf6Bf16Vop3(const MachineInst *inst)
@@ -4335,8 +7318,210 @@ VCvtScalef32SrPk32Bf6Bf16Vop3::VCvtScalef32SrPk32Bf6Bf16Vop3(const MachineInst *
 }
 
 void VCvtScalef32SrPk32Bf6Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  auto rd = [&](const auto &op, uint32_t lane, uint32_t dw) -> uint32_t {
+    return cu.read_vgpr(vb + op.unified_vgpr_index() + dw, lane);
+  };
+  auto wr = [&](const auto &op, uint32_t lane, uint32_t dw, uint32_t val) {
+    cu.write_vgpr(vb + op.unified_vgpr_index() + dw, lane, val);
+  };
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src2.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu)
+      continue;
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint32_t seed = src1.read_lane(wf, lane);
+    uint8_t vals[32];
+    {
+      uint32_t dw = rd(src0, lane, 0);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[0] = util::f32_to_bf6_e3m2_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[1] = util::f32_to_bf6_e3m2_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 1);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[2] = util::f32_to_bf6_e3m2_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[3] = util::f32_to_bf6_e3m2_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 2);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[4] = util::f32_to_bf6_e3m2_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[5] = util::f32_to_bf6_e3m2_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 3);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[6] = util::f32_to_bf6_e3m2_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[7] = util::f32_to_bf6_e3m2_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 4);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[8] = util::f32_to_bf6_e3m2_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[9] = util::f32_to_bf6_e3m2_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 5);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[10] = util::f32_to_bf6_e3m2_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[11] = util::f32_to_bf6_e3m2_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 6);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[12] = util::f32_to_bf6_e3m2_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[13] = util::f32_to_bf6_e3m2_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 7);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[14] = util::f32_to_bf6_e3m2_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[15] = util::f32_to_bf6_e3m2_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 8);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[16] = util::f32_to_bf6_e3m2_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[17] = util::f32_to_bf6_e3m2_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 9);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[18] = util::f32_to_bf6_e3m2_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[19] = util::f32_to_bf6_e3m2_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 10);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[20] = util::f32_to_bf6_e3m2_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[21] = util::f32_to_bf6_e3m2_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 11);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[22] = util::f32_to_bf6_e3m2_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[23] = util::f32_to_bf6_e3m2_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 12);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[24] = util::f32_to_bf6_e3m2_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[25] = util::f32_to_bf6_e3m2_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 13);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[26] = util::f32_to_bf6_e3m2_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[27] = util::f32_to_bf6_e3m2_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 14);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[28] = util::f32_to_bf6_e3m2_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[29] = util::f32_to_bf6_e3m2_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    {
+      uint32_t dw = rd(src0, lane, 15);
+      float v0 = util::bf16_to_f32(static_cast<uint16_t>(dw & 0xFFFF));
+      float v1 = util::bf16_to_f32(static_cast<uint16_t>((dw >> 16) & 0xFFFF));
+      float sv0 = static_cast<float>(static_cast<double>(v0) / scale);
+      float sv1 = static_cast<float>(static_cast<double>(v1) / scale);
+      vals[30] = util::f32_to_bf6_e3m2_sr(sv0, seed);
+      seed = util::prng_advance(seed);
+      vals[31] = util::f32_to_bf6_e3m2_sr(sv1, seed);
+      seed = util::prng_advance(seed);
+    }
+    uint32_t dwords[6];
+    util::pack_6bit(vals, dwords);
+    wr(vdst, lane, 0, dwords[0]);
+    wr(vdst, lane, 1, dwords[1]);
+    wr(vdst, lane, 2, dwords[2]);
+    wr(vdst, lane, 3, dwords[3]);
+    wr(vdst, lane, 4, dwords[4]);
+    wr(vdst, lane, 5, dwords[5]);
+  }
 }
 
 VCvtScalef32Pk32F16Fp6Vop3::VCvtScalef32Pk32F16Fp6Vop3(const MachineInst *inst)
@@ -4353,8 +7538,145 @@ VCvtScalef32Pk32F16Fp6Vop3::VCvtScalef32Pk32F16Fp6Vop3(const MachineInst *inst)
 }
 
 void VCvtScalef32Pk32F16Fp6Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  auto rd = [&](const auto &op, uint32_t lane, uint32_t dw) -> uint32_t {
+    return cu.read_vgpr(vb + op.unified_vgpr_index() + dw, lane);
+  };
+  auto wr = [&](const auto &op, uint32_t lane, uint32_t dw, uint32_t val) {
+    cu.write_vgpr(vb + op.unified_vgpr_index() + dw, lane, val);
+  };
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src1.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu)
+      continue;
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint32_t src_dwords[6];
+    src_dwords[0] = rd(src0, lane, 0);
+    src_dwords[1] = rd(src0, lane, 1);
+    src_dwords[2] = rd(src0, lane, 2);
+    src_dwords[3] = rd(src0, lane, 3);
+    src_dwords[4] = rd(src0, lane, 4);
+    src_dwords[5] = rd(src0, lane, 5);
+    uint8_t vals[32];
+    util::unpack_6bit(src_dwords, vals);
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[0])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[1])) * scale);
+      wr(vdst, lane, 0,
+         static_cast<uint32_t>(util::f32_to_f16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_f16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[2])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[3])) * scale);
+      wr(vdst, lane, 1,
+         static_cast<uint32_t>(util::f32_to_f16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_f16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[4])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[5])) * scale);
+      wr(vdst, lane, 2,
+         static_cast<uint32_t>(util::f32_to_f16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_f16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[6])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[7])) * scale);
+      wr(vdst, lane, 3,
+         static_cast<uint32_t>(util::f32_to_f16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_f16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[8])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[9])) * scale);
+      wr(vdst, lane, 4,
+         static_cast<uint32_t>(util::f32_to_f16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_f16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[10])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[11])) * scale);
+      wr(vdst, lane, 5,
+         static_cast<uint32_t>(util::f32_to_f16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_f16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[12])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[13])) * scale);
+      wr(vdst, lane, 6,
+         static_cast<uint32_t>(util::f32_to_f16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_f16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[14])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[15])) * scale);
+      wr(vdst, lane, 7,
+         static_cast<uint32_t>(util::f32_to_f16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_f16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[16])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[17])) * scale);
+      wr(vdst, lane, 8,
+         static_cast<uint32_t>(util::f32_to_f16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_f16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[18])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[19])) * scale);
+      wr(vdst, lane, 9,
+         static_cast<uint32_t>(util::f32_to_f16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_f16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[20])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[21])) * scale);
+      wr(vdst, lane, 10,
+         static_cast<uint32_t>(util::f32_to_f16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_f16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[22])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[23])) * scale);
+      wr(vdst, lane, 11,
+         static_cast<uint32_t>(util::f32_to_f16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_f16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[24])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[25])) * scale);
+      wr(vdst, lane, 12,
+         static_cast<uint32_t>(util::f32_to_f16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_f16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[26])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[27])) * scale);
+      wr(vdst, lane, 13,
+         static_cast<uint32_t>(util::f32_to_f16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_f16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[28])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[29])) * scale);
+      wr(vdst, lane, 14,
+         static_cast<uint32_t>(util::f32_to_f16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_f16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[30])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[31])) * scale);
+      wr(vdst, lane, 15,
+         static_cast<uint32_t>(util::f32_to_f16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_f16(f1)) << 16));
+    }
+  }
 }
 
 VCvtScalef32Pk32Bf16Fp6Vop3::VCvtScalef32Pk32Bf16Fp6Vop3(const MachineInst *inst)
@@ -4371,8 +7693,145 @@ VCvtScalef32Pk32Bf16Fp6Vop3::VCvtScalef32Pk32Bf16Fp6Vop3(const MachineInst *inst
 }
 
 void VCvtScalef32Pk32Bf16Fp6Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  auto rd = [&](const auto &op, uint32_t lane, uint32_t dw) -> uint32_t {
+    return cu.read_vgpr(vb + op.unified_vgpr_index() + dw, lane);
+  };
+  auto wr = [&](const auto &op, uint32_t lane, uint32_t dw, uint32_t val) {
+    cu.write_vgpr(vb + op.unified_vgpr_index() + dw, lane, val);
+  };
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src1.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu)
+      continue;
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint32_t src_dwords[6];
+    src_dwords[0] = rd(src0, lane, 0);
+    src_dwords[1] = rd(src0, lane, 1);
+    src_dwords[2] = rd(src0, lane, 2);
+    src_dwords[3] = rd(src0, lane, 3);
+    src_dwords[4] = rd(src0, lane, 4);
+    src_dwords[5] = rd(src0, lane, 5);
+    uint8_t vals[32];
+    util::unpack_6bit(src_dwords, vals);
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[0])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[1])) * scale);
+      wr(vdst, lane, 0,
+         static_cast<uint32_t>(util::f32_to_bf16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_bf16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[2])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[3])) * scale);
+      wr(vdst, lane, 1,
+         static_cast<uint32_t>(util::f32_to_bf16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_bf16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[4])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[5])) * scale);
+      wr(vdst, lane, 2,
+         static_cast<uint32_t>(util::f32_to_bf16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_bf16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[6])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[7])) * scale);
+      wr(vdst, lane, 3,
+         static_cast<uint32_t>(util::f32_to_bf16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_bf16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[8])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[9])) * scale);
+      wr(vdst, lane, 4,
+         static_cast<uint32_t>(util::f32_to_bf16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_bf16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[10])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[11])) * scale);
+      wr(vdst, lane, 5,
+         static_cast<uint32_t>(util::f32_to_bf16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_bf16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[12])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[13])) * scale);
+      wr(vdst, lane, 6,
+         static_cast<uint32_t>(util::f32_to_bf16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_bf16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[14])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[15])) * scale);
+      wr(vdst, lane, 7,
+         static_cast<uint32_t>(util::f32_to_bf16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_bf16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[16])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[17])) * scale);
+      wr(vdst, lane, 8,
+         static_cast<uint32_t>(util::f32_to_bf16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_bf16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[18])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[19])) * scale);
+      wr(vdst, lane, 9,
+         static_cast<uint32_t>(util::f32_to_bf16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_bf16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[20])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[21])) * scale);
+      wr(vdst, lane, 10,
+         static_cast<uint32_t>(util::f32_to_bf16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_bf16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[22])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[23])) * scale);
+      wr(vdst, lane, 11,
+         static_cast<uint32_t>(util::f32_to_bf16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_bf16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[24])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[25])) * scale);
+      wr(vdst, lane, 12,
+         static_cast<uint32_t>(util::f32_to_bf16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_bf16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[26])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[27])) * scale);
+      wr(vdst, lane, 13,
+         static_cast<uint32_t>(util::f32_to_bf16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_bf16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[28])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[29])) * scale);
+      wr(vdst, lane, 14,
+         static_cast<uint32_t>(util::f32_to_bf16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_bf16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[30])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::fp6_e2m3_to_f32(vals[31])) * scale);
+      wr(vdst, lane, 15,
+         static_cast<uint32_t>(util::f32_to_bf16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_bf16(f1)) << 16));
+    }
+  }
 }
 
 VCvtScalef32Pk32F16Bf6Vop3::VCvtScalef32Pk32F16Bf6Vop3(const MachineInst *inst)
@@ -4389,8 +7848,145 @@ VCvtScalef32Pk32F16Bf6Vop3::VCvtScalef32Pk32F16Bf6Vop3(const MachineInst *inst)
 }
 
 void VCvtScalef32Pk32F16Bf6Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  auto rd = [&](const auto &op, uint32_t lane, uint32_t dw) -> uint32_t {
+    return cu.read_vgpr(vb + op.unified_vgpr_index() + dw, lane);
+  };
+  auto wr = [&](const auto &op, uint32_t lane, uint32_t dw, uint32_t val) {
+    cu.write_vgpr(vb + op.unified_vgpr_index() + dw, lane, val);
+  };
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src1.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu)
+      continue;
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint32_t src_dwords[6];
+    src_dwords[0] = rd(src0, lane, 0);
+    src_dwords[1] = rd(src0, lane, 1);
+    src_dwords[2] = rd(src0, lane, 2);
+    src_dwords[3] = rd(src0, lane, 3);
+    src_dwords[4] = rd(src0, lane, 4);
+    src_dwords[5] = rd(src0, lane, 5);
+    uint8_t vals[32];
+    util::unpack_6bit(src_dwords, vals);
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[0])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[1])) * scale);
+      wr(vdst, lane, 0,
+         static_cast<uint32_t>(util::f32_to_f16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_f16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[2])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[3])) * scale);
+      wr(vdst, lane, 1,
+         static_cast<uint32_t>(util::f32_to_f16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_f16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[4])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[5])) * scale);
+      wr(vdst, lane, 2,
+         static_cast<uint32_t>(util::f32_to_f16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_f16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[6])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[7])) * scale);
+      wr(vdst, lane, 3,
+         static_cast<uint32_t>(util::f32_to_f16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_f16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[8])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[9])) * scale);
+      wr(vdst, lane, 4,
+         static_cast<uint32_t>(util::f32_to_f16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_f16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[10])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[11])) * scale);
+      wr(vdst, lane, 5,
+         static_cast<uint32_t>(util::f32_to_f16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_f16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[12])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[13])) * scale);
+      wr(vdst, lane, 6,
+         static_cast<uint32_t>(util::f32_to_f16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_f16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[14])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[15])) * scale);
+      wr(vdst, lane, 7,
+         static_cast<uint32_t>(util::f32_to_f16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_f16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[16])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[17])) * scale);
+      wr(vdst, lane, 8,
+         static_cast<uint32_t>(util::f32_to_f16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_f16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[18])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[19])) * scale);
+      wr(vdst, lane, 9,
+         static_cast<uint32_t>(util::f32_to_f16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_f16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[20])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[21])) * scale);
+      wr(vdst, lane, 10,
+         static_cast<uint32_t>(util::f32_to_f16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_f16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[22])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[23])) * scale);
+      wr(vdst, lane, 11,
+         static_cast<uint32_t>(util::f32_to_f16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_f16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[24])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[25])) * scale);
+      wr(vdst, lane, 12,
+         static_cast<uint32_t>(util::f32_to_f16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_f16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[26])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[27])) * scale);
+      wr(vdst, lane, 13,
+         static_cast<uint32_t>(util::f32_to_f16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_f16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[28])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[29])) * scale);
+      wr(vdst, lane, 14,
+         static_cast<uint32_t>(util::f32_to_f16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_f16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[30])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[31])) * scale);
+      wr(vdst, lane, 15,
+         static_cast<uint32_t>(util::f32_to_f16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_f16(f1)) << 16));
+    }
+  }
 }
 
 VCvtScalef32Pk32Bf16Bf6Vop3::VCvtScalef32Pk32Bf16Bf6Vop3(const MachineInst *inst)
@@ -4407,8 +8003,145 @@ VCvtScalef32Pk32Bf16Bf6Vop3::VCvtScalef32Pk32Bf16Bf6Vop3(const MachineInst *inst
 }
 
 void VCvtScalef32Pk32Bf16Bf6Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  auto rd = [&](const auto &op, uint32_t lane, uint32_t dw) -> uint32_t {
+    return cu.read_vgpr(vb + op.unified_vgpr_index() + dw, lane);
+  };
+  auto wr = [&](const auto &op, uint32_t lane, uint32_t dw, uint32_t val) {
+    cu.write_vgpr(vb + op.unified_vgpr_index() + dw, lane, val);
+  };
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src1.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu)
+      continue;
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint32_t src_dwords[6];
+    src_dwords[0] = rd(src0, lane, 0);
+    src_dwords[1] = rd(src0, lane, 1);
+    src_dwords[2] = rd(src0, lane, 2);
+    src_dwords[3] = rd(src0, lane, 3);
+    src_dwords[4] = rd(src0, lane, 4);
+    src_dwords[5] = rd(src0, lane, 5);
+    uint8_t vals[32];
+    util::unpack_6bit(src_dwords, vals);
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[0])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[1])) * scale);
+      wr(vdst, lane, 0,
+         static_cast<uint32_t>(util::f32_to_bf16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_bf16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[2])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[3])) * scale);
+      wr(vdst, lane, 1,
+         static_cast<uint32_t>(util::f32_to_bf16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_bf16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[4])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[5])) * scale);
+      wr(vdst, lane, 2,
+         static_cast<uint32_t>(util::f32_to_bf16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_bf16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[6])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[7])) * scale);
+      wr(vdst, lane, 3,
+         static_cast<uint32_t>(util::f32_to_bf16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_bf16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[8])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[9])) * scale);
+      wr(vdst, lane, 4,
+         static_cast<uint32_t>(util::f32_to_bf16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_bf16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[10])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[11])) * scale);
+      wr(vdst, lane, 5,
+         static_cast<uint32_t>(util::f32_to_bf16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_bf16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[12])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[13])) * scale);
+      wr(vdst, lane, 6,
+         static_cast<uint32_t>(util::f32_to_bf16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_bf16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[14])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[15])) * scale);
+      wr(vdst, lane, 7,
+         static_cast<uint32_t>(util::f32_to_bf16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_bf16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[16])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[17])) * scale);
+      wr(vdst, lane, 8,
+         static_cast<uint32_t>(util::f32_to_bf16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_bf16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[18])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[19])) * scale);
+      wr(vdst, lane, 9,
+         static_cast<uint32_t>(util::f32_to_bf16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_bf16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[20])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[21])) * scale);
+      wr(vdst, lane, 10,
+         static_cast<uint32_t>(util::f32_to_bf16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_bf16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[22])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[23])) * scale);
+      wr(vdst, lane, 11,
+         static_cast<uint32_t>(util::f32_to_bf16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_bf16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[24])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[25])) * scale);
+      wr(vdst, lane, 12,
+         static_cast<uint32_t>(util::f32_to_bf16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_bf16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[26])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[27])) * scale);
+      wr(vdst, lane, 13,
+         static_cast<uint32_t>(util::f32_to_bf16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_bf16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[28])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[29])) * scale);
+      wr(vdst, lane, 14,
+         static_cast<uint32_t>(util::f32_to_bf16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_bf16(f1)) << 16));
+    }
+    {
+      float f0 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[30])) * scale);
+      float f1 = static_cast<float>(static_cast<double>(util::bf6_e3m2_to_f32(vals[31])) * scale);
+      wr(vdst, lane, 15,
+         static_cast<uint32_t>(util::f32_to_bf16(f0)) |
+             (static_cast<uint32_t>(util::f32_to_bf16(f1)) << 16));
+    }
+  }
 }
 
 VAshrPkI8I32Vop3::VAshrPkI8I32Vop3(const MachineInst *inst)
@@ -4542,8 +8275,30 @@ VCvtScalef32PkBf16Fp8Vop3::VCvtScalef32PkBf16Fp8Vop3(const MachineInst *inst)
 }
 
 void VCvtScalef32PkBf16Fp8Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src1.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu) {
+      vdst.write_lane(wf, lane,
+                      static_cast<uint32_t>(0x7FC0u) | (static_cast<uint32_t>(0x7FC0u) << 16));
+      continue;
+    }
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint32_t src_raw = src0.read_lane(wf, lane);
+    bool src_hi = inst_.op_sel & 1;
+    uint32_t half = src_hi ? (src_raw >> 16) : (src_raw & 0xFFFFu);
+    float f0 = static_cast<float>(
+        static_cast<double>(util::fp8_e4m3_to_f32(static_cast<uint8_t>(half & 0xFF))) * scale);
+    float f1 = static_cast<float>(
+        static_cast<double>(util::fp8_e4m3_to_f32(static_cast<uint8_t>((half >> 8) & 0xFF))) *
+        scale);
+    uint32_t result = static_cast<uint32_t>(util::f32_to_bf16(f0)) |
+                      (static_cast<uint32_t>(util::f32_to_bf16(f1)) << 16);
+    vdst.write_lane(wf, lane, result);
+  }
 }
 
 VCvtScalef32PkBf16Bf8Vop3::VCvtScalef32PkBf16Bf8Vop3(const MachineInst *inst)
@@ -4560,8 +8315,30 @@ VCvtScalef32PkBf16Bf8Vop3::VCvtScalef32PkBf16Bf8Vop3(const MachineInst *inst)
 }
 
 void VCvtScalef32PkBf16Bf8Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t scale_bits = src1.read_lane(wf, lane);
+    uint32_t biased_exp = (scale_bits >> 23) & 0xFFu;
+    if (biased_exp == 0xFFu) {
+      vdst.write_lane(wf, lane,
+                      static_cast<uint32_t>(0x7FC0u) | (static_cast<uint32_t>(0x7FC0u) << 16));
+      continue;
+    }
+    double scale = std::ldexp(1.0, static_cast<int>(biased_exp) - 127);
+    uint32_t src_raw = src0.read_lane(wf, lane);
+    bool src_hi = inst_.op_sel & 1;
+    uint32_t half = src_hi ? (src_raw >> 16) : (src_raw & 0xFFFFu);
+    float f0 = static_cast<float>(
+        static_cast<double>(util::bf8_e5m2_to_f32(static_cast<uint8_t>(half & 0xFF))) * scale);
+    float f1 = static_cast<float>(
+        static_cast<double>(util::bf8_e5m2_to_f32(static_cast<uint8_t>((half >> 8) & 0xFF))) *
+        scale);
+    uint32_t result = static_cast<uint32_t>(util::f32_to_bf16(f0)) |
+                      (static_cast<uint32_t>(util::f32_to_bf16(f1)) << 16);
+    vdst.write_lane(wf, lane, result);
+  }
 }
 
 VAddF64Vop3::VAddF64Vop3(const MachineInst *inst)
@@ -5109,7 +8886,13 @@ void VCvtPkFp8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
     float s1 = std::bit_cast<float>(src1.read_lane(wf, lane));
     uint32_t lo = util::f32_to_fp8_e4m3_rne(s0);
     uint32_t hi = util::f32_to_fp8_e4m3_rne(s1);
-    vdst.write_lane(wf, lane, lo | (hi << 8));
+    uint32_t packed = static_cast<uint32_t>(lo) | (static_cast<uint32_t>(hi) << 8);
+    bool word_hi = (inst_.op_sel >> 3) & 1;
+    uint32_t old = vdst.read_lane(wf, lane);
+    if (word_hi)
+      vdst.write_lane(wf, lane, (old & 0xFFFFu) | (packed << 16));
+    else
+      vdst.write_lane(wf, lane, (old & 0xFFFF0000u) | (packed & 0xFFFFu));
   }
 }
 
@@ -5135,7 +8918,13 @@ void VCvtPkBf8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
     float s1 = std::bit_cast<float>(src1.read_lane(wf, lane));
     uint32_t lo = util::f32_to_bf8_e5m2_rne(s0);
     uint32_t hi = util::f32_to_bf8_e5m2_rne(s1);
-    vdst.write_lane(wf, lane, lo | (hi << 8));
+    uint32_t packed = static_cast<uint32_t>(lo) | (static_cast<uint32_t>(hi) << 8);
+    bool word_hi = (inst_.op_sel >> 3) & 1;
+    uint32_t old = vdst.read_lane(wf, lane);
+    if (word_hi)
+      vdst.write_lane(wf, lane, (old & 0xFFFFu) | (packed << 16));
+    else
+      vdst.write_lane(wf, lane, (old & 0xFFFF0000u) | (packed & 0xFFFFu));
   }
 }
 
@@ -5153,8 +8942,18 @@ VCvtSrFp8F32Vop3::VCvtSrFp8F32Vop3(const MachineInst *inst)
 }
 
 void VCvtSrFp8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    float s0 = std::bit_cast<float>(static_cast<uint32_t>(src0.read_lane(wf, lane)));
+    uint32_t seed = src1.read_lane(wf, lane);
+    uint8_t result = util::f32_to_fp8_e4m3_sr(s0, seed);
+    uint32_t dst_byte = (inst_.op_sel >> 2) & 0x3;
+    uint32_t old = vdst.read_lane(wf, lane);
+    uint32_t mask = ~(0xFFu << (dst_byte * 8));
+    vdst.write_lane(wf, lane, (old & mask) | (static_cast<uint32_t>(result) << (dst_byte * 8)));
+  }
 }
 
 VCvtSrBf8F32Vop3::VCvtSrBf8F32Vop3(const MachineInst *inst)
@@ -5171,8 +8970,18 @@ VCvtSrBf8F32Vop3::VCvtSrBf8F32Vop3(const MachineInst *inst)
 }
 
 void VCvtSrBf8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    float s0 = std::bit_cast<float>(static_cast<uint32_t>(src0.read_lane(wf, lane)));
+    uint32_t seed = src1.read_lane(wf, lane);
+    uint8_t result = util::f32_to_bf8_e5m2_sr(s0, seed);
+    uint32_t dst_byte = (inst_.op_sel >> 2) & 0x3;
+    uint32_t old = vdst.read_lane(wf, lane);
+    uint32_t mask = ~(0xFFu << (dst_byte * 8));
+    vdst.write_lane(wf, lane, (old & mask) | (static_cast<uint32_t>(result) << (dst_byte * 8)));
+  }
 }
 
 VCvtSrF16F32Vop3::VCvtSrF16F32Vop3(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/operand.cpp
@@ -1285,8 +1285,10 @@ uint32_t Operand::read_lane(const amdgpu::Wavefront &wf, uint32_t lane) const {
     uint32_t raw = wf.cu().read_vgpr(wf.vgpr_alloc().base + off, lane);
     return (raw >> packed->shift) & 0xffffu;
   }
-  if (auto off = Isa::resolved_vgpr_offset(wf, opr_type_, ev, vgpr_msb_role()))
-    return wf.cu().read_vgpr(wf.vgpr_alloc().base + *off, lane);
+  if (auto off = Isa::resolved_vgpr_offset(wf, opr_type_, ev, vgpr_msb_role())) {
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, false) : *off;
+    return wf.cu().read_vgpr(wf.vgpr_alloc().base + voff, lane);
+  }
   if (is_immediate_type(opr_type_))
     return static_cast<uint32_t>(ev);
   return resolve_src_scalar(wf, ev);
@@ -1298,7 +1300,8 @@ void Operand::write_scalar(amdgpu::Wavefront &wf, uint32_t val) const {
 
 void Operand::write_lane(amdgpu::Wavefront &wf, uint32_t lane, uint32_t val) const {
   if (auto off = Isa::resolved_vgpr_offset(wf, opr_type_, encoding_value_, vgpr_msb_role())) {
-    wf.cu().write_vgpr(wf.vgpr_alloc().base + *off, lane, val);
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, true) : *off;
+    wf.cu().write_vgpr(wf.vgpr_alloc().base + voff, lane, val);
     return;
   }
   throw std::logic_error("write_lane called on non-VGPR operand type");
@@ -1309,7 +1312,8 @@ uint64_t Operand::read_lane64(const amdgpu::Wavefront &wf, uint32_t lane) const 
     return delegate()->read_lane64(wf, lane);
   int ev = encoding_value_;
   if (auto off = Isa::resolved_vgpr_offset(wf, opr_type_, ev, vgpr_msb_role())) {
-    uint32_t idx = wf.vgpr_alloc().base + *off;
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, false) : *off;
+    uint32_t idx = wf.vgpr_alloc().base + voff;
     uint32_t lo = wf.cu().read_vgpr(idx, lane);
     uint32_t hi = wf.cu().read_vgpr(idx + 1, lane);
     return static_cast<uint64_t>(hi) << 32 | lo;
@@ -1323,7 +1327,8 @@ uint64_t Operand::read_lane64(const amdgpu::Wavefront &wf, uint32_t lane) const 
 
 void Operand::write_lane64(amdgpu::Wavefront &wf, uint32_t lane, uint64_t val) const {
   if (auto off = Isa::resolved_vgpr_offset(wf, opr_type_, encoding_value_, vgpr_msb_role())) {
-    uint32_t idx = wf.vgpr_alloc().base + *off;
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, true) : *off;
+    uint32_t idx = wf.vgpr_alloc().base + voff;
     wf.cu().write_vgpr(idx, lane, static_cast<uint32_t>(val));
     wf.cu().write_vgpr(idx + 1, lane, static_cast<uint32_t>(val >> 32));
     return;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop1.cpp
@@ -11507,7 +11507,20 @@ void VCvtPkF32Fp8Vop1::execute_impl(amdgpu::Wavefront &wf) {
   }
   if (dpp_src0_)
     src0.set_delegate(dpp_src0_.get());
-  amdgpu::execute_v_cvt_pk_f32_fp8_vop1(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t packed = src0.read_lane(wf, lane);
+    bool src_hi = 0u & 1;
+    uint32_t half = src_hi ? (packed >> 16) : (packed & 0xFFFFu);
+    float lo = util::fp8_e4m3_to_f32(static_cast<uint8_t>(half & 0xFFu));
+    float hi = util::fp8_e4m3_to_f32(static_cast<uint8_t>((half >> 8) & 0xFFu));
+    uint32_t lo_bits = std::bit_cast<uint32_t>(lo);
+    uint32_t hi_bits = std::bit_cast<uint32_t>(hi);
+    vdst.write_lane64(wf, lane,
+                      static_cast<uint64_t>(lo_bits) | (static_cast<uint64_t>(hi_bits) << 32));
+  }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
@@ -11628,7 +11641,20 @@ void VCvtPkF32Bf8Vop1::execute_impl(amdgpu::Wavefront &wf) {
   }
   if (dpp_src0_)
     src0.set_delegate(dpp_src0_.get());
-  amdgpu::execute_v_cvt_pk_f32_bf8_vop1(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t packed = src0.read_lane(wf, lane);
+    bool src_hi = 0u & 1;
+    uint32_t half = src_hi ? (packed >> 16) : (packed & 0xFFFFu);
+    float lo = util::bf8_e5m2_to_f32(static_cast<uint8_t>(half & 0xFFu));
+    float hi = util::bf8_e5m2_to_f32(static_cast<uint8_t>((half >> 8) & 0xFFu));
+    uint32_t lo_bits = std::bit_cast<uint32_t>(lo);
+    uint32_t hi_bits = std::bit_cast<uint32_t>(hi);
+    vdst.write_lane64(wf, lane,
+                      static_cast<uint64_t>(lo_bits) | (static_cast<uint64_t>(hi_bits) << 32));
+  }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
@@ -11955,9 +11981,11 @@ void VCvtPkF16Fp8Vop1::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    uint32_t raw = src0.read_lane(wf, lane);
-    float lo = util::fp8_e4m3_to_f32(static_cast<uint8_t>(raw & 0xFFu));
-    float hi = util::fp8_e4m3_to_f32(static_cast<uint8_t>((raw >> 8) & 0xFFu));
+    uint32_t packed = src0.read_lane(wf, lane);
+    bool src_hi = 0u & 1;
+    uint32_t half = src_hi ? (packed >> 16) : (packed & 0xFFFFu);
+    float lo = util::fp8_e4m3_to_f32(static_cast<uint8_t>(half & 0xFFu));
+    float hi = util::fp8_e4m3_to_f32(static_cast<uint8_t>((half >> 8) & 0xFFu));
     uint32_t lo_bits = util::f32_to_f16(lo);
     uint32_t hi_bits = util::f32_to_f16(hi);
     vdst.write_lane(wf, lane, lo_bits | (hi_bits << 16));
@@ -12086,9 +12114,11 @@ void VCvtPkF16Bf8Vop1::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    uint32_t raw = src0.read_lane(wf, lane);
-    float lo = util::bf8_e5m2_to_f32(static_cast<uint8_t>(raw & 0xFFu));
-    float hi = util::bf8_e5m2_to_f32(static_cast<uint8_t>((raw >> 8) & 0xFFu));
+    uint32_t packed = src0.read_lane(wf, lane);
+    bool src_hi = 0u & 1;
+    uint32_t half = src_hi ? (packed >> 16) : (packed & 0xFFFFu);
+    float lo = util::bf8_e5m2_to_f32(static_cast<uint8_t>(half & 0xFFu));
+    float hi = util::bf8_e5m2_to_f32(static_cast<uint8_t>((half >> 8) & 0xFFu));
     uint32_t lo_bits = util::f32_to_f16(lo);
     uint32_t hi_bits = util::f32_to_f16(hi);
     vdst.write_lane(wf, lane, lo_bits | (hi_bits << 16));

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_part1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_part1.cpp
@@ -2799,9 +2799,11 @@ void VCvtPkF32Fp8Vop3::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    uint32_t raw = src0.read_lane(wf, lane);
-    float lo = util::fp8_e4m3_to_f32(static_cast<uint8_t>(raw & 0xFFu));
-    float hi = util::fp8_e4m3_to_f32(static_cast<uint8_t>((raw >> 8) & 0xFFu));
+    uint32_t packed = src0.read_lane(wf, lane);
+    bool src_hi = 0u & 1;
+    uint32_t half = src_hi ? (packed >> 16) : (packed & 0xFFFFu);
+    float lo = util::fp8_e4m3_to_f32(static_cast<uint8_t>(half & 0xFFu));
+    float hi = util::fp8_e4m3_to_f32(static_cast<uint8_t>((half >> 8) & 0xFFu));
     uint32_t lo_bits = std::bit_cast<uint32_t>(lo);
     uint32_t hi_bits = std::bit_cast<uint32_t>(hi);
     vdst.write_lane64(wf, lane,
@@ -2838,9 +2840,11 @@ void VCvtPkF32Bf8Vop3::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    uint32_t raw = src0.read_lane(wf, lane);
-    float lo = util::bf8_e5m2_to_f32(static_cast<uint8_t>(raw & 0xFFu));
-    float hi = util::bf8_e5m2_to_f32(static_cast<uint8_t>((raw >> 8) & 0xFFu));
+    uint32_t packed = src0.read_lane(wf, lane);
+    bool src_hi = 0u & 1;
+    uint32_t half = src_hi ? (packed >> 16) : (packed & 0xFFFFu);
+    float lo = util::bf8_e5m2_to_f32(static_cast<uint8_t>(half & 0xFFu));
+    float hi = util::bf8_e5m2_to_f32(static_cast<uint8_t>((half >> 8) & 0xFFu));
     uint32_t lo_bits = std::bit_cast<uint32_t>(lo);
     uint32_t hi_bits = std::bit_cast<uint32_t>(hi);
     vdst.write_lane64(wf, lane,
@@ -2971,9 +2975,11 @@ void VCvtPkF16Fp8Vop3::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    uint32_t raw = src0.read_lane(wf, lane);
-    float lo = util::fp8_e4m3_to_f32(static_cast<uint8_t>(raw & 0xFFu));
-    float hi = util::fp8_e4m3_to_f32(static_cast<uint8_t>((raw >> 8) & 0xFFu));
+    uint32_t packed = src0.read_lane(wf, lane);
+    bool src_hi = 0u & 1;
+    uint32_t half = src_hi ? (packed >> 16) : (packed & 0xFFFFu);
+    float lo = util::fp8_e4m3_to_f32(static_cast<uint8_t>(half & 0xFFu));
+    float hi = util::fp8_e4m3_to_f32(static_cast<uint8_t>((half >> 8) & 0xFFu));
     uint32_t lo_bits = util::f32_to_f16(lo);
     uint32_t hi_bits = util::f32_to_f16(hi);
     vdst.write_lane(wf, lane, lo_bits | (hi_bits << 16));
@@ -3009,9 +3015,11 @@ void VCvtPkF16Bf8Vop3::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    uint32_t raw = src0.read_lane(wf, lane);
-    float lo = util::bf8_e5m2_to_f32(static_cast<uint8_t>(raw & 0xFFu));
-    float hi = util::bf8_e5m2_to_f32(static_cast<uint8_t>((raw >> 8) & 0xFFu));
+    uint32_t packed = src0.read_lane(wf, lane);
+    bool src_hi = 0u & 1;
+    uint32_t half = src_hi ? (packed >> 16) : (packed & 0xFFFFu);
+    float lo = util::bf8_e5m2_to_f32(static_cast<uint8_t>(half & 0xFFu));
+    float hi = util::bf8_e5m2_to_f32(static_cast<uint8_t>((half >> 8) & 0xFFu));
     uint32_t lo_bits = util::f32_to_f16(lo);
     uint32_t hi_bits = util::f32_to_f16(hi);
     vdst.write_lane(wf, lane, lo_bits | (hi_bits << 16));

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_part2.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_part2.cpp
@@ -4105,8 +4105,42 @@ VCvtScalef32SrPk8Fp4F32Vop3::VCvtScalef32SrPk8Fp4F32Vop3(const MachineInst *inst
 }
 
 void VCvtScalef32SrPk8Fp4F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t dst_base =
+        wf.vgpr_alloc().base +
+        *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
+    float scale = std::bit_cast<float>(src2.read_lane(wf, lane));
+    uint32_t seed = static_cast<uint32_t>(src1.read_lane(wf, lane));
+    uint32_t src_base =
+        wf.vgpr_alloc().base +
+        *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    uint32_t src_words[8] = {};
+    for (uint32_t word = 0; word < 8u; ++word)
+      src_words[word] = wf.cu().read_vgpr(src_base + word, lane);
+    auto read_scaled_input = [&](uint32_t index) -> float {
+      return std::bit_cast<float>(src_words[index]);
+    };
+    uint32_t dst_words[1] = {};
+    auto pack_scaled_dst = [&](uint32_t index, uint32_t code) {
+      code &= 0xfu;
+      uint32_t bit = index * 4u;
+      uint32_t word = bit / 32u;
+      uint32_t shift = bit & 31u;
+      dst_words[word] |= code << shift;
+      if (shift + 4u > 32u)
+        dst_words[word + 1u] |= code >> (32u - shift);
+    };
+    for (uint32_t index = 0; index < 8u; ++index) {
+      float value = read_scaled_input(index) / scale;
+      pack_scaled_dst(index, util::f32_to_fp4_e2m1_sr(value, seed));
+      seed = util::prng_advance(seed);
+    }
+    for (uint32_t word = 0; word < 1u; ++word)
+      wf.cu().write_vgpr(dst_base + word, lane, dst_words[word]);
+  }
 }
 
 VCvtScalef32SrPk8Fp8F32Vop3::VCvtScalef32SrPk8Fp8F32Vop3(const MachineInst *inst)
@@ -4162,8 +4196,42 @@ VCvtScalef32SrPk8Fp8F32Vop3::VCvtScalef32SrPk8Fp8F32Vop3(const MachineInst *inst
 }
 
 void VCvtScalef32SrPk8Fp8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t dst_base =
+        wf.vgpr_alloc().base +
+        *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
+    float scale = std::bit_cast<float>(src2.read_lane(wf, lane));
+    uint32_t seed = static_cast<uint32_t>(src1.read_lane(wf, lane));
+    uint32_t src_base =
+        wf.vgpr_alloc().base +
+        *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    uint32_t src_words[8] = {};
+    for (uint32_t word = 0; word < 8u; ++word)
+      src_words[word] = wf.cu().read_vgpr(src_base + word, lane);
+    auto read_scaled_input = [&](uint32_t index) -> float {
+      return std::bit_cast<float>(src_words[index]);
+    };
+    uint32_t dst_words[2] = {};
+    auto pack_scaled_dst = [&](uint32_t index, uint32_t code) {
+      code &= 0xffu;
+      uint32_t bit = index * 8u;
+      uint32_t word = bit / 32u;
+      uint32_t shift = bit & 31u;
+      dst_words[word] |= code << shift;
+      if (shift + 8u > 32u)
+        dst_words[word + 1u] |= code >> (32u - shift);
+    };
+    for (uint32_t index = 0; index < 8u; ++index) {
+      float value = read_scaled_input(index) / scale;
+      pack_scaled_dst(index, util::f32_to_fp8_e4m3_sr(value, seed));
+      seed = util::prng_advance(seed);
+    }
+    for (uint32_t word = 0; word < 2u; ++word)
+      wf.cu().write_vgpr(dst_base + word, lane, dst_words[word]);
+  }
 }
 
 VCvtScalef32SrPk8Bf8F32Vop3::VCvtScalef32SrPk8Bf8F32Vop3(const MachineInst *inst)
@@ -4219,8 +4287,42 @@ VCvtScalef32SrPk8Bf8F32Vop3::VCvtScalef32SrPk8Bf8F32Vop3(const MachineInst *inst
 }
 
 void VCvtScalef32SrPk8Bf8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t dst_base =
+        wf.vgpr_alloc().base +
+        *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
+    float scale = std::bit_cast<float>(src2.read_lane(wf, lane));
+    uint32_t seed = static_cast<uint32_t>(src1.read_lane(wf, lane));
+    uint32_t src_base =
+        wf.vgpr_alloc().base +
+        *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    uint32_t src_words[8] = {};
+    for (uint32_t word = 0; word < 8u; ++word)
+      src_words[word] = wf.cu().read_vgpr(src_base + word, lane);
+    auto read_scaled_input = [&](uint32_t index) -> float {
+      return std::bit_cast<float>(src_words[index]);
+    };
+    uint32_t dst_words[2] = {};
+    auto pack_scaled_dst = [&](uint32_t index, uint32_t code) {
+      code &= 0xffu;
+      uint32_t bit = index * 8u;
+      uint32_t word = bit / 32u;
+      uint32_t shift = bit & 31u;
+      dst_words[word] |= code << shift;
+      if (shift + 8u > 32u)
+        dst_words[word + 1u] |= code >> (32u - shift);
+    };
+    for (uint32_t index = 0; index < 8u; ++index) {
+      float value = read_scaled_input(index) / scale;
+      pack_scaled_dst(index, util::f32_to_bf8_e5m2_sr(value, seed));
+      seed = util::prng_advance(seed);
+    }
+    for (uint32_t word = 0; word < 2u; ++word)
+      wf.cu().write_vgpr(dst_base + word, lane, dst_words[word]);
+  }
 }
 
 VCvtScalePk8F16Fp4Vop3::VCvtScalePk8F16Fp4Vop3(const MachineInst *inst)
@@ -4839,7 +4941,7 @@ void VCvtScalef32Pk8Fp4F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
         dst_words[word + 1u] |= code >> (32u - shift);
     };
     for (uint32_t index = 0; index < 8u; ++index) {
-      float value = read_scaled_input(index) * scale;
+      float value = read_scaled_input(index) / scale;
       pack_scaled_dst(index, util::f32_to_fp4_e2m1_rne(value));
     }
     for (uint32_t word = 0; word < 1u; ++word)
@@ -4915,7 +5017,7 @@ void VCvtScalef32Pk8Fp4F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
         dst_words[word + 1u] |= code >> (32u - shift);
     };
     for (uint32_t index = 0; index < 8u; ++index) {
-      float value = read_scaled_input(index) * scale;
+      float value = read_scaled_input(index) / scale;
       pack_scaled_dst(index, util::f32_to_fp4_e2m1_rne(value));
     }
     for (uint32_t word = 0; word < 1u; ++word)
@@ -4991,7 +5093,7 @@ void VCvtScalef32Pk8Fp8Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
         dst_words[word + 1u] |= code >> (32u - shift);
     };
     for (uint32_t index = 0; index < 8u; ++index) {
-      float value = read_scaled_input(index) * scale;
+      float value = read_scaled_input(index) / scale;
       pack_scaled_dst(index, util::f32_to_fp8_e4m3_rne(value));
     }
     for (uint32_t word = 0; word < 2u; ++word)
@@ -5067,7 +5169,7 @@ void VCvtScalef32Pk8Bf8Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
         dst_words[word + 1u] |= code >> (32u - shift);
     };
     for (uint32_t index = 0; index < 8u; ++index) {
-      float value = read_scaled_input(index) * scale;
+      float value = read_scaled_input(index) / scale;
       pack_scaled_dst(index, util::f32_to_bf8_e5m2_rne(value));
     }
     for (uint32_t word = 0; word < 2u; ++word)
@@ -5143,7 +5245,7 @@ void VCvtScalef32Pk8Fp4Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
         dst_words[word + 1u] |= code >> (32u - shift);
     };
     for (uint32_t index = 0; index < 8u; ++index) {
-      float value = read_scaled_input(index) * scale;
+      float value = read_scaled_input(index) / scale;
       pack_scaled_dst(index, util::f32_to_fp4_e2m1_rne(value));
     }
     for (uint32_t word = 0; word < 1u; ++word)
@@ -5204,8 +5306,43 @@ VCvtScalef32SrPk8Fp4F16Vop3::VCvtScalef32SrPk8Fp4F16Vop3(const MachineInst *inst
 }
 
 void VCvtScalef32SrPk8Fp4F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t dst_base =
+        wf.vgpr_alloc().base +
+        *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
+    float scale = std::bit_cast<float>(src2.read_lane(wf, lane));
+    uint32_t seed = static_cast<uint32_t>(src1.read_lane(wf, lane));
+    uint32_t src_base =
+        wf.vgpr_alloc().base +
+        *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    uint32_t src_words[4] = {};
+    for (uint32_t word = 0; word < 4u; ++word)
+      src_words[word] = wf.cu().read_vgpr(src_base + word, lane);
+    auto read_scaled_input = [&](uint32_t index) -> float {
+      uint32_t raw = src_words[index / 2u];
+      return util::f16_to_f32(static_cast<uint16_t>(raw >> ((index & 1u) * 16u)));
+    };
+    uint32_t dst_words[1] = {};
+    auto pack_scaled_dst = [&](uint32_t index, uint32_t code) {
+      code &= 0xfu;
+      uint32_t bit = index * 4u;
+      uint32_t word = bit / 32u;
+      uint32_t shift = bit & 31u;
+      dst_words[word] |= code << shift;
+      if (shift + 4u > 32u)
+        dst_words[word + 1u] |= code >> (32u - shift);
+    };
+    for (uint32_t index = 0; index < 8u; ++index) {
+      float value = read_scaled_input(index) / scale;
+      pack_scaled_dst(index, util::f32_to_fp4_e2m1_sr(value, seed));
+      seed = util::prng_advance(seed);
+    }
+    for (uint32_t word = 0; word < 1u; ++word)
+      wf.cu().write_vgpr(dst_base + word, lane, dst_words[word]);
+  }
 }
 
 VCvtScalef32SrPk8Fp4Bf16Vop3::VCvtScalef32SrPk8Fp4Bf16Vop3(const MachineInst *inst)
@@ -5261,8 +5398,43 @@ VCvtScalef32SrPk8Fp4Bf16Vop3::VCvtScalef32SrPk8Fp4Bf16Vop3(const MachineInst *in
 }
 
 void VCvtScalef32SrPk8Fp4Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t dst_base =
+        wf.vgpr_alloc().base +
+        *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
+    float scale = std::bit_cast<float>(src2.read_lane(wf, lane));
+    uint32_t seed = static_cast<uint32_t>(src1.read_lane(wf, lane));
+    uint32_t src_base =
+        wf.vgpr_alloc().base +
+        *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    uint32_t src_words[4] = {};
+    for (uint32_t word = 0; word < 4u; ++word)
+      src_words[word] = wf.cu().read_vgpr(src_base + word, lane);
+    auto read_scaled_input = [&](uint32_t index) -> float {
+      uint32_t raw = src_words[index / 2u];
+      return util::bf16_to_f32(static_cast<uint16_t>(raw >> ((index & 1u) * 16u)));
+    };
+    uint32_t dst_words[1] = {};
+    auto pack_scaled_dst = [&](uint32_t index, uint32_t code) {
+      code &= 0xfu;
+      uint32_t bit = index * 4u;
+      uint32_t word = bit / 32u;
+      uint32_t shift = bit & 31u;
+      dst_words[word] |= code << shift;
+      if (shift + 4u > 32u)
+        dst_words[word + 1u] |= code >> (32u - shift);
+    };
+    for (uint32_t index = 0; index < 8u; ++index) {
+      float value = read_scaled_input(index) / scale;
+      pack_scaled_dst(index, util::f32_to_fp4_e2m1_sr(value, seed));
+      seed = util::prng_advance(seed);
+    }
+    for (uint32_t word = 0; word < 1u; ++word)
+      wf.cu().write_vgpr(dst_base + word, lane, dst_words[word]);
+  }
 }
 
 VCvtScalef32SrPk8Fp8F16Vop3::VCvtScalef32SrPk8Fp8F16Vop3(const MachineInst *inst)
@@ -5318,8 +5490,43 @@ VCvtScalef32SrPk8Fp8F16Vop3::VCvtScalef32SrPk8Fp8F16Vop3(const MachineInst *inst
 }
 
 void VCvtScalef32SrPk8Fp8F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t dst_base =
+        wf.vgpr_alloc().base +
+        *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
+    float scale = std::bit_cast<float>(src2.read_lane(wf, lane));
+    uint32_t seed = static_cast<uint32_t>(src1.read_lane(wf, lane));
+    uint32_t src_base =
+        wf.vgpr_alloc().base +
+        *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    uint32_t src_words[4] = {};
+    for (uint32_t word = 0; word < 4u; ++word)
+      src_words[word] = wf.cu().read_vgpr(src_base + word, lane);
+    auto read_scaled_input = [&](uint32_t index) -> float {
+      uint32_t raw = src_words[index / 2u];
+      return util::f16_to_f32(static_cast<uint16_t>(raw >> ((index & 1u) * 16u)));
+    };
+    uint32_t dst_words[2] = {};
+    auto pack_scaled_dst = [&](uint32_t index, uint32_t code) {
+      code &= 0xffu;
+      uint32_t bit = index * 8u;
+      uint32_t word = bit / 32u;
+      uint32_t shift = bit & 31u;
+      dst_words[word] |= code << shift;
+      if (shift + 8u > 32u)
+        dst_words[word + 1u] |= code >> (32u - shift);
+    };
+    for (uint32_t index = 0; index < 8u; ++index) {
+      float value = read_scaled_input(index) / scale;
+      pack_scaled_dst(index, util::f32_to_fp8_e4m3_sr(value, seed));
+      seed = util::prng_advance(seed);
+    }
+    for (uint32_t word = 0; word < 2u; ++word)
+      wf.cu().write_vgpr(dst_base + word, lane, dst_words[word]);
+  }
 }
 
 VCvtScalef32SrPk8Fp8Bf16Vop3::VCvtScalef32SrPk8Fp8Bf16Vop3(const MachineInst *inst)
@@ -5375,8 +5582,43 @@ VCvtScalef32SrPk8Fp8Bf16Vop3::VCvtScalef32SrPk8Fp8Bf16Vop3(const MachineInst *in
 }
 
 void VCvtScalef32SrPk8Fp8Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t dst_base =
+        wf.vgpr_alloc().base +
+        *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
+    float scale = std::bit_cast<float>(src2.read_lane(wf, lane));
+    uint32_t seed = static_cast<uint32_t>(src1.read_lane(wf, lane));
+    uint32_t src_base =
+        wf.vgpr_alloc().base +
+        *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    uint32_t src_words[4] = {};
+    for (uint32_t word = 0; word < 4u; ++word)
+      src_words[word] = wf.cu().read_vgpr(src_base + word, lane);
+    auto read_scaled_input = [&](uint32_t index) -> float {
+      uint32_t raw = src_words[index / 2u];
+      return util::bf16_to_f32(static_cast<uint16_t>(raw >> ((index & 1u) * 16u)));
+    };
+    uint32_t dst_words[2] = {};
+    auto pack_scaled_dst = [&](uint32_t index, uint32_t code) {
+      code &= 0xffu;
+      uint32_t bit = index * 8u;
+      uint32_t word = bit / 32u;
+      uint32_t shift = bit & 31u;
+      dst_words[word] |= code << shift;
+      if (shift + 8u > 32u)
+        dst_words[word + 1u] |= code >> (32u - shift);
+    };
+    for (uint32_t index = 0; index < 8u; ++index) {
+      float value = read_scaled_input(index) / scale;
+      pack_scaled_dst(index, util::f32_to_fp8_e4m3_sr(value, seed));
+      seed = util::prng_advance(seed);
+    }
+    for (uint32_t word = 0; word < 2u; ++word)
+      wf.cu().write_vgpr(dst_base + word, lane, dst_words[word]);
+  }
 }
 
 VCvtScalef32SrPk8Bf8F16Vop3::VCvtScalef32SrPk8Bf8F16Vop3(const MachineInst *inst)
@@ -5432,8 +5674,43 @@ VCvtScalef32SrPk8Bf8F16Vop3::VCvtScalef32SrPk8Bf8F16Vop3(const MachineInst *inst
 }
 
 void VCvtScalef32SrPk8Bf8F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t dst_base =
+        wf.vgpr_alloc().base +
+        *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
+    float scale = std::bit_cast<float>(src2.read_lane(wf, lane));
+    uint32_t seed = static_cast<uint32_t>(src1.read_lane(wf, lane));
+    uint32_t src_base =
+        wf.vgpr_alloc().base +
+        *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    uint32_t src_words[4] = {};
+    for (uint32_t word = 0; word < 4u; ++word)
+      src_words[word] = wf.cu().read_vgpr(src_base + word, lane);
+    auto read_scaled_input = [&](uint32_t index) -> float {
+      uint32_t raw = src_words[index / 2u];
+      return util::f16_to_f32(static_cast<uint16_t>(raw >> ((index & 1u) * 16u)));
+    };
+    uint32_t dst_words[2] = {};
+    auto pack_scaled_dst = [&](uint32_t index, uint32_t code) {
+      code &= 0xffu;
+      uint32_t bit = index * 8u;
+      uint32_t word = bit / 32u;
+      uint32_t shift = bit & 31u;
+      dst_words[word] |= code << shift;
+      if (shift + 8u > 32u)
+        dst_words[word + 1u] |= code >> (32u - shift);
+    };
+    for (uint32_t index = 0; index < 8u; ++index) {
+      float value = read_scaled_input(index) / scale;
+      pack_scaled_dst(index, util::f32_to_bf8_e5m2_sr(value, seed));
+      seed = util::prng_advance(seed);
+    }
+    for (uint32_t word = 0; word < 2u; ++word)
+      wf.cu().write_vgpr(dst_base + word, lane, dst_words[word]);
+  }
 }
 
 VCvtScalef32SrPk8Bf8Bf16Vop3::VCvtScalef32SrPk8Bf8Bf16Vop3(const MachineInst *inst)
@@ -5489,8 +5766,43 @@ VCvtScalef32SrPk8Bf8Bf16Vop3::VCvtScalef32SrPk8Bf8Bf16Vop3(const MachineInst *in
 }
 
 void VCvtScalef32SrPk8Bf8Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t dst_base =
+        wf.vgpr_alloc().base +
+        *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
+    float scale = std::bit_cast<float>(src2.read_lane(wf, lane));
+    uint32_t seed = static_cast<uint32_t>(src1.read_lane(wf, lane));
+    uint32_t src_base =
+        wf.vgpr_alloc().base +
+        *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    uint32_t src_words[4] = {};
+    for (uint32_t word = 0; word < 4u; ++word)
+      src_words[word] = wf.cu().read_vgpr(src_base + word, lane);
+    auto read_scaled_input = [&](uint32_t index) -> float {
+      uint32_t raw = src_words[index / 2u];
+      return util::bf16_to_f32(static_cast<uint16_t>(raw >> ((index & 1u) * 16u)));
+    };
+    uint32_t dst_words[2] = {};
+    auto pack_scaled_dst = [&](uint32_t index, uint32_t code) {
+      code &= 0xffu;
+      uint32_t bit = index * 8u;
+      uint32_t word = bit / 32u;
+      uint32_t shift = bit & 31u;
+      dst_words[word] |= code << shift;
+      if (shift + 8u > 32u)
+        dst_words[word + 1u] |= code >> (32u - shift);
+    };
+    for (uint32_t index = 0; index < 8u; ++index) {
+      float value = read_scaled_input(index) / scale;
+      pack_scaled_dst(index, util::f32_to_bf8_e5m2_sr(value, seed));
+      seed = util::prng_advance(seed);
+    }
+    for (uint32_t word = 0; word < 2u; ++word)
+      wf.cu().write_vgpr(dst_base + word, lane, dst_words[word]);
+  }
 }
 
 VCvtScalef32Pk8Fp8F32Vop3::VCvtScalef32Pk8Fp8F32Vop3(const MachineInst *inst)
@@ -5560,7 +5872,7 @@ void VCvtScalef32Pk8Fp8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
         dst_words[word + 1u] |= code >> (32u - shift);
     };
     for (uint32_t index = 0; index < 8u; ++index) {
-      float value = read_scaled_input(index) * scale;
+      float value = read_scaled_input(index) / scale;
       pack_scaled_dst(index, util::f32_to_fp8_e4m3_rne(value));
     }
     for (uint32_t word = 0; word < 2u; ++word)
@@ -5636,7 +5948,7 @@ void VCvtScalef32Pk8Fp8F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
         dst_words[word + 1u] |= code >> (32u - shift);
     };
     for (uint32_t index = 0; index < 8u; ++index) {
-      float value = read_scaled_input(index) * scale;
+      float value = read_scaled_input(index) / scale;
       pack_scaled_dst(index, util::f32_to_fp8_e4m3_rne(value));
     }
     for (uint32_t word = 0; word < 2u; ++word)
@@ -5711,7 +6023,7 @@ void VCvtScalef32Pk8Bf8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
         dst_words[word + 1u] |= code >> (32u - shift);
     };
     for (uint32_t index = 0; index < 8u; ++index) {
-      float value = read_scaled_input(index) * scale;
+      float value = read_scaled_input(index) / scale;
       pack_scaled_dst(index, util::f32_to_bf8_e5m2_rne(value));
     }
     for (uint32_t word = 0; word < 2u; ++word)
@@ -5787,7 +6099,7 @@ void VCvtScalef32Pk8Bf8F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
         dst_words[word + 1u] |= code >> (32u - shift);
     };
     for (uint32_t index = 0; index < 8u; ++index) {
-      float value = read_scaled_input(index) * scale;
+      float value = read_scaled_input(index) / scale;
       pack_scaled_dst(index, util::f32_to_bf8_e5m2_rne(value));
     }
     for (uint32_t word = 0; word < 2u; ++word)
@@ -6294,7 +6606,7 @@ void VCvtScalef32Pk16Fp6F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
         dst_words[word + 1u] |= code >> (32u - shift);
     };
     for (uint32_t index = 0; index < 16u; ++index) {
-      float value = read_scaled_input(index) * scale;
+      float value = read_scaled_input(index) / scale;
       pack_scaled_dst(index, util::f32_to_fp6_e2m3_rne(value));
     }
     for (uint32_t word = 0; word < 3u; ++word)
@@ -6369,7 +6681,7 @@ void VCvtScalef32Pk16Bf6F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
         dst_words[word + 1u] |= code >> (32u - shift);
     };
     for (uint32_t index = 0; index < 16u; ++index) {
-      float value = read_scaled_input(index) * scale;
+      float value = read_scaled_input(index) / scale;
       pack_scaled_dst(index, util::f32_to_bf6_e3m2_rne(value));
     }
     for (uint32_t word = 0; word < 3u; ++word)
@@ -6445,7 +6757,7 @@ void VCvtScalef32Pk16Fp6F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
         dst_words[word + 1u] |= code >> (32u - shift);
     };
     for (uint32_t index = 0; index < 16u; ++index) {
-      float value = read_scaled_input(index) * scale;
+      float value = read_scaled_input(index) / scale;
       pack_scaled_dst(index, util::f32_to_fp6_e2m3_rne(value));
     }
     for (uint32_t word = 0; word < 3u; ++word)
@@ -6521,7 +6833,7 @@ void VCvtScalef32Pk16Bf6F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
         dst_words[word + 1u] |= code >> (32u - shift);
     };
     for (uint32_t index = 0; index < 16u; ++index) {
-      float value = read_scaled_input(index) * scale;
+      float value = read_scaled_input(index) / scale;
       pack_scaled_dst(index, util::f32_to_bf6_e3m2_rne(value));
     }
     for (uint32_t word = 0; word < 3u; ++word)
@@ -6597,7 +6909,7 @@ void VCvtScalef32Pk16Fp6Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
         dst_words[word + 1u] |= code >> (32u - shift);
     };
     for (uint32_t index = 0; index < 16u; ++index) {
-      float value = read_scaled_input(index) * scale;
+      float value = read_scaled_input(index) / scale;
       pack_scaled_dst(index, util::f32_to_fp6_e2m3_rne(value));
     }
     for (uint32_t word = 0; word < 3u; ++word)
@@ -6673,7 +6985,7 @@ void VCvtScalef32Pk16Bf6Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
         dst_words[word + 1u] |= code >> (32u - shift);
     };
     for (uint32_t index = 0; index < 16u; ++index) {
-      float value = read_scaled_input(index) * scale;
+      float value = read_scaled_input(index) / scale;
       pack_scaled_dst(index, util::f32_to_bf6_e3m2_rne(value));
     }
     for (uint32_t word = 0; word < 3u; ++word)
@@ -6734,8 +7046,42 @@ VCvtScalef32SrPk16Fp6F32Vop3::VCvtScalef32SrPk16Fp6F32Vop3(const MachineInst *in
 }
 
 void VCvtScalef32SrPk16Fp6F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t dst_base =
+        wf.vgpr_alloc().base +
+        *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
+    float scale = std::bit_cast<float>(src2.read_lane(wf, lane));
+    uint32_t seed = static_cast<uint32_t>(src1.read_lane(wf, lane));
+    uint32_t src_base =
+        wf.vgpr_alloc().base +
+        *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    uint32_t src_words[16] = {};
+    for (uint32_t word = 0; word < 16u; ++word)
+      src_words[word] = wf.cu().read_vgpr(src_base + word, lane);
+    auto read_scaled_input = [&](uint32_t index) -> float {
+      return std::bit_cast<float>(src_words[index]);
+    };
+    uint32_t dst_words[3] = {};
+    auto pack_scaled_dst = [&](uint32_t index, uint32_t code) {
+      code &= 0x3fu;
+      uint32_t bit = index * 6u;
+      uint32_t word = bit / 32u;
+      uint32_t shift = bit & 31u;
+      dst_words[word] |= code << shift;
+      if (shift + 6u > 32u)
+        dst_words[word + 1u] |= code >> (32u - shift);
+    };
+    for (uint32_t index = 0; index < 16u; ++index) {
+      float value = read_scaled_input(index) / scale;
+      pack_scaled_dst(index, util::f32_to_fp6_e2m3_sr(value, seed));
+      seed = util::prng_advance(seed);
+    }
+    for (uint32_t word = 0; word < 3u; ++word)
+      wf.cu().write_vgpr(dst_base + word, lane, dst_words[word]);
+  }
 }
 
 VCvtScalef32SrPk16Bf6F32Vop3::VCvtScalef32SrPk16Bf6F32Vop3(const MachineInst *inst)
@@ -6791,8 +7137,42 @@ VCvtScalef32SrPk16Bf6F32Vop3::VCvtScalef32SrPk16Bf6F32Vop3(const MachineInst *in
 }
 
 void VCvtScalef32SrPk16Bf6F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t dst_base =
+        wf.vgpr_alloc().base +
+        *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
+    float scale = std::bit_cast<float>(src2.read_lane(wf, lane));
+    uint32_t seed = static_cast<uint32_t>(src1.read_lane(wf, lane));
+    uint32_t src_base =
+        wf.vgpr_alloc().base +
+        *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    uint32_t src_words[16] = {};
+    for (uint32_t word = 0; word < 16u; ++word)
+      src_words[word] = wf.cu().read_vgpr(src_base + word, lane);
+    auto read_scaled_input = [&](uint32_t index) -> float {
+      return std::bit_cast<float>(src_words[index]);
+    };
+    uint32_t dst_words[3] = {};
+    auto pack_scaled_dst = [&](uint32_t index, uint32_t code) {
+      code &= 0x3fu;
+      uint32_t bit = index * 6u;
+      uint32_t word = bit / 32u;
+      uint32_t shift = bit & 31u;
+      dst_words[word] |= code << shift;
+      if (shift + 6u > 32u)
+        dst_words[word + 1u] |= code >> (32u - shift);
+    };
+    for (uint32_t index = 0; index < 16u; ++index) {
+      float value = read_scaled_input(index) / scale;
+      pack_scaled_dst(index, util::f32_to_bf6_e3m2_sr(value, seed));
+      seed = util::prng_advance(seed);
+    }
+    for (uint32_t word = 0; word < 3u; ++word)
+      wf.cu().write_vgpr(dst_base + word, lane, dst_words[word]);
+  }
 }
 
 VCvtScalef32SrPk16Fp6F16Vop3::VCvtScalef32SrPk16Fp6F16Vop3(const MachineInst *inst)
@@ -6848,8 +7228,43 @@ VCvtScalef32SrPk16Fp6F16Vop3::VCvtScalef32SrPk16Fp6F16Vop3(const MachineInst *in
 }
 
 void VCvtScalef32SrPk16Fp6F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t dst_base =
+        wf.vgpr_alloc().base +
+        *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
+    float scale = std::bit_cast<float>(src2.read_lane(wf, lane));
+    uint32_t seed = static_cast<uint32_t>(src1.read_lane(wf, lane));
+    uint32_t src_base =
+        wf.vgpr_alloc().base +
+        *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    uint32_t src_words[8] = {};
+    for (uint32_t word = 0; word < 8u; ++word)
+      src_words[word] = wf.cu().read_vgpr(src_base + word, lane);
+    auto read_scaled_input = [&](uint32_t index) -> float {
+      uint32_t raw = src_words[index / 2u];
+      return util::f16_to_f32(static_cast<uint16_t>(raw >> ((index & 1u) * 16u)));
+    };
+    uint32_t dst_words[3] = {};
+    auto pack_scaled_dst = [&](uint32_t index, uint32_t code) {
+      code &= 0x3fu;
+      uint32_t bit = index * 6u;
+      uint32_t word = bit / 32u;
+      uint32_t shift = bit & 31u;
+      dst_words[word] |= code << shift;
+      if (shift + 6u > 32u)
+        dst_words[word + 1u] |= code >> (32u - shift);
+    };
+    for (uint32_t index = 0; index < 16u; ++index) {
+      float value = read_scaled_input(index) / scale;
+      pack_scaled_dst(index, util::f32_to_fp6_e2m3_sr(value, seed));
+      seed = util::prng_advance(seed);
+    }
+    for (uint32_t word = 0; word < 3u; ++word)
+      wf.cu().write_vgpr(dst_base + word, lane, dst_words[word]);
+  }
 }
 
 VCvtScalef32SrPk16Bf6F16Vop3::VCvtScalef32SrPk16Bf6F16Vop3(const MachineInst *inst)
@@ -6905,8 +7320,43 @@ VCvtScalef32SrPk16Bf6F16Vop3::VCvtScalef32SrPk16Bf6F16Vop3(const MachineInst *in
 }
 
 void VCvtScalef32SrPk16Bf6F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t dst_base =
+        wf.vgpr_alloc().base +
+        *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
+    float scale = std::bit_cast<float>(src2.read_lane(wf, lane));
+    uint32_t seed = static_cast<uint32_t>(src1.read_lane(wf, lane));
+    uint32_t src_base =
+        wf.vgpr_alloc().base +
+        *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    uint32_t src_words[8] = {};
+    for (uint32_t word = 0; word < 8u; ++word)
+      src_words[word] = wf.cu().read_vgpr(src_base + word, lane);
+    auto read_scaled_input = [&](uint32_t index) -> float {
+      uint32_t raw = src_words[index / 2u];
+      return util::f16_to_f32(static_cast<uint16_t>(raw >> ((index & 1u) * 16u)));
+    };
+    uint32_t dst_words[3] = {};
+    auto pack_scaled_dst = [&](uint32_t index, uint32_t code) {
+      code &= 0x3fu;
+      uint32_t bit = index * 6u;
+      uint32_t word = bit / 32u;
+      uint32_t shift = bit & 31u;
+      dst_words[word] |= code << shift;
+      if (shift + 6u > 32u)
+        dst_words[word + 1u] |= code >> (32u - shift);
+    };
+    for (uint32_t index = 0; index < 16u; ++index) {
+      float value = read_scaled_input(index) / scale;
+      pack_scaled_dst(index, util::f32_to_bf6_e3m2_sr(value, seed));
+      seed = util::prng_advance(seed);
+    }
+    for (uint32_t word = 0; word < 3u; ++word)
+      wf.cu().write_vgpr(dst_base + word, lane, dst_words[word]);
+  }
 }
 
 VCvtScalef32SrPk16Fp6Bf16Vop3::VCvtScalef32SrPk16Fp6Bf16Vop3(const MachineInst *inst)
@@ -6962,8 +7412,43 @@ VCvtScalef32SrPk16Fp6Bf16Vop3::VCvtScalef32SrPk16Fp6Bf16Vop3(const MachineInst *
 }
 
 void VCvtScalef32SrPk16Fp6Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t dst_base =
+        wf.vgpr_alloc().base +
+        *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
+    float scale = std::bit_cast<float>(src2.read_lane(wf, lane));
+    uint32_t seed = static_cast<uint32_t>(src1.read_lane(wf, lane));
+    uint32_t src_base =
+        wf.vgpr_alloc().base +
+        *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    uint32_t src_words[8] = {};
+    for (uint32_t word = 0; word < 8u; ++word)
+      src_words[word] = wf.cu().read_vgpr(src_base + word, lane);
+    auto read_scaled_input = [&](uint32_t index) -> float {
+      uint32_t raw = src_words[index / 2u];
+      return util::bf16_to_f32(static_cast<uint16_t>(raw >> ((index & 1u) * 16u)));
+    };
+    uint32_t dst_words[3] = {};
+    auto pack_scaled_dst = [&](uint32_t index, uint32_t code) {
+      code &= 0x3fu;
+      uint32_t bit = index * 6u;
+      uint32_t word = bit / 32u;
+      uint32_t shift = bit & 31u;
+      dst_words[word] |= code << shift;
+      if (shift + 6u > 32u)
+        dst_words[word + 1u] |= code >> (32u - shift);
+    };
+    for (uint32_t index = 0; index < 16u; ++index) {
+      float value = read_scaled_input(index) / scale;
+      pack_scaled_dst(index, util::f32_to_fp6_e2m3_sr(value, seed));
+      seed = util::prng_advance(seed);
+    }
+    for (uint32_t word = 0; word < 3u; ++word)
+      wf.cu().write_vgpr(dst_base + word, lane, dst_words[word]);
+  }
 }
 
 VCvtScalef32SrPk16Bf6Bf16Vop3::VCvtScalef32SrPk16Bf6Bf16Vop3(const MachineInst *inst)
@@ -7019,8 +7504,43 @@ VCvtScalef32SrPk16Bf6Bf16Vop3::VCvtScalef32SrPk16Bf6Bf16Vop3(const MachineInst *
 }
 
 void VCvtScalef32SrPk16Bf6Bf16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t dst_base =
+        wf.vgpr_alloc().base +
+        *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
+    float scale = std::bit_cast<float>(src2.read_lane(wf, lane));
+    uint32_t seed = static_cast<uint32_t>(src1.read_lane(wf, lane));
+    uint32_t src_base =
+        wf.vgpr_alloc().base +
+        *Isa::resolved_vgpr_offset(wf, src0.opr_type_, src0.encoding_value_, src0.vgpr_msb_role());
+    uint32_t src_words[8] = {};
+    for (uint32_t word = 0; word < 8u; ++word)
+      src_words[word] = wf.cu().read_vgpr(src_base + word, lane);
+    auto read_scaled_input = [&](uint32_t index) -> float {
+      uint32_t raw = src_words[index / 2u];
+      return util::bf16_to_f32(static_cast<uint16_t>(raw >> ((index & 1u) * 16u)));
+    };
+    uint32_t dst_words[3] = {};
+    auto pack_scaled_dst = [&](uint32_t index, uint32_t code) {
+      code &= 0x3fu;
+      uint32_t bit = index * 6u;
+      uint32_t word = bit / 32u;
+      uint32_t shift = bit & 31u;
+      dst_words[word] |= code << shift;
+      if (shift + 6u > 32u)
+        dst_words[word + 1u] |= code >> (32u - shift);
+    };
+    for (uint32_t index = 0; index < 16u; ++index) {
+      float value = read_scaled_input(index) / scale;
+      pack_scaled_dst(index, util::f32_to_bf6_e3m2_sr(value, seed));
+      seed = util::prng_advance(seed);
+    }
+    for (uint32_t word = 0; word < 3u; ++word)
+      wf.cu().write_vgpr(dst_base + word, lane, dst_words[word]);
+  }
 }
 
 VMadNcU64U32Vop3::VMadNcU64U32Vop3(const MachineInst *inst)
@@ -7086,517 +7606,6 @@ void VMadNcU64U32Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t result = s0 * s1 + s2;
     vdst.write_lane64(wf, lane, result);
   }
-}
-
-VMadNcI64I32Vop3::VMadNcI64I32Vop3(const MachineInst *inst)
-    : Vop3("v_mad_nc_i64_i32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMadNcI64I32Vop3>()),
-      vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
-      src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
-      src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
-      src2(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src2) {
-  dst_operands_[0] = &vdst;
-  src_operands_[0] = &src0;
-  src_operands_[1] = &src1;
-  src_operands_[2] = &src2;
-  num_src_ = 3;
-  num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
-    src0 = Operand(
-        32, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src0 = Operand(32, OperandType::OPR_SIMM64, literal64, true);
-  }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
-    src1 = Operand(
-        32, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src1 = Operand(32, OperandType::OPR_SIMM64, literal64, true);
-  }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src2 == 255)
-    src2 = Operand(
-        64, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src2 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src2 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
-  }
-  vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
-  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
-  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
-  src2.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src2);
-}
-
-void VMadNcI64I32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    int64_t s0 = static_cast<int32_t>(src0.read_lane(wf, lane));
-    int64_t s1 = static_cast<int32_t>(src1.read_lane(wf, lane));
-    int64_t s2 = static_cast<int64_t>(src2.read_lane64(wf, lane));
-    uint64_t result = static_cast<uint64_t>(s0 * s1 + s2);
-    vdst.write_lane64(wf, lane, result);
-  }
-}
-
-VAddNcU16Vop3::VAddNcU16Vop3(const MachineInst *inst)
-    : Vop3("v_add_nc_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAddNcU16Vop3>()),
-      vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
-      src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
-      src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
-  dst_operands_[0] = &vdst;
-  src_operands_[0] = &src0;
-  src_operands_[1] = &src1;
-  num_src_ = 2;
-  num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
-    src0 = Operand(
-        16, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src0 = Operand(16, OperandType::OPR_SIMM64, literal64, true);
-  }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
-    src1 = Operand(
-        16, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src1 = Operand(16, OperandType::OPR_SIMM64, literal64, true);
-  }
-  vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
-  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
-  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
-}
-
-void VAddNcU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_add_nc_u16_vop3(*this, wf);
-}
-
-VSubNcU16Vop3::VSubNcU16Vop3(const MachineInst *inst)
-    : Vop3("v_sub_nc_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubNcU16Vop3>()),
-      vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
-      src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
-      src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
-  dst_operands_[0] = &vdst;
-  src_operands_[0] = &src0;
-  src_operands_[1] = &src1;
-  num_src_ = 2;
-  num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
-    src0 = Operand(
-        16, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src0 = Operand(16, OperandType::OPR_SIMM64, literal64, true);
-  }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
-    src1 = Operand(
-        16, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src1 = Operand(16, OperandType::OPR_SIMM64, literal64, true);
-  }
-  vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
-  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
-  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
-}
-
-void VSubNcU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_sub_nc_u16_vop3(*this, wf);
-}
-
-VMulLoU16Vop3::VMulLoU16Vop3(const MachineInst *inst)
-    : Vop3("v_mul_lo_u16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VMulLoU16Vop3>()),
-      vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
-      src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
-      src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
-  dst_operands_[0] = &vdst;
-  src_operands_[0] = &src0;
-  src_operands_[1] = &src1;
-  num_src_ = 2;
-  num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
-    src0 = Operand(
-        16, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src0 = Operand(16, OperandType::OPR_SIMM64, literal64, true);
-  }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
-    src1 = Operand(
-        16, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src1 = Operand(16, OperandType::OPR_SIMM64, literal64, true);
-  }
-  vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
-  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
-  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
-}
-
-void VMulLoU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_mul_lo_u16_vop3(*this, wf);
-}
-
-VCvtPkI16F32Vop3::VCvtPkI16F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_i16_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkI16F32Vop3>()),
-      vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
-      src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
-      src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
-  dst_operands_[0] = &vdst;
-  src_operands_[0] = &src0;
-  src_operands_[1] = &src1;
-  num_src_ = 2;
-  num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
-    src0 = Operand(
-        32, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src0 = Operand(32, OperandType::OPR_SIMM64, literal64, true);
-  }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
-    src1 = Operand(
-        32, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src1 = Operand(32, OperandType::OPR_SIMM64, literal64, true);
-  }
-  vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
-  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
-  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
-}
-
-void VCvtPkI16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cvt_pk_i16_f32_vop3(*this, wf);
-}
-
-VCvtPkU16F32Vop3::VCvtPkU16F32Vop3(const MachineInst *inst)
-    : Vop3("v_cvt_pk_u16_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCvtPkU16F32Vop3>()),
-      vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
-      src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
-      src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
-  dst_operands_[0] = &vdst;
-  src_operands_[0] = &src0;
-  src_operands_[1] = &src1;
-  num_src_ = 2;
-  num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
-    src0 = Operand(
-        32, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src0 = Operand(32, OperandType::OPR_SIMM64, literal64, true);
-  }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
-    src1 = Operand(
-        32, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src1 = Operand(32, OperandType::OPR_SIMM64, literal64, true);
-  }
-  vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
-  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
-  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
-}
-
-void VCvtPkU16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cvt_pk_u16_f32_vop3(*this, wf);
-}
-
-VMaxU16Vop3::VMaxU16Vop3(const MachineInst *inst)
-    : Vop3("v_max_u16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxU16Vop3>()),
-      vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
-      src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
-      src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
-  dst_operands_[0] = &vdst;
-  src_operands_[0] = &src0;
-  src_operands_[1] = &src1;
-  num_src_ = 2;
-  num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
-    src0 = Operand(
-        16, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src0 = Operand(16, OperandType::OPR_SIMM64, literal64, true);
-  }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
-    src1 = Operand(
-        16, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src1 = Operand(16, OperandType::OPR_SIMM64, literal64, true);
-  }
-  vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
-  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
-  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
-}
-
-void VMaxU16Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_max_u16_vop3(*this, wf); }
-
-VMaxI16Vop3::VMaxI16Vop3(const MachineInst *inst)
-    : Vop3("v_max_i16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxI16Vop3>()),
-      vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
-      src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
-      src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
-  dst_operands_[0] = &vdst;
-  src_operands_[0] = &src0;
-  src_operands_[1] = &src1;
-  num_src_ = 2;
-  num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
-    src0 = Operand(
-        16, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src0 = Operand(16, OperandType::OPR_SIMM64, literal64, true);
-  }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
-    src1 = Operand(
-        16, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src1 = Operand(16, OperandType::OPR_SIMM64, literal64, true);
-  }
-  vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
-  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
-  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
-}
-
-void VMaxI16Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_max_i16_vop3(*this, wf); }
-
-VMinU16Vop3::VMinU16Vop3(const MachineInst *inst)
-    : Vop3("v_min_u16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinU16Vop3>()),
-      vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
-      src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
-      src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
-  dst_operands_[0] = &vdst;
-  src_operands_[0] = &src0;
-  src_operands_[1] = &src1;
-  num_src_ = 2;
-  num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
-    src0 = Operand(
-        16, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src0 = Operand(16, OperandType::OPR_SIMM64, literal64, true);
-  }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
-    src1 = Operand(
-        16, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src1 = Operand(16, OperandType::OPR_SIMM64, literal64, true);
-  }
-  vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
-  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
-  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
-}
-
-void VMinU16Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_min_u16_vop3(*this, wf); }
-
-VMinI16Vop3::VMinI16Vop3(const MachineInst *inst)
-    : Vop3("v_min_i16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinI16Vop3>()),
-      vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
-      src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
-      src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
-  dst_operands_[0] = &vdst;
-  src_operands_[0] = &src0;
-  src_operands_[1] = &src1;
-  num_src_ = 2;
-  num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
-    src0 = Operand(
-        16, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src0 = Operand(16, OperandType::OPR_SIMM64, literal64, true);
-  }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
-    src1 = Operand(
-        16, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src1 = Operand(16, OperandType::OPR_SIMM64, literal64, true);
-  }
-  vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
-  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
-  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
-}
-
-void VMinI16Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_min_i16_vop3(*this, wf); }
-
-VAddNcI16Vop3::VAddNcI16Vop3(const MachineInst *inst)
-    : Vop3("v_add_nc_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VAddNcI16Vop3>()),
-      vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
-      src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
-      src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
-  dst_operands_[0] = &vdst;
-  src_operands_[0] = &src0;
-  src_operands_[1] = &src1;
-  num_src_ = 2;
-  num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
-    src0 = Operand(
-        16, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src0 = Operand(16, OperandType::OPR_SIMM64, literal64, true);
-  }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
-    src1 = Operand(
-        16, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src1 = Operand(16, OperandType::OPR_SIMM64, literal64, true);
-  }
-  vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
-  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
-  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
-}
-
-void VAddNcI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_add_nc_i16_vop3(*this, wf);
-}
-
-VSubNcI16Vop3::VSubNcI16Vop3(const MachineInst *inst)
-    : Vop3("v_sub_nc_i16", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VSubNcI16Vop3>()),
-      vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
-      src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
-      src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
-  dst_operands_[0] = &vdst;
-  src_operands_[0] = &src0;
-  src_operands_[1] = &src1;
-  num_src_ = 2;
-  num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
-    src0 = Operand(
-        16, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src0 = Operand(16, OperandType::OPR_SIMM64, literal64, true);
-  }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
-    src1 = Operand(
-        16, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src1 = Operand(16, OperandType::OPR_SIMM64, literal64, true);
-  }
-  vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
-  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
-  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
 } // namespace gfx1250

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_part3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_part3.cpp
@@ -19,6 +19,539 @@
 namespace rocjitsu {
 namespace gfx1250 {
 
+VMadNcI64I32Vop3::VMadNcI64I32Vop3(const MachineInst *inst)
+    : Vop3("v_mad_nc_i64_i32", reinterpret_cast<const OpEncoding *>(inst),
+           make_exec_fn<VMadNcI64I32Vop3>()),
+      vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
+      src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
+      src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1),
+      src2(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src2) {
+  dst_operands_[0] = &vdst;
+  src_operands_[0] = &src0;
+  src_operands_[1] = &src1;
+  src_operands_[2] = &src2;
+  num_src_ = 3;
+  num_dst_ = 1;
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
+    src0 = Operand(
+        32, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src0 = Operand(32, OperandType::OPR_SIMM64, literal64, true);
+  }
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
+    src1 = Operand(
+        32, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src1 = Operand(32, OperandType::OPR_SIMM64, literal64, true);
+  }
+  if (reinterpret_cast<const OpEncoding *>(inst)->src2 == 255)
+    src2 = Operand(
+        64, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src2 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src2 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
+  }
+  vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
+  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
+  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
+  src2.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src2);
+}
+
+void VMadNcI64I32Vop3::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    int64_t s0 = static_cast<int32_t>(src0.read_lane(wf, lane));
+    int64_t s1 = static_cast<int32_t>(src1.read_lane(wf, lane));
+    int64_t s2 = static_cast<int64_t>(src2.read_lane64(wf, lane));
+    uint64_t result = static_cast<uint64_t>(s0 * s1 + s2);
+    vdst.write_lane64(wf, lane, result);
+  }
+}
+
+VAddNcU16Vop3::VAddNcU16Vop3(const MachineInst *inst)
+    : Vop3("v_add_nc_u16", reinterpret_cast<const OpEncoding *>(inst),
+           make_exec_fn<VAddNcU16Vop3>()),
+      vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
+      src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
+      src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
+  dst_operands_[0] = &vdst;
+  src_operands_[0] = &src0;
+  src_operands_[1] = &src1;
+  num_src_ = 2;
+  num_dst_ = 1;
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
+    src0 = Operand(
+        16, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src0 = Operand(16, OperandType::OPR_SIMM64, literal64, true);
+  }
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
+    src1 = Operand(
+        16, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src1 = Operand(16, OperandType::OPR_SIMM64, literal64, true);
+  }
+  vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
+  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
+  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
+}
+
+void VAddNcU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
+  amdgpu::execute_v_add_nc_u16_vop3(*this, wf);
+}
+
+VSubNcU16Vop3::VSubNcU16Vop3(const MachineInst *inst)
+    : Vop3("v_sub_nc_u16", reinterpret_cast<const OpEncoding *>(inst),
+           make_exec_fn<VSubNcU16Vop3>()),
+      vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
+      src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
+      src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
+  dst_operands_[0] = &vdst;
+  src_operands_[0] = &src0;
+  src_operands_[1] = &src1;
+  num_src_ = 2;
+  num_dst_ = 1;
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
+    src0 = Operand(
+        16, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src0 = Operand(16, OperandType::OPR_SIMM64, literal64, true);
+  }
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
+    src1 = Operand(
+        16, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src1 = Operand(16, OperandType::OPR_SIMM64, literal64, true);
+  }
+  vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
+  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
+  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
+}
+
+void VSubNcU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
+  amdgpu::execute_v_sub_nc_u16_vop3(*this, wf);
+}
+
+VMulLoU16Vop3::VMulLoU16Vop3(const MachineInst *inst)
+    : Vop3("v_mul_lo_u16", reinterpret_cast<const OpEncoding *>(inst),
+           make_exec_fn<VMulLoU16Vop3>()),
+      vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
+      src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
+      src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
+  dst_operands_[0] = &vdst;
+  src_operands_[0] = &src0;
+  src_operands_[1] = &src1;
+  num_src_ = 2;
+  num_dst_ = 1;
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
+    src0 = Operand(
+        16, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src0 = Operand(16, OperandType::OPR_SIMM64, literal64, true);
+  }
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
+    src1 = Operand(
+        16, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src1 = Operand(16, OperandType::OPR_SIMM64, literal64, true);
+  }
+  vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
+  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
+  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
+}
+
+void VMulLoU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
+  amdgpu::execute_v_mul_lo_u16_vop3(*this, wf);
+}
+
+VCvtPkI16F32Vop3::VCvtPkI16F32Vop3(const MachineInst *inst)
+    : Vop3("v_cvt_pk_i16_f32", reinterpret_cast<const OpEncoding *>(inst),
+           make_exec_fn<VCvtPkI16F32Vop3>()),
+      vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
+      src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
+      src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
+  dst_operands_[0] = &vdst;
+  src_operands_[0] = &src0;
+  src_operands_[1] = &src1;
+  num_src_ = 2;
+  num_dst_ = 1;
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
+    src0 = Operand(
+        32, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src0 = Operand(32, OperandType::OPR_SIMM64, literal64, true);
+  }
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
+    src1 = Operand(
+        32, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src1 = Operand(32, OperandType::OPR_SIMM64, literal64, true);
+  }
+  vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
+  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
+  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
+}
+
+void VCvtPkI16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t s0 = src0.read_lane(wf, lane);
+    uint32_t s1 = src1.read_lane(wf, lane);
+    int16_t lo = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s0), -32768, 32767));
+    int16_t hi = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s1), -32768, 32767));
+    vdst.write_lane(wf, lane,
+                    (static_cast<uint32_t>(static_cast<uint16_t>(hi)) << 16) |
+                        static_cast<uint32_t>(static_cast<uint16_t>(lo)));
+  }
+}
+
+VCvtPkU16F32Vop3::VCvtPkU16F32Vop3(const MachineInst *inst)
+    : Vop3("v_cvt_pk_u16_f32", reinterpret_cast<const OpEncoding *>(inst),
+           make_exec_fn<VCvtPkU16F32Vop3>()),
+      vdst(32, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
+      src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
+      src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
+  dst_operands_[0] = &vdst;
+  src_operands_[0] = &src0;
+  src_operands_[1] = &src1;
+  num_src_ = 2;
+  num_dst_ = 1;
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
+    src0 = Operand(
+        32, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src0 = Operand(32, OperandType::OPR_SIMM64, literal64, true);
+  }
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
+    src1 = Operand(
+        32, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src1 = Operand(32, OperandType::OPR_SIMM64, literal64, true);
+  }
+  vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
+  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
+  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
+}
+
+void VCvtPkU16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t s0 = src0.read_lane(wf, lane);
+    uint32_t s1 = src1.read_lane(wf, lane);
+    int16_t lo = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s0), -32768, 32767));
+    int16_t hi = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s1), -32768, 32767));
+    vdst.write_lane(wf, lane,
+                    (static_cast<uint32_t>(static_cast<uint16_t>(hi)) << 16) |
+                        static_cast<uint32_t>(static_cast<uint16_t>(lo)));
+  }
+}
+
+VMaxU16Vop3::VMaxU16Vop3(const MachineInst *inst)
+    : Vop3("v_max_u16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxU16Vop3>()),
+      vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
+      src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
+      src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
+  dst_operands_[0] = &vdst;
+  src_operands_[0] = &src0;
+  src_operands_[1] = &src1;
+  num_src_ = 2;
+  num_dst_ = 1;
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
+    src0 = Operand(
+        16, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src0 = Operand(16, OperandType::OPR_SIMM64, literal64, true);
+  }
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
+    src1 = Operand(
+        16, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src1 = Operand(16, OperandType::OPR_SIMM64, literal64, true);
+  }
+  vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
+  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
+  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
+}
+
+void VMaxU16Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_max_u16_vop3(*this, wf); }
+
+VMaxI16Vop3::VMaxI16Vop3(const MachineInst *inst)
+    : Vop3("v_max_i16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxI16Vop3>()),
+      vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
+      src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
+      src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
+  dst_operands_[0] = &vdst;
+  src_operands_[0] = &src0;
+  src_operands_[1] = &src1;
+  num_src_ = 2;
+  num_dst_ = 1;
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
+    src0 = Operand(
+        16, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src0 = Operand(16, OperandType::OPR_SIMM64, literal64, true);
+  }
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
+    src1 = Operand(
+        16, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src1 = Operand(16, OperandType::OPR_SIMM64, literal64, true);
+  }
+  vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
+  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
+  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
+}
+
+void VMaxI16Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_max_i16_vop3(*this, wf); }
+
+VMinU16Vop3::VMinU16Vop3(const MachineInst *inst)
+    : Vop3("v_min_u16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinU16Vop3>()),
+      vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
+      src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
+      src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
+  dst_operands_[0] = &vdst;
+  src_operands_[0] = &src0;
+  src_operands_[1] = &src1;
+  num_src_ = 2;
+  num_dst_ = 1;
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
+    src0 = Operand(
+        16, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src0 = Operand(16, OperandType::OPR_SIMM64, literal64, true);
+  }
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
+    src1 = Operand(
+        16, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src1 = Operand(16, OperandType::OPR_SIMM64, literal64, true);
+  }
+  vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
+  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
+  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
+}
+
+void VMinU16Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_min_u16_vop3(*this, wf); }
+
+VMinI16Vop3::VMinI16Vop3(const MachineInst *inst)
+    : Vop3("v_min_i16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinI16Vop3>()),
+      vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
+      src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
+      src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
+  dst_operands_[0] = &vdst;
+  src_operands_[0] = &src0;
+  src_operands_[1] = &src1;
+  num_src_ = 2;
+  num_dst_ = 1;
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
+    src0 = Operand(
+        16, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src0 = Operand(16, OperandType::OPR_SIMM64, literal64, true);
+  }
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
+    src1 = Operand(
+        16, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src1 = Operand(16, OperandType::OPR_SIMM64, literal64, true);
+  }
+  vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
+  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
+  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
+}
+
+void VMinI16Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_min_i16_vop3(*this, wf); }
+
+VAddNcI16Vop3::VAddNcI16Vop3(const MachineInst *inst)
+    : Vop3("v_add_nc_i16", reinterpret_cast<const OpEncoding *>(inst),
+           make_exec_fn<VAddNcI16Vop3>()),
+      vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
+      src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
+      src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
+  dst_operands_[0] = &vdst;
+  src_operands_[0] = &src0;
+  src_operands_[1] = &src1;
+  num_src_ = 2;
+  num_dst_ = 1;
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
+    src0 = Operand(
+        16, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src0 = Operand(16, OperandType::OPR_SIMM64, literal64, true);
+  }
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
+    src1 = Operand(
+        16, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src1 = Operand(16, OperandType::OPR_SIMM64, literal64, true);
+  }
+  vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
+  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
+  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
+}
+
+void VAddNcI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
+  amdgpu::execute_v_add_nc_i16_vop3(*this, wf);
+}
+
+VSubNcI16Vop3::VSubNcI16Vop3(const MachineInst *inst)
+    : Vop3("v_sub_nc_i16", reinterpret_cast<const OpEncoding *>(inst),
+           make_exec_fn<VSubNcI16Vop3>()),
+      vdst(16, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
+      src0(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
+      src1(16, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
+  dst_operands_[0] = &vdst;
+  src_operands_[0] = &src0;
+  src_operands_[1] = &src1;
+  num_src_ = 2;
+  num_dst_ = 1;
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
+    src0 = Operand(
+        16, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src0 = Operand(16, OperandType::OPR_SIMM64, literal64, true);
+  }
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
+    src1 = Operand(
+        16, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src1 = Operand(16, OperandType::OPR_SIMM64, literal64, true);
+  }
+  vdst.set_vgpr_msb_role(amdgpu::VgprMsbRole::Dst);
+  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
+  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
+}
+
 void VSubNcI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
   amdgpu::execute_v_sub_nc_i16_vop3(*this, wf);
 }
@@ -2020,7 +2553,13 @@ void VCvtPkFp8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
     float s1 = std::bit_cast<float>(src1.read_lane(wf, lane));
     uint32_t lo = util::f32_to_fp8_e4m3_rne(s0);
     uint32_t hi = util::f32_to_fp8_e4m3_rne(s1);
-    vdst.write_lane(wf, lane, lo | (hi << 8));
+    uint32_t packed = static_cast<uint32_t>(lo) | (static_cast<uint32_t>(hi) << 8);
+    bool word_hi = (0u >> 3) & 1;
+    uint32_t old = vdst.read_lane(wf, lane);
+    if (word_hi)
+      vdst.write_lane(wf, lane, (old & 0xFFFFu) | (packed << 16));
+    else
+      vdst.write_lane(wf, lane, (old & 0xFFFF0000u) | (packed & 0xFFFFu));
   }
 }
 
@@ -2071,7 +2610,13 @@ void VCvtPkBf8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
     float s1 = std::bit_cast<float>(src1.read_lane(wf, lane));
     uint32_t lo = util::f32_to_bf8_e5m2_rne(s0);
     uint32_t hi = util::f32_to_bf8_e5m2_rne(s1);
-    vdst.write_lane(wf, lane, lo | (hi << 8));
+    uint32_t packed = static_cast<uint32_t>(lo) | (static_cast<uint32_t>(hi) << 8);
+    bool word_hi = (0u >> 3) & 1;
+    uint32_t old = vdst.read_lane(wf, lane);
+    if (word_hi)
+      vdst.write_lane(wf, lane, (old & 0xFFFFu) | (packed << 16));
+    else
+      vdst.write_lane(wf, lane, (old & 0xFFFF0000u) | (packed & 0xFFFFu));
   }
 }
 
@@ -2114,8 +2659,18 @@ VCvtSrFp8F32Vop3::VCvtSrFp8F32Vop3(const MachineInst *inst)
 }
 
 void VCvtSrFp8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    float s0 = std::bit_cast<float>(static_cast<uint32_t>(src0.read_lane(wf, lane)));
+    uint32_t seed = src1.read_lane(wf, lane);
+    uint8_t result = util::f32_to_fp8_e4m3_sr(s0, seed);
+    uint32_t dst_byte = (inst_.opsel >> 2) & 0x3;
+    uint32_t old = vdst.read_lane(wf, lane);
+    uint32_t mask = ~(0xFFu << (dst_byte * 8));
+    vdst.write_lane(wf, lane, (old & mask) | (static_cast<uint32_t>(result) << (dst_byte * 8)));
+  }
 }
 
 VCvtSrBf8F32Vop3::VCvtSrBf8F32Vop3(const MachineInst *inst)
@@ -2157,8 +2712,18 @@ VCvtSrBf8F32Vop3::VCvtSrBf8F32Vop3(const MachineInst *inst)
 }
 
 void VCvtSrBf8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    float s0 = std::bit_cast<float>(static_cast<uint32_t>(src0.read_lane(wf, lane)));
+    uint32_t seed = src1.read_lane(wf, lane);
+    uint8_t result = util::f32_to_bf8_e5m2_sr(s0, seed);
+    uint32_t dst_byte = (inst_.opsel >> 2) & 0x3;
+    uint32_t old = vdst.read_lane(wf, lane);
+    uint32_t mask = ~(0xFFu << (dst_byte * 8));
+    vdst.write_lane(wf, lane, (old & mask) | (static_cast<uint32_t>(result) << (dst_byte * 8)));
+  }
 }
 
 VCvtPkBf16F32Vop3::VCvtPkBf16F32Vop3(const MachineInst *inst)
@@ -2411,7 +2976,13 @@ void VCvtPkFp8F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     float s1 = util::f16_to_f32(static_cast<uint16_t>(raw >> 16));
     uint32_t lo = util::f32_to_fp8_e4m3_rne(s0);
     uint32_t hi = util::f32_to_fp8_e4m3_rne(s1);
-    vdst.write_lane(wf, lane, lo | (hi << 8));
+    uint32_t packed = static_cast<uint32_t>(lo) | (static_cast<uint32_t>(hi) << 8);
+    bool word_hi = (0u >> 3) & 1;
+    uint32_t old = vdst.read_lane(wf, lane);
+    if (word_hi)
+      vdst.write_lane(wf, lane, (old & 0xFFFFu) | (packed << 16));
+    else
+      vdst.write_lane(wf, lane, (old & 0xFFFF0000u) | (packed & 0xFFFFu));
   }
 }
 
@@ -2449,7 +3020,13 @@ void VCvtPkBf8F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     float s1 = util::f16_to_f32(static_cast<uint16_t>(raw >> 16));
     uint32_t lo = util::f32_to_bf8_e5m2_rne(s0);
     uint32_t hi = util::f32_to_bf8_e5m2_rne(s1);
-    vdst.write_lane(wf, lane, lo | (hi << 8));
+    uint32_t packed = static_cast<uint32_t>(lo) | (static_cast<uint32_t>(hi) << 8);
+    bool word_hi = (0u >> 3) & 1;
+    uint32_t old = vdst.read_lane(wf, lane);
+    if (word_hi)
+      vdst.write_lane(wf, lane, (old & 0xFFFFu) | (packed << 16));
+    else
+      vdst.write_lane(wf, lane, (old & 0xFFFF0000u) | (packed & 0xFFFFu));
   }
 }
 
@@ -7187,677 +7764,6 @@ VCmpxNgeF32Vop3::VCmpxNgeF32Vop3(const MachineInst *inst)
   }
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
-}
-
-void VCmpxNgeF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  uint64_t result = 0;
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    float s0 = std::bit_cast<float>(src0.read_lane(wf, lane));
-    float s1 = std::bit_cast<float>(src1.read_lane(wf, lane));
-    if (inst_.abs & (1u << 0))
-      s0 = std::fabs(s0);
-    if (inst_.neg & (1u << 0))
-      s0 = -s0;
-    if (inst_.abs & (1u << 1))
-      s1 = std::fabs(s1);
-    if (inst_.neg & (1u << 1))
-      s1 = -s1;
-    if (!(s0 >= s1))
-      result |= (1ULL << lane);
-  }
-  wf.set_exec(result);
-}
-
-VCmpxNlgF32Vop3::VCmpxNlgF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nlg_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNlgF32Vop3>()),
-      vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
-      src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
-      src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
-  dst_operands_[0] = &vdst;
-  src_operands_[0] = &src0;
-  src_operands_[1] = &src1;
-  num_src_ = 2;
-  num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
-    src0 = Operand(
-        32, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src0 = Operand(32, OperandType::OPR_SIMM64, literal64, true);
-  }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
-    src1 = Operand(
-        32, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src1 = Operand(32, OperandType::OPR_SIMM64, literal64, true);
-  }
-  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
-  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
-}
-
-void VCmpxNlgF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  uint64_t result = 0;
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    float s0 = std::bit_cast<float>(src0.read_lane(wf, lane));
-    float s1 = std::bit_cast<float>(src1.read_lane(wf, lane));
-    if (inst_.abs & (1u << 0))
-      s0 = std::fabs(s0);
-    if (inst_.neg & (1u << 0))
-      s0 = -s0;
-    if (inst_.abs & (1u << 1))
-      s1 = std::fabs(s1);
-    if (inst_.neg & (1u << 1))
-      s1 = -s1;
-    if (!(s0 < s1 || s0 > s1))
-      result |= (1ULL << lane);
-  }
-  wf.set_exec(result);
-}
-
-VCmpxNgtF32Vop3::VCmpxNgtF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ngt_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNgtF32Vop3>()),
-      vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
-      src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
-      src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
-  dst_operands_[0] = &vdst;
-  src_operands_[0] = &src0;
-  src_operands_[1] = &src1;
-  num_src_ = 2;
-  num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
-    src0 = Operand(
-        32, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src0 = Operand(32, OperandType::OPR_SIMM64, literal64, true);
-  }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
-    src1 = Operand(
-        32, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src1 = Operand(32, OperandType::OPR_SIMM64, literal64, true);
-  }
-  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
-  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
-}
-
-void VCmpxNgtF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  uint64_t result = 0;
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    float s0 = std::bit_cast<float>(src0.read_lane(wf, lane));
-    float s1 = std::bit_cast<float>(src1.read_lane(wf, lane));
-    if (inst_.abs & (1u << 0))
-      s0 = std::fabs(s0);
-    if (inst_.neg & (1u << 0))
-      s0 = -s0;
-    if (inst_.abs & (1u << 1))
-      s1 = std::fabs(s1);
-    if (inst_.neg & (1u << 1))
-      s1 = -s1;
-    if (!(s0 > s1))
-      result |= (1ULL << lane);
-  }
-  wf.set_exec(result);
-}
-
-VCmpxNleF32Vop3::VCmpxNleF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nle_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNleF32Vop3>()),
-      vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
-      src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
-      src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
-  dst_operands_[0] = &vdst;
-  src_operands_[0] = &src0;
-  src_operands_[1] = &src1;
-  num_src_ = 2;
-  num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
-    src0 = Operand(
-        32, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src0 = Operand(32, OperandType::OPR_SIMM64, literal64, true);
-  }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
-    src1 = Operand(
-        32, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src1 = Operand(32, OperandType::OPR_SIMM64, literal64, true);
-  }
-  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
-  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
-}
-
-void VCmpxNleF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  uint64_t result = 0;
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    float s0 = std::bit_cast<float>(src0.read_lane(wf, lane));
-    float s1 = std::bit_cast<float>(src1.read_lane(wf, lane));
-    if (inst_.abs & (1u << 0))
-      s0 = std::fabs(s0);
-    if (inst_.neg & (1u << 0))
-      s0 = -s0;
-    if (inst_.abs & (1u << 1))
-      s1 = std::fabs(s1);
-    if (inst_.neg & (1u << 1))
-      s1 = -s1;
-    if (!(s0 <= s1))
-      result |= (1ULL << lane);
-  }
-  wf.set_exec(result);
-}
-
-VCmpxNeqF32Vop3::VCmpxNeqF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_neq_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNeqF32Vop3>()),
-      vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
-      src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
-      src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
-  dst_operands_[0] = &vdst;
-  src_operands_[0] = &src0;
-  src_operands_[1] = &src1;
-  num_src_ = 2;
-  num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
-    src0 = Operand(
-        32, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src0 = Operand(32, OperandType::OPR_SIMM64, literal64, true);
-  }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
-    src1 = Operand(
-        32, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src1 = Operand(32, OperandType::OPR_SIMM64, literal64, true);
-  }
-  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
-  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
-}
-
-void VCmpxNeqF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  uint64_t result = 0;
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    float s0 = std::bit_cast<float>(src0.read_lane(wf, lane));
-    float s1 = std::bit_cast<float>(src1.read_lane(wf, lane));
-    if (inst_.abs & (1u << 0))
-      s0 = std::fabs(s0);
-    if (inst_.neg & (1u << 0))
-      s0 = -s0;
-    if (inst_.abs & (1u << 1))
-      s1 = std::fabs(s1);
-    if (inst_.neg & (1u << 1))
-      s1 = -s1;
-    if (s0 != s1 || std::isnan(s0) || std::isnan(s1))
-      result |= (1ULL << lane);
-  }
-  wf.set_exec(result);
-}
-
-VCmpxNltF32Vop3::VCmpxNltF32Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_nlt_f32", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxNltF32Vop3>()),
-      vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
-      src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
-      src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
-  dst_operands_[0] = &vdst;
-  src_operands_[0] = &src0;
-  src_operands_[1] = &src1;
-  num_src_ = 2;
-  num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
-    src0 = Operand(
-        32, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src0 = Operand(32, OperandType::OPR_SIMM64, literal64, true);
-  }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
-    src1 = Operand(
-        32, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src1 = Operand(32, OperandType::OPR_SIMM64, literal64, true);
-  }
-  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
-  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
-}
-
-void VCmpxNltF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  uint64_t result = 0;
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    float s0 = std::bit_cast<float>(src0.read_lane(wf, lane));
-    float s1 = std::bit_cast<float>(src1.read_lane(wf, lane));
-    if (inst_.abs & (1u << 0))
-      s0 = std::fabs(s0);
-    if (inst_.neg & (1u << 0))
-      s0 = -s0;
-    if (inst_.abs & (1u << 1))
-      s1 = std::fabs(s1);
-    if (inst_.neg & (1u << 1))
-      s1 = -s1;
-    if (!(s0 < s1))
-      result |= (1ULL << lane);
-  }
-  wf.set_exec(result);
-}
-
-VCmpxLtF64Vop3::VCmpxLtF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lt_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLtF64Vop3>()),
-      vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
-      src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
-      src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
-  dst_operands_[0] = &vdst;
-  src_operands_[0] = &src0;
-  src_operands_[1] = &src1;
-  num_src_ = 2;
-  num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
-    src0 = Operand(
-        64, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
-  }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
-    src1 = Operand(
-        64, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src1 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
-  }
-  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
-  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
-}
-
-void VCmpxLtF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  uint64_t result = 0;
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    double s0 = std::bit_cast<double>(src0.read_lane64(wf, lane));
-    double s1 = std::bit_cast<double>(src1.read_lane64(wf, lane));
-    if (inst_.abs & (1u << 0))
-      s0 = std::fabs(s0);
-    if (inst_.neg & (1u << 0))
-      s0 = -s0;
-    if (inst_.abs & (1u << 1))
-      s1 = std::fabs(s1);
-    if (inst_.neg & (1u << 1))
-      s1 = -s1;
-    if (s0 < s1)
-      result |= (1ULL << lane);
-  }
-  wf.set_exec(result);
-}
-
-VCmpxEqF64Vop3::VCmpxEqF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_eq_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxEqF64Vop3>()),
-      vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
-      src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
-      src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
-  dst_operands_[0] = &vdst;
-  src_operands_[0] = &src0;
-  src_operands_[1] = &src1;
-  num_src_ = 2;
-  num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
-    src0 = Operand(
-        64, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
-  }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
-    src1 = Operand(
-        64, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src1 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
-  }
-  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
-  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
-}
-
-void VCmpxEqF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  uint64_t result = 0;
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    double s0 = std::bit_cast<double>(src0.read_lane64(wf, lane));
-    double s1 = std::bit_cast<double>(src1.read_lane64(wf, lane));
-    if (inst_.abs & (1u << 0))
-      s0 = std::fabs(s0);
-    if (inst_.neg & (1u << 0))
-      s0 = -s0;
-    if (inst_.abs & (1u << 1))
-      s1 = std::fabs(s1);
-    if (inst_.neg & (1u << 1))
-      s1 = -s1;
-    if (s0 == s1)
-      result |= (1ULL << lane);
-  }
-  wf.set_exec(result);
-}
-
-VCmpxLeF64Vop3::VCmpxLeF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_le_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLeF64Vop3>()),
-      vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
-      src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
-      src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
-  dst_operands_[0] = &vdst;
-  src_operands_[0] = &src0;
-  src_operands_[1] = &src1;
-  num_src_ = 2;
-  num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
-    src0 = Operand(
-        64, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
-  }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
-    src1 = Operand(
-        64, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src1 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
-  }
-  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
-  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
-}
-
-void VCmpxLeF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  uint64_t result = 0;
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    double s0 = std::bit_cast<double>(src0.read_lane64(wf, lane));
-    double s1 = std::bit_cast<double>(src1.read_lane64(wf, lane));
-    if (inst_.abs & (1u << 0))
-      s0 = std::fabs(s0);
-    if (inst_.neg & (1u << 0))
-      s0 = -s0;
-    if (inst_.abs & (1u << 1))
-      s1 = std::fabs(s1);
-    if (inst_.neg & (1u << 1))
-      s1 = -s1;
-    if (s0 <= s1)
-      result |= (1ULL << lane);
-  }
-  wf.set_exec(result);
-}
-
-VCmpxGtF64Vop3::VCmpxGtF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_gt_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGtF64Vop3>()),
-      vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
-      src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
-      src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
-  dst_operands_[0] = &vdst;
-  src_operands_[0] = &src0;
-  src_operands_[1] = &src1;
-  num_src_ = 2;
-  num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
-    src0 = Operand(
-        64, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
-  }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
-    src1 = Operand(
-        64, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src1 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
-  }
-  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
-  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
-}
-
-void VCmpxGtF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  uint64_t result = 0;
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    double s0 = std::bit_cast<double>(src0.read_lane64(wf, lane));
-    double s1 = std::bit_cast<double>(src1.read_lane64(wf, lane));
-    if (inst_.abs & (1u << 0))
-      s0 = std::fabs(s0);
-    if (inst_.neg & (1u << 0))
-      s0 = -s0;
-    if (inst_.abs & (1u << 1))
-      s1 = std::fabs(s1);
-    if (inst_.neg & (1u << 1))
-      s1 = -s1;
-    if (s0 > s1)
-      result |= (1ULL << lane);
-  }
-  wf.set_exec(result);
-}
-
-VCmpxLgF64Vop3::VCmpxLgF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_lg_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxLgF64Vop3>()),
-      vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
-      src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
-      src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
-  dst_operands_[0] = &vdst;
-  src_operands_[0] = &src0;
-  src_operands_[1] = &src1;
-  num_src_ = 2;
-  num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
-    src0 = Operand(
-        64, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
-  }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
-    src1 = Operand(
-        64, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src1 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
-  }
-  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
-  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
-}
-
-void VCmpxLgF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  uint64_t result = 0;
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    double s0 = std::bit_cast<double>(src0.read_lane64(wf, lane));
-    double s1 = std::bit_cast<double>(src1.read_lane64(wf, lane));
-    if (inst_.abs & (1u << 0))
-      s0 = std::fabs(s0);
-    if (inst_.neg & (1u << 0))
-      s0 = -s0;
-    if (inst_.abs & (1u << 1))
-      s1 = std::fabs(s1);
-    if (inst_.neg & (1u << 1))
-      s1 = -s1;
-    if (s0 < s1 || s0 > s1)
-      result |= (1ULL << lane);
-  }
-  wf.set_exec(result);
-}
-
-VCmpxGeF64Vop3::VCmpxGeF64Vop3(const MachineInst *inst)
-    : Vop3("v_cmpx_ge_f64", reinterpret_cast<const OpEncoding *>(inst),
-           make_exec_fn<VCmpxGeF64Vop3>()),
-      vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
-      src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
-      src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
-  dst_operands_[0] = &vdst;
-  src_operands_[0] = &src0;
-  src_operands_[1] = &src1;
-  num_src_ = 2;
-  num_dst_ = 1;
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
-    src0 = Operand(
-        64, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
-  }
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
-    src1 = Operand(
-        64, OperandType::OPR_SIMM32,
-        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
-  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
-    const auto *words = reinterpret_cast<const uint32_t *>(inst);
-    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
-    uint64_t literal64 =
-        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
-    src1 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
-  }
-  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
-  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
-}
-
-void VCmpxGeF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  uint64_t result = 0;
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    double s0 = std::bit_cast<double>(src0.read_lane64(wf, lane));
-    double s1 = std::bit_cast<double>(src1.read_lane64(wf, lane));
-    if (inst_.abs & (1u << 0))
-      s0 = std::fabs(s0);
-    if (inst_.neg & (1u << 0))
-      s0 = -s0;
-    if (inst_.abs & (1u << 1))
-      s1 = std::fabs(s1);
-    if (inst_.neg & (1u << 1))
-      s1 = -s1;
-    if (s0 >= s1)
-      result |= (1ULL << lane);
-  }
-  wf.set_exec(result);
 }
 
 } // namespace gfx1250

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_part4.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_part4.cpp
@@ -19,6 +19,677 @@
 namespace rocjitsu {
 namespace gfx1250 {
 
+void VCmpxNgeF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t exec = wf.exec();
+  uint64_t result = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    float s0 = std::bit_cast<float>(src0.read_lane(wf, lane));
+    float s1 = std::bit_cast<float>(src1.read_lane(wf, lane));
+    if (inst_.abs & (1u << 0))
+      s0 = std::fabs(s0);
+    if (inst_.neg & (1u << 0))
+      s0 = -s0;
+    if (inst_.abs & (1u << 1))
+      s1 = std::fabs(s1);
+    if (inst_.neg & (1u << 1))
+      s1 = -s1;
+    if (!(s0 >= s1))
+      result |= (1ULL << lane);
+  }
+  wf.set_exec(result);
+}
+
+VCmpxNlgF32Vop3::VCmpxNlgF32Vop3(const MachineInst *inst)
+    : Vop3("v_cmpx_nlg_f32", reinterpret_cast<const OpEncoding *>(inst),
+           make_exec_fn<VCmpxNlgF32Vop3>()),
+      vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
+      src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
+      src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
+  dst_operands_[0] = &vdst;
+  src_operands_[0] = &src0;
+  src_operands_[1] = &src1;
+  num_src_ = 2;
+  num_dst_ = 1;
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
+    src0 = Operand(
+        32, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src0 = Operand(32, OperandType::OPR_SIMM64, literal64, true);
+  }
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
+    src1 = Operand(
+        32, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src1 = Operand(32, OperandType::OPR_SIMM64, literal64, true);
+  }
+  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
+  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
+}
+
+void VCmpxNlgF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t exec = wf.exec();
+  uint64_t result = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    float s0 = std::bit_cast<float>(src0.read_lane(wf, lane));
+    float s1 = std::bit_cast<float>(src1.read_lane(wf, lane));
+    if (inst_.abs & (1u << 0))
+      s0 = std::fabs(s0);
+    if (inst_.neg & (1u << 0))
+      s0 = -s0;
+    if (inst_.abs & (1u << 1))
+      s1 = std::fabs(s1);
+    if (inst_.neg & (1u << 1))
+      s1 = -s1;
+    if (!(s0 < s1 || s0 > s1))
+      result |= (1ULL << lane);
+  }
+  wf.set_exec(result);
+}
+
+VCmpxNgtF32Vop3::VCmpxNgtF32Vop3(const MachineInst *inst)
+    : Vop3("v_cmpx_ngt_f32", reinterpret_cast<const OpEncoding *>(inst),
+           make_exec_fn<VCmpxNgtF32Vop3>()),
+      vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
+      src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
+      src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
+  dst_operands_[0] = &vdst;
+  src_operands_[0] = &src0;
+  src_operands_[1] = &src1;
+  num_src_ = 2;
+  num_dst_ = 1;
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
+    src0 = Operand(
+        32, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src0 = Operand(32, OperandType::OPR_SIMM64, literal64, true);
+  }
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
+    src1 = Operand(
+        32, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src1 = Operand(32, OperandType::OPR_SIMM64, literal64, true);
+  }
+  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
+  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
+}
+
+void VCmpxNgtF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t exec = wf.exec();
+  uint64_t result = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    float s0 = std::bit_cast<float>(src0.read_lane(wf, lane));
+    float s1 = std::bit_cast<float>(src1.read_lane(wf, lane));
+    if (inst_.abs & (1u << 0))
+      s0 = std::fabs(s0);
+    if (inst_.neg & (1u << 0))
+      s0 = -s0;
+    if (inst_.abs & (1u << 1))
+      s1 = std::fabs(s1);
+    if (inst_.neg & (1u << 1))
+      s1 = -s1;
+    if (!(s0 > s1))
+      result |= (1ULL << lane);
+  }
+  wf.set_exec(result);
+}
+
+VCmpxNleF32Vop3::VCmpxNleF32Vop3(const MachineInst *inst)
+    : Vop3("v_cmpx_nle_f32", reinterpret_cast<const OpEncoding *>(inst),
+           make_exec_fn<VCmpxNleF32Vop3>()),
+      vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
+      src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
+      src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
+  dst_operands_[0] = &vdst;
+  src_operands_[0] = &src0;
+  src_operands_[1] = &src1;
+  num_src_ = 2;
+  num_dst_ = 1;
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
+    src0 = Operand(
+        32, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src0 = Operand(32, OperandType::OPR_SIMM64, literal64, true);
+  }
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
+    src1 = Operand(
+        32, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src1 = Operand(32, OperandType::OPR_SIMM64, literal64, true);
+  }
+  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
+  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
+}
+
+void VCmpxNleF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t exec = wf.exec();
+  uint64_t result = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    float s0 = std::bit_cast<float>(src0.read_lane(wf, lane));
+    float s1 = std::bit_cast<float>(src1.read_lane(wf, lane));
+    if (inst_.abs & (1u << 0))
+      s0 = std::fabs(s0);
+    if (inst_.neg & (1u << 0))
+      s0 = -s0;
+    if (inst_.abs & (1u << 1))
+      s1 = std::fabs(s1);
+    if (inst_.neg & (1u << 1))
+      s1 = -s1;
+    if (!(s0 <= s1))
+      result |= (1ULL << lane);
+  }
+  wf.set_exec(result);
+}
+
+VCmpxNeqF32Vop3::VCmpxNeqF32Vop3(const MachineInst *inst)
+    : Vop3("v_cmpx_neq_f32", reinterpret_cast<const OpEncoding *>(inst),
+           make_exec_fn<VCmpxNeqF32Vop3>()),
+      vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
+      src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
+      src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
+  dst_operands_[0] = &vdst;
+  src_operands_[0] = &src0;
+  src_operands_[1] = &src1;
+  num_src_ = 2;
+  num_dst_ = 1;
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
+    src0 = Operand(
+        32, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src0 = Operand(32, OperandType::OPR_SIMM64, literal64, true);
+  }
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
+    src1 = Operand(
+        32, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src1 = Operand(32, OperandType::OPR_SIMM64, literal64, true);
+  }
+  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
+  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
+}
+
+void VCmpxNeqF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t exec = wf.exec();
+  uint64_t result = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    float s0 = std::bit_cast<float>(src0.read_lane(wf, lane));
+    float s1 = std::bit_cast<float>(src1.read_lane(wf, lane));
+    if (inst_.abs & (1u << 0))
+      s0 = std::fabs(s0);
+    if (inst_.neg & (1u << 0))
+      s0 = -s0;
+    if (inst_.abs & (1u << 1))
+      s1 = std::fabs(s1);
+    if (inst_.neg & (1u << 1))
+      s1 = -s1;
+    if (s0 != s1 || std::isnan(s0) || std::isnan(s1))
+      result |= (1ULL << lane);
+  }
+  wf.set_exec(result);
+}
+
+VCmpxNltF32Vop3::VCmpxNltF32Vop3(const MachineInst *inst)
+    : Vop3("v_cmpx_nlt_f32", reinterpret_cast<const OpEncoding *>(inst),
+           make_exec_fn<VCmpxNltF32Vop3>()),
+      vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
+      src0(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
+      src1(32, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
+  dst_operands_[0] = &vdst;
+  src_operands_[0] = &src0;
+  src_operands_[1] = &src1;
+  num_src_ = 2;
+  num_dst_ = 1;
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
+    src0 = Operand(
+        32, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src0 = Operand(32, OperandType::OPR_SIMM64, literal64, true);
+  }
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
+    src1 = Operand(
+        32, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src1 = Operand(32, OperandType::OPR_SIMM64, literal64, true);
+  }
+  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
+  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
+}
+
+void VCmpxNltF32Vop3::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t exec = wf.exec();
+  uint64_t result = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    float s0 = std::bit_cast<float>(src0.read_lane(wf, lane));
+    float s1 = std::bit_cast<float>(src1.read_lane(wf, lane));
+    if (inst_.abs & (1u << 0))
+      s0 = std::fabs(s0);
+    if (inst_.neg & (1u << 0))
+      s0 = -s0;
+    if (inst_.abs & (1u << 1))
+      s1 = std::fabs(s1);
+    if (inst_.neg & (1u << 1))
+      s1 = -s1;
+    if (!(s0 < s1))
+      result |= (1ULL << lane);
+  }
+  wf.set_exec(result);
+}
+
+VCmpxLtF64Vop3::VCmpxLtF64Vop3(const MachineInst *inst)
+    : Vop3("v_cmpx_lt_f64", reinterpret_cast<const OpEncoding *>(inst),
+           make_exec_fn<VCmpxLtF64Vop3>()),
+      vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
+      src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
+      src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
+  dst_operands_[0] = &vdst;
+  src_operands_[0] = &src0;
+  src_operands_[1] = &src1;
+  num_src_ = 2;
+  num_dst_ = 1;
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
+    src0 = Operand(
+        64, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
+  }
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
+    src1 = Operand(
+        64, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src1 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
+  }
+  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
+  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
+}
+
+void VCmpxLtF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t exec = wf.exec();
+  uint64_t result = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    double s0 = std::bit_cast<double>(src0.read_lane64(wf, lane));
+    double s1 = std::bit_cast<double>(src1.read_lane64(wf, lane));
+    if (inst_.abs & (1u << 0))
+      s0 = std::fabs(s0);
+    if (inst_.neg & (1u << 0))
+      s0 = -s0;
+    if (inst_.abs & (1u << 1))
+      s1 = std::fabs(s1);
+    if (inst_.neg & (1u << 1))
+      s1 = -s1;
+    if (s0 < s1)
+      result |= (1ULL << lane);
+  }
+  wf.set_exec(result);
+}
+
+VCmpxEqF64Vop3::VCmpxEqF64Vop3(const MachineInst *inst)
+    : Vop3("v_cmpx_eq_f64", reinterpret_cast<const OpEncoding *>(inst),
+           make_exec_fn<VCmpxEqF64Vop3>()),
+      vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
+      src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
+      src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
+  dst_operands_[0] = &vdst;
+  src_operands_[0] = &src0;
+  src_operands_[1] = &src1;
+  num_src_ = 2;
+  num_dst_ = 1;
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
+    src0 = Operand(
+        64, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
+  }
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
+    src1 = Operand(
+        64, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src1 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
+  }
+  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
+  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
+}
+
+void VCmpxEqF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t exec = wf.exec();
+  uint64_t result = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    double s0 = std::bit_cast<double>(src0.read_lane64(wf, lane));
+    double s1 = std::bit_cast<double>(src1.read_lane64(wf, lane));
+    if (inst_.abs & (1u << 0))
+      s0 = std::fabs(s0);
+    if (inst_.neg & (1u << 0))
+      s0 = -s0;
+    if (inst_.abs & (1u << 1))
+      s1 = std::fabs(s1);
+    if (inst_.neg & (1u << 1))
+      s1 = -s1;
+    if (s0 == s1)
+      result |= (1ULL << lane);
+  }
+  wf.set_exec(result);
+}
+
+VCmpxLeF64Vop3::VCmpxLeF64Vop3(const MachineInst *inst)
+    : Vop3("v_cmpx_le_f64", reinterpret_cast<const OpEncoding *>(inst),
+           make_exec_fn<VCmpxLeF64Vop3>()),
+      vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
+      src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
+      src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
+  dst_operands_[0] = &vdst;
+  src_operands_[0] = &src0;
+  src_operands_[1] = &src1;
+  num_src_ = 2;
+  num_dst_ = 1;
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
+    src0 = Operand(
+        64, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
+  }
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
+    src1 = Operand(
+        64, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src1 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
+  }
+  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
+  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
+}
+
+void VCmpxLeF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t exec = wf.exec();
+  uint64_t result = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    double s0 = std::bit_cast<double>(src0.read_lane64(wf, lane));
+    double s1 = std::bit_cast<double>(src1.read_lane64(wf, lane));
+    if (inst_.abs & (1u << 0))
+      s0 = std::fabs(s0);
+    if (inst_.neg & (1u << 0))
+      s0 = -s0;
+    if (inst_.abs & (1u << 1))
+      s1 = std::fabs(s1);
+    if (inst_.neg & (1u << 1))
+      s1 = -s1;
+    if (s0 <= s1)
+      result |= (1ULL << lane);
+  }
+  wf.set_exec(result);
+}
+
+VCmpxGtF64Vop3::VCmpxGtF64Vop3(const MachineInst *inst)
+    : Vop3("v_cmpx_gt_f64", reinterpret_cast<const OpEncoding *>(inst),
+           make_exec_fn<VCmpxGtF64Vop3>()),
+      vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
+      src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
+      src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
+  dst_operands_[0] = &vdst;
+  src_operands_[0] = &src0;
+  src_operands_[1] = &src1;
+  num_src_ = 2;
+  num_dst_ = 1;
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
+    src0 = Operand(
+        64, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
+  }
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
+    src1 = Operand(
+        64, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src1 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
+  }
+  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
+  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
+}
+
+void VCmpxGtF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t exec = wf.exec();
+  uint64_t result = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    double s0 = std::bit_cast<double>(src0.read_lane64(wf, lane));
+    double s1 = std::bit_cast<double>(src1.read_lane64(wf, lane));
+    if (inst_.abs & (1u << 0))
+      s0 = std::fabs(s0);
+    if (inst_.neg & (1u << 0))
+      s0 = -s0;
+    if (inst_.abs & (1u << 1))
+      s1 = std::fabs(s1);
+    if (inst_.neg & (1u << 1))
+      s1 = -s1;
+    if (s0 > s1)
+      result |= (1ULL << lane);
+  }
+  wf.set_exec(result);
+}
+
+VCmpxLgF64Vop3::VCmpxLgF64Vop3(const MachineInst *inst)
+    : Vop3("v_cmpx_lg_f64", reinterpret_cast<const OpEncoding *>(inst),
+           make_exec_fn<VCmpxLgF64Vop3>()),
+      vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
+      src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
+      src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
+  dst_operands_[0] = &vdst;
+  src_operands_[0] = &src0;
+  src_operands_[1] = &src1;
+  num_src_ = 2;
+  num_dst_ = 1;
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
+    src0 = Operand(
+        64, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
+  }
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
+    src1 = Operand(
+        64, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src1 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
+  }
+  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
+  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
+}
+
+void VCmpxLgF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t exec = wf.exec();
+  uint64_t result = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    double s0 = std::bit_cast<double>(src0.read_lane64(wf, lane));
+    double s1 = std::bit_cast<double>(src1.read_lane64(wf, lane));
+    if (inst_.abs & (1u << 0))
+      s0 = std::fabs(s0);
+    if (inst_.neg & (1u << 0))
+      s0 = -s0;
+    if (inst_.abs & (1u << 1))
+      s1 = std::fabs(s1);
+    if (inst_.neg & (1u << 1))
+      s1 = -s1;
+    if (s0 < s1 || s0 > s1)
+      result |= (1ULL << lane);
+  }
+  wf.set_exec(result);
+}
+
+VCmpxGeF64Vop3::VCmpxGeF64Vop3(const MachineInst *inst)
+    : Vop3("v_cmpx_ge_f64", reinterpret_cast<const OpEncoding *>(inst),
+           make_exec_fn<VCmpxGeF64Vop3>()),
+      vdst(64, OperandType::OPR_EXEC, reinterpret_cast<const OpEncoding *>(inst)->vdst),
+      src0(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src0),
+      src1(64, OperandType::OPR_SRC, reinterpret_cast<const OpEncoding *>(inst)->src1) {
+  dst_operands_[0] = &vdst;
+  src_operands_[0] = &src0;
+  src_operands_[1] = &src1;
+  num_src_ = 2;
+  num_dst_ = 1;
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 255)
+    src0 = Operand(
+        64, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src0 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
+  }
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 255)
+    src1 = Operand(
+        64, OperandType::OPR_SIMM32,
+        static_cast<int>(reinterpret_cast<const Vop3InstLiteralMachineInst *>(inst)->simm32));
+  if (reinterpret_cast<const OpEncoding *>(inst)->src1 == 254) {
+    const auto *words = reinterpret_cast<const uint32_t *>(inst);
+    uint32_t literal_word = sizeof(OpEncoding) / sizeof(uint32_t);
+    uint64_t literal64 =
+        (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
+    src1 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
+  }
+  src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
+  src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
+}
+
+void VCmpxGeF64Vop3::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t exec = wf.exec();
+  uint64_t result = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    double s0 = std::bit_cast<double>(src0.read_lane64(wf, lane));
+    double s1 = std::bit_cast<double>(src1.read_lane64(wf, lane));
+    if (inst_.abs & (1u << 0))
+      s0 = std::fabs(s0);
+    if (inst_.neg & (1u << 0))
+      s0 = -s0;
+    if (inst_.abs & (1u << 1))
+      s1 = std::fabs(s1);
+    if (inst_.neg & (1u << 1))
+      s1 = -s1;
+    if (s0 >= s1)
+      result |= (1ULL << lane);
+  }
+  wf.set_exec(result);
+}
+
 VCmpxOF64Vop3::VCmpxOF64Vop3(const MachineInst *inst)
     : Vop3("v_cmpx_o_f64", reinterpret_cast<const OpEncoding *>(inst),
            make_exec_fn<VCmpxOF64Vop3>()),

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna1/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna1/operand.cpp
@@ -1365,8 +1365,10 @@ uint32_t Operand::read_lane(const amdgpu::Wavefront &wf, uint32_t lane) const {
   if (delegate())
     return delegate()->read_lane(wf, lane);
   int ev = encoding_value_;
-  if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev))
-    return wf.cu().read_vgpr(wf.vgpr_alloc().base + *off, lane);
+  if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev)) {
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, false) : *off;
+    return wf.cu().read_vgpr(wf.vgpr_alloc().base + voff, lane);
+  }
   if (is_immediate_type(opr_type_))
     return static_cast<uint32_t>(ev);
   return resolve_src_scalar(wf, ev);
@@ -1378,7 +1380,8 @@ void Operand::write_scalar(amdgpu::Wavefront &wf, uint32_t val) const {
 
 void Operand::write_lane(amdgpu::Wavefront &wf, uint32_t lane, uint32_t val) const {
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, encoding_value_)) {
-    wf.cu().write_vgpr(wf.vgpr_alloc().base + *off, lane, val);
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, true) : *off;
+    wf.cu().write_vgpr(wf.vgpr_alloc().base + voff, lane, val);
     return;
   }
   throw std::logic_error("write_lane called on non-VGPR operand type");
@@ -1389,7 +1392,8 @@ uint64_t Operand::read_lane64(const amdgpu::Wavefront &wf, uint32_t lane) const 
     return delegate()->read_lane64(wf, lane);
   int ev = encoding_value_;
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev)) {
-    uint32_t idx = wf.vgpr_alloc().base + *off;
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, false) : *off;
+    uint32_t idx = wf.vgpr_alloc().base + voff;
     uint32_t lo = wf.cu().read_vgpr(idx, lane);
     uint32_t hi = wf.cu().read_vgpr(idx + 1, lane);
     return static_cast<uint64_t>(hi) << 32 | lo;
@@ -1403,7 +1407,8 @@ uint64_t Operand::read_lane64(const amdgpu::Wavefront &wf, uint32_t lane) const 
 
 void Operand::write_lane64(amdgpu::Wavefront &wf, uint32_t lane, uint64_t val) const {
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, encoding_value_)) {
-    uint32_t idx = wf.vgpr_alloc().base + *off;
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, true) : *off;
+    uint32_t idx = wf.vgpr_alloc().base + voff;
     wf.cu().write_vgpr(idx, lane, static_cast<uint32_t>(val));
     wf.cu().write_vgpr(idx + 1, lane, static_cast<uint32_t>(val >> 32));
     return;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna2/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna2/operand.cpp
@@ -1208,8 +1208,10 @@ uint32_t Operand::read_lane(const amdgpu::Wavefront &wf, uint32_t lane) const {
   if (delegate())
     return delegate()->read_lane(wf, lane);
   int ev = encoding_value_;
-  if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev))
-    return wf.cu().read_vgpr(wf.vgpr_alloc().base + *off, lane);
+  if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev)) {
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, false) : *off;
+    return wf.cu().read_vgpr(wf.vgpr_alloc().base + voff, lane);
+  }
   if (is_immediate_type(opr_type_))
     return static_cast<uint32_t>(ev);
   return resolve_src_scalar(wf, ev);
@@ -1221,7 +1223,8 @@ void Operand::write_scalar(amdgpu::Wavefront &wf, uint32_t val) const {
 
 void Operand::write_lane(amdgpu::Wavefront &wf, uint32_t lane, uint32_t val) const {
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, encoding_value_)) {
-    wf.cu().write_vgpr(wf.vgpr_alloc().base + *off, lane, val);
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, true) : *off;
+    wf.cu().write_vgpr(wf.vgpr_alloc().base + voff, lane, val);
     return;
   }
   throw std::logic_error("write_lane called on non-VGPR operand type");
@@ -1232,7 +1235,8 @@ uint64_t Operand::read_lane64(const amdgpu::Wavefront &wf, uint32_t lane) const 
     return delegate()->read_lane64(wf, lane);
   int ev = encoding_value_;
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev)) {
-    uint32_t idx = wf.vgpr_alloc().base + *off;
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, false) : *off;
+    uint32_t idx = wf.vgpr_alloc().base + voff;
     uint32_t lo = wf.cu().read_vgpr(idx, lane);
     uint32_t hi = wf.cu().read_vgpr(idx + 1, lane);
     return static_cast<uint64_t>(hi) << 32 | lo;
@@ -1246,7 +1250,8 @@ uint64_t Operand::read_lane64(const amdgpu::Wavefront &wf, uint32_t lane) const 
 
 void Operand::write_lane64(amdgpu::Wavefront &wf, uint32_t lane, uint64_t val) const {
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, encoding_value_)) {
-    uint32_t idx = wf.vgpr_alloc().base + *off;
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, true) : *off;
+    uint32_t idx = wf.vgpr_alloc().base + voff;
     wf.cu().write_vgpr(idx, lane, static_cast<uint32_t>(val));
     wf.cu().write_vgpr(idx + 1, lane, static_cast<uint32_t>(val >> 32));
     return;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/operand.cpp
@@ -896,8 +896,10 @@ uint32_t Operand::read_lane(const amdgpu::Wavefront &wf, uint32_t lane) const {
   if (delegate())
     return delegate()->read_lane(wf, lane);
   int ev = encoding_value_;
-  if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev))
-    return wf.cu().read_vgpr(wf.vgpr_alloc().base + *off, lane);
+  if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev)) {
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, false) : *off;
+    return wf.cu().read_vgpr(wf.vgpr_alloc().base + voff, lane);
+  }
   if (is_immediate_type(opr_type_))
     return static_cast<uint32_t>(ev);
   return resolve_src_scalar(wf, ev);
@@ -909,7 +911,8 @@ void Operand::write_scalar(amdgpu::Wavefront &wf, uint32_t val) const {
 
 void Operand::write_lane(amdgpu::Wavefront &wf, uint32_t lane, uint32_t val) const {
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, encoding_value_)) {
-    wf.cu().write_vgpr(wf.vgpr_alloc().base + *off, lane, val);
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, true) : *off;
+    wf.cu().write_vgpr(wf.vgpr_alloc().base + voff, lane, val);
     return;
   }
   throw std::logic_error("write_lane called on non-VGPR operand type");
@@ -920,7 +923,8 @@ uint64_t Operand::read_lane64(const amdgpu::Wavefront &wf, uint32_t lane) const 
     return delegate()->read_lane64(wf, lane);
   int ev = encoding_value_;
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev)) {
-    uint32_t idx = wf.vgpr_alloc().base + *off;
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, false) : *off;
+    uint32_t idx = wf.vgpr_alloc().base + voff;
     uint32_t lo = wf.cu().read_vgpr(idx, lane);
     uint32_t hi = wf.cu().read_vgpr(idx + 1, lane);
     return static_cast<uint64_t>(hi) << 32 | lo;
@@ -934,7 +938,8 @@ uint64_t Operand::read_lane64(const amdgpu::Wavefront &wf, uint32_t lane) const 
 
 void Operand::write_lane64(amdgpu::Wavefront &wf, uint32_t lane, uint64_t val) const {
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, encoding_value_)) {
-    uint32_t idx = wf.vgpr_alloc().base + *off;
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, true) : *off;
+    uint32_t idx = wf.vgpr_alloc().base + voff;
     wf.cu().write_vgpr(idx, lane, static_cast<uint32_t>(val));
     wf.cu().write_vgpr(idx + 1, lane, static_cast<uint32_t>(val >> 32));
     return;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/vop3.cpp
@@ -4816,7 +4816,18 @@ VCvtPkI16F32Vop3::VCvtPkI16F32Vop3(const MachineInst *inst)
 }
 
 void VCvtPkI16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cvt_pk_i16_f32_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t s0 = src0.read_lane(wf, lane);
+    uint32_t s1 = src1.read_lane(wf, lane);
+    int16_t lo = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s0), -32768, 32767));
+    int16_t hi = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s1), -32768, 32767));
+    vdst.write_lane(wf, lane,
+                    (static_cast<uint32_t>(static_cast<uint16_t>(hi)) << 16) |
+                        static_cast<uint32_t>(static_cast<uint16_t>(lo)));
+  }
 }
 
 VCvtPkU16F32Vop3::VCvtPkU16F32Vop3(const MachineInst *inst)
@@ -4841,7 +4852,18 @@ VCvtPkU16F32Vop3::VCvtPkU16F32Vop3(const MachineInst *inst)
 }
 
 void VCvtPkU16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cvt_pk_u16_f32_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t s0 = src0.read_lane(wf, lane);
+    uint32_t s1 = src1.read_lane(wf, lane);
+    int16_t lo = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s0), -32768, 32767));
+    int16_t hi = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s1), -32768, 32767));
+    vdst.write_lane(wf, lane,
+                    (static_cast<uint32_t>(static_cast<uint16_t>(hi)) << 16) |
+                        static_cast<uint32_t>(static_cast<uint16_t>(lo)));
+  }
 }
 
 VMaxU16Vop3::VMaxU16Vop3(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/operand.cpp
@@ -903,8 +903,10 @@ uint32_t Operand::read_lane(const amdgpu::Wavefront &wf, uint32_t lane) const {
   if (delegate())
     return delegate()->read_lane(wf, lane);
   int ev = encoding_value_;
-  if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev))
-    return wf.cu().read_vgpr(wf.vgpr_alloc().base + *off, lane);
+  if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev)) {
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, false) : *off;
+    return wf.cu().read_vgpr(wf.vgpr_alloc().base + voff, lane);
+  }
   if (is_immediate_type(opr_type_))
     return static_cast<uint32_t>(ev);
   return resolve_src_scalar(wf, ev);
@@ -916,7 +918,8 @@ void Operand::write_scalar(amdgpu::Wavefront &wf, uint32_t val) const {
 
 void Operand::write_lane(amdgpu::Wavefront &wf, uint32_t lane, uint32_t val) const {
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, encoding_value_)) {
-    wf.cu().write_vgpr(wf.vgpr_alloc().base + *off, lane, val);
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, true) : *off;
+    wf.cu().write_vgpr(wf.vgpr_alloc().base + voff, lane, val);
     return;
   }
   throw std::logic_error("write_lane called on non-VGPR operand type");
@@ -927,7 +930,8 @@ uint64_t Operand::read_lane64(const amdgpu::Wavefront &wf, uint32_t lane) const 
     return delegate()->read_lane64(wf, lane);
   int ev = encoding_value_;
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev)) {
-    uint32_t idx = wf.vgpr_alloc().base + *off;
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, false) : *off;
+    uint32_t idx = wf.vgpr_alloc().base + voff;
     uint32_t lo = wf.cu().read_vgpr(idx, lane);
     uint32_t hi = wf.cu().read_vgpr(idx + 1, lane);
     return static_cast<uint64_t>(hi) << 32 | lo;
@@ -941,7 +945,8 @@ uint64_t Operand::read_lane64(const amdgpu::Wavefront &wf, uint32_t lane) const 
 
 void Operand::write_lane64(amdgpu::Wavefront &wf, uint32_t lane, uint64_t val) const {
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, encoding_value_)) {
-    uint32_t idx = wf.vgpr_alloc().base + *off;
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, true) : *off;
+    uint32_t idx = wf.vgpr_alloc().base + voff;
     wf.cu().write_vgpr(idx, lane, static_cast<uint32_t>(val));
     wf.cu().write_vgpr(idx + 1, lane, static_cast<uint32_t>(val >> 32));
     return;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/vop3.cpp
@@ -4816,7 +4816,18 @@ VCvtPkI16F32Vop3::VCvtPkI16F32Vop3(const MachineInst *inst)
 }
 
 void VCvtPkI16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cvt_pk_i16_f32_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t s0 = src0.read_lane(wf, lane);
+    uint32_t s1 = src1.read_lane(wf, lane);
+    int16_t lo = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s0), -32768, 32767));
+    int16_t hi = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s1), -32768, 32767));
+    vdst.write_lane(wf, lane,
+                    (static_cast<uint32_t>(static_cast<uint16_t>(hi)) << 16) |
+                        static_cast<uint32_t>(static_cast<uint16_t>(lo)));
+  }
 }
 
 VCvtPkU16F32Vop3::VCvtPkU16F32Vop3(const MachineInst *inst)
@@ -4841,7 +4852,18 @@ VCvtPkU16F32Vop3::VCvtPkU16F32Vop3(const MachineInst *inst)
 }
 
 void VCvtPkU16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cvt_pk_u16_f32_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t s0 = src0.read_lane(wf, lane);
+    uint32_t s1 = src1.read_lane(wf, lane);
+    int16_t lo = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s0), -32768, 32767));
+    int16_t hi = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s1), -32768, 32767));
+    vdst.write_lane(wf, lane,
+                    (static_cast<uint32_t>(static_cast<uint16_t>(hi)) << 16) |
+                        static_cast<uint32_t>(static_cast<uint16_t>(lo)));
+  }
 }
 
 VMaxU16Vop3::VMaxU16Vop3(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/operand.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/operand.cpp
@@ -949,8 +949,10 @@ uint32_t Operand::read_lane(const amdgpu::Wavefront &wf, uint32_t lane) const {
   if (delegate())
     return delegate()->read_lane(wf, lane);
   int ev = encoding_value_;
-  if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev))
-    return wf.cu().read_vgpr(wf.vgpr_alloc().base + *off, lane);
+  if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev)) {
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, false) : *off;
+    return wf.cu().read_vgpr(wf.vgpr_alloc().base + voff, lane);
+  }
   if (is_immediate_type(opr_type_))
     return static_cast<uint32_t>(ev);
   return resolve_src_scalar(wf, ev);
@@ -962,7 +964,8 @@ void Operand::write_scalar(amdgpu::Wavefront &wf, uint32_t val) const {
 
 void Operand::write_lane(amdgpu::Wavefront &wf, uint32_t lane, uint32_t val) const {
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, encoding_value_)) {
-    wf.cu().write_vgpr(wf.vgpr_alloc().base + *off, lane, val);
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, true) : *off;
+    wf.cu().write_vgpr(wf.vgpr_alloc().base + voff, lane, val);
     return;
   }
   throw std::logic_error("write_lane called on non-VGPR operand type");
@@ -973,7 +976,8 @@ uint64_t Operand::read_lane64(const amdgpu::Wavefront &wf, uint32_t lane) const 
     return delegate()->read_lane64(wf, lane);
   int ev = encoding_value_;
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, ev)) {
-    uint32_t idx = wf.vgpr_alloc().base + *off;
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, false) : *off;
+    uint32_t idx = wf.vgpr_alloc().base + voff;
     uint32_t lo = wf.cu().read_vgpr(idx, lane);
     uint32_t hi = wf.cu().read_vgpr(idx + 1, lane);
     return static_cast<uint64_t>(hi) << 32 | lo;
@@ -987,7 +991,8 @@ uint64_t Operand::read_lane64(const amdgpu::Wavefront &wf, uint32_t lane) const 
 
 void Operand::write_lane64(amdgpu::Wavefront &wf, uint32_t lane, uint64_t val) const {
   if (auto off = Isa::resolved_vgpr_offset(opr_type_, encoding_value_)) {
-    uint32_t idx = wf.vgpr_alloc().base + *off;
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, true) : *off;
+    uint32_t idx = wf.vgpr_alloc().base + voff;
     wf.cu().write_vgpr(idx, lane, static_cast<uint32_t>(val));
     wf.cu().write_vgpr(idx + 1, lane, static_cast<uint32_t>(val >> 32));
     return;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/vop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/vop1.cpp
@@ -10069,7 +10069,20 @@ void VCvtPkF32Fp8Vop1::execute_impl(amdgpu::Wavefront &wf) {
   }
   if (dpp_src0_)
     src0.set_delegate(dpp_src0_.get());
-  amdgpu::execute_v_cvt_pk_f32_fp8_vop1(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t packed = src0.read_lane(wf, lane);
+    bool src_hi = 0u & 1;
+    uint32_t half = src_hi ? (packed >> 16) : (packed & 0xFFFFu);
+    float lo = util::fp8_e4m3_to_f32(static_cast<uint8_t>(half & 0xFFu));
+    float hi = util::fp8_e4m3_to_f32(static_cast<uint8_t>((half >> 8) & 0xFFu));
+    uint32_t lo_bits = std::bit_cast<uint32_t>(lo);
+    uint32_t hi_bits = std::bit_cast<uint32_t>(hi);
+    vdst.write_lane64(wf, lane,
+                      static_cast<uint64_t>(lo_bits) | (static_cast<uint64_t>(hi_bits) << 32));
+  }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
@@ -10180,7 +10193,20 @@ void VCvtPkF32Bf8Vop1::execute_impl(amdgpu::Wavefront &wf) {
   }
   if (dpp_src0_)
     src0.set_delegate(dpp_src0_.get());
-  amdgpu::execute_v_cvt_pk_f32_bf8_vop1(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t packed = src0.read_lane(wf, lane);
+    bool src_hi = 0u & 1;
+    uint32_t half = src_hi ? (packed >> 16) : (packed & 0xFFFFu);
+    float lo = util::bf8_e5m2_to_f32(static_cast<uint8_t>(half & 0xFFu));
+    float hi = util::bf8_e5m2_to_f32(static_cast<uint8_t>((half >> 8) & 0xFFu));
+    uint32_t lo_bits = std::bit_cast<uint32_t>(lo);
+    uint32_t hi_bits = std::bit_cast<uint32_t>(hi);
+    vdst.write_lane64(wf, lane,
+                      static_cast<uint64_t>(lo_bits) | (static_cast<uint64_t>(hi_bits) << 32));
+  }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/vop3.cpp
@@ -1583,7 +1583,20 @@ VCvtPkF32Fp8Vop3::VCvtPkF32Fp8Vop3(const MachineInst *inst)
 }
 
 void VCvtPkF32Fp8Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cvt_pk_f32_fp8_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t packed = src0.read_lane(wf, lane);
+    bool src_hi = 0u & 1;
+    uint32_t half = src_hi ? (packed >> 16) : (packed & 0xFFFFu);
+    float lo = util::fp8_e4m3_to_f32(static_cast<uint8_t>(half & 0xFFu));
+    float hi = util::fp8_e4m3_to_f32(static_cast<uint8_t>((half >> 8) & 0xFFu));
+    uint32_t lo_bits = std::bit_cast<uint32_t>(lo);
+    uint32_t hi_bits = std::bit_cast<uint32_t>(hi);
+    vdst.write_lane64(wf, lane,
+                      static_cast<uint64_t>(lo_bits) | (static_cast<uint64_t>(hi_bits) << 32));
+  }
 }
 
 VCvtPkF32Bf8Vop3::VCvtPkF32Bf8Vop3(const MachineInst *inst)
@@ -1602,7 +1615,20 @@ VCvtPkF32Bf8Vop3::VCvtPkF32Bf8Vop3(const MachineInst *inst)
 }
 
 void VCvtPkF32Bf8Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cvt_pk_f32_bf8_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t packed = src0.read_lane(wf, lane);
+    bool src_hi = 0u & 1;
+    uint32_t half = src_hi ? (packed >> 16) : (packed & 0xFFFFu);
+    float lo = util::bf8_e5m2_to_f32(static_cast<uint8_t>(half & 0xFFu));
+    float hi = util::bf8_e5m2_to_f32(static_cast<uint8_t>((half >> 8) & 0xFFu));
+    uint32_t lo_bits = std::bit_cast<uint32_t>(lo);
+    uint32_t hi_bits = std::bit_cast<uint32_t>(hi);
+    vdst.write_lane64(wf, lane,
+                      static_cast<uint64_t>(lo_bits) | (static_cast<uint64_t>(hi_bits) << 32));
+  }
 }
 
 VCndmaskB32Vop3::VCndmaskB32Vop3(const MachineInst *inst)
@@ -5558,7 +5584,18 @@ VCvtPkI16F32Vop3::VCvtPkI16F32Vop3(const MachineInst *inst)
 }
 
 void VCvtPkI16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cvt_pk_i16_f32_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t s0 = src0.read_lane(wf, lane);
+    uint32_t s1 = src1.read_lane(wf, lane);
+    int16_t lo = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s0), -32768, 32767));
+    int16_t hi = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s1), -32768, 32767));
+    vdst.write_lane(wf, lane,
+                    (static_cast<uint32_t>(static_cast<uint16_t>(hi)) << 16) |
+                        static_cast<uint32_t>(static_cast<uint16_t>(lo)));
+  }
 }
 
 VCvtPkU16F32Vop3::VCvtPkU16F32Vop3(const MachineInst *inst)
@@ -5583,7 +5620,18 @@ VCvtPkU16F32Vop3::VCvtPkU16F32Vop3(const MachineInst *inst)
 }
 
 void VCvtPkU16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cvt_pk_u16_f32_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t s0 = src0.read_lane(wf, lane);
+    uint32_t s1 = src1.read_lane(wf, lane);
+    int16_t lo = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s0), -32768, 32767));
+    int16_t hi = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s1), -32768, 32767));
+    vdst.write_lane(wf, lane,
+                    (static_cast<uint32_t>(static_cast<uint16_t>(hi)) << 16) |
+                        static_cast<uint32_t>(static_cast<uint16_t>(lo)));
+  }
 }
 
 VMaxU16Vop3::VMaxU16Vop3(const MachineInst *inst)
@@ -6706,7 +6754,22 @@ VCvtPkFp8F32Vop3::VCvtPkFp8F32Vop3(const MachineInst *inst)
 }
 
 void VCvtPkFp8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cvt_pk_fp8_f32_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    float s0 = std::bit_cast<float>(src0.read_lane(wf, lane));
+    float s1 = std::bit_cast<float>(src1.read_lane(wf, lane));
+    uint32_t lo = util::f32_to_fp8_e4m3_rne(s0);
+    uint32_t hi = util::f32_to_fp8_e4m3_rne(s1);
+    uint32_t packed = static_cast<uint32_t>(lo) | (static_cast<uint32_t>(hi) << 8);
+    bool word_hi = (0u >> 3) & 1;
+    uint32_t old = vdst.read_lane(wf, lane);
+    if (word_hi)
+      vdst.write_lane(wf, lane, (old & 0xFFFFu) | (packed << 16));
+    else
+      vdst.write_lane(wf, lane, (old & 0xFFFF0000u) | (packed & 0xFFFFu));
+  }
 }
 
 VCvtPkBf8F32Vop3::VCvtPkBf8F32Vop3(const MachineInst *inst)
@@ -6731,7 +6794,22 @@ VCvtPkBf8F32Vop3::VCvtPkBf8F32Vop3(const MachineInst *inst)
 }
 
 void VCvtPkBf8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cvt_pk_bf8_f32_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    float s0 = std::bit_cast<float>(src0.read_lane(wf, lane));
+    float s1 = std::bit_cast<float>(src1.read_lane(wf, lane));
+    uint32_t lo = util::f32_to_bf8_e5m2_rne(s0);
+    uint32_t hi = util::f32_to_bf8_e5m2_rne(s1);
+    uint32_t packed = static_cast<uint32_t>(lo) | (static_cast<uint32_t>(hi) << 8);
+    bool word_hi = (0u >> 3) & 1;
+    uint32_t old = vdst.read_lane(wf, lane);
+    if (word_hi)
+      vdst.write_lane(wf, lane, (old & 0xFFFFu) | (packed << 16));
+    else
+      vdst.write_lane(wf, lane, (old & 0xFFFF0000u) | (packed & 0xFFFFu));
+  }
 }
 
 VCvtSrFp8F32Vop3::VCvtSrFp8F32Vop3(const MachineInst *inst)
@@ -6757,8 +6835,18 @@ VCvtSrFp8F32Vop3::VCvtSrFp8F32Vop3(const MachineInst *inst)
 }
 
 void VCvtSrFp8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    float s0 = std::bit_cast<float>(static_cast<uint32_t>(src0.read_lane(wf, lane)));
+    uint32_t seed = src1.read_lane(wf, lane);
+    uint8_t result = util::f32_to_fp8_e4m3_sr(s0, seed);
+    uint32_t dst_byte = (inst_.opsel >> 2) & 0x3;
+    uint32_t old = vdst.read_lane(wf, lane);
+    uint32_t mask = ~(0xFFu << (dst_byte * 8));
+    vdst.write_lane(wf, lane, (old & mask) | (static_cast<uint32_t>(result) << (dst_byte * 8)));
+  }
 }
 
 VCvtSrBf8F32Vop3::VCvtSrBf8F32Vop3(const MachineInst *inst)
@@ -6784,8 +6872,18 @@ VCvtSrBf8F32Vop3::VCvtSrBf8F32Vop3(const MachineInst *inst)
 }
 
 void VCvtSrBf8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  (void)wf;
-  throw util::UnimplementedInst(mnemonic());
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    float s0 = std::bit_cast<float>(static_cast<uint32_t>(src0.read_lane(wf, lane)));
+    uint32_t seed = src1.read_lane(wf, lane);
+    uint8_t result = util::f32_to_bf8_e5m2_sr(s0, seed);
+    uint32_t dst_byte = (inst_.opsel >> 2) & 0x3;
+    uint32_t old = vdst.read_lane(wf, lane);
+    uint32_t mask = ~(0xFFu << (dst_byte * 8));
+    vdst.write_lane(wf, lane, (old & mask) | (static_cast<uint32_t>(result) << (dst_byte * 8)));
+  }
 }
 
 VCmpLtF16Vop3::VCmpLtF16Vop3(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/addr_calc_flat.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/addr_calc_flat.h
@@ -43,7 +43,11 @@ void flat_calculate_addresses(const FlatInst &inst, amdgpu::Wavefront &wf, Vecto
   // Compute signed 13-bit offset for GLOBAL/SCRATCH, unsigned 12-bit for FLAT.
   int64_t offset;
   if (inst.seg != 0) {
-    uint32_t raw = inst.offset | (inst.pad_12 << 12);
+    uint32_t raw;
+    if constexpr (requires { inst.pad_12; })
+      raw = inst.offset | (inst.pad_12 << 12);
+    else
+      raw = inst.offset;
     offset = static_cast<int64_t>(static_cast<int32_t>(raw << 19) >> 19);
   } else {
     offset = inst.offset & 0xFFF;
@@ -65,6 +69,8 @@ void flat_calculate_addresses(const FlatInst &inst, amdgpu::Wavefront &wf, Vecto
     bool has_vaddr = true;
     if constexpr (requires { inst.sve; })
       has_vaddr = (inst.sve == 1);
+    else if (inst.seg == 1)
+      has_vaddr = (inst.lds == 1);
     for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
       if (!(exec & (1ULL << lane)))
         continue;
@@ -100,13 +106,23 @@ void flat_calculate_addresses(const FlatInst &inst, amdgpu::Wavefront &wf, Vecto
     }
   } else {
     // FLAT: 64-bit VGPR pair + unsigned 12-bit offset.
+    // Real hardware checks the address against private/shared apertures and
+    // routes accordingly. We perform the same conversion here so that private
+    // (scratch) accesses reach the mapped scratch buffer instead of the
+    // unmapped aperture VA range.
+    uint32_t priv_hi = static_cast<uint32_t>(wf.private_aperture_base() >> 32);
+    uint64_t scratch_base = wf.scratch_base();
+    uint32_t lane_stride = wf.scratch_lane_size();
     for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
       if (!(exec & (1ULL << lane)))
         continue;
       uint32_t vbase = wf.vgpr_alloc().base + inst.addr;
       uint64_t vaddr =
           (static_cast<uint64_t>(cu.read_vgpr(vbase + 1, lane)) << 32) | cu.read_vgpr(vbase, lane);
-      d.per_lane_addr[lane] = vaddr + offset;
+      uint64_t addr = vaddr + offset;
+      if (priv_hi != 0 && static_cast<uint32_t>(addr >> 32) == priv_hi)
+        addr = scratch_base + static_cast<uint64_t>(lane) * lane_stride + (addr & 0xFFFFFFFFULL);
+      d.per_lane_addr[lane] = addr;
     }
   }
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
@@ -2364,15 +2364,30 @@ inline void execute_s_sendmsghalt_sopp([[maybe_unused]] Inst &inst,
 
 template <typename Inst>
 inline void execute_s_set_gpr_idx_idx_sop1([[maybe_unused]] Inst &inst,
-                                           [[maybe_unused]] Wavefront &wf) {}
+                                           [[maybe_unused]] Wavefront &wf) {
+  wf.set_m0((wf.m0() & 0xFFFFFF00u) | (inst.ssrc0.read_scalar(wf) & 0xFF));
+}
 
 template <typename Inst>
 inline void execute_s_set_gpr_idx_mode_sopp([[maybe_unused]] Inst &inst,
-                                            [[maybe_unused]] Wavefront &wf) {}
+                                            [[maybe_unused]] Wavefront &wf) {
+  wf.set_m0((wf.m0() & 0xFFFFF0FFu) | ((inst.simm16.read_scalar(wf) & 0xF) << 8));
+}
 
 template <typename Inst>
 inline void execute_s_set_gpr_idx_off_sopp([[maybe_unused]] Inst &inst,
-                                           [[maybe_unused]] Wavefront &wf) {}
+                                           [[maybe_unused]] Wavefront &wf) {
+  wf.set_mode_raw(wf.mode_raw() & ~Wavefront::GPR_IDX_EN_BIT);
+}
+
+template <typename Inst>
+inline void execute_s_set_gpr_idx_on_sopc([[maybe_unused]] Inst &inst,
+                                          [[maybe_unused]] Wavefront &wf) {
+  uint32_t idx = inst.ssrc0.read_scalar(wf) & 0xFF;
+  uint32_t mode = inst.ssrc1.read_scalar(wf) & 0xF;
+  wf.set_m0((wf.m0() & 0xFFFFF000u) | (mode << 8) | idx);
+  wf.set_mode_raw(wf.mode_raw() | Wavefront::GPR_IDX_EN_BIT);
+}
 
 template <typename Inst>
 inline void execute_s_set_inst_prefetch_distance_sopp([[maybe_unused]] Inst &inst,
@@ -9668,121 +9683,6 @@ inline void execute_v_cvt_off_f32_i4_vop3([[maybe_unused]] Inst &inst,
 }
 
 template <typename Inst>
-inline void execute_v_cvt_pk_bf8_f32_vop3([[maybe_unused]] Inst &inst,
-                                          [[maybe_unused]] Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    float s0 = std::bit_cast<float>(inst.src0.read_lane(wf, lane));
-    float s1 = std::bit_cast<float>(inst.src1.read_lane(wf, lane));
-    uint32_t lo = util::f32_to_bf8_e5m2_rne(s0);
-    uint32_t hi = util::f32_to_bf8_e5m2_rne(s1);
-    inst.vdst.write_lane(wf, lane, lo | (hi << 8));
-  }
-}
-
-template <typename Inst>
-inline void execute_v_cvt_pk_f32_bf8_vop1([[maybe_unused]] Inst &inst,
-                                          [[maybe_unused]] Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t raw = inst.src0.read_lane(wf, lane);
-    float lo = util::bf8_e5m2_to_f32(static_cast<uint8_t>(raw & 0xFFu));
-    float hi = util::bf8_e5m2_to_f32(static_cast<uint8_t>((raw >> 8) & 0xFFu));
-    uint32_t lo_bits = std::bit_cast<uint32_t>(lo);
-    uint32_t hi_bits = std::bit_cast<uint32_t>(hi);
-    inst.vdst.write_lane64(wf, lane,
-                           static_cast<uint64_t>(lo_bits) | (static_cast<uint64_t>(hi_bits) << 32));
-  }
-}
-
-template <typename Inst>
-inline void execute_v_cvt_pk_f32_bf8_vop3([[maybe_unused]] Inst &inst,
-                                          [[maybe_unused]] Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t raw = inst.src0.read_lane(wf, lane);
-    float lo = util::bf8_e5m2_to_f32(static_cast<uint8_t>(raw & 0xFFu));
-    float hi = util::bf8_e5m2_to_f32(static_cast<uint8_t>((raw >> 8) & 0xFFu));
-    uint32_t lo_bits = std::bit_cast<uint32_t>(lo);
-    uint32_t hi_bits = std::bit_cast<uint32_t>(hi);
-    inst.vdst.write_lane64(wf, lane,
-                           static_cast<uint64_t>(lo_bits) | (static_cast<uint64_t>(hi_bits) << 32));
-  }
-}
-
-template <typename Inst>
-inline void execute_v_cvt_pk_f32_fp8_vop1([[maybe_unused]] Inst &inst,
-                                          [[maybe_unused]] Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t raw = inst.src0.read_lane(wf, lane);
-    float lo = util::fp8_e4m3_to_f32(static_cast<uint8_t>(raw & 0xFFu));
-    float hi = util::fp8_e4m3_to_f32(static_cast<uint8_t>((raw >> 8) & 0xFFu));
-    uint32_t lo_bits = std::bit_cast<uint32_t>(lo);
-    uint32_t hi_bits = std::bit_cast<uint32_t>(hi);
-    inst.vdst.write_lane64(wf, lane,
-                           static_cast<uint64_t>(lo_bits) | (static_cast<uint64_t>(hi_bits) << 32));
-  }
-}
-
-template <typename Inst>
-inline void execute_v_cvt_pk_f32_fp8_vop3([[maybe_unused]] Inst &inst,
-                                          [[maybe_unused]] Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t raw = inst.src0.read_lane(wf, lane);
-    float lo = util::fp8_e4m3_to_f32(static_cast<uint8_t>(raw & 0xFFu));
-    float hi = util::fp8_e4m3_to_f32(static_cast<uint8_t>((raw >> 8) & 0xFFu));
-    uint32_t lo_bits = std::bit_cast<uint32_t>(lo);
-    uint32_t hi_bits = std::bit_cast<uint32_t>(hi);
-    inst.vdst.write_lane64(wf, lane,
-                           static_cast<uint64_t>(lo_bits) | (static_cast<uint64_t>(hi_bits) << 32));
-  }
-}
-
-template <typename Inst>
-inline void execute_v_cvt_pk_fp8_f32_vop3([[maybe_unused]] Inst &inst,
-                                          [[maybe_unused]] Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    float s0 = std::bit_cast<float>(inst.src0.read_lane(wf, lane));
-    float s1 = std::bit_cast<float>(inst.src1.read_lane(wf, lane));
-    uint32_t lo = util::f32_to_fp8_e4m3_rne(s0);
-    uint32_t hi = util::f32_to_fp8_e4m3_rne(s1);
-    inst.vdst.write_lane(wf, lane, lo | (hi << 8));
-  }
-}
-
-template <typename Inst>
-inline void execute_v_cvt_pk_i16_f32_vop3([[maybe_unused]] Inst &inst,
-                                          [[maybe_unused]] Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t s0 = inst.src0.read_lane(wf, lane);
-    uint32_t s1 = inst.src1.read_lane(wf, lane);
-    int16_t lo = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s0), -32768, 32767));
-    int16_t hi = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s1), -32768, 32767));
-    inst.vdst.write_lane(wf, lane,
-                         (static_cast<uint32_t>(static_cast<uint16_t>(hi)) << 16) |
-                             static_cast<uint32_t>(static_cast<uint16_t>(lo)));
-  }
-}
-
-template <typename Inst>
 inline void execute_v_cvt_pk_i16_i32_vop3([[maybe_unused]] Inst &inst,
                                           [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOP3_BINARY_INT(uint32_t, [](auto a, auto b) {
@@ -9922,23 +9822,6 @@ inline void execute_v_cvt_pk_rtz_f16_f32_vop3([[maybe_unused]] Inst &inst,
     uint32_t lo = util::f32_to_f16(s0);
     uint32_t hi = util::f32_to_f16(s1);
     inst.vdst.write_lane(wf, lane, lo | (hi << 16));
-  }
-}
-
-template <typename Inst>
-inline void execute_v_cvt_pk_u16_f32_vop3([[maybe_unused]] Inst &inst,
-                                          [[maybe_unused]] Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t s0 = inst.src0.read_lane(wf, lane);
-    uint32_t s1 = inst.src1.read_lane(wf, lane);
-    int16_t lo = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s0), -32768, 32767));
-    int16_t hi = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s1), -32768, 32767));
-    inst.vdst.write_lane(wf, lane,
-                         (static_cast<uint32_t>(static_cast<uint16_t>(hi)) << 16) |
-                             static_cast<uint32_t>(static_cast<uint16_t>(lo)));
   }
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
@@ -208,7 +208,8 @@ private:
           return pt_it->second.host_ptr;
       }
     }
-    if (passthrough_)
+    static constexpr uint64_t kUserSpaceLimit = 0x800000000000ULL;
+    if (passthrough_ && addr < kUserSpaceLimit)
       return reinterpret_cast<uint8_t *>(addr & ~PAGE_MASK);
     return nullptr;
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/wavefront.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/wavefront.h
@@ -206,6 +206,11 @@ public:
   /// @param val New M0 value.
   void set_m0(uint32_t val) { m0_ = val; }
 
+  static constexpr uint32_t GPR_IDX_EN_BIT = 1u << 27;
+  bool gpr_idx_en() const { return mode_raw_ & GPR_IDX_EN_BIT; }
+  uint32_t gpr_idx_offset() const { return m0_ & 0xFF; }
+  uint32_t gpr_idx_mode() const { return (m0_ >> 8) & 0xF; }
+
   /// @brief Return the per-wavefront scratch (private segment) base address.
   /// @returns Byte address in GPU memory where this wavefront's scratch starts.
   uint64_t scratch_base() const { return scratch_base_; }
@@ -513,6 +518,13 @@ private:
 
   friend class ComputeUnitCore; // CU sets allocation fields during dispatch.
 };
+
+inline uint32_t apply_gpr_idx(const Wavefront &wf, uint32_t vgpr_off, bool is_dst) {
+  uint32_t mode = wf.gpr_idx_mode();
+  if ((!is_dst && (mode & 0x7)) || (is_dst && (mode & 0x8)))
+    return vgpr_off + wf.gpr_idx_offset();
+  return vgpr_off;
+}
 
 /// @brief ISA-parameterized concrete wavefront with ISA-specific status register.
 ///

--- a/emulation/rocjitsu/lib/util/include/util/data_types.h
+++ b/emulation/rocjitsu/lib/util/include/util/data_types.h
@@ -23,9 +23,8 @@
 
 namespace util {
 
-// IEEE 754 half-precision (FP16) conversion
+// ---- IEEE 754 half-precision (FP16) ----
 
-/// @brief Convert a 16-bit IEEE 754 half-precision value to float.
 inline float f16_to_f32(uint16_t h) {
   uint32_t sign = (h >> 15) & 1;
   uint32_t exp = (h >> 10) & 0x1F;
@@ -90,60 +89,48 @@ inline void f16_to_f32_block(const uint16_t *src, float *dst, size_t n) {
   for (; i < n; ++i)
     dst[i] = f16_to_f32(src[i]);
 }
-
-/// @brief Convert a float to 16-bit IEEE 754 half-precision.
 inline uint16_t f32_to_f16(float val) {
   uint32_t f = std::bit_cast<uint32_t>(val);
   uint32_t sign = (f >> 16) & 0x8000;
   uint32_t f_exp = (f >> 23) & 0xFF;
   uint32_t f_mant = f & 0x7FFFFF;
 
-  // Inf or NaN.
   if (f_exp == 0xFF) {
     if (f_mant)
-      return static_cast<uint16_t>(sign | 0x7C00 | (f_mant >> 13) |
-                                   1);           // NaN, preserve payload MSBs
-    return static_cast<uint16_t>(sign | 0x7C00); // Inf
+      return static_cast<uint16_t>(sign | 0x7C00 | (f_mant >> 13) | 1);
+    return static_cast<uint16_t>(sign | 0x7C00);
   }
 
-  // Rebias exponent from F32 (bias 127) to F16 (bias 15).
   int32_t exp = static_cast<int32_t>(f_exp) - 127 + 15;
 
-  // F16 denormal or underflow.
   if (exp <= 0) {
     if (exp < -10)
-      return static_cast<uint16_t>(sign); // too small, flush to zero
-    // Denormal: shift mantissa right, add implicit 1-bit.
+      return static_cast<uint16_t>(sign);
     uint32_t mant = f_mant | 0x800000;
-    int shift = 14 - exp; // shift = 14 when exp=0, 24 when exp=-10
+    int shift = 14 - exp;
     uint32_t round_bit = (mant >> (shift - 1)) & 1;
     uint32_t sticky = (mant & ((1u << (shift - 1)) - 1)) ? 1 : 0;
     uint32_t result = mant >> shift;
-    // Round-to-nearest-even.
     result += round_bit & (sticky | (result & 1));
     return static_cast<uint16_t>(sign | result);
   }
 
-  // Overflow → Inf.
   if (exp >= 31)
     return static_cast<uint16_t>(sign | 0x7C00);
 
-  // Normal number: round-to-nearest-even on the 13 truncated mantissa bits.
   uint32_t round_bit = (f_mant >> 12) & 1;
   uint32_t sticky = (f_mant & 0xFFF) ? 1 : 0;
   uint32_t mant = f_mant >> 13;
   mant += round_bit & (sticky | (mant & 1));
-  // Rounding may overflow mantissa into exponent.
   if (mant > 0x3FF) {
     mant = 0;
     exp += 1;
     if (exp >= 31)
-      return static_cast<uint16_t>(sign | 0x7C00); // overflow to Inf
+      return static_cast<uint16_t>(sign | 0x7C00);
   }
   return static_cast<uint16_t>(sign | (static_cast<uint32_t>(exp) << 10) | mant);
 }
 
-/// @brief Convert a float to 16-bit IEEE 754 half-precision, rounding toward zero.
 inline uint16_t f32_to_f16_rtz(float val) {
   uint32_t f = std::bit_cast<uint32_t>(val);
   uint32_t sign = (f >> 16) & 0x8000;
@@ -171,21 +158,18 @@ inline uint16_t f32_to_f16_rtz(float val) {
   return static_cast<uint16_t>(sign | (static_cast<uint32_t>(exp) << 10) | (f_mant >> 13));
 }
 
-// BFloat16 (BF16) conversion
+// ---- BFloat16 (BF16) ----
 
-/// @brief Convert a 16-bit BFloat16 value to float.
 inline float bf16_to_f32(uint16_t h) {
   uint32_t f = static_cast<uint32_t>(h) << 16;
   return std::bit_cast<float>(f);
 }
 
-/// @brief Convert a float to 16-bit BFloat16 (truncation, no rounding).
 inline uint16_t f32_to_bf16(float val) {
   uint32_t f = std::bit_cast<uint32_t>(val);
   return static_cast<uint16_t>(f >> 16);
 }
 
-/// @brief Convert a float to 16-bit BFloat16 with round-to-nearest-even.
 inline uint16_t f32_to_bf16_rne(float val) {
   uint32_t f = std::bit_cast<uint32_t>(val);
   if ((f & 0x7f800000u) != 0x7f800000u) {
@@ -196,9 +180,8 @@ inline uint16_t f32_to_bf16_rne(float val) {
   return static_cast<uint16_t>(f >> 16);
 }
 
-// FP8 (E4M3) conversion - 1 sign, 4 exponent, 3 mantissa bits
+// ---- FP8 E4M3 (OCP E4M3FN) — 1 sign, 4 exponent, 3 mantissa, bias=7 ----
 
-/// @brief Convert an 8-bit E4M3 FP8 value to float.
 inline float fp8_e4m3_to_f32(uint8_t v) {
   uint32_t sign = (v >> 7) & 1;
   uint32_t exp = (v >> 3) & 0xF;
@@ -206,12 +189,14 @@ inline float fp8_e4m3_to_f32(uint8_t v) {
   if (exp == 0 && mant == 0)
     return std::bit_cast<float>(sign << 31);
   if (exp == 15) {
-    // E4M3FN has a single NaN encoding when exponent and mantissa are all ones.
+    // OCP E4M3FN: NaN only when exp=15 AND mant=7 (0x7F/0xFF)
     if (mant == 7)
       return std::bit_cast<float>((sign << 31) | 0x7FC00000u);
+    // exp=15, mant=0..6 → normal values (256..448)
+    uint32_t f = (sign << 31) | ((15 + 127 - 7) << 23) | (mant << 20);
+    return std::bit_cast<float>(f);
   }
   if (exp == 0) {
-    // Denormalized
     float result = std::ldexp(static_cast<float>(mant), -9);
     return sign ? -result : result;
   }
@@ -219,7 +204,6 @@ inline float fp8_e4m3_to_f32(uint8_t v) {
   return std::bit_cast<float>(f);
 }
 
-/// @brief Convert a float to 8-bit E4M3 FP8 (truncation).
 inline uint8_t f32_to_fp8_e4m3(float val) {
   uint32_t f = std::bit_cast<uint32_t>(val);
   uint32_t sign = (f >> 24) & 0x80;
@@ -232,36 +216,91 @@ inline uint8_t f32_to_fp8_e4m3(float val) {
   return static_cast<uint8_t>(sign | (static_cast<uint32_t>(exp) << 3) | mant);
 }
 
-/// @brief Convert a float to 8-bit E4M3FN FP8 with round-to-nearest-even.
 inline uint8_t f32_to_fp8_e4m3_rne(float val) {
-  uint32_t bits = std::bit_cast<uint32_t>(val);
-  uint8_t sign = static_cast<uint8_t>((bits >> 24) & 0x80u);
-  uint32_t abs_bits = bits & 0x7FFFFFFFu;
-  if (abs_bits > 0x7F800000u)
-    return static_cast<uint8_t>(sign | 0x7Fu);
-  if (abs_bits == 0x7F800000u)
-    return static_cast<uint8_t>(sign | 0x7Fu);
-
-  float abs_val = std::bit_cast<float>(abs_bits);
-  if (abs_val > 464.0f)
-    return static_cast<uint8_t>(sign | 0x7Fu);
-
-  uint8_t best = 0;
-  float best_diff = std::numeric_limits<float>::infinity();
-  for (uint8_t code = 0; code <= 0x7Eu; ++code) {
-    float candidate = fp8_e4m3_to_f32(code);
-    float diff = std::fabs(abs_val - candidate);
-    if (diff < best_diff || (diff == best_diff && ((code & 1u) == 0u) && ((best & 1u) != 0u))) {
-      best = code;
-      best_diff = diff;
+  uint32_t f = std::bit_cast<uint32_t>(val);
+  uint32_t sign = (f >> 24) & 0x80;
+  if (std::isnan(val))
+    return static_cast<uint8_t>(sign | 0x7F);
+  int32_t f_exp = static_cast<int32_t>((f >> 23) & 0xFF);
+  uint32_t f_mant = f & 0x7FFFFF;
+  if (f_exp == 0xFF)
+    return static_cast<uint8_t>(sign | 0x7E);
+  int32_t exp = f_exp - 127 + 7;
+  if (exp <= 0) {
+    if (exp < -3)
+      return static_cast<uint8_t>(sign);
+    uint32_t mant = f_mant | 0x800000;
+    int shift = 21 - exp;
+    if (shift > 23)
+      return static_cast<uint8_t>(sign);
+    uint32_t round_bit = (mant >> (shift - 1)) & 1;
+    uint32_t sticky = (mant & ((1u << (shift - 1)) - 1)) ? 1 : 0;
+    uint32_t result = mant >> shift;
+    result += round_bit & (sticky | (result & 1));
+    if (result >= 8) {
+      return static_cast<uint8_t>(sign | (1 << 3));
     }
+    return static_cast<uint8_t>(sign | (result & 0x7));
   }
-  return static_cast<uint8_t>(sign | best);
+  if (exp > 15)
+    return static_cast<uint8_t>(sign | 0x7E);
+  uint32_t round_bit = (f_mant >> 19) & 1;
+  uint32_t sticky = (f_mant & 0x7FFFF) ? 1 : 0;
+  uint32_t mant = (f_mant >> 20) & 0x7;
+  mant += round_bit & (sticky | (mant & 1));
+  if (mant > 0x7) {
+    mant = 0;
+    exp += 1;
+  }
+  if (exp > 15 || (exp == 15 && mant >= 7))
+    return static_cast<uint8_t>(sign | 0x7E);
+  return static_cast<uint8_t>(sign | (static_cast<uint32_t>(exp) << 3) | mant);
 }
 
-// BF8 (E5M2) conversion - 1 sign, 5 exponent, 2 mantissa bits
+inline uint8_t f32_to_fp8_e4m3_sr(float val, uint32_t seed) {
+  if (std::isnan(val))
+    return static_cast<uint8_t>((std::bit_cast<uint32_t>(val) >> 24) & 0x80) | 0x7F;
+  uint32_t f = std::bit_cast<uint32_t>(val);
+  uint32_t sign = (f >> 24) & 0x80;
+  int32_t f_exp = static_cast<int32_t>((f >> 23) & 0xFF);
+  uint32_t f_mant = f & 0x7FFFFF;
+  if (f_exp == 0xFF)
+    return static_cast<uint8_t>(sign | 0x7E);
+  int32_t exp = f_exp - 127 + 7;
+  if (exp <= 0) {
+    uint32_t full_mant = f_mant | 0x800000;
+    int shift = 21 - exp;
+    if (shift > 24)
+      return static_cast<uint8_t>(sign);
+    uint32_t result = full_mant >> shift;
+    uint32_t trunc_mask = (1u << shift) - 1;
+    uint32_t trunc_bits = full_mant & trunc_mask;
+    uint32_t random_add = seed >> (32 - shift);
+    if ((trunc_bits + random_add) >= (1u << shift))
+      result += 1;
+    if (result >= 8)
+      return static_cast<uint8_t>(sign | (1 << 3));
+    return static_cast<uint8_t>(sign | (result & 0x7));
+  }
+  if (exp > 15)
+    return static_cast<uint8_t>(sign | 0x7E);
+  uint32_t trunc_bits = f_mant & 0xFFFFF;
+  uint32_t random_add = seed >> 12;
+  uint32_t mant = (f_mant >> 20) & 0x7;
+  if ((trunc_bits + random_add) > 0xFFFFF) {
+    mant += 1;
+    if (mant > 0x7) {
+      mant = 0;
+      exp += 1;
+    }
+  }
+  if (exp > 15 || (exp == 15 && mant >= 7))
+    return static_cast<uint8_t>(sign | 0x7E);
+  return static_cast<uint8_t>(sign | (static_cast<uint32_t>(exp) << 3) | mant);
+}
 
-/// @brief Convert an 8-bit E5M2 BF8 value to float.
+// ---- BF8 E5M2 — 1 sign, 5 exponent, 2 mantissa, bias=15 ----
+
 inline float bf8_e5m2_to_f32(uint8_t v) {
   uint32_t sign = (v >> 7) & 1;
   uint32_t exp = (v >> 2) & 0x1F;
@@ -271,7 +310,7 @@ inline float bf8_e5m2_to_f32(uint8_t v) {
   if (exp == 31) {
     if (mant != 0)
       return std::bit_cast<float>((sign << 31) | 0x7FC00000u);
-    return std::bit_cast<float>((sign << 31) | 0x7F800000u); // infinity
+    return std::bit_cast<float>((sign << 31) | 0x7F800000u);
   }
   if (exp == 0) {
     float result = std::ldexp(static_cast<float>(mant), -16);
@@ -281,7 +320,6 @@ inline float bf8_e5m2_to_f32(uint8_t v) {
   return std::bit_cast<float>(f);
 }
 
-/// @brief Convert a float to 8-bit E5M2 BF8 (truncation).
 inline uint8_t f32_to_bf8_e5m2(float val) {
   uint32_t f = std::bit_cast<uint32_t>(val);
   uint32_t sign = (f >> 24) & 0x80;
@@ -294,32 +332,89 @@ inline uint8_t f32_to_bf8_e5m2(float val) {
   return static_cast<uint8_t>(sign | (static_cast<uint32_t>(exp) << 2) | mant);
 }
 
-/// @brief Convert a float to 8-bit E5M2 BF8 with round-to-nearest-even.
 inline uint8_t f32_to_bf8_e5m2_rne(float val) {
-  uint32_t bits = std::bit_cast<uint32_t>(val);
-  uint8_t sign = static_cast<uint8_t>((bits >> 24) & 0x80u);
-  uint32_t abs_bits = bits & 0x7FFFFFFFu;
-  if (abs_bits > 0x7F800000u)
-    return static_cast<uint8_t>(sign | 0x7Fu);
-  if (abs_bits == 0x7F800000u)
-    return static_cast<uint8_t>(sign | 0x7Cu);
+  uint32_t f = std::bit_cast<uint32_t>(val);
+  uint32_t sign = (f >> 24) & 0x80;
+  if (std::isnan(val))
+    return static_cast<uint8_t>(sign | 0x7F);
+  int32_t f_exp = static_cast<int32_t>((f >> 23) & 0xFF);
+  uint32_t f_mant = f & 0x7FFFFF;
+  if (f_exp == 0xFF)
+    return static_cast<uint8_t>(sign | 0x7C);
+  int32_t exp = f_exp - 127 + 15;
+  if (exp <= 0) {
+    if (exp < -1)
+      return static_cast<uint8_t>(sign);
+    uint32_t mant = f_mant | 0x800000;
+    int shift = 22 - exp;
+    if (shift > 23)
+      return static_cast<uint8_t>(sign);
+    uint32_t round_bit = (mant >> (shift - 1)) & 1;
+    uint32_t sticky = (mant & ((1u << (shift - 1)) - 1)) ? 1 : 0;
+    uint32_t result = mant >> shift;
+    result += round_bit & (sticky | (result & 1));
+    if (result >= 4)
+      return static_cast<uint8_t>(sign | (1 << 2));
+    return static_cast<uint8_t>(sign | (result & 0x3));
+  }
+  if (exp >= 31)
+    return static_cast<uint8_t>(sign | 0x7C);
+  uint32_t round_bit = (f_mant >> 20) & 1;
+  uint32_t sticky = (f_mant & 0xFFFFF) ? 1 : 0;
+  uint32_t mant = (f_mant >> 21) & 0x3;
+  mant += round_bit & (sticky | (mant & 1));
+  if (mant > 0x3) {
+    mant = 0;
+    exp += 1;
+    if (exp >= 31)
+      return static_cast<uint8_t>(sign | 0x7C);
+  }
+  return static_cast<uint8_t>(sign | (static_cast<uint32_t>(exp) << 2) | mant);
+}
 
-  float abs_val = std::bit_cast<float>(abs_bits);
-  if (abs_val >= 61440.0f)
-    return static_cast<uint8_t>(sign | 0x7Cu);
-
-  uint8_t best = 0;
-  float best_diff = std::numeric_limits<float>::infinity();
-  for (uint8_t code = 0; code <= 0x7Bu; ++code) {
-    float candidate = bf8_e5m2_to_f32(code);
-    float diff = std::fabs(abs_val - candidate);
-    if (diff < best_diff || (diff == best_diff && ((code & 1u) == 0u) && ((best & 1u) != 0u))) {
-      best = code;
-      best_diff = diff;
+inline uint8_t f32_to_bf8_e5m2_sr(float val, uint32_t seed) {
+  if (std::isnan(val))
+    return static_cast<uint8_t>((std::bit_cast<uint32_t>(val) >> 24) & 0x80) | 0x7F;
+  uint32_t f = std::bit_cast<uint32_t>(val);
+  uint32_t sign = (f >> 24) & 0x80;
+  int32_t f_exp = static_cast<int32_t>((f >> 23) & 0xFF);
+  uint32_t f_mant = f & 0x7FFFFF;
+  if (f_exp == 0xFF)
+    return static_cast<uint8_t>(sign | 0x7C);
+  int32_t exp = f_exp - 127 + 15;
+  if (exp <= 0) {
+    uint32_t full_mant = f_mant | 0x800000;
+    int shift = 22 - exp;
+    if (shift > 24)
+      return static_cast<uint8_t>(sign);
+    uint32_t result = full_mant >> shift;
+    uint32_t trunc_mask = (1u << shift) - 1;
+    uint32_t trunc_bits = full_mant & trunc_mask;
+    uint32_t random_add = seed >> (32 - shift);
+    if ((trunc_bits + random_add) >= (1u << shift))
+      result += 1;
+    if (result >= 4)
+      return static_cast<uint8_t>(sign | (1 << 2));
+    return static_cast<uint8_t>(sign | (result & 0x3));
+  }
+  if (exp >= 31)
+    return static_cast<uint8_t>(sign | 0x7C);
+  uint32_t trunc_bits = f_mant & 0x1FFFFF;
+  uint32_t random_add = seed >> 11;
+  uint32_t mant = (f_mant >> 21) & 0x3;
+  if ((trunc_bits + random_add) > 0x1FFFFF) {
+    mant += 1;
+    if (mant > 0x3) {
+      mant = 0;
+      exp += 1;
+      if (exp >= 31)
+        return static_cast<uint8_t>(sign | 0x7C);
     }
   }
-  return static_cast<uint8_t>(sign | best);
+  return static_cast<uint8_t>(sign | (static_cast<uint32_t>(exp) << 2) | mant);
 }
+
+// ---- Generalized SR + OCP MX helpers (used by gfx1250 WMMA) ----
 
 inline uint32_t f32_to_binary_float_sr(float val, uint32_t seed, uint32_t exp_bits,
                                        uint32_t mant_bits, int32_t bias, int32_t max_exp,
@@ -379,30 +474,16 @@ inline uint32_t f32_to_binary_float_sr(float val, uint32_t seed, uint32_t exp_bi
   return sign | (biased_exp << mant_bits) | mant;
 }
 
-/// @brief Convert a float to 16-bit IEEE 754 half-precision with stochastic rounding.
 inline uint16_t f32_to_f16_sr(float val, uint32_t seed) {
   return static_cast<uint16_t>(
       f32_to_binary_float_sr(val, seed, 5, 10, 15, 15, -14, 0x7FFFu, 0x7C00u));
 }
 
-/// @brief Convert a float to 16-bit BFloat16 with stochastic rounding.
 inline uint16_t f32_to_bf16_sr(float val, uint32_t seed) {
   return static_cast<uint16_t>(
       f32_to_binary_float_sr(val, seed, 8, 7, 127, 127, -126, 0x7FFFu, 0x7F80u));
 }
 
-/// @brief Convert a float to 8-bit E4M3FN FP8 with stochastic rounding.
-inline uint8_t f32_to_fp8_e4m3_sr(float val, uint32_t seed) {
-  return static_cast<uint8_t>(f32_to_binary_float_sr(val, seed, 4, 3, 7, 8, -6, 0x7Fu, 0x7Fu));
-}
-
-/// @brief Convert a float to 8-bit E5M2 BF8 with stochastic rounding.
-inline uint8_t f32_to_bf8_e5m2_sr(float val, uint32_t seed) {
-  return static_cast<uint8_t>(f32_to_binary_float_sr(val, seed, 5, 2, 15, 15, -14, 0x7Fu, 0x7Cu));
-}
-
-// OCP MX low-precision formats used by gfx1250 WMMA matrix format fields.
-// Encoding parameters match HIP's amd_hip_ocp_host.hpp fallback model.
 inline float ocp_mx_to_f32(uint32_t raw, uint32_t exp_bits, uint32_t mant_bits, int32_t bias) {
   uint32_t sign = (raw >> (exp_bits + mant_bits)) & 1;
   uint32_t exp = (raw >> mant_bits) & ((1u << exp_bits) - 1u);
@@ -449,38 +530,342 @@ inline uint8_t f32_to_ocp_mx_rne(float val, uint32_t exp_bits, uint32_t mant_bit
   return static_cast<uint8_t>(sign | best);
 }
 
-/// @brief Convert a 4-bit OCP FP4 E2M1 value to float.
-inline float fp4_e2m1_to_f32(uint8_t v) { return ocp_mx_to_f32(v & 0xFu, 2, 1, 1); }
+// ---- FP4 E2M1 — 1 sign, 2 exponent, 1 mantissa, bias=1, no NaN/Inf, max=6.0 ----
 
-/// @brief Convert a float to 4-bit OCP FP4 E2M1 with round-to-nearest-even.
-inline uint8_t f32_to_fp4_e2m1_rne(float v) { return f32_to_ocp_mx_rne(v, 2, 1, 1); }
-
-/// @brief Convert a float to 4-bit OCP FP4 E2M1 with stochastic rounding.
-inline uint8_t f32_to_fp4_e2m1_sr(float v, uint32_t seed) {
-  return static_cast<uint8_t>(f32_to_binary_float_sr(v, seed, 2, 1, 1, 2, 0, 0x7u, 0x7u));
+inline float fp4_e2m1_to_f32(uint8_t v) {
+  uint32_t sign = (v >> 3) & 1;
+  uint32_t exp = (v >> 1) & 0x3;
+  uint32_t mant = v & 0x1;
+  if (exp == 0 && mant == 0)
+    return std::bit_cast<float>(sign << 31);
+  if (exp == 0) {
+    float result = 0.5f;
+    return sign ? -result : result;
+  }
+  uint32_t f = (sign << 31) | ((exp + 127 - 1) << 23) | (mant << 22);
+  return std::bit_cast<float>(f);
 }
 
-/// @brief Convert a 6-bit OCP FP6 E2M3 value to float.
-inline float fp6_e2m3_to_f32(uint8_t v) { return ocp_mx_to_f32(v & 0x3Fu, 2, 3, 1); }
-
-/// @brief Convert a float to 6-bit OCP FP6 E2M3 with round-to-nearest-even.
-inline uint8_t f32_to_fp6_e2m3_rne(float v) { return f32_to_ocp_mx_rne(v, 2, 3, 1); }
-
-/// @brief Convert a float to 6-bit OCP FP6 E2M3 with stochastic rounding.
-inline uint8_t f32_to_fp6_e2m3_sr(float v, uint32_t seed) {
-  return static_cast<uint8_t>(f32_to_binary_float_sr(v, seed, 2, 3, 1, 2, 0, 0x3Fu, 0x3Fu));
+inline uint8_t f32_to_fp4_e2m1_rne(float val) {
+  if (std::isnan(val))
+    return 0;
+  uint32_t f = std::bit_cast<uint32_t>(val);
+  uint32_t sign = (f >> 28) & 0x8;
+  if (std::isinf(val))
+    return static_cast<uint8_t>(sign | 0x7);
+  float absval = std::fabs(val);
+  if (absval > 6.0f)
+    return static_cast<uint8_t>(sign | 0x7);
+  if (absval < 0.25f)
+    return static_cast<uint8_t>(sign);
+  int32_t f_exp = static_cast<int32_t>((f >> 23) & 0xFF);
+  uint32_t f_mant = f & 0x7FFFFF;
+  int32_t exp = f_exp - 127 + 1;
+  if (exp <= 0) {
+    uint32_t full_mant = f_mant | 0x800000;
+    int shift = 23 - exp;
+    if (shift > 23)
+      return static_cast<uint8_t>(sign);
+    uint32_t round_bit = (full_mant >> (shift - 1)) & 1;
+    uint32_t sticky = (full_mant & ((1u << (shift - 1)) - 1)) ? 1 : 0;
+    uint32_t result = full_mant >> shift;
+    result += round_bit & (sticky | (result & 1));
+    if (result >= 2)
+      return static_cast<uint8_t>(sign | (1 << 1));
+    return static_cast<uint8_t>(sign | (result & 0x1));
+  }
+  if (exp > 3)
+    return static_cast<uint8_t>(sign | 0x7);
+  uint32_t round_bit = (f_mant >> 21) & 1;
+  uint32_t sticky = (f_mant & 0x1FFFFF) ? 1 : 0;
+  uint32_t mant = (f_mant >> 22) & 0x1;
+  mant += round_bit & (sticky | (mant & 1));
+  if (mant > 1) {
+    mant = 0;
+    exp += 1;
+    if (exp > 3)
+      return static_cast<uint8_t>(sign | 0x7);
+  }
+  return static_cast<uint8_t>(sign | (static_cast<uint32_t>(exp) << 1) | mant);
 }
 
-/// @brief Convert a 6-bit OCP BF6 E3M2 value to float.
-inline float bf6_e3m2_to_f32(uint8_t v) { return ocp_mx_to_f32(v & 0x3Fu, 3, 2, 3); }
-
-/// @brief Convert a float to 6-bit OCP BF6 E3M2 with round-to-nearest-even.
-inline uint8_t f32_to_bf6_e3m2_rne(float v) { return f32_to_ocp_mx_rne(v, 3, 2, 3); }
-
-/// @brief Convert a float to 6-bit OCP BF6 E3M2 with stochastic rounding.
-inline uint8_t f32_to_bf6_e3m2_sr(float v, uint32_t seed) {
-  return static_cast<uint8_t>(f32_to_binary_float_sr(v, seed, 3, 2, 3, 4, -2, 0x3Fu, 0x3Fu));
+inline uint8_t f32_to_fp4_e2m1_sr(float val, uint32_t seed) {
+  if (std::isnan(val))
+    return 0;
+  uint32_t f = std::bit_cast<uint32_t>(val);
+  uint32_t sign = (f >> 28) & 0x8;
+  if (std::isinf(val) || std::fabs(val) > 6.0f)
+    return static_cast<uint8_t>(sign | 0x7);
+  if (std::fabs(val) < 0.25f)
+    return static_cast<uint8_t>(sign);
+  int32_t f_exp = static_cast<int32_t>((f >> 23) & 0xFF);
+  uint32_t f_mant = f & 0x7FFFFF;
+  int32_t exp = f_exp - 127 + 1;
+  if (exp <= 0) {
+    uint32_t full_mant = f_mant | 0x800000;
+    int shift = 23 - exp;
+    if (shift > 24)
+      return static_cast<uint8_t>(sign);
+    uint32_t result = full_mant >> shift;
+    uint32_t trunc_mask = (1u << shift) - 1;
+    uint32_t trunc_bits = full_mant & trunc_mask;
+    uint32_t random_add = seed >> (32 - shift);
+    if ((trunc_bits + random_add) >= (1u << shift))
+      result += 1;
+    if (result >= 2)
+      return static_cast<uint8_t>(sign | (1 << 1));
+    return static_cast<uint8_t>(sign | (result & 0x1));
+  }
+  if (exp > 3)
+    return static_cast<uint8_t>(sign | 0x7);
+  uint32_t trunc_bits = f_mant & 0x3FFFFF;
+  uint32_t random_add = seed >> 10;
+  uint32_t mant = (f_mant >> 22) & 0x1;
+  if ((trunc_bits + random_add) > 0x3FFFFF) {
+    mant += 1;
+    if (mant > 1) {
+      mant = 0;
+      exp += 1;
+      if (exp > 3)
+        return static_cast<uint8_t>(sign | 0x7);
+    }
+  }
+  return static_cast<uint8_t>(sign | (static_cast<uint32_t>(exp) << 1) | mant);
 }
+
+// ---- FP6 E2M3 — 1 sign, 2 exponent, 3 mantissa, bias=1, no NaN/Inf, max=7.5 ----
+
+inline float fp6_e2m3_to_f32(uint8_t v) {
+  uint32_t sign = (v >> 5) & 1;
+  uint32_t exp = (v >> 3) & 0x3;
+  uint32_t mant = v & 0x7;
+  if (exp == 0 && mant == 0)
+    return std::bit_cast<float>(sign << 31);
+  if (exp == 0) {
+    float result = std::ldexp(static_cast<float>(mant), -3);
+    return sign ? -result : result;
+  }
+  uint32_t f = (sign << 31) | ((exp + 127 - 1) << 23) | (mant << 20);
+  return std::bit_cast<float>(f);
+}
+
+inline uint8_t f32_to_fp6_e2m3_rne(float val) {
+  if (std::isnan(val))
+    return 0;
+  uint32_t f = std::bit_cast<uint32_t>(val);
+  uint32_t sign = (f >> 26) & 0x20;
+  if (std::isinf(val) || std::fabs(val) > 7.5f)
+    return static_cast<uint8_t>(sign | 0x1F);
+  float absval = std::fabs(val);
+  if (absval < std::ldexp(1.0f, -4))
+    return static_cast<uint8_t>(sign);
+  int32_t f_exp = static_cast<int32_t>((f >> 23) & 0xFF);
+  uint32_t f_mant = f & 0x7FFFFF;
+  int32_t exp = f_exp - 127 + 1;
+  if (exp <= 0) {
+    uint32_t full_mant = f_mant | 0x800000;
+    int shift = 21 - exp;
+    if (shift > 23)
+      return static_cast<uint8_t>(sign);
+    uint32_t round_bit = (full_mant >> (shift - 1)) & 1;
+    uint32_t sticky = (full_mant & ((1u << (shift - 1)) - 1)) ? 1 : 0;
+    uint32_t result = full_mant >> shift;
+    result += round_bit & (sticky | (result & 1));
+    if (result >= 8)
+      return static_cast<uint8_t>(sign | (1 << 3));
+    return static_cast<uint8_t>(sign | (result & 0x7));
+  }
+  if (exp > 3)
+    return static_cast<uint8_t>(sign | 0x1F);
+  uint32_t round_bit = (f_mant >> 19) & 1;
+  uint32_t sticky = (f_mant & 0x7FFFF) ? 1 : 0;
+  uint32_t mant = (f_mant >> 20) & 0x7;
+  mant += round_bit & (sticky | (mant & 1));
+  if (mant > 0x7) {
+    mant = 0;
+    exp += 1;
+    if (exp > 3)
+      return static_cast<uint8_t>(sign | 0x1F);
+  }
+  return static_cast<uint8_t>(sign | (static_cast<uint32_t>(exp) << 3) | mant);
+}
+
+inline uint8_t f32_to_fp6_e2m3_sr(float val, uint32_t seed) {
+  if (std::isnan(val))
+    return 0;
+  uint32_t f = std::bit_cast<uint32_t>(val);
+  uint32_t sign = (f >> 26) & 0x20;
+  if (std::isinf(val) || std::fabs(val) > 7.5f)
+    return static_cast<uint8_t>(sign | 0x1F);
+  if (std::fabs(val) < std::ldexp(1.0f, -4))
+    return static_cast<uint8_t>(sign);
+  int32_t f_exp = static_cast<int32_t>((f >> 23) & 0xFF);
+  uint32_t f_mant = f & 0x7FFFFF;
+  int32_t exp = f_exp - 127 + 1;
+  if (exp <= 0) {
+    uint32_t full_mant = f_mant | 0x800000;
+    int shift = 21 - exp;
+    if (shift > 24)
+      return static_cast<uint8_t>(sign);
+    uint32_t result = full_mant >> shift;
+    uint32_t trunc_mask = (1u << shift) - 1;
+    uint32_t trunc_bits = full_mant & trunc_mask;
+    uint32_t random_add = seed >> (32 - shift);
+    if ((trunc_bits + random_add) >= (1u << shift))
+      result += 1;
+    if (result >= 8)
+      return static_cast<uint8_t>(sign | (1 << 3));
+    return static_cast<uint8_t>(sign | (result & 0x7));
+  }
+  if (exp > 3)
+    return static_cast<uint8_t>(sign | 0x1F);
+  uint32_t trunc_bits = f_mant & 0xFFFFF;
+  uint32_t random_add = seed >> 12;
+  uint32_t mant = (f_mant >> 20) & 0x7;
+  if ((trunc_bits + random_add) > 0xFFFFF) {
+    mant += 1;
+    if (mant > 0x7) {
+      mant = 0;
+      exp += 1;
+      if (exp > 3)
+        return static_cast<uint8_t>(sign | 0x1F);
+    }
+  }
+  return static_cast<uint8_t>(sign | (static_cast<uint32_t>(exp) << 3) | mant);
+}
+
+// ---- BF6 E3M2 — 1 sign, 3 exponent, 2 mantissa, bias=3, no NaN/Inf, max=28.0 ----
+
+inline float bf6_e3m2_to_f32(uint8_t v) {
+  uint32_t sign = (v >> 5) & 1;
+  uint32_t exp = (v >> 2) & 0x7;
+  uint32_t mant = v & 0x3;
+  if (exp == 0 && mant == 0)
+    return std::bit_cast<float>(sign << 31);
+  if (exp == 0) {
+    float result = std::ldexp(static_cast<float>(mant), -4);
+    return sign ? -result : result;
+  }
+  uint32_t f = (sign << 31) | ((exp + 127 - 3) << 23) | (mant << 21);
+  return std::bit_cast<float>(f);
+}
+
+inline uint8_t f32_to_bf6_e3m2_rne(float val) {
+  if (std::isnan(val))
+    return 0;
+  uint32_t f = std::bit_cast<uint32_t>(val);
+  uint32_t sign = (f >> 26) & 0x20;
+  if (std::isinf(val) || std::fabs(val) > 28.0f)
+    return static_cast<uint8_t>(sign | 0x1F);
+  float absval = std::fabs(val);
+  if (absval < std::ldexp(1.0f, -5))
+    return static_cast<uint8_t>(sign);
+  int32_t f_exp = static_cast<int32_t>((f >> 23) & 0xFF);
+  uint32_t f_mant = f & 0x7FFFFF;
+  int32_t exp = f_exp - 127 + 3;
+  if (exp <= 0) {
+    uint32_t full_mant = f_mant | 0x800000;
+    int shift = 22 - exp;
+    if (shift > 23)
+      return static_cast<uint8_t>(sign);
+    uint32_t round_bit = (full_mant >> (shift - 1)) & 1;
+    uint32_t sticky = (full_mant & ((1u << (shift - 1)) - 1)) ? 1 : 0;
+    uint32_t result = full_mant >> shift;
+    result += round_bit & (sticky | (result & 1));
+    if (result >= 4)
+      return static_cast<uint8_t>(sign | (1 << 2));
+    return static_cast<uint8_t>(sign | (result & 0x3));
+  }
+  if (exp > 7)
+    return static_cast<uint8_t>(sign | 0x1F);
+  uint32_t round_bit = (f_mant >> 20) & 1;
+  uint32_t sticky = (f_mant & 0xFFFFF) ? 1 : 0;
+  uint32_t mant = (f_mant >> 21) & 0x3;
+  mant += round_bit & (sticky | (mant & 1));
+  if (mant > 0x3) {
+    mant = 0;
+    exp += 1;
+    if (exp > 7)
+      return static_cast<uint8_t>(sign | 0x1F);
+  }
+  return static_cast<uint8_t>(sign | (static_cast<uint32_t>(exp) << 2) | mant);
+}
+
+inline uint8_t f32_to_bf6_e3m2_sr(float val, uint32_t seed) {
+  if (std::isnan(val))
+    return 0;
+  uint32_t f = std::bit_cast<uint32_t>(val);
+  uint32_t sign = (f >> 26) & 0x20;
+  if (std::isinf(val) || std::fabs(val) > 28.0f)
+    return static_cast<uint8_t>(sign | 0x1F);
+  if (std::fabs(val) < std::ldexp(1.0f, -5))
+    return static_cast<uint8_t>(sign);
+  int32_t f_exp = static_cast<int32_t>((f >> 23) & 0xFF);
+  uint32_t f_mant = f & 0x7FFFFF;
+  int32_t exp = f_exp - 127 + 3;
+  if (exp <= 0) {
+    uint32_t full_mant = f_mant | 0x800000;
+    int shift = 22 - exp;
+    if (shift > 24)
+      return static_cast<uint8_t>(sign);
+    uint32_t result = full_mant >> shift;
+    uint32_t trunc_mask = (1u << shift) - 1;
+    uint32_t trunc_bits = full_mant & trunc_mask;
+    uint32_t random_add = seed >> (32 - shift);
+    if ((trunc_bits + random_add) >= (1u << shift))
+      result += 1;
+    if (result >= 4)
+      return static_cast<uint8_t>(sign | (1 << 2));
+    return static_cast<uint8_t>(sign | (result & 0x3));
+  }
+  if (exp > 7)
+    return static_cast<uint8_t>(sign | 0x1F);
+  uint32_t trunc_bits = f_mant & 0x1FFFFF;
+  uint32_t random_add = seed >> 11;
+  uint32_t mant = (f_mant >> 21) & 0x3;
+  if ((trunc_bits + random_add) > 0x1FFFFF) {
+    mant += 1;
+    if (mant > 0x3) {
+      mant = 0;
+      exp += 1;
+      if (exp > 7)
+        return static_cast<uint8_t>(sign | 0x1F);
+    }
+  }
+  return static_cast<uint8_t>(sign | (static_cast<uint32_t>(exp) << 2) | mant);
+}
+
+// ---- 6-bit packing/unpacking (32×6-bit values ↔ 6 DWORDs, little-endian) ----
+
+inline void pack_6bit(const uint8_t vals[32], uint32_t dwords[6]) {
+  for (int d = 0; d < 6; ++d)
+    dwords[d] = 0;
+  for (int i = 0; i < 32; ++i) {
+    uint64_t bit_offset = static_cast<uint64_t>(i) * 6;
+    uint32_t dw_idx = static_cast<uint32_t>(bit_offset / 32);
+    uint32_t bit_pos = static_cast<uint32_t>(bit_offset % 32);
+    uint32_t val6 = vals[i] & 0x3F;
+    dwords[dw_idx] |= val6 << bit_pos;
+    if (bit_pos > 26)
+      dwords[dw_idx + 1] |= val6 >> (32 - bit_pos);
+  }
+}
+
+inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {
+  for (int i = 0; i < 32; ++i) {
+    uint64_t bit_offset = static_cast<uint64_t>(i) * 6;
+    uint32_t dw_idx = static_cast<uint32_t>(bit_offset / 32);
+    uint32_t bit_pos = static_cast<uint32_t>(bit_offset % 32);
+    uint32_t val = (dwords[dw_idx] >> bit_pos) & 0x3F;
+    if (bit_pos > 26)
+      val |= (dwords[dw_idx + 1] << (32 - bit_pos)) & 0x3F;
+    vals[i] = static_cast<uint8_t>(val);
+  }
+}
+
+// ---- Stochastic rounding LFSR ----
+
+inline uint32_t prng_advance(uint32_t seed) { return (seed << 1) ^ ((seed >> 31) ? 197u : 0u); }
 
 } // namespace util
 

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -102,6 +102,7 @@ add_executable(
     execution_plugin_test.cpp
     race-detector/race_detector_tests.cpp
     race-detector/interval_set_tests.cpp
+    data_types_test.cpp
 )
 target_link_libraries(
     rocjitsu_tests
@@ -725,4 +726,28 @@ if(HIPCC_EXECUTABLE AND HSA_RUNTIME64)
     message(STATUS "HIP tests enabled (found ${HIPCC_EXECUTABLE})")
 else()
     message(STATUS "HIP tests disabled (hipcc or libhsa-runtime64 not found)")
+endif()
+
+# --- Narrow conversion HIP CTS tests ---
+# Uses hipcc (rocjitsu emulator does not yet support amdclang++ -x hip binaries).
+if(HIPCC_EXECUTABLE AND HSA_RUNTIME64)
+    set(CVT_NARROW_BIN ${CMAKE_CURRENT_BINARY_DIR}/hip_cvt_narrow_test)
+    add_custom_command(
+        OUTPUT ${CVT_NARROW_BIN}
+        COMMAND
+            ${HIPCC_EXECUTABLE} --offload-arch=gfx950 -std=c++20
+            -I${CMAKE_SOURCE_DIR}/lib/util/include -o ${CVT_NARROW_BIN}
+            ${CMAKE_CURRENT_SOURCE_DIR}/hip_cvt_narrow_test.cpp
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/hip_cvt_narrow_test.cpp
+        COMMENT "Building hip_cvt_narrow_test with hipcc (gfx950)"
+        VERBATIM
+    )
+    add_custom_target(hip_cvt_narrow_test_target ALL DEPENDS ${CVT_NARROW_BIN})
+    add_dependencies(hip_cvt_narrow_test_target rocjitsu_bin rocjitsu_kmd_shim)
+
+    add_test(
+        NAME "CvtNarrow.AllTests"
+        COMMAND ${RJ_CLI} --config ${RJ_CDNA4_KMD_CONFIG} -- ${CVT_NARROW_BIN}
+    )
+    set_tests_properties("CvtNarrow.AllTests" PROPERTIES TIMEOUT 300)
 endif()

--- a/emulation/rocjitsu/tests/data_types_test.cpp
+++ b/emulation/rocjitsu/tests/data_types_test.cpp
@@ -1,0 +1,337 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "util/data_types.h"
+
+#include <gtest/gtest.h>
+
+#include <bit>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+
+namespace {
+
+// ---- FP4 E2M1 (exhaustive — 16 values) ----
+
+// Hardcoded truth table for positive FP4 E2M1 codes (independent of data_types.h).
+// FP4 E2M1: 1s+2e+1m, bias=1, no NaN/Inf, max=6.0
+// code -> value: exp=0 denorm: 0.0, 0.5; exp=1..3 normal: (1+m)*2^(exp-1)
+static constexpr float kFp4TruthPositive[8] = {
+    0.0f, 0.5f, 1.0f, 1.5f, 2.0f, 3.0f, 4.0f, 6.0f,
+};
+
+TEST(Fp4E2M1, ExhaustiveWiden) {
+  for (uint8_t code = 0; code < 8; ++code) {
+    EXPECT_EQ(util::fp4_e2m1_to_f32(code), kFp4TruthPositive[code]) << "code=" << int(code);
+    float neg = util::fp4_e2m1_to_f32(code | 0x8);
+    if (code == 0)
+      EXPECT_TRUE(std::signbit(neg) && neg == 0.0f);
+    else
+      EXPECT_EQ(neg, -kFp4TruthPositive[code]) << "neg code=" << int(code);
+  }
+}
+
+TEST(Fp4E2M1, RneRoundTrip) {
+  for (uint8_t code = 0; code < 8; ++code) {
+    float val = kFp4TruthPositive[code];
+    uint8_t narrow = util::f32_to_fp4_e2m1_rne(val);
+    EXPECT_EQ(narrow, code) << "code=" << int(code) << " val=" << val;
+  }
+}
+
+TEST(Fp4E2M1, RneEdgeCases) {
+  EXPECT_EQ(util::f32_to_fp4_e2m1_rne(std::numeric_limits<float>::quiet_NaN()), 0);
+  EXPECT_EQ(util::f32_to_fp4_e2m1_rne(std::numeric_limits<float>::infinity()), 0x7);
+  EXPECT_EQ(util::f32_to_fp4_e2m1_rne(-std::numeric_limits<float>::infinity()), 0xF);
+  EXPECT_EQ(util::f32_to_fp4_e2m1_rne(7.0f), 0x7);
+  EXPECT_EQ(util::f32_to_fp4_e2m1_rne(100.0f), 0x7);
+  // 4.0 must map to code 0x6 (exp=3, mant=0), NOT saturate to 6.0
+  EXPECT_EQ(util::f32_to_fp4_e2m1_rne(4.0f), 0x6);
+}
+
+TEST(Fp4E2M1, SrDeterministic) {
+  uint8_t r = util::f32_to_fp4_e2m1_sr(1.0f, 0);
+  EXPECT_EQ(r, 0x2);
+  r = util::f32_to_fp4_e2m1_sr(6.0f, 0xFFFFFFFF);
+  EXPECT_EQ(r, 0x7);
+}
+
+// ---- FP6 E2M3 (exhaustive — 64 values) ----
+
+static float fp6_reference(uint8_t code) {
+  uint32_t sign = (code >> 5) & 1;
+  uint32_t exp = (code >> 3) & 0x3;
+  uint32_t mant = code & 0x7;
+  if (exp == 0 && mant == 0)
+    return sign ? -0.0f : 0.0f;
+  if (exp == 0) {
+    float v = std::ldexp(static_cast<float>(mant), -3);
+    return sign ? -v : v;
+  }
+  uint32_t f = (sign << 31) | ((exp + 127 - 1) << 23) | (mant << 20);
+  return std::bit_cast<float>(f);
+}
+
+TEST(Fp6E2M3, ExhaustiveWiden) {
+  for (uint8_t code = 0; code < 64; ++code) {
+    float got = util::fp6_e2m3_to_f32(code);
+    float ref = fp6_reference(code);
+    EXPECT_EQ(std::bit_cast<uint32_t>(got), std::bit_cast<uint32_t>(ref)) << "code=" << int(code);
+  }
+}
+
+TEST(Fp6E2M3, RneRoundTrip) {
+  for (uint8_t code = 0; code < 32; ++code) {
+    float val = util::fp6_e2m3_to_f32(code);
+    uint8_t narrow = util::f32_to_fp6_e2m3_rne(val);
+    EXPECT_EQ(narrow, code) << "code=" << int(code) << " val=" << val;
+  }
+}
+
+TEST(Fp6E2M3, RneEdgeCases) {
+  EXPECT_EQ(util::f32_to_fp6_e2m3_rne(std::numeric_limits<float>::quiet_NaN()), 0);
+  EXPECT_EQ(util::f32_to_fp6_e2m3_rne(std::numeric_limits<float>::infinity()), 0x1F);
+  EXPECT_EQ(util::f32_to_fp6_e2m3_rne(10.0f), 0x1F);
+  // 4.0 maps to exp=3, mant=0 (code 0x18)
+  EXPECT_EQ(util::f32_to_fp6_e2m3_rne(4.0f), 0x18);
+}
+
+TEST(Fp6E2M3, SrDeterministic) {
+  uint8_t r = util::f32_to_fp6_e2m3_sr(1.0f, 0);
+  EXPECT_EQ(r, 0x08);
+}
+
+TEST(Fp6E2M3, SrDenormRoundTrip) {
+  for (uint8_t code = 1; code < 8; ++code) {
+    float val = util::fp6_e2m3_to_f32(code);
+    uint8_t narrow = util::f32_to_fp6_e2m3_sr(val, 0);
+    EXPECT_EQ(narrow, code) << "code=" << int(code) << " val=" << val;
+  }
+}
+
+// ---- BF6 E3M2 (exhaustive — 64 values) ----
+
+static float bf6_reference(uint8_t code) {
+  uint32_t sign = (code >> 5) & 1;
+  uint32_t exp = (code >> 2) & 0x7;
+  uint32_t mant = code & 0x3;
+  if (exp == 0 && mant == 0)
+    return sign ? -0.0f : 0.0f;
+  if (exp == 0) {
+    float v = std::ldexp(static_cast<float>(mant), -4);
+    return sign ? -v : v;
+  }
+  uint32_t f = (sign << 31) | ((exp + 127 - 3) << 23) | (mant << 21);
+  return std::bit_cast<float>(f);
+}
+
+TEST(Bf6E3M2, ExhaustiveWiden) {
+  for (uint8_t code = 0; code < 64; ++code) {
+    float got = util::bf6_e3m2_to_f32(code);
+    float ref = bf6_reference(code);
+    EXPECT_EQ(std::bit_cast<uint32_t>(got), std::bit_cast<uint32_t>(ref)) << "code=" << int(code);
+  }
+}
+
+TEST(Bf6E3M2, RneRoundTrip) {
+  for (uint8_t code = 0; code < 32; ++code) {
+    float val = util::bf6_e3m2_to_f32(code);
+    uint8_t narrow = util::f32_to_bf6_e3m2_rne(val);
+    EXPECT_EQ(narrow, code) << "code=" << int(code) << " val=" << val;
+  }
+}
+
+TEST(Bf6E3M2, RneEdgeCases) {
+  EXPECT_EQ(util::f32_to_bf6_e3m2_rne(std::numeric_limits<float>::quiet_NaN()), 0);
+  EXPECT_EQ(util::f32_to_bf6_e3m2_rne(std::numeric_limits<float>::infinity()), 0x1F);
+  EXPECT_EQ(util::f32_to_bf6_e3m2_rne(50.0f), 0x1F);
+  // 16.0 maps to exp=7, mant=0 (code 0x1C)
+  EXPECT_EQ(util::f32_to_bf6_e3m2_rne(16.0f), 0x1C);
+}
+
+TEST(Bf6E3M2, SrDeterministic) {
+  uint8_t r = util::f32_to_bf6_e3m2_sr(1.0f, 0);
+  EXPECT_EQ(r, 0x0C);
+}
+
+TEST(Bf6E3M2, SrDenormRoundTrip) {
+  for (uint8_t code = 1; code < 4; ++code) {
+    float val = util::bf6_e3m2_to_f32(code);
+    uint8_t narrow = util::f32_to_bf6_e3m2_sr(val, 0);
+    EXPECT_EQ(narrow, code) << "code=" << int(code) << " val=" << val;
+  }
+}
+
+// ---- FP8 E4M3 (OCP E4M3FN) ----
+
+TEST(Fp8E4M3, KeyValues) {
+  EXPECT_EQ(util::fp8_e4m3_to_f32(0x00), 0.0f);
+  EXPECT_EQ(util::fp8_e4m3_to_f32(0x38), 1.0f);
+  EXPECT_EQ(util::fp8_e4m3_to_f32(0x7E), 448.0f);
+  EXPECT_TRUE(std::isnan(util::fp8_e4m3_to_f32(0x7F)));
+  EXPECT_TRUE(std::isnan(util::fp8_e4m3_to_f32(0xFF)));
+  // exp=15, mant=0..6 are valid normals (256..448)
+  EXPECT_FALSE(std::isnan(util::fp8_e4m3_to_f32(0x78)));
+  EXPECT_EQ(util::fp8_e4m3_to_f32(0x78), 256.0f);
+  EXPECT_EQ(util::fp8_e4m3_to_f32(0x79), 288.0f);
+}
+
+TEST(Fp8E4M3, RneNarrow) {
+  EXPECT_EQ(util::f32_to_fp8_e4m3_rne(std::numeric_limits<float>::quiet_NaN()), 0x7F);
+  EXPECT_EQ(util::f32_to_fp8_e4m3_rne(std::numeric_limits<float>::infinity()), 0x7E);
+  EXPECT_EQ(util::f32_to_fp8_e4m3_rne(0.0f), 0x00);
+  EXPECT_EQ(util::f32_to_fp8_e4m3_rne(1.0f), 0x38);
+  EXPECT_EQ(util::f32_to_fp8_e4m3_rne(448.0f), 0x7E);
+  EXPECT_EQ(util::f32_to_fp8_e4m3_rne(500.0f), 0x7E);
+  // Denorm overflow: largest denorm (code 7 = 7*2^-9) rounds up to
+  // smallest normal (code 8 = 2^-6) for values just above midpoint.
+  float largest_denorm = util::fp8_e4m3_to_f32(0x07);
+  float smallest_normal = util::fp8_e4m3_to_f32(0x08);
+  float midpoint = (largest_denorm + smallest_normal) / 2.0f;
+  EXPECT_EQ(util::f32_to_fp8_e4m3_rne(midpoint + 1e-9f), 0x08);
+}
+
+TEST(Fp8E4M3, RneExp15) {
+  // exp=15, mant=0..6 are valid normals: 256, 288, 320, 352, 384, 416, 448
+  static constexpr float kExp15Values[] = {256.0f, 288.0f, 320.0f, 352.0f, 384.0f, 416.0f, 448.0f};
+  for (int m = 0; m < 7; ++m) {
+    uint8_t code = 0x78 | m;
+    EXPECT_EQ(util::fp8_e4m3_to_f32(code), kExp15Values[m]) << "decode m=" << m;
+    EXPECT_EQ(util::f32_to_fp8_e4m3_rne(kExp15Values[m]), code) << "encode m=" << m;
+  }
+  // 272.0 is midpoint between 256 (m=0) and 288 (m=1) — RNE to even (m=0)
+  EXPECT_EQ(util::f32_to_fp8_e4m3_rne(272.0f), 0x78);
+  // 280.0 > midpoint(272), rounds up to 288
+  EXPECT_EQ(util::f32_to_fp8_e4m3_rne(280.0f), 0x79);
+  // 304.0 is midpoint between 288 (m=1) and 320 (m=2) — RNE to even (m=2)
+  EXPECT_EQ(util::f32_to_fp8_e4m3_rne(304.0f), 0x7A);
+  // Values above 448 saturate to 0x7E (max finite, not NaN 0x7F)
+  EXPECT_EQ(util::f32_to_fp8_e4m3_rne(449.0f), 0x7E);
+  EXPECT_EQ(util::f32_to_fp8_e4m3_rne(1000.0f), 0x7E);
+}
+
+TEST(Fp8E4M3, SrExp15) {
+  // Exact exp=15 values should round-trip with seed=0
+  static constexpr float kExp15Values[] = {256.0f, 288.0f, 320.0f, 352.0f, 384.0f, 416.0f, 448.0f};
+  for (int m = 0; m < 7; ++m) {
+    uint8_t code = 0x78 | m;
+    EXPECT_EQ(util::f32_to_fp8_e4m3_sr(kExp15Values[m], 0), code) << "sr m=" << m;
+  }
+  // Values above max saturate to 0x7E
+  EXPECT_EQ(util::f32_to_fp8_e4m3_sr(500.0f, 0), 0x7E);
+  EXPECT_EQ(util::f32_to_fp8_e4m3_sr(500.0f, 0xFFFFFFFF), 0x7E);
+}
+
+TEST(Fp8E4M3, SrNarrow) {
+  uint8_t r = util::f32_to_fp8_e4m3_sr(1.0f, 0);
+  EXPECT_EQ(r, 0x38);
+  EXPECT_EQ(util::f32_to_fp8_e4m3_sr(std::numeric_limits<float>::quiet_NaN(), 0), 0x7F);
+  EXPECT_EQ(util::f32_to_fp8_e4m3_sr(std::numeric_limits<float>::infinity(), 0), 0x7E);
+}
+
+TEST(Fp8E4M3, SrDenormRoundTrip) {
+  for (uint8_t code = 1; code < 8; ++code) {
+    float val = util::fp8_e4m3_to_f32(code);
+    uint8_t narrow = util::f32_to_fp8_e4m3_sr(val, 0);
+    EXPECT_EQ(narrow, code) << "code=" << int(code) << " val=" << val;
+  }
+}
+
+// ---- BF8 E5M2 ----
+
+TEST(Bf8E5M2, KeyValues) {
+  EXPECT_EQ(util::bf8_e5m2_to_f32(0x00), 0.0f);
+  EXPECT_EQ(util::bf8_e5m2_to_f32(0x3C), 1.0f);
+  EXPECT_TRUE(std::isinf(util::bf8_e5m2_to_f32(0x7C)));
+  EXPECT_TRUE(std::isnan(util::bf8_e5m2_to_f32(0x7F)));
+  EXPECT_EQ(util::bf8_e5m2_to_f32(0x7B), 57344.0f);
+}
+
+TEST(Bf8E5M2, RneNarrow) {
+  EXPECT_EQ(util::f32_to_bf8_e5m2_rne(std::numeric_limits<float>::quiet_NaN()), 0x7F);
+  EXPECT_EQ(util::f32_to_bf8_e5m2_rne(std::numeric_limits<float>::infinity()), 0x7C);
+  EXPECT_EQ(util::f32_to_bf8_e5m2_rne(0.0f), 0x00);
+  EXPECT_EQ(util::f32_to_bf8_e5m2_rne(1.0f), 0x3C);
+}
+
+TEST(Bf8E5M2, SrNarrow) {
+  EXPECT_EQ(util::f32_to_bf8_e5m2_sr(1.0f, 0), 0x3C);
+  EXPECT_EQ(util::f32_to_bf8_e5m2_sr(std::numeric_limits<float>::quiet_NaN(), 0), 0x7F);
+  EXPECT_EQ(util::f32_to_bf8_e5m2_sr(std::numeric_limits<float>::infinity(), 0), 0x7C);
+}
+
+TEST(Bf8E5M2, SrDenormRoundTrip) {
+  for (uint8_t code = 1; code < 4; ++code) {
+    float val = util::bf8_e5m2_to_f32(code);
+    uint8_t narrow = util::f32_to_bf8_e5m2_sr(val, 0);
+    EXPECT_EQ(narrow, code) << "code=" << int(code) << " val=" << val;
+  }
+}
+
+// ---- FP16 ----
+
+TEST(Fp16, RoundTrip) {
+  auto rt = [](float v) { return util::f16_to_f32(util::f32_to_f16(v)); };
+  EXPECT_EQ(rt(0.0f), 0.0f);
+  EXPECT_EQ(rt(1.0f), 1.0f);
+  EXPECT_EQ(rt(65504.0f), 65504.0f);
+  EXPECT_TRUE(std::isinf(rt(std::numeric_limits<float>::infinity())));
+  EXPECT_TRUE(std::isnan(rt(std::numeric_limits<float>::quiet_NaN())));
+  EXPECT_TRUE(std::signbit(rt(-0.0f)));
+}
+
+// ---- BF16 ----
+
+TEST(Bf16, RoundTrip) {
+  auto rt = [](float v) { return util::bf16_to_f32(util::f32_to_bf16(v)); };
+  EXPECT_EQ(rt(0.0f), 0.0f);
+  EXPECT_EQ(rt(1.0f), 1.0f);
+  EXPECT_TRUE(std::signbit(rt(-0.0f)));
+}
+
+// ---- 6-bit pack/unpack ----
+
+TEST(Pack6Bit, RoundTrip) {
+  uint8_t vals[32];
+  for (int i = 0; i < 32; ++i)
+    vals[i] = static_cast<uint8_t>(i * 2);
+  uint32_t dwords[6];
+  util::pack_6bit(vals, dwords);
+  uint8_t unpacked[32];
+  util::unpack_6bit(dwords, unpacked);
+  for (int i = 0; i < 32; ++i)
+    EXPECT_EQ(unpacked[i], vals[i] & 0x3F) << "i=" << i;
+}
+
+TEST(Pack6Bit, AllOnes) {
+  uint8_t vals[32];
+  for (int i = 0; i < 32; ++i)
+    vals[i] = 0x3F;
+  uint32_t dwords[6];
+  util::pack_6bit(vals, dwords);
+  uint8_t unpacked[32];
+  util::unpack_6bit(dwords, unpacked);
+  for (int i = 0; i < 32; ++i)
+    EXPECT_EQ(unpacked[i], 0x3F) << "i=" << i;
+}
+
+// ---- PRNG LFSR ----
+
+TEST(PrngAdvance, KnownSequence) {
+  uint32_t s = 1;
+  s = util::prng_advance(s);
+  EXPECT_EQ(s, 2u);
+  s = util::prng_advance(s);
+  EXPECT_EQ(s, 4u);
+}
+
+TEST(PrngAdvance, ZeroFixedPoint) { EXPECT_EQ(util::prng_advance(0), 0u); }
+
+TEST(PrngAdvance, HighBitSet) {
+  uint32_t s = 0x80000000u;
+  s = util::prng_advance(s);
+  EXPECT_EQ(s, 197u);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/hip_cvt_narrow_test.cpp
+++ b/emulation/rocjitsu/tests/hip_cvt_narrow_test.cpp
@@ -1,0 +1,680 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <hip/hip_runtime.h>
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+#include "util/data_types.h"
+
+#define HIP_CHECK(e)                                                                               \
+  do {                                                                                             \
+    hipError_t e_ = (e);                                                                           \
+    if (e_ != hipSuccess) {                                                                        \
+      printf("HIP error %d: %s at %s:%d\n", e_, hipGetErrorString(e_), __FILE__, __LINE__);        \
+      return 1;                                                                                    \
+    }                                                                                              \
+  } while (0)
+
+// Vector types for builtins (ext_vector_type, not HIP vector types).
+using v2f = float __attribute__((ext_vector_type(2)));
+using v2s = short __attribute__((ext_vector_type(2)));
+using v16f = float __attribute__((ext_vector_type(16)));
+using v32f = float __attribute__((ext_vector_type(32)));
+using v6u = unsigned __attribute__((ext_vector_type(6)));
+
+static int g_pass = 0;
+static int g_fail = 0;
+static int g_skip = 0;
+
+static void pass(const char *name) {
+  printf("[  PASS  ] %s\n", name);
+  g_pass++;
+}
+static void fail(const char *name, const char *msg) {
+  printf("[  FAIL  ] %s: %s\n", name, msg);
+  g_fail++;
+}
+static void skip(const char *name) {
+  printf("[  SKIP  ] %s\n", name);
+  g_skip++;
+}
+
+static bool have_device() {
+  int n = 0;
+  return hipGetDeviceCount(&n) == hipSuccess && n > 0;
+}
+
+// ---- Non-scaled FP8 kernels ----
+
+__global__ void k_pk_fp8_f32(float a, float b, int *out) {
+  *out = __builtin_amdgcn_cvt_pk_fp8_f32(a, b, 0, false);
+}
+
+__global__ void k_pk_bf8_f32(float a, float b, int *out) {
+  *out = __builtin_amdgcn_cvt_pk_bf8_f32(a, b, 0, false);
+}
+
+__global__ void k_pk_f32_fp8(int src, float *out) {
+  v2f r = __builtin_amdgcn_cvt_pk_f32_fp8(src, false);
+  out[0] = r[0];
+  out[1] = r[1];
+}
+
+__global__ void k_pk_f32_bf8(int src, float *out) {
+  v2f r = __builtin_amdgcn_cvt_pk_f32_bf8(src, false);
+  out[0] = r[0];
+  out[1] = r[1];
+}
+
+__global__ void k_sr_fp8_f32(float val, int rnd, int *out) {
+  *out = __builtin_amdgcn_cvt_sr_fp8_f32(val, rnd, 0, 0);
+}
+
+__global__ void k_sr_bf8_f32(float val, int rnd, int *out) {
+  *out = __builtin_amdgcn_cvt_sr_bf8_f32(val, rnd, 0, 0);
+}
+
+// ---- Scaled FP8/BF8 kernels ----
+
+__global__ void k_scalef32_pk_fp8_f32(float a, float b, float scale, unsigned *out) {
+  v2s zero = {0, 0};
+  v2s r = __builtin_amdgcn_cvt_scalef32_pk_fp8_f32(zero, a, b, scale, false);
+  unsigned packed;
+  __builtin_memcpy(&packed, &r, sizeof(packed));
+  *out = packed;
+}
+
+__global__ void k_scalef32_pk_bf8_f32(float a, float b, float scale, unsigned *out) {
+  v2s zero = {0, 0};
+  v2s r = __builtin_amdgcn_cvt_scalef32_pk_bf8_f32(zero, a, b, scale, false);
+  unsigned packed;
+  __builtin_memcpy(&packed, &r, sizeof(packed));
+  *out = packed;
+}
+
+__global__ void k_scalef32_pk_f32_fp8(unsigned src, float scale, float *out) {
+  v2f r = __builtin_amdgcn_cvt_scalef32_pk_f32_fp8(src, scale, false);
+  out[0] = r[0];
+  out[1] = r[1];
+}
+
+__global__ void k_scalef32_pk_f32_bf8(unsigned src, float scale, float *out) {
+  v2f r = __builtin_amdgcn_cvt_scalef32_pk_f32_bf8(src, scale, false);
+  out[0] = r[0];
+  out[1] = r[1];
+}
+
+template <int BYTE> __global__ void k_scalef32_f32_fp8(unsigned src, float scale, float *out) {
+  out[0] = __builtin_amdgcn_cvt_scalef32_f32_fp8(src, scale, BYTE);
+}
+
+__global__ void k_scalef32_sr_fp8_f32(float val, unsigned rnd, float scale, int *out) {
+  *out = __builtin_amdgcn_cvt_scalef32_sr_fp8_f32(0, val, rnd, scale, 0);
+}
+
+__global__ void k_scalef32_sr_bf8_f32(float val, unsigned rnd, float scale, int *out) {
+  *out = __builtin_amdgcn_cvt_scalef32_sr_bf8_f32(0, val, rnd, scale, 0);
+}
+
+// ---- Scaled FP4 kernels ----
+
+__global__ void k_scalef32_pk_fp4_f32(float a, float b, float scale, int *out) {
+  *out = __builtin_amdgcn_cvt_scalef32_pk_fp4_f32(0, a, b, scale, 0);
+}
+
+__global__ void k_scalef32_pk_f32_fp4(unsigned src, float scale, float *out) {
+  v2f r = __builtin_amdgcn_cvt_scalef32_pk_f32_fp4(src, scale, 0);
+  out[0] = r[0];
+  out[1] = r[1];
+}
+
+__global__ void k_scalef32_sr_pk_fp4_f32(float a, float b, unsigned seed, float scale, int *out) {
+  v2f data = {a, b};
+  *out = __builtin_amdgcn_cvt_scalef32_sr_pk_fp4_f32(0, data, seed, scale, 0);
+}
+
+// ---- Wide FP6/BF6 kernels ----
+
+__global__ void k_scalef32_2xpk16_fp6_f32(const float *in, unsigned *out, float scale) {
+  v16f lo, hi;
+  for (int i = 0; i < 16; ++i) {
+    lo[i] = in[i];
+    hi[i] = in[16 + i];
+  }
+  v6u r = __builtin_amdgcn_cvt_scalef32_2xpk16_fp6_f32(lo, hi, scale);
+  for (int i = 0; i < 6; ++i)
+    out[i] = r[i];
+}
+
+__global__ void k_scalef32_pk32_f32_fp6(const unsigned *in, float *out, float scale) {
+  v6u src;
+  for (int i = 0; i < 6; ++i)
+    src[i] = in[i];
+  v32f r = __builtin_amdgcn_cvt_scalef32_pk32_f32_fp6(src, scale);
+  for (int i = 0; i < 32; ++i)
+    out[i] = r[i];
+}
+
+__global__ void k_scalef32_2xpk16_bf6_f32(const float *in, unsigned *out, float scale) {
+  v16f lo, hi;
+  for (int i = 0; i < 16; ++i) {
+    lo[i] = in[i];
+    hi[i] = in[16 + i];
+  }
+  v6u r = __builtin_amdgcn_cvt_scalef32_2xpk16_bf6_f32(lo, hi, scale);
+  for (int i = 0; i < 6; ++i)
+    out[i] = r[i];
+}
+
+__global__ void k_scalef32_pk32_f32_bf6(const unsigned *in, float *out, float scale) {
+  v6u src;
+  for (int i = 0; i < 6; ++i)
+    src[i] = in[i];
+  v32f r = __builtin_amdgcn_cvt_scalef32_pk32_f32_bf6(src, scale);
+  for (int i = 0; i < 32; ++i)
+    out[i] = r[i];
+}
+
+// ---- Device memory helpers ----
+
+template <class T> static T *alloc_dev(size_t n) {
+  T *d = nullptr;
+  (void)hipMalloc(&d, n * sizeof(T));
+  return d;
+}
+
+template <class T> static T read_dev(const T *d) {
+  T h;
+  (void)hipMemcpy(&h, d, sizeof(T), hipMemcpyDeviceToHost);
+  return h;
+}
+
+template <class T> static void write_dev(T *d, const T &val) {
+  (void)hipMemcpy(d, &val, sizeof(T), hipMemcpyHostToDevice);
+}
+
+template <class T> static std::vector<T> read_dev_vec(const T *d, size_t n) {
+  std::vector<T> h(n);
+  (void)hipMemcpy(h.data(), d, n * sizeof(T), hipMemcpyDeviceToHost);
+  return h;
+}
+
+template <class T> static T *to_dev(const std::vector<T> &h) {
+  T *d = alloc_dev<T>(h.size());
+  (void)hipMemcpy(d, h.data(), h.size() * sizeof(T), hipMemcpyHostToDevice);
+  return d;
+}
+
+// ---- Test implementations ----
+
+static int test_nonscaled_pk_fp8_f32() {
+  int *dO = alloc_dev<int>(1);
+  k_pk_fp8_f32<<<1, 1>>>(1.0f, 2.0f, dO);
+  HIP_CHECK(hipDeviceSynchronize());
+  int result = read_dev(dO);
+  uint8_t lo = result & 0xFF;
+  uint8_t hi = (result >> 8) & 0xFF;
+  uint8_t exp_lo = util::f32_to_fp8_e4m3_rne(1.0f);
+  uint8_t exp_hi = util::f32_to_fp8_e4m3_rne(2.0f);
+  (void)hipFree(dO);
+  if (lo != exp_lo || hi != exp_hi) {
+    printf("  got lo=%02x hi=%02x, expected lo=%02x hi=%02x\n", lo, hi, exp_lo, exp_hi);
+    return 1;
+  }
+  return 0;
+}
+
+static int test_nonscaled_pk_bf8_f32() {
+  int *dO = alloc_dev<int>(1);
+  k_pk_bf8_f32<<<1, 1>>>(1.0f, 2.0f, dO);
+  HIP_CHECK(hipDeviceSynchronize());
+  int result = read_dev(dO);
+  uint8_t lo = result & 0xFF;
+  uint8_t hi = (result >> 8) & 0xFF;
+  uint8_t exp_lo = util::f32_to_bf8_e5m2_rne(1.0f);
+  uint8_t exp_hi = util::f32_to_bf8_e5m2_rne(2.0f);
+  (void)hipFree(dO);
+  if (lo != exp_lo || hi != exp_hi) {
+    printf("  got lo=%02x hi=%02x, expected lo=%02x hi=%02x\n", lo, hi, exp_lo, exp_hi);
+    return 1;
+  }
+  return 0;
+}
+
+static int test_nonscaled_pk_f32_fp8() {
+  float *dO = alloc_dev<float>(2);
+  uint8_t fp8_1 = util::f32_to_fp8_e4m3_rne(1.0f);
+  uint8_t fp8_2 = util::f32_to_fp8_e4m3_rne(2.0f);
+  int packed = fp8_1 | (fp8_2 << 8);
+  k_pk_f32_fp8<<<1, 1>>>(packed, dO);
+  HIP_CHECK(hipDeviceSynchronize());
+  auto got = read_dev_vec(dO, 2);
+  (void)hipFree(dO);
+  if (got[0] != 1.0f || got[1] != 2.0f) {
+    printf("  got [%f, %f], expected [1.0, 2.0]\n", got[0], got[1]);
+    return 1;
+  }
+  return 0;
+}
+
+static int test_nonscaled_pk_f32_bf8() {
+  float *dO = alloc_dev<float>(2);
+  uint8_t bf8_1 = util::f32_to_bf8_e5m2_rne(1.0f);
+  uint8_t bf8_2 = util::f32_to_bf8_e5m2_rne(2.0f);
+  int packed = bf8_1 | (bf8_2 << 8);
+  k_pk_f32_bf8<<<1, 1>>>(packed, dO);
+  HIP_CHECK(hipDeviceSynchronize());
+  auto got = read_dev_vec(dO, 2);
+  (void)hipFree(dO);
+  if (got[0] != 1.0f || got[1] != 2.0f) {
+    printf("  got [%f, %f], expected [1.0, 2.0]\n", got[0], got[1]);
+    return 1;
+  }
+  return 0;
+}
+
+static int test_nonscaled_sr_fp8_f32() {
+  int *dO = alloc_dev<int>(1);
+  k_sr_fp8_f32<<<1, 1>>>(1.0f, 0, dO);
+  HIP_CHECK(hipDeviceSynchronize());
+  int result = read_dev(dO);
+  uint8_t got = result & 0xFF;
+  uint8_t expected = util::f32_to_fp8_e4m3_sr(1.0f, 0);
+  (void)hipFree(dO);
+  if (got != expected) {
+    printf("  got %02x, expected %02x\n", got, expected);
+    return 1;
+  }
+  return 0;
+}
+
+static int test_nonscaled_sr_bf8_f32() {
+  int *dO = alloc_dev<int>(1);
+  k_sr_bf8_f32<<<1, 1>>>(1.0f, 0, dO);
+  HIP_CHECK(hipDeviceSynchronize());
+  int result = read_dev(dO);
+  uint8_t got = result & 0xFF;
+  uint8_t expected = util::f32_to_bf8_e5m2_sr(1.0f, 0);
+  (void)hipFree(dO);
+  if (got != expected) {
+    printf("  got %02x, expected %02x\n", got, expected);
+    return 1;
+  }
+  return 0;
+}
+
+// ---- Scaled FP8 tests ----
+
+static int test_scaled_pk_fp8_f32() {
+  unsigned *dO = alloc_dev<unsigned>(1);
+  k_scalef32_pk_fp8_f32<<<1, 1>>>(1.0f, 2.0f, 1.0f, dO);
+  HIP_CHECK(hipDeviceSynchronize());
+  unsigned packed = read_dev(dO);
+  uint8_t lo = packed & 0xFF;
+  uint8_t hi = (packed >> 8) & 0xFF;
+  uint8_t exp_lo = util::f32_to_fp8_e4m3_rne(1.0f);
+  uint8_t exp_hi = util::f32_to_fp8_e4m3_rne(2.0f);
+  (void)hipFree(dO);
+  if (lo != exp_lo || hi != exp_hi) {
+    printf("  got lo=%02x hi=%02x, expected lo=%02x hi=%02x\n", lo, hi, exp_lo, exp_hi);
+    return 1;
+  }
+  return 0;
+}
+
+static int test_scaled_pk_bf8_f32() {
+  unsigned *dO = alloc_dev<unsigned>(1);
+  k_scalef32_pk_bf8_f32<<<1, 1>>>(1.0f, 2.0f, 1.0f, dO);
+  HIP_CHECK(hipDeviceSynchronize());
+  unsigned packed = read_dev(dO);
+  uint8_t lo = packed & 0xFF;
+  uint8_t hi = (packed >> 8) & 0xFF;
+  uint8_t exp_lo = util::f32_to_bf8_e5m2_rne(1.0f);
+  uint8_t exp_hi = util::f32_to_bf8_e5m2_rne(2.0f);
+  (void)hipFree(dO);
+  if (lo != exp_lo || hi != exp_hi) {
+    printf("  got lo=%02x hi=%02x, expected lo=%02x hi=%02x\n", lo, hi, exp_lo, exp_hi);
+    return 1;
+  }
+  return 0;
+}
+
+static int test_scaled_pk_f32_fp8() {
+  float *dO = alloc_dev<float>(2);
+  uint8_t fp8_1 = util::f32_to_fp8_e4m3_rne(1.0f);
+  uint8_t fp8_2 = util::f32_to_fp8_e4m3_rne(2.0f);
+  unsigned packed = fp8_1 | (fp8_2 << 8);
+  k_scalef32_pk_f32_fp8<<<1, 1>>>(packed, 1.0f, dO);
+  HIP_CHECK(hipDeviceSynchronize());
+  auto got = read_dev_vec(dO, 2);
+  (void)hipFree(dO);
+  if (got[0] != 1.0f || got[1] != 2.0f) {
+    printf("  got [%f, %f], expected [1.0, 2.0]\n", got[0], got[1]);
+    return 1;
+  }
+  return 0;
+}
+
+static int test_scaled_pk_f32_bf8() {
+  float *dO = alloc_dev<float>(2);
+  uint8_t bf8_1 = util::f32_to_bf8_e5m2_rne(1.0f);
+  uint8_t bf8_2 = util::f32_to_bf8_e5m2_rne(2.0f);
+  unsigned packed = bf8_1 | (bf8_2 << 8);
+  k_scalef32_pk_f32_bf8<<<1, 1>>>(packed, 1.0f, dO);
+  HIP_CHECK(hipDeviceSynchronize());
+  auto got = read_dev_vec(dO, 2);
+  (void)hipFree(dO);
+  if (got[0] != 1.0f || got[1] != 2.0f) {
+    printf("  got [%f, %f], expected [1.0, 2.0]\n", got[0], got[1]);
+    return 1;
+  }
+  return 0;
+}
+
+static int test_scaled_f32_fp8_byte_sel() {
+  float *dO = alloc_dev<float>(1);
+  uint8_t fp8_vals[4] = {
+      util::f32_to_fp8_e4m3_rne(1.0f),
+      util::f32_to_fp8_e4m3_rne(2.0f),
+      util::f32_to_fp8_e4m3_rne(3.0f),
+      util::f32_to_fp8_e4m3_rne(4.0f),
+  };
+  unsigned packed = fp8_vals[0] | (fp8_vals[1] << 8) | (fp8_vals[2] << 16) | (fp8_vals[3] << 24);
+  float expected[4] = {1.0f, 2.0f, 3.0f, 4.0f};
+  auto run_byte = [&](int byte) -> int {
+    switch (byte) {
+    case 0:
+      k_scalef32_f32_fp8<0><<<1, 1>>>(packed, 1.0f, dO);
+      break;
+    case 1:
+      k_scalef32_f32_fp8<1><<<1, 1>>>(packed, 1.0f, dO);
+      break;
+    case 2:
+      k_scalef32_f32_fp8<2><<<1, 1>>>(packed, 1.0f, dO);
+      break;
+    case 3:
+      k_scalef32_f32_fp8<3><<<1, 1>>>(packed, 1.0f, dO);
+      break;
+    }
+    return hipDeviceSynchronize();
+  };
+  for (int byte = 0; byte < 4; ++byte) {
+    HIP_CHECK(static_cast<hipError_t>(run_byte(byte)));
+    float got = read_dev(dO);
+    if (got != expected[byte]) {
+      printf("  byte_sel=%d: got %f, expected %f\n", byte, got, expected[byte]);
+      (void)hipFree(dO);
+      return 1;
+    }
+  }
+  (void)hipFree(dO);
+  return 0;
+}
+
+static int test_scaled_sr_fp8_f32() {
+  int *dO = alloc_dev<int>(1);
+  k_scalef32_sr_fp8_f32<<<1, 1>>>(1.0f, 0u, 1.0f, dO);
+  HIP_CHECK(hipDeviceSynchronize());
+  int result = read_dev(dO);
+  uint8_t got = result & 0xFF;
+  uint8_t expected = util::f32_to_fp8_e4m3_sr(1.0f, 0);
+  (void)hipFree(dO);
+  if (got != expected) {
+    printf("  got %02x, expected %02x\n", got, expected);
+    return 1;
+  }
+  return 0;
+}
+
+static int test_scaled_sr_bf8_f32() {
+  int *dO = alloc_dev<int>(1);
+  k_scalef32_sr_bf8_f32<<<1, 1>>>(1.0f, 0u, 1.0f, dO);
+  HIP_CHECK(hipDeviceSynchronize());
+  int result = read_dev(dO);
+  uint8_t got = result & 0xFF;
+  uint8_t expected = util::f32_to_bf8_e5m2_sr(1.0f, 0);
+  (void)hipFree(dO);
+  if (got != expected) {
+    printf("  got %02x, expected %02x\n", got, expected);
+    return 1;
+  }
+  return 0;
+}
+
+// ---- FP4 tests ----
+
+static int test_scaled_fp4_roundtrip() {
+  // Hardcoded truth table for positive FP4 E2M1 values.
+  static constexpr float kFp4Truth[8] = {0.0f, 0.5f, 1.0f, 1.5f, 2.0f, 3.0f, 4.0f, 6.0f};
+  int *dNarrow = alloc_dev<int>(1);
+  float *dWide = alloc_dev<float>(2);
+  int errs = 0;
+  for (int ca = 0; ca < 8; ++ca) {
+    for (int cb = 0; cb < 8; ++cb) {
+      float a = kFp4Truth[ca];
+      float b = kFp4Truth[cb];
+      k_scalef32_pk_fp4_f32<<<1, 1>>>(a, b, 1.0f, dNarrow);
+      HIP_CHECK(hipDeviceSynchronize());
+      int packed = read_dev(dNarrow);
+      uint8_t nibble0 = packed & 0xF;
+      uint8_t nibble1 = (packed >> 4) & 0xF;
+      if (nibble0 != ca || nibble1 != cb) {
+        printf("  narrow: a=%d b=%d -> nib0=%d nib1=%d (expected %d %d)\n", ca, cb, nibble0,
+               nibble1, ca, cb);
+        errs++;
+        if (errs > 5)
+          break;
+      }
+      k_scalef32_pk_f32_fp4<<<1, 1>>>(static_cast<unsigned>(packed), 1.0f, dWide);
+      HIP_CHECK(hipDeviceSynchronize());
+      auto widened = read_dev_vec(dWide, 2);
+      if (widened[0] != a || widened[1] != b) {
+        printf("  widen: a=%d b=%d -> [%f, %f] (expected [%f, %f])\n", ca, cb, widened[0],
+               widened[1], a, b);
+        errs++;
+        if (errs > 5)
+          break;
+      }
+    }
+    if (errs > 5)
+      break;
+  }
+  (void)hipFree(dNarrow);
+  (void)hipFree(dWide);
+  return errs > 0 ? 1 : 0;
+}
+
+static int test_scaled_sr_pk_fp4_f32() {
+  static constexpr float kFp4Truth[8] = {0.0f, 0.5f, 1.0f, 1.5f, 2.0f, 3.0f, 4.0f, 6.0f};
+  int *dO = alloc_dev<int>(1);
+  int errs = 0;
+  for (int ca = 0; ca < 8; ++ca) {
+    for (int cb = 0; cb < 8; ++cb) {
+      float a = kFp4Truth[ca];
+      float b = kFp4Truth[cb];
+      k_scalef32_sr_pk_fp4_f32<<<1, 1>>>(a, b, 0xdeadbeefu, 1.0f, dO);
+      HIP_CHECK(hipDeviceSynchronize());
+      int packed = read_dev(dO);
+      uint8_t nibble0 = packed & 0xF;
+      uint8_t nibble1 = (packed >> 4) & 0xF;
+      if (nibble0 != ca || nibble1 != cb) {
+        printf("  sr_pk_fp4: a=%d b=%d -> nib0=%d nib1=%d (expected %d %d)\n", ca, cb, nibble0,
+               nibble1, ca, cb);
+        errs++;
+        if (errs > 5)
+          break;
+      }
+    }
+    if (errs > 5)
+      break;
+  }
+  (void)hipFree(dO);
+  return errs > 0 ? 1 : 0;
+}
+
+// ---- Wide FP6/BF6 tests ----
+// Round-trip: narrow 32 floats to 6-bit packed, widen back, compare against
+// the original values (which are exact FP6/BF6 representable values).
+
+static int test_wide_fp6_roundtrip() {
+  float *dIn = alloc_dev<float>(32);
+  unsigned *dPacked = alloc_dev<unsigned>(6);
+  float *dOut = alloc_dev<float>(32);
+  int errs = 0;
+  for (int base = 0; base < 64; base += 32) {
+    std::vector<float> in(32);
+    for (int c = 0; c < 32; ++c)
+      in[c] = util::fp6_e2m3_to_f32(static_cast<uint8_t>(base + c));
+    (void)hipMemcpy(dIn, in.data(), 32 * sizeof(float), hipMemcpyHostToDevice);
+    k_scalef32_2xpk16_fp6_f32<<<1, 1>>>(dIn, dPacked, 1.0f);
+    HIP_CHECK(hipDeviceSynchronize());
+    k_scalef32_pk32_f32_fp6<<<1, 1>>>(dPacked, dOut, 1.0f);
+    HIP_CHECK(hipDeviceSynchronize());
+    auto widened = read_dev_vec(dOut, 32);
+    // 2xpk16 interleaves: field[2k]=lo[k], field[2k+1]=hi[k]
+    // pk32_f32 reads contiguously, so out[2k]=in[k], out[2k+1]=in[16+k]
+    for (int k = 0; k < 16; ++k) {
+      if (widened[2 * k] != in[k]) {
+        printf("  fp6 rt base=%d lo[%d]: got %f, expected %f\n", base, k, widened[2 * k], in[k]);
+        errs++;
+      }
+      if (widened[2 * k + 1] != in[16 + k]) {
+        printf("  fp6 rt base=%d hi[%d]: got %f, expected %f\n", base, k, widened[2 * k + 1],
+               in[16 + k]);
+        errs++;
+      }
+    }
+  }
+  (void)hipFree(dIn);
+  (void)hipFree(dPacked);
+  (void)hipFree(dOut);
+  return errs > 0 ? 1 : 0;
+}
+
+static int test_wide_bf6_roundtrip() {
+  float *dIn = alloc_dev<float>(32);
+  unsigned *dPacked = alloc_dev<unsigned>(6);
+  float *dOut = alloc_dev<float>(32);
+  int errs = 0;
+  for (int base = 0; base < 64; base += 32) {
+    std::vector<float> in(32);
+    for (int c = 0; c < 32; ++c)
+      in[c] = util::bf6_e3m2_to_f32(static_cast<uint8_t>(base + c));
+    (void)hipMemcpy(dIn, in.data(), 32 * sizeof(float), hipMemcpyHostToDevice);
+    k_scalef32_2xpk16_bf6_f32<<<1, 1>>>(dIn, dPacked, 1.0f);
+    HIP_CHECK(hipDeviceSynchronize());
+    k_scalef32_pk32_f32_bf6<<<1, 1>>>(dPacked, dOut, 1.0f);
+    HIP_CHECK(hipDeviceSynchronize());
+    auto widened = read_dev_vec(dOut, 32);
+    // 2xpk16 interleaves: field[2k]=lo[k], field[2k+1]=hi[k]
+    // pk32_f32 reads contiguously, so out[2k]=in[k], out[2k+1]=in[16+k]
+    for (int k = 0; k < 16; ++k) {
+      if (widened[2 * k] != in[k]) {
+        printf("  bf6 rt base=%d lo[%d]: got %f, expected %f\n", base, k, widened[2 * k], in[k]);
+        errs++;
+      }
+      if (widened[2 * k + 1] != in[16 + k]) {
+        printf("  bf6 rt base=%d hi[%d]: got %f, expected %f\n", base, k, widened[2 * k + 1],
+               in[16 + k]);
+        errs++;
+      }
+    }
+  }
+  (void)hipFree(dIn);
+  (void)hipFree(dPacked);
+  (void)hipFree(dOut);
+  return errs > 0 ? 1 : 0;
+}
+
+// ---- Scale edge cases ----
+
+static int test_scale_variation() {
+  unsigned *dO = alloc_dev<unsigned>(1);
+  k_scalef32_pk_fp8_f32<<<1, 1>>>(1.0f, 2.0f, 2.0f, dO);
+  HIP_CHECK(hipDeviceSynchronize());
+  unsigned packed = read_dev(dO);
+  uint8_t lo = packed & 0xFF;
+  uint8_t hi = (packed >> 8) & 0xFF;
+  uint8_t exp_lo = util::f32_to_fp8_e4m3_rne(1.0f / 2.0f);
+  uint8_t exp_hi = util::f32_to_fp8_e4m3_rne(2.0f / 2.0f);
+  (void)hipFree(dO);
+  if (lo != exp_lo || hi != exp_hi) {
+    printf("  scale=2: got lo=%02x hi=%02x, expected lo=%02x hi=%02x\n", lo, hi, exp_lo, exp_hi);
+    return 1;
+  }
+  return 0;
+}
+
+static int test_nan_inf_saturation() {
+  int *dO = alloc_dev<int>(1);
+  float nan_val = std::numeric_limits<float>::quiet_NaN();
+  float inf_val = std::numeric_limits<float>::infinity();
+  k_scalef32_pk_fp4_f32<<<1, 1>>>(nan_val, inf_val, 1.0f, dO);
+  HIP_CHECK(hipDeviceSynchronize());
+  int packed = read_dev(dO);
+  uint8_t nib0 = packed & 0xF;
+  uint8_t nib1 = (packed >> 4) & 0xF;
+  (void)hipFree(dO);
+  if (nib0 != 0) {
+    printf("  NaN->fp4: got %d, expected 0\n", nib0);
+    return 1;
+  }
+  if (nib1 != 0x7) {
+    printf("  Inf->fp4: got %d, expected 7 (max)\n", nib1);
+    return 1;
+  }
+  return 0;
+}
+
+// ---- Main ----
+
+struct TestCase {
+  const char *name;
+  int (*func)();
+};
+
+int main() {
+  if (!have_device()) {
+    printf("No HIP device found, skipping all tests\n");
+    return 0;
+  }
+
+  TestCase tests[] = {
+      {"NonScaled.PkFp8F32", test_nonscaled_pk_fp8_f32},
+      {"NonScaled.PkBf8F32", test_nonscaled_pk_bf8_f32},
+      {"NonScaled.PkF32Fp8", test_nonscaled_pk_f32_fp8},
+      {"NonScaled.PkF32Bf8", test_nonscaled_pk_f32_bf8},
+      {"NonScaled.SrFp8F32", test_nonscaled_sr_fp8_f32},
+      {"NonScaled.SrBf8F32", test_nonscaled_sr_bf8_f32},
+      {"Scaled.PkFp8F32", test_scaled_pk_fp8_f32},
+      {"Scaled.PkBf8F32", test_scaled_pk_bf8_f32},
+      {"Scaled.PkF32Fp8", test_scaled_pk_f32_fp8},
+      {"Scaled.PkF32Bf8", test_scaled_pk_f32_bf8},
+      {"Scaled.F32Fp8ByteSel", test_scaled_f32_fp8_byte_sel},
+      {"Scaled.SrFp8F32", test_scaled_sr_fp8_f32},
+      {"Scaled.SrBf8F32", test_scaled_sr_bf8_f32},
+      {"Scaled.Fp4RoundTrip", test_scaled_fp4_roundtrip},
+      {"Scaled.SrPkFp4F32", test_scaled_sr_pk_fp4_f32},
+      {"Wide.Fp6RoundTrip", test_wide_fp6_roundtrip},
+      {"Wide.Bf6RoundTrip", test_wide_bf6_roundtrip},
+      {"Scale.Variation", test_scale_variation},
+      {"Edge.NanInfSaturation", test_nan_inf_saturation},
+  };
+
+  for (auto &tc : tests) {
+    printf("[ RUN    ] %s\n", tc.name);
+    int result = tc.func();
+    if (result == 0)
+      pass(tc.name);
+    else
+      fail(tc.name, "see above");
+  }
+
+  printf("\n%d passed, %d failed, %d skipped\n", g_pass, g_fail, g_skip);
+  return g_fail > 0 ? 1 : 0;
+}

--- a/emulation/rocjitsu/tests/shared_infra_test.cpp
+++ b/emulation/rocjitsu/tests/shared_infra_test.cpp
@@ -338,14 +338,14 @@ TEST(ScratchAddrCalcTest, FlatScratchUsesWavefrontBase) {
   // Set EXEC so only lane 0 is active.
   wf->set_exec(1ULL);
 
-  // Build a FlatMachineInst with seg=1 (SCRATCH), saddr=0x7F (no SADDR),
-  // offset=0x10.
-  cdna4::FlatMachineInst inst{};
+  // Build a FlatScratchMachineInst with seg=1 (SCRATCH), sve=1 (VADDR enabled),
+  // saddr=0x7F (no SADDR), offset=0x10.
+  cdna4::FlatScratchMachineInst inst{};
   inst.seg = 1;       // SCRATCH
+  inst.sve = 1;       // VADDR enabled
   inst.saddr = 0x7F;  // No SADDR
   inst.addr = 0;      // VGPR index 0
-  inst.offset = 0x10; // 12-bit immediate offset
-  inst.pad_12 = 0;
+  inst.offset = 0x10; // 13-bit signed offset
 
   amdgpu::VectorMemState d(amdgpu::GLOBAL_MEM);
   amdgpu::addr_calc::flat_calculate_addresses(inst, *wf, d);


### PR DESCRIPTION
## Motivation
49 v_cvt_scalef32_* (CDNA4 scaled FP8/BF8/FP4/FP6/BF6 format conversions)
and 6 non-scaled v_cvt_{pk,sr}_{fp8,bf8}_f32 instructions were throwing
UnimplementedInst. These are critical for MI300-era AI workloads using
narrow floating-point formats.

## Technical Details
Codegen (vector_special.py):
- Added gen_cvt_fp8 and gen_cvt_scalef32 codegen handlers with
  sub-dispatchers for narrowing (RNE/SR), widening, and wide
  (pk32/2xpk16) variants
- Semantic class routing in semantics.py: cvt_fp8 for non-scaled
  FP8/BF8, cvt_scalef32 for all 49 scaled variants
- Dynamic opsel field name (_opsel_field) for CDNA op_sel vs RDNA4
- Added both classes to _NON_SHAREABLE_CLASSES (VOP1 lacks op_sel)
- Fixed Black-incompatible PEP 701 f-string nested quotes in
  __main__.py and _generator.py

Conversion utilities (data_types.h):
- Consolidated all narrow FP conversion functions (FP8 E4M3, BF8
  E5M2, FP4 E2M1, FP6 E2M3, BF6 E3M2) with RNE, SR, pack/unpack,
  and PRNG advance
- Fixed FP8 E4M3 NaN detection: exp==15 && mant!=0 -> exp==15 &&
  mant==7 per OCP E4M3FN spec
- Fixed SR denorm truncation in all five f32_to_*_sr() functions:
  `if (exp <= 0) return sign;` zeroed all denorm-range values.
  Added full_mant + shift SR denorm calculation matching each
  format's RNE function
- Handles E8M0 scale factor (per-lane VGPR), OPSEL byte/half
  selection, saturation for formats without NaN/Inf, LFSR seed
  advancement for SR

Conformance fixes found via fpsan hardware validation:
- Wide VGPR access off-by-256: encoding_value() returns 256+n for
  VGPRs; fixed to unified_vgpr_index() which returns n
- pk_fp4_f32 fell into FP8 branch: added dst_fmt != 'fp4' guard
- sr_pk_fp4_f32 read one data element twice: fixed to read val1
  from the next VGPR of the 64-bit pair
- SR PK FP4 operand mapping: removed incorrect "reversed operands"
  special case; LLVM maps float2 data->src0 for all variants
- 2xpk16 FP6/BF6 interleaving: hardware interleaves lo/hi groups
  (field[2k]=lo[k], field[2k+1]=hi[k]), not contiguous

## JIRA ID
N/A

## Test Plan
- CPU unit tests (data_types_test.cpp, 29 tests): exhaustive
  widen/RNE round-trip for FP4/FP6/BF6, key-value checks for
  FP8/BF8, SR denorm round-trip for all 5 formats, 6-bit
  pack/unpack, PRNG advance
- HIP CTS tests (hip_cvt_narrow_test.cpp, 17 tests): non-scaled
  FP8/BF8 (pk/sr/widen), scaled FP8/BF8 (pk/sr/widen/byte_sel),
  scaled FP4 (pk/sr_pk/round-trip), wide FP6/BF6 (2xpk16->pk32
  with interleave verification), NaN/Inf/saturation edge cases.
  Built with hipcc --offload-arch=gfx950, run through emulator.
- fpsan validation (bjacob's OCP reference): 11/11 cvt_gfx950
  tests and 12/12 cvt_scalef32_mx_gfx950 tests pass through
  the emulator

## Test Results
- 29/29 CPU unit tests: PASSED
- 17/17 HIP CTS tests: PASSED
- 11/11 fpsan gfx950 tests: PASSED
- 12/12 fpsan MX gfx950 tests: PASSED
- 459/459 ctest (full suite): PASSED

## Submission Checklist
- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.