### PR TITLE
[rocprofiler-compute] Add method-aware --pc-sampling-interval default

### DIFF
--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -44,6 +44,8 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 * PC sampling analysis without `-k` now shows the full per-instruction table across all kernels (with a `Kernel_Name` column), identical in schema to the single-kernel view, instead of a collapsed source-line summary.
 
+* `--pc-sampling-interval` now defaults to a method-appropriate value (512 microseconds for `host_trap`, 1048576 cycles for `stochastic`). Stochastic intervals are validated to be a power of 2 and at least 65536; previously invalid values were passed through silently.
+
 ### Removed
 
 * ``--path`` and ``--subpath`` options have been removed from profile mode. Use ``--output-directory`` instead.

--- a/projects/rocprofiler-compute/docs/how-to/pc_sampling.rst
+++ b/projects/rocprofiler-compute/docs/how-to/pc_sampling.rst
@@ -28,7 +28,7 @@ Profiling options
 For using profiling options for PC sampling the configuration needed are:
 
 * ``--pc-sampling-method``: Should be either ``stochastic`` or ``host_trap``, (DEFAULT: stochastic)
-* ``--pc-sampling-interval``: For ``stochastic`` sampling, the interval is in cycles; it must be a power of 2 and at least 65536 (DEFAULT: 1048576). For ``host_trap`` sampling, the interval is in microseconds and may be any positive integer (DEFAULT: 512). When omitted, the method-appropriate default is used.
+* ``--pc-sampling-interval``: For ``stochastic`` sampling, the interval is in cycles; it must be a power of 2 and at least 65536 (DEFAULT: 1048576). These are hardware limits reported by the driver. For ``host_trap`` sampling, the interval is in microseconds and may be any positive integer (DEFAULT: 512). When omitted, the method-appropriate default is used.
 
 **Sample command:**
 

--- a/projects/rocprofiler-compute/docs/how-to/pc_sampling.rst
+++ b/projects/rocprofiler-compute/docs/how-to/pc_sampling.rst
@@ -28,13 +28,13 @@ Profiling options
 For using profiling options for PC sampling the configuration needed are:
 
 * ``--pc-sampling-method``: Should be either ``stochastic`` or ``host_trap``, (DEFAULT: stochastic)
-* ``--pc-sampling-interval``: For stochastic sampling, the interval is in cycles. The finest granularity is 1 cycle. For ``host_trap`` sampling, the interval is in microsecond (DEFAULT: 1048576). The interval should be the power of 2. You are recommended try starting from 1048576, and lowering until reaching 65536.
+* ``--pc-sampling-interval``: For ``stochastic`` sampling, the interval is in cycles; it must be a power of 2 and at least 65536 (DEFAULT: 1048576). For ``host_trap`` sampling, the interval is in microseconds and may be any positive integer (DEFAULT: 512). When omitted, the method-appropriate default is used.
 
 **Sample command:**
 
 .. code-block:: shell
 
-   $ rocprof-compute profile -n pc_test --no-roof --experimental --pc-sampling --pc-sampling-method stochastic --pc-sampling-interval 1048576 -VVV -- target_app
+   $ rocprof-compute profile -n pc_test --experimental --pc-sampling --no-roof --pc-sampling-method stochastic -VVV -- target_app
 
 Analysis options
 ================

--- a/projects/rocprofiler-compute/docs/how-to/pc_sampling.rst
+++ b/projects/rocprofiler-compute/docs/how-to/pc_sampling.rst
@@ -34,7 +34,7 @@ For using profiling options for PC sampling the configuration needed are:
 
 .. code-block:: shell
 
-   $ rocprof-compute profile -n pc_test --experimental --pc-sampling --no-roof --pc-sampling-method stochastic -VVV -- target_app
+   $ rocprof-compute profile -n pc_test --no-roof --experimental --pc-sampling --pc-sampling-method stochastic -VVV -- target_app
 
 Analysis options
 ================

--- a/projects/rocprofiler-compute/src/argparser.py
+++ b/projects/rocprofiler-compute/src/argparser.py
@@ -588,16 +588,18 @@ Examples:
         required=False,
         metavar="",
         dest="pc_sampling_interval",
-        default=1048576,
+        default=None,
+        type=int,
         base_action="store",
         action=ExperimentalAction,
         experimental_enabled=experimental_enabled,
         feature_label="PC Sampling",
         help=(
             "\t\t\tSet the interval of pc sampling.\n"
-            "\t\t\t  For stochastic sampling, the interval is in cycles.\n"
-            "\t\t\t  For host_trap sampling, the interval is in microsecond "
-            "(DEFAULT: 1048576)."
+            "\t\t\t  For stochastic sampling, the interval is in cycles; it "
+            "must be a power of 2 and at least 65536 (DEFAULT: 1048576).\n"
+            "\t\t\t  For host_trap sampling, the interval is in microseconds "
+            "(DEFAULT: 512)."
         ),
     )
 

