### PR TITLE
fix(rocdbgapi): Keep waves halted when resuming with exceptions

### DIFF
--- a/projects/rocdbgapi/src/architecture.cpp
+++ b/projects/rocdbgapi/src/architecture.cpp
@@ -341,7 +341,8 @@ public:
   virtual exception_mask_t signaled_exceptions (const wave_t &) const;
   virtual exception_mask_t set_exceptions (wave_t &, exception_mask_t,
                                            exception_mask_t) const;
-  void clear_stop_reasons (wave_t &) const;
+  void clear_stop_reasons (wave_t &,
+                           amd_dbgapi_exceptions_t clear_exceptions) const;
 
   void record_spi_ttmps_setup (const wave_t &wave,
                                bool enabled) const override;
@@ -351,8 +352,8 @@ public:
 
   std::pair<amd_dbgapi_wave_state_t, amd_dbgapi_wave_stop_reasons_t>
   wave_get_state (wave_t &wave) const override;
-  void wave_set_state (wave_t &wave,
-                       amd_dbgapi_wave_state_t state) const override;
+  void wave_set_state (wave_t &wave, amd_dbgapi_wave_state_t state,
+                       amd_dbgapi_exceptions_t keep_exceptions) const override;
 
   bool wave_get_halt (const wave_t &wave) const override;
   void wave_set_halt (wave_t &wave, bool halt) const override;
@@ -1390,38 +1391,50 @@ amdgcn_architecture_t::set_exceptions (wave_t &wave, exception_mask_t mask,
 }
 
 void
-amdgcn_architecture_t::clear_stop_reasons (wave_t &wave) const
+amdgcn_architecture_t::clear_stop_reasons (
+  wave_t &wave, amd_dbgapi_exceptions_t clear_exceptions) const
 {
   amd_dbgapi_wave_stop_reasons_t stop_reason = wave.stop_reason ();
-  exception_mask_t exceptions
-    = exception_mask_t::wave_begin | exception_mask_t::wave_end;
 
-  if (stop_reason & AMD_DBGAPI_WAVE_STOP_REASON_MEMORY_VIOLATION)
+  exception_mask_t exceptions = {};
+  if (!!(clear_exceptions & AMD_DBGAPI_EXCEPTION_WAVE_TRAP))
+    exceptions = exception_mask_t::wave_begin | exception_mask_t::wave_end;
+
+  if (stop_reason & AMD_DBGAPI_WAVE_STOP_REASON_MEMORY_VIOLATION
+      && !!(clear_exceptions & AMD_DBGAPI_EXCEPTION_WAVE_MEMORY_VIOLATION))
     exceptions |= exception_mask_t::mem_viol | exception_mask_t::xnack_error;
-  if (stop_reason & AMD_DBGAPI_WAVE_STOP_REASON_ADDRESS_ERROR)
+  if (stop_reason & AMD_DBGAPI_WAVE_STOP_REASON_ADDRESS_ERROR
+      && !!(clear_exceptions & AMD_DBGAPI_EXCEPTION_WAVE_ADDRESS_ERROR))
     exceptions |= exception_mask_t::mem_viol;
-  if (stop_reason & AMD_DBGAPI_WAVE_STOP_REASON_ILLEGAL_INSTRUCTION)
+  if (stop_reason & AMD_DBGAPI_WAVE_STOP_REASON_ILLEGAL_INSTRUCTION
+      && !!(clear_exceptions & AMD_DBGAPI_EXCEPTION_WAVE_ILLEGAL_INSTRUCTION))
     exceptions |= exception_mask_t::illegal_inst;
-  if (stop_reason & AMD_DBGAPI_WAVE_STOP_REASON_FP_INVALID_OPERATION)
-    exceptions |= exception_mask_t::invalid;
-  if (stop_reason & AMD_DBGAPI_WAVE_STOP_REASON_FP_INPUT_DENORMAL)
-    exceptions |= exception_mask_t::input_denorm;
-  if (stop_reason & AMD_DBGAPI_WAVE_STOP_REASON_FP_DIVIDE_BY_0)
-    exceptions |= exception_mask_t::float_div0;
-  if (stop_reason & AMD_DBGAPI_WAVE_STOP_REASON_FP_OVERFLOW)
-    exceptions |= exception_mask_t::overflow;
-  if (stop_reason & AMD_DBGAPI_WAVE_STOP_REASON_FP_UNDERFLOW)
-    exceptions |= exception_mask_t::underflow;
-  if (stop_reason & AMD_DBGAPI_WAVE_STOP_REASON_FP_INEXACT)
-    exceptions |= exception_mask_t::inexact;
-  if (stop_reason & AMD_DBGAPI_WAVE_STOP_REASON_INT_DIVIDE_BY_0)
-    exceptions |= exception_mask_t::int_div0;
-  if (stop_reason & AMD_DBGAPI_WAVE_STOP_REASON_WATCHPOINT)
-    exceptions |= exception_mask_t::addr_watch0 | exception_mask_t::addr_watch1
-                  | exception_mask_t::addr_watch2
-                  | exception_mask_t::addr_watch3;
+  if (!!(clear_exceptions & AMD_DBGAPI_EXCEPTION_WAVE_MATH_ERROR))
+    {
+      if (stop_reason & AMD_DBGAPI_WAVE_STOP_REASON_FP_INVALID_OPERATION)
+        exceptions |= exception_mask_t::invalid;
+      if (stop_reason & AMD_DBGAPI_WAVE_STOP_REASON_FP_INPUT_DENORMAL)
+        exceptions |= exception_mask_t::input_denorm;
+      if (stop_reason & AMD_DBGAPI_WAVE_STOP_REASON_FP_DIVIDE_BY_0)
+        exceptions |= exception_mask_t::float_div0;
+      if (stop_reason & AMD_DBGAPI_WAVE_STOP_REASON_FP_OVERFLOW)
+        exceptions |= exception_mask_t::overflow;
+      if (stop_reason & AMD_DBGAPI_WAVE_STOP_REASON_FP_UNDERFLOW)
+        exceptions |= exception_mask_t::underflow;
+      if (stop_reason & AMD_DBGAPI_WAVE_STOP_REASON_FP_INEXACT)
+        exceptions |= exception_mask_t::inexact;
+      if (stop_reason & AMD_DBGAPI_WAVE_STOP_REASON_INT_DIVIDE_BY_0)
+        exceptions |= exception_mask_t::int_div0;
+    }
+
+  /* None of the remaining exceptions can meaningfully be forwarded to the
+     runtime (they were caused by the debugger in the first place).  */
   if (stop_reason & AMD_DBGAPI_WAVE_STOP_REASON_SINGLE_STEP)
     exceptions |= exception_mask_t::trap_after_inst;
+  if (stop_reason & AMD_DBGAPI_WAVE_STOP_REASON_WATCHPOINT)
+    exceptions |= exception_mask_t::addr_watch0 | exception_mask_t::addr_watch1
+      | exception_mask_t::addr_watch2
+      | exception_mask_t::addr_watch3;
 
   set_exceptions (wave, exceptions, {});
 }
