### PR TITLE
Avoid per-row SDMA fallback for narrow/tall hipMemcpy2D rects

### DIFF
--- a/projects/clr/CHANGELOG.md
+++ b/projects/clr/CHANGELOG.md
@@ -4,6 +4,17 @@ Full documentation for HIP is available at [rocm.docs.amd.com](https://rocm.docs
 
 ## HIP 7.14 for ROCm 7.14
 
+### Optimizations
+
+* `hipMemcpy2D`/`hipMemcpy2DAsync`: avoid a severe slowdown for narrow, tall host&harr;device copies (small `width`, large `height`). When the row/slice pitch is not 4-byte aligned (for example `width = 1` byte), `KernelBlitManager::copyBufferRect` previously used the SDMA rect path, which falls back to one `hsa_amd_memory_async_copy` per row. For a 1&nbsp;MB transfer of 1,048,576 rows &times; 1 byte on gfx942 this issued ~1M single-byte SDMA copies and took several seconds, while the equivalent NVIDIA/CUDA path completes in a few milliseconds. Such narrow, non-dword-aligned 2D copies are now routed to the shader `BlitCopyBufferRect` kernel (single dispatch). Measured before/after on gfx942 / ROCm 7.2 (1,048,576 rows, best-of-3):
+    - width=1, H2D pinned: 8615.79 ms &rarr; 0.283 ms
+    - width=1, H2D pageable: 8627.17 ms &rarr; 0.284 ms
+    - width=1, D2H pinned: 7908.23 ms &rarr; 0.334 ms
+    - width=1, D2H pageable: 7912.22 ms &rarr; 0.335 ms
+    - dword-aligned widths (4 / 8 / 128 bytes): unchanged
+
+  `rocprofv3` confirms the per-row submissions (one `MEMORY_COPY` record per row) collapse into a single `__amd_rocclr_copyBufferRect` dispatch. Copies at or below the 256-row threshold are unaffected.
+
 ### Added
 * New HIP APIs
     - Execution Context Management: Support for the following APIs for parity with corresponding CUDA APIs.

--- a/projects/clr/CHANGELOG.md
+++ b/projects/clr/CHANGELOG.md
@@ -6,14 +6,14 @@ Full documentation for HIP is available at [rocm.docs.amd.com](https://rocm.docs
 
 ### Optimizations
 
-* `hipMemcpy2D`/`hipMemcpy2DAsync`: avoid a severe slowdown for narrow, tall host&harr;device copies (small `width`, large `height`). When the row/slice pitch is not 4-byte aligned (for example `width = 1` byte), `KernelBlitManager::copyBufferRect` previously used the SDMA rect path, which falls back to one `hsa_amd_memory_async_copy` per row. For a 1&nbsp;MB transfer of 1,048,576 rows &times; 1 byte on gfx942 this issued ~1M single-byte SDMA copies and took several seconds, while the equivalent NVIDIA/CUDA path completes in a few milliseconds. Such narrow, non-dword-aligned 2D copies are now routed to the shader `BlitCopyBufferRect` kernel (single dispatch). Measured before/after on gfx942 / ROCm 7.2 (1,048,576 rows, best-of-3):
+* `hipMemcpy2D`/`hipMemcpy2DAsync`: avoid a severe slowdown for copies that have a small row width but a large number of rows (for example a `width` of 1 byte with a row count in the millions). When the row/slice pitch is not 4-byte aligned, `KernelBlitManager::copyBufferRect` previously fell back to issuing a separate copy for every row, so a 1&nbsp;MB transfer of 1,048,576 rows &times; 1 byte on MI300 took several seconds, while the equivalent NVIDIA/CUDA path completes in a few milliseconds. Such copies are now performed in a single shader-based copy. Measured before/after on MI300 / ROCm 7.2 (1,048,576 rows):
     - width=1, H2D pinned: 8615.79 ms &rarr; 0.283 ms
     - width=1, H2D pageable: 8627.17 ms &rarr; 0.284 ms
     - width=1, D2H pinned: 7908.23 ms &rarr; 0.334 ms
     - width=1, D2H pageable: 7912.22 ms &rarr; 0.335 ms
-    - dword-aligned widths (4 / 8 / 128 bytes): unchanged
+    - dword-aligned widths (4 / 8 / 128 bytes) &rarr; unchanged
 
-  `rocprofv3` confirms the per-row submissions (one `MEMORY_COPY` record per row) collapse into a single `__amd_rocclr_copyBufferRect` dispatch. Copies at or below the 256-row threshold are unaffected.
+  Copies at or below the 256-row threshold are unaffected.
 
 ### Added
 * New HIP APIs

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -2017,8 +2017,8 @@ bool KernelBlitManager::copyBufferRect(device::Memory& srcMemory, device::Memory
       ((dstRectIn.rowPitch_ % 4) == 0) && ((dstRectIn.slicePitch_ % 4) == 0);
   const bool hostDeviceRect =
       srcMemory.isHostMemDirectAccess() != dstMemory.isHostMemDirectAccess();
-  const bool sdmaRectWouldSerialize = !dwordAlignedRect && hostDeviceRect &&
-      ((sizeIn[1] * sizeIn[2]) > kSdmaRectRowSerializeLimit);
+  const bool sdmaRectWouldSerialize =
+      !dwordAlignedRect && hostDeviceRect && ((sizeIn[1] * sizeIn[2]) > kSdmaRectRowSerializeLimit);
 
   // Fall into the ROC path for rejected transfers
   if (dev().info().pcie_atomics_ && !sdmaRectWouldSerialize &&

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -2003,8 +2003,25 @@ bool KernelBlitManager::copyBufferRect(device::Memory& srcMemory, device::Memory
   bool result = false;
   bool rejected = false;
 
+  // hsa_amd_memory_async_copy_rect requires dword-aligned row/slice pitches.
+  // When they are not aligned, DmaBlitManager::copyBufferRect falls back to one
+  // hsa_amd_memory_async_copy per row. For tall, narrow host<->device rects
+  // (e.g. hipMemcpy2D with width=1 and a very large height) this issues one
+  // single-byte SDMA submission per row - up to millions of descriptors - which
+  // is orders of magnitude slower than the shader rect kernel below
+  // (BlitCopyBufferRect handles 1-byte alignment in a single dispatch). Skip the
+  // SDMA rect path in that pathological case and let the shader kernel handle it.
+  constexpr size_t kSdmaRectRowSerializeLimit = 256;
+  const bool dwordAlignedRect =
+      ((srcRectIn.rowPitch_ % 4) == 0) && ((srcRectIn.slicePitch_ % 4) == 0) &&
+      ((dstRectIn.rowPitch_ % 4) == 0) && ((dstRectIn.slicePitch_ % 4) == 0);
+  const bool hostDeviceRect =
+      srcMemory.isHostMemDirectAccess() != dstMemory.isHostMemDirectAccess();
+  const bool sdmaRectWouldSerialize = !dwordAlignedRect && hostDeviceRect &&
+      ((sizeIn[1] * sizeIn[2]) > kSdmaRectRowSerializeLimit);
+
   // Fall into the ROC path for rejected transfers
-  if (dev().info().pcie_atomics_ &&
+  if (dev().info().pcie_atomics_ && !sdmaRectWouldSerialize &&
       (setup_.disableCopyBufferRect_ || srcMemory.isHostMemDirectAccess() ||
        dstMemory.isHostMemDirectAccess())) {
     result = DmaBlitManager::copyBufferRect(srcMemory, dstMemory, srcRectIn, dstRectIn, sizeIn,


### PR DESCRIPTION
KernelBlitManager::copyBufferRect routes host<->device rect copies to the SDMA rect path (DmaBlitManager::copyBufferRect) first. The hardware rect copy hsa_amd_memory_async_copy_rect requires dword-aligned row/slice pitches; when they are not aligned, DmaBlitManager::copyBufferRect degenerates into one hsa_amd_memory_async_copy per row.

For tall, narrow rects such as hipMemcpy2D(width=1, height=1M) this submits ~1,048,576 single-byte SDMA copies. Detect this case (row/slice pitch not dword-aligned, host<->device direction, row count > 256) and skip the SDMA rect path so the existing shader BlitCopyBufferRect kernel (alignment list {16,4,1}) handles the copy in a single dispatch.

## Motivation

Customer issue: a production AI serving customer porting a CUDA workload hit `hipMemcpy2D` with a small, non-dword-aligned width and large height (e.g. width=1, height=1M) taking ~8.6 s on gfx942/ROCm 7.2, versus ~2.6 ms on the equivalent CUDA `cudaMemcpy2D` (and ~0.03 ms for a flat `hipMemcpy` of the same bytes). `width=1` is legal API usage (strided 1-byte column / array-of-structs de-interleave), so this is a CUDA-portability gap, not a usage error.

## Technical Details

`hsa_amd_memory_async_copy_rect` requires dword-aligned row/slice pitches. When they are not aligned, `DmaBlitManager::copyBufferRect` falls back to one `hsa_amd_memory_async_copy` per row, so a `width=1, height=1M` copy issues ~1M single-byte SDMA submissions (cost scales with row count, not bytes; pinning/warmup do not help). This change adds a guard in `KernelBlitManager::copyBufferRect`: when the rect is not dword-aligned, is a true host<->device transfer, and has more than 256 rows, it skips the SDMA rect path so the existing shader `BlitCopyBufferRect` kernel performs the copy in a single dispatch. Dword-aligned widths and small (<=256-row) rects are unchanged.

## JIRA ID

N/A — customer-reported CUDA-parity gap (no JIRA filed).

## Test Plan

Built `libamdhip64` from this change on gfx942 / ROCm 7.2 and compared the stock runtime vs the patched runtime via `LD_PRELOAD`:
- `hipMemcpy2D` round-trip (H2D then D2H) byte-exact correctness across widths {1,2,3,4,5,8,16,128} x heights {1,255,256,257,1024,65537} = 48 cases.
- `rocprofv3 --kernel-trace --memory-copy-trace` on a width=1 copy.
- Microbenchmark timing for width=1 vs width=4 (H2D).

## Test Result

- Correctness: 48/48 byte-exact on both stock and patched — no data regression from the shader blit path; aligned widths and small rects unchanged.
- rocprofv3: the per-row `MEMORY_COPY` records collapse into a single `__amd_rocclr_copyBufferRect` dispatch.
- Timing: width=1 H2D 8615.79 ms -> 0.283 ms (~30,000x); width=4 unchanged (~4 ms).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.