### PR TITLE
[rocjitsu] Fix gfx1250 SMEM scaled offset handling

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -2760,7 +2760,11 @@ class CodeGenerator:
         L.append('  d->is_load = true;')
         self._append_wait_counter_type(L, 'smem_load')
         L.append(f'  d->mtype = {self._mtype_expr(is_smem=True)};')
-        L.append('  d->addr = smem_calculate_address(inst_, wf);')
+        if self.isa_spec.profile.smem_address_uses_access_size:
+            addr_args = 'inst_, wf, d->elem_size * d->num_dwords'
+        else:
+            addr_args = 'inst_, wf'
+        L.append(f'  d->addr = smem_calculate_address({addr_args});')
         # Counter increment handled by MemoryPipeline::issue().
         L.append('  set_data(std::move(d));')
         return '\n'.join(L)
@@ -2772,6 +2776,8 @@ class CodeGenerator:
         nd = sem.num_elems
         L.append('  auto d = std::make_unique<amdgpu::ScalarMemState>();')
         L.append(f'  d->num_dwords = {nd};')
+        if self.isa_spec.profile.smem_address_uses_access_size:
+            L.append('  d->elem_size = 4;')
         L.append('  d->is_load = false;')
         self._append_wait_counter_type(L, 'smem_store')
         L.append(f'  d->mtype = {self._mtype_expr(is_smem=True)};')
@@ -2779,7 +2785,11 @@ class CodeGenerator:
         L.append('  uint32_t sdata_base = wf.sgpr_alloc().base + inst_.sdata;')
         L.append(f'  for (uint32_t i = 0; i < {nd}; ++i)')
         L.append('    d->store_data[i] = cu.read_sgpr(sdata_base + i);')
-        L.append('  d->addr = smem_calculate_address(inst_, wf);')
+        if self.isa_spec.profile.smem_address_uses_access_size:
+            addr_args = 'inst_, wf, d->elem_size * d->num_dwords'
+        else:
+            addr_args = 'inst_, wf'
+        L.append(f'  d->addr = smem_calculate_address({addr_args});')
         # Counter increment handled by MemoryPipeline::issue().
         L.append('  set_data(std::move(d));')
         return '\n'.join(L)

--- a/emulation/rocjitsu/lib/python/amdisa/isa_profile.py
+++ b/emulation/rocjitsu/lib/python/amdisa/isa_profile.py
@@ -246,6 +246,11 @@ class IsaProfile(ABC):
         return False
 
     @property
