### PR TITLE
[ROCM-25770] Return NOT_SUPPORTED from fabric telemetry on non-IFoE systems

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -75,6 +75,9 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
   - Also removed the incorrect "in MHz" note from the `current` field, which is a frequency index, not a frequency value.
   - Updated the Python API reference to state the unit is Hz.
 
+- **Fixed fabric telemetry APIs returning the wrong status on non-IFoE systems**.  
+  - `amdsmi_alloc_fabric_telemetry()`, `amdsmi_get_fabric_telemetry_data()`, and `amdsmi_free_fabric_telemetry()` now return `AMDSMI_STATUS_NOT_SUPPORTED` on systems without fabric hardware, consistent with `amdsmi_get_gpu_fabric_info()`.
+
 ## amd_smi_lib for ROCm 7.13.0
 
 ### Added

--- a/projects/amdsmi/src/amd_smi/amd_smi_ualoe.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_ualoe.cc
@@ -617,8 +617,9 @@ amdsmi_status_t amdsmi_alloc_fabric_telemetry(amdsmi_processor_handle processor_
 
   ualoe_handle_t ualoe_handle = device->get_ualoe_handle();
 
+  // No UALoE session: fabric telemetry is unsupported on this device.
   if (ualoe_handle == -1) {
-    return AMDSMI_STATUS_NOT_INIT;
+    return AMDSMI_STATUS_NOT_SUPPORTED;
   }
 
   uint32_t ualoe_category_mask = category_mask;
@@ -652,8 +653,9 @@ amdsmi_status_t amdsmi_get_fabric_telemetry_data(amdsmi_processor_handle process
 
   ualoe_handle_t ualoe_handle = device->get_ualoe_handle();
 
+  // No UALoE session: fabric telemetry is unsupported on this device.
   if (ualoe_handle == -1) {
-    return AMDSMI_STATUS_NOT_INIT;
+    return AMDSMI_STATUS_NOT_SUPPORTED;
   }
 
   // Cast AMDSMI telemetry directly to UALoE telemetry since structures are now binary compatible
@@ -684,8 +686,9 @@ amdsmi_status_t amdsmi_free_fabric_telemetry(amdsmi_processor_handle processor_h
 
   ualoe_handle_t ualoe_handle = device->get_ualoe_handle();
 
+  // No UALoE session: fabric telemetry is unsupported on this device.
   if (ualoe_handle == -1) {
-    return AMDSMI_STATUS_NOT_INIT;
+    return AMDSMI_STATUS_NOT_SUPPORTED;
   }
 
   // Cast AMDSMI telemetry directly to UALoE telemetry since structures are now binary compatible

--- a/projects/amdsmi/tests/amd_smi_test/functional/fabric_read.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/fabric_read.cc
@@ -79,6 +79,27 @@ void TestFabricRead::Run(void) {
     auto device = processor_handles_[dv_ind];
     PrintDeviceHeader(device);
 
+    // Without a UALoE session the telemetry APIs must report NOT_SUPPORTED,
+    // not NOT_INIT.
+    {
+      amdsmi_fabric_telemetry_t* probe = nullptr;
+      err = amdsmi_alloc_fabric_telemetry(device, kAllCategories, &probe);
+      ASSERT_NE(err, AMDSMI_STATUS_NOT_INIT);
+      if (err == AMDSMI_STATUS_SUCCESS) {
+        ASSERT_NE(probe, nullptr);
+        err = amdsmi_get_fabric_telemetry_data(device, probe);
+        ASSERT_NE(err, AMDSMI_STATUS_NOT_INIT);
+        err = amdsmi_free_fabric_telemetry(device, probe);
+        ASSERT_NE(err, AMDSMI_STATUS_NOT_INIT);
+      } else {
+        amdsmi_fabric_telemetry_t dummy = {};
+        err = amdsmi_get_fabric_telemetry_data(device, &dummy);
+        ASSERT_NE(err, AMDSMI_STATUS_NOT_INIT);
+        err = amdsmi_free_fabric_telemetry(device, &dummy);
+        ASSERT_NE(err, AMDSMI_STATUS_NOT_INIT);
+      }
+    }
+
     // ── amdsmi_get_gpu_fabric_info ─────────────────────────────────────────
     IF_VERB(STANDARD) { std::cout << "\t** Testing amdsmi_get_gpu_fabric_info()" << std::endl; }
 


### PR DESCRIPTION
## Summary

Fixes **ROCM-25770** — the fabric (UALoE) GTest fails on any system without IFoE/fabric hardware.

On a device with no IFoE/UALoE session (no matching IFoE BDF under `/sys/bus/pci/drivers/ifoe/`, or `ualoe_open()` failed), the device's UALoE handle stays at `-1`. The three fabric telemetry APIs returned `AMDSMI_STATUS_NOT_INIT` in that case:

- `amdsmi_alloc_fabric_telemetry()`
- `amdsmi_get_fabric_telemetry_data()`
- `amdsmi_free_fabric_telemetry()`

This contradicts the **documented non-IFoE contract**, which promises `AMDSMI_STATUS_NOT_SUPPORTED` (see `AMDSmiGPUDevice` in `amd_smi_gpu_device.h` and the INFO log in `populate_ifoe_fabric_bdf_list()`). Because `tests/amd_smi_test/functional/fabric_read.cc` only treats `NOT_SUPPORTED` as a "skip this device" condition and otherwise hits `CHK_ERR_ASRT`, the test **fails** on every non-IFoE box.

`amdsmi_get_gpu_fabric_info()` was unaffected because it is sysfs-only and already returns `NOT_SUPPORTED`/`NO_DATA`.

## Change

Return `AMDSMI_STATUS_NOT_SUPPORTED` from the three telemetry handle guards so the implementation honors its own documented contract and matches `amdsmi_get_gpu_fabric_info()`. The test then skips cleanly on non-IFoE hardware.

## Why not patch the test instead

Accepting `NOT_INIT` in the test would only mask the contract violation. The header and runtime INFO log both promise `NOT_SUPPORTED` for non-IFoE systems, so the implementation is the correct place to fix.

## Testing

- Regular HW available locally to runtime-verify; fix is contract-level and matches the documented behavior.
