### PR TITLE
[rocprofiler-compute] Fix vL1D cache detection on harvested GPUs

### DIFF
--- a/projects/rocprofiler-compute/src/utils/specs.py
+++ b/projects/rocprofiler-compute/src/utils/specs.py
@@ -958,17 +958,25 @@ def set_cache_sizes(num_cu: int, cache_info: dict, num_dies: int) -> dict[str, i
         console_error("Failed to retrieve GPU cache information from AMD-SMI.")
 
     cache_sizes = {}
+
+    # vL1D is the per-CU vector L1 data cache, i.e. the level-1 data cache
+    # with one instance per physical CU. It is identified as the L1 data
+    # cache with the most instances rather than by matching num_cu, since
+    # physical CU count exceeds the active count on harvested parts.
+    l1_data_caches = [
+        cache_values
+        for cache_values in cache_info["cache"]
+        if cache_values["cache_level"] == 1
+        and "DATA_CACHE" in cache_values["cache_properties"]
+    ]
+    if l1_data_caches:
+        vl1d = max(l1_data_caches, key=lambda cache: cache["num_cache_instance"])
+        cache_sizes["L1"] = vl1d["cache_size"] * 1024
+
+    # Cache levels L2 and L3/MALL are shared across all CUs
+    # therefore only have one cache instance
     for cache_values in cache_info["cache"]:
-        # Cache level is L1 and we are looking for vL1d which means
-        # there should be a cache instance per CU available on the GPU
-        if (
-            cache_values["cache_level"] == 1
-            and cache_values["num_cache_instance"] == num_cu
-        ):
-            cache_sizes["L1"] = cache_values["cache_size"] * 1024
-        # Cache levels L2 and L3/MALL are shared across all CUs
-        # therefore only have one cache instance
-        elif cache_values["cache_level"] == 2:
+        if cache_values["cache_level"] == 2:
             cache_sizes["L2"] = cache_values["cache_size"] * 1024
         elif cache_values["cache_level"] == 3 and num_dies > 0:
             cache_sizes["MALL"] = int(cache_values["cache_size"] * 1024 / num_dies)

--- a/projects/rocprofiler-compute/src/utils/specs.py
+++ b/projects/rocprofiler-compute/src/utils/specs.py
@@ -959,10 +959,8 @@ def set_cache_sizes(num_cu: int, cache_info: dict, num_dies: int) -> dict[str, i
 
     cache_sizes = {}
 
-    # vL1D is the per-CU vector L1 data cache, i.e. the level-1 data cache
-    # with one instance per physical CU. It is identified as the L1 data
-    # cache with the most instances rather than by matching num_cu, since
-    # physical CU count exceeds the active count on harvested parts.
+    # vL1D is the level-1 data cache with the most instances (one per CU).
+    # Match by instance count, not num_cu, to stay correct on harvested parts.
     l1_data_caches = [
         cache_values
         for cache_values in cache_info["cache"]
@@ -973,8 +971,7 @@ def set_cache_sizes(num_cu: int, cache_info: dict, num_dies: int) -> dict[str, i
         vl1d = max(l1_data_caches, key=lambda cache: cache["num_cache_instance"])
         cache_sizes["L1"] = vl1d["cache_size"] * 1024
 
-    # Cache levels L2 and L3/MALL are shared across all CUs
-    # therefore only have one cache instance
+    # L2 and L3/MALL cache sizes
     for cache_values in cache_info["cache"]:
         if cache_values["cache_level"] == 2:
             cache_sizes["L2"] = cache_values["cache_size"] * 1024

--- a/projects/rocprofiler-compute/tests/test_utils.py
+++ b/projects/rocprofiler-compute/tests/test_utils.py
@@ -6806,52 +6806,31 @@ def test_reconfigure_stdio_utf8_end_to_end_makes_non_ascii_print_safe():
     assert raw.getvalue() == "│ box │\n".encode("utf-8")
 
 
-def cache_entry(props, size, level, shared, instances):
-    return {
-        "cache_properties": props,
-        "cache_size": size,
-        "cache_level": level,
-        "max_num_cu_shared": shared,
-        "num_cache_instance": instances,
-    }
-
-
-# MI210 is a harvested part: the vL1D instance count (112) exceeds the active
-# CU count (104), so matching instances to num_cu used to drop the L1 entry.
-mi210_cache = {
-    "cache": [
-        cache_entry(["DATA_CACHE", "SIMD_CACHE"], 16, 1, 1, 112),
-        cache_entry(["INST_CACHE", "SIMD_CACHE"], 32, 1, 2, 48),
-        cache_entry(["INST_CACHE", "SIMD_CACHE"], 32, 1, 1, 8),
-        cache_entry(["DATA_CACHE", "SIMD_CACHE"], 16, 1, 2, 48),
-        cache_entry(["DATA_CACHE", "SIMD_CACHE"], 8192, 2, 104, 1),
-    ]
-}
-
-# MI300X has two per-CU level-1 data caches; the vL1D is the one with the
-# most instances (304), not the smaller 16-instance cache.
-mi300x_cache = {
-    "cache": [
-        cache_entry(["DATA_CACHE", "SIMD_CACHE"], 32, 1, 1, 304),
-        cache_entry(["INST_CACHE", "SIMD_CACHE"], 64, 1, 2, 144),
-        cache_entry(["INST_CACHE", "SIMD_CACHE"], 64, 1, 1, 16),
-        cache_entry(["DATA_CACHE", "SIMD_CACHE"], 16, 1, 2, 144),
-        cache_entry(["DATA_CACHE", "SIMD_CACHE"], 16, 1, 1, 16),
-    ]
-}
-
-
-@pytest.mark.parametrize(
-    "num_cu, cache_info, expected_l1",
-    [
-        (104, mi210_cache, 16 * 1024),
-        (304, mi300x_cache, 32 * 1024),
-    ],
-)
-def test_set_cache_sizes_picks_vl1d(num_cu, cache_info, expected_l1):
-    """vL1D is the level-1 data cache with the most instances, even when that
-    count differs from the active CU count (harvested parts)."""
+def test_set_cache_sizes_selects_vl1d_by_instance_count():
+    """vL1D is the level-1 data cache with the most instances; that count need
+    not equal the active CU count, which it does not on harvested parts."""
     from utils.specs import set_cache_sizes
 
-    sizes = set_cache_sizes(num_cu, cache_info, num_dies=1)
-    assert sizes["L1"] == expected_l1
+    def l1(props, size, instances):
+        return {
+            "cache_properties": props,
+            "cache_size": size,
+            "cache_level": 1,
+            "max_num_cu_shared": 1,
+            "num_cache_instance": instances,
+        }
+
+    # Harvested: vL1D instances (112) exceed active CUs (104). It must still
+    # win over a smaller data cache and an instruction cache.
+    harvested = {
+        "cache": [
+            l1(["DATA_CACHE"], 16, 112),
+            l1(["DATA_CACHE"], 8, 16),
+            l1(["INST_CACHE"], 32, 112),
+        ]
+    }
+    assert set_cache_sizes(104, harvested, num_dies=1)["L1"] == 16 * 1024
+
+    # Non-harvested: vL1D instances equal active CUs.
+    non_harvested = {"cache": [l1(["DATA_CACHE"], 32, 304), l1(["DATA_CACHE"], 16, 16)]}
+    assert set_cache_sizes(304, non_harvested, num_dies=1)["L1"] == 32 * 1024

--- a/projects/rocprofiler-compute/tests/test_utils.py
+++ b/projects/rocprofiler-compute/tests/test_utils.py
@@ -6804,3 +6804,54 @@ def test_reconfigure_stdio_utf8_end_to_end_makes_non_ascii_print_safe():
     wrapper.write("│ box │\n")  # would raise UnicodeEncodeError under ascii/strict
     wrapper.flush()
     assert raw.getvalue() == "│ box │\n".encode("utf-8")
+
+
+def cache_entry(props, size, level, shared, instances):
+    return {
+        "cache_properties": props,
+        "cache_size": size,
+        "cache_level": level,
+        "max_num_cu_shared": shared,
+        "num_cache_instance": instances,
+    }
+
+
+# MI210 is a harvested part: the vL1D instance count (112) exceeds the active
+# CU count (104), so matching instances to num_cu used to drop the L1 entry.
+mi210_cache = {
+    "cache": [
+        cache_entry(["DATA_CACHE", "SIMD_CACHE"], 16, 1, 1, 112),
+        cache_entry(["INST_CACHE", "SIMD_CACHE"], 32, 1, 2, 48),
+        cache_entry(["INST_CACHE", "SIMD_CACHE"], 32, 1, 1, 8),
+        cache_entry(["DATA_CACHE", "SIMD_CACHE"], 16, 1, 2, 48),
+        cache_entry(["DATA_CACHE", "SIMD_CACHE"], 8192, 2, 104, 1),
+    ]
+}
+
+# MI300X has two per-CU level-1 data caches; the vL1D is the one with the
+# most instances (304), not the smaller 16-instance cache.
+mi300x_cache = {
+    "cache": [
+        cache_entry(["DATA_CACHE", "SIMD_CACHE"], 32, 1, 1, 304),
+        cache_entry(["INST_CACHE", "SIMD_CACHE"], 64, 1, 2, 144),
+        cache_entry(["INST_CACHE", "SIMD_CACHE"], 64, 1, 1, 16),
+        cache_entry(["DATA_CACHE", "SIMD_CACHE"], 16, 1, 2, 144),
+        cache_entry(["DATA_CACHE", "SIMD_CACHE"], 16, 1, 1, 16),
+    ]
+}
+
+
+@pytest.mark.parametrize(
+    "num_cu, cache_info, expected_l1",
+    [
+        (104, mi210_cache, 16 * 1024),
+        (304, mi300x_cache, 32 * 1024),
+    ],
+)
+def test_set_cache_sizes_picks_vl1d(num_cu, cache_info, expected_l1):
+    """vL1D is the level-1 data cache with the most instances, even when that
+    count differs from the active CU count (harvested parts)."""
+    from utils.specs import set_cache_sizes
+
+    sizes = set_cache_sizes(num_cu, cache_info, num_dies=1)
+    assert sizes["L1"] == expected_l1


### PR DESCRIPTION
## Motivation

Roofline benchmarking on MI200-class GPUs (e.g. MI210) aborted with
`KeyError: 'L1'` and produced no roofline.csv. The vL1D cache size was
matched by `num_cache_instance == num_cu`, which fails on harvested parts
where the physical CU count (L1 instances) exceeds the active CU count.

Bugfix: detect the vL1D as the level-1 data cache with the most instances,
so L1 roofline bandwidth is collected on harvested GPUs.

## Technical Details

- `set_cache_sizes()` in `src/utils/specs.py`: identify vL1D as the
  level-1 `DATA_CACHE` with the greatest `num_cache_instance` (one per
  physical CU), replacing the `num_cache_instance == num_cu` match.

## JIRA ID

AIPROFCOMP-653

## Test Plan

- `rocprof-compute profile --bench-only` on MI210 and MI300X; confirm
  roofline.csv has populated `L1Bw`.
- ctest roofline tests (roofline_1, roofline_2, sort).

## Test Result

- MI210: `L1Bw` populated (was `KeyError: 'L1'`).
- MI300X (8 devices): L1 = 32 KB, unchanged from prior behavior.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.