--- a/projects/rocprofiler-compute/src/argparser.py
+++ b/projects/rocprofiler-compute/src/argparser.py
@@ -574,6 +574,7 @@ Examples:
         metavar="",
         dest="pc_sampling_method",
         default="stochastic",
+        choices=["stochastic", "host_trap"],
         base_action="store",
         action=ExperimentalAction,
         experimental_enabled=experimental_enabled,

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -635,21 +635,25 @@ class RocProfCompute:
         if not getattr(args, "pc_sampling", False):
             return
 
-        interval_defaults = {"stochastic": 1048576, "host_trap": 512}
-        stochastic_min_interval = 65536
+        stochastic_default_interval_in_cycles = 1048576
+        stochastic_min_interval_in_cycles = 65536
+        host_trap_default_interval_in_microseconds = 512
 
         method = args.pc_sampling_method
         if args.pc_sampling_interval is None:
-            args.pc_sampling_interval = interval_defaults[method]
+            if method == "stochastic":
+                args.pc_sampling_interval = stochastic_default_interval_in_cycles
+            else:
+                args.pc_sampling_interval = host_trap_default_interval_in_microseconds
             return
 
         interval = args.pc_sampling_interval
         if method == "stochastic":
             is_power_of_two = interval > 0 and interval & (interval - 1) == 0
-            if not is_power_of_two or interval < stochastic_min_interval:
+            if not is_power_of_two or interval < stochastic_min_interval_in_cycles:
                 console_error(
                     "--pc-sampling-interval for stochastic sampling must be a "
-                    f"power of 2 and at least {stochastic_min_interval} "
+                    f"power of 2 and at least {stochastic_min_interval_in_cycles} "
                     f"(got {interval})."
                 )
         elif interval <= 0:

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -193,6 +193,7 @@ class RocProfCompute:
 
         if self.__mode == "profile":
             self._validate_profile_mode_arguments()
+            self._resolve_pc_sampling_interval()
 
         # fallback to csv output format, if rocpd public api not available
         if self.__mode == "profile" and self.__args.format_rocprof_output == "rocpd":
@@ -626,6 +627,36 @@ class RocProfCompute:
 
         if getattr(args, "bench_only", False) and getattr(args, "no_roof", False):
             console_error("--bench-only cannot be used with --no-roof.")
