### PR TITLE
fix(rocjitsu): link rocjitsu_kmd as part of rocjitsu_shared

### DIFF
--- a/emulation/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/CMakeLists.txt
@@ -212,6 +212,7 @@ target_link_libraries(
         rocjitsu_isa_gfx1250
         rocjitsu_isa_risc_v
         simdojo
+        rocjitsu_kmd
         rocjitsu_vm
         rocjitsu_vm_amdgpu
         rocjitsu_vm_risc_v


### PR DESCRIPTION
## Motivation

CI validation (`validate_shared_library.py`) fails when loading `librocjitsu.so` with:

```
OSError: .../librocjitsu.so: undefined symbol: _ZN8rocjitsu15SimulatedDriver12open_processEv
```

The symbol demangles to `rocjitsu::SimulatedDriver::open_process()`. The shared library is missing the definition, so it cannot be loaded by `ctypes.cdll.LoadLibrary`. This PR fixes the link configuration so `librocjitsu.so` is self-contained.

## Technical Details

`librocjitsu.so` is produced by the `rocjitsu_shared` target, which assembles the object libraries via `target_link_libraries`.

- rj_vm.cpp (in the `rocjitsu_vm` object library) makes a direct, non-virtual call `drv->open_process()` after a `dynamic_cast<SimulatedDriver*>`.
- `SimulatedDriver::open_process()` is defined in simulated_driver.cpp, which lives in the `rocjitsu_kmd` object library.
- `rocjitsu_shared` linked `rocjitsu_vm` but **not** `rocjitsu_kmd`, leaving the symbol unresolved. Only this symbol surfaced because the other `SimulatedDriver` methods called from `rocjitsu_vm` are virtual and resolve through the vtable; `open_process()` is the lone non-virtual, direct call. The `rocjitsu_kmd_shim` target was unaffected because it already links `rocjitsu_kmd`.

Fix: add `rocjitsu_kmd` to the `rocjitsu_shared` link list in CMakeLists.txt. The object library is named `rocjitsu_kmd` on both Linux (`kmd/linux`) and Windows (`kmd/windows`), so the fix is cross-platform.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->

## Test Plan

- Rebuild the `rocjitsu_shared` target.
- Load the resulting `librocjitsu.so` via `ctypes.cdll.LoadLibrary` (mirroring `validate_shared_library.py`) to confirm there are no undefined symbols.

```bash
cmake --build build --target rocjitsu_shared
python3 -c "import ctypes; ctypes.cdll.LoadLibrary('build/librocjitsu.so'); print('OK')"
```

## Test Result

- `rocjitsu_shared` builds and links successfully.
- `librocjitsu.so` loads cleanly with no undefined symbols (`OK: loaded, no undefined symbols`), resolving the original CI failure.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.