### PR TITLE
Fix missing break in gfx950 MFMA F8F6F4 benchmark kernel (FP8_E4M3 falls through to BF8_E5M2)

### DIFF
--- a/projects/rocprofiler-compute/src/roofline/benchmark/gfx9/benchmark_gfx950.py
+++ b/projects/rocprofiler-compute/src/roofline/benchmark/gfx9/benchmark_gfx950.py
@@ -173,6 +173,7 @@ class Bench_gfx950(benchmark_gfx9_base.Bench_gfx9):
                             0
                         );
                     }
+                    break;
                 case BF8_E5M2: // bf8 x bf8
                     for(int i = 0; i < iter; ++i)
                     {


### PR DESCRIPTION
# Fix missing `break` in gfx950 MFMA F8F6F4 benchmark kernel

## Summary

In the gfx950 (MI350X / MI355X) roofline benchmark kernel `mfma_f8f6f4`, the
`case FP8_E4M3:` of the datatype `switch` is missing a `break;`. Execution would
fall through into `case BF8_E5M2:`, so an `mfma_f8f6f4<FP8_E4M3>` instantiation
would run **both** the fp8 loop and the bf8 loop, while the flop counter
(`matrix_ops`) accounts for only a single pass.

Every other case in the switch (`BF8_E5M2`, `FP6_E2M3`, `BF6_E3M2`, `FP4_E2M1`,
`FP6_FP4_MIXED`) ends with `break;`. `FP8_E4M3` is the only one that does not.

### Why this is currently dormant

The fallthrough does not affect any benchmark today, because the `FP8_E4M3`
case is never instantiated:

- `matrix_kernel_selector` routes the `mfma_f8f6f4` template only for the
  `F4`, `F6`, and `F6F4` keys (`<FP4_E2M1>`, `<FP6_E2M3>`, `<FP6_FP4_MIXED>`).
- The `F8` roofline uses a separate `mfma_f8` kernel, not the f8f6f4 path.
- `matrix_bench` compiles only the selected kernel name, so the `FP8_E4M3`
  template is never instantiated and the missing `break;` never executes.

This is a latent correctness fix. It prevents the bug if an F8 variant is ever
routed through the `mfma_f8f6f4` kernel.

File: `src/roofline/benchmark/gfx9/benchmark_gfx950.py`

```c
case FP8_E4M3: // fp8 x fp8
    for (int i = 0; i < iter; ++i) {
        result = __builtin_amdgcn_mfma_scale_f32_32x32x64_f8f6f4(a, a, result, 0, 0, 0, 0, 0, 0);
    }
                // <-- missing `break;` : falls through into BF8_E5M2
case BF8_E5M2: // bf8 x bf8
    for (int i = 0; i < iter; ++i) {
        result = __builtin_amdgcn_mfma_scale_f32_32x32x64_f8f6f4(a, a, result, 1, 1, 0, 0, 0, 0);
    }
    break;
```

## The fix

One line. Add the missing `break;` so the fp8 case executes only its own loop:

```diff
                         );
                     }
+                    break;
                 case BF8_E5M2: // bf8 x bf8
```
