### PR TITLE
[rocprofiler-sdk] Fix SLES CI docker image build and misc. 

### DIFF
--- a/.github/workflows/rocprof-trace-decoder-continuous_integration.yml
+++ b/.github/workflows/rocprof-trace-decoder-continuous_integration.yml
@@ -171,19 +171,19 @@ jobs:
           git submodule status --recursive -- ${SUBMODULE_PATHS} > .git-submodules-status-raw
           awk '{print $1,$2}' .git-submodules-status-raw > .git-submodules-status
           echo "hash=$(sha256sum .git-submodules-status | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+          # cache scoped submodule working trees plus their .git/modules gitdirs
           awk '{print $2}' .git-submodules-status-raw > .git-submodule-paths
+          for p in ${SUBMODULE_PATHS}; do echo ".git/modules/${p}"; done >> .git-submodule-paths
           { echo "paths<<EOF"; cat .git-submodule-paths; echo "EOF"; } >> "$GITHUB_OUTPUT"
 
       - name: Restore submodule cache
         uses: actions/cache@v4
         with:
           path: |
-            .git/modules
             ${{ steps.submods.outputs.paths }}
-          key: submods-${{ runner.os }}-${{ steps.submods.outputs.hash }}
+          key: submods-scoped-v1-${{ runner.os }}-${{ steps.submods.outputs.hash }}
           restore-keys: |
-            submods-${{ runner.os }}-
-            submods-
+            submods-scoped-v1-${{ runner.os }}-
 
       - name: Init/Update submodules
         run: git submodule update --init --recursive --jobs 16 -- ${SUBMODULE_PATHS}

--- a/.github/workflows/rocprof-trace-decoder-continuous_integration.yml
+++ b/.github/workflows/rocprof-trace-decoder-continuous_integration.yml
@@ -43,6 +43,8 @@ env:
 
   CI_MODE: "Continuous"
 
+  SUBMODULE_PATHS: "projects/rocprofiler-sdk projects/aqlprofile projects/rocprofiler-register projects/rocprof-trace-decoder projects/rocr-runtime projects/clr projects/hip"
+
 jobs:
   build-and-test-ubuntu:
     name: Build & Test • mi325 • Ubuntu 22.04
@@ -166,9 +168,10 @@ jobs:
         run: |
           git --version
           git config --global --add safe.directory '*'
-          git submodule status --recursive | awk '{print $1,$2}' > .git-submodules-status
+          git submodule status --recursive -- ${SUBMODULE_PATHS} > .git-submodules-status-raw
+          awk '{print $1,$2}' .git-submodules-status-raw > .git-submodules-status
           echo "hash=$(sha256sum .git-submodules-status | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
-          git config --file .gitmodules --get-regexp path | awk '{print $2}' > .git-submodule-paths
+          awk '{print $2}' .git-submodules-status-raw > .git-submodule-paths
           { echo "paths<<EOF"; cat .git-submodule-paths; echo "EOF"; } >> "$GITHUB_OUTPUT"
 
       - name: Restore submodule cache
@@ -183,7 +186,7 @@ jobs:
             submods-
 
       - name: Init/Update submodules
-        run: git submodule update --init --recursive --jobs 16
+        run: git submodule update --init --recursive --jobs 16 -- ${SUBMODULE_PATHS}
 
       - name: Install requirements (venv)
         timeout-minutes: 10

--- a/.github/workflows/rocprofiler-register-continuous-integration.yml
+++ b/.github/workflows/rocprofiler-register-continuous-integration.yml
@@ -86,6 +86,7 @@ jobs:
       PACKAGING_INSTALL_PREFIX: /opt/rocm
       GIT_DISCOVERY_ACROSS_FILESYSTEM: 1
       PATH: /usr/bin:$PATH
+      SUBMODULE_PATHS: "projects/rocprofiler-register"
 
     steps:
     - name: Install Latest Nightly ROCm
@@ -107,8 +108,13 @@ jobs:
     - uses: actions/checkout@v6
       with:
         sparse-checkout: projects/rocprofiler-register
-        submodules: true
+        submodules: false
         set-safe-directory: true
+
+    - name: Init/Update submodules
+      run: |
+        git config --global --add safe.directory '*'
+        git submodule update --init --recursive --jobs 16 -- ${SUBMODULE_PATHS}
 
     - name: Install Packages
       timeout-minutes: 25

