### PR TITLE
[rocjtisu] Add back tests dropped from CMakeLists.txt

### DIFF
--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -53,6 +53,8 @@ add_executable(
     waitcnt_counter_test.cpp
     instruction_execution_harness_test.cpp
     decode_execute_benchmark.cpp
+    util_simd_test.cpp
+    v_add_simd_benchmark.cpp
     execution_plugin_test.cpp
 )
 target_link_libraries(
@@ -65,6 +67,12 @@ target_link_libraries(
         Threads::Threads
         GTest::gtest_main
 )
+if(HAS_DEVICE_KERNELS)
+    target_sources(
+        rocjitsu_tests
+        PRIVATE dbt/device_kernels_translate_tests.cpp
+    )
+endif()
 rj_configure_target(rocjitsu_tests TEST)
 
 include(GoogleTest)


### PR DESCRIPTION
Adding back some test that were dropped in a CMakeLists.txt reshuffle. util_simd_test.cpp and v_add_simd_benchmark.cpp exist in the source tree but were not compiled into rocjitsu_tests. The HAS_DEVICE_KERNELS conditional for dbt/device_kernels_translate_tests.cpp was also missing. Alternatively we should remove the .cpp files? 
