### PR TITLE
[hipfile] Add include guard to CMake files

### DIFF
--- a/projects/hipfile/cmake/AISClangSafeBuffers.cmake
+++ b/projects/hipfile/cmake/AISClangSafeBuffers.cmake
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+include_guard(GLOBAL)
+
 #-----------------------------------------------------------------------------
 # Warn about unsafe buffer operations (llvm C++ only)
 #

--- a/projects/hipfile/cmake/AISClangTidy.cmake
+++ b/projects/hipfile/cmake/AISClangTidy.cmake
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+include_guard(GLOBAL)
+
 #-----------------------------------------------------------------------------
 # Option to use the clang-tidy tool
 #

--- a/projects/hipfile/cmake/AISDocumentation.cmake
+++ b/projects/hipfile/cmake/AISDocumentation.cmake
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+include_guard(GLOBAL)
+
 #-----------------------------------------------------------------------------
 # Option to build the hipFile API documentation
 #-----------------------------------------------------------------------------

--- a/projects/hipfile/cmake/AISIWYU.cmake
+++ b/projects/hipfile/cmake/AISIWYU.cmake
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+include_guard(GLOBAL)
+
 #-----------------------------------------------------------------------------
 # Option to use the include-what-you-use tool
 #

--- a/projects/hipfile/cmake/AISInstall.cmake
+++ b/projects/hipfile/cmake/AISInstall.cmake
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+include_guard(GLOBAL)
+
 # Install hipFile
 
 # From the rocm-cmake repo

--- a/projects/hipfile/cmake/AISSanitizers.cmake
+++ b/projects/hipfile/cmake/AISSanitizers.cmake
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+include_guard(GLOBAL)
+
 option(AIS_USE_SANITIZERS "Build with sanitizers (clang only - see docs for a list)" OFF)
 option(AIS_USE_THREAD_SANITIZER "Build with -fsanitize=thread (clang only - not compatible with AIS_USE_SANITIZERS)" OFF)
 

--- a/projects/hipfile/cmake/AISUseTBB.cmake
+++ b/projects/hipfile/cmake/AISUseTBB.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
 #
 # SPDX-License-Identifier: MIT
-#
+
 include(AISSanitizers)
 include(FetchContent)
 


### PR DESCRIPTION
## Motivation

Some of our CMake files are being included multiple times, generating multiple log messages.

## Technical Details

Add `include_guard(GLOBAL)` to the following files:

* AISClangSafeBuffers.cmake
* AISClangTidy.cmake
* AISDocumentation.cmake
* AISIWYU.cmake
* AISInstall.cmake
* AISSanitizers.cmake

The change to AISUseTBB.cmake is just comment cleanup

## JIRA ID

N/A

## Test Plan

Make sure the features still configure properly (manually)

## Test Result

Success

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
