### PR TITLE
[rocprofiler-compute] Add native PC sampling collection to the tool library

### DIFF
--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.amd.com/projects/rocprofiler-compute/en/latest/](https://rocm.docs.amd.com/projects/rocprofiler-compute/en/latest/).
 
-
 ## ROCm Compute Profiler 3.7.0 for ROCm 7.14.0
 
 ### Added
+
+* Added native PC sampling collection. rocprof-compute captures stochastic and host-trap PC samples on every supporting GPU agent and writes them to a PID-prefixed ``<pid>_ps_file_results.json``. The source files referenced by the sampled ISA are snapshotted into a ``code_obj_sources/`` directory alongside the results.
 
 * Added ``--bench-only`` profile mode option to run the roofline microbenchmark standalone (without profiling an application or collecting performance counters). No application run is required. Useful for regenerating ``roofline.csv`` in an existing workload directory or running the microbenchmark on systems where only HIP is available but rocprofiler-sdk is not.
 

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/CMakeLists.txt
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/CMakeLists.txt
@@ -12,6 +12,11 @@ add_library(
     code_object_writer.cpp
     file_writer.h
     file_writer.cpp
+    pair_hash.h
+    pc_sample_types.h
+    pc_sample_types.cpp
+    pc_sample_decode.h
+    pc_sample_decode.cpp
     pc_sample_writer.h
     pc_sample_writer.cpp
     source_snapshot.h

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/CMakeLists.txt
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/CMakeLists.txt
@@ -10,6 +10,12 @@ add_library(
     code_object_translator.cpp
     code_object_writer.h
     code_object_writer.cpp
+    file_writer.h
+    file_writer.cpp
+    pc_sample_writer.h
+    pc_sample_writer.cpp
+    source_snapshot.h
+    source_snapshot.cpp
 )
 
 target_include_directories(${target} PUBLIC .)

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/code_object_translator.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/code_object_translator.cpp
@@ -21,6 +21,7 @@ void code_object_translator_impl_t::add_code_object(const char* filepath,
 {
     m_translator->addDecoder(filepath, id, load_addr, mem_size);
     m_obj_id_to_load_addr[id] = load_addr;
+    m_obj_id_to_load_size[id] = mem_size;
     m_obj_ids.push_back(id);
 }
 
@@ -32,6 +33,7 @@ void code_object_translator_impl_t::add_code_object(uint64_t memory_base,
 {
     m_translator->addDecoder(reinterpret_cast<void*>(memory_base), memory_size, id, load_base, load_size);
     m_obj_id_to_load_addr[id] = load_base;
+    m_obj_id_to_load_size[id] = load_size;
     m_obj_ids.push_back(id);
 }
 
@@ -45,6 +47,11 @@ uint64_t code_object_translator_impl_t::get_load_base(size_t object_id) const
     return m_obj_id_to_load_addr.at(object_id);
 }
 
+uint64_t code_object_translator_impl_t::get_load_size(size_t object_id) const
+{
+    return m_obj_id_to_load_size.at(object_id);
+}
+
 std::vector<symbol_t> code_object_translator_impl_t::get_symbols(size_t object_id) const
 {
     Expects(m_obj_id_to_load_addr.find(object_id) != m_obj_id_to_load_addr.end());
@@ -55,8 +62,11 @@ std::vector<symbol_t> code_object_translator_impl_t::get_symbols(size_t object_i
     {
         Expects(virtual_address == symbol_info.vaddr);
         symbol_t sym{};
-        sym.name               = symbol_info.name;
-        sym.code_object_offset = symbol_info.faddr;
+        sym.name = symbol_info.name;
+        // PC samples carry the loaded-basis offset (vaddr - load_base). Key the
+        // symbol on the same basis so analyze joins to it, not the ELF file
+        // offset (faddr), which differs from the loaded layout.
+        sym.code_object_offset = symbol_info.vaddr;
         sym.virtual_address    = symbol_info.vaddr + load_address;
         sym.size               = symbol_info.mem_size;
         symbol_map.push_back(sym);
@@ -66,12 +76,25 @@ std::vector<symbol_t> code_object_translator_impl_t::get_symbols(size_t object_i
 
 instruction_t code_object_translator_impl_t::get_instruction(size_t object_id, uint64_t virtual_address) const
 {
-    const auto& inst = m_translator->get(virtual_address);
-    if (inst)
+    // The underlying COMGR disassembler throws on bytes it cannot decode (e.g.
+    // data/padding inside the loaded range). The full-range walk in write() must
+    // tolerate that: return an empty (size 0) instruction so the caller can skip
+    // and advance rather than aborting serialization.
+    try
     {
-        return {inst->inst, inst->comment, virtual_address, inst->faddr, inst->size};
+        const auto& inst = m_translator->get(virtual_address);
+        if (inst)
+        {
+            // inst->vaddr is the loaded-basis offset (global vaddr - load_base),
+            // which matches a PC sample's code_object_offset. Use it as the join
+            // key rather than inst->faddr (the ELF file offset), so analyze
+            // attributes the right instruction to each sampled PC.
+            return {inst->inst, inst->comment, virtual_address, inst->vaddr, inst->size};
+        }
     }
-    std::clog << "Could not get instruction for object id " << object_id << " at virtual address "
-              << virtual_address << std::endl;
+    catch (const std::exception&)
+    {
+        // fall through to the empty instruction below
+    }
     return {};
 }

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/code_object_translator.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/code_object_translator.cpp
@@ -40,6 +40,11 @@ const std::vector<size_t>& code_object_translator_impl_t::get_code_object_ids() 
     return m_obj_ids;
 }
 
+uint64_t code_object_translator_impl_t::get_load_base(size_t object_id) const
+{
+    return m_obj_id_to_load_addr.at(object_id);
+}
+
 std::vector<symbol_t> code_object_translator_impl_t::get_symbols(size_t object_id) const
 {
     Expects(m_obj_id_to_load_addr.find(object_id) != m_obj_id_to_load_addr.end());

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/code_object_translator.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/code_object_translator.h
@@ -47,6 +47,7 @@ public:
     virtual std::vector<symbol_t>      get_symbols(size_t object_id) const                  = 0;
     virtual instruction_t get_instruction(size_t object_id, uint64_t virtual_address) const = 0;
     virtual uint64_t      get_load_base(size_t object_id) const                             = 0;
+    virtual uint64_t      get_load_size(size_t object_id) const                             = 0;
 };
 
 class code_object_translator_impl_t : public code_object_translator_t
@@ -65,11 +66,13 @@ public:
     std::vector<symbol_t>      get_symbols(size_t object_id) const override;
     instruction_t get_instruction(size_t object_id, uint64_t virtual_address) const override;
     uint64_t      get_load_base(size_t object_id) const override;
+    uint64_t      get_load_size(size_t object_id) const override;
 
 private:
     std::unique_ptr<rocprofiler::sdk::codeobj::disassembly::CodeobjAddressTranslate> m_translator;
     std::vector<size_t>                                                              m_obj_ids;
     std::map<size_t, uint64_t> m_obj_id_to_load_addr;
+    std::map<size_t, uint64_t> m_obj_id_to_load_size;
 };
 
 }  // namespace rocprofiler_compute_tool

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/code_object_translator.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/code_object_translator.h
@@ -46,6 +46,7 @@ public:
     virtual const std::vector<size_t>& get_code_object_ids() const                          = 0;
     virtual std::vector<symbol_t>      get_symbols(size_t object_id) const                  = 0;
     virtual instruction_t get_instruction(size_t object_id, uint64_t virtual_address) const = 0;
+    virtual uint64_t      get_load_base(size_t object_id) const                             = 0;
 };
 
 class code_object_translator_impl_t : public code_object_translator_t
@@ -63,6 +64,7 @@ public:
     const std::vector<size_t>& get_code_object_ids() const override;
     std::vector<symbol_t>      get_symbols(size_t object_id) const override;
     instruction_t get_instruction(size_t object_id, uint64_t virtual_address) const override;
+    uint64_t      get_load_base(size_t object_id) const override;
 
 private:
     std::unique_ptr<rocprofiler::sdk::codeobj::disassembly::CodeobjAddressTranslate> m_translator;

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/code_object_writer.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/code_object_writer.cpp
@@ -2,12 +2,17 @@
 // SPDX-License-Identifier:  MIT
 #include "code_object_writer.h"
 
+#include "file_writer.h"
 #include "gsl_assert.h"
 
-#include <fstream>
 #include <iostream>
 
 using namespace rocprofiler_compute_tool;
+
+std::shared_ptr<code_object_writer_t> code_object_writer_t::create()
+{
+    return std::make_shared<code_object_writer_json_t>();
+}
 
 void code_object_writer_json_t::start_code_obj(size_t obj_id)
 {
@@ -76,28 +81,7 @@ std::string code_object_writer_json_t::get_result()
 
 void code_object_writer_json_t::flush(const std::filesystem::path& output_file_path)
 {
-    Expects(!output_file_path.empty());
-    create_parent_dir(output_file_path);
-
-    std::ofstream out_file(output_file_path, std::ios::out);
-    if (!out_file.is_open())
-    {
-        std::cerr << "Failed to open output file: " << output_file_path << "\n";
-        return;
-    }
-    out_file << get_result();
+    file_writer_t::create()->write(output_file_path, get_result());
     std::clog << "[rocprofiler-compute] [" << __FUNCTION__
               << "] Code object data has been written to: " << output_file_path << "\n";
-}
-
-void code_object_writer_json_t::create_parent_dir(const std::filesystem::path& output_file_path)
-{
-    Expects(output_file_path.has_parent_path());
-    std::error_code error;
-    std::filesystem::create_directories(output_file_path.parent_path(), error);
-    if (error)
-    {
-        throw std::runtime_error("Failed to create output directory: " + output_file_path.string() +
-                                 ", error: " + error.message());
-    }
 }

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/code_object_writer.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/code_object_writer.h
@@ -5,6 +5,7 @@
 #include "nlohmann/json.hpp"
 
 #include <filesystem>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -13,6 +14,8 @@ namespace rocprofiler_compute_tool
 class code_object_writer_t
 {
 public:
+    static std::shared_ptr<code_object_writer_t> create();
+
     virtual ~code_object_writer_t()                                  = default;
     virtual void        start_code_obj(size_t obj_id)                = 0;
     virtual void        end_code_obj()                               = 0;
@@ -35,8 +38,6 @@ public:
     void        flush(const std::filesystem::path& output_file_path) override;
 
 private:
-    static void create_parent_dir(const std::filesystem::path& output_file_path);
-
     int32_t m_code_object_closure_count = 0;
     int32_t m_symbol_closure_count      = 0;
 

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/file_writer.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/file_writer.cpp
@@ -1,0 +1,38 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#include "file_writer.h"
+
+#include "gsl_assert.h"
+
+#include <fstream>
+#include <memory>
+#include <stdexcept>
+
+namespace rocprofiler_compute_tool
+{
+std::shared_ptr<file_writer_t> file_writer_t::create()
+{
+    return std::make_shared<file_writer_json_t>();
+}
+
+void file_writer_json_t::write(const std::filesystem::path& output_file_path, const std::string& contents)
+{
+    Expects(!output_file_path.empty());
+    Expects(output_file_path.has_parent_path());
+
+    std::error_code error;
+    std::filesystem::create_directories(output_file_path.parent_path(), error);
+    if (error)
+    {
+        throw std::runtime_error("Failed to create output directory: " + output_file_path.string() +
+                                 ", error: " + error.message());
+    }
+
+    std::ofstream out_file(output_file_path, std::ios::out);
+    if (!out_file.is_open())
+    {
+        throw std::runtime_error("Failed to open output file: " + output_file_path.string());
+    }
+    out_file << contents;
+}
+}  // namespace rocprofiler_compute_tool

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/file_writer.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/file_writer.h
@@ -1,0 +1,24 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#pragma once
+#include <filesystem>
+#include <memory>
+#include <string>
+
+namespace rocprofiler_compute_tool
+{
+class file_writer_t
+{
+public:
+    static std::shared_ptr<file_writer_t> create();
+
+    virtual ~file_writer_t() = default;
+    virtual void write(const std::filesystem::path& output_file_path, const std::string& contents) = 0;
+};
+
+class file_writer_json_t : public file_writer_t
+{
+public:
+    void write(const std::filesystem::path& output_file_path, const std::string& contents) override;
+};
+}  // namespace rocprofiler_compute_tool

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pair_hash.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pair_hash.h
@@ -1,0 +1,23 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#pragma once
+
+#include <cstddef>
+#include <functional>
+#include <utility>
+
+namespace rocprofiler_compute_tool
+{
+// Generic hash for std::pair, combining the element hashes with the boost-style
+// hash_combine mix. Single-sourced so the magic constant lives in one place.
+struct pair_hash_t
+{
+    template<typename A, typename B>
+    size_t operator()(const std::pair<A, B>& p) const
+    {
+        const size_t h1 = std::hash<A>{}(p.first);
+        const size_t h2 = std::hash<B>{}(p.second);
+        return h1 ^ (h2 + 0x9e3779b97f4a7c15ULL + (h1 << 6) + (h1 >> 2));
+    }
+};
+}  // namespace rocprofiler_compute_tool

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sample_decode.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sample_decode.cpp
@@ -1,0 +1,142 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#ifndef ROCPROFILER_SDK_EXPERIMENTAL
+#    define ROCPROFILER_SDK_EXPERIMENTAL
+#endif
+
+#include "pc_sample_decode.h"
+
+#include <rocprofiler-sdk/buffer_tracing.h>
+#include <rocprofiler-sdk/fwd.h>
+#include <rocprofiler-sdk/pc_sampling.h>
+
+using namespace rocprofiler_compute_tool;
+
+namespace
+{
+pc_sample_hw_id_t map_hw_id(const rocprofiler_pc_sampling_hw_id_v0_t& hw)
+{
+    pc_sample_hw_id_t out{};
+    out.chiplet          = hw.chiplet;
+    out.wave_id          = hw.wave_id;
+    out.simd_id          = hw.simd_id;
+    out.pipe_id          = hw.pipe_id;
+    out.cu_or_wgp_id     = hw.cu_or_wgp_id;
+    out.shader_array_id  = hw.shader_array_id;
+    out.shader_engine_id = hw.shader_engine_id;
+    out.workgroup_id     = hw.workgroup_id;
+    out.vm_id            = hw.vm_id;
+    out.queue_id         = hw.queue_id;
+    out.microengine_id   = hw.microengine_id;
+    return out;
+}
+
+pc_sample_pc_t map_pc(const rocprofiler_pc_t& pc)
+{
+    pc_sample_pc_t out{};
+    out.code_object_id     = pc.code_object_id;
+    out.code_object_offset = pc.code_object_offset;
+    return out;
+}
+
+pc_sample_dim3_t map_dim3(const rocprofiler_dim3_t& d)
+{
+    pc_sample_dim3_t out{};
+    out.x = d.x;
+    out.y = d.y;
+    out.z = d.z;
+    return out;
+}
+
+// Templated because both SDK record structs expose these members by the same names.
+template<typename RecT>
+void map_common_fields(pc_sample_record_t& out, const RecT& rec)
+{
+    out.hw_id            = map_hw_id(rec.hw_id);
+    out.pc               = map_pc(rec.pc);
+    out.exec_mask        = rec.exec_mask;
+    out.timestamp        = rec.timestamp;
+    out.dispatch_id      = rec.dispatch_id;
+    out.corr_id.internal = rec.correlation_id.internal;
+    out.corr_id.external = rec.correlation_id.external.value;
+    out.wrkgrp_id        = map_dim3(rec.workgroup_id);
+    out.wave_in_grp      = rec.wave_in_group;
+}
+}  // namespace
+
+std::optional<pc_sample_record_t> rocprofiler_compute_tool::decode_pc_sample_record(
+    const rocprofiler_record_header_t& header)
+{
+    if (header.category != ROCPROFILER_BUFFER_CATEGORY_PC_SAMPLING)
+        return std::nullopt;
+
+    if (header.kind == ROCPROFILER_PC_SAMPLING_RECORD_STOCHASTIC_V0_SAMPLE)
+    {
+        const auto& rec = *reinterpret_cast<const rocprofiler_pc_sampling_record_stochastic_v0_t*>(
+            header.payload);
+
+        pc_sample_record_t out{};
+        out.kind = pc_sample_kind_t::Stochastic;
+        map_common_fields(out, rec);
+        out.flags.has_mem_cnt = rec.flags.has_memory_counter;
+        out.wave_issued       = rec.wave_issued;
+        out.inst_type         = rec.inst_type;
+        out.wave_cnt          = rec.wave_count;
+
+        out.snapshot.stall_reason = rec.snapshot.reason_not_issued;
+        // Copy the plain uint32 fields from the single-sourced field list.
+#define PC_SAMPLE_SNAPSHOT_COPY(field) out.snapshot.field = rec.snapshot.field;
+        PC_SAMPLE_SNAPSHOT_PLAIN_FIELDS(PC_SAMPLE_SNAPSHOT_COPY)
+#undef PC_SAMPLE_SNAPSHOT_COPY
+
+        return out;
+    }
+
+    if (header.kind == ROCPROFILER_PC_SAMPLING_RECORD_HOST_TRAP_V0_SAMPLE)
+    {
+        const auto& rec = *reinterpret_cast<const rocprofiler_pc_sampling_record_host_trap_v0_t*>(
+            header.payload);
+
+        pc_sample_record_t out{};
+        out.kind = pc_sample_kind_t::HostTrap;
+        map_common_fields(out, rec);
+
+        return out;
+    }
+
+    return std::nullopt;
+}
+
+std::optional<kernel_dispatch_record_t> rocprofiler_compute_tool::decode_kernel_dispatch_record(
+    const rocprofiler_record_header_t& header)
+{
+    if (header.category != ROCPROFILER_BUFFER_CATEGORY_TRACING ||
+        header.kind != ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH)
+        return std::nullopt;
+
+    const auto& rec = *reinterpret_cast<const rocprofiler_buffer_tracing_kernel_dispatch_record_t*>(
+        header.payload);
+    const auto& di = rec.dispatch_info;
+
+    kernel_dispatch_record_t out{};
+    out.size            = rec.size;
+    out.kind            = rec.kind;
+    out.operation       = rec.operation;
+    out.thread_id       = rec.thread_id;
+    out.corr_internal   = rec.correlation_id.internal;
+    out.corr_external   = rec.correlation_id.external.value;
+    out.start_timestamp = rec.start_timestamp;
+    out.end_timestamp   = rec.end_timestamp;
+
+    out.dispatch_info_size   = di.size;
+    out.agent_id_handle      = di.agent_id.handle;
+    out.queue_id_handle      = di.queue_id.handle;
+    out.kernel_id            = di.kernel_id;
+    out.dispatch_id          = di.dispatch_id;
+    out.private_segment_size = di.private_segment_size;
+    out.group_segment_size   = di.group_segment_size;
+    out.workgroup_size       = map_dim3(di.workgroup_size);
+    out.grid_size            = map_dim3(di.grid_size);
+
+    return out;
+}

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sample_decode.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sample_decode.h
@@ -1,0 +1,24 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#pragma once
+
+#ifndef ROCPROFILER_SDK_EXPERIMENTAL
+#    define ROCPROFILER_SDK_EXPERIMENTAL
+#endif
+
+#include "pc_sample_types.h"
+
+#include <rocprofiler-sdk/fwd.h>
+
+#include <optional>
+
+namespace rocprofiler_compute_tool
+{
+// Returns std::nullopt when header.category != ROCPROFILER_BUFFER_CATEGORY_PC_SAMPLING
+// or header.kind is not one of the two supported PC sampling record kinds.
+std::optional<pc_sample_record_t> decode_pc_sample_record(const rocprofiler_record_header_t& header);
+
+// Returns std::nullopt when header.category != ROCPROFILER_BUFFER_CATEGORY_TRACING
+// or header.kind != ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH.
+std::optional<kernel_dispatch_record_t> decode_kernel_dispatch_record(const rocprofiler_record_header_t& header);
+}  // namespace rocprofiler_compute_tool

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sample_types.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sample_types.cpp
@@ -1,0 +1,33 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#include "pc_sample_types.h"
+
+#include <utility>
+
+using namespace rocprofiler_compute_tool;
+
+size_t pc_string_table_t::insert(const std::string& instruction_text, const std::string& comment)
+{
+    // Look up via views over the caller's strings so a cache hit copies nothing.
+    if (const auto it = m_index.find(
+            std::make_pair(std::string_view{instruction_text}, std::string_view{comment}));
+        it != m_index.end())
+        return it->second;
+
+    const size_t idx = m_instructions.size();
+    // deque element addresses are stable, so the views stored below stay valid.
+    const std::string& stored_text    = m_instructions.emplace_back(instruction_text);
+    const std::string& stored_comment = m_comments.emplace_back(comment);
+    m_index.emplace(std::make_pair(std::string_view{stored_text}, std::string_view{stored_comment}), idx);
+    return idx;
+}
+
+const std::deque<std::string>& pc_string_table_t::instructions() const
+{
+    return m_instructions;
+}
+
+const std::deque<std::string>& pc_string_table_t::comments() const
+{
+    return m_comments;
+}

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sample_types.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sample_types.h
@@ -62,27 +62,27 @@ struct pc_sample_dim3_t
 // special handling on both the decode and serialize sides). Single-sourced here
 // so the struct definition, the SDK->struct copy in decode, and the JSON emit are
 // all driven from one list; adding/renaming a field is a one-line edit.
-#define PC_SAMPLE_SNAPSHOT_PLAIN_FIELDS(X)                                                          \
-    X(dual_issue_valu)                                                                              \
-    X(arb_state_issue_valu)                                                                         \
-    X(arb_state_issue_matrix)                                                                       \
-    X(arb_state_issue_lds)                                                                          \
-    X(arb_state_issue_lds_direct)                                                                   \
-    X(arb_state_issue_scalar)                                                                       \
-    X(arb_state_issue_vmem_tex)                                                                     \
-    X(arb_state_issue_flat)                                                                         \
-    X(arb_state_issue_exp)                                                                          \
-    X(arb_state_issue_misc)                                                                         \
-    X(arb_state_issue_brmsg)                                                                        \
-    X(arb_state_stall_valu)                                                                         \
-    X(arb_state_stall_matrix)                                                                       \
-    X(arb_state_stall_lds)                                                                          \
-    X(arb_state_stall_lds_direct)                                                                   \
-    X(arb_state_stall_scalar)                                                                       \
-    X(arb_state_stall_vmem_tex)                                                                     \
-    X(arb_state_stall_flat)                                                                         \
-    X(arb_state_stall_exp)                                                                          \
-    X(arb_state_stall_misc)                                                                         \
+#define PC_SAMPLE_SNAPSHOT_PLAIN_FIELDS(X) \
+    X(dual_issue_valu)                     \
+    X(arb_state_issue_valu)                \
+    X(arb_state_issue_matrix)              \
+    X(arb_state_issue_lds)                 \
+    X(arb_state_issue_lds_direct)          \
+    X(arb_state_issue_scalar)              \
+    X(arb_state_issue_vmem_tex)            \
+    X(arb_state_issue_flat)                \
+    X(arb_state_issue_exp)                 \
+    X(arb_state_issue_misc)                \
+    X(arb_state_issue_brmsg)               \
+    X(arb_state_stall_valu)                \
+    X(arb_state_stall_matrix)              \
+    X(arb_state_stall_lds)                 \
+    X(arb_state_stall_lds_direct)          \
+    X(arb_state_stall_scalar)              \
+    X(arb_state_stall_vmem_tex)            \
+    X(arb_state_stall_flat)                \
+    X(arb_state_stall_exp)                 \
+    X(arb_state_stall_misc)                \
     X(arb_state_stall_brmsg)
 
 struct pc_sample_snapshot_t

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sample_types.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sample_types.h
@@ -1,0 +1,171 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#pragma once
+
+#include "pair_hash.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace rocprofiler_compute_tool
+{
+enum class pc_sample_kind_t : uint8_t
+{
+    Stochastic,
+    HostTrap
+};
+
+struct pc_sample_flags_t
+{
+    uint32_t has_mem_cnt = 0;
+};
+
+struct pc_sample_hw_id_t
+{
+    uint64_t chiplet          = 0;
+    uint64_t wave_id          = 0;
+    uint64_t simd_id          = 0;
+    uint64_t pipe_id          = 0;
+    uint64_t cu_or_wgp_id     = 0;
+    uint64_t shader_array_id  = 0;
+    uint64_t shader_engine_id = 0;
+    uint64_t workgroup_id     = 0;
+    uint64_t vm_id            = 0;
+    uint64_t queue_id         = 0;
+    uint64_t microengine_id   = 0;
+};
+
+struct pc_sample_pc_t
+{
+    uint64_t code_object_id     = 0;
+    uint64_t code_object_offset = 0;
+};
+
+struct pc_sample_correlation_t
+{
+    uint64_t internal = 0;
+    uint64_t external = 0;
+};
+
+struct pc_sample_dim3_t
+{
+    uint64_t x = 0, y = 0, z = 0;
+};
+
+// The plain uint32 snapshot fields (every field except stall_reason, which needs
+// special handling on both the decode and serialize sides). Single-sourced here
+// so the struct definition, the SDK->struct copy in decode, and the JSON emit are
+// all driven from one list; adding/renaming a field is a one-line edit.
+#define PC_SAMPLE_SNAPSHOT_PLAIN_FIELDS(X)                                                          \
+    X(dual_issue_valu)                                                                              \
+    X(arb_state_issue_valu)                                                                         \
+    X(arb_state_issue_matrix)                                                                       \
+    X(arb_state_issue_lds)                                                                          \
+    X(arb_state_issue_lds_direct)                                                                   \
+    X(arb_state_issue_scalar)                                                                       \
+    X(arb_state_issue_vmem_tex)                                                                     \
+    X(arb_state_issue_flat)                                                                         \
+    X(arb_state_issue_exp)                                                                          \
+    X(arb_state_issue_misc)                                                                         \
+    X(arb_state_issue_brmsg)                                                                        \
+    X(arb_state_stall_valu)                                                                         \
+    X(arb_state_stall_matrix)                                                                       \
+    X(arb_state_stall_lds)                                                                          \
+    X(arb_state_stall_lds_direct)                                                                   \
+    X(arb_state_stall_scalar)                                                                       \
+    X(arb_state_stall_vmem_tex)                                                                     \
+    X(arb_state_stall_flat)                                                                         \
+    X(arb_state_stall_exp)                                                                          \
+    X(arb_state_stall_misc)                                                                         \
+    X(arb_state_stall_brmsg)
+
+struct pc_sample_snapshot_t
+{
+    uint32_t stall_reason = 0;  // raw SDK not-issued-reason enum; name resolved at serialization
+#define PC_SAMPLE_SNAPSHOT_DECLARE(field) uint32_t field = 0;
+    PC_SAMPLE_SNAPSHOT_PLAIN_FIELDS(PC_SAMPLE_SNAPSHOT_DECLARE)
+#undef PC_SAMPLE_SNAPSHOT_DECLARE
+};
+
+struct pc_sample_record_t
+{
+    pc_sample_kind_t        kind = pc_sample_kind_t::HostTrap;
+    pc_sample_flags_t       flags{};
+    pc_sample_hw_id_t       hw_id{};
+    pc_sample_pc_t          pc{};
+    uint64_t                exec_mask = 0, timestamp = 0, dispatch_id = 0;
+    pc_sample_correlation_t corr_id{};
+    pc_sample_dim3_t        wrkgrp_id{};
+    uint32_t                wave_in_grp = 0;
+    uint32_t                wave_issued = 0;
+    uint32_t inst_type = 0;  // raw SDK instruction-type enum; name resolved at serialization
+    uint32_t wave_cnt  = 0;
+    pc_sample_snapshot_t snapshot{};
+};
+
+struct kernel_symbol_entry_t
+{
+    uint64_t    code_object_id = 0;
+    std::string formatted_kernel_name{};
+    uint64_t    kernel_id = 0;
+};
+
+// Minimal agent record; the consumer builds its GPU-id map from GPU-type agents
+// sorted by node_id.
+struct agent_record_t
+{
+    uint64_t size            = 0;  // sizeof the SDK agent struct (for SDK-shape parity)
+    uint64_t id_handle       = 0;
+    uint32_t type            = 0;  // raw rocprofiler_agent_type_t value
+    uint32_t node_id         = 0;
+    int32_t  logical_node_id = 0;
+    uint32_t cu_count        = 0;
+    uint64_t gpu_id          = 0;  // KFD identifier (GPU only)
+    uint32_t wave_front_size = 0;
+    uint32_t simd_count      = 0;
+};
+
+struct kernel_dispatch_record_t
+{
+    uint64_t size            = 0;
+    uint32_t kind            = 0;  // raw rocprofiler_buffer_tracing_kind_t value
+    uint32_t operation       = 0;
+    uint64_t thread_id       = 0;
+    uint64_t corr_internal   = 0;
+    uint64_t corr_external   = 0;
+    uint64_t start_timestamp = 0;
+    uint64_t end_timestamp   = 0;
+
+    uint64_t         dispatch_info_size   = 0;
+    uint64_t         agent_id_handle      = 0;
+    uint64_t         queue_id_handle      = 0;
+    uint64_t         kernel_id            = 0;
+    uint64_t         dispatch_id          = 0;
+    uint32_t         private_segment_size = 0;
+    uint32_t         group_segment_size   = 0;
+    pc_sample_dim3_t workgroup_size{};
+    pc_sample_dim3_t grid_size{};
+};
+
+class pc_string_table_t
+{
+public:
+    // Dedups by (instruction_text, comment); returns the shared index (position in BOTH arrays).
+    size_t insert(const std::string& instruction_text, const std::string& comment);
+    const std::deque<std::string>& instructions() const;
+    const std::deque<std::string>& comments() const;
+
+private:
+    // Canonical strings live in deques (stable addresses); m_index keys on views
+    // into them, so a cache hit allocates nothing.
+    std::deque<std::string> m_instructions;
+    std::deque<std::string> m_comments;
+    std::unordered_map<std::pair<std::string_view, std::string_view>, size_t, pair_hash_t> m_index;
+};
+}  // namespace rocprofiler_compute_tool

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sample_writer.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sample_writer.cpp
@@ -1,0 +1,488 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#ifndef ROCPROFILER_SDK_EXPERIMENTAL
+#    define ROCPROFILER_SDK_EXPERIMENTAL
+#endif
+
+#include "pc_sample_writer.h"
+
+#include "file_writer.h"
+#include "gsl_assert.h"
+#include "nlohmann/json.hpp"
+
+#include <rocprofiler-sdk/buffer_tracing.h>
+#include <rocprofiler-sdk/fwd.h>
+#include <rocprofiler-sdk/pc_sampling.h>
+
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+
+using namespace rocprofiler_compute_tool;
+
+namespace
+{
+std::string instruction_type_name(uint32_t inst_type)
+{
+    const char* name = rocprofiler_get_pc_sampling_instruction_type_name(
+        static_cast<rocprofiler_pc_sampling_instruction_type_t>(inst_type));
+    return name != nullptr ? std::string{name} : std::string{};
+}
+
+std::string not_issued_reason_name(uint32_t reason)
+{
+    const char* name = rocprofiler_get_pc_sampling_instruction_not_issued_reason_name(
+        static_cast<rocprofiler_pc_sampling_instruction_not_issued_reason_t>(reason));
+    return name != nullptr ? std::string{name} : std::string{};
+}
+
+pc_sample_hw_id_t map_hw_id(const rocprofiler_pc_sampling_hw_id_v0_t& hw)
+{
+    pc_sample_hw_id_t out{};
+    out.chiplet          = hw.chiplet;
+    out.wave_id          = hw.wave_id;
+    out.simd_id          = hw.simd_id;
+    out.pipe_id          = hw.pipe_id;
+    out.cu_or_wgp_id     = hw.cu_or_wgp_id;
+    out.shader_array_id  = hw.shader_array_id;
+    out.shader_engine_id = hw.shader_engine_id;
+    out.workgroup_id     = hw.workgroup_id;
+    out.vm_id            = hw.vm_id;
+    out.queue_id         = hw.queue_id;
+    out.microengine_id   = hw.microengine_id;
+    return out;
+}
+
+pc_sample_pc_t map_pc(const rocprofiler_pc_t& pc)
+{
+    pc_sample_pc_t out{};
+    out.code_object_id     = pc.code_object_id;
+    out.code_object_offset = pc.code_object_offset;
+    return out;
+}
+
+pc_sample_dim3_t map_dim3(const rocprofiler_dim3_t& d)
+{
+    pc_sample_dim3_t out{};
+    out.x = d.x;
+    out.y = d.y;
+    out.z = d.z;
+    return out;
+}
+
+nlohmann::json hw_id_to_json(const pc_sample_hw_id_t& hw)
+{
+    return nlohmann::json::object({
+        {"chiplet", hw.chiplet},
+        {"wave_id", hw.wave_id},
+        {"simd_id", hw.simd_id},
+        {"pipe_id", hw.pipe_id},
+        {"cu_or_wgp_id", hw.cu_or_wgp_id},
+        {"shader_array_id", hw.shader_array_id},
+        {"shader_engine_id", hw.shader_engine_id},
+        {"workgroup_id", hw.workgroup_id},
+        {"vm_id", hw.vm_id},
+        {"queue_id", hw.queue_id},
+        {"microengine_id", hw.microengine_id},
+    });
+}
+
+nlohmann::json pc_to_json(const pc_sample_pc_t& pc)
+{
+    return nlohmann::json::object({
+        {"code_object_id", pc.code_object_id},
+        {"code_object_offset", pc.code_object_offset},
+    });
+}
+
+nlohmann::json corr_to_json(const pc_sample_correlation_t& corr)
+{
+    return nlohmann::json::object({
+        {"internal", corr.internal},
+        {"external", corr.external},
+    });
+}
+
+nlohmann::json dim3_to_json(const pc_sample_dim3_t& d)
+{
+    return nlohmann::json::object({
+        {"x", d.x},
+        {"y", d.y},
+        {"z", d.z},
+    });
+}
+
+nlohmann::json snapshot_to_json(const pc_sample_snapshot_t& s)
+{
+    return nlohmann::json::object({
+        {"stall_reason", not_issued_reason_name(s.stall_reason)},
+        {"dual_issue_valu", s.dual_issue_valu},
+        {"arb_state_issue_valu", s.arb_state_issue_valu},
+        {"arb_state_issue_matrix", s.arb_state_issue_matrix},
+        {"arb_state_issue_lds", s.arb_state_issue_lds},
+        {"arb_state_issue_lds_direct", s.arb_state_issue_lds_direct},
+        {"arb_state_issue_scalar", s.arb_state_issue_scalar},
+        {"arb_state_issue_vmem_tex", s.arb_state_issue_vmem_tex},
+        {"arb_state_issue_flat", s.arb_state_issue_flat},
+        {"arb_state_issue_exp", s.arb_state_issue_exp},
+        {"arb_state_issue_misc", s.arb_state_issue_misc},
+        {"arb_state_issue_brmsg", s.arb_state_issue_brmsg},
+        {"arb_state_stall_valu", s.arb_state_stall_valu},
+        {"arb_state_stall_matrix", s.arb_state_stall_matrix},
+        {"arb_state_stall_lds", s.arb_state_stall_lds},
+        {"arb_state_stall_lds_direct", s.arb_state_stall_lds_direct},
+        {"arb_state_stall_scalar", s.arb_state_stall_scalar},
+        {"arb_state_stall_vmem_tex", s.arb_state_stall_vmem_tex},
+        {"arb_state_stall_flat", s.arb_state_stall_flat},
+        {"arb_state_stall_exp", s.arb_state_stall_exp},
+        {"arb_state_stall_misc", s.arb_state_stall_misc},
+        {"arb_state_stall_brmsg", s.arb_state_stall_brmsg},
+    });
+}
+
+// Host-trap samples emit exactly these fields; stochastic adds more on top.
+nlohmann::json common_record_to_json(const pc_sample_record_t& r)
+{
+    return nlohmann::json::object({
+        {"hw_id", hw_id_to_json(r.hw_id)},
+        {"pc", pc_to_json(r.pc)},
+        {"exec_mask", r.exec_mask},
+        {"timestamp", r.timestamp},
+        {"dispatch_id", r.dispatch_id},
+        {"corr_id", corr_to_json(r.corr_id)},
+        {"wrkgrp_id", dim3_to_json(r.wrkgrp_id)},
+        {"wave_in_grp", r.wave_in_grp},
+    });
+}
+
+nlohmann::json stochastic_record_to_json(const pc_sample_record_t& r)
+{
+    auto out           = common_record_to_json(r);
+    out["flags"]       = nlohmann::json::object({{"has_mem_cnt", r.flags.has_mem_cnt}});
+    out["wave_issued"] = r.wave_issued;
+    out["inst_type"]   = instruction_type_name(r.inst_type);
+    out["wave_cnt"]    = r.wave_cnt;
+    out["snapshot"]    = snapshot_to_json(r.snapshot);
+    return out;
+}
+}  // namespace
+
+size_t pc_string_table_t::insert(const std::string& instruction_text, const std::string& comment)
+{
+    // Look up via views over the caller's strings so a cache hit copies nothing.
+    if (const auto it = m_index.find(
+            std::make_pair(std::string_view{instruction_text}, std::string_view{comment}));
+        it != m_index.end())
+        return it->second;
+
+    const size_t idx = m_instructions.size();
+    // deque element addresses are stable, so the views stored below stay valid.
+    const std::string& stored_text    = m_instructions.emplace_back(instruction_text);
+    const std::string& stored_comment = m_comments.emplace_back(comment);
+    m_index.emplace(std::make_pair(std::string_view{stored_text}, std::string_view{stored_comment}), idx);
+    return idx;
+}
+
+const std::deque<std::string>& pc_string_table_t::instructions() const
+{
+    return m_instructions;
+}
+
+const std::deque<std::string>& pc_string_table_t::comments() const
+{
+    return m_comments;
+}
+
+namespace
+{
+// Templated because both SDK record structs expose these members by the same names.
+template<typename RecT>
+void map_common_fields(pc_sample_record_t& out, const RecT& rec)
+{
+    out.hw_id            = map_hw_id(rec.hw_id);
+    out.pc               = map_pc(rec.pc);
+    out.exec_mask        = rec.exec_mask;
+    out.timestamp        = rec.timestamp;
+    out.dispatch_id      = rec.dispatch_id;
+    out.corr_id.internal = rec.correlation_id.internal;
+    out.corr_id.external = rec.correlation_id.external.value;
+    out.wrkgrp_id        = map_dim3(rec.workgroup_id);
+    out.wave_in_grp      = rec.wave_in_group;
+}
+}  // namespace
+
+std::optional<pc_sample_record_t> rocprofiler_compute_tool::decode_pc_sample_record(
+    const rocprofiler_record_header_t& header)
+{
+    if (header.category != ROCPROFILER_BUFFER_CATEGORY_PC_SAMPLING)
+        return std::nullopt;
+
+    if (header.kind == ROCPROFILER_PC_SAMPLING_RECORD_STOCHASTIC_V0_SAMPLE)
+    {
+        const auto& rec = *reinterpret_cast<const rocprofiler_pc_sampling_record_stochastic_v0_t*>(
+            header.payload);
+
+        pc_sample_record_t out{};
+        out.kind = pc_sample_kind_t::Stochastic;
+        map_common_fields(out, rec);
+        out.flags.has_mem_cnt = rec.flags.has_memory_counter;
+        out.wave_issued       = rec.wave_issued;
+        out.inst_type         = rec.inst_type;
+        out.wave_cnt          = rec.wave_count;
+
+        out.snapshot.stall_reason               = rec.snapshot.reason_not_issued;
+        out.snapshot.dual_issue_valu            = rec.snapshot.dual_issue_valu;
+        out.snapshot.arb_state_issue_valu       = rec.snapshot.arb_state_issue_valu;
+        out.snapshot.arb_state_issue_matrix     = rec.snapshot.arb_state_issue_matrix;
+        out.snapshot.arb_state_issue_lds        = rec.snapshot.arb_state_issue_lds;
+        out.snapshot.arb_state_issue_lds_direct = rec.snapshot.arb_state_issue_lds_direct;
+        out.snapshot.arb_state_issue_scalar     = rec.snapshot.arb_state_issue_scalar;
+        out.snapshot.arb_state_issue_vmem_tex   = rec.snapshot.arb_state_issue_vmem_tex;
+        out.snapshot.arb_state_issue_flat       = rec.snapshot.arb_state_issue_flat;
+        out.snapshot.arb_state_issue_exp        = rec.snapshot.arb_state_issue_exp;
+        out.snapshot.arb_state_issue_misc       = rec.snapshot.arb_state_issue_misc;
+        out.snapshot.arb_state_issue_brmsg      = rec.snapshot.arb_state_issue_brmsg;
+        out.snapshot.arb_state_stall_valu       = rec.snapshot.arb_state_stall_valu;
+        out.snapshot.arb_state_stall_matrix     = rec.snapshot.arb_state_stall_matrix;
+        out.snapshot.arb_state_stall_lds        = rec.snapshot.arb_state_stall_lds;
+        out.snapshot.arb_state_stall_lds_direct = rec.snapshot.arb_state_stall_lds_direct;
+        out.snapshot.arb_state_stall_scalar     = rec.snapshot.arb_state_stall_scalar;
+        out.snapshot.arb_state_stall_vmem_tex   = rec.snapshot.arb_state_stall_vmem_tex;
+        out.snapshot.arb_state_stall_flat       = rec.snapshot.arb_state_stall_flat;
+        out.snapshot.arb_state_stall_exp        = rec.snapshot.arb_state_stall_exp;
+        out.snapshot.arb_state_stall_misc       = rec.snapshot.arb_state_stall_misc;
+        out.snapshot.arb_state_stall_brmsg      = rec.snapshot.arb_state_stall_brmsg;
+
+        return out;
+    }
+
+    if (header.kind == ROCPROFILER_PC_SAMPLING_RECORD_HOST_TRAP_V0_SAMPLE)
+    {
+        const auto& rec = *reinterpret_cast<const rocprofiler_pc_sampling_record_host_trap_v0_t*>(
+            header.payload);
+
+        pc_sample_record_t out{};
+        out.kind = pc_sample_kind_t::HostTrap;
+        map_common_fields(out, rec);
+
+        return out;
+    }
+
+    return std::nullopt;
+}
+
+std::optional<kernel_dispatch_record_t> rocprofiler_compute_tool::decode_kernel_dispatch_record(
+    const rocprofiler_record_header_t& header)
+{
+    if (header.category != ROCPROFILER_BUFFER_CATEGORY_TRACING ||
+        header.kind != ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH)
+        return std::nullopt;
+
+    const auto& rec = *reinterpret_cast<const rocprofiler_buffer_tracing_kernel_dispatch_record_t*>(
+        header.payload);
+    const auto& di = rec.dispatch_info;
+
+    kernel_dispatch_record_t out{};
+    out.size            = rec.size;
+    out.kind            = rec.kind;
+    out.operation       = rec.operation;
+    out.thread_id       = rec.thread_id;
+    out.corr_internal   = rec.correlation_id.internal;
+    out.corr_external   = rec.correlation_id.external.value;
+    out.start_timestamp = rec.start_timestamp;
+    out.end_timestamp   = rec.end_timestamp;
+
+    out.dispatch_info_size   = di.size;
+    out.agent_id_handle      = di.agent_id.handle;
+    out.queue_id_handle      = di.queue_id.handle;
+    out.kernel_id            = di.kernel_id;
+    out.dispatch_id          = di.dispatch_id;
+    out.private_segment_size = di.private_segment_size;
+    out.group_segment_size   = di.group_segment_size;
+    out.workgroup_size       = map_dim3(di.workgroup_size);
+    out.grid_size            = map_dim3(di.grid_size);
+
+    return out;
+}
+
+std::shared_ptr<pc_sample_writer_t> pc_sample_writer_t::create()
+{
+    return std::make_shared<pc_sample_writer_json_t>();
+}
+
+void pc_sample_writer_json_t::begin()
+{
+    m_pid = 0;
+    m_stochastic.clear();
+    m_host_trap.clear();
+    m_instructions.clear();
+    m_comments.clear();
+    m_kernel_symbols.clear();
+    m_agents.clear();
+    m_kernel_dispatches.clear();
+}
+
+void pc_sample_writer_json_t::append_stochastic(const pc_sample_record_t& r, size_t inst_index)
+{
+    m_stochastic.push_back(r);
+    m_stochastic.back().inst_index = inst_index;
+}
+
+void pc_sample_writer_json_t::append_host_trap(const pc_sample_record_t& r, size_t inst_index)
+{
+    m_host_trap.push_back(r);
+    m_host_trap.back().inst_index = inst_index;
+}
+
+void pc_sample_writer_json_t::set_strings(const pc_string_table_t& table)
+{
+    const auto& instructions = table.instructions();
+    const auto& comments     = table.comments();
+    m_instructions.assign(instructions.begin(), instructions.end());
+    m_comments.assign(comments.begin(), comments.end());
+}
+
+void pc_sample_writer_json_t::set_kernel_symbols(const std::vector<kernel_symbol_entry_t>& syms)
+{
+    m_kernel_symbols = syms;
+}
+
+void pc_sample_writer_json_t::set_agents(const std::vector<agent_record_t>& agents)
+{
+    m_agents = agents;
+}
+
+void pc_sample_writer_json_t::set_kernel_dispatches(const std::vector<kernel_dispatch_record_t>& dispatches)
+{
+    m_kernel_dispatches = dispatches;
+}
+
+void pc_sample_writer_json_t::set_metadata(int pid)
+{
+    m_pid = pid;
+}
+
+std::string pc_sample_writer_json_t::get_result()
+{
+    auto stochastic_records = nlohmann::json::array();
+    for (const auto& r : m_stochastic)
+    {
+        stochastic_records.push_back(nlohmann::json::object({
+            {"record", stochastic_record_to_json(r)},
+            {"inst_index", r.inst_index},
+        }));
+    }
+
+    auto host_trap_records = nlohmann::json::array();
+    for (const auto& r : m_host_trap)
+    {
+        host_trap_records.push_back(nlohmann::json::object({
+            {"record", common_record_to_json(r)},
+            {"inst_index", r.inst_index},
+        }));
+    }
+
+    auto kernel_symbols = nlohmann::json::array();
+    for (const auto& s : m_kernel_symbols)
+    {
+        kernel_symbols.push_back(nlohmann::json::object({
+            {"code_object_id", s.code_object_id},
+            {"formatted_kernel_name", s.formatted_kernel_name},
+            {"kernel_id", s.kernel_id},
+        }));
+    }
+
+    auto agents = nlohmann::json::array();
+    for (const auto& a : m_agents)
+    {
+        agents.push_back(nlohmann::json::object({
+            {"size", a.size},
+            {"id", nlohmann::json::object({{"handle", a.id_handle}})},
+            {"type", a.type},
+            {"node_id", a.node_id},
+            {"logical_node_id", a.logical_node_id},
+            {"cu_count", a.cu_count},
+            {"gpu_id", a.gpu_id},
+            {"wave_front_size", a.wave_front_size},
+            {"simd_count", a.simd_count},
+        }));
+    }
+
+    auto kernel_dispatch = nlohmann::json::array();
+    for (const auto& d : m_kernel_dispatches)
+    {
+        kernel_dispatch.push_back(nlohmann::json::object({
+            {"size", d.size},
+            {"kind", d.kind},
+            {"operation", d.operation},
+            {"thread_id", d.thread_id},
+            {"correlation_id",
+             nlohmann::json::object({
+                 {"internal", d.corr_internal},
+                 {"external", d.corr_external},
+             })},
+            {"start_timestamp", d.start_timestamp},
+            {"end_timestamp", d.end_timestamp},
+            {"dispatch_info",
+             nlohmann::json::object({
+                 {"size", d.dispatch_info_size},
+                 {"agent_id", nlohmann::json::object({{"handle", d.agent_id_handle}})},
+                 {"queue_id", nlohmann::json::object({{"handle", d.queue_id_handle}})},
+                 {"kernel_id", d.kernel_id},
+                 {"dispatch_id", d.dispatch_id},
+                 {"private_segment_size", d.private_segment_size},
+                 {"group_segment_size", d.group_segment_size},
+                 {"workgroup_size", dim3_to_json(d.workgroup_size)},
+                 {"grid_size", dim3_to_json(d.grid_size)},
+             })},
+        }));
+    }
+
+    auto entry = nlohmann::json::object({
+        {"metadata", nlohmann::json::object({{"pid", m_pid}})},
+        {"agents", std::move(agents)},
+        {"counters", nlohmann::json::array()},
+        {"summary", nlohmann::json::array()},
+        {"host_functions", nlohmann::json::array()},
+        {"callback_records", nlohmann::json::object()},
+        {"code_objects", nlohmann::json::array()},
+        {"kernel_symbols", std::move(kernel_symbols)},
+        {"strings",
+         nlohmann::json::object({
+             {"pc_sample_instructions", m_instructions},
+             {"pc_sample_comments", m_comments},
+             {"code_object_snapshot_filenames", nlohmann::json::array()},
+             {"att_filenames", nlohmann::json::array()},
+         })},
+        {"buffer_records",
+         nlohmann::json::object({
+             {"pc_sample_stochastic", std::move(stochastic_records)},
+             {"pc_sample_host_trap", std::move(host_trap_records)},
+             {"kernel_dispatch", std::move(kernel_dispatch)},
+             {"hip_api", nlohmann::json::array()},
+             {"hsa_api", nlohmann::json::array()},
+             {"memory_copy", nlohmann::json::array()},
+             {"marker_api", nlohmann::json::array()},
+             {"rccl_api", nlohmann::json::array()},
+             {"memory_allocation", nlohmann::json::array()},
+             {"scratch_memory", nlohmann::json::array()},
+             {"kfd", nlohmann::json::array()},
+             {"rocdecode_api", nlohmann::json::array()},
+             {"rocjpeg_api", nlohmann::json::array()},
+         })},
+    });
+
+    auto root = nlohmann::json::object({
+        {"rocprofiler-sdk-tool", nlohmann::json::array({std::move(entry)})},
+    });
+
+    return root.dump();
+}
+
+void pc_sample_writer_json_t::flush(const std::filesystem::path& output_file_path)
+{
+    file_writer_t::create()->write(output_file_path, get_result());
+    std::clog << "[rocprofiler-compute] [" << __FUNCTION__
+              << "] PC sampling data has been written to: " << output_file_path << "\n";
+}

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sample_writer.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sample_writer.cpp
@@ -7,17 +7,12 @@
 #include "pc_sample_writer.h"
 
 #include "file_writer.h"
-#include "gsl_assert.h"
 #include "nlohmann/json.hpp"
 
-#include <rocprofiler-sdk/buffer_tracing.h>
-#include <rocprofiler-sdk/fwd.h>
 #include <rocprofiler-sdk/pc_sampling.h>
 
-#include <fstream>
 #include <iostream>
 #include <memory>
-#include <stdexcept>
 
 using namespace rocprofiler_compute_tool;
 
@@ -35,40 +30,6 @@ std::string not_issued_reason_name(uint32_t reason)
     const char* name = rocprofiler_get_pc_sampling_instruction_not_issued_reason_name(
         static_cast<rocprofiler_pc_sampling_instruction_not_issued_reason_t>(reason));
     return name != nullptr ? std::string{name} : std::string{};
-}
-
-pc_sample_hw_id_t map_hw_id(const rocprofiler_pc_sampling_hw_id_v0_t& hw)
-{
-    pc_sample_hw_id_t out{};
-    out.chiplet          = hw.chiplet;
-    out.wave_id          = hw.wave_id;
-    out.simd_id          = hw.simd_id;
-    out.pipe_id          = hw.pipe_id;
-    out.cu_or_wgp_id     = hw.cu_or_wgp_id;
-    out.shader_array_id  = hw.shader_array_id;
-    out.shader_engine_id = hw.shader_engine_id;
-    out.workgroup_id     = hw.workgroup_id;
-    out.vm_id            = hw.vm_id;
-    out.queue_id         = hw.queue_id;
-    out.microengine_id   = hw.microengine_id;
-    return out;
-}
-
-pc_sample_pc_t map_pc(const rocprofiler_pc_t& pc)
-{
-    pc_sample_pc_t out{};
-    out.code_object_id     = pc.code_object_id;
-    out.code_object_offset = pc.code_object_offset;
-    return out;
-}
-
-pc_sample_dim3_t map_dim3(const rocprofiler_dim3_t& d)
-{
-    pc_sample_dim3_t out{};
-    out.x = d.x;
-    out.y = d.y;
-    out.z = d.z;
-    return out;
 }
 
 nlohmann::json hw_id_to_json(const pc_sample_hw_id_t& hw)
@@ -115,30 +76,13 @@ nlohmann::json dim3_to_json(const pc_sample_dim3_t& d)
 
 nlohmann::json snapshot_to_json(const pc_sample_snapshot_t& s)
 {
-    return nlohmann::json::object({
-        {"stall_reason", not_issued_reason_name(s.stall_reason)},
-        {"dual_issue_valu", s.dual_issue_valu},
-        {"arb_state_issue_valu", s.arb_state_issue_valu},
-        {"arb_state_issue_matrix", s.arb_state_issue_matrix},
-        {"arb_state_issue_lds", s.arb_state_issue_lds},
-        {"arb_state_issue_lds_direct", s.arb_state_issue_lds_direct},
-        {"arb_state_issue_scalar", s.arb_state_issue_scalar},
-        {"arb_state_issue_vmem_tex", s.arb_state_issue_vmem_tex},
-        {"arb_state_issue_flat", s.arb_state_issue_flat},
-        {"arb_state_issue_exp", s.arb_state_issue_exp},
-        {"arb_state_issue_misc", s.arb_state_issue_misc},
-        {"arb_state_issue_brmsg", s.arb_state_issue_brmsg},
-        {"arb_state_stall_valu", s.arb_state_stall_valu},
-        {"arb_state_stall_matrix", s.arb_state_stall_matrix},
-        {"arb_state_stall_lds", s.arb_state_stall_lds},
-        {"arb_state_stall_lds_direct", s.arb_state_stall_lds_direct},
-        {"arb_state_stall_scalar", s.arb_state_stall_scalar},
-        {"arb_state_stall_vmem_tex", s.arb_state_stall_vmem_tex},
-        {"arb_state_stall_flat", s.arb_state_stall_flat},
-        {"arb_state_stall_exp", s.arb_state_stall_exp},
-        {"arb_state_stall_misc", s.arb_state_stall_misc},
-        {"arb_state_stall_brmsg", s.arb_state_stall_brmsg},
-    });
+    auto out = nlohmann::json::object();
+    out["stall_reason"] = not_issued_reason_name(s.stall_reason);
+    // Emit the plain uint32 fields from the single-sourced field list.
+#define PC_SAMPLE_SNAPSHOT_EMIT(field) out[#field] = s.field;
+    PC_SAMPLE_SNAPSHOT_PLAIN_FIELDS(PC_SAMPLE_SNAPSHOT_EMIT)
+#undef PC_SAMPLE_SNAPSHOT_EMIT
+    return out;
 }
 
 // Host-trap samples emit exactly these fields; stochastic adds more on top.
@@ -168,144 +112,6 @@ nlohmann::json stochastic_record_to_json(const pc_sample_record_t& r)
 }
 }  // namespace
 
-size_t pc_string_table_t::insert(const std::string& instruction_text, const std::string& comment)
-{
-    // Look up via views over the caller's strings so a cache hit copies nothing.
-    if (const auto it = m_index.find(
-            std::make_pair(std::string_view{instruction_text}, std::string_view{comment}));
-        it != m_index.end())
-        return it->second;
-
-    const size_t idx = m_instructions.size();
-    // deque element addresses are stable, so the views stored below stay valid.
-    const std::string& stored_text    = m_instructions.emplace_back(instruction_text);
-    const std::string& stored_comment = m_comments.emplace_back(comment);
-    m_index.emplace(std::make_pair(std::string_view{stored_text}, std::string_view{stored_comment}), idx);
-    return idx;
-}
-
-const std::deque<std::string>& pc_string_table_t::instructions() const
-{
-    return m_instructions;
-}
-
-const std::deque<std::string>& pc_string_table_t::comments() const
-{
-    return m_comments;
-}
-
-namespace
-{
-// Templated because both SDK record structs expose these members by the same names.
-template<typename RecT>
-void map_common_fields(pc_sample_record_t& out, const RecT& rec)
-{
-    out.hw_id            = map_hw_id(rec.hw_id);
-    out.pc               = map_pc(rec.pc);
-    out.exec_mask        = rec.exec_mask;
-    out.timestamp        = rec.timestamp;
-    out.dispatch_id      = rec.dispatch_id;
-    out.corr_id.internal = rec.correlation_id.internal;
-    out.corr_id.external = rec.correlation_id.external.value;
-    out.wrkgrp_id        = map_dim3(rec.workgroup_id);
-    out.wave_in_grp      = rec.wave_in_group;
-}
-}  // namespace
-
-std::optional<pc_sample_record_t> rocprofiler_compute_tool::decode_pc_sample_record(
-    const rocprofiler_record_header_t& header)
-{
-    if (header.category != ROCPROFILER_BUFFER_CATEGORY_PC_SAMPLING)
-        return std::nullopt;
-
-    if (header.kind == ROCPROFILER_PC_SAMPLING_RECORD_STOCHASTIC_V0_SAMPLE)
-    {
-        const auto& rec = *reinterpret_cast<const rocprofiler_pc_sampling_record_stochastic_v0_t*>(
-            header.payload);
-
-        pc_sample_record_t out{};
-        out.kind = pc_sample_kind_t::Stochastic;
-        map_common_fields(out, rec);
-        out.flags.has_mem_cnt = rec.flags.has_memory_counter;
-        out.wave_issued       = rec.wave_issued;
-        out.inst_type         = rec.inst_type;
-        out.wave_cnt          = rec.wave_count;
-
-        out.snapshot.stall_reason               = rec.snapshot.reason_not_issued;
-        out.snapshot.dual_issue_valu            = rec.snapshot.dual_issue_valu;
-        out.snapshot.arb_state_issue_valu       = rec.snapshot.arb_state_issue_valu;
-        out.snapshot.arb_state_issue_matrix     = rec.snapshot.arb_state_issue_matrix;
-        out.snapshot.arb_state_issue_lds        = rec.snapshot.arb_state_issue_lds;
-        out.snapshot.arb_state_issue_lds_direct = rec.snapshot.arb_state_issue_lds_direct;
-        out.snapshot.arb_state_issue_scalar     = rec.snapshot.arb_state_issue_scalar;
-        out.snapshot.arb_state_issue_vmem_tex   = rec.snapshot.arb_state_issue_vmem_tex;
-        out.snapshot.arb_state_issue_flat       = rec.snapshot.arb_state_issue_flat;
-        out.snapshot.arb_state_issue_exp        = rec.snapshot.arb_state_issue_exp;
-        out.snapshot.arb_state_issue_misc       = rec.snapshot.arb_state_issue_misc;
-        out.snapshot.arb_state_issue_brmsg      = rec.snapshot.arb_state_issue_brmsg;
-        out.snapshot.arb_state_stall_valu       = rec.snapshot.arb_state_stall_valu;
-        out.snapshot.arb_state_stall_matrix     = rec.snapshot.arb_state_stall_matrix;
-        out.snapshot.arb_state_stall_lds        = rec.snapshot.arb_state_stall_lds;
-        out.snapshot.arb_state_stall_lds_direct = rec.snapshot.arb_state_stall_lds_direct;
-        out.snapshot.arb_state_stall_scalar     = rec.snapshot.arb_state_stall_scalar;
-        out.snapshot.arb_state_stall_vmem_tex   = rec.snapshot.arb_state_stall_vmem_tex;
-        out.snapshot.arb_state_stall_flat       = rec.snapshot.arb_state_stall_flat;
-        out.snapshot.arb_state_stall_exp        = rec.snapshot.arb_state_stall_exp;
-        out.snapshot.arb_state_stall_misc       = rec.snapshot.arb_state_stall_misc;
-        out.snapshot.arb_state_stall_brmsg      = rec.snapshot.arb_state_stall_brmsg;
-
-        return out;
-    }
-
-    if (header.kind == ROCPROFILER_PC_SAMPLING_RECORD_HOST_TRAP_V0_SAMPLE)
-    {
-        const auto& rec = *reinterpret_cast<const rocprofiler_pc_sampling_record_host_trap_v0_t*>(
-            header.payload);
-
-        pc_sample_record_t out{};
-        out.kind = pc_sample_kind_t::HostTrap;
-        map_common_fields(out, rec);
-
-        return out;
-    }
-
-    return std::nullopt;
-}
-
-std::optional<kernel_dispatch_record_t> rocprofiler_compute_tool::decode_kernel_dispatch_record(
-    const rocprofiler_record_header_t& header)
-{
-    if (header.category != ROCPROFILER_BUFFER_CATEGORY_TRACING ||
-        header.kind != ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH)
-        return std::nullopt;
-
-    const auto& rec = *reinterpret_cast<const rocprofiler_buffer_tracing_kernel_dispatch_record_t*>(
-        header.payload);
-    const auto& di = rec.dispatch_info;
-
-    kernel_dispatch_record_t out{};
-    out.size            = rec.size;
-    out.kind            = rec.kind;
-    out.operation       = rec.operation;
-    out.thread_id       = rec.thread_id;
-    out.corr_internal   = rec.correlation_id.internal;
-    out.corr_external   = rec.correlation_id.external.value;
-    out.start_timestamp = rec.start_timestamp;
-    out.end_timestamp   = rec.end_timestamp;
-
-    out.dispatch_info_size   = di.size;
-    out.agent_id_handle      = di.agent_id.handle;
-    out.queue_id_handle      = di.queue_id.handle;
-    out.kernel_id            = di.kernel_id;
-    out.dispatch_id          = di.dispatch_id;
-    out.private_segment_size = di.private_segment_size;
-    out.group_segment_size   = di.group_segment_size;
-    out.workgroup_size       = map_dim3(di.workgroup_size);
-    out.grid_size            = map_dim3(di.grid_size);
-
-    return out;
-}
-
 std::shared_ptr<pc_sample_writer_t> pc_sample_writer_t::create()
 {
     return std::make_shared<pc_sample_writer_json_t>();
@@ -325,14 +131,12 @@ void pc_sample_writer_json_t::begin()
 
 void pc_sample_writer_json_t::append_stochastic(const pc_sample_record_t& r, size_t inst_index)
 {
-    m_stochastic.push_back(r);
-    m_stochastic.back().inst_index = inst_index;
+    m_stochastic.push_back(sample_entry_t{r, inst_index});
 }
 
 void pc_sample_writer_json_t::append_host_trap(const pc_sample_record_t& r, size_t inst_index)
 {
-    m_host_trap.push_back(r);
-    m_host_trap.back().inst_index = inst_index;
+    m_host_trap.push_back(sample_entry_t{r, inst_index});
 }
 
 void pc_sample_writer_json_t::set_strings(const pc_string_table_t& table)
@@ -366,20 +170,20 @@ void pc_sample_writer_json_t::set_metadata(int pid)
 std::string pc_sample_writer_json_t::get_result()
 {
     auto stochastic_records = nlohmann::json::array();
-    for (const auto& r : m_stochastic)
+    for (const auto& e : m_stochastic)
     {
         stochastic_records.push_back(nlohmann::json::object({
-            {"record", stochastic_record_to_json(r)},
-            {"inst_index", r.inst_index},
+            {"record", stochastic_record_to_json(e.record)},
+            {"inst_index", e.inst_index},
         }));
     }
 
     auto host_trap_records = nlohmann::json::array();
-    for (const auto& r : m_host_trap)
+    for (const auto& e : m_host_trap)
     {
         host_trap_records.push_back(nlohmann::json::object({
-            {"record", common_record_to_json(r)},
-            {"inst_index", r.inst_index},
+            {"record", common_record_to_json(e.record)},
+            {"inst_index", e.inst_index},
         }));
     }
 

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sample_writer.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sample_writer.cpp
@@ -76,7 +76,7 @@ nlohmann::json dim3_to_json(const pc_sample_dim3_t& d)
 
 nlohmann::json snapshot_to_json(const pc_sample_snapshot_t& s)
 {
-    auto out = nlohmann::json::object();
+    auto out            = nlohmann::json::object();
     out["stall_reason"] = not_issued_reason_name(s.stall_reason);
     // Emit the plain uint32 fields from the single-sourced field list.
 #define PC_SAMPLE_SNAPSHOT_EMIT(field) out[#field] = s.field;

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sample_writer.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sample_writer.h
@@ -2,178 +2,17 @@
 // SPDX-License-Identifier:  MIT
 #pragma once
 
-#ifndef ROCPROFILER_SDK_EXPERIMENTAL
-#    define ROCPROFILER_SDK_EXPERIMENTAL
-#endif
-
-#include <rocprofiler-sdk/fwd.h>
+#include "pc_sample_types.h"
 
 #include <cstddef>
-#include <cstdint>
-#include <deque>
 #include <filesystem>
 #include <memory>
-#include <optional>
 #include <string>
-#include <string_view>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
 namespace rocprofiler_compute_tool
 {
-enum class pc_sample_kind_t : uint8_t
-{
-    Stochastic,
-    HostTrap
-};
-
-struct pc_sample_flags_t
-{
-    uint32_t has_mem_cnt = 0;
-};
-
-struct pc_sample_hw_id_t
-{
-    uint64_t chiplet          = 0;
-    uint64_t wave_id          = 0;
-    uint64_t simd_id          = 0;
-    uint64_t pipe_id          = 0;
-    uint64_t cu_or_wgp_id     = 0;
-    uint64_t shader_array_id  = 0;
-    uint64_t shader_engine_id = 0;
-    uint64_t workgroup_id     = 0;
-    uint64_t vm_id            = 0;
-    uint64_t queue_id         = 0;
-    uint64_t microengine_id   = 0;
-};
-
-struct pc_sample_pc_t
-{
-    uint64_t code_object_id     = 0;
-    uint64_t code_object_offset = 0;
-};
-
-struct pc_sample_correlation_t
-{
-    uint64_t internal = 0;
-    uint64_t external = 0;
-};
-
-struct pc_sample_dim3_t
-{
-    uint64_t x = 0, y = 0, z = 0;
-};
-
-struct pc_sample_snapshot_t
-{
-    uint32_t stall_reason    = 0;  // raw SDK not-issued-reason enum; name resolved at serialization
-    uint32_t dual_issue_valu = 0;
-    uint32_t arb_state_issue_valu = 0, arb_state_issue_matrix = 0, arb_state_issue_lds = 0,
-             arb_state_issue_lds_direct = 0, arb_state_issue_scalar = 0,
-             arb_state_issue_vmem_tex = 0, arb_state_issue_flat = 0, arb_state_issue_exp = 0,
-             arb_state_issue_misc = 0, arb_state_issue_brmsg = 0;
-    uint32_t arb_state_stall_valu = 0, arb_state_stall_matrix = 0, arb_state_stall_lds = 0,
-             arb_state_stall_lds_direct = 0, arb_state_stall_scalar = 0,
-             arb_state_stall_vmem_tex = 0, arb_state_stall_flat = 0, arb_state_stall_exp = 0,
-             arb_state_stall_misc = 0, arb_state_stall_brmsg = 0;
-};
-
-struct pc_sample_record_t
-{
-    pc_sample_kind_t        kind = pc_sample_kind_t::HostTrap;
-    pc_sample_flags_t       flags{};
-    pc_sample_hw_id_t       hw_id{};
-    pc_sample_pc_t          pc{};
-    uint64_t                exec_mask = 0, timestamp = 0, dispatch_id = 0;
-    pc_sample_correlation_t corr_id{};
-    pc_sample_dim3_t        wrkgrp_id{};
-    uint32_t                wave_in_grp = 0;
-    uint32_t                wave_issued = 0;
-    uint32_t inst_type = 0;  // raw SDK instruction-type enum; name resolved at serialization
-    uint32_t wave_cnt  = 0;
-    pc_sample_snapshot_t snapshot{};
-    size_t               inst_index = 0;
-};
-
-struct kernel_symbol_entry_t
-{
-    uint64_t    code_object_id = 0;
-    std::string formatted_kernel_name{};
-    uint64_t    kernel_id = 0;
-};
-
-// Minimal agent record; the consumer builds its GPU-id map from GPU-type agents
-// sorted by node_id.
-struct agent_record_t
-{
-    uint64_t size            = 0;  // sizeof the SDK agent struct (for SDK-shape parity)
-    uint64_t id_handle       = 0;
-    uint32_t type            = 0;  // raw rocprofiler_agent_type_t value
-    uint32_t node_id         = 0;
-    int32_t  logical_node_id = 0;
-    uint32_t cu_count        = 0;
-    uint64_t gpu_id          = 0;  // KFD identifier (GPU only)
-    uint32_t wave_front_size = 0;
-    uint32_t simd_count      = 0;
-};
-
-struct kernel_dispatch_record_t
-{
-    uint64_t size            = 0;
-    uint32_t kind            = 0;  // raw rocprofiler_buffer_tracing_kind_t value
-    uint32_t operation       = 0;
-    uint64_t thread_id       = 0;
-    uint64_t corr_internal   = 0;
-    uint64_t corr_external   = 0;
-    uint64_t start_timestamp = 0;
-    uint64_t end_timestamp   = 0;
-
-    uint64_t         dispatch_info_size   = 0;
-    uint64_t         agent_id_handle      = 0;
-    uint64_t         queue_id_handle      = 0;
-    uint64_t         kernel_id            = 0;
-    uint64_t         dispatch_id          = 0;
-    uint32_t         private_segment_size = 0;
-    uint32_t         group_segment_size   = 0;
-    pc_sample_dim3_t workgroup_size{};
-    pc_sample_dim3_t grid_size{};
-};
-
-class pc_string_table_t
-{
-public:
-    // Dedups by (instruction_text, comment); returns the shared index (position in BOTH arrays).
-    size_t insert(const std::string& instruction_text, const std::string& comment);
-    const std::deque<std::string>& instructions() const;
-    const std::deque<std::string>& comments() const;
-
-private:
-    struct view_pair_hash_t
-    {
-        size_t operator()(const std::pair<std::string_view, std::string_view>& p) const
-        {
-            const size_t h1 = std::hash<std::string_view>{}(p.first);
-            const size_t h2 = std::hash<std::string_view>{}(p.second);
-            return h1 ^ (h2 + 0x9e3779b97f4a7c15ULL + (h1 << 6) + (h1 >> 2));
-        }
-    };
-
-    // Canonical strings live in deques (stable addresses); m_index keys on views
-    // into them, so a cache hit allocates nothing.
-    std::deque<std::string> m_instructions;
-    std::deque<std::string> m_comments;
-    std::unordered_map<std::pair<std::string_view, std::string_view>, size_t, view_pair_hash_t> m_index;
-};
-
-// Returns std::nullopt when header.category != ROCPROFILER_BUFFER_CATEGORY_PC_SAMPLING
-// or header.kind is not one of the two supported PC sampling record kinds.
-std::optional<pc_sample_record_t> decode_pc_sample_record(const rocprofiler_record_header_t& header);
-
-// Returns std::nullopt when header.category != ROCPROFILER_BUFFER_CATEGORY_TRACING
-// or header.kind != ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH.
-std::optional<kernel_dispatch_record_t> decode_kernel_dispatch_record(const rocprofiler_record_header_t& header);
-
 class pc_sample_writer_t
 {
 public:
@@ -208,9 +47,16 @@ public:
     void        flush(const std::filesystem::path& output_file_path) override;
 
 private:
+    // A decoded sample paired with its interned (instruction, comment) index.
+    struct sample_entry_t
+    {
+        pc_sample_record_t record;
+        size_t             inst_index = 0;
+    };
+
     int                                   m_pid = 0;
-    std::vector<pc_sample_record_t>       m_stochastic;
-    std::vector<pc_sample_record_t>       m_host_trap;
+    std::vector<sample_entry_t>           m_stochastic;
+    std::vector<sample_entry_t>           m_host_trap;
     std::vector<std::string>              m_instructions;
     std::vector<std::string>              m_comments;
     std::vector<kernel_symbol_entry_t>    m_kernel_symbols;

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sample_writer.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sample_writer.h
@@ -1,0 +1,220 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#pragma once
+
+#ifndef ROCPROFILER_SDK_EXPERIMENTAL
+#    define ROCPROFILER_SDK_EXPERIMENTAL
+#endif
+
+#include <rocprofiler-sdk/fwd.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace rocprofiler_compute_tool
+{
+enum class pc_sample_kind_t : uint8_t
+{
+    Stochastic,
+    HostTrap
+};
+
+struct pc_sample_flags_t
+{
+    uint32_t has_mem_cnt = 0;
+};
+
+struct pc_sample_hw_id_t
+{
+    uint64_t chiplet          = 0;
+    uint64_t wave_id          = 0;
+    uint64_t simd_id          = 0;
+    uint64_t pipe_id          = 0;
+    uint64_t cu_or_wgp_id     = 0;
+    uint64_t shader_array_id  = 0;
+    uint64_t shader_engine_id = 0;
+    uint64_t workgroup_id     = 0;
+    uint64_t vm_id            = 0;
+    uint64_t queue_id         = 0;
+    uint64_t microengine_id   = 0;
+};
+
+struct pc_sample_pc_t
+{
+    uint64_t code_object_id     = 0;
+    uint64_t code_object_offset = 0;
+};
+
+struct pc_sample_correlation_t
+{
+    uint64_t internal = 0;
+    uint64_t external = 0;
+};
+
+struct pc_sample_dim3_t
+{
+    uint64_t x = 0, y = 0, z = 0;
+};
+
+struct pc_sample_snapshot_t
+{
+    uint32_t stall_reason    = 0;  // raw SDK not-issued-reason enum; name resolved at serialization
+    uint32_t dual_issue_valu = 0;
+    uint32_t arb_state_issue_valu = 0, arb_state_issue_matrix = 0, arb_state_issue_lds = 0,
+             arb_state_issue_lds_direct = 0, arb_state_issue_scalar = 0,
+             arb_state_issue_vmem_tex = 0, arb_state_issue_flat = 0, arb_state_issue_exp = 0,
+             arb_state_issue_misc = 0, arb_state_issue_brmsg = 0;
+    uint32_t arb_state_stall_valu = 0, arb_state_stall_matrix = 0, arb_state_stall_lds = 0,
+             arb_state_stall_lds_direct = 0, arb_state_stall_scalar = 0,
+             arb_state_stall_vmem_tex = 0, arb_state_stall_flat = 0, arb_state_stall_exp = 0,
+             arb_state_stall_misc = 0, arb_state_stall_brmsg = 0;
+};
+
+struct pc_sample_record_t
+{
+    pc_sample_kind_t        kind = pc_sample_kind_t::HostTrap;
+    pc_sample_flags_t       flags{};
+    pc_sample_hw_id_t       hw_id{};
+    pc_sample_pc_t          pc{};
+    uint64_t                exec_mask = 0, timestamp = 0, dispatch_id = 0;
+    pc_sample_correlation_t corr_id{};
+    pc_sample_dim3_t        wrkgrp_id{};
+    uint32_t                wave_in_grp = 0;
+    uint32_t                wave_issued = 0;
+    uint32_t inst_type = 0;  // raw SDK instruction-type enum; name resolved at serialization
+    uint32_t wave_cnt  = 0;
+    pc_sample_snapshot_t snapshot{};
+    size_t               inst_index = 0;
+};
+
+struct kernel_symbol_entry_t
+{
+    uint64_t    code_object_id = 0;
+    std::string formatted_kernel_name{};
+    uint64_t    kernel_id = 0;
+};
+
+// Minimal agent record; the consumer builds its GPU-id map from GPU-type agents
+// sorted by node_id.
+struct agent_record_t
+{
+    uint64_t size            = 0;  // sizeof the SDK agent struct (for SDK-shape parity)
+    uint64_t id_handle       = 0;
+    uint32_t type            = 0;  // raw rocprofiler_agent_type_t value
+    uint32_t node_id         = 0;
+    int32_t  logical_node_id = 0;
+    uint32_t cu_count        = 0;
+    uint64_t gpu_id          = 0;  // KFD identifier (GPU only)
+    uint32_t wave_front_size = 0;
+    uint32_t simd_count      = 0;
+};
+
+struct kernel_dispatch_record_t
+{
+    uint64_t size            = 0;
+    uint32_t kind            = 0;  // raw rocprofiler_buffer_tracing_kind_t value
+    uint32_t operation       = 0;
+    uint64_t thread_id       = 0;
+    uint64_t corr_internal   = 0;
+    uint64_t corr_external   = 0;
+    uint64_t start_timestamp = 0;
+    uint64_t end_timestamp   = 0;
+
+    uint64_t         dispatch_info_size   = 0;
+    uint64_t         agent_id_handle      = 0;
+    uint64_t         queue_id_handle      = 0;
+    uint64_t         kernel_id            = 0;
+    uint64_t         dispatch_id          = 0;
+    uint32_t         private_segment_size = 0;
+    uint32_t         group_segment_size   = 0;
+    pc_sample_dim3_t workgroup_size{};
+    pc_sample_dim3_t grid_size{};
+};
+
+class pc_string_table_t
+{
+public:
+    // Dedups by (instruction_text, comment); returns the shared index (position in BOTH arrays).
+    size_t insert(const std::string& instruction_text, const std::string& comment);
+    const std::deque<std::string>& instructions() const;
+    const std::deque<std::string>& comments() const;
+
+private:
+    struct view_pair_hash_t
+    {
+        size_t operator()(const std::pair<std::string_view, std::string_view>& p) const
+        {
+            const size_t h1 = std::hash<std::string_view>{}(p.first);
+            const size_t h2 = std::hash<std::string_view>{}(p.second);
+            return h1 ^ (h2 + 0x9e3779b97f4a7c15ULL + (h1 << 6) + (h1 >> 2));
+        }
+    };
+
+    // Canonical strings live in deques (stable addresses); m_index keys on views
+    // into them, so a cache hit allocates nothing.
+    std::deque<std::string> m_instructions;
+    std::deque<std::string> m_comments;
+    std::unordered_map<std::pair<std::string_view, std::string_view>, size_t, view_pair_hash_t> m_index;
+};
+
+// Returns std::nullopt when header.category != ROCPROFILER_BUFFER_CATEGORY_PC_SAMPLING
+// or header.kind is not one of the two supported PC sampling record kinds.
+std::optional<pc_sample_record_t> decode_pc_sample_record(const rocprofiler_record_header_t& header);
+
+// Returns std::nullopt when header.category != ROCPROFILER_BUFFER_CATEGORY_TRACING
+// or header.kind != ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH.
+std::optional<kernel_dispatch_record_t> decode_kernel_dispatch_record(const rocprofiler_record_header_t& header);
+
+class pc_sample_writer_t
+{
+public:
+    static std::shared_ptr<pc_sample_writer_t> create();
+
+    virtual ~pc_sample_writer_t() = default;
+    virtual void begin()          = 0;
+    // inst_index is the interned (instruction, comment) index for this sample.
+    virtual void append_stochastic(const pc_sample_record_t& r, size_t inst_index)              = 0;
+    virtual void append_host_trap(const pc_sample_record_t& r, size_t inst_index)               = 0;
+    virtual void set_strings(const pc_string_table_t& table)                                    = 0;
+    virtual void set_kernel_symbols(const std::vector<kernel_symbol_entry_t>& syms)             = 0;
+    virtual void set_agents(const std::vector<agent_record_t>& agents)                          = 0;
+    virtual void set_kernel_dispatches(const std::vector<kernel_dispatch_record_t>& dispatches) = 0;
+    virtual void set_metadata(int pid)                                                          = 0;
+    virtual std::string get_result()                                                            = 0;
+    virtual void        flush(const std::filesystem::path& output_file_path)                    = 0;
+};
+
+class pc_sample_writer_json_t : public pc_sample_writer_t
+{
+public:
+    void begin() override;
+    void append_stochastic(const pc_sample_record_t& r, size_t inst_index) override;
+    void append_host_trap(const pc_sample_record_t& r, size_t inst_index) override;
+    void set_strings(const pc_string_table_t& table) override;
+    void set_kernel_symbols(const std::vector<kernel_symbol_entry_t>& syms) override;
+    void set_agents(const std::vector<agent_record_t>& agents) override;
+    void set_kernel_dispatches(const std::vector<kernel_dispatch_record_t>& dispatches) override;
+    void set_metadata(int pid) override;
+    std::string get_result() override;
+    void        flush(const std::filesystem::path& output_file_path) override;
+
+private:
+    int                                   m_pid = 0;
+    std::vector<pc_sample_record_t>       m_stochastic;
+    std::vector<pc_sample_record_t>       m_host_trap;
+    std::vector<std::string>              m_instructions;
+    std::vector<std::string>              m_comments;
+    std::vector<kernel_symbol_entry_t>    m_kernel_symbols;
+    std::vector<agent_record_t>           m_agents;
+    std::vector<kernel_dispatch_record_t> m_kernel_dispatches;
+};
+}  // namespace rocprofiler_compute_tool

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sampling_collector.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sampling_collector.cpp
@@ -55,21 +55,39 @@ void pc_sampling_collector_impl_t::write(code_object_writer_t& writer)
     for (const auto& id : m_translator->get_code_object_ids())
     {
         writer.start_code_obj(id);
-        const auto& symbols = m_translator->get_symbols(id);
-        for (const auto& sym : symbols)
+
+        // Disassemble the whole loaded code-object range, not just named symbols.
+        // PC samples can land on any instruction, including code that has no ELF
+        // symbol; analyze joins each sample's code_object_offset to an entry here,
+        // so every loaded instruction must be present. Group them under one span
+        // symbol -- the consumer flattens symbols and reads only the instruction
+        // list, keyed by the loaded-basis code_obj_offset.
+        const uint64_t base      = m_translator->get_load_base(id);
+        const uint64_t range_end = base + m_translator->get_load_size(id);
+
+        symbol_t span{};
+        span.name               = "<code object>";
+        span.virtual_address    = base;
+        span.code_object_offset = 0;
+        span.size               = range_end - base;
+        writer.start_symbol(span);
+
+        uint64_t pc = base;
+        while (pc < range_end)
         {
-            writer.start_symbol(sym);
-            uint64_t       pc  = sym.virtual_address;
-            const uint64_t end = sym.virtual_address + sym.size;
-            while (pc < end)
+            const auto inst = m_translator->get_instruction(id, pc);
+            if (inst.size == 0)
             {
-                const auto& inst = m_translator->get_instruction(id, pc);
-                Expects(inst.size);
-                writer.write_instruction(inst);
-                pc += inst.size;
+                // Undecodable padding/data: advance a word so the walk progresses
+                // instead of aborting the whole code object.
+                pc += sizeof(uint32_t);
+                continue;
             }
-            writer.end_symbol();
+            writer.write_instruction(inst);
+            pc += inst.size;
         }
+
+        writer.end_symbol();
         writer.end_code_obj();
     }
 }
@@ -167,7 +185,7 @@ size_t pc_sampling_collector_impl_t::snapshot_sources(const std::filesystem::pat
     // accumulating one string per instruction.
     std::set<std::string> unique_refs;
     for_each_instruction(
-        [&unique_refs, &snapshotter](uint64_t /*id*/, const symbol_t& /*sym*/, const instruction_t& inst)
+        [&unique_refs, &snapshotter](uint64_t /*id*/, const instruction_t& inst)
         {
             if (const auto ref = snapshotter->parse_ref(inst.comment))
             {

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sampling_collector.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sampling_collector.cpp
@@ -3,11 +3,34 @@
 #include "pc_sampling_collector.h"
 
 #include "gsl_assert.h"
+#include "source_snapshot.h"
+
+#include <unistd.h>
 
 #include <ios>
 #include <iostream>
+#include <mutex>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 using namespace rocprofiler_compute_tool;
+
+namespace
+{
+struct pc_location_hash_t
+{
+    size_t operator()(const std::pair<uint64_t, uint64_t>& p) const
+    {
+        const size_t h1 = std::hash<uint64_t>{}(p.first);
+        const size_t h2 = std::hash<uint64_t>{}(p.second);
+        return h1 ^ (h2 + 0x9e3779b97f4a7c15ULL + (h1 << 6) + (h1 >> 2));
+    }
+};
+}  // namespace
 
 pc_sampling_collector_t::ptr pc_sampling_collector_t::create()
 {
@@ -60,4 +83,105 @@ void pc_sampling_collector_impl_t::write(code_object_writer_t& writer)
         }
         writer.end_code_obj();
     }
+}
+
+void pc_sampling_collector_impl_t::append_sample(const pc_sample_record_t& record)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_samples.push_back(record);
+}
+
+void pc_sampling_collector_impl_t::add_kernel_symbol(uint64_t           code_object_id,
+                                                     const std::string& formatted_kernel_name,
+                                                     uint64_t           kernel_id)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_kernel_symbols.push_back(kernel_symbol_entry_t{code_object_id, formatted_kernel_name, kernel_id});
+}
+
+void pc_sampling_collector_impl_t::add_agent(const agent_record_t& agent)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_agents.push_back(agent);
+}
+
+void pc_sampling_collector_impl_t::append_kernel_dispatch(const kernel_dispatch_record_t& record)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_kernel_dispatches.push_back(record);
+}
+
+instruction_t pc_sampling_collector_impl_t::resolve_instruction(uint64_t code_object_id,
+                                                                uint64_t code_object_offset)
+{
+    // PC sample offsets are relative to the code object's load base, but
+    // get_instruction keys on a global virtual address. Translate before lookup.
+    try
+    {
+        const uint64_t vaddr = code_object_offset + m_translator->get_load_base(code_object_id);
+        return m_translator->get_instruction(code_object_id, vaddr);
+    }
+    catch (const std::out_of_range&)
+    {
+        return instruction_t{};
+    }
+}
+
+void pc_sampling_collector_impl_t::write_samples(pc_sample_writer_t& writer)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    writer.begin();
+    // Many samples hit the same PC, so cache the string-table index per location
+    // to avoid re-disassembling and re-inserting each one.
+    std::unordered_map<std::pair<uint64_t, uint64_t>, size_t, pc_location_hash_t> idx_by_location;
+    for (const auto& sample : m_samples)
+    {
+        const auto location = std::make_pair(sample.pc.code_object_id, sample.pc.code_object_offset);
+        size_t idx = 0;
+        if (const auto it = idx_by_location.find(location); it != idx_by_location.end())
+        {
+            idx = it->second;
+        }
+        else
+        {
+            const instruction_t inst = resolve_instruction(sample.pc.code_object_id,
+                                                           sample.pc.code_object_offset);
+            idx                      = m_string_table.insert(inst.name, inst.comment);
+            idx_by_location.emplace(location, idx);
+        }
+
+        switch (sample.kind)
+        {
+        case pc_sample_kind_t::Stochastic:
+            writer.append_stochastic(sample, idx);
+            break;
+        case pc_sample_kind_t::HostTrap:
+            writer.append_host_trap(sample, idx);
+            break;
+        }
+    }
+
+    writer.set_strings(m_string_table);
+    writer.set_kernel_symbols(m_kernel_symbols);
+    writer.set_agents(m_agents);
+    writer.set_kernel_dispatches(m_kernel_dispatches);
+    writer.set_metadata(static_cast<int>(getpid()));
+}
+
+size_t pc_sampling_collector_impl_t::snapshot_sources(const std::filesystem::path& output_root)
+{
+    const std::shared_ptr<source_snapshot_t> snapshotter = source_snapshot_t::create();
+
+    std::vector<std::string> refs;
+    for_each_instruction(
+        [&refs, &snapshotter](uint64_t /*id*/, const symbol_t& /*sym*/, const instruction_t& inst)
+        {
+            if (const auto ref = snapshotter->parse_ref(inst.comment))
+            {
+                refs.push_back(*ref);
+            }
+        });
+
+    return snapshotter->snapshot(refs, output_root);
 }

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sampling_collector.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sampling_collector.cpp
@@ -71,7 +71,9 @@ void pc_sampling_collector_impl_t::write(code_object_writer_t& writer)
         span.size               = m_translator->get_load_size(id);
         writer.start_symbol(span);
 
-        for_each_instruction_in(id, [&writer](const instruction_t& inst) { writer.write_instruction(inst); });
+        for_each_instruction_in(id,
+                                [&writer](const instruction_t& inst)
+                                { writer.write_instruction(inst); });
 
         writer.end_symbol();
         writer.end_code_obj();

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sampling_collector.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sampling_collector.cpp
@@ -62,30 +62,16 @@ void pc_sampling_collector_impl_t::write(code_object_writer_t& writer)
         // so every loaded instruction must be present. Group them under one span
         // symbol -- the consumer flattens symbols and reads only the instruction
         // list, keyed by the loaded-basis code_obj_offset.
-        const uint64_t base      = m_translator->get_load_base(id);
-        const uint64_t range_end = base + m_translator->get_load_size(id);
+        const uint64_t base = m_translator->get_load_base(id);
 
         symbol_t span{};
         span.name               = "<code object>";
         span.virtual_address    = base;
         span.code_object_offset = 0;
-        span.size               = range_end - base;
+        span.size               = m_translator->get_load_size(id);
         writer.start_symbol(span);
 
-        uint64_t pc = base;
-        while (pc < range_end)
-        {
-            const auto inst = m_translator->get_instruction(id, pc);
-            if (inst.size == 0)
-            {
-                // Undecodable padding/data: advance a word so the walk progresses
-                // instead of aborting the whole code object.
-                pc += sizeof(uint32_t);
-                continue;
-            }
-            writer.write_instruction(inst);
-            pc += inst.size;
-        }
+        for_each_instruction_in(id, [&writer](const instruction_t& inst) { writer.write_instruction(inst); });
 
         writer.end_symbol();
         writer.end_code_obj();

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sampling_collector.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sampling_collector.cpp
@@ -3,6 +3,7 @@
 #include "pc_sampling_collector.h"
 
 #include "gsl_assert.h"
+#include "pair_hash.h"
 #include "source_snapshot.h"
 
 #include <unistd.h>
@@ -11,6 +12,7 @@
 #include <iostream>
 #include <mutex>
 #include <optional>
+#include <set>
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
@@ -18,19 +20,6 @@
 #include <vector>
 
 using namespace rocprofiler_compute_tool;
-
-namespace
-{
-struct pc_location_hash_t
-{
-    size_t operator()(const std::pair<uint64_t, uint64_t>& p) const
-    {
-        const size_t h1 = std::hash<uint64_t>{}(p.first);
-        const size_t h2 = std::hash<uint64_t>{}(p.second);
-        return h1 ^ (h2 + 0x9e3779b97f4a7c15ULL + (h1 << 6) + (h1 >> 2));
-    }
-};
-}  // namespace
 
 pc_sampling_collector_t::ptr pc_sampling_collector_t::create()
 {
@@ -134,7 +123,7 @@ void pc_sampling_collector_impl_t::write_samples(pc_sample_writer_t& writer)
     writer.begin();
     // Many samples hit the same PC, so cache the string-table index per location
     // to avoid re-disassembling and re-inserting each one.
-    std::unordered_map<std::pair<uint64_t, uint64_t>, size_t, pc_location_hash_t> idx_by_location;
+    std::unordered_map<std::pair<uint64_t, uint64_t>, size_t, pair_hash_t> idx_by_location;
     for (const auto& sample : m_samples)
     {
         const auto location = std::make_pair(sample.pc.code_object_id, sample.pc.code_object_offset);
@@ -173,15 +162,19 @@ size_t pc_sampling_collector_impl_t::snapshot_sources(const std::filesystem::pat
 {
     const std::shared_ptr<source_snapshot_t> snapshotter = source_snapshot_t::create();
 
-    std::vector<std::string> refs;
+    // A large kernel can annotate hundreds of thousands of instructions with the
+    // same handful of source files, so dedup at collection time rather than
+    // accumulating one string per instruction.
+    std::set<std::string> unique_refs;
     for_each_instruction(
-        [&refs, &snapshotter](uint64_t /*id*/, const symbol_t& /*sym*/, const instruction_t& inst)
+        [&unique_refs, &snapshotter](uint64_t /*id*/, const symbol_t& /*sym*/, const instruction_t& inst)
         {
             if (const auto ref = snapshotter->parse_ref(inst.comment))
             {
-                refs.push_back(*ref);
+                unique_refs.insert(*ref);
             }
         });
 
+    const std::vector<std::string> refs(unique_refs.begin(), unique_refs.end());
     return snapshotter->snapshot(refs, output_root);
 }

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sampling_collector.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sampling_collector.h
@@ -66,6 +66,9 @@ private:
     instruction_t resolve_instruction(uint64_t code_object_id, uint64_t code_object_offset);
 
     template<typename Fn>
+    void for_each_instruction_in(uint64_t id, Fn&& fn);
+
+    template<typename Fn>
     void for_each_instruction(Fn&& fn);
 
     std::shared_ptr<code_object_translator_t> m_translator;
@@ -79,27 +82,35 @@ private:
 };
 
 template<typename Fn>
+void pc_sampling_collector_impl_t::for_each_instruction_in(uint64_t id, Fn&& fn)
+{
+    // Walk the whole loaded range so callers see every instruction, including
+    // code outside named symbols. PC samples can land on any instruction.
+    const uint64_t base      = m_translator->get_load_base(id);
+    const uint64_t range_end = base + m_translator->get_load_size(id);
+
+    uint64_t pc = base;
+    while (pc < range_end)
+    {
+        const auto inst = m_translator->get_instruction(id, pc);
+        if (inst.size == 0)
+        {
+            // Undecodable padding/data: advance a word so the walk progresses
+            // instead of aborting the whole code object.
+            pc += sizeof(uint32_t);
+            continue;
+        }
+        fn(inst);
+        pc += inst.size;
+    }
+}
+
+template<typename Fn>
 void pc_sampling_collector_impl_t::for_each_instruction(Fn&& fn)
 {
     for (const auto& id : m_translator->get_code_object_ids())
     {
-        // Walk the whole loaded range so callers (e.g. source snapshotting) see
-        // every instruction, including code outside named symbols.
-        const uint64_t base      = m_translator->get_load_base(id);
-        const uint64_t range_end = base + m_translator->get_load_size(id);
-
-        uint64_t pc = base;
-        while (pc < range_end)
-        {
-            const auto inst = m_translator->get_instruction(id, pc);
-            if (inst.size == 0)
-            {
-                pc += sizeof(uint32_t);
-                continue;
-            }
-            fn(id, inst);
-            pc += inst.size;
-        }
+        for_each_instruction_in(id, [&fn, id](const instruction_t& inst) { fn(id, inst); });
     }
 }
 }  // namespace rocprofiler_compute_tool

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sampling_collector.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sampling_collector.h
@@ -3,10 +3,18 @@
 #pragma once
 #include "code_object_translator.h"
 #include "code_object_writer.h"
+#include "gsl_assert.h"
+#include "pc_sample_writer.h"
 
 #include <rocprofiler-sdk/rocprofiler.h>
 
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
 #include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
 
 namespace rocprofiler_compute_tool
 {
@@ -27,6 +35,15 @@ public:
     virtual ~pc_sampling_collector_t() = default;
     virtual void on_code_object_load(const rocprofiler_callback_tracing_code_object_load_data_t& info) = 0;
     virtual void write(code_object_writer_t& writer) = 0;
+
+    virtual void   append_sample(const pc_sample_record_t& record)                = 0;
+    virtual void   add_kernel_symbol(uint64_t           code_object_id,
+                                     const std::string& formatted_kernel_name,
+                                     uint64_t           kernel_id)                = 0;
+    virtual void   add_agent(const agent_record_t& agent)                         = 0;
+    virtual void   append_kernel_dispatch(const kernel_dispatch_record_t& record) = 0;
+    virtual void   write_samples(pc_sample_writer_t& writer)                      = 0;
+    virtual size_t snapshot_sources(const std::filesystem::path& output_root)     = 0;
 };
 
 class pc_sampling_collector_impl_t : public pc_sampling_collector_t
@@ -36,7 +53,49 @@ public:
     void on_code_object_load(const rocprofiler_callback_tracing_code_object_load_data_t& info) override;
     void write(code_object_writer_t& writer) override;
 
+    void   append_sample(const pc_sample_record_t& record) override;
+    void   add_kernel_symbol(uint64_t           code_object_id,
+                             const std::string& formatted_kernel_name,
+                             uint64_t           kernel_id) override;
+    void   add_agent(const agent_record_t& agent) override;
+    void   append_kernel_dispatch(const kernel_dispatch_record_t& record) override;
+    void   write_samples(pc_sample_writer_t& writer) override;
+    size_t snapshot_sources(const std::filesystem::path& output_root) override;
+
 private:
+    instruction_t resolve_instruction(uint64_t code_object_id, uint64_t code_object_offset);
+
+    template<typename Fn>
+    void for_each_instruction(Fn&& fn);
+
     std::shared_ptr<code_object_translator_t> m_translator;
+
+    std::mutex                            m_mutex;
+    std::vector<pc_sample_record_t>       m_samples;
+    std::vector<kernel_symbol_entry_t>    m_kernel_symbols;
+    std::vector<agent_record_t>           m_agents;
+    std::vector<kernel_dispatch_record_t> m_kernel_dispatches;
+    pc_string_table_t                     m_string_table;
 };
+
+template<typename Fn>
+void pc_sampling_collector_impl_t::for_each_instruction(Fn&& fn)
+{
+    for (const auto& id : m_translator->get_code_object_ids())
+    {
+        const auto& symbols = m_translator->get_symbols(id);
+        for (const auto& sym : symbols)
+        {
+            uint64_t       pc  = sym.virtual_address;
+            const uint64_t end = sym.virtual_address + sym.size;
+            while (pc < end)
+            {
+                const auto& inst = m_translator->get_instruction(id, pc);
+                Expects(inst.size);
+                fn(id, sym, inst);
+                pc += inst.size;
+            }
+        }
+    }
+}
 }  // namespace rocprofiler_compute_tool

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sampling_collector.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sampling_collector.h
@@ -83,18 +83,22 @@ void pc_sampling_collector_impl_t::for_each_instruction(Fn&& fn)
 {
     for (const auto& id : m_translator->get_code_object_ids())
     {
-        const auto& symbols = m_translator->get_symbols(id);
-        for (const auto& sym : symbols)
+        // Walk the whole loaded range so callers (e.g. source snapshotting) see
+        // every instruction, including code outside named symbols.
+        const uint64_t base      = m_translator->get_load_base(id);
+        const uint64_t range_end = base + m_translator->get_load_size(id);
+
+        uint64_t pc = base;
+        while (pc < range_end)
         {
-            uint64_t       pc  = sym.virtual_address;
-            const uint64_t end = sym.virtual_address + sym.size;
-            while (pc < end)
+            const auto inst = m_translator->get_instruction(id, pc);
+            if (inst.size == 0)
             {
-                const auto& inst = m_translator->get_instruction(id, pc);
-                Expects(inst.size);
-                fn(id, sym, inst);
-                pc += inst.size;
+                pc += sizeof(uint32_t);
+                continue;
             }
+            fn(id, inst);
+            pc += inst.size;
         }
     }
 }

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/source_snapshot.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/source_snapshot.cpp
@@ -60,6 +60,15 @@ size_t rocprofiler_compute_tool::source_snapshot_impl_t::snapshot(
         std::error_code             ec;
         const std::filesystem::path src{ref};
 
+        // Reject a symlinked source outright (lstat, no follow): copy_file follows
+        // symlinks at the source, so a symlink could redirect the read outside
+        // allowed_root after the containment check (TOCTOU). Refusing symlinks
+        // closes that window at the cost of not snapshotting symlinked sources.
+        if (std::filesystem::is_symlink(std::filesystem::symlink_status(src, ec)) || ec)
+        {
+            continue;
+        }
+
         // Resolve symlinks and require the source inside allowed_root.
         const auto canon_src = std::filesystem::weakly_canonical(src, ec);
         if (ec || canon_allowed_root.empty() || !is_inside(canon_allowed_root, canon_src))

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/source_snapshot.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/source_snapshot.cpp
@@ -1,0 +1,108 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#include "source_snapshot.h"
+
+#include <memory>
+#include <set>
+#include <system_error>
+
+using namespace rocprofiler_compute_tool;
+
+std::shared_ptr<source_snapshot_t> source_snapshot_t::create()
+{
+    return std::make_shared<source_snapshot_impl_t>();
+}
+
+std::optional<std::string> rocprofiler_compute_tool::source_snapshot_impl_t::parse_ref(
+    const std::string& comment) const
+{
+    if (comment.empty())
+    {
+        return std::nullopt;
+    }
+
+    const auto pos = comment.rfind(':');
+    if (pos == std::string::npos || pos == 0)
+    {
+        return std::nullopt;
+    }
+
+    return comment.substr(0, pos);
+}
+
+size_t rocprofiler_compute_tool::source_snapshot_impl_t::snapshot(
+    const std::vector<std::string>& source_refs,
+    const std::filesystem::path&    output_root,
+    const std::filesystem::path&    allowed_root) const
+{
+    const std::filesystem::path sources_root = output_root / "code_obj_sources";
+
+    std::set<std::string> unique_refs;
+    for (const auto& ref : source_refs)
+    {
+        unique_refs.insert(ref);
+    }
+
+    // Canonicalize the roots so the bounds checks below resolve symlinks.
+    std::error_code root_ec;
+    const auto      canon_allowed_root = std::filesystem::weakly_canonical(allowed_root, root_ec);
+    const auto      canon_sources_root = std::filesystem::weakly_canonical(sources_root, root_ec);
+
+    const auto is_inside = [](const std::filesystem::path& base, const std::filesystem::path& candidate)
+    {
+        const auto rel = candidate.lexically_relative(base);
+        return !rel.empty() && *rel.begin() != "..";
+    };
+
+    size_t copied = 0;
+    for (const auto& ref : unique_refs)
+    {
+        std::error_code             ec;
+        const std::filesystem::path src{ref};
+
+        // Resolve symlinks and require the source inside allowed_root.
+        const auto canon_src = std::filesystem::weakly_canonical(src, ec);
+        if (ec || canon_allowed_root.empty() || !is_inside(canon_allowed_root, canon_src))
+        {
+            continue;
+        }
+        if (!std::filesystem::is_regular_file(canon_src, ec) || ec)
+        {
+            continue;
+        }
+
+        std::string relative = ref;
+        while (!relative.empty() && relative.front() == '/')
+        {
+            relative.erase(relative.begin());
+        }
+
+        const std::filesystem::path dst = sources_root / relative;
+
+        // Reject destinations escaping code_obj_sources, canonicalizing the existing
+        // prefix so a planted symlink cannot redirect the write out of the snapshot dir.
+        const auto canon_dst_parent = std::filesystem::weakly_canonical(dst.parent_path(), ec);
+        if (ec || canon_sources_root.empty() || !is_inside(canon_sources_root, canon_dst_parent))
+        {
+            continue;
+        }
+
+        std::filesystem::create_directories(dst.parent_path(), ec);
+        if (ec)
+        {
+            continue;
+        }
+
+        // skip_existing avoids following/clobbering a pre-planted destination.
+        const bool ok = std::filesystem::copy_file(canon_src,
+                                                   dst,
+                                                   std::filesystem::copy_options::skip_existing,
+                                                   ec);
+        if (ok && !ec)
+        {
+            ++copied;
+        }
+    }
+
+    return copied;
+}

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/source_snapshot.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/source_snapshot.h
@@ -1,0 +1,40 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#pragma once
+
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace rocprofiler_compute_tool
+{
+class source_snapshot_t
+{
+public:
+    static std::shared_ptr<source_snapshot_t> create();
+
+    virtual ~source_snapshot_t() = default;
+
+    // Returns the substring before the last ':' (the path); std::nullopt if there is none.
+    virtual std::optional<std::string> parse_ref(const std::string& comment) const = 0;
+
+    // Copies each unique ref under output_root/"code_obj_sources"/<ref path>; returns the count.
+    // Refs are untrusted, so one is read only if it resolves inside allowed_root and its
+    // destination stays within code_obj_sources; others are skipped without throwing.
+    virtual size_t snapshot(
+        const std::vector<std::string>& source_refs,
+        const std::filesystem::path&    output_root,
+        const std::filesystem::path&    allowed_root = std::filesystem::current_path()) const = 0;
+};
+
+class source_snapshot_impl_t : public source_snapshot_t
+{
+public:
+    std::optional<std::string> parse_ref(const std::string& comment) const override;
+    size_t snapshot(const std::vector<std::string>& source_refs,
+                    const std::filesystem::path&    output_root,
+                    const std::filesystem::path& allowed_root = std::filesystem::current_path()) const override;
+};
+}  // namespace rocprofiler_compute_tool

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/CMakeLists.txt
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/CMakeLists.txt
@@ -9,6 +9,14 @@ add_executable(
     test_pc_sampling_collector.cpp
     test_code_object_writer.h
     test_code_object_writer.cpp
+    test_pc_sample_writer.h
+    test_pc_sample_writer.cpp
+    test_pc_sample_decode.h
+    test_pc_sample_decode.cpp
+    test_pc_string_table.h
+    test_pc_string_table.cpp
+    test_source_snapshot.h
+    test_source_snapshot.cpp
     mocks.h
     mocks.cpp
 )

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/mocks.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/mocks.cpp
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier:  MIT
 #include "mocks.h"
 
+#include <stdexcept>
+#include <utility>
+
 using namespace rocprofiler_compute_tool;
 
 void mock_code_object_translator_t::add_code_object(const char* filepath,
@@ -37,9 +40,25 @@ std::vector<symbol_t> mock_code_object_translator_t::get_symbols(size_t object_i
     return {};
 }
 
-instruction_t mock_code_object_translator_t::get_instruction(size_t, uint64_t) const
+instruction_t mock_code_object_translator_t::get_instruction(size_t object_id, uint64_t virtual_address) const
 {
+    m_instruction_queries.emplace_back(object_id, virtual_address);
+    if (m_throw_virtual_address && *m_throw_virtual_address == virtual_address)
+    {
+        throw std::out_of_range("mock: no instruction at virtual address");
+    }
     return m_instruction;
+}
+
+uint64_t mock_code_object_translator_t::get_load_base(size_t object_id) const
+{
+    for (const auto& info : m_mem_code_obj_info)
+        if (info.id == object_id)
+            return info.load_base;
+    for (const auto& info : m_file_code_obj_info)
+        if (info.id == object_id)
+            return info.load_base;
+    return 0;
 }
 
 void mock_code_object_translator_t::add_symbols(size_t object_id,
@@ -51,6 +70,16 @@ void mock_code_object_translator_t::add_symbols(size_t object_id,
 void mock_code_object_translator_t::add_instruction(const rocprofiler_compute_tool::instruction_t& instruction)
 {
     m_instruction = instruction;
+}
+
+void mock_code_object_translator_t::throw_for_virtual_address(uint64_t virtual_address)
+{
+    m_throw_virtual_address = virtual_address;
+}
+
+const std::vector<std::pair<size_t, uint64_t>>& mock_code_object_translator_t::get_instruction_queries() const
+{
+    return m_instruction_queries;
 }
 
 const std::vector<mock_code_object_translator_t::mem_code_object_info_t>&

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/mocks.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/mocks.cpp
@@ -61,6 +61,17 @@ uint64_t mock_code_object_translator_t::get_load_base(size_t object_id) const
     return 0;
 }
 
+uint64_t mock_code_object_translator_t::get_load_size(size_t object_id) const
+{
+    for (const auto& info : m_mem_code_obj_info)
+        if (info.id == object_id)
+            return info.load_size;
+    for (const auto& info : m_file_code_obj_info)
+        if (info.id == object_id)
+            return info.load_size;
+    return 0;
+}
+
 void mock_code_object_translator_t::add_symbols(size_t object_id,
                                                 const std::vector<rocprofiler_compute_tool::symbol_t>& symbols)
 {

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/mocks.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/mocks.h
@@ -4,8 +4,10 @@
 #include "code_object_translator.h"
 #include "code_object_writer.h"
 
+#include <optional>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 class mock_code_object_translator_t : public rocprofiler_compute_tool::code_object_translator_t
@@ -39,19 +41,28 @@ public:
     std::vector<rocprofiler_compute_tool::symbol_t> get_symbols(size_t object_id) const override;
     rocprofiler_compute_tool::instruction_t get_instruction(size_t object_id,
                                                             uint64_t virtual_address) const override;
+    uint64_t get_load_base(size_t object_id) const override;
 
     void add_symbols(size_t object_id, const std::vector<rocprofiler_compute_tool::symbol_t>& symbols);
     void add_instruction(const rocprofiler_compute_tool::instruction_t& instruction);
 
+    // When set, get_instruction throws std::out_of_range for this virtual
+    // address, modelling a PC that resolves to no decoded instruction.
+    void throw_for_virtual_address(uint64_t virtual_address);
+
     const std::vector<mem_code_object_info_t>&  get_mem_code_object_info() const;
     const std::vector<file_code_object_info_t>& get_file_code_object_info() const;
+    // get_instruction queries, in call order.
+    const std::vector<std::pair<size_t, uint64_t>>& get_instruction_queries() const;
 
 private:
     std::vector<mem_code_object_info_t>  m_mem_code_obj_info;
     std::vector<file_code_object_info_t> m_file_code_obj_info;
     std::vector<size_t>                  m_code_object_ids;
     std::unordered_map<size_t, std::vector<rocprofiler_compute_tool::symbol_t>> m_symbols_per_obj;
-    rocprofiler_compute_tool::instruction_t m_instruction = {"", "", 0, 0, 1};
+    rocprofiler_compute_tool::instruction_t          m_instruction = {"", "", 0, 0, 1};
+    mutable std::vector<std::pair<size_t, uint64_t>> m_instruction_queries;
+    std::optional<uint64_t>                          m_throw_virtual_address;
 };
 
 class mock_code_object_writer_t : public rocprofiler_compute_tool::code_object_writer_t

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/mocks.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/mocks.h
@@ -42,6 +42,7 @@ public:
     rocprofiler_compute_tool::instruction_t get_instruction(size_t object_id,
                                                             uint64_t virtual_address) const override;
     uint64_t get_load_base(size_t object_id) const override;
+    uint64_t get_load_size(size_t object_id) const override;
 
     void add_symbols(size_t object_id, const std::vector<rocprofiler_compute_tool::symbol_t>& symbols);
     void add_instruction(const rocprofiler_compute_tool::instruction_t& instruction);

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_pc_sample_decode.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_pc_sample_decode.cpp
@@ -92,6 +92,62 @@ TEST_F(test_pc_sample_decode_t, ProvidedHostTrapHeader_MapsCommonFieldsAndLeaves
     EXPECT_EQ(decoded->snapshot.stall_reason, 0u);
 }
 
+TEST_F(test_pc_sample_decode_t, ProvidedKernelDispatchHeader_MapsEveryFieldOneToOne)
+{
+    auto rec    = make_kernel_dispatch_record();
+    auto header = make_header(ROCPROFILER_BUFFER_CATEGORY_TRACING,
+                              ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH,
+                              &rec);
+
+    const auto decoded = rct::decode_kernel_dispatch_record(header);
+    ASSERT_TRUE(decoded.has_value());
+
+    EXPECT_EQ(decoded->size, sizeof(rec));
+    EXPECT_EQ(decoded->kind, static_cast<uint32_t>(ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH));
+    EXPECT_EQ(decoded->operation, static_cast<uint32_t>(ROCPROFILER_KERNEL_DISPATCH_COMPLETE));
+    EXPECT_EQ(decoded->thread_id, 4242u);
+    EXPECT_EQ(decoded->corr_internal, 55u);
+    EXPECT_EQ(decoded->corr_external, 66u);
+    EXPECT_EQ(decoded->start_timestamp, 1000u);
+    EXPECT_EQ(decoded->end_timestamp, 2000u);
+
+    EXPECT_EQ(decoded->dispatch_info_size, sizeof(rec.dispatch_info));
+    EXPECT_EQ(decoded->agent_id_handle, 7u);
+    EXPECT_EQ(decoded->queue_id_handle, 8u);
+    EXPECT_EQ(decoded->kernel_id, 9u);
+    EXPECT_EQ(decoded->dispatch_id, 10u);
+    EXPECT_EQ(decoded->private_segment_size, 11u);
+    EXPECT_EQ(decoded->group_segment_size, 12u);
+
+    EXPECT_EQ(decoded->workgroup_size.x, 64u);
+    EXPECT_EQ(decoded->workgroup_size.y, 2u);
+    EXPECT_EQ(decoded->workgroup_size.z, 1u);
+
+    EXPECT_EQ(decoded->grid_size.x, 1024u);
+    EXPECT_EQ(decoded->grid_size.y, 16u);
+    EXPECT_EQ(decoded->grid_size.z, 4u);
+}
+
+TEST_F(test_pc_sample_decode_t, ProvidedNonTracingCategoryToKernelDispatch_ReturnsNullopt)
+{
+    auto rec    = make_kernel_dispatch_record();
+    auto header = make_header(ROCPROFILER_BUFFER_CATEGORY_PC_SAMPLING,
+                              ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH,
+                              &rec);
+
+    EXPECT_FALSE(rct::decode_kernel_dispatch_record(header).has_value());
+}
+
+TEST_F(test_pc_sample_decode_t, ProvidedWrongTracingKindToKernelDispatch_ReturnsNullopt)
+{
+    auto rec    = make_kernel_dispatch_record();
+    auto header = make_header(ROCPROFILER_BUFFER_CATEGORY_TRACING,
+                              ROCPROFILER_BUFFER_TRACING_MEMORY_COPY,
+                              &rec);
+
+    EXPECT_FALSE(rct::decode_kernel_dispatch_record(header).has_value());
+}
+
 TEST_F(test_pc_sample_decode_t, ProvidedNonPcSamplingCategory_ReturnsNullopt)
 {
     auto rec    = make_stochastic_record();

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_pc_sample_decode.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_pc_sample_decode.cpp
@@ -1,0 +1,111 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#include "test_pc_sample_decode.h"
+
+namespace rct = rocprofiler_compute_tool;
+
+TEST_F(test_pc_sample_decode_t, ProvidedStochasticHeader_MapsEveryFieldOneToOne)
+{
+    auto rec    = make_stochastic_record();
+    auto header = make_header(ROCPROFILER_BUFFER_CATEGORY_PC_SAMPLING,
+                              ROCPROFILER_PC_SAMPLING_RECORD_STOCHASTIC_V0_SAMPLE,
+                              &rec);
+
+    const auto decoded = rct::decode_pc_sample_record(header);
+    ASSERT_TRUE(decoded.has_value());
+
+    EXPECT_EQ(decoded->kind, rct::pc_sample_kind_t::Stochastic);
+
+    EXPECT_EQ(decoded->hw_id.chiplet, 3u);
+    EXPECT_EQ(decoded->hw_id.wave_id, 5u);
+    EXPECT_EQ(decoded->hw_id.simd_id, 2u);
+    EXPECT_EQ(decoded->hw_id.pipe_id, 4u);
+    EXPECT_EQ(decoded->hw_id.cu_or_wgp_id, 6u);
+    EXPECT_EQ(decoded->hw_id.shader_array_id, 1u);
+    EXPECT_EQ(decoded->hw_id.shader_engine_id, 7u);
+    EXPECT_EQ(decoded->hw_id.workgroup_id, 9u);
+    EXPECT_EQ(decoded->hw_id.vm_id, 11u);
+    EXPECT_EQ(decoded->hw_id.queue_id, 4u);
+    EXPECT_EQ(decoded->hw_id.microengine_id, 2u);
+
+    EXPECT_EQ(decoded->pc.code_object_id, 2u);
+    EXPECT_EQ(decoded->pc.code_object_offset, 8040u);
+
+    EXPECT_EQ(decoded->exec_mask, 0xFFFFFFFFFFFFFFFFULL);
+    EXPECT_EQ(decoded->timestamp, 1234567890ULL);
+    EXPECT_EQ(decoded->dispatch_id, 3u);
+
+    EXPECT_EQ(decoded->corr_id.internal, 3u);
+    EXPECT_EQ(decoded->corr_id.external, 99u);
+
+    EXPECT_EQ(decoded->wrkgrp_id.x, 142u);
+    EXPECT_EQ(decoded->wrkgrp_id.y, 0u);
+    EXPECT_EQ(decoded->wrkgrp_id.z, 0u);
+
+    EXPECT_EQ(decoded->wave_in_grp, 1u);
+    EXPECT_EQ(decoded->wave_issued, 0u);
+    EXPECT_EQ(decoded->wave_cnt, 12u);
+
+    // Decode stores the raw SDK enum value; the name is resolved at serialization.
+    EXPECT_EQ(decoded->inst_type, static_cast<uint32_t>(ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_VALU));
+
+    EXPECT_EQ(decoded->snapshot.stall_reason,
+              static_cast<uint32_t>(ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_WAITCNT));
+
+    EXPECT_EQ(decoded->snapshot.dual_issue_valu, 1u);
+    EXPECT_EQ(decoded->snapshot.arb_state_issue_valu, 1u);
+    EXPECT_EQ(decoded->snapshot.arb_state_stall_lds, 1u);
+}
+
+TEST_F(test_pc_sample_decode_t, ProvidedHostTrapHeader_MapsCommonFieldsAndLeavesStochasticDefault)
+{
+    auto rec    = make_host_trap_record();
+    auto header = make_header(ROCPROFILER_BUFFER_CATEGORY_PC_SAMPLING,
+                              ROCPROFILER_PC_SAMPLING_RECORD_HOST_TRAP_V0_SAMPLE,
+                              &rec);
+
+    const auto decoded = rct::decode_pc_sample_record(header);
+    ASSERT_TRUE(decoded.has_value());
+
+    EXPECT_EQ(decoded->kind, rct::pc_sample_kind_t::HostTrap);
+
+    EXPECT_EQ(decoded->hw_id.chiplet, 3u);
+    EXPECT_EQ(decoded->hw_id.wave_id, 5u);
+    EXPECT_EQ(decoded->hw_id.shader_engine_id, 7u);
+
+    EXPECT_EQ(decoded->pc.code_object_id, 2u);
+    EXPECT_EQ(decoded->pc.code_object_offset, 8040u);
+
+    EXPECT_EQ(decoded->exec_mask, 0xFFFFFFFFFFFFFFFFULL);
+    EXPECT_EQ(decoded->timestamp, 1234567890ULL);
+    EXPECT_EQ(decoded->dispatch_id, 3u);
+
+    EXPECT_EQ(decoded->corr_id.internal, 3u);
+    EXPECT_EQ(decoded->corr_id.external, 99u);
+
+    EXPECT_EQ(decoded->wrkgrp_id.x, 142u);
+    EXPECT_EQ(decoded->wave_in_grp, 1u);
+
+    // Stochastic-only fields are left default (0) for host-trap samples.
+    EXPECT_EQ(decoded->wave_cnt, 0u);
+    EXPECT_EQ(decoded->inst_type, 0u);
+    EXPECT_EQ(decoded->snapshot.stall_reason, 0u);
+}
+
+TEST_F(test_pc_sample_decode_t, ProvidedNonPcSamplingCategory_ReturnsNullopt)
+{
+    auto rec    = make_stochastic_record();
+    auto header = make_header(ROCPROFILER_BUFFER_CATEGORY_TRACING,
+                              ROCPROFILER_PC_SAMPLING_RECORD_STOCHASTIC_V0_SAMPLE,
+                              &rec);
+
+    EXPECT_FALSE(rct::decode_pc_sample_record(header).has_value());
+}
+
+TEST_F(test_pc_sample_decode_t, ProvidedUnsupportedKind_ReturnsNullopt)
+{
+    auto rec    = make_stochastic_record();
+    auto header = make_header(ROCPROFILER_BUFFER_CATEGORY_PC_SAMPLING, 0xFFFFFFFFu, &rec);
+
+    EXPECT_FALSE(rct::decode_pc_sample_record(header).has_value());
+}

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_pc_sample_decode.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_pc_sample_decode.h
@@ -7,6 +7,7 @@
 #include "gtest/gtest.h"
 #include "pc_sample_decode.h"
 
+#include <rocprofiler-sdk/buffer_tracing.h>
 #include <rocprofiler-sdk/fwd.h>
 #include <rocprofiler-sdk/pc_sampling.h>
 
@@ -90,6 +91,38 @@ protected:
         rec.workgroup_id.z = 0;
 
         rec.wave_in_group = 1;
+
+        return rec;
+    }
+
+    // Fully-populated kernel-dispatch record. Every field is given a distinct,
+    // non-zero value so a field swap in the decoder is observable.
+    static rocprofiler_buffer_tracing_kernel_dispatch_record_t make_kernel_dispatch_record()
+    {
+        rocprofiler_buffer_tracing_kernel_dispatch_record_t rec{};
+        rec.size            = sizeof(rec);
+        rec.kind            = ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH;
+        rec.operation       = ROCPROFILER_KERNEL_DISPATCH_COMPLETE;
+        rec.thread_id       = 4242;
+        rec.start_timestamp = 1000;
+        rec.end_timestamp   = 2000;
+
+        rec.correlation_id.internal       = 55;
+        rec.correlation_id.external.value = 66;
+
+        rec.dispatch_info.size                 = sizeof(rec.dispatch_info);
+        rec.dispatch_info.agent_id.handle      = 7;
+        rec.dispatch_info.queue_id.handle      = 8;
+        rec.dispatch_info.kernel_id            = 9;
+        rec.dispatch_info.dispatch_id          = 10;
+        rec.dispatch_info.private_segment_size = 11;
+        rec.dispatch_info.group_segment_size   = 12;
+        rec.dispatch_info.workgroup_size.x     = 64;
+        rec.dispatch_info.workgroup_size.y     = 2;
+        rec.dispatch_info.workgroup_size.z     = 1;
+        rec.dispatch_info.grid_size.x          = 1024;
+        rec.dispatch_info.grid_size.y          = 16;
+        rec.dispatch_info.grid_size.z          = 4;
 
         return rec;
     }

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_pc_sample_decode.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_pc_sample_decode.h
@@ -5,7 +5,7 @@
 #define ROCPROFILER_SDK_EXPERIMENTAL
 
 #include "gtest/gtest.h"
-#include "pc_sample_writer.h"
+#include "pc_sample_decode.h"
 
 #include <rocprofiler-sdk/fwd.h>
 #include <rocprofiler-sdk/pc_sampling.h>

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_pc_sample_decode.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_pc_sample_decode.h
@@ -1,0 +1,106 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#pragma once
+
+#define ROCPROFILER_SDK_EXPERIMENTAL
+
+#include "gtest/gtest.h"
+#include "pc_sample_writer.h"
+
+#include <rocprofiler-sdk/fwd.h>
+#include <rocprofiler-sdk/pc_sampling.h>
+
+class test_pc_sample_decode_t : public ::testing::Test
+{
+protected:
+    // Fully-populated stochastic record.
+    static rocprofiler_pc_sampling_record_stochastic_v0_t make_stochastic_record()
+    {
+        rocprofiler_pc_sampling_record_stochastic_v0_t rec{};
+        rec.size = sizeof(rec);
+
+        rec.hw_id.chiplet          = 3;
+        rec.hw_id.wave_id          = 5;
+        rec.hw_id.simd_id          = 2;
+        rec.hw_id.pipe_id          = 4;
+        rec.hw_id.cu_or_wgp_id     = 6;
+        rec.hw_id.shader_array_id  = 1;
+        rec.hw_id.shader_engine_id = 7;
+        rec.hw_id.workgroup_id     = 9;
+        rec.hw_id.vm_id            = 11;
+        rec.hw_id.queue_id         = 4;
+        rec.hw_id.microengine_id   = 2;
+
+        rec.pc.code_object_id     = 2;
+        rec.pc.code_object_offset = 8040;
+
+        rec.exec_mask   = 0xFFFFFFFFFFFFFFFFULL;
+        rec.timestamp   = 1234567890ULL;
+        rec.dispatch_id = 3;
+
+        rec.correlation_id.internal       = 3;
+        rec.correlation_id.external.value = 99;
+
+        rec.workgroup_id.x = 142;
+        rec.workgroup_id.y = 0;
+        rec.workgroup_id.z = 0;
+
+        rec.wave_in_group = 1;
+        rec.wave_issued   = 0;
+        rec.inst_type     = ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_VALU;
+        rec.wave_count    = 12;
+
+        rec.snapshot.reason_not_issued = ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_WAITCNT;
+        rec.snapshot.dual_issue_valu      = 1;
+        rec.snapshot.arb_state_issue_valu = 1;
+        rec.snapshot.arb_state_stall_lds  = 1;
+
+        return rec;
+    }
+
+    static rocprofiler_pc_sampling_record_host_trap_v0_t make_host_trap_record()
+    {
+        rocprofiler_pc_sampling_record_host_trap_v0_t rec{};
+        rec.size = sizeof(rec);
+
+        rec.hw_id.chiplet          = 3;
+        rec.hw_id.wave_id          = 5;
+        rec.hw_id.simd_id          = 2;
+        rec.hw_id.pipe_id          = 4;
+        rec.hw_id.cu_or_wgp_id     = 6;
+        rec.hw_id.shader_array_id  = 1;
+        rec.hw_id.shader_engine_id = 7;
+        rec.hw_id.workgroup_id     = 9;
+        rec.hw_id.vm_id            = 11;
+        rec.hw_id.queue_id         = 4;
+        rec.hw_id.microengine_id   = 2;
+
+        rec.pc.code_object_id     = 2;
+        rec.pc.code_object_offset = 8040;
+
+        rec.exec_mask   = 0xFFFFFFFFFFFFFFFFULL;
+        rec.timestamp   = 1234567890ULL;
+        rec.dispatch_id = 3;
+
+        rec.correlation_id.internal       = 3;
+        rec.correlation_id.external.value = 99;
+
+        rec.workgroup_id.x = 142;
+        rec.workgroup_id.y = 0;
+        rec.workgroup_id.z = 0;
+
+        rec.wave_in_group = 1;
+
+        return rec;
+    }
+
+    // Wrap a record payload into a buffer record header with the given (category, kind).
+    static rocprofiler_record_header_t make_header(uint32_t category, uint32_t kind, void* payload)
+    {
+        rocprofiler_record_header_t header{};
+        header.category = category;
+        header.kind     = kind;
+        header.payload  = payload;
+        return header;
+    }
+};

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_pc_sample_writer.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_pc_sample_writer.cpp
@@ -24,7 +24,7 @@ TEST_F(test_pc_sample_writer_t, ProvidedStochasticRecord_SerializesUnderStochast
     const auto record = make_stochastic_record();
 
     m_writer.begin();
-    m_writer.append_stochastic(record, record.inst_index);
+    m_writer.append_stochastic(record, 5);
 
     const auto  json       = nlohmann::json::parse(m_writer.get_result());
     const auto& root       = json["rocprofiler-sdk-tool"][0];
@@ -115,7 +115,7 @@ TEST_F(test_pc_sample_writer_t, ProvidedHostTrapRecord_SerializesWithoutStochast
     const auto record = make_host_trap_record();
 
     m_writer.begin();
-    m_writer.append_host_trap(record, record.inst_index);
+    m_writer.append_host_trap(record, 8);
 
     const auto  json      = nlohmann::json::parse(m_writer.get_result());
     const auto& root      = json["rocprofiler-sdk-tool"][0];

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_pc_sample_writer.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_pc_sample_writer.cpp
@@ -1,0 +1,367 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#include "test_pc_sample_writer.h"
+
+#include "nlohmann/json.hpp"
+
+#include <unistd.h>
+
+#include <filesystem>
+#include <fstream>
+
+TEST_F(test_pc_sample_writer_t, ProvidedBegin_TopKeyIsSingleElementArray)
+{
+    m_writer.begin();
+
+    const auto json = nlohmann::json::parse(m_writer.get_result());
+    ASSERT_TRUE(json.contains("rocprofiler-sdk-tool"));
+    ASSERT_TRUE(json["rocprofiler-sdk-tool"].is_array());
+    EXPECT_EQ(json["rocprofiler-sdk-tool"].size(), 1u);
+}
+
+TEST_F(test_pc_sample_writer_t, ProvidedStochasticRecord_SerializesUnderStochasticBuffer)
+{
+    const auto record = make_stochastic_record();
+
+    m_writer.begin();
+    m_writer.append_stochastic(record, record.inst_index);
+
+    const auto  json       = nlohmann::json::parse(m_writer.get_result());
+    const auto& root       = json["rocprofiler-sdk-tool"][0];
+    const auto& stochastic = root["buffer_records"]["pc_sample_stochastic"];
+    ASSERT_EQ(stochastic.size(), 1u);
+
+    const auto& entry = stochastic[0];
+
+    // inst_index is a SIBLING of "record", not inside it.
+    ASSERT_TRUE(entry.contains("inst_index"));
+    EXPECT_EQ(entry["inst_index"], 5);
+
+    const auto& rec = entry["record"];
+    ASSERT_FALSE(rec.contains("inst_index"));
+
+    EXPECT_EQ(rec["flags"]["has_mem_cnt"], record.flags.has_mem_cnt);
+
+    EXPECT_EQ(rec["hw_id"]["chiplet"], record.hw_id.chiplet);
+    EXPECT_EQ(rec["hw_id"]["wave_id"], record.hw_id.wave_id);
+    EXPECT_EQ(rec["hw_id"]["simd_id"], record.hw_id.simd_id);
+    EXPECT_EQ(rec["hw_id"]["pipe_id"], record.hw_id.pipe_id);
+    EXPECT_EQ(rec["hw_id"]["cu_or_wgp_id"], record.hw_id.cu_or_wgp_id);
+    EXPECT_EQ(rec["hw_id"]["shader_array_id"], record.hw_id.shader_array_id);
+    EXPECT_EQ(rec["hw_id"]["shader_engine_id"], record.hw_id.shader_engine_id);
+    EXPECT_EQ(rec["hw_id"]["workgroup_id"], record.hw_id.workgroup_id);
+    EXPECT_EQ(rec["hw_id"]["vm_id"], record.hw_id.vm_id);
+    EXPECT_EQ(rec["hw_id"]["queue_id"], record.hw_id.queue_id);
+    EXPECT_EQ(rec["hw_id"]["microengine_id"], record.hw_id.microengine_id);
+
+    EXPECT_EQ(rec["pc"]["code_object_id"], record.pc.code_object_id);
+    EXPECT_EQ(rec["pc"]["code_object_offset"], record.pc.code_object_offset);
+
+    EXPECT_EQ(rec["exec_mask"], record.exec_mask);
+    EXPECT_EQ(rec["timestamp"], record.timestamp);
+    EXPECT_EQ(rec["dispatch_id"], record.dispatch_id);
+
+    EXPECT_EQ(rec["corr_id"]["internal"], record.corr_id.internal);
+    EXPECT_EQ(rec["corr_id"]["external"], record.corr_id.external);
+
+    EXPECT_EQ(rec["wrkgrp_id"]["x"], record.wrkgrp_id.x);
+    EXPECT_EQ(rec["wrkgrp_id"]["y"], record.wrkgrp_id.y);
+    EXPECT_EQ(rec["wrkgrp_id"]["z"], record.wrkgrp_id.z);
+
+    EXPECT_EQ(rec["wave_in_grp"], record.wave_in_grp);
+    EXPECT_EQ(rec["wave_issued"], record.wave_issued);
+    EXPECT_EQ(rec["wave_cnt"], record.wave_cnt);
+
+    // inst_type is serialized as the SDK enum-name string for the raw value.
+    ASSERT_TRUE(rec["inst_type"].is_string());
+    EXPECT_EQ(rec["inst_type"],
+              rocprofiler_get_pc_sampling_instruction_type_name(
+                  static_cast<rocprofiler_pc_sampling_instruction_type_t>(record.inst_type)));
+
+    // snapshot.stall_reason is serialized as the SDK enum-name string.
+    const auto& snap = rec["snapshot"];
+    ASSERT_TRUE(snap["stall_reason"].is_string());
+    EXPECT_EQ(snap["stall_reason"],
+              rocprofiler_get_pc_sampling_instruction_not_issued_reason_name(
+                  static_cast<rocprofiler_pc_sampling_instruction_not_issued_reason_t>(
+                      record.snapshot.stall_reason)));
+    EXPECT_EQ(snap["dual_issue_valu"], record.snapshot.dual_issue_valu);
+
+    EXPECT_EQ(snap["arb_state_issue_valu"], record.snapshot.arb_state_issue_valu);
+    EXPECT_EQ(snap["arb_state_issue_matrix"], record.snapshot.arb_state_issue_matrix);
+    EXPECT_EQ(snap["arb_state_issue_lds"], record.snapshot.arb_state_issue_lds);
+    EXPECT_EQ(snap["arb_state_issue_lds_direct"], record.snapshot.arb_state_issue_lds_direct);
+    EXPECT_EQ(snap["arb_state_issue_scalar"], record.snapshot.arb_state_issue_scalar);
+    EXPECT_EQ(snap["arb_state_issue_vmem_tex"], record.snapshot.arb_state_issue_vmem_tex);
+    EXPECT_EQ(snap["arb_state_issue_flat"], record.snapshot.arb_state_issue_flat);
+    EXPECT_EQ(snap["arb_state_issue_exp"], record.snapshot.arb_state_issue_exp);
+    EXPECT_EQ(snap["arb_state_issue_misc"], record.snapshot.arb_state_issue_misc);
+    EXPECT_EQ(snap["arb_state_issue_brmsg"], record.snapshot.arb_state_issue_brmsg);
+
+    EXPECT_EQ(snap["arb_state_stall_valu"], record.snapshot.arb_state_stall_valu);
+    EXPECT_EQ(snap["arb_state_stall_matrix"], record.snapshot.arb_state_stall_matrix);
+    EXPECT_EQ(snap["arb_state_stall_lds"], record.snapshot.arb_state_stall_lds);
+    EXPECT_EQ(snap["arb_state_stall_lds_direct"], record.snapshot.arb_state_stall_lds_direct);
+    EXPECT_EQ(snap["arb_state_stall_scalar"], record.snapshot.arb_state_stall_scalar);
+    EXPECT_EQ(snap["arb_state_stall_vmem_tex"], record.snapshot.arb_state_stall_vmem_tex);
+    EXPECT_EQ(snap["arb_state_stall_flat"], record.snapshot.arb_state_stall_flat);
+    EXPECT_EQ(snap["arb_state_stall_exp"], record.snapshot.arb_state_stall_exp);
+    EXPECT_EQ(snap["arb_state_stall_misc"], record.snapshot.arb_state_stall_misc);
+    EXPECT_EQ(snap["arb_state_stall_brmsg"], record.snapshot.arb_state_stall_brmsg);
+}
+
+TEST_F(test_pc_sample_writer_t, ProvidedHostTrapRecord_SerializesWithoutStochasticOnlyFields)
+{
+    const auto record = make_host_trap_record();
+
+    m_writer.begin();
+    m_writer.append_host_trap(record, record.inst_index);
+
+    const auto  json      = nlohmann::json::parse(m_writer.get_result());
+    const auto& root      = json["rocprofiler-sdk-tool"][0];
+    const auto& host_trap = root["buffer_records"]["pc_sample_host_trap"];
+    ASSERT_EQ(host_trap.size(), 1u);
+
+    const auto& entry = host_trap[0];
+    ASSERT_TRUE(entry.contains("inst_index"));
+    EXPECT_EQ(entry["inst_index"], 8);
+
+    const auto& rec = entry["record"];
+    EXPECT_FALSE(rec.contains("snapshot"));
+    EXPECT_FALSE(rec.contains("wave_cnt"));
+    EXPECT_FALSE(rec.contains("inst_type"));
+
+    ASSERT_TRUE(rec.contains("hw_id"));
+    ASSERT_TRUE(rec.contains("pc"));
+    EXPECT_EQ(rec["exec_mask"], record.exec_mask);
+    EXPECT_EQ(rec["timestamp"], record.timestamp);
+    EXPECT_EQ(rec["dispatch_id"], record.dispatch_id);
+    EXPECT_EQ(rec["corr_id"]["internal"], record.corr_id.internal);
+    EXPECT_EQ(rec["corr_id"]["external"], record.corr_id.external);
+    EXPECT_EQ(rec["wrkgrp_id"]["x"], record.wrkgrp_id.x);
+    EXPECT_EQ(rec["wave_in_grp"], record.wave_in_grp);
+}
+
+TEST_F(test_pc_sample_writer_t, ProvidedStringTable_SerializesInstructionsAndComments)
+{
+    rocprofiler_compute_tool::pc_string_table_t string_table;
+    string_table.insert("s_nop", "a.cpp:1");
+    string_table.insert("v_add", "b.cpp:2");
+
+    m_writer.begin();
+    m_writer.set_strings(string_table);
+
+    const auto  json    = nlohmann::json::parse(m_writer.get_result());
+    const auto& strings = json["rocprofiler-sdk-tool"][0]["strings"];
+
+    ASSERT_TRUE(strings["pc_sample_instructions"].is_array());
+    ASSERT_EQ(strings["pc_sample_instructions"].size(), 2u);
+    EXPECT_EQ(strings["pc_sample_instructions"][0], "s_nop");
+    EXPECT_EQ(strings["pc_sample_instructions"][1], "v_add");
+
+    ASSERT_TRUE(strings["pc_sample_comments"].is_array());
+    ASSERT_EQ(strings["pc_sample_comments"].size(), 2u);
+    EXPECT_EQ(strings["pc_sample_comments"][0], "a.cpp:1");
+    EXPECT_EQ(strings["pc_sample_comments"][1], "b.cpp:2");
+}
+
+TEST_F(test_pc_sample_writer_t, ProvidedKernelSymbols_SerializesThemInOrder)
+{
+    const std::vector<rocprofiler_compute_tool::kernel_symbol_entry_t> syms{
+        {2, "foo"},
+        {3, "bar"},
+    };
+
+    m_writer.begin();
+    m_writer.set_kernel_symbols(syms);
+
+    const auto  json           = nlohmann::json::parse(m_writer.get_result());
+    const auto& kernel_symbols = json["rocprofiler-sdk-tool"][0]["kernel_symbols"];
+
+    ASSERT_EQ(kernel_symbols.size(), 2u);
+    EXPECT_EQ(kernel_symbols[0]["code_object_id"], 2);
+    EXPECT_EQ(kernel_symbols[0]["formatted_kernel_name"], "foo");
+    EXPECT_EQ(kernel_symbols[1]["code_object_id"], 3);
+    EXPECT_EQ(kernel_symbols[1]["formatted_kernel_name"], "bar");
+}
+
+TEST_F(test_pc_sample_writer_t, ProvidedNoApiTraces_AllApiCategoriesAreEmptyArrays)
+{
+    m_writer.begin();
+
+    const auto  json           = nlohmann::json::parse(m_writer.get_result());
+    const auto& buffer_records = json["rocprofiler-sdk-tool"][0]["buffer_records"];
+
+    for (const char* category : {"hip_api",
+                                 "hsa_api",
+                                 "memory_copy",
+                                 "marker_api",
+                                 "rccl_api",
+                                 "memory_allocation",
+                                 "scratch_memory",
+                                 "kfd",
+                                 "rocdecode_api",
+                                 "rocjpeg_api"})
+    {
+        ASSERT_TRUE(buffer_records.contains(category)) << category;
+        ASSERT_TRUE(buffer_records[category].is_array()) << category;
+        EXPECT_EQ(buffer_records[category].size(), 0u) << category;
+    }
+}
+
+TEST_F(test_pc_sample_writer_t, ProvidedNoRecords_ReturnsValidJsonWithEmptySampleArrays)
+{
+    m_writer.begin();
+
+    const auto& result = m_writer.get_result();
+    EXPECT_FALSE(result.empty());
+    EXPECT_TRUE(nlohmann::json::accept(result));
+
+    const auto  json           = nlohmann::json::parse(result);
+    const auto& buffer_records = json["rocprofiler-sdk-tool"][0]["buffer_records"];
+
+    ASSERT_TRUE(buffer_records["pc_sample_stochastic"].is_array());
+    EXPECT_EQ(buffer_records["pc_sample_stochastic"].size(), 0u);
+
+    ASSERT_TRUE(buffer_records["pc_sample_host_trap"].is_array());
+    EXPECT_EQ(buffer_records["pc_sample_host_trap"].size(), 0u);
+}
+
+TEST_F(test_pc_sample_writer_t, ProvidedEmptyOutputFilePath_Throws)
+{
+    m_writer.begin();
+    EXPECT_THROW(m_writer.flush(""), std::runtime_error);
+}
+
+TEST_F(test_pc_sample_writer_t, ProvidedUnopenableOutputFilePath_Throws)
+{
+    m_writer.begin();
+    // A path whose "parent" is an existing regular file cannot be opened/created.
+    const auto tmp = std::filesystem::temp_directory_path() /
+                     ("rpc_pcw_" + std::to_string(::getpid()) + ".json");
+    {
+        std::ofstream ofs(tmp);
+        ofs << "x";
+    }
+    const auto unopenable = tmp / "child.json";  // tmp is a file, not a dir
+    EXPECT_THROW(m_writer.flush(unopenable), std::runtime_error);
+    std::error_code ec;
+    std::filesystem::remove(tmp, ec);
+}
+
+// Cross-language contract: pin the exact key path the Python analyze side
+// (analysis_db.calc_pc_sampling_data) reads, so a rename here fails loudly.
+TEST_F(test_pc_sample_writer_t, SerializesContractKeyPathConsumedByAnalyze)
+{
+    const auto stochastic = make_stochastic_record();
+    const auto host_trap  = make_host_trap_record();
+
+    rocprofiler_compute_tool::pc_string_table_t string_table;
+    const size_t                                idx = string_table.insert("v_add", "kernel.cpp:7");
+
+    m_writer.begin();
+    m_writer.append_stochastic(stochastic, idx);
+    m_writer.append_host_trap(host_trap, idx);
+    m_writer.set_strings(string_table);
+    m_writer.set_kernel_symbols({{42, "my_kernel(int)"}});
+    m_writer.set_metadata(1234);
+
+    const auto json = nlohmann::json::parse(m_writer.get_result());
+
+    ASSERT_TRUE(json["rocprofiler-sdk-tool"].is_array());
+    const auto& root = json["rocprofiler-sdk-tool"][0];
+
+    ASSERT_TRUE(root["buffer_records"]["pc_sample_stochastic"].is_array());
+    ASSERT_TRUE(root["buffer_records"]["pc_sample_host_trap"].is_array());
+    ASSERT_TRUE(root["strings"]["pc_sample_instructions"].is_array());
+    ASSERT_TRUE(root["strings"]["pc_sample_comments"].is_array());
+    ASSERT_TRUE(root["kernel_symbols"].is_array());
+
+    // inst_index is a sibling of "record", referencing the string tables.
+    const auto& s_entry = root["buffer_records"]["pc_sample_stochastic"][0];
+    ASSERT_TRUE(s_entry.contains("record"));
+    ASSERT_TRUE(s_entry.contains("inst_index"));
+    EXPECT_EQ(s_entry["inst_index"], idx);
+    EXPECT_EQ(root["strings"]["pc_sample_instructions"][idx], "v_add");
+    EXPECT_EQ(root["strings"]["pc_sample_comments"][idx], "kernel.cpp:7");
+
+    const auto& k = root["kernel_symbols"][0];
+    EXPECT_EQ(k["code_object_id"], 42u);
+    EXPECT_EQ(k["formatted_kernel_name"], "my_kernel(int)");
+}
+
+TEST_F(test_pc_sample_writer_t, ProvidedAgents_SerializesThemInSdkShape)
+{
+    const auto agent = make_agent_record();
+
+    m_writer.begin();
+    m_writer.set_agents({agent});
+
+    const auto  json   = nlohmann::json::parse(m_writer.get_result());
+    const auto& agents = json["rocprofiler-sdk-tool"][0]["agents"];
+
+    ASSERT_TRUE(agents.is_array());
+    ASSERT_EQ(agents.size(), 1u);
+
+    const auto& a = agents[0];
+    EXPECT_EQ(a["size"], agent.size);
+    EXPECT_EQ(a["id"]["handle"], agent.id_handle);
+    EXPECT_EQ(a["type"], agent.type);
+    EXPECT_EQ(a["node_id"], agent.node_id);
+    EXPECT_EQ(a["logical_node_id"], agent.logical_node_id);
+    EXPECT_EQ(a["cu_count"], agent.cu_count);
+    EXPECT_EQ(a["gpu_id"], agent.gpu_id);
+    EXPECT_EQ(a["wave_front_size"], agent.wave_front_size);
+    EXPECT_EQ(a["simd_count"], agent.simd_count);
+}
+
+TEST_F(test_pc_sample_writer_t, ProvidedKernelDispatches_SerializesThemInSdkShape)
+{
+    const auto dispatch = make_kernel_dispatch_record();
+
+    m_writer.begin();
+    m_writer.set_kernel_dispatches({dispatch});
+
+    const auto  json = nlohmann::json::parse(m_writer.get_result());
+    const auto& kd   = json["rocprofiler-sdk-tool"][0]["buffer_records"]["kernel_dispatch"];
+
+    ASSERT_TRUE(kd.is_array());
+    ASSERT_EQ(kd.size(), 1u);
+
+    const auto& d = kd[0];
+    EXPECT_EQ(d["size"], dispatch.size);
+    EXPECT_EQ(d["kind"], dispatch.kind);
+    EXPECT_EQ(d["operation"], dispatch.operation);
+    EXPECT_EQ(d["thread_id"], dispatch.thread_id);
+    EXPECT_EQ(d["correlation_id"]["internal"], dispatch.corr_internal);
+    EXPECT_EQ(d["correlation_id"]["external"], dispatch.corr_external);
+    EXPECT_EQ(d["start_timestamp"], dispatch.start_timestamp);
+    EXPECT_EQ(d["end_timestamp"], dispatch.end_timestamp);
+
+    const auto& di = d["dispatch_info"];
+    EXPECT_EQ(di["size"], dispatch.dispatch_info_size);
+    EXPECT_EQ(di["agent_id"]["handle"], dispatch.agent_id_handle);
+    EXPECT_EQ(di["queue_id"]["handle"], dispatch.queue_id_handle);
+    EXPECT_EQ(di["kernel_id"], dispatch.kernel_id);
+    EXPECT_EQ(di["dispatch_id"], dispatch.dispatch_id);
+    EXPECT_EQ(di["private_segment_size"], dispatch.private_segment_size);
+    EXPECT_EQ(di["group_segment_size"], dispatch.group_segment_size);
+    EXPECT_EQ(di["workgroup_size"]["x"], dispatch.workgroup_size.x);
+    EXPECT_EQ(di["workgroup_size"]["y"], dispatch.workgroup_size.y);
+    EXPECT_EQ(di["workgroup_size"]["z"], dispatch.workgroup_size.z);
+    EXPECT_EQ(di["grid_size"]["x"], dispatch.grid_size.x);
+    EXPECT_EQ(di["grid_size"]["y"], dispatch.grid_size.y);
+    EXPECT_EQ(di["grid_size"]["z"], dispatch.grid_size.z);
+}
+
+TEST_F(test_pc_sample_writer_t, ProvidedKernelSymbols_SerializesKernelId)
+{
+    m_writer.begin();
+    m_writer.set_kernel_symbols({{7, "foo", 99}});
+
+    const auto  json = nlohmann::json::parse(m_writer.get_result());
+    const auto& k    = json["rocprofiler-sdk-tool"][0]["kernel_symbols"][0];
+    EXPECT_EQ(k["code_object_id"], 7u);
+    EXPECT_EQ(k["formatted_kernel_name"], "foo");
+    EXPECT_EQ(k["kernel_id"], 99u);
+}

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_pc_sample_writer.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_pc_sample_writer.h
@@ -1,0 +1,157 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#pragma once
+
+#include "gtest/gtest.h"
+#include "pc_sample_writer.h"
+
+#include <rocprofiler-sdk/pc_sampling.h>
+
+class test_pc_sample_writer_t : public ::testing::Test
+{
+protected:
+    rocprofiler_compute_tool::pc_sample_writer_json_t m_writer;
+
+    static rocprofiler_compute_tool::pc_sample_record_t make_stochastic_record()
+    {
+        rocprofiler_compute_tool::pc_sample_record_t r{};
+        r.kind = rocprofiler_compute_tool::pc_sample_kind_t::Stochastic;
+
+        r.flags.has_mem_cnt = 1;
+
+        r.hw_id.chiplet          = 1;
+        r.hw_id.wave_id          = 2;
+        r.hw_id.simd_id          = 3;
+        r.hw_id.pipe_id          = 4;
+        r.hw_id.cu_or_wgp_id     = 5;
+        r.hw_id.shader_array_id  = 6;
+        r.hw_id.shader_engine_id = 7;
+        r.hw_id.workgroup_id     = 8;
+        r.hw_id.vm_id            = 9;
+        r.hw_id.queue_id         = 10;
+        r.hw_id.microengine_id   = 11;
+
+        r.pc.code_object_id     = 42;
+        r.pc.code_object_offset = 0x1234;
+
+        r.exec_mask   = 0xABCDEF;
+        r.timestamp   = 555;
+        r.dispatch_id = 77;
+
+        r.corr_id.internal = 3;
+        r.corr_id.external = 99;
+
+        r.wrkgrp_id.x = 12;
+        r.wrkgrp_id.y = 0;
+        r.wrkgrp_id.z = 0;
+
+        r.wave_in_grp = 2;
+        r.wave_issued = 1;
+        r.inst_type   = ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_VALU;
+        r.wave_cnt    = 27;
+
+        r.snapshot.stall_reason    = ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_WAITCNT;
+        r.snapshot.dual_issue_valu = 1;
+
+        r.snapshot.arb_state_issue_valu       = 1;
+        r.snapshot.arb_state_issue_matrix     = 2;
+        r.snapshot.arb_state_issue_lds        = 3;
+        r.snapshot.arb_state_issue_lds_direct = 4;
+        r.snapshot.arb_state_issue_scalar     = 5;
+        r.snapshot.arb_state_issue_vmem_tex   = 6;
+        r.snapshot.arb_state_issue_flat       = 7;
+        r.snapshot.arb_state_issue_exp        = 8;
+        r.snapshot.arb_state_issue_misc       = 9;
+        r.snapshot.arb_state_issue_brmsg      = 10;
+
+        r.snapshot.arb_state_stall_valu       = 11;
+        r.snapshot.arb_state_stall_matrix     = 12;
+        r.snapshot.arb_state_stall_lds        = 13;
+        r.snapshot.arb_state_stall_lds_direct = 14;
+        r.snapshot.arb_state_stall_scalar     = 15;
+        r.snapshot.arb_state_stall_vmem_tex   = 16;
+        r.snapshot.arb_state_stall_flat       = 17;
+        r.snapshot.arb_state_stall_exp        = 18;
+        r.snapshot.arb_state_stall_misc       = 19;
+        r.snapshot.arb_state_stall_brmsg      = 20;
+
+        r.inst_index = 5;
+        return r;
+    }
+
+    static rocprofiler_compute_tool::pc_sample_record_t make_host_trap_record()
+    {
+        rocprofiler_compute_tool::pc_sample_record_t r{};
+        r.kind = rocprofiler_compute_tool::pc_sample_kind_t::HostTrap;
+
+        r.hw_id.chiplet          = 1;
+        r.hw_id.wave_id          = 2;
+        r.hw_id.simd_id          = 3;
+        r.hw_id.pipe_id          = 4;
+        r.hw_id.cu_or_wgp_id     = 5;
+        r.hw_id.shader_array_id  = 6;
+        r.hw_id.shader_engine_id = 7;
+        r.hw_id.workgroup_id     = 8;
+        r.hw_id.vm_id            = 9;
+        r.hw_id.queue_id         = 10;
+        r.hw_id.microengine_id   = 11;
+
+        r.pc.code_object_id     = 42;
+        r.pc.code_object_offset = 0x1234;
+
+        r.exec_mask   = 0xABCDEF;
+        r.timestamp   = 555;
+        r.dispatch_id = 77;
+
+        r.corr_id.internal = 3;
+        r.corr_id.external = 99;
+
+        r.wrkgrp_id.x = 12;
+        r.wrkgrp_id.y = 0;
+        r.wrkgrp_id.z = 0;
+
+        r.wave_in_grp = 2;
+
+        r.inst_index = 8;
+        return r;
+    }
+
+    static rocprofiler_compute_tool::agent_record_t make_agent_record()
+    {
+        rocprofiler_compute_tool::agent_record_t a{};
+        a.size            = 312;
+        a.id_handle       = 18942;
+        a.type            = 2;  // GPU
+        a.node_id         = 2;
+        a.logical_node_id = 2;
+        a.cu_count        = 304;
+        a.gpu_id          = 4567;
+        a.wave_front_size = 64;
+        a.simd_count      = 1216;
+        return a;
+    }
+
+    static rocprofiler_compute_tool::kernel_dispatch_record_t make_kernel_dispatch_record()
+    {
+        rocprofiler_compute_tool::kernel_dispatch_record_t d{};
+        d.size            = 184;
+        d.kind            = 11;
+        d.operation       = 2;
+        d.thread_id       = 298597;
+        d.corr_internal   = 1;
+        d.corr_external   = 0;
+        d.start_timestamp = 1987779595190273ULL;
+        d.end_timestamp   = 1987779595198565ULL;
+
+        d.dispatch_info_size   = 72;
+        d.agent_id_handle      = 18942;
+        d.queue_id_handle      = 2;
+        d.kernel_id            = 12;
+        d.dispatch_id          = 1;
+        d.private_segment_size = 0;
+        d.group_segment_size   = 0;
+        d.workgroup_size       = {256, 1, 1};
+        d.grid_size            = {1048576, 1, 1};
+        return d;
+    }
+};

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_pc_sample_writer.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_pc_sample_writer.h
@@ -75,7 +75,6 @@ protected:
         r.snapshot.arb_state_stall_misc       = 19;
         r.snapshot.arb_state_stall_brmsg      = 20;
 
-        r.inst_index = 5;
         return r;
     }
 
@@ -112,7 +111,6 @@ protected:
 
         r.wave_in_grp = 2;
 
-        r.inst_index = 8;
         return r;
     }
 

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_pc_sampling_collector.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_pc_sampling_collector.cpp
@@ -50,45 +50,53 @@ TEST_F(test_pc_sampling_collector_t, ProvidedCodeObjects_WritesTheirIds)
     EXPECT_EQ(m_writer->get_start_code_obj_ids()[1], m_mem_info.code_object_id);
 }
 
-TEST_F(test_pc_sampling_collector_t, ProvidedCodeObjectSymbols_WritesThem)
+TEST_F(test_pc_sampling_collector_t, WritesOneSpanSymbolPerCodeObject)
 {
+    // write() now disassembles the whole loaded range under a single span symbol
+    // per code object, independent of named ELF symbols.
     m_pc_sampling_collector->on_code_object_load(m_file_info);
     m_pc_sampling_collector->on_code_object_load(m_mem_info);
-    const std::vector<symbol_t> symbols0 = {{"name0", 0x10, 0x1000, 1}, {"name1", 0x20, 0x2000, 0x60}};
-    const std::vector<symbol_t> symbols1 = {{"name2", 0x11, 0x1001, 1}, {"name3", 0x21, 0x2001, 0x61}};
-    m_translator->add_symbols(m_file_info.code_object_id, symbols0);
-    m_translator->add_symbols(m_mem_info.code_object_id, symbols1);
+    const instruction_t instruction = {"inst0", "comment0", 0x1000, 0x10, 4};
+    m_translator->add_instruction(instruction);
+
     m_pc_sampling_collector->write(*m_writer);
-    EXPECT_EQ(m_writer->get_symbol_descriptions().size(), 4);
-    EXPECT_EQ(m_writer->get_symbol_descriptions()[0].name, symbols0[0].name);
-    EXPECT_EQ(m_writer->get_symbol_descriptions()[1].name, symbols0[1].name);
-    EXPECT_EQ(m_writer->get_symbol_descriptions()[2].name, symbols1[0].name);
-    EXPECT_EQ(m_writer->get_symbol_descriptions()[3].name, symbols1[1].name);
+
+    // One span symbol per code object, each covering the full load_size.
+    ASSERT_EQ(m_writer->get_symbol_descriptions().size(), 2u);
+    EXPECT_EQ(m_writer->get_symbol_descriptions()[0].size, m_file_info.load_size);
+    EXPECT_EQ(m_writer->get_symbol_descriptions()[1].size, m_mem_info.load_size);
+    EXPECT_EQ(m_writer->get_symbol_descriptions()[0].code_object_offset, 0u);
 }
 
-TEST_F(test_pc_sampling_collector_t, ProvidedSymbolInstructions_WritesThem)
+TEST_F(test_pc_sampling_collector_t, WritesInstructionsAcrossTheWholeLoadedRange)
 {
-    m_pc_sampling_collector->on_code_object_load(m_file_info);
     m_pc_sampling_collector->on_code_object_load(m_mem_info);
-    const std::vector<symbol_t> symbols = {{"name0", 0x10, 0x1000, 2}};
-    m_translator->add_symbols(m_file_info.code_object_id, symbols);
-    m_translator->add_symbols(m_mem_info.code_object_id, symbols);
-    const instruction_t instruction = {"inst0", "comment0", 0x1000, 0x10, 1};
+    // Fixed-size instruction; the walk covers [load_base, load_base + load_size).
+    const instruction_t instruction = {"inst0", "comment0", 0x1000, 0x10, 4};
     m_translator->add_instruction(instruction);
+
     m_pc_sampling_collector->write(*m_writer);
-    EXPECT_EQ(m_writer->get_instruction_descriptions().size(), symbols[0].size * 2);
+
+    // load_size / inst.size instructions, regardless of named symbols.
+    const size_t expected = m_mem_info.load_size / instruction.size;
+    EXPECT_EQ(m_writer->get_instruction_descriptions().size(), expected);
+    // The walk queries the decoder at load_base + offset across the range.
+    const auto& queries = m_translator->get_instruction_queries();
+    ASSERT_FALSE(queries.empty());
+    EXPECT_EQ(queries.front().second, m_mem_info.load_base);
 }
 
-TEST_F(test_pc_sampling_collector_t, ProvidedSymbolInstructionSizeZero_Throws)
+TEST_F(test_pc_sampling_collector_t, UndecodableRegionDoesNotAbortWalk)
 {
-    m_pc_sampling_collector->on_code_object_load(m_file_info);
     m_pc_sampling_collector->on_code_object_load(m_mem_info);
-    const std::vector<symbol_t> symbols = {{"name0", 0x10, 0x1000, 2}};
-    m_translator->add_symbols(m_file_info.code_object_id, symbols);
-    m_translator->add_symbols(m_mem_info.code_object_id, symbols);
-    const instruction_t instruction = {"inst0", "comment0", 0x1000, 0x10, 0};
+    // size 0 models an undecodable word; the walk must skip it and keep going,
+    // not loop forever or throw.
+    const instruction_t instruction = {"", "", 0x1000, 0x0, 0};
     m_translator->add_instruction(instruction);
-    EXPECT_THROW(m_pc_sampling_collector->write(*m_writer), std::runtime_error);
+
+    EXPECT_NO_THROW(m_pc_sampling_collector->write(*m_writer));
+    EXPECT_EQ(m_writer->get_instruction_descriptions().size(), 0u);
+    EXPECT_EQ(m_writer->get_end_code_obj_count(), 1u);
 }
 
 TEST_F(test_pc_sampling_collector_t, WriteSamples_DedupsAndRoutesByKind)
@@ -196,9 +204,8 @@ TEST_F(test_pc_sampling_collector_t, SnapshotSources_CopiesSourcesParsedFromInst
                               ("rpc_snapshot_out_" + std::to_string(::getpid()));
 
     m_pc_sampling_collector->on_code_object_load(m_mem_info);
-    const std::vector<symbol_t> symbols = {{"name0", 0x10, 0x1000, 1}};
-    m_translator->add_symbols(m_mem_info.code_object_id, symbols);
-    // Comment parses to rel_src.
+    // Comment parses to rel_src. The full-range walk surfaces it without needing
+    // a named symbol.
     m_translator->add_instruction({"v_add", rel_src.string() + ":7", 0x1000, 0x10, 1});
 
     const size_t copied = m_pc_sampling_collector->snapshot_sources(out_root);

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_pc_sampling_collector.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_pc_sampling_collector.cpp
@@ -2,6 +2,14 @@
 // SPDX-License-Identifier:  MIT
 #include "test_pc_sampling_collector.h"
 
+#include "nlohmann/json.hpp"
+
+#include <unistd.h>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
 using namespace rocprofiler_compute_tool;
 
 TEST_F(test_pc_sampling_collector_t, ProvidedFileCodeObject_PassesItToDecode)
@@ -81,6 +89,126 @@ TEST_F(test_pc_sampling_collector_t, ProvidedSymbolInstructionSizeZero_Throws)
     const instruction_t instruction = {"inst0", "comment0", 0x1000, 0x10, 0};
     m_translator->add_instruction(instruction);
     EXPECT_THROW(m_pc_sampling_collector->write(*m_writer), std::runtime_error);
+}
+
+TEST_F(test_pc_sampling_collector_t, WriteSamples_DedupsAndRoutesByKind)
+{
+    m_pc_sampling_collector->on_code_object_load(m_mem_info);
+    // The mock translator returns this instruction for any (id, vaddr) lookup,
+    // so both samples resolve to the same (name, comment) index 0.
+    m_translator->add_instruction({"v_add", "kernel.cpp:7", 0x1000, 0x10, 4});
+
+    pc_sample_record_t stochastic{};
+    stochastic.kind                  = pc_sample_kind_t::Stochastic;
+    stochastic.pc.code_object_id     = m_mem_info.code_object_id;
+    stochastic.pc.code_object_offset = 0x10;
+
+    pc_sample_record_t host_trap{};
+    host_trap.kind                  = pc_sample_kind_t::HostTrap;
+    host_trap.pc.code_object_id     = m_mem_info.code_object_id;
+    host_trap.pc.code_object_offset = 0x20;
+
+    m_pc_sampling_collector->append_sample(stochastic);
+    m_pc_sampling_collector->append_sample(host_trap);
+
+    pc_sample_writer_json_t writer;
+    m_pc_sampling_collector->write_samples(writer);
+
+    const auto  json = nlohmann::json::parse(writer.get_result());
+    const auto& root = json["rocprofiler-sdk-tool"][0];
+
+    ASSERT_EQ(root["buffer_records"]["pc_sample_stochastic"].size(), 1u);
+    ASSERT_EQ(root["buffer_records"]["pc_sample_host_trap"].size(), 1u);
+
+    EXPECT_EQ(root["buffer_records"]["pc_sample_stochastic"][0]["inst_index"], 0);
+    EXPECT_EQ(root["buffer_records"]["pc_sample_host_trap"][0]["inst_index"], 0);
+    ASSERT_EQ(root["strings"]["pc_sample_instructions"].size(), 1u);
+    EXPECT_EQ(root["strings"]["pc_sample_instructions"][0], "v_add");
+    EXPECT_EQ(root["strings"]["pc_sample_comments"][0], "kernel.cpp:7");
+}
+
+TEST_F(test_pc_sampling_collector_t, WriteSamples_TranslatesOffsetByLoadBase)
+{
+    m_pc_sampling_collector->on_code_object_load(m_mem_info);
+    m_translator->add_instruction({"v_add", "kernel.cpp:7", 0x1000, 0x10, 4});
+
+    pc_sample_record_t sample{};
+    sample.kind                  = pc_sample_kind_t::HostTrap;
+    sample.pc.code_object_id     = m_mem_info.code_object_id;
+    sample.pc.code_object_offset = 0x40;
+    m_pc_sampling_collector->append_sample(sample);
+
+    pc_sample_writer_json_t writer;
+    m_pc_sampling_collector->write_samples(writer);
+
+    // The PC offset (0x40) must be translated to a virtual address by adding the
+    // code object's load base (0x1000) before instruction lookup.
+    const auto& queries = m_translator->get_instruction_queries();
+    ASSERT_EQ(queries.size(), 1u);
+    EXPECT_EQ(queries[0].first, m_mem_info.code_object_id);
+    EXPECT_EQ(queries[0].second, 0x40u + m_mem_info.load_base);
+}
+
+TEST_F(test_pc_sampling_collector_t, WriteSamples_UnresolvedPcInsertsEmptyInstruction)
+{
+    m_pc_sampling_collector->on_code_object_load(m_mem_info);
+    m_translator->add_instruction({"v_add", "kernel.cpp:7", 0x1000, 0x10, 4});
+
+    // A PC whose translated virtual address has no decoded instruction: the
+    // translator throws std::out_of_range and the sample degrades to an empty
+    // (instruction, comment) entry instead of aborting serialization.
+    const uint64_t offset = 0x40;
+    m_translator->throw_for_virtual_address(offset + m_mem_info.load_base);
+
+    pc_sample_record_t sample{};
+    sample.kind                  = pc_sample_kind_t::HostTrap;
+    sample.pc.code_object_id     = m_mem_info.code_object_id;
+    sample.pc.code_object_offset = offset;
+    m_pc_sampling_collector->append_sample(sample);
+
+    pc_sample_writer_json_t writer;
+    EXPECT_NO_THROW(m_pc_sampling_collector->write_samples(writer));
+
+    const auto  json = nlohmann::json::parse(writer.get_result());
+    const auto& root = json["rocprofiler-sdk-tool"][0];
+
+    ASSERT_EQ(root["buffer_records"]["pc_sample_host_trap"].size(), 1u);
+    EXPECT_EQ(root["buffer_records"]["pc_sample_host_trap"][0]["inst_index"], 0);
+    ASSERT_EQ(root["strings"]["pc_sample_instructions"].size(), 1u);
+    EXPECT_EQ(root["strings"]["pc_sample_instructions"][0], "");
+    EXPECT_EQ(root["strings"]["pc_sample_comments"][0], "");
+}
+
+TEST_F(test_pc_sampling_collector_t, SnapshotSources_CopiesSourcesParsedFromInstructionComments)
+{
+    namespace fs = std::filesystem;
+
+    // snapshot_sources resolves refs against the current working directory, so
+    // the source file must live under CWD to be inside the allowed root.
+    const fs::path rel_dir = fs::path{"rpc_snapshot_sources_test_" + std::to_string(::getpid())};
+    const fs::path rel_src = rel_dir / "kernel.cpp";
+    fs::create_directories(rel_dir);
+    {
+        std::ofstream ofs(rel_src);
+        ofs << "source contents\n";
+    }
+    const fs::path out_root = fs::temp_directory_path() /
+                              ("rpc_snapshot_out_" + std::to_string(::getpid()));
+
+    m_pc_sampling_collector->on_code_object_load(m_mem_info);
+    const std::vector<symbol_t> symbols = {{"name0", 0x10, 0x1000, 1}};
+    m_translator->add_symbols(m_mem_info.code_object_id, symbols);
+    // Comment parses to rel_src.
+    m_translator->add_instruction({"v_add", rel_src.string() + ":7", 0x1000, 0x10, 1});
+
+    const size_t copied = m_pc_sampling_collector->snapshot_sources(out_root);
+
+    EXPECT_EQ(copied, 1u);
+    EXPECT_TRUE(fs::exists(out_root / "code_obj_sources" / rel_dir / "kernel.cpp"));
+
+    std::error_code ec;
+    fs::remove_all(rel_dir, ec);
+    fs::remove_all(out_root, ec);
 }
 
 void test_pc_sampling_collector_t::SetUp()

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_pc_string_table.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_pc_string_table.cpp
@@ -1,0 +1,64 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#include "test_pc_string_table.h"
+
+TEST_F(test_pc_string_table_t, ProvidedFreshTable_InsertReturnsZeroAndStoresPair)
+{
+    EXPECT_EQ(m_string_table.insert("a", "x"), 0u);
+    ASSERT_EQ(m_string_table.instructions().size(), 1u);
+    ASSERT_EQ(m_string_table.comments().size(), 1u);
+    EXPECT_EQ(m_string_table.instructions()[0], "a");
+    EXPECT_EQ(m_string_table.comments()[0], "x");
+}
+
+TEST_F(test_pc_string_table_t, ProvidedSamePairTwice_DedupsToSameIndexWithoutGrowing)
+{
+    EXPECT_EQ(m_string_table.insert("a", "x"), 0u);
+    EXPECT_EQ(m_string_table.insert("a", "x"), 0u);
+    EXPECT_EQ(m_string_table.instructions().size(), 1u);
+    EXPECT_EQ(m_string_table.comments().size(), 1u);
+}
+
+TEST_F(test_pc_string_table_t, ProvidedNewPair_ReturnsNextIndexAndGrowsBothArrays)
+{
+    EXPECT_EQ(m_string_table.insert("a", "x"), 0u);
+    EXPECT_EQ(m_string_table.insert("b", "y"), 1u);
+    ASSERT_EQ(m_string_table.instructions().size(), 2u);
+    ASSERT_EQ(m_string_table.comments().size(), 2u);
+    EXPECT_EQ(m_string_table.instructions()[1], "b");
+    EXPECT_EQ(m_string_table.comments()[1], "y");
+}
+
+TEST_F(test_pc_string_table_t, ProvidedPartialMatches_KeyIsTheFullPairNotEitherFieldAlone)
+{
+    EXPECT_EQ(m_string_table.insert("a", "x"), 0u);
+
+    // Same text, different comment -> new entry.
+    const size_t same_text_idx = m_string_table.insert("a", "z");
+    EXPECT_NE(same_text_idx, 0u);
+
+    // Different text, same comment -> also new entry.
+    const size_t same_comment_idx = m_string_table.insert("c", "x");
+    EXPECT_NE(same_comment_idx, 0u);
+    EXPECT_NE(same_comment_idx, same_text_idx);
+
+    EXPECT_EQ(m_string_table.instructions().size(), 3u);
+    EXPECT_EQ(m_string_table.comments().size(), 3u);
+}
+
+TEST_F(test_pc_string_table_t, ProvidedSeveralPairs_ReturnedIndexEqualsPositionInBothParallelArrays)
+{
+    const size_t i0 = m_string_table.insert("mov", "// a");
+    const size_t i1 = m_string_table.insert("add", "// b");
+    const size_t i2 = m_string_table.insert("mul", "// c");
+
+    EXPECT_EQ(m_string_table.instructions()[i0], "mov");
+    EXPECT_EQ(m_string_table.comments()[i0], "// a");
+    EXPECT_EQ(m_string_table.instructions()[i1], "add");
+    EXPECT_EQ(m_string_table.comments()[i1], "// b");
+    EXPECT_EQ(m_string_table.instructions()[i2], "mul");
+    EXPECT_EQ(m_string_table.comments()[i2], "// c");
+
+    ASSERT_EQ(m_string_table.instructions().size(), m_string_table.comments().size());
+    EXPECT_EQ(m_string_table.insert("add", "// b"), i1);
+}

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_pc_string_table.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_pc_string_table.h
@@ -1,0 +1,12 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#pragma once
+
+#include "gtest/gtest.h"
+#include "pc_sample_writer.h"
+
+class test_pc_string_table_t : public ::testing::Test
+{
+protected:
+    rocprofiler_compute_tool::pc_string_table_t m_string_table;
+};

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_pc_string_table.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_pc_string_table.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #include "gtest/gtest.h"
-#include "pc_sample_writer.h"
+#include "pc_sample_types.h"
 
 class test_pc_string_table_t : public ::testing::Test
 {

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_source_snapshot.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_source_snapshot.cpp
@@ -132,3 +132,61 @@ TEST_F(test_source_snapshot_t, SnapshotSourceFiles_RefInsideAllowedRoot_IsCopied
     EXPECT_EQ(copied, 1u);
     EXPECT_TRUE(copied_somewhere_with_tail(m_output_root / "code_obj_sources", m_file_a, m_contents_a));
 }
+
+TEST_F(test_source_snapshot_t, SnapshotSourceFiles_SymlinkedSourceInsideAllowedRoot_IsRejected)
+{
+    // A symlink that lives INSIDE allowed_root but points OUTSIDE it must not be
+    // followed: copy_file would otherwise read the out-of-root target. Rejecting
+    // symlinked sources closes that TOCTOU window.
+    const auto allowed_root = m_tmp_root / "proj";
+    const auto outside      = m_tmp_root / "secret.txt";
+    write_file(outside, "secret\n");
+
+    const auto link = allowed_root / "link.cpp";
+    std::error_code ec;
+    std::filesystem::create_symlink(outside, link, ec);
+    ASSERT_FALSE(ec) << ec.message();
+
+    size_t copied = 0;
+    EXPECT_NO_THROW(copied = m_snapshotter.snapshot({link.string()}, m_output_root, allowed_root));
+
+    EXPECT_EQ(copied, 0u);
+    EXPECT_FALSE(copied_somewhere_with_tail(m_output_root / "code_obj_sources", outside, "secret\n"));
+}
+
+TEST_F(test_source_snapshot_t, SnapshotSourceFiles_DestinationParentSymlinkEscapingSourcesRoot_IsRejected)
+{
+    // Pre-plant a symlink at the first relative-path component inside
+    // code_obj_sources, pointing outside it. The destination for m_file_a resolves
+    // THROUGH that symlink, so the write must be refused: canon_dst_parent lands
+    // outside sources_root.
+    const auto allowed_root     = m_tmp_root / "proj";
+    const auto code_obj_sources = m_output_root / "code_obj_sources";
+    const auto escape_target    = m_tmp_root / "escape_target";
+    std::filesystem::create_directories(code_obj_sources);
+    std::filesystem::create_directories(escape_target);
+
+    // The impl strips leading '/' from the ref; the first remaining component is
+    // where we plant the redirecting symlink.
+    std::string relative = m_file_a.string();
+    while (!relative.empty() && relative.front() == '/')
+        relative.erase(relative.begin());
+    const auto first_component = std::filesystem::path{relative}.begin()->string();
+
+    std::error_code ec;
+    std::filesystem::create_directory_symlink(escape_target, code_obj_sources / first_component, ec);
+    ASSERT_FALSE(ec) << ec.message();
+
+    size_t copied = 0;
+    EXPECT_NO_THROW(copied = m_snapshotter.snapshot({m_file_a.string()}, m_output_root, allowed_root));
+
+    EXPECT_EQ(copied, 0u);
+    // Nothing was written THROUGH the symlink into escape_target.
+    bool escaped = false;
+    for (const auto& entry : std::filesystem::recursive_directory_iterator(escape_target))
+    {
+        if (entry.is_regular_file())
+            escaped = true;
+    }
+    EXPECT_FALSE(escaped);
+}

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_source_snapshot.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_source_snapshot.cpp
@@ -142,7 +142,7 @@ TEST_F(test_source_snapshot_t, SnapshotSourceFiles_SymlinkedSourceInsideAllowedR
     const auto outside      = m_tmp_root / "secret.txt";
     write_file(outside, "secret\n");
 
-    const auto link = allowed_root / "link.cpp";
+    const auto      link = allowed_root / "link.cpp";
     std::error_code ec;
     std::filesystem::create_symlink(outside, link, ec);
     ASSERT_FALSE(ec) << ec.message();

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_source_snapshot.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_source_snapshot.cpp
@@ -1,0 +1,134 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#include "test_source_snapshot.h"
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace
+{
+bool copied_somewhere_with_tail(const std::filesystem::path& code_obj_sources,
+                                const std::filesystem::path& original,
+                                const std::string&           expected_contents)
+{
+    if (!std::filesystem::exists(code_obj_sources))
+        return false;
+
+    const std::string tail = original.filename().string();
+    for (const auto& entry : std::filesystem::recursive_directory_iterator(code_obj_sources))
+    {
+        if (!entry.is_regular_file())
+            continue;
+        if (entry.path().filename().string() != tail)
+            continue;
+
+        std::ifstream     ifs(entry.path());
+        const std::string contents{std::istreambuf_iterator<char>(ifs),
+                                   std::istreambuf_iterator<char>{}};
+        if (contents == expected_contents)
+            return true;
+    }
+    return false;
+}
+}  // namespace
+
+TEST_F(test_source_snapshot_t, ParseSourceRef_PathBeforeLastColon)
+{
+    EXPECT_EQ(m_snapshotter.parse_ref("foo/bar.cpp:42"), std::optional<std::string>{"foo/bar.cpp"});
+    EXPECT_EQ(m_snapshotter.parse_ref("a:b:10"), std::optional<std::string>{"a:b"});
+}
+
+TEST_F(test_source_snapshot_t, ParseSourceRef_NoColon_ReturnsNullopt)
+{
+    EXPECT_EQ(m_snapshotter.parse_ref("no colon here"), std::nullopt);
+}
+
+TEST_F(test_source_snapshot_t, ParseSourceRef_LeadingColonOrEmpty_ReturnsNullopt)
+{
+    EXPECT_EQ(m_snapshotter.parse_ref(":30"), std::nullopt);
+    EXPECT_EQ(m_snapshotter.parse_ref(""), std::nullopt);
+}
+
+TEST_F(test_source_snapshot_t, SnapshotSourceFiles_CopiesExistingFilesPreservingTail)
+{
+    const std::vector<std::string> refs{m_file_a.string(), m_file_b.string()};
+
+    const size_t copied = m_snapshotter.snapshot(refs, m_output_root, m_tmp_root);
+
+    const auto code_obj_sources = m_output_root / "code_obj_sources";
+    EXPECT_EQ(copied, 2u);
+    EXPECT_TRUE(copied_somewhere_with_tail(code_obj_sources, m_file_a, m_contents_a));
+    EXPECT_TRUE(copied_somewhere_with_tail(code_obj_sources, m_file_b, m_contents_b));
+}
+
+TEST_F(test_source_snapshot_t, SnapshotSourceFiles_SkipsMissingRefs)
+{
+    const auto                     missing = (m_tmp_root / "proj" / "does_not_exist.cpp").string();
+    const std::vector<std::string> refs{m_file_a.string(), missing, m_file_b.string()};
+
+    size_t copied = 0;
+    EXPECT_NO_THROW(copied = m_snapshotter.snapshot(refs, m_output_root, m_tmp_root));
+
+    const auto code_obj_sources = m_output_root / "code_obj_sources";
+    EXPECT_EQ(copied, 2u);
+    EXPECT_TRUE(copied_somewhere_with_tail(code_obj_sources, m_file_a, m_contents_a));
+    EXPECT_TRUE(copied_somewhere_with_tail(code_obj_sources, m_file_b, m_contents_b));
+}
+
+TEST_F(test_source_snapshot_t, SnapshotSourceFiles_DedupsDuplicateRefs)
+{
+    const std::vector<std::string> refs{m_file_a.string(), m_file_a.string()};
+
+    const size_t copied = m_snapshotter.snapshot(refs, m_output_root, m_tmp_root);
+
+    const auto code_obj_sources = m_output_root / "code_obj_sources";
+    EXPECT_EQ(copied, 1u);
+    EXPECT_TRUE(copied_somewhere_with_tail(code_obj_sources, m_file_a, m_contents_a));
+}
+
+TEST_F(test_source_snapshot_t, SnapshotSourceFiles_RefEscapingAllowedRootViaDotDot_IsRejected)
+{
+    // A pre-existing file OUTSIDE the allowed root that a traversal ref targets.
+    const auto outside = m_tmp_root / "victim.txt";
+    write_file(outside, "original\n");
+
+    // allowed_root is the project subtree (m_tmp_root/proj). A ref that uses ".."
+    // to climb out of it to the victim must be refused: the resolved source lies
+    // outside allowed_root.
+    const auto allowed_root = m_tmp_root / "proj";
+    const auto traversal    = (allowed_root / ".." / "victim.txt").string();
+
+    size_t copied = 0;
+    EXPECT_NO_THROW(copied = m_snapshotter.snapshot({traversal}, m_output_root, allowed_root));
+
+    EXPECT_EQ(copied, 0u);
+    EXPECT_EQ(read_file(outside), "original\n");  // unchanged: not read/copied
+}
+
+TEST_F(test_source_snapshot_t, SnapshotSourceFiles_RefOutsideAllowedRoot_IsRejected)
+{
+    // A real, existing file that lives OUTSIDE the allowed root. A hostile ISA
+    // comment naming an absolute path (e.g. /etc/passwd) must not be read/copied.
+    const auto outside = m_tmp_root / "secret.txt";
+    write_file(outside, "secret\n");
+
+    const auto allowed_root = m_tmp_root / "proj";
+
+    size_t copied = 0;
+    EXPECT_NO_THROW(copied = m_snapshotter.snapshot({outside.string()}, m_output_root, allowed_root));
+
+    EXPECT_EQ(copied, 0u);
+    EXPECT_FALSE(copied_somewhere_with_tail(m_output_root / "code_obj_sources", outside, "secret\n"));
+}
+
+TEST_F(test_source_snapshot_t, SnapshotSourceFiles_RefInsideAllowedRoot_IsCopied)
+{
+    // Sanity: a file inside the allowed root IS copied (m_file_a lives under proj/).
+    const auto allowed_root = m_tmp_root / "proj";
+
+    const size_t copied = m_snapshotter.snapshot({m_file_a.string()}, m_output_root, allowed_root);
+
+    EXPECT_EQ(copied, 1u);
+    EXPECT_TRUE(copied_somewhere_with_tail(m_output_root / "code_obj_sources", m_file_a, m_contents_a));
+}

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_source_snapshot.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_source_snapshot.h
@@ -1,0 +1,59 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#pragma once
+
+#include "gtest/gtest.h"
+#include "source_snapshot.h"
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+class test_source_snapshot_t : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        m_tmp_root    = std::filesystem::temp_directory_path() /
+                        ("rpc_source_snapshot_" + std::to_string(::getpid()) + "_" +
+                         std::to_string(reinterpret_cast<uintptr_t>(this)));
+        m_output_root = m_tmp_root / "out";
+
+        m_file_a = m_tmp_root / "proj" / "a.cpp";
+        m_file_b = m_tmp_root / "proj" / "sub" / "b.cpp";
+
+        std::filesystem::create_directories(m_file_a.parent_path());
+        std::filesystem::create_directories(m_file_b.parent_path());
+        std::filesystem::create_directories(m_output_root);
+
+        write_file(m_file_a, m_contents_a);
+        write_file(m_file_b, m_contents_b);
+    }
+
+    void TearDown() override
+    {
+        std::error_code ec;
+        std::filesystem::remove_all(m_tmp_root, ec);
+    }
+
+    static void write_file(const std::filesystem::path& path, const std::string& contents)
+    {
+        std::ofstream ofs(path);
+        ofs << contents;
+    }
+
+    static std::string read_file(const std::filesystem::path& path)
+    {
+        std::ifstream ifs(path);
+        return std::string(std::istreambuf_iterator<char>(ifs), std::istreambuf_iterator<char>());
+    }
+
+    rocprofiler_compute_tool::source_snapshot_impl_t m_snapshotter;
+
+    std::filesystem::path m_tmp_root;
+    std::filesystem::path m_output_root;
+    std::filesystem::path m_file_a;
+    std::filesystem::path m_file_b;
+    const std::string     m_contents_a{"contents of a.cpp\n"};
+    const std::string     m_contents_b{"contents of sub/b.cpp\n"};
+};

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/environ_cache.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/environ_cache.cpp
@@ -8,11 +8,20 @@ extern "C" char** environ;
 
 namespace
 {
-constexpr std::string_view kRocprofPrefix{"ROCPROF"};
+// Capture the project's own ROCPROF_* variables and the rocprofiler-sdk's
+// ROCPROFILER_* family (e.g. ROCPROFILER_PC_SAMPLING_BETA_ENABLED). Matched
+// explicitly rather than via a bare "ROCPROF" substring so the namespace
+// boundary stays intentional and self-documenting.
+constexpr std::string_view kRocprofPrefixes[]{"ROCPROF_", "ROCPROFILER_"};
 
 bool has_rocprof_prefix(std::string_view name)
 {
-    return name.size() >= kRocprofPrefix.size() && name.substr(0, kRocprofPrefix.size()) == kRocprofPrefix;
+    for (const auto prefix : kRocprofPrefixes)
+    {
+        if (name.size() >= prefix.size() && name.substr(0, prefix.size()) == prefix)
+            return true;
+    }
+    return false;
 }
 
 }  // namespace

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/environ_cache.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/environ_cache.cpp
@@ -8,7 +8,7 @@ extern "C" char** environ;
 
 namespace
 {
-constexpr std::string_view kRocprofPrefix{"ROCPROF_"};
+constexpr std::string_view kRocprofPrefix{"ROCPROF"};
 
 bool has_rocprof_prefix(std::string_view name)
 {

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/input_parameters.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/input_parameters.cpp
@@ -55,3 +55,8 @@ std::string_view EnvInputParameters::get_pc_sampling_beta_enabled()
 {
     return get("ROCPROFILER_PC_SAMPLING_BETA_ENABLED", kDefaultPcSamplingBetaEnabled);
 }
+
+std::string_view EnvInputParameters::get_pc_sampling_interval()
+{
+    return get("ROCPROF_PC_SAMPLING_INTERVAL", kDefaultPcSamplingInterval);
+}

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/input_parameters.h
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/input_parameters.h
@@ -21,6 +21,7 @@ public:
     virtual std::string_view get_kernel_filter_range()         = 0;
     virtual std::string_view get_pc_sampling_method()          = 0;
     virtual std::string_view get_pc_sampling_beta_enabled()    = 0;
+    virtual std::string_view get_pc_sampling_interval()        = 0;
 };
 
 class EnvInputParameters : public InputParameters
@@ -33,6 +34,7 @@ public:
     static constexpr std::string_view kDefaultKernelFilterRange{""};
     static constexpr std::string_view kDefaultPcSamplingMethod{""};
     static constexpr std::string_view kDefaultPcSamplingBetaEnabled{""};
+    static constexpr std::string_view kDefaultPcSamplingInterval{""};
 
     explicit EnvInputParameters(std::shared_ptr<const EnvironCache> environ = EnvironCache::instance());
     std::string_view get_output_path() override;
@@ -42,6 +44,7 @@ public:
     std::string_view get_kernel_filter_range() override;
     std::string_view get_pc_sampling_method() override;
     std::string_view get_pc_sampling_beta_enabled() override;
+    std::string_view get_pc_sampling_interval() override;
 
 private:
     std::string_view get(std::string_view env_var_name, std::string_view default_value);

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/pc_sampling_feature.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/pc_sampling_feature.cpp
@@ -4,6 +4,8 @@
 
 #include "code_object_writer.h"
 
+#include <memory>
+
 using namespace rocprofiler_compute_tool;
 
 PcSamplingMode rocprofiler_compute_tool::parse_pc_sampling_mode(const std::string& mode)
@@ -15,17 +17,28 @@ PcSamplingMode rocprofiler_compute_tool::parse_pc_sampling_mode(const std::strin
     return PcSamplingMode::Disabled;
 }
 
-pc_sampling_feature_t::pc_sampling_feature_t(PcSamplingMode mode, std::filesystem::path output_path)
-    : pc_sampling_feature_t(mode, std::move(output_path), pc_sampling_collector_t::create())
+pc_sampling_feature_t::pc_sampling_feature_t(PcSamplingMode        mode,
+                                             std::filesystem::path output_root,
+                                             std::filesystem::path code_obj_path,
+                                             std::filesystem::path pc_samples_path)
+    : pc_sampling_feature_t(mode,
+                            std::move(output_root),
+                            std::move(code_obj_path),
+                            std::move(pc_samples_path),
+                            pc_sampling_collector_t::create())
 {
 }
 
 pc_sampling_feature_t::pc_sampling_feature_t(PcSamplingMode               mode,
-                                             std::filesystem::path        output_path,
+                                             std::filesystem::path        output_root,
+                                             std::filesystem::path        code_obj_path,
+                                             std::filesystem::path        pc_samples_path,
                                              pc_sampling_collector_t::ptr collector)
     : m_enabled(true)
     , m_mode(mode)
-    , m_output_path(std::move(output_path))
+    , m_code_obj_path(std::move(code_obj_path))
+    , m_output_root(std::move(output_root))
+    , m_pc_samples_path(std::move(pc_samples_path))
     , m_collector(std::move(collector))
 {
 }
@@ -35,9 +48,37 @@ void pc_sampling_feature_t::on_code_object_load(const rocprofiler_callback_traci
     m_collector->on_code_object_load(info);
 }
 
+void pc_sampling_feature_t::append_sample(const pc_sample_record_t& record)
+{
+    m_collector->append_sample(record);
+}
+
+void pc_sampling_feature_t::add_kernel_symbol(uint64_t           code_object_id,
+                                              const std::string& formatted_kernel_name,
+                                              uint64_t           kernel_id)
+{
+    m_collector->add_kernel_symbol(code_object_id, formatted_kernel_name, kernel_id);
+}
+
+void pc_sampling_feature_t::add_agent(const agent_record_t& agent)
+{
+    m_collector->add_agent(agent);
+}
+
+void pc_sampling_feature_t::append_kernel_dispatch(const kernel_dispatch_record_t& record)
+{
+    m_collector->append_kernel_dispatch(record);
+}
+
 void pc_sampling_feature_t::finalize()
 {
-    code_object_writer_json_t writer;
-    m_collector->write(writer);
-    writer.flush(m_output_path);
+    const std::shared_ptr<code_object_writer_t> writer = code_object_writer_t::create();
+    m_collector->write(*writer);
+    writer->flush(m_code_obj_path);
+
+    const std::shared_ptr<pc_sample_writer_t> pc_writer = pc_sample_writer_t::create();
+    m_collector->write_samples(*pc_writer);
+    pc_writer->flush(m_pc_samples_path);
+
+    m_collector->snapshot_sources(m_output_root);
 }

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/pc_sampling_feature.h
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/pc_sampling_feature.h
@@ -14,24 +14,37 @@ class pc_sampling_feature_t
 {
 public:
     pc_sampling_feature_t() = default;
-    pc_sampling_feature_t(PcSamplingMode mode, std::filesystem::path output_path);
+    pc_sampling_feature_t(PcSamplingMode        mode,
+                          std::filesystem::path output_root,
+                          std::filesystem::path code_obj_path,
+                          std::filesystem::path pc_samples_path);
     pc_sampling_feature_t(PcSamplingMode               mode,
-                          std::filesystem::path        output_path,
+                          std::filesystem::path        output_root,
+                          std::filesystem::path        code_obj_path,
+                          std::filesystem::path        pc_samples_path,
                           pc_sampling_collector_t::ptr collector);
 
     bool enabled() const { return m_enabled; }
 
     PcSamplingMode mode() const { return m_mode; }
 
-    const std::filesystem::path& output_path() const { return m_output_path; }
-
     void on_code_object_load(const rocprofiler_callback_tracing_code_object_load_data_t& info);
+
+    void append_sample(const pc_sample_record_t& record);
+    void add_kernel_symbol(uint64_t           code_object_id,
+                           const std::string& formatted_kernel_name,
+                           uint64_t           kernel_id);
+    void add_agent(const agent_record_t& agent);
+    void append_kernel_dispatch(const kernel_dispatch_record_t& record);
+
     void finalize();
 
 private:
     bool                         m_enabled = false;
     PcSamplingMode               m_mode    = PcSamplingMode::Disabled;
-    std::filesystem::path        m_output_path;
+    std::filesystem::path        m_code_obj_path;
+    std::filesystem::path        m_output_root;
+    std::filesystem::path        m_pc_samples_path;
     pc_sampling_collector_t::ptr m_collector;
 };
 }  // namespace rocprofiler_compute_tool

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/rocprofiler_compute_tool.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/rocprofiler_compute_tool.cpp
@@ -9,6 +9,7 @@
 
 #include "counters_writer.h"
 #include "input_parameters.h"
+#include "pc_sample_decode.h"
 #include "pc_sample_writer.h"
 #include "sdk_callbacks.h"
 #include "sdk_wrapper.h"

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/rocprofiler_compute_tool.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/rocprofiler_compute_tool.cpp
@@ -1,20 +1,33 @@
 // Copyright (c) Advanced Micro Devices, Inc.
 // SPDX-License-Identifier:  MIT
 
+#ifndef ROCPROFILER_SDK_EXPERIMENTAL
+#    define ROCPROFILER_SDK_EXPERIMENTAL
+#endif
+
 #include "rocprofiler_compute_tool.h"
 
 #include "counters_writer.h"
 #include "input_parameters.h"
+#include "pc_sample_writer.h"
 #include "sdk_callbacks.h"
 #include "sdk_wrapper.h"
 
+#include <rocprofiler-sdk/buffer.h>
+#include <rocprofiler-sdk/pc_sampling.h>
 #include <unistd.h>
 
 #include <atomic>
+#include <charconv>
+#include <cstdint>
+#include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <mutex>
 #include <sstream>
+#include <string>
 #include <string_view>
+#include <vector>
 
 using namespace rocprofiler_compute_tool;
 
@@ -99,6 +112,205 @@ void tool_tracing_callback(rocprofiler_callback_tracing_record_t record,
     g_sdk_callbacks->tool_tracing_callback(record, callback_data);
 }
 
+void pc_sampling_buffer_callback(rocprofiler_context_id_t /*context*/,
+                                 rocprofiler_buffer_id_t /*buffer_id*/,
+                                 rocprofiler_record_header_t** headers,
+                                 size_t                        num_headers,
+                                 void*                         tool_data,
+                                 uint64_t /*drop_count*/)
+{
+    if (headers == nullptr)
+        return;
+
+    auto* tool = static_cast<std::unique_ptr<tool_data_t>*>(tool_data)->get();
+
+    // Decode the whole batch, then append under one lock rather than locking per record.
+    std::vector<pc_sample_record_t> decoded;
+    decoded.reserve(num_headers);
+    for (size_t i = 0; i < num_headers; ++i)
+    {
+        if (headers[i] == nullptr)
+            continue;
+        auto rec = decode_pc_sample_record(*headers[i]);
+        if (!rec)
+            continue;
+        decoded.push_back(std::move(*rec));
+    }
+
+    if (decoded.empty())
+        return;
+
+    std::lock_guard<std::mutex> lock(tool->mut);
+    for (const auto& rec : decoded)
+        tool->pc_sampling.append_sample(rec);
+}
+
+void kernel_dispatch_buffer_callback(rocprofiler_context_id_t /*context*/,
+                                     rocprofiler_buffer_id_t /*buffer_id*/,
+                                     rocprofiler_record_header_t** headers,
+                                     size_t                        num_headers,
+                                     void*                         tool_data,
+                                     uint64_t /*drop_count*/)
+{
+    if (headers == nullptr)
+        return;
+
+    auto* tool = static_cast<std::unique_ptr<tool_data_t>*>(tool_data)->get();
+
+    std::vector<kernel_dispatch_record_t> decoded;
+    decoded.reserve(num_headers);
+    for (size_t i = 0; i < num_headers; ++i)
+    {
+        if (headers[i] == nullptr)
+            continue;
+        auto rec = decode_kernel_dispatch_record(*headers[i]);
+        if (!rec)
+            continue;
+        decoded.push_back(std::move(*rec));
+    }
+
+    if (decoded.empty())
+        return;
+
+    std::lock_guard<std::mutex> lock(tool->mut);
+    for (const auto& rec : decoded)
+        tool->pc_sampling.append_kernel_dispatch(rec);
+}
+
+namespace
+{
+struct pc_sampling_config_query_t
+{
+    bool                             found                  = false;
+    bool                             supported_method_found = false;
+    size_t                           min_interval           = 0;
+    size_t                           max_interval           = 0;
+    rocprofiler_pc_sampling_method_t method                 = ROCPROFILER_PC_SAMPLING_METHOD_NONE;
+    rocprofiler_pc_sampling_unit_t   unit                   = ROCPROFILER_PC_SAMPLING_UNIT_NONE;
+    rocprofiler_pc_sampling_method_t requested_method       = ROCPROFILER_PC_SAMPLING_METHOD_NONE;
+};
+
+rocprofiler_status_t pc_sampling_config_cb(const rocprofiler_pc_sampling_configuration_t* configs,
+                                           size_t num_config,
+                                           void*  user_data)
+{
+    auto* query = static_cast<pc_sampling_config_query_t*>(user_data);
+    for (size_t i = 0; i < num_config; ++i)
+    {
+        const bool is_requested = configs[i].method == query->requested_method;
+        // Record the first config seen, then let a requested-method match override it.
+        if (!query->found || is_requested)
+        {
+            query->found        = true;
+            query->min_interval = configs[i].min_interval;
+            query->max_interval = configs[i].max_interval;
+            query->method       = configs[i].method;
+            query->unit         = configs[i].unit;
+        }
+        if (is_requested)
+            query->supported_method_found = true;
+    }
+    return ROCPROFILER_STATUS_SUCCESS;
+}
+}  // namespace
+
+void setup_pc_sampling(rocprofiler_context_id_t ctx, tool_data_t* tool, void* user_data)
+{
+    std::vector<rocprofiler_agent_id_t> agents;
+    g_sdk_wrapper->query_available_gpu_agents(agents);
+
+    // Persist agent metadata so the consumer can build its GPU-id map without an external CSV.
+    std::vector<agent_record_t> agent_records;
+    g_sdk_wrapper->query_agent_records(agent_records);
+    for (const auto& rec : agent_records)
+        tool->pc_sampling.add_agent(rec);
+
+    constexpr size_t kBufferSize = 4 * 1024 * 1024;
+    g_sdk_wrapper->create_buffer(ctx,
+                                 kBufferSize,
+                                 kBufferSize / 2,
+                                 ROCPROFILER_BUFFER_POLICY_LOSSLESS,
+                                 pc_sampling_buffer_callback,
+                                 user_data,
+                                 &tool->pc_sampling_buffer_id);
+
+    // The buffered kernel-dispatch tracing service is the timestamp source: its records carry
+    // start/end_timestamp and full dispatch_info, which the counting-service callback does not.
+    g_sdk_wrapper->create_buffer(ctx,
+                                 kBufferSize,
+                                 kBufferSize / 2,
+                                 ROCPROFILER_BUFFER_POLICY_LOSSLESS,
+                                 kernel_dispatch_buffer_callback,
+                                 user_data,
+                                 &tool->kernel_dispatch_buffer_id);
+    g_sdk_wrapper->configure_buffer_tracing_service(ctx,
+                                                    ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH,
+                                                    tool->kernel_dispatch_buffer_id);
+
+    const auto requested_method = (tool->pc_sampling.mode() == PcSamplingMode::Stochastic)
+                                      ? ROCPROFILER_PC_SAMPLING_METHOD_STOCHASTIC
+                                      : ROCPROFILER_PC_SAMPLING_METHOD_HOST_TRAP;
+
+    for (const auto& agent : agents)
+    {
+        pc_sampling_config_query_t query{};
+        query.requested_method = requested_method;
+        g_sdk_wrapper->query_pc_sampling_configs(agent, pc_sampling_config_cb, &query);
+
+        if (!query.found || !query.supported_method_found)
+        {
+            std::clog << "\033[33m[rocprofiler-compute] [" << __FUNCTION__
+                      << "] WARNING: requested PC sampling method not supported on agent (handle="
+                      << agent.handle << "); skipping.\033[0m" << std::endl;
+            continue;
+        }
+
+        const auto method = requested_method;
+        const auto unit   = query.unit;
+
+        // Honor the env value when set, else clamp to the agent's range. Parse the whole
+        // string so garbage ("-1", "100abc") falls back instead of wrapping or truncating.
+        uint64_t interval = query.min_interval;
+        if (!tool->pc_sampling_interval.empty())
+        {
+            const auto& s        = tool->pc_sampling_interval;
+            uint64_t    val      = 0;
+            const auto [ptr, ec] = std::from_chars(s.data(), s.data() + s.size(), val);
+            if (ec == std::errc{} && ptr == s.data() + s.size())
+            {
+                interval = val;
+            }
+            else
+            {
+                std::clog << "\033[33m[rocprofiler-compute] [" << __FUNCTION__
+                          << "] WARNING: invalid ROCPROF_PC_SAMPLING_INTERVAL '" << s
+                          << "'; falling back to the agent minimum (" << query.min_interval
+                          << ").\033[0m" << std::endl;
+            }
+        }
+        if (query.max_interval != 0 && interval > query.max_interval)
+            interval = query.max_interval;
+        if (interval < query.min_interval)
+            interval = query.min_interval;
+
+        auto st = g_sdk_wrapper->configure_pc_sampling_service(ctx,
+                                                               agent,
+                                                               method,
+                                                               unit,
+                                                               interval,
+                                                               tool->pc_sampling_buffer_id,
+                                                               0);
+        if (st != ROCPROFILER_STATUS_SUCCESS)
+        {
+            std::clog << "\033[33m[rocprofiler-compute] [" << __FUNCTION__
+                      << "] WARNING: PC sampling configuration failed for agent (handle=" << agent.handle
+                      << "): " << rocprofiler_get_status_string(st)
+                      << "; continuing without PC sampling for this agent.\033[0m" << std::endl;
+            continue;
+        }
+    }
+}
+
 void on_hsa_runtime_loaded(rocprofiler_intercept_table_t /*type*/,
                            uint64_t /*lib_version*/,
                            uint64_t /*lib_instance*/,
@@ -130,16 +342,25 @@ int tool_init(rocprofiler_client_finalize_t, void* user_data)
                                                       tool_tracing_callback,
                                                       user_data);
 
+    auto* tool = static_cast<std::unique_ptr<tool_data_t>*>(user_data)->get();
+
     // Declare counters before HSA loads so the SDK picks the legacy intercept path;
     // queue interposition (the default) cannot collect counters.
-    auto* tool_data_ptr = static_cast<std::unique_ptr<tool_data_t>*>(user_data);
-    if (!tool_data_ptr->get()->requested_counters.empty())
+    if (!tool->requested_counters.empty())
     {
         g_sdk_wrapper->configure_callback_dispatch_counting_service(get_client_ctx(),
                                                                     dispatch_callback,
                                                                     user_data,
                                                                     record_callback,
                                                                     user_data);
+    }
+
+    // Buffer creation and service configuration must happen inside the rocprofiler
+    // configuration period (tool_init); the SDK rejects them afterwards. Only
+    // start_context is deferred to on_hsa_runtime_loaded.
+    if (tool->pc_sampling.enabled())
+    {
+        setup_pc_sampling(get_client_ctx(), tool, user_data);
     }
     return 0;
 }
@@ -167,7 +388,22 @@ void generate_output(tool_data_t* tool_data)
     }
 
     if (tool_data->pc_sampling.enabled())
-        tool_data->pc_sampling.finalize();
+    {
+        // finalize() runs inside the SDK tool-fini callback, which has no exception
+        // barrier; a serialization failure must not escape and std::terminate shutdown.
+        try
+        {
+            g_sdk_wrapper->flush_buffer(tool_data->pc_sampling_buffer_id);
+            g_sdk_wrapper->flush_buffer(tool_data->kernel_dispatch_buffer_id);
+            tool_data->pc_sampling.finalize();
+        }
+        catch (const std::exception& e)
+        {
+            std::clog << "\033[33m[rocprofiler-compute] [" << __FUNCTION__
+                      << "] WARNING: PC sampling serialization failed: " << e.what()
+                      << "; continuing shutdown.\033[0m" << std::endl;
+        }
+    }
 }
 
 void tool_fini(void* user_data)
@@ -206,8 +442,13 @@ std::unique_ptr<tool_data_t> create_tool_data(rocprofiler_client_id_t* /*id*/)
     {
         const auto pc_mode = parse_pc_sampling_mode(
             std::string{g_input_parameters->get_pc_sampling_method()});
+        tool_data->pc_sampling_interval = std::string{g_input_parameters->get_pc_sampling_interval()};
+        // PID-prefix the outputs so concurrent runs sharing an output dir do not clobber each other.
         tool_data->pc_sampling =
-            pc_sampling_feature_t{pc_mode, generate_output_filename(output_path, "_code_obj_info.json")};
+            pc_sampling_feature_t{pc_mode,
+                                  std::filesystem::path{output_path},
+                                  generate_output_filename(output_path, "_code_obj_info.json"),
+                                  generate_output_filename(output_path, "_ps_file_results.json")};
     }
 
     // ROCPROF_COUNTERS env. var. is a string like "pmc: counter1 counter2 ..."

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/sdk_callbacks.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/sdk_callbacks.cpp
@@ -341,6 +341,26 @@ void SdkCallbacksImpl::tool_tracing_callback(rocprofiler_callback_tracing_record
         // if matches store kernel id
         // Lock before modifying target_kernel_ids
         std::lock_guard<std::mutex> lock(tool->mut);
+
+        // Demangled+truncated name for PC sampling attribution; fall back to raw on failure.
+        if (tool->pc_sampling.enabled())
+        {
+            std::string formatted_name;
+            try
+            {
+                int  demangle_status = 0;
+                auto demangled       = cxa_demangle(data->kernel_name, &demangle_status);
+                formatted_name       = truncate_name(demangled);
+            }
+            catch (...)
+            {
+                formatted_name.clear();
+            }
+            if (formatted_name.empty() && data->kernel_name != nullptr)
+                formatted_name = data->kernel_name;
+            tool->pc_sampling.add_kernel_symbol(data->code_object_id, formatted_name, data->kernel_id);
+        }
+
         if (!tool->kernel_filter_include_regex.empty())
         {
             try

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/sdk_callbacks.h
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/sdk_callbacks.h
@@ -85,7 +85,10 @@ struct tool_data_t
     std::vector<counter_info_record_t>         counter_records;
     std::set<uint64_t>                         target_kernel_ids{};
     iteration_multiplexing_mode_t iteration_multiplexing_mode{iteration_multiplexing_mode_t::DISABLED};
-    pc_sampling_feature_t pc_sampling{};
+    pc_sampling_feature_t   pc_sampling{};
+    std::string             pc_sampling_interval{};
+    rocprofiler_buffer_id_t pc_sampling_buffer_id{};
+    rocprofiler_buffer_id_t kernel_dispatch_buffer_id{};
 };
 
 class SdkCallbacks

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/sdk_wrapper.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/sdk_wrapper.cpp
@@ -100,3 +100,99 @@ void SdkWrapperImpl::at_intercept_table_registration_hsa(rocprofiler_intercept_l
     ROCPROFILER_CALL(rocprofiler_at_intercept_table_registration(callback, ROCPROFILER_HSA_TABLE, user_data),
                      "register HSA intercept table callback");
 }
+
+void SdkWrapperImpl::query_available_gpu_agents(std::vector<rocprofiler_agent_id_t>& out_gpu_agents)
+{
+    ROCPROFILER_CALL(
+        rocprofiler_query_available_agents(
+            ROCPROFILER_AGENT_INFO_VERSION_0,
+            [](rocprofiler_agent_version_t, const void** agents, size_t num_agents, void* user_data)
+            {
+                auto* out = static_cast<std::vector<rocprofiler_agent_id_t>*>(user_data);
+                for (size_t i = 0; i < num_agents; ++i)
+                {
+                    const auto* agent = static_cast<const rocprofiler_agent_v0_t*>(agents[i]);
+                    if (agent->type == ROCPROFILER_AGENT_TYPE_GPU)
+                        out->push_back(agent->id);
+                }
+                return ROCPROFILER_STATUS_SUCCESS;
+            },
+            sizeof(rocprofiler_agent_v0_t),
+            static_cast<void*>(&out_gpu_agents)),
+        "query available agents");
+}
+
+void SdkWrapperImpl::query_pc_sampling_configs(rocprofiler_agent_id_t agent_id,
+                                               rocprofiler_available_pc_sampling_configurations_cb_t cb,
+                                               void* user_data)
+{
+    ROCPROFILER_CALL(rocprofiler_query_pc_sampling_agent_configurations(agent_id, cb, user_data),
+                     "query pc sampling agent configurations");
+}
+
+void SdkWrapperImpl::create_buffer(rocprofiler_context_id_t        context_id,
+                                   size_t                          size,
+                                   size_t                          watermark,
+                                   rocprofiler_buffer_policy_t     policy,
+                                   rocprofiler_buffer_tracing_cb_t callback,
+                                   void*                           callback_data,
+                                   rocprofiler_buffer_id_t*        buffer_id)
+{
+    ROCPROFILER_CALL(
+        rocprofiler_create_buffer(context_id, size, watermark, policy, callback, callback_data, buffer_id),
+        "create buffer");
+}
+
+rocprofiler_status_t SdkWrapperImpl::configure_pc_sampling_service(rocprofiler_context_id_t context_id,
+                                                                   rocprofiler_agent_id_t agent_id,
+                                                                   rocprofiler_pc_sampling_method_t method,
+                                                                   rocprofiler_pc_sampling_unit_t unit,
+                                                                   uint64_t interval,
+                                                                   rocprofiler_buffer_id_t buffer_id,
+                                                                   int flags)
+{
+    return rocprofiler_configure_pc_sampling_service(context_id, agent_id, method, unit, interval, buffer_id, flags);
+}
+
+void SdkWrapperImpl::flush_buffer(rocprofiler_buffer_id_t buffer_id)
+{
+    ROCPROFILER_CALL(rocprofiler_flush_buffer(buffer_id), "flush buffer");
+}
+
+void SdkWrapperImpl::configure_buffer_tracing_service(rocprofiler_context_id_t          context_id,
+                                                      rocprofiler_buffer_tracing_kind_t kind,
+                                                      rocprofiler_buffer_id_t           buffer_id)
+{
+    ROCPROFILER_CALL(rocprofiler_configure_buffer_tracing_service(context_id, kind, nullptr, 0, buffer_id),
+                     "configure buffer tracing service");
+}
+
+void SdkWrapperImpl::query_agent_records(std::vector<agent_record_t>& out_agents)
+{
+    ROCPROFILER_CALL(
+        rocprofiler_query_available_agents(
+            ROCPROFILER_AGENT_INFO_VERSION_0,
+            [](rocprofiler_agent_version_t, const void** agents, size_t num_agents, void* user_data)
+            {
+                auto* out = static_cast<std::vector<agent_record_t>*>(user_data);
+                for (size_t i = 0; i < num_agents; ++i)
+                {
+                    const auto*    agent = static_cast<const rocprofiler_agent_v0_t*>(agents[i]);
+                    agent_record_t rec{};
+                    rec.size            = agent->size;
+                    rec.id_handle       = agent->id.handle;
+                    rec.type            = static_cast<uint32_t>(agent->type);
+                    rec.node_id         = agent->node_id;
+                    rec.logical_node_id = agent->logical_node_id;
+                    rec.cu_count        = agent->cu_count;
+                    rec.gpu_id          = agent->gpu_id;
+                    rec.wave_front_size = agent->wave_front_size;
+                    rec.simd_count      = agent->simd_count;
+                    out->push_back(rec);
+                }
+                return ROCPROFILER_STATUS_SUCCESS;
+            },
+            sizeof(rocprofiler_agent_v0_t),
+            static_cast<void*>(&out_agents)),
+        "query available agents");
+}

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/sdk_wrapper.h
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/sdk_wrapper.h
@@ -6,7 +6,7 @@
 #    define ROCPROFILER_SDK_EXPERIMENTAL
 #endif
 
-#include "pc_sample_writer.h"
+#include "pc_sample_types.h"
 
 #include <rocprofiler-sdk/agent.h>
 #include <rocprofiler-sdk/buffer.h>

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/sdk_wrapper.h
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/sdk_wrapper.h
@@ -1,7 +1,21 @@
 // Copyright (c) Advanced Micro Devices, Inc.
 // SPDX-License-Identifier:  MIT
 #pragma once
+
+#ifndef ROCPROFILER_SDK_EXPERIMENTAL
+#    define ROCPROFILER_SDK_EXPERIMENTAL
+#endif
+
+#include "pc_sample_writer.h"
+
+#include <rocprofiler-sdk/agent.h>
+#include <rocprofiler-sdk/buffer.h>
+#include <rocprofiler-sdk/buffer_tracing.h>
+#include <rocprofiler-sdk/pc_sampling.h>
 #include <rocprofiler-sdk/rocprofiler.h>
+
+#include <cstdint>
+#include <vector>
 
 namespace rocprofiler_compute_tool
 {
@@ -44,6 +58,37 @@ public:
 
     virtual void at_intercept_table_registration_hsa(rocprofiler_intercept_library_cb_t callback,
                                                      void* user_data) = 0;
+
+    virtual void query_available_gpu_agents(std::vector<rocprofiler_agent_id_t>& out_gpu_agents) = 0;
+
+    virtual void query_pc_sampling_configs(rocprofiler_agent_id_t agent_id,
+                                           rocprofiler_available_pc_sampling_configurations_cb_t cb,
+                                           void* user_data) = 0;
+
+    virtual void create_buffer(rocprofiler_context_id_t        context_id,
+                               size_t                          size,
+                               size_t                          watermark,
+                               rocprofiler_buffer_policy_t     policy,
+                               rocprofiler_buffer_tracing_cb_t callback,
+                               void*                           callback_data,
+                               rocprofiler_buffer_id_t*        buffer_id) = 0;
+
+    virtual rocprofiler_status_t configure_pc_sampling_service(rocprofiler_context_id_t context_id,
+                                                               rocprofiler_agent_id_t   agent_id,
+                                                               rocprofiler_pc_sampling_method_t method,
+                                                               rocprofiler_pc_sampling_unit_t unit,
+                                                               uint64_t                interval,
+                                                               rocprofiler_buffer_id_t buffer_id,
+                                                               int                     flags) = 0;
+
+    virtual void flush_buffer(rocprofiler_buffer_id_t buffer_id) = 0;
+
+    virtual void configure_buffer_tracing_service(rocprofiler_context_id_t          context_id,
+                                                  rocprofiler_buffer_tracing_kind_t kind,
+                                                  rocprofiler_buffer_id_t           buffer_id) = 0;
+
+    // Returns minimal records for all agents (CPU + GPU); GPU-id mapping is the consumer's job.
+    virtual void query_agent_records(std::vector<agent_record_t>& out_agents) = 0;
 };
 
 class SdkWrapperImpl : public SdkWrapper
@@ -78,5 +123,28 @@ public:
 
     void at_intercept_table_registration_hsa(rocprofiler_intercept_library_cb_t callback,
                                              void*                              user_data) override;
+    void query_available_gpu_agents(std::vector<rocprofiler_agent_id_t>& out_gpu_agents) override;
+    void query_pc_sampling_configs(rocprofiler_agent_id_t                                agent_id,
+                                   rocprofiler_available_pc_sampling_configurations_cb_t cb,
+                                   void* user_data) override;
+    void create_buffer(rocprofiler_context_id_t        context_id,
+                       size_t                          size,
+                       size_t                          watermark,
+                       rocprofiler_buffer_policy_t     policy,
+                       rocprofiler_buffer_tracing_cb_t callback,
+                       void*                           callback_data,
+                       rocprofiler_buffer_id_t*        buffer_id) override;
+    rocprofiler_status_t configure_pc_sampling_service(rocprofiler_context_id_t         context_id,
+                                                       rocprofiler_agent_id_t           agent_id,
+                                                       rocprofiler_pc_sampling_method_t method,
+                                                       rocprofiler_pc_sampling_unit_t   unit,
+                                                       uint64_t                         interval,
+                                                       rocprofiler_buffer_id_t          buffer_id,
+                                                       int flags) override;
+    void                 flush_buffer(rocprofiler_buffer_id_t buffer_id) override;
+    void configure_buffer_tracing_service(rocprofiler_context_id_t          context_id,
+                                          rocprofiler_buffer_tracing_kind_t kind,
+                                          rocprofiler_buffer_id_t           buffer_id) override;
+    void query_agent_records(std::vector<agent_record_t>& out_agents) override;
 };
 }  // namespace rocprofiler_compute_tool

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/CMakeLists.txt
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/CMakeLists.txt
@@ -10,6 +10,10 @@ add_executable(
     test_sdk_callbacks.cpp
     test_environ_cache.h
     test_environ_cache.cpp
+    test_pc_sampling_input.h
+    test_pc_sampling_input.cpp
+    test_pc_sampling_gpu.h
+    test_pc_sampling_gpu.cpp
     mocks.h
     mocks.cpp
     main.cpp

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.cpp
@@ -271,14 +271,23 @@ void MockSdkWrapper::query_pc_sampling_configs(rocprofiler_agent_id_t /*agent_id
     if (!m_pc_sampling_config_set)
         return;
 
-    rocprofiler_pc_sampling_configuration_t config{};
-    config.size         = sizeof(rocprofiler_pc_sampling_configuration_t);
-    config.method       = m_pc_sampling_config.method;
-    config.unit         = m_pc_sampling_config.unit;
-    config.min_interval = m_pc_sampling_config.min_interval;
-    config.max_interval = m_pc_sampling_config.max_interval;
-    config.flags        = 0;
-    cb(&config, 1, user_data);
+    std::vector<pc_sampling_config_t> all{m_pc_sampling_config};
+    all.insert(all.end(), m_extra_pc_sampling_configs.begin(), m_extra_pc_sampling_configs.end());
+
+    std::vector<rocprofiler_pc_sampling_configuration_t> configs;
+    configs.reserve(all.size());
+    for (const auto& c : all)
+    {
+        rocprofiler_pc_sampling_configuration_t config{};
+        config.size         = sizeof(rocprofiler_pc_sampling_configuration_t);
+        config.method       = c.method;
+        config.unit         = c.unit;
+        config.min_interval = c.min_interval;
+        config.max_interval = c.max_interval;
+        config.flags        = 0;
+        configs.push_back(config);
+    }
+    cb(configs.data(), configs.size(), user_data);
 }
 
 void MockSdkWrapper::create_buffer(rocprofiler_context_id_t context_id,
@@ -348,6 +357,14 @@ void MockSdkWrapper::set_pc_sampling_config(size_t                           min
 {
     m_pc_sampling_config     = pc_sampling_config_t{min_interval, max_interval, method, unit};
     m_pc_sampling_config_set = true;
+}
+
+void MockSdkWrapper::add_pc_sampling_config(size_t                           min_interval,
+                                            size_t                           max_interval,
+                                            rocprofiler_pc_sampling_method_t method,
+                                            rocprofiler_pc_sampling_unit_t   unit)
+{
+    m_extra_pc_sampling_configs.push_back(pc_sampling_config_t{min_interval, max_interval, method, unit});
 }
 
 void MockSdkWrapper::set_configure_pc_sampling_status(rocprofiler_status_t status)

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.cpp
@@ -51,6 +51,16 @@ std::string_view MockInputParameters::get_pc_sampling_beta_enabled()
     return std::string_view{m_pc_sampling_beta_enabled};
 }
 
+std::string_view MockInputParameters::get_pc_sampling_interval()
+{
+    return std::string_view{m_pc_sampling_interval};
+}
+
+void MockInputParameters::set_pc_sampling_interval(const std::string& interval)
+{
+    m_pc_sampling_interval = interval;
+}
+
 void MockInputParameters::set_pc_sampling_method(const std::string& method)
 {
     m_pc_sampling_method = method;
@@ -249,6 +259,117 @@ const std::vector<MockSdkWrapper::query_counter_record_info>& MockSdkWrapper::ge
     return m_query_counter_record_info;
 }
 
+void MockSdkWrapper::query_available_gpu_agents(std::vector<rocprofiler_agent_id_t>& out_gpu_agents)
+{
+    out_gpu_agents = m_gpu_agents;
+}
+
+void MockSdkWrapper::query_pc_sampling_configs(rocprofiler_agent_id_t /*agent_id*/,
+                                               rocprofiler_available_pc_sampling_configurations_cb_t cb,
+                                               void* user_data)
+{
+    if (!m_pc_sampling_config_set)
+        return;
+
+    rocprofiler_pc_sampling_configuration_t config{};
+    config.size         = sizeof(rocprofiler_pc_sampling_configuration_t);
+    config.method       = m_pc_sampling_config.method;
+    config.unit         = m_pc_sampling_config.unit;
+    config.min_interval = m_pc_sampling_config.min_interval;
+    config.max_interval = m_pc_sampling_config.max_interval;
+    config.flags        = 0;
+    cb(&config, 1, user_data);
+}
+
+void MockSdkWrapper::create_buffer(rocprofiler_context_id_t context_id,
+                                   size_t                   size,
+                                   size_t                   watermark,
+                                   rocprofiler_buffer_policy_t /*policy*/,
+                                   rocprofiler_buffer_tracing_cb_t /*callback*/,
+                                   void* /*callback_data*/,
+                                   rocprofiler_buffer_id_t* buffer_id)
+{
+    const uint64_t assigned = m_next_buffer_id++;
+    if (buffer_id != nullptr)
+        buffer_id->handle = assigned;
+    m_create_buffer_info.push_back(create_buffer_info{context_id.handle, size, watermark, assigned});
+}
+
+rocprofiler_status_t MockSdkWrapper::configure_pc_sampling_service(rocprofiler_context_id_t /*context_id*/,
+                                                                   rocprofiler_agent_id_t agent_id,
+                                                                   rocprofiler_pc_sampling_method_t method,
+                                                                   rocprofiler_pc_sampling_unit_t unit,
+                                                                   uint64_t interval,
+                                                                   rocprofiler_buffer_id_t buffer_id,
+                                                                   int /*flags*/)
+{
+    m_configure_pc_sampling_info.push_back(
+        configure_pc_sampling_info{agent_id, method, unit, interval, buffer_id.handle});
+    return m_configure_pc_sampling_status;
+}
+
+void MockSdkWrapper::flush_buffer(rocprofiler_buffer_id_t buffer_id)
+{
+    m_flush_buffer_info.push_back(flush_buffer_info{buffer_id.handle});
+}
+
+void MockSdkWrapper::configure_buffer_tracing_service(rocprofiler_context_id_t          context_id,
+                                                      rocprofiler_buffer_tracing_kind_t kind,
+                                                      rocprofiler_buffer_id_t           buffer_id)
+{
+    m_buffer_tracing_service_info.push_back(
+        buffer_tracing_service_info{context_id.handle, kind, buffer_id.handle});
+}
+
+void MockSdkWrapper::query_agent_records(std::vector<rocprofiler_compute_tool::agent_record_t>& out_agents)
+{
+    out_agents = m_agent_records;
+}
+
+void MockSdkWrapper::set_available_gpu_agents(std::vector<rocprofiler_agent_id_t> agents)
+{
+    m_gpu_agents = std::move(agents);
+}
+
+void MockSdkWrapper::set_agent_records(std::vector<rocprofiler_compute_tool::agent_record_t> agents)
+{
+    m_agent_records = std::move(agents);
+}
+
+const std::vector<MockSdkWrapper::buffer_tracing_service_info>& MockSdkWrapper::get_buffer_tracing_service_info() const
+{
+    return m_buffer_tracing_service_info;
+}
+
+void MockSdkWrapper::set_pc_sampling_config(size_t                           min_interval,
+                                            size_t                           max_interval,
+                                            rocprofiler_pc_sampling_method_t method,
+                                            rocprofiler_pc_sampling_unit_t   unit)
+{
+    m_pc_sampling_config     = pc_sampling_config_t{min_interval, max_interval, method, unit};
+    m_pc_sampling_config_set = true;
+}
+
+void MockSdkWrapper::set_configure_pc_sampling_status(rocprofiler_status_t status)
+{
+    m_configure_pc_sampling_status = status;
+}
+
+const std::vector<MockSdkWrapper::create_buffer_info>& MockSdkWrapper::get_create_buffer_info() const
+{
+    return m_create_buffer_info;
+}
+
+const std::vector<MockSdkWrapper::configure_pc_sampling_info>& MockSdkWrapper::get_configure_pc_sampling_info() const
+{
+    return m_configure_pc_sampling_info;
+}
+
+const std::vector<MockSdkWrapper::flush_buffer_info>& MockSdkWrapper::get_flush_buffer_info() const
+{
+    return m_flush_buffer_info;
+}
+
 /////////////////////////////////////////////////////////////////////////
 // MockCountersWriter
 void MockCountersWriter::write_counters(rocprofiler_compute_tool::tool_data_t* tool_data)
@@ -274,3 +395,41 @@ void MockPcSamplingCollector::on_code_object_load(
 }
 
 void MockPcSamplingCollector::write(rocprofiler_compute_tool::code_object_writer_t& /*writer*/) {}
+
+void MockPcSamplingCollector::append_sample(const rocprofiler_compute_tool::pc_sample_record_t& record)
+{
+    ++append_sample_count;
+    appended_samples.push_back(record);
+}
+
+void MockPcSamplingCollector::add_kernel_symbol(uint64_t           code_object_id,
+                                                const std::string& formatted_kernel_name,
+                                                uint64_t           kernel_id)
+{
+    added_kernel_symbols.emplace_back(code_object_id, formatted_kernel_name);
+    added_kernel_ids.push_back(kernel_id);
+}
+
+void MockPcSamplingCollector::add_agent(const rocprofiler_compute_tool::agent_record_t& agent)
+{
+    ++add_agent_count;
+    added_agents.push_back(agent);
+}
+
+void MockPcSamplingCollector::append_kernel_dispatch(
+    const rocprofiler_compute_tool::kernel_dispatch_record_t& record)
+{
+    ++append_kernel_dispatch_count;
+    appended_kernel_dispatches.push_back(record);
+}
+
+void MockPcSamplingCollector::write_samples(rocprofiler_compute_tool::pc_sample_writer_t& /*writer*/)
+{
+    ++write_samples_count;
+}
+
+size_t MockPcSamplingCollector::snapshot_sources(const std::filesystem::path& /*output_root*/)
+{
+    ++snapshot_sources_count;
+    return 0;
+}

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.h
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.h
@@ -8,8 +8,12 @@
 
 #include <gmock/gmock.h>
 
+#include <cstdint>
+#include <filesystem>
 #include <string>
 #include <string_view>
+#include <utility>
+#include <vector>
 
 class MockInputParameters : public rocprofiler_compute_tool::InputParameters
 {
@@ -21,6 +25,7 @@ public:
     std::string_view get_kernel_filter_range() override;
     std::string_view get_pc_sampling_method() override;
     std::string_view get_pc_sampling_beta_enabled() override;
+    std::string_view get_pc_sampling_interval() override;
 
     void set_output_path(const std::string& output_path);
     void set_requested_counters(const std::string& counters);
@@ -29,6 +34,7 @@ public:
     void set_kernel_filter_range(const std::string& range);
     void set_pc_sampling_method(const std::string& method);
     void set_pc_sampling_beta_enabled(const std::string& value);
+    void set_pc_sampling_interval(const std::string& interval);
 
     void unset_output_path();
     void unset_requested_counters();
@@ -45,6 +51,7 @@ private:
     std::string m_kernel_filter_range         = m_non_empty_str;
     std::string m_pc_sampling_method;
     std::string m_pc_sampling_beta_enabled;
+    std::string m_pc_sampling_interval;
 
     bool m_output_path_set                 = true;
     bool m_requested_counters_set          = true;
@@ -107,10 +114,71 @@ public:
     void at_intercept_table_registration_hsa(rocprofiler_intercept_library_cb_t callback,
                                              void*                              user_data) override;
 
+    void query_available_gpu_agents(std::vector<rocprofiler_agent_id_t>& out_gpu_agents) override;
+    void query_pc_sampling_configs(rocprofiler_agent_id_t                                agent_id,
+                                   rocprofiler_available_pc_sampling_configurations_cb_t cb,
+                                   void* user_data) override;
+    void create_buffer(rocprofiler_context_id_t        context_id,
+                       size_t                          size,
+                       size_t                          watermark,
+                       rocprofiler_buffer_policy_t     policy,
+                       rocprofiler_buffer_tracing_cb_t callback,
+                       void*                           callback_data,
+                       rocprofiler_buffer_id_t*        buffer_id) override;
+    rocprofiler_status_t configure_pc_sampling_service(rocprofiler_context_id_t         context_id,
+                                                       rocprofiler_agent_id_t           agent_id,
+                                                       rocprofiler_pc_sampling_method_t method,
+                                                       rocprofiler_pc_sampling_unit_t   unit,
+                                                       uint64_t                         interval,
+                                                       rocprofiler_buffer_id_t          buffer_id,
+                                                       int flags) override;
+    void                 flush_buffer(rocprofiler_buffer_id_t buffer_id) override;
+    void configure_buffer_tracing_service(rocprofiler_context_id_t          context_id,
+                                          rocprofiler_buffer_tracing_kind_t kind,
+                                          rocprofiler_buffer_id_t           buffer_id) override;
+    void query_agent_records(std::vector<rocprofiler_compute_tool::agent_record_t>& out_agents) override;
+
+    struct buffer_tracing_service_info
+    {
+        uint64_t                          context   = 0;
+        rocprofiler_buffer_tracing_kind_t kind      = ROCPROFILER_BUFFER_TRACING_NONE;
+        uint64_t                          buffer_id = 0;
+    };
+
     struct hsa_intercept_registration_info
     {
         rocprofiler_intercept_library_cb_t callback  = nullptr;
         void*                              user_data = nullptr;
+    };
+
+    struct create_buffer_info
+    {
+        uint64_t context   = 0;
+        size_t   size      = 0;
+        size_t   watermark = 0;
+        uint64_t buffer_id = 0;
+    };
+
+    struct configure_pc_sampling_info
+    {
+        rocprofiler_agent_id_t           agent{};
+        rocprofiler_pc_sampling_method_t method    = ROCPROFILER_PC_SAMPLING_METHOD_NONE;
+        rocprofiler_pc_sampling_unit_t   unit      = ROCPROFILER_PC_SAMPLING_UNIT_NONE;
+        uint64_t                         interval  = 0;
+        uint64_t                         buffer_id = 0;
+    };
+
+    struct flush_buffer_info
+    {
+        uint64_t buffer_id = 0;
+    };
+
+    struct pc_sampling_config_t
+    {
+        size_t                           min_interval = 0;
+        size_t                           max_interval = 0;
+        rocprofiler_pc_sampling_method_t method       = ROCPROFILER_PC_SAMPLING_METHOD_NONE;
+        rocprofiler_pc_sampling_unit_t   unit         = ROCPROFILER_PC_SAMPLING_UNIT_NONE;
     };
 
     // Test functions
@@ -122,6 +190,19 @@ public:
     const std::vector<query_counter_record_info>&       get_query_counter_record_info() const;
     const std::vector<hsa_intercept_registration_info>& get_hsa_intercept_registration_info() const;
 
+    void set_available_gpu_agents(std::vector<rocprofiler_agent_id_t> agents);
+    void set_agent_records(std::vector<rocprofiler_compute_tool::agent_record_t> agents);
+    const std::vector<buffer_tracing_service_info>& get_buffer_tracing_service_info() const;
+    void set_pc_sampling_config(size_t                           min_interval,
+                                size_t                           max_interval,
+                                rocprofiler_pc_sampling_method_t method,
+                                rocprofiler_pc_sampling_unit_t   unit);
+    void set_configure_pc_sampling_status(rocprofiler_status_t status);
+
+    const std::vector<create_buffer_info>&         get_create_buffer_info() const;
+    const std::vector<configure_pc_sampling_info>& get_configure_pc_sampling_info() const;
+    const std::vector<flush_buffer_info>&          get_flush_buffer_info() const;
+
 private:
     std::vector<rocprofiler_counter_id_t> get_counters() const;
 
@@ -132,6 +213,17 @@ private:
     std::vector<query_counter_record_info>       m_query_counter_record_info;
     std::vector<std::string>                     m_counter_names;
     std::vector<hsa_intercept_registration_info> m_hsa_intercept_registration_info;
+
+    std::vector<rocprofiler_agent_id_t>                   m_gpu_agents;
+    std::vector<rocprofiler_compute_tool::agent_record_t> m_agent_records;
+    std::vector<buffer_tracing_service_info>              m_buffer_tracing_service_info;
+    pc_sampling_config_t                                  m_pc_sampling_config{};
+    bool                                                  m_pc_sampling_config_set = false;
+    rocprofiler_status_t            m_configure_pc_sampling_status = ROCPROFILER_STATUS_SUCCESS;
+    uint64_t                        m_next_buffer_id               = 1;
+    std::vector<create_buffer_info> m_create_buffer_info;
+    std::vector<configure_pc_sampling_info> m_configure_pc_sampling_info;
+    std::vector<flush_buffer_info>          m_flush_buffer_info;
 };
 
 class MockCountersWriter : public rocprofiler_compute_tool::CountersWriter
@@ -156,5 +248,24 @@ public:
     void on_code_object_load(const rocprofiler_callback_tracing_code_object_load_data_t& info) override;
     void write(rocprofiler_compute_tool::code_object_writer_t& writer) override;
 
-    int load_count = 0;
+    void append_sample(const rocprofiler_compute_tool::pc_sample_record_t& record) override;
+    void add_kernel_symbol(uint64_t           code_object_id,
+                           const std::string& formatted_kernel_name,
+                           uint64_t           kernel_id) override;
+    void add_agent(const rocprofiler_compute_tool::agent_record_t& agent) override;
+    void append_kernel_dispatch(const rocprofiler_compute_tool::kernel_dispatch_record_t& record) override;
+    void   write_samples(rocprofiler_compute_tool::pc_sample_writer_t& writer) override;
+    size_t snapshot_sources(const std::filesystem::path& output_root) override;
+
+    int                                                       load_count                   = 0;
+    int                                                       append_sample_count          = 0;
+    int                                                       write_samples_count          = 0;
+    int                                                       snapshot_sources_count       = 0;
+    int                                                       add_agent_count              = 0;
+    int                                                       append_kernel_dispatch_count = 0;
+    std::vector<rocprofiler_compute_tool::pc_sample_record_t> appended_samples;
+    std::vector<std::pair<uint64_t, std::string>>             added_kernel_symbols;
+    std::vector<uint64_t>                                     added_kernel_ids;
+    std::vector<rocprofiler_compute_tool::agent_record_t>     added_agents;
+    std::vector<rocprofiler_compute_tool::kernel_dispatch_record_t> appended_kernel_dispatches;
 };

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.h
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.h
@@ -197,6 +197,13 @@ public:
                                 size_t                           max_interval,
                                 rocprofiler_pc_sampling_method_t method,
                                 rocprofiler_pc_sampling_unit_t   unit);
