### PR TITLE
[ci] Adding `test_type` during CI updates

### DIFF
--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -20,13 +20,17 @@ from therock_matrix import (
     windows_only_subtrees,
 )
 import time
-from typing import Mapping, Optional, Iterable
+from typing import Mapping, Optional, Iterable, List
 import os
 
 # Add TheRock's github_actions to path for shared utilities
 THEROCK_ACTIONS_PATH = Path("TheRock") / "build_tools" / "github_actions"
 sys.path.insert(0, str(THEROCK_ACTIONS_PATH))
 from amdgpu_family_matrix import get_build_runner_labels, select_weighted_label
+
+# Valid test types in order of comprehensiveness (least to most)
+VALID_TEST_TYPES = ["quick", "standard", "comprehensive", "full"]
+TEST_TYPE_PRIORITY = {t: i for i, t in enumerate(VALID_TEST_TYPES)}
 
 logging.basicConfig(level=logging.INFO)
 
@@ -99,6 +103,44 @@ def check_for_workflow_file_related_to_ci(paths: Optional[Iterable[str]]) -> boo
     if paths is None:
         return False
     return any(is_path_workflow_file_related_to_ci(p) for p in paths)
+
+
+def get_pr_labels(args) -> List[str]:
+    """Gets a list of labels applied to a pull request."""
+    data = json.loads(args.get("pr_labels", "{}"))
+    labels = []
+    for label in data.get("labels", []):
+        labels.append(label["name"])
+    return labels
+
+
+def parse_test_type_from_labels(pr_labels: List[str]) -> Optional[str]:
+    """
+    Parse PR labels to extract test type.
+
+    Looks for labels like 'test_type:quick', 'test_type:comprehensive'.
+    If multiple test_type labels exist, the most comprehensive one takes precedence.
+
+    Returns:
+        The test type string if found, None otherwise.
+    """
+    test_type = None
+
+    for label in pr_labels:
+        if label.startswith("test_type:"):
+            label_test_type = label.split("test_type:")[-1]
+            if label_test_type in VALID_TEST_TYPES:
+                # If multiple test_type labels, use the most comprehensive one
+                if (
+                    test_type is None
+                    or TEST_TYPE_PRIORITY[label_test_type]
+                    > TEST_TYPE_PRIORITY[test_type]
+                ):
+                    test_type = label_test_type
+            else:
+                logging.warning(f"Unknown test type in label: {label}")
+
+    return test_type
 
 
 def check_trigger_windows_ci_for_subtree_path(path):
@@ -233,6 +275,12 @@ def check_only_rccl_changes(modified_paths: Iterable[str]) -> bool:
 
 
 def retrieve_projects(args):
+    # Default test type is "standard" for normal CI runs
+    test_type = "standard"
+
+    # Variables to track if labels override defaults
+    label_test_type = None
+
     # Nightly (schedule): use same test coverage as TheRock submodule bump PRs —
     # single nightly job with THEROCK_ENABLE_ALL=ON and full projects_to_test list.
     # Run all builds and tests including RCCL.
@@ -242,14 +290,16 @@ def retrieve_projects(args):
             logging.warning(
                 "No 'nightly' entry in project_map, nightly will have no jobs"
             )
-            return []
+            return [], "comprehensive"
+        # Nightly runs use comprehensive testing
+        test_type = "comprehensive"
         # Run full coverage on both Linux and Windows (no path-based skip).
         return [
             {
                 "cmake_options": nightly_config.get("cmake_options", ""),
                 "projects_to_test": nightly_config.get("projects_to_test", ""),
             }
-        ]
+        ], test_type
 
     # Check if CI should be skipped based on modified paths
     # (only for push and pull_request events, not workflow_dispatch or nightly)
@@ -257,20 +307,31 @@ def retrieve_projects(args):
     modified_paths = get_modified_paths(base_ref)
     print("modified_paths (max 200):", modified_paths[:200])
 
+    # Parse PR labels for test_type override
+    if args.get("is_pull_request"):
+        pr_labels = get_pr_labels(args)
+        label_test_type = parse_test_type_from_labels(pr_labels)
+        if label_test_type:
+            test_type = label_test_type
+            logging.info(f"Test type overridden by label: {test_type}")
+
     # If only skippable paths were modified, skip CI
     if args.get("is_push") or args.get("is_pull_request"):
         if not check_for_non_skippable_path(modified_paths):
             logging.info("Only skippable paths were modified, skipping CI")
