### PR TITLE
[rocprofiler-sdk] Fix codespell issues

### DIFF
--- a/projects/rocprofiler-sdk/CONTRIBUTING.md
+++ b/projects/rocprofiler-sdk/CONTRIBUTING.md
@@ -174,7 +174,7 @@ If rocprofv3 requires application replay, execute `set follow-fork-mode child` w
   * The first parameter to `TEST(<group>, <name>)` or `TEST_F(<group>, <name>)` should either be the name of the file, e.g. `TEST(agent, <name>)` in `agent.cpp`, or the name of test executable.
   * If the unit test is limit to a certain source file, e.g. `source/lib/common/utility.cpp`, then unit tests in the tests folder should be in a file by the same name, e.g. `source/lib/common/tests/utility.cpp`.
   * All of the source files in a unit test folder should be compiled into one executable and CTests should be added via `gtest_add_tests(...)`
-  * It is permitted to deactive clang-tidy for unit tests via `rocprofiler_deactivate_clang_tidy()`
+  * It is permitted to deactivate clang-tidy for unit tests via `rocprofiler_deactivate_clang_tidy()`
   * The `add_subdirectory(tests)` in parent directory's `CMakeLists.txt` should be guarded with `if(ROCPROFILER_BUILD_TESTS)`
 
 ## Code License ##

--- a/projects/rocprofiler-sdk/benchmark/source/bin/mandelbrot/mandelbrot.cpp
+++ b/projects/rocprofiler-sdk/benchmark/source/bin/mandelbrot/mandelbrot.cpp
@@ -345,7 +345,7 @@ public:
     void run(unsigned int testCase, unsigned int deviceId);
     void printResults(void);
 
-    // array of funtion pointers
+    // array of function pointers
     typedef void (hipPerfMandelBrot::*funPtr)(uint*        out,
                                               uint         width,
                                               float        xPos,

--- a/projects/rocprofiler-sdk/benchmark/source/bin/mandelbrot/utils.hpp
+++ b/projects/rocprofiler-sdk/benchmark/source/bin/mandelbrot/utils.hpp
@@ -18,7 +18,7 @@ THE SOFTWARE.
 */
 
 /*
- * File is intended to C and CPP compliant hence any CPP specic changes
+ * File is intended to C and CPP compliant hence any CPP specific changes
  * should be added into CPP section
  *
  */
@@ -248,7 +248,7 @@ checkArray(T hData, T hOutputData, size_t width, size_t height, size_t depth)
                 {
                     std::cerr << '[' << i << ',' << j << ',' << k << "]:" << hData[offset] << "----"
                               << hOutputData[offset] << "  ";
-                    failed("mistmatch at:%d %d %d", i, j, k);
+                    failed("mismatch at:%d %d %d", i, j, k);
                 }
             }
         }
@@ -268,7 +268,7 @@ checkArray(T input, T output, size_t height, size_t width)
             {
                 std::cerr << '[' << i << ',' << j << ',' << "]:" << input[offset] << "----"
                           << output[offset] << "  ";
-                failed("mistmatch at:%d %d", i, j);
+                failed("mismatch at:%d %d", i, j);
             }
         }
     }

--- a/projects/rocprofiler-sdk/benchmark/source/bin/rocprofv3-benchmark.py
+++ b/projects/rocprofiler-sdk/benchmark/source/bin/rocprofv3-benchmark.py
@@ -599,7 +599,7 @@ def insert_benchmark_config(cursor, sdk_id, config_record, args):
         "rocdecode_trace": "rocDecode",
         "rocjpeg_trace": "rocJPEG",
         "pc_sampling_host_trap": "PC Sampling (Host Trap)",
-        "pc_sampling_stocastic": "PC Sampling (Stocastic)",
+        "pc_sampling_stocastic": "PC Sampling (Stochastic)",
         "advanced_thread_trace": "ATT",
         "pmc_counters": "PMC",
     }

--- a/projects/rocprofiler-sdk/cmake/Modules/Findrocm_version.cmake
+++ b/projects/rocprofiler-sdk/cmake/Modules/Findrocm_version.cmake
@@ -135,7 +135,7 @@ function(ROCM_VERSION_COMPUTE FULL_VERSION_STRING _VAR_PREFIX)
     endforeach()
 endfunction()
 
-# this macro watches for changes in the variables and unsets the remaining cache varaible
+# this macro watches for changes in the variables and unsets the remaining cache variable
 # when they change
 function(ROCM_VERSION_WATCH_FOR_CHANGE _var)
     set(_rocm_version_watch_var_name rocm_version_WATCH_VALUE_${_var})

--- a/projects/rocprofiler-sdk/samples/counter_collection/buffered_client.cpp
+++ b/projects/rocprofiler-sdk/samples/counter_collection/buffered_client.cpp
@@ -226,7 +226,7 @@ dispatch_callback(rocprofiler_dispatch_counting_service_data_t dispatch_data,
  * get_gpu_device_agents()) and a set of counter names to collect. It returns a profile
  * that can be used when a dispatch is received for the agent to collect the specified
  * counters. Note: while you can dynamically create these profiles, it is more efficient
- * to consturct them once in advance (i.e. in tool_init()) since there are non-trivial
+ * to construct them once in advance (i.e. in tool_init()) since there are non-trivial
  * costs associated with constructing the profile.
  */
 rocprofiler_counter_config_id_t
@@ -349,7 +349,7 @@ tool_init(rocprofiler_client_finalize_t, void* user_data)
     {
         // get_profile_cache() is a map that can be accessed by dispatch_callback
         // below to select the profile config to use when a kernel dispatch is
-        // recieved.
+        // received.
         get_profile_cache().emplace(
             agent.id.handle, build_profile_for_agent(agent.id, std::set<std::string>{"TCC_HIT"}));
     }

--- a/projects/rocprofiler-sdk/samples/counter_collection/callback_client.cpp
+++ b/projects/rocprofiler-sdk/samples/counter_collection/callback_client.cpp
@@ -173,7 +173,7 @@ dispatch_callback(rocprofiler_dispatch_counting_service_data_t dispatch_data,
         }
     }
 
