### PR TITLE
[kpack] fix co_index mismatch between TOC and wrapper reserved1

### DIFF
--- a/shared/kpack/python/rocm_kpack/artifact_splitter.py
+++ b/shared/kpack/python/rocm_kpack/artifact_splitter.py
@@ -346,9 +346,12 @@ class ArtifactSplitter:
             # Create a BundledBinary instance with our toolchain
             binary = BundledBinary(binary_path, toolchain=self.toolchain)
 
-            # Track code object index per (binary, arch) for multi-TU support
-            # Each TU in a -fgpu-rdc binary gets a unique index
-            code_object_index: Dict[str, int] = defaultdict(int)
+            # Track code object index as a global counter across all architectures.
+            # This must match the absolute wrapper index written to reserved1 by
+            # rewrite_hipfatbin_magic(), which iterates all wrappers in order
+            # (not per-arch). At runtime, CLR passes that reserved1 value as
+            # co_index, so the TOC key must use the same absolute position.
+            code_object_index: int = 0
 
             # Extract kernels using context manager
             with binary.unbundle() as unbundled:
@@ -360,7 +363,9 @@ class ArtifactSplitter:
                         if self.gpu_targets is not None:
                             bare_arch = strip_target_features(arch)
                             if bare_arch not in self.gpu_targets:
