### PR TITLE
[rocprof-systems]: Add live AMD SMI metric availability to rocprof-sys-avail

### DIFF
--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/avail.cpp
@@ -104,6 +104,12 @@ write_hw_counter_info(std::ostream&, format_options& fmt_opts,
                       const array_t<bool, N>& = {}, const array_t<bool, N>& = {},
                       const array_t<string_t, N>& = {});
 
+template <size_t N = num_smi_metric_options>
+void
+write_smi_metric_info(std::ostream&, format_options& fmt_opts,
+                      const array_t<bool, N>& = {}, const array_t<bool, N>& = {},
+                      const array_t<string_t, N>& = {});
+
 namespace
 {
 // initialize HIP before main so that librocprof-sys is not HSA_TOOLS_LIB
@@ -149,6 +155,7 @@ main(int argc, char** argv)
     }
     _category_options.emplace("hw_counters::CPU");
     _category_options.emplace("hw_counters::GPU");
+    _category_options.emplace("smi_metrics::GPU");
 
     // Remove unused TIMEMORY third-party libraries
     _category_options.erase("component::tpls::openmp");
@@ -183,6 +190,7 @@ main(int argc, char** argv)
     bool include_settings    = false;
     bool include_components  = false;
     bool include_hw_counters = false;
+    bool include_smi_metrics = false;
 
     std::string file = {};
 
@@ -230,6 +238,10 @@ main(int argc, char** argv)
         .add_argument({ "-H", "--hw-counters", "--print-hw-counters" },
                       "Write the available hardware counters")
         .max_count(1);
+    parser
+        .add_argument({ "-m", "--smi-metrics", "--print-smi-metrics" },
+                      "Write the available AMD SMI GPU metrics")
+        .max_count(1);
 
     parser.add_argument({ "-a", "--all" }, "Print all available info")
         .max_count(1)
@@ -244,6 +256,7 @@ main(int argc, char** argv)
                 include_components  = true;
                 include_settings    = true;
                 include_hw_counters = true;
+                include_smi_metrics = true;
             }
         });
 
@@ -615,6 +628,7 @@ main(int argc, char** argv)
     _parser_set_if_exists(include_components, "components");
     _parser_set_if_exists(include_settings, "settings");
     _parser_set_if_exists(include_hw_counters, "hw-counters");
+    _parser_set_if_exists(include_smi_metrics, "smi-metrics");
 
     // Only query GPU devices and hardware counters when they are actually
     // requested. This avoids initializing the ROCm runtime for settings-only
@@ -644,6 +658,24 @@ main(int argc, char** argv)
             verbprintf(1,
                        "No HIP devices found. GPU HW counters will not be available\n");
         }
+    }
+
+    if(include_smi_metrics)
+    {
+        size_t _num_metrics = 0;
+        try
+        {
+            _num_metrics = rocprofsys::amd_smi::format_avail_entries(
+                               rocprofsys::amd_smi::probe_devices())
+                               .size();
+        } catch(std::runtime_error& _e)
+        {
+            verbprintf(0, "Retrieving AMD SMI metrics failed: %s", _e.what());
+        } catch(std::exception& _e)
+        {
+            verbprintf(0, "Exception retrieving AMD SMI metrics: %s", _e.what());
+        }
+        verbprintf(1, "Found %zu AMD SMI GPU metrics\n", _num_metrics);
     }
 
     if(parser.exists("generate-config"))
@@ -697,10 +729,12 @@ main(int argc, char** argv)
 
     if(category_view.empty()) category_view = _category_options;
 
-    if(!include_components && !include_settings && !include_hw_counters)
+    if(!include_components && !include_settings && !include_hw_counters &&
+       !include_smi_metrics)
         include_settings = true;
 
-    if(fmt_opts.markdown || include_hw_counters) fmt_opts.padding = 6;
+    if(fmt_opts.markdown || include_hw_counters || include_smi_metrics)
+        fmt_opts.padding = 6;
 
     std::ostream* os = nullptr;
     std::ofstream ofs;
@@ -743,6 +777,15 @@ main(int argc, char** argv)
                               { true, true,
                                 !fmt_opts.force_brief && !fmt_opts.available_only,
                                 !fmt_opts.force_brief && !options[DESC], options[DESC] });
+    }
+    dump_log();
+
+    if(include_smi_metrics)
+    {
+        write_smi_metric_info(*os, fmt_opts,
+                              { true, true,
+                                !fmt_opts.force_brief && !fmt_opts.available_only,
+                                !fmt_opts.force_brief && options[DESC], options[DESC] });
     }
     dump_log();
 
@@ -1371,6 +1414,171 @@ write_hw_counter_info(std::ostream& os, format_options& fmt_opts,
             os << hl_selected(ss.str());
             os << "\n";
         }
