### PR TITLE
Use generic tensor load/store intrinsic.

### DIFF
--- a/projects/hip-tests/catch/unit/TDM/tdm_basic_load_store.cc
+++ b/projects/hip-tests/catch/unit/TDM/tdm_basic_load_store.cc
@@ -4,6 +4,9 @@
 
 #include <string>
 
+typedef int v4i __attribute__((ext_vector_type(4)));
+typedef int v8i __attribute__((ext_vector_type(8)));
+
 #if defined(__clang__) && defined(__HIP__)
 __global__ void  TDM_load_store_tester([[maybe_unused]] const int* data,
                                        [[maybe_unused]] int* result,
@@ -26,14 +29,16 @@ __global__ void  TDM_load_store_tester([[maybe_unused]] const int* data,
     group1.tileDim0(sizex);
     group1.tileDim1(sizey);
 
-    __builtin_amdgcn_tensor_load_to_lds_d2(group0.m_bitfield, group1.m_bitfield, 0);
+    v4i v4i_zeros = (v4i){0, 0, 0, 0};
+    v8i v8i_zeros = (v8i){0, 0, 0, 0, 0, 0, 0, 0};
+    __builtin_amdgcn_tensor_load_to_lds(group0.m_bitfield, group1.m_bitfield, v4i_zeros, v4i_zeros, v8i_zeros, 0);
     __builtin_amdgcn_s_wait_tensorcnt(0);
     __syncthreads();
 
     // write back to global
 
     group0.globalAddr((uintptr_t)result);
-    __builtin_amdgcn_tensor_store_from_lds_d2(group0.m_bitfield, group1.m_bitfield, 0);
+    __builtin_amdgcn_tensor_store_from_lds(group0.m_bitfield, group1.m_bitfield, v4i_zeros, v4i_zeros, v8i_zeros, 0);
     __builtin_amdgcn_s_wait_tensorcnt(0);
 
     #endif // #if defined(__gfx1250__) || defined(__gfx1251__)
@@ -48,7 +53,7 @@ TEST_CASE("TDM_Basic_load_2d")
     HIP_CHECK(hipGetDeviceProperties(&props, device));
     const std::string arch(props.gcnArchName);
     if (arch.find("gfx1250") == std::string::npos && arch.find("gfx1251") == std::string::npos) {
-        HipTest::HIP_SKIP_TEST("TDM_Basic_load_2d requires gfx1250 or gfx1251");
+        HIP_SKIP_TEST("TDM_Basic_load_2d requires gfx1250 or gfx1251");
         return;
     }
 #endif
@@ -72,7 +77,7 @@ TEST_CASE("TDM_Basic_load_2d")
     HIP_CHECK(hipDeviceSynchronize());
     HIP_CHECK(hipMemcpy(result.ptr(), result_dev.ptr(), alloc_size, hipMemcpyDeviceToHost));
 
-    for(int i =0; i < alloc_size;++i)
+    for(int i = 0; i < kAllocSize; ++i)
     {
         REQUIRE(result.ptr()[i] == input.ptr()[i]);
     }

--- a/projects/hip-tests/catch/unit/TDM/tdm_basic_load_store.cc
+++ b/projects/hip-tests/catch/unit/TDM/tdm_basic_load_store.cc
@@ -4,10 +4,9 @@
 
 #include <string>
 
+#if defined(__clang__) && defined(__HIP__)
 typedef int v4i __attribute__((ext_vector_type(4)));
 typedef int v8i __attribute__((ext_vector_type(8)));
-
-#if defined(__clang__) && defined(__HIP__)
 __global__ void  TDM_load_store_tester([[maybe_unused]] const int* data,
                                        [[maybe_unused]] int* result,
                                        [[maybe_unused]] int sizex,
@@ -29,8 +28,8 @@ __global__ void  TDM_load_store_tester([[maybe_unused]] const int* data,
     group1.tileDim0(sizex);
     group1.tileDim1(sizey);
 
-    v4i v4i_zeros = (v4i){0, 0, 0, 0};
-    v8i v8i_zeros = (v8i){0, 0, 0, 0, 0, 0, 0, 0};
+    v4i v4i_zeros{0, 0, 0, 0};
+    v8i v8i_zeros{0, 0, 0, 0, 0, 0, 0, 0};
     __builtin_amdgcn_tensor_load_to_lds(group0.m_bitfield, group1.m_bitfield, v4i_zeros, v4i_zeros, v8i_zeros, 0);
     __builtin_amdgcn_s_wait_tensorcnt(0);
     __syncthreads();


### PR DESCRIPTION
## Motivation

Compiler added generic tensor load/store intrinsic for multidims.
https://github.com/llvm/llvm-project/pull/182334

## Technical Details

Use generic tensor load/store intrinsic.

## JIRA ID

NA

## Test Plan

TDM_Basic_load_2d on MI450

## Test Result

TDM_Basic_load_2d pass on MI450

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