--- a/.github/workflows/rocprofiler-sdk-build-ci-docker-images.yml
+++ b/.github/workflows/rocprofiler-sdk-build-ci-docker-images.yml
@@ -72,6 +72,7 @@ jobs:
       - name: Build & Push (to Docker Hub; cache to GHA)
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
+          context: .
           file: projects/rocprofiler-sdk/docker/Dockerfile.ci
           platforms: linux/amd64
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/rocprofiler-sdk-code_coverage.yml
+++ b/.github/workflows/rocprofiler-sdk-code_coverage.yml
@@ -43,6 +43,7 @@ env:
   ROCM_PATH: "/opt/rocm"
   GPU_TARGETS: "gfx906 gfx908 gfx90a gfx942 gfx950 gfx1030 gfx1100 gfx1101 gfx1102 gfx1201"
   PATH: "/usr/bin:$PATH"
+  SUBMODULE_PATHS: "projects/rocprofiler-sdk projects/aqlprofile projects/rocprofiler-register projects/rocr-runtime projects/clr projects/hip"
   ## No tests should be excluded here except for extreme emergencies; tests should only be disabled in CMake
   ## A task should be assigned directly to fix the issue
   ## Scratch memory tests need to be fixed for ROCm 7.0 release
@@ -119,10 +120,10 @@ jobs:
       shell: bash
       run: |
         git config --global --add safe.directory '*'
-        git submodule status --recursive | awk '{print $1,$2}' > .git-submodules-status
+        git submodule status --recursive -- ${SUBMODULE_PATHS} > .git-submodules-status-raw
+        awk '{print $1,$2}' .git-submodules-status-raw > .git-submodules-status
         echo "hash=$(sha256sum .git-submodules-status | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
-        # collect submodule paths for cache 'path'
-        git config --file .gitmodules --get-regexp path | awk '{print $2}' > .git-submodule-paths
+        awk '{print $2}' .git-submodules-status-raw > .git-submodule-paths
         { echo "paths<<EOF"; cat .git-submodule-paths; echo "EOF"; } >> "$GITHUB_OUTPUT"
 
     - name: Restore submodule cache
@@ -137,7 +138,7 @@ jobs:
           submods-
 
     - name: Init/Update submodules
-      run: git submodule update --init --recursive --jobs 16
+      run: git submodule update --init --recursive --jobs 16 -- ${SUBMODULE_PATHS}
 
     - name: Clone ROCDecode
       uses: actions/checkout@v6

--- a/.github/workflows/rocprofiler-sdk-code_coverage.yml
+++ b/.github/workflows/rocprofiler-sdk-code_coverage.yml
@@ -123,19 +123,19 @@ jobs:
         git submodule status --recursive -- ${SUBMODULE_PATHS} > .git-submodules-status-raw
         awk '{print $1,$2}' .git-submodules-status-raw > .git-submodules-status
         echo "hash=$(sha256sum .git-submodules-status | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+        # cache scoped submodule working trees plus their .git/modules gitdirs
         awk '{print $2}' .git-submodules-status-raw > .git-submodule-paths
+        for p in ${SUBMODULE_PATHS}; do echo ".git/modules/${p}"; done >> .git-submodule-paths
         { echo "paths<<EOF"; cat .git-submodule-paths; echo "EOF"; } >> "$GITHUB_OUTPUT"
 
     - name: Restore submodule cache
       uses: actions/cache@v4
       with:
         path: |
-          .git/modules
           ${{ steps.submods.outputs.paths }}
-        key: submods-${{ runner.os }}-${{ steps.submods.outputs.hash }}
+        key: submods-scoped-v1-${{ runner.os }}-${{ steps.submods.outputs.hash }}
         restore-keys: |
-          submods-${{ runner.os }}-
-          submods-
+          submods-scoped-v1-${{ runner.os }}-
 
     - name: Init/Update submodules
       run: git submodule update --init --recursive --jobs 16 -- ${SUBMODULE_PATHS}

--- a/.github/workflows/rocprofiler-sdk-codeql.yml
+++ b/.github/workflows/rocprofiler-sdk-codeql.yml
@@ -36,6 +36,7 @@ env:
   ROCM_PATH: "/opt/rocm"
   GPU_TARGETS: "gfx906;gfx908;gfx90a;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1102;gfx1201"
   PATH: "/usr/bin:$PATH"
