### PR TITLE
[AILITOOLS-268] Deprecate notice amdsmi_get_gpu_vram_vendor

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -39,6 +39,9 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 - **Added `AMDSMI_LINK_TYPE_NUMA` and `AMDSMI_LINK_TYPE_XNUMA` to `amdsmi_link_type_t` enum**.  
   - Added the new types to `amdsmi_link_types` as part of support for NICs
 
+### Changed
+- **Deprecated `amdsmi_get_gpu_vram_vendor()` in favor of `amdsmi_get_gpu_vram_info()`**.  
+
 ### Resolved Issues
 
 - **Fixed AMD GPU manufacturer name display in `amd-smi static --board`**.  

--- a/projects/amdsmi/docs/reference/amdsmi-py-api.md
+++ b/projects/amdsmi/docs/reference/amdsmi-py-api.md
@@ -5032,7 +5032,7 @@ finally:
 
 ### amdsmi_get_gpu_vram_vendor
 
-Description: Get the vram vendor string of a gpu device.
+Description: **deprecated** Get the vram vendor string of a gpu device.
 
 Input parameters:
 

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -3640,6 +3640,8 @@ amdsmi_status_t amdsmi_get_gpu_vendor_name(amdsmi_processor_handle processor_han
 /**
  *  @brief Get the vram vendor string of a device.
  *
+ *  @deprecated ::amdsmi_get_gpu_vram_info() should be used instead
+ *
  *  @ingroup tagIdentQuery
  *
  *  @platform{gpu_bm_linux}

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -4269,6 +4269,16 @@ def amdsmi_get_gpu_id(processor_handle: processor_handle_t):
 
 
 def amdsmi_get_gpu_vram_vendor(processor_handle: processor_handle_t):
+    """Deprecated: Use amdsmi_get_gpu_vram_info() instead.\
+        Will be deprecated in Rocm 9.0.
+    """
+    import warnings
+
+    warnings.warn(
+        "amdsmi_get_gpu_vram_vendor() is deprecated, use amdsmi_get_gpu_vram_info() instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
 

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -2627,7 +2627,10 @@ amdsmi_status_t amdsmi_get_gpu_vendor_name(amdsmi_processor_handle processor_han
 
 amdsmi_status_t amdsmi_get_gpu_vram_vendor(amdsmi_processor_handle processor_handle, char* brand,
                                            uint32_t len) {
-  return rsmi_wrapper(rsmi_dev_vram_vendor_get, processor_handle, 0, brand, len);
+  amdsmi_vram_info_t info;
+  amdsmi_status_t r = amdsmi_get_gpu_vram_info(processor_handle, &info);
+  snprintf(brand, len, "%s", info.vram_vendor);
+  return (r);
 }
 
 amdsmi_status_t amdsmi_get_gpu_vram_info(amdsmi_processor_handle processor_handle,


### PR DESCRIPTION
## Motivation
The API amdsmi_get_gpu_vram_vendor() is being deprecated in favor of amdsmi_get_gpu_vram_info()

## Technical Details
Mark amdsmi_get_gpu_vram_vendor() as deprecated.

## JIRA ID
AILITOOLS-268