### PR TITLE
fix(rocr): Fix out-of-bounds read in ElfSize() for ELF objects

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_elf_image.hpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_elf_image.hpp
@@ -223,7 +223,7 @@ namespace elf {
     Image* NewElf32Image();
     Image* NewElf64Image();
 
-    uint64_t ElfSize(const void* buffer);
+    uint64_t ElfSize(const void* buffer, size_t buffer_size);
 
     std::string GetNoteString(uint32_t s_size, const char* s);
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_hsa_loader.hpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_hsa_loader.hpp
@@ -145,6 +145,8 @@ struct CodeObjectReaderImpl final {
   const void *GetCodeObjectMemory() const { return code_object_memory; };
   size_t GetCodeObjectSize() const { return code_object_size; };
 
+  size_t GetCodeObjectSize() const { return code_object_size; }
+
   std::string GetUri() const { return uri; };
 
  private:

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_hsa_loader.hpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_hsa_loader.hpp
@@ -143,8 +143,6 @@ struct CodeObjectReaderImpl final {
       size_t _code_object_size);
 
   const void *GetCodeObjectMemory() const { return code_object_memory; };
-  size_t GetCodeObjectSize() const { return code_object_size; };
-
   size_t GetCodeObjectSize() const { return code_object_size; }
 
   std::string GetUri() const { return uri; };

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa.cpp
@@ -2300,9 +2300,14 @@ hsa_status_t hsa_executable_load_code_object(
     return HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
   }
   CodeObjectReaderImpl reader;
-  reader.SetMemory(code_object_p, amd::elf::ElfSize(code_object_p));
+  size_t code_object_size = amd::elf::ElfSize(code_object_p, 0);
+  if (code_object_size == 0) {
+    return HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
+  }
+  reader.SetMemory(code_object_p, code_object_size);
 
-  return exec->LoadCodeObject(agent, code_object, options, reader.GetUri());
+  return exec->LoadCodeObject(agent, code_object, code_object_size, options,
+                              reader.GetUri());
   CATCH;
 }
 
@@ -2328,7 +2333,8 @@ hsa_status_t hsa_executable_load_program_code_object(
   hsa_code_object_t code_object =
       {reinterpret_cast<uint64_t>(reader->GetCodeObjectMemory())};
   return exec->LoadCodeObject(
-      {0}, code_object, options, reader->GetUri(), loaded_code_object);
+      {0}, code_object, reader->GetCodeObjectSize(), options,
+      reader->GetUri(), loaded_code_object);
   CATCH;
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa.cpp
@@ -2300,11 +2300,15 @@ hsa_status_t hsa_executable_load_code_object(
     return HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
   }
   CodeObjectReaderImpl reader;
+  // buffer_size == 0 means unbounded size discovery for in-memory ELF images.
   size_t code_object_size = amd::elf::ElfSize(code_object_p, 0);
   if (code_object_size == 0) {
     return HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
   }
-  reader.SetMemory(code_object_p, code_object_size);
+  hsa_status_t status = reader.SetMemory(code_object_p, code_object_size);
+  if (status != HSA_STATUS_SUCCESS) {
+    return status;
+  }
 
   return exec->LoadCodeObject(agent, code_object, code_object_size, options,
                               reader.GetUri());

--- a/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/amd_elf_image.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/amd_elf_image.cpp
@@ -1790,6 +1790,11 @@ namespace elf {
         return 0;
       }
 
+      // The loop indexes shdr[i] with sizeof(Elf64_Shdr) stride.
+      if (ehdr->e_shentsize != sizeof(Elf64_Shdr)) {
+        return 0;
+      }
+
       if (bounded && ehdr->e_shoff >= buffer_size) {
         return 0;
       }
@@ -1806,6 +1811,15 @@ namespace elf {
       uint64_t total_size = max_offset + shdr_table_size;
 
       for (uint16_t i = 0; i < ehdr->e_shnum; ++i) {
+        if (bounded) {
+          uint64_t shdr_entry_offset =
+              static_cast<uint64_t>(ehdr->e_shoff) +
+              static_cast<uint64_t>(i) * sizeof(Elf64_Shdr);
+          if (shdr_entry_offset + sizeof(Elf64_Shdr) > buffer_size) {
+            return 0;
+          }
+        }
+
         uint64_t cur_offset = static_cast<uint64_t>(shdr[i].sh_offset);
         if (max_offset < cur_offset) {
           max_offset = cur_offset;

--- a/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/amd_elf_image.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/amd_elf_image.cpp
@@ -1431,8 +1431,11 @@ namespace elf {
     bool GElfImage::initAsBuffer(const void* buffer, size_t size)
     {
       if (size == 0) {
-        out << "Error: buffer size must be specified" << std::endl;
-        return false;
+        size = ElfSize(buffer, 0);
+        if (size == 0) {
+          out << "Error: failed to determine buffer size" << std::endl;
+          return false;
+        }
       }
       if ((e = elf_memory(reinterpret_cast<char*>(const_cast<void*>(buffer)), size
 #ifdef AMD_LIBELF
@@ -1773,18 +1776,27 @@ namespace elf {
 
     uint64_t ElfSize(const void* emi, size_t buffer_size)
     {
-      const Elf64_Ehdr *ehdr = (const Elf64_Ehdr*) emi;
-      if (ehdr == NULL || EV_CURRENT != ehdr->e_version || buffer_size == 0) {
+      if (emi == NULL) {
         return 0;
       }
 
-      if (ehdr->e_shoff >= buffer_size) {
+      const bool bounded = buffer_size != 0;
+      if (bounded && buffer_size < sizeof(Elf64_Ehdr)) {
+        return 0;
+      }
+
+      const Elf64_Ehdr *ehdr = (const Elf64_Ehdr*) emi;
+      if (EV_CURRENT != ehdr->e_version) {
+        return 0;
+      }
+
+      if (bounded && ehdr->e_shoff >= buffer_size) {
         return 0;
       }
 
       uint64_t shdr_table_size =
           static_cast<uint64_t>(ehdr->e_shentsize) * static_cast<uint64_t>(ehdr->e_shnum);
-      if (shdr_table_size > buffer_size - ehdr->e_shoff) {
+      if (bounded && shdr_table_size > buffer_size - ehdr->e_shoff) {
         return 0;
       }
 
@@ -1798,17 +1810,16 @@ namespace elf {
         if (max_offset < cur_offset) {
           max_offset = cur_offset;
           total_size = max_offset;
+          if (bounded && cur_offset >= buffer_size) {
+            return 0;
+          }
           if (SHT_NOBITS != shdr[i].sh_type) {
-            if (shdr[i].sh_size > buffer_size - cur_offset) {
+            if (bounded && shdr[i].sh_size > buffer_size - cur_offset) {
               return 0;
             }
             total_size += static_cast<uint64_t>(shdr[i].sh_size);
           }
         }
-      }
-
-      if (total_size > buffer_size) {
-        return 0;
       }
 
       return total_size;

--- a/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/amd_elf_image.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/amd_elf_image.cpp
@@ -1418,7 +1418,10 @@ namespace elf {
 
     bool GElfImage::initFromBuffer(const void* buffer, size_t size)
     {
-      if (size == 0) { size = ElfSize(buffer); }
+      if (size == 0) {
+        out << "Error: buffer size must be specified" << std::endl;
+        return false;
+      }
       if (!img.create()) { return imgError(); }
       if (!img.copyFrom(buffer, size)) { return imgError(); }
       if (!elfBegin(ELF_C_RDWR)) { return false; }
@@ -1427,7 +1430,10 @@ namespace elf {
 
     bool GElfImage::initAsBuffer(const void* buffer, size_t size)
     {
-      if (size == 0) { size = ElfSize(buffer); }
+      if (size == 0) {
+        out << "Error: buffer size must be specified" << std::endl;
+        return false;
+      }
       if ((e = elf_memory(reinterpret_cast<char*>(const_cast<void*>(buffer)), size
 #ifdef AMD_LIBELF
                        , NULL
@@ -1532,7 +1538,7 @@ namespace elf {
     uint64_t GElfImage::size()
     {
       if (buffer) {
-        return ElfSize(buffer);
+        return bufferSize;
       } else {
         return img.getSize();
       }
@@ -1765,20 +1771,27 @@ namespace elf {
     Image* NewElf32Image() { return new GElfImage(ELFCLASS32); }
     Image* NewElf64Image() { return new GElfImage(ELFCLASS64); }
 
-    uint64_t ElfSize(const void* emi)
+    uint64_t ElfSize(const void* emi, size_t buffer_size)
     {
       const Elf64_Ehdr *ehdr = (const Elf64_Ehdr*) emi;
-      if (NULL == ehdr || EV_CURRENT != ehdr->e_version) {
-        return false;
+      if (ehdr == NULL || EV_CURRENT != ehdr->e_version || buffer_size == 0) {
+        return 0;
       }
 
-      const Elf64_Shdr *shdr = (const Elf64_Shdr*)((char*)emi + ehdr->e_shoff);
-      if (NULL == shdr) {
-        return false;
+      if (ehdr->e_shoff >= buffer_size) {
+        return 0;
       }
+
+      uint64_t shdr_table_size =
+          static_cast<uint64_t>(ehdr->e_shentsize) * static_cast<uint64_t>(ehdr->e_shnum);
+      if (shdr_table_size > buffer_size - ehdr->e_shoff) {
+        return 0;
+      }
+
+      const Elf64_Shdr *shdr = (const Elf64_Shdr*)((const char*)emi + ehdr->e_shoff);
 
       uint64_t max_offset = ehdr->e_shoff;
-      uint64_t total_size = max_offset + static_cast<uint64_t>(ehdr->e_shentsize) * static_cast<uint64_t>(ehdr->e_shnum);
+      uint64_t total_size = max_offset + shdr_table_size;
 
       for (uint16_t i = 0; i < ehdr->e_shnum; ++i) {
         uint64_t cur_offset = static_cast<uint64_t>(shdr[i].sh_offset);
@@ -1786,9 +1799,16 @@ namespace elf {
           max_offset = cur_offset;
           total_size = max_offset;
           if (SHT_NOBITS != shdr[i].sh_type) {
+            if (shdr[i].sh_size > buffer_size - cur_offset) {
+              return 0;
+            }
             total_size += static_cast<uint64_t>(shdr[i].sh_size);
           }
         }
+      }
+
+      if (total_size > buffer_size) {
+        return 0;
       }
 
       return total_size;

--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
@@ -1297,7 +1297,12 @@ hsa_status_t ExecutableImpl::LoadCodeObject(
   }
   std::vector<char> buffer;
   if (substituteFileName.empty()) {
-   if (!code->InitAsHandle(code_object)) {
+    if (code_object_size != 0) {
+      if (!code->InitAsBuffer(reinterpret_cast<const void*>(code_object.handle),
+                              code_object_size)) {
+        return HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
+      }
+    } else if (!code->InitAsHandle(code_object)) {
       return HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
     }
   } else {

--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
@@ -1251,6 +1251,17 @@ hsa_status_t ExecutableImpl::LoadCodeObject(
     return HSA_STATUS_ERROR_FROZEN_EXECUTABLE;
   }
 
+  if (code_object_size == 0) {
+    const void* elf_data = reinterpret_cast<const void*>(code_object.handle);
+    if (!elf_data) {
+      return HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
+    }
+    code_object_size = amd::elf::ElfSize(elf_data, 0);
+    if (code_object_size == 0) {
+      return HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
+    }
+  }
+
   LoaderOptions loaderOptions;
   if (options && !loaderOptions.ParseOptions(options)) {
     return HSA_STATUS_ERROR;
@@ -1297,12 +1308,8 @@ hsa_status_t ExecutableImpl::LoadCodeObject(
   }
   std::vector<char> buffer;
   if (substituteFileName.empty()) {
-    if (code_object_size != 0) {
-      if (!code->InitAsBuffer(reinterpret_cast<const void*>(code_object.handle),
-                              code_object_size)) {
-        return HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
-      }
-    } else if (!code->InitAsHandle(code_object)) {
+    if (!code->InitAsBuffer(reinterpret_cast<const void*>(code_object.handle),
+                            code_object_size)) {
       return HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
     }
   } else {


### PR DESCRIPTION
## Summary

Validate section table offsets and sizes against the known buffer size, require explicit buffer sizes for in-memory ELF initialization, and propagate code object sizes through the loader API to prevent parsing beyond the end of untrusted .hsaco input.

## JIRA ID

JIRA ID : SWSPLAT-24382

## Test plan

- [ ] Load a normal code object; confirm no regression.
- [ ] Load a crafted code object with truncated section table; confirm rejection instead of out-of-bounds read.