+    // Append an additional config; query_pc_sampling_configs delivers every
+    // configured entry in one callback so the multi-config selection path can be
+    // exercised.
+    void add_pc_sampling_config(size_t                           min_interval,
+                                size_t                           max_interval,
+                                rocprofiler_pc_sampling_method_t method,
+                                rocprofiler_pc_sampling_unit_t   unit);
     void set_configure_pc_sampling_status(rocprofiler_status_t status);
 
     const std::vector<create_buffer_info>&         get_create_buffer_info() const;
@@ -219,6 +226,7 @@ private:
     std::vector<buffer_tracing_service_info>              m_buffer_tracing_service_info;
     pc_sampling_config_t                                  m_pc_sampling_config{};
     bool                                                  m_pc_sampling_config_set = false;
+    std::vector<pc_sampling_config_t>                     m_extra_pc_sampling_configs;
     rocprofiler_status_t            m_configure_pc_sampling_status = ROCPROFILER_STATUS_SUCCESS;
     uint64_t                        m_next_buffer_id               = 1;
     std::vector<create_buffer_info> m_create_buffer_info;

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_environ_cache.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_environ_cache.cpp
@@ -79,6 +79,16 @@ TEST_F(TestEnvironCache, MultipleRocprofKeys_AllCaptured)
               std::optional<std::string_view>{std::string_view{"1-5"}});
 }
 