+  SUBMODULE_PATHS: "projects/rocprofiler-sdk projects/clr projects/hip"
   EXCLUDED_PATHS: "external /tmp/build/external"
   GLOBAL_CMAKE_OPTIONS: "-DROCPROFILER_INTERNAL_RCCL_API_TRACE=ON"
   ENABLE_ROCR_BUILD: "false"
@@ -109,7 +110,13 @@ jobs:
           projects/hip
           .github/workflows/rocprofiler-sdk-codeql.yml
           .github/workflows/rocprofiler-sdk-formatting.yml
-        submodules: 'true'
+        submodules: 'false'
+
+    - name: Init/Update submodules
+      shell: bash
+      run: |
+        git config --global --add safe.directory '*'
+        git submodule update --init --recursive --jobs 16 -- ${SUBMODULE_PATHS}
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/rocprofiler-sdk-continuous_integration.yml
+++ b/.github/workflows/rocprofiler-sdk-continuous_integration.yml
@@ -140,20 +140,19 @@ jobs:
           git submodule status --recursive -- ${SUBMODULE_PATHS} > .git-submodules-status-raw
           awk '{print $1,$2}' .git-submodules-status-raw > .git-submodules-status
           echo "hash=$(sha256sum .git-submodules-status | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
-          # collect submodule paths for cache 'path'
+          # cache scoped submodule working trees plus their .git/modules gitdirs
           awk '{print $2}' .git-submodules-status-raw > .git-submodule-paths
+          for p in ${SUBMODULE_PATHS}; do echo ".git/modules/${p}"; done >> .git-submodule-paths
           { echo "paths<<EOF"; cat .git-submodule-paths; echo "EOF"; } >> "$GITHUB_OUTPUT"
 
       - name: Restore submodule cache
         uses: actions/cache@v4
         with:
           path: |
-            .git/modules
             ${{ steps.submods.outputs.paths }}
-          key: submods-${{ runner.os }}-${{ steps.submods.outputs.hash }}
+          key: submods-scoped-v1-${{ runner.os }}-${{ steps.submods.outputs.hash }}
           restore-keys: |
-            submods-${{ runner.os }}-
-            submods-
+            submods-scoped-v1-${{ runner.os }}-
 
       - name: Init/Update submodules
         run: git submodule update --init --recursive --jobs 16 -- ${SUBMODULE_PATHS}
@@ -366,20 +365,19 @@ jobs:
           git submodule status --recursive -- ${SUBMODULE_PATHS} > .git-submodules-status-raw
           awk '{print $1,$2}' .git-submodules-status-raw > .git-submodules-status
           echo "hash=$(sha256sum .git-submodules-status | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
-          # collect submodule paths for cache 'path'
+          # cache scoped submodule working trees plus their .git/modules gitdirs
           awk '{print $2}' .git-submodules-status-raw > .git-submodule-paths
+          for p in ${SUBMODULE_PATHS}; do echo ".git/modules/${p}"; done >> .git-submodule-paths
           { echo "paths<<EOF"; cat .git-submodule-paths; echo "EOF"; } >> "$GITHUB_OUTPUT"
 
       - name: Restore submodule cache
         uses: actions/cache@v4
         with:
           path: |
-            .git/modules
             ${{ steps.submods.outputs.paths }}
-          key: submods-${{ runner.os }}-${{ steps.submods.outputs.hash }}
+          key: submods-scoped-v1-${{ runner.os }}-${{ steps.submods.outputs.hash }}
           restore-keys: |
-            submods-${{ runner.os }}-
-            submods-
+            submods-scoped-v1-${{ runner.os }}-
 
       - name: Init/Update submodules
         run: git submodule update --init --recursive --jobs 16 -- ${SUBMODULE_PATHS}
@@ -511,20 +509,19 @@ jobs:
         git submodule status --recursive -- ${SUBMODULE_PATHS} > .git-submodules-status-raw
         awk '{print $1,$2}' .git-submodules-status-raw > .git-submodules-status
         echo "hash=$(sha256sum .git-submodules-status | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
