### PR TITLE
disable hanging test on rocm-systems CI

### DIFF
--- a/projects/hip-tests/catch/config/configs/unit/multiThread.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/multiThread.yaml
@@ -2,6 +2,8 @@
 multiThread:
   Unit_hipMemsetAsync_QueueJobsMultithreaded:
     <<: *level_2
+    # AIRUNTIME-2291: hang on rocm-systems CI
+    disabled : [amd_linux]
     tags: [memory]
   Unit_hipMultiThreadDevice_Streams:
     <<: *level_2


### PR DESCRIPTION
## Motivation
Hanging test on rocm-systems CI unrelated to changes blocking many people.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
disable Unit_hipMemsetAsync_QueueJobsMultithreaded in Linux.
<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
AIRUNTIME-2291
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
local testing.
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
local test passes.
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
