### PR TITLE
[rocjitsu] Adding the rocjitsu-core-team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -63,6 +63,7 @@
 # Emulation
 /emulation/                                                           @atgutier
 /emulation/mirage/                                                    @atgutier @amd-arosa
+/emulation/rocjitsu/                                                  @atgutier @ROCm/rocjitsu-core-team
 
 # Profilers
 /profilers/profiler-hub                                               @ROCm/rocm-profiler-hub


### PR DESCRIPTION
## Motivation

Added the rocjitsu-core-team as code owners of emulation/rocjitsu. I considered breaking down the owners by type (emulation, dbt/dbi, amdisa, plugins) but ultimately was convinced that the team is small enough that this is not necessary yet.

## Submission Checklist

- [ X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
