### PR TITLE
[profiler-hub]: hide bundled sqlite3 symbols (-fvisibility=hidden + --exclude-libs)

### DIFF
--- a/profilers/profiler-hub/CMakeLists.txt
+++ b/profilers/profiler-hub/CMakeLists.txt
@@ -207,6 +207,18 @@ add_library(profiler-hub SHARED $<TARGET_OBJECTS:profiler-hub-objects>)
 add_library(profiler-hub-static STATIC $<TARGET_OBJECTS:profiler-hub-objects>)
 set_target_properties(profiler-hub-static PROPERTIES OUTPUT_NAME profiler-hub)
 
+# Belt-and-suspenders for the shared library: even though the bundled SQLite is
+# compiled with hidden visibility, also instruct the linker not to re-export any
+# symbol that came from the SQLite static archive. This keeps the 262 sqlite3_*
+# symbols out of libprofiler-hub.so's dynamic symbol table so they cannot
+# collide with other sqlite3 versions present on TheRock.
+if(NOT PROFILER_HUB_SQLITE3_USE_SYSTEM)
+    target_link_options(
+        profiler-hub
+        PRIVATE -Wl,--exclude-libs,libprofiler-hub-sqlite3-static.a
+    )
+endif()
+
 # Embed semantic version + ABI version on the shared library so that
 # libprofiler-hub.so.<MAJOR> is the SONAME and libprofiler-hub.so.<MAJOR>.<MINOR>.<PATCH>
 # is the actual file, with both symlinks installed alongside libprofiler-hub.so.

--- a/profilers/profiler-hub/cmake/sqlite3.cmake
+++ b/profilers/profiler-hub/cmake/sqlite3.cmake
@@ -145,7 +145,13 @@ else()
             SQLITE_OMIT_SHARED_CACHE=1
     )
 
