### PR TITLE
[hipfile] Complete the batch implementation.

### DIFF
--- a/projects/hipfile/include/hipfile.h
+++ b/projects/hipfile/include/hipfile.h
@@ -718,7 +718,8 @@ typedef struct hipFileIOParams {
 typedef struct hipFileIOEvents {
     void *cookie; //!< Optionally used to track IO operations (e.g. pointer to corresponding hipFileIOParams)
     hipFileStatus_t status; //!< Status of the batch IO operation
-    size_t          ret;    //!< Number of bytes transferred or POSIX error code if negative
+    size_t          ret;    //!< Number of bytes transferred if status is hipFileComplete
+                //!< Negative POSIX or hipFileError_t error if status is hipFileFailed (cast to ssize_t)
 } hipFileIOEvents_t;
 
 /*!

--- a/projects/hipfile/src/amd_detail/batch/batch.cpp
+++ b/projects/hipfile/src/amd_detail/batch/batch.cpp
@@ -456,6 +456,34 @@ BatchContext::getStatus(unsigned min_nr, unsigned *nr, hipFileIOEvents_t *iocbp,
 }
 
 void
+BatchContext::cancelOperations()
+{
+    auto task_group_to_cancel = Context<IThreadPool>::get()->makeTaskGroup();
+    {
+        std::unique_lock<std::shared_mutex> lock{context_mutex};
+
+        task_group.swap(task_group_to_cancel);
+        task_group_to_cancel->cancel();
+        for (const auto &op : outstanding_ops) {
+            op->tryCancel();
+        }
+        status_cv.notify_all();
+    }
+
+    try {
+        task_group_to_cancel->wait();
+    }
+    catch (...) {
+        // This shouldn't throw, but catch for safety
+    }
+
+    {
+        std::unique_lock<std::shared_mutex> lock{context_mutex};
+        status_cv.notify_all();
+    }
+}
+
+void
 BatchContextMap::clear()
 {
     std::unique_lock<std::shared_mutex> ulock{batch_mutex};

--- a/projects/hipfile/src/amd_detail/batch/batch.cpp
+++ b/projects/hipfile/src/amd_detail/batch/batch.cpp
@@ -94,13 +94,13 @@ BatchContext::BatchContext(unsigned _capacity) : capacity{_capacity}
 }
 
 unsigned
-BatchContext::get_capacity() const noexcept
+BatchContext::getCapacity() const noexcept
 {
     return capacity;
 }
 
 void
-BatchContext::submit_operations(const hipFileIOParams_t *params, unsigned num_params)
+BatchContext::submitOperations(const hipFileIOParams_t *params, unsigned num_params)
 {
     std::unique_lock<std::shared_mutex> _ulock{context_mutex};
 

--- a/projects/hipfile/src/amd_detail/batch/batch.cpp
+++ b/projects/hipfile/src/amd_detail/batch/batch.cpp
@@ -8,13 +8,16 @@
 #include "context.h"
 #include "file.h"
 #include "hipfile.h"
+#include "hipfile-private.h"
 #include "state.h"
+#include "thread-pool.h"
 
 #include <cstddef>
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -228,6 +231,48 @@ BatchOperation::isTerminal() const
 }
 
 void
+BatchOperation::run() noexcept
+try {
+    {
+        std::lock_guard<std::mutex> lock{state_mutex};
+        if (std::holds_alternative<Canceled>(state)) {
+            return;
+        }
+        transitionTo(Running{});
+    }
+
+    ssize_t result   = 0;
+    auto    backends = Context<DriverState>::get()->getBackends();
+    try {
+        if (io_params->opcode == hipFileBatchRead) {
+            result = hipFileIo(IoType::Read, file, buffer, io_params->u.batch.size,
+                               io_params->u.batch.file_offset, io_params->u.batch.devPtr_offset, backends);
+        }
+        else {
+            result = hipFileIo(IoType::Write, file, buffer, io_params->u.batch.size,
+                               io_params->u.batch.file_offset, io_params->u.batch.devPtr_offset, backends);
+        }
+        if (result == -1) {
+            result = -errno;
+        }
+    }
+    catch (const Hip::RuntimeError &) {
+        result = -hipFileHipDriverError;
+    }
+
+    std::lock_guard<std::mutex> lock{state_mutex};
+    if (result >= 0) {
+        transitionTo(Complete{result});
+    }
+    else {
+        transitionTo(Failed{result});
+    }
+}
+catch (...) {
+    recordInternalError();
+}
+
+void
 BatchOperation::recordInternalError()
 {
     std::lock_guard<std::mutex> lock{state_mutex};
@@ -243,7 +288,11 @@ BatchContext::BatchContext(unsigned _capacity) : capacity{_capacity}
     if (_capacity > MAX_SIZE) {
         throw std::invalid_argument("Batch capacity is limited to " + std::to_string(MAX_SIZE));
     }
+
+    task_group = Context<IThreadPool>::get()->makeTaskGroup();
 }
+
+BatchContext::~BatchContext() = default;
 
 unsigned
 BatchContext::getCapacity() const noexcept
@@ -254,15 +303,17 @@ BatchContext::getCapacity() const noexcept
 void
 BatchContext::submitOperations(const hipFileIOParams_t *params, unsigned num_params)
 {
+    if (!params) {
+        throw std::invalid_argument("params cannot be null");
+    }
+    if (num_params == 0) {
+        throw std::invalid_argument("num_params must be greater than 0");
+    }
     std::unique_lock<std::shared_mutex> _ulock{context_mutex};
 
     // Check num_params first before doing anything else
     if (num_params > capacity - outstanding_ops.size()) {
-        std::stringstream msg;
-        msg << "Submission exceeds the capacity of this context. Number of ops submitted: ";
-        msg << num_params << ". Context capacity: " << capacity << ". Current outstanding ops: ";
-        msg << outstanding_ops.size();
-        throw std::invalid_argument(msg.str());
+        throw BatchFull();
     }
 
     std::vector<std::shared_ptr<BatchOperation>> pending_ops{};
@@ -282,7 +333,14 @@ BatchContext::submitOperations(const hipFileIOParams_t *params, unsigned num_par
     }
 
     // All submitted operations look valid at this point. Accept them.
+    for (const auto &op : pending_ops) {
+        op->markPending();
+    }
     outstanding_ops.insert(pending_ops.begin(), pending_ops.end());
+
+    for (const auto &op : pending_ops) {
+        task_group->run([op]() { op->run(); });
+    }
 }
 
 void

--- a/projects/hipfile/src/amd_detail/batch/batch.cpp
+++ b/projects/hipfile/src/amd_detail/batch/batch.cpp
@@ -507,17 +507,21 @@ BatchContextMap::createContext(unsigned capacity)
 void
 BatchContextMap::destroyContext(hipFileBatchHandle_t handle)
 {
-    std::unique_lock<std::shared_mutex> ulock{batch_mutex};
+    std::shared_ptr<IBatchContext> context;
 
-    auto context = active_contexts.find(handle);
-    if (context == active_contexts.end()) {
-        throw InvalidBatchHandle();
+    {
+        std::unique_lock<std::shared_mutex> ulock{batch_mutex};
+
+        auto iter = active_contexts.find(handle);
+        if (iter == active_contexts.end()) {
+            throw InvalidBatchHandle();
+        }
+
+        context = std::move(iter->second);
+        active_contexts.erase(iter);
     }
-    // TODO: Check for outstanding operations.
-    // TODO: Attempt to cancel any outstanding operations.
-    // TODO: Determine if we return unconditionally or require
-    //       outstanding ops to terminate first.
-    active_contexts.erase(handle);
+
+    context->cancelOperations();
 }
 
 std::shared_ptr<IBatchContext>

--- a/projects/hipfile/src/amd_detail/batch/batch.cpp
+++ b/projects/hipfile/src/amd_detail/batch/batch.cpp
@@ -280,6 +280,13 @@ BatchOperation::recordInternalError()
     transitionTo(Failed{-hipFileInternalError});
 }
 
+std::shared_ptr<IBatchOperation>
+BatchOperationFactory::create(std::unique_ptr<const hipFileIOParams_t> params,
+                              std::shared_ptr<IBuffer> buffer, std::shared_ptr<IFile> file)
+{
+    return std::make_shared<BatchOperation>(std::move(params), std::move(buffer), std::move(file));
+}
+
 BatchContext::BatchContext(unsigned _capacity) : capacity{_capacity}
 {
     if (_capacity == 0) {
@@ -301,7 +308,8 @@ BatchContext::getCapacity() const noexcept
 }
 
 void
-BatchContext::submitOperations(const hipFileIOParams_t *params, unsigned num_params)
+BatchContext::submitOperations(const hipFileIOParams_t *params, unsigned num_params,
+                               IBatchOperationFactory *operation_factory)
 {
     if (!params) {
         throw std::invalid_argument("params cannot be null");
@@ -316,7 +324,9 @@ BatchContext::submitOperations(const hipFileIOParams_t *params, unsigned num_par
         throw BatchFull();
     }
 
-    std::vector<std::shared_ptr<BatchOperation>> pending_ops{};
+    std::vector<std::shared_ptr<IBatchOperation>> pending_ops{};
+    BatchOperationFactory                         default_factory{};
+    IBatchOperationFactory &factory = operation_factory == nullptr ? default_factory : *operation_factory;
 
     // It would be more performant to be able to perform multiple lookups
     // rather than waiting to lock the DriverState lock for each lookup.
@@ -327,7 +337,7 @@ BatchContext::submitOperations(const hipFileIOParams_t *params, unsigned num_par
         // file flags.
         auto [_file, _buffer] =
             Context<DriverState>::get()->getFileAndBuffer(param_copy->fh, param_copy->u.batch.devPtr_base);
-        auto op = std::make_shared<BatchOperation>(std::move(param_copy), _buffer, _file);
+        auto op = factory.create(std::move(param_copy), std::move(_buffer), std::move(_file));
 
         pending_ops.push_back(std::move(op));
     }

--- a/projects/hipfile/src/amd_detail/batch/batch.cpp
+++ b/projects/hipfile/src/amd_detail/batch/batch.cpp
@@ -22,6 +22,104 @@
 
 namespace hipFile {
 
+namespace {
+
+    using batchOperationState::Canceled;
+    using batchOperationState::Complete;
+    using batchOperationState::Failed;
+    using batchOperationState::Invalid;
+    using batchOperationState::OperationState;
+    using batchOperationState::Pending;
+    using batchOperationState::Running;
+    using batchOperationState::Timeout;
+    using batchOperationState::Waiting;
+
+}
+
+InvalidStateTransition::InvalidStateTransition(const char *from, const char *to)
+    : std::logic_error{std::string{"Invalid batch operation state transition: "} + from + " -> " + to}
+{
+}
+
+namespace batchOperationState {
+
+    Pending Waiting::transitionTo(const Pending &next) const
+    {
+        return next;
+    }
+
+    Invalid Waiting::transitionTo(const Invalid &next) const
+    {
+        return next;
+    }
+
+    Failed Waiting::transitionTo(const Failed &next) const
+    {
+        return next;
+    }
+
+    Running Pending::transitionTo(const Running &next) const
+    {
+        return next;
+    }
+
+    Canceled Pending::transitionTo(const Canceled &next) const
+    {
+        return next;
+    }
+
+    Failed Pending::transitionTo(const Failed &next) const
+    {
+        return next;
+    }
+
+    Complete Running::transitionTo(const Complete &next) const
+    {
+        return next;
+    }
+
+    Failed Running::transitionTo(const Failed &next) const
+    {
+        return next;
+    }
+
+    Timeout Running::transitionTo(const Timeout &next) const
+    {
+        return next;
+    }
+
+    Failed Complete::transitionTo(const Failed &next) const
+    {
+        return next;
+    }
+
+    Canceled Canceled::transitionTo(const Canceled &) const
+    {
+        return *this;
+    }
+
+    Failed Canceled::transitionTo(const Failed &next) const
+    {
+        return next;
+    }
+
+    Failed Invalid::transitionTo(const Failed &next) const
+    {
+        return next;
+    }
+
+    Failed Timeout::transitionTo(const Failed &next) const
+    {
+        return next;
+    }
+
+    Failed Failed::transitionTo(const Failed &next) const
+    {
+        return next;
+    }
+
+}
+
 BatchOperation::BatchOperation(std::unique_ptr<const hipFileIOParams_t> params,
                                std::shared_ptr<IBuffer> _buffer, std::shared_ptr<IFile> _file)
     : io_params{std::move(params)}, buffer{_buffer}, file{_file}
@@ -81,6 +179,60 @@ BatchOperation::BatchOperation(std::unique_ptr<const hipFileIOParams_t> params,
         msg << ". Cookie: " << io_params->cookie;
         throw std::invalid_argument(msg.str());
     }
+}
+
+template <class Next>
+void
+BatchOperation::transitionTo(Next next)
+{
+    state = std::visit([&next](const auto &current) -> OperationState { return current.transitionTo(next); },
+                       state);
+}
+
+void
+BatchOperation::markPending()
+{
+    std::lock_guard<std::mutex> lock{state_mutex};
+
+    transitionTo(Pending{});
+}
+
+void
+BatchOperation::tryCancel()
+{
+    std::lock_guard<std::mutex> lock{state_mutex};
+
+    try {
+        transitionTo(Canceled{});
+    }
+    catch (const InvalidStateTransition &) {
+    }
+}
+
+hipFileIOEvents_t
+BatchOperation::event() const
+{
+    std::lock_guard<std::mutex> lock{state_mutex};
+    return std::visit(
+        [this](const auto &current) -> hipFileIOEvents_t {
+            return {io_params->cookie, current.toPublic(), static_cast<size_t>(current.ret())};
+        },
+        state);
+}
+
+bool
+BatchOperation::isTerminal() const
+{
+    std::lock_guard<std::mutex> lock{state_mutex};
+    return std::visit([](const auto &current) { return current.isTerminal(); }, state);
+}
+
+void
+BatchOperation::recordInternalError()
+{
+    std::lock_guard<std::mutex> lock{state_mutex};
+
+    transitionTo(Failed{-hipFileInternalError});
 }
 
 BatchContext::BatchContext(unsigned _capacity) : capacity{_capacity}

--- a/projects/hipfile/src/amd_detail/batch/batch.cpp
+++ b/projects/hipfile/src/amd_detail/batch/batch.cpp
@@ -486,8 +486,20 @@ BatchContext::cancelOperations()
 void
 BatchContextMap::clear()
 {
-    std::unique_lock<std::shared_mutex> ulock{batch_mutex};
-    active_contexts.clear();
+    std::vector<std::shared_ptr<IBatchContext>> contexts;
+
+    {
+        std::unique_lock<std::shared_mutex> ulock{batch_mutex};
+        contexts.reserve(active_contexts.size());
+        for (auto &context : active_contexts) {
+            contexts.push_back(std::move(context.second));
+        }
+        active_contexts.clear();
+    }
+
+    for (const auto &context : contexts) {
+        context->cancelOperations();
+    }
 }
 
 hipFileBatchHandle_t

--- a/projects/hipfile/src/amd_detail/batch/batch.cpp
+++ b/projects/hipfile/src/amd_detail/batch/batch.cpp
@@ -12,6 +12,8 @@
 #include "state.h"
 #include "thread-pool.h"
 
+#include <algorithm>
+#include <chrono>
 #include <cstddef>
 #include <memory>
 #include <mutex>
@@ -36,6 +38,27 @@ namespace {
     using batchOperationState::Running;
     using batchOperationState::Timeout;
     using batchOperationState::Waiting;
+
+    bool is_zero_timeout(const struct timespec *timeout) noexcept
+    {
+        return timeout != nullptr && timeout->tv_sec == 0 && timeout->tv_nsec == 0;
+    }
+
+    void validate_timeout(const struct timespec *timeout)
+    {
+        if (timeout == nullptr) {
+            return;
+        }
+        if (timeout->tv_sec < 0 || timeout->tv_nsec < 0 || timeout->tv_nsec >= 1000000000L) {
+            throw std::invalid_argument("Invalid batch status timeout");
+        }
+    }
+
+    std::chrono::steady_clock::time_point timeout_deadline(const struct timespec *timeout)
+    {
+        return std::chrono::steady_clock::now() + std::chrono::seconds{timeout->tv_sec} +
+               std::chrono::nanoseconds{timeout->tv_nsec};
+    }
 
 }
 
@@ -348,9 +371,88 @@ BatchContext::submitOperations(const hipFileIOParams_t *params, unsigned num_par
     }
     outstanding_ops.insert(pending_ops.begin(), pending_ops.end());
 
+    auto self = shared_from_this();
     for (const auto &op : pending_ops) {
-        task_group->run([op]() { op->run(); });
+        task_group->run([self, op]() {
+            op->run();
+            {
+                std::shared_lock<std::shared_mutex> _slock{self->context_mutex};
+                self->status_cv.notify_all();
+            }
+        });
     }
+}
+
+void
+BatchContext::getStatus(unsigned min_nr, unsigned *nr, hipFileIOEvents_t *iocbp, struct timespec *timeout)
+{
+    if (iocbp == nullptr) {
+        throw std::invalid_argument("Event buffer cannot be null");
+    }
+    if (nr == nullptr) {
+        throw std::invalid_argument("Number of events cannot be null");
+    }
+    if (*nr == 0) {
+        throw std::invalid_argument("Number of events cannot be zero");
+    }
+    if (min_nr > *nr) {
+        throw std::invalid_argument("Minimum event count exceeds event buffer capacity");
+    }
+    validate_timeout(timeout);
+
+    const unsigned event_capacity = *nr;
+    *nr                           = 0;
+
+    std::unique_lock<std::shared_mutex> ulock{context_mutex};
+
+    auto terminal_count = [this]() {
+        unsigned count = 0;
+        for (const auto &op : outstanding_ops) {
+            if (op->isTerminal()) {
+                count++;
+            }
+        }
+        return count;
+    };
+
+    auto collect_terminal_events = [this, event_capacity, nr, iocbp]() {
+        unsigned copied = 0;
+        for (auto op_iter = outstanding_ops.begin();
+             op_iter != outstanding_ops.end() && copied < event_capacity;) {
+            if (!(*op_iter)->isTerminal()) {
+                ++op_iter;
+                continue;
+            }
+
+            iocbp[copied++] = (*op_iter)->event();
+            op_iter         = outstanding_ops.erase(op_iter);
+        }
+        *nr = copied;
+        return copied;
+    };
+
+    // Cap to what's actually outstanding so an over-large min_nr does not block forever.
+    min_nr                = std::min(min_nr, static_cast<unsigned>(outstanding_ops.size()));
+    unsigned num_terminal = terminal_count();
+
+    if (num_terminal >= min_nr || num_terminal == outstanding_ops.size() || is_zero_timeout(timeout)) {
+        collect_terminal_events();
+        return;
+    }
+
+    auto ready = [&terminal_count, min_nr, this]() {
+        unsigned num_terminal_now = terminal_count();
+        return num_terminal_now >= min_nr || num_terminal_now == outstanding_ops.size();
+    };
+
+    if (timeout == nullptr) {
+        status_cv.wait(ulock, ready);
+    }
+    else {
+        status_cv.wait_until(ulock, timeout_deadline(timeout), ready);
+    }
+
+    collect_terminal_events();
 }
 
 void

--- a/projects/hipfile/src/amd_detail/batch/batch.h
+++ b/projects/hipfile/src/amd_detail/batch/batch.h
@@ -7,11 +7,14 @@
 
 #include "hipfile.h"
 
+#include <cstddef>
 #include <memory>
+#include <mutex>
 #include <shared_mutex>
 #include <stdexcept>
 #include <unordered_map>
 #include <unordered_set>
+#include <variant>
 
 namespace hipFile {
 class IBuffer;
@@ -28,6 +31,230 @@ struct InvalidBatchHandle : public std::invalid_argument {
     }
 };
 
+struct InvalidStateTransition : public std::logic_error {
+    InvalidStateTransition(const char *from, const char *to);
+};
+
+namespace batchOperationState {
+
+    struct Waiting;
+    struct Pending;
+    struct Running;
+    struct Complete;
+    struct Canceled;
+    struct Invalid;
+    struct Timeout;
+    struct Failed;
+
+    template <class Derived> struct StateBase {
+        ssize_t ret() const noexcept
+        {
+            return 0;
+        }
+
+        bool isTerminal() const noexcept
+        {
+            return false;
+        }
+
+        template <class To> [[noreturn]] To transitionTo(const To &to) const
+        {
+            throw InvalidStateTransition{self().name(), to.name()};
+        }
+
+    private:
+        const Derived &self() const noexcept
+        {
+            return static_cast<const Derived &>(*this);
+        }
+    };
+
+    struct Waiting : StateBase<Waiting> {
+        using StateBase<Waiting>::transitionTo;
+
+        const char *name() const noexcept
+        {
+            return "hipFileWaiting";
+        }
+
+        hipFileStatus_t toPublic() const noexcept
+        {
+            return hipFileWaiting;
+        }
+
+        Pending transitionTo(const Pending &next) const;
+        Invalid transitionTo(const Invalid &next) const;
+        Failed  transitionTo(const Failed &next) const;
+    };
+
+    struct Pending : StateBase<Pending> {
+        using StateBase<Pending>::transitionTo;
+
+        const char *name() const noexcept
+        {
+            return "hipFilePending";
+        }
+
+        hipFileStatus_t toPublic() const noexcept
+        {
+            return hipFilePending;
+        }
+
+        Running  transitionTo(const Running &next) const;
+        Canceled transitionTo(const Canceled &next) const;
+        Failed   transitionTo(const Failed &next) const;
+    };
+
+    struct Running : StateBase<Running> {
+        using StateBase<Running>::transitionTo;
+
+        const char *name() const noexcept
+        {
+            return "hipFileRunning";
+        }
+
+        hipFileStatus_t toPublic() const noexcept
+        {
+            return hipFilePending;
+        }
+
+        Complete transitionTo(const Complete &next) const;
+        Failed   transitionTo(const Failed &next) const;
+        Timeout  transitionTo(const Timeout &next) const;
+    };
+
+    struct Complete : StateBase<Complete> {
+        using StateBase<Complete>::transitionTo;
+
+        explicit Complete(ssize_t _num_bytes) : num_bytes{_num_bytes}
+        {
+        }
+
+        const char *name() const noexcept
+        {
+            return "hipFileComplete";
+        }
+
+        hipFileStatus_t toPublic() const noexcept
+        {
+            return hipFileComplete;
+        }
+
+        ssize_t ret() const noexcept
+        {
+            return num_bytes;
+        }
+
+        bool isTerminal() const noexcept
+        {
+            return true;
+        }
+
+        Failed transitionTo(const Failed &next) const;
+
+        ssize_t num_bytes;
+    };
+
+    struct Canceled : StateBase<Canceled> {
+        using StateBase<Canceled>::transitionTo;
+
+        const char *name() const noexcept
+        {
+            return "hipFileCanceled";
+        }
+
+        hipFileStatus_t toPublic() const noexcept
+        {
+            return hipFileCanceled;
+        }
+
+        bool isTerminal() const noexcept
+        {
+            return true;
+        }
+
+        Canceled transitionTo(const Canceled &) const;
+        Failed   transitionTo(const Failed &next) const;
+    };
+
+    struct Invalid : StateBase<Invalid> {
+        using StateBase<Invalid>::transitionTo;
+
+        const char *name() const noexcept
+        {
+            return "hipFileInvalid";
+        }
+
+        hipFileStatus_t toPublic() const noexcept
+        {
+            return hipFileInvalid;
+        }
+
+        bool isTerminal() const noexcept
+        {
+            return true;
+        }
+
+        Failed transitionTo(const Failed &next) const;
+    };
+
+    struct Timeout : StateBase<Timeout> {
+        using StateBase<Timeout>::transitionTo;
+
+        const char *name() const noexcept
+        {
+            return "hipFileTimeout";
+        }
+
+        hipFileStatus_t toPublic() const noexcept
+        {
+            return hipFileTimeout;
+        }
+
+        bool isTerminal() const noexcept
+        {
+            return true;
+        }
+
+        Failed transitionTo(const Failed &next) const;
+    };
+
+    struct Failed : StateBase<Failed> {
+        using StateBase<Failed>::transitionTo;
+
+        explicit Failed(ssize_t _error) : error{_error}
+        {
+        }
+
+        const char *name() const noexcept
+        {
+            return "hipFileFailed";
+        }
+
+        hipFileStatus_t toPublic() const noexcept
+        {
+            return hipFileFailed;
+        }
+
+        ssize_t ret() const noexcept
+        {
+            return error;
+        }
+
+        bool isTerminal() const noexcept
+        {
+            return true;
+        }
+
+        Failed transitionTo(const Failed &next) const;
+
+        ssize_t error;
+    };
+
+    using OperationState =
+        std::variant<Waiting, Pending, Running, Complete, Canceled, Invalid, Timeout, Failed>;
+}
+
 /// @brief Represents a single IO Request
 class BatchOperation {
 public:
@@ -37,6 +264,21 @@ public:
     /// @param [in] file File corresponding params->fh
     BatchOperation(std::unique_ptr<const hipFileIOParams_t> params, std::shared_ptr<IBuffer> buffer,
                    std::shared_ptr<IFile> file);
+
+    /// @brief Mark the operation as accepted and ready to run.
+    void markPending();
+
+    /// @brief Cancel the operation if it can be transitioned to Canceled; otherwise no-op.
+    void tryCancel();
+
+    /// @brief Record an internal execution failure on the operation.
+    void recordInternalError();
+
+    /// @brief Return a snapshot of the operation event state.
+    hipFileIOEvents_t event() const;
+
+    /// @brief Return whether the operation has reached a terminal status.
+    bool isTerminal() const;
 
 private:
     /// @brief A copy of the params provided by the application.
@@ -48,6 +290,15 @@ private:
 
     /// @brief A reference to the specified registered File.
     const std::shared_ptr<const IFile> file;
+
+    /// @brief Protects operation state.
+    mutable std::mutex state_mutex;
+
+    /// @brief Current operation state.
+    batchOperationState::OperationState state{batchOperationState::Waiting{}};
+
+    /// @brief Move to the next operation state. Caller must hold state_mutex.
+    template <class Next> void transitionTo(Next next);
 };
 
 class IBatchContext {

--- a/projects/hipfile/src/amd_detail/batch/batch.h
+++ b/projects/hipfile/src/amd_detail/batch/batch.h
@@ -258,6 +258,14 @@ namespace batchOperationState {
 /// @brief Represents a single IO Request
 class BatchOperation {
 public:
+    // Don't allow copying
+    BatchOperation(const BatchOperation &)            = delete;
+    BatchOperation &operator=(const BatchOperation &) = delete;
+
+    // Don't allow moving
+    BatchOperation(BatchOperation &&)            = delete;
+    BatchOperation &operator=(BatchOperation &&) = delete;
+
     /// @brief Create an operation to handle and track an IO request.
     /// @param [in] params IO parameters
     /// @param [in] buffer Buffer corresponding to params->u.batch.devPtr_base
@@ -312,6 +320,14 @@ public:
 
 class BatchContext : public IBatchContext {
 public:
+    // Don't allow copying
+    BatchContext(const BatchContext &)            = delete;
+    BatchContext &operator=(const BatchContext &) = delete;
+
+    // Don't allow moving
+    BatchContext(BatchContext &&)            = delete;
+    BatchContext &operator=(BatchContext &&) = delete;
+
     ///
     /// @brief Return the max number of concurrent operations supported by this BatchContext.
     ///

--- a/projects/hipfile/src/amd_detail/batch/batch.h
+++ b/projects/hipfile/src/amd_detail/batch/batch.h
@@ -372,6 +372,7 @@ public:
                                       IBatchOperationFactory *operation_factory = nullptr) = 0;
     virtual void     getStatus(unsigned min_nr, unsigned *nr, hipFileIOEvents_t *iocbp,
                                struct timespec *timeout)                                   = 0;
+    virtual void     cancelOperations()                                                    = 0;
 };
 
 class BatchContext : public IBatchContext, public std::enable_shared_from_this<BatchContext> {
@@ -413,6 +414,11 @@ public:
     ///
     void getStatus(unsigned min_nr, unsigned *nr, hipFileIOEvents_t *iocbp,
                    struct timespec *timeout) override;
+
+    ///
+    /// @brief Cancel outstanding operations from this Context and wait for running ops.
+    ///
+    void cancelOperations() override;
 
 private:
     const unsigned capacity;

--- a/projects/hipfile/src/amd_detail/batch/batch.h
+++ b/projects/hipfile/src/amd_detail/batch/batch.h
@@ -54,9 +54,9 @@ class IBatchContext {
 public:
     static constexpr unsigned MAX_SIZE = 128;
 
-    virtual ~IBatchContext()                                                                 = default;
-    virtual unsigned get_capacity() const noexcept                                           = 0;
-    virtual void     submit_operations(const hipFileIOParams_t *params, unsigned num_params) = 0;
+    virtual ~IBatchContext()                                                                = default;
+    virtual unsigned getCapacity() const noexcept                                           = 0;
+    virtual void     submitOperations(const hipFileIOParams_t *params, unsigned num_params) = 0;
 };
 
 class BatchContext : public IBatchContext {
@@ -66,7 +66,7 @@ public:
     ///
     /// @return The max number of concurrent operations that can be processed by this BatchContext.
     /// @note This may not exceed the value returned by `MAX_SIZE`.
-    unsigned get_capacity() const noexcept override;
+    unsigned getCapacity() const noexcept override;
 
     ///
     /// @brief Submit one or more operations to this Context.
@@ -76,7 +76,7 @@ public:
     /// @note This is an All or None operation. If one submitted operation is not valid, no operations
     ///       will be submitted.
     ///
-    void submit_operations(const hipFileIOParams_t *params, const unsigned num_params) override;
+    void submitOperations(const hipFileIOParams_t *params, const unsigned num_params) override;
 
 private:
     const unsigned capacity;

--- a/projects/hipfile/src/amd_detail/batch/batch.h
+++ b/projects/hipfile/src/amd_detail/batch/batch.h
@@ -7,7 +7,7 @@
 
 #include "hipfile.h"
 
-#include <cstddef>
+#include <condition_variable>
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
@@ -370,9 +370,11 @@ public:
     virtual unsigned getCapacity() const noexcept                                          = 0;
     virtual void     submitOperations(const hipFileIOParams_t *params, unsigned num_params,
                                       IBatchOperationFactory *operation_factory = nullptr) = 0;
+    virtual void     getStatus(unsigned min_nr, unsigned *nr, hipFileIOEvents_t *iocbp,
+                               struct timespec *timeout)                                   = 0;
 };
 
-class BatchContext : public IBatchContext {
+class BatchContext : public IBatchContext, public std::enable_shared_from_this<BatchContext> {
 public:
     // Don't allow copying
     BatchContext(const BatchContext &)            = delete;
@@ -402,12 +404,25 @@ public:
     void submitOperations(const hipFileIOParams_t *params, const unsigned num_params,
                           IBatchOperationFactory *operation_factory = nullptr) override;
 
+    ///
+    /// @brief Poll for completed operations from this Context.
+    /// @param [in]     min_nr  Minimum number of events requested before returning.
+    /// @param [in,out] nr      Input event capacity and output number of events returned.
+    /// @param [out]    iocbp   Event output buffer.
+    /// @param [in]     timeout Maximum amount of time to wait.
+    ///
+    void getStatus(unsigned min_nr, unsigned *nr, hipFileIOEvents_t *iocbp,
+                   struct timespec *timeout) override;
+
 private:
     const unsigned capacity;
 
     /// Per-Context mutex to limit access to one caller at a time.
     /// Shared as internally we can be more strategic about concurrent access.
     mutable std::shared_mutex context_mutex;
+
+    /// Wakes callers waiting for operations to become terminal.
+    std::condition_variable_any status_cv;
 
     /// An outstanding operation is a BatchOperation that has been submitted
     /// but is not yet complete or completed but not yet retrieved by the

--- a/projects/hipfile/src/amd_detail/batch/batch.h
+++ b/projects/hipfile/src/amd_detail/batch/batch.h
@@ -22,11 +22,20 @@ class IBuffer;
 namespace hipFile {
 class IFile;
 }
+namespace hipFile {
+class ITaskGroup;
+}
 
 namespace hipFile {
 
 struct InvalidBatchHandle : public std::invalid_argument {
     InvalidBatchHandle() : std::invalid_argument{"Invalid batch handle"}
+    {
+    }
+};
+
+struct BatchFull : public std::invalid_argument {
+    BatchFull() : std::invalid_argument{"Not enough room in batch"}
     {
     }
 };
@@ -279,6 +288,9 @@ public:
     /// @brief Cancel the operation if it can be transitioned to Canceled; otherwise no-op.
     void tryCancel();
 
+    /// @brief Execute the operation.
+    void run() noexcept;
+
     /// @brief Record an internal execution failure on the operation.
     void recordInternalError();
 
@@ -294,10 +306,10 @@ private:
     const std::unique_ptr<const hipFileIOParams_t> io_params;
 
     /// @brief A reference to the specified Buffer.
-    const std::shared_ptr<const IBuffer> buffer;
+    const std::shared_ptr<IBuffer> buffer;
 
     /// @brief A reference to the specified registered File.
-    const std::shared_ptr<const IFile> file;
+    const std::shared_ptr<IFile> file;
 
     /// @brief Protects operation state.
     mutable std::mutex state_mutex;
@@ -328,6 +340,8 @@ public:
     BatchContext(BatchContext &&)            = delete;
     BatchContext &operator=(BatchContext &&) = delete;
 
+    ~BatchContext() override;
+
     ///
     /// @brief Return the max number of concurrent operations supported by this BatchContext.
     ///
@@ -357,6 +371,9 @@ private:
     /// application.
     /// shared_ptr as it may need to be passed to a backend.
     std::unordered_set<std::shared_ptr<BatchOperation>> outstanding_ops;
+
+    /// Task group used for all submitted operations owned by this context.
+    std::unique_ptr<ITaskGroup> task_group;
 
     BatchContext(unsigned capacity);
 

--- a/projects/hipfile/src/amd_detail/batch/batch.h
+++ b/projects/hipfile/src/amd_detail/batch/batch.h
@@ -265,7 +265,31 @@ namespace batchOperationState {
 }
 
 /// @brief Represents a single IO Request
-class BatchOperation {
+class IBatchOperation {
+public:
+    virtual ~IBatchOperation() = default;
+
+    /// @brief Mark the operation as accepted and ready to run.
+    virtual void markPending() = 0;
+
+    /// @brief Cancel the operation if it can be transitioned to Canceled; otherwise no-op.
+    virtual void tryCancel() = 0;
+
+    /// @brief Execute the operation.
+    virtual void run() noexcept = 0;
+
+    /// @brief Record an internal execution failure on the operation.
+    virtual void recordInternalError() = 0;
+
+    /// @brief Return a snapshot of the operation event state.
+    virtual hipFileIOEvents_t event() const = 0;
+
+    /// @brief Return whether the operation has reached a terminal status.
+    virtual bool isTerminal() const = 0;
+};
+
+/// @brief Represents a single IO Request
+class BatchOperation : public IBatchOperation {
 public:
     // Don't allow copying
     BatchOperation(const BatchOperation &)            = delete;
@@ -274,6 +298,7 @@ public:
     // Don't allow moving
     BatchOperation(BatchOperation &&)            = delete;
     BatchOperation &operator=(BatchOperation &&) = delete;
+    ~BatchOperation() override                   = default;
 
     /// @brief Create an operation to handle and track an IO request.
     /// @param [in] params IO parameters
@@ -283,22 +308,22 @@ public:
                    std::shared_ptr<IFile> file);
 
     /// @brief Mark the operation as accepted and ready to run.
-    void markPending();
+    void markPending() override;
 
     /// @brief Cancel the operation if it can be transitioned to Canceled; otherwise no-op.
-    void tryCancel();
+    void tryCancel() override;
 
     /// @brief Execute the operation.
-    void run() noexcept;
+    void run() noexcept override;
 
     /// @brief Record an internal execution failure on the operation.
-    void recordInternalError();
+    void recordInternalError() override;
 
     /// @brief Return a snapshot of the operation event state.
-    hipFileIOEvents_t event() const;
+    hipFileIOEvents_t event() const override;
 
     /// @brief Return whether the operation has reached a terminal status.
-    bool isTerminal() const;
+    bool isTerminal() const override;
 
 private:
     /// @brief A copy of the params provided by the application.
@@ -321,13 +346,30 @@ private:
     template <class Next> void transitionTo(Next next);
 };
 
+class IBatchOperationFactory {
+public:
+    virtual ~IBatchOperationFactory() = default;
+
+    virtual std::shared_ptr<IBatchOperation> create(std::unique_ptr<const hipFileIOParams_t> params,
+                                                    std::shared_ptr<IBuffer>                 buffer,
+                                                    std::shared_ptr<IFile>                   file) = 0;
+};
+
+class BatchOperationFactory : public IBatchOperationFactory {
+public:
+    std::shared_ptr<IBatchOperation> create(std::unique_ptr<const hipFileIOParams_t> params,
+                                            std::shared_ptr<IBuffer>                 buffer,
+                                            std::shared_ptr<IFile>                   file) override;
+};
+
 class IBatchContext {
 public:
     static constexpr unsigned MAX_SIZE = 128;
 
-    virtual ~IBatchContext()                                                                = default;
-    virtual unsigned getCapacity() const noexcept                                           = 0;
-    virtual void     submitOperations(const hipFileIOParams_t *params, unsigned num_params) = 0;
+    virtual ~IBatchContext()                                                               = default;
+    virtual unsigned getCapacity() const noexcept                                          = 0;
+    virtual void     submitOperations(const hipFileIOParams_t *params, unsigned num_params,
+                                      IBatchOperationFactory *operation_factory = nullptr) = 0;
 };
 
 class BatchContext : public IBatchContext {
@@ -357,7 +399,8 @@ public:
     /// @note This is an All or None operation. If one submitted operation is not valid, no operations
     ///       will be submitted.
     ///
-    void submitOperations(const hipFileIOParams_t *params, const unsigned num_params) override;
+    void submitOperations(const hipFileIOParams_t *params, const unsigned num_params,
+                          IBatchOperationFactory *operation_factory = nullptr) override;
 
 private:
     const unsigned capacity;
@@ -370,7 +413,7 @@ private:
     /// but is not yet complete or completed but not yet retrieved by the
     /// application.
     /// shared_ptr as it may need to be passed to a backend.
-    std::unordered_set<std::shared_ptr<BatchOperation>> outstanding_ops;
+    std::unordered_set<std::shared_ptr<IBatchOperation>> outstanding_ops;
 
     /// Task group used for all submitted operations owned by this context.
     std::unique_ptr<ITaskGroup> task_group;

--- a/projects/hipfile/src/amd_detail/hipfile-private.h
+++ b/projects/hipfile/src/amd_detail/hipfile-private.h
@@ -13,7 +13,14 @@
 
 namespace hipFile {
 enum class IoType;
+class IBuffer;
+class IFile;
 struct Backend;
+
+ssize_t hipFileIo(hipFile::IoType type, std::shared_ptr<hipFile::IFile> file,
+                  std::shared_ptr<hipFile::IBuffer> buffer, size_t size, hoff_t file_offset,
+                  hoff_t buffer_offset,
+                  const std::vector<std::shared_ptr<hipFile::Backend>> &backends);
 
 ssize_t hipFileIo(hipFile::IoType type, hipFileHandle_t fh, const void *buffer_base, size_t size,
                   hoff_t file_offset, hoff_t buffer_offset,

--- a/projects/hipfile/src/amd_detail/hipfile.cpp
+++ b/projects/hipfile/src/amd_detail/hipfile.cpp
@@ -433,13 +433,24 @@ hipFileBatchIOGetStatus(hipFileBatchHandle_t batch_idp, unsigned min_nr, unsigne
                         hipFileIOEvents_t *iocbp, struct timespec *timeout)
 try {
     hipFileInit();
-    (void)batch_idp;
-    (void)min_nr;
-    (void)nr;
-    (void)iocbp;
-    (void)timeout;
 
-    throw std::runtime_error("Not Implemented");
+    if (iocbp == nullptr) {
+        return {hipFileInvalidValue, hipSuccess};
+    }
+    if (nr == nullptr || *nr == 0) {
+        return {hipFileInvalidValue, hipSuccess};
+    }
+    if (min_nr > *nr) {
+        return {hipFileInvalidValue, hipSuccess};
+    }
+
+    std::shared_ptr<IBatchContext> batch_context = Context<DriverState>::get()->getBatchContext(batch_idp);
+    batch_context->getStatus(min_nr, nr, iocbp, timeout);
+
+    return {hipFileSuccess, hipSuccess};
+}
+catch (const std::invalid_argument &) {
+    return {hipFileInvalidValue, hipSuccess};
 }
 catch (...) {
     return handle_exception();

--- a/projects/hipfile/src/amd_detail/hipfile.cpp
+++ b/projects/hipfile/src/amd_detail/hipfile.cpp
@@ -460,9 +460,14 @@ hipFileError_t
 hipFileBatchIOCancel(hipFileBatchHandle_t batch_idp)
 try {
     hipFileInit();
-    (void)batch_idp;
 
-    throw std::runtime_error("Not Implemented");
+    std::shared_ptr<IBatchContext> batch_context = Context<DriverState>::get()->getBatchContext(batch_idp);
+    batch_context->cancelOperations();
+
+    return {hipFileSuccess, hipSuccess};
+}
+catch (const std::invalid_argument &) {
+    return {hipFileInvalidValue, hipSuccess};
 }
 catch (...) {
     return handle_exception();

--- a/projects/hipfile/src/amd_detail/hipfile.cpp
+++ b/projects/hipfile/src/amd_detail/hipfile.cpp
@@ -406,10 +406,20 @@ try {
     hipFileInit();
     (void)flags; // Unused at this time.
 
+    if (nr == 0 || iocbp == nullptr) {
+        return {hipFileInvalidValue, hipSuccess};
+    }
+
     std::shared_ptr<IBatchContext> batch_context = Context<DriverState>::get()->getBatchContext(batch_idp);
     batch_context->submitOperations(iocbp, nr);
 
     return {hipFileSuccess, hipSuccess};
+}
+catch (const BatchFull &) {
+    return {hipFileBatchFull, hipSuccess};
+}
+catch (const FileNotRegistered &) {
+    return {hipFileHandleNotRegistered, hipSuccess};
 }
 catch (const std::invalid_argument &) {
     return {hipFileInvalidValue, hipSuccess};

--- a/projects/hipfile/src/amd_detail/hipfile.cpp
+++ b/projects/hipfile/src/amd_detail/hipfile.cpp
@@ -477,9 +477,11 @@ void
 hipFileBatchIODestroy(hipFileBatchHandle_t batch_idp)
 try {
     hipFileInit();
-    (void)batch_idp;
+    if (batch_idp == nullptr) {
+        return;
+    }
 
-    throw std::runtime_error("Not Implemented");
+    Context<DriverState>::get()->destroyBatchContext(batch_idp);
 }
 catch (...) {
     return;

--- a/projects/hipfile/src/amd_detail/hipfile.cpp
+++ b/projects/hipfile/src/amd_detail/hipfile.cpp
@@ -175,10 +175,9 @@ getCachedBackends()
 }
 
 ssize_t
-hipFileIo(IoType type, hipFileHandle_t fh, const void *buffer_base, size_t size, hoff_t file_offset,
-          hoff_t buffer_offset, const vector<shared_ptr<Backend>> &backends)
+hipFileIo(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,
+          hoff_t file_offset, hoff_t buffer_offset, const vector<shared_ptr<Backend>> &backends)
 try {
-    auto [file, buffer] = Context<DriverState>::get()->getFileAndBuffer(fh, buffer_base);
     int                      score{-1};
     std::shared_ptr<Backend> backend{};
 
@@ -199,13 +198,34 @@ try {
         }
     }
 
-    return backend->io(type, file, buffer, size, file_offset, buffer_offset);
-}
-catch (const DriverNotInitialized &) {
-    return -hipFileDriverNotInitialized;
+    return backend->io(type, std::move(file), std::move(buffer), size, file_offset, buffer_offset);
 }
 catch (hipFileError_t e) {
     return -e.err;
+}
+catch (const std::invalid_argument &) {
+    return -hipFileInvalidValue;
+}
+catch (const Hip::RuntimeError &) {
+    throw;
+}
+catch (const std::system_error &e) {
+    errno = e.code().value();
+    return -1;
+}
+catch (...) {
+    return -hipFileInternalError;
+}
+
+ssize_t
+hipFileIo(IoType type, hipFileHandle_t fh, const void *buffer_base, size_t size, hoff_t file_offset,
+          hoff_t buffer_offset, const vector<shared_ptr<Backend>> &backends)
+try {
+    auto [file, buffer] = Context<DriverState>::get()->getFileAndBuffer(fh, buffer_base);
+    return hipFileIo(type, std::move(file), std::move(buffer), size, file_offset, buffer_offset, backends);
+}
+catch (const DriverNotInitialized &) {
+    return -hipFileDriverNotInitialized;
 }
 catch (const InvalidMemoryType &) {
     return -hipFileHipMemoryTypeInvalid;
@@ -218,10 +238,6 @@ catch (const FileNotRegistered &) {
 }
 catch (const Hip::RuntimeError &e) {
     return -e.error;
-}
-catch (const std::system_error &e) {
-    errno = e.code().value();
-    return -1;
 }
 catch (...) {
     return -hipFileInternalError;

--- a/projects/hipfile/src/amd_detail/hipfile.cpp
+++ b/projects/hipfile/src/amd_detail/hipfile.cpp
@@ -391,7 +391,7 @@ try {
     (void)flags; // Unused at this time.
 
     std::shared_ptr<IBatchContext> batch_context = Context<DriverState>::get()->getBatchContext(batch_idp);
-    batch_context->submit_operations(iocbp, nr);
+    batch_context->submitOperations(iocbp, nr);
 
     return {hipFileSuccess, hipSuccess};
 }

--- a/projects/hipfile/src/amd_detail/state.cpp
+++ b/projects/hipfile/src/amd_detail/state.cpp
@@ -243,6 +243,7 @@ DriverState::decrRefCount()
 
     // Clear the maps if the reference count just hit zero
     if (ref_count == 0) {
+        batch_map->clear();
         buffer_map->clear();
         file_map->clear();
     }

--- a/projects/hipfile/src/nvidia_detail/hipfile.cpp
+++ b/projects/hipfile/src/nvidia_detail/hipfile.cpp
@@ -221,19 +221,19 @@ try {
     CUfileBatchHandle_t cu_batch_idp = batch_idp;
     CUfileError_t       status;
 
-    if (iocbp) {
-        vector<CUfileIOEvents> io_events(*nr);
-
-        status = cuFileBatchIOGetStatus(cu_batch_idp, min_nr, nr, io_events.data(), timeout);
-
-        if (status.err == CU_FILE_SUCCESS) {
-            for (unsigned i = 0; i < *nr; i++) {
-                iocbp[i] = toHipFileIOEvents(io_events[i]);
-            }
-        }
+    vector<CUfileIOEvents> io_events;
+    CUfileIOEvents_t      *cu_iocbp = nullptr;
+    if (nr && *nr > 0 && iocbp) {
+        io_events.resize(*nr);
+        cu_iocbp = io_events.data();
     }
-    else {
-        status = cuFileBatchIOGetStatus(cu_batch_idp, min_nr, nr, nullptr, timeout);
+
+    status = cuFileBatchIOGetStatus(cu_batch_idp, min_nr, nr, cu_iocbp, timeout);
+
+    if (status.err == CU_FILE_SUCCESS && nr && iocbp) {
+        for (unsigned i = 0; i < *nr; i++) {
+            iocbp[i] = toHipFileIOEvents(io_events[i]);
+        }
     }
 
     return toHipFileError(status);

--- a/projects/hipfile/test/CMakeLists.txt
+++ b/projects/hipfile/test/CMakeLists.txt
@@ -21,6 +21,7 @@ set(UNIT_TEST_SOURCE_FILES
 # and configured on the system.
 set(SYSTEM_TEST_SOURCE_FILES
     system/async.cpp
+    system/batch.cpp
     system/buffer.cpp
     system/config.cpp
     system/driver.cpp

--- a/projects/hipfile/test/CMakeLists.txt
+++ b/projects/hipfile/test/CMakeLists.txt
@@ -25,6 +25,7 @@ set(SYSTEM_TEST_SOURCE_FILES
     system/config.cpp
     system/driver.cpp
     system/main.cpp
+    system/util.cpp
     system/version.cpp
 )
 

--- a/projects/hipfile/test/amd_detail/batch/batch.cpp
+++ b/projects/hipfile/test/amd_detail/batch/batch.cpp
@@ -68,6 +68,8 @@ TEST_F(HipFileBatch, CreateOperationRead)
     io_params->opcode = hipFileBatchRead;
 
     BatchOperation op = BatchOperation{std::move(io_params), default_mock_buffer, default_mock_file};
+
+    ASSERT_EQ(op.event().status, hipFileWaiting);
 }
 
 TEST_F(HipFileBatch, CreateOperationWrite)
@@ -75,6 +77,69 @@ TEST_F(HipFileBatch, CreateOperationWrite)
     io_params->opcode = hipFileBatchWrite;
 
     BatchOperation op = BatchOperation{std::move(io_params), default_mock_buffer, default_mock_file};
+
+    ASSERT_EQ(op.event().status, hipFileWaiting);
+}
+
+TEST_F(HipFileBatch, MarkOperationPending)
+{
+    BatchOperation op = BatchOperation{std::move(io_params), default_mock_buffer, default_mock_file};
+
+    op.markPending();
+
+    ASSERT_EQ(op.event().status, hipFilePending);
+}
+
+TEST_F(HipFileBatch, TryCancelWaitingOperationIsNoOp)
+{
+    BatchOperation op = BatchOperation{std::move(io_params), default_mock_buffer, default_mock_file};
+
+    op.tryCancel();
+
+    ASSERT_EQ(op.event().status, hipFileWaiting);
+}
+
+TEST_F(HipFileBatch, MarkPendingPendingOperationThrowsInvalidStateTransition)
+{
+    BatchOperation op = BatchOperation{std::move(io_params), default_mock_buffer, default_mock_file};
+
+    op.markPending();
+
+    ASSERT_THROW(op.markPending(), InvalidStateTransition);
+    ASSERT_EQ(op.event().status, hipFilePending);
+}
+
+TEST_F(HipFileBatch, CancelPendingOperation)
+{
+    BatchOperation op = BatchOperation{std::move(io_params), default_mock_buffer, default_mock_file};
+
+    op.markPending();
+    op.tryCancel();
+
+    ASSERT_EQ(op.event().status, hipFileCanceled);
+}
+
+TEST_F(HipFileBatch, CancelPendingOperationIsIdempotent)
+{
+    BatchOperation op = BatchOperation{std::move(io_params), default_mock_buffer, default_mock_file};
+
+    op.markPending();
+    op.tryCancel();
+    op.tryCancel();
+
+    ASSERT_EQ(op.event().status, hipFileCanceled);
+}
+
+TEST_F(HipFileBatch, MarkPendingCanceledOperationThrowsInvalidStateTransition)
+{
+    BatchOperation op = BatchOperation{std::move(io_params), default_mock_buffer, default_mock_file};
+
+    op.markPending();
+    op.tryCancel();
+
+    ASSERT_THROW(op.markPending(), InvalidStateTransition);
+
+    ASSERT_EQ(op.event().status, hipFileCanceled);
 }
 
 TEST_F(HipFileBatch, CreateOperationBadBuffer)

--- a/projects/hipfile/test/amd_detail/batch/batch.cpp
+++ b/projects/hipfile/test/amd_detail/batch/batch.cpp
@@ -28,10 +28,13 @@
 #include <vector>
 
 using ::testing::_;
+using ::testing::AllOf;
 using ::testing::ByMove;
+using ::testing::Field;
 using ::testing::Return;
 using ::testing::StrictMock;
 using ::testing::Throw;
+using ::testing::UnorderedElementsAre;
 
 using namespace hipFile;
 
@@ -365,6 +368,15 @@ struct HipFileBatchContext : public HipFileUnopened {
         return raw;
     }
 
+    void expectTaskQueueFlushed()
+    {
+        auto old_task_group = mock_task_group;
+        mock_task_group     = expectTaskGroupCreated();
+
+        EXPECT_CALL(*old_task_group, cancel()).Times(1);
+        EXPECT_CALL(*old_task_group, wait()).Times(1);
+    }
+
     std::shared_ptr<StrictMock<MBatchOperation>> makeOperation()
     {
         auto op = std::make_shared<StrictMock<MBatchOperation>>();
@@ -512,6 +524,200 @@ TEST_F(HipFileBatchContext, SubmitBatchWithBadOpThrows)
     EXPECT_CALL(*mock_task_group, run(_)).Times(0);
 
     ASSERT_THROW(_context->submitOperations(params.data(), params.size()), std::invalid_argument);
+}
+
+TEST_F(HipFileBatchContext, SubmittedWorkKeepsContextAliveUntilReleased)
+{
+    std::function<void()>        enqueued_work;
+    std::weak_ptr<IBatchContext> weak_context = _context;
+
+    // enqueued_work will capture the function that has been passed to the thread pool
+    EXPECT_CALL(*mock_task_group, run(_)).WillOnce([&enqueued_work](std::function<void()> work) {
+        enqueued_work = std::move(work);
+    });
+
+    ASSERT_NO_THROW(_context->submitOperations(&io_params, 1));
+    // enqueued_work has been assigned
+    ASSERT_TRUE(enqueued_work);
+
+    // Destroy the context and our shared_ptr to it
+    batch_map.destroyContext(_context.get());
+    _context.reset();
+
+    // BatchContext is still valid because it was captured by lambda
+    ASSERT_FALSE(weak_context.expired());
+
+    // Assigning empty function will call destructor for the lambda that was assigned
+    enqueued_work = {};
+
+    // The shared_ptr has been destroyed
+    ASSERT_TRUE(weak_context.expired());
+}
+
+TEST_F(HipFileBatchContext, GetStatusNoOutstandingReturnsNothing)
+{
+    unsigned          nr = 1;
+    hipFileIOEvents_t event{};
+    struct timespec   timeout{1, 0};
+
+    ASSERT_NO_THROW(_context->getStatus(1, &nr, &event, &timeout));
+    ASSERT_EQ(nr, 0);
+}
+
+TEST_F(HipFileBatchContext, GetStatusNullNumEventsThrowsInvalidArgument)
+{
+    hipFileIOEvents_t event{};
+
+    ASSERT_THROW(_context->getStatus(1, nullptr, &event, nullptr), std::invalid_argument);
+}
+
+TEST_F(HipFileBatchContext, GetStatusZeroNumEventsThrowsInvalidArgument)
+{
+    hipFileIOEvents_t event{};
+    unsigned          nr = 0;
+
+    ASSERT_THROW(_context->getStatus(0, &nr, &event, nullptr), std::invalid_argument);
+}
+
+TEST_F(HipFileBatchContext, GetStatusNullEventsThrowsInvalidArgument)
+{
+    unsigned nr = 1;
+
+    ASSERT_THROW(_context->getStatus(0, &nr, nullptr, nullptr), std::invalid_argument);
+}
+
+TEST_F(HipFileBatchContext, GetStatusMinimumExceedsCapacityThrowsInvalidArgument)
+{
+    unsigned          nr = 1;
+    hipFileIOEvents_t event{};
+
+    ASSERT_THROW(_context->getStatus(2, &nr, &event, nullptr), std::invalid_argument);
+}
+
+TEST_F(HipFileBatchContext, GetStatusNegativeTimeoutSecondsThrowsInvalidArgument)
+{
+    unsigned          nr = 1;
+    hipFileIOEvents_t event{};
+    struct timespec   timeout{-1, 0};
+
+    ASSERT_THROW(_context->getStatus(0, &nr, &event, &timeout), std::invalid_argument);
+}
+
+TEST_F(HipFileBatchContext, GetStatusReturnsCompletedOperationAndConsumesIt)
+{
+    int               cookie{};
+    auto              op = makeOperation();
+    hipFileIOEvents_t completed_event{&cookie, hipFileComplete, 9};
+    EXPECT_CALL(*op, isTerminal()).WillRepeatedly(Return(true));
+    EXPECT_CALL(*op, event()).WillOnce(Return(completed_event));
+    submitMockOperations({op});
+
+    unsigned          nr = 1;
+    hipFileIOEvents_t event{};
+    ASSERT_NO_THROW(_context->getStatus(1, &nr, &event, nullptr));
+
+    ASSERT_EQ(nr, 1);
+    ASSERT_EQ(event.cookie, &cookie);
+    ASSERT_EQ(event.status, hipFileComplete);
+    ASSERT_EQ(event.ret, 9);
+
+    nr = 1;
+    ASSERT_NO_THROW(_context->getStatus(0, &nr, &event, nullptr));
+    ASSERT_EQ(nr, 0);
+}
+
+TEST_F(HipFileBatchContext, GetStatusReturnsFailedAndCanceledOperations)
+{
+    int               failed_cookie{};
+    int               canceled_cookie{};
+    auto              failed_op      = makeOperation();
+    auto              canceled_op    = makeOperation();
+    hipFileIOEvents_t failed_event   = {&failed_cookie, hipFileFailed,
+                                        static_cast<size_t>(-hipFileInternalError)};
+    hipFileIOEvents_t canceled_event = {&canceled_cookie, hipFileCanceled, 0};
+    EXPECT_CALL(*failed_op, isTerminal()).WillRepeatedly(Return(true));
+    EXPECT_CALL(*failed_op, event()).WillRepeatedly(Return(failed_event));
+    EXPECT_CALL(*canceled_op, isTerminal()).WillRepeatedly(Return(true));
+    EXPECT_CALL(*canceled_op, event()).WillRepeatedly(Return(canceled_event));
+    submitMockOperations({failed_op, canceled_op});
+
+    unsigned                         nr = 2;
+    std::array<hipFileIOEvents_t, 2> events{};
+    ASSERT_NO_THROW(_context->getStatus(2, &nr, events.data(), nullptr));
+
+    ASSERT_EQ(nr, 2);
+    ASSERT_THAT(events, UnorderedElementsAre(
+                            AllOf(Field(&hipFileIOEvents_t::cookie, static_cast<void *>(&failed_cookie)),
+                                  Field(&hipFileIOEvents_t::status, hipFileFailed),
+                                  Field(&hipFileIOEvents_t::ret, static_cast<size_t>(-hipFileInternalError))),
+                            AllOf(Field(&hipFileIOEvents_t::cookie, static_cast<void *>(&canceled_cookie)),
+                                  Field(&hipFileIOEvents_t::status, hipFileCanceled))));
+}
+
+TEST_F(HipFileBatchContext, GetStatusDoesNotReturnNonTerminalOperation)
+{
+    auto              op = makeOperation();
+    hipFileIOEvents_t completed_event{nullptr, hipFileComplete, 1};
+    EXPECT_CALL(*op, event()).WillOnce(Return(completed_event));
+    submitMockOperations({op});
+
+    unsigned          nr = 1;
+    hipFileIOEvents_t event{};
+    struct timespec   timeout{0, 0};
+    EXPECT_CALL(*op, isTerminal()).Times(2).WillRepeatedly(Return(false));
+    ASSERT_NO_THROW(_context->getStatus(0, &nr, &event, &timeout));
+
+    ASSERT_EQ(nr, 0);
+
+    EXPECT_CALL(*op, isTerminal()).WillRepeatedly(Return(true));
+    nr = 1;
+    ASSERT_NO_THROW(_context->getStatus(0, &nr, &event, nullptr));
+    ASSERT_EQ(nr, 1);
+    ASSERT_EQ(event.status, hipFileComplete);
+}
+
+TEST_F(HipFileBatchContext, GetStatusReturnsAtMostCallerCapacity)
+{
+    auto op1 = makeOperation();
+    auto op2 = makeOperation();
+    EXPECT_CALL(*op1, isTerminal()).WillRepeatedly(Return(true));
+    EXPECT_CALL(*op2, isTerminal()).WillRepeatedly(Return(true));
+    EXPECT_CALL(*op1, event()).WillRepeatedly(Return(hipFileIOEvents_t{nullptr, hipFileComplete, 1}));
+    EXPECT_CALL(*op2, event()).WillRepeatedly(Return(hipFileIOEvents_t{nullptr, hipFileComplete, 2}));
+    submitMockOperations({op1, op2});
+
+    unsigned          nr = 1;
+    hipFileIOEvents_t event{};
+    ASSERT_NO_THROW(_context->getStatus(0, &nr, &event, nullptr));
+
+    ASSERT_EQ(nr, 1);
+
+    nr = 2;
+    std::array<hipFileIOEvents_t, 2> events{};
+    ASSERT_NO_THROW(_context->getStatus(0, &nr, events.data(), nullptr));
+    ASSERT_EQ(nr, 1);
+}
+
+TEST_F(HipFileBatchContext, GetStatusZeroTimeoutWillReturnLessThanMin)
+{
+    int               cookie{};
+    auto              complete_op = makeOperation();
+    auto              pending_op  = makeOperation();
+    hipFileIOEvents_t completed_event{&cookie, hipFileComplete, 4};
+    EXPECT_CALL(*complete_op, isTerminal()).WillRepeatedly(Return(true));
+    EXPECT_CALL(*pending_op, isTerminal()).WillRepeatedly(Return(false));
+    EXPECT_CALL(*complete_op, event()).WillOnce(Return(completed_event));
+    submitMockOperations({complete_op, pending_op});
+
+    unsigned          nr = 2;
+    hipFileIOEvents_t event[2];
+    struct timespec   timeout{0, 0};
+    ASSERT_NO_THROW(_context->getStatus(2, &nr, &event[0], &timeout));
+
+    ASSERT_EQ(nr, 1);
+    ASSERT_EQ(event[0].cookie, &cookie);
+    ASSERT_EQ(event[0].status, hipFileComplete);
+    ASSERT_EQ(event[0].ret, 4);
 }
 
 TEST_F(HipFileBatchContext, SubmitSingleBadBuffer)

--- a/projects/hipfile/test/amd_detail/batch/batch.cpp
+++ b/projects/hipfile/test/amd_detail/batch/batch.cpp
@@ -13,9 +13,11 @@
 #include "mbuffer.h"
 #include "mfile.h"
 #include "mstate.h"
+#include "mthread-pool.h"
 #include "state.h"
 
-#include <cstdio>
+#include "gmock/gmock.h"
+#include <array>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <memory>
@@ -23,6 +25,7 @@
 #include <utility>
 
 using ::testing::_;
+using ::testing::ByMove;
 using ::testing::DoDefault;
 using ::testing::Return;
 using ::testing::StrictMock;
@@ -33,15 +36,18 @@ using namespace hipFile;
 HIPFILE_WARN_NO_GLOBAL_CTOR_OFF
 
 struct HipFileBatch : public HipFileUnopened {
-    BatchContextMap                      batch_map = BatchContextMap{};
-    std::unique_ptr<hipFileIOParams_t>   io_params;
-    std::shared_ptr<StrictMock<MBuffer>> default_mock_buffer;
-    std::shared_ptr<StrictMock<MFile>>   default_mock_file;
-    const hipFileHandle_t                file_handle{reinterpret_cast<void *>(0xDEADBEEF)};
-    void *const                          buffer_pointer{reinterpret_cast<void *>(0x0BADF00D)};
+    BatchContextMap                           batch_map = BatchContextMap{};
+    std::unique_ptr<hipFileIOParams_t>        io_params;
+    std::unique_ptr<StrictMock<MDriverState>> mock_driver_state;
+    std::shared_ptr<StrictMock<MBuffer>>      default_mock_buffer;
+    std::shared_ptr<StrictMock<MFile>>        default_mock_file;
+    const hipFileHandle_t                     file_handle{reinterpret_cast<void *>(0xDEADBEEF)};
+    void *const                               buffer_pointer{reinterpret_cast<void *>(0x0BADF00D)};
+    int                                       cookie{};
 
     void SetUp() override
     {
+        mock_driver_state   = std::make_unique<StrictMock<MDriverState>>();
         default_mock_buffer = std::make_shared<StrictMock<MBuffer>>();
         EXPECT_CALL(*default_mock_buffer, getBuffer).WillRepeatedly(Return(buffer_pointer));
         EXPECT_CALL(*default_mock_buffer, getLength).WillRepeatedly(Return(1));
@@ -55,6 +61,7 @@ struct HipFileBatch : public HipFileUnopened {
         io_params->fh                  = file_handle;
         io_params->mode                = hipFileBatch;
         io_params->opcode              = hipFileBatchRead;
+        io_params->cookie              = &cookie;
     }
 };
 
@@ -135,6 +142,32 @@ TEST_F(HipFileBatch, MarkPendingCanceledOperationThrowsInvalidStateTransition)
     ASSERT_THROW(op.markPending(), InvalidStateTransition);
 
     ASSERT_EQ(op.event().status, hipFileCanceled);
+}
+
+TEST_F(HipFileBatch, RunCanceledOperationReturnsImmediately)
+{
+    BatchOperation op = BatchOperation{std::move(io_params), default_mock_buffer, default_mock_file};
+
+    op.markPending();
+    op.tryCancel();
+    EXPECT_CALL(*mock_driver_state, getBackends).Times(0);
+    op.run();
+
+    hipFileIOEvents_t event = op.event();
+    ASSERT_EQ(event.status, hipFileCanceled);
+}
+
+TEST_F(HipFileBatch, RunInternalStateErrorRecordsFailedEvent)
+{
+    BatchOperation op = BatchOperation{std::move(io_params), default_mock_buffer, default_mock_file};
+
+    // Running waiting op results in invalid transition
+    op.run();
+
+    hipFileIOEvents_t event = op.event();
+    ASSERT_EQ(event.status, hipFileFailed);
+    ASSERT_EQ(event.ret, static_cast<size_t>(-hipFileInternalError));
+    ASSERT_EQ(event.cookie, &cookie);
 }
 
 TEST_F(HipFileBatch, CreateOperationBadBuffer)
@@ -288,6 +321,8 @@ struct HipFileBatchContext : public HipFileUnopened {
     std::shared_ptr<IBatchContext>            _context;
     unsigned                                  _context_capacity = 2;
     std::unique_ptr<StrictMock<MDriverState>> mock_driver_state;
+    std::unique_ptr<StrictMock<MThreadPool>>  mock_thread_pool;
+    StrictMock<MTaskGroup>                   *mock_task_group = nullptr;
 
     hipFileIOParams_t                    io_params{};
     std::shared_ptr<StrictMock<MBuffer>> default_mock_buffer;
@@ -312,38 +347,85 @@ struct HipFileBatchContext : public HipFileUnopened {
         io_params.opcode              = hipFileBatchRead;
 
         mock_driver_state = std::make_unique<StrictMock<MDriverState>>();
+        mock_thread_pool  = std::make_unique<StrictMock<MThreadPool>>();
+        mock_task_group   = expectTaskGroupCreated();
         _context          = batch_map.get(batch_map.createContext(_context_capacity));
         // May be overridden with EXPECT_CALL in the test.
         EXPECT_CALL(*mock_driver_state, getFileAndBuffer).WillRepeatedly(Return(std::move(default_fb_pair)));
+    }
+
+    StrictMock<MTaskGroup> *expectTaskGroupCreated()
+    {
+        auto task_group = std::make_unique<StrictMock<MTaskGroup>>();
+        auto raw        = task_group.get();
+        EXPECT_CALL(*mock_thread_pool, makeTaskGroup()).WillOnce(Return(ByMove(std::move(task_group))));
+        return raw;
     }
 };
 
 TEST_F(HipFileBatchContext, SubmitSingleGoodOp)
 {
-    _context->submitOperations(&io_params, 1);
+    EXPECT_CALL(*mock_task_group, run(_)).Times(1);
+
+    ASSERT_NO_THROW(_context->submitOperations(&io_params, 1));
 }
 
-TEST_F(HipFileBatchContext, SubmitZeroOperations)
+TEST_F(HipFileBatchContext, SubmitSingleGoodWriteOp)
 {
-    _context->submitOperations(nullptr, 0);
+    io_params.opcode = hipFileBatchWrite;
+
+    EXPECT_CALL(*mock_task_group, run(_)).Times(1);
+
+    ASSERT_NO_THROW(_context->submitOperations(&io_params, 1));
+}
+
+TEST_F(HipFileBatchContext, SubmitMultipleGoodOps)
+{
+    std::array<hipFileIOParams_t, 2> params{io_params, io_params};
+
+    EXPECT_CALL(*mock_task_group, run(_)).Times(params.size());
+
+    ASSERT_NO_THROW(_context->submitOperations(params.data(), params.size()));
+}
+
+TEST_F(HipFileBatchContext, nullptrParamsThrows)
+{
+    ASSERT_THROW(_context->submitOperations(nullptr, 1), std::invalid_argument);
+}
+
+TEST_F(HipFileBatchContext, zeroNumParamsThrows)
+{
+    ASSERT_THROW(_context->submitOperations(&io_params, 0), std::invalid_argument);
 }
 
 TEST_F(HipFileBatchContext, SubmitOverCapacity)
 {
-    // We should fail before we ever try touching the nullptr.
-    ASSERT_THROW(_context->submitOperations(nullptr, _context_capacity + 1), std::invalid_argument);
+    EXPECT_CALL(*mock_driver_state, getFileAndBuffer).Times(0);
+    ASSERT_THROW(_context->submitOperations(&io_params, _context_capacity + 1), BatchFull);
 }
 
 TEST_F(HipFileBatchContext, SubmitOverCapacityOverMultipleSubmissions)
 {
     // Submit one at a time up to the capacity.
     // In the future we might care that we are submitting the same operation.
+    EXPECT_CALL(*mock_task_group, run(_)).Times(static_cast<int>(_context_capacity));
+
     for (unsigned i = 0; i < _context_capacity; i++) {
-        printf("i: %u\n", i);
         _context->submitOperations(&io_params, 1);
     }
 
-    ASSERT_THROW(_context->submitOperations(nullptr, 1), std::invalid_argument);
+    EXPECT_CALL(*mock_driver_state, getFileAndBuffer).Times(0);
+    ASSERT_THROW(_context->submitOperations(&io_params, 1), BatchFull);
+}
+
+TEST_F(HipFileBatchContext, SubmitBatchWithBadOpThrows)
+{
+    std::array<hipFileIOParams_t, 2> params{io_params, io_params};
+    params[1].opcode = invalidEnum<hipFileOpcode_t>(-1);
+
+    EXPECT_CALL(*mock_task_group, run(_)).Times(0);
+
+    ASSERT_THROW(_context->submitOperations(params.data(), params.size()), std::invalid_argument);
 }
 
 TEST_F(HipFileBatchContext, SubmitSingleBadBuffer)

--- a/projects/hipfile/test/amd_detail/batch/batch.cpp
+++ b/projects/hipfile/test/amd_detail/batch/batch.cpp
@@ -286,6 +286,26 @@ TEST_F(HipFileBatch, DestroyContext)
     batch_map.destroyContext(handle);
 }
 
+TEST_F(HipFileBatch, DestroyContextRemovesHandle)
+{
+    hipFileBatchHandle_t handle = batch_map.createContext(1);
+
+    batch_map.destroyContext(handle);
+
+    ASSERT_THROW(batch_map.get(handle), InvalidBatchHandle);
+}
+
+TEST_F(HipFileBatch, DestroyContextPreservesOtherContexts)
+{
+    hipFileBatchHandle_t handle1 = batch_map.createContext(1);
+    hipFileBatchHandle_t handle2 = batch_map.createContext(1);
+
+    batch_map.destroyContext(handle1);
+
+    ASSERT_THROW(batch_map.get(handle1), InvalidBatchHandle);
+    ASSERT_NE(batch_map.get(handle2), nullptr);
+}
+
 TEST_F(HipFileBatch, DestroyMissingContext)
 {
     ASSERT_THROW(batch_map.destroyContext(reinterpret_cast<hipFileBatchHandle_t>(1)), InvalidBatchHandle);
@@ -542,6 +562,7 @@ TEST_F(HipFileBatchContext, SubmittedWorkKeepsContextAliveUntilReleased)
     // enqueued_work has been assigned
     ASSERT_TRUE(enqueued_work);
 
+    expectTaskQueueFlushed();
     // Destroy the context and our shared_ptr to it
     batch_map.destroyContext(_context.get());
     _context.reset();
@@ -823,31 +844,32 @@ TEST_F(HipFileBatchContext, CancelOperationsCancelableAndTerminalOp)
                           Field(&hipFileIOEvents_t::ret, static_cast<size_t>(-hipFileInternalError)))));
 }
 
-TEST_F(HipFileBatchContext, CancelOperationsRepeatedIsIdempotent)
+TEST_F(HipFileBatchContext, DestroyContextCancelsPendingOperations)
 {
-    hipFileIOEvents_t canceled_event{nullptr, hipFileCanceled, 0};
-    auto              op = std::make_shared<StrictMock<MBatchOperation>>();
+    auto op1 = std::make_shared<StrictMock<MBatchOperation>>();
+    auto op2 = std::make_shared<StrictMock<MBatchOperation>>();
+    EXPECT_CALL(*op1, markPending()).Times(1);
+    EXPECT_CALL(*op2, markPending()).Times(1);
+    submitMockOperations({op1, op2});
+
+    EXPECT_CALL(*op1, tryCancel()).Times(1);
+    EXPECT_CALL(*op2, tryCancel()).Times(1);
+    expectTaskQueueFlushed();
+    batch_map.destroyContext(_context.get());
+}
+
+TEST_F(HipFileBatchContext, DestroyContextRemovesHandle)
+{
+    auto op = std::make_shared<StrictMock<MBatchOperation>>();
     EXPECT_CALL(*op, markPending()).Times(1);
     submitMockOperations({op});
+    hipFileBatchHandle_t handle = _context.get();
 
-    expectTaskQueueFlushed();
     EXPECT_CALL(*op, tryCancel()).Times(1);
-    ASSERT_NO_THROW(_context->cancelOperations());
     expectTaskQueueFlushed();
-    EXPECT_CALL(*op, tryCancel()).Times(1);
-    ASSERT_NO_THROW(_context->cancelOperations());
+    batch_map.destroyContext(handle);
 
-    EXPECT_CALL(*op, isTerminal()).WillRepeatedly(Return(true));
-    EXPECT_CALL(*op, event()).WillRepeatedly(Return(canceled_event));
-
-    unsigned          nr = 1;
-    hipFileIOEvents_t event{};
-    ASSERT_NO_THROW(_context->getStatus(1, &nr, &event, nullptr));
-    ASSERT_EQ(nr, 1);
-
-    nr = 1;
-    ASSERT_NO_THROW(_context->getStatus(0, &nr, &event, nullptr));
-    ASSERT_EQ(nr, 0);
+    ASSERT_THROW(batch_map.get(handle), InvalidBatchHandle);
 }
 
 TEST_F(HipFileBatchContext, SubmitSingleBadBuffer)

--- a/projects/hipfile/test/amd_detail/batch/batch.cpp
+++ b/projects/hipfile/test/amd_detail/batch/batch.cpp
@@ -10,6 +10,7 @@
 #include "hipfile-test.h"
 #include "hipfile-warnings.h"
 #include "invalid-enum.h"
+#include "mbatch.h"
 #include "mbuffer.h"
 #include "mfile.h"
 #include "mstate.h"
@@ -18,15 +19,16 @@
 
 #include "gmock/gmock.h"
 #include <array>
+#include <functional>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <memory>
 #include <stdexcept>
 #include <utility>
+#include <vector>
 
 using ::testing::_;
 using ::testing::ByMove;
-using ::testing::DoDefault;
 using ::testing::Return;
 using ::testing::StrictMock;
 using ::testing::Throw;
@@ -323,6 +325,7 @@ struct HipFileBatchContext : public HipFileUnopened {
     std::unique_ptr<StrictMock<MDriverState>> mock_driver_state;
     std::unique_ptr<StrictMock<MThreadPool>>  mock_thread_pool;
     StrictMock<MTaskGroup>                   *mock_task_group = nullptr;
+    StrictMock<MBatchOperationFactory>        mock_operation_factory;
 
     hipFileIOParams_t                    io_params{};
     std::shared_ptr<StrictMock<MBuffer>> default_mock_buffer;
@@ -361,6 +364,35 @@ struct HipFileBatchContext : public HipFileUnopened {
         EXPECT_CALL(*mock_thread_pool, makeTaskGroup()).WillOnce(Return(ByMove(std::move(task_group))));
         return raw;
     }
+
+    std::shared_ptr<StrictMock<MBatchOperation>> makeOperation()
+    {
+        auto op = std::make_shared<StrictMock<MBatchOperation>>();
+        EXPECT_CALL(*op, markPending()).Times(1);
+        return op;
+    }
+
+    void expectOperationFactoryCreates(const std::vector<std::shared_ptr<StrictMock<MBatchOperation>>> &ops)
+    {
+        auto index = std::make_shared<size_t>(0);
+        EXPECT_CALL(mock_operation_factory, create(_, _, _))
+            .Times(static_cast<int>(ops.size()))
+            .WillRepeatedly([ops, index](std::unique_ptr<const hipFileIOParams_t>, std::shared_ptr<IBuffer>,
+                                         std::shared_ptr<IFile>) -> std::shared_ptr<IBatchOperation> {
+                return ops[(*index)++];
+            });
+    }
+
+    void submitMockOperations(const std::vector<std::shared_ptr<StrictMock<MBatchOperation>>> &ops)
+    {
+        std::vector<hipFileIOParams_t> params(ops.size(), io_params);
+
+        expectOperationFactoryCreates(ops);
+        EXPECT_CALL(*mock_task_group, run(_)).Times(static_cast<int>(ops.size()));
+
+        _context->submitOperations(params.data(), static_cast<unsigned>(params.size()),
+                                   &mock_operation_factory);
+    }
 };
 
 TEST_F(HipFileBatchContext, SubmitSingleGoodOp)
@@ -396,6 +428,60 @@ TEST_F(HipFileBatchContext, nullptrParamsThrows)
 TEST_F(HipFileBatchContext, zeroNumParamsThrows)
 {
     ASSERT_THROW(_context->submitOperations(&io_params, 0), std::invalid_argument);
+}
+
+TEST_F(HipFileBatchContext, SubmitUsesProvidedOperationFactory)
+{
+    auto op = makeOperation();
+
+    EXPECT_CALL(mock_operation_factory, create(_, _, _))
+        .WillOnce([this, op](std::unique_ptr<const hipFileIOParams_t> params, std::shared_ptr<IBuffer> buffer,
+                             std::shared_ptr<IFile> file) -> std::shared_ptr<IBatchOperation> {
+            EXPECT_EQ(params->fh, io_params.fh);
+            EXPECT_EQ(params->u.batch.devPtr_base, io_params.u.batch.devPtr_base);
+            EXPECT_EQ(buffer.get(), default_mock_buffer.get());
+            EXPECT_EQ(file.get(), default_mock_file.get());
+            return op;
+        });
+    EXPECT_CALL(*mock_task_group, run(_)).Times(1);
+
+    _context->submitOperations(&io_params, 1, &mock_operation_factory);
+}
+
+TEST_F(HipFileBatchContext, SubmittedFactoryOperationRunsFromQueuedWork)
+{
+    std::function<void()> enqueued_work;
+    auto                  op = makeOperation();
+
+    expectOperationFactoryCreates({op});
+    EXPECT_CALL(*mock_task_group, run(_)).WillOnce([&enqueued_work](std::function<void()> work) {
+        enqueued_work = std::move(work);
+    });
+
+    _context->submitOperations(&io_params, 1, &mock_operation_factory);
+    ASSERT_TRUE(enqueued_work);
+
+    EXPECT_CALL(*op, run()).Times(1);
+    enqueued_work();
+}
+
+TEST_F(HipFileBatchContext, SubmitFactoryFailureFailsBatch)
+{
+    std::array<hipFileIOParams_t, 2> params{io_params, io_params};
+    auto                             op = std::make_shared<StrictMock<MBatchOperation>>();
+
+    EXPECT_CALL(mock_operation_factory, create(_, _, _))
+        .WillOnce([op](std::unique_ptr<const hipFileIOParams_t>, std::shared_ptr<IBuffer>,
+                       std::shared_ptr<IFile>) -> std::shared_ptr<IBatchOperation> { return op; })
+        .WillOnce([](std::unique_ptr<const hipFileIOParams_t>, std::shared_ptr<IBuffer>,
+                     std::shared_ptr<IFile>) -> std::shared_ptr<IBatchOperation> {
+            throw std::invalid_argument("factory error");
+        });
+    EXPECT_CALL(*mock_task_group, run(_)).Times(0);
+
+    ASSERT_THROW(_context->submitOperations(params.data(), static_cast<unsigned>(params.size()),
+                                            &mock_operation_factory),
+                 std::invalid_argument);
 }
 
 TEST_F(HipFileBatchContext, SubmitOverCapacity)

--- a/projects/hipfile/test/amd_detail/batch/batch.cpp
+++ b/projects/hipfile/test/amd_detail/batch/batch.cpp
@@ -56,11 +56,6 @@ struct HipFileBatch : public HipFileUnopened {
         io_params->mode                = hipFileBatch;
         io_params->opcode              = hipFileBatchRead;
     }
-
-    HipFileBatch()
-    {
-        batch_map.clear();
-    }
 };
 
 TEST_F(HipFileBatch, CreateOperationRead)
@@ -320,12 +315,6 @@ struct HipFileBatchContext : public HipFileUnopened {
         _context          = batch_map.get(batch_map.createContext(_context_capacity));
         // May be overridden with EXPECT_CALL in the test.
         EXPECT_CALL(*mock_driver_state, getFileAndBuffer).WillRepeatedly(Return(std::move(default_fb_pair)));
-    }
-
-    void TearDown() override
-    {
-        batch_map.destroyContext(_context.get());
-        mock_driver_state.reset();
     }
 };
 

--- a/projects/hipfile/test/amd_detail/batch/batch.cpp
+++ b/projects/hipfile/test/amd_detail/batch/batch.cpp
@@ -266,18 +266,18 @@ struct HipFileBatchContext : public HipFileUnopened {
 
 TEST_F(HipFileBatchContext, SubmitSingleGoodOp)
 {
-    _context->submit_operations(&io_params, 1);
+    _context->submitOperations(&io_params, 1);
 }
 
 TEST_F(HipFileBatchContext, SubmitZeroOperations)
 {
-    _context->submit_operations(nullptr, 0);
+    _context->submitOperations(nullptr, 0);
 }
 
 TEST_F(HipFileBatchContext, SubmitOverCapacity)
 {
     // We should fail before we ever try touching the nullptr.
-    ASSERT_THROW(_context->submit_operations(nullptr, _context_capacity + 1), std::invalid_argument);
+    ASSERT_THROW(_context->submitOperations(nullptr, _context_capacity + 1), std::invalid_argument);
 }
 
 TEST_F(HipFileBatchContext, SubmitOverCapacityOverMultipleSubmissions)
@@ -286,22 +286,22 @@ TEST_F(HipFileBatchContext, SubmitOverCapacityOverMultipleSubmissions)
     // In the future we might care that we are submitting the same operation.
     for (unsigned i = 0; i < _context_capacity; i++) {
         printf("i: %u\n", i);
-        _context->submit_operations(&io_params, 1);
+        _context->submitOperations(&io_params, 1);
     }
 
-    ASSERT_THROW(_context->submit_operations(nullptr, 1), std::invalid_argument);
+    ASSERT_THROW(_context->submitOperations(nullptr, 1), std::invalid_argument);
 }
 
 TEST_F(HipFileBatchContext, SubmitSingleBadBuffer)
 {
     EXPECT_CALL(*mock_driver_state, getFileAndBuffer).WillOnce(Throw(BufferNotRegistered()));
-    ASSERT_THROW(_context->submit_operations(&io_params, 1), BufferNotRegistered);
+    ASSERT_THROW(_context->submitOperations(&io_params, 1), BufferNotRegistered);
 }
 
 TEST_F(HipFileBatchContext, SubmitSingleBadFileHandle)
 {
     EXPECT_CALL(*mock_driver_state, getFileAndBuffer).WillOnce(Throw(FileNotRegistered()));
-    ASSERT_THROW(_context->submit_operations(&io_params, 1), FileNotRegistered);
+    ASSERT_THROW(_context->submitOperations(&io_params, 1), FileNotRegistered);
 }
 
 // BatchOperation is not mocked.
@@ -309,42 +309,42 @@ TEST_F(HipFileBatchContext, SubmitSingleBadParamBufferOffsetNegative)
 {
     hipFileIOParams_t bad_io_params     = io_params;
     bad_io_params.u.batch.devPtr_offset = -1;
-    ASSERT_THROW(_context->submit_operations(&bad_io_params, 1), std::invalid_argument);
+    ASSERT_THROW(_context->submitOperations(&bad_io_params, 1), std::invalid_argument);
 }
 
 TEST_F(HipFileBatchContext, SubmitSingleBadParamBufferOffsetTooLarge)
 {
     hipFileIOParams_t bad_io_params     = io_params;
     bad_io_params.u.batch.devPtr_offset = default_mock_buffer_length;
-    ASSERT_THROW(_context->submit_operations(&bad_io_params, 1), std::invalid_argument);
+    ASSERT_THROW(_context->submitOperations(&bad_io_params, 1), std::invalid_argument);
 }
 
 TEST_F(HipFileBatchContext, SubmitSingleBadParamIOSizeTooLarge)
 {
     hipFileIOParams_t bad_io_params = io_params;
     bad_io_params.u.batch.size      = static_cast<size_t>(default_mock_buffer_length + 1);
-    ASSERT_THROW(_context->submit_operations(&bad_io_params, 1), std::invalid_argument);
+    ASSERT_THROW(_context->submitOperations(&bad_io_params, 1), std::invalid_argument);
 }
 
 TEST_F(HipFileBatchContext, SubmitSingleBadParamFileOffsetNegative)
 {
     hipFileIOParams_t bad_io_params   = io_params;
     bad_io_params.u.batch.file_offset = -1;
-    ASSERT_THROW(_context->submit_operations(&bad_io_params, 1), std::invalid_argument);
+    ASSERT_THROW(_context->submitOperations(&bad_io_params, 1), std::invalid_argument);
 }
 
 TEST_F(HipFileBatchContext, SubmitSingleBadParamOpcodeInvalid)
 {
     hipFileIOParams_t bad_io_params = io_params;
     bad_io_params.opcode            = invalidEnum<hipFileOpcode_t>(-1);
-    ASSERT_THROW(_context->submit_operations(&bad_io_params, 1), std::invalid_argument);
+    ASSERT_THROW(_context->submitOperations(&bad_io_params, 1), std::invalid_argument);
 }
 
 TEST_F(HipFileBatchContext, SubmitSingleBadParamModeInvalid)
 {
     hipFileIOParams_t bad_io_params = io_params;
     bad_io_params.mode              = invalidEnum<hipFileBatchMode_t>(-1);
-    ASSERT_THROW(_context->submit_operations(&bad_io_params, 1), std::invalid_argument);
+    ASSERT_THROW(_context->submitOperations(&bad_io_params, 1), std::invalid_argument);
 }
 
 HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/projects/hipfile/test/amd_detail/batch/batch.cpp
+++ b/projects/hipfile/test/amd_detail/batch/batch.cpp
@@ -381,6 +381,8 @@ struct HipFileBatchContext : public HipFileUnopened {
     {
         auto op = std::make_shared<StrictMock<MBatchOperation>>();
         EXPECT_CALL(*op, markPending()).Times(1);
+        EXPECT_CALL(*op, tryCancel()).Times(testing::AnyNumber());
+        EXPECT_CALL(*op, isTerminal()).Times(testing::AnyNumber()).WillRepeatedly(Return(false));
         return op;
     }
 
@@ -718,6 +720,134 @@ TEST_F(HipFileBatchContext, GetStatusZeroTimeoutWillReturnLessThanMin)
     ASSERT_EQ(event[0].cookie, &cookie);
     ASSERT_EQ(event[0].status, hipFileComplete);
     ASSERT_EQ(event[0].ret, 4);
+}
+
+TEST_F(HipFileBatchContext, CancelOperationsEmptySucceeds)
+{
+    expectTaskQueueFlushed();
+
+    ASSERT_NO_THROW(_context->cancelOperations());
+}
+
+TEST_F(HipFileBatchContext, CancelOperationsCancelsAndWaitsForTaskGroup)
+{
+    auto op = std::make_shared<StrictMock<MBatchOperation>>();
+    EXPECT_CALL(*op, markPending()).Times(1);
+    submitMockOperations({op});
+
+    expectTaskQueueFlushed();
+    EXPECT_CALL(*op, tryCancel()).Times(1);
+
+    ASSERT_NO_THROW(_context->cancelOperations());
+}
+
+TEST_F(HipFileBatchContext, CancelOperationsCancelsPendingOperations)
+{
+    auto op1 = std::make_shared<StrictMock<MBatchOperation>>();
+    auto op2 = std::make_shared<StrictMock<MBatchOperation>>();
+    EXPECT_CALL(*op1, markPending()).Times(1);
+    EXPECT_CALL(*op2, markPending()).Times(1);
+    submitMockOperations({op1, op2});
+
+    expectTaskQueueFlushed();
+    EXPECT_CALL(*op1, tryCancel()).Times(1);
+    EXPECT_CALL(*op2, tryCancel()).Times(1);
+    ASSERT_NO_THROW(_context->cancelOperations());
+}
+
+TEST_F(HipFileBatchContext, CancelOperationsLeavesTerminalOperationsUnchanged)
+{
+    hipFileIOEvents_t complete_event{nullptr, hipFileComplete, 7};
+    hipFileIOEvents_t failed_event{nullptr, hipFileFailed, static_cast<size_t>(-hipFileInternalError)};
+    auto              complete_op = std::make_shared<StrictMock<MBatchOperation>>();
+    auto              failed_op   = std::make_shared<StrictMock<MBatchOperation>>();
+    EXPECT_CALL(*complete_op, markPending()).Times(1);
+    EXPECT_CALL(*failed_op, markPending()).Times(1);
+    submitMockOperations({complete_op, failed_op});
+
+    expectTaskQueueFlushed();
+    EXPECT_CALL(*complete_op, tryCancel()).Times(1);
+    EXPECT_CALL(*failed_op, tryCancel()).Times(1);
+    ASSERT_NO_THROW(_context->cancelOperations());
+
+    EXPECT_CALL(*complete_op, isTerminal()).WillRepeatedly(Return(true));
+    EXPECT_CALL(*complete_op, event()).WillRepeatedly(Return(complete_event));
+    EXPECT_CALL(*failed_op, isTerminal()).WillRepeatedly(Return(true));
+    EXPECT_CALL(*failed_op, event()).WillRepeatedly(Return(failed_event));
+
+    unsigned                         nr = 2;
+    std::array<hipFileIOEvents_t, 2> events{};
+    ASSERT_NO_THROW(_context->getStatus(2, &nr, events.data(), nullptr));
+    ASSERT_EQ(nr, 2);
+    ASSERT_THAT(events, UnorderedElementsAre(AllOf(Field(&hipFileIOEvents_t::status, hipFileComplete),
+                                                   Field(&hipFileIOEvents_t::ret, static_cast<size_t>(7))),
+                                             AllOf(Field(&hipFileIOEvents_t::status, hipFileFailed),
+                                                   Field(&hipFileIOEvents_t::ret,
+                                                         static_cast<size_t>(-hipFileInternalError)))));
+}
+
+TEST_F(HipFileBatchContext, CancelOperationsCancelableAndTerminalOp)
+{
+    int               pending_cookie{};
+    int               failed_cookie{};
+    hipFileIOEvents_t pending_event{&pending_cookie, hipFileCanceled, 0};
+    hipFileIOEvents_t failed_event{&failed_cookie, hipFileFailed, static_cast<size_t>(-hipFileInternalError)};
+    auto              pending_op = std::make_shared<StrictMock<MBatchOperation>>();
+    auto              failed_op  = std::make_shared<StrictMock<MBatchOperation>>();
+    EXPECT_CALL(*pending_op, markPending()).Times(1);
+    EXPECT_CALL(*failed_op, markPending()).Times(1);
+    submitMockOperations({pending_op, failed_op});
+
+    expectTaskQueueFlushed();
+    EXPECT_CALL(*pending_op, tryCancel()).Times(1);
+    EXPECT_CALL(*failed_op, tryCancel()).Times(1);
+    ASSERT_NO_THROW(_context->cancelOperations());
+
+    EXPECT_CALL(*pending_op, isTerminal()).WillRepeatedly(Return(true));
+    EXPECT_CALL(*pending_op, event()).WillRepeatedly(Return(pending_event));
+    EXPECT_CALL(*failed_op, isTerminal()).WillRepeatedly(Return(true));
+    EXPECT_CALL(*failed_op, event()).WillRepeatedly(Return(failed_event));
+
+    unsigned                         nr = 2;
+    std::array<hipFileIOEvents_t, 2> events{};
+    ASSERT_NO_THROW(_context->getStatus(2, &nr, events.data(), nullptr));
+
+    ASSERT_EQ(nr, 2);
+    std::vector<hipFileIOEvents_t> returned_events{events.begin(), events.begin() + nr};
+    ASSERT_THAT(returned_events,
+                UnorderedElementsAre(
+                    AllOf(Field(&hipFileIOEvents_t::cookie, static_cast<void *>(&pending_cookie)),
+                          Field(&hipFileIOEvents_t::status, hipFileCanceled)),
+                    AllOf(Field(&hipFileIOEvents_t::cookie, static_cast<void *>(&failed_cookie)),
+                          Field(&hipFileIOEvents_t::status, hipFileFailed),
+                          Field(&hipFileIOEvents_t::ret, static_cast<size_t>(-hipFileInternalError)))));
+}
+
+TEST_F(HipFileBatchContext, CancelOperationsRepeatedIsIdempotent)
+{
+    hipFileIOEvents_t canceled_event{nullptr, hipFileCanceled, 0};
+    auto              op = std::make_shared<StrictMock<MBatchOperation>>();
+    EXPECT_CALL(*op, markPending()).Times(1);
+    submitMockOperations({op});
+
+    expectTaskQueueFlushed();
+    EXPECT_CALL(*op, tryCancel()).Times(1);
+    ASSERT_NO_THROW(_context->cancelOperations());
+    expectTaskQueueFlushed();
+    EXPECT_CALL(*op, tryCancel()).Times(1);
+    ASSERT_NO_THROW(_context->cancelOperations());
+
+    EXPECT_CALL(*op, isTerminal()).WillRepeatedly(Return(true));
+    EXPECT_CALL(*op, event()).WillRepeatedly(Return(canceled_event));
+
+    unsigned          nr = 1;
+    hipFileIOEvents_t event{};
+    ASSERT_NO_THROW(_context->getStatus(1, &nr, &event, nullptr));
+    ASSERT_EQ(nr, 1);
+
+    nr = 1;
+    ASSERT_NO_THROW(_context->getStatus(0, &nr, &event, nullptr));
+    ASSERT_EQ(nr, 0);
 }
 
 TEST_F(HipFileBatchContext, SubmitSingleBadBuffer)

--- a/projects/hipfile/test/amd_detail/hipfile-api.cpp
+++ b/projects/hipfile/test/amd_detail/hipfile-api.cpp
@@ -96,7 +96,7 @@ TEST_F(HipFileUnit, TestHipFileBatchIOSubmitSuccess)
     std::shared_ptr<MBatchContext> mock_b_context = std::make_shared<MBatchContext>();
 
     EXPECT_CALL(mock_state, getBatchContext).WillOnce(Return(mock_b_context));
-    EXPECT_CALL(*mock_b_context, submit_operations);
+    EXPECT_CALL(*mock_b_context, submitOperations);
 
     auto result = hipFileBatchIOSubmit(b_handle, 1, &io_param, 0);
     ASSERT_EQ(result, HIPFILE_SUCCESS);
@@ -109,7 +109,7 @@ TEST_F(HipFileUnit, TestHipFileBatchIOSubmitBadHandle)
     std::shared_ptr<MBatchContext> mock_b_context = std::make_shared<MBatchContext>();
 
     EXPECT_CALL(mock_state, getBatchContext).WillOnce(Throw(InvalidBatchHandle()));
-    EXPECT_CALL(*mock_b_context, submit_operations).Times(0);
+    EXPECT_CALL(*mock_b_context, submitOperations).Times(0);
 
     auto           result          = hipFileBatchIOSubmit(b_handle, 1, &io_param, 0);
     hipFileError_t expected_result = {hipFileInvalidValue, hipSuccess};
@@ -123,7 +123,7 @@ TEST_F(HipFileUnit, TestHipFileBatchIOSubmitBadArgument)
     std::shared_ptr<MBatchContext> mock_b_context = std::make_shared<MBatchContext>();
 
     EXPECT_CALL(mock_state, getBatchContext).WillOnce(Return(mock_b_context));
-    EXPECT_CALL(*mock_b_context, submit_operations).WillOnce(Throw(std::invalid_argument("")));
+    EXPECT_CALL(*mock_b_context, submitOperations).WillOnce(Throw(std::invalid_argument("")));
 
     auto result = hipFileBatchIOSubmit(b_handle, 1, &io_param, 0);
     ASSERT_EQ(result, HIPFILE_INVALID_VALUE);

--- a/projects/hipfile/test/amd_detail/hipfile-api.cpp
+++ b/projects/hipfile/test/amd_detail/hipfile-api.cpp
@@ -96,7 +96,7 @@ TEST_F(HipFileUnit, TestHipFileBatchIOSubmitSuccess)
     std::shared_ptr<MBatchContext> mock_b_context = std::make_shared<MBatchContext>();
 
     EXPECT_CALL(mock_state, getBatchContext(b_handle)).WillOnce(Return(mock_b_context));
-    EXPECT_CALL(*mock_b_context, submitOperations(&io_param, 1));
+    EXPECT_CALL(*mock_b_context, submitOperations(&io_param, 1, nullptr));
 
     auto result = hipFileBatchIOSubmit(b_handle, 1, &io_param, 0);
     ASSERT_EQ(result, HIPFILE_SUCCESS);
@@ -109,7 +109,7 @@ TEST_F(HipFileUnit, TestHipFileBatchIOSubmitNonZeroFlagsIgnored)
     std::shared_ptr<MBatchContext> mock_b_context = std::make_shared<MBatchContext>();
 
     EXPECT_CALL(mock_state, getBatchContext(b_handle)).WillOnce(Return(mock_b_context));
-    EXPECT_CALL(*mock_b_context, submitOperations(&io_param, 1));
+    EXPECT_CALL(*mock_b_context, submitOperations(&io_param, 1, nullptr));
 
     auto result = hipFileBatchIOSubmit(b_handle, 1, &io_param, 0x1234);
     ASSERT_EQ(result, HIPFILE_SUCCESS);
@@ -122,7 +122,7 @@ TEST_F(HipFileUnit, TestHipFileBatchIOSubmitNullHandle)
     std::shared_ptr<MBatchContext> mock_b_context = std::make_shared<MBatchContext>();
 
     EXPECT_CALL(mock_state, getBatchContext(b_handle)).WillOnce(Throw(InvalidBatchHandle()));
-    EXPECT_CALL(*mock_b_context, submitOperations).Times(0);
+    EXPECT_CALL(*mock_b_context, submitOperations(_, _, _)).Times(0);
 
     auto           result          = hipFileBatchIOSubmit(b_handle, 1, &io_param, 0);
     hipFileError_t expected_result = {hipFileInvalidValue, hipSuccess};
@@ -136,7 +136,7 @@ TEST_F(HipFileUnit, TestHipFileBatchIOSubmitUnknownHandle)
     std::shared_ptr<MBatchContext> mock_b_context = std::make_shared<MBatchContext>();
 
     EXPECT_CALL(mock_state, getBatchContext(b_handle)).WillOnce(Throw(InvalidBatchHandle()));
-    EXPECT_CALL(*mock_b_context, submitOperations).Times(0);
+    EXPECT_CALL(*mock_b_context, submitOperations(_, _, _)).Times(0);
 
     auto result = hipFileBatchIOSubmit(b_handle, 1, &io_param, 0);
     ASSERT_EQ(result, HIPFILE_INVALID_VALUE);
@@ -170,7 +170,7 @@ TEST_F(HipFileUnit, TestHipFileBatchIOSubmitBatchFull)
     std::shared_ptr<MBatchContext> mock_b_context = std::make_shared<MBatchContext>();
 
     EXPECT_CALL(mock_state, getBatchContext(b_handle)).WillOnce(Return(mock_b_context));
-    EXPECT_CALL(*mock_b_context, submitOperations).WillOnce(Throw(BatchFull()));
+    EXPECT_CALL(*mock_b_context, submitOperations(_, _, _)).WillOnce(Throw(BatchFull()));
 
     auto result = hipFileBatchIOSubmit(b_handle, 1, &io_param, 0);
     ASSERT_EQ(result, HipFileOpError(hipFileBatchFull));
@@ -183,7 +183,7 @@ TEST_F(HipFileUnit, TestHipFileBatchIOSubmitBadArgument)
     std::shared_ptr<MBatchContext> mock_b_context = std::make_shared<MBatchContext>();
 
     EXPECT_CALL(mock_state, getBatchContext(b_handle)).WillOnce(Return(mock_b_context));
-    EXPECT_CALL(*mock_b_context, submitOperations).WillOnce(Throw(std::invalid_argument("")));
+    EXPECT_CALL(*mock_b_context, submitOperations(_, _, _)).WillOnce(Throw(std::invalid_argument("")));
 
     auto result = hipFileBatchIOSubmit(b_handle, 1, &io_param, 0);
     ASSERT_EQ(result, HIPFILE_INVALID_VALUE);
@@ -196,7 +196,7 @@ TEST_F(HipFileUnit, TestHipFileBatchIOSubmitUnexpectedException)
     std::shared_ptr<MBatchContext> mock_b_context = std::make_shared<MBatchContext>();
 
     EXPECT_CALL(mock_state, getBatchContext(b_handle)).WillOnce(Return(mock_b_context));
-    EXPECT_CALL(*mock_b_context, submitOperations).WillOnce(Throw(std::runtime_error("test error")));
+    EXPECT_CALL(*mock_b_context, submitOperations(_, _, _)).WillOnce(Throw(std::runtime_error("test error")));
 
     auto result = hipFileBatchIOSubmit(b_handle, 1, &io_param, 0);
     ASSERT_EQ(result, HipFileOpError(hipFileInternalError));

--- a/projects/hipfile/test/amd_detail/hipfile-api.cpp
+++ b/projects/hipfile/test/amd_detail/hipfile-api.cpp
@@ -327,6 +327,66 @@ TEST_F(HipFileUnit, TestHipFileBatchIOGetStatusUnexpectedException)
     ASSERT_EQ(result, HipFileOpError(hipFileInternalError));
 }
 
+TEST_F(HipFileUnit, TestHipFileBatchIOCancelNullHandle)
+{
+    hipFileBatchHandle_t           b_handle       = nullptr;
+    std::shared_ptr<MBatchContext> mock_b_context = std::make_shared<MBatchContext>();
+
+    EXPECT_CALL(mock_state, getBatchContext(b_handle)).WillOnce(Throw(InvalidBatchHandle()));
+    EXPECT_CALL(*mock_b_context, cancelOperations).Times(0);
+
+    auto result = hipFileBatchIOCancel(b_handle);
+    ASSERT_EQ(result, HIPFILE_INVALID_VALUE);
+}
+
+TEST_F(HipFileUnit, TestHipFileBatchIOCancelUnknownHandle)
+{
+    hipFileBatchHandle_t           b_handle       = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
+    std::shared_ptr<MBatchContext> mock_b_context = std::make_shared<MBatchContext>();
+
+    EXPECT_CALL(mock_state, getBatchContext(b_handle)).WillOnce(Throw(InvalidBatchHandle()));
+    EXPECT_CALL(*mock_b_context, cancelOperations).Times(0);
+
+    auto result = hipFileBatchIOCancel(b_handle);
+    ASSERT_EQ(result, HIPFILE_INVALID_VALUE);
+}
+
+TEST_F(HipFileUnit, TestHipFileBatchIOCancelSuccess)
+{
+    hipFileBatchHandle_t           b_handle       = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
+    std::shared_ptr<MBatchContext> mock_b_context = std::make_shared<MBatchContext>();
+
+    EXPECT_CALL(mock_state, getBatchContext(b_handle)).WillOnce(Return(mock_b_context));
+    EXPECT_CALL(*mock_b_context, cancelOperations);
+
+    auto result = hipFileBatchIOCancel(b_handle);
+    ASSERT_EQ(result, HIPFILE_SUCCESS);
+}
+
+TEST_F(HipFileUnit, TestHipFileBatchIOCancelBadArgument)
+{
+    hipFileBatchHandle_t           b_handle       = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
+    std::shared_ptr<MBatchContext> mock_b_context = std::make_shared<MBatchContext>();
+
+    EXPECT_CALL(mock_state, getBatchContext(b_handle)).WillOnce(Return(mock_b_context));
+    EXPECT_CALL(*mock_b_context, cancelOperations).WillOnce(Throw(std::invalid_argument("")));
+
+    auto result = hipFileBatchIOCancel(b_handle);
+    ASSERT_EQ(result, HIPFILE_INVALID_VALUE);
+}
+
+TEST_F(HipFileUnit, TestHipFileBatchIOCancelUnexpectedException)
+{
+    hipFileBatchHandle_t           b_handle       = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
+    std::shared_ptr<MBatchContext> mock_b_context = std::make_shared<MBatchContext>();
+
+    EXPECT_CALL(mock_state, getBatchContext(b_handle)).WillOnce(Return(mock_b_context));
+    EXPECT_CALL(*mock_b_context, cancelOperations).WillOnce(Throw(std::runtime_error("test error")));
+
+    auto result = hipFileBatchIOCancel(b_handle);
+    ASSERT_EQ(result, HipFileOpError(hipFileInternalError));
+}
+
 /// @brief Test hipFileIO function
 struct HipFileIoParam : public TestWithParam<IoType> {
     hipFileHandle_t                  file_handle{};

--- a/projects/hipfile/test/amd_detail/hipfile-api.cpp
+++ b/projects/hipfile/test/amd_detail/hipfile-api.cpp
@@ -95,25 +95,85 @@ TEST_F(HipFileUnit, TestHipFileBatchIOSubmitSuccess)
     hipFileIOParams_t              io_param;
     std::shared_ptr<MBatchContext> mock_b_context = std::make_shared<MBatchContext>();
 
-    EXPECT_CALL(mock_state, getBatchContext).WillOnce(Return(mock_b_context));
-    EXPECT_CALL(*mock_b_context, submitOperations);
+    EXPECT_CALL(mock_state, getBatchContext(b_handle)).WillOnce(Return(mock_b_context));
+    EXPECT_CALL(*mock_b_context, submitOperations(&io_param, 1));
 
     auto result = hipFileBatchIOSubmit(b_handle, 1, &io_param, 0);
     ASSERT_EQ(result, HIPFILE_SUCCESS);
 }
 
-TEST_F(HipFileUnit, TestHipFileBatchIOSubmitBadHandle)
+TEST_F(HipFileUnit, TestHipFileBatchIOSubmitNonZeroFlagsIgnored)
+{
+    hipFileBatchHandle_t           b_handle = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
+    hipFileIOParams_t              io_param;
+    std::shared_ptr<MBatchContext> mock_b_context = std::make_shared<MBatchContext>();
+
+    EXPECT_CALL(mock_state, getBatchContext(b_handle)).WillOnce(Return(mock_b_context));
+    EXPECT_CALL(*mock_b_context, submitOperations(&io_param, 1));
+
+    auto result = hipFileBatchIOSubmit(b_handle, 1, &io_param, 0x1234);
+    ASSERT_EQ(result, HIPFILE_SUCCESS);
+}
+
+TEST_F(HipFileUnit, TestHipFileBatchIOSubmitNullHandle)
 {
     hipFileBatchHandle_t           b_handle = nullptr;
     hipFileIOParams_t              io_param;
     std::shared_ptr<MBatchContext> mock_b_context = std::make_shared<MBatchContext>();
 
-    EXPECT_CALL(mock_state, getBatchContext).WillOnce(Throw(InvalidBatchHandle()));
+    EXPECT_CALL(mock_state, getBatchContext(b_handle)).WillOnce(Throw(InvalidBatchHandle()));
     EXPECT_CALL(*mock_b_context, submitOperations).Times(0);
 
     auto           result          = hipFileBatchIOSubmit(b_handle, 1, &io_param, 0);
     hipFileError_t expected_result = {hipFileInvalidValue, hipSuccess};
     ASSERT_EQ(result, expected_result);
+}
+
+TEST_F(HipFileUnit, TestHipFileBatchIOSubmitUnknownHandle)
+{
+    hipFileBatchHandle_t           b_handle = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
+    hipFileIOParams_t              io_param;
+    std::shared_ptr<MBatchContext> mock_b_context = std::make_shared<MBatchContext>();
+
+    EXPECT_CALL(mock_state, getBatchContext(b_handle)).WillOnce(Throw(InvalidBatchHandle()));
+    EXPECT_CALL(*mock_b_context, submitOperations).Times(0);
+
+    auto result = hipFileBatchIOSubmit(b_handle, 1, &io_param, 0);
+    ASSERT_EQ(result, HIPFILE_INVALID_VALUE);
+}
+
+TEST_F(HipFileUnit, TestHipFileBatchIOSubmitNullParams)
+{
+    hipFileBatchHandle_t b_handle = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
+
+    EXPECT_CALL(mock_state, getBatchContext).Times(0);
+
+    auto result = hipFileBatchIOSubmit(b_handle, 1, nullptr, 0);
+    ASSERT_EQ(result, HIPFILE_INVALID_VALUE);
+}
+
+TEST_F(HipFileUnit, TestHipFileBatchIOSubmitZeroRequests)
+{
+    hipFileBatchHandle_t b_handle = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
+    hipFileIOParams_t    io_param;
+
+    EXPECT_CALL(mock_state, getBatchContext).Times(0);
+
+    auto result = hipFileBatchIOSubmit(b_handle, 0, &io_param, 0);
+    ASSERT_EQ(result, HIPFILE_INVALID_VALUE);
+}
+
+TEST_F(HipFileUnit, TestHipFileBatchIOSubmitBatchFull)
+{
+    hipFileBatchHandle_t           b_handle = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
+    hipFileIOParams_t              io_param{};
+    std::shared_ptr<MBatchContext> mock_b_context = std::make_shared<MBatchContext>();
+
+    EXPECT_CALL(mock_state, getBatchContext(b_handle)).WillOnce(Return(mock_b_context));
+    EXPECT_CALL(*mock_b_context, submitOperations).WillOnce(Throw(BatchFull()));
+
+    auto result = hipFileBatchIOSubmit(b_handle, 1, &io_param, 0);
+    ASSERT_EQ(result, HipFileOpError(hipFileBatchFull));
 }
 
 TEST_F(HipFileUnit, TestHipFileBatchIOSubmitBadArgument)
@@ -122,11 +182,24 @@ TEST_F(HipFileUnit, TestHipFileBatchIOSubmitBadArgument)
     hipFileIOParams_t              io_param;
     std::shared_ptr<MBatchContext> mock_b_context = std::make_shared<MBatchContext>();
 
-    EXPECT_CALL(mock_state, getBatchContext).WillOnce(Return(mock_b_context));
+    EXPECT_CALL(mock_state, getBatchContext(b_handle)).WillOnce(Return(mock_b_context));
     EXPECT_CALL(*mock_b_context, submitOperations).WillOnce(Throw(std::invalid_argument("")));
 
     auto result = hipFileBatchIOSubmit(b_handle, 1, &io_param, 0);
     ASSERT_EQ(result, HIPFILE_INVALID_VALUE);
+}
+
+TEST_F(HipFileUnit, TestHipFileBatchIOSubmitUnexpectedException)
+{
+    hipFileBatchHandle_t           b_handle = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
+    hipFileIOParams_t              io_param;
+    std::shared_ptr<MBatchContext> mock_b_context = std::make_shared<MBatchContext>();
+
+    EXPECT_CALL(mock_state, getBatchContext(b_handle)).WillOnce(Return(mock_b_context));
+    EXPECT_CALL(*mock_b_context, submitOperations).WillOnce(Throw(std::runtime_error("test error")));
+
+    auto result = hipFileBatchIOSubmit(b_handle, 1, &io_param, 0);
+    ASSERT_EQ(result, HipFileOpError(hipFileInternalError));
 }
 
 /// @brief Test hipFileIO function

--- a/projects/hipfile/test/amd_detail/hipfile-api.cpp
+++ b/projects/hipfile/test/amd_detail/hipfile-api.cpp
@@ -387,6 +387,49 @@ TEST_F(HipFileUnit, TestHipFileBatchIOCancelUnexpectedException)
     ASSERT_EQ(result, HipFileOpError(hipFileInternalError));
 }
 
+TEST_F(HipFileUnit, TestHipFileBatchIODestroyNullHandle)
+{
+    EXPECT_CALL(mock_state, destroyBatchContext).Times(0);
+
+    ASSERT_NO_THROW(hipFileBatchIODestroy(nullptr));
+}
+
+TEST_F(HipFileUnit, TestHipFileBatchIODestroySuccess)
+{
+    hipFileBatchHandle_t b_handle = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
+
+    EXPECT_CALL(mock_state, destroyBatchContext(b_handle));
+
+    ASSERT_NO_THROW(hipFileBatchIODestroy(b_handle));
+}
+
+TEST_F(HipFileUnit, TestHipFileBatchIODestroyUnknownHandle)
+{
+    hipFileBatchHandle_t b_handle = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
+
+    EXPECT_CALL(mock_state, destroyBatchContext(b_handle)).WillOnce(Throw(InvalidBatchHandle()));
+
+    ASSERT_NO_THROW(hipFileBatchIODestroy(b_handle));
+}
+
+TEST_F(HipFileUnit, TestHipFileBatchIODestroyBadArgument)
+{
+    hipFileBatchHandle_t b_handle = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
+
+    EXPECT_CALL(mock_state, destroyBatchContext(b_handle)).WillOnce(Throw(std::invalid_argument("")));
+
+    ASSERT_NO_THROW(hipFileBatchIODestroy(b_handle));
+}
+
+TEST_F(HipFileUnit, TestHipFileBatchIODestroyUnexpectedException)
+{
+    hipFileBatchHandle_t b_handle = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
+
+    EXPECT_CALL(mock_state, destroyBatchContext(b_handle)).WillOnce(Throw(std::runtime_error("test error")));
+
+    ASSERT_NO_THROW(hipFileBatchIODestroy(b_handle));
+}
+
 /// @brief Test hipFileIO function
 struct HipFileIoParam : public TestWithParam<IoType> {
     hipFileHandle_t                  file_handle{};

--- a/projects/hipfile/test/amd_detail/hipfile-api.cpp
+++ b/projects/hipfile/test/amd_detail/hipfile-api.cpp
@@ -202,6 +202,131 @@ TEST_F(HipFileUnit, TestHipFileBatchIOSubmitUnexpectedException)
     ASSERT_EQ(result, HipFileOpError(hipFileInternalError));
 }
 
+TEST_F(HipFileUnit, TestHipFileBatchIOGetStatusNullHandle)
+{
+    hipFileBatchHandle_t           b_handle = nullptr;
+    unsigned                       nr       = 1;
+    hipFileIOEvents_t              event{};
+    std::shared_ptr<MBatchContext> mock_b_context = std::make_shared<MBatchContext>();
+
+    EXPECT_CALL(mock_state, getBatchContext(b_handle)).WillOnce(Throw(InvalidBatchHandle()));
+    EXPECT_CALL(*mock_b_context, getStatus).Times(0);
+
+    auto result = hipFileBatchIOGetStatus(b_handle, 1, &nr, &event, nullptr);
+    ASSERT_EQ(result, HIPFILE_INVALID_VALUE);
+}
+
+TEST_F(HipFileUnit, TestHipFileBatchIOGetStatusUnknownHandle)
+{
+    hipFileBatchHandle_t           b_handle = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
+    unsigned                       nr       = 1;
+    hipFileIOEvents_t              event{};
+    std::shared_ptr<MBatchContext> mock_b_context = std::make_shared<MBatchContext>();
+
+    EXPECT_CALL(mock_state, getBatchContext(b_handle)).WillOnce(Throw(InvalidBatchHandle()));
+    EXPECT_CALL(*mock_b_context, getStatus).Times(0);
+
+    auto result = hipFileBatchIOGetStatus(b_handle, 1, &nr, &event, nullptr);
+    ASSERT_EQ(result, HIPFILE_INVALID_VALUE);
+}
+
+TEST_F(HipFileUnit, TestHipFileBatchIOGetStatusNullNumEvents)
+{
+    hipFileBatchHandle_t b_handle = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
+    hipFileIOEvents_t    event{};
+
+    EXPECT_CALL(mock_state, getBatchContext).Times(0);
+
+    auto result = hipFileBatchIOGetStatus(b_handle, 0, nullptr, &event, nullptr);
+    ASSERT_EQ(result, HIPFILE_INVALID_VALUE);
+}
+
+TEST_F(HipFileUnit, TestHipFileBatchIOGetStatusNullEventsWithCapacity)
+{
+    hipFileBatchHandle_t b_handle = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
+    unsigned             nr       = 1;
+
+    EXPECT_CALL(mock_state, getBatchContext).Times(0);
+
+    auto result = hipFileBatchIOGetStatus(b_handle, 0, &nr, nullptr, nullptr);
+    ASSERT_EQ(result, HIPFILE_INVALID_VALUE);
+}
+
+TEST_F(HipFileUnit, TestHipFileBatchIOGetStatusZeroCapacityWithMinimum)
+{
+    hipFileBatchHandle_t b_handle = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
+    unsigned             nr       = 0;
+    hipFileIOEvents_t    event{};
+
+    EXPECT_CALL(mock_state, getBatchContext).Times(0);
+
+    auto result = hipFileBatchIOGetStatus(b_handle, 1, &nr, &event, nullptr);
+    ASSERT_EQ(result, HIPFILE_INVALID_VALUE);
+}
+
+TEST_F(HipFileUnit, TestHipFileBatchIOGetStatusMinimumExceedsCapacity)
+{
+    hipFileBatchHandle_t             b_handle = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
+    unsigned                         nr       = 1;
+    std::array<hipFileIOEvents_t, 1> events{};
+
+    EXPECT_CALL(mock_state, getBatchContext).Times(0);
+
+    auto result = hipFileBatchIOGetStatus(b_handle, 2, &nr, events.data(), nullptr);
+    ASSERT_EQ(result, HIPFILE_INVALID_VALUE);
+}
+
+TEST_F(HipFileUnit, TestHipFileBatchIOGetStatusSuccess)
+{
+    hipFileBatchHandle_t             b_handle = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
+    unsigned                         nr       = 2;
+    std::array<hipFileIOEvents_t, 2> events{};
+    struct timespec                  timeout{};
+    std::shared_ptr<MBatchContext>   mock_b_context = std::make_shared<MBatchContext>();
+
+    EXPECT_CALL(mock_state, getBatchContext(b_handle)).WillOnce(Return(mock_b_context));
+    EXPECT_CALL(*mock_b_context, getStatus(1, &nr, events.data(), &timeout))
+        .WillOnce(Invoke([](unsigned, unsigned *num_events, hipFileIOEvents_t *io_events, struct timespec *) {
+            io_events[0].status = hipFileComplete;
+            io_events[0].ret    = 7;
+            *num_events         = 1;
+        }));
+
+    auto result = hipFileBatchIOGetStatus(b_handle, 1, &nr, events.data(), &timeout);
+    ASSERT_EQ(result, HIPFILE_SUCCESS);
+    ASSERT_EQ(nr, 1);
+    ASSERT_EQ(events[0].status, hipFileComplete);
+    ASSERT_EQ(events[0].ret, 7);
+}
+
+TEST_F(HipFileUnit, TestHipFileBatchIOGetStatusBadArgument)
+{
+    hipFileBatchHandle_t           b_handle = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
+    unsigned                       nr       = 1;
+    hipFileIOEvents_t              event{};
+    std::shared_ptr<MBatchContext> mock_b_context = std::make_shared<MBatchContext>();
+
+    EXPECT_CALL(mock_state, getBatchContext(b_handle)).WillOnce(Return(mock_b_context));
+    EXPECT_CALL(*mock_b_context, getStatus).WillOnce(Throw(std::invalid_argument("")));
+
+    auto result = hipFileBatchIOGetStatus(b_handle, 1, &nr, &event, nullptr);
+    ASSERT_EQ(result, HIPFILE_INVALID_VALUE);
+}
+
+TEST_F(HipFileUnit, TestHipFileBatchIOGetStatusUnexpectedException)
+{
+    hipFileBatchHandle_t           b_handle = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
+    unsigned                       nr       = 1;
+    hipFileIOEvents_t              event{};
+    std::shared_ptr<MBatchContext> mock_b_context = std::make_shared<MBatchContext>();
+
+    EXPECT_CALL(mock_state, getBatchContext(b_handle)).WillOnce(Return(mock_b_context));
+    EXPECT_CALL(*mock_b_context, getStatus).WillOnce(Throw(std::runtime_error("test error")));
+
+    auto result = hipFileBatchIOGetStatus(b_handle, 1, &nr, &event, nullptr);
+    ASSERT_EQ(result, HipFileOpError(hipFileInternalError));
+}
+
 /// @brief Test hipFileIO function
 struct HipFileIoParam : public TestWithParam<IoType> {
     hipFileHandle_t                  file_handle{};

--- a/projects/hipfile/test/amd_detail/mbatch.h
+++ b/projects/hipfile/test/amd_detail/mbatch.h
@@ -15,10 +15,30 @@
 
 namespace hipFile {
 
+class MBatchOperation : public IBatchOperation {
+public:
+    MOCK_METHOD(void, markPending, (), (override));
+    MOCK_METHOD(void, tryCancel, (), (override));
+    MOCK_METHOD(void, run, (), (noexcept, override));
+    MOCK_METHOD(void, recordInternalError, (), (override));
+    MOCK_METHOD(hipFileIOEvents_t, event, (), (const, override));
+    MOCK_METHOD(bool, isTerminal, (), (const, override));
+};
+
+class MBatchOperationFactory : public IBatchOperationFactory {
+public:
+    MOCK_METHOD(std::shared_ptr<IBatchOperation>, create,
+                (std::unique_ptr<const hipFileIOParams_t> params, std::shared_ptr<IBuffer> buffer,
+                 std::shared_ptr<IFile> file),
+                (override));
+};
+
 class MBatchContext : public IBatchContext {
 public:
     MOCK_METHOD(unsigned, getCapacity, (), (const, noexcept, override));
-    MOCK_METHOD(void, submitOperations, (const hipFileIOParams_t *params, const unsigned num_params),
+    MOCK_METHOD(void, submitOperations,
+                (const hipFileIOParams_t *params, const unsigned num_params,
+                 IBatchOperationFactory *operation_factory),
                 (override));
 };
 

--- a/projects/hipfile/test/amd_detail/mbatch.h
+++ b/projects/hipfile/test/amd_detail/mbatch.h
@@ -40,6 +40,9 @@ public:
                 (const hipFileIOParams_t *params, const unsigned num_params,
                  IBatchOperationFactory *operation_factory),
                 (override));
+    MOCK_METHOD(void, getStatus,
+                (unsigned min_nr, unsigned *nr, hipFileIOEvents_t *iocbp, struct timespec *timeout),
+                (override));
 };
 
 }

--- a/projects/hipfile/test/amd_detail/mbatch.h
+++ b/projects/hipfile/test/amd_detail/mbatch.h
@@ -43,6 +43,7 @@ public:
     MOCK_METHOD(void, getStatus,
                 (unsigned min_nr, unsigned *nr, hipFileIOEvents_t *iocbp, struct timespec *timeout),
                 (override));
+    MOCK_METHOD(void, cancelOperations, (), (override));
 };
 
 }

--- a/projects/hipfile/test/amd_detail/mbatch.h
+++ b/projects/hipfile/test/amd_detail/mbatch.h
@@ -17,8 +17,8 @@ namespace hipFile {
 
 class MBatchContext : public IBatchContext {
 public:
-    MOCK_METHOD(unsigned, get_capacity, (), (const, noexcept, override));
-    MOCK_METHOD(void, submit_operations, (const hipFileIOParams_t *params, const unsigned num_params),
+    MOCK_METHOD(unsigned, getCapacity, (), (const, noexcept, override));
+    MOCK_METHOD(void, submitOperations, (const hipFileIOParams_t *params, const unsigned num_params),
                 (override));
 };
 

--- a/projects/hipfile/test/system/async.cpp
+++ b/projects/hipfile/test/system/async.cpp
@@ -19,13 +19,12 @@
 #include "hipfile.h"
 #include "test-common.h"
 #include "test-options.h"
+#include "util.h"
 
 #include <array>
-#include <cassert>
 #include <cstdint>
 #include <cstddef>
 #include <cstring>
-#include <fcntl.h>
 #include <gtest/gtest.h>
 #include <hip/hip_runtime_api.h>
 #include <memory>
@@ -35,11 +34,6 @@
 #include <tuple>
 #include <variant>
 #include <vector>
-#include <unistd.h>
-
-#ifdef __HIP_PLATFORM_NVIDIA__
-#include <cuda.h>
-#endif
 
 #ifdef __HIP_PLATFORM_AMD__
 using namespace hipFile;
@@ -56,180 +50,6 @@ struct AsyncIoFunction {
 static std::array<AsyncIoFunction, 2> asyncIOFns{
     {{hipFileReadAsync, "hipFileReadAsync"}, {hipFileWriteAsync, "hipFileWriteAsync"}}};
 HIPFILE_WARN_NO_EXIT_DTOR_ON
-
-struct ScopedHipStream {
-    ScopedHipStream()
-    {
-        assert(hipStreamCreateWithFlags(&stream_, hipStreamNonBlocking) == hipSuccess);
-    }
-    ~ScopedHipStream()
-    {
-        assert(hipStreamDestroy(stream_) == hipSuccess);
-    }
-    hipStream_t stream() const
-    {
-        return stream_;
-    }
-
-private:
-    hipStream_t stream_;
-};
-
-struct HipFileDataOps {
-    static bool isGpuMemory(void *mem)
-    {
-        hipPointerAttribute_t attrs;
-        hipError_t            err = hipPointerGetAttributes(&attrs, mem);
-
-#ifdef __HIP_PLATFORM_NVIDIA__
-        // NVIDIA doesn't support pointers allocated outside of runtime
-        if (err == hipErrorInvalidValue) {
-            return false;
-        }
-#endif
-        assert(err == hipSuccess);
-        return attrs.type == hipMemoryTypeDevice;
-    }
-
-    static std::vector<uint8_t> copyGpuMemory(void *gpu_mem, hoff_t gpu_mem_offset, size_t region_size)
-    {
-        std::vector<uint8_t> mem_region(region_size);
-        assert(hipMemcpyAsync(mem_region.data(),
-                              reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(gpu_mem) +
-                                                       static_cast<size_t>(gpu_mem_offset)),
-                              region_size, hipMemcpyDeviceToHost, staticHipStream()) == hipSuccess);
-        assert(hipStreamSynchronize(staticHipStream()) == hipSuccess);
-        return mem_region;
-    }
-
-    static void assertMemoryRegionsMatch(void *mem1, hoff_t mem1_offset, void *mem2, hoff_t mem2_offset,
-                                         size_t region_size)
-    {
-        std::vector<uint8_t> mem1_v;
-        std::vector<uint8_t> mem2_v;
-        assert(mem1_offset >= 0);
-        assert(mem2_offset >= 0);
-        if (isGpuMemory(mem1)) {
-            mem1_v = copyGpuMemory(mem1, mem1_offset, region_size);
-            mem1   = mem1_v.data();
-        }
-        else {
-            mem1 = reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(mem1) +
-                                            static_cast<uintptr_t>(mem1_offset));
-        }
-        if (isGpuMemory(mem2)) {
-            mem2_v = copyGpuMemory(mem2, mem2_offset, region_size);
-            mem2   = mem2_v.data();
-        }
-        else {
-            mem2 = reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(mem2) +
-                                            static_cast<uintptr_t>(mem2_offset));
-        }
-        assert(std::memcmp(mem1, mem2, region_size) == 0);
-    }
-
-    static void assertFileAndMemoryRegionsMatch(void *mem, hoff_t mem_offset, int fd, hoff_t fd_offset,
-                                                size_t region_size)
-    {
-        assert(fd_offset >= 0);
-        auto file_region = std::vector<uint8_t>(region_size);
-
-        ssize_t rv = pread(fd, file_region.data(), region_size, fd_offset);
-        assert(rv > 0 && static_cast<size_t>(rv) == region_size);
-
-        assertMemoryRegionsMatch(file_region.data(), 0, mem, mem_offset, region_size);
-    }
-
-    static void assertZeroedMemRegion(void *mem, hoff_t mem_offset, size_t region_size)
-    {
-        std::vector<uint8_t> mem_v;
-        assert(mem_offset >= 0);
-        if (isGpuMemory(mem)) {
-            mem_v = copyGpuMemory(mem, mem_offset, region_size);
-            mem   = mem_v.data();
-        }
-        else {
-            mem = reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(mem) +
-                                           static_cast<uintptr_t>(mem_offset));
-        }
-        for (size_t i = 0; i < region_size; ++i) {
-            assert(reinterpret_cast<uint8_t *>(mem)[i] == 0);
-        }
-    }
-
-    static void assertZeroedFileRegion(int fd, hoff_t fd_offset, size_t region_size)
-    {
-        assert(fd_offset >= 0);
-        auto    file_region = std::vector<uint8_t>(region_size);
-        ssize_t rv          = pread(fd, file_region.data(), region_size, fd_offset);
-        assert(rv > 0 && static_cast<size_t>(rv) == region_size);
-        for (size_t i = 0; i < region_size; ++i) {
-            assert(file_region.data()[i] == 0);
-        }
-    }
-
-    static void randomizeMemoryRegion(void *mem, hoff_t offset, size_t region_size)
-    {
-        ssize_t rv;
-        int     rand_fd = open("/dev/urandom", O_RDONLY);
-        assert(rand_fd != -1);
-        if (isGpuMemory(mem)) {
-            std::vector<uint8_t> mem_v(region_size);
-            rv = read(rand_fd, mem_v.data(), region_size);
-            assert(rv > 0 && static_cast<size_t>(rv) == region_size);
-            assert(
-                hipMemcpyAsync(
-                    reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(mem) + static_cast<size_t>(offset)),
-                    mem_v.data(), region_size, hipMemcpyHostToDevice, staticHipStream()) == hipSuccess);
-            assert(hipStreamSynchronize(staticHipStream()) == hipSuccess);
-        }
-        else {
-            rv =
-                read(rand_fd,
-                     reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(mem) + static_cast<size_t>(offset)),
-                     region_size);
-            assert(rv > 0 && static_cast<size_t>(rv) == region_size);
-        }
-        assert(close(rand_fd) == 0);
-    }
-
-    static void zeroMemoryRegion(void *mem, hoff_t offset, size_t region_size)
-    {
-        if (isGpuMemory(mem)) {
-            assert(hipMemsetAsync(reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(mem) +
-                                                           static_cast<size_t>(offset)),
-                                  0, region_size, staticHipStream()) == hipSuccess);
-            assert(hipStreamSynchronize(staticHipStream()) == hipSuccess);
-        }
-        else {
-            memset(reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(mem) + static_cast<size_t>(offset)),
-                   0, region_size);
-        }
-    }
-
-    static void zeroFileRegion(int fd, size_t size, hoff_t offset = 0)
-    {
-        auto    vec = std::vector<uint8_t>(size, 0);
-        ssize_t rv  = pwrite(fd, vec.data(), size, offset);
-        assert(rv > 0 && static_cast<size_t>(rv) == size);
-    }
-
-    static void randomizeFileRegion(int fd, size_t size, hoff_t offset = 0)
-    {
-        auto vec = std::vector<uint8_t>(size, 0);
-        randomizeMemoryRegion(vec.data(), 0, size);
-        ssize_t rv = pwrite(fd, vec.data(), size, offset);
-        assert(rv > 0 && static_cast<size_t>(rv) == size);
-    }
-
-    static hipStream_t staticHipStream()
-    {
-        HIPFILE_WARN_NO_EXIT_DTOR_OFF
-        static ScopedHipStream s;
-        HIPFILE_WARN_NO_EXIT_DTOR_ON
-        return s.stream();
-    }
-};
 
 #ifdef __HIP_PLATFORM_AMD__
 class HipAsyncMemcpyKernel : public ::testing::Test {

--- a/projects/hipfile/test/system/batch.cpp
+++ b/projects/hipfile/test/system/batch.cpp
@@ -1,0 +1,445 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "hipfile-literals.h"
+#include "hipfile-warnings.h"
+#include "hipfile.h"
+#include "test-common.h"
+#include "test-options.h"
+#include "util.h"
+
+#include <algorithm>
+#include <array>
+#include <cerrno>
+#include <csignal>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <gtest/gtest.h>
+#include <hip/hip_runtime_api.h>
+#include <sys/resource.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <vector>
+
+HIPFILE_WARN_NO_GLOBAL_CTOR_OFF
+
+extern SystemTestOptions test_env;
+
+struct BatchOpCookie {
+    size_t index;
+};
+
+struct BatchTest : public testing::Test {
+    Tmpfile         tmpfile{test_env.ais_capable_dir};
+    hipFileHandle_t file_handle{};
+    void           *device_buffer{};
+    size_t          op_size{4096};
+    unsigned        op_count{4};
+    size_t          file_size{op_size * op_count};
+
+    size_t                     device_buffer_size{file_size};
+    hipFileBatchHandle_t       batch_handle{};
+    std::vector<BatchOpCookie> cookies;
+
+    void SetUp() override
+    {
+        ASSERT_EQ(ftruncate(tmpfile.fd, static_cast<off_t>(file_size)), 0);
+
+        hipFileDescr_t descr{};
+        descr.type      = hipFileHandleTypeOpaqueFD;
+        descr.handle.fd = tmpfile.fd;
+        ASSERT_EQ(hipFileHandleRegister(&file_handle, &descr), HIPFILE_SUCCESS);
+
+        ASSERT_EQ(hipMalloc(&device_buffer, device_buffer_size), hipSuccess);
+        HipFileDataOps::zeroMemoryRegion(device_buffer, 0, device_buffer_size);
+        ASSERT_EQ(hipFileBufRegister(device_buffer, device_buffer_size, 0), HIPFILE_SUCCESS);
+
+        cookies.resize(op_count);
+        for (size_t i = 0; i < cookies.size(); ++i) {
+            cookies[i].index = i;
+        }
+    }
+
+    void TearDown() override
+    {
+        if (batch_handle != nullptr) {
+            hipFileBatchIODestroy(batch_handle);
+            batch_handle = nullptr;
+        }
+        if (device_buffer != nullptr) {
+            EXPECT_EQ(hipFileBufDeregister(device_buffer), HIPFILE_SUCCESS);
+            EXPECT_EQ(hipFree(device_buffer), hipSuccess);
+            device_buffer = nullptr;
+        }
+        if (file_handle != nullptr) {
+            hipFileHandleDeregister(file_handle);
+            file_handle = nullptr;
+        }
+        while (hipFileUseCount() > 0) {
+            EXPECT_EQ(hipFileDriverClose(), HIPFILE_SUCCESS);
+        }
+    }
+
+    void setupBatch(unsigned capacity)
+    {
+        ASSERT_EQ(hipFileBatchIOSetUp(&batch_handle, capacity), HIPFILE_SUCCESS);
+        ASSERT_NE(batch_handle, nullptr);
+    }
+
+    hipFileIOParams_t makeOp(size_t index, hipFileOpcode_t opcode)
+    {
+        hipFileIOParams_t op{};
+        op.mode                  = hipFileBatch;
+        op.u.batch.devPtr_base   = device_buffer;
+        op.u.batch.file_offset   = static_cast<int64_t>(index * op_size);
+        op.u.batch.devPtr_offset = static_cast<int64_t>(index * op_size);
+        op.u.batch.size          = op_size;
+        op.fh                    = file_handle;
+        op.opcode                = opcode;
+        op.cookie                = &cookies[index];
+        return op;
+    }
+
+    std::vector<hipFileIOEvents_t> waitForEvents(unsigned expected)
+    {
+        std::vector<hipFileIOEvents_t> events(expected);
+        unsigned                       nr = expected;
+        EXPECT_EQ(hipFileBatchIOGetStatus(batch_handle, expected, &nr, events.data(), nullptr),
+                  HIPFILE_SUCCESS);
+        events.resize(nr);
+        return events;
+    }
+
+    void expectCompleteEvents(const std::vector<hipFileIOEvents_t> &events, unsigned expected)
+    {
+        ASSERT_EQ(events.size(), expected);
+        std::vector<size_t> seen;
+        seen.reserve(events.size());
+        for (const auto &event : events) {
+            ASSERT_NE(event.cookie, nullptr);
+            const auto *cookie = static_cast<const BatchOpCookie *>(event.cookie);
+            EXPECT_LT(cookie->index, op_count);
+            seen.push_back(cookie->index);
+            EXPECT_EQ(event.status, hipFileComplete);
+            EXPECT_EQ(event.ret, op_size);
+        }
+        std::sort(seen.begin(), seen.end());
+        ASSERT_EQ(std::adjacent_find(seen.begin(), seen.end()), seen.end());
+    }
+};
+
+TEST_F(BatchTest, BatchReadSingleOperation)
+{
+    HipFileDataOps::randomizeFileRegion(tmpfile.fd, op_size);
+    HipFileDataOps::zeroMemoryRegion(device_buffer, 0, op_size);
+
+    setupBatch(1);
+    auto op = makeOp(0, hipFileBatchRead);
+    ASSERT_EQ(hipFileBatchIOSubmit(batch_handle, 1, &op, 0), HIPFILE_SUCCESS);
+
+    const auto events = waitForEvents(1);
+    expectCompleteEvents(events, 1);
+
+    HipFileDataOps::assertFileAndMemoryRegionsMatch(device_buffer, 0, tmpfile.fd, 0, op_size);
+}
+
+TEST_F(BatchTest, BatchReadMultipleOperations)
+{
+    HipFileDataOps::randomizeFileRegion(tmpfile.fd, file_size);
+    HipFileDataOps::zeroMemoryRegion(device_buffer, 0, device_buffer_size);
+
+    setupBatch(op_count);
+    std::vector<hipFileIOParams_t> ops(op_count);
+    for (size_t i = 0; i < ops.size(); ++i) {
+        ops[i] = makeOp(i, hipFileBatchRead);
+    }
+    ASSERT_EQ(hipFileBatchIOSubmit(batch_handle, static_cast<unsigned>(ops.size()), ops.data(), 0),
+              HIPFILE_SUCCESS);
+
+    const auto events = waitForEvents(static_cast<unsigned>(ops.size()));
+    expectCompleteEvents(events, static_cast<unsigned>(ops.size()));
+
+    HipFileDataOps::assertFileAndMemoryRegionsMatch(device_buffer, 0, tmpfile.fd, 0, file_size);
+}
+
+TEST_F(BatchTest, GetStatusWithTimeoutReturnsSubmittedBatchOperations)
+{
+    HipFileDataOps::randomizeFileRegion(tmpfile.fd, file_size);
+    HipFileDataOps::zeroMemoryRegion(device_buffer, 0, device_buffer_size);
+
+    setupBatch(op_count);
+    std::vector<hipFileIOParams_t> ops(op_count);
+    for (size_t i = 0; i < ops.size(); ++i) {
+        ops[i] = makeOp(i, hipFileBatchRead);
+    }
+    ASSERT_EQ(hipFileBatchIOSubmit(batch_handle, static_cast<unsigned>(ops.size()), ops.data(), 0),
+              HIPFILE_SUCCESS);
+
+    std::vector<hipFileIOEvents_t> events(op_count);
+    unsigned                       nr = static_cast<unsigned>(events.size());
+    struct timespec                timeout{10, 0};
+    ASSERT_EQ(hipFileBatchIOGetStatus(batch_handle, static_cast<unsigned>(ops.size()), &nr, events.data(),
+                                      &timeout),
+              HIPFILE_SUCCESS);
+    events.resize(nr);
+
+    expectCompleteEvents(events, static_cast<unsigned>(ops.size()));
+    HipFileDataOps::assertFileAndMemoryRegionsMatch(device_buffer, 0, tmpfile.fd, 0, file_size);
+}
+
+TEST_F(BatchTest, BatchReadCanSubmitAfterCancel)
+{
+    const auto half_size         = file_size / 2;
+    const auto second_half_index = op_count / 2;
+
+    HipFileDataOps::randomizeFileRegion(tmpfile.fd, file_size);
+    HipFileDataOps::zeroMemoryRegion(device_buffer, 0, device_buffer_size);
+
+    setupBatch(1);
+
+    auto first_half         = makeOp(0, hipFileBatchRead);
+    first_half.u.batch.size = half_size;
+    ASSERT_EQ(hipFileBatchIOSubmit(batch_handle, 1, &first_half, 0), HIPFILE_SUCCESS);
+
+    auto events = waitForEvents(1);
+    ASSERT_EQ(events.size(), 1);
+    EXPECT_EQ(events[0].cookie, &cookies[0]);
+    EXPECT_EQ(events[0].status, hipFileComplete);
+    EXPECT_EQ(events[0].ret, half_size);
+    HipFileDataOps::assertFileAndMemoryRegionsMatch(device_buffer, 0, tmpfile.fd, 0, half_size);
+
+    ASSERT_EQ(hipFileBatchIOCancel(batch_handle), HIPFILE_SUCCESS);
+
+    auto second_half         = makeOp(second_half_index, hipFileBatchRead);
+    second_half.u.batch.size = half_size;
+    ASSERT_EQ(hipFileBatchIOSubmit(batch_handle, 1, &second_half, 0), HIPFILE_SUCCESS);
+
+    events = waitForEvents(1);
+    ASSERT_EQ(events.size(), 1);
+    EXPECT_EQ(events[0].cookie, &cookies[second_half_index]);
+    EXPECT_EQ(events[0].status, hipFileComplete);
+    EXPECT_EQ(events[0].ret, half_size);
+    HipFileDataOps::assertFileAndMemoryRegionsMatch(device_buffer, static_cast<hoff_t>(half_size), tmpfile.fd,
+                                                    static_cast<hoff_t>(half_size), half_size);
+}
+
+TEST_F(BatchTest, BatchWriteSingleOperation)
+{
+    HipFileDataOps::randomizeMemoryRegion(device_buffer, 0, op_size);
+    HipFileDataOps::zeroFileRegion(tmpfile.fd, op_size);
+
+    setupBatch(1);
+    auto op = makeOp(0, hipFileBatchWrite);
+    ASSERT_EQ(hipFileBatchIOSubmit(batch_handle, 1, &op, 0), HIPFILE_SUCCESS);
+
+    const auto events = waitForEvents(1);
+    expectCompleteEvents(events, 1);
+    HipFileDataOps::assertFileAndMemoryRegionsMatch(device_buffer, 0, tmpfile.fd, 0, op_size);
+}
+
+TEST_F(BatchTest, BatchWriteMultipleOperations)
+{
+    HipFileDataOps::randomizeMemoryRegion(device_buffer, 0, device_buffer_size);
+    HipFileDataOps::zeroFileRegion(tmpfile.fd, file_size);
+
+    setupBatch(op_count);
+    std::vector<hipFileIOParams_t> ops(op_count);
+    for (size_t i = 0; i < ops.size(); ++i) {
+        ops[i] = makeOp(i, hipFileBatchWrite);
+    }
+    ASSERT_EQ(hipFileBatchIOSubmit(batch_handle, static_cast<unsigned>(ops.size()), ops.data(), 0),
+              HIPFILE_SUCCESS);
+
+    const auto events = waitForEvents(static_cast<unsigned>(ops.size()));
+    expectCompleteEvents(events, static_cast<unsigned>(ops.size()));
+    HipFileDataOps::assertFileAndMemoryRegionsMatch(device_buffer, 0, tmpfile.fd, 0, file_size);
+}
+
+TEST_F(BatchTest, GetStatusWithSmallEventBufferReturnsRemainingEventsLater)
+{
+    HipFileDataOps::randomizeFileRegion(tmpfile.fd, file_size);
+
+    setupBatch(op_count);
+    std::vector<hipFileIOParams_t> ops(op_count);
+    for (size_t i = 0; i < ops.size(); ++i) {
+        ops[i] = makeOp(i, hipFileBatchRead);
+    }
+    ASSERT_EQ(hipFileBatchIOSubmit(batch_handle, static_cast<unsigned>(ops.size()), ops.data(), 0),
+              HIPFILE_SUCCESS);
+
+    std::vector<hipFileIOEvents_t> all_events;
+    while (all_events.size() < op_count) {
+        std::array<hipFileIOEvents_t, 2> events{};
+        unsigned                         nr = events.size();
+        ASSERT_EQ(hipFileBatchIOGetStatus(batch_handle, 1, &nr, events.data(), nullptr), HIPFILE_SUCCESS);
+        ASSERT_GT(nr, 0);
+        ASSERT_LE(nr, events.size());
+        all_events.insert(all_events.end(), events.begin(), events.begin() + nr);
+    }
+    expectCompleteEvents(all_events, op_count);
+}
+
+TEST_F(BatchTest, GetStatusNoOutstandingReturnsZero)
+{
+    setupBatch(1);
+    hipFileIOEvents_t event{};
+    unsigned          nr = 1;
+    struct timespec   timeout{1, 0};
+
+    ASSERT_EQ(hipFileBatchIOGetStatus(batch_handle, 1, &nr, &event, &timeout), HIPFILE_SUCCESS);
+    ASSERT_EQ(nr, 0);
+}
+
+TEST_F(BatchTest, CancelEmptyBatchSucceeds)
+{
+    setupBatch(1);
+    ASSERT_EQ(hipFileBatchIOCancel(batch_handle), HIPFILE_SUCCESS);
+
+    hipFileIOEvents_t event{};
+    unsigned          nr = 1;
+    ASSERT_EQ(hipFileBatchIOGetStatus(batch_handle, 0, &nr, &event, nullptr), HIPFILE_SUCCESS);
+    ASSERT_EQ(nr, 0);
+}
+
+TEST_F(BatchTest, DestroyEmptyBatchDoesNotCrash)
+{
+    setupBatch(1);
+    hipFileBatchIODestroy(batch_handle);
+    batch_handle = nullptr;
+
+    hipFileBatchIODestroy(batch_handle);
+}
+
+TEST_F(BatchTest, SubmitRejectsInvalidArguments)
+{
+    setupBatch(1);
+    auto                             op = makeOp(0, hipFileBatchRead);
+    std::array<hipFileIOParams_t, 2> ops{op, makeOp(1, hipFileBatchRead)};
+
+#if defined(__HIP_PLATFORM_NVIDIA__)
+    constexpr auto invalid_submit_arg_error      = HipFileOpError(hipFileInternalError);
+    constexpr auto invalid_submit_capacity_error = HipFileOpError(hipFileInternalError);
+#else
+    constexpr auto invalid_submit_arg_error      = HipFileOpError(hipFileInvalidValue);
+    constexpr auto invalid_submit_capacity_error = HipFileOpError(hipFileBatchFull);
+#endif
+    ASSERT_EQ(hipFileBatchIOSubmit(batch_handle, 0, &op, 0), invalid_submit_arg_error);
+    ASSERT_EQ(hipFileBatchIOSubmit(batch_handle, 1, nullptr, 0), invalid_submit_arg_error);
+    ASSERT_EQ(hipFileBatchIOSubmit(batch_handle, ops.size(), ops.data(), 0), invalid_submit_capacity_error);
+}
+
+TEST_F(BatchTest, GetStatusRejectsInvalidArguments)
+{
+    setupBatch(1);
+    hipFileIOEvents_t event{};
+    unsigned          nr = 1;
+
+#if defined(__HIP_PLATFORM_NVIDIA__)
+    constexpr auto invalid_status_arg_error = HipFileOpError(hipFileInternalError);
+#else
+    constexpr auto invalid_status_arg_error = HipFileOpError(hipFileInvalidValue);
+#endif
+    ASSERT_EQ(hipFileBatchIOGetStatus(batch_handle, 0, nullptr, &event, nullptr), invalid_status_arg_error);
+    ASSERT_EQ(hipFileBatchIOGetStatus(batch_handle, 0, &nr, nullptr, nullptr), invalid_status_arg_error);
+    ASSERT_EQ(hipFileBatchIOGetStatus(batch_handle, 2, &nr, &event, nullptr), invalid_status_arg_error);
+    nr = 0;
+    ASSERT_EQ(hipFileBatchIOGetStatus(batch_handle, 0, &nr, &event, nullptr), invalid_status_arg_error);
+}
+
+struct BatchWriteFailureTest : public BatchTest {
+    void SetUp() override
+    {
+        file_size          = 1_MiB;
+        device_buffer_size = 1_MiB;
+#if defined(__HIP_PLATFORM_NVIDIA__)
+        // This fixture has a test that constrains process file writes. Keep cuFile logging out
+        // of that limit so only the target I/O sees the failure.
+        ASSERT_EQ(setenv("CUFILE_LOGFILE_PATH", "/dev/null", 1), 0);
+#endif
+        BatchTest::SetUp();
+    }
+};
+
+struct ScopedSignalAction {
+    int ignore(int signal_number_)
+    {
+        signal_number = signal_number_;
+        old_handler   = std::signal(signal_number, SIG_IGN);
+        active        = old_handler != SIG_ERR;
+        return active ? 0 : -1;
+    }
+
+    ~ScopedSignalAction()
+    {
+        if (active) {
+            (void)std::signal(signal_number, old_handler);
+        }
+    }
+
+    using SignalHandler = void (*)(int);
+
+    int           signal_number{};
+    SignalHandler old_handler{SIG_DFL};
+    bool          active{};
+};
+
+struct ScopedFileSizeLimit {
+    int limit(rlim_t soft_limit)
+    {
+        if (getrlimit(RLIMIT_FSIZE, &old_limit) != 0) {
+            return -1;
+        }
+
+        struct rlimit new_limit = old_limit;
+        new_limit.rlim_cur      = soft_limit;
+        const int status        = setrlimit(RLIMIT_FSIZE, &new_limit);
+        active                  = status == 0;
+        return status;
+    }
+
+    ~ScopedFileSizeLimit()
+    {
+        if (active) {
+            (void)setrlimit(RLIMIT_FSIZE, &old_limit);
+        }
+    }
+
+    struct rlimit old_limit{};
+    bool          active{};
+};
+
+TEST_F(BatchWriteFailureTest, FailedBatchWriteReportsErrorInEventRet)
+{
+    ScopedSignalAction xfsz;
+    ASSERT_EQ(xfsz.ignore(SIGXFSZ), 0);
+
+    ScopedFileSizeLimit file_size_limit;
+    ASSERT_EQ(file_size_limit.limit(static_cast<rlim_t>(file_size)), 0);
+
+    setupBatch(1);
+    auto op                = makeOp(0, hipFileBatchWrite);
+    op.u.batch.size        = op_size;
+    op.u.batch.file_offset = static_cast<hoff_t>(file_size - 1);
+
+    ASSERT_EQ(hipFileBatchIOSubmit(batch_handle, 1, &op, 0), HIPFILE_SUCCESS);
+
+    const auto events = waitForEvents(1);
+    ASSERT_EQ(events.size(), 1);
+
+    const auto &event = events[0];
+    ASSERT_EQ(event.cookie, &cookies[0]);
+    EXPECT_EQ(event.status, hipFileFailed);
+
+#if defined(__HIP_PLATFORM_NVIDIA__)
+    const auto expected_ret = -static_cast<ssize_t>(EIO);
+#else
+    const auto expected_ret = -static_cast<ssize_t>(EFBIG);
+#endif
+    EXPECT_EQ(static_cast<ssize_t>(event.ret), expected_ret);
+    EXPECT_EQ(event.ret, static_cast<size_t>(expected_ret));
+}
+
+HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/projects/hipfile/test/system/driver.cpp
+++ b/projects/hipfile/test/system/driver.cpp
@@ -245,8 +245,8 @@ TEST_F(DriverNoInit, hipFileBatchIOGetStatus)
 
 TEST_F(DriverNoInit, hipFileBatchIOCancelNullArgs)
 {
-#ifdef __HIP_PLATFORM_AMD__ // Not implemented on AMD
-    ASSERT_EQ(hipFileBatchIOCancel(nullptr), HipFileOpError(hipFileInternalError));
+#ifdef __HIP_PLATFORM_AMD__
+    ASSERT_EQ(hipFileBatchIOCancel(nullptr), HipFileOpError(hipFileInvalidValue));
 #else
     ASSERT_EQ(hipFileBatchIOCancel(nullptr), HIPFILE_SUCCESS);
 #endif
@@ -256,8 +256,8 @@ TEST_F(DriverNoInit, hipFileBatchIOCancel)
 {
     hipFileBatchHandle_t handle{};
 
-#ifdef __HIP_PLATFORM_AMD__ // Not implemented on AMD
-    ASSERT_EQ(hipFileBatchIOCancel(handle), HipFileOpError(hipFileInternalError));
+#ifdef __HIP_PLATFORM_AMD__
+    ASSERT_EQ(hipFileBatchIOCancel(handle), HipFileOpError(hipFileInvalidValue));
 #else
     ASSERT_EQ(hipFileBatchIOCancel(handle), HIPFILE_SUCCESS); // Weird
 #endif

--- a/projects/hipfile/test/system/driver.cpp
+++ b/projects/hipfile/test/system/driver.cpp
@@ -218,8 +218,13 @@ TEST_F(DriverNoInit, hipFileBatchIOSubmit)
 
 TEST_F(DriverNoInit, hipFileBatchIOGetStatusNullArgs)
 {
+#ifdef __HIP_PLATFORM_AMD__
+    ASSERT_EQ(hipFileBatchIOGetStatus(nullptr, 0, nullptr, nullptr, nullptr),
+              HipFileOpError(hipFileInvalidValue));
+#else
     ASSERT_EQ(hipFileBatchIOGetStatus(nullptr, 0, nullptr, nullptr, nullptr),
               HipFileOpError(hipFileInternalError));
+#endif
 }
 
 TEST_F(DriverNoInit, hipFileBatchIOGetStatus)
@@ -231,7 +236,11 @@ TEST_F(DriverNoInit, hipFileBatchIOGetStatus)
         0, 0
     };
 
+#ifdef __HIP_PLATFORM_AMD__
+    ASSERT_EQ(hipFileBatchIOGetStatus(handle, 0, &nr, &event, &ts), HipFileOpError(hipFileInvalidValue));
+#else
     ASSERT_EQ(hipFileBatchIOGetStatus(handle, 0, &nr, &event, &ts), HipFileOpError(hipFileInternalError));
+#endif
 }
 
 TEST_F(DriverNoInit, hipFileBatchIOCancelNullArgs)

--- a/projects/hipfile/test/system/driver.cpp
+++ b/projects/hipfile/test/system/driver.cpp
@@ -163,6 +163,28 @@ TEST_F(DriverInit, hipFileDriverCloseDeregisteresHandle)
     ASSERT_EQ(hipFileHandleRegister(&handle, &descr), HIPFILE_SUCCESS);
 }
 
+TEST_F(DriverInit, hipFileDriverCloseClearsBatchContexts)
+{
+    hipFileBatchHandle_t handle{};
+
+    ASSERT_EQ(hipFileDriverOpen(), HIPFILE_SUCCESS);
+    ASSERT_EQ(hipFileUseCount(), 1);
+    ASSERT_EQ(hipFileBatchIOSetUp(&handle, 1), HIPFILE_SUCCESS);
+    ASSERT_NE(handle, nullptr);
+
+    ASSERT_EQ(hipFileDriverClose(), HIPFILE_SUCCESS);
+    ASSERT_EQ(hipFileUseCount(), 0);
+
+    hipFileIOEvents_t event{};
+    unsigned          nr{1};
+#ifdef __HIP_PLATFORM_NVIDIA__
+    auto constexpr expected_error = hipFileInternalError;
+#else
+    auto constexpr expected_error = hipFileInvalidValue;
+#endif
+    ASSERT_EQ(hipFileBatchIOGetStatus(handle, 0, &nr, &event, nullptr), HipFileOpError(expected_error));
+}
+
 TEST_F(DriverInit, hipFileReadAsync)
 {
     ASSERT_EQ(hipFileReadAsync(nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr),
@@ -232,9 +254,7 @@ TEST_F(DriverNoInit, hipFileBatchIOGetStatus)
     hipFileBatchHandle_t handle{};
     hipFileIOEvents_t    event{};
     unsigned             nr{1};
-    struct timespec      ts {
-        0, 0
-    };
+    struct timespec      ts{0, 0};
 
 #ifdef __HIP_PLATFORM_AMD__
     ASSERT_EQ(hipFileBatchIOGetStatus(handle, 0, &nr, &event, &ts), HipFileOpError(hipFileInvalidValue));

--- a/projects/hipfile/test/system/util.cpp
+++ b/projects/hipfile/test/system/util.cpp
@@ -1,0 +1,202 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "hipfile-warnings.h"
+#include "util.h"
+
+#include <cassert>
+#include <cstdint>
+#include <cstring>
+#include <fcntl.h>
+#include <hip/hip_runtime_api.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <vector>
+
+#ifdef __HIP_PLATFORM_NVIDIA__
+#include <cuda.h>
+#endif
+
+namespace {
+struct ScopedHipStream {
+    ScopedHipStream()
+    {
+        assert(hipStreamCreateWithFlags(&stream_, hipStreamNonBlocking) == hipSuccess);
+    }
+    ~ScopedHipStream()
+    {
+        assert(hipStreamDestroy(stream_) == hipSuccess);
+    }
+    hipStream_t stream() const
+    {
+        return stream_;
+    }
+
+private:
+    hipStream_t stream_;
+};
+
+hipStream_t
+staticHipStream()
+{
+    HIPFILE_WARN_NO_EXIT_DTOR_OFF
+    static ScopedHipStream s;
+    HIPFILE_WARN_NO_EXIT_DTOR_ON
+    return s.stream();
+}
+
+bool
+isGpuMemory(void *mem)
+{
+    hipPointerAttribute_t attrs;
+    hipError_t            err = hipPointerGetAttributes(&attrs, mem);
+
+#ifdef __HIP_PLATFORM_NVIDIA__
+    // NVIDIA doesn't support pointers allocated outside of runtime
+    if (err == hipErrorInvalidValue) {
+        return false;
+    }
+#endif
+    assert(err == hipSuccess);
+    return attrs.type == hipMemoryTypeDevice;
+}
+
+std::vector<uint8_t>
+copyGpuMemory(void *gpu_mem, hoff_t gpu_mem_offset, size_t region_size)
+{
+    std::vector<uint8_t> mem_region(region_size);
+    assert(hipMemcpyAsync(mem_region.data(),
+                          reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(gpu_mem) +
+                                                   static_cast<size_t>(gpu_mem_offset)),
+                          region_size, hipMemcpyDeviceToHost, staticHipStream()) == hipSuccess);
+    assert(hipStreamSynchronize(staticHipStream()) == hipSuccess);
+    return mem_region;
+}
+} // namespace
+
+void
+HipFileDataOps::assertMemoryRegionsMatch(void *mem1, hoff_t mem1_offset, void *mem2, hoff_t mem2_offset,
+                                         size_t region_size)
+{
+    std::vector<uint8_t> mem1_v;
+    std::vector<uint8_t> mem2_v;
+    assert(mem1_offset >= 0);
+    assert(mem2_offset >= 0);
+    if (isGpuMemory(mem1)) {
+        mem1_v = copyGpuMemory(mem1, mem1_offset, region_size);
+        mem1   = mem1_v.data();
+    }
+    else {
+        mem1 =
+            reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(mem1) + static_cast<uintptr_t>(mem1_offset));
+    }
+    if (isGpuMemory(mem2)) {
+        mem2_v = copyGpuMemory(mem2, mem2_offset, region_size);
+        mem2   = mem2_v.data();
+    }
+    else {
+        mem2 =
+            reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(mem2) + static_cast<uintptr_t>(mem2_offset));
+    }
+    assert(std::memcmp(mem1, mem2, region_size) == 0);
+}
+
+void
+HipFileDataOps::assertFileAndMemoryRegionsMatch(void *mem, hoff_t mem_offset, int fd, hoff_t fd_offset,
+                                                size_t region_size)
+{
+    assert(fd_offset >= 0);
+    auto file_region = std::vector<uint8_t>(region_size);
+
+    ssize_t rv = pread(fd, file_region.data(), region_size, fd_offset);
+    assert(rv > 0 && static_cast<size_t>(rv) == region_size);
+
+    assertMemoryRegionsMatch(file_region.data(), 0, mem, mem_offset, region_size);
+}
+
+void
+HipFileDataOps::assertZeroedMemRegion(void *mem, hoff_t mem_offset, size_t region_size)
+{
+    std::vector<uint8_t> mem_v;
+    assert(mem_offset >= 0);
+    if (isGpuMemory(mem)) {
+        mem_v = copyGpuMemory(mem, mem_offset, region_size);
+        mem   = mem_v.data();
+    }
+    else {
+        mem = reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(mem) + static_cast<uintptr_t>(mem_offset));
+    }
+    for (size_t i = 0; i < region_size; ++i) {
+        assert(reinterpret_cast<uint8_t *>(mem)[i] == 0);
+    }
+}
+
+void
+HipFileDataOps::assertZeroedFileRegion(int fd, hoff_t fd_offset, size_t region_size)
+{
+    assert(fd_offset >= 0);
+    auto    file_region = std::vector<uint8_t>(region_size);
+    ssize_t rv          = pread(fd, file_region.data(), region_size, fd_offset);
+    assert(rv > 0 && static_cast<size_t>(rv) == region_size);
+    for (size_t i = 0; i < region_size; ++i) {
+        assert(file_region.data()[i] == 0);
+    }
+}
+
+void
+HipFileDataOps::randomizeMemoryRegion(void *mem, hoff_t offset, size_t region_size)
+{
+    ssize_t rv;
+    int     rand_fd = open("/dev/urandom", O_RDONLY);
+    assert(rand_fd != -1);
+    if (isGpuMemory(mem)) {
+        std::vector<uint8_t> mem_v(region_size);
+        rv = read(rand_fd, mem_v.data(), region_size);
+        assert(rv > 0 && static_cast<size_t>(rv) == region_size);
+        assert(hipMemcpyAsync(
+                   reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(mem) + static_cast<size_t>(offset)),
+                   mem_v.data(), region_size, hipMemcpyHostToDevice, staticHipStream()) == hipSuccess);
+        assert(hipStreamSynchronize(staticHipStream()) == hipSuccess);
+    }
+    else {
+        rv = read(rand_fd,
+                  reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(mem) + static_cast<size_t>(offset)),
+                  region_size);
+        assert(rv > 0 && static_cast<size_t>(rv) == region_size);
+    }
+    assert(close(rand_fd) == 0);
+}
+
+void
+HipFileDataOps::zeroMemoryRegion(void *mem, hoff_t offset, size_t region_size)
+{
+    if (isGpuMemory(mem)) {
+        assert(hipMemsetAsync(
+                   reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(mem) + static_cast<size_t>(offset)),
+                   0, region_size, staticHipStream()) == hipSuccess);
+        assert(hipStreamSynchronize(staticHipStream()) == hipSuccess);
+    }
+    else {
+        memset(reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(mem) + static_cast<size_t>(offset)), 0,
+               region_size);
+    }
+}
+
+void
+HipFileDataOps::zeroFileRegion(int fd, size_t size, hoff_t offset)
+{
+    auto    vec = std::vector<uint8_t>(size, 0);
+    ssize_t rv  = pwrite(fd, vec.data(), size, offset);
+    assert(rv > 0 && static_cast<size_t>(rv) == size);
+}
+
+void
+HipFileDataOps::randomizeFileRegion(int fd, size_t size, hoff_t offset)
+{
+    auto vec = std::vector<uint8_t>(size, 0);
+    randomizeMemoryRegion(vec.data(), 0, size);
+    ssize_t rv = pwrite(fd, vec.data(), size, offset);
+    assert(rv > 0 && static_cast<size_t>(rv) == size);
+}

--- a/projects/hipfile/test/system/util.h
+++ b/projects/hipfile/test/system/util.h
@@ -1,0 +1,23 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include "hipfile.h"
+
+#include <cstddef>
+
+struct HipFileDataOps {
+    static void assertMemoryRegionsMatch(void *mem1, hoff_t mem1_offset, void *mem2, hoff_t mem2_offset,
+                                         size_t region_size);
+    static void assertFileAndMemoryRegionsMatch(void *mem, hoff_t mem_offset, int fd, hoff_t fd_offset,
+                                                size_t region_size);
+    static void assertZeroedMemRegion(void *mem, hoff_t mem_offset, size_t region_size);
+    static void assertZeroedFileRegion(int fd, hoff_t fd_offset, size_t region_size);
+    static void randomizeMemoryRegion(void *mem, hoff_t offset, size_t region_size);
+    static void zeroMemoryRegion(void *mem, hoff_t offset, size_t region_size);
+    static void zeroFileRegion(int fd, size_t size, hoff_t offset = 0);
+    static void randomizeFileRegion(int fd, size_t size, hoff_t offset = 0);
+};


### PR DESCRIPTION
## Motivation

Adds the rest of the batch implementation.  For the public API, this is:

- hipFileBatchIOSubmit
- hipFileBatchIOGetStatus
- hipFileBatchIOCancel
- hipFileBatchIODestroy

## Technical Details

- Adds a state machine for BatchOperation state
- Ops submitted with hipFileIOSubmit are verified run on the BatchContext's task_group
- Mocking of batch operations is added and can be used with the new factory argument on BatchContext::submitOperations to mock submitted operations
- BatchContext::submitOperations waits on a condition_variable for terminal operations, and is notified as they complete
- BatchContext::cancelOperations trys to set the cancel state on each operation, then notifies waiters on the condition variable
- BatchContextMap::destroyContext removes the context from the map, then cancels and waits for any in-progress operations to complete

## JIRA ID

AIHIPFILE-65

## Test Plan

Unit tests and system tests are added.

## Test Result

Tests run successfully.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
