### PR TITLE
[RCCL] Default to SIMPLE protocol for SHM in Navi4

### DIFF
--- a/projects/rccl/src/rccl_wrap.cc
+++ b/projects/rccl/src/rccl_wrap.cc
@@ -98,8 +98,17 @@ void rcclUpdateCollectiveProtocol(struct ncclComm* comm, size_t const& nBytes, s
   } else if (!userProtocolInput && IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942") && comm->nNodes == 1 && (info->func == ncclFuncReduceScatter) && sizePerRank <= 352128) {
     // Change LL protocol threshold
     info->protocol = NCCL_PROTO_LL;
-  } else if (!userProtocolInput && IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx12") && comm->nNodes == 1){
-    info->protocol = rcclGetProtoForGfx12( info->func,sizePerRank);
+  } else if (!userProtocolInput && IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx12")){
+    if ( comm->nNodes == 1 ) {
+      info->protocol = rcclGetProtoForGfx12( info->func,sizePerRank);
+    }
+    const char* str = ncclGetEnv("NCCL_P2P_DISABLE");
+    if (str) { 
+      int disable = strtol(str, NULL, 0);
+      if (disable == 1) {
+        info->protocol = NCCL_PROTO_SIMPLE;
+      } 
+    }  
   } else if(!userProtocolInput && comm->nNodes >= 2 && (info->func == ncclFuncReduceScatter || info->func == ncclFuncAllGather || info->func == ncclFuncAllReduce || info->func == ncclFuncBroadcast || info->func == ncclFuncReduce)) {
     auto tunableIndex = rcclGetTunableIndex(info->func);
     auto llMin = comm->minMaxLLRange[tunableIndex][NCCL_PROTO_LL][RCCL_PROTOCOL_MIN_IDX];


### PR DESCRIPTION
## Motivation

- In SHM/direct/direct  path with LL protocol, The collectives slow down , almost like hang. This PR sets SIMPLE protocol when NCCL_P2P_DISABLE=1  on Navi platform. 

- NCCL_P2P_DISABLE=1 on MI300 system still uses P2P/IPC

## Technical Details



## JIRA ID
ROCM-25206

## Test Plan


## Test Result


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