-    target_compile_options(profiler-hub-sqlite3-static PRIVATE -O2 -fPIC)
+    # Seal the bundled SQLite symbols so they are not exported from
+    # libprofiler-hub.{so,a} and cannot collide with (or be interposed by)
+    # other sqlite3 versions bundled by sibling components on TheRock.
+    target_compile_options(
+        profiler-hub-sqlite3-static
+        PRIVATE -O2 -fPIC -fvisibility=hidden
+    )
 
     set_target_properties(
         profiler-hub-sqlite3-static

--- a/profilers/profiler-hub/tests/integration/CMakeLists.txt
+++ b/profilers/profiler-hub/tests/integration/CMakeLists.txt
@@ -12,6 +12,13 @@ include(gtest)
 
 set(INTEGRATION_TEST_SOURCES writer_test.cpp reader_test.cpp backend_test.cpp)
 
+# Build-artifact regression guard: verify libprofiler-hub.so does not export the
+# bundled sqlite3_* symbols (the symbol seal). Only meaningful with the bundled
+# SQLite; the system SQLite has no private copy to seal.
+if(NOT PROFILER_HUB_SQLITE3_USE_SYSTEM)
+    list(APPEND INTEGRATION_TEST_SOURCES symbol_seal_test.cpp)
+endif()
+
 add_executable(profiler-hub_integration_tests ${INTEGRATION_TEST_SOURCES})
 
 # Link the STATIC profiler-hub so the backend's explicitly-instantiated members
@@ -42,6 +49,16 @@ target_compile_definitions(
     profiler-hub_integration_tests
     PUBLIC ROCPD_DB_PATH="${ROCPD_DB_PATH}"
 )
+
+# Inject the absolute path of the built shared library so symbol_seal_test can
+# inspect it with nm, and ensure the library is built before this test runs.
+if(NOT PROFILER_HUB_SQLITE3_USE_SYSTEM)
+    target_compile_definitions(
+        profiler-hub_integration_tests
+        PRIVATE PROFILER_HUB_SHARED_LIB="$<TARGET_FILE:profiler-hub>"
+    )
+    add_dependencies(profiler-hub_integration_tests profiler-hub)
+endif()
 
 target_include_directories(
     profiler-hub_integration_tests

--- a/profilers/profiler-hub/tests/integration/symbol_seal_test.cpp
+++ b/profilers/profiler-hub/tests/integration/symbol_seal_test.cpp
@@ -1,0 +1,134 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+// Regression guard (GTest): the bundled SQLite must stay sealed.
+//
+// profiler-hub bundles its own static SQLite compiled with hidden visibility
+// (-fvisibility=hidden) and links libprofiler-hub.so with --exclude-libs, so no
+// sqlite3_* symbol is exported from the shared library and therefore cannot
+// collide with (or be interposed by) other sqlite3 versions present on TheRock.
+//
+// This test inspects the BUILT shared library with `nm` and fails if any
+// defined, exported sqlite3_* dynamic symbol reappears. It asserts a property
+// of the build artifact, not runtime behavior; the absolute path of the library
+// is injected by CMake via PROFILER_HUB_SHARED_LIB.
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdio>
+#include <memory>
+#include <regex>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+// Absolute path to the built libprofiler-hub.so, injected by CMake.
+constexpr const char* k_shared_library = PROFILER_HUB_SHARED_LIB;
+
+// Closes a popen() stream; used as a unique_ptr deleter. A dedicated functor
+// (rather than decltype(&pclose)) avoids -Wignored-attributes on libc symbols.
+struct file_op
+{
+    void operator()(FILE* pipe) const noexcept
+    {
+        if(pipe != nullptr)
+        {
+            pclose(pipe);
+        }
+    }
+};
+
+// Run a shell command and capture its stdout. Returns false if the command
+// could not be launched.
+bool
+run_capture(const std::string& command, std::string& output)
+{
+    output.clear();
+    std::unique_ptr<FILE, file_op> pipe(popen(command.c_str(), "r"));
+    if(!pipe)
+    {
+        return false;
+    }
+
+    std::array<char, 4096> buffer{};
+    while(std::fgets(buffer.data(), static_cast<int>(buffer.size()), pipe.get()) !=
+          nullptr)
+    {
+        output += buffer.data();
+    }
+    return true;
+}
+
+// Locate an `nm`-like tool; empty string if none is available.
+std::string
+find_nm()
+{
+    for(const char* candidate : { "nm", "llvm-nm" })
+    {
+        std::string out;
+        if(run_capture(std::string{ candidate } + " --version 2>/dev/null", out) &&
+           !out.empty())
+        {
+            return candidate;
+        }
+    }
+    return {};
+}
+
+TEST(sqlite3_symbol_seal, shared_library_exports_no_sqlite3_symbols)
+{
+    const std::string nm = find_nm();
+    if(nm.empty())
+    {
+        GTEST_SKIP() << "no 'nm'/'llvm-nm' available to inspect exported symbols";
+    }
+
+    // -D: dynamic (exported) symbols, --defined-only: only symbols defined here.
+    std::string nm_output;
+    ASSERT_TRUE(run_capture(
+        nm + " -D --defined-only \"" + k_shared_library + "\" 2>/dev/null", nm_output))
+        << "failed to run " << nm << " on " << k_shared_library;
+
+    // Match exact sqlite3_* symbol names, e.g. "0000... T sqlite3_open"; ignore
+    // mangled C++ names that merely contain the substring "sqlite3_".
+    const std::regex exported_sqlite{
+        R"(^[0-9a-fA-F]+ [A-Za-z] (sqlite3_[A-Za-z0-9_]+)$)"
+    };
+
+    std::vector<std::string> leaked;
+    std::istringstream       stream(nm_output);
+    std::string              line;
+    while(std::getline(stream, line))
+    {
+        if(!line.empty() && line.back() == '\r')
+        {
+            line.pop_back();
+        }
+
+        std::smatch match;
+        if(std::regex_match(line, match, exported_sqlite))
+        {
+            leaked.push_back(match[1].str());
+        }
+    }
+
+    std::string detail;
+    for(const auto& symbol : leaked)
+    {
+        detail += "\n  " + symbol;
+    }
+
+    EXPECT_TRUE(leaked.empty())
+        << "'" << k_shared_library << "' exports " << leaked.size()
+        << " bundled sqlite3_* symbol(s):" << detail
+        << "\nThese must remain local (hidden) so they cannot collide with other "
+           "sqlite3 versions on TheRock. Check the -fvisibility=hidden compile "
+           "option on profiler-hub-sqlite3-static and the --exclude-libs link "
+           "option on the profiler-hub shared library.";
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary
Seals the bundled static SQLite so no sqlite3_* symbols are exported from libprofiler-hub.so, preventing collisions with (or interposition by) other sqlite3 versions bundled by sibling components on TheRock.

- Compile profiler-hub-sqlite3-static with -fvisibility=hidden so the ~262 sqlite3_* symbols stay local.
- Link libprofiler-hub.so with -Wl,--exclude-libs,libprofiler-hub-sqlite3-static.a so the linker does not re-export them.
- Add an nm-based regression guard (tests/regression/symbol_seal_test.cpp) that fails if any exported sqlite3_* dynamic symbol reappears. Wired only when the bundled SQLite is used (NOT PROFILER_HUB_SQLITE3_USE_SYSTEM).



## Test plan
- [x] sqlite3_symbol_seal regression gtest passes against the built libprofiler-hub.so.
- [x] Validated against the rocprofiler-systems build: 0 exported sqlite3_* symbols, ~269 local/hidden.