-                                code_object_index[arch] += 1
+                                # Still advance the global index to stay aligned
+                                # with the absolute wrapper position in the binary.
+                                code_object_index += 1
                                 if self.verbose:
                                     print(
                                         f"    Skipping kernel for {arch}: "
@@ -372,12 +377,12 @@ class ArtifactSplitter:
                         # Read kernel data while the file still exists
                         kernel_data = kernel_path.read_bytes()
 
-                        # Build source_binary_relpath with index suffix
-                        # TOC always uses indexed format: "lib/foo.so#0", "lib/foo.so#1"
-                        # This matches the co_index in wrapper's reserved1 field
+                        # Build source_binary_relpath with index suffix.
+                        # TOC uses the absolute wrapper position so it matches
+                        # the reserved1 field written by rewrite_hipfatbin_magic.
                         base_relpath = binary_path.relative_to(prefix_path).as_posix()
-                        index = code_object_index[arch]
-                        code_object_index[arch] += 1
+                        index = code_object_index
+                        code_object_index += 1
                         indexed_relpath = f"{base_relpath}#{index}"
 
                         # Create ExtractedKernel object


### PR DESCRIPTION
**Problem Statement:**
rocBLAS/rocHPL workloads fail on gfx942 (MI300X) hardware built by TheRock with hipErrorInvalidImage (error 200) when loading kernels at runtime.

**Analysis:**

Hardware rocminfo reports ISA: amdgcn-amd-amdhsa--gfx942:sramecc+:xnack-

When run with KPACK_DEBUG=1, the kpack runtime showed:

```
kpack: opened and cached archive: blas_lib_gfx942.kpack
kpack:   architecture: gfx942
kpack: trying architecture: amdgcn-amd-amdhsa--gfx942:sramecc+:xnack-
kpack:   archive blas_lib_gfx942.kpack has architecture gfx942
kpack:   kernel not found in this archive (error 5)
```

TheRock builds rocBLAS with bare gfx942 target (no xnack feature flags). The resulting fat binary librocblas.so contains multiple translation units (TUs) for each architecture, bundled as __CudaFatBinaryWrapper structs in the .hipFatBinSegment ELF section.

The kpack artifact splitter (artifact_splitter.py) extracts these kernels and packs them into blas_lib_gfx942.kpack with a TOC keyed by {binary_path}#{index}. The kpack transform step (elf/kpack_transform.py) rewrites each wrapper's reserved1 field with its absolute wrapper index (i in the loop over all wrappers across all architectures).

The bug: the TOC was keyed with a per-architecture sequential counter (code_object_index[arch]), while the runtime uses the absolute wrapper index (reserved1) to construct the lookup key. For a multi-arch fat binary like:

```
Wrapper 0: gfx942   → reserved1=0,  TOC key: librocblas.so#0  (gfx942)  ✓
Wrapper 1: gfx1100  → reserved1=1,  TOC key: librocblas.so#0  (gfx1100) ← per-arch resets to 0
Wrapper 2: gfx942   → reserved1=2,  TOC key: librocblas.so#1  (gfx942)  ✗ runtime asks #2
Wrapper 3: gfx1100  → reserved1=3,  TOC key: librocblas.so#1  (gfx1100) ✗ runtime asks #3
...
Wrapper 52: gfx942  → reserved1=52, TOC key: librocblas.so#N  (gfx942)  ✗ runtime asks #52
```

Every kernel past the first architecture is misaligned, returning KPACK_ERROR_KERNEL_NOT_FOUND (error 5). The early-return in loader.cpp line 462 surfaces this as hipErrorInvalidImage to the caller.

**Fix:** 

rocm-systems (shared/kpack/python/rocm_kpack/artifact_splitter.py)
 Changed code_object_index from a per-arch Dict[str, int] to a single global int that increments for every wrapper entry (including skipped arches), matching the absolute wrapper position written to reserved1 by rewrite_hipfatbin_magic().


## JIRA ID

Resolves ROCM-24723

## Test Plan

Test rocHPL with the ci build

## Test Result

Results using the build : https://github.com/ROCm/TheRock/actions/runs/27119969222/
```
./build/mpirun_rochpl -P 4 -Q 2 -N 256000 --NB 512
Node Binding: Process 0 [(p,q)=(0,0)] GPU: 0, CPU Cores: 14 - {0-13}
Node Binding: Process 1 [(p,q)=(1,0)] GPU: 1, CPU Cores: 14 - {14-27}
Node Binding: Process 3 [(p,q)=(3,0)] GPU: 3, CPU Cores: 14 - {42-55}
Node Binding: Process 2 [(p,q)=(2,0)] GPU: 2, CPU Cores: 14 - {28-41}
Node Binding: Process 5 [(p,q)=(1,1)] GPU: 5, CPU Cores: 14 - {70-83}
Node Binding: Process 4 [(p,q)=(0,1)] GPU: 4, CPU Cores: 14 - {56-69}
Node Binding: Process 7 [(p,q)=(3,1)] GPU: 7, CPU Cores: 14 - {98-111}
Node Binding: Process 6 [(p,q)=(2,1)] GPU: 6, CPU Cores: 14 - {84-97}
Local matrix size       = 61.0662 GiBs
Total device memory use = 63.0322 GiBs
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
   %   | Column    | Step Time (s) ||         DGEMM GFLOPS         || pdfact (s) | pmxswp (s) | Lbcast (s) | laswp (s) | GPU Sync (s) | Step GFLOPS | Overall GFLOPS
       |           |               |  Small   |  First   | Second   |            |            |            |           |              |             |
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
  0.2% | 000000512 |    0.1607174  |          | 6.012e+04| 6.316e+04|            |            |  2.746e-02 | 4.290e-02 |   8.946e-02  |  4.167e+05  |    3.558e+05
  0.4% | 000001024 |    0.1548192  | 4.673e+04| 5.943e+04| 6.318e+04|  1.628e-02 |  4.237e-03 |  8.041e-03 | 3.844e-02 |   8.966e-02  |  4.309e+05  |    3.896e+05
  0.6% | 000001536 |    0.1517172  |          | 5.968e+04| 6.280e+04|            |            |  1.539e-02 | 6.261e-02 |   7.325e-02  |  4.379e+05  |    4.044e+05
  0.8% | 000002048 |    0.1553104  | 4.662e+04| 5.869e+04| 6.318e+04|  1.651e-02 |  3.529e-03 |  8.059e-03 | 1.483e-02 |   1.141e-01  |  4.261e+05  |    4.096e+05
.....

Final Score:    3.7800e+05 GFLOPS
Residual value = 0.000045001387602 (0x3f0797fbe7794cc3)


```

