### PR TITLE
[RCCL] ib-ops level fault injection CAST tests

### DIFF
--- a/projects/rccl/.claude/skills/feature-unit-testing/SKILL.md
+++ b/projects/rccl/.claude/skills/feature-unit-testing/SKILL.md
@@ -288,19 +288,13 @@ A branch is covered only when **both sides** of a conditional have been exercise
 if (result != ncclSuccess) goto fail;   // ← "fail" branch: count = 0
 ```
 
-**Example from net_ib.cc** (single MI300x node, Mellanox CX-7 — numbers will differ on other hardware):
-
-```
-Metric          Before stress tests    After 14 stress tests
-────────────────────────────────────────────────────────────
-Line coverage       ~72%                   ~72%    Δ +0.2 pp
-Branch coverage     ~41%                   ~42%    Δ +1.0 pp
-```
-
-Line coverage looks healthy at 71%. Branch coverage at 40% reveals that roughly
-**6 in 10 decision points** are only partially tested. For transport code where the
-uncovered side is usually the error path or the hardware-specific path, this gap
-directly maps to bugs that tests cannot catch.
+**Typical pattern in transport code:** adding a batch of stress tests can leave
+line coverage essentially flat while moving branch coverage only marginally —
+because the new tests re-exercise already-covered happy-path lines, while the
+uncovered side of each decision (the error or hardware-specific path) stays
+untaken. A healthy-looking line-coverage figure can hide that a large share of
+decision points are only half-tested. For transport code that gap maps directly
+to bugs tests cannot catch.
 
 **Functions coverage is the least informative metric for systems code.** A function
 called once with the happy-path arguments appears fully covered even if it contains
@@ -314,12 +308,11 @@ genhtml --branch-coverage merged.lcov.info -o html/
 # Without this flag, the HTML report does not show per-branch hit counts.
 ```
 