-            return []
+            return [], test_type
 
     # Push event → check which subtrees were modified
     if args.get("is_push"):
         matched_subtrees = {get_matched_subtree(p) for p in modified_paths} - {None}
 
-        # Change in CI workflow triggers full subtree evaluation
+        # Change in CI workflow triggers full subtree evaluation with quick tests
         if check_for_workflow_file_related_to_ci(modified_paths):
-            logging.info("CI workflow files changed, evaluating all subtrees")
+            logging.info("CI workflow files changed, evaluating all subtrees with quick tests")
             subtrees = list(subtree_to_project_map.keys())
+            # Use quick tests for CI workflow changes unless overridden by label
+            if not label_test_type:
+                test_type = "quick"
         elif matched_subtrees:
             # Known subtrees changed - run CI for those subtrees
             subtrees = list(matched_subtrees)
@@ -302,10 +363,13 @@ def retrieve_projects(args):
                 if path.startswith(subtree + "/") or path == subtree:
                     matched_subtrees.add(subtree)
 
-        # Change in CI workflow triggers full subtree evaluation
+        # Change in CI workflow triggers full subtree evaluation with quick tests
         if check_for_workflow_file_related_to_ci(modified_paths):
-            logging.info("CI workflow files changed, evaluating all subtrees")
+            logging.info("CI workflow files changed, evaluating all subtrees with quick tests")
             subtrees = list(subtree_to_project_map.keys())
+            # Use quick tests for CI workflow changes unless overridden by label
+            if not label_test_type:
+                test_type = "quick"
 
         # Pull request
         elif args.get("is_pull_request"):
@@ -347,12 +411,12 @@ def retrieve_projects(args):
         if args.get("is_workflow_dispatch"):
             if not any(check_trigger_windows_ci_for_subtree(s) for s in subtrees):
                 logging.info("Selected subtrees do not require Windows CI, skipping")
-                return []
+                return [], test_type
         elif not any(
             check_trigger_windows_ci_for_subtree_path(path) for path in modified_paths
         ):
             logging.info("Modified paths do not require Windows CI, skipping")
-            return []
+            return [], test_type
     # Determine logical projects impacted
     projects = {
         subtree_to_project_map[subtree]
@@ -361,7 +425,7 @@ def retrieve_projects(args):
     }
 
     if not projects:
-        return []
+        return [], test_type
 
     merged_flags = set()
     merged_tests = set()
@@ -400,7 +464,7 @@ def retrieve_projects(args):
             "cmake_options": final_flags,
             "projects_to_test": ", ".join(sorted(merged_tests)),
         }
-    ]
+    ], test_type
 
 
 def select_build_runner(platform: str) -> str:
@@ -421,9 +485,13 @@ def select_build_runner(platform: str) -> str:
 
 def run(args):
     platform = args.get("platform")
-    project_to_run = retrieve_projects(args)
+    project_to_run, test_type = retrieve_projects(args)
     build_runs_on = select_build_runner(platform)
-    outputs = {"projects": json.dumps(project_to_run), "build_runs_on": build_runs_on}
+    outputs = {
+        "projects": json.dumps(project_to_run),
+        "build_runs_on": build_runs_on,
+        "test_type": test_type,
+    }
 
     # Determine if RCCL CI should run (only relevant for Linux platform)
     if args.get("platform") == "linux":
@@ -486,6 +554,9 @@ if __name__ == "__main__":
     args["platform"] = input_platform
 
     args["base_ref"] = os.environ.get("BASE_REF", "HEAD^")
+
+    # PR labels for test_type override
+    args["pr_labels"] = os.environ.get("PR_LABELS", '{"labels": []}')
 
     logging.info(f"Retrieved arguments {args}")
 

--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -20,7 +20,7 @@ from therock_matrix import (
     windows_only_subtrees,
 )
 import time
-from typing import Mapping, Optional, Iterable, List
+from typing import Mapping, Optional, Iterable
 import os
 
 # Add TheRock's github_actions to path for shared utilities
@@ -30,7 +30,6 @@ from amdgpu_family_matrix import get_build_runner_labels, select_weighted_label
 
 # Valid test types in order of comprehensiveness (least to most)
 VALID_TEST_TYPES = ["quick", "standard", "comprehensive", "full"]
