### PR TITLE
[rocjitsu] Experiment: intentional build error

### DIFF
--- a/emulation/rocjitsu/lib/util/include/util/log.h
+++ b/emulation/rocjitsu/lib/util/include/util/log.h
@@ -6,7 +6,7 @@
 
 #include <concepts>
 #include <format>
-#include <iostream>
+#include <iostreammm>
 #include <mutex>
 #include <ostream>
 #include <sstream>


### PR DESCRIPTION
## Summary

Intentional build error to test CI behavior — introduces a typo in `#include <iostreammm>` in `util/log.h`.

**Do not merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)