+TEST_F(TestEnvironCache, RocprofilerSdkKeyInEnviron_ReturnsValue)
+{
+    // The ROCPROFILER_ family (rocprofiler-sdk vars) must be captured too; this
+    // would NOT match a bare "ROCPROF_" prefix.
+    Envp         envp{{"ROCPROFILER_PC_SAMPLING_BETA_ENABLED=1"}};
+    EnvironCache cache{envp.data()};
+    EXPECT_EQ(cache.get("ROCPROFILER_PC_SAMPLING_BETA_ENABLED"),
+              std::optional<std::string_view>{std::string_view{"1"}});
+}
+
 TEST_F(TestEnvironCache, DuplicateEnvironEntries_FirstWins)
 {
     Envp         envp{{"ROCPROF_OUTPUT_PATH=/tmp/first", "ROCPROF_OUTPUT_PATH=/tmp/second"}};

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_pc_sampling_gpu.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_pc_sampling_gpu.cpp
@@ -1,0 +1,78 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#include "test_pc_sampling_gpu.h"
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+using namespace rocprofiler_compute_tool;
+
+namespace
+{
+struct PcConfigCollector
+{
+    std::vector<rocprofiler_pc_sampling_configuration_t> configs;
+    bool                                                 has_usable_method = false;
+};
+
+rocprofiler_status_t collect_pc_configs(const rocprofiler_pc_sampling_configuration_t* cfgs,
+                                        size_t                                         num_cfgs,
+                                        void*                                          user_data)
+{
+    auto* collector = static_cast<PcConfigCollector*>(user_data);
+    for (size_t i = 0; i < num_cfgs; ++i)
+    {
+        collector->configs.push_back(cfgs[i]);
+        if (cfgs[i].method != ROCPROFILER_PC_SAMPLING_METHOD_NONE)
+        {
+            collector->has_usable_method = true;
+        }
+    }
+    return ROCPROFILER_STATUS_SUCCESS;
+}
+}  // namespace
+
+// Self-skipping GPU integration test: asserts a real agent advertises at least
+// one usable PC-sampling config, and skips cleanly when no GPU/support is present.
+TEST_F(TestPcSamplingGpu, QueriesPcSamplingConfigsOnRealAgent)
+{
+    std::vector<rocprofiler_agent_id_t> agents;
+    try
+    {
+        sdk.query_available_gpu_agents(agents);
+    }
+    catch (...)
+    {
+        GTEST_SKIP() << "no GPU agent present";
+        return;
+    }
+
+    if (agents.empty())
+    {
+        GTEST_SKIP() << "no GPU agent present";
+        return;
+    }
+
+    // The SDK throws when the driver does not implement PC sampling; skip rather than fail.
+    PcConfigCollector collector{};
+    try
+    {
+        sdk.query_pc_sampling_configs(agents.front(), collect_pc_configs, &collector);
+    }
+    catch (...)
+    {
+        GTEST_SKIP() << "PC sampling not supported on this agent/driver";
+        return;
+    }
+
+    if (collector.configs.empty() || !collector.has_usable_method)
+    {
+        GTEST_SKIP() << "agent advertises no usable PC-sampling configuration";
+        return;
+    }
+
+    EXPECT_GE(agents.size(), 1u);
+    EXPECT_FALSE(collector.configs.empty());
+    EXPECT_TRUE(collector.has_usable_method);
+}

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_pc_sampling_gpu.h
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_pc_sampling_gpu.h
@@ -1,0 +1,19 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#pragma once
+
+// Must be defined before any <rocprofiler-sdk/...> include to expose PC-sampling types.
+#define ROCPROFILER_SDK_EXPERIMENTAL
+
+#include "sdk_wrapper.h"
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+// GPU-gated integration fixture; the TEST_F self-skips on CPU-only CI.
+class TestPcSamplingGpu : public ::testing::Test
+{
+protected:
+    rocprofiler_compute_tool::SdkWrapperImpl sdk{};
+};

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_pc_sampling_input.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_pc_sampling_input.cpp
@@ -201,6 +201,58 @@ TEST_F(TestPcSamplingInput, OnHsaRuntimeLoaded_BetaDisabled_ConfiguresNothing)
     EXPECT_TRUE(m_sdk_wrapper->get_configure_pc_sampling_info().empty());
 }
 