-        # collect submodule paths for cache 'path'
+        # cache scoped submodule working trees plus their .git/modules gitdirs
         awk '{print $2}' .git-submodules-status-raw > .git-submodule-paths
+        for p in ${SUBMODULE_PATHS}; do echo ".git/modules/${p}"; done >> .git-submodule-paths
         { echo "paths<<EOF"; cat .git-submodule-paths; echo "EOF"; } >> "$GITHUB_OUTPUT"
 
     - name: Restore submodule cache
       uses: actions/cache@v4
       with:
         path: |
-          .git/modules
           ${{ steps.submods.outputs.paths }}
-        key: submods-${{ runner.os }}-${{ steps.submods.outputs.hash }}
+        key: submods-scoped-v1-${{ runner.os }}-${{ steps.submods.outputs.hash }}
         restore-keys: |
-          submods-${{ runner.os }}-
-          submods-
+          submods-scoped-v1-${{ runner.os }}-
 
     - name: Init/Update submodules
       run: git submodule update --init --recursive --jobs 16 -- ${SUBMODULE_PATHS}

--- a/.github/workflows/rocprofiler-sdk-continuous_integration.yml
+++ b/.github/workflows/rocprofiler-sdk-continuous_integration.yml
@@ -49,6 +49,9 @@ env:
   GPU_TARGETS: "gfx906 gfx908 gfx90a gfx942 gfx950 gfx1030 gfx1100 gfx1101 gfx1102 gfx1201"
   PATH: "/usr/bin:$PATH"
 
+  ## Submodule paths required by the rocprofiler-sdk build.
+  SUBMODULE_PATHS: "projects/rocprofiler-sdk projects/aqlprofile projects/rocprofiler-register projects/rocprof-trace-decoder projects/rocr-runtime projects/clr projects/hip"
+
   ## No tests should be excluded here except for extreme emergencies; tests should only be disabled in CMake
   ## A task should be assigned directly to fix the issues
   ## Scratch memory tests need to be fixed for ROCm 7.0 release
@@ -95,7 +98,7 @@ jobs:
           # TEMPORARILY DISABLED: navi3/navi4 jobs pending CI stabilization
           # - { gpu: 'navi4', runner: 'rocprofiler-navi4-dind', os: 'ubuntu-22.04', build-type: 'RelWithDebInfo', ci-flags: '--linter clang-tidy', gpu-target: 'gfx120X' }
           # - { gpu: 'navi3', runner: 'rocprofiler-navi3-dind', os: 'ubuntu-22.04', build-type: 'RelWithDebInfo', ci-flags: '--linter clang-tidy', gpu-target: 'gfx110X' }
-          - { gpu: 'mi325', runner: 'linux-gfx942-1gpu-ccs-ossci-rocm', os: 'ubuntu-22.04', build-type: 'RelWithDebInfo', ci-flags: '--linter clang-tidy', gpu-target: 'gfx94X' }
+          - { gpu: 'mi325', runner: 'linux-gfx942-1gpu-core42-ossci-rocm', os: 'ubuntu-22.04', build-type: 'RelWithDebInfo', ci-flags: '--linter clang-tidy', gpu-target: 'gfx94X' }
     runs-on: ${{ matrix.system.runner }}
     container:
       image: docker.io/rocm/rocprofiler-private:${{ matrix.system.os }}-${{ matrix.system.gpu-target }}-latest
@@ -134,10 +137,11 @@ jobs:
         run: |
           git --version
           git config --global --add safe.directory '*'
-          git submodule status --recursive | awk '{print $1,$2}' > .git-submodules-status
+          git submodule status --recursive -- ${SUBMODULE_PATHS} > .git-submodules-status-raw
+          awk '{print $1,$2}' .git-submodules-status-raw > .git-submodules-status
           echo "hash=$(sha256sum .git-submodules-status | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
           # collect submodule paths for cache 'path'
-          git config --file .gitmodules --get-regexp path | awk '{print $2}' > .git-submodule-paths
+          awk '{print $2}' .git-submodules-status-raw > .git-submodule-paths
           { echo "paths<<EOF"; cat .git-submodule-paths; echo "EOF"; } >> "$GITHUB_OUTPUT"
 
       - name: Restore submodule cache
@@ -152,7 +156,7 @@ jobs:
             submods-
 
       - name: Init/Update submodules