-TEST_TYPE_PRIORITY = {t: i for i, t in enumerate(VALID_TEST_TYPES)}
 
 logging.basicConfig(level=logging.INFO)
 
@@ -103,44 +102,6 @@ def check_for_workflow_file_related_to_ci(paths: Optional[Iterable[str]]) -> boo
     if paths is None:
         return False
     return any(is_path_workflow_file_related_to_ci(p) for p in paths)
-
-
-def get_pr_labels(args) -> List[str]:
-    """Gets a list of labels applied to a pull request."""
-    data = json.loads(args.get("pr_labels", "{}"))
-    labels = []
-    for label in data.get("labels", []):
-        labels.append(label["name"])
-    return labels
-
-
-def parse_test_type_from_labels(pr_labels: List[str]) -> Optional[str]:
-    """
-    Parse PR labels to extract test type.
-
-    Looks for labels like 'test_type:quick', 'test_type:comprehensive'.
-    If multiple test_type labels exist, the most comprehensive one takes precedence.
-
-    Returns:
-        The test type string if found, None otherwise.
-    """
-    test_type = None
-
-    for label in pr_labels:
-        if label.startswith("test_type:"):
-            label_test_type = label.split("test_type:")[-1]
-            if label_test_type in VALID_TEST_TYPES:
-                # If multiple test_type labels, use the most comprehensive one
-                if (
-                    test_type is None
-                    or TEST_TYPE_PRIORITY[label_test_type]
-                    > TEST_TYPE_PRIORITY[test_type]
-                ):
-                    test_type = label_test_type
-            else:
-                logging.warning(f"Unknown test type in label: {label}")
-
-    return test_type
 
 
 def check_trigger_windows_ci_for_subtree_path(path):
@@ -278,9 +239,6 @@ def retrieve_projects(args):
     # Default test type is "standard" for normal CI runs
     test_type = "standard"
 
-    # Variables to track if labels override defaults
-    label_test_type = None
-
     # Nightly (schedule): use same test coverage as TheRock submodule bump PRs —
     # single nightly job with THEROCK_ENABLE_ALL=ON and full projects_to_test list.
     # Run all builds and tests including RCCL.
@@ -307,14 +265,6 @@ def retrieve_projects(args):
     modified_paths = get_modified_paths(base_ref)
     print("modified_paths (max 200):", modified_paths[:200])
 
-    # Parse PR labels for test_type override
-    if args.get("is_pull_request"):
-        pr_labels = get_pr_labels(args)
-        label_test_type = parse_test_type_from_labels(pr_labels)
-        if label_test_type:
-            test_type = label_test_type
-            logging.info(f"Test type overridden by label: {test_type}")
-
     # If only skippable paths were modified, skip CI
     if args.get("is_push") or args.get("is_pull_request"):
         if not check_for_non_skippable_path(modified_paths):
@@ -329,9 +279,7 @@ def retrieve_projects(args):
         if check_for_workflow_file_related_to_ci(modified_paths):
             logging.info("CI workflow files changed, evaluating all subtrees with quick tests")
             subtrees = list(subtree_to_project_map.keys())
-            # Use quick tests for CI workflow changes unless overridden by label
-            if not label_test_type:
-                test_type = "quick"
+            test_type = "quick"
         elif matched_subtrees:
             # Known subtrees changed - run CI for those subtrees
             subtrees = list(matched_subtrees)
@@ -367,9 +315,7 @@ def retrieve_projects(args):
         if check_for_workflow_file_related_to_ci(modified_paths):
             logging.info("CI workflow files changed, evaluating all subtrees with quick tests")
             subtrees = list(subtree_to_project_map.keys())
-            # Use quick tests for CI workflow changes unless overridden by label
-            if not label_test_type:
-                test_type = "quick"
+            test_type = "quick"
 
         # Pull request
         elif args.get("is_pull_request"):
@@ -554,9 +500,6 @@ if __name__ == "__main__":
     args["platform"] = input_platform
 
     args["base_ref"] = os.environ.get("BASE_REF", "HEAD^")
-
-    # PR labels for test_type override
-    args["pr_labels"] = os.environ.get("PR_LABELS", '{"labels": []}')
 
     logging.info(f"Retrieved arguments {args}")
 

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -7,6 +7,9 @@ on:
         type: string
       projects_to_test:
         type: string
+      test_type:
+        type: string
+        default: "standard"
       package_version:
         type: string
         required: true
