### PR TITLE
[hipFile] Add sanitizer flags to fetched libraries.

### DIFF
--- a/projects/hipfile/cmake/AISSanitizers.cmake
+++ b/projects/hipfile/cmake/AISSanitizers.cmake
@@ -18,6 +18,11 @@ function(ais_add_sanitizers target)
         message(FATAL_ERROR "AIS_USE_SANITIZERS is not compatible with AIS_USE_THREAD_SANITIZER")
     endif()
 
+    get_target_property(aliased_target "${target}" ALIASED_TARGET)
+    if(aliased_target)
+        set(target "${aliased_target}")
+    endif()
+
     if(AIS_USE_SANITIZERS)
         set(SANITIZER_LIST address,float-divide-by-zero,integer,leak,local-bounds,nullability,undefined,vptr)
         target_compile_options(${target} PRIVATE

--- a/projects/hipfile/cmake/AISUseGTest.cmake
+++ b/projects/hipfile/cmake/AISUseGTest.cmake
@@ -42,6 +42,11 @@ else()
     message(STATUS "Using system GoogleTest")
 endif()
 
+if(AIS_USE_SANITIZERS OR AIS_USE_THREAD_SANITIZER)
+    ais_add_sanitizers(GTest::gtest)
+    ais_add_sanitizers(GTest::gmock)
+endif()
+
 include(GoogleTest)
 
 function(ais_gtest_discover_tests target)

--- a/projects/hipfile/cmake/AISUseTBB.cmake
+++ b/projects/hipfile/cmake/AISUseTBB.cmake
@@ -32,3 +32,7 @@ if(NOT TBB_FOUND)
 else()
     message(STATUS "Using system TBB")
 endif()
+
+if(AIS_USE_SANITIZERS OR AIS_USE_THREAD_SANITIZER)
+    ais_add_sanitizers(TBB::tbb)
+endif()


### PR DESCRIPTION
The sanitizer flags were not being applied to our fetched libraries.  This PR gets the target from each alias, and sets the sanitizer flags on it.