-        run: git submodule update --init --recursive --jobs 16
+        run: git submodule update --init --recursive --jobs 16 -- ${SUBMODULE_PATHS}
 
       - name: Clone ROCDecode
         uses: actions/checkout@v6
@@ -359,10 +363,11 @@ jobs:
         run: |
           git --version
           git config --global --add safe.directory '*'
-          git submodule status --recursive | awk '{print $1,$2}' > .git-submodules-status
+          git submodule status --recursive -- ${SUBMODULE_PATHS} > .git-submodules-status-raw
+          awk '{print $1,$2}' .git-submodules-status-raw > .git-submodules-status
           echo "hash=$(sha256sum .git-submodules-status | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
           # collect submodule paths for cache 'path'
-          git config --file .gitmodules --get-regexp path | awk '{print $2}' > .git-submodule-paths
+          awk '{print $2}' .git-submodules-status-raw > .git-submodule-paths
           { echo "paths<<EOF"; cat .git-submodule-paths; echo "EOF"; } >> "$GITHUB_OUTPUT"
 
       - name: Restore submodule cache
@@ -377,7 +382,7 @@ jobs:
             submods-
 
       - name: Init/Update submodules
-        run: git submodule update --init --recursive --jobs 16
+        run: git submodule update --init --recursive --jobs 16 -- ${SUBMODULE_PATHS}
 
       - name: Install requirements (venv)
         timeout-minutes: 10
@@ -503,10 +508,11 @@ jobs:
       run: |
         git --version
         git config --global --add safe.directory '*'
-        git submodule status --recursive | awk '{print $1,$2}' > .git-submodules-status
+        git submodule status --recursive -- ${SUBMODULE_PATHS} > .git-submodules-status-raw
+        awk '{print $1,$2}' .git-submodules-status-raw > .git-submodules-status
         echo "hash=$(sha256sum .git-submodules-status | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
         # collect submodule paths for cache 'path'
-        git config --file .gitmodules --get-regexp path | awk '{print $2}' > .git-submodule-paths
+        awk '{print $2}' .git-submodules-status-raw > .git-submodule-paths
         { echo "paths<<EOF"; cat .git-submodule-paths; echo "EOF"; } >> "$GITHUB_OUTPUT"
 
     - name: Restore submodule cache
@@ -521,7 +527,7 @@ jobs:
           submods-
 
     - name: Init/Update submodules
-      run: git submodule update --init --recursive --jobs 16
+      run: git submodule update --init --recursive --jobs 16 -- ${SUBMODULE_PATHS}
 
     - name: Install requirements
       timeout-minutes: 10

--- a/.github/workflows/rocprofiler-sdk-docs.yml
+++ b/.github/workflows/rocprofiler-sdk-docs.yml
@@ -35,6 +35,7 @@ env:
   ENABLE_ROCPROFILER_REGISTER_BUILD: "false"
   ENABLE_AQLPROFILE_BUILD: "false"
   INSTALL_NIGHTLY_ROCM: "true"
+  SUBMODULE_PATHS: "projects/rocprofiler-sdk projects/rocr-runtime projects/clr projects/hip"
 
 jobs:
   build-docs:
@@ -119,7 +120,7 @@ jobs:
           git config --system --add safe.directory '*'
 
       - name: Init/Update submodules
-        run: git submodule update --init --recursive --jobs 16
+        run: git submodule update --init --recursive --jobs 16 -- ${SUBMODULE_PATHS}
 
       - name: Setup
         shell: bash

--- a/.github/workflows/rocprofiler-sdk-docs.yml
+++ b/.github/workflows/rocprofiler-sdk-docs.yml
@@ -50,8 +50,12 @@ jobs:
         uses: actions/checkout@v6
         with:
           sparse-checkout: projects/rocprofiler-sdk
-          submodules: true
+          submodules: false
           set-safe-directory: true
+      - name: Init/Update submodules
+        run: |
+          git config --global --add safe.directory '*'
+          git submodule update --init --recursive --jobs 16 -- ${SUBMODULE_PATHS}
       - name: Create Docs Directory
         run: |
           git config --global --add safe.directory '*'