+    }
+
+    dump_log();
+
+    if(!fmt_opts.markdown) os << banner(_widths, _wusing, fmt_opts, '-');
+}
+
+//======================================================================================//
+//
+//                                  SMI METRICS
+//
+//======================================================================================//
+
+template <size_t N>
+void
+write_smi_metric_info(std::ostream& os, format_options& fmt_opts,
+                      const array_t<bool, N>& options, const array_t<bool, N>&,
+                      const array_t<string_t, N>&)
+{
+    static_assert(N >= num_smi_metric_options,
+                  "Error! Too few smi metric options + fields");
+
+    using width_type = array_t<std::int64_t, N>;
+    using width_bool = array_t<bool, N>;
+
+    auto _smi_metrics =
+        rocprofsys::amd_smi::format_avail_entries(rocprofsys::amd_smi::probe_devices());
+
+    if(fmt_opts.available_only)
+    {
+        _smi_metrics.erase(std::remove_if(_smi_metrics.begin(), _smi_metrics.end(),
+                                          [](const auto& itr) { return !itr.available; }),
+                           _smi_metrics.end());
+    }
+
+    if(!category_view.empty() && category_view.count("smi_metrics::GPU") == 0 &&
+       category_view.count("GPU") == 0)
+    {
+        _smi_metrics.clear();
+    }
+
+    array_t<string_t, N> _labels = { "SMI METRIC", "DEVICE", "AVAILABLE", "SUMMARY",
+                                     "CATEGORY" };
+    array_t<bool, N>     _center = { false, true, true, false, false };
+    array_t<bool, N>     _mark   = { true, false, false, false, false };
+
+    width_type _widths{};
+    width_bool _wusing{};
+    _widths.fill(0);
+    _wusing.fill(false);
+
+    for(size_t i = 0; i < _widths.size(); ++i)
+    {
+        if(i != 1 && i != 2) _widths.at(i) = _labels.at(i).length() + fmt_opts.padding;
+        _wusing.at(i) = options[i];
+    }
+
+    auto _valid_symbols = std::set<std::string>{};
+    for(const auto& itr : _smi_metrics)
+    {
+        int _selected = 0;
+        if(options[0]) _selected += (is_selected(itr.symbol)) ? 1 : 0;
+        if(options[2])
+        {
+            std::stringstream _avss{};
+            _avss << std::boolalpha << itr.available;
+            _selected += (is_selected(_avss.str())) ? 1 : 0;
+        }
+        for(size_t i = 3; i < N; ++i)
+        {
+            if(options[i])
+            {
+                _selected += (is_selected(i == 3 ? itr.summary : itr.category)) ? 1 : 0;
+            }
+        }
+        if(_selected > 0) _valid_symbols.emplace(itr.symbol);
+    }
+
+    _smi_metrics.erase(std::remove_if(_smi_metrics.begin(), _smi_metrics.end(),
+                                      [&_valid_symbols](const auto& itr) {
+                                          return _valid_symbols.count(itr.symbol) == 0;
+                                      }),
+                       _smi_metrics.end());
+
+    if(fmt_opts.alphabetical)
+    {
+        std::sort(
+            _smi_metrics.begin(), _smi_metrics.end(),
+            [](const auto& lhs, const auto& rhs) {
+                constexpr auto suffix      = std::string_view{ ":device=" };
+                const auto     metric_name = [suffix](const std::string& symbol) {
+                    if(const auto pos = symbol.rfind(suffix); pos != std::string::npos)
+                    {
+                        return symbol.substr(0, pos);
+                    }
+                    return symbol;
+                };
+                const auto device_index =
+                    [suffix](const std::string& symbol) -> std::size_t {
+                    if(const auto pos = symbol.rfind(suffix); pos != std::string::npos)
+                    {
+                        return static_cast<std::size_t>(
+                            std::stoull(symbol.substr(pos + suffix.size())));
+                    }
+                    return 0;
+                };
+
+                const auto lhs_name = metric_name(lhs.symbol);
+                const auto rhs_name = metric_name(rhs.symbol);
+                if(lhs_name != rhs_name) return lhs_name < rhs_name;
+                return device_index(lhs.symbol) < device_index(rhs.symbol);
+            });
+    }
+
+    for(const auto& itr : _smi_metrics)
+    {
+        width_type _w = { { static_cast<std::int64_t>(itr.symbol.length()),
+                            static_cast<std::int64_t>(3), static_cast<std::int64_t>(6),
+                            static_cast<std::int64_t>(itr.summary.length()),
+                            static_cast<std::int64_t>(itr.category.length()) } };
+        for(auto& witr : _w)
+            witr += fmt_opts.padding;
+
+        for(size_t i = 0; i < N; ++i)
+        {
+            if(_wusing.at(i))
+                _widths.at(i) = std::max<std::int64_t>(_widths.at(i), _w.at(i));
+        }
+    }
+
+    _widths = compute_max_columns(_widths, _wusing, fmt_opts);
+
+    if(!fmt_opts.markdown) os << banner(_widths, _wusing, fmt_opts, '-');
+    if(!fmt_opts.csv) os << fmt_opts.delim;
+
+    for(size_t i = 0; i < _labels.size(); ++i)
+    {
+        if(options[i])
+            write_entry(os, _labels.at(i), _widths.at(i), true, false, fmt_opts);
+    }
+    os << "\n" << banner(_widths, _wusing, fmt_opts, '-');
+
+    for(const auto& itr : _smi_metrics)
+    {
+        std::stringstream ss;
+        if(options[0])
+            write_entry(ss, itr.symbol, _widths.at(0), _center.at(0), _mark.at(0),
+                        fmt_opts);
+
+        write_entry(ss, "GPU", _widths.at(1), _center.at(1), _mark.at(1), fmt_opts);
+
+        if(options[2])
+            write_entry(ss, itr.available, _widths.at(2), _center.at(2), _mark.at(1),
+                        fmt_opts);
+
+        if(options[3])
+            write_wrap_entry(ss, itr.summary, _widths.at(3), _center.at(3), _mark.at(3),
+                             3, _widths, _wusing, fmt_opts);
+        if(options[4])
+            write_wrap_entry(ss, itr.category, _widths.at(4), _center.at(4), _mark.at(4),
+                             4, _widths, _wusing, fmt_opts);
+
+        if(!fmt_opts.csv) os << fmt_opts.delim;
+        os << hl_selected(ss.str());
+        os << "\n";
     }
 
     dump_log();

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.cpp
@@ -293,8 +293,9 @@ process_categories(parser_t& p, const str_set_t& _category_options)
     // Cache lowercase -> original category mapping to avoid repeated string conversions
     // Also pre-compute shorthand mappings (e.g., "wallclock" -> "component::WallClock")
     std::unordered_map<std::string, std::string> _category_map;
-    constexpr std::array<std::string_view, 3> _prefixes = { "component::", "settings::",
-                                                            "hw_counters::" };
+    constexpr std::array<std::string_view, 4>    _prefixes = {
+        "component::", "settings::", "hw_counters::", "smi_metrics::"
+    };
 
     for(const auto& opt : _category_options)
     {

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.hpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-avail/common.hpp
@@ -64,6 +64,7 @@ enum : int
 constexpr size_t num_component_options   = 7;
 constexpr size_t num_settings_options    = 4;
 constexpr size_t num_hw_counter_options  = 5;
+constexpr size_t num_smi_metric_options  = 5;
 constexpr size_t num_dump_config_options = TOTAL;
 
 extern bool              debug_msg;

--- a/projects/rocprofiler-systems/source/lib/core/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/core/CMakeLists.txt
@@ -29,6 +29,7 @@ set(core_headers
     ${CMAKE_CURRENT_LIST_DIR}/agent_info.hpp
     ${CMAKE_CURRENT_LIST_DIR}/agent_manager.hpp
     ${CMAKE_CURRENT_LIST_DIR}/amd_smi.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/amd_smi_probe.hpp
     ${CMAKE_CURRENT_LIST_DIR}/argparse.hpp
     ${CMAKE_CURRENT_LIST_DIR}/categories.hpp
     ${CMAKE_CURRENT_LIST_DIR}/common.hpp

--- a/projects/rocprofiler-systems/source/lib/core/amd_smi.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/amd_smi.cpp
@@ -4,13 +4,20 @@
 #include "core/amd_smi.hpp"
 #include "core/common.hpp"
 #include "core/config.hpp"
-#include "core/gpu.hpp"
 #include "timemory.hpp"
 
 #include "logger/debug.hpp"
 
+#include <algorithm>
+#include <array>
+#include <atomic>
 #include <cctype>
+#include <limits>
+#include <mutex>
+#include <set>
+#include <sstream>
 #include <string_view>
+#include <vector>
 
 namespace rocprofsys
 {
@@ -46,66 +53,540 @@ get_setting_name(std::string_view input)
         }                                                                                \
         return _config->find(ENV_NAME)->second;                                          \
     }()
+
+void
+check_amdsmi_error(amdsmi_status_t code, const char* file, int line)
+{
+    if(code == AMDSMI_STATUS_SUCCESS) return;
+    const char* msg = nullptr;
+    auto        err = amdsmi_status_code_to_string(code, &msg);
+    if(err != AMDSMI_STATUS_SUCCESS)
+    {
+        throw std::runtime_error(fmt::format(
+            "amdsmi_status_code_to_string failed. No error message available. "
+            "Error code {} originated at {}:{}",
+            static_cast<int>(code), file, line));
+    }
+    throw std::runtime_error(fmt::format("[{}:{}] Error code {} :: {}", file, line,
+                                         static_cast<int>(code), msg));
+}
+
+#define ROCPROFSYS_AMD_SMI_CALL(ERROR_CODE)                                              \
+    check_amdsmi_error(ERROR_CODE, __FILE__, __LINE__)
+
+std::atomic<bool> amdsmi_initialized{ false };
+std::mutex        processor_mutex{};
+
+std::vector<amdsmi_processor_handle> processor_handles{};
+
+template <typename T>
+constexpr bool
+is_metric_supported(T value, T invalid_sentinel = std::numeric_limits<T>::max())
+{
+    return value != invalid_sentinel;
+}
+
+struct converted_metrics : probe_input
+{};
+
+template <typename T>
+constexpr bool
+populate_if_supported(T& dest, T src, T invalid_sentinel = std::numeric_limits<T>::max())
+{
+    const bool valid = is_metric_supported(src, invalid_sentinel);
+    dest             = valid ? src : T{ 0 };
+    return valid;
+}
+
+probe_input
+convert_gpu_metrics(const amdsmi_gpu_metrics_t& raw)
+{
+    converted_metrics out{};
+    out.current_socket_power = raw.current_socket_power;
+    out.average_socket_power = raw.average_socket_power;
+    out.hotspot_temperature  = raw.temperature_hotspot;
+    out.edge_temperature     = raw.temperature_edge;
+    out.gfx_activity         = raw.average_gfx_activity;
+    out.umc_activity         = raw.average_umc_activity;
+    out.mm_activity          = raw.average_mm_activity;
+
+    for(std::size_t xcp = 0; xcp < MAX_NUM_XCP; ++xcp)
+    {
+        std::copy(std::begin(raw.xcp_stats[xcp].vcn_busy),
+                  std::end(raw.xcp_stats[xcp].vcn_busy),
+                  out.xcp_stats[xcp].vcn_busy.begin());
+
+        constexpr std::size_t copy_count =
+            std::min(static_cast<std::size_t>(sizeof(raw.xcp_stats[0].jpeg_busy) /
+                                              sizeof(std::uint16_t)),
+                     MAX_NUM_JPEG_V1);
+        std::copy_n(std::begin(raw.xcp_stats[xcp].jpeg_busy), copy_count,
+                    out.xcp_stats[xcp].jpeg_busy.begin());
+    }
+
+    std::copy(std::begin(raw.vcn_activity), std::end(raw.vcn_activity),
+              out.vcn_activity.begin());
+    std::copy(std::begin(raw.jpeg_activity), std::end(raw.jpeg_activity),
+              out.jpeg_activity.begin());
+
+    populate_if_supported(out.xgmi.width, raw.xgmi_link_width);
+    populate_if_supported(out.xgmi.speed, raw.xgmi_link_speed);
+    for(std::size_t idx = 0; idx < MAX_NUM_XGMI_LINKS; ++idx)
+    {
+        populate_if_supported(out.xgmi.data_acc.read[idx], raw.xgmi_read_data_acc[idx]);
+        populate_if_supported(out.xgmi.data_acc.write[idx], raw.xgmi_write_data_acc[idx]);
+    }
+
+    populate_if_supported(out.pcie.width, raw.pcie_link_width);
+    populate_if_supported(out.pcie.speed, raw.pcie_link_speed);
+    populate_if_supported(out.pcie.bandwidth.acc, raw.pcie_bandwidth_acc);
+    populate_if_supported(out.pcie.bandwidth.inst, raw.pcie_bandwidth_inst);
+
+    populate_if_supported(out.gfx_clock_mhz,
+                          static_cast<std::uint32_t>(raw.current_gfxclk),
+                          static_cast<std::uint32_t>(0xFFFFU));
+    populate_if_supported(out.mem_clock_mhz, static_cast<std::uint32_t>(raw.current_uclk),
+                          static_cast<std::uint32_t>(0xFFFFU));
+
+    return out;
+}
+
+metric_availability
+compute_availability_impl(const probe_input& raw, bool memory_usage, bool sdma_supported)
+{
+    metric_availability result{};
+
+    result.bits.memory_usage = memory_usage ? 1 : 0;
+    result.bits.current_socket_power =
+        is_metric_supported(raw.current_socket_power, METRIC_VALUE_NOT_SUPPORTED_16) ? 1
+                                                                                     : 0;
+    result.bits.average_socket_power =
+        is_metric_supported(raw.average_socket_power, METRIC_VALUE_NOT_SUPPORTED_16) ? 1
+                                                                                     : 0;
+    result.bits.hotspot_temperature =
+        is_metric_supported(raw.hotspot_temperature, METRIC_VALUE_NOT_SUPPORTED_16) ? 1
+                                                                                    : 0;
+    result.bits.edge_temperature =
+        is_metric_supported(raw.edge_temperature, METRIC_VALUE_NOT_SUPPORTED_16) ? 1 : 0;
+    result.bits.gfx_activity =
+        is_metric_supported(raw.gfx_activity, METRIC_VALUE_NOT_SUPPORTED_16) ? 1 : 0;
+    result.bits.umc_activity =
+        is_metric_supported(raw.umc_activity, METRIC_VALUE_NOT_SUPPORTED_16) ? 1 : 0;
+    result.bits.mm_activity =
+        is_metric_supported(raw.mm_activity, METRIC_VALUE_NOT_SUPPORTED_16) ? 1 : 0;
+
+    result.bits.vcn_busy =
+        std::any_of(raw.xcp_stats.begin(), raw.xcp_stats.end(),
+                    [](const probe_input::xcp_metrics& xcp) {
+                        return std::any_of(
+                            xcp.vcn_busy.begin(), xcp.vcn_busy.end(),
+                            [](std::uint16_t val) { return is_metric_supported(val); });
+                    })
+            ? 1
+            : 0;
+
+    result.bits.jpeg_busy =
+        std::any_of(raw.xcp_stats.begin(), raw.xcp_stats.end(),
+                    [](const probe_input::xcp_metrics& xcp) {
+                        return std::any_of(
+                            xcp.jpeg_busy.begin(), xcp.jpeg_busy.end(),
+                            [](std::uint16_t val) { return is_metric_supported(val); });
+                    })
+            ? 1
+            : 0;
+
+    result.bits.vcn_activity =
+        (!result.bits.vcn_busy &&
+         std::any_of(raw.vcn_activity.begin(), raw.vcn_activity.end(),
+                     [](std::uint16_t val) { return is_metric_supported(val); }))
+            ? 1
+            : 0;
+
+    result.bits.jpeg_activity =
+        (!result.bits.jpeg_busy &&
+         std::any_of(raw.jpeg_activity.begin(), raw.jpeg_activity.end(),
+                     [](std::uint16_t val) { return is_metric_supported(val); }))
+            ? 1
+            : 0;
+
+    result.bits.xgmi =
+        (is_metric_supported(raw.xgmi.width) || is_metric_supported(raw.xgmi.speed) ||
+         std::any_of(raw.xgmi.data_acc.read.begin(), raw.xgmi.data_acc.read.end(),
+                     [](std::uint64_t val) { return is_metric_supported(val); }))
+            ? 1
+            : 0;
+
+    result.bits.pcie =
+        (is_metric_supported(raw.pcie.width) || is_metric_supported(raw.pcie.speed) ||
+         is_metric_supported(raw.pcie.bandwidth.acc) ||
+         is_metric_supported(raw.pcie.bandwidth.inst))
+            ? 1
+            : 0;
+
+    result.bits.gfx_clock =
+        is_metric_supported(raw.gfx_clock_mhz, METRIC_VALUE_NOT_SUPPORTED_16) ? 1 : 0;
+    result.bits.mem_clock =
+        is_metric_supported(raw.mem_clock_mhz, METRIC_VALUE_NOT_SUPPORTED_16) ? 1 : 0;
+    result.bits.sdma_usage = sdma_supported ? 1 : 0;
+
+    return result;
+}
+
+void
+append_scalar_entry(std::vector<metric_entry>& entries, std::size_t device_index,
+                    const std::string& name, const std::string& category,
+                    const std::string& summary, bool available)
+{
+    entries.push_back(metric_entry{ name + ":device=" + std::to_string(device_index),
+                                    category, summary, available });
+}
+
+struct metric_symbol_parts
+{
+    std::string name;
+    std::size_t device = 0;
+};
+
+metric_symbol_parts
+parse_metric_symbol(const std::string& symbol)
+{
+    constexpr auto suffix = std::string_view{ ":device=" };
+
+    metric_symbol_parts parts{};
+    parts.name = symbol;
+    if(const auto pos = symbol.rfind(suffix); pos != std::string::npos)
+    {
+        parts.name = symbol.substr(0, pos);
+        parts.device =
+            static_cast<std::size_t>(std::stoull(symbol.substr(pos + suffix.size())));
+    }
+    return parts;
+}
+
+bool
+compare_metric_entries(const metric_entry& lhs, const metric_entry& rhs)
+{
+    const auto l = parse_metric_symbol(lhs.symbol);
+    const auto r = parse_metric_symbol(rhs.symbol);
+    if(l.name != r.name) return l.name < r.name;
+    return l.device < r.device;
+}
+
+void
+build_metric_entries_impl(std::size_t device_index, const probe_input& raw,
+                          const metric_availability& metrics,
+                          std::vector<metric_entry>& entries)
+{
+    append_scalar_entry(entries, device_index, "CURRENT_SOCKET_POWER", "power",
+                        "current_socket_power", metrics.bits.current_socket_power != 0);
+    append_scalar_entry(entries, device_index, "AVERAGE_SOCKET_POWER", "power",
+                        "average_socket_power", metrics.bits.average_socket_power != 0);
+    append_scalar_entry(entries, device_index, "MEMORY_USAGE", "mem_usage",
+                        "amdsmi_get_gpu_memory_usage (VRAM)",
+                        metrics.bits.memory_usage != 0);
+    append_scalar_entry(entries, device_index, "HOTSPOT_TEMPERATURE", "temp",
+                        "temperature_hotspot", metrics.bits.hotspot_temperature != 0);
+    append_scalar_entry(entries, device_index, "EDGE_TEMPERATURE", "temp",
+                        "temperature_edge", metrics.bits.edge_temperature != 0);
+    append_scalar_entry(entries, device_index, "GFX_ACTIVITY", "busy",
+                        "average_gfx_activity", metrics.bits.gfx_activity != 0);
+    append_scalar_entry(entries, device_index, "UMC_ACTIVITY", "busy",
+                        "average_umc_activity", metrics.bits.umc_activity != 0);
+    append_scalar_entry(entries, device_index, "MM_ACTIVITY", "busy",
+                        "average_mm_activity", metrics.bits.mm_activity != 0);
+    append_scalar_entry(entries, device_index, "VCN_BUSY", "vcn_activity", "vcn_busy",
+                        metrics.bits.vcn_busy != 0);
+    append_scalar_entry(entries, device_index, "VCN_ACTIVITY", "vcn_activity",
+                        "vcn_activity", metrics.bits.vcn_activity != 0);
+    append_scalar_entry(entries, device_index, "JPEG_BUSY", "jpeg_activity", "jpeg_busy",
+                        metrics.bits.jpeg_busy != 0);
+    append_scalar_entry(entries, device_index, "JPEG_ACTIVITY", "jpeg_activity",
+                        "jpeg_activity", metrics.bits.jpeg_activity != 0);
+
+    append_scalar_entry(entries, device_index, "XGMI_LINK_WIDTH", "xgmi",
+                        "xgmi_link_width", is_metric_supported(raw.xgmi.width));
+    append_scalar_entry(entries, device_index, "XGMI_LINK_SPEED", "xgmi",
+                        "xgmi_link_speed", is_metric_supported(raw.xgmi.speed));
+
+    const bool xgmi_read_supported =
+        std::any_of(raw.xgmi.data_acc.read.begin(), raw.xgmi.data_acc.read.end(),
+                    [](std::uint64_t val) { return is_metric_supported(val); });
+    const bool xgmi_write_supported =
+        std::any_of(raw.xgmi.data_acc.write.begin(), raw.xgmi.data_acc.write.end(),
+                    [](std::uint64_t val) { return is_metric_supported(val); });
+    append_scalar_entry(entries, device_index, "XGMI_READ", "xgmi", "xgmi_read_data",
+                        xgmi_read_supported);
+    append_scalar_entry(entries, device_index, "XGMI_WRITE", "xgmi", "xgmi_write_data",
+                        xgmi_write_supported);
+
+    append_scalar_entry(entries, device_index, "PCIE_LINK_WIDTH", "pcie",
+                        "pcie_link_width", is_metric_supported(raw.pcie.width));
+    append_scalar_entry(entries, device_index, "PCIE_LINK_SPEED", "pcie",
+                        "pcie_link_speed", is_metric_supported(raw.pcie.speed));
+    append_scalar_entry(entries, device_index, "PCIE_BANDWIDTH_ACC", "pcie",
+                        "pcie_bandwidth_acc",
+                        is_metric_supported(raw.pcie.bandwidth.acc));
+    append_scalar_entry(entries, device_index, "PCIE_BANDWIDTH_INST", "pcie",
+                        "pcie_bandwidth_inst",
+                        is_metric_supported(raw.pcie.bandwidth.inst));
+    append_scalar_entry(entries, device_index, "SDMA_USAGE", "sdma_usage",
+                        "amdsmi_get_gpu_process_list", metrics.bits.sdma_usage != 0);
+    append_scalar_entry(entries, device_index, "GFX_CLOCK", "gfx_clock",
+                        "current_gfxclk (MHz)", metrics.bits.gfx_clock != 0);
+    append_scalar_entry(entries, device_index, "MEM_CLOCK", "mem_clock",
+                        "current_uclk (MHz)", metrics.bits.mem_clock != 0);
+}
+
+bool
+query_memory_usage(amdsmi_processor_handle handle, std::uint64_t& usage)
+{
+    usage = 0;
+    return amdsmi_get_gpu_memory_usage(handle, AMDSMI_MEM_TYPE_VRAM, &usage) ==
+           AMDSMI_STATUS_SUCCESS;
+}
+
+bool
+query_sdma_supported(amdsmi_processor_handle handle)
+{
+#if defined(AMD_SMI_SDMA_SUPPORTED) && AMD_SMI_SDMA_SUPPORTED == 1
+    std::uint32_t num_processes = 0;
+    return amdsmi_get_gpu_process_list(handle, &num_processes, nullptr) ==
+           AMDSMI_STATUS_SUCCESS;
+#else
+    (void) handle;
+    return false;
+#endif
+}
+
+void
+enumerate_processors()
+{
+    std::lock_guard<std::mutex> lock(processor_mutex);
+    processor_handles.clear();
+
+    std::uint32_t socket_count = 0;
+    if(amdsmi_get_socket_handles(&socket_count, nullptr) != AMDSMI_STATUS_SUCCESS)
+    {
+        return;
+    }
+
+    std::vector<amdsmi_socket_handle> sockets(socket_count);
+    if(amdsmi_get_socket_handles(&socket_count, sockets.data()) != AMDSMI_STATUS_SUCCESS)
+    {
+        return;
+    }
+
+    for(auto& socket : sockets)
+    {
+        std::uint32_t processor_count = 0;
+        if(amdsmi_get_processor_handles(socket, &processor_count, nullptr) !=
+           AMDSMI_STATUS_SUCCESS)
+        {
+            continue;
+        }
+
+        std::vector<amdsmi_processor_handle> processors(processor_count);
+        if(amdsmi_get_processor_handles(socket, &processor_count, processors.data()) !=
+           AMDSMI_STATUS_SUCCESS)
+        {
+            continue;
+        }
+
+        for(auto& processor : processors)
+        {
+            processor_type_t processor_type = {};
+            if(amdsmi_get_processor_type(processor, &processor_type) !=
+               AMDSMI_STATUS_SUCCESS)
+            {
+                continue;
+            }
+#ifdef AINIC_SUPPORTED
+            if(processor_type == AMDSMI_PROCESSOR_TYPE_AMD_NIC)
+            {
+                continue;
+            }
+#endif
+            if(processor_type != AMDSMI_PROCESSOR_TYPE_AMD_GPU)
+            {
+                continue;
+            }
+            processor_handles.push_back(processor);
+        }
+    }
+}
+
+device_probe_result
+probe_processor_internal(amdsmi_processor_handle handle, std::size_t device_index)
+{
+    device_probe_result result{};
+    result.device_index = device_index;
+
+    amdsmi_asic_info_t asic_info{};
+    if(amdsmi_get_gpu_asic_info(handle, &asic_info) == AMDSMI_STATUS_SUCCESS)
+    {
+        result.product_name = asic_info.market_name;
+        result.vendor_name  = asic_info.vendor_name;
+    }
+    else
+    {
+        result.product_name = "Unknown GPU";
+        result.vendor_name  = "AMD";
+    }
+
+    std::uint64_t memory_usage = 0;
+    const bool    memory_ok    = query_memory_usage(handle, memory_usage);
+    const bool    memory_supported =
+        memory_ok && is_metric_supported(memory_usage, METRIC_VALUE_NOT_SUPPORTED_64);
+
+    probe_input          raw{};
+    amdsmi_gpu_metrics_t gpu_metrics{};
+    if(amdsmi_get_gpu_metrics_info(handle, &gpu_metrics) == AMDSMI_STATUS_SUCCESS)
+    {
+        raw = convert_gpu_metrics(gpu_metrics);
+    }
+
+    const bool sdma_supported = query_sdma_supported(handle);
+    result.metrics = compute_availability_impl(raw, memory_supported, sdma_supported);
+    build_metric_entries_impl(device_index, raw, result.metrics, result.entries);
+    return result;
+}
 }  // namespace
+
+metric_availability
+compute_availability(const probe_input& raw, bool memory_usage, bool sdma_supported)
+{
+    return compute_availability_impl(raw, memory_usage, sdma_supported);
+}
+
+void
+build_metric_entries(std::size_t device_index, const probe_input& raw,
+                     const metric_availability& metrics,
+                     std::vector<metric_entry>& entries)
+{
+    build_metric_entries_impl(device_index, raw, metrics, entries);
+}
+
+bool
+ensure_initialized()
+{
+    if(amdsmi_initialized.load()) return !processor_handles.empty();
+
+    try
+    {
+        std::uint64_t init_flags = AMDSMI_INIT_AMD_GPUS;
+#ifdef AINIC_SUPPORTED
+        init_flags |= AMDSMI_INIT_AMD_NICS;
+#endif
+        ROCPROFSYS_AMD_SMI_CALL(::amdsmi_init(init_flags));
+        enumerate_processors();
+        amdsmi_initialized.store(true);
+    } catch(const std::exception& e)
+    {
+        LOG_ERROR("Exception thrown initializing amd-smi: {}", e.what());
+        amdsmi_initialized.store(false);
+        processor_handles.clear();
+        return false;
+    }
+
+    return !processor_handles.empty();
+}
+
+metric_availability
+probe_processor(amdsmi_processor_handle handle)
+{
+    return probe_processor_internal(handle, 0).metrics;
+}
+
+std::vector<device_probe_result>
+probe_devices()
+{
+    std::vector<device_probe_result> results;
+    if(!ensure_initialized()) return results;
+
+    results.reserve(processor_handles.size());
+    for(std::size_t i = 0; i < processor_handles.size(); ++i)
+    {
+        results.emplace_back(probe_processor_internal(processor_handles[i], i));
+    }
+    return results;
+}
+
+std::string
+format_settings_description(const std::vector<device_probe_result>& devices)
+{
+    metric_availability union_metrics{};
+    for(const auto& device : devices)
+    {
+        union_metrics.value |= device.metrics.value;
+    }
+
+    std::vector<std::string> categories;
+    auto                     add = [&](bool cond, const char* name) {
+        if(cond) categories.emplace_back(name);
+    };
+
+    add(union_metrics.bits.gfx_activity || union_metrics.bits.umc_activity ||
+            union_metrics.bits.mm_activity,
+        "busy");
+    add(union_metrics.bits.hotspot_temperature || union_metrics.bits.edge_temperature,
+        "temp");
+    add(union_metrics.bits.current_socket_power ||
+            union_metrics.bits.average_socket_power,
+        "power");
+    add(union_metrics.bits.memory_usage, "mem_usage");
+    add(union_metrics.bits.vcn_activity || union_metrics.bits.vcn_busy, "vcn_activity");
+    add(union_metrics.bits.jpeg_activity || union_metrics.bits.jpeg_busy,
+        "jpeg_activity");
+    add(union_metrics.bits.xgmi, "xgmi");
+    add(union_metrics.bits.pcie, "pcie");
+    add(union_metrics.bits.sdma_usage, "sdma_usage");
+    add(union_metrics.bits.gfx_clock, "gfx_clock");
+    add(union_metrics.bits.mem_clock, "mem_clock");
+
+    std::ostringstream desc;
+    desc << "amd-smi metrics to collect: ";
+    if(categories.empty())
+    {
+        desc << "none detected on this system";
+    }
+    else
+    {
+        for(std::size_t i = 0; i < categories.size(); ++i)
+        {
+            if(i > 0) desc << ", ";
+            desc << categories[i];
+        }
+    }
+    desc << ". An empty value implies 'all' and 'none' suppresses all.";
+    return desc.str();
+}
+
+std::vector<metric_entry>
+format_avail_entries(const std::vector<device_probe_result>& devices)
+{
+    std::vector<metric_entry> entries;
+    for(const auto& device : devices)
+    {
+        entries.insert(entries.end(), device.entries.begin(), device.entries.end());
+    }
+
+    std::sort(entries.begin(), entries.end(), compare_metric_entries);
+    return entries;
+}
 
 void
 config_settings(const std::shared_ptr<settings>& _config)
 {
-    if(!get_use_amd_smi() || !gpu::initialize_amdsmi()) return;
+    if(!get_use_amd_smi()) return;
 
-    std::string default_metrics =
-        "busy, temp, power, mem_usage, sdma_usage, gfx_clock, mem_clock";
-    // No distinction between busy and activity shown in description
-    std::string jpeg_activity_support{};
-    std::string vcn_activity_support{};
-    std::string xgmi_support{};
-    std::string pcie_support{};
-    std::string sdma_support{};
+    const auto devices = probe_devices();
+    if(devices.empty()) return;
 
-    size_t device_count = gpu::get_processor_count();
-    for(size_t i = 0; i < device_count; i++)
-    {
-        if(gpu::vcn_is_device_level_only(i) || gpu::is_vcn_busy_supported(i))
-        {
-            vcn_activity_support += ", vcn_activity";
-            break;
-        }
-    }
-    for(size_t i = 0; i < device_count; i++)
-    {
-        if(gpu::jpeg_is_device_level_only(i) || gpu::is_jpeg_busy_supported(i))
-        {
-            jpeg_activity_support += ", jpeg_activity";
-            break;
-        }
-    }
-    for(size_t i = 0; i < device_count; i++)
-    {
-        if(gpu::is_xgmi_supported(i))
-        {
-            xgmi_support += ", xgmi";
-            break;
-        }
-    }
-    for(size_t i = 0; i < device_count; i++)
-    {
-        if(gpu::is_pcie_supported(i))
-        {
-            pcie_support += ", pcie";
-            break;
-        }
-    }
+    const auto description = format_settings_description(devices);
 
-#if AMD_SMI_SDMA_SUPPORTED == 1
-    sdma_support += ", sdma_usage";
-#endif
-
-    ROCPROFSYS_CONFIG_SETTING(
-        std::string, "ROCPROFSYS_AMD_SMI_METRICS",
-        "amd-smi metrics to collect: " + default_metrics + jpeg_activity_support +
-            vcn_activity_support + xgmi_support + pcie_support + sdma_support + ". " +
-            "An empty value implies 'all' and 'none' suppresses all.",
-        "busy, temp, power, mem_usage", "backend", "amd_smi", "rocm", "process_sampling");
+    ROCPROFSYS_CONFIG_SETTING(std::string, "ROCPROFSYS_AMD_SMI_METRICS", description,
+                              "busy, temp, power, mem_usage", "backend", "amd_smi",
+                              "rocm", "process_sampling");
 }
 }  // namespace amd_smi
 }  // namespace rocprofsys