@@ -1580,8 +1593,9 @@ amdgcn_architecture_t::wave_get_state (wave_t &wave) const
 }
 
 void
-amdgcn_architecture_t::wave_set_state (wave_t &wave,
-                                       amd_dbgapi_wave_state_t state) const
+amdgcn_architecture_t::wave_set_state (
+  wave_t &wave, amd_dbgapi_wave_state_t state,
+  amd_dbgapi_exceptions_t resume_exceptions) const
 {
   uint32_t status_reg, mode_reg, ttmp6;
   wave.read_register (amdgpu_regnum_t::status, &status_reg);
@@ -1609,6 +1623,16 @@ amdgcn_architecture_t::wave_set_state (wave_t &wave,
       break;
 
     case AMD_DBGAPI_WAVE_STATE_RUN:
+      /* We are resuming a wave with exceptions.  This is done when the client
+         resumes the wave, with the intention to have the exception it
+         received be forwarded to the runtime.  In this case, we need to leave
+         the wave as it is (stopped), so the runtime can observe it as it
+         was when the exception was first reported.  This is important if we
+         want the runtime to be able to produce a valid core dump.  */
+      if (resume_exceptions != AMD_DBGAPI_EXCEPTION_NONE
+          && wave.state () == AMD_DBGAPI_WAVE_STATE_STOP)
+        break;
+
       /* Restore status.halt from ttmp6.saved_status_halt, put the wave in the
          run state (ttmp6.wave_stopped=0), and set mode.debug_en=0.  */
       status_reg
@@ -1648,7 +1672,7 @@ amdgcn_architecture_t::wave_set_state (wave_t &wave,
   if (state != AMD_DBGAPI_WAVE_STATE_STOP
       && wave.state () == AMD_DBGAPI_WAVE_STATE_STOP
       && wave.stop_reason () != AMD_DBGAPI_WAVE_STOP_REASON_NONE)
-    clear_stop_reasons (wave);
+    clear_stop_reasons (wave, ~resume_exceptions);
 }
 
 bool
@@ -2708,7 +2732,8 @@ gfx9_architecture_t::wave_get_state (wave_t &wave) const
           instruction && is_sequential (*instruction))
         {
           /* Resume the wave in single-step mode.  */
-          wave_set_state (wave, AMD_DBGAPI_WAVE_STATE_SINGLE_STEP);
+          wave_set_state (wave, AMD_DBGAPI_WAVE_STATE_SINGLE_STEP,
+                          AMD_DBGAPI_EXCEPTION_NONE);
 
           log_info ("%s (pc=%s) ignore spurious single-step",
                     to_cstring (wave.id ()), to_cstring (wave.pc ()));
@@ -6359,8 +6384,9 @@ protected:
   exception_mask_t set_exceptions (wave_t &, exception_mask_t,
                                    exception_mask_t) const override;
 
-  void wave_set_state (wave_t &wave,
-                       amd_dbgapi_wave_state_t state) const override;
+  void
+  wave_set_state (wave_t &wave, amd_dbgapi_wave_state_t state,
+                  amd_dbgapi_exceptions_t resume_exceptions) const override;
 
   bool wave_get_halt (const wave_t &wave) const override;
 
@@ -6633,8 +6659,9 @@ gfx12_architecture_t::set_exceptions (wave_t &wave, exception_mask_t mask,
 }
 
 void
-gfx12_architecture_t::wave_set_state (wave_t &wave,
-                                      amd_dbgapi_wave_state_t state) const
+gfx12_architecture_t::wave_set_state (
+  wave_t &wave, amd_dbgapi_wave_state_t state,
+  amd_dbgapi_exceptions_t resume_exceptions) const
 {
   uint32_t state_priv_reg, ttmp6, trap_ctrl_reg;
 
@@ -6658,6 +6685,16 @@ gfx12_architecture_t::wave_set_state (wave_t &wave,
       break;
 
     case AMD_DBGAPI_WAVE_STATE_RUN:
+      /* We are resuming a wave with exceptions.  This is done when the client
+         resumes the wave, with the intention to have the exception it
+         received be forwarded to the runtime.  In this case, we need to leave
+         the wave as it is (stopped), so the runtime can observe it as it
+         was when the exception was first reported.  This is important if we
+         want the runtime to be able to produce a valid core dump.  */
+      if (resume_exceptions != AMD_DBGAPI_EXCEPTION_NONE
+          && wave.state () == AMD_DBGAPI_WAVE_STATE_STOP)
+        break;
+
       /* Restore status.halt from ttmp6.saved_status_halt, put the wave in the
          run state (ttmp6.wave_stopped=0), and set mode.debug_en=0.  */
       state_priv_reg &= ~sq_wave_state_priv_halt_mask;
@@ -6696,7 +6733,7 @@ gfx12_architecture_t::wave_set_state (wave_t &wave,
   if (state != AMD_DBGAPI_WAVE_STATE_STOP
       && wave.state () == AMD_DBGAPI_WAVE_STATE_STOP
       && wave.stop_reason () != AMD_DBGAPI_WAVE_STOP_REASON_NONE)
-    clear_stop_reasons (wave);
+    clear_stop_reasons (wave, ~resume_exceptions);
 }
 
 bool

--- a/projects/rocdbgapi/src/architecture.h
+++ b/projects/rocdbgapi/src/architecture.h
@@ -370,9 +370,9 @@ public:
 
   virtual std::pair<amd_dbgapi_wave_state_t, amd_dbgapi_wave_stop_reasons_t>
   wave_get_state (wave_t &wave) const = 0;
-  virtual void wave_set_state (wave_t &wave,
-                               amd_dbgapi_wave_state_t state) const
-    = 0;
+  virtual void wave_set_state (wave_t &wave, amd_dbgapi_wave_state_t state,
+                               amd_dbgapi_exceptions_t reasons
+                               = AMD_DBGAPI_EXCEPTION_NONE) const = 0;
 
   virtual bool wave_get_halt (const wave_t &wave) const = 0;
   virtual void wave_set_halt (wave_t &wave, bool halt) const = 0;

--- a/projects/rocdbgapi/src/wave.cpp
+++ b/projects/rocdbgapi/src/wave.cpp
@@ -479,7 +479,7 @@ wave_t::set_state (amd_dbgapi_wave_state_t state,
               : "",
             to_cstring (pc ()));
 
-  architecture.wave_set_state (*this, state);
+  architecture.wave_set_state (*this, state, exceptions);
   m_state = state;
   queue ().wave_state_changed (*this);
 


### PR DESCRIPTION
When resuming a wave after it received an exception, a client debugger can do 2 things:
- swallow the exception, and call amd_dbgapi_wave_resume with exceptions=AMD_DBGAPI_EXCEPTION_NONE
- keep the exception and transmit it to the runtime, i.e. call amd_dbgapi_wave_resume with a non-0 exception.

In the second case, dbgapi currently calls
architecture_t::wave_set_state which when called with STATE_RUN clears all the exceptions marker (calls architecture_::clear_stop_reasons). This is an issue if after we resume a wave with exceptions, the runtime decides to create a core dump.  In such scenario, the runtime can correctly create a core dump, but the wave which caused the core to be created has all its exception bits cleared, making it indistinguishable from a perfectly "healthy" wave.

This patch proposes to do the following changes:
- When calling amd_dbgapi_wave_resume with a non-0 exception, we do not actually resume the wave and keep it in the stopped state.  However, from dbgapi's point of view, we record the wave as resumed (m_state is RUNNING), so if we are to see this wave again, it looks like it re-raised the same exception (but this should never happen).
- When clearing exceptions from a wave, make sure to not clear exceptions associated with the exceptions we resume with, so the runtime can still observe those bits.

Tested with ROCgdb's testsuite of gfx1031.