### PR TITLE
[AMD-SMI] Skip ESMI init when CPUID core capacity exceeds online cores

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -41,6 +41,10 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 ### Resolved Issues
 
+- **Fixed `amd-smi` crashing (`SIGSEGV`) at startup on certain CPUs when the reported per-socket core capacity exceeds the number of online cores**.  
+  - For CPU family `0x1A` models `0x00`-`0x1F` and `0x50`-`0x5F`, the esmi library reads the per-socket core capacity from CPUID `0x80000008` and derives the socket count as `total_sockets = online_cpus / cores_per_socket`. When fewer cores are online than the reported capacity, this division truncates to `0`, after which esmi performs a zero-size allocation for its socket map and writes past it - crashing inside `esmi_init()`. Because the crash is a native `SIGSEGV` it could not be caught by the CLI, taking down GPU and NIC functionality with it.
+  - The CLI now reproduces the same socket-count computation before enabling CPU/ESMI initialization and skips it when the result would be `0`, so GPU and NIC discovery proceed normally. All other CPUs - and any CPUID read failure - are treated as safe and initialize unchanged.
+
 - **Fixed AMD GPU manufacturer name display in `amd-smi static --board`**.  
   - The CLI now displays the canonical vendor name `Advanced Micro Devices, Inc. [AMD/ATI]` when the board manufacturer name is reported as the raw AMD PCI vendor ID (`0x1002`) because the host `pci.ids` lookup is unavailable. The C and Python APIs continue to return the raw value unchanged.
   - Standardized the hardcoded AMD vendor string on the canonical `pci.ids` spelling (with the comma) so `VENDOR_NAME` and `MANUFACTURER_NAME` are consistent with `lspci`.

--- a/projects/amdsmi/amdsmi_cli/amdsmi_init.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_init.py
@@ -24,6 +24,7 @@
 import atexit
 import logging
 import signal
+import struct
 import sys
 import os
 import threading
@@ -93,6 +94,43 @@ def check_amd_ionic_driver():
     return False
 
 