--- a/projects/rocprofiler-systems/source/lib/core/amd_smi.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/amd_smi.hpp
@@ -1,14 +1,15 @@
 // Copyright (c) Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
+#pragma once
+
+#include "core/amd_smi_probe.hpp"
 #include "core/sdma_feature.hpp"
 #include "core/timemory.hpp"
 
 #include <amd_smi/amdsmi.h>
 
 // AMD-SMI >= 26.3 also exposes NIC APIs (gated independently by ROCPROFSYS_USE_AINIC).
-// The SDMA feature flag lives in sdma_feature.hpp so that mock_driver.hpp can include
-// it directly and avoid the ODR fragility from include-order dependence.
 #if AMDSMI_LIB_VERSION_MAJOR > 26 ||                                                     \
     (AMDSMI_LIB_VERSION_MAJOR == 26 && AMDSMI_LIB_VERSION_MINOR > 2)
 #    if ROCPROFSYS_USE_AINIC > 0
@@ -20,7 +21,22 @@ namespace rocprofsys
 {
 namespace amd_smi
 {
+bool
+ensure_initialized();
+
+metric_availability
+probe_processor(amdsmi_processor_handle handle);
+
+std::vector<device_probe_result>
+probe_devices();
+
+std::string
+format_settings_description(const std::vector<device_probe_result>& devices);
+
+std::vector<metric_entry>
+format_avail_entries(const std::vector<device_probe_result>& devices);
+
 void
-config_settings(const std::shared_ptr<settings>&);
+config_settings(const std::shared_ptr<settings>& config);
 }  // namespace amd_smi
 }  // namespace rocprofsys

