### PR TITLE
[rocshmem] use constmem for backend and provider muxing

### DIFF
--- a/projects/rocshmem/include/rocshmem/rocshmem_common.hpp
+++ b/projects/rocshmem/include/rocshmem/rocshmem_common.hpp
@@ -145,7 +145,7 @@ void set_internal_ctx(rocshmem_ctx_t *ctx);
  */
 //TODO: this should remain internal?
 enum class BackendType { GDA_BACKEND, RO_BACKEND, IPC_BACKEND };
-BackendType get_backend_type();
+BackendType rocshmem_query_backend_type();
 
 typedef uint64_t *rocshmem_team_t;
 

--- a/projects/rocshmem/src/backend_bc.hpp
+++ b/projects/rocshmem/src/backend_bc.hpp
@@ -293,7 +293,7 @@ class Backend {
    */
   TeamTracker team_tracker{};
 
-  BackendType get_backend_type() { return type; }
+  BackendType get_type() { return type; }
 
   /**
    * Fine grained memory allocator for buffers used in collectives Routines

--- a/projects/rocshmem/src/backend_type.hpp
+++ b/projects/rocshmem/src/backend_type.hpp
@@ -59,7 +59,7 @@ namespace rocshmem {
  */
 #if defined(USE_GDA) && defined(USE_RO) && defined(USE_IPC)
 #define DISPATCH(Func)                     \
-  switch(constmem.backend_type) {                 \
+  switch(constmem.backend_type) {          \
   case BackendType::GDA_BACKEND:           \
     static_cast<GDAContext *>(this)->Func; \
     break;                                 \
@@ -86,16 +86,16 @@ namespace rocshmem {
  * @brief Device static dispatch method call with a return value.
  */
 #if defined(USE_GDA) && defined(USE_RO) && defined(USE_IPC)
-#define DISPATCH_RET(Func)                                \
-  if (constmem.backend_type == BackendType::GDA_BACKEND) {       \
-    auto ret1 = static_cast<GDAContext *>(this)->Func;    \
-    return ret1;                                          \
-  } else if(constmem.backend_type == BackendType::RO_BACKEND) {   \
-    auto ret2 = static_cast<ROContext *>(this)->Func;     \
-    return ret2;                                          \
-  } else {                                                \
-    auto ret3 = static_cast<IPCContext *>(this)->Func;    \
-    return ret3;                                          \
+#define DISPATCH_RET(Func)                                      \
+  if (constmem.backend_type == BackendType::GDA_BACKEND) {      \
+    auto ret1 = static_cast<GDAContext *>(this)->Func;          \
+    return ret1;                                                \
+  } else if(constmem.backend_type == BackendType::RO_BACKEND) { \
+    auto ret2 = static_cast<ROContext *>(this)->Func;           \
+    return ret2;                                                \
+  } else {                                                      \
+    auto ret3 = static_cast<IPCContext *>(this)->Func;          \
+    return ret3;                                                \
   }
 #elif defined(USE_GDA)
 #define DISPATCH_RET(Func)                              \
@@ -117,7 +117,7 @@ namespace rocshmem {
 #if defined(USE_GDA) && defined(USE_RO) && defined(USE_IPC)
 #define DISPATCH_RET_PTR(Func)                       \
   void *ret_val{nullptr};                            \
-  switch(constmem.backend_type) {                           \
+  switch(constmem.backend_type) {                    \
   case BackendType::GDA_BACKEND:                     \
     ret_val = static_cast<GDAContext *>(this)->Func; \
     break;                                           \

--- a/projects/rocshmem/src/backend_type.hpp
+++ b/projects/rocshmem/src/backend_type.hpp
@@ -37,6 +37,7 @@
  */
 
 #include "rocshmem/rocshmem_config.h"  // NOLINT(build/include_subdir)
+#include "constmem.hpp"
 
 namespace rocshmem {
 
@@ -58,7 +59,7 @@ namespace rocshmem {
  */
 #if defined(USE_GDA) && defined(USE_RO) && defined(USE_IPC)
 #define DISPATCH(Func)                     \
-  switch(this->btype) {                    \
+  switch(constmem.backend_type) {                 \
   case BackendType::GDA_BACKEND:           \
     static_cast<GDAContext *>(this)->Func; \
     break;                                 \
@@ -86,10 +87,10 @@ namespace rocshmem {
  */
 #if defined(USE_GDA) && defined(USE_RO) && defined(USE_IPC)
 #define DISPATCH_RET(Func)                                \
-  if (this->btype == BackendType::GDA_BACKEND) {          \
+  if (constmem.backend_type == BackendType::GDA_BACKEND) {       \
     auto ret1 = static_cast<GDAContext *>(this)->Func;    \
     return ret1;                                          \
-  } else if(this->btype == BackendType::RO_BACKEND) {     \
+  } else if(constmem.backend_type == BackendType::RO_BACKEND) {   \
     auto ret2 = static_cast<ROContext *>(this)->Func;     \
     return ret2;                                          \
   } else {                                                \
@@ -116,7 +117,7 @@ namespace rocshmem {
 #if defined(USE_GDA) && defined(USE_RO) && defined(USE_IPC)
 #define DISPATCH_RET_PTR(Func)                       \
   void *ret_val{nullptr};                            \
-  switch(this->btype) {                              \
+  switch(constmem.backend_type) {                           \
   case BackendType::GDA_BACKEND:                     \
     ret_val = static_cast<GDAContext *>(this)->Func; \
     break;                                           \

--- a/projects/rocshmem/src/constmem.cpp
+++ b/projects/rocshmem/src/constmem.cpp
@@ -35,7 +35,9 @@ void init_constant_memory(void) {
 
   constmem_values.backend_type = backend->get_type();
 #if defined(USE_GDA)
-  constmem_values.gda_provider = static_cast<GDABackend*>(backend)->get_gda_provider();
+  if (constmem_values.backend_type == BackendType::GDA_BACKEND) {
+    constmem_values.gda_provider = static_cast<GDABackend*>(backend)->get_gda_provider();
+  }
 #endif
 
   CHECK_HIP(hipMemcpyToSymbol(HIP_SYMBOL(constmem), &constmem_values, sizeof(constmem_t)));

--- a/projects/rocshmem/src/constmem.cpp
+++ b/projects/rocshmem/src/constmem.cpp
@@ -1,6 +1,9 @@
 #include "constmem.hpp"
 #include "backend_bc.hpp"
 #include "envvar.hpp"
+#if defined(USE_GDA)
+#include "gda/backend_gda.hpp"
+#endif
 
 namespace rocshmem {
 
@@ -28,6 +31,9 @@ void init_constant_memory(void) {
                                  ? backend->ipcImpl.shm_size : 0;
 
   constmem_values.backend_type = backend->get_type();
+#if defined(USE_GDA)
+  constmem_values.gda_provider = static_cast<GDABackend*>(backend)->get_gda_provider();
+#endif
 
   CHECK_HIP(hipMemcpyToSymbol(HIP_SYMBOL(constmem), &constmem_values, sizeof(constmem_t)));
 }

--- a/projects/rocshmem/src/constmem.cpp
+++ b/projects/rocshmem/src/constmem.cpp
@@ -23,6 +23,9 @@ void init_constant_memory(void) {
     constmem_values.alltoall_wg_algo = gda::ALLTOALLV_WG_ALGO_COPY;
   }
 
+  constmem_values.my_pe = backend->getMyPE();
+  constmem_values.num_pes = backend->getNumPEs();
+
   constmem_values.ipc_first_pe = backend->ipcImpl.ipc_first_pe;
   constmem_values.ipc_stride = backend->ipcImpl.ipc_stride;
   // ipc_shm_size == 0 means IPC disabled (fast early return on device).

--- a/projects/rocshmem/src/constmem.cpp
+++ b/projects/rocshmem/src/constmem.cpp
@@ -27,6 +27,8 @@ void init_constant_memory(void) {
   constmem_values.ipc_shm_size = (backend->ipcImpl.pes_with_ipc_avail != nullptr)
                                  ? backend->ipcImpl.shm_size : 0;
 
+  constmem_values.backend_type = backend->get_type();
+
   CHECK_HIP(hipMemcpyToSymbol(HIP_SYMBOL(constmem), &constmem_values, sizeof(constmem_t)));
 }
 

--- a/projects/rocshmem/src/constmem.hpp
+++ b/projects/rocshmem/src/constmem.hpp
@@ -35,6 +35,7 @@ namespace rocshmem {
 
 struct constmem_t {
   BackendType backend_type;
+  gda::provider gda_provider;
   uint64_t alltoall_wg_algo;
   int ipc_first_pe;
   int ipc_stride;    // 0 = pattern invalid (use fallback linear scan)

--- a/projects/rocshmem/src/constmem.hpp
+++ b/projects/rocshmem/src/constmem.hpp
@@ -37,6 +37,8 @@ struct constmem_t {
   BackendType backend_type;
   GDAProvider gda_provider;
   uint64_t alltoall_wg_algo;
+  int my_pe;
+  int num_pes;
   int ipc_first_pe;
   int ipc_stride;    // 0 = pattern invalid (use fallback linear scan)
   int ipc_shm_size;

--- a/projects/rocshmem/src/constmem.hpp
+++ b/projects/rocshmem/src/constmem.hpp
@@ -25,12 +25,16 @@
 #ifndef LIBRARY_SRC_CONSTMEM_HPP_
 #define LIBRARY_SRC_CONSTMEM_HPP_
 
+#include <array>
+
 #include "gda/gda_enums.hpp"
+#include "rocshmem/rocshmem_common.hpp"
 #include "util.hpp"
 
 namespace rocshmem {
 
 struct constmem_t {
+  BackendType backend_type;
   uint64_t alltoall_wg_algo;
   int ipc_first_pe;
   int ipc_stride;    // 0 = pattern invalid (use fallback linear scan)

--- a/projects/rocshmem/src/constmem.hpp
+++ b/projects/rocshmem/src/constmem.hpp
@@ -35,7 +35,7 @@ namespace rocshmem {
 
 struct constmem_t {
   BackendType backend_type;
-  gda::provider gda_provider;
+  GDAProvider gda_provider;
   uint64_t alltoall_wg_algo;
   int ipc_first_pe;
   int ipc_stride;    // 0 = pattern invalid (use fallback linear scan)

--- a/projects/rocshmem/src/gda/backend_gda.cpp
+++ b/projects/rocshmem/src/gda/backend_gda.cpp
@@ -805,48 +805,48 @@ void GDABackend::rte_barrier() {
   }
 }
 
-gda::provider GDABackend::requested_provider() {
+GDAProvider GDABackend::requested_provider() {
   /* Check whether the user explicitly requests a particular provider type */
   std::string envstr = envvar::gda::provider;
   std::transform(envstr.begin(), envstr.end(), envstr.begin(), ::tolower);
   if (!envstr.empty()) {
     LOG_INFO("Found environment variable ROCSHMEM_GDA_PROVIDER, value is %s", envstr.c_str());
     if (envstr.find("bnxt") != std::string::npos) {
-      return gda::provider::BNXT;
+      return GDAProvider::BNXT;
     }
     if (envstr.find("ionic") != std::string::npos || envstr.find("pensando") != std::string::npos) {
-      return gda::provider::IONIC;
+      return GDAProvider::IONIC;
     }
     if (envstr.find("mlx5") != std::string::npos) {
-      return gda::provider::MLX5;
+      return GDAProvider::MLX5;
     }
   }
-  return gda::provider::UNSET;
+  return GDAProvider::UNSET;
 }
 
 /* Check if a device's vendor ID matches the expected vendor for a given provider.
  * Returns true if the device matches, false otherwise.
  */
-bool GDABackend::device_matches_provider_vendor(gda::provider provider,
+bool GDABackend::device_matches_provider_vendor(GDAProvider provider,
                                                  const struct ibv_device_attr &device_attr,
                                                  [[maybe_unused]] const char *device_name) {
   uint32_t expected_vendor_id = 0;
   [[maybe_unused]] const char *vendor_name = nullptr;
 
   switch (provider) {
-    case gda::provider::BNXT:
+    case GDAProvider::BNXT:
       expected_vendor_id = GDA_BNXT_VENDOR_ID;
       vendor_name = "BNXT/Broadcom";
       break;
-    case gda::provider::IONIC:
+    case GDAProvider::IONIC:
       expected_vendor_id = GDA_IONIC_VENDOR_ID;
       vendor_name = "IONIC/Pensando";
       break;
-    case gda::provider::MLX5:
+    case GDAProvider::MLX5:
       expected_vendor_id = GDA_MLX5_VENDOR_ID;
       vendor_name = "MLX5/Mellanox";
       break;
-    case gda::provider::UNSET:
+    case GDAProvider::UNSET:
       // UNSET accepts any vendor
       return true;
     default:
@@ -867,7 +867,7 @@ bool GDABackend::device_matches_provider_vendor(gda::provider provider,
  * the wrong NIC when multiple vendors are present.
  * Returns true if at least one active port is found on a matching device.
  */
-bool GDABackend::has_active_ib_interface(gda::provider provider) {
+bool GDABackend::has_active_ib_interface(GDAProvider provider) {
   struct ibv_device **device_list = nullptr;
   int num_devices = 0;
   bool has_active = false;
@@ -925,7 +925,7 @@ bool GDABackend::has_active_ib_interface(gda::provider provider) {
  */
 int GDABackend::backend_can_run() {
   void *handle{nullptr};
-  gda::provider requested = requested_provider();
+  GDAProvider requested = requested_provider();
 
   /* Libnuma ? */
   if (!numa.is_available()) {
@@ -938,10 +938,10 @@ int GDABackend::backend_can_run() {
 
   /* Try opening bnxt DV libraries */
 #if defined(GDA_BNXT)
-  if (requested == gda::provider::UNSET || requested == gda::provider::BNXT) {
+  if (requested == GDAProvider::UNSET || requested == GDAProvider::BNXT) {
     handle = bnxt_dv_dlopen();
     if (handle) {
-      auto ret = has_active_ib_interface(gda::provider::BNXT);
+      auto ret = has_active_ib_interface(GDAProvider::BNXT);
 //      dlclose(handle); //TODO: unloading the lib crashes the next call to ibv_open_device
       if (ret) return ROCSHMEM_SUCCESS;
       LOG_TRACE("BNXT DV library found but no active InfiniBand interface available");
@@ -951,10 +951,10 @@ int GDABackend::backend_can_run() {
 
   /* Try opening ionic DV libraries */
 #if defined(GDA_IONIC)
-  if (requested == gda::provider::UNSET || requested == gda::provider::IONIC) {
+  if (requested == GDAProvider::UNSET || requested == GDAProvider::IONIC) {
     handle = ionic_dv_dlopen();
     if (handle) {
-      auto ret = has_active_ib_interface(gda::provider::IONIC);
+      auto ret = has_active_ib_interface(GDAProvider::IONIC);
 //      dlclose(handle); //TODO: unloading the lib crashes the next call to ibv_open_device
       if (ret) return ROCSHMEM_SUCCESS;
       LOG_TRACE("IONIC DV library found but no active InfiniBand interface available");
@@ -964,10 +964,10 @@ int GDABackend::backend_can_run() {
 
   /* Try opening mlx5 DV libraries */
 #if defined(GDA_MLX5)
-  if (requested == gda::provider::UNSET || requested == gda::provider::MLX5) {
+  if (requested == GDAProvider::UNSET || requested == GDAProvider::MLX5) {
     handle = mlx5_dv_dlopen();
     if (handle) {
-      auto ret = has_active_ib_interface(gda::provider::MLX5);
+      auto ret = has_active_ib_interface(GDAProvider::MLX5);
 //      dlclose(handle); //TODO: unloading the lib crashes the next call to ibv_open_device
       if (ret) return ROCSHMEM_SUCCESS;
       LOG_TRACE("MLX5 DV library found but no active InfiniBand interface available");
@@ -997,7 +997,7 @@ void GDABackend::setup_ibv() {
 void GDABackend::cleanup_ibv() {
   int err;
 
-  if (gda_provider == gda::provider::BNXT) {
+  if (gda_provider == GDAProvider::BNXT) {
     for (size_t i = 0; i < qps.size(); i++) {
       NicDevice &nic = nic_for_qp(i);
 
@@ -1039,7 +1039,7 @@ void GDABackend::cleanup_ibv() {
       qp_allocator_->deallocate(bnxt_scqs[i].buf);
       qp_allocator_->deallocate(bnxt_rcqs[i].buf);
     }
-  } else if (gda_provider == gda::provider::MLX5) {
+  } else if (gda_provider == GDAProvider::MLX5) {
     for (size_t i = 0; i < mlx5_qps.size(); i++) {
       // mlx5dv::destroy_qp also destroys the associated CQ
       err = mlx5dv.destroy_qp(mlx5_qps[i]);
@@ -1056,7 +1056,7 @@ void GDABackend::cleanup_ibv() {
   }
 
   for (auto &nic : nic_devices_) {
-    if (gda_provider == gda::provider::IONIC) {
+    if (gda_provider == GDAProvider::IONIC) {
       if (nic.pd_uxdma[0]) {
         err = ibv.dealloc_pd(nic.pd_uxdma[0]);
         CHECK_ZERO(err, "ibv_dealloc_pd (uxdma[0])");
@@ -1084,18 +1084,18 @@ void GDABackend::cleanup_ibv() {
 
 void GDABackend::open_dv_libs() {
   int ret;
-  gda::provider requested = requested_provider();
+  GDAProvider requested = requested_provider();
 
   //this hardcoded init order will always prefer BNXT>IONIC>MLX5
   //if all three drivers are installed and enabled
 
 #if defined(GDA_BNXT)
-  if (gda_provider == gda::provider::UNSET
-  && (requested == gda::provider::UNSET || requested == gda::provider::BNXT)) {
+  if (gda_provider == GDAProvider::UNSET
+  && (requested == GDAProvider::UNSET || requested == GDAProvider::BNXT)) {
     ret = bnxt_dv_dl_init();
 
     if (ret == ROCSHMEM_SUCCESS) {
-      gda_provider = gda::provider::BNXT;
+      gda_provider = GDAProvider::BNXT;
     } else {
       LOG_TRACE("Initializing rocSHMEM BNXT GDA support failed");
     }
@@ -1103,12 +1103,12 @@ void GDABackend::open_dv_libs() {
 #endif // defined(GDA_BNXT)
 
 #if defined(GDA_IONIC)
-  if (gda_provider == gda::provider::UNSET
-  && (requested == gda::provider::UNSET || requested == gda::provider::IONIC)) {
+  if (gda_provider == GDAProvider::UNSET
+  && (requested == GDAProvider::UNSET || requested == GDAProvider::IONIC)) {
     ret = ionic_dv_dl_init();
 
     if (ret == ROCSHMEM_SUCCESS) {
-      gda_provider = gda::provider::IONIC;
+      gda_provider = GDAProvider::IONIC;
     } else {
       LOG_TRACE("Initializing rocSHMEM IONIC GDA support failed");
     }
@@ -1116,19 +1116,19 @@ void GDABackend::open_dv_libs() {
 #endif // defined(GDA_IONIC)
 
 #if defined(GDA_MLX5)
-  if (gda_provider == gda::provider::UNSET
-  && (requested == gda::provider::UNSET || requested == gda::provider::MLX5)) {
+  if (gda_provider == GDAProvider::UNSET
+  && (requested == GDAProvider::UNSET || requested == GDAProvider::MLX5)) {
     ret = mlx5_dv_dl_init();
 
     if (ret == ROCSHMEM_SUCCESS) {
-      gda_provider = gda::provider::MLX5;
+      gda_provider = GDAProvider::MLX5;
     } else {
       LOG_TRACE("Initializing rocSHMEM MLX5 GDA support failed");
     }
   }
 #endif // defined(GDA_MLX5)
 
-  if (gda_provider == gda::provider::UNSET) {
+  if (gda_provider == GDAProvider::UNSET) {
     LOG_ERROR_EXIT("gda:open_dv_libs: no DV library could dlopen for IONIC, BNXT, or MLX5 GDA support");
   }
 }
@@ -1143,14 +1143,14 @@ void GDABackend::close_dv_libs() {
   if (mlx5dv_handle_ != nullptr)
     dlclose(mlx5dv_handle_);
 
-  gda_provider = gda::provider::UNSET;
+  gda_provider = GDAProvider::UNSET;
 }
 
 void GDABackend::exchange_qp_dest_info() {
   for (size_t i = 0; i < qps.size(); i++) {
     NicDevice &nic = nic_for_qp(i);
     dest_info[i].lid = nic.portinfo.lid;
-    if (gda_provider == gda::provider::MLX5) {
+    if (gda_provider == GDAProvider::MLX5) {
       dest_info[i].qpn = mlx5_qps[i].qpn;
     } else {
       dest_info[i].qpn = qps[i]->qp_num;
@@ -1287,7 +1287,7 @@ void GDABackend::open_ib_device() {
         nic.nic_name.c_str());
     }
 
-    if (gda_provider == gda::provider::MLX5) {
+    if (gda_provider == GDAProvider::MLX5) {
       /* Explicitly request DevX context */
       struct mlx5dv_context_attr context_attr = {};
       context_attr.flags = MLX5DV_CONTEXT_FLAGS_DEVX;
@@ -1305,7 +1305,7 @@ void GDABackend::open_ib_device() {
     CHECK_NNULL(nic.pd_orig, "ib allocate pd");
     dump_ibv_pd(nic.pd_orig);
 
-    if (gda_provider == gda::provider::IONIC) {
+    if (gda_provider == GDAProvider::IONIC) {
       create_parent_domain(nic);
     }
 
@@ -1339,12 +1339,12 @@ void GDABackend::validate_ib_device(NicDevice &nic) {
   err = ibv.query_device(nic.context, &nic.device_attr);
   CHECK_ZERO(err, "ibv_query_device");
 
-  if (gda_provider == gda::provider::BNXT) {
+  if (gda_provider == GDAProvider::BNXT) {
     const std::set<uint32_t> supported_bnxt_part_ids = { 0x1760 /* BCM57608 */};
     const char min_supported_bnxt_fw_ver[12] = "233.2.104.0";
 
     if (nic.device_attr.vendor_id != GDA_BNXT_VENDOR_ID) {
-      LOG_ERROR_EXIT("%s gda::provider::BNXT requested but an invalid device is selected", debug_str.c_str());
+      LOG_ERROR_EXIT("%s GDAProvider::BNXT requested but an invalid device is selected", debug_str.c_str());
     }
 
     if (supported_bnxt_part_ids.find(nic.device_attr.vendor_part_id) == supported_bnxt_part_ids.end()) {
@@ -1397,9 +1397,9 @@ void GDABackend::modify_qps_reset_to_init() {
     NicDevice &nic = nic_for_qp(i);
     attr.port_num = nic.port;
 
-    if (gda_provider == gda::provider::BNXT) {
+    if (gda_provider == GDAProvider::BNXT) {
       err = bnxt_re_dv.modify_qp(qps[i], &attr, attr_mask, 0, 0);
-    } else if (gda_provider == gda::provider::MLX5) {
+    } else if (gda_provider == GDAProvider::MLX5) {
       err = mlx5dv.modify_qp(mlx5_qps[i], &attr, attr_mask, nic.gid_type);
     } else {
       err = ibv.modify_qp(qps[i], &attr, attr_mask);
@@ -1417,7 +1417,7 @@ void GDABackend::modify_qps_init_to_rtr() {
   attr.qp_state               = IBV_QPS_RTR;
   attr.min_rnr_timer          = 12;
 
-  if (gda_provider == gda::provider::IONIC) {
+  if (gda_provider == GDAProvider::IONIC) {
     attr.max_dest_rd_atomic = 15;
   } else {
     attr.max_dest_rd_atomic = 1;
@@ -1460,9 +1460,9 @@ void GDABackend::modify_qps_init_to_rtr() {
       attr.ah_attr.dlid = dest_info[i].lid;
     }
 
-    if (gda_provider == gda::provider::BNXT) {
+    if (gda_provider == GDAProvider::BNXT) {
       err = bnxt_re_dv.modify_qp(qps[i], &attr, attr_mask, 0, 0);
-    } else if (gda_provider == gda::provider::MLX5) {
+    } else if (gda_provider == GDAProvider::MLX5) {
       err = mlx5dv.modify_qp(mlx5_qps[i], &attr, attr_mask, nic.gid_type);
     } else {
       err = ibv.modify_qp(qps[i], &attr, attr_mask);
@@ -1482,7 +1482,7 @@ void GDABackend::modify_qps_rtr_to_rts() {
   attr.retry_cnt     = 7;
   attr.rnr_retry     = 7;
 
-  if (gda_provider == gda::provider::IONIC) {
+  if (gda_provider == GDAProvider::IONIC) {
     attr.max_rd_atomic = 15;
   } else {
     attr.max_rd_atomic = 1;
@@ -1499,9 +1499,9 @@ void GDABackend::modify_qps_rtr_to_rts() {
     NicDevice &nic = nic_for_qp(i);
     attr.sq_psn = dest_info[i].psn;
 
-    if (gda_provider == gda::provider::BNXT) {
+    if (gda_provider == GDAProvider::BNXT) {
       err = bnxt_re_dv.modify_qp(qps[i], &attr, attr_mask, 0, 0);
-    } else if (gda_provider == gda::provider::MLX5) {
+    } else if (gda_provider == GDAProvider::MLX5) {
       err = mlx5dv.modify_qp(mlx5_qps[i], &attr, attr_mask, nic.gid_type);
     } else {
       err = ibv.modify_qp(qps[i], &attr, attr_mask);
@@ -1514,7 +1514,7 @@ void GDABackend::create_queues() {
   int ncqes;
   uint32_t sq_size = envvar::gda::sq_size;
 
-  if (gda_provider == gda::provider::IONIC) {
+  if (gda_provider == GDAProvider::IONIC) {
     ncqes = sq_size << 1;
   } else {
     ncqes = sq_size;
@@ -1530,13 +1530,13 @@ void GDABackend::create_queues() {
 
   mlx5_qps.resize(num_qps);
 
-  if (gda_provider == gda::provider::BNXT) {
+  if (gda_provider == GDAProvider::BNXT) {
     bnxt_create_cqs(ncqes);
     bnxt_create_qps(sq_size);
-  } else if (gda_provider == gda::provider::IONIC) {
+  } else if (gda_provider == GDAProvider::IONIC) {
     ionic_create_cqs(ncqes);
     create_qps(sq_size);
-  } else if (gda_provider == gda::provider::MLX5) {
+  } else if (gda_provider == GDAProvider::MLX5) {
     // mlx5_create_qps also creates the associated CQs
     mlx5_create_qps(sq_size);
   }
@@ -1624,7 +1624,7 @@ void GDABackend::create_parent_domain(NicDevice &nic) {
   pattr.free       = GDABackend::pd_release;
   pattr.pd_context = nullptr;
 
-  if (gda_provider == gda::provider::IONIC) {
+  if (gda_provider == GDAProvider::IONIC) {
     pattr.alloc      = GDABackend::pd_alloc_device_uncached;
   } else {
     pattr.alloc      = GDABackend::pd_alloc_host;
@@ -1634,7 +1634,7 @@ void GDABackend::create_parent_domain(NicDevice &nic) {
   CHECK_NNULL(nic.pd_parent, "ibv_alloc_parent_domain");
   dump_ibv_pd(nic.pd_parent);
 
-  if (gda_provider == gda::provider::IONIC) {
+  if (gda_provider == GDAProvider::IONIC) {
     ionic_setup_parent_domain(nic, &pattr);
   }
 }
@@ -1643,8 +1643,8 @@ void GDABackend::create_cqs(int cqe) {
   struct ibv_cq_init_attr_ex cq_attr;
   struct ibv_cq_ex *cq_ex;
 
-  assert(gda_provider != gda::provider::BNXT);
-  assert(gda_provider != gda::provider::IONIC);
+  assert(gda_provider != GDAProvider::BNXT);
+  assert(gda_provider != GDAProvider::IONIC);
 
   memset(&cq_attr, 0, sizeof(struct ibv_cq_init_attr_ex));
   cq_attr.cqe           = cqe;
@@ -1660,7 +1660,7 @@ void GDABackend::create_cqs(int cqe) {
    *    and linux/include/linux/mlx5/mlx5_ifc.h for Completion Queue Context definition
    *  - see also rdma-core/libibverbs/cmd_cq.c and linux/drivers/infiniband/hw/mlx5/cq.c
    *    for how this flag sets the bit */
-  if (gda_provider == gda::provider::MLX5) {
+  if (gda_provider == GDAProvider::MLX5) {
     cq_attr.cqe         = 1;
     cq_attr.comp_mask  |= IBV_CQ_INIT_ATTR_MASK_FLAGS;
     cq_attr.flags      |= IBV_CREATE_CQ_ATTR_IGNORE_OVERRUN;
@@ -1679,19 +1679,19 @@ void GDABackend::create_cqs(int cqe) {
 
 void GDABackend::initialize_gpu_qp(QueuePair* gpu_qp, int conn_num) {
   switch (gda_provider) {
-  case gda::provider::IONIC:
+  case GDAProvider::IONIC:
     ionic_initialize_gpu_qp(gpu_qp, conn_num);
     dump_ibv_qp(qps[conn_num], conn_num);
     break;
-  case gda::provider::BNXT:
+  case GDAProvider::BNXT:
     bnxt_initialize_gpu_qp(gpu_qp, conn_num);
     dump_ibv_qp(qps[conn_num], conn_num);
     break;
-  case gda::provider::MLX5:
+  case GDAProvider::MLX5:
     mlx5_initialize_gpu_qp(gpu_qp, conn_num);
     break;
   default:
-    assert(false /* gda::provider initialize_gpu_qp */);
+    assert(false /* GDAProvider initialize_gpu_qp */);
   }
 }
 
@@ -1706,13 +1706,13 @@ void GDABackend::create_qps(int sq_length) {
   attr.qp_type             = IBV_QPT_RC;
   attr.comp_mask           = IBV_QP_INIT_ATTR_PD;
 
-  if (gda_provider == gda::provider::IONIC) {
+  if (gda_provider == GDAProvider::IONIC) {
     attr.cap.max_recv_sge    = 1; // TODO allow zero sges in the driver
   }
 
   for (size_t i = 0; i < qps.size(); i++) {
     NicDevice &nic = nic_for_qp(i);
-    if (gda_provider == gda::provider::IONIC) {
+    if (gda_provider == GDAProvider::IONIC) {
       attr.pd = nic.pd_uxdma[i & 1];
     } else {
       attr.pd = nic.pd_parent;

--- a/projects/rocshmem/src/gda/backend_gda.cpp
+++ b/projects/rocshmem/src/gda/backend_gda.cpp
@@ -805,48 +805,48 @@ void GDABackend::rte_barrier() {
   }
 }
 
-GDAProvider GDABackend::requested_provider() {
+gda::provider GDABackend::requested_provider() {
   /* Check whether the user explicitly requests a particular provider type */
   std::string envstr = envvar::gda::provider;
   std::transform(envstr.begin(), envstr.end(), envstr.begin(), ::tolower);
   if (!envstr.empty()) {
     LOG_INFO("Found environment variable ROCSHMEM_GDA_PROVIDER, value is %s", envstr.c_str());
     if (envstr.find("bnxt") != std::string::npos) {
-      return GDAProvider::BNXT;
+      return gda::provider::BNXT;
     }
     if (envstr.find("ionic") != std::string::npos || envstr.find("pensando") != std::string::npos) {
-      return GDAProvider::IONIC;
+      return gda::provider::IONIC;
     }
     if (envstr.find("mlx5") != std::string::npos) {
-      return GDAProvider::MLX5;
+      return gda::provider::MLX5;
     }
   }
-  return GDAProvider::UNSET;
+  return gda::provider::UNSET;
 }
 
 /* Check if a device's vendor ID matches the expected vendor for a given provider.
  * Returns true if the device matches, false otherwise.
  */
-bool GDABackend::device_matches_provider_vendor(GDAProvider provider,
+bool GDABackend::device_matches_provider_vendor(gda::provider provider,
                                                  const struct ibv_device_attr &device_attr,
                                                  [[maybe_unused]] const char *device_name) {
   uint32_t expected_vendor_id = 0;
   [[maybe_unused]] const char *vendor_name = nullptr;
 
   switch (provider) {
-    case GDAProvider::BNXT:
+    case gda::provider::BNXT:
       expected_vendor_id = GDA_BNXT_VENDOR_ID;
       vendor_name = "BNXT/Broadcom";
       break;
-    case GDAProvider::IONIC:
+    case gda::provider::IONIC:
       expected_vendor_id = GDA_IONIC_VENDOR_ID;
       vendor_name = "IONIC/Pensando";
       break;
-    case GDAProvider::MLX5:
+    case gda::provider::MLX5:
       expected_vendor_id = GDA_MLX5_VENDOR_ID;
       vendor_name = "MLX5/Mellanox";
       break;
-    case GDAProvider::UNSET:
+    case gda::provider::UNSET:
       // UNSET accepts any vendor
       return true;
     default:
@@ -867,7 +867,7 @@ bool GDABackend::device_matches_provider_vendor(GDAProvider provider,
  * the wrong NIC when multiple vendors are present.
  * Returns true if at least one active port is found on a matching device.
  */
-bool GDABackend::has_active_ib_interface(GDAProvider provider) {
+bool GDABackend::has_active_ib_interface(gda::provider provider) {
   struct ibv_device **device_list = nullptr;
   int num_devices = 0;
   bool has_active = false;
@@ -925,7 +925,7 @@ bool GDABackend::has_active_ib_interface(GDAProvider provider) {
  */
 int GDABackend::backend_can_run() {
   void *handle{nullptr};
-  GDAProvider requested = requested_provider();
+  gda::provider requested = requested_provider();
 
   /* Libnuma ? */
   if (!numa.is_available()) {
@@ -938,10 +938,10 @@ int GDABackend::backend_can_run() {
 
   /* Try opening bnxt DV libraries */
 #if defined(GDA_BNXT)
-  if (requested == GDAProvider::UNSET || requested == GDAProvider::BNXT) {
+  if (requested == gda::provider::UNSET || requested == gda::provider::BNXT) {
     handle = bnxt_dv_dlopen();
     if (handle) {
-      auto ret = has_active_ib_interface(GDAProvider::BNXT);
+      auto ret = has_active_ib_interface(gda::provider::BNXT);
 //      dlclose(handle); //TODO: unloading the lib crashes the next call to ibv_open_device
       if (ret) return ROCSHMEM_SUCCESS;
       LOG_TRACE("BNXT DV library found but no active InfiniBand interface available");
@@ -951,10 +951,10 @@ int GDABackend::backend_can_run() {
 
   /* Try opening ionic DV libraries */
 #if defined(GDA_IONIC)
-  if (requested == GDAProvider::UNSET || requested == GDAProvider::IONIC) {
+  if (requested == gda::provider::UNSET || requested == gda::provider::IONIC) {
     handle = ionic_dv_dlopen();
     if (handle) {
-      auto ret = has_active_ib_interface(GDAProvider::IONIC);
+      auto ret = has_active_ib_interface(gda::provider::IONIC);
 //      dlclose(handle); //TODO: unloading the lib crashes the next call to ibv_open_device
       if (ret) return ROCSHMEM_SUCCESS;
       LOG_TRACE("IONIC DV library found but no active InfiniBand interface available");
@@ -964,10 +964,10 @@ int GDABackend::backend_can_run() {
 
   /* Try opening mlx5 DV libraries */
 #if defined(GDA_MLX5)
-  if (requested == GDAProvider::UNSET || requested == GDAProvider::MLX5) {
+  if (requested == gda::provider::UNSET || requested == gda::provider::MLX5) {
     handle = mlx5_dv_dlopen();
     if (handle) {
-      auto ret = has_active_ib_interface(GDAProvider::MLX5);
+      auto ret = has_active_ib_interface(gda::provider::MLX5);
 //      dlclose(handle); //TODO: unloading the lib crashes the next call to ibv_open_device
       if (ret) return ROCSHMEM_SUCCESS;
       LOG_TRACE("MLX5 DV library found but no active InfiniBand interface available");
@@ -997,7 +997,7 @@ void GDABackend::setup_ibv() {
 void GDABackend::cleanup_ibv() {
   int err;
 
-  if (gda_provider == GDAProvider::BNXT) {
+  if (gda_provider == gda::provider::BNXT) {
     for (size_t i = 0; i < qps.size(); i++) {
       NicDevice &nic = nic_for_qp(i);
 
@@ -1039,7 +1039,7 @@ void GDABackend::cleanup_ibv() {
       qp_allocator_->deallocate(bnxt_scqs[i].buf);
       qp_allocator_->deallocate(bnxt_rcqs[i].buf);
     }
-  } else if (gda_provider == GDAProvider::MLX5) {
+  } else if (gda_provider == gda::provider::MLX5) {
     for (size_t i = 0; i < mlx5_qps.size(); i++) {
       // mlx5dv::destroy_qp also destroys the associated CQ
       err = mlx5dv.destroy_qp(mlx5_qps[i]);
@@ -1056,7 +1056,7 @@ void GDABackend::cleanup_ibv() {
   }
 
   for (auto &nic : nic_devices_) {
-    if (gda_provider == GDAProvider::IONIC) {
+    if (gda_provider == gda::provider::IONIC) {
       if (nic.pd_uxdma[0]) {
         err = ibv.dealloc_pd(nic.pd_uxdma[0]);
         CHECK_ZERO(err, "ibv_dealloc_pd (uxdma[0])");
@@ -1084,18 +1084,18 @@ void GDABackend::cleanup_ibv() {
 
 void GDABackend::open_dv_libs() {
   int ret;
-  GDAProvider requested = requested_provider();
+  gda::provider requested = requested_provider();
 
   //this hardcoded init order will always prefer BNXT>IONIC>MLX5
   //if all three drivers are installed and enabled
 
 #if defined(GDA_BNXT)
-  if (gda_provider == GDAProvider::UNSET
-  && (requested == GDAProvider::UNSET || requested == GDAProvider::BNXT)) {
+  if (gda_provider == gda::provider::UNSET
+  && (requested == gda::provider::UNSET || requested == gda::provider::BNXT)) {
     ret = bnxt_dv_dl_init();
 
     if (ret == ROCSHMEM_SUCCESS) {
-      gda_provider = GDAProvider::BNXT;
+      gda_provider = gda::provider::BNXT;
     } else {
       LOG_TRACE("Initializing rocSHMEM BNXT GDA support failed");
     }
@@ -1103,12 +1103,12 @@ void GDABackend::open_dv_libs() {
 #endif // defined(GDA_BNXT)
 
 #if defined(GDA_IONIC)
-  if (gda_provider == GDAProvider::UNSET
-  && (requested == GDAProvider::UNSET || requested == GDAProvider::IONIC)) {
+  if (gda_provider == gda::provider::UNSET
+  && (requested == gda::provider::UNSET || requested == gda::provider::IONIC)) {
     ret = ionic_dv_dl_init();
 
     if (ret == ROCSHMEM_SUCCESS) {
-      gda_provider = GDAProvider::IONIC;
+      gda_provider = gda::provider::IONIC;
     } else {
       LOG_TRACE("Initializing rocSHMEM IONIC GDA support failed");
     }
@@ -1116,19 +1116,19 @@ void GDABackend::open_dv_libs() {
 #endif // defined(GDA_IONIC)
 
 #if defined(GDA_MLX5)
-  if (gda_provider == GDAProvider::UNSET
-  && (requested == GDAProvider::UNSET || requested == GDAProvider::MLX5)) {
+  if (gda_provider == gda::provider::UNSET
+  && (requested == gda::provider::UNSET || requested == gda::provider::MLX5)) {
     ret = mlx5_dv_dl_init();
 
     if (ret == ROCSHMEM_SUCCESS) {
-      gda_provider = GDAProvider::MLX5;
+      gda_provider = gda::provider::MLX5;
     } else {
       LOG_TRACE("Initializing rocSHMEM MLX5 GDA support failed");
     }
   }
 #endif // defined(GDA_MLX5)
 
-  if (gda_provider == GDAProvider::UNSET) {
+  if (gda_provider == gda::provider::UNSET) {
     LOG_ERROR_EXIT("gda:open_dv_libs: no DV library could dlopen for IONIC, BNXT, or MLX5 GDA support");
   }
 }
@@ -1143,14 +1143,14 @@ void GDABackend::close_dv_libs() {
   if (mlx5dv_handle_ != nullptr)
     dlclose(mlx5dv_handle_);
 
-  gda_provider = GDAProvider::UNSET;
+  gda_provider = gda::provider::UNSET;
 }
 
 void GDABackend::exchange_qp_dest_info() {
   for (size_t i = 0; i < qps.size(); i++) {
     NicDevice &nic = nic_for_qp(i);
     dest_info[i].lid = nic.portinfo.lid;
-    if (gda_provider == GDAProvider::MLX5) {
+    if (gda_provider == gda::provider::MLX5) {
       dest_info[i].qpn = mlx5_qps[i].qpn;
     } else {
       dest_info[i].qpn = qps[i]->qp_num;
@@ -1287,7 +1287,7 @@ void GDABackend::open_ib_device() {
         nic.nic_name.c_str());
     }
 
-    if (gda_provider == GDAProvider::MLX5) {
+    if (gda_provider == gda::provider::MLX5) {
       /* Explicitly request DevX context */
       struct mlx5dv_context_attr context_attr = {};
       context_attr.flags = MLX5DV_CONTEXT_FLAGS_DEVX;
@@ -1305,7 +1305,7 @@ void GDABackend::open_ib_device() {
     CHECK_NNULL(nic.pd_orig, "ib allocate pd");
     dump_ibv_pd(nic.pd_orig);
 
-    if (gda_provider == GDAProvider::IONIC) {
+    if (gda_provider == gda::provider::IONIC) {
       create_parent_domain(nic);
     }
 
@@ -1339,12 +1339,12 @@ void GDABackend::validate_ib_device(NicDevice &nic) {
   err = ibv.query_device(nic.context, &nic.device_attr);
   CHECK_ZERO(err, "ibv_query_device");
 
-  if (gda_provider == GDAProvider::BNXT) {
+  if (gda_provider == gda::provider::BNXT) {
     const std::set<uint32_t> supported_bnxt_part_ids = { 0x1760 /* BCM57608 */};
     const char min_supported_bnxt_fw_ver[12] = "233.2.104.0";
 
     if (nic.device_attr.vendor_id != GDA_BNXT_VENDOR_ID) {
-      LOG_ERROR_EXIT("%s GDAProvider::BNXT requested but an invalid device is selected", debug_str.c_str());
+      LOG_ERROR_EXIT("%s gda::provider::BNXT requested but an invalid device is selected", debug_str.c_str());
     }
 
     if (supported_bnxt_part_ids.find(nic.device_attr.vendor_part_id) == supported_bnxt_part_ids.end()) {
@@ -1397,9 +1397,9 @@ void GDABackend::modify_qps_reset_to_init() {
     NicDevice &nic = nic_for_qp(i);
     attr.port_num = nic.port;
 
-    if (gda_provider == GDAProvider::BNXT) {
+    if (gda_provider == gda::provider::BNXT) {
       err = bnxt_re_dv.modify_qp(qps[i], &attr, attr_mask, 0, 0);
-    } else if (gda_provider == GDAProvider::MLX5) {
+    } else if (gda_provider == gda::provider::MLX5) {
       err = mlx5dv.modify_qp(mlx5_qps[i], &attr, attr_mask, nic.gid_type);
     } else {
       err = ibv.modify_qp(qps[i], &attr, attr_mask);
@@ -1417,7 +1417,7 @@ void GDABackend::modify_qps_init_to_rtr() {
   attr.qp_state               = IBV_QPS_RTR;
   attr.min_rnr_timer          = 12;
 
-  if (gda_provider == GDAProvider::IONIC) {
+  if (gda_provider == gda::provider::IONIC) {
     attr.max_dest_rd_atomic = 15;
   } else {
     attr.max_dest_rd_atomic = 1;
@@ -1460,9 +1460,9 @@ void GDABackend::modify_qps_init_to_rtr() {
       attr.ah_attr.dlid = dest_info[i].lid;
     }
 
-    if (gda_provider == GDAProvider::BNXT) {
+    if (gda_provider == gda::provider::BNXT) {
       err = bnxt_re_dv.modify_qp(qps[i], &attr, attr_mask, 0, 0);
-    } else if (gda_provider == GDAProvider::MLX5) {
+    } else if (gda_provider == gda::provider::MLX5) {
       err = mlx5dv.modify_qp(mlx5_qps[i], &attr, attr_mask, nic.gid_type);
     } else {
       err = ibv.modify_qp(qps[i], &attr, attr_mask);
@@ -1482,7 +1482,7 @@ void GDABackend::modify_qps_rtr_to_rts() {
   attr.retry_cnt     = 7;
   attr.rnr_retry     = 7;
 
-  if (gda_provider == GDAProvider::IONIC) {
+  if (gda_provider == gda::provider::IONIC) {
     attr.max_rd_atomic = 15;
   } else {
     attr.max_rd_atomic = 1;
@@ -1499,9 +1499,9 @@ void GDABackend::modify_qps_rtr_to_rts() {
     NicDevice &nic = nic_for_qp(i);
     attr.sq_psn = dest_info[i].psn;
 
-    if (gda_provider == GDAProvider::BNXT) {
+    if (gda_provider == gda::provider::BNXT) {
       err = bnxt_re_dv.modify_qp(qps[i], &attr, attr_mask, 0, 0);
-    } else if (gda_provider == GDAProvider::MLX5) {
+    } else if (gda_provider == gda::provider::MLX5) {
       err = mlx5dv.modify_qp(mlx5_qps[i], &attr, attr_mask, nic.gid_type);
     } else {
       err = ibv.modify_qp(qps[i], &attr, attr_mask);
@@ -1514,7 +1514,7 @@ void GDABackend::create_queues() {
   int ncqes;
   uint32_t sq_size = envvar::gda::sq_size;
 
-  if (gda_provider == GDAProvider::IONIC) {
+  if (gda_provider == gda::provider::IONIC) {
     ncqes = sq_size << 1;
   } else {
     ncqes = sq_size;
@@ -1530,13 +1530,13 @@ void GDABackend::create_queues() {
 
   mlx5_qps.resize(num_qps);
 
-  if (gda_provider == GDAProvider::BNXT) {
+  if (gda_provider == gda::provider::BNXT) {
     bnxt_create_cqs(ncqes);
     bnxt_create_qps(sq_size);
-  } else if (gda_provider == GDAProvider::IONIC) {
+  } else if (gda_provider == gda::provider::IONIC) {
     ionic_create_cqs(ncqes);
     create_qps(sq_size);
-  } else if (gda_provider == GDAProvider::MLX5) {
+  } else if (gda_provider == gda::provider::MLX5) {
     // mlx5_create_qps also creates the associated CQs
     mlx5_create_qps(sq_size);
   }
@@ -1624,7 +1624,7 @@ void GDABackend::create_parent_domain(NicDevice &nic) {
   pattr.free       = GDABackend::pd_release;
   pattr.pd_context = nullptr;
 
-  if (gda_provider == GDAProvider::IONIC) {
+  if (gda_provider == gda::provider::IONIC) {
     pattr.alloc      = GDABackend::pd_alloc_device_uncached;
   } else {
     pattr.alloc      = GDABackend::pd_alloc_host;
@@ -1634,7 +1634,7 @@ void GDABackend::create_parent_domain(NicDevice &nic) {
   CHECK_NNULL(nic.pd_parent, "ibv_alloc_parent_domain");
   dump_ibv_pd(nic.pd_parent);
 
-  if (gda_provider == GDAProvider::IONIC) {
+  if (gda_provider == gda::provider::IONIC) {
     ionic_setup_parent_domain(nic, &pattr);
   }
 }
@@ -1643,8 +1643,8 @@ void GDABackend::create_cqs(int cqe) {
   struct ibv_cq_init_attr_ex cq_attr;
   struct ibv_cq_ex *cq_ex;
 
-  assert(gda_provider != GDAProvider::BNXT);
-  assert(gda_provider != GDAProvider::IONIC);
+  assert(gda_provider != gda::provider::BNXT);
+  assert(gda_provider != gda::provider::IONIC);
 
   memset(&cq_attr, 0, sizeof(struct ibv_cq_init_attr_ex));
   cq_attr.cqe           = cqe;
@@ -1660,7 +1660,7 @@ void GDABackend::create_cqs(int cqe) {
    *    and linux/include/linux/mlx5/mlx5_ifc.h for Completion Queue Context definition
    *  - see also rdma-core/libibverbs/cmd_cq.c and linux/drivers/infiniband/hw/mlx5/cq.c
    *    for how this flag sets the bit */
-  if (gda_provider == GDAProvider::MLX5) {
+  if (gda_provider == gda::provider::MLX5) {
     cq_attr.cqe         = 1;
     cq_attr.comp_mask  |= IBV_CQ_INIT_ATTR_MASK_FLAGS;
     cq_attr.flags      |= IBV_CREATE_CQ_ATTR_IGNORE_OVERRUN;
@@ -1679,19 +1679,19 @@ void GDABackend::create_cqs(int cqe) {
 
 void GDABackend::initialize_gpu_qp(QueuePair* gpu_qp, int conn_num) {
   switch (gda_provider) {
-  case GDAProvider::IONIC:
+  case gda::provider::IONIC:
     ionic_initialize_gpu_qp(gpu_qp, conn_num);
     dump_ibv_qp(qps[conn_num], conn_num);
     break;
-  case GDAProvider::BNXT:
+  case gda::provider::BNXT:
     bnxt_initialize_gpu_qp(gpu_qp, conn_num);
     dump_ibv_qp(qps[conn_num], conn_num);
     break;
-  case GDAProvider::MLX5:
+  case gda::provider::MLX5:
     mlx5_initialize_gpu_qp(gpu_qp, conn_num);
     break;
   default:
-    assert(false /* GDAProvider initialize_gpu_qp */);
+    assert(false /* gda::provider initialize_gpu_qp */);
   }
 }
 
@@ -1706,13 +1706,13 @@ void GDABackend::create_qps(int sq_length) {
   attr.qp_type             = IBV_QPT_RC;
   attr.comp_mask           = IBV_QP_INIT_ATTR_PD;
 
-  if (gda_provider == GDAProvider::IONIC) {
+  if (gda_provider == gda::provider::IONIC) {
     attr.cap.max_recv_sge    = 1; // TODO allow zero sges in the driver
   }
 
   for (size_t i = 0; i < qps.size(); i++) {
     NicDevice &nic = nic_for_qp(i);
-    if (gda_provider == GDAProvider::IONIC) {
+    if (gda_provider == gda::provider::IONIC) {
       attr.pd = nic.pd_uxdma[i & 1];
     } else {
       attr.pd = nic.pd_parent;

--- a/projects/rocshmem/src/gda/backend_gda.hpp
+++ b/projects/rocshmem/src/gda/backend_gda.hpp
@@ -82,7 +82,7 @@ class GDABackend : public Backend {
     union ibv_gid gid;
   } dest_info_t;
 
-  gda::provider gda_provider = gda::provider::UNSET;
+  GDAProvider gda_provider = GDAProvider::UNSET;
 
   uint32_t *heap_rkey = nullptr;
 
@@ -159,10 +159,10 @@ class GDABackend : public Backend {
   /**
    * @brief return user-preferred GDA provider (or NONE if not specified)
    */
-  static gda::provider requested_provider();
+  static GDAProvider requested_provider();
 
  public:
-  gda::provider get_gda_provider() const { return gda_provider; }
+  GDAProvider get_gda_provider() const { return gda_provider; }
 
   friend GDAContext;
 
@@ -185,7 +185,7 @@ class GDABackend : public Backend {
    * @param device_name The device name (for debug messages)
    * @return true if the device vendor matches the provider, false otherwise
    */
-  static bool device_matches_provider_vendor(gda::provider provider,
+  static bool device_matches_provider_vendor(GDAProvider provider,
                                              const struct ibv_device_attr &device_attr,
                                              const char *device_name);
 
@@ -197,7 +197,7 @@ class GDABackend : public Backend {
    * @return true if at least one active port on a matching vendor device is found,
    *         false otherwise
    */
-  static bool has_active_ib_interface(gda::provider provider);
+  static bool has_active_ib_interface(GDAProvider provider);
 
   /**
    * @brief Verify whether GDA Backend could run

--- a/projects/rocshmem/src/gda/backend_gda.hpp
+++ b/projects/rocshmem/src/gda/backend_gda.hpp
@@ -30,6 +30,7 @@
 #include "gda/nic_policy.hpp"
 
 #include "backend_bc.hpp"
+#include "gda_enums.hpp"
 #include "containers/free_list_impl.hpp"
 #include "hdp_proxy.hpp" //TODO useless?
 #include "memory/hip_allocator.hpp"
@@ -47,13 +48,6 @@ class GDAContext;
 class GDAHostContext;
 class QueuePair;
 class HostInterface;
-
-enum GDAProvider {
-  UNSET,
-  IONIC,
-  BNXT,
-  MLX5
-};
 
 inline constexpr uint32_t GDA_IONIC_VENDOR_ID = 0x1DD8;
 inline constexpr uint32_t GDA_MLX5_VENDOR_ID  = 0x02c9; //PCI-ID is 15b3
@@ -88,7 +82,7 @@ class GDABackend : public Backend {
     union ibv_gid gid;
   } dest_info_t;
 
-  enum GDAProvider gda_provider = GDAProvider::UNSET;
+  gda::provider gda_provider = gda::provider::UNSET;
 
   uint32_t *heap_rkey = nullptr;
 
@@ -165,9 +159,11 @@ class GDABackend : public Backend {
   /**
    * @brief return user-preferred GDA provider (or NONE if not specified)
    */
-  static GDAProvider requested_provider();
+  static gda::provider requested_provider();
 
  public:
+  gda::provider get_gda_provider() const { return gda_provider; }
+
   friend GDAContext;
 
   /**
@@ -189,7 +185,7 @@ class GDABackend : public Backend {
    * @param device_name The device name (for debug messages)
    * @return true if the device vendor matches the provider, false otherwise
    */
-  static bool device_matches_provider_vendor(GDAProvider provider,
+  static bool device_matches_provider_vendor(gda::provider provider,
                                              const struct ibv_device_attr &device_attr,
                                              const char *device_name);
 
@@ -201,7 +197,7 @@ class GDABackend : public Backend {
    * @return true if at least one active port on a matching vendor device is found,
    *         false otherwise
    */
-  static bool has_active_ib_interface(GDAProvider provider);
+  static bool has_active_ib_interface(gda::provider provider);
 
   /**
    * @brief Verify whether GDA Backend could run

--- a/projects/rocshmem/src/gda/context_gda_device.cpp
+++ b/projects/rocshmem/src/gda/context_gda_device.cpp
@@ -176,7 +176,7 @@ __device__ void GDAContext::fence(int pe) {
   if (num_qps_per_pe > 1) {
     ActiveWFInfo wf_info(ctx_id_);
     for(uint32_t i = 0; i < num_qps_per_pe; i++) {
-      int qp_index = i * num_pes + pe;
+      int qp_index = i * constmem.num_pes + pe;
       qps[qp_index].quiet(wf_info);
     }
   }
@@ -189,7 +189,7 @@ __device__ void GDAContext::fence(int pe) {
    * back to sdmaQuietAll().
    */
   int local_pe;
-  if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
+  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
     ipcImpl_.ipcFence(local_pe);
   }
 }
@@ -209,7 +209,7 @@ __device__ void GDAContext::internal_quiet(ActiveWFInfo &wf_info) {
 __device__ void GDAContext::pe_quiet(size_t pe) {
   ActiveWFInfo wf_info(ctx_id_);
   for(uint32_t i = 0; i < num_qps_per_pe; i++) {
-    int qp_index = i * num_pes + pe;
+    int qp_index = i * constmem.num_pes + pe;
     qps[qp_index].quiet(wf_info);
   }
   ipcImpl_.ipcQuiet();
@@ -218,7 +218,7 @@ __device__ void GDAContext::pe_quiet(size_t pe) {
 __device__ void *GDAContext::shmem_ptr(const void *dest, int pe) {
   void *ret = nullptr;
   int local_pe{-1};
-  if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
+  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
     void *dst = const_cast<void *>(dest);
     uint64_t L_offset = reinterpret_cast<char *>(dst) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank];
     ret = ipcImpl_.ipc_bases[local_pe] + L_offset;
@@ -229,13 +229,13 @@ __device__ void *GDAContext::shmem_ptr(const void *dest, int pe) {
 __device__ void GDAContext::putmem_wg(void *dest, const void *source,
                                       size_t nelems, int pe) {
   int local_pe{-1};
-  if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
+  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
     uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank];
     ipcImpl_.ipcCopy_wg<MemcpyKind::PutBlocking>(ipcImpl_.ipc_bases[local_pe] + L_offset, const_cast<void *>(source), nelems, local_pe);
     return;
   }
   if (is_thread_zero_in_block()) {
-    uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[my_pe];
+    uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[constmem.my_pe];
     ActiveWFInfo wf_info(pe, ThreadScope::wg);
     int qp_index = get_qp_index(pe, wf_info);
     qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, pe, wf_info);
@@ -247,13 +247,13 @@ __device__ void GDAContext::getmem_wg(void *dest, const void *source,
                                       size_t nelems, int pe) {
   const char *src_typed = reinterpret_cast<const char *>(source);
   int local_pe{-1};
-  if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
+  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
     uint64_t L_offset = const_cast<char *>(src_typed) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank];
     ipcImpl_.ipcCopy_wg<MemcpyKind::GetBlocking>(dest, ipcImpl_.ipc_bases[local_pe] + L_offset, nelems, local_pe);
     return;
   }
   if (is_thread_zero_in_block()) {
-    uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[my_pe];
+    uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[constmem.my_pe];
     ActiveWFInfo wf_info(pe, ThreadScope::wg);
     int qp_index = get_qp_index(pe, wf_info);
     qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe, wf_info);
@@ -264,13 +264,13 @@ __device__ void GDAContext::getmem_wg(void *dest, const void *source,
 __device__ void GDAContext::putmem_nbi_wg(void *dest, const void *source,
                                           size_t nelems, int pe) {
   int local_pe{-1};
-  if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
+  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
     uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank];
     ipcImpl_.ipcCopy_wg<MemcpyKind::Put>(ipcImpl_.ipc_bases[local_pe] + L_offset, const_cast<void *>(source), nelems, local_pe);
     return;
   }
   if (is_thread_zero_in_block()) {
-    uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[my_pe];
+    uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[constmem.my_pe];
     ActiveWFInfo wf_info(pe, ThreadScope::wg);
     int qp_index = get_qp_index(pe, wf_info);
     qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, pe, wf_info);
@@ -281,13 +281,13 @@ __device__ void GDAContext::getmem_nbi_wg(void *dest, const void *source,
                                           size_t nelems, int pe) {
   const char *src_typed = reinterpret_cast<const char *>(source);
   int local_pe{-1};
-  if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
+  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
     uint64_t L_offset = const_cast<char *>(src_typed) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank];
     ipcImpl_.ipcCopy_wg<MemcpyKind::Get>(dest, ipcImpl_.ipc_bases[local_pe] + L_offset, nelems, local_pe);
     return;
   }
   if (is_thread_zero_in_block()) {
-    uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[my_pe];
+    uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[constmem.my_pe];
     ActiveWFInfo wf_info(pe, ThreadScope::wg);
     int qp_index = get_qp_index(pe, wf_info);
     qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe, wf_info);
@@ -297,7 +297,7 @@ __device__ void GDAContext::getmem_nbi_wg(void *dest, const void *source,
 __device__ void GDAContext::putmem_wave(void *dest, const void *source,
                                         size_t nelems, int pe) {
   int local_pe{-1};
-  if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
+  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
     uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank];
     ipcImpl_.ipcCopy_wave<MemcpyKind::PutBlocking>(ipcImpl_.ipc_bases[local_pe] + L_offset, const_cast<void *>(source), nelems, local_pe);
     return;
@@ -305,7 +305,7 @@ __device__ void GDAContext::putmem_wave(void *dest, const void *source,
   if (is_thread_zero_in_wave()) {
     ActiveWFInfo wf_info(pe, ThreadScope::wave);
     int qp_index = get_qp_index(pe, wf_info);
-    uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[my_pe];
+    uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[constmem.my_pe];
     qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, pe, wf_info);
     qps[qp_index].quiet(wf_info);
   }
@@ -315,7 +315,7 @@ __device__ void GDAContext::getmem_wave(void *dest, const void *source,
                                         size_t nelems, int pe) {
   const char *src_typed = reinterpret_cast<const char *>(source);
   int local_pe{-1};
-  if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
+  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
     uint64_t L_offset = const_cast<char *>(src_typed) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank];
     ipcImpl_.ipcCopy_wave<MemcpyKind::GetBlocking>(dest, ipcImpl_.ipc_bases[local_pe] + L_offset, nelems, local_pe);
     return;
@@ -323,7 +323,7 @@ __device__ void GDAContext::getmem_wave(void *dest, const void *source,
   if (is_thread_zero_in_wave()) {
     ActiveWFInfo wf_info(pe, ThreadScope::wave);
     int qp_index = get_qp_index(pe, wf_info);
-    uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[my_pe];
+    uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[constmem.my_pe];
     qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe, wf_info);
     qps[qp_index].quiet(wf_info);
   }
@@ -332,7 +332,7 @@ __device__ void GDAContext::getmem_wave(void *dest, const void *source,
 __device__ void GDAContext::putmem_nbi_wave(void *dest, const void *source,
                                             size_t nelems, int pe) {
   int local_pe{-1};
-  if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
+  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
     uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank];
     ipcImpl_.ipcCopy_wave<MemcpyKind::Put>(ipcImpl_.ipc_bases[local_pe] + L_offset, const_cast<void *>(source), nelems, local_pe);
     return;
@@ -340,7 +340,7 @@ __device__ void GDAContext::putmem_nbi_wave(void *dest, const void *source,
   if (is_thread_zero_in_wave()) {
     ActiveWFInfo wf_info(pe, ThreadScope::wave);
     int qp_index = get_qp_index(pe, wf_info);
-    uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[my_pe];
+    uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[constmem.my_pe];
     qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, pe, wf_info);
   }
 }
@@ -349,7 +349,7 @@ __device__ void GDAContext::getmem_nbi_wave(void *dest, const void *source,
                                             size_t nelems, int pe) {
   const char *src_typed = reinterpret_cast<const char *>(source);
   int local_pe{-1};
-  if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
+  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
     uint64_t L_offset = const_cast<char *>(src_typed) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank];
     ipcImpl_.ipcCopy_wave<MemcpyKind::Get>(dest, ipcImpl_.ipc_bases[local_pe] + L_offset, nelems, local_pe);
     return;
@@ -357,7 +357,7 @@ __device__ void GDAContext::getmem_nbi_wave(void *dest, const void *source,
   if (is_thread_zero_in_wave()) {
     ActiveWFInfo wf_info(pe, ThreadScope::wave);
     int qp_index = get_qp_index(pe, wf_info);
-    uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[my_pe];
+    uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[constmem.my_pe];
     qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe, wf_info);
   }
 }
@@ -453,20 +453,20 @@ __device__ void GDAContext::putmem_signal_nbi_wave(void *dest,
 }
 
 __device__ uint64_t GDAContext::signal_fetch(const uint64_t *sig_addr) {
-  ActiveWFInfo wf_info(my_pe);
-  int qp_index = get_qp_index(my_pe, wf_info);
+  ActiveWFInfo wf_info(constmem.my_pe);
+  int qp_index = get_qp_index(constmem.my_pe, wf_info);
   uint64_t *dst = const_cast<uint64_t*>(sig_addr);
-  return internal_amo_fetch_add<uint64_t>(static_cast<void*>(dst), 0, my_pe,
+  return internal_amo_fetch_add<uint64_t>(static_cast<void*>(dst), 0, constmem.my_pe,
            qp_index, wf_info);
 }
 
 __device__ uint64_t GDAContext::signal_fetch_wg(const uint64_t *sig_addr) {
   if (is_thread_zero_in_block()) {
-    ActiveWFInfo wf_info(my_pe, ThreadScope::wg);
-    int qp_index = get_qp_index(my_pe, wf_info);
+    ActiveWFInfo wf_info(constmem.my_pe, ThreadScope::wg);
+    int qp_index = get_qp_index(constmem.my_pe, wf_info);
     uint64_t *dst = const_cast<uint64_t*>(sig_addr);
     wg_signal_scratch = internal_amo_fetch_add<uint64_t>(static_cast<void*>(dst), 0,
-                                                         my_pe, qp_index, wf_info);
+                                                         constmem.my_pe, qp_index, wf_info);
   }
   __syncthreads();
   return wg_signal_scratch;
@@ -475,10 +475,10 @@ __device__ uint64_t GDAContext::signal_fetch_wg(const uint64_t *sig_addr) {
 __device__ uint64_t GDAContext::signal_fetch_wave(const uint64_t *sig_addr) {
   uint64_t value = 0;
   if (is_thread_zero_in_wave()) {
-    ActiveWFInfo wf_info(my_pe, ThreadScope::wave);
-    int qp_index = get_qp_index(my_pe, wf_info);
+    ActiveWFInfo wf_info(constmem.my_pe, ThreadScope::wave);
+    int qp_index = get_qp_index(constmem.my_pe, wf_info);
     uint64_t *dst = const_cast<uint64_t*>(sig_addr);
-    value = internal_amo_fetch_add<uint64_t>(static_cast<void*>(dst), 0, my_pe,
+    value = internal_amo_fetch_add<uint64_t>(static_cast<void*>(dst), 0, constmem.my_pe,
               qp_index, wf_info);
   }
   __threadfence_block();
@@ -490,12 +490,12 @@ __device__ uint64_t GDAContext::signal_fetch_wave(const uint64_t *sig_addr) {
 __device__ void GDAContext::internal_putmem(void *dest, const void *source, size_t nelems,
     int pe, int qp_index, ActiveWFInfo &wf_info) {
   int local_pe{-1};
-  if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
+  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
     uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank];
     ipcImpl_.ipcCopy<MemcpyKind::PutBlocking>(ipcImpl_.ipc_bases[local_pe] + L_offset, const_cast<void *>(source), nelems, local_pe);
     return;
   }
-  uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[my_pe];
+  uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[constmem.my_pe];
   qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, pe, wf_info);
   qps[qp_index].quiet(wf_info);
 }
@@ -504,12 +504,12 @@ __device__ void GDAContext::internal_getmem(void *dest, const void *source, size
     int pe, int qp_index, ActiveWFInfo &wf_info) {
   const char *src_typed = reinterpret_cast<const char *>(source);
   int local_pe{-1};
-  if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
+  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
     uint64_t L_offset = const_cast<char *>(src_typed) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank];
     ipcImpl_.ipcCopy<MemcpyKind::GetBlocking>(dest, ipcImpl_.ipc_bases[local_pe] + L_offset, nelems, local_pe);
     return;
   }
-  uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[my_pe];
+  uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[constmem.my_pe];
   qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe, wf_info);
   qps[qp_index].quiet(wf_info);
 }
@@ -517,13 +517,13 @@ __device__ void GDAContext::internal_getmem(void *dest, const void *source, size
 __device__ void GDAContext::internal_putmem_wg(void *dest, const void *source,
     size_t nelems, int pe, int qp_index, ActiveWFInfo &wf_info) {
   int local_pe{-1};
-  if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
+  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
     uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank];
     ipcImpl_.ipcCopy_wg<MemcpyKind::PutBlocking>(ipcImpl_.ipc_bases[local_pe] + L_offset, const_cast<void *>(source), nelems, local_pe);
     return;
   }
   if (is_thread_zero_in_block()) {
-    uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[my_pe];
+    uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[constmem.my_pe];
     qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, pe, wf_info);
     qps[qp_index].quiet(wf_info);
   }
@@ -533,13 +533,13 @@ __device__ void GDAContext::internal_getmem_wg(void *dest, const void *source,
     size_t nelems, int pe, int qp_index, ActiveWFInfo &wf_info) {
   const char *src_typed = reinterpret_cast<const char *>(source);
   int local_pe{-1};
-  if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
+  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
     uint64_t L_offset = const_cast<char *>(src_typed) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank];
     ipcImpl_.ipcCopy_wg<MemcpyKind::GetBlocking>(dest, ipcImpl_.ipc_bases[local_pe] + L_offset, nelems, local_pe);
     return;
   }
   if (is_wave_zero_in_block()) {
-    uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[my_pe];
+    uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[constmem.my_pe];
     qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe, wf_info);
     qps[qp_index].quiet(wf_info);
   }
@@ -548,13 +548,13 @@ __device__ void GDAContext::internal_getmem_wg(void *dest, const void *source,
 __device__ void GDAContext::internal_putmem_wave(void *dest, const void *source,
     size_t nelems, int pe, int qp_index, ActiveWFInfo &wf_info) {
   int local_pe{-1};
-  if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
+  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
     uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank];
     ipcImpl_.ipcCopy_wave<MemcpyKind::PutBlocking>(ipcImpl_.ipc_bases[local_pe] + L_offset, const_cast<void *>(source), nelems, local_pe);
     return;
   }
   if (is_thread_zero_in_wave()) {
-    uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[my_pe];
+    uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[constmem.my_pe];
     qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, pe, wf_info);
     qps[qp_index].quiet(wf_info);
   }
@@ -564,13 +564,13 @@ __device__ void GDAContext::internal_getmem_wave(void *dest, const void *source,
     size_t nelems, int pe, int qp_index, ActiveWFInfo &wf_info) {
   const char *src_typed = reinterpret_cast<const char *>(source);
   int local_pe{-1};
-  if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
+  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
     uint64_t L_offset = const_cast<char *>(src_typed) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank];
     ipcImpl_.ipcCopy_wave<MemcpyKind::GetBlocking>(dest, ipcImpl_.ipc_bases[local_pe] + L_offset, nelems, local_pe);
     return;
   }
   if (is_thread_zero_in_wave()) {
-    uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[my_pe];
+    uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[constmem.my_pe];
     qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe, wf_info);
     qps[qp_index].quiet(wf_info);
   }
@@ -579,12 +579,12 @@ __device__ void GDAContext::internal_getmem_wave(void *dest, const void *source,
 __device__ void GDAContext::internal_putmem_nbi(void *dest, const void *source, size_t nelems,
     int pe, int qp_index, ActiveWFInfo &wf_info) {
   int local_pe{-1};
-  if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
+  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
     uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank];
     ipcImpl_.ipcCopy<MemcpyKind::Put>(ipcImpl_.ipc_bases[local_pe] + L_offset, const_cast<void *>(source), nelems, local_pe);
     return;
   }
-  uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[my_pe];
+  uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[constmem.my_pe];
   qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, pe, wf_info);
 }
 
@@ -592,25 +592,25 @@ __device__ void GDAContext::internal_getmem_nbi(void *dest, const void *source, 
     int pe, int qp_index, ActiveWFInfo &wf_info) {
   const char *src_typed = reinterpret_cast<const char *>(source);
   int local_pe{-1};
-  if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
+  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
     uint64_t L_offset = const_cast<char *>(src_typed) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank];
     ipcImpl_.ipcCopy<MemcpyKind::Get>(dest, ipcImpl_.ipc_bases[local_pe] + L_offset, nelems, local_pe);
     return;
   }
-  uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[my_pe];
+  uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[constmem.my_pe];
   qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe, wf_info);
 }
 
 __device__ void GDAContext::internal_putmem_nbi_wg(void *dest, const void *source,
     size_t nelems, int pe, int qp_index, ActiveWFInfo &wf_info) {
   int local_pe{-1};
-  if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
+  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
     uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank];
     ipcImpl_.ipcCopy_wg<MemcpyKind::Put>(ipcImpl_.ipc_bases[local_pe] + L_offset, const_cast<void *>(source), nelems, local_pe);
     return;
   }
   if (is_wave_zero_in_block()) {
-    uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[my_pe];
+    uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[constmem.my_pe];
     qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, pe, wf_info);
   }
 }
@@ -619,13 +619,13 @@ __device__ void GDAContext::internal_getmem_nbi_wg(void *dest, const void *sourc
     size_t nelems, int pe, int qp_index, ActiveWFInfo &wf_info) {
   const char *src_typed = reinterpret_cast<const char *>(source);
   int local_pe{-1};
-  if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
+  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
     uint64_t L_offset = const_cast<char *>(src_typed) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank];
     ipcImpl_.ipcCopy_wg<MemcpyKind::Get>(dest, ipcImpl_.ipc_bases[local_pe] + L_offset, nelems, local_pe);
     return;
   }
   if (is_wave_zero_in_block()) {
-    uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[my_pe];
+    uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[constmem.my_pe];
     qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe, wf_info);
   }
 }
@@ -633,13 +633,13 @@ __device__ void GDAContext::internal_getmem_nbi_wg(void *dest, const void *sourc
 __device__ void GDAContext::internal_putmem_nbi_wave(void *dest, const void *source,
     size_t nelems, int pe, int qp_index, ActiveWFInfo &wf_info) {
   int local_pe{-1};
-  if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
+  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
     uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank];
     ipcImpl_.ipcCopy_wave<MemcpyKind::Put>(ipcImpl_.ipc_bases[local_pe] + L_offset, const_cast<void *>(source), nelems, local_pe);
     return;
   }
   if (is_thread_zero_in_wave()) {
-    uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[my_pe];
+    uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[constmem.my_pe];
     qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, pe, wf_info);
   }
 }
@@ -648,13 +648,13 @@ __device__ void GDAContext::internal_getmem_nbi_wave(void *dest, const void *sou
     size_t nelems, int pe, int qp_index, ActiveWFInfo &wf_info) {
   const char *src_typed = reinterpret_cast<const char *>(source);
   int local_pe{-1};
-  if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
+  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
     uint64_t L_offset = const_cast<char *>(src_typed) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank];
     ipcImpl_.ipcCopy_wave<MemcpyKind::Get>(dest, ipcImpl_.ipc_bases[local_pe] + L_offset, nelems, local_pe);
     return;
   }
   if (is_thread_zero_in_wave()) {
-    uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[my_pe];
+    uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[constmem.my_pe];
     qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe, wf_info);
   }
 }

--- a/projects/rocshmem/src/gda/context_gda_device.cpp
+++ b/projects/rocshmem/src/gda/context_gda_device.cpp
@@ -80,14 +80,14 @@ __host__ GDAContext::~GDAContext() {
 __device__ void GDAContext::putmem(void *dest, const void *source, size_t nelems,
                                    int pe) {
   int local_pe{-1};
-  if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
+  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
     uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank];
     ipcImpl_.ipcCopy<MemcpyKind::PutBlocking>(ipcImpl_.ipc_bases[local_pe] + L_offset, const_cast<void *>(source), nelems, local_pe);
     return;
   }
   ActiveWFInfo wf_info(pe);
   int qp_index = get_qp_index(pe, wf_info);
-  uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[my_pe];
+  uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[constmem.my_pe];
   qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, pe, wf_info);
   qps[qp_index].quiet(wf_info);
 }
@@ -96,14 +96,14 @@ __device__ void GDAContext::getmem(void *dest, const void *source, size_t nelems
                                    int pe) {
   const char *src_typed = reinterpret_cast<const char *>(source);
   int local_pe{-1};
-  if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
+  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
     uint64_t L_offset = const_cast<char *>(src_typed) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank];
     ipcImpl_.ipcCopy<MemcpyKind::GetBlocking>(dest, ipcImpl_.ipc_bases[local_pe] + L_offset, nelems, local_pe);
     return;
   }
   ActiveWFInfo wf_info(pe);
   int qp_index = get_qp_index(pe, wf_info);
-  uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[my_pe];
+  uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[constmem.my_pe];
   qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe, wf_info);
   qps[qp_index].quiet(wf_info);
 }
@@ -111,14 +111,14 @@ __device__ void GDAContext::getmem(void *dest, const void *source, size_t nelems
 __device__ void GDAContext::putmem_nbi(void *dest, const void *source,
                                        size_t nelems, int pe) {
   int local_pe{-1};
-  if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
+  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
     uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank];
     ipcImpl_.ipcCopy<MemcpyKind::Put>(ipcImpl_.ipc_bases[local_pe] + L_offset, const_cast<void *>(source), nelems, local_pe);
     return;
   }
   ActiveWFInfo wf_info(pe);
   int qp_index = get_qp_index(pe, wf_info);
-  uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[my_pe];
+  uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[constmem.my_pe];
   qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, pe, wf_info);
 }
 
@@ -126,14 +126,14 @@ __device__ void GDAContext::getmem_nbi(void *dest, const void *source,
                                        size_t nelems, int pe) {
   const char *src_typed = reinterpret_cast<const char *>(source);
   int local_pe{-1};
-  if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
+  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
     uint64_t L_offset = const_cast<char *>(src_typed) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank];
     ipcImpl_.ipcCopy<MemcpyKind::Get>(dest, ipcImpl_.ipc_bases[local_pe] + L_offset, nelems, local_pe);
     return;
   }
   ActiveWFInfo wf_info(pe);
   int qp_index = get_qp_index(pe, wf_info);
-  uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[my_pe];
+  uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[constmem.my_pe];
   qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe, wf_info);
 }
 

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -46,7 +46,7 @@ namespace rocshmem {
 template <typename T>
 __device__ void GDAContext::p(T *dest, T value, int pe) {
   int local_pe{-1};
-  if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
+  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
     long L_offset{reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank]};
     ipcImpl_.ipcCopy<MemcpyKind::Put>(ipcImpl_.ipc_bases[local_pe] + L_offset, reinterpret_cast<void *>(&value), sizeof(T), local_pe);
     return;
@@ -68,7 +68,7 @@ template <typename T>
 __device__ T GDAContext::g(const T *source, int pe) {
   T ret{};
   int local_pe{-1};
-  if (ipcImpl_.isIpcAvailable(my_pe, pe, &local_pe)) {
+  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
     const char *src_typed{reinterpret_cast<const char *>(source)};
     long L_offset{const_cast<char *>(src_typed) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank]};
     ipcImpl_.ipcCopy<MemcpyKind::Get>(&ret, ipcImpl_.ipc_bases[local_pe] + L_offset, sizeof(T), local_pe);
@@ -94,7 +94,7 @@ __device__ void GDAContext::get_nbi(T *dest, const T *source, size_t nelems, int
 template <typename T>
 __device__ void GDAContext::amo_add(void *dst, T value, int pe) {
   if constexpr (sizeof(T) != 8) { LOGD_ERROR_ABORT("gda::amo_add not implemented for non-64bit types"); }//TODO:support for non-uint64t
-  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
+  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[constmem.my_pe];
   ActiveWFInfo wf_info(pe);
   int qp_index = get_qp_index(pe, wf_info);
   bool need_turn {true};
@@ -118,7 +118,7 @@ __device__ void GDAContext::amo_set(void *dst, T value, int pe) {
 template <typename T>
 __device__ T GDAContext::amo_swap(void *dst, T value, int pe) {
   if constexpr (sizeof(T) != 8) { LOGD_ERROR_ABORT("gda::amo_set not implemented for non-64bit types"); }//TODO:support for non-uint64t
-  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
+  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[constmem.my_pe];
   ActiveWFInfo wf_info(pe);
   int qp_index = get_qp_index(pe, wf_info);
   bool need_turn {true};
@@ -148,7 +148,7 @@ __device__ T GDAContext::amo_swap(void *dst, T value, int pe) {
 template <typename T>
 __device__ T GDAContext::amo_fetch_and(void *dst, T value, int pe) {
   if constexpr (sizeof(T) != 8) { LOGD_ERROR_ABORT("gda::amo_fetch_and not implemented for non-64bit types"); }//TODO:support for non-uint64t
-  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
+  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[constmem.my_pe];
   ActiveWFInfo wf_info(pe);
   int qp_index = get_qp_index(pe, wf_info);
   bool need_turn {true};
@@ -180,7 +180,7 @@ __device__ void GDAContext::amo_and(void *dst, T value, int pe) {
 template <typename T>
 __device__ T GDAContext::amo_fetch_or(void *dst, T value, int pe) {
   if constexpr (sizeof(T) != 8) { LOGD_ERROR_ABORT("gda::amo_fetch_or not implemented for non-64bit types"); }//TODO:support for non-uint64t
-  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
+  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[constmem.my_pe];
   ActiveWFInfo wf_info(pe);
   int qp_index = get_qp_index(pe, wf_info);
   bool need_turn {true};
@@ -212,7 +212,7 @@ __device__ void GDAContext::amo_or(void *dst, T value, int pe) {
 template <typename T>
 __device__ T GDAContext::amo_fetch_xor(void *dst, T value, int pe) {
   if constexpr (sizeof(T) != 8) { LOGD_ERROR_ABORT("gda::amo_fetch_xor not implemented for non-64bit types"); }//TODO:support for non-uint64t
-  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
+  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[constmem.my_pe];
   ActiveWFInfo wf_info(pe);
   int qp_index = get_qp_index(pe, wf_info);
   bool need_turn {true};
@@ -244,7 +244,7 @@ __device__ void GDAContext::amo_xor(void *dst, T value, int pe) {
 template <typename T>
 __device__ void GDAContext::amo_cas(void *dst, T value, T cond, int pe) {
   if constexpr (sizeof(T) != 8) { LOGD_ERROR_ABORT("gda::amo_cas not implemented for non-64bit types"); }//TODO:support for non-uint64t
-  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
+  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[constmem.my_pe];
   ActiveWFInfo wf_info(pe);
   int qp_index = get_qp_index(pe, wf_info);
   bool need_turn {true};
@@ -263,7 +263,7 @@ __device__ void GDAContext::amo_cas(void *dst, T value, T cond, int pe) {
 template <typename T>
 __device__ T GDAContext::amo_fetch_add(void *dst, T value, int pe) {
   if constexpr (sizeof(T) != 8) { LOGD_ERROR_ABORT("gda::amo_fadd not implemented for non-64bit types"); }//TODO:support for non-uint64t
-  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
+  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[constmem.my_pe];
   ActiveWFInfo wf_info(pe);
   int qp_index = get_qp_index(pe, wf_info);
   T ret_val = 0;
@@ -284,7 +284,7 @@ __device__ T GDAContext::amo_fetch_add(void *dst, T value, int pe) {
 template <typename T>
 __device__ T GDAContext::amo_fetch_cas(void *dst, T value, T cond, int pe) {
   if constexpr (sizeof(T) != 8) { LOGD_ERROR_ABORT("gda::amo_fcas not implemented for non-64bit types"); }//TODO:support for non-uint64t
-  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
+  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[constmem.my_pe];
   ActiveWFInfo wf_info(pe);
   int qp_index = get_qp_index(pe, wf_info);
   bool need_turn {true};
@@ -322,7 +322,7 @@ __device__ void GDAContext::internal_direct_allreduce(T *dst, const T *src,
   T *pWrk = reinterpret_cast<T *>(team_obj->pWrk);
 
   int finish = PE_start + stride * PE_size;
-  int pe = my_pe;
+  int pe = constmem.my_pe;
 
   int wg_id = get_flat_block_id();
   int wg_size = get_flat_block_size();
@@ -364,7 +364,7 @@ __device__ void GDAContext::internal_direct_allreduce(T *dst, const T *src,
 
   __syncthreads();
 
-  for (int i = wg_id; i < num_pes; i += wg_size) {
+  for (int i = wg_id; i < constmem.num_pes; i += wg_size) {
     pSync[i] = ROCSHMEM_SYNC_VALUE;
   }
   threadfence_system();
@@ -500,7 +500,7 @@ __device__ void GDAContext::internal_ring_allreduce(T *dst, const T *src,
   }
   __syncthreads();
 
-  for (int i = wg_id; i < 2 * num_pes - 2; i += wg_size) {
+  for (int i = wg_id; i < 2 * constmem.num_pes - 2; i += wg_size) {
     pSync[i] = ROCSHMEM_SYNC_VALUE;
   }
   __syncthreads();
@@ -574,10 +574,10 @@ template <typename T>
 __device__ void GDAContext::internal_put_broadcast(T *dst, const T *src,
     int nelems, int pe_root, int pe_start, int stride, int pe_size,
     ActiveWFInfo &wf_info) {  // NOLINT(runtime/int)
-  if (my_pe == pe_root) {
+  if (constmem.my_pe == pe_root) {
     int finish = pe_start + stride * pe_size;
     for (int i = pe_start; i < finish; i += stride) {
-      if (i != my_pe) {
+      if (i != constmem.my_pe) {
         internal_putmem_nbi_wg(dst, src, nelems * sizeof(T), i, i, wf_info);
       }
     }
@@ -587,7 +587,7 @@ __device__ void GDAContext::internal_put_broadcast(T *dst, const T *src,
 template <typename T>
 __device__ void GDAContext::internal_get_broadcast(T *dst, const T *src,
     int nelems, int pe_root, ActiveWFInfo &wf_info) {  // NOLINT(runtime/int)
-  if (my_pe != pe_root) {
+  if (constmem.my_pe != pe_root) {
     internal_getmem_wg(dst, src, nelems * sizeof(T), pe_root, pe_root, wf_info);
   }
 }
@@ -613,7 +613,7 @@ __device__ void GDAContext::internal_broadcast(T *dst, const T *src,
     int nelems, int pe_root, int pe_start, int stride, int pe_size,
     long *p_sync) {  // NOLINT(runtime/int)
   ActiveWFInfo wf_info(ctx_id_, ThreadScope::wg);
-  if (num_pes < 4) { //TODO: optimized for IPC
+  if (constmem.num_pes < 4) { //TODO: optimized for IPC
     internal_put_broadcast(dst, src, nelems, pe_root, pe_start, stride,
       pe_size, wf_info);
   } else {
@@ -621,7 +621,7 @@ __device__ void GDAContext::internal_broadcast(T *dst, const T *src,
   }
 
   // Synchronize on completion of broadcast
-  internal_sync_wg(my_pe, pe_start, stride, pe_size, p_sync, wf_info);
+  internal_sync_wg(constmem.my_pe, pe_start, stride, pe_size, p_sync, wf_info);
 }
 
 template <typename T>
@@ -665,13 +665,13 @@ __device__ void GDAContext::alltoallv_copy(rocshmem_team_t team, T *dest,
   // Have each PE put their designated data to the other PEs
   for (int j = tid; j < pe_size; j+= step_size) {
     int dest_pe = team_obj->get_pe_in_world(j);
-    uint64_t base_heap_offset = base_heap[dest_pe] - base_heap[my_pe];
+    uint64_t base_heap_offset = base_heap[dest_pe] - base_heap[constmem.my_pe];
     size_t nelems = source_nelems[dest_pe] * sizeof(T);
     char* amo_dst = ((char*)&pSync[alltoall_pSync_offset + my_pe_in_team] + base_heap_offset);
 
     if (nelems != 0) {
       T* src = (T*)((char*)source + (source_displs[j] * sizeof(T)));
-      T* dst = (T*)((char*)&tmp_buf[my_pe * tmp_buf_off] + base_heap_offset);
+      T* dst = (T*)((char*)&tmp_buf[constmem.my_pe * tmp_buf_off] + base_heap_offset);
       qps[dest_pe].put_nbi_single(dst, src, nelems, false);
     }
 
@@ -737,7 +737,7 @@ __device__ void GDAContext::alltoallv_get(rocshmem_team_t team, T *dest,
     uint64_t displ_bits;
 
     int dest_pe = team_obj->get_pe_in_world(j);
-    uint64_t base_heap_offset = base_heap[dest_pe] - base_heap[my_pe];
+    uint64_t base_heap_offset = base_heap[dest_pe] - base_heap[constmem.my_pe];
 
     /* Pack Ctrl Message * 16 bits seq | 48bit displ */
     seq_bits = (seq_mask & (a2a_sn + 1)) << seq_shift;
@@ -746,7 +746,7 @@ __device__ void GDAContext::alltoallv_get(rocshmem_team_t team, T *dest,
 
     /* Prepare Ctrl Message */
     src = (uint64_t*)&ctrl_msg;
-    dst = (uint64_t*)((char*)&tmp_buf[my_pe] + base_heap_offset);
+    dst = (uint64_t*)((char*)&tmp_buf[constmem.my_pe] + base_heap_offset);
 
     qps[dest_pe].put_nbi_single(dst, src, sizeof(uint64_t), true);
 
@@ -814,7 +814,7 @@ __device__ void GDAContext::alltoall_linear(rocshmem_team_t team, T *dst,
   }
 
   // wait until everyone has obtained their designated data
-  internal_sync_wg(my_pe, pe_start, stride, pe_size, pSync, wf_info);
+  internal_sync_wg(constmem.my_pe, pe_start, stride, pe_size, pSync, wf_info);
 }
 
 template <typename T>
@@ -833,7 +833,7 @@ __device__ void GDAContext::alltoall_linear_thread_puts(rocshmem_team_t team,
   // Have each PE put their designated data to the other PEs
   for (int j = tid; j < pe_size; j += step_size) {
     int dest_pe = team_obj->get_pe_in_world(j);
-    uint64_t base_heap_offset = base_heap[dest_pe] - base_heap[my_pe];
+    uint64_t base_heap_offset = base_heap[dest_pe] - base_heap[constmem.my_pe];
     qps[dest_pe].put_nbi_single(
       reinterpret_cast<char*>(&dst[my_pe_in_team * nelems]) + base_heap_offset,
       &src[j * nelems], nelems * sizeof(T), false);
@@ -894,7 +894,7 @@ __device__ void GDAContext::fcollect_linear(rocshmem_team_t team, T *dst,
     }
   }
   // wait until everyone has obtained their designated data
-  internal_sync_wg(my_pe, pe_start, stride, pe_size, pSync, wf_info);
+  internal_sync_wg(constmem.my_pe, pe_start, stride, pe_size, pSync, wf_info);
 }
 
 // Block/wave functions
@@ -962,7 +962,7 @@ template <typename T>
 __device__ void GDAContext::internal_amo_add(void *dst, T value, int pe,
     int qp_index, ActiveWFInfo &wf_info) {
   if constexpr (sizeof(T) != 8) { LOGD_ERROR_ABORT("gda::amo_add not implemented for non-64bit types"); }//TODO:support for non-uint64t
-  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
+  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[constmem.my_pe];
   bool need_turn {true};
   uint64_t turns = __ballot(need_turn);
   while (turns) {
@@ -980,7 +980,7 @@ template <typename T>
 __device__ T GDAContext::internal_amo_fetch_add(void *dst, T value, int pe,
     int qp_index, ActiveWFInfo &wf_info) {
   if constexpr (sizeof(T) != 8) { LOGD_ERROR_ABORT("gda::amo_fadd not implemented for non-64bit types"); }//TODO:support for non-uint64t
-  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
+  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[constmem.my_pe];
   T ret_val = 0;
   bool need_turn {true};
   uint64_t turns = __ballot(need_turn);
@@ -1000,7 +1000,7 @@ template <typename T>
 __device__ T GDAContext::internal_amo_swap(void *dst, T value, int pe,
     int qp_index, ActiveWFInfo &wf_info) {
   if constexpr (sizeof(T) != 8) { LOGD_ERROR_ABORT("gda::amo_set not implemented for non-64bit types"); }//TODO:support for non-uint64t
-  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[my_pe];
+  uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[constmem.my_pe];
   bool need_turn {true};
   uint64_t turns = __ballot(need_turn);
   T ret_val;
@@ -1067,7 +1067,7 @@ __device__ __forceinline__ uint32_t GDAContext::get_qp_index(int pe,
     //                                        __HIP_MEMORY_SCOPE_AGENT);
     // local_qp_counter %= num_qps_per_pe;
     // qp_index = (local_qp_counter * num_pes) + pe;
-    qp_index = (qp_counter[pe]++ % num_qps_per_pe) * num_pes + pe;
+    qp_index = (qp_counter[pe]++ % num_qps_per_pe) * constmem.num_pes + pe;
   }
 
   // Broadcast the qp_index value to other lanes in the wavefront

--- a/projects/rocshmem/src/gda/gda_enums.hpp
+++ b/projects/rocshmem/src/gda/gda_enums.hpp
@@ -39,6 +39,9 @@ namespace gda {
     ALLTOALLV_WG_ALGO_COPY,
   };
 }  // namespace gda
+
+using GDAProvider = gda::provider;
+
 }  // namespace rocshmem
 
 #endif  // LIBRARY_SRC_GDA_ENUMS_HPP_

--- a/projects/rocshmem/src/gda/gda_enums.hpp
+++ b/projects/rocshmem/src/gda/gda_enums.hpp
@@ -27,6 +27,13 @@
 
 namespace rocshmem {
 namespace gda {
+  enum provider {
+    UNSET,
+    IONIC,
+    BNXT,
+    MLX5
+  };
+
   enum alltoallv_wg_algos {
     ALLTOALLV_WG_ALGO_GET = 0,
     ALLTOALLV_WG_ALGO_COPY,

--- a/projects/rocshmem/src/gda/gda_enums.hpp
+++ b/projects/rocshmem/src/gda/gda_enums.hpp
@@ -25,8 +25,6 @@
 #ifndef LIBRARY_SRC_GDA_ENUMS_HPP_
 #define LIBRARY_SRC_GDA_ENUMS_HPP_
 
-#include "team.hpp"
-
 namespace rocshmem {
 namespace gda {
   enum alltoallv_wg_algos {

--- a/projects/rocshmem/src/gda/queue_pair.cpp
+++ b/projects/rocshmem/src/gda/queue_pair.cpp
@@ -32,7 +32,8 @@
 
 namespace rocshmem {
 
-QueuePair::QueuePair(struct ibv_pd* pd, int gda_provider) {
+QueuePair::QueuePair(struct ibv_pd* pd, int gda_provider)
+    : gda_provider_(gda_provider) {
   int access = IBV_ACCESS_LOCAL_WRITE
              | IBV_ACCESS_REMOTE_WRITE
              | IBV_ACCESS_REMOTE_READ
@@ -99,8 +100,6 @@ QueuePair::QueuePair(struct ibv_pd* pd, int gda_provider) {
   default:
     assert(false /* invalid nic provider */);
   }
-  gda_provider_ = gda_provider;
-
   /* Setup User Buffer Registration Mechanism */
   pd_ = pd;
   num_user_buffers = envvar::gda::num_user_buffers;
@@ -161,6 +160,7 @@ __device__ void QueuePair::post_wqe_rma([[maybe_unused]] int pe, int32_t size, u
 #endif
   default:
     assert(false /* invalid nic provider */);
+    __builtin_unreachable();
   }
 }
 
@@ -184,6 +184,7 @@ __device__ void QueuePair::post_wqe_rma_single([[maybe_unused]] int32_t size, ui
 #endif
   default:
     assert(false /* invalid nic provider */);
+    __builtin_unreachable();
   }
 }
 
@@ -208,7 +209,7 @@ __device__ uint64_t QueuePair::post_wqe_amo([[maybe_unused]] int32_t size, uintp
 #endif
   default:
     assert(false /* invalid nic provider */);
-    return 0;
+    __builtin_unreachable();
   }
 }
 
@@ -230,7 +231,7 @@ __device__ uint64_t QueuePair::post_wqe_amo_single(uintptr_t raddr,
 #endif
   default:
     assert(false /* invalid nic provider */);
-    return 0;
+    __builtin_unreachable();
   }
 }
 
@@ -254,6 +255,7 @@ __device__ void QueuePair::quiet([[maybe_unused]] ActiveWFInfo &wf_info) {
     #endif
       default:
         assert(false /* invalid nic provider */);
+        __builtin_unreachable();
       }
   }
 }
@@ -277,6 +279,7 @@ __device__ void QueuePair::quiet_single() {
 #endif
   default:
     assert(false /* invalid nic provider */);
+    __builtin_unreachable();
   }
 }
 

--- a/projects/rocshmem/src/gda/queue_pair.cpp
+++ b/projects/rocshmem/src/gda/queue_pair.cpp
@@ -27,13 +27,13 @@
 #include <hip/hip_runtime.h>
 
 #include "backend_gda.hpp"
+#include "constmem.hpp"
 #include "constants.hpp"
 #include "util.hpp"
 
 namespace rocshmem {
 
-QueuePair::QueuePair(struct ibv_pd* pd, int gda_provider)
-    : gda_provider_(gda_provider) {
+QueuePair::QueuePair(struct ibv_pd* pd, int gda_provider) {
   int access = IBV_ACCESS_LOCAL_WRITE
              | IBV_ACCESS_REMOTE_WRITE
              | IBV_ACCESS_REMOTE_READ
@@ -56,7 +56,7 @@ QueuePair::QueuePair(struct ibv_pd* pd, int gda_provider)
   mr_fetching_atomic = ibv.reg_mr(pd, fetching_atomic, 8 * FETCHING_ATOMIC_CNT, access, &allocator);
   CHECK_NNULL(mr_fetching_atomic, "ibv_reg_mr");
 
-  if (gda_provider == GDAProvider::MLX5) {
+  if (gda_provider == gda::provider::MLX5) {
     nonfetching_atomic_lkey = htobe32(mr_nonfetching_atomic->lkey);
     fetching_atomic_lkey = htobe32(mr_fetching_atomic->lkey);
   } else {
@@ -74,7 +74,7 @@ QueuePair::QueuePair(struct ibv_pd* pd, int gda_provider)
   /* Set Correct opcodes for each NIC */
   switch (gda_provider) {
 #if defined(GDA_IONIC)
-  case GDAProvider::IONIC:
+  case gda::provider::IONIC:
     gda_op_rdma_write = IONIC_V2_OP_RDMA_WRITE;
     gda_op_rdma_read  = IONIC_V2_OP_RDMA_READ;
     gda_op_atomic_fa  = IONIC_V2_OP_ATOMIC_FA;
@@ -82,7 +82,7 @@ QueuePair::QueuePair(struct ibv_pd* pd, int gda_provider)
     break;
 #endif //defined(GDA_IONIC)
 #if defined(GDA_BNXT)
-  case GDAProvider::BNXT:
+  case gda::provider::BNXT:
     gda_op_rdma_write = BNXT_RE_WR_OPCD_RDMA_WRITE;
     gda_op_rdma_read  = BNXT_RE_WR_OPCD_RDMA_READ;
     gda_op_atomic_fa  = BNXT_RE_WR_OPCD_ATOMIC_FA;
@@ -90,7 +90,7 @@ QueuePair::QueuePair(struct ibv_pd* pd, int gda_provider)
     break;
 #endif //defined(GDA_BNXT)
 #if defined(GDA_MLX5)
-  case GDAProvider::MLX5:
+  case gda::provider::MLX5:
     gda_op_rdma_write = MLX5_OPCODE_RDMA_WRITE;
     gda_op_rdma_read  = MLX5_OPCODE_RDMA_READ;
     gda_op_atomic_fa  = MLX5_OPCODE_ATOMIC_FA;
@@ -142,19 +142,19 @@ __device__ uint64_t QueuePair::get_same_qp_lane_mask() {
  *****************************************************************************/
 __device__ void QueuePair::post_wqe_rma([[maybe_unused]] int pe, int32_t size, uintptr_t laddr,
     uintptr_t raddr, uint8_t opcode, ActiveWFInfo &wf_info) {
-  switch (gda_provider_) {
+  switch (constmem.gda_provider) {
 #if defined(GDA_IONIC)
-  case GDAProvider::IONIC:
+  case gda::provider::IONIC:
     ionic_post_wqe_rma(size, laddr, raddr, opcode, wf_info);
     return;
 #endif
 #if defined(GDA_BNXT)
-  case GDAProvider::BNXT:
+  case gda::provider::BNXT:
     bnxt_post_wqe_rma(size, laddr, raddr, opcode, wf_info);
     return;
 #endif
 #if defined(GDA_MLX5)
-  case GDAProvider::MLX5:
+  case gda::provider::MLX5:
     mlx5_post_wqe_rma(size, laddr, raddr, opcode, wf_info);
     return;
 #endif
@@ -165,20 +165,20 @@ __device__ void QueuePair::post_wqe_rma([[maybe_unused]] int pe, int32_t size, u
 }
 
 __device__ void QueuePair::post_wqe_rma_single([[maybe_unused]] int32_t size, uintptr_t laddr,
-    uintptr_t raddr, uint8_t opcode, [[maybe_unused]] bool ring_db) {
-  switch (gda_provider_) {
+    uintptr_t raddr, uint8_t opcode, bool ring_db) {
+  switch (constmem.gda_provider) {
 #if defined(GDA_IONIC)
-  case GDAProvider::IONIC:
+  case gda::provider::IONIC:
     ionic_post_wqe_rma_single(size, laddr, raddr, opcode);
     return;
 #endif
 #if defined(GDA_BNXT)
-  case GDAProvider::BNXT:
+  case gda::provider::BNXT:
     bnxt_post_wqe_rma_single(size, laddr, raddr, opcode, ring_db);
     return;
 #endif
 #if defined(GDA_MLX5)
-  case GDAProvider::MLX5:
+  case gda::provider::MLX5:
     mlx5_post_wqe_rma_single(size, laddr, raddr, opcode, ring_db);
     return;
 #endif
@@ -191,19 +191,19 @@ __device__ void QueuePair::post_wqe_rma_single([[maybe_unused]] int32_t size, ui
 __device__ uint64_t QueuePair::post_wqe_amo([[maybe_unused]] int32_t size, uintptr_t raddr,
     uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp,
     bool fetching, ActiveWFInfo &wf_info) {
-  switch (gda_provider_) {
+  switch (constmem.gda_provider) {
 #if defined(GDA_IONIC)
-  case GDAProvider::IONIC:
+  case gda::provider::IONIC:
     return ionic_post_wqe_amo(size, raddr, opcode, atomic_data, atomic_cmp,
            fetching, wf_info);
 #endif
 #if defined(GDA_BNXT)
-  case GDAProvider::BNXT:
+  case gda::provider::BNXT:
     return bnxt_post_wqe_amo(raddr, opcode, atomic_data, atomic_cmp, fetching,
            wf_info);
 #endif
 #if defined(GDA_MLX5)
-  case GDAProvider::MLX5:
+  case gda::provider::MLX5:
     return mlx5_post_wqe_amo(size, raddr, opcode, atomic_data, atomic_cmp,
            fetching, wf_info);
 #endif
@@ -215,18 +215,18 @@ __device__ uint64_t QueuePair::post_wqe_amo([[maybe_unused]] int32_t size, uintp
 
 __device__ uint64_t QueuePair::post_wqe_amo_single(uintptr_t raddr,
     uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp, bool fetching) {
-  switch (gda_provider_) {
+  switch (constmem.gda_provider) {
 #if defined(GDA_IONIC)
-  case GDAProvider::IONIC:
+  case gda::provider::IONIC:
     return ionic_post_wqe_amo_single(8 /*size_bytes (only 8-byte atomics implemented)*/, raddr, opcode, atomic_data, atomic_cmp, fetching);
 #endif
 #if defined(GDA_BNXT)
-  case GDAProvider::BNXT:
+  case gda::provider::BNXT:
     return bnxt_post_wqe_amo_single(raddr, opcode, atomic_data, atomic_cmp,
            fetching);
 #endif
 #if defined(GDA_MLX5)
-  case GDAProvider::MLX5:
+  case gda::provider::MLX5:
     return mlx5_post_wqe_amo_single(8 /* 8-byte atomics */, raddr, opcode, atomic_data, atomic_cmp, fetching);
 #endif
   default:
@@ -235,22 +235,22 @@ __device__ uint64_t QueuePair::post_wqe_amo_single(uintptr_t raddr,
   }
 }
 
-__device__ void QueuePair::quiet([[maybe_unused]] ActiveWFInfo &wf_info) {
-  if(wf_info.is_pe_group_first) {
-      switch (gda_provider_) {
+__device__ void QueuePair::quiet(ActiveWFInfo &wf_info) {
+  if(wf_info.is_pe_group_leader) {
+      switch (constmem.gda_provider) {
     #if defined(GDA_IONIC)
-      case GDAProvider::IONIC:
+      case gda::provider::IONIC:
         ionic_quiet(wf_info);
         return;
     #endif
     #if defined(GDA_BNXT)
-      case GDAProvider::BNXT:
-          bnxt_quiet();
+      case gda::provider::BNXT:
+          bnxt_quiet(wf_info);
         return;
     #endif
     #if defined(GDA_MLX5)
-      case GDAProvider::MLX5:
-          mlx5_quiet();
+      case gda::provider::MLX5:
+          mlx5_quiet(wf_info);
         return;
     #endif
       default:
@@ -261,19 +261,19 @@ __device__ void QueuePair::quiet([[maybe_unused]] ActiveWFInfo &wf_info) {
 }
 
 __device__ void QueuePair::quiet_single() {
-  switch (gda_provider_) {
+  switch (constmem.gda_provider) {
 #if defined(GDA_IONIC)
-  case GDAProvider::IONIC:
+  case gda::provider::IONIC:
     ionic_quiet_single();
     return;
 #endif
 #if defined(GDA_BNXT)
-  case GDAProvider::BNXT:
+  case gda::provider::BNXT:
     bnxt_quiet_single();
     return;
 #endif
 #if defined(GDA_MLX5)
-  case GDAProvider::MLX5:
+  case gda::provider::MLX5:
     mlx5_quiet_single();
     return;
 #endif
@@ -376,7 +376,7 @@ int QueuePair::buffer_register(uintptr_t addr, size_t length) {
       user_buf_info[i].addr   = addr;
       user_buf_info[i].length = length;
 
-      if (gda_provider_ == GDAProvider::MLX5) {
+      if (gda_provider_ == gda::provider::MLX5) {
         user_buf_info[i].lkey = htobe32(mr->lkey);
       } else {
         user_buf_info[i].lkey = mr->lkey;

--- a/projects/rocshmem/src/gda/queue_pair.cpp
+++ b/projects/rocshmem/src/gda/queue_pair.cpp
@@ -100,6 +100,7 @@ QueuePair::QueuePair(struct ibv_pd* pd, int gda_provider) {
   default:
     assert(false /* invalid nic provider */);
   }
+  gda_provider_ = gda_provider;
   /* Setup User Buffer Registration Mechanism */
   pd_ = pd;
   num_user_buffers = envvar::gda::num_user_buffers;
@@ -376,7 +377,7 @@ int QueuePair::buffer_register(uintptr_t addr, size_t length) {
       user_buf_info[i].addr   = addr;
       user_buf_info[i].length = length;
 
-      if (constmem.gda_provider == GDAProvider::MLX5) {
+      if (gda_provider_ == GDAProvider::MLX5) {
         user_buf_info[i].lkey = htobe32(mr->lkey);
       } else {
         user_buf_info[i].lkey = mr->lkey;

--- a/projects/rocshmem/src/gda/queue_pair.cpp
+++ b/projects/rocshmem/src/gda/queue_pair.cpp
@@ -56,7 +56,7 @@ QueuePair::QueuePair(struct ibv_pd* pd, int gda_provider) {
   mr_fetching_atomic = ibv.reg_mr(pd, fetching_atomic, 8 * FETCHING_ATOMIC_CNT, access, &allocator);
   CHECK_NNULL(mr_fetching_atomic, "ibv_reg_mr");
 
-  if (gda_provider == gda::provider::MLX5) {
+  if (gda_provider == GDAProvider::MLX5) {
     nonfetching_atomic_lkey = htobe32(mr_nonfetching_atomic->lkey);
     fetching_atomic_lkey = htobe32(mr_fetching_atomic->lkey);
   } else {
@@ -74,7 +74,7 @@ QueuePair::QueuePair(struct ibv_pd* pd, int gda_provider) {
   /* Set Correct opcodes for each NIC */
   switch (gda_provider) {
 #if defined(GDA_IONIC)
-  case gda::provider::IONIC:
+  case GDAProvider::IONIC:
     gda_op_rdma_write = IONIC_V2_OP_RDMA_WRITE;
     gda_op_rdma_read  = IONIC_V2_OP_RDMA_READ;
     gda_op_atomic_fa  = IONIC_V2_OP_ATOMIC_FA;
@@ -82,7 +82,7 @@ QueuePair::QueuePair(struct ibv_pd* pd, int gda_provider) {
     break;
 #endif //defined(GDA_IONIC)
 #if defined(GDA_BNXT)
-  case gda::provider::BNXT:
+  case GDAProvider::BNXT:
     gda_op_rdma_write = BNXT_RE_WR_OPCD_RDMA_WRITE;
     gda_op_rdma_read  = BNXT_RE_WR_OPCD_RDMA_READ;
     gda_op_atomic_fa  = BNXT_RE_WR_OPCD_ATOMIC_FA;
@@ -90,7 +90,7 @@ QueuePair::QueuePair(struct ibv_pd* pd, int gda_provider) {
     break;
 #endif //defined(GDA_BNXT)
 #if defined(GDA_MLX5)
-  case gda::provider::MLX5:
+  case GDAProvider::MLX5:
     gda_op_rdma_write = MLX5_OPCODE_RDMA_WRITE;
     gda_op_rdma_read  = MLX5_OPCODE_RDMA_READ;
     gda_op_atomic_fa  = MLX5_OPCODE_ATOMIC_FA;
@@ -144,17 +144,17 @@ __device__ void QueuePair::post_wqe_rma([[maybe_unused]] int pe, int32_t size, u
     uintptr_t raddr, uint8_t opcode, ActiveWFInfo &wf_info) {
   switch (constmem.gda_provider) {
 #if defined(GDA_IONIC)
-  case gda::provider::IONIC:
+  case GDAProvider::IONIC:
     ionic_post_wqe_rma(size, laddr, raddr, opcode, wf_info);
     return;
 #endif
 #if defined(GDA_BNXT)
-  case gda::provider::BNXT:
+  case GDAProvider::BNXT:
     bnxt_post_wqe_rma(size, laddr, raddr, opcode, wf_info);
     return;
 #endif
 #if defined(GDA_MLX5)
-  case gda::provider::MLX5:
+  case GDAProvider::MLX5:
     mlx5_post_wqe_rma(size, laddr, raddr, opcode, wf_info);
     return;
 #endif
@@ -165,20 +165,20 @@ __device__ void QueuePair::post_wqe_rma([[maybe_unused]] int pe, int32_t size, u
 }
 
 __device__ void QueuePair::post_wqe_rma_single([[maybe_unused]] int32_t size, uintptr_t laddr,
-    uintptr_t raddr, uint8_t opcode, bool ring_db) {
+    uintptr_t raddr, uint8_t opcode, [[maybe_unused]] bool ring_db) {
   switch (constmem.gda_provider) {
 #if defined(GDA_IONIC)
-  case gda::provider::IONIC:
+  case GDAProvider::IONIC:
     ionic_post_wqe_rma_single(size, laddr, raddr, opcode);
     return;
 #endif
 #if defined(GDA_BNXT)
-  case gda::provider::BNXT:
+  case GDAProvider::BNXT:
     bnxt_post_wqe_rma_single(size, laddr, raddr, opcode, ring_db);
     return;
 #endif
 #if defined(GDA_MLX5)
-  case gda::provider::MLX5:
+  case GDAProvider::MLX5:
     mlx5_post_wqe_rma_single(size, laddr, raddr, opcode, ring_db);
     return;
 #endif
@@ -193,17 +193,17 @@ __device__ uint64_t QueuePair::post_wqe_amo([[maybe_unused]] int32_t size, uintp
     bool fetching, ActiveWFInfo &wf_info) {
   switch (constmem.gda_provider) {
 #if defined(GDA_IONIC)
-  case gda::provider::IONIC:
+  case GDAProvider::IONIC:
     return ionic_post_wqe_amo(size, raddr, opcode, atomic_data, atomic_cmp,
            fetching, wf_info);
 #endif
 #if defined(GDA_BNXT)
-  case gda::provider::BNXT:
+  case GDAProvider::BNXT:
     return bnxt_post_wqe_amo(raddr, opcode, atomic_data, atomic_cmp, fetching,
            wf_info);
 #endif
 #if defined(GDA_MLX5)
-  case gda::provider::MLX5:
+  case GDAProvider::MLX5:
     return mlx5_post_wqe_amo(size, raddr, opcode, atomic_data, atomic_cmp,
            fetching, wf_info);
 #endif
@@ -217,16 +217,16 @@ __device__ uint64_t QueuePair::post_wqe_amo_single(uintptr_t raddr,
     uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp, bool fetching) {
   switch (constmem.gda_provider) {
 #if defined(GDA_IONIC)
-  case gda::provider::IONIC:
+  case GDAProvider::IONIC:
     return ionic_post_wqe_amo_single(8 /*size_bytes (only 8-byte atomics implemented)*/, raddr, opcode, atomic_data, atomic_cmp, fetching);
 #endif
 #if defined(GDA_BNXT)
-  case gda::provider::BNXT:
+  case GDAProvider::BNXT:
     return bnxt_post_wqe_amo_single(raddr, opcode, atomic_data, atomic_cmp,
            fetching);
 #endif
 #if defined(GDA_MLX5)
-  case gda::provider::MLX5:
+  case GDAProvider::MLX5:
     return mlx5_post_wqe_amo_single(8 /* 8-byte atomics */, raddr, opcode, atomic_data, atomic_cmp, fetching);
 #endif
   default:
@@ -236,21 +236,21 @@ __device__ uint64_t QueuePair::post_wqe_amo_single(uintptr_t raddr,
 }
 
 __device__ void QueuePair::quiet(ActiveWFInfo &wf_info) {
-  if(wf_info.is_pe_group_leader) {
+  if(wf_info.is_pe_group_first) {
       switch (constmem.gda_provider) {
     #if defined(GDA_IONIC)
-      case gda::provider::IONIC:
+      case GDAProvider::IONIC:
         ionic_quiet(wf_info);
         return;
     #endif
     #if defined(GDA_BNXT)
-      case gda::provider::BNXT:
-          bnxt_quiet(wf_info);
+      case GDAProvider::BNXT:
+          bnxt_quiet();
         return;
     #endif
     #if defined(GDA_MLX5)
-      case gda::provider::MLX5:
-          mlx5_quiet(wf_info);
+      case GDAProvider::MLX5:
+          mlx5_quiet();
         return;
     #endif
       default:
@@ -263,17 +263,17 @@ __device__ void QueuePair::quiet(ActiveWFInfo &wf_info) {
 __device__ void QueuePair::quiet_single() {
   switch (constmem.gda_provider) {
 #if defined(GDA_IONIC)
-  case gda::provider::IONIC:
+  case GDAProvider::IONIC:
     ionic_quiet_single();
     return;
 #endif
 #if defined(GDA_BNXT)
-  case gda::provider::BNXT:
+  case GDAProvider::BNXT:
     bnxt_quiet_single();
     return;
 #endif
 #if defined(GDA_MLX5)
-  case gda::provider::MLX5:
+  case GDAProvider::MLX5:
     mlx5_quiet_single();
     return;
 #endif
@@ -376,7 +376,7 @@ int QueuePair::buffer_register(uintptr_t addr, size_t length) {
       user_buf_info[i].addr   = addr;
       user_buf_info[i].length = length;
 
-      if (gda_provider_ == gda::provider::MLX5) {
+      if (constmem.gda_provider == GDAProvider::MLX5) {
         user_buf_info[i].lkey = htobe32(mr->lkey);
       } else {
         user_buf_info[i].lkey = mr->lkey;

--- a/projects/rocshmem/src/gda/queue_pair.hpp
+++ b/projects/rocshmem/src/gda/queue_pair.hpp
@@ -361,7 +361,7 @@ class QueuePair {
   __device__ void ionic_ring_doorbell_single(uint32_t pos);
 #endif
 
-  int gda_provider_{0};
+  const int gda_provider_{0};
 
   /* GDAProvider::BNXT START */
   uint64_t *bnxt_dbr;

--- a/projects/rocshmem/src/gda/queue_pair.hpp
+++ b/projects/rocshmem/src/gda/queue_pair.hpp
@@ -361,9 +361,7 @@ class QueuePair {
   __device__ void ionic_ring_doorbell_single(uint32_t pos);
 #endif
 
-  const int gda_provider_{0};
-
-  /* GDAProvider::BNXT START */
+  /* gda::provider::BNXT START */
   uint64_t *bnxt_dbr;
   struct bnxt_device_cq bnxt_cq;
   struct bnxt_device_sq bnxt_sq;
@@ -371,9 +369,9 @@ class QueuePair {
   __device__ void bnxt_poll_cq_until(uint32_t requested_available_slots);
   [[maybe_unused]] __device__ __attribute__((noinline)) void bnxt_print_cqe_error(uint8_t status);
 
-  /* GDAProvider::BNXT END */
+  /* gda::provider::BNXT END */
 
-  /* GDAProvider::MLX5 START */
+  /* gda::provider::MLX5 START */
 
   gda_mlx5_device_cq mlx5_cq;
   gda_mlx5_device_sq mlx5_sq;
@@ -381,9 +379,9 @@ class QueuePair {
   __device__ void mlx5_poll_cq_until(uint16_t requested_available_slots);
   [[maybe_unused]] __device__ __attribute__((noinline)) void mlx5_print_cqe_error(const mlx5_cqe64* cqe, uint8_t opcode);
 
-  /* GDAProvider::MLX5 END */
+  /* gda::provider::MLX5 END */
 
-  /* GDAProvider::IONIC START */
+  /* gda::provider::IONIC START */
 
   uint64_t *cq_dbreg{nullptr};
   uint64_t cq_dbval{0};
@@ -450,7 +448,7 @@ class QueuePair {
   __device__ __attribute__((noinline))
   void ionic_quiet_internal(ActiveWFInfo &wf_info, uint32_t cons);
 
-  /* GDAProvider::IONIC END */
+  /* gda::provider::IONIC END */
 
   uint32_t inline_threshold{0};
 

--- a/projects/rocshmem/src/gda/queue_pair.hpp
+++ b/projects/rocshmem/src/gda/queue_pair.hpp
@@ -361,7 +361,7 @@ class QueuePair {
   __device__ void ionic_ring_doorbell_single(uint32_t pos);
 #endif
 
-  /* gda::provider::BNXT START */
+  /* GDAProvider::BNXT START */
   uint64_t *bnxt_dbr;
   struct bnxt_device_cq bnxt_cq;
   struct bnxt_device_sq bnxt_sq;
@@ -369,9 +369,9 @@ class QueuePair {
   __device__ void bnxt_poll_cq_until(uint32_t requested_available_slots);
   [[maybe_unused]] __device__ __attribute__((noinline)) void bnxt_print_cqe_error(uint8_t status);
 
-  /* gda::provider::BNXT END */
+  /* GDAProvider::BNXT END */
 
-  /* gda::provider::MLX5 START */
+  /* GDAProvider::MLX5 START */
 
   gda_mlx5_device_cq mlx5_cq;
   gda_mlx5_device_sq mlx5_sq;
@@ -379,9 +379,9 @@ class QueuePair {
   __device__ void mlx5_poll_cq_until(uint16_t requested_available_slots);
   [[maybe_unused]] __device__ __attribute__((noinline)) void mlx5_print_cqe_error(const mlx5_cqe64* cqe, uint8_t opcode);
 
-  /* gda::provider::MLX5 END */
+  /* GDAProvider::MLX5 END */
 
-  /* gda::provider::IONIC START */
+  /* GDAProvider::IONIC START */
 
   uint64_t *cq_dbreg{nullptr};
   uint64_t cq_dbval{0};
@@ -448,7 +448,7 @@ class QueuePair {
   __device__ __attribute__((noinline))
   void ionic_quiet_internal(ActiveWFInfo &wf_info, uint32_t cons);
 
-  /* gda::provider::IONIC END */
+  /* GDAProvider::IONIC END */
 
   uint32_t inline_threshold{0};
 

--- a/projects/rocshmem/src/gda/queue_pair.hpp
+++ b/projects/rocshmem/src/gda/queue_pair.hpp
@@ -483,6 +483,7 @@ class QueuePair {
 
   struct user_buf_info_t *user_buf_info = nullptr;
   size_t num_user_buffers = 0;
+  int gda_provider_{0};  // host-side only; device dispatch uses constmem.gda_provider
 
   int buffer_register(uintptr_t addr, size_t length);
   int buffer_unregister(uintptr_t addr);

--- a/projects/rocshmem/src/rocshmem.cpp
+++ b/projects/rocshmem/src/rocshmem.cpp
@@ -84,7 +84,7 @@ rocshmem_ctx_t ROCSHMEM_HOST_CTX_DEFAULT;
  * Begin Host Code
  **/
 
-BackendType get_backend_type() { return backend->get_backend_type(); }
+BackendType rocshmem_query_backend_type() { return backend->get_type(); }
 
 #if defined(USE_GDA) && defined(USE_RO) && defined(USE_IPC)
 static BackendType select_backend_type(MPI_Comm comm, TcpBootstrap *bootstrap) {

--- a/projects/rocshmem/src/rocshmem_gpu.cpp
+++ b/projects/rocshmem/src/rocshmem_gpu.cpp
@@ -208,6 +208,11 @@ __host__ int rocshmem_hipmodule_init(hipModule_t module, hipStream_t stream) {
                                    "ROCSHMEM_TEAM_SHARED") != ROCSHMEM_SUCCESS) {
     return ROCSHMEM_ERROR;
   }
+  if (copy_device_symbol_to_module(constmem, "_ZN8rocshmem8constmemE",
+                                   sizeof(constmem_t), module, stream,
+                                   "constmem") != ROCSHMEM_SUCCESS) {
+    return ROCSHMEM_ERROR;
+  }
   return ROCSHMEM_SUCCESS;
 }
 

--- a/projects/rocshmem/src/rocshmem_gpu.cpp
+++ b/projects/rocshmem/src/rocshmem_gpu.cpp
@@ -166,7 +166,7 @@ static int copy_device_symbol_to_module(Symbol &builtin_symbol,
   size_t symbol_size {0};
   err = hipModuleGetGlobal(&target, &symbol_size, module, module_symbol_name);
   if (err != hipSuccess) {
-    LOG_ERROR("Failed to get %s symbol from module: %s", 
+    LOG_ERROR("Failed to get %s symbol from module: %s",
               label, hipGetErrorString(err));
     return ROCSHMEM_ERROR;
   }
@@ -208,10 +208,17 @@ __host__ int rocshmem_hipmodule_init(hipModule_t module, hipStream_t stream) {
                                    "ROCSHMEM_TEAM_SHARED") != ROCSHMEM_SUCCESS) {
     return ROCSHMEM_ERROR;
   }
-  if (copy_device_symbol_to_module(constmem, "_ZN8rocshmem8constmemE",
+  {
+    void *probe{nullptr}; size_t probe_size{0};
+    if (hipModuleGetGlobal(&probe, &probe_size, module,
+                           "_ZN8rocshmem8constmemE") == hipSuccess) {
+      copy_device_symbol_to_module(constmem, "_ZN8rocshmem8constmemE",
                                    sizeof(constmem_t), module, stream,
-                                   "constmem") != ROCSHMEM_SUCCESS) {
-    return ROCSHMEM_ERROR;
+                                   "constmem");
+    } else {
+      LOG_WARN("constmem not in module — module does not use rocshmem "
+               "device APIs that read constmem directly");
+    }
   }
   return ROCSHMEM_SUCCESS;
 }

--- a/projects/rocshmem/tests/functional_tests/tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/tester.cpp
@@ -174,7 +174,7 @@ std::vector<Tester*> Tester::create(TesterArguments args) {
   std::vector<Tester*> testers;
   std::string test_name;
 
-  BackendType backend_type = get_backend_type();
+  BackendType backend_type = rocshmem_query_backend_type();
   TestType type = (TestType)args.algorithm;
 
   switch (type) {


### PR DESCRIPTION
## Motivation

  The GDA device hot path (put_nbi → post_wqe_rma → quiet) repeatedly loads values from Context and QueuePair members that are constant after initialization. On CDNA GPUs, __constant__ memory is served by the scalar unit (SGPR-cached), avoiding vector memory unit
  contention and VGPR pressure. The backend_type and gda_provider moves have the additional benefit of enabling dead-code elimination in single-backend/single-provider builds — the compiler can resolve the dispatch at compile time.


## Technical Details

 - Move backend_type and gda_provider to __constant__ memory, replacing per-context HBM loads in device-side DISPATCH macros and provider switch statements with scalar-cached reads
  - For single-provider builds (e.g., GDA_MLX5 only), the compiler eliminates dead switch branches entirely, reducing code size and removing branch divergence on the hot path
  - Add __builtin_unreachable() to default cases in provider dispatch switches to enable better optimization
  - Remove gda_provider_ from GDAContext (was redundant with the per-QP copy); provider is now read from constmem on device
  - Move world my_pe and num_pes to __constant__ memory, replacing per-context HBM pointer chases in putmem_nbi, getmem_nbi, get_qp_index, collectives, and atomics



## JIRA ID

AIROCSHMEM-306
AIROCSHMEM-307

## Test Plan

CI/functional tests

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