@@ -144,6 +147,7 @@ jobs:
     uses: ./.github/workflows/therock-test-packages.yml
     with:
       projects_to_test: ${{ inputs.projects_to_test }}
+      test_type: ${{ inputs.test_type }}
       amdgpu_families: ${{ inputs.amdgpu_families }}
       test_runs_on: ${{ inputs.test_runs_on }}
       platform: "linux"

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -7,6 +7,9 @@ on:
         type: string
       projects_to_test:
         type: string
+      test_type:
+        type: string
+        default: "standard"
       package_version:
         type: string
         required: true
@@ -165,6 +168,7 @@ jobs:
     uses: ./.github/workflows/therock-test-packages.yml
     with:
       projects_to_test: ${{ inputs.projects_to_test }}
+      test_type: ${{ inputs.test_type }}
       amdgpu_families: ${{ inputs.amdgpu_families }}
       test_runs_on: ${{ inputs.test_runs_on }}
       platform: "windows"

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -10,8 +10,6 @@ on:
       - opened
       - synchronize
       - reopened
-      - labeled
-      - unlabeled
   workflow_dispatch:
     inputs:
       projects:
@@ -99,14 +97,6 @@ jobs:
             --repo "${{ github.repository }}" \
             --pr "${{ github.event.pull_request.number }}" \
             --config ".github/repos-config.json"
-
-      - name: Set PR_LABELS variable with labels assigned to pull request
-        if: ${{ github.event.pull_request }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.number }}
-        run: |
-          echo "PR_LABELS=$(gh pr view ${PR_NUMBER} --json labels)" >> $GITHUB_ENV
 
       - name: Determine Linux projects to run
         id: linux_projects

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -10,6 +10,8 @@ on:
       - opened
       - synchronize
       - reopened
+      - labeled
+      - unlabeled
   workflow_dispatch:
     inputs:
       projects:
@@ -48,6 +50,7 @@ jobs:
       windows_projects: ${{ steps.windows_projects.outputs.projects }}
       run_linux_rccl_ci: ${{ steps.linux_projects.outputs.run_linux_rccl_ci }}
       run_mi455_test: ${{ steps.linux_projects.outputs.run_mi455_test }}
+      test_type: ${{ steps.linux_projects.outputs.test_type }}
       package_version: ${{ steps.rocm_package_version.outputs.rocm_package_version }}
       linux_package_targets: ${{ steps.configure_linux.outputs.package_targets }}
       windows_package_targets: ${{ steps.configure_windows.outputs.package_targets }}
@@ -96,6 +99,14 @@ jobs:
             --repo "${{ github.repository }}" \
             --pr "${{ github.event.pull_request.number }}" \
             --config ".github/repos-config.json"
+
+      - name: Set PR_LABELS variable with labels assigned to pull request
+        if: ${{ github.event.pull_request }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          echo "PR_LABELS=$(gh pr view ${PR_NUMBER} --json labels)" >> $GITHUB_ENV
 
       - name: Determine Linux projects to run
         id: linux_projects
@@ -153,6 +164,7 @@ jobs:
     with:
       cmake_options: ${{ matrix.projects.cmake_options }}
       projects_to_test: ${{ matrix.projects.projects_to_test }}
+      test_type: ${{ needs.setup.outputs.test_type }}
       package_version: ${{ needs.setup.outputs.package_version }}
       amdgpu_families: ${{ matrix.target_bundle.amdgpu_family }}
       test_runs_on: ${{ matrix.target_bundle.test_machine }}
@@ -203,6 +215,7 @@ jobs:
     with:
       cmake_options: ${{ matrix.projects.cmake_options }}
       projects_to_test: ${{ matrix.projects.projects_to_test }}
+      test_type: ${{ needs.setup.outputs.test_type }}
       package_version: ${{ needs.setup.outputs.package_version }}
       amdgpu_families: ${{ matrix.target_bundle.amdgpu_family }}
       test_runs_on: ${{ matrix.target_bundle.test_machine }}

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -5,6 +5,9 @@ on:
     inputs:
       projects_to_test:
         type: string
+      test_type:
+        type: string
+        default: "standard"
       amdgpu_families:
         type: string
       test_runs_on:


### PR DESCRIPTION
In order for hip-tests to be impact on windows strix halos, we are bumping CI hash and including test_types for CI updates