--- a/projects/rocprofiler-systems/source/lib/core/amd_smi_probe.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/amd_smi_probe.hpp
@@ -1,0 +1,122 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace rocprofsys
+{
+namespace amd_smi
+{
+constexpr std::size_t MAX_NUM_VCN        = 4;
+constexpr std::size_t MAX_NUM_JPEG       = 32;
+constexpr std::size_t MAX_NUM_JPEG_V1    = 40;
+constexpr std::size_t MAX_NUM_XCP        = 8;
+constexpr std::size_t MAX_NUM_XGMI_LINKS = 8;
+
+constexpr std::uint32_t METRIC_VALUE_NOT_SUPPORTED_16 = 0xFFFF;
+constexpr std::uint64_t METRIC_VALUE_NOT_SUPPORTED_64 = 0xFFFFFFFFFFFFFFFFULL;
+
+/**
+ * @brief Bitfield for AMD SMI metric availability on a GPU.
+ *
+ * Bit layout matches pmc::collectors::gpu::enabled_metrics so callers can copy
+ * .value directly.
+ */
+union metric_availability
+{
+    struct
+    {
+        std::uint32_t current_socket_power : 1;
+        std::uint32_t average_socket_power : 1;
+        std::uint32_t memory_usage         : 1;
+        std::uint32_t hotspot_temperature  : 1;
+        std::uint32_t edge_temperature     : 1;
+        std::uint32_t gfx_activity         : 1;
+        std::uint32_t umc_activity         : 1;
+        std::uint32_t mm_activity          : 1;
+        std::uint32_t vcn_activity         : 1;
+        std::uint32_t jpeg_activity        : 1;
+        std::uint32_t vcn_busy             : 1;
+        std::uint32_t jpeg_busy            : 1;
+        std::uint32_t xgmi                 : 1;
+        std::uint32_t pcie                 : 1;
+        std::uint32_t sdma_usage           : 1;
+        std::uint32_t gfx_clock            : 1;
+        std::uint32_t mem_clock            : 1;
+    } bits;
+    std::uint32_t value = 0;
+};
+
+struct metric_entry
+{
+    std::string symbol;
+    std::string category;
+    std::string summary;
+    bool        available = false;
+};
+
+struct probe_input
+{
+    std::uint32_t                           current_socket_power = 0;
+    std::uint32_t                           average_socket_power = 0;
+    std::uint32_t                           hotspot_temperature  = 0;
+    std::uint32_t                           edge_temperature     = 0;
+    std::uint32_t                           gfx_activity         = 0;
+    std::uint32_t                           umc_activity         = 0;
+    std::uint32_t                           mm_activity          = 0;
+    std::uint32_t                           gfx_clock_mhz        = 0;
+    std::uint32_t                           mem_clock_mhz        = 0;
+    std::array<std::uint16_t, MAX_NUM_VCN>  vcn_activity         = {};
+    std::array<std::uint16_t, MAX_NUM_JPEG> jpeg_activity        = {};
+    struct xcp_metrics
+    {
+        std::array<std::uint16_t, MAX_NUM_JPEG_V1> jpeg_busy = {};
+        std::array<std::uint16_t, MAX_NUM_VCN>     vcn_busy  = {};
+    };
+    std::array<xcp_metrics, MAX_NUM_XCP> xcp_stats{};
+    struct
+    {
+        std::uint16_t width = 0;
+        std::uint16_t speed = 0;
+        struct
+        {
+            std::array<std::uint64_t, MAX_NUM_XGMI_LINKS> read  = {};
+            std::array<std::uint64_t, MAX_NUM_XGMI_LINKS> write = {};
+        } data_acc;
+    } xgmi;
+    struct
+    {
+        std::uint16_t width = 0;
+        std::uint16_t speed = 0;
+        struct
+        {
+            std::uint64_t acc  = 0;
+            std::uint64_t inst = 0;
+        } bandwidth;
+    } pcie;
+};
+
+struct device_probe_result
+{
+    std::size_t               device_index = 0;
+    std::string               product_name;
+    std::string               vendor_name;
+    metric_availability       metrics{};
+    std::vector<metric_entry> entries;
+};
+
+metric_availability
+compute_availability(const probe_input& raw, bool memory_usage, bool sdma_supported);
+
+void
+build_metric_entries(std::size_t device_index, const probe_input& raw,
+                     const metric_availability& metrics,
+                     std::vector<metric_entry>& entries);
+}  // namespace amd_smi
+}  // namespace rocprofsys