-    // Create a colleciton profile for the counters
+    // Create a collection profile for the counters
     rocprofiler_counter_config_id_t profile = {.handle = 0};
     ROCPROFILER_CALL(rocprofiler_create_counter_config(dispatch_data.dispatch_info.agent_id,
                                                        collect_counters.data(),

--- a/projects/rocprofiler-sdk/samples/pc_sampling/client.cpp
+++ b/projects/rocprofiler-sdk/samples/pc_sampling/client.cpp
@@ -74,7 +74,8 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* /*tool_data*/)
 
     if(client::pcs::gpu_agents.empty())
     {
-        *utils::get_output_stream() << "No availabe gpu agents supporting PC sampling" << std::endl;
+        *utils::get_output_stream()
+            << "No available gpu agents supporting PC sampling" << std::endl;
         // Emit the message to explicitly skip the sample.
         std::cerr << "PC sampling unavailable" << std::endl;
         // Exit with no error if none of the GPUs support PC sampling.

--- a/projects/rocprofiler-sdk/samples/pc_sampling/pcs.cpp
+++ b/projects/rocprofiler-sdk/samples/pc_sampling/pcs.cpp
@@ -101,7 +101,7 @@ find_all_gpu_agents_supporting_pc_sampling_impl(rocprofiler_agent_version_t vers
         if(_agents[i]->type == ROCPROFILER_AGENT_TYPE_GPU)
         {
             // Instantiate the tool_agent_info.
-            // Store pointer to the rocprofiler_agent_t and instatiate a vector of
+            // Store pointer to the rocprofiler_agent_t and instantiate a vector of
             // available configurations.
             // Move the ownership to the _out_agents
             auto tool_gpu_agent           = std::make_unique<tool_agent_info>();
@@ -215,7 +215,7 @@ configure_pc_sampling_prefer_stochastic(tool_agent_info*         agent_info,
         auto success = query_avail_configs_for_agent(agent_info);
         if(!success)
         {
-            // An error occured while querying PC sampling capabilities,
+            // An error occurred while querying PC sampling capabilities,
             // so avoid trying configuring PC sampling service.
             // Instead return false to indicated a failure.
             ROCPROFILER_CHECK(ROCPROFILER_STATUS_ERROR);
@@ -281,7 +281,7 @@ configure_pc_sampling_prefer_stochastic(tool_agent_info*         agent_info,
         // but before the `rocprofiler_configure_pc_sampling_service` is called,
         // then the `rocprofiler_configure_pc_sampling_service` will fail again.
         // The process P1 executing this loop can spin wait (starve) if it is unlucky enough
-        // to always be interuppted by some other process P2 that creates/destroys
+        // to always be interrupted by some other process P2 that creates/destroys
         // PC sampling service on the same device while P1 is executing the code
         // after the `query_avail_configs_for_agent` and
         // before the `rocprofiler_configure_pc_sampling_service`.

--- a/projects/rocprofiler-sdk/samples/pc_sampling/utils.cpp
+++ b/projects/rocprofiler-sdk/samples/pc_sampling/utils.cpp
@@ -29,7 +29,7 @@ namespace utils
 std::ostream*&
 get_output_stream()
 {
-    // The output strea is initially unitialized
+    // The output stream is initially uninitialized
     static std::ostream* _v = nullptr;
     return _v;
 }

--- a/projects/rocprofiler-sdk/source/bin/rocprofv3.py
+++ b/projects/rocprofiler-sdk/source/bin/rocprofv3.py
@@ -935,13 +935,13 @@ For attachment profiling of running processes:
         When --process-sync is set to true,
         and rocprofv3 tool will force process to wait for its peer processes finishing write the trace data,
         then they proceed.
-        Note: some workloads will teminate the process group when one of the process is finished""",
+        Note: some workloads will terminate the process group when one of the processes is finished""",
     )
 
     advanced_options.add_argument(
         "--minimum-output-data",
         help="""Output files are generated only if output data size > minimum output data".
-        It can be used for controlling the generation of output files so that user don't recieve empty files.
+        It can be used for controlling the generation of output files so that user don't receive empty files.
         The input is in KB units.""",
         default=None,
         type=int,

--- a/projects/rocprofiler-sdk/source/docs/api-reference/rocprofiler-sdk_api/modules/internal_threading_management.rst
+++ b/projects/rocprofiler-sdk/source/docs/api-reference/rocprofiler-sdk_api/modules/internal_threading_management.rst
@@ -1,5 +1,5 @@
 .. meta::
-  :description: The intenal threading management reference page.
+  :description: The internal threading management reference page.
 
 .. _internal_threading_management_reference:
 

--- a/projects/rocprofiler-sdk/source/docs/how-to/advanced-rocprofv3-options.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/advanced-rocprofv3-options.rst
@@ -583,7 +583,7 @@ To set the agent index to relative, use:
 
     rocprofv3 --kernel-trace --agent-index=relative --output-format csv -- <application_path>
 
-Here is the generated ouput file with ``Agent_Id`` as "Agent 7":
+Here is the generated output file with ``Agent_Id`` as "Agent 7":
 
 .. code-block:: shell
 
@@ -598,7 +598,7 @@ To set the agent index to type-relative, use:
 
     rocprofv3 --kernel-trace --agent-index=type-relative --output-format csv -- <application_path>
 
-Here is the generated ouput file with ``Agent_Id`` as "GPU 3":
+Here is the generated output file with ``Agent_Id`` as "GPU 3":
 
 .. code-block:: shell
 

--- a/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofiler-sdk-roctx.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofiler-sdk-roctx.rst
@@ -185,7 +185,7 @@ Two modes of operation
 
 When running ``rocprofv3`` without the ``--selected-regions`` option, profiling is **enabled** as soon as the application starts. The ``roctxProfilerPause()`` and ``roctxProfilerResume()`` APIs are used to temporarily hide specific sections of code from profiling.
 
-- Use case: Profile everything exluding the specific regions.
+- Use case: Profile everything excluding the specific regions.
 - Profiler starts: **Enabled**
 - ``roctxProfilerPause()``: Temporarily stops data collection.
 - ``roctxProfilerResume()``: Resumes data collection.

--- a/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3-avail.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3-avail.rst
@@ -49,7 +49,7 @@ The ``rocprofv3-avail list`` command displays the list of agents and hardware co
 
    rocprofv3-avail list
 
-The output contains the logical node id, name, and the list of Performace Monitoring Counters (PMC) supported on the agent.
+The output contains the logical node id, name, and the list of Performance Monitoring Counters (PMC) supported on the agent.
 
 Sample output (truncated):
 

--- a/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3.rst
@@ -1023,7 +1023,7 @@ An example of the interval period for this input is given below:
     Device 1, <Kernel A>, Collect SQ_WAVES, GRBM_COUNT
     Device 1, <Kernel B>, Collect SQ_WAVES, GRBM_COUNT
     Device 1, <Kernel C>, Collect SQ_WAVES, GRBM_COUNT
-    <Interval reached on Device 1, Swtiching Counters>
+    <Interval reached on Device 1, Switching Counters>
     Device 1, <Kernel D>, Collect GRBM_GUI_ACTIVE
 
 Here is the same sample in JSON format:
@@ -1501,7 +1501,7 @@ Here are the properties of the JSON output schema:
                   -  **wave_id** *(integer)*: Wave slot index.
                   -  **simd_id** *(integer)*: SIMD index.
                   -  **pipe_id** *(integer)*: Pipe index.
-                  -  **cu_or_wgp_id** *(integer)*: Index of compute unit or workgroup processer.
+                  -  **cu_or_wgp_id** *(integer)*: Index of compute unit or workgroup processor.
                   -  **shader_array_id** *(integer)*: Shader array index.
                   -  **shader_engine_id** *(integer)*: Shader engine
                      index.

--- a/projects/rocprofiler-sdk/source/docs/rocprofv3-schema.json
+++ b/projects/rocprofiler-sdk/source/docs/rocprofv3-schema.json
@@ -751,11 +751,11 @@
                                 },
                                 "kernel_id": {
                                     "type": "integer",
-                                    "description": "ID of the corressponding kernel."
+                                    "description": "ID of the corresponding kernel."
                                 },
                                 "code_object_id": {
                                     "type": "integer",
-                                    "description": "ID of the corressponding code object."
+                                    "description": "ID of the corresponding code object."
                                 },
                                 "host_function_address": {
                                     "type": "integer",
@@ -1063,7 +1063,7 @@
                                                 },
                                                 "cu_or_wgp_id":{
                                                     "type": "integer",
-                                                    "description": "Index of compute unit or workgroup processer."
+                                                    "description": "Index of compute unit or workgroup processor."
                                                 },
                                                 "shader_array_id":{
                                                     "type": "integer",

--- a/projects/rocprofiler-sdk/source/docs/rocprofv3_input_schema.json
+++ b/projects/rocprofiler-sdk/source/docs/rocprofv3_input_schema.json
@@ -168,7 +168,7 @@
                      },
                      "minimum-output-data":{
                       "type": "integer",
-                      "description": "Minimum output data, the output files are generated only if output data size is greater than minimum output data size. It can be used for controlling the generation of output files so that user don't recieve empty files. The input is in KB units"
+                      "description": "Minimum output data, the output files are generated only if output data size is greater than minimum output data size. It can be used for controlling the generation of output files so that user don't receive empty files. The input is in KB units"
                      },
                      "disable-signal-handlers":{
                          "type": "boolean",
@@ -176,7 +176,7 @@
                      },
                     "process-sync":{
                          "type": "boolean",
-                         "description": "Enables the process synchronization in the rocprofv3 tool finalization stage. When --process-sync is set to true, rocprofv3 tool will force process to wait for its peer processes finishing write the trace data, then they proceed. Note: some workload will teminate the process group when one of the process is finished"
+                         "description": "Enables the process synchronization in the rocprofv3 tool finalization stage. When --process-sync is set to true, rocprofv3 tool will force process to wait for its peer processes finishing write the trace data, then they proceed. Note: some workloads will terminate the process group when one of the processes is finished"
                     },
                      "pc_sampling_unit": {
                       "type": "string",

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/agent.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/agent.h
@@ -135,7 +135,7 @@ typedef struct rocprofiler_agent_v0_t
     rocprofiler_agent_type_t type;  ///< Enumeration for identifying the agent type (CPU, GPU, etc.)
     uint32_t cpu_cores_count;  ///< # of latency (= CPU) cores present on this HSA node. This value
                                ///< is 0 for a HSA node with no such cores, e.g a "discrete HSA GPU"
-    uint32_t simd_count;  ///< # of HSA throughtput (= GPU) FCompute cores ("SIMD") present in a
+    uint32_t simd_count;       ///< # of HSA throughput (= GPU) FCompute cores ("SIMD") present in a
                           ///< node. This value is 0 if no FCompute cores are present (e.g. pure
                           ///< "CPU node").
     uint32_t mem_banks_count;  ///< # of discoverable memory bank affinity properties on this
@@ -238,7 +238,7 @@ typedef struct rocprofiler_agent_v0_t
     /// value). This field is intended to help with environment variable indexing used to mask GPUs
     /// at runtime (i.e. HIP_VISIBLE_DEVICES and ROCR_VISIBLE_DEVICES) which start at zero and only
     /// apply to GPUs, e.g., logical_node_type_id value for first GPU will be 0, second GPU will
-    /// have value of 1, etc., regardless of however many agents of a different type preceeded (and
+    /// have value of 1, etc., regardless of however many agents of a different type preceded (and
     /// thus increased the ::rocprofiler_agent_v0_t.node_id or
     /// ::rocprofiler_agent_v0_t.logical_node_id).
     ///

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/buffer_tracing.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/buffer_tracing.h
@@ -615,7 +615,7 @@ rocprofiler_configure_buffer_tracing_service(rocprofiler_context_id_t           
  *
  * @param [in] kind Buffer tracing domain
  * @param [out] name If non-null and the name is a constant string that does not require dynamic
- * allocation, this paramter will be set to the address of the string literal, otherwise it will
+ * allocation, this parameter will be set to the address of the string literal, otherwise it will
  * be set to nullptr
  * @param [out] name_len If non-null, this will be assigned the length of the name (regardless of
  * the name is a constant string or requires dynamic allocation)
@@ -637,7 +637,7 @@ rocprofiler_query_buffer_tracing_kind_name(rocprofiler_buffer_tracing_kind_t kin
  * @param [in] kind Buffer tracing domain
  * @param [in] operation Enumeration id value which maps to a specific API function or event type
  * @param [out] name If non-null and the name is a constant string that does not require dynamic
- * allocation, this paramter will be set to the address of the string literal, otherwise it will
+ * allocation, this parameter will be set to the address of the string literal, otherwise it will
  * be set to nullptr
  * @param [out] name_len If non-null, this will be assigned the length of the name (regardless of
  * the name is a constant string or requires dynamic allocation)
@@ -676,7 +676,7 @@ rocprofiler_iterate_buffer_tracing_kinds(rocprofiler_buffer_tracing_kind_cb_t ca
  * @brief Iterates over all the operations for a given @ref
  * rocprofiler_buffer_tracing_kind_t and invokes the callback with the kind and operation
  * id. This is useful to build a map of the operation names during tool initialization instead of
- * querying rocprofiler everytime in the callback hotpath.
+ * querying rocprofiler every time in the callback hotpath.
  *
  * @param [in] kind which buffer tracing kind operations to iterate over
  * @param [in] callback Callback function invoked for each operation associated with @ref

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/callback_tracing.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/callback_tracing.h
@@ -360,7 +360,7 @@ typedef struct rocprofiler_callback_tracing_hip_stream_data_t
  * correlation id in the exit callback.
  *
  * @param [in] record Callback record data
- * @param [in,out] user_data This paramter can be used to retain information in between the enter
+ * @param [in,out] user_data This parameter can be used to retain information in between the enter
  * and exit phases.
  * @param [in] callback_data User data provided when configuring the callback tracing service
  */
@@ -459,7 +459,7 @@ rocprofiler_configure_callback_tracing_service(rocprofiler_context_id_t         
  *
  * @param [in] kind Callback tracing domain
  * @param [out] name If non-null and the name is a constant string that does not require dynamic
- * allocation, this paramter will be set to the address of the string literal, otherwise it will
+ * allocation, this parameter will be set to the address of the string literal, otherwise it will
  * be set to nullptr
  * @param [out] name_len If non-null, this will be assigned the length of the name (regardless of
  * the name is a constant string or requires dynamic allocation)
@@ -478,7 +478,7 @@ rocprofiler_query_callback_tracing_kind_name(rocprofiler_callback_tracing_kind_t
  * @param [in] kind Callback tracing domain
  * @param [in] operation Enumeration id value which maps to a specific API function or event type
  * @param [out] name If non-null and the name is a constant string that does not require dynamic
- * allocation, this paramter will be set to the address of the string literal, otherwise it will
+ * allocation, this parameter will be set to the address of the string literal, otherwise it will
  * be set to nullptr
  * @param [out] name_len If non-null, this will be assigned the length of the name (regardless of
  * the name is a constant string or requires dynamic allocation)

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/counters.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/counters.h
@@ -195,7 +195,7 @@ rocprofiler_query_counter_info(rocprofiler_counter_id_t              counter_id,
  *        counters variable is owned by rocprofiler and should not be free'd.
  *
  * @param [in] agent_id Agent ID of the current callback
- * @param [in] counters An array of counters that are avialable on the agent
+ * @param [in] counters An array of counters that are available on the agent
  *      ::rocprofiler_iterate_agent_supported_counters was called on.
  * @param [in] num_counters Number of counters contained in counters
  * @param [in] user_data User data supplied by

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/cxx/details/mpl.hpp
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/cxx/details/mpl.hpp
@@ -179,7 +179,7 @@ ROCPROFILER_IMPL_SFINAE_CONCEPT(is_iterable,
                                 std::begin(std::declval<Tp>()),
                                 std::end(std::declval<Tp>()))
 
-// compatability
+// compatibility
 template <typename Tp>
 using supports_ostream = can_stringify<Tp>;
 

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/device_counting_service.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/device_counting_service.h
@@ -46,7 +46,7 @@ ROCPROFILER_EXTERN_C_INIT
  * call outside of context startup.
  * @retval ::ROCPROFILER_STATUS_ERROR_AGENT_MISMATCH Agent of profile does not match agent of the
  * context.
- * @retval ::ROCPROFILER_STATUS_SUCCESS Returned if succesfully configured
+ * @retval ::ROCPROFILER_STATUS_SUCCESS Returned if successfully configured
  */
 ROCPROFILER_SDK_EXPERIMENTAL
 typedef rocprofiler_status_t (*rocprofiler_device_counting_agent_cb_t)(
@@ -91,7 +91,7 @@ typedef void (*rocprofiler_device_counting_service_cb_t)(
  * @retval ::ROCPROFILER_STATUS_ERROR_BUFFER_NOT_FOUND Returned if the buffer is not found.
  * @retval ::ROCPROFILER_STATUS_ERROR_INVALID_ARGUMENT Returned if context already has agent
  *                                                     profiling configured for agent_id.
- * @retval ::ROCPROFILER_STATUS_SUCCESS Returned if succesfully configured
+ * @retval ::ROCPROFILER_STATUS_SUCCESS Returned if successfully configured
  */
 ROCPROFILER_SDK_EXPERIMENTAL
 rocprofiler_status_t

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/registration.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/registration.h
@@ -76,7 +76,7 @@ typedef void (*rocprofiler_tool_detach_t)(void* tool_data);
  * @brief Callback function for iterating over the libraries which have registered
  * with rocprofiler-register. @see rocprofiler_iterate_runtime_registration_info
  *
- * @param [in] info Pointer to library registration instance. Invokee should make a copy
+ * @param [in] info Pointer to library registration instance. Caller should make a copy
  * for reference outside of callback.
  * @param [in] data User data passed to ::rocprofiler_iterate_runtime_registration_info
  * @return int

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/thread-trace/trace_decoder_types.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/experimental/thread-trace/trace_decoder_types.h
@@ -160,7 +160,7 @@ typedef struct rocprofiler_thread_trace_decoder_wave_t
     uint8_t cu;        ///< CU id (gfx9) or wgp id (gfx10+). This is always the target_cu.
     uint8_t simd;      ///< SIMD ID [0,3].
     uint8_t wave_id;   ///< Wave slot ID within SIMD.
-    uint8_t contexts;  ///< Counts how many CWSR events have occured during the wave lifetime.
+    uint8_t contexts;  ///< Counts how many CWSR events have occurred during the wave lifetime.
 
     uint32_t _rsvd1;
     uint32_t _rsvd2;

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/external_correlation.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/external_correlation.h
@@ -143,7 +143,7 @@ rocprofiler_configure_external_correlation_id_request_service(
  *
  * @param [in] kind External correlation id request domain
  * @param [out] name If non-null and the name is a constant string that does not require dynamic
- * allocation, this paramter will be set to the address of the string literal, otherwise it will
+ * allocation, this parameter will be set to the address of the string literal, otherwise it will
  * be set to nullptr
  * @param [out] name_len If non-null, this will be assigned the length of the name (regardless of
  * the name is a constant string or requires dynamic allocation)

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/fwd.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/fwd.h
@@ -204,7 +204,7 @@ typedef enum rocprofiler_buffer_tracing_kind_t  // NOLINT(performance-enum-size)
     ROCPROFILER_BUFFER_TRACING_MARKER_NAME_API,     ///< @see ::rocprofiler_marker_name_api_id_t
     ROCPROFILER_BUFFER_TRACING_MEMORY_COPY,         ///< @see ::rocprofiler_memory_copy_operation_t
     ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH,     ///< Buffer kernel dispatch info
-    ROCPROFILER_BUFFER_TRACING_SCRATCH_MEMORY,      ///< Buffer scratch memory reclaimation info
+    ROCPROFILER_BUFFER_TRACING_SCRATCH_MEMORY,      ///< Buffer scratch memory reclamation info
     ROCPROFILER_BUFFER_TRACING_CORRELATION_ID_RETIREMENT,  ///< Correlation ID in no longer in use
     ROCPROFILER_BUFFER_TRACING_RCCL_API,                   ///< RCCL tracing
     ROCPROFILER_BUFFER_TRACING_OMPT,                       ///< @see ::rocprofiler_ompt_operation_t
@@ -327,7 +327,7 @@ typedef enum rocprofiler_kernel_dispatch_operation_t  // NOLINT(performance-enum
     /// captured and it is safe to disable those contexts without affecting the delivery of the
     /// requested data when the kernel completes. It is important to note that, even if the context
     /// associated with the kernel dispatch callback tracing service is disabled in between the
-    /// enter and exit phase, the exit phase callback is still delievered but that context will not
+    /// enter and exit phase, the exit phase callback is still delivered but that context will not
     /// be captured when the kernel is enqueued and therefore will not provide a
     /// ::ROCPROFILER_KERNEL_DISPATCH_COMPLETE callback. Furthermore, it should be
     /// noted that if a tool encodes information into the `::rocprofiler_user_data_t` output
@@ -516,7 +516,7 @@ typedef uint64_t rocprofiler_thread_id_t;
  * @brief Tracing Operation ID. Depending on the kind, operations can be determined.
  * If the value is equal to zero that means all operations will be considered
  * for tracing. Detailed API tracing operations can be found at associated header file
- * for that partiular operation. i.e: For ROCProfiler enumeration of HSA AMD Extended API tracing
+ * for that particular operation. i.e: For ROCProfiler enumeration of HSA AMD Extended API tracing
  * operations, look at source/include/rocprofiler-sdk/hsa/amd_ext_api_id.h
  */
 typedef int32_t rocprofiler_tracing_operation_t;
@@ -542,7 +542,7 @@ typedef uint64_t rocprofiler_counter_instance_id_t;
 /**
  * @brief A dimension for counter instances. Some example
  *        dimensions include XCC, SM (Shader), etc. This
- *        value represents the dimension beind described
+ *        value represents the dimension behind described
  *        or queried about.
  */
 typedef uint64_t rocprofiler_counter_dimension_id_t;
@@ -569,7 +569,7 @@ typedef union rocprofiler_user_data_t
  */
 typedef union rocprofiler_address_t
 {
-    uint64_t    handle;  ///< compatability
+    uint64_t    handle;  ///< compatibility
     uint64_t    value;   ///< usage example: store address in uint64_t format
     const void* ptr;     ///< usage example: generic form of address
 } rocprofiler_address_t;

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/intercept_table.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/intercept_table.h
@@ -75,7 +75,7 @@ typedef void (*rocprofiler_intercept_library_cb_t)(rocprofiler_intercept_table_t
  *
  * @param [in] kind Intercept table kind
  * @param [out] name If non-null and the name is a constant string that does not require dynamic
- * allocation, this paramter will be set to the address of the string literal, otherwise it will
+ * allocation, this parameter will be set to the address of the string literal, otherwise it will
  * be set to nullptr
  * @param [out] name_len If non-null, this will be assigned the length of the name (regardless of
  * the name is a constant string or requires dynamic allocation)

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/internal_threading.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/internal_threading.h
@@ -113,7 +113,7 @@ rocprofiler_create_callback_thread(rocprofiler_callback_thread_t* cb_thread_id) 
 
 /**
  * @brief (experimental) By default, all buffered results are delivered on the same thread. Using
- * ::rocprofiler_create_callback_thread, one or more buffers can be assigned to deliever their
+ * ::rocprofiler_create_callback_thread, one or more buffers can be assigned to deliver their
  * results on a unique, dedicated thread.
  *
  * @param [in] buffer_id Buffer identifier

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/pc_sampling.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/pc_sampling.h
@@ -54,7 +54,7 @@ ROCPROFILER_EXTERN_C_INIT
  * where available_config is the instance of the @see rocprofiler_pc_sampling_configuration_s
  * supported/available at the moment.
  *
- * Rocprofiler-SDK checks whether the requsted configuration is actually supported
+ * Rocprofiler-SDK checks whether the requested configuration is actually supported
  * at the moment of calling this function. If the answer is yes, it returns
  * the @see ROCPROFILER_STATUS_SUCCESS. Otherwise, it notifies the client about the
  * rejection reason via the returned status code. For more information
@@ -164,7 +164,7 @@ typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_pc_sampling_configuratio
     /// @var unit
     /// @brief A unit used to specify the interval of the @ref method for samples generation.
     /// @var min_interval
-    /// @brief the highest possible frequencey for generating samples using @ref method.
+    /// @brief the highest possible frequency for generating samples using @ref method.
     /// @var max_interval
     /// @brief the lowest possible frequency for generating samples using @ref method
 
@@ -404,7 +404,7 @@ typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_pc_sampling_snapshot_v0_
     /// @brief Two VALU instructions were issued for coexecution (MI3xx specific)
     /// @var sampling_lock_error
     /// @brief At least one wave was locked out from taking a sample,
-    /// due to the latency instroduced by current sample read.
+    /// due to the latency introduced by current sample read.
     /// Too many samples with this bit on indicates that the sampling frequency is too high
 } rocprofiler_pc_sampling_snapshot_v0_t;
 
@@ -443,8 +443,8 @@ typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_pc_sampling_memory_count
     /// @var tensor_cnt
     /// @brief Counts the number of tensor instructions issued but not yet completed.
     /// @var xnack_cnt
-    /// @brief Counts the number of oustanding memory instruction not yet reported
-    /// XNACK ackwlodgement.
+    /// @brief Counts the number of outstanding memory instructions not yet reported
+    /// XNACK acknowledgment.
 } rocprofiler_pc_sampling_memory_counters_t;
 
 /**

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/rccl/details/rccl.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/rccl/details/rccl.h
@@ -123,7 +123,7 @@ typedef struct ncclConfig_v22800
     int         cgaClusterSize;      /*!< Cooperative group array cluster size */
     int         minCTAs;             /*!< Minimum number of cooperative thread arrays (blocks) */
     int         maxCTAs;             /*!< Maximum number of cooperative thread arrays (blocks) */
-    const char* netName;             /*!< Force NCCL to use a specfic network */
+    const char* netName;             /*!< Force NCCL to use a specific network */
     int         splitShare;          /*!< Allow communicators to share resources */
     int         trafficClass;        /*!< Traffic class*/
     const char* commName;            /*!< Name of the communicator*/
@@ -263,7 +263,7 @@ pncclCommInitRankConfig(ncclComm_t*   comm,
 /*! @brief      Creates a new communicator (multi thread/process version).
     @details    Rank must be between 0 and nranks-1 and unique within a communicator clique.
                 Each rank is associated to a CUDA device, which has to be set before calling
-                ncclCommInitRank.  ncclCommInitRank implicitly syncronizes with other ranks,
+                ncclCommInitRank.  ncclCommInitRank implicitly synchronizes with other ranks,
                 so it must be called by different threads/processes or use
    ncclGroupStart/ncclGroupEnd.
     @return     Result code. See @ref rccl_result_code for more details.
@@ -370,7 +370,7 @@ pncclCommSplit(ncclComm_t comm, int color, int key, ncclComm_t* newcomm, ncclCon
     @return     Result code. See @ref rccl_result_code for more details.
 
     @param[in]  comm                  Original communicator object for this rank
-    @param[in]  excludeRanksList      List of ranks to be exluded
+    @param[in]  excludeRanksList      List of ranks to be excluded
     @param[in]  excludeRanksCount     Number of ranks to be excluded
     @param[out] newcomm               Pointer to new communicator
     @param[in]  config                Config file for new communicator. May be NULL to inherit from

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/registration.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/registration.h
@@ -40,8 +40,8 @@ ROCPROFILER_EXTERN_C_INIT
  * pointer to this data structure is provided to the client tool initialization function. The name
  * member can be set by the client to assist with debugging (e.g. rocprofiler cannot start your
  * context because there is a conflicting context started by `<name>` -- at least that is the plan).
- * The handle member is a unique identifer assigned by rocprofiler for the client and the client can
- * store it and pass it to the ::rocprofiler_client_finalize_t function to force finalization
+ * The handle member is a unique identifier assigned by rocprofiler for the client and the client
+ * can store it and pass it to the ::rocprofiler_client_finalize_t function to force finalization
  * (i.e. deactivate all of it's contexts) for the client.
  */
 typedef struct ROCPROFILER_SDK_EXPERIMENTAL rocprofiler_client_id_t

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/rocdecode/details/rocdecode.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/rocdecode/details/rocdecode.h
@@ -523,9 +523,9 @@ typedef struct _RocdecAvcSliceParams
 {
     uint32_t slice_data_size;    // slice size in bytes
     uint32_t slice_data_offset;  // byte offset of the current slice in the slice data buffer
-    uint32_t slice_data_flag;    /* see VA_SLICE_DATA_FLAG_XXX defintions */
+    uint32_t slice_data_flag;    /* see VA_SLICE_DATA_FLAG_XXX definitions */
     /**
-     * \brief Bit offset from NAL Header Unit to the begining of slice_data().
+     * \brief Bit offset from NAL Header Unit to the beginning of slice_data().
      *
      * This bit offset is relative to and includes the NAL unit byte
      * and represents the number of bits parsed in the slice_header()
@@ -647,7 +647,7 @@ typedef struct _RocdecHevcPicParams
     uint8_t num_tile_rows_minus1;
     /**
      * when uniform_spacing_flag equals 1, application should populate
-     * column_width_minus[], and row_height_minus1[] with approperiate values.
+     * column_width_minus[], and row_height_minus1[] with appropriate values.
      */
     uint16_t column_width_minus1[19];
     uint16_t row_height_minus1[21];
@@ -721,7 +721,7 @@ typedef struct _RocdecHevcSliceParams
     /** \brief Slice data buffer flags. See \c VA_SLICE_DATA_FLAG_XXX. */
     uint32_t slice_data_flag;
     /**
-     * \brief Byte offset from NAL unit header to the begining of slice_data().
+     * \brief Byte offset from NAL unit header to the beginning of slice_data().
      *
      * This byte offset is relative to and includes the NAL unit header
      * and represents the number of bytes parsed in the slice_header()
@@ -1067,7 +1067,7 @@ typedef struct _RocdecVp9SliceParams
 {
     /** \brief The byte count of current frame in the bitstream buffer,
      *  starting from first byte of the buffer.
-     *  It uses the name slice_data_size to be consitent with other codec,
+     *  It uses the name slice_data_size to be consistent with other codec,
      *  but actually means frame_data_size.
      */
     uint32_t slice_data_size;
@@ -1337,9 +1337,9 @@ typedef struct _RocdecAV1PicParams
      *  pixel frames. And this process may happen multiple times.
      *  The array anchor_frames_list[] is used to register all the available
      *  anchor frames from both external and internal, up to the current
-     *  frame instance. If a previously registerred anchor frame is no longer
+     *  frame instance. If a previously registered anchor frame is no longer
      *  needed, it should be removed from the list. But it does not prevent
-     *  applications from relacing the frame buffer with new anchor frames.
+     *  applications from replacing the frame buffer with new anchor frames.
      *  Please note that the internal anchor frames may not still be present
      *  in the current DPB buffer. But if it is in the anchor_frames_list[],
      *  it should not be replaced with other frames or removed from memory
@@ -1856,7 +1856,7 @@ rocDecReconfigureDecoder(rocDecDecoderHandle           decoder_handle,
 //! \ingroup group_amd_rocdecode
 //! Post-process and map video frame corresponding to pic_idx for use in HIP. Returns HIP device
 //! pointer and associated pitch(horizontal stride) of the video frame. Returns device memory
-//! pointers and pitch for each plane (Y, U and V) seperately horizontal_pitch is a pointer to an
+//! pointers and pitch for each plane (Y, U and V) separately horizontal_pitch is a pointer to an
 //! unsigned 32-bit integer array of size 3.
 /************************************************************************************************************************/
 extern rocDecStatus ROCDECAPI

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/aql_profile_v2.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/aql_profile_v2.h
@@ -417,7 +417,7 @@ aqlprofile_validate_pmc_event(aqlprofile_agent_handle_t     agent,
  * @param[in] handle The handle returned from aqlprofile_pmc_create_packets()
  * @param[in] callback CB where the resulting event values are going to be returned
  * @param[in] userdata Data sent back to user
- * @retval HSA_STATUS_SUCCESS all operations exited succesfully
+ * @retval HSA_STATUS_SUCCESS all operations exited successfully
  * @retval HSA_STATUS_ERROR if some callback returns an error
  * @retval HSA_STATUS_ERROR_INVALID_ARGUMENT if invalid handle is given
  */
@@ -466,7 +466,7 @@ aqlprofile_pmc_delete_packets(aqlprofile_handle_t handle);
  * @param[in] handle The handle returned from aqlprofile_att_create_packets()
  * @param[in] callback CB where the resulting data is going to be returned
  * @param[in] userdata Data sent back to user
- * @retval HSA_STATUS_SUCCESS all operations exited succesfully
+ * @retval HSA_STATUS_SUCCESS all operations exited successfully
  * @retval HSA_STATUS_ERROR if some callback returns an error
  * @retval HSA_STATUS_ERROR_INVALID_ARGUMENT if invalid handle is given
  */
@@ -490,7 +490,7 @@ typedef struct
  * @param[out] packets Packets returned by this function to start and stop thread trace
  * @param[in] profile Agent information and extra parameters for thread trace
  * @param[in] callback Memory allocation fn which may request cpu or gpu memory
- * @retval HSA_STATUS_SUCCESS if all packets created succesfully
+ * @retval HSA_STATUS_SUCCESS if all packets created successfully
  * @retval HSA_STATUS_ERROR otherwise
  */
 hsa_status_t
@@ -514,11 +514,11 @@ aqlprofile_att_delete_packets(aqlprofile_handle_t handle);
  * @param[out] header If not zero, must be inserted as first 8 bytes.
  * @param[out] query_status To be inserted before calls to aqlprofile_att_get_buffer_status
  * @param[out] buffer_swap array of AQLPROFILE_ATT_PARAMETER_NAME_NUM_BUFFERS transition packets
- * @param[inout] num_buffer_swap In: # of packets in number buffer_swap. Out: # of buffers used.
+ * @param[in,out] num_buffer_swap In: # of packets in number buffer_swap. Out: # of buffers used.
  * @param[in] handle Created in aqlprofile_att_create_packets()
  * @param[in] shader_engine_id Shader engine to get packets from
  * @param[in] flags Must be zero
- * @retval HSA_STATUS_SUCCESS if all packets created succesfully
+ * @retval HSA_STATUS_SUCCESS if all packets created successfully
  * @retval HSA_STATUS_ERROR otherwise
  */
 hsa_status_t
@@ -549,7 +549,7 @@ typedef struct aqlprofile_att_buffer_status_t
  * @param[in] handle What was passed to aqlprofile_att_get_buffer_packets
  * @param[in] shader_engine_id Shader engine (SE) ID
  * @param[in] flags Must be zero
- * @retval HSA_STATUS_SUCCESS if all packets created succesfully
+ * @retval HSA_STATUS_SUCCESS if all packets created successfully
  * @retval HSA_STATUS_ERROR otherwise
  */
 hsa_status_t
@@ -574,7 +574,7 @@ typedef hsa_status_t (*aqlprofile_eventname_callback_t)(int id, const char* name
  * @param [in] callback Callback to use for iteration of dimensions
  * @param [in] user_data Data to supply to callback @ref aqlprofile_eventname_callback_t
  * @retval HSA_STATUS_SUCCESS if successful
- * @retval HSA_STATUS_ERROR if error on interation
+ * @retval HSA_STATUS_ERROR if error on iteration
  * @retval OTHERS If @ref aqlprofile_eventname_callback_t returns non-HSA_STATUS_SUCCESS,
  *         that value is returned.
  */
@@ -650,7 +650,7 @@ typedef struct
 
 typedef struct
 {
-    void*  data;  // Valid until delete_packets() is scalled. Caller must save contents otherwise.
+    void*  data;  // Valid until delete_packets() is called. Caller must save contents otherwise.
     size_t size;  // Size of "data"
 } aqlprofile_spm_buffer_desc_t;
 

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/core/gfx10_factory.cpp
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/core/gfx10_factory.cpp
@@ -127,7 +127,7 @@ const GpuBlockInfo* Gfx10Factory::block_table_[AQLPROFILE_BLOCKS_NUMBER] = {
     &GcrCounterBlockInfo,
     &GusCounterBlockInfo};
 
-// Pm4Factory create mathods
+// Pm4Factory create methods
 Pm4Factory*
 Pm4Factory::Gfx10Create(const AgentInfo* agent_info)
 {

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/core/gfx11_factory.cpp
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/core/gfx11_factory.cpp
@@ -104,7 +104,7 @@ const GpuBlockInfo* Gfx11Factory::block_table_[AQLPROFILE_BLOCKS_NUMBER] = {
     &GcrCounterBlockInfo,
     &GusCounterBlockInfo};
 
-// Pm4Factory create mathods
+// Pm4Factory create methods
 Pm4Factory*
 Pm4Factory::Gfx11Create(const AgentInfo* agent_info)
 {

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/core/gfx12_factory.cpp
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/core/gfx12_factory.cpp
@@ -132,7 +132,7 @@ Gfx12Factory::ConstructTable(const AgentInfo* agent_info)
     }
 }
 
-// Pm4Factory create mathods
+// Pm4Factory create methods
 Pm4Factory*
 Pm4Factory::Gfx12Create(const AgentInfo* agent_info)
 {

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/core/gfx9_factory.cpp
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/core/gfx9_factory.cpp
@@ -145,7 +145,7 @@ const GpuBlockInfo* Gfx9Factory::block_table_[AQLPROFILE_BLOCKS_NUMBER] = {
     NULL /*&UmcCounterBlockInfo*/
 };
 
-// Pm4Factory create mathods
+// Pm4Factory create methods
 Pm4Factory*
 Pm4Factory::Gfx9Create(const AgentInfo* agent_info)
 {

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/core/pm4_factory.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/core/pm4_factory.h
@@ -189,7 +189,7 @@ public:
         return info;
     }
 
-    // Return block info foor a given event
+    // Return block info for a given event
     const GpuBlockInfo* GetBlockInfo(const event_t* event) const
     {
         const GpuBlockInfo* info = block_map_.Get(event->block_name);
@@ -278,7 +278,7 @@ private:
     {
         bool operator()(const AgentInfo& a, const AgentInfo& b) const
         {
-            // using name instead of gfxip due to backward compatability with rocprofv2,
+            // using name instead of gfxip due to backward compatibility with rocprofv2,
             // as in newer api which rocprofv3 uses both name and gfxip strings are same for a
             // agent.
             int cmp = strcmp(a.name, b.name);

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/core/populate_aql.cpp
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/core/populate_aql.cpp
@@ -37,7 +37,7 @@ PopulateAql(const uint32_t* ib_packet, packet_t* aql_packet)
 {
     // Populate relevant fields of Aql pkt
     // Size of IB pkt is four DWords
-    // Header and completion sinal are not set
+    // Header and completion signal are not set
     amd_aql_pm4_ib_packet_t* aql_pm4_ib = reinterpret_cast<amd_aql_pm4_ib_packet_t*>(aql_packet);
     aql_pm4_ib->pm4_ib_format           = AMD_AQL_PM4_IB_FORMAT;
     aql_pm4_ib->pm4_ib_command[0]       = ib_packet[0];

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/core/spm_data.cpp
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/core/spm_data.cpp
@@ -108,7 +108,7 @@ producer(spm_state_t* s)
         args.size_copied = 0;
         args.dest_buf    = s->prod_buf;
         // s->stop_prod_thread should be set after SPM End() sequence is submitted, this is the
-        // handshake protocal between app/library and aqlprofile.
+        // handshake protocol between app/library and aqlprofile.
         // If s->stop_prod_thread is set in current loop, producer thread will exit after all
         // SPM counters are drained (args.size_copied == 0) which could be at least one
         // HsaSpmSetDestBuffer() call or maybe more than one.
@@ -166,7 +166,7 @@ producer(spm_state_t* s)
 exit_:
     if(status != HSA_STATUS_SUCCESS)
     {
-        // Even when HsaSpmSetDestBuffer() fails, we still need to fulfill the handshake protocal
+        // Even when HsaSpmSetDestBuffer() fails, we still need to fulfill the handshake protocol
         // between producer and consumer
         std::unique_lock<std::mutex> lock(s->work_mutex);
         s->size_copied = 0;

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/core/spm_v2.cpp
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/core/spm_v2.cpp
@@ -524,7 +524,7 @@ producer(std::shared_ptr<spm_state_t> s)
         args.size_copied = 0;
         args.dest_buf    = s->prod_buf;
         // s->stop_prod_thread should be set after SPM End() sequence is submitted, this is the
-        // handshake protocal between app/library and aqlprofile.
+        // handshake protocol between app/library and aqlprofile.
         // If s->stop_prod_thread is set in current loop, producer thread will exit after all
         // SPM counters are drained (args.size_copied == 0) which could be at least one
         // HsaSpmSetDestBuffer() call or maybe more than one.

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/gfxip/gfx9/gfx9_primitives.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/gfxip/gfx9/gfx9_primitives.h
@@ -427,7 +427,7 @@ public:
 #endif
     }
 
-    // SQ Counter Control enable perfomance counter in graphics pipeline stages
+    // SQ Counter Control enable performance counter in graphics pipeline stages
     static uint32_t sq_control_enable_value()
     {
         uint32_t sq_perfcounter_ctrl = SET_REG_FIELD_BITS(SQ_PERFCOUNTER_CTRL, PS_EN, 0x1) |

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/gfx10_cmd_builder.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/gfx10_cmd_builder.h
@@ -86,7 +86,7 @@ public:
         uint32_t dword3 = PACKET3_ACQUIRE_MEM__COHER_SIZE((uint32_t(size)));
         uint32_t dword4 = PACKET3_ACQUIRE_MEM__COHER_SIZE_HI((uint32_t(size >> 32)));
 
-        // Specify the poll interval for determing if operation is complete
+        // Specify the poll interval for determining if operation is complete
         uint32_t dword7 = PACKET3_ACQUIRE_MEM__POLL_INTERVAL(0x10);
 
         // Program GCR Control Register. Initialize L2 Cache flush

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/gfx11_cmd_builder.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/gfx11_cmd_builder.h
@@ -92,7 +92,7 @@ public:
         uint32_t dword3 = PACKET3_ACQUIRE_MEM__COHER_SIZE((uint32_t(size)));
         uint32_t dword4 = PACKET3_ACQUIRE_MEM__COHER_SIZE_HI((uint32_t(size >> 32)));
 
-        // Specify the poll interval for determing if operation is complete
+        // Specify the poll interval for determining if operation is complete
         uint32_t dword7 = PACKET3_ACQUIRE_MEM__POLL_INTERVAL(0x10);
 
         // Program GCR Control Register. Initialize L2 Cache flush

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/gfx12_cmd_builder.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/gfx12_cmd_builder.h
@@ -378,7 +378,7 @@ public:
         uint32_t dword3 = PACKET3_ACQUIRE_MEM__COHER_SIZE((uint32_t(size)));
         uint32_t dword4 = PACKET3_ACQUIRE_MEM__COHER_SIZE_HI((uint32_t(size >> 32)));
 
-        // Specify the poll interval for determing if operation is complete
+        // Specify the poll interval for determining if operation is complete
         uint32_t dword7 = PACKET3_ACQUIRE_MEM__POLL_INTERVAL(0x10);
 
         // Program GCR Control Register. Initialize L2 Cache flush

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/gfx9_cmd_builder.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/gfx9_cmd_builder.h
@@ -107,7 +107,7 @@ public:
         uint32_t dword3 = PACKET3_ACQUIRE_MEM__COHER_SIZE(uint32_t(size));
         uint32_t dword4 = PACKET3_ACQUIRE_MEM__COHER_SIZE_HI(uint32_t(size >> 32));
 
-        // Specify the poll interval for determing if operation is complete
+        // Specify the poll interval for determining if operation is complete
         uint32_t dword7 = PACKET3_ACQUIRE_MEM__POLL_INTERVAL(0x10);
 
         // Program Coherence Control Register. Initialize L2 Cache flush

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/pmc_builder.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/pmc_builder.h
@@ -77,7 +77,7 @@ public:
     {
         if(is_mi300_)
         {
-            // PRED_EXEC aplies to MI300 only
+            // PRED_EXEC applies to MI300 only
             pos_ = cmd_buffer->DwSize();
             builder.BuildPredExecPacket(cmd_buffer, target_xcc_, 0);
             initial_buff_size_ = cmd_buffer->DwSize();
@@ -88,7 +88,7 @@ public:
     {
         if(is_mi300_)
         {
-            // PRED_EXEC aplies to MI300 only
+            // PRED_EXEC applies to MI300 only
             CmdBuffer pred_exec;
             // update first PRED_EXEC packet to its correct value
             builder.BuildPredExecPacket(
@@ -306,7 +306,7 @@ public:
         return 1;
     };
 
-    // Build PMC enable PM4 comands - enable CP counting for a specific queue
+    // Build PMC enable PM4 commands - enable CP counting for a specific queue
     void Enable(CmdBuffer* cmd_buffer)
     {
         // Program Compute Perfcount Enable register to support perf counting
@@ -314,7 +314,7 @@ public:
                                       Primitives::COMPUTE_PERFCOUNT_ENABLE_ADDR,
                                       Primitives::cp_perfcount_enable_value());
     }
-    // Build PMC disable PM4 comands - enable CP counting for a specific queue
+    // Build PMC disable PM4 commands - enable CP counting for a specific queue
     void Disable(CmdBuffer* cmd_buffer)
     {
         // Program Compute Perfcount Enable register to support perf counting
@@ -322,14 +322,14 @@ public:
                                       Primitives::COMPUTE_PERFCOUNT_ENABLE_ADDR,
                                       Primitives::cp_perfcount_disable_value());
     }
-    // Build PMC waite-idle PM4 comands - enable CP counting for a specific queue
+    // Build PMC waite-idle PM4 commands - enable CP counting for a specific queue
     void WaitIdle(CmdBuffer* cmd_buffer)
     {
         // Program Compute Perfcount WaiteIdle register to support perf counting
         builder.BuildWriteWaitIdlePacket(cmd_buffer);
     }
 
-    // Build PMC start PM4 comands
+    // Build PMC start PM4 commands
     void Start(CmdBuffer* cmd_buffer, const counters_vector& counters_vec) override
     {
         // Issue barrier command
@@ -346,7 +346,7 @@ public:
         // Reset perf counters
         SetPerfmonCntl(
             cmd_buffer, Primitives::cp_perfmon_cntl_reset_value(), counters_vec.get_attr());
-        // Enable SQ Counter Control enable perfomance counter in graphics pipeline if implied
+        // Enable SQ Counter Control enable performance counter in graphics pipeline if implied
         Primitives::validate_counters(counters_vec.get_attr());
         if(counters_vec.get_attr() & CounterBlockTcAttr)
         {
@@ -472,7 +472,7 @@ public:
                 }
                 else
                 {
-                    // MI200 and MI300 have seperate select and control registers
+                    // MI200 and MI300 have separate select and control registers
                     const auto sdma_index = counter_des.block_des.index;
                     const auto target_aid_index =
                         sdma_index / (block_info->instance_count / MAX_AID);
@@ -746,7 +746,7 @@ public:
             }
             else if(block_info->attr & CounterBlockSdmaAttr)
             {
-                // Stop SDMA: this code path appplies only to non-MI300
+                // Stop SDMA: this code path applies only to non-MI300
                 if(reg_info.control_addr.offset == 0)
                 {
                     // MI100: stopped per instance
@@ -907,7 +907,7 @@ public:
         return read_counter * sizeof(uint32_t);
     }
 
-    // Build PMC stop PM4 comands
+    // Build PMC stop PM4 commands
     void Stop(CmdBuffer* cmd_buffer, const counters_vector& counters_vec) override
     {
         GCMode gc_mode =
@@ -1003,7 +1003,7 @@ public:
         builder.BuildWriteWaitIdlePacket(cmd_buffer);
     }
 
-    // Build PMC read PM4 comands
+    // Build PMC read PM4 commands
     uint32_t Read(CmdBuffer*             cmd_buffer,
                   const counters_vector& counters_vec,
                   void*                  data_buffer) override

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/spm_builder.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/spm_builder.h
@@ -361,7 +361,7 @@ public:
                 is_spm_inited = true;
                 if(block_info->attr & CounterBlockSpmGlobalAttr)
                 {
-                    // for each instance of a global block we progam its delay
+                    // for each instance of a global block we program its delay
                     for(size_t j = 0; j < block_info->instance_count; ++j)
                     {
                         builder.BuildWriteUConfigRegPacket(

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/sqtt_builder.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/sqtt_builder.h
@@ -147,7 +147,7 @@ public:
     virtual size_t GetWritePtrMask() const = 0;
     // Returns size of block in bytes per increment in WPTR
     virtual size_t GetWritePtrBlk() const = 0;
-    // Returns number of bits used for TTrace buffer alignement (e.g. 12 for 4KB alignment)
+    // Returns number of bits used for TTrace buffer alignment (e.g. 12 for 4KB alignment)
     virtual size_t BufferAlignment() const = 0;
 };
 
@@ -183,7 +183,7 @@ public:
     virtual size_t GetWritePtrMask() const override { return Primitives::TT_WRITE_PTR_MASK; };
     // Returns size of block in bytes per increment in WPTR
     virtual size_t GetWritePtrBlk() const override { return 32; };
-    // Returns number of bits used for TTrace buffer alignement (e.g. 12 for 4KB alignment)
+    // Returns number of bits used for TTrace buffer alignment (e.g. 12 for 4KB alignment)
     virtual size_t BufferAlignment() const override { return Primitives::TT_BUFF_ALIGN_SHIFT; }
 
     void SetGRBMToBroadcast(CmdBuffer* cmd_buffer)

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/util/hsa_rsrc_factory.cpp
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/util/hsa_rsrc_factory.cpp
@@ -454,7 +454,7 @@ HsaRsrcFactory::AddAgentInfo(const hsa_agent_t agent)
     return agent_info;
 }
 
-// Return systen agent info
+// Return system agent info
 const AgentInfo*
 HsaRsrcFactory::GetAgentInfo(const hsa_agent_t agent)
 {
@@ -594,7 +594,7 @@ HsaRsrcFactory::AllocateLocalMemory(const AgentInfo* agent_info, size_t size)
 }
 
 // Allocate memory to pass kernel parameters.
-// Memory is alocated accessible for all CPU agents and for GPU given by AgentInfo parameter.
+// Memory is allocated accessible for all CPU agents and for GPU given by AgentInfo parameter.
 // @param agent_info Agent from whose memory region to allocate
 // @param size Size of memory in terms of bytes
 // @return uint8_t* Pointer to buffer, null if allocation fails.

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/util/hsa_rsrc_factory.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/util/hsa_rsrc_factory.h
@@ -171,7 +171,7 @@ public:
         sysclock_factor_ = (freq_t) 1000000000 / (freq_t) sysclock_hz;
     }
 
-    // Methids for system-clock/ns conversion
+    // Methods for system-clock/ns conversion
     timestamp_t sysclock_to_ns(const timestamp_t& sysclock) const
     {
         return timestamp_t((freq_t) sysclock * sysclock_factor_);
@@ -272,14 +272,14 @@ public:
     uint8_t* AllocateLocalMemory(const AgentInfo* agent_info, size_t size);
 
     // Allocate memory tp pass kernel parameters
-    // Memory is alocated accessible for all CPU agents and for GPU given by AgentInfo parameter.
+    // Memory is allocated accessible for all CPU agents and for GPU given by AgentInfo parameter.
     // @param agent_info Agent from whose memory region to allocate
     // @param size Size of memory in terms of bytes
     // @return uint8_t* Pointer to buffer, null if allocation fails.
     uint8_t* AllocateKernArgMemory(const AgentInfo* agent_info, size_t size);
 
     // Allocate system memory accessible from both CPU and GPU
-    // Memory is alocated accessible to all CPU agents and AgentInfo parameter is ignored.
+    // Memory is allocated accessible to all CPU agents and AgentInfo parameter is ignored.
     // @param agent_info Agent from whose memory region to allocate
     // @param size Size of memory in terms of bytes
     // @return uint8_t* Pointer to buffer, null if allocation fails.

--- a/projects/rocprofiler-sdk/source/lib/att-tool/waitcnt/tests/att_decoder_waitcnt_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/att-tool/waitcnt/tests/att_decoder_waitcnt_test.cpp
@@ -372,7 +372,7 @@ TEST(att_decoder_waitcnt_test, fail_conditions)
     ASSERT_TRUE(WaitcntList(10, wave, isa_map).mem_unroll.empty());
     ASSERT_TRUE(WaitcntList(12, wave, isa_map).mem_unroll.empty());
 
-    // it cant operate on invalid gfxip
+    // it can't operate on invalid gfxip
     try
     {
         WaitcntList(-1, wave, isa_map);

--- a/projects/rocprofiler-sdk/source/lib/common/container/record_header_buffer.hpp
+++ b/projects/rocprofiler-sdk/source/lib/common/container/record_header_buffer.hpp
@@ -258,7 +258,7 @@ record_header_buffer::emplace(uint64_t _hash, Tp& _v)
     {
         // if there is space in the buffer, atomically get an index
         // for where the header record should be placed.
-        // NOTE: m_headers was resized to be large enough to accomodate
+        // NOTE: m_headers was resized to be large enough to accommodate
         // sizeof(Tp) == 1 for every entry in buffer
         auto idx = m_index.fetch_add(1, std::memory_order_release);
 
@@ -301,7 +301,7 @@ record_header_buffer::emplace(uint32_t _category, uint32_t _kind, Tp& _v)
     {
         // if there is space in the buffer, atomically get an index
         // for where the header record should be placed.
-        // NOTE: m_headers was resized to be large enough to accomodate
+        // NOTE: m_headers was resized to be large enough to accommodate
         // sizeof(Tp) == 1 for every entry in buffer
         auto idx = m_index.fetch_add(1, std::memory_order_release);
 

--- a/projects/rocprofiler-sdk/source/lib/common/container/ring_buffer.cpp
+++ b/projects/rocprofiler-sdk/source/lib/common/container/ring_buffer.cpp
@@ -112,7 +112,7 @@ ring_buffer::destroy()
 {
     if(m_ptr && m_init)
     {
-        // Unmap the mapped virtual memmory.
+        // Unmap the mapped virtual memory.
         auto ret = munmap(m_ptr, m_size);
         if(ret != 0) perror("ring_buffer: munmap failed");
     }

--- a/projects/rocprofiler-sdk/source/lib/common/container/ring_buffer.hpp
+++ b/projects/rocprofiler-sdk/source/lib/common/container/ring_buffer.hpp
@@ -117,7 +117,7 @@ struct ring_buffer
     /// Returns number of bytes currently held by the buffer.
     size_t count() const { return (m_write_count - m_read_count); }
 
-    /// Returns how many bytes are availiable in the buffer.
+    /// Returns how many bytes are available in the buffer.
     size_t free() const { return (m_size - count()); }
 
     /// Returns if the buffer is empty.
@@ -342,7 +342,7 @@ struct ring_buffer : private base::ring_buffer
     /// Returns number of Tp instances currently held by the buffer.
     size_t count() const { return (base_type::count()) / aligned_data_size(); }
 
-    /// Returns how many Tp instances are availiable in the buffer.
+    /// Returns how many Tp instances are available in the buffer.
     size_t free() const { return (base_type::free()) / aligned_data_size(); }
 
     /// Returns if the buffer is empty.

--- a/projects/rocprofiler-sdk/source/lib/common/md5sum.cpp
+++ b/projects/rocprofiler-sdk/source/lib/common/md5sum.cpp
@@ -292,7 +292,7 @@ md5sum::update(const unsigned char input[], size_type length)
     return *this;
 }
 
-// for convenience provide a verson with signed char
+// for convenience provide a version with signed char
 md5sum&
 md5sum::update(const char input[], size_type length)
 {

--- a/projects/rocprofiler-sdk/source/lib/common/synchronized.hpp
+++ b/projects/rocprofiler-sdk/source/lib/common/synchronized.hpp
@@ -33,7 +33,7 @@ namespace rocprofiler
 namespace common
 {
 /**
- * Sychronized is a wrapper that adds lock based write/read
+ * Synchronized is a wrapper that adds lock based write/read
  * protection around a datatype. The protected data is accessed
  * only by rlock/wlock. rlock(lambda) gets a reader lock of the
  * protected value, passing the protected value to the lambda as a

--- a/projects/rocprofiler-sdk/source/lib/output/generatePerfetto.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generatePerfetto.cpp
@@ -111,8 +111,8 @@ write_perfetto(
         buffer_config->set_fill_policy(
             ::perfetto::protos::gen::TraceConfig_BufferConfig_FillPolicy_RING_BUFFER);
     else
-        ROCP_FATAL << "Unsupport perfetto buffer fill policy: '" << ocfg.perfetto_buffer_fill_policy
-                   << "'. Supported: discard, ring_buffer";
+        ROCP_FATAL << "Unsupported perfetto buffer fill policy: '"
+                   << ocfg.perfetto_buffer_fill_policy << "'. Supported: discard, ring_buffer";
 
     auto* ds_cfg = cfg.add_data_sources()->mutable_config();
     ds_cfg->set_name("track_event");  // this MUST be track_event
@@ -125,7 +125,7 @@ write_perfetto(
     else if(ocfg.perfetto_backend == "system")
         args.backends |= ::perfetto::kSystemBackend;
     else
-        ROCP_FATAL << "Unsupport perfetto backend: '" << ocfg.perfetto_backend
+        ROCP_FATAL << "Unsupported perfetto backend: '" << ocfg.perfetto_backend
                    << "'. Supported: inprocess, system";
 
     ::perfetto::Tracing::Initialize(args);
@@ -894,7 +894,7 @@ write_perfetto(
                 else if(itr.operation == ROCPROFILER_MEMORY_ALLOCATION_FREE ||
                         itr.operation == ROCPROFILER_MEMORY_ALLOCATION_VMEM_FREE)
                 {
-                    // Store free memory operations in seperate vector to pair with agent
+                    // Store free memory operations in separate vector to pair with agent
                     // and allocation size in following loop
                     free_mem_info.push_back(free_memory_information{
                         itr.start_timestamp, itr.end_timestamp, itr.address});

--- a/projects/rocprofiler-sdk/source/lib/output/sql/common.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/sql/common.cpp
@@ -159,7 +159,7 @@ extract_row_count(sqlite3* conn, std::string_view query)
         return 0;
     }
 
-    ROCP_CI_LOG_IF(ERROR, _stmt == nullptr) << "Error preparing statment: " << query;
+    ROCP_CI_LOG_IF(ERROR, _stmt == nullptr) << "Error preparing statement: " << query;
 
     int64_t nrows = 0;
     if(_stmt && sqlite3_column_count(_stmt) == 1 && sqlite3_step(_stmt) == SQLITE_ROW)

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/__main__.py
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/__main__.py
@@ -92,7 +92,7 @@ Example usage:
     Package and copy/consolidate all the databases from my_MPI_run_1.rpdb folder append node5/db5.db and make new folder
     $ rocpd package -i my_MPI_run_1.rpdb node5/db5.db -d my_MPI_run_1_append_5 --consolidate --copy
 
-    Use my_MPI_run_1.rpdb folder and move/consolidate node7/db7.db and re-use same .rpdb folder
+    Use my_MPI_run_1.rpdb folder and move/consolidate node7/db7.db and reuse same .rpdb folder
     $ rocpd package -i my_MPI_run_1.rpdb node7/db7.db -d my_MPI_run_1 --consolidate
 """
 
@@ -117,7 +117,7 @@ Example usage:
     Aggregate 3 databases and output all summary files and include summary by rank/process ID, to csv file output
     $ rocpd summary -i db{1..3}.db --summary-by-rank --format csv
 
-    Output all summaries to console and exlude all regions to save processing time
+    Output all summaries to console and exclude all regions to save processing time
     $ rocpd summary -i db0.db --region-categories NONE
 
     Aggregate 2 databases and output all summary files to HTML, only include HIP and MARKER regions, include domain summary

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/source/perfetto.cpp
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/source/perfetto.cpp
@@ -100,7 +100,7 @@ PerfettoSession::PerfettoSession(const tool::output_config& output_cfg, sqlite3*
         buffer_config->set_fill_policy(
             ::perfetto::protos::gen::TraceConfig_BufferConfig_FillPolicy_RING_BUFFER);
     else
-        ROCP_FATAL << "Unsupport perfetto buffer fill policy: '"
+        ROCP_FATAL << "Unsupported perfetto buffer fill policy: '"
                    << config.perfetto_buffer_fill_policy << "'. Supported: discard, ring_buffer";
 
     auto* ds_cfg = cfg.add_data_sources()->mutable_config();
@@ -114,7 +114,7 @@ PerfettoSession::PerfettoSession(const tool::output_config& output_cfg, sqlite3*
     else if(config.perfetto_backend == "system")
         args.backends |= ::perfetto::kSystemBackend;
     else
-        ROCP_FATAL << "Unsupport perfetto backend: '" << config.perfetto_backend
+        ROCP_FATAL << "Unsupported perfetto backend: '" << config.perfetto_backend
                    << "'. Supported: inprocess, system";
 
     ::perfetto::Tracing::Initialize(args);
@@ -949,7 +949,7 @@ write_perfetto(
                 }
                 else if(itr.type == "FREE")
                 {
-                    // Store free memory operations in seperate vector to pair with agent
+                    // Store free memory operations in separate vector to pair with agent
                     // and allocation size in following loop
                     if(itr.level == "REAL")
                     {

--- a/projects/rocprofiler-sdk/source/lib/python/rocpd/source/serialization/sql.cpp
+++ b/projects/rocprofiler-sdk/source/lib/python/rocpd/source/serialization/sql.cpp
@@ -43,7 +43,7 @@ SQLite3InputArchive::SQLite3InputArchive(sqlite3*         conn,
                    sqlite3_prepare_v2(m_conn, m_query.c_str(), -1, &m_stmt, nullptr) != SQLITE_OK)
         << "Error preparing select statement: " << sqlite3_errmsg(m_conn);
 
-    ROCP_CI_LOG_IF(ERROR, m_stmt == nullptr) << "Error preparing statment: " << query;
+    ROCP_CI_LOG_IF(ERROR, m_stmt == nullptr) << "Error preparing statement: " << query;
 
     if(!m_stmt) return;
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/auxv.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/auxv.cpp
@@ -77,7 +77,7 @@ get_auxv_entry(int pid, void*& entry_addr)
 
     if(entry_addr == nullptr)
     {
-        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Unexpected mising AT_ENTRY for " << filename;
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Unexpected missing AT_ENTRY for " << filename;
         return ROCATTACH_STATUS_ERROR;
     }
     ROCP_TRACE << "[rocprofiler-sdk-rocattach] Entry address found to be " << entry_addr << " from "

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_runner.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_runner.cpp
@@ -150,7 +150,7 @@ public:
         m_runners.wlock([&](auto& runners) {
             if(runners.count(pid) > 0)
             {
-                // if thread already exists, re-use it
+                // if thread already exists, reuse it
                 runner = runners.at(pid);
             }
             else if(op == PTRACE_SEIZE)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_session.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/ptrace_session.cpp
@@ -254,7 +254,7 @@ PTraceSession::ptrace_signal_handler_func(
 
         // make a non-blocking call to waitpid to check on our tracee process
         retval = waitpid(_pid, &status, WNOHANG);
-        // if retval is 0, no error occured and no state change was observed
+        // if retval is 0, no error occurred and no state change was observed
         if(retval == 0)
         {
             std::this_thread::yield();

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
@@ -240,7 +240,7 @@ resolve_attach_tid(pid_t pid)
 rocattach_status_t
 setup(int pid)
 {
-    // Setup attachement for rocprofiler
+    // Setup attachment for rocprofiler
     ROCP_TRACE << "[rocprofiler-sdk-rocattach] Attachment library rocattach_attach function called "
                   "for pid "
                << pid;
@@ -398,7 +398,7 @@ collect_process_tree(pid_t root_pid)
 rocattach_status_t
 teardown(int pid)
 {
-    // Setup attachement for rocprofiler
+    // Setup attachment for rocprofiler
     ROCP_TRACE << "[rocprofiler-sdk-rocattach] Attachment library rocattach_detach function called "
                   "for pid "
                << pid;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
@@ -119,7 +119,7 @@ get_library_handle(std::string_view _lib_name)
         }
     }
 
-    // try to load with the absoulte path
+    // try to load with the absolute path
     if(!_lib_handle)
     {
         _lib_path   = _lib_path_abs;
@@ -239,7 +239,7 @@ find_symbol(int target_pid, void*& addr, const std::string& library, const std::
         return false;
     }
 
-    // Caluclate the offset
+    // Calculate the offset
     size_t offset =
         reinterpret_cast<size_t>(symboladdr) - reinterpret_cast<size_t>(hostlibraryaddr);
     ROCP_TRACE << "[rocprofiler-sdk-rocattach] Offset of " << symbol << " into " << library

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/config.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/config.cpp
@@ -83,7 +83,7 @@ trim(std::string s, bool (*f)(int) = not_is_space)
     return s;
 }
 
-// replace unsuported specail chars with space
+// replace unsupported special chars with space
 void
 handle_special_chars(std::string& str)
 {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/agent.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/agent.cpp
@@ -148,9 +148,10 @@ update_agent_runtime_visibility(rocprofiler_agent_t& agent_info)
         auto set_hip_visibility = [&agent_info](bool is_hip_visible) {
             if(is_hip_visible && agent_info.runtime_visibility.hsa == 0)
             {
-                ROCP_WARNING << fmt::format("Attempt to enable hip visiblity for agent-{} which is "
-                                            "not visible to HSA (ROCR)",
-                                            agent_info.node_id);
+                ROCP_WARNING << fmt::format(
+                    "Attempt to enable hip visibility for agent-{} which is "
+                    "not visible to HSA (ROCR)",
+                    agent_info.node_id);
                 return;
             }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/packet_construct.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/packet_construct.hpp
@@ -68,10 +68,10 @@ namespace aql
 {
 /**
  * Class to construct AQL Packets for a specific agent and metric set.
- * Thie class checks that the counters supplied are collectable on the
+ * This class checks that the counters supplied are collectable on the
  * agent in question (including making sure that they stay within block
  * limits). construct_packet returns an AQLPacket class containing the
- * consturcted start/stop/read packets along with allocated buffers needed
+ * constructed start/stop/read packets along with allocated buffers needed
  * to collect the counter data.
  */
 class CounterPacketConstruct

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.hpp
@@ -78,11 +78,11 @@ struct buffer_tracing_service
 struct dispatch_counter_collection_service
 {
     // Contains a vector of counter collection instances associated with this context.
-    // Each instance is assocated with an agent and a counter collection profile.
+    // Each instance is associated with an agent and a counter collection profile.
     // Contains callback information along with other data needed to collect/process
     // counters.
     std::vector<std::shared_ptr<counters::counter_callback_info>> callbacks{};
-    // A flag to state wether or not the counter set is currently enabled. This is primarily
+    // A flag to state whether or not the counter set is currently enabled. This is primarily
     // to protect against multithreaded calls to enable a context (and enabling already enabled
     // counters).
     common::Synchronized<bool> enabled{false};
@@ -94,7 +94,7 @@ struct spm_dispatch_counter_collection_service
     // Contains callback information along with other data needed to collect/process
     // SPM counters.
     std::vector<std::shared_ptr<spm::spm_counter_callback_info>> callbacks{};
-    // A flag to state wether or not the counter set is currently enabled. This is primarily
+    // A flag to state whether or not the counter set is currently enabled. This is primarily
     // to protect against multithreaded calls to enable a context (and enabling already enabled
     // counters).
     common::Synchronized<bool> enabled{false};

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/controller.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/controller.cpp
@@ -39,7 +39,7 @@ namespace counters
 {
 CounterController::CounterController()
 {
-    // Pre-read metrics map file to catch faliures during initial setup.
+    // Pre-read metrics map file to catch failures during initial setup.
     rocprofiler::counters::loadMetrics();
     rocprofiler::counters::check_installed_firmware_restrictions();
 }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/core.cpp
@@ -84,14 +84,14 @@ counter_callback_info::setup_counter_config(std::shared_ptr<counter_config>& pro
             rocprofiler::common::get_val(asts->arch_to_counter_asts, agent_name);
         if(!agent_map)
         {
-            ROCP_ERROR << fmt::format("Coult not build AST for {}", agent_name);
+            ROCP_ERROR << fmt::format("Could not build AST for {}", agent_name);
             return ROCPROFILER_STATUS_ERROR_AST_GENERATION_FAILED;
         }
 
         const auto* counter_ast = rocprofiler::common::get_val(*agent_map, metric.name());
         if(!counter_ast)
         {
-            ROCP_ERROR << fmt::format("Coult not find AST for {}", metric.name());
+            ROCP_ERROR << fmt::format("Could not find AST for {}", metric.name());
             return ROCPROFILER_STATUS_ERROR_AST_NOT_FOUND;
         }
         config.asts.push_back(*counter_ast);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/metrics.cpp
@@ -68,7 +68,7 @@ getCustomCounterDefinition()
 }
 
 /**
- * Constant/speical metrics are treated as psudo-metrics in that they
+ * Constant/special metrics are treated as pseudo-metrics in that they
  * are given their own metric id. MAX_WAVE_SIZE for example is not collected
  * by AQL Profiler but is a constant from the topology. It will still have
  * a counter associated with it. Nearly all metrics contained in
@@ -100,14 +100,14 @@ get_constants(uint64_t starting_id)
  * Expected YAML Format:
  * COUNTER_NAME:
  *  architectures:
- *   gfxXX: // Can be more than one, / deliminated if they share idential data
+ *   gfxXX: // Can be more than one, / delimited if they share identical data
  *     block: <Optional>
  *     event: <Optional>
  *     expression: <optional>
  *     description: <Optional>
  *   gfxYY:
  *      ...
- *  description: General counter desctiption
+ *  description: General counter description
  */
 counter_metrics_t
 loadYAML(const std::string& filename, std::optional<ArchMetric> add_metric)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/parser/raw_ast.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/parser/raw_ast.hpp
@@ -94,7 +94,7 @@ struct RawAST
     std::string        reduce_op{};
     ACCUMULATE_OP_TYPE accumulate_op{ACCUMULATE_OP_TYPE::NONE};
 
-    // Stores either the name or digit dependening on whether this
+    // Stores either the name or digit depending on whether this
     // is a name or number
     std::variant<std::monostate, std::string, int64_t> value{std::monostate{}};
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/core.cpp
@@ -146,7 +146,7 @@ buffered_callback(rocprofiler_context_id_t,
     // /**
     //  * Specific counters default to a size of 128 even if they have less data (primarily
     //  * TCP). This is a known quirk on AQL profile's end where it will allocate for 128 entries
-    //  * but return less (and the data may be duplicated across entries). Skip these entires for
+    //  * but return less (and the data may be duplicated across entries). Skip these entries for
     //  * testing purposes since we cannot determine what mock data will be in the return (and its
     //  * arch dependent).
     //  */

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/device_counting.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/device_counting.cpp
@@ -720,7 +720,7 @@ TEST_F(device_counting_service_test, sync_sq_waves_verify)
 TEST_F(device_counting_service_test, sync_sq_waves_verify_non_intercept)
 {
     // If this test fails, device counters will not be read correctly by a system-wide profiler
-    // deamon.
+    // daemon.
     if(!counters::counter_collection_has_device_lock())
     {
         ROCP_INFO << "Unsupported kernel driver version, skipping test";

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/hsa_tables.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/hsa_tables.cpp
@@ -81,7 +81,7 @@ get_ext_table()
         val.hsa_amd_ipc_signal_create_fn             = hsa_amd_ipc_signal_create;
         val.hsa_amd_ipc_signal_attach_fn             = hsa_amd_ipc_signal_attach;
         val.hsa_amd_register_system_event_handler_fn = hsa_amd_register_system_event_handler;
-        // Cannot be set, no visable public symbols
+        // Cannot be set, no visible public symbols
         // val.hsa_amd_queue_intercept_create_fn = hsa_amd_queue_intercept_create;
         // val.hsa_amd_queue_intercept_register_fn = hsa_amd_queue_intercept_register;
         val.hsa_amd_queue_set_priority_fn     = hsa_amd_queue_set_priority;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/metrics_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/metrics_test.cpp
@@ -131,7 +131,7 @@ TEST(metrics, derived_load)
 {
     auto loaded_metrics = counters::loadMetrics();
     auto rocp_data      = [&]() {
-        // get only derrived metrics
+        // get only derived metrics
         std::unordered_map<std::string, std::vector<counters::Metric>> ret;
         for(const auto& [gfx, metrics] : loaded_metrics->arch_to_metric)
         {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/metrics_test.h
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/metrics_test.h
@@ -277,7 +277,7 @@ static const std::unordered_map<std::string, std::vector<std::vector<std::string
        "159",
        "<None>",
        "Count number of context-restored waves sent to SQs. This value represents the number "
-       "of waves whos current register state has been restored from a register bank during "
+       "of waves whose current register state has been restored from a register bank during "
        "the collection timeframe (for dispatch profiling this is the timeframe of kernel "
        "execution, for agent profiling it is the timeframe between start_context and read "
        "counter data). Context saving/restoring is a slow operation and should be limited. "
@@ -390,7 +390,7 @@ static const std::unordered_map<std::string, std::vector<std::vector<std::string
        "89",
        "<None>",
        "Number of inflight instruction fetch requests from the cache. This is a value "
-       "returned per-sharder engine. Best used with accumlate() functions as part of a "
+       "returned per-shader engine. Best used with accumulate() functions as part of a "
        "derived counter."},
       {"TCC_RW_REQ",
        "TCC",
@@ -812,7 +812,7 @@ static const std::unordered_map<std::string, std::vector<std::vector<std::string
        "160",
        "<None>",
        "Count number of context-saved waves sent to SQs. This value represents the number "
-       "of waves whos current register state has been saved to a register bank during the "
+       "of waves whose current register state has been saved to a register bank during the "
        "collection timeframe (for dispatch profiling this is the timeframe of kernel "
        "execution, for agent profiling it is the timeframe between start_context and read "
        "counter data) . Context saving/restoring is a slow operation and should be limited. "

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/details/kfd_ioctl.h
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/details/kfd_ioctl.h
@@ -610,7 +610,7 @@ enum KFD_MIGRATE_TRIGGERS
     KFD_MIGRATE_TRIGGER_TTM_EVICTION   /* TTM eviction */
 };
 
-/* The reason of user queue evition event */
+/* The reason of user queue eviction event */
 enum KFD_QUEUE_EVICTION_TRIGGERS
 {
     KFD_QUEUE_EVICTION_TRIGGER_SVM,     /* SVM buffer migration */
@@ -717,7 +717,7 @@ struct kfd_ioctl_spm_args
 /**
  * kfd_ioctl_spm_buffer_header - SPM Buffer header for kfd_ioctl_spm_args->dest_buf
  *
- * @version        [out]: spm versiom
+ * @version        [out]: spm version
  * @bytes_copied   [out]: amount of data for each sub-block
  * @has_data_loss: [out]: boolean indicating whether data was lost for each sub-block
  *                        (e.g. due to a ring-buffer overflow)
@@ -745,7 +745,7 @@ struct kfd_ioctl_spm_buffer_header
  *    mask to start record the event to the kfifo, use bitmap mask combination
  *    for multiple events. New event mask will overwrite the previous event mask.
  *    KFD_SMI_EVENT_MASK_FROM_INDEX(KFD_SMI_EVENT_ALL_PROCESS) bit requires sudo
- *    permisson to receive SVM events from all process.
+ *    permission to receive SVM events from all processes.
  *
  * To receive the event
  *    Application can poll file descriptor to wait for the events, then read event
@@ -1236,7 +1236,7 @@ struct kfd_runtime_info
  *
  * Coordinates debug exception signalling and debug device enablement with runtime.
  *
- * @r_debug - pointer to user struct for sharing information between ROCr and the debuggger
+ * @r_debug - pointer to user struct for sharing information between ROCr and the debugger
  * @mode_mask - mask to set mode
  *	KFD_RUNTIME_ENABLE_MODE_ENABLE_MASK - enable runtime for debugging, otherwise disable
  *	KFD_RUNTIME_ENABLE_MODE_TTMP_SAVE_MASK - enable trap temporary setup (ignore on disable)
@@ -1350,7 +1350,7 @@ enum kfd_dbg_trap_operations
  *     @exception_mask (IN)	- exceptions to raise to the debugger
  *     @rinfo_ptr      (IN)	- pointer to runtime info buffer (see kfd_runtime_info)
  *     @rinfo_size     (IN/OUT)	- size of runtime info buffer in bytes
- *     @dbg_fd	       (IN)	- fd the KFD will nofify the debugger with of raised
+ *     @dbg_fd	       (IN)	- fd the KFD will notify the debugger of raised
  *				  exceptions set in exception_mask.
  *
  *     Generic errors apply (see kfd_dbg_trap_operations).

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/aql_packet.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/aql_packet.hpp
@@ -92,7 +92,7 @@ public:
     AQLPacket()          = default;
     virtual ~AQLPacket() = default;
 
-    // Keep move constuctors (i.e. std::move())
+    // Keep move constructors (i.e. std::move())
     AQLPacket(AQLPacket&& other) = default;
     AQLPacket& operator=(AQLPacket&& other) = default;
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
@@ -413,7 +413,7 @@ WriteInterceptor(const void* packets,
         // handler to complete during finalization.
         queue.async_started();
 
-        // Searching accross all the packets given during this write
+        // Searching across all the packets given during this write
         for(size_t i = 0; i < _num_packets; ++i)
         {
             const auto& original_packet = _packets[i].kernel_dispatch;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.hpp
@@ -163,7 +163,7 @@ public:
 
     // Tracks the number of in flight kernel executions we
     // are waiting on. We cannot destroy Queue until all kernels
-    // have comleted.
+    // have completed.
     void    async_started() { _core_api.hsa_signal_add_relaxed_fn(_active_kernels, 1); }
     void    async_complete() { _core_api.hsa_signal_subtract_relaxed_fn(_active_kernels, 1); }
     int64_t active_async_packets() const

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
@@ -525,7 +525,7 @@ write_interceptor(Queue*                                queue,
                                                   .correlation_id = corr_id,
                                                   .packet_data    = packet_data_array_t{}};
 
-        // Searching accross all the packets given during this write
+        // Searching across all the packets given during this write
         for(size_t i = 0; i < _num_packets; ++i)
         {
             const auto& original_packet = _packets[i].kernel_dispatch;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/scratch_memory.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/scratch_memory.cpp
@@ -606,7 +606,7 @@ update_table(const context_array_t& ctxs, hsa_amd_tool_table_t* _orig)
         _func = get_hsa_amd_tool_api_impl<TableIdx, OpIdx>(_func);
     }
 
-    // suppress unused paramter
+    // suppress unused parameter
     common::consume_args(ctxs, _orig);
 }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/internal_threading.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/internal_threading.cpp
@@ -349,7 +349,7 @@ create_task_group(size_t pool_size)
 task_group_t*
 create_task_group(void* addr, size_t pool_size)
 {
-    // notify that rocprofiler library is about to create an inernal thread
+    // notify that rocprofiler library is about to create an internal thread
     notify_pre_internal_thread_create(ROCPROFILER_LIBRARY);
 
     // placement new to construct task group at provided address

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/ompt.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/ompt.cpp
@@ -176,7 +176,7 @@ initialize(ompt_function_lookup_t lookup, int /*initial_device_num*/, ompt_data_
     set_ompt_callbacks();
     init_status.store(1);
 
-    return 1;  // bizarre abberation in the OMPT spec, not 0
+    return 1;  // bizarre aberration in the OMPT spec, not 0
 }
 #undef SETCB
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/cid_manager.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/cid_manager.cpp
@@ -49,16 +49,16 @@ PCSCIDManager::manage_cids_implicit(const pc_samples_copy_fn_t& pc_samples_copy_
         // Note: two buffer flushes happened since kernels of q3's CIDs completed.
         q3 = std::move(q2);
         // Move all CIDs from q1 to q2.
-        // Note: exactly one buffer flush occured since kernels of q2's CIDs completed.
+        // Note: exactly one buffer flush occurred since kernels of q2's CIDs completed.
         q2 = std::move(q1);
 
         // We move CIDs from one queue to another to reflect that an implicit ROCr's buffer flush
-        // occured. move from q1 to q2 reflects the first buffer flush since kernels of q1's CIDs
+        // occurred. move from q1 to q2 reflects the first buffer flush since kernels of q1's CIDs
         // completed move from q2 to local q3 reflects the second buffer flush since kernels of q2's
         // CIDs completed.
 
         // Empty the q1 to indicate that there are no CIDs with the following property:
-        // no buffer flush occured since the kernel of CID is marked completed.
+        // no buffer flush occurred since the kernel of CID is marked completed.
         q1.clear();
 
         // The code that follows does not change the state of the PCSCIDManager, so release the lock
@@ -68,7 +68,7 @@ PCSCIDManager::manage_cids_implicit(const pc_samples_copy_fn_t& pc_samples_copy_
     // Copy PC samples from the ROCr's buffer to the SDK's buffer by invoking the passed function.
     pc_samples_copy_fn();
 
-    // Exactly two implicit buffer flushes occured since kernels of q3's CIDs completed.
+    // Exactly two implicit buffer flushes occurred since kernels of q3's CIDs completed.
     // Since all PC samples corresponding to these CIDs are placed in the SDK's buffer,
     // decrement their reference counters to indicate that PC sampling service will not use
     // these CIDs anymore.

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/cid_manager.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/cid_manager.hpp
@@ -80,7 +80,7 @@ class PCSCIDManager
     /// Correlation IDs with the following property: no ROCr's buffer flush happened
     /// since a corresponding kernel completed
     std::vector<context::correlation_id*> q1;
-    /// Correlation IDs with the following property: exactly one ROCr's buffer flush occured
+    /// Correlation IDs with the following property: exactly one ROCr's buffer flush occurred
     /// since a corresponding kernel completed
     std::vector<context::correlation_id*> q2;
     /// A pointer to the PC sampling parser to be notified when the CID is retired.

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/ioctl/ioctl_adapter.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/ioctl/ioctl_adapter.cpp
@@ -140,7 +140,7 @@ get_ioctl_version(rocprofiler_ioctl_version_info_t& ioctl_version)
     struct kfd_ioctl_get_version_args args = {.major_version = 0, .minor_version = 0};
     if(ioctl(get_kfd_fd(), AMDKFD_IOC_GET_VERSION, &args) != 0)
     {
-        // An error occured while querying KFD IOCTL version.
+        // An error occurred while querying KFD IOCTL version.
         return ROCPROFILER_STATUS_ERROR;
     }
 
@@ -193,7 +193,7 @@ get_pc_sampling_ioctl_version(uint32_t kfd_gpu_id, pcs_ioctl_version_t* pcs_ioct
     }
     else if(ret != 0)
     {
-        // An unexpected error occured, so we cannot be sure if the
+        // An unexpected error occurred, so we cannot be sure if the
         // context of the `version` is valid.
         return ROCPROFILER_STATUS_ERROR;
     }
@@ -399,7 +399,7 @@ ioctl_query_pc_sampling_capabilities(uint32_t  kfd_gpu_id,
     {
         if(ret == -EBUSY)
         {
-            // Querying PC sampling capabilities is requsted from within the ROCgdb
+            // Querying PC sampling capabilities is requested from within the ROCgdb
             // which is not supported.
             return ROCPROFILER_IOCTL_STATUS_UNAVAILABLE;
         }
@@ -453,7 +453,7 @@ convert_ioctl_pcs_config_to_rocp(const rocprofiler_ioctl_pc_sampling_info_t& ioc
     if(ioctl_pcs_config.interval != 0)
     {
         // The pc sampling is configured on the corresponding device.
-        // The `interval` contains the value of the interval used for deliverying samples.
+        // The `interval` contains the value of the interval used for delivering samples.
         // Values of `interval_min` and `interval_max` are irrelevant.
         rocp_pcs_config.min_interval = ioctl_pcs_config.interval;
         rocp_pcs_config.max_interval = ioctl_pcs_config.interval;
@@ -633,7 +633,7 @@ ioctl_pcs_create(const rocprofiler_agent_t*       agent,
         if(errno == EBUSY || errno == EEXIST)
         {
             // Currently, KFD uses EBUSY when e.g., PC sampling create is requested from
-            // withing the ROCgdb.
+            // within the ROCgdb.
             // On the other hand, EEXIST is used when one tries to create a PC sampling
             // with a configuration different than the one already active.
             return ROCPROFILER_STATUS_ERROR_NOT_AVAILABLE;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/ioctl/ioctl_adapter_types.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/ioctl/ioctl_adapter_types.hpp
@@ -56,7 +56,7 @@ typedef enum rocprofiler_ioctl_status_t
     ROCPROFILER_IOCTL_STATUS_BUFFER_TOO_SMALL =
         7,  /// A buffer needed to handle a request is too small                     //USED
     ROCPROFILER_IOCTL_STATUS_NOT_IMPLEMENTED =
-        10,  /// KFD function is not implemented for this set of paramters
+        10,  /// KFD function is not implemented for this set of parameters
     ROCPROFILER_IOCTL_STATUS_UNAVAILABLE = 12,  /// KFD function is not available currently on this
                                                 /// // USED node (but may be at a later time)
     ROCPROFILER_IOCTL_STATUS_OUT_OF_RESOURCES =

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/parser/correlation.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/parser/correlation.hpp
@@ -54,7 +54,7 @@ struct dispatch_correlation_ids_t
 };
 
 /**
- * @brief Struct immitating the correlation_id returned by the trap handler in raw PC samples.
+ * @brief Struct imitating the correlation_id returned by the trap handler in raw PC samples.
  */
 union trap_correlation_id_t
 {
@@ -129,7 +129,7 @@ public:
     };
 
     /**
-     * Checks wether a dispatch pkt will generate a collision.
+     * Checks whether a dispatch pkt will generate a collision.
      * @returns true on collision and false when slot is available.
      */
     bool checkDispatch(const dispatch_pkt_id_t& pkt) const
@@ -196,7 +196,7 @@ public:
      * @param[in] write_idx The dispatch packet write index, [optional] not wrapped
      * @param[in] queue_size The queue size. [optional] If write_index is already wrapped,
      *                       then this value can just be a large integer > queue_size.
-     * @returns The correlation_id immitating the ones returned by the trap handler.
+     * @returns The correlation_id imitating the ones returned by the trap handler.
      */
     static trap_correlation_id_t trap_correlation_id(uint64_t doorbell,
                                                      uint64_t write_idx,

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/parser/pc_record_interface.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/parser/pc_record_interface.hpp
@@ -102,7 +102,7 @@ public:
      */
     void newDispatch(const dispatch_pkt_id_t& pkt);
     /**
-     * @brief Checkes if a dispatch packet will generate a collision with dorbell_id and
+     * @brief Checks if a dispatch packet will generate a collision with doorbell_id and
      * dispatch_index.
      * @param[in] pkt Struct containing the dispatch packet data.
      * @returns boolean

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/parser/stochastic_records.h
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/parser/stochastic_records.h
@@ -41,7 +41,7 @@ typedef struct rocprofiler_pc_sampling_record_stochastic_header_t
 } rocprofiler_pc_sampling_record_stochastic_header_t;
 
 /**
- * @brief Enumaration describing sampled instruction type.
+ * @brief Enumeration describing sampled instruction type.
  */
 typedef enum rocprofiler_pc_sampling_instruction_type_t
 {
@@ -67,7 +67,7 @@ typedef enum rocprofiler_pc_sampling_instruction_type_t
 } rocprofiler_pc_sampling_instruction_type_t;
 
 /**
- * @brief Enumaration describing reason for not issuing an instruction.
+ * @brief Enumeration describing reason for not issuing an instruction.
  */
 typedef enum pcsample_reason_not_issued
 {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/parser/tests/correlation_id_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/parser/tests/correlation_id_test.cpp
@@ -245,7 +245,7 @@ pcs_parser_random_samples()
 }
 
 /**
- * Creates a few queues with a few dispatchs per queue.
+ * Creates a few queues with a few dispatches per queue.
  * Adds random samples per dispatch, and checks the result.
  */
 TEST(pcs_parser, random_samples)
@@ -354,7 +354,7 @@ pcs_parser_queue_hammer()
 }
 
 /**
- * Hammers the parser by creating and destrying queues at random, adding dispatches at random
+ * Hammers the parser by creating and destroying queues at random, adding dispatches at random
  * and generating PC samples at random. By default we use all 4 unique doorbells,
  * queue size is 16 and we generate 10k samples dispatch.
  */

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/parser/tests/gfx12test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/parser/tests/gfx12test.cpp
@@ -192,7 +192,7 @@ class WaveIssueAndErrorTestGFX12
                 genPCSample(valid, issued);
     }
 
-    // Could be reused with assumption that the num_combinations will be overriden
+    // Could be reused with assumption that the num_combinations will be overridden
     void CheckBuffers() override
     {
         const int num_combinations = 4;
@@ -256,7 +256,7 @@ class WaveIssueAndErrorTestGFX12
 template <typename PcSamplingRecordT>
 class HwIdTest : public WaveSnapTest<GFX12, PcSamplingRecordT>
 {
-    // The combined hw_id1 and hw_id2 encoded by ROCr's 2nd level trap hadler
+    // The combined hw_id1 and hw_id2 encoded by ROCr's 2nd level trap handler
     union gfx12_hw_id_t
     {
         uint32_t raw;
@@ -351,7 +351,7 @@ class HwIdTest : public WaveSnapTest<GFX12, PcSamplingRecordT>
         ::memset(&sample, 0, sizeof(sample));
 
         // Unpacking individual fields
-        // NOTE: chiplet is tested in a WaveOtherFieldsTest test, becuase it's not
+        // NOTE: chiplet is tested in a WaveOtherFieldsTest test, because it's not
         // transferred via hw_id, but chiplet_and_wave_id field.
         sample.hw_id.wave_id          = hw_id.wave_id;
         sample.hw_id.simd_id          = hw_id.simd_id;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/parser/tests/gfx9test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/parser/tests/gfx9test.cpp
@@ -267,7 +267,7 @@ class HwIdTest : public WaveSnapTest<GFX9, PcSamplingRecordT>
             uint32_t wave_id : 4;  ///< wave slot index
             uint32_t simd_id : 2;  ///< SIMD index
             uint32_t pipe_id : 2;  ///< pipe index
-            uint32_t cu_id : 4;  ///< Index of compute unit on GFX9 or workgroup processer on other
+            uint32_t cu_id : 4;  ///< Index of compute unit on GFX9 or workgroup processor on other
                                  ///< architectures
             uint32_t shader_array_id  : 1;  ///< Shared array index
             uint32_t shader_engine_id : 3;  ///< shared engine index
@@ -355,7 +355,7 @@ class HwIdTest : public WaveSnapTest<GFX9, PcSamplingRecordT>
         PcSamplingRecordT sample;
         ::memset(&sample, 0, sizeof(sample));
         // Unpacking individual fields
-        // NOTE: chiplet is tested in a WaveOtherFieldsTest test, becuase it's not
+        // NOTE: chiplet is tested in a WaveOtherFieldsTest test, because it's not
         // transferred via hw_id, but chiplet_and_wave_id field.
         sample.hw_id.wave_id          = hw_id.wave_id;
         sample.hw_id.simd_id          = hw_id.simd_id;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/parser/tests/mocks.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/parser/tests/mocks.hpp
@@ -280,7 +280,7 @@ private:
 
 /**
  * Lightweight class to represent a wave in the particular dispatch.
- * Capable of generating PC samples and submiting them to the buffer.
+ * Capable of generating PC samples and submitting them to the buffer.
  * Instead of generating a valid program counter, this class uses the snapshot.pc field to
  * store the original dispatch's unique_id for later correctness verification.
  */

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/tests/configure_service.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/tests/configure_service.cpp
@@ -161,7 +161,7 @@ extract_pc_sampling_config_prefer(rocprofiler_pc_sampling_method_t method,
 
     const rocprofiler_pc_sampling_configuration_t* first_preferred_method_config = nullptr;
     const rocprofiler_pc_sampling_configuration_t* first_remained_method_config  = nullptr;
-    // Search until encountering the prefered method configuration, if any.
+    // Search until encountering the preferred method configuration, if any.
     // Otherwise, use what remained.
     for(auto const& cfg : configs)
     {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/tests/query_configuration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/tests/query_configuration.cpp
@@ -312,7 +312,7 @@ TEST(pc_sampling, query_configs_after_service_setup)
             const auto* cfg = &configs[0];
             EXPECT_EQ(cfg->method, picked_cfg->method);
             EXPECT_EQ(cfg->unit, picked_cfg->unit);
-            // Min and max interval are equeal when PC sampling is enabled
+            // Min and max interval are equal when PC sampling is enabled
             EXPECT_EQ(cfg->min_interval, cfg->max_interval);
             // When set up the PC sampling, we used the max_interval of the picked_cfg
             EXPECT_EQ(cfg->max_interval, picked_cfg->max_interval);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/core.cpp
@@ -145,7 +145,7 @@ destroy_spm_counter_profile(rocprofiler_counter_config_id_t id)
 }
 
 /**
- * @brief looks into the config's packet cache to re-use the packet
+ * @brief looks into the config's packet cache to reuse the packet
  * If not, constructs the packet using packet generator
  * updates packet_return map
  */

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/dispatch_handlers.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/spm/dispatch_handlers.cpp
@@ -219,10 +219,10 @@ pre_kernel_call(const context::context*                                  ctx,
 
 /**
  * @brief Callback called by HSA interceptor when the kernel has completed processing.
- * Destroys the depedency signal of barrier packet2
+ * Destroys the dependency signal of barrier packet2
  * Invokes KFD SPM stop
  * Removes entry in packet_return_map
- * Puts the aql packet into config's packets cache for re-use
+ * Puts the aql packet into config's packets cache for reuse
  */
 void
 post_kernel_call(const context::context*                           ctx,

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/tests/details/agent.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/tests/details/agent.cpp
@@ -184,7 +184,7 @@ AcquireAgentInfoEntry(hsa_agent_t agent, agent_info_t* agent_i)
         agent, (hsa_agent_info_t) HSA_AMD_AGENT_INFO_DRIVER_NODE_ID, &agent_i->internal_node_id);
     RET_IF_HSA_ERR(err);
 
-    // Max number of watch points on mem. addr. ranges to generate exeception
+    // Max number of watch points on mem. addr. ranges to generate exception
     // events
     err = hsa_agent_get_info(agent,
                              (hsa_agent_info_t) HSA_AMD_AGENT_INFO_MAX_ADDRESS_WATCH_POINTS,
@@ -454,8 +454,8 @@ CheckInitError()
 
 // Print out all static information known to HSA about the target system.
 // Throughout this program, the Acquire-type functions make HSA calls to
-// interate through HSA objects and then perform HSA get_info calls to
-// acccumulate information about those objects. Corresponding to each
+// iterate through HSA objects and then perform HSA get_info calls to
+// accumulate information about those objects. Corresponding to each
 // Acquire-type function is a Display* function which display the
 // accumulated data in a formatted way.
 int

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/tests/enum_string.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/tests/enum_string.cpp
@@ -383,7 +383,7 @@ ROCPROFILER_ENUM_LABEL(TEST_ENUM_VALUE_V3);
 }  // namespace sdk
 }  // namespace rocprofiler
 
-TEST(enum_string, unsuported)
+TEST(enum_string, unsupported)
 {
     using namespace rocprofiler::sdk;
     using namespace enum_string_test;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/trace_decoder_api.h
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/trace_decoder_api.h
@@ -60,7 +60,7 @@ typedef rocprofiler_thread_trace_decoder_status_t (*rocprof_trace_decoder_trace_
  * If call returns _SUCCESS, isa_size and source_size must be written with bytes used.
  * @param[out] instruction Where to copy the ISA line to.
  * @param[out] memory_size (Auto) The number of bytes to next instruction. 0 for custom ISA.
- * @param[inout] size Size of returned ISA string.
+ * @param[in,out] size Size of returned ISA string.
  * @param[in] address The code object ID and offset from base vaddr.
  * If marker_id == 0, this parameter is raw virtual address with no codeobj ID information.
  * @param[in] userdata Arbitrary data pointer to be sent back to the user via callback.

--- a/projects/rocprofiler-sdk/source/libexec/rocprofiler-sdk/rocprofiler-sdk-launch-compiler/rocprofiler-sdk-launch-compiler.sh
+++ b/projects/rocprofiler-sdk/source/libexec/rocprofiler-sdk/rocprofiler-sdk-launch-compiler/rocprofiler-sdk-launch-compiler.sh
@@ -49,7 +49,7 @@ debug_message()
 # if rocprofiler-sdk compiler is not passed, someone is probably trying to invoke it directly
 if [ -z "${1}" ]; then
     echo -e "\n${BASH_SOURCE[0]} was invoked without the rocprofiler-sdk compiler as the first argument."
-    echo "This script is not indended to be directly invoked by any mechanism other"
+    echo "This script is not intended to be directly invoked by any mechanism other"
     echo -e "than through a RULE_LAUNCH_COMPILE or RULE_LAUNCH_LINK property set in CMake.\n"
     exit 1
 fi
@@ -57,7 +57,7 @@ fi
 # if rocprofiler-sdk compiler is not passed, someone is probably trying to invoke it directly
 if [ -z "${2}" ]; then
     echo -e "\n${BASH_SOURCE[0]} was invoked without the C++ compiler as the second argument."
-    echo "This script is not indended to be directly invoked by any mechanism other"
+    echo "This script is not intended to be directly invoked by any mechanism other"
     echo -e "than through a RULE_LAUNCH_COMPILE or RULE_LAUNCH_LINK property set in CMake.\n"
     exit 1
 fi

--- a/projects/rocprofiler-sdk/source/scripts/update-docs.sh
+++ b/projects/rocprofiler-sdk/source/scripts/update-docs.sh
@@ -14,7 +14,7 @@ message "Source directory is ${SOURCE_DIR}"
 message "Changing directory to ${SOURCE_DIR}"
 cd ${SOURCE_DIR}
 
-message "Configurating cmake..."
+message "Configuring CMake..."
 cmake -B build-docs ${SOURCE_DIR} -DROCPROFILER_INTERNAL_BUILD_DOCS=ON
 
 message "Changing directory to ${WORK_DIR}"

--- a/projects/rocprofiler-sdk/source/share/rocprofiler-sdk/basic_counters.xml
+++ b/projects/rocprofiler-sdk/source/share/rocprofiler-sdk/basic_counters.xml
@@ -236,7 +236,7 @@
   <metric name="SQ_ACTIVE_INST_VALU" block=SQ event=99 descr="Number of cycles the SQ instruction arbiter is working on a VALU instruction. (per-simd, emulated). Units in quad-cycles(4 cycles)"></metric>
   <metric name="SQ_ACTIVE_INST_SCA" block=SQ event=100 descr="Number of cycles the SQ instruction arbiter is working on a SALU or SMEM instruction. (per-simd, emulated). Units in quad-cycles(4 cycles)"></metric>
   <metric name="SQ_ACTIVE_INST_EXP_GDS" block=SQ event=101 descr="Number of cycles the SQ instruction arbiter is working on an EXPORT or GDS instruction. (per-simd, emulated). Units in quad-cycles(4 cycles)"></metric>
-  <metric name="SQ_ACTIVE_INST_MISC" block=SQ event=102 descr="Number of cycles the SQ instruction aribter is working on a BRANCH or SENDMSG instruction. (per-simd, emulated). Units in quad-cycles(4 cycles)"></metric>
+  <metric name="SQ_ACTIVE_INST_MISC" block=SQ event=102 descr="Number of cycles the SQ instruction arbiter is working on a BRANCH or SENDMSG instruction. (per-simd, emulated). Units in quad-cycles(4 cycles)"></metric>
   <metric name="SQ_ACTIVE_INST_FLAT" block=SQ event=103 descr="Number of cycles the SQ instruction arbiter is working on a FLAT instruction. (per-simd, emulated). Units in quad-cycles(4 cycles)"></metric>
   <metric name="SQ_INST_CYCLES_VMEM_WR" block=SQ event=104 descr="Number of cycles needed to send addr and cmd data for VMEM write instructions. (per-simd, emulated). Units in quad-cycles(4 cycles)"></metric>
   <metric name="SQ_INST_CYCLES_VMEM_RD" block=SQ event=105 descr="Number of cycles needed to send addr and cmd data for VMEM read instructions. (per-simd, emulated). Units in quad-cycles(4 cycles)"></metric>
@@ -502,7 +502,7 @@
   <metric name="SQ_ACTIVE_INST_VALU" block=SQ event=104 descr="Number of cycles the SQ instruction arbiter is working on a VALU instruction. (per-simd, emulated). Units in quad-cycles(4 cycles)"></metric>
   <metric name="SQ_ACTIVE_INST_SCA" block=SQ event=105 descr="Number of cycles the SQ instruction arbiter is working on a SALU or SMEM instruction. (per-simd, emulated). Units in quad-cycles(4 cycles)"></metric>
   <metric name="SQ_ACTIVE_INST_EXP_GDS" block=SQ event=106 descr="Number of cycles the SQ instruction arbiter is working on an EXPORT or GDS instruction. (per-simd, emulated). Units in quad-cycles(4 cycles)"></metric>
-  <metric name="SQ_ACTIVE_INST_MISC" block=SQ event=107 descr="Number of cycles the SQ instruction aribter is working on a BRANCH or SENDMSG instruction. (per-simd, emulated). Units in quad-cycles(4 cycles)"></metric>
+  <metric name="SQ_ACTIVE_INST_MISC" block=SQ event=107 descr="Number of cycles the SQ instruction arbiter is working on a BRANCH or SENDMSG instruction. (per-simd, emulated). Units in quad-cycles(4 cycles)"></metric>
   <metric name="SQ_ACTIVE_INST_FLAT" block=SQ event=108 descr="Number of cycles the SQ instruction arbiter is working on a FLAT instruction. (per-simd, emulated). Units in quad-cycles(4 cycles)"></metric>
   <metric name="SQ_INST_CYCLES_VMEM_WR" block=SQ event=109 descr="Number of cycles needed to send addr and cmd data for VMEM write instructions. (per-simd, emulated). Units in quad-cycles(4 cycles)"></metric>
   <metric name="SQ_INST_CYCLES_VMEM_RD" block=SQ event=110 descr="Number of cycles needed to send addr and cmd data for VMEM read instructions. (per-simd, emulated). Units in quad-cycles(4 cycles)"></metric>

--- a/projects/rocprofiler-sdk/source/share/rocprofiler-sdk/config.yaml
+++ b/projects/rocprofiler-sdk/source/share/rocprofiler-sdk/config.yaml
@@ -38,7 +38,7 @@ rocprofiler-sdk:
             - gfx90a
           expression: reduce(SQ_THREAD_CYCLES_VALU,sum)/reduce(SQ_ACTIVE_INST_VALU,sum)
     - name: CHA_BUSY
-      description: Count busy cyles. Not windowable.
+      description: Count busy cycles. Not windowable.
       properties: []
       definitions:
         - architectures:
@@ -3815,7 +3815,7 @@ rocprofiler-sdk:
           event: 136
     - name: SQ_IFETCH_LEVEL
       description: Number of inflight instruction fetch requests from the cache. This is a value 
-        returned per-sharder engine. Best used with accumlate() functions as part of a derived 
+        returned per-shader engine. Best used with accumulate() functions as part of a derived 
         counter.
       properties: []
       definitions:
@@ -4567,7 +4567,7 @@ rocprofiler-sdk:
           event: 42
     - name: SQ_INSTS_VALU_MFMA_F8
       description: The number of MFMA (Matrix-Fused-Multiply-Add) operating on F8 format (V_MFMA or 
-        V_SMFMAC). See AMD CDNA3 ISA for more informations.
+        V_SMFMAC). See AMD CDNA3 ISA for more information.
       properties: []
       definitions:
         - architectures:
@@ -5825,7 +5825,7 @@ rocprofiler-sdk:
           event: 7
     - name: SQ_WAVES_RESTORED
       description: Count number of context-restored waves sent to SQs. This value represents the 
-        number of waves whos current register state has been restored from a register bank during 
+        number of waves whose current register state has been restored from a register bank during 
         the collection timeframe (for dispatch profiling this is the timeframe of kernel execution, 
         for agent profiling it is the timeframe between start_context and read counter data). 
         Context saving/restoring is a slow operation and should be limited. High values can also 
@@ -5853,9 +5853,9 @@ rocprofiler-sdk:
           event: 201
     - name: SQ_WAVES_SAVED
       description: Count number of context-saved waves sent to SQs. This value represents the number
-        of waves whos current register state has been saved to a register bank during the collection
-        timeframe (for dispatch profiling this is the timeframe of kernel execution, for agent 
-        profiling it is the timeframe between start_context and read counter data) . Context 
+        of waves whose current register state has been saved to a register bank during the 
+        collection timeframe (for dispatch profiling this is the timeframe of kernel execution, for 
+        agent profiling it is the timeframe between start_context and read counter data) . Context 
         saving/restoring is a slow operation and should be limited. High values can also indicate 
         that stalling may be taking place (waiting for free register space). Returns one value 
         per-SE (aggregates of SIMD values).

--- a/projects/rocprofiler-sdk/source/share/rocprofiler-sdk/derived_counters.xml
+++ b/projects/rocprofiler-sdk/source/share/rocprofiler-sdk/derived_counters.xml
@@ -67,8 +67,8 @@
 
   <metric name="TCC_HIT_sum" expr=reduce(TCC_HIT,sum) descr="Number of cache hits. Sum over TCC instances."></metric>
   <metric name="TCC_MISS_sum" expr=reduce(TCC_MISS,sum) descr="Number of cache misses. Sum over TCC instances."></metric>
-  <metric name="TCC_MC_RDREQ_sum" expr=reduce(TCC_MC_RDREQ,sum) descr="Number of 32-byte reads. Sum over TCC instaces."></metric>
-  <metric name="TCC_MC_WRREQ_sum" expr=reduce(TCC_MC_WRREQ,sum) descr="Number of 32-byte transactions going over the TC_MC_wrreq interface. Sum over TCC instaces."></metric>
+  <metric name="TCC_MC_RDREQ_sum" expr=reduce(TCC_MC_RDREQ,sum) descr="Number of 32-byte reads. Sum over TCC instances."></metric>
+  <metric name="TCC_MC_WRREQ_sum" expr=reduce(TCC_MC_WRREQ,sum) descr="Number of 32-byte transactions going over the TC_MC_wrreq interface. Sum over TCC instances."></metric>
   <metric name="TCC_WRREQ_STALL_max" expr=reduce(TCC_MC_WRREQ_STALL,max) descr="Number of cycles a write request was stalled. Max over TCC instances."></metric>
 
   <metric name="FETCH_SIZE" expr=(TCC_MC_RDREQ_sum*32)/1024 descr="The total kilobytes fetched from the video memory. This is measured with all extra fetches and any cache or memory effects taken into account."></metric>

--- a/projects/rocprofiler-sdk/tests/bin/hsa-queue-dependency/multiqueue_app.cpp
+++ b/projects/rocprofiler-sdk/tests/bin/hsa-queue-dependency/multiqueue_app.cpp
@@ -113,7 +113,7 @@ main()
     status                           = hsa_signal_create(1, 0, nullptr, &completion_signal_1);
     RET_IF_HSA_ERR(status)
 
-    // First dispath packet on queue 1, Kernel A
+    // First dispatch packet on queue 1, Kernel A
     {
         MQDependencyTest::Aql packet{};
         packet.header.type    = HSA_PACKET_TYPE_KERNEL_DISPATCH;
@@ -164,7 +164,7 @@ main()
         obj.submit_packet(queue1, packet);
     }
 
-    // Second dispath packet on queue 1, Kernel C
+    // Second dispatch packet on queue 1, Kernel C
     {
         MQDependencyTest::Aql packet{};
         packet.header.type    = HSA_PACKET_TYPE_KERNEL_DISPATCH;
@@ -216,7 +216,7 @@ main()
         obj.submit_packet(queue2, packet);
     }
 
-    // Third dispath packet on queue 2, Kernel B
+    // Third dispatch packet on queue 2, Kernel B
     {
         MQDependencyTest::Aql packet{};
         packet.header.type    = HSA_PACKET_TYPE_KERNEL_DISPATCH;

--- a/projects/rocprofiler-sdk/tests/bin/rocjpeg/rocjpeg.cpp
+++ b/projects/rocprofiler-sdk/tests/bin/rocjpeg/rocjpeg.cpp
@@ -261,7 +261,7 @@ main(int argc, char** argv)
             }
             if(num_jpegs_with_unknown_subsampling)
             {
-                std::cout << " ,total images with unknwon chroam subsampling: "
+                std::cout << " ,total images with unknown chroam subsampling: "
                           << num_jpegs_with_unknown_subsampling;
             }
             if(num_jpegs_with_unsupported_resolution)

--- a/projects/rocprofiler-sdk/tests/bin/simple-transpose/simple-transpose.cpp
+++ b/projects/rocprofiler-sdk/tests/bin/simple-transpose/simple-transpose.cpp
@@ -127,7 +127,7 @@ main()
     roctxProfilerResume(tid);
 
     roctxMark("pre-kernel-launch");
-    // Lauching kernel from host
+    // Launching kernel from host
     hipLaunchKernelGGL(matrixTranspose,
                        dim3(WIDTH / THREADS_PER_BLOCK_X, WIDTH / THREADS_PER_BLOCK_Y),
                        dim3(THREADS_PER_BLOCK_X, THREADS_PER_BLOCK_Y),

--- a/projects/rocprofiler-sdk/tests/pc_sampling/pcs.cpp
+++ b/projects/rocprofiler-sdk/tests/pc_sampling/pcs.cpp
@@ -90,7 +90,7 @@ public:
     // The set that keeps track of reported code object loading/unloading events.
     // At the end of the test, the sets needs to be empty.
     // Namely, each loading event will insert a code object id into the set,
-    // while each unloading event will delete a code ojbect id from the set.
+    // while each unloading event will delete a code object id from the set.
     code_object_id_set_t active_code_objects = {};
 };
 
@@ -124,7 +124,7 @@ find_all_gpu_agents_supporting_pc_sampling_impl(rocprofiler_agent_version_t vers
         if(_agents[i]->type == ROCPROFILER_AGENT_TYPE_GPU)
         {
             // Instantiate the tool_agent_info.
-            // Store pointer to the rocprofiler_agent_t and instatiate a vector of
+            // Store pointer to the rocprofiler_agent_t and instantiate a vector of
             // available configurations.
             // Move the ownership to the _out_agents
             auto tool_gpu_agent           = std::make_unique<tool_agent_info>();
@@ -238,7 +238,7 @@ configure_pc_sampling_prefer_stochastic(tool_agent_info*         agent_info,
         auto success = query_avail_configs_for_agent(agent_info);
         if(!success)
         {
-            // An error occured while querying PC sampling capabilities,
+            // An error occurred while querying PC sampling capabilities,
             // so avoid trying configuring PC sampling service.
             // Instead return false to indicated a failure.
             ROCPROFILER_CALL(ROCPROFILER_STATUS_ERROR,
@@ -298,7 +298,7 @@ configure_pc_sampling_prefer_stochastic(tool_agent_info*         agent_info,
         // but before the `rocprofiler_configure_pc_sampling_service` is called,
         // then the `rocprofiler_configure_pc_sampling_service` will fail again.
         // The process P1 executing this loop can spin wait (starve) if it is unlucky enough
-        // to always be interuppted by some other process P2 that creates/destroys
+        // to always be interrupted by some other process P2 that creates/destroys
         // PC sampling service on the same device while P1 is executing the code
         // after the `query_avail_configs_for_agent` and
         // before the `rocprofiler_configure_pc_sampling_service`.
@@ -514,7 +514,7 @@ configure_pc_sampling_on_all_agents(rocprofiler_context_id_t context)
 
     if(pc_sampler->gpu_agents.empty())
     {
-        *utils::get_output_stream() << "No availabe gpu agents supporting PC sampling"
+        *utils::get_output_stream() << "No available gpu agents supporting PC sampling"
                                     << "\n";
         // Emit the message to skip the test.
         std::cerr << "PC sampling unavailable"

--- a/projects/rocprofiler-sdk/tests/pc_sampling/utils.cpp
+++ b/projects/rocprofiler-sdk/tests/pc_sampling/utils.cpp
@@ -29,7 +29,7 @@ namespace utils
 std::ostream*&
 get_output_stream()
 {
-    // The output strea is initially unitialized
+    // The output stream is initially uninitialized
     static std::ostream* _v = nullptr;
     return _v;
 }

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/exec_mask_manipulation/csv.py
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/exec_mask_manipulation/csv.py
@@ -93,7 +93,7 @@ def validate_instruction_comment(df):
 def validate_instruction_correlation_id_relation(df):
     # Samples with no decoded instructions originates from either
     # blit kernels or self modifying code. The correlation id for this
-    # type of samples should alway be zero.
+    # type of samples should always be zero.
     # Thus, Correlation_Id is 0 `iff`` instruction is not decoded.
 
     # The previous statement has two implications.

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/exec_mask_manipulation/json.py
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/exec_mask_manipulation/json.py
@@ -55,7 +55,7 @@ def validate_json_exec_mask_manipulation(
     # Although, it would be more elegant to wrap some of the checks in dedicated functions,
     # I noticed that it can introduce significant overhead, so I decided to inline those checks.
 
-    # the function assume homogenous system
+    # the function assumes homogeneous system
     agents = data_json["agents"]
     gpu_agents = list(filter(lambda agent: agent["type"] == 2, agents))
     # There should be at least one GPU agent
@@ -125,7 +125,7 @@ def validate_json_exec_mask_manipulation(
 
         if cid == 0:
             # Samples originates either from a blit kernel or self-modifying code.
-            # Thus, code object is uknown, as well as the instruction.
+            # Thus, code object is unknown, as well as the instruction.
             assert record["pc"]["code_object_id"] == 0
             assert inst_index == -1
         else:
@@ -138,7 +138,7 @@ def validate_json_exec_mask_manipulation(
             assert inst_index != -1
 
             wgid = record["wrkgrp_id"]
-            # check corrdinates of the workgroup
+            # check coordinates of the workgroup
             assert wgid["x"] >= 0 and wgid["x"] <= 1023
             # FIXME: Navi4x wgid is currently broken
             # assert wgid["y"] == 0
@@ -179,7 +179,7 @@ def validate_json_exec_mask_manipulation(
                 assert cid == unique_kernels_num
                 # Monitor wave_in_group being sampled
                 last_kernel_sampled_wave_in_grp.add(wave_in_grp)
-                # chekcs specific for samples from the last kernel
+                # checks specific for samples from the last kernel
                 assert wave_in_grp >= 0 and wave_in_grp <= 3
 
                 # validate instruction decoding

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx9/s_instructions/__init__.py
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx9/s_instructions/__init__.py
@@ -35,7 +35,7 @@ from .message_instructions import validate_message_instructions
 from .barrier_instructions import validate_barrier_instructions
 
 # Using Prefix Tree to classify the instruction type
-# I did this instead of the regex becuase I wanted to try if we could
+# I did this instead of the regex because I wanted to try if we could
 # generalize this approach for other types of instructions.
 # The dream scenario: We have a giant list of all instructions and their
 # types. Then we parse the list and dynamically determine the checks
@@ -87,14 +87,14 @@ instructions_with_types = [
     ("s_", "SCALAR"),  # Scalar instructions (general category)
     ("s_waitcnt", "WAITCNT"),  # WAITCNT (specific)
     ("s_sendmsg", "MESSAGE"),  # MESSAGE (specific)
-    ("s_barrier", "BARRIER"),  # BARRIER (specifix)
+    ("s_barrier", "BARRIER"),  # BARRIER (specific)
     ("s_swappc", "JUMP"),  # JUMP (specific)
     ("s_setpc", "JUMP"),  # JUMP
     ("s_setpc", "JUMP"),  # JUMP
     ("s_sleep", "JUMP"),  # JUMP
     ("s_branch", "BRANCH"),  # BRANCH
     ("s_cbranch", "BRANCH"),  # BRANCH (conditional)
-    ("s_wakeup", "OTHER"),  # OHTER
+    ("s_wakeup", "OTHER"),  # OTHER
     ("s_nop", "INTERNAL"),  # INTERNAL
     ("s_sleep", "INTERNAL"),  # INTERNAL
 ]
@@ -120,7 +120,7 @@ def classify_instruction_by_prefix(prefix_tree, instruction):
     # Classify based on the Trie (general classification)
     instruction_types = prefix_tree.get_instruction_type(base_instruction)
 
-    # aways use the specific type
+    # always use the specific type
     return instruction_types[-1]
 
 

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/json/gfx9/__init__.py
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/json/gfx9/__init__.py
@@ -41,7 +41,7 @@ from .s_instructions import (
 )
 
 # Using Prefix Tree to classify the instruction type
-# I did this instead of the regex becuase I wanted to try if we could
+# I did this instead of the regex because I wanted to try if we could
 # generalize this approach for other types of instructions.
 # The dream scenario: We have a giant list of all instructions and their
 # types. Then we parse the list and dynamically determine the checks
@@ -93,14 +93,14 @@ instructions_with_types = [
     ("s_", "SCALAR"),  # Scalar instructions (general category)
     ("s_waitcnt", "WAITCNT"),  # WAITCNT (specific)
     ("s_sendmsg", "MESSAGE"),  # MESSAGE (specific)
-    ("s_barrier", "BARRIER"),  # BARRIER (specifix)
+    ("s_barrier", "BARRIER"),  # BARRIER (specific)
     ("s_swappc", "JUMP"),  # JUMP (specific)
     ("s_setpc", "JUMP"),  # JUMP
     ("s_setpc", "JUMP"),  # JUMP
     ("s_sleep", "JUMP"),  # JUMP
     ("s_branch", "BRANCH"),  # BRANCH
     ("s_cbranch", "BRANCH"),  # BRANCH (conditional)
-    ("s_wakeup", "OTHER"),  # OHTER
+    ("s_wakeup", "OTHER"),  # OTHER
     ("s_nop", "INTERNAL"),  # INTERNAL
     ("s_sleep", "INTERNAL"),  # INTERNAL
     ("v_", "VALU"),  # VALU

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/json/gfx9/arbiter_state.py
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/json/gfx9/arbiter_state.py
@@ -77,7 +77,7 @@ def validate_arbiter_state(snapshot):
     # According to Joe's slides, the misc_stall cannot be 0.
     # However, the condition representing this case fails for `transpose` application
     #   assert((samples['Arbiter_State_Stall_Misc'] == 0).all())
-    # Instead, I had to replace is with the condition belowe
+    # Instead, I had to replace is with the condition below
     #   misc_issue = 0 & misc_stall = 1 is not allowed
     assert not (
         snapshot["arb_state_issue_misc"] == 0 and snapshot["arb_state_stall_misc"] == 1

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pytest_utils/perfetto_reader.py
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pytest_utils/perfetto_reader.py
@@ -126,7 +126,7 @@ class PerfettoReader:
     def configure(self, **kwargs):
 
         # pre-compile the regex patterns for extracting the func, file, and line info
-        # users can use their own pattens via patterns=[...]. An empty set of patterns
+        # users can use their own patterns via patterns=[...]. An empty set of patterns
         # is valid for avoiding parsing func/file/line info
         _default_patterns = [
             # func [file:line]

--- a/projects/rocprofiler-sdk/tests/rocprofv3/advanced-thread-trace/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/advanced-thread-trace/validate.py
@@ -110,7 +110,7 @@ def test_realtime_clock(output_path):
 
         # Sort by shader_clock (index 0)
         timestamps_sorted = sorted(timestamps, key=lambda ts: ts[0])
-        # Ensure realtime clock is non descreasing
+        # Ensure realtime clock is non-decreasing
         assert all(
             curr[1] >= prev[1]
             for prev, curr in zip(timestamps_sorted, timestamps_sorted[1:])

--- a/projects/rocprofiler-sdk/tests/rocprofv3/rocpd-kernel-rename/conftest.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/rocpd-kernel-rename/conftest.py
@@ -57,7 +57,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--generated-no-rename-csv-input",
         action="store",
-        help="Path to generted non-kernel rename trace file.",
+        help="Path to generated non-kernel rename trace file.",
     )
 
 

--- a/projects/rocprofiler-sdk/tests/thread-trace/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/thread-trace/CMakeLists.txt
@@ -77,7 +77,7 @@ rocprofiler_add_integration_execute_test(
     ENVIRONMENT "TRIPLEBUFFER=1;ATT_NODETAIL=1;ATT_SLOW_CALLBACK=0"
     DISABLED ${TRIPLE_BUFFER_DISABLED})
 
-# Collects a lot of data, and check if parsering works successfully
+# Collects a lot of data, and check if parsing works successfully
 rocprofiler_add_integration_execute_test(
     thread-trace-api-triple-buffer-hammer-test
     TARGET thread-trace-test-app

--- a/projects/rocprofiler-sdk/tests/tools/json-tool.cpp
+++ b/projects/rocprofiler-sdk/tests/tools/json-tool.cpp
@@ -691,7 +691,7 @@ dispatch_callback(rocprofiler_dispatch_counting_service_data_t dispatch_data,
         }
     }
 
-    // Create a colleciton profile for the counters
+    // Create a collection profile for the counters
     rocprofiler_counter_config_id_t profile = {.handle = 0};
     ROCPROFILER_CALL(rocprofiler_create_counter_config(dispatch_data.dispatch_info.agent_id,
                                                        collect_counters.data(),

--- a/projects/rocprofiler-sdk/tests/tools/thread-trace-agent-tool.cpp
+++ b/projects/rocprofiler-sdk/tests/tools/thread-trace-agent-tool.cpp
@@ -149,7 +149,7 @@ query_available_agents(rocprofiler_agent_version_t /* version */,
 
         uint64_t buffer_size_bytes = buffer_size_gb << 30;
         if(agent->gfx_target_version / 10000 == 11u)
-            buffer_size_bytes = 255ul << 20;  // gfx11 limititation
+            buffer_size_bytes = 255ul << 20;  // gfx11 limitation
 
         auto parameters = std::vector<rocprofiler_thread_trace_parameter_t>{};
         parameters.push_back({ROCPROFILER_THREAD_TRACE_PARAMETER_TARGET_CU, {1}});

--- a/projects/rocprofiler-sdk/tests/tools/thread-trace-callbacks.cpp
+++ b/projects/rocprofiler-sdk/tests/tools/thread-trace-callbacks.cpp
@@ -123,7 +123,7 @@ finalize(void* /* tool_data */)
     if(decoder.handle != 0)
     {
         if(extra_args && latency != 0)
-            throw std::runtime_error("Got detailled profling in nondetail mode");
+            throw std::runtime_error("Got detailed profiling in nondetail mode");
         else if(!extra_args && latency == 0)
             throw std::runtime_error("Missing detailed profiling!");
 


### PR DESCRIPTION
## Motivation

We should fix spelling errors in rocm-systems, especially when customer-visible

## Technical Details

* Almost all are comments and output strings
* XML and json changes should be vetted
* One (unused) parameter name change
* Did not fix grammar issues

## JIRA ID

N/A

## Test Plan

`codespell -L=HSA,hsa,VALU,VALUs,interm,valu,deviceC,savy,namess,renderD,bloc`

## Test Result

No spelling issues

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
