### PR TITLE
[rocprofiler-sdk] Enable rocpd multiproc rocprofv3 ctests

### DIFF
--- a/projects/rocprofiler-sdk/tests/rocprofv3/rocpd/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/rocpd/CMakeLists.txt
@@ -27,10 +27,6 @@ else()
     set(MULTIPROC_LAUNCHER)
 endif()
 
-if(ROCPROFILER_DISABLE_UNSTABLE_CTESTS)
-    set(MULTIPROC_IS_DISABLED ON) # fails on mi300 SLES for some unknown reason
-endif()
-
 #########################################################################################
 #
 # generate rocpd database and the old-way outputs csv, otf2, perfetto to compare
@@ -62,6 +58,7 @@ rocprofiler_add_integration_execute_test(
     TIMEOUT 120
     LABELS "integration-tests;rocpd"
     PRELOAD "${PRELOAD_ENV}"
+    ENVIRONMENT "${rocprofv3-rocpd-env}"
     FIXTURES_SETUP rocprofv3-test-rocpd-multiproc
     DISABLED "${MULTIPROC_IS_DISABLED}")
 
@@ -114,7 +111,7 @@ rocprofiler_add_integration_execute_test(
     PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
     ENVIRONMENT "${rocprofv3-rocpd-env}"
     FIXTURES_SETUP rocprofv3-test-rocpd-generation
-    FIXTURES_REQUIRED rocprofv3-test-rocpd
+    FIXTURES_REQUIRED rocprofv3-test-rocpd-multiproc
     DISABLED "${MULTIPROC_IS_DISABLED}")
 
 #########################################################################################
@@ -151,7 +148,7 @@ rocprofiler_add_integration_execute_test(
     PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
     ENVIRONMENT "${rocprofv3-rocpd-env}"
     FIXTURES_SETUP rocprofv3-test-rocpd-generation
-    FIXTURES_REQUIRED rocprofv3-test-rocpd
+    FIXTURES_REQUIRED rocprofv3-test-rocpd-multiproc
     DISABLED "${MULTIPROC_IS_DISABLED}")
 
 #########################################################################################
@@ -207,7 +204,7 @@ rocprofiler_add_integration_execute_test(
     PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
     ENVIRONMENT "${rocprofv3-rocpd-env}"
     FIXTURES_SETUP rocprofv3-test-rocpd-generation
-    FIXTURES_REQUIRED rocprofv3-test-rocpd
+    FIXTURES_REQUIRED rocprofv3-test-rocpd-multiproc
     DISABLED "${MULTIPROC_IS_DISABLED}")
 
 rocprofiler_add_integration_execute_test(


### PR DESCRIPTION
## Motivation

The 8 `rocprofv3-test-rocpd-*-multiproc` tests were disabled due to instability. The instability was caused by test-harness
misconfiguration, not by the feature under test. This PR fixes the root causes and re-enables the tests so RocPD multi-process profiling is actually covered in CI.

## Technical Details

Changes in `projects/rocprofiler-sdk/tests/rocprofv3/rocpd/CMakeLists.txt`:
- Removed the blanket `ROCPROFILER_DISABLE_UNSTABLE_CTESTS` guard that unconditionally disabled the multiproc tests.
- Added the required `ENVIRONMENT` (MPI vars `OMPI_ALLOW_RUN_AS_ROOT*` + `PYTHONPATH`) to the `mpiexec`-launched test so OpenMPI can run under root and resolve the `rocprofv3` Python module.
- Repointed the `otf2` / `perfetto` / `summary` `generation-multiproc` converter tests to the multiproc fixture (was the single-proc fixture), fixing a race that produced missing input DBs under parallel ctest.

## JIRA ID

Resolves AIROCVAL-46

## Test Plan

Tests are MPI-gated (`find_package(MPI)`); when MPI is absent they are skipped. They will activate automatically once OpenMPI is provisioned in the CI image (tracked separately in #6671). Verified locally with MPI present: all 8 multiproc tests pass, serial and parallel.

- Built rocprofiler-sdk with rocpd + MPI and ran the 8 multiproc tests locally.
- Serial run, repeated parallel runs (10x), and direct `mpiexec` reproduction.
- Confirmed no interference with the single-proc rocpd tests.

## Test Result

- Multiproc tests: 100% pass, serial and parallel, with no flakiness across repeated runs.
- A rare single-proc PMC GPU memory-fault flake was observed but reproduces with these tests disabled too — it is pre-existing and orthogonal to this change.

## Submission Checklist

- [V] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
