### PR TITLE
Fix out-of-bounds read in ELF note section parsing.

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/amd_elf_image.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/amd_elf_image.cpp
@@ -1225,19 +1225,39 @@ namespace elf {
       Elf_Scn *scn = elf_getscn(elf->e, ndxscn);
       assert(scn);
       while ((data = elf_getdata(scn, data)) != 0) {
-        uint32_t note_offset = 0;
-        while (note_offset < data->d_size) {
+        size_t note_offset = 0;
+        const size_t data_size = data->d_size;
+        while (note_offset < data_size) {
+          if (note_offset + sizeof(Elf64_Nhdr) > data_size) {
+            return false;
+          }
           char* notec = (char *) data->d_buf + note_offset;
           Elf64_Nhdr* note = (Elf64_Nhdr*) notec;
+          const size_t namesz_aligned = alignUp(note->n_namesz, 4);
+          const size_t descsz_aligned = alignUp(note->n_descsz, 4);
+          size_t entry_size = sizeof(Elf64_Nhdr);
+          if (entry_size + namesz_aligned < entry_size ||
+              entry_size + namesz_aligned + descsz_aligned < entry_size + namesz_aligned) {
+            return false;
+          }
+          entry_size += namesz_aligned + descsz_aligned;
+          if (note_offset + entry_size > data_size || note_offset + entry_size < note_offset) {
+            return false;
+          }
           if (type == note->n_type) {
+            const size_t desc_offset = note_offset + sizeof(Elf64_Nhdr) + namesz_aligned;
+            if (note_offset + sizeof(Elf64_Nhdr) + note->n_namesz > data_size ||
+                desc_offset + note->n_descsz > data_size) {
+              return false;
+            }
             std::string note_name = GetNoteString(note->n_namesz, notec + sizeof(Elf64_Nhdr));
             if (name == note_name) {
-              *desc = notec + sizeof(Elf64_Nhdr) + alignUp(note->n_namesz, 4);
+              *desc = notec + sizeof(Elf64_Nhdr) + namesz_aligned;
               *desc_size = note->n_descsz;
               return true;
             }
           }
-          note_offset += sizeof(Elf64_Nhdr) + alignUp(note->n_namesz, 4) + alignUp(note->n_descsz, 4);
+          note_offset += entry_size;
         }
       }
       return false;


### PR DESCRIPTION
Validate note entry bounds before reading headers and descriptor data to prevent heap OOB reads and infinite loops on malformed note sections.

Resolves SWSPLAT-24380