### PR TITLE
[rocprofiler-sdk] Fix record_header_buffer save/load payload pointer relocation

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/common/container/record_header_buffer.cpp
+++ b/projects/rocprofiler-sdk/source/lib/common/container/record_header_buffer.cpp
@@ -26,6 +26,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <new>
@@ -186,13 +187,14 @@ record_header_buffer::load(std::fstream& _fs)
     const auto _new_addr = reinterpret_cast<uintptr_t>(m_buffer.data());
     if(_old_base != nullptr && _new_addr != 0 && _new_addr != _old_addr)
     {
-        auto _idx = m_index.load(std::memory_order_acquire);
+        // Use pointer arithmetic (char* + ptrdiff_t) rather than casting an integer back to a
+        // pointer, which avoids the performance-no-int-to-ptr clang-tidy diagnostic.
+        const auto _delta = static_cast<std::ptrdiff_t>(_new_addr - _old_addr);
+        auto       _idx   = m_index.load(std::memory_order_acquire);
         for(size_t i = 0; i < _idx; ++i)
         {
             auto& _hdr = m_headers.at(i);
-            if(_hdr.payload != nullptr)
-                _hdr.payload = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(_hdr.payload) -
-                                                       _old_addr + _new_addr);
+            if(_hdr.payload != nullptr) _hdr.payload = static_cast<char*>(_hdr.payload) + _delta;
         }
     }
 }

--- a/projects/rocprofiler-sdk/source/lib/common/container/record_header_buffer.cpp
+++ b/projects/rocprofiler-sdk/source/lib/common/container/record_header_buffer.cpp
@@ -26,6 +26,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <cstdint>
 #include <cstring>
 #include <new>
 
@@ -143,11 +144,13 @@ record_header_buffer::save(std::fstream& _fs)
 {
     auto _lk = rhb_raii_lock{*this};
 
-    auto _idx = m_index.load(std::memory_order_acquire);
-    auto _sz  = m_headers.size();
+    auto        _idx  = m_index.load(std::memory_order_acquire);
+    auto        _sz   = m_headers.size();
+    const void* _base = m_buffer.data();
     _fs.write(reinterpret_cast<char*>(&_idx), sizeof(_idx));
     _fs.write(reinterpret_cast<char*>(&_sz), sizeof(_sz));
     _fs.write(reinterpret_cast<char*>(m_headers.data()), sizeof(rocprofiler_record_header_t) * _sz);
+    _fs.write(reinterpret_cast<const char*>(&_base), sizeof(_base));
     m_buffer.save(_fs);
 }
 
@@ -170,6 +173,27 @@ record_header_buffer::load(std::fstream& _fs)
                  sizeof(rocprofiler_record_header_t) * _sz);
     }
 
+    // Read the base address that the payload pointers were relative to when saved.
+    const void* _old_base = nullptr;
+    _fs.read(reinterpret_cast<char*>(&_old_base), sizeof(_old_base));
+
     m_buffer.load(_fs);
+
+    // The buffer was just remapped and may now live at a different base address. Relocate
+    // each payload pointer by the difference between the new and old base addresses so the
+    // restored absolute pointers reference the reloaded data instead of the stale mapping.
+    const auto _old_addr = reinterpret_cast<uintptr_t>(_old_base);
+    const auto _new_addr = reinterpret_cast<uintptr_t>(m_buffer.data());
+    if(_old_base != nullptr && _new_addr != 0 && _new_addr != _old_addr)
+    {
+        auto _idx = m_index.load(std::memory_order_acquire);
+        for(size_t i = 0; i < _idx; ++i)
+        {
+            auto& _hdr = m_headers.at(i);
+            if(_hdr.payload != nullptr)
+                _hdr.payload = reinterpret_cast<void*>(
+                    reinterpret_cast<uintptr_t>(_hdr.payload) - _old_addr + _new_addr);
+        }
+    }
 }
 }  // namespace rocprofiler::common::container

--- a/projects/rocprofiler-sdk/source/lib/common/container/record_header_buffer.cpp
+++ b/projects/rocprofiler-sdk/source/lib/common/container/record_header_buffer.cpp
@@ -191,8 +191,8 @@ record_header_buffer::load(std::fstream& _fs)
         {
             auto& _hdr = m_headers.at(i);
             if(_hdr.payload != nullptr)
-                _hdr.payload = reinterpret_cast<void*>(
-                    reinterpret_cast<uintptr_t>(_hdr.payload) - _old_addr + _new_addr);
+                _hdr.payload = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(_hdr.payload) -
+                                                       _old_addr + _new_addr);
         }
     }
 }

--- a/projects/rocprofiler-sdk/source/lib/common/container/ring_buffer.hpp
+++ b/projects/rocprofiler-sdk/source/lib/common/container/ring_buffer.hpp
@@ -65,6 +65,9 @@ struct ring_buffer
     /// Returns whether the buffer has been allocated
     bool is_initialized() const { return m_init; }
 
+    /// Base address of the allocation
+    const void* data() const { return m_ptr; }
+
     /// Get the total number of bytes supported
     size_t capacity() const { return m_size; }
 


### PR DESCRIPTION
## Motivation

`unit.buffering.save_load` intermittently segfaulted in CI. The crash is a real serialization bug, not flakiness: record `payload`s are absolute pointers into an `mmap`'d buffer. `save()` wrote them verbatim; `load()` `munmap`s and re-`mmap`s the buffer, which can return a different base address, leaving the restored `payload` pointers dangling → SIGSEGV on the next dereference. It's intermittent because `munmap`+`mmap` usually reuses the same address on a quiet box (passes locally) but not on busy CI runners.

## Technical Details

- `base::ring_buffer`: add read-only `data()` accessor for the mapping base.
- `record_header_buffer::save()`: persist the buffer base address.
- `record_header_buffer::load()`: after remap, relocate each non-null `payload` by `new_base - old_base` (`uintptr_t` math).

Format gains 8 bytes; `save`/`load` are paired and only used by the buffering unit test. Re-enables `unit.buffering.save_load`.

## JIRA ID

Resolves AIROCVAL-121
285 - unit.buffering.save_load (SEGFAULT)

## Test Plan

cmake --build build --target buffering-tests
ctest -R 'unit\.buffering' --output-on-failure          # functional
ctest --repeat until-fail:25 -R unit.buffering.save_load # stability

## Test Result

ctest -R 'unit\.buffering' → 3/3 passed.
save_load repeated 25× → all passed.
Forced relocation: crashes (SIGSEGV) without the fix, passes with it; passes either way without forcing (address reuse), matching the original "passes locally" behavior.

## Submission Checklist

- [V] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
