### PR TITLE
Fix hip_graph_internal.hpp

### DIFF
--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -2232,8 +2232,8 @@ class GraphMemcpyNode1D : public GraphMemcpyNode {
   // introducing a separate source of truth.
   virtual bool WillBypassSdmaEngine() const override {
     size_t sOffset = 0, dOffset = 0;
-    amd::Memory* srcMemory = getMemoryObject(src_, sOffset);
-    amd::Memory* dstMemory = getMemoryObject(dst_, dOffset);
+    amd::Memory* srcMemory = getMemoryObjectForCurrentDevice(src_, sOffset);
+    amd::Memory* dstMemory = getMemoryObjectForCurrentDevice(dst_, dOffset);
 
     hip::MemcpyType type = hipHostToHost;
     if (srcMemory != nullptr && dstMemory != nullptr) {


### PR DESCRIPTION
## Motivation

Fix break caused by #5866 

## Technical Details

getMemoryObject was refactored, due to the ordering of CI and merges, this created a break without any code-conflicts and a passing CI. This PR fixes this issue

## JIRA ID

ROCM-21854

## Test Plan

Existing testing is suitable

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