--- a/projects/rocprofiler-systems/source/lib/core/gpu.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/gpu.cpp
@@ -22,15 +22,11 @@
 
 #include "core/agent_manager.hpp"
 
-#include "core/amd_smi.hpp"
 #include <rocprofiler-sdk/agent.h>
 #include <rocprofiler-sdk/cxx/serialization.hpp>
 #include <rocprofiler-sdk/fwd.h>
 
 #include "logger/debug.hpp"
-
-#include <atomic>
-#include <mutex>
 
 namespace rocprofsys
 {
@@ -38,51 +34,6 @@ namespace gpu
 {
 namespace
 {
-#define ROCPROFSYS_AMD_SMI_CALL(ERROR_CODE)                                              \
-    ::rocprofsys::gpu::check_amdsmi_error(ERROR_CODE, __FILE__, __LINE__)
-
-void
-check_amdsmi_error(amdsmi_status_t _code, const char* _file, int _line)
-{
-    if(_code == AMDSMI_STATUS_SUCCESS) return;
-    const char* _msg = nullptr;
-    auto        _err = amdsmi_status_code_to_string(_code, &_msg);
-    if(_err != AMDSMI_STATUS_SUCCESS)
-    {
-        throw std::runtime_error(fmt::format(
-            "amdsmi_status_code_to_string failed. No error message available. "
-            "Error code {} originated at {}:{}",
-            static_cast<int>(_code), _file, _line));
-    }
-    throw std::runtime_error(fmt::format("[{}:{}] Error code {} :: {}", _file, _line,
-                                         static_cast<int>(_code), _msg));
-}
-
-std::atomic<bool> amdsmi_initialized{ false };
-
-bool
-amdsmi_init()
-{
-    if(amdsmi_initialized.exchange(true)) return true;
-
-    try
-    {
-        // Currently, only AMDSMI_INIT_AMD_GPUS and AMDSMI_INIT_AMD_NICS are supported
-        std::uint64_t init_flags = AMDSMI_INIT_AMD_GPUS;
-#ifdef AINIC_SUPPORTED
-        init_flags |= AMDSMI_INIT_AMD_NICS;
-#endif
-        ROCPROFSYS_AMD_SMI_CALL(::amdsmi_init(init_flags));
-        get_processor_handles();
-    } catch(std::exception& _e)
-    {
-        LOG_ERROR("Exception thrown initializing amd-smi: {}", _e.what());
-        amdsmi_initialized.store(false);
-        return false;
-    }
-    return true;
-}
-
 size_t
 query_rocm_agents()
 {
@@ -136,21 +87,6 @@ device_count()
     return _num_devices;
 }
 
-bool
-initialize_amdsmi()
-{
-    return amdsmi_init();
-}
-
-bool
-reinitialize_amdsmi()
-{
-    static std::mutex           mtx;
-    std::lock_guard<std::mutex> lock(mtx);
-    amdsmi_initialized.store(false);
-    return amdsmi_init();
-}
-
 template <typename ArchiveT>
 void
 add_device_metadata(ArchiveT& ar)
@@ -202,187 +138,6 @@ add_device_metadata()
             LOG_ERROR("Exception thrown adding device metadata: {}", _e.what());
         }
     });
