### PR TITLE
[rocjitsu] Synthesize NCCL topology XML so RCCL ignores host PCIe state

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/vm/rj_vm.h
+++ b/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/vm/rj_vm.h
@@ -210,6 +210,16 @@ RJ_API_EXPORT rj_status_t rj_vm_topology_path(rj_vm_t *vm, const char **path);
 /// @param[out] path Pointer to the DRM path string (owned by the VM).
 RJ_API_EXPORT rj_status_t rj_vm_drm_path(rj_vm_t *vm, const char **path);
 
+/// @brief Get the path of the synthesized NCCL topology XML file.
+/// @details The path is empty if no topology has been generated yet. The
+/// interposer sets NCCL_TOPO_FILE to this path so RCCL uses our symmetric
+/// XGMI graph instead of reading real /sys/bus/pci/devices/<bdf>/... state
+/// (which would contaminate the topology with whatever real PCIe devices
+/// happen to occupy our simulated BDFs).
+/// @param[in] vm VM handle.
+/// @param[out] path Pointer to the NCCL topo path string (owned by the VM).
+RJ_API_EXPORT rj_status_t rj_vm_nccl_topo_path(rj_vm_t *vm, const char **path);
+
 /// @brief Get the backing memory handle (local mode).
 RJ_API_EXPORT rj_status_t rj_vm_get_shared_mem(rj_vm_t *vm, int64_t offset, rj_handle_t *handle);
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -210,6 +210,13 @@ public:
     if (fd < 0)
       return nullptr;
     remote_kfd_fd_ = fd;
+    // Point RCCL at the daemon-synthesized NCCL topology and disable IB
+    // probing. Without these, RCCL reads real /sys/bus/pci/devices/... at
+    // our simulated BDFs (not interposed) and tries to open real RoCE
+    // hardware. overwrite=0 on IB_DISABLE lets the user opt back in.
+    if (!remote_->nccl_topo_path().empty())
+      ::setenv("NCCL_TOPO_FILE", remote_->nccl_topo_path().c_str(), 1);
+    ::setenv("NCCL_IB_DISABLE", "1", 0);
     return remote_;
   }
 
@@ -330,6 +337,14 @@ public:
         return nullptr;
       }
       std::thread([vm = rj_vm_]() { rj_vm_run(vm, nullptr); }).detach();
+      // Same NCCL topology + IB defense as the daemon path. The Sysfs
+      // synthesis runs inside rj_vm_create (driver setup_topology), so the
+      // path is already available here.
+      const char *nccl_path = nullptr;
+      if (rj_vm_nccl_topo_path(rj_vm_, &nccl_path) == ROCJITSU_STATUS_SUCCESS && nccl_path &&
+          nccl_path[0] != '\0')
+        ::setenv("NCCL_TOPO_FILE", nccl_path, 1);
+      ::setenv("NCCL_IB_DISABLE", "1", 0);
       in_construction = false;
     }
     return driver();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.cpp
@@ -144,6 +144,14 @@ int RemoteDriver::open() {
       return -1;
   }
 
+  if (hs.nccl_topo_path_len > kMaxPathLen)
+    return -1;
+  if (hs.nccl_topo_path_len > 0) {
+    nccl_topo_path_.resize(hs.nccl_topo_path_len);
+    if (!rpc_recv_exact(sock_, nccl_topo_path_.data(), hs.nccl_topo_path_len))
+      return -1;
+  }
+
   // Create a high-numbered synthetic KFD fd to avoid collisions with ROCR's
   // internal fd lifecycle. Use the top of the current rlimit range (same
   // approach as SimulatedDriver::init_reserved_fd_range).

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.h
@@ -40,6 +40,9 @@ public:
   /// @brief Get the daemon's DRM sysfs directory path.
   [[nodiscard]] const std::string &drm_path() const { return drm_path_; }
 
+  /// @brief Get the daemon's NCCL topology XML file path (used for NCCL_TOPO_FILE).
+  [[nodiscard]] const std::string &nccl_topo_path() const { return nccl_topo_path_; }
+
   /// @brief Find a stored memfd that covers the given GPUVM address.
   /// @details Used by the interposer to intercept anonymous MAP_FIXED at
   /// addresses that have daemon-shared memfd mappings.
@@ -97,6 +100,7 @@ private:
   uint32_t next_id_ = 0;             ///< Monotonic request ID counter (for debugging).
   std::string topology_path_;        ///< Daemon's sysfs topology directory path.
   std::string drm_path_;             ///< Daemon's DRM sysfs directory path.