+
+    def _resolve_pc_sampling_interval(self) -> None:
+        """Apply the method-aware default for --pc-sampling-interval and
+        validate a user-supplied value."""
+        args = self.__args
+        if not getattr(args, "pc_sampling", False):
+            return
+
+        interval_defaults = {"stochastic": 1048576, "host_trap": 512}
+        stochastic_min_interval = 65536
+
+        method = args.pc_sampling_method
+        if args.pc_sampling_interval is None:
+            args.pc_sampling_interval = interval_defaults[method]
+            return
+
+        interval = args.pc_sampling_interval
+        if method == "stochastic":
+            is_power_of_two = interval > 0 and interval & (interval - 1) == 0
+            if not is_power_of_two or interval < stochastic_min_interval:
+                console_error(
+                    "--pc-sampling-interval for stochastic sampling must be a "
+                    f"power of 2 and at least {stochastic_min_interval} "
+                    f"(got {interval})."
+                )
+        elif interval <= 0:
+            console_error(
+                "--pc-sampling-interval for host_trap sampling must be a "
+                f"positive integer (got {interval})."
+            )
 
     def _validate_list_option_exclusions(self) -> None:
         """Validate that list/discovery options aren't combined with --block.

--- a/projects/rocprofiler-compute/tests/test_pc_sampling.py
+++ b/projects/rocprofiler-compute/tests/test_pc_sampling.py
@@ -55,8 +55,6 @@ def test_pc_sampling_host_trap(binary_handler_profile_rocprof_compute, monkeypat
         "21",
         "--pc-sampling-method",
         "host_trap",
-        "--pc-sampling-interval",
-        "256",
     ]
 
     workload_dir = common.get_output_dir()
@@ -182,8 +180,6 @@ def test_multi_rank_warning_pc_sampling_with_counters(
         "2",
         "--pc-sampling-method",
         "host_trap",
-        "--pc-sampling-interval",
-        "256",
     ]
 
     _, stdout, stderr = binary_handler_profile_rocprof_compute(
@@ -317,8 +313,6 @@ def test_pc_sampling_with_sol_block(
         "2",
         "--pc-sampling-method",
         "host_trap",
-        "--pc-sampling-interval",
-        "256",
     ]
 
     workload_dir = common.get_output_dir()

--- a/projects/rocprofiler-compute/tests/test_pc_sampling.py
+++ b/projects/rocprofiler-compute/tests/test_pc_sampling.py
@@ -94,8 +94,6 @@ def test_pc_sampling_stochastic(binary_handler_profile_rocprof_compute, monkeypa
         "21",
         "--pc-sampling-method",
         "stochastic",
-        "--pc-sampling-interval",
-        "1048576",
     ]
 
     workload_dir = common.get_output_dir()
@@ -141,8 +139,6 @@ def test_multi_rank_pc_sampling_only(
         "21",
         "--pc-sampling-method",
         "host_trap",
-        "--pc-sampling-interval",
-        "256",
     ]
 
     _, stdout, stderr = binary_handler_profile_rocprof_compute(
@@ -231,8 +227,6 @@ def test_pc_sampling_profile_then_analyze(
         "21",
         "--pc-sampling-method",
         "host_trap",
-        "--pc-sampling-interval",
-        "256",
     ]
 
     workload_dir = common.get_output_dir()

--- a/projects/rocprofiler-compute/tests/test_profiler_base.py
+++ b/projects/rocprofiler-compute/tests/test_profiler_base.py
@@ -306,6 +306,8 @@ def _make_rpc_args(
     filter_blocks=None,
     filter_metrics=None,
     pc_sampling=False,
+    pc_sampling_method="stochastic",
+    pc_sampling_interval=None,
     membw_analysis=False,
     experimental=False,
     mode="profile",
@@ -321,6 +323,8 @@ def _make_rpc_args(
         filter_blocks=filter_blocks,
         filter_metrics=filter_metrics,
         pc_sampling=pc_sampling,
+        pc_sampling_method=pc_sampling_method,
+        pc_sampling_interval=pc_sampling_interval,
         membw_analysis=membw_analysis,
         experimental=experimental,
         set_selected=None,
@@ -538,3 +542,34 @@ def test_run_profiling_pc_sampling_gating(
         for call in mock_warning.call_args_list
     )
     assert multirank_warned is expect_multirank_warning
+
+
+@pytest.mark.parametrize(
+    "method, interval, expect_error, expected_interval",
+    [
+        pytest.param("host_trap", None, False, 512, id="host_trap_unset_default"),
+        pytest.param("stochastic", None, False, 1048576, id="stochastic_unset_default"),
+        pytest.param("stochastic", 65536, False, 65536, id="stochastic_min_accepted"),
+        pytest.param("stochastic", 12345, True, None, id="stochastic_not_pow2"),
+        pytest.param("stochastic", 32768, True, None, id="stochastic_below_min"),
+        pytest.param("host_trap", 100, False, 100, id="host_trap_positive_accepted"),
+    ],
+)
+def test_sanitize_pc_sampling_interval(
+    method, interval, expect_error, expected_interval
+):
+    """Unit test: --pc-sampling-interval default and stochastic validation."""
+    args = _make_rpc_args(
+        pc_sampling=True,
+        experimental=True,
+        filter_blocks=[],
+        pc_sampling_method=method,
+        pc_sampling_interval=interval,
+    )
+    instance = _make_rpc_with_args(args)
+    if expect_error:
+        with pytest.raises(SystemExit):
+            instance.sanitize()
+    else:
+        instance.sanitize()
+        assert args.pc_sampling_interval == expected_interval

--- a/projects/rocprofiler-compute/tests/test_profiler_base.py
+++ b/projects/rocprofiler-compute/tests/test_profiler_base.py
@@ -553,6 +553,8 @@ def test_run_profiling_pc_sampling_gating(
         pytest.param("stochastic", 12345, True, None, id="stochastic_not_pow2"),
         pytest.param("stochastic", 32768, True, None, id="stochastic_below_min"),
         pytest.param("host_trap", 100, False, 100, id="host_trap_positive_accepted"),
+        pytest.param("host_trap", 0, True, None, id="host_trap_zero_rejected"),
+        pytest.param("host_trap", -1, True, None, id="host_trap_negative_rejected"),
     ],
 )
 def test_sanitize_pc_sampling_interval(


### PR DESCRIPTION
## Motivation

`--pc-sampling-interval` previously defaulted to `1048576` for both
sampling methods. That value suits `stochastic` (cycles) but is far too
large for `host_trap` (microseconds), making the default profiling run
ineffective. This makes the default method-aware and validates
user-supplied values.

Stacked on #6890; the base of this PR is that branch, not
`rocprofiler-compute-develop`. Retarget once #6890 merges.

## Technical Details

- `--pc-sampling-interval` defaults to `None` in argparse and resolves in
  `sanitize()` to a method-appropriate value: 512 microseconds for
  `host_trap`, 1048576 cycles for `stochastic`, so every downstream
  consumer reads the concrete value.
- Bugfix: stochastic intervals are validated to be a power of 2 and at
  least 65536, and host_trap intervals to be positive; invalid values now
  raise a clear error instead of being passed through silently.
- `type=int` on the argument rejects non-integer input at parse time.

## JIRA ID

AIPROFCOMP-605

## Test Plan

- `pytest tests/test_profiler_base.py`
- Smoke: `rocprof-compute profile --experimental --pc-sampling
  --pc-sampling-method host_trap ... -- app` records a 512 us interval;
  `--pc-sampling-method stochastic --pc-sampling-interval 12345` is
  rejected.

## Test Result

- [x] `ruff check` / `ruff format --check` clean
- [x] `pytest tests/test_profiler_base.py`: 37 passed
- [ ] GPU-dependent PC sampling profile tests left to CI

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.