-}
-
-/*
- * Required amdsmi methods to get processors and handles
- */
-
-std::uint32_t                        processors::total_processor_count  = 0;
-std::vector<amdsmi_processor_handle> processors::processors_list        = {};
-std::vector<bool>                    processors::vcn_device_level_only  = {};
-std::vector<bool>                    processors::jpeg_device_level_only = {};
-std::vector<bool>                    processors::vcn_busy_supported     = {};
-std::vector<bool>                    processors::jpeg_busy_supported    = {};
-std::vector<bool>                    processors::xgmi_supported         = {};
-std::vector<bool>                    processors::pcie_supported         = {};
-
-std::vector<amdsmi_processor_handle> processors::ainic_list        = {};
-std::uint32_t                        processors::total_ainic_count = 0;
-
-void
-get_processor_handles()
-{
-    std::uint32_t socket_count;
-    std::uint32_t processor_count;
-    processors::processors_list.clear();
-    processors::ainic_list.clear();
-
-    // Passing nullptr will return us the number of sockets available for read in this
-    // system
-    auto ret = amdsmi_get_socket_handles(&socket_count, nullptr);
-    if(ret != AMDSMI_STATUS_SUCCESS)
-    {
-        return;
-    }
-    std::vector<amdsmi_socket_handle> sockets(socket_count);
-    ret = amdsmi_get_socket_handles(&socket_count, sockets.data());
-    for(auto& socket : sockets)
-    {
-        // Passing nullptr will return us the number of processors available for read for
-        // this socket
-        ret = amdsmi_get_processor_handles(socket, &processor_count, nullptr);
-        if(ret != AMDSMI_STATUS_SUCCESS)
-        {
-            return;
-        }
-        std::vector<amdsmi_processor_handle> all_processors(processor_count);
-        ret =
-            amdsmi_get_processor_handles(socket, &processor_count, all_processors.data());
-        if(ret != AMDSMI_STATUS_SUCCESS)
-        {
-            return;
-        }
-
-        for(auto& processor : all_processors)
-        {
-            processor_type_t processor_type = {};
-            ret = amdsmi_get_processor_type(processor, &processor_type);
-#ifdef AINIC_SUPPORTED
-            if(processor_type == AMDSMI_PROCESSOR_TYPE_AMD_NIC)
-            {
-                processors::ainic_list.push_back(processor);
-                continue;
-            }
-#endif  // AINIC_SUPPORTED
-            if(processor_type != AMDSMI_PROCESSOR_TYPE_AMD_GPU)
-            {
-                throw std::runtime_error("Not AMD_GPU device type!");
-            }
-            processors::processors_list.push_back(processor);
-
-            amdsmi_gpu_metrics_t gpu_metrics;
-            bool                 vcn_supported = false, jpeg_supported = false;
-            bool                 v_busy_supported = false, j_busy_supported = false;
-            bool                 xgmi_supported = false, pcie_supported = false;
-            // AMD SMI will not report VCN_activity and JPEG_activity, if VCN_busy or
-            // JPEG_busy fields are available.
-            if(amdsmi_get_gpu_metrics_info(processor, &gpu_metrics) ==
-               AMDSMI_STATUS_SUCCESS)
-            {
-                // Helper lambda to check if any value in the array is valid (not
-                // UINT16_MAX)
-                auto has_valid_u16 = [](const auto& arr) {
-                    return std::any_of(std::begin(arr), std::end(arr),
-                                       [](auto val) { return val != UINT16_MAX; });
-                };
-
-                // Helper lambda to check if any value in the array is valid (not
-                // UINT64_MAX)
-                auto has_valid_u64 = [](const auto& arr) {
-                    return std::any_of(std::begin(arr), std::end(arr),
-                                       [](auto val) { return val != UINT64_MAX; });
-                };
-
-                vcn_supported  = has_valid_u16(gpu_metrics.vcn_activity);
-                jpeg_supported = has_valid_u16(gpu_metrics.jpeg_activity);
-
-                // Check if VCN and JPEG busy metrics are available
-                for(const auto& xcp : gpu_metrics.xcp_stats)
-                {
-                    if(!v_busy_supported && has_valid_u16(xcp.vcn_busy))
-                        v_busy_supported = true;
-                    if(!j_busy_supported && has_valid_u16(xcp.jpeg_busy))
-                        j_busy_supported = true;
-                    if(v_busy_supported && j_busy_supported) break;
-                }
-
-                // Check if XGMI metrics are supported (any value not at max)
-                xgmi_supported = (gpu_metrics.xgmi_link_width != UINT16_MAX) ||
-                                 (gpu_metrics.xgmi_link_speed != UINT16_MAX) ||
-                                 has_valid_u64(gpu_metrics.xgmi_read_data_acc) ||
-                                 has_valid_u64(gpu_metrics.xgmi_write_data_acc);
-
-                // Check if PCIe metrics are supported (any value not at max)
-                pcie_supported = (gpu_metrics.pcie_link_width != UINT16_MAX) ||
-                                 (gpu_metrics.pcie_link_speed != UINT16_MAX) ||
-                                 (gpu_metrics.pcie_bandwidth_acc != UINT64_MAX) ||
-                                 (gpu_metrics.pcie_bandwidth_inst != UINT64_MAX);
-            }
-            processors::vcn_device_level_only.push_back(vcn_supported);
-            processors::jpeg_device_level_only.push_back(jpeg_supported);
-            processors::vcn_busy_supported.push_back(v_busy_supported);
-            processors::jpeg_busy_supported.push_back(j_busy_supported);
-            processors::xgmi_supported.push_back(xgmi_supported);
-            processors::pcie_supported.push_back(pcie_supported);
-        }
-    }
-    processors::total_processor_count = processors::processors_list.size();
-    processors::total_ainic_count     = processors::ainic_list.size();
-}
-
-bool
-vcn_is_device_level_only(std::uint32_t dev_id)
-{
-    if(dev_id >= processors::vcn_device_level_only.size()) return false;
-    return processors::vcn_device_level_only[dev_id];
-}
-
-bool
-jpeg_is_device_level_only(std::uint32_t dev_id)
-{
-    if(dev_id >= processors::jpeg_device_level_only.size()) return false;
-    return processors::jpeg_device_level_only[dev_id];
-}
-
-bool
-is_vcn_busy_supported(std::uint32_t dev_id)
-{
-    if(dev_id >= processors::vcn_busy_supported.size()) return false;
-    return processors::vcn_busy_supported[dev_id];
-}
-
-bool
-is_jpeg_busy_supported(std::uint32_t dev_id)
-{
-    if(dev_id >= processors::jpeg_busy_supported.size()) return false;
-    return processors::jpeg_busy_supported[dev_id];
-}
-
-bool
-is_xgmi_supported(std::uint32_t dev_id)
-{
-    if(dev_id >= processors::xgmi_supported.size()) return false;
-    return processors::xgmi_supported[dev_id];
-}
-
-bool
-is_pcie_supported(std::uint32_t dev_id)
-{
-    if(dev_id >= processors::pcie_supported.size()) return false;
-    return processors::pcie_supported[dev_id];
-}
-
-std::uint32_t
-get_processor_count()
-{
-    return processors::total_processor_count;
-}
-
-amdsmi_processor_handle
-get_handle_from_id(std::uint32_t dev_id)
-{
-    return processors::processors_list[dev_id];
 }
 
 }  // namespace gpu

