### PR TITLE
[rocprofiler-systems] Improve output format handling in cli arguments

### DIFF
--- a/projects/rocprofiler-systems/CHANGELOG.md
+++ b/projects/rocprofiler-systems/CHANGELOG.md
@@ -8,6 +8,13 @@ Full documentation for ROCm Systems Profiler is available at [https://rocm.docs.
 
 ### Added
 
+- `--output-format` flag for `rocprof-sys-run` and `rocprof-sys-sample` to select
+  output format(s) in a single, intuitive option: `proto` (Perfetto), `rocpd`
+  (RocPD database), and `json` / `text` (Timemory profile; `txt` aliases `text`).
+  Tokens are space- or comma-separated and authoritative — only the listed
+  formats are produced. The existing `--trace`, `--profile`, `--profile-format`
+  flags and their environment variables remain available.
+
 - Unified-memory profiling reports (`unified_memory.txt` and
   `unified_memory.json`) summarizing KFD page-fault and page-migration events,
   including per-GPU counts, trigger breakdown (`gpu_page_fault`,

--- a/projects/rocprofiler-systems/CHANGELOG.md
+++ b/projects/rocprofiler-systems/CHANGELOG.md
@@ -12,8 +12,9 @@ Full documentation for ROCm Systems Profiler is available at [https://rocm.docs.
   output format(s) in a single, intuitive option: `proto` (Perfetto), `rocpd`
   (RocPD database), and `json` / `text` (Timemory profile; `txt` aliases `text`).
   Tokens are space- or comma-separated and authoritative — only the listed
-  formats are produced. The existing `--trace`, `--profile`, `--profile-format`
-  flags and their environment variables remain available.
+  formats are produced. The existing `--trace`, `--profile`, `--flat-profile`,
+  and `--profile-format` flags and their environment variables remain available,
+  but cannot be combined with `--output-format` on the same command line.
 
 - Unified-memory profiling reports (`unified_memory.txt` and
   `unified_memory.json`) summarizing KFD page-fault and page-migration events,

--- a/projects/rocprofiler-systems/docs/conceptual/data-collection-modes.rst
+++ b/projects/rocprofiler-systems/docs/conceptual/data-collection-modes.rst
@@ -236,7 +236,7 @@ Tokens are space- or comma-separated and can be combined, for example:
 
    rocprof-sys-run --output-format proto rocpd -- ./myapp
 
-The ``--trace``, ``--profile``, and ``--profile-format`` flags and their environment variables remain available; ``--output-format`` is a convenience umbrella over the same settings.
+The ``--trace``, ``--profile``, ``--flat-profile``, and ``--profile-format`` flags and their environment variables remain available, but cannot be combined with ``--output-format`` on the same command line: because ``--output-format`` is authoritative over the same settings, mixing it with those flags is rejected to avoid an ambiguous result. Use either ``--output-format`` or the individual flags, not both.
 
 Sampling mode
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/projects/rocprofiler-systems/docs/conceptual/data-collection-modes.rst
+++ b/projects/rocprofiler-systems/docs/conceptual/data-collection-modes.rst
@@ -205,6 +205,39 @@ Profile types:
 
 .. tip:: Start with a flat profile to identify high-impact functions, then use a hierarchical profile to analyze critical paths.
 
+Selecting output formats
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``--output-format`` flag (available in ``rocprof-sys-run`` and ``rocprof-sys-sample``) selects which output format(s) to produce in a single, intuitive option. The selection is authoritative: only the formats you name are produced.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 15 35 50
+
+   * - Token
+     - Output
+     - Equivalent environment variable(s)
+   * - ``proto``
+     - Perfetto trace
+     - ``ROCPROFSYS_TRACE=true``
+   * - ``rocpd``
+     - RocPD SQLite database
+     - ``ROCPROFSYS_USE_ROCPD=true``
+   * - ``json``
+     - Timemory profile, JSON serialization
+     - ``ROCPROFSYS_PROFILE=true`` and ``ROCPROFSYS_JSON_OUTPUT=true``
+   * - ``text`` (alias ``txt``)
+     - Timemory profile, text serialization
+     - ``ROCPROFSYS_PROFILE=true`` and ``ROCPROFSYS_TEXT_OUTPUT=true``
+
+Tokens are space- or comma-separated and can be combined, for example:
+
+.. code-block:: shell
+
+   rocprof-sys-run --output-format proto rocpd -- ./myapp
+
+The ``--trace``, ``--profile``, and ``--profile-format`` flags and their environment variables remain available; ``--output-format`` is a convenience umbrella over the same settings.
+
 Sampling mode
 ^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/projects/rocprofiler-systems/docs/conceptual/data-collection-modes.rst
+++ b/projects/rocprofiler-systems/docs/conceptual/data-collection-modes.rst
@@ -208,7 +208,7 @@ Profile types:
 Selecting output formats
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``--output-format`` flag (available in ``rocprof-sys-run`` and ``rocprof-sys-sample``) selects which output format(s) to produce in a single, intuitive option. The selection is authoritative: only the formats you name are produced.
+The ``--output-format`` flag (available in ``rocprof-sys-run`` and ``rocprof-sys-sample``) selects which output format(s) to produce in a single, intuitive option. The selection is authoritative: only the formats you name are produced. Use either ``--output-format`` or the legacy individual flags, not both.
 
 .. list-table::
    :header-rows: 1

--- a/projects/rocprofiler-systems/source/bin/common/common_utils.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/common_utils.cpp
@@ -530,6 +530,7 @@ get_help_topic_map()
         { "general", { "[GENERAL OPTIONS]" } },
         { "tracing", { "[TRACING OPTIONS]" } },
         { "profiling", { "[PROFILE OPTIONS]" } },
+        { "output", { "[OUTPUT FORMAT OPTIONS]" } },
         { "sampling",
           { "[GENERAL SAMPLING OPTIONS]", "[SAMPLING TIMER OPTIONS]",
             "[ADVANCED SAMPLING OPTIONS]" } },
@@ -576,8 +577,9 @@ const related_topics_map&
 get_related_topics_map()
 {
     static const related_topics_map map = {
-        { "tracing", { "rocm", "process", "backend" } },
-        { "profiling", { "sampling", "counters", "backend" } },
+        { "tracing", { "rocm", "process", "backend", "output" } },
+        { "profiling", { "sampling", "counters", "backend", "output" } },
+        { "output", { "tracing", "profiling", "backend" } },
         { "sampling", { "process", "profiling", "counters", "cpu" } },
         { "process", { "gpu", "sampling" } },
         { "counters", { "gpu", "cpu", "sampling" } },

--- a/projects/rocprofiler-systems/source/bin/common/tests/test_help_system.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/tests/test_help_system.cpp
@@ -37,6 +37,10 @@ Options:
     --trace-file                   Set the trace output file (min: 1, dtype: filepath)
     --trace-buffer-size            Set buffer size in KB (min: 1, dtype: KB)
 
+    [OUTPUT FORMAT OPTIONS]  Unified selection of output format(s)
+
+    --output-format                Select output format(s) (min: 1, dtype: [format...])
+
     [PRESET OPTIONS]   Load a profiling preset
 
     --preset                       Load a preset configuration (max: 1, dtype: string)
@@ -198,6 +202,18 @@ TEST_F(help_system_test, topic_filter_sampling_extracts_timer_options)
     EXPECT_NE(output.find("--sampling-freq"), std::string::npos);
     EXPECT_NE(output.find("--sample-cputime"), std::string::npos);
     EXPECT_NE(output.find("--sample-realtime"), std::string::npos);
+}
+
+TEST_F(help_system_test, topic_filter_output_extracts_format_option)
+{
+    std::ostringstream oss;
+    bool result = print_help_for_topic(synthetic_help, "output", "run", oss);
+    auto output = oss.str();
+
+    EXPECT_TRUE(result);
+    EXPECT_NE(output.find("--output-format"), std::string::npos);
+    EXPECT_EQ(output.find("--preset"), std::string::npos);
+    EXPECT_EQ(output.find("--trace-file"), std::string::npos);
 }
 
 TEST_F(help_system_test, topic_filter_returns_false_for_unknown_topic)

--- a/projects/rocprofiler-systems/source/lib/core/argparse.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse.cpp
@@ -151,11 +151,10 @@ output_format_selection
 resolve_output_format(const strset_t& tokens)
 {
     output_format_selection _sel;
-    _sel.perfetto = tokens.count("proto") != 0;
-    _sel.rocpd    = tokens.count("rocpd") != 0;
-    _sel.json     = tokens.count("json") != 0;
-    _sel.text     = tokens.count("text") != 0 || tokens.count("txt") != 0;
-    _sel.profile  = _sel.json || _sel.text;
+    _sel.perfetto = tokens.contains("proto");
+    _sel.rocpd    = tokens.contains("rocpd");
+    _sel.json     = tokens.contains("json");
+    _sel.text     = tokens.contains("text") || tokens.contains("txt");
     return _sel;
 }
 
@@ -824,19 +823,22 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
                 "Select output format(s); only the listed formats are produced: "
                 "proto (Perfetto trace), rocpd (RocPD database), json/text (Timemory "
                 "profile; txt aliases text). Space- or comma-separated, e.g. "
-                "--output-format proto rocpd. See also --trace, --profile, "
-                "--profile-format.")
+                "--output-format proto rocpd. Cannot be combined with --trace, "
+                "--profile, --flat-profile, or --profile-format.")
             .min_count(1)
             .max_count(5)
             .dtype("[format...]")
             .choices({ "proto", "rocpd", "json", "text", "txt" })
+            .conflicts(
+                { "trace", "profile", "flat-profile", "profile-format", "use-rocpd" })
             .action([&](parser_t& p) {
                 const auto _sel = resolve_output_format(p.get<strset_t>("output-format"));
                 update_env(_data, "ROCPROFSYS_TRACE", _sel.perfetto);
                 update_env(_data, "ROCPROFSYS_USE_ROCPD", _sel.rocpd);
-                update_env(_data, "ROCPROFSYS_PROFILE", _sel.profile);
+                update_env(_data, "ROCPROFSYS_PROFILE", _sel.profile());
                 update_env(_data, "ROCPROFSYS_JSON_OUTPUT", _sel.json);
                 update_env(_data, "ROCPROFSYS_TEXT_OUTPUT", _sel.text);
+                update_env(_data, "ROCPROFSYS_COUT_OUTPUT", false);
             });
 
         _data.reg.processed_environs.emplace("output_format");

--- a/projects/rocprofiler-systems/source/lib/core/argparse.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse.cpp
@@ -147,6 +147,18 @@ add_torch_library_path(parser_data& _data)
     return _data;
 }
 
+output_format_selection
+resolve_output_format(const strset_t& tokens)
+{
+    output_format_selection _sel;
+    _sel.perfetto = tokens.count("proto") != 0;
+    _sel.rocpd    = tokens.count("rocpd") != 0;
+    _sel.json     = tokens.count("json") != 0;
+    _sel.text     = tokens.count("text") != 0 || tokens.count("txt") != 0;
+    _sel.profile  = _sel.json || _sel.text;
+    return _sel;
+}
+
 parser_data&
 add_core_arguments(parser_t& _parser, parser_data& _data)
 {
@@ -308,7 +320,8 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
     {
         _parser
             .add_argument({ "-T", "--trace" },
-                          "Generate a detailed trace (perfetto output)")
+                          "Generate a detailed trace (perfetto output). See also "
+                          "--output-format.")
             .max_count(1)
             .action([&](parser_t& p) {
                 update_env(_data, "ROCPROFSYS_TRACE", p.get<bool>("trace"));
@@ -332,7 +345,8 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
         _parser
             .add_argument(
                 { "-P", "--profile" },
-                "Generate a call-stack-based profile (conflicts with --flat-profile)")
+                "Generate a call-stack-based profile (conflicts with --flat-profile). "
+                "See also --output-format.")
             .max_count(1)
             .conflicts({ "flat-profile" })
             .action([&](parser_t& p) {
@@ -799,13 +813,45 @@ add_core_arguments(parser_t& _parser, parser_data& _data)
         _data.reg.processed_environs.emplace("trace_period_clock_id");
     }
 
+    _parser.start_group("OUTPUT FORMAT OPTIONS",
+                        "Unified selection of which output format(s) to produce");
+
+    if(_data.reg.environ_filter("output_format", _data))
+    {
+        _parser
+            .add_argument(
+                { "--output-format" },
+                "Select output format(s); only the listed formats are produced: "
+                "proto (Perfetto trace), rocpd (RocPD database), json/text (Timemory "
+                "profile; txt aliases text). Space- or comma-separated, e.g. "
+                "--output-format proto rocpd. See also --trace, --profile, "
+                "--profile-format.")
+            .min_count(1)
+            .max_count(5)
+            .dtype("[format...]")
+            .choices({ "proto", "rocpd", "json", "text", "txt" })
+            .action([&](parser_t& p) {
+                const auto _sel = resolve_output_format(p.get<strset_t>("output-format"));
+                update_env(_data, "ROCPROFSYS_TRACE", _sel.perfetto);
+                update_env(_data, "ROCPROFSYS_USE_ROCPD", _sel.rocpd);
+                update_env(_data, "ROCPROFSYS_PROFILE", _sel.profile);
+                update_env(_data, "ROCPROFSYS_JSON_OUTPUT", _sel.json);
+                update_env(_data, "ROCPROFSYS_TEXT_OUTPUT", _sel.text);
+            });
+
+        _data.reg.processed_environs.emplace("output_format");
+    }
+
     _parser.start_group("PROFILE OPTIONS",
                         "Specific options controlling profiling (i.e. deterministic "
                         "measurements which are aggregated into a summary)");
 
     if(_data.reg.environ_filter("profile_format", _data))
     {
-        _parser.add_argument({ "--profile-format" }, "Data formats for profiling results")
+        _parser
+            .add_argument({ "--profile-format" },
+                          "Data formats for profiling results. See also "
+                          "--output-format.")
             .min_count(1)
             .max_count(3)
             .dtype("string")

--- a/projects/rocprofiler-systems/source/lib/core/argparse.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse.hpp
@@ -44,9 +44,11 @@ struct output_format_selection
 {
     bool perfetto = false;  // ROCPROFSYS_TRACE
     bool rocpd    = false;  // ROCPROFSYS_USE_ROCPD
-    bool profile  = false;  // ROCPROFSYS_PROFILE
     bool json     = false;  // ROCPROFSYS_JSON_OUTPUT
     bool text     = false;  // ROCPROFSYS_TEXT_OUTPUT
+
+    // ROCPROFSYS_PROFILE: derived — any Timemory profile sub-format implies profiling.
+    [[nodiscard]] bool profile() const { return json || text; }
 };
 
 /**

--- a/projects/rocprofiler-systems/source/lib/core/argparse.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/argparse.hpp
@@ -40,6 +40,25 @@ default_environ_filter(std::string_view, const parser_data&);
 bool
 default_grouping_filter(std::string_view, const parser_data&);
 
+struct output_format_selection
+{
+    bool perfetto = false;  // ROCPROFSYS_TRACE
+    bool rocpd    = false;  // ROCPROFSYS_USE_ROCPD
+    bool profile  = false;  // ROCPROFSYS_PROFILE
+    bool json     = false;  // ROCPROFSYS_JSON_OUTPUT
+    bool text     = false;  // ROCPROFSYS_TEXT_OUTPUT
+};
+
+/**
+ * Map selected --output-format tokens to the authoritative backend/sub-format set.
+ * Unlisted formats resolve to false so the returned selection fully defines the
+ * active outputs, which is required because ROCPROFSYS_TRACE and ROCPROFSYS_PROFILE
+ * otherwise derive their defaults from each other.
+ * @param tokens proto | rocpd | json | text | txt (txt aliases text)
+ */
+[[nodiscard]] output_format_selection
+resolve_output_format(const strset_t& tokens);
+
 struct env_snapshot
 {
     std::unordered_set<std::string> initial = {};

--- a/projects/rocprofiler-systems/source/lib/core/tests/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/core/tests/CMakeLists.txt
@@ -9,3 +9,23 @@ target_link_libraries(
 )
 
 target_include_directories(demangler-tests PRIVATE ${PROJECT_SOURCE_DIR}/source/lib)
+
+add_library(output-format-tests OBJECT test_output_format.cpp)
+
+target_link_libraries(
+    output-format-tests
+    PRIVATE
+        rocprofiler-systems-googletest-library
+        rocprofiler-systems-core-library
+        rocprofiler-systems-logger
+        rocprofiler-systems-ghc-filesystem
+        rocprofiler-systems-headers
+        rocprofiler-systems-rocm
+        rocprofiler-systems-json
+        rocprofiler-systems-timemory
+)
+
+target_include_directories(
+    output-format-tests
+    PRIVATE ${PROJECT_SOURCE_DIR}/source/lib ${CMAKE_BINARY_DIR}/source/lib/
+)

--- a/projects/rocprofiler-systems/source/lib/core/tests/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/core/tests/CMakeLists.txt
@@ -18,10 +18,7 @@ target_link_libraries(
         rocprofiler-systems-googletest-library
         rocprofiler-systems-core-library
         rocprofiler-systems-logger
-        rocprofiler-systems-ghc-filesystem
         rocprofiler-systems-headers
-        rocprofiler-systems-rocm
-        rocprofiler-systems-json
         rocprofiler-systems-timemory
 )
 

--- a/projects/rocprofiler-systems/source/lib/core/tests/test_output_format.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/tests/test_output_format.cpp
@@ -13,7 +13,7 @@ TEST(output_format, proto_enables_only_perfetto)
     const auto sel = resolve_output_format(strset_t{ "proto" });
     EXPECT_TRUE(sel.perfetto);
     EXPECT_FALSE(sel.rocpd);
-    EXPECT_FALSE(sel.profile);
+    EXPECT_FALSE(sel.profile());
     EXPECT_FALSE(sel.json);
     EXPECT_FALSE(sel.text);
 }
@@ -23,15 +23,38 @@ TEST(output_format, rocpd_disables_perfetto_and_profile)
     const auto sel = resolve_output_format(strset_t{ "rocpd" });
     EXPECT_FALSE(sel.perfetto);
     EXPECT_TRUE(sel.rocpd);
-    EXPECT_FALSE(sel.profile);
+    EXPECT_FALSE(sel.profile());
+    EXPECT_FALSE(sel.json);
+    EXPECT_FALSE(sel.text);
 }
 
 TEST(output_format, json_selects_timemory_json)
 {
     const auto sel = resolve_output_format(strset_t{ "json" });
-    EXPECT_TRUE(sel.profile);
+    EXPECT_TRUE(sel.profile());
     EXPECT_TRUE(sel.json);
     EXPECT_FALSE(sel.text);
+    EXPECT_FALSE(sel.perfetto);
+    EXPECT_FALSE(sel.rocpd);
+}
+
+TEST(output_format, text_selects_timemory_text)
+{
+    const auto sel = resolve_output_format(strset_t{ "text" });
+    EXPECT_TRUE(sel.profile());
+    EXPECT_TRUE(sel.text);
+    EXPECT_FALSE(sel.json);
+    EXPECT_FALSE(sel.perfetto);
+    EXPECT_FALSE(sel.rocpd);
+}
+
+TEST(output_format, json_and_text_both_enable_profile)
+{
+    // two profile sub-formats together; profile() stays true, both flags set
+    const auto sel = resolve_output_format(strset_t{ "json", "text" });
+    EXPECT_TRUE(sel.json);
+    EXPECT_TRUE(sel.text);
+    EXPECT_TRUE(sel.profile());
     EXPECT_FALSE(sel.perfetto);
     EXPECT_FALSE(sel.rocpd);
 }
@@ -41,10 +64,10 @@ TEST(output_format, txt_aliases_text)
     const auto from_txt  = resolve_output_format(strset_t{ "txt" });
     const auto from_text = resolve_output_format(strset_t{ "text" });
     EXPECT_TRUE(from_txt.text);
-    EXPECT_TRUE(from_txt.profile);
+    EXPECT_TRUE(from_txt.profile());
     EXPECT_FALSE(from_txt.json);
     EXPECT_EQ(from_txt.text, from_text.text);
-    EXPECT_EQ(from_txt.profile, from_text.profile);
+    EXPECT_EQ(from_txt.profile(), from_text.profile());
 }
 
 TEST(output_format, proto_and_rocpd_combine)
@@ -52,14 +75,16 @@ TEST(output_format, proto_and_rocpd_combine)
     const auto sel = resolve_output_format(strset_t{ "proto", "rocpd" });
     EXPECT_TRUE(sel.perfetto);
     EXPECT_TRUE(sel.rocpd);
-    EXPECT_FALSE(sel.profile);
+    EXPECT_FALSE(sel.profile());
+    EXPECT_FALSE(sel.json);
+    EXPECT_FALSE(sel.text);
 }
 
 TEST(output_format, proto_and_json_combine)
 {
     const auto sel = resolve_output_format(strset_t{ "proto", "json" });
     EXPECT_TRUE(sel.perfetto);
-    EXPECT_TRUE(sel.profile);
+    EXPECT_TRUE(sel.profile());
     EXPECT_TRUE(sel.json);
     EXPECT_FALSE(sel.text);
     EXPECT_FALSE(sel.rocpd);
@@ -70,7 +95,7 @@ TEST(output_format, empty_selection_disables_all)
     const auto sel = resolve_output_format(strset_t{});
     EXPECT_FALSE(sel.perfetto);
     EXPECT_FALSE(sel.rocpd);
-    EXPECT_FALSE(sel.profile);
+    EXPECT_FALSE(sel.profile());
     EXPECT_FALSE(sel.json);
     EXPECT_FALSE(sel.text);
 }

--- a/projects/rocprofiler-systems/source/lib/core/tests/test_output_format.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/tests/test_output_format.cpp
@@ -1,0 +1,76 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "gtest/gtest.h"
+
+#include "core/argparse.hpp"
+
+using rocprofsys::argparse::resolve_output_format;
+using rocprofsys::argparse::strset_t;
+
+TEST(output_format, proto_enables_only_perfetto)
+{
+    const auto sel = resolve_output_format(strset_t{ "proto" });
+    EXPECT_TRUE(sel.perfetto);
+    EXPECT_FALSE(sel.rocpd);
+    EXPECT_FALSE(sel.profile);
+    EXPECT_FALSE(sel.json);
+    EXPECT_FALSE(sel.text);
+}
+
+TEST(output_format, rocpd_disables_perfetto_and_profile)
+{
+    const auto sel = resolve_output_format(strset_t{ "rocpd" });
+    EXPECT_FALSE(sel.perfetto);
+    EXPECT_TRUE(sel.rocpd);
+    EXPECT_FALSE(sel.profile);
+}
+
+TEST(output_format, json_selects_timemory_json)
+{
+    const auto sel = resolve_output_format(strset_t{ "json" });
+    EXPECT_TRUE(sel.profile);
+    EXPECT_TRUE(sel.json);
+    EXPECT_FALSE(sel.text);
+    EXPECT_FALSE(sel.perfetto);
+    EXPECT_FALSE(sel.rocpd);
+}
+
+TEST(output_format, txt_aliases_text)
+{
+    const auto from_txt  = resolve_output_format(strset_t{ "txt" });
+    const auto from_text = resolve_output_format(strset_t{ "text" });
+    EXPECT_TRUE(from_txt.text);
+    EXPECT_TRUE(from_txt.profile);
+    EXPECT_FALSE(from_txt.json);
+    EXPECT_EQ(from_txt.text, from_text.text);
+    EXPECT_EQ(from_txt.profile, from_text.profile);
+}
+
+TEST(output_format, proto_and_rocpd_combine)
+{
+    const auto sel = resolve_output_format(strset_t{ "proto", "rocpd" });
+    EXPECT_TRUE(sel.perfetto);
+    EXPECT_TRUE(sel.rocpd);
+    EXPECT_FALSE(sel.profile);
+}
+
+TEST(output_format, proto_and_json_combine)
+{
+    const auto sel = resolve_output_format(strset_t{ "proto", "json" });
+    EXPECT_TRUE(sel.perfetto);
+    EXPECT_TRUE(sel.profile);
+    EXPECT_TRUE(sel.json);
+    EXPECT_FALSE(sel.text);
+    EXPECT_FALSE(sel.rocpd);
+}
+
+TEST(output_format, empty_selection_disables_all)
+{
+    const auto sel = resolve_output_format(strset_t{});
+    EXPECT_FALSE(sel.perfetto);
+    EXPECT_FALSE(sel.rocpd);
+    EXPECT_FALSE(sel.profile);
+    EXPECT_FALSE(sel.json);
+    EXPECT_FALSE(sel.text);
+}

--- a/projects/rocprofiler-systems/source/tests/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ set(UNIT_TEST_OBJECTS
     $<TARGET_OBJECTS:lib-common-tests>
     $<TARGET_OBJECTS:trace-cache-tests>
     $<TARGET_OBJECTS:demangler-tests>
+    $<TARGET_OBJECTS:output-format-tests>
     $<TARGET_OBJECTS:progress-tests>
     $<TARGET_OBJECTS:logger-tests>
     $<TARGET_OBJECTS:lib-components-tests>

--- a/projects/rocprofiler-systems/tests/pytest/test_tool_runner.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_tool_runner.py
@@ -76,3 +76,51 @@ class TestProfileFlatProfileConflict(RocprofsysTest):
             result,
             pass_regex=[r"--profile.*conflicts.*--flat-profile"],
         )
+
+
+# ============================================================================
+# --output-format selects backends authoritatively
+# ----------------------------------------------------------------------------
+# --output-format names the exact set of outputs to produce: listed formats are
+# enabled and every unlisted backend is explicitly disabled. A lone "rocpd" must
+# not leave tracing on through the perfetto/profile default derivation, where
+# ROCPROFSYS_TRACE otherwise defaults to the negation of ROCPROFSYS_PROFILE.
+# ============================================================================
+
+
+@pytest.mark.timeout(30)
+@pytest.mark.class_name("tool-runner-output-format")
+class TestOutputFormatSelection(RocprofsysTest):
+    @pytest.mark.parametrize("target", TARGETS)
+    def test_proto_rocpd_enables_both(self, target):
+        result = self.run_test(
+            "baseline",
+            target=target,
+            run_args=["--output-format", "proto", "rocpd", "-v", "2", "--", "ls"],
+            fail_on_not_found=True,
+        )
+        self.assert_regex(
+            result,
+            pass_regex=[
+                r"ROCPROFSYS_TRACE=true",
+                r"ROCPROFSYS_USE_ROCPD=true",
+                r"ROCPROFSYS_PROFILE=false",
+            ],
+        )
+
+    @pytest.mark.parametrize("target", TARGETS)
+    def test_rocpd_only_disables_perfetto(self, target):
+        result = self.run_test(
+            "baseline",
+            target=target,
+            run_args=["--output-format", "rocpd", "-v", "2", "--", "ls"],
+            fail_on_not_found=True,
+        )
+        self.assert_regex(
+            result,
+            pass_regex=[
+                r"ROCPROFSYS_USE_ROCPD=true",
+                r"ROCPROFSYS_TRACE=false",
+                r"ROCPROFSYS_PROFILE=false",
+            ],
+        )

--- a/projects/rocprofiler-systems/tests/pytest/test_tool_runner.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_tool_runner.py
@@ -124,3 +124,26 @@ class TestOutputFormatSelection(RocprofsysTest):
                 r"ROCPROFSYS_PROFILE=false",
             ],
         )
