### PR TITLE
rocr: Fix unsigned underflow in P2P SDMA engine count

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -142,8 +142,8 @@ GpuAgent::GpuAgent(HSAuint32 node, const HsaNodeProperties& node_props, bool xna
   assert(err == HSA_STATUS_SUCCESS && "hsaGetClockCounters error");
 
   num_h2d_d2h_engines_ = properties_.NumSdmaEngines > 2 ? 2 : properties_.NumSdmaEngines;
-  num_p2p_engines_ =  properties_.NumSdmaXgmiEngines ? properties_.NumSdmaXgmiEngines
-                      : std::max(0U, properties_.NumSdmaEngines - 2);
+  num_p2p_engines_ = properties_.NumSdmaXgmiEngines ? properties_.NumSdmaXgmiEngines
+                     : properties_.NumSdmaEngines - num_h2d_d2h_engines_;
 
   const core::Isa *isa_base;
 


### PR DESCRIPTION
## Motivation

When no XGMI SDMA engines are present, num_p2p_engines_ was computed as
std::max(0U, NumSdmaEngines - 2). NumSdmaEngines is unsigned, so when it
is 0 or 1 the subtraction underflows before std::max runs, leaving the
clamp ineffective. num_p2p_engines_ became huge and blit_cnt_ =
DefaultBlitCount + num_p2p_engines_ wrapped to 2. blits_ was then resized
to 2 while InitDma() indexes blits_[BlitDevToHost] (index 2), causing a
heap-buffer-overflow during hsa_init() (caught by ASan, silent corruption
otherwise).

## Technical Details

Compute the P2P engine count as the remainder of the SDMA engines after
the H2D/D2H reservation: NumSdmaEngines - num_h2d_d2h_engines_. Since
num_h2d_d2h_engines_ is clamped to min(NumSdmaEngines, 2), this can never
underflow, removes the duplicated '2' constant, and keeps
num_h2d_d2h_engines_ + num_p2p_engines_ == NumSdmaEngines.

## JIRA ID

[ROCM-25880](https://amd-hub.atlassian.net/browse/ROCM-25880)

Fixes: d5c7cec809f9 ("rocr: gfx1250 Fix SDMA engine selection")

[ROCM-25880]: https://amd-hub.atlassian.net/browse/ROCM-25880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