### PR TITLE
[rocprofiler-systems] Remove throw when push count is greater than pop

### DIFF
--- a/projects/rocprofiler-systems/CHANGELOG.md
+++ b/projects/rocprofiler-systems/CHANGELOG.md
@@ -75,6 +75,10 @@ Full documentation for ROCm Systems Profiler is available at [https://rocm.docs.
   building for TheRock. The system version of `elfutils` was used, rather than
   the vendored version causing package install failures.
 
+### Known issues
+
+- Some workloads may report an imbalance in the push/pop trace counts.
+
 ## ROCm Systems Profiler 1.6.0 for ROCm 7.13.0
 
 ### Added

--- a/projects/rocprofiler-systems/CHANGELOG.md
+++ b/projects/rocprofiler-systems/CHANGELOG.md
@@ -77,7 +77,10 @@ Full documentation for ROCm Systems Profiler is available at [https://rocm.docs.
 
 ### Known issues
 
-- Some workloads may report an imbalance in the push/pop trace counts.
+- A push/pop trace count imbalance can occur for workloads that instrument runtime
+  internals such as OMPT. When pushes exceed pops, rocprof-sys completes
+  finalization, emits a warning, and omits any still-open trace regions from the
+  generated trace output.
 
 ## ROCm Systems Profiler 1.6.0 for ROCm 7.13.0
 

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -265,12 +265,6 @@ configure_settings(bool _init)
                               "for continuous integration)",
                               false, "debugging", "advanced");
 
-    ROCPROFSYS_CONFIG_SETTING(
-        bool, "ROCPROFSYS_CI_SKIP_PUSH_POP_CHECK",
-        "Skip CI validation check for push/pop trace count mismatch "
-        "(used only for tests with known imbalances)",
-        false, "debugging", "advanced");
-
     ROCPROFSYS_CONFIG_SETTING(bool, "ROCPROFSYS_MONOCHROME", "Disable colorized logging",
                               false, "debugging", "advanced");
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
@@ -1278,14 +1278,12 @@ rocprofsys_finalize_hidden(void)
                                              get_perfetto_output_filename()));
     }
 
-    if(_push_count > _pop_count &&
-       !get_env<bool>("ROCPROFSYS_CI_SKIP_PUSH_POP_CHECK", false))
+    if(_push_count > _pop_count)
     {
-        throw std::runtime_error(fmt::format(
-            "rocprofsys_push_trace was called more times than "
-            "rocprofsys_pop_trace. The inverse is fine but the current state "
-            "means not every measurement was ended :: pushed: {} vs. popped: {}",
-            _push_count, _pop_count));
+        LOG_ERROR("rocprofsys_push_trace was called more times than "
+                  "rocprofsys_pop_trace. The inverse is fine but the current state "
+                  "means not every measurement was ended :: pushed: {} vs. popped: {}.",
+                  _push_count, _pop_count);
     }
 
     // debug::close_file();

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library.cpp
@@ -1280,10 +1280,11 @@ rocprofsys_finalize_hidden(void)
 
     if(_push_count > _pop_count)
     {
-        LOG_ERROR("rocprofsys_push_trace was called more times than "
-                  "rocprofsys_pop_trace. The inverse is fine but the current state "
-                  "means not every measurement was ended :: pushed: {} vs. popped: {}.",
-                  _push_count, _pop_count);
+        LOG_WARNING("rocprofsys_push_trace was called more times than "
+                    "rocprofsys_pop_trace. This is not fatal, but trace output will "
+                    "not include regions that were still open during finalization :: "
+                    "pushed: {} vs. popped: {}.",
+                    _push_count, _pop_count);
     }
 
     // debug::close_file();

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/category_region.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/category_region.hpp
@@ -166,10 +166,6 @@ using tim::type_list;
 
 // these categories increment push/pop counts, which are used for sanity checks since
 // they should ALWAYS be popped if they were pushed
-// Note: There is a known imbalance in the push/pop counts for category::host when using
-//       OpenMP Tools (OMPT).
-//       In general, for known imbalances, add ROCPROFSYS_CI_SKIP_PUSH_POP_CHECK=ON to the
-//       ctest environment to avoid the CI_THROW check.
 using tracing_count_categories_t =
     type_list<category::host, category::mpi, category::pthread, category::rocm_hip_api,
               category::rocm_hsa_api, category::rocm_rccl>;

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/category_region.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/category_region.hpp
@@ -166,6 +166,8 @@ using tim::type_list;
 
 // these categories increment push/pop counts, which are used for sanity checks since
 // they should ALWAYS be popped if they were pushed
+// Note: There is a known imbalance in the push/pop counts for category::host when using
+//       OpenMP Tools (OMPT).
 using tracing_count_categories_t =
     type_list<category::host, category::mpi, category::pthread, category::rocm_hip_api,
               category::rocm_hsa_api, category::rocm_rccl>;

