### PR TITLE
[rocprofiler-compute] Unify PC sampling analysis for db and cli

### DIFF
--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -40,7 +40,9 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 * PC sampling in profile mode now opts in via the `--experimental --pc-sampling` option. Explicit `-b 21` / `--block 21` is no longer accepted on its own.
 
-* PC sampling analysis without kernel filtering now reads the results JSON, as a prerequisite for showing the detailed per-instruction stall-reason view consistent with single-kernel filtering. This increases no-filter analysis time and memory for large workloads.
+* PC sampling profiling now emits only `ps_file_results.json`. The per-sample, kernel-trace, and agent-info CSV artifacts are no longer produced or consumed by analysis.
+
+* PC sampling analysis without `-k` now shows the full per-instruction table across all kernels (with a `Kernel_Name` column), identical in schema to the single-kernel view, instead of a collapsed source-line summary.
 
 ### Removed
 

--- a/projects/rocprofiler-compute/docs/how-to/pc_sampling.rst
+++ b/projects/rocprofiler-compute/docs/how-to/pc_sampling.rst
@@ -62,7 +62,7 @@ Selecting single kernel stochastic PC sampling:
    :align: left
    :alt: Stochastic PC sampling snapshot
 
-If you don't filter by kernel, the output shows the aggregated data from ``rocprofiler-sdk`` for all the kernels:
+If you don't filter by kernel, the output shows the same per-instruction table across all kernels, with a ``Kernel_Name`` column identifying each row's kernel:
 
 .. image:: ../data/pc_sampling/pc_sampling_no_kernel_filtering.png
    :align: left

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
@@ -5,7 +5,7 @@ import ast
 import re
 import warnings
 from pathlib import Path
-from typing import Any, Callable, Optional, Union
+from typing import Any, Optional
 
 import astunparse
 import numpy as np
@@ -46,9 +46,7 @@ from utils.metrics.noise_clamper import (
     to_noise_clamp,
 )
 from utils.mi_gpu_spec import mi_gpu_specs
