### PR TITLE
[hipfile] Remove uint overflow from UBSAN checks

### DIFF
--- a/projects/hipfile/cmake/AISSanitizers.cmake
+++ b/projects/hipfile/cmake/AISSanitizers.cmake
@@ -27,12 +27,16 @@ function(ais_add_sanitizers target)
 
     if(AIS_USE_SANITIZERS)
         set(SANITIZER_LIST address,float-divide-by-zero,integer,leak,local-bounds,nullability,undefined,vptr)
+        # unsigned-integer-overflow is well-defined wrap-around in C++ (not UB).
+        # Keep -fsanitize=integer enabled, but disable the unsigned overflow check.
         target_compile_options(${target} PRIVATE
             $<$<COMPILE_LANGUAGE:CXX>:-fsanitize=${SANITIZER_LIST}>
+            $<$<COMPILE_LANGUAGE:CXX>:-fno-sanitize=unsigned-integer-overflow>
             $<$<COMPILE_LANGUAGE:CXX>:-fno-sanitize-recover=integer>
         )
         target_link_options(${target} PRIVATE
             -Xarch_host -fsanitize=${SANITIZER_LIST}
+            -Xarch_host -fno-sanitize=unsigned-integer-overflow
             -Xarch_host -fno-sanitize-recover=integer
         )
     endif()


### PR DESCRIPTION
This is well-defined behaviour and third-party libraries depend on it, generating false positives.

## Motivation

hipFile needs to be sanitizer-clean. The undefined behaviour sanitizer currently trips over unsigned integer overflows in third-party libraries like the oneAPI Threading Building Blocks (oneTBB).

## Technical Details

Unsigned integer overflow is not undefined behaviour, so we remove those checks.

## JIRA ID

AIHIPFILE-154

## Test Plan

CI passes, manual tests w/ sanitizers

## Test Result

Passes

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
