### PR TITLE
[ROCM-25246] sanitize gpu_metrics temperature to reject firmware glitches

### DIFF
--- a/projects/rocm-smi-lib/src/rocm_smi_gpu_metrics.cc
+++ b/projects/rocm-smi-lib/src/rocm_smi_gpu_metrics.cc
@@ -35,6 +35,7 @@
 #include <ctime>
 #include <fstream>
 #include <iostream>
+#include <limits>
 #include <map>
 #include <memory>
 #include <optional>
@@ -3882,6 +3883,27 @@ rsmi_status_t rsmi_dev_gpu_metrics_info_get(uint32_t dv_ind, rsmi_gpu_metrics_t*
   }
 
   *smu = external_metrics;
+
+  // Sanitize temperature fields: clamp physically impossible values to
+  // UINT16_MAX (interpreted as N/A by all consumers).  Firmware can
+  // produce transient corrupt readings (e.g. 2112 °C) when the PMFW
+  // updates the gpu_metrics struct while the kernel is reading it.
+  auto clamp_temp = [](uint16_t& t) {
+    constexpr uint16_t kMaxPlausibleTempC = 500;
+    if (t > kMaxPlausibleTempC && t != std::numeric_limits<uint16_t>::max()) {
+      t = std::numeric_limits<uint16_t>::max();
+    }
+  };
+  clamp_temp(smu->temperature_edge);
+  clamp_temp(smu->temperature_hotspot);
+  clamp_temp(smu->temperature_mem);
+  clamp_temp(smu->temperature_vrgfx);
+  clamp_temp(smu->temperature_vrsoc);
+  clamp_temp(smu->temperature_vrmem);
+  for (auto& t : smu->temperature_hbm) {
+    clamp_temp(t);
+  }
+
   ss << __PRETTY_FUNCTION__ << " | ======= end ======= "
      << " | Success "
      << " | Device #: " << dv_ind << " | Returning = " << getRSMIStatusString(status_code) << " |";


### PR DESCRIPTION
## Summary

- PMFW updates the `gpu_metrics` sysfs struct non-atomically while the kernel reads it, causing torn reads that produce physically impossible temperature values (e.g. 2112 C on MI350X OAM units)
- AGFHC relies on `amdsmi_get_gpu_metrics_info()` for TEMP_CHECK and falsely flags GPUs as faulty when a corrupt `temperature_mem` value is returned
- Adds temperature sanitization in `rsmi_dev_gpu_metrics_info_get()` — the single funnel function all consumers call — clamping any temperature > 500 C to `UINT16_MAX` (already interpreted as N/A by all downstream consumers: amdsmi, amd-smi CLI, AGFHC, RDC)

## Root Cause

Investigated on `banff-bv-1e707-e02-5` (MI350X, 8 GPUs, amdgpu 6.14.14, ROCm 7.0.2). The `gpu_metrics` binary from `/sys/class/drm/cardN/device/gpu_metrics` is a 3872-byte v1.8 firmware struct. Under heavy GPU load (AGFHC HBM stress, XGMI tests), the PMFW firmware updates this struct mid-read, producing transient corrupt values in temperature fields. The value 2112 (0x0840) is not a valid temperature for any semiconductor component.

The existing validation only rejects `UINT16_MAX` (0xFFFF) as N/A. Values like 2112 pass through unchecked to AGFHC, which flags them as thermal faults.

## Test plan

- [x] Verify `amd-smi metric --temperature` still reports correct values on MI350X idle system
- [x] Verify temperature values > 500 C are reported as N/A instead of the raw firmware value
- [x] Run AGFHC lvl5 on MI350X to confirm TEMP_CHECK_FAIL no longer triggers on torn reads
- [x] Verify no regression on MI300X (gpu_metrics v1.3 with `temperature_hbm[]`)