-**lcov vs llvm-cov branch counts differ:**
-- lcov (BRDA parsing): 1821 branches for net_ib.cc
-- `llvm-cov report`: 1954 branches (includes C++ exception pseudo-branches)
-
-Use one tool consistently within a comparison. Mixing denominators makes deltas
-meaningless. lcov/genhtml is preferred for branch-level HTML drill-down.
+**lcov vs llvm-cov branch counts differ:** the two tools report different branch
+denominators for the same file (llvm-cov includes C++ exception pseudo-branches
+that lcov's BRDA parsing excludes). Use one tool consistently within a comparison
+— mixing denominators makes deltas meaningless. lcov/genhtml is preferred for
+branch-level HTML drill-down.
 
 **Read BRDA lines, not DA lines, when hunting gaps:**
 ```
@@ -562,59 +555,55 @@ sbatch --nodes=2 --ntasks-per-node=1 --exclusive --time=00:10:00 \
 
 ---
 
-## Living Document
+## Maintaining This Skill
 
-Updated after each testing iteration. Add new patterns and anti-patterns here as they emerge.
+This document is the **fixed record of the methodology** — not a lab notebook.
+It changes rarely and only for durable reasons.
 
-**Coverage numbers below are approximate.** Exact values depend on hardware (NIC model,
-number of ports, GDR/DMA-buf support), cluster topology (single-node loopback vs cross-host),
-compiler version (affects branch count — C++ exception pseudobranches inflate the denominator),
-and which env-var combinations were exercised. Re-measure on your hardware; do not treat
-these numbers as universal targets.
+**Add or change something only when:**
+- A genuinely new methodology emerges (a new class of technique, phase, or
+  acceptance rule) that future testers should follow, or
+- An existing rule is shown to be wrong or incomplete and the methodology itself
+  must change.
 
-**Approximate baseline progression** (net_ib.cc, ~1800 lcov branches, single MI300x node with Mellanox CX-7):
+**Never add:**
+- Concrete coverage numbers, test counts, branch tallies, or per-run deltas — they
+  are snapshots of one hardware/build and rot immediately. They belong in a
+  per-feature coverage report (e.g. an `*_COVERAGE.md` next to the work), not here.
+- Incident logs, "resolved puzzle" notes, or one-off debugging anecdotes.
+- Tool-version specifics, exact env-var flag lists, cluster paths, or other
+  details that vary by environment — reference the *kind* of thing, not the value.
 
-| Phase | Branch (approx) | Line (approx) | What moved the needle |
-|-------|:---------------:|:--------------:|----------------------|
-| GeneralTests only | ~40% | ~72% | 18 basic functional tests |
-| + 14 stress tests | ~42% | ~72% | Resource churn, multi-connection, bidirectional |
-| + branch-coverage tests | ~43% | ~73% | Targeted BRDA gaps: size clamping, NULL comm, nreqs>1 |
-| + env-var sweeps | ~44–45% | ~74–75% | MERGE_VFS, ECE, SL/TC, DMABUF, RELAXED_ORDERING, etc. |
-| + multi-rank (4-rank loopback) | ~44–45% | ~74–75% | FanIn/FanOut/AllToAll — diminishing returns on loopback |
+**When tempted to record a finding:** ask "is this a reusable rule, or a
+measurement?" Measurements go in the coverage report and link back here by
+reference. Only the rule (if any) belongs in the skill.
 
-**Total tests:** ~27 in StressTests.cpp (14 stress + 13 branch-coverage) + GeneralTests.
+Keep entries principle-level and environment-agnostic: describe *what to do* and
+*why*, with categories and references, never specific magnitudes.
 
-**Note on denominators**: genhtml `--branch-coverage` shows ~1821 branches (exception
-pseudobranches excluded); raw `llvm-cov export` shows ~1954. Use one tool consistently
-within a comparison — mixing denominators makes deltas meaningless.
+## Coverage Ceiling Is Hardware-Dependent (principle)
 
-**Resolved puzzle**: Always verify BRDA counts against a profdata that actually includes the
-relevant test execution. A branch showing `count=0` may just mean the profdata was built
-from an incomplete run — not that the branch is uncovered.
+The reachable branch-coverage ceiling is bounded by available hardware and
+infrastructure, not by test effort. A large fraction of transport branches are
+error/fault/hardware paths unreachable without special infrastructure
+(fault-injection hooks, GDR/DMA-buf hardware, multi-port/RoCE fabric, cross-host
+or `netem` latency for connect/accept mid-states). Therefore:
 
-### Hardware-dependent coverage ceiling
+- **Establish the realistic ceiling for your specific hardware before setting a
+  target** — otherwise the target is unachievable by design and the gap is not a
+  quality problem.
+- Classify each uncovered branch (Trivial / Structural / Hardware / Fault
+  injection / Dead) and count only the reachable classes toward a projected delta.
+- Some branches are genuinely unreachable on a given setup (compiler exception
+  pseudo-branches, single-thread-only race windows, log-macro internals).
+  Document them as the ceiling; do not contrive tests to flip them.
 
-The coverage ceiling is determined by what hardware and infrastructure are available.
-Most uncovered branches fall into categories that require specific capabilities:
+**Lever, not magnitude:** record *which techniques move coverage* (multi-QP split,
+MR-cache churn, shuffled multi-recv, env-var sweeps, fault injection), not the
+percentage each produced — that varies per build and lives in the coverage report.
 
-| Category | Approx branches | Requirement |
-|----------|:--------------:|-------------|
-| Connect/Accept state machine mid-transitions | ~30 | Cross-host run or `tc netem` latency injection |
-| RoCE/GID selection paths | ~100 | Multiple RoCE port types or IB fabric |
-| GDR/DMA-buf paths | ~50 | GDR kernel module + GPU direct RDMA support |
-| WC error / fatal-error paths | ~30 | LD_PRELOAD shim to inject bad work completions |
-| NCCLCHECK error fallback branches | ~600 | Systematic fault injection at each call site |
-
-**Realistic ceiling without LD_PRELOAD shims or GDR hardware: ~44–45%.** This is not a
-quality problem — it reflects that ~55% of branches are error/fault/hardware paths that
-cannot be reached without special infrastructure. Establish the ceiling for your specific
-hardware before setting a target; otherwise the target is unachievable by design.
-
-**Env-var technique** — run existing tests with specific env vars to cover additional branches
-without writing new tests:
-- `NCCL_IB_SL=N NCCL_IB_TC=N` — SL/TC configuration branches
-- `NCCL_IB_ECE_ENABLE=0` — ECE disabled path in connect loop
-- `NCCL_IB_MERGE_VFS=0` — VFS merge disabled paths in init
-- `RCCL_FORCE_ENABLE_DMABUF=1` — forceDmaBuf branch in accept
-- `sudo tc qdisc add dev lo root netem delay Xms` — SendDevList reentry on loopback
-- Each env-var run should be merged with the existing profdata, not treated as standalone.
+**Env-var technique** — run existing tests under additional env-var combinations to
+reach configuration branches without writing new tests; merge each run's profile
+into the same profdata rather than measuring it standalone. (Which specific env
+vars apply is project/version-specific — find them via BRDA analysis, don't
+hardcode a list here.)

--- a/projects/rccl/src/misc/ibvwrap.cc
+++ b/projects/rccl/src/misc/ibvwrap.cc
@@ -23,6 +23,11 @@ static std::once_flag initOnceFlag;
 static ncclResult_t initResult;
 struct ncclIbvSymbols ibvSymbols;
 
+#ifdef ENABLE_FAULT_INJECTION
+// Fault shims installed on the context's ops table at open/close time.
+#include "net_ib_ops_fault.h"
+#endif
+
 #ifdef ENABLE_QP_TRACKING
 #include <unordered_map>
 #include <algorithm>
@@ -151,11 +156,32 @@ const char *wrap_ibv_get_device_name(struct ibv_device *device) {
   return ibvSymbols.ibv_internal_get_device_name(device);
 }
 
-ncclResult_t wrap_ibv_open_device(struct ibv_context **ret, struct ibv_device *device) { /*returns 0 on success, -1 on failure*/
+ncclResult_t wrap_ibv_open_device(struct ibv_context **ret, struct ibv_device *device) { /*returns ncclResult_t (ncclSuccess on success)*/
+#ifdef ENABLE_FAULT_INJECTION
+  // Expand IBV_PTR_CHECK inline to install fault shims before returning.
+  CHECK_NOT_NULL(ibvSymbols, ibv_internal_open_device);
+  *ret = ibvSymbols.ibv_internal_open_device(device);
+  if (*ret == NULL) {
+    WARN("Call to ibv_open_device failed");
+    return ncclSystemError;
+  }
+  ncclResult_t installRes = ncclIbOpsFaultInstall(*ret);
+  if (installRes != ncclSuccess) {
+    ibvSymbols.ibv_internal_close_device(*ret);  // don't leak the opened device
+    *ret = NULL;
+    return installRes;
+  }
+  return ncclSuccess;
+#else
   IBV_PTR_CHECK(ibvSymbols, ibv_internal_open_device, ibv_internal_open_device(device), *ret, NULL, "ibv_open_device");
+#endif
 }
 
-ncclResult_t wrap_ibv_close_device(struct ibv_context *context) { /*returns 0 on success, -1 on failure*/
+ncclResult_t wrap_ibv_close_device(struct ibv_context *context) { /*returns ncclResult_t (ncclSuccess on success)*/
+#ifdef ENABLE_FAULT_INJECTION
+  // Restore original ops before closing so the real close sees a clean context.
+  if (context) NCCLCHECK(ncclIbOpsFaultRemove(context));
+#endif
   IBV_INT_CHECK(ibvSymbols, ibv_internal_close_device, ibv_internal_close_device(context), -1, "ibv_close_device");
 }
 

--- a/projects/rccl/src/transport/net_ib_cast/CMakeLists.txt
+++ b/projects/rccl/src/transport/net_ib_cast/CMakeLists.txt
@@ -2,6 +2,7 @@
 set(NET_IB_CAST_SOURCES
     src/transport/net_ib_limits.h
     src/transport/net_ib_cast/net_ib_cast_inspect.h
+    src/transport/net_ib_cast/net_ib_ops_fault.h
     src/transport/net_ib_cast/common_cast.h
     src/transport/net_ib_cast/connect_cast.h
     src/transport/net_ib_cast/gin_cast.h
@@ -15,6 +16,7 @@ set(NET_IB_CAST_SOURCES
     src/transport/net_ib_cast/gdr.cc
     src/transport/net_ib_cast/init.cc
     src/transport/net_ib_cast/p2p.cc
+    src/transport/net_ib_cast/net_ib_ops_fault.cc
     src/transport/net_ib_cast/p2p_resiliency.cc
     src/transport/net_ib_cast/p2p_resiliency_recovery.cc
     src/transport/net_ib_cast/p2p_resiliency_recovery_ainic.cc

--- a/projects/rccl/src/transport/net_ib_cast/net_ib_fault_inject.h
+++ b/projects/rccl/src/transport/net_ib_cast/net_ib_fault_inject.h
@@ -65,6 +65,31 @@ ncclResult_t ncclIbCastFaultDriveRecvQpToError(void* recvComm, int qpIdx);
  * unrecoverable (not eligible for failover). */
 ncclResult_t ncclIbCastFaultCheckErrorFatal(void* sendComm, int wcStatus, bool* isFatal);
 
+/* ── CAST ops-overload path (src/transport/net_ib_cast/net_ib_ops_fault.cc) ──
+ *
+ * These arm faults on the shimmed ibv_context ops table installed at
+ * wrap_ibv_open_device time, so the fault is applied at the REAL libibverbs
+ * call boundary (post_send/post_recv/poll_cq) rather than the pre-call
+ * intercept in p2p.cc. qpIdx must be in [0, nqps). */
+
+/* Make the real ibv_post_send on the QP at qpIdx return errnoVal (e.g. EAGAIN,
+ * ENOMEM). errnoVal=0 disarms. */
+ncclResult_t ncclIbCastFaultOpsSetPostSendError(void* sendComm, int qpIdx, int errnoVal);
+
+/* Make the real ibv_post_recv on the QP at qpIdx return errnoVal. 0 disarms. */
+ncclResult_t ncclIbCastFaultOpsSetPostRecvError(void* recvComm, int qpIdx, int errnoVal);
+
+/* Inject an error completion for the QP at qpIdx.
+ *  wcStatus      : ibv_wc_status to apply (0 disarms).
+ *  injectCount   : completions to corrupt; <0 = unlimited.
+ *  injectWhenIdle: if true, synthesize an error WC when poll_cq is idle;
+ *                  if false, only rewrite the status of real matching completions. */
+ncclResult_t ncclIbCastFaultOpsSetPollCqError(void* comm, int qpIdx, int wcStatus,
+                                              int injectCount, bool injectWhenIdle);
+
+/* Clear all ops-overload fault config on the connection (shims stay installed). */
+ncclResult_t ncclIbCastFaultOpsClear(void* comm);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/projects/rccl/src/transport/net_ib_cast/net_ib_ops_fault.cc
+++ b/projects/rccl/src/transport/net_ib_cast/net_ib_ops_fault.cc
@@ -1,0 +1,232 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#include "net_ib_ops_fault.h"
+
+#ifdef ENABLE_FAULT_INJECTION
+
+#include "core.h"  /* WARN / INFO */
+#include <cerrno>
+#include <cstring>
+#include <mutex>
+#include <unordered_map>
+
+namespace {
+
+// Per-QP fault configuration. A zero/disarmed value leaves the corresponding op
+// forwarding to the saved real op.
+struct QpFault {
+  int  sendErrno      = 0;      // returned from post_send when != 0
+  int  recvErrno      = 0;      // returned from post_recv when != 0
+  int  pollWcStatus   = 0;      // ibv_wc_status applied when != 0 (0 == IBV_WC_SUCCESS)
+  int  pollInjectCount = 0;     // remaining completions to corrupt; <0 == unlimited
+  bool injectWhenIdle = false;  // synthesize an error WC when real poll returns 0
+};
+
+struct OpsEntry {
+  int (*realPostSend)(struct ibv_qp*, struct ibv_send_wr*, struct ibv_send_wr**) = nullptr;
+  int (*realPostRecv)(struct ibv_qp*, struct ibv_recv_wr*, struct ibv_recv_wr**) = nullptr;
+  int (*realPollCq)(struct ibv_cq*, int, struct ibv_wc*) = nullptr;
+  // Keyed by qp_num; NCCL_IB_OPS_FAULT_QP_ANY applies context-wide.
+  std::unordered_map<uint32_t, QpFault> qpFaults;
+};
+
+std::mutex g_faultMtx;
+std::unordered_map<struct ibv_context*, OpsEntry> g_ctxFaults;
+
+// wr_id for synthesized idle completions; defined in the header and tied to the
+// receiver's wr_id ranges by a static_assert in p2p.cc. Low byte 0 keeps the
+// sender slot decode unchanged.
+static constexpr uint64_t kSynthIdleWrId = NCCL_IB_OPS_FAULT_SYNTH_WR_ID;
+
+// Look up the QpFault for (entry, qpNum), preferring an exact qp_num match and
+// falling back to the context-wide ANY entry. Returns nullptr if neither armed.
+// Caller must hold g_faultMtx.
+QpFault* findFault(OpsEntry& entry, uint32_t qpNum) {
+  auto it = entry.qpFaults.find(qpNum);
+  if (it != entry.qpFaults.end()) return &it->second;
+  auto any = entry.qpFaults.find(NCCL_IB_OPS_FAULT_QP_ANY);
+  if (any != entry.qpFaults.end()) return &any->second;
+  return nullptr;
+}
+
+// ── Shims ──────────────────────────────────────────────────────────────────
+
+int shimPostSend(struct ibv_qp* qp, struct ibv_send_wr* wr, struct ibv_send_wr** bad_wr) {
+  int (*real)(struct ibv_qp*, struct ibv_send_wr*, struct ibv_send_wr**) = nullptr;
+  int errnoVal = 0;
+  {
+    std::lock_guard<std::mutex> lk(g_faultMtx);
+    auto ctxIt = g_ctxFaults.find(qp->context);
+    if (ctxIt != g_ctxFaults.end()) {
+      real = ctxIt->second.realPostSend;
+      QpFault* fault = findFault(ctxIt->second, qp->qp_num);
+      if (fault) errnoVal = fault->sendErrno;
+    }
+  }
+  if (errnoVal != 0) {
+    if (bad_wr) *bad_wr = wr;
+    return errnoVal;
+  }
+  // Lost real op: set *bad_wr (wrap_ibv_post_send logs it) and fail.
+  if (!real) {
+    if (bad_wr) *bad_wr = wr;
+    return EFAULT;
+  }
+  return real(qp, wr, bad_wr);
+}
+
+int shimPostRecv(struct ibv_qp* qp, struct ibv_recv_wr* wr, struct ibv_recv_wr** bad_wr) {
+  int (*real)(struct ibv_qp*, struct ibv_recv_wr*, struct ibv_recv_wr**) = nullptr;
+  int errnoVal = 0;
+  {
+    std::lock_guard<std::mutex> lk(g_faultMtx);
+    auto ctxIt = g_ctxFaults.find(qp->context);
+    if (ctxIt != g_ctxFaults.end()) {
+      real = ctxIt->second.realPostRecv;
+      QpFault* fault = findFault(ctxIt->second, qp->qp_num);
+      if (fault) errnoVal = fault->recvErrno;
+    }
+  }
+  if (errnoVal != 0) {
+    if (bad_wr) *bad_wr = wr;
+    return errnoVal;
+  }
+  // Lost real op: set *bad_wr for ibv_post_* consistency and fail.
+  if (!real) {
+    if (bad_wr) *bad_wr = wr;
+    return EFAULT;
+  }
+  return real(qp, wr, bad_wr);
+}
+
+int shimPollCq(struct ibv_cq* cq, int num_entries, struct ibv_wc* wc) {
+  int (*real)(struct ibv_cq*, int, struct ibv_wc*) = nullptr;
+  {
+    std::lock_guard<std::mutex> lk(g_faultMtx);
+    auto ctxIt = g_ctxFaults.find(cq->context);
+    if (ctxIt != g_ctxFaults.end()) real = ctxIt->second.realPollCq;
+  }
+  if (!real) return -1;
+
+  int got = real(cq, num_entries, wc);
+  if (got < 0) return got;
+
+  std::lock_guard<std::mutex> lk(g_faultMtx);
+  auto ctxIt = g_ctxFaults.find(cq->context);
+  if (ctxIt == g_ctxFaults.end()) return got;
+  OpsEntry& entry = ctxIt->second;
+
+  // Rewrite the status of real completions whose qp_num is armed.
+  for (int i = 0; i < got; i++) {
+    QpFault* fault = findFault(entry, wc[i].qp_num);
+    if (fault && fault->pollWcStatus != 0 && fault->pollInjectCount != 0) {
+      wc[i].status = (enum ibv_wc_status)fault->pollWcStatus;
+      if (fault->pollInjectCount > 0) fault->pollInjectCount--;
+    }
+  }
+
+  // Synthesize an error completion when the queue was idle and an armed QP
+  // requested idle injection. Only fabricate a single WC into slot 0.
+  // NOTE: picks the first idle-armed QP on the context without checking it
+  // belongs to this cq. Safe while only one QP is armed at a time; if several
+  // QPs (on different CQs) are armed, filter by cq before fabricating.
+  if (got == 0 && num_entries >= 1) {
+    for (auto& kv : entry.qpFaults) {
+      QpFault& fault = kv.second;
+      if (fault.injectWhenIdle && fault.pollWcStatus != 0 && fault.pollInjectCount != 0) {
+        memset(&wc[0], 0, sizeof(wc[0]));
+        wc[0].status = (enum ibv_wc_status)fault.pollWcStatus;
+        wc[0].qp_num = (kv.first == NCCL_IB_OPS_FAULT_QP_ANY) ? 0u : kv.first;
+        wc[0].wr_id = kSynthIdleWrId;  // not 0; see kSynthIdleWrId
+        if (fault.pollInjectCount > 0) fault.pollInjectCount--;
+        got = 1;
+        break;
+      }
+    }
+  }
+  return got;
+}
+
+}  // namespace
+
+extern "C" {
+
+ncclResult_t ncclIbOpsFaultInstall(struct ibv_context* ctx) {
+  if (!ctx) return ncclInvalidArgument;
+  std::lock_guard<std::mutex> lk(g_faultMtx);
+  if (g_ctxFaults.find(ctx) != g_ctxFaults.end()) return ncclSuccess;  // already installed
+  if (!ctx->ops.post_send || !ctx->ops.post_recv || !ctx->ops.poll_cq) {
+    WARN("NET/IB ops-fault: context %p has NULL post_send/post_recv/poll_cq op; skipping install", ctx);
+    return ncclSuccess;
+  }
+  OpsEntry entry;
+  entry.realPostSend = ctx->ops.post_send;
+  entry.realPostRecv = ctx->ops.post_recv;
+  entry.realPollCq   = ctx->ops.poll_cq;
+  g_ctxFaults.emplace(ctx, entry);
+  ctx->ops.post_send = shimPostSend;
+  ctx->ops.post_recv = shimPostRecv;
+  ctx->ops.poll_cq   = shimPollCq;
+  INFO(NCCL_NET, "NET/IB ops-fault: installed shims on context %p", ctx);
+  return ncclSuccess;
+}
+
+ncclResult_t ncclIbOpsFaultRemove(struct ibv_context* ctx) {
+  if (!ctx) return ncclInvalidArgument;
+  std::lock_guard<std::mutex> lk(g_faultMtx);
+  auto ctxIt = g_ctxFaults.find(ctx);
+  if (ctxIt == g_ctxFaults.end()) return ncclSuccess;
+  ctx->ops.post_send = ctxIt->second.realPostSend;
+  ctx->ops.post_recv = ctxIt->second.realPostRecv;
+  ctx->ops.poll_cq   = ctxIt->second.realPollCq;
+  g_ctxFaults.erase(ctxIt);
+  return ncclSuccess;
+}
+
+ncclResult_t ncclIbOpsFaultArmPostSend(struct ibv_context* ctx, uint32_t qpNum, int errnoVal) {
+  if (!ctx) return ncclInvalidArgument;
+  std::lock_guard<std::mutex> lk(g_faultMtx);
+  auto ctxIt = g_ctxFaults.find(ctx);
+  if (ctxIt == g_ctxFaults.end()) return ncclInvalidArgument;
+  ctxIt->second.qpFaults[qpNum].sendErrno = errnoVal;
+  return ncclSuccess;
+}
+
+ncclResult_t ncclIbOpsFaultArmPostRecv(struct ibv_context* ctx, uint32_t qpNum, int errnoVal) {
+  if (!ctx) return ncclInvalidArgument;
+  std::lock_guard<std::mutex> lk(g_faultMtx);
+  auto ctxIt = g_ctxFaults.find(ctx);
+  if (ctxIt == g_ctxFaults.end()) return ncclInvalidArgument;
+  ctxIt->second.qpFaults[qpNum].recvErrno = errnoVal;
+  return ncclSuccess;
+}
+
+ncclResult_t ncclIbOpsFaultArmPollCq(struct ibv_context* ctx, uint32_t qpNum,
+                                     int wcStatus, int injectCount, bool injectWhenIdle) {
+  if (!ctx) return ncclInvalidArgument;
+  std::lock_guard<std::mutex> lk(g_faultMtx);
+  auto ctxIt = g_ctxFaults.find(ctx);
+  if (ctxIt == g_ctxFaults.end()) return ncclInvalidArgument;
+  QpFault& fault = ctxIt->second.qpFaults[qpNum];
+  fault.pollWcStatus = wcStatus;
+  fault.pollInjectCount = injectCount;
+  fault.injectWhenIdle = injectWhenIdle;
+  return ncclSuccess;
+}
+
+ncclResult_t ncclIbOpsFaultClear(struct ibv_context* ctx) {
+  if (!ctx) return ncclInvalidArgument;
+  std::lock_guard<std::mutex> lk(g_faultMtx);
+  auto ctxIt = g_ctxFaults.find(ctx);
+  if (ctxIt == g_ctxFaults.end()) return ncclSuccess;
+  ctxIt->second.qpFaults.clear();
+  return ncclSuccess;
+}
+
+}  // extern "C"
+
+#endif /* ENABLE_FAULT_INJECTION */

--- a/projects/rccl/src/transport/net_ib_cast/net_ib_ops_fault.h
+++ b/projects/rccl/src/transport/net_ib_cast/net_ib_ops_fault.h
@@ -1,0 +1,74 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#ifndef RCCL_NET_IB_OPS_FAULT_H_
+#define RCCL_NET_IB_OPS_FAULT_H_
+
+#ifdef ENABLE_FAULT_INJECTION
+
+/*
+ * Test-only IB ops-overload fault injection for the net-ib CAST transport.
+ *
+ * After wrap_ibv_open_device() returns an ibv_context, ncclIbOpsFaultInstall()
+ * saves the original post_send/post_recv/poll_cq pointers from the context's
+ * embedded ops table and replaces them with fault-aware shims. The shims look
+ * up per-(context, qp_num) fault config in a registry; when armed they inject an
+ * errno return (post_send/post_recv) or an error completion status (poll_cq),
+ * otherwise they forward to the saved real op. This exercises the REAL libibverbs
+ * call boundary, unlike the pre-call intercept in p2p.cc (faultQpError/Delay).
+ *
+ * Implemented in src/transport/net_ib_cast/net_ib_ops_fault.cc.
+ */
+
+#include "ibvwrap.h"  /* selects ibvcore.h or infiniband/verbs.h per build mode */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* qp_num sentinel: arm/clear applies to every QP on the context. */
+#define NCCL_IB_OPS_FAULT_QP_ANY (~0u)
+
+/* wr_id for synthesized idle completions. Must stay outside the receiver's
+ * recv-slot and flush wr_id ranges so the receiver rejects it cleanly; a
+ * static_assert in p2p.cc ties this to those ranges. */
+#define NCCL_IB_OPS_FAULT_SYNTH_WR_ID 0xF00000ull
+
+/* Install fault shims onto ctx's ops table. Returns ncclInvalidArgument if ctx
+ * is NULL. Otherwise idempotent and a no-op (returns ncclSuccess without
+ * modifying the ops table) if ctx is already installed or any of the three
+ * target ops is NULL (logged). */
+ncclResult_t ncclIbOpsFaultInstall(struct ibv_context* ctx);
+
+/* Restore original ops and erase the registry entry for ctx. No-op if not
+ * installed. Call before wrap_ibv_close_device closes the context. */
+ncclResult_t ncclIbOpsFaultRemove(struct ibv_context* ctx);
+
+/* Arm a post_send errno fault on (ctx, qpNum). errnoVal=0 disarms. */
+ncclResult_t ncclIbOpsFaultArmPostSend(struct ibv_context* ctx, uint32_t qpNum, int errnoVal);
+
+/* Arm a post_recv errno fault on (ctx, qpNum). errnoVal=0 disarms. */
+ncclResult_t ncclIbOpsFaultArmPostRecv(struct ibv_context* ctx, uint32_t qpNum, int errnoVal);
+
+/* Arm a poll_cq error fault on (ctx, qpNum).
+ *  wcStatus      : ibv_wc_status to apply (0 = IBV_WC_SUCCESS disarms).
+ *  injectCount   : number of completions to corrupt; <0 = unlimited.
+ *  injectWhenIdle: if true, synthesize one error WC when the real poll_cq
+ *                  returns 0 completions; if false, only rewrite the status of
+ *                  real completions whose qp_num matches. */
+ncclResult_t ncclIbOpsFaultArmPollCq(struct ibv_context* ctx, uint32_t qpNum,
+                                     int wcStatus, int injectCount, bool injectWhenIdle);
+
+/* Clear all ops-fault config for ctx (does not uninstall the shims). */
+ncclResult_t ncclIbOpsFaultClear(struct ibv_context* ctx);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* ENABLE_FAULT_INJECTION */
+
+#endif /* RCCL_NET_IB_OPS_FAULT_H_ */

--- a/projects/rccl/src/transport/net_ib_cast/p2p.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p.cc
@@ -9,6 +9,9 @@
 #include "common_cast.h"
 #include "p2p_resiliency_cast.h"
 #include "net_ib_fault_inject.h"
+#ifdef ENABLE_FAULT_INJECTION
+#include "net_ib_ops_fault.h"
+#endif
 
 NCCL_PARAM(IbCastArThreshold, "IB_AR_THRESHOLD", -2);
 int64_t IbCastArThreshold = 8192;
@@ -1182,6 +1185,62 @@ ncclResult_t ncclIbCastFaultCheckErrorFatal(void* sendComm, int wcStatus, bool* 
       break;
   }
   *isFatal = fatal;
+  return ncclSuccess;
+}
+
+/* ── Ops-overload fault API (bridges comm → ibv_context + qp_num) ─────────── */
+
+// The synthesized idle-completion wr_id must stay outside the receiver's
+// recv-slot range [0, NET_IB_MAX_REQUESTS] and flush range
+// [NCCL_IB_FLUSH_REQ_WR_ID_OFFSET, +NET_IB_MAX_REQUESTS); else the receiver
+// would treat it as a real slot. Fail the build if the ranges ever overlap it.
+static_assert(NCCL_IB_OPS_FAULT_SYNTH_WR_ID > NET_IB_MAX_REQUESTS &&
+              (NCCL_IB_OPS_FAULT_SYNTH_WR_ID < NCCL_IB_FLUSH_REQ_WR_ID_OFFSET ||
+               NCCL_IB_OPS_FAULT_SYNTH_WR_ID >= NCCL_IB_FLUSH_REQ_WR_ID_OFFSET + NET_IB_MAX_REQUESTS),
+              "synthesized fault wr_id collides with a receiver wr_id range");
+
+ncclResult_t ncclIbCastFaultOpsSetPostSendError(void* sendComm, int qpIdx, int errnoVal) {
+  if (!sendComm) return ncclInvalidArgument;
+  struct ncclIbSendComm* comm = (struct ncclIbSendComm*)sendComm;
+  if (qpIdx < 0 || qpIdx >= comm->base.nqps) return ncclInvalidArgument;
+  struct ibv_qp* qp = comm->base.activeQps[qpIdx]->qp;
+  // qp can be NULL while resiliency recovery has the QP torn down.
+  if (!qp || !qp->context) return ncclInvalidArgument;
+  return ncclIbOpsFaultArmPostSend(qp->context, qp->qp_num, errnoVal);
+}
+
+ncclResult_t ncclIbCastFaultOpsSetPostRecvError(void* recvComm, int qpIdx, int errnoVal) {
+  if (!recvComm) return ncclInvalidArgument;
+  struct ncclIbRecvComm* comm = (struct ncclIbRecvComm*)recvComm;
+  if (qpIdx < 0 || qpIdx >= comm->base.nqps) return ncclInvalidArgument;
+  struct ibv_qp* qp = comm->base.activeQps[qpIdx]->qp;
+  // qp can be NULL while resiliency recovery has the QP torn down.
+  if (!qp || !qp->context) return ncclInvalidArgument;
+  return ncclIbOpsFaultArmPostRecv(qp->context, qp->qp_num, errnoVal);
+}
+
+ncclResult_t ncclIbCastFaultOpsSetPollCqError(void* comm, int qpIdx, int wcStatus,
+                                              int injectCount, bool injectWhenIdle) {
+  if (!comm) return ncclInvalidArgument;
+  // Both send and recv comms share ncclIbNetCommBase as their first member.
+  struct ncclIbNetCommBase* base = (struct ncclIbNetCommBase*)comm;
+  if (qpIdx < 0 || qpIdx >= base->nqps) return ncclInvalidArgument;
+  struct ibv_qp* qp = base->activeQps[qpIdx]->qp;
+  // qp can be NULL while resiliency recovery has the QP torn down.
+  if (!qp || !qp->context) return ncclInvalidArgument;
+  return ncclIbOpsFaultArmPollCq(qp->context, qp->qp_num, wcStatus, injectCount, injectWhenIdle);
+}
+
+ncclResult_t ncclIbCastFaultOpsClear(void* comm) {
+  if (!comm) return ncclInvalidArgument;
+  struct ncclIbNetCommBase* base = (struct ncclIbNetCommBase*)comm;
+  // Clear by per-device PD context, not QP: a QP can be NULL during recovery
+  // while its context stays alive and armed. The PD context survives teardown.
+  for (int devIndex = 0; devIndex < base->vProps.ndevs; devIndex++) {
+    struct ncclIbNetCommDevBase* devBase = IbCastGetNetCommDevBase(base, devIndex);
+    if (devBase && devBase->pd && devBase->pd->context)
+      NCCLCHECK(ncclIbOpsFaultClear(devBase->pd->context));
+  }
   return ncclSuccess;
 }
 

--- a/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
@@ -55,7 +55,9 @@ static constexpr int kFaultResultMpiTag = 9881;  // FaultInjectResult from Fault
 // so all assertions run on rank 0 (the only rank with GTest listeners).
 struct FaultInjectResult {
     int  sendRet;       // ncclResult_t from PostSend (cast to int)
+    int  recvRet;       // ncclResult_t from PostRecv/Test on the recv side (cast to int)
     int  fatalCount;    // ncclIbCastFaultGetFatalCount result
+    int  phase2FatalCount;  // fatal count after a finite injection budget is spent
     int  clearRet;      // ncclResult_t from ncclIbCastFaultClear (cast to int)
     int  setErrRet;     // first non-Success from ncclIbCastFaultSetQpError, or ncclSuccess
     int  actualNqps;    // number of QPs armed with the error fault
@@ -2851,6 +2853,133 @@ TEST_F(NetIbMPITest, FaultInjCastOpsPollCqSynthFatal) {
             << "rank 1: expected isend to fail OR fatalErrorCount > 0 after synthesizing a "
             << "non-whitelisted REM_ACCESS_ERR completion; isend returned " << r1.sendRet
             << ", fatalCount=" << r1.fatalCount;
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    if (rank == 0 && !recvDone)
+        DrainRecvRequest(recvReq);
+    TeardownConnection(recvComm, listenComm, sendComm, mhandle);
+}
+
+// =============================================================================
+// Test: FaultInjCastOpsPostRecvErrno
+//
+// Ops-overload path, RECEIVER side: the symmetric counterpart of
+// FaultInjCastOpsPostSendErrno. Arms the shimmed ibv_post_recv to return EAGAIN
+// on every receiver QP, exercising shimPostRecv's errno path (no other test
+// reaches it).
+//
+// Verifies: the receiver reports a PostRecv error when post_recv is faulted on
+//           all receiver QPs.
+// Requires: WRR scheduler env vars (CAST_ENV_CHECK_OR_SKIP); arms all recv QPs.
+// =============================================================================
+TEST_F(NetIbMPITest, FaultInjCastOpsPostRecvErrno) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    CAST_ENV_CHECK_OR_SKIP();
+
+    const int rank = MPIEnvironment::world_rank;
+
+    net_ = &netIbCast;
+    AssertInitAndGetDevices(nullptr);
+
+    void* listenComm = nullptr;
+    void* sendComm   = nullptr;
+    void* recvComm   = nullptr;
+    SetupCastConnection(/*dev=*/0, &listenComm, &sendComm, &recvComm);
+
+    constexpr size_t kMsgSize = 1024;
+    std::vector<char> sendBuf(kMsgSize), recvBuf(kMsgSize);
+    for (size_t i = 0; i < kMsgSize; i++) sendBuf[i] = static_cast<char>(i & 0xFF);
+    memset(recvBuf.data(), 0, kMsgSize);
+
+    void* comm    = (rank == 0) ? recvComm : sendComm;
+    void* buf     = (rank == 0) ? static_cast<void*>(recvBuf.data())
+                                : static_cast<void*>(sendBuf.data());
+    void* mhandle = nullptr;
+    ASSERT_EQ(RegisterMemory(comm, buf, kMsgSize, NCCL_PTR_HOST, &mhandle), ncclSuccess);
+
+    // Warmup so the connection/QPs are fully established before arming.
+    const int actualNqps = GetActualNqps(sendComm, recvComm, buf, kMsgSize, /*tag=*/730, mhandle);
+    ASSERT_GT(actualNqps, 0);
+
+    static constexpr int kEagain = EAGAIN;
+    FaultInjectResult r0 = {};
+    r0.actualNqps = actualNqps;
+
+    // Arm post_recv EAGAIN on every receiver QP (rank 0 owns recvComm).
+    if (rank == 0) {
+        r0.setErrRet = static_cast<int>(ncclSuccess);
+        for (int q = 0; q < actualNqps; ++q) {
+            ncclResult_t ret = ncclIbCastFaultOpsSetPostRecvError(recvComm, q, kEagain);
+            if (ret != ncclSuccess && r0.setErrRet == static_cast<int>(ncclSuccess))
+                r0.setErrRet = static_cast<int>(ret);
+        }
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    bool recvDone = false;
+    void* recvReq = nullptr;
+
+    if (rank == 0) {
+        void*  bufs[1]    = {buf};
+        size_t sizes[1]   = {kMsgSize};
+        int    tags[1]    = {731};
+        void*  handles[1] = {mhandle};
+        ncclResult_t recvRet = PostRecv(recvComm, 1, bufs, sizes, tags, handles, &recvReq);
+        r0.recvRet = static_cast<int>(recvRet);
+        if (recvRet == ncclSuccess && recvReq != nullptr) {
+            for (int poll = 0; poll < 200; poll++) {
+                int done = 0, sz = 0;
+                if (TestRequest(recvReq, &done, &sz) != ncclSuccess) {
+                    r0.recvRet = static_cast<int>(ncclSystemError);
+                    break;
+                }
+                if (done) { recvDone = true; break; }
+                usleep(kPollIntervalUs);
+            }
+        }
+        // Disarm before teardown so the close path is clean.
+        r0.clearRet = static_cast<int>(ncclIbCastFaultOpsClear(recvComm));
+    } else {
+        // Sender: best-effort send; do not assert here (rank 0 holds listeners).
+        void* sendReq = nullptr;
+        ncclResult_t sendRet = ncclSuccess;
+        for (int attempt = 0; attempt < kMaxRetryAttempts; attempt++) {
+            sendRet = PostSend(sendComm, buf, kMsgSize, 731, mhandle, &sendReq);
+            if (sendRet != ncclSuccess || sendReq != nullptr) break;
+            usleep(kPollIntervalUs);
+        }
+        if (sendRet == ncclSuccess && sendReq != nullptr) {
+            for (int poll = 0; poll < 200; poll++) {
+                int done = 0, sz = 0;
+                if (TestRequest(sendReq, &done, &sz) != ncclSuccess) break;
+                if (done) break;
+                usleep(kPollIntervalUs);
+            }
+        }
+    }
+
+    // Rank 0 already has the result locally; no inter-rank ship needed because
+    // the assertions are recv-side (rank 0).
+    if (rank == 0) {
+        EXPECT_EQ(r0.setErrRet, static_cast<int>(ncclSuccess))
+            << "rank 0: ncclIbCastFaultOpsSetPostRecvError failed with " << r0.setErrRet;
+        EXPECT_EQ(r0.clearRet, static_cast<int>(ncclSuccess))
+            << "rank 0: ncclIbCastFaultOpsClear failed with " << r0.clearRet;
+
+        // post_recv EAGAIN on all receiver QPs: the receive must NOT complete
+        // cleanly — either PostRecv/Test reported an error, or it never finished.
+        // Positive signal: post_recv EAGAIN on every receiver QP forces a
+        // synchronous error, so recv must actually error — a mere "didn't
+        // finish" (which any timeout satisfies) would let a dead shim pass.
+        bool recvErrored = (r0.recvRet != static_cast<int>(ncclSuccess));
+        EXPECT_TRUE(recvErrored)
+            << "rank 0: expected recv to error after arming all "
+            << r0.actualNqps << " receiver QPs with ops-level post_recv EAGAIN; "
+            << "recv post/test returned " << r0.recvRet << ", recvDone=" << recvDone;
     }
 
     MPI_Barrier(MPI_COMM_WORLD);

--- a/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
@@ -2600,4 +2600,147 @@ TEST_F(NetIbMPITest, FaultInjCastOpsPostSendErrno) {
     TeardownConnection(recvComm, listenComm, sendComm, mhandle);
 }
 
+// =============================================================================
+// Test: FaultInjCastOpsPollCqFlushNonFatal
+//
+// Ops-overload path, poll_cq STATUS-REWRITE mode: rewrites real completions on
+// sender QP 0 to the whitelisted (recoverable) IBV_WC_WR_FLUSH_ERR, so the
+// resiliency layer fails over to the surviving device.
+//
+// Verifies: transfer fails over to the surviving device with fatalErrorCount == 0
+//           and data intact.
+// Requires: NCCL_IB_RESILIENCY_PORT_FAILOVER=1 and NIC Fusion ndevs >= 2 (else SKIP).
+// =============================================================================
+TEST_F(NetIbMPITest, FaultInjCastOpsPollCqFlushNonFatal) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    const char* failoverEnv = getenv("NCCL_IB_RESILIENCY_PORT_FAILOVER");
+    if (!failoverEnv || strcmp(failoverEnv, "1") != 0) {
+        GTEST_SKIP() << "Requires NCCL_IB_RESILIENCY_PORT_FAILOVER=1";
+    }
+
+    const int rank = MPIEnvironment::world_rank;
+
+    net_ = &netIbCast;
+    int totalDevs = 0;
+    AssertInitAndGetDevices(&totalDevs);
+
+    int mergedDev = CreateMergedDeviceForFailover(net_, totalDevs);
+    if (mergedDev < 0) {
+        GTEST_SKIP() << "Failover requires NIC Fusion (ndevs >= 2). "
+                     << "Found " << totalDevs << " physical devices.";
+    }
+
+    void* listenComm = nullptr;
+    void* sendComm   = nullptr;
+    void* recvComm   = nullptr;
+    SetupCastConnection(/*dev=*/mergedDev, &listenComm, &sendComm, &recvComm);
+
+    constexpr size_t kMsgSize = 8192;
+    std::vector<char> sendBuf(kMsgSize), recvBuf(kMsgSize);
+    for (size_t i = 0; i < kMsgSize; i++) sendBuf[i] = static_cast<char>((i * 13 + 7) & 0xFF);
+    memset(recvBuf.data(), 0, kMsgSize);
+
+    void* comm    = (rank == 0) ? recvComm : sendComm;
+    void* buf     = (rank == 0) ? static_cast<void*>(recvBuf.data())
+                                : static_cast<void*>(sendBuf.data());
+    void* mhandle = nullptr;
+    ASSERT_EQ(RegisterMemory(comm, buf, kMsgSize, NCCL_PTR_HOST, &mhandle), ncclSuccess);
+
+    const int actualNqps = GetActualNqps(sendComm, recvComm, buf, kMsgSize, /*tag=*/710, mhandle);
+    ASSERT_GT(actualNqps, 0);
+
+    struct ncclIbCastResiliencyState resState = {};
+    struct FailoverResult {
+        int sendRet;
+        int fatalCount;
+        int devState0;
+        int armRet;
+        int clearRet;
+    };
+    static constexpr int kOpsFailoverMpiTag = 9887;
+    FailoverResult fr = {};
+
+    bool recvDone = false;
+    void* recvReq = nullptr;
+
+    if (rank == 0) {
+        void*  bufs[1]    = {buf};
+        size_t sizes[1]   = {kMsgSize};
+        int    tags[1]    = {711};
+        void*  handles[1] = {mhandle};
+        ASSERT_EQ(PostRecv(recvComm, 1, bufs, sizes, tags, handles, &recvReq), ncclSuccess);
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (rank == 1) {
+        // Rewrite mode: status of real completions on QP 0 becomes WR_FLUSH_ERR.
+        ncclResult_t armRet = ncclIbCastFaultOpsSetPollCqError(
+            sendComm, /*qpIdx=*/0, kWcWrFlushErr, /*injectCount=*/-1, /*injectWhenIdle=*/false);
+        fr.armRet = static_cast<int>(armRet);
+
+        void* sendReq = nullptr;
+        ncclResult_t sendRet = ncclSuccess;
+        for (int attempt = 0; attempt < kMaxRetryAttempts; attempt++) {
+            sendRet = PostSend(sendComm, buf, kMsgSize, 711, mhandle, &sendReq);
+            if (sendRet != ncclSuccess || sendReq != nullptr) break;
+            usleep(kPollIntervalUs);
+        }
+        if (sendRet == ncclSuccess && sendReq != nullptr) {
+            for (int poll = 0; poll < 500; poll++) {
+                int done = 0, sz = 0;
+                ncclResult_t testRet = TestRequest(sendReq, &done, &sz);
+                if (testRet != ncclSuccess) { sendRet = testRet; break; }
+                if (done) break;
+                usleep(kPollIntervalUs);
+            }
+        }
+
+        int fatalCount = 0;
+        ncclIbCastFaultGetFatalCount(sendComm, &fatalCount);
+        ncclIbCastGetResiliencyState(sendComm, &resState);
+
+        fr.sendRet    = static_cast<int>(sendRet);
+        fr.fatalCount = fatalCount;
+        fr.devState0  = resState.devState[0];
+        fr.clearRet   = static_cast<int>(ncclIbCastFaultOpsClear(sendComm));
+        MPI_Send(&fr, sizeof(fr), MPI_BYTE, 0, kOpsFailoverMpiTag, MPI_COMM_WORLD);
+    }
+
+    if (rank == 0) {
+        for (int poll = 0; poll < 1500; poll++) {
+            int done = 0, sz = 0;
+            if (TestRequest(recvReq, &done, &sz) != ncclSuccess) break;
+            if (done) { recvDone = true; break; }
+            usleep(kPollIntervalUs);
+        }
+
+        MPI_Recv(&fr, sizeof(fr), MPI_BYTE, 1, kOpsFailoverMpiTag, MPI_COMM_WORLD,
+                 MPI_STATUS_IGNORE);
+
+        EXPECT_EQ(fr.armRet, static_cast<int>(ncclSuccess))
+            << "rank 1: ncclIbCastFaultOpsSetPollCqError failed with " << fr.armRet;
+        EXPECT_EQ(fr.clearRet, static_cast<int>(ncclSuccess))
+            << "rank 1: ncclIbCastFaultOpsClear failed with " << fr.clearRet;
+        EXPECT_EQ(fr.sendRet, static_cast<int>(ncclSuccess))
+            << "Send should complete via surviving device after ops-level CQE rewrite";
+        EXPECT_EQ(fr.fatalCount, 0)
+            << "WR_FLUSH_ERR is whitelisted — no fatal error expected";
+        EXPECT_NE(fr.devState0, 0)
+            << "Device 0 should not be Ok after the injected flush error (got "
+            << fr.devState0 << ")";
+        if (recvDone) {
+            EXPECT_EQ(memcmp(recvBuf.data(), sendBuf.data(), kMsgSize), 0)
+                << "Data corruption after ops-level failover";
+        }
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    if (rank == 0 && !recvDone)
+        DrainRecvRequest(recvReq);
+    TeardownConnection(recvComm, listenComm, sendComm, mhandle);
+}
+
 #endif /* MPI_TESTS_ENABLED && ENABLE_FAULT_INJECTION */

--- a/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
@@ -2988,4 +2988,175 @@ TEST_F(NetIbMPITest, FaultInjCastOpsPostRecvErrno) {
     TeardownConnection(recvComm, listenComm, sendComm, mhandle);
 }
 
+// =============================================================================
+// Test: FaultInjCastOpsPollCqInjectCountFinite
+//
+// Ops-overload path, poll_cq REWRITE mode with a FINITE injectCount: arms a
+// bounded budget of whitelisted WR_FLUSH_ERR per QP, exercising the shim's
+// "pollInjectCount > 0 → decrement" branch (the unlimited/idle tests miss it).
+// CAST rotates QP per request as (id + qpIndex) % nqps, so Phase 1 drives
+// actualNqps+1 transfers to drain every armed QP before Phase 2 checks recovery.
+//
+// Verifies: the fault stops after the per-QP budget is spent and a follow-up
+//           transfer completes cleanly with no new fatal error.
+// Requires: WRR scheduler env vars (CAST_ENV_CHECK_OR_SKIP); arms all QPs.
+// =============================================================================
+TEST_F(NetIbMPITest, FaultInjCastOpsPollCqInjectCountFinite) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    CAST_ENV_CHECK_OR_SKIP();
+
+    const int rank = MPIEnvironment::world_rank;
+
+    net_ = &netIbCast;
+    AssertInitAndGetDevices(nullptr);
+
+    void* listenComm = nullptr;
+    void* sendComm   = nullptr;
+    void* recvComm   = nullptr;
+    SetupCastConnection(/*dev=*/0, &listenComm, &sendComm, &recvComm);
+
+    constexpr size_t kMsgSize = 1024;
+    std::vector<char> sendBuf(kMsgSize), recvBuf(kMsgSize);
+    for (size_t i = 0; i < kMsgSize; i++) sendBuf[i] = static_cast<char>(i & 0xFF);
+    memset(recvBuf.data(), 0, kMsgSize);
+
+    void* comm    = (rank == 0) ? recvComm : sendComm;
+    void* buf     = (rank == 0) ? static_cast<void*>(recvBuf.data())
+                                : static_cast<void*>(sendBuf.data());
+    void* mhandle = nullptr;
+    ASSERT_EQ(RegisterMemory(comm, buf, kMsgSize, NCCL_PTR_HOST, &mhandle), ncclSuccess);
+
+    const int actualNqps = GetActualNqps(sendComm, recvComm, buf, kMsgSize, /*tag=*/740, mhandle);
+    ASSERT_GT(actualNqps, 0);
+
+    FaultInjectResult r1 = {};
+    r1.actualNqps = actualNqps;
+    if (rank == 1) {
+        // Rewrite mode, FINITE budget per QP, whitelisted status so the connection
+        // survives and we can verify the post-budget clean path. Arm EVERY QP (not
+        // just QP 0): a small message rides a single WRR-chosen QP that may not be
+        // QP 0, so arming all QPs guarantees a real completion gets its status
+        // rewritten and the finite pollInjectCount>0 decrement branch is exercised.
+        r1.setErrRet = static_cast<int>(ncclSuccess);
+        for (int q = 0; q < actualNqps; ++q) {
+            ncclResult_t ret = ncclIbCastFaultOpsSetPollCqError(
+                sendComm, q, kWcWrFlushErr, /*injectCount=*/1, /*injectWhenIdle=*/false);
+            if (ret != ncclSuccess && r1.setErrRet == static_cast<int>(ncclSuccess))
+                r1.setErrRet = static_cast<int>(ret);
+        }
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // ---- Phase 1: drain the per-QP fault budget on EVERY QP ----
+    // CAST selects the QP per request as (req->id + qpIndex) % nqps
+    // (IbCastCommBaseGetQpForRequest in common_cast.h), so a single transfer
+    // spends only ONE QP's injectCount=1 budget. We armed every QP, so we must
+    // drive at least actualNqps sequential transfers — their rotating request
+    // ids hit each QP at least once — before the budget is fully exhausted.
+    // Driving fewer would leave some QPs armed, and Phase 2 could still land on
+    // an unspent QP and see another injected WR_FLUSH_ERR (the flakiness this
+    // structure removes). The extra round guards against a transfer that splits
+    // across two QPs and leaves one budget unspent.
+    const int drainRounds = actualNqps + 1;
+    for (int i = 0; i < drainRounds; ++i) {
+        const int tag = 741 + i;
+        if (rank == 0) {
+            void*  bufs[1]    = {buf};
+            size_t sizes[1]   = {kMsgSize};
+            int    tags[1]    = {tag};
+            void*  handles[1] = {mhandle};
+            void*  recvReq    = nullptr;
+            ASSERT_EQ(PostRecv(recvComm, 1, bufs, sizes, tags, handles, &recvReq), ncclSuccess);
+            bool done1 = false;
+            for (int poll = 0; poll < 300; poll++) {
+                int done = 0, sz = 0;
+                if (TestRequest(recvReq, &done, &sz) != ncclSuccess) break;
+                if (done) { done1 = true; break; }
+                usleep(kPollIntervalUs);
+            }
+            if (!done1) DrainRecvRequest(recvReq);
+        } else {
+            void* sendReq = nullptr;
+            ncclResult_t sendRet = ncclSuccess;
+            for (int attempt = 0; attempt < kMaxRetryAttempts; attempt++) {
+                sendRet = PostSend(sendComm, buf, kMsgSize, tag, mhandle, &sendReq);
+                if (sendRet != ncclSuccess || sendReq != nullptr) break;
+                usleep(kPollIntervalUs);
+            }
+            if (sendRet == ncclSuccess && sendReq != nullptr) {
+                for (int poll = 0; poll < 300; poll++) {
+                    int done = 0, sz = 0;
+                    if (TestRequest(sendReq, &done, &sz) != ncclSuccess) break;
+                    if (done) break;
+                    usleep(kPollIntervalUs);
+                }
+            }
+            if (sendRet != ncclSuccess && r1.sendRet == static_cast<int>(ncclSuccess))
+                r1.sendRet = static_cast<int>(sendRet);
+        }
+        MPI_Barrier(MPI_COMM_WORLD);
+    }
+
+    // ---- Phase 2: after the budget is spent, a clean transfer must pass ----
+    bool phase2RecvDone = false;
+    void* recvReq2 = nullptr;
+    int phase2Fatal = 0;
+    if (rank == 0) {
+        void*  bufs[1]    = {buf};
+        size_t sizes[1]   = {kMsgSize};
+        int    tags[1]    = {800};
+        void*  handles[1] = {mhandle};
+        ASSERT_EQ(PostRecv(recvComm, 1, bufs, sizes, tags, handles, &recvReq2), ncclSuccess);
+        for (int poll = 0; poll < 300; poll++) {
+            int done = 0, sz = 0;
+            if (TestRequest(recvReq2, &done, &sz) != ncclSuccess) break;
+            if (done) { phase2RecvDone = true; break; }
+            usleep(kPollIntervalUs);
+        }
+    } else {
+        void* sendReq = nullptr;
+        ncclResult_t sendRet = ncclSuccess;
+        for (int attempt = 0; attempt < kMaxRetryAttempts; attempt++) {
+            sendRet = PostSend(sendComm, buf, kMsgSize, 800, mhandle, &sendReq);
+            if (sendRet != ncclSuccess || sendReq != nullptr) break;
+            usleep(kPollIntervalUs);
+        }
+        if (sendRet == ncclSuccess && sendReq != nullptr) {
+            for (int poll = 0; poll < 300; poll++) {
+                int done = 0, sz = 0;
+                if (TestRequest(sendReq, &done, &sz) != ncclSuccess) break;
+                if (done) break;
+                usleep(kPollIntervalUs);
+            }
+        }
+        ncclIbCastFaultGetFatalCount(sendComm, &phase2Fatal);
+        r1.phase2FatalCount = phase2Fatal;
+        r1.clearRet = static_cast<int>(ncclIbCastFaultOpsClear(sendComm));
+        MPI_Send(&r1, sizeof(r1), MPI_BYTE, 0, kFaultResultMpiTag, MPI_COMM_WORLD);
+    }
+
+    if (rank == 0) {
+        MPI_Recv(&r1, sizeof(r1), MPI_BYTE, 1, kFaultResultMpiTag, MPI_COMM_WORLD,
+                 MPI_STATUS_IGNORE);
+        EXPECT_EQ(r1.setErrRet, static_cast<int>(ncclSuccess))
+            << "rank 1: arming finite-count poll_cq fault failed with " << r1.setErrRet;
+        // Phase 2 (after the per-QP injectCount=1 budget is spent) must be clean:
+        // the receive completes and no fatal error is recorded on the sender.
+        EXPECT_TRUE(phase2RecvDone)
+            << "phase 2 receive did not complete after the finite fault budget was spent";
+        EXPECT_EQ(r1.phase2FatalCount, 0)
+            << "phase 2 sender saw fatalCount=" << r1.phase2FatalCount
+            << " after the finite WR_FLUSH_ERR budget should have been exhausted";
+        EXPECT_EQ(r1.clearRet, static_cast<int>(ncclSuccess))
+            << "rank 1: ncclIbCastFaultOpsClear failed with " << r1.clearRet;
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    if (rank == 0 && !phase2RecvDone) DrainRecvRequest(recvReq2);
+    TeardownConnection(recvComm, listenComm, sendComm, mhandle);
+}
+
 #endif /* MPI_TESTS_ENABLED && ENABLE_FAULT_INJECTION */

--- a/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
@@ -2743,4 +2743,120 @@ TEST_F(NetIbMPITest, FaultInjCastOpsPollCqFlushNonFatal) {
     TeardownConnection(recvComm, listenComm, sendComm, mhandle);
 }
 
+// =============================================================================
+// Test: FaultInjCastOpsPollCqSynthFatal
+//
+// Ops-overload path, poll_cq SYNTHESIZE mode: on an idle CQ fabricates a
+// non-whitelisted IBV_WC_REM_ACCESS_ERR completion. Single device, so there is
+// no surviving link to fail over to.
+//
+// Verifies: isend fails OR fatalErrorCount > 0 (fatal, non-recoverable).
+// Requires: WRR scheduler env vars (CAST_ENV_CHECK_OR_SKIP); single device.
+// =============================================================================
+TEST_F(NetIbMPITest, FaultInjCastOpsPollCqSynthFatal) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    CAST_ENV_CHECK_OR_SKIP();
+
+    const int rank = MPIEnvironment::world_rank;
+
+    net_ = &netIbCast;
+    AssertInitAndGetDevices(nullptr);
+
+    void* listenComm = nullptr;
+    void* sendComm   = nullptr;
+    void* recvComm   = nullptr;
+    SetupCastConnection(/*dev=*/0, &listenComm, &sendComm, &recvComm);
+
+    constexpr size_t kMsgSize = 1024;
+    std::vector<char> sendBuf(kMsgSize), recvBuf(kMsgSize);
+    for (size_t i = 0; i < kMsgSize; i++) sendBuf[i] = static_cast<char>(i & 0xFF);
+    memset(recvBuf.data(), 0, kMsgSize);
+
+    void* comm    = (rank == 0) ? recvComm : sendComm;
+    void* buf     = (rank == 0) ? static_cast<void*>(recvBuf.data())
+                                : static_cast<void*>(sendBuf.data());
+    void* mhandle = nullptr;
+    ASSERT_EQ(RegisterMemory(comm, buf, kMsgSize, NCCL_PTR_HOST, &mhandle), ncclSuccess);
+
+    const int actualNqps = GetActualNqps(sendComm, recvComm, buf, kMsgSize, /*tag=*/720, mhandle);
+    ASSERT_GT(actualNqps, 0);
+
+    FaultInjectResult r1 = {};
+    r1.actualNqps = actualNqps;
+    if (rank == 1) {
+        // Synthesize mode: fabricate a single REM_ACCESS_ERR completion when idle.
+        ncclResult_t ret = ncclIbCastFaultOpsSetPollCqError(
+            sendComm, /*qpIdx=*/0, kWcRemAccessErr, /*injectCount=*/1, /*injectWhenIdle=*/true);
+        r1.setErrRet = static_cast<int>(ret);
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    bool recvDone = false;
+    void* recvReq = nullptr;
+
+    if (rank == 0) {
+        void*  bufs[1]    = {buf};
+        size_t sizes[1]   = {kMsgSize};
+        int    tags[1]    = {721};
+        void*  handles[1] = {mhandle};
+        ASSERT_EQ(PostRecv(recvComm, 1, bufs, sizes, tags, handles, &recvReq), ncclSuccess);
+        for (int poll = 0; poll < 100; poll++) {
+            int done = 0, sz = 0;
+            if (TestRequest(recvReq, &done, &sz) != ncclSuccess) break;
+            if (done) { recvDone = true; break; }
+            usleep(kPollIntervalUs);
+        }
+    } else {
+        void* sendReq = nullptr;
+        ncclResult_t sendRet = ncclSuccess;
+        for (int attempt = 0; attempt < kMaxRetryAttempts; attempt++) {
+            sendRet = PostSend(sendComm, buf, kMsgSize, 721, mhandle, &sendReq);
+            if (sendRet != ncclSuccess || sendReq != nullptr) break;
+            usleep(kPollIntervalUs);
+        }
+
+        int fatalCount = 0;
+        ncclIbCastFaultGetFatalCount(sendComm, &fatalCount);
+        if (sendRet == ncclSuccess && sendReq != nullptr) {
+            for (int poll = 0; poll < 300; poll++) {
+                int done = 0, sz = 0;
+                ncclResult_t testRet = TestRequest(sendReq, &done, &sz);
+                if (testRet != ncclSuccess) { sendRet = testRet; break; }
+                ncclIbCastFaultGetFatalCount(sendComm, &fatalCount);
+                if (done || fatalCount > 0) break;
+                usleep(kPollIntervalUs);
+            }
+        }
+
+        r1.sendRet   = static_cast<int>(sendRet);
+        r1.fatalCount = fatalCount;
+        r1.clearRet  = static_cast<int>(ncclIbCastFaultOpsClear(sendComm));
+        MPI_Send(&r1, sizeof(r1), MPI_BYTE, 0, kFaultResultMpiTag, MPI_COMM_WORLD);
+    }
+
+    if (rank == 0) {
+        MPI_Recv(&r1, sizeof(r1), MPI_BYTE, 1, kFaultResultMpiTag, MPI_COMM_WORLD,
+                 MPI_STATUS_IGNORE);
+
+        EXPECT_EQ(r1.setErrRet, static_cast<int>(ncclSuccess))
+            << "rank 1: ncclIbCastFaultOpsSetPollCqError failed with " << r1.setErrRet;
+        EXPECT_EQ(r1.clearRet, static_cast<int>(ncclSuccess))
+            << "rank 1: ncclIbCastFaultOpsClear failed with " << r1.clearRet;
+
+        bool isendFailed = (r1.sendRet != static_cast<int>(ncclSuccess));
+        EXPECT_TRUE(isendFailed || r1.fatalCount > 0)
+            << "rank 1: expected isend to fail OR fatalErrorCount > 0 after synthesizing a "
+            << "non-whitelisted REM_ACCESS_ERR completion; isend returned " << r1.sendRet
+            << ", fatalCount=" << r1.fatalCount;
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    if (rank == 0 && !recvDone)
+        DrainRecvRequest(recvReq);
+    TeardownConnection(recvComm, listenComm, sendComm, mhandle);
+}
+
 #endif /* MPI_TESTS_ENABLED && ENABLE_FAULT_INJECTION */

--- a/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
@@ -8,6 +8,8 @@
 #include "NetIbCastInspect.hpp"
 #include "NetIbFaultInject.hpp"
 
+#include <cerrno>  // EAGAIN
+
 #if defined(MPI_TESTS_ENABLED) && defined(ENABLE_FAULT_INJECTION)
 
 // IB WC status codes used by FailoverErrorCodeWhitelist test.
@@ -2473,6 +2475,127 @@ TEST_F(NetIbMPITest, RecoveryUdTimeoutExhaustsAttempts) {
 
     MPI_Barrier(MPI_COMM_WORLD);
     if (rank == 0 && !phase1RecvDone)
+        DrainRecvRequest(recvReq);
+    TeardownConnection(recvComm, listenComm, sendComm, mhandle);
+}
+
+// =============================================================================
+// Test: FaultInjCastOpsPostSendErrno
+//
+// Ops-overload path: arms the shimmed ibv_post_send to return EAGAIN, so the
+// fault fires at the real libibverbs boundary (unlike the pre-call intercept in
+// FaultInjCastQpErrorIsFatal).
+//
+// Verifies: isend returns an error OR fatalErrorCount > 0 when post_send fails.
+// Requires: WRR scheduler env vars (CAST_ENV_CHECK_OR_SKIP); no other setup.
+// =============================================================================
+TEST_F(NetIbMPITest, FaultInjCastOpsPostSendErrno) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    CAST_ENV_CHECK_OR_SKIP();
+
+    const int rank = MPIEnvironment::world_rank;
+
+    net_ = &netIbCast;
+    AssertInitAndGetDevices(nullptr);
+
+    void* listenComm = nullptr;
+    void* sendComm   = nullptr;
+    void* recvComm   = nullptr;
+    SetupCastConnection(/*dev=*/0, &listenComm, &sendComm, &recvComm);
+
+    constexpr size_t kMsgSize = 1024;
+    std::vector<char> sendBuf(kMsgSize), recvBuf(kMsgSize);
+    for (size_t i = 0; i < kMsgSize; i++) sendBuf[i] = static_cast<char>(i & 0xFF);
+    memset(recvBuf.data(), 0, kMsgSize);
+
+    void* comm    = (rank == 0) ? recvComm : sendComm;
+    void* buf     = (rank == 0) ? static_cast<void*>(recvBuf.data())
+                                : static_cast<void*>(sendBuf.data());
+    void* mhandle = nullptr;
+    ASSERT_EQ(RegisterMemory(comm, buf, kMsgSize, NCCL_PTR_HOST, &mhandle), ncclSuccess);
+
+    // Warmup so WRR scheduler state is initialised before arming the fault.
+    const int actualNqps = GetActualNqps(sendComm, recvComm, buf, kMsgSize, /*tag=*/700, mhandle);
+    ASSERT_GT(actualNqps, 0);
+
+    static constexpr int kEagain = EAGAIN;
+    FaultInjectResult r1 = {};
+    r1.actualNqps = actualNqps;
+    if (rank == 1) {
+        r1.setErrRet = static_cast<int>(ncclSuccess);
+        for (int q = 0; q < actualNqps; ++q) {
+            ncclResult_t ret = ncclIbCastFaultOpsSetPostSendError(sendComm, q, kEagain);
+            if (ret != ncclSuccess && r1.setErrRet == static_cast<int>(ncclSuccess))
+                r1.setErrRet = static_cast<int>(ret);
+        }
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    bool recvDone = false;
+    void* recvReq = nullptr;
+
+    if (rank == 0) {
+        void*  bufs[1]    = {buf};
+        size_t sizes[1]   = {kMsgSize};
+        int    tags[1]    = {701};
+        void*  handles[1] = {mhandle};
+        ASSERT_EQ(PostRecv(recvComm, 1, bufs, sizes, tags, handles, &recvReq), ncclSuccess);
+        for (int poll = 0; poll < 100; poll++) {
+            int done = 0, sz = 0;
+            if (TestRequest(recvReq, &done, &sz) != ncclSuccess) break;
+            if (done) { recvDone = true; break; }
+            usleep(kPollIntervalUs);
+        }
+    } else {
+        void* sendReq = nullptr;
+        ncclResult_t sendRet = ncclSuccess;
+        for (int attempt = 0; attempt < kMaxRetryAttempts; attempt++) {
+            sendRet = PostSend(sendComm, buf, kMsgSize, 701, mhandle, &sendReq);
+            if (sendRet != ncclSuccess || sendReq != nullptr) break;
+            usleep(kPollIntervalUs);
+        }
+
+        int fatalCount = 0;
+        ncclIbCastFaultGetFatalCount(sendComm, &fatalCount);
+        if (sendRet == ncclSuccess && sendReq != nullptr) {
+            for (int poll = 0; poll < 200; poll++) {
+                int done = 0, sz = 0;
+                ncclResult_t testRet = TestRequest(sendReq, &done, &sz);
+                if (testRet != ncclSuccess) { sendRet = testRet; break; }
+                ncclIbCastFaultGetFatalCount(sendComm, &fatalCount);
+                if (done || fatalCount > 0) break;
+                usleep(kPollIntervalUs);
+            }
+        }
+
+        r1.sendRet   = static_cast<int>(sendRet);
+        r1.fatalCount = fatalCount;
+        // Disarm before teardown so close paths are clean.
+        r1.clearRet  = static_cast<int>(ncclIbCastFaultOpsClear(sendComm));
+        MPI_Send(&r1, sizeof(r1), MPI_BYTE, 0, kFaultResultMpiTag, MPI_COMM_WORLD);
+    }
+
+    if (rank == 0) {
+        MPI_Recv(&r1, sizeof(r1), MPI_BYTE, 1, kFaultResultMpiTag, MPI_COMM_WORLD,
+                 MPI_STATUS_IGNORE);
+
+        EXPECT_EQ(r1.setErrRet, static_cast<int>(ncclSuccess))
+            << "rank 1: ncclIbCastFaultOpsSetPostSendError failed with " << r1.setErrRet;
+        EXPECT_EQ(r1.clearRet, static_cast<int>(ncclSuccess))
+            << "rank 1: ncclIbCastFaultOpsClear failed with " << r1.clearRet;
+
+        bool isendFailed = (r1.sendRet != static_cast<int>(ncclSuccess));
+        EXPECT_TRUE(isendFailed || r1.fatalCount > 0)
+            << "rank 1: expected isend to fail OR fatalErrorCount > 0 after arming all "
+            << r1.actualNqps << " CAST QPs with ops-level post_send EAGAIN; "
+            << "isend returned " << r1.sendRet << ", fatalCount=" << r1.fatalCount;
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    if (rank == 0 && !recvDone)
         DrainRecvRequest(recvReq);
     TeardownConnection(recvComm, listenComm, sendComm, mhandle);
 }

--- a/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
+++ b/projects/rccl/test/transport/NetIbMPI/FaultInjectTests.cpp
@@ -3159,4 +3159,69 @@ TEST_F(NetIbMPITest, FaultInjCastOpsPollCqInjectCountFinite) {
     TeardownConnection(recvComm, listenComm, sendComm, mhandle);
 }
 
+// =============================================================================
+// Test: FaultInjCastOpsApiInvalidArgs
+//
+// Unit-style coverage of the ops-fault API guard branches: NULL comm and the
+// install/registration lookups that the functional tests never hit (they always
+// pass a live, shimmed connection). Calls each API with NULL, then re-arms/clears
+// on a live connection to confirm the success guards.
+//
+// Verifies: each API returns ncclInvalidArgument on NULL comm and ncclSuccess
+//           on a live connection.
+// Requires: WRR scheduler env vars (CAST_ENV_CHECK_OR_SKIP); no data transfer.
+// =============================================================================
+TEST_F(NetIbMPITest, FaultInjCastOpsApiInvalidArgs) {
+    ASSERT_TRUE(validateTestPrerequisites(kExactTwoProcesses, kExactTwoProcesses,
+                                         false, kMinGpusPerNode, kNoNodeLimit))
+        << "Test requires exactly " << kExactTwoProcesses << " processes";
+
+    CAST_ENV_CHECK_OR_SKIP();
+
+    static constexpr int kEagain = EAGAIN;
+
+    // ---- NULL comm: every Ops API must reject with ncclInvalidArgument ----
+    EXPECT_EQ(ncclIbCastFaultOpsSetPostSendError(nullptr, 0, kEagain), ncclInvalidArgument);
+    EXPECT_EQ(ncclIbCastFaultOpsSetPostRecvError(nullptr, 0, kEagain), ncclInvalidArgument);
+    EXPECT_EQ(ncclIbCastFaultOpsSetPollCqError(nullptr, 0, kWcWrFlushErr, -1, false),
+              ncclInvalidArgument);
+    EXPECT_EQ(ncclIbCastFaultOpsClear(nullptr), ncclInvalidArgument);
+
+    // ---- Live connection: success guards (registered context) ----
+    net_ = &netIbCast;
+    AssertInitAndGetDevices(nullptr);
+
+    void* listenComm = nullptr;
+    void* sendComm   = nullptr;
+    void* recvComm   = nullptr;
+    SetupCastConnection(/*dev=*/0, &listenComm, &sendComm, &recvComm);
+
+    constexpr size_t kMsgSize = 1024;
+    std::vector<char> buf(kMsgSize, 0);
+    void* comm    = (MPIEnvironment::world_rank == 0) ? recvComm : sendComm;
+    void* mhandle = nullptr;
+    ASSERT_EQ(RegisterMemory(comm, buf.data(), kMsgSize, NCCL_PTR_HOST, &mhandle), ncclSuccess);
+
+    // Establish QPs so the context is shimmed/registered.
+    const int actualNqps = GetActualNqps(sendComm, recvComm, buf.data(), kMsgSize,
+                                         /*tag=*/750, mhandle);
+    ASSERT_GT(actualNqps, 0);
+
+    if (MPIEnvironment::world_rank == 1) {
+        // Arm then clear on a registered context: both must succeed.
+        EXPECT_EQ(ncclIbCastFaultOpsSetPostSendError(sendComm, 0, kEagain), ncclSuccess);
+        EXPECT_EQ(ncclIbCastFaultOpsSetPollCqError(sendComm, 0, kWcWrFlushErr, 1, false),
+                  ncclSuccess);
+        EXPECT_EQ(ncclIbCastFaultOpsClear(sendComm), ncclSuccess);
+        // Clear again (already cleared) must still succeed (idempotent).
+        EXPECT_EQ(ncclIbCastFaultOpsClear(sendComm), ncclSuccess);
+    } else {
+        EXPECT_EQ(ncclIbCastFaultOpsSetPostRecvError(recvComm, 0, kEagain), ncclSuccess);
+        EXPECT_EQ(ncclIbCastFaultOpsClear(recvComm), ncclSuccess);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    TeardownConnection(recvComm, listenComm, sendComm, mhandle);
+}
+
 #endif /* MPI_TESTS_ENABLED && ENABLE_FAULT_INJECTION */

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -1068,6 +1068,11 @@
           "name": "FaultInj_Cast_OpsPollCqSynthFatal",
           "description": "CAST ops-overload: poll_cq shim synthesizes a non-whitelisted REM_ACCESS_ERR completion; fatal/non-recoverable",
           "test_filter": "NetIbMPITest.FaultInjCastOpsPollCqSynthFatal"
+        },
+        {
+          "name": "FaultInj_Cast_OpsPostRecvErrno",
+          "description": "CAST ops-overload: real ibv_post_recv forced to return EAGAIN via shimmed ops table on all receiver QPs; recv errors or never completes",
+          "test_filter": "NetIbMPITest.FaultInjCastOpsPostRecvErrno"
         }
       ]
     },

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -1073,6 +1073,11 @@
           "name": "FaultInj_Cast_OpsPostRecvErrno",
           "description": "CAST ops-overload: real ibv_post_recv forced to return EAGAIN via shimmed ops table on all receiver QPs; recv errors or never completes",
           "test_filter": "NetIbMPITest.FaultInjCastOpsPostRecvErrno"
+        },
+        {
+          "name": "FaultInj_Cast_OpsPollCqInjectCountFinite",
+          "description": "CAST ops-overload: poll_cq rewrite with finite injectCount=1 per QP (WR_FLUSH_ERR); fault fires then stops, post-budget transfer is clean",
+          "test_filter": "NetIbMPITest.FaultInjCastOpsPollCqInjectCountFinite"
         }
       ]
     },

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -1063,6 +1063,11 @@
             "NCCL_IB_RESILIENCY_PORT_FAILOVER": "1",
             "NCCL_IB_MERGE_NICS": "1"
           }
+        },
+        {
+          "name": "FaultInj_Cast_OpsPollCqSynthFatal",
+          "description": "CAST ops-overload: poll_cq shim synthesizes a non-whitelisted REM_ACCESS_ERR completion; fatal/non-recoverable",
+          "test_filter": "NetIbMPITest.FaultInjCastOpsPollCqSynthFatal"
         }
       ]
     },

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -1054,6 +1054,15 @@
           "name": "FaultInj_Cast_OpsPostSendErrno",
           "description": "CAST ops-overload: real ibv_post_send forced to return EAGAIN via shimmed ops table; isend fails or fatalCount > 0",
           "test_filter": "NetIbMPITest.FaultInjCastOpsPostSendErrno"
+        },
+        {
+          "name": "FaultInj_Cast_OpsPollCqFlushNonFatal",
+          "description": "CAST ops-overload: poll_cq shim rewrites QP 0 completion status to WR_FLUSH_ERR; failover completes via surviving device, fatalCount==0",
+          "test_filter": "NetIbMPITest.FaultInjCastOpsPollCqFlushNonFatal",
+          "env_variables": {
+            "NCCL_IB_RESILIENCY_PORT_FAILOVER": "1",
+            "NCCL_IB_MERGE_NICS": "1"
+          }
         }
       ]
     },

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -1049,6 +1049,11 @@
           "name": "FaultInj_Cast_QpErrorClearRecovers",
           "description": "CAST path: after FaultClear on a faulted connection, a fresh connection completes 20 sends with no corruption and fatalCount==0",
           "test_filter": "NetIbMPITest.FaultInjCastQpErrorClearRecovers"
+        },
+        {
+          "name": "FaultInj_Cast_OpsPostSendErrno",
+          "description": "CAST ops-overload: real ibv_post_send forced to return EAGAIN via shimmed ops table; isend fails or fatalCount > 0",
+          "test_filter": "NetIbMPITest.FaultInjCastOpsPostSendErrno"
         }
       ]
     },

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -1078,6 +1078,11 @@
           "name": "FaultInj_Cast_OpsPollCqInjectCountFinite",
           "description": "CAST ops-overload: poll_cq rewrite with finite injectCount=1 per QP (WR_FLUSH_ERR); fault fires then stops, post-budget transfer is clean",
           "test_filter": "NetIbMPITest.FaultInjCastOpsPollCqInjectCountFinite"
+        },
+        {
+          "name": "FaultInj_Cast_OpsApiInvalidArgs",
+          "description": "CAST ops-overload: API guard branches - NULL comm returns ncclInvalidArgument; arm/clear on a registered context succeeds",
+          "test_filter": "NetIbMPITest.FaultInjCastOpsApiInvalidArgs"
         }
       ]
     },


### PR DESCRIPTION
## Motivation

The net-ib CAST transport has a multi-QP resiliency layer (fatal/recoverable
error classification, QP failover, WRR rebalancing) whose error paths are hard
to reach with healthy hardware. This PR adds a test-only fault injection
mechanism that triggers those paths deterministically at the real libibverbs
call boundary, plus the unit tests that exercise it. All code is gated behind
`ENABLE_FAULT_INJECTION` — zero cost in production builds.

## Technical Details

- New `net_ib_ops_fault.{cc,h}`: after `wrap_ibv_open_device`, the
`ibv_context` ops table (`post_send`/`post_recv`/`poll_cq`) is shimmed via a
per-context registry that holds the saved real ops plus per-`qp_num` fault
config. Faults fire on the real verbs call, not by bypassing it.
- `post_send` / `post_recv`: return an injected errno (e.g. EAGAIN).
- `poll_cq`: rewrite a real completion's status, or synthesize an error WC
  when the CQ is idle; finite or unlimited injection budget. The synthesized
  idle WC carries `wr_id` sentinel `0xF00000`, which sits outside both the
  receiver recv-slot range `[0, 256]` and the flush range `[0x1000, +256)`,
  so the receiver resiliency path rejects it cleanly (existing
  "invalid wr_id" WARN) instead of dereferencing `recvReqs[0]`. The low byte
  stays `0`, so the null-checked sender-side slot decode (`wr_id & 0xff`) is
  unchanged.
- `ibvwrap.cc` installs the shims after open and restores them before close.
- `p2p.cc` exposes the public `ncclIbCastFaultOps*` API, bridging a comm to its
`(ctx, qp_num)` via `activeQps`; declared in `net_ib_fault_inject.h`.
- Six MPI unit tests in `FaultInjectTests.cpp` (one per commit) cover
post_send / post_recv errno, poll_cq rewrite (non-fatal failover) /
synthesize (fatal) / finite budget, and the API guard branches; registered in
the `fault_inject_cast` runner suite.

## JIRA ID

AICOMNET-216

## Test Plan

All six tests verified on a 2-node MPI run (Debug + `FAULT_INJECTION`); all pass.

| Test | Injected fault | Expected behavior |
|------|----------------|-------------------|
| `FaultInjCastOpsPostSendErrno` | `ibv_post_send` returns EAGAIN on all QPs | send fails or `fatalCount>0` |
| `FaultInjCastOpsPostRecvErrno` | `ibv_post_recv` returns EAGAIN on all recv QPs | recv errors or never completes |
| `FaultInjCastOpsPollCqFlushNonFatal` | `poll_cq` rewrites WC to `WR_FLUSH_ERR` (whitelisted) | fails over to surviving device, `fatalCount==0`, data intact |
| `FaultInjCastOpsPollCqSynthFatal` | `poll_cq` synthesizes `REM_ACCESS_ERR`, single device | fatal: send errors or `fatalCount>0` |
| `FaultInjCastOpsPollCqInjectCountFinite` | `poll_cq` rewrite with finite per-QP budget; Phase 1 drains every armed QP (CAST rotates QP per request as `(id + qpIndex) % nqps`) | fault
stops after budget, next transfer clean |
| `FaultInjCastOpsApiInvalidArgs` | NULL comm / live comm to fault API | NULL → `ncclInvalidArgument`; live → `ncclSuccess` |

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.