+
+    @pytest.mark.parametrize(
+        "legacy_args",
+        [
+            ["--trace"],
+            ["--profile"],
+            ["--flat-profile"],
+            ["--profile-format", "text"],
+        ],
+    )
+    @pytest.mark.parametrize("target", TARGETS)
+    def test_conflicts_with_legacy_flags(self, target, legacy_args):
+        result = self.run_test(
+            "baseline",
+            target=target,
+            run_args=["--output-format", "rocpd", *legacy_args, "--", "ls"],
+            fail_on_not_found=True,
+            fail_on_pass=True,
+        )
+        self.assert_regex(
+            result,
+            pass_regex=[r"--output-format.*conflicts.*"],
+        )


### PR DESCRIPTION
## Motivation

At the moment 3 separate environment variables are used to determine which output format will be produced when running our profiling tools. This PR unifies that by providing a user clear CLI interface option `--output-format` from which he/she can select desired formats.

## Technical Details

- Implemented `--output-format` command line option for selecting between `json, text, rocpd, or perfetto` generated output
- User can apply multiple formats for the single run. 
- Same exclusion rules apply as for the existing env variables
- Documentation is updated accordingly
- The help output references now both newly added option as well as existing env vars

## JIRA ID

AIPROFSYST-534

## Test Plan

- Build to ensure no regression is added
- Run existing unit ant e2e test suites
- Added additional test suit to verify that format selection as well as exclusion is working as expected

## Test Result

- Build finishes without any errors
- Existing unit/e2e tests are passing
- Newly added tests confirm feature is working as expected

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
