### PR TITLE
[RCCL] Enable symmetric-memory ReduceScatter (RailA2A_LsaLD) kernel

### DIFF
--- a/projects/rccl/src/collectives.cc
+++ b/projects/rccl/src/collectives.cc
@@ -17,6 +17,7 @@
 #include "dda_reduce_scatter_ipc.h"
 #include "dda_all_gather_ipc.h"
 #include "dda_alltoall_ipc.h"
+#include "sym_kernels.h"
 
 #ifdef ENABLE_ROCSHMEM
 #include <rocshmem/rocshmem.hpp>
@@ -561,7 +562,17 @@ ncclResult_t ncclReduceScatter_impl(const void* sendbuff, void* recvbuff, size_t
 
   // Reset value forcing direct reduce scatter algorithm 
   comm->enableDirectReduceScatter = 0;
-  if (rcclDdaEnabled(comm, nRanks * recvcount * ncclTypeSize(datatype), 8388608) &&
+
+  // Skip DIRECT (DDA IPC and legacy) if the symmetric path will handle this op, so both don't run and deadlock.
+  bool symEligible = false;
+  // Symmetric reduce-scatter is sum-only (refer ncclSymkImplemented), so only gate on ncclSum.
+  if (comm->symmetricSupport && op == ncclSum) {
+    NCCLCHECK(ncclSymkInitOnce(comm));
+    symEligible = ncclSymkAvailable(comm, ncclFuncReduceScatter, (int)ncclDevSum, datatype, recvcount);
+  }
+
+  if (!symEligible &&
+      rcclDdaEnabled(comm, nRanks * recvcount * ncclTypeSize(datatype), 8388608) &&
       ncclReduceScatterDdaIpcEligible(comm, sendbuff, recvbuff, recvcount, datatype, op)) {
     NCCLCHECK(ncclReduceScatterDdaIpc(
         sendbuff,
@@ -574,7 +585,7 @@ ncclResult_t ncclReduceScatter_impl(const void* sendbuff, void* recvbuff, size_t
     return ncclSuccess;
   }
 
-  if (rcclUseReduceScatterDirect(comm, msgSize)) {
+  if (!symEligible && rcclUseReduceScatterDirect(comm, msgSize)) {
     INFO(NCCL_INIT, "RCCL DIRECT REDUCE-SCATTER recvcount=%zu msgSize=%zu rank=%d nRanks=%d nNodes=%d comm=%p stream=%p sendbuff=%p recvbuff=%p",
       recvcount, msgSize, comm->rank, nRanks, comm->nNodes, comm, stream, sendbuff, recvbuff);
 

--- a/projects/rccl/src/collectives.cc
+++ b/projects/rccl/src/collectives.cc
@@ -564,11 +564,12 @@ ncclResult_t ncclReduceScatter_impl(const void* sendbuff, void* recvbuff, size_t
   comm->enableDirectReduceScatter = 0;
 
   // Skip DDA IPC and Direct RS if the symmetric path will handle this op, so they don't collide and deadlock.
+  // Symmetric reduce-scatter implements sum and avg (ncclDevSumPostDiv), refer ncclSymkImplemented
   bool symEligible = false;
-  // Symmetric reduce-scatter is sum-only (refer ncclSymkImplemented), so only gate on ncclSum.
-  if (comm->symmetricSupport && op == ncclSum) {
+  if (comm->symmetricSupport && (op == ncclSum || op == ncclAvg)) {
     NCCLCHECK(ncclSymkInitOnce(comm));
-    symEligible = ncclSymkAvailable(comm, ncclFuncReduceScatter, (int)ncclDevSum, datatype, recvcount);
+    int symkOp = (op == ncclAvg) ? (int)ncclDevSumPostDiv : (int)ncclDevSum;
+    symEligible = ncclSymkAvailable(comm, ncclFuncReduceScatter, symkOp, datatype, recvcount);
   }
 
   if (!symEligible &&

--- a/projects/rccl/src/collectives.cc
+++ b/projects/rccl/src/collectives.cc
@@ -563,7 +563,7 @@ ncclResult_t ncclReduceScatter_impl(const void* sendbuff, void* recvbuff, size_t
   // Reset value forcing direct reduce scatter algorithm 
   comm->enableDirectReduceScatter = 0;
 
-  // Skip DIRECT (DDA IPC and legacy) if the symmetric path will handle this op, so both don't run and deadlock.
+  // Skip DDA IPC and Direct RS if the symmetric path will handle this op, so they don't collide and deadlock.
   bool symEligible = false;
   // Symmetric reduce-scatter is sum-only (refer ncclSymkImplemented), so only gate on ncclSum.
   if (comm->symmetricSupport && op == ncclSum) {

--- a/projects/rccl/src/device/reduce_kernel.h
+++ b/projects/rccl/src/device/reduce_kernel.h
@@ -891,6 +891,42 @@ struct FuncSumPostDiv<__nv_fp8_e5m2> {
 #endif
 #endif
 
+#if defined(__HIP_PLATFORM_AMD__)
+// FuncSumPostDiv for the raw ROCm float types exists only so the GIN kernel's mmRed
+// (Red<rawT> srcRedMc) is a constructible type; its reduce/postOp are never invoked on
+// ROCm (non-multimem), where avg is accumulated in a float AccT via srcRedUc.
+template<>
+struct FuncSumPostDiv<hip_bfloat16> {
+  using EltType = hip_bfloat16;
+  float scalar;
+  __device__ __forceinline__ FuncSumPostDiv(uint64_t opArg=0) {
+    union { uint64_t u64; float val; };
+    u64 = opArg;
+    scalar = val;
+  }
+};
+template<>
+struct FuncSumPostDiv<rccl_float8> {
+  using EltType = rccl_float8;
+  float scalar;
+  __device__ __forceinline__ FuncSumPostDiv(uint64_t opArg=0) {
+    union { uint64_t u64; float val; };
+    u64 = opArg;
+    scalar = val;
+  }
+};
+template<>
+struct FuncSumPostDiv<rccl_bfloat8> {
+  using EltType = rccl_bfloat8;
+  float scalar;
+  __device__ __forceinline__ FuncSumPostDiv(uint64_t opArg=0) {
+    union { uint64_t u64; float val; };
+    u64 = opArg;
+    scalar = val;
+  }
+};
+#endif
+
 template<typename T>
 struct Divider {
   __device__ __forceinline__ static T divide(T dividend, T divisor) {

--- a/projects/rccl/src/device/symmetric/data_ops.cuh
+++ b/projects/rccl/src/device/symmetric/data_ops.cuh
@@ -25,9 +25,8 @@ static __device__ __forceinline__ T ldcs(GMemTag, T *p) {
     uint64_t u64[(sizeof(T)+8-1)/8];
     uint4 u32v4[(sizeof(T)+16-1)/16];
   };
-  // HIP/ROCm has no __ldcs(); use clang non-temporal (streaming) loads instead.
-  // The 16-byte case is decomposed into two 8-byte loads since HIP's uint4 is a
-  // struct, not a type accepted by __builtin_nontemporal_load (see op128.h).
+#if defined(__HIP_PLATFORM_AMD__)
+  // HIP has no __ldcs(); use clang non-temporal loads (16B as two 8B; HIP uint4 is a struct).
   switch (alignof(T)) {
   case 1: for (int i=0; i < sizeof(T)/1; i++) u8[i] = __builtin_nontemporal_load((uint8_t*)p + i); break;
   case 2: for (int i=0; i < sizeof(T)/2; i++) u16[i] = __builtin_nontemporal_load((uint16_t*)p + i); break;
@@ -36,6 +35,16 @@ static __device__ __forceinline__ T ldcs(GMemTag, T *p) {
   case 16: for (int i=0; i < sizeof(T)/8; i++) u64[i] = __builtin_nontemporal_load((uint64_t*)p + i); break;
   default: __builtin_unreachable();
   }
+#else
+  switch (alignof(T)) {
+  case 1: for (int i=0; i < sizeof(T)/1; i++) u8[i] = __ldcs((uint8_t*)p + i); break;
+  case 2: for (int i=0; i < sizeof(T)/2; i++) u16[i] = __ldcs((uint16_t*)p + i); break;
+  case 4: for (int i=0; i < sizeof(T)/4; i++) u32[i] = __ldcs((uint32_t*)p + i); break;
+  case 8: for (int i=0; i < sizeof(T)/8; i++) u64[i] = __ldcs((uint64_t*)p + i); break;
+  case 16: for (int i=0; i < sizeof(T)/16; i++) u32v4[i] = __ldcs((uint4*)p + i); break;
+  default: __builtin_unreachable();
+  }
+#endif
   return x;
 }
 
@@ -61,9 +70,8 @@ static __device__ __forceinline__ void stcs(GMemTag, T *p, T val) {
     uint4 u32v4[(sizeof(T)+16-1)/16];
   };
   x = val;
-  // HIP/ROCm has no __stcs(); use clang non-temporal (streaming) stores instead.
-  // Note __builtin_nontemporal_store takes (value, ptr). The 16-byte case is
-  // decomposed into two 8-byte stores (HIP uint4 is a struct, see op128.h).
+#if defined(__HIP_PLATFORM_AMD__)
+  // HIP has no __stcs(); use clang non-temporal stores, arg order (value, ptr) (16B as two 8B).
   switch (alignof(T)) {
   case 1: for (int i=0; i < sizeof(T)/1; i++) __builtin_nontemporal_store(u8[i], (uint8_t*)p + i); break;
   case 2: for (int i=0; i < sizeof(T)/2; i++) __builtin_nontemporal_store(u16[i], (uint16_t*)p + i); break;
@@ -72,6 +80,16 @@ static __device__ __forceinline__ void stcs(GMemTag, T *p, T val) {
   case 16: for (int i=0; i < sizeof(T)/8; i++) __builtin_nontemporal_store(u64[i], (uint64_t*)p + i); break;
   default: __builtin_unreachable();
   }
+#else
+  switch (alignof(T)) {
+  case 1: for (int i=0; i < sizeof(T)/1; i++) __stcs((uint8_t*)p + i, u8[i]); break;
+  case 2: for (int i=0; i < sizeof(T)/2; i++) __stcs((uint16_t*)p + i, u16[i]); break;
+  case 4: for (int i=0; i < sizeof(T)/4; i++) __stcs((uint32_t*)p + i, u32[i]); break;
+  case 8: for (int i=0; i < sizeof(T)/8; i++) __stcs((uint64_t*)p + i, u64[i]); break;
+  case 16: for (int i=0; i < sizeof(T)/16; i++) __stcs((uint4*)p + i, u32v4[i]); break;
+  default: __builtin_unreachable();
+  }
+#endif
 }
 
 // Load packs from element buffer. Pack index=0 is loaded from the buffer rounded

--- a/projects/rccl/src/device/symmetric/data_ops.cuh
+++ b/projects/rccl/src/device/symmetric/data_ops.cuh
@@ -30,14 +30,17 @@ static __device__ __forceinline__ T ldcs(GMemTag, T *p) {
     uint4 u32v4[(sizeof(T)+16-1)/16];
   };
 #if defined(__HIP_PLATFORM_AMD__)
-  // HIP has no __ldcs(); use clang non-temporal loads (16B as two 8B; HIP uint4 is a struct).
-  switch (alignof(T)) {
-  case 1: for (int i=0; i < sizeof(T)/1; i++) u8[i] = __builtin_nontemporal_load((uint8_t*)p + i); break;
-  case 2: for (int i=0; i < sizeof(T)/2; i++) u16[i] = __builtin_nontemporal_load((uint16_t*)p + i); break;
-  case 4: for (int i=0; i < sizeof(T)/4; i++) u32[i] = __builtin_nontemporal_load((uint32_t*)p + i); break;
-  case 8: for (int i=0; i < sizeof(T)/8; i++) u64[i] = __builtin_nontemporal_load((uint64_t*)p + i); break;
-  case 16: for (int i=0; i < sizeof(T)/8; i++) u64[i] = __builtin_nontemporal_load((uint64_t*)p + i); break;
-  default: __builtin_unreachable();
+  // HIP has no __ldcs(); use clang non-temporal loads, dispatched on alignof(T).
+  if constexpr (alignof(T) == 1) {
+    for (int i=0; i < sizeof(T)/1; i++) u8[i] = __builtin_nontemporal_load((uint8_t*)p + i);
+  } else if constexpr (alignof(T) == 2) {
+    for (int i=0; i < sizeof(T)/2; i++) u16[i] = __builtin_nontemporal_load((uint16_t*)p + i);
+  } else if constexpr (alignof(T) == 4) {
+    for (int i=0; i < sizeof(T)/4; i++) u32[i] = __builtin_nontemporal_load((uint32_t*)p + i);
+  } else if constexpr (alignof(T) == 8 || alignof(T) == 16) {
+    for (int i=0; i < sizeof(T)/8; i++) u64[i] = __builtin_nontemporal_load((uint64_t*)p + i);
+  } else {
+    __builtin_unreachable();
   }
 #else
   switch (alignof(T)) {
@@ -75,14 +78,17 @@ static __device__ __forceinline__ void stcs(GMemTag, T *p, T val) {
   };
   x = val;
 #if defined(__HIP_PLATFORM_AMD__)
-  // HIP has no __stcs(); use clang non-temporal stores, arg order (value, ptr) (16B as two 8B).
-  switch (alignof(T)) {
-  case 1: for (int i=0; i < sizeof(T)/1; i++) __builtin_nontemporal_store(u8[i], (uint8_t*)p + i); break;
-  case 2: for (int i=0; i < sizeof(T)/2; i++) __builtin_nontemporal_store(u16[i], (uint16_t*)p + i); break;
-  case 4: for (int i=0; i < sizeof(T)/4; i++) __builtin_nontemporal_store(u32[i], (uint32_t*)p + i); break;
-  case 8: for (int i=0; i < sizeof(T)/8; i++) __builtin_nontemporal_store(u64[i], (uint64_t*)p + i); break;
-  case 16: for (int i=0; i < sizeof(T)/8; i++) __builtin_nontemporal_store(u64[i], (uint64_t*)p + i); break;
-  default: __builtin_unreachable();
+  // HIP has no __stcs(); use clang non-temporal stores (value, ptr), dispatched on alignof(T).
+  if constexpr (alignof(T) == 1) {
+    for (int i=0; i < sizeof(T)/1; i++) __builtin_nontemporal_store(u8[i], (uint8_t*)p + i);
+  } else if constexpr (alignof(T) == 2) {
+    for (int i=0; i < sizeof(T)/2; i++) __builtin_nontemporal_store(u16[i], (uint16_t*)p + i);
+  } else if constexpr (alignof(T) == 4) {
+    for (int i=0; i < sizeof(T)/4; i++) __builtin_nontemporal_store(u32[i], (uint32_t*)p + i);
+  } else if constexpr (alignof(T) == 8 || alignof(T) == 16) {
+    for (int i=0; i < sizeof(T)/8; i++) __builtin_nontemporal_store(u64[i], (uint64_t*)p + i);
+  } else {
+    __builtin_unreachable();
   }
 #else
   switch (alignof(T)) {

--- a/projects/rccl/src/device/symmetric/data_ops.cuh
+++ b/projects/rccl/src/device/symmetric/data_ops.cuh
@@ -1,4 +1,4 @@
-#include "primitives.cuh"
+#include "symmetric/primitives.h"
 
 struct SMemTag {}; // Shared memory
 struct GMemTag {}; // Global memory
@@ -25,12 +25,15 @@ static __device__ __forceinline__ T ldcs(GMemTag, T *p) {
     uint64_t u64[(sizeof(T)+8-1)/8];
     uint4 u32v4[(sizeof(T)+16-1)/16];
   };
+  // HIP/ROCm has no __ldcs(); use clang non-temporal (streaming) loads instead.
+  // The 16-byte case is decomposed into two 8-byte loads since HIP's uint4 is a
+  // struct, not a type accepted by __builtin_nontemporal_load (see op128.h).
   switch (alignof(T)) {
-  case 1: for (int i=0; i < sizeof(T)/1; i++) u8[i] = __ldcs((uint8_t*)p + i); break;
-  case 2: for (int i=0; i < sizeof(T)/2; i++) u16[i] = __ldcs((uint16_t*)p + i); break;
-  case 4: for (int i=0; i < sizeof(T)/4; i++) u32[i] = __ldcs((uint32_t*)p + i); break;
-  case 8: for (int i=0; i < sizeof(T)/8; i++) u64[i] = __ldcs((uint64_t*)p + i); break;
-  case 16: for (int i=0; i < sizeof(T)/16; i++) u32v4[i] = __ldcs((uint4*)p + i); break;
+  case 1: for (int i=0; i < sizeof(T)/1; i++) u8[i] = __builtin_nontemporal_load((uint8_t*)p + i); break;
+  case 2: for (int i=0; i < sizeof(T)/2; i++) u16[i] = __builtin_nontemporal_load((uint16_t*)p + i); break;
+  case 4: for (int i=0; i < sizeof(T)/4; i++) u32[i] = __builtin_nontemporal_load((uint32_t*)p + i); break;
+  case 8: for (int i=0; i < sizeof(T)/8; i++) u64[i] = __builtin_nontemporal_load((uint64_t*)p + i); break;
+  case 16: for (int i=0; i < sizeof(T)/8; i++) u64[i] = __builtin_nontemporal_load((uint64_t*)p + i); break;
   default: __builtin_unreachable();
   }
   return x;
@@ -58,12 +61,15 @@ static __device__ __forceinline__ void stcs(GMemTag, T *p, T val) {
     uint4 u32v4[(sizeof(T)+16-1)/16];
   };
   x = val;
+  // HIP/ROCm has no __stcs(); use clang non-temporal (streaming) stores instead.
+  // Note __builtin_nontemporal_store takes (value, ptr). The 16-byte case is
+  // decomposed into two 8-byte stores (HIP uint4 is a struct, see op128.h).
   switch (alignof(T)) {
-  case 1: for (int i=0; i < sizeof(T)/1; i++) __stcs((uint8_t*)p + i, u8[i]); break;
-  case 2: for (int i=0; i < sizeof(T)/2; i++) __stcs((uint16_t*)p + i, u16[i]); break;
-  case 4: for (int i=0; i < sizeof(T)/4; i++) __stcs((uint32_t*)p + i, u32[i]); break;
-  case 8: for (int i=0; i < sizeof(T)/8; i++) __stcs((uint64_t*)p + i, u64[i]); break;
-  case 16: for (int i=0; i < sizeof(T)/16; i++) __stcs((uint4*)p + i, u32v4[i]); break;
+  case 1: for (int i=0; i < sizeof(T)/1; i++) __builtin_nontemporal_store(u8[i], (uint8_t*)p + i); break;
+  case 2: for (int i=0; i < sizeof(T)/2; i++) __builtin_nontemporal_store(u16[i], (uint16_t*)p + i); break;
+  case 4: for (int i=0; i < sizeof(T)/4; i++) __builtin_nontemporal_store(u32[i], (uint32_t*)p + i); break;
+  case 8: for (int i=0; i < sizeof(T)/8; i++) __builtin_nontemporal_store(u64[i], (uint64_t*)p + i); break;
+  case 16: for (int i=0; i < sizeof(T)/8; i++) __builtin_nontemporal_store(u64[i], (uint64_t*)p + i); break;
   default: __builtin_unreachable();
   }
 }

--- a/projects/rccl/src/device/symmetric/data_ops.cuh
+++ b/projects/rccl/src/device/symmetric/data_ops.cuh
@@ -1,4 +1,8 @@
+#if defined(__HIP_PLATFORM_AMD__)
 #include "symmetric/primitives.h"
+#else
+#include "primitives.cuh"
+#endif
 
 struct SMemTag {}; // Shared memory
 struct GMemTag {}; // Global memory

--- a/projects/rccl/src/device/symmetric/generate.py
+++ b/projects/rccl/src/device/symmetric/generate.py
@@ -103,11 +103,7 @@ def enumerate_kernels():
       for algo in ["LL","LD"]:
         # ReduceScatter emits sum and avg for every float type.
         yield Rec(coll="ReduceScatter", algo=algo, red=red, ty=ty)
-      # [RCCL] Multi-node GIN symmetric ReduceScatter (non-multicast). The
-      # multicast variant (RailA2A_LsaLDMC) is intentionally omitted: it is in
-      # kernelMask_LDMC and is masked off whenever LSA multimem is unavailable
-      # (always on ROCm/gfx, since there is no NVLS/multimem), so only the
-      # non-MC RailA2A_LsaLD kernel can ever be selected here.
+      # Multi-node GIN ReduceScatter; non-multicast only (no NVLS/multimem on ROCm).
       for algo in ["RailA2A_LsaLD"]:
         yield Rec(coll="ReduceScatter", algo=algo, red=red, ty=ty)
 
@@ -136,8 +132,7 @@ def kernel_fdep(k):
 
 def kernel_fname(k):
   if k.coll in reductions:
-    # GIN algos compile their own (heavier) device path; keep them in a
-    # separate TU so the intra-node LL/LD kernels are unaffected.
+    # GIN algos compile a heavier device path; keep them in a separate TU.
     if k.algo in gin_algos:
       return paste('_', coll_to_lower[k.coll], 'gin', k.red, k.ty) + '.cpp'
     if k.algo in ldmc_algos and k.ty.startswith('f8'):
@@ -221,8 +216,7 @@ for (fname, coll), ks in kernels_by_file.items():
     print("-- Generating %s" % os.path.join(gensrc, fname))
     emitln(f, '#include "sym_kernels.h"')
     emitln(f, '#include "symmetric/kernel.h"')
-    # GIN instantiation TUs pull in the *_gin.h header, which provides the
-    # ncclSymkRun_*_RailA2A/RailRing definitions (the non-GIN header does not).
+    # GIN instantiation TUs need the *_gin.h header for the RailA2A/RailRing defs.
     if ks and all(k.algo in gin_algos for k in ks):
       emitln(f, '#include "symmetric/{coll}_gin.h"'.format(coll=coll_to_lower[coll]))
     else:

--- a/projects/rccl/src/device/symmetric/generate.py
+++ b/projects/rccl/src/device/symmetric/generate.py
@@ -103,6 +103,13 @@ def enumerate_kernels():
       for algo in ["LL","LD"]:
         # ReduceScatter emits sum and avg for every float type.
         yield Rec(coll="ReduceScatter", algo=algo, red=red, ty=ty)
+      # [RCCL] Multi-node GIN symmetric ReduceScatter (non-multicast). The
+      # multicast variant (RailA2A_LsaLDMC) is intentionally omitted: it is in
+      # kernelMask_LDMC and is masked off whenever LSA multimem is unavailable
+      # (always on ROCm/gfx, since there is no NVLS/multimem), so only the
+      # non-MC RailA2A_LsaLD kernel can ever be selected here.
+      for algo in ["RailA2A_LsaLD"]:
+        yield Rec(coll="ReduceScatter", algo=algo, red=red, ty=ty)
 
 def required_cuda(k):
   cudart, arch, specific_sms  = 0, 600, None
@@ -129,6 +136,10 @@ def kernel_fdep(k):
 
 def kernel_fname(k):
   if k.coll in reductions:
+    # GIN algos compile their own (heavier) device path; keep them in a
+    # separate TU so the intra-node LL/LD kernels are unaffected.
+    if k.algo in gin_algos:
+      return paste('_', coll_to_lower[k.coll], 'gin', k.red, k.ty) + '.cpp'
     if k.algo in ldmc_algos and k.ty.startswith('f8'):
       return paste('_', coll_to_lower[k.coll], k.red, k.ty, k.algo) + '.cpp'
     else:
@@ -210,7 +221,12 @@ for (fname, coll), ks in kernels_by_file.items():
     print("-- Generating %s" % os.path.join(gensrc, fname))
     emitln(f, '#include "sym_kernels.h"')
     emitln(f, '#include "symmetric/kernel.h"')
-    emitln(f, '#include "symmetric/{coll}.h"'.format(coll=coll_to_lower[coll]))
+    # GIN instantiation TUs pull in the *_gin.h header, which provides the
+    # ncclSymkRun_*_RailA2A/RailRing definitions (the non-GIN header does not).
+    if ks and all(k.algo in gin_algos for k in ks):
+      emitln(f, '#include "symmetric/{coll}_gin.h"'.format(coll=coll_to_lower[coll]))
+    else:
+      emitln(f, '#include "symmetric/{coll}.h"'.format(coll=coll_to_lower[coll]))
     for k in ks:
       emitln(f, instantiate(k))
 

--- a/projects/rccl/src/device/symmetric/generate.py
+++ b/projects/rccl/src/device/symmetric/generate.py
@@ -104,7 +104,10 @@ def enumerate_kernels():
         # ReduceScatter emits sum and avg for every float type.
         yield Rec(coll="ReduceScatter", algo=algo, red=red, ty=ty)
       # Multi-node GIN ReduceScatter; non-multicast only (no NVLS/multimem on ROCm).
+      # Sum only: the GIN kernel has no avg (post-divide) accumulator path.
       for algo in ["RailA2A_LsaLD"]:
+        if red == "avg":
+          continue
         yield Rec(coll="ReduceScatter", algo=algo, red=red, ty=ty)
 
 def required_cuda(k):

--- a/projects/rccl/src/device/symmetric/generate.py
+++ b/projects/rccl/src/device/symmetric/generate.py
@@ -104,10 +104,7 @@ def enumerate_kernels():
         # ReduceScatter emits sum and avg for every float type.
         yield Rec(coll="ReduceScatter", algo=algo, red=red, ty=ty)
       # Multi-node GIN ReduceScatter; non-multicast only (no NVLS/multimem on ROCm).
-      # Sum only: the GIN kernel has no avg (post-divide) accumulator path.
       for algo in ["RailA2A_LsaLD"]:
-        if red == "avg":
-          continue
         yield Rec(coll="ReduceScatter", algo=algo, red=red, ty=ty)
 
 def required_cuda(k):

--- a/projects/rccl/src/device/symmetric/gin_scratch__funcs.h
+++ b/projects/rccl/src/device/symmetric/gin_scratch__funcs.h
@@ -225,7 +225,7 @@ NCCL_DEVICE_INLINE void ncclGinInboxA2ASession<Coop, ginBackendMask>::postSends(
     int nElts = getEltCount(i, peer);
     this->gin.put(this->team, peer,
       /*dst=*/this->getBufSymPtr(monoStep), /*src=*/(ncclSymPtr<char>)srcPtr,
-      /*size=*/nElts*(int)sizeof(decltype(srcPtr)::ElementType),
+      /*size=*/nElts*(int)sizeof(typename decltype(srcPtr)::ElementType),
       ncclGin_SignalInc{this->getR2RSignal(monoStep)},
       getCompletion(i, peer));
   }

--- a/projects/rccl/src/device/symmetric/primitives.cuh
+++ b/projects/rccl/src/device/symmetric/primitives.cuh
@@ -18,10 +18,7 @@ struct tmaSmemStruct {
   alignas(8) __mbarrier_t bar;
 };
 
-// HIP/ROCm does not provide CUDA's __isShared() address-space query, which the
-// symmetric kernels use only as a __builtin_assume() hint. Map it to the AMDGCN
-// builtin so these hints still compile. Guarded so we never clash with a HIP
-// runtime that already declares __isShared().
+// HIP has no __isShared() (used only as a __builtin_assume hint); map it to the AMDGCN builtin.
 #if defined(__HIP_PLATFORM_AMD__) && !defined(NCCL_SYMK_HAVE_ISSHARED)
 #define NCCL_SYMK_HAVE_ISSHARED 1
 static __device__ __forceinline__ bool __isShared(const void* p) {

--- a/projects/rccl/src/device/symmetric/primitives.cuh
+++ b/projects/rccl/src/device/symmetric/primitives.cuh
@@ -258,6 +258,13 @@ template<> struct ncclSymkGinAccumType<FuncSumPostDiv, __nv_fp8_e4m3> { using Ty
 template<> struct ncclSymkGinAccumType<FuncSumPostDiv, __nv_fp8_e5m2> { using Type = __half; };
 #endif
 
+#if defined(__HIP_PLATFORM_AMD__)
+// avg reduces in float on ROCm: raw bf16/fp8 have no FuncSumPostDiv, but FuncSumPostDiv<float> does.
+template<> struct ncclSymkGinAccumType<FuncSumPostDiv, hip_bfloat16> { using Type = float; };
+template<> struct ncclSymkGinAccumType<FuncSumPostDiv, rccl_float8>  { using Type = float; };
+template<> struct ncclSymkGinAccumType<FuncSumPostDiv, rccl_bfloat8> { using Type = float; };
+#endif
+
 static __device__ __forceinline__ void tmaLoadStoreMc(void* dest, void* smem, void* source, size_t size, __mbarrier_t* bar) {
   cp_async_bulk_global_to_shared(smem, source, bar, size);
   __mbarrier_token_t token = barrier_arrive1_tx_relaxed(bar, size);

--- a/projects/rccl/src/device/symmetric/primitives.cuh
+++ b/projects/rccl/src/device/symmetric/primitives.cuh
@@ -18,6 +18,17 @@ struct tmaSmemStruct {
   alignas(8) __mbarrier_t bar;
 };
 
+// HIP/ROCm does not provide CUDA's __isShared() address-space query, which the
+// symmetric kernels use only as a __builtin_assume() hint. Map it to the AMDGCN
+// builtin so these hints still compile. Guarded so we never clash with a HIP
+// runtime that already declares __isShared().
+#if defined(__HIP_PLATFORM_AMD__) && !defined(NCCL_SYMK_HAVE_ISSHARED)
+#define NCCL_SYMK_HAVE_ISSHARED 1
+static __device__ __forceinline__ bool __isShared(const void* p) {
+  return __builtin_amdgcn_is_shared((void*)p);
+}
+#endif
+
 #if __CUDA_ARCH__ >= 700
 // __grid_constant__ appears to break cuda-gdb
 #define NCCL_GRID_CONSTANT __grid_constant__

--- a/projects/rccl/src/device/symmetric/reduce_scatter_gin.cuh
+++ b/projects/rccl/src/device/symmetric/reduce_scatter_gin.cuh
@@ -1,7 +1,8 @@
 #include "sym_kernels.h"
-#include "kernel.cuh"
-#include "primitives.cuh"
-#include "data_ops.cuh"
+#include "symmetric/kernel.h"
+#include "symmetric/primitives.h"
+#include "symmetric/data_ops.h"
+#include "symmetric/gin_scratch__funcs.h"
 
 template<template<typename> typename Red, typename T, bool multimem>
 static __device__ void rsAlgoHier(ncclSymkDevWorkArgs const* args, BoolTag<multimem> multimemTag) {
@@ -16,7 +17,13 @@ static __device__ void rsAlgoHier(ncclSymkDevWorkArgs const* args, BoolTag<multi
   Red<AccT> red(handler.devWork->redOpArg);
   Red<T> mmRed(handler.devWork->redOpArg);
 
-  int nWorkWarps = blockDim.x/32 - 2;
+  // [RCCL] Warps here are hardware wavefronts of WARP_SIZE threads. ncclCoopWarpSpan
+  // measures thread_rank()/size()/sync() in units of WARP_SIZE (64 on gfx9), so the
+  // warp/role partitioning below must use WARP_SIZE too. Upstream NCCL hardcodes 32;
+  // keeping that on a wave64 GPU makes the stage-1 spans address threads [256,512) of a
+  // 256-thread block, yielding negative coop thread_rank() and out-of-bounds GIN signal
+  // indices (illegal memory access). Matches the WARP_SIZE usage in all_gather_gin.cuh.
+  int nWorkWarps = blockDim.x/WARP_SIZE - 2;
   int stage0_nWorkWarps;
   if (lsa.nRanks == 1) {
     stage0_nWorkWarps = 0; // Stage 0 just posts sends so no workers.
@@ -29,14 +36,14 @@ static __device__ void rsAlgoHier(ncclSymkDevWorkArgs const* args, BoolTag<multi
   }
 
   // 2 stage pipeline, one coop per stage.
-  int stage = threadIdx.x/32 < 1 + stage0_nWorkWarps ? 0 : 1;
+  int stage = threadIdx.x/WARP_SIZE < 1 + stage0_nWorkWarps ? 0 : 1;
   ncclCoopWarpSpan coopStage{
     /*warp0=*/stage == 0 ? 0 : 1 + stage0_nWorkWarps,
     /*nWarps=*/1 + (stage == 0 ? stage0_nWorkWarps : nWorkWarps-stage0_nWorkWarps),
     /*id=*/stage
   };
   // Within each stage we have 2 roles: GIN warp, worker warps.
-  bool roleIsWorker = 32 <= coopStage.thread_rank();
+  bool roleIsWorker = WARP_SIZE <= coopStage.thread_rank();
   ncclCoopWarpSpan coopRole{
     /*warp0=*/(stage == 0 ? 0 : 1 + stage0_nWorkWarps) + (roleIsWorker ? 1 : 0),
     /*nWarps=*/!roleIsWorker ? 1 : (stage == 0 ? stage0_nWorkWarps : nWorkWarps - stage0_nWorkWarps),
@@ -138,11 +145,10 @@ static __device__ void rsAlgoHier(ncclSymkDevWorkArgs const* args, BoolTag<multi
               if (!roleIsWorker) {
                 if (coopRole.thread_rank() == 0) {
                   // totalSends += rail.nRanks-1;
-                  #if __CUDA_ARCH__ >= 700
-                  asm volatile("red.relaxed.shared.add.s32 [%0],%1;" :: "r"((uint32_t)__cvta_generic_to_shared(&totalSends)), "r"(rail.nRanks-1) : "memory");
-                  #else
-                  __trap();
-                  #endif
+                  // [RCCL] The upstream NVPTX `red.relaxed.shared.add.s32` inline
+                  // asm has no amdgcn equivalent (the #else path traps). atomicAdd
+                  // lowers to a relaxed shared-memory atomic on both HIP and CUDA.
+                  atomicAdd(&totalSends, rail.nRanks-1);
                 }
               } else {
                 // outbox.apportion() was told to defer sync so that we don't sync
@@ -277,7 +283,7 @@ static __device__ void rsAlgoHier(ncclSymkDevWorkArgs const* args, BoolTag<multi
         gin.waitCounter(ncclCoopThread(), handler.ginCounterPerBlock + blockIdx.x, totalSends, 32);
       }
     } else {
-      outbox.template ~ncclGinOutboxSession<ncclCoopWarpSpan>();
+      outbox.~ncclGinOutboxSession<ncclCoopWarpSpan>();
     }
   }
 

--- a/projects/rccl/src/device/symmetric/reduce_scatter_gin.cuh
+++ b/projects/rccl/src/device/symmetric/reduce_scatter_gin.cuh
@@ -17,12 +17,8 @@ static __device__ void rsAlgoHier(ncclSymkDevWorkArgs const* args, BoolTag<multi
   Red<AccT> red(handler.devWork->redOpArg);
   Red<T> mmRed(handler.devWork->redOpArg);
 
-  // [RCCL] Warps here are hardware wavefronts of WARP_SIZE threads. ncclCoopWarpSpan
-  // measures thread_rank()/size()/sync() in units of WARP_SIZE (64 on gfx9), so the
-  // warp/role partitioning below must use WARP_SIZE too. Upstream NCCL hardcodes 32;
-  // keeping that on a wave64 GPU makes the stage-1 spans address threads [256,512) of a
-  // 256-thread block, yielding negative coop thread_rank() and out-of-bounds GIN signal
-  // indices (illegal memory access). Matches the WARP_SIZE usage in all_gather_gin.cuh.
+  // Warp/role partitioning is in units of WARP_SIZE (64 on gfx9); upstream's hardcoded 32
+  // would address threads past the block on wave64. ncclCoopWarpSpan uses WARP_SIZE too.
   int nWorkWarps = blockDim.x/WARP_SIZE - 2;
   int stage0_nWorkWarps;
   if (lsa.nRanks == 1) {
@@ -49,6 +45,9 @@ static __device__ void rsAlgoHier(ncclSymkDevWorkArgs const* args, BoolTag<multi
     /*nWarps=*/!roleIsWorker ? 1 : (stage == 0 ? stage0_nWorkWarps : nWorkWarps - stage0_nWorkWarps),
     /*id=*/2 + stage
   };
+
+  // Zero the AMD software warp-span barrier slots before any coop sync (no-op on NVIDIA).
+  ncclCoopNamedBarrierInit();
 
   // Construct outbox only for stage=0 when lsa peers exist.
   alignas(ncclGinOutboxSession<ncclCoopWarpSpan>) char outbox_storage[sizeof(ncclGinOutboxSession<ncclCoopWarpSpan>)];
@@ -144,10 +143,7 @@ static __device__ void rsAlgoHier(ncclSymkDevWorkArgs const* args, BoolTag<multi
             /*initFn*/[&]__device__(int nChunkElts, ncclSymPtr<T> inPtr)->void {
               if (!roleIsWorker) {
                 if (coopRole.thread_rank() == 0) {
-                  // totalSends += rail.nRanks-1;
-                  // [RCCL] The upstream NVPTX `red.relaxed.shared.add.s32` inline
-                  // asm has no amdgcn equivalent (the #else path traps). atomicAdd
-                  // lowers to a relaxed shared-memory atomic on both HIP and CUDA.
+                  // Portable replacement for upstream's NVPTX red.shared.add asm (no amdgcn equiv).
                   atomicAdd(&totalSends, rail.nRanks-1);
                 }
               } else {

--- a/projects/rccl/src/device/symmetric/reduce_scatter_gin.cuh
+++ b/projects/rccl/src/device/symmetric/reduce_scatter_gin.cuh
@@ -1,8 +1,14 @@
 #include "sym_kernels.h"
+#if defined(__HIP_PLATFORM_AMD__)
 #include "symmetric/kernel.h"
 #include "symmetric/primitives.h"
 #include "symmetric/data_ops.h"
 #include "symmetric/gin_scratch__funcs.h"
+#else
+#include "kernel.cuh"
+#include "primitives.cuh"
+#include "data_ops.cuh"
+#endif
 
 template<template<typename> typename Red, typename T, bool multimem>
 static __device__ void rsAlgoHier(ncclSymkDevWorkArgs const* args, BoolTag<multimem> multimemTag) {
@@ -17,9 +23,12 @@ static __device__ void rsAlgoHier(ncclSymkDevWorkArgs const* args, BoolTag<multi
   Red<AccT> red(handler.devWork->redOpArg);
   Red<T> mmRed(handler.devWork->redOpArg);
 
-  // Warp/role partitioning is in units of WARP_SIZE (64 on gfx9); upstream's hardcoded 32
-  // would address threads past the block on wave64. ncclCoopWarpSpan uses WARP_SIZE too.
+  // Use WARP_SIZE, not a hardcoded 32, so warp partitioning is correct on AMD's 64-lane wavefronts.
+#if defined(__HIP_PLATFORM_AMD__)
   int nWorkWarps = blockDim.x/WARP_SIZE - 2;
+#else
+  int nWorkWarps = blockDim.x/32 - 2;
+#endif
   int stage0_nWorkWarps;
   if (lsa.nRanks == 1) {
     stage0_nWorkWarps = 0; // Stage 0 just posts sends so no workers.
@@ -32,14 +41,22 @@ static __device__ void rsAlgoHier(ncclSymkDevWorkArgs const* args, BoolTag<multi
   }
 
   // 2 stage pipeline, one coop per stage.
+#if defined(__HIP_PLATFORM_AMD__)
   int stage = threadIdx.x/WARP_SIZE < 1 + stage0_nWorkWarps ? 0 : 1;
+#else
+  int stage = threadIdx.x/32 < 1 + stage0_nWorkWarps ? 0 : 1;
+#endif
   ncclCoopWarpSpan coopStage{
     /*warp0=*/stage == 0 ? 0 : 1 + stage0_nWorkWarps,
     /*nWarps=*/1 + (stage == 0 ? stage0_nWorkWarps : nWorkWarps-stage0_nWorkWarps),
     /*id=*/stage
   };
   // Within each stage we have 2 roles: GIN warp, worker warps.
+#if defined(__HIP_PLATFORM_AMD__)
   bool roleIsWorker = WARP_SIZE <= coopStage.thread_rank();
+#else
+  bool roleIsWorker = 32 <= coopStage.thread_rank();
+#endif
   ncclCoopWarpSpan coopRole{
     /*warp0=*/(stage == 0 ? 0 : 1 + stage0_nWorkWarps) + (roleIsWorker ? 1 : 0),
     /*nWarps=*/!roleIsWorker ? 1 : (stage == 0 ? stage0_nWorkWarps : nWorkWarps - stage0_nWorkWarps),
@@ -143,8 +160,17 @@ static __device__ void rsAlgoHier(ncclSymkDevWorkArgs const* args, BoolTag<multi
             /*initFn*/[&]__device__(int nChunkElts, ncclSymPtr<T> inPtr)->void {
               if (!roleIsWorker) {
                 if (coopRole.thread_rank() == 0) {
+#if defined(__HIP_PLATFORM_AMD__)
                   // Portable replacement for upstream's NVPTX red.shared.add asm (no amdgcn equiv).
                   atomicAdd(&totalSends, rail.nRanks-1);
+#else
+                  // totalSends += rail.nRanks-1;
+                  #if __CUDA_ARCH__ >= 700
+                  asm volatile("red.relaxed.shared.add.s32 [%0],%1;" :: "r"((uint32_t)__cvta_generic_to_shared(&totalSends)), "r"(rail.nRanks-1) : "memory");
+                  #else
+                  __trap();
+                  #endif
+#endif
                 }
               } else {
                 // outbox.apportion() was told to defer sync so that we don't sync
@@ -279,7 +305,11 @@ static __device__ void rsAlgoHier(ncclSymkDevWorkArgs const* args, BoolTag<multi
         gin.waitCounter(ncclCoopThread(), handler.ginCounterPerBlock + blockIdx.x, totalSends, 32);
       }
     } else {
+#if defined(__HIP_PLATFORM_AMD__)
       outbox.~ncclGinOutboxSession<ncclCoopWarpSpan>();
+#else
+      outbox.template ~ncclGinOutboxSession<ncclCoopWarpSpan>();
+#endif
     }
   }
 

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -141,7 +141,7 @@ ncclResult_t ncclInitKernelsForDevice(int cudaArch, int maxSharedMem, size_t* ma
           cudaFuncAttributeMaxDynamicSharedMemorySize, dynSmem),
           result, next_kernel);
         ncclSymkKernelMaxDynamicSmem[k] = dynSmem;
-        goto next_kernel;
+        continue; // sym kernels skip the legacy ncclMaxSharedMem path
       }
 #endif
       if (ncclMaxSharedMem != 0) {

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -131,6 +131,26 @@ ncclResult_t ncclInitKernelsForDevice(int cudaArch, int maxSharedMem, size_t* ma
           result, ignore1);
       ignore1:;
       }
+#ifdef GENERATE_SYM_KERNELS
+      if (sym == 1) {
+        // [RCCL] Match upstream NCCL ncclInitKernelsForDevice(): symmetric
+        // kernels get the maximum dynamic LDS the device/function allows, and
+        // that size is recorded in ncclSymkKernelMaxDynamicSmem[] so the device
+        // (args->maxDynamicSmem) and the launch (plan->kernelDynSmem) agree on
+        // the per-chunk accumulator size (maxChunkElts = maxDynamicSmem/sizeof(AccT)).
+        // The RCCL 2.29.7 port dropped both this table write and the matching
+        // launch-time use of plan->kernelDynSmem (see ncclLaunchKernelInner),
+        // leaving the table 0 -> maxChunkElts == 0 -> runaway chunk loop and an
+        // illegal memory access.
+        int dynSmem = maxSharedMem - attr.sharedSizeBytes;
+        if (dynSmem < 0) dynSmem = 0;
+        CUDACHECKGOTO(cudaFuncSetAttribute(fn,
+          cudaFuncAttributeMaxDynamicSharedMemorySize, dynSmem),
+          result, next_kernel);
+        ncclSymkKernelMaxDynamicSmem[k] = dynSmem;
+        goto next_kernel;
+      }
+#endif
       if (ncclMaxSharedMem != 0) {
         int sharedMemSize = ncclMaxSharedMem;
         if (sharedMemSize > (maxSharedMem-attr.sharedSizeBytes)) {

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -141,7 +141,7 @@ ncclResult_t ncclInitKernelsForDevice(int cudaArch, int maxSharedMem, size_t* ma
           cudaFuncAttributeMaxDynamicSharedMemorySize, dynSmem),
           result, next_kernel);
         ncclSymkKernelMaxDynamicSmem[k] = dynSmem;
-        continue; // sym kernels skip the legacy ncclMaxSharedMem path
+        continue; // sym kernels skip the non-symmetric ncclMaxSharedMem path
       }
 #endif
       if (ncclMaxSharedMem != 0) {

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -133,15 +133,8 @@ ncclResult_t ncclInitKernelsForDevice(int cudaArch, int maxSharedMem, size_t* ma
       }
 #ifdef GENERATE_SYM_KERNELS
       if (sym == 1) {
-        // [RCCL] Match upstream NCCL ncclInitKernelsForDevice(): symmetric
-        // kernels get the maximum dynamic LDS the device/function allows, and
-        // that size is recorded in ncclSymkKernelMaxDynamicSmem[] so the device
-        // (args->maxDynamicSmem) and the launch (plan->kernelDynSmem) agree on
-        // the per-chunk accumulator size (maxChunkElts = maxDynamicSmem/sizeof(AccT)).
-        // The RCCL 2.29.7 port dropped both this table write and the matching
-        // launch-time use of plan->kernelDynSmem (see ncclLaunchKernelInner),
-        // leaving the table 0 -> maxChunkElts == 0 -> runaway chunk loop and an
-        // illegal memory access.
+        // Symmetric kernels get max dynamic LDS, recorded in ncclSymkKernelMaxDynamicSmem[]
+        // so device (args->maxDynamicSmem) and launch (plan->kernelDynSmem) agree; matches upstream.
         int dynSmem = maxSharedMem - attr.sharedSizeBytes;
         if (dynSmem < 0) dynSmem = 0;
         CUDACHECKGOTO(cudaFuncSetAttribute(fn,

--- a/projects/rccl/src/include/nccl_device/coop.h
+++ b/projects/rccl/src/include/nccl_device/coop.h
@@ -147,6 +147,25 @@ struct ncclCoopLanes { // Some lanes of this warp.
 #endif
 
 #if NCCL_CHECK_CUDACC
+#if defined(__HIP_PLATFORM_AMD__)
+// AMD has no named barriers, so emulate sub-block warp-span sync with a shared,
+// sense-reversing barrier keyed by span id. Init must zero the slots before use.
+struct ncclCoopNamedBarrierSlot { uint32_t arrive; uint32_t sense; };
+
+NCCL_DEVICE_INLINE ncclCoopNamedBarrierSlot* ncclCoopNamedBarrierState() {
+  __shared__ ncclCoopNamedBarrierSlot slots[16];
+  return slots;
+}
+
+NCCL_DEVICE_INLINE void ncclCoopNamedBarrierInit() {
+  ncclCoopNamedBarrierSlot* slots = ncclCoopNamedBarrierState();
+  for (int i = threadIdx.x; i < 16; i += blockDim.x) { slots[i].arrive = 0; slots[i].sense = 0; }
+  __syncthreads();
+}
+#else
+NCCL_DEVICE_INLINE void ncclCoopNamedBarrierInit() {}
+#endif
+
 struct ncclCoopWarpSpan {
   uint32_t warp0:8, nWarps:8, id:8;
 
@@ -166,7 +185,23 @@ struct ncclCoopWarpSpan {
 
   NCCL_DEVICE_INLINE void sync() {
   #if defined(__HIP_PLATFORM_AMD__)
-    __syncthreads();
+    // __syncthreads() can't sync a subset of warps; emulate a named barrier in software.
+    // Single-warp span is lockstep: skip the shared atomic (hot path) and just fence.
+    using Atom = cuda::atomic_ref<uint32_t, cuda::thread_scope_block>;
+    if (nWarps <= 1) { cuda::atomic_thread_fence(cuda::memory_order_acq_rel, cuda::thread_scope_block); return; }
+    ncclCoopNamedBarrierSlot* slot = &ncclCoopNamedBarrierState()[id];
+    cuda::atomic_thread_fence(cuda::memory_order_release, cuda::thread_scope_block);
+    if ((threadIdx.x % WARP_SIZE) == 0) {  // one leader per warp
+      uint32_t s = Atom{slot->sense}.load(cuda::memory_order_relaxed);
+      if (Atom{slot->arrive}.fetch_add(1u, cuda::memory_order_relaxed) + 1u == (uint32_t)nWarps) {
+        Atom{slot->arrive}.store(0u, cuda::memory_order_relaxed);  // last in: reset, flip to release
+        Atom{slot->sense}.store(s ^ 1u, cuda::memory_order_release);
+      } else {
+        while (Atom{slot->sense}.load(cuda::memory_order_acquire) == s)
+          __builtin_amdgcn_s_sleep(1);
+      }
+    }
+    cuda::atomic_thread_fence(cuda::memory_order_acquire, cuda::thread_scope_block);
   #else
     asm volatile("barrier.sync %0, %1;" :: "r"(1+id), "r"(32*nWarps) : "memory");
     __barrier_sync_count(1+id, 32*nWarps);

--- a/projects/rccl/src/include/nccl_device/coop.h
+++ b/projects/rccl/src/include/nccl_device/coop.h
@@ -150,16 +150,17 @@ struct ncclCoopLanes { // Some lanes of this warp.
 #if defined(__HIP_PLATFORM_AMD__)
 // AMD has no named barriers, so emulate sub-block warp-span sync with a shared,
 // sense-reversing barrier keyed by span id. Init must zero the slots before use.
+constexpr int ncclCoopNamedBarrierSlots = 16; // mirrors CUDA's 16 hardware named barriers (ids 0-15)
 struct ncclCoopNamedBarrierSlot { uint32_t arrive; uint32_t sense; };
 
 NCCL_DEVICE_INLINE ncclCoopNamedBarrierSlot* ncclCoopNamedBarrierState() {
-  __shared__ ncclCoopNamedBarrierSlot slots[16];
+  __shared__ ncclCoopNamedBarrierSlot slots[ncclCoopNamedBarrierSlots];
   return slots;
 }
 
 NCCL_DEVICE_INLINE void ncclCoopNamedBarrierInit() {
   ncclCoopNamedBarrierSlot* slots = ncclCoopNamedBarrierState();
-  for (int i = threadIdx.x; i < 16; i += blockDim.x) { slots[i].arrive = 0; slots[i].sense = 0; }
+  for (int i = threadIdx.x; i < ncclCoopNamedBarrierSlots; i += blockDim.x) { slots[i].arrive = 0; slots[i].sense = 0; }
   __syncthreads();
 }
 #else

--- a/projects/rccl/src/include/nccl_device/gin/proxy/gin_proxy.h
+++ b/projects/rccl/src/include/nccl_device/gin/proxy/gin_proxy.h
@@ -216,21 +216,14 @@ NCCL_DEVICE_INLINE void put(Coop coop, ncclGinProxyGfd_t* gfd, ncclGinProxyGpuCt
                             ncclGinSignalDescriptor signal, ncclGinSignalOp_t signalOp,
                             uint64_t signalVal, bool hasCounter, ncclGinCounter_t counterId,
                             cuda::thread_scope required, cuda::thread_scope given) {
-  // The proxy hands the source buffer to the NIC, which is a system-scope agent
-  // (it DMA-reads GPU memory over PCIe), so the payload must be released to
-  // system scope before the GFD is published. `given` is the scope to which the
-  // caller has already released the source. Emit a system release fence whenever
-  // that is narrower than system.
-  //
-  // [RCCL] NOTE: RCCL's cuda shim (hip_compat.h) orders the thread_scope enum
-  // thread(0) < block(1) < device(2) < system(3), i.e. system is the WIDEST and
-  // LARGEST value. Upstream NVIDIA libcu++ uses the opposite ordering (system is
-  // the smallest value), where the original guard was `given > thread_scope_system`
-  // meaning "narrower than system". With the reversed hip_compat ordering that
-  // test is always false, so the fence became dead code and the worker-written
-  // outbox was never flushed to system scope before the proxy NIC read it -
-  // causing nondeterministic, page-granular stale/zero payloads on remote peers.
+  // Release the source to system scope before the GFD is published, since the NIC
+  // DMA-reads it. hip_compat.h orders thread_scope with system widest (largest), so
+  // "narrower than system" is given < system (upstream libcu++ uses the opposite order).
+#if defined(__HIP_PLATFORM_AMD__)
   if ((int)given < (int)cuda::thread_scope_system) {
+#else
+  if ((int)given > (int)cuda::thread_scope_system) {
+#endif
     cuda::atomic_thread_fence(cuda::memory_order_release, cuda::thread_scope_system);
   }
 

--- a/projects/rccl/src/include/nccl_device/gin/proxy/gin_proxy.h
+++ b/projects/rccl/src/include/nccl_device/gin/proxy/gin_proxy.h
@@ -216,7 +216,21 @@ NCCL_DEVICE_INLINE void put(Coop coop, ncclGinProxyGfd_t* gfd, ncclGinProxyGpuCt
                             ncclGinSignalDescriptor signal, ncclGinSignalOp_t signalOp,
                             uint64_t signalVal, bool hasCounter, ncclGinCounter_t counterId,
                             cuda::thread_scope required, cuda::thread_scope given) {
-  if ((int)given > (int)cuda::thread_scope_system) {
+  // The proxy hands the source buffer to the NIC, which is a system-scope agent
+  // (it DMA-reads GPU memory over PCIe), so the payload must be released to
+  // system scope before the GFD is published. `given` is the scope to which the
+  // caller has already released the source. Emit a system release fence whenever
+  // that is narrower than system.
+  //
+  // [RCCL] NOTE: RCCL's cuda shim (hip_compat.h) orders the thread_scope enum
+  // thread(0) < block(1) < device(2) < system(3), i.e. system is the WIDEST and
+  // LARGEST value. Upstream NVIDIA libcu++ uses the opposite ordering (system is
+  // the smallest value), where the original guard was `given > thread_scope_system`
+  // meaning "narrower than system". With the reversed hip_compat ordering that
+  // test is always false, so the fence became dead code and the worker-written
+  // outbox was never flushed to system scope before the proxy NIC read it -
+  // causing nondeterministic, page-granular stale/zero payloads on remote peers.
+  if ((int)given < (int)cuda::thread_scope_system) {
     cuda::atomic_thread_fence(cuda::memory_order_release, cuda::thread_scope_system);
   }
 

--- a/projects/rccl/test/transport/GinDeviceMPITests.cpp
+++ b/projects/rccl/test/transport/GinDeviceMPITests.cpp
@@ -2809,4 +2809,105 @@ TEST_F(GinMPIDeviceTests, RailConnection_Create) {
   (void)ncclDevCommDestroy(comm, &devComm);
 }
 
+
+std::string intraNodeSymReason() {
+  MPI_Comm nodeComm;
+  MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &nodeComm);
+  int nodeSize = 0;
+  MPI_Comm_size(nodeComm, &nodeSize);
+  MPI_Comm_free(&nodeComm);
+  if (nodeSize < 2)
+    return "Symmetric ReduceScatter requires >=2 ranks per node";
+  return "";
+}
+
+// End-to-end ReduceScatter through the public collective API on symmetric
+// (NCCL_WIN_COLL_SYMMETRIC) buffers. Registering the buffers makes the
+// symmetric-memory RS kernel (RailA2A_LsaLD) eligible, so this drives the
+// production kernel path -- not a hand-written reference kernel.
+TEST_F(GinMPIDeviceTests, ReduceScatter_Symmetric) {
+  if (auto reason = ginProxyTestSkipReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+
+  if (auto reason = crossNodeReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+
+  if (auto reason = intraNodeSymReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+
+  if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/8))
+    GTEST_SKIP() << "Requires 2-8 ranks";
+
+  ASSERT_EQ(ncclSuccess, createTestCommunicator());
+  ncclComm_t  comm   = getActiveCommunicator();
+  hipStream_t stream = getActiveStream();
+
+  int rank = -1, nRanks = -1;
+  ncclCommUserRank(comm, &rank);
+  ncclCommCount(comm, &nRanks);
+  ASSERT_GE(nRanks, 2);
+  ASSERT_LE(nRanks, 8);
+
+  // 1 (alignment/tail edges), 1024 (medium), 65536 (saturating).
+  const std::vector<size_t> counts = {1, 1024, size_t{1} << 16};
+
+  for (size_t count : counts) {
+    SCOPED_TRACE(::testing::Message() << "count=" << count);
+
+    // Send buffer holds one block per rank; recv holds this rank's block.
+    const size_t sendElems = count * static_cast<size_t>(nRanks);
+    const size_t sendBytes = sendElems * sizeof(float);
+    const size_t recvBytes = count * sizeof(float);
+
+    void* dSend = nullptr;
+    void* dRecv = nullptr;
+    ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dSend, sendBytes));
+    ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dRecv, recvBytes));
+    auto memCleanup = makeScopeGuard([&]() {
+      if (dSend) (void)ncclMemFree(dSend);
+      if (dRecv) (void)ncclMemFree(dRecv);
+    });
+
+    ncclWindow_t sendWin = nullptr, recvWin = nullptr;
+    ASSERT_MPI_EQ(ncclSuccess,
+        ncclCommWindowRegister(comm, dSend, sendBytes, &sendWin, NCCL_WIN_COLL_SYMMETRIC));
+    ASSERT_MPI_EQ(ncclSuccess,
+        ncclCommWindowRegister(comm, dRecv, recvBytes, &recvWin, NCCL_WIN_COLL_SYMMETRIC));
+    auto winCleanup = makeScopeGuard([&]() {
+      if (sendWin) (void)ncclCommWindowDeregister(comm, sendWin);
+      if (recvWin) (void)ncclCommWindowDeregister(comm, recvWin);
+    });
+
+    // sendbuf[j] = j + rank. After RS-sum, rank r's output element i is
+    // sum over all ranks s of ((r*count + i) + s) -- a closed form we check
+    // exactly (values stay < 2^24, so float arithmetic is exact here).
+    std::vector<float> hostSend(sendElems);
+    for (size_t j = 0; j < sendElems; j++)
+      hostSend[j] = static_cast<float>(j + static_cast<size_t>(rank));
+    std::vector<float> hostRecv(count, -1.0f);
+    ASSERT_MPI_EQ(hipSuccess,
+        hipMemcpy(dSend, hostSend.data(), sendBytes, hipMemcpyHostToDevice));
+    ASSERT_MPI_EQ(hipSuccess,
+        hipMemcpy(dRecv, hostRecv.data(), recvBytes, hipMemcpyHostToDevice));
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    ASSERT_MPI_EQ(ncclSuccess,
+        ncclReduceScatter(dSend, dRecv, count, ncclFloat32, ncclSum, comm, stream));
+    ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // Expected[i] on rank r = nRanks*(r*count + i) + nRanks*(nRanks-1)/2.
+    ASSERT_EQ(hipSuccess,
+        hipMemcpy(hostRecv.data(), dRecv, recvBytes, hipMemcpyDeviceToHost));
+    const double sumOfRanks = static_cast<double>(nRanks) * (nRanks - 1) / 2.0;
+    for (size_t i = 0; i < count; i++) {
+      const double base = static_cast<double>(static_cast<size_t>(rank) * count + i);
+      const float expected = static_cast<float>(nRanks * base + sumOfRanks);
+      ASSERT_EQ(expected, hostRecv[i]) << "rank=" << rank << " i=" << i;
+    }
+  }
+}
+
 #endif  // MPI_TESTS_ENABLED

--- a/projects/rccl/test/transport/GinDeviceMPITests.cpp
+++ b/projects/rccl/test/transport/GinDeviceMPITests.cpp
@@ -2910,4 +2910,89 @@ TEST_F(GinMPIDeviceTests, ReduceScatter_Symmetric) {
   }
 }
 
+// Same as ReduceScatter_Symmetric but exercises ncclAvg, which drives the
+// FuncSumPostDiv post-divide path on the symmetric RS kernel (RailA2A_LsaLD).
+TEST_F(GinMPIDeviceTests, ReduceScatter_Symmetric_Avg) {
+  if (auto reason = ginProxyTestSkipReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+
+  if (auto reason = crossNodeReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+
+  if (auto reason = intraNodeSymReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+
+  if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/8))
+    GTEST_SKIP() << "Requires 2-8 ranks";
+
+  ASSERT_EQ(ncclSuccess, createTestCommunicator());
+  ncclComm_t  comm   = getActiveCommunicator();
+  hipStream_t stream = getActiveStream();
+
+  int rank = -1, nRanks = -1;
+  ncclCommUserRank(comm, &rank);
+  ncclCommCount(comm, &nRanks);
+  ASSERT_GE(nRanks, 2);
+  ASSERT_LE(nRanks, 8);
+
+  const std::vector<size_t> counts = {1, 1024, size_t{1} << 16};
+
+  for (size_t count : counts) {
+    SCOPED_TRACE(::testing::Message() << "count=" << count);
+
+    const size_t sendElems = count * static_cast<size_t>(nRanks);
+    const size_t sendBytes = sendElems * sizeof(float);
+    const size_t recvBytes = count * sizeof(float);
+
+    void* dSend = nullptr;
+    void* dRecv = nullptr;
+    ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dSend, sendBytes));
+    ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dRecv, recvBytes));
+    auto memCleanup = makeScopeGuard([&]() {
+      if (dSend) (void)ncclMemFree(dSend);
+      if (dRecv) (void)ncclMemFree(dRecv);
+    });
+
+    ncclWindow_t sendWin = nullptr, recvWin = nullptr;
+    ASSERT_MPI_EQ(ncclSuccess,
+        ncclCommWindowRegister(comm, dSend, sendBytes, &sendWin, NCCL_WIN_COLL_SYMMETRIC));
+    ASSERT_MPI_EQ(ncclSuccess,
+        ncclCommWindowRegister(comm, dRecv, recvBytes, &recvWin, NCCL_WIN_COLL_SYMMETRIC));
+    auto winCleanup = makeScopeGuard([&]() {
+      if (sendWin) (void)ncclCommWindowDeregister(comm, sendWin);
+      if (recvWin) (void)ncclCommWindowDeregister(comm, recvWin);
+    });
+
+    std::vector<float> hostSend(sendElems);
+    for (size_t j = 0; j < sendElems; j++)
+      hostSend[j] = static_cast<float>(j + static_cast<size_t>(rank));
+    std::vector<float> hostRecv(count, -1.0f);
+    ASSERT_MPI_EQ(hipSuccess,
+        hipMemcpy(dSend, hostSend.data(), sendBytes, hipMemcpyHostToDevice));
+    ASSERT_MPI_EQ(hipSuccess,
+        hipMemcpy(dRecv, hostRecv.data(), recvBytes, hipMemcpyHostToDevice));
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    ASSERT_MPI_EQ(ncclSuccess,
+        ncclReduceScatter(dSend, dRecv, count, ncclFloat32, ncclAvg, comm, stream));
+    ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // Avg = sum/nRanks; expected[i] on rank r = (r*count + i) + (nRanks-1)/2.
+    // The kernel multiplies by a float 1/nRanks, so allow a small tolerance.
+    ASSERT_EQ(hipSuccess,
+        hipMemcpy(hostRecv.data(), dRecv, recvBytes, hipMemcpyDeviceToHost));
+    const double sumOfRanks = static_cast<double>(nRanks) * (nRanks - 1) / 2.0;
+    for (size_t i = 0; i < count; i++) {
+      const double base = static_cast<double>(static_cast<size_t>(rank) * count + i);
+      const double expected = (nRanks * base + sumOfRanks) / nRanks;
+      const double tol = (expected < 0 ? -expected : expected) * 1e-5 + 1e-3;
+      ASSERT_NEAR(expected, static_cast<double>(hostRecv[i]), tol)
+          << "rank=" << rank << " i=" << i;
+    }
+  }
+}
+
 #endif  // MPI_TESTS_ENABLED


### PR DESCRIPTION
## Motivation

Enable the symmetric-memory ReduceScatter path for multi-node runs.

## Technical Details

- Fixed warp-size assumptions to work on AMD's 64-lane wavefronts.
- Replaced CUDA-only intrinsics/inline-asm with ROCm equivalents.
- Added a software sub-group barrier since ROCm has no hardware named barriers.

## JIRA ID

AICOMRCCL-1224

## Test Plan

- Multi-node validation on MI300 and MI350
- Add end-to-end test to exercise the kernel

## Test Result

- Validation results added to AICOMRCCL-965
- Added `ReduceScatter_Symmetric` test in `GinDeviceMPITests.cpp`

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
