### PR TITLE
[rocjitsu] Replace hipcc with amdclang++ for HIP test builds

### DIFF
--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -457,20 +457,13 @@ else()
     message(STATUS "HSA init test disabled (libhsa-runtime64 not found)")
 endif()
 
-# --- HIP tests (requires hipcc + CLI launcher) ---
+# --- HIP tests (requires amdclang++ + CLI launcher) ---
 
-find_program(
-    HIPCC_EXECUTABLE
-    hipcc
-    PATHS /opt/rocm/bin
-    ENV ROCM_PATH
-    PATH_SUFFIXES bin
-)
-if(HIPCC_EXECUTABLE AND HSA_RUNTIME64)
+if(AMDCLANG AND HSA_RUNTIME64)
     set(GTEST_INC ${googletest_SOURCE_DIR}/googletest/include)
     set(GTEST_LIB_DIR ${CMAKE_BINARY_DIR}/lib)
 
-    # Helper: build a HIP test binary with hipcc + gtest.
+    # Helper: build a HIP test binary with amdclang++ + gtest.
     function(rj_add_hip_test TEST_NAME)
         cmake_parse_arguments(ARG "" "ARCH;SOURCE" "EXTRA_LIBS" ${ARGN})
         if(NOT ARG_ARCH)
@@ -485,12 +478,13 @@ if(HIPCC_EXECUTABLE AND HSA_RUNTIME64)
         add_custom_command(
             OUTPUT ${HIP_TEST_BIN}
             COMMAND
-                ${HIPCC_EXECUTABLE} --offload-arch=${ARG_ARCH} -std=c++20
-                -isystem ${GTEST_INC} -I${CMAKE_CURRENT_SOURCE_DIR}
+                ${AMDCLANG} --offload-arch=${ARG_ARCH} --rocm-path=${ROCM_PATH}
+                -std=c++20 -O2 -isystem ${GTEST_INC}
+                -I${CMAKE_CURRENT_SOURCE_DIR} -x hip ${HIP_TEST_SRC} -x none
                 -L${GTEST_LIB_DIR} -lgtest -lpthread ${ARG_EXTRA_LIBS}
-                -Wl,-rpath,${GTEST_LIB_DIR} -o ${HIP_TEST_BIN} ${HIP_TEST_SRC}
+                -Wl,-rpath,${GTEST_LIB_DIR} -o ${HIP_TEST_BIN}
             DEPENDS ${HIP_TEST_SRC} GTest::gtest GTest::gtest_main
-            COMMENT "Building ${TEST_NAME} with hipcc (${ARG_ARCH})"
+            COMMENT "Building ${TEST_NAME} with amdclang++ (${ARG_ARCH})"
             VERBATIM
         )
         add_custom_target(${TEST_NAME}_target ALL DEPENDS ${HIP_TEST_BIN})
@@ -651,7 +645,10 @@ if(HIPCC_EXECUTABLE AND HSA_RUNTIME64)
     rj_add_hip_test(hip_bfe_2d_test)
     rj_add_hip_test_case(hip_bfe_2d_test "BfeRegressionTest.ThreadIdxY")
 
-    message(STATUS "HIP tests enabled (found ${HIPCC_EXECUTABLE})")
+    message(STATUS "HIP tests enabled (found ${AMDCLANG})")
 else()
-    message(STATUS "HIP tests disabled (hipcc or libhsa-runtime64 not found)")
+    message(
+        STATUS
+        "HIP tests disabled (amdclang++ or libhsa-runtime64 not found)"
+    )
 endif()

--- a/emulation/rocjitsu/tests/kernels/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/kernels/CMakeLists.txt
@@ -117,3 +117,5 @@ add_custom_target(
 # Export variables to the parent scope so the test executable can use them.
 set(HAS_DEVICE_KERNELS TRUE PARENT_SCOPE)
 set(KERNEL_OUTPUT_DIR ${KERNEL_OUTPUT_DIR} PARENT_SCOPE)
+set(AMDCLANG ${AMDCLANG} PARENT_SCOPE)
+set(ROCM_PATH ${ROCM_PATH} PARENT_SCOPE)


### PR DESCRIPTION
## Summary

- Replace `hipcc` with direct `amdclang++` invocations for all HIP test
  binaries, using `-x hip` and `--rocm-path` explicitly
- Add `-O2` optimization flag — hipcc left this implicit (clang default
  is `-O0`)
- Export `AMDCLANG` and `ROCM_PATH` from `tests/kernels/CMakeLists.txt`
  so the HIP test section can reuse the same compiler discovery

## Why

`hipcc` is a wrapper around `amdclang++` that adds implicit flags. Using
`amdclang++` directly makes the compilation transparent and consistent
with device kernel compilation (which already uses `amdclang++`).

## -O0 vs -O2

With `-O0`, 3 HIP tests fail:

| Test | Result |
|------|--------|
| `HipVectorAddTest.CorrectResult` | 1015/1024 elements wrong |
| `BfeRegressionTest.ThreadIdxY` | Segfault |
| `DaemonTest.HipVectorAdd` | Failed (wraps vector add) |

With `-O2`, all HIP tests pass. Tracking: https://github.com/ROCm/rocm-systems/issues/6951

## Test plan
All tests pass