+  std::string nccl_topo_path_;       ///< Daemon's NCCL topology XML file path.
   std::atomic<bool> closing_{false}; ///< Set by close() to break WAIT_EVENTS loops.
   int shutdown_efd_ = -1;            ///< eventfd written by close() to wake WAIT_EVENTS pollers.
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/rpc.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/rpc.h
@@ -47,14 +47,15 @@ struct RpcHeader {
 };
 
 /// @brief RPC protocol version. Increment when making breaking changes.
-inline constexpr uint32_t kRpcProtocolVersion = 2;
+inline constexpr uint32_t kRpcProtocolVersion = 3;
 
 /// @brief Handshake response payload (sent after RPC_HANDSHAKE).
 struct RpcHandshakeResponse {
-  uint32_t version;           ///< Protocol version (kRpcProtocolVersion).
-  uint32_t gpu_id;            ///< KFD gpu_id for the simulated device.
-  uint32_t topology_path_len; ///< Length of the topology path string that follows.
-  uint32_t drm_path_len;      ///< Length of the DRM sysfs path string that follows.
+  uint32_t version;            ///< Protocol version (kRpcProtocolVersion).
+  uint32_t gpu_id;             ///< KFD gpu_id for the simulated device.
+  uint32_t topology_path_len;  ///< Length of the topology path string that follows.
+  uint32_t drm_path_len;       ///< Length of the DRM sysfs path string that follows.
+  uint32_t nccl_topo_path_len; ///< Length of the NCCL_TOPO_FILE path string that follows.
 };
 
 /// @brief Ioctl request payload (when opcode == RPC_IOCTL).
@@ -86,7 +87,7 @@ struct RpcMunmapRequest {
 };
 
 static_assert(sizeof(RpcHeader) == 16);
-static_assert(sizeof(RpcHandshakeResponse) == 16);
+static_assert(sizeof(RpcHandshakeResponse) == 20);
 static_assert(sizeof(RpcIoctlRequest) == 8);
 static_assert(sizeof(RpcMmapRequest) == 32);
 static_assert(sizeof(RpcMmapResponse) == 8);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_driver.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_driver.cpp
