### PR TITLE
Validate ELF segment offsets before copying to GPU memory.

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/amd_elf_image.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/amd_elf_image.cpp
@@ -842,7 +842,16 @@ namespace elf {
 
     const char* GElfSegment::data() const
     {
-      return (const char*) elf->data() + phdr.p_offset;
+      if (!elf->buffer || elf->bufferSize == 0) {
+        return nullptr;
+      }
+      if (phdr.p_offset > elf->bufferSize) {
+        return nullptr;
+      }
+      if (phdr.p_filesz > elf->bufferSize - phdr.p_offset) {
+        return nullptr;
+      }
+      return elf->buffer + phdr.p_offset;
     }
 
     bool GElfImage::Freeze()

--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
@@ -1398,10 +1398,14 @@ hsa_status_t ExecutableImpl::LoadSegmentV1(hsa_agent_t agent,
     if (s->imageSize() > s->memSize()) {
       return HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
     }
+    const char* segment_data = s->data();
+    if (!segment_data) {
+      return HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
+    }
     void* ptr = context_->SegmentAlloc(segment, agent, s->memSize(), s->align(), true);
     if (!ptr) { return HSA_STATUS_ERROR_OUT_OF_RESOURCES; }
     new_seg = std::make_shared<Segment>(this, agent, segment, ptr, s->memSize(), s->vaddr(), s->offset());
-    new_seg->Copy(s->vaddr(), s->data(), s->imageSize());
+    new_seg->Copy(s->vaddr(), segment_data, s->imageSize());
     objects.push_back(new_seg);
 
     if (segment == AMDGPU_HSA_SEGMENT_GLOBAL_PROGRAM) {
@@ -1419,7 +1423,11 @@ hsa_status_t ExecutableImpl::LoadSegmentV2(const code::Segment *data_segment,
   if (data_segment->imageSize() > data_segment->memSize()) {
     return HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
   }
-  load_segment->Copy(data_segment->vaddr(), data_segment->data(),
+  const char* segment_data = data_segment->data();
+  if (!segment_data) {
+    return HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
+  }
+  load_segment->Copy(data_segment->vaddr(), segment_data,
                      data_segment->imageSize());
 
   return HSA_STATUS_SUCCESS;


### PR DESCRIPTION
Reject program headers with out-of-bounds p_offset or p_filesz relative to the code object buffer before segment data is copied into allocations.

Resolves SWSPLAT-24378