### PR TITLE
[rocprofiler-sdk] Fix signal-handler re-entrancy deadlock and enable app-abort testsadd a thread re-entrancy guard

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -3674,6 +3674,32 @@ rocprofv3_error_signal_handler(int signo, siginfo_t* info, void* ucontext)
                                 this_func,
                                 signo);
 
+    // Guard against recursive re-entry on the same thread. This occurs when a
+    // chained signal handler (e.g. one installed by the HSA runtime *after*
+    // rocprofv3 installed its own handler) invokes the previously-registered
+    // handler, which is this very function. Without this guard the std::call_once
+    // below would be re-entered by the same thread while it is still executing
+    // the call_once callable, which deadlocks (recursive use of std::once_flag is
+    // undefined behavior). When re-entered, the finalization has already been
+    // performed (or is in progress) by this thread, so we simply break the chain
+    // loop and proceed to termination.
+    static thread_local bool _in_signal_handler = false;
+    if(_in_signal_handler)
+    {
+        ROCP_WARNING << fmt::format(
+            "[PPID={}][PID={}][TID={}][{}] rocprofv3 re-entered signal handler for {} (chained "
+            "handler looped back); terminating",
+            this_ppid,
+            this_pid,
+            this_tid,
+            this_func,
+            signo);
+        if(signal_handler_exit) ::quick_exit(signo);
+        ::raise(signo);
+        return;
+    }
+    _in_signal_handler = true;
+
     static auto _once = std::once_flag{};
     std::call_once(_once, [&]() {
         auto get_children = [&this_pid]() {

--- a/projects/rocprofiler-sdk/tests/rocprofv3/aborted-app/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/aborted-app/CMakeLists.txt
@@ -18,9 +18,7 @@ string(REPLACE "LD_PRELOAD=" "ROCPROF_PRELOAD=" PRELOAD_ENV
 if(ROCPROFILER_MEMCHECK STREQUAL "ThreadSanitizer")
     set(IS_DISABLED ON)
 else()
-    # set(IS_DISABLED OFF)
-    set(IS_DISABLED ON) # this test is currently unstable so we are disabling it
-    # unconditionally for now
+    set(IS_DISABLED OFF)
 endif()
 
 # app-abort


### PR DESCRIPTION
## Motivation

The `rocprofv3-test-app-abort` integration tests (4 tests) were disabled unconditionally as "currently unstable". The instability was a real deadlock in rocprofv3's abort signal handler that caused the profiled process to hang on every abort. This PR fixes that deadlock and re-enables the tests.

## Technical Details

Root cause: rocprofv3 installs its signal handler before HSA does, so when HSA later calls `sigaction()` it receives rocprofv3's handler as its "previous" handler. On an abort signal, `rocprofv3_error_signal_handler` finalizes output and invokes the chained HSA handler, which calls back the previous handler (rocprofv3's), re-entering the handler on the **same thread while still inside `std::call_once`**. Recursive use of `std::once_flag` deadlocks, so the process hangs and CTest times out. (`SA_RESETHAND` doesn't help — the re-entry is a direct call, not a fresh signal delivery.)

Fix:

- `source/lib/rocprofiler-sdk-tool/tool.cpp`: add a `thread_local` re-entrancy guard at handler entry that breaks the chain loop and terminates instead of recursing into `call_once`. Preserves cross-thread `call_once` semantics and is async-signal-safe.
- `tests/rocprofv3/aborted-app/CMakeLists.txt`: remove the unconditional `IS_DISABLED ON` (still disabled under ThreadSanitizer).

## JIRA ID

Resolves AIROCVAL-48

## Test Plan

Built for gfx942 (MI300X, ROCm 7.2) and ran the app-abort tests under multiple conditions:

- `ctest -R app-abort` (execute + 3 validate steps).
- `ctest --repeat until-fail:50` under heavy CPU contention (load ~205).
- ~470+ abort invocations total: serial loops, 192-way concurrent, and under CPU/memory contention, with hang detection.

## Test Result

100% pass; the execute step completes in ~1s (previously a 45s hang). **Zero hangs** across all runs and no leftover/spinning processes. The guard also correctly handled an induced `SIGABRT` loop-back during stress, terminating cleanly instead of deadlocking.

## Submission Checklist

- [V] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.