### PR TITLE
[rocm-systems] Remove Mirage hotswap gitlink

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -127,7 +127,3 @@
 [submodule "projects/rocprofiler-compute/src/lib/external/fmt"]
 	path = projects/rocprofiler-compute/src/lib/external/fmt
 	url = https://github.com/fmtlib/fmt.git
-[submodule "emulation/mirage/llvm-project-hotswap"]
-	path = emulation/mirage/llvm-project-hotswap
-	url = https://github.com/martin-luecke/llvm-project
-	branch = users/mluecke/hotswap-landing-parity

--- a/.gitmodules
+++ b/.gitmodules
@@ -127,3 +127,7 @@
 [submodule "projects/rocprofiler-compute/src/lib/external/fmt"]
 	path = projects/rocprofiler-compute/src/lib/external/fmt
 	url = https://github.com/fmtlib/fmt.git
+[submodule "emulation/mirage/llvm-project-hotswap"]
+	path = emulation/mirage/llvm-project-hotswap
+	url = https://github.com/martin-luecke/llvm-project
+	branch = users/mluecke/hotswap-landing-parity


### PR DESCRIPTION
## Summary
Remove the orphaned `emulation/mirage/llvm-project-hotswap` gitlink.

## Root Cause
The repository tree contains a gitlink at `emulation/mirage/llvm-project-hotswap`, but `.gitmodules` does not declare a matching submodule path. Git submodule commands fail with:

```text
fatal: no submodule mapping found in .gitmodules for path 'emulation/mirage/llvm-project-hotswap'
```

Mirage HotSwap already has fallback clone configuration in `emulation/mirage/hotswap/cmake/Hotswap.cmake`, so the in-tree gitlink is not required for normal submodule initialization.

## Changes
- Removed the orphaned `emulation/mirage/llvm-project-hotswap` gitlink from the tree.

## Testing
- Verified the failure before the change with `git submodule status`.
- Verified `git submodule status` exits successfully after removing the gitlink.