+    def smem_address_uses_access_size(self) -> bool:
+        """True when generated SMEM address helpers need the access size."""
+        return False
+
+    @property
     def semantic_overrides(self) -> dict[str, tuple[str, ...]]:
         """Per-instruction semantic overrides for this ISA.
 
@@ -1433,6 +1438,10 @@ class Gfx1250Profile(Rdna4Profile):
 
     @property
     def generate_scaled_wmma_vop3px2(self) -> bool:
+        return True
+
+    @property
+    def smem_address_uses_access_size(self) -> bool:
         return True
 
     @property

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
@@ -68,6 +68,7 @@ def test_gfx1250_profile_enables_generator_backed_quirks():
     assert profile.use_hwreg_helpers
     assert profile.hwreg_wave_sched_mode_id == 26
     assert profile.generate_scaled_wmma_vop3px2
+    assert profile.smem_address_uses_access_size
 
 
 def test_rdna4_profile_keeps_gfx1250_quirks_disabled():
@@ -78,6 +79,7 @@ def test_rdna4_profile_keeps_gfx1250_quirks_disabled():
     assert not profile.use_hwreg_helpers
     assert profile.hwreg_wave_sched_mode_id is None
     assert not profile.generate_scaled_wmma_vop3px2
+    assert not profile.smem_address_uses_access_size
 
 
 def test_packed_16bit_source_gate_is_limited_to_e32_16bit_sources():

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/addr_calc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/addr_calc.cpp
@@ -7,8 +7,10 @@
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"
 #include "rocjitsu/vm/amdgpu/wavefront.h"
+#include "util/bit.h"
 #include "util/except.h"
 
+#include <algorithm>
 #include <cassert>
 #include <cstdint>
 
@@ -108,15 +110,20 @@ void flat_global_calculate_addresses(const Inst &inst, amdgpu::Wavefront &wf,
 
 } // namespace
 
-uint64_t smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf) {
+uint64_t smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf,
+                                uint32_t access_size_bytes) {
   auto &cu = wf.cu();
+  assert(access_size_bytes != 0);
   uint32_t sbase = wf.sgpr_alloc().base + inst.sbase * 2;
   uint64_t base = (static_cast<uint64_t>(cu.read_sgpr(sbase + 1)) << 32) | cu.read_sgpr(sbase);
   int64_t off = static_cast<int64_t>(static_cast<int32_t>(inst.ioffset << 8) >> 8);
+  uint32_t scale = inst.scale_offset ? access_size_bytes : 1;
+  off *= scale;
   if (has_smem_offset(inst.soffset))
-    off += read_sreg_m0_operand(wf, inst.soffset);
+    off += static_cast<int64_t>(read_sreg_m0_operand(wf, inst.soffset)) * scale;
   uint64_t addr = base + off;
-  assert((addr & 0x7u) == 0 && "gfx1250 scalar memory address must be 8-byte aligned");
+  assert(util::is_aligned(addr, std::min<uint64_t>(access_size_bytes, 4u)) &&
+         "gfx1250 scalar memory address must satisfy access alignment");
   return addr;
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/addr_calc.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/addr_calc.h
@@ -18,7 +18,8 @@ struct VectorMemState;
 
 namespace rocjitsu::gfx1250 {
 
-uint64_t smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf);
+uint64_t smem_calculate_address(const SmemMachineInst &inst, amdgpu::Wavefront &wf,
+                                uint32_t access_size_bytes);
 
 void flat_calculate_addresses(const VflatMachineInst &inst, amdgpu::Wavefront &wf,
                               amdgpu::VectorMemState &d);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/smem.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/smem.cpp
@@ -50,7 +50,7 @@ void SLoadB32Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
   set_data(std::move(d));
 }
 
@@ -76,7 +76,7 @@ void SLoadB64Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
   set_data(std::move(d));
 }
 
@@ -103,7 +103,7 @@ void SLoadB128Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
   set_data(std::move(d));
 }
 
@@ -130,7 +130,7 @@ void SLoadB256Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
   set_data(std::move(d));
 }
 
@@ -157,7 +157,7 @@ void SLoadB512Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
   set_data(std::move(d));
 }
 
@@ -183,7 +183,7 @@ void SLoadB96Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
   set_data(std::move(d));
 }
 
@@ -209,7 +209,7 @@ void SLoadI8Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
   set_data(std::move(d));
 }
 
@@ -235,7 +235,7 @@ void SLoadU8Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
   set_data(std::move(d));
 }
 
@@ -261,7 +261,7 @@ void SLoadI16Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
   set_data(std::move(d));
 }
 
@@ -287,7 +287,7 @@ void SLoadU16Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
   set_data(std::move(d));
 }
 
@@ -314,7 +314,7 @@ void SBufferLoadB32Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
   set_data(std::move(d));
 }
 
@@ -341,7 +341,7 @@ void SBufferLoadB64Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
   set_data(std::move(d));
 }
 
@@ -368,7 +368,7 @@ void SBufferLoadB128Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
   set_data(std::move(d));
 }
 
@@ -395,7 +395,7 @@ void SBufferLoadB256Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
   set_data(std::move(d));
 }
 
@@ -422,7 +422,7 @@ void SBufferLoadB512Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
   set_data(std::move(d));
 }
 
@@ -449,7 +449,7 @@ void SBufferLoadB96Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
   set_data(std::move(d));
 }
 
@@ -476,7 +476,7 @@ void SBufferLoadI8Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
   set_data(std::move(d));
 }
 
@@ -503,7 +503,7 @@ void SBufferLoadU8Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
   set_data(std::move(d));
 }
 
@@ -530,7 +530,7 @@ void SBufferLoadI16Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
   set_data(std::move(d));
 }
 
@@ -557,7 +557,7 @@ void SBufferLoadU16Smem::execute_impl(amdgpu::Wavefront &wf) {
   d->is_load = true;
   d->wait_counter_type = amdgpu::WaitCounterType::KMCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
-  d->addr = smem_calculate_address(inst_, wf);
+  d->addr = smem_calculate_address(inst_, wf, d->elem_size * d->num_dwords);
   set_data(std::move(d));
 }
 

--- a/emulation/rocjitsu/lib/util/include/util/bit.h
+++ b/emulation/rocjitsu/lib/util/include/util/bit.h
@@ -249,6 +249,15 @@ constexpr inline T align_up(T val, T alignment) {
   return (val + alignment - 1) & ~(alignment - 1);
 }
 
+/// @brief Return true when @p val is aligned to @p alignment.
+/// @param alignment Must be a power of 2.
+template <typename T>
+  requires metaprogramming::IsUnsignedInt<T>
+constexpr inline bool is_aligned(T val, T alignment) {
+  assert(std::has_single_bit(alignment));
+  return (val & (alignment - 1)) == 0;
+}
+
 } // namespace util
 
 #endif // UTIL_BIT_H_

--- a/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
+++ b/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
@@ -53,6 +53,7 @@ using namespace rocjitsu;
 const std::string kGfx1250ConfigPath = std::string(CONFIG_DIR) + "/amdgpu_gfx1250.json";
 
 constexpr uint32_t S_ENDPGM_GFX12 = 0xBFB00000u;
+constexpr uint32_t S_WAIT_KMCNT_0_GFX12 = 0xBFC70000u;
 constexpr uint32_t S_SET_VGPR_MSB = 0xBF860000u;
 // LLVM references for these gfx1250 register capacities:
 // - llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp:
@@ -243,6 +244,15 @@ constexpr uint32_t make_vmov_b32(uint8_t vdst) {
 
 constexpr std::array<uint32_t, 2> make_vmov_b32_literal(uint8_t vdst, uint32_t literal) {
   return {make_vmov_b32(vdst), literal};
+}
+
+constexpr std::array<uint32_t, 2> make_s_load_b32_scaled_imm(uint8_t sdata, uint8_t sbase_pair,
+                                                             uint32_t scaled_offset) {
+  constexpr uint32_t kSmemEncoding = 0x3Du << 26;
+  constexpr uint32_t kSoffsetNull = 0x7Cu;
+  return {kSmemEncoding | ((static_cast<uint32_t>(sdata) & 0x7Fu) << 6) |
+              (static_cast<uint32_t>(sbase_pair) & 0x3Fu),
+          (scaled_offset & 0x00FF'FFFFu) | (1u << 24) | (kSoffsetNull << 25)};
 }
 
 constexpr uint16_t vopd_src0_vgpr(uint16_t reg) { return 256 + reg; }
@@ -1302,6 +1312,36 @@ TEST(Gfx1250SimulationTest, DispatchPreloadsKernargWhenDescriptorSizeIsUnknown) 
   EXPECT_EQ(read_wave_sgpr64(*sim.cu(), *wf, 0), kKernargAddr);
   EXPECT_EQ(sim.cu()->read_sgpr(sbase + 2), args[1]);
   EXPECT_EQ(sim.cu()->read_sgpr(sbase + 3), args[2]);
+}
+
+TEST(Gfx1250SimulationTest, SLoadB32ScalesImmediateOffset) {
+  using namespace rocr::llvm::amdhsa;
+
+  constexpr uint64_t kKernelAddr = 0x10000;
+  constexpr uint64_t kKernargAddr = 0x400000;
+  constexpr uint32_t kExpected = 0x12345678u;
+
+  std::vector<uint32_t> code;
+  append_instruction(code, make_s_load_b32_scaled_imm(4, 0, 1));
+  append_instruction(code, S_WAIT_KMCNT_0_GFX12);
+  append_instruction(code, S_ENDPGM_GFX12);
+
+  uint32_t kernel_code_properties = 0;
+  AMDHSA_BITS_SET(kernel_code_properties, KERNEL_CODE_PROPERTY_ENABLE_SGPR_KERNARG_SEGMENT_PTR, 1);
+
+  Gfx1250Sim sim;
+  write_global_u32(*sim.memory, kKernargAddr + 4, kExpected);
+  uint64_t kernel_object = sim.write_kernel(kKernelAddr, code.data(), code.size(), 104, 32, 2,
+                                            false, false, false, kernel_code_properties, 16);
+
+  test::AqlQueue queue(sim.memory, sim.cp());
+  queue.dispatch(kernel_object, 32, 32, kKernargAddr);
+  step_until_halted(*sim.engine, *sim.cu());
+
+  ASSERT_EQ(sim.cu()->num_wfs(), 1u);
+  auto *wf = sim.cu()->wf(0);
+  ASSERT_NE(wf, nullptr);
+  EXPECT_EQ(read_wave_sgpr(*sim.cu(), *wf, 4), kExpected);
 }
 
 TEST(Gfx1250SimulationTest, TtmpWorkgroupIdsUseGridCoordinatesFor2DDispatch) {

--- a/emulation/rocjitsu/tests/shared_infra_test.cpp
+++ b/emulation/rocjitsu/tests/shared_infra_test.cpp
@@ -24,6 +24,7 @@
 #include "rocjitsu/vm/amdgpu/l2_cache.h"
 
 #include "simdojo/sim/simulation.h"
+#include "util/bit.h"
 
 #include <gtest/gtest.h>
 
@@ -66,6 +67,12 @@ static_assert(kCdnaAccVgprsPerWf == 256);
 static_assert(cdna3::Isa::MAX_ACC_VGPRS_PER_WF == kCdnaAccVgprsPerWf);
 static_assert(cdna4::Isa::MAX_ACC_VGPRS_PER_WF == kCdnaAccVgprsPerWf);
 static_assert(gfx1250::Isa::MAX_ACC_VGPRS_PER_WF == 0);
+
+TEST(UtilBitTest, IsAlignedChecksPowerOfTwoAlignment) {
+  EXPECT_TRUE(util::is_aligned<uint64_t>(0x1000u, 4u));
+  EXPECT_TRUE(util::is_aligned<uint32_t>(0u, 8u));
+  EXPECT_FALSE(util::is_aligned<uint64_t>(0x1003u, 4u));
+}
 
 // ---------------------------------------------------------------------------
 // MFMA register layout tests


### PR DESCRIPTION
## Motivation

This is a follow up fix for https://github.com/ROCm/rocm-systems/pull/6886. The addr alignment assertion in addr_calc would fire on some tensile kernels.

## Technical Details

Instructions with scale_offset were treating the encoded offset as bytes instead of scaling it by the load/store access size. That made Tensile sparse kernels read the wrong addresses, and after the first fix attempt we also hit an overly strict 8-byte alignment assert on valid dword loads.

## JIRA ID

N/A

## Test Plan

Run all unit tests and local hip c++ / IREE / Tensile test corpus.

## Test Result

The above passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