--- a/projects/rocprofiler-systems/tests/pytest/test_binaries.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_binaries.py
@@ -476,7 +476,6 @@ class TestRocprofilerSystemsAvail(RocprofsysTest):
     def test_regex_negation(self):
         pass_regex = [
             r"ENVIRONMENT VARIABLE,[\s\S]*"
-            r"ROCPROFSYS_CI_SKIP_PUSH_POP_CHECK,[\s\S]*"
             r"ROCPROFSYS_THREAD_POOL_SIZE,[\s\S]*"
             r"ROCPROFSYS_USE_PID,"
         ]

--- a/projects/rocprofiler-systems/tests/pytest/test_lulesh.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_lulesh.py
@@ -24,7 +24,6 @@ def lulesh_base_env() -> dict[str, str]:
         "ROCPROFSYS_COUT_OUTPUT": "ON",
         "ROCPROFSYS_SAMPLING_FREQ": "50",
         "ROCPROFSYS_KOKKOSP_PREFIX": "[kokkos]",
-        "ROCPROFSYS_CI_SKIP_PUSH_POP_CHECK": "ON",
     }
     return env
 
@@ -96,7 +95,7 @@ class TestLulesh(RocprofsysTest):
         "mode", ["sampling", "binary_rewrite", "runtime_instrument", "sys_run"]
     )
     def test_kokkosp(self, mode):
-        env = {"ROCPROFSYS_USE_KOKKOSP": "ON", "ROCPROFSYS_CI_SKIP_PUSH_POP_CHECK": "ON"}
+        env = {"ROCPROFSYS_USE_KOKKOSP": "ON"}
         result = self.run_test(
             mode,
             "lulesh",
@@ -124,7 +123,6 @@ class TestLulesh(RocprofsysTest):
     def test_perfetto(self, mode, perfetto_env):
         env = perfetto_env.copy()
         env["ROCPROFSYS_USE_KOKKOSP"] = "OFF"
-        env["ROCPROFSYS_CI_SKIP_PUSH_POP_CHECK"] = "ON"
         result = self.run_test(
             mode,
             "lulesh",
@@ -152,7 +150,6 @@ class TestLulesh(RocprofsysTest):
     def test_timemory(self, mode, timemory_env):
         env = timemory_env.copy()
         env["ROCPROFSYS_USE_KOKKOSP"] = "OFF"
-        env["ROCPROFSYS_CI_SKIP_PUSH_POP_CHECK"] = "ON"
         result = self.run_test(
             mode,
             "lulesh",

--- a/projects/rocprofiler-systems/tests/pytest/test_openmp.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_openmp.py
@@ -268,8 +268,6 @@ class TestOpenMPFortran(RocprofsysTest):
     def test_host(self, mode, ompt_base_env):
         env = ompt_base_env.copy()
         env["ROCPROFSYS_COUT_OUTPUT"] = "ON"
-        if mode == "runtime_instrument":
-            env["ROCPROFSYS_CI_SKIP_PUSH_POP_CHECK"] = "ON"
 
         result = self.run_test(
             mode,
@@ -309,8 +307,6 @@ class TestOpenMPFortran(RocprofsysTest):
     def test_offload(self, mode, ompt_target_env):
         env = ompt_target_env.copy()
         env["ROCPROFSYS_COUT_OUTPUT"] = "ON"
-        if mode == "runtime_instrument":
-            env["ROCPROFSYS_CI_SKIP_PUSH_POP_CHECK"] = "ON"
 
         result = self.run_test(
             mode,


### PR DESCRIPTION
## Motivation

ROCM-25422 tracks workloads where push/pop trace count accounting can become imbalanced. Treating a push count greater than the pop count as a fatal finalize-time exception prevents profiling output from being produced for those workloads, so this change reports the imbalance without aborting the run.

## Technical Details

- Changed `rocprofsys_finalize_hidden` to emit `LOG_ERROR` when `_push_count > _pop_count` instead of throwing `std::runtime_error`.
- Removed `ROCPROFSYS_CI_SKIP_PUSH_POP_CHECK` from configuration and pytest environments because the push/pop mismatch check no longer aborts CI.
- Removed stale category-region comments that instructed tests with known imbalances to set the skip environment variable.
- Added a changelog Known issues entry noting that some workloads may report a push/pop trace count imbalance.

## JIRA ID

ROCM-25422

## Test Plan

- [x] Verified GitHub Actions formatting checks and Python linting jobs are passing on the PR.
- [x] Full rocprofiler-systems CI matrix, sanitizer jobs, code coverage, and TheRock package build are still in progress.

## Test Result

Formatting checks and Python linting have passed. The broader CI matrix is still running.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.