+def _check_esmi_safe():
+    """Returns False when esmi_init() is predicted to crash, True otherwise.
+
+    For CPU family 0x1A models 0x00-0x1F and 0x50-0x5F, the esmi library reads
+    the per-socket core capacity from CPUID 0x80000008 and derives the socket
+    count as ``total_sockets = online_cpus // cores_per_socket``. When the
+    number of online cores is smaller than that reported capacity the division
+    truncates to 0, after which esmi performs a zero-size allocation for its
+    socket map and writes past it - crashing with a SIGSEGV inside esmi_init().
+    Native crashes cannot be caught by a Python try/except, so this reproduces
+    the same computation up front and lets the caller skip CPU init when it
+    would divide to zero.
+
+    The CPUID 0x80000008 capacity field is only read for the family/model above
+    (see ``detect_packages()`` in esmi_ib_library/src/e_smi.c); every other CPU,
+    and any read/parse failure, returns True (treat as safe and let the normal
+    init path proceed).
+    """
+    try:
+        fd = os.open("/dev/cpu/0/cpuid", os.O_RDONLY)
+        try:
+            os.lseek(fd, 0x1, os.SEEK_SET)
+            eax = struct.unpack("IIII", os.read(fd, 16))[0]
+            family = ((eax >> 8) & 0xF) + ((eax >> 20) & 0xFF)
+            model = ((eax >> 16) & 0xF) * 0x10 + ((eax >> 4) & 0xF)
+            if family != 0x1A or not (0x00 <= model <= 0x1F or 0x50 <= model <= 0x5F):
+                return True
+            os.lseek(fd, 0x80000008, os.SEEK_SET)
+            ecx = struct.unpack("IIII", os.read(fd, 16))[2]
+        finally:
+            os.close(fd)
+        cores_per_socket = (ecx & 0xFFF) + 1
+        return (os.cpu_count() or 1) >= cores_per_socket
+    except Exception:
+        return True
+
+
 def amdsmi_cli_init():
     """Initializes AMDSMI Library for the CLI
 
@@ -117,8 +155,10 @@ def amdsmi_cli_init():
         logging.debug("amdgpu driver's initstate is live")
     if cpu_init_disabled:
         logging.debug("CPU/ESMI init disabled via AMDSMI_DISABLE_CPU_INIT")
-    elif check_amd_hsmp_driver() and hasattr(
-        amdsmi_interface.amdsmi_wrapper, "amdsmi_get_cpu_handles"
+    elif (
+        check_amd_hsmp_driver()
+        and hasattr(amdsmi_interface.amdsmi_wrapper, "amdsmi_get_cpu_handles")
+        and _check_esmi_safe()
     ):
         init_flag |= amdsmi_interface.AmdSmiInitFlags.INIT_AMD_CPUS
         logging.debug("hsmp driver's initstate is live")

--- a/projects/amdsmi/tests/python_unittest/esmi_safe_init_test.py
+++ b/projects/amdsmi/tests/python_unittest/esmi_safe_init_test.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) Advanced Micro Devices. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""Unit tests for the ESMI core-count safety pre-check in amdsmi_init.
+
+``amdsmi_init._check_esmi_safe()`` reproduces the socket-count computation the
+esmi library performs for CPU family 0x1A models 0x00-0x1F and 0x50-0x5F: it
+divides the number of online cores by the per-socket core capacity reported by
+CPUID 0x80000008. When the online core count is below that capacity the division
+truncates to zero, which leads esmi to a zero-size allocation and a SIGSEGV.
+These tests mock ``/dev/cpu/0/cpuid`` so the prediction logic can be exercised
+deterministically without that hardware.
+"""
+
+import os
+import struct
+import sys
+import unittest
+from unittest import mock
+
+# Resolve the amdsmi_cli and py-interface dirs relative to this test file so the
+# pure-Python init logic can be imported without GPU hardware.
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT = os.path.abspath(os.path.join(_THIS_DIR, "..", ".."))
+for _p in (os.path.join(_REPO_ROOT, "amdsmi_cli"), os.path.join(_REPO_ROOT, "py-interface")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import amdsmi_init
+
+
+def _pack_leaf(eax=0, ebx=0, ecx=0, edx=0):
+    return struct.pack("IIII", eax, ebx, ecx, edx)
+
+
+# Family 0x1A, model 0x10 - a family/model that esmi reads the CPUID 0x80000008
+# capacity field for. Encoded to satisfy esmi's own decode:
+#   family = ((eax >> 8) & 0xf) + ((eax >> 20) & 0xff)
+#   model  = ((eax >> 16) & 0xf) * 0x10 + ((eax >> 4) & 0xf)
+_AFFECTED_LEAF1_EAX = 0x00B10F00
+# Family 0x19, model 0x10 (a family that does NOT use the 0x80000008 path).
+_UNAFFECTED_LEAF1_EAX = 0x00A10F00
+
+
+class _FakeCpuid:
+    """Emulates /dev/cpu/0/cpuid: the file position selects the CPUID leaf."""
+
+    def __init__(self, leaves):
+        self._leaves = leaves
+        self._pos = 0
+
+    def open(self, path, flags):
+        return 7  # arbitrary sentinel fd
+
+    def lseek(self, fd, pos, whence):
+        self._pos = pos
+        return pos
+
+    def read(self, fd, n):
+        return self._leaves.get(self._pos, _pack_leaf())
+
+    def close(self, fd):
+        pass
+
+
+class TestCheckEsmiSafe(unittest.TestCase):
+    def _patch_cpuid(self, leaves, cpu_count):
+        fake = _FakeCpuid(leaves)
+        return mock.patch.multiple(
+            amdsmi_init.os,
+            open=fake.open,
+            lseek=fake.lseek,
+            read=fake.read,
+            close=fake.close,
+            cpu_count=lambda: cpu_count,
+        )
+
+    def test_capacity_exceeds_online_cores_is_unsafe(self):
+        # 288-core socket capacity, only 192 online -> esmi would divide to 0.
+        leaves = {
+            0x1: _pack_leaf(eax=_AFFECTED_LEAF1_EAX),
+            0x80000008: _pack_leaf(ecx=287),  # (287 & 0xFFF) + 1 == 288
+        }
+        with self._patch_cpuid(leaves, cpu_count=192):
+            self.assertFalse(amdsmi_init._check_esmi_safe())
+
+    def test_enough_online_cores_is_safe(self):
+        leaves = {0x1: _pack_leaf(eax=_AFFECTED_LEAF1_EAX), 0x80000008: _pack_leaf(ecx=287)}
+        with self._patch_cpuid(leaves, cpu_count=288):
+            self.assertTrue(amdsmi_init._check_esmi_safe())
+
+    def test_unaffected_family_is_always_safe(self):
+        # A family esmi does not read the capacity field for must not be gated by
+        # the 0x80000008 value even if it looks "too small"; esmi never takes
+        # that path here.
+        leaves = {0x1: _pack_leaf(eax=_UNAFFECTED_LEAF1_EAX), 0x80000008: _pack_leaf(ecx=287)}
+        with self._patch_cpuid(leaves, cpu_count=1):
+            self.assertTrue(amdsmi_init._check_esmi_safe())
+
+    def test_cpuid_read_failure_is_safe(self):
+        def _boom(path, flags):
+            raise OSError("no cpuid device")
+
+        with mock.patch.object(amdsmi_init.os, "open", _boom):
+            self.assertTrue(amdsmi_init._check_esmi_safe())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Motivation

On some systems `amd-smi` crashes with a native `SIGSEGV` at startup — taking down **every** invocation, including commands that don't touch the CPU, such as `amd-smi version`.

The crash originates in the esmi library's socket-count computation. For CPU family `0x1A` models `0x00`-`0x1F` and `0x50`-`0x5F`, esmi reads the per-socket core capacity from CPUID `0x80000008` and derives the socket count as `total_sockets = online_cpus / cores_per_socket`. When fewer cores are online than the reported capacity, this division truncates to `0`. esmi then performs a zero-size allocation for its socket map and writes past it while parsing `/proc/cpuinfo`, corrupting the heap and crashing inside `esmi_init()`. A Python `try`/`except` cannot catch a native segfault, and the existing 60s init timeout only guards against hangs, not crashes.

## Technical Details

- `amdsmi_cli_init()` now calls a new `_check_esmi_safe()` pre-check before enabling CPU/ESMI init. It reproduces the same socket-count computation esmi performs (reading the per-socket core capacity from CPUID `0x80000008` for the family/model esmi reads it for, and dividing the online core count by it) and drops the `INIT_AMD_CPUS` bit when the result would be `0`, so GPU and NIC discovery proceed normally instead of the whole CLI crashing.
- The CPUID `0x80000008` capacity is only read for the family/model esmi reads it for. Every other CPU — and any CPUID read/parse failure — is treated as safe, so all other systems initialize unchanged. The check is a single `/dev/cpu/0/cpuid` read with no forking.
- This is the CLI-side guard. The underlying root cause is also being addressed in the esmi library itself (returning cleanly when the socket count computes to `0`); once a fixed esmi is packaged, CPU init returns an error on these systems and the already-merged non-fatal ESMI handling skips CPU discovery gracefully.

## JIRA ID

<!-- N/A -->

## Test Plan

- New `tests/python_unittest/esmi_safe_init_test.py` mocks `/dev/cpu/0/cpuid` and asserts: a reported per-socket capacity larger than the online core count is flagged unsafe; enough online cores is safe; a family esmi does not read the capacity field for is always safe (not gated by that value); and a CPUID read failure is treated as safe.
- Verified the normal init path is unchanged on unaffected systems.