--- a/projects/rocprofiler-sdk/docker/Dockerfile.ci
+++ b/projects/rocprofiler-sdk/docker/Dockerfile.ci
@@ -15,7 +15,7 @@ ENV HIP_COMPILER=amdclang++
 ENV LLVM_PATH=/opt/rocm/llvm
 ENV CMAKE_PREFIX_PATH=/opt/rocm
 ENV PATH=/opt/rh/gcc-toolset-11/root/usr/bin:/usr/lib64/openmpi/bin:/opt/rocm/bin:/opt/rocm/llvm/bin:/usr/local/bin:~/.local/bin:${PATH}
-ENV LD_LIBRARY_PATH=/opt/rocm/lib:/opt/rocm/llvm/lib:${LD_LIBRARY_PATH}
+ENV LD_LIBRARY_PATH=/opt/rocm/lib:/opt/rocm/llvm/lib:${LD_LIBRARY_PATH:-}
 
 # Debian/Ubuntu
 RUN set-euo pipefail; \
@@ -97,5 +97,8 @@ RUN set -euo pipefail; \
         python3 -m pipx ensurepath; \
         source ~/.bashrc; \
     fi; \
-    aws s3 cp "s3://therock-nightly-tarball/${GPU_TARBALL}" rocm-${GPU_TYPE}.tar.gz --no-sign-request && \
-    mv rocm-${GPU_TYPE}.tar.gz /opt/rocm-${GPU_TYPE}.tar.gz;
+    aws s3 cp "s3://therock-nightly-tarball/${GPU_TARBALL}" /tmp/rocm-${GPU_TYPE}.tar.gz --no-sign-request && \
+    rm -rf /opt/rocm* && \
+    mkdir -p /opt/rocm && \
+    mv /tmp/rocm-${GPU_TYPE}.tar.gz /opt/rocm-${GPU_TYPE}.tar.gz && \
+    tar -xf /opt/rocm-${GPU_TYPE}.tar.gz -C /opt/rocm;

--- a/projects/rocprofiler-sdk/docker/Dockerfile.ci
+++ b/projects/rocprofiler-sdk/docker/Dockerfile.ci
@@ -73,8 +73,9 @@ RUN set -euo pipefail; \
     if [ $(grep -i "sles" /etc/os-release | wc -l) -gt 0 ]; then \
         echo -e "[ROCm-latest]\nname=ROCm\nbaseurl=https://repo.radeon.com/rocm/zyp/latest/main\nenabled=1\npriority=50\ngpgcheck=1\ngpgkey=https://repo.radeon.com/rocm/rocm.gpg.key" > /etc/zypp/repos.d/rocm.repo; \
         echo -e "[amdgpu]\nname=amdgpu\nbaseurl=https://repo.radeon.com/amdgpu/latest/sle/15.7/main/x86_64/\nenabled=1\npriority=50\ngpgcheck=1\ngpgkey=https://repo.radeon.com/rocm/rocm.gpg.key" > /etc/zypp/repos.d/amdgpu.repo; \
-        zypper --gpg-auto-import-keys refresh; \
-        zypper --non-interactive install -y rocm-openmp rocm-openmp-sdk rocm-llvm-devel hipify-clang sqlite3-devel python3-pip; \
+        zypper --gpg-auto-import-keys refresh || true; \
+        zypper --gpg-auto-import-keys refresh ROCm-latest amdgpu; \
+        zypper --non-interactive --no-refresh install -y rocm-openmp rocm-openmp-sdk rocm-llvm-devel hipify-clang sqlite3-devel python3-pip; \
         python3 -m venv rocprofiler-sdk; \
         source rocprofiler-sdk/bin/activate; \
         python3 -m pip install --upgrade pip pipx; \


### PR DESCRIPTION
## Motivation

This PR updates the rocprofiler-sdk CI container build and several GitHub Actions workflows to improve reliability (notably on SLES) and to make submodule handling more explicit/targeted for rocprofiler-related builds.

## Technical Details

- Fix SLES `zypper` refresh/install flow in the rocprofiler-sdk CI Dockerfile to refresh only the intended repositories and avoid failures from unrelated repo refresh errors.
- Update multiple workflows to disable automatic submodule checkout and instead run explicit `git submodule update --init --recursive` scoped by a shared `SUBMODULE_PATHS` env var; also adjust submodule cache-key computation accordingly.
- Minor CI workflow adjustments: runner label update for the mi325 job and explicit `context: .` for the CI Docker image build job.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
