### PR TITLE
[ci] Fix therock-ci-nightly missing package_version input

### DIFF
--- a/.github/workflows/therock-ci-nightly.yml
+++ b/.github/workflows/therock-ci-nightly.yml
@@ -32,6 +32,7 @@ jobs:
       linux_projects: ${{ steps.linux_projects.outputs.projects }}
       windows_projects: ${{ steps.windows_projects.outputs.projects }}
       run_linux_rccl_ci: ${{ steps.linux_projects.outputs.run_linux_rccl_ci }}
+      package_version: ${{ steps.rocm_package_version.outputs.rocm_package_version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -39,6 +40,13 @@ jobs:
           sparse-checkout: .github
           sparse-checkout-cone-mode: true
           fetch-depth: 2
+
+      - name: Checkout TheRock repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: "ROCm/TheRock"
+          path: TheRock
+          ref: 685f8c3b89006309b34a7c16de17e841400f0d76 # 2025-05-29 commit
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
@@ -66,6 +74,11 @@ jobs:
         run: |
           python .github/scripts/therock_configure_ci.py
 
+      - name: Compute package version
+        id: rocm_package_version
+        run: |
+          python TheRock/build_tools/compute_rocm_package_version.py --release-type=dev
+
   therock-ci-linux:
     name: Linux (${{ matrix.projects.projects_to_test }})
     permissions:
@@ -82,6 +95,7 @@ jobs:
     with:
       cmake_options: ${{ matrix.projects.cmake_options }}
       projects_to_test: ${{ matrix.projects.projects_to_test }}
+      package_version: ${{ needs.setup.outputs.package_version }}
 
   therock-rccl-ci-linux:
     name: TheRock RCCL CI Linux
@@ -99,6 +113,7 @@ jobs:
     with:
       amdgpu_families: ${{ matrix.amdgpu_family }}
       artifact_group: ${{ matrix.amdgpu_family }}
+      package_version: ${{ needs.setup.outputs.package_version }}
       cmake_options: >
         -DTHEROCK_ENABLE_ALL=OFF
         -DTHEROCK_BUILD_TESTING=ON
@@ -123,3 +138,4 @@ jobs:
     with:
       cmake_options: ${{ matrix.projects.cmake_options }}
       projects_to_test: ${{ matrix.projects.projects_to_test }}
+      package_version: ${{ needs.setup.outputs.package_version }}


### PR DESCRIPTION
Add package_version computation to the nightly workflow setup job, matching the pattern in therock-ci.yml. This fixes the workflow validation error "Input package_version is required, but not provided".

Works here: https://github.com/ROCm/rocm-systems/actions/runs/27150396761/job/80139626609 (cancelled to save resources)

Also cancelled CI job to save resources