### PR TITLE
rocr: Fix missing sys/scope fields in 64-bit SDMA poll/fence commands

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
@@ -2285,7 +2285,11 @@ void BlitSdma<useGCR, scopeFields>::BuildPoll64bCommand(char* cmd_addr, void* ad
   pkt->MASK_LO_UNION.mask_31_0 = 0xffffffff;
   pkt->MASK_HI_UNION.mask_63_32 = 0xffffffff;
 
+  pkt->HEADER_UNION.sys = 1;  // Address is in system memory.
   pkt->DW7_UNION.retry_count = 0;  // Infinite retry
+
+  if (scopeFields)
+    pkt->DW7_UNION.scope = SDMA_MEMORY_SCOPE_SYS;
 }
 
 template <bool useGCR, bool scopeFields>
@@ -2299,6 +2303,11 @@ void BlitSdma<useGCR, scopeFields>::BuildFence64bCommand(char* cmd_addr, void* f
   pkt->HEADER_UNION.op = SDMA_OP_FENCE;
   pkt->HEADER_UNION.sub_op = SDMA_SUBOP_FENCE_64B;
   pkt->HEADER_UNION.mtype = 3;
+  // Signal memory is in system memory.
+  pkt->HEADER_UNION.sys = 1;
+
+  if (scopeFields)
+    pkt->HEADER_UNION.scope = SDMA_MEMORY_SCOPE_SYS;
 
   pkt->ADDR_LO_UNION.addr_31_3 = ptrlow32(fence_addr) >> 3;
   pkt->ADDR_HI_UNION.addr_63_32 = ptrhigh32(fence_addr);


### PR DESCRIPTION
The 64-bit poll and fence commands (SDMA_PKT_POLL_MEM_64B_GFX1250, SDMA_PKT_FENCE_64B_GFX1250) for GFX12.5/12.6 are missing critical memory access configuration fields, causing SDMA page faults at address 0x0 during H2D copies >= 32KB.

Root cause:
1. BuildFence64bCommand() does not set the 'sys' field. Without sys=1, SDMA treats the target address as GPU local memory instead of system memory, causing address translation failure.
2. Both BuildFence64bCommand() and BuildPoll64bCommand() do not set the 'scope' field. The 32-bit equivalents set scope=SDMA_MEMORY_SCOPE_SYS when scopeFields template parameter is true.

Fix:
- Set sys=1 in both BuildFence64bCommand() and BuildPoll64bCommand() to indicate system memory address space.
- Set scope=SDMA_MEMORY_SCOPE_SYS when scopeFields is true, consistent with the 32-bit command implementations.

Change-Id: I0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
