### PR TITLE
feat(rocjitsu): add functional CU dispatch pool

### DIFF
--- a/emulation/rocjitsu/docs/vm-design.md
+++ b/emulation/rocjitsu/docs/vm-design.md
@@ -225,19 +225,41 @@ order. `dispatch_wf()`
 self-schedules the CU's tick via `schedule_work()`; there is no separate
 `activate()` call.
 
-Each CU runs its dispatched wavefronts independently. The CU is
-self-driving: `dispatch_wf()` calls `schedule_work()`, which schedules a
-tick event (only when the CU has runnable wavefronts) that calls
-`execute_quantum()`. A quantum executes up to `kFunctionalQuantum`
-instructions, but may yield early when a wavefront requests it (e.g.
-`s_sleep`, a vendor-dependency retry). The tick reschedules itself at
-`now + max(1, last_quantum_executed_)` — i.e. by the work actually
-executed, so an early yield resumes promptly instead of leaping a full
-quantum, while `max(1, ...)` keeps the event strictly in the future.
-Since functional mode is 1 CPI, ticks advance proportionally to
-instruction count. The quantum allows CU events to interleave,
-guaranteeing forward progress for inter-CU synchronization patterns such
-as spin-locks or semaphore acquire/release on global memory.
+Each CU runs its dispatched wavefronts independently. With serial CU dispatch,
+the CU is self-driving: `dispatch_wf()` calls `schedule_work()`, which schedules
+a tick event (only when the CU has runnable wavefronts) that calls
+`execute_quantum()`. With pooled functional dispatch, the CP owns the
+continuation event, gathers its runnable CUs, and submits one `run_quantum()`
+task per CU to the SoC's shared host pool. Pool workers mutate only their
+assigned CU state; the CP waits for the batch and then performs queue
+advancement, completion publication, cache maintenance, and cross-CU effects on
+its engine thread.
+
+The pool is host acceleration machinery, not part of the modeled GPU topology.
+Its thread budget includes the calling CP thread plus retained workers, and
+changing that budget must not change the observable result of a race-free
+workload. Hot-hook callback serialization is enforced inside
+`ExecutionPluginGroup`; replacing a plugin group neither changes the dispatch
+budget nor reconstructs the pool.
+
+One pool is shared by all CPs in an SoC, so retained worker counts do not
+multiply with the XCD count. The current pool carries one pool-wide submission
+state, however, and therefore serializes complete batches from same-SoC CPs.
+Simdojo's `num_threads` can still run those CP control paths on separate XCD
+partitions, but it does not multiply the pool's same-SoC CU execution width.
+Different SoCs own independent pools.
+
+A functional quantum is a number of CU `step()` iterations rather than a count
+of individual instructions. Each step visits the runnable wavefronts resident
+on that CU and can issue one instruction for each of them. A quantum executes up
+to `kFunctionalQuantum` such iterations, but may yield early when a wavefront
+requests it (for example, `s_sleep` or a vendor-dependency retry). The next CU
+or CP continuation is scheduled at `now + max(1, last_quantum_executed_)` -- by
+the work actually executed -- so an early yield resumes promptly instead of
+leaping a full quantum, while `max(1, ...)` keeps the event strictly in the
+future. The quantum allows CU events to interleave, guaranteeing forward
+progress for inter-CU synchronization patterns such as spin-locks or semaphore
+acquire/release on global memory.
 
 A wavefront that reaches `s_endpgm` halts: it frees its SGPR/VGPR
 resources immediately and notifies the CP of workgroup completion (there
@@ -261,7 +283,8 @@ producer writes an AQL packet into the ring, then rings the doorbell
                 cu->dispatch_wf(wg_id, pc, sgprs, vgprs)
                   └── find idle slot, allocate SGPR/VGPR blocks
                       initialize wavefront state (pc, wg_id)
-                      schedule_work() -> tick event (self-driving)
+                      serial: schedule_work() -> CU tick event
+                      pooled: CP continuation -> shared SoC pool -> CU quantum
 ```
 
 The in-flight record the CP builds from that packet is a `DispatchEntry`, which

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.cpp
@@ -439,6 +439,8 @@ std::unordered_map<std::string, FactoryFn> &factories() {
       cc.sgprs_per_wf = config_u32(cfg, "sgprs_per_wf", default_sgprs_per_wf(arch));
       cc.vgprs_per_wf = config_u32(cfg, "vgprs_per_wf", default_vgprs_per_wf(arch));
       cc.lds_size_kb = config_u32(cfg, "lds_size_kb", 160);
+      cc.functional_quantum =
+          config_u32(cfg, "functional_quantum", amdgpu::ComputeUnitCore::kFunctionalQuantum);
       return amdgpu::ComputeUnitCore::create(n, cc, mem, nullptr, mode);
     };
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.cpp
@@ -421,10 +421,10 @@ std::unordered_map<std::string, FactoryFn> &factories() {
       return std::make_unique<amdgpu::MemorySideCache>(n);
     };
 
-    f["command_processor"] = [](const std::string &n, const CfgMap &, simdojo::ExecMode,
+    f["command_processor"] = [](const std::string &n, const CfgMap &, simdojo::ExecMode mode,
                                 rj_code_arch_t arch, rj_code_target_id_t,
                                 amdgpu::GpuMemory *) -> std::unique_ptr<simdojo::Component> {
-      auto cp = std::make_unique<amdgpu::CommandProcessor>(n);
+      auto cp = std::make_unique<amdgpu::CommandProcessor>(n, mode);
       cp->configure_for_arch(arch);
       return cp;
     };

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.cpp
@@ -432,6 +432,8 @@ std::unordered_map<std::string, FactoryFn> &factories() {
       cc.sgprs_per_wf = config_u32(cfg, "sgprs_per_wf", default_sgprs_per_wf(arch));
       cc.vgprs_per_wf = config_u32(cfg, "vgprs_per_wf", default_vgprs_per_wf(arch));
       cc.lds_size_kb = config_u32(cfg, "lds_size_kb", 160);
+      cc.functional_quantum =
+          config_u32(cfg, "functional_quantum", amdgpu::ComputeUnitCore::kFunctionalQuantum);
       return amdgpu::ComputeUnitCore::create(n, cc, mem, nullptr, mode);
     };
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.cpp
@@ -415,10 +415,10 @@ std::unordered_map<std::string, FactoryFn> &factories() {
       return std::make_unique<amdgpu::MemorySideCache>(n);
     };
 
-    f["command_processor"] = [](const std::string &n, const CfgMap &, simdojo::ExecMode,
+    f["command_processor"] = [](const std::string &n, const CfgMap &, simdojo::ExecMode mode,
                                 rj_code_arch_t arch,
                                 amdgpu::GpuMemory *) -> std::unique_ptr<simdojo::Component> {
-      auto cp = std::make_unique<amdgpu::CommandProcessor>(n);
+      auto cp = std::make_unique<amdgpu::CommandProcessor>(n, mode);
       cp->configure_for_arch(arch);
       return cp;
     };

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -25,6 +25,7 @@ RJ_DIAGNOSTIC_POP
 #include <bit>
 #include <cassert>
 #include <chrono>
+#include <condition_variable>
 #include <cstring>
 #include <elf.h>
 #include <format>
@@ -274,6 +275,26 @@ uint32_t initial_mode_from_compute_pgm_rsrc1(uint32_t rsrc1, rj_code_arch_t arch
 }
 
 } // namespace
+
+CommandProcessor::CommandProcessor(std::string name) : simdojo::Component(std::move(name)) {
+  // register_queue() may start the doorbell monitor before startup(), so the
+  // event must already have a handler when the queue becomes visible.
+  doorbell_event_.set_handler(
+      [this](simdojo::Tick ts, simdojo::Message *) { handle_doorbell(ts); });
+}
+
+CommandProcessor::~CommandProcessor() { stop_doorbell_monitor(); }
+
+void CommandProcessor::set_dispatch_threads(uint32_t threads) {
+  threads = std::max(threads, 1u);
+  if (plugin_group_->requires_serial_hot_hooks())
+    threads = 1;
+  if (dispatch_threads_ == threads)
+    return;
+  dispatch_threads_ = threads;
+  for (auto *spi : spis_)
+    spi->reset_dispatch_pool();
+}
 
 void CommandProcessor::init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf,
                                            const DispatchEntry &pkt, uint32_t global_wg_id,
@@ -547,9 +568,7 @@ void CommandProcessor::startup() {
   for ([[maybe_unused]] const auto *cu : cus_)
     assert(cu->partition_id() == partition_id() &&
            "CommandProcessor and its compute units must share one partition");
-  // doorbell_event_'s handler is bound in the constructor (see there) so it is live
-  // before register_queue() can start the poll thread; nothing to (re)bind here.
-  completion_ = std::make_unique<CompletionTracker>(memory_, cus_);
+  completion_ = std::make_unique<CompletionTracker>(memory_, cus_, l2_caches_);
   completion_->set_plugin_group(plugin_group_);
   completion_->set_dispatch_retired_callback(
       [this](const DispatchEntry &entry) { erase_cluster_workgroups(entry.dispatch_id); });
@@ -746,6 +765,7 @@ void CommandProcessor::register_queue(HwQueue queue) {
     }
   }
   {
+    std::unique_lock<std::shared_mutex> structure_lock(queue_structure_mutex_);
     std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
     HwQueueState qs{};
     qs.queue_desc_va = queue.queue_desc_va;
@@ -817,6 +837,7 @@ bool CommandProcessor::signal_queue_exception(uint32_t queue_id, uint32_t proces
 void CommandProcessor::unregister_queue(uint32_t queue_id, uint32_t process_id) {
   bool drop_replicas = false;
   {
+    std::unique_lock<std::shared_mutex> structure_lock(queue_structure_mutex_);
     // Holds hw_queue_mutex_ across with_wave_state_locked(), which is the order
     // the dispatch path uses too (handle_doorbell -> dispatch_workgroups ->
     // dispatch_wf). Nothing takes them the other way any more: a wave reaching
@@ -1693,6 +1714,7 @@ uint32_t CommandProcessor::dispatch_workgroups(DispatchEntry &entry) {
     if (!dispatch_to_placement(local_wg_id, global_wg_id, *placement))
       throw std::runtime_error("dispatch_wf failed after workgroup placement was reserved");
   }
+
   return dispatched;
 }
 
@@ -1712,8 +1734,14 @@ void CommandProcessor::notify_wg_complete(uint32_t dispatch_id, uint32_t wg_id) 
   mark_cluster_workgroup_complete(dispatch_id, wg_id);
   {
     std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
-    if (completion_)
+    if (completion_) {
       completion_->notify_wg_complete(dispatch_id, wg_id, new_queue_states_);
+      // Without worker fan-out, completion arrives on the CP's engine thread, so
+      // retire promptly while another resident dispatch may wait on this signal.
+      // Parallel workers must defer draining until their fan-out rejoins the CP.
+      if (dispatch_threads_ <= 1)
+        completion_->drain_completions(new_queue_states_);
+    }
   }
 }
 
@@ -1817,6 +1845,14 @@ void CommandProcessor::process_queues() {
         break; // CU backpressure.
     }
   }
+}
+
+bool CommandProcessor::has_active_cus() const {
+  for (auto *cu : cus_) {
+    if (cu->has_active_wfs())
+      return true;
+  }
+  return false;
 }
 
 rocr::llvm::amdhsa::kernel_descriptor_t
@@ -2516,14 +2552,19 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs, simdoj
   queue.fetch_cursor = process_limit;
 }
 
-void CommandProcessor::handle_doorbell(simdojo::Tick now) {
+void CommandProcessor::handle_doorbell(simdojo::Tick timestamp) {
   doorbell_handle_count_.fetch_add(1, std::memory_order_relaxed);
+  handle_doorbell_sync(timestamp);
+}
+
+void CommandProcessor::handle_doorbell_sync(simdojo::Tick now) {
   // Release so the doorbell poll thread's acquire-load cannot observe a stale
   // "pending" after this handler has re-fetched; pairs with the release-stores at
   // the INVALID-packet and barrier/dependency stall sites. A site that is still
   // unsatisfied on this pass re-sets its flag below, re-arming the paced re-check.
   invalid_pending_.store(false, std::memory_order_release);
   stall_pending_.store(false, std::memory_order_release);
+  std::shared_lock<std::shared_mutex> structure_lock(queue_structure_mutex_);
   util::Logger::cp(
       [&](auto &os) { os << std::format("{}: DOORBELL queues={}", name(), hw_queues_.size()); });
 
@@ -2532,7 +2573,6 @@ void CommandProcessor::handle_doorbell(simdojo::Tick now) {
   drain_fanout_inbox();
 
   std::unique_lock<std::recursive_mutex> lock(hw_queue_mutex_);
-
   size_t entries_before = 0;
   for (auto &qs : new_queue_states_)
     entries_before += qs.entries.size();
@@ -2560,127 +2600,219 @@ void CommandProcessor::handle_doorbell(simdojo::Tick now) {
                       entries_after - entries_before, entries_after);
   });
 
-  // Phase 1: Dispatch-Execute-Complete loop (functional mode).
-  bool progress = true;
-  while (progress) {
-    progress = false;
+  // While the queue mutex is dropped, CU workers may append completions to
+  // new_queue_states_. The shared structure lock remains held, so concurrent
+  // registration/removal cannot invalidate the dispatch loop's vector
+  // references; worker completion callbacks continue to use only the queue
+  // mutex.
+  auto run_dispatch_workers = [&]() {
+    if (dispatch_threads_ <= 1 || !has_active_cus())
+      return FunctionalQuantumResult{};
+    lock.unlock();
+    // Wavefront execution is driven by the SPIs, which own the worker pools;
+    // the CP only orchestrates queue fetch, dispatch, and completion. SPI-less
+    // topologies (direct add_compute_unit test harnesses) fall back to driving
+    // the CUs directly.
+    FunctionalQuantumResult result;
+    if (!spis_.empty()) {
+      for (auto *spi : spis_)
+        result.merge(spi->run_active_cus_once(dispatch_threads_));
+    } else {
+      for (auto *cu : cus_) {
+        if (cu->has_active_wfs())
+          result.merge(cu->run_quantum());
+      }
+    }
+    lock.lock();
+    if (completion_)
+      completion_->drain_completions(new_queue_states_);
+    return result;
+  };
 
+  // Phase 1: Dispatch-Execute-Complete loop (functional mode).
+  //
+  // Wrapped in a rescan loop. A dependent kernel the host submits *while this
+  // handler is executing* is picked up only by the post-loop re-fetch below;
+  // without re-running the dispatch loop it would be stranded un-dispatched,
+  // blocking in-order completion of the trailing barrier packets and hanging the
+  // waiting host forever (the doorbell that delivered it was already consumed by
+  // scan_doorbells, so no further handle_doorbell fires). This races at any
+  // thread count — the resume paths that would otherwise catch it (on_cu_idle at
+  // T=1, the synchronous pool drain at T>1) have all finished by the time the
+  // late packet arrives — but the window is widest with multi-dispatch IREE
+  // kernels at dispatch thread counts > 1. After each re-fetch we rescan and
+  // re-run this loop when new packets arrived.
+  bool rescan = true;
+  bool first_pass = true;
+  bool yield_to_event_loop = false;
+  while (rescan) {
+    bool progress = true;
+    while (progress && !yield_to_event_loop) {
+      progress = false;
+
+      for (size_t qi = 0; qi < hw_queues_.size(); ++qi) {
+        if (hw_queues_[qi].is_sdma || hw_queues_[qi].debug_suspended ||
+            hw_queues_[qi].runtime_suspended)
+          continue;
+        auto &qs = new_queue_states_[qi];
+
+        while (qs.next_dispatch_idx < qs.entries.size()) {
+          auto &entry = qs.entries[qs.next_dispatch_idx];
+
+          if (entry.barrier_bit && !barrier_satisfied(qs, qs.next_dispatch_idx))
+            break;
+
+          if (entry.is_non_kernel()) {
+            entry.completed_wgs = entry.total_wgs;
+            ++qs.next_dispatch_idx;
+            if (completion_)
+              completion_->drain_completions(new_queue_states_);
+            progress = true;
+            continue;
+          }
+
+          // Dispatch-execute-retire loop: keep dispatching WGs, activating CUs,
+          // and retiring WFs until the entry is fully dispatched and completed,
+          // or we hit genuine backpressure (no CU can accept any WG).
+          // NOTE: drain_completions may pop entries, so we must re-check indices
+          // after each drain and not hold stale references.
+          uint32_t dispatch_id = entry.dispatch_id;
+          bool backpressure = false;
+          for (;;) {
+            if (qs.next_dispatch_idx >= qs.entries.size())
+              break;
+            auto &cur = qs.entries[qs.next_dispatch_idx];
+            if (cur.dispatch_id != dispatch_id)
+              break;
+
+            uint32_t sent = dispatch_workgroups(cur);
+            if (sent > 0)
+              progress = true;
+
+            auto worker_result = run_dispatch_workers();
+            if (worker_result.ran)
+              progress = true;
+            if (worker_result.yielded) {
+              yield_to_event_loop = true;
+              break;
+            }
+
+            if (completion_)
+              completion_->drain_completions(new_queue_states_);
+
+            if (qs.next_dispatch_idx >= qs.entries.size())
+              break;
+            auto &post = qs.entries[qs.next_dispatch_idx];
+            if (post.dispatch_id != dispatch_id)
+              break;
+
+            if (post.fully_dispatched()) {
+              ++qs.next_dispatch_idx;
+              break;
+            }
+            if (sent == 0 && !worker_result.ran) {
+              backpressure = true;
+              break;
+            }
+          }
+          if (yield_to_event_loop)
+            break;
+          if (backpressure)
+            break;
+        }
+        if (yield_to_event_loop)
+          break;
+      }
+
+      if (!yield_to_event_loop) {
+        auto worker_result = run_dispatch_workers();
+        if (worker_result.ran)
+          progress = true;
+        if (worker_result.yielded)
+          yield_to_event_loop = true;
+      }
+    }
+
+    // Final drain: catch any entries that became fully_completed during the
+    // last iteration but weren't drained by the re-entrant path.
+    if (completion_)
+      completion_->drain_completions(new_queue_states_);
+
+    util::Logger::cp([&](auto &os) {
+      size_t remaining = 0;
+      for (auto &qs : new_queue_states_)
+        remaining += qs.entries.size();
+      uint32_t active_cus = 0;
+      for (auto *cu : cus_)
+        if (cu->has_active_wfs())
+          ++active_cus;
+      os << std::format("{}: PHASE1_DONE remaining={} active_cus={}/{}", name(), remaining,
+                        active_cus, cus_.size());
+      for (size_t qi = 0; qi < new_queue_states_.size(); ++qi) {
+        auto &qs = new_queue_states_[qi];
+        if (qs.entries.empty())
+          continue;
+        os << std::format("\n  queue[{}] entries={} next_disp={} implicit_barrier={}", qi,
+                          qs.entries.size(), qs.next_dispatch_idx, qs.implicit_barrier_next);
+        for (size_t ei = 0; ei < qs.entries.size(); ++ei) {
+          auto &e = qs.entries[ei];
+          os << std::format(
+              "\n    [{}] d={} qid={} total_wgs={} disp={} comp={} barrier={} sig={:#x} "
+              "non_kern={}",
+              ei, e.dispatch_id, e.queue_id, e.total_wgs, e.dispatched_wgs, e.completed_wgs,
+              e.barrier_bit, e.completion_signal, e.is_non_kernel());
+        }
+      }
+    });
+
+    if (yield_to_event_loop)
+      break;
+
+    // Re-fetch: pick up any packets the host submitted while we were executing
+    // (e.g., barrier packets queued after a kernel dispatch). Process them
+    // immediately so host signal waits see completed barriers before returning.
+    //
+    // SDMA queues are re-fetched only on the first pass. The compute (AQL) re-fetch
+    // is clamped to last_doorbell so repeating it is safe, but the SDMA path reads
+    // the live doorbell value and would read ahead of an observed doorbell —
+    // re-polling the ring across rescan iterations races with the host's
+    // concurrent ring writes (torn packet -> bad copy). Late *kernel* packets,
+    // which is all the rescan needs, only arrive on the compute queue anyway;
+    // SDMA packets are picked up by their own doorbell-driven passes.
+    const uint32_t dispatch_id_before_refetch = next_dispatch_id_;
+    for (size_t i = 0; i < hw_queues_.size(); ++i) {
+      if (hw_queues_[i].is_sdma && !first_pass)
+        continue;
+      fetch_from_queue(hw_queues_[i], new_queue_states_[i], now);
+    }
+    first_pass = false;
+    // Process any new non-kernel entries (barriers with total_wgs==0).
     for (size_t qi = 0; qi < hw_queues_.size(); ++qi) {
-      if (hw_queues_[qi].is_sdma || hw_queues_[qi].debug_suspended ||
-          hw_queues_[qi].runtime_suspended)
+      if (hw_queues_[qi].debug_suspended || hw_queues_[qi].runtime_suspended)
         continue;
       auto &qs = new_queue_states_[qi];
-
       while (qs.next_dispatch_idx < qs.entries.size()) {
         auto &entry = qs.entries[qs.next_dispatch_idx];
-
         if (entry.barrier_bit && !barrier_satisfied(qs, qs.next_dispatch_idx))
           break;
-
-        if (entry.is_non_kernel()) {
-          entry.completed_wgs = entry.total_wgs;
-          ++qs.next_dispatch_idx;
-          if (completion_)
-            completion_->drain_completions(new_queue_states_);
-          progress = true;
-          continue;
-        }
-
-        // Dispatch-execute-retire loop: keep dispatching WGs, activating CUs,
-        // and retiring WFs until the entry is fully dispatched and completed,
-        // or we hit genuine backpressure (no CU can accept any WG).
-        // NOTE: drain_completions may pop entries, so we must re-check indices
-        // after each drain and not hold stale references.
-        uint32_t dispatch_id = entry.dispatch_id;
-        bool backpressure = false;
-        for (;;) {
-          if (qs.next_dispatch_idx >= qs.entries.size())
-            break;
-          auto &cur = qs.entries[qs.next_dispatch_idx];
-          if (cur.dispatch_id != dispatch_id)
-            break;
-
-          uint32_t sent = dispatch_workgroups(cur);
-          if (sent > 0)
-            progress = true;
-
-          if (completion_)
-            completion_->drain_completions(new_queue_states_);
-
-          if (qs.next_dispatch_idx >= qs.entries.size())
-            break;
-          auto &post = qs.entries[qs.next_dispatch_idx];
-          if (post.dispatch_id != dispatch_id)
-            break;
-
-          if (post.fully_dispatched()) {
-            ++qs.next_dispatch_idx;
-            break;
-          }
-          if (sent == 0) {
-            backpressure = true;
-            break;
-          }
-        }
-        if (backpressure)
+        if (!entry.is_non_kernel())
           break;
+        entry.completed_wgs = entry.total_wgs;
+        ++qs.next_dispatch_idx;
       }
     }
-  }
+    if (completion_)
+      completion_->drain_completions(new_queue_states_);
 
-  // Final drain: catch any entries that became fully_completed during the
-  // last iteration but weren't drained by the re-entrant path.
-  if (completion_)
-    completion_->drain_completions(new_queue_states_);
-
-  util::Logger::cp([&](auto &os) {
-    size_t remaining = 0;
-    for (auto &qs : new_queue_states_)
-      remaining += qs.entries.size();
-    uint32_t active_cus = 0;
-    for (auto *cu : cus_)
-      if (cu->has_active_wfs())
-        ++active_cus;
-    os << std::format("{}: PHASE1_DONE remaining={} active_cus={}/{}", name(), remaining,
-                      active_cus, cus_.size());
-    for (size_t qi = 0; qi < new_queue_states_.size(); ++qi) {
-      auto &qs = new_queue_states_[qi];
-      if (qs.entries.empty())
-        continue;
-      os << std::format("\n  queue[{}] entries={} next_disp={} implicit_barrier={}", qi,
-                        qs.entries.size(), qs.next_dispatch_idx, qs.implicit_barrier_next);
-      for (size_t ei = 0; ei < qs.entries.size(); ++ei) {
-        auto &e = qs.entries[ei];
-        os << std::format(
-            "\n    [{}] d={} qid={} total_wgs={} disp={} comp={} barrier={} sig={:#x} non_kern={}",
-            ei, e.dispatch_id, e.queue_id, e.total_wgs, e.dispatched_wgs, e.completed_wgs,
-            e.barrier_bit, e.completion_signal, e.is_non_kernel());
-      }
-    }
-  });
-
-  // Re-fetch: pick up any packets the host submitted while we were executing
-  // (e.g., barrier packets queued after a kernel dispatch). Process them
-  // immediately so host signal waits see completed barriers before returning.
-  for (size_t i = 0; i < hw_queues_.size(); ++i)
-    fetch_from_queue(hw_queues_[i], new_queue_states_[i], now);
-  // Process any new non-kernel entries (barrier-kind packets).
-  for (size_t qi = 0; qi < hw_queues_.size(); ++qi) {
-    if (hw_queues_[qi].debug_suspended || hw_queues_[qi].runtime_suspended)
-      continue;
-    auto &qs = new_queue_states_[qi];
-    while (qs.next_dispatch_idx < qs.entries.size()) {
-      auto &entry = qs.entries[qs.next_dispatch_idx];
-      if (entry.barrier_bit && !barrier_satisfied(qs, qs.next_dispatch_idx))
-        break;
-      if (!entry.is_non_kernel())
-        break;
-      entry.completed_wgs = entry.total_wgs;
-      ++qs.next_dispatch_idx;
-    }
-  }
-  if (completion_)
-    completion_->drain_completions(new_queue_states_);
+    // Re-run Phase 1 only if the re-fetch actually pulled in NEW packets
+    // (next_dispatch_id_ advances exactly once per fetched packet). Gating on new
+    // packets — rather than "a dispatchable entry still exists" — is what
+    // guarantees termination: a kernel held back by CU backpressure stays
+    // "dispatchable" but creates no new dispatch ids, so it cannot spin the loop.
+    // New arrivals are finite: they are bounded by host submissions, which are
+    // themselves gated on the completion signals we deliver here.
+    rescan = (next_dispatch_id_ != dispatch_id_before_refetch);
+  } // while (rescan)
 
   arm_grid_wait_recheck();
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -282,8 +282,11 @@ CommandProcessor::CommandProcessor(std::string name, simdojo::ExecMode exec_mode
   // event must already have a handler when the queue becomes visible.
   doorbell_event_.set_handler(
       [this](simdojo::Tick ts, simdojo::Message *) { handle_doorbell(ts); });
-  dispatch_continuation_event_.set_handler([this](simdojo::Tick ts, simdojo::Message *) {
+  dispatch_continuation_event_.set_handler([this](simdojo::Tick ts, simdojo::Message *message) {
+    if (!message || message->payload() != dispatch_continuation_generation_)
+      return;
     dispatch_continuation_pending_ = false;
+    dispatch_continuation_tick_ = simdojo::TICK_MAX;
     handle_doorbell_sync(ts);
   });
 }
@@ -300,16 +303,73 @@ void CommandProcessor::set_dispatch_threads(uint32_t threads) {
   threads = std::max(threads, 1u);
   if (exec_mode_ != simdojo::ExecMode::FUNCTIONAL || plugin_group_->requires_serial_hot_hooks())
     threads = 1;
-  const bool pool_driven = threads > 1;
-  for (auto *cu : cus_)
-    cu->set_pool_driven(pool_driven);
   if (dispatch_threads_ == threads)
     return;
+
+  const bool was_pool_driven = dispatch_threads_ > 1;
+  const bool pool_driven = threads > 1;
   dispatch_threads_ = threads;
   local_dispatch_pool_.reset();
-  if (!pool_driven)
+
+  if (was_pool_driven == pool_driven) {
     for (auto *cu : cus_)
-      cu->schedule_work();
+      cu->set_pool_driven(pool_driven);
+    return;
+  }
+
+  simdojo::Tick now = 0;
+  if (engine())
+    now = engine()->context(partition_id()).current_tick();
+
+  if (pool_driven) {
+    pooled_due_ticks_.clear();
+    for (auto *cu : cus_) {
+      const simdojo::Tick serial_due = cu->suspend_scheduled_work();
+      cu->set_pool_driven(true);
+      if (cu->has_active_wfs()) {
+        simdojo::Tick tick = serial_due == simdojo::TICK_MAX ? now + 1 : serial_due;
+        if (tick < now)
+          tick = now + 1;
+        pooled_due_ticks_[cu] = tick;
+      }
+    }
+    const simdojo::Tick next = next_pooled_due_tick(now);
+    if (next != simdojo::TICK_MAX)
+      arm_dispatch_continuation(next);
+    return;
+  }
+
+  cancel_dispatch_continuation();
+  for (auto *cu : cus_) {
+    cu->set_pool_driven(false);
+    if (!cu->has_active_wfs())
+      continue;
+    auto due = pooled_due_ticks_.find(cu);
+    simdojo::Tick tick = due == pooled_due_ticks_.end() ? now + 1 : due->second;
+    if (tick < now)
+      tick = now + 1;
+    cu->schedule_work_at(tick);
+  }
+  pooled_due_ticks_.clear();
+}
+
+void CommandProcessor::arm_dispatch_continuation(simdojo::Tick tick) {
+  if (!engine())
+    return;
+  if (dispatch_continuation_pending_ && dispatch_continuation_tick_ <= tick)
+    return;
+
+  dispatch_continuation_pending_ = true;
+  dispatch_continuation_tick_ = tick;
+  const uintptr_t generation = ++dispatch_continuation_generation_;
+  schedule_event(&dispatch_continuation_event_, tick,
+                 std::make_unique<simdojo::Message>(simdojo::MessageHeader{}, generation));
+}
+
+void CommandProcessor::cancel_dispatch_continuation() {
+  dispatch_continuation_pending_ = false;
+  dispatch_continuation_tick_ = simdojo::TICK_MAX;
+  ++dispatch_continuation_generation_;
 }
 
 void CommandProcessor::init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf,
@@ -984,8 +1044,8 @@ void CommandProcessor::set_queue_debug_suspended(uint32_t queue_id, uint32_t pro
           // neither resume path with anything to release.
           if (state.next_dispatch_idx < state.entries.size()) {
             const auto &entry = state.entries[state.next_dispatch_idx];
-            const bool barrier_ready =
-                !entry.wait_for_predecessors || barrier_satisfied(state, state.next_dispatch_idx);
+            const bool barrier_ready = !entry.wait_for_predecessors ||
+                                       barrier_satisfied(state, state.next_dispatch_idx);
             q.debug_work_deferred |=
                 barrier_ready && (entry.is_non_kernel() || !entry.fully_dispatched());
           }
@@ -1882,7 +1942,28 @@ bool CommandProcessor::has_active_cus() const {
   return false;
 }
 
-FunctionalQuantumResult CommandProcessor::run_active_cus_once() {
+void CommandProcessor::refresh_pooled_due_ticks(simdojo::Tick now) {
+  for (auto it = pooled_due_ticks_.begin(); it != pooled_due_ticks_.end();) {
+    if (!it->first->has_active_wfs())
+      it = pooled_due_ticks_.erase(it);
+    else
+      ++it;
+  }
+  for (auto *cu : cus_)
+    if (cu->has_active_wfs())
+      pooled_due_ticks_.try_emplace(cu, now + 1);
+}
+
+simdojo::Tick CommandProcessor::next_pooled_due_tick(simdojo::Tick now) {
+  refresh_pooled_due_ticks(now);
+  simdojo::Tick next = simdojo::TICK_MAX;
+  for (const auto &[_, tick] : pooled_due_ticks_)
+    next = std::min(next, tick);
+  return next;
+}
+
+FunctionalQuantumResult CommandProcessor::run_active_cus_once(simdojo::Tick now) {
+  refresh_pooled_due_ticks(now);
   active_cu_scratch_.clear();
   if (!spis_.empty()) {
     for (auto *spi : spis_)
@@ -1893,23 +1974,38 @@ FunctionalQuantumResult CommandProcessor::run_active_cus_once() {
         active_cu_scratch_.push_back(cu);
     }
   }
+  std::erase_if(active_cu_scratch_, [&](ComputeUnitCore *cu) {
+    auto due = pooled_due_ticks_.find(cu);
+    return due == pooled_due_ticks_.end() || due->second > now;
+  });
 
   if (active_cu_scratch_.empty())
     return {};
 
+  quantum_result_scratch_.resize(active_cu_scratch_.size());
   uint32_t effective_threads =
       std::min<uint32_t>(dispatch_threads_, static_cast<uint32_t>(active_cu_scratch_.size()));
+  FunctionalQuantumResult result;
   if (shared_dispatch_pool_)
-    return shared_dispatch_pool_->run(active_cu_scratch_, effective_threads);
-  if (effective_threads > 1) {
+    result =
+        shared_dispatch_pool_->run(active_cu_scratch_, effective_threads, quantum_result_scratch_);
+  else if (effective_threads > 1) {
     if (!local_dispatch_pool_ || local_dispatch_pool_->thread_count() < effective_threads)
       local_dispatch_pool_ = std::make_unique<CpuDispatchPool>(effective_threads);
-    return local_dispatch_pool_->run(active_cu_scratch_, effective_threads);
+    result =
+        local_dispatch_pool_->run(active_cu_scratch_, effective_threads, quantum_result_scratch_);
+  } else {
+    quantum_result_scratch_.front() = active_cu_scratch_.front()->run_quantum();
+    result = quantum_result_scratch_.front();
   }
 
-  FunctionalQuantumResult result;
-  for (auto *cu : active_cu_scratch_)
-    result.merge(cu->run_quantum());
+  for (size_t i = 0; i < active_cu_scratch_.size(); ++i) {
+    auto *cu = active_cu_scratch_[i];
+    if (cu->has_active_wfs())
+      pooled_due_ticks_[cu] = now + std::max<uint64_t>(1, quantum_result_scratch_[i].iterations);
+    else
+      pooled_due_ticks_.erase(cu);
+  }
   return result;
 }
 
@@ -2676,7 +2772,7 @@ void CommandProcessor::handle_doorbell_sync(simdojo::Tick now) {
     lock.unlock();
     // One shared pool and thread budget covers the CP's complete active-CU
     // batch instead of retaining a separate pool for every SPI.
-    FunctionalQuantumResult result = run_active_cus_once();
+    FunctionalQuantumResult result = run_active_cus_once(now);
     lock.lock();
     drain_pending_wg_completions();
     if (completion_)
@@ -2873,11 +2969,11 @@ void CommandProcessor::handle_doorbell_sync(simdojo::Tick now) {
   }
 
   if (dispatch_threads_ > 1) {
-    if (yield_to_event_loop && (has_active_cus() || pending_entries() > 0) &&
-        !dispatch_continuation_pending_) {
-      dispatch_continuation_pending_ = true;
-      schedule_event(&dispatch_continuation_event_, now + 1);
-    }
+    const simdojo::Tick next = next_pooled_due_tick(now);
+    if (next != simdojo::TICK_MAX)
+      arm_dispatch_continuation(next);
+    else
+      cancel_dispatch_continuation();
   } else {
     for (size_t i = 0; i < cus_.size(); ++i) {
       if (!cus_[i]->is_idle()) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -301,7 +301,7 @@ void CommandProcessor::set_shared_dispatch_pool(CpuDispatchPool *pool) {
 
 void CommandProcessor::set_dispatch_threads(uint32_t threads) {
   threads = std::max(threads, 1u);
-  if (exec_mode_ != simdojo::ExecMode::FUNCTIONAL || plugin_group_->requires_serial_hot_hooks())
+  if (exec_mode_ != simdojo::ExecMode::FUNCTIONAL)
     threads = 1;
   if (dispatch_threads_ == threads)
     return;
@@ -326,7 +326,7 @@ void CommandProcessor::set_dispatch_threads(uint32_t threads) {
     for (auto *cu : cus_) {
       const simdojo::Tick serial_due = cu->suspend_scheduled_work();
       cu->set_pool_driven(true);
-      if (cu->has_active_wfs()) {
+      if (cu->has_runnable_wfs()) {
         simdojo::Tick tick = serial_due == simdojo::TICK_MAX ? now + 1 : serial_due;
         if (tick < now)
           tick = now + 1;
@@ -1919,6 +1919,16 @@ void CommandProcessor::on_cu_idle() {
   arm_grid_wait_recheck();
 }
 
+void CommandProcessor::on_cu_pool_ready(ComputeUnitCore *cu) {
+  if (dispatch_threads_ <= 1 || !engine() || !cu->has_runnable_wfs())
+    return;
+
+  std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
+  const simdojo::Tick now = engine()->context(partition_id()).current_tick();
+  pooled_due_ticks_[cu] = now + 1;
+  arm_dispatch_continuation(now + 1);
+}
+
 bool CommandProcessor::step() {
   // Process dispatches across all queues.
   process_queues();
@@ -1954,9 +1964,9 @@ void CommandProcessor::process_queues() {
   }
 }
 
-bool CommandProcessor::has_active_cus() const {
+bool CommandProcessor::has_runnable_cus() const {
   for (auto *cu : cus_) {
-    if (cu->has_active_wfs())
+    if (cu->has_runnable_wfs())
       return true;
   }
   return false;
@@ -1964,13 +1974,13 @@ bool CommandProcessor::has_active_cus() const {
 
 void CommandProcessor::refresh_pooled_due_ticks(simdojo::Tick now) {
   for (auto it = pooled_due_ticks_.begin(); it != pooled_due_ticks_.end();) {
-    if (!it->first->has_active_wfs())
+    if (!it->first->has_runnable_wfs())
       it = pooled_due_ticks_.erase(it);
     else
       ++it;
   }
   for (auto *cu : cus_)
-    if (cu->has_active_wfs())
+    if (cu->has_runnable_wfs())
       pooled_due_ticks_.try_emplace(cu, now + 1);
 }
 
@@ -1990,13 +2000,13 @@ FunctionalQuantumResult CommandProcessor::run_active_cus_once(simdojo::Tick now)
       spi->append_active_cus(active_cu_scratch_);
   } else {
     for (auto *cu : cus_) {
-      if (cu->has_active_wfs())
+      if (cu->has_runnable_wfs())
         active_cu_scratch_.push_back(cu);
     }
   }
   std::erase_if(active_cu_scratch_, [&](ComputeUnitCore *cu) {
     auto due = pooled_due_ticks_.find(cu);
-    return due == pooled_due_ticks_.end() || due->second > now;
+    return !cu->has_runnable_wfs() || due == pooled_due_ticks_.end() || due->second > now;
   });
 
   if (active_cu_scratch_.empty())
@@ -2021,7 +2031,7 @@ FunctionalQuantumResult CommandProcessor::run_active_cus_once(simdojo::Tick now)
 
   for (size_t i = 0; i < active_cu_scratch_.size(); ++i) {
     auto *cu = active_cu_scratch_[i];
-    if (cu->has_active_wfs())
+    if (cu->has_runnable_wfs())
       pooled_due_ticks_[cu] = now + std::max<uint64_t>(1, quantum_result_scratch_[i].iterations);
     else
       pooled_due_ticks_.erase(cu);
@@ -2787,7 +2797,8 @@ void CommandProcessor::handle_doorbell_sync(simdojo::Tick now) {
   // records only. The shared structure lock keeps queue/CU storage stable; once
   // the batch rejoins, the CP thread applies every stateful retirement action.
   auto run_dispatch_workers = [&]() {
-    if (exec_mode_ != simdojo::ExecMode::FUNCTIONAL || dispatch_threads_ <= 1 || !has_active_cus())
+    if (exec_mode_ != simdojo::ExecMode::FUNCTIONAL || dispatch_threads_ <= 1 ||
+        !has_runnable_cus())
       return FunctionalQuantumResult{};
     lock.unlock();
     // One shared pool and thread budget covers the CP's complete active-CU
@@ -2901,6 +2912,16 @@ void CommandProcessor::handle_doorbell_sync(simdojo::Tick now) {
     drain_pending_wg_completions();
     if (completion_)
       completion_->drain_completions(new_queue_states_);
+
+    // A completed batch can free every resident slot while the same dispatch
+    // still owns undispatched workgroups. Refill those slots before yielding,
+    // but leave their execution to the next continuation event so one event
+    // still runs at most one functional quantum per CU.
+    if (yield_to_event_loop) {
+      process_queues();
+      if (completion_)
+        completion_->drain_completions(new_queue_states_);
+    }
 
     util::Logger::cp([&](auto &os) {
       size_t remaining = 0;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -276,7 +276,8 @@ uint32_t initial_mode_from_compute_pgm_rsrc1(uint32_t rsrc1, rj_code_arch_t arch
 
 } // namespace
 
-CommandProcessor::CommandProcessor(std::string name) : simdojo::Component(std::move(name)) {
+CommandProcessor::CommandProcessor(std::string name, simdojo::ExecMode exec_mode)
+    : simdojo::Component(std::move(name)), exec_mode_(exec_mode) {
   // register_queue() may start the doorbell monitor before startup(), so the
   // event must already have a handler when the queue becomes visible.
   doorbell_event_.set_handler(
@@ -285,15 +286,20 @@ CommandProcessor::CommandProcessor(std::string name) : simdojo::Component(std::m
 
 CommandProcessor::~CommandProcessor() { stop_doorbell_monitor(); }
 
+void CommandProcessor::set_shared_dispatch_pool(CpuDispatchPool *pool) {
+  shared_dispatch_pool_ = pool;
+  if (shared_dispatch_pool_)
+    local_dispatch_pool_.reset();
+}
+
 void CommandProcessor::set_dispatch_threads(uint32_t threads) {
   threads = std::max(threads, 1u);
-  if (plugin_group_->requires_serial_hot_hooks())
+  if (exec_mode_ != simdojo::ExecMode::FUNCTIONAL || plugin_group_->requires_serial_hot_hooks())
     threads = 1;
   if (dispatch_threads_ == threads)
     return;
   dispatch_threads_ = threads;
-  for (auto *spi : spis_)
-    spi->reset_dispatch_pool();
+  local_dispatch_pool_.reset();
 }
 
 void CommandProcessor::init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf,
@@ -1855,6 +1861,37 @@ bool CommandProcessor::has_active_cus() const {
   return false;
 }
 
+FunctionalQuantumResult CommandProcessor::run_active_cus_once() {
+  active_cu_scratch_.clear();
+  if (!spis_.empty()) {
+    for (auto *spi : spis_)
+      spi->append_active_cus(active_cu_scratch_);
+  } else {
+    for (auto *cu : cus_) {
+      if (cu->has_active_wfs())
+        active_cu_scratch_.push_back(cu);
+    }
+  }
+
+  if (active_cu_scratch_.empty())
+    return {};
+
+  uint32_t effective_threads =
+      std::min<uint32_t>(dispatch_threads_, static_cast<uint32_t>(active_cu_scratch_.size()));
+  if (shared_dispatch_pool_)
+    return shared_dispatch_pool_->run(active_cu_scratch_, effective_threads);
+  if (effective_threads > 1) {
+    if (!local_dispatch_pool_ || local_dispatch_pool_->thread_count() < effective_threads)
+      local_dispatch_pool_ = std::make_unique<CpuDispatchPool>(effective_threads);
+    return local_dispatch_pool_->run(active_cu_scratch_, effective_threads);
+  }
+
+  FunctionalQuantumResult result;
+  for (auto *cu : active_cu_scratch_)
+    result.merge(cu->run_quantum());
+  return result;
+}
+
 rocr::llvm::amdhsa::kernel_descriptor_t
 CommandProcessor::read_kernel_descriptor(uint64_t kernel_object, uint32_t vmid,
                                          [[maybe_unused]] bool host_accessible) {
@@ -2606,23 +2643,12 @@ void CommandProcessor::handle_doorbell_sync(simdojo::Tick now) {
   // references; worker completion callbacks continue to use only the queue
   // mutex.
   auto run_dispatch_workers = [&]() {
-    if (dispatch_threads_ <= 1 || !has_active_cus())
+    if (exec_mode_ != simdojo::ExecMode::FUNCTIONAL || dispatch_threads_ <= 1 || !has_active_cus())
       return FunctionalQuantumResult{};
     lock.unlock();
-    // Wavefront execution is driven by the SPIs, which own the worker pools;
-    // the CP only orchestrates queue fetch, dispatch, and completion. SPI-less
-    // topologies (direct add_compute_unit test harnesses) fall back to driving
-    // the CUs directly.
-    FunctionalQuantumResult result;
-    if (!spis_.empty()) {
-      for (auto *spi : spis_)
-        result.merge(spi->run_active_cus_once(dispatch_threads_));
-    } else {
-      for (auto *cu : cus_) {
-        if (cu->has_active_wfs())
-          result.merge(cu->run_quantum());
-      }
-    }
+    // One shared pool and thread budget covers the CP's complete active-CU
+    // batch instead of retaining a separate pool for every SPI.
+    FunctionalQuantumResult result = run_active_cus_once();
     lock.lock();
     if (completion_)
       completion_->drain_completions(new_queue_states_);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -1044,8 +1044,8 @@ void CommandProcessor::set_queue_debug_suspended(uint32_t queue_id, uint32_t pro
           // neither resume path with anything to release.
           if (state.next_dispatch_idx < state.entries.size()) {
             const auto &entry = state.entries[state.next_dispatch_idx];
-            const bool barrier_ready = !entry.wait_for_predecessors ||
-                                       barrier_satisfied(state, state.next_dispatch_idx);
+            const bool barrier_ready =
+                !entry.wait_for_predecessors || barrier_satisfied(state, state.next_dispatch_idx);
             q.debug_work_deferred |=
                 barrier_ready && (entry.is_non_kernel() || !entry.fully_dispatched());
           }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -1318,6 +1318,25 @@ void CommandProcessor::drain_pending_wg_completions() {
   pending_wg_completions_.clear();
 }
 
+void CommandProcessor::drain_pending_cluster_barrier_completions() {
+  std::vector<PendingClusterBarrierCompletion> completions;
+  {
+    std::lock_guard<std::recursive_mutex> lock(cluster_placements_mutex_);
+    completions.swap(pending_cluster_barrier_completions_);
+  }
+
+  for (auto &completion : completions) {
+    std::vector<Wavefront *> members;
+    for (auto [cu, peer_wg_id] : completion.peers) {
+      auto peer_members =
+          cu->complete_barrier(completion.dispatch_id, peer_wg_id, completion.completion_bit);
+      members.insert(members.end(), peer_members.begin(), peer_members.end());
+    }
+    if (!members.empty())
+      plugin_group_->onAmdgpuBarrierResolved(std::span<Wavefront *>(members));
+  }
+}
+
 void CommandProcessor::register_cluster_workgroup(const DispatchEntry &entry, uint32_t local_wg_id,
                                                   uint32_t global_wg_id, ComputeUnitCore *cu,
                                                   uint32_t lds_base) {
@@ -1404,7 +1423,6 @@ uint32_t CommandProcessor::cluster_barrier_state(const Wavefront &wf, int32_t ba
 
 bool CommandProcessor::cluster_barrier_signal(Wavefront &wf, int32_t barrier_id) {
   bool is_first = false;
-  std::vector<std::pair<ComputeUnitCore *, uint32_t>> peers;
   const uint8_t completion_bit = static_cast<uint8_t>(-barrier_id);
   {
     std::lock_guard<std::recursive_mutex> lock(cluster_placements_mutex_);
@@ -1422,21 +1440,22 @@ bool CommandProcessor::cluster_barrier_signal(Wavefront &wf, int32_t barrier_id)
       return is_first;
 
     barriers->signaled_workgroups[index].clear();
+    PendingClusterBarrierCompletion completion{wf.dispatch_id(), completion_bit, {}};
+    auto &peers = completion.peers;
     peers.reserve(placement->peer_wg_ids.size());
     for (uint32_t peer_wg_id : placement->peer_wg_ids) {
       auto peer = cluster_wg_placements_.find(wg_key(wf.dispatch_id(), peer_wg_id));
       if (peer != cluster_wg_placements_.end() && peer->second.cu)
         peers.emplace_back(peer->second.cu, peer_wg_id);
     }
+    pending_cluster_barrier_completions_.push_back(std::move(completion));
   }
 
-  std::vector<Wavefront *> members;
-  for (auto [cu, peer_wg_id] : peers) {
-    auto peer_members = cu->complete_barrier(wf.dispatch_id(), peer_wg_id, completion_bit);
-    members.insert(members.end(), peer_members.begin(), peer_members.end());
-  }
-  if (!members.empty())
-    plugin_group_->onAmdgpuBarrierResolved(std::span<Wavefront *>(members));
+  // In serial mode this instruction already runs on the CP/engine thread, so
+  // preserve immediate barrier resolution. Pool workers leave the compact
+  // record queued until the fan-out rejoins below.
+  if (dispatch_threads_ <= 1)
+    drain_pending_cluster_barrier_completions();
   return is_first;
 }
 
@@ -1838,6 +1857,7 @@ void CommandProcessor::on_cu_idle() {
 
   std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
 
+  drain_pending_cluster_barrier_completions();
   drain_pending_wg_completions();
   if (completion_)
     completion_->drain_completions(new_queue_states_);
@@ -2774,6 +2794,7 @@ void CommandProcessor::handle_doorbell_sync(simdojo::Tick now) {
     // batch instead of retaining a separate pool for every SPI.
     FunctionalQuantumResult result = run_active_cus_once(now);
     lock.lock();
+    drain_pending_cluster_barrier_completions();
     drain_pending_wg_completions();
     if (completion_)
       completion_->drain_completions(new_queue_states_);
@@ -2876,6 +2897,7 @@ void CommandProcessor::handle_doorbell_sync(simdojo::Tick now) {
 
     // Final drain: catch any entries that became fully_completed during the
     // last worker batch.
+    drain_pending_cluster_barrier_completions();
     drain_pending_wg_completions();
     if (completion_)
       completion_->drain_completions(new_queue_states_);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -282,6 +282,10 @@ CommandProcessor::CommandProcessor(std::string name, simdojo::ExecMode exec_mode
   // event must already have a handler when the queue becomes visible.
   doorbell_event_.set_handler(
       [this](simdojo::Tick ts, simdojo::Message *) { handle_doorbell(ts); });
+  dispatch_continuation_event_.set_handler([this](simdojo::Tick ts, simdojo::Message *) {
+    dispatch_continuation_pending_ = false;
+    handle_doorbell_sync(ts);
+  });
 }
 
 CommandProcessor::~CommandProcessor() { stop_doorbell_monitor(); }
@@ -296,10 +300,16 @@ void CommandProcessor::set_dispatch_threads(uint32_t threads) {
   threads = std::max(threads, 1u);
   if (exec_mode_ != simdojo::ExecMode::FUNCTIONAL || plugin_group_->requires_serial_hot_hooks())
     threads = 1;
+  const bool pool_driven = threads > 1;
+  for (auto *cu : cus_)
+    cu->set_pool_driven(pool_driven);
   if (dispatch_threads_ == threads)
     return;
   dispatch_threads_ = threads;
   local_dispatch_pool_.reset();
+  if (!pool_driven)
+    for (auto *cu : cus_)
+      cu->schedule_work();
 }
 
 void CommandProcessor::init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf,
@@ -975,7 +985,7 @@ void CommandProcessor::set_queue_debug_suspended(uint32_t queue_id, uint32_t pro
           if (state.next_dispatch_idx < state.entries.size()) {
             const auto &entry = state.entries[state.next_dispatch_idx];
             const bool barrier_ready =
-                !entry.barrier_bit || barrier_satisfied(state, state.next_dispatch_idx);
+                !entry.wait_for_predecessors || barrier_satisfied(state, state.next_dispatch_idx);
             q.debug_work_deferred |=
                 barrier_ready && (entry.is_non_kernel() || !entry.fully_dispatched());
           }
@@ -1233,6 +1243,19 @@ bool CommandProcessor::barrier_satisfied(const HwQueueState &qs, size_t idx) con
       return false;
   }
   return true;
+}
+
+void CommandProcessor::drain_pending_wg_completions() {
+  for (const auto completion : pending_wg_completions_) {
+    plugin_group_->onAmdgpuWorkgroupCompleted(completion.dispatch_id, completion.wg_id);
+    for (auto *spi : spis_)
+      if (spi->release_wgp_workgroup(completion.dispatch_id, completion.wg_id))
+        break;
+    mark_cluster_workgroup_complete(completion.dispatch_id, completion.wg_id);
+    if (completion_)
+      completion_->notify_wg_complete(completion.dispatch_id, completion.wg_id, new_queue_states_);
+  }
+  pending_wg_completions_.clear();
 }
 
 void CommandProcessor::register_cluster_workgroup(const DispatchEntry &entry, uint32_t local_wg_id,
@@ -1731,22 +1754,15 @@ uint32_t CommandProcessor::dispatch_workgroups(DispatchEntry &entry) {
 void CommandProcessor::notify_wg_complete(uint32_t dispatch_id, uint32_t wg_id) {
   util::Logger::cp(
       [&](auto &os) { os << std::format("WG_COMPLETE d={} wg={}", dispatch_id, wg_id); });
-  {
-    std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
-    for (auto *spi : spis_)
-      if (spi->release_wgp_workgroup(dispatch_id, wg_id))
-        break;
-  }
-  mark_cluster_workgroup_complete(dispatch_id, wg_id);
-  {
-    std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
+  std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
+  pending_wg_completions_.push_back({dispatch_id, wg_id});
+  if (dispatch_threads_ <= 1) {
+    drain_pending_wg_completions();
     if (completion_) {
-      completion_->notify_wg_complete(dispatch_id, wg_id, new_queue_states_);
       // Without worker fan-out, completion arrives on the CP's engine thread, so
       // retire promptly while another resident dispatch may wait on this signal.
       // Parallel workers must defer draining until their fan-out rejoins the CP.
-      if (dispatch_threads_ <= 1)
-        completion_->drain_completions(new_queue_states_);
+      completion_->drain_completions(new_queue_states_);
     }
   }
 }
@@ -1762,6 +1778,7 @@ void CommandProcessor::on_cu_idle() {
 
   std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
 
+  drain_pending_wg_completions();
   if (completion_)
     completion_->drain_completions(new_queue_states_);
 
@@ -1773,11 +1790,13 @@ void CommandProcessor::on_cu_idle() {
     auto &qs = new_queue_states_[qi];
     while (qs.next_dispatch_idx < qs.entries.size()) {
       auto &e = qs.entries[qs.next_dispatch_idx];
-      if (e.barrier_bit && !barrier_satisfied(qs, qs.next_dispatch_idx))
+      if (e.wait_for_predecessors && !barrier_satisfied(qs, qs.next_dispatch_idx))
         break;
       if (!e.is_non_kernel())
         break;
       e.completed_wgs = e.total_wgs;
+      if (completion_)
+        completion_->complete_non_kernel(e);
       ++qs.next_dispatch_idx;
     }
   }
@@ -1801,7 +1820,7 @@ void CommandProcessor::on_cu_idle() {
     auto &qs = new_queue_states_[qi];
     if (qs.next_dispatch_idx < qs.entries.size()) {
       auto &entry = qs.entries[qs.next_dispatch_idx];
-      if (entry.barrier_bit && !barrier_satisfied(qs, qs.next_dispatch_idx))
+      if (entry.wait_for_predecessors && !barrier_satisfied(qs, qs.next_dispatch_idx))
         continue;
       if (!entry.is_non_kernel() && !entry.fully_dispatched()) {
         uint32_t sent = dispatch_workgroups(entry);
@@ -1835,11 +1854,13 @@ void CommandProcessor::process_queues() {
     while (qs.next_dispatch_idx < qs.entries.size()) {
       auto &entry = qs.entries[qs.next_dispatch_idx];
 
-      if (entry.barrier_bit && !barrier_satisfied(qs, qs.next_dispatch_idx))
+      if (entry.wait_for_predecessors && !barrier_satisfied(qs, qs.next_dispatch_idx))
         break; // Stalled on barrier bit.
 
       if (entry.is_non_kernel()) {
         entry.completed_wgs = entry.total_wgs; // 0 == 0, immediately complete.
+        if (completion_)
+          completion_->complete_non_kernel(entry);
         ++qs.next_dispatch_idx;
         continue;
       }
@@ -2102,7 +2123,7 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
   dp.workgroup_size_z = pkt.workgroup_size_z;
   dp.completion_signal = pkt.completion_signal.handle;
   dp.host_signal = false;
-  dp.barrier_bit = (pkt.header >> HSA_PACKET_HEADER_BARRIER) & 1;
+  dp.wait_for_predecessors = (pkt.header >> HSA_PACKET_HEADER_BARRIER) & 1;
 
   // Process AQL acquire fence: invalidate caches so the kernel sees the
   // latest host/agent writes (kernarg data, input buffers, etc.).
@@ -2442,12 +2463,20 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs, simdoj
           .process_id = queue.process_id,
           .completion_signal = sig,
           .kind = DispatchPacketKind::NonKernel,
-          .barrier_bit = ((pkt.header >> HSA_PACKET_HEADER_BARRIER) & 1) != 0,
+          .wait_for_predecessors = ((pkt.header >> HSA_PACKET_HEADER_BARRIER) & 1) != 0,
+          .blocks_following = true,
       };
 
+      const bool blocks_following = dp.blocks_following;
       if (queue.xcd_fanout)
         replicate_non_kernel_entry(dp);
       qs.push_entry(std::move(dp));
+      ++read_idx;
+      if (blocks_following) {
+        process_limit = read_idx;
+        break;
+      }
+      continue;
     } else if (pkt_type == HSA_PACKET_TYPE_VENDOR_SPECIFIC) {
       AmdExtKernelDispatchPacket ext{};
       std::memcpy(&ext, &pkt, sizeof(ext));
@@ -2500,7 +2529,8 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs, simdoj
             .process_id = queue.process_id,
             .completion_signal = barrier.completion_signal.handle,
             .kind = DispatchPacketKind::NonKernel,
-            .barrier_bit = ((barrier.header >> HSA_PACKET_HEADER_BARRIER) & 1) != 0,
+            .wait_for_predecessors = ((barrier.header >> HSA_PACKET_HEADER_BARRIER) & 1) != 0,
+            .blocks_following = true,
         };
 
         if (queue.xcd_fanout)
@@ -2563,7 +2593,7 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs, simdoj
             .process_id = queue.process_id,
             .completion_signal = sig,
             .kind = DispatchPacketKind::NonKernel,
-            .barrier_bit = ((pkt.header >> HSA_PACKET_HEADER_BARRIER) & 1) != 0,
+            .wait_for_predecessors = ((pkt.header >> HSA_PACKET_HEADER_BARRIER) & 1) != 0,
         };
 
         if (queue.xcd_fanout)
@@ -2637,11 +2667,9 @@ void CommandProcessor::handle_doorbell_sync(simdojo::Tick now) {
                       entries_after - entries_before, entries_after);
   });
 
-  // While the queue mutex is dropped, CU workers may append completions to
-  // new_queue_states_. The shared structure lock remains held, so concurrent
-  // registration/removal cannot invalidate the dispatch loop's vector
-  // references; worker completion callbacks continue to use only the queue
-  // mutex.
+  // While the queue mutex is dropped, CU workers append compact completion
+  // records only. The shared structure lock keeps queue/CU storage stable; once
+  // the batch rejoins, the CP thread applies every stateful retirement action.
   auto run_dispatch_workers = [&]() {
     if (exec_mode_ != simdojo::ExecMode::FUNCTIONAL || dispatch_threads_ <= 1 || !has_active_cus())
       return FunctionalQuantumResult{};
@@ -2650,12 +2678,16 @@ void CommandProcessor::handle_doorbell_sync(simdojo::Tick now) {
     // batch instead of retaining a separate pool for every SPI.
     FunctionalQuantumResult result = run_active_cus_once();
     lock.lock();
+    drain_pending_wg_completions();
     if (completion_)
       completion_->drain_completions(new_queue_states_);
     return result;
   };
 
-  // Phase 1: Dispatch-Execute-Complete loop (functional mode).
+  // Phase 1: Dispatch-Execute-Complete loop (functional mode). Dispatch all
+  // queues that currently have capacity, then execute at most one active-CU
+  // batch. Returning after that batch lets peer components publish state before
+  // a polling wave is resumed by the CP continuation event.
   //
   // Wrapped in a rescan loop. A dependent kernel the host submits *while this
   // handler is executing* is picked up only by the post-loop re-fetch below;
@@ -2685,11 +2717,13 @@ void CommandProcessor::handle_doorbell_sync(simdojo::Tick now) {
         while (qs.next_dispatch_idx < qs.entries.size()) {
           auto &entry = qs.entries[qs.next_dispatch_idx];
 
-          if (entry.barrier_bit && !barrier_satisfied(qs, qs.next_dispatch_idx))
+          if (entry.wait_for_predecessors && !barrier_satisfied(qs, qs.next_dispatch_idx))
             break;
 
           if (entry.is_non_kernel()) {
             entry.completed_wgs = entry.total_wgs;
+            if (completion_)
+              completion_->complete_non_kernel(entry);
             ++qs.next_dispatch_idx;
             if (completion_)
               completion_->drain_completions(new_queue_states_);
@@ -2697,11 +2731,9 @@ void CommandProcessor::handle_doorbell_sync(simdojo::Tick now) {
             continue;
           }
 
-          // Dispatch-execute-retire loop: keep dispatching WGs, activating CUs,
-          // and retiring WFs until the entry is fully dispatched and completed,
-          // or we hit genuine backpressure (no CU can accept any WG).
-          // NOTE: drain_completions may pop entries, so we must re-check indices
-          // after each drain and not hold stale references.
+          // Dispatch WGs until the entry is fully dispatched or all CUs apply
+          // backpressure. Execution is deferred until every queue gets this
+          // dispatch pass, preventing a polling queue from starving its peers.
           uint32_t dispatch_id = entry.dispatch_id;
           bool backpressure = false;
           for (;;) {
@@ -2715,17 +2747,6 @@ void CommandProcessor::handle_doorbell_sync(simdojo::Tick now) {
             if (sent > 0)
               progress = true;
 
-            auto worker_result = run_dispatch_workers();
-            if (worker_result.ran)
-              progress = true;
-            if (worker_result.yielded) {
-              yield_to_event_loop = true;
-              break;
-            }
-
-            if (completion_)
-              completion_->drain_completions(new_queue_states_);
-
             if (qs.next_dispatch_idx >= qs.entries.size())
               break;
             auto &post = qs.entries[qs.next_dispatch_idx];
@@ -2736,13 +2757,11 @@ void CommandProcessor::handle_doorbell_sync(simdojo::Tick now) {
               ++qs.next_dispatch_idx;
               break;
             }
-            if (sent == 0 && !worker_result.ran) {
+            if (sent == 0) {
               backpressure = true;
               break;
             }
           }
-          if (yield_to_event_loop)
-            break;
           if (backpressure)
             break;
         }
@@ -2752,15 +2771,16 @@ void CommandProcessor::handle_doorbell_sync(simdojo::Tick now) {
 
       if (!yield_to_event_loop) {
         auto worker_result = run_dispatch_workers();
-        if (worker_result.ran)
+        if (worker_result.ran) {
           progress = true;
-        if (worker_result.yielded)
           yield_to_event_loop = true;
+        }
       }
     }
 
     // Final drain: catch any entries that became fully_completed during the
-    // last iteration but weren't drained by the re-entrant path.
+    // last worker batch.
+    drain_pending_wg_completions();
     if (completion_)
       completion_->drain_completions(new_queue_states_);
 
@@ -2783,10 +2803,10 @@ void CommandProcessor::handle_doorbell_sync(simdojo::Tick now) {
         for (size_t ei = 0; ei < qs.entries.size(); ++ei) {
           auto &e = qs.entries[ei];
           os << std::format(
-              "\n    [{}] d={} qid={} total_wgs={} disp={} comp={} barrier={} sig={:#x} "
+              "\n    [{}] d={} qid={} total_wgs={} disp={} comp={} wait_pred={} sig={:#x} "
               "non_kern={}",
               ei, e.dispatch_id, e.queue_id, e.total_wgs, e.dispatched_wgs, e.completed_wgs,
-              e.barrier_bit, e.completion_signal, e.is_non_kernel());
+              e.wait_for_predecessors, e.completion_signal, e.is_non_kernel());
         }
       }
     });
@@ -2819,11 +2839,13 @@ void CommandProcessor::handle_doorbell_sync(simdojo::Tick now) {
       auto &qs = new_queue_states_[qi];
       while (qs.next_dispatch_idx < qs.entries.size()) {
         auto &entry = qs.entries[qs.next_dispatch_idx];
-        if (entry.barrier_bit && !barrier_satisfied(qs, qs.next_dispatch_idx))
+        if (entry.wait_for_predecessors && !barrier_satisfied(qs, qs.next_dispatch_idx))
           break;
         if (!entry.is_non_kernel())
           break;
         entry.completed_wgs = entry.total_wgs;
+        if (completion_)
+          completion_->complete_non_kernel(entry);
         ++qs.next_dispatch_idx;
       }
     }
@@ -2850,12 +2872,20 @@ void CommandProcessor::handle_doorbell_sync(simdojo::Tick now) {
     is_primary_ = true;
   }
 
-  for (size_t i = 0; i < cus_.size(); ++i) {
-    if (!cus_[i]->is_idle()) {
-      if (dispatch_ports_[i]->link())
-        dispatch_ports_[i]->send(std::make_unique<simdojo::Message>(simdojo::MessageHeader{}));
-      else
-        cus_[i]->schedule_work();
+  if (dispatch_threads_ > 1) {
+    if (yield_to_event_loop && (has_active_cus() || pending_entries() > 0) &&
+        !dispatch_continuation_pending_) {
+      dispatch_continuation_pending_ = true;
+      schedule_event(&dispatch_continuation_event_, now + 1);
+    }
+  } else {
+    for (size_t i = 0; i < cus_.size(); ++i) {
+      if (!cus_[i]->is_idle()) {
+        if (dispatch_ports_[i]->link())
+          dispatch_ports_[i]->send(std::make_unique<simdojo::Message>(simdojo::MessageHeader{}));
+        else
+          cus_[i]->schedule_work();
+      }
     }
   }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -287,6 +287,10 @@ CommandProcessor::CommandProcessor(std::string name, simdojo::ExecMode exec_mode
   // event must already have a handler when the queue becomes visible.
   doorbell_event_.set_handler(
       [this](simdojo::Tick ts, simdojo::Message *) { handle_doorbell(ts); });
+  dispatch_continuation_event_.set_handler([this](simdojo::Tick ts, simdojo::Message *) {
+    dispatch_continuation_pending_ = false;
+    handle_doorbell_sync(ts);
+  });
 }
 
 CommandProcessor::~CommandProcessor() { stop_doorbell_monitor(); }
@@ -301,10 +305,16 @@ void CommandProcessor::set_dispatch_threads(uint32_t threads) {
   threads = std::max(threads, 1u);
   if (exec_mode_ != simdojo::ExecMode::FUNCTIONAL || plugin_group_->requires_serial_hot_hooks())
     threads = 1;
+  const bool pool_driven = threads > 1;
+  for (auto *cu : cus_)
+    cu->set_pool_driven(pool_driven);
   if (dispatch_threads_ == threads)
     return;
   dispatch_threads_ = threads;
   local_dispatch_pool_.reset();
+  if (!pool_driven)
+    for (auto *cu : cus_)
+      cu->schedule_work();
 }
 
 void CommandProcessor::init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf,
@@ -990,12 +1000,25 @@ bool CommandProcessor::barrier_satisfied(const HwQueueState &qs, size_t idx) con
   if (idx == 0 && !qs.implicit_barrier_next)
     return true;
 
-  // Barrier bit: all prior entries must be fully completed.
+  // Header barrier bit: all prior entries must be fully completed.
   for (size_t i = 0; i < idx; ++i) {
     if (!qs.entries[i].fully_completed())
       return false;
   }
   return true;
+}
+
+void CommandProcessor::drain_pending_wg_completions() {
+  for (const auto completion : pending_wg_completions_) {
+    plugin_group_->onAmdgpuWorkgroupCompleted(completion.dispatch_id, completion.wg_id);
+    for (auto *spi : spis_)
+      if (spi->release_wgp_workgroup(completion.dispatch_id, completion.wg_id))
+        break;
+    mark_cluster_workgroup_complete(completion.dispatch_id, completion.wg_id);
+    if (completion_)
+      completion_->notify_wg_complete(completion.dispatch_id, completion.wg_id, new_queue_states_);
+  }
+  pending_wg_completions_.clear();
 }
 
 void CommandProcessor::register_cluster_workgroup(const DispatchEntry &entry, uint32_t local_wg_id,
@@ -1484,22 +1507,15 @@ uint32_t CommandProcessor::dispatch_workgroups(DispatchEntry &entry) {
 void CommandProcessor::notify_wg_complete(uint32_t dispatch_id, uint32_t wg_id) {
   util::Logger::cp(
       [&](auto &os) { os << std::format("WG_COMPLETE d={} wg={}", dispatch_id, wg_id); });
-  {
-    std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
-    for (auto *spi : spis_)
-      if (spi->release_wgp_workgroup(dispatch_id, wg_id))
-        break;
-  }
-  mark_cluster_workgroup_complete(dispatch_id, wg_id);
-  {
-    std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
+  std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
+  pending_wg_completions_.push_back({dispatch_id, wg_id});
+  if (dispatch_threads_ <= 1) {
+    drain_pending_wg_completions();
     if (completion_) {
-      completion_->notify_wg_complete(dispatch_id, wg_id, new_queue_states_);
       // Without worker fan-out, completion arrives on the CP's engine thread, so
       // retire promptly while another resident dispatch may wait on this signal.
       // Parallel workers must defer draining until their fan-out rejoins the CP.
-      if (dispatch_threads_ <= 1)
-        completion_->drain_completions(new_queue_states_);
+      completion_->drain_completions(new_queue_states_);
     }
   }
 }
@@ -1515,6 +1531,7 @@ void CommandProcessor::on_cu_idle() {
 
   std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
 
+  drain_pending_wg_completions();
   if (completion_)
     completion_->drain_completions(new_queue_states_);
 
@@ -1526,11 +1543,13 @@ void CommandProcessor::on_cu_idle() {
     auto &qs = new_queue_states_[qi];
     while (qs.next_dispatch_idx < qs.entries.size()) {
       auto &e = qs.entries[qs.next_dispatch_idx];
-      if (e.barrier_bit && !barrier_satisfied(qs, qs.next_dispatch_idx))
+      if (e.wait_for_predecessors && !barrier_satisfied(qs, qs.next_dispatch_idx))
         break;
       if (!e.is_non_kernel())
         break;
       e.completed_wgs = e.total_wgs;
+      if (completion_)
+        completion_->complete_non_kernel(e);
       ++qs.next_dispatch_idx;
     }
   }
@@ -1554,7 +1573,7 @@ void CommandProcessor::on_cu_idle() {
     auto &qs = new_queue_states_[qi];
     if (qs.next_dispatch_idx < qs.entries.size()) {
       auto &entry = qs.entries[qs.next_dispatch_idx];
-      if (entry.barrier_bit && !barrier_satisfied(qs, qs.next_dispatch_idx))
+      if (entry.wait_for_predecessors && !barrier_satisfied(qs, qs.next_dispatch_idx))
         continue;
       if (!entry.is_non_kernel() && !entry.fully_dispatched()) {
         uint32_t sent = dispatch_workgroups(entry);
@@ -1584,11 +1603,13 @@ void CommandProcessor::process_queues() {
     while (qs.next_dispatch_idx < qs.entries.size()) {
       auto &entry = qs.entries[qs.next_dispatch_idx];
 
-      if (entry.barrier_bit && !barrier_satisfied(qs, qs.next_dispatch_idx))
+      if (entry.wait_for_predecessors && !barrier_satisfied(qs, qs.next_dispatch_idx))
         break; // Stalled on barrier bit.
 
       if (entry.is_non_kernel()) {
         entry.completed_wgs = entry.total_wgs; // 0 == 0, immediately complete.
+        if (completion_)
+          completion_->complete_non_kernel(entry);
         ++qs.next_dispatch_idx;
         continue;
       }
@@ -1829,7 +1850,7 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
   dp.workgroup_size_z = pkt.workgroup_size_z;
   dp.completion_signal = pkt.completion_signal.handle;
   dp.host_signal = false;
-  dp.barrier_bit = (pkt.header >> HSA_PACKET_HEADER_BARRIER) & 1;
+  dp.wait_for_predecessors = (pkt.header >> HSA_PACKET_HEADER_BARRIER) & 1;
 
   // Process AQL acquire fence: invalidate caches so the kernel sees the
   // latest host/agent writes (kernarg data, input buffers, etc.).
@@ -2103,13 +2124,18 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs, simdoj
           .queue_id = queue.queue_id,
           .process_id = queue.process_id,
           .completion_signal = sig,
-          .barrier_bit = true,
+          .wait_for_predecessors = ((pkt.header >> HSA_PACKET_HEADER_BARRIER) & 1) != 0,
+          .blocks_following = true,
       };
 
+      const bool blocks_following = dp.blocks_following;
       qs.entries.push_back(std::move(dp));
       ++read_idx;
-      process_limit = read_idx;
-      break;
+      if (blocks_following) {
+        process_limit = read_idx;
+        break;
+      }
+      continue;
     } else if (pkt_type == HSA_PACKET_TYPE_VENDOR_SPECIFIC) {
       AmdExtKernelDispatchPacket ext{};
       std::memcpy(&ext, &pkt, sizeof(ext));
@@ -2161,7 +2187,8 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs, simdoj
             .queue_id = queue.queue_id,
             .process_id = queue.process_id,
             .completion_signal = barrier.completion_signal.handle,
-            .barrier_bit = ((barrier.header >> HSA_PACKET_HEADER_BARRIER) & 1) != 0,
+            .wait_for_predecessors = ((barrier.header >> HSA_PACKET_HEADER_BARRIER) & 1) != 0,
+            .blocks_following = true,
         };
 
         qs.entries.push_back(std::move(dp));
@@ -2221,7 +2248,7 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs, simdoj
             .queue_id = queue.queue_id,
             .process_id = queue.process_id,
             .completion_signal = sig,
-            .barrier_bit = ((pkt.header >> HSA_PACKET_HEADER_BARRIER) & 1) != 0,
+            .wait_for_predecessors = ((pkt.header >> HSA_PACKET_HEADER_BARRIER) & 1) != 0,
         };
 
         qs.entries.push_back(std::move(dp));
@@ -2282,11 +2309,9 @@ void CommandProcessor::handle_doorbell_sync(simdojo::Tick now) {
                       entries_after - entries_before, entries_after);
   });
 
-  // While the queue mutex is dropped, CU workers may append completions to
-  // new_queue_states_. The shared structure lock remains held, so concurrent
-  // registration/removal cannot invalidate the dispatch loop's vector
-  // references; worker completion callbacks continue to use only the queue
-  // mutex.
+  // While the queue mutex is dropped, CU workers append compact completion
+  // records only. The shared structure lock keeps queue/CU storage stable; once
+  // the batch rejoins, the CP thread applies every stateful retirement action.
   auto run_dispatch_workers = [&]() {
     if (exec_mode_ != simdojo::ExecMode::FUNCTIONAL || dispatch_threads_ <= 1 || !has_active_cus())
       return FunctionalQuantumResult{};
@@ -2295,12 +2320,16 @@ void CommandProcessor::handle_doorbell_sync(simdojo::Tick now) {
     // batch instead of retaining a separate pool for every SPI.
     FunctionalQuantumResult result = run_active_cus_once();
     lock.lock();
+    drain_pending_wg_completions();
     if (completion_)
       completion_->drain_completions(new_queue_states_);
     return result;
   };
 
-  // Phase 1: Dispatch-Execute-Complete loop (functional mode).
+  // Phase 1: Dispatch-Execute-Complete loop (functional mode). Dispatch all
+  // queues that currently have capacity, then execute at most one active-CU
+  // batch. Returning after that batch lets peer components publish state before
+  // a polling wave is resumed by the CP continuation event.
   //
   // Wrapped in a rescan loop. A dependent kernel the host submits *while this
   // handler is executing* is picked up only by the post-loop re-fetch below;
@@ -2330,11 +2359,13 @@ void CommandProcessor::handle_doorbell_sync(simdojo::Tick now) {
         while (qs.next_dispatch_idx < qs.entries.size()) {
           auto &entry = qs.entries[qs.next_dispatch_idx];
 
-          if (entry.barrier_bit && !barrier_satisfied(qs, qs.next_dispatch_idx))
+          if (entry.wait_for_predecessors && !barrier_satisfied(qs, qs.next_dispatch_idx))
             break;
 
           if (entry.is_non_kernel()) {
             entry.completed_wgs = entry.total_wgs;
+            if (completion_)
+              completion_->complete_non_kernel(entry);
             ++qs.next_dispatch_idx;
             if (completion_)
               completion_->drain_completions(new_queue_states_);
@@ -2342,11 +2373,9 @@ void CommandProcessor::handle_doorbell_sync(simdojo::Tick now) {
             continue;
           }
 
-          // Dispatch-execute-retire loop: keep dispatching WGs, activating CUs,
-          // and retiring WFs until the entry is fully dispatched and completed,
-          // or we hit genuine backpressure (no CU can accept any WG).
-          // NOTE: drain_completions may pop entries, so we must re-check indices
-          // after each drain and not hold stale references.
+          // Dispatch WGs until the entry is fully dispatched or all CUs apply
+          // backpressure. Execution is deferred until every queue gets this
+          // dispatch pass, preventing a polling queue from starving its peers.
           uint32_t dispatch_id = entry.dispatch_id;
           bool backpressure = false;
           for (;;) {
@@ -2360,17 +2389,6 @@ void CommandProcessor::handle_doorbell_sync(simdojo::Tick now) {
             if (sent > 0)
               progress = true;
 
-            auto worker_result = run_dispatch_workers();
-            if (worker_result.ran)
-              progress = true;
-            if (worker_result.yielded) {
-              yield_to_event_loop = true;
-              break;
-            }
-
-            if (completion_)
-              completion_->drain_completions(new_queue_states_);
-
             if (qs.next_dispatch_idx >= qs.entries.size())
               break;
             auto &post = qs.entries[qs.next_dispatch_idx];
@@ -2381,13 +2399,11 @@ void CommandProcessor::handle_doorbell_sync(simdojo::Tick now) {
               ++qs.next_dispatch_idx;
               break;
             }
-            if (sent == 0 && !worker_result.ran) {
+            if (sent == 0) {
               backpressure = true;
               break;
             }
           }
-          if (yield_to_event_loop)
-            break;
           if (backpressure)
             break;
         }
@@ -2397,15 +2413,16 @@ void CommandProcessor::handle_doorbell_sync(simdojo::Tick now) {
 
       if (!yield_to_event_loop) {
         auto worker_result = run_dispatch_workers();
-        if (worker_result.ran)
+        if (worker_result.ran) {
           progress = true;
-        if (worker_result.yielded)
           yield_to_event_loop = true;
+        }
       }
     }
 
     // Final drain: catch any entries that became fully_completed during the
-    // last iteration but weren't drained by the re-entrant path.
+    // last worker batch.
+    drain_pending_wg_completions();
     if (completion_)
       completion_->drain_completions(new_queue_states_);
 
@@ -2464,11 +2481,13 @@ void CommandProcessor::handle_doorbell_sync(simdojo::Tick now) {
       auto &qs = new_queue_states_[qi];
       while (qs.next_dispatch_idx < qs.entries.size()) {
         auto &entry = qs.entries[qs.next_dispatch_idx];
-        if (entry.barrier_bit && !barrier_satisfied(qs, qs.next_dispatch_idx))
+        if (entry.wait_for_predecessors && !barrier_satisfied(qs, qs.next_dispatch_idx))
           break;
         if (!entry.is_non_kernel())
           break;
         entry.completed_wgs = entry.total_wgs;
+        if (completion_)
+          completion_->complete_non_kernel(entry);
         ++qs.next_dispatch_idx;
       }
     }
@@ -2493,12 +2512,20 @@ void CommandProcessor::handle_doorbell_sync(simdojo::Tick now) {
     is_primary_ = true;
   }
 
-  for (size_t i = 0; i < cus_.size(); ++i) {
-    if (!cus_[i]->is_idle()) {
-      if (dispatch_ports_[i]->link())
-        dispatch_ports_[i]->send(std::make_unique<simdojo::Message>(simdojo::MessageHeader{}));
-      else
-        cus_[i]->schedule_work();
+  if (dispatch_threads_ > 1) {
+    if (yield_to_event_loop && (has_active_cus() || pending_entries() > 0) &&
+        !dispatch_continuation_pending_) {
+      dispatch_continuation_pending_ = true;
+      schedule_event(&dispatch_continuation_event_, now + 1);
+    }
+  } else {
+    for (size_t i = 0; i < cus_.size(); ++i) {
+      if (!cus_[i]->is_idle()) {
+        if (dispatch_ports_[i]->link())
+          dispatch_ports_[i]->send(std::make_unique<simdojo::Message>(simdojo::MessageHeader{}));
+        else
+          cus_[i]->schedule_work();
+      }
     }
   }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -832,8 +832,8 @@ void CommandProcessor::set_queue_debug_suspended(uint32_t queue_id, uint32_t pro
           // neither resume path with anything to release.
           if (state.next_dispatch_idx < state.entries.size()) {
             const auto &entry = state.entries[state.next_dispatch_idx];
-            const bool barrier_ready = !entry.wait_for_predecessors ||
-                                       barrier_satisfied(state, state.next_dispatch_idx);
+            const bool barrier_ready =
+                !entry.wait_for_predecessors || barrier_satisfied(state, state.next_dispatch_idx);
             q.debug_work_deferred |=
                 barrier_ready && (entry.is_non_kernel() || !entry.fully_dispatched());
           }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -24,6 +24,7 @@ RJ_DIAGNOSTIC_POP
 #include <bit>
 #include <cassert>
 #include <chrono>
+#include <condition_variable>
 #include <cstring>
 #include <elf.h>
 #include <format>
@@ -280,6 +281,26 @@ uint32_t initial_mode_from_compute_pgm_rsrc1(uint32_t rsrc1, rj_code_arch_t arch
 
 } // namespace
 
+CommandProcessor::CommandProcessor(std::string name) : simdojo::Component(std::move(name)) {
+  // register_queue() may start the doorbell monitor before startup(), so the
+  // event must already have a handler when the queue becomes visible.
+  doorbell_event_.set_handler(
+      [this](simdojo::Tick ts, simdojo::Message *) { handle_doorbell(ts); });
+}
+
+CommandProcessor::~CommandProcessor() { stop_doorbell_monitor(); }
+
+void CommandProcessor::set_dispatch_threads(uint32_t threads) {
+  threads = std::max(threads, 1u);
+  if (plugin_group_->requires_serial_hot_hooks())
+    threads = 1;
+  if (dispatch_threads_ == threads)
+    return;
+  dispatch_threads_ = threads;
+  for (auto *spi : spis_)
+    spi->reset_dispatch_pool();
+}
+
 void CommandProcessor::init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf,
                                            const DispatchEntry &pkt, uint32_t global_wg_id,
                                            uint32_t wf_index_in_wg) {
@@ -529,9 +550,7 @@ void CommandProcessor::startup() {
   for ([[maybe_unused]] const auto *cu : cus_)
     assert(cu->partition_id() == partition_id() &&
            "CommandProcessor and its compute units must share one partition");
-  // doorbell_event_'s handler is bound in the constructor (see there) so it is live
-  // before register_queue() can start the poll thread; nothing to (re)bind here.
-  completion_ = std::make_unique<CompletionTracker>(memory_, cus_);
+  completion_ = std::make_unique<CompletionTracker>(memory_, cus_, l2_caches_);
   completion_->set_plugin_group(plugin_group_);
   completion_->set_dispatch_retired_callback(
       [this](const DispatchEntry &entry) { erase_cluster_workgroups(entry.dispatch_id); });
@@ -558,6 +577,7 @@ void CommandProcessor::register_queue(HwQueue queue) {
   });
   bool start_poll = queue.host_accessible;
   {
+    std::unique_lock<std::shared_mutex> structure_lock(queue_structure_mutex_);
     std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
     HwQueueState qs{};
     qs.queue_desc_va = queue.queue_desc_va;
@@ -627,6 +647,7 @@ bool CommandProcessor::signal_queue_exception(uint32_t queue_id, uint32_t proces
 
 void CommandProcessor::unregister_queue(uint32_t queue_id, uint32_t process_id) {
   {
+    std::unique_lock<std::shared_mutex> structure_lock(queue_structure_mutex_);
     // Holds hw_queue_mutex_ across with_wave_state_locked(), which is the order
     // the dispatch path uses too (handle_doorbell -> dispatch_workgroups ->
     // dispatch_wf). Nothing takes them the other way any more: a wave reaching
@@ -1446,6 +1467,7 @@ uint32_t CommandProcessor::dispatch_workgroups(DispatchEntry &entry) {
     if (!dispatch_to_placement(local_wg_id, global_wg_id, *placement))
       throw std::runtime_error("dispatch_wf failed after workgroup placement was reserved");
   }
+
   return dispatched;
 }
 
@@ -1465,8 +1487,14 @@ void CommandProcessor::notify_wg_complete(uint32_t dispatch_id, uint32_t wg_id) 
   mark_cluster_workgroup_complete(dispatch_id, wg_id);
   {
     std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
-    if (completion_)
+    if (completion_) {
       completion_->notify_wg_complete(dispatch_id, wg_id, new_queue_states_);
+      // Without worker fan-out, completion arrives on the CP's engine thread, so
+      // retire promptly while another resident dispatch may wait on this signal.
+      // Parallel workers must defer draining until their fan-out rejoins the CP.
+      if (dispatch_threads_ <= 1)
+        completion_->drain_completions(new_queue_states_);
+    }
   }
 }
 
@@ -1566,6 +1594,14 @@ void CommandProcessor::process_queues() {
         break; // CU backpressure.
     }
   }
+}
+
+bool CommandProcessor::has_active_cus() const {
+  for (auto *cu : cus_) {
+    if (cu->has_active_wfs())
+      return true;
+  }
+  return false;
 }
 
 rocr::llvm::amdhsa::kernel_descriptor_t
@@ -1762,10 +1798,8 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
   // latest host/agent writes (kernarg data, input buffers, etc.).
   // On real hardware the CP issues GL1_INV + GL2_INV for SYSTEM/AGENT scope.
   uint32_t acquire_scope = (pkt.header >> HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE) & 0x3;
-  if (acquire_scope >= HSA_FENCE_SCOPE_AGENT && !cus_.empty()) {
-    for (auto *cu : cus_)
-      cu->flush_all(queue.process_id);
-  }
+  if (acquire_scope >= HSA_FENCE_SCOPE_AGENT && !cus_.empty() && completion_)
+    completion_->flush_caches(queue.process_id);
 
   std::string kernel_symbol;
   if (host_accessible && memory_) {
@@ -2032,10 +2066,13 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs, simdoj
           .queue_id = queue.queue_id,
           .process_id = queue.process_id,
           .completion_signal = sig,
-          .barrier_bit = ((pkt.header >> HSA_PACKET_HEADER_BARRIER) & 1) != 0,
+          .barrier_bit = true,
       };
 
       qs.entries.push_back(std::move(dp));
+      ++read_idx;
+      process_limit = read_idx;
+      break;
     } else if (pkt_type == HSA_PACKET_TYPE_VENDOR_SPECIFIC) {
       AmdExtKernelDispatchPacket ext{};
       std::memcpy(&ext, &pkt, sizeof(ext));
@@ -2171,18 +2208,22 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs, simdoj
   queue.fetch_cursor = process_limit;
 }
 
-void CommandProcessor::handle_doorbell(simdojo::Tick now) {
+void CommandProcessor::handle_doorbell(simdojo::Tick timestamp) {
   doorbell_handle_count_.fetch_add(1, std::memory_order_relaxed);
+  handle_doorbell_sync(timestamp);
+}
+
+void CommandProcessor::handle_doorbell_sync(simdojo::Tick now) {
   // Release so the doorbell poll thread's acquire-load cannot observe a stale
   // "pending" after this handler has re-fetched; pairs with the release-stores at
   // the INVALID-packet and barrier/dependency stall sites. A site that is still
   // unsatisfied on this pass re-sets its flag below, re-arming the paced re-check.
   invalid_pending_.store(false, std::memory_order_release);
   stall_pending_.store(false, std::memory_order_release);
+  std::shared_lock<std::shared_mutex> structure_lock(queue_structure_mutex_);
+  std::unique_lock<std::recursive_mutex> lock(hw_queue_mutex_);
   util::Logger::cp(
       [&](auto &os) { os << std::format("{}: DOORBELL queues={}", name(), hw_queues_.size()); });
-
-  std::unique_lock<std::recursive_mutex> lock(hw_queue_mutex_);
 
   size_t entries_before = 0;
   for (auto &qs : new_queue_states_)
@@ -2204,127 +2245,219 @@ void CommandProcessor::handle_doorbell(simdojo::Tick now) {
                       entries_after - entries_before, entries_after);
   });
 
-  // Phase 1: Dispatch-Execute-Complete loop (functional mode).
-  bool progress = true;
-  while (progress) {
-    progress = false;
+  // While the queue mutex is dropped, CU workers may append completions to
+  // new_queue_states_. The shared structure lock remains held, so concurrent
+  // registration/removal cannot invalidate the dispatch loop's vector
+  // references; worker completion callbacks continue to use only the queue
+  // mutex.
+  auto run_dispatch_workers = [&]() {
+    if (dispatch_threads_ <= 1 || !has_active_cus())
+      return FunctionalQuantumResult{};
+    lock.unlock();
+    // Wavefront execution is driven by the SPIs, which own the worker pools;
+    // the CP only orchestrates queue fetch, dispatch, and completion. SPI-less
+    // topologies (direct add_compute_unit test harnesses) fall back to driving
+    // the CUs directly.
+    FunctionalQuantumResult result;
+    if (!spis_.empty()) {
+      for (auto *spi : spis_)
+        result.merge(spi->run_active_cus_once(dispatch_threads_));
+    } else {
+      for (auto *cu : cus_) {
+        if (cu->has_active_wfs())
+          result.merge(cu->run_quantum());
+      }
+    }
+    lock.lock();
+    if (completion_)
+      completion_->drain_completions(new_queue_states_);
+    return result;
+  };
 
+  // Phase 1: Dispatch-Execute-Complete loop (functional mode).
+  //
+  // Wrapped in a rescan loop. A dependent kernel the host submits *while this
+  // handler is executing* is picked up only by the post-loop re-fetch below;
+  // without re-running the dispatch loop it would be stranded un-dispatched,
+  // blocking in-order completion of the trailing barrier packets and hanging the
+  // waiting host forever (the doorbell that delivered it was already consumed by
+  // scan_doorbells, so no further handle_doorbell fires). This races at any
+  // thread count — the resume paths that would otherwise catch it (on_cu_idle at
+  // T=1, the synchronous pool drain at T>1) have all finished by the time the
+  // late packet arrives — but the window is widest with multi-dispatch IREE
+  // kernels at dispatch thread counts > 1. After each re-fetch we rescan and
+  // re-run this loop when new packets arrived.
+  bool rescan = true;
+  bool first_pass = true;
+  bool yield_to_event_loop = false;
+  while (rescan) {
+    bool progress = true;
+    while (progress && !yield_to_event_loop) {
+      progress = false;
+
+      for (size_t qi = 0; qi < hw_queues_.size(); ++qi) {
+        if (hw_queues_[qi].is_sdma || hw_queues_[qi].debug_suspended ||
+            hw_queues_[qi].runtime_suspended)
+          continue;
+        auto &qs = new_queue_states_[qi];
+
+        while (qs.next_dispatch_idx < qs.entries.size()) {
+          auto &entry = qs.entries[qs.next_dispatch_idx];
+
+          if (entry.barrier_bit && !barrier_satisfied(qs, qs.next_dispatch_idx))
+            break;
+
+          if (entry.is_non_kernel()) {
+            entry.completed_wgs = entry.total_wgs;
+            ++qs.next_dispatch_idx;
+            if (completion_)
+              completion_->drain_completions(new_queue_states_);
+            progress = true;
+            continue;
+          }
+
+          // Dispatch-execute-retire loop: keep dispatching WGs, activating CUs,
+          // and retiring WFs until the entry is fully dispatched and completed,
+          // or we hit genuine backpressure (no CU can accept any WG).
+          // NOTE: drain_completions may pop entries, so we must re-check indices
+          // after each drain and not hold stale references.
+          uint32_t dispatch_id = entry.dispatch_id;
+          bool backpressure = false;
+          for (;;) {
+            if (qs.next_dispatch_idx >= qs.entries.size())
+              break;
+            auto &cur = qs.entries[qs.next_dispatch_idx];
+            if (cur.dispatch_id != dispatch_id)
+              break;
+
+            uint32_t sent = dispatch_workgroups(cur);
+            if (sent > 0)
+              progress = true;
+
+            auto worker_result = run_dispatch_workers();
+            if (worker_result.ran)
+              progress = true;
+            if (worker_result.yielded) {
+              yield_to_event_loop = true;
+              break;
+            }
+
+            if (completion_)
+              completion_->drain_completions(new_queue_states_);
+
+            if (qs.next_dispatch_idx >= qs.entries.size())
+              break;
+            auto &post = qs.entries[qs.next_dispatch_idx];
+            if (post.dispatch_id != dispatch_id)
+              break;
+
+            if (post.fully_dispatched()) {
+              ++qs.next_dispatch_idx;
+              break;
+            }
+            if (sent == 0 && !worker_result.ran) {
+              backpressure = true;
+              break;
+            }
+          }
+          if (yield_to_event_loop)
+            break;
+          if (backpressure)
+            break;
+        }
+        if (yield_to_event_loop)
+          break;
+      }
+
+      if (!yield_to_event_loop) {
+        auto worker_result = run_dispatch_workers();
+        if (worker_result.ran)
+          progress = true;
+        if (worker_result.yielded)
+          yield_to_event_loop = true;
+      }
+    }
+
+    // Final drain: catch any entries that became fully_completed during the
+    // last iteration but weren't drained by the re-entrant path.
+    if (completion_)
+      completion_->drain_completions(new_queue_states_);
+
+    util::Logger::cp([&](auto &os) {
+      size_t remaining = 0;
+      for (auto &qs : new_queue_states_)
+        remaining += qs.entries.size();
+      uint32_t active_cus = 0;
+      for (auto *cu : cus_)
+        if (cu->has_active_wfs())
+          ++active_cus;
+      os << std::format("{}: PHASE1_DONE remaining={} active_cus={}/{}", name(), remaining,
+                        active_cus, cus_.size());
+      for (size_t qi = 0; qi < new_queue_states_.size(); ++qi) {
+        auto &qs = new_queue_states_[qi];
+        if (qs.entries.empty())
+          continue;
+        os << std::format("\n  queue[{}] entries={} next_disp={} implicit_barrier={}", qi,
+                          qs.entries.size(), qs.next_dispatch_idx, qs.implicit_barrier_next);
+        for (size_t ei = 0; ei < qs.entries.size(); ++ei) {
+          auto &e = qs.entries[ei];
+          os << std::format(
+              "\n    [{}] d={} qid={} total_wgs={} disp={} comp={} barrier={} sig={:#x} "
+              "non_kern={}",
+              ei, e.dispatch_id, e.queue_id, e.total_wgs, e.dispatched_wgs, e.completed_wgs,
+              e.barrier_bit, e.completion_signal, e.is_non_kernel());
+        }
+      }
+    });
+
+    if (yield_to_event_loop)
+      break;
+
+    // Re-fetch: pick up any packets the host submitted while we were executing
+    // (e.g., barrier packets queued after a kernel dispatch). Process them
+    // immediately so host signal waits see completed barriers before returning.
+    //
+    // SDMA queues are re-fetched only on the first pass. The compute (AQL) re-fetch
+    // is clamped to last_doorbell so repeating it is safe, but the SDMA path reads
+    // the live doorbell value and would read ahead of an observed doorbell —
+    // re-polling the ring across rescan iterations races with the host's
+    // concurrent ring writes (torn packet -> bad copy). Late *kernel* packets,
+    // which is all the rescan needs, only arrive on the compute queue anyway;
+    // SDMA packets are picked up by their own doorbell-driven passes.
+    const uint32_t dispatch_id_before_refetch = next_dispatch_id_;
+    for (size_t i = 0; i < hw_queues_.size(); ++i) {
+      if (hw_queues_[i].is_sdma && !first_pass)
+        continue;
+      fetch_from_queue(hw_queues_[i], new_queue_states_[i], now);
+    }
+    first_pass = false;
+    // Process any new non-kernel entries (barriers with total_wgs==0).
     for (size_t qi = 0; qi < hw_queues_.size(); ++qi) {
-      if (hw_queues_[qi].is_sdma || hw_queues_[qi].debug_suspended ||
-          hw_queues_[qi].runtime_suspended)
+      if (hw_queues_[qi].debug_suspended || hw_queues_[qi].runtime_suspended)
         continue;
       auto &qs = new_queue_states_[qi];
-
       while (qs.next_dispatch_idx < qs.entries.size()) {
         auto &entry = qs.entries[qs.next_dispatch_idx];
-
         if (entry.barrier_bit && !barrier_satisfied(qs, qs.next_dispatch_idx))
           break;
-
-        if (entry.is_non_kernel()) {
-          entry.completed_wgs = entry.total_wgs;
-          ++qs.next_dispatch_idx;
-          if (completion_)
-            completion_->drain_completions(new_queue_states_);
-          progress = true;
-          continue;
-        }
-
-        // Dispatch-execute-retire loop: keep dispatching WGs, activating CUs,
-        // and retiring WFs until the entry is fully dispatched and completed,
-        // or we hit genuine backpressure (no CU can accept any WG).
-        // NOTE: drain_completions may pop entries, so we must re-check indices
-        // after each drain and not hold stale references.
-        uint32_t dispatch_id = entry.dispatch_id;
-        bool backpressure = false;
-        for (;;) {
-          if (qs.next_dispatch_idx >= qs.entries.size())
-            break;
-          auto &cur = qs.entries[qs.next_dispatch_idx];
-          if (cur.dispatch_id != dispatch_id)
-            break;
-
-          uint32_t sent = dispatch_workgroups(cur);
-          if (sent > 0)
-            progress = true;
-
-          if (completion_)
-            completion_->drain_completions(new_queue_states_);
-
-          if (qs.next_dispatch_idx >= qs.entries.size())
-            break;
-          auto &post = qs.entries[qs.next_dispatch_idx];
-          if (post.dispatch_id != dispatch_id)
-            break;
-
-          if (post.fully_dispatched()) {
-            ++qs.next_dispatch_idx;
-            break;
-          }
-          if (sent == 0) {
-            backpressure = true;
-            break;
-          }
-        }
-        if (backpressure)
+        if (!entry.is_non_kernel())
           break;
+        entry.completed_wgs = entry.total_wgs;
+        ++qs.next_dispatch_idx;
       }
     }
-  }
+    if (completion_)
+      completion_->drain_completions(new_queue_states_);
 
-  // Final drain: catch any entries that became fully_completed during the
-  // last iteration but weren't drained by the re-entrant path.
-  if (completion_)
-    completion_->drain_completions(new_queue_states_);
-
-  util::Logger::cp([&](auto &os) {
-    size_t remaining = 0;
-    for (auto &qs : new_queue_states_)
-      remaining += qs.entries.size();
-    uint32_t active_cus = 0;
-    for (auto *cu : cus_)
-      if (cu->has_active_wfs())
-        ++active_cus;
-    os << std::format("{}: PHASE1_DONE remaining={} active_cus={}/{}", name(), remaining,
-                      active_cus, cus_.size());
-    for (size_t qi = 0; qi < new_queue_states_.size(); ++qi) {
-      auto &qs = new_queue_states_[qi];
-      if (qs.entries.empty())
-        continue;
-      os << std::format("\n  queue[{}] entries={} next_disp={} implicit_barrier={}", qi,
-                        qs.entries.size(), qs.next_dispatch_idx, qs.implicit_barrier_next);
-      for (size_t ei = 0; ei < qs.entries.size(); ++ei) {
-        auto &e = qs.entries[ei];
-        os << std::format(
-            "\n    [{}] d={} qid={} total_wgs={} disp={} comp={} barrier={} sig={:#x} non_kern={}",
-            ei, e.dispatch_id, e.queue_id, e.total_wgs, e.dispatched_wgs, e.completed_wgs,
-            e.barrier_bit, e.completion_signal, e.is_non_kernel());
-      }
-    }
-  });
-
-  // Re-fetch: pick up any packets the host submitted while we were executing
-  // (e.g., barrier packets queued after a kernel dispatch). Process them
-  // immediately so host signal waits see completed barriers before returning.
-  for (size_t i = 0; i < hw_queues_.size(); ++i)
-    fetch_from_queue(hw_queues_[i], new_queue_states_[i], now);
-  // Process any new non-kernel entries (barriers with total_wgs==0).
-  for (size_t qi = 0; qi < hw_queues_.size(); ++qi) {
-    if (hw_queues_[qi].debug_suspended || hw_queues_[qi].runtime_suspended)
-      continue;
-    auto &qs = new_queue_states_[qi];
-    while (qs.next_dispatch_idx < qs.entries.size()) {
-      auto &entry = qs.entries[qs.next_dispatch_idx];
-      if (entry.barrier_bit && !barrier_satisfied(qs, qs.next_dispatch_idx))
-        break;
-      if (!entry.is_non_kernel())
-        break;
-      entry.completed_wgs = entry.total_wgs;
-      ++qs.next_dispatch_idx;
-    }
-  }
-  if (completion_)
-    completion_->drain_completions(new_queue_states_);
+    // Re-run Phase 1 only if the re-fetch actually pulled in NEW packets
+    // (next_dispatch_id_ advances exactly once per fetched packet). Gating on new
+    // packets — rather than "a dispatchable entry still exists" — is what
+    // guarantees termination: a kernel held back by CU backpressure stays
+    // "dispatchable" but creates no new dispatch ids, so it cannot spin the loop.
+    // New arrivals are finite: they are bounded by host submissions, which are
+    // themselves gated on the completion signals we deliver here.
+    rescan = (next_dispatch_id_ != dispatch_id_before_refetch);
+  } // while (rescan)
 
   // Register as primary on first dispatch (internal test queues only).
   // KFD queues rely on the VM-level primary registered at rj_vm.cpp.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -281,7 +281,8 @@ uint32_t initial_mode_from_compute_pgm_rsrc1(uint32_t rsrc1, rj_code_arch_t arch
 
 } // namespace
 
-CommandProcessor::CommandProcessor(std::string name) : simdojo::Component(std::move(name)) {
+CommandProcessor::CommandProcessor(std::string name, simdojo::ExecMode exec_mode)
+    : simdojo::Component(std::move(name)), exec_mode_(exec_mode) {
   // register_queue() may start the doorbell monitor before startup(), so the
   // event must already have a handler when the queue becomes visible.
   doorbell_event_.set_handler(
@@ -290,15 +291,20 @@ CommandProcessor::CommandProcessor(std::string name) : simdojo::Component(std::m
 
 CommandProcessor::~CommandProcessor() { stop_doorbell_monitor(); }
 
+void CommandProcessor::set_shared_dispatch_pool(CpuDispatchPool *pool) {
+  shared_dispatch_pool_ = pool;
+  if (shared_dispatch_pool_)
+    local_dispatch_pool_.reset();
+}
+
 void CommandProcessor::set_dispatch_threads(uint32_t threads) {
   threads = std::max(threads, 1u);
-  if (plugin_group_->requires_serial_hot_hooks())
+  if (exec_mode_ != simdojo::ExecMode::FUNCTIONAL || plugin_group_->requires_serial_hot_hooks())
     threads = 1;
   if (dispatch_threads_ == threads)
     return;
   dispatch_threads_ = threads;
-  for (auto *spi : spis_)
-    spi->reset_dispatch_pool();
+  local_dispatch_pool_.reset();
 }
 
 void CommandProcessor::init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf,
@@ -1604,6 +1610,37 @@ bool CommandProcessor::has_active_cus() const {
   return false;
 }
 
+FunctionalQuantumResult CommandProcessor::run_active_cus_once() {
+  active_cu_scratch_.clear();
+  if (!spis_.empty()) {
+    for (auto *spi : spis_)
+      spi->append_active_cus(active_cu_scratch_);
+  } else {
+    for (auto *cu : cus_) {
+      if (cu->has_active_wfs())
+        active_cu_scratch_.push_back(cu);
+    }
+  }
+
+  if (active_cu_scratch_.empty())
+    return {};
+
+  uint32_t effective_threads =
+      std::min<uint32_t>(dispatch_threads_, static_cast<uint32_t>(active_cu_scratch_.size()));
+  if (shared_dispatch_pool_)
+    return shared_dispatch_pool_->run(active_cu_scratch_, effective_threads);
+  if (effective_threads > 1) {
+    if (!local_dispatch_pool_ || local_dispatch_pool_->thread_count() < effective_threads)
+      local_dispatch_pool_ = std::make_unique<CpuDispatchPool>(effective_threads);
+    return local_dispatch_pool_->run(active_cu_scratch_, effective_threads);
+  }
+
+  FunctionalQuantumResult result;
+  for (auto *cu : active_cu_scratch_)
+    result.merge(cu->run_quantum());
+  return result;
+}
+
 rocr::llvm::amdhsa::kernel_descriptor_t
 CommandProcessor::read_kernel_descriptor(uint64_t kernel_object, uint32_t vmid,
                                          [[maybe_unused]] bool host_accessible) {
@@ -2251,23 +2288,12 @@ void CommandProcessor::handle_doorbell_sync(simdojo::Tick now) {
   // references; worker completion callbacks continue to use only the queue
   // mutex.
   auto run_dispatch_workers = [&]() {
-    if (dispatch_threads_ <= 1 || !has_active_cus())
+    if (exec_mode_ != simdojo::ExecMode::FUNCTIONAL || dispatch_threads_ <= 1 || !has_active_cus())
       return FunctionalQuantumResult{};
     lock.unlock();
-    // Wavefront execution is driven by the SPIs, which own the worker pools;
-    // the CP only orchestrates queue fetch, dispatch, and completion. SPI-less
-    // topologies (direct add_compute_unit test harnesses) fall back to driving
-    // the CUs directly.
-    FunctionalQuantumResult result;
-    if (!spis_.empty()) {
-      for (auto *spi : spis_)
-        result.merge(spi->run_active_cus_once(dispatch_threads_));
-    } else {
-      for (auto *cu : cus_) {
-        if (cu->has_active_wfs())
-          result.merge(cu->run_quantum());
-      }
-    }
+    // One shared pool and thread budget covers the CP's complete active-CU
+    // batch instead of retaining a separate pool for every SPI.
+    FunctionalQuantumResult result = run_active_cus_once();
     lock.lock();
     if (completion_)
       completion_->drain_completions(new_queue_states_);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -1081,6 +1081,25 @@ void CommandProcessor::drain_pending_wg_completions() {
   pending_wg_completions_.clear();
 }
 
+void CommandProcessor::drain_pending_cluster_barrier_completions() {
+  std::vector<PendingClusterBarrierCompletion> completions;
+  {
+    std::lock_guard<std::recursive_mutex> lock(cluster_placements_mutex_);
+    completions.swap(pending_cluster_barrier_completions_);
+  }
+
+  for (auto &completion : completions) {
+    std::vector<Wavefront *> members;
+    for (auto [cu, peer_wg_id] : completion.peers) {
+      auto peer_members =
+          cu->complete_barrier(completion.dispatch_id, peer_wg_id, completion.completion_bit);
+      members.insert(members.end(), peer_members.begin(), peer_members.end());
+    }
+    if (!members.empty())
+      plugin_group_->onAmdgpuBarrierResolved(std::span<Wavefront *>(members));
+  }
+}
+
 void CommandProcessor::register_cluster_workgroup(const DispatchEntry &entry, uint32_t local_wg_id,
                                                   uint32_t global_wg_id, ComputeUnitCore *cu,
                                                   uint32_t lds_base) {
@@ -1167,7 +1186,6 @@ uint32_t CommandProcessor::cluster_barrier_state(const Wavefront &wf, int32_t ba
 
 bool CommandProcessor::cluster_barrier_signal(Wavefront &wf, int32_t barrier_id) {
   bool is_first = false;
-  std::vector<std::pair<ComputeUnitCore *, uint32_t>> peers;
   const uint8_t completion_bit = static_cast<uint8_t>(-barrier_id);
   {
     std::lock_guard<std::recursive_mutex> lock(cluster_placements_mutex_);
@@ -1185,21 +1203,22 @@ bool CommandProcessor::cluster_barrier_signal(Wavefront &wf, int32_t barrier_id)
       return is_first;
 
     barriers->signaled_workgroups[index].clear();
+    PendingClusterBarrierCompletion completion{wf.dispatch_id(), completion_bit, {}};
+    auto &peers = completion.peers;
     peers.reserve(placement->peer_wg_ids.size());
     for (uint32_t peer_wg_id : placement->peer_wg_ids) {
       auto peer = cluster_wg_placements_.find(wg_key(wf.dispatch_id(), peer_wg_id));
       if (peer != cluster_wg_placements_.end() && peer->second.cu)
         peers.emplace_back(peer->second.cu, peer_wg_id);
     }
+    pending_cluster_barrier_completions_.push_back(std::move(completion));
   }
 
-  std::vector<Wavefront *> members;
-  for (auto [cu, peer_wg_id] : peers) {
-    auto peer_members = cu->complete_barrier(wf.dispatch_id(), peer_wg_id, completion_bit);
-    members.insert(members.end(), peer_members.begin(), peer_members.end());
-  }
-  if (!members.empty())
-    plugin_group_->onAmdgpuBarrierResolved(std::span<Wavefront *>(members));
+  // In serial mode this instruction already runs on the CP/engine thread, so
+  // preserve immediate barrier resolution. Pool workers leave the compact
+  // record queued until the fan-out rejoins below.
+  if (dispatch_threads_ <= 1)
+    drain_pending_cluster_barrier_completions();
   return is_first;
 }
 
@@ -1591,6 +1610,7 @@ void CommandProcessor::on_cu_idle() {
 
   std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
 
+  drain_pending_cluster_barrier_completions();
   drain_pending_wg_completions();
   if (completion_)
     completion_->drain_completions(new_queue_states_);
@@ -2416,6 +2436,7 @@ void CommandProcessor::handle_doorbell_sync(simdojo::Tick now) {
     // batch instead of retaining a separate pool for every SPI.
     FunctionalQuantumResult result = run_active_cus_once(now);
     lock.lock();
+    drain_pending_cluster_barrier_completions();
     drain_pending_wg_completions();
     if (completion_)
       completion_->drain_completions(new_queue_states_);
@@ -2518,6 +2539,7 @@ void CommandProcessor::handle_doorbell_sync(simdojo::Tick now) {
 
     // Final drain: catch any entries that became fully_completed during the
     // last worker batch.
+    drain_pending_cluster_barrier_completions();
     drain_pending_wg_completions();
     if (completion_)
       completion_->drain_completions(new_queue_states_);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -287,8 +287,11 @@ CommandProcessor::CommandProcessor(std::string name, simdojo::ExecMode exec_mode
   // event must already have a handler when the queue becomes visible.
   doorbell_event_.set_handler(
       [this](simdojo::Tick ts, simdojo::Message *) { handle_doorbell(ts); });
-  dispatch_continuation_event_.set_handler([this](simdojo::Tick ts, simdojo::Message *) {
+  dispatch_continuation_event_.set_handler([this](simdojo::Tick ts, simdojo::Message *message) {
+    if (!message || message->payload() != dispatch_continuation_generation_)
+      return;
     dispatch_continuation_pending_ = false;
+    dispatch_continuation_tick_ = simdojo::TICK_MAX;
     handle_doorbell_sync(ts);
   });
 }
@@ -305,16 +308,73 @@ void CommandProcessor::set_dispatch_threads(uint32_t threads) {
   threads = std::max(threads, 1u);
   if (exec_mode_ != simdojo::ExecMode::FUNCTIONAL || plugin_group_->requires_serial_hot_hooks())
     threads = 1;
-  const bool pool_driven = threads > 1;
-  for (auto *cu : cus_)
-    cu->set_pool_driven(pool_driven);
   if (dispatch_threads_ == threads)
     return;
+
+  const bool was_pool_driven = dispatch_threads_ > 1;
+  const bool pool_driven = threads > 1;
   dispatch_threads_ = threads;
   local_dispatch_pool_.reset();
-  if (!pool_driven)
+
+  if (was_pool_driven == pool_driven) {
     for (auto *cu : cus_)
-      cu->schedule_work();
+      cu->set_pool_driven(pool_driven);
+    return;
+  }
+
+  simdojo::Tick now = 0;
+  if (engine())
+    now = engine()->context(partition_id()).current_tick();
+
+  if (pool_driven) {
+    pooled_due_ticks_.clear();
+    for (auto *cu : cus_) {
+      const simdojo::Tick serial_due = cu->suspend_scheduled_work();
+      cu->set_pool_driven(true);
+      if (cu->has_active_wfs()) {
+        simdojo::Tick tick = serial_due == simdojo::TICK_MAX ? now + 1 : serial_due;
+        if (tick < now)
+          tick = now + 1;
+        pooled_due_ticks_[cu] = tick;
+      }
+    }
+    const simdojo::Tick next = next_pooled_due_tick(now);
+    if (next != simdojo::TICK_MAX)
+      arm_dispatch_continuation(next);
+    return;
+  }
+
+  cancel_dispatch_continuation();
+  for (auto *cu : cus_) {
+    cu->set_pool_driven(false);
+    if (!cu->has_active_wfs())
+      continue;
+    auto due = pooled_due_ticks_.find(cu);
+    simdojo::Tick tick = due == pooled_due_ticks_.end() ? now + 1 : due->second;
+    if (tick < now)
+      tick = now + 1;
+    cu->schedule_work_at(tick);
+  }
+  pooled_due_ticks_.clear();
+}
+
+void CommandProcessor::arm_dispatch_continuation(simdojo::Tick tick) {
+  if (!engine())
+    return;
+  if (dispatch_continuation_pending_ && dispatch_continuation_tick_ <= tick)
+    return;
+
+  dispatch_continuation_pending_ = true;
+  dispatch_continuation_tick_ = tick;
+  const uintptr_t generation = ++dispatch_continuation_generation_;
+  schedule_event(&dispatch_continuation_event_, tick,
+                 std::make_unique<simdojo::Message>(simdojo::MessageHeader{}, generation));
+}
+
+void CommandProcessor::cancel_dispatch_continuation() {
+  dispatch_continuation_pending_ = false;
+  dispatch_continuation_tick_ = simdojo::TICK_MAX;
+  ++dispatch_continuation_generation_;
 }
 
 void CommandProcessor::init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf,
@@ -772,8 +832,8 @@ void CommandProcessor::set_queue_debug_suspended(uint32_t queue_id, uint32_t pro
           // neither resume path with anything to release.
           if (state.next_dispatch_idx < state.entries.size()) {
             const auto &entry = state.entries[state.next_dispatch_idx];
-            const bool barrier_ready =
-                !entry.barrier_bit || barrier_satisfied(state, state.next_dispatch_idx);
+            const bool barrier_ready = !entry.wait_for_predecessors ||
+                                       barrier_satisfied(state, state.next_dispatch_idx);
             q.debug_work_deferred |=
                 barrier_ready && (entry.is_non_kernel() || !entry.fully_dispatched());
           }
@@ -1631,7 +1691,28 @@ bool CommandProcessor::has_active_cus() const {
   return false;
 }
 
-FunctionalQuantumResult CommandProcessor::run_active_cus_once() {
+void CommandProcessor::refresh_pooled_due_ticks(simdojo::Tick now) {
+  for (auto it = pooled_due_ticks_.begin(); it != pooled_due_ticks_.end();) {
+    if (!it->first->has_active_wfs())
+      it = pooled_due_ticks_.erase(it);
+    else
+      ++it;
+  }
+  for (auto *cu : cus_)
+    if (cu->has_active_wfs())
+      pooled_due_ticks_.try_emplace(cu, now + 1);
+}
+
+simdojo::Tick CommandProcessor::next_pooled_due_tick(simdojo::Tick now) {
+  refresh_pooled_due_ticks(now);
+  simdojo::Tick next = simdojo::TICK_MAX;
+  for (const auto &[_, tick] : pooled_due_ticks_)
+    next = std::min(next, tick);
+  return next;
+}
+
+FunctionalQuantumResult CommandProcessor::run_active_cus_once(simdojo::Tick now) {
+  refresh_pooled_due_ticks(now);
   active_cu_scratch_.clear();
   if (!spis_.empty()) {
     for (auto *spi : spis_)
@@ -1642,23 +1723,38 @@ FunctionalQuantumResult CommandProcessor::run_active_cus_once() {
         active_cu_scratch_.push_back(cu);
     }
   }
+  std::erase_if(active_cu_scratch_, [&](ComputeUnitCore *cu) {
+    auto due = pooled_due_ticks_.find(cu);
+    return due == pooled_due_ticks_.end() || due->second > now;
+  });
 
   if (active_cu_scratch_.empty())
     return {};
 
+  quantum_result_scratch_.resize(active_cu_scratch_.size());
   uint32_t effective_threads =
       std::min<uint32_t>(dispatch_threads_, static_cast<uint32_t>(active_cu_scratch_.size()));
+  FunctionalQuantumResult result;
   if (shared_dispatch_pool_)
-    return shared_dispatch_pool_->run(active_cu_scratch_, effective_threads);
-  if (effective_threads > 1) {
+    result =
+        shared_dispatch_pool_->run(active_cu_scratch_, effective_threads, quantum_result_scratch_);
+  else if (effective_threads > 1) {
     if (!local_dispatch_pool_ || local_dispatch_pool_->thread_count() < effective_threads)
       local_dispatch_pool_ = std::make_unique<CpuDispatchPool>(effective_threads);
-    return local_dispatch_pool_->run(active_cu_scratch_, effective_threads);
+    result =
+        local_dispatch_pool_->run(active_cu_scratch_, effective_threads, quantum_result_scratch_);
+  } else {
+    quantum_result_scratch_.front() = active_cu_scratch_.front()->run_quantum();
+    result = quantum_result_scratch_.front();
   }
 
-  FunctionalQuantumResult result;
-  for (auto *cu : active_cu_scratch_)
-    result.merge(cu->run_quantum());
+  for (size_t i = 0; i < active_cu_scratch_.size(); ++i) {
+    auto *cu = active_cu_scratch_[i];
+    if (cu->has_active_wfs())
+      pooled_due_ticks_[cu] = now + std::max<uint64_t>(1, quantum_result_scratch_[i].iterations);
+    else
+      pooled_due_ticks_.erase(cu);
+  }
   return result;
 }
 
@@ -2318,7 +2414,7 @@ void CommandProcessor::handle_doorbell_sync(simdojo::Tick now) {
     lock.unlock();
     // One shared pool and thread budget covers the CP's complete active-CU
     // batch instead of retaining a separate pool for every SPI.
-    FunctionalQuantumResult result = run_active_cus_once();
+    FunctionalQuantumResult result = run_active_cus_once(now);
     lock.lock();
     drain_pending_wg_completions();
     if (completion_)
@@ -2445,10 +2541,10 @@ void CommandProcessor::handle_doorbell_sync(simdojo::Tick now) {
         for (size_t ei = 0; ei < qs.entries.size(); ++ei) {
           auto &e = qs.entries[ei];
           os << std::format(
-              "\n    [{}] d={} qid={} total_wgs={} disp={} comp={} barrier={} sig={:#x} "
+              "\n    [{}] d={} qid={} total_wgs={} disp={} comp={} wait_pred={} sig={:#x} "
               "non_kern={}",
               ei, e.dispatch_id, e.queue_id, e.total_wgs, e.dispatched_wgs, e.completed_wgs,
-              e.barrier_bit, e.completion_signal, e.is_non_kernel());
+              e.wait_for_predecessors, e.completion_signal, e.is_non_kernel());
         }
       }
     });
@@ -2513,11 +2609,11 @@ void CommandProcessor::handle_doorbell_sync(simdojo::Tick now) {
   }
 
   if (dispatch_threads_ > 1) {
-    if (yield_to_event_loop && (has_active_cus() || pending_entries() > 0) &&
-        !dispatch_continuation_pending_) {
-      dispatch_continuation_pending_ = true;
-      schedule_event(&dispatch_continuation_event_, now + 1);
-    }
+    const simdojo::Tick next = next_pooled_due_tick(now);
+    if (next != simdojo::TICK_MAX)
+      arm_dispatch_continuation(next);
+    else
+      cancel_dispatch_continuation();
   } else {
     for (size_t i = 0; i < cus_.size(); ++i) {
       if (!cus_[i]->is_idle()) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
@@ -541,7 +541,11 @@ private:
   void process_queues();
 
   bool has_active_cus() const;
-  FunctionalQuantumResult run_active_cus_once();
+  FunctionalQuantumResult run_active_cus_once(simdojo::Tick now);
+  void refresh_pooled_due_ticks(simdojo::Tick now);
+  simdojo::Tick next_pooled_due_tick(simdojo::Tick now);
+  void arm_dispatch_continuation(simdojo::Tick tick);
+  void cancel_dispatch_continuation();
 
   /// @brief Called from CU on_idle callback. In functional mode with quantum>0,
   /// checks for stalled dispatches that can resume.
@@ -646,6 +650,8 @@ private:
   CpuDispatchPool *shared_dispatch_pool_ = nullptr;
   std::unique_ptr<CpuDispatchPool> local_dispatch_pool_;
   std::vector<ComputeUnitCore *> active_cu_scratch_;
+  std::vector<FunctionalQuantumResult> quantum_result_scratch_;
+  std::unordered_map<ComputeUnitCore *, simdojo::Tick> pooled_due_ticks_;
 
   struct PendingWorkgroupCompletion {
     uint32_t dispatch_id = 0;
@@ -684,6 +690,8 @@ private:
   simdojo::Event doorbell_event_{this, simdojo::EventType::TIMER_CALLBACK};
   simdojo::Event dispatch_continuation_event_{this, simdojo::EventType::TIMER_CALLBACK};
   bool dispatch_continuation_pending_ = false;
+  simdojo::Tick dispatch_continuation_tick_ = simdojo::TICK_MAX;
+  uintptr_t dispatch_continuation_generation_ = 0;
   // Guards changes to the shape of hw_queues_ and new_queue_states_. The
   // dispatch handler holds a shared lock while worker execution temporarily
   // releases hw_queue_mutex_, keeping its vector references stable.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
@@ -39,6 +39,7 @@
 #include <limits>
 #include <memory>
 #include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -124,16 +125,8 @@ enum class SdmaPacketDialect {
 /// not on global CU idle. Signals fire in per-queue submission order.
 class CommandProcessor : public simdojo::Component {
 public:
-  explicit CommandProcessor(std::string name) : simdojo::Component(std::move(name)) {
-    // Bind the doorbell handler at construction, not in startup(): register_queue()
-    // may start the doorbell poll thread (which fires doorbell_event_ via
-    // schedule_event_now) as soon as a host-accessible queue is registered, which can
-    // happen before startup() runs. Binding here removes that ordering hazard — a
-    // handlerless doorbell_event_ would be silently dropped by the engine.
-    doorbell_event_.set_handler(
-        [this](simdojo::Tick ts, simdojo::Message *) { handle_doorbell(ts); });
-  }
-  ~CommandProcessor() override { stop_doorbell_monitor(); }
+  explicit CommandProcessor(std::string name);
+  ~CommandProcessor() override;
 
   void set_memory(GpuMemory *mem) { memory_ = mem; }
   void add_l2_cache(L2Cache *l2) {
@@ -149,6 +142,8 @@ public:
   SdmaPacketDialect sdma_packet_dialect() const { return sdma_packet_dialect_; }
   /// @brief Configure launch and packet behavior derived from the GPU architecture.
   void configure_for_arch(rj_code_arch_t arch);
+  void set_dispatch_threads(uint32_t threads);
+  uint32_t dispatch_threads() const { return dispatch_threads_; }
   /// @brief Update doorbell_base for all queues belonging to a process.
   /// @details Called when the doorbell page is mmap'd after queue creation.
   void set_doorbell_base(uint32_t process_id, void *base);
@@ -218,6 +213,7 @@ public:
     if (completion_) {
       completion_->set_plugin_group(plugin_group_);
     }
+    set_dispatch_threads(dispatch_threads_);
   }
 
   void add_spi(ShaderProcessorInput *spi) { spis_.push_back(spi); }
@@ -539,12 +535,16 @@ private:
   /// @brief Process all queues: dispatch undispatched entries, handle non-kernel entries.
   void process_queues();
 
+  bool has_active_cus() const;
+
   /// @brief Called from CU on_idle callback. In functional mode with quantum>0,
   /// checks for stalled dispatches that can resume.
   void on_cu_idle();
 
   /// @brief Queue scheduling: select next queue with undispatched entries.
   HwQueueState *schedule_next_queue();
+
+  void handle_doorbell_sync(simdojo::Tick timestamp);
 
   /// @brief Check if barrier is satisfied for an entry.
   bool barrier_satisfied(const HwQueueState &qs, size_t idx) const;
@@ -635,6 +635,7 @@ private:
   uint32_t dispatch_id_base_ = 1;
   size_t total_dispatched_ = 0;
   std::atomic<uint64_t> dispatched_workgroups_{0};
+  uint32_t dispatch_threads_ = 1;
 
   struct ClusterWorkgroupPlacement {
     ComputeUnitCore *cu = nullptr;
@@ -665,6 +666,10 @@ private:
   std::unordered_map<uint64_t, ClusterBarrierState> cluster_barriers_;
 
   simdojo::Event doorbell_event_{this, simdojo::EventType::TIMER_CALLBACK};
+  // Guards changes to the shape of hw_queues_ and new_queue_states_. The
+  // dispatch handler holds a shared lock while worker execution temporarily
+  // releases hw_queue_mutex_, keeping its vector references stable.
+  std::shared_mutex queue_structure_mutex_;
   mutable std::recursive_mutex hw_queue_mutex_;
 
   std::shared_ptr<ExecutionPluginGroup> plugin_group_ = ExecutionPluginGroup::empty_group();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
@@ -525,6 +525,7 @@ private:
   bool find_valid_cluster_barrier_locked(const Wavefront &wf, int32_t barrier_id,
                                          const ClusterWorkgroupPlacement *&placement,
                                          const ClusterBarrierState *&barriers) const;
+  void drain_pending_cluster_barrier_completions();
   void drain_pending_wg_completions();
   void mark_cluster_workgroup_complete(uint32_t dispatch_id, uint32_t wg_id);
   void erase_cluster_workgroup(uint32_t dispatch_id, uint32_t wg_id);
@@ -658,6 +659,13 @@ private:
     uint32_t wg_id = 0;
   };
   std::vector<PendingWorkgroupCompletion> pending_wg_completions_;
+
+  struct PendingClusterBarrierCompletion {
+    uint32_t dispatch_id = 0;
+    uint8_t completion_bit = 0;
+    std::vector<std::pair<ComputeUnitCore *, uint32_t>> peers;
+  };
+  std::vector<PendingClusterBarrierCompletion> pending_cluster_barrier_completions_;
 
   struct ClusterWorkgroupPlacement {
     ComputeUnitCore *cu = nullptr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
@@ -232,6 +232,7 @@ public:
         std::max(scratch_shader_engine_count_, cu->shader_engine_id() + 1);
     scratch_waves_per_se_ =
         std::max(scratch_waves_per_se_, cu->scratch_scoreboard_base() + cu->num_wf_slots());
+    cu->set_pool_driven(dispatch_threads_ > 1);
     cu->set_command_processor(this);
     cu->set_on_idle([this]() { on_cu_idle(); });
   }
@@ -524,6 +525,7 @@ private:
   bool find_valid_cluster_barrier_locked(const Wavefront &wf, int32_t barrier_id,
                                          const ClusterWorkgroupPlacement *&placement,
                                          const ClusterBarrierState *&barriers) const;
+  void drain_pending_wg_completions();
   void mark_cluster_workgroup_complete(uint32_t dispatch_id, uint32_t wg_id);
   void erase_cluster_workgroup(uint32_t dispatch_id, uint32_t wg_id);
   void erase_cluster_workgroups(uint32_t dispatch_id);
@@ -645,6 +647,12 @@ private:
   std::unique_ptr<CpuDispatchPool> local_dispatch_pool_;
   std::vector<ComputeUnitCore *> active_cu_scratch_;
 
+  struct PendingWorkgroupCompletion {
+    uint32_t dispatch_id = 0;
+    uint32_t wg_id = 0;
+  };
+  std::vector<PendingWorkgroupCompletion> pending_wg_completions_;
+
   struct ClusterWorkgroupPlacement {
     ComputeUnitCore *cu = nullptr;
     uint32_t lds_base = 0;
@@ -674,6 +682,8 @@ private:
   std::unordered_map<uint64_t, ClusterBarrierState> cluster_barriers_;
 
   simdojo::Event doorbell_event_{this, simdojo::EventType::TIMER_CALLBACK};
+  simdojo::Event dispatch_continuation_event_{this, simdojo::EventType::TIMER_CALLBACK};
+  bool dispatch_continuation_pending_ = false;
   // Guards changes to the shape of hw_queues_ and new_queue_states_. The
   // dispatch handler holds a shared lock while worker execution temporarily
   // releases hw_queue_mutex_, keeping its vector references stable.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
@@ -23,6 +23,7 @@
 #include "rocjitsu/vm/amdgpu/cluster_lds_multicast.h"
 #include "rocjitsu/vm/amdgpu/completion_tracker.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/cpu_dispatch_pool.h"
 #include "rocjitsu/vm/amdgpu/dispatch_entry.h"
 #include "rocjitsu/vm/amdgpu/gpu_memory.h"
 #include "rocjitsu/vm/amdgpu/l2_cache.h"
@@ -125,7 +126,8 @@ enum class SdmaPacketDialect {
 /// not on global CU idle. Signals fire in per-queue submission order.
 class CommandProcessor : public simdojo::Component {
 public:
-  explicit CommandProcessor(std::string name);
+  explicit CommandProcessor(std::string name,
+                            simdojo::ExecMode exec_mode = simdojo::ExecMode::FUNCTIONAL);
   ~CommandProcessor() override;
 
   void set_memory(GpuMemory *mem) { memory_ = mem; }
@@ -142,6 +144,7 @@ public:
   SdmaPacketDialect sdma_packet_dialect() const { return sdma_packet_dialect_; }
   /// @brief Configure launch and packet behavior derived from the GPU architecture.
   void configure_for_arch(rj_code_arch_t arch);
+  void set_shared_dispatch_pool(CpuDispatchPool *pool);
   void set_dispatch_threads(uint32_t threads);
   uint32_t dispatch_threads() const { return dispatch_threads_; }
   /// @brief Update doorbell_base for all queues belonging to a process.
@@ -536,6 +539,7 @@ private:
   void process_queues();
 
   bool has_active_cus() const;
+  FunctionalQuantumResult run_active_cus_once();
 
   /// @brief Called from CU on_idle callback. In functional mode with quantum>0,
   /// checks for stalled dispatches that can resume.
@@ -635,7 +639,11 @@ private:
   uint32_t dispatch_id_base_ = 1;
   size_t total_dispatched_ = 0;
   std::atomic<uint64_t> dispatched_workgroups_{0};
+  simdojo::ExecMode exec_mode_ = simdojo::ExecMode::FUNCTIONAL;
   uint32_t dispatch_threads_ = 1;
+  CpuDispatchPool *shared_dispatch_pool_ = nullptr;
+  std::unique_ptr<CpuDispatchPool> local_dispatch_pool_;
+  std::vector<ComputeUnitCore *> active_cu_scratch_;
 
   struct ClusterWorkgroupPlacement {
     ComputeUnitCore *cu = nullptr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
@@ -235,6 +235,7 @@ public:
     cu->set_pool_driven(dispatch_threads_ > 1);
     cu->set_command_processor(this);
     cu->set_on_idle([this]() { on_cu_idle(); });
+    cu->set_on_pool_ready([this, cu]() { on_cu_pool_ready(cu); });
   }
 
   void startup() override;
@@ -541,7 +542,7 @@ private:
   /// @brief Process all queues: dispatch undispatched entries, handle non-kernel entries.
   void process_queues();
 
-  bool has_active_cus() const;
+  bool has_runnable_cus() const;
   FunctionalQuantumResult run_active_cus_once(simdojo::Tick now);
   void refresh_pooled_due_ticks(simdojo::Tick now);
   simdojo::Tick next_pooled_due_tick(simdojo::Tick now);
@@ -551,6 +552,9 @@ private:
   /// @brief Called from CU on_idle callback. In functional mode with quantum>0,
   /// checks for stalled dispatches that can resume.
   void on_cu_idle();
+
+  /// @brief Wake the CP-owned functional driver after a pooled CU becomes runnable.
+  void on_cu_pool_ready(ComputeUnitCore *cu);
 
   /// @brief Queue scheduling: select next queue with undispatched entries.
   HwQueueState *schedule_next_queue();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
@@ -38,6 +38,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -106,16 +107,8 @@ enum class SdmaPacketDialect {
 /// not on global CU idle. Signals fire in per-queue submission order.
 class CommandProcessor : public simdojo::Component {
 public:
-  explicit CommandProcessor(std::string name) : simdojo::Component(std::move(name)) {
-    // Bind the doorbell handler at construction, not in startup(): register_queue()
-    // may start the doorbell poll thread (which fires doorbell_event_ via
-    // schedule_event_now) as soon as a host-accessible queue is registered, which can
-    // happen before startup() runs. Binding here removes that ordering hazard — a
-    // handlerless doorbell_event_ would be silently dropped by the engine.
-    doorbell_event_.set_handler(
-        [this](simdojo::Tick ts, simdojo::Message *) { handle_doorbell(ts); });
-  }
-  ~CommandProcessor() override { stop_doorbell_monitor(); }
+  explicit CommandProcessor(std::string name);
+  ~CommandProcessor() override;
 
   void set_memory(GpuMemory *mem) { memory_ = mem; }
   void add_l2_cache(L2Cache *l2) {
@@ -133,6 +126,8 @@ public:
   SdmaPacketDialect sdma_packet_dialect() const { return sdma_packet_dialect_; }
   /// @brief Configure launch and packet behavior derived from the GPU architecture.
   void configure_for_arch(rj_code_arch_t arch);
+  void set_dispatch_threads(uint32_t threads);
+  uint32_t dispatch_threads() const { return dispatch_threads_; }
   /// @brief Update doorbell_base for all queues belonging to a process.
   /// @details Called when the doorbell page is mmap'd after queue creation.
   void set_doorbell_base(uint32_t process_id, void *base);
@@ -175,6 +170,7 @@ public:
     if (completion_) {
       completion_->set_plugin_group(plugin_group_);
     }
+    set_dispatch_threads(dispatch_threads_);
   }
 
   void add_spi(ShaderProcessorInput *spi) { spis_.push_back(spi); }
@@ -347,12 +343,16 @@ private:
   /// @brief Process all queues: dispatch undispatched entries, handle non-kernel entries.
   void process_queues();
 
+  bool has_active_cus() const;
+
   /// @brief Called from CU on_idle callback. In functional mode with quantum>0,
   /// checks for stalled dispatches that can resume.
   void on_cu_idle();
 
   /// @brief Queue scheduling: select next queue with undispatched entries.
   HwQueueState *schedule_next_queue();
+
+  void handle_doorbell_sync(simdojo::Tick timestamp);
 
   /// @brief Check if barrier is satisfied for an entry.
   bool barrier_satisfied(const HwQueueState &qs, size_t idx) const;
@@ -408,6 +408,7 @@ private:
   uint32_t next_dispatch_id_ = 1;
   size_t total_dispatched_ = 0;
   std::atomic<uint64_t> dispatched_workgroups_{0};
+  uint32_t dispatch_threads_ = 1;
 
   struct ClusterWorkgroupPlacement {
     ComputeUnitCore *cu = nullptr;
@@ -438,6 +439,10 @@ private:
   std::unordered_map<uint64_t, ClusterBarrierState> cluster_barriers_;
 
   simdojo::Event doorbell_event_{this, simdojo::EventType::TIMER_CALLBACK};
+  // Guards changes to the shape of hw_queues_ and new_queue_states_. The
+  // dispatch handler holds a shared lock while worker execution temporarily
+  // releases hw_queue_mutex_, keeping its vector references stable.
+  std::shared_mutex queue_structure_mutex_;
   std::recursive_mutex hw_queue_mutex_;
 
   std::shared_ptr<ExecutionPluginGroup> plugin_group_ = ExecutionPluginGroup::empty_group();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
@@ -349,7 +349,11 @@ private:
   void process_queues();
 
   bool has_active_cus() const;
-  FunctionalQuantumResult run_active_cus_once();
+  FunctionalQuantumResult run_active_cus_once(simdojo::Tick now);
+  void refresh_pooled_due_ticks(simdojo::Tick now);
+  simdojo::Tick next_pooled_due_tick(simdojo::Tick now);
+  void arm_dispatch_continuation(simdojo::Tick tick);
+  void cancel_dispatch_continuation();
 
   /// @brief Called from CU on_idle callback. In functional mode with quantum>0,
   /// checks for stalled dispatches that can resume.
@@ -419,6 +423,8 @@ private:
   CpuDispatchPool *shared_dispatch_pool_ = nullptr;
   std::unique_ptr<CpuDispatchPool> local_dispatch_pool_;
   std::vector<ComputeUnitCore *> active_cu_scratch_;
+  std::vector<FunctionalQuantumResult> quantum_result_scratch_;
+  std::unordered_map<ComputeUnitCore *, simdojo::Tick> pooled_due_ticks_;
 
   struct PendingWorkgroupCompletion {
     uint32_t dispatch_id = 0;
@@ -457,6 +463,8 @@ private:
   simdojo::Event doorbell_event_{this, simdojo::EventType::TIMER_CALLBACK};
   simdojo::Event dispatch_continuation_event_{this, simdojo::EventType::TIMER_CALLBACK};
   bool dispatch_continuation_pending_ = false;
+  simdojo::Tick dispatch_continuation_tick_ = simdojo::TICK_MAX;
+  uintptr_t dispatch_continuation_generation_ = 0;
   // Guards changes to the shape of hw_queues_ and new_queue_states_. The
   // dispatch handler holds a shared lock while worker execution temporarily
   // releases hw_queue_mutex_, keeping its vector references stable.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
@@ -185,6 +185,7 @@ public:
                                                 simdojo::PortProtocol::DISPATCH);
     dispatch_ports_.push_back(add_port(std::move(port)));
     cus_.push_back(cu);
+    cu->set_pool_driven(dispatch_threads_ > 1);
     cu->set_command_processor(this);
     cu->set_on_idle([this]() { on_cu_idle(); });
   }
@@ -332,6 +333,7 @@ private:
   bool find_valid_cluster_barrier_locked(const Wavefront &wf, int32_t barrier_id,
                                          const ClusterWorkgroupPlacement *&placement,
                                          const ClusterBarrierState *&barriers) const;
+  void drain_pending_wg_completions();
   void mark_cluster_workgroup_complete(uint32_t dispatch_id, uint32_t wg_id);
   void erase_cluster_workgroup(uint32_t dispatch_id, uint32_t wg_id);
   void erase_cluster_workgroups(uint32_t dispatch_id);
@@ -418,6 +420,12 @@ private:
   std::unique_ptr<CpuDispatchPool> local_dispatch_pool_;
   std::vector<ComputeUnitCore *> active_cu_scratch_;
 
+  struct PendingWorkgroupCompletion {
+    uint32_t dispatch_id = 0;
+    uint32_t wg_id = 0;
+  };
+  std::vector<PendingWorkgroupCompletion> pending_wg_completions_;
+
   struct ClusterWorkgroupPlacement {
     ComputeUnitCore *cu = nullptr;
     uint32_t lds_base = 0;
@@ -447,6 +455,8 @@ private:
   std::unordered_map<uint64_t, ClusterBarrierState> cluster_barriers_;
 
   simdojo::Event doorbell_event_{this, simdojo::EventType::TIMER_CALLBACK};
+  simdojo::Event dispatch_continuation_event_{this, simdojo::EventType::TIMER_CALLBACK};
+  bool dispatch_continuation_pending_ = false;
   // Guards changes to the shape of hw_queues_ and new_queue_states_. The
   // dispatch handler holds a shared lock while worker execution temporarily
   // releases hw_queue_mutex_, keeping its vector references stable.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
@@ -23,6 +23,7 @@
 #include "rocjitsu/vm/amdgpu/cluster_lds_multicast.h"
 #include "rocjitsu/vm/amdgpu/completion_tracker.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/cpu_dispatch_pool.h"
 #include "rocjitsu/vm/amdgpu/dispatch_entry.h"
 #include "rocjitsu/vm/amdgpu/gpu_memory.h"
 #include "rocjitsu/vm/amdgpu/l2_cache.h"
@@ -107,7 +108,8 @@ enum class SdmaPacketDialect {
 /// not on global CU idle. Signals fire in per-queue submission order.
 class CommandProcessor : public simdojo::Component {
 public:
-  explicit CommandProcessor(std::string name);
+  explicit CommandProcessor(std::string name,
+                            simdojo::ExecMode exec_mode = simdojo::ExecMode::FUNCTIONAL);
   ~CommandProcessor() override;
 
   void set_memory(GpuMemory *mem) { memory_ = mem; }
@@ -126,6 +128,7 @@ public:
   SdmaPacketDialect sdma_packet_dialect() const { return sdma_packet_dialect_; }
   /// @brief Configure launch and packet behavior derived from the GPU architecture.
   void configure_for_arch(rj_code_arch_t arch);
+  void set_shared_dispatch_pool(CpuDispatchPool *pool);
   void set_dispatch_threads(uint32_t threads);
   uint32_t dispatch_threads() const { return dispatch_threads_; }
   /// @brief Update doorbell_base for all queues belonging to a process.
@@ -344,6 +347,7 @@ private:
   void process_queues();
 
   bool has_active_cus() const;
+  FunctionalQuantumResult run_active_cus_once();
 
   /// @brief Called from CU on_idle callback. In functional mode with quantum>0,
   /// checks for stalled dispatches that can resume.
@@ -408,7 +412,11 @@ private:
   uint32_t next_dispatch_id_ = 1;
   size_t total_dispatched_ = 0;
   std::atomic<uint64_t> dispatched_workgroups_{0};
+  simdojo::ExecMode exec_mode_ = simdojo::ExecMode::FUNCTIONAL;
   uint32_t dispatch_threads_ = 1;
+  CpuDispatchPool *shared_dispatch_pool_ = nullptr;
+  std::unique_ptr<CpuDispatchPool> local_dispatch_pool_;
+  std::vector<ComputeUnitCore *> active_cu_scratch_;
 
   struct ClusterWorkgroupPlacement {
     ComputeUnitCore *cu = nullptr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
@@ -333,6 +333,7 @@ private:
   bool find_valid_cluster_barrier_locked(const Wavefront &wf, int32_t barrier_id,
                                          const ClusterWorkgroupPlacement *&placement,
                                          const ClusterBarrierState *&barriers) const;
+  void drain_pending_cluster_barrier_completions();
   void drain_pending_wg_completions();
   void mark_cluster_workgroup_complete(uint32_t dispatch_id, uint32_t wg_id);
   void erase_cluster_workgroup(uint32_t dispatch_id, uint32_t wg_id);
@@ -431,6 +432,13 @@ private:
     uint32_t wg_id = 0;
   };
   std::vector<PendingWorkgroupCompletion> pending_wg_completions_;
+
+  struct PendingClusterBarrierCompletion {
+    uint32_t dispatch_id = 0;
+    uint8_t completion_bit = 0;
+    std::vector<std::pair<ComputeUnitCore *, uint32_t>> peers;
+  };
+  std::vector<PendingClusterBarrierCompletion> pending_cluster_barrier_completions_;
 
   struct ClusterWorkgroupPlacement {
     ComputeUnitCore *cu = nullptr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
@@ -216,7 +216,6 @@ public:
     if (completion_) {
       completion_->set_plugin_group(plugin_group_);
     }
-    set_dispatch_threads(dispatch_threads_);
   }
 
   void add_spi(ShaderProcessorInput *spi) { spis_.push_back(spi); }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/completion_tracker.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/completion_tracker.cpp
@@ -6,6 +6,7 @@
 #include "rocjitsu/vm/amdgpu/hsa_clock.h"
 
 #include "rocjitsu/base/rj_compiler.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
 RJ_DIAGNOSTIC_PUSH
 RJ_DIAGNOSTIC_IGNORE_PEDANTIC
 #include "hsa/amd_hsa_queue.h"
@@ -17,6 +18,7 @@ RJ_DIAGNOSTIC_POP
 #include <atomic>
 #include <cstring>
 #include <format>
+#include <set>
 
 namespace rocjitsu {
 namespace amdgpu {
@@ -31,7 +33,9 @@ void CompletionTracker::notify_wg_complete(uint32_t dispatch_id, uint32_t wg_id,
           os << std::format("CT: wg_complete d={} wg={} completed={}/{}", dispatch_id, wg_id,
                             entry.completed_wgs, entry.total_wgs);
         });
-        drain_completions(queues);
+        // Completion callbacks can run from CU worker threads. The CP drains
+        // completions after dispatch fan-out rejoins, keeping cache flushes and
+        // signal firing on the CP path.
         return;
       }
     }
@@ -169,8 +173,16 @@ void CompletionTracker::fire_queue_idle_signal(uint64_t queue_desc_va, uint32_t 
 }
 
 void CompletionTracker::flush_caches(uint32_t vmid) {
-  for (auto *cu : cus_)
-    cu->flush_all(vmid);
+  std::set<L2Cache *> flushed_l2s;
+  for (auto *cu : cus_) {
+    cu->flush_l1(vmid);
+    if (auto *l2 = cu->l2(); l2 && flushed_l2s.insert(l2).second)
+      l2->flush_all(vmid);
+  }
+  for (auto *l2 : l2_caches_) {
+    if (l2 && flushed_l2s.insert(l2).second)
+      l2->flush_all(vmid);
+  }
 }
 
 bool CompletionTracker::all_complete(const std::vector<HwQueueState> &queues) const {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/completion_tracker.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/completion_tracker.cpp
@@ -55,44 +55,9 @@ void CompletionTracker::drain_completions(std::vector<HwQueueState> &queues) {
                           entry.completed_wgs, entry.total_wgs, entry.completion_signal);
       });
 
-      // Publish this XCD's share only after its own caches are flushed. The
-      // release in publish_share() pairs with the acquire in grid_retired(), so
-      // the XCD that fires the signal cannot do so while another XCD's results
-      // are still sitting in its caches.
-      // Both are done exactly once per entry. A shard that finished ahead of its
-      // siblings stays parked at the head of this queue below, so the loop
-      // re-enters on it every time the tracker drains; re-flushing every CU of the
-      // XCD on each of those passes would be pure waste.
-      if (!entry.grid_share_published) {
-        // Latch only after the flush actually ran. flush_caches walks every CU and
-        // writes back; if it threw, latching first would leave this share forever
-        // unpublished and park the owner on a grid that can never retire.
-        flush_caches(entry.process_id);
-        entry.grid_share_published = true;
-        // publish_share elects a single caller as the one whose share completed
-        // the grid, so the wake happens once rather than once per racing XCD.
-        if (entry.grid_completion && entry.grid_completion->publish_share(entry.total_wgs) &&
-            grid_retired_cb_)
-          grid_retired_cb_(entry);
-      }
-
-      // Every XCD holds the head of its queue until the dispatch is done
-      // device-wide, peers included. Popping a peer's shard as soon as its own
-      // share finished would erase the only evidence that the packet is still
-      // outstanding, and barrier_satisfied() -- which inspects the entries still
-      // sitting ahead of a barrier'd packet -- would then let this XCD start the
-      // next packet while a sibling was still running this one.
-      if (!entry.grid_fully_completed())
+      deliver_completion(entry);
+      if (!entry.completion_notified)
         break;
-
-      // Only the XCD that read the packet reports the dispatch and signals it.
-      // The retired callback is per-XCD local cleanup, so every XCD runs it.
-      if (!entry.fanout_peer) {
-        plugin_group_->onAmdgpuDispatchExecutionEnd(entry.dispatch_id);
-        if (entry.completion_signal != 0) {
-          fire_signal(entry);
-        }
-      }
       if (dispatch_retired_cb_)
         dispatch_retired_cb_(entry);
 
@@ -114,6 +79,39 @@ void CompletionTracker::drain_completions(std::vector<HwQueueState> &queues) {
         interrupt_cb_(last_process_id, 0);
     }
   }
+}
+
+void CompletionTracker::complete_non_kernel(DispatchEntry &entry) {
+  if (entry.is_non_kernel())
+    deliver_completion(entry);
+}
+
+void CompletionTracker::deliver_completion(DispatchEntry &entry) {
+  if (entry.completion_notified)
+    return;
+
+  // Publish this XCD's share only after its own caches are flushed. The release
+  // in publish_share() pairs with the acquire in grid_retired(), so the signal
+  // cannot fire while another XCD's results remain in its caches.
+  if (!entry.grid_share_published) {
+    flush_caches(entry.process_id);
+    entry.grid_share_published = true;
+    if (entry.grid_completion && entry.grid_completion->publish_share(entry.total_wgs) &&
+        grid_retired_cb_)
+      grid_retired_cb_(entry);
+  }
+
+  // A completed local shard remains queued until all peer XCD shares retire.
+  if (!entry.grid_fully_completed())
+    return;
+
+  // Only the XCD that read the packet reports completion and fires its signal.
+  if (!entry.fanout_peer) {
+    plugin_group_->onAmdgpuDispatchExecutionEnd(entry.dispatch_id);
+    if (entry.completion_signal != 0)
+      fire_signal(entry);
+  }
+  entry.completion_notified = true;
 }
 
 void CompletionTracker::fire_queue_idle_signal(uint64_t queue_desc_va, uint32_t process_id) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/completion_tracker.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/completion_tracker.cpp
@@ -6,6 +6,7 @@
 #include "rocjitsu/vm/amdgpu/hsa_clock.h"
 
 #include "rocjitsu/base/rj_compiler.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
 RJ_DIAGNOSTIC_PUSH
 RJ_DIAGNOSTIC_IGNORE_PEDANTIC
 #include "hsa/amd_hsa_queue.h"
@@ -17,6 +18,7 @@ RJ_DIAGNOSTIC_POP
 #include <atomic>
 #include <cstring>
 #include <format>
+#include <set>
 
 namespace rocjitsu {
 namespace amdgpu {
@@ -31,7 +33,9 @@ void CompletionTracker::notify_wg_complete(uint32_t dispatch_id, uint32_t wg_id,
           os << std::format("CT: wg_complete d={} wg={} completed={}/{}", dispatch_id, wg_id,
                             entry.completed_wgs, entry.total_wgs);
         });
-        drain_completions(queues);
+        // Completion callbacks can run from CU worker threads. The CP drains
+        // completions after dispatch fan-out rejoins, keeping cache flushes and
+        // signal firing on the CP path.
         return;
       }
     }
@@ -133,8 +137,16 @@ void CompletionTracker::fire_queue_idle_signal(uint64_t queue_desc_va, uint32_t 
 }
 
 void CompletionTracker::flush_caches(uint32_t vmid) {
-  for (auto *cu : cus_)
-    cu->flush_all(vmid);
+  std::set<L2Cache *> flushed_l2s;
+  for (auto *cu : cus_) {
+    cu->flush_l1(vmid);
+    if (auto *l2 = cu->l2(); l2 && flushed_l2s.insert(l2).second)
+      l2->flush_all(vmid);
+  }
+  for (auto *l2 : l2_caches_) {
+    if (l2 && flushed_l2s.insert(l2).second)
+      l2->flush_all(vmid);
+  }
 }
 
 bool CompletionTracker::all_complete(const std::vector<HwQueueState> &queues) const {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/completion_tracker.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/completion_tracker.cpp
@@ -55,11 +55,7 @@ void CompletionTracker::drain_completions(std::vector<HwQueueState> &queues) {
                           entry.completed_wgs, entry.total_wgs, entry.completion_signal);
       });
 
-      flush_caches(entry.process_id);
-      plugin_group_->onAmdgpuDispatchExecutionEnd(entry.dispatch_id);
-      if (entry.completion_signal != 0) {
-        fire_signal(entry);
-      }
+      deliver_completion(entry);
       if (dispatch_retired_cb_)
         dispatch_retired_cb_(entry);
 
@@ -78,6 +74,21 @@ void CompletionTracker::drain_completions(std::vector<HwQueueState> &queues) {
         interrupt_cb_(last_process_id, 0);
     }
   }
+}
+
+void CompletionTracker::complete_non_kernel(DispatchEntry &entry) {
+  if (entry.is_non_kernel())
+    deliver_completion(entry);
+}
+
+void CompletionTracker::deliver_completion(DispatchEntry &entry) {
+  if (entry.completion_notified)
+    return;
+  flush_caches(entry.process_id);
+  plugin_group_->onAmdgpuDispatchExecutionEnd(entry.dispatch_id);
+  if (entry.completion_signal != 0)
+    fire_signal(entry);
+  entry.completion_notified = true;
 }
 
 void CompletionTracker::fire_queue_idle_signal(uint64_t queue_desc_va, uint32_t process_id) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/completion_tracker.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/completion_tracker.h
@@ -53,6 +53,9 @@ public:
   /// @brief Scan all queues and fire completion signals for retired dispatches.
   void drain_completions(std::vector<HwQueueState> &queues);
 
+  /// @brief Deliver an out-of-order-ready non-kernel packet's completion.
+  void complete_non_kernel(DispatchEntry &entry);
+
   /// @brief Flush L1/L2 caches before firing a completion signal.
   void flush_caches(uint32_t vmid = 0);
 
@@ -63,6 +66,7 @@ public:
   void fire_queue_idle_signal(uint64_t queue_desc_va, uint32_t process_id);
 
 private:
+  void deliver_completion(DispatchEntry &entry);
   void fire_signal(const DispatchEntry &entry);
 
   GpuMemory *memory_;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/completion_tracker.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/completion_tracker.h
@@ -22,6 +22,8 @@
 namespace rocjitsu {
 namespace amdgpu {
 
+class L2Cache;
+
 class CompletionTracker {
 public:
   using InterruptCallback = std::function<void(uint32_t process_id, uint32_t event_id)>;
@@ -31,8 +33,9 @@ public:
   /// signal, and any peer parked behind a barrier bit waiting on this dispatch.
   using GridRetiredCallback = std::function<void(const DispatchEntry &entry)>;
 
-  CompletionTracker(GpuMemory *mem, std::vector<ComputeUnitCore *> &cus)
-      : memory_(mem), cus_(cus) {}
+  CompletionTracker(GpuMemory *mem, std::vector<ComputeUnitCore *> &cus,
+                    std::vector<L2Cache *> &l2_caches)
+      : memory_(mem), cus_(cus), l2_caches_(l2_caches) {}
 
   void set_plugin_group(std::shared_ptr<ExecutionPluginGroup> pg) {
     plugin_group_ = pg ? pg : ExecutionPluginGroup::empty_group();
@@ -64,6 +67,7 @@ private:
 
   GpuMemory *memory_;
   std::vector<ComputeUnitCore *> &cus_;
+  std::vector<L2Cache *> &l2_caches_;
   InterruptCallback interrupt_cb_;
   DispatchRetiredCallback dispatch_retired_cb_;
   GridRetiredCallback grid_retired_cb_;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/completion_tracker.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/completion_tracker.h
@@ -22,13 +22,16 @@
 namespace rocjitsu {
 namespace amdgpu {
 
+class L2Cache;
+
 class CompletionTracker {
 public:
   using InterruptCallback = std::function<void(uint32_t process_id, uint32_t event_id)>;
   using DispatchRetiredCallback = std::function<void(const DispatchEntry &entry)>;
 
-  CompletionTracker(GpuMemory *mem, std::vector<ComputeUnitCore *> &cus)
-      : memory_(mem), cus_(cus) {}
+  CompletionTracker(GpuMemory *mem, std::vector<ComputeUnitCore *> &cus,
+                    std::vector<L2Cache *> &l2_caches)
+      : memory_(mem), cus_(cus), l2_caches_(l2_caches) {}
 
   void set_plugin_group(std::shared_ptr<ExecutionPluginGroup> pg) {
     plugin_group_ = pg ? pg : ExecutionPluginGroup::empty_group();
@@ -59,6 +62,7 @@ private:
 
   GpuMemory *memory_;
   std::vector<ComputeUnitCore *> &cus_;
+  std::vector<L2Cache *> &l2_caches_;
   InterruptCallback interrupt_cb_;
   DispatchRetiredCallback dispatch_retired_cb_;
   std::shared_ptr<ExecutionPluginGroup> plugin_group_ = ExecutionPluginGroup::empty_group();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/completion_tracker.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/completion_tracker.h
@@ -48,6 +48,9 @@ public:
   /// @brief Scan all queues and fire completion signals for retired dispatches.
   void drain_completions(std::vector<HwQueueState> &queues);
 
+  /// @brief Deliver an out-of-order-ready non-kernel packet's completion.
+  void complete_non_kernel(DispatchEntry &entry);
+
   /// @brief Flush L1/L2 caches before firing a completion signal.
   void flush_caches(uint32_t vmid = 0);
 
@@ -58,6 +61,7 @@ public:
   void fire_queue_idle_signal(uint64_t queue_desc_va, uint32_t process_id);
 
 private:
+  void deliver_completion(DispatchEntry &entry);
   void fire_signal(const DispatchEntry &entry);
 
   GpuMemory *memory_;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
@@ -882,7 +882,6 @@ void ComputeUnitCore::issue_instruction(Wavefront *active) {
       uint64_t target = RegisterAccess(*active).read_scalar64(*target_operand);
       if (target == 0) {
         active->halt();
-        delete inst;
         return;
       }
     }
@@ -919,10 +918,8 @@ void ComputeUnitCore::issue_instruction(Wavefront *active) {
   // below; the immediate-halt case does not. onAmdgpuWavefrontHalted is the
   // authoritative terminal hook and fires in both cases — consumers should observe
   // termination there, not via the after-execute hook.
-  if (active->is_halted()) {
-    delete inst;
+  if (active->is_halted())
     return;
-  }
 
   plugin_group_->onAmdgpuAfterExecuteInstruction(active->pc, *inst, *active);
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
@@ -545,7 +545,6 @@ void ComputeUnitCore::release_wf(uint32_t dispatch_id, uint32_t wg_id,
 
   auto it = active_wgs_.find(key);
   if (it != active_wgs_.end() && --it->second == 0) {
-    plugin_group_->onAmdgpuWorkgroupCompleted(dispatch_id, wg_id);
     active_wgs_.erase(it);
     barrier_wgs_.erase(key);
     // Queued rather than sent: notify_wg_complete() takes the CP's

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
@@ -881,6 +881,7 @@ void ComputeUnitCore::issue_instruction(Wavefront *active) {
       uint64_t target = RegisterAccess(*active).read_scalar64(*target_operand);
       if (target == 0) {
         active->halt();
+        delete inst;
         return;
       }
     }
@@ -917,8 +918,10 @@ void ComputeUnitCore::issue_instruction(Wavefront *active) {
   // below; the immediate-halt case does not. onAmdgpuWavefrontHalted is the
   // authoritative terminal hook and fires in both cases — consumers should observe
   // termination there, not via the after-execute hook.
-  if (active->is_halted())
+  if (active->is_halted()) {
+    delete inst;
     return;
+  }
 
   plugin_group_->onAmdgpuAfterExecuteInstruction(active->pc, *inst, *active);
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
@@ -891,7 +891,12 @@ void ComputeUnitCore::issue_instruction(Wavefront *active) {
   // transition rather than a per-ISA mnemonic list. See its use.
   const bool was_in_trap_handler = active->in_trap_handler();
 
-  execute_instruction(inst, *active);
+  try {
+    execute_instruction(inst, *active);
+  } catch (...) {
+    delete inst;
+    throw;
+  }
 
   if (active->instruction_execution_failed()) {
     const InstructionExecutionError error = active->instruction_execution_error();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
@@ -787,7 +787,6 @@ void ComputeUnitCore::issue_instruction(Wavefront *active) {
                         (static_cast<uint64_t>(read_sgpr(sb + ssrc0_idx + 1)) << 32);
       if (target == 0) {
         active->halt();
-        delete inst;
         return;
       }
     }
@@ -811,10 +810,8 @@ void ComputeUnitCore::issue_instruction(Wavefront *active) {
   // below; the immediate-halt case does not. onAmdgpuWavefrontHalted is the
   // authoritative terminal hook and fires in both cases — consumers should observe
   // termination there, not via the after-execute hook.
-  if (active->is_halted()) {
-    delete inst;
+  if (active->is_halted())
     return;
-  }
 
   plugin_group_->onAmdgpuAfterExecuteInstruction(active->pc, *inst, *active);
 
@@ -937,9 +934,9 @@ void ComputeUnitCore::issue_instruction(Wavefront *active) {
       auto *d = inst->data_as<VectorMemState>();
       d->issue_pc = active->pc;
     }
-    route_memory_inst(inst, *active);
-  } else
-    delete inst;
+    route_memory_inst(inst.get(), *active);
+    inst.release();
+  }
 
   active->pc += inst_size;
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
@@ -786,6 +786,7 @@ void ComputeUnitCore::issue_instruction(Wavefront *active) {
                         (static_cast<uint64_t>(read_sgpr(sb + ssrc0_idx + 1)) << 32);
       if (target == 0) {
         active->halt();
+        delete inst;
         return;
       }
     }
@@ -809,8 +810,10 @@ void ComputeUnitCore::issue_instruction(Wavefront *active) {
   // below; the immediate-halt case does not. onAmdgpuWavefrontHalted is the
   // authoritative terminal hook and fires in both cases — consumers should observe
   // termination there, not via the after-execute hook.
-  if (active->is_halted())
+  if (active->is_halted()) {
+    delete inst;
     return;
+  }
 
   plugin_group_->onAmdgpuAfterExecuteInstruction(active->pc, *inst, *active);
 
@@ -933,9 +936,9 @@ void ComputeUnitCore::issue_instruction(Wavefront *active) {
       auto *d = inst->data_as<VectorMemState>();
       d->issue_pc = active->pc;
     }
-    route_memory_inst(inst.get(), *active);
-    inst.release();
-  }
+    route_memory_inst(inst, *active);
+  } else
+    delete inst;
 
   active->pc += inst_size;
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
@@ -796,7 +796,12 @@ void ComputeUnitCore::issue_instruction(Wavefront *active) {
   // transition rather than a per-ISA mnemonic list. See its use.
   const bool was_in_trap_handler = active->in_trap_handler();
 
-  execute_instruction(inst, *active);
+  try {
+    execute_instruction(inst, *active);
+  } catch (...) {
+    delete inst;
+    throw;
+  }
 
   // A terminating instruction (s_endpgm with no pending waits) halts the wave
   // inside execute_instruction, which frees and resets its slot. Its registers,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
@@ -490,7 +490,6 @@ void ComputeUnitCore::release_wf(uint32_t dispatch_id, uint32_t wg_id,
 
   auto it = active_wgs_.find(key);
   if (it != active_wgs_.end() && --it->second == 0) {
-    plugin_group_->onAmdgpuWorkgroupCompleted(dispatch_id, wg_id);
     active_wgs_.erase(it);
     barrier_wgs_.erase(key);
     // Queued rather than sent: notify_wg_complete() takes the CP's

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -72,6 +72,16 @@ inline constexpr uint8_t kWorkgroupTrapBarrierBit = 2;
 inline constexpr uint8_t kClusterBarrierBit = 3;
 inline constexpr uint8_t kClusterTrapBarrierBit = 4;
 
+struct FunctionalQuantumResult {
+  bool ran = false;
+  bool yielded = false;
+
+  void merge(const FunctionalQuantumResult &other) {
+    ran |= other.ran;
+    yielded |= other.yielded;
+  }
+};
+
 /// @brief Base AMDGPU compute unit that owns wavefront slots and register files.
 ///
 /// @details Owns the physical SGPR and VGPR register files and a fixed array of
@@ -106,6 +116,7 @@ public:
     uint32_t sgprs_per_wf; ///< Scalar GPRs per wavefront (allocation granularity).
     uint32_t vgprs_per_wf; ///< Vector GPRs per wavefront (allocation granularity).
     uint32_t lds_size_kb;  ///< Local Data Share size in kilobytes.
+    uint32_t functional_quantum = kFunctionalQuantum; ///< Max instructions per functional slice.
   };
 
   ~ComputeUnitCore() override = default;
@@ -180,6 +191,30 @@ public:
   /// Used by wait-like instructions such as s_sleep so other simulated
   /// components can publish the state on which the wavefront is polling.
   void request_functional_yield() { functional_yield_requested_ = true; }
+
+  uint32_t functional_quantum() const {
+    return config_.functional_quantum == 0 ? UINT32_MAX : config_.functional_quantum;
+  }
+
+  /// @brief Execute up to one functional quantum of instructions on this CU.
+  /// @returns Whether wavefronts ran and whether one requested an event-loop yield.
+  FunctionalQuantumResult run_quantum() {
+    // A request left by direct step() execution must not shorten this quantum.
+    functional_yield_requested_ = false;
+    FunctionalQuantumResult result;
+    for (uint32_t i = 0, quantum = functional_quantum(); i < quantum; ++i) {
+      if (!has_active_wfs())
+        break;
+      result.ran = true;
+      if (!step())
+        break;
+      if (std::exchange(functional_yield_requested_, false)) {
+        result.yielded = true;
+        break;
+      }
+    }
+    return result;
+  }
 
   /// @brief Schedule the tick event if the CU is not already executing.
   /// Called from dispatch_wf(), the cpl_ port handler, and single-threaded VM
@@ -323,7 +358,7 @@ public:
 
   /// @brief Set the execution plugin group (shared ownership).
   void set_plugin_group(std::shared_ptr<ExecutionPluginGroup> pg) {
-    plugin_group_ = pg ? pg : ExecutionPluginGroup::empty_group();
+    plugin_group_ = pg ? std::move(pg) : ExecutionPluginGroup::empty_group();
     observes_sgpr_reads_ = plugin_group_->observes_sgpr_reads();
   }
 
@@ -639,8 +674,6 @@ public:
   /// ownership and the explicit executing wave are preserved.
   /// @param reg_idx Physical register index.
   /// @returns Register value.
-  // TODO(newling) consider cmake flag to build without plugins, this call
-  // overhead might be non-negligible.
   uint32_t read_sgpr(uint32_t reg_idx) const {
     if (reg_idx >= sgpr_file_.total_regs())
       return 0;
@@ -1113,7 +1146,8 @@ public:
       // A request left by direct step() execution must not shorten this quantum.
       functional_yield_requested_ = false;
       last_quantum_executed_ = 0;
-      const uint32_t quantum = debug_active() ? kDebugFunctionalQuantum : kFunctionalQuantum;
+      const uint32_t quantum =
+          debug_active() ? kDebugFunctionalQuantum : this->functional_quantum();
       for (uint32_t i = 0; i < quantum && step(); ++i) {
         ++last_quantum_executed_;
         if (std::exchange(functional_yield_requested_, false))

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -75,10 +75,12 @@ inline constexpr uint8_t kClusterTrapBarrierBit = 4;
 struct FunctionalQuantumResult {
   bool ran = false;
   bool yielded = false;
+  uint64_t iterations = 0;
 
   void merge(const FunctionalQuantumResult &other) {
     ran |= other.ran;
     yielded |= other.yielded;
+    iterations = std::max(iterations, other.iterations);
   }
 };
 
@@ -206,12 +208,14 @@ public:
     // A request left by direct step() execution must not shorten this quantum.
     functional_yield_requested_ = false;
     FunctionalQuantumResult result;
-    for (uint32_t i = 0, quantum = functional_quantum(); i < quantum; ++i) {
+    const uint32_t quantum = debug_active() ? kDebugFunctionalQuantum : functional_quantum();
+    for (uint32_t i = 0; i < quantum; ++i) {
       if (!has_active_wfs())
         break;
       result.ran = true;
       if (!step())
         break;
+      ++result.iterations;
       if (std::exchange(functional_yield_requested_, false)) {
         result.yielded = true;
         break;
@@ -224,6 +228,13 @@ public:
   /// Called from dispatch_wf(), the cpl_ port handler, and single-threaded VM
   /// initialization after engine creation but before simulation workers start.
   virtual void schedule_work() = 0;
+
+  /// @brief Schedule the serial CU driver at an absolute simulation tick.
+  virtual void schedule_work_at(simdojo::Tick tick) = 0;
+
+  /// @brief Retire the serial CU driver and return its next due tick.
+  /// @returns TICK_MAX when no serial driver was scheduled.
+  virtual simdojo::Tick suspend_scheduled_work() = 0;
 
   /// @brief Thread-safe scheduling for debugger resume from an ioctl thread.
   virtual void schedule_work_async() = 0;
@@ -1154,16 +1165,7 @@ public:
       return false;
     }
     if constexpr (Mode == simdojo::ExecMode::FUNCTIONAL) {
-      // A request left by direct step() execution must not shorten this quantum.
-      functional_yield_requested_ = false;
-      last_quantum_executed_ = 0;
-      const uint32_t quantum =
-          debug_active() ? kDebugFunctionalQuantum : this->functional_quantum();
-      for (uint32_t i = 0; i < quantum && step(); ++i) {
-        ++last_quantum_executed_;
-        if (std::exchange(functional_yield_requested_, false))
-          break;
-      }
+      last_quantum_executed_ = this->run_quantum().iterations;
     } else {
       /// @todo: Support CLOCKED pipeline cycle.
     }
@@ -1195,11 +1197,25 @@ public:
     // resident on this CU, so scheduling work for it would spin the engine
     // against a wave that cannot retire an instruction until the debugger
     // resumes it.
+    if (!this->engine())
+      return;
+    auto now = this->engine()->context(this->partition_id()).current_tick();
+    schedule_work_at(now + 1);
+  }
+
+  void schedule_work_at(simdojo::Tick tick) override {
     if (this->pool_driven() || executing_ || !this->engine() || !this->has_runnable_wfs())
       return;
     executing_ = true;
-    auto now = this->engine()->context(this->partition_id()).current_tick();
-    this->schedule_event(&tick_event_, now + 1);
+    schedule_next_tick(tick);
+  }
+
+  simdojo::Tick suspend_scheduled_work() override {
+    const simdojo::Tick tick = scheduled_tick_;
+    scheduled_tick_ = simdojo::TICK_MAX;
+    ++driver_generation_;
+    executing_ = false;
+    return tick;
   }
 
   void schedule_work_async() override {
@@ -1208,6 +1224,13 @@ public:
   }
 
 private:
+  void schedule_next_tick(simdojo::Tick tick) {
+    scheduled_tick_ = tick;
+    const uintptr_t generation = ++driver_generation_;
+    this->schedule_event(&tick_event_, tick,
+                         std::make_unique<simdojo::Message>(simdojo::MessageHeader{}, generation));
+  }
+
   // Reschedule by the number of quantum loop iterations taken, not a fixed
   // kFunctionalQuantum: a wavefront that requests a yield after k<kFunctionalQuantum
   // iterations (e.g. s_sleep, vendor-dep retry) resumes at now+k so a peer
@@ -1216,16 +1239,22 @@ private:
   // step() advances even when every wave is WAITCNT/BARRIER-stalled — so a fully
   // stalled CU still advances by the full quantum. max(1,...) keeps the event
   // strictly in the future so re-entries never collapse onto one tick.
-  simdojo::Event tick_event_{
-      this, simdojo::EventType::TIMER_CALLBACK, [this](simdojo::Tick now, simdojo::Message *) {
-        if (execute_quantum())
-          this->schedule_event(&tick_event_, now + std::max<uint64_t>(1, last_quantum_executed_));
-      }};
+  simdojo::Event tick_event_{this, simdojo::EventType::TIMER_CALLBACK,
+                             [this](simdojo::Tick now, simdojo::Message *message) {
+                               if (!message || message->payload() != driver_generation_)
+                                 return;
+                               scheduled_tick_ = simdojo::TICK_MAX;
+                               if (execute_quantum())
+                                 schedule_next_tick(now +
+                                                    std::max<uint64_t>(1, last_quantum_executed_));
+                             }};
   // Cross-thread debugger resumes first enter this event. Its handler runs on
   // the CU partition and can safely update executing_ through schedule_work().
   simdojo::Event resume_event_{this, simdojo::EventType::TIMER_CALLBACK,
                                [this](simdojo::Tick, simdojo::Message *) { schedule_work(); }};
   uint64_t last_quantum_executed_ = 0;
+  simdojo::Tick scheduled_tick_ = simdojo::TICK_MAX;
+  uintptr_t driver_generation_ = 0;
   bool executing_ = false;
 };
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -252,6 +252,9 @@ public:
   /// @param cb Callback to invoke when idle.
   void set_on_idle(std::function<void()> cb) { on_idle_ = std::move(cb); }
 
+  /// @brief Register the CP wakeup used when a pool-driven CU becomes runnable.
+  void set_on_pool_ready(std::function<void()> cb) { on_pool_ready_ = std::move(cb); }
+
   struct TrapHandlerConfig {
     uint64_t tba = 0;
     uint64_t tma = 0;
@@ -968,6 +971,11 @@ protected:
       on_idle_();
   }
 
+  void notify_pool_ready() {
+    if (on_pool_ready_)
+      on_pool_ready_();
+  }
+
   Config config_;
   GpuMemory *memory_;
   uint32_t wf_size_ = 0;
@@ -1040,7 +1048,8 @@ protected:
   ScalarMemPipeline scalar_mem_pipeline_;
   GlobalMemPipeline global_mem_pipeline_;
   LocalMemPipeline local_mem_pipeline_;
-  std::function<void()> on_idle_; ///< Callback invoked when CU becomes idle.
+  std::function<void()> on_idle_;       ///< Callback invoked when CU becomes idle.
+  std::function<void()> on_pool_ready_; ///< Callback that wakes the CP-owned pool driver.
   TrapHandlerResolver trap_handler_resolver_;
   SendmsgHandler sendmsg_handler_;
   TrapCompletionHandler trap_completion_handler_;
@@ -1249,9 +1258,14 @@ private:
                                                     std::max<uint64_t>(1, last_quantum_executed_));
                              }};
   // Cross-thread debugger resumes first enter this event. Its handler runs on
-  // the CU partition and can safely update executing_ through schedule_work().
+  // the CU/CP partition and wakes whichever driver currently owns execution.
   simdojo::Event resume_event_{this, simdojo::EventType::TIMER_CALLBACK,
-                               [this](simdojo::Tick, simdojo::Message *) { schedule_work(); }};
+                               [this](simdojo::Tick, simdojo::Message *) {
+                                 if (this->pool_driven())
+                                   this->notify_pool_ready();
+                                 else
+                                   schedule_work();
+                               }};
   uint64_t last_quantum_executed_ = 0;
   simdojo::Tick scheduled_tick_ = simdojo::TICK_MAX;
   uintptr_t driver_generation_ = 0;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -196,6 +196,10 @@ public:
     return config_.functional_quantum == 0 ? UINT32_MAX : config_.functional_quantum;
   }
 
+  /// @brief Select whether the CP continuation event owns functional execution.
+  void set_pool_driven(bool value) { pool_driven_ = value; }
+  bool pool_driven() const { return pool_driven_; }
+
   /// @brief Execute up to one functional quantum of instructions on this CU.
   /// @returns Whether wavefronts ran and whether one requested an event-loop yield.
   FunctionalQuantumResult run_quantum() {
@@ -1060,6 +1064,7 @@ protected:
 
   std::shared_ptr<ExecutionPluginGroup> plugin_group_ = ExecutionPluginGroup::empty_group();
   bool observes_sgpr_reads_ = false;
+  bool pool_driven_ = false;
 
   /// @brief Resolve the owner of a physical SGPR from its allocation block.
   /// @details Power-of-two block sizes use a shift on the instruction read path;
@@ -1142,6 +1147,12 @@ public:
 
   /// @brief Execute work up to the quantum limit, then yield.
   bool execute_quantum() override {
+    // A CP continuation event owns pool-driven execution. If the policy changed
+    // while a CU tick was already queued, retire that stale driver here.
+    if (this->pool_driven()) {
+      executing_ = false;
+      return false;
+    }
     if constexpr (Mode == simdojo::ExecMode::FUNCTIONAL) {
       // A request left by direct step() execution must not shorten this quantum.
       functional_yield_requested_ = false;
@@ -1184,7 +1195,7 @@ public:
     // resident on this CU, so scheduling work for it would spin the engine
     // against a wave that cannot retire an instruction until the debugger
     // resumes it.
-    if (executing_ || !this->engine() || !this->has_runnable_wfs())
+    if (this->pool_driven() || executing_ || !this->engine() || !this->has_runnable_wfs())
       return;
     executing_ = true;
     auto now = this->engine()->context(this->partition_id()).current_tick();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -188,6 +188,10 @@ public:
     return config_.functional_quantum == 0 ? UINT32_MAX : config_.functional_quantum;
   }
 
+  /// @brief Select whether the CP continuation event owns functional execution.
+  void set_pool_driven(bool value) { pool_driven_ = value; }
+  bool pool_driven() const { return pool_driven_; }
+
   /// @brief Execute up to one functional quantum of instructions on this CU.
   /// @returns Whether wavefronts ran and whether one requested an event-loop yield.
   FunctionalQuantumResult run_quantum() {
@@ -870,6 +874,7 @@ protected:
   uint64_t private_aperture_limit_ = 0;
 
   std::shared_ptr<ExecutionPluginGroup> plugin_group_ = ExecutionPluginGroup::empty_group();
+  bool pool_driven_ = false;
 
   /// Reverse lookup: physical SGPR index -> owning wavefront (for race detection).
   /// Populated at dispatch_wf time. Null entries mean "not allocated".
@@ -934,6 +939,12 @@ public:
 
   /// @brief Execute work up to the quantum limit, then yield.
   bool execute_quantum() override {
+    // A CP continuation event owns pool-driven execution. If the policy changed
+    // while a CU tick was already queued, retire that stale driver here.
+    if (this->pool_driven()) {
+      executing_ = false;
+      return false;
+    }
     if constexpr (Mode == simdojo::ExecMode::FUNCTIONAL) {
       // A request left by direct step() execution must not shorten this quantum.
       functional_yield_requested_ = false;
@@ -976,7 +987,7 @@ public:
     // resident on this CU, so scheduling work for it would spin the engine
     // against a wave that cannot retire an instruction until the debugger
     // resumes it.
-    if (executing_ || !this->engine() || !this->has_runnable_wfs())
+    if (this->pool_driven() || executing_ || !this->engine() || !this->has_runnable_wfs())
       return;
     executing_ = true;
     auto now = this->engine()->context(this->partition_id()).current_tick();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -69,10 +69,12 @@ inline constexpr uint8_t kClusterTrapBarrierBit = 4;
 struct FunctionalQuantumResult {
   bool ran = false;
   bool yielded = false;
+  uint64_t iterations = 0;
 
   void merge(const FunctionalQuantumResult &other) {
     ran |= other.ran;
     yielded |= other.yielded;
+    iterations = std::max(iterations, other.iterations);
   }
 };
 
@@ -198,12 +200,14 @@ public:
     // A request left by direct step() execution must not shorten this quantum.
     functional_yield_requested_ = false;
     FunctionalQuantumResult result;
-    for (uint32_t i = 0, quantum = functional_quantum(); i < quantum; ++i) {
+    const uint32_t quantum = debug_active() ? kDebugFunctionalQuantum : functional_quantum();
+    for (uint32_t i = 0; i < quantum; ++i) {
       if (!has_active_wfs())
         break;
       result.ran = true;
       if (!step())
         break;
+      ++result.iterations;
       if (std::exchange(functional_yield_requested_, false)) {
         result.yielded = true;
         break;
@@ -216,6 +220,13 @@ public:
   /// Called from dispatch_wf(), the cpl_ port handler, and single-threaded VM
   /// initialization after engine creation but before simulation workers start.
   virtual void schedule_work() = 0;
+
+  /// @brief Schedule the serial CU driver at an absolute simulation tick.
+  virtual void schedule_work_at(simdojo::Tick tick) = 0;
+
+  /// @brief Retire the serial CU driver and return its next due tick.
+  /// @returns TICK_MAX when no serial driver was scheduled.
+  virtual simdojo::Tick suspend_scheduled_work() = 0;
 
   /// @brief Thread-safe scheduling for debugger resume from an ioctl thread.
   virtual void schedule_work_async() = 0;
@@ -946,16 +957,7 @@ public:
       return false;
     }
     if constexpr (Mode == simdojo::ExecMode::FUNCTIONAL) {
-      // A request left by direct step() execution must not shorten this quantum.
-      functional_yield_requested_ = false;
-      last_quantum_executed_ = 0;
-      const uint32_t quantum =
-          debug_active() ? kDebugFunctionalQuantum : this->functional_quantum();
-      for (uint32_t i = 0; i < quantum && step(); ++i) {
-        ++last_quantum_executed_;
-        if (std::exchange(functional_yield_requested_, false))
-          break;
-      }
+      last_quantum_executed_ = this->run_quantum().iterations;
     } else {
       /// @todo: Support CLOCKED pipeline cycle.
     }
@@ -987,11 +989,25 @@ public:
     // resident on this CU, so scheduling work for it would spin the engine
     // against a wave that cannot retire an instruction until the debugger
     // resumes it.
+    if (!this->engine())
+      return;
+    auto now = this->engine()->context(this->partition_id()).current_tick();
+    schedule_work_at(now + 1);
+  }
+
+  void schedule_work_at(simdojo::Tick tick) override {
     if (this->pool_driven() || executing_ || !this->engine() || !this->has_runnable_wfs())
       return;
     executing_ = true;
-    auto now = this->engine()->context(this->partition_id()).current_tick();
-    this->schedule_event(&tick_event_, now + 1);
+    schedule_next_tick(tick);
+  }
+
+  simdojo::Tick suspend_scheduled_work() override {
+    const simdojo::Tick tick = scheduled_tick_;
+    scheduled_tick_ = simdojo::TICK_MAX;
+    ++driver_generation_;
+    executing_ = false;
+    return tick;
   }
 
   void schedule_work_async() override {
@@ -1000,6 +1016,13 @@ public:
   }
 
 private:
+  void schedule_next_tick(simdojo::Tick tick) {
+    scheduled_tick_ = tick;
+    const uintptr_t generation = ++driver_generation_;
+    this->schedule_event(&tick_event_, tick,
+                         std::make_unique<simdojo::Message>(simdojo::MessageHeader{}, generation));
+  }
+
   // Reschedule by the number of quantum loop iterations taken, not a fixed
   // kFunctionalQuantum: a wavefront that requests a yield after k<kFunctionalQuantum
   // iterations (e.g. s_sleep, vendor-dep retry) resumes at now+k so a peer
@@ -1008,16 +1031,22 @@ private:
   // step() advances even when every wave is WAITCNT/BARRIER-stalled — so a fully
   // stalled CU still advances by the full quantum. max(1,...) keeps the event
   // strictly in the future so re-entries never collapse onto one tick.
-  simdojo::Event tick_event_{
-      this, simdojo::EventType::TIMER_CALLBACK, [this](simdojo::Tick now, simdojo::Message *) {
-        if (execute_quantum())
-          this->schedule_event(&tick_event_, now + std::max<uint64_t>(1, last_quantum_executed_));
-      }};
+  simdojo::Event tick_event_{this, simdojo::EventType::TIMER_CALLBACK,
+                             [this](simdojo::Tick now, simdojo::Message *message) {
+                               if (!message || message->payload() != driver_generation_)
+                                 return;
+                               scheduled_tick_ = simdojo::TICK_MAX;
+                               if (execute_quantum())
+                                 schedule_next_tick(now +
+                                                    std::max<uint64_t>(1, last_quantum_executed_));
+                             }};
   // Cross-thread debugger resumes first enter this event. Its handler runs on
   // the CU partition and can safely update executing_ through schedule_work().
   simdojo::Event resume_event_{this, simdojo::EventType::TIMER_CALLBACK,
                                [this](simdojo::Tick, simdojo::Message *) { schedule_work(); }};
   uint64_t last_quantum_executed_ = 0;
+  simdojo::Tick scheduled_tick_ = simdojo::TICK_MAX;
+  uintptr_t driver_generation_ = 0;
   bool executing_ = false;
 };
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -66,6 +66,16 @@ inline constexpr uint8_t kWorkgroupTrapBarrierBit = 2;
 inline constexpr uint8_t kClusterBarrierBit = 3;
 inline constexpr uint8_t kClusterTrapBarrierBit = 4;
 
+struct FunctionalQuantumResult {
+  bool ran = false;
+  bool yielded = false;
+
+  void merge(const FunctionalQuantumResult &other) {
+    ran |= other.ran;
+    yielded |= other.yielded;
+  }
+};
+
 /// @brief Base AMDGPU compute unit that owns wavefront slots and register files.
 ///
 /// @details Owns the physical SGPR and VGPR register files and a fixed array of
@@ -99,6 +109,7 @@ public:
     uint32_t sgprs_per_wf; ///< Scalar GPRs per wavefront (allocation granularity).
     uint32_t vgprs_per_wf; ///< Vector GPRs per wavefront (allocation granularity).
     uint32_t lds_size_kb;  ///< Local Data Share size in kilobytes.
+    uint32_t functional_quantum = kFunctionalQuantum; ///< Max instructions per functional slice.
   };
 
   ~ComputeUnitCore() override = default;
@@ -172,6 +183,30 @@ public:
   /// Used by wait-like instructions such as s_sleep so other simulated
   /// components can publish the state on which the wavefront is polling.
   void request_functional_yield() { functional_yield_requested_ = true; }
+
+  uint32_t functional_quantum() const {
+    return config_.functional_quantum == 0 ? UINT32_MAX : config_.functional_quantum;
+  }
+
+  /// @brief Execute up to one functional quantum of instructions on this CU.
+  /// @returns Whether wavefronts ran and whether one requested an event-loop yield.
+  FunctionalQuantumResult run_quantum() {
+    // A request left by direct step() execution must not shorten this quantum.
+    functional_yield_requested_ = false;
+    FunctionalQuantumResult result;
+    for (uint32_t i = 0, quantum = functional_quantum(); i < quantum; ++i) {
+      if (!has_active_wfs())
+        break;
+      result.ran = true;
+      if (!step())
+        break;
+      if (std::exchange(functional_yield_requested_, false)) {
+        result.yielded = true;
+        break;
+      }
+    }
+    return result;
+  }
 
   /// @brief Schedule the tick event if the CU is not already executing.
   /// Called from dispatch_wf(), the cpl_ port handler, and single-threaded VM
@@ -304,7 +339,7 @@ public:
 
   /// @brief Set the execution plugin group (shared ownership).
   void set_plugin_group(std::shared_ptr<ExecutionPluginGroup> pg) {
-    plugin_group_ = pg ? pg : ExecutionPluginGroup::empty_group();
+    plugin_group_ = pg ? std::move(pg) : ExecutionPluginGroup::empty_group();
   }
 
   /// @brief Return the execution plugin group.
@@ -515,12 +550,9 @@ public:
   /// RegisterAccess APIs instead.
   /// @param reg_idx Physical register index.
   /// @returns Register value.
-  // TODO(newling) consider cmake flag to build without plugins, this call
-  // overhead might be non-negligible.
   uint32_t read_sgpr(uint32_t reg_idx) const {
-    if (auto *wf = sgpr_to_wave_[reg_idx]) {
+    if (auto *wf = sgpr_to_wave_[reg_idx])
       plugin_group_->onAmdgpuReadSgpr(wf, reg_idx);
-    }
     return sgpr_file_[reg_idx];
   }
 
@@ -906,7 +938,8 @@ public:
       // A request left by direct step() execution must not shorten this quantum.
       functional_yield_requested_ = false;
       last_quantum_executed_ = 0;
-      const uint32_t quantum = debug_active() ? kDebugFunctionalQuantum : kFunctionalQuantum;
+      const uint32_t quantum =
+          debug_active() ? kDebugFunctionalQuantum : this->functional_quantum();
       for (uint32_t i = 0; i < quantum && step(); ++i) {
         ++last_quantum_executed_;
         if (std::exchange(functional_yield_requested_, false))

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -118,7 +118,9 @@ public:
     uint32_t sgprs_per_wf; ///< Scalar GPRs per wavefront (allocation granularity).
     uint32_t vgprs_per_wf; ///< Vector GPRs per wavefront (allocation granularity).
     uint32_t lds_size_kb;  ///< Local Data Share size in kilobytes.
-    uint32_t functional_quantum = kFunctionalQuantum; ///< Max instructions per functional slice.
+    /// Maximum CU step() iterations per functional slice. One step can issue
+    /// one instruction for every runnable wavefront resident on the CU.
+    uint32_t functional_quantum = kFunctionalQuantum;
   };
 
   ~ComputeUnitCore() override = default;
@@ -202,7 +204,7 @@ public:
   void set_pool_driven(bool value) { pool_driven_ = value; }
   bool pool_driven() const { return pool_driven_; }
 
-  /// @brief Execute up to one functional quantum of instructions on this CU.
+  /// @brief Execute up to one functional quantum of step() iterations on this CU.
   /// @returns Whether wavefronts ran and whether one requested an event-loop yield.
   FunctionalQuantumResult run_quantum() {
     // A request left by direct step() execution must not shorten this quantum.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/cpu_dispatch_pool.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/cpu_dispatch_pool.h
@@ -15,12 +15,16 @@
 #include <cstdint>
 #include <exception>
 #include <mutex>
+#include <optional>
 #include <span>
+#include <stdexcept>
 #include <thread>
 #include <vector>
 
 namespace rocjitsu {
 namespace amdgpu {
+
+class CpuDispatchPoolTestAccess;
 
 /// @brief Pool of host threads executing one functional quantum per active CU.
 ///
@@ -36,13 +40,7 @@ namespace amdgpu {
 /// scaling from collapsing into lock contention when many short quanta retire.
 class CpuDispatchPool {
 public:
-  explicit CpuDispatchPool(uint32_t threads) {
-    threads = std::max(threads, 1u);
-    uint32_t worker_count = threads > 1 ? threads - 1 : 0;
-    workers_.reserve(worker_count);
-    for (uint32_t i = 0; i < worker_count; ++i)
-      workers_.emplace_back([this](std::stop_token stop) { worker_loop(stop); });
-  }
+  explicit CpuDispatchPool(uint32_t threads) : CpuDispatchPool(threads, std::nullopt) {}
 
   ~CpuDispatchPool() {
     {
@@ -62,6 +60,8 @@ public:
   FunctionalQuantumResult run(std::span<ComputeUnitCore *> tasks, uint32_t threads) {
     if (tasks.empty())
       return {};
+
+    std::lock_guard<std::mutex> run_lock(run_mutex_);
 
     threads = std::clamp<uint32_t>(threads, 1, static_cast<uint32_t>(tasks.size()));
     uint32_t worker_goal =
@@ -108,6 +108,18 @@ public:
   }
 
 private:
+  friend class CpuDispatchPoolTestAccess;
+
+  CpuDispatchPool(uint32_t threads, std::optional<uint32_t> fail_after) {
+    threads = std::max(threads, 1u);
+    uint32_t worker_count = threads > 1 ? threads - 1 : 0;
+    workers_.reserve(worker_count);
+    for (uint32_t i = 0; i < worker_count; ++i) {
+      if (fail_after && i == *fail_after)
+        throw std::runtime_error("injected worker construction failure");
+      workers_.emplace_back([this](std::stop_token stop) { worker_loop(stop); });
+    }
+  }
   /// @brief Claim and execute CUs until the task queue is drained.
   ///
   /// Lock-free: each claim is one atomic fetch_add; the last completion wakes
@@ -140,9 +152,7 @@ private:
   void worker_loop(std::stop_token stop) {
     while (true) {
       std::unique_lock<std::mutex> lock(mutex_);
-      work_cv_.wait(lock, [this, &stop]() {
-        return stopping_ || stop.stop_requested() || worker_tickets_ != 0;
-      });
+      work_cv_.wait(lock, stop, [this]() { return stopping_ || worker_tickets_ != 0; });
       if (stopping_ || stop.stop_requested())
         return;
       --worker_tickets_;
@@ -160,8 +170,9 @@ private:
     }
   }
 
+  std::mutex run_mutex_;
   std::mutex mutex_;
-  std::condition_variable work_cv_;
+  std::condition_variable_any work_cv_;
   std::condition_variable done_cv_;
   std::vector<std::jthread> workers_;
   std::vector<ComputeUnitCore *> tasks_;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/cpu_dispatch_pool.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/cpu_dispatch_pool.h
@@ -31,7 +31,8 @@ class CpuDispatchPoolTestAccess;
 /// @details run() distributes one ComputeUnitCore::run_quantum() call per CU
 /// across the calling thread plus up to N-1 workers. Each CU is executed by
 /// exactly one thread per run() (no intra-CU parallelism). run() returns when
-/// all CUs have completed their quantum.
+/// all CUs have completed their quantum. The output-span overload preserves
+/// each CU's result so its owner can schedule the next quantum independently.
 ///
 /// Task hand-out is lock-free: workers and the calling thread claim CUs with a
 /// single atomic fetch_add on @ref next_task_, and signal completion by
@@ -58,10 +59,19 @@ public:
   uint32_t thread_count() const { return static_cast<uint32_t>(workers_.size() + 1); }
 
   FunctionalQuantumResult run(std::span<ComputeUnitCore *> tasks, uint32_t threads) {
+    std::vector<FunctionalQuantumResult> results(tasks.size());
+    return run(tasks, threads, results);
+  }
+
+  FunctionalQuantumResult run(std::span<ComputeUnitCore *> tasks, uint32_t threads,
+                              std::span<FunctionalQuantumResult> results) {
     if (tasks.empty())
       return {};
+    if (results.size() != tasks.size())
+      throw std::invalid_argument("dispatch result count must match task count");
 
     std::lock_guard<std::mutex> run_lock(run_mutex_);
+    std::fill(results.begin(), results.end(), FunctionalQuantumResult{});
 
     threads = std::clamp<uint32_t>(threads, 1, static_cast<uint32_t>(tasks.size()));
     uint32_t worker_goal =
@@ -69,8 +79,10 @@ public:
 
     if (worker_goal == 0) {
       FunctionalQuantumResult result;
-      for (auto *cu : tasks)
-        result.merge(cu->run_quantum());
+      for (size_t i = 0; i < tasks.size(); ++i) {
+        results[i] = tasks[i]->run_quantum();
+        result.merge(results[i]);
+      }
       return result;
     }
 
@@ -78,13 +90,12 @@ public:
       std::lock_guard<std::mutex> lock(mutex_);
       tasks_.assign(tasks.begin(), tasks.end());
       task_data_.store(tasks_.data(), std::memory_order_release);
+      result_data_.store(results.data(), std::memory_order_release);
       task_count_.store(tasks_.size(), std::memory_order_release);
       next_task_.store(0, std::memory_order_relaxed);
       remaining_.store(tasks_.size(), std::memory_order_relaxed);
       worker_tickets_ = worker_goal;
       first_exception_ = nullptr;
-      batch_ran_.store(false, std::memory_order_relaxed);
-      batch_yielded_.store(false, std::memory_order_relaxed);
     }
     for (uint32_t i = 0; i < worker_goal; ++i)
       work_cv_.notify_one();
@@ -97,14 +108,17 @@ public:
     done_cv_.wait(lock, [this]() { return worker_tickets_ == 0 && active_workers_ == 0; });
     task_count_.store(0, std::memory_order_release);
     task_data_.store(nullptr, std::memory_order_release);
+    result_data_.store(nullptr, std::memory_order_release);
     tasks_.clear();
     std::exception_ptr first_exception = first_exception_;
     first_exception_ = nullptr;
     lock.unlock();
     if (first_exception)
       std::rethrow_exception(first_exception);
-    return {batch_ran_.load(std::memory_order_relaxed),
-            batch_yielded_.load(std::memory_order_relaxed)};
+    FunctionalQuantumResult result;
+    for (const auto &task_result : results)
+      result.merge(task_result);
+    return result;
   }
 
 private:
@@ -126,17 +140,14 @@ private:
   /// the thread blocked in run() via done_cv_.
   void drain_tasks() {
     ComputeUnitCore **tasks = task_data_.load(std::memory_order_acquire);
+    FunctionalQuantumResult *results = result_data_.load(std::memory_order_acquire);
     size_t task_count = task_count_.load(std::memory_order_acquire);
     while (true) {
       size_t i = next_task_.fetch_add(1, std::memory_order_relaxed);
       if (i >= task_count)
         return;
       try {
-        auto result = tasks[i]->run_quantum();
-        if (result.ran)
-          batch_ran_.store(true, std::memory_order_relaxed);
-        if (result.yielded)
-          batch_yielded_.store(true, std::memory_order_relaxed);
+        results[i] = tasks[i]->run_quantum();
       } catch (...) {
         std::lock_guard<std::mutex> lock(mutex_);
         if (!first_exception_)
@@ -177,11 +188,10 @@ private:
   std::vector<std::jthread> workers_;
   std::vector<ComputeUnitCore *> tasks_;
   std::atomic<ComputeUnitCore **> task_data_ = nullptr;
+  std::atomic<FunctionalQuantumResult *> result_data_ = nullptr;
   std::atomic<size_t> task_count_ = 0;
   std::atomic<size_t> next_task_ = 0;
   std::atomic<size_t> remaining_ = 0;
-  std::atomic<bool> batch_ran_ = false;
-  std::atomic<bool> batch_yielded_ = false;
   // Protected by mutex_; keeps the task vector alive until ticketed workers leave drain_tasks().
   size_t worker_tickets_ = 0;
   size_t active_workers_ = 0;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/cpu_dispatch_pool.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/cpu_dispatch_pool.h
@@ -77,15 +77,6 @@ public:
     uint32_t worker_goal =
         std::min<uint32_t>(threads > 1 ? threads - 1 : 0, static_cast<uint32_t>(workers_.size()));
 
-    if (worker_goal == 0) {
-      FunctionalQuantumResult result;
-      for (size_t i = 0; i < tasks.size(); ++i) {
-        results[i] = tasks[i]->run_quantum();
-        result.merge(results[i]);
-      }
-      return result;
-    }
-
     {
       std::lock_guard<std::mutex> lock(mutex_);
       tasks_.assign(tasks.begin(), tasks.end());

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/cpu_dispatch_pool.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/cpu_dispatch_pool.h
@@ -1,0 +1,184 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file cpu_dispatch_pool.h
+/// @brief Host CPU worker pool that drives CU wavefront execution in parallel.
+
+#ifndef ROCJITSU_VM_AMDGPU_CPU_DISPATCH_POOL_H_
+#define ROCJITSU_VM_AMDGPU_CPU_DISPATCH_POOL_H_
+
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+
+#include <algorithm>
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <exception>
+#include <mutex>
+#include <span>
+#include <thread>
+#include <vector>
+
+namespace rocjitsu {
+namespace amdgpu {
+
+/// @brief Pool of host threads executing one functional quantum per active CU.
+///
+/// @details run() distributes one ComputeUnitCore::run_quantum() call per CU
+/// across the calling thread plus up to N-1 workers. Each CU is executed by
+/// exactly one thread per run() (no intra-CU parallelism). run() returns when
+/// all CUs have completed their quantum.
+///
+/// Task hand-out is lock-free: workers and the calling thread claim CUs with a
+/// single atomic fetch_add on @ref next_task_, and signal completion by
+/// decrementing @ref remaining_. The mutex is held only for the wakeup/teardown
+/// condition-variable predicates, never on the per-CU hot path. This keeps
+/// scaling from collapsing into lock contention when many short quanta retire.
+class CpuDispatchPool {
+public:
+  explicit CpuDispatchPool(uint32_t threads) {
+    threads = std::max(threads, 1u);
+    uint32_t worker_count = threads > 1 ? threads - 1 : 0;
+    workers_.reserve(worker_count);
+    for (uint32_t i = 0; i < worker_count; ++i)
+      workers_.emplace_back([this](std::stop_token stop) { worker_loop(stop); });
+  }
+
+  ~CpuDispatchPool() {
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      stopping_ = true;
+    }
+    for (auto &worker : workers_)
+      worker.request_stop();
+    work_cv_.notify_all();
+    for (auto &worker : workers_)
+      if (worker.joinable())
+        worker.join();
+  }
+
+  uint32_t thread_count() const { return static_cast<uint32_t>(workers_.size() + 1); }
+
+  FunctionalQuantumResult run(std::span<ComputeUnitCore *> tasks, uint32_t threads) {
+    if (tasks.empty())
+      return {};
+
+    threads = std::clamp<uint32_t>(threads, 1, static_cast<uint32_t>(tasks.size()));
+    uint32_t worker_goal =
+        std::min<uint32_t>(threads > 1 ? threads - 1 : 0, static_cast<uint32_t>(workers_.size()));
+
+    if (worker_goal == 0) {
+      FunctionalQuantumResult result;
+      for (auto *cu : tasks)
+        result.merge(cu->run_quantum());
+      return result;
+    }
+
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      tasks_.assign(tasks.begin(), tasks.end());
+      task_data_.store(tasks_.data(), std::memory_order_release);
+      task_count_.store(tasks_.size(), std::memory_order_release);
+      next_task_.store(0, std::memory_order_relaxed);
+      remaining_.store(tasks_.size(), std::memory_order_relaxed);
+      worker_tickets_ = worker_goal;
+      first_exception_ = nullptr;
+      batch_ran_.store(false, std::memory_order_relaxed);
+      batch_yielded_.store(false, std::memory_order_relaxed);
+    }
+    for (uint32_t i = 0; i < worker_goal; ++i)
+      work_cv_.notify_one();
+
+    // The calling thread participates as one of the workers.
+    drain_tasks();
+
+    std::unique_lock<std::mutex> lock(mutex_);
+    done_cv_.wait(lock, [this]() { return remaining_.load(std::memory_order_acquire) == 0; });
+    done_cv_.wait(lock, [this]() { return worker_tickets_ == 0 && active_workers_ == 0; });
+    task_count_.store(0, std::memory_order_release);
+    task_data_.store(nullptr, std::memory_order_release);
+    tasks_.clear();
+    std::exception_ptr first_exception = first_exception_;
+    first_exception_ = nullptr;
+    lock.unlock();
+    if (first_exception)
+      std::rethrow_exception(first_exception);
+    return {batch_ran_.load(std::memory_order_relaxed),
+            batch_yielded_.load(std::memory_order_relaxed)};
+  }
+
+private:
+  /// @brief Claim and execute CUs until the task queue is drained.
+  ///
+  /// Lock-free: each claim is one atomic fetch_add; the last completion wakes
+  /// the thread blocked in run() via done_cv_.
+  void drain_tasks() {
+    ComputeUnitCore **tasks = task_data_.load(std::memory_order_acquire);
+    size_t task_count = task_count_.load(std::memory_order_acquire);
+    while (true) {
+      size_t i = next_task_.fetch_add(1, std::memory_order_relaxed);
+      if (i >= task_count)
+        return;
+      try {
+        auto result = tasks[i]->run_quantum();
+        if (result.ran)
+          batch_ran_.store(true, std::memory_order_relaxed);
+        if (result.yielded)
+          batch_yielded_.store(true, std::memory_order_relaxed);
+      } catch (...) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (!first_exception_)
+          first_exception_ = std::current_exception();
+      }
+      if (remaining_.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        done_cv_.notify_one();
+      }
+    }
+  }
+
+  void worker_loop(std::stop_token stop) {
+    while (true) {
+      std::unique_lock<std::mutex> lock(mutex_);
+      work_cv_.wait(lock, [this, &stop]() {
+        return stopping_ || stop.stop_requested() || worker_tickets_ != 0;
+      });
+      if (stopping_ || stop.stop_requested())
+        return;
+      --worker_tickets_;
+      ++active_workers_;
+      lock.unlock();
+
+      // Lock-free task draining; extra woken workers simply observe an empty
+      // queue and loop back to wait.
+      drain_tasks();
+
+      lock.lock();
+      --active_workers_;
+      if (worker_tickets_ == 0 && active_workers_ == 0)
+        done_cv_.notify_one();
+    }
+  }
+
+  std::mutex mutex_;
+  std::condition_variable work_cv_;
+  std::condition_variable done_cv_;
+  std::vector<std::jthread> workers_;
+  std::vector<ComputeUnitCore *> tasks_;
+  std::atomic<ComputeUnitCore **> task_data_ = nullptr;
+  std::atomic<size_t> task_count_ = 0;
+  std::atomic<size_t> next_task_ = 0;
+  std::atomic<size_t> remaining_ = 0;
+  std::atomic<bool> batch_ran_ = false;
+  std::atomic<bool> batch_yielded_ = false;
+  // Protected by mutex_; keeps the task vector alive until ticketed workers leave drain_tasks().
+  size_t worker_tickets_ = 0;
+  size_t active_workers_ = 0;
+  std::exception_ptr first_exception_;
+  bool stopping_ = false;
+};
+
+} // namespace amdgpu
+} // namespace rocjitsu
+
+#endif // ROCJITSU_VM_AMDGPU_CPU_DISPATCH_POOL_H_

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/cpu_dispatch_pool.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/cpu_dispatch_pool.h
@@ -33,12 +33,17 @@ class CpuDispatchPoolTestAccess;
 /// exactly one thread per run() (no intra-CU parallelism). run() returns when
 /// all CUs have completed their quantum. The output-span overload preserves
 /// each CU's result so its owner can schedule the next quantum independently.
+/// This is host acceleration machinery, not a modeled GPU resource: changing
+/// its width must preserve the observable result of race-free workloads.
 ///
 /// Task hand-out is lock-free: workers and the calling thread claim CUs with a
 /// single atomic fetch_add on @ref next_task_, and signal completion by
 /// decrementing @ref remaining_. The mutex is held only for the wakeup/teardown
 /// condition-variable predicates, never on the per-CU hot path. This keeps
 /// scaling from collapsing into lock contention when many short quanta retire.
+/// A pool may be shared by multiple command processors, but run() currently
+/// serializes their complete submissions because the batch state below is
+/// pool-wide.
 class CpuDispatchPool {
 public:
   explicit CpuDispatchPool(uint32_t threads) : CpuDispatchPool(threads, std::nullopt) {}
@@ -172,6 +177,9 @@ private:
     }
   }
 
+  // TODO: Move task/result/counter/exception state into per-submission objects
+  // and feed one shared worker queue so XCD-local CPs can submit concurrently
+  // while retaining independent join and exception-propagation boundaries.
   std::mutex run_mutex_;
   std::mutex mutex_;
   std::condition_variable_any work_cv_;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
@@ -175,7 +175,12 @@ struct DispatchEntry {
   /// What this entry carries. Every site that queues an entry must set it.
   DispatchPacketKind kind = DispatchPacketKind::Unset;
   bool host_signal = false;
-  bool barrier_bit = false;
+  /// Header barrier bit: this packet waits for all earlier packets in its queue.
+  bool wait_for_predecessors = false;
+  /// Packet-type ordering: following packets cannot pass this packet.
+  bool blocks_following = false;
+  /// Completion hooks and signal have already been delivered.
+  bool completion_notified = false;
   bool execution_begun = false;
   /// The packet carried an acquire fence of at least agent scope. Recorded on the
   /// entry so that every XCD running part of the grid can invalidate its own caches

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
@@ -108,7 +108,12 @@ struct DispatchEntry {
   /// fields, and this keeps HIP/MIOpen event timing consistent for guest queues.
   uint64_t profiling_start_timestamp = 0;
   bool host_signal = false;
-  bool barrier_bit = false;
+  /// Header barrier bit: this packet waits for all earlier packets in its queue.
+  bool wait_for_predecessors = false;
+  /// Packet-type ordering: following packets cannot pass this packet.
+  bool blocks_following = false;
+  /// Completion hooks and signal have already been delivered.
+  bool completion_notified = false;
   bool execution_begun = false;
 
   bool fully_dispatched() const { return dispatched_wgs >= total_wgs; }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/spi.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/spi.h
@@ -14,6 +14,7 @@
 #define ROCJITSU_VM_AMDGPU_SPI_H_
 
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/cpu_dispatch_pool.h"
 #include "rocjitsu/vm/amdgpu/dispatch_entry.h"
 #include "rocjitsu/vm/amdgpu/workgroup_key.h"
 #include "util/bit.h"
@@ -142,6 +143,48 @@ public:
     }
     return any_runnable;
   }
+
+  /// @brief Check whether any CU in this SE has active wavefronts.
+  bool has_active_cus() const {
+    for (auto *cu : cus_)
+      if (cu->has_active_wfs())
+        return true;
+    return false;
+  }
+
+  /// @brief Execute one functional quantum on each active CU.
+  ///
+  /// @details Drives wavefront execution for this SE's CUs, fanning out
+  /// across up to @p threads host threads via an SPI-owned worker pool.
+  /// @returns Whether any CU ran and whether one requested an event-loop yield.
+  FunctionalQuantumResult run_active_cus_once(uint32_t threads) {
+    // Reused across calls (one dispatch thread drives an SPI) to avoid a heap
+    // allocation on every dispatch quantum.
+    active_scratch_.clear();
+    for (auto *cu : cus_) {
+      if (cu->has_active_wfs())
+        active_scratch_.push_back(cu);
+    }
+    if (active_scratch_.empty())
+      return {};
+    auto &active = active_scratch_;
+
+    uint32_t effective_threads = std::min<uint32_t>(threads, static_cast<uint32_t>(active.size()));
+    FunctionalQuantumResult result;
+    if (effective_threads > 1) {
+      if (!dispatch_pool_ || dispatch_pool_->thread_count() < effective_threads)
+        dispatch_pool_ = std::make_unique<CpuDispatchPool>(effective_threads);
+      result = dispatch_pool_->run(active, effective_threads);
+    } else {
+      for (auto *cu : active)
+        result.merge(cu->run_quantum());
+    }
+    return result;
+  }
+
+  /// @brief Tear down the worker pool (e.g., on thread-count change).
+  void reset_dispatch_pool() { dispatch_pool_.reset(); }
+
   /// @brief Check if any WGs are queued or any CU is active.
   bool has_pending() const {
     for (auto &q : pipe_queues_)
@@ -291,6 +334,9 @@ private:
   std::unordered_map<uint64_t, WgpReservation> resident_wgp_workgroups_;
   std::vector<std::deque<WgRequest>> pipe_queues_;
   size_t next_pipe_ = 0;
+  std::unique_ptr<CpuDispatchPool> dispatch_pool_; ///< Drives wavefront execution on host threads.
+  std::vector<ComputeUnitCore *>
+      active_scratch_; ///< Reused active-CU list for run_active_cus_once.
 };
 
 } // namespace amdgpu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/spi.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/spi.h
@@ -14,7 +14,6 @@
 #define ROCJITSU_VM_AMDGPU_SPI_H_
 
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
-#include "rocjitsu/vm/amdgpu/cpu_dispatch_pool.h"
 #include "rocjitsu/vm/amdgpu/dispatch_entry.h"
 #include "rocjitsu/vm/amdgpu/workgroup_key.h"
 #include "util/bit.h"
@@ -152,38 +151,13 @@ public:
     return false;
   }
 
-  /// @brief Execute one functional quantum on each active CU.
-  ///
-  /// @details Drives wavefront execution for this SE's CUs, fanning out
-  /// across up to @p threads host threads via an SPI-owned worker pool.
-  /// @returns Whether any CU ran and whether one requested an event-loop yield.
-  FunctionalQuantumResult run_active_cus_once(uint32_t threads) {
-    // Reused across calls (one dispatch thread drives an SPI) to avoid a heap
-    // allocation on every dispatch quantum.
-    active_scratch_.clear();
+  /// @brief Append this SPI's active CUs to a command-processor work batch.
+  void append_active_cus(std::vector<ComputeUnitCore *> &active) const {
     for (auto *cu : cus_) {
       if (cu->has_active_wfs())
-        active_scratch_.push_back(cu);
+        active.push_back(cu);
     }
-    if (active_scratch_.empty())
-      return {};
-    auto &active = active_scratch_;
-
-    uint32_t effective_threads = std::min<uint32_t>(threads, static_cast<uint32_t>(active.size()));
-    FunctionalQuantumResult result;
-    if (effective_threads > 1) {
-      if (!dispatch_pool_ || dispatch_pool_->thread_count() < effective_threads)
-        dispatch_pool_ = std::make_unique<CpuDispatchPool>(effective_threads);
-      result = dispatch_pool_->run(active, effective_threads);
-    } else {
-      for (auto *cu : active)
-        result.merge(cu->run_quantum());
-    }
-    return result;
   }
-
-  /// @brief Tear down the worker pool (e.g., on thread-count change).
-  void reset_dispatch_pool() { dispatch_pool_.reset(); }
 
   /// @brief Check if any WGs are queued or any CU is active.
   bool has_pending() const {
@@ -334,9 +308,6 @@ private:
   std::unordered_map<uint64_t, WgpReservation> resident_wgp_workgroups_;
   std::vector<std::deque<WgRequest>> pipe_queues_;
   size_t next_pipe_ = 0;
-  std::unique_ptr<CpuDispatchPool> dispatch_pool_; ///< Drives wavefront execution on host threads.
-  std::vector<ComputeUnitCore *>
-      active_scratch_; ///< Reused active-CU list for run_active_cus_once.
 };
 
 } // namespace amdgpu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/spi.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/spi.h
@@ -14,7 +14,6 @@
 #define ROCJITSU_VM_AMDGPU_SPI_H_
 
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
-#include "rocjitsu/vm/amdgpu/cpu_dispatch_pool.h"
 #include "rocjitsu/vm/amdgpu/dispatch_entry.h"
 #include "rocjitsu/vm/amdgpu/workgroup_key.h"
 #include "util/bit.h"
@@ -151,38 +150,13 @@ public:
     return false;
   }
 
-  /// @brief Execute one functional quantum on each active CU.
-  ///
-  /// @details Drives wavefront execution for this SE's CUs, fanning out
-  /// across up to @p threads host threads via an SPI-owned worker pool.
-  /// @returns Whether any CU ran and whether one requested an event-loop yield.
-  FunctionalQuantumResult run_active_cus_once(uint32_t threads) {
-    // Reused across calls (one dispatch thread drives an SPI) to avoid a heap
-    // allocation on every dispatch quantum.
-    active_scratch_.clear();
+  /// @brief Append this SPI's active CUs to a command-processor work batch.
+  void append_active_cus(std::vector<ComputeUnitCore *> &active) const {
     for (auto *cu : cus_) {
       if (cu->has_active_wfs())
-        active_scratch_.push_back(cu);
+        active.push_back(cu);
     }
-    if (active_scratch_.empty())
-      return {};
-    auto &active = active_scratch_;
-
-    uint32_t effective_threads = std::min<uint32_t>(threads, static_cast<uint32_t>(active.size()));
-    FunctionalQuantumResult result;
-    if (effective_threads > 1) {
-      if (!dispatch_pool_ || dispatch_pool_->thread_count() < effective_threads)
-        dispatch_pool_ = std::make_unique<CpuDispatchPool>(effective_threads);
-      result = dispatch_pool_->run(active, effective_threads);
-    } else {
-      for (auto *cu : active)
-        result.merge(cu->run_quantum());
-    }
-    return result;
   }
-
-  /// @brief Tear down the worker pool (e.g., on thread-count change).
-  void reset_dispatch_pool() { dispatch_pool_.reset(); }
 
   /// @brief Check if any WGs are queued or any CU is active.
   bool has_pending() const {
@@ -333,9 +307,6 @@ private:
   std::unordered_map<uint64_t, WgpReservation> resident_wgp_workgroups_;
   std::vector<std::deque<WgRequest>> pipe_queues_;
   size_t next_pipe_ = 0;
-  std::unique_ptr<CpuDispatchPool> dispatch_pool_; ///< Drives wavefront execution on host threads.
-  std::vector<ComputeUnitCore *>
-      active_scratch_; ///< Reused active-CU list for run_active_cus_once.
 };
 
 } // namespace amdgpu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/spi.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/spi.h
@@ -14,6 +14,7 @@
 #define ROCJITSU_VM_AMDGPU_SPI_H_
 
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/cpu_dispatch_pool.h"
 #include "rocjitsu/vm/amdgpu/dispatch_entry.h"
 #include "rocjitsu/vm/amdgpu/workgroup_key.h"
 #include "util/bit.h"
@@ -141,6 +142,48 @@ public:
     }
     return any_runnable;
   }
+
+  /// @brief Check whether any CU in this SE has active wavefronts.
+  bool has_active_cus() const {
+    for (auto *cu : cus_)
+      if (cu->has_active_wfs())
+        return true;
+    return false;
+  }
+
+  /// @brief Execute one functional quantum on each active CU.
+  ///
+  /// @details Drives wavefront execution for this SE's CUs, fanning out
+  /// across up to @p threads host threads via an SPI-owned worker pool.
+  /// @returns Whether any CU ran and whether one requested an event-loop yield.
+  FunctionalQuantumResult run_active_cus_once(uint32_t threads) {
+    // Reused across calls (one dispatch thread drives an SPI) to avoid a heap
+    // allocation on every dispatch quantum.
+    active_scratch_.clear();
+    for (auto *cu : cus_) {
+      if (cu->has_active_wfs())
+        active_scratch_.push_back(cu);
+    }
+    if (active_scratch_.empty())
+      return {};
+    auto &active = active_scratch_;
+
+    uint32_t effective_threads = std::min<uint32_t>(threads, static_cast<uint32_t>(active.size()));
+    FunctionalQuantumResult result;
+    if (effective_threads > 1) {
+      if (!dispatch_pool_ || dispatch_pool_->thread_count() < effective_threads)
+        dispatch_pool_ = std::make_unique<CpuDispatchPool>(effective_threads);
+      result = dispatch_pool_->run(active, effective_threads);
+    } else {
+      for (auto *cu : active)
+        result.merge(cu->run_quantum());
+    }
+    return result;
+  }
+
+  /// @brief Tear down the worker pool (e.g., on thread-count change).
+  void reset_dispatch_pool() { dispatch_pool_.reset(); }
+
   /// @brief Check if any WGs are queued or any CU is active.
   bool has_pending() const {
     for (auto &q : pipe_queues_)
@@ -290,6 +333,9 @@ private:
   std::unordered_map<uint64_t, WgpReservation> resident_wgp_workgroups_;
   std::vector<std::deque<WgRequest>> pipe_queues_;
   size_t next_pipe_ = 0;
+  std::unique_ptr<CpuDispatchPool> dispatch_pool_; ///< Drives wavefront execution on host threads.
+  std::vector<ComputeUnitCore *>
+      active_scratch_; ///< Reused active-CU list for run_active_cus_once.
 };
 
 } // namespace amdgpu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/xcd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/xcd.cpp
@@ -26,7 +26,7 @@ Xcd::Xcd(std::string name, const Config &config, rj_code_arch_t arch, GpuMemory 
   add_child(std::move(l2));
 
   // Create command processor for this XCD.
-  auto cp = std::make_unique<CommandProcessor>(xcd_name + ".cp");
+  auto cp = std::make_unique<CommandProcessor>(xcd_name + ".cp", exec_mode);
   cp_ = cp.get();
   cp_->configure_for_arch(arch);
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.cpp
@@ -84,8 +84,31 @@ void SoC::set_plugin_group(std::shared_ptr<ExecutionPluginGroup> plugin_group) {
   plugin_group_ = plugin_group ? plugin_group : ExecutionPluginGroup::empty_group();
   for (auto *xcd : xcds_)
     xcd->set_plugin_group(plugin_group_);
-  if (plugin_group_->requires_serial_hot_hooks())
-    for_each_cp([](auto *cp) { cp->set_dispatch_threads(1); });
+  apply_dispatch_threads();
+}
+
+void SoC::set_dispatch_threads(uint32_t threads) {
+  requested_dispatch_threads_ = std::max(threads, 1u);
+  apply_dispatch_threads();
+}
+
+void SoC::apply_dispatch_threads() {
+  uint32_t effective_threads = requested_dispatch_threads_;
+  if (exec_mode_ != simdojo::ExecMode::FUNCTIONAL ||
+      (plugin_group_ && plugin_group_->requires_serial_hot_hooks()))
+    effective_threads = 1;
+
+  std::unique_ptr<amdgpu::CpuDispatchPool> new_pool;
+  if (effective_threads > 1)
+    new_pool = std::make_unique<amdgpu::CpuDispatchPool>(effective_threads);
+
+  auto *pool = new_pool.get();
+  for_each_cp([pool, effective_threads](auto *cp) {
+    cp->set_shared_dispatch_pool(pool);
+    cp->set_dispatch_threads(effective_threads);
+  });
+  dispatch_pool_ = std::move(new_pool);
+  dispatch_threads_ = effective_threads;
 }
 
 void SoC::flush_all() {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.cpp
@@ -84,6 +84,8 @@ void SoC::set_plugin_group(std::shared_ptr<ExecutionPluginGroup> plugin_group) {
   plugin_group_ = plugin_group ? plugin_group : ExecutionPluginGroup::empty_group();
   for (auto *xcd : xcds_)
     xcd->set_plugin_group(plugin_group_);
+  if (plugin_group_->requires_serial_hot_hooks())
+    for_each_cp([](auto *cp) { cp->set_dispatch_threads(1); });
 }
 
 void SoC::flush_all() {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.cpp
@@ -94,8 +94,7 @@ void SoC::set_dispatch_threads(uint32_t threads) {
 
 void SoC::apply_dispatch_threads() {
   uint32_t effective_threads = requested_dispatch_threads_;
-  if (exec_mode_ != simdojo::ExecMode::FUNCTIONAL ||
-      (plugin_group_ && plugin_group_->requires_serial_hot_hooks()))
+  if (exec_mode_ != simdojo::ExecMode::FUNCTIONAL)
     effective_threads = 1;
 
   std::unique_ptr<amdgpu::CpuDispatchPool> new_pool;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.cpp
@@ -6,6 +6,7 @@
 #include "simdojo/sim/simulation.h"
 #include "simdojo/sim/topology.h"
 
+#include <algorithm>
 #include <memory>
 #include <string>
 
@@ -82,8 +83,31 @@ void SoC::set_plugin_group(std::shared_ptr<ExecutionPluginGroup> plugin_group) {
   plugin_group_ = plugin_group ? plugin_group : ExecutionPluginGroup::empty_group();
   for (auto *xcd : xcds_)
     xcd->set_plugin_group(plugin_group_);
-  if (plugin_group_->requires_serial_hot_hooks())
-    for_each_cp([](auto *cp) { cp->set_dispatch_threads(1); });
+  apply_dispatch_threads();
+}
+
+void SoC::set_dispatch_threads(uint32_t threads) {
+  requested_dispatch_threads_ = std::max(threads, 1u);
+  apply_dispatch_threads();
+}
+
+void SoC::apply_dispatch_threads() {
+  uint32_t effective_threads = requested_dispatch_threads_;
+  if (exec_mode_ != simdojo::ExecMode::FUNCTIONAL ||
+      (plugin_group_ && plugin_group_->requires_serial_hot_hooks()))
+    effective_threads = 1;
+
+  std::unique_ptr<amdgpu::CpuDispatchPool> new_pool;
+  if (effective_threads > 1)
+    new_pool = std::make_unique<amdgpu::CpuDispatchPool>(effective_threads);
+
+  auto *pool = new_pool.get();
+  for_each_cp([pool, effective_threads](auto *cp) {
+    cp->set_shared_dispatch_pool(pool);
+    cp->set_dispatch_threads(effective_threads);
+  });
+  dispatch_pool_ = std::move(new_pool);
+  dispatch_threads_ = effective_threads;
 }
 
 void SoC::flush_all() {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.cpp
@@ -82,6 +82,8 @@ void SoC::set_plugin_group(std::shared_ptr<ExecutionPluginGroup> plugin_group) {
   plugin_group_ = plugin_group ? plugin_group : ExecutionPluginGroup::empty_group();
   for (auto *xcd : xcds_)
     xcd->set_plugin_group(plugin_group_);
+  if (plugin_group_->requires_serial_hot_hooks())
+    for_each_cp([](auto *cp) { cp->set_dispatch_threads(1); });
 }
 
 void SoC::flush_all() {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.cpp
@@ -84,7 +84,6 @@ void SoC::set_plugin_group(std::shared_ptr<ExecutionPluginGroup> plugin_group) {
   plugin_group_ = plugin_group ? plugin_group : ExecutionPluginGroup::empty_group();
   for (auto *xcd : xcds_)
     xcd->set_plugin_group(plugin_group_);
-  apply_dispatch_threads();
 }
 
 void SoC::set_dispatch_threads(uint32_t threads) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.h
@@ -7,6 +7,7 @@
 #ifndef ROCJITSU_VM_SOC_H_
 #define ROCJITSU_VM_SOC_H_
 
+#include "rocjitsu/vm/amdgpu/cpu_dispatch_pool.h"
 #include "rocjitsu/vm/amdgpu/gpu_memory.h"
 #include "rocjitsu/vm/amdgpu/hbm_controller.h"
 #include "rocjitsu/vm/amdgpu/iod.h"
@@ -24,6 +25,10 @@
 #include <vector>
 
 namespace rocjitsu {
+
+namespace test {
+class SoCTestAccess;
+}
 
 /// @brief System-on-Chip container with XCDs, I/O Dies, and shared GPU memory.
 ///
@@ -188,11 +193,19 @@ public:
   /// @brief Set the execution plugin group and distribute to CPs/CUs.
   void set_plugin_group(std::shared_ptr<ExecutionPluginGroup> plugin_group);
 
+  /// @brief Set the shared host-thread budget for CU dispatch across this SoC.
+  void set_dispatch_threads(uint32_t threads);
+  uint32_t dispatch_threads() const { return dispatch_threads_; }
+
   const std::vector<amdgpu::ComputeUnitCore *> &all_cus();
 
   ExecutionPluginGroup &plugin_group() { return *plugin_group_; }
 
 private:
+  friend class test::SoCTestAccess;
+
+  void apply_dispatch_threads();
+
   static inline std::atomic<uint32_t> next_gpu_id_{0};
   uint32_t gpu_id_ = next_gpu_id_++;
   rj_code_arch_t arch_ = ROCJITSU_CODE_ARCH_INVALID;
@@ -201,6 +214,9 @@ private:
   std::vector<amdgpu::Iod *> iods_;
   amdgpu::GpuMemory *memory_ = nullptr;
   std::unique_ptr<amdgpu::HbmController> hbm_standalone_; ///< Used when num_iods == 0.
+  std::unique_ptr<amdgpu::CpuDispatchPool> dispatch_pool_;
+  uint32_t requested_dispatch_threads_ = 1;
+  uint32_t dispatch_threads_ = 1;
   std::shared_ptr<ExecutionPluginGroup> plugin_group_;
   std::vector<amdgpu::ComputeUnitCore *> all_cus_cache_;
 };

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.h
@@ -7,6 +7,7 @@
 #ifndef ROCJITSU_VM_SOC_H_
 #define ROCJITSU_VM_SOC_H_
 
+#include "rocjitsu/vm/amdgpu/cpu_dispatch_pool.h"
 #include "rocjitsu/vm/amdgpu/gpu_memory.h"
 #include "rocjitsu/vm/amdgpu/hbm_controller.h"
 #include "rocjitsu/vm/amdgpu/iod.h"
@@ -24,6 +25,10 @@
 #include <vector>
 
 namespace rocjitsu {
+
+namespace test {
+class SoCTestAccess;
+}
 
 /// @brief System-on-Chip container with XCDs, I/O Dies, and shared GPU memory.
 ///
@@ -179,11 +184,19 @@ public:
   /// @brief Set the execution plugin group and distribute to CPs/CUs.
   void set_plugin_group(std::shared_ptr<ExecutionPluginGroup> plugin_group);
 
+  /// @brief Set the shared host-thread budget for CU dispatch across this SoC.
+  void set_dispatch_threads(uint32_t threads);
+  uint32_t dispatch_threads() const { return dispatch_threads_; }
+
   const std::vector<amdgpu::ComputeUnitCore *> &all_cus();
 
   ExecutionPluginGroup &plugin_group() { return *plugin_group_; }
 
 private:
+  friend class test::SoCTestAccess;
+
+  void apply_dispatch_threads();
+
   static inline std::atomic<uint32_t> next_gpu_id_{0};
   uint32_t gpu_id_ = next_gpu_id_++;
   rj_code_arch_t arch_ = ROCJITSU_CODE_ARCH_INVALID;
@@ -192,6 +205,9 @@ private:
   std::vector<amdgpu::Iod *> iods_;
   amdgpu::GpuMemory *memory_ = nullptr;
   std::unique_ptr<amdgpu::HbmController> hbm_standalone_; ///< Used when num_iods == 0.
+  std::unique_ptr<amdgpu::CpuDispatchPool> dispatch_pool_;
+  uint32_t requested_dispatch_threads_ = 1;
+  uint32_t dispatch_threads_ = 1;
   std::shared_ptr<ExecutionPluginGroup> plugin_group_;
   std::vector<amdgpu::ComputeUnitCore *> all_cus_cache_;
 };

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/soc.h
@@ -193,7 +193,12 @@ public:
   /// @brief Set the execution plugin group and distribute to CPs/CUs.
   void set_plugin_group(std::shared_ptr<ExecutionPluginGroup> plugin_group);
 
-  /// @brief Set the shared host-thread budget for CU dispatch across this SoC.
+  /// @brief Set the shared host-thread budget for functional CU execution.
+  ///
+  /// @details This controls host acceleration rather than modeled GPU
+  /// resources or timing. The count includes the command-processor thread that
+  /// calls the pool. One pool is shared across the SoC, and its current
+  /// single-submission implementation serializes batches from different CPs.
   void set_dispatch_threads(uint32_t threads);
   uint32_t dispatch_threads() const { return dispatch_threads_; }
 

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -435,6 +435,7 @@ add_executable(
     instruction_cache_test.cpp
     scaling_thread_counts_test.cpp
     sparse_memory_test.cpp
+    cpu_dispatch_pool_test.cpp
     simdojo_sim_test.cpp
     partitioning_test.cpp
     simulated_kfd_test.cpp

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -413,6 +413,7 @@ add_executable(
     cdna5_tensor_dma_test.cpp
     l2_cache_test.cpp
     sparse_memory_test.cpp
+    cpu_dispatch_pool_test.cpp
     simdojo_sim_test.cpp
     partitioning_test.cpp
     simulated_kfd_test.cpp

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -4469,7 +4469,8 @@ TEST(AqlDispatchTest, PoolContinuationLetsPeerQueueSatisfyPollingWave) {
                                 test::AqlQueue::DEFAULT_RING_SIZE,
                                 /*read_ptr_addr=*/0xE0010000,
                                 /*write_ptr_addr=*/0xE0010008,
-                                /*doorbell_addr=*/0xE0010010);
+                                /*doorbell_addr=*/0xE0010010,
+                                /*xcd_fanout=*/false, /*queue_id=*/2);
   auto waiter_packet = make_dispatch_packet(waiter, waiter_signal);
   waiter_packet.kernarg_address = reinterpret_cast<void *>(producer_signal);
   waiter_queue.submit(waiter_packet);

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -3667,14 +3667,21 @@ TEST_P(IsaTest, VendorSpecificBarrierValueOrdersQueueEntries) {
 }
 
 TEST_P(IsaTest, NonKernelBarrierPacketsOrderQueueEntries) {
-  constexpr std::array packet_types{
-      HSA_PACKET_TYPE_BARRIER_AND,
-      HSA_PACKET_TYPE_BARRIER_OR,
-      HSA_PACKET_TYPE_VENDOR_SPECIFIC,
+  struct BarrierCase {
+    uint16_t packet_type;
+    bool header_barrier_bit;
+  };
+  constexpr std::array barrier_cases{
+      BarrierCase{HSA_PACKET_TYPE_BARRIER_AND, true},
+      BarrierCase{HSA_PACKET_TYPE_BARRIER_AND, false},
+      BarrierCase{HSA_PACKET_TYPE_BARRIER_OR, true},
+      BarrierCase{HSA_PACKET_TYPE_BARRIER_OR, false},
+      BarrierCase{HSA_PACKET_TYPE_VENDOR_SPECIFIC, true},
   };
 
-  for (const auto packet_type : packet_types) {
+  for (const auto [packet_type, header_barrier_bit] : barrier_cases) {
     SCOPED_TRACE(packet_type);
+    SCOPED_TRACE(header_barrier_bit);
     VmFixture f(arch(), 1, 8);
 
     const uint32_t code[] = {SOPP_S_NOP, SOPP_S_ENDPGM};
@@ -3697,7 +3704,7 @@ TEST_P(IsaTest, NonKernelBarrierPacketsOrderQueueEntries) {
     dispatch.kernel_object = ko;
 
     hsa_kernel_dispatch_packet_t barrier{};
-    barrier.header = packet_type | (1 << HSA_PACKET_HEADER_BARRIER);
+    barrier.header = packet_type | (header_barrier_bit ? (1 << HSA_PACKET_HEADER_BARRIER) : 0);
     if (packet_type == HSA_PACKET_TYPE_VENDOR_SPECIFIC)
       barrier.setup = amdgpu::kAmdAqlFormatPm4Ib;
     barrier.completion_signal.handle = kBarrierCompletionSignal;

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -368,6 +368,22 @@ hsa_kernel_dispatch_packet_t make_dispatch_packet(uint64_t kernel_object, uint64
   return pkt;
 }
 
+uint64_t write_test_kernel(amdgpu::GpuMemory *memory, uint64_t addr,
+                           std::span<const uint32_t> code) {
+  using namespace rocr::llvm::amdhsa;
+  kernel_descriptor_t descriptor{};
+  descriptor.kernel_code_entry_byte_offset = sizeof(kernel_descriptor_t);
+  AMDHSA_BITS_SET(descriptor.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT,
+                  31);
+  AMDHSA_BITS_SET(descriptor.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT,
+                  12);
+  AMDHSA_BITS_SET(descriptor.compute_pgm_rsrc2, COMPUTE_PGM_RSRC2_USER_SGPR_COUNT, 2);
+  memory->load_image(reinterpret_cast<const uint8_t *>(&descriptor), sizeof(descriptor), addr);
+  memory->load_image(reinterpret_cast<const uint8_t *>(code.data()), code.size_bytes(),
+                     addr + sizeof(descriptor));
+  return addr;
+}
+
 // Drive the engine until the listed CUs have no resident wavefronts. A wavefront
 // frees itself at s_endpgm (num_wfs()/has_active_wfs() drop as it halts), so the
 // kernel is complete once every listed CU reports idle. Waves that need their final
@@ -3716,8 +3732,12 @@ TEST_P(IsaTest, NonKernelBarrierPacketsOrderQueueEntries) {
     queue.submit(dispatch);
     (void)f.engine->step();
 
-    EXPECT_EQ(f.cu()->num_wfs(), 1u);
-    EXPECT_EQ(f.mem()->read64(kBarrierCompletionSignal + kSignalValueOffset), 1u);
+    const bool completes_ahead_of_prior_dispatch =
+        !header_barrier_bit &&
+        (packet_type == HSA_PACKET_TYPE_BARRIER_AND || packet_type == HSA_PACKET_TYPE_BARRIER_OR);
+    EXPECT_EQ(f.cu()->num_wfs(), completes_ahead_of_prior_dispatch ? 2u : 1u);
+    EXPECT_EQ(f.mem()->read64(kBarrierCompletionSignal + kSignalValueOffset),
+              completes_ahead_of_prior_dispatch ? 0u : 1u);
     EXPECT_EQ(f.mem()->read64(kLaterCompletionSignal + kSignalValueOffset), 1u);
 
     f.engine->run();
@@ -3725,6 +3745,46 @@ TEST_P(IsaTest, NonKernelBarrierPacketsOrderQueueEntries) {
     EXPECT_EQ(f.mem()->read64(kBarrierCompletionSignal + kSignalValueOffset), 0u);
     EXPECT_EQ(f.mem()->read64(kLaterCompletionSignal + kSignalValueOffset), 0u);
   }
+}
+
+TEST(AqlDispatchTest, HeaderClearBarrierUnblocksPriorPollingKernelBeforeLaterDispatch) {
+  VmFixture f("cdna4", /*num_cus=*/2);
+  f.cp()->set_dispatch_threads(2);
+
+  const uint32_t waiter_code[] = {
+      0xC0060080u,
+      0x00000008u, // s_load_dwordx2 s[2:3], s[0:1], 8
+      0xBF8C0000u, // s_waitcnt 0
+      0xBF128002u, // s_cmp_eq_u64 s[2:3], 0
+      0xBF84FFFBu, // s_cbranch_scc0 -5
+      SOPP_S_ENDPGM,
+  };
+  const uint32_t later_code[] = {SOPP_S_NOP, SOPP_S_ENDPGM};
+  const uint64_t waiter = f.write_kernel(0x1000, waiter_code, sizeof(waiter_code));
+  const uint64_t later = f.write_kernel(0x2000, later_code, sizeof(later_code));
+
+  constexpr uint64_t barrier_signal = 0xF0022000;
+  constexpr uint64_t waiter_signal = 0xF0022100;
+  constexpr uint64_t later_signal = 0xF0022200;
+  init_completion_signal(f.mem(), barrier_signal);
+  init_completion_signal(f.mem(), waiter_signal);
+  init_completion_signal(f.mem(), later_signal);
+
+  auto waiter_packet = make_dispatch_packet(waiter, waiter_signal);
+  waiter_packet.kernarg_address = reinterpret_cast<void *>(barrier_signal);
+  hsa_kernel_dispatch_packet_t barrier{};
+  barrier.header = HSA_PACKET_TYPE_BARRIER_AND;
+  barrier.completion_signal.handle = barrier_signal;
+
+  test::AqlQueue queue(f.mem(), f.cp());
+  queue.submit(waiter_packet);
+  queue.submit(barrier);
+  queue.submit(make_dispatch_packet(later, later_signal));
+  f.engine->run();
+
+  EXPECT_EQ(completion_signal_value(f.mem(), barrier_signal), 0);
+  EXPECT_EQ(completion_signal_value(f.mem(), waiter_signal), 0);
+  EXPECT_EQ(completion_signal_value(f.mem(), later_signal), 0);
 }
 
 TEST_P(IsaTest, VendorSpecificRejectsUnsupportedFormats) {
@@ -3775,6 +3835,26 @@ TEST(ClusterDispatchTest, AccountsForPerWorkgroupLdsAlignmentWhenPlanningCluster
 
   EXPECT_THROW((void)f.engine->step(), std::runtime_error);
   EXPECT_FALSE(f.cu()->has_active_wfs());
+}
+
+TEST(ClusterDispatchTest, ParallelGfx1250RetiresClusterAfterWorkersRejoin) {
+  VmFixture f("gfx1250", /*num_cus=*/2, /*num_wf_slots=*/1, /*lds_size_kb=*/64,
+              /*sgprs_per_wf=*/128);
+  f.cp()->set_dispatch_threads(2);
+
+  const uint32_t code[] = {0xBFB00000u}; // s_endpgm
+  uint64_t ko = f.write_kernel(0x1000, code, sizeof(code), /*sgprs=*/128);
+  test::AqlQueue queue(f.mem(), f.cp());
+  queue.dispatch_clustered(ko, /*cluster_count_x=*/1, /*cluster_size_x=*/2,
+                           /*workgroup_size_x=*/32);
+
+  ASSERT_NO_THROW(f.engine->run());
+  EXPECT_FALSE(f.cu(0)->has_active_wfs());
+  EXPECT_FALSE(f.cu(1)->has_active_wfs());
+  EXPECT_TRUE(f.cp()
+                  ->cluster_lds_targets(/*dispatch_id=*/1, /*wg_id=*/0,
+                                        /*mcast_mask=*/0x3)
+                  .empty());
 }
 
 TEST(ClusterDispatchTest, ReclaimsLdsBetweenClusterWaves) {
@@ -4305,7 +4385,6 @@ void run_deferred_rescan_late_completion_test(uint32_t dispatch_threads, SubmitT
 
   ASSERT_TRUE(f.engine->step());
   EXPECT_TRUE(submitter->submitted());
-  EXPECT_EQ(f.cp()->dispatched_count(), 2u);
 
   for (uint32_t i = 0; i < 10000 && (completion_signal_value(f.mem(), sig_a) != 0 ||
                                      completion_signal_value(f.mem(), sig_b) != 0);
@@ -4315,6 +4394,7 @@ void run_deferred_rescan_late_completion_test(uint32_t dispatch_threads, SubmitT
 
   EXPECT_EQ(completion_signal_value(f.mem(), sig_a), 0);
   EXPECT_EQ(completion_signal_value(f.mem(), sig_b), 0);
+  EXPECT_EQ(f.cp()->dispatched_count(), 2u);
   EXPECT_FALSE(f.cu(0)->has_active_wfs());
   EXPECT_FALSE(f.cu(1)->has_active_wfs());
 }
@@ -4361,6 +4441,113 @@ TEST(AqlDispatchTest, SerialCompletionUnblocksCoResidentSignalWaiter) {
   EXPECT_EQ(completion_signal_value(f.mem(), producer_signal), 0);
   EXPECT_EQ(completion_signal_value(f.mem(), waiter_signal), 0);
   EXPECT_FALSE(f.cu()->has_active_wfs());
+}
+
+TEST(AqlDispatchTest, PoolContinuationLetsPeerQueueSatisfyPollingWave) {
+  VmFixture f("cdna4", /*num_cus=*/2, /*num_wf_slots=*/1);
+  f.cp()->set_dispatch_threads(2);
+
+  const uint32_t waiter_code[] = {
+      0xC0060080u,
+      0x00000008u, // s_load_dwordx2 s[2:3], s[0:1], 8
+      enc::S_WAITCNT_0, 0xBF128002u, enc::s_cbranch_scc0(-5), SOPP_S_ENDPGM,
+  };
+  const uint32_t producer_code[] = {SOPP_S_NOP, SOPP_S_ENDPGM};
+  const uint64_t waiter = f.write_kernel(0x1000, waiter_code, sizeof(waiter_code));
+  const uint64_t producer = f.write_kernel(0x2000, producer_code, sizeof(producer_code));
+
+  constexpr uint64_t producer_signal = 0xF0023000;
+  constexpr uint64_t waiter_signal = 0xF0023100;
+  init_completion_signal(f.mem(), producer_signal);
+  init_completion_signal(f.mem(), waiter_signal);
+
+  test::AqlQueue waiter_queue(f.mem(), f.cp());
+  test::AqlQueue producer_queue(f.mem(), f.cp(), /*ring_addr=*/0xE0000000,
+                                test::AqlQueue::DEFAULT_RING_SIZE,
+                                /*read_ptr_addr=*/0xE0010000,
+                                /*write_ptr_addr=*/0xE0010008,
+                                /*doorbell_addr=*/0xE0010010);
+  auto waiter_packet = make_dispatch_packet(waiter, waiter_signal);
+  waiter_packet.kernarg_address = reinterpret_cast<void *>(producer_signal);
+  waiter_queue.submit(waiter_packet);
+  producer_queue.submit(make_dispatch_packet(producer, producer_signal));
+
+  f.engine->run();
+
+  EXPECT_EQ(completion_signal_value(f.mem(), producer_signal), 0);
+  EXPECT_EQ(completion_signal_value(f.mem(), waiter_signal), 0);
+}
+
+TEST(AqlDispatchTest, PoolContinuationLetsPeerCommandProcessorSatisfyPollingWave) {
+  const char *json = R"({"max_ticks":10000,"num_threads":1,"vm":{"arch":"cdna4"},
+    "topology":{"root":{"name":"soc","type":"soc","children":[
+      {"name":"vram","type":"gpu_memory"},
+      {"name":"xcd0","type":"xcd","children":[
+        {"name":"l2","type":"l2_cache"},{"name":"cp","type":"command_processor"},
+        {"name":"se0","type":"shader_engine","children":[
+          {"name":"cu0","type":"compute_unit","config":[
+            {"key":"num_wf_slots","value":"1"},{"key":"sgprs_per_wf","value":"104"},
+            {"key":"vgprs_per_wf","value":"256"},{"key":"lds_size_kb","value":"64"}]}]}]},
+      {"name":"xcd1","type":"xcd","children":[
+        {"name":"l2","type":"l2_cache"},{"name":"cp","type":"command_processor"},
+        {"name":"se0","type":"shader_engine","children":[
+          {"name":"cu0","type":"compute_unit","config":[
+            {"key":"num_wf_slots","value":"1"},{"key":"sgprs_per_wf","value":"104"},
+            {"key":"vgprs_per_wf","value":"256"},{"key":"lds_size_kb","value":"64"}]}]}]}
+    ]},"links":[
+      {"src":"xcd0.cp.req_0","dst":"xcd0.se0.cu0.cpl","latency":1,"weight":2},
+      {"src":"xcd0.se0.cu0.req","dst":"xcd0.l2.cpl_0","latency":1,"weight":10},
+      {"src":"xcd1.cp.req_0","dst":"xcd1.se0.cu0.cpl","latency":1,"weight":2},
+      {"src":"xcd1.se0.cu0.req","dst":"xcd1.l2.cpl_0","latency":1,"weight":10}
+    ]}})";
+  auto loaded = config::load_config_from_string(json, rocjitsu::kEmbeddedSchema);
+  auto *soc_ptr = loaded.soc();
+  auto *memory = loaded.memory();
+  simdojo::SimulationEngine engine(loaded.engine_config);
+  engine.topology().set_root(loaded.take_root());
+  loaded.wire_links(engine.topology());
+  engine.create();
+  soc_ptr->set_dispatch_threads(2);
+
+  const uint32_t waiter_code[] = {
+      0xC0060080u,
+      0x00000008u, // s_load_dwordx2 s[2:3], s[0:1], 8
+      enc::S_WAITCNT_0, 0xBF128002u, enc::s_cbranch_scc0(-5), SOPP_S_ENDPGM,
+  };
+  const uint64_t waiter = write_test_kernel(memory, 0x1000, waiter_code);
+
+  constexpr uint64_t producer_signal = 0xF0024000;
+  constexpr uint64_t waiter_signal = 0xF0024100;
+  init_completion_signal(memory, producer_signal);
+  init_completion_signal(memory, waiter_signal);
+
+  auto *waiter_cp = soc_ptr->xcd(0)->command_processor();
+  auto *producer_cp = soc_ptr->xcd(1)->command_processor();
+  test::AqlQueue waiter_queue(memory, waiter_cp);
+  auto waiter_packet = make_dispatch_packet(waiter, waiter_signal);
+  waiter_packet.kernarg_address = reinterpret_cast<void *>(producer_signal);
+  waiter_queue.submit(waiter_packet);
+
+  bool producer_event_ran = false;
+  simdojo::Event producer_event{producer_cp, simdojo::EventType::TIMER_CALLBACK,
+                                [&](simdojo::Tick, simdojo::Message *) {
+                                  producer_event_ran = true;
+                                  memory->write64(producer_signal + 8, 0);
+                                  soc_ptr->xcd(0)->shader_engine(0)->compute_unit(0)->flush_l1();
+                                  soc_ptr->xcd(0)->l2_cache()->invalidate_all();
+                                }};
+  engine.schedule_event_async(&producer_event, 1);
+
+  for (uint32_t i = 0; i < 10000 && (completion_signal_value(memory, producer_signal) != 0 ||
+                                     completion_signal_value(memory, waiter_signal) != 0);
+       ++i)
+    ASSERT_TRUE(engine.step());
+
+  EXPECT_TRUE(producer_event_ran);
+  EXPECT_EQ(completion_signal_value(memory, producer_signal), 0);
+  EXPECT_EQ(completion_signal_value(memory, waiter_signal), 0)
+      << "waiter dispatches=" << waiter_cp->dispatched_count()
+      << " exit=" << engine.last_exit().message;
 }
 
 TEST_P(IsaTest, EngineRunsToCompletion) {

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -2528,8 +2528,8 @@ TEST(ClusterDispatchTest, AccountsForPerWorkgroupLdsAlignmentWhenPlanningCluster
   EXPECT_FALSE(f.cu()->has_active_wfs());
 }
 
-TEST(ClusterDispatchTest, ParallelGfx1250RetiresClusterAfterWorkersRejoin) {
-  VmFixture f("gfx1250", /*num_cus=*/2, /*num_wf_slots=*/1, /*lds_size_kb=*/64,
+TEST(ClusterDispatchTest, ParallelCdna5RetiresClusterAfterWorkersRejoin) {
+  VmFixture f("cdna5", /*num_cus=*/2, /*num_wf_slots=*/1, /*lds_size_kb=*/64,
               /*sgprs_per_wf=*/128);
   f.cp()->set_dispatch_threads(2);
 
@@ -3062,6 +3062,9 @@ void run_deferred_rescan_late_completion_test(uint32_t dispatch_threads, SubmitT
   queue.submit(packet_a);
 
   ASSERT_TRUE(f.engine->step());
+  if (!submitter->submitted()) {
+    ASSERT_TRUE(f.engine->step());
+  }
   EXPECT_TRUE(submitter->submitted());
 
   for (uint32_t i = 0; i < 10000 && (completion_signal_value(f.mem(), sig_a) != 0 ||
@@ -4133,6 +4136,147 @@ TEST(L1ScalarCacheVmidTest, WriteThroughStoreUsesStoreVmid) {
   mem.unregister_process(kVmidB);
 }
 
+std::vector<uint32_t> make_multi_quantum_nop_kernel() {
+  std::vector<uint32_t> code(2048, SOPP_S_NOP);
+  code.push_back(SOPP_S_ENDPGM);
+  return code;
+}
+
+void step_until_first_quantum(VmFixture &fixture, amdgpu::ComputeUnitCore *cu) {
+  for (uint32_t i = 0; i < 16 && cu->wf(0)->trace_inst_count_ < cu->functional_quantum(); ++i)
+    ASSERT_TRUE(fixture.engine->step());
+  ASSERT_EQ(cu->wf(0)->trace_inst_count_, cu->functional_quantum());
+  ASSERT_TRUE(cu->has_active_wfs());
+}
+
+class LiveSerialDispatchPlugin final : public ExecutionPlugin {
+public:
+  LiveSerialDispatchPlugin() : ExecutionPlugin("live_serial_dispatch") {}
+  bool requires_serial_hot_hooks() const override { return true; }
+};
+
+class LiveParallelDispatchPlugin final : public ExecutionPlugin {
+public:
+  LiveParallelDispatchPlugin() : ExecutionPlugin("live_parallel_dispatch") {}
+  bool requires_serial_hot_hooks() const override { return false; }
+};
+
+TEST(AqlDispatchTest, ActiveDispatchSurvivesSerialToPoolTransition) {
+  VmFixture f("cdna4", /*num_cus=*/1, /*num_wf_slots=*/1);
+  auto code = make_multi_quantum_nop_kernel();
+  uint64_t kernel = f.write_kernel(0x1000, code.data(), code.size() * sizeof(uint32_t));
+  test::AqlQueue queue(f.mem(), f.cp());
+  queue.dispatch(kernel, /*grid_size=*/64, /*workgroup_size=*/64);
+
+  step_until_first_quantum(f, f.cu());
+  f.cp()->set_dispatch_threads(2);
+  EXPECT_EQ(f.cp()->dispatch_threads(), 2u);
+
+  f.engine->run();
+  EXPECT_TRUE(f.cu()->is_idle());
+}
+
+TEST(AqlDispatchTest, ActiveDispatchSurvivesPoolToSerialTransition) {
+  VmFixture f("cdna4", /*num_cus=*/1, /*num_wf_slots=*/1);
+  f.cp()->set_dispatch_threads(2);
+  auto code = make_multi_quantum_nop_kernel();
+  uint64_t kernel = f.write_kernel(0x1000, code.data(), code.size() * sizeof(uint32_t));
+  test::AqlQueue queue(f.mem(), f.cp());
+  queue.dispatch(kernel, /*grid_size=*/64, /*workgroup_size=*/64);
+
+  step_until_first_quantum(f, f.cu());
+  f.cp()->set_dispatch_threads(1);
+  EXPECT_EQ(f.cp()->dispatch_threads(), 1u);
+
+  f.engine->run();
+  EXPECT_TRUE(f.cu()->is_idle());
+}
+
+TEST(AqlDispatchTest, LivePluginReplacementRestoresPoolDuringActiveDispatch) {
+  VmFixture f("cdna4", /*num_cus=*/1, /*num_wf_slots=*/1);
+  f.soc_ptr->set_dispatch_threads(2);
+  auto serial_group = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
+  ASSERT_TRUE(serial_group->add(std::make_unique<LiveSerialDispatchPlugin>()));
+  f.soc_ptr->set_plugin_group(serial_group);
+  ASSERT_EQ(f.cp()->dispatch_threads(), 1u);
+
+  auto code = make_multi_quantum_nop_kernel();
+  uint64_t kernel = f.write_kernel(0x1000, code.data(), code.size() * sizeof(uint32_t));
+  test::AqlQueue queue(f.mem(), f.cp());
+  queue.dispatch(kernel, /*grid_size=*/64, /*workgroup_size=*/64);
+  step_until_first_quantum(f, f.cu());
+
+  auto parallel_group = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
+  ASSERT_TRUE(parallel_group->add(std::make_unique<LiveParallelDispatchPlugin>()));
+  f.soc_ptr->set_plugin_group(parallel_group);
+  EXPECT_EQ(f.soc_ptr->dispatch_threads(), 2u);
+  EXPECT_EQ(f.cp()->dispatch_threads(), 2u);
+
+  f.engine->run();
+  EXPECT_TRUE(f.cu()->is_idle());
+}
+
+uint64_t instructions_visible_at_tick_ten(uint32_t dispatch_threads) {
+  VmFixture f("cdna4", /*num_cus=*/1, /*num_wf_slots=*/1);
+  f.cp()->set_dispatch_threads(dispatch_threads);
+  auto code = make_multi_quantum_nop_kernel();
+  uint64_t kernel = f.write_kernel(0x1000, code.data(), code.size() * sizeof(uint32_t));
+  test::AqlQueue queue(f.mem(), f.cp());
+  queue.dispatch(kernel, /*grid_size=*/64, /*workgroup_size=*/64);
+
+  uint64_t observed = 0;
+  simdojo::Event producer_event{
+      f.cp(), simdojo::EventType::TIMER_CALLBACK,
+      [&](simdojo::Tick, simdojo::Message *) { observed = f.cu()->wf(0)->trace_inst_count_; }};
+  f.engine->schedule_event_async(&producer_event, 10);
+  f.engine->run();
+  return observed;
+}
+
+TEST(AqlDispatchTest, PoolPreservesSerialQuantumSpacingAroundPeerEvent) {
+  EXPECT_EQ(instructions_visible_at_tick_ten(/*dispatch_threads=*/1), 1024u);
+  EXPECT_EQ(instructions_visible_at_tick_ten(/*dispatch_threads=*/2), 1024u);
+}
+
+TEST(AqlDispatchTest, PoolTracksIndependentCuDueTicks) {
+  constexpr uint32_t kSSleep = 0xBF8E0001u;
+  VmFixture f("cdna4", /*num_cus=*/2, /*num_wf_slots=*/1);
+  f.cp()->set_dispatch_threads(2);
+
+  const uint32_t short_code[] = {kSSleep, SOPP_S_ENDPGM};
+  auto long_code = make_multi_quantum_nop_kernel();
+  uint64_t short_kernel = f.write_kernel(0x1000, short_code, sizeof(short_code));
+  uint64_t long_kernel =
+      f.write_kernel(0x4000, long_code.data(), long_code.size() * sizeof(uint32_t));
+  test::AqlQueue queue(f.mem(), f.cp());
+  queue.dispatch(short_kernel, /*grid_size=*/64, /*workgroup_size=*/64);
+  queue.dispatch(long_kernel, /*grid_size=*/64, /*workgroup_size=*/64);
+
+  uint32_t idle_cus = 0;
+  uint32_t active_cus = 0;
+  uint64_t active_instructions = 0;
+  simdojo::Event observer_event{f.cp(), simdojo::EventType::TIMER_CALLBACK,
+                                [&](simdojo::Tick, simdojo::Message *) {
+                                  for (uint32_t i = 0; i < 2; ++i) {
+                                    auto *cu = f.cu(i);
+                                    if (cu->is_idle())
+                                      ++idle_cus;
+                                    else {
+                                      ++active_cus;
+                                      active_instructions = cu->wf(0)->trace_inst_count_;
+                                    }
+                                  }
+                                }};
+  f.engine->schedule_event_async(&observer_event, 3);
+  f.engine->run();
+
+  EXPECT_EQ(idle_cus, 1u);
+  EXPECT_EQ(active_cus, 1u);
+  EXPECT_EQ(active_instructions, 1024u);
+  EXPECT_TRUE(f.cu(0)->is_idle());
+  EXPECT_TRUE(f.cu(1)->is_idle());
+}
+
 class BlockingInstructionPlugin final : public ExecutionPlugin {
 public:
   BlockingInstructionPlugin() : ExecutionPlugin("blocking_instruction") {}
@@ -4174,6 +4318,7 @@ TEST(AqlDispatchTest, WorkerExceptionPropagatesThroughEngineStep) {
   test::AqlQueue queue(f.mem(), f.cp());
   queue.dispatch(kernel, /*grid_size=*/128, /*workgroup_size=*/64);
 
+  ASSERT_TRUE(f.engine->step()); // Doorbell dispatches work for tick 1.
   EXPECT_THROW((void)f.engine->step(), std::exception);
 }
 
@@ -4197,11 +4342,13 @@ TEST(AqlDispatchTest, WorkerYieldReturnsToEventLoopBeforeResuming) {
                               peer_saw_yielded_waves = wf0 && wf1 && wf0->trace_inst_count_ == 1 &&
                                                        wf1->trace_inst_count_ == 1;
                             }};
-  f.engine->schedule_event_async(&peer_event, 1);
+  f.engine->schedule_event_async(&peer_event, 2);
 
-  ASSERT_TRUE(f.engine->step()); // Doorbell: both CUs stop after s_sleep.
+  ASSERT_TRUE(f.engine->step()); // Doorbell schedules both CUs for tick 1.
   EXPECT_FALSE(peer_event_ran);
-  ASSERT_TRUE(f.engine->step()); // Peer event runs before the CU resume events.
+  ASSERT_TRUE(f.engine->step()); // Both CUs stop after s_sleep.
+  EXPECT_FALSE(peer_event_ran);
+  ASSERT_TRUE(f.engine->step()); // Peer event runs before the tick-2 CU resume.
   EXPECT_TRUE(peer_event_ran);
   EXPECT_TRUE(peer_saw_yielded_waves);
 
@@ -4231,6 +4378,7 @@ TEST(AqlDispatchTest, QueueMutationWaitsForDispatchWorkerWindow) {
   f.cp()->register_queue(removable_queue);
   dispatch_queue.dispatch(kernel, /*grid_size=*/128, /*workgroup_size=*/64);
 
+  ASSERT_TRUE(f.engine->step()); // Doorbell schedules the worker batch.
   auto step = std::async(std::launch::async, [&]() { return f.engine->step(); });
   const bool entered = blocker->wait_until_entered(2s);
   EXPECT_TRUE(entered) << "CU execution did not reach the blocking plugin";

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -2358,14 +2358,21 @@ TEST_P(IsaTest, VendorSpecificBarrierValueOrdersQueueEntries) {
 }
 
 TEST_P(IsaTest, NonKernelBarrierPacketsOrderQueueEntries) {
-  constexpr std::array packet_types{
-      HSA_PACKET_TYPE_BARRIER_AND,
-      HSA_PACKET_TYPE_BARRIER_OR,
-      HSA_PACKET_TYPE_VENDOR_SPECIFIC,
+  struct BarrierCase {
+    uint16_t packet_type;
+    bool header_barrier_bit;
+  };
+  constexpr std::array barrier_cases{
+      BarrierCase{HSA_PACKET_TYPE_BARRIER_AND, true},
+      BarrierCase{HSA_PACKET_TYPE_BARRIER_AND, false},
+      BarrierCase{HSA_PACKET_TYPE_BARRIER_OR, true},
+      BarrierCase{HSA_PACKET_TYPE_BARRIER_OR, false},
+      BarrierCase{HSA_PACKET_TYPE_VENDOR_SPECIFIC, true},
   };
 
-  for (const auto packet_type : packet_types) {
+  for (const auto [packet_type, header_barrier_bit] : barrier_cases) {
     SCOPED_TRACE(packet_type);
+    SCOPED_TRACE(header_barrier_bit);
     VmFixture f(arch(), 1, 8);
 
     const uint32_t code[] = {SOPP_S_NOP, SOPP_S_ENDPGM};
@@ -2388,7 +2395,7 @@ TEST_P(IsaTest, NonKernelBarrierPacketsOrderQueueEntries) {
     dispatch.kernel_object = ko;
 
     hsa_kernel_dispatch_packet_t barrier{};
-    barrier.header = packet_type | (1 << HSA_PACKET_HEADER_BARRIER);
+    barrier.header = packet_type | (header_barrier_bit ? (1 << HSA_PACKET_HEADER_BARRIER) : 0);
     if (packet_type == HSA_PACKET_TYPE_VENDOR_SPECIFIC)
       barrier.setup = amdgpu::kAmdAqlFormatPm4Ib;
     barrier.completion_signal.handle = kBarrierCompletionSignal;

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -17,6 +17,7 @@
 #include "rocjitsu/vm/amdgpu/l1_scalar_cache.h"
 #include "rocjitsu/vm/amdgpu/l2_cache.h"
 #include "rocjitsu/vm/amdgpu/wavefront.h"
+#include "rocjitsu/vm/plugins/execution_plugin_group.h"
 #include "rocjitsu/vm/rj_vm.h"
 #include "rocjitsu/vm/soc.h"
 
@@ -37,9 +38,11 @@ RJ_DIAGNOSTIC_POP
 #include <barrier>
 #include <bit>
 #include <chrono>
+#include <condition_variable>
 #include <cstdint>
 #include <cstring>
 #include <functional>
+#include <future>
 #include <limits>
 #include <memory>
 #include <new>
@@ -203,6 +206,72 @@ TEST(ComputeUnitConfigTest, RejectsWavefrontSlotsAboveIsaMaximum) {
 
 TEST(ComputeUnitConfigTest, RejectsVgprSpanAboveIsaMaximum) {
   EXPECT_THROW((void)VmFixture("cdna3", 1, 32, 64, 104, 513), util::ConfigError);
+}
+
+enum class SubmitTrigger { DispatchBegin, AfterInstruction };
+
+class SubmitDispatchDuringWorkerPlugin final : public ExecutionPlugin {
+public:
+  SubmitDispatchDuringWorkerPlugin(test::AqlQueue &queue,
+                                   const hsa_kernel_dispatch_packet_t &packet,
+                                   SubmitTrigger trigger)
+      : ExecutionPlugin("submit_dispatch_during_worker"), queue_(queue), packet_(packet),
+        trigger_(trigger) {}
+
+  void onAmdgpuDispatchExecutionBegin(uint32_t /*dispatch_id*/) override {
+    if (trigger_ == SubmitTrigger::DispatchBegin)
+      submit_once();
+  }
+
+  void onAmdgpuAfterExecuteInstruction(uint64_t /*pc*/, const Instruction & /*inst*/,
+                                       amdgpu::Wavefront & /*wf*/) override {
+    if (trigger_ == SubmitTrigger::AfterInstruction)
+      submit_once();
+  }
+
+  bool submitted() const { return submitted_.load(); }
+
+  bool requires_serial_hot_hooks() const override { return false; }
+
+private:
+  void submit_once() {
+    bool expected = false;
+    if (submitted_.compare_exchange_strong(expected, true))
+      queue_.submit(packet_);
+  }
+
+  test::AqlQueue &queue_;
+  hsa_kernel_dispatch_packet_t packet_{};
+  SubmitTrigger trigger_;
+  std::atomic_bool submitted_{false};
+};
+
+void init_completion_signal(amdgpu::GpuMemory *mem, uint64_t signal_addr) {
+  mem->write64(signal_addr, 0);
+  mem->write64(signal_addr + 8, 1);
+  mem->write64(signal_addr + 16, 0);
+  mem->write32(signal_addr + 24, 0);
+}
+
+int64_t completion_signal_value(amdgpu::GpuMemory *mem, uint64_t signal_addr) {
+  return static_cast<int64_t>(mem->read64(signal_addr + 8));
+}
+
+hsa_kernel_dispatch_packet_t make_dispatch_packet(uint64_t kernel_object, uint64_t signal_addr,
+                                                  uint32_t grid_size_x = 64,
+                                                  uint16_t workgroup_size_x = 64) {
+  hsa_kernel_dispatch_packet_t pkt{};
+  pkt.header = HSA_PACKET_TYPE_KERNEL_DISPATCH;
+  pkt.setup = 1;
+  pkt.workgroup_size_x = workgroup_size_x;
+  pkt.workgroup_size_y = 1;
+  pkt.workgroup_size_z = 1;
+  pkt.grid_size_x = grid_size_x;
+  pkt.grid_size_y = 1;
+  pkt.grid_size_z = 1;
+  pkt.kernel_object = kernel_object;
+  pkt.completion_signal.handle = signal_addr;
+  return pkt;
 }
 
 // Drive the engine until the listed CUs have no resident wavefronts. A wavefront
@@ -2876,6 +2945,95 @@ TEST_P(IsaTest, RoundRobinScheduling) {
   EXPECT_EQ(f.cp()->dispatched_count(), 2u);
 }
 
+void run_deferred_rescan_late_completion_test(uint32_t dispatch_threads, SubmitTrigger trigger) {
+  VmFixture f("cdna3", /*num_cus=*/2);
+  f.cp()->set_dispatch_threads(dispatch_threads);
+
+  auto prog_a = ExecFixture::cat({{SOPP_S_NOP}, {SOPP_S_NOP}, {SOPP_S_ENDPGM}});
+  auto prog_b = ExecFixture::cat({{SOPP_S_NOP}, {SOPP_S_ENDPGM}});
+  uint64_t ko_a = f.write_kernel(0x1000, prog_a.data(), prog_a.size() * sizeof(uint32_t));
+  uint64_t ko_b = f.write_kernel(0x2000, prog_b.data(), prog_b.size() * sizeof(uint32_t));
+
+  constexpr uint64_t sig_a = 0xF0020000;
+  constexpr uint64_t sig_b = 0xF0020100;
+  init_completion_signal(f.mem(), sig_a);
+  init_completion_signal(f.mem(), sig_b);
+
+  test::AqlQueue queue(f.mem(), f.cp());
+  auto packet_b = make_dispatch_packet(ko_b, sig_b, /*grid_size_x=*/128);
+
+  auto pg = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
+  auto plugin = std::make_unique<SubmitDispatchDuringWorkerPlugin>(queue, packet_b, trigger);
+  auto *submitter = plugin.get();
+  ASSERT_TRUE(pg->add(std::move(plugin)));
+  f.soc_ptr->set_plugin_group(pg);
+  f.cp()->set_dispatch_threads(dispatch_threads);
+
+  ASSERT_EQ(f.cp()->dispatch_threads(), dispatch_threads);
+
+  auto packet_a = make_dispatch_packet(ko_a, sig_a, /*grid_size_x=*/128);
+  queue.submit(packet_a);
+
+  ASSERT_TRUE(f.engine->step());
+  EXPECT_TRUE(submitter->submitted());
+  EXPECT_EQ(f.cp()->dispatched_count(), 2u);
+
+  for (uint32_t i = 0; i < 10000 && (completion_signal_value(f.mem(), sig_a) != 0 ||
+                                     completion_signal_value(f.mem(), sig_b) != 0);
+       ++i) {
+    ASSERT_TRUE(f.engine->step());
+  }
+
+  EXPECT_EQ(completion_signal_value(f.mem(), sig_a), 0);
+  EXPECT_EQ(completion_signal_value(f.mem(), sig_b), 0);
+  EXPECT_FALSE(f.cu(0)->has_active_wfs());
+  EXPECT_FALSE(f.cu(1)->has_active_wfs());
+}
+
+TEST(AqlDispatchTest, DeferredRescanFiresLateCompletionSignalSerialWorker) {
+  run_deferred_rescan_late_completion_test(1, SubmitTrigger::DispatchBegin);
+}
+
+TEST(AqlDispatchTest, DeferredRescanFiresLateCompletionSignalParallelWorkers) {
+  run_deferred_rescan_late_completion_test(3, SubmitTrigger::AfterInstruction);
+}
+
+TEST(AqlDispatchTest, SerialCompletionUnblocksCoResidentSignalWaiter) {
+  VmFixture f("cdna3", /*num_cus=*/1);
+  f.cp()->set_dispatch_threads(1);
+
+  const uint32_t producer_code[] = {SOPP_S_NOP, SOPP_S_ENDPGM};
+  const uint32_t waiter_code[] = {
+      0xC0060080u,
+      0x00000008u, // s_load_dwordx2 s[2:3], s[0:1], 8
+      enc::S_WAITCNT_0,
+      0xBF128002u,             // s_cmp_eq_u64 s[2:3], 0
+      enc::s_cbranch_scc0(-5), // retry until producer completion is delivered
+      SOPP_S_ENDPGM,
+  };
+  const uint64_t producer = f.write_kernel(0x1000, producer_code, sizeof(producer_code));
+  const uint64_t waiter = f.write_kernel(0x2000, waiter_code, sizeof(waiter_code));
+
+  constexpr uint64_t producer_signal = 0xF0021000;
+  constexpr uint64_t waiter_signal = 0xF0021100;
+  init_completion_signal(f.mem(), producer_signal);
+  init_completion_signal(f.mem(), waiter_signal);
+
+  test::AqlQueue queue(f.mem(), f.cp());
+  auto producer_packet = make_dispatch_packet(producer, producer_signal);
+  auto waiter_packet = make_dispatch_packet(waiter, waiter_signal);
+  waiter_packet.kernarg_address = reinterpret_cast<void *>(producer_signal);
+  queue.submit(producer_packet);
+  queue.submit(waiter_packet);
+
+  for (uint32_t i = 0; i < 16 && completion_signal_value(f.mem(), waiter_signal) != 0; ++i)
+    ASSERT_TRUE(f.engine->step());
+
+  EXPECT_EQ(completion_signal_value(f.mem(), producer_signal), 0);
+  EXPECT_EQ(completion_signal_value(f.mem(), waiter_signal), 0);
+  EXPECT_FALSE(f.cu()->has_active_wfs());
+}
+
 TEST_P(IsaTest, EngineRunsToCompletion) {
   VmFixture f(arch());
   auto *snap = f.capture_halts();
@@ -3779,6 +3937,147 @@ TEST(L1ScalarCacheVmidTest, WriteThroughStoreUsesStoreVmid) {
 
   mem.unregister_process(kVmidA);
   mem.unregister_process(kVmidB);
+}
+
+class BlockingInstructionPlugin final : public ExecutionPlugin {
+public:
+  BlockingInstructionPlugin() : ExecutionPlugin("blocking_instruction") {}
+
+  void onAmdgpuBeforeExecuteInstruction(uint64_t, const Instruction &,
+                                        amdgpu::Wavefront &) override {
+    std::unique_lock<std::mutex> lock(mutex_);
+    if (entered_)
+      return;
+    entered_ = true;
+    cv_.notify_all();
+    cv_.wait(lock, [this]() { return released_; });
+  }
+
+  bool wait_until_entered(std::chrono::milliseconds timeout) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    return cv_.wait_for(lock, timeout, [this]() { return entered_; });
+  }
+
+  void release() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    released_ = true;
+    cv_.notify_all();
+  }
+
+private:
+  std::mutex mutex_;
+  std::condition_variable cv_;
+  bool entered_ = false;
+  bool released_ = false;
+};
+
+TEST(AqlDispatchTest, WorkerExceptionPropagatesThroughEngineStep) {
+  constexpr uint32_t kSSetvskip = 0xBF100000u;
+  VmFixture f("cdna4", /*num_cus=*/2);
+  f.cp()->set_dispatch_threads(2);
+
+  uint64_t kernel = f.write_kernel(0x1000, &kSSetvskip, sizeof(kSSetvskip));
+  test::AqlQueue queue(f.mem(), f.cp());
+  queue.dispatch(kernel, /*grid_size=*/128, /*workgroup_size=*/64);
+
+  EXPECT_THROW((void)f.engine->step(), std::exception);
+}
+
+TEST(AqlDispatchTest, WorkerYieldReturnsToEventLoopBeforeResuming) {
+  constexpr uint32_t kSSleep = 0xBF8E0001u;
+  VmFixture f("cdna4", /*num_cus=*/2);
+  f.cp()->set_dispatch_threads(2);
+
+  const uint32_t code[] = {kSSleep, SOPP_S_ENDPGM};
+  uint64_t kernel = f.write_kernel(0x1000, code, sizeof(code));
+  test::AqlQueue queue(f.mem(), f.cp());
+  queue.dispatch(kernel, /*grid_size=*/128, /*workgroup_size=*/64);
+
+  bool peer_event_ran = false;
+  bool peer_saw_yielded_waves = false;
+  simdojo::Event peer_event{f.cp(), simdojo::EventType::TIMER_CALLBACK,
+                            [&](simdojo::Tick, simdojo::Message *) {
+                              peer_event_ran = true;
+                              auto *wf0 = f.cu(0)->wf(0);
+                              auto *wf1 = f.cu(1)->wf(0);
+                              peer_saw_yielded_waves = wf0 && wf1 && wf0->trace_inst_count_ == 1 &&
+                                                       wf1->trace_inst_count_ == 1;
+                            }};
+  f.engine->schedule_event_async(&peer_event, 1);
+
+  ASSERT_TRUE(f.engine->step()); // Doorbell: both CUs stop after s_sleep.
+  EXPECT_FALSE(peer_event_ran);
+  ASSERT_TRUE(f.engine->step()); // Peer event runs before the CU resume events.
+  EXPECT_TRUE(peer_event_ran);
+  EXPECT_TRUE(peer_saw_yielded_waves);
+
+  while (f.engine->step()) {
+  }
+  EXPECT_TRUE(f.cu(0)->is_idle());
+  EXPECT_TRUE(f.cu(1)->is_idle());
+}
+
+TEST(AqlDispatchTest, QueueMutationWaitsForDispatchWorkerWindow) {
+  using namespace std::chrono_literals;
+
+  VmFixture f("cdna4", /*num_cus=*/2);
+  auto group = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
+  auto blocking_plugin = std::make_unique<BlockingInstructionPlugin>();
+  auto *blocker = blocking_plugin.get();
+  ASSERT_TRUE(group->add(std::move(blocking_plugin)));
+  f.soc_ptr->set_plugin_group(group);
+  f.cp()->set_dispatch_threads(2);
+
+  const uint32_t code[] = {SOPP_S_NOP, SOPP_S_ENDPGM};
+  uint64_t kernel = f.write_kernel(0x1000, code, sizeof(code));
+  test::AqlQueue dispatch_queue(f.mem(), f.cp());
+  amdgpu::HwQueue removable_queue{};
+  removable_queue.process_id = 9;
+  removable_queue.queue_id = 42;
+  f.cp()->register_queue(removable_queue);
+  dispatch_queue.dispatch(kernel, /*grid_size=*/128, /*workgroup_size=*/64);
+
+  auto step = std::async(std::launch::async, [&]() { return f.engine->step(); });
+  const bool entered = blocker->wait_until_entered(2s);
+  EXPECT_TRUE(entered) << "CU execution did not reach the blocking plugin";
+  if (!entered) {
+    blocker->release();
+    return;
+  }
+
+  amdgpu::HwQueue added_queue{};
+  added_queue.process_id = 9;
+  added_queue.queue_id = 43;
+  std::promise<void> registration_started_promise;
+  auto registration_started = registration_started_promise.get_future();
+  auto registration =
+      std::async(std::launch::async, [cp = f.cp(), added_queue,
+                                      started = std::move(registration_started_promise)]() mutable {
+        started.set_value();
+        cp->register_queue(std::move(added_queue));
+      });
+  std::promise<void> removal_started_promise;
+  auto removal_started = removal_started_promise.get_future();
+  auto removal =
+      std::async(std::launch::async, [cp = f.cp(), removable_queue,
+                                      started = std::move(removal_started_promise)]() mutable {
+        started.set_value();
+        cp->unregister_queue(removable_queue.queue_id, removable_queue.process_id);
+      });
+
+  registration_started.wait();
+  removal_started.wait();
+
+  EXPECT_EQ(registration.wait_for(50ms), std::future_status::timeout)
+      << "queue structure changed while dispatch workers held live references";
+  EXPECT_EQ(removal.wait_for(50ms), std::future_status::timeout)
+      << "queue structure changed while dispatch workers held live references";
+
+  blocker->release();
+  EXPECT_TRUE(step.get());
+  registration.get();
+  removal.get();
+  f.cp()->unregister_queue(added_queue.queue_id, added_queue.process_id);
 }
 
 TEST(DoorbellMonitorLifecycle, RetiresAfterLastQueueAndRestartsOnNewQueue) {

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -274,6 +274,22 @@ hsa_kernel_dispatch_packet_t make_dispatch_packet(uint64_t kernel_object, uint64
   return pkt;
 }
 
+uint64_t write_test_kernel(amdgpu::GpuMemory *memory, uint64_t addr,
+                           std::span<const uint32_t> code) {
+  using namespace rocr::llvm::amdhsa;
+  kernel_descriptor_t descriptor{};
+  descriptor.kernel_code_entry_byte_offset = sizeof(kernel_descriptor_t);
+  AMDHSA_BITS_SET(descriptor.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT,
+                  31);
+  AMDHSA_BITS_SET(descriptor.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT,
+                  12);
+  AMDHSA_BITS_SET(descriptor.compute_pgm_rsrc2, COMPUTE_PGM_RSRC2_USER_SGPR_COUNT, 2);
+  memory->load_image(reinterpret_cast<const uint8_t *>(&descriptor), sizeof(descriptor), addr);
+  memory->load_image(reinterpret_cast<const uint8_t *>(code.data()), code.size_bytes(),
+                     addr + sizeof(descriptor));
+  return addr;
+}
+
 // Drive the engine until the listed CUs have no resident wavefronts. A wavefront
 // frees itself at s_endpgm (num_wfs()/has_active_wfs() drop as it halts), so the
 // kernel is complete once every listed CU reports idle. Waves that need their final
@@ -2407,8 +2423,12 @@ TEST_P(IsaTest, NonKernelBarrierPacketsOrderQueueEntries) {
     queue.submit(dispatch);
     (void)f.engine->step();
 
-    EXPECT_EQ(f.cu()->num_wfs(), 1u);
-    EXPECT_EQ(f.mem()->read64(kBarrierCompletionSignal + kSignalValueOffset), 1u);
+    const bool completes_ahead_of_prior_dispatch =
+        !header_barrier_bit &&
+        (packet_type == HSA_PACKET_TYPE_BARRIER_AND || packet_type == HSA_PACKET_TYPE_BARRIER_OR);
+    EXPECT_EQ(f.cu()->num_wfs(), completes_ahead_of_prior_dispatch ? 2u : 1u);
+    EXPECT_EQ(f.mem()->read64(kBarrierCompletionSignal + kSignalValueOffset),
+              completes_ahead_of_prior_dispatch ? 0u : 1u);
     EXPECT_EQ(f.mem()->read64(kLaterCompletionSignal + kSignalValueOffset), 1u);
 
     f.engine->run();
@@ -2416,6 +2436,46 @@ TEST_P(IsaTest, NonKernelBarrierPacketsOrderQueueEntries) {
     EXPECT_EQ(f.mem()->read64(kBarrierCompletionSignal + kSignalValueOffset), 0u);
     EXPECT_EQ(f.mem()->read64(kLaterCompletionSignal + kSignalValueOffset), 0u);
   }
+}
+
+TEST(AqlDispatchTest, HeaderClearBarrierUnblocksPriorPollingKernelBeforeLaterDispatch) {
+  VmFixture f("cdna4", /*num_cus=*/2);
+  f.cp()->set_dispatch_threads(2);
+
+  const uint32_t waiter_code[] = {
+      0xC0060080u,
+      0x00000008u, // s_load_dwordx2 s[2:3], s[0:1], 8
+      0xBF8C0000u, // s_waitcnt 0
+      0xBF128002u, // s_cmp_eq_u64 s[2:3], 0
+      0xBF84FFFBu, // s_cbranch_scc0 -5
+      SOPP_S_ENDPGM,
+  };
+  const uint32_t later_code[] = {SOPP_S_NOP, SOPP_S_ENDPGM};
+  const uint64_t waiter = f.write_kernel(0x1000, waiter_code, sizeof(waiter_code));
+  const uint64_t later = f.write_kernel(0x2000, later_code, sizeof(later_code));
+
+  constexpr uint64_t barrier_signal = 0xF0022000;
+  constexpr uint64_t waiter_signal = 0xF0022100;
+  constexpr uint64_t later_signal = 0xF0022200;
+  init_completion_signal(f.mem(), barrier_signal);
+  init_completion_signal(f.mem(), waiter_signal);
+  init_completion_signal(f.mem(), later_signal);
+
+  auto waiter_packet = make_dispatch_packet(waiter, waiter_signal);
+  waiter_packet.kernarg_address = reinterpret_cast<void *>(barrier_signal);
+  hsa_kernel_dispatch_packet_t barrier{};
+  barrier.header = HSA_PACKET_TYPE_BARRIER_AND;
+  barrier.completion_signal.handle = barrier_signal;
+
+  test::AqlQueue queue(f.mem(), f.cp());
+  queue.submit(waiter_packet);
+  queue.submit(barrier);
+  queue.submit(make_dispatch_packet(later, later_signal));
+  f.engine->run();
+
+  EXPECT_EQ(completion_signal_value(f.mem(), barrier_signal), 0);
+  EXPECT_EQ(completion_signal_value(f.mem(), waiter_signal), 0);
+  EXPECT_EQ(completion_signal_value(f.mem(), later_signal), 0);
 }
 
 TEST_P(IsaTest, VendorSpecificRejectsUnsupportedFormats) {
@@ -2466,6 +2526,26 @@ TEST(ClusterDispatchTest, AccountsForPerWorkgroupLdsAlignmentWhenPlanningCluster
 
   EXPECT_THROW((void)f.engine->step(), std::runtime_error);
   EXPECT_FALSE(f.cu()->has_active_wfs());
+}
+
+TEST(ClusterDispatchTest, ParallelGfx1250RetiresClusterAfterWorkersRejoin) {
+  VmFixture f("gfx1250", /*num_cus=*/2, /*num_wf_slots=*/1, /*lds_size_kb=*/64,
+              /*sgprs_per_wf=*/128);
+  f.cp()->set_dispatch_threads(2);
+
+  const uint32_t code[] = {0xBFB00000u}; // s_endpgm
+  uint64_t ko = f.write_kernel(0x1000, code, sizeof(code), /*sgprs=*/128);
+  test::AqlQueue queue(f.mem(), f.cp());
+  queue.dispatch_clustered(ko, /*cluster_count_x=*/1, /*cluster_size_x=*/2,
+                           /*workgroup_size_x=*/32);
+
+  ASSERT_NO_THROW(f.engine->run());
+  EXPECT_FALSE(f.cu(0)->has_active_wfs());
+  EXPECT_FALSE(f.cu(1)->has_active_wfs());
+  EXPECT_TRUE(f.cp()
+                  ->cluster_lds_targets(/*dispatch_id=*/1, /*wg_id=*/0,
+                                        /*mcast_mask=*/0x3)
+                  .empty());
 }
 
 TEST(ClusterDispatchTest, ReclaimsLdsBetweenClusterWaves) {
@@ -2983,7 +3063,6 @@ void run_deferred_rescan_late_completion_test(uint32_t dispatch_threads, SubmitT
 
   ASSERT_TRUE(f.engine->step());
   EXPECT_TRUE(submitter->submitted());
-  EXPECT_EQ(f.cp()->dispatched_count(), 2u);
 
   for (uint32_t i = 0; i < 10000 && (completion_signal_value(f.mem(), sig_a) != 0 ||
                                      completion_signal_value(f.mem(), sig_b) != 0);
@@ -2993,6 +3072,7 @@ void run_deferred_rescan_late_completion_test(uint32_t dispatch_threads, SubmitT
 
   EXPECT_EQ(completion_signal_value(f.mem(), sig_a), 0);
   EXPECT_EQ(completion_signal_value(f.mem(), sig_b), 0);
+  EXPECT_EQ(f.cp()->dispatched_count(), 2u);
   EXPECT_FALSE(f.cu(0)->has_active_wfs());
   EXPECT_FALSE(f.cu(1)->has_active_wfs());
 }
@@ -3039,6 +3119,113 @@ TEST(AqlDispatchTest, SerialCompletionUnblocksCoResidentSignalWaiter) {
   EXPECT_EQ(completion_signal_value(f.mem(), producer_signal), 0);
   EXPECT_EQ(completion_signal_value(f.mem(), waiter_signal), 0);
   EXPECT_FALSE(f.cu()->has_active_wfs());
+}
+
+TEST(AqlDispatchTest, PoolContinuationLetsPeerQueueSatisfyPollingWave) {
+  VmFixture f("cdna4", /*num_cus=*/2, /*num_wf_slots=*/1);
+  f.cp()->set_dispatch_threads(2);
+
+  const uint32_t waiter_code[] = {
+      0xC0060080u,
+      0x00000008u, // s_load_dwordx2 s[2:3], s[0:1], 8
+      enc::S_WAITCNT_0, 0xBF128002u, enc::s_cbranch_scc0(-5), SOPP_S_ENDPGM,
+  };
+  const uint32_t producer_code[] = {SOPP_S_NOP, SOPP_S_ENDPGM};
+  const uint64_t waiter = f.write_kernel(0x1000, waiter_code, sizeof(waiter_code));
+  const uint64_t producer = f.write_kernel(0x2000, producer_code, sizeof(producer_code));
+
+  constexpr uint64_t producer_signal = 0xF0023000;
+  constexpr uint64_t waiter_signal = 0xF0023100;
+  init_completion_signal(f.mem(), producer_signal);
+  init_completion_signal(f.mem(), waiter_signal);
+
+  test::AqlQueue waiter_queue(f.mem(), f.cp());
+  test::AqlQueue producer_queue(f.mem(), f.cp(), /*ring_addr=*/0xE0000000,
+                                test::AqlQueue::DEFAULT_RING_SIZE,
+                                /*read_ptr_addr=*/0xE0010000,
+                                /*write_ptr_addr=*/0xE0010008,
+                                /*doorbell_addr=*/0xE0010010);
+  auto waiter_packet = make_dispatch_packet(waiter, waiter_signal);
+  waiter_packet.kernarg_address = reinterpret_cast<void *>(producer_signal);
+  waiter_queue.submit(waiter_packet);
+  producer_queue.submit(make_dispatch_packet(producer, producer_signal));
+
+  f.engine->run();
+
+  EXPECT_EQ(completion_signal_value(f.mem(), producer_signal), 0);
+  EXPECT_EQ(completion_signal_value(f.mem(), waiter_signal), 0);
+}
+
+TEST(AqlDispatchTest, PoolContinuationLetsPeerCommandProcessorSatisfyPollingWave) {
+  const char *json = R"({"max_ticks":10000,"num_threads":1,"vm":{"arch":"cdna4"},
+    "topology":{"root":{"name":"soc","type":"soc","children":[
+      {"name":"vram","type":"gpu_memory"},
+      {"name":"xcd0","type":"xcd","children":[
+        {"name":"l2","type":"l2_cache"},{"name":"cp","type":"command_processor"},
+        {"name":"se0","type":"shader_engine","children":[
+          {"name":"cu0","type":"compute_unit","config":[
+            {"key":"num_wf_slots","value":"1"},{"key":"sgprs_per_wf","value":"104"},
+            {"key":"vgprs_per_wf","value":"256"},{"key":"lds_size_kb","value":"64"}]}]}]},
+      {"name":"xcd1","type":"xcd","children":[
+        {"name":"l2","type":"l2_cache"},{"name":"cp","type":"command_processor"},
+        {"name":"se0","type":"shader_engine","children":[
+          {"name":"cu0","type":"compute_unit","config":[
+            {"key":"num_wf_slots","value":"1"},{"key":"sgprs_per_wf","value":"104"},
+            {"key":"vgprs_per_wf","value":"256"},{"key":"lds_size_kb","value":"64"}]}]}]}
+    ]},"links":[
+      {"src":"xcd0.cp.req_0","dst":"xcd0.se0.cu0.cpl","latency":1,"weight":2},
+      {"src":"xcd0.se0.cu0.req","dst":"xcd0.l2.cpl_0","latency":1,"weight":10},
+      {"src":"xcd1.cp.req_0","dst":"xcd1.se0.cu0.cpl","latency":1,"weight":2},
+      {"src":"xcd1.se0.cu0.req","dst":"xcd1.l2.cpl_0","latency":1,"weight":10}
+    ]}})";
+  auto loaded = config::load_config_from_string(json, rocjitsu::kEmbeddedSchema);
+  auto *soc_ptr = loaded.soc();
+  auto *memory = loaded.memory();
+  simdojo::SimulationEngine engine(loaded.engine_config);
+  engine.topology().set_root(loaded.take_root());
+  loaded.wire_links(engine.topology());
+  engine.create();
+  soc_ptr->set_dispatch_threads(2);
+
+  const uint32_t waiter_code[] = {
+      0xC0060080u,
+      0x00000008u, // s_load_dwordx2 s[2:3], s[0:1], 8
+      enc::S_WAITCNT_0, 0xBF128002u, enc::s_cbranch_scc0(-5), SOPP_S_ENDPGM,
+  };
+  const uint64_t waiter = write_test_kernel(memory, 0x1000, waiter_code);
+
+  constexpr uint64_t producer_signal = 0xF0024000;
+  constexpr uint64_t waiter_signal = 0xF0024100;
+  init_completion_signal(memory, producer_signal);
+  init_completion_signal(memory, waiter_signal);
+
+  auto *waiter_cp = soc_ptr->xcd(0)->command_processor();
+  auto *producer_cp = soc_ptr->xcd(1)->command_processor();
+  test::AqlQueue waiter_queue(memory, waiter_cp);
+  auto waiter_packet = make_dispatch_packet(waiter, waiter_signal);
+  waiter_packet.kernarg_address = reinterpret_cast<void *>(producer_signal);
+  waiter_queue.submit(waiter_packet);
+
+  bool producer_event_ran = false;
+  simdojo::Event producer_event{producer_cp, simdojo::EventType::TIMER_CALLBACK,
+                                [&](simdojo::Tick, simdojo::Message *) {
+                                  producer_event_ran = true;
+                                  memory->write64(producer_signal + 8, 0);
+                                  soc_ptr->xcd(0)->shader_engine(0)->compute_unit(0)->flush_l1();
+                                  soc_ptr->xcd(0)->l2_cache()->invalidate_all();
+                                }};
+  engine.schedule_event_async(&producer_event, 1);
+
+  for (uint32_t i = 0; i < 10000 && (completion_signal_value(memory, producer_signal) != 0 ||
+                                     completion_signal_value(memory, waiter_signal) != 0);
+       ++i)
+    ASSERT_TRUE(engine.step());
+
+  EXPECT_TRUE(producer_event_ran);
+  EXPECT_EQ(completion_signal_value(memory, producer_signal), 0);
+  EXPECT_EQ(completion_signal_value(memory, waiter_signal), 0)
+      << "waiter dispatches=" << waiter_cp->dispatched_count()
+      << " exit=" << engine.last_exit().message;
 }
 
 TEST_P(IsaTest, EngineRunsToCompletion) {

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -25,6 +25,7 @@
 #include "rocjitsu/vm/amdgpu/l2_cache.h"
 #include "rocjitsu/vm/amdgpu/request_mtype_resolver.h"
 #include "rocjitsu/vm/amdgpu/wavefront.h"
+#include "rocjitsu/vm/plugins/execution_plugin_group.h"
 #include "rocjitsu/vm/rj_vm.h"
 #include "rocjitsu/vm/soc.h"
 
@@ -46,9 +47,11 @@ RJ_DIAGNOSTIC_POP
 #include <barrier>
 #include <bit>
 #include <chrono>
+#include <condition_variable>
 #include <cstdint>
 #include <cstring>
 #include <functional>
+#include <future>
 #include <limits>
 #include <memory>
 #include <new>
@@ -297,6 +300,72 @@ TEST(ComputeUnitConfigTest, DirectFactoryRejectsTargetFromAnotherArchitecture) {
 
   EXPECT_THROW((void)amdgpu::ComputeUnitCore::create("cu", config, &memory, &l2),
                util::ConfigError);
+}
+
+enum class SubmitTrigger { DispatchBegin, AfterInstruction };
+
+class SubmitDispatchDuringWorkerPlugin final : public ExecutionPlugin {
+public:
+  SubmitDispatchDuringWorkerPlugin(test::AqlQueue &queue,
+                                   const hsa_kernel_dispatch_packet_t &packet,
+                                   SubmitTrigger trigger)
+      : ExecutionPlugin("submit_dispatch_during_worker"), queue_(queue), packet_(packet),
+        trigger_(trigger) {}
+
+  void onAmdgpuDispatchExecutionBegin(uint32_t /*dispatch_id*/) override {
+    if (trigger_ == SubmitTrigger::DispatchBegin)
+      submit_once();
+  }
+
+  void onAmdgpuAfterExecuteInstruction(uint64_t /*pc*/, const Instruction & /*inst*/,
+                                       amdgpu::Wavefront & /*wf*/) override {
+    if (trigger_ == SubmitTrigger::AfterInstruction)
+      submit_once();
+  }
+
+  bool submitted() const { return submitted_.load(); }
+
+  bool requires_serial_hot_hooks() const override { return false; }
+
+private:
+  void submit_once() {
+    bool expected = false;
+    if (submitted_.compare_exchange_strong(expected, true))
+      queue_.submit(packet_);
+  }
+
+  test::AqlQueue &queue_;
+  hsa_kernel_dispatch_packet_t packet_{};
+  SubmitTrigger trigger_;
+  std::atomic_bool submitted_{false};
+};
+
+void init_completion_signal(amdgpu::GpuMemory *mem, uint64_t signal_addr) {
+  mem->write64(signal_addr, 0);
+  mem->write64(signal_addr + 8, 1);
+  mem->write64(signal_addr + 16, 0);
+  mem->write32(signal_addr + 24, 0);
+}
+
+int64_t completion_signal_value(amdgpu::GpuMemory *mem, uint64_t signal_addr) {
+  return static_cast<int64_t>(mem->read64(signal_addr + 8));
+}
+
+hsa_kernel_dispatch_packet_t make_dispatch_packet(uint64_t kernel_object, uint64_t signal_addr,
+                                                  uint32_t grid_size_x = 64,
+                                                  uint16_t workgroup_size_x = 64) {
+  hsa_kernel_dispatch_packet_t pkt{};
+  pkt.header = HSA_PACKET_TYPE_KERNEL_DISPATCH;
+  pkt.setup = 1;
+  pkt.workgroup_size_x = workgroup_size_x;
+  pkt.workgroup_size_y = 1;
+  pkt.workgroup_size_z = 1;
+  pkt.grid_size_x = grid_size_x;
+  pkt.grid_size_y = 1;
+  pkt.grid_size_z = 1;
+  pkt.kernel_object = kernel_object;
+  pkt.completion_signal.handle = signal_addr;
+  return pkt;
 }
 
 // Drive the engine until the listed CUs have no resident wavefronts. A wavefront
@@ -4198,6 +4267,95 @@ TEST_P(IsaTest, RoundRobinScheduling) {
   EXPECT_EQ(f.cp()->dispatched_count(), 2u);
 }
 
+void run_deferred_rescan_late_completion_test(uint32_t dispatch_threads, SubmitTrigger trigger) {
+  VmFixture f("cdna3", /*num_cus=*/2);
+  f.cp()->set_dispatch_threads(dispatch_threads);
+
+  auto prog_a = ExecFixture::cat({{SOPP_S_NOP}, {SOPP_S_NOP}, {SOPP_S_ENDPGM}});
+  auto prog_b = ExecFixture::cat({{SOPP_S_NOP}, {SOPP_S_ENDPGM}});
+  uint64_t ko_a = f.write_kernel(0x1000, prog_a.data(), prog_a.size() * sizeof(uint32_t));
+  uint64_t ko_b = f.write_kernel(0x2000, prog_b.data(), prog_b.size() * sizeof(uint32_t));
+
+  constexpr uint64_t sig_a = 0xF0020000;
+  constexpr uint64_t sig_b = 0xF0020100;
+  init_completion_signal(f.mem(), sig_a);
+  init_completion_signal(f.mem(), sig_b);
+
+  test::AqlQueue queue(f.mem(), f.cp());
+  auto packet_b = make_dispatch_packet(ko_b, sig_b, /*grid_size_x=*/128);
+
+  auto pg = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
+  auto plugin = std::make_unique<SubmitDispatchDuringWorkerPlugin>(queue, packet_b, trigger);
+  auto *submitter = plugin.get();
+  ASSERT_TRUE(pg->add(std::move(plugin)));
+  f.soc_ptr->set_plugin_group(pg);
+  f.cp()->set_dispatch_threads(dispatch_threads);
+
+  ASSERT_EQ(f.cp()->dispatch_threads(), dispatch_threads);
+
+  auto packet_a = make_dispatch_packet(ko_a, sig_a, /*grid_size_x=*/128);
+  queue.submit(packet_a);
+
+  ASSERT_TRUE(f.engine->step());
+  EXPECT_TRUE(submitter->submitted());
+  EXPECT_EQ(f.cp()->dispatched_count(), 2u);
+
+  for (uint32_t i = 0; i < 10000 && (completion_signal_value(f.mem(), sig_a) != 0 ||
+                                     completion_signal_value(f.mem(), sig_b) != 0);
+       ++i) {
+    ASSERT_TRUE(f.engine->step());
+  }
+
+  EXPECT_EQ(completion_signal_value(f.mem(), sig_a), 0);
+  EXPECT_EQ(completion_signal_value(f.mem(), sig_b), 0);
+  EXPECT_FALSE(f.cu(0)->has_active_wfs());
+  EXPECT_FALSE(f.cu(1)->has_active_wfs());
+}
+
+TEST(AqlDispatchTest, DeferredRescanFiresLateCompletionSignalSerialWorker) {
+  run_deferred_rescan_late_completion_test(1, SubmitTrigger::DispatchBegin);
+}
+
+TEST(AqlDispatchTest, DeferredRescanFiresLateCompletionSignalParallelWorkers) {
+  run_deferred_rescan_late_completion_test(3, SubmitTrigger::AfterInstruction);
+}
+
+TEST(AqlDispatchTest, SerialCompletionUnblocksCoResidentSignalWaiter) {
+  VmFixture f("cdna3", /*num_cus=*/1);
+  f.cp()->set_dispatch_threads(1);
+
+  const uint32_t producer_code[] = {SOPP_S_NOP, SOPP_S_ENDPGM};
+  const uint32_t waiter_code[] = {
+      0xC0060080u,
+      0x00000008u, // s_load_dwordx2 s[2:3], s[0:1], 8
+      enc::S_WAITCNT_0,
+      0xBF128002u,             // s_cmp_eq_u64 s[2:3], 0
+      enc::s_cbranch_scc0(-5), // retry until producer completion is delivered
+      SOPP_S_ENDPGM,
+  };
+  const uint64_t producer = f.write_kernel(0x1000, producer_code, sizeof(producer_code));
+  const uint64_t waiter = f.write_kernel(0x2000, waiter_code, sizeof(waiter_code));
+
+  constexpr uint64_t producer_signal = 0xF0021000;
+  constexpr uint64_t waiter_signal = 0xF0021100;
+  init_completion_signal(f.mem(), producer_signal);
+  init_completion_signal(f.mem(), waiter_signal);
+
+  test::AqlQueue queue(f.mem(), f.cp());
+  auto producer_packet = make_dispatch_packet(producer, producer_signal);
+  auto waiter_packet = make_dispatch_packet(waiter, waiter_signal);
+  waiter_packet.kernarg_address = reinterpret_cast<void *>(producer_signal);
+  queue.submit(producer_packet);
+  queue.submit(waiter_packet);
+
+  for (uint32_t i = 0; i < 16 && completion_signal_value(f.mem(), waiter_signal) != 0; ++i)
+    ASSERT_TRUE(f.engine->step());
+
+  EXPECT_EQ(completion_signal_value(f.mem(), producer_signal), 0);
+  EXPECT_EQ(completion_signal_value(f.mem(), waiter_signal), 0);
+  EXPECT_FALSE(f.cu()->has_active_wfs());
+}
+
 TEST_P(IsaTest, EngineRunsToCompletion) {
   VmFixture f(arch());
   auto *snap = f.capture_halts();
@@ -5536,6 +5694,147 @@ TEST(L1ScalarCacheVmidTest, WriteThroughStoreUsesStoreVmid) {
 
   mem.unregister_process(kVmidA);
   mem.unregister_process(kVmidB);
+}
+
+class BlockingInstructionPlugin final : public ExecutionPlugin {
+public:
+  BlockingInstructionPlugin() : ExecutionPlugin("blocking_instruction") {}
+
+  void onAmdgpuBeforeExecuteInstruction(uint64_t, const Instruction &,
+                                        amdgpu::Wavefront &) override {
+    std::unique_lock<std::mutex> lock(mutex_);
+    if (entered_)
+      return;
+    entered_ = true;
+    cv_.notify_all();
+    cv_.wait(lock, [this]() { return released_; });
+  }
+
+  bool wait_until_entered(std::chrono::milliseconds timeout) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    return cv_.wait_for(lock, timeout, [this]() { return entered_; });
+  }
+
+  void release() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    released_ = true;
+    cv_.notify_all();
+  }
+
+private:
+  std::mutex mutex_;
+  std::condition_variable cv_;
+  bool entered_ = false;
+  bool released_ = false;
+};
+
+TEST(AqlDispatchTest, WorkerExceptionPropagatesThroughEngineStep) {
+  constexpr uint32_t kSSetvskip = 0xBF100000u;
+  VmFixture f("cdna4", /*num_cus=*/2);
+  f.cp()->set_dispatch_threads(2);
+
+  uint64_t kernel = f.write_kernel(0x1000, &kSSetvskip, sizeof(kSSetvskip));
+  test::AqlQueue queue(f.mem(), f.cp());
+  queue.dispatch(kernel, /*grid_size=*/128, /*workgroup_size=*/64);
+
+  EXPECT_THROW((void)f.engine->step(), std::exception);
+}
+
+TEST(AqlDispatchTest, WorkerYieldReturnsToEventLoopBeforeResuming) {
+  constexpr uint32_t kSSleep = 0xBF8E0001u;
+  VmFixture f("cdna4", /*num_cus=*/2);
+  f.cp()->set_dispatch_threads(2);
+
+  const uint32_t code[] = {kSSleep, SOPP_S_ENDPGM};
+  uint64_t kernel = f.write_kernel(0x1000, code, sizeof(code));
+  test::AqlQueue queue(f.mem(), f.cp());
+  queue.dispatch(kernel, /*grid_size=*/128, /*workgroup_size=*/64);
+
+  bool peer_event_ran = false;
+  bool peer_saw_yielded_waves = false;
+  simdojo::Event peer_event{f.cp(), simdojo::EventType::TIMER_CALLBACK,
+                            [&](simdojo::Tick, simdojo::Message *) {
+                              peer_event_ran = true;
+                              auto *wf0 = f.cu(0)->wf(0);
+                              auto *wf1 = f.cu(1)->wf(0);
+                              peer_saw_yielded_waves = wf0 && wf1 && wf0->trace_inst_count_ == 1 &&
+                                                       wf1->trace_inst_count_ == 1;
+                            }};
+  f.engine->schedule_event_async(&peer_event, 1);
+
+  ASSERT_TRUE(f.engine->step()); // Doorbell: both CUs stop after s_sleep.
+  EXPECT_FALSE(peer_event_ran);
+  ASSERT_TRUE(f.engine->step()); // Peer event runs before the CU resume events.
+  EXPECT_TRUE(peer_event_ran);
+  EXPECT_TRUE(peer_saw_yielded_waves);
+
+  while (f.engine->step()) {
+  }
+  EXPECT_TRUE(f.cu(0)->is_idle());
+  EXPECT_TRUE(f.cu(1)->is_idle());
+}
+
+TEST(AqlDispatchTest, QueueMutationWaitsForDispatchWorkerWindow) {
+  using namespace std::chrono_literals;
+
+  VmFixture f("cdna4", /*num_cus=*/2);
+  auto group = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
+  auto blocking_plugin = std::make_unique<BlockingInstructionPlugin>();
+  auto *blocker = blocking_plugin.get();
+  ASSERT_TRUE(group->add(std::move(blocking_plugin)));
+  f.soc_ptr->set_plugin_group(group);
+  f.cp()->set_dispatch_threads(2);
+
+  const uint32_t code[] = {SOPP_S_NOP, SOPP_S_ENDPGM};
+  uint64_t kernel = f.write_kernel(0x1000, code, sizeof(code));
+  test::AqlQueue dispatch_queue(f.mem(), f.cp());
+  amdgpu::HwQueue removable_queue{};
+  removable_queue.process_id = 9;
+  removable_queue.queue_id = 42;
+  f.cp()->register_queue(removable_queue);
+  dispatch_queue.dispatch(kernel, /*grid_size=*/128, /*workgroup_size=*/64);
+
+  auto step = std::async(std::launch::async, [&]() { return f.engine->step(); });
+  const bool entered = blocker->wait_until_entered(2s);
+  EXPECT_TRUE(entered) << "CU execution did not reach the blocking plugin";
+  if (!entered) {
+    blocker->release();
+    return;
+  }
+
+  amdgpu::HwQueue added_queue{};
+  added_queue.process_id = 9;
+  added_queue.queue_id = 43;
+  std::promise<void> registration_started_promise;
+  auto registration_started = registration_started_promise.get_future();
+  auto registration =
+      std::async(std::launch::async, [cp = f.cp(), added_queue,
+                                      started = std::move(registration_started_promise)]() mutable {
+        started.set_value();
+        cp->register_queue(std::move(added_queue));
+      });
+  std::promise<void> removal_started_promise;
+  auto removal_started = removal_started_promise.get_future();
+  auto removal =
+      std::async(std::launch::async, [cp = f.cp(), removable_queue,
+                                      started = std::move(removal_started_promise)]() mutable {
+        started.set_value();
+        cp->unregister_queue(removable_queue.queue_id, removable_queue.process_id);
+      });
+
+  registration_started.wait();
+  removal_started.wait();
+
+  EXPECT_EQ(registration.wait_for(50ms), std::future_status::timeout)
+      << "queue structure changed while dispatch workers held live references";
+  EXPECT_EQ(removal.wait_for(50ms), std::future_status::timeout)
+      << "queue structure changed while dispatch workers held live references";
+
+  blocker->release();
+  EXPECT_TRUE(step.get());
+  registration.get();
+  removal.get();
+  f.cp()->unregister_queue(added_queue.queue_id, added_queue.process_id);
 }
 
 TEST(DoorbellMonitorLifecycle, RetiresAfterLastQueueAndRestartsOnNewQueue) {

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -4482,6 +4482,22 @@ TEST(AqlDispatchTest, PoolContinuationLetsPeerQueueSatisfyPollingWave) {
   EXPECT_EQ(completion_signal_value(f.mem(), waiter_signal), 0);
 }
 
+TEST(AqlDispatchTest, CompletedPoolBatchRefillsIdleComputeUnits) {
+  VmFixture f("cdna4", /*num_cus=*/2, /*num_wf_slots=*/1);
+  f.cp()->set_dispatch_threads(2);
+  const uint32_t code[] = {SOPP_S_ENDPGM};
+  const uint64_t kernel = f.write_kernel(0x1000, code, sizeof(code));
+  constexpr uint64_t signal = 0xF0030000;
+  init_completion_signal(f.mem(), signal);
+  test::AqlQueue queue(f.mem(), f.cp());
+  queue.submit(make_dispatch_packet(kernel, signal, /*grid_size_x=*/192));
+
+  while (f.engine->step()) {
+  }
+
+  EXPECT_EQ(completion_signal_value(f.mem(), signal), 0);
+}
+
 TEST(AqlDispatchTest, PoolContinuationLetsPeerCommandProcessorSatisfyPollingWave) {
   const char *json = R"({"max_ticks":10000,"num_threads":1,"vm":{"arch":"cdna4"},
     "topology":{"root":{"name":"soc","type":"soc","children":[
@@ -5907,17 +5923,55 @@ void step_until_first_quantum(VmFixture &fixture, amdgpu::ComputeUnitCore *cu) {
   ASSERT_TRUE(cu->has_active_wfs());
 }
 
-class LiveSerialDispatchPlugin final : public ExecutionPlugin {
+class LiveSerializedHotHookPlugin final : public ExecutionPlugin {
 public:
-  LiveSerialDispatchPlugin() : ExecutionPlugin("live_serial_dispatch") {}
+  LiveSerializedHotHookPlugin() : ExecutionPlugin("live_serial_hot_hook") {}
   bool requires_serial_hot_hooks() const override { return true; }
 };
 
-class LiveParallelDispatchPlugin final : public ExecutionPlugin {
+class LiveConcurrentHotHookPlugin final : public ExecutionPlugin {
 public:
-  LiveParallelDispatchPlugin() : ExecutionPlugin("live_parallel_dispatch") {}
+  LiveConcurrentHotHookPlugin() : ExecutionPlugin("live_concurrent_hot_hook") {}
   bool requires_serial_hot_hooks() const override { return false; }
 };
+
+TEST(AqlDispatchTest, DebugPausedPoolWaveDoesNotKeepSchedulingContinuations) {
+  VmFixture f("cdna4", /*num_cus=*/1, /*num_wf_slots=*/1);
+  f.cp()->set_dispatch_threads(2);
+  auto code = make_multi_quantum_nop_kernel();
+  const uint64_t kernel = f.write_kernel(0x1000, code.data(), code.size() * sizeof(uint32_t));
+  test::AqlQueue queue(f.mem(), f.cp());
+  queue.dispatch(kernel, /*grid_size=*/64, /*workgroup_size=*/64);
+
+  step_until_first_quantum(f, f.cu());
+  auto *wave = f.cu()->wf(0);
+  ASSERT_NE(wave, nullptr);
+  wave->set_debug_suspended(true);
+
+  ASSERT_TRUE(f.engine->step()); // Consume the already-armed continuation.
+  EXPECT_FALSE(f.engine->step()) << "a debug-paused wave kept the pool continuation chain alive";
+}
+
+TEST(AqlDispatchTest, DebugResumeWakesQuiescedPoolDriver) {
+  VmFixture f("cdna4", /*num_cus=*/1, /*num_wf_slots=*/1);
+  f.cp()->set_dispatch_threads(2);
+  auto code = make_multi_quantum_nop_kernel();
+  const uint64_t kernel = f.write_kernel(0x1000, code.data(), code.size() * sizeof(uint32_t));
+  test::AqlQueue queue(f.mem(), f.cp());
+  queue.dispatch(kernel, /*grid_size=*/64, /*workgroup_size=*/64);
+
+  step_until_first_quantum(f, f.cu());
+  auto *wave = f.cu()->wf(0);
+  ASSERT_NE(wave, nullptr);
+  wave->set_debug_suspended(true);
+  ASSERT_TRUE(f.engine->step()); // Consume the already-armed continuation.
+
+  wave->set_debug_suspended(false);
+  f.cu()->schedule_work_async();
+  f.engine->run();
+
+  EXPECT_TRUE(f.cu()->is_idle());
+}
 
 TEST(AqlDispatchTest, ActiveDispatchSurvivesSerialToPoolTransition) {
   VmFixture f("cdna4", /*num_cus=*/1, /*num_wf_slots=*/1);
@@ -5950,13 +6004,13 @@ TEST(AqlDispatchTest, ActiveDispatchSurvivesPoolToSerialTransition) {
   EXPECT_TRUE(f.cu()->is_idle());
 }
 
-TEST(AqlDispatchTest, LivePluginReplacementRestoresPoolDuringActiveDispatch) {
+TEST(AqlDispatchTest, LivePluginReplacementPreservesPoolDuringActiveDispatch) {
   VmFixture f("cdna4", /*num_cus=*/1, /*num_wf_slots=*/1);
   f.soc_ptr->set_dispatch_threads(2);
   auto serial_group = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
-  ASSERT_TRUE(serial_group->add(std::make_unique<LiveSerialDispatchPlugin>()));
+  ASSERT_TRUE(serial_group->add(std::make_unique<LiveSerializedHotHookPlugin>()));
   f.soc_ptr->set_plugin_group(serial_group);
-  ASSERT_EQ(f.cp()->dispatch_threads(), 1u);
+  ASSERT_EQ(f.cp()->dispatch_threads(), 2u);
 
   auto code = make_multi_quantum_nop_kernel();
   uint64_t kernel = f.write_kernel(0x1000, code.data(), code.size() * sizeof(uint32_t));
@@ -5965,7 +6019,7 @@ TEST(AqlDispatchTest, LivePluginReplacementRestoresPoolDuringActiveDispatch) {
   step_until_first_quantum(f, f.cu());
 
   auto parallel_group = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
-  ASSERT_TRUE(parallel_group->add(std::make_unique<LiveParallelDispatchPlugin>()));
+  ASSERT_TRUE(parallel_group->add(std::make_unique<LiveConcurrentHotHookPlugin>()));
   f.soc_ptr->set_plugin_group(parallel_group);
   EXPECT_EQ(f.soc_ptr->dispatch_threads(), 2u);
   EXPECT_EQ(f.cp()->dispatch_threads(), 2u);

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -3837,8 +3837,8 @@ TEST(ClusterDispatchTest, AccountsForPerWorkgroupLdsAlignmentWhenPlanningCluster
   EXPECT_FALSE(f.cu()->has_active_wfs());
 }
 
-TEST(ClusterDispatchTest, ParallelGfx1250RetiresClusterAfterWorkersRejoin) {
-  VmFixture f("gfx1250", /*num_cus=*/2, /*num_wf_slots=*/1, /*lds_size_kb=*/64,
+TEST(ClusterDispatchTest, ParallelCdna5RetiresClusterAfterWorkersRejoin) {
+  VmFixture f("cdna5", /*num_cus=*/2, /*num_wf_slots=*/1, /*lds_size_kb=*/64,
               /*sgprs_per_wf=*/128);
   f.cp()->set_dispatch_threads(2);
 
@@ -4384,6 +4384,9 @@ void run_deferred_rescan_late_completion_test(uint32_t dispatch_threads, SubmitT
   queue.submit(packet_a);
 
   ASSERT_TRUE(f.engine->step());
+  if (!submitter->submitted()) {
+    ASSERT_TRUE(f.engine->step());
+  }
   EXPECT_TRUE(submitter->submitted());
 
   for (uint32_t i = 0; i < 10000 && (completion_signal_value(f.mem(), sig_a) != 0 ||
@@ -5890,6 +5893,147 @@ TEST(L1ScalarCacheVmidTest, WriteThroughStoreUsesStoreVmid) {
   mem.unregister_process(kVmidB);
 }
 
+std::vector<uint32_t> make_multi_quantum_nop_kernel() {
+  std::vector<uint32_t> code(2048, SOPP_S_NOP);
+  code.push_back(SOPP_S_ENDPGM);
+  return code;
+}
+
+void step_until_first_quantum(VmFixture &fixture, amdgpu::ComputeUnitCore *cu) {
+  for (uint32_t i = 0; i < 16 && cu->wf(0)->trace_inst_count_ < cu->functional_quantum(); ++i)
+    ASSERT_TRUE(fixture.engine->step());
+  ASSERT_EQ(cu->wf(0)->trace_inst_count_, cu->functional_quantum());
+  ASSERT_TRUE(cu->has_active_wfs());
+}
+
+class LiveSerialDispatchPlugin final : public ExecutionPlugin {
+public:
+  LiveSerialDispatchPlugin() : ExecutionPlugin("live_serial_dispatch") {}
+  bool requires_serial_hot_hooks() const override { return true; }
+};
+
+class LiveParallelDispatchPlugin final : public ExecutionPlugin {
+public:
+  LiveParallelDispatchPlugin() : ExecutionPlugin("live_parallel_dispatch") {}
+  bool requires_serial_hot_hooks() const override { return false; }
+};
+
+TEST(AqlDispatchTest, ActiveDispatchSurvivesSerialToPoolTransition) {
+  VmFixture f("cdna4", /*num_cus=*/1, /*num_wf_slots=*/1);
+  auto code = make_multi_quantum_nop_kernel();
+  uint64_t kernel = f.write_kernel(0x1000, code.data(), code.size() * sizeof(uint32_t));
+  test::AqlQueue queue(f.mem(), f.cp());
+  queue.dispatch(kernel, /*grid_size=*/64, /*workgroup_size=*/64);
+
+  step_until_first_quantum(f, f.cu());
+  f.cp()->set_dispatch_threads(2);
+  EXPECT_EQ(f.cp()->dispatch_threads(), 2u);
+
+  f.engine->run();
+  EXPECT_TRUE(f.cu()->is_idle());
+}
+
+TEST(AqlDispatchTest, ActiveDispatchSurvivesPoolToSerialTransition) {
+  VmFixture f("cdna4", /*num_cus=*/1, /*num_wf_slots=*/1);
+  f.cp()->set_dispatch_threads(2);
+  auto code = make_multi_quantum_nop_kernel();
+  uint64_t kernel = f.write_kernel(0x1000, code.data(), code.size() * sizeof(uint32_t));
+  test::AqlQueue queue(f.mem(), f.cp());
+  queue.dispatch(kernel, /*grid_size=*/64, /*workgroup_size=*/64);
+
+  step_until_first_quantum(f, f.cu());
+  f.cp()->set_dispatch_threads(1);
+  EXPECT_EQ(f.cp()->dispatch_threads(), 1u);
+
+  f.engine->run();
+  EXPECT_TRUE(f.cu()->is_idle());
+}
+
+TEST(AqlDispatchTest, LivePluginReplacementRestoresPoolDuringActiveDispatch) {
+  VmFixture f("cdna4", /*num_cus=*/1, /*num_wf_slots=*/1);
+  f.soc_ptr->set_dispatch_threads(2);
+  auto serial_group = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
+  ASSERT_TRUE(serial_group->add(std::make_unique<LiveSerialDispatchPlugin>()));
+  f.soc_ptr->set_plugin_group(serial_group);
+  ASSERT_EQ(f.cp()->dispatch_threads(), 1u);
+
+  auto code = make_multi_quantum_nop_kernel();
+  uint64_t kernel = f.write_kernel(0x1000, code.data(), code.size() * sizeof(uint32_t));
+  test::AqlQueue queue(f.mem(), f.cp());
+  queue.dispatch(kernel, /*grid_size=*/64, /*workgroup_size=*/64);
+  step_until_first_quantum(f, f.cu());
+
+  auto parallel_group = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
+  ASSERT_TRUE(parallel_group->add(std::make_unique<LiveParallelDispatchPlugin>()));
+  f.soc_ptr->set_plugin_group(parallel_group);
+  EXPECT_EQ(f.soc_ptr->dispatch_threads(), 2u);
+  EXPECT_EQ(f.cp()->dispatch_threads(), 2u);
+
+  f.engine->run();
+  EXPECT_TRUE(f.cu()->is_idle());
+}
+
+uint64_t instructions_visible_at_tick_ten(uint32_t dispatch_threads) {
+  VmFixture f("cdna4", /*num_cus=*/1, /*num_wf_slots=*/1);
+  f.cp()->set_dispatch_threads(dispatch_threads);
+  auto code = make_multi_quantum_nop_kernel();
+  uint64_t kernel = f.write_kernel(0x1000, code.data(), code.size() * sizeof(uint32_t));
+  test::AqlQueue queue(f.mem(), f.cp());
+  queue.dispatch(kernel, /*grid_size=*/64, /*workgroup_size=*/64);
+
+  uint64_t observed = 0;
+  simdojo::Event producer_event{
+      f.cp(), simdojo::EventType::TIMER_CALLBACK,
+      [&](simdojo::Tick, simdojo::Message *) { observed = f.cu()->wf(0)->trace_inst_count_; }};
+  f.engine->schedule_event_async(&producer_event, 10);
+  f.engine->run();
+  return observed;
+}
+
+TEST(AqlDispatchTest, PoolPreservesSerialQuantumSpacingAroundPeerEvent) {
+  EXPECT_EQ(instructions_visible_at_tick_ten(/*dispatch_threads=*/1), 1024u);
+  EXPECT_EQ(instructions_visible_at_tick_ten(/*dispatch_threads=*/2), 1024u);
+}
+
+TEST(AqlDispatchTest, PoolTracksIndependentCuDueTicks) {
+  constexpr uint32_t kSSleep = 0xBF8E0001u;
+  VmFixture f("cdna4", /*num_cus=*/2, /*num_wf_slots=*/1);
+  f.cp()->set_dispatch_threads(2);
+
+  const uint32_t short_code[] = {kSSleep, SOPP_S_ENDPGM};
+  auto long_code = make_multi_quantum_nop_kernel();
+  uint64_t short_kernel = f.write_kernel(0x1000, short_code, sizeof(short_code));
+  uint64_t long_kernel =
+      f.write_kernel(0x4000, long_code.data(), long_code.size() * sizeof(uint32_t));
+  test::AqlQueue queue(f.mem(), f.cp());
+  queue.dispatch(short_kernel, /*grid_size=*/64, /*workgroup_size=*/64);
+  queue.dispatch(long_kernel, /*grid_size=*/64, /*workgroup_size=*/64);
+
+  uint32_t idle_cus = 0;
+  uint32_t active_cus = 0;
+  uint64_t active_instructions = 0;
+  simdojo::Event observer_event{f.cp(), simdojo::EventType::TIMER_CALLBACK,
+                                [&](simdojo::Tick, simdojo::Message *) {
+                                  for (uint32_t i = 0; i < 2; ++i) {
+                                    auto *cu = f.cu(i);
+                                    if (cu->is_idle())
+                                      ++idle_cus;
+                                    else {
+                                      ++active_cus;
+                                      active_instructions = cu->wf(0)->trace_inst_count_;
+                                    }
+                                  }
+                                }};
+  f.engine->schedule_event_async(&observer_event, 3);
+  f.engine->run();
+
+  EXPECT_EQ(idle_cus, 1u);
+  EXPECT_EQ(active_cus, 1u);
+  EXPECT_EQ(active_instructions, 1024u);
+  EXPECT_TRUE(f.cu(0)->is_idle());
+  EXPECT_TRUE(f.cu(1)->is_idle());
+}
+
 class BlockingInstructionPlugin final : public ExecutionPlugin {
 public:
   BlockingInstructionPlugin() : ExecutionPlugin("blocking_instruction") {}
@@ -5931,6 +6075,7 @@ TEST(AqlDispatchTest, WorkerExceptionPropagatesThroughEngineStep) {
   test::AqlQueue queue(f.mem(), f.cp());
   queue.dispatch(kernel, /*grid_size=*/128, /*workgroup_size=*/64);
 
+  ASSERT_TRUE(f.engine->step()); // Doorbell dispatches work for tick 1.
   EXPECT_THROW((void)f.engine->step(), std::exception);
 }
 
@@ -5954,11 +6099,13 @@ TEST(AqlDispatchTest, WorkerYieldReturnsToEventLoopBeforeResuming) {
                               peer_saw_yielded_waves = wf0 && wf1 && wf0->trace_inst_count_ == 1 &&
                                                        wf1->trace_inst_count_ == 1;
                             }};
-  f.engine->schedule_event_async(&peer_event, 1);
+  f.engine->schedule_event_async(&peer_event, 2);
 
-  ASSERT_TRUE(f.engine->step()); // Doorbell: both CUs stop after s_sleep.
+  ASSERT_TRUE(f.engine->step()); // Doorbell schedules both CUs for tick 1.
   EXPECT_FALSE(peer_event_ran);
-  ASSERT_TRUE(f.engine->step()); // Peer event runs before the CU resume events.
+  ASSERT_TRUE(f.engine->step()); // Both CUs stop after s_sleep.
+  EXPECT_FALSE(peer_event_ran);
+  ASSERT_TRUE(f.engine->step()); // Peer event runs before the tick-2 CU resume.
   EXPECT_TRUE(peer_event_ran);
   EXPECT_TRUE(peer_saw_yielded_waves);
 
@@ -5988,6 +6135,7 @@ TEST(AqlDispatchTest, QueueMutationWaitsForDispatchWorkerWindow) {
   f.cp()->register_queue(removable_queue);
   dispatch_queue.dispatch(kernel, /*grid_size=*/128, /*workgroup_size=*/64);
 
+  ASSERT_TRUE(f.engine->step()); // Doorbell schedules the worker batch.
   auto step = std::async(std::launch::async, [&]() { return f.engine->step(); });
   const bool entered = blocker->wait_until_entered(2s);
   EXPECT_TRUE(entered) << "CU execution did not reach the blocking plugin";

--- a/emulation/rocjitsu/tests/cdna5_instruction_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_instruction_test.cpp
@@ -4,6 +4,10 @@
 #include "cdna5_sim_test_common.h"
 #include "decode_test_util.h"
 
+#include <atomic>
+#include <mutex>
+#include <thread>
+
 namespace {
 
 using namespace rocjitsu;
@@ -13,18 +17,47 @@ class BarrierSpanPlugin final : public ExecutionPlugin {
 public:
   BarrierSpanPlugin() : ExecutionPlugin("barrier_span") {}
 
+  struct Resolution {
+    size_t span_size = 0;
+    std::vector<uint32_t> workgroup_ids;
+    std::thread::id callback_thread;
+    uint32_t active_instructions = 0;
+  };
+
+  void onAmdgpuBeforeExecuteInstruction(uint64_t, const Instruction &,
+                                        amdgpu::Wavefront &) override {
+    active_instructions_.fetch_add(1, std::memory_order_relaxed);
+  }
+
+  void onAmdgpuAfterExecuteInstruction(uint64_t, const Instruction &,
+                                       amdgpu::Wavefront &) override {
+    active_instructions_.fetch_sub(1, std::memory_order_relaxed);
+  }
+
   void onAmdgpuBarrierResolved(std::span<amdgpu::Wavefront *> wavefronts) override {
-    span_sizes.push_back(wavefronts.size());
+    Resolution resolution;
+    resolution.span_size = wavefronts.size();
+    resolution.callback_thread = std::this_thread::get_id();
+    resolution.active_instructions = active_instructions_.load(std::memory_order_relaxed);
     std::vector<uint32_t> workgroups;
     for (const auto *wf : wavefronts)
       workgroups.push_back(wf->wg_id());
     std::ranges::sort(workgroups);
     workgroups.erase(std::unique(workgroups.begin(), workgroups.end()), workgroups.end());
-    workgroup_ids.push_back(std::move(workgroups));
+    resolution.workgroup_ids = std::move(workgroups);
+    std::lock_guard<std::mutex> lock(mutex_);
+    resolutions_.push_back(std::move(resolution));
   }
 
-  std::vector<size_t> span_sizes;
-  std::vector<std::vector<uint32_t>> workgroup_ids;
+  std::vector<Resolution> resolutions() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return resolutions_;
+  }
+
+private:
+  std::atomic<uint32_t> active_instructions_{0};
+  mutable std::mutex mutex_;
+  std::vector<Resolution> resolutions_;
 };
 
 class ForceScalarGuard {
@@ -618,7 +651,7 @@ TEST(Gfx1250SimulationTest, AqlDescriptorAllocatesNamedBarriersForTwoWaveKernel)
     EXPECT_EQ(wf.sgpr(4), 0x01000021u);
 }
 
-TEST(Gfx1250SimulationTest, ClusterBarrierSynchronizesWorkgroupsAcrossComputeUnits) {
+TEST(Gfx1250SimulationTest, ParallelClusterBarrierSynchronizesWorkgroupsAcrossComputeUnits) {
   constexpr auto read_first_workitem =
       cdna5::build_vop1(cdna5::kVReadfirstlaneB32Vop1, {.src0 = 256, .vdst = 4});
   constexpr auto is_first_wave =
@@ -638,11 +671,14 @@ TEST(Gfx1250SimulationTest, ClusterBarrierSynchronizesWorkgroupsAcrossComputeUni
   auto plugin = std::make_unique<BarrierSpanPlugin>();
   auto *barrier_span = plugin.get();
   ASSERT_TRUE(sim.plugin_group->add(std::move(plugin)));
+  sim.cp()->set_dispatch_threads(2);
+  ASSERT_EQ(sim.cp()->dispatch_threads(), 2u);
   uint64_t kernel_object = sim.write_kernel(0x10000, code, std::size(code), 104, 32, 2, false,
                                             false, false, 0, 0, 0, 0, 0, 1);
   test::AqlQueue queue(sim.memory, sim.cp());
   queue.dispatch_clustered(kernel_object, /*cluster_count_x=*/1, /*cluster_size_x=*/2,
                            /*workgroup_size_x=*/64);
+  const auto cp_thread = std::this_thread::get_id();
   step_until_xcd_halted(sim);
 
   ASSERT_EQ(sim.snapshot->snapshots().size(), 4u);
@@ -653,9 +689,12 @@ TEST(Gfx1250SimulationTest, ClusterBarrierSynchronizesWorkgroupsAcrossComputeUni
     EXPECT_EQ((state >> 16) & 0x7fu, 0u);
     EXPECT_TRUE(member_count == 1 || member_count == 2);
   }
-  ASSERT_EQ(barrier_span->span_sizes.size(), 1u);
-  EXPECT_EQ(barrier_span->span_sizes[0], 4u);
-  EXPECT_EQ(barrier_span->workgroup_ids[0], (std::vector<uint32_t>{0, 1}));
+  const auto resolutions = barrier_span->resolutions();
+  ASSERT_EQ(resolutions.size(), 1u);
+  EXPECT_EQ(resolutions[0].span_size, 4u);
+  EXPECT_EQ(resolutions[0].workgroup_ids, (std::vector<uint32_t>{0, 1}));
+  EXPECT_EQ(resolutions[0].callback_thread, cp_thread);
+  EXPECT_EQ(resolutions[0].active_instructions, 0u);
 }
 
 TEST(Gfx1250SimulationTest, ClusterBarrierCompletesAfterWorkgroupTerminatesEarly) {

--- a/emulation/rocjitsu/tests/cdna5_instruction_test.cpp
+++ b/emulation/rocjitsu/tests/cdna5_instruction_test.cpp
@@ -4,6 +4,10 @@
 #include "cdna5_sim_test_common.h"
 #include "decode_test_util.h"
 
+#include <atomic>
+#include <mutex>
+#include <thread>
+
 namespace {
 
 using namespace rocjitsu;
@@ -13,18 +17,47 @@ class BarrierSpanPlugin final : public ExecutionPlugin {
 public:
   BarrierSpanPlugin() : ExecutionPlugin("barrier_span") {}
 
+  struct Resolution {
+    size_t span_size = 0;
+    std::vector<uint32_t> workgroup_ids;
+    std::thread::id callback_thread;
+    uint32_t active_instructions = 0;
+  };
+
+  void onAmdgpuBeforeExecuteInstruction(uint64_t, const Instruction &,
+                                        amdgpu::Wavefront &) override {
+    active_instructions_.fetch_add(1, std::memory_order_relaxed);
+  }
+
+  void onAmdgpuAfterExecuteInstruction(uint64_t, const Instruction &,
+                                       amdgpu::Wavefront &) override {
+    active_instructions_.fetch_sub(1, std::memory_order_relaxed);
+  }
+
   void onAmdgpuBarrierResolved(std::span<amdgpu::Wavefront *> wavefronts) override {
-    span_sizes.push_back(wavefronts.size());
+    Resolution resolution;
+    resolution.span_size = wavefronts.size();
+    resolution.callback_thread = std::this_thread::get_id();
+    resolution.active_instructions = active_instructions_.load(std::memory_order_relaxed);
     std::vector<uint32_t> workgroups;
     for (const auto *wf : wavefronts)
       workgroups.push_back(wf->wg_id());
     std::ranges::sort(workgroups);
     workgroups.erase(std::unique(workgroups.begin(), workgroups.end()), workgroups.end());
-    workgroup_ids.push_back(std::move(workgroups));
+    resolution.workgroup_ids = std::move(workgroups);
+    std::lock_guard<std::mutex> lock(mutex_);
+    resolutions_.push_back(std::move(resolution));
   }
 
-  std::vector<size_t> span_sizes;
-  std::vector<std::vector<uint32_t>> workgroup_ids;
+  std::vector<Resolution> resolutions() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return resolutions_;
+  }
+
+private:
+  std::atomic<uint32_t> active_instructions_{0};
+  mutable std::mutex mutex_;
+  std::vector<Resolution> resolutions_;
 };
 
 TEST(Gfx1250SimulationTest, SGetPcI64ReturnsNextInstructionAddress) {
@@ -555,7 +588,7 @@ TEST(Gfx1250SimulationTest, AqlDescriptorAllocatesNamedBarriersForTwoWaveKernel)
     EXPECT_EQ(wf.sgpr(4), 0x01000021u);
 }
 
-TEST(Gfx1250SimulationTest, ClusterBarrierSynchronizesWorkgroupsAcrossComputeUnits) {
+TEST(Gfx1250SimulationTest, ParallelClusterBarrierSynchronizesWorkgroupsAcrossComputeUnits) {
   constexpr auto read_first_workitem =
       cdna5::build_vop1(cdna5::kVReadfirstlaneB32Vop1, {.src0 = 256, .vdst = 4});
   constexpr auto is_first_wave =
@@ -575,11 +608,14 @@ TEST(Gfx1250SimulationTest, ClusterBarrierSynchronizesWorkgroupsAcrossComputeUni
   auto plugin = std::make_unique<BarrierSpanPlugin>();
   auto *barrier_span = plugin.get();
   ASSERT_TRUE(sim.plugin_group->add(std::move(plugin)));
+  sim.cp()->set_dispatch_threads(2);
+  ASSERT_EQ(sim.cp()->dispatch_threads(), 2u);
   uint64_t kernel_object = sim.write_kernel(0x10000, code, std::size(code), 104, 32, 2, false,
                                             false, false, 0, 0, 0, 0, 0, 1);
   test::AqlQueue queue(sim.memory, sim.cp());
   queue.dispatch_clustered(kernel_object, /*cluster_count_x=*/1, /*cluster_size_x=*/2,
                            /*workgroup_size_x=*/64);
+  const auto cp_thread = std::this_thread::get_id();
   step_until_xcd_halted(sim);
 
   ASSERT_EQ(sim.snapshot->snapshots().size(), 4u);
@@ -590,9 +626,12 @@ TEST(Gfx1250SimulationTest, ClusterBarrierSynchronizesWorkgroupsAcrossComputeUni
     EXPECT_EQ((state >> 16) & 0x7fu, 0u);
     EXPECT_TRUE(member_count == 1 || member_count == 2);
   }
-  ASSERT_EQ(barrier_span->span_sizes.size(), 1u);
-  EXPECT_EQ(barrier_span->span_sizes[0], 4u);
-  EXPECT_EQ(barrier_span->workgroup_ids[0], (std::vector<uint32_t>{0, 1}));
+  const auto resolutions = barrier_span->resolutions();
+  ASSERT_EQ(resolutions.size(), 1u);
+  EXPECT_EQ(resolutions[0].span_size, 4u);
+  EXPECT_EQ(resolutions[0].workgroup_ids, (std::vector<uint32_t>{0, 1}));
+  EXPECT_EQ(resolutions[0].callback_thread, cp_thread);
+  EXPECT_EQ(resolutions[0].active_instructions, 0u);
 }
 
 TEST(Gfx1250SimulationTest, ClusterBarrierCompletesAfterWorkgroupTerminatesEarly) {

--- a/emulation/rocjitsu/tests/config_test.cpp
+++ b/emulation/rocjitsu/tests/config_test.cpp
@@ -275,7 +275,7 @@ TEST(ConfigLoaderTest, LoadFourGpuMi455xKmdConfig) {
 
 TEST(ConfigLoaderTest, DispatchPoolBudgetIsSharedAcrossProductionTopology) {
   auto loaded =
-      config::load_config(CONFIG_DIR_PATH + "/gfx950_cdna4.json", rocjitsu::kEmbeddedSchema);
+      config::load_config(CONFIG_DIR_PATH + "/gfx950_mi355x.json", rocjitsu::kEmbeddedSchema);
   auto *soc = loaded.soc();
 
   soc->set_dispatch_threads(8);
@@ -289,7 +289,7 @@ TEST(ConfigLoaderTest, DispatchPoolBudgetIsSharedAcrossProductionTopology) {
 
 TEST(ConfigLoaderTest, SerialPluginRemovesSharedPoolAcrossProductionTopology) {
   auto loaded =
-      config::load_config(CONFIG_DIR_PATH + "/gfx950_cdna4.json", rocjitsu::kEmbeddedSchema);
+      config::load_config(CONFIG_DIR_PATH + "/gfx950_mi355x.json", rocjitsu::kEmbeddedSchema);
   auto *soc = loaded.soc();
   soc->set_dispatch_threads(8);
 

--- a/emulation/rocjitsu/tests/config_test.cpp
+++ b/emulation/rocjitsu/tests/config_test.cpp
@@ -41,6 +41,7 @@ RJ_DIAGNOSTIC_POP
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 namespace {
 
@@ -90,6 +91,83 @@ TEST(ConfigLoaderTest, LoadCdna2Config) {
   EXPECT_LE(loaded.device.simd_count, loaded.device.num_shader_engines *
                                           loaded.device.num_shader_arrays_per_engine *
                                           loaded.device.num_cu_per_sh * loaded.device.simd_per_cu);
+}
+
+std::pair<uint32_t, uint32_t> run_two_spi_dispatch() {
+  const char *json = R"({"max_ticks":10000,"num_threads":1,
+    "vm":{"arch":"cdna3"},
+    "topology":{
+      "root":{
+        "name":"soc","type":"soc",
+        "children":[
+          {"name":"vram","type":"gpu_memory"},
+          {"name":"xcd0","type":"xcd","children":[
+            {"name":"l2","type":"l2_cache"},
+            {"name":"cp","type":"command_processor"},
+            {"name":"se0","type":"shader_engine","children":[
+              {"name":"cu0","type":"compute_unit","config":[
+                {"key":"num_wf_slots","value":"10"},
+                {"key":"sgprs_per_wf","value":"104"},
+                {"key":"vgprs_per_wf","value":"256"},
+                {"key":"lds_size_kb","value":"64"}
+              ]}
+            ]},
+            {"name":"se1","type":"shader_engine","children":[
+              {"name":"cu0","type":"compute_unit","config":[
+                {"key":"num_wf_slots","value":"10"},
+                {"key":"sgprs_per_wf","value":"104"},
+                {"key":"vgprs_per_wf","value":"256"},
+                {"key":"lds_size_kb","value":"64"}
+              ]}
+            ]}
+          ]}
+        ]
+      },
+      "links":[
+        {"src":"xcd0.cp.req_0","dst":"xcd0.se0.cu0.cpl","latency":1,"weight":2},
+        {"src":"xcd0.cp.req_1","dst":"xcd0.se1.cu0.cpl","latency":1,"weight":2},
+        {"src":"xcd0.se0.cu0.req","dst":"xcd0.l2.cpl_0","latency":1,"weight":10},
+        {"src":"xcd0.se1.cu0.req","dst":"xcd0.l2.cpl_1","latency":1,"weight":10}
+      ]
+    }
+  })";
+
+  auto loaded = config::load_config_from_string(json, rocjitsu::kEmbeddedSchema);
+  auto *soc = loaded.soc();
+
+  simdojo::SimulationEngine engine(loaded.engine_config);
+  engine.topology().set_root(loaded.take_root());
+  loaded.wire_links(engine.topology());
+  engine.create();
+
+  rocjitsu::test::DispatchCountPlugin *dispatch_count = nullptr;
+  soc->set_plugin_group(rocjitsu::test::make_dispatch_count_group(&dispatch_count));
+
+  using namespace rocr::llvm::amdhsa;
+  kernel_descriptor_t kd{};
+  kd.kernel_code_entry_byte_offset = sizeof(kernel_descriptor_t);
+  AMDHSA_BITS_SET(kd.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT,
+                  ((256 / 8) - 1));
+  AMDHSA_BITS_SET(kd.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT,
+                  ((104 / 8) - 1));
+  AMDHSA_BITS_SET(kd.compute_pgm_rsrc2, COMPUTE_PGM_RSRC2_USER_SGPR_COUNT, 2);
+
+  constexpr uint64_t KD_ADDR = 0x1000;
+  soc->memory()->load_image(reinterpret_cast<const uint8_t *>(&kd), sizeof(kd), KD_ADDR);
+  soc->memory()->write32(KD_ADDR + sizeof(kernel_descriptor_t), 0xFFFFFFFF);
+
+  auto *xcd = soc->xcd(0);
+  auto *cp = xcd->command_processor();
+  cp->set_dispatch_threads(2);
+  assert(cp->dispatch_threads() == 2);
+
+  test::AqlQueue queue(soc->memory(), cp);
+  queue.dispatch(KD_ADDR, 128, 64);
+
+  engine.step();
+
+  return {dispatch_count->for_cu(xcd->shader_engine(0)->compute_unit(0)),
+          dispatch_count->for_cu(xcd->shader_engine(1)->compute_unit(0))};
 }
 
 TEST(ConfigLoaderTest, LoadCdna4Config) {
@@ -1242,6 +1320,13 @@ TEST(ConfigLoaderTest, DispatchDistributesAcrossCUs) {
   auto *se = soc->xcd(0)->shader_engine(0);
   EXPECT_EQ(dispatch_count->for_cu(se->compute_unit(0)), 1u);
   EXPECT_EQ(dispatch_count->for_cu(se->compute_unit(1)), 1u);
+}
+
+TEST(ConfigLoaderTest, DispatchPlacementDoesNotFollowHostThreadCount) {
+  auto [se0_wfs, se1_wfs] = run_two_spi_dispatch();
+
+  EXPECT_EQ(se0_wfs, 2u);
+  EXPECT_EQ(se1_wfs, 0u);
 }
 
 TEST(CheckpointTest, SaveAndRestoreMemory) {

--- a/emulation/rocjitsu/tests/config_test.cpp
+++ b/emulation/rocjitsu/tests/config_test.cpp
@@ -426,7 +426,8 @@ TEST(ConfigLoaderTest, BuildFromJsonString) {
                     { "key": "num_wf_slots", "value": "20" },
                     { "key": "sgprs_per_wf", "value": "104" },
                     { "key": "vgprs_per_wf", "value": "256" },
-                    { "key": "lds_size_kb", "value": "64" }
+                    { "key": "lds_size_kb", "value": "64" },
+                    { "key": "functional_quantum", "value": "7" }
                   ]
                 }]
               },
@@ -471,6 +472,7 @@ TEST(ConfigLoaderTest, BuildFromJsonString) {
   EXPECT_EQ(xcd->num_shader_engines(), 2u);
   EXPECT_EQ(xcd->shader_engine(0)->num_compute_units(), 3u);
   EXPECT_EQ(xcd->shader_engine(1)->num_compute_units(), 3u);
+  EXPECT_EQ(xcd->shader_engine(0)->compute_unit(0)->config().functional_quantum, 7u);
 }
 
 TEST(ConfigLoaderTest, DeviceCapabilityFieldsDefaultToAutoCompute) {

--- a/emulation/rocjitsu/tests/config_test.cpp
+++ b/emulation/rocjitsu/tests/config_test.cpp
@@ -59,9 +59,9 @@ namespace {
 
 const std::string CONFIG_DIR_PATH = CONFIG_DIR;
 
-class SerialDispatchPolicyPlugin final : public rocjitsu::ExecutionPlugin {
+class SerializedHotHookPlugin final : public rocjitsu::ExecutionPlugin {
 public:
-  SerialDispatchPolicyPlugin() : rocjitsu::ExecutionPlugin("serial_dispatch_policy") {}
+  SerializedHotHookPlugin() : rocjitsu::ExecutionPlugin("serialized_hot_hook") {}
   bool requires_serial_hot_hooks() const override { return true; }
 };
 
@@ -287,19 +287,19 @@ TEST(ConfigLoaderTest, DispatchPoolBudgetIsSharedAcrossProductionTopology) {
   EXPECT_EQ(test::SoCTestAccess::dispatch_pool_threads(*soc), 0u);
 }
 
-TEST(ConfigLoaderTest, SerialPluginRemovesSharedPoolAcrossProductionTopology) {
+TEST(ConfigLoaderTest, SerializedHotHookPluginKeepsSharedPoolAcrossProductionTopology) {
   auto loaded =
       config::load_config(CONFIG_DIR_PATH + "/gfx950_mi355x.json", rocjitsu::kEmbeddedSchema);
   auto *soc = loaded.soc();
   soc->set_dispatch_threads(8);
 
   auto group = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
-  ASSERT_TRUE(group->add(std::make_unique<SerialDispatchPolicyPlugin>()));
+  ASSERT_TRUE(group->add(std::make_unique<SerializedHotHookPlugin>()));
   soc->set_plugin_group(group);
 
-  EXPECT_EQ(soc->dispatch_threads(), 1u);
-  EXPECT_EQ(test::SoCTestAccess::dispatch_pool_threads(*soc), 0u);
-  soc->for_each_cp([](auto *cp) { EXPECT_EQ(cp->dispatch_threads(), 1u); });
+  EXPECT_EQ(soc->dispatch_threads(), 8u);
+  EXPECT_EQ(test::SoCTestAccess::dispatch_pool_threads(*soc), 8u);
+  soc->for_each_cp([](auto *cp) { EXPECT_EQ(cp->dispatch_threads(), 8u); });
 }
 
 TEST(ConfigLoaderTest, LoadRdnaKmdConfigs) {

--- a/emulation/rocjitsu/tests/config_test.cpp
+++ b/emulation/rocjitsu/tests/config_test.cpp
@@ -59,6 +59,12 @@ namespace {
 
 const std::string CONFIG_DIR_PATH = CONFIG_DIR;
 
+class SerialDispatchPolicyPlugin final : public rocjitsu::ExecutionPlugin {
+public:
+  SerialDispatchPolicyPlugin() : rocjitsu::ExecutionPlugin("serial_dispatch_policy") {}
+  bool requires_serial_hot_hooks() const override { return true; }
+};
+
 // \NPI new GPU: add a config-load test for its configs/<gpu>.json here.
 using namespace rocjitsu;
 
@@ -279,6 +285,21 @@ TEST(ConfigLoaderTest, DispatchPoolBudgetIsSharedAcrossProductionTopology) {
 
   soc->set_dispatch_threads(1);
   EXPECT_EQ(test::SoCTestAccess::dispatch_pool_threads(*soc), 0u);
+}
+
+TEST(ConfigLoaderTest, SerialPluginRemovesSharedPoolAcrossProductionTopology) {
+  auto loaded =
+      config::load_config(CONFIG_DIR_PATH + "/gfx950_cdna4.json", rocjitsu::kEmbeddedSchema);
+  auto *soc = loaded.soc();
+  soc->set_dispatch_threads(8);
+
+  auto group = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
+  ASSERT_TRUE(group->add(std::make_unique<SerialDispatchPolicyPlugin>()));
+  soc->set_plugin_group(group);
+
+  EXPECT_EQ(soc->dispatch_threads(), 1u);
+  EXPECT_EQ(test::SoCTestAccess::dispatch_pool_threads(*soc), 0u);
+  soc->for_each_cp([](auto *cp) { EXPECT_EQ(cp->dispatch_threads(), 1u); });
 }
 
 TEST(ConfigLoaderTest, LoadRdnaKmdConfigs) {

--- a/emulation/rocjitsu/tests/config_test.cpp
+++ b/emulation/rocjitsu/tests/config_test.cpp
@@ -43,6 +43,18 @@ RJ_DIAGNOSTIC_POP
 #include <string_view>
 #include <utility>
 #include <vector>
+
+namespace rocjitsu::test {
+
+class SoCTestAccess {
+public:
+  static uint32_t dispatch_pool_threads(const SoC &soc) {
+    return soc.dispatch_pool_ ? soc.dispatch_pool_->thread_count() : 0;
+  }
+};
+
+} // namespace rocjitsu::test
+
 namespace {
 
 const std::string CONFIG_DIR_PATH = CONFIG_DIR;
@@ -253,6 +265,20 @@ TEST(ConfigLoaderTest, LoadFourGpuMi455xKmdConfig) {
 
   for (const auto &build : loaded.extra_gpu_builds)
     EXPECT_NE(dynamic_cast<SoC *>(build.root.get()), nullptr);
+}
+
+TEST(ConfigLoaderTest, DispatchPoolBudgetIsSharedAcrossProductionTopology) {
+  auto loaded =
+      config::load_config(CONFIG_DIR_PATH + "/gfx950_cdna4.json", rocjitsu::kEmbeddedSchema);
+  auto *soc = loaded.soc();
+
+  soc->set_dispatch_threads(8);
+  EXPECT_EQ(soc->dispatch_threads(), 8u);
+  EXPECT_EQ(test::SoCTestAccess::dispatch_pool_threads(*soc), 8u);
+  soc->for_each_cp([](auto *cp) { EXPECT_EQ(cp->dispatch_threads(), 8u); });
+
+  soc->set_dispatch_threads(1);
+  EXPECT_EQ(test::SoCTestAccess::dispatch_pool_threads(*soc), 0u);
 }
 
 TEST(ConfigLoaderTest, LoadRdnaKmdConfigs) {
@@ -1801,6 +1827,71 @@ TEST(CApiTest, CreateAndDestroyFromString) {
   EXPECT_EQ(rj_vm_create_from_string(json, RJ_VM_MODE_DEFAULT, &handle), ROCJITSU_STATUS_SUCCESS);
   ASSERT_NE(handle, nullptr);
   rj_vm_destroy(handle);
+}
+
+TEST(CApiTest, ClockedDispatchStaysEventDriven) {
+  const char *json = R"({"max_ticks":10000,"num_threads":1,
+    "exec_mode":"clocked",
+    "vm":{"arch":"cdna3"},
+    "topology":{
+      "root":{
+        "name":"soc","type":"soc",
+        "children":[
+          {"name":"vram","type":"gpu_memory"},
+          {"name":"xcd0","type":"xcd","children":[
+            {"name":"l2","type":"l2_cache"},
+            {"name":"cp","type":"command_processor"},
+            {"name":"se0","type":"shader_engine","children":[
+              {"name":"cu[0:1]","type":"compute_unit","config":[
+                {"key":"num_wf_slots","value":"10"},
+                {"key":"sgprs_per_wf","value":"104"},
+                {"key":"vgprs_per_wf","value":"256"},
+                {"key":"lds_size_kb","value":"64"}
+              ]}
+            ]}
+          ]}
+        ]
+      },
+      "links":[
+        {"src":"xcd0.cp.req_0","dst":"xcd0.se0.cu0.cpl","latency":1,"weight":2},
+        {"src":"xcd0.se0.cu0.req","dst":"xcd0.l2.cpl_0","latency":1,"weight":10}
+      ]
+    }
+  })";
+  rj_vm_t *raw = nullptr;
+  ASSERT_EQ(rj_vm_create_from_string(json, RJ_VM_MODE_DEFAULT, &raw), ROCJITSU_STATUS_SUCCESS);
+  ASSERT_NE(raw, nullptr);
+  std::unique_ptr<rj_vm_t, decltype(&rj_vm_destroy)> handle(raw, &rj_vm_destroy);
+  auto *cp = handle->soc->xcd(0)->command_processor();
+  cp->set_dispatch_threads(8);
+  EXPECT_EQ(cp->dispatch_threads(), 1u);
+
+  using namespace rocr::llvm::amdhsa;
+  kernel_descriptor_t kd{};
+  kd.kernel_code_entry_byte_offset = sizeof(kernel_descriptor_t);
+  AMDHSA_BITS_SET(kd.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT,
+                  ((256 / 8) - 1));
+  AMDHSA_BITS_SET(kd.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT,
+                  ((104 / 8) - 1));
+  AMDHSA_BITS_SET(kd.compute_pgm_rsrc2, COMPUTE_PGM_RSRC2_USER_SGPR_COUNT, 2);
+
+  constexpr uint64_t kKernelAddress = 0x1000;
+  constexpr uint32_t kCode[] = {0xBF800000u, 0xBF810000u}; // s_nop; s_endpgm
+  handle->soc->memory()->load_image(reinterpret_cast<const uint8_t *>(&kd), sizeof(kd),
+                                    kKernelAddress);
+  handle->soc->memory()->load_image(reinterpret_cast<const uint8_t *>(kCode), sizeof(kCode),
+                                    kKernelAddress + sizeof(kd));
+
+  test::AqlQueue queue(handle->soc->memory(), cp);
+  queue.dispatch(kKernelAddress, /*grid_size=*/64, /*workgroup_size=*/64);
+
+  int active = 0;
+  const auto tick_before_doorbell = handle->engine->global_time();
+  EXPECT_EQ(rj_vm_step(handle.get(), &active), ROCJITSU_STATUS_SUCCESS);
+  EXPECT_EQ(handle->engine->global_time(), tick_before_doorbell);
+  auto *cu = handle->soc->xcd(0)->shader_engine(0)->compute_unit(0);
+  ASSERT_NE(cu->wf(0), nullptr);
+  EXPECT_EQ(cu->wf(0)->trace_inst_count_, 0u);
 }
 
 TEST(CApiTest, CheckpointRoundTrip) {

--- a/emulation/rocjitsu/tests/config_test.cpp
+++ b/emulation/rocjitsu/tests/config_test.cpp
@@ -55,6 +55,12 @@ namespace {
 
 const std::string CONFIG_DIR_PATH = CONFIG_DIR;
 
+class SerialDispatchPolicyPlugin final : public rocjitsu::ExecutionPlugin {
+public:
+  SerialDispatchPolicyPlugin() : rocjitsu::ExecutionPlugin("serial_dispatch_policy") {}
+  bool requires_serial_hot_hooks() const override { return true; }
+};
+
 // \NPI new GPU: add a config-load test for its configs/<gpu>.json here.
 using namespace rocjitsu;
 
@@ -171,6 +177,21 @@ TEST(ConfigLoaderTest, DispatchPoolBudgetIsSharedAcrossProductionTopology) {
 
   soc->set_dispatch_threads(1);
   EXPECT_EQ(test::SoCTestAccess::dispatch_pool_threads(*soc), 0u);
+}
+
+TEST(ConfigLoaderTest, SerialPluginRemovesSharedPoolAcrossProductionTopology) {
+  auto loaded =
+      config::load_config(CONFIG_DIR_PATH + "/gfx950_cdna4.json", rocjitsu::kEmbeddedSchema);
+  auto *soc = loaded.soc();
+  soc->set_dispatch_threads(8);
+
+  auto group = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
+  ASSERT_TRUE(group->add(std::make_unique<SerialDispatchPolicyPlugin>()));
+  soc->set_plugin_group(group);
+
+  EXPECT_EQ(soc->dispatch_threads(), 1u);
+  EXPECT_EQ(test::SoCTestAccess::dispatch_pool_threads(*soc), 0u);
+  soc->for_each_cp([](auto *cp) { EXPECT_EQ(cp->dispatch_threads(), 1u); });
 }
 
 TEST(ConfigLoaderTest, LoadRdnaKmdConfigs) {

--- a/emulation/rocjitsu/tests/config_test.cpp
+++ b/emulation/rocjitsu/tests/config_test.cpp
@@ -313,7 +313,8 @@ TEST(ConfigLoaderTest, BuildFromJsonString) {
                     { "key": "num_wf_slots", "value": "20" },
                     { "key": "sgprs_per_wf", "value": "104" },
                     { "key": "vgprs_per_wf", "value": "256" },
-                    { "key": "lds_size_kb", "value": "64" }
+                    { "key": "lds_size_kb", "value": "64" },
+                    { "key": "functional_quantum", "value": "7" }
                   ]
                 }]
               },
@@ -358,6 +359,7 @@ TEST(ConfigLoaderTest, BuildFromJsonString) {
   EXPECT_EQ(xcd->num_shader_engines(), 2u);
   EXPECT_EQ(xcd->shader_engine(0)->num_compute_units(), 3u);
   EXPECT_EQ(xcd->shader_engine(1)->num_compute_units(), 3u);
+  EXPECT_EQ(xcd->shader_engine(0)->compute_unit(0)->config().functional_quantum, 7u);
 }
 
 TEST(ConfigLoaderTest, DeviceCapabilityFieldsDefaultToAutoCompute) {

--- a/emulation/rocjitsu/tests/config_test.cpp
+++ b/emulation/rocjitsu/tests/config_test.cpp
@@ -38,6 +38,7 @@ RJ_DIAGNOSTIC_POP
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <utility>
 namespace {
 
 const std::string CONFIG_DIR_PATH = CONFIG_DIR;
@@ -49,6 +50,83 @@ test::ScopedTempFile write_temp_config(std::string_view json) {
   test::ScopedTempFile file("rocjitsu-config-");
   file.write(json);
   return file;
+}
+
+std::pair<uint32_t, uint32_t> run_two_spi_dispatch() {
+  const char *json = R"({"max_ticks":10000,"num_threads":1,
+    "vm":{"arch":"cdna3"},
+    "topology":{
+      "root":{
+        "name":"soc","type":"soc",
+        "children":[
+          {"name":"vram","type":"gpu_memory"},
+          {"name":"xcd0","type":"xcd","children":[
+            {"name":"l2","type":"l2_cache"},
+            {"name":"cp","type":"command_processor"},
+            {"name":"se0","type":"shader_engine","children":[
+              {"name":"cu0","type":"compute_unit","config":[
+                {"key":"num_wf_slots","value":"10"},
+                {"key":"sgprs_per_wf","value":"104"},
+                {"key":"vgprs_per_wf","value":"256"},
+                {"key":"lds_size_kb","value":"64"}
+              ]}
+            ]},
+            {"name":"se1","type":"shader_engine","children":[
+              {"name":"cu0","type":"compute_unit","config":[
+                {"key":"num_wf_slots","value":"10"},
+                {"key":"sgprs_per_wf","value":"104"},
+                {"key":"vgprs_per_wf","value":"256"},
+                {"key":"lds_size_kb","value":"64"}
+              ]}
+            ]}
+          ]}
+        ]
+      },
+      "links":[
+        {"src":"xcd0.cp.req_0","dst":"xcd0.se0.cu0.cpl","latency":1,"weight":2},
+        {"src":"xcd0.cp.req_1","dst":"xcd0.se1.cu0.cpl","latency":1,"weight":2},
+        {"src":"xcd0.se0.cu0.req","dst":"xcd0.l2.cpl_0","latency":1,"weight":10},
+        {"src":"xcd0.se1.cu0.req","dst":"xcd0.l2.cpl_1","latency":1,"weight":10}
+      ]
+    }
+  })";
+
+  auto loaded = config::load_config_from_string(json, rocjitsu::kEmbeddedSchema);
+  auto *soc = loaded.soc();
+
+  simdojo::SimulationEngine engine(loaded.engine_config);
+  engine.topology().set_root(loaded.take_root());
+  loaded.wire_links(engine.topology());
+  engine.create();
+
+  rocjitsu::test::DispatchCountPlugin *dispatch_count = nullptr;
+  soc->set_plugin_group(rocjitsu::test::make_dispatch_count_group(&dispatch_count));
+
+  using namespace rocr::llvm::amdhsa;
+  kernel_descriptor_t kd{};
+  kd.kernel_code_entry_byte_offset = sizeof(kernel_descriptor_t);
+  AMDHSA_BITS_SET(kd.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT,
+                  ((256 / 8) - 1));
+  AMDHSA_BITS_SET(kd.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT,
+                  ((104 / 8) - 1));
+  AMDHSA_BITS_SET(kd.compute_pgm_rsrc2, COMPUTE_PGM_RSRC2_USER_SGPR_COUNT, 2);
+
+  constexpr uint64_t KD_ADDR = 0x1000;
+  soc->memory()->load_image(reinterpret_cast<const uint8_t *>(&kd), sizeof(kd), KD_ADDR);
+  soc->memory()->write32(KD_ADDR + sizeof(kernel_descriptor_t), 0xFFFFFFFF);
+
+  auto *xcd = soc->xcd(0);
+  auto *cp = xcd->command_processor();
+  cp->set_dispatch_threads(2);
+  assert(cp->dispatch_threads() == 2);
+
+  test::AqlQueue queue(soc->memory(), cp);
+  queue.dispatch(KD_ADDR, 128, 64);
+
+  engine.step();
+
+  return {dispatch_count->for_cu(xcd->shader_engine(0)->compute_unit(0)),
+          dispatch_count->for_cu(xcd->shader_engine(1)->compute_unit(0))};
 }
 
 TEST(ConfigLoaderTest, LoadCdna4Config) {
@@ -954,6 +1032,13 @@ TEST(ConfigLoaderTest, DispatchDistributesAcrossCUs) {
   auto *se = soc->xcd(0)->shader_engine(0);
   EXPECT_EQ(dispatch_count->for_cu(se->compute_unit(0)), 1u);
   EXPECT_EQ(dispatch_count->for_cu(se->compute_unit(1)), 1u);
+}
+
+TEST(ConfigLoaderTest, DispatchPlacementDoesNotFollowHostThreadCount) {
+  auto [se0_wfs, se1_wfs] = run_two_spi_dispatch();
+
+  EXPECT_EQ(se0_wfs, 2u);
+  EXPECT_EQ(se1_wfs, 0u);
 }
 
 TEST(CheckpointTest, SaveAndRestoreMemory) {

--- a/emulation/rocjitsu/tests/config_test.cpp
+++ b/emulation/rocjitsu/tests/config_test.cpp
@@ -39,6 +39,18 @@ RJ_DIAGNOSTIC_POP
 #include <string>
 #include <string_view>
 #include <utility>
+
+namespace rocjitsu::test {
+
+class SoCTestAccess {
+public:
+  static uint32_t dispatch_pool_threads(const SoC &soc) {
+    return soc.dispatch_pool_ ? soc.dispatch_pool_->thread_count() : 0;
+  }
+};
+
+} // namespace rocjitsu::test
+
 namespace {
 
 const std::string CONFIG_DIR_PATH = CONFIG_DIR;
@@ -145,6 +157,20 @@ TEST(ConfigLoaderTest, LoadCdna4Config) {
   EXPECT_EQ(soc->assign_queue_cp(0), soc->xcd(0)->command_processor());
   EXPECT_EQ(soc->assign_queue_cp(1), soc->xcd(1)->command_processor());
   EXPECT_EQ(soc->assign_queue_cp(soc->num_xcds()), soc->xcd(0)->command_processor());
+}
+
+TEST(ConfigLoaderTest, DispatchPoolBudgetIsSharedAcrossProductionTopology) {
+  auto loaded =
+      config::load_config(CONFIG_DIR_PATH + "/gfx950_cdna4.json", rocjitsu::kEmbeddedSchema);
+  auto *soc = loaded.soc();
+
+  soc->set_dispatch_threads(8);
+  EXPECT_EQ(soc->dispatch_threads(), 8u);
+  EXPECT_EQ(test::SoCTestAccess::dispatch_pool_threads(*soc), 8u);
+  soc->for_each_cp([](auto *cp) { EXPECT_EQ(cp->dispatch_threads(), 8u); });
+
+  soc->set_dispatch_threads(1);
+  EXPECT_EQ(test::SoCTestAccess::dispatch_pool_threads(*soc), 0u);
 }
 
 TEST(ConfigLoaderTest, LoadRdnaKmdConfigs) {
@@ -1462,6 +1488,71 @@ TEST(CApiTest, CreateAndDestroyFromString) {
   EXPECT_EQ(rj_vm_create_from_string(json, RJ_VM_MODE_DEFAULT, &handle), ROCJITSU_STATUS_SUCCESS);
   ASSERT_NE(handle, nullptr);
   rj_vm_destroy(handle);
+}
+
+TEST(CApiTest, ClockedDispatchStaysEventDriven) {
+  const char *json = R"({"max_ticks":10000,"num_threads":1,
+    "exec_mode":"clocked",
+    "vm":{"arch":"cdna3"},
+    "topology":{
+      "root":{
+        "name":"soc","type":"soc",
+        "children":[
+          {"name":"vram","type":"gpu_memory"},
+          {"name":"xcd0","type":"xcd","children":[
+            {"name":"l2","type":"l2_cache"},
+            {"name":"cp","type":"command_processor"},
+            {"name":"se0","type":"shader_engine","children":[
+              {"name":"cu[0:1]","type":"compute_unit","config":[
+                {"key":"num_wf_slots","value":"10"},
+                {"key":"sgprs_per_wf","value":"104"},
+                {"key":"vgprs_per_wf","value":"256"},
+                {"key":"lds_size_kb","value":"64"}
+              ]}
+            ]}
+          ]}
+        ]
+      },
+      "links":[
+        {"src":"xcd0.cp.req_0","dst":"xcd0.se0.cu0.cpl","latency":1,"weight":2},
+        {"src":"xcd0.se0.cu0.req","dst":"xcd0.l2.cpl_0","latency":1,"weight":10}
+      ]
+    }
+  })";
+  rj_vm_t *raw = nullptr;
+  ASSERT_EQ(rj_vm_create_from_string(json, RJ_VM_MODE_DEFAULT, &raw), ROCJITSU_STATUS_SUCCESS);
+  ASSERT_NE(raw, nullptr);
+  std::unique_ptr<rj_vm_t, decltype(&rj_vm_destroy)> handle(raw, &rj_vm_destroy);
+  auto *cp = handle->soc->xcd(0)->command_processor();
+  cp->set_dispatch_threads(8);
+  EXPECT_EQ(cp->dispatch_threads(), 1u);
+
+  using namespace rocr::llvm::amdhsa;
+  kernel_descriptor_t kd{};
+  kd.kernel_code_entry_byte_offset = sizeof(kernel_descriptor_t);
+  AMDHSA_BITS_SET(kd.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT,
+                  ((256 / 8) - 1));
+  AMDHSA_BITS_SET(kd.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT,
+                  ((104 / 8) - 1));
+  AMDHSA_BITS_SET(kd.compute_pgm_rsrc2, COMPUTE_PGM_RSRC2_USER_SGPR_COUNT, 2);
+
+  constexpr uint64_t kKernelAddress = 0x1000;
+  constexpr uint32_t kCode[] = {0xBF800000u, 0xBF810000u}; // s_nop; s_endpgm
+  handle->soc->memory()->load_image(reinterpret_cast<const uint8_t *>(&kd), sizeof(kd),
+                                    kKernelAddress);
+  handle->soc->memory()->load_image(reinterpret_cast<const uint8_t *>(kCode), sizeof(kCode),
+                                    kKernelAddress + sizeof(kd));
+
+  test::AqlQueue queue(handle->soc->memory(), cp);
+  queue.dispatch(kKernelAddress, /*grid_size=*/64, /*workgroup_size=*/64);
+
+  int active = 0;
+  const auto tick_before_doorbell = handle->engine->global_time();
+  EXPECT_EQ(rj_vm_step(handle.get(), &active), ROCJITSU_STATUS_SUCCESS);
+  EXPECT_EQ(handle->engine->global_time(), tick_before_doorbell);
+  auto *cu = handle->soc->xcd(0)->shader_engine(0)->compute_unit(0);
+  ASSERT_NE(cu->wf(0), nullptr);
+  EXPECT_EQ(cu->wf(0)->trace_inst_count_, 0u);
 }
 
 TEST(CApiTest, CheckpointRoundTrip) {

--- a/emulation/rocjitsu/tests/config_test.cpp
+++ b/emulation/rocjitsu/tests/config_test.cpp
@@ -167,7 +167,7 @@ TEST(ConfigLoaderTest, LoadCdna4Config) {
 
 TEST(ConfigLoaderTest, DispatchPoolBudgetIsSharedAcrossProductionTopology) {
   auto loaded =
-      config::load_config(CONFIG_DIR_PATH + "/gfx950_cdna4.json", rocjitsu::kEmbeddedSchema);
+      config::load_config(CONFIG_DIR_PATH + "/gfx950_mi355x.json", rocjitsu::kEmbeddedSchema);
   auto *soc = loaded.soc();
 
   soc->set_dispatch_threads(8);
@@ -181,7 +181,7 @@ TEST(ConfigLoaderTest, DispatchPoolBudgetIsSharedAcrossProductionTopology) {
 
 TEST(ConfigLoaderTest, SerialPluginRemovesSharedPoolAcrossProductionTopology) {
   auto loaded =
-      config::load_config(CONFIG_DIR_PATH + "/gfx950_cdna4.json", rocjitsu::kEmbeddedSchema);
+      config::load_config(CONFIG_DIR_PATH + "/gfx950_mi355x.json", rocjitsu::kEmbeddedSchema);
   auto *soc = loaded.soc();
   soc->set_dispatch_threads(8);
 

--- a/emulation/rocjitsu/tests/config_test.cpp
+++ b/emulation/rocjitsu/tests/config_test.cpp
@@ -51,6 +51,10 @@ public:
   static uint32_t dispatch_pool_threads(const SoC &soc) {
     return soc.dispatch_pool_ ? soc.dispatch_pool_->thread_count() : 0;
   }
+
+  static const amdgpu::CpuDispatchPool *dispatch_pool(const SoC &soc) {
+    return soc.dispatch_pool_.get();
+  }
 };
 
 } // namespace rocjitsu::test
@@ -292,6 +296,8 @@ TEST(ConfigLoaderTest, SerializedHotHookPluginKeepsSharedPoolAcrossProductionTop
       config::load_config(CONFIG_DIR_PATH + "/gfx950_mi355x.json", rocjitsu::kEmbeddedSchema);
   auto *soc = loaded.soc();
   soc->set_dispatch_threads(8);
+  const auto *pool = test::SoCTestAccess::dispatch_pool(*soc);
+  ASSERT_NE(pool, nullptr);
 
   auto group = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
   ASSERT_TRUE(group->add(std::make_unique<SerializedHotHookPlugin>()));
@@ -299,6 +305,7 @@ TEST(ConfigLoaderTest, SerializedHotHookPluginKeepsSharedPoolAcrossProductionTop
 
   EXPECT_EQ(soc->dispatch_threads(), 8u);
   EXPECT_EQ(test::SoCTestAccess::dispatch_pool_threads(*soc), 8u);
+  EXPECT_EQ(test::SoCTestAccess::dispatch_pool(*soc), pool);
   soc->for_each_cp([](auto *cp) { EXPECT_EQ(cp->dispatch_threads(), 8u); });
 }
 

--- a/emulation/rocjitsu/tests/cpu_dispatch_pool_test.cpp
+++ b/emulation/rocjitsu/tests/cpu_dispatch_pool_test.cpp
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/vm/amdgpu/cpu_dispatch_pool.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t kSNop = 0xBF800000u;
+constexpr uint32_t kSSetvskip = 0xBF100000u;
+constexpr uint64_t kProgramBase = 0x100000;
+
+struct DispatchPoolFixture {
+  explicit DispatchPoolFixture(uint32_t cu_count) : l2("pool_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = 104;
+    cfg.vgprs_per_wf = 256;
+    cfg.lds_size_kb = 64;
+    cfg.functional_quantum = 1;
+
+    for (uint32_t i = 0; i < 256; ++i)
+      memory.write32(kProgramBase + i * sizeof(uint32_t), kSNop);
+
+    cus.reserve(cu_count);
+    tasks.reserve(cu_count);
+    wfs.reserve(cu_count);
+    for (uint32_t i = 0; i < cu_count; ++i) {
+      auto cu = amdgpu::ComputeUnitCore::create("pool_cu" + std::to_string(i), cfg, &memory, &l2);
+      auto *wf = cu->dispatch_wf(/*wg_id=*/i, kProgramBase, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
+      EXPECT_NE(wf, nullptr);
+      tasks.push_back(cu.get());
+      wfs.push_back(wf);
+      cus.push_back(std::move(cu));
+    }
+  }
+
+  amdgpu::GpuMemory memory{"pool_memory"};
+  amdgpu::L2Cache l2;
+  std::vector<std::unique_ptr<amdgpu::ComputeUnitCore>> cus;
+  std::vector<amdgpu::ComputeUnitCore *> tasks;
+  std::vector<amdgpu::Wavefront *> wfs;
+};
+
+TEST(CpuDispatchPoolTest, ReusedBatchesRunEachCuOnceAtRequestedThreadCounts) {
+  DispatchPoolFixture fixture(/*cu_count=*/8);
+  amdgpu::CpuDispatchPool pool(/*threads=*/8);
+
+  constexpr std::array<uint32_t, 6> kThreadCounts = {1, 2, 8, 3, 8, 1};
+  uint32_t expected_quanta = 0;
+  for (uint32_t repeat = 0; repeat < 8; ++repeat) {
+    for (uint32_t thread_count : kThreadCounts) {
+      pool.run(std::span<amdgpu::ComputeUnitCore *>(fixture.tasks), thread_count);
+      ++expected_quanta;
+
+      for (auto *wf : fixture.wfs) {
+        EXPECT_EQ(wf->trace_inst_count_, expected_quanta);
+        EXPECT_EQ(wf->pc, kProgramBase + expected_quanta * sizeof(uint32_t));
+      }
+    }
+  }
+}
+
+TEST(CpuDispatchPoolTest, ZeroThreadsFallsBackToCallingThread) {
+  DispatchPoolFixture fixture(/*cu_count=*/1);
+  amdgpu::CpuDispatchPool pool(/*threads=*/0);
+
+  EXPECT_EQ(pool.thread_count(), 1u);
+  pool.run(std::span<amdgpu::ComputeUnitCore *>(fixture.tasks), /*threads=*/0);
+  EXPECT_EQ(fixture.wfs.front()->trace_inst_count_, 1u);
+}
+
+TEST(CpuDispatchPoolTest, WorkerExceptionsRethrowAndPoolRemainsReusable) {
+  DispatchPoolFixture fixture(/*cu_count=*/64);
+  amdgpu::CpuDispatchPool pool(/*threads=*/8);
+
+  fixture.memory.write32(kProgramBase, kSSetvskip);
+  EXPECT_THROW(pool.run(std::span<amdgpu::ComputeUnitCore *>(fixture.tasks), /*threads=*/8),
+               std::exception);
+
+  fixture.memory.write32(kProgramBase, kSNop);
+  for (auto *wf : fixture.wfs)
+    wf->pc = kProgramBase;
+  EXPECT_NO_THROW(pool.run(std::span<amdgpu::ComputeUnitCore *>(fixture.tasks), /*threads=*/8));
+  for (auto *wf : fixture.wfs)
+    EXPECT_EQ(wf->pc, kProgramBase + sizeof(uint32_t));
+}
+
+TEST(CpuDispatchPoolTest, DestroyJoinsParkedWorkers) {
+  for (uint32_t i = 0; i < 100; ++i) {
+    amdgpu::CpuDispatchPool pool(/*threads=*/8);
+    EXPECT_EQ(pool.thread_count(), 8u);
+  }
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/cpu_dispatch_pool_test.cpp
+++ b/emulation/rocjitsu/tests/cpu_dispatch_pool_test.cpp
@@ -145,6 +145,19 @@ TEST(CpuDispatchPoolTest, WorkerExceptionsRethrowAndPoolRemainsReusable) {
     EXPECT_EQ(wf->pc, kProgramBase + sizeof(uint32_t));
 }
 
+TEST(CpuDispatchPoolTest, OneThreadFinishesBatchBeforeRethrowing) {
+  constexpr uint64_t kBadProgramBase = kProgramBase + 0x2000;
+  DispatchPoolFixture fixture(/*cu_count=*/4);
+  amdgpu::CpuDispatchPool pool(/*threads=*/4);
+  fixture.memory.write32(kBadProgramBase, kSSetvskip);
+  fixture.wfs[0]->pc = kBadProgramBase;
+
+  EXPECT_THROW(pool.run(std::span<amdgpu::ComputeUnitCore *>(fixture.tasks), /*threads=*/1),
+               std::exception);
+  for (size_t i = 1; i < fixture.wfs.size(); ++i)
+    EXPECT_EQ(fixture.wfs[i]->pc, kProgramBase + sizeof(uint32_t));
+}
+
 TEST(CpuDispatchPoolTest, DestroyJoinsParkedWorkers) {
   for (uint32_t i = 0; i < 100; ++i) {
     amdgpu::CpuDispatchPool pool(/*threads=*/8);

--- a/emulation/rocjitsu/tests/cpu_dispatch_pool_test.cpp
+++ b/emulation/rocjitsu/tests/cpu_dispatch_pool_test.cpp
@@ -103,6 +103,7 @@ TEST(CpuDispatchPoolTest, ZeroFunctionalQuantumRunsUntilWavefrontHalts) {
   auto result = fixture.cus.front()->run_quantum();
 
   EXPECT_TRUE(result.ran);
+  EXPECT_EQ(result.iterations, 2u);
   EXPECT_TRUE(fixture.cus.front()->is_idle());
 }
 

--- a/emulation/rocjitsu/tests/cpu_dispatch_pool_test.cpp
+++ b/emulation/rocjitsu/tests/cpu_dispatch_pool_test.cpp
@@ -35,14 +35,14 @@ constexpr uint32_t kSSetvskip = 0xBF100000u;
 constexpr uint64_t kProgramBase = 0x100000;
 
 struct DispatchPoolFixture {
-  explicit DispatchPoolFixture(uint32_t cu_count) : l2("pool_l2") {
+  explicit DispatchPoolFixture(uint32_t cu_count, uint32_t functional_quantum = 1) : l2("pool_l2") {
     amdgpu::ComputeUnitCore::Config cfg{};
     cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
     cfg.num_wf_slots = 1;
     cfg.sgprs_per_wf = 104;
     cfg.vgprs_per_wf = 256;
     cfg.lds_size_kb = 64;
-    cfg.functional_quantum = 1;
+    cfg.functional_quantum = functional_quantum;
 
     for (uint32_t i = 0; i < 256; ++i)
       memory.write32(kProgramBase + i * sizeof(uint32_t), kSNop);
@@ -93,6 +93,17 @@ TEST(CpuDispatchPoolTest, ZeroThreadsFallsBackToCallingThread) {
   EXPECT_EQ(pool.thread_count(), 1u);
   pool.run(std::span<amdgpu::ComputeUnitCore *>(fixture.tasks), /*threads=*/0);
   EXPECT_EQ(fixture.wfs.front()->trace_inst_count_, 1u);
+}
+
+TEST(CpuDispatchPoolTest, ZeroFunctionalQuantumRunsUntilWavefrontHalts) {
+  constexpr uint32_t kSEndpgm = 0xBF810000u;
+  DispatchPoolFixture fixture(/*cu_count=*/1, /*functional_quantum=*/0);
+  fixture.memory.write32(kProgramBase + 2 * sizeof(uint32_t), kSEndpgm);
+
+  auto result = fixture.cus.front()->run_quantum();
+
+  EXPECT_TRUE(result.ran);
+  EXPECT_TRUE(fixture.cus.front()->is_idle());
 }
 
 TEST(CpuDispatchPoolTest, WorkerExceptionsRethrowAndPoolRemainsReusable) {

--- a/emulation/rocjitsu/tests/cpu_dispatch_pool_test.cpp
+++ b/emulation/rocjitsu/tests/cpu_dispatch_pool_test.cpp
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <memory>
 #include <span>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -97,14 +98,33 @@ TEST(CpuDispatchPoolTest, ZeroThreadsFallsBackToCallingThread) {
 
 TEST(CpuDispatchPoolTest, ZeroFunctionalQuantumRunsUntilWavefrontHalts) {
   constexpr uint32_t kSEndpgm = 0xBF810000u;
-  DispatchPoolFixture fixture(/*cu_count=*/1, /*functional_quantum=*/0);
+  constexpr uint64_t kSecondProgramBase = kProgramBase + 128 * sizeof(uint32_t);
+  DispatchPoolFixture fixture(/*cu_count=*/2, /*functional_quantum=*/0);
   fixture.memory.write32(kProgramBase + 2 * sizeof(uint32_t), kSEndpgm);
+  fixture.memory.write32(kSecondProgramBase + 3 * sizeof(uint32_t), kSEndpgm);
+  fixture.wfs[1]->pc = kSecondProgramBase;
 
-  auto result = fixture.cus.front()->run_quantum();
+  amdgpu::CpuDispatchPool pool(/*threads=*/2);
+  std::array<amdgpu::FunctionalQuantumResult, 2> per_cu{};
+  auto result = pool.run(std::span<amdgpu::ComputeUnitCore *>(fixture.tasks), /*threads=*/2,
+                         std::span<amdgpu::FunctionalQuantumResult>(per_cu));
 
   EXPECT_TRUE(result.ran);
-  EXPECT_EQ(result.iterations, 2u);
-  EXPECT_TRUE(fixture.cus.front()->is_idle());
+  EXPECT_FALSE(result.yielded);
+  EXPECT_EQ(result.iterations, 3u);
+  EXPECT_TRUE(per_cu[0].ran);
+  EXPECT_FALSE(per_cu[0].yielded);
+  EXPECT_EQ(per_cu[0].iterations, 2u);
+  EXPECT_TRUE(per_cu[1].ran);
+  EXPECT_FALSE(per_cu[1].yielded);
+  EXPECT_EQ(per_cu[1].iterations, 3u);
+  EXPECT_TRUE(fixture.cus[0]->is_idle());
+  EXPECT_TRUE(fixture.cus[1]->is_idle());
+
+  std::array<amdgpu::FunctionalQuantumResult, 1> wrong_size{};
+  EXPECT_THROW(pool.run(std::span<amdgpu::ComputeUnitCore *>(fixture.tasks), /*threads=*/2,
+                        std::span<amdgpu::FunctionalQuantumResult>(wrong_size)),
+               std::invalid_argument);
 }
 
 TEST(CpuDispatchPoolTest, WorkerExceptionsRethrowAndPoolRemainsReusable) {
@@ -116,6 +136,8 @@ TEST(CpuDispatchPoolTest, WorkerExceptionsRethrowAndPoolRemainsReusable) {
                std::exception);
 
   fixture.memory.write32(kProgramBase, kSNop);
+  for (auto &cu : fixture.cus)
+    cu->instruction_cache().invalidate_all();
   for (auto *wf : fixture.wfs)
     wf->pc = kProgramBase;
   EXPECT_NO_THROW(pool.run(std::span<amdgpu::ComputeUnitCore *>(fixture.tasks), /*threads=*/8));

--- a/emulation/rocjitsu/tests/cpu_dispatch_pool_test.cpp
+++ b/emulation/rocjitsu/tests/cpu_dispatch_pool_test.cpp
@@ -15,6 +15,17 @@
 #include <string>
 #include <vector>
 
+namespace rocjitsu::amdgpu {
+
+class CpuDispatchPoolTestAccess {
+public:
+  static void construct_with_failure(uint32_t threads, uint32_t fail_after) {
+    CpuDispatchPool pool(threads, fail_after);
+  }
+};
+
+} // namespace rocjitsu::amdgpu
+
 namespace {
 
 using namespace rocjitsu;
@@ -105,6 +116,12 @@ TEST(CpuDispatchPoolTest, DestroyJoinsParkedWorkers) {
     amdgpu::CpuDispatchPool pool(/*threads=*/8);
     EXPECT_EQ(pool.thread_count(), 8u);
   }
+}
+
+TEST(CpuDispatchPoolTest, PartialConstructionJoinsParkedWorkers) {
+  EXPECT_THROW(amdgpu::CpuDispatchPoolTestAccess::construct_with_failure(/*threads=*/8,
+                                                                         /*fail_after=*/2),
+               std::runtime_error);
 }
 
 } // namespace

--- a/emulation/rocjitsu/tests/cpu_dispatch_pool_test.cpp
+++ b/emulation/rocjitsu/tests/cpu_dispatch_pool_test.cpp
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <memory>
 #include <span>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -97,14 +98,33 @@ TEST(CpuDispatchPoolTest, ZeroThreadsFallsBackToCallingThread) {
 
 TEST(CpuDispatchPoolTest, ZeroFunctionalQuantumRunsUntilWavefrontHalts) {
   constexpr uint32_t kSEndpgm = 0xBF810000u;
-  DispatchPoolFixture fixture(/*cu_count=*/1, /*functional_quantum=*/0);
+  constexpr uint64_t kSecondProgramBase = kProgramBase + 128 * sizeof(uint32_t);
+  DispatchPoolFixture fixture(/*cu_count=*/2, /*functional_quantum=*/0);
   fixture.memory.write32(kProgramBase + 2 * sizeof(uint32_t), kSEndpgm);
+  fixture.memory.write32(kSecondProgramBase + 3 * sizeof(uint32_t), kSEndpgm);
+  fixture.wfs[1]->pc = kSecondProgramBase;
 
-  auto result = fixture.cus.front()->run_quantum();
+  amdgpu::CpuDispatchPool pool(/*threads=*/2);
+  std::array<amdgpu::FunctionalQuantumResult, 2> per_cu{};
+  auto result = pool.run(std::span<amdgpu::ComputeUnitCore *>(fixture.tasks), /*threads=*/2,
+                         std::span<amdgpu::FunctionalQuantumResult>(per_cu));
 
   EXPECT_TRUE(result.ran);
-  EXPECT_EQ(result.iterations, 2u);
-  EXPECT_TRUE(fixture.cus.front()->is_idle());
+  EXPECT_FALSE(result.yielded);
+  EXPECT_EQ(result.iterations, 3u);
+  EXPECT_TRUE(per_cu[0].ran);
+  EXPECT_FALSE(per_cu[0].yielded);
+  EXPECT_EQ(per_cu[0].iterations, 2u);
+  EXPECT_TRUE(per_cu[1].ran);
+  EXPECT_FALSE(per_cu[1].yielded);
+  EXPECT_EQ(per_cu[1].iterations, 3u);
+  EXPECT_TRUE(fixture.cus[0]->is_idle());
+  EXPECT_TRUE(fixture.cus[1]->is_idle());
+
+  std::array<amdgpu::FunctionalQuantumResult, 1> wrong_size{};
+  EXPECT_THROW(pool.run(std::span<amdgpu::ComputeUnitCore *>(fixture.tasks), /*threads=*/2,
+                        std::span<amdgpu::FunctionalQuantumResult>(wrong_size)),
+               std::invalid_argument);
 }
 
 TEST(CpuDispatchPoolTest, WorkerExceptionsRethrowAndPoolRemainsReusable) {

--- a/emulation/rocjitsu/tests/execution_plugin_test.cpp
+++ b/emulation/rocjitsu/tests/execution_plugin_test.cpp
@@ -208,6 +208,7 @@ struct HookEvent {
   uint64_t lane_mask = 0;
   uint8_t byte_mask = 0;
   uint64_t pc = 0;
+  std::thread::id callback_thread;
   std::string mnemonic;
   std::string kernel_name;
   std::string kernel_symbol;
@@ -385,6 +386,56 @@ class ParallelSafePlugin final : public ExecutionPlugin {
 public:
   ParallelSafePlugin() : ExecutionPlugin("parallel_safe") {}
   bool requires_serial_hot_hooks() const override { return false; }
+};
+
+class ParallelColdHookRecorder final : public ExecutionPlugin {
+public:
+  ParallelColdHookRecorder() : ExecutionPlugin("parallel_cold_hook_recorder"), startup_(2) {}
+
+  void onAmdgpuBeforeExecuteInstruction(uint64_t, const Instruction &,
+                                        amdgpu::Wavefront &) override {
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      hot_hook_threads_.insert(std::this_thread::get_id());
+    }
+    if (startup_arrivals_.fetch_add(1, std::memory_order_relaxed) < 2)
+      startup_.arrive_and_wait();
+  }
+
+  void onAmdgpuWorkgroupDispatched(uint32_t dispatch_id, uint32_t wg_id, uint32_t, uint32_t,
+                                   std::span<amdgpu::Wavefront *>) override {
+    record(HookEvent::WORKGROUP_DISPATCHED, dispatch_id, wg_id);
+  }
+
+  void onAmdgpuWorkgroupCompleted(uint32_t dispatch_id, uint32_t wg_id) override {
+    record(HookEvent::WORKGROUP_COMPLETED, dispatch_id, wg_id);
+  }
+
+  std::vector<HookEvent> events() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return events_;
+  }
+
+  std::set<std::thread::id> hot_hook_threads() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return hot_hook_threads_;
+  }
+
+private:
+  void record(HookEvent::Kind kind, uint32_t dispatch_id, uint32_t wg_id) {
+    HookEvent event{kind};
+    event.dispatch_id = dispatch_id;
+    event.wg_id = wg_id;
+    event.callback_thread = std::this_thread::get_id();
+    std::lock_guard<std::mutex> lock(mutex_);
+    events_.push_back(std::move(event));
+  }
+
+  std::barrier<> startup_;
+  std::atomic<uint32_t> startup_arrivals_{0};
+  mutable std::mutex mutex_;
+  std::vector<HookEvent> events_;
+  std::set<std::thread::id> hot_hook_threads_;
 };
 
 class SerialHotHookPlugin final : public ExecutionPlugin {
@@ -774,14 +825,24 @@ private:
   const std::vector<HookEvent> &events_;
 };
 
-/// Minimal SoC fixture: 1 XCD, 1 SE, 1 CU.
+/// Minimal SoC fixture: 1 XCD, 1 SE, and a configurable CU count.
 struct PluginFixture {
   std::unique_ptr<simdojo::SimulationEngine> engine;
   SoC *soc = nullptr;
   amdgpu::GpuMemory *mem = nullptr;
 
   explicit PluginFixture(uint32_t num_wf_slots = 10, std::string_view arch = "cdna4",
-                         uint32_t wavefront_size = 64) {
+                         uint32_t wavefront_size = 64, uint32_t num_cus = 1) {
+    std::string cu_range = "cu[0:" + std::to_string(num_cus) + "]";
+    std::string links;
+    for (uint32_t i = 0; i < num_cus; ++i) {
+      if (!links.empty())
+        links += ',';
+      links += R"({"src":"xcd0.cp.req_)" + std::to_string(i) + R"(","dst":"xcd0.se0.cu)" +
+               std::to_string(i) + R"(.cpl","latency":1,"weight":2})";
+      links += R"(,{"src":"xcd0.se0.cu)" + std::to_string(i) + R"(.req","dst":"xcd0.l2.cpl_)" +
+               std::to_string(i) + R"(","latency":1,"weight":10})";
+    }
     std::string json = std::format(R"({{
       "max_ticks":10000,"num_threads":1,"exec_mode":"functional",
       "vm":{{"arch":"{}","gpu":{{"device":{{"wave_front_size":{}}}}}}},
@@ -791,7 +852,7 @@ struct PluginFixture {
           {{"name":"l2","type":"l2_cache"}},
           {{"name":"cp","type":"command_processor"}},
           {{"name":"se0","type":"shader_engine","children":[
-            {{"name":"cu[0:1]","type":"compute_unit","config":[
+            {{"name":"{}","type":"compute_unit","config":[
               {{"key":"num_wf_slots","value":"{}"}},
               {{"key":"sgprs_per_wf","value":"104"}},
               {{"key":"vgprs_per_wf","value":"256"}},
@@ -799,12 +860,9 @@ struct PluginFixture {
             ]}}
           ]}}
         ]}}
-      ]}},"links":[
-        {{"src":"xcd0.cp.req_0","dst":"xcd0.se0.cu0.cpl","latency":1,"weight":2}},
-        {{"src":"xcd0.se0.cu0.req","dst":"xcd0.l2.cpl_0","latency":1,"weight":10}}
-      ]}}}}
+      ]}},"links":[{}]}}}}
     )",
-                                   arch, wavefront_size, num_wf_slots);
+                                   arch, wavefront_size, cu_range, num_wf_slots, links);
     auto loaded = config::load_config_from_string(json, rocjitsu::kEmbeddedSchema);
     soc = loaded.soc();
     mem = loaded.memory();
@@ -814,7 +872,9 @@ struct PluginFixture {
     engine->create();
   }
 
-  amdgpu::ComputeUnitCore *cu() { return soc->xcd(0)->shader_engine(0)->compute_unit(0); }
+  amdgpu::ComputeUnitCore *cu(uint32_t idx = 0) {
+    return soc->xcd(0)->shader_engine(0)->compute_unit(idx);
+  }
   amdgpu::CommandProcessor *cp() { return soc->xcd(0)->command_processor(); }
 
   uint64_t write_kernel(uint64_t addr, const uint32_t *code, size_t num_words) {
@@ -3115,6 +3175,51 @@ TEST(HookOrderingTest, FiveDispatchLifecycle) {
   for (size_t i = 0; i + 1 < N; ++i) {
     log.assertLastBeforeFirst(HookEvent::DISPATCH_EXECUTION_END, dispatches[i],
                               HookEvent::DISPATCH_EXECUTION_BEGIN, dispatches[i + 1]);
+  }
+}
+
+TEST(HookOrderingTest, ParallelWorkgroupLifecycleRunsOnCommandProcessorAfterWorkersRejoin) {
+  PluginFixture f(/*num_wf_slots=*/2, "cdna4", /*wavefront_size=*/64, /*num_cus=*/2);
+  auto group = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
+  auto plugin = std::make_unique<ParallelColdHookRecorder>();
+  auto *recorder = plugin.get();
+  ASSERT_TRUE(group->add(std::move(plugin)));
+  f.soc->set_plugin_group(group);
+  f.cp()->set_dispatch_threads(2);
+  ASSERT_EQ(f.cp()->dispatch_threads(), 2u);
+
+  const uint32_t kernel_a[] = {S_NOP, S_ENDPGM};
+  const uint32_t kernel_b[] = {S_NOP, S_NOP, S_ENDPGM};
+  const uint64_t ko_a = f.write_kernel(0x1000, kernel_a, std::size(kernel_a));
+  const uint64_t ko_b = f.write_kernel(0x2000, kernel_b, std::size(kernel_b));
+  test::AqlQueue queue(f.mem, f.cp());
+  queue.dispatch(ko_a, /*grid_size=*/128, /*workgroup_size=*/64);
+  queue.dispatch(ko_b, /*grid_size=*/128, /*workgroup_size=*/64);
+
+  const auto cp_thread = std::this_thread::get_id();
+  f.run_until_idle();
+
+  const auto events = recorder->events();
+  const auto hot_hook_threads = recorder->hot_hook_threads();
+  ASSERT_EQ(hot_hook_threads.size(), 2u);
+  EXPECT_TRUE(hot_hook_threads.contains(cp_thread));
+
+  EventLog log(events);
+  std::set<uint32_t> dispatch_ids;
+  for (const auto &event : events) {
+    if (event.kind == HookEvent::WORKGROUP_DISPATCHED)
+      dispatch_ids.insert(event.dispatch_id);
+    EXPECT_EQ(event.callback_thread, cp_thread);
+  }
+
+  ASSERT_EQ(dispatch_ids.size(), 2u);
+  EXPECT_EQ(log.count(HookEvent::WORKGROUP_DISPATCHED), 4u);
+  EXPECT_EQ(log.count(HookEvent::WORKGROUP_COMPLETED), 4u);
+  for (uint32_t dispatch_id : dispatch_ids) {
+    EXPECT_EQ(log.count(HookEvent::WORKGROUP_DISPATCHED, dispatch_id), 2u);
+    EXPECT_EQ(log.count(HookEvent::WORKGROUP_COMPLETED, dispatch_id), 2u);
+    log.assertPairedByWg(HookEvent::WORKGROUP_DISPATCHED, HookEvent::WORKGROUP_COMPLETED,
+                         dispatch_id);
   }
 }
 

--- a/emulation/rocjitsu/tests/execution_plugin_test.cpp
+++ b/emulation/rocjitsu/tests/execution_plugin_test.cpp
@@ -2897,6 +2897,27 @@ TEST(ExecutionPluginTest, DispatchPacketNameResolvesForVmidMappedCodeObject) {
   EXPECT_EQ(kernel_symbol, "vmid_dispatch_kernel");
 }
 
+TEST(ExecutionPluginTest, PluginCapabilitiesSetCpuDispatchPolicy) {
+  {
+    PluginFixture f;
+    f.cp()->set_dispatch_threads(8);
+    auto pg = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
+    pg->add(std::make_unique<SerialHotHookPlugin>());
+    f.soc->set_plugin_group(pg);
+    EXPECT_EQ(f.cp()->dispatch_threads(), 1u);
+    f.cp()->set_dispatch_threads(8);
+    EXPECT_EQ(f.cp()->dispatch_threads(), 1u);
+  }
+  {
+    PluginFixture f;
+    auto pg = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
+    pg->add(std::make_unique<ParallelSafePlugin>());
+    f.soc->set_plugin_group(pg);
+    f.cp()->set_dispatch_threads(8);
+    EXPECT_EQ(f.cp()->dispatch_threads(), 8u);
+  }
+}
+
 // -- Ordering tests ----------------------------------------------------------
 //
 // These tests use functional mode (the PluginFixture default). Tests that

--- a/emulation/rocjitsu/tests/execution_plugin_test.cpp
+++ b/emulation/rocjitsu/tests/execution_plugin_test.cpp
@@ -3747,16 +3747,16 @@ TEST(ExecutionPluginTest, DispatchPacketNameResolvesForVmidMappedCodeObject) {
   EXPECT_EQ(kernel_symbol, "vmid_dispatch_kernel");
 }
 
-TEST(ExecutionPluginTest, PluginCapabilitiesSetCpuDispatchPolicy) {
+TEST(ExecutionPluginTest, HotHookSerializationDoesNotSetCpuDispatchPolicy) {
   {
     PluginFixture f;
-    f.cp()->set_dispatch_threads(8);
+    f.soc->set_dispatch_threads(8);
     auto pg = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
     pg->add(std::make_unique<SerialHotHookPlugin>());
     f.soc->set_plugin_group(pg);
-    EXPECT_EQ(f.cp()->dispatch_threads(), 1u);
+    EXPECT_EQ(f.cp()->dispatch_threads(), 8u);
     f.cp()->set_dispatch_threads(8);
-    EXPECT_EQ(f.cp()->dispatch_threads(), 1u);
+    EXPECT_EQ(f.cp()->dispatch_threads(), 8u);
   }
   {
     PluginFixture f;

--- a/emulation/rocjitsu/tests/execution_plugin_test.cpp
+++ b/emulation/rocjitsu/tests/execution_plugin_test.cpp
@@ -238,6 +238,7 @@ struct HookEvent {
   uint64_t lane_mask = 0;
   uint8_t byte_mask = 0;
   uint64_t pc = 0;
+  std::thread::id callback_thread;
   std::string mnemonic;
   std::string kernel_name;
   std::string kernel_symbol;
@@ -429,6 +430,56 @@ class ParallelSafePlugin final : public ExecutionPlugin {
 public:
   ParallelSafePlugin() : ExecutionPlugin("parallel_safe") {}
   bool requires_serial_hot_hooks() const override { return false; }
+};
+
+class ParallelColdHookRecorder final : public ExecutionPlugin {
+public:
+  ParallelColdHookRecorder() : ExecutionPlugin("parallel_cold_hook_recorder"), startup_(2) {}
+
+  void onAmdgpuBeforeExecuteInstruction(uint64_t, const Instruction &,
+                                        amdgpu::Wavefront &) override {
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      hot_hook_threads_.insert(std::this_thread::get_id());
+    }
+    if (startup_arrivals_.fetch_add(1, std::memory_order_relaxed) < 2)
+      startup_.arrive_and_wait();
+  }
+
+  void onAmdgpuWorkgroupDispatched(uint32_t dispatch_id, uint32_t wg_id, uint32_t, uint32_t,
+                                   std::span<amdgpu::Wavefront *>) override {
+    record(HookEvent::WORKGROUP_DISPATCHED, dispatch_id, wg_id);
+  }
+
+  void onAmdgpuWorkgroupCompleted(uint32_t dispatch_id, uint32_t wg_id) override {
+    record(HookEvent::WORKGROUP_COMPLETED, dispatch_id, wg_id);
+  }
+
+  std::vector<HookEvent> events() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return events_;
+  }
+
+  std::set<std::thread::id> hot_hook_threads() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return hot_hook_threads_;
+  }
+
+private:
+  void record(HookEvent::Kind kind, uint32_t dispatch_id, uint32_t wg_id) {
+    HookEvent event{kind};
+    event.dispatch_id = dispatch_id;
+    event.wg_id = wg_id;
+    event.callback_thread = std::this_thread::get_id();
+    std::lock_guard<std::mutex> lock(mutex_);
+    events_.push_back(std::move(event));
+  }
+
+  std::barrier<> startup_;
+  std::atomic<uint32_t> startup_arrivals_{0};
+  mutable std::mutex mutex_;
+  std::vector<HookEvent> events_;
+  std::set<std::thread::id> hot_hook_threads_;
 };
 
 class SerialHotHookPlugin final : public ExecutionPlugin {
@@ -829,7 +880,7 @@ private:
   const std::vector<HookEvent> &events_;
 };
 
-/// Minimal SoC fixture: 1 XCD, 1 SE, 1 CU.
+/// Minimal SoC fixture: 1 XCD, 1 SE, and a configurable CU count.
 struct PluginFixture {
   std::unique_ptr<simdojo::SimulationEngine> engine;
   SoC *soc = nullptr;
@@ -837,7 +888,17 @@ struct PluginFixture {
 
   explicit PluginFixture(uint32_t num_wf_slots = 10, std::string_view arch = "cdna4",
                          uint32_t wavefront_size = 64, uint32_t sgprs_per_wf = 104,
-                         uint32_t vgprs_per_wf = 256) {
+                         uint32_t vgprs_per_wf = 256, uint32_t num_cus = 1) {
+    std::string cu_range = "cu[0:" + std::to_string(num_cus) + "]";
+    std::string links;
+    for (uint32_t i = 0; i < num_cus; ++i) {
+      if (!links.empty())
+        links += ',';
+      links += R"({"src":"xcd0.cp.req_)" + std::to_string(i) + R"(","dst":"xcd0.se0.cu)" +
+               std::to_string(i) + R"(.cpl","latency":1,"weight":2})";
+      links += R"(,{"src":"xcd0.se0.cu)" + std::to_string(i) + R"(.req","dst":"xcd0.l2.cpl_)" +
+               std::to_string(i) + R"(","latency":1,"weight":10})";
+    }
     std::string json = std::format(R"({{
       "max_ticks":10000,"num_threads":1,"exec_mode":"functional",
       "vm":{{"arch":"{}","gpu":{{"device":{{"wave_front_size":{},
@@ -848,7 +909,7 @@ struct PluginFixture {
           {{"name":"l2","type":"l2_cache"}},
           {{"name":"cp","type":"command_processor"}},
           {{"name":"se0","type":"shader_engine","children":[
-            {{"name":"cu[0:1]","type":"compute_unit","config":[
+            {{"name":"{}","type":"compute_unit","config":[
               {{"key":"num_wf_slots","value":"{}"}},
               {{"key":"sgprs_per_wf","value":"{}"}},
               {{"key":"vgprs_per_wf","value":"{}"}},
@@ -856,12 +917,10 @@ struct PluginFixture {
             ]}}
           ]}}
         ]}}
-      ]}},"links":[
-        {{"src":"xcd0.cp.req_0","dst":"xcd0.se0.cu0.cpl","latency":1,"weight":2}},
-        {{"src":"xcd0.se0.cu0.req","dst":"xcd0.l2.cpl_0","latency":1,"weight":10}}
-      ]}}}}
+      ]}},"links":[{}]}}}}
     )",
-                                   arch, wavefront_size, num_wf_slots, sgprs_per_wf, vgprs_per_wf);
+                                   arch, wavefront_size, cu_range, num_wf_slots, sgprs_per_wf,
+                                   vgprs_per_wf, links);
     auto loaded = config::load_config_from_string(json, rocjitsu::kEmbeddedSchema);
     soc = loaded.soc();
     mem = loaded.memory();
@@ -871,7 +930,9 @@ struct PluginFixture {
     engine->create();
   }
 
-  amdgpu::ComputeUnitCore *cu() { return soc->xcd(0)->shader_engine(0)->compute_unit(0); }
+  amdgpu::ComputeUnitCore *cu(uint32_t idx = 0) {
+    return soc->xcd(0)->shader_engine(0)->compute_unit(idx);
+  }
   amdgpu::CommandProcessor *cp() { return soc->xcd(0)->command_processor(); }
 
   uint64_t write_kernel(uint64_t addr, const uint32_t *code, size_t num_words,
@@ -3906,6 +3967,52 @@ TEST(HookOrderingTest, FiveDispatchLifecycle) {
   for (size_t i = 0; i + 1 < N; ++i) {
     log.assertLastBeforeFirst(HookEvent::DISPATCH_EXECUTION_END, dispatches[i],
                               HookEvent::DISPATCH_EXECUTION_BEGIN, dispatches[i + 1]);
+  }
+}
+
+TEST(HookOrderingTest, ParallelWorkgroupLifecycleRunsOnCommandProcessorAfterWorkersRejoin) {
+  PluginFixture f(/*num_wf_slots=*/2, "cdna4", /*wavefront_size=*/64,
+                  /*sgprs_per_wf=*/104, /*vgprs_per_wf=*/256, /*num_cus=*/2);
+  auto group = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
+  auto plugin = std::make_unique<ParallelColdHookRecorder>();
+  auto *recorder = plugin.get();
+  ASSERT_TRUE(group->add(std::move(plugin)));
+  f.soc->set_plugin_group(group);
+  f.cp()->set_dispatch_threads(2);
+  ASSERT_EQ(f.cp()->dispatch_threads(), 2u);
+
+  const uint32_t kernel_a[] = {S_NOP, S_ENDPGM};
+  const uint32_t kernel_b[] = {S_NOP, S_NOP, S_ENDPGM};
+  const uint64_t ko_a = f.write_kernel(0x1000, kernel_a, std::size(kernel_a));
+  const uint64_t ko_b = f.write_kernel(0x2000, kernel_b, std::size(kernel_b));
+  test::AqlQueue queue(f.mem, f.cp());
+  queue.dispatch(ko_a, /*grid_size=*/128, /*workgroup_size=*/64);
+  queue.dispatch(ko_b, /*grid_size=*/128, /*workgroup_size=*/64);
+
+  const auto cp_thread = std::this_thread::get_id();
+  f.run_until_idle();
+
+  const auto events = recorder->events();
+  const auto hot_hook_threads = recorder->hot_hook_threads();
+  ASSERT_EQ(hot_hook_threads.size(), 2u);
+  EXPECT_TRUE(hot_hook_threads.contains(cp_thread));
+
+  EventLog log(events);
+  std::set<uint32_t> dispatch_ids;
+  for (const auto &event : events) {
+    if (event.kind == HookEvent::WORKGROUP_DISPATCHED)
+      dispatch_ids.insert(event.dispatch_id);
+    EXPECT_EQ(event.callback_thread, cp_thread);
+  }
+
+  ASSERT_EQ(dispatch_ids.size(), 2u);
+  EXPECT_EQ(log.count(HookEvent::WORKGROUP_DISPATCHED), 4u);
+  EXPECT_EQ(log.count(HookEvent::WORKGROUP_COMPLETED), 4u);
+  for (uint32_t dispatch_id : dispatch_ids) {
+    EXPECT_EQ(log.count(HookEvent::WORKGROUP_DISPATCHED, dispatch_id), 2u);
+    EXPECT_EQ(log.count(HookEvent::WORKGROUP_COMPLETED, dispatch_id), 2u);
+    log.assertPairedByWg(HookEvent::WORKGROUP_DISPATCHED, HookEvent::WORKGROUP_COMPLETED,
+                         dispatch_id);
   }
 }
 

--- a/emulation/rocjitsu/tests/execution_plugin_test.cpp
+++ b/emulation/rocjitsu/tests/execution_plugin_test.cpp
@@ -3686,6 +3686,27 @@ TEST(ExecutionPluginTest, DispatchPacketNameResolvesForVmidMappedCodeObject) {
   EXPECT_EQ(kernel_symbol, "vmid_dispatch_kernel");
 }
 
+TEST(ExecutionPluginTest, PluginCapabilitiesSetCpuDispatchPolicy) {
+  {
+    PluginFixture f;
+    f.cp()->set_dispatch_threads(8);
+    auto pg = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
+    pg->add(std::make_unique<SerialHotHookPlugin>());
+    f.soc->set_plugin_group(pg);
+    EXPECT_EQ(f.cp()->dispatch_threads(), 1u);
+    f.cp()->set_dispatch_threads(8);
+    EXPECT_EQ(f.cp()->dispatch_threads(), 1u);
+  }
+  {
+    PluginFixture f;
+    auto pg = std::make_shared<ExecutionPluginGroup>(PluginSinkConfig{});
+    pg->add(std::make_unique<ParallelSafePlugin>());
+    f.soc->set_plugin_group(pg);
+    f.cp()->set_dispatch_threads(8);
+    EXPECT_EQ(f.cp()->dispatch_threads(), 8u);
+  }
+}
+
 // -- Ordering tests ----------------------------------------------------------
 //
 // These tests use functional mode (the PluginFixture default). Tests that

--- a/emulation/rocjitsu/tests/halt_snapshot_plugin.h
+++ b/emulation/rocjitsu/tests/halt_snapshot_plugin.h
@@ -193,6 +193,8 @@ public:
     total_++;
   }
 
+  bool requires_serial_hot_hooks() const override { return false; }
+
   uint32_t total() const {
     std::lock_guard<std::mutex> lk(mutex_);
     return total_;

--- a/emulation/rocjitsu/tests/vector_add_test.cpp
+++ b/emulation/rocjitsu/tests/vector_add_test.cpp
@@ -87,7 +87,7 @@ void run_vector_add(uint32_t dispatch_threads, VectorAddRunResult &result) {
   auto loaded = config::load_config(CONFIG_PATH, rocjitsu::kEmbeddedSchema);
   auto *soc = loaded.soc();
   auto *memory = loaded.memory();
-  soc->for_each_cp([dispatch_threads](auto *cp) { cp->set_dispatch_threads(dispatch_threads); });
+  soc->set_dispatch_threads(dispatch_threads);
   auto engine = std::make_unique<simdojo::SimulationEngine>(loaded.engine_config);
   engine->topology().set_root(loaded.take_root());
   loaded.wire_links(engine->topology());

--- a/emulation/rocjitsu/tests/vector_add_test.cpp
+++ b/emulation/rocjitsu/tests/vector_add_test.cpp
@@ -42,6 +42,8 @@ RJ_DIAGNOSTIC_POP
 #include <memory>
 #include <optional>
 #include <string>
+#include <unordered_map>
+#include <utility>
 #include <vector>
 
 #ifdef HAS_DEVICE_KERNELS
@@ -68,7 +70,12 @@ constexpr uint64_t SIGNAL_ADDR = 0x500000;
 // amd_signal_t::value sits 8 bytes into the signal object.
 constexpr uint32_t SIGNAL_VALUE_OFFSET = 8;
 
-TEST(VectorAddStressTest, AllCUsGoldenReference) {
+struct VectorAddRunResult {
+  std::vector<uint32_t> output_words;
+  std::vector<float> expected;
+};
+
+void run_vector_add(uint32_t dispatch_threads, VectorAddRunResult &result) {
   // Load the compiled vector_add kernel.
   Executable exec(kernel_path("vector_add"));
   ASSERT_TRUE(exec.is_valid()) << "Failed to load vector_add.o";
@@ -80,6 +87,7 @@ TEST(VectorAddStressTest, AllCUsGoldenReference) {
   auto loaded = config::load_config(CONFIG_PATH, rocjitsu::kEmbeddedSchema);
   auto *soc = loaded.soc();
   auto *memory = loaded.memory();
+  soc->for_each_cp([dispatch_threads](auto *cp) { cp->set_dispatch_threads(dispatch_threads); });
   auto engine = std::make_unique<simdojo::SimulationEngine>(loaded.engine_config);
   engine->topology().set_root(loaded.take_root());
   loaded.wire_links(engine->topology());
@@ -133,17 +141,63 @@ TEST(VectorAddStressTest, AllCUsGoldenReference) {
   engine->run();
   soc->flush_all();
 
-  // Read back results and compare against golden reference.
+  std::vector<uint32_t> output_words(N);
+  for (uint32_t i = 0; i < N; ++i)
+    output_words[i] = memory->read32(C_ADDR + i * sizeof(float));
+
+  result.output_words = std::move(output_words);
+  result.expected = std::move(C_expected);
+}
+
+void expect_vector_add_matches_golden(const std::vector<uint32_t> &output_words,
+                                      const std::vector<float> &expected) {
+  ASSERT_EQ(output_words.size(), expected.size());
+
   unsigned mismatches = 0;
-  for (uint32_t i = 0; i < N; ++i) {
-    float actual = std::bit_cast<float>(memory->read32(C_ADDR + i * sizeof(float)));
-    if (std::abs(actual - C_expected[i]) > 1e-6f) {
+  for (size_t i = 0; i < output_words.size(); ++i) {
+    float actual = std::bit_cast<float>(output_words[i]);
+    if (std::abs(actual - expected[i]) > 1e-6f) {
       if (mismatches < 10)
-        ADD_FAILURE() << "Mismatch at C[" << i << "]: GPU=" << actual << " CPU=" << C_expected[i];
+        ADD_FAILURE() << "Mismatch at C[" << i << "]: GPU=" << actual << " CPU=" << expected[i];
       ++mismatches;
     }
   }
   EXPECT_EQ(mismatches, 0u) << mismatches << " elements differ (showing first 10)";
+}
+
+void expect_same_output_words(const std::vector<uint32_t> &expected_words,
+                              const std::vector<uint32_t> &actual_words) {
+  ASSERT_EQ(actual_words.size(), expected_words.size());
+
+  unsigned mismatches = 0;
+  for (size_t i = 0; i < actual_words.size(); ++i) {
+    if (actual_words[i] == expected_words[i])
+      continue;
+    if (mismatches < 10) {
+      ADD_FAILURE() << "Output word mismatch at C[" << i
+                    << "]: dispatch_threads=1 word=" << expected_words[i]
+                    << " threaded word=" << actual_words[i];
+    }
+    ++mismatches;
+  }
+  EXPECT_EQ(mismatches, 0u) << mismatches << " output words differ (showing first 10)";
+}
+
+TEST(VectorAddStressTest, AllCUsGoldenReference) {
+  VectorAddRunResult result;
+  ASSERT_NO_FATAL_FAILURE(run_vector_add(1, result));
+  expect_vector_add_matches_golden(result.output_words, result.expected);
+}
+
+TEST(VectorAddStressTest, CpuDispatchThreadsPreserveOutputBytes) {
+  VectorAddRunResult serial;
+  VectorAddRunResult threaded;
+  ASSERT_NO_FATAL_FAILURE(run_vector_add(1, serial));
+  ASSERT_NO_FATAL_FAILURE(run_vector_add(TOTAL_XCDS, threaded));
+
+  expect_vector_add_matches_golden(serial.output_words, serial.expected);
+  expect_vector_add_matches_golden(threaded.output_words, threaded.expected);
+  expect_same_output_words(serial.output_words, threaded.output_words);
 }
 
 // Multi-threaded version: one worker thread per XCD (8 threads).

--- a/emulation/rocjitsu/tests/vector_add_test.cpp
+++ b/emulation/rocjitsu/tests/vector_add_test.cpp
@@ -81,7 +81,7 @@ void run_vector_add(uint32_t dispatch_threads, VectorAddRunResult &result) {
   auto loaded = config::load_config(CONFIG_PATH, rocjitsu::kEmbeddedSchema);
   auto *soc = loaded.soc();
   auto *memory = loaded.memory();
-  soc->for_each_cp([dispatch_threads](auto *cp) { cp->set_dispatch_threads(dispatch_threads); });
+  soc->set_dispatch_threads(dispatch_threads);
   auto engine = std::make_unique<simdojo::SimulationEngine>(loaded.engine_config);
   engine->topology().set_root(loaded.take_root());
   loaded.wire_links(engine->topology());

--- a/emulation/rocjitsu/tests/vector_add_test.cpp
+++ b/emulation/rocjitsu/tests/vector_add_test.cpp
@@ -34,10 +34,13 @@ RJ_DIAGNOSTIC_POP
 #include <gtest/gtest.h>
 
 #include <bit>
+#include <cmath>
 #include <cstdint>
 #include <cstring>
 #include <memory>
 #include <string>
+#include <unordered_map>
+#include <utility>
 #include <vector>
 
 #ifdef HAS_DEVICE_KERNELS
@@ -61,7 +64,12 @@ constexpr uint64_t B_ADDR = 0x200000;
 constexpr uint64_t C_ADDR = 0x300000;
 constexpr uint64_t KERNARG_ADDR = 0x400000;
 
-TEST(VectorAddStressTest, AllCUsGoldenReference) {
+struct VectorAddRunResult {
+  std::vector<uint32_t> output_words;
+  std::vector<float> expected;
+};
+
+void run_vector_add(uint32_t dispatch_threads, VectorAddRunResult &result) {
   // Load the compiled vector_add kernel.
   Executable exec(kernel_path("vector_add"));
   ASSERT_TRUE(exec.is_valid()) << "Failed to load vector_add.o";
@@ -73,6 +81,7 @@ TEST(VectorAddStressTest, AllCUsGoldenReference) {
   auto loaded = config::load_config(CONFIG_PATH, rocjitsu::kEmbeddedSchema);
   auto *soc = loaded.soc();
   auto *memory = loaded.memory();
+  soc->for_each_cp([dispatch_threads](auto *cp) { cp->set_dispatch_threads(dispatch_threads); });
   auto engine = std::make_unique<simdojo::SimulationEngine>(loaded.engine_config);
   engine->topology().set_root(loaded.take_root());
   loaded.wire_links(engine->topology());
@@ -126,17 +135,63 @@ TEST(VectorAddStressTest, AllCUsGoldenReference) {
   engine->run();
   soc->flush_all();
 
-  // Read back results and compare against golden reference.
+  std::vector<uint32_t> output_words(N);
+  for (uint32_t i = 0; i < N; ++i)
+    output_words[i] = memory->read32(C_ADDR + i * sizeof(float));
+
+  result.output_words = std::move(output_words);
+  result.expected = std::move(C_expected);
+}
+
+void expect_vector_add_matches_golden(const std::vector<uint32_t> &output_words,
+                                      const std::vector<float> &expected) {
+  ASSERT_EQ(output_words.size(), expected.size());
+
   unsigned mismatches = 0;
-  for (uint32_t i = 0; i < N; ++i) {
-    float actual = std::bit_cast<float>(memory->read32(C_ADDR + i * sizeof(float)));
-    if (std::abs(actual - C_expected[i]) > 1e-6f) {
+  for (size_t i = 0; i < output_words.size(); ++i) {
+    float actual = std::bit_cast<float>(output_words[i]);
+    if (std::abs(actual - expected[i]) > 1e-6f) {
       if (mismatches < 10)
-        ADD_FAILURE() << "Mismatch at C[" << i << "]: GPU=" << actual << " CPU=" << C_expected[i];
+        ADD_FAILURE() << "Mismatch at C[" << i << "]: GPU=" << actual << " CPU=" << expected[i];
       ++mismatches;
     }
   }
   EXPECT_EQ(mismatches, 0u) << mismatches << " elements differ (showing first 10)";
+}
+
+void expect_same_output_words(const std::vector<uint32_t> &expected_words,
+                              const std::vector<uint32_t> &actual_words) {
+  ASSERT_EQ(actual_words.size(), expected_words.size());
+
+  unsigned mismatches = 0;
+  for (size_t i = 0; i < actual_words.size(); ++i) {
+    if (actual_words[i] == expected_words[i])
+      continue;
+    if (mismatches < 10) {
+      ADD_FAILURE() << "Output word mismatch at C[" << i
+                    << "]: dispatch_threads=1 word=" << expected_words[i]
+                    << " threaded word=" << actual_words[i];
+    }
+    ++mismatches;
+  }
+  EXPECT_EQ(mismatches, 0u) << mismatches << " output words differ (showing first 10)";
+}
+
+TEST(VectorAddStressTest, AllCUsGoldenReference) {
+  VectorAddRunResult result;
+  ASSERT_NO_FATAL_FAILURE(run_vector_add(1, result));
+  expect_vector_add_matches_golden(result.output_words, result.expected);
+}
+
+TEST(VectorAddStressTest, CpuDispatchThreadsPreserveOutputBytes) {
+  VectorAddRunResult serial;
+  VectorAddRunResult threaded;
+  ASSERT_NO_FATAL_FAILURE(run_vector_add(1, serial));
+  ASSERT_NO_FATAL_FAILURE(run_vector_add(TOTAL_XCDS, threaded));
+
+  expect_vector_add_matches_golden(serial.output_words, serial.expected);
+  expect_vector_add_matches_golden(threaded.output_words, threaded.expected);
+  expect_same_output_words(serial.output_words, threaded.output_words);
 }
 
 // Multi-threaded version: one worker thread per XCD (8 threads).


### PR DESCRIPTION
## Summary

Add the core bounded host CPU worker pool for functional-mode CU execution.

- Use one pool per SoC, shared by its command processors, so the retained worker count stays bounded across a production topology.
- Let the command processor collect active CUs and execute at most one functional quantum per active CU in each batch.
- Keep CLOCKED mode on the existing event-driven path.
- Preserve deferred queue rescans, completion ordering, functional yields, plugin callback-serialization contracts, and byte-identical threaded execution.
- Honor declarative CU `functional_quantum` values and preserve BARRIER_AND/OR queue ordering even when the packet header barrier bit is clear.

## Concurrency and failure handling

- Queue registration and removal take an exclusive structural lock; dispatch holds the shared side while CU work temporarily releases the queue mutex.
- Worker exceptions finish batch bookkeeping before the first exception is rethrown on the engine thread.
- Pool construction and teardown use stop-aware waits so partial construction and parked workers cannot hang.
- Plugins can request serialized hot-hook callbacks without changing CU dispatch concurrency.

## Validation

- GCC 13 Release build of the standalone core layer.
- Core full `rocjitsu_tests`: 2,807 passed, 1 expected skip.
- Combined stack at #8965: 2,823 passed, 1 expected skip.
- The clear-header-bit barrier regression fails against the previous behavior and passes with this change.
- Repository pre-commit and GitHub release/sanitizer checks passed.

## PR stack

Review and merge in order:

1. #6962 — core functional CU dispatch pool
2. #10074 — public configuration and SoC-wide dispatch controls
3. #8965 — functional hot-path optimizations

The prerequisite concurrency and plugin-policy changes are already merged in #8702, #8703, #8705, and #8706.

ISSUE ID: #6447