+TEST_F(TestPcSamplingInput, OnHsaRuntimeLoaded_StochasticMethod_ConfiguresStochastic)
+{
+    constexpr rocprofiler_agent_id_t agent{55};
+    m_input_parameters->set_pc_sampling_beta_enabled("1");
+    m_input_parameters->set_pc_sampling_method("stochastic");
+    m_sdk_wrapper->set_available_gpu_agents({agent});
+    m_sdk_wrapper->set_pc_sampling_config(1,
+                                          1000,
+                                          ROCPROFILER_PC_SAMPLING_METHOD_STOCHASTIC,
+                                          ROCPROFILER_PC_SAMPLING_UNIT_CYCLES);
+    m_sdk_wrapper->set_configure_pc_sampling_status(ROCPROFILER_STATUS_SUCCESS);
+
+    drive_hsa_runtime_loaded();
+
+    ASSERT_EQ(m_sdk_wrapper->get_configure_pc_sampling_info().size(), 1u);
+    EXPECT_EQ(m_sdk_wrapper->get_configure_pc_sampling_info()[0].method,
+              ROCPROFILER_PC_SAMPLING_METHOD_STOCHASTIC);
+}
+
+TEST_F(TestPcSamplingInput, OnHsaRuntimeLoaded_MultipleConfigs_RequestedMethodOverridesFirstSeen)
+{
+    constexpr rocprofiler_agent_id_t agent{66};
+    m_input_parameters->set_pc_sampling_beta_enabled("1");
+    m_input_parameters->set_pc_sampling_method("host_trap");
+    m_input_parameters->set_pc_sampling_interval("");  // unset -> use the chosen config's min
+    m_sdk_wrapper->set_available_gpu_agents({agent});
+    // First-seen config is STOCHASTIC (non-requested) with a distinct interval range;
+    // the requested HOST_TRAP config appears second and must win.
+    m_sdk_wrapper->set_pc_sampling_config(1000,
+                                          2000,
+                                          ROCPROFILER_PC_SAMPLING_METHOD_STOCHASTIC,
+                                          ROCPROFILER_PC_SAMPLING_UNIT_CYCLES);
+    m_sdk_wrapper->add_pc_sampling_config(64,
+                                          4096,
+                                          ROCPROFILER_PC_SAMPLING_METHOD_HOST_TRAP,
+                                          ROCPROFILER_PC_SAMPLING_UNIT_CYCLES);
+    m_sdk_wrapper->set_configure_pc_sampling_status(ROCPROFILER_STATUS_SUCCESS);
+
+    drive_hsa_runtime_loaded();
+
+    ASSERT_EQ(m_sdk_wrapper->get_configure_pc_sampling_info().size(), 1u);
+    const auto& info = m_sdk_wrapper->get_configure_pc_sampling_info()[0];
+    EXPECT_EQ(info.method, ROCPROFILER_PC_SAMPLING_METHOD_HOST_TRAP);
+    // Interval derives from the requested (HOST_TRAP) config's min, not the first-seen one.
+    EXPECT_EQ(info.interval, 64u);
+}
+
+TEST_F(TestPcSamplingInput, OnHsaRuntimeLoaded_MaxIntervalZero_NoUpperClamp)
+{
+    EXPECT_EQ(configured_interval_for("100000", 64, 0), 100000u);
+}
+
 void TestPcSamplingInput::SetUp()
 {
     m_input_parameters = std::make_shared<MockInputParameters>();

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_pc_sampling_input.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_pc_sampling_input.cpp
@@ -1,0 +1,250 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#define ROCPROFILER_SDK_EXPERIMENTAL
+
+#include "test_pc_sampling_input.h"
+
+#include "environ_cache.h"
+#include "input_parameters.h"
+#include "mocks.h"
+#include "rocprofiler_compute_tool.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+using namespace rocprofiler_compute_tool;
+
+TEST_F(TestPcSamplingInput, EnvInputParameters_PcSamplingInterval_ReturnInjectedValue)
+{
+    Envp               envp{{"ROCPROF_PC_SAMPLING_INTERVAL=1048576"}};
+    EnvInputParameters input_parameters{std::make_shared<EnvironCache>(envp.data())};
+
+    EXPECT_EQ(input_parameters.get_pc_sampling_interval(), std::string_view{"1048576"});
+}
+
+TEST_F(TestPcSamplingInput, EnvInputParameters_PcSamplingIntervalUnset_ReturnEmpty)
+{
+    Envp               envp{{}};
+    EnvInputParameters input_parameters{std::make_shared<EnvironCache>(envp.data())};
+
+    EXPECT_EQ(input_parameters.get_pc_sampling_interval(), std::string_view{""});
+}
+
+TEST_F(TestPcSamplingInput, MockInputParameters_SetPcSamplingInterval_RoundTrips)
+{
+    m_input_parameters->set_pc_sampling_interval("256");
+    EXPECT_EQ(m_input_parameters->get_pc_sampling_interval(), std::string_view{"256"});
+}
+
+TEST_F(TestPcSamplingInput, MockInputParameters_PcSamplingInterval_DefaultEmpty)
+{
+    EXPECT_EQ(m_input_parameters->get_pc_sampling_interval(), std::string_view{""});
+}
+
+TEST_F(TestPcSamplingInput, OnHsaRuntimeLoaded_SupportingAgent_CreatesBufferAndConfiguresService)
+{
+    constexpr rocprofiler_agent_id_t agent{42};
+    m_input_parameters->set_pc_sampling_beta_enabled("1");
+    m_input_parameters->set_pc_sampling_method("host_trap");
+    m_sdk_wrapper->set_available_gpu_agents({agent});
+    m_sdk_wrapper->set_pc_sampling_config(/*min_interval=*/1,
+                                          /*max_interval=*/1000,
+                                          ROCPROFILER_PC_SAMPLING_METHOD_HOST_TRAP,
+                                          ROCPROFILER_PC_SAMPLING_UNIT_CYCLES);
+    m_sdk_wrapper->set_configure_pc_sampling_status(ROCPROFILER_STATUS_SUCCESS);
+
+    drive_hsa_runtime_loaded();
+
+    // Two buffers are created: one for PC samples and one for the buffered
+    // kernel-dispatch tracing service (the timestamp source for kernel_dispatch
+    // records in the results JSON).
+    ASSERT_EQ(m_sdk_wrapper->get_create_buffer_info().size(), 2u);
+    ASSERT_EQ(m_sdk_wrapper->get_configure_pc_sampling_info().size(), 1u);
+    EXPECT_EQ(m_sdk_wrapper->get_configure_pc_sampling_info()[0].agent.handle, agent.handle);
+
+    // The kernel-dispatch buffer tracing service was configured exactly once.
+    ASSERT_EQ(m_sdk_wrapper->get_buffer_tracing_service_info().size(), 1u);
+    EXPECT_EQ(m_sdk_wrapper->get_buffer_tracing_service_info()[0].kind,
+              ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH);
+}
+
+TEST_F(TestPcSamplingInput, OnHsaRuntimeLoaded_ConfigureReturnsError_DoesNotThrowAndStillAttempts)
+{
+    constexpr rocprofiler_agent_id_t agent{7};
+    m_input_parameters->set_pc_sampling_beta_enabled("1");
+    m_input_parameters->set_pc_sampling_method("host_trap");
+    m_sdk_wrapper->set_available_gpu_agents({agent});
+    m_sdk_wrapper->set_pc_sampling_config(/*min_interval=*/1,
+                                          /*max_interval=*/1000,
+                                          ROCPROFILER_PC_SAMPLING_METHOD_HOST_TRAP,
+                                          ROCPROFILER_PC_SAMPLING_UNIT_CYCLES);
+    m_sdk_wrapper->set_configure_pc_sampling_status(ROCPROFILER_STATUS_ERROR);
+
+    EXPECT_NO_THROW(drive_hsa_runtime_loaded());
+
+    // The configure call was attempted (recorded) even though it failed.
+    EXPECT_EQ(m_sdk_wrapper->get_configure_pc_sampling_info().size(), 1u);
+}
+
+TEST_F(TestPcSamplingInput, OnHsaRuntimeLoaded_IntervalEnvUnset_UsesValueWithinAdvertisedRange)
+{
+    constexpr rocprofiler_agent_id_t agent{99};
+    constexpr uint64_t               min_interval = 64;
+    constexpr uint64_t               max_interval = 4096;
+
+    // Interval env intentionally left unset (default empty).
+    m_input_parameters->set_pc_sampling_beta_enabled("1");
+    m_input_parameters->set_pc_sampling_method("host_trap");
+    m_input_parameters->set_pc_sampling_interval("");
+    m_sdk_wrapper->set_available_gpu_agents({agent});
+    m_sdk_wrapper->set_pc_sampling_config(min_interval,
+                                          max_interval,
+                                          ROCPROFILER_PC_SAMPLING_METHOD_HOST_TRAP,
+                                          ROCPROFILER_PC_SAMPLING_UNIT_CYCLES);
+    m_sdk_wrapper->set_configure_pc_sampling_status(ROCPROFILER_STATUS_SUCCESS);
+
+    drive_hsa_runtime_loaded();
+
+    ASSERT_EQ(m_sdk_wrapper->get_configure_pc_sampling_info().size(), 1u);
+    const auto chosen_interval = m_sdk_wrapper->get_configure_pc_sampling_info()[0].interval;
+    EXPECT_GE(chosen_interval, min_interval);
+    EXPECT_LE(chosen_interval, max_interval);
+}
+
+TEST_F(TestPcSamplingInput, OnHsaRuntimeLoaded_IntervalInRange_PassedThrough)
+{
+    EXPECT_EQ(configured_interval_for("256", 64, 4096), 256u);
+}
+
+TEST_F(TestPcSamplingInput, OnHsaRuntimeLoaded_IntervalAboveMax_ClampedToMax)
+{
+    EXPECT_EQ(configured_interval_for("100000", 64, 4096), 4096u);
+}
+
+TEST_F(TestPcSamplingInput, OnHsaRuntimeLoaded_IntervalBelowMin_RaisedToMin)
+{
+    EXPECT_EQ(configured_interval_for("1", 64, 4096), 64u);
+}
+
+TEST_F(TestPcSamplingInput, OnHsaRuntimeLoaded_IntervalNonNumeric_FallsBackToMin)
+{
+    EXPECT_EQ(configured_interval_for("abc", 64, 4096), 64u);
+}
+
+TEST_F(TestPcSamplingInput, OnHsaRuntimeLoaded_IntervalNegative_FallsBackToMin)
+{
+    // "-1" must not wrap to a huge value then clamp to max; it is invalid input.
+    EXPECT_EQ(configured_interval_for("-1", 64, 4096), 64u);
+}
+
+TEST_F(TestPcSamplingInput, OnHsaRuntimeLoaded_IntervalTrailingGarbage_FallsBackToMin)
+{
+    EXPECT_EQ(configured_interval_for("100abc", 64, 4096), 64u);
+}
+
+TEST_F(TestPcSamplingInput, OnHsaRuntimeLoaded_MultipleSupportingAgents_ConfiguresEach)
+{
+    constexpr rocprofiler_agent_id_t agent_a{11};
+    constexpr rocprofiler_agent_id_t agent_b{22};
+    m_input_parameters->set_pc_sampling_beta_enabled("1");
+    m_input_parameters->set_pc_sampling_method("host_trap");
+    m_sdk_wrapper->set_available_gpu_agents({agent_a, agent_b});
+    m_sdk_wrapper->set_pc_sampling_config(1,
+                                          1000,
+                                          ROCPROFILER_PC_SAMPLING_METHOD_HOST_TRAP,
+                                          ROCPROFILER_PC_SAMPLING_UNIT_CYCLES);
+    m_sdk_wrapper->set_configure_pc_sampling_status(ROCPROFILER_STATUS_SUCCESS);
+
+    drive_hsa_runtime_loaded();
+
+    ASSERT_EQ(m_sdk_wrapper->get_configure_pc_sampling_info().size(), 2u);
+    EXPECT_EQ(m_sdk_wrapper->get_configure_pc_sampling_info()[0].agent.handle, agent_a.handle);
+    EXPECT_EQ(m_sdk_wrapper->get_configure_pc_sampling_info()[1].agent.handle, agent_b.handle);
+}
+
+TEST_F(TestPcSamplingInput, OnHsaRuntimeLoaded_AgentLacksRequestedMethod_SkipsConfigure)
+{
+    constexpr rocprofiler_agent_id_t agent{33};
+    m_input_parameters->set_pc_sampling_beta_enabled("1");
+    m_input_parameters->set_pc_sampling_method("host_trap");
+    m_sdk_wrapper->set_available_gpu_agents({agent});
+    // Agent advertises STOCHASTIC only; requested method is HOST_TRAP.
+    m_sdk_wrapper->set_pc_sampling_config(1,
+                                          1000,
+                                          ROCPROFILER_PC_SAMPLING_METHOD_STOCHASTIC,
+                                          ROCPROFILER_PC_SAMPLING_UNIT_CYCLES);
+
+    EXPECT_NO_THROW(drive_hsa_runtime_loaded());
+
+    EXPECT_TRUE(m_sdk_wrapper->get_configure_pc_sampling_info().empty());
+}
+
+TEST_F(TestPcSamplingInput, OnHsaRuntimeLoaded_BetaDisabled_ConfiguresNothing)
+{
+    constexpr rocprofiler_agent_id_t agent{44};
+    // Beta intentionally left unset.
+    m_input_parameters->set_pc_sampling_method("host_trap");
+    m_sdk_wrapper->set_available_gpu_agents({agent});
+    m_sdk_wrapper->set_pc_sampling_config(1,
+                                          1000,
+                                          ROCPROFILER_PC_SAMPLING_METHOD_HOST_TRAP,
+                                          ROCPROFILER_PC_SAMPLING_UNIT_CYCLES);
+
+    drive_hsa_runtime_loaded();
+
+    EXPECT_TRUE(m_sdk_wrapper->get_create_buffer_info().empty());
+    EXPECT_TRUE(m_sdk_wrapper->get_configure_pc_sampling_info().empty());
+}
+
+void TestPcSamplingInput::SetUp()
+{
+    m_input_parameters = std::make_shared<MockInputParameters>();
+    m_sdk_wrapper      = std::make_shared<MockSdkWrapper>();
+    m_counters_writer  = std::make_shared<MockCountersWriter>();
+
+    test_knobs::set_input_parameters(m_input_parameters);
+    test_knobs::set_sdk_wrapper(m_sdk_wrapper);
+    test_knobs::set_csv_writer(m_counters_writer);
+}
+
+void TestPcSamplingInput::TearDown()
+{
+    test_knobs::reset_cfg();
+}
+
+tool_data_t* TestPcSamplingInput::get_tool_data(const rocprofiler_tool_configure_result_t* cfg)
+{
+    return (static_cast<std::unique_ptr<tool_data_t>*>(cfg->tool_data))->get();
+}
+
+void TestPcSamplingInput::drive_hsa_runtime_loaded()
+{
+    const auto cfg = rocprofiler_configure(1, "", 1, &m_client_id);
+    ASSERT_EQ(cfg->initialize(nullptr, cfg->tool_data), 0);
+    ASSERT_EQ(m_sdk_wrapper->get_hsa_intercept_registration_info().size(), 1u);
+    const auto reg = m_sdk_wrapper->get_hsa_intercept_registration_info()[0];
+    reg.callback(ROCPROFILER_HSA_TABLE, 0, 0, nullptr, 0, reg.user_data);
+}
+
+uint64_t TestPcSamplingInput::configured_interval_for(const std::string& env_interval,
+                                                      uint64_t           min_interval,
+                                                      uint64_t           max_interval)
+{
+    constexpr rocprofiler_agent_id_t agent{101};
+    m_input_parameters->set_pc_sampling_beta_enabled("1");
+    m_input_parameters->set_pc_sampling_method("host_trap");
+    m_input_parameters->set_pc_sampling_interval(env_interval);
+    m_sdk_wrapper->set_available_gpu_agents({agent});
+    m_sdk_wrapper->set_pc_sampling_config(min_interval,
+                                          max_interval,
+                                          ROCPROFILER_PC_SAMPLING_METHOD_HOST_TRAP,
+                                          ROCPROFILER_PC_SAMPLING_UNIT_CYCLES);
+    m_sdk_wrapper->set_configure_pc_sampling_status(ROCPROFILER_STATUS_SUCCESS);
+    drive_hsa_runtime_loaded();
+    return m_sdk_wrapper->get_configure_pc_sampling_info().at(0).interval;
+}

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_pc_sampling_input.h
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_pc_sampling_input.h
@@ -1,0 +1,73 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#pragma once
+
+#define ROCPROFILER_SDK_EXPERIMENTAL
+
+#include "mocks.h"
+#include "rocprofiler_compute_tool.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+// Fixture for the PC-sampling tool-side wiring tests: injects the Mock* objects
+// through test_knobs so rocprofiler_configure()/initialize() drive the real tool
+// code against them, and exposes Envp for injecting an EnvironCache.
+class TestPcSamplingInput : public ::testing::Test
+{
+protected:
+    void SetUp() override;
+    void TearDown() override;
+
+    // Owns the storage backing a NULL-terminated char** envp; non-copyable/movable
+    // so tests must hold it as a named local while data() is in use.
+    class Envp
+    {
+    public:
+        explicit Envp(const std::vector<std::string>& entries)
+        {
+            m_owned.reserve(entries.size());
+            m_pointers.reserve(entries.size() + 1);
+
+            for (const auto& entry : entries)
+            {
+                m_owned.emplace_back(entry.begin(), entry.end());
+                m_owned.back().push_back('\0');
+                m_pointers.push_back(m_owned.back().data());
+            }
+
+            m_pointers.push_back(nullptr);
+        }
+
+        Envp(const Envp&)            = delete;
+        Envp& operator=(const Envp&) = delete;
+        Envp(Envp&&)                 = delete;
+        Envp& operator=(Envp&&)      = delete;
+
+        char** data() { return m_pointers.data(); }
+
+    private:
+        std::vector<std::vector<char>> m_owned;
+        std::vector<char*>             m_pointers;
+    };
+
+    static rocprofiler_compute_tool::tool_data_t* get_tool_data(const rocprofiler_tool_configure_result_t* cfg);
+
+    // Drives the on_hsa_runtime_loaded path: registers the HSA intercept by
+    // running initialize(), then fires the recorded intercept callback once.
+    void drive_hsa_runtime_loaded();
+
+    // Configures one supporting agent with the given env interval and advertised
+    // [min,max] range, returning the interval handed to the SDK.
+    uint64_t configured_interval_for(const std::string& env_interval,
+                                     uint64_t           min_interval,
+                                     uint64_t           max_interval);
+
+    rocprofiler_client_id_t              m_client_id{};
+    std::shared_ptr<MockInputParameters> m_input_parameters;
+    std::shared_ptr<MockSdkWrapper>      m_sdk_wrapper;
+    std::shared_ptr<MockCountersWriter>  m_counters_writer;
+};

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_sdk_callbacks.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_sdk_callbacks.cpp
@@ -5,6 +5,11 @@
 #include "fmt/format.h"
 #include "rocprofiler_compute_tool.h"
 
+#include <unistd.h>
+
+#include <filesystem>
+#include <string>
+
 using namespace rocprofiler_compute_tool;
 
 TEST_F(TestSdkCallbacks, ProvidedSameKernelWithMultiplexingDisabled_DispatchCbReturnsFirstPmc)
@@ -167,8 +172,12 @@ TEST_F(TestSdkCallbacks, ProvidedTracingRecord_ToolTracingCbReturnsKernelIdsFrom
 
 TEST_F(TestSdkCallbacks, ProvidedCodeObjectLoadWithPcSamplingEnabled_ForwardsToCollector)
 {
-    auto collector = std::make_shared<MockPcSamplingCollector>();
-    m_tool_data->pc_sampling = pc_sampling_feature_t{PcSamplingMode::HostTrap, "unused.json", collector};
+    auto collector           = std::make_shared<MockPcSamplingCollector>();
+    m_tool_data->pc_sampling = pc_sampling_feature_t{PcSamplingMode::HostTrap,
+                                                     "unused",
+                                                     "unused.json",
+                                                     "unused.json",
+                                                     collector};
 
     rocprofiler_callback_tracing_record_t                record  = {};
     rocprofiler_callback_tracing_code_object_load_data_t payload = {};
@@ -180,6 +189,38 @@ TEST_F(TestSdkCallbacks, ProvidedCodeObjectLoadWithPcSamplingEnabled_ForwardsToC
     m_sdk_callbacks->tool_tracing_callback(record, &m_tool_data);
 
     EXPECT_EQ(collector->load_count, 1);
+}
+
+TEST_F(TestSdkCallbacks, FeatureDelegatesSampleIngestionAndFinalizeToCollector)
+{
+    namespace fs            = std::filesystem;
+    const fs::path out_root = fs::temp_directory_path() /
+                              ("rpc_feature_finalize_" + std::to_string(::getpid()));
+    fs::create_directories(out_root);
+
+    auto                  collector = std::make_shared<MockPcSamplingCollector>();
+    pc_sampling_feature_t feature{PcSamplingMode::HostTrap,
+                                  out_root,
+                                  out_root / "code_obj.json",
+                                  out_root / "ps_file_results.json",
+                                  collector};
+
+    pc_sample_record_t sample{};
+    feature.append_sample(sample);
+    feature.add_kernel_symbol(42, "kernel_name", 7);
+    feature.finalize();
+
+    EXPECT_EQ(collector->append_sample_count, 1);
+    ASSERT_EQ(collector->added_kernel_symbols.size(), 1u);
+    EXPECT_EQ(collector->added_kernel_symbols[0].first, 42u);
+    EXPECT_EQ(collector->added_kernel_symbols[0].second, "kernel_name");
+    ASSERT_EQ(collector->added_kernel_ids.size(), 1u);
+    EXPECT_EQ(collector->added_kernel_ids[0], 7u);
+    EXPECT_EQ(collector->write_samples_count, 1);
+    EXPECT_EQ(collector->snapshot_sources_count, 1);
+
+    std::error_code ec;
+    fs::remove_all(out_root, ec);
 }
 
 TEST_P(TestSdkCallbacksKernelFiltering, ProvidedKernelFilteringEnabled_ReturnsKernelIdsOnlyForMathing)

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_sdk_callbacks.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_sdk_callbacks.cpp
@@ -342,7 +342,7 @@ TEST_F(TestSdkCallbacks, PcSamplingBufferCallback_NullEntryAndForeignRecords_Are
                                                      collector};
 
     rocprofiler_pc_sampling_record_host_trap_v0_t rec{};
-    rec.size = sizeof(rec);
+    rec.size     = sizeof(rec);
     auto foreign = make_pc_header(ROCPROFILER_BUFFER_CATEGORY_TRACING,
                                   ROCPROFILER_PC_SAMPLING_RECORD_HOST_TRAP_V0_SAMPLE,
                                   &rec);
@@ -362,10 +362,10 @@ TEST_F(TestSdkCallbacks, PcSamplingBufferCallback_MixedBatch_AppendsOnlyValidRec
                                                      collector};
 
     rocprofiler_pc_sampling_record_host_trap_v0_t valid{};
-    valid.size = sizeof(valid);
-    auto good  = make_pc_header(ROCPROFILER_BUFFER_CATEGORY_PC_SAMPLING,
-                               ROCPROFILER_PC_SAMPLING_RECORD_HOST_TRAP_V0_SAMPLE,
-                               &valid);
+    valid.size   = sizeof(valid);
+    auto good    = make_pc_header(ROCPROFILER_BUFFER_CATEGORY_PC_SAMPLING,
+                                  ROCPROFILER_PC_SAMPLING_RECORD_HOST_TRAP_V0_SAMPLE,
+                                  &valid);
     auto garbage = make_pc_header(ROCPROFILER_BUFFER_CATEGORY_PC_SAMPLING, 0xFFFFFFFFu, &valid);
 
     rocprofiler_record_header_t* headers[] = {&good, nullptr, &garbage, &good};
@@ -383,10 +383,10 @@ TEST_F(TestSdkCallbacks, KernelDispatchBufferCallback_MixedBatch_AppendsOnlyVali
                                                      collector};
 
     rocprofiler_buffer_tracing_kernel_dispatch_record_t kd{};
-    kd.size = sizeof(kd);
-    auto good = make_pc_header(ROCPROFILER_BUFFER_CATEGORY_TRACING,
-                              ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH,
-                              &kd);
+    kd.size      = sizeof(kd);
+    auto good    = make_pc_header(ROCPROFILER_BUFFER_CATEGORY_TRACING,
+                                  ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH,
+                                  &kd);
     auto foreign = make_pc_header(ROCPROFILER_BUFFER_CATEGORY_PC_SAMPLING,
                                   ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH,
                                   &kd);

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_sdk_callbacks.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_sdk_callbacks.cpp
@@ -259,6 +259,66 @@ TEST_F(TestSdkCallbacks, FeatureDelegatesSampleIngestionAndFinalizeToCollector)
     fs::remove_all(out_root, ec);
 }
 
+TEST_F(TestSdkCallbacks, KernelSymbolRegisterWithPcSamplingEnabled_DemanglesAndTruncatesName)
+{
+    auto collector           = std::make_shared<MockPcSamplingCollector>();
+    m_tool_data->pc_sampling = pc_sampling_feature_t{PcSamplingMode::HostTrap,
+                                                     "unused",
+                                                     "unused.json",
+                                                     "unused.json",
+                                                     collector};
+
+    rocprofiler_callback_tracing_record_t                                  record  = {};
+    rocprofiler_callback_tracing_code_object_kernel_symbol_register_data_t payload = {};
+    record.phase     = ROCPROFILER_CALLBACK_PHASE_LOAD;
+    record.kind      = ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT;
+    record.operation = ROCPROFILER_CODE_OBJECT_DEVICE_KERNEL_SYMBOL_REGISTER;
+    record.payload   = &payload;
+
+    payload.code_object_id = 7;
+    payload.kernel_id      = 42;
+    payload.kernel_name    = "_Z9my_kernelv";  // demangles to "my_kernel()"
+
+    m_sdk_callbacks->tool_tracing_callback(record, &m_tool_data);
+
+    ASSERT_EQ(collector->added_kernel_symbols.size(), 1u);
+    EXPECT_EQ(collector->added_kernel_symbols[0].first, 7u);
+    EXPECT_EQ(collector->added_kernel_symbols[0].second, "my_kernel");
+    ASSERT_EQ(collector->added_kernel_ids.size(), 1u);
+    EXPECT_EQ(collector->added_kernel_ids[0], 42u);
+}
+
+TEST_F(TestSdkCallbacks, KernelSymbolRegisterWithPcSamplingEnabled_FallsBackToRawNameWhenTruncateEmpty)
+{
+    auto collector           = std::make_shared<MockPcSamplingCollector>();
+    m_tool_data->pc_sampling = pc_sampling_feature_t{PcSamplingMode::HostTrap,
+                                                     "unused",
+                                                     "unused.json",
+                                                     "unused.json",
+                                                     collector};
+
+    rocprofiler_callback_tracing_record_t                                  record  = {};
+    rocprofiler_callback_tracing_code_object_kernel_symbol_register_data_t payload = {};
+    record.phase     = ROCPROFILER_CALLBACK_PHASE_LOAD;
+    record.kind      = ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT;
+    record.operation = ROCPROFILER_CODE_OBJECT_DEVICE_KERNEL_SYMBOL_REGISTER;
+    record.payload   = &payload;
+
+    // "()" is not a valid mangled name and truncates to empty, so the callback
+    // must fall back to storing the raw kernel_name verbatim.
+    payload.code_object_id = 3;
+    payload.kernel_id      = 99;
+    payload.kernel_name    = "()";
+
+    m_sdk_callbacks->tool_tracing_callback(record, &m_tool_data);
+
+    ASSERT_EQ(collector->added_kernel_symbols.size(), 1u);
+    EXPECT_EQ(collector->added_kernel_symbols[0].first, 3u);
+    EXPECT_EQ(collector->added_kernel_symbols[0].second, "()");
+    ASSERT_EQ(collector->added_kernel_ids.size(), 1u);
+    EXPECT_EQ(collector->added_kernel_ids[0], 99u);
+}
+
 TEST_F(TestSdkCallbacks, PcSamplingBufferCallback_NullHeaders_DoesNothing)
 {
     auto collector           = std::make_shared<MockPcSamplingCollector>();

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_sdk_callbacks.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_sdk_callbacks.cpp
@@ -3,14 +3,50 @@
 #include "test_sdk_callbacks.h"
 
 #include "fmt/format.h"
+#include "pc_sample_writer.h"
 #include "rocprofiler_compute_tool.h"
 
+#include <rocprofiler-sdk/fwd.h>
+#include <rocprofiler-sdk/pc_sampling.h>
 #include <unistd.h>
 
 #include <filesystem>
+#include <fstream>
+#include <memory>
 #include <string>
+#include <vector>
 
 using namespace rocprofiler_compute_tool;
+
+namespace rocprofiler_compute_tool
+{
+// Namespace-scope tool functions exercised directly by the tests below.
+void pc_sampling_buffer_callback(rocprofiler_context_id_t,
+                                 rocprofiler_buffer_id_t,
+                                 rocprofiler_record_header_t**,
+                                 size_t,
+                                 void*,
+                                 uint64_t);
+void kernel_dispatch_buffer_callback(rocprofiler_context_id_t,
+                                     rocprofiler_buffer_id_t,
+                                     rocprofiler_record_header_t**,
+                                     size_t,
+                                     void*,
+                                     uint64_t);
+void generate_output(tool_data_t* tool_data);
+}  // namespace rocprofiler_compute_tool
+
+namespace
+{
+rocprofiler_record_header_t make_pc_header(uint32_t category, uint32_t kind, void* payload)
+{
+    rocprofiler_record_header_t header{};
+    header.category = category;
+    header.kind     = kind;
+    header.payload  = payload;
+    return header;
+}
+}  // namespace
 
 TEST_F(TestSdkCallbacks, ProvidedSameKernelWithMultiplexingDisabled_DispatchCbReturnsFirstPmc)
 {
@@ -218,6 +254,112 @@ TEST_F(TestSdkCallbacks, FeatureDelegatesSampleIngestionAndFinalizeToCollector)
     EXPECT_EQ(collector->added_kernel_ids[0], 7u);
     EXPECT_EQ(collector->write_samples_count, 1);
     EXPECT_EQ(collector->snapshot_sources_count, 1);
+
+    std::error_code ec;
+    fs::remove_all(out_root, ec);
+}
+
+TEST_F(TestSdkCallbacks, PcSamplingBufferCallback_NullHeaders_DoesNothing)
+{
+    auto collector           = std::make_shared<MockPcSamplingCollector>();
+    m_tool_data->pc_sampling = pc_sampling_feature_t{PcSamplingMode::HostTrap,
+                                                     "unused",
+                                                     "unused.json",
+                                                     "unused.json",
+                                                     collector};
+
+    EXPECT_NO_THROW(pc_sampling_buffer_callback({}, {}, nullptr, 0, &m_tool_data, 0));
+    EXPECT_EQ(collector->append_sample_count, 0);
+}
+
+TEST_F(TestSdkCallbacks, PcSamplingBufferCallback_NullEntryAndForeignRecords_AreSkipped)
+{
+    auto collector           = std::make_shared<MockPcSamplingCollector>();
+    m_tool_data->pc_sampling = pc_sampling_feature_t{PcSamplingMode::HostTrap,
+                                                     "unused",
+                                                     "unused.json",
+                                                     "unused.json",
+                                                     collector};
+
+    rocprofiler_pc_sampling_record_host_trap_v0_t rec{};
+    rec.size = sizeof(rec);
+    auto foreign = make_pc_header(ROCPROFILER_BUFFER_CATEGORY_TRACING,
+                                  ROCPROFILER_PC_SAMPLING_RECORD_HOST_TRAP_V0_SAMPLE,
+                                  &rec);
+
+    rocprofiler_record_header_t* headers[] = {nullptr, &foreign};
+    EXPECT_NO_THROW(pc_sampling_buffer_callback({}, {}, headers, 2, &m_tool_data, 0));
+    EXPECT_EQ(collector->append_sample_count, 0);
+}
+
+TEST_F(TestSdkCallbacks, PcSamplingBufferCallback_MixedBatch_AppendsOnlyValidRecords)
+{
+    auto collector           = std::make_shared<MockPcSamplingCollector>();
+    m_tool_data->pc_sampling = pc_sampling_feature_t{PcSamplingMode::HostTrap,
+                                                     "unused",
+                                                     "unused.json",
+                                                     "unused.json",
+                                                     collector};
+
+    rocprofiler_pc_sampling_record_host_trap_v0_t valid{};
+    valid.size = sizeof(valid);
+    auto good  = make_pc_header(ROCPROFILER_BUFFER_CATEGORY_PC_SAMPLING,
+                               ROCPROFILER_PC_SAMPLING_RECORD_HOST_TRAP_V0_SAMPLE,
+                               &valid);
+    auto garbage = make_pc_header(ROCPROFILER_BUFFER_CATEGORY_PC_SAMPLING, 0xFFFFFFFFu, &valid);
+
+    rocprofiler_record_header_t* headers[] = {&good, nullptr, &garbage, &good};
+    EXPECT_NO_THROW(pc_sampling_buffer_callback({}, {}, headers, 4, &m_tool_data, 0));
+    EXPECT_EQ(collector->append_sample_count, 2);
+}
+
+TEST_F(TestSdkCallbacks, KernelDispatchBufferCallback_MixedBatch_AppendsOnlyValidRecords)
+{
+    auto collector           = std::make_shared<MockPcSamplingCollector>();
+    m_tool_data->pc_sampling = pc_sampling_feature_t{PcSamplingMode::HostTrap,
+                                                     "unused",
+                                                     "unused.json",
+                                                     "unused.json",
+                                                     collector};
+
+    rocprofiler_buffer_tracing_kernel_dispatch_record_t kd{};
+    kd.size = sizeof(kd);
+    auto good = make_pc_header(ROCPROFILER_BUFFER_CATEGORY_TRACING,
+                              ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH,
+                              &kd);
+    auto foreign = make_pc_header(ROCPROFILER_BUFFER_CATEGORY_PC_SAMPLING,
+                                  ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH,
+                                  &kd);
+
+    rocprofiler_record_header_t* headers[] = {&good, nullptr, &foreign};
+    EXPECT_NO_THROW(kernel_dispatch_buffer_callback({}, {}, headers, 3, &m_tool_data, 0));
+    EXPECT_EQ(collector->append_kernel_dispatch_count, 1);
+}
+
+TEST_F(TestSdkCallbacks, GenerateOutput_FinalizeThrows_DoesNotEscape)
+{
+    namespace fs            = std::filesystem;
+    const fs::path out_root = fs::temp_directory_path() /
+                              ("rpc_gen_output_throw_" + std::to_string(::getpid()));
+    fs::create_directories(out_root);
+
+    // A pc-samples path whose parent is a regular file makes the real writer's
+    // flush throw std::runtime_error during finalize(); generate_output must
+    // swallow it so shutdown is not aborted.
+    const fs::path file_parent = out_root / "afile";
+    {
+        std::ofstream ofs(file_parent);
+        ofs << "x";
+    }
+    const fs::path bad_pc_path = file_parent / "ps_file_results.json";
+
+    // A real collector + feature so finalize() actually runs the writer.
+    m_tool_data->pc_sampling = pc_sampling_feature_t{PcSamplingMode::HostTrap,
+                                                     out_root,
+                                                     out_root / "code_obj.json",
+                                                     bad_pc_path};
+
+    EXPECT_NO_THROW(generate_output(m_tool_data.get()));
 
     std::error_code ec;
     fs::remove_all(out_root, ec);


### PR DESCRIPTION
## Motivation

The native C++ tool library could not capture PC sampling, leaving no instruction-level stall data for the analysis flow. This adds the native collector portion of the PC sampling; the Python profile/analysis integration ships separately.

## Technical Details

- Configure SDK buffered PC sampling service per supporting GPU agent
- Decode stochastic + host-trap records under a single lock on the hot path
- Serialize at exit to `<pid>_ps_file_results.json`
- Snapshot ISA-referenced sources into `code_obj_sources/` with path-traversal hardening
- Gate on `ROCPROFILER_PC_SAMPLING_BETA_ENABLED`; unsupported agents warn and continue

## High-Level Design

The feature splits into two layers. The **tool layer** (`rocprofiler_compute_tool/`) owns SDK lifecycle: it configures services during `tool_init`, receives buffered records on SDK callbacks, and drives serialization at `tool_fini`. The **collector layer** (`pc_sampling_collector/`) is SDK-agnostic: it accumulates decoded records, disassembles loaded code objects, interns instruction strings, and emits the PC sampling results along with kernel trace and agent info, plus a source snapshot. `pc_sampling_feature_t` is the seam between them, holding the collector behind an interface so the tool wiring can be unit-tested with mocks.

### Runtime flow (configure → collect → serialize)

```mermaid
flowchart TD
    subgraph Tool["Tool layer (SDK-facing)"]
        cfg["rocprofiler_configure / tool_init"]
        setup["setup_pc_sampling"]
        pcb["pc_sampling_buffer_callback"]
        kcb["kernel_dispatch_buffer_callback"]
        tcb["tool_tracing_callback"]
        fini["tool_fini / generate_output"]
    end

    subgraph Decode["Decode helpers"]
        dps["decode_pc_sample_record"]
        dkd["decode_kernel_dispatch_record"]
    end

    subgraph Feature["pc_sampling_feature_t"]
        feat["enabled / mode / finalize"]
    end

    subgraph Collector["pc_sampling_collector_impl_t"]
        app["append_sample / append_kernel_dispatch"]
        sym["add_kernel_symbol / add_agent"]
        col["on_code_object_load"]
        wr["write / write_samples / snapshot_sources"]
    end

    cfg --> setup
    setup -->|"query agents, create buffers,\nconfigure PC sampling + dispatch tracing"| sdk["SdkWrapper → rocprofiler-sdk"]
    sdk -->|stochastic/host-trap records| pcb
    sdk -->|dispatch records| kcb
    sdk -->|code object + kernel symbol| tcb

    pcb --> dps --> app
    kcb --> dkd --> app
    tcb --> col
    tcb --> sym

    col --> trans["code_object_translator_t"]

    fini --> feat
    feat --> wr
    wr --> cow["code_object_writer_t → *_code_obj_info.json"]
    wr --> psw["pc_sample_writer_t → *_ps_file_results.json"]
    wr --> snap["source_snapshot_t → code_obj_sources/"]
```

### Class / module structure

```mermaid
classDiagram
    class pc_sampling_feature_t {
        +enabled() bool
        +mode() PcSamplingMode
        +on_code_object_load()
        +append_sample()
        +append_kernel_dispatch()
        +add_kernel_symbol()
        +add_agent()
        +finalize()
        -pc_sampling_collector_t::ptr m_collector
    }

    class pc_sampling_collector_t {
        <<interface>>
        +on_code_object_load()
        +append_sample()
        +add_kernel_symbol()
        +add_agent()
        +append_kernel_dispatch()
        +write(code_object_writer_t&)
        +write_samples(pc_sample_writer_t&)
        +snapshot_sources(path) size_t
    }
    class pc_sampling_collector_impl_t {
        -std::mutex m_mutex
        -vector~pc_sample_record_t~ m_samples
        -vector~kernel_symbol_entry_t~ m_kernel_symbols
        -vector~agent_record_t~ m_agents
        -vector~kernel_dispatch_record_t~ m_kernel_dispatches
        -pc_string_table_t m_string_table
    }

    class code_object_translator_t {
        <<interface>>
        +add_code_object()
        +get_instruction() instruction_t
        +get_load_base() uint64_t
        +get_load_size() uint64_t
    }
    class pc_sample_writer_t {
        <<interface>>
        +append_stochastic()
        +append_host_trap()
        +set_strings() / set_agents() / ...
        +flush(path)
    }
    class code_object_writer_t {
        <<interface>>
        +start_code_obj() / write_instruction()
        +flush(path)
    }
    class source_snapshot_t {
        <<interface>>
        +parse_ref(comment) optional~string~
        +snapshot(refs, out, allowed_root) size_t
    }
    class pc_string_table_t {
        +insert(inst, comment) size_t
        +instructions() / comments()
    }

    pc_sampling_feature_t o-- pc_sampling_collector_t
    pc_sampling_collector_t <|.. pc_sampling_collector_impl_t
    pc_sampling_collector_impl_t o-- code_object_translator_t
    pc_sampling_collector_impl_t *-- pc_string_table_t
    pc_sampling_collector_impl_t ..> pc_sample_writer_t : write_samples
    pc_sampling_collector_impl_t ..> code_object_writer_t : write
    pc_sampling_collector_impl_t ..> source_snapshot_t : snapshot_sources
```

## JIRA ID

AIPROFCOMP-592

## Test Plan

- [x] Native ctest: `test-pc-sampling-collector` + `test-rocprofiler-compute-tool`
- [x] Unit tests: record decode, rocprofv3 serialization, string table, source snapshot
- [x] Tool wiring: multi-agent config, unsupported-method skip, disabled-by-default, interval fallback
- [x] Security: source-snapshot path-traversal rejection
- [x] GPU-gated integration test (self-skips without a device)

## Test Result

- [x] Collector + tool suites pass
- [x] Decode/serialization/string-table/snapshot unit tests pass
- [x] Wiring behavioral tests pass (warn-and-skip log verified)
- [x] Traversal regression passes (escaping ref rejected, victim file unchanged)
- [x] GPU test reports SKIPPED, not FAILED on CPU-only host

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
- [x] Changelog entry added (Unreleased -> Added)
- [x] Tests added for new behavior