--- a/projects/rocprofiler-systems/source/lib/core/gpu.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/gpu.hpp
@@ -3,74 +3,14 @@
 
 #pragma once
 
-#include <amd_smi/amdsmi.h>
 #include <cstdint>
 
 namespace rocprofsys
 {
 namespace gpu
 {
-void
-get_processor_handles();
-
-std::uint32_t
-get_processor_count();
-
-amdsmi_processor_handle
-get_handle_from_id(std::uint32_t dev_id);
-
-bool
-vcn_is_device_level_only(std::uint32_t dev_id);
-
-bool
-jpeg_is_device_level_only(std::uint32_t dev_id);
-
-bool
-is_vcn_busy_supported(std::uint32_t dev_id);
-
-bool
-is_jpeg_busy_supported(std::uint32_t dev_id);
-
-bool
-is_xgmi_supported(std::uint32_t dev_id);
-
-bool
-is_pcie_supported(std::uint32_t dev_id);
-
-struct processors
-{
-    static std::uint32_t                        total_processor_count;
-    static std::vector<amdsmi_processor_handle> processors_list;
-    static std::vector<bool>                    vcn_device_level_only;
-    static std::vector<bool>                    jpeg_device_level_only;
-    static std::vector<bool>                    vcn_busy_supported;
-    static std::vector<bool>                    jpeg_busy_supported;
-    static std::vector<bool>                    xgmi_supported;
-    static std::vector<bool>                    pcie_supported;
-    static std::uint32_t                        total_ainic_count;
-    static std::vector<amdsmi_processor_handle> ainic_list;
-
-private:
-    friend void                    rocprofsys::gpu::get_processor_handles();
-    friend std::uint32_t           rocprofsys::gpu::get_processor_count();
-    friend amdsmi_processor_handle rocprofsys::gpu::get_handle_from_id(
-        std::uint32_t dev_id);
-    friend bool rocprofsys::gpu::vcn_is_device_level_only(std::uint32_t dev_id);
-    friend bool rocprofsys::gpu::jpeg_is_device_level_only(std::uint32_t dev_id);
-    friend bool rocprofsys::gpu::is_vcn_busy_supported(std::uint32_t dev_id);
-    friend bool rocprofsys::gpu::is_jpeg_busy_supported(std::uint32_t dev_id);
-    friend bool rocprofsys::gpu::is_xgmi_supported(std::uint32_t dev_id);
-    friend bool rocprofsys::gpu::is_pcie_supported(std::uint32_t dev_id);
-};
-
 int
 device_count();
-
-bool
-initialize_amdsmi();
-
-bool
-reinitialize_amdsmi();
 
 void
 add_device_metadata();

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/gpu/device.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/gpu/device.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "core/amd_smi_probe.hpp"
 #include "library/pmc/collectors/gpu/types.hpp"
 #include "logger/debug.hpp"
 
@@ -182,95 +183,63 @@ private:
 
     bool initialize_supported_metrics()
     {
+        static_assert(sizeof(enabled_metrics) ==
+                          sizeof(::rocprofsys::amd_smi::metric_availability),
+                      "enabled_metrics and metric_availability must match");
+
+        bool memory_supported = false;
         try
         {
             const auto usage = m_driver->get_memory_usage();
-            m_supported_metrics.bits.memory_usage =
-                is_metric_supported(usage, METRIC_VALUE_NOT_SUPPORTED_64) ? 1 : 0;
+            memory_supported = is_metric_supported(usage, METRIC_VALUE_NOT_SUPPORTED_64);
         } catch(const std::runtime_error&)
         {
-            m_supported_metrics.bits.memory_usage = 0;
+            memory_supported = false;
         }
 
-        metrics raw{};
+        ::rocprofsys::amd_smi::probe_input input{};
         try
         {
-            raw = m_driver->get_gpu_metrics();
+            const auto raw             = m_driver->get_gpu_metrics();
+            input.current_socket_power = raw.current_socket_power;
+            input.average_socket_power = raw.average_socket_power;
+            input.hotspot_temperature  = raw.hotspot_temperature;
+            input.edge_temperature     = raw.edge_temperature;
+            input.gfx_activity         = raw.gfx_activity;
+            input.umc_activity         = raw.umc_activity;
+            input.mm_activity          = raw.mm_activity;
+            input.gfx_clock_mhz        = raw.gfx_clock_mhz;
+            input.mem_clock_mhz        = raw.mem_clock_mhz;
+            input.vcn_activity         = raw.vcn_activity;
+            input.jpeg_activity        = raw.jpeg_activity;
+            for(std::size_t xcp = 0; xcp < MAX_NUM_XCP; ++xcp)
+            {
+                input.xcp_stats[xcp].vcn_busy  = raw.xcp_stats[xcp].vcn_busy;
+                input.xcp_stats[xcp].jpeg_busy = raw.xcp_stats[xcp].jpeg_busy;
+            }
+            input.xgmi.width          = raw.xgmi.link.width;
+            input.xgmi.speed          = raw.xgmi.link.speed;
+            input.xgmi.data_acc.read  = raw.xgmi.data_acc.read;
+            input.xgmi.data_acc.write = raw.xgmi.data_acc.write;
+            input.pcie.width          = raw.pcie.link.width;
+            input.pcie.speed          = raw.pcie.link.speed;
+            input.pcie.bandwidth.acc  = raw.pcie.bandwidth.acc;
+            input.pcie.bandwidth.inst = raw.pcie.bandwidth.inst;
         } catch(const std::runtime_error&)
         {
+            m_supported_metrics.value = memory_supported ? (1u << 2) : 0;
             return m_supported_metrics.value != 0;
         }
 
-        m_supported_metrics.bits.current_socket_power =
-            is_metric_supported(raw.current_socket_power, METRIC_VALUE_NOT_SUPPORTED_16);
-        m_supported_metrics.bits.average_socket_power =
-            is_metric_supported(raw.average_socket_power, METRIC_VALUE_NOT_SUPPORTED_16);
-        m_supported_metrics.bits.hotspot_temperature =
-            is_metric_supported(raw.hotspot_temperature, METRIC_VALUE_NOT_SUPPORTED_16);
-        m_supported_metrics.bits.edge_temperature =
-            is_metric_supported(raw.edge_temperature, METRIC_VALUE_NOT_SUPPORTED_16);
-        m_supported_metrics.bits.gfx_activity =
-            is_metric_supported(raw.gfx_activity, METRIC_VALUE_NOT_SUPPORTED_16);
-        m_supported_metrics.bits.umc_activity =
-            is_metric_supported(raw.umc_activity, METRIC_VALUE_NOT_SUPPORTED_16);
-        m_supported_metrics.bits.mm_activity =
-            is_metric_supported(raw.mm_activity, METRIC_VALUE_NOT_SUPPORTED_16);
-
-        m_supported_metrics.bits.vcn_busy =
-            std::any_of(raw.xcp_stats.begin(), raw.xcp_stats.end(),
-                        [](const metrics::xcp_metrics& xcp) {
-                            return std::any_of(xcp.vcn_busy.begin(), xcp.vcn_busy.end(),
-                                               [](std::uint16_t val) {
-                                                   return is_metric_supported(val);
-                                               });
-                        });
-
-        m_supported_metrics.bits.jpeg_busy =
-            std::any_of(raw.xcp_stats.begin(), raw.xcp_stats.end(),
-                        [](const metrics::xcp_metrics& xcp) {
-                            return std::any_of(xcp.jpeg_busy.begin(), xcp.jpeg_busy.end(),
-                                               [](std::uint16_t val) {
-                                                   return is_metric_supported(val);
-                                               });
-                        });
-
-        m_supported_metrics.bits.vcn_activity =
-            !m_supported_metrics.bits.vcn_busy &&
-            std::any_of(raw.vcn_activity.begin(), raw.vcn_activity.end(),
-                        [](std::uint16_t val) { return is_metric_supported(val); });
-
-        m_supported_metrics.bits.jpeg_activity =
-            !m_supported_metrics.bits.jpeg_busy &&
-            std::any_of(raw.jpeg_activity.begin(), raw.jpeg_activity.end(),
-                        [](std::uint16_t val) { return is_metric_supported(val); });
-
-        m_supported_metrics.bits.xgmi =
-            is_metric_supported(raw.xgmi.link.width) ||
-            is_metric_supported(raw.xgmi.link.speed) ||
-            std::any_of(raw.xgmi.data_acc.read.begin(), raw.xgmi.data_acc.read.end(),
-                        [](std::uint64_t val) { return is_metric_supported(val); });
-
-        m_supported_metrics.bits.pcie = is_metric_supported(raw.pcie.link.width) ||
-                                        is_metric_supported(raw.pcie.link.speed) ||
-                                        is_metric_supported(raw.pcie.bandwidth.acc) ||
-                                        is_metric_supported(raw.pcie.bandwidth.inst);
-
-        m_supported_metrics.bits.gfx_clock =
-            is_metric_supported(raw.gfx_clock_mhz, METRIC_VALUE_NOT_SUPPORTED_16);
-        m_supported_metrics.bits.mem_clock =
-            is_metric_supported(raw.mem_clock_mhz, METRIC_VALUE_NOT_SUPPORTED_16);
-
-        initialize_sdma_support();
+        const bool sdma_supported = m_driver->is_sdma_supported();
+        m_supported_metrics.value = ::rocprofsys::amd_smi::compute_availability(
+                                        input, memory_supported, sdma_supported)
+                                        .value;
 
         LOG_DEBUG("Device [{}] supported metrics: {}", m_index,
                   format_supported_metrics(m_supported_metrics));
 
         return m_supported_metrics.value != 0;
-    }
-
-    void initialize_sdma_support()
-    {
-        m_supported_metrics.bits.sdma_usage = m_driver->is_sdma_supported() ? 1 : 0;
     }
 
     void collect_sdma_metrics([[maybe_unused]] const enabled_metrics& enabled_cfg,


### PR DESCRIPTION
## Motivation

Today, AMD SMI metric availability is inferred indirectly (static settings text). This adds `rocprof-sys-avail -m` or `rocprof-sys-avail --smi-metrics` to live-probe the same AMD SMI APIs the PMC GPU collector uses, so users and tests can see per-GPU, per-metric support.

## Technical Details

- Add `-m` / `--smi-metrics` to `rocprof-sys-avail`, modeled on `-H` hw counters (table with METRIC, DEVICE, AVAILABLE, optional SUMMARY/CATEGORY via -d).
- Introduce core/amd_smi live probe: `probe_devices()`, `compute_availability()`, `format_avail_entries()`, and `build_metric_entries()` using `amdsmi_get_gpu_metrics_info`, `amdsmi_get_gpu_memory_usage`, and SDMA process-list APIs.
- Add `amd_smi_probe.hpp` with shared types (`probe_input`, `metric_availability`, `metric_entry`) so PMC tests and avail can use probe logic without pulling in full AMD SMI headers.
- Refactor PMC GPU collector `initialize_supported_metrics()` to call shared `amd_smi::compute_availability()` instead of duplicating sentinel/availability checks inline.
- Remove AMD SMI enumeration/coarse flags from `gpu.cpp`; drive ROCPROFSYS_AMD_SMI_METRICS setting description from live probe instead of static `gpu::is_*_supported()` heuristics.
- Register `smi_metrics::GPU` category prefix and include SMI metrics in `-a / --all` when AMD SMI is enabled.
- Memory and SDMA remain separate API probes (passed as flags to `compute_availability()`), matching existing collector behavior.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
