### PR TITLE
clr: profile graph when using ext-dispatch packets

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -3756,10 +3756,17 @@ void Device::ApplyHwEventPatches(const std::vector<HwEventPatch>& patches,
       // kernel dispatches (not synthetic barriers).
       ps->flags_.done_ = false;
       uint16_t hdr;
-      memcpy(&hdr, raw, sizeof(hdr));
+      memcpy(&hdr, patch.packet, sizeof(hdr));
       uint8_t pktType = hdr & ((1 << HSA_PACKET_HEADER_WIDTH_TYPE) - 1);
+      // A kernel dispatch could be a vendor-specific ext-kernel-dispatch
+      // packet, identified by amd_format (byte 2).  Classify it as a dispatch so
+      // the patched last-node completion signal contributes its GPU timing like
+      // every other graph kernel node.
+      const uint8_t amdFormat = patch.packet[2];
       ps->flags_.isPacketDispatch_ =
-          (pktType == HSA_PACKET_TYPE_KERNEL_DISPATCH);
+          (pktType == HSA_PACKET_TYPE_KERNEL_DISPATCH) ||
+          (pktType == HSA_PACKET_TYPE_VENDOR_SPECIFIC &&
+           amdFormat == HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH);
     } else {
       // dep_slot >= 0: patch a barrier's dependency signal slot (cross-segment wait)
       auto* pkt = reinterpret_cast<hsa_barrier_and_packet_t*>(raw);

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1545,6 +1545,15 @@ bool VirtualGPU::dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPack
         const uint16_t hdr = static_cast<uint16_t>(validFullHeaders[i]);
         const uint8_t pktType =
             extractAqlBits(hdr, HSA_PACKET_HEADER_TYPE, HSA_PACKET_HEADER_WIDTH_TYPE);
+        const uint8_t amdFormat = static_cast<uint8_t>((validFullHeaders[i] >> 16) & 0xFF);
+        // Classify purely from the packet header/type fields: ext-kernel-dispatch
+        // packets can be emitted opportunistically (e.g. cluster-dimension launches)
+        // regardless of the global ext_dispatch_packet_ setting.
+        const bool isBaseKernelDispatch = (pktType == HSA_PACKET_TYPE_KERNEL_DISPATCH);
+        const bool isKernelDispatch =
+            isBaseKernelDispatch ||
+            (pktType == HSA_PACKET_TYPE_VENDOR_SPECIFIC &&
+             amdFormat == HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH);
         if (timestamp_ != nullptr) {
           // When pre_patched, skip any slot whose completion_signal was already
           // written by ApplyHwEventPatches (non-zero means pre-patched).
@@ -1552,20 +1561,21 @@ bool VirtualGPU::dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPack
           if (!has_prepatched_signal) {
             slot->completion_signal =
                 Barriers().ActiveSignal(kInitSignalValueOne, timestamp_, true);
-            if (pktType == HSA_PACKET_TYPE_KERNEL_DISPATCH) {
-              if (amd::activity_prof::IsEnabled(OP_ID_DISPATCH)) {
+            if (isKernelDispatch) {
+              // reserved2 correlation-id stamping is only valid for the base
+              // hsa_kernel_dispatch_packet_t layout; the ext packet has a
+              // different field at that offset.
+              if (isBaseKernelDispatch && amd::activity_prof::IsEnabled(OP_ID_DISPATCH)) {
                 slot->reserved2 = timestamp_->command().profilingInfo().correlation_id_;
               }
               Barriers().GetLastSignal()->flags_.isPacketDispatch_ = true;
             }
-          } else if (has_prepatched_signal &&
-                     pktType == HSA_PACKET_TYPE_KERNEL_DISPATCH &&
+          } else if (has_prepatched_signal && isBaseKernelDispatch &&
                      amd::activity_prof::IsEnabled(OP_ID_DISPATCH)) {
             slot->reserved2 = timestamp_->command().profilingInfo().correlation_id_;
           }
         }
-        if (kernelNames != nullptr && i < kernelNames->size() &&
-            pktType == HSA_PACKET_TYPE_KERNEL_DISPATCH) {
+        if (kernelNames != nullptr && i < kernelNames->size() && isKernelDispatch) {
           ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_KERN2, "Graph ShaderName : %s, device id : %u",
                   (*kernelNames)[i]->c_str(), dev().index());
           ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL,


### PR DESCRIPTION
With ext_dispatch_packet_, graph kernel nodes are emitted as vendor-specific ext-kernel-dispatch packets (HSA_PACKET_TYPE_VENDOR_SPECIFIC, amd_format == HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH) rather than HSA_PACKET_TYPE_KERNEL_DISPATCH. dispatchAqlPacketBatchFlat() and ApplyHwEventPatches() only set ProfilingSignal::isPacketDispatch_ for the legacy packet type, so addTimestamps() dropped every per-node timestamp and the built-in CLR profiler recorded zero kernels for segment-scheduled graph launches on MI450.

Classify ext-kernel-dispatch packets as kernel dispatches in both paths so per-node profiling signals are tagged and real GPU timestamps accumulate. reserved2 correlation-id stamping stays gated to the base packet layout to avoid corrupting the ext packet. Direct (non-graph) dispatch and pre-gfx12 are unaffected.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
