### PR TITLE
Reduce debug standard rccl-UnitTests exec time in CI

### DIFF
--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -525,7 +525,8 @@
       "num_gpus": 8,
       "timeout": 0,
       "env_variables": {
-        "NCCL_DEBUG": ""
+        "NCCL_DEBUG": "",
+        "UT_MIN_GPUS": "8"
       },
       "rerun_env_variables": {
         "NCCL_DEBUG": "INFO"


### PR DESCRIPTION
## Motivation

Reduce code coverage debug run time in the CI by running standard tests for 8 ranks only using UT_MIN_GPUS=8. Other pipelines do exercises all the ranks so no need to duplicate. This will help reduce the runtime from 4.5 hours to ~1hr.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
