### PR TITLE
[rocprofv3] Fail fast on mutually exclusive --selected-regions options

### DIFF
--- a/projects/rocprofiler-sdk/source/bin/rocprofv3.py
+++ b/projects/rocprofiler-sdk/source/bin/rocprofv3.py
@@ -2233,6 +2233,20 @@ def main(argv=None):
             "Multi-pass counter collection (multiple --pmc flags) is not compatible with --collection-period"
         )
 
+    def validate_selected_regions_conflicts(_args):
+        if getattr(_args, "selected_regions", False) and getattr(
+            _args, "att_consecutive_kernels", None
+        ):
+            fatal_error(
+                "--selected-regions and --att-consecutive-kernels are mutually exclusive"
+            )
+        if getattr(_args, "selected_regions", False) and getattr(
+            _args, "collection_period", None
+        ):
+            fatal_error(
+                "--selected-regions and --collection-period are mutually exclusive"
+            )
+
     # Check if we should use multi-pass mode:
     # 1. Multiple --pmc flags on CLI (cli_multipass)
     # 2. Multiple pmc lines in input file (len(inp_args) > 1)
@@ -2249,6 +2263,7 @@ def main(argv=None):
             cmd_args.pmc = cmd_args.pmc[0]
 
         args = get_args(cmd_args, inp_args[0])
+        validate_selected_regions_conflicts(args)
 
         if args.pid:
             # For reattachment support, args must be the same as previous rocprofv3 sessions
@@ -2330,6 +2345,8 @@ def main(argv=None):
             else:
                 # Input file pass: merge cmd_args with the full job config
                 pass_args = get_args(cmd_args, pass_config["config"])
+
+            validate_selected_regions_conflicts(pass_args)
 
             _ec = run(
                 app_args,

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -2884,6 +2884,10 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* tool_data)
     if(include && (!exclude || tool::get_config().kernel_filter_exclude.empty()))
         add_kernel_target(0, tool::get_config().kernel_filter_range);
 
+    ROCP_ERROR_IF(tool::get_config().selected_regions &&
+                  !tool::get_config().collection_periods.empty())
+        << "selected-regions and collection-period options are mutually exclusive";
+
     if(tool::get_config().benchmark_mode == tool::config::benchmark::disabled_contexts_overhead)
     {
         ROCP_INFO << "rocprofv3 is not recording data because the overhead of inactive contexts is "

--- a/projects/rocprofiler-sdk/tests/rocprofv3/advanced-thread-trace/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/advanced-thread-trace/CMakeLists.txt
@@ -397,7 +397,7 @@ rocprofiler_add_integration_execute_test(
     LABELS "integration-tests;thread-trace"
     WILL_FAIL
     DISABLED ${IS_DISABLED}
-    FAIL_REGULAR_EXPRESSION "att-consecutive-kernels options are mutually exclusive")
+    FAIL_REGULAR_EXPRESSION "att-consecutive-kernels( options)? are mutually exclusive")
 
 set(SHADERDATA_OUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/att-rocprofv3-shaderdata")
 

--- a/projects/rocprofiler-sdk/tests/rocprofv3/advanced-thread-trace/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/advanced-thread-trace/CMakeLists.txt
@@ -397,7 +397,8 @@ rocprofiler_add_integration_execute_test(
     LABELS "integration-tests;thread-trace"
     WILL_FAIL
     DISABLED ${IS_DISABLED}
-    FAIL_REGULAR_EXPRESSION "att-consecutive-kernels( options)? are mutually exclusive")
+    FAIL_REGULAR_EXPRESSION
+        "--selected-regions and --att-consecutive-kernels are mutually exclusive")
 
 set(SHADERDATA_OUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/att-rocprofv3-shaderdata")
 

--- a/projects/rocprofiler-sdk/tests/rocprofv3/collection-period/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/collection-period/CMakeLists.txt
@@ -61,3 +61,16 @@ rocprofiler_add_integration_validate_test(
     LABELS "integration-tests"
     FIXTURES_REQUIRED rocprofv3-test-collection-period
     UNSTABLE)
+
+# Conflict: --selected-regions + --collection-period should fail
+rocprofiler_add_integration_execute_test(
+    rocprofv3-test-collection-period-selected-regions-conflict-will-fail
+    COMMAND
+        $<TARGET_FILE:rocprofiler-sdk::rocprofv3> --selected-regions --collection-period
+        0:1:1 --collection-period-unit sec -- $<TARGET_FILE:reproducible-runtime> 100 1
+    DEPENDS reproducible-runtime
+    TIMEOUT 45
+    LABELS "integration-tests"
+    WILL_FAIL
+    FAIL_REGULAR_EXPRESSION
+        "--selected-regions and --collection-period are mutually exclusive")


### PR DESCRIPTION
Validate at the rocprofv3.py CLI level (after CLI + input-file args are merged) that --selected-regions is not combined with --att-consecutive-kernels or --collection-period. Previously these combinations were only flagged by a ROCP_ERROR_IF deep inside the tool library, which logs and continues with undefined behavior. Add a matching ROCP_ERROR_IF for the selected-regions + collection-period case as defense-in-depth for direct env-var users, and add an integration test covering the new conflict.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
AIPROFSDK-874
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