@@ -262,6 +262,15 @@ bool SimulatedDriver::is_doorbell_range(const void *addr, size_t length) const {
 }
 
 int SimulatedDriver::open() {
+  static std::once_flag raise_nofile_flag;
+  std::call_once(raise_nofile_flag, [] {
+    struct rlimit rl {};
+    if (getrlimit(RLIMIT_NOFILE, &rl) == 0 && rl.rlim_cur < 8192) {
+      rl.rlim_cur = std::min<rlim_t>(rl.rlim_max, 65536);
+      setrlimit(RLIMIT_NOFILE, &rl);
+    }
+  });
+
   if (fd_ < 0) {
     fd_ = static_cast<int>(syscall(SYS_memfd_create, "rocjitsu_kfd", 0));
     if (fd_ < 0)
@@ -764,14 +773,14 @@ void *SimulatedDriver::dispatch_mmap(KfdProcess &proc, void *addr, size_t length
       if (raw_events_fd < 0)
         return MAP_FAILED;
       proc.event_state_.memfd = fcntl(raw_events_fd, F_DUPFD_CLOEXEC, 4096);
+      if (proc.event_state_.memfd < 0)
+        proc.event_state_.memfd = raw_events_fd;
+      else
+        syscall(SYS_close, raw_events_fd);
       {
         std::lock_guard<std::mutex> lk(owned_fds_mutex_);
-        if (proc.event_state_.memfd >= 0)
-          owned_fds_.insert(proc.event_state_.memfd);
+        owned_fds_.insert(proc.event_state_.memfd);
       }
-      syscall(SYS_close, raw_events_fd);
-      if (proc.event_state_.memfd < 0)
-        return MAP_FAILED;
       if (ftruncate(proc.event_state_.memfd, static_cast<off_t>(length)) != 0) {
         syscall(SYS_close, proc.event_state_.memfd);
         proc.event_state_.memfd = -1;
@@ -1011,12 +1020,14 @@ int SimulatedDriver::alloc_memory_ioctl(KfdProcess &proc, void *arg) {
         syscall(SYS_memfd_create, "rocjitsu_alloc", MFD_CLOEXEC | MFD_ALLOW_SEALING));
     if (raw_fd >= 0) {
       alloc.memfd = fcntl(raw_fd, F_DUPFD_CLOEXEC, 4096);
+      if (alloc.memfd < 0)
+        alloc.memfd = raw_fd;
+      else
+        syscall(SYS_close, raw_fd);
       {
         std::lock_guard<std::mutex> lk(owned_fds_mutex_);
-        if (alloc.memfd >= 0)
-          owned_fds_.insert(alloc.memfd);
+        owned_fds_.insert(alloc.memfd);
       }
-      syscall(SYS_close, raw_fd);
       if (alloc.memfd >= 0) {
         [[maybe_unused]] auto ft_rc = ftruncate(alloc.memfd, static_cast<off_t>(alloc.size));
         fallocate(alloc.memfd, 0, 0, static_cast<off_t>(alloc.size));
@@ -1077,9 +1088,10 @@ bool SimulatedDriver::allocate_scratch_backing(uint32_t process_id, uint64_t gpu
     return false;
 
   int memfd = fcntl(raw_fd, F_DUPFD_CLOEXEC, 4096);
-  syscall(SYS_close, raw_fd);
   if (memfd < 0)
-    return false;
+    memfd = raw_fd;
+  else
+    syscall(SYS_close, raw_fd);
   {
     std::lock_guard<std::mutex> lk(owned_fds_mutex_);
     owned_fds_.insert(memfd);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/sysfs.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/sysfs.cpp
@@ -6,9 +6,11 @@
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <functional>
 #include <iomanip>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <unistd.h>
 
 namespace rocjitsu {
@@ -17,15 +19,20 @@ namespace fs = std::filesystem;
 
 Sysfs::~Sysfs() { cleanup(); }
 
-Sysfs::Sysfs(Sysfs &&other) noexcept : topology_dir_(std::move(other.topology_dir_)) {
+Sysfs::Sysfs(Sysfs &&other) noexcept
+    : topology_dir_(std::move(other.topology_dir_)),
+      nccl_topo_path_(std::move(other.nccl_topo_path_)) {
   other.topology_dir_.clear();
+  other.nccl_topo_path_.clear();
 }
 
 Sysfs &Sysfs::operator=(Sysfs &&other) noexcept {
   if (this != &other) {
     cleanup();
     topology_dir_ = std::move(other.topology_dir_);
+    nccl_topo_path_ = std::move(other.nccl_topo_path_);
     other.topology_dir_.clear();
+    other.nccl_topo_path_.clear();
   }
   return *this;
 }
@@ -46,6 +53,9 @@ void Sysfs::cleanup() {
     fs::remove_all(drm_dir_);
     drm_dir_.clear();
   }
+  // nccl_topo_path_ lives under topology_dir_; remove_all above handles the
+  // file. Clear the cached path so the accessor reflects post-cleanup state.
+  nccl_topo_path_.clear();
 }
 
 void Sysfs::setup_environment() {}
@@ -361,6 +371,102 @@ void Sysfs::write_drm_tree(const std::vector<GpuInfo> &gpus) {
   write_file(drm_dir_ + "/version", "drm 1.1.0\n");
 }
 
+namespace {
+
+std::string format_bdf(uint32_t location_id) {
+  uint32_t bus = (location_id >> 8) & 0xFF;
+  uint32_t dev = (location_id >> 3) & 0x1F;
+  uint32_t func = location_id & 0x7;
+  std::ostringstream os;
+  os << "0000:" << std::hex << std::setw(2) << std::setfill('0') << bus << ":" << std::setw(2)
+     << std::setfill('0') << dev << "." << func;
+  return os.str();
+}
+
+// Decode gfx_target_version (encoded as major*10000 + minor*100 + step) into
+// the "gfxNNN" string RCCL expects (e.g. 90500 -> "gfx950", 90010 -> "gfx90a").
+// Returns empty if the value is missing or doesn't fit the standard encoding;
+// the caller then omits the gcn attribute entirely rather than emit a wrong
+// label. Every real ROCm target so far (gfx908..gfx950, gfx10xx..gfx12xx)
+// decodes cleanly here, so the empty path only triggers on a misconfigured
+// or unset gfx_target_version.
+std::string gfx_name_from_target_version(uint32_t v) {
+  if (v == 0)
+    return {};
+  uint32_t major = v / 10000;
+  uint32_t minor = (v / 100) % 100;
+  uint32_t step = v % 100;
+  if (minor >= 10)
+    return {};
+  std::ostringstream os;
+  os << "gfx" << major << minor;
+  if (step < 10)
+    os << step;
+  else if (step == 10)
+    os << 'a';
+  else if (step == 11)
+    os << 'b';
+  else if (step == 12)
+    os << 'c';
+  else
+    return {};
+  return os.str();
+}
+
+uint64_t host_hash_value() {
+  char hostname[256] = {};
+  if (gethostname(hostname, sizeof(hostname) - 1) != 0)
+    hostname[0] = '\0';
+  return std::hash<std::string_view>{}(std::string_view(hostname));
+}
+
+} // namespace
+
+void Sysfs::write_nccl_topo(const std::vector<GpuInfo> &gpus) {
+  if (topology_dir_.empty())
+    return;
+
+  std::ostringstream os;
+  os << "<system version=\"2\">\n"
+     << "  <cpu host_hash=\"0x" << std::hex << host_hash_value() << std::dec
+     << "\" numaid=\"0\" affinity=\"ffffffff,ffffffff,ffffffff,ffffffff\""
+        " arch=\"x86_64\" vendor=\"AuthenticAMD\" familyid=\"175\" modelid=\"17\">\n";
+
+  for (size_t i = 0; i < gpus.size(); ++i) {
+    const auto &gpu = gpus[i];
+    std::string bdf = format_bdf(gpu.location_id);
+
+    std::ostringstream vendor_hex;
+    vendor_hex << "0x" << std::hex << std::setw(4) << std::setfill('0') << gpu.vendor_id;
+    std::ostringstream device_hex;
+    device_hex << "0x" << std::hex << std::setw(4) << std::setfill('0') << gpu.device_id;
+
+    os << "    <pci busid=\"" << bdf << "\" class=\"0x130000\" vendor=\"" << vendor_hex.str()
+       << "\" device=\"" << device_hex.str() << "\" subsystem_vendor=\"" << vendor_hex.str()
+       << "\" subsystem_device=\"0x0c34\" link_speed=\"32.0 GT/s PCIe\" link_width=\"16\">\n"
+       << "      <gpu dev=\"" << i << "\" sm=\"256\"";
+    if (auto gcn = gfx_name_from_target_version(gpu.gfx_target_version); !gcn.empty())
+      os << " gcn=\"" << gcn << "\"";
+    os << " arch=\"38911\" rank=\"" << i << "\" gdr=\"0\">\n";
+
+    for (size_t j = 0; j < gpus.size(); ++j) {
+      if (j == i)
+        continue;
+      os << "        <xgmi target=\"" << format_bdf(gpus[j].location_id)
+         << "\" count=\"1\" tclass=\"0x130000\"/>\n";
+    }
+
+    os << "      </gpu>\n"
+       << "    </pci>\n";
+  }
+
+  os << "  </cpu>\n"
+     << "</system>\n";
+
+  nccl_topo_path_ = topology_dir_ + "/nccl_topo.xml";
+  write_file(nccl_topo_path_, os.str());
+}
+
 std::string Sysfs::generate(const GpuInfo &gpu) { return generate(std::vector<GpuInfo>{gpu}); }
 
 std::string Sysfs::generate(const std::vector<GpuInfo> &gpus) {
@@ -388,6 +494,7 @@ std::string Sysfs::generate(const std::vector<GpuInfo> &gpus) {
     write_gpu_node(nodes_dir, i + 1, gpus[i], num_gpus);
 
   write_drm_tree(gpus);
+  write_nccl_topo(gpus);
 
   return topology_dir_;
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/sysfs.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/sysfs.h
@@ -102,6 +102,13 @@ public:
   /// @brief Get the generated DRM sysfs path (empty if not yet generated).
   const std::string &drm_path() const { return drm_dir_; }
 
+  /// @brief Get the generated NCCL topology XML file path (empty if not yet generated).
+  /// @details RCCL otherwise reads /sys/bus/pci/devices/<bdf>/... (which the
+  /// LD_PRELOAD interposer does not interpose) and sees real host PCIe state at
+  /// our simulated BDFs, producing asymmetric XGMI links that fail path
+  /// discovery. Pointing NCCL_TOPO_FILE at this file bypasses that probe.
+  const std::string &nccl_topo_path() const { return nccl_topo_path_; }
+
   /// @brief Get the GPU info used to generate the topology.
   const GpuInfo &gpu_info() const { return gpu_info_; }
 
@@ -114,6 +121,7 @@ public:
 private:
   std::string topology_dir_;
   std::string drm_dir_;
+  std::string nccl_topo_path_;
   GpuInfo gpu_info_{};
 
   void write_file(const std::string &path, const std::string &content);
@@ -124,6 +132,7 @@ private:
   void write_gpu_node(const std::string &nodes_dir, uint32_t node_idx, const GpuInfo &gpu,
                       uint32_t total_gpus);
   void write_drm_tree(const std::vector<GpuInfo> &gpus);
+  void write_nccl_topo(const std::vector<GpuInfo> &gpus);
 };
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/rj_vm.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/rj_vm.cpp
@@ -346,6 +346,15 @@ rj_status_t rj_vm_drm_path(rj_vm_t *vm, const char **path) {
   return ROCJITSU_STATUS_SUCCESS;
 }
 
+rj_status_t rj_vm_nccl_topo_path(rj_vm_t *vm, const char **path) {
+  if (!vm || !path || !vm->vm || !vm->vm->driver())
+    return ROCJITSU_STATUS_INVALID_ARGUMENT;
+  static thread_local std::string cached_nccl_topo;
+  cached_nccl_topo = vm->vm->driver()->topology().nccl_topo_path();
+  *path = cached_nccl_topo.c_str();
+  return ROCJITSU_STATUS_SUCCESS;
+}
+
 rj_status_t rj_vm_get_shared_mem(rj_vm_t *vm, int64_t offset, rj_handle_t *handle) {
   if (!vm || !handle || !vm->vm || !vm->vm->driver())
     return ROCJITSU_STATUS_INVALID_ARGUMENT;

--- a/emulation/rocjitsu/tools/rocjitsu/main.cpp
+++ b/emulation/rocjitsu/tools/rocjitsu/main.cpp
@@ -65,6 +65,10 @@ static void handle_client(int client_fd, rj_vm_t *vm, std::stop_token stop) {
       rj_vm_drm_path(vm, &drm);
       auto drm_len = drm ? std::strlen(drm) : 0;
 
+      const char *nccl = nullptr;
+      rj_vm_nccl_topo_path(vm, &nccl);
+      auto nccl_len = nccl ? std::strlen(nccl) : 0;
+
       RpcHeader resp{};
       resp.request_id = hdr.request_id;
 
@@ -73,14 +77,18 @@ static void handle_client(int client_fd, rj_vm_t *vm, std::stop_token stop) {
       hs.gpu_id = gpu_id;
       hs.topology_path_len = static_cast<uint32_t>(topo_len);
       hs.drm_path_len = static_cast<uint32_t>(drm_len);
+      hs.nccl_topo_path_len = static_cast<uint32_t>(nccl_len);
 
-      resp.payload_bytes = sizeof(hs) + hs.topology_path_len + hs.drm_path_len;
+      resp.payload_bytes =
+          sizeof(hs) + hs.topology_path_len + hs.drm_path_len + hs.nccl_topo_path_len;
       rpc_send_exact(client_fd, &resp, sizeof(resp));
       rpc_send_exact(client_fd, &hs, sizeof(hs));
       if (topo_len > 0)
         rpc_send_exact(client_fd, topo, topo_len);
       if (drm_len > 0)
         rpc_send_exact(client_fd, drm, drm_len);
+      if (nccl_len > 0)
+        rpc_send_exact(client_fd, nccl, nccl_len);
       break;
     }
 


### PR DESCRIPTION
## Motivation

The LD_PRELOAD interposer redirects /sys/class/{drm,kfd} but not /sys/bus/pci/devices/.... When RCCL builds its NCCL topology it falls back to real host PCIe data at the BDFs our simulated GPUs claim (location_id  0x300/0x400 -> 0000:03:00.0/0000:04:00.0, which on the test host are real AMD devices with mismatched PCI classes and bridge parents). The asymmetric class codes produced an asymmetric XGMI graph, NCCL's path BFS rejected it ("Failed to find reverse path"), and the five RcclDaemonTest.{AllReduce,Broadcast,AllGather,ReduceScatter, SendRecv} tests failed. NCCL also probed the host's real RoCE NIC and timed out on ibv_create_cq.

## Fix 

Mirror the existing fake-sysfs pattern: the daemon now writes a symmetric NCCL topology XML (all <pci> direct children of <cpu>, class=0x130000, mutual <xgmi tclass=0x130000>) into the existing topology_dir_, and the interposer points clients at it via NCCL_TOPO_FILE. NCCL_IB_DISABLE=1 is set with overwrite=0 so users can opt back in for IB testing. The handshake protocol bumps to v3 to carry the new path; mismatched daemon/client fail fast at the existing version check. Local mode (in-process simulation) gets the same env wiring after VM creation.

## Test Plan

RcclDaemonTests need to all pass

## Test Result

All tests pass now

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