-from utils.parser import (
-    PC_SAMPLING_NOT_ISSUE_PREFIX,
-)
+from utils.pc_sampling_analysis import load_aggregated_pc_sampling
 from utils.roofline_calc import (
     CACHE_HIERARCHY,
     MATRIX_DATATYPES,
@@ -390,96 +388,24 @@ class db_analysis(OmniAnalyze_Base):
                 console_warning(f"PC sampling data not found for {workload_path}.")
                 continue
 
-            pc_sampling_stochastic = pc_sampling_data["buffer_records"][
-                "pc_sample_stochastic"
-            ]
-            pc_sampling_host_trap = pc_sampling_data["buffer_records"][
-                "pc_sample_host_trap"
-            ]
-            pc_sampling_instruction = pc_sampling_data["strings"][
-                "pc_sample_instructions"
-            ]
-            pc_sampling_comments = pc_sampling_data["strings"]["pc_sample_comments"]
-            pc_sampling_kernel_name_dict = {
-                symbol["code_object_id"]: symbol["formatted_kernel_name"]
-                for symbol in pc_sampling_data["kernel_symbols"]
-            }
-
-            pc_df = pd.DataFrame([
-                {
-                    "inst_index": pc_sample["inst_index"],
-                    "code_object_id": pc_sample["record"]["pc"]["code_object_id"],
-                    "code_object_offset": pc_sample["record"]["pc"][
-                        "code_object_offset"
-                    ],
-                    "stall_reason": pc_sample["record"]
-                    .get("snapshot", {})
-                    .get("stall_reason"),
-                    "wave_issued": pc_sample["record"].get("wave_issued"),
-                }
-                for pc_sample in pc_sampling_stochastic + pc_sampling_host_trap
-            ])
-
-            def custom_aggregator(
-                column_name: str,
-            ) -> Callable[[pd.Series], Union[int, dict[str, int], None]]:
-                if column_name == "count_issued":
-
-                    def aggregator(series: pd.Series) -> Optional[int]:
-                        return None if series.isnull().all() else series.sum()
-
-                    return aggregator
-                if column_name == "count_stalled":
-
-                    def aggregator(series: pd.Series) -> Optional[int]:
-                        if series.isnull().all():
-                            return None
-                        return series.count() - series.sum()
-
-                    return aggregator
-                if column_name == "stall_reason":
-
-                    def aggregator(series: pd.Series) -> Optional[dict[str, int]]:
-                        if series.isnull().all():
-                            return None
-                        cleaned_series = series.dropna().str[
-                            len(PC_SAMPLING_NOT_ISSUE_PREFIX) :
-                        ]
-                        return cleaned_series.value_counts().to_dict()
-
-                    return aggregator
-                raise ValueError(f"Unknown column name: {column_name}")
-
-            grouped_df = (
-                pc_df
-                .groupby(["code_object_id", "code_object_offset"])
-                .agg(
-                    count=("code_object_id", "size"),
-                    inst_index=("inst_index", "last"),
-                    count_issued=("wave_issued", custom_aggregator("count_issued")),
-                    count_stalled=("wave_issued", custom_aggregator("count_stalled")),
-                    stall_reason=("stall_reason", custom_aggregator("stall_reason")),
-                )
-                .reset_index()
-            )
-
-            grouped_df["instruction"] = grouped_df["inst_index"].apply(
-                lambda x: (
-                    pc_sampling_instruction[x]
-                    if x < len(pc_sampling_instruction)
-                    else None
-                )
-            )
-            grouped_df["source_line"] = grouped_df["inst_index"].apply(
-                lambda x: (
-                    pc_sampling_comments[x] if x < len(pc_sampling_comments) else None
-                )
-            )
-            grouped_df["kernel_name"] = grouped_df["code_object_id"].apply(
-                lambda x: pc_sampling_kernel_name_dict.get(x)
+            grouped_df = load_aggregated_pc_sampling(
+                pc_sampling_data,
+                group_by=["code_object_id", "code_object_offset"],
+                attach={"instruction", "source_line", "kernel_name"},
             )
             grouped_df = grouped_df.rename(columns={"code_object_offset": "offset"})
-            grouped_df = grouped_df.drop(columns=["code_object_id", "inst_index"])
+            grouped_df = grouped_df[
+                [
+                    "offset",
+                    "count",
+                    "count_issued",
+                    "count_stalled",
+                    "stall_reason",
+                    "instruction",
+                    "source_line",
+                    "kernel_name",
+                ]
+            ]
 
             pc_sampling_data_per_workload[workload_path] = grouped_df
 

--- a/projects/rocprofiler-compute/src/utils/parser.py
+++ b/projects/rocprofiler-compute/src/utils/parser.py
@@ -2,10 +2,9 @@
 # SPDX-License-Identifier:  MIT
 
 import argparse
-import json
 import re
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 import pandas as pd
 
@@ -14,6 +13,13 @@ from utils.logger import console_error, console_warning, demarcate
 from utils.metrics.evaluation_pipeline import eval_metric
 from utils.metrics.expression import gen_counter_list
 from utils.pattern_matching import fnmatch_glob_matches
+from utils.pc_sampling_analysis import (
+    SOURCE_LINE_MISSING,
+    aggregate_pc_sample_records,
+    detect_pc_sampling_method,
+    enrich_with_metadata,
+    load_pc_sample_records,
+)
 from utils.specs import MachineSpecs
 from utils.utils_common import (
     METRIC_ID_RE,
@@ -38,8 +44,6 @@ from utils.utils_common import (
 PMC_KERNEL_TOP_TABLE_ID: int = 1
 # 002 is ID of pmc_dispatch_info.csv table
 PMC_DISPATCH_INFO_TABLE_ID: int = 2
-
-PC_SAMPLING_NOT_ISSUE_PREFIX = "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_"
 
 
 @demarcate
@@ -394,263 +398,60 @@ def apply_dispatch_filter(df: pd.DataFrame, workload: schema.Workload) -> pd.Dat
     return df
 
 
-def search_pc_sampling_record(
-    records: Union[list[dict], dict],
-) -> Optional[list[tuple]]:
-    """
-    Search PC sampling records.
-
-    Group by (code_object_id, code_object_offset, inst_index), and aggregate
-    counts, stall reasons, and dispatch IDs.
-
-    Returns:
-        A sorted list of tuples:
-        (
-            code_object_id,
-            code_object_offset,
-            inst_index,
-            total_count,
-            count_issued,
-            count_stalled,
-            sorted_stall_reasons,
-            sorted_dispatch_ids,
-        )
-    """
-
-    if not records:
-        console_warning("PC sampling: no pc sampling record found!")
-        return None
-
-    # records should always be a list of dict
-    if isinstance(records, dict):
-        records = [records]
-
-    rocp_inst_not_issued_prefix_len = len(PC_SAMPLING_NOT_ISSUE_PREFIX)
-
-    stall_reason_keys = {
-        "NONE": 0,
-        # No instruction available in the instruction cache.
-        "NO_INSTRUCTION_AVAILABLE": 0,
-        "ALU_DEPENDENCY": 0,  # ALU dependency not resolved.
-        "WAITCNT": 0,
-        "INTERNAL_INSTRUCTION": 0,  # Wave executes an internal instruction.
-        "BARRIER_WAIT": 0,
-        "ARBITER_NOT_WIN": 0,  # The instruction did not win the arbiter.
-        "ARBITER_WIN_EX_STALL": 0,
-        # Arbiter issued an instruction, but the execution pipe
-        # pushed it back from execution.
-        "OTHER_WAIT": 0,
-        # Other types of wait (e.g., wait for XNACK acknowledgment).
-        "SLEEP_WAIT": 0,
-        "LAST": 0,
-    }
-
-    grouped_data: dict[tuple, list] = {}
-
-    for item in records:
-        record = item.get("record", {})
-        pc_info = record.get("pc", {})
-
-        code_object_id = pc_info.get("code_object_id")
-        code_object_offset = pc_info.get("code_object_offset")
-        inst_index = item.get("inst_index")
-        dispatch_id = record.get("dispatch_id")
-
-        if None in (code_object_id, code_object_offset, inst_index):
-            continue
-
-        key = (code_object_id, code_object_offset, inst_index)
-
-        snapshot = record.get("snapshot", {})
-        issued = record.get("wave_issued", False)
-
-        if key not in grouped_data:
-            grouped_data[key] = [0, 0, 0, {}, set()]
-
-        entry = grouped_data[key]
-
-        # Update counts
-        entry[0] += 1  # total_count
-        if issued:
-            entry[1] += 1  # count_issued
-        else:
-            entry[2] += 1  # count_stalled
-            stall_reason = snapshot.get("stall_reason")
-            if stall_reason and len(stall_reason) > rocp_inst_not_issued_prefix_len:
-                reason_key = stall_reason[rocp_inst_not_issued_prefix_len:]
-                if reason_key in stall_reason_keys:
-                    entry[3][reason_key] = entry[3].get(reason_key, 0) + 1
-
-        # Add dispatch_id if valid
-        if dispatch_id is not None:
-            entry[4].add(dispatch_id)
-
-    if not grouped_data:
-        console_warning("PC sampling: no pc sampling record found!")
-        return None
-
-    # Convert to sorted list of tuples:
-    sorted_counts = sorted(
-        [
-            (
-                code_object_id,
-                code_object_offset,
-                inst_index,
-                info[0],  # total_count
-                info[1],  # count_issued
-                info[2],  # count_stalled
-                sorted(
-                    ((k, v) for k, v in info[3].items() if v > 0),
-                    key=lambda item: item[1],
-                    reverse=True,
-                ),  # sorted stall reasons
-                sorted(info[4]),  # sorted dispatch_ids list
-            )
-            for (
-                code_object_id,
-                code_object_offset,
-                inst_index,
-            ), info in grouped_data.items()
-        ],
-        key=lambda x: (x[0], x[1], x[2]),
-    )
-
-    return sorted_counts
-
-
 @demarcate
 def load_pc_sampling_data_per_kernel(
     method: str,
     tool_data: dict[str, Any],
-    kernel_name: str,
     sorting_type: str,
+    kernel_name: Optional[str] = None,
 ) -> pd.DataFrame:
-    """
-    Count and sort PC sampling data for a single kernel from a parsed
-    ``rocprofiler-sdk-tool`` record, ordering by compiled asm and
-    associating with kernel source code if available, then return df.
+    """Build the detailed per-instruction PC sampling table from *tool_data*.
+
+    Filtered to *kernel_name* when given, otherwise every kernel's rows.
 
     :param method: "host_trap" or "stochastic".
-    :type method: str
     :param tool_data: The parsed ``rocprofiler-sdk-tool[0]`` dict.
-    :type tool_data: dict
-    :param kernel_name: The kernel name to be filtered out.
-    :type kernel_name: str
     :param sorting_type: "offset" or "count".
-    :type sorting_type: str
-    :return: The counted and reordering pc sampling info.
-    :rtype: pd.DataFrame:
+    :param kernel_name: Kernel to filter to, or None for all kernels.
     """
-    buffer_records = tool_data["buffer_records"]
-
-    # Map dispatch_id -> kernel_id (kernel dispatch records) and
-    # kernel_id -> kernel name (kernel symbols). A single code object can
-    # hold many kernels, so dispatch_id is the reliable kernel attribution.
-    kernel_id_to_name = {
-        symbol["kernel_id"]: symbol["formatted_kernel_name"]
-        for symbol in tool_data["kernel_symbols"]
-    }
-    dispatch_to_kernel_id = {
-        dispatch["dispatch_info"]["dispatch_id"]: dispatch["dispatch_info"]["kernel_id"]
-        for dispatch in buffer_records["kernel_dispatch"]
-    }
-
-    if kernel_name not in kernel_id_to_name.values():
-        console_warning(f"PC sampling: cannot find kernel '{kernel_name}'")
-        return pd.DataFrame()
-
-    pc_samples = buffer_records[
+    pc_samples = tool_data["buffer_records"][
         "pc_sample_host_trap" if method == "host_trap" else "pc_sample_stochastic"
     ]
     if not pc_samples:
         console_error("PC sampling: can not find pc sample.")
 
-    # Get processed sampling data grouped by (code_object_id, offset, inst_index)
-    records = search_pc_sampling_record(pc_samples)
-    if not records:
-        console_warning("PC sampling: no records found in PC sampling data.")
-        return pd.DataFrame()
-
-    # Flatten records by dispatch_id to create one row per dispatch ID
-    rows = []
-    for (
-        code_object_id,
-        offset,
-        inst_index,
-        count,
-        count_issued,
-        count_stalled,
-        stall_reasons,
-        dispatch_ids,
-    ) in records:
-        for dispatch_id in dispatch_ids:
-            rows.append({
-                "dispatch_id": dispatch_id,
-                "code_object_id": code_object_id,
-                "offset": offset,
-                "inst_index": inst_index,
-                "count": count,
-                "count_issued": count_issued,
-                "count_stalled": count_stalled,
-                "stall_reason": stall_reasons,
-            })
-
-    df = pd.DataFrame(rows)
-    if df.empty:
-        console_warning("PC sampling: no records found after flattening dispatch IDs.")
-        return df
-
-    # Map dispatch_id to kernel info (kernel_id and kernel_name)
-    df["kernel_id"] = df["dispatch_id"].map(dispatch_to_kernel_id)
-    df["kernel_name"] = df["kernel_id"].map(kernel_id_to_name)
-
-    # Drop dispatch_id
-    df.drop(columns=["dispatch_id"], inplace=True)
-
-    def merge_stall_reasons(
-        stall_reason_series: list[Optional[list[tuple[str, int]]]],
-    ) -> list[tuple[str, int]]:
-        """
-        Function to merge stall_reason lists (list of dicts -> merged & sorted dict)
-        """
-        merged_counts = {}
-
-        for entry in stall_reason_series:
-            if not entry:
-                continue
-            # Each entry is a list of (key, count) tuples
-            for k, v in entry:
-                if v > 0:
-                    merged_counts[k] = merged_counts.get(k, 0) + v
-
-        # Return sorted list of tuples by descending count
-        return sorted(merged_counts.items(), key=lambda item: item[1], reverse=True)
-
-    # Group and aggregate
-    df = df.groupby(["code_object_id", "offset", "kernel_id"], as_index=False).agg({
-        "inst_index": "first",
-        "count": "sum",
-        "count_issued": "sum",
-        "count_stalled": "sum",
-        "stall_reason": merge_stall_reasons,
-        "kernel_name": "first",
-    })
-
-    # Filter DataFrame to only include rows matching the requested kernel_name
-    df = df[df["kernel_name"] == kernel_name]
-
-    # Instruction disassembly and source-line comments are indexed by inst_index.
     instructions = tool_data["strings"]["pc_sample_instructions"]
     comments = tool_data["strings"]["pc_sample_comments"]
     if not instructions or not comments:
         console_error("PC sampling: instruction or comment string table is empty.")
 
-    df["instruction"] = df["inst_index"].apply(
-        lambda x: instructions[x] if x < len(instructions) else None
+    records_df = load_pc_sample_records(tool_data)
+    aggregated_df = aggregate_pc_sample_records(
+        records_df,
+        group_by=["code_object_id", "code_object_offset", "kernel_id"],
     )
-    df["source_line"] = df["inst_index"].apply(
-        lambda x: f".../{Path(comments[x]).name}" if x < len(comments) else None
+    df = enrich_with_metadata(
+        aggregated_df,
+        tool_data,
+        attach={"instruction", "source_line", "kernel_name"},
     )
+    if df.empty:
+        console_warning("PC sampling: no records found in PC sampling data.")
+        return df
+
+    df = df.rename(
+        columns={"code_object_offset": "offset", "kernel_name": "Kernel_Name"}
+    )
+
+    if kernel_name is not None:
+        df = df[df["Kernel_Name"] == kernel_name]
+        if df.empty:
+            console_warning(f"PC sampling: cannot find kernel '{kernel_name}'")
+            return df
+
+    # Project stall_reason as a descending list[(reason, count)].
+    df["stall_reason"] = df["stall_reason"].apply(_stall_reason_dict_to_list)
+    df["source_line"] = df["source_line"].apply(_trim_source_line)
 
     # Sort on the numeric offset (lexicographic hex order is wrong), then
     # format offset as hex for display.
@@ -666,63 +467,47 @@ def load_pc_sampling_data_per_kernel(
 
     df_sorted["offset"] = df_sorted["offset"].apply(hex)
 
-    columns_to_return = (
-        [
-            "source_line",
-            "instruction",
-            "code_object_id",
-            "offset",
-            "count",
-        ]
-        if method == "host_trap"
-        else [
-            "source_line",
-            "instruction",
-            "code_object_id",
-            "offset",
-            "count",
-            "count_issued",
-            "count_stalled",
-            "stall_reason",
-        ]
+    # Stochastic adds issue/stall detail on top of the host_trap columns.
+    shared_columns = ["source_line", "instruction", "code_object_id", "offset", "count"]
+    stochastic_only_columns = ["count_issued", "count_stalled", "stall_reason"]
+    columns_to_return = shared_columns + (
+        stochastic_only_columns if method == "stochastic" else []
     )
-
+    columns_to_return.append("Kernel_Name")
     return df_sorted[columns_to_return]
-    # might support sort by stall reason in the future
 
 
 @demarcate
 def load_pc_sampling_data(
     workload: schema.Workload,
-    dir_path: str,
     file_prefix: str,
     sorting_type: str,
-    tool_data: Optional[dict[str, Any]] = None,
+    tool_data: Optional[dict[str, Any]],
 ) -> pd.DataFrame:
-    """
-    Load PC sampling raw data, filter and sort it by specified conditions,
-    then return df.
+    """Return the detailed per-instruction table for a single kernel or all.
 
-    *tool_data* is a parsed ``rocprofiler-sdk-tool[0]`` dict. When omitted
-    the (potentially multi-GB) results json is parsed from *dir_path*;
-    callers that already hold the parsed data should pass it to avoid
-    re-reading the file.
+    Thin dispatcher over :func:`load_pc_sampling_data_per_kernel`: detects the
+    method, then builds the table for all kernels (no ``-k``) or a single
+    kernel (one ``-k``). The output schema is identical either way. Callers
+    pass the already-parsed *tool_data*.
     """
-
-    if not file_prefix or file_prefix.lower() == "none":
+    if not file_prefix or file_prefix.lower() == "none" or tool_data is None:
         return pd.DataFrame()
 
-    if tool_data is None:
-        json_file_path = Path(dir_path) / f"{file_prefix}_results.json"
-        if not json_file_path.exists():
-            console_warning(f"PC sampling: can not read {json_file_path}")
-            return pd.DataFrame()
-        with json_file_path.open(encoding="utf-8") as json_file:
-            tool_data = json.load(json_file)["rocprofiler-sdk-tool"][0]
+    pc_sampling_method = detect_pc_sampling_method(tool_data)
+    if pc_sampling_method is None:
+        console_warning(
+            f"PC sampling: can not detect pc sampling method for {file_prefix}"
+        )
+        return pd.DataFrame()
 
-    # No kernel filter: aggregate samples across all kernels by source line.
+    # No kernel filter: return every kernel's rows.
     if not workload.filter_kernel_ids:
-        return _load_pc_sampling_no_filter_data(tool_data)
+        return load_pc_sampling_data_per_kernel(
+            pc_sampling_method,
+            tool_data,
+            sorting_type,
+        )
 
     if len(workload.filter_kernel_ids) > 1:
         console_error(
@@ -742,103 +527,29 @@ def load_pc_sampling_data(
         )
         return pd.DataFrame()
 
-    pc_sampling_method = _detect_pc_sampling_method(tool_data)
-    if pc_sampling_method is None:
-        console_warning(
-            f"PC sampling: can not detect pc sampling method for {file_prefix}"
-        )
-        return pd.DataFrame()
-
     kernel_name = kernel_top_df.iloc[kernel_index]["Kernel_Name"]
     return load_pc_sampling_data_per_kernel(
         pc_sampling_method,
         tool_data,
-        kernel_name,
         sorting_type,
+        kernel_name,
     )
 
 
-def _detect_pc_sampling_method(tool_data: dict[str, Any]) -> Optional[str]:
-    """Detect the PC sampling method from the populated buffer record array.
-
-    Prioritizes stochastic over host_trap. Returns None when neither
-    array holds any samples.
-    """
-    buffer_records = tool_data["buffer_records"]
-    if buffer_records["pc_sample_stochastic"]:
-        return "stochastic"
-    if buffer_records["pc_sample_host_trap"]:
-        return "host_trap"
-    return None
+def _stall_reason_dict_to_list(
+    stall_reason: Optional[dict[str, int]],
+) -> list[tuple[str, int]]:
+    """Convert a {reason: count} dict to a descending list[(reason, count)]."""
+    if not stall_reason:
+        return []
+    return sorted(stall_reason.items(), key=lambda item: item[1], reverse=True)
 
 
-def _load_pc_sampling_no_filter_data(tool_data: dict[str, Any]) -> pd.DataFrame:
-    """Aggregate all-kernel PC samples by source line.
-
-    Kernel name is resolved per sample via dispatch_id (dispatch -> kernel_id
-    -> name), so kernels that share a code object are attributed correctly.
-    """
-    buffer_records = tool_data["buffer_records"]
-    samples = (
-        buffer_records["pc_sample_stochastic"] + buffer_records["pc_sample_host_trap"]
-    )
-    instructions = tool_data["strings"]["pc_sample_instructions"]
-    comments = tool_data["strings"]["pc_sample_comments"]
-    if not instructions or not comments:
-        console_error("PC sampling: instruction or comment string table is empty.")
-    kernel_id_to_name = {
-        symbol["kernel_id"]: symbol["formatted_kernel_name"]
-        for symbol in tool_data["kernel_symbols"]
-    }
-    dispatch_to_kernel_id = {
-        dispatch["dispatch_info"]["dispatch_id"]: dispatch["dispatch_info"]["kernel_id"]
-        for dispatch in buffer_records["kernel_dispatch"]
-    }
-
-    # Correlate each sample to its kernel through the dispatch it belongs to:
-    # record.dispatch_id -> kernel_id -> formatted name. code_object_id is not
-    # usable here because one code object can hold several kernels.
-    rows = [
-        {
-            "source_line": (
-                comments[sample["inst_index"]]
-                if sample["inst_index"] < len(comments)
-                else None
-            ),
-            "instruction": (
-                instructions[sample["inst_index"]]
-                if sample["inst_index"] < len(instructions)
-                else None
-            ),
-            "Kernel_Name": kernel_id_to_name.get(
-                dispatch_to_kernel_id.get(sample["record"]["dispatch_id"])
-            ),
-        }
-        for sample in samples
-    ]
-
-    # Aggregate per source line: count is the number of samples on that line.
-    # instruction and Kernel_Name take a representative (first) value, since one
-    # source line can map to several instructions.
-    df = pd.DataFrame(rows, columns=["source_line", "instruction", "Kernel_Name"])
-    grouped_counts = (
-        df
-        .groupby("source_line")
-        .agg(
-            count=("source_line", "count"),
-            instruction=("instruction", "first"),
-            Kernel_Name=("Kernel_Name", "first"),
-        )
-        .reset_index()
-    )
-    grouped_counts = grouped_counts[
-        ["source_line", "Kernel_Name", "instruction", "count"]
-    ]
-    grouped_counts["source_line"] = grouped_counts["source_line"].apply(
-        lambda x: f".../{Path(x).name}" if isinstance(x, str) and x else x
-    )
-
-    return grouped_counts.sort_values(by="count", ascending=False)
+def _trim_source_line(source_line: str) -> str:
+    """Show only the trailing path component of a real source line."""
+    if source_line == SOURCE_LINE_MISSING:
+        return source_line
+    return f".../{Path(source_line).name}"
 
 
 def nullify_unevaluated_metric_values(
@@ -910,10 +621,9 @@ def load_non_mertrics_table(
         elif "from_pc_sampling" in df.columns:
             tmp[df_id] = load_pc_sampling_data(
                 workload,
-                dir_path,
                 df.loc[0, "from_pc_sampling"],
                 args.pc_sampling_sorting_type,
-                tool_data=pc_sampling_tool_data,
+                pc_sampling_tool_data,
             )
 
     workload.dfs.update(tmp)

--- a/projects/rocprofiler-compute/src/utils/pc_sampling_analysis.py
+++ b/projects/rocprofiler-compute/src/utils/pc_sampling_analysis.py
@@ -1,0 +1,202 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
+"""PC sampling analysis utilities.
+
+Helpers for building a normalized PC sampling dataframe from a parsed
+``rocprofiler-sdk-tool[0]`` dict.
+"""
+
+from typing import Any, Optional
+
+import pandas as pd
+
+PC_SAMPLING_NOT_ISSUE_PREFIX = "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_"
+
+# Canonical not-issued stall reasons (rocprofiler-sdk enum, prefix stripped).
+# Reasons outside this set are dropped during aggregation.
+STALL_REASON_KEYS = frozenset({
+    "NONE",
+    "NO_INSTRUCTION_AVAILABLE",
+    "ALU_DEPENDENCY",
+    "WAITCNT",
+    "INTERNAL_INSTRUCTION",
+    "BARRIER_WAIT",
+    "ARBITER_NOT_WIN",
+    "ARBITER_WIN_EX_STALL",
+    "OTHER_WAIT",
+    "SLEEP_WAIT",
+    "LAST",
+})
+
+NORMALIZED_RECORD_COLUMNS = [
+    "inst_index",
+    "code_object_id",
+    "code_object_offset",
+    "dispatch_id",
+    "kernel_id",
+    "wave_issued",
+    "stall_reason",
+]
+
+SOURCE_LINE_MISSING = "N/A"
+
+
+def detect_pc_sampling_method(tool_data: dict[str, Any]) -> Optional[str]:
+    """Detect the PC sampling method from the populated buffer record array.
+
+    Prioritizes stochastic over host_trap. Returns None when neither array
+    holds any samples.
+    """
+    buffer_records = tool_data["buffer_records"]
+    if buffer_records["pc_sample_stochastic"]:
+        return "stochastic"
+    if buffer_records["pc_sample_host_trap"]:
+        return "host_trap"
+    return None
+
+
+def load_pc_sample_records(tool_data: dict[str, Any]) -> pd.DataFrame:
+    """Flatten the PC sample arrays into normalized per-sample rows."""
+    buffer_records = tool_data["buffer_records"]
+    samples = (
+        buffer_records["pc_sample_stochastic"] + buffer_records["pc_sample_host_trap"]
+    )
+    # kernel_id via dispatch correlation so kernels sharing a code object are
+    # attributed correctly.
+    dispatch_to_kernel_id = {
+        dispatch["dispatch_info"]["dispatch_id"]: dispatch["dispatch_info"]["kernel_id"]
+        for dispatch in buffer_records["kernel_dispatch"]
+    }
+
+    rows = []
+    for sample in samples:
+        record = sample.get("record", {})
+        pc_info = record.get("pc", {})
+        code_object_id = pc_info.get("code_object_id")
+        code_object_offset = pc_info.get("code_object_offset")
+        inst_index = sample.get("inst_index")
+        # Skip records without the keys needed to place and label the sample.
+        if None in (code_object_id, code_object_offset, inst_index):
+            continue
+        dispatch_id = record.get("dispatch_id")
+        rows.append({
+            "inst_index": inst_index,
+            "code_object_id": code_object_id,
+            "code_object_offset": code_object_offset,
+            "dispatch_id": dispatch_id,
+            "kernel_id": dispatch_to_kernel_id.get(dispatch_id),
+            "wave_issued": record.get("wave_issued"),
+            "stall_reason": record.get("snapshot", {}).get("stall_reason"),
+        })
+
+    return pd.DataFrame(rows, columns=NORMALIZED_RECORD_COLUMNS)
+
+
+def aggregate_pc_sample_records(
+    records_df: pd.DataFrame,
+    group_by: list[str],
+) -> pd.DataFrame:
+    """Group normalized records into per-group counts and stall reasons."""
+    # inst_index and kernel_id are constant within a group; carry the first when
+    # they are not group keys.
+    carried = [
+        column for column in ("inst_index", "kernel_id") if column not in group_by
+    ]
+    if records_df.empty:
+        return pd.DataFrame(
+            columns=[
+                *group_by,
+                "count",
+                "count_issued",
+                "count_stalled",
+                "stall_reason",
+                *carried,
+            ]
+        )
+
+    aggregations = {
+        "count": ("inst_index", "size"),
+        "count_issued": ("wave_issued", _aggregate_count_issued),
+        "count_stalled": ("wave_issued", _aggregate_count_stalled),
+        "stall_reason": ("stall_reason", _aggregate_stall_reason),
+    }
+    for column in carried:
+        aggregations[column] = (column, "first")
+
+    return records_df.groupby(group_by, as_index=False).agg(**aggregations)
+
+
+def enrich_with_metadata(
+    aggregated_df: pd.DataFrame,
+    tool_data: dict[str, Any],
+    attach: set[str],
+) -> pd.DataFrame:
+    """Attach the columns named in *attach* by index into *tool_data*."""
+    df = aggregated_df.copy()
+    strings = tool_data["strings"]
+    instructions = strings["pc_sample_instructions"]
+    comments = strings["pc_sample_comments"]
+
+    if "instruction" in attach:
+        df["instruction"] = df["inst_index"].apply(
+            lambda index: instructions[index] if index < len(instructions) else None
+        )
+    if "source_line" in attach:
+        # Keep the raw comment; "N/A" (not "") when empty or out of range so the
+        # caller trims real strings and display code keeps the column.
+        df["source_line"] = df["inst_index"].apply(
+            lambda index: (
+                comments[index]
+                if index < len(comments) and comments[index]
+                else SOURCE_LINE_MISSING
+            )
+        )
+    if "kernel_name" in attach:
+        kernel_id_to_name = {
+            symbol["kernel_id"]: symbol["formatted_kernel_name"]
+            for symbol in tool_data["kernel_symbols"]
+        }
+        # .get (not .map) so an unmapped kernel_id yields None, not NaN.
+        df["kernel_name"] = df["kernel_id"].apply(kernel_id_to_name.get)
+
+    return df
+
+
+def load_aggregated_pc_sampling(
+    tool_data: dict[str, Any],
+    group_by: list[str],
+    attach: set[str],
+) -> pd.DataFrame:
+    """Run load -> aggregate -> enrich for the given grouping and columns."""
+    records_df = load_pc_sample_records(tool_data)
+    aggregated_df = aggregate_pc_sample_records(records_df, group_by)
+    return enrich_with_metadata(aggregated_df, tool_data, attach)
+
+
+def _aggregate_count_issued(wave_issued: pd.Series) -> Optional[int]:
+    """Sum issued waves; None when no wave_issued info exists (host_trap)."""
+    if wave_issued.isnull().all():
+        return None
+    return int(wave_issued.sum())
+
+
+def _aggregate_count_stalled(wave_issued: pd.Series) -> Optional[int]:
+    """Count not-issued waves; None when no wave_issued info exists (host_trap)."""
+    if wave_issued.isnull().all():
+        return None
+    return int(wave_issued.count() - wave_issued.sum())
+
+
+def _aggregate_stall_reason(stall_reason: pd.Series) -> Optional[dict[str, int]]:
+    """Count valid not-issued stall reasons as a descending {reason: count} dict.
+
+    None when no stall info exists (host_trap). Reasons outside
+    ``STALL_REASON_KEYS`` (e.g. malformed or unknown enum values) are dropped.
+    """
+    present = stall_reason.dropna()
+    if present.empty:
+        return None
+    stripped = present.str[len(PC_SAMPLING_NOT_ISSUE_PREFIX) :]
+    valid = stripped[stripped.isin(STALL_REASON_KEYS)]
+    return valid.value_counts().to_dict()

--- a/projects/rocprofiler-compute/src/utils/pc_sampling_analysis.py
+++ b/projects/rocprofiler-compute/src/utils/pc_sampling_analysis.py
@@ -124,7 +124,11 @@ def aggregate_pc_sample_records(
     for column in carried:
         aggregations[column] = (column, "first")
 
-    return records_df.groupby(group_by, as_index=False).agg(**aggregations)
+    # dropna=False keeps samples whose kernel_id is unmapped (None) instead of
+    # silently dropping them from the all-kernel view.
+    return records_df.groupby(group_by, as_index=False, dropna=False).agg(
+        **aggregations
+    )
 
 
 def enrich_with_metadata(

--- a/projects/rocprofiler-compute/src/utils/tty.py
+++ b/projects/rocprofiler-compute/src/utils/tty.py
@@ -750,8 +750,9 @@ def format_table_output(
         for col_idx in range(len(df.columns))
     )
 
-    # Do not print the table if any column is empty
-    if is_empty_columns_exist:
+    # Do not print the table if any column is empty. PC sampling table 21.1 is
+    # exempt: its source column is all N/A when the workload lacks debug info.
+    if is_empty_columns_exist and table_id_str != "21.1":
         title = table_config.get("title", "")
         console_log(f"Not showing table with empty column(s): {table_id_str} {title}")
         return content

--- a/projects/rocprofiler-compute/tests/test_analyze_commands.py
+++ b/projects/rocprofiler-compute/tests/test_analyze_commands.py
@@ -15,6 +15,8 @@ import pytest
 from rocprof_compute_analyze.analysis_cli import cli_analysis
 from utils.metrics.expression import build_eval_string
 from utils.metrics.metric_evaluator import MetricEvaluator
+from utils.parser import load_pc_sampling_data
+from utils.pc_sampling_analysis import load_pc_sample_records
 
 config = {}
 config["cleanup"] = True
@@ -1336,28 +1338,25 @@ def test_missing_files_scenarios(binary_handler_analyze_rocprof_compute):
 def test_pc_sampling_basic_coverage():
     """Test PC sampling functions with minimal data"""
 
-    import tempfile
-
-    from utils.parser import load_pc_sampling_data, search_pc_sampling_record
-
     class MockWorkload:
         filter_kernel_ids = []
 
     workload = MockWorkload()
 
-    with tempfile.TemporaryDirectory() as temp_dir:
-        result = load_pc_sampling_data(workload, temp_dir, "none", "count")
-        assert result.empty
+    assert load_pc_sampling_data(workload, "none", "count", None).empty
+    assert load_pc_sampling_data(workload, "missing", "count", None).empty
 
-        result = load_pc_sampling_data(workload, temp_dir, "missing", "count")
-        assert result.empty
+    workload.filter_kernel_ids = [0, 1, 2]  # Multiple kernels
+    assert load_pc_sampling_data(workload, "test", "count", None).empty
 
-        workload.filter_kernel_ids = [0, 1, 2]  # Multiple kernels
-        result = load_pc_sampling_data(workload, temp_dir, "test", "count")
-        assert result.empty
-
-        result = search_pc_sampling_record([])
-        assert result is None
+    empty_records = load_pc_sample_records({
+        "buffer_records": {
+            "pc_sample_stochastic": [],
+            "pc_sample_host_trap": [],
+            "kernel_dispatch": [],
+        },
+    })
+    assert empty_records.empty
 
 
 @pytest.mark.division_by_zero
@@ -2106,10 +2105,6 @@ def test_apply_kernel_filter_string_names(mock_workload_for_filter):
 def test_pc_sampling_single_kernel_uses_workload_dfs():
     """Test single kernel filter reads from workload.dfs[1],
     kernel index out of bounds warning."""
-    import tempfile
-
-    from utils.parser import load_pc_sampling_data
-
     # Create mock workload with dfs populated
     workload = Mock()
     workload.dfs = {
@@ -2119,44 +2114,26 @@ def test_pc_sampling_single_kernel_uses_workload_dfs():
             "Sum(ns)": [900, 800, 200],
         }),
     }
+    tool_data = {
+        "buffer_records": {"pc_sample_stochastic": [{}], "pc_sample_host_trap": []}
+    }
 
-    with tempfile.TemporaryDirectory() as temp_dir:
-        # Test with single kernel filter - valid index, but results json missing
-        workload.filter_kernel_ids = [0]  # kernel_a
-        # Since json file is missing, it should return empty and warn
-        with patch("utils.parser.console_warning") as mock_warning:
-            result = load_pc_sampling_data(workload, temp_dir, "test", "count")
-            # Should warn about missing json file
-            assert result.empty
+    # Kernel index out of bounds warns and returns empty.
+    workload.filter_kernel_ids = [99]
+    with patch("utils.parser.console_warning") as mock_warning:
+        result = load_pc_sampling_data(workload, "test", "count", tool_data)
+        mock_warning.assert_called()
+        call_args_str = str(mock_warning.call_args)
+        assert "out of bounds" in call_args_str or "99" in call_args_str
+        assert result.empty
 
-        # Test kernel index out of bounds warning
-        workload.filter_kernel_ids = [99]  # Out of bounds
-
-        # Create results json so processing proceeds to the bounds check
-        json_path = Path(temp_dir) / "test_results.json"
-        json_path.write_text(
-            '{"rocprofiler-sdk-tool": [{"buffer_records": '
-            '{"pc_sample_stochastic": [{}], "pc_sample_host_trap": []}}]}'
-        )
-
-        with patch("utils.parser.console_warning") as mock_warning:
-            result = load_pc_sampling_data(workload, temp_dir, "test", "count")
-            # Should warn about index out of bounds
-            mock_warning.assert_called()
-            call_args_str = str(mock_warning.call_args)
-            assert "out of bounds" in call_args_str or "99" in call_args_str
-            assert result.empty
-
-        # Test that kernel name is extracted from workload.dfs[1]
-        workload.filter_kernel_ids = [1]  # kernel_b
-        with patch("utils.parser.load_pc_sampling_data_per_kernel") as mock_per_kernel:
-            mock_per_kernel.return_value = pd.DataFrame()
-            load_pc_sampling_data(workload, temp_dir, "test", "count")
-            # Verify the kernel name extracted from dfs[1] is kernel_b
-            if mock_per_kernel.called:
-                call_kwargs = mock_per_kernel.call_args
-                # The kernel_name argument should be "kernel_b"
-                assert "kernel_b" in str(call_kwargs)
+    # Kernel name is extracted from workload.dfs[1].
+    workload.filter_kernel_ids = [1]  # kernel_b
+    with patch("utils.parser.load_pc_sampling_data_per_kernel") as mock_per_kernel:
+        mock_per_kernel.return_value = pd.DataFrame()
+        load_pc_sampling_data(workload, "test", "count", tool_data)
+        if mock_per_kernel.called:
+            assert "kernel_b" in str(mock_per_kernel.call_args)
 
 
 # =============================================================================

--- a/projects/rocprofiler-compute/tests/test_pc_sampling_analysis.py
+++ b/projects/rocprofiler-compute/tests/test_pc_sampling_analysis.py
@@ -22,7 +22,13 @@ from utils.parser import (
     load_pc_sampling_data,
     load_pc_sampling_data_per_kernel,
     nullify_unevaluated_metric_values,
-    search_pc_sampling_record,
+)
+from utils.pc_sampling_analysis import (
+    aggregate_pc_sample_records,
+    detect_pc_sampling_method,
+    enrich_with_metadata,
+    load_aggregated_pc_sampling,
+    load_pc_sample_records,
 )
 from utils.utils_common import is_only_pc_sampling
 
@@ -55,6 +61,25 @@ def make_record(
             "dispatch_id": dispatch_id,
             "wave_issued": wave_issued,
             "snapshot": snapshot,
+        },
+    }
+
+
+def make_host_trap_record(
+    code_object_id: int,
+    offset: int,
+    inst_index: int,
+    dispatch_id: int,
+) -> dict:
+    """A host_trap sample: no wave_issued / snapshot (no issue/stall info)."""
+    return {
+        "inst_index": inst_index,
+        "record": {
+            "pc": {
+                "code_object_id": code_object_id,
+                "code_object_offset": offset,
+            },
+            "dispatch_id": dispatch_id,
         },
     }
 
@@ -151,187 +176,173 @@ def test_is_only_pc_sampling(filter_blocks: list[str], expected: bool) -> None:
 
 
 # ═══════════════════════════════════════════════════════════════
-# search_pc_sampling_record
+# detect_pc_sampling_method
 # ═══════════════════════════════════════════════════════════════
 
 
-def test_search_pc_sampling_record_empty_list_returns_none() -> None:
-    """Return None when the input record list is empty."""
-    assert search_pc_sampling_record([]) is None
+@pytest.mark.parametrize(
+    "stochastic, host_trap, expected",
+    [
+        (None, None, None),
+        ([make_record(1, 0x10, 0, dispatch_id=0)], None, "stochastic"),
+        (None, [make_record(1, 0x10, 0, dispatch_id=0)], "host_trap"),
+        (
+            [make_record(1, 0x10, 0, dispatch_id=0)],
+            [make_record(1, 0x10, 0, dispatch_id=0)],
+            "stochastic",
+        ),
+    ],
+)
+def test_detect_pc_sampling_method(
+    stochastic: list | None,
+    host_trap: list | None,
+    expected: str | None,
+) -> None:
+    """Detection prioritizes stochastic and returns None when no samples exist."""
+    tool_data = make_tool_data(stochastic=stochastic, host_trap=host_trap)
+    assert detect_pc_sampling_method(tool_data) == expected
 
 
-def test_search_pc_sampling_record_single_dict_input_issued() -> None:
-    """Accept a single dict (not a list) and count it as one issued sample."""
-    record = make_record(
-        code_object_id=1,
-        offset=0x10,
-        inst_index=0,
-        dispatch_id=0,
-        wave_issued=True,
+# ═══════════════════════════════════════════════════════════════
+# load_pc_sample_records
+# ═══════════════════════════════════════════════════════════════
+
+
+def test_load_pc_sample_records_empty() -> None:
+    """No samples yield an empty df that still carries the normalized columns."""
+    df = load_pc_sample_records(make_tool_data())
+    assert df.empty
+    assert "kernel_id" in df.columns
+    assert "stall_reason" in df.columns
+
+
+@pytest.mark.parametrize("placement", ["stochastic", "host_trap", "mixed"])
+def test_load_pc_sample_records_flattens_both_arrays(placement: str) -> None:
+    """Both sample arrays are flattened; kernel_id resolved via dispatch."""
+    s0 = make_record(5, 0x10, 0, dispatch_id=0)
+    s1 = make_record(5, 0x20, 1, dispatch_id=1)
+    if placement == "stochastic":
+        kwargs = {"stochastic": [s0, s1]}
+    elif placement == "host_trap":
+        kwargs = {"host_trap": [s0, s1]}
+    else:
+        kwargs = {"stochastic": [s0], "host_trap": [s1]}
+    tool_data = make_tool_data(
+        kernel_dispatch=[make_dispatch(0, 100), make_dispatch(1, 101)],
+        **kwargs,
     )
-    result = search_pc_sampling_record(record)
-    assert result is not None
-    assert len(result) == 1
-    co_id, off, idx, total, issued, stalled, _, _ = result[0]
-    assert (co_id, off, idx) == (1, 0x10, 0)
-    assert total == 1
-    assert issued == 1
-    assert stalled == 0
+    df = load_pc_sample_records(tool_data)
+    assert len(df) == 2
+    by_offset = dict(zip(df["code_object_offset"], df["kernel_id"]))
+    assert by_offset[0x10] == 100
+    assert by_offset[0x20] == 101
 
 
-def test_search_pc_sampling_record_groups_by_key() -> None:
-    """
-    Group records by (code_object_id, offset, inst_index)
-    and sum counts per group.
-    """
-    records = [
-        make_record(1, 0x10, 0, dispatch_id=0),
-        make_record(1, 0x10, 0, dispatch_id=1),
-        make_record(1, 0x20, 1, dispatch_id=2),
-    ]
-    result = search_pc_sampling_record(records)
-    assert result is not None
-    assert len(result) == 2
-    assert result[0][3] == 2  # total_count for first key
-    assert result[1][3] == 1
+def test_load_pc_sample_records_missing_snapshot() -> None:
+    """A record without a snapshot key yields a None stall_reason, not an error."""
+    record = {
+        "inst_index": 0,
+        "record": {
+            "pc": {"code_object_id": 1, "code_object_offset": 0x10},
+            "dispatch_id": 0,
+            "wave_issued": False,
+        },
+    }
+    df = load_pc_sample_records(make_tool_data(stochastic=[record]))
+    assert len(df) == 1
+    assert df.iloc[0]["stall_reason"] is None
 
 
-def test_search_pc_sampling_record_dispatch_id_collection() -> None:
-    """Collect unique dispatch IDs across duplicate records for the same key."""
-    records = [
-        make_record(1, 0x10, 0, dispatch_id=0),
-        make_record(1, 0x10, 0, dispatch_id=0),
-        make_record(1, 0x10, 0, dispatch_id=1),
-    ]
-    result = search_pc_sampling_record(records)
-    assert result is not None
-    dispatch_ids = result[0][7]
-    assert dispatch_ids == [0, 1]
-
-
-def test_search_pc_sampling_record_skips_none_fields() -> None:
-    """Skip records whose code_object_id or offset is None."""
+def test_load_pc_sample_records_skips_incomplete_pc() -> None:
+    """Records missing code_object_id / offset / inst_index are skipped."""
     valid = make_record(1, 0x10, 0, dispatch_id=0)
     invalid = {
         "inst_index": 0,
         "record": {
-            "pc": {
-                "code_object_id": None,
-                "code_object_offset": 0x10,
-            },
+            "pc": {"code_object_id": None, "code_object_offset": 0x10},
             "dispatch_id": 1,
             "wave_issued": True,
             "snapshot": {},
         },
     }
-    result = search_pc_sampling_record([valid, invalid])
-    assert result is not None
-    assert len(result) == 1
+    df = load_pc_sample_records(make_tool_data(stochastic=[valid, invalid]))
+    assert len(df) == 1
 
 
-def make_record_without_snapshot(
-    code_object_id: int,
-    offset: int,
-    inst_index: int,
-    dispatch_id: int | None,
-    wave_issued: bool,
-) -> dict:
-    """A record missing the ``snapshot`` key entirely."""
-    return {
-        "inst_index": inst_index,
-        "record": {
-            "pc": {
-                "code_object_id": code_object_id,
-                "code_object_offset": offset,
-            },
-            "dispatch_id": dispatch_id,
-            "wave_issued": wave_issued,
-        },
-    }
+def test_load_pc_sample_records_unmapped_dispatch_kernel_id_none() -> None:
+    """A dispatch_id absent from kernel_dispatch leaves kernel_id None."""
+    df = load_pc_sample_records(
+        make_tool_data(stochastic=[make_record(1, 0x10, 0, dispatch_id=99)])
+    )
+    assert df.iloc[0]["kernel_id"] is None
 
 
-@pytest.mark.parametrize(
-    "records, expected",
-    [
-        pytest.param(
-            [
+# ═══════════════════════════════════════════════════════════════
+# aggregate_pc_sample_records
+# ═══════════════════════════════════════════════════════════════
+
+
+def test_aggregate_empty_records_returns_columns() -> None:
+    """Aggregating an empty record df returns the expected (empty) columns."""
+    empty = load_pc_sample_records(make_tool_data())
+    result = aggregate_pc_sample_records(
+        empty, group_by=["code_object_id", "code_object_offset"]
+    )
+    assert result.empty
+    for column in ("count", "count_issued", "count_stalled", "stall_reason"):
+        assert column in result.columns
+    # kernel_id / inst_index are carried since they are not group keys.
+    assert "kernel_id" in result.columns
+    assert "inst_index" in result.columns
+
+
+def test_aggregate_counts_issued_and_stalled() -> None:
+    """A mix of issued and stalled samples produces the documented counts."""
+    records = load_pc_sample_records(
+        make_tool_data(
+            stochastic=[
                 make_record(1, 0x10, 0, dispatch_id=0, wave_issued=True),
-                make_record(1, 0x10, 0, dispatch_id=1, wave_issued=True),
-            ],
-            {
-                "total": 2,
-                "issued": 2,
-                "stalled": 0,
-                "reasons": set(),
-                "dispatch_ids": [0, 1],
-            },
-            id="all_issued",
-        ),
-        pytest.param(
-            [
-                make_record(
-                    1,
-                    0x10,
-                    0,
-                    dispatch_id=0,
-                    wave_issued=False,
-                    stall_reason=f"{PREFIX}WAITCNT",
-                ),
                 make_record(
                     1,
                     0x10,
                     0,
                     dispatch_id=1,
                     wave_issued=False,
-                    stall_reason=f"{PREFIX}ALU_DEPENDENCY",
+                    stall_reason=f"{PREFIX}WAITCNT",
                 ),
-            ],
-            {
-                "total": 2,
-                "issued": 0,
-                "stalled": 2,
-                "reasons": {"WAITCNT", "ALU_DEPENDENCY"},
-                "dispatch_ids": [0, 1],
-            },
-            id="all_stalled",
-        ),
-        pytest.param(
-            [
-                make_record_without_snapshot(
-                    1, 0x10, 0, dispatch_id=0, wave_issued=False
-                )
-            ],
-            {
-                "total": 1,
-                "issued": 0,
-                "stalled": 1,
-                "reasons": set(),
-                "dispatch_ids": [0],
-            },
-            id="missing_snapshot",
-        ),
-        pytest.param(
-            [
-                make_record(
-                    1,
-                    0x10,
-                    0,
-                    dispatch_id=0,
-                    wave_issued=False,
-                    stall_reason="SHORT",
-                )
-            ],
-            {
-                "total": 1,
-                "issued": 0,
-                "stalled": 1,
-                "reasons": set(),
-                "dispatch_ids": [0],
-            },
-            id="short_stall_reason",
-        ),
-        pytest.param(
-            [
+            ]
+        )
+    )
+    result = aggregate_pc_sample_records(
+        records, group_by=["code_object_id", "code_object_offset"]
+    )
+    row = result.iloc[0]
+    assert row["count"] == 2
+    assert row["count_issued"] == 1
+    assert row["count_stalled"] == 1
+    assert row["stall_reason"] == {"WAITCNT": 1}
+
+
+def test_aggregate_host_trap_counts_are_none() -> None:
+    """Without wave_issued info, issued/stalled counts and reasons are None."""
+    records = load_pc_sample_records(
+        make_tool_data(host_trap=[make_host_trap_record(1, 0x10, 0, dispatch_id=0)])
+    )
+    result = aggregate_pc_sample_records(
+        records, group_by=["code_object_id", "code_object_offset"]
+    )
+    row = result.iloc[0]
+    assert row["count"] == 1
+    assert row["count_issued"] is None
+    assert row["count_stalled"] is None
+    assert row["stall_reason"] is None
+
+
+def test_aggregate_unknown_stall_key_dropped() -> None:
+    """A stall reason outside the canonical key set is dropped."""
+    records = load_pc_sample_records(
+        make_tool_data(
+            stochastic=[
                 make_record(
                     1,
                     0x10,
@@ -340,42 +351,109 @@ def make_record_without_snapshot(
                     wave_issued=False,
                     stall_reason=f"{PREFIX}NOT_A_REAL_KEY",
                 )
+            ]
+        )
+    )
+    result = aggregate_pc_sample_records(
+        records, group_by=["code_object_id", "code_object_offset"]
+    )
+    assert result.iloc[0]["stall_reason"] == {}
+
+
+def test_aggregate_group_by_kernel_id_separates_shared_code_object() -> None:
+    """Grouping by kernel_id keeps two kernels in one code object distinct."""
+    records = load_pc_sample_records(
+        make_tool_data(
+            stochastic=[
+                make_record(5, 0x10, 0, dispatch_id=0),
+                make_record(5, 0x20, 1, dispatch_id=1),
             ],
-            {
-                "total": 1,
-                "issued": 0,
-                "stalled": 1,
-                "reasons": set(),
-                "dispatch_ids": [0],
-            },
-            id="unknown_stall_key",
-        ),
-        pytest.param(
-            [make_record(1, 0x10, 0, dispatch_id=None, wave_issued=True)],
-            {
-                "total": 1,
-                "issued": 1,
-                "stalled": 0,
-                "reasons": set(),
-                "dispatch_ids": [],
-            },
-            id="missing_dispatch_id",
-        ),
-    ],
-)
-def test_search_pc_sampling_record_field_edges(
-    records: list[dict], expected: dict
-) -> None:
-    """Exercise snapshot/stall-reason/dispatch-id edge cases for a single group."""
-    result = search_pc_sampling_record(records)
-    assert result is not None
-    assert len(result) == 1
-    _, _, _, total, issued, stalled, reasons, dispatch_ids = result[0]
-    assert total == expected["total"]
-    assert issued == expected["issued"]
-    assert stalled == expected["stalled"]
-    assert {reason for reason, _ in reasons} == expected["reasons"]
-    assert dispatch_ids == expected["dispatch_ids"]
+            kernel_dispatch=[make_dispatch(0, 100), make_dispatch(1, 101)],
+        )
+    )
+    result = aggregate_pc_sample_records(
+        records, group_by=["code_object_id", "code_object_offset", "kernel_id"]
+    )
+    assert len(result) == 2
+    assert set(result["kernel_id"]) == {100, 101}
+
+
+# ═══════════════════════════════════════════════════════════════
+# enrich_with_metadata
+# ═══════════════════════════════════════════════════════════════
+
+
+def make_aggregated_row(inst_index: int = 0, kernel_id: int = 100) -> pd.DataFrame:
+    """A one-row aggregated df suitable for enrichment."""
+    return pd.DataFrame([{"inst_index": inst_index, "kernel_id": kernel_id}])
+
+
+def test_enrich_attach_subset_only_adds_requested_columns() -> None:
+    """Only the requested attach columns are added."""
+    tool_data = make_tool_data(
+        instructions=["v_mov"],
+        comments=["/s/a.cpp:1"],
+        kernel_symbols=[make_kernel_symbol(100, 5, "vecCopy")],
+    )
+    df = enrich_with_metadata(make_aggregated_row(), tool_data, attach={"instruction"})
+    assert "instruction" in df.columns
+    assert "source_line" not in df.columns
+    assert "kernel_name" not in df.columns
+
+
+def test_enrich_source_line_out_of_range_is_na() -> None:
+    """An inst_index past the comment table yields the 'N/A' sentinel, not ''."""
+    tool_data = make_tool_data(instructions=["v_mov"], comments=["/s/a.cpp:1"])
+    df = enrich_with_metadata(
+        make_aggregated_row(inst_index=5), tool_data, attach={"source_line"}
+    )
+    assert df.iloc[0]["source_line"] == "N/A"
+
+
+def test_enrich_empty_source_line_is_na() -> None:
+    """An empty comment string yields the 'N/A' sentinel, not ''."""
+    tool_data = make_tool_data(instructions=["v_mov"], comments=[""])
+    df = enrich_with_metadata(
+        make_aggregated_row(inst_index=0), tool_data, attach={"source_line"}
+    )
+    assert df.iloc[0]["source_line"] == "N/A"
+
+
+def test_enrich_kernel_name_unmapped_is_none() -> None:
+    """A kernel_id absent from kernel_symbols maps to a None kernel_name."""
+    tool_data = make_tool_data(
+        kernel_symbols=[make_kernel_symbol(100, 5, "vecCopy")],
+    )
+    df = enrich_with_metadata(
+        make_aggregated_row(kernel_id=999), tool_data, attach={"kernel_name"}
+    )
+    assert df.iloc[0]["kernel_name"] is None
+
+
+# ═══════════════════════════════════════════════════════════════
+# load_aggregated_pc_sampling
+# ═══════════════════════════════════════════════════════════════
+
+
+def test_load_aggregated_pc_sampling_happy_path() -> None:
+    """The combined helper loads, aggregates and enriches in one call."""
+    tool_data = make_tool_data(
+        stochastic=[make_record(5, 0x10, 0, dispatch_id=0, wave_issued=True)],
+        instructions=["v_mov"],
+        comments=["/s/a.cpp:1"],
+        kernel_symbols=[make_kernel_symbol(100, 5, "vecCopy")],
+        kernel_dispatch=[make_dispatch(0, 100)],
+    )
+    df = load_aggregated_pc_sampling(
+        tool_data,
+        group_by=["code_object_id", "code_object_offset"],
+        attach={"instruction", "source_line", "kernel_name"},
+    )
+    row = df.iloc[0]
+    assert row["count"] == 1
+    assert row["instruction"] == "v_mov"
+    assert row["source_line"] == "/s/a.cpp:1"
+    assert row["kernel_name"] == "vecCopy"
 
 
 # ═══════════════════════════════════════════════════════════════
@@ -447,11 +525,18 @@ def test_load_per_kernel_schema_and_sort(
         "code_object_id",
         "offset",
         "count",
+        "Kernel_Name",
     ]
-    stochastic_cols = host_trap_cols + [
+    stochastic_cols = [
+        "source_line",
+        "instruction",
+        "code_object_id",
+        "offset",
+        "count",
         "count_issued",
         "count_stalled",
         "stall_reason",
+        "Kernel_Name",
     ]
     expected_columns = host_trap_cols if method == "host_trap" else stochastic_cols
     tool_data = setup_per_kernel_data(method=method)
@@ -515,7 +600,7 @@ def make_per_kernel_guard_data(
 
 
 @pytest.mark.parametrize(
-    "instructions, comments, instruction_none, source_line_none, indices",
+    "instructions, comments, instruction_none, source_line_na, indices",
     [
         pytest.param(
             ["v_mov"],
@@ -547,10 +632,14 @@ def test_load_per_kernel_out_of_range_index_guards(
     instructions: list | None,
     comments: list | None,
     instruction_none: str,
-    source_line_none: str,
+    source_line_na: str,
     indices: tuple[int, int],
 ) -> None:
-    """An inst_index past the end of a string table yields None, not an error."""
+    """An inst_index past a string table yields None / 'N/A', not an error.
+
+    instruction stays None when out of range; source_line uses the "N/A"
+    sentinel so display code does not suppress the table.
+    """
     tool_data = make_per_kernel_guard_data(instructions, comments, indices)
     df = load_pc_sampling_data_per_kernel(
         method="host_trap",
@@ -560,7 +649,7 @@ def test_load_per_kernel_out_of_range_index_guards(
     )
     assert not df.empty
     assert_none_kind(df["instruction"], instruction_none)
-    assert_none_kind(df["source_line"], source_line_none)
+    assert_na_kind(df["source_line"], source_line_na)
 
 
 @pytest.mark.parametrize(
@@ -593,6 +682,17 @@ def assert_none_kind(column: pd.Series, kind: str) -> None:
         assert column.isna().any() and not column.isna().all()
     else:
         assert not column.isna().any()
+
+
+def assert_na_kind(column: pd.Series, kind: str) -> None:
+    """Assert how many entries in *column* are the 'N/A' sentinel: all/some/none."""
+    is_na = column == "N/A"
+    if kind == "all":
+        assert is_na.all()
+    elif kind == "some":
+        assert is_na.any() and not is_na.all()
+    else:
+        assert not is_na.any()
 
 
 def test_load_per_kernel_multi_dispatch_groupby() -> None:
@@ -690,51 +790,35 @@ def test_load_per_kernel_invalid_sorting_type() -> None:
 # ═══════════════════════════════════════════════════════════════
 
 
-def test_load_pc_sampling_data_empty_prefix(
-    tmp_path: Path,
-) -> None:
+def test_load_pc_sampling_data_empty_prefix() -> None:
     """Return an empty DataFrame when the file prefix is an empty string."""
-    workload = schema.Workload()
-    df = load_pc_sampling_data(workload, str(tmp_path), "", "count")
+    df = load_pc_sampling_data(schema.Workload(), "", "count", make_tool_data())
     assert df.empty
 
 
-def test_load_pc_sampling_data_none_prefix(
-    tmp_path: Path,
-) -> None:
-    """Return an empty DataFrame when the file prefix is the literal string 'none'."""
-    workload = schema.Workload()
-    df = load_pc_sampling_data(workload, str(tmp_path), "none", "count")
+def test_load_pc_sampling_data_none_prefix() -> None:
+    """Return an empty DataFrame when the file prefix is the literal 'none'."""
+    df = load_pc_sampling_data(schema.Workload(), "none", "count", make_tool_data())
     assert df.empty
 
 
-def test_load_pc_sampling_data_missing_results_json(
-    tmp_path: Path,
-) -> None:
-    """Return an empty DataFrame when ps_file_results.json does not exist."""
-    workload = schema.Workload()
-    df = load_pc_sampling_data(workload, str(tmp_path), "ps_file", "count")
+def test_load_pc_sampling_data_no_tool_data() -> None:
+    """Return an empty DataFrame when no parsed tool data is provided."""
+    df = load_pc_sampling_data(schema.Workload(), "ps_file", "count", None)
     assert df.empty
 
 
 @pytest.mark.parametrize("method", ["stochastic", "host_trap"])
-def test_load_pc_sampling_data_no_filter(
-    tmp_path: Path,
-    method: str,
-) -> None:
-    """No-filter aggregates by source line; kernel name resolved per dispatch.
-
-    vecCopy (kernel_id 100) and vecAdd (kernel_id 101) share code object 5,
-    so each sample's kernel must be resolved via its dispatch_id, not the
-    shared code_object_id.
-    """
+def test_load_pc_sampling_data_no_filter_schema_parity(method: str) -> None:
+    """No-filter has the same columns as the single-kernel view, with more rows."""
     samples = [
         make_record(5, 0x10, 0, dispatch_id=0),
         make_record(5, 0x10, 0, dispatch_id=0),
         make_record(5, 0x20, 1, dispatch_id=1),
     ]
-    write_results_json(
-        tmp_path / "ps_file_results.json",
+    # vecCopy (kernel 100) and vecAdd (kernel 101) share code object 5 at distinct
+    # offsets, so each row's kernel resolves via dispatch correlation.
+    tool_data = make_tool_data(
         instructions=["v_mov_b32 v0 v1", "s_waitcnt vmcnt(0)"],
         comments=["/src/vcopy.cpp:42", "/src/vadd.cpp:99"],
         kernel_symbols=[
@@ -744,182 +828,128 @@ def test_load_pc_sampling_data_no_filter(
         kernel_dispatch=[make_dispatch(0, 100), make_dispatch(1, 101)],
         **{method: samples},
     )
-    workload = schema.Workload()
-    df = load_pc_sampling_data(workload, str(tmp_path), "ps_file", "count")
-    assert not df.empty
-    assert list(df.columns) == [
-        "source_line",
-        "Kernel_Name",
-        "instruction",
-        "count",
-    ]
-    by_kernel = dict(zip(df["source_line"], df["Kernel_Name"]))
-    assert df.iloc[0]["source_line"].startswith("...")
-    assert df.iloc[0]["count"] == 2
-    # Samples sharing code object 5 still resolve to their own kernels.
+    kernel_top_df = pd.DataFrame({"Kernel_Name": ["vecCopy", "vecAdd"]})
+    no_filter = load_pc_sampling_data(schema.Workload(), "ps_file", "offset", tool_data)
+    single = load_pc_sampling_data(
+        schema.Workload(
+            filter_kernel_ids=[0], dfs={PMC_KERNEL_TOP_TABLE_ID: kernel_top_df}
+        ),
+        "ps_file",
+        "offset",
+        tool_data,
+    )
+    assert list(no_filter.columns) == list(single.columns)
+    assert "Kernel_Name" in no_filter.columns
+    assert set(no_filter["Kernel_Name"]) == {"vecCopy", "vecAdd"}
+    assert set(single["Kernel_Name"]) == {"vecCopy"}
+    assert len(no_filter) > len(single)
+    by_kernel = dict(zip(no_filter["source_line"], no_filter["Kernel_Name"]))
     assert by_kernel[".../vcopy.cpp:42"] == "vecCopy"
     assert by_kernel[".../vadd.cpp:99"] == "vecAdd"
 
 
-def test_load_pc_sampling_data_multiple_kernels_error(
-    tmp_path: Path,
-) -> None:
-    """
-    Return an empty DataFrame and log an error when more
-    than one kernel ID is filtered.
-    """
-    write_results_json(
-        tmp_path / "ps_file_results.json",
-        stochastic=[make_record(100, 0x10, 0, dispatch_id=0)],
-    )
+def test_load_pc_sampling_data_multiple_kernels_error() -> None:
+    """Return an empty DataFrame and log an error when >1 kernel ID is filtered."""
+    tool_data = make_tool_data(stochastic=[make_record(100, 0x10, 0, dispatch_id=0)])
     workload = schema.Workload(filter_kernel_ids=[0, 1])
     with patch("utils.parser.console_error"):
-        df = load_pc_sampling_data(
-            workload,
-            str(tmp_path),
-            "ps_file",
-            "count",
-        )
+        df = load_pc_sampling_data(workload, "ps_file", "count", tool_data)
     assert df.empty
 
 
-def test_load_pc_sampling_data_single_kernel_valid(
-    tmp_path: Path,
-) -> None:
+def test_load_pc_sampling_data_single_kernel_valid() -> None:
     """Return per-kernel data when exactly one valid kernel ID is filtered."""
-    write_results_json(
-        tmp_path / "ps_file_results.json",
+    tool_data = make_tool_data(
         stochastic=[make_record(100, 0x10, 0, dispatch_id=0)],
         instructions=["v_mov_b32"],
         comments=["/src/vcopy.cpp:42"],
         kernel_symbols=[make_kernel_symbol(100, 100, "vecCopy")],
         kernel_dispatch=[make_dispatch(0, 100)],
     )
-    kernel_top_df = pd.DataFrame({"Kernel_Name": ["vecCopy"]})
     workload = schema.Workload(
         filter_kernel_ids=[0],
-        dfs={PMC_KERNEL_TOP_TABLE_ID: kernel_top_df},
+        dfs={PMC_KERNEL_TOP_TABLE_ID: pd.DataFrame({"Kernel_Name": ["vecCopy"]})},
     )
-    df = load_pc_sampling_data(workload, str(tmp_path), "ps_file", "count")
+    df = load_pc_sampling_data(workload, "ps_file", "count", tool_data)
     assert not df.empty
 
 
-def test_load_pc_sampling_data_single_kernel_out_of_bounds(
-    tmp_path: Path,
-) -> None:
-    """
-    Return an empty DataFrame when the filtered kernel ID
-    exceeds the kernel-top table range.
-    """
-    write_results_json(
-        tmp_path / "ps_file_results.json",
+def test_load_pc_sampling_data_single_kernel_out_of_bounds() -> None:
+    """Return an empty DataFrame when the filtered kernel ID exceeds kernel-top."""
+    tool_data = make_tool_data(
         stochastic=[make_record(100, 0x10, 0, dispatch_id=0)],
         kernel_symbols=[make_kernel_symbol(100, 100, "vecCopy")],
         kernel_dispatch=[make_dispatch(0, 100)],
     )
-    kernel_top_df = pd.DataFrame({"Kernel_Name": ["vecCopy", "vecAdd"]})
     workload = schema.Workload(
         filter_kernel_ids=[99],
-        dfs={PMC_KERNEL_TOP_TABLE_ID: kernel_top_df},
+        dfs={
+            PMC_KERNEL_TOP_TABLE_ID: pd.DataFrame({
+                "Kernel_Name": ["vecCopy", "vecAdd"]
+            })
+        },
     )
-    df = load_pc_sampling_data(workload, str(tmp_path), "ps_file", "count")
+    df = load_pc_sampling_data(workload, "ps_file", "count", tool_data)
     assert df.empty
 
 
-def test_load_pc_sampling_data_method_not_detected(
-    tmp_path: Path,
-) -> None:
-    """
-    Return an empty DataFrame for a single-kernel filter when neither
-    pc_sample array is populated (no detectable method).
-    """
-    write_results_json(
-        tmp_path / "ps_file_results.json",
+def test_load_pc_sampling_data_method_not_detected() -> None:
+    """Return an empty DataFrame when neither pc_sample array is populated."""
+    tool_data = make_tool_data(
         kernel_symbols=[make_kernel_symbol(100, 100, "vecCopy")],
         kernel_dispatch=[make_dispatch(0, 100)],
     )
-    kernel_top_df = pd.DataFrame({"Kernel_Name": ["vecCopy"]})
     workload = schema.Workload(
         filter_kernel_ids=[0],
-        dfs={PMC_KERNEL_TOP_TABLE_ID: kernel_top_df},
+        dfs={PMC_KERNEL_TOP_TABLE_ID: pd.DataFrame({"Kernel_Name": ["vecCopy"]})},
     )
-    df = load_pc_sampling_data(workload, str(tmp_path), "ps_file", "count")
+    df = load_pc_sampling_data(workload, "ps_file", "count", tool_data)
     assert df.empty
 
 
 @pytest.mark.parametrize(
     "populated, expected_column_count",
     [
-        ("host_trap", 5),  # host_trap-only is detected
-        ("both", 8),  # stochastic wins when both arrays are populated
+        ("host_trap", 6),  # host_trap-only is detected
+        ("both", 9),  # stochastic wins when both arrays are populated
     ],
 )
 def test_load_pc_sampling_data_method_detection(
-    tmp_path: Path,
     populated: str,
     expected_column_count: int,
 ) -> None:
     """Single-kernel method detection: host_trap-only and stochastic-priority."""
-    host_trap = [make_record(5, 0x10, 0, dispatch_id=0)]
-    kwargs = {"host_trap": host_trap}
+    kwargs = {"host_trap": [make_record(5, 0x10, 0, dispatch_id=0)]}
     if populated == "both":
         kwargs["stochastic"] = [make_record(5, 0x10, 0, dispatch_id=0)]
-    write_results_json(
-        tmp_path / "ps_file_results.json",
+    tool_data = make_tool_data(
         instructions=["v_mov"],
         comments=["/s/a.cpp:1"],
         kernel_symbols=[make_kernel_symbol(100, 5, "vecCopy")],
         kernel_dispatch=[make_dispatch(0, 100)],
         **kwargs,
     )
-    kernel_top_df = pd.DataFrame({"Kernel_Name": ["vecCopy"]})
     workload = schema.Workload(
         filter_kernel_ids=[0],
-        dfs={PMC_KERNEL_TOP_TABLE_ID: kernel_top_df},
+        dfs={PMC_KERNEL_TOP_TABLE_ID: pd.DataFrame({"Kernel_Name": ["vecCopy"]})},
     )
-    df = load_pc_sampling_data(workload, str(tmp_path), "ps_file", "count")
+    df = load_pc_sampling_data(workload, "ps_file", "count", tool_data)
     assert len(df.columns) == expected_column_count
 
 
-def test_load_pc_sampling_data_no_filter_instruction_out_of_range(
-    tmp_path: Path,
-) -> None:
+def test_load_pc_sampling_data_no_filter_instruction_out_of_range() -> None:
     """No-filter: an inst_index past the instruction table yields a None entry."""
-    write_results_json(
-        tmp_path / "ps_file_results.json",
+    tool_data = make_tool_data(
         stochastic=[make_record(5, 0x10, 1, dispatch_id=0)],
         instructions=["v_mov"],  # len 1; inst_index 1 is out of range
         comments=["/s/a.cpp:1", "/s/a.cpp:2"],  # len 2; inst_index 1 in range
         kernel_symbols=[make_kernel_symbol(100, 5, "vecCopy")],
         kernel_dispatch=[make_dispatch(0, 100)],
     )
-    workload = schema.Workload()
-    df = load_pc_sampling_data(workload, str(tmp_path), "ps_file", "count")
+    df = load_pc_sampling_data(schema.Workload(), "ps_file", "count", tool_data)
     assert not df.empty
     assert df.iloc[0]["instruction"] is None
     assert df.iloc[0]["source_line"] == ".../a.cpp:2"
-
-
-def test_load_pc_sampling_data_uses_provided_tool_data(tmp_path: Path) -> None:
-    """When tool_data is passed, use it without reading the results json.
-
-    No ps_file_results.json is written, so a non-empty result proves the
-    provided dict was used (the file-parse fallback would warn and return
-    empty).
-    """
-    tool_data = make_tool_data(
-        stochastic=[make_record(5, 0x10, 0, dispatch_id=0)],
-        instructions=["v_mov"],
-        comments=["/s/a.cpp:1"],
-        kernel_symbols=[make_kernel_symbol(100, 5, "vecCopy")],
-        kernel_dispatch=[make_dispatch(0, 100)],
-    )
-    workload = schema.Workload()  # no kernel filter -> no-filter path
-    df = load_pc_sampling_data(
-        workload, str(tmp_path), "ps_file", "count", tool_data=tool_data
-    )
-    assert not df.empty
-    assert df.iloc[0]["Kernel_Name"] == "vecCopy"
 
 
 # ═══════════════════════════════════════════════════════════════
@@ -1162,8 +1192,13 @@ def test_calc_pc_sampling_data_aggregation(
         instructions=["v_mov", "v_add"],
         comments=["/s/a.cpp:1", "/s/a.cpp:2"],
         kernel_symbols=[
-            {"code_object_id": 100, "formatted_kernel_name": "vecCopy"},
-            {"code_object_id": 101, "formatted_kernel_name": "vecAdd"},
+            make_kernel_symbol(100, 100, "vecCopy"),
+            make_kernel_symbol(101, 101, "vecAdd"),
+        ],
+        kernel_dispatch=[
+            make_dispatch(0, 100),
+            make_dispatch(1, 100),
+            make_dispatch(2, 101),
         ],
         **kwargs,
     )
@@ -1194,16 +1229,63 @@ def test_calc_pc_sampling_data_aggregation(
     assert row_add["kernel_name"] == "vecAdd"
 
 
+def test_calc_pc_sampling_data_shared_code_object_kernel_names(
+    tmp_path: Path,
+) -> None:
+    """Each offset in a shared code object gets its own kernel name."""
+    # code object 5 holds vecCopy (kernel 100) and vecAdd (kernel 101) at
+    # distinct offsets; names resolve via kernel_id (dispatch correlation).
+    write_results_json(
+        tmp_path / "ps_file_results.json",
+        stochastic=[
+            make_record(5, 0x10, 0, dispatch_id=0, wave_issued=True),
+            make_record(5, 0x20, 1, dispatch_id=1, wave_issued=True),
+        ],
+        instructions=["v_mov", "v_add"],
+        comments=["/s/a.cpp:1", "/s/a.cpp:2"],
+        kernel_symbols=[
+            make_kernel_symbol(100, 5, "vecCopy"),
+            make_kernel_symbol(101, 5, "vecAdd"),
+        ],
+        kernel_dispatch=[make_dispatch(0, 100), make_dispatch(1, 101)],
+    )
+    instance = make_db_analysis(str(tmp_path))
+    df = instance.calc_pc_sampling_data({
+        str(tmp_path): load_pc_sampling_results(str(tmp_path))
+    })[str(tmp_path)]
+    by_offset = dict(zip(df["offset"], df["kernel_name"]))
+    assert by_offset[0x10] == "vecCopy"
+    assert by_offset[0x20] == "vecAdd"
+
+
+def test_load_pc_sampling_data_no_debug_info_source_line_na() -> None:
+    """Empty comment strings yield 'N/A' source lines across a multi-row table."""
+    # Without debug info every comment is "", which must not collapse the table.
+    tool_data = make_tool_data(
+        stochastic=[
+            make_record(5, 0x10, 0, dispatch_id=0, wave_issued=True),
+            make_record(5, 0x20, 1, dispatch_id=0, wave_issued=True),
+        ],
+        instructions=["v_mov", "v_add"],
+        comments=["", ""],
+        kernel_symbols=[make_kernel_symbol(100, 5, "vecCopy")],
+        kernel_dispatch=[make_dispatch(0, 100)],
+    )
+    df = load_pc_sampling_data(schema.Workload(), "ps_file", "count", tool_data)
+    assert len(df) == 2
+    assert (df["source_line"] == "N/A").all()
+
+
 def test_calc_pc_sampling_data_unmapped_kernel(
     tmp_path: Path,
 ) -> None:
-    """A code_object_id absent from kernel_symbols maps to a None kernel_name."""
+    """A sample whose dispatch has no kernel mapping yields a None kernel_name."""
     write_results_json(
         tmp_path / "ps_file_results.json",
         stochastic=[make_record(999, 0x10, 0, dispatch_id=0, wave_issued=True)],
         instructions=["v_mov"],
         comments=["/s/a.cpp:1"],
-        kernel_symbols=[{"code_object_id": 100, "formatted_kernel_name": "vecCopy"}],
+        kernel_symbols=[make_kernel_symbol(100, 100, "vecCopy")],
     )
     instance = make_db_analysis(str(tmp_path))
     df = instance.calc_pc_sampling_data({
@@ -1219,6 +1301,7 @@ def test_calc_pc_sampling_data_uses_provided_tool_data(tmp_path: Path) -> None:
         instructions=["v_mov"],
         comments=["/s/a.cpp:1"],
         kernel_symbols=[make_kernel_symbol(100, 5, "vecCopy")],
+        kernel_dispatch=[make_dispatch(0, 100)],
     )
     instance = make_db_analysis(str(tmp_path))
     # No ps_file_results.json on disk: a populated result proves the map was used.

--- a/projects/rocprofiler-compute/tests/test_tty.py
+++ b/projects/rocprofiler-compute/tests/test_tty.py
@@ -1,0 +1,46 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier:  MIT
+
+"""Unit tests for src/utils/tty.py."""
+
+import argparse
+
+import pandas as pd
+
+from utils.tty import format_table_output
+
+
+def make_args() -> argparse.Namespace:
+    """Minimal args for the plain-table render path."""
+    return argparse.Namespace(decimal=2, view=None, normal_unit="per_wave")
+
+
+def test_format_table_output_suppresses_empty_column() -> None:
+    """A non-PC-sampling table with an all-'N/A' column is suppressed."""
+    df = pd.DataFrame({"Metric": ["a", "b"], "Value": ["N/A", "N/A"]})
+    content = format_table_output(
+        make_args(),
+        {"id": 1101, "title": "Some Table"},
+        df,
+        "metric_table",
+        runs={"only": object()},
+    )
+    assert content == ""
+
+
+def test_format_table_output_keeps_pc_sampling_table_21_1() -> None:
+    """PC sampling table 21.1 is shown even with an all-'N/A' source column."""
+    df = pd.DataFrame({
+        "source_line": ["N/A", "N/A"],
+        "instruction": ["v_mov", "v_add"],
+        "count": [3, 1],
+    })
+    content = format_table_output(
+        make_args(),
+        {"id": 2101, "title": "PC Sampling"},
+        df,
+        "pc_sampling_table",
+        runs={"only": object()},
+    )
+    assert content != ""
+    assert "v_mov" in content


### PR DESCRIPTION
## Motivation

The analysis-database path (`analysis_db.calc_pc_sampling_data`) and the
CLI/TUI path (`parser.load_pc_sampling_data*`) each built a normalized PC
sampling dataframe from the same parsed tool data with duplicated logic.
This unifies that work into one module both consume and fixes two
correctness issues along the way.

Stacked on #6873; the base of this PR is that branch, not
rocprofiler-compute-develop. Retarget once #6873 merges.

## Technical Details

- New utils/pc_sampling_analysis.py: load_pc_sample_records,
  aggregate_pc_sample_records, enrich_with_metadata,
  load_aggregated_pc_sampling, detect_pc_sampling_method.
- calc_pc_sampling_data (db) and the parser load paths now build on the
  shared helpers; the parser's filtered and no-filter paths are unified
  into one detailed function.
- Kernel names resolve via kernel_id (dispatch correlation) instead of a
  last-wins code_object_id map, so kernels sharing a code object are
  attributed correctly.
- A workload without source-line debug info has an all-empty source column.
  enrich emits the literal "N/A" for such rows, and tty exempts table 21.1
  from the all-empty-column suppression so the table still shows.
- No-filter analysis returns the full per-instruction table (with
  Kernel_Name), identical in schema to the single-kernel view.
- load_pc_sampling_data no longer reads the results json itself; callers
  pass the already-parsed tool_data (avoids accidental multi-GB re-reads).

## JIRA ID

AIPROFCOMP-605

## Test Plan

- pytest tests/test_pc_sampling_analysis.py -k "not analyze"
- pytest tests/test_tty.py
- pytest tests/test_analyze_commands.py -k pc_sampling

## Test Result

- [x] ruff check / ruff format --check clean
- [x] 77 PC sampling + tty + analyze-command unit tests pass (integration deselected)
- [ ] CPU-heavy analyze integration + db-mode left to CI

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.